### PR TITLE
nurlapi: immutability migration + nurl_changelog MCP tool

### DIFF
--- a/nurlapi/e2e_test.py
+++ b/nurlapi/e2e_test.py
@@ -186,12 +186,13 @@ def t_mcp_info(c: Client) -> None:
     assert_eq("transport", j.get("transport"), "streamable-http")
     assert_eq("url_path", j.get("url_path"), "/mcp")
     tools = j.get("tools", [])
-    assert_eq("15 tools advertised", len(tools), 15)
+    assert_eq("16 tools advertised", len(tools), 16)
     for t in (
         "nurl_build_native",
         "nurl_build_wasm",
         "nurl_list_examples",
         "nurl_read_grammar",
+        "nurl_changelog",
     ):
         assert_true(f"tool {t} listed", t in tools)
     assert_true(
@@ -243,7 +244,7 @@ def t_tools_list(c: Client) -> None:
     print("\n[MCP] tools/list")
     _, _, env = c.rpc({"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
     tools = env.get("result", {}).get("tools", [])
-    assert_eq("15 tools", len(tools), 15)
+    assert_eq("16 tools", len(tools), 16)
     names = {t.get("name") for t in tools}
     for required in (
         "nurl_build_native",
@@ -261,6 +262,7 @@ def t_tools_list(c: Client) -> None:
         "nurl_read_readme",
         "nurl_read_roadmap",
         "nurl_read_gotchas",
+        "nurl_changelog",
     ):
         assert_true(f"tools/list has {required}", required in names)
     # Each tool has description + inputSchema.
@@ -329,6 +331,36 @@ def t_tools_call_reads(c: Client) -> None:
     env = _tool_call(c, "nurl_read_stdlib", {"name": "core/string.nu"})
     text = _tool_text(env)
     assert_true("core/string.nu returned (non-empty)", len(text) > 0)
+
+
+def t_tools_call_changelog(c: Client) -> None:
+    print("\n[MCP] tools/call nurl_changelog (index / query / release / no-match)")
+
+    # Index mode: no arguments → release index with entry counts.
+    env = _tool_call(c, "nurl_changelog", {})
+    text = _tool_text(env)
+    assert_true("index lists releases", "releases," in text and "[Unreleased]" in text)
+    assert_true("index shows entry counts", " entries" in text)
+
+    # Query mode: every release heading carries a date, so 'compiler'
+    # is a safe always-matching term; entries come back with provenance.
+    env = _tool_call(c, "nurl_changelog", {"query": "compiler", "limit": 2})
+    text = _tool_text(env)
+    assert_true("query header reports match counts", " changelog entries match query 'compiler'" in text)
+    assert_true("entries carry [release] provenance", "\n[" in text)
+
+    # limit respected: at most 2 entry blocks (3 with header+footer parts).
+    assert_true("limit caps emitted entries", text.count("\n\n[") <= 2)
+
+    # Release filter alone returns that release's entries.
+    env = _tool_call(c, "nurl_changelog", {"release": "Unreleased", "limit": 1})
+    text = _tool_text(env)
+    assert_true("release filter scopes to heading", "in release 'Unreleased'" in text)
+
+    # No-match path gives actionable guidance instead of silence.
+    env = _tool_call(c, "nurl_changelog", {"query": "zzz-no-such-term-zzz"})
+    text = _tool_text(env)
+    assert_true("no-match has guidance", "No matches" in text)
 
 
 def t_tools_call_traversal(c: Client) -> None:
@@ -566,6 +598,7 @@ def main() -> int:
     t_tools_list(c)
     t_tools_call_listing(c)
     t_tools_call_reads(c)
+    t_tools_call_changelog(c)
     t_tools_call_traversal(c)
     t_tools_call_unknown(c)
     if not args.quick:

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -71,6 +71,8 @@ $ `stdlib/std/thread.nu`
 
 @ get_mcp_server_version → String { ^ ( env_var_or `NURL_MCP_SERVER_VERSION` `1.9.4` ) }
 
+@ get_changelog_path → String { ^ ( env_var_or `NURL_CHANGELOG_PATH` `/opt/nurl/CHANGELOG.md` ) }
+
 // Per-zig-target runtime object path. Used by /build_target so we don't
 // have to keep a switch in NURL code — the Dockerfile builds one
 // runtime.<id>.o per registered target and the path lookup follows
@@ -1435,6 +1437,7 @@ s combined_stdout s combined_stderr → v {
     ( __mcp_info_push_str tools `nurl_read_readme` )
     ( __mcp_info_push_str tools `nurl_read_roadmap` )
     ( __mcp_info_push_str tools `nurl_read_gotchas` )
+    ( __mcp_info_push_str tools `nurl_changelog` )
     ( json_obj_set j `tools` tools )
 
     : Json resources ( json_arr_new )
@@ -3441,6 +3444,15 @@ s combined_stdout s combined_stderr → v {
     }
 }
 
+// Integer tool argument: JNum → i; absent / non-numeric → default.
+@ __mcp_args_get_int s key Json args i default → i {
+    : ?Json v ( json_obj_get args key )
+    ?? v {
+        T j → { ^ ?? ( json_num_as_i j ) { T n → n F _ → default } }
+        F _ → { ^ default }
+    }
+}
+
 // ── Tool schemas — small helpers keep the descriptor table terse.
 
 @ __mcp_prop s ptype s desc → Json {
@@ -3631,6 +3643,293 @@ s combined_stdout s combined_stderr → v {
     ^ result
 }
 
+// ── nurl_changelog — targeted CHANGELOG.md retrieval ────────────────
+//
+// CHANGELOG.md is ~240 KB and growing; dumping it whole into a model
+// context to answer "when did X change?" wastes the window. This tool
+// returns COMPLETE changelog entries — one top-level `- ` bullet plus a
+// `[release] — date › category` provenance line — selected by
+// AND-matched case-insensitive terms, optionally narrowed to one
+// release. With no arguments it returns a compact index (releases +
+// ent counts) so a model can orient itself with one cheap call.
+// Output is byte-capped; a trailing note reports how many further
+// matches were omitted so the model knows to refine, not re-read.
+
+// Lowercase an owned copy of a borrowed `s`.
+@ __lc_owned s raw → String {
+    : String tmp ( string_from raw )
+    : String lc ( string_to_lower tmp )
+    ( string_free tmp )
+    ^ lc
+}
+
+@ __cl_is_ws i c → b { ^ | | | == c 10 == c 13 == c 32 == c 9 }
+
+// True iff every non-empty term occurs in `hay_lc` (both lowercase).
+@ __cl_terms_match String hay_lc ( Vec String ) terms → b {
+    : i n ( vec_len [String] terms )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] terms k ) {
+            T t → {
+                ? & > ( string_len t ) 0 < ( nurl_str_find ( string_data hay_lc ) ( string_data t ) ) 0 { ^ F } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ T
+}
+
+// Total output cap (bytes) for one tool call. Entries average ~1-2 KB;
+// 32 KB keeps even a generous `limit` from flooding the caller's
+// context while still fitting ~15-25 full entries.
+@ __cl_out_cap → i { ^ 32768 }
+
+// Flush one accumulated ent: count it, run the release filter and the
+// term match, and append it to `out` when within `limit` and the byte
+// cap. `ctr` is the shared [total, matched, emitted] counter Vec (Vec is
+// a shared boxed handle — mutations are visible to the caller). Clears
+// `ent` so the caller can keep accumulating into the same String.
+@ __cl_flush String ent String cur_rel String cur_rel_lc String cur_cat
+( Vec String ) terms String rel_lc String out i limit ( Vec i ) ctr → v {
+    ? > ( string_len ent ) 0 {
+        // Trim trailing blank lines / whitespace off the body.
+        : ~ i e ( string_len ent )
+        ~ & > e 0 ( __cl_is_ws ( string_get ent - e 1 ) ) { = e - e 1 }
+        : String body ( string_substr ent 0 e )
+
+        : i total ?? ( vec_get [i] ctr 0 ) { T v → v F _ → 0 }
+        ( vec_set [i] ctr 0 + total 1 )
+
+        // Release filter: empty = all; else substring of the heading.
+        : b rel_ok | == ( string_len rel_lc ) 0 >= ( nurl_str_find ( string_data cur_rel_lc ) ( string_data rel_lc ) ) 0
+        ? rel_ok {
+            // Provenance line, e.g. `[0.9.6] — 2026-06-08 › Fixed`.
+            : String prov ( string_with_cap 64 )
+            ( string_push_str prov ( string_data cur_rel ) )
+            ? > ( string_len cur_cat ) 0 {
+                ( string_push_str prov ` › ` )
+                ( string_push_str prov ( string_data cur_cat ) )
+            } {}
+            // Match against provenance + body so terms like `fixed` or a
+            // release date can hit the heading too.
+            : String hay ( string_with_cap + + ( string_len prov ) ( string_len body ) 2 )
+            ( string_push_str hay ( string_data prov ) )
+            ( string_push_char hay 10 )
+            ( string_push_str hay ( string_data body ) )
+            : String hay_lc ( string_to_lower hay )
+            ? ( __cl_terms_match hay_lc terms ) {
+                : i matched ?? ( vec_get [i] ctr 1 ) { T v → v F _ → 0 }
+                ( vec_set [i] ctr 1 + matched 1 )
+                : i emitted ?? ( vec_get [i] ctr 2 ) { T v → v F _ → 0 }
+                ? & < emitted limit < ( string_len out ) ( __cl_out_cap ) {
+                    ( string_push_str out ( string_data prov ) )
+                    ( string_push_char out 10 )
+                    ( string_push_str out ( string_data body ) )
+                    ( string_push_str out `\n\n` )
+                    ( vec_set [i] ctr 2 + emitted 1 )
+                } {}
+            } {}
+            ( string_free hay_lc ) ( string_free hay ) ( string_free prov )
+        } {}
+        ( string_free body )
+        ( string_clear ent )
+    } {}
+}
+
+// Walk the changelog line by line, accumulating top-level `- ` bullets.
+// Continuation lines are indented or blank; a non-indented line that is
+// not a bullet or heading (intro prose, the link-reference definitions
+// at the bottom) terminates the open ent without joining it.
+@ __changelog_entries String src ( Vec String ) terms String rel_lc String out i limit ( Vec i ) ctr → v {
+    : ( Vec String ) lines ( string_split src `\n` )
+    : i nl ( vec_len [String] lines )
+    : ~ String cur_rel ( string_from `` )
+    : ~ String cur_rel_lc ( string_from `` )
+    : ~ String cur_cat ( string_from `` )
+    : String ent ( string_new )
+    : ~ i li 0
+    ~ < li nl {
+        ?? ( vec_get [String] lines li ) {
+            T line → {
+                : i ln ( string_len line )
+                ? ( string_starts_with line `## ` ) {
+                    ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc out limit ctr )
+                    ( string_free cur_rel ) = cur_rel ( string_substr line 3 - ln 3 )
+                    ( string_free cur_rel_lc ) = cur_rel_lc ( string_to_lower cur_rel )
+                    ( string_free cur_cat ) = cur_cat ( string_from `` )
+                } {
+                    ? ( string_starts_with line `### ` ) {
+                        ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc out limit ctr )
+                        ( string_free cur_cat ) = cur_cat ( string_substr line 4 - ln 4 )
+                    } {
+                        // Both bullet styles appear in the file: `- ` in the
+                        // 0.9.1+ sections, `* ` in the older ones.
+                        ? | ( string_starts_with line `- ` ) ( string_starts_with line `* ` ) {
+                            ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc out limit ctr )
+                            ( string_push_str ent ( string_data line ) )
+                            ( string_push_char ent 10 )
+                        } {
+                            : ~ b is_cont F
+                            ? == ln 0 { = is_cont T } {
+                                : i c0 ( string_get line 0 )
+                                ? | == c0 32 == c0 9 { = is_cont T } {}
+                            }
+                            ? is_cont {
+                                ? > ( string_len ent ) 0 {
+                                    ( string_push_str ent ( string_data line ) )
+                                    ( string_push_char ent 10 )
+                                } {}
+                            } {
+                                ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc out limit ctr )
+                            }
+                        }
+                    }
+                }
+            }
+            F _ → {}
+        }
+        = li + li 1
+    }
+    ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc out limit ctr )
+    ( string_free cur_rel ) ( string_free cur_rel_lc ) ( string_free cur_cat ) ( string_free ent )
+    ( vec_free_with [String] lines \ String l → v { ( string_free l ) } )
+}
+
+@ __cl_idx_line String idx String rel i count → v {
+    ( string_push_str idx ( string_data rel ) )
+    ( string_push_str idx ` — ` )
+    ( string_push_int idx count )
+    ( string_push_str idx ` entries\n` )
+}
+
+// Index mode (no query, no release): release headings + entry counts.
+@ __changelog_index_result String src → Json {
+    : ( Vec String ) lines ( string_split src `\n` )
+    : i nl ( vec_len [String] lines )
+    : String idx ( string_with_cap 1024 )
+    : ~ String cur_rel ( string_from `` )
+    : ~ i cur_count 0
+    : ~ i total 0
+    : ~ i releases 0
+    : ~ i li 0
+    ~ < li nl {
+        ?? ( vec_get [String] lines li ) {
+            T line → {
+                : i ln ( string_len line )
+                ? ( string_starts_with line `## ` ) {
+                    ? > ( string_len cur_rel ) 0 { ( __cl_idx_line idx cur_rel cur_count ) } {}
+                    ( string_free cur_rel ) = cur_rel ( string_substr line 3 - ln 3 )
+                    = cur_count 0
+                    = releases + releases 1
+                } {
+                    ? | ( string_starts_with line `- ` ) ( string_starts_with line `* ` ) {
+                        = cur_count + cur_count 1
+                        = total + total 1
+                    } {}
+                }
+            }
+            F _ → {}
+        }
+        = li + li 1
+    }
+    ? > ( string_len cur_rel ) 0 { ( __cl_idx_line idx cur_rel cur_count ) } {}
+    ( string_free cur_rel )
+    ( vec_free_with [String] lines \ String l → v { ( string_free l ) } )
+
+    : String hdr ( string_with_cap + ( string_len idx ) 256 )
+    ( string_push_str hdr `CHANGELOG.md — ` )
+    ( string_push_int hdr releases )
+    ( string_push_str hdr ` releases, ` )
+    ( string_push_int hdr total )
+    ( string_push_str hdr ` entries. Call again with 'query' (space-separated terms, ALL must match, case-insensitive) and/or 'release' (e.g. 0.9.6 or Unreleased) to fetch full entries; 'limit' defaults to 10.\n\n` )
+    ( string_push_str hdr ( string_data idx ) )
+    : Json result ( __mcp_result_text ( string_data hdr ) )
+    ( string_free hdr ) ( string_free idx )
+    ^ result
+}
+
+@ __mcp_tool_changelog Json args → Json {
+    : s query ( __mcp_args_get `query` args `` )
+    : s release ( __mcp_args_get `release` args `` )
+    : ~ i limit ( __mcp_args_get_int `limit` args 10 )
+    ? < limit 1 { = limit 1 } {}
+    ? > limit 50 { = limit 50 } {}
+
+    : String fp ( get_changelog_path )
+    : !( Vec u ) IoErr rd ( read_file_bytes ( string_data fp ) )
+    ( string_free fp )
+    ?? rd {
+        T bytes → {
+            : String src ( bytes_to_str bytes )
+            ( vec_free [u] bytes )
+            ? & == ( nurl_str_len query ) 0 == ( nurl_str_len release ) 0 {
+                : Json r ( __changelog_index_result src )
+                ( string_free src )
+                ^ r
+            } {}
+
+            : String q_lc ( __lc_owned query )
+            : ( Vec String ) terms ( string_split q_lc ` ` )
+            : String rel_lc ( __lc_owned release )
+            : String out ( string_with_cap 4096 )
+            : ( Vec i ) ctr ( vec_new [i] )
+            ( vec_push [i] ctr 0 ) ( vec_push [i] ctr 0 ) ( vec_push [i] ctr 0 )
+            ( __changelog_entries src terms rel_lc out limit ctr )
+            : i total ?? ( vec_get [i] ctr 0 ) { T v → v F _ → 0 }
+            : i matched ?? ( vec_get [i] ctr 1 ) { T v → v F _ → 0 }
+            : i emitted ?? ( vec_get [i] ctr 2 ) { T v → v F _ → 0 }
+
+            : String hdr ( string_with_cap + ( string_len out ) 256 )
+            ( string_push_int hdr matched )
+            ( string_push_str hdr ` of ` )
+            ( string_push_int hdr total )
+            ( string_push_str hdr ` changelog entries match` )
+            ? > ( nurl_str_len query ) 0 {
+                ( string_push_str hdr ` query '` )
+                ( string_push_str hdr query )
+                ( string_push_str hdr `'` )
+            } {}
+            ? > ( nurl_str_len release ) 0 {
+                ( string_push_str hdr ` in release '` )
+                ( string_push_str hdr release )
+                ( string_push_str hdr `'` )
+            } {}
+            ( string_push_str hdr `.\n\n` )
+            ( string_push_str hdr ( string_data out ) )
+            ? == matched 0 {
+                ( string_push_str hdr `No matches — terms are AND-ed substrings; try fewer or shorter terms, or call without arguments for the release index.\n` )
+            } {}
+            ? > matched emitted {
+                ( string_push_str hdr `… ` )
+                ( string_push_int hdr - matched emitted )
+                ( string_push_str hdr ` more matching entries omitted (limit/byte cap) — narrow the query, filter by release, or raise 'limit'.\n` )
+            } {}
+            : Json result ( __mcp_result_text ( string_data hdr ) )
+            ( string_free hdr ) ( string_free out ) ( string_free rel_lc )
+            ( vec_free_with [String] terms \ String t → v { ( string_free t ) } )
+            ( string_free q_lc ) ( vec_free [i] ctr ) ( string_free src )
+            ^ result
+        }
+        F _ → { ^ ( __mcp_result_error `CHANGELOG.md not found` ) }
+    }
+}
+
+@ __mcp_schema_changelog → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    : Json props ( json_obj_new )
+    ( json_obj_set props `query`
+    ( __mcp_prop `string` `Space-separated search terms; an entry matches only if EVERY term occurs in it (case-insensitive substring). Omit together with 'release' to get the release index.` ) )
+    ( json_obj_set props `release`
+    ( __mcp_prop `string` `Restrict to one release, e.g. '0.9.6' or 'Unreleased' (substring match on the release heading).` ) )
+    ( json_obj_set props `limit`
+    ( __mcp_prop `integer` `Maximum entries to return (default 10, max 50). Output is also byte-capped at 32 KB.` ) )
+    ( json_obj_set schema `properties` props )
+    ^ schema
+}
+
 // ── Tool dispatch by name ──────────────────────────────────────────
 
 @ __mcp_dispatch_tool s name Json args → Json {
@@ -3729,6 +4028,11 @@ s combined_stdout s combined_stderr → v {
         ( string_free fp ) ^ result
     } {}
 
+    // Targeted changelog retrieval.
+    ? != 0 ( nurl_str_eq name `nurl_changelog` ) {
+        ^ ( __mcp_tool_changelog args )
+    } {}
+
     ^ ( __mcp_result_error `unknown tool` )
 }
 
