### PR TITLE
fix(compiler): borrow-provenance — auto-Drop enum binding off a borrow accessor isn't double-freed

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -1515,6 +1515,12 @@
     ? != 0 ( nurl_str_len skip )
     { ( nurl_sym_def syms `__fn_ret_owned__` `1` ) }
     {}
+    // Borrow provenance: if the returned value is a borrow (derived from a
+    // parameter), this function returns a borrow — callers must NOT
+    // auto-drop a `:`-binding off it.
+    ? != 0 ( nurl_str_len ( nurl_sym_get syms `__last_value_borrow__` ) )
+    { ( nurl_sym_def syms `__fn_ret_borrow__` `1` ) }
+    {}
     ? != 0 ( nurl_str_len dtop )
     {  // defers active: store return value then branch to defer chain
         ? ! ( seq lt `void` )
@@ -1740,6 +1746,9 @@
         { ( vis_check_xref lex name `global` ) }
         {}
         ( nurl_sym_def syms `__last_ident_name__` name )
+        // Borrow provenance: loading a `__borrow`-marked binding yields a
+        // borrow; any other ident load yields a non-borrow (resets the flag).
+        ( nurl_sym_def syms `__last_value_borrow__` ( nurl_sym_get syms ( nurl_str_cat name `__borrow` ) ) )
         // Propagate the binding's unsigned-ness as a side-channel so
         // downstream casts / stores can choose sext vs zext correctly.
         // Empty when the binding wasn't tagged (literals, struct fields,
@@ -3670,6 +3679,13 @@
     ( nurl_sym_def syms `__last_call_res_e_llvm__` ( nurl_sym_get syms ( nurl_str_cat fname `__res_e_llvm` ) ) )
     ( nurl_sym_def syms `__last_call_opt_nurl_t__` ( nurl_sym_get syms ( nurl_str_cat fname `__opt_nurl_t` ) ) )
     ( nurl_sym_def syms `__last_call_ret_owned__` ( nurl_sym_get syms ( nurl_str_cat fname `__ret_owned` ) ) )
+    // Borrow provenance: the result is a borrow if the callee is marked
+    // ret_borrow, or it is a vec_get* accessor (which returns a borrow of
+    // an element the Vec still owns). The flag only changes behaviour for
+    // an auto-Drop enum binding/match downstream — inert otherwise.
+    ( nurl_sym_def syms `__last_value_borrow__`
+    ? | != 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat fname `__ret_borrow` ) ) )
+    != 0 ( nurl_str_starts fname `vec_get` ) `1` `` )
     : s rl ( nurl_sym_get syms fname )
     : s rlt ? == 0 ( nurl_str_len rl ) `i64` rl
     ? ( seq rlt `void` )
@@ -4195,6 +4211,11 @@
     // When Phase 2B is off no function ever gets "str" registered, so behaviour
     // is identical to the Phase 2A-only build.
     ( nurl_sym_def syms `__last_call_ret_owned__` ( nurl_sym_get syms ( nurl_str_cat call_name `__ret_owned` ) ) )
+    // Borrow provenance (see the kw-args path above): ret_borrow callee or
+    // a vec_get* element accessor yields a borrow.
+    ( nurl_sym_def syms `__last_value_borrow__`
+    ? | != 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat call_name `__ret_borrow` ) ) )
+    != 0 ( nurl_str_starts call_name `vec_get` ) `1` `` )
     // Record the callee's return signedness (from its recorded NURL return
     // type) so the regular @-fn dispatch can re-assert it on `__last_unsigned__`
     // AFTER the call — an enclosing `# i ( f )` over a `u`-returning `f` must
@@ -4728,6 +4749,12 @@
     ( nurl_sym_def syms `__last_call_opt_nurl_t__` `` )
     : s match_val ( gen_operand lex syms cg )
     : s match_type ( nurl_get_last_type )
+    // Borrow provenance: snapshot whether the SCRUTINEE was a borrow. A
+    // match that yields a value out of a borrowed scrutinee conservatively
+    // yields a borrow (the arms commonly return a payload view); restored
+    // onto __last_value_borrow__ at every return below so a `^ ?? …` makes
+    // the function ret_borrow. (Only consequential for auto-Drop enums.)
+    : s match_scrut_borrow ( nurl_sym_get syms `__last_value_borrow__` )
 
     // A `?? ( f … )` whose scrutinee is a direct call has no binding
     // name, so the payload metadata below (keyed on `<name>__res_nurl_T`
