### PR TITLE
feat(nurlpkg): transitive registry deps via X-Nurl-Deps on publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Transitive registry dependencies — `nurlpkg publish` sends `X-Nurl-Deps`.**
+  Publishing now includes the manifest's registry dependencies (a JSON
+  `[{name, req}]` built by `__deps_json`) as the `X-Nurl-Deps` header, which
+  the registry records in the package index. `pkg_publish` gained a
+  `deps_json` parameter. With the deps in the index, `resolve_registry`
+  pulls **sub-dependencies transitively** — previously the index always
+  recorded `deps: []`, so only leaf registry packages installed correctly.
+  Verified end-to-end against the local Cloudflare Worker: publish `tdep-b`,
+  publish `tdep-a` (depends on `tdep-b ^1.0`), then `install` a consumer of
+  only `tdep-a` → both land in `deps/` and the lock. Registry now supports
+  real dependency graphs. `stdlib/ext/pkg_publish.nu`, `tools/nurlpkg/main.nu`.
+
 - **Package registry service — Cloudflare Worker + R2 + D1 (`registry/`,
   ROADMAP §4 phase 6).** The deployable server side of the ecosystem, in
   TypeScript. The read path serves the static `index/<name>.json` +

--- a/stdlib/ext/pkg_publish.nu
+++ b/stdlib/ext/pkg_publish.nu
@@ -8,6 +8,7 @@
 //   Authorization: Bearer <token>
 //   X-Nurl-Package: <name>
 //   X-Nurl-Version: <version>
+//   X-Nurl-Deps: [{"name":"bar","req":"^0.3"}]   (registry deps; for the index)
 //   Content-Type: application/gzip
 //   <body = the .tar.gz bytes>
 //
@@ -22,7 +23,7 @@
 //
 // API:
 //   ( pkg_pack root )                              → ! ( Vec u ) PackErr
-//   ( pkg_publish registry token tarball name ver ) → ! i PublishErr (0 = ok)
+//   ( pkg_publish registry token tarball name ver deps_json ) → ! i PublishErr (0 = ok)
 //   ( pack_err_name e ) / ( publish_err_name e )    → s
 
 $ `stdlib/core/string.nu`
@@ -173,10 +174,14 @@ $ `stdlib/ext/http.nu`
     ^ out
 }
 
-@ pkg_publish s registry s token ( Vec u ) tarball s name s version → !i PublishErr {
+// `deps_json` is a JSON array of { name, req } for this package's registry
+// dependencies (built by the caller from the manifest), sent as
+// X-Nurl-Deps so the registry records them in the index and transitive
+// registry resolution works. Pass `[]` (or empty) for none.
+@ pkg_publish s registry s token ( Vec u ) tarball s name s version s deps_json → !i PublishErr {
     ? == ( nurl_str_len token ) 0 { ^ @ !i PublishErr { F # PublishErr PubNoToken } } {}
     : String url ( __publish_url registry )
-    : String hb ( string_with_cap 200 )
+    : String hb ( string_with_cap 256 )
     ( string_push_str hb `Authorization: Bearer ` )
     ( string_push_str hb token )
     ( string_push_str hb `\r\n` )
@@ -186,6 +191,11 @@ $ `stdlib/ext/http.nu`
     ( string_push_str hb `X-Nurl-Version: ` )
     ( string_push_str hb version )
     ( string_push_str hb `\r\n` )
+    ? > ( nurl_str_len deps_json ) 0 {
+        ( string_push_str hb `X-Nurl-Deps: ` )
+        ( string_push_str hb deps_json )
+        ( string_push_str hb `\r\n` )
+    } {}
     ( string_push_str hb `Content-Type: application/gzip\r\n` )
     : !Response HttpErr rr ( http_request_bytes `POST` ( string_data url ) tarball ( string_data hb ) )
     ( string_free url )

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -80,6 +80,38 @@ $ `stdlib/std/bytes.nu`
     ^ c
 }
 
+// Build the X-Nurl-Deps JSON array of { name, req } from a manifest's
+// REGISTRY dependencies (path deps are local and not part of the published
+// package's index entry). Names/reqs are simple tokens (no JSON-special
+// chars), so a direct build is safe. Empty deps → "[]".
+@ __deps_json Manifest m → String {
+    : String out ( string_with_cap 64 )
+    ( string_push_char out 91 )    // [
+    : i n ( vec_len [Dep] . m dependencies )
+    : ~ i first 1
+    : ~ i k 0
+    ~ < k n {
+        : ?Dep dk ( vec_get [Dep] . m dependencies k )
+        ?? dk {
+            T d → {
+                ? ( dep_is_registry d ) {
+                    ? == first 0 { ( string_push_char out 44 ) } {}    // ,
+                    = first 0
+                    ( string_push_str out `{"name":"` )
+                    ( string_push_str out ( string_data . d name ) )
+                    ( string_push_str out `","req":"` )
+                    ( string_push_str out ( string_data . d version ) )
+                    ( string_push_str out `"}` )
+                } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( string_push_char out 93 )    // ]
+    ^ out
+}
+
 // Index of the registry LockPkg named `name`, or -1.
 @ __reg_lookup ( Vec LockPkg ) regpkgs s name → i {
     : i n ( vec_len [LockPkg] regpkgs )
@@ -1208,7 +1240,9 @@ $ `stdlib/std/bytes.nu`
                             ( nurl_print `)\nto ` )
                             ( nurl_print ( string_data reg ) )
                             ( nurl_print `\n` )
-                            : !i PublishErr ur ( pkg_publish ( string_data reg ) ( string_data token ) tarball ( string_data . m name ) ( string_data . m version ) )
+                            : String deps_json ( __deps_json m )
+                            : !i PublishErr ur ( pkg_publish ( string_data reg ) ( string_data token ) tarball ( string_data . m name ) ( string_data . m version ) ( string_data deps_json ) )
+                            ( string_free deps_json )
                             ?? ur {
                                 T _ → ( nurl_print `published.\n` )
                                 F ue → {


### PR DESCRIPTION
Closes the last functional gap in the registry: **transitive registry dependencies now resolve**.

`nurlpkg publish` sends the manifest's registry deps as an `X-Nurl-Deps` JSON header (`[{name, req}]`). The Worker already records that into the package index, and `resolve_registry` already walks index deps — so sub-dependencies pull transitively. Before, the index always stored `deps: []`, so only **leaf** registry packages installed correctly.

- `pkg_publish` gains a `deps_json` parameter (sent as `X-Nurl-Deps` when non-empty).
- `__deps_json` in nurlpkg builds the array from the manifest's registry deps (path deps stay local).

**Verified end-to-end against the local Cloudflare Worker**: publish `tdep-b`, publish `tdep-a` (depends on `tdep-b ^1.0` — `index/tdep-a.json` records it), then `install` a consumer of only `tdep-a` → **both** `tdep-a` and `tdep-b` land in `deps/` + the lock. Full corpus green; `nurlpkg` + `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)