### PR TITLE
fix(compiler): reject unbalanced braces / stray top-level tokens

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -113,7 +113,10 @@
 
 @ expect i lex i tt → v {
     ? != ( nurl_lex_type lex ) tt
-    { ( die lex ( nurl_str_cat `unexpected token, expected tt=` ( nurl_str_int tt ) ) ) }
+    { ( die lex ( nurl_str_cat3
+        ( nurl_str_cat `expected ` ( __tok_label tt `` ) )
+        ` but found `
+        ( __tok_label ( nurl_lex_type lex ) ( nurl_lex_val lex ) ) ) ) }
     {}
     ( nurl_lex_advance lex )
 }
@@ -1595,6 +1598,10 @@
     ? == tt TT_RBRACE { ^ `'}' (the enclosing block ends here)` } {}
     ? == tt TT_RPAREN { ^ `')'` } {}
     ? == tt TT_RBRACK { ^ `']'` } {}
+    ? == tt TT_LBRACE { ^ `'{'` } {}
+    ? == tt TT_LPAREN { ^ `'('` } {}
+    ? == tt TT_LBRACK { ^ `'['` } {}
+    ? == tt TT_AT { ^ `'@'` } {}
     ? == tt TT_EOF { ^ `end of input` } {}
     ? == tt TT_ARROW { ^ `'->'` } {}
     ? != 0 ( nurl_str_len val ) { ^ ( nurl_str_cat3 `'` val `'` ) } {}
@@ -13673,7 +13680,23 @@
         ? == tt TT_AMP { ( gen_ffi_decl lex syms ) }
         ? == tt TT_DOLLAR { ( gen_import_decl lex syms cg ) }
         ? == tt TT_PERCENT { ( gen_trait_or_impl lex syms cg ) }
-        { ( nurl_lex_advance lex ) }
+        // A bare `|` is the most common near-miss: enums are declared
+        // `: | Name { … }`, not `| Name { … }`. (The `:`-less spelling
+        // used to be silently skipped — and only "worked" when the enum
+        // was also imported under the same name; now it's a diagnostic.)
+        ? == tt TT_PIPE { ( die lex `enum declarations start with ': |', not a bare '|' — write ': | Name { Variant... }'` ) }
+        // Anything else at the top level is a hard error. The decl loop
+        // used to silently advance past stray tokens — which is exactly
+        // how an unbalanced-brace function body slipped through: an extra
+        // `}` closed the body early, and the leftover statements (`^ x`,
+        // a stray `}`, …) leaked here and were swallowed, leaving the
+        // truncated function to silently miscompile (undef return) or to
+        // desync the scan_fn_sigs pre-pass. Refusing them turns that whole
+        // class into a diagnostic at the first leaked token.
+        { ( die lex ( nurl_str_cat3
+            `unexpected `
+            ( __tok_label tt ( nurl_lex_val lex ) )
+            ` at the top level — expected a declaration (@ fn, : const/struct/enum, & ffi, $ import, or % trait/impl). A stray '}' or leftover expression here usually means an earlier function body has unbalanced braces.` ) ) }
     }
 }
 

--- a/compiler/tests/result_multifield.nu
+++ b/compiler/tests/result_multifield.nu
@@ -28,31 +28,36 @@ $ `stdlib/core/string.nu`
     i count
 }
 
