### PR TITLE
feat(stdlib): bigint division/modulo (Knuth Algorithm D) + fix recover env leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`std/bigint`: arbitrary-precision division and modulo** —
+  `bigint_div` / `bigint_rem` (`stdlib/std/bigint.nu`), closing the last
+  gap in the bigint arithmetic surface. The magnitude core is Knuth
+  Algorithm D (TAOCP vol. 2, §4.3.1) over the base-2¹⁶ limbs: D1
+  normalization reuses the existing small-multiply helper (top divisor
+  limb ≥ base/2, so every trial digit is off by at most one), the
+  multiply-and-subtract step uses a per-limb {0,1} borrow (no negative
+  shifts), and the rare add-back step is exercised by both classic
+  Hacker's Delight `divmnu` trigger vectors. A single-limb divisor
+  short-circuits through `__mag_divmod_small_inplace`. Semantics are
+  truncated division exactly like the native `/` and `%`: the quotient
+  rounds toward zero, the remainder takes the dividend's sign, and
+  `x == (x/y)*y + x%y` holds for every `y ≠ 0`. Division by zero panics
+  (recoverable via `recover`) — a defect, not a data error, so it is not
+  threaded through `!`. Regression `compiler/tests/bigint_div.nu`: all
+  four sign combinations, zero/`a<b`/exact edges, both add-back vectors,
+  a 39-digit ÷ 21-digit case, a 60-round deterministic invariant sweep
+  (reconstruction, `|r| < |y|`, remainder sign) over growing multi-limb
+  operands, and the recovered divide-by-zero panic; ASan+UBSan clean,
+  leak-free. Additionally verified against Python on 300 random cases
+  (mixed limb counts/signs, near-power-of-2¹⁶ divisors).
+
 ### Fixed
+
+- **`recover` leaked the closure's captured environment**
+  (`stdlib/std/panic.nu`). `recover` decomposes its closure into
+  `(fn_ptr, env_ptr)` and hands them to the C trampoline; passing the
+  raw env pointer onward suppresses the parameter's auto-drop (the
+  compiler must assume the env escapes — and in `thread_spawn`, whose
+  shape this mirrors, it really does). But `nurl_recover` is
+  synchronous: once it returns, the closure can never run again, so the
+  env was simply leaked — one allocation per `recover` call with a
+  capturing closure, panic or not. `recover` now frees the env right
+  after `nurl_recover` returns (NULL-safe for capture-less closures),
+  on both the normal and the unwind path. Found via ASan on the new
+  `bigint_div` divide-by-zero regression; the existing
+  `recover_basic` / `http_server_panic` goldens are unaffected (output
+  is unchanged — only the leak is gone).
 
 - **HTTP/1.1 server hardening — four root-cause bug fixes from a focused
   security bughunt** (`stdlib/ext/http_request.nu`, `http_server.nu`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -185,8 +185,8 @@ Not blocking 1.0; ordered roughly by likely value.
   embedded profile. The RISC-V / ARM64 static cross-compiles already prove the
   shape; these extend it.
 - **Numeric breadth** — arbitrary-precision integers shipped (`std/bigint`:
-  signed, base-2¹⁶ limbs, add/sub/mul, comparison, base-10 parse/format;
-  bignum÷bignum division is the remaining follow-up). Fixed-point decimal is
+  signed, base-2¹⁶ limbs, add/sub/mul, truncated div/rem via Knuth
+  Algorithm D, comparison, base-10 parse/format). Fixed-point decimal is
   still open. Acceptable to omit for systems work today; tracked for
   completeness.
 - **Runtime split (organisational)** — separate `stdlib/runtime.c` into

