### PR TITLE
feat(stdlib): collection types — deque, binary heap, ordered map

### DIFF
--- a/compiler/tests/deque_basic.nu
+++ b/compiler/tests/deque_basic.nu
@@ -1,0 +1,74 @@
+// Regression: std/deque.nu ring buffer. Exercises both-ends push/pop,
+// indexed access, wraparound + growth while head != 0, and the
+// owned-element free_with path (ASan). Prints a FAIL line per failed
+// check; returns the failure count.
+
+$ `stdlib/std/deque.nu`
+$ `stdlib/core/string.nu`
+
+@ expect_int i got i want s label → i {
+    ? == got want { ^ 0 } {}
+    ( nurl_print `  FAIL ` ) ( nurl_print label )
+    ( nurl_print ` got ` ) ( nurl_print ( nurl_str_int got ) )
+    ( nurl_print ` want ` ) ( nurl_print ( nurl_str_int want ) ) ( nurl_print `\n` )
+    ^ 1
+}
+
+@ expect_opt_i ?i got i want s label → i {
+    : ~ i bad 1
+    ?? got { T v → { ? == v want { = bad 0 } {} } F → {} }
+    ? > bad 0 { ( nurl_print `  FAIL opt ` ) ( nurl_print label ) ( nurl_print `\n` ) } {}
+    ^ bad
+}
+
+@ main → i {
+    : ~ i fails 0
+
+    : ( Deque i ) d ( deque_new [i] )
+    ( deque_push_back [i] d 1 )
+    ( deque_push_back [i] d 2 )
+    ( deque_push_back [i] d 3 )
+    ( deque_push_front [i] d 0 )    // [0,1,2,3]
+    = fails + fails ( expect_int ( deque_len [i] d ) 4 `len4` )
+    = fails + fails ( expect_opt_i ( deque_front [i] d ) 0 `front` )
+    = fails + fails ( expect_opt_i ( deque_back [i] d ) 3 `back` )
+    = fails + fails ( expect_opt_i ( deque_get [i] d 2 ) 2 `get2` )
+    = fails + fails ( expect_opt_i ( deque_pop_front [i] d ) 0 `pf` )
+    = fails + fails ( expect_opt_i ( deque_pop_back [i] d ) 3 `pb` )   // [1,2]
+    = fails + fails ( expect_int ( deque_len [i] d ) 2 `len2` )
+
+    // Force several growths while head != 0 so the unwrap path runs.
+    : ~ i i 0
+    ~ < i 20 { ( deque_push_back [i] d + 100 i ) = i + i 1 }
+    = fails + fails ( expect_int ( deque_len [i] d ) 22 `len22` )
+    = fails + fails ( expect_opt_i ( deque_pop_front [i] d ) 1 `seq1` )
+    = fails + fails ( expect_opt_i ( deque_pop_front [i] d ) 2 `seq2` )
+    : ~ i k 0
+    : ~ b okseq T
+    ~ < k 20 {
+        : i want + 100 k
+        ?? ( deque_pop_front [i] d ) { T v → { ? != v want { = okseq F } {} } F → { = okseq F } }
+        = k + k 1
+    }
+    ? ! okseq { ( nurl_print `  FAIL wrap-seq\n` ) = fails + fails 1 } {}
+    = fails + fails ( expect_int ( deque_len [i] d ) 0 `drained` )
+    ? ! ( deque_is_empty [i] d ) { ( nurl_print `  FAIL not empty\n` ) = fails + fails 1 } {}
+    // pop on empty → None
+    ?? ( deque_pop_front [i] d ) { T _ → { ( nurl_print `  FAIL empty-pop\n` ) = fails + fails 1 } F → {} }
+    ( deque_free [i] d )
+
+    // Owned String elements + free_with (ASan / leak path).
+    : ( Deque String ) sd ( deque_new [String] )
+    ( deque_push_back [String] sd ( string_from `a` ) )
+    ( deque_push_front [String] sd ( string_from `b` ) )   // [b, a]
+    = fails + fails ( expect_int ( deque_len [String] sd ) 2 `slen` )
+    : ?String fo ( deque_front [String] sd )
+    : s fr ?? fo { T s → ( string_data s ) F → `` }
+    ? != 1 ( nurl_str_eq fr `b` ) { ( nurl_print `  FAIL sfront\n` ) = fails + fails 1 } {}
+    ( deque_free_with [String] sd \ String s → v { ( string_free s ) } )
+
+    ? == fails 0 { ( nurl_print `deque: all checks PASS\n` ) } {
+        ( nurl_print `deque: ` ) ( nurl_print ( nurl_str_int fails ) ) ( nurl_print ` FAILURES\n` )
+    }
+    ^ fails
+}

