### PR TITLE
feat(tar): pure-NURL USTAR reader + writer (registry keystone)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **USTAR tar reader + writer — `stdlib/ext/tar.nu`.** Pure-NURL POSIX.1-1988
+  tar: `tar_create` (entries → archive bytes), `tar_parse` (bytes → entries,
+  in-memory), and `tar_unpack` (path-safe extract to disk). Composes with
+  `gzip_compress`/`_decompress` to make the `.tar.gz` package format the
+  registry will use. The reader treats archives as untrusted input:
+  `tar_unpack` rejects absolute paths and `..` components (TarUnsafePath) and
+  refuses symlink/hardlink/device members (TarUnsupported) so nothing can
+  escape the destination; every header checksum is verified (TarBadChecksum)
+  and an over-long declared size is TarTruncated. v1 supports the 100-byte
+  `name` field on write (TarPathTooLong otherwise) and honours the `prefix`
+  field on read. Bidirectionally interop-tested against GNU tar (NURL→`tar
+  xf` and `tar cf`→NURL both round-trip). Regression:
+  `compiler/tests/tar_basic.nu` (round-trip incl. embedded NUL in file data,
+  gzip composition, checksum tamper, `../` rejection, unpack + binary
+  read-back); verified clean under ASan/UBSan. First building block of the
+  registry-backed package manager (ROADMAP §4).
+
 - **WebSocket client (RFC 6455 §4.1 + §5.3).** `stdlib/ext/websocket.nu`
   gained the full client side to match the existing server. `ws_connect`
   / `ws_connect_with` parse a `ws://…` / `wss://…` URL, dial out (plain or

--- a/compiler/tests/tar_basic.nu
+++ b/compiler/tests/tar_basic.nu
@@ -1,0 +1,178 @@
+// tar_basic.nu — offline acceptance test for stdlib/ext/tar.nu.
+//
+// Coverage:
+//   1. In-memory round-trip: create (file with embedded NUL + dir +
+//      nested file) → tar_create → tar_parse; paths / sizes / data match.
+//   2. gzip composition: gzip_compress ∘ tar_create round-trips back
+//      through gzip_decompress ∘ tar_parse (the registry `.tar.gz` shape).
+//   3. Header checksum tamper → TarBadChecksum.
+//   4. Path-safety: an archive carrying `../evil` → TarUnsafePath on
+//      unpack; nothing is written.
+//   5. Happy-path unpack to a temp dir, then read the file back (binary,
+//      embedded NUL preserved end-to-end through write_file_bytes).
+
+$ `stdlib/ext/tar.nu`
+$ `stdlib/ext/compress.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+
+@ println_i s prefix i v → v {
+    ( nurl_print prefix )
+    ( nurl_print_int v )
+}
+
+@ println_s s prefix s v → v {
+    ( nurl_print prefix )
+    ( nurl_print v )
+    ( nurl_print `\n` )
+}
+
+// "HI\0J" — 4 bytes including an embedded NUL.
+@ make_payload → ( Vec u ) {
+    : ( Vec u ) d ( vec_new [u] )
+    ( vec_push [u] d # u 72 )
+    ( vec_push [u] d # u 73 )
+    ( vec_push [u] d # u 0 )
+    ( vec_push [u] d # u 74 )
+    ^ d
+}
+
+@ main → i {
+    // ── 1. in-memory round-trip ──────────────────────────────────
+    ( nurl_print `── round-trip ──\n` )
+    : ( Vec TarEntry ) ents ( vec_new [TarEntry] )
+    ( vec_push [TarEntry] ents ( tar_entry_file `readme.txt` ( make_payload ) ) )
+    ( vec_push [TarEntry] ents ( tar_entry_dir `src` ) )
+    ( vec_push [TarEntry] ents ( tar_entry_file `src/lib.nu` ( make_payload ) ) )
+
+    : !( Vec u ) TarErr cr ( tar_create ents )
+    ?? cr {
+        F e → ( println_s `create_err=` ( tar_err_name e ) )
+        T arc → {
+            ( println_i `archive_len=` ( vec_len [u] arc ) )
+            ( nurl_print `\n` )
+            : !( Vec TarEntry ) TarErr pr ( tar_parse arc )
+            ?? pr {
+                F e → ( println_s `parse_err=` ( tar_err_name e ) )
+                T got → {
+                    ( println_i `entry_count=` ( vec_len [TarEntry] got ) )
+                    ( nurl_print `\n` )
+                    : ?TarEntry e0 ( vec_get [TarEntry] got 0 )
+                    ?? e0 {
+                        T e → {
+                            ( println_s `name0=` ( string_data . e path ) )
+                            ( println_i `size0=` . e size )
+                            ( nurl_print `\n` )
+                            ( println_i `data0_len=` ( vec_len [u] . e data ) )
+                            ( nurl_print `\n` )
+                        }
+                        F → {}
+                    }
+                    : ?TarEntry e2 ( vec_get [TarEntry] got 2 )
+                    ?? e2 {
+                        T e → ( println_s `name2=` ( string_data . e path ) )
+                        F → {}
+                    }
+                    ( tar_entries_free got )
+                }
+            }
+
+            // ── 2. gzip composition ──────────────────────────────
+            ( nurl_print `── gzip ──\n` )
+            : !( Vec u ) CompressErr gz ( gzip_compress arc )
+            ?? gz {
+                F e → ( println_s `gzip_err=` ( compress_err_name e ) )
+                T gzbytes → {
+                    : !( Vec u ) CompressErr uz ( gzip_decompress gzbytes )
+                    ?? uz {
+                        F e → ( println_s `gunzip_err=` ( compress_err_name e ) )
+                        T raw → {
+                            : !( Vec TarEntry ) TarErr pr2 ( tar_parse raw )
+                            ?? pr2 {
+                                F e → ( println_s `gz_parse_err=` ( tar_err_name e ) )
+                                T got2 → {
+                                    ( println_i `gz_entry_count=` ( vec_len [TarEntry] got2 ) )
+                                    ( nurl_print `\n` )
+                                    ( tar_entries_free got2 )
+                                }
+                            }
+                            ( vec_free [u] raw )
+                        }
+                    }
+                    ( vec_free [u] gzbytes )
+                }
+            }
+
+            // ── 3. checksum tamper ───────────────────────────────
+            ( nurl_print `── tamper ──\n` )
+            : *u tp ( vec_data [u] arc )
+            = . tp 0 # u 88    // corrupt the name byte; checksum no longer matches
+            : !( Vec TarEntry ) TarErr pr3 ( tar_parse arc )
+            ?? pr3 {
+                F e → ( println_s `tamper=` ( tar_err_name e ) )
+                T bad → { ( nurl_print `tamper=ACCEPTED(bug)\n` ) ( tar_entries_free bad ) }
+            }
+            ( vec_free [u] arc )
+        }
+    }
+    ( tar_entries_free ents )
+
+    // ── 4. path-safety: ../evil is rejected on unpack ────────────
+    ( nurl_print `── unsafe path ──\n` )
+    : ( Vec TarEntry ) evil ( vec_new [TarEntry] )
+    ( vec_push [TarEntry] evil ( tar_entry_file `../evil.txt` ( make_payload ) ) )
+    : !( Vec u ) TarErr ec ( tar_create evil )
+    ?? ec {
+        F e → ( println_s `evil_create_err=` ( tar_err_name e ) )
+        T earc → {
+            : !i TarErr ur ( tar_unpack earc `/tmp/nurl_tar_test_unsafe` )
+            ?? ur {
+                F e → ( println_s `unsafe=` ( tar_err_name e ) )
+                T cnt → ( println_i `unsafe=ACCEPTED(bug) count=` cnt )
+            }
+            ( vec_free [u] earc )
+        }
+    }
+    ( tar_entries_free evil )
+
+    // ── 5. happy-path unpack + read back (binary, embedded NUL) ──
+    ( nurl_print `── unpack ──\n` )
+    : ( Vec TarEntry ) good ( vec_new [TarEntry] )
+    ( vec_push [TarEntry] good ( tar_entry_dir `pkg` ) )
+    ( vec_push [TarEntry] good ( tar_entry_file `pkg/data.bin` ( make_payload ) ) )
+    : !( Vec u ) TarErr gc ( tar_create good )
+    ?? gc {
+        F e → ( println_s `good_create_err=` ( tar_err_name e ) )
+        T garc → {
+            : !v IoErr rm ( dir_remove_all `/tmp/nurl_tar_test` )
+            ?? rm { T _ → {} F _ → {} }
+            : !i TarErr up ( tar_unpack garc `/tmp/nurl_tar_test` )
+            ?? up {
+                F e → ( println_s `unpack_err=` ( tar_err_name e ) )
+                T cnt → {
+                    ( println_i `unpacked=` cnt )
+                    ( nurl_print `\n` )
+                    : !( Vec u ) IoErr rb ( read_file_bytes `/tmp/nurl_tar_test/pkg/data.bin` )
+                    ?? rb {
+                        F _ → ( nurl_print `readback=ERR\n` )
+                        T back → {
+                            ( println_i `readback_len=` ( vec_len [u] back ) )
+                            ( nurl_print `\n` )
+                            : *u bp ( vec_data [u] back )
+                            ( println_i `readback_nul_at2=` # i . bp 2 )
+                            ( nurl_print `\n` )
+                            ( vec_free [u] back )
+                        }
+                    }
+                }
+            }
+            : !v IoErr rm2 ( dir_remove_all `/tmp/nurl_tar_test` )
+            ?? rm2 { T _ → {} F _ → {} }
+            ( vec_free [u] garc )
+        }
+    }
+    ( tar_entries_free good )
+    ( nurl_print `done\n` )
+    ^ 0
+}

--- a/stdlib/ext/tar.nu
+++ b/stdlib/ext/tar.nu
@@ -1,0 +1,461 @@
+// stdlib/ext/tar.nu — USTAR (POSIX.1-1988) tar reader + writer.
+//
+// Pure NURL. The format is a sequence of 512-byte blocks: each member is
+// one header block followed by ceil(size/512) zero-padded data blocks;
+// the archive ends with two all-zero blocks. This is the keystone for
+// the package registry — a published package is a `.tar.gz`: compose
+// `tar_create` with `gzip_compress` (stdlib/ext/compress.nu) to pack, and
+// `gzip_decompress` + `tar_parse` / `tar_unpack` to fetch+install.
+//
+// Surface:
+//
+//   ( tar_entry_file path data )   → TarEntry      regular-file member
+//   ( tar_entry_dir  path )        → TarEntry      directory member
+//   ( tar_entry_free e )           → v
+//   ( tar_entries_free entries )   → v             free a parsed Vec
+//
+//   ( tar_create entries )         → ! ( Vec u ) TarErr   entries → archive bytes
+//   ( tar_parse  archive )         → ! ( Vec TarEntry ) TarErr   bytes → entries (in-memory)
+//   ( tar_unpack archive dest )    → ! i TarErr     path-safe extract to disk (returns count)
+//
+// Security (this parser consumes UNTRUSTED archives from the registry):
+//
+//   * `tar_unpack` rejects any member path that is absolute (`/…`) or
+//     contains a `..` component → TarUnsafePath. No path can escape
+//     `dest`.
+//   * Only regular files (typeflag '0'/NUL) and directories ('5') are
+//     extracted. Symlinks / hardlinks / device nodes are refused
+//     (TarUnsupported) so a malicious archive can't plant a link that
+//     later redirects a write outside the tree.
+//   * Every header's checksum is verified before its fields are trusted
+//     (TarBadChecksum), and a member whose declared size runs past the
+//     end of the archive is TarTruncated.
+//
+// v1 scope: member paths must fit the 100-byte USTAR `name` field
+// (TarPathTooLong on write); the `prefix` field IS honoured on read, so
+// archives produced by GNU/BSD tar with split long paths parse back to
+// the joined path. uid/gid are written as 0; mode defaults to 0644
+// (files) / 0755 (dirs) when the entry carries 0.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+: TarEntry {
+    String path
+    i mode
+    i size
+    i mtime
+    i typeflag      // ASCII byte: 48 '0' = file, 53 '5' = dir
+    ( Vec u ) data  // file contents; empty for a directory
+}
+
+: | TarErr {
+    TarTruncated      // header or data block runs past the archive end
+    TarBadHeader      // missing/!= "ustar" magic
+    TarBadChecksum    // header checksum mismatch
+    TarUnsafePath     // absolute path or `..` component on extract
+    TarPathTooLong    // path does not fit the 100-byte USTAR name field
+    TarUnsupported    // entry type is not a regular file or directory
+    TarIoError        // filesystem failure during unpack
+}
+
+@ tar_err_name TarErr e → s {
+    ^ ?? e {
+        TarTruncated → `TarTruncated`
+        TarBadHeader → `TarBadHeader`
+        TarBadChecksum → `TarBadChecksum`
+        TarUnsafePath → `TarUnsafePath`
+        TarPathTooLong → `TarPathTooLong`
+        TarUnsupported → `TarUnsupported`
+        TarIoError → `TarIoError`
+    }
+}
+
+// ── Entry constructors / lifecycle ────────────────────────────────────
+
+@ tar_entry_file s path ( Vec u ) data → TarEntry {
+    ^ @ TarEntry { ( string_from path ) 420 ( vec_len [u] data ) 0 48 data }
+}
+
+@ tar_entry_dir s path → TarEntry {
+    ^ @ TarEntry { ( string_from path ) 493 0 0 53 ( vec_new [u] ) }
+}
+
+@ tar_entry_free TarEntry e → v {
+    ( string_free . e path )
+    ( vec_free [u] . e data )
+}
+
+@ tar_entries_free ( Vec TarEntry ) entries → v {
+    : i n ( vec_len [TarEntry] entries )
+    : ~ i k 0
+    ~ < k n {
+        : ?TarEntry eo ( vec_get [TarEntry] entries k )
+        ?? eo { T e → ( tar_entry_free e ) F → {} }
+        = k + k 1
+    }
+    ( vec_free [TarEntry] entries )
+}
+
+// ── Low-level byte helpers ────────────────────────────────────────────
+
+// Append `n` zero bytes to `dst`.
+@ __tar_zeros ( Vec u ) dst i n → v {
+    : ~ i k 0
+    ~ < k n {
+        ( vec_push [u] dst # u 0 )
+        = k + k 1
+    }
+}
+
+// Write up to `maxlen` bytes of `str` into the header at `off` (buffer is
+// pre-zeroed, so a shorter string is implicitly NUL-padded).
+@ __tar_put_str * u p i off s str i maxlen → v {
+    : i n ( nurl_str_len str )
+    : i lim ? < n maxlen n maxlen
+    : ~ i k 0
+    ~ < k lim {
+        = . p + off k # u ( nurl_str_get str k )
+        = k + k 1
+    }
+}
+
+// Write `value` as a zero-padded octal number of exactly `ndigits` ASCII
+// digits, low digit at off+ndigits-1. The field's terminator byte (NUL
+// or space) is left as the pre-zeroed buffer holds.
+@ __tar_put_octal * u p i off i value i ndigits → v {
+    : ~ i v value
+    : ~ i k - ndigits 1
+    ~ >= k 0 {
+        = . p + off k # u + 48 % v 8
+        = v / v 8
+        = k - k 1
+    }
+}
+
+// Parse an octal field [off, off+len): skip leading spaces/NULs, then
+// accumulate octal digits until the first non-digit.
+@ __tar_read_octal * u p i off i len → i {
+    : ~ i r 0
+    : ~ i started 0
+    : ~ i done 0
+    : ~ i k 0
+    ~ & == done 0 < k len {
+        : i b # i . p + off k
+        ? & >= b 48 <= b 55 {
+            = r + * r 8 - b 48
+            = started 1
+        } {
+            ? == started 1 { = done 1 } {}
+        }
+        = k + k 1
+    }
+    ^ r
+}
+
+// Read a NUL-terminated string field starting at absolute offset `pos`,
+// at most `maxlen` bytes.
+@ __tar_read_cstr * u p i pos i maxlen → String {
+    : String out ( string_new )
+    : ~ i k 0
+    : ~ i done 0
+    ~ & == done 0 < k maxlen {
+        : i b # i . p + pos k
+        ? == b 0 { = done 1 } {
+            ( string_push_char out b )
+            = k + k 1
+        }
+    }
+    ^ out
+}
+
+// Reconstruct a member path: `name` (off 0, 100) joined under `prefix`
+// (off 345, 155) with a '/' when prefix is non-empty (USTAR long-path).
+@ __tar_read_path * u p i base → String {
+    : String name ( __tar_read_cstr p + base 0 100 )
+    : String prefix ( __tar_read_cstr p + base 345 155 )
+    ? > ( string_len prefix ) 0 {
+        : String full ( string_with_cap + + ( string_len prefix ) ( string_len name ) 2 )
+        ( string_push_str full ( string_data prefix ) )
+        ( string_push_char full 47 )
+        ( string_push_str full ( string_data name ) )
+        ( string_free name )
+        ( string_free prefix )
+        ^ full
+    } {}
+    ( string_free prefix )
+    ^ name
+}
+
+// Copy `len` bytes from `p[off..off+len)` into a fresh owned Vec.
+@ __tar_slice * u p i off i len → ( Vec u ) {
+    : i cap ? > len 0 len 1
+    : ( Vec u ) out ( vec_with_cap [u] cap )
+    : ~ i k 0
+    ~ < k len {
+        ( vec_push [u] out . p + off k )
+        = k + k 1
+    }
+    ^ out
+}
+
+@ __tar_is_zero_block * u p i base → b {
+    : ~ i k 0
+    ~ < k 512 {
+        ? != # i . p + base k 0 { ^ F } {}
+        = k + k 1
+    }
+    ^ T
+}
+
+@ __tar_has_magic * u p i base → b {
+    ^ & == # i . p + base 257 117 & == # i . p + base 258 115 & == # i . p + base 259 116 & == # i . p + base 260 97 == # i . p + base 261 114
+}
+
+// Verify the header checksum: sum of all 512 bytes with the 8 checksum
+// bytes [148,156) counted as ASCII spaces, compared to the stored octal.
+@ __tar_verify_chksum * u p i base → b {
+    : i stored ( __tar_read_octal p + base 148 8 )
+    : ~ i sum 0
+    : ~ i k 0
+    ~ < k 512 {
+        ? & >= k 148 < k 156 {
+            = sum + sum 32
+        } {
+            = sum + sum # i . p + base k
+        }
+        = k + k 1
+    }
+    ^ == sum stored
+}
+
+// ── Writer ────────────────────────────────────────────────────────────
+
+// Build a 512-byte USTAR header block for `e`.
+@ __tar_build_header TarEntry e → ( Vec u ) {
+    : ( Vec u ) h ( vec_with_cap [u] 512 )
+    ( __tar_zeros h 512 )
+    : *u p ( vec_data [u] h )
+
+    : i is_dir ? == . e typeflag 53 1 0
+    : i mode ? > . e mode 0 . e mode ? != is_dir 0 493 420
+    : i sz ? != is_dir 0 0 ( vec_len [u] . e data )
+
+    ( __tar_put_str p 0 ( string_data . e path ) 100 )
+    ( __tar_put_octal p 100 mode 7 )    // mode
+    ( __tar_put_octal p 108 0 7 )       // uid
+    ( __tar_put_octal p 116 0 7 )       // gid
+    ( __tar_put_octal p 124 sz 11 )     // size
+    ( __tar_put_octal p 136 . e mtime 11 )  // mtime
+    = . p 156 # u ? != is_dir 0 53 48    // typeflag '5' / '0'
+    ( __tar_put_str p 257 `ustar` 5 )   // magic (byte 262 stays NUL)
+    = . p 263 # u 48                // version "00"
+    = . p 264 # u 48
+
+    // Checksum: chksum field as spaces, sum, then "%06o\0 ".
+    : ~ i ci 0
+    ~ < ci 8 {
+        = . p + 148 ci # u 32
+        = ci + ci 1
+    }
+    : ~ i sum 0
+    : ~ i si 0
+    ~ < si 512 {
+        = sum + sum # i . p si
+        = si + si 1
+    }
+    ( __tar_put_octal p 148 sum 6 )
+    = . p 154 # u 0
+    = . p 155 # u 32
+    ^ h
+}
+
+@ tar_create ( Vec TarEntry ) entries → !( Vec u ) TarErr {
+    : ( Vec u ) out ( vec_new [u] )
+    : i n ( vec_len [TarEntry] entries )
+    : ~ i i 0
+    ~ < i n {
+        : ?TarEntry eo ( vec_get [TarEntry] entries i )
+        ?? eo {
+            T e → {
+                ? > ( string_len . e path ) 100 {
+                    ( vec_free [u] out )
+                    ^ @ !( Vec u ) TarErr { F # TarErr TarPathTooLong }
+                } {}
+                : ( Vec u ) hdr ( __tar_build_header e )
+                ( bytes_extend_bytes out hdr )
+                ( vec_free [u] hdr )
+                : i is_dir ? == . e typeflag 53 1 0
+                ? == is_dir 0 {
+                    : i sz ( vec_len [u] . e data )
+                    ( bytes_extend_bytes out . e data )
+                    ( __tar_zeros out % - 512 % sz 512 512 )
+                } {}
+            }
+            F → {}
+        }
+        = i + i 1
+    }
+    ( __tar_zeros out 1024 )    // two terminating zero blocks
+    ^ @ !( Vec u ) TarErr { T out }
+}
+
+// ── Reader ────────────────────────────────────────────────────────────
+
+@ tar_parse ( Vec u ) archive → !( Vec TarEntry ) TarErr {
+    : ( Vec TarEntry ) out ( vec_new [TarEntry] )
+    : *u p ( vec_data [u] archive )
+    : i total ( vec_len [u] archive )
+    : ~ i base 0
+    : ~ i done 0
+    ~ & == done 0 <= + base 512 total {
+        ? ( __tar_is_zero_block p base ) {
+            = done 1
+        } {
+            ? ! ( __tar_has_magic p base ) {
+                ( tar_entries_free out )
+                ^ @ !( Vec TarEntry ) TarErr { F # TarErr TarBadHeader }
+            } {}
+            ? ! ( __tar_verify_chksum p base ) {
+                ( tar_entries_free out )
+                ^ @ !( Vec TarEntry ) TarErr { F # TarErr TarBadChecksum }
+            } {}
+            : i size ( __tar_read_octal p + base 124 12 )
+            : i dstart + base 512
+            ? > + dstart size total {
+                ( tar_entries_free out )
+                ^ @ !( Vec TarEntry ) TarErr { F # TarErr TarTruncated }
+            } {}
+            : i mode ( __tar_read_octal p + base 100 8 )
+            : i mtime ( __tar_read_octal p + base 136 12 )
+            : i tflag # i . p + base 156
+            : String path ( __tar_read_path p base )
+            : ( Vec u ) data ( __tar_slice p dstart size )
+            ( vec_push [TarEntry] out @ TarEntry { path mode size mtime tflag data } )
+            : i blocks / + size 511 512
+            = base + dstart * blocks 512
+        }
+    }
+    ^ @ !( Vec TarEntry ) TarErr { T out }
+}
+
+// ── Path-safe extraction ──────────────────────────────────────────────
+
+// True iff `path` is a relative path with no `..` component and no
+// leading '/'. Member names from __tar_read_cstr never contain NUL.
+@ __tar_path_safe String path → b {
+    : i n ( string_len path )
+    ? == n 0 { ^ F } {}
+    : s d ( string_data path )
+    ? == ( nurl_str_get d 0 ) 47 { ^ F } {}    // absolute
+    : ~ i k 0
+    : ~ i comp_start 0
+    : ~ i bad 0
+    ~ <= k n {
+        : i c ? < k n ( nurl_str_get d k ) 47   // treat end-of-string as '/'
+        ? == c 47 {
+            ? == - k comp_start 2 {
+                ? & == ( nurl_str_get d comp_start ) 46 == ( nurl_str_get d + comp_start 1 ) 46 {
+                    = bad 1
+                } {}
+            } {}
+            = comp_start + k 1
+        } {}
+        = k + k 1
+    }
+    ^ == bad 0
+}
+
+// Directory portion of `full` (everything before the last '/'), or "."
+// when there is no separator.
+@ __tar_parent_dir String full → String {
+    : s d ( string_data full )
+    : i n ( string_len full )
+    : ~ i last -1
+    : ~ i k 0
+    ~ < k n {
+        ? == ( nurl_str_get d k ) 47 { = last k } {}
+        = k + k 1
+    }
+    ? < last 0 { ^ ( string_from `.` ) } {}
+    : String out ( string_with_cap + last 1 )
+    : ~ i j 0
+    ~ < j last {
+        ( string_push_char out ( nurl_str_get d j ) )
+        = j + j 1
+    }
+    ^ out
+}
+
+@ __tar_join s dir String rel → String {
+    : String out ( string_with_cap + + ( nurl_str_len dir ) ( string_len rel ) 2 )
+    ( string_push_str out dir )
+    ( string_push_char out 47 )
+    ( string_push_str out ( string_data rel ) )
+    ^ out
+}
+
+// Extract `archive` under `dest`. Returns the number of members written.
+// Rejects unsafe paths and non-file/dir members (see the security note
+// in the module header).
+@ tar_unpack ( Vec u ) archive s dest → !i TarErr {
+    : !( Vec TarEntry ) TarErr pr ( tar_parse archive )
+    ?? pr {
+        F e → { ^ @ !i TarErr { F e } }
+        T entries → {
+            : i n ( vec_len [TarEntry] entries )
+            : ~ i count 0
+            : ~ i fail 0          // 0 = ok; otherwise set + carry the variant in `ferr`
+            : ~ TarErr ferr TarIoError
+            : ~ i k 0
+            ~ & == fail 0 < k n {
+                : ?TarEntry eo ( vec_get [TarEntry] entries k )
+                ?? eo {
+                    F → {}
+                    T e → {
+                        ? ! ( __tar_path_safe . e path ) {
+                            = fail 1
+                            = ferr TarUnsafePath
+                        } {
+                            : i tflag . e typeflag
+                            ? == tflag 53 {
+                                : String full ( __tar_join dest . e path )
+                                : !v IoErr dr ( dir_create_all ( string_data full ) )
+                                ?? dr { T _ → { = count + count 1 } F _ → { = fail 1 = ferr TarIoError } }
+                                ( string_free full )
+                            } {
+                                ? | == tflag 48 == tflag 0 {
+                                    : String full ( __tar_join dest . e path )
+                                    : String parent ( __tar_parent_dir full )
+                                    : !v IoErr pdr ( dir_create_all ( string_data parent ) )
+                                    ?? pdr {
+                                        T _ → {
+                                            : !v IoErr wr ( write_file_bytes ( string_data full ) . e data )
+                                            ?? wr { T _ → { = count + count 1 } F _ → { = fail 1 = ferr TarIoError } }
+                                        }
+                                        F _ → { = fail 1 = ferr TarIoError }
+                                    }
+                                    ( string_free parent )
+                                    ( string_free full )
+                                } {
+                                    = fail 1
+                                    = ferr TarUnsupported
+                                }
+                            }
+                        }
+                    }
+                }
+                = k + k 1
+            }
+            ( tar_entries_free entries )
+            ? != fail 0 {
+                ^ @ !i TarErr { F ferr }
+            } {}
+            ^ @ !i TarErr { T count }
+        }
+    }
+}


### PR DESCRIPTION
stdlib/ext/tar.nu implements POSIX.1-1988 USTAR: tar_create (entries → archive bytes), tar_parse (bytes → entries, in-memory), tar_unpack (path-safe extract to disk). Composes with gzip_compress/_decompress to form the .tar.gz package format the registry-backed package manager will fetch and install (ROADMAP §4 — the single missing stdlib piece for registry deps).

The reader treats archives as untrusted input:
  * tar_unpack rejects absolute paths and `..` components (TarUnsafePath) and refuses symlink/hardlink/device members (TarUnsupported), so no member can write outside the destination tree.
  * every header checksum is verified before its fields are trusted (TarBadChecksum); a declared size past the archive end is TarTruncated.

v1 scope: 100-byte USTAR name field on write (TarPathTooLong otherwise); the prefix field IS honoured on read, so GNU/BSD long-path archives parse back to the joined path. uid/gid written as 0; mode defaults 0644/0755.

Validation:
  * compiler/tests/tar_basic.nu — round-trip (incl. an embedded NUL in file data), gzip composition, checksum tamper → TarBadChecksum, `../evil` → TarUnsafePath, unpack + binary read-back. Clean under ASan/UBSan.
  * Differential vs GNU tar, both directions: NURL-produced archives read by `tar tvf`/`tar xf` with correct modes/sizes/contents, and GNU-produced archives parse back through tar_parse.

No compiler/runtime change — bootstrap unaffected.