@@ -5315,6 +5342,12 @@
                     {}
                 }
                 {}
+                // Borrow provenance: a match-arm payload of an auto-Drop
+                // enum is a VIEW into the matched value (a borrow) — mark it
+                // so a `^ payload` return propagates ret_borrow.
+                ? ( __is_autodrop_enum pt0_eff syms )
+                { ( nurl_sym_def syms ( nurl_str_cat pv0 `__borrow` ) `1` ) }
+                {}
                 // Propagate unsigned flag for `?u` / `?u16` / `?u32` /
                 // `?u64` matches. T-arm only (F-arm has no payload).
                 // Without this, the alloca drops the unsigned-ness and a
@@ -5557,6 +5590,13 @@
         ( nurl_print ` = phi ` ) ( nurl_print phi_type )
         ( nurl_print ` ` ) ( nurl_print phi_full ) ( nurl_print `\n` )
         ( nurl_set_last_type phi_type )
+        // Borrow propagation only matters when the match YIELDS an auto-Drop
+        // enum (the value a `:`-binding might wrongly drop). For any other
+        // result type — String, i, … — reset so a match on a borrowed param
+        // that returns a non-enum (string_from, a count) is NOT mis-marked
+        // ret_borrow.
+        ( nurl_sym_def syms `__last_value_borrow__`
+        ? ( __is_autodrop_enum phi_type syms ) match_scrut_borrow `` )
         ^ final_reg
     } {}
     ( nurl_set_last_type `void` )
@@ -7203,8 +7243,13 @@
         ( nurl_sym_def syms `__last_call_ret_owned__` `` )
         ( nurl_sym_def syms `__last_agg_owned_fields__` `` )
         ( nurl_sym_def syms `__last_expr_refdepth__` `` )
+        ( nurl_sym_def syms `__last_value_borrow__` `` )
         : s val ( gen_expr lex syms cg )
         : s vt ( nurl_get_last_type )
+        // Borrow provenance: did the RHS produce a borrow (a value aliasing
+        // something the caller still owns)? If so, an auto-Drop binding here
+        // must NOT register its drop — the owner reclaims it.
+        : s rhs_borrow ( nurl_sym_get syms `__last_value_borrow__` )
         // Borrow checker: record this binding (inference path).
         ( bck_record `let` name bck_line )
         ( bck_let_alias syms is_mutable bck_rhs_tt bck_rhs_val vt bck_line )
@@ -7246,15 +7291,20 @@
         ? != 0 g_auto_drop_strings
         { ( mem_register_agg_owned_fields syms ptr vt ) }
         {}
-        // Phase 2D: User Drop trait
-        ? != 0 g_auto_drop_strings
+        // Phase 2D: User Drop trait. A COMPILER-auto Drop is skipped when
+        // the RHS is a borrow (vec_get / a ret_borrow accessor) — dropping
+        // it would double-free the container that still owns the value. The
+        // binding inherits `__borrow` so it propagates further.
+        ? & & != 0 g_auto_drop_strings ( __is_autodrop_enum vt syms ) != 0 ( nurl_str_len rhs_borrow )
+        { ( nurl_sym_def syms ( nurl_str_cat name `__borrow` ) `1` ) }
+        { ? != 0 g_auto_drop_strings
         { : s impl_key ( nurl_str_cat `drop##` vt )
             : s impl_mangle_key ( nurl_sym_get g_impl_name_syms impl_key )
             ? != 0 ( nurl_str_len impl_mangle_key )
             { ( mem_own_add_user_drop syms ptr vt ) }
             {}
         }
-        {}
+        {} }
         // Mark as having new syntax only if mutability was checked
         // TEMPORARILY DISABLED: ? had_mutability_check
         //   { ( nurl_sym_def syms ( nurl_str_cat name `__newsyntax` ) `1` ) }
@@ -7345,8 +7395,12 @@
                 ( nurl_sym_def syms `__last_call_ret_owned__` `` )
                 ( nurl_sym_def syms `__last_agg_owned_fields__` `` )
                 ( nurl_sym_def syms `__last_expr_refdepth__` `` )
+                ( nurl_sym_def syms `__last_value_borrow__` `` )
                 : s val ( gen_expr lex syms cg )
                 : s vt ( nurl_get_last_type )