--- a/compiler/tests/heap_basic.nu
+++ b/compiler/tests/heap_basic.nu
@@ -1,0 +1,46 @@
+// Regression: std/heap.nu binary heap. Min-heap via `a - b`: pushing a
+// scrambled set and popping must yield ascending order; peek must show
+// the current minimum. Returns the failure count.
+
+$ `stdlib/std/heap.nu`
+
+@ main → i {
+    : ~ i fails 0
+
+    : ( Heap i ) h ( heap_new [i] )
+    ( heap_push [i] h 5 \ i a i b → i { ^ - a b } )
+    ( heap_push [i] h 3 \ i a i b → i { ^ - a b } )
+    ( heap_push [i] h 8 \ i a i b → i { ^ - a b } )
+    ( heap_push [i] h 1 \ i a i b → i { ^ - a b } )
+    ( heap_push [i] h 9 \ i a i b → i { ^ - a b } )
+    ( heap_push [i] h 2 \ i a i b → i { ^ - a b } )
+
+    ? != ( heap_len [i] h ) 6 { ( nurl_print `  FAIL len\n` ) = fails + fails 1 } {}
+    ?? ( heap_peek [i] h ) { T v → { ? != v 1 { ( nurl_print `  FAIL peek\n` ) = fails + fails 1 } {} } F → { ( nurl_print `  FAIL peek none\n` ) = fails + fails 1 } }
+
+    // Pop everything — must come out 1,2,3,5,8,9.
+    : ~ i prev -1
+    : ~ b ordered T
+    : ~ i seen 0
+    : ~ b go T
+    ~ go {
+        ?? ( heap_pop [i] h \ i a i b → i { ^ - a b } ) {
+            T v → {
+                ? < v prev { = ordered F } {}
+                = prev v
+                = seen + seen 1
+            }
+            F → { = go F }
+        }
+    }
+    ? ! ordered { ( nurl_print `  FAIL not ascending\n` ) = fails + fails 1 } {}
+    ? != seen 6 { ( nurl_print `  FAIL popped count\n` ) = fails + fails 1 } {}
+    ? != prev 9 { ( nurl_print `  FAIL last != max\n` ) = fails + fails 1 } {}
+    ? ! ( heap_is_empty [i] h ) { ( nurl_print `  FAIL not empty\n` ) = fails + fails 1 } {}
+    ( heap_free [i] h )
+
+    ? == fails 0 { ( nurl_print `heap: all checks PASS\n` ) } {
+        ( nurl_print `heap: ` ) ( nurl_print ( nurl_str_int fails ) ) ( nurl_print ` FAILURES\n` )
+    }
+    ^ fails
+}

