### PR TITLE
fix(http2): client SETTINGS map + read/write interleave + per-stream WINDOW_UPDATE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **HTTP/2 client: request bodies larger than 256 bytes now work, and a
+  large body no longer deadlocks the driver.** Three related fixes:
+  - **SETTINGS parameter-ID mismap (critical).** The client's SETTINGS
+    parser handled id `3` (`MAX_CONCURRENT_STREAMS`) as
+    `INITIAL_WINDOW_SIZE` and ignored id `4` (the real
+    `INITIAL_WINDOW_SIZE`), so every stream's send window was seeded with
+    the peer's max-concurrent-streams value (typically 256) instead of its
+    advertised window (65535). Any POST/PUT body over ~256 bytes stalled
+    forever waiting for a WINDOW_UPDATE that never needed to come. IDs are
+    now mapped correctly.
+  - **Driver read/write interleave.** Each pump step now drains every
+    inbound frame already available (readiness-probed via
+    `nurl_reactor_wait_read`) *before* flushing pending DATA, keeping the
+    peer's send buffer to us empty so it never blocks writing and keeps
+    reading our DATA — removing the documented single-socket deadlock on a
+    large request body.
+  - **Server per-stream WINDOW_UPDATE** (`stdlib/ext/http2_conn.nu`). The
+    h2 server replenished only the connection window, so it could not
+    receive a request body larger than the 64 KB initial *stream* window;
+    it now also replenishes each stream's window as it consumes DATA.
+
+  Regression: `compiler/tests/http2_client.nu` gains a live 200 KB POST
+  (spanning many DATA frames and several flow-control windows) over the
+  in-repo h2 server, gated on `NURL_NET_TESTS=1`.
+
 - **`inout` / `sink` parameter conventions now work on trait impl
   methods** (grammar-v2 borrow checker). An `inout` (or `sink`) parameter
   on an impl method silently miscompiled: the convention was recorded

--- a/compiler/tests/http2_client.nu
+++ b/compiler/tests/http2_client.nu
@@ -183,6 +183,43 @@ $ `stdlib/ext/http2_client.nu`
     }
 }
 
