### PR TITLE
feat(mcp): resources/subscribe + resources.updated notifications

### DIFF
--- a/compiler/tests/mcp_resource_subscribe.nu
+++ b/compiler/tests/mcp_resource_subscribe.nu
@@ -1,0 +1,110 @@
+// mcp_resource_subscribe.nu — regression for MCP resources/subscribe
+// (spec §6.5): per-session resource subscriptions + the
+// notifications/resources/updated fan-out. Pure in-memory; no sockets.
+// Returns the failure count.
+
+$ `stdlib/ext/mcp_session.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/mcp.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+@ notif_method Json j → s {
+    : ?Json m ( json_obj_get j `method` )
+    ^ ?? m { T x → ( json_as_str x ) F → `` }
+}
+
+@ notif_uri Json j → s {
+    : ?Json p ( json_obj_get j `params` )
+    ^ ?? p {
+        T pj → {
+            : ?Json u ( json_obj_get pj `uri` )
+            ^ ?? u { T x → ( json_as_str x ) F → `` }
+        }
+        F → ``
+    }
+}
+
+// Count the messages in a drained queue that target `uri`, freeing the
+// queue (and its Json elements) as it goes.
+@ drain_count_uri ( Vec Json ) q s uri → i {
+    : i n ( vec_len [Json] q )
+    : ~ i k 0
+    : ~ i hits 0
+    ~ < k n {
+        : ?Json e ( vec_get [Json] q k )
+        ?? e {
+            T j → {
+                ? & != 0 ( nurl_str_eq ( notif_method j ) `notifications/resources/updated` )
+                != 0 ( nurl_str_eq ( notif_uri j ) uri )
+                { = hits + hits 1 } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [Json] q \ Json j → v { ( json_free j ) } )
+    ^ hits
+}
+
+@ main → i {
+    : ~ i fails 0
+
+    : McpSessionStore store ( mcp_session_store_new )
+    : String id1 ( mcp_session_create store )
+    : String id2 ( mcp_session_create store )
+    : s s1 ( string_data id1 )
+    : s s2 ( string_data id2 )
+
+    : s uriA `file:///a.txt`
+    : s uriB `file:///b.txt`
+
+    // ── subscribe ──
+    ? ! ( mcp_session_subscribe store s1 uriA ) { ( nurl_print `  FAIL sub s1 A\n` ) = fails + fails 1 } {}
+    ? ! ( mcp_session_subscribe store s1 uriB ) { ( nurl_print `  FAIL sub s1 B\n` ) = fails + fails 1 } {}
+    ? ! ( mcp_session_subscribe store s2 uriA ) { ( nurl_print `  FAIL sub s2 A\n` ) = fails + fails 1 } {}
+    ? ! ( mcp_session_subscribe store `bogus` uriA ) {} { ( nurl_print `  FAIL sub bogus should be F\n` ) = fails + fails 1 }
+
+    // ── is_subscribed ──
+    ? ! ( mcp_session_is_subscribed store s1 uriA ) { ( nurl_print `  FAIL is_sub s1 A\n` ) = fails + fails 1 } {}
+    ? ( mcp_session_is_subscribed store s2 uriB ) { ( nurl_print `  FAIL s2 not sub B\n` ) = fails + fails 1 } {}
+
+    // ── notify uriA → both sessions; uriB → only s1 ──
+    ? != ( mcp_session_notify_resource_updated store uriA ) 2 { ( nurl_print `  FAIL notifyA count\n` ) = fails + fails 1 } {}
+    ? != ( mcp_session_notify_resource_updated store uriB ) 1 { ( nurl_print `  FAIL notifyB count\n` ) = fails + fails 1 } {}
+
+    // s1 queue: one A + one B. s2 queue: one A.
+    : ( Vec Json ) q1 ( mcp_session_drain_notify store s1 )
+    : i q1n ( vec_len [Json] q1 )
+    ? != q1n 2 { ( nurl_print `  FAIL s1 queue len\n` ) = fails + fails 1 } {}
+    ? != ( drain_count_uri q1 uriA ) 1 { ( nurl_print `  FAIL s1 got A\n` ) = fails + fails 1 } {}
+
+    : ( Vec Json ) q2 ( mcp_session_drain_notify store s2 )
+    ? != ( vec_len [Json] q2 ) 1 { ( nurl_print `  FAIL s2 queue len\n` ) = fails + fails 1 } {}
+    ? != ( drain_count_uri q2 uriA ) 1 { ( nurl_print `  FAIL s2 got A\n` ) = fails + fails 1 } {}
+
+    // ── unsubscribe s1 from A ──
+    ? ! ( mcp_session_unsubscribe store s1 uriA ) { ( nurl_print `  FAIL unsub s1 A\n` ) = fails + fails 1 } {}
+    ? ( mcp_session_unsubscribe store s1 uriA ) { ( nurl_print `  FAIL unsub twice should be F\n` ) = fails + fails 1 } {}
+    ? ( mcp_session_is_subscribed store s1 uriA ) { ( nurl_print `  FAIL s1 still sub A\n` ) = fails + fails 1 } {}
+    ? ! ( mcp_session_is_subscribed store s1 uriB ) { ( nurl_print `  FAIL s1 lost B\n` ) = fails + fails 1 } {}
+
+    // Now only s2 is subscribed to A.
+    ? != ( mcp_session_notify_resource_updated store uriA ) 1 { ( nurl_print `  FAIL notifyA after unsub\n` ) = fails + fails 1 } {}
+    : ( Vec Json ) q3 ( mcp_session_drain_notify store s2 )
+    ? != ( drain_count_uri q3 uriA ) 1 { ( nurl_print `  FAIL s2 got A again\n` ) = fails + fails 1 } {}
+
+    // ── idempotent subscribe: double-subscribe then single unsubscribe
+    //    must fully remove it (proves no duplicate entry). ──
+    ( mcp_session_subscribe store s2 uriA )
+    ( mcp_session_subscribe store s2 uriA )
+    ( mcp_session_unsubscribe store s2 uriA )
+    ? ( mcp_session_is_subscribed store s2 uriA ) { ( nurl_print `  FAIL idempotent sub\n` ) = fails + fails 1 } {}
+
+    ( string_free id1 )
+    ( string_free id2 )
+    ( mcp_session_store_free store )
+
+    ? == fails 0 { ( nurl_print `all ok\n` ) } {}
+    ^ fails
+}

