### PR TITLE
fix(proxy): binary-safe streaming response bodies (no NUL truncation)

### DIFF
--- a/compiler/tests/bytes_basic.nu
+++ b/compiler/tests/bytes_basic.nu
@@ -221,6 +221,29 @@ $ `stdlib/std/fs.nu`
         }
     }
 
+    // ── bytes_extend_raw is BINARY-SAFE: copies an exact byte count
+    //    straight past embedded NULs, where bytes_extend_str (strlen)
+    //    would truncate at the first NUL. Build A \0 B \0 C and confirm
+    //    all 5 bytes land (len 5, byte[4] == 'C' = 67). ──────────────
+    : s rawbuf ( nurl_alloc 5 )
+    : *u rb # *u rawbuf
+    = . rb 0 # u 65  // 'A'
+    = . rb 1 # u 0  // NUL
+    = . rb 2 # u 66  // 'B'
+    = . rb 3 # u 0  // NUL
+    = . rb 4 # u 67  // 'C'
+    : ( Vec u ) raw_v ( vec_new [u] )
+    ( bytes_extend_raw raw_v rawbuf 5 )
+    ( nurl_print `extend_raw len: ` )
+    ( nurl_print ( nurl_str_int ( vec_len [u] raw_v ) ) )  // 5
+    ( nurl_print `\n` )
+    : *u rvp ( vec_data [u] raw_v )
+    ( nurl_print `extend_raw byte4: ` )
+    ( nurl_print ( nurl_str_int & 255 # i . rvp 4 ) )  // 67
+    ( nurl_print `\n` )
+    ( vec_free [u] raw_v )
+    ( nurl_free rawbuf )
+
     ( vec_free [u] hello )
     ^ 0
 }

--- a/stdlib/ext/http.nu
+++ b/stdlib/ext/http.nu
@@ -97,6 +97,7 @@
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/errors.nu`
+$ `stdlib/std/bytes.nu`
 
 // HttpErr tags — see stdlib/runtime.c §14 NURL_HTTP_ERR_*.
 //
@@ -969,6 +970,42 @@ i timeout_ms i connect_timeout_ms
     ? == # i p 0 { ^ @ ?String { F # String 0 } } {}
     : String s ( string_from p )
     ^ @ ?String { T s }
+}
+
+// Binary-safe body-chunk pull. Reads the stream's accumulated byte
+// length from the state (slot 4) BEFORE swapping the buffer out, then
+// copies exactly that many bytes — so embedded NUL bytes survive,
+// unlike `http_stream_next` whose `?String` carrier truncates at the
+// first NUL. Use this when forwarding arbitrary / binary upstream
+// bodies (the reverse proxy). None at end-of-stream or on error —
+// consult `http_stream_err` to tell them apart.
+@ __http_stream_next_bytes_libcurl i raw → ?( Vec u ) {
+    : *u state # *u raw
+    ~ && == ( nurl_peek state 4 ) 0 == ( nurl_peek state 11 ) 0 {
+        ( __http_stream_pump_once state )
+    }
+    : i blen ( nurl_peek state 4 )  // body_buf.len, before take resets it
+    ? == blen 0 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    : s p ( nurl_curl_stream_take_body state )
+    ? == # i p 0 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    : ( Vec u ) out ( vec_with_cap [u] blen )
+    ( bytes_extend_raw out p blen )
+    ( nurl_free p )
+    ^ @ ?( Vec u ) { T out }
+}
+
+@ http_stream_next_bytes HttpStream st → ?( Vec u ) {
+    : i raw . st raw
+    ? != ( nurl_curl_available ) 0 {
+        ^ ( __http_stream_next_bytes_libcurl raw )
+    } {}
+    // Stub / WinHTTP backend: no length channel, so fall back through
+    // the NUL-terminated carrier (truncates at the first embedded NUL —
+    // the same limitation the s-body stream path already documents).
+    : s p ( nurl_http_stream_next raw )
+    ? == # i p 0 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    : ( Vec u ) out ( bytes_from_str p )
+    ^ @ ?( Vec u ) { T out }
 }
 
 @ http_stream_status HttpStream st → i {

--- a/stdlib/ext/http_proxy.nu
+++ b/stdlib/ext/http_proxy.nu
@@ -66,10 +66,12 @@
 //     `( Vec u )` request body through `CURLOPT_COPYPOSTFIELDS` +
 //     an explicit `POSTFIELDSIZE`, so embedded NUL bytes (binary file
 //     uploads) survive the proxy hop.
-//   * Streaming-mode response body chunks travel through a NUL-
-//     terminated `char*` carrier in `nurl_http_stream_next`; binary
-//     responses with embedded NULs would be truncated. SSE / JSON /
-//     text (i.e. every LLM output today) is fine.
+//   * Streaming-mode response body is now binary-safe too: chunks are
+//     pulled via `http_stream_next_bytes`, which reads the libcurl
+//     stream's byte length and copies exactly that many bytes into a
+//     `( Vec u )` — so embedded NUL bytes survive instead of being
+//     truncated at the first NUL (the old `http_stream_next` `?String`
+//     carrier). (The stub / WinHTTP fallback still truncates.)
 //   * `proxy_serve_run` accepts every connection unconditionally —
 //     no auth, no rate limit. For those, build the loop yourself
 //     with `tcp_accept` + your auth check + `proxy_stream_to_conn`.
@@ -297,21 +299,18 @@ $ `stdlib/ext/http_server.nu`
             : ~ b done F
             : ~ i status_local 0  // 0 = ok, 1 = client_write, 2 = upstream
             ~ ! done {
-                : ?String chunk_opt ( http_stream_next st )
+                : ?( Vec u ) chunk_opt ( http_stream_next_bytes st )
                 ?? chunk_opt {
-                    T chunk → {
-                        : i clen ( string_len chunk )
+                    T cb → {
+                        : i clen ( vec_len [u] cb )
                         ? > clen 0 {
-                            : ( Vec u ) cb ( vec_with_cap [u] clen )
-                            ( bytes_extend_str cb ( string_data chunk ) )
                             : !v NetErr wr ( response_write_chunk conn cb )
-                            ( vec_free [u] cb )
                             ?? wr {
                                 T _ → {}
                                 F _ → { = status_local 1 = done T }
                             }
                         } {}
-                        ( string_free chunk )
+                        ( vec_free [u] cb )
                     }
                     F _ → { = done T }
                 }

--- a/stdlib/std/bytes.nu
+++ b/stdlib/std/bytes.nu
@@ -84,6 +84,24 @@ $ `stdlib/core/errors.nu`
     } {}
 }
 
+// Append exactly `n` raw bytes from pointer `raw` onto `v` — the
+// length-explicit, BINARY-SAFE sibling of `bytes_extend_str` (which
+// stops at the first NUL via strlen). Use this to copy out a runtime-
+// owned byte buffer whose length is known independently of any NUL
+// terminator (e.g. a streamed HTTP body chunk that may contain NULs).
+// `raw` is BORROWED. No-op when `n <= 0`.
+@ bytes_extend_raw ( Vec u ) v s raw i n → v {
+    ? > n 0 {
+        ( vec_reserve [u] v n )
+        : *u src # *u raw
+        : *u dst ( vec_data [u] v )
+        : i len ( vec_len [u] v )
+        : *u dst_at # *u + # i dst len
+        ( nurl_memcpy dst_at src n )
+        ( vec_set_len [u] v + len n )
+    } {}
+}
+
 // Append the decimal-text bytes of `n` onto `v` (no leading zeros, '-' for
 // negatives). Convenience over `bytes_extend_str ( nurl_str_int n )` —
 // hides the malloc'd intermediate from caller-side accounting.


### PR DESCRIPTION
## Summary

Closes the **"Reverse proxy: stop NUL-truncating binary bodies"** TODO item (Tier 5).

The reverse proxy forwarded streaming upstream bodies via `http_stream_next`, whose `?String` carrier is NUL-terminated — a binary response with an embedded NUL was **truncated at the first NUL** (only SSE / JSON / text survived). Request bodies were already binary-safe (`http_stream_open_bytes_to` + `POSTFIELDSIZE`); this closes the response-side gap.

### Why it's a pure-NURL fix (no runtime/compiler change)
The libcurl stream state already tracks the chunk's true byte length (`NurlHttpStream.body_buf.len`, peekable at slot 4) — and it's readable **before** `nurl_curl_stream_take_body` swaps the buffer out and zeroes the length. So we read the length first, then copy exactly that many raw bytes.

### Changes
- **`std/bytes.nu`** — add `bytes_extend_raw`: the length-explicit, binary-safe sibling of `bytes_extend_str` (which derives length via `strlen`). Bulk `nurl_memcpy` of exactly `n` bytes.
- **`ext/http.nu`** — add `http_stream_next_bytes` (+ a libcurl helper): reads the chunk length from slot 4, takes the owned buffer, copies exactly that many bytes into a `( Vec u )`. Embedded NULs survive. The stub / WinHTTP backend falls back through the NUL-terminated carrier (pre-existing documented limitation, unchanged).
- **`ext/http_proxy.nu`** — pull body chunks via `http_stream_next_bytes` instead of `http_stream_next` + `bytes_extend_str`, dropping the `strlen` round-trip entirely; updated the module-header limitation note.

## Test plan
- **`compiler/tests/bytes_basic.nu`** — builds `A \0 B \0 C` in a raw buffer and asserts `bytes_extend_raw` yields **len 5** with **byte[4] == 'C' (67)** — copied straight past two embedded NULs (the `strlen` path would have stopped at len 1). Verified: `extend_raw len: 5` / `extend_raw byte4: 67`.
- `./build.sh` — green (bootstrap fixed point + full suite, fresh baseline).
- Changed files are `nurlfmt`-canonical (`http.nu`'s unrelated pre-existing formatting drift left untouched).

## Notes
- Stdlib-only, no `nurlc.nu` / `runtime.c` change.
- The end-to-end binary-proxy path itself needs libcurl + a live upstream (the proxy tests are network-gated), so the regression targets the binary-safe copy primitive that is the root of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)