--- a/compiler/tests/bigint_div.nu
+++ b/compiler/tests/bigint_div.nu
@@ -1,0 +1,248 @@
+// bigint_div.nu — acceptance test for bigint_div / bigint_rem
+// (stdlib/std/bigint.nu, Knuth Algorithm D). Pure computation, runs
+// ungated. Covers truncated-division sign semantics across all four
+// sign combinations, the a < b and exact-division edges, the
+// single-limb fast path, multi-limb Algorithm D, both classic add-back
+// trigger vectors (Hacker's Delight divmnu test data), a deterministic
+// invariant sweep (x == q*y + r, |r| < |y|, remainder sign follows the
+// dividend) over growing multi-limb operands, and the division-by-zero
+// panic (caught via recover). main returns the failure count.
+
+$ `stdlib/std/bigint.nu`
+$ `stdlib/std/panic.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/errors.nu`
+
+// Check quotient AND remainder of x / y against expected decimal strings.
+@ ck_divmod s label BigInt x BigInt y s wantq s wantr ( Vec i ) fails → v {
+    : BigInt q ( bigint_div x y )
+    : BigInt r ( bigint_rem x y )
+    : String qs ( bigint_to_string q )
+    : String rs ( bigint_to_string r )
+    ? & != 0 ( nurl_str_eq ( string_data qs ) wantq ) != 0 ( nurl_str_eq ( string_data rs ) wantr ) {
+        ( nurl_print `  ok   ` ) ( nurl_print label )
+        ( nurl_print ` → q=` ) ( nurl_print wantq )
+        ( nurl_print ` r=` ) ( nurl_print wantr ) ( nurl_print `\n` )
+    } {
+        ( nurl_print `  FAIL ` ) ( nurl_print label )
+        ( nurl_print ` got q=` ) ( nurl_print ( string_data qs ) )
+        ( nurl_print ` r=` ) ( nurl_print ( string_data rs ) )
+        ( nurl_print ` want q=` ) ( nurl_print wantq )
+        ( nurl_print ` r=` ) ( nurl_print wantr ) ( nurl_print `\n` )
+        ( vec_push [i] fails 1 )
+    }
+    ( string_free qs ) ( string_free rs )
+    ( bigint_free q ) ( bigint_free r )
+}
+
+// Parse a decimal literal, asserting it succeeds; on failure record it
+// and return zero so the caller can keep going.
+@ parse_ok s lit ( Vec i ) fails → BigInt {
+    : !BigInt ParseErr r ( bigint_from_string lit )
+    ?? r {
+        T b → { ^ b }
+        F _ → {
+            ( nurl_print `  FAIL parse ` ) ( nurl_print lit ) ( nurl_print `\n` )
+            ( vec_push [i] fails 1 )
+            ^ ( bigint_zero )
+        }
+    }
+}
+
+@ big_abs BigInt v → BigInt {
+    : BigInt z ( bigint_zero )
+    : i c ( bigint_cmp v z )
+    ( bigint_free z )
+    ? < c 0 { ^ ( bigint_neg v ) } {}
+    ^ ( bigint_clone v )
+}
+
+// One invariant probe: q*y + r == x, |r| < |y|, sign(r) follows sign(x).
+// Returns 1 on any violation (and prints it), else 0.
+@ probe BigInt x BigInt y → i {
+    : ~ i bad 0
+    : BigInt q ( bigint_div x y )
+    : BigInt r ( bigint_rem x y )
+    : BigInt qy ( bigint_mul q y )
+    : BigInt rec ( bigint_add qy r )
+    ? != ( bigint_cmp rec x ) 0 {
+        ( nurl_print `  FAIL invariant q*y+r != x\n` )
+        = bad 1
+    } {}
+    : BigInt ra ( big_abs r )
+    : BigInt ya ( big_abs y )
+    ? >= ( bigint_cmp ra ya ) 0 {
+        ( nurl_print `  FAIL invariant |r| >= |y|\n` )
+        = bad 1
+    } {}
+    : BigInt z ( bigint_zero )
+    : i xs ( bigint_cmp x z )
+    : i rs ( bigint_cmp r z )
+    ? & >= xs 0 < rs 0 {
+        ( nurl_print `  FAIL invariant sign: x >= 0 but r < 0\n` )
+        = bad 1
+    } {}
+    ? & < xs 0 > rs 0 {
+        ( nurl_print `  FAIL invariant sign: x < 0 but r > 0\n` )
+        = bad 1
+    } {}
+    ( bigint_free z ) ( bigint_free ya ) ( bigint_free ra )
+    ( bigint_free rec ) ( bigint_free qy )
+    ( bigint_free r ) ( bigint_free q )
+    ^ bad
+}
+
+@ run → i {
+    : ( Vec i ) fails ( vec_new [i] )
+
+    // ── truncated semantics: all four sign combinations ──
+    : BigInt p7 ( bigint_from_i 7 )
+    : BigInt n7 ( bigint_from_i -7 )
+    : BigInt p2 ( bigint_from_i 2 )
+    : BigInt n2 ( bigint_from_i -2 )
+    ( ck_divmod `7/2` p7 p2 `3` `1` fails )
+    ( ck_divmod `-7/2` n7 p2 `-3` `-1` fails )
+    ( ck_divmod `7/-2` p7 n2 `-3` `1` fails )
+    ( ck_divmod `-7/-2` n7 n2 `3` `-1` fails )
+    ( bigint_free p7 ) ( bigint_free n7 )
+    ( bigint_free p2 ) ( bigint_free n2 )
+
+    // ── edges: zero dividend, a < b, exact division, x == y ──
+    : BigInt z0 ( bigint_from_i 0 )
+    : BigInt p5 ( bigint_from_i 5 )
+    : BigInt n3 ( bigint_from_i -3 )
+    ( ck_divmod `0/5` z0 p5 `0` `0` fails )
+    ( ck_divmod `-3/5` n3 p5 `0` `-3` fails )
+    ( ck_divmod `5/5` p5 p5 `1` `0` fails )
+    : BigInt n10 ( bigint_from_i -10 )
+    ( ck_divmod `-10/5` n10 p5 `-2` `0` fails )
+    ( bigint_free z0 ) ( bigint_free p5 )
+    ( bigint_free n3 ) ( bigint_free n10 )
+
+    // ── single-limb fast path: 10^30 / 7 ──
+    : BigInt e30 ( parse_ok `1000000000000000000000000000000` fails )
+    : BigInt s7 ( bigint_from_i 7 )
+    ( ck_divmod `10^30/7` e30 s7 `142857142857142857142857142857` `1` fails )
+    ( bigint_free s7 )
+
+    // ── multi-limb: (10^30 + 12345) / 10^15 ──
+    : BigInt e30b ( parse_ok `1000000000000000000000000012345` fails )
+    : BigInt e15 ( parse_ok `1000000000000000` fails )
+    ( ck_divmod `(10^30+12345)/10^15` e30b e15 `1000000000000000` `12345` fails )
+    ( bigint_free e30b ) ( bigint_free e15 ) ( bigint_free e30 )
+
+    // ── exact multi-limb: 25! / 23! ──
+    : ~ BigInt f25 ( bigint_from_i 1 )
+    : ~ BigInt f23 ( bigint_from_i 1 )
+    : ~ i k 2
+    ~ <= k 25 {
+        : BigInt kk ( bigint_from_i k )
+        : BigInt nx ( bigint_mul f25 kk )
+        ( bigint_free f25 )
+        = f25 nx
+        ? <= k 23 {
+            : BigInt ny ( bigint_mul f23 kk )
+            ( bigint_free f23 )
+            = f23 ny
+        } {}
+        ( bigint_free kk )
+        = k + k 1
+    }
+    ( ck_divmod `25!/23!` f25 f23 `600` `0` fails )
+    ( bigint_free f25 ) ( bigint_free f23 )
+
+    // ── Algorithm D add-back triggers (Hacker's Delight divmnu data) ──
+    // limbs u=[0,0,0x8000,0x7fff] v=[1,0,0x8000] → q=0xfffe
+    : BigInt ab1u ( parse_ok `9223231299366420480` fails )
+    : BigInt ab1v ( parse_ok `140737488355329` fails )
+    ( ck_divmod `add-back 1` ab1u ab1v `65534` `140737488289794` fails )
+    ( bigint_free ab1u ) ( bigint_free ab1v )
+    // limbs u=[0,0xfffe,0x8000] v=[0xffff,0x8000] → q=0xffff
+    : BigInt ab2u ( parse_ok `140741783191552` fails )
+    : BigInt ab2v ( parse_ok `2147549183` fails )
+    ( ck_divmod `add-back 2` ab2u ab2v `65535` `2147483647` fails )
+    ( bigint_free ab2u ) ( bigint_free ab2v )
+
+    // ── wide multi-limb quotient + remainder ──
+    : BigInt wa ( parse_ok `123456789012345678901234567890123456789` fails )
+    : BigInt wb ( parse_ok `987654321098765432109` fails )
+    ( ck_divmod `39-digit/21-digit` wa wb `124999998860937500` `14172067901781269289` fails )
+    ( bigint_free wa ) ( bigint_free wb )
+
+    // ── deterministic invariant sweep over growing operands ──
+    // x grows ~5 digits per round, y ~4.8 — multi-limb divisors and
+    // multi-limb quotients throughout; signs rotate through all four
+    // combinations.
+    : BigInt gx ( bigint_from_i 99991 )
+    : BigInt gy ( bigint_from_i 65521 )
+    : BigInt three ( bigint_from_i 3 )
+    : ~ BigInt x ( bigint_from_i 1234567 )
+    : ~ BigInt y ( bigint_from_i 37 )
+    : ~ i bad 0
+    : ~ i it 0
+    ~ < it 60 {
+        : BigInt itb ( bigint_from_i it )
+        : BigInt xm ( bigint_mul x gx )
+        : BigInt xn ( bigint_add xm itb )
+        ( bigint_free x ) ( bigint_free xm )
+        = x xn
+        : BigInt ym ( bigint_mul y gy )
+        : BigInt yn ( bigint_add ym three )
+        ( bigint_free y ) ( bigint_free ym )
+        = y yn
+        ( bigint_free itb )
+
+        : ~ BigInt xs ( bigint_clone x )
+        ? == % it 3 0 {
+            ( bigint_free xs )
+            = xs ( bigint_neg x )
+        } {}
+        : ~ BigInt ys ( bigint_clone y )
+        ? == % it 4 0 {
+            ( bigint_free ys )
+            = ys ( bigint_neg y )
+        } {}
+        = bad + bad ( probe xs ys )
+        // also probe the inverted ratio (dividend smaller than divisor)
+        = bad + bad ( probe ys xs )
+        ( bigint_free xs ) ( bigint_free ys )
+        = it + it 1
+    }
+    ( bigint_free x ) ( bigint_free y )
+    ( bigint_free gx ) ( bigint_free gy ) ( bigint_free three )
+    ? == bad 0 { ( nurl_print `  ok   invariant sweep 60 rounds x 2 probes\n` ) }
+              { ( vec_push [i] fails 1 ) }
+
+    // ── division by zero panics (and is recoverable) ──
+    : BigInt dz ( bigint_from_i 42 )
+    : BigInt zz ( bigint_zero )
+    : !v PanicInfo pr ( recover \ → v {
+        : BigInt q ( bigint_div dz zz )
+        ( bigint_free q )
+    } )
+    ?? pr {
+        T _ → {
+            ( nurl_print `  FAIL div by zero did not panic\n` )
+            ( vec_push [i] fails 1 )
+        }
+        F p → {
+            ( nurl_print `  ok   div by zero → panic: ` )
+            ( nurl_print ( string_data . p msg ) )
+            ( nurl_print `\n` )
+            ( panic_info_free p )
+        }
+    }
+    ( bigint_free dz ) ( bigint_free zz )
+
+    : i n ( vec_len [i] fails )
+    ( vec_free [i] fails )
+    ^ n
+}
+
+@ main → i {
+    : i f ( run )
+    ? == f 0 { ( nurl_print `bigint_div: all checks passed\n` ) }
+            { ( nurl_print `bigint_div: FAILURES\n` ) }
+    ^ f
+}