@@ -3793,6 +4097,11 @@ s combined_stdout s combined_stderr → v {
     ( json_arr_push arr ( __mcp_tool_desc `nurl_read_gotchas`
     `Return docs/GOTCHAS.md verbatim — known compiler quirks with workarounds.`
     ( __mcp_schema_empty ) ) )
+
+    // Changelog.
+    ( json_arr_push arr ( __mcp_tool_desc `nurl_changelog`
+    `Targeted CHANGELOG.md retrieval — the changelog is large (240+ KB) and growing, so never fetch it whole. Call with NO arguments first to get a compact index (releases + entry counts). Then pass query (space-separated terms, ALL must occur, case-insensitive) and/or release (e.g. 0.9.6 or Unreleased) to get complete changelog entries, each prefixed with its '[release] — date › category' provenance, newest first. Use this to find out when/whether a feature, fix, or rename happened. Results respect limit (default 10) and a 32 KB byte cap; a trailing note reports omitted match counts.`
+    ( __mcp_schema_changelog ) ) )
 
     : Json out ( json_obj_new )
     ( json_obj_set out `tools` arr )

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -180,7 +180,7 @@ $ `stdlib/std/thread.nu`
 }
 
 @ prepare_ir_for_wasi String ir → String {
-    : String res ( string_from ( string_data ir ) )
+    : ~ String res ( string_from ( string_data ir ) )
 
     // 0. Mask `@` inside string constants so the symbol rewrites below
     //    can't corrupt emitted-IR data (see note above). Restored at the
@@ -226,7 +226,7 @@ $ `stdlib/std/thread.nu`
         ?? entry_opt { T entry → {
                 : ( Vec String ) parts ( string_split entry `:` )
                 ? == ( vec_len [String] parts ) 3 {
-                    : String name ( string_new ) : String ret ( string_new ) : String pms ( string_new )
+                    : ~ String name ( string_new ) : ~ String ret ( string_new ) : ~ String pms ( string_new )
                     : ?String n_o ( vec_get [String] parts 0 ) ?? n_o { T s → { ( string_free name ) = name ( string_from ( string_data s ) ) } F → {} }
                     : ?String r_o ( vec_get [String] parts 1 ) ?? r_o { T s → { ( string_free ret ) = ret ( string_from ( string_data s ) ) } F → {} }
                     : ?String p_o ( vec_get [String] parts 2 ) ?? p_o { T s → { = pms ( string_from ( string_data s ) ) } F → {} }
@@ -236,7 +236,7 @@ $ `stdlib/std/thread.nu`
                     ? ( string_contains res ( string_data pat ) ) {
                         : String sname ( string_from `@__nurl_` ) ( string_push_str sname ( string_data name ) ) ( string_push_str sname `_shim(` )
 
-                        : b already_shimmed F
+                        : ~ b already_shimmed F
                         : ~ i si 0 ~ < si ( vec_len [String] shimmed ) {
                             : ?String s_o ( vec_get [String] shimmed si ) ?? s_o { T s → { ? ( string_eq s name ) { = already_shimmed T } {} } F → {} }
                             = si + si 1
@@ -750,14 +750,13 @@ s combined_stdout s combined_stderr → v {
                 T _ → {
                     : String nu_path ( path_join ( string_data build_dir ) filename )
                     ( write_file ( string_data nu_path ) source )
-                    : String bin_name ( string_from filename )
+                    : ~ String bin_name ( string_from filename )
                     ? ( string_ends_with bin_name `.nu` ) { : String tmp ( string_substr bin_name 0 - ( string_len bin_name ) 3 ) ( string_free bin_name ) = bin_name tmp } {}
                     : String ll_name ( string_from ( string_data bin_name ) ) ( string_push_str ll_name `.ll` )
                     : String ll_path ( path_join ( string_data build_dir ) ( string_data ll_name ) )
                     : String bin_path ( path_join ( string_data build_dir ) ( string_data bin_name ) )
 
                     : b uses_canvas >= ( nurl_str_find source `stdlib/ext/canvas.nu` ) 0
-                    : b uses_audio >= ( nurl_str_find source `stdlib/ext/audio.nu` ) 0
 
                     : ( Vec s ) nurlc_args ( vec_new [s] ) ( vec_push [s] nurlc_args ( string_data nu_path ) )
                     : !Output ProcessErr nurlc_res ( process_run ( string_data ( get_nurlc_path ) ) nurlc_args `` ) ( vec_free [s] nurlc_args )
@@ -871,13 +870,13 @@ s combined_stdout s combined_stderr → v {
                 T _ → {
                     : String nu_path ( path_join ( string_data build_dir ) filename )
                     ( write_file ( string_data nu_path ) source )
-                    : String bin_name ( string_from filename )
+                    : ~ String bin_name ( string_from filename )
                     ? ( string_ends_with bin_name `.nu` ) { : String tmp ( string_substr bin_name 0 - ( string_len bin_name ) 3 ) ( string_free bin_name ) = bin_name tmp } {}
                     : String ll_name ( string_from ( string_data bin_name ) ) ( string_push_str ll_name `.ll` )
                     : String wasm_name ( string_from ( string_data bin_name ) ) ( string_push_str wasm_name `.wasm` )
 
                     : String ll_path ( path_join ( string_data build_dir ) ( string_data ll_name ) )
-                    : String wasm_path ( path_join ( string_data build_dir ) ( string_data wasm_name ) )
+                    : ~ String wasm_path ( path_join ( string_data build_dir ) ( string_data wasm_name ) )
 
                     : b uses_canvas >= ( nurl_str_find source `stdlib/ext/canvas.nu` ) 0
                     : b uses_audio >= ( nurl_str_find source `stdlib/ext/audio.nu` ) 0
@@ -901,11 +900,11 @@ s combined_stdout s combined_stderr → v {
                                 // via stdlib/ext/canvas.nu) only show up in the post-IR scan,
                                 // so this matters — sand.nu and doomfire.nu silently failed
                                 // to link canvas.wasm.o until this fix.
-                                : b uses_canvas F
+                                : ~ b uses_canvas F
                                 : !Regex ParseErr re_canv ( regex_compile `@canvas_(open|present|sleep|should_close|close|mouse_x|mouse_y|mouse_btn)\(` )
                                 ?? re_canv { T rc → { = uses_canvas ( regex_test rc ( string_data ir_fixed ) ) ( regex_free rc ) } F _ → {} }
 
-                                : b uses_audio F
+                                : ~ b uses_audio F
                                 : !Regex ParseErr re_aud ( regex_compile `@audio_(level|bin|bin_count|peak_bin|centroid|freq_of|sample_rate|is_silent|ready)\(` )
                                 ?? re_aud { T ra → { = uses_audio ( regex_test ra ( string_data ir_fixed ) ) ( regex_free ra ) } F _ → {} }
 
@@ -995,7 +994,7 @@ s combined_stdout s combined_stderr → v {
                                         ( json_obj_set res `uses_canvas` ( json_bool uses_canvas ) )
                                         ( json_obj_set res `uses_audio` ( json_bool uses_audio ) )
 
-                                        : String b64 ( string_new ) : String wasm_url ( string_new )
+                                        : ~ String b64 ( string_new ) : ~ String wasm_url ( string_new )
                                         ? == c_rc 0 {
                                             : !i IoErr wasm_size_res ( file_size ( string_data wasm_path ) )
                                             : i w_bytes ?? wasm_size_res { T s → s F _ → 0 }
@@ -1063,7 +1062,7 @@ s combined_stdout s combined_stderr → v {
                     : String nu_path ( path_join ( string_data build_dir ) filename )
                     ( write_file ( string_data nu_path ) source )
                     : String ll_path ( path_join ( string_data build_dir ) `main.ll` )
-                    : String bin_name ( string_from filename )
+                    : ~ String bin_name ( string_from filename )
                     ? ( string_ends_with bin_name `.nu` ) { : String tmp ( string_substr bin_name 0 - ( string_len bin_name ) 3 ) ( string_free bin_name ) = bin_name tmp } {}
                     ( string_push_str bin_name `.exe` )
                     : String bin_path ( path_join ( string_data build_dir ) ( string_data bin_name ) )
@@ -1247,7 +1246,7 @@ s combined_stdout s combined_stderr → v {
                     : String nu_path ( path_join ( string_data build_dir ) filename )
                     ( write_file ( string_data nu_path ) source )
                     : String ll_path ( path_join ( string_data build_dir ) `main.ll` )
-                    : String bin_name ( string_from filename )
+                    : ~ String bin_name ( string_from filename )
                     ? ( string_ends_with bin_name `.nu` ) { : String tmp ( string_substr bin_name 0 - ( string_len bin_name ) 3 ) ( string_free bin_name ) = bin_name tmp } {}
                     : String bin_path ( path_join ( string_data build_dir ) ( string_data bin_name ) )
                     : ( Vec s ) nurlc_args ( vec_new [s] ) ( vec_push [s] nurlc_args ( string_data nu_path ) )
@@ -2541,7 +2540,7 @@ s combined_stdout s combined_stderr → v {
                     = in_code T
                 } {
                     // Heading?
-                    : i hcount 0
+                    : ~ i hcount 0
                     : ~ i hi 0
                     ~ < hi line_len {
                         ? & == ( nurl_str_get lp hi ) 35 < hi 6 { = hcount + hcount 1 = hi + hi 1 } { = hi line_len }
@@ -3297,7 +3296,7 @@ s combined_stdout s combined_stderr → v {
                     : String nu_path ( path_join ( string_data build_dir ) filename )
                     ( write_file ( string_data nu_path ) source )
                     : String ll_path ( path_join ( string_data build_dir ) `main.ll` )
-                    : String bin_name ( string_from filename )
+                    : ~ String bin_name ( string_from filename )
                     ? ( string_ends_with bin_name `.nu` ) { : String tmp ( string_substr bin_name 0 - ( string_len bin_name ) 3 ) ( string_free bin_name ) = bin_name tmp } {}
                     : String bin_path ( path_join ( string_data build_dir ) ( string_data bin_name ) )
                     : String rt_o ( get_runtime_target_o target )


### PR DESCRIPTION
## Summary

Two changes to the playground/MCP server (`nurlapi/main.nu`):

### 1. Fix: file no longer compiled after `:` immutability enforcement

The 2026-06-10 tree-wide immutability migration (#99) only covered what `build.sh` compiles. `nurlapi/main.nu` is built separately via its Dockerfile and was missed — `nurlc` rejected it outright. Fixed by adding `~` to its 13 latent violations (`~` is codegen-neutral, so emitted code is byte-identical), plus removed a dead `uses_audio` binding the lint flagged in the native build handler.

### 2. Feature: `nurl_changelog` MCP tool — targeted CHANGELOG.md retrieval

CHANGELOG.md is ~240 KB and growing; a model answering "when did X change?" shouldn't read it whole. The new tool returns **complete changelog entries** (one top-level bullet + `[release] — date › category` provenance), newest first:

- **no arguments** → compact index (23 releases + entry counts) for cheap orientation
- **`query`** — space-separated AND terms, case-insensitive substrings, matched against provenance + body
- **`release`** — substring filter on the release heading (works with or without `query`)
- **`limit`** (default 10, max 50) + 32 KB byte cap, with an explicit *"N more matching entries omitted"* note so the model refines instead of re-reading
- 0 matches → actionable guidance instead of silence

Parses both bullet styles (`- ` in 0.9.1+ sections, `* ` in older ones); indented/blank lines continue an entry, non-indented prose and the link-reference block terminate it. Path overridable via `NURL_CHANGELOG_PATH`.

## Testing

- `./check.sh nurlapi/main.nu` clean
- Built and ran the server locally; exercised all modes over live `POST /mcp` (index, AND query, release filter, limit + omitted counts, byte cap at `limit=50`, no-match)
- e2e suite extended: tool count 15→16, new `t_tools_call_changelog` (index / query / release / limit / no-match) — 89/90 locally, the one failure being the host lacking `/opt/nurl/build/nurlc`
- ASan+UBSan run (`NURL_SAN=1`): **zero leaks in the new code**; the run surfaced a pre-existing ~680 B/request leak in the HTTP request plumbing (`header_get` / `__read_request_head` option boxes), recorded in the local critic.md backlog as A4b for a separate fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)