### PR TITLE
feat(mcp): stateful sessions + SSE stream + sampling reverse RPC

### DIFF
--- a/compiler/tests/mcp_http_session.nu
+++ b/compiler/tests/mcp_http_session.nu
@@ -1,0 +1,143 @@
+// Regression: stdlib/ext/mcp_http.nu session-aware handler
+// (mcp_http_handler_session). Builds synthetic HttpRequests in-memory
+// and drives them through the handler — no socket — checking: session
+// issuance on initialize, echo + validation of Mcp-Session-Id, 404 on
+// an unknown id, GET draining the outbound queue as SSE events, the
+// reverse-RPC response settling path, and DELETE teardown. Returns the
+// failure count.
+
+$ `stdlib/ext/mcp_http.nu`
+$ `stdlib/ext/mcp_session.nu`
+$ `stdlib/ext/mcp.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/http.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+// Build a synthetic request; sid == "" omits the session header.
+@ make_req s method s body s sid → HttpRequest {
+    : HttpRequest req ( request_new )
+    ( string_push_str . req method method )
+    ( string_push_str . req path `/mcp` )
+    ? > ( nurl_str_len sid ) 0 {
+        ( vec_push [Header] . req headers ( header_new `Mcp-Session-Id` sid ) )
+    } {}
+    ? > ( nurl_str_len body ) 0 { ( bytes_extend_str . req body body ) } {}
+    ^ req
+}
+
+@ resp_body_str HttpResponse r → String {
+    ^ ( bytes_to_str . r body )
+}
+
+// Minimal dispatcher: initialize → result envelope; ping → {ok:true};
+// anything with no id → notification (None).
+@ test_dispatch Json req → ?Json {
+    : ?Json ido ( json_obj_get req `id` )
+    : b has_id ?? ido { T _ → T F → F }
+    ? ! has_id { ^ @ ?Json { F # Json 0 } } {}
+    : ?Json mo ( json_obj_get req `method` )
+    : s method ?? mo { T mj → ( json_str_data mj ) F → `` }
+    : ?Json idc ( json_obj_get req `id` )
+    : Json id ?? idc { T j → ( json_clone j ) F → ( json_null ) }
+    ? == 1 ( nurl_str_eq method `initialize` ) {
+        : Json res ( mcp_initialize_result `test` `0.1` )
+        : Json out ( mcp_response_result id res )
+        ( json_free id )
+        ^ @ ?Json { T out }
+    } {}
+    : Json res ( json_obj_new )
+    ( json_obj_set res `ok` ( json_bool T ) )
+    : Json out ( mcp_response_result id res )
+    ( json_free id )
+    ^ @ ?Json { T out }
+}
+
+@ main → i {
+    : ~ i fails 0
+    : McpSessionStore store ( mcp_session_store_new )
+    : ( @ HttpResponse HttpRequest ) handler ( mcp_http_handler_session store \ Json req → ?Json { ^ ( test_dispatch req ) } )
+
+    // 1. initialize → 200, and a Mcp-Session-Id is minted.
+    : HttpRequest r1 ( make_req `POST` `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` `` )
+    : HttpResponse resp1 ( handler r1 )
+    ? != . resp1 status 200 { ( nurl_print `  FAIL init status\n` ) = fails + fails 1 } {}
+    : String sid ( string_new )
+    : ?String sido ( header_get . resp1 headers `Mcp-Session-Id` )
+    ?? sido { T s → { ( string_push_str sid ( string_data s ) ) ( string_free s ) } F _ → {} }
+    ? != ( string_len sid ) 32 { ( nurl_print `  FAIL no session id minted\n` ) = fails + fails 1 } {}
+    ? != ( mcp_session_count store ) 1 { ( nurl_print `  FAIL store count\n` ) = fails + fails 1 } {}
+    ( request_free r1 )
+    ( http_response_free resp1 )
+
+    // 2. follow-up with the valid session id → 200, echoed back.
+    : HttpRequest r2 ( make_req `POST` `{"jsonrpc":"2.0","id":2,"method":"ping"}` ( string_data sid ) )
+    : HttpResponse resp2 ( handler r2 )
+    ? != . resp2 status 200 { ( nurl_print `  FAIL ping status\n` ) = fails + fails 1 } {}
+    : ?String echo ( header_get . resp2 headers `Mcp-Session-Id` )
+    ?? echo { T s → { ? != 1 ( nurl_str_eq ( string_data s ) ( string_data sid ) ) { ( nurl_print `  FAIL echo mismatch\n` ) = fails + fails 1 } {} ( string_free s ) } F _ → { ( nurl_print `  FAIL no echo\n` ) = fails + fails 1 } }
+    ( request_free r2 )
+    ( http_response_free resp2 )
+
+    // 3. unknown session id → 404.
+    : HttpRequest r3 ( make_req `POST` `{"jsonrpc":"2.0","id":3,"method":"ping"}` `deadbeefdeadbeefdeadbeefdeadbeef` )
+    : HttpResponse resp3 ( handler r3 )
+    ? != . resp3 status 404 { ( nurl_print `  FAIL unknown-session status\n` ) = fails + fails 1 } {}
+    ( request_free r3 )
+    ( http_response_free resp3 )
+
+    // 4. queue a server→client message, then GET drains it as SSE.
+    ( mcp_session_push_notify store ( string_data sid ) ( mcp_notification `notifications/message` ( json_str_lit `ping-from-server` ) ) )
+    : HttpRequest r4 ( make_req `GET` `` ( string_data sid ) )
+    : HttpResponse resp4 ( handler r4 )
+    ? != . resp4 status 200 { ( nurl_print `  FAIL get status\n` ) = fails + fails 1 } {}
+    : String sse ( resp_body_str resp4 )
+    ? ! ( string_starts_with sse `event: message\r\ndata: ` ) { ( nurl_print `  FAIL sse not drained\n` ) = fails + fails 1 } {}
+    ? < ( nurl_str_find ( string_data sse ) `ping-from-server` ) 0 { ( nurl_print `  FAIL sse payload\n` ) = fails + fails 1 } {}
+    ( string_free sse )
+    ( request_free r4 )
+    ( http_response_free resp4 )
+    // Queue is now empty: a second GET yields the ready stub.
+    : HttpRequest r4b ( make_req `GET` `` ( string_data sid ) )
+    : HttpResponse resp4b ( handler r4b )
+    : String sse2 ( resp_body_str resp4b )
+    ? < ( nurl_str_find ( string_data sse2 ) `event: message` ) 0 {} { ( nurl_print `  FAIL queue not cleared\n` ) = fails + fails 1 }
+    ( string_free sse2 )
+    ( request_free r4b )
+    ( http_response_free resp4b )
+
+    // 5. reverse-RPC response (no method, has result) → 202 + resolved.
+    : i rid ( mcp_session_begin_rpc store ( string_data sid ) `sampling/createMessage` ( json_obj_new ) )
+    ? != rid 1 { ( nurl_print `  FAIL begin_rpc id\n` ) = fails + fails 1 } {}
+    : HttpRequest r5 ( make_req `POST` `{"jsonrpc":"2.0","id":1,"result":{"role":"assistant"}}` ( string_data sid ) )
+    : HttpResponse resp5 ( handler r5 )
+    ? != . resp5 status 202 { ( nurl_print `  FAIL rpc-response status\n` ) = fails + fails 1 } {}
+    ? ( mcp_session_is_pending store ( string_data sid ) rid ) { ( nurl_print `  FAIL rpc still pending\n` ) = fails + fails 1 } {}
+    ?? ( mcp_session_take_result store ( string_data sid ) rid ) { T j → ( json_free j ) F → { ( nurl_print `  FAIL rpc not resolved\n` ) = fails + fails 1 } }
+    ( request_free r5 )
+    ( http_response_free resp5 )
+    // begin_rpc also enqueued an outbound request frame — drain + drop it.
+    : ( Vec Json ) leftover ( mcp_session_drain_notify store ( string_data sid ) )
+    : ~ i li 0
+    ~ < li ( vec_len [Json] leftover ) { ?? ( vec_get [Json] leftover li ) { T j → ( json_free j ) F → {} } = li + li 1 }
+    ( vec_free [Json] leftover )
+
+    // 6. DELETE tears the session down.
+    : HttpRequest r6 ( make_req `DELETE` `` ( string_data sid ) )
+    : HttpResponse resp6 ( handler r6 )
+    ? != . resp6 status 204 { ( nurl_print `  FAIL delete status\n` ) = fails + fails 1 } {}
+    ? != ( mcp_session_count store ) 0 { ( nurl_print `  FAIL not deleted\n` ) = fails + fails 1 } {}
+    ( request_free r6 )
+    ( http_response_free resp6 )
+
+    ( string_free sid )
+    ( mcp_session_store_free store )
+
+    ? == fails 0 { ( nurl_print `mcp_http_session: all checks PASS\n` ) } {
+        ( nurl_print `mcp_http_session: ` ) ( nurl_print ( nurl_str_int fails ) ) ( nurl_print ` FAILURES\n` )
+    }
+    ^ fails
+}

--- a/compiler/tests/mcp_session_basic.nu
+++ b/compiler/tests/mcp_session_basic.nu
@@ -1,0 +1,106 @@
+// Regression: stdlib/ext/mcp_session.nu — stateful MCP session store,
+// outbound notification queue, and server→client (reverse) RPC
+// correlation for sampling/createMessage. Pure in-memory; no sockets.
+// Returns the failure count.
+
+$ `stdlib/ext/mcp_session.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/mcp.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+@ main → i {
+    : ~ i fails 0
+
+    : McpSessionStore store ( mcp_session_store_new )
+    ? != ( mcp_session_count store ) 0 { ( nurl_print `  FAIL count0\n` ) = fails + fails 1 } {}
+
+    : String id ( mcp_session_create store )
+    : s sid ( string_data id )
+    ? != ( mcp_session_count store ) 1 { ( nurl_print `  FAIL count1\n` ) = fails + fails 1 } {}
+    ? ! ( mcp_session_valid store sid ) { ( nurl_print `  FAIL valid\n` ) = fails + fails 1 } {}
+    ? ( mcp_session_valid store `bogus` ) { ( nurl_print `  FAIL valid-bogus\n` ) = fails + fails 1 } {}
+    // 32 hex chars of session id
+    ? != ( nurl_str_len sid ) 32 { ( nurl_print `  FAIL id-len\n` ) = fails + fails 1 } {}
+    ? ! ( mcp_session_touch store sid 12345 ) { ( nurl_print `  FAIL touch\n` ) = fails + fails 1 } {}
+
+    // ── Outbound notification queue ──
+    ( mcp_session_push_notify store sid ( mcp_notification `notifications/message` ( json_str_lit `hi` ) ) )
+    ( mcp_session_push_notify store sid ( mcp_notification `notifications/message` ( json_str_lit `bye` ) ) )
+    : ( Vec Json ) q1 ( mcp_session_drain_notify store sid )
+    ? != ( vec_len [Json] q1 ) 2 { ( nurl_print `  FAIL drain2\n` ) = fails + fails 1 } {}
+    ( vec_free_with [Json] q1 \ Json j → v { ( json_free j ) } )
+    // Drain again → empty (queue cleared).
+    : ( Vec Json ) q2 ( mcp_session_drain_notify store sid )
+    ? != ( vec_len [Json] q2 ) 0 { ( nurl_print `  FAIL drain-empty\n` ) = fails + fails 1 } {}
+    ( vec_free [Json] q2 )
+
+    // ── Reverse RPC: sampling/createMessage ──
+    : ( Vec Json ) msgs ( vec_new [Json] )
+    ( vec_push [Json] msgs ( mcp_sampling_message `user` `What is 2+2?` ) )
+    : i rpc_id ( mcp_session_request_sampling store sid msgs `Be terse.` 64 )
+    ? != rpc_id 1 { ( nurl_print `  FAIL rpc-id\n` ) = fails + fails 1 } {}
+    ? ! ( mcp_session_is_pending store sid rpc_id ) { ( nurl_print `  FAIL pending\n` ) = fails + fails 1 } {}
+
+    // The request must be queued for the client; inspect method + id.
+    : ( Vec Json ) outq ( mcp_session_drain_notify store sid )
+    ? != ( vec_len [Json] outq ) 1 { ( nurl_print `  FAIL rpc-queued\n` ) = fails + fails 1 } {}
+    : ?Json reqo ( vec_get [Json] outq 0 )
+    ?? reqo {
+        T req → {
+            : ?Json mo ( json_obj_get req `method` )
+            ?? mo { T mj → { ? != 1 ( nurl_str_eq ( json_str_data mj ) `sampling/createMessage` ) { ( nurl_print `  FAIL rpc-method\n` ) = fails + fails 1 } {} } F → { ( nurl_print `  FAIL no-method\n` ) = fails + fails 1 } }
+            : ?Json io ( json_obj_get req `id` )
+            ?? io { T ij → { ? != ( json_as_int ij ) 1 { ( nurl_print `  FAIL rpc-reqid\n` ) = fails + fails 1 } {} } F → {} }
+        }
+        F → {}
+    }
+    ( vec_free_with [Json] outq \ Json j → v { ( json_free j ) } )
+
+    // Take before resolve → None.
+    ?? ( mcp_session_take_result store sid rpc_id ) { T j → { ( nurl_print `  FAIL early-result\n` ) ( json_free j ) = fails + fails 1 } F → {} }
+
+    // Client posts back the response → resolve.
+    : Json result ( json_obj_new )
+    ( json_obj_set result `role` ( json_str_lit `assistant` ) )
+    ( json_obj_set result `content` ( mcp_text_content `4` ) )
+    : Json id_node ( json_int rpc_id )
+    : Json response ( mcp_response_result id_node result )
+    ( json_free id_node )
+    ? ! ( mcp_session_resolve_rpc store sid response ) { ( nurl_print `  FAIL resolve\n` ) = fails + fails 1 } {}
+    // Pending marker cleared.
+    ? ( mcp_session_is_pending store sid rpc_id ) { ( nurl_print `  FAIL still-pending\n` ) = fails + fails 1 } {}
+
+    // Caller collects the result.
+    ?? ( mcp_session_take_result store sid rpc_id ) {
+        T j → {
+            : ?Json ro ( json_obj_get j `result` )
+            ? ?? ro { T _ → F F → T } { ( nurl_print `  FAIL result-shape\n` ) = fails + fails 1 } {}
+            ( json_free j )
+        }
+        F → { ( nurl_print `  FAIL no-result\n` ) = fails + fails 1 }
+    }
+    // Taken once → gone.
+    ?? ( mcp_session_take_result store sid rpc_id ) { T j → { ( nurl_print `  FAIL double-take\n` ) ( json_free j ) = fails + fails 1 } F → {} }
+
+    // ── SSE frame format ──
+    : Json sse_data ( json_str_lit `ok` )
+    : String frame ( mcp_sse_frame `message` sse_data )
+    ( json_free sse_data )   // mcp_sse_frame borrows its data
+    ? ! ( string_starts_with frame `event: message\r\ndata: ` ) { ( nurl_print `  FAIL sse-prefix\n` ) = fails + fails 1 } {}
+    ? ! ( string_ends_with frame `\r\n\r\n` ) { ( nurl_print `  FAIL sse-suffix\n` ) = fails + fails 1 } {}
+    ( string_free frame )
+
+    // ── Delete ──
+    ? ! ( mcp_session_delete store sid ) { ( nurl_print `  FAIL delete\n` ) = fails + fails 1 } {}
+    ? != ( mcp_session_count store ) 0 { ( nurl_print `  FAIL count-after-delete\n` ) = fails + fails 1 } {}
+    ? ( mcp_session_valid store sid ) { ( nurl_print `  FAIL valid-after-delete\n` ) = fails + fails 1 } {}
+
+    ( string_free id )
+    ( mcp_session_store_free store )
+
+    ? == fails 0 { ( nurl_print `mcp_session: all checks PASS\n` ) } {
+        ( nurl_print `mcp_session: ` ) ( nurl_print ( nurl_str_int fails ) ) ( nurl_print ` FAILURES\n` )
+    }
+    ^ fails
+}

