### PR TITLE
fix: reconstruct struct payloads in enum match slots 1 and 2

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5384,15 +5384,44 @@
                     ( nurl_print `  ` ) ( nurl_print cv1 )
                     ( nurl_print ` = trunc i64 ` ) ( nurl_print t64 ) ( nurl_print ` to ` ) ( nurl_print pt1 ) ( nurl_print `\n` )
                 } {
-                    ( nurl_print `  ` ) ( nurl_print cv1 )
-                    ? == ( nurl_str_get pt1 0 ) 123
-                    {  // Anonymous aggregate: load value from ptr
-                        ( nurl_print ` = load ` ) ( nurl_print pt1 )
-                        ( nurl_print `, ptr ` ) ( nurl_print pr1 ) ( nurl_print `\n` )
-                    }
-                    ? ( seq pt1 `i64` )
-                    { ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr1 ) ( nurl_print ` to i64\n` ) }
-                    { ( nurl_print ` = bitcast ptr ` ) ( nurl_print pr1 ) ( nurl_print ` to i8*\n` ) }
+                    // Mirror slot-0 reconstruction (the inverse of
+                    // gen_agg_lit's enum-construction boxing). A `%`-named
+                    // payload is either a single-pointer handle (Vec/String/…:
+                    // f0 is a pointer, stashed bare → rebuild via insertvalue)
+                    // or a multi-field struct / enum / anon aggregate (heap-
+                    // boxed → load through the box pointer). Without this,
+                    // slots 1-2 fell straight to the i8* bitcast and stored a
+                    // `ptr` into a `%Struct` slot (clang reject — the
+                    // non-slot-0 struct-payload hole).
+                    : b pt1_is_struct_handle F
+                    : s pt1_f0_ty ``
+                    ? == ( nurl_str_get pt1 0 ) 37
+                    { : s sname_pt1 ( nurl_str_slice pt1 1 - ( nurl_str_len pt1 ) 1 )
+                        : s var_list_pt1 ( nurl_sym_get syms ( nurl_str_cat sname_pt1 `__variants` ) )
+                        ? == 0 ( nurl_str_len var_list_pt1 )
+                        { = pt1_f0_ty ( nurl_sym_get syms ( nurl_str_cat3 sname_pt1 `__idx_0` `__type` ) )
+                            ? & != 0 ( nurl_str_len pt1_f0_ty )
+                            == ( nurl_str_get pt1_f0_ty - ( nurl_str_len pt1_f0_ty ) 1 ) 42
+                            { = pt1_is_struct_handle T } {} }
+                        {} }
+                    {}
+                    ? pt1_is_struct_handle
+                    { ( nurl_print `  ` ) ( nurl_print cv1 )
+                        ( nurl_print ` = insertvalue ` ) ( nurl_print pt1 )
+                        ( nurl_print ` undef, ` ) ( nurl_print pt1_f0_ty )
+                        ( nurl_print ` ` ) ( nurl_print pr1 ) ( nurl_print `, 0\n` ) }
+                    { ( nurl_print `  ` ) ( nurl_print cv1 )
+                        ? | == ( nurl_str_get pt1 0 ) 123
+                        & == ( nurl_str_get pt1 0 ) 37
+                        != ( nurl_str_get pt1 - ( nurl_str_len pt1 ) 1 ) 42
+                        {  // Anon aggregate OR named non-pointer struct / enum:
+                            // load the whole value back through the box pointer.
+                            ( nurl_print ` = load ` ) ( nurl_print pt1 )
+                            ( nurl_print `, ptr ` ) ( nurl_print pr1 ) ( nurl_print `\n` )
+                        }
+                        ? ( seq pt1 `i64` )
+                        { ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr1 ) ( nurl_print ` to i64\n` ) }
+                        { ( nurl_print ` = bitcast ptr ` ) ( nurl_print pr1 ) ( nurl_print ` to i8*\n` ) } }
                 }
                 : s vp1 ( nurl_cg_reg cg )
                 ( nurl_print `  ` ) ( nurl_print vp1 )
