### PR TITLE
fix(codegen): two silent integer miscompiles + differential fuzzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two silent integer miscompiles, found by a new differential fuzzer
+  (`tools/fuzz`) and fixed at the root in `compiler/nurlc.nu`.** Both
+  produced wrong values with no error — the worst class of bug.
+  1. **Unsigned-byte cast widening sign-extended.** `# i64 # u 217` gave
+     −39 instead of 217: a nested cast-to-unsigned never set the
+     `__last_unsigned__` side-channel the enclosing widening cast consults,
+     so it defaulted to `sext`. `gen_cast` now records the cast target's
+     signedness for an enclosing widen / binop / shift. (Previously only
+     casts whose subject was a typed *binding* — where `gen_ident` sets the
+     flag — widened correctly.)
+  2. **Signed `i8` arithmetic treated as unsigned.** `gen_binary` inferred
+     unsignedness from the LLVM type `i8`, but both the unsigned NURL `u`
+     and the *signed* `i8` lower to LLVM i8 — so signed i8 `/ % >> <`
+     selected `udiv`/`urem`/`lshr`/`icmp u*` and the result was marked
+     unsigned, silently zero-extending a negative value at the next widen.
+     Signedness now comes solely from the `__last_unsigned__` flag (set by
+     `gen_ident` from a binding's `__unsigned` and by `gen_cast` from an
+     unsigned cast target), never from the ambiguous LLVM type.
+  Bootstrap fixed point holds; full suite + ASan/UBSan green. Regression
+  `compiler/tests/cast_signedness.nu` (12 known-answer checks). Validated
+  by 340 fuzzer seeds (0 divergences).
+
 ### Added
+
+- **Differential fuzzer for `nurlc` integer codegen (`tools/fuzz`).**
+  `gen.py` generates random sized-integer expression trees and, from the
+  same tree, both a self-checking NURL program (prints each result's exact
+  64-bit pattern) and a Python reference oracle with explicit
+  two's-complement / width / signedness semantics. `fuzz.sh` compiles each
+  at `-O0` and `-O2` and requires `stdout(-O0) == stdout(-O2) == oracle`,
+  catching miscompiles that are wrong at every optimisation level. Biased
+  toward the historically fragile surface (width coercions, unsigned
+  arithmetic, mixed signed/unsigned); generates no UB. Found and fixed two
+  silent miscompiles on its first run (see Fixed, above). See
+  `tools/fuzz/README.md`.
 
 - **WebSocket client (RFC 6455 §4.1 + §5.3).** `stdlib/ext/websocket.nu`
   gained the full client side to match the existing server. `ws_connect`

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -1812,15 +1812,16 @@
     ? & == tt TT_CARETCARET isf
     { ( die lex `operator '^^' (XOR) requires integer or bool operands, not a float` ) }
     {}
-    // Unsigned operand path. Three triggers, OR-ed:
-    //   * Legacy 8-bit byte (`u` → i8): retained for v1.6 compatibility.
-    //   * Either operand carries the `__unsigned` flag (sized u types).
-    // NURL is strongly typed (no implicit conversions), so lt == rt
-    // always holds for arithmetic operands — the OR over both operands'
-    // flags is defensive against asymmetric loss along complex paths
-    // rather than meaningful signedness coercion.
-    : b isu | | ( seq lt `i8` ) != 0 ( nurl_str_len lu_snap )
-    != 0 ( nurl_str_len ru_snap )
+    // Unsigned operand path. Triggered ONLY by the `__unsigned` side-channel
+    // (set by gen_ident from a binding's `__unsigned` flag and by gen_cast
+    // from a cast to an unsigned target). We must NOT infer unsignedness from
+    // the LLVM type `i8`: both the unsigned NURL `u` (byte) AND the SIGNED
+    // `i8` lower to LLVM i8, so a `seq lt i8` heuristic would mis-select
+    // udiv/urem/lshr/icmp-u for signed i8 arithmetic and mark its result
+    // unsigned (silently zext-widening a negative value). NURL is strongly
+    // typed (lt == rt for arithmetic operands), so the OR over both operands'
+    // flags is defensive against asymmetric loss along complex paths.
+    : b isu | != 0 ( nurl_str_len lu_snap ) != 0 ( nurl_str_len ru_snap )
     : s ins ( binop_instr tt isf isu )
     // Pointer comparison coercion. LLVM forbids `icmp <op> i8* %p, 0`
     // (integer constant at pointer type) and rejects comparing two