+// Large-body POST: ~200 KB spans many DATA frames and far exceeds the
+// default 64 KB flow-control window, so the client must send a burst,
+// block on the window, read the server's WINDOW_UPDATE, and resume —
+// the exact read/write interleave the single-socket driver depends on.
+// Reuses the already-connected client + server connection.
+@ check_big_post H2Client client → i {
+    : ~ i fails 0
+    : ( Vec Header ) h ( vec_new [Header] )
+    : ( Vec u ) body ( vec_new [u] )
+    : ~ i bi 0
+    ~ < bi 200000 {
+        ( vec_push [u] body # u 65 )
+        = bi + bi 1
+    }
+    // submit takes ownership of `body` (mirrors the empty-body calls below).
+    : !i H2ClientErr sr ( h2_client_submit client `POST` `http`
+    `127.0.0.1` `/big` h body )
+    ( vec_free_with [Header] h \ Header hh → v { ( header_free hh ) } )
+    ?? sr {
+        T sid → {
+            : !v H2ClientErr rr ( h2_client_run_until_complete client )
+            ?? rr {
+                T _ → { = fails + fails ( check_resp client sid `/big` ) }
+                F e → {
+                    ( nurl_print `  big_run_err=` ) ( nurl_print ( h2_client_err_name e ) ) ( nurl_print `\n` )
+                    = fails + fails 1
+                }
+            }
+        }
+        F e → {
+            ( nurl_print `  big_submit_err=` ) ( nurl_print ( h2_client_err_name e ) ) ( nurl_print `\n` )
+            = fails + fails 1
+        }
+    }
+    ^ fails
+}
+
 @ run_live_test → i {
     : ~ i fails 0
     : !TcpListener NetErr lr ( tcp_listen `127.0.0.1` 18811 )
@@ -225,6 +262,8 @@ $ `stdlib/ext/http2_client.nu`
                                         T _ → {
                                             = fails + fails ( check_resp client sid1 `/alpha` )
                                             = fails + fails ( check_resp client sid2 `/beta` )
+                                            // Large-body POST over the same connection.
+                                            = fails + fails ( check_big_post client )
                                         }
                                         F e → {
                                             ( nurl_print `  run_err=` )

--- a/stdlib/ext/http2_client.nu
+++ b/stdlib/ext/http2_client.nu
@@ -46,10 +46,17 @@
 //   * Single-owner: one driver, one socket reader. Not safe to use a
 //     single H2Client from multiple fibers concurrently (mirrors the
 //     server's per-connection model).
-//   * The driver interleaves reads and writes single-threaded; a very
-//     large request body could in theory deadlock if the peer withholds
-//     WINDOW_UPDATE until we read while we block writing — acceptable
-//     for v1 (TCP buffering covers ordinary sizes).
+//   * The driver interleaves reads and writes single-threaded: each pump
+//     step DRAINS every inbound frame already available (readiness-probed
+//     with `nurl_reactor_wait_read`, so a frame read only ever blocks for
+//     the rest of a frame the peer is actively sending) BEFORE flushing
+//     pending DATA. Draining first keeps the peer's send buffer to us
+//     empty, so the peer never blocks writing and keeps reading our DATA —
+//     which is what lets our (blocking) DATA writes drain instead of
+//     deadlocking on a large request body. A peer that advertises a large
+//     window and then stalls reading entirely is bounded by the 30 s
+//     socket timeout rather than hanging forever. Single-owner: not safe
+//     to share one client across fibers concurrently.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -184,6 +191,14 @@ $ `stdlib/ext/http2_hpack.nu`
 
 @ __h2c_set_conn_window H2Client c i v → v { ( nurl_poke . c st 1 v ) }
 
+// Underlying socket fd, for readiness polling (nurl_reactor_wait_*).
+@ __h2c_fd H2Client c → i { ^ ( nurl_tcp_get_fd # i . . c tcp raw ) }
+
+// Non-blocking readiness probes. `nurl_reactor_wait_{read,write}` return
+// >= 0 when the fd is ready and < 0 on timeout; a 0 ms timeout makes them
+// pure polls. (Runtime builtins, also used by std/net.nu's async path.)
+@ __h2c_readable i fd → b { ^ >= ( nurl_reactor_wait_read fd 0 ) 0 }
+
 @ __h2c_goaway H2Client c → i { ^ ( nurl_peek . c st 7 ) }
 
 // ── Small byte / string helpers ───────────────────────────────────────
@@ -288,9 +303,13 @@ $ `stdlib/ext/http2_hpack.nu`
         : i v2 & 255 # i . p + k 4
         : i v3 & 255 # i . p + k 5
         : i value + + + << v0 24 << v1 16 << v2 8 v3
+        // SETTINGS parameter IDs (RFC 9113 §6.5.2):
+        //   1 HEADER_TABLE_SIZE   2 ENABLE_PUSH   3 MAX_CONCURRENT_STREAMS
+        //   4 INITIAL_WINDOW_SIZE 5 MAX_FRAME_SIZE 6 MAX_HEADER_LIST_SIZE
         ?? id {
-            1 → { ( nurl_poke . c st 5 value ) }
-            3 → {
+            1 → { ( nurl_poke . c st 5 value ) }  // HEADER_TABLE_SIZE
+            3 → { ( nurl_poke . c st 6 value ) }  // MAX_CONCURRENT_STREAMS
+            4 → {  // INITIAL_WINDOW_SIZE — the per-stream send-window seed.
                 ? > value ( h2_max_window_size ) {
                     = err # H2ClientErr H2CFlowControl
                     = status 1
@@ -310,7 +329,7 @@ $ `stdlib/ext/http2_hpack.nu`
                     }
                 }
             }
-            5 → {
+            5 → {  // MAX_FRAME_SIZE
                 ? | < value 16384 > value ( h2_max_frame_size_upper_bound ) {
                     = err # H2ClientErr H2CProtocol
                     = status 1
@@ -318,8 +337,7 @@ $ `stdlib/ext/http2_hpack.nu`
                     ( nurl_poke . c st 4 value )
                 }
             }
-            6 → { ( nurl_poke . c st 6 value ) }
-            _ → {}  // ENABLE_PUSH / MAX_HEADER_LIST_SIZE / unknown — ignore
+            _ → {}  // ENABLE_PUSH(2) / MAX_HEADER_LIST_SIZE(6) / unknown — ignore
         }
         = k + k 6
     }
@@ -890,19 +908,62 @@ $ `stdlib/ext/http2_hpack.nu`
     ^ @ !v H2ClientErr { T 0 }
 }
 
-// Flush sendable DATA, then read + dispatch exactly one inbound frame.
+// One driver step. Interleaves reads and writes so a large request body
+// can't deadlock the single socket: we DRAIN every inbound frame already
+// available (readiness-probed, so a frame read only blocks for the rest
+// of a frame the peer is actively sending) BEFORE flushing pending DATA.
+// Draining first keeps the peer's send buffer to us empty, so it never
+// blocks writing and keeps reading our DATA — which lets our writes drain.
+// Only when nothing was readable do we block, on the read that can
+// actually unblock us (a WINDOW_UPDATE or the response).
 @ h2_client_pump_once H2Client c → !v H2ClientErr {
+    : i fd ( __h2c_fd c )
+    : ~ b did F
+    : ~ i status 0
+    : ~ H2ClientErr err H2COther
+
+    // 1. Drain every frame already available. We only enter h2_read_frame
+    //    when the socket reports readable, so a blocking frame read only
+    //    waits for the remainder of a frame the peer is actively sending.
+    ~ & == status 0 ( __h2c_readable fd ) {
+        : !H2Frame H2FrameErr rf ( h2_read_frame . c tcp 16384 )
+        ?? rf {
+            T frame → {
+                : !v H2ClientErr dr ( __h2c_dispatch c frame )
+                ( h2_frame_free frame )
+                ?? dr { T _ → { = did T } F e → { = err e = status 1 } }
+            }
+            F e → { = err ( __h2c_frame_err_to_client e ) = status 1 }
+        }
+    }
+    ? == status 1 { ^ @ !v H2ClientErr { F err } } {}
+
+    // 2. Flush as much sendable DATA as the flow-control windows permit
+    //    (stops at window==0 / body done). Because step 1 already drained
+    //    inbound frames, any WINDOW_UPDATE the peer sent has reopened the
+    //    window here, and the peer's send buffer to us is empty — so it is
+    //    not blocked writing and keeps reading our DATA, which is what lets
+    //    these (blocking) writes complete instead of deadlocking.
     : !v H2ClientErr fr ( __h2c_flush_pending c )
     ?? fr { T _ → {} F e → { ^ @ !v H2ClientErr { F e } } }
-    : !H2Frame H2FrameErr rf ( h2_read_frame . c tcp 16384 )
-    ?? rf {
-        T frame → {
-            : !v H2ClientErr dr ( __h2c_dispatch c frame )
-            ( h2_frame_free frame )
-            ^ dr
+
+    // 3. If nothing was readable in step 1, block for the peer's next
+    //    frame — progress now depends on it (a WINDOW_UPDATE to reopen the
+    //    window, or the response). The 30 s socket timeout bounds a peer
+    //    that goes fully silent.
+    ? ! did {
+        : !H2Frame H2FrameErr rf2 ( h2_read_frame . c tcp 16384 )
+        ?? rf2 {
+            T frame → {
+                : !v H2ClientErr dr ( __h2c_dispatch c frame )
+                ( h2_frame_free frame )
+                ?? dr { T _ → {} F e → { = err e = status 1 } }
+            }
+            F e → { = err ( __h2c_frame_err_to_client e ) = status 1 }
         }
-        F e → { ^ @ !v H2ClientErr { F ( __h2c_frame_err_to_client e ) } }
-    }
+    } {}
+    ? == status 1 { ^ @ !v H2ClientErr { F err } } {}
+    ^ @ !v H2ClientErr { T 0 }
 }
 
 // Pump until every submitted stream has completed (or a fatal error).

--- a/stdlib/ext/http2_conn.nu
+++ b/stdlib/ext/http2_conn.nu
@@ -1358,6 +1358,24 @@ $ `stdlib/ext/http2_hpack.nu`
                                         = . s end_stream_received T
                                         = . s state ( h2_state_half_closed_remote )
                                     } {}
+                                    // Replenish the PER-STREAM window too (the
+                                    // connection-level grant below covers stream
+                                    // 0 only). Without this the peer's stream
+                                    // send_window hits 0 after the initial 64 KB
+                                    // and never reopens, so a request body larger
+                                    // than the stream window can never be fully
+                                    // received. Skip once END_STREAM is in — no
+                                    // more DATA will arrive on this stream.
+                                    ? & ! . s end_stream_received
+                                    < . s recv_window / ( h2_default_initial_window_size ) 2
+                                    {
+                                        : i sgrant - ( h2_default_initial_window_size )
+                                        . s recv_window
+                                        : !v H2FrameErr swu
+                                        ( h2_send_window_update . cur tcp sid sgrant )
+                                        ?? swu { T _ → {} F _ → {} }
+                                        = . s recv_window ( h2_default_initial_window_size )
+                                    } {}
                                     ( __h2_set_stream cur idx s )
                                     // Replenish flow-control credit when
                                     // window drops below half. Keeps the


### PR DESCRIPTION
Started as the §3 *"HTTP/2 client flow-control deadlock"* item; adding a
large-body regression test surfaced a **more serious latent bug**, so this lands
three related fixes.

## 1. SETTINGS parameter-ID mismap (critical, client)

`__h2c_apply_settings` handled SETTINGS id `3` (`MAX_CONCURRENT_STREAMS`) as
`INITIAL_WINDOW_SIZE` and **ignored** id `4` (the real `INITIAL_WINDOW_SIZE`). So
every stream's send window was seeded with the peer's max-concurrent-streams
value — typically **256** — instead of its advertised **65535**. Any POST/PUT
body over ~256 bytes stalled forever, waiting on a WINDOW_UPDATE the peer had no
reason to send. IDs are now mapped per RFC 9113 §6.5.2.

*(This is why the deadlock was "documented but rarely hit" — small/no-body
requests fit in 256 bytes and worked; anything bigger silently hung.)*

## 2. Driver read/write interleave (client)

`h2_client_pump_once` now **drains every inbound frame already available**
(readiness-probed via `nurl_reactor_wait_read`, so a frame read only blocks for
the rest of a frame the peer is actively sending) **before** flushing pending
DATA. Draining first keeps the peer's send buffer to us empty, so it never blocks
writing and keeps reading our DATA — removing the documented single-socket
deadlock on a large request body.

## 3. Server per-stream WINDOW_UPDATE (`http2_conn.nu`)

The h2 server replenished only the **connection** window, so it could not receive
a request body larger than the 64 KB initial **stream** window (the peer's stream
send window hit 0 and never reopened). It now replenishes each stream's window as
it consumes DATA, mirroring the connection-level grant.

## Tests

`compiler/tests/http2_client.nu` gains a live **200 KB POST** — many DATA frames
across several flow-control windows, over the in-repo h2 server, gated on
`NURL_NET_TESTS=1`. Verified end-to-end: 3 streams (2 GET + the big POST) all
200 OK; no new leaks under ASan (only the test's pre-existing thread-closure env
leak). Bootstrap fixed point holds; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)