### PR TITLE
feat(stdlib): CLI argument parser (std/args.nu) + base32 (RFC 4648)

### DIFF
--- a/compiler/tests/args_parser.nu
+++ b/compiler/tests/args_parser.nu
@@ -1,0 +1,123 @@
+// Regression: std/args.nu CLI parser. Drives an explicit token list
+// (so the test is deterministic, independent of real argv) covering:
+//   --flag, --opt VALUE, --opt=VALUE, -s, -sVALUE clusters, the `--`
+//   terminator, positional collection, and the unknown-option error
+//   path. Prints PASS / a FAIL line per failed check and returns the
+//   failure count (non-zero exit surfaces in failures.txt).
+
+$ `stdlib/std/args.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+@ push_tok ( Vec String ) v s lit → v {
+    ( vec_push [String] v ( string_from lit ) )
+}
+
+// Compare an owned ?String to an expected literal; frees the payload.
+@ expect_val ?String got s exp s label → i {
+    : ~ i bad 1
+    ?? got {
+        T s → {
+            : String e ( string_from exp )
+            ? ( string_eq s e ) { = bad 0 } {}
+            ( string_free s )
+            ( string_free e )
+        }
+        F → {}
+    }
+    ? > bad 0 { ( nurl_print `  FAIL val ` ) ( nurl_print label ) ( nurl_print `\n` ) } {}
+    ^ bad
+}
+
+@ expect_int i got i want s label → i {
+    ? == got want { ^ 0 } {}
+    ( nurl_print `  FAIL int ` ) ( nurl_print label )
+    ( nurl_print ` got ` ) ( nurl_print ( nurl_str_int got ) )
+    ( nurl_print ` want ` ) ( nurl_print ( nurl_str_int want ) )
+    ( nurl_print `\n` )
+    ^ 1
+}
+
+@ main → i {
+    : ~ i fails 0
+
+    : ArgParser p ( args_new `demo` `a demo tool` )
+    ( args_flag p `verbose` 118 `be loud` )       // -v
+    ( args_opt p `output` 111 `FILE` `out path` )  // -o
+    ( args_opt p `count` 99 `N` `repeat count` )    // -c
+    ( args_flag p `aa` 97 `flag a` )               // -a
+    ( args_flag p `bb` 98 `flag b` )               // -b
+
+    : ( Vec String ) toks ( vec_new [String] )
+    ( push_tok toks `-v` )
+    ( push_tok toks `--output` )
+    ( push_tok toks `out.txt` )
+    ( push_tok toks `--count=3` )
+    ( push_tok toks `-ab` )
+    ( push_tok toks `file1` )
+    ( push_tok toks `--` )
+    ( push_tok toks `--weird` )
+    ( push_tok toks `file2` )
+
+    : b ok ( args_parse p toks )
+    ? ! ok { ( nurl_print `  FAIL parse returned F\n` ) = fails + fails 1 } {}
+    ? ( args_has_error p ) { ( nurl_print `  FAIL unexpected error\n` ) = fails + fails 1 } {}
+
+    = fails + fails ( expect_int ( args_count p `verbose` ) 1 `verbose` )
+    = fails + fails ( expect_int ( args_count p `aa` ) 1 `aa` )
+    = fails + fails ( expect_int ( args_count p `bb` ) 1 `bb` )
+    = fails + fails ( expect_val ( args_value p `output` ) `out.txt` `output` )
+    = fails + fails ( expect_val ( args_value p `count` ) `3` `count` )
+
+    = fails + fails ( expect_int ( args_positional_count p ) 3 `npos` )
+    : ( Vec String ) pos ( args_positionals p )
+    : s p0 ?? ( vec_get [String] pos 0 ) { T s → ( string_data s ) F → `` }
+    : s p1 ?? ( vec_get [String] pos 1 ) { T s → ( string_data s ) F → `` }
+    : s p2 ?? ( vec_get [String] pos 2 ) { T s → ( string_data s ) F → `` }
+    ? != 1 ( nurl_str_eq p0 `file1` ) { ( nurl_print `  FAIL pos0\n` ) = fails + fails 1 } {}
+    ? != 1 ( nurl_str_eq p1 `--weird` ) { ( nurl_print `  FAIL pos1\n` ) = fails + fails 1 } {}
+    ? != 1 ( nurl_str_eq p2 `file2` ) { ( nurl_print `  FAIL pos2\n` ) = fails + fails 1 } {}
+
+    // value_or falls back to the default for an unset option
+    : String mv ( args_value_or p `missing` `dflt` )
+    ? != 1 ( nurl_str_eq ( string_data mv ) `dflt` ) { ( nurl_print `  FAIL value_or\n` ) = fails + fails 1 } {}
+    ( string_free mv )
+
+    // usage generation must produce non-empty, prog-bearing text
+    : String u ( args_usage p )
+    ? < ( string_len u ) 10 { ( nurl_print `  FAIL usage too short\n` ) = fails + fails 1 } {}
+    ? < ( nurl_str_find ( string_data u ) `--output` ) 0 { ( nurl_print `  FAIL usage missing option\n` ) = fails + fails 1 } {}
+    ( string_free u )
+
+    ( vec_free_with [String] toks \ String s → v { ( string_free s ) } )
+    ( args_free p )
+
+    // ── glued short value: -ofoo → output == "foo" ──
+    : ArgParser p2 ( args_new `demo2` `` )
+    ( args_opt p2 `output` 111 `FILE` `out` )
+    : ( Vec String ) t2 ( vec_new [String] )
+    ( push_tok t2 `-ofoo` )
+    : b ok2 ( args_parse p2 t2 )
+    ? ! ok2 { ( nurl_print `  FAIL parse2\n` ) = fails + fails 1 } {}
+    = fails + fails ( expect_val ( args_value p2 `output` ) `foo` `glued` )
+    ( vec_free_with [String] t2 \ String s → v { ( string_free s ) } )
+    ( args_free p2 )
+
+    // ── unknown option must error ──
+    : ArgParser p3 ( args_new `demo3` `` )
+    ( args_flag p3 `verbose` 118 `` )
+    : ( Vec String ) t3 ( vec_new [String] )
+    ( push_tok t3 `--nope` )
+    : b ok3 ( args_parse p3 t3 )
+    ? ok3 { ( nurl_print `  FAIL: accepted unknown option\n` ) = fails + fails 1 } {}
+    ? ! ( args_has_error p3 ) { ( nurl_print `  FAIL: no error set\n` ) = fails + fails 1 } {}
+    ( vec_free_with [String] t3 \ String s → v { ( string_free s ) } )
+    ( args_free p3 )
+
+    ? == fails 0 {
+        ( nurl_print `args: all checks PASS\n` )
+    } {
+        ( nurl_print `args: ` ) ( nurl_print ( nurl_str_int fails ) ) ( nurl_print ` FAILURES\n` )
+    }
+    ^ fails
+}

--- a/compiler/tests/encode_base32.nu
+++ b/compiler/tests/encode_base32.nu
@@ -1,0 +1,110 @@
+// Regression: RFC 4648 §10 Base32 test vectors (the alphabet RFC 6238
+// TOTP secrets use). Exercises the binary-safe MSB-first encoder, the
+// `=` padding to an 8-char boundary, and the case-insensitive,
+// whitespace-skipping, padding-optional decoder.
+//
+//   ""       → ""
+//   "f"      → "MY======"
+//   "fo"     → "MZXQ===="
+//   "foo"    → "MZXW6==="
+//   "foob"   → "MZXW6YQ="
+//   "fooba"  → "MZXW6YTB"
+//   "foobar" → "MZXW6YTBOI======"
+//
+// Prints PASS / FAIL lines and returns the failure count, so a broken
+// codec surfaces in the suite's failures.txt with a non-zero exit.
+
+$ `stdlib/std/encode.nu`
+$ `stdlib/core/string.nu`
+
+// Encode `in`, compare to `exp`; decode `exp`, compare to `in`.
+// Returns the number of mismatches (0 = both directions correct).
+@ rt s in s exp → i {
+    : ~ i fails 0
+    : String enc ( b32_encode in )
+    : String want ( string_from exp )
+    ? ! ( string_eq enc want ) {
+        ( nurl_print `  enc FAIL "` )
+        ( nurl_print in )
+        ( nurl_print `" got "` )
+        ( nurl_print ( string_data enc ) )
+        ( nurl_print `" want "` )
+        ( nurl_print exp )
+        ( nurl_print `"\n` )
+        = fails + fails 1
+    } {}
+    ( string_free enc )
+    ( string_free want )
+    : !String ParseErr dr ( b32_decode exp )
+    ?? dr {
+        T dec → {
+            : String iin ( string_from in )
+            ? ! ( string_eq dec iin ) {
+                ( nurl_print `  dec FAIL "` )
+                ( nurl_print exp )
+                ( nurl_print `"\n` )
+                = fails + fails 1
+            } {}
+            ( string_free dec )
+            ( string_free iin )
+        }
+        F → {
+            ( nurl_print `  dec ERR "` )
+            ( nurl_print exp )
+            ( nurl_print `"\n` )
+            = fails + fails 1
+        }
+    }
+    ^ fails
+}
+
+@ main → i {
+    : ~ i fails 0
+    = fails + fails ( rt `` `` )
+    = fails + fails ( rt `f` `MY======` )
+    = fails + fails ( rt `fo` `MZXQ====` )
+    = fails + fails ( rt `foo` `MZXW6===` )
+    = fails + fails ( rt `foob` `MZXW6YQ=` )
+    = fails + fails ( rt `fooba` `MZXW6YTB` )
+    = fails + fails ( rt `foobar` `MZXW6YTBOI======` )
+
+    // TOTP-style decode: lowercase + embedded whitespace + no padding
+    // must still recover the original bytes.
+    : !String ParseErr lr ( b32_decode `mzxw 6ytb oi` )
+    ?? lr {
+        T dec → {
+            : String want ( string_from `foobar` )
+            ? ! ( string_eq dec want ) {
+                ( nurl_print `  lax-decode FAIL\n` )
+                = fails + fails 1
+            } {}
+            ( string_free dec )
+            ( string_free want )
+        }
+        F → {
+            ( nurl_print `  lax-decode ERR\n` )
+            = fails + fails 1
+        }
+    }
+
+    // Malformed input ('1' and '8' are outside the A-Z2-7 alphabet)
+    // must be rejected, not silently accepted.
+    : !String ParseErr br ( b32_decode `MZXW6Y18` )
+    ?? br {
+        T bad → {
+            ( nurl_print `  reject FAIL: accepted bad alphabet\n` )
+            ( string_free bad )
+            = fails + fails 1
+        }
+        F → {}
+    }
+
+    ? == fails 0 {
+        ( nurl_print `base32: all vectors PASS\n` )
+    } {
+        ( nurl_print `base32: ` )
+        ( nurl_print ( nurl_str_int fails ) )
+        ( nurl_print ` FAILURES\n` )
+    }
+    ^ fails
+}

