### PR TITLE
fix(nurlapi): bound concurrent compiles to stop OOM crashes

### DIFF
--- a/compiler/tests/semaphore_basic.nu
+++ b/compiler/tests/semaphore_basic.nu
@@ -1,0 +1,120 @@
+// semaphore_basic.nu — regression for the counting Semaphore added to
+// stdlib/std/thread.nu (sem_new / acquire / try_acquire / release /
+// avail / free).
+//
+// The counting logic is checked deterministically and single-threaded via
+// sem_try_acquire (no scheduler dependence). A live multi-threaded
+// exercise — N threads bounded by a sem(K), asserting the observed peak
+// concurrency never exceeds K — is gated behind NURL_NET_TESTS=1, the
+// same convention thread_basic.nu uses (thread spawn is occasionally
+// flaky on loaded CI hosts; the default path stays deterministic).
+//
+// main returns the number of failed checks (0 = all pass).
+
+$ `stdlib/std/thread.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/core/string.nu`
+
+// Shared state for the live concurrency test (module-level mutables, the
+// pattern thread_basic.nu uses for closure-captured counters).
+: ~ i live_active 0
+: ~ i live_peak 0
+
+@ chk b cond s tag → i {
+    ? cond {
+        ( nurl_print tag ) ( nurl_print ` ok\n` ) ^ 0
+    } {
+        ( nurl_print tag ) ( nurl_print ` FAIL\n` ) ^ 1
+    }
+}
+
+@ run_live_test i n_threads i permits Mutex guard Semaphore gate → v {
+    : ( @ v ) worker \ → v {
+        : ~ i it 0
+        ~ < it 50 {
+            ( sem_acquire gate )
+            // Enter the bounded region: bump active + track the peak.
+            ( mutex_lock guard )
+            = live_active + live_active 1
+            ? > live_active live_peak { = live_peak live_active } {}
+            ( mutex_unlock guard )
+            // Spin a little so overlap is likely (keeps the region busy).
+            : ~ i spin 0
+            ~ < spin 2000 { = spin + spin 1 }
+            // Leave the bounded region.
+            ( mutex_lock guard )
+            = live_active - live_active 1
+            ( mutex_unlock guard )
+            ( sem_release gate )
+            = it + it 1
+        }
+    }
+    : s thandles ( nurl_alloc * n_threads 8 )
+    : ~ i j 0
+    ~ < j n_threads {
+        : !Thread ThreadErr r ( thread_spawn worker )
+        ?? r {
+            T t → { ( nurl_poke thandles j # i . t raw ) }
+            F _ → { ( nurl_poke thandles j 0 ) }
+        }
+        = j + j 1
+    }
+    = j 0
+    ~ < j n_threads {
+        : i traw ( nurl_peek thandles j )
+        ? != traw 0 { ( thread_join @ Thread { # s traw } ) } {}
+        = j + j 1
+    }
+    ( nurl_free thandles )
+}
+
+@ main → i {
+    : ~ i f 0
+
+    // ── Deterministic counting via try_acquire (no threads) ──
+    : Semaphore s ( sem_new 2 )
+    = f + f ( chk == ( sem_avail s ) 2 `avail_initial_2` )
+    = f + f ( chk ( sem_try_acquire s ) `try1_ok` )  // 2 → 1
+    = f + f ( chk ( sem_try_acquire s ) `try2_ok` )  // 1 → 0
+    = f + f ( chk == ( sem_avail s ) 0 `avail_zero` )
+    = f + f ( chk ! ( sem_try_acquire s ) `try3_blocked` )  // 0 → fail
+    ( sem_release s )  // 0 → 1
+    = f + f ( chk == ( sem_avail s ) 1 `avail_after_release` )
+    = f + f ( chk ( sem_try_acquire s ) `try4_ok` )  // 1 → 0
+    = f + f ( chk ! ( sem_try_acquire s ) `try5_blocked` )
+    ( sem_release s )
+    ( sem_release s )
+    = f + f ( chk == ( sem_avail s ) 2 `avail_restored` )
+    ( sem_free s )
+
+    // sem_new clamps a non-positive count to 0 (never negative permits).
+    : Semaphore z ( sem_new - 0 3 )
+    = f + f ( chk == ( sem_avail z ) 0 `neg_clamped_to_0` )
+    = f + f ( chk ! ( sem_try_acquire z ) `neg_no_permit` )
+    ( sem_free z )
+
+    // ── Live concurrency bound (gated) ──
+    : ?String gate_env ( env_get `NURL_NET_TESTS` )
+    ?? gate_env {
+        T g → {
+            ( string_free g )
+            : i permits 3
+            : Mutex guard ( mutex_new )
+            : Semaphore gate ( sem_new permits )
+            = live_active 0
+            = live_peak 0
+            ( run_live_test 8 permits guard gate )
+            // The hard invariant: peak concurrency never exceeded the
+            // permit count, and the region was actually entered.
+            = f + f ( chk <= live_peak permits `live_peak_within_bound` )
+            = f + f ( chk >= live_peak 1 `live_region_entered` )
+            ( sem_free gate )
+            ( mutex_free guard )
+        }
+        F _ → {
+            ( nurl_print `live_concurrency skipped (set NURL_NET_TESTS=1)\n` )
+        }
+    }
+
+    ^ f
+}

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -11,6 +11,7 @@ $ `stdlib/std/random.nu`
 $ `stdlib/ext/regex.nu`
 $ `stdlib/ext/mcp.nu`
 $ `stdlib/ext/mcp_http.nu`
+$ `stdlib/std/thread.nu`
 
 // ── Globals ──────────────────────────────────────────────────────────
 
@@ -1338,9 +1339,9 @@ s combined_stdout s combined_stderr → v {
             // stays JSON for the playground's examples dropdown / wasm runner.
             : i nlen ( string_len name )
             ? & & & >= nlen 4
-                == ( nurl_str_get ( string_data name ) - nlen 3 ) 46
-                == ( nurl_str_get ( string_data name ) - nlen 2 ) 109
-                == ( nurl_str_get ( string_data name ) - nlen 1 ) 100 {
+            == ( nurl_str_get ( string_data name ) - nlen 3 ) 46
+            == ( nurl_str_get ( string_data name ) - nlen 2 ) 109
+            == ( nurl_str_get ( string_data name ) - nlen 1 ) 100 {
                 : String rel ( string_with_cap + nlen 10 )
                 ( string_push_str rel `examples/` ) ( string_push_str rel ( string_data name ) )
                 : HttpResponse mr ( __serve_repo_doc ( string_data rel ) )
@@ -2723,14 +2724,14 @@ s combined_stdout s combined_stderr → v {
     : String fp ( path_join ( string_data root ) rel )
     : i rn ( nurl_str_len rel )
     : b is_md & & & >= rn 4
-        == ( nurl_str_get rel - rn 3 ) 46
-        == ( nurl_str_get rel - rn 2 ) 109
-        == ( nurl_str_get rel - rn 1 ) 100
+    == ( nurl_str_get rel - rn 3 ) 46
+    == ( nurl_str_get rel - rn 2 ) 109
+    == ( nurl_str_get rel - rn 1 ) 100
     : String rawp ( string_with_cap + rn 1 )
     ( string_push_char rawp 47 ) ( string_push_str rawp rel )
     : HttpResponse r ? is_md
-        ( __serve_md_as_html ( string_data fp ) rel ( string_data rawp ) `not found\n` )
-        ( __serve_file_text ( string_data fp ) `text/plain; charset=utf-8` `not found\n` )
+    ( __serve_md_as_html ( string_data fp ) rel ( string_data rawp ) `not found\n` )
+    ( __serve_file_text ( string_data fp ) `text/plain; charset=utf-8` `not found\n` )
     ( string_free root ) ( string_free fp ) ( string_free rawp )
     ^ r
 }
@@ -2752,7 +2753,9 @@ s combined_stdout s combined_stderr → v {
 }
 
 @ h_docs_file HttpRequest req Params params → HttpResponse { ^ ( __serve_repo_subdir params `docs/` ) }
+
 @ h_spec_file HttpRequest req Params params → HttpResponse { ^ ( __serve_repo_subdir params `spec/` ) }
+
 @ h_bench_file HttpRequest req Params params → HttpResponse { ^ ( __serve_repo_subdir params `bench/` ) }
 
 // ── Doc passthrough — README.md / grammar.ebnf ────────────────────
@@ -4175,6 +4178,56 @@ s combined_stdout s combined_stderr → v {
     ^ ( wrapped req )
 }
 
+// ── Compile-concurrency gate ──────────────────────────────────────────
+//
+// The worker pool (server_run_pool, NURL_WORKERS=16) lets up to 16
+// requests run at once. A compile request spawns `clang -O2 -flto`, which
+// can use hundreds of MB; 16 of those simultaneously can blow the
+// container's memory cap and get the whole process OOM-killed (the
+// "container is not listening" symptom). The accept pool stays wide so
+// light requests (docs, examples, MCP tools/list, SSE) keep flowing, but
+// the heavy COMPILE step is bounded by a counting semaphore. Default 4
+// concurrent compiles; tune with NURL_COMPILE_SLOTS.
+@ get_compile_slots → i {
+    : String s ( env_var_or `NURL_COMPILE_SLOTS` `4` )
+    : i n ?? ( int_parse ( string_data s ) ) { T v → v F _ → 4 }
+    ( string_free s )
+    ^ ? > n 0 n 1
+}
+
+// A request that triggers a compile: POST /build* (native/wasm/win/mac/
+// target) or POST /mcp (the build_* MCP tools). GET /mcp is the light SSE
+// drain and is deliberately NOT gated.
+@ __is_compile_route HttpRequest req → b {
+    : s m ( string_data . req method )
+    ? == 0 ( nurl_str_eq m `POST` ) { ^ F } {}
+    : s p ( string_data . req path )
+    ? != 0 ( nurl_str_eq p `/mcp` ) { ^ T } {}
+    : String ps ( string_from p )
+    : b hit ( string_starts_with ps `/build` )
+    ( string_free ps )
+    ^ hit
+}
+
+// Dispatch a request, holding a compile permit across the handler for
+// compile routes. The permit is released even if the handler panics
+// (NURL `recover` would otherwise let the server-level recovery skip our
+// release, leaking a permit and eventually deadlocking the gate). Kept a
+// top-level fn — not a closure body — so the inner `recover` closure is
+// not nested inside another closure.
+@ __gated_handle Router r Semaphore gate HttpRequest req → HttpResponse {
+    ? ( __is_compile_route req ) {
+        ( sem_acquire gate )
+        : ~ HttpResponse resp ( response_text 500 `internal error: handler panicked\n` )
+        : !v PanicInfo pr ( recover \ → v { = resp ( router_handle r req ) } )
+        ( sem_release gate )
+        ?? pr { T _ → {} F p → { ( panic_info_free p ) } }
+        ^ resp
+    } {
+        ^ ( router_handle r req )
+    }
+}
+
 @ main → i {
     // Anchor the process at NURL_WORK_ROOT so that nurlc subprocesses inherit
     // a cwd from which `$ "stdlib/std/time.nu"`-style imports resolve. NURL's
@@ -4258,7 +4311,11 @@ s combined_stdout s combined_stderr → v {
             ( router_get r `/` \ HttpRequest req Params params → HttpResponse { ^ ( h_static req params ) } )
             ( router_get r `/*path` \ HttpRequest req Params params → HttpResponse { ^ ( h_static req params ) } )
 
-            : ( @ HttpResponse HttpRequest ) base \ HttpRequest req → HttpResponse { ^ ( router_handle r req ) }
+            // Compile-concurrency gate: bound how many `clang` compiles run
+            // at once so a wide worker pool can't OOM the container.
+            : i compile_slots ( get_compile_slots )
+            : Semaphore compile_gate ( sem_new compile_slots )
+            : ( @ HttpResponse HttpRequest ) base \ HttpRequest req → HttpResponse { ^ ( __gated_handle r compile_gate req ) }
             : ( @ HttpResponse HttpRequest ) logged ( with_access_log base )
             ( signal_install_shutdown listener )
 
@@ -4270,10 +4327,12 @@ s combined_stdout s combined_stderr → v {
             ( nurl_print `[boot] registered routes: ` ) ( nurl_print ( nurl_str_int ( router_count r ) ) ) ( nurl_print `\n` )
             ( nurl_print `NURL API listening on http://0.0.0.0:8000/ (workers=` )
             ( nurl_print ( nurl_str_int workers ) )
+            ( nurl_print `, compile_slots=` )
+            ( nurl_print ( nurl_str_int compile_slots ) )
             ( nurl_print `, idle=5000ms)\n` )
             : HttpServer srv ( server_new_with_timeout listener logged 5000 )
             : !v NetErr rr ( server_run_pool srv workers )
-            ( signal_clear_shutdown ) ( server_stop srv ) ( router_free r )
+            ( signal_clear_shutdown ) ( server_stop srv ) ( sem_free compile_gate ) ( router_free r )
             ?? rr { T _ → { ^ 0 } F e → { ( nurl_eprint `[srv] runtime error: ` ) ( nurl_eprint ( net_err_name e ) ) ( nurl_eprint `\n` ) ^ 1 } }
         }
         F e → { ( nurl_eprint `[boot] could not bind 0.0.0.0:8000: ` ) ( nurl_eprint ( net_err_name e ) ) ( nurl_eprint `\n` ) ^ 1 }

--- a/stdlib/std/thread.nu
+++ b/stdlib/std/thread.nu
@@ -34,6 +34,12 @@
 //   ( cond_signal    Cond c )              → v
 //   ( cond_broadcast Cond c )              → v
 //   ( cond_free      Cond c )              → v
+//   ( sem_new        i n )                 → Semaphore  n permits
+//   ( sem_acquire    Semaphore s )         → v   block for a permit
+//   ( sem_try_acquire Semaphore s )        → b   non-blocking
+//   ( sem_release    Semaphore s )         → v   return a permit
+//   ( sem_avail      Semaphore s )         → i   free permits (diagnostic)
+//   ( sem_free       Semaphore s )         → v
 //   ( thread_err_name ThreadErr e )        → s
 //
 // Memory model:
@@ -122,6 +128,16 @@ $ `stdlib/core/cell.nu`
 : Thread { s raw }
 : Mutex { Cell c }
 : Cond { Cell c }
+
+// Counting semaphore built on Mutex + Cond. The permit count lives in a
+// heap cell (`* i count`) so copying a Semaphore by value — e.g.
+// capturing it in a worker closure — shares the same count, mutex, and
+// condvar across threads (same handle-sharing as Mutex/Cond).
+: Semaphore {
+    Mutex m
+    Cond c
+    * i count
+}
 
 // ── Thread lifecycle ──────────────────────────────────────────────
 
@@ -225,4 +241,78 @@ $ `stdlib/core/cell.nu`
         ( pthread_cond_destroy ( cell_ptr cell ) )
     }
     ( cell_free cell )
+}
+
+// ── Semaphore ─────────────────────────────────────────────────────
+//
+// Counting semaphore: at most `n` holders may hold a permit at once.
+// `sem_acquire` blocks until a permit is free; `sem_release` returns one
+// and wakes a waiter. The classic tool for bounding concurrency — e.g.
+// capping how many worker threads run a memory-heavy job (a compiler
+// invocation, a large download) simultaneously while leaving the rest of
+// the pool free to serve light requests.
+//
+//   : Semaphore gate ( sem_new 4 )
+//   // on each worker, around the heavy section:
+//   ( sem_acquire gate )  ( do_heavy_work )  ( sem_release gate )
+//   // ... at shutdown:
+//   ( sem_free gate )
+
+@ sem_new i n → Semaphore {
+    : Mutex m ( mutex_new )
+    : Cond c ( cond_new )
+    : *i count # *i ( nurl_alloc 8 )
+    = . count 0 ? > n 0 n 0
+    ^ @ Semaphore { m c count }
+}
+
+// Block until a permit is available, then take one.
+@ sem_acquire Semaphore s → v {
+    : *i cp . s count
+    ( mutex_lock . s m )
+    ~ <= . cp 0 0 {
+        ( cond_wait . s c . s m )
+    }
+    = . cp 0 - . cp 0 1
+    ( mutex_unlock . s m )
+}
+
+// Take a permit if one is free right now; never blocks. Returns T iff a
+// permit was acquired (caller must sem_release on T).
+@ sem_try_acquire Semaphore s → b {
+    : *i cp . s count
+    ( mutex_lock . s m )
+    : ~ b ok F
+    ? > . cp 0 0 {
+        = . cp 0 - . cp 0 1
+        = ok T
+    } {}
+    ( mutex_unlock . s m )
+    ^ ok
+}
+
+// Return a permit and wake one waiter.
+@ sem_release Semaphore s → v {
+    : *i cp . s count
+    ( mutex_lock . s m )
+    = . cp 0 + . cp 0 1
+    ( cond_signal . s c )
+    ( mutex_unlock . s m )
+}
+
+// Current free-permit count. A point-in-time read (no lock held by the
+// caller) — for diagnostics, not for acquire decisions (use
+// sem_try_acquire, which is atomic).
+@ sem_avail Semaphore s → i {
+    : *i cp . s count
+    ( mutex_lock . s m )
+    : i v . cp 0
+    ( mutex_unlock . s m )
+    ^ v
+}
+
+@ sem_free Semaphore s → v {
+    ( mutex_free . s m )
+    ( cond_free . s c )
+    ( nurl_free # s . s count )
 }


### PR DESCRIPTION
## Problem

The playground/MCP container runs `server_run_pool` with **16 worker threads**,
so up to 16 requests run concurrently. A compile request spawns
`clang -O2 -flto`, which can use hundreds of MB. 16 of those at once can blow
the container's memory cap → the whole process is OOM-killed → *"Error proxying
request to container: The container is not listening in the TCP address …"*.
(One fault on any of the 16 threads takes the process down — NURL `recover`
catches explicit `panic`, not `SIGKILL`/`SIGSEGV`.)

## Fix

Keep the accept pool wide so **light** requests (docs, examples, MCP
`tools/list`, SSE) keep flowing, but bound the **heavy compile step** with a
counting semaphore:

- `POST /build*` and `POST /mcp` acquire a permit before dispatch, release after.
- Default **4** concurrent compiles, tunable via `NURL_COMPILE_SLOTS`.
- `GET /mcp` (SSE drain) is deliberately **not** gated.
- The permit is released even if a handler panics — an inner `recover` inside a
  top-level `__gated_handle`, so the server-level recovery can't skip our
  release and leak a permit (which would slowly deadlock the gate).

## New stdlib primitive

A reusable counting **`Semaphore`** in `stdlib/std/thread.nu`:
`sem_new` / `sem_acquire` / `sem_try_acquire` / `sem_release` / `sem_avail` /
`sem_free`, built on the existing `Mutex` + `Cond`. The permit count lives in a
heap cell, so copying a `Semaphore` by value (e.g. capturing it in a worker
closure) shares the count/mutex/condvar across threads — the same handle-sharing
`Mutex`/`Cond` already rely on.

## Tests

`compiler/tests/semaphore_basic.nu`: deterministic counting via `sem_try_acquire`
(initial count, exhaustion, release/reacquire, non-positive clamp), plus a gated
(`NURL_NET_TESTS=1`) 8-thread live test asserting the observed **peak concurrency
never exceeds the permit count**. Default path is ASan-clean; the gated live
path's closure-env leak matches `thread_basic.nu`'s existing behaviour. nurlapi
builds + links; bootstrap fixed point holds; full suite green.

## Deploy / verify

1. First confirm the cause: container logs showing `OOMKilled` ⇒ memory (this fix
   addresses it); a segfault trace ⇒ a separate memory bug.
2. Quick A/B: deploy and watch peak RSS. Tune `NURL_COMPILE_SLOTS` (try 2–4) and
   keep `NURL_WORKERS=16`. Pair with a container restart policy while observing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)