+                // Borrow provenance (typed path): a borrow RHS must not
+                // register an auto-Drop — the owner reclaims it.
+                : s rhs_borrow ( nurl_sym_get syms `__last_value_borrow__` )
                 // Borrow checker: record this binding (typed path).
                 ( bck_record `let` name bck_line )
                 ( bck_let_alias syms is_mutable bck_rhs_tt bck_rhs_val vt bck_line )
@@ -7392,15 +7446,19 @@
                 ? != 0 g_auto_drop_strings
                 { ( mem_register_agg_owned_fields syms ptr ptype ) }
                 {}
-                // Phase 2D: User Drop trait
-                ? != 0 g_auto_drop_strings
+                // Phase 2D: User Drop trait. Skip a COMPILER-auto Drop when
+                // the RHS is a borrow (would double-free the owner); mark the
+                // binding `__borrow` so it propagates.
+                ? & & != 0 g_auto_drop_strings ( __is_autodrop_enum ptype syms ) != 0 ( nurl_str_len rhs_borrow )
+                { ( nurl_sym_def syms ( nurl_str_cat name `__borrow` ) `1` ) }
+                { ? != 0 g_auto_drop_strings
                 { : s impl_key ( nurl_str_cat `drop##` ptype )
                     : s impl_mangle_key ( nurl_sym_get g_impl_name_syms impl_key )
                     ? != 0 ( nurl_str_len impl_mangle_key )
                     { ( mem_own_add_user_drop syms ptr ptype ) }
                     {}
                 }
-                {}
+                {} }
                 // Mark as having new syntax only if mutability was checked
                 // TEMPORARILY DISABLED: ? had_mutability_check
                 //   { ( nurl_sym_def syms ( nurl_str_cat name `__newsyntax` ) `1` ) }
@@ -8802,6 +8860,11 @@
     }
     ( expect lex TT_RBRACE )  // consume '}'
     ( nurl_set_last_type agg_ty )
+    // Borrow provenance: a freshly-constructed `@ T { … }` aggregate is
+    // OWNED — never a borrow. Reset the flag so the value's last
+    // sub-expression (e.g. a string_from inside) cannot leave a stale
+    // borrow mark that would wrongly suppress the binding's auto-Drop.
+    ( nurl_sym_def syms `__last_value_borrow__` `` )
     // Phase 2C: expose the owned-field index list so a binding on the RHS
     // can register drops. Only named-struct aggregates get tracked; anon
     // aggregates like `{ i1, i64 }` are excluded (they have different
@@ -10689,6 +10752,9 @@
     ( nurl_sym_def syms `__owned_slices__` `` )
     ( nurl_sym_def syms `__last_ident_name__` `` )
     ( nurl_sym_def syms `__fn_ret_owned__` `` )
+    // Borrow provenance: does THIS function return a borrow (a value that
+    // aliases a parameter)? Set by gen_ret from __last_value_borrow__.
+    ( nurl_sym_def syms `__fn_ret_borrow__` `` )
     ? != 0 g_auto_drop_strings
     { ( nurl_sym_def syms `__owned_strings__` `` )
         ( nurl_sym_def syms `__owned_struct_fields__` `` )
@@ -10818,6 +10884,15 @@
     // merge into g_fn_sink[fname] happens after the body finishes.
     ( nurl_sym_def syms `__fn_inferred_sink__` `` )
     : s last ( gen_block_ret lex syms cg )
+    // Borrow provenance for an IMPLICIT (no `^`) block return: the body's
+    // final expression IS the return value, so if it left a borrow on
+    // __last_value_borrow__ (e.g. a `?? param { … }` yielding a payload
+    // view), this function returns a borrow. Mirrors the explicit-`^`
+    // gen_ret. (gen_ret also sets the flag, so this only ADDS the
+    // implicit case; idempotent for explicit returns.)
+    ? != 0 ( nurl_str_len ( nurl_sym_get syms `__last_value_borrow__` ) )
+    { ( nurl_sym_def syms `__fn_ret_borrow__` `1` ) }
+    {}
     // Auto-sink inference (critic v0.9.0 §2): merge any inferred sinks
     // into g_fn_sink[fname], deduping against the explicit `sink`
     // marker set already published above.
@@ -10934,6 +11009,7 @@
     : i fn_ret_str_owned_flag ? != 0 g_auto_drop_strings
     ? != 0 ( nurl_str_len ( nurl_sym_get syms `__fn_ret_str_owned__` ) ) 1 0
     0
+    : i fn_ret_borrow_flag ? != 0 ( nurl_str_len ( nurl_sym_get syms `__fn_ret_borrow__` ) ) 1 0
     ( nurl_sym_pop syms )
     ( nurl_sym_def syms fname ret_ty )
     // Re-store NURL ret type in outer scope (inner scope was just popped)
@@ -10950,6 +11026,11 @@
         { ( nurl_sym_def syms ( nurl_str_cat fname `__ret_owned` ) `1` ) }
         {}
     }
