### PR TITLE
fix(http): direct cross-thread server_stop no longer UAFs pool/seq servers (critic B19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`server_stop` from another thread freed the listener under blocked
+  pool workers** (`stdlib/ext/http_server.nu`). `server_run_pool`'s
+  documented shutdown — call `server_stop s` from another thread while
+  workers block in accept — was a heap-use-after-free: workers hold no
+  reference on the listener, so the stop's `nurl_tcp_close` dropped the
+  last ref and freed the struct while every worker was still polling
+  its `shutting_down` flag and wake-pipe fd (3/3 reproducible under
+  ASan; single-threaded `server_run` raced identically). `server_run`
+  and `server_run_pool` now retain the listener for the whole
+  run→join window and release it only after no worker can touch the
+  handle — the same contract `server_run_async` already followed for
+  its accept fiber. The two-phase `tcp_shutdown_listener` → join →
+  `server_stop` pattern remains valid; it is simply no longer the only
+  safe shutdown. Regression `compiler/tests/http_server_stop_direct.nu`
+  drives both fixed paths with a direct cross-thread stop (ASan-clean
+  10/10 under `NURL_NET_TESTS=1`). Closes critic.md B19 together with
+  the earlier accept-wake fix (f470571).
+
 - **`recover` leaked the closure's captured environment**
   (`stdlib/std/panic.nu`). `recover` decomposes its closure into
   `(fn_ptr, env_ptr)` and hands them to the C trampoline; passing the

--- a/compiler/tests/http_server_stop_direct.nu
+++ b/compiler/tests/http_server_stop_direct.nu
@@ -1,0 +1,105 @@
+// http_server_stop_direct.nu — regression lock for the direct
+// `server_stop`-from-another-thread shutdown path (critic.md B19).
+//
+// `server_run_pool`'s contract has always documented this shape:
+// workers block in accept, another thread calls `server_stop s`.
+// Pre-fix, that path was a heap-use-after-free: pool workers hold no
+// reference on the listener, so `server_stop`'s nurl_tcp_close freed
+// the struct while every worker was still polling it
+// (runtime.c nurl_tcp_accept's shutting_down check; 3/3 reproducible
+// under ASan). `server_run` (single-threaded) had the same race.
+//
+// The fix mirrors `server_run_async`'s existing contract: both run
+// functions retain the listener for the spawn→join window and release
+// it only after no worker can touch the handle, so a concurrent stop
+// defers the struct free instead of racing it.
+//
+// Live test (NURL_NET_TESTS=1) drives both fixed paths end to end —
+// no soft-close `tcp_shutdown_listener` staging, no deferred final
+// `server_stop`; just the documented one-call shutdown:
+//
+//   phase 1: 4-worker pool on 127.0.0.1:18801, stopper thread sleeps
+//            200 ms then calls `server_stop` directly. Pool must
+//            return Ok (no hang, no crash).
+//   phase 2: same shape against single-threaded `server_run` on
+//            127.0.0.1:18802.
+//
+// Run under run_san_tests.sh with NURL_NET_TESTS=1 to assert the
+// ASan-clean part; the plain runner asserts no hang / clean exit.
+//
+// Default (NURL_NET_TESTS unset): prints the skip notice — compile +
+// link of both paths is still exercised.
+
+$ `stdlib/ext/http_server.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/core/string.nu`
+
+// One phase: listen on `port`, spawn a thread that direct-stops the
+// server after 200 ms, run with `n_workers` (0 ⇒ single-threaded
+// server_run), report the outcome under `label`.
+@ run_stop_direct_phase i port i n_workers s label → v {
+    : !TcpListener NetErr lr ( tcp_listen_with_backlog `127.0.0.1` port 16 )
+    ?? lr {
+        F e → {
+            ( nurl_print label )
+            ( nurl_print `: listen failed: ` )
+            ( nurl_print ( net_err_name e ) )
+            ( nurl_print `\n` )
+        }
+        T listener → {
+            : ( @ HttpResponse HttpRequest ) handler \ HttpRequest req → HttpResponse {
+                ^ ( response_text 200 `ok\n` )
+            }
+            : HttpServer srv ( server_new listener handler )
+
+            : ( @ v ) stopper \ → v {
+                ( sleep_ms 200 )
+                // The point of the test: ONE direct call, from another
+                // thread, while workers are blocked in accept.
+                ( server_stop srv )
+            }
+            : !Thread ThreadErr st ( thread_spawn stopper )
+            ?? st {
+                T t → {
+                    : ~ b clean F
+                    ? > n_workers 1 {
+                        : !v NetErr rp ( server_run_pool srv n_workers )
+                        ?? rp { T _ → { = clean T } F e → {} }
+                    } {
+                        : !v NetErr rp ( server_run srv )
+                        ?? rp { T _ → { = clean T } F e → {} }
+                    }
+                    ( nurl_print label )
+                    ? clean
+                    { ( nurl_print `: clean shutdown\n` ) }
+                    { ( nurl_print `: run returned error\n` ) }
+                    ( thread_join t )
+                    : *u stopper_env # *u stopper 1
+                    ( nurl_free # s stopper_env )
+                }
+                F e → {
+                    ( nurl_print label )
+                    ( nurl_print `: stopper spawn failed: ` )
+                    ( nurl_print ( thread_err_name e ) )
+                    ( nurl_print `\n` )
+                    ( server_stop srv )
+                }
+            }
+        }
+    }
+}
+
+@ main → i {
+    : ?String gate ( env_get `NURL_NET_TESTS` )
+    ?? gate {
+        T s → {
+            ( string_free s )
+            ( run_stop_direct_phase 18801 4 `pool` )
+            ( run_stop_direct_phase 18802 0 `seq` )
+        }
+        F → { ( nurl_print `direct-stop test skipped (set NURL_NET_TESTS=1 to enable)\n` ) }
+    }
+    ^ 0
+}

--- a/stdlib/ext/http_server.nu
+++ b/stdlib/ext/http_server.nu
@@ -835,6 +835,14 @@ $ `stdlib/ext/http_response.nu`
 // server_stop), Err on infrastructure failure mid-flight.
 
 @ server_run HttpServer s → !v NetErr {
+    // Retain the listener for the duration of the loop. `server_stop`
+    // fired from another thread closes the listener fd + wakes the
+    // blocked accept, but its struct free must wait until this thread
+    // has returned from `tcp_accept` and stopped reading the handle —
+    // without the ref, the close frees the struct mid-poll
+    // (heap-use-after-free, observed under ASan). Same contract
+    // `server_run_async` already follows for its accept fiber.
+    ( tcp_listener_retain . s listener )
     // Loop forever (until either a clean stop or a real error). One
     // NURL compiler quirk still shapes this implementation:
     //   * Multiple early-`^`-returns inside `?? r { T → … F → … }` arms
@@ -863,6 +871,7 @@ $ `stdlib/ext/http_response.nu`
             }
         }
     }
