### PR TITLE
feat(mcp): completion/complete on the server registry

### DIFF
--- a/compiler/tests/mcp_completion.nu
+++ b/compiler/tests/mcp_completion.nu
@@ -1,0 +1,167 @@
+// mcp_completion.nu — offline regression for MCP completion/complete
+// (spec §6.7) on the server registry.
+//
+// Registers a prompt-argument completer and a resource completer, then
+// drives completion/complete through mcp_registry_dispatch and prints the
+// spec-shaped {completion: {values, total, hasMore}} envelope. Also
+// checks that `initialize` now advertises the `completions` capability.
+// No sockets — pure dispatcher exercise (mirrors mcp_registry.nu).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/mcp.nu`
+$ `stdlib/ext/mcp_registry.nu`
+
+@ print_label s tag s value → v {
+    ( nurl_print tag ) ( nurl_print `=` ) ( nurl_print value ) ( nurl_print `\n` )
+}
+
+// Push `cand` onto `arr` iff it starts with `prefix`. Frees the
+// temporary String it builds for the prefix test.
+@ push_if_prefix Json arr s cand s prefix → v {
+    : String cs ( string_from cand )
+    ? ( string_starts_with cs prefix )
+    { ( json_arr_push arr ( json_str_lit cand ) ) } {}
+    ( string_free cs )
+}
+
+// Completion provider for the `language` prompt argument: prefix-filter a
+// fixed candidate list against the partial `value` the client typed.
+@ lang_completion Json arg → Json {
+    : ~ s prefix ``
+    : ?Json v ( json_obj_get arg `value` )
+    ?? v {
+        T jv → { = prefix ( json_as_str jv ) }
+        F _ → {}
+    }
+    : Json out ( json_arr_new )
+    ( push_if_prefix out `python` prefix )
+    ( push_if_prefix out `ruby` prefix )
+    ( push_if_prefix out `rust` prefix )
+    ( push_if_prefix out `go` prefix )
+    ^ out
+}
+
+// Completion provider for a resource URI argument: returns a fixed list.
+@ branch_completion Json arg → Json {
+    : Json out ( json_arr_new )
+    ( json_arr_push out ( json_str_lit `main` ) )
+    ( json_arr_push out ( json_str_lit `develop` ) )
+    ^ out
+}
+
+@ build_registry → McpRegistry {
+    : McpRegistry r ( mcp_registry_new `nurl-completion-test` `1.0.0` )
+
+    // A prompt the completion is attached to.
+    : Json greet_args ( json_arr_new )
+    ( mcp_registry_add_prompt r `greet` `Greeting` greet_args
+    \ Json a → Json { ^ ( json_obj_new ) } )
+
+    // completion for the prompt's `language` argument.
+    ( mcp_registry_add_completion r `ref/prompt` `greet`
+    \ Json a → Json { ^ ( lang_completion a ) } )
+
+    // completion for a resource template argument.
+    ( mcp_registry_add_completion r `ref/resource` `git://repo`
+    \ Json a → Json { ^ ( branch_completion a ) } )
+
+    ^ r
+}
+
+// Print values count, total, hasMore, and the first value (if any).
+@ report_completion s tag Json result → v {
+    : ?Json comp ( json_obj_get result `completion` )
+    ?? comp {
+        T c → {
+            : ?Json vals ( json_obj_get c `values` )
+            ?? vals {
+                T arr → {
+                    ( print_label ( nurl_str_cat tag `.count` ) ( nurl_str_int ( json_arr_len arr ) ) )
+                    : ?Json v0 ( json_arr_get arr 0 )
+                    ?? v0 {
+                        T jv → ( print_label ( nurl_str_cat tag `.first` ) ( json_as_str jv ) )
+                        F _ → ( print_label ( nurl_str_cat tag `.first` ) `(none)` )
+                    }
+                }
+                F _ → ( nurl_print `no values array\n` )
+            }
+            : ?Json tot ( json_obj_get c `total` )
+            ?? tot { T jt → ( print_label ( nurl_str_cat tag `.total` ) ( nurl_str_int ( json_as_int jt ) ) ) F _ → {} }
+            : ?Json hm ( json_obj_get c `hasMore` )
+            ?? hm { T jh → ( print_label ( nurl_str_cat tag `.hasMore` ) ? ( json_as_bool jh ) `T` `F` ) F _ → {} }
+        }
+        F _ → ( nurl_print `no completion object\n` )
+    }
+}
+
+@ complete_params s ref_type s ref_id s arg_name s arg_value → Json {
+    : Json ref ( json_obj_new )
+    ( json_obj_set ref `type` ( json_str_lit ref_type ) )
+    ? != 0 ( nurl_str_eq ref_type `ref/resource` )
+    { ( json_obj_set ref `uri` ( json_str_lit ref_id ) ) }
+    { ( json_obj_set ref `name` ( json_str_lit ref_id ) ) }
+    : Json argo ( json_obj_new )
+    ( json_obj_set argo `name` ( json_str_lit arg_name ) )
+    ( json_obj_set argo `value` ( json_str_lit arg_value ) )
+    : Json params ( json_obj_new )
+    ( json_obj_set params `ref` ref )
+    ( json_obj_set params `argument` argo )
+    ^ params
+}
+
+@ main → i {
+    : McpRegistry reg ( build_registry )
+
+    // ── initialize advertises the completions capability ───────────────
+    ( nurl_print `--- initialize ---\n` )
+    : Json init ( mcp_registry_dispatch reg `initialize` @ ?Json { F ( json_null ) } )
+    : ?Json caps ( json_obj_get init `capabilities` )
+    ?? caps {
+        T cp → {
+            : ?Json comp_cap ( json_obj_get cp `completions` )
+            ?? comp_cap {
+                T _ → ( print_label `completions_capability` `present` )
+                F _ → ( print_label `completions_capability` `absent` )
+            }
+        }
+        F _ → {}
+    }
+    ( json_free init )
+
+    // ── completion/complete: prompt arg, prefix "r" → ruby, rust ───────
+    ( nurl_print `--- completion prompt (prefix r) ---\n` )
+    : Json p1 ( complete_params `ref/prompt` `greet` `language` `r` )
+    : Json r1 ( mcp_registry_dispatch reg `completion/complete` @ ?Json { T p1 } )
+    ( report_completion `prompt_r` r1 )
+    ( json_free r1 )
+    ( json_free p1 )
+
+    // ── completion/complete: prompt arg, empty prefix → all 4 ──────────
+    ( nurl_print `--- completion prompt (empty prefix) ---\n` )
+    : Json p2 ( complete_params `ref/prompt` `greet` `language` `` )
+    : Json r2 ( mcp_registry_dispatch reg `completion/complete` @ ?Json { T p2 } )
+    ( report_completion `prompt_all` r2 )
+    ( json_free r2 )
+    ( json_free p2 )
+
+    // ── completion/complete: resource ref ──────────────────────────────
+    ( nurl_print `--- completion resource ---\n` )
+    : Json p3 ( complete_params `ref/resource` `git://repo` `branch` `` )
+    : Json r3 ( mcp_registry_dispatch reg `completion/complete` @ ?Json { T p3 } )
+    ( report_completion `resource` r3 )
+    ( json_free r3 )
+    ( json_free p3 )
+
+    // ── completion/complete: unknown ref → empty list ──────────────────
+    ( nurl_print `--- completion unknown ref ---\n` )
+    : Json p4 ( complete_params `ref/prompt` `nonexistent` `x` `a` )
+    : Json r4 ( mcp_registry_dispatch reg `completion/complete` @ ?Json { T p4 } )
+    ( report_completion `unknown` r4 )
+    ( json_free r4 )
+    ( json_free p4 )
+
+    ( mcp_registry_free reg )
+    ^ 0
+}

