### PR TITLE
Release v0.9.1 — closes v0.9.0 critic backlog (20/20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+(Empty — the next ship lands its `### Added` / `### Changed` / `### Fixed`
+notes here.)
+
+## [0.9.1] — 2026-05-26
+
+### Release summary
+
+The "critic v0.9.0 backlog closes" release. v0.9.0's external peer
+review (`critic.md`, 24 May 2026) distilled into `IMPROVEMENTS.md`
+across Tiers A–E; v0.9.1 ships the entire remaining set (20 of 20
+actionable items) and a handful of opportunistic perf + stdlib wins
+that landed in the same window. `IMPROVEMENTS.md` is retired this
+release — the surviving long-running item (Mobile / Embedded
+targets) graduated to ROADMAP §4.
+
+**Headline wins:**
+
+- **Borrow checker promoted to hard errors by default** (BORROW.md
+  Phase 8 final). Five bug classes are now compile errors: use-after-
+  move, alias double-free, closure escape, aliased mutable-borrow at
+  call sites, iterator invalidation. `--no-borrowck` is the escape
+  hatch.
+- **Networking complete:** UDP datagrams (dual-stack IPv4/IPv6 with
+  multicast) + standalone DNS resolver (`getaddrinfo` /
+  `getnameinfo`) land alongside the existing TCP / TLS / HTTP stack.
+- **JSON parser ~34× faster** — pure-NURL `stdlib/ext/json.nu`
+  rewritten around a single-pass scanner; 479 ms → 14 ms on the
+  `bench/json_parse` micro-benchmark.
+- **First peer benchmarks shipped** — `bench/` v1 compares NURL with
+  Python / Rust / Node on three reproducible micro-benches plus an
+  HTTP-server-vs-Rust-hyper / Node-http sweep. NURL parity with Rust
+  on compute-bound work; NURL holds the lowest tail latency across
+  the whole HTTP concurrency sweep (p99 0.62 ms at C=200 vs Rust's
+  6.19 ms).
+- **CI lit up** — GitHub Actions workflow with parallel build-test +
+  sanitizer (ASan + UBSan) jobs.
+- **Formal language spec** — `docs/spec.md` (~1 000 lines) covers the
+  semantic side the grammar EBNF doesn't.
+- **Generic signal handling** + **structured logging** + **silent-
+  miscompile diagnostics** round out the stdlib + compiler surface.
+
+Bootstrap fixed point at release time: stage1 ≡ stage2 byte-identical
+IR at **1 620 300 B**. Full test corpus + sanitizers green.
+
 ### Added — UDP datagram sockets + full DNS resolver (Tier D #6, 2026-05-26)
 
 Closes the last `IMPROVEMENTS.md` Tier D Roadmap §3 item the v0.9.0

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ A reproducible micro-benchmark suite lives in [`bench/`](bench/) — one source 
 
 (Lower = better, median wall-clock ms across 5 runs.) On compute-bound work NURL lands within measurement noise of Rust — same LLVM `-O2 -flto` codegen. On `json_parse` NURL's pure-NURL parser beats Python's C-extension `json` ~2.4× and trails a hand-written zero-copy Rust parser by ~3×.
 
+**HTTP server peer bench** — [`bench/HTTP_RESULTS.md`](bench/HTTP_RESULTS.md), driven via [`oha`](https://github.com/hatoo/oha) (10 s × 3 runs, median):
+
+| Concurrency | NURL (req/s) | Rust hyper | Node http | NURL p99 (ms) | Rust p99 | Node p99 |
+|---:|---:|---:|---:|---:|---:|---:|
+|   1 |  14 451  |  14 507  |   8 708  | **0.14** | 0.11 |  0.51 |
+|  10 | **68 960** |  47 703  |  16 726  | **0.56** | 1.16 |  2.43 |
+|  50 |  60 897  | **86 699** |  17 108  | **0.67** | 2.82 | 12.30 |
+| 200 |  59 044  | **114 694** |  15 555  | **0.62** | 6.19 | 21.16 |
+
+Parity with Rust hyper at C=1; NURL **1.45× ahead** at C=10 (the 8-worker pool fits the workload); Rust pulls ahead at C ≥ 50 with deeper async machinery. **NURL holds the lowest tail latency across the whole sweep** — p99 0.62 ms at C=200 vs Rust 6.19 ms, Node 21 ms.
+
 ---
 
 ## Architecture
@@ -539,10 +550,11 @@ exercised by the build scripts today.
 | Linux x86_64      | LLVM         | primary dev target — `build.sh` + tests  |
 | Windows x86_64    | LLVM         | fully supported — `build.bat` runs the same bootstrap + snapshot test suite as `build.sh` |
 | macOS x86_64      | LLVM + zig cc | cross-compiled from the `api/` container via `POST /build_macos`; Mach-O binary links only libSystem (no Apple SDK needed). Runs on Apple Silicon via Rosetta 2. canvas/audio/libcurl-HTTP not supported on this target. |
-| macOS ARM64       | LLVM         | should work via clang; untested          |
+| macOS ARM64       | LLVM + zig cc | cross-compiled via `POST /build_target` (`target=macos-arm64`) — native Apple Silicon Mach-O, links only libSystem. Unsigned, so clear quarantine attribute before running. |
 | WebAssembly       | wasm32-wasi  | supported via the `api/` container (WASI SDK 24.0); browser execution via `browser_wasi_shim`. The self-hosting compiler itself also builds to wasm — see `buildwasm.sh` / `wasmnurl.sh` below |
-| Android / iOS     | LLVM cross   | planned                                  |
-| Embedded (no_std) | LLVM         | planned                                  |
+| Linux ARM64 / RISC-V64 | LLVM + zig cc | cross-compiled via `POST /build_target` — fully-static `musl` ELFs (`linux-arm64-musl`, `linux-riscv64-musl`) or dynamic glibc (`linux-arm64-gnu`). Milk-V Duo (RISC-V C906) validated on-device. |
+| Android / iOS     | LLVM cross   | planned (ROADMAP §4)                     |
+| Embedded (no_std) | LLVM         | planned (ROADMAP §4)                     |
 | JVM               | JVM bytecode | future                                   |
 | .NET CLR          | CIL          | future                                   |
 
@@ -551,15 +563,33 @@ exercised by the build scripts today.
 ## Networking
 
 NURL reaches the network through a pure-POSIX socket layer in the C
-runtime (`nurl_tcp_*`) — no libcurl, no framework. Both directions are
-covered:
+runtime (`nurl_tcp_*` / `nurl_udp_*` / `nurl_dns_*`) — no libcurl,
+no framework. Four primitives, every one of them dual-stack IPv4/IPv6
+and integrated with the fiber reactor for async I/O:
 
-- **Server** — `tcp_listen` / `tcp_listen_tls` + `tcp_accept`, with a
-  full HTTP/1.1 server stack on top (`stdlib/ext/http_*` — routing,
-  static files, middleware, multipart, TLS; see `HTTP_SERVER_PLAN.md`).
-- **Client** — `tcp_connect` / `tcp_connect_tls` (runtime §18b/§18c:
-  DNS via `getaddrinfo`, a TLS client handshake with SNI). The
-  primitive any outbound client needs.
+- **TCP server** — `tcp_listen` / `tcp_listen_tls` + `tcp_accept`,
+  with a full HTTP/1.1 server stack on top (`stdlib/ext/http_*` —
+  routing, static files, middleware, multipart, WebSockets, TLS
+  with SNI + ALPN + mTLS + live cert reload; see
+  `HTTP_SERVER_PLAN.md`).
+- **TCP client** — `tcp_connect` / `tcp_connect_tls` (runtime §18).
+  TLS client handshake with SNI; peer-certificate verification is
+  an opt-in flag. The primitive behind the MQTT 5.0 client and any
+  outbound TLS application.
+- **UDP** (`stdlib/std/udp.nu`, runtime §18b) — `udp_bind` (dual-
+  stack wildcard via `AF_INET6 + IPV6_V6ONLY=0`), `udp_connect`,
+  `udp_send_to` / `udp_recv_from`, connected-mode `udp_send` /
+  `udp_recv`, broadcast and multicast (`udp_join_group` /
+  `_leave_group` / `_set_multicast_ttl` / `_set_multicast_loop`).
+  Sync + fiber-aware async on every send/recv via the same context
+  dispatch as the TCP primitives.
+- **DNS** (`stdlib/std/dns.nu`, runtime §18c) — system-resolver
+  wrappers over `getaddrinfo` / `getnameinfo`, no c-ares dep.
+  `dns_resolve host → ! (Vec String) NetErr` lists the A/AAAA
+  literals in the kernel's preferred order; `dns_resolve_port host
+  port` formats each entry as `"ip:port"` (IPv4) or `"[ip]:port"`
+  (IPv6, RFC 3986 §3.2.2) ready for direct `tcp_connect` /
+  `udp_connect`; `dns_reverse ip → ? String` runs `NI_NAMEREQD`.
 
 ### MQTT 5.0 client
 
@@ -942,13 +972,13 @@ see [`docs/GOTCHAS.md`](docs/GOTCHAS.md).
 
 | Capability | Notes |
 |---|---|
-| **TLS server-side shipped 2026-05-15** via `tcp_listen_tls host port cert_path key_path → !TcpListener NetErr` | Build-time dependency: `libssl` (pkg-config). HttpServer integrates without code changes — just swap `tcp_listen` for `tcp_listen_tls`. |
-| **TLS client-side shipped 2026-05-22** via `tcp_connect_tls host port verify` (runtime §18c) | DNS resolution + `connect` + a TLS client handshake with SNI. The primitive behind the MQTT client and any outbound TLS. Peer-certificate verification is an opt-in flag. |
-| TLS 1.2 minimum | TLS 1.0 / 1.1 / SSL 3.0 disabled in the SSL_CTX |
-| No SNI in v1 (single cert per listener) | Follow-up item |
-| No ALPN in v1 (no HTTP/2 to negotiate yet anyway) | Follow-up item |
-| No client-cert auth | Follow-up item |
-| No live cert reload | Follow-up item — would need a `tcp_set_tls_cert` runtime fn |
+| **TLS server-side** via `tcp_listen_tls host port cert_path key_path → !TcpListener NetErr` | Build-time dependency: `libssl` (pkg-config). HttpServer integrates without code changes — just swap `tcp_listen` for `tcp_listen_tls`. |
+| **TLS client-side** via `tcp_connect_tls host port verify` (runtime §18) | TLS client handshake with SNI; peer-certificate verification is an opt-in flag. The primitive behind the MQTT client and any outbound TLS. |
+| TLS 1.2 minimum | TLS 1.0 / 1.1 / SSL 3.0 disabled in the SSL_CTX. |
+| **SNI** (RFC 6066 §3) — `tcp_tls_add_sni listener hostname cert key` | Multi-tenant HTTPS — register per-hostname cert/key pairs on one listener; handshake-time selection from client's SNI extension; no-match falls through to the default cert. Idempotent on re-add. |
+| **ALPN** (RFC 7301) — `tcp_listen_tls_with_alpn` (server-preference list `"h2 http/1.1"`); `tcp_alpn_protocol conn` reads the negotiated protocol post-accept | Required by HTTP/2-over-TLS (RFC 9113 §3.3). |
+| **Mutual TLS (mTLS)** — `tcp_tls_require_client_cert listener ca_bundle strict?`; `tcp_peer_cert_subject conn` reads the peer's DN | Both strict mode (handshake fails without a cert) and opportunistic mode (handshake completes; app decides via the subject string). |
+| **Live cert reload** — `tcp_tls_reload listener hostname cert key` | Hot-swaps the SSL_CTX under a per-listener mutex; in-flight `SSL_read` / `SSL_write` on the old ctx survive until close via OpenSSL's refcount. Standard use case: Let's Encrypt rotation triggered from a control endpoint or SIGHUP handler. |
 
 ---
 


### PR DESCRIPTION
## Summary

Cuts NURL **v0.9.1** — the release that closes the entire v0.9.0
external-critic backlog (`IMPROVEMENTS.md`, now retired). 20 of 20
actionable items shipped across Tiers A–E plus a handful of
opportunistic perf + stdlib wins.

### Headline wins

- **Borrow checker promoted to hard errors by default** (BORROW.md Phase 8 final) — 5 bug classes are now compile errors.
- **Networking complete:** UDP datagrams (dual-stack IPv4/IPv6 + multicast) + standalone DNS resolver land alongside the existing TCP/TLS/HTTP stack.
- **JSON parser ~34× faster** (479 ms → 14 ms on `bench/json_parse`).
- **First peer benchmarks** — NURL vs Python/Rust/Node on three micro-benches + an HTTP server-vs-Rust-hyper / Node-http concurrency sweep. NURL holds the lowest tail latency across the whole HTTP sweep.
- **GitHub Actions CI** — parallel build-test + sanitizer (ASan + UBSan) jobs.
- **Formal language spec** — `docs/spec.md` (~1 000 lines).
- **Generic signal handling** + **structured logging (JSON + kv)** + **silent-miscompile diagnostics** (`^` vs `^^`, use-after-explicit-free, bare-identifier-as-statement, generic-instantiation source locations).

### Release prep done in this PR

- `CHANGELOG.md`: `[Unreleased]` → `## [0.9.1] — 2026-05-26` with a release-summary header at the top of the block.
- `README.md` (4 staleness fixes, all sitting since earlier ships):
  - Networking section rewritten — UDP + DNS get first-class billing.
  - HTTPS / TLS limits table — 4 "follow-up" rows replaced with their shipped status (SNI, ALPN, mTLS, live cert reload).
  - Performance section — HTTP-server peer-bench sub-table added.
  - Target platforms — macOS ARM64 + Linux ARM64/RISC-V64 rows updated to reflect the `api/build_target` reality.

### Quality gates

- Bootstrap fixed point: stage1 ≡ stage2 byte-identical IR at **1 620 300 B**.
- `./build.sh` + `./compiler/tests/run_tests.sh` (offline default): zero failures, zero baseline drift.
- `NURL_NET_TESTS=1` corpus: zero failures.
- Sanitizer corpus (CI): zero `SAN_FAIL` (the 9 `COMPILE_FAIL` rows are deliberate `borrow_*` baseline tests — `run_san_tests.sh:163` classifies them as expected).

## Test plan

- [ ] CI green on Linux (`build-test` + `sanitizers` jobs).
- [ ] Manual: spot-check `udp_basic` + `dns_basic` runs.
- [ ] After merge, tag `v0.9.1` on `main` and push: `git tag v0.9.1 && git push --tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)