### PR TITLE
fix(compiler): drop the scrutinee of `^ ?? owned { … }` returning a scalar

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5597,6 +5597,16 @@
         // ret_borrow.
         ( nurl_sym_def syms `__last_value_borrow__`
         ? ( __is_autodrop_enum phi_type syms ) match_scrut_borrow `` )
+        // A SCALAR match result (i*/double) cannot alias the scrutinee's
+        // storage, so clear `__last_ident_name__` (which still names the
+        // scrutinee binding from its eval). Otherwise `^ ?? owned { _ → 0 }`
+        // makes gen_ret mistake `owned` for the returned value and SKIP its
+        // auto-drop — leaking it. For a non-scalar result we leave the name
+        // as-is (conservative: it MIGHT be a payload view of the
+        // scrutinee, and skipping the drop avoids a use-after-free).
+        ? | > ( int_width phi_type ) 0 ( seq phi_type `double` )
+        { ( nurl_sym_def syms `__last_ident_name__` `` ) }
+        {}
         ^ final_reg
     } {}
     ( nurl_set_last_type `void` )

--- a/compiler/tests/ret_match_scalar_drop.nu
+++ b/compiler/tests/ret_match_scalar_drop.nu
@@ -1,0 +1,33 @@
+// Regression: `^ ?? owned { … }` returning a SCALAR must still drop the
+// owned scrutinee. gen_ret's escape analysis used the lingering
+// `__last_ident_name__` (the match scrutinee) to skip the returned
+// value's auto-drop — but the value returned is the match RESULT (an
+// int), not the scrutinee, so the owned binding leaked. A scalar match
+// result cannot alias the scrutinee's storage, so gen_match now clears
+// the ident name and the scrutinee drops normally.
+//
+// Builds via ./build.sh; the leak proof is under ASan/LSan.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+: Elem { String tag ( Vec Node ) kids }
+: | Node { NText String  NElem Elem }
+
+@ mk_text s t → Node { ^ @ Node { NText ( string_from t ) } }
+
+// The repro: an owned local matched in RETURN position, yielding an int.
+// `owned` is not the returned value, so it must be reclaimed here.
+@ classify_owned → i {
+    : Node owned ( mk_text `owned-then-returned-as-scalar` )
+    ^ ?? owned { NText _ → 0  NElem _ → 1 }
+}
+
+@ main → i {
+    : ~ i fails 0
+    ? != ( classify_owned ) 0 { ( nurl_print `  FAIL classify\n` ) = fails + fails 1 } {}
+    ? == fails 0 { ( nurl_print `ret_match_scalar_drop: PASS\n` ) } {
+        ( nurl_print `ret_match_scalar_drop: ` ) ( nurl_print ( nurl_str_int fails ) ) ( nurl_print ` FAILURES\n` )
+    }
+    ^ fails
+}


### PR DESCRIPTION
A function whose return is a match in tail position — `^ ?? owned { _ → 0 … }` — **leaked the owned scrutinee**.

`gen_ret`'s escape analysis skips the auto-drop of the value it's *returning*, identified via the lingering `__last_ident_name__`. After a match, that name still pointed at the **scrutinee** binding (set when the scrutinee was evaluated), so gen_ret mistook `owned` for the returned value and skipped its drop — even though the value actually returned was the match **result** (an int), not the scrutinee.

## Fix
`gen_match` clears `__last_ident_name__` when the match yields a **scalar** (`i*`/`double`) result. A scalar can't alias the scrutinee's storage, so the scrutinee is genuinely not escaping and drops normally. For a **non-scalar** result the name is left as-is — conservative: the result might be a payload *view* of the scrutinee (e.g. `^ ?? owned { T x → x }`), and keeping the skip avoids a **use-after-free** (that path may still leak, which is safe).

## Context
This was the residual flagged in the borrow-provenance work (#74).

## Verification
`compiler/tests/ret_match_scalar_drop.nu`: an owned enum local matched in return position yielding an int is now reclaimed — **LSan clean**. Bootstrap fixed point holds (nurlc.nu uses no such pattern → zero IR delta); full suite green, 0 failures, no regressions.

## Known separate residual (out of scope)
A fresh auto-Drop-enum **temporary** passed as a call argument (`( f ( mk_text … ) )`) is not dropped after the call — `mem_drop_arg_temps` reclaims only `i8*` string temps, not enum boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)