--- a/stdlib/ext/mcp_http.nu
+++ b/stdlib/ext/mcp_http.nu
@@ -437,6 +437,22 @@ s host i port
     }
 }
 
+// Build a JSON-RPC success envelope with an empty result object, echoing
+// the request's `id`. Used for resources/(un)subscribe acks.
+@ __mcp_subscribe_reply Json req → Json {
+    : ?Json idf ( json_obj_get req `id` )
+    : Json res ( json_obj_new )
+    ?? idf {
+        T j → { ^ ( mcp_response_result j res ) }
+        F → {
+            : Json nullid ( json_null )
+            : Json env ( mcp_response_result nullid res )
+            ( json_free nullid )
+            ^ env
+        }
+    }
+}
+
 @ __mcp_req_is_response Json req → b {
     // A JSON-RPC response carries result/error and no method.
     ? ( json_obj_has req `method` ) { ^ F } {}
@@ -563,6 +579,43 @@ McpSessionStore store
                     ( json_free jreq )
                     : HttpResponse r ( __mcp_http_jsonrpc_error mcp_err_invalid_request `unknown or expired Mcp-Session-Id` )
                     = . r status 404
+                    ( __mcp_http_apply_cors r )
+                    ^ r
+                } {}
+
+                // resources/subscribe & resources/unsubscribe are
+                // session-scoped: handle them here (the dispatch closure is
+                // session-agnostic) by recording the subscription against
+                // this request's Mcp-Session-Id, then reply with an empty
+                // result. The change-notification side is driven by the
+                // application calling mcp_session_notify_resource_updated.
+                : b is_sub ( nurl_str_eq method `resources/subscribe` )
+                : b is_unsub ( nurl_str_eq method `resources/unsubscribe` )
+                ? | is_sub is_unsub {
+                    : ~ s sub_uri ``
+                    : ?Json prm ( json_obj_get jreq `params` )
+                    ?? prm {
+                        T pj → {
+                            : ?Json uj ( json_obj_get pj `uri` )
+                            ?? uj { T x → { = sub_uri ( json_as_str x ) } F _ → {} }
+                        }
+                        F _ → {}
+                    }
+                    : ?String ssid ( header_get . req headers `Mcp-Session-Id` )
+                    ?? ssid {
+                        T s → {
+                            ? & is_sub != 0 ( nurl_str_len sub_uri )
+                            { ( mcp_session_subscribe store ( string_data s ) sub_uri ) } {}
+                            ? & is_unsub != 0 ( nurl_str_len sub_uri )
+                            { ( mcp_session_unsubscribe store ( string_data s ) sub_uri ) } {}
+                            ( string_free s )
+                        }
+                        F _ → {}
+                    }
+                    : Json env ( __mcp_subscribe_reply jreq )
+                    ( json_free jreq )
+                    : HttpResponse r ( __mcp_http_response_for_json req env )
+                    ( __mcp_http_echo_session req r )
                     ( __mcp_http_apply_cors r )
                     ^ r
                 } {}

