### PR TITLE
fix(http): free fire-and-forget closure envs in server_run_pool/_async

### DIFF
--- a/compiler/tests/async_http_server.nu
+++ b/compiler/tests/async_http_server.nu
@@ -85,6 +85,15 @@ $ `stdlib/ext/env.nu`
             ?? d { T _ → {} F → {} }
             ?? ct { T t → { ( thread_join t ) } F _ → {} }
 
+            // The client thread has joined and server_run_async has
+            // returned (all fibers drained), so both closures' heap-
+            // captured envs are now dead — release them (spawn /
+            // thread_spawn borrow the env; they never free it).
+            : *u client_env # *u client 1
+            ( nurl_free # s client_env )
+            : *u handler_env # *u async_test_handler_cl 1
+            ( nurl_free # s handler_env )
+
             ( nurl_print `client_ok=` )
             ( nurl_print ( nurl_str_int client_ok ) )
             ( nurl_print `\n` )

--- a/compiler/tests/http_server_pool.nu
+++ b/compiler/tests/http_server_pool.nu
@@ -72,6 +72,10 @@ $ `stdlib/core/string.nu`
                     }
                     ( thread_join t )
                     ( server_stop srv )  // Final free — no thread is still reading h.
+                    // Release the shutdown closure's heap-captured env now
+                    // that its thread has joined (thread_spawn borrows it).
+                    : *u shutdown_env # *u shutdown 1
+                    ( nurl_free # s shutdown_env )
                 }
                 F e → {
                     ( nurl_print `shutdown thread spawn failed: ` )

--- a/stdlib/ext/http_server.nu
+++ b/stdlib/ext/http_server.nu
@@ -939,6 +939,12 @@ $ `stdlib/ext/http_response.nu`
         = j + j 1
     }
     ( nurl_free thandles )
+    // Every worker has joined and the threads shared this one `worker`
+    // closure's heap-captured env (thread_spawn BORROWS it — it is never
+    // freed by the thread). Release it now that no worker can touch it,
+    // mirroring the per-server cleanup contract.
+    : *u worker_env # *u worker 1
+    ( nurl_free # s worker_env )
     ^ @ !v NetErr { T 0 }
 }
 
@@ -1017,8 +1023,16 @@ $ `stdlib/std/async.nu`
     ( tcp_listener_retain . s listener )
     // Spawn one accept fiber; runtime_run blocks until the accept
     // fiber exits AND every in-flight conn fiber drains (pending=0).
-    ( spawn \ → v { ( __async_accept_loop s ) } )
+    // Bind the closure so we can free its heap-captured env afterwards:
+    // `spawn` BORROWS the env (the fiber runtime never frees it), so a
+    // fire-and-forget inline closure here would leak its env once per
+    // server start. runtime_run returns only after the accept fiber has
+    // exited, so the env is safe to release at that point.
+    : ( @ v ) accept_fiber \ → v { ( __async_accept_loop s ) }
+    ( spawn accept_fiber )
     ( runtime_run )
     ( tcp_listener_release . s listener )
+    : *u accept_env # *u accept_fiber 1
+    ( nurl_free # s accept_env )
     ^ @ !v NetErr { T 0 }
 }


### PR DESCRIPTION
Follow-up to the leak observation from #93. `server_run_pool` and `server_run_async` each spawn a long-lived **fire-and-forget closure** (the per-worker body; the accept-loop fiber) and never release its heap-captured environment.

`thread_spawn` / `spawn` **borrow** the env — the runtime frees the fiber *control block* but not the closure *env* (per `stdlib/std/async.nu`'s ownership contract: the caller keeps the binding alive across the run and frees it afterwards). So each call leaked one 88-byte env for the life of the process. Both functions now bind the closure and free its env once the workers have joined / `runtime_run` has drained every fiber — exactly when no thread or fiber can still touch it.

## Investigation notes
- `server_run_pool`'s `thandles` array is **not** leaked (already freed via `nurl_free thandles`); the 88-byte hit was the worker closure env.
- **No per-connection / growing leak**: a 5-connection async probe shows the *same two* one-time leaks as a 1-connection run — the per-conn serve closures are reclaimed. These were benign per-server leaks, not a DoS; fixed for correctness + LeakSanitizer-clean servers.

## Also
The two regression tests free their own closures (`http_server_pool`'s shutdown closure; `async_http_server`'s client + handler closures) so both run **fully LeakSanitizer-clean** under `NURL_NET_TESTS=1`.

## Verification
- `async_http_server` (184 → 0 bytes) and `http_server_pool` (104 → 0 bytes): **ASan + LSan clean**, both still shut down cleanly.
- Full offline suite green, **zero diff**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)