### PR TITLE
fix(http): HTTP/1.1 server security bughunt — four root-cause fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **HTTP/1.1 server hardening — four root-cause bug fixes from a focused
+  security bughunt** (`stdlib/ext/http_request.nu`, `http_server.nu`,
+  `http_response.nu`):
+  - **Chunked request bodies were silently dropped on keep-alive
+    connections.** `__finish_body` only handled `Content-Length`, so a
+    `Transfer-Encoding: chunked` body was left undrained in the connection
+    carry buffer — the handler saw an *empty* body and the leftover bytes
+    were mis-parsed as the next request (a desync / request-smuggling
+    vector). `__finish_body` now decodes chunked bodies carry-aware
+    (draining from the buffer + socket, leaving any pipelined successor).
+  - **Chunk-size integer overflow → smuggling/DoS.** `__parse_hex_size`
+    accumulated an unbounded hex value; `0x10000000000000000` wrapped i64
+    to `0` (read as the terminating chunk, ending the body early) or to a
+    small positive (wrong boundary) — both smuggling vectors, and a huge
+    positive could drive an enormous allocation. Now rejects any value
+    past a sane ceiling, well clear of i64 overflow.
+  - **Content-Length + Transfer-Encoding smuggling.** A request carrying
+    both framing headers (RFC 7230 §3.3.3) is now rejected at head parse
+    (and in `read_body_to`) instead of silently letting `Transfer-Encoding`
+    win — the classic CL.TE desync.
+  - **HTTP response splitting (CWE-113).** Response header names/values
+    were serialised verbatim, so a value reflected from untrusted input
+    (a redirect `Location`, an echoed header) could inject
+    `\r\n<header>` and split the response. The serialiser (and the chunked
+    `response_begin_chunked` path) now strips CR/LF from every emitted
+    header name and value.
+
+  Regressions: `compiler/tests/http_request_parser.nu` (CL+TE rejection,
+  chunk-size overflow rejection), `http_response_builder.nu` (header
+  CR/LF stripping), and a new live `http_server_chunked.nu` (chunked body
+  decoded + keep-alive survives a chunked request, gated on
+  `NURL_NET_TESTS=1`).
+
 - **HTTP/2 client: request bodies larger than 256 bytes now work, and a
   large body no longer deadlocks the driver.** Three related fixes:
   - **SETTINGS parameter-ID mismap (critical).** The client's SETTINGS

--- a/compiler/tests/http_request_parser.nu
+++ b/compiler/tests/http_request_parser.nu
@@ -174,7 +174,34 @@ $ `stdlib/ext/http.nu`
     ( run_case `malformed_request_line`
     `BADREQUEST\r\n\r\n` )
 
+    // Request smuggling: BOTH Content-Length and Transfer-Encoding present
+    // (RFC 7230 §3.3.3) → rejected at head parse → HttpReqMalformed.
+    ( run_case `cl_te_smuggling`
+    `POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n` )
+
+    ( run_hex )
     ( run_oversized )
     ( run_query_decode )
     ^ 0
+}
+
+// __parse_hex_size must reject overflowing chunk-size lines (a 17-digit
+// hex wraps i64 to a small value → request smuggling) and accept valid
+// sizes. Pins the overflow guard.
+@ run_hex → v {
+    ( nurl_print `── chunk_hex_size ──\n` )
+    ( show_hex `1a` )  // valid → 26
+    ( show_hex `0` )  // valid → 0 (terminating chunk)
+    ( show_hex `200` )  // valid → 512
+    ( show_hex `10000000000000000` )  // 2^64 → would wrap to 0 → reject
+    ( show_hex `ffffffffffffffff` )  // 2^64-1 → would wrap to -1 → reject
+}
+
+@ show_hex s raw → v {
+    : String s ( string_from raw )
+    ?? ( __parse_hex_size s ) {
+        T n → ( println_int ( nurl_str_cat `  ` ( nurl_str_cat raw ` -> ` ) ) n )
+        F _ → ( println_str `  ` ( nurl_str_cat raw ` -> reject` ) )
+    }
+    ( string_free s )
 }

