### PR TITLE
Add registry resolution and binary-safe HTTP response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Registry resolution core — `stdlib/ext/registry_index.nu` +
+  `stdlib/ext/resolver.nu` (ROADMAP §4 phase 4).** The read side of the
+  package registry. A registry serves a static JSON index per package at
+  `<registry>/index/<name>.json` (versions, each with a tarball SHA-256
+  `checksum`, `yanked` flag, and `deps`); tarballs live at the
+  content-addressed `<registry>/pkgs/<name>/<name>-<ver>.tar.gz`, so the
+  whole read path is a cacheable CDN with no compute.
+  `registry_index.nu` parses an index and `regindex_select` picks the
+  highest non-yanked version satisfying a semver requirement.
+  `resolver.nu`'s `resolve_registry` walks the transitive dependency graph
+  (BFS) and emits a `Vec[LockPkg]` ready for `lock_serialize` — the index
+  fetcher is injected as a closure (`name → index-JSON`), so resolution is
+  pure and offline-testable; nurlpkg will wire it to an HTTP GET. v1 policy:
+  one version per name (first requirement wins; a later one must share that
+  version or it's ResolveConflict), sub-deps from the parent's registry,
+  path deps left to the existing symlink installer. Regressions:
+  `compiler/tests/registry_index_basic.nu` (parse + select + yanked
+  exclusion + tarball URL) and `compiler/tests/resolver_basic.nu`
+  (transitive resolve with a mock index, ResolveNoMatch, ResolveNotFound).
+  Both clean under ASan/UBSan and leak-free.
+
 ### Changed
 
 - **Signedness is now coupled to the value's type instead of a free-floating

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Binary-safe HTTP response body — `http_body_bytes` / `http_body_len`.**
+  `http_body_str` reads the response body through a NUL-terminated carrier
+  (truncates at the first embedded NUL). The new `http_body_bytes` returns
+  an owned, length-accurate `( Vec u )` copy, and `http_body_len` exposes
+  the byte count — required for binary downloads (package tarballs, images,
+  compressed payloads). Completes the binary HTTP story alongside the
+  earlier binary-safe request body. Regression:
+  `compiler/tests/http_response_binary.nu` (loopback server replies a
+  5-byte `A B \0 C D` body; client confirms full length + the NUL via
+  `http_body_bytes`; `NURL_NET_TESTS=1`). Clean under ASan/UBSan.
+  `stdlib/ext/http.nu`.
+
 - **Registry resolution core — `stdlib/ext/registry_index.nu` +
   `stdlib/ext/resolver.nu` (ROADMAP §4 phase 4).** The read side of the
   package registry. A registry serves a static JSON index per package at

--- a/compiler/tests/http_response_binary.nu
+++ b/compiler/tests/http_response_binary.nu
@@ -1,0 +1,83 @@
+// http_response_binary.nu — binary-safe HTTP response body round-trip.
+//
+// Companion to http_binary_body.nu (which covers the request side). A
+// loopback NURL server replies with a 5-byte body `A B \0 C D`; the NURL
+// client reads it with http_body_bytes and confirms the full length and
+// the embedded NUL survive (http_body_str would truncate at byte 2).
+// Results funnel through globals so the two-thread output is deterministic.
+// Live socket exercise gated behind NURL_NET_TESTS=1.
+
+$ `stdlib/std/net.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/http.nu`
+$ `stdlib/ext/http_server.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+
+: ~ i g_len -1
+: ~ i g_nul -1
+: ~ i g_status -1
+
+@ bin_handler HttpRequest r → HttpResponse {
+    : HttpResponse resp ( response_new 200 )
+    : ( Vec u ) body ( vec_new [u] )
+    ( vec_push [u] body # u 65 )   // 'A'
+    ( vec_push [u] body # u 66 )   // 'B'
+    ( vec_push [u] body # u 0 )    // embedded NUL
+    ( vec_push [u] body # u 67 )   // 'C'
+    ( vec_push [u] body # u 68 )   // 'D'
+    ( response_set_body_bytes resp body )   // copies the bytes
+    ( vec_free [u] body )
+    ^ resp
+}
+
+@ run_test → v {
+    : !TcpListener NetErr lr ( tcp_listen `127.0.0.1` 18942 )
+    ?? lr {
+        T listener → {
+            : ( @ HttpResponse HttpRequest ) h \ HttpRequest req → HttpResponse { ^ ( bin_handler req ) }
+            : HttpServer srv ( server_new listener h )
+
+            : ( @ v ) client \ → v {
+                ( sleep_ms 250 )
+                : !Response HttpErr rr ( http_get `http://127.0.0.1:18942/blob` )
+                ?? rr {
+                    T resp → {
+                        = g_status ( http_status resp )
+                        : ( Vec u ) body ( http_body_bytes resp )
+                        = g_len ( vec_len [u] body )
+                        : *u bp ( vec_data [u] body )
+                        ? > ( vec_len [u] body ) 2 { = g_nul # i . bp 2 } {}
+                        ( vec_free [u] body )
+                        ( response_free resp )
+                    }
+                    F → { = g_status -2 }
+                }
+            }
+            : !Thread ThreadErr ct ( thread_spawn client )
+
+            : !v NetErr sr ( server_run_once srv )
+            ?? sr { T _ → {} F e → { ( nurl_print `server_err=` ) ( nurl_print ( net_err_name e ) ) ( nurl_print `\n` ) } }
+            ?? ct { T t → ( thread_join t ) F _ → {} }
+
+            ( nurl_print `status=` ) ( nurl_print_int g_status )
+            ( nurl_print `body_len=` ) ( nurl_print_int g_len )
+            ( nurl_print `nul_at2=` ) ( nurl_print_int g_nul )
+            ( nurl_print `done\n` )
+        }
+        F e → { ( nurl_print `listen_fail=` ) ( nurl_print ( net_err_name e ) ) ( nurl_print `\n` ) }
+    }
+}
+
+@ main → i {
+    : ?String gate ( env_get `NURL_NET_TESTS` )
+    ?? gate {
+        T s → { ( string_free s ) ( run_test ) }
+        F → { ( nurl_print `response binary test skipped (set NURL_NET_TESTS=1)\n` ) }
+    }
+    ^ 0
+}

