### PR TITLE
docs: state the exact pub-visibility contract + lock it with a test

### DIFF
--- a/compiler/tests/pub_trait_ffi_vis_mod.nu
+++ b/compiler/tests/pub_trait_ffi_vis_mod.nu
@@ -1,0 +1,23 @@
+// Helper for pub_trait_ffi_visibility.nu — the DELIBERATELY UNENFORCED
+// half of the grammar-v2 visibility contract.
+//
+// The file is in strict mode (vtf_anchor is `pub`), and only the anchor
+// fn and the `VtfWidget` struct are exported. The trait `VtfShow`, its
+// `VtfShow (VtfWidget)` impl method, and the `abs` FFI are all UNMARKED
+// — yet they must stay usable from an importer, because trait dispatch
+// is type-mangled (not name-resolved) and FFI symbols are linker-level
+// globals. See spec §3.3.
+
+pub @ vtf_anchor → i { ^ 0 }
+
+pub : VtfWidget { i id }
+
+% VtfShow [T] {
+    @ vtf_show T x → i
+}
+
+% VtfShow ( VtfWidget ) {
+    @ vtf_show VtfWidget w → i { ^ . w id }
+}
+
+& `c` @ abs i x → i

--- a/compiler/tests/pub_trait_ffi_visibility.nu
+++ b/compiler/tests/pub_trait_ffi_visibility.nu
@@ -1,0 +1,26 @@
+// pub_trait_ffi_visibility.nu — positive lock test for the grammar-v2
+// visibility contract's deliberately-unenforced surface (spec §3.3).
+//
+// The helper (pub_trait_ffi_vis_mod.nu) is in strict mode and exports
+// only `vtf_anchor` + `VtfWidget`. Its trait `VtfShow`, the
+// `VtfShow (VtfWidget)` impl method `vtf_show`, and the `abs` FFI are all
+// UNMARKED. Per the documented contract these stay callable across files:
+// trait dispatch is type-mangled and FFI symbols are linker globals, so
+// name-based visibility does not apply to them. This pins that conscious
+// decision so it can't silently regress into enforcement (which would
+// break type-driven dispatch and every cross-file FFI binding).
+//
+// The complementary NEGATIVE cases — a private @-fn / struct / const /
+// enum variant rejected across files — live in the should_fail_pub_*
+// tests. Together they lock the full contract.
+
+$ `compiler/tests/pub_trait_ffi_vis_mod.nu`
+
+@ main → i {
+    : VtfWidget w @ VtfWidget { 42 }
+    // Non-pub trait method, resolved by type across the file boundary.
+    ( nurl_print `trait_show=` ) ( nurl_print ( nurl_str_int ( vtf_show w ) ) ) ( nurl_print `\n` )
+    // Non-pub FFI extern, callable across the file boundary.
+    ( nurl_print `ffi_abs=` ) ( nurl_print ( nurl_str_int ( abs - 0 7 ) ) ) ( nurl_print `\n` )
+    ^ 0
+}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -207,12 +207,26 @@ file:line:col: error: private function 'X' is not visible across files;
                        defined in 'Y'
 ```
 
-**Enforcement scope as of v2.0:** only `@`-function calls observe the
-visibility check. `pub` on struct/enum/const decls is parsed and
-recorded forward-compat but does not yet gate cross-file references.
-`pub` on FFI and trait/impl decls is parsed forward-compat and has no
-runtime effect — FFI symbols are linker-level globals; trait dispatch
-is type-mangled.
+**Enforcement scope.** In strict mode the cross-file visibility check
+covers `@`-functions, structs, enums, top-level consts, and enum
+variants — referencing an unmarked one of these from another file is a
+hard compile error (e.g. `private type 'X' is not visible across files`).
+
+`pub` on **traits, impl methods, and FFI** declarations is accepted
+(forward-compat) but has **no cross-file effect, by design** — this is a
+deliberate, locked decision, not a missing feature:
+
+- trait dispatch is resolved by the *type-mangled method name* produced at
+  monomorphisation, not by the trait's own name, so a trait/impl has no
+  name-based identity to gate; and
+- FFI symbols are linker-level ABI globals with no NURL-source identity —
+  the linker resolves them across the whole program regardless of which
+  file declared them.
+
+The contract is pinned by tests: `pub_trait_ffi_visibility.nu` proves the
+unenforced surface (a non-`pub` trait method + FFI) stays callable across
+files, and the `should_fail_pub_*` tests prove the enforced surface (a
+private fn / struct / const / enum variant) is rejected.
 
 ## 4. Types
 


### PR DESCRIPTION
Resolves the TODO §1 lock-critical item *"finish pub enforcement for
traits/impl/FFI, or consciously lock the current semantics"* — by doing the
latter, which is the correct call, and pinning it with a test.

## The stale spec

`docs/spec.md` §3.3 claimed *"only `@`-function calls observe the visibility
check"* and that `pub` on struct/enum/const *"does not yet gate cross-file
references."* Both are **no longer true** — verified against current code: a
non-`pub` type used across files is rejected (`private type 'X' is not visible
across files`), and `should_fail_pub_{type,const,variant}_neg` already cover it.

## The actual contract (now documented)

- **Enforced** cross-file (strict mode): `@`-functions, structs, enums,
  top-level consts, enum variants.
- **Accepted but not enforced, by design**: traits, impl methods, FFI.
  - Trait dispatch resolves by the *type-mangled method name* at
    monomorphisation, not by the trait's own name — there's no name-based
    identity to gate.
  - FFI symbols are linker-level ABI globals with no NURL-source identity.

This is a deliberate, locked 1.0 decision — name-based visibility simply doesn't
apply to type-driven dispatch or linker globals.

## Test lock

New `pub_trait_ffi_visibility.nu` (+ `_mod` helper): a strict-mode helper exports
only an anchor fn and a struct, but its **non-`pub` trait method** and
**non-`pub` FFI** stay callable from the importer. Pins the unenforced surface so
it can't silently regress into enforcement (which would break type-driven
dispatch and every cross-file FFI binding). Together with the existing
`should_fail_pub_*` negatives, the full contract is test-locked.

Docs + tests only; bootstrap fixed point holds, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)