--- a/stdlib/ext/mcp_registry.nu
+++ b/stdlib/ext/mcp_registry.nu
@@ -20,11 +20,11 @@
 //   * tools/list, tools/call
 //   * prompts/list, prompts/get
 //   * resources/list, resources/read
+//   * completion/complete (argument autocompletion for prompts/resources)
 //   * ping (heartbeat — empty result)
 //
 // Out of scope here (deferred):
 //   * resources/subscribe + change notifications (needs SSE push)
-//   * completion/complete (rarely-used spec feature)
 //   * sampling/createMessage (server→client; bidirectional reverse RPC)
 //   * roots/list (client-side feature)
 //
@@ -80,6 +80,19 @@ $ `stdlib/ext/http_response.nu`
     ( @ Json ) handler
 }
 
+// Completion provider (spec §6.7, completion/complete). Bound to a
+// single reference — a prompt (`ref/prompt` + name) or a resource
+// template (`ref/resource` + uri). The handler receives the request's
+// `argument` object (`{name, value}` — the argument being completed and
+// the partial text typed so far) and returns a Json ARRAY of candidate
+// string values. The dispatcher wraps that array in the spec-shaped
+// `{completion: {values, total, hasMore}}` envelope.
+: McpCompletion {
+    String ref_type
+    String ref_id
+    ( @ Json Json ) handler
+}
+
 // ── Registry ──────────────────────────────────────────────────────────
 
 : McpRegistry {
@@ -88,6 +101,7 @@ $ `stdlib/ext/http_response.nu`
     ( Vec McpTool ) tools
     ( Vec McpPrompt ) prompts
     ( Vec McpResource ) resources
+    ( Vec McpCompletion ) completions
 }
 
 @ mcp_registry_new s name s version → McpRegistry {
@@ -97,6 +111,7 @@ $ `stdlib/ext/http_response.nu`
         ( vec_new [McpTool] )
         ( vec_new [McpPrompt] )
         ( vec_new [McpResource] )
+        ( vec_new [McpCompletion] )
     }
 }
 
