### PR TITLE
feat(rng): seedable deterministic PRNG — std/rng.nu (xoshiro256**)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Seedable, deterministic PRNG — `stdlib/std/rng.nu` (xoshiro256\*\*).**
+  Companion to `std/random.nu`'s OS CSPRNG, which draws from the kernel
+  entropy pool and *cannot be seeded*. `rng.nu` gives a reproducible stream:
+  `( rng_seed s )` expands any i64 seed into a 256-bit xoshiro256\*\* state
+  via SplitMix64 (so even `0`/`1` produce well-distributed, uncorrelated
+  streams), and the same seed yields a **byte-identical sequence on every
+  platform and build** — the determinism guarantee extends here because the
+  generator is integer-only (no float state, `>>` lowers to a logical
+  `lshr` on the `u64`-typed words). Surface: `rng_next` (raw 64-bit),
+  `rng_below` (unbiased, rejection-sampled `[0,n)`), `rng_range`, `rng_u01`
+  (uniform double in `[0,1)`, 53-bit), `rng_bool`, `rng_free`. Opaque-handle
+  lifecycle (same shape as `Arena`/`Channel`/`String`); state mutates in
+  place. **Not** a CSPRNG — predictable, so never for security; use
+  `std/random.nu` there. Regression `compiler/tests/rng_seedable.nu` pins
+  the exact stream for seeds `0` and `0x1234` against an independent
+  reference implementation, and checks determinism, `rng_below` bounds, and
+  the inverted-range guard.
+
 ## [0.9.5] — 2026-06-04
 
 ### Added

