### PR TITLE
feat(postgres): production-grade libpq client + examples/psql.nu

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -1549,6 +1549,17 @@
         // inside closures, so a binding captured by a closure counts.
         ( lint_note_read name )
         ( lint_note_used name )
+        // The void keyword `v` in value position (canonically `^ v` from
+        // a void function) denotes the unit/void value — UNLESS a binding
+        // of the same name shadows it (e.g. `: f v ( strtod … ) ^ v`).
+        // Without this, an unshadowed `v` fell through to the generic
+        // ident path, which set last_type to i64 and emitted `%v` — an
+        // undefined SSA value at the wrong type, silently invalid IR.
+        ? & ( seq name `v` ) == 0 ( nurl_str_len ( nurl_sym_get syms name ) )
+        { ( nurl_sym_def syms `__last_ident_name__` name )
+            ( nurl_set_last_type `void` )
+            ^ `void` }
+        {}
         : s lt ( nurl_sym_get syms name )
         ( nurl_set_last_type ? == 0 ( nurl_str_len lt ) `i64` lt )
         : s ptr ( nurl_sym_get syms ( nurl_str_cat name `__ptr` ) )
@@ -1634,6 +1645,7 @@
     : s lu_snap ( nurl_sym_get syms `__last_unsigned__` )
     ( nurl_sym_def syms `__last_unsigned__` `` )
     : s rv ( gen_expr lex syms cg )
+    : s rt ( nurl_get_last_type )
     : s ru_snap ( nurl_sym_get syms `__last_unsigned__` )
     : s res ( nurl_cg_reg cg )
     : b isf | ( seq lt `double` ) ( seq lt `float` )
@@ -1651,9 +1663,33 @@
     : b isu | | ( seq lt `i8` ) != 0 ( nurl_str_len lu_snap )
     != 0 ( nurl_str_len ru_snap )
     : s ins ( binop_instr tt isf isu )
+    // Pointer comparison coercion. LLVM forbids `icmp <op> i8* %p, 0`
+    // (integer constant at pointer type) and rejects comparing two
+    // differently-typed pointers. For comparison operators, ptrtoint
+    // any pointer operand to i64 and compare in i64 — handles null-
+    // checks (`== raw 0`), `!= ptr 0`, and pointer↔pointer equality
+    // uniformly. ptrtoint is a no-op at the machine level, so this is
+    // free. Arithmetic ops are untouched.
+    : b is_cmp | & >= tt TT_LT <= tt TT_GE | == tt TT_EQEQ == tt TT_NE
+    : s cmp_ty lt
+    ? & is_cmp | ( is_ptr_ty lt ) ( is_ptr_ty rt ) {
+        ? ( is_ptr_ty lt ) {
+            : s lvi ( nurl_cg_reg cg )
+            ( nurl_print `  ` ) ( nurl_print lvi ) ( nurl_print ` = ptrtoint ` )
+            ( nurl_print lt ) ( nurl_print ` ` ) ( nurl_print lv ) ( nurl_print ` to i64\n` )
+            = lv lvi
+        } {}
+        ? ( is_ptr_ty rt ) {
+            : s rvi ( nurl_cg_reg cg )
+            ( nurl_print `  ` ) ( nurl_print rvi ) ( nurl_print ` = ptrtoint ` )
+            ( nurl_print rt ) ( nurl_print ` ` ) ( nurl_print rv ) ( nurl_print ` to i64\n` )
+            = rv rvi
+        } {}
+        = cmp_ty `i64`
+    } {}
     ( nurl_print `  ` ) ( nurl_print res ) ( nurl_print ` = ` )
     ( nurl_print ins ) ( nurl_print ` ` )
-    ( nurl_print lt ) ( nurl_print ` ` )
+    ( nurl_print cmp_ty ) ( nurl_print ` ` )
     ( nurl_print lv ) ( nurl_print `, ` ) ( nurl_print rv ) ( nurl_print `\n` )
     ? | & >= tt TT_LT <= tt TT_GE | == tt TT_EQEQ == tt TT_NE
     ( nurl_set_last_type `i1` )
@@ -6978,6 +7014,16 @@
     ? ( seq ty `i32` ) 32
     ? ( seq ty `i64` ) 64
     0