@@ -7656,6 +7657,16 @@
 @ gen_cast i lex i syms i cg → s {
     ( nurl_lex_advance lex )
     : s dt ( parse_type lex )
+    // Capture the cast TARGET's signedness from the raw NURL token now,
+    // before `gen_operand` (below) parses the cast subject and clobbers
+    // the `__last_nurl_type__` side-channel. Used at the integer-result
+    // return paths to mark `__last_unsigned__` so an ENCLOSING widening
+    // cast / binop / shift sees the right signedness — e.g. the inner
+    // `# u …` in `# i64 # u <expr>` must make the outer widen a `zext`,
+    // not a `sext`. (Without this, only casts whose subject was a typed
+    // BINDING — where gen_ident sets the flag — widened correctly; a
+    // nested cast-to-unsigned silently sign-extended.)
+    : b dst_unsigned ( nurl_type_is_unsigned ( nurl_sym_get g_res_type_syms `__last_nurl_type__` ) )
     // Diagnose `# T { ... }` parsing as cast-to-T applied to a
     // block expression, NOT as a struct/enum literal. Users coming
     // from Rust / TypeScript reflexively write `#` here and silently
@@ -7963,9 +7974,21 @@
                             ( nurl_print st ) ( nurl_print ` ` ) ( nurl_print val )
                             ( nurl_print ` to ` ) ( nurl_print dt ) ( nurl_print `\n` )
                             ( nurl_set_last_type dt )
+                            // The result is now the cast TARGET's type — record
+                            // its signedness so an ENCLOSING widening cast /
+                            // binop / shift reads the right flag (e.g. the inner
+                            // `# u …` in `# i64 # u <expr>` must make the outer
+                            // widen a zext, not a sext).
+                            ( nurl_sym_def syms `__last_unsigned__` ? dst_unsigned `1` `` )
                             ^ res
                         }
-                        { ( nurl_set_last_type dt ) ^ val }
+                        { ( nurl_set_last_type dt )
+                            // Same-width reinterpret (e.g. `# u <i8>`): still
+                            // record destination signedness for an enclosing op.
+                            ? > ( int_width dt ) 0
+                            { ( nurl_sym_def syms `__last_unsigned__` ? dst_unsigned `1` `` ) }
+                            {}
+                            ^ val }
                     }
                 }
             }

