### PR TITLE
docs: drop dangling ROADMAP_old.md link

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,11 +2,10 @@
 
 This roadmap describes where NURL is **today** and where it is going. It is
 forward-looking and deliberately concise — the full, reverse-chronological
-record of *what shipped when* lives in [`CHANGELOG.md`](CHANGELOG.md), and the
-previous changelog-style roadmap is preserved as
-[`ROADMAP_old.md`](ROADMAP_old.md). Anything marked done here has a regression
-test in [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap
-fixed point.
+record of *what shipped when* lives in [`CHANGELOG.md`](CHANGELOG.md).
+Anything marked done here has a regression test in
+[`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
+point.
 
 _Last reviewed: 2026-06-07 · Current release: **0.9.5** · Language: **Grammar
 v2.2** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._


### PR DESCRIPTION
`ROADMAP_old.md` was deleted after the roadmap rewrite landed (commit
`2b56bd0`), leaving a dangling link in `ROADMAP.md`'s intro. Removes the
reference and points readers to `CHANGELOG.md` for the historical ship log.
The only remaining reference to the old file repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)