### PR TITLE
runtime: deferred-emission buffer is now a stack — fixes nested closu…

### DIFF
--- a/compiler/tests/nested_closure_decl.nu
+++ b/compiler/tests/nested_closure_decl.nu
@@ -1,0 +1,47 @@
+// nested_closure_decl.nu — guard against the IR-codegen regression
+// fixed 2026-05-23: a `: ( @ v ) name \ → v { ... }` binding inside
+// ANOTHER closure's body used to spill the outer closure's body
+// bytes at module scope, producing `error: expected 'type' after
+// name` at LLVM-link time. Root cause was the single-instance print
+// buffer in `stdlib/runtime.c §1` — the inner gen_closure_expr's
+// reset+start wiped the parent's buffered IR.
+//
+// Fix: the print buffer is now a 32-deep stack; `start` pushes a
+// fresh empty frame, `stop` snapshots-and-pops. `reset` is a no-op
+// when the stack is non-empty so it cannot reach across frames.
+// See `nurl_print_buf_start` in runtime.c for the protocol.
+
+@ leaf → v {
+    ( puts `leaf` )
+}
+
+@ outer → v {
+    : ( @ v ) outer_cb \ → v {
+        // Nested :-binding inside outer_cb's body — the failing case.
+        : ( @ v ) inner_cb \ → v {
+            ( leaf )
+        }
+        ( inner_cb )
+    }
+    ( outer_cb )
+}
+
+// Three-level nesting exercises the stack to depth ≥3.
+@ outer3 → v {
+    : ( @ v ) lvl1 \ → v {
+        : ( @ v ) lvl2 \ → v {
+            : ( @ v ) lvl3 \ → v {
+                ( puts `lvl3` )
+            }
+            ( lvl3 )
+        }
+        ( lvl2 )
+    }
+    ( lvl1 )
+}
+
+@ main → i {
+    ( outer )
+    ( outer3 )
+    ^ 0
+}

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -158,27 +158,117 @@ const char *nurl_read_n_bytes(long long n) {
     return buf;
 }
 
-/* ── Output buffer for deferred emission (closure bodies etc.) ── */
-#define OUTBUF_SIZE (8*1024*1024)  /* 8 MB deferred output buffer */
+/* ── Output buffer for deferred emission (closure bodies etc.) ──
+ *
+ * Stack-based: every `start` pushes a fresh empty frame and switches
+ * to buffering; every `stop` snapshots the current frame's contents
+ * to a strdup'd return value and pops back to whatever was there
+ * before (which may itself be a buffering frame).
+ *
+ * Why stack instead of single-slot: `gen_closure_expr` in
+ * `compiler/nurlc.nu` brackets each closure body with start/stop. A
+ * closure body that itself defines another closure (nested
+ * `:`-binding of a `\ → R { ... }`) re-enters `gen_closure_expr`
+ * recursively. Under the old single-slot model the inner call's
+ * `reset` cleared the bytes the outer body had emitted so far, and
+ * the inner's `stop` switched back to stdout — so the outer's
+ * remaining body bytes leaked out at module scope. The deferred
+ * function for the outer closure ended up being only the inner
+ * closure's body, while the outer's tail spilled into global IR.
+ * Symptom: `error: expected 'type' after name` on what is plainly
+ * function-body IR sitting outside any `define`. Stack semantics
+ * makes nested `start`/`stop` pairs do the obvious thing without a
+ * single line of compiler-side change. (Fix landed 2026-05-23 in
+ * the async-runtime cleanup; see docs/GOTCHAS.md §12.)
+ */
+#define OUTBUF_SIZE       (8*1024*1024)  /* 8 MB per-frame buffer */
+#define OUTBUF_STACK_MAX  32
+
+struct OutbufFrame {
+    char  *bytes;    /* saved snapshot; NULL when frame was empty */
+    size_t len;
+    int    mode;
+};
+
 static char  *g_outbuf      = NULL;
 static size_t g_outbuf_len  = 0;
 static int    g_outbuf_mode = 0;   /* 0 = stdout, 1 = buffer */
+static struct OutbufFrame g_outbuf_stack[OUTBUF_STACK_MAX];
+static int    g_outbuf_sp   = 0;   /* 0 = stack empty */
 
 static void outbuf_init(void) {
     if (!g_outbuf) { g_outbuf = (char*)malloc(OUTBUF_SIZE); g_outbuf[0] = '\0'; }
 }
 
