### PR TITLE
feat(stdlib): arbitrary-precision integers (std/bigint) + doc refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ nurl/
 
 ## Name
 
-**NURL** = **N**eural **U**nified **R**epresentation **L**anguage — also
-**N**on-h**U**man **R**eadable **L**anguage. File extension: `.nu`.
+**NURL** = **N**eural **U**nified **R**epresentation **L**anguage. File
+extension: `.nu`.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-06-08 · Current release: **0.9.6** · Language: **Grammar
+_Last reviewed: 2026-06-09 · Current release: **0.9.6** · Language: **Grammar
 v2.2** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---
@@ -92,7 +92,8 @@ platform-specific shims.
 - **core** — `string`, `vec`, `option`, `result`, `errors`, `char`, `slice`,
   `pair`, `box`, `cell`, `mem`, `io`, `symtab`, `posix`.
 - **std/collections & algorithms** — `hashmap`, `set`, `deque`, `heap`,
-  `ordmap`, `iter`, `sort`, `cmp`, `bytes`, `bufio`, `fmt`, `int`, `float`.
+  `ordmap`, `iter`, `sort`, `cmp`, `bytes`, `bufio`, `fmt`, `int`, `float`,
+  `bigint` (arbitrary-precision integers).
 - **std/runtime services** — `async`, `thread`, `channel`, `arc`, `rc`,
   `arena`, `signal`, `panic`/`recover`, `process`, `log` (text + JSON),
   `time` (incl. timezone/DST), `args` (CLI parser).