--- a/compiler/tests/http_response_builder.nu
+++ b/compiler/tests/http_response_builder.nu
@@ -126,6 +126,15 @@ $ `stdlib/core/vec.nu`
     ( response_add_header r4 `Set-Cookie` `b=2; Path=/admin` )
     ( run_case `add_header_repeats` r4 )
 
+    // ── Response-splitting defence (CWE-113): a header value carrying an
+    //    embedded CRLF + injected header must be emitted CR/LF-stripped,
+    //    i.e. on a single line — NOT split into an extra header. The
+    //    snapshot shows `X-Evil: aInjected: 1` on one line (no `\r\n`
+    //    inside the value), proving the injection was neutralised. ──
+    : HttpResponse r5 ( response_text 200 `x` )
+    ( response_set_header r5 `X-Evil` `a\r\nInjected: 1` )
+    ( run_case `header_crlf_strip` r5 )
+
     // ── chunk-size hex formatter sanity (exercises __append_hex_size
     //    via response_write_chunk's frame builder, but we can probe it
     //    by using a fresh response_begin_chunked output? No — needs a

--- a/compiler/tests/http_server_chunked.nu
+++ b/compiler/tests/http_server_chunked.nu
@@ -1,0 +1,141 @@
+// http_server_chunked.nu — live regression for chunked request bodies on
+// a keep-alive connection (stdlib/ext/http_server.nu). Gated behind
+// NURL_NET_TESTS=1 (opens a loopback socket + spawns a server thread).
+//
+// Before the fix, __finish_body only handled Content-Length: a
+// Transfer-Encoding: chunked body was left undrained in the connection
+// carry buffer — the handler saw an EMPTY body, and the leftover bytes
+// were mis-parsed as the next request (a desync / smuggling vector).
+//
+// This drives ONE keep-alive connection with two pipelined-style
+// requests: a chunked POST (body "hello world", 11 bytes) followed by a
+// plain GET. The handler echoes `len=<bodylen> path=<path>`. We assert:
+//   * the POST handler saw 11 body bytes (chunked decoded, not dropped);
+//   * the GET response is present and correct (no keep-alive desync).
+//
+// main returns the failure count.
+
+$ `stdlib/std/net.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/http.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_server.nu`
+
+// Raw client connect (no high-level tcp_connect exists; mirror the
+// http2_client / websocket client shape).
+& `libc` @ nurl_tcp_connect s host i port → i
+
+@ echo_handler HttpRequest req → HttpResponse {
+    : String b ( string_from `len=` )
+    ( string_push_str b ( nurl_str_int ( vec_len [u] . req body ) ) )
+    ( string_push_str b ` path=` )
+    ( string_push_str b ( string_data . req path ) )
+    : HttpResponse r ( response_text 200 ( string_data b ) )
+    ( string_free b )
+    ^ r
+}
+
+// Read from the client socket until `buf` contains `needle` or we hit a
+// few empty/again reads. Best-effort — enough to collect two small
+// pipelined responses on loopback.
+@ drain_until TcpConn conn String buf s needle → v {
+    ( tcp_set_timeout conn 2000 )
+    : ~ i tries 0
+    : ~ b done F
+    ~ & ! done < tries 40 {
+        ? ( __buf_has buf needle ) { = done T } {
+            : !( Vec u ) NetErr r ( tcp_read_chunk conn 4096 )
+            ?? r {
+                T chunk → {
+                    : i got ( vec_len [u] chunk )
+                    ? > got 0 { ( bytes_extend_str_from buf chunk ) } { = tries + tries 1 }
+                    ( vec_free [u] chunk )
+                }
+                F _ → { = tries + tries 1 }
+            }
+        }
+    }
+}
+
+@ __buf_has String buf s needle → b {
+    ^ ( string_contains buf needle )
+}
+
+@ bytes_extend_str_from String buf ( Vec u ) chunk → v {
+    : i n ( vec_len [u] chunk )
+    : *u p ( vec_data [u] chunk )
+    : ~ i k 0
+    ~ < k n {
+        ( string_push_char buf & 255 # i . p k )
+        = k + k 1
+    }
+}
+
+@ run_live → i {
+    : ~ i fails 0
+    : !TcpListener NetErr lr ( tcp_listen `127.0.0.1` 18823 )
+    ?? lr {
+        T listener → {
+            : HttpServer srv ( server_new listener \ HttpRequest req → HttpResponse { ^ ( echo_handler req ) } )
+            : ( @ v ) server_fn \ → v {
+                : !v NetErr r ( server_run_once srv )
+                ?? r { T _ → {} F _ → {} }
+            }
+            : !Thread ThreadErr st ( thread_spawn server_fn )
+            ( sleep_ms 100 )
+
+            : i craw ( nurl_tcp_connect `127.0.0.1` 18823 )
+            : i cek ( nurl_tcp_err_kind craw )
+            ? != cek 0 {
+                ( nurl_print `  FAIL connect\n` ) = fails + fails 1
+            } {
+                : TcpConn conn @ TcpConn { # s craw }
+                {
+                    // Chunked POST: "hello" + " world" = 11 bytes, then a GET.
+                    : ( Vec u ) wbuf ( vec_new [u] )
+                    ( bytes_extend_str wbuf `POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n` )
+                    ( bytes_extend_str wbuf `GET /ping HTTP/1.1\r\nHost: x\r\n\r\n` )
+                    : !v NetErr ww ( tcp_write_all conn wbuf )
+                    ( vec_free [u] wbuf )
+                    ?? ww { T _ → {} F _ → { = fails + fails 1 } }
+
+                    : String resp ( string_new )
+                    ( drain_until conn resp `path=/ping` )
+
+                    // POST body must have decoded to 11 bytes (not dropped).
+                    ? ( __buf_has resp `len=11 path=/echo` ) {} {
+                        ( nurl_print `  FAIL chunked body not decoded\n` ) = fails + fails 1
+                    }
+                    // GET after the chunked POST must parse cleanly (no desync).
+                    ? ( __buf_has resp `len=0 path=/ping` ) {} {
+                        ( nurl_print `  FAIL keep-alive desync after chunked\n` ) = fails + fails 1
+                    }
+                    ( string_free resp )
+                    ( tcp_close_conn conn )
+                }
+            }
+            : i _sj ?? st { T th → ( thread_join th ) F _ → 0 }
+            ( tcp_close_listener listener )
+        }
+        F _ → { ( nurl_print `  FAIL listen\n` ) = fails + fails 1 }
+    }
+    ^ fails
+}
+
+@ main → i {
+    : ?String gate ( env_get `NURL_NET_TESTS` )
+    ?? gate {
+        T s → {
+            ( string_free s )
+            : i f ( run_live )
+            ? == f 0 { ( nurl_print `chunked keep-alive ok\n` ) } {}
+            ^ f
+        }
+        F → { ( nurl_print `http_server_chunked skipped (NURL_NET_TESTS != 1)\n` ) ^ 0 }
+    }
+}

--- a/stdlib/ext/http_request.nu
+++ b/stdlib/ext/http_request.nu
@@ -703,6 +703,21 @@ $ `stdlib/ext/http.nu`
         ^ @ !ParsedHeadOk HttpReqErr { F # HttpReqErr HttpReqMalformed }
     } {}
 
+    // Request-smuggling defence (RFC 7230 §3.3.3): a message carrying BOTH
+    // Transfer-Encoding and Content-Length is ambiguous — a front-end and
+    // back-end may disagree on the body framing. Reject it outright rather
+    // than silently letting Transfer-Encoding win (the classic CL.TE
+    // desync). Checked here, at head parse, so every caller is covered.
+    : ?String __te ( header_get . hr headers `Transfer-Encoding` )
+    : ?String __cl ( header_get . hr headers `Content-Length` )
+    : b __has_te ?? __te { T x → { ( string_free x ) T } F _ → F }
+    : b __has_cl ?? __cl { T x → { ( string_free x ) T } F _ → F }
+    ? & __has_te __has_cl {
+        ( __req_line_parts_free rl )
+        ( headers_free . hr headers )
+        ^ @ !ParsedHeadOk HttpReqErr { F # HttpReqErr HttpReqMalformed }
+    } {}
+
     : HttpRequest req @ HttpRequest {
         . rl method
         . rl path
@@ -729,6 +744,14 @@ $ `stdlib/ext/http.nu`
     : ?String te ( header_get . req headers `Transfer-Encoding` )
     ?? te {
         T tev → {
+            // CL.TE smuggling defence (also enforced at head parse): a body
+            // with both Transfer-Encoding and Content-Length is ambiguous.
+            : ?String __cl2 ( header_get . req headers `Content-Length` )
+            : b __both ?? __cl2 { T x → { ( string_free x ) T } F _ → F }
+            ? __both {
+                ( string_free tev )
+                ^ @ !( Vec u ) HttpReqErr { F # HttpReqErr HttpReqMalformed }
+            } {}
             : String tev_lc ( string_to_lower tev )
             : b is_chunked != 0 ( nurl_str_eq ( string_data tev_lc ) `chunked` )
             ( string_free tev_lc )
@@ -938,8 +961,19 @@ $ `stdlib/ext/http.nu`
         ? == c 59 { = k n } {
             : i v ( __hex_val c )
             ? < v 0 { = ok F } {
-                = acc + * acc 16 v
-                = k + k 1
+                // Overflow guard: a chunk-size line can be up to 8192 hex
+                // digits (see __read_crlf_line), which would wrap i64 —
+                // `0x10000000000000000` wraps to 0 (read as the terminating
+                // chunk, ending the body early) or to a small positive value
+                // (wrong chunk boundary): both are request-smuggling vectors.
+                // Reject once `acc` passes a ceiling far above any legitimate
+                // chunk (2^48, vastly larger than any body limit) yet well
+                // clear of i64 overflow in the `* acc 16` below and in the
+                // caller's `vec_len + n` bound check.
+                ? > acc 0xFFFFFFFFFFFF { = ok F } {
+                    = acc + * acc 16 v
+                    = k + k 1
+                }
             }
         }
     }

--- a/stdlib/ext/http_response.nu
+++ b/stdlib/ext/http_response.nu
@@ -201,6 +201,22 @@ $ `stdlib/ext/json.nu`
 // owned — caller frees with `( vec_free [u] out )`. Content-Length is
 // auto-prepended unless the response carries a Transfer-Encoding
 // header (RFC 7230 §3.3.2). Headers are emitted in insertion order.
+// Append `str`'s bytes to `out`, dropping any CR (13) / LF (10). Header
+// field names and values are emitted through this so a value reflected
+// from untrusted input (a redirect Location, an echoed header, …) cannot
+// inject `\r\n<injected-header>` and split the response (CWE-113). RFC
+// 9110 §5.5 forbids CR/LF in field values anyway, so stripping them is
+// lossless for any well-formed header.
+@ __push_header_no_crlf ( Vec u ) out s str → v {
+    : i n ( nurl_str_len str )
+    : ~ i k 0
+    ~ < k n {
+        : i c & 255 ( nurl_str_get str k )
+        ? | == c 13 == c 10 {} { ( vec_push [u] out # u c ) }
+        = k + k 1
+    }
+}
+
 @ response_serialize HttpResponse r → ( Vec u ) {
     : ( Vec u ) out ( vec_with_cap [u] + 64 ( vec_len [u] . r body ) )
 
@@ -217,9 +233,9 @@ $ `stdlib/ext/json.nu`
     : ~ i k 0
     ~ < k hcount {
         : Header h . hdata k
-        ( bytes_extend_str out ( string_data . h name ) )
+        ( __push_header_no_crlf out ( string_data . h name ) )
         ( bytes_extend_str out `: ` )
-        ( bytes_extend_str out ( string_data . h value ) )
+        ( __push_header_no_crlf out ( string_data . h value ) )
         ( bytes_extend_str out `\r\n` )
         = k + k 1
     }
@@ -361,9 +377,9 @@ $ `stdlib/ext/json.nu`
         : b is_te != 0 ( nurl_str_eq nm `Transfer-Encoding` )
         : b is_cl != 0 ( nurl_str_eq nm `Content-Length` )
         ? & ! is_te ! is_cl {
-            ( bytes_extend_str head nm )
+            ( __push_header_no_crlf head nm )
             ( bytes_extend_str head `: ` )
-            ( bytes_extend_str head ( string_data . h value ) )
+            ( __push_header_no_crlf head ( string_data . h value ) )
             ( bytes_extend_str head `\r\n` )
         } {}
         = k + k 1

--- a/stdlib/ext/http_server.nu
+++ b/stdlib/ext/http_server.nu
@@ -352,7 +352,130 @@ $ `stdlib/ext/http_response.nu`
 //
 // Returns T on success, F on transport / format error.
 
+// Ensure `carry` holds at least `n` bytes, topping up from the socket.
+// Returns F on EOF / IO before reaching `n`.
+@ __carry_ensure TcpConn conn ( Vec u ) carry i n → b {
+    : ~ b ok T
+    ~ & ok < ( vec_len [u] carry ) n {
+        : !( Vec u ) NetErr r ( tcp_read_chunk conn 4096 )
+        ?? r {
+            T chunk → {
+                : i got ( vec_len [u] chunk )
+                ( vec_extend [u] carry chunk )
+                ( vec_free [u] chunk )
+                ? <= got 0 { = ok F } {}
+            }
+            F _ → { = ok F }
+        }
+    }
+    ^ ok
+}
+
+// Index of the next CRLF in `carry`, topping up from the socket until
+// found or `cap` bytes have accumulated. Returns the CR index, or -1 on
+// EOF / IO / cap exceeded (a chunk-size or trailer line longer than `cap`
+// is rejected, mirroring __read_crlf_line's 8 KiB guard).
+@ __carry_find_crlf TcpConn conn ( Vec u ) carry i cap → i {
+    : ~ i found -1
+    : ~ b stop F
+    ~ & == found -1 ! stop {
+        : i len ( vec_len [u] carry )
+        : *u p ( vec_data [u] carry )
+        : ~ i k 0
+        ~ & == found -1 < k - len 1 {
+            ? & == 13 & 255 # i . p k == 10 & 255 # i . p + k 1 { = found k } {}
+            = k + k 1
+        }
+        ? >= found 0 {} {
+            ? >= len cap { = stop T } {
+                : !( Vec u ) NetErr r ( tcp_read_chunk conn 4096 )
+                ?? r {
+                    T chunk → {
+                        : i got ( vec_len [u] chunk )
+                        ( vec_extend [u] carry chunk )
+                        ( vec_free [u] chunk )
+                        ? <= got 0 { = stop T } {}
+                    }
+                    F _ → { = stop T }
+                }
+            }
+        }
+    }
+    ^ found
+}
+
+// Decode a Transfer-Encoding: chunked body off `carry` (+ socket top-ups)
+// into `req.body`, leaving any pipelined-successor bytes after the
+// terminating chunk in `carry`. Mirrors read_body's chunked decoder but
+// is carry-aware so it works inside the keep-alive loop. Returns F on
+// malformed framing, IO error, or a body exceeding `body_max`.
+@ __finish_body_chunked TcpConn conn HttpRequest req ( Vec u ) carry i body_max → b {
+    : ~ b done F
+    : ~ b ok T
+    ~ & ok ! done {
+        : i crlf ( __carry_find_crlf conn carry 8192 )
+        ? < crlf 0 { = ok F } {
+            : String szline ( __bsubstr carry 0 crlf )
+            ( __vec_drop_front_u carry + crlf 2 )
+            : !i ParseErr szr ( __parse_hex_size szline )
+            ( string_free szline )
+            ?? szr {
+                T n → {
+                    ? < n 0 { = ok F } {
+                        ? == n 0 {
+                            // Terminating chunk: consume trailer lines up to
+                            // the closing empty line.
+                            : ~ b tdone F
+                            ~ & ok ! tdone {
+                                : i tc ( __carry_find_crlf conn carry 8192 )
+                                ? < tc 0 { = ok F } {
+                                    ( __vec_drop_front_u carry + tc 2 )
+                                    ? == tc 0 { = tdone T } {}
+                                }
+                            }
+                            = done T
+                        } {
+                            ? > + ( vec_len [u] . req body ) n body_max { = ok F } {
+                                // Need n bytes of data + the trailing CRLF.
+                                ? ( __carry_ensure conn carry + n 2 ) {
+                                    : *u cd ( vec_data [u] carry )
+                                    : ~ i k 0
+                                    ~ < k n {
+                                        ( vec_push [u] . req body & 255 # i . cd k )
+                                        = k + k 1
+                                    }
+                                    ( __vec_drop_front_u carry + n 2 )
+                                } { = ok F }
+                            }
+                        }
+                    }
+                }
+                F _ → { = ok F }
+            }
+        }
+    }
+    ^ ok
+}
+
 @ __finish_body TcpConn conn HttpRequest req ( Vec u ) carry i body_max → b {
+    // Transfer-Encoding takes precedence (RFC 7230 §3.3.3). A chunked body
+    // MUST be drained here too — otherwise its bytes are left in `carry`,
+    // handed to the handler as an empty body, and mis-parsed as the next
+    // request on a keep-alive connection (a desync / smuggling vector).
+    : ?String te ( header_get . req headers `Transfer-Encoding` )
+    ?? te {
+        T tev → {
+            : String te_lc ( string_to_lower tev )
+            : b is_chunked != 0 ( nurl_str_eq ( string_data te_lc ) `chunked` )
+            ( string_free te_lc )
+            ( string_free tev )
+            ? is_chunked { ^ ( __finish_body_chunked conn req carry body_max ) } {}
+            // Non-chunked Transfer-Encoding is unsupported (and CL+TE is
+            // already rejected at head parse) — fail the body read.
+            ^ F
+        }
+        F _ → {}
+    }
     : ?String cl ( header_get . req headers `Content-Length` )
     ?? cl {
         T clv → {


### PR DESCRIPTION
A focused bughunt on the HTTP/1.1 server stack turned up **four real defects**,
each fixed at the root with regression tests.

## 1. Chunked request bodies dropped on keep-alive  *(`http_server.nu`)*
`__finish_body` only handled `Content-Length`, so a `Transfer-Encoding: chunked`
body was left **undrained** in the connection carry buffer — the handler saw an
**empty body**, and the leftover bytes were mis-parsed as the next request
(connection desync / request smuggling). `__finish_body` now decodes chunked
bodies *carry-aware* (new `__carry_ensure` / `__carry_find_crlf` /
`__finish_body_chunked`): it drains from the buffer then the socket, bounds by
the body limit, and leaves any pipelined successor intact.

## 2. Chunk-size integer overflow → smuggling / DoS  *(`http_request.nu`)*
`__parse_hex_size` accumulated an unbounded hex value. `0x10000000000000000`
wrapped i64 to **0** (read as the terminating chunk → body ends early) or to a
small positive (wrong boundary) — both smuggling vectors; a huge positive could
also drive an enormous allocation. Now rejected past a 2^48 ceiling, clear of
i64 overflow and of the caller's bound check.

## 3. Content-Length + Transfer-Encoding smuggling  *(`http_request.nu`)*
A request carrying **both** framing headers (RFC 7230 §3.3.3) is now rejected at
head parse (and in `read_body_to`) instead of silently letting `Transfer-Encoding`
win — the classic CL.TE desync.

## 4. HTTP response splitting / CWE-113  *(`http_response.nu`)*
Header names/values were serialised **verbatim**, so a value reflected from
untrusted input (a redirect `Location`, an echoed header) could inject
`\r\n<header>` and split the response. The serialiser **and** the chunked
`response_begin_chunked` path now strip CR/LF from every emitted header name and
value (RFC 9110 §5.5 forbids them anyway).

## Tests
- `http_request_parser.nu` — CL+TE rejection, chunk-size overflow rejection (offline).
- `http_response_builder.nu` — header CR/LF stripping (offline).
- **new** `http_server_chunked.nu` — live: a chunked POST body is decoded to its
  real length AND a GET after it on the same keep-alive connection parses cleanly
  (gated on `NURL_NET_TESTS=1`).

ASan-clean; bootstrap byte-identical fixed point holds; full suite green; live
server tests (seq / pipelined / limits / chunked) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)