### PR TITLE
feat(pkg): package manager → MLP — login/search/info, yank, token-revoke, catalog UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Package manager → MLP: login/search/info, yank, token-revoke, catalog UI
+  (ROADMAP §4).** Rounds the registry out into a minimum *lovable* product.
+  - **CLI ergonomics.** `nurlpkg login` stores a per-registry publish token
+    in `~/.nurl/credentials` (chmod 600) — `publish`/`yank` resolve the token
+    `$NURL_TOKEN` → credentials, so it no longer has to live in the
+    environment. `nurlpkg logout [--revoke]` forgets it (and optionally
+    revokes it server-side). `nurlpkg search <q>` and `nurlpkg info <name>`
+    query the registry (`info` with no arg still prints the local manifest).
+    New `stdlib/ext/credentials.nu`.
+  - **Registry hygiene.** `nurlpkg yank|unyank <name> <version>` flips a
+    version's yanked flag (owner-only, via `POST /api/v1/{yank,unyank}`); the
+    resolver already skips yanked versions, so a yanked release disappears
+    from resolution. `nurlpkg logout --revoke` (`POST /api/v1/revoke`) deletes
+    the presented token from D1.
+  - **Catalog UI.** The Worker's `/` is now a searchable package list and
+    `/packages/<name>` a detail page (versions with yank state, latest
+    dependencies, an install snippet); `GET /api/v1/search?q=` backs the CLI.
+  - Client helpers: `pkg_search` (`pkg_fetch.nu`), `pkg_yank` / `pkg_revoke`
+    (`pkg_publish.nu`). Regression `compiler/tests/credentials_basic.nu`
+    (set/get/upsert/multi-registry/remove; gated `NURL_CREDS_TESTS=1`, clean
+    under ASan/UBSan). Whole feature set verified end-to-end against the
+    Worker under `wrangler dev`: login → creds-based publish → search → info
+    → yank (install then fails ResolveNoMatch) → unyank → catalog → logout
+    --revoke → publish rejected (PubAuth).
+
 - **Transitive registry dependencies — `nurlpkg publish` sends `X-Nurl-Deps`.**
   Publishing now includes the manifest's registry dependencies (a JSON
   `[{name, req}]` built by `__deps_json`) as the `X-Nurl-Deps` header, which

--- a/compiler/tests/credentials_basic.nu
+++ b/compiler/tests/credentials_basic.nu
@@ -1,0 +1,45 @@
+// credentials_basic.nu — ~/.nurl/credentials set / get / upsert / remove.
+//
+// Writes under $HOME/.nurl, so it is GATED behind NURL_CREDS_TESTS=1 (and
+// meant to be run with HOME pointed at a throwaway dir) to never touch a
+// real credentials file during the default corpus run.
+
+$ `stdlib/ext/credentials.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/core/string.nu`
+
+@ ignore !v IoErr r → v { ?? r { T _ → {} F _ → {} } }
+
+@ show s label s reg → v {
+    : String t ( creds_get reg )
+    ( nurl_print label ) ( nurl_print `=` )
+    ? > ( string_len t ) 0 { ( nurl_print ( string_data t ) ) } { ( nurl_print `<none>` ) }
+    ( nurl_print `\n` )
+    ( string_free t )
+}
+
+@ run → v {
+    : s r1 `https://reg.a/`
+    : s r2 `https://reg.b/`
+    ( ignore ( creds_set r1 `tok-a1` ) )
+    ( show `a` r1 )                 // tok-a1
+    ( ignore ( creds_set r2 `tok-b1` ) )
+    ( show `a_keep` r1 )            // tok-a1 (still there after 2nd registry)
+    ( show `b` r2 )                 // tok-b1
+    ( ignore ( creds_set r1 `tok-a2` ) )
+    ( show `a_upsert` r1 )          // tok-a2 (replaced, not duplicated)
+    ( show `b_keep` r2 )            // tok-b1
+    ( ignore ( creds_remove r1 ) )
+    ( show `a_removed` r1 )         // <none>
+    ( show `b_final` r2 )           // tok-b1
+    ( ignore ( creds_remove r2 ) )
+}
+
+@ main → i {
+    : ?String g ( env_get `NURL_CREDS_TESTS` )
+    ?? g {
+        T s → { ( string_free s ) ( run ) ( nurl_print `done\n` ) }
+        F → { ( nurl_print `credentials test skipped (set NURL_CREDS_TESTS=1)\n` ) }
+    }
+    ^ 0
+}