--- a/stdlib/ext/mcp_session.nu
+++ b/stdlib/ext/mcp_session.nu
@@ -36,6 +36,11 @@
 //   ( mcp_session_delete store sid )                → b
 //   ( mcp_session_push_notify store sid msg )       → b   CONSUMES msg
 //   ( mcp_session_drain_notify store sid )          → ( Vec Json )  owned
+//   ( mcp_session_subscribe store sid uri )         → b
+//   ( mcp_session_unsubscribe store sid uri )       → b
+//   ( mcp_session_is_subscribed store sid uri )     → b
+//   ( mcp_session_notify_resource_updated store uri ) → i   sessions notified
+//   ( mcp_resource_updated_notification uri )       → Json  notification msg
 //   ( mcp_session_begin_rpc store sid method params ) → i  request id, CONSUMES params
 //   ( mcp_session_request_sampling store sid msgs system max_tokens ) → i
 //   ( mcp_session_is_pending store sid id )         → b
@@ -59,10 +64,11 @@ $ `stdlib/core/vec.nu`
     String id
     i created_ms
     i last_ms
-    i next_rpc_id           // server→client request id allocator (1-based)
-    ( Vec Json ) notify     // outbound queue (notifications + reverse-RPC requests)
-    ( Vec i ) pending_ids   // reverse-RPC request ids awaiting a response
-    ( Vec Json ) results    // inbound reverse-RPC responses, matched by their "id"
+    i next_rpc_id  // server→client request id allocator (1-based)
+    ( Vec Json ) notify  // outbound queue (notifications + reverse-RPC requests)
+    ( Vec i ) pending_ids  // reverse-RPC request ids awaiting a response
+    ( Vec Json ) results  // inbound reverse-RPC responses, matched by their "id"
+    ( Vec String ) subscriptions  // resource URIs this session subscribed to
 }
 
 : McpSessionStore { ( Vec McpSession ) sessions }
@@ -99,6 +105,7 @@ $ `stdlib/core/vec.nu`
     : McpSession se @ McpSession {
         id now now 1
         ( vec_new [Json] ) ( vec_new [i] ) ( vec_new [Json] )
+        ( vec_new [String] )
     }
     ( vec_push [McpSession] . store sessions se )
     ^ ret
@@ -131,6 +138,7 @@ $ `stdlib/core/vec.nu`
     ( vec_free_with [Json] . se notify \ Json j → v { ( json_free j ) } )
     ( vec_free [i] . se pending_ids )
     ( vec_free_with [Json] . se results \ Json j → v { ( json_free j ) } )
+    ( vec_free_with [String] . se subscriptions \ String s → v { ( string_free s ) } )
 }
 
 @ mcp_session_delete McpSessionStore store s sid → b {
@@ -184,6 +192,107 @@ $ `stdlib/core/vec.nu`
         F → {}
     }
     ^ out
