### PR TITLE
fix(ci): registry-deploy workflow — secrets not allowed in if:

### DIFF
--- a/.github/workflows/registry-deploy.yml
+++ b/.github/workflows/registry-deploy.yml
@@ -17,24 +17,34 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # Skip if the deploy token hasn't been configured yet (placeholder).
-    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_API_TOKEN != 'REPLACE_ME' }}
+    # `secrets` can't be used in an `if:` directly, so derive a boolean in
+    # job-level `env` (which may read secrets) and gate each step on it.
+    # When the deploy token is unset / still the REPLACE_ME placeholder the
+    # steps skip and the job is a green no-op.
+    env:
+      DEPLOY_ENABLED: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_API_TOKEN != 'REPLACE_ME' }}
     defaults:
       run:
         working-directory: registry
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - if: env.DEPLOY_ENABLED == 'true'
+        uses: actions/checkout@v4
+      - if: env.DEPLOY_ENABLED == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npm ci
-      - run: npx tsc --noEmit
+      - if: env.DEPLOY_ENABLED == 'true'
+        run: npm ci
+      - if: env.DEPLOY_ENABLED == 'true'
+        run: npx tsc --noEmit
       - name: Apply D1 migrations
+        if: env.DEPLOY_ENABLED == 'true'
         run: npx wrangler d1 migrations apply REG_DB --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Deploy
+        if: env.DEPLOY_ENABLED == 'true'
         run: npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
GitHub flagged the workflow as invalid: `Unrecognized named-value: 'secrets'` at the job-level `if:`. The `secrets` context isn't available in `if:` expressions (only `github`/`needs`/`vars`/`inputs`).

Fix: derive a boolean in **job-level `env`** (which *may* reference `secrets`) and gate each step on `env.DEPLOY_ENABLED == 'true'` (step-level `if:` *can* read `env`). Behaviour is unchanged — when `CLOUDFLARE_API_TOKEN` is unset or still `REPLACE_ME`, every step skips and the job is a green no-op. YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)