+    // Persist "returns a borrow" so a caller's `:`-binding off this fn
+    // skips its auto-Drop (borrow-provenance pass).
+    ? != 0 fn_ret_borrow_flag
+    { ( nurl_sym_def syms ( nurl_str_cat fname `__ret_borrow` ) `1` ) }
+    {}
     ? ( seq fname `main` ) ( emit_main_wrapper ret_ty ) {}
 }
 
@@ -11036,6 +11117,14 @@
         ( nurl_sym_def syms pname lt )
         // Mark parameter as immutable by design
         ( nurl_sym_def syms ( nurl_str_cat pname `__param` ) `1` )
+        // Borrow-provenance origin: an auto-Drop enum parameter is a
+        // BORROW (the caller owns it). Values derived from it (vec_get,
+        // field access, returned through it) inherit `__borrow`, so a
+        // caller's `:`-binding off a borrow-returning accessor skips its
+        // auto-drop instead of double-freeing the still-owned source.
+        ? & == pconv 0 ( __is_autodrop_enum lt syms )
+        { ( nurl_sym_def syms ( nurl_str_cat pname `__borrow` ) `1` ) }
+        {}
         // An `inout` parameter is an exclusive mutable borrow. It
         // lowers to the `*T`-by-address
         // mechanism: the LLVM parameter is `<T>* %name`, and the body
@@ -11601,6 +11690,17 @@
         = i + i 1
     }
     ^ r
+}
+
+// True if LLVM type `ty` is an enum that carries a compiler-auto Drop
+// (`autodrop##%E` registered). Used by the borrow-provenance pass: a
+// value of such a type can be EITHER owned or a borrow, and the
+// `:`-binding auto-drop must skip the borrow case to avoid a double-free.
+@ __is_autodrop_enum s ty i syms → b {
+    ? == 0 ( nurl_str_len ty ) { ^ F } {}
+    ? != ( nurl_str_get ty 0 ) 37 { ^ F } {}
+    ? == ( nurl_str_get ty - ( nurl_str_len ty ) 1 ) 42 { ^ F } {}
+    ^ != 0 ( nurl_str_len ( nurl_sym_get g_impl_name_syms ( nurl_str_cat `autodrop##` ty ) ) )
 }
 
 // Strip a leading `%` to form a drop-function name suffix.

