### PR TITLE
Postgres: binary protocol, async, LISTEN/NOTIFY, COPY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **PostgreSQL advanced protocol features — binary, async, LISTEN/NOTIFY,
+  COPY** (`stdlib/ext/postgres.nu`). Closes the last Tier-5 Postgres gap;
+  all four are pure-NURL libpq FFI (no `runtime.c` bridge) and are
+  exercised end to end by the new `examples/pg_advanced.nu`, live-verified
+  against PostgreSQL 16.14.
+  - *Binary result protocol*: `pg_exec_params_binary` requests
+    `resultFormat = 1`; `pg_get_i16_bin` / `_i32_bin` / `_i64_bin` /
+    `_bool_bin` / `_f64_bin` decode network-byte-order cells (`float8`
+    reinterpreted from its IEEE-754 bit pattern, not a numeric cast), with
+    `pg_get_length` / `pg_field_format` / `pg_binary_tuples`.
+  - *Asynchronous queries*: `pg_send` / `pg_send_params` dispatch without
+    blocking; `pg_get_result` (→ `?PgResult`, `None` when finished) and the
+    blocking convenience `pg_await` collect results; `pg_consume_input` /
+    `pg_is_busy` / `pg_socket` / `pg_flush` / `pg_set_nonblocking` hook into
+    an event loop.
+  - *LISTEN/NOTIFY*: `pg_listen`, `pg_notify_send`, `pg_notifies`
+    (→ `?PgNotify { relname, be_pid, extra }`, read after
+    `pg_consume_input`) and `pg_notify_free`.
+  - *COPY*: `pg_copy_start` (accepts the `PGRES_COPY_IN` / `COPY_OUT`
+    handshake that plain `pg_exec` rejects), `pg_put_copy_data` /
+    `pg_put_copy_str` / `pg_put_copy_end` for `COPY … FROM STDIN`, and
+    `pg_get_copy_data` (→ `?String`) for `COPY … TO STDOUT`.
+
+### Fixed
+
+- **Compiler: `??`-match on a result/option-typed *parameter* dropped its
+  payload.** `@ f !S E r → S { ?? r { T x → ^ x } }` emitted `ret i64`
+  against the `%S` return type (an LLVM "value doesn't match function
+  result type" error), and the same gap mishandled a `( Vec u )` handle
+  payload and dropped the unsigned flag on a `?u` parameter (sign-extending
+  a byte ≥ `0x80`). `gen_fn_param` now records the
+  `<param>__res_nurl_T` / `__res_t_llvm` / `__res_e_llvm` / `__opt_nurl_T`
+  metadata that `gen_let_or_struct` already records for let-bound result
+  vars, so `gen_match` reconstructs struct / pointer / unsigned payloads
+  for a parameter scrutinee exactly as it does for a let binding. Bootstrap
+  fixed point held; regression `compiler/tests/match_param_payload.nu`.
+
+### Security
+
+- **`pg_listen` SQL injection (critical) — fixed.** A channel name is a SQL
+  *identifier* and cannot be a bound parameter, so it now goes through
+  `pg_escape_identifier` (PQescapeIdentifier) before interpolation; raw
+  concatenation previously let `pg_listen c "x; DROP TABLE …; --"` execute
+  the injected statement. (`pg_notify_send` was already safe — it binds the
+  channel as a value to `pg_notify($1, $2)`.)
+- **Out-of-bounds read in the binary accessors (medium) — fixed.** A new
+  `PQgetlength`-checked `__pg_bin_ptr` guards every `pg_get_*_bin`:
+  reading an `int4` cell with the 8-byte `pg_get_i64_bin`, or any accessor
+  on a binary SQL `NULL` (0 bytes), now returns `0` instead of reading past
+  the cell into adjacent libpq buffer memory.
+- **TLS is not verified by default — documented.** `pg_connect` and the
+  file header now carry a prominent warning that libpq's default
+  `sslmode=prefer` neither prevents a silent plaintext fallback nor
+  verifies the server certificate (MITM-able), recommending
+  `sslmode=verify-full sslrootcert=…` for non-local connections. Not
+  force-defaulted, as that would break legitimate unix-socket / trusted-LAN
+  connections. Minor: `pg_get_bool` gained a NULL-pointer guard, and the
+  empty-on-NULL behaviour of `pg_escape_literal` / `pg_escape_identifier`
+  is now documented.
+
 ## [0.9.3] — 2026-05-31
 
 ### Summary

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -10559,8 +10559,25 @@
     // gen_call move-marks the argument), so it needs no special
     // handling here beyond the side-channel below.
     : i pconv ( parse_param_marker lex )
+    // Reset the result/option side-channels so a `! T E` / `? T` parameter
+    // type leaves fresh metadata here (and a non-result param doesn't
+    // inherit a previous param's stale values). Mirrors the resets
+    // gen_fn_decl_concrete does before parsing the return type.
+    ( nurl_sym_def g_res_type_syms `__last_res_nurl__` `` )
+    ( nurl_sym_def g_res_type_syms `__last_res_t_llvm__` `` )
+    ( nurl_sym_def g_res_type_syms `__last_res_err_llvm__` `` )
+    ( nurl_sym_def g_res_type_syms `__last_opt_nurl_t__` `` )
     : s lt ( parse_type lex )
     : s p_nurl_type ( nurl_sym_get g_res_type_syms `__last_nurl_type__` )
+    // Capture the `! T E` / `? T` payload metadata for this parameter so a
+    // `?? <param> { T x → … }` match can reconstruct a struct / pointer
+    // payload from its i64 slot — exactly as gen_let_or_struct does for a
+    // let-bound result var. Without this a struct-typed T-arm binding on a
+    // result PARAMETER stayed a raw i64 (miscompiled `^ x` to `ret i64`).
+    : s p_res_nurl ( nurl_sym_get g_res_type_syms `__last_res_nurl__` )
+    : s p_res_t_llvm ( nurl_sym_get g_res_type_syms `__last_res_t_llvm__` )
+    : s p_res_e_llvm ( nurl_sym_get g_res_type_syms `__last_res_err_llvm__` )
+    : s p_opt_nurl_t ( nurl_sym_get g_res_type_syms `__last_opt_nurl_t__` )
     ? ( is_ident_tok ( nurl_lex_type lex ) )
     { : s pname ( nurl_lex_val lex )
         // Reject parameter names that collide with LLVM reserved basic-
@@ -10611,6 +10628,24 @@
             ? ( nurl_type_is_unsigned p_nurl_type )
             { ( nurl_sym_def syms ( nurl_str_cat pname `__unsigned` ) `1` ) }
             {} }
+        {}
+        // Stash `! T E` / `? T` payload metadata for this parameter, mirroring
+        // gen_let_or_struct, so a `?? <param>` match can reconstruct a struct /
+        // pointer / unsigned payload binding rather than leaving it a raw i64.
+        ? != 0 ( nurl_str_len p_res_nurl )
+        { : s pinner_t ( str_first_word ( str_skip_word p_res_nurl ) )
+            : s pinner_e ( str_first_word ( str_skip_word ( str_skip_word p_res_nurl ) ) )
+            ( nurl_sym_def syms ( nurl_str_cat pname `__res_nurl_T` ) pinner_t )
+            ( nurl_sym_def syms ( nurl_str_cat pname `__res_nurl_E` ) pinner_e ) }
+        {}
+        ? != 0 ( nurl_str_len p_res_t_llvm )
+        { ( nurl_sym_def syms ( nurl_str_cat pname `__res_t_llvm` ) p_res_t_llvm ) }
+        {}
+        ? != 0 ( nurl_str_len p_res_e_llvm )
+        { ( nurl_sym_def syms ( nurl_str_cat pname `__res_e_llvm` ) p_res_e_llvm ) }
+        {}
+        ? != 0 ( nurl_str_len p_opt_nurl_t )
+        { ( nurl_sym_def syms ( nurl_str_cat pname `__opt_nurl_T` ) p_opt_nurl_t ) }
         {}
         // Append this param's name + LLVM type to the function's param
         // roster so gen_fn_decl_concrete can later (post-`entry:`) emit

--- a/compiler/tests/match_param_payload.nu
+++ b/compiler/tests/match_param_payload.nu
@@ -1,0 +1,54 @@
+// Regression: a `??`-match on a result/option-typed PARAMETER must
+// reconstruct a struct / pointer / unsigned payload in the T-arm — the
+// same way a let-bound result var does.
+//
+// The bug: gen_fn_param parsed a parameter's `! T E` / `? T` type but
+// never recorded the `<param>__res_nurl_T` / `__res_t_llvm` /
+// `__opt_nurl_T` metadata that gen_let_or_struct records for let-bound
+// result vars. So `@ f !S E r → S { ?? r { T x → ^ x } }` left `x` as
+// the raw i64 payload slot and emitted `ret i64` against the `%S`
+// return type — an LLVM "value doesn't match function result type"
+// error. The same gap mishandled a `( Vec u )` handle payload and
+// dropped the unsigned flag on a `?u` parameter (sign-extending a byte
+// ≥ 0x80). Fix: gen_fn_param now mirrors gen_let_or_struct's metadata
+// recording for result/option parameters.
+//
+// Each printed line is deterministic so the output is baselined.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+: S { s name }
+: | E { Ea Eb }
+
+// (1) single-pointer-handle struct payload, returned straight from a
+// result PARAMETER's T-arm.
+@ unwrap_struct !S E r → S {
+    ?? r { T x → ^ x  F e → ^ @ S { `?` } }
+}
+
+// (2) `( Vec u )` handle payload from a result PARAMETER.
+@ unwrap_vec ! ( Vec u ) E r → ( Vec u ) {
+    ?? r { T x → ^ x  F e → ^ ( vec_new [u] ) }
+}
+
+// (3) unsigned-byte payload from an option PARAMETER — must zext, not
+// sext (0x86 = 134, not -122).
+@ unwrap_opt_u ?u o → i {
+    ?? o { T b → ^ # i b  F _ → ^ -1 }
+}
+
+@ main → i {
+    : S s1 ( unwrap_struct @ !S E { T @ S { `hello` } } )
+    ( nurl_print `struct=` ) ( nurl_print . s1 name ) ( nurl_print `\n` )
+
+    : ( Vec u ) v ( vec_with_cap [u] 3 )
+    ( vec_push [u] v # u 0x86 )
+    ( vec_push [u] v # u 2 )
+    : ( Vec u ) v2 ( unwrap_vec @ ! ( Vec u ) E { T v } )
+    ( nurl_print `veclen=` ) ( nurl_print ( nurl_str_int ( vec_len [u] v2 ) ) ) ( nurl_print `\n` )
+
+    ( nurl_print `optu=` ) ( nurl_print ( nurl_str_int ( unwrap_opt_u @ ?u { T 0x86 } ) ) ) ( nurl_print `\n` )
+    ( nurl_print `optn=` ) ( nurl_print ( nurl_str_int ( unwrap_opt_u @ ?u { F # u 0 } ) ) ) ( nurl_print `\n` )
+    ^ 0
+}

--- a/examples/pg_advanced.nu
+++ b/examples/pg_advanced.nu
@@ -1,0 +1,179 @@
+// examples/pg_advanced.nu — the four advanced libpq capabilities NURL's
+// postgres binding now covers end to end:
+//
+//   1. Binary result protocol  — request resultFormat = 1 and decode the
+//      raw network-byte-order cells with the pg_get_*_bin accessors.
+//   2. Asynchronous queries    — pg_send + pg_await dispatch a command
+//      without blocking on its reply.
+//   3. LISTEN / NOTIFY         — pg_listen + pg_notify_send + (after
+//      pg_consume_input) pg_notifies for async pub/sub.
+//   4. COPY                    — pg_put_copy_* to bulk-load and
+//      pg_get_copy_data to bulk-dump rows.
+//
+// Build:  ./nurl.sh examples/pg_advanced.nu pg_advanced
+// Run:    ./pg_advanced "host=127.0.0.1 port=5433 user=wau dbname=postgres"
+//         (or set $PG_CONNINFO; falls back to libpq's PG* defaults)
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/postgres.nu`
+
+@ say s msg → v { ( nurl_print msg ) ( nurl_print `\n` ) }
+@ sayi s label i n → v {
+    ( nurl_print label ) ( nurl_print ( nurl_str_int n ) ) ( nurl_print `\n` )
+}
+
+// Print the connection's error text, then exit non-zero.
+@ die Connection c s ctx → v {
+    : String em ( pg_err_msg c )
+    ( nurl_print `FAIL [` ) ( nurl_print ctx ) ( nurl_print `]: ` )
+    ( nurl_print ( string_data em ) ) ( nurl_print `\n` )
+    ( string_free em )
+    ( pg_close c )
+    ( nurl_exit 1 )
+}
+
+// Unwrap a !PgResult, returning the live result (caller clears it).
+@ must Connection c !PgResult PgErr r s ctx → PgResult {
+    ?? r {
+        T res → ^ res
+        F e → { ( die c ctx )  ^ @ PgResult { # s 0 } }
+    }
+}
+
+// Run a !PgResult command for effect: unwrap, then clear the result.
+@ okc Connection c !PgResult PgErr r s ctx → v {
+    ( pg_clear ( must c r ctx ) )
+}
+
+// Unwrap a !i command (pg_send / copy / notify family) for effect.
+@ oki Connection c !i PgErr r s ctx → v {
+    ?? r { T _ → {}  F e → ( die c ctx ) }
+}
+
+// ── 1. Binary result protocol ────────────────────────────────────
+@ demo_binary Connection c → v {
+    ( say `── 1. binary protocol ──` )
+    // Text params in, binary columns out. We exercise int2/int4/int8,
+    // bool, and float8 so every decoder runs.
+    : PgParams ps ( pg_params 1 )
+    ( pg_bind_int ps 1000000 )
+    : !PgResult PgErr rr ( pg_exec_params_binary c
+        `SELECT ($1::int8 * 1000)::int8, 42::int4, 7::int2, true, 3.5::float8` ps )
+    : PgResult r ( must c rr `binary select` )
+    ( nurl_print `  binary columns? ` )
+    ( say ? ( pg_binary_tuples r ) `yes` `no` )
+    ( sayi `  int8  = ` ( pg_get_i64_bin r 0 0 ) )
+    ( sayi `  int4  = ` ( pg_get_i32_bin r 0 1 ) )
+    ( sayi `  int2  = ` ( pg_get_i16_bin r 0 2 ) )
+    ( nurl_print `  bool  = ` ) ( say ? ( pg_get_bool_bin r 0 3 ) `true` `false` )
+    ( nurl_print `  f64   = ` )
+    : s fs ( float_to_string ( pg_get_f64_bin r 0 4 ) )
+    ( nurl_print fs ) ( nurl_print `\n` )
+    ( pg_clear r )
+}
+
+// ── 2. Asynchronous queries ──────────────────────────────────────
+@ demo_async Connection c → v {
+    ( say `── 2. async query ──` )
+    ?? ( pg_send c `SELECT count(*) FROM generate_series(1, 50000)` ) {
+        F e → { ( say `  pg_send failed` ) ^ v }
+        T _ → {}
+    }
+    ( nurl_print `  socket fd = ` ) ( nurl_print ( nurl_str_int ( pg_socket c ) ) ) ( nurl_print `\n` )
+    : !PgResult PgErr rr ( pg_await c )
+    : PgResult r ( must c rr `async await` )
+    : String v0 ( pg_get_value r 0 0 )
+    ( nurl_print `  count = ` ) ( nurl_print ( string_data v0 ) ) ( nurl_print `\n` )
+    ( string_free v0 )
+    ( pg_clear r )
+}
+
+// ── 3. LISTEN / NOTIFY ───────────────────────────────────────────
+@ demo_notify Connection c → v {
+    ( say `── 3. LISTEN / NOTIFY ──` )
+    ( oki c ( pg_listen c `chan` ) `listen` )       // LISTEN chan
+    ( oki c ( pg_notify_send c `chan` `hello-from-nurl` ) `notify` )
+    // Server delivers async notifications on the next socket read.
+    ( oki c ( pg_consume_input c ) `consume` )
+    : ~ i got 0
+    : ?PgNotify n ( pg_notifies c )
+    ?? n {
+        T note → {
+            = got 1
+            ( nurl_print `  notify on "` ) ( nurl_print ( string_data . note relname ) )
+            ( nurl_print `" payload "` ) ( nurl_print ( string_data . note extra ) )
+            ( nurl_print `" from pid ` ) ( nurl_print ( nurl_str_int . note be_pid ) )
+            ( nurl_print `\n` )
+            ( pg_notify_free note )
+        }
+        F _ → ( say `  (no notification received)` )
+    }
+}
+
+// ── 4. COPY ──────────────────────────────────────────────────────
+@ demo_copy Connection c → v {
+    ( say `── 4. COPY ──` )
+    ( okc c ( pg_exec c `CREATE TEMP TABLE pts (id int, label text)` ) `create temp` )
+
+    // COPY FROM STDIN — bulk load three rows.
+    ( oki c ( pg_copy_start c `COPY pts FROM STDIN` ) `copy in start` )
+    ( oki c ( pg_put_copy_str c ( string_from `1\talpha\n` ) ) `put row 1` )
+    ( oki c ( pg_put_copy_str c ( string_from `2\tbeta\n` ) ) `put row 2` )
+    ( oki c ( pg_put_copy_str c ( string_from `3\tgamma\n` ) ) `put row 3` )
+    ( oki c ( pg_put_copy_end c ) `copy end` )
+    ( okc c ( pg_await c ) `copy in result` )    // COMMAND_OK
+    ( say `  loaded 3 rows via COPY FROM STDIN` )
+
+    // COPY TO STDOUT — bulk dump them back.
+    ( oki c ( pg_copy_start c `COPY pts TO STDOUT` ) `copy out start` )
+    : ~ i nrows 0
+    : ~ i more 1
+    ~ != 0 more {
+        : ?String row ( pg_get_copy_data c )
+        ?? row {
+            T line → {
+                = nrows + nrows 1
+                ( nurl_print `  out: ` ) ( nurl_print ( string_data line ) )
+                ( string_free line )
+            }
+            F _ → = more 0
+        }
+    }
+    ( okc c ( pg_await c ) `copy out result` )   // COMMAND_OK
+    ( sayi `  dumped rows = ` nrows )
+}
+
+@ main → i {
+    : ( Vec String ) args ( env_args_list )
+    : ~ s conninfo ``
+    ?? ( vec_get [String] args 1 ) {
+        T av → = conninfo ( string_data av )
+        F _ → {
+            ?? ( env_get `PG_CONNINFO` ) {
+                T ev → = conninfo ( string_data ev )
+                F _ → {}
+            }
+        }
+    }
+
+    : Connection c ( pg_connect conninfo )
+    ? ! ( pg_ok c ) {
+        : String em ( pg_err_msg c )
+        ( nurl_print `connect error: ` ) ( nurl_print ( string_data em ) )
+        ( string_free em )
+        ( pg_close c )
+        ^ 1
+    } {}
+
+    ( demo_binary c )
+    ( demo_async c )
+    ( demo_notify c )
+    ( demo_copy c )
+
+    ( pg_close c )
+    ( say `\nAll four advanced Postgres capabilities exercised.` )
+    ^ 0
+}

--- a/stdlib/ext/postgres.nu
+++ b/stdlib/ext/postgres.nu
@@ -60,6 +60,38 @@
 //     ( pg_get_bool … )                    → b       't'/'f' → true/false
 //     ( pg_clear PgResult )                → v
 //
+//   Binary result protocol (resultFormat = 1; text params, binary cells)
+//     ( pg_exec_params_binary Conn s sql PgParams )      → ! PgResult PgErr
+//     ( pg_get_i16_bin / _i32_bin / _i64_bin … i col )   → i   network-order
+//     ( pg_get_bool_bin … )                → b
+//     ( pg_get_f64_bin … )                 → f       IEEE-754 bit pattern
+//     ( pg_get_length PgResult i row i col)→ i       cell byte length
+//     ( pg_field_format PgResult i col )   → i       0 text / 1 binary
+//     ( pg_binary_tuples PgResult )        → b
+//
+//   Asynchronous command processing (non-blocking dispatch)
+//     ( pg_send Conn s sql )               → ! i PgErr
+//     ( pg_send_params Conn s sql PgParams)→ ! i PgErr   CONSUMES params
+//     ( pg_get_result Conn )               → ? PgResult  None when finished
+//     ( pg_await Conn )                    → ! PgResult PgErr  final result
+//     ( pg_consume_input Conn )            → ! i PgErr
+//     ( pg_is_busy Conn ) / ( pg_socket Conn ) / ( pg_flush Conn )
+//     ( pg_set_nonblocking Conn b ) / ( pg_is_nonblocking Conn )
+//
+//   LISTEN / NOTIFY (async pub/sub)
+//     ( pg_listen Conn s channel )         → ! i PgErr      LISTEN channel
+//     ( pg_notify_send Conn s channel s payload ) → ! i PgErr
+//     ( pg_notifies Conn )                 → ? PgNotify  (after consume_input)
+//     ( pg_notify_free PgNotify )          → v           frees owned Strings
+//       PgNotify fields: relname (String), be_pid (i), extra (String)
+//
+//   COPY (bulk row streaming)
+//     ( pg_copy_start Conn s sql )         → ! i PgErr   accepts COPY_IN/OUT
+//     ( pg_put_copy_data Conn s buf i n )  → ! i PgErr   one chunk
+//     ( pg_put_copy_str Conn String row )  → ! i PgErr   one text row
+//     ( pg_put_copy_end Conn )             → ! i PgErr   finish FROM STDIN
+//     ( pg_get_copy_data Conn )            → ? String    None at end; OWNED
+//
 // Memory model:
 //
 //   * `pg_connect` ALWAYS returns a Connection handle — libpq's
@@ -76,6 +108,18 @@
 //   * `pg_get_value` / `pg_field_name` / `pg_err_msg` / escape / info
 //     getters return OWNED Strings (copied via `string_from` because
 //     libpq's pointers become invalid after `PQclear` / `PQfinish`).
+//
+// Security:
+//
+//   * TLS is NOT verified by default — see `pg_connect`. Put
+//     `sslmode=verify-full sslrootcert=…` in the conninfo for any
+//     non-local connection, or the link is MITM-able.
+//   * Pass VALUES as bound parameters (`PgParams` / `pg_exec_params_b` /
+//     `pg_exec_prepared_b`), never string-concatenated into the SQL.
+//     IDENTIFIERS (table / column / channel names) cannot be bound — quote
+//     them with `pg_escape_identifier` (as `pg_listen` does). String
+//     LITERALS, if you truly must inline them, go through
+//     `pg_escape_literal`.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -146,6 +190,41 @@ $ `stdlib/core/vec.nu`
 & `pq` @ PQgetvalue s res i32 row i32 col → s
 & `pq` @ PQgetisnull s res i32 row i32 col → i32
 
+// Binary protocol — request binary result columns (resultFormat = 1) and
+// read raw network-byte-order cell bytes. PQgetvalue still returns the
+// cell pointer, but for a binary column it points at `PQgetlength` bytes
+// of big-endian binary, not a NUL-terminated text rendering.
+& `pq` @ PQgetlength s res i32 row i32 col → i32
+& `pq` @ PQfformat s res i32 col → i32  // 0 = text column, 1 = binary
+& `pq` @ PQbinaryTuples s res → i32
+
+// Asynchronous command processing — dispatch a command without blocking
+// on its result, then collect results with PQgetResult (NULL = done).
+// PQconsumeInput / PQisBusy let an event loop poll PQsocket for readiness.
+& `pq` @ PQsendQuery s conn s sql → i32
+& `pq` @ PQsendQueryParams s conn s sql i32 n_params *u types **u values *i32 lens *i32 fmts i32 res_fmt → i32
+& `pq` @ PQsendPrepare s conn s stmt s query i32 n_params *u types → i32
+& `pq` @ PQsendQueryPrepared s conn s stmt i32 n_params **u values *i32 lens *i32 fmts i32 res_fmt → i32
+& `pq` @ PQgetResult s conn → s  // PGresult* or NULL when no more results
+& `pq` @ PQconsumeInput s conn → i32  // 1 = ok, 0 = error
+& `pq` @ PQisBusy s conn → i32  // 1 = a PQgetResult would block
+& `pq` @ PQsetnonblocking s conn i32 arg → i32
+& `pq` @ PQisnonblocking s conn → i32
+& `pq` @ PQflush s conn → i32  // 0 = sent, 1 = more queued, -1 = error
+& `pq` @ PQsocket s conn → i32  // file descriptor, -1 if no connection
+
+// LISTEN / NOTIFY — PQnotifies pops the next buffered async notification
+// (a PGnotify*) after PQconsumeInput has drained the socket; NULL when
+// none are pending. The struct is `{ char *relname; int be_pid;
+// char *extra; … }` — freed with PQfreemem.
+& `pq` @ PQnotifies s conn → s
+
+// COPY — bulk row streaming. PQputCopyData / PQputCopyEnd feed a
+// COPY FROM STDIN; PQgetCopyData pulls rows from a COPY TO STDOUT.
+& `pq` @ PQputCopyData s conn s buffer i32 nbytes → i32  // 1 ok, 0 full, -1 err
+& `pq` @ PQputCopyEnd s conn s errormsg → i32  // errormsg NULL = success
+& `pq` @ PQgetCopyData s conn **u buffer i32 async → i32  // >0 len, -1 done, -2 err
+
 // PQstatus:        CONNECTION_OK = 0,  CONNECTION_BAD = 1
 // PQresultStatus:  PGRES_COMMAND_OK = 1,  PGRES_TUPLES_OK = 2,
 //                  PGRES_FATAL_ERROR = 7, …
@@ -154,6 +233,18 @@ $ `stdlib/core/vec.nu`
 
 // Open a connection. ALWAYS returns a handle (even on failure) so the
 // caller can read `pg_err_msg`. Check `pg_ok`; always `pg_close`.
+//
+// ⚠ SECURITY — TLS is NOT verified by default. `conninfo` is passed
+// verbatim to libpq, whose default `sslmode=prefer` uses TLS only if the
+// server offers it, SILENTLY falls back to plaintext otherwise, and NEVER
+// verifies the server certificate. Over an untrusted network that is
+// MITM-able. For any non-local connection put
+//   sslmode=verify-full sslrootcert=/path/to/ca.crt
+// in `conninfo` (verify-full also checks the host name against the cert).
+// `verify-full` is the only mode that authenticates the server; `require`
+// encrypts but still trusts any certificate. Unix-socket / trusted-LAN
+// connections legitimately need no TLS — hence this is a caller decision,
+// not a forced default (forcing verify-full would break those).
 @ pg_connect s conninfo → Connection {
     : s raw ( PQconnectdb conninfo )
     ^ @ Connection { raw }
@@ -200,6 +291,14 @@ $ `stdlib/core/vec.nu`
 //
 // PQescapeLiteral / PQescapeIdentifier return a freshly-malloc'd,
 // already-quoted C string we must copy then release with PQfreemem.
+//
+// NULL return (OOM, or invalid UTF-8 for the connection's encoding)
+// surfaces here as an EMPTY String, NOT an error value. This is safe
+// against injection — an empty literal/identifier spliced into SQL yields
+// a syntax error, never an unescaped value — but it IS a silent failure:
+// if you must distinguish "escaped to empty" from "escape failed", check
+// the connection with pg_err_msg, or prefer bound parameters (PgParams /
+// pg_exec_params_b) for values, which never need manual escaping.
 
 @ pg_escape_literal Connection c s str → String {
     : i len ( nurl_str_len str )
@@ -582,13 +681,364 @@ $ `stdlib/core/vec.nu`
 }
 
 // PostgreSQL renders boolean as the single byte 't' / 'f'.
+// PostgreSQL renders boolean text as a single byte 't' / 'f'. A SQL NULL
+// (or out-of-range row/col) gives an empty cell → not 't' → false. The
+// explicit NULL guard avoids relying on libpq always handing back a
+// non-NULL pointer (and keeps nurl_str_get's strlen off a NULL).
 @ pg_get_bool PgResult r i row i col → b {
     : i32 r32 # i32 row
     : i32 c32 # i32 col
     : s v ( PQgetvalue . r raw r32 c32 )
+    ? == # i v 0 { ^ F } {}
     ^ == ( nurl_str_get v 0 ) 116
 }
 
 @ pg_clear PgResult r → v {
     ( PQclear . r raw )
+}
+
+// ══════════════════════════════════════════════════════════════════
+//  Binary result protocol
+// ══════════════════════════════════════════════════════════════════
+//
+// Parameters are still sent as text (the common pattern), but every
+// result column is requested in binary (resultFormat = 1): each cell is
+// raw big-endian wire bytes rather than a text rendering. Decode them
+// with the `pg_get_*_bin` accessors below. CONSUMES `p`.
+//
+//   : PgParams ps ( pg_params 1 )
+//   ( pg_bind_int ps 41 )
+//   : !PgResult PgErr rr ( pg_exec_params_binary c `SELECT $1::int8 + 1` ps )
+//   ?? rr { T r → { : i v ( pg_get_i64_bin r 0 0 )  ( pg_clear r ) }  F e → {} }
+@ pg_exec_params_binary Connection c s sql PgParams p → !PgResult PgErr {
+    : i n ( pg_params_len p )
+    : s vals ( __pg_params_vals p )
+    : **u vptr # **u vals
+    : *u types # *u 0
+    : *i32 lens # *i32 0
+    : *i32 fmts # *i32 0
+    : i32 nn # i32 n
+    : i32 one # i32 1
+    : !PgResult PgErr res ( __pg_wrap_result ( PQexecParams . c raw sql nn types vptr lens fmts one ) )
+    ( nurl_free vals )
+    ( pg_params_free p )
+    ^ res
+}
+
+// Byte length of a result cell (text or binary).
+@ pg_get_length PgResult r i row i col → i {
+    : i32 r32 # i32 row
+    : i32 c32 # i32 col
+    ^ # i ( PQgetlength . r raw r32 c32 )
+}
+
+// Wire format of a column: 0 = text, 1 = binary.
+@ pg_field_format PgResult r i col → i {
+    ^ # i ( PQfformat . r raw # i32 col )
+}
+
+// True if the result's columns are all binary-format.
+@ pg_binary_tuples PgResult r → b {
+    ^ != 0 # i ( PQbinaryTuples . r raw )
+}
+
+// Read `nbytes` big-endian (network order) bytes from a raw cell pointer
+// into an unsigned i64 accumulator. PostgreSQL sends binary integers and
+// the IEEE-754 bit pattern of float8 in network byte order.
+@ __pg_be_read s ptr i nbytes → i {
+    ? == # i ptr 0 { ^ 0 } {}
+    : *u p # *u ptr
+    : ~ i acc 0
+    : ~ i k 0
+    ~ < k nbytes {
+        : u b . p k
+        = acc | << acc 8 & # i b 255
+        = k + k 1
+    }
+    ^ acc
+}
+
+// Bounds-checked binary cell pointer. Returns the raw cell pointer ONLY
+// when the cell holds at least `need` bytes; otherwise NULL (# s 0), which
+// __pg_be_read reads as 0. This guards against reading past a cell that is
+// shorter than the accessor's fixed width — e.g. a binary SQL NULL (0
+// bytes), or calling pg_get_i64_bin (8 bytes) on an int4 column (4 bytes).
+// Without it the decoder walked into adjacent libpq buffer memory (an
+// out-of-bounds read).
+@ __pg_bin_ptr PgResult r i row i col i need → s {
+    : i32 r32 # i32 row
+    : i32 c32 # i32 col
+    ? < # i ( PQgetlength . r raw r32 c32 ) need { ^ # s 0 } {}
+    ^ ( PQgetvalue . r raw r32 c32 )
+}
+
+// int2 / smallint — 2-byte big-endian, sign-extended.
+@ pg_get_i16_bin PgResult r i row i col → i {
+    : i v ( __pg_be_read ( __pg_bin_ptr r row col 2 ) 2 )
+    ^ ? >= v 32768 - v 65536 v
+}
+
+// int4 / integer — 4-byte big-endian, sign-extended.
+@ pg_get_i32_bin PgResult r i row i col → i {
+    : i v ( __pg_be_read ( __pg_bin_ptr r row col 4 ) 4 )
+    ^ ? >= v 2147483648 - v 4294967296 v
+}
+
+// int8 / bigint — 8-byte big-endian.
+@ pg_get_i64_bin PgResult r i row i col → i {
+    ^ ( __pg_be_read ( __pg_bin_ptr r row col 8 ) 8 )
+}
+
+// boolean — single binary byte, non-zero = true.
+@ pg_get_bool_bin PgResult r i row i col → b {
+    ^ != 0 ( __pg_be_read ( __pg_bin_ptr r row col 1 ) 1 )
+}
+
+// float8 / double precision — 8-byte big-endian IEEE-754, reinterpreted
+// from its bit pattern (not a numeric int→float conversion). A short /
+// NULL cell yields 0.0 via the bounds-checked pointer.
+@ pg_get_f64_bin PgResult r i row i col → f {
+    : i bits ( __pg_be_read ( __pg_bin_ptr r row col 8 ) 8 )
+    : s buf ( nurl_alloc 8 )
+    ( nurl_poke buf 0 bits )
+    : *f fp # *f buf
+    : f out . fp 0
+    ( nurl_free buf )
+    ^ out
+}
+
+// ══════════════════════════════════════════════════════════════════
+//  Asynchronous command processing
+// ══════════════════════════════════════════════════════════════════
+//
+// `pg_send` / `pg_send_params` dispatch a command without blocking on its
+// reply. Collect results with `pg_get_result` (None = the command is
+// finished) — or just call `pg_await` to block for the final result.
+// `pg_socket` + `pg_consume_input` + `pg_is_busy` integrate with an event
+// loop: wait for the socket to be readable, consume input, and only call
+// `pg_get_result` while `pg_is_busy` is false. ALWAYS drain every result
+// (loop to None) before the next command on the same connection.
+
+@ pg_send Connection c s sql → !i PgErr {
+    ? == 0 # i ( PQsendQuery . c raw sql ) {
+        ^ @ !i PgErr { F # PgErr PgExecFailed }
+    } {}
+    ^ @ !i PgErr { T 1 }
+}
+
+@ pg_send_params Connection c s sql PgParams p → !i PgErr {
+    : i n ( pg_params_len p )
+    : s vals ( __pg_params_vals p )
+    : **u vptr # **u vals
+    : *u types # *u 0
+    : *i32 lens # *i32 0
+    : *i32 fmts # *i32 0
+    : i32 nn # i32 n
+    : i32 zero # i32 0
+    : i rc # i ( PQsendQueryParams . c raw sql nn types vptr lens fmts zero )
+    ( nurl_free vals )
+    ( pg_params_free p )
+    ? == 0 rc { ^ @ !i PgErr { F # PgErr PgExecFailed } } {}
+    ^ @ !i PgErr { T 1 }
+}
+
+// Drain buffered server data into libpq (1 = ok). Call before
+// `pg_is_busy` / `pg_notifies` when the socket signals readable.
+@ pg_consume_input Connection c → !i PgErr {
+    ? == 0 # i ( PQconsumeInput . c raw ) {
+        ^ @ !i PgErr { F # PgErr PgExecFailed }
+    } {}
+    ^ @ !i PgErr { T 1 }
+}
+
+// True if a `pg_get_result` would block (more input needed first).
+@ pg_is_busy Connection c → b {
+    ^ != 0 # i ( PQisBusy . c raw )
+}
+
+// Underlying socket fd for select/poll, or -1 if not connected.
+@ pg_socket Connection c → i {
+    ^ # i ( PQsocket . c raw )
+}
+
+// Toggle non-blocking send mode. In non-blocking mode `pg_flush` must be
+// pumped until it returns 0.
+@ pg_set_nonblocking Connection c b on → !i PgErr {
+    : i32 arg # i32 ? on 1 0
+    ? == -1 # i ( PQsetnonblocking . c raw arg ) {
+        ^ @ !i PgErr { F # PgErr PgExecFailed }
+    } {}
+    ^ @ !i PgErr { T 1 }
+}
+
+@ pg_is_nonblocking Connection c → b {
+    ^ != 0 # i ( PQisnonblocking . c raw )
+}
+
+// Flush queued output. 0 = all sent, 1 = data still queued, -1 = error.
+@ pg_flush Connection c → i {
+    ^ # i ( PQflush . c raw )
+}
+
+// Pop the next result of an in-flight async command. None signals the
+// command produced all its results (libpq returned a NULL PGresult).
+// A non-OK result still comes back as Some — inspect it, then `pg_clear`
+// every Some you receive.
+@ pg_get_result Connection c → ?PgResult {
+    : s raw ( PQgetResult . c raw )
+    ? == # i raw 0 { ^ @ ?PgResult { F # PgResult 0 } } {}
+    ^ @ ?PgResult { T @ PgResult { raw } }
+}
+
+// Block until the in-flight command finishes and return its final result.
+// Intermediate results (only from multi-statement command strings) are
+// cleared. CALLER `pg_clear`s the returned PgResult on the T arm.
+@ pg_await Connection c → !PgResult PgErr {
+    : ~ s last # s 0
+    : ~ s cur ( PQgetResult . c raw )
+    ~ != 0 # i cur {
+        ? != 0 # i last { ( PQclear last ) } {}
+        = last cur
+        = cur ( PQgetResult . c raw )
+    }
+    ^ ( __pg_wrap_result last )
+}
+
+// ══════════════════════════════════════════════════════════════════
+//  LISTEN / NOTIFY
+// ══════════════════════════════════════════════════════════════════
+//
+// Issue `LISTEN chan` (via pg_run) on a connection, then have producers
+// `NOTIFY chan, 'payload'`. To receive: when the connection's socket is
+// readable, `pg_consume_input` then loop `pg_notifies` until None. Each
+// PgNotify owns its `relname` / `extra` Strings — free with
+// `pg_notify_free` (or read its fields then free).
+: PgNotify { String relname  i be_pid  String extra }
+
+// Pop the next buffered notification, or None if the queue is empty.
+// Reads libpq's `PGnotify { char *relname; int be_pid; char *extra; }`
+// (slots 0/1/2 of the i64-slot view; be_pid occupies the low 32 bits of
+// slot 1) and copies the strings into owned Strings before freeing the
+// libpq struct with PQfreemem.
+@ pg_notifies Connection c → ?PgNotify {
+    : s raw ( PQnotifies . c raw )
+    ? == # i raw 0 { ^ @ ?PgNotify { F # PgNotify 0 } } {}
+    : s rel # s ( nurl_peek raw 0 )
+    : i pid & ( nurl_peek raw 1 ) 4294967295
+    : s ext # s ( nurl_peek raw 2 )
+    : String relname ? == # i rel 0 ( string_from `` ) ( string_from rel )
+    : String extra ? == # i ext 0 ( string_from `` ) ( string_from ext )
+    ( PQfreemem raw )
+    ^ @ ?PgNotify { T @ PgNotify { relname pid extra } }
+}
+
+// Convenience: start listening on a channel. Auto-clears the result.
+//
+// SECURITY: a channel name is a SQL *identifier*, not a value, so it can
+// NOT be bound with a `$1` placeholder — it must be quoted with
+// PQescapeIdentifier (via pg_escape_identifier) before interpolation.
+// Concatenating `channel` raw would be a SQL-injection hole
+// (`pg_listen c "x; DROP TABLE users; --"`). `pg_notify_send` below has
+// no such issue: it binds the channel as a *value* to `pg_notify($1,$2)`.
+@ pg_listen Connection c s channel → !i PgErr {
+    // pg_escape_identifier returns an OWNED, double-quote-wrapped String
+    // (e.g. `"chan"`); free it after the exec. `nurl_str_cat`'s heap
+    // result is auto-dropped at scope exit (libpq's PQexec has copied it
+    // by the time pg_run returns — a manual nurl_free would double-free).
+    : String esc ( pg_escape_identifier c channel )
+    : s sql ( nurl_str_cat `LISTEN ` ( string_data esc ) )
+    : !i PgErr r ( pg_run c sql )
+    ( string_free esc )
+    ^ r
+}
+
+// Convenience: send a notification with a text payload on a channel.
+@ pg_notify_send Connection c s channel s payload → !i PgErr {
+    : PgParams ps ( pg_params 2 )
+    ( pg_bind_text ps channel )
+    ( pg_bind_text ps payload )
+    : !PgResult PgErr rr ( pg_exec_params_b c `SELECT pg_notify($1, $2)` ps )
+    ^ ?? rr {
+        T r → { ( pg_clear r )  @ !i PgErr { T 1 } }
+        F e → @ !i PgErr { F # PgErr e }
+    }
+}
+
+// Release a PgNotify's owned Strings.
+@ pg_notify_free PgNotify n → v {
+    ( string_free . n relname )
+    ( string_free . n extra )
+}
+
+// ══════════════════════════════════════════════════════════════════
+//  COPY — bulk row streaming
+// ══════════════════════════════════════════════════════════════════
+//
+// COPY FROM STDIN (load):
+//   ( pg_copy_start c `COPY t (a,b) FROM STDIN` )    // PGRES_COPY_IN (4)
+//   ( pg_put_copy_str c ( string_from "1\tlo\n" ) )  // one row per call
+//   ( pg_put_copy_end c )                      // finish the stream
+//   ( pg_await c )                             // collect the COMMAND_OK
+//
+// COPY TO STDOUT (dump):
+//   ( pg_copy_start c `COPY t TO STDOUT` )           // PGRES_COPY_OUT (3)
+//   ~ … { ?? ( pg_get_copy_data c ) { T row → … F _ → break } }
+//   ( pg_await c )                             // final COMMAND_OK
+
+// Begin a COPY. Runs a `COPY … FROM STDIN` / `COPY … TO STDOUT` command
+// and accepts its handshake status — PGRES_COPY_IN (4) or PGRES_COPY_OUT
+// (3) — as success (plain pg_exec rejects these, since they are neither
+// COMMAND_OK nor TUPLES_OK). The handshake result is cleared; the T arm
+// carries the status so the caller can confirm the expected direction.
+@ pg_copy_start Connection c s sql → !i PgErr {
+    : s raw ( PQexec . c raw sql )
+    ? == # i raw 0 { ^ @ !i PgErr { F # PgErr PgNullResult } } {}
+    : PgResult r @ PgResult { raw }
+    : i st ( pg_result_status r )
+    ( pg_clear r )
+    ? | == st 3 == st 4 { ^ @ !i PgErr { T st } } {}
+    ^ @ !i PgErr { F # PgErr PgExecFailed }
+}
+
+// Feed `nbytes` of raw row data into a COPY FROM STDIN stream. 1 = ok,
+// 0 = would block (non-blocking mode), -1 = error.
+@ pg_put_copy_data Connection c s buf i nbytes → !i PgErr {
+    : i32 nb # i32 nbytes
+    : i rc # i ( PQputCopyData . c raw buf nb )
+    ? < rc 0 { ^ @ !i PgErr { F # PgErr PgExecFailed } } {}
+    ^ @ !i PgErr { T rc }
+}
+
+// Feed one text-format COPY row (caller includes the trailing newline).
+@ pg_put_copy_str Connection c String row → !i PgErr {
+    ^ ( pg_put_copy_data c ( string_data row ) ( string_len row ) )
+}
+
+// Close a COPY FROM STDIN stream successfully (NULL errormsg).
+@ pg_put_copy_end Connection c → !i PgErr {
+    : i rc # i ( PQputCopyEnd . c raw # s 0 )
+    ? < rc 0 { ^ @ !i PgErr { F # PgErr PgExecFailed } } {}
+    ^ @ !i PgErr { T rc }
+}
+
+// Pull the next COPY TO STDOUT row. None marks end-of-data (libpq -1 or
+// -2). Each Some is an OWNED String holding one row's wire bytes (text
+// COPY: the row text including its trailing newline). CALLER frees it.
+@ pg_get_copy_data Connection c → ?String {
+    : s slot ( nurl_alloc 8 )
+    ( nurl_poke slot 0 0 )
+    : **u bp # **u slot
+    : i32 az # i32 0
+    : i n # i ( PQgetCopyData . c raw bp az )
+    ? <= n 0 {
+        : s b0 # s ( nurl_peek slot 0 )
+        ? != 0 # i b0 { ( PQfreemem b0 ) } {}
+        ( nurl_free slot )
+        ^ @ ?String { F # String 0 }
+    } {}
+    : s buf # s ( nurl_peek slot 0 )
+    ( nurl_free slot )
+    : String out ( string_from_bytes # *u buf n )
+    ( PQfreemem buf )
+    ^ @ ?String { T out }
 }


### PR DESCRIPTION
Close the last Tier-5 Postgres TODO gap. All four are pure-NURL libpq
FFI in stdlib/ext/postgres.nu and are exercised end to end by the new
examples/pg_advanced.nu, live-verified against PostgreSQL 16.14:

- Binary results: pg_exec_params_binary + pg_get_{i16,i32,i64,bool,f64}_bin
  (network byte order; float8 reinterpreted from its IEEE-754 bits).
- Async: pg_send/pg_send_params/pg_get_result/pg_await + consume/is_busy/
  socket/flush/set_nonblocking poll hooks.
- LISTEN/NOTIFY: pg_listen/pg_notify_send/pg_notifies/pg_notify_free.
- COPY: pg_copy_start + pg_put_copy_* / pg_get_copy_data.

Compiler fix: result/option-typed function PARAMETERS now record the
payload metadata (__res_nurl_T/__res_t_llvm/__res_e_llvm/__opt_nurl_T)
that gen_let_or_struct already records for let-bound result vars, so
`?? param { T x -> ^ x }` reconstructs struct/pointer/unsigned payloads
instead of miscompiling to `ret i64`. Regression
compiler/tests/match_param_payload.nu; bootstrap fixed point held.

Security hardening (from a review):
- pg_listen SQL injection (critical): channel name now escaped via
  pg_escape_identifier (it is an identifier, not a bindable value).
- OOB read in binary accessors (medium): __pg_bin_ptr PQgetlength-guards
  every pg_get_*_bin, so a short/NULL cell yields 0, not adjacent memory.
- TLS-not-verified-by-default documented on pg_connect + file header
  (recommend sslmode=verify-full); pg_get_bool NULL guard; escape
  empty-on-NULL behaviour documented.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>