--- a/compiler/tests/registry_index_basic.nu
+++ b/compiler/tests/registry_index_basic.nu
@@ -1,0 +1,71 @@
+// registry_index_basic.nu — registry index parse + version selection.
+//
+// Covers: JSON index parse (name + versions + per-version checksum/yanked/
+// deps), highest-satisfying selection with yanked exclusion, and the
+// content-addressed tarball URL builder.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/registry_index.nu`
+
+@ sel RegIndex idx s req → v {
+    : i k ( regindex_select idx req )
+    ( nurl_print `select ` ) ( nurl_print req ) ( nurl_print ` -> ` )
+    ? < k 0 {
+        ( nurl_print `none\n` )
+    } {
+        : ?IdxVersion vo ( vec_get [IdxVersion] . idx versions k )
+        ?? vo {
+            T v → { ( nurl_print ( string_data . v version ) ) ( nurl_print `\n` ) }
+            F → ( nurl_print `?\n` )
+        }
+    }
+}
+
+@ main → i {
+    : s src `{
+  "name": "foo",
+  "versions": [
+    { "version": "1.0.0", "checksum": "aaa", "yanked": false, "deps": [] },
+    { "version": "1.2.0", "checksum": "bbb", "yanked": false, "deps": [ { "name": "bar", "req": "^0.3" } ] },
+    { "version": "1.4.0", "checksum": "ccc", "yanked": true, "deps": [] },
+    { "version": "2.0.0", "checksum": "ddd", "yanked": false, "deps": [] }
+  ]
+}`
+    : !RegIndex RegIndexErr ir ( regindex_parse src )
+    ?? ir {
+        F e → ( nurl_print ( regindex_err_name e ) )
+        T idx → {
+            ( nurl_print `name=` ) ( nurl_print ( string_data . idx name ) ) ( nurl_print `\n` )
+            ( nurl_print `versions=` ) ( nurl_print_int ( vec_len [IdxVersion] . idx versions ) ) ( nurl_print `\n` )
+
+            ( sel idx `^1.0.0` )     // 1.2.0 (1.4.0 yanked, 2.0.0 out of range)
+            ( sel idx `>=1.0.0` )    // 2.0.0
+            ( sel idx `^1.3.0` )     // none (only 1.4.0 in range, but yanked)
+            ( sel idx `=2.0.0` )     // 2.0.0
+            ( sel idx `^3.0.0` )     // none
+
+            : i k2 ( regindex_select idx `=1.2.0` )
+            : ?IdxVersion v2 ( vec_get [IdxVersion] . idx versions k2 )
+            ?? v2 {
+                T v → {
+                    ( nurl_print `v120_checksum=` ) ( nurl_print ( string_data . v checksum ) ) ( nurl_print `\n` )
+                    ( nurl_print `v120_deps=` ) ( nurl_print_int ( vec_len [IdxDep] . v deps ) ) ( nurl_print `\n` )
+                    : ?IdxDep d0 ( vec_get [IdxDep] . v deps 0 )
+                    ?? d0 {
+                        T d → { ( nurl_print `dep0=` ) ( nurl_print ( string_data . d name ) ) ( nurl_print ` ` ) ( nurl_print ( string_data . d req ) ) ( nurl_print `\n` ) }
+                        F → {}
+                    }
+                }
+                F → {}
+            }
+
+            : String url ( regindex_tarball_url `https://reg.nurl-lang.org` `foo` `1.2.0` )
+            ( nurl_print `url=` ) ( nurl_print ( string_data url ) ) ( nurl_print `\n` )
+            ( string_free url )
+            ( regindex_free idx )
+        }
+    }
+    ( nurl_print `done\n` )
+    ^ 0
+}