--- a/stdlib/std/args.nu
+++ b/stdlib/std/args.nu
@@ -1,0 +1,428 @@
+// stdlib/std/args.nu — getopt/argparse-style CLI argument parser
+//
+// A small, allocation-light command-line parser. You build a spec by
+// registering options (boolean flags and value-taking options), then
+// parse either the real process argv or an explicit token list. Parse
+// results are queried by long name.
+//
+// Supported syntax (GNU-ish):
+//   --long                  boolean flag
+//   --long VALUE            value option, value in the next token
+//   --long=VALUE            value option, value glued with '='
+//   -s                      short flag
+//   -s VALUE / -sVALUE      short value option
+//   -abc                    clustered short flags (each a flag)
+//   --                      end-of-options terminator; the rest are
+//                           positionals (so a positional can start '-')
+//   -                       a lone '-' is a positional (stdin convention)
+//
+// API:
+//   ( args_new prog about )            → ArgParser   prog name + one-line blurb
+//   ( args_flag p long short help )    → v   register a boolean flag
+//   ( args_opt p long short mv help )  → v   register a value option (mv =
+//                                            metavar shown in usage, e.g. `FILE`)
+//   ( args_parse_argv p )              → b   parse real argv[1..]; F on error
+//   ( args_parse p tokens )            → b   parse an explicit ( Vec String )
+//   ( args_present p long )            → b   was the option seen?
+//   ( args_count p long )              → i   times seen (clustered/repeated)
+//   ( args_value p long )              → ? String   last value (owned copy)
+//   ( args_value_or p long default )   → String     value or a default (owned)
+//   ( args_positional_count p )        → i
+//   ( args_positionals p )             → ( Vec String )  BORROW — do not free
+//   ( args_has_error p )               → b
+//   ( args_error p )                   → s   borrowed message ("" when ok)
+//   ( args_usage p )                   → String   generated --help text
+//   ( args_free p )                    → v   release everything
+//
+// `short` is a byte/char code (e.g. `v` is 118); pass 0 for none. Pass
+// `` (empty) for a missing long name. Query functions key off the long
+// name, so give every option a long name if you want to look it up.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+// ── Types ─────────────────────────────────────────────────────────────
+//
+// Spec and parse state live in parallel vectors indexed by option slot.
+// `counts` is mutated in place (primitive, no ownership churn); captured
+// values are append-only (val_idx[k] = which option, val_str[k] = value),
+// so a repeated value option keeps its history and the last one wins.
+
+: ArgParser {
+    String prog
+    String about
+    ( Vec String ) longs        // long name per option, "" if none
+    ( Vec i ) shorts            // short char code per option, 0 if none
+    ( Vec i ) kinds             // 0 = flag, 1 = value option
+    ( Vec String ) metavars     // usage placeholder for value options
+    ( Vec String ) helps        // help text per option
+    ( Vec i ) counts            // parse result: times each option was seen
+    ( Vec i ) val_idx           // append-only: option slot for a captured value
+    ( Vec String ) val_str      // append-only: the captured value
+    ( Vec String ) positionals  // collected positional arguments
+    String error                // non-empty after a failed parse
+}
+
+@ args_new s prog s about → ArgParser {
+    ^ @ ArgParser {
+        ( string_from prog )
+        ( string_from about )
+        ( vec_new [String] )
+        ( vec_new [i] )
+        ( vec_new [i] )
+        ( vec_new [String] )
+        ( vec_new [String] )
+        ( vec_new [i] )
+        ( vec_new [i] )
+        ( vec_new [String] )
+        ( vec_new [String] )
+        ( string_new )
+    }
+}
+
+// ── Registration ──────────────────────────────────────────────────────
+
+@ __args_add ArgParser p s long i short i kind s metavar s help → v {
+    ( vec_push [String] . p longs ( string_from long ) )
+    ( vec_push [i] . p shorts short )
+    ( vec_push [i] . p kinds kind )
+    ( vec_push [String] . p metavars ( string_from metavar ) )
+    ( vec_push [String] . p helps ( string_from help ) )
+    ( vec_push [i] . p counts 0 )
+}
+
+@ args_flag ArgParser p s long i short s help → v {
+    ( __args_add p long short 0 `` help )
+}
+
+@ args_opt ArgParser p s long i short s metavar s help → v {
+    ( __args_add p long short 1 metavar help )
+}
+
+// ── Internal lookups / mutation ───────────────────────────────────────
+
+@ __args_find_long ArgParser p s name → i {
+    : i n ( vec_len [String] . p longs )
+    : ~ i k 0
+    : ~ i res -1
+    ~ < k n {
+        : ?String lo ( vec_get [String] . p longs k )
+        : s lraw ?? lo { T x → ( string_data x ) F → `` }
+        ? == 1 ( nurl_str_eq lraw name ) { = res k = k n } {}
+        = k + k 1
+    }
+    ^ res
+}
+
+@ __args_find_short ArgParser p i ch → i {
+    : i n ( vec_len [i] . p shorts )
+    : ~ i k 0
+    : ~ i res -1
+    ~ < k n {
+        : i sc ?? ( vec_get [i] . p shorts k ) { T x → x F → 0 }
+        ? & == sc ch != ch 0 { = res k = k n } {}
+        = k + k 1
+    }
+    ^ res
+}
+
+@ __args_bump ArgParser p i idx → v {
+    : i c ?? ( vec_get [i] . p counts idx ) { T x → x F → 0 }
+    ( vec_set [i] . p counts idx + c 1 )
+}
+
+@ __args_err3 ArgParser p s a s b s c → v {
+    ( string_clear . p error )
+    ( string_push_str . p error a )
+    ( string_push_str . p error b )
+    ( string_push_str . p error c )
+}
+
+// ── Parsing ───────────────────────────────────────────────────────────
+
+@ __args_is_long String tok → b {
+    ^ ( string_starts_with tok `--` )
+}
+
+@ __args_is_short String tok → b {
+    ? > ( string_len tok ) 1 { ^ ( string_starts_with tok `-` ) } {}
+    ^ F
+}
+
+// Handle a `--…` token. Returns the number of input tokens consumed
+// (1 or 2), or -1 on error (with p.error set).
+@ __args_do_long ArgParser p String tok ( Vec String ) toks i i → i {
+    : i tl ( string_len tok )
+    : ?i eqo ( string_index_of tok `=` )
+    : ~ i keyend tl
+    : ~ b haveval F
+    : ~ i valstart tl
+    ?? eqo {
+        T x → { = keyend x = haveval T = valstart + x 1 }
+        F → {}
+    }
+    : String key ( string_substr tok 2 - keyend 2 )
+    : i idx ( __args_find_long p ( string_data key ) )
+    ? < idx 0 {
+        ( __args_err3 p `unknown option: --` ( string_data key ) `` )
+        ( string_free key )
+        ^ -1
+    } {}
+    : i kind ?? ( vec_get [i] . p kinds idx ) { T x → x F → 0 }
+    ? == kind 0 {
+        ? haveval {
+            ( __args_err3 p `option '--` ( string_data key ) `' takes no value` )
+            ( string_free key )
+            ^ -1
+        } {}
+        ( __args_bump p idx )
+        ( string_free key )
+        ^ 1
+    } {}
+    // value option
+    ? haveval {
+        : String valstr ( string_substr tok valstart - tl valstart )
+        ( vec_push [i] . p val_idx idx )
+        ( vec_push [String] . p val_str valstr )
+        ( __args_bump p idx )
+        ( string_free key )
+        ^ 1
+    } {}
+    : i n ( vec_len [String] toks )
+    ? < + i 1 n {
+        : ?String nxo ( vec_get [String] toks + i 1 )
+        : s nraw ?? nxo { T x → ( string_data x ) F → `` }
+        ( vec_push [i] . p val_idx idx )
+        ( vec_push [String] . p val_str ( string_from nraw ) )
+        ( __args_bump p idx )
+        ( string_free key )
+        ^ 2
+    } {}
+    ( __args_err3 p `option '--` ( string_data key ) `' requires a value` )
+    ( string_free key )
+    ^ -1
+}
+
+// Handle a `-…` token (possibly a cluster). Returns tokens consumed
+// (1 or 2), or -1 on error.
+@ __args_do_short ArgParser p String tok ( Vec String ) toks i i → i {
+    : i tl ( string_len tok )
+    : s raw ( string_data tok )
+    : ~ i j 1
+    ~ < j tl {
+        : i ch ( nurl_str_get raw j )
+        : i idx ( __args_find_short p ch )
+        ? < idx 0 {
+            ( string_clear . p error )
+            ( string_push_str . p error `unknown option: -` )
+            ( string_push_char . p error ch )
+            ^ -1
+        } {}
+        : i kind ?? ( vec_get [i] . p kinds idx ) { T x → x F → 0 }
+        ? == kind 0 {
+            ( __args_bump p idx )
+            = j + j 1
+        } {
+            // value option: take the rest of the cluster, else next token
+            ? < + j 1 tl {
+                : String valstr ( string_substr tok + j 1 - tl + j 1 )
+                ( vec_push [i] . p val_idx idx )
+                ( vec_push [String] . p val_str valstr )
+                ( __args_bump p idx )
+                ^ 1
+            } {}
+            : i n ( vec_len [String] toks )
+            ? < + i 1 n {
+                : ?String nxo ( vec_get [String] toks + i 1 )
+                : s nraw ?? nxo { T x → ( string_data x ) F → `` }
+                ( vec_push [i] . p val_idx idx )
+                ( vec_push [String] . p val_str ( string_from nraw ) )
+                ( __args_bump p idx )
+                ^ 2
+            } {}
+            ( string_clear . p error )
+            ( string_push_str . p error `option '-` )
+            ( string_push_char . p error ch )
+            ( string_push_str . p error `' requires a value` )
+            ^ -1
+        }
+    }
+    ^ 1
+}
+
+@ args_parse ArgParser p ( Vec String ) toks → b {
+    : i n ( vec_len [String] toks )
+    : ~ i i 0
+    : ~ b term F
+    : ~ b ok T
+    ~ & ok < i n {
+        : ?String toko ( vec_get [String] toks i )
+        : s traw ?? toko { T x → ( string_data x ) F → `` }
+        : String tok ( string_from traw )
+        : i tl ( string_len tok )
+        ? term {
+            ( vec_push [String] . p positionals ( string_from traw ) )
+            = i + i 1
+        } {
+            ? ( __args_is_long tok ) {
+                ? == tl 2 {
+                    = term T
+                    = i + i 1
+                } {
+                    : i adv ( __args_do_long p tok toks i )
+                    ? < adv 0 { = ok F } { = i + i adv }
+                }
+            } {
+                ? ( __args_is_short tok ) {
+                    : i adv ( __args_do_short p tok toks i )
+                    ? < adv 0 { = ok F } { = i + i adv }
+                } {
+                    ( vec_push [String] . p positionals ( string_from traw ) )
+                    = i + i 1
+                }
+            }
+        }
+        ( string_free tok )
+    }
+    ^ ok
+}
+
+@ args_parse_argv ArgParser p → b {
+    : i n ( nurl_argv_count )
+    : ( Vec String ) toks ( vec_new [String] )
+    : ~ i k 1
+    ~ < k n {
+        : s raw ( nurl_argv_get k )
+        ( vec_push [String] toks ( string_from raw ) )
+        = k + k 1
+    }
+    : b ok ( args_parse p toks )
+    ( vec_free_with [String] toks \ String s → v { ( string_free s ) } )
+    ^ ok
+}
+
+// ── Queries ───────────────────────────────────────────────────────────
+
+@ args_count ArgParser p s long → i {
+    : i idx ( __args_find_long p long )
+    ? < idx 0 { ^ 0 } {}
+    ^ ?? ( vec_get [i] . p counts idx ) { T x → x F → 0 }
+}
+
+@ args_present ArgParser p s long → b {
+    ^ > ( args_count p long ) 0
+}
+
+@ args_value ArgParser p s long → ?String {
+    : i idx ( __args_find_long p long )
+    ? < idx 0 { ^ @ ?String { F # String 0 } } {}
+    : i n ( vec_len [i] . p val_idx )
+    : ~ i found -1
+    : ~ i k 0
+    ~ < k n {
+        : i vi ?? ( vec_get [i] . p val_idx k ) { T x → x F → -1 }
+        ? == vi idx { = found k } {}
+        = k + k 1
+    }
+    ? < found 0 { ^ @ ?String { F # String 0 } } {}
+    : ?String so ( vec_get [String] . p val_str found )
+    : s vraw ?? so { T x → ( string_data x ) F → `` }
+    ^ @ ?String { T ( string_from vraw ) }
+}
+
+@ args_value_or ArgParser p s long s default → String {
+    : ?String v ( args_value p long )
+    ^ ?? v {
+        T s → s
+        F → ( string_from default )
+    }
+}
+
+@ args_positional_count ArgParser p → i {
+    ^ ( vec_len [String] . p positionals )
+}
+
+// BORROW: the returned Vec is owned by the parser; iterate it with
+// vec_get [String] + string_data, but do NOT free it (args_free does).
+@ args_positionals ArgParser p → ( Vec String ) {
+    ^ . p positionals
+}
+
+@ args_has_error ArgParser p → b {
+    ^ > ( string_len . p error ) 0
+}
+
+@ args_error ArgParser p → s {
+    ^ ( string_data . p error )
+}
+
+// ── Usage text ────────────────────────────────────────────────────────
+
+@ args_usage ArgParser p → String {
+    : String out ( string_new )
+    ( string_push_str out `Usage: ` )
+    ( string_push_str out ( string_data . p prog ) )
+    ( string_push_str out ` [OPTIONS] [ARGS]\n` )
+    ? > ( string_len . p about ) 0 {
+        ( string_push_str out ( string_data . p about ) )
+        ( string_push_char out 10 )
+    } {}
+    : i n ( vec_len [String] . p longs )
+    ? > n 0 { ( string_push_str out `\nOptions:\n` ) } {}
+    : ~ i k 0
+    ~ < k n {
+        ( string_push_str out `  ` )
+        : i sh ?? ( vec_get [i] . p shorts k ) { T x → x F → 0 }
+        ? > sh 0 {
+            ( string_push_char out 45 )  // '-'
+            ( string_push_char out sh )
+        } {
+            ( string_push_str out `  ` )
+        }
+        : ?String lo ( vec_get [String] . p longs k )
+        : s lraw ?? lo { T x → ( string_data x ) F → `` }
+        ? > ( nurl_str_len lraw ) 0 {
+            ? > sh 0 { ( string_push_str out `, ` ) } { ( string_push_str out `  ` ) }
+            ( string_push_str out `--` )
+            ( string_push_str out lraw )
+        } {}
+        : i kind ?? ( vec_get [i] . p kinds k ) { T x → x F → 0 }
+        ? == kind 1 {
+            ( string_push_char out 32 )
+            : ?String mv ( vec_get [String] . p metavars k )
+            : s mraw ?? mv { T x → ( string_data x ) F → `` }
+            ? > ( nurl_str_len mraw ) 0 {
+                ( string_push_str out mraw )
+            } {
+                ( string_push_str out `VALUE` )
+            }
+        } {}
+        ( string_push_char out 10 )
+        : ?String hp ( vec_get [String] . p helps k )
+        : s hraw ?? hp { T x → ( string_data x ) F → `` }
+        ? > ( nurl_str_len hraw ) 0 {
+            ( string_push_str out `      ` )
+            ( string_push_str out hraw )
+            ( string_push_char out 10 )
+        } {}
+        = k + k 1
+    }
+    ^ out
+}
+
+// ── Cleanup ───────────────────────────────────────────────────────────
+
+@ args_free ArgParser p → v {
+    ( string_free . p prog )
+    ( string_free . p about )
+    ( string_free . p error )
+    ( vec_free_with [String] . p longs \ String s → v { ( string_free s ) } )
+    ( vec_free [i] . p shorts )
+    ( vec_free [i] . p kinds )
+    ( vec_free_with [String] . p metavars \ String s → v { ( string_free s ) } )
+    ( vec_free_with [String] . p helps \ String s → v { ( string_free s ) } )
+    ( vec_free [i] . p counts )
+    ( vec_free [i] . p val_idx )
+    ( vec_free_with [String] . p val_str \ String s → v { ( string_free s ) } )
+    ( vec_free_with [String] . p positionals \ String s → v { ( string_free s ) } )
+}

--- a/stdlib/std/encode.nu
+++ b/stdlib/std/encode.nu
@@ -15,6 +15,11 @@
 //   ( b64_decode s )           → ! String ParseErr   standard, padding optional
 //   ( b64_url_encode s )       → String              URL-safe (- _), no padding
 //   ( b64_url_decode s )       → ! String ParseErr   URL-safe, padding optional
+//   ( b32_encode s )           → String              standard alphabet, padded
+//   ( b32_encode_len s i )     → String              binary-safe (NUL ok)
+//   ( b32_encode_vec (Vec u) ) → String              binary-safe
+//   ( b32_decode s )           → ! String ParseErr   standard, padding optional,
+//                                                     case-insensitive (TOTP)
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/errors.nu`
@@ -235,6 +240,147 @@ $ `stdlib/core/errors.nu`
 @ b64_url_decode s str → !String ParseErr {
     : String out ( string_with_cap ( nurl_str_len str ) )
     : !v ParseErr r ( __b64_decode_into out str T )
+    ?? r {
+        T _ → { ^ @ !String ParseErr { T out } }
+        F e → {
+            ( string_free out )
+            ^ @ !String ParseErr { F e }
+        }
+    }
+}
+
+// ── Base32 (RFC 4648) ───────────────────────────────────────────────
+//
+// Standard alphabet `A-Z2-7`, padded with `=` to an 8-char boundary.
+// This is the alphabet RFC 6238 TOTP secrets use. The decoder is
+// case-insensitive, ignores ASCII whitespace, and treats padding as
+// optional, so a bare uppercase TOTP secret decodes without massaging.
+
+// Encode index n in 0..31 to its alphabet character.
+@ __b32_digit i n → i {
+    ? < n 26 { ^ + 65 n } {}  // 'A' + n
+    ^ + 50 - n 26  // '2' + (n-26)
+}
+
+// Binary-safe emitter. Processes exactly n_in bytes from str, packing
+// 5 bits per output char via an MSB-first bit accumulator. Trailing
+// bits are zero-padded up to the final 5-bit group; `pad` then appends
+// `=` to the next 8-char boundary (count fixed by n_in mod 5).
+@ __b32_emit String out s str i n_in b pad → v {
+    : *u data # *u str
+    : ~ i acc 0
+    : ~ i nbits 0
+    : ~ i i 0
+    ~ < i n_in {
+        : i bb & 255 # i . data i
+        = acc + * acc 256 bb
+        = nbits + nbits 8
+        = i + i 1
+        ~ >= nbits 5 {
+            = nbits - nbits 5
+            ( string_push_char out ( __b32_digit & 31 >> acc nbits ) )
+            : i mask - << 1 nbits 1
+            = acc & acc mask
+        }
+    }
+    ? > nbits 0 {
+        // Left-justify the residual bits into a final 5-bit group.
+        ( string_push_char out ( __b32_digit & 31 << acc - 5 nbits ) )
+    } {}
+    ? pad {
+        : i rem % n_in 5
+        : ~ i padn 0
+        ? == rem 1 { = padn 6 } {}
+        ? == rem 2 { = padn 4 } {}
+        ? == rem 3 { = padn 3 } {}
+        ? == rem 4 { = padn 1 } {}
+        : ~ i p 0
+        ~ < p padn {
+            ( string_push_char out 61 )  // '='
+            = p + p 1
+        }
+    } {}
+    ( __string_seal out )
+}
+
+@ b32_encode s str → String {
+    : i len ( nurl_str_len str )
+    ^ ( b32_encode_len str len )
+}
+
+@ b32_encode_len s str i len → String {
+    : String out ( string_with_cap * 8 + 1 / len 5 )
+    ( __b32_emit out str len T )
+    ^ out
+}
+
+@ b32_encode_vec ( Vec u ) v → String {
+    : i len ( vec_len [u] v )
+    : s data # s ( vec_data [u] v )
+    ^ ( b32_encode_len data len )
+}
+
+// Returns 0..31, or -1 on non-alphabet byte. Padding `=` (61) returns
+// -2. Both letter cases map to the same value (case-insensitive).
+@ __b32_value i c → i {
+    ? & >= c 65 <= c 90 { ^ - c 65 } {}  // A-Z → 0..25
+    ? & >= c 97 <= c 122 { ^ - c 97 } {}  // a-z → 0..25
+    ? & >= c 50 <= c 55 { ^ + 26 - c 50 } {}  // '2'-'7' → 26..31
+    ? == c 61 { ^ -2 } {}  // '='
+    ^ -1
+}
+
+// Internal decoder: ignores ASCII whitespace, fills `out` with bytes,
+// returns ! v ParseErr.
+@ __b32_decode_into String out s str → !v ParseErr {
+    : i len ( nurl_str_len str )
+    : ~ i pad 0
+    : ~ i acc 0
+    : ~ i nbits 0
+    : ~ i i 0
+    ~ < i len {
+        : i c ( nurl_str_get str i )
+        = i + i 1
+        // Skip ASCII whitespace: space, tab, lf, cr, ff, vt
+        ? | | | | | == c 32 == c 9 == c 10 == c 13 == c 12 == c 11 {} {
+            : i v ( __b32_value c )
+            ? == v -2 {
+                = pad + pad 1
+                ? > pad 6 {
+                    ^ @ !v ParseErr { F @ ParseErr { TrailingGarbage } }
+                } {}
+            } {
+                ? > pad 0 {
+                    // Non-padding char after '=' is malformed.
+                    ^ @ !v ParseErr { F @ ParseErr { TrailingGarbage } }
+                } {}
+                ? < v 0 {
+                    ^ @ !v ParseErr { F @ ParseErr { BadFormat } }
+                } {}
+                = acc + * acc 32 v
+                = nbits + nbits 5
+                ? >= nbits 8 {
+                    = nbits - nbits 8
+                    : i mask - << 1 nbits 1
+                    : i byte & 255 >> acc nbits
+                    ( string_push_char out byte )
+                    = acc & acc mask
+                } {}
+            }
+        }
+    }
+    // Partial group with non-zero residual bits is malformed.
+    ? > nbits 0 {
+        ? != acc 0 {
+            ^ @ !v ParseErr { F @ ParseErr { BadFormat } }
+        } {}
+    } {}
+    ^ @ !v ParseErr { T 0 }
+}
+
+@ b32_decode s str → !String ParseErr {
+    : String out ( string_with_cap ( nurl_str_len str ) )
+    : !v ParseErr r ( __b32_decode_into out str )
     ?? r {
         T _ → { ^ @ !String ParseErr { T out } }
         F e → {


### PR DESCRIPTION
Ships the two cheapest / highest-leverage Tier 5b stdlib gaps from `TODO.md`. Both are pure NURL with **no compiler change**.

## `std/args.nu` — getopt/argparse-style CLI parser

Supported syntax (GNU-ish):
- `--long` boolean flag
- `--long VALUE` and `--long=VALUE` value options
- `-s` short flag, `-sVALUE` / `-s VALUE` short value option
- `-abc` clustered short flags
- `--` end-of-options terminator; a lone `-` is a positional

Spec and parse state live in parallel vectors indexed by option slot. `counts` is mutated in place via `vec_set` (primitive — no ownership churn); captured values are append-only (`val_idx[k]` = option slot, `val_str[k]` = value), so a repeated value option keeps its history and the last one wins. This deliberately avoids rewriting struct slots that hold owned `String`s.

API: `args_new` / `args_flag` / `args_opt` / `args_parse` / `args_parse_argv` / `args_present` / `args_count` / `args_value` / `args_value_or` / `args_positional_count` / `args_positionals` / `args_has_error` / `args_error` / `args_usage` / `args_free`. `args_usage` generates `--help` text.

## `std/encode.nu` — base32 (RFC 4648)

Standard `A-Z2-7` alphabet (the one RFC 6238 TOTP secrets use), `=`-padded to an 8-char boundary. Binary-safe encoder (`b32_encode` / `b32_encode_len` / `b32_encode_vec`) mirroring the existing base64 shape, plus a case-insensitive, whitespace-skipping, padding-optional decoder (`b32_decode`).

## Tests

- `compiler/tests/encode_base32.nu` — RFC 4648 §10 vectors (`""`, `f`, `fo`, `foo`, `foob`, `fooba`, `foobar`), a lax TOTP-style decode (lowercase + embedded whitespace + no padding), and a malformed-alphabet rejection.
- `compiler/tests/args_parser.nu` — drives an explicit token list across every syntax form, plus `args_value_or`, `args_usage`, and the unknown-option error path.

Both run clean under `-fsanitize=address,undefined` with leak detection. Full suite green (`failures.txt` empty, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)