### PR TITLE
fix(mcp): bulletproofing pass — root-cause fixes across the MCP stack

### DIFF
--- a/compiler/tests/mcp_hardening.nu
+++ b/compiler/tests/mcp_hardening.nu
@@ -1,0 +1,116 @@
+// mcp_hardening.nu — regressions for the MCP bulletproofing pass.
+//
+//   1. Registry handler panic-guard. A tool handler that PANICS must yield a
+//      tool-error envelope (isError:true) — never unwind the dispatch, which
+//      over stdio would crash the whole MCP server process. A handler that
+//      SUCCEEDS must still return its real result (the panic guard carries
+//      the value out of the recover closure through a shared-ctl Vec sink;
+//      a naive `= result ...` inside the closure does NOT propagate, so the
+//      success case is the load-bearing half of this test).
+//   2. Reverse-RPC id gating. mcp_session_resolve_rpc must REJECT a response
+//      whose id was never issued (forged / non-pending — otherwise a client
+//      floods the results queue and can inject forged results), while still
+//      settling a genuinely-pending reverse RPC.
+//
+// main returns the failure count (0 = pass).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/panic.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/mcp.nu`
+$ `stdlib/ext/mcp_registry.nu`
+$ `stdlib/ext/mcp_session.nu`
+
+@ echo_handler Json args → Json {
+    ^ ( mcp_tool_result_text `HELLO_REAL` )
+}
+
+// A tool handler that always panics. Handlers BORROW args (the dispatcher
+// frees it), so we must NOT free args here.
+@ boom_handler Json args → Json {
+    ( panic `kaboom` )
+    ^ ( json_null )
+}
+
+// Pull the first content item's `text` out of a tool-result envelope.
+@ first_text Json res → s {
+    : ?Json c ( json_obj_get res `content` )
+    ^ ?? c {
+        T arr → {
+            : ?Json e0 ( json_arr_get arr 0 )
+            ^ ?? e0 {
+                T el → {
+                    : ?Json t ( json_obj_get el `text` )
+                    ^ ?? t { T tj → ( json_str_data tj ) F → `(notext)` }
+                }
+                F → `(noel)`
+            }
+        }
+        F → `(nocontent)`
+    }
+}
+
+@ call_tool McpRegistry r s name → Json {
+    : Json p ( json_obj_new )
+    ( json_obj_set p `name` ( json_str_lit name ) )
+    ( json_obj_set p `arguments` ( json_obj_new ) )
+    : Json out ( mcp_registry_dispatch r `tools/call` @ ?Json { T p } )
+    ( json_free p )
+    ^ out
+}
+
+@ run → i {
+    : ~ i fails 0
+
+    : McpRegistry r ( mcp_registry_new `t` `1.0` )
+    ( mcp_registry_add_tool r `echo` `ok` ( json_obj_new ) \ Json a → Json { ^ ( echo_handler a ) } )
+    ( mcp_registry_add_tool r `boom` `panics` ( json_obj_new ) \ Json a → Json { ^ ( boom_handler a ) } )
+
+    // 1a. Success path must return the real result.
+    : Json r1 ( call_tool r `echo` )
+    : s t1 ( first_text r1 )
+    ? != 0 ( nurl_str_eq t1 `HELLO_REAL` ) { ( puts `ok: success tool returned real result` ) }
+    { ( nurl_eprintln ( nurl_str_cat `FAIL: success path got: ` t1 ) ) = fails + fails 1 }
+    ( json_free r1 )
+
+    // 1b. Panic path must return an isError envelope, not crash.
+    : Json r2 ( call_tool r `boom` )
+    : ?Json ie ( json_obj_get r2 `isError` )
+    ?? ie {
+        T j → {
+            ? ( json_as_bool j ) { ( puts `ok: tool panic returned isError` ) }
+            { ( nurl_eprintln `FAIL: isError not true` ) = fails + fails 1 }
+        }
+        F → { ( nurl_eprintln `FAIL: no isError field` ) = fails + fails 1 }
+    }
+    ( json_free r2 )
+    ( mcp_registry_free r )
+
+    // 2. resolve_rpc rejects a non-pending (forged) id, settles a pending one.
+    : McpSessionStore st ( mcp_session_store_new )
+    : String sid ( mcp_session_create st )
+    : s sids ( string_data sid )
+
+    : Json forged ( json_obj_new )
+    ( json_obj_set forged `id` ( json_int 999 ) )
+    ( json_obj_set forged `result` ( json_obj_new ) )
+    : b accepted ( mcp_session_resolve_rpc st sids forged )
+    ? accepted { ( nurl_eprintln `FAIL: forged response accepted` ) = fails + fails 1 }
+    { ( puts `ok: forged reverse-RPC response rejected` ) }
+
+    : Json p ( json_obj_new )
+    : i rid ( mcp_session_begin_rpc st sids `sampling/createMessage` p )
+    : Json good ( json_obj_new )
+    ( json_obj_set good `id` ( json_int rid ) )
+    ( json_obj_set good `result` ( json_obj_new ) )
+    : b ok2 ( mcp_session_resolve_rpc st sids good )
+    ? ok2 { ( puts `ok: pending reverse-RPC response settled` ) }
+    { ( nurl_eprintln `FAIL: pending response rejected` ) = fails + fails 1 }
+
+    ( string_free sid )
+    ( mcp_session_store_free st )
+    ^ fails
+}
+
+@ main → i { ^ ( run ) }