+}
+
+// ── Resource subscriptions (spec §6.5) ────────────────────────────────
+//
+// A session may subscribe to individual resource URIs; when the server
+// observes a change it calls `mcp_session_notify_resource_updated`, which
+// enqueues a `notifications/resources/updated` message onto every
+// subscribed session's outbound queue (delivered over the SSE stream by
+// the existing drain path). Subscription URIs are owned String copies.
+
+@ __mcp_sub_index ( Vec String ) subs s uri → i {
+    : i n ( vec_len [String] subs )
+    : ~ i k 0
+    : ~ i res -1
+    ~ < k n {
+        : ?String so ( vec_get [String] subs k )
+        ?? so {
+            T s → { ? == 1 ( nurl_str_eq ( string_data s ) uri ) { = res k = k n } {} }
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ res
+}
+
+// Subscribe `sid` to `uri`. Idempotent: a duplicate URI is a no-op.
+// Returns F if the session is unknown.
+@ mcp_session_subscribe McpSessionStore store s sid s uri → b {
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ^ F } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → {
+            // Subscriptions ride the heap-stable Vec ctl, so a push
+            // persists through the struct copy without a vec_set.
+            ? >= ( __mcp_sub_index . se subscriptions uri ) 0
+            {}
+            { ( vec_push [String] . se subscriptions ( string_from uri ) ) }
+            ^ T
+        }
+        F → { ^ F }
+    }
+}
+
+// Unsubscribe `sid` from `uri`. Returns T iff the URI was subscribed.
+@ mcp_session_unsubscribe McpSessionStore store s sid s uri → b {
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ^ F } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → {
+            : i si ( __mcp_sub_index . se subscriptions uri )
+            ? < si 0 { ^ F } {}
+            : ?String victim ( vec_get [String] . se subscriptions si )
+            ?? victim { T s → ( string_free s ) F → {} }
+            ( vec_remove [String] . se subscriptions si )
+            ^ T
+        }
+        F → { ^ F }
+    }
+}
+
+@ mcp_session_is_subscribed McpSessionStore store s sid s uri → b {
+    : i idx ( __mcp_session_find store sid )
+    ? < idx 0 { ^ F } {}
+    : ?McpSession so ( vec_get [McpSession] . store sessions idx )
+    ?? so {
+        T se → { ^ >= ( __mcp_sub_index . se subscriptions uri ) 0 }
+        F → { ^ F }
+    }
+}
+
+// Build the spec-shaped `notifications/resources/updated` message for a
+// changed `uri` (no id — it is a notification, not a request).
+@ mcp_resource_updated_notification s uri → Json {
+    : Json params ( json_obj_new )
+    ( json_obj_set params `uri` ( json_str_lit uri ) )
+    ^ ( mcp_notification `notifications/resources/updated` params )
+}
+
+// Notify every session subscribed to `uri` that the resource changed.
+// Enqueues one `notifications/resources/updated` per subscribed session.
+// Returns the number of sessions notified.
+@ mcp_session_notify_resource_updated McpSessionStore store s uri → i {
+    : i n ( vec_len [McpSession] . store sessions )
+    : ~ i k 0
+    : ~ i count 0
+    ~ < k n {
+        : ?McpSession so ( vec_get [McpSession] . store sessions k )
+        ?? so {
+            T se → {
+                ? >= ( __mcp_sub_index . se subscriptions uri ) 0 {
+                    ( vec_push [Json] . se notify ( mcp_resource_updated_notification uri ) )
+                    = count + count 1
+                } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ count
 }
 
 // ── Reverse RPC (server → client) ─────────────────────────────────────


### PR DESCRIPTION
## What

Adds per-session **resource subscriptions** (MCP spec §6.5) to the session-aware
server — the last server-side resource gap.

## Session store (`mcp_session.nu`)

Each `McpSession` gains an owned `subscriptions` URI list:

- `mcp_session_subscribe store sid uri` — idempotent
- `mcp_session_unsubscribe store sid uri` — frees the stored URI, reports presence
- `mcp_session_is_subscribed store sid uri`
- `mcp_session_notify_resource_updated store uri` — fans a
  `notifications/resources/updated` message out to every session subscribed to
  the changed URI (via the existing outbound queue → SSE drain), returns the
  count notified
- `mcp_resource_updated_notification uri` — wire-message builder

## Transport (`mcp_http.nu`)

The session HTTP handler intercepts `resources/subscribe` / `resources/unsubscribe`
— these are session-scoped, which the stateless dispatch closure can't see — records
the subscription against the request's `Mcp-Session-Id`, and replies with an
empty-result ack.

## Tests

`compiler/tests/mcp_resource_subscribe.nu`: subscribe/unsubscribe/is_subscribed,
two-session vs one-session fan-out, post-unsubscribe delivery, an unknown-session
guard, and idempotency. **ASan + leak-detection clean.** Bootstrap fixed point
holds; full suite green.

## Deliberately out of scope

Advertising the `resources.subscribe` capability needs a mutable scalar flag on
the by-value `McpRegistry` struct, which doesn't propagate back (only the
heap-stable `Vec` fields do). Doing it properly needs a boxed registry — a
separate change. Subscriptions are serviced regardless of advertisement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)