--- a/compiler/tests/outputs/bigint_div.txt
+++ b/compiler/tests/outputs/bigint_div.txt
@@ -1,0 +1,21 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+  ok   7/2 → q=3 r=1
+  ok   -7/2 → q=-3 r=-1
+  ok   7/-2 → q=-3 r=1
+  ok   -7/-2 → q=3 r=-1
+  ok   0/5 → q=0 r=0
+  ok   -3/5 → q=0 r=-3
+  ok   5/5 → q=1 r=0
+  ok   -10/5 → q=-2 r=0
+  ok   10^30/7 → q=142857142857142857142857142857 r=1
+  ok   (10^30+12345)/10^15 → q=1000000000000000 r=12345
+  ok   25!/23! → q=600 r=0
+  ok   add-back 1 → q=65534 r=140737488289794
+  ok   add-back 2 → q=65535 r=2147483647
+  ok   39-digit/21-digit → q=124999998860937500 r=14172067901781269289
+  ok   invariant sweep 60 rounds x 2 probes
+  ok   div by zero → panic: bigint_div: division by zero
+bigint_div: all checks passed

--- a/stdlib/std/bigint.nu
+++ b/stdlib/std/bigint.nu
@@ -21,20 +21,27 @@
 //   ( bigint_add     BigInt x BigInt y )  → BigInt
 //   ( bigint_sub     BigInt x BigInt y )  → BigInt
 //   ( bigint_mul     BigInt x BigInt y )  → BigInt
