### PR TITLE
ci: GitHub Actions deploy for playground API on v* tags

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -1,0 +1,89 @@
+name: Deploy playground API
+
+# Builds the NURL toolchain image (nurlapi/Dockerfile), pushes it to Docker Hub
+# under an explicit semver tag (nurllang/nurl:v1.2.3 — no :latest), then pins
+# cloudflare/Dockerfile's FROM to that exact tag and deploys the Cloudflare
+# Container Worker in cloudflare/. Pinning makes each deploy reproducible.
+# Triggered by pushing a v* tag, or manually via the Actions tab.
+#
+# Required GitHub Actions repo secrets:
+#   DOCKERHUB_USERNAME, DOCKERHUB_TOKEN  — Docker Hub push credentials
+#   CLOUDFLARE_API_TOKEN                 — token with Workers + Containers edit rights
+#   CLOUDFLARE_ACCOUNT_ID                — Cloudflare account id
+# When CLOUDFLARE_API_TOKEN is unset / still the REPLACE_ME placeholder every
+# step skips and the job is a green no-op (e.g. on forks).
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # `secrets` can't be used in an `if:` directly, so derive a boolean in
+    # job-level `env` and gate each step on it.
+    env:
+      DEPLOY_ENABLED: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_API_TOKEN != 'REPLACE_ME' }}
+    steps:
+      - if: env.DEPLOY_ENABLED == 'true'
+        uses: actions/checkout@v4
+
+      # Tag pushes give v1.2.3; a manual run on a branch has no tag, so fall
+      # back to a short-sha label for the image version tag.
+      - name: Derive image version tag
+        if: env.DEPLOY_ENABLED == 'true'
+        id: ver
+        run: |
+          v="${GITHUB_REF_NAME}"
+          case "$v" in v*) ;; *) v="manual-$(git rev-parse --short HEAD)";; esac
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - if: env.DEPLOY_ENABLED == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: env.DEPLOY_ENABLED == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & push API image
+        if: env.DEPLOY_ENABLED == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: nurlapi/Dockerfile
+          push: true
+          tags: nurllang/nurl:${{ steps.ver.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - if: env.DEPLOY_ENABLED == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Cloudflare deps
+        if: env.DEPLOY_ENABLED == 'true'
+        working-directory: cloudflare
+        run: npm ci
+
+      # Point the container image at the exact tag we just pushed (no :latest),
+      # so this deploy is reproducible. The edit is ephemeral (CI checkout only).
+      - name: Pin container image to released version
+        if: env.DEPLOY_ENABLED == 'true'
+        run: |
+          sed -i -E "s#^FROM docker\.io/nurllang/nurl:.*#FROM docker.io/nurllang/nurl:${{ steps.ver.outputs.version }}#" cloudflare/Dockerfile
+          grep '^FROM' cloudflare/Dockerfile
+
+      # wrangler pulls the pinned image, retags it into the Cloudflare managed
+      # registry and deploys the Worker + Container.
+      - name: Deploy to Cloudflare
+        if: env.DEPLOY_ENABLED == 'true'
+        working-directory: cloudflare
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/registry-deploy.yml
+++ b/.github/workflows/registry-deploy.yml
@@ -1,17 +1,16 @@
 name: Deploy registry Worker
 
-# Deploys the NURL package registry (registry/) to Cloudflare on pushes to
-# main that touch it. Requires two GitHub Actions repo secrets (placeholders
-# are pre-created; fill them in Settings → Secrets and variables → Actions):
+# Deploys the NURL package registry (registry/) to Cloudflare. The registry
+# changes rarely, so this is triggered manually from the Actions tab
+# (Run workflow) rather than on every push. Requires two GitHub Actions repo
+# secrets (placeholders are pre-created; fill them in Settings → Secrets and
+# variables → Actions):
 #   CLOUDFLARE_API_TOKEN   — a token with Workers + R2 + D1 edit rights
 #   CLOUDFLARE_ACCOUNT_ID  — your Cloudflare account id
 # Runtime secrets (GITHUB_CLIENT_SECRET, TOKEN_PEPPER) are NOT here — they
 # are set once with `wrangler secret put` (see registry/DEPLOY.md).
 
 on:
-  push:
-    branches: [main]
-    paths: ["registry/**", ".github/workflows/registry-deploy.yml"]
   workflow_dispatch: {}
 
 jobs:

--- a/cloudflare/Dockerfile
+++ b/cloudflare/Dockerfile
@@ -2,6 +2,10 @@
 # on pääsy — `wrangler deploy` vetää tämän imagen (Docker Hub), uudelleen-
 # tagittaa sen Cloudflaren managed-rekisteriin ja julkaisee sen.
 #
-# Hindurable/nurl kuuntelee porttia 8000, joka on määritelty
+# nurllang/nurl kuuntelee porttia 8000, joka on määritelty
 # src/index.ts:n NurlContainer.defaultPort-kentässä.
-FROM docker.io/hindurable/nurl:latest
+#
+# HUOM: api-deploy.yml -workflow ylikirjoittaa alla olevan tägin julkaistuun
+# semveriin (esim. :v0.9.5) ennen deployta — tuotannon deploy ei käytä :latestiä.
+# :latest jää vain paikallisen dockerpush.sh-fallbackin oletukseksi.
+FROM docker.io/nurllang/nurl:latest

--- a/dockerpush.sh
+++ b/dockerpush.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Build the API image and push it to Docker Hub under hindurable/nurl:latest.
+# Build the API image and push it to Docker Hub under nurllang/nurl:latest.
 # Run from the repo root. Requires `docker login` to have been done once.
 set -euo pipefail
 
-IMAGE="hindurable/nurl:latest"
+IMAGE="nurllang/nurl:latest"
 
 cd "$(dirname "$0")"
 

--- a/nurlapi.sh
+++ b/nurlapi.sh
@@ -51,7 +51,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-IMAGE="hindurable/nurl"
+IMAGE="nurllang/nurl"
 HOST_PORT=8000
 NO_CACHE=""
 RM_FLAG=""

--- a/startdev.bat
+++ b/startdev.bat
@@ -1,2 +1,2 @@
-docker build -f api/Dockerfile -t hindurable/nurl:latest .
-docker run --rm -p 8000:8000 hindurable/nurl:latest
+docker build -f nurlapi/Dockerfile -t nurllang/nurl:latest .
+docker run --rm -p 8000:8000 nurllang/nurl:latest

--- a/startdev.sh
+++ b/startdev.sh
@@ -1,2 +1,2 @@
-docker build -f nurlapi/Dockerfile -t hindurable/nurl:latest .
-docker run --rm -p 8000:8000 hindurable/nurl:latest
+docker build -f nurlapi/Dockerfile -t nurllang/nurl:latest .
+docker run --rm -p 8000:8000 nurllang/nurl:latest


### PR DESCRIPTION
## Mitä

Automatisoi playground/API-deployn (`cloudflare/`, play.nurl-lang.org) GitHub Actioniksi. Aiemmin manuaalinen: `dockerpush.sh` + `cd cloudflare && npx wrangler deploy`.

## Muutokset

- **Uusi `.github/workflows/api-deploy.yml`** — laukeaa `v*`-tägillä (+ `workflow_dispatch`):
  1. buildaa `nurlapi/Dockerfile`n (buildx + `type=gha` layer-cache)
  2. pushaa Docker Hubiin **vain semver-tägillä** `nurllang/nurl:vX.Y.Z` (ei `:latest`)
  3. pinnaa `cloudflare/Dockerfile`n `FROM`-tägin tuohon versioon (sed, ephemeral) → deploy on toistettava
  4. `npm ci && npx wrangler deploy` `cloudflare/`-kansiossa
  - Sama secret-gated no-op -kuvio kuin `registry-deploy.yml`:ssä (vihreä no-op jos `CLOUDFLARE_API_TOKEN` puuttuu)
- **Docker image `hindurable/nurl` → `nurllang/nurl`** (`startdev.sh`/`.bat`, `dockerpush.sh`, `nurlapi.sh`, `cloudflare/Dockerfile`); korjattu `startdev.bat`:n vanha `api/Dockerfile`-polku
- **`registry-deploy.yml` manuaaliseksi** (`workflow_dispatch` only) — rekisteri muuttuu harvoin

## Secretit

Tarvitsee repo-secretit: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` (lisätty), `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` (jo olemassa).

## Testaus

Mergen jälkeen `api-deploy.yml` näkyy Actions-välilehdellä → "Run workflow" (workflow_dispatch) manuaaliajoa varten. Manuaaliajo tägittää imagen muotoon `manual-<sha>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)