@@ -5429,15 +5458,37 @@
                     ( nurl_print `  ` ) ( nurl_print cv2 )
                     ( nurl_print ` = trunc i64 ` ) ( nurl_print t64 ) ( nurl_print ` to ` ) ( nurl_print pt2 ) ( nurl_print `\n` )
                 } {
-                    ( nurl_print `  ` ) ( nurl_print cv2 )
-                    ? == ( nurl_str_get pt2 0 ) 123
-                    {  // Anonymous aggregate: load value from ptr
-                        ( nurl_print ` = load ` ) ( nurl_print pt2 )
-                        ( nurl_print `, ptr ` ) ( nurl_print pr2 ) ( nurl_print `\n` )
-                    }
-                    ? ( seq pt2 `i64` )
-                    { ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr2 ) ( nurl_print ` to i64\n` ) }
-                    { ( nurl_print ` = bitcast ptr ` ) ( nurl_print pr2 ) ( nurl_print ` to i8*\n` ) }
+                    // Mirror slot-0 reconstruction — same struct-payload hole
+                    // as slot 1, one slot over (enum field 3).
+                    : b pt2_is_struct_handle F
+                    : s pt2_f0_ty ``
+                    ? == ( nurl_str_get pt2 0 ) 37
+                    { : s sname_pt2 ( nurl_str_slice pt2 1 - ( nurl_str_len pt2 ) 1 )
+                        : s var_list_pt2 ( nurl_sym_get syms ( nurl_str_cat sname_pt2 `__variants` ) )
+                        ? == 0 ( nurl_str_len var_list_pt2 )
+                        { = pt2_f0_ty ( nurl_sym_get syms ( nurl_str_cat3 sname_pt2 `__idx_0` `__type` ) )
+                            ? & != 0 ( nurl_str_len pt2_f0_ty )
+                            == ( nurl_str_get pt2_f0_ty - ( nurl_str_len pt2_f0_ty ) 1 ) 42
+                            { = pt2_is_struct_handle T } {} }
+                        {} }
+                    {}
+                    ? pt2_is_struct_handle
+                    { ( nurl_print `  ` ) ( nurl_print cv2 )
+                        ( nurl_print ` = insertvalue ` ) ( nurl_print pt2 )
+                        ( nurl_print ` undef, ` ) ( nurl_print pt2_f0_ty )
+                        ( nurl_print ` ` ) ( nurl_print pr2 ) ( nurl_print `, 0\n` ) }
+                    { ( nurl_print `  ` ) ( nurl_print cv2 )
+                        ? | == ( nurl_str_get pt2 0 ) 123
+                        & == ( nurl_str_get pt2 0 ) 37
+                        != ( nurl_str_get pt2 - ( nurl_str_len pt2 ) 1 ) 42
+                        {  // Anon aggregate OR named non-pointer struct / enum:
+                            // load the whole value back through the box pointer.
+                            ( nurl_print ` = load ` ) ( nurl_print pt2 )
+                            ( nurl_print `, ptr ` ) ( nurl_print pr2 ) ( nurl_print `\n` )
+                        }
+                        ? ( seq pt2 `i64` )
+                        { ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr2 ) ( nurl_print ` to i64\n` ) }
+                        { ( nurl_print ` = bitcast ptr ` ) ( nurl_print pr2 ) ( nurl_print ` to i8*\n` ) } }
                 }
                 : s vp2 ( nurl_cg_reg cg )
                 ( nurl_print `  ` ) ( nurl_print vp2 )

