### PR TITLE
feat(arena): chained-chunk growing arena + typed arena_alloc_n [T]

### DIFF
--- a/compiler/tests/arena_growing.nu
+++ b/compiler/tests/arena_growing.nu
@@ -1,0 +1,117 @@
+// arena_growing.nu — regression for the chained-chunk GROWING arena and
+// the typed `arena_alloc_n [T]` allocator added on feature/arena-growing.
+//
+// Covers:
+//   * a growing arena spills into multiple chunks once a chunk fills;
+//   * pointers handed out BEFORE a grow stay valid AFTER it (chunks are
+//     never moved/realloc'd) — the whole point of the chained model;
+//   * arena_used / arena_cap sum across chunks;
+//   * an oversized request (> chunk_sz) gets its own exact-fit chunk;
+//   * typed arena_alloc_n [T] round-trips a struct array;
+//   * arena_reset frees the extra chunks, keeps one base chunk, and the
+//     arena is reusable;
+//   * a FIXED arena still OOMs (no silent growth).
+//
+// Pointer bookkeeping deliberately avoids Vec (a standalone single-file
+// compile can't realise the %Vec__i64 monomorph) — a small FIXED arena
+// holds the pointer-as-int table instead, exercising that path too.
+//
+// main returns the number of failed checks (0 = all pass).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/arena.nu`
+
+: Pt { i x i y }
+
+@ chk i got i want s tag → i {
+    ? == got want {
+        ( nurl_print tag ) ( nurl_print ` ok\n` ) ^ 0
+    } {
+        ( nurl_print tag ) ( nurl_print ` FAIL\n` ) ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i f 0
+
+    // Growing arena, tiny chunks (32 bytes ⇒ 4 i64 slots per chunk).
+    : Arena g ( arena_growing 32 )
+    // Side table holding 20 slot pointers (as ints) — a FIXED arena.
+    : Arena store ( arena_with_cap 200 )
+    : *i pbuf # *i ( arena_alloc store 160 )
+
+    // Allocate 20 i64 slots one at a time, writing k into slot k. This
+    // forces several grows; record every pointer in pbuf.
+    : ~ i k 0
+    ~ < k 20 {
+        : *i slot # *i ( arena_alloc g 8 )
+        = . slot 0 k
+        : *i cell # *i + # i pbuf * k 8
+        = . cell 0 # i slot
+        = k + k 1
+    }
+
+    // It must actually have grown past one chunk.
+    = f + f ( chk ? > ( arena_chunk_count g ) 1 1 0 1 `grew_multiple_chunks` )
+
+    // Read every earlier pointer back — none corrupted by later grows.
+    : ~ i sum 0
+    : ~ i j 0
+    ~ < j 20 {
+        : *i cell # *i + # i pbuf * j 8
+        : *i sp # *i . cell 0
+        = sum + sum . sp 0
+        = j + j 1
+    }
+    = f + f ( chk sum 190 `pointers_valid_across_growth` )  // 0+1+…+19
+
+    // Accounting across chunks: 20 × 8 = 160 bytes consumed.
+    = f + f ( chk ( arena_used g ) 160 `used_sums_chunks` )
+    = f + f ( chk ? >= ( arena_cap g ) 160 1 0 1 `cap_covers_used` )
+
+    // Oversized request (> chunk_sz = 32) gets its own exact-fit chunk.
+    : *u big ( arena_alloc g 256 )
+    = f + f ( chk ? != 0 # i big 1 0 1 `oversize_alloc_ok` )
+
+    // Typed allocation: an array of 5 Pt in one shot.
+    : *Pt arr ( arena_alloc_n [Pt] g 5 )
+    = f + f ( chk ? != 0 # i arr 1 0 1 `alloc_n_nonnull` )
+    : ~ i w 0
+    ~ < w 5 {
+        : *Pt e # *Pt + # i arr * w Z Pt
+        = . e x w
+        = . e y * w 10
+        = w + w 1
+    }
+    : ~ i tsum 0
+    : ~ i r 0
+    ~ < r 5 {
+        : *Pt e # *Pt + # i arr * r Z Pt
+        = tsum + tsum + . e x . e y
+        = r + r 1
+    }
+    // (0+1+2+3+4) + (0+10+20+30+40) = 10 + 100
+    = f + f ( chk tsum 110 `alloc_n_roundtrip` )
+
+    // Reset: extra chunks freed, back to one base chunk, reusable.
+    ( arena_reset g )
+    = f + f ( chk ( arena_chunk_count g ) 1 `reset_keeps_one_chunk` )
+    = f + f ( chk ( arena_used g ) 0 `reset_zeroes_used` )
+    : *i after # *i ( arena_alloc g 8 )
+    = . after 0 777
+    = f + f ( chk . after 0 777 `usable_after_reset` )
+
+    ( arena_free g )
+    ( arena_free store )
+
+    // FIXED arena still OOMs — no silent growth.
+    : Arena fx ( arena_with_cap 16 )
+    : *u o1 ( arena_alloc fx 16 )
+    : *u o2 ( arena_alloc fx 8 )
+    = f + f ( chk ? != 0 # i o1 1 0 1 `fixed_first_ok` )
+    = f + f ( chk ? == 0 # i o2 1 0 1 `fixed_oom_null` )
+    = f + f ( chk ( arena_chunk_count fx ) 1 `fixed_never_grows` )
+    ( arena_free fx )
+
+    ^ f
+}

--- a/stdlib/std/arena.nu
+++ b/stdlib/std/arena.nu
@@ -1,50 +1,67 @@
 // stdlib/std/arena.nu — bump-pointer arena allocator.
 //
-// An `Arena` owns a single contiguous byte buffer. `arena_alloc`
-// hands out 8-byte-aligned pointers into that buffer in O(1) bump.
-// `arena_reset` invalidates every outstanding pointer and rewinds
-// the bump cursor to 0 — the buffer can be reused. `arena_free`
-// releases the buffer.
+// An `Arena` hands out 8-byte-aligned pointers in O(1) bump. It comes in
+// two flavours that share one API:
+//
+//   * FIXED   — a single contiguous buffer of a chosen capacity.
+//               `arena_alloc` returns NULL once the buffer is full.
+//               Construct with `arena_new` / `arena_with_cap`.
+//   * GROWING — a linked list of chunks. When the current chunk can't
+//               satisfy a request the arena allocates a fresh chunk and
+//               keeps allocating; pointers handed out from earlier chunks
+//               stay valid (chunks are never realloc'd or moved). This is
+//               the canonical arena model. Construct with `arena_growing`.
+//
+// `arena_reset` invalidates every outstanding pointer and rewinds the
+// bump cursor — the buffer (FIXED) or the base chunk (GROWING) is kept
+// for reuse; any extra chunks are released. `arena_free` releases
+// everything.
 //
 // Designed for parser / AST / regex-NFA / per-request workloads:
 // hundreds of small allocations whose lifetimes are tied to a single
-// outer scope. Single `nurl_free` at the end instead of one per
+// outer scope. One `arena_free` at the end instead of one free per
 // allocation. No need to track per-allocation ownership.
 //
 // API:
 //
-//   ( arena_new )              → Arena                empty (cap = 0)
-//   ( arena_with_cap n )       → Arena                preallocated
-//   ( arena_alloc a n )        → *u                   8-byte aligned, NULL on OOM
-//   ( arena_alloc_aligned a n align ) → *u            custom alignment
-//   ( arena_used a )           → i                    bytes consumed
-//   ( arena_cap a )            → i                    buffer capacity
-//   ( arena_remaining a )      → i                    cap - used
-//   ( arena_reset a )          → v                    rewind to empty, keep buffer
-//   ( arena_free a )           → v                    release buffer + handle
+//   ( arena_new )              → Arena    empty FIXED arena (cap = 0)
+//   ( arena_with_cap n )       → Arena    FIXED arena, buffer preallocated
+//   ( arena_growing chunk_sz ) → Arena    GROWING arena; chunks default to
+//                                          `chunk_sz` bytes (a larger request
+//                                          gets its own exact-fit chunk)
+//   ( arena_alloc a n )        → *u       8-byte aligned, NULL on OOM
+//   ( arena_alloc_aligned a n align ) → *u   custom alignment
+//   ( arena_alloc_n [T] a count ) → *T    typed: count items of T, 8-aligned
+//   ( arena_used a )           → i        total bytes consumed (all chunks)
+//   ( arena_cap a )            → i        total capacity (all chunks)
+//   ( arena_remaining a )      → i        bytes left in the current chunk
+//   ( arena_chunk_count a )    → i        number of live chunks (>1 ⇒ grew)
+//   ( arena_reset a )          → v        rewind to empty, keep base storage
+//   ( arena_free a )           → v        release every chunk + handle
 //
 // Memory model:
 //
 //   * `Arena { s ctl }` is a single-pointer handle to a heap-allocated
 //     `ArenaImpl`. Passing an Arena by value copies the 8-byte handle
-//     — every copy shares the same underlying buffer + bump cursor.
-//     This is the same opaque-handle pattern as `Channel` and `String`.
-//   * `arena_alloc` returns a BORROWED pointer into the arena's
-//     buffer. Pointers are valid until `arena_reset` (invalidates
-//     ALL outstanding pointers) or `arena_free` (frees the buffer
-//     entirely). Never `nurl_free` a pointer returned by
-//     `arena_alloc` — the arena owns the storage.
-//   * `arena_alloc` returns NULL when the next allocation would
-//     exceed `cap`. Callers MUST check. The arena does not grow
-//     automatically (growth would require either reallocating the
-//     buffer — invalidating outstanding pointers — or chaining
-//     additional chunks; both are explicit follow-ups, not v1).
+//     — every copy shares the same chunk list + bump cursor. Same
+//     opaque-handle pattern as `Channel` and `String`.
+//   * `arena_alloc` returns a BORROWED pointer into a chunk's buffer.
+//     Pointers are valid until `arena_reset` (invalidates ALL
+//     outstanding pointers) or `arena_free`. Never `nurl_free` a
+//     pointer returned by `arena_alloc` — the arena owns the storage.
+//   * A GROWING arena keeps every pointer valid across growth: new
+//     chunks are linked in, old ones are never moved or freed until
+//     reset/free. A FIXED arena returns NULL when the next allocation
+//     would exceed `cap`; callers MUST check.
 //   * Default alignment is 8 bytes: sufficient for `i64`, `f64`,
 //     pointers, and any single-pointer-handle struct on x86-64 /
 //     AArch64 targets NURL ships to. `arena_alloc_aligned` covers
-//     SIMD (16 / 32) or byte-tight (1) cases.
+//     SIMD (16 / 32) or byte-tight (1) cases. (Custom alignment aligns
+//     the offset within the chunk and so assumes the chunk's base
+//     pointer is at least as aligned, which `nurl_alloc` provides for
+//     the 8/16-byte cases in practice.)
 //
-// Lifecycle pattern:
+// Lifecycle pattern (fixed):
 //
 //   : Arena ar ( arena_with_cap 65536 )
 //   : *u p1 ( arena_alloc ar 128 )
@@ -54,44 +71,86 @@
 //
 // Reset-and-reuse pattern (per-request workloads, regex engine):
 //
-//   : Arena scratch ( arena_with_cap 16384 )
+//   : Arena scratch ( arena_growing 16384 )
 //   ~ have_work {
-//       ( do_work scratch )   // allocates into `scratch`
-//       ( arena_reset scratch ) // rewind, ready for next iteration
+//       ( do_work scratch )      // allocates into `scratch`, growing if needed
+//       ( arena_reset scratch )  // rewind, keep the base chunk, ready again
 //   }
 //   ( arena_free scratch )
-//
-// What this module is NOT (yet):
-//
-//   * A growing arena. `arena_alloc` returns NULL on OOM; it does
-//     not realloc the buffer (would invalidate outstanding pointers)
-//     nor chain additional chunks (would need a linked list of
-//     buffers). Both are tractable v2 work — chained chunks keep
-//     pointer validity and is the canonical arena model.
-//   * A typed allocator. `arena_alloc` returns `*u` (byte pointer);
-//     callers cast to `*T` via `# *T ptr`. A generic
-//     `arena_alloc_n [T] arena count → *T` wrapper is straight-line
-//     work atop the byte allocator; defer until a real call site
-//     asks for it.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/mem.nu`
 
-: ArenaImpl {
+// One contiguous buffer + its bump cursor. A GROWING arena links these
+// into a list (`next` points at the previously-current chunk); a FIXED
+// arena has exactly one. `next` is a self-referential pointer field —
+// NURL resolves the forward reference to `ArenaChunk` itself.
+: ArenaChunk {
     * u data
     i used
     i cap
+    * ArenaChunk next
+}
+
+: ArenaImpl {
+    * ArenaChunk head  // current chunk to allocate from (newest)
+    * ArenaChunk base  // first chunk ever created (kept across reset); 0 if none
+    i chunk_sz  // 0 = FIXED (no auto-grow); >0 = GROWING default chunk size
 }
 
 : Arena { s ctl }
+
+// ── Internal chunk helpers ───────────────────────────────────────────
+
+// Allocate one chunk with a `cap`-byte buffer. Returns NULL on OOM (and
+// frees the partial allocation so nothing leaks).
+@ __arena_new_chunk i cap → *ArenaChunk {
+    : *ArenaChunk c # *ArenaChunk ( nurl_alloc Z ArenaChunk )
+    ? == 0 # i c { ^ # *ArenaChunk 0 } {}
+    : *u buf # *u ( nurl_alloc cap )
+    ? == 0 # i buf {
+        ( nurl_free # s c )
+        ^ # *ArenaChunk 0
+    } {}
+    = . c data buf
+    = . c used 0
+    = . c cap cap
+    = . c next # *ArenaChunk 0
+    ^ c
+}
+
+@ __arena_free_chunk * ArenaChunk c → v {
+    ? != 0 # i . c data { ( nurl_free # s . c data ) } {}
+    ( nurl_free # s c )
+}
+
+@ __arena_sum_used * ArenaChunk head → i {
+    : ~ i acc 0
+    : ~ * ArenaChunk cur head
+    ~ != 0 # i cur {
+        = acc + acc . cur used
+        = cur . cur next
+    }
+    ^ acc
+}
+
+@ __arena_sum_cap * ArenaChunk head → i {
+    : ~ i acc 0
+    : ~ * ArenaChunk cur head
+    ~ != 0 # i cur {
+        = acc + acc . cur cap
+        = cur . cur next
+    }
+    ^ acc
+}
 
 // ── Constructors ─────────────────────────────────────────────────────
 
 @ arena_new → Arena {
     : *ArenaImpl impl # *ArenaImpl ( nurl_alloc Z ArenaImpl )
-    = . impl data # *u 0
-    = . impl used 0
-    = . impl cap 0
+    = . impl head # *ArenaChunk 0
+    = . impl base # *ArenaChunk 0
+    = . impl chunk_sz 0
     ^ @ Arena { # s impl }
 }
 
@@ -99,10 +158,21 @@ $ `stdlib/core/mem.nu`
     : Arena a ( arena_new )
     ? > n 0 {
         : *ArenaImpl impl # *ArenaImpl . a ctl
-        : *u buf # *u ( nurl_alloc n )
-        = . impl data buf
-        = . impl cap n
+        : *ArenaChunk c ( __arena_new_chunk n )
+        = . impl head c
+        = . impl base c
     } {}
+    ^ a
+}
+
+// A growing arena. `chunk_sz` is the default size of each chunk; a
+// request larger than `chunk_sz` gets its own exact-fit chunk so a
+// single big allocation never wastes a whole default chunk. The first
+// chunk is created lazily on the first allocation.
+@ arena_growing i chunk_sz → Arena {
+    : Arena a ( arena_new )
+    : *ArenaImpl impl # *ArenaImpl . a ctl
+    = . impl chunk_sz ? > chunk_sz 0 chunk_sz 1
     ^ a
 }
 
@@ -110,69 +180,144 @@ $ `stdlib/core/mem.nu`
 
 @ arena_used Arena a → i {
     : *ArenaImpl impl # *ArenaImpl . a ctl
-    ^ . impl used
+    ^ ( __arena_sum_used . impl head )
 }
 
 @ arena_cap Arena a → i {
     : *ArenaImpl impl # *ArenaImpl . a ctl
-    ^ . impl cap
+    ^ ( __arena_sum_cap . impl head )
 }
 
+// Bytes left in the CURRENT chunk before a grow (FIXED: cap − used).
 @ arena_remaining Arena a → i {
     : *ArenaImpl impl # *ArenaImpl . a ctl
-    ^ - . impl cap . impl used
+    : *ArenaChunk h . impl head
+    ? == 0 # i h { ^ 0 } {}
+    ^ - . h cap . h used
+}
+
+@ arena_chunk_count Arena a → i {
+    : *ArenaImpl impl # *ArenaImpl . a ctl
+    : ~ i n 0
+    : ~ * ArenaChunk cur . impl head
+    ~ != 0 # i cur {
+        = n + n 1
+        = cur . cur next
+    }
+    ^ n
 }
 
 // ── Allocation ───────────────────────────────────────────────────────
 
-// Allocate `n` bytes, 8-byte aligned. Returns NULL on overflow.
+// Allocate `n` bytes, 8-byte aligned. FIXED: NULL once the buffer is
+// full. GROWING: links a fresh chunk and never returns NULL unless the
+// underlying `nurl_alloc` itself fails.
 @ arena_alloc Arena a i n → *u {
     ? <= n 0 { ^ # *u 0 } {}
     : *ArenaImpl impl # *ArenaImpl . a ctl
-    // Align `used` UP to the next 8-byte boundary. `& (x + 7) -8` =
-    // `(x + 7) & ~7` since -8 is two's-complement all-ones-with-low-
-    // three-bits-zero.
-    : i used_aligned & + . impl used 7 -8
-    : i needed + used_aligned n
-    ? > needed . impl cap { ^ # *u 0 } {}
-    : *u p # *u + # i . impl data used_aligned
-    = . impl used needed
+    : *ArenaChunk h . impl head
+    // Try the current head chunk first.
+    ? != 0 # i h {
+        : i used_aligned & + . h used 7 -8
+        : i needed + used_aligned n
+        ? <= needed . h cap {
+            : *u p # *u + # i . h data used_aligned
+            = . h used needed
+            ^ p
+        } {}
+    } {}
+    // Head full (or none yet). FIXED arena → OOM.
+    ? <= . impl chunk_sz 0 { ^ # *u 0 } {}
+    // GROWING arena → new chunk big enough for n (default size, or exact
+    // fit for an oversized request).
+    : i want ? > n . impl chunk_sz n . impl chunk_sz
+    : *ArenaChunk nc ( __arena_new_chunk want )
+    ? == 0 # i nc { ^ # *u 0 } {}
+    = . nc next . impl head
+    = . impl head nc
+    ? == 0 # i . impl base { = . impl base nc } {}
+    : *u p # *u # i . nc data
+    = . nc used n
     ^ p
 }
 
 // Allocate `n` bytes with the requested alignment. `align` must be a
-// power of two. `align <= 1` is treated as no-alignment. Returns NULL
-// on overflow (after alignment).
+// power of two; `align <= 1` means no alignment. FIXED: NULL on
+// overflow (after alignment). GROWING: a fresh chunk if the head can't
+// satisfy the aligned request.
 @ arena_alloc_aligned Arena a i n i align → *u {
     ? <= n 0 { ^ # *u 0 } {}
     : *ArenaImpl impl # *ArenaImpl . a ctl
-    : ~ i used_aligned . impl used
-    ? > align 1 {
-        : i mask - align 1
-        = used_aligned & + . impl used mask - 0 align
+    : *ArenaChunk h . impl head
+    ? != 0 # i h {
+        // Align `used` UP to `align`: `(used + align-1) & -align`. -align
+        // is two's-complement all-ones with the low log2(align) bits zero.
+        : ~ i used_aligned . h used
+        ? > align 1 {
+            : i mask - align 1
+            = used_aligned & + . h used mask - 0 align
+        } {}
+        : i needed + used_aligned n
+        ? <= needed . h cap {
+            : *u p # *u + # i . h data used_aligned
+            = . h used needed
+            ^ p
+        } {}
     } {}
-    : i needed + used_aligned n
-    ? > needed . impl cap { ^ # *u 0 } {}
-    : *u p # *u + # i . impl data used_aligned
-    = . impl used needed
+    ? <= . impl chunk_sz 0 { ^ # *u 0 } {}
+    // GROWING arena: a fresh chunk's `nurl_alloc` base is already
+    // 8/16-byte aligned and its cursor starts at 0, so the aligned offset
+    // is 0 — allocate `n` straight from the chunk's base.
+    : i base_want ? > n . impl chunk_sz n . impl chunk_sz
+    : *ArenaChunk nc ( __arena_new_chunk base_want )
+    ? == 0 # i nc { ^ # *u 0 } {}
+    = . nc next . impl head
+    = . impl head nc
+    ? == 0 # i . impl base { = . impl base nc } {}
+    : *u p # *u # i . nc data
+    = . nc used n
     ^ p
+}
+
+// Typed allocation: `count` contiguous items of T, 8-byte aligned.
+// Returns a borrowed `*T` into the arena (NULL on OOM, like
+// `arena_alloc`). Never `nurl_free` it — the arena owns the storage.
+@ arena_alloc_n [T] Arena a i count → *T {
+    ? <= count 0 { ^ # *T 0 } {}
+    ^ # *T ( arena_alloc a * count Z T )
 }
 
 // ── Lifecycle ────────────────────────────────────────────────────────
 
-// Rewind to empty. All previously-issued pointers become invalid.
-// The underlying buffer is retained for reuse.
+// Rewind to empty. All previously-issued pointers become invalid. The
+// base chunk's buffer is retained for reuse; any extra chunks a GROWING
+// arena added are released.
 @ arena_reset Arena a → v {
     : *ArenaImpl impl # *ArenaImpl . a ctl
-    = . impl used 0
+    : *ArenaChunk base . impl base
+    ? != 0 # i base {
+        // Free every chunk from head down to (but not including) base.
+        : ~ * ArenaChunk cur . impl head
+        ~ != # i cur # i base {
+            : *ArenaChunk nxt . cur next
+            ( __arena_free_chunk cur )
+            = cur nxt
+        }
+        = . base used 0
+        = . base next # *ArenaChunk 0
+        = . impl head base
+    } {}
 }
 
-// Release the buffer and the impl block. After this the handle is
-// dead — do not pass it to any other arena_* function.
+// Release every chunk and the impl block. After this the handle is dead
+// — do not pass it to any other arena_* function.
 @ arena_free Arena a → v {
     : *ArenaImpl impl # *ArenaImpl . a ctl
-    ? != 0 # i . impl data {
-        ( nurl_free # s . impl data )
-    } {}
+    : ~ * ArenaChunk cur . impl head
+    ~ != 0 # i cur {
+        : *ArenaChunk nxt . cur next
+        ( __arena_free_chunk cur )
+        = cur nxt
+    }
     ( nurl_free # s impl )
 }


### PR DESCRIPTION
## What

Closes the two outstanding arena follow-ups that `stdlib/std/arena.nu` itself
documented as v2 work: **chained-chunk growth** and a **typed allocator**.

## Growing arena — `arena_growing chunk_sz`

The impl is now a linked list of `ArenaChunk`s. When the head chunk can't
satisfy a request, a fresh chunk is linked in and allocation continues. Old
chunks are **never moved or realloc'd**, so every pointer handed out before a
grow stays valid after it — the canonical, pointer-stable arena model (not a
realloc shim). A request larger than `chunk_sz` gets its own exact-fit chunk.

```nurl
: Arena g ( arena_growing 16384 )
: *Node n1 ( arena_alloc_n [Node] g 1 )   // chunk 1
// ... thousands of allocations, arena grows transparently ...
: *Node n2 ( arena_alloc_n [Node] g 1 )   // chunk N — n1 still valid
( arena_reset g )   // frees extra chunks, keeps base chunk for reuse
( arena_free g )
```

## Typed allocation — `arena_alloc_n [T] a count → *T`

Allocates `count` contiguous items of `T` (8-byte aligned), returns a borrowed
`*T`. Thin generic wrapper over `arena_alloc a (* count Z T)`.

## Backward compatibility

`arena_new` / `arena_with_cap` remain **FIXED** arenas: a single buffer,
`arena_alloc` returns NULL on overflow. The existing `arena_basic.nu` test
produces **byte-identical output** — existing callers are unaffected.

Other API: `arena_used` / `arena_cap` now sum across chunks; `arena_remaining`
reports the current chunk's free space; new `arena_chunk_count` exposes the
live-chunk count.

## Tests

New `compiler/tests/arena_growing.nu` — 13 checks: growth across multiple
chunks, **pointer validity across a grow**, used/cap summing, an oversized
one-chunk allocation, the typed `alloc_n` round-trip over a struct array,
reset-keeps-one-chunk reuse, and that a FIXED arena still OOMs (no silent
growth). **ASan + leak-detection clean.** Bootstrap byte-identical fixed point
holds; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)