### PR TITLE
fix(codegen): two struct-field signedness miscompiles + struct fuzz dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Narrow sized-int enum payloads now compile and round-trip correctly.**
+  An enum variant carrying a `u`/`i8`/`u16`/`i16`/`u32`/`i32` payload (e.g.
+  `: | E { None Val u }`) was accepted by the front-end but emitted invalid
+  IR: `gen_agg_lit` only converted i64/i32 payloads into the enum's pointer
+  slot (so an i8 payload hit `insertvalue …, i8 …` against a `ptr` field —
+  clang reject), and `gen_match` only un-converted i1/i64 (storing a `ptr`
+  into an `i8` binding). Now construction widens a narrow payload to i64
+  (zext for an unsigned payload, sext for signed — from the payload
+  signedness `gen_enum_decl` now records) before `inttoptr`, and the match
+  `ptrtoint`s back and truncs to the payload width, carrying the payload's
+  signedness onto the binding so a later widen zero-extends an unsigned
+  payload. Found by hand-probing the fuzzer's struct dimension outward.
+  Bootstrap fixed point holds; full suite + ASan/UBSan green. Regression
+  `compiler/tests/enum_payload_signedness.nu` (5 known-answer checks).
+
 - **Two silent struct-field signedness miscompiles** (same fuzzer, extended
   with a struct dimension; same root cause — the LLVM field type can't carry
   NURL's signedness). Both fixed in `compiler/nurlc.nu`; regression

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A call to an unsigned-returning function sign-extended at the call
+  site.** `# i ( f )` where `f → u` returns 200 gave −56 (and likewise for
+  `u16`/`u32`): the call site never carried the callee's return signedness
+  onto the `__last_unsigned__` side-channel the enclosing widening cast
+  reads (the LLVM return type i8/i16/i32 can't distinguish `u` from `i8`).
+  `scan_fn_sigs` now records `<fn>__ret_unsigned` in the persistent pre-pass
+  symbol table (the per-function `gen_fn_decl` scope doesn't reach call
+  sites), and `gen_call` re-asserts it on `__last_unsigned__` after the
+  call. Regression `compiler/tests/fn_return_signedness.nu` (5 known-answer
+  checks). Bootstrap fixed point holds; full suite + ASan/UBSan green.
+
 - **Narrow sized-int enum payloads now compile and round-trip correctly.**
   An enum variant carrying a `u`/`i8`/`u16`/`i16`/`u32`/`i32` payload (e.g.
   `: | E { None Val u }`) was accepted by the front-end but emitted invalid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two silent struct-field signedness miscompiles** (same fuzzer, extended
+  with a struct dimension; same root cause — the LLVM field type can't carry
+  NURL's signedness). Both fixed in `compiler/nurlc.nu`; regression
+  `compiler/tests/struct_field_signedness.nu` (8 known-answer checks);
+  validated by 600 fuzzer seeds with the struct dimension.
+  1. **Reading an unsigned field sign-extended.** `# i . rec u8field` over a
+     `u`/`u16`/`u32` field holding e.g. 200 read back −56: `gen_member` never
+     surfaced the field's declared signedness onto `__last_unsigned__`.
+     `gen_struct_decl` now records `<S>__<field>__unsigned`, and both the
+     value (extractvalue) and pointer (GEP+load) field-load paths set the
+     flag from it.
+  2. **Constructing a wider field from a narrower unsigned value
+     sign-extended.** `@ Wide { # u 130 }` into an `i64` field stored −126
+     instead of 130 — `gen_agg_lit`'s field-store widening hardcoded `sext`.
+     It now picks `zext` when the field value is unsigned (the
+     `__last_unsigned__` snapshot it already takes), `sext` otherwise.
+
 - **Two silent integer miscompiles, found by a new differential fuzzer
   (`tools/fuzz`) and fixed at the root in `compiler/nurlc.nu`.** Both
   produced wrong values with no error — the worst class of bug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two more silent unsigned-widening miscompiles** (same `__last_unsigned__`
+  side-channel hazard; fixed in `compiler/nurlc.nu`). Regression
+  `compiler/tests/const_ternary_signedness.nu` (7 known-answer checks).
+  1. **An unsigned global const load sign-extended.** `# i GU` over
+     `: u GU 200` gave −56. `gen_const_decl` now records `<const>__unsigned`
+     (which `gen_ident` already turns into `__last_unsigned__` on load).
+  2. **A `?` (ternary) result didn't carry its arms' signedness.**
+     `# i ? c (# u 200) (# u 100)` sign-extended the selected value.
+     `gen_cond` now snapshots each arm's `__last_unsigned__` and sets the
+     result flag (the arms share a type, so either suffices).
+
 - **A call to an unsigned-returning function sign-extended at the call
   site.** `# i ( f )` where `f → u` returns 200 gave −56 (and likewise for
   `u16`/`u32`): the call site never carried the callee's return signedness

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5261,12 +5261,12 @@
                 ( nurl_print ` = extractvalue ` ) ( nurl_print match_type )
                 ( nurl_print ` ` ) ( nurl_print match_val ) ( nurl_print `, 2\n` )
                 : s cv1 ( nurl_cg_reg cg )
-                ? ( seq pt1 `i1` ) {
+                ? & > ( int_width pt1 ) 0 < ( int_width pt1 ) 64 {
                     : s t64 ( nurl_cg_reg cg )
                     ( nurl_print `  ` ) ( nurl_print t64 )
                     ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr1 ) ( nurl_print ` to i64\n` )
                     ( nurl_print `  ` ) ( nurl_print cv1 )
-                    ( nurl_print ` = trunc i64 ` ) ( nurl_print t64 ) ( nurl_print ` to i1\n` )
+                    ( nurl_print ` = trunc i64 ` ) ( nurl_print t64 ) ( nurl_print ` to ` ) ( nurl_print pt1 ) ( nurl_print `\n` )
                 } {
                     ( nurl_print `  ` ) ( nurl_print cv1 )
                     ? == ( nurl_str_get pt1 0 ) 123
@@ -5287,6 +5287,8 @@
                 ( nurl_print `* ` ) ( nurl_print vp1 ) ( nurl_print `\n` )
                 ( nurl_sym_def syms pv1 pt1 )
                 ( nurl_sym_def syms ( nurl_str_cat pv1 `__ptr` ) vp1 )
+                ( nurl_sym_def syms ( nurl_str_cat pv1 `__unsigned` )
+                ( nurl_sym_get syms ( nurl_str_cat pattern_name `__payload__1__unsigned` ) ) )
                 ? != 0 g_auto_drop_strings
                 { : s a1_key ( nurl_str_cat `drop##` pt1 )
                     ? != 0 ( nurl_str_len ( nurl_sym_get g_impl_name_syms a1_key ) )
@@ -5303,12 +5305,12 @@
                 ( nurl_print ` = extractvalue ` ) ( nurl_print match_type )
                 ( nurl_print ` ` ) ( nurl_print match_val ) ( nurl_print `, 3\n` )
                 : s cv2 ( nurl_cg_reg cg )
-                ? ( seq pt2 `i1` ) {
+                ? & > ( int_width pt2 ) 0 < ( int_width pt2 ) 64 {
                     : s t64 ( nurl_cg_reg cg )
                     ( nurl_print `  ` ) ( nurl_print t64 )
                     ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr2 ) ( nurl_print ` to i64\n` )
                     ( nurl_print `  ` ) ( nurl_print cv2 )
-                    ( nurl_print ` = trunc i64 ` ) ( nurl_print t64 ) ( nurl_print ` to i1\n` )
+                    ( nurl_print ` = trunc i64 ` ) ( nurl_print t64 ) ( nurl_print ` to ` ) ( nurl_print pt2 ) ( nurl_print `\n` )
                 } {
                     ( nurl_print `  ` ) ( nurl_print cv2 )
                     ? == ( nurl_str_get pt2 0 ) 123
@@ -5329,6 +5331,8 @@
                 ( nurl_print `* ` ) ( nurl_print vp2 ) ( nurl_print `\n` )
                 ( nurl_sym_def syms pv2 pt2 )
                 ( nurl_sym_def syms ( nurl_str_cat pv2 `__ptr` ) vp2 )
+                ( nurl_sym_def syms ( nurl_str_cat pv2 `__unsigned` )
+                ( nurl_sym_get syms ( nurl_str_cat pattern_name `__payload__2__unsigned` ) ) )
                 ? != 0 g_auto_drop_strings
                 { : s a2_key ( nurl_str_cat `drop##` pt2 )
                     ? != 0 ( nurl_str_len ( nurl_sym_get g_impl_name_syms a2_key ) )

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -4141,6 +4141,12 @@
     // When Phase 2B is off no function ever gets "str" registered, so behaviour
     // is identical to the Phase 2A-only build.
     ( nurl_sym_def syms `__last_call_ret_owned__` ( nurl_sym_get syms ( nurl_str_cat call_name `__ret_owned` ) ) )
+    // Record the callee's return signedness (from its recorded NURL return
+    // type) so the regular @-fn dispatch can re-assert it on `__last_unsigned__`
+    // AFTER the call — an enclosing `# i ( f )` over a `u`-returning `f` must
+    // zero-extend. (The LLVM return type i8/i16/i32 can't carry it.)
+    ( nurl_sym_def syms `__last_call_ret_unsigned__`
+    ( nurl_sym_get syms ( nurl_str_cat call_name `__ret_unsigned` ) ) )
 
     // Check if this is a stored closure variable first
     : s var_ptr ( nurl_sym_get syms ( nurl_str_cat call_name `__ptr` ) )
@@ -4242,6 +4248,10 @@
                 ( nurl_print `(` ) ( nurl_print argstr ) ( nurl_print `)` ) ( emit_dbg_eol )
                 ( mem_drop_arg_temps owned_arg_temps )
                 ( nurl_set_last_type rlt )
+                // Re-assert the callee's return signedness (cleared/overwritten
+                // by argument evaluation) so an enclosing `# i ( f )` widens a
+                // `u`-returning call with zext.
+                ( nurl_sym_def syms `__last_unsigned__` ( nurl_sym_get syms `__last_call_ret_unsigned__` ) )
                 res
             }
         }
@@ -12947,6 +12957,14 @@
                                 { ( nurl_lex_advance lex )
                                     : s ret_ty ( parse_type lex )
                                     ( nurl_sym_def syms fname ret_ty )
+                                    // Persistent (pre-pass) record of the return
+                                    // signedness — read at call sites to widen a
+                                    // `u`-returning call with zext. gen_fn_decl's
+                                    // own recording lives in a scope that doesn't
+                                    // reach call sites, so this is the source of
+                                    // truth.
+                                    ( nurl_sym_def syms ( nurl_str_cat fname `__ret_unsigned` )
+                                    ? ( nurl_type_is_unsigned ( nurl_sym_get g_res_type_syms `__last_nurl_type__` ) ) `1` `` )
                                 }
                                 {}
                                 ( skip_balanced lex )

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5156,12 +5156,17 @@
                 : s cv0 ? did_reconstruct pr0_eff
                 ? pt0_is_opt_bool pr0 ( nurl_cg_reg cg )
                 ? pt0_is_opt_bool {} {
-                    ? ( seq pt0 `i1` ) {
+                    ? & > ( int_width pt0 ) 0 < ( int_width pt0 ) 64 {
+                        // Narrow integer payload (i1 / i8 / i16 / i32, incl.
+                        // the unsigned u/u16/u32): the value rode the ptr slot
+                        // widened to i64 (gen_agg_lit), so ptrtoint back to i64
+                        // and trunc to the payload's width. Signedness for a
+                        // later widen is set on the binding below.
                         : s t64 ( nurl_cg_reg cg )
                         ( nurl_print `  ` ) ( nurl_print t64 )
                         ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr0 ) ( nurl_print ` to i64\n` )
                         ( nurl_print `  ` ) ( nurl_print cv0 )
-                        ( nurl_print ` = trunc i64 ` ) ( nurl_print t64 ) ( nurl_print ` to i1\n` )
+                        ( nurl_print ` = trunc i64 ` ) ( nurl_print t64 ) ( nurl_print ` to ` ) ( nurl_print pt0 ) ( nurl_print `\n` )
                     } {
                         // Struct-handle payload (e.g. %Vec__Json, %String): the payload
                         // ptr stored in the enum slot IS the struct's field-0 pointer
@@ -5214,6 +5219,11 @@
                 ( nurl_print `* ` ) ( nurl_print vp0 ) ( nurl_print `\n` )
                 ( nurl_sym_def syms pv0 pt0_eff )
                 ( nurl_sym_def syms ( nurl_str_cat pv0 `__ptr` ) vp0 )
+                // Carry the payload's NURL signedness onto the binding so a
+                // later `# i <b>` widen zero-extends a `u`-family payload
+                // (gen_ident copies `<name>__unsigned` → `__last_unsigned__`).
+                ( nurl_sym_def syms ( nurl_str_cat pv0 `__unsigned` )
+                ( nurl_sym_get syms ( nurl_str_cat pattern_name `__payload__0__unsigned` ) ) )
                 // Phase 2D: a match-arm payload binding OWNS its value just
                 // like a `:` let, so a `% Drop` impl on the payload type must
                 // fire at arm scope exit. Register it here (mirrors gen_let's
@@ -8556,12 +8566,25 @@
                         = actual_fval conv_reg2
                         = actual_fty `ptr`
                     }
-                    ? | ( seq fty `i64` ) ( seq fty `i32` )
-                    {  // Convert integer to ptr
+                    ? & > ( int_width fty ) 0 ! ( seq fty `i1` )
+                    {  // Integer payload → ptr slot. A NARROW int (i8/i16/i32,
+                        // incl. the unsigned u/u16/u32) must first widen to i64
+                        // so the value survives the ptr round-trip — zext when
+                        // the payload value is unsigned (`fld_unsigned`), sext
+                        // otherwise. `inttoptr i8 … to ptr` would zero-extend
+                        // unconditionally and corrupt a signed payload. i64
+                        // payloads inttoptr directly.
+                        : s wide_val fval
+                        ? < ( int_width fty ) 64
+                        { : s ext_reg ( nurl_cg_reg cg )
+                            : s ext_op ? != 0 ( nurl_str_len fld_unsigned ) ` = zext ` ` = sext `
+                            ( nurl_print `  ` ) ( nurl_print ext_reg ) ( nurl_print ext_op )
+                            ( nurl_print fty ) ( nurl_print ` ` ) ( nurl_print fval ) ( nurl_print ` to i64\n` )
+                            = wide_val ext_reg }
+                        {}
                         : s conv_reg ( nurl_cg_reg cg )
                         ( nurl_print `  ` ) ( nurl_print conv_reg )
-                        ( nurl_print ` = inttoptr ` ) ( nurl_print fty ) ( nurl_print ` ` )
-                        ( nurl_print fval ) ( nurl_print ` to ptr\n` )
+                        ( nurl_print ` = inttoptr i64 ` ) ( nurl_print wide_val ) ( nurl_print ` to ptr\n` )
                         = actual_fval conv_reg
                         = actual_fty `ptr`
                     }
@@ -11491,6 +11514,12 @@
         ~ & != ( nurl_lex_type lex ) TT_RBRACE ( could_be_payload_type lex syms ) {
             : s pt ( parse_type lex )
             ( nurl_sym_def syms ( nurl_str_cat vname ( nurl_str_cat `__payload__` ( nurl_str_int pcount ) ) ) pt )
+            // Record the payload's NURL signedness (the LLVM type can't carry
+            // it) so the match binding widens with zext for a `u`-family
+            // payload — same hazard as struct fields.
+            ( nurl_sym_def syms
+            ( nurl_str_cat vname ( nurl_str_cat `__payload__` ( nurl_str_cat ( nurl_str_int pcount ) `__unsigned` ) ) )
+            ? ( nurl_type_is_unsigned ( nurl_sym_get g_res_type_syms `__last_nurl_type__` ) ) `1` `` )
             = pcount + pcount 1
         }
         ( nurl_sym_def syms ( nurl_str_cat vname `__paycount` ) ( nurl_str_int pcount ) )

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -4304,6 +4304,8 @@
     = g_ret_forbidden 0
     : s tv ( gen_expr lex syms cg )
     : s tt2 ( nurl_get_last_type )
+    // Snapshot the then-arm's signedness for the `?`-result flag below.
+    : s then_unsigned ( nurl_sym_get syms `__last_unsigned__` )
     : s tlbl ( nurl_sym_get syms `__cur_lbl__` )
     : i tdr g_did_ret
     ? == tdr 0
@@ -4338,6 +4340,7 @@
     = g_ret_forbidden 0
     : s ev ( gen_expr lex syms cg )
     : s et2 ( nurl_get_last_type )
+    : s else_unsigned ( nurl_sym_get syms `__last_unsigned__` )
     : s elbl ( nurl_sym_get syms `__cur_lbl__` )
     : i edr g_did_ret
     ? == edr 0
@@ -4407,6 +4410,11 @@
         { ( nurl_set_last_type `void` ) }
     }
     {}
+    // The `?`-result is unsigned iff its arms are (NURL types match across
+    // arms, so either flag suffices — OR them defensively). Lets an enclosing
+    // `# i ? c (# u …) (# u …)` widen the selected value with zext.
+    ( nurl_sym_def syms `__last_unsigned__`
+    ? | != 0 ( nurl_str_len then_unsigned ) != 0 ( nurl_str_len else_unsigned ) `1` `` )
     result
 }
 
@@ -11295,6 +11303,11 @@
             ( nurl_print `\n\n` )
             ( nurl_sym_def syms cname lt )
             ( nurl_sym_def syms ( nurl_str_cat cname `__global` ) `1` )
+            // Record the const's signedness (the LLVM type can't carry it) so
+            // gen_ident sets `__last_unsigned__` on load and an enclosing
+            // `# i GU` over a `: u GU 200` widens with zext, not sext.
+            ( nurl_sym_def syms ( nurl_str_cat cname `__unsigned` )
+            ? ( nurl_type_is_unsigned ty_tok ) `1` `` )
             ? is_mutable
             { ( nurl_sym_def syms ( nurl_str_cat cname `__mutable` ) `1` ) }
             {}

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -8076,6 +8076,7 @@
             : s var_t ( nurl_sym_get syms fname )
             : s fidx_s ``
             : s ftype ``
+            : ~ s fld_uns ``
             ? & elem_is_struct ( is_ident_tok ( nurl_lex_type lex ) )
             { ? > ( int_width var_t ) 0
                 {}  // Integer variable index: skip field access check
@@ -8085,6 +8086,7 @@
                     { = is_field_access T
                         = fidx_s fidx_check
                         = ftype ( nurl_sym_get syms ( nurl_str_cat sname ( nurl_str_cat `__` ( nurl_str_cat fname `__type` ) ) ) )
+                        = fld_uns ( nurl_sym_get syms ( nurl_str_cat sname ( nurl_str_cat `__` ( nurl_str_cat fname `__unsigned` ) ) ) )
                     }
                     {}
                 }
@@ -8105,6 +8107,8 @@
                 ( nurl_print `, ` ) ( nurl_print ftype )
                 ( nurl_print `* ` ) ( nurl_print gep ) ( nurl_print `\n` )
                 ( nurl_set_last_type ftype )
+                // Field's NURL signedness for an enclosing widening cast.
+                ( nurl_sym_def syms `__last_unsigned__` fld_uns )
                 ^ res
             }
             {  // Variable / arbitrary expression index → array-style access
@@ -8228,6 +8232,10 @@
                     ( nurl_print ` ` ) ( nurl_print ov )
                     ( nurl_print `, ` ) ( nurl_print ( nurl_str_int fidx ) ) ( nurl_print `\n` )
                     ( nurl_set_last_type ftype )
+                    // Surface the field's NURL signedness so an enclosing
+                    // widening cast picks zext (unsigned field) vs sext.
+                    ( nurl_sym_def syms `__last_unsigned__`
+                    ( nurl_sym_get syms ( nurl_str_cat sname ( nurl_str_cat `__` ( nurl_str_cat fname `__unsigned` ) ) ) ) )
                     ^ res
                 }
             }
@@ -8663,8 +8671,14 @@
         : i have_iw ( int_width actual_fty )
         ? & & > decl_iw 0 > have_iw 0 != decl_iw have_iw
         { : s cv ( nurl_cg_reg cg )
+            // Widen with zext when the VALUE is unsigned (`fld_unsigned`,
+            // snapshotted from `__last_unsigned__` above) — storing a `u`
+            // byte 130 into an i64 field must give 130, not −126. sext only
+            // for a signed source; trunc when the field is narrower.
+            : s widen_op ? != 0 ( nurl_str_len fld_unsigned ) ` = zext ` ` = sext `
+            : s coerce_op ? > decl_iw have_iw widen_op ` = trunc `
             ( nurl_print `  ` ) ( nurl_print cv )
-            ( nurl_print ? > decl_iw have_iw ` = sext ` ` = trunc ` )
+            ( nurl_print coerce_op )
             ( nurl_print actual_fty ) ( nurl_print ` ` ) ( nurl_print actual_fval )
             ( nurl_print ` to ` ) ( nurl_print decl_fty ) ( nurl_print `\n` )
             = actual_fval cv
@@ -11129,6 +11143,18 @@
             ( nurl_sym_def syms
             ( nurl_str_cat3 sname `__idx_` ( nurl_str_cat ( nurl_str_int fidx ) `__name` ) )
             fname )
+            // Record the field's NURL-level signedness — the LLVM type
+            // `flt` (i8/i16/i32) can't distinguish `u`/`u16`/`u32` from the
+            // signed `i8`/`i16`/`i32`, so a field load must consult this to
+            // widen with zext (unsigned) vs sext (signed). Captured from the
+            // `__last_nurl_type__` side-channel parse_type_base just set.
+            : b fld_uns ( nurl_type_is_unsigned ( nurl_sym_get g_res_type_syms `__last_nurl_type__` ) )
+            ( nurl_sym_def syms
+            ( nurl_str_cat3 sname `__idx_` ( nurl_str_cat ( nurl_str_int fidx ) `__unsigned` ) )
+            ? fld_uns `1` `` )
+            ( nurl_sym_def syms
+            ( nurl_str_cat sname ( nurl_str_cat `__` ( nurl_str_cat fname `__unsigned` ) ) )
+            ? fld_uns `1` `` )
         }
         {}
         ? != first 0

--- a/compiler/tests/const_ternary_signedness.nu
+++ b/compiler/tests/const_ternary_signedness.nu
@@ -1,0 +1,45 @@
+// const_ternary_signedness.nu — regression for two silent miscompiles
+// found by hand-probing while extending the differential fuzzer
+// (tools/fuzz) on 2026-06-02.
+//
+// Same root cause as the rest of the signedness family — the LLVM integer
+// type can't carry NURL's u-vs-signed distinction, so it rides the
+// `__last_unsigned__` side-channel, and these two value-producing sites
+// forgot to set it:
+//   * An unsigned-typed GLOBAL CONST load (`# i GU` over `: u GU 200`)
+//     widened with sext → −56 instead of 200. gen_const_decl now records
+//     `<const>__unsigned`, which gen_ident already propagates.
+//   * A `?` (ternary) result whose arms are unsigned (`# i ? c (# u 200)
+//     (# u 100)`) widened with sext. gen_cond now snapshots each arm's
+//     signedness and sets the result flag.
+//
+// main returns the number of failed checks (0 = all pass).
+
+: u   GU 200
+: u16 GW 50000
+: u32 GD 2147483649
+: i8  GS 200          // signed const, must stay sext
+
+@ chk i got i want s tag → i {
+    ? == got want {
+        ( nurl_print tag ) ( nurl_print ` ok\n` ) ^ 0
+    } {
+        ( nurl_print tag ) ( nurl_print ` FAIL\n` ) ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i f 0
+    // Unsigned global consts → zext.
+    = f + f ( chk # i64 # i GU 200 `const_u8_zext` )
+    = f + f ( chk # i64 # i GW 50000 `const_u16_zext` )
+    = f + f ( chk # i64 # i GD 2147483649 `const_u32_zext` )
+    // Signed global const → sext (200 as i8 = −56).
+    = f + f ( chk # i64 # i64 GS - 0 56 `const_i8_sext` )
+    // Ternary whose arms are unsigned → zext the selected value.
+    = f + f ( chk # i64 # i ? > 1 0 # u 200 # u 100 200 `tern_u8_zext` )
+    = f + f ( chk # i64 # i ? > 0 1 # u16 1 GW 50000 `tern_u16_zext` )
+    // Ternary whose arms are signed → sext.
+    = f + f ( chk # i64 # i64 ? > 1 0 # i8 200 # i8 5 - 0 56 `tern_i8_sext` )
+    ^ f
+}

--- a/compiler/tests/enum_payload_signedness.nu
+++ b/compiler/tests/enum_payload_signedness.nu
@@ -21,6 +21,10 @@
 : | EW { NoneW  WideV  u16 }   // unsigned 16 payload
 : | EH { NoneH  HalfV  i16 }   // signed 16 payload
 : | ED { NoneD  DwV    u32 }   // unsigned 32 payload
+// Multi-payload variants — each payload slot (pt0/pt1/pt2) needs the same
+// narrow-int widen/trunc + signedness, not just slot 0.
+: | MP { NoneM  Pair  u i16 }
+: | T3 { NoneT  Trip  u u16 u32 }
 
 @ chk i got i want s tag → i {
     ? == got want {
@@ -42,5 +46,24 @@
     = f + f ?? e { HalfV b → ( chk # i64 # i64 b - 0 15536 `i16_payload_sext` )  NoneH → 1 }
     : ED g @ ED { DwV # u32 2147483649 }
     = f + f ?? g { DwV b → ( chk # i64 # i b 2147483649 `u32_payload_zext` )  NoneD → 1 }
+    // Multi-payload: slots 0 + 1 (u8 zext, i16 sext).
+    : MP p @ MP { Pair # u 200 # i16 50000 }
+    ?? p {
+        Pair a b → {
+            = f + f ( chk # i64 # i a 200 `mp_slot0_u8` )
+            = f + f ( chk # i64 # i64 b - 0 15536 `mp_slot1_i16` )
+        }
+        NoneM → {}
+    }
+    // Multi-payload: slots 0 + 1 + 2, all unsigned (zext).
+    : T3 t @ T3 { Trip # u 200 # u16 50000 # u32 2147483649 }
+    ?? t {
+        Trip a b c → {
+            = f + f ( chk # i64 # i a 200 `t3_slot0_u8` )
+            = f + f ( chk # i64 # i b 50000 `t3_slot1_u16` )
+            = f + f ( chk # i64 # i c 2147483649 `t3_slot2_u32` )
+        }
+        NoneT → {}
+    }
     ^ f
 }

--- a/compiler/tests/enum_payload_signedness.nu
+++ b/compiler/tests/enum_payload_signedness.nu
@@ -1,0 +1,46 @@
+// enum_payload_signedness.nu — regression for narrow sized-int enum
+// payloads, found by hand-probing while extending the differential fuzzer
+// (tools/fuzz) on 2026-06-02.
+//
+// Before the fix, an enum variant carrying a NARROW sized-int payload
+// (`u`/`i8`/`u16`/`i16`/`u32`/`i32`) was accepted by the front-end but
+// emitted invalid IR — `gen_agg_lit` only converted i64/i32 payloads to the
+// enum's pointer slot, and `gen_match` only un-converted i1/i64, so an i8
+// payload hit `insertvalue %E …, i8 …, ptr-field` (clang reject) and the
+// match stored a `ptr` into an `i8` binding. Now:
+//   * construction widens a narrow payload to i64 (zext for unsigned, sext
+//     for signed, per the recorded payload signedness) before inttoptr;
+//   * the match ptrtoint's back to i64 and truncs to the payload width, and
+//     carries the payload's signedness onto the binding so a later widen
+//     zero-extends an unsigned payload.
+//
+// main returns the number of failed checks (0 = all pass).
+
+: | EU { NoneU  ByteV  u   }   // unsigned byte payload
+: | ES { NoneS  ByteS  i8  }   // signed byte payload
+: | EW { NoneW  WideV  u16 }   // unsigned 16 payload
+: | EH { NoneH  HalfV  i16 }   // signed 16 payload
+: | ED { NoneD  DwV    u32 }   // unsigned 32 payload
+
+@ chk i got i want s tag → i {
+    ? == got want {
+        ( nurl_print tag ) ( nurl_print ` ok\n` ) ^ 0
+    } {
+        ( nurl_print tag ) ( nurl_print ` FAIL\n` ) ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i f 0
+    : EU a @ EU { ByteV # u 200 }
+    = f + f ?? a { ByteV b → ( chk # i64 # i b 200 `u8_payload_zext` )  NoneU → 1 }
+    : ES c @ ES { ByteS # i8 200 }
+    = f + f ?? c { ByteS b → ( chk # i64 # i64 b - 0 56 `i8_payload_sext` )  NoneS → 1 }
+    : EW d @ EW { WideV # u16 50000 }
+    = f + f ?? d { WideV b → ( chk # i64 # i b 50000 `u16_payload_zext` )  NoneW → 1 }
+    : EH e @ EH { HalfV # i16 50000 }
+    = f + f ?? e { HalfV b → ( chk # i64 # i64 b - 0 15536 `i16_payload_sext` )  NoneH → 1 }
+    : ED g @ ED { DwV # u32 2147483649 }
+    = f + f ?? g { DwV b → ( chk # i64 # i b 2147483649 `u32_payload_zext` )  NoneD → 1 }
+    ^ f
+}

--- a/compiler/tests/fn_return_signedness.nu
+++ b/compiler/tests/fn_return_signedness.nu
@@ -1,0 +1,40 @@
+// fn_return_signedness.nu — regression for a silent miscompile found by
+// hand-probing while extending the differential fuzzer (tools/fuzz) on
+// 2026-06-02.
+//
+// Bug: a call to a function whose return type is an unsigned sized int
+// (`u`/`u16`/`u32`), with the result immediately widened (`# i ( f )`),
+// sign-extended — `# i ( ret_u )` over a `→ u` returning 200 gave −56. The
+// call site never carried the callee's return signedness onto the
+// `__last_unsigned__` side-channel the enclosing widening cast consults
+// (the LLVM return type i8/i16/i32 can't distinguish `u` from `i8`).
+// scan_fn_sigs now records `<fn>__ret_unsigned`; gen_call re-asserts it on
+// `__last_unsigned__` after the call.
+//
+// main returns the number of failed checks (0 = all pass).
+
+@ ret_u → u { ^ # u 200 }
+@ ret_i8 → i8 { ^ # i8 200 }
+@ ret_u16 → u16 { ^ # u16 50000 }
+@ ret_u32 → u32 { ^ # u32 2147483649 }
+@ add_u u a u b → u { ^ + a b }       // unsigned return computed from params
+
+@ chk i got i want s tag → i {
+    ? == got want {
+        ( nurl_print tag ) ( nurl_print ` ok\n` ) ^ 0
+    } {
+        ( nurl_print tag ) ( nurl_print ` FAIL\n` ) ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i f 0
+    = f + f ( chk # i64 # i ( ret_u ) 200 `ret_u_zext` )
+    = f + f ( chk # i64 # i64 ( ret_i8 ) - 0 56 `ret_i8_sext` )
+    = f + f ( chk # i64 # i ( ret_u16 ) 50000 `ret_u16_zext` )
+    = f + f ( chk # i64 # i ( ret_u32 ) 2147483649 `ret_u32_zext` )
+    // Unsigned return widened correctly even with args + wrapping: 200+100
+    // wraps in u8 to 44, then zero-extends to 44 (not a negative).
+    = f + f ( chk # i64 # i ( add_u # u 200 # u 100 ) 44 `add_u_zext` )
+    ^ f
+}

--- a/compiler/tests/struct_field_signedness.nu
+++ b/compiler/tests/struct_field_signedness.nu
@@ -1,0 +1,58 @@
+// struct_field_signedness.nu — regression for a silent struct-field-load
+// miscompile found by hand-probing while extending the differential fuzzer
+// (tools/fuzz) on 2026-06-02.
+//
+// Bug: loading an UNSIGNED sized-int struct field and widening it
+// (`# i . rec u8field`) sign-extended instead of zero-extending — a u8
+// field holding 200 read back as −56, a u16 50000 as a negative, a u32
+// 0x80000001 as negative. Same root cause as the earlier casts: the LLVM
+// field type (i8/i16/i32) can't carry NURL's signedness, and `gen_member`
+// never surfaced the field's declared `u`/`u16`/`u32`-ness onto the
+// `__last_unsigned__` side-channel the enclosing widening cast consults.
+// `gen_struct_decl` now records `<S>__<field>__unsigned`; both the value
+// (extractvalue) and pointer (GEP+load) field-load paths set it.
+//
+// main returns the number of failed checks (0 = all pass).
+
+: Rec {
+    u   b0      // unsigned byte
+    i8  s0      // signed byte
+    u16 w0      // unsigned 16
+    i16 h0      // signed 16
+    u32 d0      // unsigned 32
+}
+
+// Wider fields fed NARROWER unsigned values — the construction store must
+// zero-extend (a `u` 130 into an i64 field is 130, not −126), the mirror of
+// the field-LOAD bug, fixed in gen_agg_lit.
+: Wide {
+    i64 a       // fed u8 130
+    i32 b       // fed u16 50000
+    i64 c       // fed u32 0x80000001
+}
+
+@ chk i got i want s tag → i {
+    ? == got want {
+        ( nurl_print tag ) ( nurl_print ` ok\n` ) ^ 0
+    } {
+        ( nurl_print tag ) ( nurl_print ` FAIL\n` ) ^ 1
+    }
+}
+
+@ main → i {
+    : Rec r @ Rec { # u 200 # i8 200 # u16 50000 # i16 50000 # u32 2147483649 }
+    : ~ i f 0
+    // Unsigned fields → zero-extend.
+    = f + f ( chk # i64 # i . r b0 200 `u8_field_zext` )
+    = f + f ( chk # i64 # i . r w0 50000 `u16_field_zext` )
+    = f + f ( chk # i64 # i . r d0 2147483649 `u32_field_zext` )
+    // Signed fields → sign-extend (i16 50000 wraps to −15536).
+    = f + f ( chk # i64 # i64 . r s0 - 0 56 `i8_field_sext` )
+    = f + f ( chk # i64 # i64 . r h0 - 0 15536 `i16_field_sext` )
+    // Construction store coercion: narrower unsigned value into wider field.
+    : Wide w @ Wide { # u 130 # u16 50000 # u32 2147483649 }
+    = f + f ( chk # i64 . w a 130 `u8_into_i64_field` )
+    = f + f ( chk # i64 # i64 . w b 50000 `u16_into_i32_field` )
+    = f + f ( chk # i64 . w c 2147483649 `u32_into_i64_field` )
+    ^ f
+}

--- a/tools/fuzz/README.md
+++ b/tools/fuzz/README.md
@@ -63,6 +63,10 @@ Failures are saved under `tools/fuzz/failures/` as `seed_N.nu` +
 - Integer expression trees: `+ - * / % & | ^^ << >>` and `# T` width casts.
 - Float arithmetic: `# i64 OP # f a # f b` (fadd/fsub/fmul/fdiv) over
   bounded int-derived doubles, truncated back to i64 — exact f64 oracle.
+- Structs: declare a struct of random-typed fields, construct an instance
+  (field initialisers of a different type → field store coercion), and read
+  each field back — probes `gen_member` field-load + `gen_agg_lit`
+  field-store signedness.
 - `let` bindings with a declared type that may differ from the initialiser
   (store coercion via `coerce_store_val`), plus variable reuse (binding
   reload signedness).
@@ -74,8 +78,9 @@ Failures are saved under `tools/fuzz/failures/` as `seed_N.nu` +
 
 ## Bugs found (2026-06-02)
 
-Five silent miscompiles, all fixed at the root in `compiler/nurlc.nu`;
-locked in by `compiler/tests/cast_signedness.nu` + `cast_int_float.nu`.
+Seven silent miscompiles, all fixed at the root in `compiler/nurlc.nu`;
+locked in by `compiler/tests/cast_signedness.nu` + `cast_int_float.nu` +
+`struct_field_signedness.nu`.
 Every one is the same underlying hazard: **the LLVM integer type cannot
 carry NURL's signedness, so it must ride the `__last_unsigned__`
 side-channel — and any path that forgets to set/clear it miscompiles.**
@@ -89,6 +94,10 @@ side-channel — and any path that forgets to set/clear it miscompiles.**
 4. Float → int ignored target signedness (no `fptoui`).
 5. A float result leaked its source int's stale unsigned flag into a later
    `*`/`/` (negative product divided with `udiv`).
+6. Reading an unsigned struct field sign-extended (`gen_member` didn't
+   surface the field's signedness).
+7. Constructing a wider field from a narrower unsigned value sign-extended
+   (`gen_agg_lit` field-store hardcoded `sext`).
 
 ## Scope / future
 

--- a/tools/fuzz/gen.py
+++ b/tools/fuzz/gen.py
@@ -116,6 +116,22 @@ class Var(Node):
         return self._value
 
 
+class FieldRead(Node):
+    """Read a struct field: `. <inst> <field>`. The field's NURL type is its
+    declared type; its value is the construction value coerced to that type
+    (store coercion). Probes gen_member's field-load signedness — a u-field
+    must widen with zext, not sext."""
+    def __init__(self, ty, inst, field, value):
+        super().__init__(ty)
+        self.inst, self.field, self._value = inst, field, value
+
+    def render(self):
+        return f". {self.inst} {self.field}"
+
+    def eval(self):
+        return self._value
+
+
 class Cmp(Node):
     """A comparison — value type i64 (0 or 1, via i1→i64 zext). Exercises the
     signed-vs-unsigned icmp selection (`< # i8 …` must be slt, not ult)."""
@@ -340,14 +356,27 @@ $ `stdlib/core/string.nu`
     ( nurl_print `\\n` )
     ( string_free s )
 }
-
-@ main → i {
 """
 
 
 def build(seed, n_exprs, depth):
     rng = random.Random(seed)
     g = Gen(rng)
+    # ~60% of programs declare a struct whose fields span random sized types,
+    # construct one instance (field initialisers of a possibly-different type
+    # → field store coercion), and expose each field as a readable leaf —
+    # exercising gen_member's field-load signedness + field store coercion.
+    struct = None
+    if rng.random() < 0.6:
+        fields = []                        # (fname, ftype, init_node, value)
+        for i in range(rng.randint(2, 5)):
+            ftype = rng.choice(TYPE_NAMES)
+            init = g.gen(rng.choice(TYPE_NAMES), max(1, depth - 1))
+            fname = f"g{i}"
+            fields.append((fname, ftype, init, wrap(init.eval(), ftype)))
+        struct = ("FZ", fields)
+        for fname, ftype, _init, val in fields:
+            g.env.append(FieldRead(ftype, "fz", fname, val))
     # A prelude of `let` bindings whose declared type may differ from the
     # initialiser's — exercises coerce_store_val's store-time width coercion
     # (a DIFFERENT int-width branch than `# T` casts). The stored value is
@@ -365,13 +394,25 @@ def build(seed, n_exprs, depth):
     for _ in range(n_exprs):
         ty = rng.choice(TYPE_NAMES)
         nodes.append((ty, g.gen(ty, depth)))
-    return lets, nodes
+    return struct, lets, nodes
 
 
-def emit_program(lets, nodes):
+def emit_program(struct, lets, nodes):
     lines = [PRELUDE]
-    for name, bty, init in lets:
-        lines.append(f"    : {bty} {name} {init.render()}")
+    if struct:
+        name, fields = struct
+        lines.append(f": {name} {{")
+        for fname, ftype, _init, _val in fields:
+            lines.append(f"    {ftype} {fname}")
+        lines.append("}")
+    lines.append("")
+    lines.append("@ main → i {")
+    if struct:
+        name, fields = struct
+        inits = " ".join(init.render() for _f, _t, init, _v in fields)
+        lines.append(f"    : {name} fz @ {name} {{ {inits} }}")
+    for vname, bty, init in lets:
+        lines.append(f"    : {bty} {vname} {init.render()}")
     for ty, node in nodes:
         lines.append(f"    ( phex # i64 {node.render()} )")
     lines.append("    ^ 0")
@@ -379,7 +420,7 @@ def emit_program(lets, nodes):
     return "\n".join(lines) + "\n"
 
 
-def emit_oracle(lets, nodes):
+def emit_oracle(struct, lets, nodes):
     out = []
     for ty, node in nodes:
         bits = to_u64_bits(node.eval(), ty)
@@ -399,9 +440,9 @@ def main():
         n_exprs = int(args[args.index("--exprs") + 1])
     if "--depth" in args:
         depth = int(args[args.index("--depth") + 1])
-    lets, nodes = build(seed, n_exprs, depth)
-    sys.stdout.write(emit_oracle(lets, nodes) if oracle
-                     else emit_program(lets, nodes))
+    struct, lets, nodes = build(seed, n_exprs, depth)
+    sys.stdout.write(emit_oracle(struct, lets, nodes) if oracle
+                     else emit_program(struct, lets, nodes))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extend the differential fuzzer (tools/fuzz) with a struct dimension —
declare a struct of random-typed fields, construct an instance (field
initialisers of a possibly-different type → field store coercion), and read
each field back — and fix the two silent miscompiles it surfaced. Same root
cause as the earlier int/float bugs: the LLVM field type (i8/i16/i32) can't
distinguish NURL's `u`/`u16`/`u32` from the signed `i8`/`i16`/`i32`, so the
signedness must ride the `__last_unsigned__` side-channel.

1. Reading an unsigned field sign-extended: `# i . rec u8field` over a `u`
   field holding 200 read back -56. gen_member never set __last_unsigned__
   from the field's declared signedness. gen_struct_decl now records
   <S>__<field>__unsigned (captured from the parse_type_base side-channel);
   both field-load paths (value extractvalue + pointer GEP+load) set the
   flag from it.

2. Constructing a wider field from a narrower unsigned value sign-extended:
   `@ Wide { # u 130 }` into an i64 field stored -126, not 130 —
   gen_agg_lit's field-store widening hardcoded `sext`. It now picks `zext`
   when the field value is unsigned (the __last_unsigned__ snapshot it
   already takes). (Written with explicit bindings rather than a nested
   ternary in operand position — the latter is miscompiled by the older
   bootstrap snapshot.)

Bootstrap fixed point holds; full suite + ASan/UBSan green. Regression
compiler/tests/struct_field_signedness.nu (8 known-answer checks). 600
fuzzer seeds with the struct dimension clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>