### PR TITLE
fix(http): security bughunt — five root-cause fixes across the stack

### DIFF
--- a/compiler/tests/http2_continuation_flood.nu
+++ b/compiler/tests/http2_continuation_flood.nu
@@ -1,0 +1,133 @@
+// http2_continuation_flood.nu — live regression for the HTTP/2
+// CONTINUATION-flood DoS (CVE-2024-27316 class), gated NURL_NET_TESTS=1.
+//
+// A peer opens a HEADERS frame WITHOUT END_HEADERS, then sends a stream
+// of CONTINUATION frames that also never set END_HEADERS. Before the fix
+// the server appended every CONTINUATION payload to the stream's
+// header_block with no cap → unbounded memory growth. Now the
+// accumulation is bounded by __h2_max_header_block_bytes (64 KiB); past
+// it the server raises a connection error → GOAWAY + close.
+//
+// We craft the raw frames with h2_write_frame and assert the server
+// answers the flood with a GOAWAY (or closes) rather than swallowing an
+// unbounded block. main returns the failure count.
+
+$ `stdlib/std/net.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/http.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http2_frame.nu`
+$ `stdlib/ext/http2_server.nu`
+
+& `libc` @ nurl_tcp_connect s host i port → i
+
+@ flood_handler HttpRequest req → HttpResponse {
+    ^ ( response_text 200 `ok` )
+}
+
+@ filler i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] n )
+    : ~ i k 0
+    ~ < k n {
+        ( vec_push [u] v # u 0 )
+        = k + k 1
+    }
+    ^ v
+}
+
+// Write one frame; returns T on success. CONSUMES `payload`.
+@ wf TcpConn conn i ftype i flags i sid ( Vec u ) payload → b {
+    : H2Frame f @ H2Frame { ftype flags sid payload }
+    : !v H2FrameErr r ( h2_write_frame conn f 16384 )
+    ( h2_frame_free f )
+    ^ ?? r { T _ → T  F _ → F }
+}
+
+@ run → i {
+    : ~ i fails 0
+    : !TcpListener NetErr lr ( tcp_listen `127.0.0.1` 18824 )
+    ?? lr {
+        T listener → {
+            : ( @ v ) server_fn \ → v {
+                : !TcpConn NetErr ar ( tcp_accept listener )
+                ?? ar {
+                    T conn → {
+                        : !v H2ConnErr sr ( http2_serve conn \ HttpRequest req → HttpResponse { ^ ( flood_handler req ) } )
+                        ?? sr { T _ → {} F _ → {} }
+                        ( tcp_close_conn conn )
+                    }
+                    F _ → {}
+                }
+            }
+            : !Thread ThreadErr st ( thread_spawn server_fn )
+            ( sleep_ms 100 )
+
+            : i craw ( nurl_tcp_connect `127.0.0.1` 18824 )
+            : i cek ( nurl_tcp_err_kind craw )
+            ? != cek 0 {
+                ( nurl_print `  FAIL connect\n` ) = fails + fails 1
+            } {
+                : TcpConn conn @ TcpConn { # s craw }
+                ( tcp_set_timeout conn 3000 )
+                : !v H2FrameErr pf ( h2_write_preface conn )
+                ?? pf { T _ → {} F _ → {} }
+                // Client SETTINGS (empty) — required first frame (§3.4).
+                : b _s ( wf conn ( h2_type_settings ) 0 0 ( vec_new [u] ) )
+                // HEADERS on stream 1, NO END_HEADERS → opens an
+                // accumulation the CONTINUATION flood feeds.
+                : b _h ( wf conn ( h2_type_headers ) 0 1 ( filler 16000 ) )
+                // 5 × 16000 + 16000 = 96 KiB > the 64 KiB cap.
+                : ~ i c 0
+                : ~ b wok T
+                ~ & wok < c 5 {
+                    = wok ( wf conn ( h2_type_continuation ) 0 1 ( filler 16000 ) )
+                    = c + c 1
+                }
+                // The server must answer with GOAWAY (or close) — it must
+                // NOT keep accepting an unbounded block. Read frames,
+                // skipping the server's own SETTINGS etc., until GOAWAY or
+                // the connection drops.
+                : ~ b defended F
+                : ~ i reads 0
+                ~ & ! defended < reads 20 {
+                    : !H2Frame H2FrameErr rr ( h2_read_frame conn 16384 )
+                    ?? rr {
+                        T fr → {
+                            ? == . fr frame_type ( h2_type_goaway ) { = defended T } {}
+                            ( h2_frame_free fr )
+                        }
+                        F _ → { = defended T }
+                    }
+                    = reads + reads 1
+                }
+                ? defended {} {
+                    ( nurl_print `  FAIL no GOAWAY/close on CONTINUATION flood\n` )
+                    = fails + fails 1
+                }
+                ( tcp_close_conn conn )
+            }
+            : i _sj ?? st { T th → ( thread_join th ) F _ → 0 }
+            ( tcp_close_listener listener )
+        }
+        F _ → { ( nurl_print `  FAIL listen\n` ) = fails + fails 1 }
+    }
+    ^ fails
+}
+
+@ main → i {
+    : ?String gate ( env_get `NURL_NET_TESTS` )
+    ?? gate {
+        T s → {
+            ( string_free s )
+            : i f ( run )
+            ? == f 0 { ( nurl_print `continuation-flood defended\n` ) } {}
+            ^ f
+        }
+        F → { ( nurl_print `http2_continuation_flood skipped (NURL_NET_TESTS != 1)\n` ) ^ 0 }
+    }
+}

--- a/compiler/tests/http2_stream_prune.nu
+++ b/compiler/tests/http2_stream_prune.nu
@@ -1,0 +1,119 @@
+// http2_stream_prune.nu — offline regression for __h2_prune_closed and
+// the closed-stream accounting fix in stdlib/ext/http2_conn.nu.
+//
+// Bug: the new-stream admission check counted EVERY entry in the stream
+// table, including CLOSED streams that are never removed. RFC 9113
+// §5.1.2 says only "open"/"half-closed" streams count toward
+// SETTINGS_MAX_CONCURRENT_STREAMS, so on a long-lived connection the
+// closed records pile up until the 256 cap is hit and all further
+// requests are wrongly REFUSED — and the table grows without bound (the
+// memory dimension of Rapid Reset, CVE-2023-44487).
+//
+// Fix: __h2_prune_closed drops closed streams (freeing their buffers)
+// before each admission count. This test builds a connection table by
+// hand, prunes, and asserts only the active streams survive — with their
+// ids/order intact. No socket: runs on every CI host.
+
+$ `stdlib/ext/http2_conn.nu`
+
+@ mkstream i id i st → H2Stream {
+    // Give closed streams some buffer content so the prune's free path is
+    // exercised (and shows up under the sanitized runner).
+    : ( Vec u ) hb ( vec_new [u] )
+    ( vec_push [u] hb # u 0xAB )
+    ( vec_push [u] hb # u 0xCD )
+    : ( Vec u ) bd ( vec_new [u] )
+    ( vec_push [u] bd # u 0xEF )
+    ^ @ H2Stream { id st hb F F ( vec_new [Header] ) bd F 65535 65535 }
+}
+
+// Build an H2Connection with an empty stream table and a dummy socket
+// handle (prune never touches `tcp`). Mirrors h2_conn_new's field order.
+@ mkconn → H2Connection {
+    : TcpConn tc @ TcpConn { # s 0 }
+    ^ @ H2Connection {
+        tc
+        4096 0 256 65535 16384 0
+        4096 1 0 65535 16384 0
+        ( hpack_dyn_new 4096 )
+        ( hpack_dyn_new 4096 )
+        ( vec_new [H2Stream] )
+        ( h2_default_initial_window_size )
+        ( h2_default_initial_window_size )
+        0
+        F
+        0
+    }
+}
+
+@ assert_eq s label i got i want ( Vec i ) fails → v {
+    ? == got want {
+        ( nurl_print `  ok   ` ) ( nurl_print label )
+        ( nurl_print ` = ` ) ( nurl_print ( nurl_str_int got ) ) ( nurl_print `\n` )
+    } {
+        ( nurl_print `  FAIL ` ) ( nurl_print label )
+        ( nurl_print ` got ` ) ( nurl_print ( nurl_str_int got ) )
+        ( nurl_print ` want ` ) ( nurl_print ( nurl_str_int want ) ) ( nurl_print `\n` )
+        ( vec_push [i] fails 1 )
+    }
+}
+
+@ run → i {
+    : ( Vec i ) fails ( vec_new [i] )
+
+    // ── Mixed table: 1 closed, 3 open, 5 closed, 7 half-closed-remote,
+    //    9 closed → after prune only 3 and 7 (active) survive, in order.
+    : ~ H2Connection c ( mkconn )
+    ( vec_push [H2Stream] . c streams ( mkstream 1 ( h2_state_closed ) ) )
+    ( vec_push [H2Stream] . c streams ( mkstream 3 ( h2_state_open ) ) )
+    ( vec_push [H2Stream] . c streams ( mkstream 5 ( h2_state_closed ) ) )
+    ( vec_push [H2Stream] . c streams ( mkstream 7 ( h2_state_half_closed_remote ) ) )
+    ( vec_push [H2Stream] . c streams ( mkstream 9 ( h2_state_closed ) ) )
+
+    = c ( __h2_prune_closed c )
+    ( assert_eq `mixed: active count` ( vec_len [H2Stream] . c streams ) 2 fails )
+
+    : *H2Stream sp ( vec_data [H2Stream] . c streams )
+    ? > ( vec_len [H2Stream] . c streams ) 0 {
+        : H2Stream s0 . sp 0
+        ( assert_eq `mixed: survivor[0] id`    . s0 id    3 fails )
+        ( assert_eq `mixed: survivor[0] state` . s0 state ( h2_state_open ) fails )
+    } {}
+    ? > ( vec_len [H2Stream] . c streams ) 1 {
+        : H2Stream s1 . sp 1
+        ( assert_eq `mixed: survivor[1] id`    . s1 id    7 fails )
+        ( assert_eq `mixed: survivor[1] state` . s1 state ( h2_state_half_closed_remote ) fails )
+    } {}
+    ( h2_conn_free c )
+
+    // ── All-closed table → empty after prune (the Rapid Reset / cap-
+    //    exhaustion case): pile up 300 closed streams, prune to zero.
+    : ~ H2Connection c2 ( mkconn )
+    : ~ i k 0
+    ~ < k 300 {
+        ( vec_push [H2Stream] . c2 streams ( mkstream + 1 * k 2 ( h2_state_closed ) ) )
+        = k + k 1
+    }
+    = c2 ( __h2_prune_closed c2 )
+    ( assert_eq `all-closed: count` ( vec_len [H2Stream] . c2 streams ) 0 fails )
+    ( h2_conn_free c2 )
+
+    // ── All-active table → unchanged.
+    : ~ H2Connection c3 ( mkconn )
+    ( vec_push [H2Stream] . c3 streams ( mkstream 1 ( h2_state_open ) ) )
+    ( vec_push [H2Stream] . c3 streams ( mkstream 3 ( h2_state_half_closed_remote ) ) )
+    = c3 ( __h2_prune_closed c3 )
+    ( assert_eq `all-active: count` ( vec_len [H2Stream] . c3 streams ) 2 fails )
+    ( h2_conn_free c3 )
+
+    : i n ( vec_len [i] fails )
+    ( vec_free [i] fails )
+    ^ n
+}
+
+@ main → i {
+    : i f ( run )
+    ? == f 0 { ( nurl_print `http2_stream_prune: all checks passed\n` ) }
+            { ( nurl_print `http2_stream_prune: FAILURES\n` ) }
+    ^ f
+}

--- a/compiler/tests/http_proxy.nu
+++ b/compiler/tests/http_proxy.nu
@@ -102,6 +102,25 @@ $ `stdlib/core/vec.nu`
     ( string_free u4 )
     ( request_free r4 )
 
+    // SSRF defence: base WITHOUT a trailing slash + a target WITHOUT a
+    // leading slash must NOT merge into the authority. Pre-fix these
+    // produced "https://api.example.com@evil.com" (userinfo split →
+    // host evil.com) and "https://api.example.comevil.com" — both let
+    // the client choose the upstream host. The fix inserts exactly one
+    // '/' so the host stays api.example.com and the token lands in the
+    // path.
+    : HttpRequest r5 ( make_req `GET` `@evil.com/x` `` )
+    : String u5 ( __build_upstream_url `https://api.example.com` r5 )
+    ( println_s `  ssrf_userinfo=` ( string_data u5 ) )
+    ( string_free u5 )
+    ( request_free r5 )
+
+    : HttpRequest r6 ( make_req `GET` `evil.com/x` `` )
+    : String u6 ( __build_upstream_url `https://api.example.com` r6 )
+    ( println_s `  ssrf_hostmerge=` ( string_data u6 ) )
+    ( string_free u6 )
+    ( request_free r6 )
+
     // ── 5. __build_request_headers_blob ──────────────────────────
     ( nurl_print `── __build_request_headers_blob ──\n` )
     : HttpRequest hr ( make_req `POST` `/v1/messages` `` )

--- a/compiler/tests/http_static_traversal.nu
+++ b/compiler/tests/http_static_traversal.nu
@@ -1,0 +1,156 @@
+// http_static_traversal.nu — regression for the serve_static
+// path-traversal / arbitrary-file-read fix. Pure filesystem exercise (no
+// socket), so it runs ungated like http_request_parser.
+//
+// The bug: __resolve_static_path stripped only ONE leading separator from
+// the request path before joining with the served dir. A request for
+// "//<abs>/secret" therefore became "/<abs>/secret", which path_join
+// treats as an absolute `b` and returns VERBATIM — discarding the served
+// dir and serving any file on the host. The fix strips ALL leading
+// separators (so the tail is always relative) and rejects a tail that is
+// still absolute (Windows drive-letter form) or contains a ".." segment.
+//
+// We lay out:
+//   <tmp>/secret.txt        — a "secret" OUTSIDE the served root
+//   <tmp>/pubdir/index.html    — the served directory's index
+//   <tmp>/pubdir/ok.txt        — a legitimate file
+// then drive serve_static with crafted request paths and assert that
+// legitimate requests succeed (200) while every escape attempt is BLOCKED
+// (NOT 200, and never serving the secret). main returns the failure count.
+
+$ `stdlib/std/fs.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/http.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_static.nu`
+
+// Build a borrowed request with the given path. Caller frees with
+// request_free.
+@ mkreq s path → HttpRequest {
+    : HttpRequest req ( request_new )
+    ( string_free . req method )
+    = . req method ( string_from `GET` )
+    ( string_free . req path )
+    = . req path ( string_from path )
+    ^ req
+}
+
+// Run serve_static for `path`, return the status code, free everything.
+@ status_for s dir s path → i {
+    : HttpRequest req ( mkreq path )
+    : HttpResponse resp ( serve_static dir req )
+    : i st . resp status
+    ( http_response_free resp )
+    ( request_free req )
+    ^ st
+}
+
+@ check_eq s label i got i want ( Vec i ) fails → v {
+    ? == got want {
+        ( nurl_print `  ok   ` ) ( nurl_print label )
+        ( nurl_print ` = ` ) ( nurl_print ( nurl_str_int got ) ) ( nurl_print `\n` )
+    } {
+        ( nurl_print `  FAIL ` ) ( nurl_print label )
+        ( nurl_print ` got ` ) ( nurl_print ( nurl_str_int got ) )
+        ( nurl_print ` want ` ) ( nurl_print ( nurl_str_int want ) ) ( nurl_print `\n` )
+        ( vec_push [i] fails 1 )
+    }
+}
+
+// Assert the response is NOT 200 (the escape was blocked). Both 403 and
+// 404 are acceptable "blocked" dispositions.
+@ check_blocked s label i got ( Vec i ) fails → v {
+    ? != got 200 {
+        ( nurl_print `  ok   ` ) ( nurl_print label )
+        ( nurl_print ` blocked (` ) ( nurl_print ( nurl_str_int got ) ) ( nurl_print `)\n` )
+    } {
+        ( nurl_print `  FAIL ` ) ( nurl_print label )
+        ( nurl_print ` SERVED (200) — escape not blocked\n` )
+        ( vec_push [i] fails 1 )
+    }
+}
+
+@ run s base → i {
+    : ( Vec i ) fails ( vec_new [i] )
+
+    : String pubdir ( string_new )
+    ( string_push_str pubdir base )
+    ( string_push_str pubdir `/pubdir` )
+    : s pubpath ( string_data pubdir )
+
+    // Legitimate requests succeed.
+    ( check_eq `GET /ok.txt`   ( status_for pubpath `/ok.txt` )       200 fails )
+    ( check_eq `GET / (index)` ( status_for pubpath `/` )             200 fails )
+
+    // ".." traversal → 403.
+    ( check_eq `GET /../secret.txt` ( status_for pubpath `/../secret.txt` ) 403 fails )
+
+    // The core bug: a double-leading-slash absolute path that, pre-fix,
+    // path_join would serve verbatim from outside `pubdir`.
+    : String esc ( string_new )
+    ( string_push_str esc `/` )
+    ( string_push_str esc base )
+    ( string_push_str esc `/secret.txt` )
+    ( check_blocked `GET //<abs>/secret.txt` ( status_for pubpath ( string_data esc ) ) fails )
+    ( string_free esc )
+
+    // A bare absolute-style escape to a well-known path.
+    ( check_blocked `GET //etc/hostname` ( status_for pubpath `//etc/hostname` ) fails )
+
+    ( string_free pubdir )
+    : i n ( vec_len [i] fails )
+    ( vec_free [i] fails )
+    ^ n
+}
+
+@ main → i {
+    // Unique-ish temp root under /tmp.
+    : String base ( string_new )
+    ( string_push_str base `/tmp/nurl_static_traversal_test` )
+    : s b ( string_data base )
+
+    : String pubdir ( string_new )
+    ( string_push_str pubdir b )
+    ( string_push_str pubdir `/pubdir` )
+
+    : !v IoErr d1 ( dir_create_all ( string_data pubdir ) )
+    ?? d1 { T _ → {} F _ → {} }
+
+    // secret OUTSIDE pubdir
+    : String secret_path ( string_new )
+    ( string_push_str secret_path b )
+    ( string_push_str secret_path `/secret.txt` )
+    : !v IoErr w1 ( write_file ( string_data secret_path ) `TOP-SECRET\n` )
+    ?? w1 { T _ → {} F _ → {} }
+
+    // index.html + ok.txt INSIDE pubdir
+    : String idx ( string_new )
+    ( string_push_str idx ( string_data pubdir ) )
+    ( string_push_str idx `/index.html` )
+    : !v IoErr w2 ( write_file ( string_data idx ) `<h1>index</h1>\n` )
+    ?? w2 { T _ → {} F _ → {} }
+
+    : String okp ( string_new )
+    ( string_push_str okp ( string_data pubdir ) )
+    ( string_push_str okp `/ok.txt` )
+    : !v IoErr w3 ( write_file ( string_data okp ) `ok\n` )
+    ?? w3 { T _ → {} F _ → {} }
+
+    : i fails ( run b )
+
+    ( string_free okp )
+    ( string_free idx )
+    ( string_free secret_path )
+    ( string_free pubdir )
+    ( string_free base )
+
+    ? == fails 0 {
+        ( nurl_print `http_static_traversal: all checks passed\n` )
+    } {
+        ( nurl_print `http_static_traversal: FAILURES\n` )
+    }
+    ^ fails
+}

--- a/compiler/tests/run_tests.sh
+++ b/compiler/tests/run_tests.sh
@@ -237,6 +237,7 @@ for src in "${tests[@]}"; do
           && "$name" != "http_response_builder" \
           && "$name" != "http_options" \
           && "$name" != "http_router" \
+          && "$name" != "http_static_traversal" \
           && "$name" != "http_extras" \
           && "$name" != "http_middleware" \
           && "$name" != "http_form" \

--- a/stdlib/ext/http2_conn.nu
+++ b/stdlib/ext/http2_conn.nu
@@ -319,6 +319,59 @@ $ `stdlib/ext/http2_hpack.nu`
     = . sp idx s
 }
 
+// Drop every CLOSED stream from the connection's stream table, freeing
+// its owned buffers, and keep the rest. Two problems are solved here:
+//
+//   1. CORRECTNESS / availability. RFC 9113 §5.1.2 says only streams in
+//      the "open" or a "half-closed" state count toward
+//      SETTINGS_MAX_CONCURRENT_STREAMS — closed streams do NOT. The new-
+//      stream admission check counts `vec_len streams`, so without
+//      pruning a long-lived connection's closed records accumulate and,
+//      once 256 (our advertised max) have piled up, EVERY further request
+//      is answered with REFUSED_STREAM even though nothing is actually in
+//      flight. That breaks HTTP/2's core connection-reuse model.
+//
+//   2. MEMORY / DoS. The table otherwise grows without bound for the life
+//      of the connection (the memory dimension of the Rapid Reset attack,
+//      CVE-2023-44487: open + immediate RST_STREAM never lowers the
+//      count). Pruning bounds the table to the genuinely-active streams.
+//
+// Safe because closed-stream reuse is rejected via `last_peer_stream_id`
+// (which never decreases), independently of whether a record is present:
+// a HEADERS / WINDOW_UPDATE / RST_STREAM / DATA frame arriving for a
+// pruned id takes the same `idx < 0` path it would for any other
+// already-closed stream.
+//
+// MUST compact the stream table IN PLACE. A `Vec` is a boxed handle
+// (pointer to a shared {data,len,cap} control block); every by-value copy
+// of the H2Connection — including the one the caller of h2_conn_serve
+// holds for its final h2_conn_free — shares that same control block.
+// Freeing it and swapping in a fresh Vec would leave those other copies
+// pointing at freed memory (use-after-free at connection teardown). So we
+// keep the same control block: free each closed stream's buffers, slide
+// the survivors down, and shrink the length via vec_set_len. The
+// abandoned tail slots are outside [0,len) and are never traversed again
+// (their buffers now live in the lower survivor slots — no double free).
+@ __h2_prune_closed H2Connection c → H2Connection {
+    : ~ H2Connection cur c
+    : i n ( vec_len [H2Stream] . cur streams )
+    : *H2Stream sp ( vec_data [H2Stream] . cur streams )
+    : ~ i w 0
+    : ~ i r 0
+    ~ < r n {
+        : H2Stream s . sp r
+        ? == . s state ( h2_state_closed ) {
+            ( __h2_stream_free s )
+        } {
+            ? != w r { = . sp w s } {}
+            = w + w 1
+        }
+        = r + r 1
+    }
+    : b _sl ( vec_set_len [H2Stream] . cur streams w )
+    ^ cur
+}
+
 // ── SETTINGS application ─────────────────────────────────────────────
 //
 // Apply received settings to peer_settings + adjust derived state.
@@ -403,6 +456,14 @@ $ `stdlib/ext/http2_hpack.nu`
 // 31-bit dependency value masked of the exclusive-bit, or -1 if the
 // flag is not set / the payload is malformed (caller falls back on its
 // own length check).
+// Hard cap on the accumulated HEADERS+CONTINUATION block per stream.
+// `our_max_header_list_size` defaults to 0 (unadvertised / unlimited), so
+// without this a peer could open HEADERS without END_HEADERS and append
+// unbounded CONTINUATION frames, growing `header_block` without limit
+// (the CONTINUATION-flood DoS, CVE-2024-27316 class). 64 KiB of ENCODED
+// header bytes is far beyond any legitimate request yet bounds memory.
+@ __h2_max_header_block_bytes → i { ^ 65536 }
+
 @ __h2_headers_priority_dep H2Frame f → i {
     ? == 0 & . f flags ( h2_flag_priority ) { ^ -1 } {}
     : i n ( vec_len [u] . f payload )
@@ -1205,6 +1266,11 @@ $ `stdlib/ext/http2_hpack.nu`
                                 // open record — closed-stream reuse.
                                 = err H2ConnProtocol = ok F
                             } {
+                                // Reclaim closed streams before counting, so
+                                // the cap reflects only genuinely-active
+                                // streams (RFC 9113 §5.1.2) and the table
+                                // stays bounded (see __h2_prune_closed).
+                                = cur ( __h2_prune_closed cur )
                                 : i ns ( vec_len [H2Stream] . cur streams )
                                 ? & > . cur our_max_concurrent_streams 0
                                 >= ns . cur our_max_concurrent_streams
@@ -1222,6 +1288,9 @@ $ `stdlib/ext/http2_hpack.nu`
                                         T hb → {
                                             ( vec_extend [u] . new_s header_block hb )
                                             ( vec_free [u] hb )
+                                            ? > ( vec_len [u] . new_s header_block ) ( __h2_max_header_block_bytes ) {
+                                                = err H2ConnProtocol = ok F
+                                            } {}
                                             = . new_s state ( h2_state_open )
                                             ? != 0 & . frame flags ( h2_flag_end_stream ) {
                                                 = . new_s end_stream_received T
@@ -1236,7 +1305,8 @@ $ `stdlib/ext/http2_hpack.nu`
                                             ( vec_push [H2Stream] . cur streams new_s )
                                             = . cur last_peer_stream_id sid
                                             // If complete, decode + dispatch
-                                            ? . new_s headers_complete {
+                                            // (skip if the cap guard tripped).
+                                            ? & ok . new_s headers_complete {
                                                 : i sidx ( __h2_find_stream_index cur sid )
                                                 : !H2Connection H2ConnErr dr
                                                 ( __h2_decode_stream_headers cur sidx )
@@ -1283,12 +1353,18 @@ $ `stdlib/ext/http2_hpack.nu`
                             } {
                                 : H2Stream s ( __h2_get_stream cur idx )
                                 ( vec_extend [u] . s header_block . frame payload )
+                                // CONTINUATION-flood guard: bound the total
+                                // accumulated header block (see
+                                // __h2_max_header_block_bytes).
+                                ? > ( vec_len [u] . s header_block ) ( __h2_max_header_block_bytes ) {
+                                    = err H2ConnProtocol = ok F
+                                } {}
                                 ? != 0 & . frame flags ( h2_flag_end_headers ) {
                                     = . s headers_complete T
                                     = . cur partial_headers_stream 0
                                 } {}
                                 ( __h2_set_stream cur idx s )
-                                ? . s headers_complete {
+                                ? & ok . s headers_complete {
                                     : !H2Connection H2ConnErr dr
                                     ( __h2_decode_stream_headers cur idx )
                                     ?? dr {

--- a/stdlib/ext/http_proxy.nu
+++ b/stdlib/ext/http_proxy.nu
@@ -146,8 +146,18 @@ $ `stdlib/ext/http_server.nu`
 }
 
 // Build the upstream URL by joining `base` with `req.path` + `?` +
-// `req.query`. If `base` ends with `/` AND `req.path` starts with `/`
-// we strip one to avoid `https://api.example.com//v1/foo`.
+// `req.query`.
+//
+// The separator handling is security-critical, not cosmetic. The request
+// target is NOT guaranteed to start with `/` (the request-line parser
+// accepts any non-empty target — absolute-form, authority-form, or a
+// bare token). If `base` has no trailing `/` AND the path has no leading
+// `/`, naive concatenation merges them into the authority: base
+// "http://api" + path "@evil.com" → "http://api@evil.com" (userinfo
+// split → host evil.com), or + "evil.com" → "http://apievil.com". Both
+// are SSRF — the client picks the upstream host. So we guarantee EXACTLY
+// one `/` between base and path: strip a duplicate when both supply one,
+// and INSERT one when neither does.
 @ __build_upstream_url s base HttpRequest req → String {
     : i bn ( nurl_str_len base )
     : i pn ( string_len . req path )
@@ -160,6 +170,9 @@ $ `stdlib/ext/http_server.nu`
     ? > pn 0 { ? == ( string_get . req path 0 ) 47 { = path_slash T } {} } {}
     : ~ i path_start 0
     ? & base_slash path_slash { = path_start 1 } {}
+    // Neither side supplies a separator → insert one so the path can
+    // never bleed into the authority (SSRF defence, see above).
+    ? & ! base_slash ! path_slash { ( string_push_char url 47 ) } {}
     ? > pn path_start {
         : ~ i k path_start
         ~ < k pn {

--- a/stdlib/ext/http_request.nu
+++ b/stdlib/ext/http_request.nu
@@ -853,11 +853,24 @@ $ `stdlib/ext/http.nu`
                     T n → {
                         ? < n 0 { = status 0 = done T } {}
                         ? == n 0 {
-                            // Trailer-headers terminator: read an empty line.
-                            : !String HttpReqErr trailer ( __read_crlf_line conn 0 )
-                            ?? trailer {
-                                T t → ( string_free t )
-                                F _ → = status 0
+                            // Terminating chunk. Consume the trailer section
+                            // (RFC 7230 §4.1.2) up to its closing empty line —
+                            // zero or more trailer header lines may follow the
+                            // "0" chunk. Reading only the first line would
+                            // leave the remaining trailers + the empty
+                            // terminator on the socket, desyncing a persistent
+                            // connection (a request-smuggling vector).
+                            : ~ b tdone F
+                            ~ & == status 1 ! tdone {
+                                : !String HttpReqErr trailer ( __read_crlf_line conn 0 )
+                                ?? trailer {
+                                    T t → {
+                                        : i tl ( string_len t )
+                                        ( string_free t )
+                                        ? == tl 0 { = tdone T } {}
+                                    }
+                                    F _ → { = status 0 = tdone T }
+                                }
                             }
                             = done T
                         } {

--- a/stdlib/ext/http_static.nu
+++ b/stdlib/ext/http_static.nu
@@ -144,48 +144,73 @@ $ `stdlib/std/bytes.nu`
     ^ found
 }
 
+@ __is_sep_byte i c → b {
+    ? == c 47 { ^ T } {}
+    ? == c 92 { ^ T } {}
+    ^ F
+}
+
+// Build the relative request tail: strip ALL leading separators so the
+// result can never be an absolute path. Stripping only ONE separator
+// (the old behaviour) left "//etc/passwd" → "/etc/passwd", which
+// path_join treats as an absolute `b` and returns verbatim — discarding
+// `dir` and serving an arbitrary file outside the static root. Stripping
+// every leading '/' and '\\' guarantees the tail is relative, so the
+// path_join result always stays under `dir`. (A Windows drive-letter
+// tail like "C:/.." survives separator-stripping and is rejected
+// separately by serve_static's path_is_absolute guard.)
+@ __static_rel_tail s path → String {
+    : i pn ( nurl_str_len path )
+    : ~ i start 0
+    ~ & < start pn ( __is_sep_byte ( nurl_str_get path start ) ) {
+        = start + start 1
+    }
+    : String out ( string_with_cap - pn start )
+    : ~ i k start
+    ~ < k pn {
+        ( string_push_char out ( nurl_str_get path k ) )
+        = k + k 1
+    }
+    ^ out
+}
+
 // ── serve_static ─────────────────────────────────────────────────────
 //
-// Path resolution is intentionally simple:
+// Path resolution:
 //
-//   * If the request path is just "/", serve `dir/index.html`.
-//   * Otherwise strip leading '/' from the request path and join with
-//     `dir`. Empty `dir` means CWD-relative.
-//   * Any '..' segment in the request path → 403.
-//   * read_file_bytes failure → 404.
+//   * Strip ALL leading separators from the request path to obtain a
+//     guaranteed-relative tail (see __static_rel_tail).
+//   * Empty tail ("/" or all-separators) → serve `dir/index.html`.
+//   * Reject (403) any '..' segment, or a tail that is still absolute
+//     (a drive-letter form like "C:/..") after separator-stripping.
+//   * Join the tail with `dir` (empty `dir` means CWD-relative) and read
+//     the file; read_file_bytes / file_size failure → 404.
 //
 // The body Vec is OWNED by the response after `response_set_body_bytes`
 // copies it; we then free the original buffer to avoid double ownership.
 
-@ __resolve_static_path s dir String req_path → String {
-    : i pn ( string_len req_path )
-    // "/" → "index.html" relative to dir.
-    ? <= pn 1 {
-        : ?i found_slash ( string_index_of req_path `/` )
-        ?? found_slash {
-            T _ → { ^ ( path_join dir `index.html` ) }
-            F _ → { ^ ( path_join dir ( string_data req_path ) ) }
-        }
-    } {}
-    // Strip the leading '/' (every well-formed HTTP target starts with one).
-    : i first ( string_get req_path 0 )
-    ? == first 47 {
-        : String tail ( string_substr req_path 1 - pn 1 )
-        : String full ( path_join dir ( string_data tail ) )
-        ( string_free tail )
-        ^ full
-    } {}
-    ^ ( path_join dir ( string_data req_path ) )
-}
-
 @ serve_static s dir HttpRequest req → HttpResponse {
-    // Path-traversal defence runs on the raw request path BEFORE join,
-    // so even an attacker-controlled `..` blocked even if `dir` is empty.
-    ? ( __has_dotdot_segment ( string_data . req path ) ) {
+    // Resolve to a guaranteed-relative tail FIRST (strips every leading
+    // separator), then run the traversal defences on that tail — so a
+    // "//etc/passwd" or "/C:/secret" can never escape `dir`, even when
+    // `dir` is empty.
+    : String rel ( __static_rel_tail ( string_data . req path ) )
+    : s rels ( string_data rel )
+    // Reject any ".." segment, and reject a tail that is still absolute
+    // after separator-stripping (a Windows drive-letter form, which
+    // path_join would otherwise honour and serve outside `dir`).
+    ? | ( __has_dotdot_segment rels ) ( path_is_absolute rels ) {
+        ( string_free rel )
         ^ ( response_text 403 `forbidden\n` )
     } {}
 
-    : String full ( __resolve_static_path dir . req path )
+    // Empty tail ("/" or all-separators) → directory index.
+    : ~ String full ( path_join dir `index.html` )
+    ? > ( string_len rel ) 0 {
+        ( string_free full )
+        = full ( path_join dir rels )
+    } {}
+    ( string_free rel )
 
     // Refuse to serve a directory entry directly (e.g. someone requested
     // `/static/css/`). file_exists returns F for directories under POSIX


### PR DESCRIPTION
Hardens the HTTP/1.1 + HTTP/2 stack against arbitrary file read, SSRF, request smuggling, and two HTTP/2 DoS / availability defects. Every fix targets the **root cause** (no workarounds); each ships a regression test — offline where possible, `NURL_NET_TESTS`-gated for the live socket paths.

## Fixes

**1. `serve_static` — arbitrary file read (path traversal)**
`__resolve_static_path` stripped only **one** leading separator before `path_join`, so `//etc/passwd` became `/etc/passwd` — an absolute `b` that `path_join` returns verbatim, discarding the served dir. Now strips **all** leading separators (tail always relative) and rejects a tail that is still absolute (drive-letter form) or holds a `..` segment. *Verified: pre-fix served the real `/etc/hostname`; post-fix 404.*

**2. `http_proxy.__build_upstream_url` — SSRF via host injection**
The request target is not guaranteed to start with `/`. With a base lacking a trailing slash, `@evil.com` / `evil.com` concatenated into `http://api@evil.com` / `http://apievil.com` — the client chose the upstream host. Now guarantees exactly one `/` between base and path (inserts one when neither side supplies it).

**3. `http2_conn` — CONTINUATION flood (CVE-2024-27316 class)**
A peer could open HEADERS without END_HEADERS and append unbounded CONTINUATION frames, growing `header_block` without limit. Bounded by `__h2_max_header_block_bytes` (64 KiB) → connection error → GOAWAY.

**4. `http2_conn` — closed-stream accounting (availability + memory DoS)**
Closed streams were never removed yet counted toward `SETTINGS_MAX_CONCURRENT_STREAMS`, so a long-lived connection was wrongly REFUSED after 256 total requests (RFC 9113 §5.1.2: closed streams MUST NOT count) and the table grew without bound (memory dimension of Rapid Reset, CVE-2023-44487). `__h2_prune_closed` reclaims closed streams before each admission count, **compacting in place** — a `Vec` is a shared boxed handle, so freeing + swapping caused a use-after-free at `h2_conn_free` (caught under ASan and fixed).

**5. `http_request.__read_body_chunked` — keep-alive desync**
The standalone chunked reader consumed only the **first** trailer line, leaving the rest + terminator on the socket (smuggling/desync vector if reused on a persistent connection). Now drains the whole trailer section per RFC 7230 §4.1.2, matching the server loop's carry-aware decoder.

## Tests
- `http_static_traversal.nu` (offline) — confirmed it fails against the unpatched handler (served the secret) and passes after.
- `http2_stream_prune.nu` (offline, ASan/LSan-clean) — mixed / all-closed / all-active tables.
- `http2_continuation_flood.nu` (net-gated) — asserts GOAWAY/close on the flood.
- New SSRF cases in `http_proxy.nu`.

Full offline suite is additive-clean (no existing test changed). Live HTTP/2 client + continuation-flood pass under `NURL_NET_TESTS=1` with ASan.

## Out of scope / pre-existing
`http_server_pool` and `async_http_server` hang under `NURL_NET_TESTS=1` on this host (blocking `accept()` not interrupted by `tcp_shutdown_listener`). Reproduced with **all changes reverted** — pre-existing, net-gated, orthogonal to this hardening. Left for a separate runtime/threading fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)