### PR TITLE
feat(postgres): option-typed params + getters (Vec ?String, ?String r…

### DIFF
--- a/compiler/tests/postgres_basic.nu
+++ b/compiler/tests/postgres_basic.nu
@@ -90,6 +90,25 @@ $ `stdlib/ext/postgres.nu`
         }
     }
 
+    // INSERT id=6 with a NULL body via the OPTION-typed params API
+    // (`Vec ?String`, None = SQL NULL — internally walked with
+    // `vec_get [?String]` → `??String`).
+    : ( Vec ?String ) op ( vec_with_cap [?String] 4 )
+    ( vec_push [?String] op @ ?String { T ( string_from `6` ) } )
+    ( vec_push [?String] op @ ?String { F # String 0 } )
+    ( vec_push [?String] op @ ?String { T ( string_from `106` ) } )
+    ( vec_push [?String] op @ ?String { T ( string_from `t` ) } )
+    : !PgResult PgErr inso ( pg_exec_params_opt c `INSERT INTO pg_notes (id, body, score, ok) VALUES ($1,$2,$3,$4)` op )
+    ?? inso {
+        F e → ( fail_pg c `insert_opt` e )
+        T r → {
+            : String cs ( pg_cmd_status r )
+            ( kv `insert_opt` ( string_data cs ) )
+            ( string_free cs )
+            ( pg_clear r )
+        }
+    }
+
     // Transaction: insert id=5 inside begin/commit.
     : !i PgErr bt ( pg_begin c )
     ?? bt { F e → ( fail_pg c `begin` e )  T _ → {} }
@@ -133,17 +152,18 @@ $ `stdlib/ext/postgres.nu`
             ~ < row nrows {
                 : i id ( pg_get_int r row 0 )
                 ( nurl_print `row id=` ) ( nurl_print ( nurl_str_int id ) )
-                ? ( pg_get_is_null r row 1 ) {
-                    ( nurl_print ` body=<null>` )
-                } {
-                    : String body ( pg_get_value r row 1 )
-                    ( nurl_print ` body=` ) ( nurl_print ( string_data body ) )
-                    ( string_free body )
+                // Option-typed read: body comes back as ?String (None on NULL).
+                ?? ( pg_get_opt r row 1 ) {
+                    T body → {
+                        ( nurl_print ` body=` ) ( nurl_print ( string_data body ) )
+                        ( string_free body )
+                    }
+                    F _ → ( nurl_print ` body=<null>` )
                 }
-                ? ( pg_get_is_null r row 2 ) {
-                    ( nurl_print ` score=<null>` )
-                } {
-                    ( nurl_print ` score=` ) ( nurl_print ( nurl_str_int ( pg_get_int r row 2 ) ) )
+                // Option-typed integer read for the (nullable) score.
+                ?? ( pg_get_opt_int r row 2 ) {
+                    T sc → { ( nurl_print ` score=` ) ( nurl_print ( nurl_str_int sc ) ) }
+                    F _ → ( nurl_print ` score=<null>` )
                 }
                 ( nurl_print ` ok=` ) ( nurl_print ? ( pg_get_bool r row 3 ) `T` `F` )
                 ( nurl_print `\n` )

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ clang -O2 -flto /tmp/fizzbuzz.ll stdlib/runtime.o -lm -lpthread -o /tmp/fizzbuzz
 /tmp/fizzbuzz
 ```
 
-## Catalogue (37 examples)
+## Catalogue (38 examples)
 
 Each example is tagged for where it can run:
 
@@ -86,6 +86,7 @@ Each example is tagged for where it can run:
 | File | What it does | Tag |
 |---|---|---|
 | [`psql.nu`](psql.nu) | A real `psql`-style PostgreSQL client on `stdlib/ext/postgres.nu` (direct libpq FFI): reads SQL from stdin one `;`-terminated statement at a time, renders result sets as aligned tables, reports command tags / `ERROR:` messages, and supports `\dt \d \l \du \conninfo \? \q` plus `-c "SQL"` one-shot mode. Connect via a conninfo arg, `$PG_CONNINFO`, or libpq's own `PG*` env defaults. | local (PostgreSQL + libpq) |
+| [`pg_optional.nu`](pg_optional.nu) | PostgreSQL with the language's **option types**: binds nullable parameters with `Vec ?String` (`F` = SQL NULL) via `pg_exec_params_opt` — internally walked with `vec_get [?String]` → `??String` — and reads nullable columns back as `?String` / `?i` via `pg_get_opt` / `pg_get_opt_int`, matched with `??`. | local (PostgreSQL + libpq) |
 
 ### LLM / Anthropic API
 

--- a/examples/pg_optional.nu
+++ b/examples/pg_optional.nu
@@ -1,0 +1,110 @@
+// examples/pg_optional.nu — PostgreSQL with the language's option types.
+//
+// Shows the option-typed surface of `stdlib/ext/postgres.nu` end to end:
+//
+//   * Binding parameters with `Vec ?String` — `T text` binds a value,
+//     `F` (None) binds SQL NULL — via `pg_exec_params_opt`. Internally
+//     that walks the params with `vec_get [?String]` → `??String`.
+//   * Reading nullable columns back as `?String` / `?i` via
+//     `pg_get_opt` / `pg_get_opt_int`, matched with `??`.
+//
+// Connect via a conninfo argument or $PG_CONNINFO, e.g.
+//   ./pg_optional "host=/tmp port=5433 user=postgres dbname=postgres"
+//   PG_CONNINFO="host=/tmp …" ./pg_optional
+//
+// Build:  ./nurl.sh examples/pg_optional.nu pg_optional
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/postgres.nu`
+
+// Push a `T value` (some text) onto a `Vec ?String`.
+@ push_some ( Vec ?String ) ps s text → v {
+    ( vec_push [?String] ps @ ?String { T ( string_from text ) } )
+}
+
+// Push an `F` (None) — binds SQL NULL.
+@ push_null ( Vec ?String ) ps → v {
+    ( vec_push [?String] ps @ ?String { F # String 0 } )
+}
+
+// Insert one (name, nickname) row where nickname may be NULL.
+@ insert_person Connection c s name b has_nick s nick → v {
+    : ( Vec ?String ) ps ( vec_with_cap [?String] 2 )
+    ( push_some ps name )
+    ? has_nick { ( push_some ps nick ) } { ( push_null ps ) }
+    : !PgResult PgErr r ( pg_exec_params_opt c `INSERT INTO people (name, nickname) VALUES ($1, $2)` ps )
+    ?? r {
+        F e → {
+            : String em ( pg_err_msg c )
+            ( nurl_print `insert failed: ` ) ( nurl_print ( string_data em ) )
+            ( string_free em )
+        }
+        T res → ( pg_clear res )
+    }
+}
+
+@ run Connection c → v {
+    // Schema — TEMP TABLE auto-drops at session end.
+    : !i PgErr ddl ( pg_run c `CREATE TEMP TABLE people (id SERIAL PRIMARY KEY, name TEXT NOT NULL, nickname TEXT)` )
+    ?? ddl { F _ → ( nurl_print `ddl failed\n` )  T _ → {} }
+
+    ( insert_person c `Ada`     T `Countess` )
+    ( insert_person c `Alan`    F `` )
+    ( insert_person c `Grace`   T `Amazing` )
+    ( insert_person c `Dijkstra` F `` )
+
+    // Read back, treating nickname as an optional value.
+    : !PgResult PgErr q ( pg_exec c `SELECT name, nickname FROM people ORDER BY id` )
+    ?? q {
+        F e → {
+            : String em ( pg_err_msg c )
+            ( nurl_print `select failed: ` ) ( nurl_print ( string_data em ) )
+            ( string_free em )
+        }
+        T r → {
+            : i nrows ( pg_ntuples r )
+            : ~ i row 0
+            ~ < row nrows {
+                : String name ( pg_get_value r row 0 )
+                ( nurl_print ( string_data name ) ) ( nurl_print ` — ` )
+                // pg_get_opt → ?String: None means the column was SQL NULL.
+                ?? ( pg_get_opt r row 1 ) {
+                    T nick → {
+                        ( nurl_print `"` ) ( nurl_print ( string_data nick ) ) ( nurl_print `"\n` )
+                        ( string_free nick )
+                    }
+                    F _ → ( nurl_print `(no nickname)\n` )
+                }
+                ( string_free name )
+                = row + row 1
+            }
+            ( nurl_print `(` ) ( nurl_print ( nurl_str_int nrows ) ) ( nurl_print ` rows)\n` )
+            ( pg_clear r )
+        }
+    }
+}
+
+@ main → i {
+    : ~ s conninfo ``
+    : ( Vec String ) args ( env_args_list )
+    ? > ( vec_len [String] args ) 1 {
+        ?? ( vec_get [String] args 1 ) { T a → = conninfo ( string_data a )  F _ → {} }
+    } {}
+    ? == 0 ( nurl_str_len conninfo ) {
+        ?? ( env_get `PG_CONNINFO` ) { T ev → = conninfo ( string_data ev )  F _ → {} }
+    } {}
+
+    : Connection c ( pg_connect conninfo )
+    ? ! ( pg_ok c ) {
+        : String em ( pg_err_msg c )
+        ( nurl_print `connect failed: ` ) ( nurl_print ( string_data em ) )
+        ( string_free em )
+        ( pg_close c )
+        ^ 1
+    } {}
+    ( run c )
+    ( pg_close c )
+    ^ 0
+}

--- a/stdlib/ext/postgres.nu
+++ b/stdlib/ext/postgres.nu
@@ -26,6 +26,7 @@
 //   Statement execution
 //     ( pg_exec Connection s sql )                       → ! PgResult PgErr
 //     ( pg_exec_params Connection s sql ( Vec String ) ) → ! PgResult PgErr  (all-text, no NULLs)
+//     ( pg_exec_params_opt Conn s sql ( Vec ?String ) )  → ! PgResult PgErr  (option-typed; None = SQL NULL)
 //     ( pg_exec_params_b Connection s sql PgParams )     → ! PgResult PgErr  (typed + NULL binds)
 //     ( pg_prepare Conn s name s query i nparams )       → ! PgResult PgErr
 //     ( pg_exec_prepared Conn s name ( Vec String ) )    → ! PgResult PgErr
@@ -52,6 +53,8 @@
 //     ( pg_ftype PgResult i col )          → i       column type OID
 //     ( pg_get_value PgResult i row i col )→ String  OWNED
 //     ( pg_get_is_null PgResult i row i col) → b
+//     ( pg_get_opt PgResult i row i col )  → ?String  None on SQL NULL (OWNED on Some)
+//     ( pg_get_opt_int PgResult i row i col) → ?i      None on SQL NULL
 //     ( pg_get_int / pg_get_i64 … i col )  → i       text → integer
 //     ( pg_get_f64 … )                     → f       text → double
 //     ( pg_get_bool … )                    → b       't'/'f' → true/false
@@ -261,6 +264,43 @@ $ `stdlib/core/vec.nu`
     ( nurl_free vals )
     // Exec done — libpq copied the params, safe to release the Strings.
     ( vec_free_with [String] params \ String s → v { ( string_free s ) } )
+    ^ res
+}
+
+// Option-typed NULL-aware parameterised exec. `params` is a `Vec ?String`
+// where a `T text` element binds that text and an `F` (None) element
+// binds SQL NULL — the idiomatic way to express "this column may be NULL"
+// with the language's own option type. CONSUMES `params` (frees every
+// Some-String and the Vec backing after the exec).
+//
+//   : ( Vec ?String ) ps ( vec_with_cap [?String] 2 )
+//   ( vec_push [?String] ps @ ?String { T ( string_from `alice` ) } )
+//   ( vec_push [?String] ps @ ?String { F # String 0 } )   // → SQL NULL
+//   : !PgResult PgErr r ( pg_exec_params_opt c `INSERT … VALUES ($1,$2)` ps )
+@ pg_exec_params_opt Connection c s sql ( Vec ?String ) params → !PgResult PgErr {
+    : i n ( vec_len [?String] params )
+    : s vals ( nurl_alloc * ? > n 0 n 1 8 )
+    : ~ i k 0
+    ~ < k n {
+        // vec_get over a `Vec ?String` yields `??String`: the outer
+        // option is the bounds check, the inner is the value-or-NULL.
+        : ??String pk ( vec_get [?String] params k )
+        ?? pk {
+            T inner → {
+                ?? inner {
+                    T sv → ( nurl_poke vals k # i ( string_data sv ) )
+                    F _ → ( nurl_poke vals k 0 )
+                }
+            }
+            F _ → ( nurl_poke vals k 0 )
+        }
+        = k + k 1
+    }
+    : !PgResult PgErr res ( __pg_exec_params_raw c sql n vals )
+    ( nurl_free vals )
+    ( vec_free_with [?String] params \ ?String o → v {
+        ?? o { T sv → ( string_free sv )  F _ → {} }
+    } )
     ^ res
 }
 
@@ -509,6 +549,22 @@ $ `stdlib/core/vec.nu`
     : i32 r32 # i32 row
     : i32 c32 # i32 col
     ^ != 0 # i ( PQgetisnull . r raw r32 c32 )
+}
+
+// Option-typed cell read: `F` (None) for a SQL NULL, `T text` (an OWNED
+// String the caller frees) otherwise. Lets a caller handle nullability
+// with the language's own option type:
+//
+//   ?? ( pg_get_opt r row col ) { T s → … ( string_free s )  F _ → … }
+@ pg_get_opt PgResult r i row i col → ?String {
+    ? ( pg_get_is_null r row col ) { ^ @ ?String { F # String 0 } } {}
+    ^ @ ?String { T ( pg_get_value r row col ) }
+}
+
+// Option-typed integer read: `F` for SQL NULL, `T n` otherwise.
+@ pg_get_opt_int PgResult r i row i col → ?i {
+    ? ( pg_get_is_null r row col ) { ^ @ ?i { F # i 0 } } {}
+    ^ @ ?i { T ( pg_get_int r row col ) }
 }
 
 // Typed accessors — read the text cell directly (no owned-String copy)


### PR DESCRIPTION
…eads)

Use the language's option types throughout the PostgreSQL client, now that generics over option types are supported.

stdlib/ext/postgres.nu:
- pg_exec_params_opt ( Vec ?String ) — bind nullable parameters with the option type: `T text` binds a value, `F` (None) binds SQL NULL. Walks the params with `vec_get [?String]` → `??String` and consumes the Vec.
- pg_get_opt → ?String / pg_get_opt_int → ?i — read a nullable column as an option: `F` (None) on SQL NULL, `T value` otherwise.

examples/pg_optional.nu — a focused example demonstrating both ends: nullable inserts via `Vec ?String` and optional reads via `pg_get_opt`, matched with `??`.

compiler/tests/postgres_basic.nu — exercises the option-typed insert (`pg_exec_params_opt`) and option-typed reads (`pg_get_opt` / `pg_get_opt_int`), so the build compiles the option-generics instantiations through postgres.nu.

Verified live against PostgreSQL 16 and clean under AddressSanitizer.