### PR TITLE
feat(esp32): NURL UART stdlib (stdlib/hal) + fully-NURL UART echo exa…

### DIFF
--- a/examples/esp32/README.md
+++ b/examples/esp32/README.md
@@ -76,6 +76,38 @@ change the pin mask + the IO_MUX address in `nurl/nurl_blink.nu`.
 
 ---
 
+## Xtensa: UART echo, fully NURL-driven (`idf-uart/`)
+
+A second ESP-IDF project that shows NURL doing **bidirectional** hardware I/O,
+not just output. The whole read-echo cycle is in NURL — C's `app_main` calls
+`nurl_uart_echo()` once and never returns. NURL polls UART0's RX FIFO and
+writes its TX FIFO directly through device registers (TX via the APB FIFO, RX
+via the AHB FIFO at `0x60000000` to dodge an ESP32 RX erratum).
+
+It's built on a **new hardware-abstraction stdlib**:
+
+- `stdlib/hal/mmio.nu`  — generic 32-bit MMIO primitives (`mmio_read32` /
+  `mmio_write32` / `mmio_set32` / `mmio_clear32`).
+- `stdlib/hal/esp32.nu` — ESP32 register map: GPIO + UART0, built on `mmio`.
+
+```sh
+. $IDF_PATH/export.sh
+cd idf-uart
+idf.py set-target esp32
+idf.py -p /dev/ttyUSB0 flash monitor      # type — NURL echoes every byte
+```
+
+Verified on hardware: typing `Hello, NURL!⏎` returns `Hello, NURL!` with the
+Enter turned into a fresh `> ` prompt, all by NURL register pokes.
+
+**`-O0` matters here.** `esp32_uart_getc/putc` spin on a FIFO-status read, and
+NURL has no `volatile`, so at `-O2` LLVM's LICM can hoist that read out of the
+loop and the spin never exits. `gen_object.sh` builds the UART object at `-O0`;
+the blink (no spin loops) stays at `-O2`. The task watchdog is turned off in
+`sdkconfig.defaults` because the echo task intentionally owns the CPU.
+
+---
+
 ## RISC-V: build a linked ELF (stock LLVM)
 
 `blink.nu` is the same blink for the RISC-V ESP32 variants. Stock LLVM's
@@ -113,18 +145,26 @@ stock toolchain handles ESP32-C3/C6/H2 directly.
 ## Files
 
 ```
-idf-blink/                 ESP-IDF project — the Xtensa blink that runs on hardware
+idf-blink/                 ESP-IDF project — Xtensa GPIO blink, runs on hardware
   main/app_main.c          C entry: vTaskDelay timing + serial log; calls into NURL
   main/CMakeLists.txt      auto-runs nurlc + esp-clang, links the NURL object
   nurl/nurl_blink.nu       all GPIO register control, in NURL
   nurl/gen_object.sh       nurlc -> .ll -> esp-clang -> .o
   sdkconfig.defaults
 
+idf-uart/                  ESP-IDF project — Xtensa UART echo, fully NURL-driven
+  main/app_main.c          C entry: hands UART0 to NURL and never returns
+  nurl/nurl_uart.nu        greeting + RX->TX echo loop; imports stdlib/hal/esp32.nu
+  nurl/gen_object.sh       same pipeline, built at -O0 (MMIO spin loops)
+
 blink.nu                   RISC-V (ESP32-C3) blink — buildable with stock LLVM
 blink_xtensa.nu            standalone Xtensa blink (IR/codegen demo, no IDF)
 start.c, esp32c3.ld        freestanding startup + linker script for the RISC-V ELF
 build.sh                   RISC-V pipeline driver -> build/blink.elf
 ```
+
+The reusable hardware HAL lives in the main tree:
+`stdlib/hal/mmio.nu` (generic MMIO) and `stdlib/hal/esp32.nu` (ESP32 GPIO + UART).
 
 ---
 

--- a/examples/esp32/blink.nu
+++ b/examples/esp32/blink.nu
@@ -20,34 +20,34 @@
 // --- ESP32-C3 GPIO register map (TRM ch. "IO MUX and GPIO Matrix") ---
 //     addresses are `i` (i64) because in this nurlc `u` lowers to i8;
 //     the MMIO access itself is a 32-bit store via a `*i32` pointer.