--- a/compiler/tests/cast_signedness.nu
+++ b/compiler/tests/cast_signedness.nu
@@ -1,0 +1,46 @@
+// cast_signedness.nu — regression for two silent integer miscompiles
+// found by the differential fuzzer (tools/fuzz) on 2026-06-02.
+//
+// Bug 1 — unsigned-byte cast widening: `# i64 # u 217` sign-extended a
+//   `u` (unsigned byte) instead of zero-extending, because a nested
+//   cast-to-unsigned never set the `__last_unsigned__` side-channel that
+//   the enclosing widening cast consults. (Only casts whose subject was a
+//   typed BINDING widened correctly.)
+//
+// Bug 2 — signed `i8` mis-classified as unsigned: gen_binary inferred
+//   "unsigned" from the LLVM type `i8`, but BOTH the unsigned NURL `u` and
+//   the SIGNED `i8` lower to LLVM i8. So signed i8 arithmetic selected
+//   udiv/urem/lshr/icmp-u and marked its result unsigned (silently
+//   zero-extending a negative value at the next widen).
+//
+// main returns the number of failed checks (0 = all pass), so any
+// regression trips the suite's exit-code gate.
+
+@ chk i got i want s tag → i {
+    ? == got want {
+        ( nurl_print tag ) ( nurl_print ` ok\n` ) ^ 0
+    } {
+        ( nurl_print tag ) ( nurl_print ` FAIL\n` ) ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i f 0
+    // Bug 1: unsigned widening must zero-extend.
+    = f + f ( chk # i64 # u 217 217 `u8_zext` )
+    = f + f ( chk # i64 # u16 50000 50000 `u16_zext` )
+    = f + f ( chk # i64 # u32 2147483649 2147483649 `u32_zext` )
+    // Bug 1 mirror: signed widening must still sign-extend.
+    = f + f ( chk # i64 # i8 200 - 0 56 `i8_sext` )
+    = f + f ( chk # i64 # i16 # i8 200 - 0 56 `i8_i16_sext` )
+    // Bug 2: signed i8 arithmetic must use SIGNED ops.
+    = f + f ( chk # i64 / # i8 200 # i8 7 - 0 8 `i8_sdiv` )       // -56 / 7 = -8
+    = f + f ( chk # i64 >> # i8 200 # i8 1 - 0 28 `i8_ashr` )     // -56 >> 1 = -28
+    = f + f ( chk # i64 ? < # i8 200 # i8 5 1 0 1 `i8_slt` )      // -56 < 5 = true
+    = f + f ( chk # i64 # i16 << + # i8 80 # i8 94 # i8 5 - 0 64 `i8_shl_widen` )
+    // Unsigned `u` must still use UNSIGNED ops (no regression).
+    = f + f ( chk # i64 / # u 200 # u 7 28 `u8_udiv` )            // 200 / 7 = 28
+    = f + f ( chk # i64 >> # u 200 # u 1 100 `u8_lshr` )          // 200 >> 1 = 100
+    = f + f ( chk # i64 ? < # u 200 # u 5 1 0 0 `u8_ult` )        // 200 < 5 = false
+    ^ f
+}

--- a/tools/fuzz/.gitignore
+++ b/tools/fuzz/.gitignore
@@ -1,0 +1,1 @@
+failures/

--- a/tools/fuzz/README.md
+++ b/tools/fuzz/README.md
@@ -1,0 +1,81 @@
+# tools/fuzz — differential miscompile testing for nurlc
+
+A generative, oracle-backed fuzzer that systematically hunts silent
+integer miscompiles in `nurlc`. It complements the hand-written
+`compiler/tests/` corpus: instead of checking a fixed set of programs, it
+generates thousands of random ones and checks each against an independent
+reference.
+
+## How it works
+
+`gen.py` builds a random **integer expression tree** over NURL's sized
+types (`i8 i16 i32 i64 u u16 u32 u64`) and operators (`+ - * / % & | << >>`
+and width casts `# T`). It then does two things from the *same* tree:
+
+1. **Emits a self-contained NURL program** that computes each expression
+   and prints its exact 64-bit pattern (16 hex digits, MSB first — robust
+   to arithmetic-vs-logical shift, so the print path can't mask a bug).
+2. **Computes the expected output itself**, in Python, with explicit
+   two's-complement / width / signedness semantics (the *oracle*).
+
+`fuzz.sh` compiles each program at **`-O0` and `-O2`** and requires:
+
+```
+stdout(-O0) == stdout(-O2) == oracle      (value correctness)
+exit(-O0)   == exit(-O2)   == 0           (no crash)
+```
+
+Any divergence is a compiler bug. Because the oracle is an independent
+implementation, this catches miscompiles that are wrong at *every*
+optimisation level (frontend codegen bugs) — not just opt-sensitive ones.
+
+The generator is deterministic per seed, so every failure reproduces
+exactly, and is biased toward the historically fragile surface: width
+coercions (`# T` trunc/sext/zext), unsigned arithmetic
+(udiv/urem/lshr/icmp-u), and mixed signed/unsigned operands.
+
+No UB is generated: divisors are positive literals (no `/0`, no
+`INT_MIN/-1`), shift amounts are `< width`, and `nurlc` emits plain
+wrapping `add`/`mul` (no `nsw`/`nuw`), so signed overflow is defined.
+
+## Usage
+
+```sh
+# Build the compiler first (needs build/nurlc + stdlib/runtime.o).
+./build.sh
+
+# Run 200 seeds (default), 12 expressions each, depth 4:
+tools/fuzz/fuzz.sh
+
+# Custom: START COUNT EXPRS DEPTH
+tools/fuzz/fuzz.sh 1 1000 16 6
+
+# Inspect / reproduce one seed:
+python3 tools/fuzz/gen.py 42 --exprs 12 --depth 5            # the program
+python3 tools/fuzz/gen.py 42 --exprs 12 --depth 5 --oracle   # expected output
+```
+
+Failures are saved under `tools/fuzz/failures/` as `seed_N.nu` +
+`seed_N.expected` + `seed_N.out0/.out2` + `seed_N.diff_o0` for triage.
+
+## Bugs found (2026-06-02, first run)
+
+Two silent miscompiles, both fixed at the root in `compiler/nurlc.nu`;
+locked in by `compiler/tests/cast_signedness.nu`:
+
+1. **`# i64 # u 217` sign-extended an unsigned byte** (gave −39, not 217).
+   A nested cast-to-unsigned never set `__last_unsigned__`, so the
+   enclosing widen defaulted to `sext`. Fixed: `gen_cast` records the cast
+   target's signedness for an enclosing op.
+2. **Signed `i8` arithmetic treated as unsigned.** `gen_binary` inferred
+   unsignedness from the LLVM type `i8` — but both NURL `u` and signed
+   `i8` lower to LLVM i8. Signed i8 `/ % >> <` picked udiv/urem/lshr/icmp-u
+   and the result was marked unsigned (zero-extending a negative value).
+   Fixed: signedness comes only from the `__last_unsigned__` flag.
+
+## Scope / future
+
+v1 covers integer value semantics. Natural extensions: float arithmetic
+(needs a rounding-aware oracle), option/result construction + `??` match
+payload widths, struct field round-trips, and `-O0`-vs-`-O2` divergence on
+loop/recursion-heavy programs.

--- a/tools/fuzz/fuzz.sh
+++ b/tools/fuzz/fuzz.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# tools/fuzz/fuzz.sh — differential miscompile runner for nurlc.
+#
+# For each seed: generate a self-checking NURL program (gen.py) plus its
+# Python-computed oracle output, compile it at BOTH -O0 and -O2, run both,
+# and require:
+#     stdout(-O0) == stdout(-O2) == oracle      (value correctness)
+#     exit(-O0) == exit(-O2) == 0                (no crash)
+# Any divergence is a compiler bug; the offending program + oracle + actual
+# outputs are saved under tools/fuzz/failures/ for triage.
+#
+# Usage:
+#   tools/fuzz/fuzz.sh [START] [COUNT] [EXPRS] [DEPTH]
+# Defaults: START=1 COUNT=200 EXPRS=12 DEPTH=4
+#
+# Programs are loop-free, bounded-depth integer expression trees, so the
+# -O0 alloca-in-loop stack caveat in nurl.sh does not apply.
+
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GEN="$ROOT/tools/fuzz/gen.py"
+NURL="$ROOT/nurl.sh"
+FAILDIR="$ROOT/tools/fuzz/failures"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+START="${1:-1}"
+COUNT="${2:-200}"
+EXPRS="${3:-12}"
+DEPTH="${4:-4}"
+
+mkdir -p "$FAILDIR"
+pass=0
+fail=0
+buildfail=0
+
+end=$((START + COUNT - 1))
+for seed in $(seq "$START" "$end"); do
+    prog="$TMP/p.nu"
+    exp="$TMP/p.expected"
+    python3 "$GEN" "$seed" --exprs "$EXPRS" --depth "$DEPTH" > "$prog"
+    python3 "$GEN" "$seed" --exprs "$EXPRS" --depth "$DEPTH" --oracle > "$exp"
+
+    if ! "$NURL" -O0 "$prog" "$TMP/o0" >"$TMP/b0.log" 2>&1; then
+        echo "SEED $seed: -O0 BUILD FAIL"; buildfail=$((buildfail+1))
+        cp "$prog" "$FAILDIR/seed_${seed}_buildfail.nu"; cp "$TMP/b0.log" "$FAILDIR/seed_${seed}_build.log"
+        continue
+    fi
+    if ! "$NURL" -O2 "$prog" "$TMP/o2" >"$TMP/b2.log" 2>&1; then
+        echo "SEED $seed: -O2 BUILD FAIL"; buildfail=$((buildfail+1))
+        cp "$prog" "$FAILDIR/seed_${seed}_buildfail.nu"; cp "$TMP/b2.log" "$FAILDIR/seed_${seed}_build.log"
+        continue
+    fi
+
+    "$TMP/o0" > "$TMP/out0" 2>/dev/null; rc0=$?
+    "$TMP/o2" > "$TMP/out2" 2>/dev/null; rc2=$?
+
+    ok=1
+    if ! cmp -s "$TMP/out0" "$exp"; then ok=0; reason="O0 != oracle"; fi
+    if ! cmp -s "$TMP/out2" "$exp"; then ok=0; reason="O2 != oracle"; fi
+    if [[ $rc0 -ne 0 || $rc2 -ne 0 ]]; then ok=0; reason="nonzero exit (o0=$rc0 o2=$rc2)"; fi
+
+    if [[ $ok -eq 1 ]]; then
+        pass=$((pass+1))
+    else
+        fail=$((fail+1))
+        echo "SEED $seed: MISCOMPILE — $reason"
+        cp "$prog" "$FAILDIR/seed_${seed}.nu"
+        cp "$exp"  "$FAILDIR/seed_${seed}.expected"
+        cp "$TMP/out0" "$FAILDIR/seed_${seed}.out0"
+        cp "$TMP/out2" "$FAILDIR/seed_${seed}.out2"
+        diff "$exp" "$TMP/out0" > "$FAILDIR/seed_${seed}.diff_o0" 2>&1
+    fi
+done
+
+echo "─────────────────────────────────────────"
+echo "seeds $START..$end   pass=$pass  miscompile=$fail  buildfail=$buildfail"
+[[ $fail -eq 0 && $buildfail -eq 0 ]]

--- a/tools/fuzz/gen.py
+++ b/tools/fuzz/gen.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# tools/fuzz/gen.py — random NURL integer-expression generator + oracle.
+#
+# Differential testing of nurlc's integer code generation. Each run emits a
+# self-contained NURL program that computes K random expressions over the
+# sized integer types and prints each result as its exact 64-bit pattern
+# (16 hex digits, MSB first). The SAME generator computes the expected
+# values itself (a trusted reference oracle implemented in Python with
+# explicit two's-complement / width / signedness semantics), so a divergence
+# between what the compiled program prints and what the oracle says is a
+# miscompile — no second compiler needed.
+#
+# The generator is intentionally biased toward the historically buggy
+# surface in nurlc: width coercions (`# T` trunc/sext/zext), unsigned
+# arithmetic (udiv/urem/lshr/icmp u*), and mixed signed/unsigned operands.
+#
+# Usage:
+#   gen.py SEED                  → prints the NURL program to stdout
+#   gen.py SEED --oracle         → prints the expected stdout (K hex lines)
+#   gen.py SEED --exprs N --depth D   (tunables)
+#
+# nurlc emits plain `add`/`mul`/`shl` (no nsw/nuw), so signed overflow is
+# defined wrapping — the oracle wraps to match. Division/shift UB is avoided
+# by construction (positive small divisors, shift amounts < width).
+
+import sys
+import random
+
+# token -> (bit width, is_signed). `i` aliases i64, `u` is u8.
+TYPES = {
+    "i8":  (8,  True),
+    "i16": (16, True),
+    "i32": (32, True),
+    "i64": (64, True),
+    "u":   (8,  False),
+    "u16": (16, False),
+    "u32": (32, False),
+    "u64": (64, False),
+}
+TYPE_NAMES = list(TYPES.keys())
+
+
+def mask(w):
+    return (1 << w) - 1
+
+
+def wrap(value, ty):
+    """Reduce a Python int to the value of NURL type `ty` (two's complement)."""
+    w, signed = TYPES[ty]
+    v = value & mask(w)
+    if signed and (v >> (w - 1)) & 1:
+        v -= (1 << w)
+    return v
+
+
+def to_u64_bits(value, ty):
+    """The exact 64-bit pattern after `# i64 <value:ty>` — sext if the source
+    is signed, zext if unsigned — matching nurlc's widening rule."""
+    w, signed = TYPES[ty]
+    v = wrap(value, ty)
+    if signed:
+        return v & mask(64)          # Python negative & mask == two's complement
+    return v & mask(w)               # unsigned: zero-extended
+
+
+# ── AST: each node carries its NURL type and knows how to (a) render to
+#    source and (b) evaluate under the oracle. ──────────────────────────
+
+class Node:
+    def __init__(self, ty):
+        self.ty = ty
+
+    def render(self):
+        raise NotImplementedError
+
+    def eval(self):
+        raise NotImplementedError
+
+
+class Lit(Node):
+    def __init__(self, ty, bits):
+        super().__init__(ty)
+        self.bits = bits            # non-negative bit pattern in [0, 2^w)
+
+    def render(self):
+        # A bare decimal literal is i64; `# T` truncates to the type width.
+        return f"# {self.ty} {self.bits}"
+
+    def eval(self):
+        return wrap(self.bits, self.ty)
+
+
+class Cast(Node):
+    def __init__(self, ty, child):
+        super().__init__(ty)
+        self.child = child
+
+    def render(self):
+        return f"# {self.ty} {self.child.render()}"
+
+    def eval(self):
+        return wrap(self.child.eval(), self.ty)
+
+
+class Bin(Node):
+    def __init__(self, ty, op, a, b):
+        super().__init__(ty)
+        self.op, self.a, self.b = op, a, b
+
+    def render(self):
+        return f"{self.op} {self.a.render()} {self.b.render()}"
+
+    def eval(self):
+        w, signed = TYPES[self.ty]
+        va, vb = self.a.eval(), self.b.eval()
+        op = self.op
+        if op == "+":
+            r = va + vb
+        elif op == "-":
+            r = va - vb
+        elif op == "*":
+            r = va * vb
+        elif op == "&":
+            r = (va & mask(w)) & (vb & mask(w))
+        elif op == "|":
+            r = (va & mask(w)) | (vb & mask(w))
+        elif op == "/":
+            r = self._divrem(va, vb, signed, w, rem=False)
+        elif op == "%":
+            r = self._divrem(va, vb, signed, w, rem=True)
+        elif op == "<<":
+            r = (va & mask(w)) << vb
+        elif op == ">>":
+            if signed:
+                r = va >> vb                      # Python >> on signed == ashr
+            else:
+                r = (va & mask(w)) >> vb           # lshr
+        else:
+            raise ValueError(op)
+        return wrap(r, self.ty)
+
+    @staticmethod
+    def _divrem(va, vb, signed, w, rem):
+        if signed:
+            # C / LLVM sdiv/srem: truncate toward zero, srem takes dividend sign.
+            a, b = va, vb
+            q = abs(a) // abs(b)
+            if (a < 0) != (b < 0):
+                q = -q
+            if not rem:
+                return q
+            return a - q * b
+        else:
+            ua, ub = va & mask(w), vb & mask(w)
+            return ua % ub if rem else ua // ub
+
+
+# ── Generator ───────────────────────────────────────────────────────────
+
+class Gen:
+    def __init__(self, rng):
+        self.rng = rng
+
+    def leaf(self, ty):
+        w, _ = TYPES[ty]
+        # 64-bit literals stay in non-negative i64 range to dodge literal
+        # parsing edges; high-bit / negative 64-bit values still arise via
+        # arithmetic, shifts, and widening casts from unsigned types.
+        hi = (1 << 63) if w == 64 else (1 << w)
+        return Lit(ty, self.rng.randrange(hi))
+
+    def small_pos(self, ty):
+        """A positive literal in [1, 63] — safe nonzero divisor / shift amount."""
+        return Lit(ty, self.rng.randint(1, 63))
+
+    def gen(self, ty, depth):
+        if depth <= 0:
+            return self.leaf(ty)
+        kind = self.rng.choice(
+            ["cast", "arith", "arith", "divrem", "bitwise", "shift", "leaf"]
+        )
+        if kind == "leaf":
+            return self.leaf(ty)
+        if kind == "cast":
+            src = self.rng.choice(TYPE_NAMES)
+            return Cast(ty, self.gen(src, depth - 1))
+        if kind == "arith":
+            op = self.rng.choice(["+", "-", "*"])
+            return Bin(ty, op, self.gen(ty, depth - 1), self.gen(ty, depth - 1))
+        if kind == "divrem":
+            op = self.rng.choice(["/", "%"])
+            return Bin(ty, op, self.gen(ty, depth - 1), self.small_pos(ty))
+        if kind == "bitwise":
+            op = self.rng.choice(["&", "|"])
+            return Bin(ty, op, self.gen(ty, depth - 1), self.gen(ty, depth - 1))
+        if kind == "shift":
+            w, _ = TYPES[ty]
+            op = self.rng.choice(["<<", ">>"])
+            sh = Lit(ty, self.rng.randrange(w))   # 0..w-1, defined shift
+            return Bin(ty, op, self.gen(ty, depth - 1), sh)
+        raise AssertionError(kind)
+
+
+PRELUDE = """\
+// AUTO-GENERATED by tools/fuzz/gen.py — differential miscompile probe.
+$ `stdlib/core/string.nu`
+
+@ hexd i n → i { ? < n 10 { ^ + 48 n } { ^ + 87 n } }
+
+// Print the exact 64-bit pattern of `v` as 16 hex digits, MSB first.
+// `& 15 >> v (4*k)` extracts nibble k correctly for any k regardless of
+// arithmetic vs logical shift (the mask discards sign-filled high bits).
+@ phex i v → v {
+    : String s ( string_new )
+    : ~ i k 15
+    ~ >= k 0 {
+        ( string_push_char s ( hexd & 15 >> v * k 4 ) )
+        = k - k 1
+    }
+    ( nurl_print ( string_data s ) )
+    ( nurl_print `\\n` )
+    ( string_free s )
+}
+
+@ main → i {
+"""
+
+
+def build(seed, n_exprs, depth):
+    rng = random.Random(seed)
+    g = Gen(rng)
+    nodes = []
+    for _ in range(n_exprs):
+        ty = rng.choice(TYPE_NAMES)
+        nodes.append((ty, g.gen(ty, depth)))
+    return nodes
+
+
+def emit_program(nodes):
+    lines = [PRELUDE]
+    for ty, node in nodes:
+        lines.append(f"    ( phex # i64 {node.render()} )")
+    lines.append("    ^ 0")
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def emit_oracle(nodes):
+    out = []
+    for ty, node in nodes:
+        bits = to_u64_bits(node.eval(), ty)
+        out.append(f"{bits:016x}")
+    return "\n".join(out) + "\n"
+
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        sys.exit("usage: gen.py SEED [--oracle] [--exprs N] [--depth D]")
+    seed = int(args[0])
+    oracle = "--oracle" in args
+    n_exprs = 12
+    depth = 4
+    if "--exprs" in args:
+        n_exprs = int(args[args.index("--exprs") + 1])
+    if "--depth" in args:
+        depth = int(args[args.index("--depth") + 1])
+    nodes = build(seed, n_exprs, depth)
+    sys.stdout.write(emit_oracle(nodes) if oracle else emit_program(nodes))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a generative, oracle-backed fuzzer (tools/fuzz) that hunts silent integer miscompiles in nurlc, and fix the two it found on its first run. Both produced wrong values with no error — the worst bug class.

The fuzzer (tools/fuzz/gen.py + fuzz.sh) builds random sized-integer expression trees and, from the same tree, emits both a self-checking NURL program (prints each result's exact 64-bit pattern) and a Python reference oracle with explicit two's-complement / width / signedness semantics. Each program is compiled at -O0 and -O2 and required to satisfy stdout(-O0) == stdout(-O2) == oracle, so it catches miscompiles that are wrong at every optimisation level, not just opt-sensitive ones. It generates no UB (positive divisors, in-range shift amounts; nurlc emits plain wrapping add/mul).

Fixes in compiler/nurlc.nu:

1. Unsigned-byte cast widening sign-extended. `# i64 # u 217` gave -39 instead of 217: a nested cast-to-unsigned never set the `__last_unsigned__` side-channel that the enclosing widening cast consults, so it defaulted to sext. gen_cast now records the cast target's signedness for an enclosing widen / binop / shift. (Only casts whose subject was a typed binding widened correctly before.)

2. Signed i8 arithmetic treated as unsigned. gen_binary inferred unsignedness from the LLVM type i8 — but both the unsigned NURL `u` and the signed `i8` lower to LLVM i8, so signed i8 `/ % >> <` selected udiv/urem/lshr/icmp-u and the result was marked unsigned, silently zero-extending a negative value at the next widen. Signedness now comes solely from the `__last_unsigned__` flag, never from the LLVM type.

Bootstrap fixed point holds; full suite + ASan/UBSan green. Regression compiler/tests/cast_signedness.nu (12 known-answer checks covering both bugs and the unsigned-still-correct mirror). Validated by 340 fuzzer seeds (0 divergences).