--- a/compiler/tests/enum_struct_payload_slots.nu
+++ b/compiler/tests/enum_struct_payload_slots.nu
@@ -1,0 +1,79 @@
+// enum_struct_payload_slots.nu — regression for a codegen hole where a
+// multi-field STRUCT value carried as an enum payload in a NON-slot-0
+// position (`: | E { Nil  V  i Pt }`) emitted invalid IR.
+//
+// Bug: enum construction (gen_agg_lit) heap-boxes a `%`-named struct
+// payload for EVERY payload slot, but the match/unbox side only
+// reconstructed it for slot 0 (`pv0`). Slots 1 and 2 (`pv1`/`pv2`) fell
+// through to the catch-all `bitcast ptr … to i8*`, so the arm bound a
+// `ptr`/`i8*` where the struct type was expected — clang rejected the
+// store (`'%rNN' defined with type 'ptr' but expected '%Pt'`). A struct
+// payload only round-tripped when it happened to be the FIRST payload.
+//
+// Fix: slots 1/2 now mirror slot 0's reconstruction — a single-pointer
+// handle (f0 is a pointer) is rebuilt via `insertvalue`; a multi-field
+// struct / enum / anon aggregate is loaded back through its heap-box
+// pointer.
+//
+// main returns the number of failed checks (0 = all pass).
+
+: Pt { i x i y }
+: Trip { i a i b i c }
+
+// Struct payload in each non-trivial slot position.
+: | S1 { NilA WrapA i Pt }  // struct in slot 1 (after an int)
+: | S2 { NilB WrapB i i Pt }  // struct in slot 2 (after two ints)
+: | S0 { NilC WrapC Pt }  // struct in slot 0 (regression guard)
+: | TwoS { NilD WrapD Pt Pt }  // structs in slots 0 AND 1
+: | Mix { NilE WrapE Pt i Trip }  // struct, int, bigger struct across all 3
+
+@ chk i got i want s tag → i {
+    ? == got want {
+        ( nurl_print tag ) ( nurl_print ` ok\n` ) ^ 0
+    } {
+        ( nurl_print tag ) ( nurl_print ` FAIL\n` ) ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i f 0
+
+    // Slot 1: int + struct.
+    : Pt p1 @ Pt { 10 20 }
+    : S1 e1 @ S1 { WrapA 5 p1 }
+    = f + f ?? e1 { WrapA n q → ( chk + n + . q x . q y 35 `slot1_struct` ) NilA → 1 }
+
+    // Slot 2: int + int + struct.
+    : Pt p2 @ Pt { 100 200 }
+    : S2 e2 @ S2 { WrapB 1 2 p2 }
+    = f + f ?? e2 { WrapB a b q → ( chk + a + b + . q x . q y 303 `slot2_struct` ) NilB → 1 }
+
+    // Slot 0 only (the path that already worked — guard against regression).
+    : Pt p0 @ Pt { 3 4 }
+    : S0 e0 @ S0 { WrapC p0 }
+    = f + f ?? e0 { WrapC q → ( chk + . q x . q y 7 `slot0_struct` ) NilC → 1 }
+
+    // Two struct payloads, slots 0 and 1.
+    : Pt pa @ Pt { 3 4 }
+    : Pt pb @ Pt { 5 6 }
+    : TwoS et @ TwoS { WrapD pa pb }
+    = f + f ?? et {
+        WrapD a b → ( chk + . a x + . a y + . b x . b y 18 `slot0_and_slot1_struct` )
+        NilD → 1
+    }
+
+    // All three slots populated: struct (2-field), int, struct (3-field).
+    : Pt mp @ Pt { 7 8 }
+    : Trip mt @ Trip { 1 2 3 }
+    : Mix em @ Mix { WrapE mp 9 mt }
+    ?? em {
+        WrapE q n t → {
+            = f + f ( chk + . q x . q y 15 `mix_slot0_struct` )
+            = f + f ( chk n 9 `mix_slot1_int` )
+            = f + f ( chk + . t a + . t b . t c 6 `mix_slot2_struct` )
+        }
+        NilE → {}
+    }
+
+    ^ f
+}


### PR DESCRIPTION
## What

Fixes a codegen hole where a **multi-field struct value carried as an enum
payload in a non-slot-0 position** emitted invalid IR and was rejected by clang.

```nurl
: Pt { i x  i y }
: | E { Nil  V  i Pt }        // struct payload in slot 1

@ main → i {
    : Pt p @ Pt { 10 20 }
    : E e @ E { V 5 p }
    ^ ?? e { V n q → + n + . q x . q y  Nil → 0 }   // before: clang reject
}
```

## Root cause

Enum construction (`gen_agg_lit`) heap-boxes a `%`-named struct payload for
**every** payload slot, but the match/unbox side only reconstructed it for
**slot 0** (`pv0`). Slots 1 and 2 (`pv1`/`pv2`) fell through to the catch-all
`bitcast ptr … to i8*`, so the arm bound a `ptr`/`i8*` where the struct type
was expected:

```
%rNN = bitcast ptr %payload to i8*
store %Pt %rNN, %Pt* %slot     ; clang: 'ptr' but expected '%Pt'
```

A struct payload therefore only round-tripped when it happened to be the
*first* payload.

## Fix

Slots 1/2 now mirror slot 0's reconstruction in `gen_match`:
- a single-pointer handle (f0 is a pointer) is rebuilt via `insertvalue`;
- a multi-field struct / enum / anon aggregate is loaded back through its
  heap-box pointer.

This is the inverse of the construction-side boxing that was already correct
for all slots, so the two sides now agree.

## Scope / non-goals

Two adjacent limitations are **pre-existing and unrelated** — they reproduce
identically in slot 0 (untouched code) and are out of scope here:
- a bare user-struct *name* as a payload type (`String`) is read as a phantom
  variant (parse-level disambiguation);
- a `( Vec i )` local in a standalone single-file compile hits an unsized
  `%Vec__i64` alloca.

## Tests

New regression `compiler/tests/enum_struct_payload_slots.nu`: struct payload in
slots 0/1/2, two struct payloads (slots 0+1), and a struct/int/struct mix
across all three slots. **ASan+UBSan clean, leak-free.** Bootstrap byte-identical
fixed point holds; full suite green.

Closes the "multi-value variant 2nd/3rd payload as a `%Name` aggregate" item on
the road to the 1.0 language lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)