+    ( tcp_listener_release . s listener )
     ? had_err
     { ^ @ !v NetErr { F last_err } }
     {}
@@ -903,6 +912,16 @@ $ `stdlib/ext/http_response.nu`
 //     exits. That's fine but observable as a small lag.
 @ server_run_pool HttpServer s i n_workers → !v NetErr {
     ? <= n_workers 1 { ^ ( server_run s ) } {}
+
+    // Retain the listener across the workers' whole lifetime. Workers
+    // blocked in `tcp_accept` hold no reference of their own, so a
+    // `server_stop` fired from another thread used to free the
+    // listener struct while every worker was still polling it
+    // (heap-use-after-free at runtime.c's shutting_down check). The
+    // ref spans spawn → join; the release below runs only after no
+    // worker can touch the handle. Same contract `server_run_async`
+    // follows for its accept fiber.
+    ( tcp_listener_retain . s listener )
 
     // Storage for n thread handles, indexed by worker number.
     : s thandles ( nurl_alloc * n_workers 8 )
@@ -973,6 +992,7 @@ $ `stdlib/ext/http_response.nu`
     // mirroring the per-server cleanup contract.
     : *u worker_env # *u worker 1
     ( nurl_free # s worker_env )
+    ( tcp_listener_release . s listener )
     ^ @ !v NetErr { T 0 }
 }
 


### PR DESCRIPTION
## Summary

Closes critic B19's residual half. The accept-**hang** was already fixed by f470571 (listener self-pipe wakeup). What remained: `server_run_pool`'s *documented* shutdown — call `server_stop s` from another thread while workers block in accept — was a **heap-use-after-free**:

- Pool workers (and the `server_run` thread) hold no reference on the listener.
- `server_stop` → `nurl_tcp_close` performs the wake side-effects, then drops the **last** ref and frees the `NurlTcp` struct — while every worker is still inside `nurl_tcp_accept`'s poll loop reading `l->shutting_down` / `l->wake_rfd`.
- 3/3 reproducible under ASan (`READ of size 4 … runtime.c:2946 … freed by nurl_tcp_close`).

`server_run_async` was already safe — it retains the listener for the life of its accept fiber.

## Fix

Give `server_run` and `server_run_pool` the same lifetime contract: `tcp_listener_retain` before entering the loop / spawning workers, `tcp_listener_release` only after the loop exits / all workers joined. A concurrent `server_stop` then defers the struct free to the release instead of racing the workers. No runtime.c change needed; the refcount machinery existed.

The two-phase `tcp_shutdown_listener` → join → `server_stop` pattern remains valid — it's just no longer the only safe shutdown.

## Verification

- Pre-fix probe (direct stop, 4 workers, ASan): **3/3 UAF**. Post-fix: **10/10 clean**, `pool: clean shutdown`, no LSan leaks (refcount balances to destroy-once).
- New regression `compiler/tests/http_server_stop_direct.nu`: pool (4 workers) + single-threaded `server_run`, each stopped by one direct cross-thread `server_stop`; ASan-clean 10/10 with `NURL_NET_TESTS=1`.
- Existing `http_server_pool.nu` + `async_http_server.nu` live tests: still green (3 consecutive runs each).
- Full suite: **333 PASS · 0 FAIL · 0 MISSING · 0 ORPHAN**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)