+//   ( bigint_div     BigInt x BigInt y )  → BigInt  (truncated quotient)
+//   ( bigint_rem     BigInt x BigInt y )  → BigInt  (sign of the dividend)
 //   ( bigint_to_string BigInt x )         → String  (base 10, signed)
+//
+// Division is TRUNCATED (the quotient rounds toward zero, the remainder
+// takes the dividend's sign), matching the native `/` and `%` on `i` —
+// so for any y ≠ 0:  x == (x/y)*y + x%y  and  |x%y| < |y|.
+// Division by zero PANICS (`panic`, recoverable via `recover`): it is a
+// program defect, not a data error, so it is not threaded through `!`.
+// The magnitude core is Knuth Algorithm D (TAOCP vol. 2, 4.3.1) over the
+// base-2^16 limbs; a single-limb divisor short-circuits through
+// __mag_divmod_small_inplace.
 //
 // Memory: every BigInt OWNS its limb vector. Operations BORROW their
 // arguments (never freed) and return a freshly-allocated BigInt; the
 // caller frees each BigInt it holds with `bigint_free` (mirrors the
 // `http_response_free` / `query_pairs_free` convention — plain structs
 // are not auto-dropped). bigint_to_string returns an OWNED String.
-//
-// Not yet implemented: bignum ÷ bignum division / modulo (Knuth
-// Algorithm D). Division by a single small limb exists internally
-// (__mag_divmod_small_inplace) and powers base-10 formatting; the full
-// quotient is tracked as a follow-up (see ROADMAP "Numeric breadth").
 
 $ `stdlib/core/errors.nu`
