### PR TITLE
Add binary-safe HTTP request bodies via http_*_bytes family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Binary-safe HTTP request bodies — `http_*_bytes` family.** The s-body
+  `http_request` / `http_post` / `http_put` family recovers the body length
+  via `strlen`, so a request body with embedded NUL bytes (binary file
+  uploads, MessagePack, protobuf) truncated at the first NUL. New
+  length-carrying variants take the body as a `( Vec u )` and ship it via
+  `CURLOPT_COPYPOSTFIELDS` + an explicit `POSTFIELDSIZE`, so the exact byte
+  count is sent: `http_request_bytes` / `http_request_bytes_to`,
+  `http_post_bytes`, `http_put_bytes`, and the streaming
+  `http_stream_open_bytes_to`. The `body` argument is borrowed (the caller
+  still owns it). Binary fidelity requires the libcurl backend; the
+  WinHTTP/stub fallback round-trips through a NUL-terminated `s` and
+  degrades to the old truncation. `stdlib/ext/http.nu`.
+
+### Fixed
+
+- **Reverse-proxy request body is now binary-safe + a latent use-after-free
+  is closed.** `proxy_stream_to_conn_with` forwarded the upstream request
+  body by converting the request's `( Vec u )` body to a NUL-terminated `s`
+  and shipping it through `CURLOPT_POSTFIELDS` (strlen-sized), truncating
+  binary uploads at the first NUL. Worse, the streaming opener set
+  non-copying `CURLOPT_POSTFIELDS` and the proxy freed the body buffer
+  *before* the first `multi_perform` read it — a dangling-pointer read that
+  only escaped notice on small JSON bodies. Both are fixed by routing the
+  length-tracked body through `http_stream_open_bytes_to`, which uses
+  `CURLOPT_COPYPOSTFIELDS` (libcurl snapshots the bytes at open time, so the
+  caller may free immediately and embedded NULs survive). Regression:
+  `compiler/tests/http_binary_body.nu` (NURL client `http_post_bytes` of a
+  5-byte `A B \0 C D` body to a loopback NURL server, asserting the server
+  parsed all 5 bytes; `NURL_NET_TESTS=1`). Verified clean under ASan/UBSan.
+  `stdlib/ext/http.nu`, `stdlib/ext/http_proxy.nu`.
+
 ## [0.9.4] — 2026-06-02
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ NURL has achieved a stable self-hosted compiler (Grammar v2.1 — see [`spec/gra
 **What's actually left (not yet shipped):**
 - **HTTP/2 + WebSocket client-side** (both are server-side only today).
 - **Mobile / embedded targets** (Android NDK, iOS, `no_std`) — Milk-V Duo RISC-V is already validated; the rest follow the same cross-compile shape.
-- **reverse-proxy binary-body** pass-through (request/response currently NUL-truncate). *(SQLite BLOB/double/transactions shipped 2026-06-01; the full SHA/MD5/HMAC/BLAKE3 hash family is complete.)*
+- **reverse-proxy binary-body** pass-through: **request side fixed** (the `http_*_bytes` family ships the length-tracked body via `CURLOPT_COPYPOSTFIELDS` — binary uploads through the proxy are now lossless); the **response** stream still NUL-truncates (chunks ride a NUL-terminated `char*` carrier in `nurl_http_stream_next`). *(SQLite BLOB/double/transactions shipped 2026-06-01; the full SHA/MD5/HMAC/BLAKE3 hash family is complete.)*
 - **MCP**: continuous SSE stream, stateful sessions, Bearer-auth middleware (batch + GET-SSE stub + session-id echo already shipped).
 - **Organisational / aspirational:** split `runtime.c` into bootstrap-vs-stdlib-FFI files (PURIFY shrank it 8 254 → ~5 750 LOC but it is still one file); a compiler-embedded LLM for self-correcting errors; bench peers (Go) + a compiler self-host benchmark.
 

--- a/compiler/tests/http_binary_body.nu
+++ b/compiler/tests/http_binary_body.nu
@@ -1,0 +1,99 @@
+// http_binary_body.nu — binary-safe HTTP request body round-trip.
+//
+// Regression for the request-body NUL-truncation bug: the s-body
+// http_request_* family recovers the body length via strlen, so a body
+// with an embedded NUL byte truncates at the first NUL. The new
+// http_post_bytes / http_request_bytes family carries the body as a
+// length-tracked ( Vec u ) and ships it via CURLOPT_COPYPOSTFIELDS +
+// an explicit POSTFIELDSIZE, so the exact byte count is sent.
+//
+// Shape: a NURL HTTP server runs one accept on loopback; a separate
+// pthread POSTs a 5-byte body `A B \0 C D` with the binary-safe
+// client. The handler records the body length it actually parsed.
+// PASS  → server_saw_len=5 (full body shipped through the NUL).
+// FAIL  → server_saw_len=2 (truncated at the embedded NUL).
+//
+// Both results funnel through globals and are printed in fixed order
+// after the client thread joins, so the two-thread output stays
+// deterministic for the baseline diff. Live socket exercise gated
+// behind NURL_NET_TESTS=1.
+
+$ `stdlib/std/net.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/http.nu`
+$ `stdlib/ext/http_server.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+
+: ~ i g_saw_len -1
+: ~ i g_client_status -1
+
+@ echo_len_handler HttpRequest r → HttpResponse {
+    = g_saw_len ( vec_len [u] . r body )
+    ^ ( response_text 200 `ok\n` )
+}
+
+@ run_binary_body_test → v {
+    : !TcpListener NetErr lr ( tcp_listen `127.0.0.1` 18941 )
+    ?? lr {
+        T listener → {
+            : ( @ HttpResponse HttpRequest ) h \ HttpRequest req → HttpResponse { ^ ( echo_len_handler req ) }
+            : HttpServer srv ( server_new listener h )
+
+            : ( @ v ) client \ → v {
+                ( sleep_ms 250 )
+                : ( Vec u ) body ( vec_new [u] )
+                ( vec_push [u] body # u 65 )   // 'A'
+                ( vec_push [u] body # u 66 )   // 'B'
+                ( vec_push [u] body # u 0 )    // embedded NUL
+                ( vec_push [u] body # u 67 )   // 'C'
+                ( vec_push [u] body # u 68 )   // 'D'
+                : !Response HttpErr r ( http_post_bytes `http://127.0.0.1:18941/echo` body `application/octet-stream` )
+                ?? r {
+                    T resp → {
+                        = g_client_status ( http_status resp )
+                        ( response_free resp )
+                    }
+                    F e → { = g_client_status -2 }
+                }
+                ( vec_free [u] body )
+            }
+            : !Thread ThreadErr ct ( thread_spawn client )
+
+            : !v NetErr rr ( server_run_once srv )
+            ?? rr {
+                T _ → {}
+                F e → {
+                    ( nurl_print `server_err=` )
+                    ( nurl_print ( net_err_name e ) )
+                    ( nurl_print `\n` )
+                }
+            }
+            ?? ct { T t → { ( thread_join t ) } F _ → {} }
+
+            ( nurl_print `server_saw_len=` )
+            ( nurl_print_int g_saw_len )
+            ( nurl_print `client_status=` )
+            ( nurl_print_int g_client_status )
+            ( nurl_print `done\n` )
+        }
+        F e → {
+            ( nurl_print `listen_fail=` )
+            ( nurl_print ( net_err_name e ) )
+            ( nurl_print `\n` )
+        }
+    }
+}
+
+@ main → i {
+    : ?String gate ( env_get `NURL_NET_TESTS` )
+    ?? gate {
+        T s → { ( string_free s ) ( run_binary_body_test ) }
+        F → { ( nurl_print `binary body test skipped (set NURL_NET_TESTS=1)\n` ) }
+    }
+    ^ 0
+}

--- a/compiler/tests/run_tests.sh
+++ b/compiler/tests/run_tests.sh
@@ -247,6 +247,7 @@ for src in "${tests[@]}"; do
           && "$name" != "http_server_limits" \
           && "$name" != "http_server_tls" \
           && "$name" != "http_server_panic" \
+          && "$name" != "http_binary_body" \
           && "$ENABLE_HTTP_TESTS" != "1" ]]; then
         continue
     fi
@@ -254,7 +255,8 @@ for src in "${tests[@]}"; do
             || "$name" == "http_server_pipelined" \
             || "$name" == "http_server_limits" \
             || "$name" == "http_server_tls" \
-            || "$name" == "http_server_panic" ) \
+            || "$name" == "http_server_panic" \
+            || "$name" == "http_binary_body" ) \
           && "$ENABLE_NET_TESTS" != "1" ]]; then
         continue
     fi

--- a/stdlib/ext/http.nu
+++ b/stdlib/ext/http.nu
@@ -95,6 +95,7 @@
 //   HttpOther      6   anything else / runtime built without libcurl
 
 $ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
 $ `stdlib/core/errors.nu`
 
 // HttpErr tags — see stdlib/runtime.c §14 NURL_HTTP_ERR_*.
@@ -307,7 +308,7 @@ $ `stdlib/core/errors.nu`
 // All per-request knobs (timeouts, redirect policy, TLS verification,
 // User-Agent) ride in `opt`. The timeout-only `__libcurl_perform_full_to`
 // below is a thin shim that builds a default-options struct.
-@ __libcurl_perform_full_opts s url s method s body s headers_blob
+@ __libcurl_perform_full_opts s url s method *u body_ptr i body_len s headers_blob
 HttpOptions opt → i {
     : i resp # i ( nurl_zalloc 48 )
     ? == resp 0 { ^ 0 } {}
@@ -369,19 +370,24 @@ HttpOptions opt → i {
     : i is_put ( nurl_str_eq method `PUT` )
     : i is_del ( nurl_str_eq method `DELETE` )
     : i is_patch ( nurl_str_eq method `PATCH` )
-    : i has_body && != # i body 0 != ( nurl_str_len body ) 0
-    : s post_body ? != has_body 0 body ``
-    : i post_len ? != has_body 0 ( nurl_str_len body ) 0
+    : i has_body && != # i body_ptr 0 > body_len 0
     ? != is_post 0 {
         ( nurl_curl_setopt_l eh 47 1 )  // CURLOPT_POST
-        ( nurl_curl_setopt_s eh 10015 post_body )  // CURLOPT_POSTFIELDS
-        ( nurl_curl_setopt_l eh 60 post_len )  // CURLOPT_POSTFIELDSIZE
+        ? != has_body 0 {
+            // POSTFIELDSIZE before COPYPOSTFIELDS so libcurl copies the
+            // exact byte count (embedded NULs survive) rather than strlen.
+            ( nurl_curl_setopt_l eh 60 body_len )  // CURLOPT_POSTFIELDSIZE
+            ( nurl_curl_setopt_p eh 10165 body_ptr )  // CURLOPT_COPYPOSTFIELDS
+        } {
+            ( nurl_curl_setopt_l eh 60 0 )  // CURLOPT_POSTFIELDSIZE
+            ( nurl_curl_setopt_s eh 10015 `` )  // CURLOPT_POSTFIELDS (empty)
+        }
     } {
         ? || || != is_put 0 != is_del 0 != is_patch 0 {
             ( nurl_curl_setopt_s eh 10036 method )  // CURLOPT_CUSTOMREQUEST
             ? != has_body 0 {
-                ( nurl_curl_setopt_s eh 10015 body )
-                ( nurl_curl_setopt_l eh 60 post_len )
+                ( nurl_curl_setopt_l eh 60 body_len )  // CURLOPT_POSTFIELDSIZE
+                ( nurl_curl_setopt_p eh 10165 body_ptr )  // CURLOPT_COPYPOSTFIELDS
             } {}
         } {}
     }
@@ -426,10 +432,10 @@ HttpOptions opt → i {
 // Timeout-only shim over the orchestrator: builds a default-options
 // struct (follow redirects, verify TLS, stock UA) overriding just the
 // two timeouts. Kept for the existing http_request_to call path.
-@ __libcurl_perform_full_to s url s method s body s headers_blob
+@ __libcurl_perform_full_to s url s method *u body_ptr i body_len s headers_blob
 i timeout_ms i connect_timeout_ms → i {
     : HttpOptions opt @ HttpOptions { timeout_ms connect_timeout_ms 1 -1 1 `` }
-    ^ ( __libcurl_perform_full_opts url method body headers_blob opt )
+    ^ ( __libcurl_perform_full_opts url method body_ptr body_len headers_blob opt )
 }
 
 // Internal: dispatch the runtime call result onto a NURL ! Response HttpErr.
@@ -485,7 +491,8 @@ i timeout_ms i connect_timeout_ms → i {
 @ http_request_to s method s url s body s headers_blob i timeout_ms i connect_timeout_ms
 → !Response HttpErr {
     ? != ( nurl_curl_available ) 0 {
-        : i raw ( __libcurl_perform_full_to url method body headers_blob timeout_ms connect_timeout_ms )
+        // s-body path: recover length via strlen (text/JSON callers).
+        : i raw ( __libcurl_perform_full_to url method # *u body ( nurl_str_len body ) headers_blob timeout_ms connect_timeout_ms )
         ^ ( __http_dispatch raw )
     } {}
     : i raw ( nurl_http_perform_full_to url method body headers_blob
@@ -500,7 +507,7 @@ i timeout_ms i connect_timeout_ms → i {
 @ http_request_with_opts s method s url s body s headers_blob HttpOptions opt
 → !Response HttpErr {
     ? != ( nurl_curl_available ) 0 {
-        : i raw ( __libcurl_perform_full_opts url method body headers_blob opt )
+        : i raw ( __libcurl_perform_full_opts url method # *u body ( nurl_str_len body ) headers_blob opt )
         ^ ( __http_dispatch raw )
     } {}
     : i otmo . opt timeout_ms
@@ -581,6 +588,49 @@ i timeout_ms i connect_timeout_ms → i {
 
 @ http_delete s url → !Response HttpErr {
     ^ ( http_request `DELETE` url `` `` )
+}
+
+// ── Binary-safe body (length-carrying ( Vec u )) ───────────────────
+//
+// The s-body http_request_* family recovers the body length via
+// strlen, so a body with embedded NUL bytes (binary file uploads,
+// MessagePack, protobuf, …) truncates at the first NUL. These
+// variants carry the body as a length-tracked ( Vec u ) and ship it
+// via CURLOPT_COPYPOSTFIELDS + an explicit POSTFIELDSIZE, so the exact
+// byte count is sent. `body` is BORROWED — the caller still owns it.
+//
+// Backend note: binary fidelity requires the libcurl backend (the
+// default on Linux/macOS/Windows builds with -DNURL_HAVE_LIBCURL). On
+// the WinHTTP / stub fallback the body round-trips through a
+// NUL-terminated s and truncates at the first embedded NUL.
+@ http_request_bytes_to s method s url ( Vec u ) body s headers_blob
+i timeout_ms i connect_timeout_ms → !Response HttpErr {
+    ? != ( nurl_curl_available ) 0 {
+        : i raw ( __libcurl_perform_full_to url method ( vec_data [u] body ) ( vec_len [u] body ) headers_blob timeout_ms connect_timeout_ms )
+        ^ ( __http_dispatch raw )
+    } {}
+    : String tmp ( string_from_bytes ( vec_data [u] body ) ( vec_len [u] body ) )
+    : i raw ( nurl_http_perform_full_to url method ( string_data tmp ) headers_blob timeout_ms connect_timeout_ms )
+    ( string_free tmp )
+    ^ ( __http_dispatch raw )
+}
+
+@ http_request_bytes s method s url ( Vec u ) body s headers_blob → !Response HttpErr {
+    ^ ( http_request_bytes_to method url body headers_blob 0 0 )
+}
+
+@ http_post_bytes s url ( Vec u ) body s content_type → !Response HttpErr {
+    : String hb ( __with_ct content_type `` )
+    : !Response HttpErr res ( http_request_bytes `POST` url body ( string_data hb ) )
+    ( string_free hb )
+    ^ res
+}
+
+@ http_put_bytes s url ( Vec u ) body s content_type → !Response HttpErr {
+    : String hb ( __with_ct content_type `` )
+    : !Response HttpErr res ( http_request_bytes `PUT` url body ( string_data hb ) )
+    ( string_free hb )
+    ^ res
 }
 
 // ── Accessors (borrowed views) — pure NURL over the NurlHttpResponse
@@ -718,7 +768,7 @@ i timeout_ms i connect_timeout_ms → i {
 // nurl_http_stream_open_to in stdlib/runtime.c §14b (now stub-only
 // when libcurl is linked — NURL drives via this path). Returns the
 // i64 heap pointer; 0 only on the state-struct allocation failure.
-@ __http_stream_open_to_libcurl s method s url s body s headers_blob
+@ __http_stream_open_to_libcurl s method s url *u body_ptr i body_len s headers_blob
 i timeout_ms i connect_timeout_ms → i {
     : *u state ( nurl_curl_stream_alloc )
     ? == # i state 0 { ^ 0 } {}
@@ -757,19 +807,25 @@ i timeout_ms i connect_timeout_ms → i {
 
     : i is_post ( nurl_str_eq method `POST` )
     : i is_get ( nurl_str_eq method `GET` )
-    : i has_body && != # i body 0 != ( nurl_str_len body ) 0
-    : s post_body ? != has_body 0 body ``
-    : i post_len ? != has_body 0 ( nurl_str_len body ) 0
+    : i has_body && != # i body_ptr 0 > body_len 0
     ? != is_post 0 {
         ( nurl_curl_setopt_l easy 47 1 )  // CURLOPT_POST
-        ( nurl_curl_setopt_s easy 10015 post_body )  // CURLOPT_POSTFIELDS
-        ( nurl_curl_setopt_l easy 60 post_len )  // CURLOPT_POSTFIELDSIZE
+        ? != has_body 0 {
+            // COPYPOSTFIELDS copies body_len bytes at setopt time, so the
+            // caller may free the buffer right after open — and embedded
+            // NULs survive (POSTFIELDSIZE set first).
+            ( nurl_curl_setopt_l easy 60 body_len )  // CURLOPT_POSTFIELDSIZE
+            ( nurl_curl_setopt_p easy 10165 body_ptr )  // CURLOPT_COPYPOSTFIELDS
+        } {
+            ( nurl_curl_setopt_l easy 60 0 )  // CURLOPT_POSTFIELDSIZE
+            ( nurl_curl_setopt_s easy 10015 `` )  // CURLOPT_POSTFIELDS (empty)
+        }
     } {
         ? == is_get 0 {
             ( nurl_curl_setopt_s easy 10036 method )  // CURLOPT_CUSTOMREQUEST
             ? != has_body 0 {
-                ( nurl_curl_setopt_s easy 10015 body )
-                ( nurl_curl_setopt_l easy 60 post_len )
+                ( nurl_curl_setopt_l easy 60 body_len )  // CURLOPT_POSTFIELDSIZE
+                ( nurl_curl_setopt_p easy 10165 body_ptr )  // CURLOPT_COPYPOSTFIELDS
             } {}
         } {}
     }
@@ -824,18 +880,13 @@ i timeout_ms i connect_timeout_ms → i {
 
 : HttpStream { i raw }
 
-@ http_stream_open_to s method s url s body s headers_blob
-i timeout_ms i connect_timeout_ms
-→ !HttpStream HttpErr {
-    : i raw ? != ( nurl_curl_available ) 0
-    ( __http_stream_open_to_libcurl method url body headers_blob timeout_ms connect_timeout_ms )
-    ( nurl_http_stream_open_to method url body headers_blob timeout_ms connect_timeout_ms )
+// Shared open-result dispatch for both the s-body and ( Vec u )-body
+// stream openers. Probes err_kind in case open succeeded structurally
+// but libcurl refused (e.g. malformed URL).
+@ __http_stream_dispatch_open i raw → !HttpStream HttpErr {
     ? == raw 0 {
         ^ @ !HttpStream HttpErr { F # HttpErr HttpOther }
     } {}
-    // Probe err_kind in case open succeeded structurally but libcurl
-    // refused (e.g. malformed URL) — match the dispatch shape used by
-    // the synchronous wrapper so call sites stay symmetric.
     : i ek ( nurl_peek # *u raw 13 )
     ? != ek 0 {
         ( nurl_http_stream_close raw )
@@ -847,6 +898,34 @@ i timeout_ms i connect_timeout_ms
         ^ @ !HttpStream HttpErr { F # HttpErr HttpOther }
     } {}
     ^ @ !HttpStream HttpErr { T @ HttpStream { raw } }
+}
+
+@ http_stream_open_to s method s url s body s headers_blob
+i timeout_ms i connect_timeout_ms
+→ !HttpStream HttpErr {
+    : i raw ? != ( nurl_curl_available ) 0
+    ( __http_stream_open_to_libcurl method url # *u body ( nurl_str_len body ) headers_blob timeout_ms connect_timeout_ms )
+    ( nurl_http_stream_open_to method url body headers_blob timeout_ms connect_timeout_ms )
+    ^ ( __http_stream_dispatch_open raw )
+}
+
+// Binary-safe streaming open: the body is a length-carrying ( Vec u ),
+// so embedded NUL bytes survive (the s-body opener recovers length via
+// strlen). COPYPOSTFIELDS copies the bytes during open, so `body` may be
+// freed as soon as this returns. libcurl backend only — the stub
+// fallback round-trips through a NUL-terminated s (truncates at the
+// first embedded NUL).
+@ http_stream_open_bytes_to s method s url ( Vec u ) body s headers_blob
+i timeout_ms i connect_timeout_ms
+→ !HttpStream HttpErr {
+    ? != ( nurl_curl_available ) 0 {
+        : i raw ( __http_stream_open_to_libcurl method url ( vec_data [u] body ) ( vec_len [u] body ) headers_blob timeout_ms connect_timeout_ms )
+        ^ ( __http_stream_dispatch_open raw )
+    } {}
+    : String tmp ( string_from_bytes ( vec_data [u] body ) ( vec_len [u] body ) )
+    : i raw ( nurl_http_stream_open_to method url ( string_data tmp ) headers_blob timeout_ms connect_timeout_ms )
+    ( string_free tmp )
+    ^ ( __http_stream_dispatch_open raw )
 }
 
 @ http_stream_open s method s url s body s headers_blob

--- a/stdlib/ext/http_proxy.nu
+++ b/stdlib/ext/http_proxy.nu
@@ -61,11 +61,11 @@
 //
 // Limitations (v1):
 //
-//   * Request body is shipped via `CURLOPT_POSTFIELDS` which uses
-//     `strlen(body)` on the C runtime side — embedded NUL bytes in
-//     the request body are truncated. JSON / text payloads work as
-//     expected; binary file uploads through the proxy are not
-//     guaranteed lossless until a length-aware POSTFIELDS path lands.
+//   * Request body is now binary-safe: it ships via
+//     `http_stream_open_bytes_to`, which carries the length-tracked
+//     `( Vec u )` request body through `CURLOPT_COPYPOSTFIELDS` +
+//     an explicit `POSTFIELDSIZE`, so embedded NUL bytes (binary file
+//     uploads) survive the proxy hop.
 //   * Streaming-mode response body chunks travel through a NUL-
 //     terminated `char*` carrier in `nurl_http_stream_next`; binary
 //     responses with embedded NULs would be truncated. SSE / JSON /
@@ -246,20 +246,20 @@ $ `stdlib/ext/http_server.nu`
 
 @ proxy_stream_to_conn_with TcpConn conn HttpRequest req s upstream_url ProxyOpts opts → !v ProxyErr {
     : String headers_blob ( __build_request_headers_blob req opts )
-    : i bn ( vec_len [u] . req body )
-    : *u bdata ( vec_data [u] . req body )
-    : String body_s ( string_from_bytes bdata bn )
 
-    : !HttpStream HttpErr or ( http_stream_open_to
+    // The request body is a length-carrying ( Vec u ); ship it through
+    // the binary-safe stream opener so embedded NUL bytes (binary
+    // uploads) survive the proxy hop. COPYPOSTFIELDS snapshots the
+    // bytes during open, so `req.body` stays the caller's to free.
+    : !HttpStream HttpErr or ( http_stream_open_bytes_to
     ( string_data . req method )
     upstream_url
-    ( string_data body_s )
+    . req body
     ( string_data headers_blob )
     . opts timeout_ms
     . opts connect_timeout_ms )
 
     ( string_free headers_blob )
-    ( string_free body_s )
 
     ?? or {
         T st → {


### PR DESCRIPTION
## Summary

Adds binary-safe HTTP request body support to prevent NUL-byte truncation in request bodies. The existing `http_request` / `http_post` / `http_put` family recovers body length via `strlen`, which truncates bodies containing embedded NUL bytes (binary file uploads, MessagePack, protobuf). New `http_*_bytes` variants accept length-carrying `( Vec u )` bodies and use `CURLOPT_COPYPOSTFIELDS` with explicit `POSTFIELDSIZE` to preserve exact byte counts.

## Key Changes

- **New HTTP request APIs** (`stdlib/ext/http.nu`):
  - `http_request_bytes` / `http_request_bytes_to` — binary-safe request with method/URL/body/headers
  - `http_post_bytes` / `http_put_bytes` — convenience wrappers for POST/PUT
  - `http_stream_open_bytes_to` — binary-safe streaming request opener
  - All take body as `( Vec u )` with borrowed semantics (caller retains ownership)

- **Internal refactoring** (`stdlib/ext/http.nu`):
  - Changed `__libcurl_perform_full_opts` and `__libcurl_perform_full_to` signatures from `s body` to `*u body_ptr i body_len` to accept raw pointers + lengths
  - Updated `__http_stream_open_to_libcurl` similarly for streaming requests
  - Extracted `__http_stream_dispatch_open` helper to deduplicate open-result dispatch logic
  - Use `CURLOPT_COPYPOSTFIELDS` (pointer-based) instead of `CURLOPT_POSTFIELDS` (string-based) when body length is known, ensuring libcurl snapshots bytes at setopt time

- **Fixed reverse-proxy binary safety** (`stdlib/ext/http_proxy.nu`):
  - `proxy_stream_to_conn_with` now routes upstream request body through `http_stream_open_bytes_to` instead of converting to NUL-terminated string
  - Eliminates both NUL-truncation bug and a latent use-after-free (was setting non-copying `CURLOPT_POSTFIELDS` then freeing body before first `multi_perform` read)

- **Test coverage** (`compiler/tests/http_binary_body.nu`):
  - New regression test: NURL HTTP server accepts a loopback POST with 5-byte body `A B \0 C D`
  - Verifies server receives all 5 bytes (not truncated at embedded NUL)
  - Gated behind `NURL_NET_TESTS=1` environment variable

## Implementation Details

- Body argument is **borrowed** — caller retains ownership and may free immediately after the call returns (libcurl copies via `COPYPOSTFIELDS`)
- Binary fidelity requires libcurl backend; WinHTTP/stub fallback degrades to old truncation behavior (converts to NUL-terminated string)
- `POSTFIELDSIZE` is set before `COPYPOSTFIELDS` to ensure libcurl copies the exact byte count rather than using `strlen`
- All changes verified clean under ASan/UBSan

https://claude.ai/code/session_019dTVS7nqMEN65w1WbtfMqa