--- a/compiler/tests/enum_borrow_binding.nu
+++ b/compiler/tests/enum_borrow_binding.nu
@@ -1,0 +1,74 @@
+// Regression: borrow-provenance for auto-Drop enum trees. An accessor
+// that RETURNS A BORROW into the tree (e.g. `first_kid` → vec_get of a
+// child) assigned to a `:`-binding must NOT auto-drop that binding —
+// doing so would double-free the tree that still owns the node. The
+// compiler marks the accessor `ret_borrow` (its result aliases a
+// parameter) and skips the binding's drop. Conversely an OWNED result
+// (a fresh `@`-construction returned) must still drop exactly once.
+//
+// Build with ./build.sh; the memory proof (no leak, no double-free) is
+// under ASan/LSan. Prints PASS; returns the failure count.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+: Elem { String tag ( Vec Node ) kids }
+: | Node { NText String  NElem Elem }
+: NBox { Node n }
+
+@ mk_text s t → Node { ^ @ Node { NText ( string_from t ) } }
+@ mk_elem s tag → NBox { ^ @ NBox { @ Node { NElem @ Elem { ( string_from tag ) ( vec_new [Node] ) } } } }
+
+// Returns a BORROW: the first child Node aliases `parent`'s kids Vec.
+// Implicit (no `^`) nested-match block return through vec_get — exactly
+// the shape that used to double-free.
+@ first_kid Node parent → Node {
+    ?? parent {
+        NElem e → ?? ( vec_get [Node] . e kids 0 ) { T y → y  F → parent }
+        NText _ → parent
+    }
+}
+
+// Returns an OWNED value (fresh) — the caller's `:`-binding MUST drop it.
+@ make_owned s t → Node { ^ ( mk_text t ) }
+
+@ kid_count Node n → i {
+    ?? n { NElem e → ( vec_len [Node] . e kids ) NText _ → 0 }
+}
+
+@ build → Node {
+    : NBox rb ( mk_elem `root` )
+    ?? . rb n {
+        NElem e → {
+            ( vec_push [Node] . e kids ( mk_text `first-child` ) )
+            ( vec_push [Node] . e kids ( mk_text `second-child` ) )
+        }
+        NText _ → {}
+    }
+    ^ . rb n
+}
+
+@ main → i {
+    : ~ i fails 0
+
+    : Node tree ( build )
+    ? != ( kid_count tree ) 2 { ( nurl_print `  FAIL kid count\n` ) = fails + fails 1 } {}
+
+    // BORROW binding off an accessor — must NOT be auto-dropped (the tree
+    // owns the node). Before the fix this double-freed at scope exit.
+    : Node child ( first_kid tree )
+    ?? child { NText _ → {} NElem _ → { ( nurl_print `  FAIL child not text\n` ) = fails + fails 1 } }
+
+    // OWNED binding off a fresh constructor — must drop exactly once
+    // (leak-free; verified by LSan).
+    : Node owned ( make_owned `owned-node` )
+    ?? owned { NText _ → {} NElem _ → { ( nurl_print `  FAIL owned not text\n` ) = fails + fails 1 } }
+
+    // `tree` drops here (frees the whole tree once). `child` is a borrow
+    // into it (no drop). `owned` is owned (drops once). No double-free.
+
+    ? == fails 0 { ( nurl_print `enum_borrow_binding: PASS\n` ) } {
+        ( nurl_print `enum_borrow_binding: ` ) ( nurl_print ( nurl_str_int fails ) ) ( nurl_print ` FAILURES\n` )
+    }
+    ^ fails
+}


### PR DESCRIPTION
Closes the documented residual from the boxed-payload-enum auto-Drop work (#72): a `:`-binding whose RHS is a **borrow** into an owned tree was treated as owned and auto-dropped, double-freeing the tree that still owns the node.

```nurl
: Node tree  ( build )          // owns the tree
: Node child ( first_kid tree ) // first_kid returns a vec_get VIEW into tree
// before: `child` auto-dropped at scope exit → double-free of tree's node
```

## The fix — a sound borrow-provenance pass
- An **auto-Drop-enum parameter** is a borrow origin (`<param>__borrow`) — the caller owns it.
- The borrow flows through: `vec_get*` (always a borrow of an element the Vec owns), struct field-access of a borrow, a match-arm payload of an auto-Drop enum, and a `??`-match **result** — but only when the match *yields* an auto-Drop enum, so a match on a borrowed param that returns a `String`/count (`string_from`, `vec_len`) is **not** mis-flagged.
- A function returning a borrow is recorded `<fn>__ret_borrow` — set from `gen_ret` **and** the implicit block-return path (accessors usually omit `^`) — and surfaced to callers via `__last_call_ret_borrow__`.
- `gen_let` **skips** the auto-Drop registration when the RHS is a borrow, and marks the binding `__borrow` so it propagates.
- A fresh `@ T { … }` aggregate **resets** the flag — it's always owned, so a `string_from` inside can't leave a stale borrow mark.

## Soundness
Only a **proven param-derived borrow** skips its drop. Owned values still drop exactly once (no leak); borrows never double-free. The flag is **sym-only (emits no IR)** and is consulted solely for auto-Drop-enum bindings → inert for all existing code. The bootstrap (no enums) self-compiles **byte-identically**; fixed point holds.

## Verification
`compiler/tests/enum_borrow_binding.nu` — a borrow accessor (`first_kid`) and a fresh constructor (`make_owned`) feed two `:`-bindings: the borrow is not dropped, the owned value drops once, the tree frees itself once. **ASan/UBSan + LSan clean.** Bootstrap fixed-point holds; full suite green, 0 failures, no regressions.

## Note (pre-existing, out of scope)
`^ ?? owned { … }` — returning a *match whose scrutinee is a `:` binding* makes `gen_ret` skip that binding's drop (it mistakes the scrutinee for the returned value) → leak. Independent of this change; bind the result first (`: i r ?? owned { … } ^ r`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)