@@ -108,7 +109,10 @@ platform-specific shims.
   metrics, DoS caps, graceful shutdown, per-request timeouts, panic recovery),
   HTTP client, **TLS** (SNI + ALPN + mTLS + live cert reload), **HTTP/2**
   (RFC 9113 + HPACK, **server and client**), **WebSocket** (RFC 6455, **server
-  and client**), reverse proxy with binary-safe streaming.
+  and client**), reverse proxy with binary-safe streaming. The stack has had a
+  dedicated security-hardening pass (path-traversal, SSRF, request-smuggling,
+  HTTP/2 CONTINUATION-flood + stream-accounting, and clean cross-thread
+  listener shutdown) with regression tests.
 - **ext/data services** — `sqlite` (production-hardened), `postgres` (binary
   protocol, async, LISTEN/NOTIFY, COPY), `mqtt` 5.0 client.
 - **ext/AI & agents** — `mcp` (+ `client`, `http`, `session`, `stdio`,
@@ -180,8 +184,11 @@ Not blocking 1.0; ordered roughly by likely value.
 - **Mobile & embedded targets** — Android (NDK), iOS, and a `no_std`-style
   embedded profile. The RISC-V / ARM64 static cross-compiles already prove the
   shape; these extend it.
-- **Numeric breadth** — arbitrary-precision integers and/or fixed-point
-  decimal. Acceptable to omit for systems work today; tracked for completeness.
+- **Numeric breadth** — arbitrary-precision integers shipped (`std/bigint`:
+  signed, base-2¹⁶ limbs, add/sub/mul, comparison, base-10 parse/format;
+  bignum÷bignum division is the remaining follow-up). Fixed-point decimal is
+  still open. Acceptable to omit for systems work today; tracked for
+  completeness.
 - **Runtime split (organisational)** — separate `stdlib/runtime.c` into
   bootstrap-internal helpers vs. stdlib FFI shims. The PURIFY effort already
   moved most platform code into pure-NURL `& \`c\`` FFI; the file-level split

--- a/compiler/tests/bigint.nu
+++ b/compiler/tests/bigint.nu
@@ -1,0 +1,198 @@
+// bigint.nu — acceptance test for stdlib/std/bigint.nu. Pure computation,
+// no socket, runs ungated. Covers from_i / to_string round-trips across
+// the i64 range (incl. min), add/sub/mul with mixed signs, comparison,
+// base-10 parse beyond i64, and a 25! magnitude check against a known
+// value. main returns the failure count.
+
+$ `stdlib/std/bigint.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/errors.nu`
+
+@ ck_str s label BigInt x s expected ( Vec i ) fails → v {
+    : String got ( bigint_to_string x )
+    ? != 0 ( nurl_str_eq ( string_data got ) expected ) {
+        ( nurl_print `  ok   ` ) ( nurl_print label )
+        ( nurl_print ` = ` ) ( nurl_print expected ) ( nurl_print `\n` )
+    } {
+        ( nurl_print `  FAIL ` ) ( nurl_print label )
+        ( nurl_print ` got ` ) ( nurl_print ( string_data got ) )
+        ( nurl_print ` want ` ) ( nurl_print expected ) ( nurl_print `\n` )
+        ( vec_push [i] fails 1 )
+    }
+    ( string_free got )
+}
+
+@ ck_int s label i got i want ( Vec i ) fails → v {
+    ? == got want {
+        ( nurl_print `  ok   ` ) ( nurl_print label )
+        ( nurl_print ` = ` ) ( nurl_print ( nurl_str_int got ) ) ( nurl_print `\n` )
+    } {
+        ( nurl_print `  FAIL ` ) ( nurl_print label )
+        ( nurl_print ` got ` ) ( nurl_print ( nurl_str_int got ) )
+        ( nurl_print ` want ` ) ( nurl_print ( nurl_str_int want ) ) ( nurl_print `\n` )
+        ( vec_push [i] fails 1 )
+    }
+}
+
+// Parse a decimal literal, asserting it succeeds; on failure record it and
+// return zero so the caller can keep going.
+@ parse_ok s lit ( Vec i ) fails → BigInt {
+    : !BigInt ParseErr r ( bigint_from_string lit )
+    ?? r {
+        T b → { ^ b }
+        F _ → {
+            ( nurl_print `  FAIL parse `  ) ( nurl_print lit ) ( nurl_print `\n` )
+            ( vec_push [i] fails 1 )
+            ^ ( bigint_zero )
+        }
+    }
+}
+
+@ run → i {
+    : ( Vec i ) fails ( vec_new [i] )
+
+    // ── from_i / to_string across the i64 range ──
+    : BigInt z ( bigint_from_i 0 )
+    ( ck_str `0` z `0` fails )
+    ( bigint_free z )
+
+    : BigInt one ( bigint_from_i 1 )
+    ( ck_str `1` one `1` fails )
+    ( bigint_free one )
+
+    : BigInt negone ( bigint_from_i -1 )
+    ( ck_str `-1` negone `-1` fails )
+    ( bigint_free negone )
+
+    : BigInt big ( bigint_from_i 123456789 )
+    ( ck_str `123456789` big `123456789` fails )
+    ( bigint_free big )
+
+    : BigInt nbig ( bigint_from_i -987654321 )
+    ( ck_str `-987654321` nbig `-987654321` fails )
+    ( bigint_free nbig )
+
+    : BigInt imax ( bigint_from_i 9223372036854775807 )
+    ( ck_str `i64max` imax `9223372036854775807` fails )
+    ( bigint_free imax )
+
+    : BigInt imin ( bigint_from_i -9223372036854775808 )
+    ( ck_str `i64min` imin `-9223372036854775808` fails )
+    ( bigint_free imin )
+
+    // ── add ──
+    : BigInt a1 ( bigint_from_i 999999999 )
+    : BigInt b1 ( bigint_from_i 1 )
+    : BigInt s1 ( bigint_add a1 b1 )
+    ( ck_str `999999999+1` s1 `1000000000` fails )
+    ( bigint_free a1 ) ( bigint_free b1 ) ( bigint_free s1 )
+
+    // mixed-sign add that cancels toward negative
+    : BigInt a2 ( bigint_from_i 3 )
+    : BigInt b2 ( bigint_from_i -5 )
+    : BigInt s2 ( bigint_add a2 b2 )
+    ( ck_str `3+(-5)` s2 `-2` fails )
+    ( bigint_free a2 ) ( bigint_free b2 ) ( bigint_free s2 )
+
+    // mixed-sign add that cancels to zero
+    : BigInt a3 ( bigint_from_i -42 )
+    : BigInt b3 ( bigint_from_i 42 )
+    : BigInt s3 ( bigint_add a3 b3 )
+    ( ck_str `-42+42` s3 `0` fails )
+    ( bigint_free a3 ) ( bigint_free b3 ) ( bigint_free s3 )
+
+    // ── sub ──
+    : BigInt d1 ( parse_ok `100000000000000000000` fails )
+    : BigInt d2 ( bigint_from_i 1 )
+    : BigInt ds ( bigint_sub d1 d2 )
+    ( ck_str `1e20 - 1` ds `99999999999999999999` fails )
+    ( bigint_free d1 ) ( bigint_free d2 ) ( bigint_free ds )
+
+    // ── mul ──
+    : BigInt m1 ( bigint_from_i 12345 )
+    : BigInt m2 ( bigint_from_i 67890 )
+    : BigInt mp ( bigint_mul m1 m2 )
+    ( ck_str `12345*67890` mp `838102050` fails )
+    ( bigint_free m1 ) ( bigint_free m2 ) ( bigint_free mp )
+
+    // negative * negative = positive
+    : BigInt n1 ( bigint_from_i -7 )
+    : BigInt n2 ( bigint_from_i -8 )
+    : BigInt np ( bigint_mul n1 n2 )
+    ( ck_str `-7*-8` np `56` fails )
+    ( bigint_free n1 ) ( bigint_free n2 ) ( bigint_free np )
+
+    // negative * positive = negative
+    : BigInt n3 ( bigint_from_i -7 )
+    : BigInt n4 ( bigint_from_i 8 )
+    : BigInt np2 ( bigint_mul n3 n4 )
+    ( ck_str `-7*8` np2 `-56` fails )
+    ( bigint_free n3 ) ( bigint_free n4 ) ( bigint_free np2 )
+
+    // ── 25! via repeated multiply (well beyond i64) ──
+    : ~ BigInt acc ( bigint_from_i 1 )
+    : ~ i k 2
+    ~ <= k 25 {
+        : BigInt kk ( bigint_from_i k )
+        : BigInt next ( bigint_mul acc kk )
+        ( bigint_free acc )
+        ( bigint_free kk )
+        = acc next
+        = k + k 1
+    }
+    ( ck_str `25!` acc `15511210043330985984000000` fails )
+    ( bigint_free acc )
+
+    // ── from_string round-trip beyond i64 ──
+    : BigInt huge ( parse_ok `123456789012345678901234567890` fails )
+    ( ck_str `parse 30-digit` huge `123456789012345678901234567890` fails )
+    ( bigint_free huge )
+
+    : BigInt nhuge ( parse_ok `-123456789012345678901234567890` fails )
+    ( ck_str `parse -30-digit` nhuge `-123456789012345678901234567890` fails )
+    ( bigint_free nhuge )
+
+    // ── comparison ──
+    : BigInt c1 ( parse_ok `100000000000000000000` fails )
+    : BigInt c2 ( parse_ok `99999999999999999999` fails )
+    ( ck_int `cmp 1e20 99..9` ( bigint_cmp c1 c2 ) 1 fails )
+    ( ck_int `cmp 99..9 1e20` ( bigint_cmp c2 c1 ) -1 fails )
+    ( ck_int `cmp eq` ( bigint_cmp c1 c1 ) 0 fails )
+    ( bigint_free c1 ) ( bigint_free c2 )
+
+    : BigInt neg5 ( bigint_from_i -5 )
+    : BigInt pos3 ( bigint_from_i 3 )
+    ( ck_int `cmp -5 vs 3` ( bigint_cmp neg5 pos3 ) -1 fails )
+    : BigInt neg9 ( bigint_from_i -9 )
+    ( ck_int `cmp -5 vs -9` ( bigint_cmp neg5 neg9 ) 1 fails )
+    ( bigint_free neg5 ) ( bigint_free pos3 ) ( bigint_free neg9 )
+
+    // ── parse errors ──
+    : !BigInt ParseErr e1 ( bigint_from_string `` )
+    ?? e1 {
+        T b → { ( nurl_print `  FAIL empty parsed\n` ) ( bigint_free b ) ( vec_push [i] fails 1 ) }
+        F _ → { ( nurl_print `  ok   empty → err\n` ) }
+    }
+    : !BigInt ParseErr e2 ( bigint_from_string `12a34` )
+    ?? e2 {
+        T b → { ( nurl_print `  FAIL 12a34 parsed\n` ) ( bigint_free b ) ( vec_push [i] fails 1 ) }
+        F _ → { ( nurl_print `  ok   12a34 → err\n` ) }
+    }
+    : !BigInt ParseErr e3 ( bigint_from_string `-` )
+    ?? e3 {
+        T b → { ( nurl_print `  FAIL bare-sign parsed\n` ) ( bigint_free b ) ( vec_push [i] fails 1 ) }
+        F _ → { ( nurl_print `  ok   "-" → err\n` ) }
+    }
+
+    : i n ( vec_len [i] fails )
+    ( vec_free [i] fails )
+    ^ n
+}
+
+@ main → i {
+    : i f ( run )
+    ? == f 0 { ( nurl_print `bigint: all checks passed\n` ) }
+            { ( nurl_print `bigint: FAILURES\n` ) }
+    ^ f
+}

--- a/stdlib/std/bigint.nu
+++ b/stdlib/std/bigint.nu
@@ -1,0 +1,375 @@
+// stdlib/std/bigint.nu — arbitrary-precision signed integers.
+//
+// Magnitude is a little-endian vector of base-2^16 limbs (each in
+// [0, 65535]), kept NORMALIZED (no high-order zero limb; the value zero
+// is the empty limb vector). The sign lives in a separate `neg` flag,
+// which is only ever T for a non-zero magnitude — there is no negative
+// zero. Base 2^16 keeps every intermediate (a limb product plus carry)
+// well inside i64, so the arithmetic never relies on unsigned overflow.
+//
+// API:
+//   ( bigint_zero )                       → BigInt
+//   ( bigint_from_i  i n )                → BigInt   (handles i64 min)
+//   ( bigint_from_string s str )          → ! BigInt ParseErr
+//                                            - empty / sign-only → Empty
+//                                            - non-digit byte    → BadFormat
+//   ( bigint_clone   BigInt x )           → BigInt
+//   ( bigint_free    BigInt x )           → v
+//   ( bigint_is_zero BigInt x )           → b
+//   ( bigint_neg     BigInt x )           → BigInt
+//   ( bigint_cmp     BigInt x BigInt y )  → i   (-1 / 0 / +1, signed)
+//   ( bigint_add     BigInt x BigInt y )  → BigInt
+//   ( bigint_sub     BigInt x BigInt y )  → BigInt
+//   ( bigint_mul     BigInt x BigInt y )  → BigInt
+//   ( bigint_to_string BigInt x )         → String  (base 10, signed)
+//
+// Memory: every BigInt OWNS its limb vector. Operations BORROW their
+// arguments (never freed) and return a freshly-allocated BigInt; the
+// caller frees each BigInt it holds with `bigint_free` (mirrors the
+// `http_response_free` / `query_pairs_free` convention — plain structs
+// are not auto-dropped). bigint_to_string returns an OWNED String.
+//
+// Not yet implemented: bignum ÷ bignum division / modulo (Knuth
+// Algorithm D). Division by a single small limb exists internally
+// (__mag_divmod_small_inplace) and powers base-10 formatting; the full
+// quotient is tracked as a follow-up (see ROADMAP "Numeric breadth").
+
+$ `stdlib/core/errors.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/option.nu`
+
+: BigInt {
+    b neg
+    ( Vec i ) limbs
+}
+
+@ __big_base → i { ^ 65536 }
+@ __big_mask → i { ^ 65535 }
+@ __big_shift → i { ^ 16 }
+
+// Safe limb read: out-of-range index reads as 0 (lets add/sub treat a
+// shorter operand as zero-extended).
+@ __limb ( Vec i ) v i k → i {
+    ^ ?? ( vec_get [i] v k ) { T x → x  F _ → 0 }
+}
+
+// Drop high-order zero limbs so the magnitude is canonical (zero = empty).
+@ __norm ( Vec i ) v → v {
+    : ~ i n ( vec_len [i] v )
+    ~ & > n 0 == ( __limb v - n 1 ) 0 { = n - n 1 }
+    : b _sl ( vec_set_len [i] v n )
+}
+
+@ __mag_clone ( Vec i ) a → ( Vec i ) {
+    : i n ( vec_len [i] a )
+    : ( Vec i ) out ( vec_with_cap [i] n )
+    : ~ i k 0
+    ~ < k n {
+        ( vec_push [i] out ( __limb a k ) )
+        = k + k 1
+    }
+    ^ out
+}
+
+// Compare two NORMALIZED magnitudes: -1 / 0 / +1.
+@ __mag_cmp ( Vec i ) a ( Vec i ) b → i {
+    : i na ( vec_len [i] a )
+    : i nb ( vec_len [i] b )
+    ? > na nb { ^ 1 } {}
+    ? < na nb { ^ -1 } {}
+    : ~ i k - na 1
+    : ~ i res 0
+    : ~ b done F
+    ~ & ! done >= k 0 {
+        : i av ( __limb a k )
+        : i bv ( __limb b k )
+        ? > av bv { = res 1 = done T } {}
+        ? & ! done < av bv { = res -1 = done T } {}
+        = k - k 1
+    }
+    ^ res
+}
+
+// Magnitude add (a + b), schoolbook with carry.
+@ __mag_add ( Vec i ) a ( Vec i ) b → ( Vec i ) {
+    : i na ( vec_len [i] a )
+    : i nb ( vec_len [i] b )
+    : i n ? > na nb na nb
+    : ( Vec i ) out ( vec_with_cap [i] + n 1 )
+    : ~ i carry 0
+    : ~ i k 0
+    ~ < k n {
+        : i s + + ( __limb a k ) ( __limb b k ) carry
+        ( vec_push [i] out & s ( __big_mask ) )
+        = carry >> s ( __big_shift )
+        = k + k 1
+    }
+    ? > carry 0 { ( vec_push [i] out carry ) } {}
+    ( __norm out )
+    ^ out
+}
+
+// Magnitude sub (a - b), REQUIRES a >= b. Borrow propagation.
+@ __mag_sub ( Vec i ) a ( Vec i ) b → ( Vec i ) {
+    : i na ( vec_len [i] a )
+    : ( Vec i ) out ( vec_with_cap [i] na )
+    : ~ i borrow 0
+    : ~ i k 0
+    ~ < k na {
+        : ~ i d - - ( __limb a k ) ( __limb b k ) borrow
+        ? < d 0 { = d + d ( __big_base ) = borrow 1 } { = borrow 0 }
+        ( vec_push [i] out d )
+        = k + k 1
+    }
+    ( __norm out )
+    ^ out
+}
+
+// Magnitude mul (a * b), schoolbook. Empty operand → zero.
+@ __mag_mul ( Vec i ) a ( Vec i ) b → ( Vec i ) {
+    : i na ( vec_len [i] a )
+    : i nb ( vec_len [i] b )
+    ? | == na 0 == nb 0 { ^ ( vec_new [i] ) } {}
+    : ( Vec i ) out ( vec_with_cap [i] + na nb )
+    : ~ i z 0
+    ~ < z + na nb {
+        ( vec_push [i] out 0 )
+        = z + z 1
+    }
+    // No more pushes past here → the data pointer stays valid.
+    : *i op ( vec_data [i] out )
+    : ~ i i 0
+    ~ < i na {
+        : i ai ( __limb a i )
+        : ~ i carry 0
+        : ~ i j 0
+        ~ < j nb {
+            : i idx + i j
+            : i prod + + # i . op idx * ai ( __limb b j ) carry
+            = . op idx & prod ( __big_mask )
+            = carry >> prod ( __big_shift )
+            = j + j 1
+        }
+        : ~ i idx2 + i nb
+        ~ > carry 0 {
+            : i s2 + # i . op idx2 carry
+            = . op idx2 & s2 ( __big_mask )
+            = carry >> s2 ( __big_shift )
+            = idx2 + idx2 1
+        }
+        = i + i 1
+    }
+    ( __norm out )
+    ^ out
+}
+
+// Divide a magnitude by a single small divisor (1 <= d < 2^16) IN PLACE;
+// `a` becomes the quotient (normalized) and the remainder is returned.
+@ __mag_divmod_small_inplace ( Vec i ) a i d → i {
+    : i n ( vec_len [i] a )
+    ? == n 0 { ^ 0 } {}
+    : *i ap ( vec_data [i] a )
+    : ~ i rem 0
+    : ~ i k - n 1
+    ~ >= k 0 {
+        : i cur + * rem ( __big_base ) # i . ap k
+        = . ap k / cur d
+        = rem % cur d
+        = k - k 1
+    }
+    ( __norm a )
+    ^ rem
+}
+
+// a := a * m + add IN PLACE, with small m and add (used by parsing).
+@ __mag_mul_add_small_inplace ( Vec i ) a i m i add → v {
+    : i n ( vec_len [i] a )
+    : ~ i carry add
+    ? > n 0 {
+        : *i ap ( vec_data [i] a )
+        : ~ i k 0
+        ~ < k n {
+            : i cur + * # i . ap k m carry
+            = . ap k & cur ( __big_mask )
+            = carry >> cur ( __big_shift )
+            = k + k 1
+        }
+    } {}
+    ~ > carry 0 {
+        ( vec_push [i] a & carry ( __big_mask ) )
+        = carry >> carry ( __big_shift )
+    }
+    ( __norm a )
+}
+
+// ── Public constructors ───────────────────────────────────────────────
+
+@ bigint_zero → BigInt {
+    ^ @ BigInt { F ( vec_new [i] ) }
+}
+
+@ bigint_from_i i n → BigInt {
+    // i64 min: |n| = 2^63 = limbs [0, 0, 0, 0x8000]; -n would overflow.
+    ? == n -9223372036854775808 {
+        : ( Vec i ) lm ( vec_new [i] )
+        ( vec_push [i] lm 0 )
+        ( vec_push [i] lm 0 )
+        ( vec_push [i] lm 0 )
+        ( vec_push [i] lm 32768 )
+        ^ @ BigInt { T lm }
+    } {}
+    : ~ b neg F
+    : ~ i mag n
+    ? < n 0 { = neg T = mag - 0 n } {}
+    : ( Vec i ) lm ( vec_new [i] )
+    ~ > mag 0 {
+        ( vec_push [i] lm & mag ( __big_mask ) )
+        = mag >> mag ( __big_shift )
+    }
+    ^ @ BigInt { neg lm }
+}
+
+@ bigint_clone BigInt x → BigInt {
+    ^ @ BigInt { . x neg ( __mag_clone . x limbs ) }
+}
+
+@ bigint_free BigInt x → v {
+    ( vec_free [i] . x limbs )
+}
+
+@ bigint_is_zero BigInt x → b {
+    ^ == ( vec_len [i] . x limbs ) 0
+}
+
+@ bigint_neg BigInt x → BigInt {
+    : ( Vec i ) lm ( __mag_clone . x limbs )
+    : b neg & ! . x neg > ( vec_len [i] lm ) 0
+    ^ @ BigInt { neg lm }
+}
+
+// ── Comparison ────────────────────────────────────────────────────────
+
+@ bigint_cmp BigInt x BigInt y → i {
+    : b xz ( bigint_is_zero x )
+    : b yz ( bigint_is_zero y )
+    ? & xz yz { ^ 0 } {}
+    : b xn & ! xz . x neg
+    : b yn & ! yz . y neg
+    ? & xn ! yn { ^ -1 } {}
+    ? & ! xn yn { ^ 1 } {}
+    : i mc ( __mag_cmp . x limbs . y limbs )
+    // Both negative → larger magnitude is the smaller value.
+    ? xn { ^ - 0 mc } {}
+    ^ mc
+}
+
+// ── Arithmetic ────────────────────────────────────────────────────────
+
+@ bigint_add BigInt x BigInt y → BigInt {
+    ? == . x neg . y neg {
+        // Same sign: add magnitudes, keep the sign (zero stays positive).
+        : ( Vec i ) m ( __mag_add . x limbs . y limbs )
+        : b neg & . x neg > ( vec_len [i] m ) 0
+        ^ @ BigInt { neg m }
+    } {}
+    // Opposite signs: subtract the smaller magnitude from the larger; the
+    // result takes the sign of the larger magnitude.
+    : i c ( __mag_cmp . x limbs . y limbs )
+    ? == c 0 { ^ ( bigint_zero ) } {}
+    ? > c 0 {
+        ^ @ BigInt { . x neg ( __mag_sub . x limbs . y limbs ) }
+    } {}
+    ^ @ BigInt { . y neg ( __mag_sub . y limbs . x limbs ) }
+}
+
+@ bigint_sub BigInt x BigInt y → BigInt {
+    : BigInt ny ( bigint_neg y )
+    : BigInt r ( bigint_add x ny )
+    ( bigint_free ny )
+    ^ r
+}
+
+@ bigint_mul BigInt x BigInt y → BigInt {
+    : ( Vec i ) m ( __mag_mul . x limbs . y limbs )
+    : b neg & != . x neg . y neg > ( vec_len [i] m ) 0
+    ^ @ BigInt { neg m }
+}
+
+// ── Formatting / parsing ──────────────────────────────────────────────
+
+// Append `g` (0..9999) as exactly four decimal digits (zero-padded).
+@ __push_group4 String out i g → v {
+    ( string_push_char out + 48 / g 1000 )
+    ( string_push_char out + 48 % / g 100 10 )
+    ( string_push_char out + 48 % / g 10 10 )
+    ( string_push_char out + 48 % g 10 )
+}
+
+// Append `g` (1..9999) with no leading zeros — for the leading group.
+@ __push_group_lead String out i g → v {
+    ? >= g 1000 { ( string_push_char out + 48 / g 1000 ) } {}
+    ? >= g 100 { ( string_push_char out + 48 % / g 100 10 ) } {}
+    ? >= g 10 { ( string_push_char out + 48 % / g 10 10 ) } {}
+    ( string_push_char out + 48 % g 10 )
+}
+
+@ bigint_to_string BigInt x → String {
+    ? ( bigint_is_zero x ) {
+        : String z ( string_new )
+        ( string_push_char z 48 )
+        ^ z
+    } {}
+    // Repeatedly divide a working copy by 10000, collecting base-10000
+    // groups little-endian.
+    : ( Vec i ) work ( __mag_clone . x limbs )
+    : ( Vec i ) groups ( vec_new [i] )
+    ~ > ( vec_len [i] work ) 0 {
+        : i r ( __mag_divmod_small_inplace work 10000 )
+        ( vec_push [i] groups r )
+    }
+    ( vec_free [i] work )
+    : String out ( string_new )
+    ? . x neg { ( string_push_char out 45 ) } {}
+    : i ng ( vec_len [i] groups )
+    : ~ i gi - ng 1
+    : ~ b first T
+    ~ >= gi 0 {
+        : i g ( __limb groups gi )
+        ? first {
+            ( __push_group_lead out g )
+            = first F
+        } {
+            ( __push_group4 out g )
+        }
+        = gi - gi 1
+    }
+    ( vec_free [i] groups )
+    ^ out
+}
+
+@ bigint_from_string s str → !BigInt ParseErr {
+    : i n ( nurl_str_len str )
+    ? == n 0 { ^ @ !BigInt ParseErr { F @ ParseErr { Empty } } } {}
+    : ~ i i 0
+    : ~ b neg F
+    : i c0 ( nurl_str_get str 0 )
+    ? == c0 45 { = neg T = i 1 } {}
+    ? == c0 43 { = i 1 } {}
+    ? >= i n { ^ @ !BigInt ParseErr { F @ ParseErr { Empty } } } {}
+    : ( Vec i ) mag ( vec_new [i] )
+    : ~ b ok T
+    ~ & ok < i n {
+        : i ch ( nurl_str_get str i )
+        ? & >= ch 48 <= ch 57 {
+            ( __mag_mul_add_small_inplace mag 10 - ch 48 )
+        } { = ok F }
+        = i + i 1
+    }
+    ? ! ok {
+        ( vec_free [i] mag )
+        ^ @ !BigInt ParseErr { F @ ParseErr { BadFormat } }
+    } {}
+    : b fneg & neg > ( vec_len [i] mag ) 0
+    ^ @ !BigInt ParseErr { T @ BigInt { fneg mag } }
+}


### PR DESCRIPTION
Implements a roadmap **Numeric breadth** item (arbitrary-precision integers), plus the requested doc touch-ups.

## `std/bigint.nu` — arbitrary-precision signed integers
- Magnitude as a little-endian **base-2¹⁶ limb vector** (`Vec[i]`), kept normalized (no negative zero); sign in a separate flag. Base 2¹⁶ keeps every limb product + carry well inside i64, so the arithmetic never relies on unsigned overflow.
- **API:** `bigint_from_i` (handles i64 min), `bigint_from_string` / `bigint_to_string` (base 10), `clone`, `free`, `is_zero`, `neg`, `cmp` (signed), `add`, `sub`, `mul`.
- Ownership mirrors the stdlib convention (`http_response_free` / `query_pairs_free`): operations **borrow** their args and return a freshly-allocated `BigInt` the caller frees with `bigint_free`.
- **Follow-up:** bignum ÷ bignum division/modulo (Knuth Algorithm D). Division by a single small limb exists internally and powers base-10 formatting.

## `compiler/tests/bigint.nu` — 24 offline checks
from_i/to_string across the i64 range (incl. min), mixed-sign add/sub/mul, cancellation to zero and to negative, comparison, base-10 parse **beyond i64** round-trip, **25!** against a known value, and parse-error cases (`""`, `"12a34"`, `"-"`). **ASan + UBSan + LSan clean.**

## Docs
- **README** — drop the "Non-hUman Readable Language" gloss from the *Name* section (keep "Neural Unified Representation Language").
- **ROADMAP** — bump review date to 2026-06-09; add `bigint` to the std inventory; move arbitrary-precision integers from *Planned* to shipped (fixed-point decimal stays open); note the HTTP stack's security-hardening pass (#92–#94).

## Verification
Full bootstrap **fixed point** + offline suite green; the new test is purely additive (`+=== bigint === / +EXIT 0`, nothing else changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)