### PR TITLE
feat(nurlpkg): package publishing — pkg_publish + `nurlpkg publish` (ROADMAP §4 phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Package publishing — `stdlib/ext/pkg_publish.nu` + `nurlpkg publish`
+  (ROADMAP §4 phase 5).** The write side. `pkg_pack` walks a project tree
+  into a `.tar.gz` (excluding `deps`, `.git`/dotfiles, `nurl.lock`,
+  `target`, `build`); `pkg_publish` uploads it with `POST
+  <registry>/api/v1/publish`, `Authorization: Bearer <token>`, and
+  `X-Nurl-Package` / `X-Nurl-Version` headers (binary body via
+  `http_request_bytes`), mapping status to PubAuth (401/403) / PubConflict
+  (409, version immutability) / PubRejected. `nurlpkg publish` packs the
+  current project, prints its size + SHA-256, and uploads using the token
+  from `$NURL_TOKEN` and the registry from `$NURL_REGISTRY` →
+  `[package].registry` → default; a missing token or any non-2xx exits
+  non-zero. The registry recomputes the checksum server-side — no
+  client-supplied digest is trusted. Regression
+  `compiler/tests/pkg_pack_basic.nu` (offline pack + gunzip + tar_parse
+  membership: nested source included, deps/ + dotfiles excluded), clean
+  under ASan/UBSan + leak-free. Verified end-to-end against a static
+  `python` registry: a full **publish → install round-trip** (a library
+  packed, uploaded with a Bearer token, then resolved + installed into a
+  consumer's `deps/`), plus immutability (409), bad-token (401), and
+  no-token rejections. This is the exact contract the Cloudflare
+  Worker + R2 write endpoint (phase 6) will implement.
+
 - **Verified registry install — `stdlib/ext/pkg_fetch.nu` (ROADMAP §4
   phase 4b).** The I/O side that turns a resolved `LockPkg` into files on
   disk against a static-HTTP registry (R2 + CDN shape). `pkg_fetch_index`

--- a/compiler/tests/pkg_pack_basic.nu
+++ b/compiler/tests/pkg_pack_basic.nu
@@ -1,0 +1,82 @@
+// pkg_pack_basic.nu — offline test for pkg_pack (package a directory tree).
+//
+// Builds a temp project with a nested source file, an excluded deps/ dir,
+// and a dotfile, packs it, then gunzips + tar_parses the result and checks
+// membership (dir_list order isn't deterministic, so we assert presence/
+// absence, not order).
+
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/pkg_publish.nu`
+$ `stdlib/ext/compress.nu`
+$ `stdlib/ext/tar.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+@ ignore_io !v IoErr r → v { ?? r { T _ → {} F _ → {} } }
+
+@ wfile s path s content → v { ( ignore_io ( write_file path content ) ) }
+
+// Is `want` among the parsed entry paths?
+@ has_entry ( Vec TarEntry ) ents s want → b {
+    : i n ( vec_len [TarEntry] ents )
+    : ~ i k 0
+    ~ < k n {
+        : ?TarEntry eo ( vec_get [TarEntry] ents k )
+        ?? eo { T e → { ? != 0 ( nurl_str_eq ( string_data . e path ) want ) { ^ T } {} } F → {} }
+        = k + k 1
+    }
+    ^ F
+}
+
+@ pb s label b v → v {
+    ( nurl_print label )
+    ? v { ( nurl_print `=T\n` ) } { ( nurl_print `=F\n` ) }
+}
+
+@ main → i {
+    : s root `/tmp/nurl_pack_test`
+    ( ignore_io ( dir_remove_all root ) )
+    ( ignore_io ( dir_create_all `/tmp/nurl_pack_test/src` ) )
+    ( ignore_io ( dir_create_all `/tmp/nurl_pack_test/deps/foo` ) )
+    ( wfile `/tmp/nurl_pack_test/nurl.toml` `[package]
+name = "demo"
+version = "0.1.0"
+` )
+    ( wfile `/tmp/nurl_pack_test/src/lib.nu` `@ answer -> i { ^ 42 }
+` )
+    ( wfile `/tmp/nurl_pack_test/deps/foo/junk.nu` `should be excluded
+` )
+    ( wfile `/tmp/nurl_pack_test/.secret` `excluded dotfile
+` )
+
+    : !( Vec u ) PackErr pr ( pkg_pack root )
+    ?? pr {
+        F e → ( nurl_print ( pack_err_name e ) )
+        T gz → {
+            ( nurl_print `gz_nonempty=` ) ? > ( vec_len [u] gz ) 0 { ( nurl_print `T\n` ) } { ( nurl_print `F\n` ) }
+            : !( Vec u ) CompressErr ur ( gzip_decompress gz )
+            ?? ur {
+                F e → ( nurl_print ( compress_err_name e ) )
+                T raw → {
+                    : !( Vec TarEntry ) TarErr tp ( tar_parse raw )
+                    ?? tp {
+                        F e → ( nurl_print ( tar_err_name e ) )
+                        T ents → {
+                            ( nurl_print `count=` ) ( nurl_print_int ( vec_len [TarEntry] ents ) ) ( nurl_print `\n` )
+                            ( pb `has_nurl.toml` ( has_entry ents `nurl.toml` ) )
+                            ( pb `has_src/lib.nu` ( has_entry ents `src/lib.nu` ) )
+                            ( pb `excl_deps` ( has_entry ents `deps/foo/junk.nu` ) )
+                            ( pb `excl_dotfile` ( has_entry ents `.secret` ) )
+                            ( tar_entries_free ents )
+                        }
+                    }
+                    ( vec_free [u] raw )
+                }
+            }
+            ( vec_free [u] gz )
+        }
+    }
+    ( ignore_io ( dir_remove_all root ) )
+    ( nurl_print `done\n` )
+    ^ 0
+}

--- a/stdlib/ext/pkg_publish.nu
+++ b/stdlib/ext/pkg_publish.nu
@@ -1,0 +1,204 @@
+// stdlib/ext/pkg_publish.nu — package + authenticated publish (write side).
+//
+// `pkg_pack` walks a project directory, packs the source files into a
+// `.tar.gz` (the same format the install side fetches), and `pkg_publish`
+// uploads it to the registry's write endpoint with a Bearer token:
+//
+//   POST <registry>/api/v1/publish
+//   Authorization: Bearer <token>
+//   X-Nurl-Package: <name>
+//   X-Nurl-Version: <version>
+//   Content-Type: application/gzip
+//   <body = the .tar.gz bytes>
+//
+// The token is the caller's concern (CLI reads $NURL_TOKEN). The registry
+// recomputes the tarball's SHA-256 server-side — it never trusts a
+// client-supplied digest — and is responsible for name ownership +
+// immutability (a version may not be overwritten).
+//
+// Packaging excludes installed deps and VCS/build noise: `deps`, `.git`,
+// `nurl.lock`, `target`, `build`, and any dotfile/dotdir. Member paths use
+// the 100-byte USTAR `name` field (PackTooLong otherwise).
+//
+// API:
+//   ( pkg_pack root )                              → ! ( Vec u ) PackErr
+//   ( pkg_publish registry token tarball name ver ) → ! i PublishErr (0 = ok)
+//   ( pack_err_name e ) / ( publish_err_name e )    → s
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/tar.nu`
+$ `stdlib/ext/compress.nu`
+$ `stdlib/ext/http.nu`
+
+: | PackErr {
+    PackReadFailed   // dir_list / read_file failed
+    PackEmpty        // no files to pack
+    PackTarFailed    // tar_create rejected a path (too long) / failed
+    PackGzipFailed   // gzip_compress failed
+}
+
+: | PublishErr {
+    PubNoToken    // empty auth token
+    PubHttp       // transport failure
+    PubAuth       // 401 / 403
+    PubConflict   // 409 — version already published (immutability)
+    PubRejected   // other non-2xx
+}
+
+@ pack_err_name PackErr e → s {
+    ^ ?? e {
+        PackReadFailed → `PackReadFailed`
+        PackEmpty → `PackEmpty`
+        PackTarFailed → `PackTarFailed`
+        PackGzipFailed → `PackGzipFailed`
+    }
+}
+
+@ publish_err_name PublishErr e → s {
+    ^ ?? e {
+        PubNoToken → `PubNoToken`
+        PubHttp → `PubHttp`
+        PubAuth → `PubAuth`
+        PubConflict → `PubConflict`
+        PubRejected → `PubRejected`
+    }
+}
+
+// Names never packaged (installed deps, VCS, build output, dotfiles).
+@ __pack_ignored s name → b {
+    ? != 0 ( nurl_str_eq name `deps` ) { ^ T } {}
+    ? != 0 ( nurl_str_eq name `nurl.lock` ) { ^ T } {}
+    ? != 0 ( nurl_str_eq name `target` ) { ^ T } {}
+    ? != 0 ( nurl_str_eq name `build` ) { ^ T } {}
+    : i n ( nurl_str_len name )
+    ? > n 0 { ? == ( nurl_str_get name 0 ) 46 { ^ T } {} } {}   // leading '.'
+    ^ F
+}
+
+// Recursively collect files under `root`/`rel` into `out` as TarEntries
+// keyed by their path relative to `root`. Returns 0 on success, 1 on I/O
+// failure.
+@ __pack_collect s root s rel ( Vec TarEntry ) out → i {
+    : String dir ( string_from root )
+    ? > ( nurl_str_len rel ) 0 {
+        ( string_push_char dir 47 )
+        ( string_push_str dir rel )
+    } {}
+    : !( Vec String ) IoErr lr ( dir_list ( string_data dir ) )
+    : ~ i rc 0
+    ?? lr {
+        F _ → { = rc 1 }
+        T entries → {
+            : i n ( vec_len [String] entries )
+            : ~ i k 0
+            ~ < k n {
+                : ?String eo ( vec_get [String] entries k )
+                ?? eo {
+                    T nm → {
+                        : s nm_s ( string_data nm )
+                        ? ! ( __pack_ignored nm_s ) {
+                            : String relpath ( string_new )
+                            ? > ( nurl_str_len rel ) 0 {
+                                ( string_push_str relpath rel )
+                                ( string_push_char relpath 47 )
+                            } {}
+                            ( string_push_str relpath nm_s )
+                            : String full ( string_from root )
+                            ( string_push_char full 47 )
+                            ( string_push_str full ( string_data relpath ) )
+                            : i t ( nurl_path_type ( string_data full ) )
+                            ? == t 1 {
+                                : !( Vec u ) IoErr fb ( read_file_bytes ( string_data full ) )
+                                ?? fb {
+                                    T bytes → ( vec_push [TarEntry] out ( tar_entry_file ( string_data relpath ) bytes ) )
+                                    F _ → { = rc 1 }
+                                }
+                            } {
+                                ? == t 2 {
+                                    : i sub ( __pack_collect root ( string_data relpath ) out )
+                                    ? != sub 0 { = rc 1 } {}
+                                } {}
+                            }
+                            ( string_free relpath )
+                            ( string_free full )
+                        } {}
+                        ( string_free nm )
+                    }
+                    F → {}
+                }
+                = k + k 1
+            }
+            ( vec_free [String] entries )
+        }
+    }
+    ( string_free dir )
+    ^ rc
+}
+
+@ pkg_pack s root → !( Vec u ) PackErr {
+    : ( Vec TarEntry ) ents ( vec_new [TarEntry] )
+    : i cr ( __pack_collect root `` ents )
+    ? != cr 0 {
+        ( tar_entries_free ents )
+        ^ @ !( Vec u ) PackErr { F # PackErr PackReadFailed }
+    } {}
+    ? == ( vec_len [TarEntry] ents ) 0 {
+        ( tar_entries_free ents )
+        ^ @ !( Vec u ) PackErr { F # PackErr PackEmpty }
+    } {}
+    : !( Vec u ) TarErr tr ( tar_create ents )
+    ( tar_entries_free ents )
+    ?? tr {
+        F _ → ^ @ !( Vec u ) PackErr { F # PackErr PackTarFailed }
+        T arc → {
+            : !( Vec u ) CompressErr gr ( gzip_compress arc )
+            ( vec_free [u] arc )
+            ?? gr {
+                F _ → ^ @ !( Vec u ) PackErr { F # PackErr PackGzipFailed }
+                T gz → ^ @ !( Vec u ) PackErr { T gz }
+            }
+        }
+    }
+}
+
+// <registry>/api/v1/publish  (single '/' separator ensured)
+@ __publish_url s registry → String {
+    : String out ( string_with_cap 64 )
+    ( string_push_str out registry )
+    : i rn ( nurl_str_len registry )
+    ? > rn 0 { ? != ( nurl_str_get registry - rn 1 ) 47 { ( string_push_char out 47 ) } {} } {}
+    ( string_push_str out `api/v1/publish` )
+    ^ out
+}
+
+@ pkg_publish s registry s token ( Vec u ) tarball s name s version → !i PublishErr {
+    ? == ( nurl_str_len token ) 0 { ^ @ !i PublishErr { F # PublishErr PubNoToken } } {}
+    : String url ( __publish_url registry )
+    : String hb ( string_with_cap 200 )
+    ( string_push_str hb `Authorization: Bearer ` )
+    ( string_push_str hb token )
+    ( string_push_str hb `\r\n` )
+    ( string_push_str hb `X-Nurl-Package: ` )
+    ( string_push_str hb name )
+    ( string_push_str hb `\r\n` )
+    ( string_push_str hb `X-Nurl-Version: ` )
+    ( string_push_str hb version )
+    ( string_push_str hb `\r\n` )
+    ( string_push_str hb `Content-Type: application/gzip\r\n` )
+    : !Response HttpErr rr ( http_request_bytes `POST` ( string_data url ) tarball ( string_data hb ) )
+    ( string_free url )
+    ( string_free hb )
+    ?? rr {
+        F _ → ^ @ !i PublishErr { F # PublishErr PubHttp }
+        T resp → {
+            : i st ( http_status resp )
+            ( response_free resp )
+            ? & >= st 200 < st 300 { ^ @ !i PublishErr { T 0 } } {}
+            ? | == st 401 == st 403 { ^ @ !i PublishErr { F # PublishErr PubAuth } } {}
+            ? == st 409 { ^ @ !i PublishErr { F # PublishErr PubConflict } } {}
+            ^ @ !i PublishErr { F # PublishErr PubRejected }
+        }
+    }
+}

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -41,6 +41,9 @@ $ `stdlib/ext/semver.nu`
 $ `stdlib/ext/registry_index.nu`
 $ `stdlib/ext/resolver.nu`
 $ `stdlib/ext/pkg_fetch.nu`
+$ `stdlib/ext/pkg_publish.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/bytes.nu`
 
 // ── registry config ──────────────────────────────────────────────
 //
@@ -99,6 +102,7 @@ $ `stdlib/ext/pkg_fetch.nu`
     ( nurl_print `  nurlpkg deps           List dependencies, one per line.\n` )
     ( nurl_print `  nurlpkg install        Resolve path-deps and symlink them under ./deps/.\n` )
     ( nurl_print `  nurlpkg lock           Regenerate nurl.lock from the current deps/ tree.\n` )
+    ( nurl_print `  nurlpkg publish        Pack + upload this package to the registry ($NURL_TOKEN).\n` )
     ( nurl_print `  nurlpkg add <name> [--path P] [--version V]\n` )
     ( nurl_print `                         Add a dependency entry to nurl.toml.\n` )
     ( nurl_print `  nurlpkg remove <name>  Delete a dependency entry from nurl.toml.\n` )
@@ -1154,6 +1158,81 @@ $ `stdlib/ext/pkg_fetch.nu`
     ^ rc
 }
 
+// ── publish ─────────────────────────────────────────────────────
+//
+// Pack the current project into a .tar.gz and upload it to the registry's
+// write endpoint with the Bearer token from $NURL_TOKEN. The registry is
+// resolved like install ($NURL_REGISTRY → [package].registry → default).
+@ __cmd_publish → i {
+    ? ! ( file_exists `nurl.toml` ) {
+        ( nurl_eprintln `nurlpkg: no nurl.toml in the current directory` )
+        ^ 1
+    } {}
+    : !Manifest ManifestErr mr ( manifest_load `nurl.toml` )
+    : ~ i rc 0
+    ?? mr {
+        F e → {
+            ( nurl_eprint `nurlpkg: failed to parse nurl.toml (` )
+            ( nurl_eprint ( manifest_err_name e ) )
+            ( nurl_eprintln `)` )
+            = rc 1
+        }
+        T m → {
+            : ?String tok ( env_get `NURL_TOKEN` )
+            ?? tok {
+                F → {
+                    ( nurl_eprintln `nurlpkg: no auth token — set $NURL_TOKEN to publish` )
+                    = rc 1
+                }
+                T token → {
+                    : String reg ( __registry_url m )
+                    : !( Vec u ) PackErr pr ( pkg_pack `.` )
+                    ?? pr {
+                        F pe → {
+                            ( nurl_eprint `nurlpkg: packaging failed (` )
+                            ( nurl_eprint ( pack_err_name pe ) )
+                            ( nurl_eprintln `)` )
+                            = rc 1
+                        }
+                        T tarball → {
+                            : ( Vec u ) digest ( sha256_pure tarball )
+                            : String hex ( bytes_to_hex digest )
+                            ( nurl_print `publishing ` )
+                            ( nurl_print ( string_data . m name ) )
+                            ( nurl_print ` ` )
+                            ( nurl_print ( string_data . m version ) )
+                            ( nurl_print ` (` )
+                            ( nurl_print ( nurl_str_int ( vec_len [u] tarball ) ) )
+                            ( nurl_print ` bytes, sha256 ` )
+                            ( nurl_print ( string_data hex ) )
+                            ( nurl_print `)\nto ` )
+                            ( nurl_print ( string_data reg ) )
+                            ( nurl_print `\n` )
+                            : !i PublishErr ur ( pkg_publish ( string_data reg ) ( string_data token ) tarball ( string_data . m name ) ( string_data . m version ) )
+                            ?? ur {
+                                T _ → ( nurl_print `published.\n` )
+                                F ue → {
+                                    ( nurl_eprint `nurlpkg: publish failed (` )
+                                    ( nurl_eprint ( publish_err_name ue ) )
+                                    ( nurl_eprintln `)` )
+                                    = rc 1
+                                }
+                            }
+                            ( vec_free [u] digest )
+                            ( string_free hex )
+                            ( vec_free [u] tarball )
+                        }
+                    }
+                    ( string_free reg )
+                    ( string_free token )
+                }
+            }
+            ( manifest_free m )
+        }
+    }
+    ^ rc
+}
+
 @ __cmd_install → i {
     ? ! ( file_exists `nurl.toml` ) {
         ( nurl_eprintln `nurlpkg: no nurl.toml in the current directory (run 'nurlpkg init <name>' first)` )
@@ -1381,6 +1460,10 @@ $ `stdlib/ext/pkg_fetch.nu`
     ? != 0 ( nurl_str_eq s_sub `lock` ) {
         ( string_free sub )
         ^ ( __cmd_lock )
+    } {}
+    ? != 0 ( nurl_str_eq s_sub `publish` ) {
+        ( string_free sub )
+        ^ ( __cmd_publish )
     } {}
     ? != 0 ( nurl_str_eq s_sub `add` ) {
         // Parse: nurlpkg add <name> [--path P] [--version V]


### PR DESCRIPTION
The **write side** of the package registry, completing the pure-NURL client (ROADMAP §4 phase 5). Builds on the install side (phases 1–4b) already in main.

## What's new

**`stdlib/ext/pkg_publish.nu`**
- `pkg_pack root` — recursively packs a project tree into a `.tar.gz`, excluding `deps/`, `.git` & dotfiles, `nurl.lock`, `target/`, `build/`.
- `pkg_publish registry token tarball name version` — `POST <registry>/api/v1/publish` with `Authorization: Bearer <token>` + `X-Nurl-Package` / `X-Nurl-Version` headers and the tarball as a binary body (via `http_request_bytes`). Status → `PubAuth` (401/403) / `PubConflict` (409, version immutability) / `PubRejected`.

**`nurlpkg publish`** — packs the current project, prints size + SHA-256, and uploads using the token from `$NURL_TOKEN` and the registry from `$NURL_REGISTRY` → `[package].registry` → built-in default. A missing token or any non-2xx exits non-zero. The registry recomputes the checksum server-side — no client-supplied digest is trusted.

## Validation

- **`compiler/tests/pkg_pack_basic.nu`** — offline pack + gunzip + `tar_parse` membership (nested source included; `deps/` + dotfiles excluded). Clean under ASan/UBSan, leak-free. Full corpus green.
- **End-to-end against a static `python` registry**: a complete **publish → install round-trip** (a library packed, uploaded with a Bearer token, then resolved + installed into a consumer's `deps/`), plus immutability (409), bad-token (401), and no-token rejections — each exiting non-zero.

This is the exact wire contract the Cloudflare Worker + R2 write endpoint (phase 6) will implement. No compiler/runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)