### PR TITLE
fix(compiler): inout/sink parameter conventions on trait impl methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`inout` / `sink` parameter conventions now work on trait impl
+  methods** (grammar-v2 borrow checker). An `inout` (or `sink`) parameter
+  on an impl method silently miscompiled: the convention was recorded
+  under the mangled method name (`bump__Counter`) while the call site
+  dispatches by the bare name (`( bump c )`), so the receiver was passed
+  **by value** into a `%T*` parameter — memory corruption / segfault.
+  Fixing that surfaced a second bug (applying `inout` pointerised the
+  first argument to `%T*`, which missed the `method##%T` impl-dispatch key
+  and emitted an undefined bare `@method`). Both are fixed: the bare-name
+  convention is mirrored at emission, and the impl-dispatch lookup retries
+  with the receiver pointer stripped. Regression
+  `compiler/tests/impl_inout_sink.nu` (struct `inout`, `inout` + by-value,
+  a second implementing type, and a `sink` impl method; ASan + leak
+  clean).
+
 ### Documentation
 
 - **The `pub` visibility contract is now stated exactly and locked by

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -4176,8 +4176,22 @@
     // gen_let / gen_ret does not mis-read `( f \ → v {…} )` as one.
     ( nurl_sym_def syms `__last_expr_refdepth__` `` )
     // Group F: impl method dispatch based on first arg's LLVM type
-    : s impl_key ( nurl_str_cat fname ( nurl_str_cat `##` first_arg_type ) )
-    : s impl_mangle_key ( nurl_sym_get g_impl_name_syms impl_key )
+    : ~ s impl_key ( nurl_str_cat fname ( nurl_str_cat `##` first_arg_type ) )
+    : ~ s impl_mangle_key ( nurl_sym_get g_impl_name_syms impl_key )
+    // `inout` receiver: the first argument is passed as `%T*`, but impls
+    // are registered by the value type `%T` (g_impl_name_syms key
+    // `method##%T`). On a miss with a pointer-typed first arg, retry with
+    // the trailing `*` stripped so an `inout`/`sink` impl method still
+    // dispatches. (Without this, applying `inout` pointerised the arg and
+    // the dispatch fell through to an undefined bare `@method`.)
+    ? & == 0 ( nurl_str_len impl_mangle_key )
+    & > ( nurl_str_len first_arg_type ) 1
+    == ( nurl_str_get first_arg_type - ( nurl_str_len first_arg_type ) 1 ) 42
+    { : s __fa_base ( nurl_str_slice first_arg_type 0 - ( nurl_str_len first_arg_type ) 1 )
+        = impl_key ( nurl_str_cat fname ( nurl_str_cat `##` __fa_base ) )
+        = impl_mangle_key ( nurl_sym_get g_impl_name_syms impl_key )
+    }
+    {}
     ? != 0 ( nurl_str_len impl_mangle_key )
     { : s impl_ret ( nurl_sym_get g_impl_ret_syms impl_key )
         : s impl_name ( nurl_str_cat fname ( nurl_str_cat `__` impl_mangle_key ) )
@@ -13156,6 +13170,24 @@
                     : s mangled ( nurl_str_cat mname ( nurl_str_cat `__` impl_mangle ) )
                     // gen_fn_decl_concrete reads params, →, ret, body from lex
                     ( gen_fn_decl_concrete mangled lex syms cg )
+                    // gen_fn_decl_concrete recorded the inout/sink parameter
+                    // sets under the MANGLED name (`bump__Counter`), but a
+                    // call site dispatches by the BARE method name
+                    // (`( bump c )` → call_name `bump`) and looks the sets up
+                    // there. Mirror them onto the bare name so an `inout` /
+                    // `sink` impl-method argument is passed by address /
+                    // moved — without this the receiver was passed BY VALUE
+                    // into a `T*` parameter, corrupting memory (segfault).
+                    // All impls of a trait method share the trait's parameter
+                    // conventions, so the bare-name entry is consistent across
+                    // implementing types. Only mirror non-empty sets so an
+                    // impl with no inout/sink can't clobber another's entry.
+                    : s __impl_io ( nurl_sym_get g_fn_inout mangled )
+                    : s __impl_sk ( nurl_sym_get g_fn_sink mangled )
+                    ? != 0 ( nurl_str_len __impl_io )
+                    { ( nurl_sym_def g_fn_inout mname __impl_io ) } {}
+                    ? != 0 ( nurl_str_len __impl_sk )
+                    { ( nurl_sym_def g_fn_sink mname __impl_sk ) } {}
                 }
                 { ( die lex `expected method name in impl` ) }
             }