-| ParseErr {
-    Empty
-    BadFormat
+// Self-contained error enum. Uses unique variant names so it doesn't
+// collide with the ParseErr (Empty/BadFormat) that string.nu pulls in
+// transitively via errors.nu. (This was written `| ParseErr` with a
+// bare `|`, which the front-end used to silently skip — now a hard
+// error; the canonical spelling is `: |`.)
+: | MfErr {
+    MfEmpty
+    MfBad
 }
 
-@ make_pt i x i y → !Pt2 ParseErr {
-    ? < x 0 { ^ @ !Pt2 ParseErr { F Empty } } {}
+@ make_pt i x i y → !Pt2 MfErr {
+    ? < x 0 { ^ @ !Pt2 MfErr { F MfEmpty } } {}
     : Pt2 p @ Pt2 { x y }
-    ^ @ !Pt2 ParseErr { T p }
+    ^ @ !Pt2 MfErr { T p }
 }
 
-@ make_quad → !Quad ParseErr {
+@ make_quad → !Quad MfErr {
     : Quad q @ Quad { 7 11 13 17 }
-    ^ @ !Quad ParseErr { T q }
+    ^ @ !Quad MfErr { T q }
 }
 
-@ make_tagged s lbl i n → !Tagged ParseErr {
-    ? < n 0 { ^ @ !Tagged ParseErr { F BadFormat } } {}
+@ make_tagged s lbl i n → !Tagged MfErr {
+    ? < n 0 { ^ @ !Tagged MfErr { F MfBad } } {}
     : Tagged t @ Tagged { ( string_from lbl ) n }
-    ^ @ !Tagged ParseErr { T t }
+    ^ @ !Tagged MfErr { T t }
 }
 
 @ main → i {
     // ── Pt2 (i, i) ─────────────────────────────────────────────────
-    : !Pt2 ParseErr r1 ( make_pt 3 4 )
+    : !Pt2 MfErr r1 ( make_pt 3 4 )
     ?? r1 {
         T p → {
             : Pt2 pp # Pt2 p
@@ -68,14 +73,14 @@ $ `stdlib/core/string.nu`
     }
 
     // Error path: should NOT trigger heap-box load (different variant).
-    : !Pt2 ParseErr r2 ( make_pt - 0 5 1 )
+    : !Pt2 MfErr r2 ( make_pt - 0 5 1 )
     ?? r2 {
         T p → ( nurl_print `pt-neg: ok\n` )
         F e → ( nurl_print `pt-neg: err\n` )
     }
 
     // ── Quad (4 fields) ────────────────────────────────────────────
-    : !Quad ParseErr r3 ( make_quad )
+    : !Quad MfErr r3 ( make_quad )
     ?? r3 {
         T q → {
             : Quad qq # Quad q
@@ -93,7 +98,7 @@ $ `stdlib/core/string.nu`
     }
 
     // ── Tagged (String, i) — f0 is a STRUCT (%String). ────────────
-    : !Tagged ParseErr r4 ( make_tagged `hello` 42 )
+    : !Tagged MfErr r4 ( make_tagged `hello` 42 )
     ?? r4 {
         T t → {
             : Tagged tt # Tagged t

--- a/compiler/tests/result_multifield_try.nu
+++ b/compiler/tests/result_multifield_try.nu
@@ -22,19 +22,24 @@ $ `stdlib/core/string.nu`
     i count
 }
 
-| Err1 {
-    Empty
-    BadFormat
+// Self-contained error enum with unique variant names (string.nu pulls
+// in errors.nu's Empty/BadFormat transitively, so reusing those would
+// collide). This was written `| Err1` with a bare `|`, which the
+// front-end used to silently skip — now a hard error; the canonical
+// spelling is `: |`.
+: | Err1 {
+    Err1Empty
+    Err1Bad
 }
 
 @ make_pt i x i y → !Pt2 Err1 {
-    ? < x 0 { ^ @ !Pt2 Err1 { F Empty } } {}
+    ? < x 0 { ^ @ !Pt2 Err1 { F Err1Empty } } {}
     : Pt2 p @ Pt2 { x y }
     ^ @ !Pt2 Err1 { T p }
 }
 
 @ make_tagged s lbl i n → !Tagged Err1 {
-    ? < n 0 { ^ @ !Tagged Err1 { F BadFormat } } {}
+    ? < n 0 { ^ @ !Tagged Err1 { F Err1Bad } } {}
     : Tagged t @ Tagged { ( string_from lbl ) n }
     ^ @ !Tagged Err1 { T t }
 }

--- a/compiler/tests/should_fail_bare_pipe_enum.nu
+++ b/compiler/tests/should_fail_bare_pipe_enum.nu
@@ -1,0 +1,19 @@
+// should_fail_bare_pipe_enum.nu — an enum must be declared `: | Name`,
+// not with a bare `|` at the top level.
+//
+// The `:`-less spelling used to fall through the decl loop's silent
+// catch-all: the `|` token was skipped and the enum body left to an
+// incidental generation path. It only ever "worked" when an enum of the
+// same name was also imported (the local decl being effectively dead) —
+// otherwise the variants were silently dropped or double-generated. Now
+// a bare top-level `|` is a hard error pointing at the correct `: |`
+// spelling. Expect COMPILE FAIL.
+
+| Color {
+    Red
+    Green
+}
+
+@ main → i {
+    ^ 0
+}

--- a/compiler/tests/should_fail_unbalanced_braces.nu
+++ b/compiler/tests/should_fail_unbalanced_braces.nu
@@ -1,0 +1,32 @@
+// should_fail_unbalanced_braces.nu — an unbalanced-brace function body
+// must be REJECTED by the front-end, not silently miscompiled.
+//
+// Here `f`'s `~` loop body is closed by `}}` — one `}` too many. The
+// extra close ends `f`'s body early, leaving `^ ( g x )` and the real
+// closing `}` stranded at the top level. The decl loop used to silently
+// advance past such stray tokens, so `f` compiled to a truncated body
+// (an `undef` return) AND the scan_fn_sigs pre-pass desynced and stopped
+// registering every later function — a forward call to `g` then fell
+// back to the `i64` return-type default and only clang rejected the
+// mismatched `ret`. nurlc itself exited 0. (Surfaced building
+// stdlib/ext/yaml.nu — see GOTCHAS / project memory.)
+//
+// The fix makes any non-declaration token at the top level a hard error,
+// turning the whole class into a diagnostic at the first leaked token.
+// Expect COMPILE FAIL.
+
+@ f i n → i {
+    : ~ i x 0
+    ~ < n x {
+        ? > x 5 { = x + x 1 } {}
+    }}
+    ^ ( g x )
+}
+
+@ g i n → i {
+    ^ + n 1
+}
+
+@ main → i {
+    ^ ( f 3 )
+}


### PR DESCRIPTION
## Summary

Closes the `critic.md §4` *\"every trap is a compiler diagnostic\"* hole that
surfaced while building `stdlib/ext/yaml.nu` (PR #76): a one-`}`-too-many in a
function body slipped through `check.sh` **and** a full compile, producing
either a silent miscompile or a `clang`-only error while `nurlc` exited 0.

### Root cause
`parse_program`'s top-level declaration loop ended in a silent
`( nurl_lex_advance lex )` catch-all. An extra `}` closes a function body
early; the leftover statements (`^ x`, a stray `}`, …) then leak to the top
level where they were **swallowed**. That left the truncated function to
silently miscompile (an `undef` return) and desynced the `scan_fn_sigs`
pre-pass so it stopped registering every later function — forward calls to
those functions fell back to the `i64` return-type default, and only `clang`
rejected the mismatched `ret`. `nurlc` itself exited 0.

### Fix (front-end only — no backend/ABI change)
- **`parse_program` catch-all is now a hard `die`.** A brace imbalance leaks a
  stray token to the top level and is reported there:
  `unexpected '^' at the top level — … an earlier function body has unbalanced braces`.
- **Bare top-level `| Name { … }` enum** (the `:`-less spelling) is now a
  targeted error pointing at the canonical `: |`. It used to be silently
  skipped and only \"worked\" when an enum of the same name was also imported.
- **`expect` renders both tokens** — `expected '{' but found '->'` instead of
  the opaque `expected tt=15`; `__tok_label` gained `{` / `(` / `[` / `@`.

### Tests
- New `should_fail_unbalanced_braces.nu` and `should_fail_bare_pipe_enum.nu`
  lock in the diagnostics.
- `result_multifield{,_try}.nu` had relied on the silent skip (their bare-`|`
  enum decls were dead redefinitions shadowed by the imported `ParseErr`).
  Rewritten as real, self-contained `: |` enums with unique variant names.
- Bootstrap fixed point holds; full suite green.

### LSP
No change needed — the LSP runs `build/nurlc` and parses its GCC-style stderr,
so the new diagnostics surface automatically (`__parse_diag_line` keys off the
first three colons, preserving message-internal colons).

### Before / after
```
$ nurlc bad.nu   # function body with one extra '}'
# before: exit 0, silent miscompile / clang-only error far away
# after:
bad.nu:8:5: unexpected '^' at the top level — expected a declaration
(@ fn, : const/struct/enum, & ffi, $ import, or % trait/impl). A stray '}'
or leftover expression here usually means an earlier function body has
unbalanced braces.
    ^ ( b x )
    ^
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)