--- a/stdlib/ext/mcp_registry.nu
+++ b/stdlib/ext/mcp_registry.nu
@@ -38,6 +38,7 @@
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/mem.nu`
+$ `stdlib/std/panic.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/mcp.nu`
 $ `stdlib/ext/http.nu`
@@ -355,7 +356,29 @@ $ `stdlib/ext/http_response.nu`
     : *McpTool tp ( vec_data [McpTool] . r tools )
     : McpTool t . tp idx
     : ( @ Json Json ) h . t handler
-    : Json result ( h args )
+    // Run the user handler under `recover` so a panic inside it doesn't
+    // unwind the dispatch — which over stdio (mcp_serve_stdio has no outer
+    // recover) would kill the whole server process. The handler's result is
+    // carried OUT of the recover closure through a shared-ctl Vec sink: a
+    // closure captures locals by value, so a direct `= result ...` inside it
+    // would NOT propagate, but `vec_push` mutates the Vec's shared control
+    // block in place and does. An empty sink after recover means the handler
+    // panicked, so the stock tool-error envelope stands.
+    : ( Vec Json ) sink ( vec_with_cap [Json] 1 )
+    : !v PanicInfo pr ( recover \ → v { ( vec_push [Json] sink ( h args ) ) } )
+    : ~ Json result ( mcp_tool_result_error `tool handler panicked` )
+    ?? pr {
+        T _ → {}
+        F p → {
+            ( mcp_log ( nurl_str_cat `tool handler panicked: ` ( string_data . p msg ) ) )
+            ( panic_info_free p )
+        }
+    }
+    ? > ( vec_len [Json] sink ) 0 {
+        : ?Json e0 ( vec_get [Json] sink 0 )
+        ?? e0 { T jv → { ( json_free result ) = result jv } F → {} }
+    } {}
+    ( vec_free [Json] sink )
     ( json_free args )
     ^ result
 }
@@ -417,7 +440,27 @@ $ `stdlib/ext/http_response.nu`
     : *McpPrompt pp ( vec_data [McpPrompt] . r prompts )
     : McpPrompt p . pp idx
     : ( @ Json Json ) h . p handler
-    : Json result ( h args )
+    // Panic-guard via a shared-ctl Vec sink (see __mcp_dispatch_tools_call
+    // for why a direct closure assignment can't carry the value out). On
+    // panic the default `__error__` shape — which the envelope layer maps to
+    // a JSON-RPC error — stands.
+    : ( Vec Json ) sink ( vec_with_cap [Json] 1 )
+    : !v PanicInfo pr ( recover \ → v { ( vec_push [Json] sink ( h args ) ) } )
+    : Json perr ( json_obj_new )
+    ( json_obj_set perr `__error__` ( json_str_lit `prompt handler panicked` ) )
+    : ~ Json result perr
+    ?? pr {
+        T _ → {}
+        F pi → {
+            ( mcp_log ( nurl_str_cat `prompt handler panicked: ` ( string_data . pi msg ) ) )
+            ( panic_info_free pi )
+        }
+    }
+    ? > ( vec_len [Json] sink ) 0 {
+        : ?Json e0 ( vec_get [Json] sink 0 )
+        ?? e0 { T jv → { ( json_free result ) = result jv } F → {} }
+    } {}
+    ( vec_free [Json] sink )
     ( json_free args )
     ^ result
 }
@@ -472,7 +515,28 @@ $ `stdlib/ext/http_response.nu`
     : *McpResource rp ( vec_data [McpResource] . r resources )
     : McpResource res . rp idx
     : ( @ Json ) h . res handler
-    : Json content ( h )
+    // Panic-guard via a shared-ctl Vec sink (see __mcp_dispatch_tools_call).
+    // An empty sink after recover means the handler panicked → return the
+    // bare `__error__` object; otherwise post-process the content and wrap
+    // it in the spec-shaped {contents:[...]} envelope.
+    : ( Vec Json ) sink ( vec_with_cap [Json] 1 )
+    : !v PanicInfo pr ( recover \ → v { ( vec_push [Json] sink ( h ) ) } )
+    ?? pr {
+        T _ → {}
+        F pi → {
+            ( mcp_log ( nurl_str_cat `resource handler panicked: ` ( string_data . pi msg ) ) )
+            ( panic_info_free pi )
+        }
+    }
+    ? <= ( vec_len [Json] sink ) 0 {
+        ( vec_free [Json] sink )
+        : Json rerr ( json_obj_new )
+        ( json_obj_set rerr `__error__` ( json_str_lit `resource handler panicked` ) )
+        ^ rerr
+    } {}
+    : ?Json c0 ( vec_get [Json] sink 0 )
+    : Json content ?? c0 { T jv → jv F → ( json_null ) }
+    ( vec_free [Json] sink )
     // Ensure the content has the expected fields. If handler didn't
     // include `uri` / `mimeType`, splice them in from the registry.
     : ?Json have_uri ( json_obj_get content `uri` )
@@ -545,7 +609,25 @@ $ `stdlib/ext/http_response.nu`
     : *McpCompletion cp ( vec_data [McpCompletion] . r completions )
     : McpCompletion c . cp idx
     : ( @ Json Json ) h . c handler
-    : ~ Json values ( h arg )
+    // Panic-guard via a shared-ctl Vec sink (see __mcp_dispatch_tools_call).
+    // `values` defaults to an empty array — completion is a hint, so a broken
+    // provider must not take the connection (or stdio process) down; an empty
+    // sink after recover means the handler panicked.
+    : ( Vec Json ) sink ( vec_with_cap [Json] 1 )
+    : !v PanicInfo pr ( recover \ → v { ( vec_push [Json] sink ( h arg ) ) } )
+    : ~ Json values ( json_arr_new )
+    ?? pr {
+        T _ → {}
+        F pi → {
+            ( mcp_log ( nurl_str_cat `completion handler panicked: ` ( string_data . pi msg ) ) )
+            ( panic_info_free pi )
+        }
+    }
+    ? > ( vec_len [Json] sink ) 0 {
+        : ?Json e0 ( vec_get [Json] sink 0 )
+        ?? e0 { T jv → { ( json_free values ) = values jv } F → {} }
+    } {}
+    ( vec_free [Json] sink )
     ( json_free arg )
     // Defensive: a provider that returns a non-array gets an empty list.
     ? ( json_is_arr values ) {} { ( json_free values ) = values ( json_arr_new ) }
@@ -771,15 +853,20 @@ $ `stdlib/ext/http_response.nu`
                 {
                     : i tlen ( nurl_str_len expected_token )
                     ? == - avn 7 tlen {
-                        : ~ b match T
+                        // Constant-time compare: accumulate byte differences
+                        // with no early exit, so the loop's duration does not
+                        // leak how many leading bytes matched (a timing oracle
+                        // that recovers the token byte-by-byte). `diff` stays 0
+                        // iff every byte is equal. Length is checked above —
+                        // leaking token length is standard (cf. compare_digest).
+                        : ~ i diff 0
                         : ~ i k 0
-                        ~ & match < k tlen {
-                            ? != ( nurl_str_get avs + 7 k )
+                        ~ < k tlen {
+                            = diff | diff - ( nurl_str_get avs + 7 k )
                             ( nurl_str_get expected_token k )
-                            { = match F } {}
                             = k + k 1
                         }
-                        ? match { = ok T } {}
+                        ? == diff 0 { = ok T } {}
                     } {}
                 } {}
                 ( string_free av )

--- a/stdlib/ext/mcp_session.nu
+++ b/stdlib/ext/mcp_session.nu
@@ -96,7 +96,46 @@ $ `stdlib/core/vec.nu`
     ^ res
 }
 
+// Hard cap on concurrent sessions. `initialize` is unauthenticated, so an
+// abusive client could otherwise mint sessions without bound — each owns a
+// String id plus four Vecs — and exhaust memory. At the cap a fresh
+// `initialize` evicts the least-recently-active session (smallest
+// `last_ms`) so a flood of new sessions can't push out genuinely-active
+// clients ahead of idle ones. `last_ms` is stamped at creation and kept
+// fresh by `mcp_session_touch`; sized for a local / loopback MCP server.
+@ mcp_session_max → i { ^ 4096 }
+
+// Drop the least-recently-active session to make room. Caller guarantees a
+// non-empty store. Frees the evicted session's owned Json / String state.
+@ __mcp_session_evict_lru McpSessionStore store → v {
+    : i n ( vec_len [McpSession] . store sessions )
+    ? > n 0 {
+        : ~ i victim 0
+        : ~ i oldest 0
+        : ~ b have F
+        : ~ i k 0
+        ~ < k n {
+            : ?McpSession so ( vec_get [McpSession] . store sessions k )
+            ?? so {
+                T se → {
+                    ? | ! have < . se last_ms oldest
+                    { = oldest . se last_ms = victim k = have T } {}
+                }
+                F → {}
+            }
+            = k + k 1
+        }
+        : ?McpSession vo ( vec_get [McpSession] . store sessions victim )
+        ?? vo { T se → ( __mcp_session_free se ) F → {} }
+        ( vec_remove [McpSession] . store sessions victim )
+    } {}
+}
+
 @ mcp_session_create McpSessionStore store → String {
+    // Bound the store before adding — evict the LRU session at the cap.
+    ? >= ( vec_len [McpSession] . store sessions ) ( mcp_session_max ) {
+        ( __mcp_session_evict_lru store )
+    } {}
     // 32 hex chars of CSPRNG output — collision-free for any realistic
     // server lifetime, and opaque per the MCP spec.
     : String id ( rand_hex_str 16 )
@@ -369,9 +408,16 @@ $ `stdlib/core/vec.nu`
     : ?McpSession so ( vec_get [McpSession] . store sessions idx )
     ?? so {
         T se → {
-            ( vec_push [Json] . se results response )
+            // Only accept a response whose id matches an OUTSTANDING
+            // reverse-RPC request we actually issued. Without this gate a
+            // client can POST unlimited responses carrying ids we never
+            // sent — each piles into `results` unbounded (memory DoS), and
+            // a forged result could be picked up by a later caller that
+            // reuses the id. A non-pending id is dropped.
             : i pi ( __mcp_pending_index . se pending_ids rid )
-            ? >= pi 0 { ( vec_remove [i] . se pending_ids pi ) } {}
+            ? < pi 0 { ( json_free response ) ^ F } {}
+            ( vec_remove [i] . se pending_ids pi )
+            ( vec_push [Json] . se results response )
             ^ T
         }
         F → { ( json_free response ) ^ F }


### PR DESCRIPTION
## MCP-stack bulletproofing pass

A fresh deep audit of the MCP stack (core protocol, stateful session store +
reverse RPC, registry framework, HTTP/stdio transports). Four distinct root
causes fixed at the source — no shims.

### Fixes

**1. `mcp_session.nu` — reverse-RPC forged-result injection + unbounded growth**
`mcp_session_resolve_rpc` pushed **every** client response into the session's
`results` queue, consulting `pending_ids` only to clear a marker. A client
could POST unlimited JSON-RPC responses carrying ids the server never issued:
each piled into `results` without bound (memory DoS), and a forged result
could be picked up by a later caller reusing the id. A response is now accepted
**only** when its id matches an outstanding (pending) reverse RPC; anything else
is freed and rejected.

**2. `mcp_session.nu` — unbounded session store**
`initialize` is unauthenticated, so a client could mint sessions without limit
(each owns a String id + four Vecs) and exhaust memory. Added a hard cap
(`mcp_session_max` = 4096); at the cap a fresh `initialize` evicts the
least-recently-active session (smallest `last_ms`) so a flood can't push out
genuinely-active clients ahead of idle ones.

**3. `mcp_registry.nu` — Bearer-token timing side-channel**
`mcp_http_with_bearer_auth` compared the token with an early-exit loop, so the
comparison's duration leaked how many leading bytes matched — a classic
byte-by-byte token-recovery oracle. Replaced with a constant-time compare that
accumulates byte differences over the full token length with no data-dependent
branch.

**4. `mcp_registry.nu` — handler panics crashed the stdio server**
The HTTP transport runs under the HTTP/1.1 server's `recover` backstop, but
`mcp_serve_stdio` has none, so a panic inside any registered tool / prompt /
resource / completion handler unwound the dispatch and killed the whole MCP
server process. All four handler call-sites now run under `recover` and return
the method's natural error shape on panic — the server stays up.

> **Implementation note.** NURL closures capture locals **by value**, so a
> direct `= result ( h args )` inside the recover closure does **not** propagate
> the handler's return value out (verified: even the HTTP/1.1 server's
> single-assignment shape fails to propagate in this context). The value is
> instead carried out through a **shared-ctl Vec sink** — `vec_push` mutates the
> Vec's shared control block in place, which is visible after `recover` returns.
> An empty sink is the panic signal. This also avoids the per-call leak the
> default-value shape has (it frees the unused default before reassigning).

### Audit notes (verified already-safe, no change)
- Session ids use the OS CSPRNG (`getrandom` / `arc4random_buf` /
  `BCryptGenRandom`), not a predictable PRNG.
- `json_parse` enforces `JSON_MAX_DEPTH` (1024) against nested-payload stack
  overflow.
- Response-header CRLF injection is blocked at the serializer choke point
  (`__push_header_no_crlf`), so echoing a client `Mcp-Session-Id` is safe.

### Validation
- Full `./build.sh` (bootstrap fixed-point + entire test suite) **green**.
- New `mcp_hardening.nu` regression covers the load-bearing cases: a panicking
  tool → `isError` (no crash), a **succeeding** tool still returns its real
  result (the Vec-sink propagation), and forged-vs-pending reverse-RPC gating.
- Zero pre-existing tests regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