-/* Redirect nurl_print to the internal buffer. */
-void nurl_print_buf_start(void) { outbuf_init(); g_outbuf_mode = 1; }
-/* Return to stdout mode and return accumulated buffer as a heap-owned copy
-   so Phase 2B auto-drop is safe; internal g_outbuf keeps growing until
-   nurl_print_buf_reset().                                                   */
-const char* nurl_print_buf_stop(void) {
-    g_outbuf_mode = 0;
-    return strdup(g_outbuf ? g_outbuf : "");
+/* Push a fresh empty buffering frame. The previous frame's bytes +
+ * mode are saved on the stack for `stop` to restore. */
+void nurl_print_buf_start(void) {
+    outbuf_init();
+    if (g_outbuf_sp >= OUTBUF_STACK_MAX) {
+        fputs("nurl_print_buf_start: stack overflow\n", stderr);
+        return;
+    }
+    struct OutbufFrame *f = &g_outbuf_stack[g_outbuf_sp++];
+    f->mode = g_outbuf_mode;
+    f->len  = g_outbuf_len;
+    if (g_outbuf_len > 0) {
+        f->bytes = (char*)malloc(g_outbuf_len + 1);
+        if (f->bytes) memcpy(f->bytes, g_outbuf, g_outbuf_len + 1);
+    } else {
+        f->bytes = NULL;
+    }
+    g_outbuf_len = 0;
+    g_outbuf[0] = '\0';
+    g_outbuf_mode = 1;
 }
-/* Reset the buffer (call before starting a new capture). */
-void nurl_print_buf_reset(void) { outbuf_init(); g_outbuf_len = 0; g_outbuf[0] = '\0'; }
+
+/* Snapshot the current frame as the return value, then pop the
+ * saved frame back into place. The caller owns the returned pointer
+ * (auto-drop / explicit free). */
+const char* nurl_print_buf_stop(void) {
+    outbuf_init();
+    char *ret = strdup(g_outbuf ? g_outbuf : "");
+    if (g_outbuf_sp > 0) {
+        struct OutbufFrame *f = &g_outbuf_stack[--g_outbuf_sp];
+        g_outbuf_len = f->len;
+        if (f->bytes) {
+            memcpy(g_outbuf, f->bytes, f->len + 1);
+            free(f->bytes);
+            f->bytes = NULL;
+        } else {
+            g_outbuf[0] = '\0';
+        }
+        g_outbuf_mode = f->mode;
+    } else {
+        /* Bottom of the stack — fall back to stdout mode. */
+        g_outbuf_len = 0;
+        g_outbuf[0] = '\0';
+        g_outbuf_mode = 0;
+    }
+    return ret;
+}
+
+/* Legacy: `gen_closure_expr` historically called `reset+start` to
+ * guarantee a clean buffer before capturing a closure body. Under
+ * the new stack semantics, `start` already pushes a fresh empty
+ * frame — but the bug class we're closing is exactly the case where
+ * a nested `gen_closure_expr` call invokes this reset, which under
+ * the obvious "clear current bytes" semantics would wipe the parent
+ * frame's accumulated bytes (the parent IS the current top of stack
+ * until the nested `start` fires).
+ *
+ * Resolution: clear ONLY when the stack is empty. With outstanding
+ * frames the parent buffer is preserved, and the nested `start`
+ * pushes a new fresh frame on top regardless. The end-to-end
+ * semantic of `reset+start` is unchanged at single-level call sites
+ * (where stack is empty) and now correct at nested call sites. */
+void nurl_print_buf_reset(void) {
+    outbuf_init();
+    if (g_outbuf_sp == 0) {
+        g_outbuf_len = 0;
+        g_outbuf[0] = '\0';
+    }
+}
 
 /* print without newline */
 void nurl_print(const char *s) {


### PR DESCRIPTION
…re :-binding IR-codegen bug

Closes the third of the three "workaround was the only way forward" bugs surfaced during the async-runtime ship (commit 0fb8d90). The other two — `__attribute__((noinline))` on TLS-reading runtime entry points, and the `active`-flag on reactor wait entries — are not NURL bugs:

  * `noinline` is the standard workaround for a clang/LLVM-LTO limitation in lowering `__thread` accesses across translation- unit boundaries; the alternatives (`pthread_getspecific`, relaxing `static`, atomic-load tricks) are either slower or don't help. Keep.
  * The reactor's `active` flag is the correctness mechanism that closes the park-vs-unpark race — without it another worker could swap into a fiber's context before the parker's `swapcontext` finished saving registers. It is the design, not a patch. Keep.

The third — nested `:`-binding of a closure literal inside another closure's body — was a genuine compiler bug rooted in `stdlib/runtime.c §1`'s single-instance deferred-emission buffer.

Root cause: `gen_closure_expr` brackets the body it captures with `nurl_print_buf_reset` + `_start` and ends with `_stop`. The buffer was a single global slot, so when an inner `gen_closure_expr` ran recursively from within the outer's body parsing, the inner's `reset` cleared the outer's already-buffered bytes and the inner's `stop` switched back to stdout mode — so the outer's tail spilled out at module scope. The deferred function definition stored for the OUTER closure was then truncated (missing `define ... {` header and the bytes emitted before the inner closure's `:`-binding), while the bytes emitted AFTER the inner's `:`-binding landed at LLVM module scope. Symptom: `clang: error: expected 'type' after name` on what was plainly function-body IR sitting outside any `define`.

Resolution: turn the single-slot buffer into a 32-deep stack. `nurl_print_buf_start` pushes a fresh empty frame; `nurl_print_buf_ stop` snapshots-and-pops, returning the popped frame's contents to the caller. `nurl_print_buf_reset` is now a no-op when the stack is non-empty — so a nested `reset+start` cannot reach across to clear its parent's bytes. Zero changes in `compiler/nurlc.nu` (the `reset+start+stop` idiom still does the right thing at every call site).

Regression test: `compiler/tests/nested_closure_decl.nu` exercises two- and three-level `:`-bound closure nesting, both prints land on the wire. Bootstrap fixed point holds; full 271-test corpus passes.

The async HTTP server (`stdlib/ext/http_server.nu`'s `server_run_async`) had used a top-level-@-fn workaround to dodge this bug; that code is now valid as-is but kept on the lifted shape because it's also more debuggable (real function names in stack traces).