--- a/compiler/tests/impl_inout_sink.nu
+++ b/compiler/tests/impl_inout_sink.nu
@@ -1,0 +1,91 @@
+// impl_inout_sink.nu — regression for `inout` / `sink` parameter
+// conventions on TRAIT IMPL METHODS (grammar v2 borrow-checker, §1).
+//
+// Bug (pre-fix): an `inout`/`sink` parameter on an impl method silently
+// miscompiled. gen_fn_decl_concrete recorded the convention under the
+// MANGLED method name (`bump__Counter`) but the call site dispatches by
+// the BARE name (`( bump c )` → `bump`) and looked the convention up
+// there — finding nothing, it passed the receiver BY VALUE into a `%T*`
+// parameter → memory corruption / segfault. Fixing that surfaced a
+// second bug: applying `inout` pointerises the first arg to `%T*`, which
+// missed the impl-dispatch key (`bump##%Counter`), emitting an undefined
+// bare `@bump`. Both are fixed: the bare-name convention is mirrored at
+// emission, and the impl-dispatch key retries with the receiver pointer
+// stripped.
+//
+// main returns the number of failed checks (0 = all pass).
+
+$ `stdlib/core/vec.nu`
+
+: Counter { i n }
+: Tally { i hits }
+: Holder { ( Vec i ) v }
+
+% Bumpable [T] {
+    @ bump inout T x → v
+    @ bump_by inout T x i d → v
+}
+
+% Bumpable ( Counter ) {
+    @ bump inout Counter c → v { = . c n + . c n 1 }
+    @ bump_by inout Counter c i d → v { = . c n + . c n d }
+}
+
+// A second implementing type for the same trait method names — proves
+// the type-mangled dispatch still distinguishes them once inout is on.
+% Bumpable ( Tally ) {
+    @ bump inout Tally t → v { = . t hits + . t hits 10 }
+    @ bump_by inout Tally t i d → v { = . t hits + . t hits d }
+}
+
+% Consumable [T] {
+    @ consume sink T x → i
+}
+
+% Consumable ( Holder ) {
+    @ consume sink Holder h → i {
+        : i n ( vec_len [i] . h v )
+        ( vec_free [i] . h v )
+        ^ n
+    }
+}
+
+@ chk i got i want s tag → i {
+    ? == got want {
+        ( nurl_print tag ) ( nurl_print ` ok\n` ) ^ 0
+    } {
+        ( nurl_print tag ) ( nurl_print ` FAIL\n` ) ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i f 0
+
+    // Struct inout (the former segfault): the impl mutates the caller's
+    // binding in place through the address.
+    : ~ Counter c @ Counter { 10 }
+    ( bump c )
+    ( bump c )
+    = f + f ( chk . c n 12 `struct_inout` )
+
+    // inout beside an ordinary by-value parameter.
+    ( bump_by c 5 )
+    = f + f ( chk . c n 17 `inout_plus_byval` )
+
+    // Same method names on a second type → distinct type-mangled impls.
+    : ~ Tally t @ Tally { 0 }
+    ( bump t )
+    ( bump_by t 3 )
+    = f + f ( chk . t hits 13 `second_impl_distinct` )
+
+    // sink impl method: the receiver is moved into the method, which
+    // frees its Vec exactly once — no double free with the binding's
+    // own auto-drop.
+    : ( Vec i ) v ( vec_new [i] )
+    ( vec_push [i] v 7 )
+    ( vec_push [i] v 8 )
+    : Holder h @ Holder { v }
+    = f + f ( chk ( consume h ) 2 `sink_impl` )
+
+    ^ f
+}


### PR DESCRIPTION
Resolves the bulk of the TODO §1 lock-critical *"borrow-checker Phase 4: inout/sink
on impl methods"* item — a silent miscompile (the worst class) found while
probing the lock-critical surface.

## The bug

An `inout` / `sink` parameter on a **trait impl method** segfaulted:

```nurl
% Bumpable [T] { @ bump inout T x → v }
% Bumpable ( Counter ) { @ bump inout Counter c → v { = . c n + . c n 1 } }
( bump c )   // before: receiver passed BY VALUE into %Counter* → SIGSEGV
```

`gen_trait_or_impl` emits each method via `gen_fn_decl_concrete` under the
**mangled** name (`bump__Counter`), so the inout/sink index sets landed there —
but a call site dispatches by the **bare** name (`( bump c )` → `bump`) and looks
them up under that name. Finding nothing, `gen_call` passed the receiver by value
into the impl's `%T*` parameter; its first word was read as a pointer → crash.

Mirroring the convention onto the bare name surfaced a second bug: applying
`inout` pointerises the first arg to `%T*`, which no longer matched the
impl-dispatch key `method##%T` (keyed by value type) → fell through to an
undefined bare `@method`.

## The fix

- `gen_trait_or_impl` mirrors the non-empty inout/sink sets from the mangled name
  onto the bare method name (all impls of a trait method share the trait's
  conventions, so the entry is consistent across implementing types).
- the impl-dispatch lookup retries `method##<type>` with a trailing `*` stripped
  from the first arg's LLVM type, so an inout/sink receiver (passed as `%T*`)
  still resolves to the value-type-keyed impl.

**Surgical** — only affects impl-method calls whose receiver is `inout`/`sink`;
no existing test's output changed.

## Tests

`compiler/tests/impl_inout_sink.nu` — struct `inout` (the former segfault),
`inout` beside a by-value param, a second implementing type for the same method
names (mangle distinctness), and a `sink` impl method (Vec freed once, no double
free). **ASan + leak clean.** Bootstrap fixed point holds; full suite green.

Remaining in §1: `sink` of a *compiler-auto-dropped* argument (still the
documented "not yet supported" error in `should_fail_sink_autodrop.nu`), and the
`runtime.c` split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)