--- a/compiler/tests/resolver_basic.nu
+++ b/compiler/tests/resolver_basic.nu
@@ -1,0 +1,84 @@
+// resolver_basic.nu — registry dependency resolution with a mock index.
+//
+// roots: a path dep (ignored) + registry dep foo ^1.0.
+//   foo: 1.0.0, 1.2.0 (deps bar ^0.3), 2.0.0  → picks 1.2.0
+//   bar: 0.3.0, 0.3.5, 0.4.0                   → picks 0.3.5 (^0.3)
+// Expected lock: bar 0.3.5 + foo 1.2.0 (sorted), each with source+checksum.
+// Also: ResolveNoMatch and ResolveNotFound.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/manifest.nu`
+$ `stdlib/ext/lockfile.nu`
+$ `stdlib/ext/resolver.nu`
+
+@ idx_for s name → String {
+    ? != 0 ( nurl_str_eq name `foo` ) {
+        ^ ( string_from `{ "name": "foo", "versions": [
+          { "version": "1.0.0", "checksum": "f100", "deps": [] },
+          { "version": "1.2.0", "checksum": "f120", "deps": [ { "name": "bar", "req": "^0.3" } ] },
+          { "version": "2.0.0", "checksum": "f200", "deps": [] } ] }` )
+    } {}
+    ? != 0 ( nurl_str_eq name `bar` ) {
+        ^ ( string_from `{ "name": "bar", "versions": [
+          { "version": "0.3.0", "checksum": "b030", "deps": [] },
+          { "version": "0.3.5", "checksum": "b035", "deps": [] },
+          { "version": "0.4.0", "checksum": "b040", "deps": [] } ] }` )
+    } {}
+    ^ ( string_new )
+}
+
+@ reg_dep s name s req → Dep {
+    ^ @ Dep { ( string_from name ) ( string_new ) ( string_from req ) ( string_new ) }
+}
+
+@ deps_free ( Vec Dep ) v → v {
+    : i n ( vec_len [Dep] v )
+    : ~ i k 0
+    ~ < k n {
+        : ?Dep d ( vec_get [Dep] v k )
+        ?? d { T dv → ( dep_free dv ) F → {} }
+        = k + k 1
+    }
+    ( vec_free [Dep] v )
+}
+
+@ main → i {
+    : ( @ String s ) fetch \ s name → String { ^ ( idx_for name ) }
+
+    // ── happy path ───────────────────────────────────────────────
+    ( nurl_print `── resolve ──\n` )
+    : ( Vec Dep ) roots ( vec_new [Dep] )
+    ( vec_push [Dep] roots @ Dep { ( string_from `local` ) ( string_from `../local` ) ( string_from `0.1.0` ) ( string_new ) } )
+    ( vec_push [Dep] roots ( reg_dep `foo` `^1.0` ) )
+    : !( Vec LockPkg ) ResolveErr rr ( resolve_registry roots `https://reg.nurl-lang.org/` fetch )
+    ?? rr {
+        F e → ( nurl_print ( resolve_err_name e ) )
+        T locked → {
+            : String text ( lock_serialize locked )
+            ( nurl_print ( string_data text ) )
+            ( string_free text )
+            ( lockpkgs_free locked )
+        }
+    }
+    ( deps_free roots )
+
+    // ── ResolveNoMatch ───────────────────────────────────────────
+    ( nurl_print `── no match ──\n` )
+    : ( Vec Dep ) r2 ( vec_new [Dep] )
+    ( vec_push [Dep] r2 ( reg_dep `foo` `^9.0` ) )
+    : !( Vec LockPkg ) ResolveErr rr2 ( resolve_registry r2 `https://reg/` fetch )
+    ?? rr2 { F e → { ( nurl_print ( resolve_err_name e ) ) ( nurl_print `\n` ) } T l → { ( nurl_print `ok(bug)\n` ) ( lockpkgs_free l ) } }
+    ( deps_free r2 )
+
+    // ── ResolveNotFound ──────────────────────────────────────────
+    ( nurl_print `── not found ──\n` )
+    : ( Vec Dep ) r3 ( vec_new [Dep] )
+    ( vec_push [Dep] r3 ( reg_dep `nope` `^1.0` ) )
+    : !( Vec LockPkg ) ResolveErr rr3 ( resolve_registry r3 `https://reg/` fetch )
+    ?? rr3 { F e → { ( nurl_print ( resolve_err_name e ) ) ( nurl_print `\n` ) } T l → { ( nurl_print `ok(bug)\n` ) ( lockpkgs_free l ) } }
+    ( deps_free r3 )
+
+    ( nurl_print `done\n` )
+    ^ 0
+}