--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -162,12 +162,110 @@ async function handlePublish(req: Request, env: Env): Promise<Response> {
 
 // ── GitHub OAuth (token bootstrap) ────────────────────────────────────
 
-function htmlPage(title: string, bodyHtml: string): Response {
+function htmlPage(title: string, bodyHtml: string, status = 200): Response {
   return new Response(
     `<!doctype html><meta charset=utf-8><title>${title}</title>` +
       `<body style="font-family:system-ui;max-width:42rem;margin:3rem auto;padding:0 1rem">${bodyHtml}</body>`,
-    { headers: { "content-type": "text/html; charset=utf-8" } },
+    { status, headers: { "content-type": "text/html; charset=utf-8" } },
   );
+}
+
+function esc(s: string): string {
+  return s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]!));
+}
+
+// ── Catalog UI + search ───────────────────────────────────────────────
+
+interface CatalogRow { name: string; latest: string | null; }
+
+// Most-recently-published non-yanked version per package (display only).
+const LATEST_SUBQUERY =
+  `(SELECT v.version FROM versions v WHERE v.name = p.name AND v.yanked = 0
+      ORDER BY v.published_at DESC LIMIT 1)`;
+
+async function handleCatalog(url: URL, env: Env): Promise<Response> {
+  const q = (url.searchParams.get("q") ?? "").toLowerCase().slice(0, 64);
+  const like = q ? `%${q.replace(/[%_\\]/g, "")}%` : "%";
+  const rows = await env.REG_DB.prepare(
+    `SELECT p.name AS name, ${LATEST_SUBQUERY} AS latest
+       FROM packages p WHERE p.name LIKE ? ORDER BY p.name LIMIT 200`,
+  ).bind(like).all<CatalogRow>();
+  const items = rows.results ?? [];
+  const list = items.length
+    ? `<ul>${items.map((p) =>
+        `<li><a href="/packages/${esc(p.name)}">${esc(p.name)}</a> ` +
+        (p.latest ? `<code>${esc(p.latest)}</code>` : `<em>(all versions yanked)</em>`) + `</li>`).join("")}</ul>`
+    : `<p>No packages${q ? ` matching “${esc(q)}”` : " published"} yet.</p>`;
+  return htmlPage("NURL registry",
+    `<h1>NURL package registry</h1>` +
+    `<form method=get><input name=q value="${esc(q)}" placeholder="search packages" ` +
+      `style="padding:.4rem;width:60%"> <button>Search</button></form>` +
+    `<p style="color:#666">${items.length} package(s) · <a href="/login">get a publish token →</a></p>` +
+    list);
+}
+
+async function handlePackageDetail(env: Env, name: string): Promise<Response> {
+  if (!NAME_RE.test(name)) return htmlPage("not found", `<p>Invalid package name.</p>`, 404);
+  const idx = await readIndex(env, name);
+  if (idx.versions.length === 0) {
+    return htmlPage("not found", `<p><a href="/">← all packages</a></p><h1>${esc(name)}</h1><p>Not found.</p>`, 404);
+  }
+  const newestFirst = [...idx.versions].reverse();
+  const latest = newestFirst.find((v) => !v.yanked);
+  const versionsHtml = newestFirst.map((v) =>
+    `<li><code>${esc(v.version)}</code>${v.yanked ? ` <span style="color:#b00">(yanked)</span>` : ""}</li>`).join("");
+  const depsHtml = latest && latest.deps.length
+    ? `<ul>${latest.deps.map((d) =>
+        `<li><a href="/packages/${esc(d.name)}">${esc(d.name)}</a> <code>${esc(d.req)}</code></li>`).join("")}</ul>`
+    : `<p>None.</p>`;
+  const reqStr = latest ? `^${latest.version}` : "*";
+  return htmlPage(name,
+    `<p><a href="/">← all packages</a></p><h1>${esc(name)}</h1>` +
+    `<h3>Install</h3><pre style="background:#f4f4f4;padding:1rem;border-radius:6px">` +
+      `[dependencies]\n${esc(name)} = "${esc(reqStr)}"</pre>` +
+    `<h3>Versions</h3><ul>${versionsHtml}</ul>` +
+    `<h3>Dependencies (latest)</h3>${depsHtml}`);
+}
+
+async function handleSearch(url: URL, env: Env): Promise<Response> {
+  const q = (url.searchParams.get("q") ?? "").toLowerCase().slice(0, 64);
+  const like = q ? `%${q.replace(/[%_\\]/g, "")}%` : "%";
+  const rows = await env.REG_DB.prepare(
+    `SELECT p.name AS name, ${LATEST_SUBQUERY} AS latest
+       FROM packages p WHERE p.name LIKE ? ORDER BY p.name LIMIT 50`,
+  ).bind(like).all<CatalogRow>();
+  return json({ results: (rows.results ?? []).map((r) => ({ name: r.name, version: r.latest })) });
+}
+
+// ── Yank / unyank (owner-only) + token revoke ─────────────────────────
+
+async function handleYank(req: Request, env: Env, yank: boolean): Promise<Response> {
+  const user = await userFromAuth(req, env);
+  if (!user) return json({ error: "unauthorized" }, 401);
+  const name = (req.headers.get("x-nurl-package") ?? "").toLowerCase();
+  const version = req.headers.get("x-nurl-version") ?? "";
+  if (!NAME_RE.test(name)) return json({ error: "invalid_name" }, 400);
+  if (!VERSION_RE.test(version)) return json({ error: "invalid_version" }, 400);
+  const owner = await env.REG_DB.prepare(`SELECT owner_user_id FROM packages WHERE name = ?`)
+    .bind(name).first<{ owner_user_id: number }>();
+  if (!owner) return json({ error: "not_found" }, 404);
+  if (owner.owner_user_id !== user.id) return json({ error: "not_owner" }, 403);
+  const res = await env.REG_DB.prepare(`UPDATE versions SET yanked = ? WHERE name = ? AND version = ?`)
+    .bind(yank ? 1 : 0, name, version).run();
+  if ((res.meta?.changes ?? 0) === 0) return json({ error: "version_not_found" }, 404);
+  const idx = await readIndex(env, name);
+  for (const v of idx.versions) if (v.version === version) v.yanked = yank;
+  await env.REG_BUCKET.put(`index/${name}.json`, JSON.stringify(idx));
+  return json({ ok: true, name, version, yanked: yank });
+}
+
+async function handleRevoke(req: Request, env: Env): Promise<Response> {
+  const m = (req.headers.get("authorization") ?? "").match(/^Bearer\s+(.+)$/i);
+  if (!m) return json({ error: "unauthorized" }, 401);
+  const hash = await hashToken(m[1].trim(), env.TOKEN_PEPPER);
+  const res = await env.REG_DB.prepare(`DELETE FROM tokens WHERE token_hash = ?`).bind(hash).run();
+  if ((res.meta?.changes ?? 0) === 0) return json({ error: "unknown_token" }, 401);
+  return json({ ok: true, revoked: true });
 }
 
 function handleLogin(env: Env): Response {
@@ -242,11 +340,13 @@ export default {
     const path = url.pathname;
 
     if (req.method === "GET") {
-      if (path === "/") {
-        return htmlPage("NURL registry", `<h1>NURL package registry</h1><p>Visit <a href="/login">/login</a> to get a publish token.</p>`);
-      }
+      if (path === "/") return handleCatalog(url, env);
       if (path === "/login") return handleLogin(env);
       if (path === "/auth/callback") return handleCallback(req, env);
+      if (path === "/api/v1/search") return handleSearch(url, env);
+      if (path.startsWith("/packages/")) {
+        return handlePackageDetail(env, decodeURIComponent(path.slice("/packages/".length)).toLowerCase());
+      }
       if (path.startsWith("/index/") && path.endsWith(".json")) {
         const name = path.slice("/index/".length, -".json".length).toLowerCase();
         if (!NAME_RE.test(name)) return json({ error: "invalid_name" }, 400);
@@ -260,8 +360,11 @@ export default {
       return json({ error: "not_found" }, 404);
     }
 
-    if (req.method === "POST" && path === "/api/v1/publish") {
-      return handlePublish(req, env);
+    if (req.method === "POST") {
+      if (path === "/api/v1/publish") return handlePublish(req, env);
+      if (path === "/api/v1/yank") return handleYank(req, env, true);
+      if (path === "/api/v1/unyank") return handleYank(req, env, false);
+      if (path === "/api/v1/revoke") return handleRevoke(req, env);
     }
     return json({ error: "not_found" }, 404);
   },

--- a/stdlib/ext/credentials.nu
+++ b/stdlib/ext/credentials.nu
@@ -1,0 +1,168 @@
+// stdlib/ext/credentials.nu — per-registry auth tokens in ~/.nurl/credentials.
+//
+// `nurlpkg login` stores a registry's publish token here so `publish` /
+// `yank` don't need $NURL_TOKEN in the environment (and out of shell
+// history). The file is one record per line, TAB-separated:
+//
+//   <registry-url>\t<token>\n
+//
+// chmod 600 on write (owner-only). Token lookup order in the CLI is
+// $NURL_TOKEN first, then this file keyed by the exact registry URL.
+//
+// API:
+//   ( creds_path )                      → String   ~/.nurl/credentials
+//   ( creds_get registry )              → String   token, or "" if none
+//   ( creds_set registry token )        → ! v IoErr   (upsert, chmod 600)
+//   ( creds_remove registry )           → ! v IoErr
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+
+& `c` @ chmod s path i mode → i
+
+@ __creds_home → String {
+    : ?String h ( env_get `HOME` )
+    ^ ?? h {
+        T hv → { ? > ( string_len hv ) 0 hv { ( string_free hv ) ( string_from `.` ) } }
+        F → ( string_from `.` )
+    }
+}
+
+@ __creds_dir → String {
+    : String d ( __creds_home )
+    ( string_push_str d `/.nurl` )
+    ^ d
+}
+
+@ creds_path → String {
+    : String p ( __creds_dir )
+    ( string_push_str p `/credentials` )
+    ^ p
+}
+
+// Rebuild `content` with every line for `registry` removed (and blank
+// lines dropped). Used by both set (then append) and remove.
+@ __creds_without String content s registry → String {
+    : String out ( string_new )
+    : ( Vec String ) lines ( string_split content `\n` )
+    : i n ( vec_len [String] lines )
+    : ~ i k 0
+    ~ < k n {
+        : ?String lo ( vec_get [String] lines k )
+        ?? lo {
+            T line → {
+                ? > ( string_len line ) 0 {
+                    : ?i tab ( string_index_of line `\t` )
+                    : ~ i keep 1
+                    ?? tab {
+                        T ti → {
+                            : String reg ( string_substr line 0 ti )
+                            ? != 0 ( nurl_str_eq ( string_data reg ) registry ) { = keep 0 } {}
+                            ( string_free reg )
+                        }
+                        F → {}
+                    }
+                    ? != keep 0 {
+                        ( string_push_str out ( string_data line ) )
+                        ( string_push_char out 10 )
+                    } {}
+                } {}
+                ( string_free line )
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [String] lines )
+    ^ out
+}
+
+@ creds_get s registry → String {
+    : String path ( creds_path )
+    : !String IoErr rr ( read_file ( string_data path ) )
+    ( string_free path )
+    : ~ String out ( string_new )
+    ?? rr {
+        T content → {
+            : ( Vec String ) lines ( string_split content `\n` )
+            : i n ( vec_len [String] lines )
+            : ~ i k 0
+            ~ < k n {
+                : ?String lo ( vec_get [String] lines k )
+                ?? lo {
+                    T line → {
+                        : ?i tab ( string_index_of line `\t` )
+                        ?? tab {
+                            T ti → {
+                                : String reg ( string_substr line 0 ti )
+                                ? != 0 ( nurl_str_eq ( string_data reg ) registry ) {
+                                    ( string_free out )
+                                    = out ( string_substr line + ti 1 - ( string_len line ) + ti 1 )
+                                } {}
+                                ( string_free reg )
+                            }
+                            F → {}
+                        }
+                        ( string_free line )
+                    }
+                    F → {}
+                }
+                = k + k 1
+            }
+            ( vec_free [String] lines )
+            ( string_free content )
+        }
+        F → {}
+    }
+    ^ out
+}
+
+@ creds_set s registry s token → !v IoErr {
+    : String dir ( __creds_dir )
+    : !v IoErr dr ( dir_create_all ( string_data dir ) )
+    ( string_free dir )
+    ?? dr { T _ → {} F e → { ^ @ !v IoErr { F e } } }
+
+    : String path ( creds_path )
+    : ~ String body ( string_new )
+    : !String IoErr rr ( read_file ( string_data path ) )
+    ?? rr {
+        T content → {
+            ( string_free body )
+            = body ( __creds_without content registry )
+            ( string_free content )
+        }
+        F → {}
+    }
+    ( string_push_str body registry )
+    ( string_push_char body 9 )    // TAB
+    ( string_push_str body token )
+    ( string_push_char body 10 )   // \n
+    : !v IoErr wr ( write_file ( string_data path ) ( string_data body ) )
+    ( chmod ( string_data path ) 384 )    // 0600
+    ( string_free body )
+    ( string_free path )
+    ^ wr
+}
+
+@ creds_remove s registry → !v IoErr {
+    : String path ( creds_path )
+    : !String IoErr rr ( read_file ( string_data path ) )
+    : ~ i rc 0
+    ?? rr {
+        T content → {
+            : String body ( __creds_without content registry )
+            : !v IoErr wr ( write_file ( string_data path ) ( string_data body ) )
+            ?? wr { T _ → {} F _ → { = rc 1 } }
+            ( chmod ( string_data path ) 384 )
+            ( string_free body )
+            ( string_free content )
+        }
+        F → {}    // no file → nothing to remove
+    }
+    ( string_free path )
+    ? != rc 0 { ^ @ !v IoErr { F # IoErr WriteFailed } } {}
+    ^ @ !v IoErr { T 0 }
+}

--- a/stdlib/ext/pkg_fetch.nu
+++ b/stdlib/ext/pkg_fetch.nu
@@ -136,3 +136,30 @@ $ `stdlib/ext/registry_index.nu`
         }
     }
 }
+
+// ── Search (read side) ────────────────────────────────────────────────
+
+// GET <registry>/api/v1/search?q=<query> → the JSON body, or "" on
+// non-200 / transport failure. Caller parses the {"results":[...]} JSON.
+@ pkg_search s registry s query → String {
+    : String url ( string_with_cap 80 )
+    ( string_push_str url registry )
+    : i rn ( nurl_str_len registry )
+    ? > rn 0 { ? != ( nurl_str_get registry - rn 1 ) 47 { ( string_push_char url 47 ) } {} } {}
+    ( string_push_str url `api/v1/search?q=` )
+    ( string_push_str url query )
+    : !Response HttpErr rr ( http_get ( string_data url ) )
+    ( string_free url )
+    ?? rr {
+        T resp → {
+            : ~ String out ( string_new )
+            ? == ( http_status resp ) 200 {
+                ( string_free out )
+                = out ( string_from ( http_body_str resp ) )
+            } {}
+            ( response_free resp )
+            ^ out
+        }
+        F → ^ ( string_new )
+    }
+}

--- a/stdlib/ext/pkg_publish.nu
+++ b/stdlib/ext/pkg_publish.nu
@@ -212,3 +212,72 @@ $ `stdlib/ext/http.nu`
         }
     }
 }
+
+// ── Yank / unyank / token revoke (authenticated, no body) ─────────────
+
+@ __reg_api_url s registry s path → String {
+    : String out ( string_with_cap 64 )
+    ( string_push_str out registry )
+    : i rn ( nurl_str_len registry )
+    ? > rn 0 { ? != ( nurl_str_get registry - rn 1 ) 47 { ( string_push_char out 47 ) } {} } {}
+    ( string_push_str out path )
+    ^ out
+}
+
+@ __pub_status_map i st → !i PublishErr {
+    ? & >= st 200 < st 300 { ^ @ !i PublishErr { T 0 } } {}
+    ? | == st 401 == st 403 { ^ @ !i PublishErr { F # PublishErr PubAuth } } {}
+    ? == st 409 { ^ @ !i PublishErr { F # PublishErr PubConflict } } {}
+    ^ @ !i PublishErr { F # PublishErr PubRejected }
+}
+
+// POST <registry>/api/v1/revoke — deletes the presented token server-side.
+@ pkg_revoke s registry s token → !i PublishErr {
+    ? == ( nurl_str_len token ) 0 { ^ @ !i PublishErr { F # PublishErr PubNoToken } } {}
+    : String url ( __reg_api_url registry `api/v1/revoke` )
+    : String hb ( string_with_cap 96 )
+    ( string_push_str hb `Authorization: Bearer ` )
+    ( string_push_str hb token )
+    ( string_push_str hb `\r\n` )
+    : !Response HttpErr rr ( http_request `POST` ( string_data url ) `` ( string_data hb ) )
+    ( string_free url )
+    ( string_free hb )
+    ?? rr {
+        F _ → ^ @ !i PublishErr { F # PublishErr PubHttp }
+        T resp → {
+            : i st ( http_status resp )
+            ( response_free resp )
+            ^ ( __pub_status_map st )
+        }
+    }
+}
+
+// POST <registry>/api/v1/{yank,unyank} — owner-only; flips the version's
+// yanked flag (the resolver then skips yanked versions). `yank` != 0 to
+// yank, 0 to unyank.
+@ pkg_yank s registry s token s name s version i yank → !i PublishErr {
+    ? == ( nurl_str_len token ) 0 { ^ @ !i PublishErr { F # PublishErr PubNoToken } } {}
+    : s ep ? != yank 0 `api/v1/yank` `api/v1/unyank`
+    : String url ( __reg_api_url registry ep )
+    : String hb ( string_with_cap 160 )
+    ( string_push_str hb `Authorization: Bearer ` )
+    ( string_push_str hb token )
+    ( string_push_str hb `\r\n` )
+    ( string_push_str hb `X-Nurl-Package: ` )
+    ( string_push_str hb name )
+    ( string_push_str hb `\r\n` )
+    ( string_push_str hb `X-Nurl-Version: ` )
+    ( string_push_str hb version )
+    ( string_push_str hb `\r\n` )
+    : !Response HttpErr rr ( http_request `POST` ( string_data url ) `` ( string_data hb ) )
+    ( string_free url )
+    ( string_free hb )
+    ?? rr {
+        F _ → ^ @ !i PublishErr { F # PublishErr PubHttp }
+        T resp → {
+            : i st ( http_status resp )
+            ( response_free resp )
+            ^ ( __pub_status_map st )
+        }
+    }
+}

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -42,6 +42,9 @@ $ `stdlib/ext/registry_index.nu`
 $ `stdlib/ext/resolver.nu`
 $ `stdlib/ext/pkg_fetch.nu`
 $ `stdlib/ext/pkg_publish.nu`
+$ `stdlib/ext/credentials.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/core/io.nu`
 $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/bytes.nu`
 
@@ -66,6 +69,28 @@ $ `stdlib/std/bytes.nu`
         ^ ( string_from ( string_data . m registry ) )
     } {}
     ^ ( string_from ( __default_registry ) )
+}
+
+// Registry for project-independent commands (login/search/yank): the
+// $NURL_REGISTRY override, else the built-in default.
+@ __reg_default → String {
+    : ?String ev ( env_get `NURL_REGISTRY` )
+    ?? ev {
+        T e → { ? > ( string_len e ) 0 { ^ e } { ( string_free e ) } }
+        F → {}
+    }
+    ^ ( string_from ( __default_registry ) )
+}
+
+// Publish/yank auth token: $NURL_TOKEN first, then the stored credential
+// for `registry` (from `nurlpkg login`). Returns "" if neither is set.
+@ __resolve_token s registry → String {
+    : ?String ev ( env_get `NURL_TOKEN` )
+    ?? ev {
+        T e → { ? > ( string_len e ) 0 { ^ e } { ( string_free e ) } }
+        F → {}
+    }
+    ^ ( creds_get registry )
 }
 
 @ __count_registry ( Vec Dep ) deps → i {
@@ -134,7 +159,12 @@ $ `stdlib/std/bytes.nu`
     ( nurl_print `  nurlpkg deps           List dependencies, one per line.\n` )
     ( nurl_print `  nurlpkg install        Resolve path-deps and symlink them under ./deps/.\n` )
     ( nurl_print `  nurlpkg lock           Regenerate nurl.lock from the current deps/ tree.\n` )
-    ( nurl_print `  nurlpkg publish        Pack + upload this package to the registry ($NURL_TOKEN).\n` )
+    ( nurl_print `  nurlpkg publish        Pack + upload this package to the registry.\n` )
+    ( nurl_print `  nurlpkg login          Store a publish token in ~/.nurl/credentials.\n` )
+    ( nurl_print `  nurlpkg logout [--revoke]  Forget the local token (and optionally revoke it).\n` )
+    ( nurl_print `  nurlpkg search <q>     Search the registry for packages.\n` )
+    ( nurl_print `  nurlpkg info <name>    Show a package's published versions.\n` )
+    ( nurl_print `  nurlpkg yank|unyank <name> <version>  Hide/unhide a published version.\n` )
     ( nurl_print `  nurlpkg add <name> [--path P] [--version V]\n` )
     ( nurl_print `                         Add a dependency entry to nurl.toml.\n` )
     ( nurl_print `  nurlpkg remove <name>  Delete a dependency entry from nurl.toml.\n` )
@@ -1190,11 +1220,171 @@ $ `stdlib/std/bytes.nu`
     ^ rc
 }
 
+// ── login / logout ───────────────────────────────────────────────
+
+@ __cmd_login → i {
+    : String reg ( __reg_default )
+    ( nurl_print `Registry: ` ) ( nurl_print ( string_data reg ) ) ( nurl_print `\n` )
+    ( nurl_print `Paste a publish token (get one at <registry>/login): ` )
+    : String token ( read_line )
+    : ~ i rc 0
+    ? == ( string_len token ) 0 {
+        ( nurl_eprintln `nurlpkg: empty token; aborted` )
+        = rc 1
+    } {
+        : !v IoErr sr ( creds_set ( string_data reg ) ( string_data token ) )
+        ?? sr {
+            T _ → {
+                : String p ( creds_path )
+                ( nurl_print `Saved token to ` ) ( nurl_print ( string_data p ) ) ( nurl_print `\n` )
+                ( string_free p )
+            }
+            F _ → { ( nurl_eprintln `nurlpkg: failed to write credentials` ) = rc 1 }
+        }
+    }
+    ( string_free token )
+    ( string_free reg )
+    ^ rc
+}
+
+@ __cmd_logout i revoke → i {
+    : String reg ( __reg_default )
+    : ~ i rc 0
+    ? != revoke 0 {
+        : String tok ( creds_get ( string_data reg ) )
+        ? > ( string_len tok ) 0 {
+            : !i PublishErr rr ( pkg_revoke ( string_data reg ) ( string_data tok ) )
+            ?? rr {
+                T _ → ( nurl_print `Revoked token server-side.\n` )
+                F e → { ( nurl_eprint `nurlpkg: revoke failed (` ) ( nurl_eprint ( publish_err_name e ) ) ( nurl_eprintln `)` ) = rc 1 }
+            }
+        } { ( nurl_print `No stored token to revoke.\n` ) }
+        ( string_free tok )
+    } {}
+    : !v IoErr cr ( creds_remove ( string_data reg ) )
+    ?? cr {
+        T _ → ( nurl_print `Removed local credential.\n` )
+        F _ → { ( nurl_eprintln `nurlpkg: failed to update credentials` ) = rc 1 }
+    }
+    ( string_free reg )
+    ^ rc
+}
+
+// ── search / info ────────────────────────────────────────────────
+
+@ __cmd_search s query → i {
+    : String reg ( __reg_default )
+    : String body ( pkg_search ( string_data reg ) query )
+    : ~ i rc 0
+    ? == ( string_len body ) 0 {
+        ( nurl_eprintln `nurlpkg: search failed (no response)` )
+        = rc 1
+    } {
+        : !Json JsonError jr ( json_parse ( string_data body ) )
+        ?? jr {
+            F _ → { ( nurl_eprintln `nurlpkg: bad search response` ) = rc 1 }
+            T root → {
+                : ?Json ra ( json_obj_get root `results` )
+                ?? ra {
+                    T arr → {
+                        : i n ( json_arr_len arr )
+                        ? == n 0 { ( nurl_print `No matches.\n` ) } {}
+                        : ~ i k 0
+                        ~ < k n {
+                            : ?Json eo ( json_arr_get arr k )
+                            ?? eo {
+                                T e → {
+                                    : ?Json no ( json_obj_get e `name` )
+                                    ?? no { T nm → ( nurl_print ( json_as_str nm ) ) F → {} }
+                                    : ?Json vo ( json_obj_get e `version` )
+                                    ?? vo { T vv → { ( nurl_print `  ` ) ( nurl_print ( json_as_str vv ) ) } F → {} }
+                                    ( nurl_print `\n` )
+                                }
+                                F → {}
+                            }
+                            = k + k 1
+                        }
+                    }
+                    F → {}
+                }
+                ( json_free root )
+            }
+        }
+    }
+    ( string_free body )
+    ( string_free reg )
+    ^ rc
+}
+
+@ __cmd_registry_info s name → i {
+    : String reg ( __reg_default )
+    : String body ( pkg_fetch_index ( string_data reg ) name )
+    : ~ i rc 0
+    ? == ( string_len body ) 0 {
+        ( nurl_eprint `nurlpkg: package not found: ` ) ( nurl_eprintln name )
+        = rc 1
+    } {
+        : !RegIndex RegIndexErr ir ( regindex_parse ( string_data body ) )
+        ?? ir {
+            F _ → { ( nurl_eprintln `nurlpkg: bad index response` ) = rc 1 }
+            T idx → {
+                ( nurl_print ( string_data . idx name ) ) ( nurl_print `\nversions:\n` )
+                : i n ( vec_len [IdxVersion] . idx versions )
+                : ~ i k 0
+                ~ < k n {
+                    : ?IdxVersion vo ( vec_get [IdxVersion] . idx versions k )
+                    ?? vo {
+                        T v → {
+                            ( nurl_print `  ` ) ( nurl_print ( string_data . v version ) )
+                            ? . v yanked { ( nurl_print ` (yanked)` ) } {}
+                            ( nurl_print `\n` )
+                        }
+                        F → {}
+                    }
+                    = k + k 1
+                }
+                ( regindex_free idx )
+            }
+        }
+    }
+    ( string_free body )
+    ( string_free reg )
+    ^ rc
+}
+
+// ── yank / unyank ────────────────────────────────────────────────
+
+@ __cmd_yank s name s version i yank → i {
+    : String reg ( __reg_default )
+    : String token ( __resolve_token ( string_data reg ) )
+    : ~ i rc 0
+    ? == ( string_len token ) 0 {
+        ( nurl_eprintln `nurlpkg: no auth token — run 'nurlpkg login' or set $NURL_TOKEN` )
+        = rc 1
+    } {
+        : !i PublishErr yr ( pkg_yank ( string_data reg ) ( string_data token ) name version yank )
+        ?? yr {
+            T _ → {
+                ( nurl_print ? != yank 0 `yanked ` `unyanked ` )
+                ( nurl_print name ) ( nurl_print ` ` ) ( nurl_print version ) ( nurl_print `\n` )
+            }
+            F e → {
+                ( nurl_eprint `nurlpkg: ` ) ( nurl_eprint ? != yank 0 `yank` `unyank` )
+                ( nurl_eprint ` failed (` ) ( nurl_eprint ( publish_err_name e ) ) ( nurl_eprintln `)` )
+                = rc 1
+            }
+        }
+    }
+    ( string_free token )
+    ( string_free reg )
+    ^ rc
+}
+
 // ── publish ─────────────────────────────────────────────────────
 //
 // Pack the current project into a .tar.gz and upload it to the registry's
-// write endpoint with the Bearer token from $NURL_TOKEN. The registry is
-// resolved like install ($NURL_REGISTRY → [package].registry → default).
+// write endpoint. The token comes from $NURL_TOKEN or `nurlpkg login`; the
+// registry from $NURL_REGISTRY → [package].registry → default.
 @ __cmd_publish → i {
     ? ! ( file_exists `nurl.toml` ) {
         ( nurl_eprintln `nurlpkg: no nurl.toml in the current directory` )
@@ -1210,14 +1400,12 @@ $ `stdlib/std/bytes.nu`
             = rc 1
         }
         T m → {
-            : ?String tok ( env_get `NURL_TOKEN` )
-            ?? tok {
-                F → {
-                    ( nurl_eprintln `nurlpkg: no auth token — set $NURL_TOKEN to publish` )
-                    = rc 1
-                }
-                T token → {
-                    : String reg ( __registry_url m )
+            : String reg ( __registry_url m )
+            : String token ( __resolve_token ( string_data reg ) )
+            ? == ( string_len token ) 0 {
+                ( nurl_eprintln `nurlpkg: no auth token — run 'nurlpkg login' or set $NURL_TOKEN` )
+                = rc 1
+            } {
                     : !( Vec u ) PackErr pr ( pkg_pack `.` )
                     ?? pr {
                         F pe → {
@@ -1257,10 +1445,9 @@ $ `stdlib/std/bytes.nu`
                             ( vec_free [u] tarball )
                         }
                     }
-                    ( string_free reg )
-                    ( string_free token )
-                }
             }
+            ( string_free reg )
+            ( string_free token )
             ( manifest_free m )
         }
     }
@@ -1480,6 +1667,14 @@ $ `stdlib/std/bytes.nu`
         ^ rc
     } {}
     ? != 0 ( nurl_str_eq s_sub `info` ) {
+        // `info` (no arg) → local manifest; `info <name>` → registry package.
+        ? >= argc 3 {
+            : String name ( env_arg 2 )
+            : i rc ( __cmd_registry_info ( string_data name ) )
+            ( string_free name )
+            ( string_free sub )
+            ^ rc
+        } {}
         ( string_free sub )
         ^ ( __cmd_info )
     } {}
@@ -1498,6 +1693,44 @@ $ `stdlib/std/bytes.nu`
     ? != 0 ( nurl_str_eq s_sub `publish` ) {
         ( string_free sub )
         ^ ( __cmd_publish )
+    } {}
+    ? != 0 ( nurl_str_eq s_sub `login` ) {
+        ( string_free sub )
+        ^ ( __cmd_login )
+    } {}
+    ? != 0 ( nurl_str_eq s_sub `logout` ) {
+        // nurlpkg logout [--revoke]
+        : ~ i revoke 0
+        ? >= argc 3 {
+            : String f ( env_arg 2 )
+            ? != 0 ( nurl_str_eq ( string_data f ) `--revoke` ) { = revoke 1 } {}
+            ( string_free f )
+        } {}
+        ( string_free sub )
+        ^ ( __cmd_logout revoke )
+    } {}
+    ? != 0 ( nurl_str_eq s_sub `search` ) {
+        : ~ String q ( string_new )
+        ? >= argc 3 { = q ( env_arg 2 ) } {}
+        : i rc ( __cmd_search ( string_data q ) )
+        ( string_free q )
+        ( string_free sub )
+        ^ rc
+    } {}
+    ? | != 0 ( nurl_str_eq s_sub `yank` ) != 0 ( nurl_str_eq s_sub `unyank` ) {
+        : i yk ( nurl_str_eq s_sub `yank` )
+        ? < argc 4 {
+            ( nurl_eprintln `nurlpkg: usage: nurlpkg yank|unyank <name> <version>` )
+            ( string_free sub )
+            ^ 1
+        } {}
+        : String name ( env_arg 2 )
+        : String version ( env_arg 3 )
+        : i rc ( __cmd_yank ( string_data name ) ( string_data version ) yk )
+        ( string_free version )
+        ( string_free name )
+        ( string_free sub )
+        ^ rc
     } {}
     ? != 0 ( nurl_str_eq s_sub `add` ) {
         // Parse: nurlpkg add <name> [--path P] [--version V]


### PR DESCRIPTION
Rounds the live registry into a **Minimum Lovable Product**, covering all three goal areas in one solution. Builds on the live registry (publish/install/transitive deps) already in main.

## CLI ergonomics
- **`nurlpkg login`** — stores a per-registry publish token in `~/.nurl/credentials` (chmod 600). `publish`/`yank` resolve the token `$NURL_TOKEN` → credentials, so it no longer has to sit in the environment. New `stdlib/ext/credentials.nu`.
- **`nurlpkg logout [--revoke]`** — forgets the local token; `--revoke` also deletes it server-side.
- **`nurlpkg search <q>`** and **`nurlpkg info <name>`** query the registry (`info` with no arg still prints the local manifest).

## Registry hygiene
- **`nurlpkg yank|unyank <name> <version>`** (owner-only, `POST /api/v1/{yank,unyank}`) flips a version's yanked flag in D1 + the index; the resolver already skips yanked versions, so a yank removes a release from resolution.
- **Token revoke** — `nurlpkg logout --revoke` → `POST /api/v1/revoke` deletes the presented token from D1.

## Catalog UI
- The Worker's **`/`** is now a searchable package list and **`/packages/<name>`** a detail page (versions with yank state, latest dependencies, an install snippet). `GET /api/v1/search?q=` backs the CLI.

## Validation
- `compiler/tests/credentials_basic.nu` (set/get/upsert/multi-registry/remove; gated `NURL_CREDS_TESTS=1`) — clean under ASan/UBSan, leak-free. It caught a real `String`-vs-`s` type bug in the creds rewriter. Worker `tsc` clean; full corpus green.
- **End-to-end against the Worker under `wrangler dev`** (miniflare R2 + D1): login → creds-based publish → search → info → yank (install then fails `ResolveNoMatch`) → unyank → catalog → `logout --revoke` → publish rejected (`PubAuth`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)