--- a/stdlib/ext/mcp_http.nu
+++ b/stdlib/ext/mcp_http.nu
@@ -75,16 +75,23 @@
 //   * On the None arm, the placeholder Json (a JNull node) is freed
 //     by the handler. Cost is one tiny allocation per notification.
 //
+// Stateful transport (sessions + SSE + reverse RPC) — SHIPPED. The
+// `mcp_http_handler_session store dispatch` handler (bottom of this file,
+// built on `mcp_session.nu`) issues an `Mcp-Session-Id` on `initialize`,
+// validates it on later requests (404 on an unknown id), drains a
+// per-session outbound queue to SSE `message` events on GET, settles
+// server→client (reverse) RPC responses (`sampling/createMessage`), and
+// tears the session down on DELETE. The `mcp_sse_*` chunked helpers give
+// a custom accept loop the pieces for a continuous long-lived stream.
+// The plain `mcp_http_handler` below stays the stateless single/batch
+// path.
+//
 // Limitations / not yet implemented (each is straight-line work, just
 // outside the MVP):
-//   * GET /mcp continuous SSE stream — v2 returns a single ready
-//     event then closes the connection. Pushing notifications over
-//     time needs a notification queue + Last-Event-ID resumption + a
-//     custom accept loop using the chunked streaming primitives
-//     (`response_begin_chunked` / `_write_chunk` / `_end_chunked`).
-//   * Mcp-Session-Id state pinning — v2 echoes the header but stores
-//     no per-session state. Stateful dispatch needs a session-id →
-//     state map + per-session dispatcher closure.
+//   * Last-Event-ID resumption for the continuous SSE stream (the queue
+//     is fire-and-forget; a dropped connection loses un-flushed events).
+//   * Session-aware handler is single-request only — batch arrays still
+//     go through the stateless `mcp_http_handler`.
 //   * (BATCH NOW SHIPPED) Top-level `[req1, req2, ...]` arrays route
 //     through `dispatch` per element; non-notification responses are
 //     collected into an array response; pure-notification batches