@@ -140,6 +155,17 @@ $ `stdlib/ext/http_response.nu`
         = k + k 1
     }
     ( vec_free [McpResource] . r resources )
+    // Completions
+    : i cn ( vec_len [McpCompletion] . r completions )
+    : *McpCompletion cp ( vec_data [McpCompletion] . r completions )
+    = k 0
+    ~ < k cn {
+        : McpCompletion c . cp k
+        ( string_free . c ref_type )
+        ( string_free . c ref_id )
+        = k + k 1
+    }
+    ( vec_free [McpCompletion] . r completions )
 }
 
 // CONSUMES `name`, `description`, `schema`. Handler is borrowed.
@@ -172,6 +198,20 @@ $ `stdlib/ext/http_response.nu`
         handler
     }
     ( vec_push [McpResource] . r resources res )
+}
+
+// Register a completion provider. `ref_type` is `ref/prompt` or
+// `ref/resource`; `ref_id` is the prompt name or resource URI the
+// completion is attached to. The handler receives the `argument`
+// object and returns a Json array of candidate string values.
+// CONSUMES `ref_type`, `ref_id`. Handler is borrowed.
+@ mcp_registry_add_completion McpRegistry r s ref_type s ref_id ( @ Json Json ) handler → v {
+    : McpCompletion c @ McpCompletion {
+        ( string_from ref_type )
+        ( string_from ref_id )
+        handler
+    }
+    ( vec_push [McpCompletion] . r completions c )
 }
 
 // ── Lookup helpers ────────────────────────────────────────────────────
@@ -215,6 +255,21 @@ $ `stdlib/ext/http_response.nu`
     ^ found
 }
 
+@ __mcp_find_completion_index McpRegistry r s ref_type s ref_id → i {
+    : i n ( vec_len [McpCompletion] . r completions )
+    : *McpCompletion cp ( vec_data [McpCompletion] . r completions )
+    : ~ i k 0
+    : ~ i found -1
+    ~ & == found -1 < k n {
+        : McpCompletion c . cp k
+        ? & != 0 ( nurl_str_eq ( string_data . c ref_type ) ref_type )
+        != 0 ( nurl_str_eq ( string_data . c ref_id ) ref_id )
+        { = found k } {}
+        = k + k 1
+    }
+    ^ found
+}
+
 // ── Per-method dispatchers ────────────────────────────────────────────
 
 // initialize: returns server capabilities + info per spec §3.2.
@@ -232,6 +287,8 @@ $ `stdlib/ext/http_response.nu`
     { ( json_obj_set caps `prompts` ( json_obj_new ) ) } {}
     ? > ( vec_len [McpResource] . r resources ) 0
     { ( json_obj_set caps `resources` ( json_obj_new ) ) } {}
+    ? > ( vec_len [McpCompletion] . r completions ) 0
+    { ( json_obj_set caps `completions` ( json_obj_new ) ) } {}
 
     : Json out ( json_obj_new )
     ( json_obj_set out `protocolVersion` ( json_str_lit ( mcp_protocol_version ) ) )
@@ -435,6 +492,66 @@ $ `stdlib/ext/http_response.nu`
     ^ out
 }
 
