### PR TITLE
release: v0.9.5 — playground version pill + CHANGELOG

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -57,6 +57,7 @@ jobs:
           file: nurlapi/Dockerfile
           push: true
           tags: nurllang/nurl:${{ steps.ver.outputs.version }}
+          build-args: NURL_VERSION=${{ steps.ver.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.5] — 2026-06-04
+
 ### Added
+
+- **Playground shows its deployed version, and the API auto-deploys on
+  release tags.** The playground header now carries a version pill — a
+  `__NURL_VERSION__` placeholder in `index.html` is stamped at image-build
+  time from the `NURL_VERSION` build-arg (`dev` for local builds). A new
+  `.github/workflows/api-deploy.yml` builds the API image on a `v*` tag (or
+  manual dispatch), pushes it to Docker Hub under the exact semver
+  (`nurllang/nurl:vX.Y.Z` — no `:latest`), pins `cloudflare/Dockerfile`'s
+  `FROM` to that tag and runs `wrangler deploy`, so a git tag is now a
+  reproducible playground release. The Docker image was renamed
+  `hindurable/nurl` → `nurllang/nurl`; `registry-deploy.yml` is now
+  manual-only (the registry changes rarely).
+
+- **MQTT-over-WebSocket transport — `mqtt_connect_ws`.** Adds a WebSocket
+  transport alongside the raw TCP/TLS path so a client can reach a broker's
+  MQTT-over-WS endpoint (e.g. `wss://host:8084/mqtt`) — handy when a firewall
+  only permits the WS port inbound. `wss://` enables TLS with certificate
+  verification and negotiates the `mqtt` subprotocol automatically; the codec
+  and framed packet reader stay transport-blind behind two chokepoints. New
+  entrypoints `mqtt_connect_ws` / `mqtt_connect_ws_cfg`; `mqtt_disconnect`
+  also sends a WS Close frame, and `mqtt_reconnect` rejects WS clients (no URL
+  to redo the upgrade). `stdlib/ext/mqtt.nu`.
 
 - **Package manager → MLP: login/search/info, yank, token-revoke, catalog UI
   (ROADMAP §4).** Rounds the registry out into a minimum *lovable* product.

--- a/nurlapi/Dockerfile
+++ b/nurlapi/Dockerfile
@@ -200,6 +200,11 @@ WORKDIR /app
 COPY --from=builder /src/nurlapi/nurlapi /app/nurlapi
 COPY --from=builder /src/nurlapi/static /app/static
 
+# Stamp the deployed version into the playground UI. api-deploy.yml passes the
+# released semver via --build-arg NURL_VERSION=vX.Y.Z; local builds get "dev".
+ARG NURL_VERSION=dev
+RUN sed -i "s/__NURL_VERSION__/${NURL_VERSION}/g" /app/static/index.html
+
 # Bring in all cross-compilation artifacts
 RUN mkdir -p /opt/nurl/build /opt/nurl/stdlib /app/output /opt/nurl/examples /opt/nurl/compiler /opt/nurl/spec /opt/nurl/docs
 COPY --from=builder /src/build/nurlc             /opt/nurl/build/nurlc

--- a/nurlapi/static/index.html
+++ b/nurlapi/static/index.html
@@ -41,6 +41,11 @@
   }
   .status-pill.ok { color: var(--accent-2); border-color: #2b4a2a; }
   .status-pill.bad { color: var(--err); border-color: #4a2b2b; }
+  .ver-pill {
+    font-size: .72rem; color: var(--accent); cursor: default;
+    padding: .2rem .5rem; border: 1px solid var(--border); border-radius: 999px;
+    font-variant-numeric: tabular-nums;
+  }
 
   main {
     flex: 1; display: grid;
@@ -140,6 +145,10 @@
 <body>
 <header>
   <h1>NURL Playground</h1>
+  <!-- Version pill: the token below is replaced at image build time from the
+       NURL_VERSION build-arg (api-deploy.yml passes the released semver;
+       local builds default to "dev"). -->
+  <span id="version" class="ver-pill" title="Deployed NURL version">__NURL_VERSION__</span>
   <span id="health" class="status-pill">checking…</span>
   <div class="spacer"></div>
   <a href="/readme" target="_blank" rel="noopener">README</a>


### PR DESCRIPTION
## Mitä

Valmistelee `v0.9.5`-releasen ja lisää playgroundiin versionäytön.

## Muutokset

- **Playground-versionäyttö.** Headeriin version-pill; `index.html`:n `__NURL_VERSION__`-placeholder leimataan image-buildissa `NURL_VERSION`-build-argista (`nurlapi/Dockerfile`). `api-deploy.yml` antaa argiksi julkaistun semverin → tägäyksen jälkeen playground näyttää aina deployatun version. Paikallisbuildit saavat `dev`.
- **CHANGELOG.** `[Unreleased]` → `## [0.9.5] — 2026-06-04`, uusi tyhjä `[Unreleased]`. Lisätty kaksi vielä kirjaamatonta kohtaa:
  - playground-versionäyttö + API:n auto-deploy-workflow
  - **MQTT-over-WebSocket** -transport (`mqtt_connect_ws`)

## Testaus tägäyksellä (mergen jälkeen)

`git tag v0.9.5 && git push origin v0.9.5` → `api-deploy.yml` buildaa imagen, pushaa `nurllang/nurl:v0.9.5`, pinnaa `cloudflare/Dockerfile`n ja deployaa. play.nurl-lang.org:n headerissa pitäisi näkyä `v0.9.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)