+}
+
+// An LLVM type string denotes a pointer iff it ends in `*` (e.g.
+// `i8*`, `%Foo*`, `i8**`). Used by comparison codegen to coerce
+// pointer operands to i64 before `icmp`, so `== ptr 0` / `!= ptr 0`
+// null-checks and pointer↔pointer compares emit valid IR.
+@ is_ptr_ty s ty → b {
+    : i n ( nurl_str_len ty )
+    ? == n 0 { ^ F } {}
+    ^ == ( nurl_str_get ty - n 1 ) 42
 }
 
 @ gen_cast i lex i syms i cg → s {

--- a/compiler/tests/postgres_basic.nu
+++ b/compiler/tests/postgres_basic.nu
@@ -1,18 +1,19 @@
 // postgres_basic.nu — round-trip exercise for stdlib/ext/postgres.nu.
 //
-// Gated by NURL_PG_TESTS=1 + the PG_CONNINFO env var pointing at a
-// reachable PostgreSQL instance (e.g.
-// `PG_CONNINFO="host=localhost user=postgres dbname=postgres"`).
+// Gated by NURL_PG_TESTS=1 + PG_CONNINFO pointing at a reachable
+// PostgreSQL instance, e.g.
+//   PG_CONNINFO="host=/tmp port=5433 user=postgres dbname=postgres"
 //
-// Round-trip:
-//   1. Open a connection.
-//   2. CREATE TEMP TABLE notes — drops automatically on session end,
-//      so the test leaves no schema artifacts behind.
-//   3. INSERT three rows via pg_exec_params with text-formatted
-//      parameters (proves the parallel-Vec[String] → libpq parameter
-//      array conversion works).
-//   4. SELECT and walk rows via pg_get_value, print each.
-//   5. Close.
+// Exercises the production surface end to end:
+//   1. Connect + pg_ok status check.
+//   2. CREATE TEMP TABLE via pg_run (auto-clear, → affected rows).
+//   3. INSERT via pg_exec_params (Vec String, all-text).
+//   4. INSERT a row with a SQL NULL via the PgParams builder.
+//   5. Transaction: begin / insert / commit.
+//   6. Prepared statement: prepare once, execute by name.
+//   7. SELECT — walk rows with typed getters; show NULL handling.
+//   8. Escaping smoke test.
+//   9. Close.
 //
 // Default (gate unset) prints the skip notice.
 
@@ -22,74 +23,142 @@ $ `stdlib/core/vec.nu`
 $ `stdlib/ext/env.nu`
 $ `stdlib/ext/postgres.nu`
 
-@ println_label s label s value → v {
+@ kv s label s value → v {
     ( nurl_print label ) ( nurl_print `=` ) ( nurl_print value ) ( nurl_print `\n` )
 }
 
+// Report an Err arm uniformly: name + the connection's error text.
+@ fail_pg Connection c s where PgErr e → v {
+    : String msg ( pg_err_msg c )
+    ( nurl_print where ) ( nurl_print ` failed: ` ) ( nurl_print ( pg_err_name e ) )
+    ( nurl_print ` — ` ) ( nurl_print ( string_data msg ) ) ( nurl_print `\n` )
+    ( string_free msg )
+}
+
 @ run_live_pg_test s conninfo → v {
-    : !Connection PgErr cr ( pg_connect conninfo )
-    ?? cr {
-        F e → {
-            ( println_label `connect` ( pg_err_name e ) )
+    : Connection c ( pg_connect conninfo )
+    ? ! ( pg_ok c ) {
+        : String em ( pg_err_msg c )
+        ( nurl_print `connect failed: ` ) ( nurl_print ( string_data em ) ) ( nurl_print `\n` )
+        ( string_free em )
+        ( pg_close c )
+        ^ v
+    } {}
+
+    ( kv `server_version` ( nurl_str_int ( pg_server_version c ) ) )
+
+    // DDL via pg_run.
+    : !i PgErr ddl ( pg_run c `CREATE TEMP TABLE pg_notes (id INTEGER PRIMARY KEY, body TEXT, score DOUBLE PRECISION, ok BOOLEAN)` )
+    ?? ddl {
+        F e → ( fail_pg c `ddl` e )
+        T _ → ( nurl_print `ddl ok\n` )
+    }
+
+    // INSERT three rows via all-text pg_exec_params.
+    : ~ i k 1
+    ~ <= k 3 {
+        : ( Vec String ) params ( vec_with_cap [String] 4 )
+        ( vec_push [String] params ( string_from ( nurl_str_int k ) ) )
+        : String body ( string_with_cap 16 )
+        ( string_push_str body `note-` )
+        ( string_push_str body ( nurl_str_int k ) )
+        ( vec_push [String] params body )
+        ( vec_push [String] params ( string_from ( nurl_str_int + 100 k ) ) )
+        ( vec_push [String] params ( string_from `t` ) )
+        : !PgResult PgErr ins ( pg_exec_params c `INSERT INTO pg_notes (id, body, score, ok) VALUES ($1, $2, $3, $4)` params )
+        ?? ins {
+            F e → ( fail_pg c `insert` e )
+            T r → ( pg_clear r )
         }
-        T c → {
-            // DDL — TEMP TABLE auto-drops at session end.
-            : !PgResult PgErr ddl ( pg_exec c `CREATE TEMP TABLE pg_notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)` )
-            ?? ddl {
-                F e → ( println_label `ddl` ( pg_err_name e ) )
-                T r → {
-                    ( println_label `ddl_status` ( nurl_str_int ( pg_result_status r ) ) )
-                    ( pg_clear r )
-                }
-            }
+        = k + k 1
+    }
 
-            // INSERT three rows via parameterised exec. Build the
-            // params Vec freshly each iteration so the per-row cleanup
-            // is unambiguous (pg_exec_params consumes the Strings).
-            : ~ i k 1
-            ~ <= k 3 {
-                : String id_s ( string_from ( nurl_str_int k ) )
-                : String body ( string_with_cap 32 )
-                ( string_push_str body `note-` )
-                ( string_push_str body ( nurl_str_int k ) )
-                : ( Vec String ) params ( vec_with_cap [String] 2 )
-                ( vec_push [String] params id_s )
-                ( vec_push [String] params body )
-                : !PgResult PgErr ins ( pg_exec_params c `INSERT INTO pg_notes (id, body) VALUES ($1, $2)` params )
-                ( vec_free [String] params )
-                ?? ins {
-                    F e → ( println_label `insert` ( pg_err_name e ) )
-                    T r → ( pg_clear r )
-                }
-                = k + k 1
-            }
-
-            // SELECT — walk rows. pg_ntuples gives the count;
-            // pg_get_value pulls each cell as an OWNED String.
-            : !PgResult PgErr q ( pg_exec c `SELECT id, body FROM pg_notes ORDER BY id ASC` )
-            ?? q {
-                F e → ( println_label `select` ( pg_err_name e ) )
-                T r → {
-                    : i nrows ( pg_ntuples r )
-                    ( println_label `nrows` ( nurl_str_int nrows ) )
-                    : ~ i row 0
-                    ~ < row nrows {
-                        : String idv ( pg_get_value r row 0 )
-                        : String bodyv ( pg_get_value r row 1 )
-                        ( nurl_print `row id=` ) ( nurl_print ( string_data idv ) )
-                        ( nurl_print ` body=` ) ( nurl_print ( string_data bodyv ) )
-                        ( nurl_print `\n` )
-                        ( string_free idv )
-                        ( string_free bodyv )
-                        = row + row 1
-                    }
-                    ( pg_clear r )
-                }
-            }
-
-            ( pg_close c )
+    // INSERT a row with a NULL body + NULL score via the builder.
+    : PgParams ps ( pg_params 4 )
+    ( pg_bind_int ps 4 )
+    ( pg_bind_null ps )
+    ( pg_bind_null ps )
+    ( pg_bind_bool ps F )
+    : !PgResult PgErr insn ( pg_exec_params_b c `INSERT INTO pg_notes (id, body, score, ok) VALUES ($1, $2, $3, $4)` ps )
+    ?? insn {
+        F e → ( fail_pg c `insert_null` e )
+        T r → {
+            : String cs ( pg_cmd_status r )
+            ( kv `insert_null` ( string_data cs ) )
+            ( string_free cs )
+            ( pg_clear r )
         }
     }
+
+    // Transaction: insert id=5 inside begin/commit.
+    : !i PgErr bt ( pg_begin c )
+    ?? bt { F e → ( fail_pg c `begin` e )  T _ → {} }
+    : ( Vec String ) tp ( vec_with_cap [String] 4 )
+    ( vec_push [String] tp ( string_from `5` ) )
+    ( vec_push [String] tp ( string_from `note-5` ) )
+    ( vec_push [String] tp ( string_from `105` ) )
+    ( vec_push [String] tp ( string_from `f` ) )
+    : !PgResult PgErr tx ( pg_exec_params c `INSERT INTO pg_notes (id, body, score, ok) VALUES ($1,$2,$3,$4)` tp )
+    ?? tx { F e → ( fail_pg c `tx_insert` e )  T r → ( pg_clear r ) }
+    : !i PgErr ct ( pg_commit c )
+    ?? ct { F e → ( fail_pg c `commit` e )  T _ → ( nurl_print `commit ok\n` ) }
+
+    // Prepared statement: count rows with score above a threshold.
+    : !PgResult PgErr pr ( pg_prepare c `cnt` `SELECT count(*) FROM pg_notes WHERE score > $1` 1 )
+    ?? pr {
+        F e → ( fail_pg c `prepare` e )
+        T r → {
+            ( pg_clear r )
+            : PgParams qp ( pg_params 1 )
+            ( pg_bind_int qp 101 )
+            : !PgResult PgErr q ( pg_exec_prepared_b c `cnt` qp )
+            ?? q {
+                F e → ( fail_pg c `exec_prepared` e )
+                T rr → {
+                    ( kv `count_score_gt_101` ( nurl_str_int ( pg_get_int rr 0 0 ) ) )
+                    ( pg_clear rr )
+                }
+            }
+        }
+    }
+
+    // SELECT — walk rows with typed getters + NULL handling.
+    : !PgResult PgErr sel ( pg_exec c `SELECT id, body, score, ok FROM pg_notes ORDER BY id ASC` )
+    ?? sel {
+        F e → ( fail_pg c `select` e )
+        T r → {
+            : i nrows ( pg_ntuples r )
+            ( kv `nrows` ( nurl_str_int nrows ) )
+            : ~ i row 0
+            ~ < row nrows {
+                : i id ( pg_get_int r row 0 )
+                ( nurl_print `row id=` ) ( nurl_print ( nurl_str_int id ) )
+                ? ( pg_get_is_null r row 1 ) {
+                    ( nurl_print ` body=<null>` )
+                } {
+                    : String body ( pg_get_value r row 1 )
+                    ( nurl_print ` body=` ) ( nurl_print ( string_data body ) )
+                    ( string_free body )
+                }
+                ? ( pg_get_is_null r row 2 ) {
+                    ( nurl_print ` score=<null>` )
+                } {
+                    ( nurl_print ` score=` ) ( nurl_print ( nurl_str_int ( pg_get_int r row 2 ) ) )
+                }
+                ( nurl_print ` ok=` ) ( nurl_print ? ( pg_get_bool r row 3 ) `T` `F` )
+                ( nurl_print `\n` )
+                = row + row 1
+            }
+            ( pg_clear r )
+        }
+    }
+
+    // Escaping smoke test — a value with an embedded quote.
+    : String lit ( pg_escape_literal c `O'Brien` )
+    ( kv `escaped` ( string_data lit ) )
+    ( string_free lit )
+
+    ( pg_close c )
 }
 
 @ main → i {

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ clang -O2 -flto /tmp/fizzbuzz.ll stdlib/runtime.o -lm -lpthread -o /tmp/fizzbuzz
 /tmp/fizzbuzz
 ```
 
-## Catalogue (36 examples)
+## Catalogue (37 examples)
 
 Each example is tagged for where it can run:
 
@@ -80,6 +80,12 @@ Each example is tagged for where it can run:
 | [`async_http_server.nu`](async_http_server.nu) | Same handler contract as `static_server.nu` but runs the request handlers on the M:N fiber runtime. | local (server listener) |
 | [`mcp_echo_server.nu`](mcp_echo_server.nu) | Minimal MCP server over stdio — one `echo` tool. Wire it into an MCP-aware client (Claude Desktop, Claude Code, etc.) and the tool is callable. | local (stdio + MCP client) |
 | [`mcp_echo_server_http.nu`](mcp_echo_server_http.nu) | Same business logic as `mcp_echo_server.nu`, but exposed over HTTP transport. | local (server listener) |
+
+### Databases
+
+| File | What it does | Tag |
+|---|---|---|
+| [`psql.nu`](psql.nu) | A real `psql`-style PostgreSQL client on `stdlib/ext/postgres.nu` (direct libpq FFI): reads SQL from stdin one `;`-terminated statement at a time, renders result sets as aligned tables, reports command tags / `ERROR:` messages, and supports `\dt \d \l \du \conninfo \? \q` plus `-c "SQL"` one-shot mode. Connect via a conninfo arg, `$PG_CONNINFO`, or libpq's own `PG*` env defaults. | local (PostgreSQL + libpq) |
 
 ### LLM / Anthropic API
 

--- a/examples/psql.nu
+++ b/examples/psql.nu
@@ -1,0 +1,340 @@
+// examples/psql.nu — a small but real `psql`-style PostgreSQL client.
+//
+// Built entirely on stdlib/ext/postgres.nu (direct libpq FFI). Behaves
+// like psql for everyday use:
+//
+//   * Connects from a conninfo argument, $PG_CONNINFO, or libpq's own
+//     PG* env-var defaults when neither is given.
+//   * Reads SQL from stdin, one statement at a time (terminated by `;`),
+//     across multiple lines, and prints result sets as aligned tables —
+//     headers, a rule, rows, and an "(N rows)" footer — exactly like
+//     psql's default aligned output.
+//   * Reports the command tag ("INSERT 0 1", "CREATE TABLE", …) for
+//     non-SELECT statements and "ERROR:  …" with the server message on
+//     failure.
+//   * Backslash meta-commands: \dt \d <table> \l \du \conninfo \? \q
+//   * One-shot mode: `psql [conninfo] -c "SQL"` runs a single command.
+//   * Prompts are shown only on an interactive terminal, so piping a
+//     script through it produces clean, prompt-free output.
+//
+// Build:  ./nurl.sh examples/psql.nu psql
+// Run:    ./psql "host=/tmp port=5433 user=postgres dbname=postgres"
+//         echo 'SELECT 1 AS one;' | ./psql "$PG_CONNINFO"
+//         ./psql "$PG_CONNINFO" -c '\dt'
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/io.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/postgres.nu`
+
+& `c` @ isatty i32 fd → i32
+
+// ── Small Vec[i] accessor with a 0 default ───────────────────────
+@ veci ( Vec i ) w i idx → i {
+    ?? ( vec_get [i] w idx ) { T x → ^ x  F _ → ^ 0 }
+}
+
+// Print `str` then pad with spaces out to column width `w`.
+@ print_padded s str i w → v {
+    ( nurl_print str )
+    : ~ i pad - w ( nurl_str_len str )
+    ~ > pad 0 { ( nurl_print ` ` ) = pad - pad 1 }
+}
+
+// ── Result rendering ─────────────────────────────────────────────
+
+// Display length of a cell: 0 for SQL NULL (rendered blank), else the
+// text length.
+@ cell_len PgResult r i row i col → i {
+    ? ( pg_get_is_null r row col ) { ^ 0 } {}
+    : String v ( pg_get_value r row col )
+    : i l ( string_len v )
+    ( string_free v )
+    ^ l
+}
+
+@ print_header PgResult r ( Vec i ) w i nf → v {
+    : ~ i ci 0
+    ~ < ci nf {
+        ? > ci 0 { ( nurl_print `|` ) } {}
+        : String hn ( pg_field_name r ci )
+        ( nurl_print ` ` )
+        ( print_padded ( string_data hn ) ( veci w ci ) )
+        ( nurl_print ` ` )
+        ( string_free hn )
+        = ci + ci 1
+    }
+    ( nurl_print `\n` )
+}
+
+@ print_rule ( Vec i ) w i nf → v {
+    : ~ i ci 0
+    ~ < ci nf {
+        ? > ci 0 { ( nurl_print `+` ) } {}
+        : ~ i d + ( veci w ci ) 2
+        ~ > d 0 { ( nurl_print `-` ) = d - d 1 }
+        = ci + ci 1
+    }
+    ( nurl_print `\n` )
+}
+
+@ print_data_row PgResult r ( Vec i ) w i nf i row → v {
+    : ~ i ci 0
+    ~ < ci nf {
+        ? > ci 0 { ( nurl_print `|` ) } {}
+        ( nurl_print ` ` )
+        ? ( pg_get_is_null r row ci ) {
+            ( print_padded `` ( veci w ci ) )
+        } {
+            : String v ( pg_get_value r row ci )
+            ( print_padded ( string_data v ) ( veci w ci ) )
+            ( string_free v )
+        }
+        ( nurl_print ` ` )
+        = ci + ci 1
+    }
+    ( nurl_print `\n` )
+}
+
+// Render a PgResult: an aligned table for row-returning statements, or
+// the command tag otherwise.
+@ render_result PgResult r → v {
+    : i nf ( pg_nfields r )
+    ? == nf 0 {
+        : String cs ( pg_cmd_status r )
+        ( nurl_print ( string_data cs ) ) ( nurl_print `\n` )
+        ( string_free cs )
+        ^ v
+    } {}
+    : i nt ( pg_ntuples r )
+    // Column widths: header length widened by each cell.
+    : ( Vec i ) w ( vec_with_cap [i] nf )
+    : ~ i ci 0
+    ~ < ci nf {
+        : String hn ( pg_field_name r ci )
+        ( vec_push [i] w ( string_len hn ) )
+        ( string_free hn )
+        = ci + ci 1
+    }
+    : ~ i ri 0
+    ~ < ri nt {
+        = ci 0
+        ~ < ci nf {
+            : i cl ( cell_len r ri ci )
+            ? > cl ( veci w ci ) { ( vec_set [i] w ci cl ) } {}
+            = ci + ci 1
+        }
+        = ri + ri 1
+    }
+    ( print_header r w nf )
+    ( print_rule w nf )
+    = ri 0
+    ~ < ri nt {
+        ( print_data_row r w nf ri )
+        = ri + ri 1
+    }
+    ( nurl_print `(` ) ( nurl_print ( nurl_str_int nt ) )
+    ( nurl_print ? == nt 1 ` row)\n\n` ` rows)\n\n` )
+    ( vec_free [i] w )
+}
+
+// Execute `sql` and render whatever comes back (rows, tag, or error).
+@ exec_and_render Connection c s sql → v {
+    : !PgResult PgErr r ( pg_exec c sql )
+    ?? r {
+        F e → {
+            // libpq's message already carries its own "ERROR:  " prefix
+            // and trailing newline — print it verbatim.
+            : String em ( pg_err_msg c )
+            ( nurl_print ( string_data em ) )
+            ( string_free em )
+        }
+        T res → {
+            ( render_result res )
+            ( pg_clear res )
+        }
+    }
+}
+
+// ── Meta-commands ────────────────────────────────────────────────
+
+@ print_help → v {
+    ( nurl_print `Meta-commands:\n` )
+    ( nurl_print `  \\dt          list tables\n` )
+    ( nurl_print `  \\d  TABLE    describe a table's columns\n` )
+    ( nurl_print `  \\l           list databases\n` )
+    ( nurl_print `  \\du          list roles\n` )
+    ( nurl_print `  \\conninfo    show connection info\n` )
+    ( nurl_print `  \\?           this help\n` )
+    ( nurl_print `  \\q           quit\n` )
+    ( nurl_print `Anything else is sent to the server as SQL (end with ';').\n` )
+}
+
+@ print_conninfo Connection c → v {
+    : String db ( pg_db c )
+    : String usr ( pg_user c )
+    : String host ( pg_host c )
+    ( nurl_print `Connected to database "` ) ( nurl_print ( string_data db ) )
+    ( nurl_print `" as user "` ) ( nurl_print ( string_data usr ) )
+    ( nurl_print `" on host "` ) ( nurl_print ( string_data host ) ) ( nurl_print `".\n` )
+    ( string_free db ) ( string_free usr ) ( string_free host )
+}
+
+// Describe a table: run an information_schema query with the table name
+// safely quoted as a SQL literal.
+@ describe_table Connection c s tbl → v {
+    : String esc ( pg_escape_literal c tbl )
+    : String q ( string_new )
+    ( string_push_str q `SELECT column_name AS column, data_type AS type, is_nullable AS nullable, column_default AS default FROM information_schema.columns WHERE table_name = ` )
+    ( string_push_str q ( string_data esc ) )
+    ( string_push_str q ` ORDER BY ordinal_position` )
+    ( exec_and_render c ( string_data q ) )
+    ( string_free q )
+    ( string_free esc )
+}
+
+// Returns 1 to quit, 0 to continue. `cmd` is the trimmed line, already
+// known to start with '\'.
+@ handle_meta Connection c s cmd → i {
+    ? ( nurl_str_eq cmd `\q` ) { ^ 1 } {}
+    ? ( nurl_str_eq cmd `\dt` ) {
+        ( exec_and_render c `SELECT schemaname AS schema, tablename AS name, tableowner AS owner FROM pg_catalog.pg_tables WHERE schemaname NOT IN ('pg_catalog','information_schema') ORDER BY 1,2` )
+        ^ 0
+    } {}
+    ? ( nurl_str_eq cmd `\l` ) {
+        ( exec_and_render c `SELECT datname AS name FROM pg_database WHERE datistemplate = false ORDER BY 1` )
+        ^ 0
+    } {}
+    ? ( nurl_str_eq cmd `\du` ) {
+        ( exec_and_render c `SELECT rolname AS role, rolsuper AS superuser, rolcanlogin AS login FROM pg_roles ORDER BY 1` )
+        ^ 0
+    } {}
+    ? ( nurl_str_eq cmd `\conninfo` ) { ( print_conninfo c ) ^ 0 } {}
+    ? ( nurl_str_eq cmd `\?` ) { ( print_help ) ^ 0 } {}
+    ? ( nurl_str_starts cmd `\d ` ) {
+        : s tbl ( nurl_str_slice cmd 3 - ( nurl_str_len cmd ) 3 )
+        ( describe_table c tbl )
+        ^ 0
+    } {}
+    ( nurl_print `invalid command: ` ) ( nurl_print cmd ) ( nurl_print `\nTry \\? for help.\n` )
+    ^ 0
+}
+
+// ── REPL ─────────────────────────────────────────────────────────
+
+// Process one input line. Accumulates into `buf` until a `;` terminator,
+// then executes. Meta-commands act only when no statement is pending.
+// Returns 1 to quit, 0 to continue.
+@ process_line Connection c String buf String line → i {
+    : String t ( string_trim line )
+    : i tl ( string_len t )
+    ? == 0 tl { ( string_free t ) ^ 0 } {}
+    ? & == 0 ( string_len buf ) == ( string_get t 0 ) 92 {
+        : i q ( handle_meta c ( string_data t ) )
+        ( string_free t )
+        ^ q
+    } {}
+    ( string_push_str buf ( string_data line ) )
+    ( string_push_char buf 32 )
+    : i done ( string_ends_with t `;` )
+    ( string_free t )
+    ? done {
+        ( exec_and_render c ( string_data buf ) )
+        ( string_clear buf )
+    } {}
+    ^ 0
+}
+
+@ run_repl Connection c i tty → v {
+    : String buf ( string_new )
+    : ~ i running 1
+    ~ != running 0 {
+        ? != 0 tty {
+            ( nurl_print ? == 0 ( string_len buf ) `nurl=> ` `nurl-> ` )
+        } {}
+        : String line ( read_line )
+        ? & == 0 ( string_len line ) ( stdin_eof ) {
+            = running 0
+            ? != 0 tty { ( nurl_print `\n` ) } {}
+        } {
+            : i q ( process_line c buf line )
+            ? != 0 q { = running 0 } {}
+        }
+        ( string_free line )
+    }
+    ( string_free buf )
+}
+
+// ── Banner + entry point ─────────────────────────────────────────
+
+@ print_banner Connection c → v {
+    : String db ( pg_db c )
+    : String usr ( pg_user c )
+    ( nurl_print `psql (NURL) — connected to "` ) ( nurl_print ( string_data db ) )
+    ( nurl_print `" as "` ) ( nurl_print ( string_data usr ) )
+    ( nurl_print `" (server ` ) ( nurl_print ( nurl_str_int ( pg_server_version c ) ) )
+    ( nurl_print `)\nType \\? for help, \\q to quit.\n\n` )
+    ( string_free db ) ( string_free usr )
+}
+
+@ main → i {
+    : ( Vec String ) args ( env_args_list )
+    : i argc ( vec_len [String] args )
+    : ~ s conninfo ``
+    : ~ s command ``
+    : ~ i has_cmd 0
+    : ~ i i 1
+    ~ < i argc {
+        ?? ( vec_get [String] args i ) {
+            T av → {
+                : s as ( string_data av )
+                ? ( nurl_str_eq as `-c` ) {
+                    = i + i 1
+                    ?? ( vec_get [String] args i ) {
+                        T cv → { = command ( string_data cv ) = has_cmd 1 }
+                        F _ → {}
+                    }
+                } {
+                    ? ( nurl_str_starts as `-` ) {} { = conninfo as }
+                }
+            }
+            F _ → {}
+        }
+        = i + i 1
+    }
+    // Fall back to $PG_CONNINFO, then to libpq's own env/defaults ("").
+    ? == 0 ( nurl_str_len conninfo ) {
+        ?? ( env_get `PG_CONNINFO` ) {
+            T ev → = conninfo ( string_data ev )
+            F _ → {}
+        }
+    } {}
+
+    : Connection c ( pg_connect conninfo )
+    ? ! ( pg_ok c ) {
+        : String em ( pg_err_msg c )
+        ( nurl_print `psql: error: ` ) ( nurl_print ( string_data em ) )
+        ( string_free em )
+        ( pg_close c )
+        ^ 1
+    } {}
+
+    ? != 0 has_cmd {
+        : String t ( string_trim ( string_from command ) )
+        ? & > ( string_len t ) 0 == ( string_get t 0 ) 92 {
+            ( handle_meta c ( string_data t ) )
+        } {
+            ( exec_and_render c command )
+        }
+        ( string_free t )
+        ( pg_close c )
+        ^ 0
+    } {}
+
+    : i tty # i ( isatty # i32 0 )
+    ? != 0 tty { ( print_banner c ) } {}
+    ( run_repl c tty )
+    ( pg_close c )
+    ^ 0
+}

--- a/stdlib/ext/postgres.nu
+++ b/stdlib/ext/postgres.nu
@@ -1,61 +1,89 @@
-// stdlib/ext/postgres.nu — PostgreSQL bindings via direct libpq FFI.
+// stdlib/ext/postgres.nu — PostgreSQL client via direct libpq FFI.
 //
 // **Pure-NURL FFI** — every libpq symbol is declared with `& `pq` @ ...`
 // directly in this file. There is no `runtime.c` bridge, in contrast
 // to `stdlib/ext/sqlite.nu` which routes through `nurl_sqlite_*`
 // runtime wrappers. The compiler's FFI-lib-check (`gen_ffi_decl`)
-// scans every `&`-decl for a build-time sentinel
-// `stdlib/runtime.<libname>`; absent libpq-dev → clear compile-time
-// diagnostic, not a cryptic linker error.
+// scans every `&`-decl for a build-time sentinel `stdlib/runtime.pq`;
+// absent libpq-dev → clear compile-time diagnostic, not a cryptic
+// linker error.
 //
-// API:
+// Production surface:
 //
-//   ( pg_connect s conninfo )                  → ! Connection PgErr
-//   ( pg_close Connection c )                  → v
-//   ( pg_err_msg Connection c )                → String          OWNED
-//   ( pg_exec Connection c s sql )             → ! PgResult PgErr
-//   ( pg_exec_params Connection c s sql ( Vec String ) params ) → ! PgResult PgErr
-//   ( pg_result_status PgResult r )            → i               raw libpq ExecStatusType
-//   ( pg_result_is_ok PgResult r )             → b
-//   ( pg_ntuples PgResult r )                  → i
-//   ( pg_nfields PgResult r )                  → i
-//   ( pg_get_value PgResult r i row i col )    → String          OWNED
-//   ( pg_get_is_null PgResult r i row i col )  → b
-//   ( pg_field_name PgResult r i col )         → String          OWNED
-//   ( pg_clear PgResult r )                    → v
+//   Connection
+//     ( pg_connect s conninfo )            → Connection  (always a handle)
+//     ( pg_ok Connection )                 → b           CONNECTION_OK?
+//     ( pg_close Connection )              → v
+//     ( pg_reset Connection )              → v           reconnect, same params
+//     ( pg_err_msg Connection )            → String      OWNED, last error text
+//     ( pg_server_version Connection )     → i           e.g. 160014 = 16.0.14
+//     ( pg_db / pg_user / pg_host Conn )   → String      OWNED
+//
+//   Escaping (SQL-injection-safe literal/identifier quoting)
+//     ( pg_escape_literal Connection s )   → String      OWNED, '…'-quoted
+//     ( pg_escape_identifier Connection s )→ String      OWNED, "…"-quoted
+//
+//   Statement execution
+//     ( pg_exec Connection s sql )                       → ! PgResult PgErr
+//     ( pg_exec_params Connection s sql ( Vec String ) ) → ! PgResult PgErr  (all-text, no NULLs)
+//     ( pg_exec_params_b Connection s sql PgParams )     → ! PgResult PgErr  (typed + NULL binds)
+//     ( pg_prepare Conn s name s query i nparams )       → ! PgResult PgErr
+//     ( pg_exec_prepared Conn s name ( Vec String ) )    → ! PgResult PgErr
+//     ( pg_exec_prepared_b Conn s name PgParams )        → ! PgResult PgErr
+//     ( pg_run Connection s sql )                        → ! i PgErr  (auto-clears, → affected rows)
+//
+//   Parameter builder (NULL-aware / typed)
+//     ( pg_params i cap )                  → PgParams
+//     ( pg_bind_text/_str/_int/_bool/_null PgParams … )  → v
+//     ( pg_params_free PgParams )          → v   (or let an exec_*_b consume it)
+//
+//   Transactions (thin pg_run wrappers; auto-clear)
+//     ( pg_begin / pg_commit / pg_rollback Connection )  → ! i PgErr
+//
+//   Result inspection
+//     ( pg_result_status PgResult )        → i   raw libpq ExecStatusType
+//     ( pg_result_is_ok PgResult )         → b
+//     ( pg_result_err PgResult )           → String  OWNED  PQresultErrorMessage
+//     ( pg_cmd_status PgResult )           → String  OWNED  e.g. "INSERT 0 3"
+//     ( pg_affected PgResult )             → i       rows touched by INSERT/UPDATE/DELETE
+//     ( pg_ntuples / pg_nfields PgResult ) → i
+//     ( pg_field_name PgResult i col )     → String  OWNED
+//     ( pg_fnumber PgResult s name )       → i       column index by name, -1 if absent
+//     ( pg_ftype PgResult i col )          → i       column type OID
+//     ( pg_get_value PgResult i row i col )→ String  OWNED
+//     ( pg_get_is_null PgResult i row i col) → b
+//     ( pg_get_int / pg_get_i64 … i col )  → i       text → integer
+//     ( pg_get_f64 … )                     → f       text → double
+//     ( pg_get_bool … )                    → b       't'/'f' → true/false
+//     ( pg_clear PgResult )                → v
 //
 // Memory model:
 //
-//   * `pg_connect` ALWAYS returns a Connection handle, even on Err —
-//     libpq's `PQconnectdb` returns a non-NULL `PGconn*` even on
-//     failure so the caller can inspect `PQerrorMessage`. On the Err
-//     arm the handle MUST still be closed via `pg_close` to release
-//     the underlying struct.
-//   * `pg_exec` / `pg_exec_params` return an OWNED PgResult; the
-//     caller MUST `pg_clear` it (`PQclear`) when done, even on Err.
-//   * `pg_get_value` / `pg_field_name` / `pg_err_msg` return OWNED
-//     Strings (copied via `string_from` because libpq's pointers
-//     become invalid after `PQclear` / `PQfinish`).
-//
-// MVP scope NOT covered (intentional follow-ups):
-//   * Binary protocol (`PQexecParams` always uses text-format here).
-//   * COPY-FROM / COPY-TO streaming.
-//   * Async / non-blocking mode (`PQsendQuery` + `PQconsumeInput`).
-//   * LISTEN / NOTIFY notification channels.
-//   * Prepared statements named on server (`PQprepare`, `PQexecPrepared`).
-//   * SSL / GSSAPI auth tuning (connection string carries `sslmode=`).
-//   * Large objects (lo_*).
-//
-// Errors — `PgErr` mirrors the most-common failure modes. libpq's
-// fine-grained `ExecStatusType` codes ride the OK arm as the raw int
-// (consulted via `pg_result_status` / `pg_result_is_ok`):
+//   * `pg_connect` ALWAYS returns a Connection handle — libpq's
+//     `PQconnectdb` returns a non-NULL `PGconn*` even on failure so the
+//     caller can inspect `pg_err_msg`. ALWAYS `pg_close` it, healthy or
+//     not, to release the underlying struct.
+//   * `pg_exec` family return an OWNED PgResult on the T arm; the caller
+//     MUST `pg_clear` it (`PQclear`). On the F arm there is nothing to
+//     clear — the failed result is cleared internally. Read the error
+//     text with `pg_err_msg` on the connection.
+//   * `pg_exec_params` / `pg_exec_params_opt` / `pg_exec_prepared`
+//     CONSUME their params Vec — they free every element String and the
+//     Vec backing after the exec. Do NOT touch or free the Vec afterward.
+//   * `pg_get_value` / `pg_field_name` / `pg_err_msg` / escape / info
+//     getters return OWNED Strings (copied via `string_from` because
+//     libpq's pointers become invalid after `PQclear` / `PQfinish`).
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 
+// Errors — `PgErr` is a lightweight code; the human-readable text is
+// always retrievable from the connection via `pg_err_msg` (libpq copies
+// the failing result's message into the connection's error buffer), so
+// the enum carries no owned payload to free.
 : | PgErr {
-    PgConnectFailed  // PQstatus(conn) != CONNECTION_OK after PQconnectdb
-    PgExecFailed  // PQresultStatus != PGRES_COMMAND_OK / PGRES_TUPLES_OK
+    PgConnectFailed  // PQstatus(conn) != CONNECTION_OK
+    PgExecFailed  // PQresultStatus not COMMAND_OK / TUPLES_OK
     PgNullResult  // PQexec / PQexecParams returned NULL (OOM / fatal)
     PgOther  // anything else
 }
@@ -74,82 +102,127 @@ $ `stdlib/core/vec.nu`
 
 // ── FFI declarations ──────────────────────────────────────────────
 //
-// All NURL `s` parameters are i8* in LLVM, which is exactly the shape
-// libpq expects for `const char *` arguments AND for returning
-// `PGconn*` / `PGresult*` opaque handles. We thread those handles
-// through NURL Connection / PgResult value structs as `s raw`.
+// Every NURL `s` parameter is i8* in LLVM, the exact shape libpq wants
+// for `const char *` arguments AND for returning `PGconn*` / `PGresult*`
+// opaque handles — threaded through NURL Connection / PgResult structs
+// as `s raw`.
 
 & `pq` @ PQconnectdb s conninfo → s
-
 & `pq` @ PQfinish s conn → v
-
+& `pq` @ PQreset s conn → v
 & `pq` @ PQstatus s conn → i32
-
 & `pq` @ PQerrorMessage s conn → s
+& `pq` @ PQserverVersion s conn → i32
+& `pq` @ PQdb s conn → s
+& `pq` @ PQuser s conn → s
+& `pq` @ PQhost s conn → s
+
+& `pq` @ PQescapeLiteral s conn s str i len → s
+& `pq` @ PQescapeIdentifier s conn s str i len → s
+& `pq` @ PQfreemem s ptr → v
 
 & `pq` @ PQexec s conn s sql → s
+// Parameterised exec — text format only (paramTypes / paramLengths /
+// paramFormats / resultFormat all 0/NULL so libpq treats every param as
+// a NUL-terminated UTF-8 string and returns text rows). A NULL entry in
+// the values array is sent as SQL NULL.
+& `pq` @ PQexecParams s conn s sql i32 n_params *u types **u values *i32 lens *i32 fmts i32 res_fmt → s
+& `pq` @ PQprepare s conn s stmt s query i32 n_params *u types → s
+& `pq` @ PQexecPrepared s conn s stmt i32 n_params **u values *i32 lens *i32 fmts i32 res_fmt → s
 
 & `pq` @ PQclear s res → v
-
 & `pq` @ PQresultStatus s res → i32
-
+& `pq` @ PQresultErrorMessage s res → s
+& `pq` @ PQcmdStatus s res → s
+& `pq` @ PQcmdTuples s res → s
 & `pq` @ PQntuples s res → i32
-
 & `pq` @ PQnfields s res → i32
-
+& `pq` @ PQfname s res i32 col → s
+& `pq` @ PQfnumber s res s name → i32
+& `pq` @ PQftype s res i32 col → u32
 & `pq` @ PQgetvalue s res i32 row i32 col → s
-
 & `pq` @ PQgetisnull s res i32 row i32 col → i32
 
-& `pq` @ PQfname s res i32 col → s
-// Parameterised exec — text format only (paramTypes / paramLengths /
-// paramFormats / resultFormat all set to 0/NULL so libpq treats every
-// param as a NUL-terminated UTF-8 string and returns text rows).
-& `pq` @ PQexecParams s conn s sql i32 n_params *u types **u values *i32 lens *i32 fmts i32 res_fmt → s
-
-// PQstatus return codes (from libpq-fe.h):
-//   CONNECTION_OK = 0
-//   CONNECTION_BAD = 1
-// PQresultStatus codes:
-//   PGRES_COMMAND_OK = 1
-//   PGRES_TUPLES_OK = 2
-//   anything else → error (PGRES_BAD_RESPONSE = 5, PGRES_FATAL_ERROR = 7, …)
+// PQstatus:        CONNECTION_OK = 0,  CONNECTION_BAD = 1
+// PQresultStatus:  PGRES_COMMAND_OK = 1,  PGRES_TUPLES_OK = 2,
+//                  PGRES_FATAL_ERROR = 7, …
 
 // ── Connection lifecycle ──────────────────────────────────────────
 
-@ pg_connect s conninfo → !Connection PgErr {
+// Open a connection. ALWAYS returns a handle (even on failure) so the
+// caller can read `pg_err_msg`. Check `pg_ok`; always `pg_close`.
+@ pg_connect s conninfo → Connection {
     : s raw ( PQconnectdb conninfo )
-    ? == 0 ( nurl_str_len raw ) {
-        ^ @ !Connection PgErr { F # PgErr PgConnectFailed }
-    } {}
-    : i32 st ( PQstatus raw )
-    : i sti # i st
-    ? != sti 0 {
-        // CONNECTION_BAD — caller must still close to release the struct.
-        : Connection bad @ Connection { raw }
-        ( pg_close bad )
-        ^ @ !Connection PgErr { F # PgErr PgConnectFailed }
-    } {}
-    ^ @ !Connection PgErr { T @ Connection { raw } }
+    ^ @ Connection { raw }
+}
+
+@ pg_ok Connection c → b {
+    : i32 st ( PQstatus . c raw )
+    ^ == # i st 0
 }
 
 @ pg_close Connection c → v {
     ( PQfinish . c raw )
 }
 
-// Read the most recent error from the connection. Returned String is
-// OWNED — caller frees with `string_free`. Empty on a healthy
-// connection.
-@ pg_err_msg Connection c → String {
-    : s borrowed ( PQerrorMessage . c raw )
-    ^ ( string_from borrowed )
+// Reset (reconnect) using the original connection parameters. Recovers
+// a connection broken by a server restart or network blip.
+@ pg_reset Connection c → v {
+    ( PQreset . c raw )
 }
 
-// ── Statement execution ──────────────────────────────────────────
+// Most recent error text. OWNED String — caller frees with `string_free`.
+// Empty on a healthy connection.
+@ pg_err_msg Connection c → String {
+    ^ ( string_from ( PQerrorMessage . c raw ) )
+}
 
-@ pg_exec Connection c s sql → !PgResult PgErr {
-    : s raw ( PQexec . c raw sql )
-    ? == 0 ( nurl_str_len raw ) {
+@ pg_server_version Connection c → i {
+    ^ # i ( PQserverVersion . c raw )
+}
+
+@ pg_db Connection c → String {
+    ^ ( string_from ( PQdb . c raw ) )
+}
+
+@ pg_user Connection c → String {
+    ^ ( string_from ( PQuser . c raw ) )
+}
+
+@ pg_host Connection c → String {
+    ^ ( string_from ( PQhost . c raw ) )
+}
+
+// ── Escaping ──────────────────────────────────────────────────────
+//
+// PQescapeLiteral / PQescapeIdentifier return a freshly-malloc'd,
+// already-quoted C string we must copy then release with PQfreemem.
+
+@ pg_escape_literal Connection c s str → String {
+    : i len ( nurl_str_len str )
+    : s raw ( PQescapeLiteral . c raw str len )
+    ? == raw 0 { ^ ( string_from `` ) } {}
+    : String out ( string_from raw )
+    ( PQfreemem raw )
+    ^ out
+}
+
+@ pg_escape_identifier Connection c s str → String {
+    : i len ( nurl_str_len str )
+    : s raw ( PQescapeIdentifier . c raw str len )
+    ? == raw 0 { ^ ( string_from `` ) } {}
+    : String out ( string_from raw )
+    ( PQfreemem raw )
+    ^ out
+}
+
+// ── Result construction helper ────────────────────────────────────
+//
+// Wrap a raw PGresult* from any of the exec entry points: NULL → Err
+// PgNullResult; status COMMAND_OK/TUPLES_OK → Ok; otherwise clear and
+// Err PgExecFailed (the message rides the connection's error buffer).
+@ __pg_wrap_result s raw → !PgResult PgErr {
+    ? == raw 0 {
         ^ @ !PgResult PgErr { F # PgErr PgNullResult }
     } {}
     : PgResult r @ PgResult { raw }
@@ -160,54 +233,225 @@ $ `stdlib/core/vec.nu`
     ^ @ !PgResult PgErr { F # PgErr PgExecFailed }
 }
 
-// Parameterised exec — every parameter is a NUL-terminated text-
-// format string. NULL parameters are not supported in this MVP (use
-// `IS NULL` in SQL with no bind). For binary parameters or NULLs,
-// extend with `pg_exec_params_ex` later.
+// ── Statement execution ──────────────────────────────────────────
+
+@ pg_exec Connection c s sql → !PgResult PgErr {
+    ^ ( __pg_wrap_result ( PQexec . c raw sql ) )
+}
+
+// Parameterised exec — every parameter is a NUL-terminated text-format
+// string. CONSUMES `params`: the element Strings and the Vec backing are
+// freed after the exec (libpq has copied the values by then).
 @ pg_exec_params Connection c s sql ( Vec String ) params → !PgResult PgErr {
     : i n ( vec_len [String] params )
-    // Build a parallel array of `char *` pointers from the params Vec.
-    // 8 bytes per pointer; libpq just reads, doesn't write.
+    // Parallel `char *` array. 8 bytes per pointer; libpq only reads it.
     : s vals ( nurl_alloc * n 8 )
     : ~ i k 0
     ~ < k n {
         : ?String pk ( vec_get [String] params k )
         ?? pk {
-            T sv → {
-                : s sdata ( string_data sv )
-                // nurl_poke uses SLOT indexing (×8 stride internally);
-                // pass `k`, NOT `k * 8`.
-                ( nurl_poke vals k # i sdata )
-                ( string_free sv )
-            }
+            // nurl_poke uses SLOT indexing (×8 internally) — pass `k`,
+            // NOT `k * 8`. Borrow string_data; do NOT free yet.
+            T sv → ( nurl_poke vals k # i ( string_data sv ) )
             F _ → ( nurl_poke vals k 0 )
         }
         = k + k 1
     }
+    : !PgResult PgErr res ( __pg_exec_params_raw c sql n vals )
+    ( nurl_free vals )
+    // Exec done — libpq copied the params, safe to release the Strings.
+    ( vec_free_with [String] params \ String s → v { ( string_free s ) } )
+    ^ res
+}
+
+// ── PgParams: NULL-aware / typed parameter builder ───────────────
+//
+// libpq binds parameters through a parallel `char**` array where a NULL
+// pointer means SQL NULL. PgParams is that array, built incrementally
+// with typed binders — the production way to pass NULLs and non-string
+// values (mirrors libpq's paramValues, pgx, and tokio-postgres). Each
+// slot keeps its text in `texts` and a `nulls` flag (1 = SQL NULL, the
+// text slot then holds a throwaway empty String). CONSUMED by
+// `pg_exec_params_b` / `pg_exec_prepared_b`, which free it after exec.
+//
+//   : PgParams ps ( pg_params 3 )
+//   ( pg_bind_text ps `alice` )
+//   ( pg_bind_int  ps 42 )
+//   ( pg_bind_null ps )
+//   : !PgResult PgErr r ( pg_exec_params_b c `INSERT … VALUES ($1,$2,$3)` ps )
+: PgParams { ( Vec String ) texts ( Vec i ) nulls }
+
+@ pg_params i cap → PgParams {
+    : i want ? > cap 0 cap 1
+    ^ @ PgParams { ( vec_with_cap [String] want ) ( vec_with_cap [i] want ) }
+}
+
+// Bind a borrowed C string (copied into an owned slot).
+@ pg_bind_text PgParams p s val → v {
+    ( vec_push [String] . p texts ( string_from val ) )
+    ( vec_push [i] . p nulls 0 )
+}
+
+// Bind an already-owned String (PgParams takes ownership).
+@ pg_bind_str PgParams p String val → v {
+    ( vec_push [String] . p texts val )
+    ( vec_push [i] . p nulls 0 )
+}
+
+@ pg_bind_int PgParams p i val → v {
+    ( vec_push [String] . p texts ( string_from ( nurl_str_int val ) ) )
+    ( vec_push [i] . p nulls 0 )
+}
+
+// PostgreSQL accepts 't'/'f' (and 'true'/'false') as boolean literals.
+@ pg_bind_bool PgParams p b val → v {
+    ( vec_push [String] . p texts ( string_from ? val `t` `f` ) )
+    ( vec_push [i] . p nulls 0 )
+}
+
+@ pg_bind_null PgParams p → v {
+    ( vec_push [String] . p texts ( string_new ) )
+    ( vec_push [i] . p nulls 1 )
+}
+
+@ pg_params_len PgParams p → i {
+    ^ ( vec_len [String] . p texts )
+}
+
+@ pg_params_free PgParams p → v {
+    ( vec_free_with [String] . p texts \ String s → v { ( string_free s ) } )
+    ( vec_free [i] . p nulls )
+}
+
+// Build the borrowed `char**` array from a PgParams. NULL slots become a
+// 0 pointer (SQL NULL); the text pointers stay valid until the params are
+// freed, which the exec wrappers do only after PQexecParams returns.
+@ __pg_params_vals PgParams p → s {
+    : ( Vec String ) texts . p texts
+    : ( Vec i ) nulls . p nulls
+    : i n ( vec_len [String] texts )
+    : s vals ( nurl_alloc * ? > n 0 n 1 8 )
+    : ~ i k 0
+    ~ < k n {
+        : ?i fl ( vec_get [i] nulls k )
+        : ~ i is_null 0
+        ?? fl { T x → = is_null x  F _ → {} }
+        ? != is_null 0 {
+            ( nurl_poke vals k 0 )
+        } {
+            ?? ( vec_get [String] texts k ) {
+                T sv → ( nurl_poke vals k # i ( string_data sv ) )
+                F _ → ( nurl_poke vals k 0 )
+            }
+        }
+        = k + k 1
+    }
+    ^ vals
+}
+
+// PgParams-driven parameterised exec. CONSUMES `p`.
+@ pg_exec_params_b Connection c s sql PgParams p → !PgResult PgErr {
+    : i n ( pg_params_len p )
+    : s vals ( __pg_params_vals p )
+    : !PgResult PgErr res ( __pg_exec_params_raw c sql n vals )
+    ( nurl_free vals )
+    ( pg_params_free p )
+    ^ res
+}
+
+// PgParams-driven prepared-statement exec. CONSUMES `p`.
+@ pg_exec_prepared_b Connection c s name PgParams p → !PgResult PgErr {
+    : i n ( pg_params_len p )
+    : s vals ( __pg_params_vals p )
+    : **u vptr # **u vals
+    : *i32 lens # *i32 0
+    : *i32 fmts # *i32 0
+    : i32 nn # i32 n
+    : i32 zero # i32 0
+    : !PgResult PgErr res ( __pg_wrap_result ( PQexecPrepared . c raw name nn vptr lens fmts zero ) )
+    ( nurl_free vals )
+    ( pg_params_free p )
+    ^ res
+}
+
+// Shared PQexecParams trampoline — `vals` is the prepared `char**`.
+@ __pg_exec_params_raw Connection c s sql i n s vals → !PgResult PgErr {
     : **u vptr # **u vals
     : *u types # *u 0
     : *i32 lens # *i32 0
     : *i32 fmts # *i32 0
     : i32 nn # i32 n
     : i32 zero # i32 0
-    : s raw ( PQexecParams . c raw sql nn types vptr lens fmts zero )
+    ^ ( __pg_wrap_result ( PQexecParams . c raw sql nn types vptr lens fmts zero ) )
+}
+
+// Server-side prepared statement. `name` is the statement name (use
+// `` for the unnamed statement). `nparams` is the placeholder count;
+// types are inferred by the server (paramTypes = NULL). Returns a
+// COMMAND_OK PgResult on success — `pg_clear` it.
+@ pg_prepare Connection c s name s query i nparams → !PgResult PgErr {
+    : i32 np # i32 nparams
+    : *u types # *u 0
+    ^ ( __pg_wrap_result ( PQprepare . c raw name query np types ) )
+}
+
+// Execute a previously-prepared statement by name. CONSUMES `params`.
+@ pg_exec_prepared Connection c s name ( Vec String ) params → !PgResult PgErr {
+    : i n ( vec_len [String] params )
+    : s vals ( nurl_alloc * n 8 )
+    : ~ i k 0
+    ~ < k n {
+        : ?String pk ( vec_get [String] params k )
+        ?? pk {
+            T sv → ( nurl_poke vals k # i ( string_data sv ) )
+            F _ → ( nurl_poke vals k 0 )
+        }
+        = k + k 1
+    }
+    : **u vptr # **u vals
+    : *i32 lens # *i32 0
+    : *i32 fmts # *i32 0
+    : i32 nn # i32 n
+    : i32 zero # i32 0
+    : !PgResult PgErr res ( __pg_wrap_result ( PQexecPrepared . c raw name nn vptr lens fmts zero ) )
     ( nurl_free vals )
-    ? == 0 ( nurl_str_len raw ) {
-        ^ @ !PgResult PgErr { F # PgErr PgNullResult }
-    } {}
-    : PgResult r @ PgResult { raw }
-    ? ( pg_result_is_ok r ) {
-        ^ @ !PgResult PgErr { T r }
-    } {}
-    ( pg_clear r )
-    ^ @ !PgResult PgErr { F # PgErr PgExecFailed }
+    ( vec_free_with [String] params \ String s → v { ( string_free s ) } )
+    ^ res
+}
+
+// Fire-and-forget exec for DDL/DML — runs `sql`, auto-clears the result,
+// and yields the number of rows affected (0 for DDL). The error text is
+// on the connection via `pg_err_msg`.
+@ pg_run Connection c s sql → !i PgErr {
+    : !PgResult PgErr rr ( pg_exec c sql )
+    ?? rr {
+        F e → ^ @ !i PgErr { F e }
+        T r → {
+            : i n ( pg_affected r )
+            ( pg_clear r )
+            ^ @ !i PgErr { T n }
+        }
+    }
+}
+
+// ── Transactions ─────────────────────────────────────────────────
+
+@ pg_begin Connection c → !i PgErr {
+    ^ ( pg_run c `BEGIN` )
+}
+
+@ pg_commit Connection c → !i PgErr {
+    ^ ( pg_run c `COMMIT` )
+}
+
+@ pg_rollback Connection c → !i PgErr {
+    ^ ( pg_run c `ROLLBACK` )
 }
 
 // ── Result inspection ────────────────────────────────────────────
 
 @ pg_result_status PgResult r → i {
-    : i32 st ( PQresultStatus . r raw )
-    ^ # i st
+    ^ # i ( PQresultStatus . r raw )
 }
 
 @ pg_result_is_ok PgResult r → b {
@@ -215,34 +459,78 @@ $ `stdlib/core/vec.nu`
     ^ | == st 1 == st 2
 }
 
+// PQresultErrorMessage — error text tied to this specific result. OWNED.
+@ pg_result_err PgResult r → String {
+    ^ ( string_from ( PQresultErrorMessage . r raw ) )
+}
+
+// Command tag, e.g. "INSERT 0 3", "UPDATE 5", "CREATE TABLE". OWNED.
+@ pg_cmd_status PgResult r → String {
+    ^ ( string_from ( PQcmdStatus . r raw ) )
+}
+
+// Rows affected by the INSERT/UPDATE/DELETE/MOVE/FETCH that produced
+// this result. 0 for statements that touch no rows (DDL, SELECT).
+@ pg_affected PgResult r → i {
+    ^ ( nurl_str_to_int ( PQcmdTuples . r raw ) )
+}
+
 @ pg_ntuples PgResult r → i {
-    : i32 n ( PQntuples . r raw )
-    ^ # i n
+    ^ # i ( PQntuples . r raw )
 }
 
 @ pg_nfields PgResult r → i {
-    : i32 n ( PQnfields . r raw )
-    ^ # i n
+    ^ # i ( PQnfields . r raw )
+}
+
+@ pg_field_name PgResult r i col → String {
+    : i32 c32 # i32 col
+    ^ ( string_from ( PQfname . r raw c32 ) )
+}
+
+// Column index for `name`, or -1 if there is no such column.
+@ pg_fnumber PgResult r s name → i {
+    ^ # i ( PQfnumber . r raw name )
+}
+
+// Column type OID (pg_type.oid). 23 = int4, 25 = text, 16 = bool, …
+@ pg_ftype PgResult r i col → i {
+    : i32 c32 # i32 col
+    ^ # i ( PQftype . r raw c32 )
 }
 
 @ pg_get_value PgResult r i row i col → String {
     : i32 r32 # i32 row
     : i32 c32 # i32 col
-    : s borrowed ( PQgetvalue . r raw r32 c32 )
-    ^ ( string_from borrowed )
+    ^ ( string_from ( PQgetvalue . r raw r32 c32 ) )
 }
 
 @ pg_get_is_null PgResult r i row i col → b {
     : i32 r32 # i32 row
     : i32 c32 # i32 col
-    : i32 v ( PQgetisnull . r raw r32 c32 )
-    ^ != 0 # i v
+    ^ != 0 # i ( PQgetisnull . r raw r32 c32 )
 }
 
-@ pg_field_name PgResult r i col → String {
+// Typed accessors — read the text cell directly (no owned-String copy)
+// and parse. NULL / empty cells parse to 0 / 0.0 / false.
+@ pg_get_int PgResult r i row i col → i {
+    : i32 r32 # i32 row
     : i32 c32 # i32 col
-    : s borrowed ( PQfname . r raw c32 )
-    ^ ( string_from borrowed )
+    ^ ( nurl_str_to_int ( PQgetvalue . r raw r32 c32 ) )
+}
+
+@ pg_get_f64 PgResult r i row i col → f {
+    : i32 r32 # i32 row
+    : i32 c32 # i32 col
+    ^ ( nurl_str_to_float ( PQgetvalue . r raw r32 c32 ) )
+}
+
+// PostgreSQL renders boolean as the single byte 't' / 'f'.
+@ pg_get_bool PgResult r i row i col → b {
+    : i32 r32 # i32 row
+    : i32 c32 # i32 col
+    : s v ( PQgetvalue . r raw r32 c32 )
+    ^ == ( nurl_str_get v 0 ) 116
 }
 
 @ pg_clear PgResult r → v {


### PR DESCRIPTION
Bring stdlib/ext/postgres.nu to production grade and add a working psql-style CLI client. Verified live against PostgreSQL 16.

postgres.nu:
- Fix a latent use-after-free: pg_exec_params freed each param String before PQexecParams read its pointer; params are now freed only after the exec returns (vec_free_with).
- pg_connect now always returns a Connection (libpq-faithful); check pg_ok. Add pg_reset / pg_err_msg / pg_server_version / pg_db / pg_user / pg_host, pg_escape_literal / pg_escape_identifier.
- PgParams builder (pg_bind_text/str/int/bool/null) for typed + NULL parameter binds — the libpq/pgx way (parallel paramValues array), with pg_exec_params_b / pg_exec_prepared_b.
- pg_prepare / pg_exec_prepared, pg_run (auto-clear -> affected rows), pg_begin / pg_commit / pg_rollback, pg_result_err / pg_cmd_status / pg_affected / pg_fnumber / pg_ftype and typed getters (pg_get_int / pg_get_f64 / pg_get_bool).

examples/psql.nu:
- Aligned-table renderer, command tags, ERROR passthrough, multi-line statement accumulation to ';', backslash meta-commands (\dt \d \l \du \conninfo \? \q), `-c "SQL"` one-shot, tty-gated prompts. Connect via conninfo arg, $PG_CONNINFO, or libpq PG* defaults.

Compiler fixes found on the way (full test suite green):
- gen_binary: pointer-vs-integer comparison emitted invalid IR (`icmp eq i8* %p, 0`). Comparison operators now ptrtoint any pointer operand to i64 and compare in i64, so `== raw 0` null-checks and pointer<->pointer compares are valid. This removes the reason the old client null-checked opaque handles via strlen.
- gen_ident: `^ v` from a void function emitted `ret i64 %v` (undefined SSA at the wrong type). An unshadowed void keyword `v` in value position now denotes the void value.