+// Wrap a values array in the spec-shaped completion result. CONSUMES
+// `values`. `total` is the array length; `hasMore` is always false (we
+// never truncate — a provider that wants paging caps its own array, and
+// the spec's 100-value soft limit is the provider's responsibility).
+@ __mcp_completion_envelope Json values → Json {
+    : i total ( json_arr_len values )
+    : Json comp ( json_obj_new )
+    ( json_obj_set comp `values` values )
+    ( json_obj_set comp `total` ( json_int total ) )
+    ( json_obj_set comp `hasMore` ( json_bool F ) )
+    : Json out ( json_obj_new )
+    ( json_obj_set out `completion` comp )
+    ^ out
+}
+
+// completion/complete (spec §6.7): resolve a completion provider by its
+// ref — `ref/prompt` + name, or `ref/resource` + uri — and invoke it
+// with the request's `argument` object. Returns
+// {completion: {values, total, hasMore}}. An unknown ref yields an empty
+// completion list rather than an error (per spec: completion is a hint).
+@ __mcp_dispatch_completion McpRegistry r ? Json params → Json {
+    : ~ s ref_type ``
+    : ~ s ref_id ``
+    : ~ Json arg ( json_null )
+    ?? params {
+        T p → {
+            : ?Json rf ( json_obj_get p `ref` )
+            ?? rf {
+                T jr → {
+                    : ?Json rt ( json_obj_get jr `type` )
+                    ?? rt { T x → { = ref_type ( json_as_str x ) } F _ → {} }
+                    : ?Json rn ( json_obj_get jr `name` )
+                    ?? rn { T x → { = ref_id ( json_as_str x ) } F _ → {} }
+                    ? == 0 ( nurl_str_len ref_id ) {
+                        : ?Json ru ( json_obj_get jr `uri` )
+                        ?? ru { T x → { = ref_id ( json_as_str x ) } F _ → {} }
+                    } {}
+                }
+                F _ → {}
+            }
+            : ?Json ag ( json_obj_get p `argument` )
+            ?? ag { T x → { ( json_free arg ) = arg ( json_clone x ) } F _ → {} }
+        }
+        F _ → {}
+    }
+    : i idx ( __mcp_find_completion_index r ref_type ref_id )
+    ? < idx 0 {
+        ( json_free arg )
+        ^ ( __mcp_completion_envelope ( json_arr_new ) )
+    } {}
+    : *McpCompletion cp ( vec_data [McpCompletion] . r completions )
+    : McpCompletion c . cp idx
+    : ( @ Json Json ) h . c handler
+    : ~ Json values ( h arg )
+    ( json_free arg )
+    // Defensive: a provider that returns a non-array gets an empty list.
+    ? ( json_is_arr values ) {} { ( json_free values ) = values ( json_arr_new ) }
+    ^ ( __mcp_completion_envelope values )
+}
+
 // ── Dispatcher ────────────────────────────────────────────────────────
 //
 // Single entry point routing JSON-RPC method names to the per-method
@@ -465,6 +582,9 @@ $ `stdlib/ext/http_response.nu`
     } {}
     ? != 0 ( nurl_str_eq method `resources/read` ) {
         ^ ( __mcp_dispatch_resources_read r params )
+    } {}
+    ? != 0 ( nurl_str_eq method `completion/complete` ) {
+        ^ ( __mcp_dispatch_completion r params )
     } {}
     ? != 0 ( nurl_str_eq method `ping` ) {
         ^ ( json_obj_new )


### PR DESCRIPTION
## What

Adds **argument autocompletion** (MCP spec §6.7 `completion/complete`) to the
pure-NURL MCP server framework — one of the registry's remaining method gaps.

## API

```nurl
// Register a completer for a prompt argument…
( mcp_registry_add_completion r `ref/prompt` `greet`
  \ Json arg → Json { ^ ( my_lang_completer arg ) } )

// …or for a resource template argument.
( mcp_registry_add_completion r `ref/resource` `git://repo`
  \ Json arg → Json { ^ ( my_branch_completer arg ) } )
```

The handler receives the request's `argument` object (`{name, value}` — the
argument being completed and the partial text typed so far) and returns a Json
array of candidate strings.

## Dispatch

`__mcp_dispatch_completion` routes `completion/complete`: resolves the provider
by its ref (prompt name or resource uri), invokes it with the cloned argument,
and wraps the result in the spec envelope:

```json
{ "completion": { "values": ["ruby", "rust"], "total": 2, "hasMore": false } }
```

- An **unknown ref returns an empty completion list**, not an error (per spec —
  completion is a hint).
- `initialize` now advertises the `completions` capability whenever any provider
  is registered.
- **No transport wiring needed**: both the stdio and HTTP servers route through
  `mcp_registry_dispatch`, so the new method works over both immediately.

`McpRegistry` gains a `( Vec McpCompletion ) completions` field; `mcp_registry_free`
releases it. Pure NURL, no compiler change.

## Tests

New `compiler/tests/mcp_completion.nu` — prefix-filtered prompt completion,
empty-prefix (all candidates), resource-ref completion, unknown-ref empty list,
and the `initialize` capability advertisement. **ASan + leak-detection clean.**
Bootstrap fixed point holds; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)