@@ -96,6 +103,7 @@
 //     using `http_router.nu`'s closure-wrapping pattern.
 
 $ `stdlib/ext/mcp.nu`
+$ `stdlib/ext/mcp_session.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
@@ -391,4 +399,268 @@ s host i port
         }
         F e → ^ @ !v NetErr { F e }
     }
+}
+
+// ── Stateful session transport (sessions + SSE + reverse RPC) ─────────
+//
+// `mcp_http_handler_session` upgrades the stateless handler with the
+// `McpSessionStore` from `mcp_session.nu`:
+//
+//   * POST initialize → a fresh session id is minted and returned in the
+//     `Mcp-Session-Id` response header. The client echoes it on every
+//     later request.
+//   * POST with a `Mcp-Session-Id` that the store does not know → 404
+//     (per the MCP spec's "session expired" semantics). A request with
+//     NO session id is allowed through (lenient — many tools omit it
+//     until they've seen one).
+//   * POST that is itself a JSON-RPC RESPONSE (no `method`, carries
+//     `result`/`error`) → routed to `mcp_session_resolve_rpc`, settling
+//     a server→client reverse RPC (e.g. `sampling/createMessage`); the
+//     server replies 202 Accepted.
+//   * GET → drains the session's outbound queue and writes each queued
+//     message as an SSE `message` event (a real notification flush, not
+//     the static stub). With no/invalid session it emits a `ready` event.
+//   * DELETE → tears the session down in the store.
+//
+// Batch arrays are not handled here — point batch clients at the
+// stateless `mcp_http_handler`; sessions are a single-request flow.
+//
+// For a CONTINUOUS (long-lived) SSE stream, a custom accept loop owns
+// the TcpConn and uses the `mcp_sse_*` chunked helpers below; the
+// per-request GET drain above is the simple, handler-compatible path.
+
+@ __mcp_session_get_method Json req → s {
+    : ?Json mo ( json_obj_get req `method` )
+    ^ ?? mo {
+        T mj → { ? ( json_is_str mj ) { ^ ( json_str_data mj ) } {} ^ `` }
+        F → ``
+    }
+}
+
+@ __mcp_req_is_response Json req → b {
+    // A JSON-RPC response carries result/error and no method.
+    ? ( json_obj_has req `method` ) { ^ F } {}
+    ^ | ( json_obj_has req `result` ) ( json_obj_has req `error` )
+}
+
+@ mcp_http_handler_session
+McpSessionStore store
+( @ ?Json Json ) dispatch
+→ ( @ HttpResponse HttpRequest ) {
+    ^ \ HttpRequest req → HttpResponse {
+        : s rm ( string_data . req method )
+
+        ? != 0 ( nurl_str_eq rm `OPTIONS` ) {
+            : HttpResponse pre ( response_status_only 204 )
+            ( response_set_header pre `Access-Control-Allow-Methods` `POST, GET, DELETE, OPTIONS` )
+            ( response_set_header pre `Access-Control-Max-Age` `86400` )
+            ( __mcp_http_apply_cors pre )
+            ( __mcp_http_echo_session req pre )
+            ^ pre
+        } {}
+
+        // GET: flush the session's outbound queue as SSE events.
+        ? != 0 ( nurl_str_eq rm `GET` ) {
+            : String body ( string_new )
+            : ~ b have F
+            : ?String sido ( header_get . req headers `Mcp-Session-Id` )
+            ?? sido {
+                T s → {
+                    ? ( mcp_session_valid store ( string_data s ) ) {
+                        = have T
+                        : ( Vec Json ) q ( mcp_session_drain_notify store ( string_data s ) )
+                        : i n ( vec_len [Json] q )
+                        : ~ i k 0
+                        ~ < k n {
+                            : ?Json e ( vec_get [Json] q k )
+                            ?? e {
+                                T jv → {
+                                    : String f ( mcp_sse_frame `message` jv )
+                                    ( string_push_str body ( string_data f ) )
+                                    ( string_free f )
+                                    ( json_free jv )
+                                }
+                                F → {}
+                            }
+                            = k + k 1
+                        }
+                        ( vec_free [Json] q )
+                    } {}
+                    ( string_free s )
+                }
+                F _ → {}
+            }
+            ? ! have { ( string_push_str body `event: ready\r\ndata: {"server":"nurl-mcp"}\r\n\r\n` ) } {}
+            : HttpResponse r ( response_text 200 ( string_data body ) )
+            ( string_free body )
+            ( response_set_header r `Content-Type` `text/event-stream` )
+            ( response_set_header r `Cache-Control` `no-cache` )
+            ( __mcp_http_apply_cors r )
+            ( __mcp_http_echo_session req r )
+            ^ r
+        } {}
+
+        // DELETE: tear the session down.
+        ? != 0 ( nurl_str_eq rm `DELETE` ) {
+            : ?String sido ( header_get . req headers `Mcp-Session-Id` )
+            ?? sido { T s → { ( mcp_session_delete store ( string_data s ) ) ( string_free s ) } F _ → {} }
+            : HttpResponse r ( response_status_only 204 )
+            ( __mcp_http_apply_cors r )
+            ( __mcp_http_echo_session req r )
+            ^ r
+        } {}
+
+        ? != 0 ( nurl_str_eq rm `POST` ) {} {
+            : HttpResponse r ( response_text 405 `Method Not Allowed\n` )
+            ( response_set_header r `Allow` `POST, GET, DELETE, OPTIONS` )
+            ( __mcp_http_apply_cors r )
+            ^ r
+        }
+
+        : i bn ( vec_len [u] . req body )
+        ? <= bn 0 {
+            : HttpResponse r ( __mcp_http_jsonrpc_error mcp_err_invalid_request `empty request body` )
+            ( __mcp_http_apply_cors r )
+            ( __mcp_http_echo_session req r )
+            ^ r
+        } {}
+
+        : String body_str ( bytes_to_str . req body )
+        : !Json JsonError pj ( json_parse ( string_data body_str ) )
+        ( string_free body_str )
+
+        ?? pj {
+            T jreq → {
+                // Reverse-RPC response from the client → settle it.
+                ? ( __mcp_req_is_response jreq ) {
+                    : ?String sido ( header_get . req headers `Mcp-Session-Id` )
+                    ?? sido {
+                        T s → { ( mcp_session_resolve_rpc store ( string_data s ) jreq ) ( string_free s ) }
+                        F _ → { ( json_free jreq ) }
+                    }
+                    : HttpResponse r ( response_status_only 202 )
+                    ( __mcp_http_apply_cors r )
+                    ( __mcp_http_echo_session req r )
+                    ^ r
+                } {}
+
+                : s method ( __mcp_session_get_method jreq )
+                : b is_init ( nurl_str_eq method `initialize` )
+
+                // Validate a provided-but-unknown session id (not on init).
+                : ~ b reject F
+                ? == is_init 0 {
+                    : ?String sv ( header_get . req headers `Mcp-Session-Id` )
+                    ?? sv {
+                        T s → {
+                            ? & > ( string_len s ) 0 ! ( mcp_session_valid store ( string_data s ) ) { = reject T } {}
+                            ( string_free s )
+                        }
+                        F _ → {}
+                    }
+                } {}
+                ? reject {
+                    ( json_free jreq )
+                    : HttpResponse r ( __mcp_http_jsonrpc_error mcp_err_invalid_request `unknown or expired Mcp-Session-Id` )
+                    = . r status 404
+                    ( __mcp_http_apply_cors r )
+                    ^ r
+                } {}
+
+                : ?Json reply ( dispatch jreq )
+                ( json_free jreq )
+
+                ?? reply {
+                    T resp_json → {
+                        : HttpResponse r ( __mcp_http_response_for_json req resp_json )
+                        // On initialize, mint and attach a new session id.
+                        ? is_init {
+                            : String newsid ( mcp_session_create store )
+                            ( response_set_header r `Mcp-Session-Id` ( string_data newsid ) )
+                            ( string_free newsid )
+                        } {
+                            ( __mcp_http_echo_session req r )
+                        }
+                        ( __mcp_http_apply_cors r )
+                        ^ r
+                    }
+                    F empty → {
+                        ( json_free empty )
+                        : HttpResponse r ( response_status_only 202 )
+                        ( __mcp_http_apply_cors r )
+                        ( __mcp_http_echo_session req r )
+                        ^ r
+                    }
+                }
+            }
+            F _ → {
+                : HttpResponse r ( __mcp_http_jsonrpc_error mcp_err_parse_error `request body is not valid JSON` )
+                ( __mcp_http_apply_cors r )
+                ^ r
+            }
+        }
+    }
+}
+
+// ── Continuous chunked SSE primitives (custom accept loop) ────────────
+//
+// Building blocks for a long-lived server→client stream. A custom accept
+// loop that owns the TcpConn calls mcp_sse_begin once, then loops:
+// mcp_sse_flush_session (push any queued messages) + mcp_sse_heartbeat
+// (keep the connection alive) on an interval, and mcp_sse_end on close.
+// Frame bytes are produced by the unit-tested `mcp_sse_frame`.
+
+@ mcp_sse_begin TcpConn conn → !v NetErr {
+    : ( Vec Header ) hs ( vec_new [Header] )
+    ( vec_push [Header] hs ( header_new `Content-Type` `text/event-stream` ) )
+    ( vec_push [Header] hs ( header_new `Cache-Control` `no-cache` ) )
+    ( vec_push [Header] hs ( header_new `Connection` `keep-alive` ) )
+    : !v NetErr r ( response_begin_chunked conn 200 hs )
+    ( vec_free_with [Header] hs \ Header h → v { ( header_free h ) } )
+    ^ r
+}
+
+@ mcp_sse_write_event TcpConn conn s event Json data → !v NetErr {
+    : String f ( mcp_sse_frame event data )
+    : ( Vec u ) bytes ( bytes_from_str ( string_data f ) )
+    ( string_free f )
+    : !v NetErr r ( response_write_chunk conn bytes )
+    ( vec_free [u] bytes )
+    ^ r
+}
+
+// Drain a session's outbound queue to the live stream. Returns the
+// number of events written, or -1 on a write error.
+@ mcp_sse_flush_session TcpConn conn McpSessionStore store s sid → i {
+    : ( Vec Json ) q ( mcp_session_drain_notify store sid )
+    : i n ( vec_len [Json] q )
+    : ~ i k 0
+    : ~ i wrote 0
+    : ~ b err F
+    ~ & ! err < k n {
+        : ?Json e ( vec_get [Json] q k )
+        ?? e {
+            T jv → {
+                : !v NetErr wr ( mcp_sse_write_event conn `message` jv )
+                ?? wr { T _ → { = wrote + wrote 1 } F → { = err T } }
+                ( json_free jv )
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [Json] q )
+    ? err { ^ -1 } {}
+    ^ wrote
+}
+
+@ mcp_sse_heartbeat TcpConn conn → !v NetErr {
+    : ( Vec u ) bytes ( bytes_from_str `: keep-alive\r\n\r\n` )
+    : !v NetErr r ( response_write_chunk conn bytes )
+    ( vec_free [u] bytes )
+    ^ r
+}
+
+@ mcp_sse_end TcpConn conn → !v NetErr {
+    ^ ( response_end_chunked conn )
 }

--- a/stdlib/ext/mcp_session.nu
+++ b/stdlib/ext/mcp_session.nu
@@ -1,0 +1,365 @@
+// stdlib/ext/mcp_session.nu — stateful MCP session core + reverse RPC
+//
+// The pieces an MCP "Streamable HTTP" server needs beyond the
+// stateless request/response path in `mcp_http.nu`:
+//
+//   1. A SESSION STORE keyed by the opaque `Mcp-Session-Id` the server
+//      hands a client on `initialize`. Each session owns an outbound
+//      NOTIFICATION QUEUE (server→client messages waiting to be flushed
+//      over the client's SSE channel) and the bookkeeping for
+//      server→client (reverse) RPC.
+//
+//   2. REVERSE RPC correlation — `sampling/createMessage` and friends.
+//      The server issues a JSON-RPC *request* (with an id it allocates)
+//      into the session's outbound queue; it rides the SSE stream to the
+//      client; the client POSTs back a JSON-RPC *response* carrying that
+//      id; the server matches it to the pending request and the original
+//      caller collects the result.
+//
+//   3. The wire builders the transport layers on top of: an SSE event
+//      frame, and the `sampling/createMessage` request envelope.
+//
+// This module is pure data structures + JSON — no sockets — so it is
+// fully unit-testable. `mcp_http.nu` wires it to the HTTP transport.
+//
+// Ownership: the store owns every session and every queued / pending /
+// resolved Json. `mcp_session_store_free` releases all of it. Functions
+// that take a Json (push_notify, begin_rpc params, resolve_rpc) CONSUME
+// it; functions that return a Json (drain_notify elements, take_result)
+// transfer ownership to the caller.
+//
+//   ( mcp_session_store_new )                       → McpSessionStore
+//   ( mcp_session_create store )                    → String  new id (owned)
+//   ( mcp_session_valid store sid )                 → b
+//   ( mcp_session_count store )                     → i
+//   ( mcp_session_touch store sid now )             → b   stamp last_ms
+//   ( mcp_session_delete store sid )                → b
+//   ( mcp_session_push_notify store sid msg )       → b   CONSUMES msg
+//   ( mcp_session_drain_notify store sid )          → ( Vec Json )  owned
+//   ( mcp_session_begin_rpc store sid method params ) → i  request id, CONSUMES params
+//   ( mcp_session_request_sampling store sid msgs system max_tokens ) → i
+//   ( mcp_session_is_pending store sid id )         → b
+//   ( mcp_session_resolve_rpc store sid response )  → b   CONSUMES response
+//   ( mcp_session_take_result store sid id )        → ? Json  owned
+//   ( mcp_session_store_free store )                → v
+//
+//   ( mcp_sse_frame event data )                    → String  borrows data
+//   ( mcp_sampling_message role text )              → Json
+//   ( mcp_sampling_params msgs system max_tokens )  → Json   CONSUMES msgs
+//   ( mcp_sampling_request id msgs system max_tokens ) → Json full envelope
+
+$ `stdlib/ext/mcp.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/std/random.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+: McpSession {
+    String id
+    i created_ms
+    i last_ms
+    i next_rpc_id           // server→client request id allocator (1-based)
+    ( Vec Json ) notify     // outbound queue (notifications + reverse-RPC requests)
+    ( Vec i ) pending_ids   // reverse-RPC request ids awaiting a response
+    ( Vec Json ) results    // inbound reverse-RPC responses, matched by their "id"
+}
+
+: McpSessionStore { ( Vec McpSession ) sessions }
+
+// ── Store / lifecycle ─────────────────────────────────────────────────
+
+@ mcp_session_store_new → McpSessionStore {
+    ^ @ McpSessionStore { ( vec_new [McpSession] ) }
+}
+
+@ __mcp_session_find McpSessionStore store s sid → i {
+    : i n ( vec_len [McpSession] . store sessions )
+    : ~ i k 0
+    : ~ i res -1
+    ~ < k n {
+        : ?McpSession so ( vec_get [McpSession] . store sessions k )
+        ?? so {
+            T se → {
+                ? == 1 ( nurl_str_eq ( string_data . se id ) sid ) { = res k = k n } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ res
+}
+
+@ mcp_session_create McpSessionStore store → String {
+    // 32 hex chars of CSPRNG output — collision-free for any realistic
+    // server lifetime, and opaque per the MCP spec.
+    : String id ( rand_hex_str 16 )
+    : String ret ( string_from ( string_data id ) )
+    : i now ( now_ms )
+    : McpSession se @ McpSession {
+        id now now 1
+        ( vec_new [Json] ) ( vec_new [i] ) ( vec_new [Json] )
+    }
+    ( vec_push [McpSession] . store sessions se )
+    ^ ret
+}
+
+@ mcp_session_valid McpSessionStore store s sid → b {
+    ^ >= ( __mcp_session_find store sid ) 0
+}
+
+@ mcp_session_count McpSessionStore store → i {
+    ^ ( vec_len [McpSession] . store sessions )
+}
+
+@ mcp_session_touch McpSessionStore store s sid i now → b {
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ^ F } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → {
+            = . se last_ms now
+            ( vec_set [McpSession] . store sessions idx se )
+            ^ T
+        }
+        F → { ^ F }
+    }
+}
+
+@ __mcp_session_free McpSession se → v {
+    ( string_free . se id )
+    ( vec_free_with [Json] . se notify \ Json j → v { ( json_free j ) } )
+    ( vec_free [i] . se pending_ids )
+    ( vec_free_with [Json] . se results \ Json j → v { ( json_free j ) } )
+}
+
+@ mcp_session_delete McpSessionStore store s sid → b {
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ^ F } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → { ( __mcp_session_free se ) }
+        F → {}
+    }
+    ( vec_remove [McpSession] . store sessions idx )
+    ^ T
+}
+
+// ── Outbound notification queue ───────────────────────────────────────
+
+@ mcp_session_push_notify McpSessionStore store s sid Json msg → b {
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ( json_free msg ) ^ F } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → {
+            // Push rides the session's Vec ctl (heap-stable), so it
+            // persists through the struct copy without a vec_set.
+            ( vec_push [Json] . se notify msg )
+            ^ T
+        }
+        F → { ( json_free msg ) ^ F }
+    }
+}
+
+// Move every queued message into a fresh owned Vec and clear the queue.
+@ mcp_session_drain_notify McpSessionStore store s sid → ( Vec Json ) {
+    : ( Vec Json ) out ( vec_new [Json] )
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ^ out } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → {
+            : i n ( vec_len [Json] . se notify )
+            : ~ i k 0
+            ~ < k n {
+                : ?Json e ( vec_get [Json] . se notify k )
+                ?? e { T j → ( vec_push [Json] out j ) F → {} }
+                = k + k 1
+            }
+            // vec_clear drops the length without freeing elements — they
+            // now live solely in `out`.
+            ( vec_clear [Json] . se notify )
+        }
+        F → {}
+    }
+    ^ out
+}
+
+// ── Reverse RPC (server → client) ─────────────────────────────────────
+
+@ __mcp_rpc_envelope i id s method Json params → Json {
+    : Json out ( json_obj_new )
+    ( json_obj_set out `jsonrpc` ( json_str_lit `2.0` ) )
+    ( json_obj_set out `id` ( json_int id ) )
+    ( json_obj_set out `method` ( json_str_lit method ) )
+    ( json_obj_set out `params` params )
+    ^ out
+}
+
+// Allocate a request id, enqueue a JSON-RPC request for the client, and
+// mark it pending. Returns the id (or -1 if the session is unknown,
+// freeing params). CONSUMES params.
+@ mcp_session_begin_rpc McpSessionStore store s sid s method Json params → i {
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ( json_free params ) ^ -1 } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → {
+            : i id . se next_rpc_id
+            : Json env ( __mcp_rpc_envelope id method params )
+            ( vec_push [Json] . se notify env )
+            ( vec_push [i] . se pending_ids id )
+            = . se next_rpc_id + id 1
+            ( vec_set [McpSession] . store sessions idx se )
+            ^ id
+        }
+        F → { ( json_free params ) ^ -1 }
+    }
+}
+
+@ mcp_session_request_sampling McpSessionStore store s sid ( Vec Json ) messages s system i max_tokens → i {
+    : Json params ( mcp_sampling_params messages system max_tokens )
+    ^ ( mcp_session_begin_rpc store sid `sampling/createMessage` params )
+}
+
+@ __mcp_pending_index ( Vec i ) ids i id → i {
+    : i n ( vec_len [i] ids )
+    : ~ i k 0
+    : ~ i res -1
+    ~ < k n {
+        : i v ?? ( vec_get [i] ids k ) { T x → x F → -1 }
+        ? == v id { = res k = k n } {}
+        = k + k 1
+    }
+    ^ res
+}
+
+@ mcp_session_is_pending McpSessionStore store s sid i id → b {
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ^ F } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → { ^ >= ( __mcp_pending_index . se pending_ids id ) 0 }
+        F → { ^ F }
+    }
+}
+
+// Accept a client's JSON-RPC response to a reverse RPC. Stores it for
+// the originating caller and clears the pending marker. CONSUMES the
+// response. Returns F if the session is unknown or the response has no
+// integer "id" (then the response is freed).
+@ mcp_session_resolve_rpc McpSessionStore store s sid Json response → b {
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ( json_free response ) ^ F } {}
+    // json_obj_get returns a BORROW into `response` — never free it.
+    : ?Json ido ( json_obj_get response `id` )
+    : ~ i rid -1
+    ?? ido { T j → { = rid ( json_as_int j ) } F → {} }
+    ? < rid 0 { ( json_free response ) ^ F } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → {
+            ( vec_push [Json] . se results response )
+            : i pi ( __mcp_pending_index . se pending_ids rid )
+            ? >= pi 0 { ( vec_remove [i] . se pending_ids pi ) } {}
+            ^ T
+        }
+        F → { ( json_free response ) ^ F }
+    }
+}
+
+// Collect a resolved reverse-RPC response by id (owned), or None if it
+// has not arrived yet.
+@ mcp_session_take_result McpSessionStore store s sid i id → ?Json {
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ^ @ ?Json { F # Json 0 } } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → {
+            : i n ( vec_len [Json] . se results )
+            : ~ i k 0
+            : ~ i hit -1
+            ~ < k n {
+                : ?Json e ( vec_get [Json] . se results k )
+                ?? e {
+                    T j → {
+                        : ?Json ido ( json_obj_get j `id` )
+                        ?? ido { T jid → { ? == ( json_as_int jid ) id { = hit k } {} } F → {} }
+                    }
+                    F → {}
+                }
+                = k + k 1
+            }
+            ? < hit 0 { ^ @ ?Json { F # Json 0 } } {}
+            ^ ( vec_remove [Json] . se results hit )
+        }
+        F → { ^ @ ?Json { F # Json 0 } }
+    }
+}
+
+@ mcp_session_store_free McpSessionStore store → v {
+    : i n ( vec_len [McpSession] . store sessions )
+    : ~ i k 0
+    ~ < k n {
+        : ?McpSession so ( vec_get [McpSession] . store sessions k )
+        ?? so { T se → ( __mcp_session_free se ) F → {} }
+        = k + k 1
+    }
+    ( vec_free [McpSession] . store sessions )
+}
+
+// ── Wire builders ─────────────────────────────────────────────────────
+
+// One SSE event frame: `event: <event>\r\ndata: <json>\r\n\r\n`. Borrows
+// `data` (stringifies it); returns an owned String.
+@ mcp_sse_frame s event Json data → String {
+    : String payload ( json_stringify data )
+    : String out ( string_with_cap + ( string_len payload ) + ( nurl_str_len event ) 24 )
+    ( string_push_str out `event: ` )
+    ( string_push_str out event )
+    ( string_push_str out `\r\ndata: ` )
+    ( string_push_str out ( string_data payload ) )
+    ( string_push_str out `\r\n\r\n` )
+    ( string_free payload )
+    ^ out
+}
+
+// A single `sampling/createMessage` message object: {role, content}.
+@ mcp_sampling_message s role s text → Json {
+    : Json content ( json_obj_new )
+    ( json_obj_set content `type` ( json_str_lit `text` ) )
+    ( json_obj_set content `text` ( json_str_lit text ) )
+    : Json out ( json_obj_new )
+    ( json_obj_set out `role` ( json_str_lit role ) )
+    ( json_obj_set out `content` content )
+    ^ out
+}
+
+// Build a `sampling/createMessage` params object. CONSUMES `messages`
+// (each element is moved into the params array).
+@ mcp_sampling_params ( Vec Json ) messages s system i max_tokens → Json {
+    : Json arr ( json_arr_new )
+    : i n ( vec_len [Json] messages )
+    : ~ i k 0
+    ~ < k n {
+        : ?Json e ( vec_get [Json] messages k )
+        ?? e { T j → ( json_arr_push arr j ) F → {} }
+        = k + k 1
+    }
+    ( vec_free [Json] messages )
+    : Json params ( json_obj_new )
+    ( json_obj_set params `messages` arr )
+    ? > ( nurl_str_len system ) 0 {
+        ( json_obj_set params `systemPrompt` ( json_str_lit system ) )
+    } {}
+    ( json_obj_set params `maxTokens` ( json_int max_tokens ) )
+    ^ params
+}
+
+// Full standalone `sampling/createMessage` request envelope with an
+// explicit id (for callers not going through a session store).
+@ mcp_sampling_request i id ( Vec Json ) messages s system i max_tokens → Json {
+    : Json params ( mcp_sampling_params messages system max_tokens )
+    ^ ( __mcp_rpc_envelope id `sampling/createMessage` params )
+}


### PR DESCRIPTION
Closes the Tier 5b **MCP server completeness** gap: stateful session dispatch, a real GET-SSE notification stream, and server→client (reverse) RPC for `sampling/createMessage`. Pure NURL, no compiler change.

## `stdlib/ext/mcp_session.nu` — the stateful core (socket-free, fully unit-tested)
- **`McpSessionStore`** keyed by a CSPRNG-generated opaque `Mcp-Session-Id` (`create` / `valid` / `count` / `touch` / `delete`).
- **Per-session outbound notification queue** (`push_notify` / `drain_notify`) — messages waiting to be flushed over the client's SSE channel.
- **Server→client reverse-RPC correlation:** `begin_rpc` allocates a request id, enqueues the JSON-RPC request, and marks it pending; the client POSTs back a response carrying that id; `resolve_rpc` matches it; the originating caller collects it via `take_result`. `request_sampling` wraps this for `sampling/createMessage`.
- **Wire builders:** `mcp_sse_frame`, `mcp_sampling_message` / `_params` / `_request`.

Ownership is explicit and documented per function (which calls consume vs. transfer a `Json`); `mcp_session_store_free` releases everything.

## `stdlib/ext/mcp_http.nu` additions
- **`mcp_http_handler_session store dispatch`** — mints an `Mcp-Session-Id` on `initialize`, validates it on later requests (**404** on an unknown/expired id), drains the session queue to SSE `message` events on **GET**, routes a JSON-RPC *response* (no `method`, carries `result`/`error`) to `resolve_rpc` and replies **202**, and tears the session down on **DELETE**. The stateless `mcp_http_handler` stays the single/batch path.
- **`mcp_sse_begin` / `_write_event` / `_flush_session` / `_heartbeat` / `_end`** — chunked-streaming building blocks (over `response_begin_chunked` / `_write_chunk` / `_end_chunked`) for a continuous long-lived SSE stream from a custom accept loop. Frame bytes come from the unit-tested `mcp_sse_frame`.

## Tests
- `compiler/tests/mcp_session_basic.nu` — the full reverse-RPC flow (begin → queue → resolve → take), the notification queue, and SSE frame format. **Leak-free under LSan** (`detect_leaks=1`).
- `compiler/tests/mcp_http_session.nu` — drives synthetic `HttpRequest`s through the handler: session issuance + echo + 404-on-unknown, GET draining the queue as SSE, the reverse-RPC settle path (202), and DELETE teardown. **ASan+UBSan clean** under the project's `detect_leaks=0` policy (the one retained allocation is the captured-handler closure environment — identical to the existing `mcp_http` handler test).

Full suite green (`failures.txt` empty, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)