--- a/compiler/tests/run_tests.sh
+++ b/compiler/tests/run_tests.sh
@@ -248,6 +248,7 @@ for src in "${tests[@]}"; do
           && "$name" != "http_server_tls" \
           && "$name" != "http_server_panic" \
           && "$name" != "http_binary_body" \
+          && "$name" != "http_response_binary" \
           && "$ENABLE_HTTP_TESTS" != "1" ]]; then
         continue
     fi
@@ -256,7 +257,8 @@ for src in "${tests[@]}"; do
             || "$name" == "http_server_limits" \
             || "$name" == "http_server_tls" \
             || "$name" == "http_server_panic" \
-            || "$name" == "http_binary_body" ) \
+            || "$name" == "http_binary_body" \
+            || "$name" == "http_response_binary" ) \
           && "$ENABLE_NET_TESTS" != "1" ]]; then
         continue
     fi

--- a/stdlib/ext/http.nu
+++ b/stdlib/ext/http.nu
@@ -656,6 +656,34 @@ i timeout_ms i connect_timeout_ms → !Response HttpErr {
     ^ ? == bp 0 `` # s bp
 }
 
+@ http_body_len Response r → i {
+    : s rp . r raw
+    : *u rawp # *u rp
+    ^ ( nurl_peek rawp 5 )
+}
+
+// Owned, length-accurate binary copy of the response body. Unlike
+// http_body_str (which stops at the first NUL via strlen on the carrier),
+// this preserves embedded NUL bytes — required for binary downloads
+// (package tarballs, images, compressed payloads). Caller frees with
+// `( vec_free [u] … )`.
+@ http_body_bytes Response r → ( Vec u ) {
+    : s rp . r raw
+    : *u rawp # *u rp
+    : i bp ( nurl_peek rawp 4 )
+    : i blen ( nurl_peek rawp 5 )
+    : ( Vec u ) out ( vec_with_cap [u] ? > blen 0 blen 1 )
+    ? & != bp 0 > blen 0 {
+        : *u src # *u bp
+        : ~ i k 0
+        ~ < k blen {
+            ( vec_push [u] out . src k )
+            = k + k 1
+        }
+    } {}
+    ^ out
+}
+
 @ http_header_count Response r → i {
     : s rp . r raw
     : *u rawp # *u rp

--- a/stdlib/ext/registry_index.nu
+++ b/stdlib/ext/registry_index.nu
@@ -1,0 +1,249 @@
+// stdlib/ext/registry_index.nu — registry package index (read side).
+//
+// A registry serves, per package, a static JSON index document at
+// `<registry>/index/<name>.json`. nurlpkg fetches it, picks the highest
+// version satisfying a semver requirement, then downloads the tarball at
+// the content-addressed path `<registry>/pkgs/<name>/<name>-<ver>.tar.gz`
+// and verifies its SHA-256 against the `checksum` recorded here. Because
+// the index and tarballs are immutable static objects, the read path is a
+// dumb CDN — no compute, infinitely cacheable (ROADMAP §4).
+//
+// Index schema (`<registry>/index/<name>.json`):
+//
+//   {
+//     "name": "foo",
+//     "versions": [
+//       {
+//         "version": "1.2.3",
+//         "checksum": "<hex sha256 of foo-1.2.3.tar.gz>",
+//         "yanked": false,
+//         "deps": [ { "name": "bar", "req": "^0.3" } ]
+//       }
+//     ]
+//   }
+//
+// The tarball URL is derived from name+version, so the index carries no
+// URLs — a version is fully identified by (name, version, checksum).
+//
+// API:
+//   ( regindex_parse json )        → ! RegIndex RegIndexErr
+//   ( regindex_select idx req )    → i   highest non-yanked version index
+//                                        satisfying `req`, or -1
+//   ( regindex_free idx )          → v
+//   ( regindex_err_name e )        → s
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/semver.nu`
+
+: IdxDep {
+    String name
+    String req       // semver requirement
+}
+
+: IdxVersion {
+    String version
+    String checksum  // hex sha256 of the tarball
+    b yanked
+    ( Vec IdxDep ) deps
+}
+
+: RegIndex {
+    String name
+    ( Vec IdxVersion ) versions
+}
+
+: | RegIndexErr {
+    RegIdxParseFailed   // not valid JSON
+    RegIdxBadShape      // JSON parsed but isn't an index object
+}
+
+@ regindex_err_name RegIndexErr e → s {
+    ^ ?? e {
+        RegIdxParseFailed → `RegIdxParseFailed`
+        RegIdxBadShape → `RegIdxBadShape`
+    }
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────
+
+@ idxdep_free IdxDep d → v {
+    ( string_free . d name )
+    ( string_free . d req )
+}
+
+@ idxversion_free IdxVersion v → v {
+    ( string_free . v version )
+    ( string_free . v checksum )
+    : i n ( vec_len [IdxDep] . v deps )
+    : ~ i k 0
+    ~ < k n {
+        : ?IdxDep dk ( vec_get [IdxDep] . v deps k )
+        ?? dk { T d → ( idxdep_free d ) F → {} }
+        = k + k 1
+    }
+    ( vec_free [IdxDep] . v deps )
+}
+
+@ regindex_free RegIndex idx → v {
+    ( string_free . idx name )
+    : i n ( vec_len [IdxVersion] . idx versions )
+    : ~ i k 0
+    ~ < k n {
+        : ?IdxVersion vk ( vec_get [IdxVersion] . idx versions k )
+        ?? vk { T v → ( idxversion_free v ) F → {} }
+        = k + k 1
+    }
+    ( vec_free [IdxVersion] . idx versions )
+}
+
+// ── JSON field helpers ────────────────────────────────────────────────
+
+// Owned String from a string-typed field; empty when absent / wrong type.
+@ __ridx_str Json obj s key → String {
+    : ?Json f ( json_obj_get obj key )
+    ?? f {
+        T fj → ^ ( string_from ( json_as_str fj ) )
+        F → ^ ( string_new )
+    }
+}
+
+@ __ridx_bool Json obj s key → b {
+    : ?Json f ( json_obj_get obj key )
+    ?? f {
+        T fj → ^ ( json_as_bool fj )
+        F → ^ F
+    }
+}
+
+@ __ridx_version Json vj → IdxVersion {
+    : String version ( __ridx_str vj `version` )
+    : String checksum ( __ridx_str vj `checksum` )
+    : b yanked ( __ridx_bool vj `yanked` )
+    : ( Vec IdxDep ) deps ( vec_new [IdxDep] )
+    : ?Json da ( json_obj_get vj `deps` )
+    ?? da {
+        T darr → {
+            : i n ( json_arr_len darr )
+            : ~ i k 0
+            ~ < k n {
+                : ?Json dobj ( json_arr_get darr k )
+                ?? dobj {
+                    T dj → {
+                        : String dn ( __ridx_str dj `name` )
+                        : String dr ( __ridx_str dj `req` )
+                        ( vec_push [IdxDep] deps @ IdxDep { dn dr } )
+                    }
+                    F → {}
+                }
+                = k + k 1
+            }
+        }
+        F → {}
+    }
+    ^ @ IdxVersion { version checksum yanked deps }
+}
+
+// ── Parse ─────────────────────────────────────────────────────────────
+
+@ regindex_parse s src → !RegIndex RegIndexErr {
+    : !Json JsonError jr ( json_parse src )
+    ?? jr {
+        F _ → ^ @ !RegIndex RegIndexErr { F # RegIndexErr RegIdxParseFailed }
+        T root → {
+            : String name ( __ridx_str root `name` )
+            : ( Vec IdxVersion ) versions ( vec_new [IdxVersion] )
+            : ?Json va ( json_obj_get root `versions` )
+            ?? va {
+                T varr → {
+                    : i n ( json_arr_len varr )
+                    : ~ i k 0
+                    ~ < k n {
+                        : ?Json vobj ( json_arr_get varr k )
+                        ?? vobj {
+                            T vj → ( vec_push [IdxVersion] versions ( __ridx_version vj ) )
+                            F → {}
+                        }
+                        = k + k 1
+                    }
+                }
+                F → {}
+            }
+            ( json_free root )
+            ^ @ !RegIndex RegIndexErr { T @ RegIndex { name versions } }
+        }
+    }
+}
+
+// ── Version selection ─────────────────────────────────────────────────
+
+// Index of the highest non-yanked version satisfying `req`, or -1.
+@ regindex_select RegIndex idx s req → i {
+    : !VersionReq SemverErr rr ( semver_req_parse req )
+    : ~ i best -1
+    ?? rr {
+        F _ → { = best -1 }
+        T r → {
+            : i n ( vec_len [IdxVersion] . idx versions )
+            : ~ i k 0
+            ~ < k n {
+                : ?IdxVersion vo ( vec_get [IdxVersion] . idx versions k )
+                ?? vo {
+                    T iv → {
+                        ? ! . iv yanked {
+                            : !Semver SemverErr cp ( semver_parse ( string_data . iv version ) )
+                            ?? cp {
+                                T cv → {
+                                    ? ( semver_req_matches r cv ) {
+                                        ? < best 0 {
+                                            = best k
+                                        } {
+                                            : ?IdxVersion bo ( vec_get [IdxVersion] . idx versions best )
+                                            ?? bo {
+                                                T biv → {
+                                                    : !Semver SemverErr bp ( semver_parse ( string_data . biv version ) )
+                                                    ?? bp {
+                                                        T bv → { ? ( semver_gt cv bv ) { = best k } {} ( semver_free bv ) }
+                                                        F → {}
+                                                    }
+                                                }
+                                                F → {}
+                                            }
+                                        }
+                                    } {}
+                                    ( semver_free cv )
+                                }
+                                F → {}
+                            }
+                        } {}
+                    }
+                    F → {}
+                }
+                = k + k 1
+            }
+            ( semver_req_free r )
+        }
+    }
+    ^ best
+}
+
+// Convenience: the content-addressed tarball URL for (registry, name, ver):
+//   <registry>/pkgs/<name>/<name>-<version>.tar.gz
+// `registry` may or may not end in '/'; a single separator is ensured.
+@ regindex_tarball_url s registry s name s version → String {
+    : String out ( string_with_cap 96 )
+    ( string_push_str out registry )
+    : i rn ( nurl_str_len registry )
+    ? > rn 0 {
+        ? != ( nurl_str_get registry - rn 1 ) 47 { ( string_push_char out 47 ) } {}
+    } {}
+    ( string_push_str out `pkgs/` )
+    ( string_push_str out name )
+    ( string_push_char out 47 )
+    ( string_push_str out name )
+    ( string_push_char out 45 )
+    ( string_push_str out version )
+    ( string_push_str out `.tar.gz` )
+    ^ out
+}

--- a/stdlib/ext/resolver.nu
+++ b/stdlib/ext/resolver.nu
@@ -1,0 +1,233 @@
+// stdlib/ext/resolver.nu — registry dependency resolution → lockfile.
+//
+// Given a manifest's registry dependencies and a way to fetch a package's
+// index JSON, walk the transitive dependency graph (BFS), pick the
+// highest version satisfying each requirement, and emit a `Vec[LockPkg]`
+// ready for `lock_serialize`. The index fetcher is injected as a closure
+// (`name → index-JSON String`, empty = not found) so the resolver is pure
+// and offline-testable; nurlpkg wires it to an HTTP GET of
+// `<registry>/index/<name>.json`.
+//
+// v1 resolution policy:
+//   * One version per package name (no multi-version / SAT solving). The
+//     first requirement to reach a name selects its version; a later
+//     requirement on the same name must also be satisfied by that already
+//     -chosen version, else ResolveConflict.
+//   * Sub-dependencies are fetched from the same registry as their parent.
+//   * Path dependencies among the roots are ignored here (nurlpkg installs
+//     them via symlink); only registry deps are resolved.
+//
+// API:
+//   ( resolve_registry roots default_registry fetch ) → ! ( Vec LockPkg ) ResolveErr
+//   ( resolve_err_name e ) → s
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/manifest.nu`
+$ `stdlib/ext/lockfile.nu`
+$ `stdlib/ext/registry_index.nu`
+$ `stdlib/ext/semver.nu`
+
+: | ResolveErr {
+    ResolveNotFound    // a package has no index (fetch returned empty)
+    ResolveBadIndex    // a fetched index didn't parse
+    ResolveNoMatch     // no published version satisfies the requirement
+    ResolveConflict    // two requirements on one name can't share a version
+}
+
+@ resolve_err_name ResolveErr e → s {
+    ^ ?? e {
+        ResolveNotFound → `ResolveNotFound`
+        ResolveBadIndex → `ResolveBadIndex`
+        ResolveNoMatch → `ResolveNoMatch`
+        ResolveConflict → `ResolveConflict`
+    }
+}
+
+: ResolveReq {
+    String name
+    String req
+    String registry
+}
+
+@ __req_free ResolveReq r → v {
+    ( string_free . r name )
+    ( string_free . r req )
+    ( string_free . r registry )
+}
+
+@ __reqs_free ( Vec ResolveReq ) q → v {
+    : i n ( vec_len [ResolveReq] q )
+    : ~ i k 0
+    ~ < k n {
+        : ?ResolveReq ro ( vec_get [ResolveReq] q k )
+        ?? ro { T r → ( __req_free r ) F → {} }
+        = k + k 1
+    }
+    ( vec_free [ResolveReq] q )
+}
+
+@ __strs_free ( Vec String ) v → v {
+    : i n ( vec_len [String] v )
+    : ~ i k 0
+    ~ < k n {
+        : ?String so ( vec_get [String] v k )
+        ?? so { T s → ( string_free s ) F → {} }
+        = k + k 1
+    }
+    ( vec_free [String] v )
+}
+
+@ __seen_has ( Vec String ) seen s name → b {
+    : i n ( vec_len [String] seen )
+    : ~ i k 0
+    ~ < k n {
+        : ?String so ( vec_get [String] seen k )
+        ?? so { T s → { ? != 0 ( nurl_str_eq ( string_data s ) name ) { ^ T } {} } F → {} }
+        = k + k 1
+    }
+    ^ F
+}
+
+// Raw version string locked for `name`, or `` if not locked.
+@ __locked_version ( Vec LockPkg ) locked s name → s {
+    : i n ( vec_len [LockPkg] locked )
+    : ~ i k 0
+    ~ < k n {
+        : ?LockPkg po ( vec_get [LockPkg] locked k )
+        ?? po { T p → { ? != 0 ( nurl_str_eq ( string_data . p name ) name ) { ^ ( string_data . p version ) } {} } F → {} }
+        = k + k 1
+    }
+    ^ ``
+}
+
+// "registry+<reg>"
+@ __reg_source s reg → String {
+    : String out ( string_with_cap 48 )
+    ( string_push_str out `registry+` )
+    ( string_push_str out reg )
+    ^ out
+}
+
+// Does the already-locked version of `name` satisfy `req`?
+@ __already_ok ( Vec LockPkg ) locked s name s req → b {
+    : s lv ( __locked_version locked name )
+    ? == ( nurl_str_len lv ) 0 { ^ T } {}
+    : !VersionReq SemverErr rr ( semver_req_parse req )
+    : !Semver SemverErr vp ( semver_parse lv )
+    : ~ b ok F
+    ?? rr {
+        T r → {
+            ?? vp {
+                T v → { = ok ( semver_req_matches r v ) ( semver_free v ) }
+                F → {}
+            }
+            ( semver_req_free r )
+        }
+        F → {}
+    }
+    ^ ok
+}
+
+@ resolve_registry ( Vec Dep ) roots s default_registry ( @ String s ) fetch → !( Vec LockPkg ) ResolveErr {
+    : ( Vec LockPkg ) locked ( vec_new [LockPkg] )
+    : ( Vec String ) seen ( vec_new [String] )
+    : ( Vec ResolveReq ) queue ( vec_new [ResolveReq] )
+
+    // Seed the queue with the registry roots.
+    : i nr ( vec_len [Dep] roots )
+    : ~ i i 0
+    ~ < i nr {
+        : ?Dep dopt ( vec_get [Dep] roots i )
+        ?? dopt {
+            T d → {
+                ? ( dep_is_registry d ) {
+                    : s reg ? > ( string_len . d registry ) 0 ( string_data . d registry ) default_registry
+                    ( vec_push [ResolveReq] queue @ ResolveReq {
+                        ( string_from ( string_data . d name ) )
+                        ( string_from ( string_data . d version ) )
+                        ( string_from reg )
+                    } )
+                } {}
+            }
+            F → {}
+        }
+        = i + i 1
+    }
+
+    : ~ i qi 0
+    : ~ i failed 0
+    : ~ ResolveErr ferr ResolveNotFound
+    ~ & == failed 0 < qi ( vec_len [ResolveReq] queue ) {
+        : ?ResolveReq ropt ( vec_get [ResolveReq] queue qi )
+        ?? ropt {
+            T req → {
+                : s nm ( string_data . req name )
+                : s rq ( string_data . req req )
+                : s reg ( string_data . req registry )
+                ? ( __seen_has seen nm ) {
+                    ? ! ( __already_ok locked nm rq ) { = failed 1 = ferr ResolveConflict } {}
+                } {
+                    : String json ( fetch nm )
+                    ? == ( string_len json ) 0 {
+                        ( string_free json )
+                        = failed 1
+                        = ferr ResolveNotFound
+                    } {
+                        : !RegIndex RegIndexErr ir ( regindex_parse ( string_data json ) )
+                        ?? ir {
+                            F _ → { = failed 1 = ferr ResolveBadIndex }
+                            T idx → {
+                                : i sel ( regindex_select idx rq )
+                                ? < sel 0 {
+                                    = failed 1
+                                    = ferr ResolveNoMatch
+                                } {
+                                    : ?IdxVersion vopt ( vec_get [IdxVersion] . idx versions sel )
+                                    ?? vopt {
+                                        T iv → {
+                                            ( vec_push [LockPkg] locked @ LockPkg {
+                                                ( string_from nm )
+                                                ( string_from ( string_data . iv version ) )
+                                                ( __reg_source reg )
+                                                ( string_from ( string_data . iv checksum ) )
+                                            } )
+                                            ( vec_push [String] seen ( string_from nm ) )
+                                            : i nd ( vec_len [IdxDep] . iv deps )
+                                            : ~ i j 0
+                                            ~ < j nd {
+                                                : ?IdxDep ddopt ( vec_get [IdxDep] . iv deps j )
+                                                ?? ddopt {
+                                                    T dd → ( vec_push [ResolveReq] queue @ ResolveReq {
+                                                        ( string_from ( string_data . dd name ) )
+                                                        ( string_from ( string_data . dd req ) )
+                                                        ( string_from reg )
+                                                    } )
+                                                    F → {}
+                                                }
+                                                = j + j 1
+                                            }
+                                        }
+                                        F → {}
+                                    }
+                                }
+                                ( regindex_free idx )
+                            }
+                        }
+                        ( string_free json )
+                    }
+                }
+            }
+            F → {}
+        }
+        = qi + qi 1
+    }
+
+    ( __reqs_free queue )
+    ( __strs_free seen )
+    ? != failed 0 {
+        ( lockpkgs_free locked )
+        ^ @ !( Vec LockPkg ) ResolveErr { F ferr }
+    } {}
+    ^ @ !( Vec LockPkg ) ResolveErr { T locked }
+}


### PR DESCRIPTION
## Summary

This PR implements the core registry dependency resolution system and adds binary-safe HTTP response body handling, completing the read-side infrastructure for package registry support (ROADMAP §4 phase 4).

## Key Changes

### Registry Index & Resolution (`stdlib/ext/registry_index.nu`, `stdlib/ext/resolver.nu`)

- **`registry_index.nu`**: Parses static JSON package indexes and selects versions
  - Defines `RegIndex`, `IdxVersion`, and `IdxDep` types for representing registry metadata
  - `regindex_parse`: Parses JSON index documents with name, versions, checksums, yanked flags, and dependencies
  - `regindex_select`: Picks the highest non-yanked version satisfying a semver requirement
  - `regindex_tarball_url`: Builds content-addressed tarball URLs (`<registry>/pkgs/<name>/<name>-<ver>.tar.gz`)
  - Comprehensive lifecycle management (free functions for all types)

- **`resolver.nu`**: Walks transitive dependency graphs and produces lockfiles
  - `resolve_registry`: BFS-based resolution with injected index fetcher (closure-based for purity/testability)
  - v1 resolution policy: one version per package name; first requirement wins; later requirements must be satisfied by that version or fail with `ResolveConflict`
  - Sub-dependencies resolved from parent's registry; path dependencies left to existing symlink installer
  - Error types: `ResolveNotFound`, `ResolveBadIndex`, `ResolveNoMatch`, `ResolveConflict`
  - Produces `Vec[LockPkg]` ready for `lock_serialize`

### Binary-Safe HTTP Response Body (`stdlib/ext/http.nu`)

- **`http_body_bytes`**: Returns owned, length-accurate `( Vec u )` copy of response body
  - Preserves embedded NUL bytes (unlike `http_body_str` which truncates at first NUL)
  - Required for binary downloads (package tarballs, images, compressed payloads)
  - Caller responsible for freeing with `( vec_free [u] … )`

- **`http_body_len`**: Exposes response body byte count for binary handling

### Tests

- **`compiler/tests/registry_index_basic.nu`**: Validates index parsing, version selection with yanked exclusion, and tarball URL generation
- **`compiler/tests/resolver_basic.nu`**: Tests transitive resolution with mock index; covers happy path, `ResolveNoMatch`, and `ResolveNotFound`
- **`compiler/tests/http_response_binary.nu`**: Loopback server test confirming binary-safe response body handling (embedded NUL preservation); gated behind `NURL_NET_TESTS=1`

## Implementation Details

- Registry indexes are immutable static JSON documents served by a dumb CDN (no compute required)
- Tarball URLs are content-addressed by (name, version), so checksums are verified post-download
- Resolution is pure and offline-testable via closure-based index fetcher injection; nurlpkg will wire it to HTTP GET
- All string and vector allocations properly freed to prevent leaks
- Clean under ASan/UBSan

https://claude.ai/code/session_019dTVS7nqMEN65w1WbtfMqa