--- a/compiler/tests/ordmap_basic.nu
+++ b/compiler/tests/ordmap_basic.nu
@@ -1,0 +1,61 @@
+// Regression: std/ordmap.nu sorted-array ordered map. Insertion in
+// scrambled order must read back sorted; get / contains / replace /
+// remove / min / max behave; plus an int→String map exercising the
+// free_with teardown (ASan). Returns the failure count.
+
+$ `stdlib/std/ordmap.nu`
+$ `stdlib/core/string.nu`
+
+@ expect_opt_i ?i got i want s label → i {
+    : ~ i bad 1
+    ?? got { T v → { ? == v want { = bad 0 } {} } F → {} }
+    ? > bad 0 { ( nurl_print `  FAIL opt ` ) ( nurl_print label ) ( nurl_print `\n` ) } {}
+    ^ bad
+}
+
+@ main → i {
+    : ~ i fails 0
+
+    : ( OrdMap i i ) m ( ordmap_new [i i] )
+    ?? ( ordmap_set [i i] m 3 30 \ i a i b → i { ^ - a b } ) { T _ → { ( nurl_print `  FAIL set3 prev\n` ) = fails + fails 1 } F → {} }
+    ?? ( ordmap_set [i i] m 1 10 \ i a i b → i { ^ - a b } ) { T _ → { ( nurl_print `  FAIL set1 prev\n` ) = fails + fails 1 } F → {} }
+    ?? ( ordmap_set [i i] m 2 20 \ i a i b → i { ^ - a b } ) { T _ → { ( nurl_print `  FAIL set2 prev\n` ) = fails + fails 1 } F → {} }
+
+    ? != ( ordmap_len [i i] m ) 3 { ( nurl_print `  FAIL len\n` ) = fails + fails 1 } {}
+    = fails + fails ( expect_opt_i ( ordmap_get [i i] m 2 \ i a i b → i { ^ - a b } ) 20 `get2` )
+    ? ! ( ordmap_contains [i i] m 2 \ i a i b → i { ^ - a b } ) { ( nurl_print `  FAIL contains2\n` ) = fails + fails 1 } {}
+    ? ( ordmap_contains [i i] m 5 \ i a i b → i { ^ - a b } ) { ( nurl_print `  FAIL contains5\n` ) = fails + fails 1 } {}
+
+    // Ordered iteration: keys must be 1,2,3 regardless of insert order.
+    = fails + fails ( expect_opt_i ( ordmap_key_at [i i] m 0 ) 1 `k0` )
+    = fails + fails ( expect_opt_i ( ordmap_key_at [i i] m 1 ) 2 `k1` )
+    = fails + fails ( expect_opt_i ( ordmap_key_at [i i] m 2 ) 3 `k2` )
+    = fails + fails ( expect_opt_i ( ordmap_min_key [i i] m ) 1 `min` )
+    = fails + fails ( expect_opt_i ( ordmap_max_key [i i] m ) 3 `max` )
+
+    // Replace returns the old value; get reflects the new one.
+    = fails + fails ( expect_opt_i ( ordmap_set [i i] m 2 25 \ i a i b → i { ^ - a b } ) 20 `replace` )
+    = fails + fails ( expect_opt_i ( ordmap_get [i i] m 2 \ i a i b → i { ^ - a b } ) 25 `get2b` )
+    ? != ( ordmap_len [i i] m ) 3 { ( nurl_print `  FAIL len after replace\n` ) = fails + fails 1 } {}
+
+    // Remove returns the value; the key is gone afterwards.
+    = fails + fails ( expect_opt_i ( ordmap_remove [i i] m 1 \ i a i b → i { ^ - a b } ) 10 `rm1` )
+    ? != ( ordmap_len [i i] m ) 2 { ( nurl_print `  FAIL len after remove\n` ) = fails + fails 1 } {}
+    ? ( ordmap_contains [i i] m 1 \ i a i b → i { ^ - a b } ) { ( nurl_print `  FAIL still has 1\n` ) = fails + fails 1 } {}
+    ?? ( ordmap_remove [i i] m 99 \ i a i b → i { ^ - a b } ) { T _ → { ( nurl_print `  FAIL removed absent\n` ) = fails + fails 1 } F → {} }
+    ( ordmap_free [i i] m )
+
+    // int → String values, freed via free_with (key drop is a no-op).
+    : ( OrdMap i String ) sm ( ordmap_new [i String] )
+    ?? ( ordmap_set [i String] sm 2 ( string_from `two` ) \ i a i b → i { ^ - a b } ) { T s → ( string_free s ) F → {} }
+    ?? ( ordmap_set [i String] sm 1 ( string_from `one` ) \ i a i b → i { ^ - a b } ) { T s → ( string_free s ) F → {} }
+    : ?String v1 ( ordmap_get [i String] sm 1 \ i a i b → i { ^ - a b } )
+    : s v1r ?? v1 { T s → ( string_data s ) F → `` }
+    ? != 1 ( nurl_str_eq v1r `one` ) { ( nurl_print `  FAIL sval\n` ) = fails + fails 1 } {}
+    ( ordmap_free_with [i String] sm \ i k → v {} \ String s → v { ( string_free s ) } )
+
+    ? == fails 0 { ( nurl_print `ordmap: all checks PASS\n` ) } {
+        ( nurl_print `ordmap: ` ) ( nurl_print ( nurl_str_int fails ) ) ( nurl_print ` FAILURES\n` )
+    }
+    ^ fails
+}

