### PR TITLE
feat(fs): readlink(2) FFI + verify symlink targets in nurlpkg

### DIFF
--- a/compiler/tests/fs_advanced.nu
+++ b/compiler/tests/fs_advanced.nu
@@ -15,6 +15,8 @@
 //   total: 20
 //   content: 0123456789ABCDEFGHIJ
 //   eof: T
+//   readlink: match
+//   readlink non-link: err
 //   remove_all: ok
 //   exists after remove: F
 //   remove_all missing: not found
@@ -118,6 +120,43 @@ $ `stdlib/core/errors.nu`
             ( nurl_print ( io_err_msg # IoErr e ) )
             ( nurl_print `\n` )
         }
+    }
+
+    // 4b. fs_symlink + fs_readlink round-trip. Create a link inside the
+    //     tree pointing at the data file, read its target back, and
+    //     confirm it matches. Then readlink a NON-symlink (the data file)
+    //     and confirm it errors (EINVAL).
+    : s link_path `nurl_fs_adv_test/link.bin`
+    ?? ( fs_symlink data_path link_path ) {
+        T → {
+            ?? ( fs_readlink link_path ) {
+                T tgt → {
+                    ( nurl_print `readlink: ` )
+                    ? != 0 ( nurl_str_eq ( string_data tgt ) data_path ) {
+                        ( nurl_print `match` )
+                    } { ( nurl_print `MISMATCH` ) }
+                    ( nurl_print `\n` )
+                    ( string_free tgt )
+                }
+                F e → {
+                    ( nurl_print `readlink: err ` )
+                    ( nurl_print ( io_err_msg # IoErr e ) )
+                    ( nurl_print `\n` )
+                }
+            }
+        }
+        F e → {
+            ( nurl_print `symlink: err ` )
+            ( nurl_print ( io_err_msg # IoErr e ) )
+            ( nurl_print `\n` )
+        }
+    }
+    ?? ( fs_readlink data_path ) {
+        T t → {
+            ( nurl_print `readlink non-link: unexpected ok\n` )
+            ( string_free t )
+        }
+        F _ → ( nurl_print `readlink non-link: err\n` )
     }
 
     // 5. dir_remove_all — wipe the whole tree (nested dirs + the file).

--- a/stdlib/std/fs.nu
+++ b/stdlib/std/fs.nu
@@ -303,6 +303,31 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
     ^ @ !v IoErr { F e }
 }
 
+// POSIX readlink(2) — writes the symlink's target into `buf` (NOT
+// NUL-terminated) and returns the byte count, or -1 with errno set
+// (EINVAL when `path` is not a symlink). `bufsiz` caps the write.
+& `c` @ readlink s path s buf i bufsiz → i
+
+// Read the target a symbolic link points to, as an owned String.
+// Returns IoErr {Other} when `path` is not a symlink (errno = EINVAL),
+// {NotFound} when it doesn't exist, etc. The target is captured into a
+// zero-filled PATH_MAX buffer so the returned String is always NUL-
+// terminated; targets longer than 4095 bytes (above the Linux symlink
+// ceiling) are truncated.
+@ fs_readlink s path → !String IoErr {
+    : i cap 4096
+    : s buf ( nurl_zalloc + cap 1 )
+    : i n ( readlink path buf cap )
+    ? < n 0 {
+        ( nurl_free buf )
+        : IoErr e ( __io_err_of_kind ( errno_kind ) )
+        ^ @ !String IoErr { F e }
+    } {}
+    : String out ( string_from buf )
+    ( nurl_free buf )
+    ^ @ !String IoErr { T out }
+}
+
 // Remove an empty directory. Returns NotFound when missing, Other when
 // the directory is non-empty (errno = ENOTEMPTY) — the errno-kind table
 // folds the latter into Other rather than introducing a new variant.

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -725,19 +725,40 @@ $ `stdlib/std/bytes.nu`
     : String linkpath ( __deps_path name )
     : s linkpath_s ( string_data linkpath )
     ? ( file_exists linkpath_s ) {
-        // Without lstat/readlink primitives we can't verify the
-        // existing entry points where we expect. v1: treat any
-        // existing entry as already-installed so `nurlpkg install`
-        // is idempotent. Name collisions across transitive deps
-        // will land here too — surface in the deps listing instead.
-        ( nurl_print `  ` ) ( nurl_print name )
-        ( nurl_print ` (already installed)\n` )
+        // An entry already exists. Use readlink(2) to confirm it's a
+        // symlink pointing where we expect — a mismatch means a name
+        // collision across transitive deps (two different targets want
+        // the same `deps/<name>` slot), which we surface as an error.
+        // A non-symlink entry (readlink → EINVAL) falls back to the v1
+        // idempotent behaviour: treat it as already-installed.
+        : ~ i existing_rc 0
+        : !String IoErr rl ( fs_readlink linkpath_s )
+        ?? rl {
+            T existing → {
+                ? != 0 ( nurl_str_eq ( string_data existing ) target_s ) {
+                    ( nurl_print `  ` ) ( nurl_print name )
+                    ( nurl_print ` (already installed, verified)\n` )
+                } {
+                    ( nurl_eprint `  ` ) ( nurl_eprint name )
+                    ( nurl_eprint `: existing link points to ` )
+                    ( nurl_eprint ( string_data existing ) )
+                    ( nurl_eprint ` not ` )
+                    ( nurl_eprintln target_s )
+                    = existing_rc 1
+                }
+                ( string_free existing )
+            }
+            F _ → {
+                ( nurl_print `  ` ) ( nurl_print name )
+                ( nurl_print ` (already installed)\n` )
+            }
+        }
         // Record it as seen so the transitive walker doesn't try
         // to re-process the same target.
         ( vec_push [String] seen ( string_from target_s ) )
         ( string_free linkpath )
         ( string_free target )
-        ^ 0
+        ^ existing_rc
     } {}
     : !v IoErr sr ( fs_symlink target_s linkpath_s )
     : ~ i rc 0


### PR DESCRIPTION
## Summary

Closes the **`readlink` FFI** TODO item (Tier 5b): *"nurlpkg `verify` falls back to `file_exists` for symlink-target verification because no readlink binding exists yet."*

- **`stdlib/std/fs.nu`** — add `fs_readlink s path → !String IoErr`: reads a symbolic link's target as an owned String. Uses a direct `` & `c` @ readlink `` binding — the same pure-NURL FFI pattern as the existing `fs_symlink`, so **no `runtime.c` and no compiler change**. Errors route through the module's `IoErr` discipline (EINVAL on a non-symlink → `Other`, ENOENT → `NotFound`, …); the target is captured into a zero-filled PATH_MAX buffer so the result is always NUL-terminated.
- **`tools/nurlpkg/main.nu`** — `__install_one` could not previously check that an existing `deps/<name>` entry pointed where expected (the `// Without lstat/readlink primitives we can't verify…` fallback treated *any* existing entry as already-installed). It now `fs_readlink`s the entry and compares the target: match → `already installed, verified`; different target → a real **error** (name collision across transitive deps); non-symlink → falls back to the prior idempotent behaviour.
- **`compiler/tests/fs_advanced.nu`** — extend the ungated, self-cleaning fs test with an `fs_symlink` → `fs_readlink` round-trip (target matches) and a readlink-on-a-non-symlink negative case (errors). The scratch symlink is wiped by the existing `dir_remove_all` step.

## Test plan
- `./build.sh` — green (bootstrap fixed point + full suite, fresh baseline).
- `fs_advanced` now prints `readlink: match` and `readlink non-link: err`.
- `stdlib/std/fs.nu`, `compiler/tests/fs_advanced.nu`, and the added nurlpkg block are `nurlfmt`-canonical. (Pre-existing, unrelated formatting drift elsewhere in `main.nu` is intentionally left untouched.)

## Notes
- Scope is deliberately small and stdlib/tooling-only — no compiler (`nurlc.nu`) changes — so it won't collide with the larger compiler work in flight on another branch.
- POSIX-only (matches `fs_symlink`, which already documents Windows as unsupported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)