--- a/compiler/tests/rng_seedable.nu
+++ b/compiler/tests/rng_seedable.nu
@@ -1,0 +1,109 @@
+// Regression: std/rng.nu — seedable deterministic PRNG (xoshiro256**).
+//
+// xoshiro256** seeded via SplitMix64 is a fully specified, portable
+// algorithm: a given seed must produce a byte-identical stream on every
+// platform and every build. The expected values below were computed by
+// an independent reference implementation of the same algorithm; this
+// test pins NURL's output to them. A drift here means either the u64
+// codegen (logical `lshr` for `>>`, wrapping `mul`/`add`, `rotl` via
+// shift-or) or the seeding regressed — both silent-miscompile classes.
+//
+// Also guards the field-vs-index `.` aliasing footgun: rng_next's locals
+// are deliberately named `w*` so they don't shadow the `s*` field names
+// (a shadow turns `. st s0` from a field load into a pointer index).
+//
+// Covers: exact stream for seeds 0 and 0x1234; determinism (two
+// generators, one seed → identical streams); rng_below bounds + zero
+// guard; rng_range inverted-range guard.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/rng.nu`
+
+// Compare; print a line and return 1 on mismatch, 0 on match.
+@ chk i got i want s label → i {
+    ? == got want {
+        ^ 0
+    } {
+        ( nurl_print `FAIL ` )
+        ( nurl_print label )
+        ( nurl_print ` got=` )
+        ( nurl_print ( nurl_str_int got ) )
+        ( nurl_print ` want=` )
+        ( nurl_print ( nurl_str_int want ) )
+        ( nurl_print `\n` )
+        ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i fails 0
+
+    // ── Exact stream, seed 0 ────────────────────────────────────────
+    : Rng g0 ( rng_seed 0 )
+    = fails + fails ( chk ( rng_next g0 ) -7355399402456485196 `seed0[0]` )
+    = fails + fails ( chk ( rng_next g0 ) -4652746763540216534 `seed0[1]` )
+    = fails + fails ( chk ( rng_next g0 ) 1900383378846508768 `seed0[2]` )
+    = fails + fails ( chk ( rng_next g0 ) 7684712102626143532 `seed0[3]` )
+    = fails + fails ( chk ( rng_next g0 ) -4925340083591827879 `seed0[4]` )
+    ( rng_free g0 )
+
+    // ── Exact stream, seed 0x1234 ───────────────────────────────────
+    : Rng g1 ( rng_seed 0x1234 )
+    = fails + fails ( chk ( rng_next g1 ) -3525385174084883479 `seed1[0]` )
+    = fails + fails ( chk ( rng_next g1 ) -5997322183977983201 `seed1[1]` )
+    = fails + fails ( chk ( rng_next g1 ) 1717958663746102582 `seed1[2]` )
+    = fails + fails ( chk ( rng_next g1 ) -1912904096732430461 `seed1[3]` )
+    = fails + fails ( chk ( rng_next g1 ) -7012801589984659952 `seed1[4]` )
+    ( rng_free g1 )
+
+    // ── Determinism: same seed → identical streams ──────────────────
+    : Rng a ( rng_seed 42 )
+    : Rng b ( rng_seed 42 )
+    : ~ i k 0
+    ~ < k 64 {
+        = fails + fails ( chk ( rng_next a ) ( rng_next b ) `det` )
+        = k + k 1
+    }
+    ( rng_free a )
+    ( rng_free b )
+
+    // ── rng_below: in-range + zero guard ────────────────────────────
+    : Rng r ( rng_seed 7 )
+    = k 0
+    ~ < k 1000 {
+        : i v ( rng_below r 6 )
+        ? | < v 0 >= v 6 {
+            = fails + fails 1
+            ( nurl_print `FAIL rng_below out of [0,6)\n` )
+        } {}
+        = k + k 1
+    }
+    // n <= 0 → 0
+    = fails + fails ( chk ( rng_below r 0 ) 0 `below0` )
+    = fails + fails ( chk ( rng_below r -3 ) 0 `belowNeg` )
+
+    // ── rng_range: inverted range returns `from` ────────────────────
+    = fails + fails ( chk ( rng_range r 10 10 ) 10 `rangeEmpty` )
+    = fails + fails ( chk ( rng_range r 10 5 ) 10 `rangeInverted` )
+    // valid range stays in [100, 110)
+    = k 0
+    ~ < k 500 {
+        : i v ( rng_range r 100 110 )
+        ? | < v 100 >= v 110 {
+            = fails + fails 1
+            ( nurl_print `FAIL rng_range out of [100,110)\n` )
+        } {}
+        = k + k 1
+    }
+    ( rng_free r )
+
+    ? == fails 0 {
+        ( nurl_print `rng: all checks passed\n` )
+        ^ 0
+    } {
+        ( nurl_print `rng: ` )
+        ( nurl_print ( nurl_str_int fails ) )
+        ( nurl_print ` checks FAILED\n` )
+        ^ 1
+    }
+}

--- a/stdlib/std/rng.nu
+++ b/stdlib/std/rng.nu
@@ -1,0 +1,182 @@
+// stdlib/std/rng.nu — seedable, deterministic PRNG (xoshiro256**)
+//
+// Companion to `std/random.nu`'s OS CSPRNG. The CSPRNG draws from the
+// kernel entropy pool and *cannot be seeded* — it's the right tool for
+// keys, nonces, and tokens, but useless when you need a *reproducible*
+// stream: simulations you can replay, property tests with a recorded
+// seed, procedural generation, shuffles you can audit. This module fills
+// that gap with a small, fast, seedable generator.
+//
+// Algorithm: xoshiro256** (Blackman & Vigna, 2018) — 256 bits of state,
+// 2^256-1 period, passes BigCrush. The seed (a single i64) is expanded
+// into the 256-bit state with SplitMix64, the seeding routine the
+// xoshiro authors recommend, so even a low-entropy seed like `0` or `1`
+// produces a well-distributed state. Same seed → byte-identical stream
+// on every platform, every build (NURL's determinism guarantee extends
+// here: integer ops only, no float state, no UB).
+//
+// This is NOT a CSPRNG. Its output is statistically excellent but
+// predictable: never use it for anything security-sensitive — reach for
+// `std/random.nu` there.
+//
+//   ( rng_seed seed )            → Rng    seed a generator (any i64 seed)
+//   ( rng_next g )               → i       next 64-bit value; the bit
+//                                          pattern is uniform over all
+//                                          2^64 values, returned in a
+//                                          signed i (reinterpret as
+//                                          unsigned for hex / packing).
+//   ( rng_below g n )            → i       uniform in [0, n); 0 if n <= 0.
+//                                          Unbiased (rejection-sampled).
+//   ( rng_range g from to )      → i       uniform in [from, to) when
+//                                          from < to; otherwise `from`.
+//   ( rng_u01 g )                → f       uniform double in [0, 1),
+//                                          53-bit mantissa resolution.
+//   ( rng_bool g )               → b       fair coin flip.
+//   ( rng_free g )               → v       release the generator.
+//
+// Lifecycle (opaque-handle pattern, same as Arena / Channel / String):
+//
+//   : Rng g ( rng_seed 0x1234 )
+//   : i a ( rng_next g )          // mutates g's state in place
+//   : i b ( rng_next g )          // a != b; stream is deterministic
+//   ( rng_free g )
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/mem.nu`
+
+// ── State ────────────────────────────────────────────────────────────
+
+// 256-bit xoshiro state. Heap-allocated; `Rng` is a single-pointer
+// handle, so passing a Rng by value shares the same stream (every copy
+// advances the one underlying state).
+: RngImpl {
+    u64 s0
+    u64 s1
+    u64 s2
+    u64 s3
+}
+
+: Rng { s ctl }
+
+// ── Bit primitives ───────────────────────────────────────────────────
+
+// Rotate a 64-bit word left by `k` bits. `x` is u64, so `>>` lowers to
+// a logical (zero-filling) shift — an arithmetic shift would corrupt the
+// rotate for words with the high bit set.
+@ __rotl u64 x i k → u64 {
+    ^ | << x k >> x - 64 k
+}
+
+// SplitMix64 finalizing mix (Steele/Lea/Vigna). Given the running
+// additive state `z`, produce one well-mixed 64-bit output. Used only to
+// expand the seed into the xoshiro state; the increment lives in
+// `rng_seed`.
+@ __splitmix_mix u64 z → u64 {
+    : ~ u64 x z
+    = x * ^^ x >> x 30 0xbf58476d1ce4e5b9
+    = x * ^^ x >> x 27 0x94d049bb133111eb
+    ^ ^^ x >> x 31
+}
+
+// ── Construction ─────────────────────────────────────────────────────
+
+// Seed a generator. Any i64 seed is acceptable, including 0: SplitMix64
+// diffuses it across all 256 state bits, so adjacent seeds (0, 1, 2 …)
+// yield uncorrelated streams. The all-zero xoshiro state is degenerate
+// (it would stay zero forever); SplitMix64 never emits it for any seed,
+// so no special-case is needed.
+@ rng_seed i seed → Rng {
+    : *RngImpl st # *RngImpl ( nurl_alloc Z RngImpl )
+    : ~ u64 sm # u64 seed
+    = sm + sm 0x9e3779b97f4a7c15
+    = . st s0 ( __splitmix_mix sm )
+    = sm + sm 0x9e3779b97f4a7c15
+    = . st s1 ( __splitmix_mix sm )
+    = sm + sm 0x9e3779b97f4a7c15
+    = . st s2 ( __splitmix_mix sm )
+    = sm + sm 0x9e3779b97f4a7c15
+    = . st s3 ( __splitmix_mix sm )
+    ^ @ Rng { # s st }
+}
+
+// ── Core step ────────────────────────────────────────────────────────
+
+// Advance the state and return the next 64-bit output. The bit pattern
+// is uniform over all 2^64 values; it's returned reinterpreted as a
+// signed i, so the sign is meaningless — feed it through `rng_below` /
+// `rng_range` / `rng_u01` for a value in a range, or treat the raw bits
+// as unsigned (e.g. `rand_hex_str`-style packing).
+// NB: the locals below are named `w*` (not `s*`): a binding named `s0`
+// would shadow the field name in `. st s0`, turning the field access
+// into a *pointer index* `st[s0]`. Distinct names keep `.` field-typed.
+@ rng_next Rng g → i {
+    : *RngImpl st # *RngImpl . g ctl
+    : u64 w0 . st s0
+    : u64 w1 . st s1
+    : u64 w2 . st s2
+    : u64 w3 . st s3
+    // result = rotl(w1 * 5, 7) * 9   (the "**" output scrambler)
+    : ~ u64 result ( __rotl * w1 5 7 )
+    = result * result 9
+    // State update (order matters — the ^= are sequential).
+    : u64 t << w1 17
+    : ~ u64 n2 ^^ w2 w0
+    : ~ u64 n3 ^^ w3 w1
+    : u64 n1 ^^ w1 n2
+    : u64 n0 ^^ w0 n3
+    = n2 ^^ n2 t
+    = n3 ( __rotl n3 45 )
+    = . st s0 n0
+    = . st s1 n1
+    = . st s2 n2
+    = . st s3 n3
+    ^ # i result
+}
+
+// ── Range / convenience wrappers ─────────────────────────────────────
+
+// Uniform integer in [0, n). Returns 0 for n <= 0. Unbiased: rejection-
+// samples on the smallest power-of-two mask covering n, so there is no
+// modulo bias.
+@ rng_below Rng g i n → i {
+    ? <= n 0 { ^ 0 } {}
+    : ~ i mask 1
+    ~ < mask n { = mask + * mask 2 1 }
+    : ~ i v 0
+    : ~ b done F
+    ~ ! done {
+        = v & ( rng_next g ) mask
+        ? < v n { = done T } {}
+    }
+    ^ v
+}
+
+// Uniform integer in [from, to). Returns `from` for an empty / inverted
+// range (from >= to).
+@ rng_range Rng g i from i to → i {
+    ? >= from to { ^ from } {}
+    ^ + from ( rng_below g - to from )
+}
+
+// Uniform double in [0, 1). Takes the top 53 bits of one output and
+// scales by 2^-53, the standard exact construction (every representable
+// double multiple of 2^-53 in [0,1) is equally likely; 1.0 never occurs).
+@ rng_u01 Rng g → f {
+    : u64 r # u64 ( rng_next g )
+    : u64 top >> r 11
+    ^ / # f top 9007199254740992.0
+}
+
+// Fair coin flip. xoshiro256**'s low bits pass the same statistical
+// tests as the high bits (the ** scrambler fixes the linear-low-bit
+// weakness of plain xoshiro+), so the bottom bit is a sound source.
+@ rng_bool Rng g → b {
+    ^ == 1 & ( rng_next g ) 1
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────
+
+// Release the generator's state. The handle is dead afterwards.
+@ rng_free Rng g → v {
+    ( nurl_free # *u . g ctl )
+}


### PR DESCRIPTION
## Summary

Adds `stdlib/std/rng.nu` — a **seedable, deterministic PRNG**, the companion to
`std/random.nu`'s OS CSPRNG. The CSPRNG draws from the kernel entropy pool and
**cannot be seeded**, which is the wrong tool whenever you need a *reproducible*
stream: simulations you can replay, property tests with a recorded seed,
procedural generation, auditable shuffles. This fills that Tier 5b stdlib gap.

- **Algorithm:** xoshiro256\*\* (Blackman & Vigna, 2018) — 256-bit state, 2²⁵⁶−1
  period, passes BigCrush. The single i64 seed is expanded into the state with
  **SplitMix64**, the authors' recommended seeding routine, so even a
  low-entropy seed like `0` or `1` yields a well-distributed, uncorrelated
  stream.
- **Determinism:** same seed → **byte-identical stream on every platform and
  every build**. NURL's determinism guarantee extends here because the
  generator is integer-only (no float state, no UB); `>>` lowers to a logical
  `lshr` on the `u64`-typed state words.
- **Not a CSPRNG.** Statistically excellent but predictable — never for
  anything security-sensitive; `std/random.nu` is the tool there. The module
  header says so prominently.

## API

| Function | Returns | Notes |
|---|---|---|
| `( rng_seed seed )` | `Rng` | any i64 seed, incl. 0 |
| `( rng_next g )` | `i` | raw 64-bit value (signed reinterpret) |
| `( rng_below g n )` | `i` | uniform `[0, n)`, unbiased (rejection-sampled), 0 if n≤0 |
| `( rng_range g from to )` | `i` | uniform `[from, to)`; `from` if inverted/empty |
| `( rng_u01 g )` | `f` | uniform double in `[0, 1)`, 53-bit resolution |
| `( rng_bool g )` | `b` | fair coin flip |
| `( rng_free g )` | `v` | release the generator |

Opaque-handle lifecycle, same shape as `Arena` / `Channel` / `String`; the
state mutates in place, so a `Rng` passed by value shares the one stream.

## Testing

`compiler/tests/rng_seedable.nu` pins the **exact stream** for seeds `0` and
`0x1234` against an independent reference implementation of the same algorithm
(SplitMix64 expansion + xoshiro256\*\*), plus:

- determinism — two generators, one seed → identical 64-value streams;
- `rng_below` bounds over 1000 draws + the `n ≤ 0` guard;
- `rng_range` inverted-range guard + a 500-draw in-range check.

The test guards two silent-miscompile classes the implementation depends on:
correct `u64` codegen (logical `lshr` for `>>`, wrapping `mul`/`add`, `rotl`
via shift-or) and the field-vs-index `.` aliasing footgun (rng_next's locals
are named `w*` so they don't shadow the `s*` field names — a shadow would turn
`. st s0` from a field load into a pointer index).

- ✅ Full regression suite green.
- ✅ `nurlfmt`-idempotent and IR-equivalent across the tree.
- ✅ Pure NURL — no compiler change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)