+$ `stdlib/std/panic.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/option.nu`
@@ -203,6 +210,121 @@ $ `stdlib/core/option.nu`
     ( __norm a )
 }
 
+// Magnitude divmod (Knuth Algorithm D). Both inputs NORMALIZED, `bdiv`
+// non-empty. Returns a fresh normalized quotient magnitude; the
+// normalized remainder limbs are appended to `rem` (caller passes it in
+// EMPTY). Borrows `a` and `bdiv`.
+@ __mag_divmod ( Vec i ) a ( Vec i ) bdiv ( Vec i ) rem → ( Vec i ) {
+    // a < b: quotient zero, remainder a.
+    ? < ( __mag_cmp a bdiv ) 0 {
+        : i nca ( vec_len [i] a )
+        : ~ i t 0
+        ~ < t nca {
+            ( vec_push [i] rem ( __limb a t ) )
+            = t + t 1
+        }
+        ^ ( vec_new [i] )
+    } {}
+    : i nb ( vec_len [i] bdiv )
+    // Single-limb divisor: the small in-place routine is exact.
+    ? == nb 1 {
+        : ( Vec i ) q ( __mag_clone a )
+        : i r ( __mag_divmod_small_inplace q ( __limb bdiv 0 ) )
+        ? > r 0 { ( vec_push [i] rem r ) } {}
+        ^ q
+    } {}
+    : i na ( vec_len [i] a )
+    // D1 normalize: scale both by d = 2^k so the top divisor limb is
+    // >= base/2 (makes every trial digit off by at most 1). Reuses the
+    // small-multiply helper, so no shift primitives are needed.
+    : ~ i d 1
+    : ~ i top ( __limb bdiv - nb 1 )
+    ~ < top 32768 {
+        = top * top 2
+        = d * d 2
+    }
+    : ( Vec i ) un ( __mag_clone a )
+    ( __mag_mul_add_small_inplace un d 0 )
+    ~ < ( vec_len [i] un ) + na 1 { ( vec_push [i] un 0 ) }
+    : ( Vec i ) vn ( __mag_clone bdiv )
+    ( __mag_mul_add_small_inplace vn d 0 )
+    : i m - na nb
+    : ( Vec i ) q ( vec_with_cap [i] + m 1 )
+    : ~ i z 0
+    ~ <= z m {
+        ( vec_push [i] q 0 )
+        = z + z 1
+    }
+    // No more pushes into un/vn/q past here → data pointers stay valid.
+    : *i up ( vec_data [i] un )
+    : *i vp ( vec_data [i] vn )
+    : *i qp ( vec_data [i] q )
+    : i vh # i . vp - nb 1
+    : i vl # i . vp - nb 2
+    : ~ i j m
+    ~ >= j 0 {
+        // D3 trial digit from the top two dividend limbs; the two-limb
+        // value is < base^2 so it stays well inside i64.
+        : i u2 + * # i . up + j nb ( __big_base ) # i . up - + j nb 1
+        : ~ i qhat / u2 vh
+        : ~ i rhat % u2 vh
+        : i ulo # i . up + j - nb 2
+        : ~ b adj T
+        ~ adj {
+            ? | >= qhat ( __big_base ) > * qhat vl + * rhat ( __big_base ) ulo {
+                = qhat - qhat 1
+                = rhat + rhat vh
+                ? >= rhat ( __big_base ) { = adj F } {}
+            } { = adj F }
+        }
+        // D4 multiply-and-subtract: u[j .. j+nb] -= qhat * v, schoolbook
+        // with a per-limb {0,1} borrow (no negative shifts needed).
+        : ( Vec i ) qv ( __mag_clone vn )
+        ( __mag_mul_add_small_inplace qv qhat 0 )
+        : ~ i borrow 0
+        : ~ i t2 0
+        ~ <= t2 nb {
+            : ~ i dd - - # i . up + t2 j ( __limb qv t2 ) borrow
+            ? < dd 0 {
+                = dd + dd ( __big_base )
+                = borrow 1
+            } { = borrow 0 }
+            = . up + t2 j dd
+            = t2 + t2 1
+        }
+        ( vec_free [i] qv )
+        // D6 add back (rare: probability ~2/base per digit): the trial
+        // digit was one too large — undo by adding v once. The top-limb
+        // carry wraps mod base, cancelling the outstanding borrow.
+        ? > borrow 0 {
+            = qhat - qhat 1
+            : ~ i c2 0
+            : ~ i t3 0
+            ~ < t3 nb {
+                : i s2 + + # i . up + t3 j # i . vp t3 c2
+                = . up + t3 j & s2 ( __big_mask )
+                = c2 >> s2 ( __big_shift )
+                = t3 + t3 1
+            }
+            = . up + j nb & + # i . up + j nb c2 ( __big_mask )
+        } {}
+        = . qp j qhat
+        = j - j 1
+    }
+    // D8 un-normalize: the remainder is u[0 .. nb) / d.
+    : ~ i t4 0
+    ~ < t4 nb {
+        ( vec_push [i] rem # i . up t4 )
+        = t4 + t4 1
+    }
+    ( __norm rem )
+    ? > d 1 { : i _r ( __mag_divmod_small_inplace rem d ) } {}
+    ( vec_free [i] un )
+    ( vec_free [i] vn )
+    ( __norm q )
+    ^ q
+}
+
 // ── Public constructors ───────────────────────────────────────────────
 
 @ bigint_zero → BigInt {
@@ -294,6 +416,28 @@ $ `stdlib/core/option.nu`
     : ( Vec i ) m ( __mag_mul . x limbs . y limbs )
     : b neg & != . x neg . y neg > ( vec_len [i] m ) 0
     ^ @ BigInt { neg m }
+}
+
+// Truncated quotient (rounds toward zero), matching the native `/`.
+// Panics on a zero divisor.
+@ bigint_div BigInt x BigInt y → BigInt {
+    ? ( bigint_is_zero y ) { ( panic `bigint_div: division by zero` ) } {}
+    : ( Vec i ) rm ( vec_new [i] )
+    : ( Vec i ) qm ( __mag_divmod . x limbs . y limbs rm )
+    ( vec_free [i] rm )
+    : b neg & != . x neg . y neg > ( vec_len [i] qm ) 0
+    ^ @ BigInt { neg qm }
+}
+
+// Remainder of truncated division (takes the dividend's sign), matching
+// the native `%`: x == (x/y)*y + x%y. Panics on a zero divisor.
+@ bigint_rem BigInt x BigInt y → BigInt {
+    ? ( bigint_is_zero y ) { ( panic `bigint_rem: division by zero` ) } {}
+    : ( Vec i ) rm ( vec_new [i] )
+    : ( Vec i ) qm ( __mag_divmod . x limbs . y limbs rm )
+    ( vec_free [i] qm )
+    : b neg & . x neg > ( vec_len [i] rm ) 0
+    ^ @ BigInt { neg rm }
 }
 
 // ── Formatting / parsing ──────────────────────────────────────────────

--- a/stdlib/std/panic.nu
+++ b/stdlib/std/panic.nu
@@ -75,6 +75,13 @@ $ `stdlib/core/string.nu`
     : *u fnp # *u closure 0
     : *u env # *u closure 1
     : i rv ( nurl_recover fnp env )
+    // nurl_recover is synchronous — whether the closure completed or
+    // longjmp'd back, it can never run again, so its captured env is
+    // dead here. Decomposing into raw pointers above suppressed the
+    // param's auto-drop (the compiler must assume the env escapes, as
+    // it really does in thread_spawn), so release it explicitly.
+    // nurl_free is free(): NULL-safe for capture-less closures.
+    ( nurl_free # s env )
     ? == rv 0 {
         ^ @ !v PanicInfo { T 0 }
     } {}


### PR DESCRIPTION
## What

Two changes, one found en route to the other:

### 1. `bigint_div` / `bigint_rem` — the last gap in `std/bigint`

ROADMAP's *Numeric breadth* entry named bignum÷bignum division as the remaining follow-up after PR #95. This closes it with Knuth Algorithm D (TAOCP vol. 2, §4.3.1) over the existing base-2¹⁶ limb representation:

- **D1 normalization** reuses `__mag_mul_add_small_inplace` (scale by 2^k so the top divisor limb ≥ base/2 → trial digit off by at most 1); the remainder is un-normalized through `__mag_divmod_small_inplace`. No new shift primitives.
- **D4 multiply-and-subtract** uses a per-limb {0,1} borrow — no arithmetic right shifts of negative intermediates anywhere.
- **D6 add-back** is covered by both classic Hacker's Delight `divmnu` trigger vectors in the regression.
- Single-limb divisors short-circuit through the existing small in-place routine; `a < b` returns `(0, a)` directly.

**Semantics:** truncated division, exactly like native `/` and `%` — quotient toward zero, remainder takes the dividend's sign, `x == (x/y)*y + x%y` for every `y ≠ 0`. Division by zero **panics** (recoverable via `recover`): a defect, not a data error, so it is not threaded through `!` — matching Go `big.Int` / Rust `num-bigint` precedent.

### 2. `recover` leaked the closure's captured environment

ASan on the new divide-by-zero regression flagged it: `recover` decomposes its closure into `(fn_ptr, env_ptr)`, and passing the raw env pointer onward suppresses the param's auto-drop (correct for `thread_spawn`, whose shape it mirrors — there the env genuinely escapes). But `nurl_recover` is synchronous, so the env is dead the moment it returns — and nobody freed it. **One allocation leaked per `recover` call with a capturing closure, panic or not** (HTTP server panic-guards call this per request). Root-cause fix: free the env immediately after `nurl_recover` returns — single free point covers both normal and unwind paths, NULL-safe for capture-less closures. Existing recover goldens are byte-identical; only the leak is gone.

## Testing

- `compiler/tests/bigint_div.nu` (+ golden): all four sign combinations, zero / `a<b` / exact / `x==y` edges, single-limb fast path (10³⁰/7), multi-limb quotient+remainder (39-digit ÷ 21-digit), **both add-back vectors**, a 60-round deterministic invariant sweep (reconstruction, `|r| < |y|`, remainder-sign) over operands growing to ~300 digits with signs rotating through all four combinations, and the recovered divide-by-zero panic.
- ASan + UBSan clean, **leak-free** (`detect_leaks=1`).
- Differential check vs Python: 300 random cases (mixed limb counts, signs, near-power-of-2¹⁶ divisors, add-back-biased shapes) — all matched.
- `./build.sh` green: bootstrap fixed point holds, full suite passes (1m29s).
- Minimal leak repros for the `recover` fix verified clean: capture+no-panic, capture+panic, capture-less, bigint divide-by-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)