--- a/stdlib/std/deque.nu
+++ b/stdlib/std/deque.nu
@@ -1,0 +1,185 @@
+// stdlib/std/deque.nu — owned generic double-ended queue (ring buffer)
+//
+// A growable circular buffer with O(1) amortized push/pop at BOTH ends
+// and O(1) indexed access. Backed by a single contiguous allocation; on
+// overflow the buffer doubles and the live elements are unwrapped into
+// logical order (head reset to 0).
+//
+// The handle ( Deque A ) wraps a heap control block of four slots:
+//   slot 0 = element buffer pointer   slot 2 = head index
+//   slot 1 = capacity (in elements)   slot 3 = length (live elements)
+//
+// Ownership mirrors Vec: deque_new returns an owned Deque the caller
+// must release. For trivial element types (i, f, b, raw pointers) use
+// deque_free; for owned element types (String, nested Vec, …) use
+// deque_free_with with a per-element drop closure.
+//
+//   ( deque_new        [A] )              → ( Deque A )   empty, no alloc
+//   ( deque_len        [A] d )            → i
+//   ( deque_is_empty   [A] d )            → b
+//   ( deque_push_back  [A] d x )          → v
+//   ( deque_push_front [A] d x )          → v
+//   ( deque_pop_front  [A] d )            → ? A           None when empty
+//   ( deque_pop_back   [A] d )            → ? A           None when empty
+//   ( deque_front      [A] d )            → ? A           peek, no remove
+//   ( deque_back       [A] d )            → ? A           peek, no remove
+//   ( deque_get        [A] d i )          → ? A           0 = front
+//   ( deque_clear      [A] d )            → v             keeps the buffer
+//   ( deque_free       [A] d )            → v
+//   ( deque_free_with  [A] d drop )       → v   drop : (@ v A)
+
+$ `stdlib/core/mem.nu`
+
+: Deque [A] { s ctl }
+
+// ── Internal ──────────────────────────────────────────────────────────
+
+// Ensure at least one free slot; double + unwrap when full. Safe at
+// cap 0 (the copy loop is empty and `% … cap` never runs).
+@ __dq_ensure [A] s ctl → v {
+    : i cap ( nurl_peek ctl 1 )
+    : i len ( nurl_peek ctl 3 )
+    ? >= len cap {
+        : i newcap ? == cap 0 4 * cap 2
+        : i head ( nurl_peek ctl 2 )
+        : s oldbuf # s ( nurl_peek ctl 0 )
+        : s newbuf ( nurl_alloc * Z A newcap )
+        : *A nd # *A newbuf
+        : *A od # *A oldbuf
+        : ~ i i 0
+        ~ < i len {
+            : i src % + head i cap
+            = . nd i . od src
+            = i + i 1
+        }
+        ? != 0 # i oldbuf { ( nurl_free oldbuf ) } {}
+        ( nurl_poke ctl 0 # i newbuf )
+        ( nurl_poke ctl 1 newcap )
+        ( nurl_poke ctl 2 0 )
+    } {}
+}
+
+// ── Constructor / inspectors ──────────────────────────────────────────
+
+@ deque_new [A] → ( Deque A ) {
+    : s ctl ( nurl_zalloc 32 )
+    ^ @ ( Deque A ) { ctl }
+}
+
+@ deque_len [A] ( Deque A ) d → i {
+    ^ ( nurl_peek . d ctl 3 )
+}
+
+@ deque_is_empty [A] ( Deque A ) d → b {
+    ^ == ( nurl_peek . d ctl 3 ) 0
+}
+
+// ── Push ──────────────────────────────────────────────────────────────
+
+@ deque_push_back [A] ( Deque A ) d A x → v {
+    : s ctl . d ctl
+    ( __dq_ensure [A] ctl )
+    : i cap ( nurl_peek ctl 1 )
+    : i head ( nurl_peek ctl 2 )
+    : i len ( nurl_peek ctl 3 )
+    : *A data # *A ( nurl_peek ctl 0 )
+    : i pos % + head len cap
+    = . data pos x
+    ( nurl_poke ctl 3 + len 1 )
+}
+
+@ deque_push_front [A] ( Deque A ) d A x → v {
+    : s ctl . d ctl
+    ( __dq_ensure [A] ctl )
+    : i cap ( nurl_peek ctl 1 )
+    : i head ( nurl_peek ctl 2 )
+    : i len ( nurl_peek ctl 3 )
+    : i nh % + - head 1 cap cap
+    : *A data # *A ( nurl_peek ctl 0 )
+    = . data nh x
+    ( nurl_poke ctl 2 nh )
+    ( nurl_poke ctl 3 + len 1 )
+}
+
+// ── Pop ───────────────────────────────────────────────────────────────
+
+@ deque_pop_front [A] ( Deque A ) d → ?A {
+    : s ctl . d ctl
+    : i len ( nurl_peek ctl 3 )
+    ? == len 0 { ^ @ ?A { F # A 0 } } {}
+    : i cap ( nurl_peek ctl 1 )
+    : i head ( nurl_peek ctl 2 )
+    : *A data # *A ( nurl_peek ctl 0 )
+    : A x . data head
+    ( nurl_poke ctl 2 % + head 1 cap )
+    ( nurl_poke ctl 3 - len 1 )
+    ^ @ ?A { T x }
+}
+
+@ deque_pop_back [A] ( Deque A ) d → ?A {
+    : s ctl . d ctl
+    : i len ( nurl_peek ctl 3 )
+    ? == len 0 { ^ @ ?A { F # A 0 } } {}
+    : i cap ( nurl_peek ctl 1 )
+    : i head ( nurl_peek ctl 2 )
+    : *A data # *A ( nurl_peek ctl 0 )
+    : i idx % + head - len 1 cap
+    : A x . data idx
+    ( nurl_poke ctl 3 - len 1 )
+    ^ @ ?A { T x }
+}
+
+// ── Peek / index (0 = front) ──────────────────────────────────────────
+
+@ deque_get [A] ( Deque A ) d i idx → ?A {
+    : s ctl . d ctl
+    : i len ( nurl_peek ctl 3 )
+    ? | < idx 0 >= idx len { ^ @ ?A { F # A 0 } } {}
+    : i cap ( nurl_peek ctl 1 )
+    : i head ( nurl_peek ctl 2 )
+    : *A data # *A ( nurl_peek ctl 0 )
+    : i pos % + head idx cap
+    : A x . data pos
+    ^ @ ?A { T x }
+}
+
+@ deque_front [A] ( Deque A ) d → ?A {
+    ^ ( deque_get [A] d 0 )
+}
+
+@ deque_back [A] ( Deque A ) d → ?A {
+    : i len ( nurl_peek . d ctl 3 )
+    ? == len 0 { ^ @ ?A { F # A 0 } } {}
+    ^ ( deque_get [A] d - len 1 )
+}
+
+// ── Clear / free ──────────────────────────────────────────────────────
+
+@ deque_clear [A] ( Deque A ) d → v {
+    ( nurl_poke . d ctl 2 0 )
+    ( nurl_poke . d ctl 3 0 )
+}
+
+@ deque_free [A] ( Deque A ) d → v {
+    : s ctl . d ctl
+    : s buf # s ( nurl_peek ctl 0 )
+    ? != 0 # i buf { ( nurl_free buf ) } {}
+    ( nurl_free ctl )
+}
+
+@ deque_free_with [A] ( Deque A ) d ( @ v A ) drop → v {
+    : s ctl . d ctl
+    : i len ( nurl_peek ctl 3 )
+    : i cap ( nurl_peek ctl 1 )
+    : i head ( nurl_peek ctl 2 )
+    : *A data # *A ( nurl_peek ctl 0 )
+    : ~ i i 0
+    ~ < i len {
+        : i pos % + head i cap
+        ( drop . data pos )
+        = i + i 1
+    }
+    : s buf # s ( nurl_peek ctl 0 )
+    ? != 0 # i buf { ( nurl_free buf ) } {}
+    ( nurl_free ctl )
+}

--- a/stdlib/std/heap.nu
+++ b/stdlib/std/heap.nu
@@ -1,0 +1,112 @@
+// stdlib/std/heap.nu — owned generic binary heap / priority queue
+//
+// An array-backed binary heap over a ( Vec A ). The ordering is decided
+// by a comparator `cmp : (@ i A A)` passed to every mutating call (the
+// same convention as sort_by / binary_search): `cmp a b` returns < 0
+// when `a` should leave the heap before `b`. So a comparator that
+// orders ascending yields a MIN-heap (smallest pops first); pass a
+// reversed comparator for a max-heap / highest-priority-first queue.
+//
+// The same comparator must be used across a heap's lifetime — mixing
+// orderings corrupts the heap invariant.
+//
+//   ( heap_new       [A] )            → ( Heap A )   empty
+//   ( heap_len       [A] h )          → i
+//   ( heap_is_empty  [A] h )          → b
+//   ( heap_push      [A] h x cmp )    → v            O(log n)
+//   ( heap_pop       [A] h cmp )      → ? A          remove + return top, O(log n)
+//   ( heap_peek      [A] h )          → ? A          inspect top, no remove
+//   ( heap_free      [A] h )          → v            trivial element types
+//   ( heap_free_with [A] h drop )     → v   drop : (@ v A)
+
+$ `stdlib/core/vec.nu`
+
+: Heap [A] { ( Vec A ) data }
+
+// ── Internal sift helpers (operate on the raw element buffer) ─────────
+
+@ __heap_swap [A] *A data i i i j → v {
+    : A t . data i
+    = . data i . data j
+    = . data j t
+}
+
+@ __heap_sift_up [A] *A data i start ( @ i A A ) cmp → v {
+    : ~ i i start
+    : ~ b go ? > i 0 T F
+    ~ go {
+        : i parent / - i 1 2
+        ? < ( cmp . data i . data parent ) 0 {
+            ( __heap_swap [A] data i parent )
+            = i parent
+            = go ? > i 0 T F
+        } {
+            = go F
+        }
+    }
+}
+
+@ __heap_sift_down [A] *A data i start i n ( @ i A A ) cmp → v {
+    : ~ i i start
+    : ~ b go T
+    ~ go {
+        : i l + * 2 i 1
+        : i r + * 2 i 2
+        : ~ i small i
+        ? & < l n < ( cmp . data l . data small ) 0 { = small l } {}
+        ? & < r n < ( cmp . data r . data small ) 0 { = small r } {}
+        ? == small i {
+            = go F
+        } {
+            ( __heap_swap [A] data i small )
+            = i small
+        }
+    }
+}
+
+// ── API ───────────────────────────────────────────────────────────────
+
+@ heap_new [A] → ( Heap A ) {
+    ^ @ ( Heap A ) { ( vec_new [A] ) }
+}
+
+@ heap_len [A] ( Heap A ) h → i {
+    ^ ( vec_len [A] . h data )
+}
+
+@ heap_is_empty [A] ( Heap A ) h → b {
+    ^ == ( vec_len [A] . h data ) 0
+}
+
+@ heap_push [A] ( Heap A ) h A x ( @ i A A ) cmp → v {
+    ( vec_push [A] . h data x )
+    : i n ( vec_len [A] . h data )
+    : *A d ( vec_data [A] . h data )
+    ( __heap_sift_up [A] d - n 1 cmp )
+}
+
+@ heap_peek [A] ( Heap A ) h → ?A {
+    ^ ( vec_get [A] . h data 0 )
+}
+
+@ heap_pop [A] ( Heap A ) h ( @ i A A ) cmp → ?A {
+    : i n ( vec_len [A] . h data )
+    ? == n 0 { ^ @ ?A { F # A 0 } } {}
+    : *A d ( vec_data [A] . h data )
+    : A root . d 0
+    // Move the last element to the root, drop the (now duplicated) tail
+    // slot, then sift the new root down over the shrunken length.
+    = . d 0 . d - n 1
+    ( vec_pop [A] . h data )
+    : i m - n 1
+    ? > m 1 { ( __heap_sift_down [A] d 0 m cmp ) } {}
+    ^ @ ?A { T root }
+}
+
+@ heap_free [A] ( Heap A ) h → v {
+    ( vec_free [A] . h data )
+}
+
+@ heap_free_with [A] ( Heap A ) h ( @ v A ) drop → v {
+    ( vec_free_with [A] . h data drop )
+}

--- a/stdlib/std/ordmap.nu
+++ b/stdlib/std/ordmap.nu
@@ -1,0 +1,136 @@
+// stdlib/std/ordmap.nu — owned generic ordered map (sorted-array backed)
+//
+// A key→value map that keeps its keys in sorted order, so iteration is
+// ordered and range/min/max queries are cheap. Backed by two parallel
+// ( Vec K ) / ( Vec V ) arrays kept in lock-step; lookup is O(log n)
+// binary search, insert/remove are O(n) (the shift), and ordered
+// iteration is O(1) per step. This is the "flat map" shape — simpler
+// and more cache-friendly than a B-tree for small/medium maps; swap the
+// backing for a B-tree later if O(log n) writes become the bottleneck.
+//
+// Ordering is decided by a key comparator `cmp : (@ i K K)` passed to
+// every keyed call (same convention as sort_by / hashmap's hash_fn):
+// `cmp a b` returns < 0 / 0 / > 0. Use the SAME comparator for a map's
+// whole lifetime.
+//
+//   ( ordmap_new       [K V] )              → ( OrdMap K V )
+//   ( ordmap_len       [K V] m )            → i
+//   ( ordmap_is_empty  [K V] m )            → b
+//   ( ordmap_get       [K V] m k cmp )      → ? V
+//   ( ordmap_set       [K V] m k v cmp )    → ? V   Some(prev) on replace
+//   ( ordmap_remove    [K V] m k cmp )      → ? V   Some(val) if removed
+//   ( ordmap_contains  [K V] m k cmp )      → b
+//   ( ordmap_key_at    [K V] m i )          → ? K   i-th smallest key
+//   ( ordmap_val_at    [K V] m i )          → ? V   its value
+//   ( ordmap_min_key   [K V] m )            → ? K
+//   ( ordmap_max_key   [K V] m )            → ? K
+//   ( ordmap_free      [K V] m )            → v     trivial K/V
+//   ( ordmap_free_with [K V] m dk dv )      → v     dk:(@ v K) dv:(@ v V)
+//
+// Ownership: mirrors Vec/HashMap. On ordmap_set REPLACE, the existing
+// equal key is kept and the passed-in `k` is NOT stored — for owned
+// keys the caller still owns that `k`. ordmap_remove returns the value;
+// for owned-key maps prefer bulk teardown via ordmap_free_with.
+
+$ `stdlib/core/vec.nu`
+
+: OrdMap [K V] { ( Vec K ) keys ( Vec V ) vals }
+
+// Smallest index `i` with keys[i] >= k (lower bound). Equals len when
+// k is greater than every key. The insertion point for k.
+@ __om_lb [K V] ( Vec K ) keys K k ( @ i K K ) cmp → i {
+    : i n ( vec_len [K] keys )
+    : ~ i lo 0
+    : ~ i hi n
+    ~ < lo hi {
+        : i mid / + lo hi 2
+        : ?K kmo ( vec_get [K] keys mid )
+        : K km ?? kmo { T x → x F → k }
+        ? < ( cmp km k ) 0 { = lo + mid 1 } { = hi mid }
+    }
+    ^ lo
+}
+
+@ ordmap_new [K V] → ( OrdMap K V ) {
+    ^ @ ( OrdMap K V ) { ( vec_new [K] ) ( vec_new [V] ) }
+}
+
+@ ordmap_len [K V] ( OrdMap K V ) m → i {
+    ^ ( vec_len [K] . m keys )
+}
+
+@ ordmap_is_empty [K V] ( OrdMap K V ) m → b {
+    ^ == ( vec_len [K] . m keys ) 0
+}
+
+@ ordmap_get [K V] ( OrdMap K V ) m K k ( @ i K K ) cmp → ?V {
+    : i idx ( __om_lb [K V] . m keys k cmp )
+    : i n ( vec_len [K] . m keys )
+    ? >= idx n { ^ @ ?V { F # V 0 } } {}
+    : ?K kmo ( vec_get [K] . m keys idx )
+    : K km ?? kmo { T x → x F → k }
+    ? == ( cmp km k ) 0 { ^ ( vec_get [V] . m vals idx ) } {}
+    ^ @ ?V { F # V 0 }
+}
+
+@ ordmap_contains [K V] ( OrdMap K V ) m K k ( @ i K K ) cmp → b {
+    ^ ?? ( ordmap_get [K V] m k cmp ) { T _ → T F → F }
+}
+
+@ ordmap_set [K V] ( OrdMap K V ) m K k V val ( @ i K K ) cmp → ?V {
+    : i idx ( __om_lb [K V] . m keys k cmp )
+    : i n ( vec_len [K] . m keys )
+    ? < idx n {
+        : ?K kmo ( vec_get [K] . m keys idx )
+        : K km ?? kmo { T x → x F → k }
+        ? == ( cmp km k ) 0 {
+            : ?V oldo ( vec_get [V] . m vals idx )
+            ( vec_set [V] . m vals idx val )
+            ^ oldo
+        } {}
+    } {}
+    ( vec_insert [K] . m keys idx k )
+    ( vec_insert [V] . m vals idx val )
+    ^ @ ?V { F # V 0 }
+}
+
+@ ordmap_remove [K V] ( OrdMap K V ) m K k ( @ i K K ) cmp → ?V {
+    : i idx ( __om_lb [K V] . m keys k cmp )
+    : i n ( vec_len [K] . m keys )
+    ? >= idx n { ^ @ ?V { F # V 0 } } {}
+    : ?K kmo ( vec_get [K] . m keys idx )
+    : K km ?? kmo { T x → x F → k }
+    ? == ( cmp km k ) 0 {
+        ( vec_remove [K] . m keys idx )
+        ^ ( vec_remove [V] . m vals idx )
+    } {}
+    ^ @ ?V { F # V 0 }
+}
+
+@ ordmap_key_at [K V] ( OrdMap K V ) m i idx → ?K {
+    ^ ( vec_get [K] . m keys idx )
+}
+
+@ ordmap_val_at [K V] ( OrdMap K V ) m i idx → ?V {
+    ^ ( vec_get [V] . m vals idx )
+}
+
+@ ordmap_min_key [K V] ( OrdMap K V ) m → ?K {
+    ^ ( vec_get [K] . m keys 0 )
+}
+
+@ ordmap_max_key [K V] ( OrdMap K V ) m → ?K {
+    : i n ( vec_len [K] . m keys )
+    ? == n 0 { ^ @ ?K { F # K 0 } } {}
+    ^ ( vec_get [K] . m keys - n 1 )
+}
+
+@ ordmap_free [K V] ( OrdMap K V ) m → v {
+    ( vec_free [K] . m keys )
+    ( vec_free [V] . m vals )
+}
+
+@ ordmap_free_with [K V] ( OrdMap K V ) m ( @ v K ) dk ( @ v V ) dv → v {
+    ( vec_free_with [K] . m keys dk )
+    ( vec_free_with [V] . m vals dv )
+}


### PR DESCRIPTION
Closes the Tier 5b **collection types** gap (deque / ring buffer, binary heap / priority queue, ordered map). All three are pure NURL with **no compiler change**, following the existing opaque-handle generic-container conventions (`nurl_peek`/`nurl_poke` ctl slots, `* A` raw element pointers, comparator closures passed per op à la `sort_by` / `hashmap`).

## `std/deque.nu` — generic `( Deque A )` ring buffer
Growable circular buffer with O(1) amortized push/pop at **both** ends and O(1) indexed access. On overflow the buffer doubles and the live elements are unwrapped into logical order (head reset to 0). `deque_push_back` / `deque_push_front` / `deque_pop_front` / `deque_pop_back` / `deque_front` / `deque_back` / `deque_get` / `deque_clear` + `deque_free` / `deque_free_with`.

## `std/heap.nu` — generic `( Heap A )` binary heap / priority queue
Array-backed binary heap over a `( Vec A )`. A comparator `cmp : (@ i A A)` is passed to each mutating call (the `sort_by` convention): ascending order yields a min-heap, a reversed comparator a max-heap. `heap_push` / `heap_pop` / `heap_peek`, O(log n).

## `std/ordmap.nu` — generic `( OrdMap K V )` ordered map
Backed by two parallel sorted key/value arrays: O(log n) binary-search lookup, ordered iteration, `min`/`max`, O(n) insert/remove (the shift). This is the flat-map shape — simpler and more cache-friendly than a B-tree for small/medium maps; the backing can be swapped for a B-tree later if O(log n) writes become the bottleneck. `ordmap_get` / `_set` (returns `Some(prev)` on replace) / `_remove` / `_contains` / `_key_at` / `_val_at` / `_min_key` / `_max_key` + `ordmap_free` / `ordmap_free_with`.

## Tests
`compiler/tests/{deque,heap,ordmap}_basic.nu` cover the full API surface: deque wraparound + repeated growth while `head != 0`, heap pop-ordering from a scrambled set, ordered-map insert-out-of-order/ordered-readback/replace/remove/min/max, and the owned-element `free_with` teardown. All three run clean under `-fsanitize=address,undefined` with leak detection. Full suite green (`failures.txt` empty, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)