-: i REG_GPIO_OUT_W1TS    1610629128   // 0x6000_4008  set output bits
-: i REG_GPIO_OUT_W1TC    1610629132   // 0x6000_400C  clear output bits
-: i REG_GPIO_ENABLE_W1TS 1610629156   // 0x6000_4024  enable as output
-: i PIN_MASK             256          // 1 << 8       GPIO8
+: i REG_GPIO_OUT_W1TS 1610629128  // 0x6000_4008  set output bits
+: i REG_GPIO_OUT_W1TC 1610629132  // 0x6000_400C  clear output bits
+: i REG_GPIO_ENABLE_W1TS 1610629156  // 0x6000_4024  enable as output
+: i PIN_MASK 256  // 1 << 8       GPIO8
 
 // 32-bit memory-mapped write: *(volatile u32*)addr = val
 @ poke i addr i32 val → v {
-  : *i32 p # *i32 addr
-  = . p 0 val
+    : *i32 p # *i32 addr
+    = . p 0 val
 }
 
 // crude busy-wait — at -O0 the loop survives; see README on volatile.
 @ delay i n → v {
-  : ~ i k 0
-  ~ < k n { = k + k 1 }
+    : ~ i k 0
+    ~ < k n { = k + k 1 }
 }
 
 @ main → i {
-  // configure GPIO8 as a push-pull output
-  ( poke REG_GPIO_ENABLE_W1TS # i32 PIN_MASK )
+    // configure GPIO8 as a push-pull output
+    ( poke REG_GPIO_ENABLE_W1TS # i32 PIN_MASK )
 
-  : ~ i n 0
-  ~ < n 1000000 {
-    ( poke REG_GPIO_OUT_W1TS # i32 PIN_MASK )   // LED on
-    ( delay 200000 )
-    ( poke REG_GPIO_OUT_W1TC # i32 PIN_MASK )   // LED off
-    ( delay 200000 )
-    = n + n 1
-  }
-  ^ 0
+    : ~ i n 0
+    ~ < n 1000000 {
+        ( poke REG_GPIO_OUT_W1TS # i32 PIN_MASK )  // LED on
+        ( delay 200000 )
+        ( poke REG_GPIO_OUT_W1TC # i32 PIN_MASK )  // LED off
+        ( delay 200000 )
+        = n + n 1
+    }
+    ^ 0
 }

--- a/examples/esp32/blink_xtensa.nu
+++ b/examples/esp32/blink_xtensa.nu
@@ -12,31 +12,31 @@
 // ============================================================
 
 // --- Classic ESP32 GPIO register map (TRM "IO_MUX / GPIO matrix") ---
-: i REG_GPIO_OUT_W1TS    1073086472   // 0x3FF4_4008  set output bits
-: i REG_GPIO_OUT_W1TC    1073086476   // 0x3FF4_400C  clear output bits
-: i REG_GPIO_ENABLE_W1TS 1073086500   // 0x3FF4_4024  enable as output
-: i PIN_MASK             4            // 1 << 2       GPIO2 (common LED)
+: i REG_GPIO_OUT_W1TS 1072971784  // 0x3FF4_4008  set output bits
+: i REG_GPIO_OUT_W1TC 1072971788  // 0x3FF4_400C  clear output bits
+: i REG_GPIO_ENABLE_W1TS 1072971812  // 0x3FF4_4024  enable as output
+: i PIN_MASK 4  // 1 << 2       GPIO2 (common LED)
 
 @ poke i addr i32 val → v {
-  : *i32 p # *i32 addr
-  = . p 0 val
+    : *i32 p # *i32 addr
+    = . p 0 val
 }
 
 @ delay i n → v {
-  : ~ i k 0
-  ~ < k n { = k + k 1 }
+    : ~ i k 0
+    ~ < k n { = k + k 1 }
 }
 
 @ main → i {
-  ( poke REG_GPIO_ENABLE_W1TS # i32 PIN_MASK )
+    ( poke REG_GPIO_ENABLE_W1TS # i32 PIN_MASK )
 
-  : ~ i n 0
-  ~ < n 1000000 {
-    ( poke REG_GPIO_OUT_W1TS # i32 PIN_MASK )   // LED on
-    ( delay 200000 )
-    ( poke REG_GPIO_OUT_W1TC # i32 PIN_MASK )   // LED off
-    ( delay 200000 )
-    = n + n 1
-  }
-  ^ 0
+    : ~ i n 0
+    ~ < n 1000000 {
+        ( poke REG_GPIO_OUT_W1TS # i32 PIN_MASK )  // LED on
+        ( delay 200000 )
+        ( poke REG_GPIO_OUT_W1TC # i32 PIN_MASK )  // LED off
+        ( delay 200000 )
+        = n + n 1
+    }
+    ^ 0
 }

--- a/examples/esp32/idf-blink/nurl/nurl_blink.nu
+++ b/examples/esp32/idf-blink/nurl/nurl_blink.nu
@@ -15,8 +15,8 @@
 //  self-contained symbols that link straight into an ESP-IDF app.
 //
 //  Register addresses verified against ESP-IDF soc/{gpio,io_mux}_reg.h.
-//  LED is GPIO2 on most ESP32 "mini" boards; change PIN_MASK and the
-//  IO_MUX address for a different pin.
+//  Decimal literals (hex in comments): nurlc takes 0x.. but nurlfmt splits
+//  it, so shipped sources stay decimal. LED is GPIO2 on most ESP32 boards.
 // ============================================================
 
 // Pure compute, no MMIO — proves the C->NURL windowed cross-call works.
@@ -24,16 +24,16 @@
 
 // 32-bit memory-mapped write: *(volatile u32*)addr = val
 @ poke i addr i32 val → v {
-  : *i32 p # *i32 addr
-  = . p 0 val
+    : *i32 p # *i32 addr
+    = . p 0 val
 }
 
 // Configure GPIO2 as a push-pull output, entirely via raw registers.
 @ nurl_led_setup → v {
-  ( poke 0x3FF49040 # i32 0x2000 )   // IO_MUX_GPIO2_REG:       MCU_SEL=2 -> GPIO function
-  ( poke 0x3FF44538 # i32 0x100 )    // GPIO_FUNC2_OUT_SEL_CFG: route pad to GPIO_OUT (idx 256)
-  ( poke 0x3FF44024 # i32 0x4 )      // GPIO_ENABLE_W1TS_REG:   bit2 -> drive as output
+    ( poke 1072992320 # i32 8192 )  // IO_MUX_GPIO2 (0x3FF49040): MCU_SEL=2 -> GPIO
+    ( poke 1072973112 # i32 256 )  // GPIO_FUNC2_OUT_SEL_CFG (0x3FF44538): pad -> GPIO_OUT
+    ( poke 1072971812 # i32 4 )  // GPIO_ENABLE_W1TS (0x3FF44024): bit2 -> output
 }
 
-@ nurl_led_on  → v { ( poke 0x3FF44008 # i32 0x4 ) }   // GPIO_OUT_W1TS_REG: GPIO2 high
-@ nurl_led_off → v { ( poke 0x3FF4400C # i32 0x4 ) }   // GPIO_OUT_W1TC_REG: GPIO2 low
+@ nurl_led_on → v { ( poke 1072971784 # i32 4 ) }  // GPIO_OUT_W1TS (0x3FF44008): GPIO2 high
+@ nurl_led_off → v { ( poke 1072971788 # i32 4 ) }  // GPIO_OUT_W1TC (0x3FF4400C): GPIO2 low

--- a/examples/esp32/idf-uart/.gitignore
+++ b/examples/esp32/idf-uart/.gitignore
@@ -1,0 +1,5 @@
+/build/
+/sdkconfig
+/sdkconfig.old
+nurl/nurl_uart.ll
+nurl/nurl_uart.o

--- a/examples/esp32/idf-uart/CMakeLists.txt
+++ b/examples/esp32/idf-uart/CMakeLists.txt
@@ -1,0 +1,4 @@
+# ESP-IDF project: fully NURL-driven UART echo (Xtensa).
+cmake_minimum_required(VERSION 3.16)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(nurl_uart)

--- a/examples/esp32/idf-uart/main/CMakeLists.txt
+++ b/examples/esp32/idf-uart/main/CMakeLists.txt
@@ -1,0 +1,14 @@
+idf_component_register(SRCS "app_main.c")
+
+# nurl_uart.nu (+ stdlib/hal/*) --(nurlc)--> .ll --(esp-clang -O0)--> .o
+set(NURL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../nurl")
+set(NURL_OBJ "${NURL_DIR}/nurl_uart.o")
+add_custom_command(
+    OUTPUT  "${NURL_OBJ}"
+    COMMAND "${NURL_DIR}/gen_object.sh"
+    DEPENDS "${NURL_DIR}/nurl_uart.nu" "${NURL_DIR}/gen_object.sh"
+    COMMENT "NURL -> Xtensa object (nurlc + esp-clang, -O0)"
+    VERBATIM)
+add_custom_target(nurl_uart_obj DEPENDS "${NURL_OBJ}")
+add_dependencies(${COMPONENT_LIB} nurl_uart_obj)
+target_link_libraries(${COMPONENT_LIB} PRIVATE "${NURL_OBJ}")

--- a/examples/esp32/idf-uart/main/app_main.c
+++ b/examples/esp32/idf-uart/main/app_main.c
@@ -1,0 +1,20 @@
+/* app_main.c — entry for the fully-NURL UART echo.
+ *
+ * The bootloader already brought UART0 up at 115200 (it's the console), so
+ * NURL inherits a working port. We hand control to NURL and never come back:
+ * nurl_uart_echo() polls the RX FIFO and writes the TX FIFO directly, in an
+ * infinite loop. The task watchdog is disabled (sdkconfig.defaults) because
+ * this task intentionally owns the CPU with a tight I/O loop.
+ */
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+
+extern void nurl_uart_echo(void);   /* nurl/nurl_uart.nu + stdlib hal modules */
+
+void app_main(void)
+{
+    ESP_LOGI("nurl-uart", "handing UART0 to NURL (stdlib/hal/esp32.nu)...");
+    vTaskDelay(pdMS_TO_TICKS(50));  /* let the IDF log flush first */
+    nurl_uart_echo();               /* never returns */
+}

--- a/examples/esp32/idf-uart/nurl/gen_object.sh
+++ b/examples/esp32/idf-uart/nurl/gen_object.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Regenerate nurl_uart.o from nurl_uart.nu (+ stdlib/hal/*).
+#   nurlc     : NURL source (with $-imports) -> portable LLVM IR
+#   esp-clang : LLVM IR -> Xtensa (xtensa-esp32-elf) object
+#
+# Built at -O0: nurl_uart spins on MMIO FIFO-status reads and NURL has no
+# `volatile`, so -O2 LICM could hoist those reads out of the loop. -O0 keeps
+# every device read where it belongs.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Walk up to the repo root (the dir that holds build/nurlc).
+ROOT="$HERE"
+while [ "$ROOT" != "/" ] && [ ! -x "$ROOT/build/nurlc" ]; do ROOT="$(dirname "$ROOT")"; done
+NURLC="$ROOT/build/nurlc"
+[ -x "$NURLC" ] || { echo "ERROR: build/nurlc not found above $HERE — run ./build.sh in the repo root." >&2; exit 1; }
+
+CLANG="$(ls "$HOME"/.espressif/tools/esp-clang/*/esp-clang/bin/clang 2>/dev/null | head -1)"
+[ -x "${CLANG:-}" ] || { echo "ERROR: esp-clang not found — python3 \$IDF_PATH/tools/idf_tools.py install esp-clang" >&2; exit 1; }
+
+# $-imports resolve relative to CWD, so compile from the repo root.
+cd "$ROOT"
+echo "==> nurlc:     nurl_uart.nu (+ stdlib/hal/*) -> nurl_uart.ll"
+"$NURLC" "$HERE/nurl_uart.nu" > "$HERE/nurl_uart.ll"
+
+echo "==> esp-clang: nurl_uart.ll -> nurl_uart.o  (xtensa-esp32-elf, -O0)"
+"$CLANG" --target=xtensa-esp32-elf -mcpu=esp32 -O0 \
+    -c "$HERE/nurl_uart.ll" -o "$HERE/nurl_uart.o" 2>&1 \
+    | grep -v "overriding the module target triple" || true
+
+echo "==> done: $HERE/nurl_uart.o"

--- a/examples/esp32/idf-uart/nurl/nurl_uart.nu
+++ b/examples/esp32/idf-uart/nurl/nurl_uart.nu
@@ -1,0 +1,23 @@
+// nurl_uart.nu — a fully NURL-driven UART echo for the classic ESP32 (Xtensa).
+//
+// Uses the new hardware HAL: stdlib/hal/esp32.nu (UART0 over MMIO) which in
+// turn builds on stdlib/hal/mmio.nu. No ESP-IDF UART driver, no FFI — NURL
+// polls the RX FIFO and writes the TX FIFO directly through device registers.
+//
+// The whole read-echo cycle lives in NURL: C's app_main just calls this once
+// and it never returns. Built at -O0 so the FIFO-status spin loops survive
+// (NURL has no `volatile` yet — see stdlib/hal/mmio.nu).
+
+$ `stdlib/hal/esp32.nu`
+
+@ nurl_uart_echo → v {
+    ( esp32_uart_puts `\r\n=== NURL UART echo on ESP32 (Xtensa) ===\r\n` )
+    ( esp32_uart_puts `Type characters - NURL reads RX and echoes TX.\r\n> ` )
+
+    ~ > 1 0 {  // forever
+        : i c ( esp32_uart_getc )  // blocking read from RX FIFO
+        ? == c 13  // Enter pressed?
+        ( esp32_uart_puts `\r\n> ` )  //   yes: newline + fresh prompt
+        ( esp32_uart_putc c )  //   no : echo the byte to TX FIFO
+    }
+}

--- a/examples/esp32/idf-uart/sdkconfig.defaults
+++ b/examples/esp32/idf-uart/sdkconfig.defaults
@@ -1,0 +1,3 @@
+# The echo task intentionally runs a tight, never-yielding NURL I/O loop, so
+# the task watchdog (which monitors idle-task starvation) is turned off.
+CONFIG_ESP_TASK_WDT_INIT=n

--- a/stdlib/hal/esp32.nu
+++ b/stdlib/hal/esp32.nu
@@ -1,0 +1,68 @@
+// stdlib/hal/esp32.nu — bare-metal register HAL for the classic ESP32 (Xtensa).
+//
+// Pure NURL over memory-mapped registers (built on stdlib/hal/mmio.nu). No
+// ESP-IDF, no FFI — just the physical register addresses from the ESP32 TRM
+// (cross-checked against ESP-IDF soc/{gpio,io_mux,uart}_reg.h).
+//
+// Addresses are written in decimal with the hex in a comment: nurlc accepts
+// 0x.. literals, but nurlfmt currently splits them ("0x10" -> "0 x10"), so
+// shipped stdlib stays decimal to survive the formatter round-trip gate.
+//
+// GPIO:
+//   ( esp32_gpio_enable_output i mask ) → v   drive these pins as outputs
+//   ( esp32_gpio_set           i mask ) → v   set pins high
+//   ( esp32_gpio_clear         i mask ) → v   set pins low
+//
+// UART0 (the chip's USB-serial console):
+//   ( esp32_uart_tx_count ) → i   bytes currently queued in the TX FIFO
+//   ( esp32_uart_rx_count ) → i   bytes available in the RX FIFO
+//   ( esp32_uart_putc  i ch ) → v blocking: wait for room, push one byte
+//   ( esp32_uart_getc       ) → i blocking: wait for a byte, return 0..255
+//   ( esp32_uart_puts  s str ) → v write a NUL-terminated string
+//
+// NOTE: esp32_uart_putc/getc spin on an MMIO status read. NURL has no
+// `volatile`, so compile any program that calls them at -O0/-O1 or the spin
+// loop may be hoisted away (LICM). See examples/esp32/idf-uart.
+
+$ `stdlib/hal/mmio.nu`
+
+// ── GPIO (DR_REG_GPIO_BASE = 0x3FF44000) ──────────────────────────────
+: i GPIO_OUT_W1TS_REG 1072971784  // 0x3FF44008
+: i GPIO_OUT_W1TC_REG 1072971788  // 0x3FF4400C
+: i GPIO_ENABLE_W1TS_REG 1072971812  // 0x3FF44024
+
+@ esp32_gpio_enable_output i mask → v { ( mmio_write32 GPIO_ENABLE_W1TS_REG # i32 mask ) }
+
+@ esp32_gpio_set i mask → v { ( mmio_write32 GPIO_OUT_W1TS_REG # i32 mask ) }
+
+@ esp32_gpio_clear i mask → v { ( mmio_write32 GPIO_OUT_W1TC_REG # i32 mask ) }
+
+// ── UART0 (DR_REG_UART_BASE = 0x3FF40000) ─────────────────────────────
+//  TX writes go to the APB FIFO; RX reads come from the AHB-mapped FIFO at
+//  0x60000000 (reading RX over APB hits an ESP32 silicon erratum).
+: i UART0_FIFO_REG 1072955392  // 0x3FF40000  write byte -> TX FIFO
+: i UART0_FIFO_AHB_REG 1610612736  // 0x60000000  read byte  <- RX FIFO
+: i UART0_STATUS_REG 1072955420  // 0x3FF4001C  [23:16]=TXFIFO_CNT [7:0]=RXFIFO_CNT
+
+@ esp32_uart_tx_count → i { ^ & >> ( mmio_read32 UART0_STATUS_REG ) 16 255 }
+
+@ esp32_uart_rx_count → i { ^ & ( mmio_read32 UART0_STATUS_REG ) 255 }
+
+@ esp32_uart_putc i ch → v {
+    ~ >= ( esp32_uart_tx_count ) 126 {}  // wait until the TX FIFO has room
+    ( mmio_write32 UART0_FIFO_REG # i32 ch )
+}
+
+@ esp32_uart_getc → i {
+    ~ == ( esp32_uart_rx_count ) 0 {}  // wait until a byte arrives
+    ^ & ( mmio_read32 UART0_FIFO_AHB_REG ) 255
+}
+
+@ esp32_uart_puts s str → v {
+    : *u p # *u str
+    : ~ i i 0
+    ~ != # i . p i 0 {
+        ( esp32_uart_putc # i . p i )
+        = i + i 1
+    }
+}

--- a/stdlib/hal/mmio.nu
+++ b/stdlib/hal/mmio.nu
@@ -1,0 +1,36 @@
+// stdlib/hal/mmio.nu — memory-mapped I/O primitives.
+//
+// The whole of an MMIO peripheral driver is "read/write a 32-bit word at a
+// fixed physical address". NURL pointers express that directly: cast an
+// integer address to `*i32` and load/store element 0.
+//
+// API:
+//   ( mmio_read32   i addr )          → i      load  *(u32*)addr (zero-ish widened to i64)
+//   ( mmio_write32  i addr i32 val )  → v      store *(u32*)addr = val
+//   ( mmio_set32    i addr i32 mask ) → v      *(u32*)addr |= mask
+//   ( mmio_clear32  i addr i32 mask ) → v      *(u32*)addr &= ~mask
+//
+// IMPORTANT — no `volatile` in NURL (yet). At -O2 the optimizer may hoist a
+// read out of a polling loop (LICM), so anything that *spins on* an MMIO
+// read (UART FIFO status, etc.) must be compiled at -O0/-O1. Plain one-shot
+// reads/writes are fine at any optimization level. See examples/esp32.
+
+@ mmio_read32 i addr → i {
+    : *i32 p # *i32 addr
+    ^ # i . p 0
+}
+
+@ mmio_write32 i addr i32 val → v {
+    : *i32 p # *i32 addr
+    = . p 0 val
+}
+
+@ mmio_set32 i addr i32 mask → v {
+    : *i32 p # *i32 addr
+    = . p 0 # i32 | # i . p 0 # i mask
+}
+
+@ mmio_clear32 i addr i32 mask → v {
+    : *i32 p # *i32 addr
+    = . p 0 # i32 & # i . p 0 ~ # i mask
+}


### PR DESCRIPTION
…mple

Add a hardware-abstraction stdlib and a second ESP32 example showing NURL doing bidirectional I/O on real Xtensa silicon, not just output.

stdlib/hal/:
  - mmio.nu  — generic 32-bit MMIO primitives (read/write/set/clear32)
  - esp32.nu — ESP32 register HAL: GPIO + UART0, built on mmio

examples/esp32/idf-uart/:
  - fully NURL-driven UART0 echo (greeting + RX->TX loop); C app_main only hands UART0 to NURL. RX read via the AHB FIFO (0x60000000) to dodge the ESP32 RX erratum. Built -O0 (NURL has no volatile, so -O2 LICM would hoist the FIFO-status spin reads). Verified on an ESP32-D0WDQ6.
  - CMake auto-runs nurlc + esp-clang to (re)generate the Xtensa object.

Also: convert example register addresses to decimal (with hex in comments) and fix several wrong hand-computed addresses — nurlfmt currently splits hex literals ("0x10" -> "0 x10"), which the stdlib/examples nurlfmt CI gate would otherwise trip. All new .nu files pass nurlfmt --check and compile clean.