### PR TITLE
feat(compiler): 'statement has no effect' warning — last silent prefix-arity cascade (critic A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **"Statement has no effect" warning — the last silent prefix-arity
+  cascade is now diagnosed** (`compiler/nurlc.nu`, critic A2). A
+  statement that produces a value without being a call or control flow
+  (bare local identifier, operator expression like `+ a 1`, a `#` cast,
+  a `.` field read) discards that value silently — under prefix
+  notation with fixed arity and no closing token, this is exactly the
+  residue left when an operator short an argument swallows the next
+  statement's leading token. The bare-literal flavor was already a
+  hard error (dangling operand); these shapes name real bindings, so
+  they warn. Value-block tail expressions (the block result), calls,
+  and `?`/`??` statements (their arms may be effectful) are exempt.
+  The diagnostic embeds the dead statement's own line — by the time
+  the block iterator sees the flag, the lexer already points at the
+  next statement. Tree-wide false-positive check: nurlc.nu
+  self-compile, the full stdlib, nurlapi, and examples produce ZERO
+  warnings. Locks: `should_warn_dead_value.nu` (four dead shapes warn;
+  tail/call/return stay silent), and `should_warn_caret_xor.nu` now
+  also catches the previously silent dead `b` in `: i x ^ a b`. This
+  closes the last undiagnosed half of the prefix-arity cascade family
+  (critic §4); the A3 closing-delimiter decision can cite it as the
+  mitigation.
+
 - **`std/bigint`: arbitrary-precision division and modulo** —
   `bigint_div` / `bigint_rem` (`stdlib/std/bigint.nu`), closing the last
   gap in the bigint arithmetic surface. The magnitude core is Knuth

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -1636,6 +1636,19 @@
 // via a block iterator), so this never false-flags an arm value.
 : ~ i g_stmt_bare_lit 0
 
+// g_stmt_bare_value — the literal flag's general sibling (critic A2,
+// the last silent prefix-arity cascade): set by gen_stmt to 1 when the
+// statement it just parsed produced a VALUE without being a call or
+// control flow — a bare local/param/const identifier, an operator
+// expression (`+ a 1`), a `#` cast, a `.` field read, an `@` aggregate
+// literal. Such a statement's value is discarded; the block iterators
+// WARN (not die — unlike a literal, these shapes at least name real
+// bindings) unless it is a value-block's final expression (the block
+// result). Recomputed unconditionally at the END of every gen_stmt
+// from the statement's own leading token + result type, so nested
+// blocks parsed mid-statement cannot leak a stale flag outward.
+: ~ i g_stmt_bare_value 0
+
 // __tok_label — a human-readable name for a token that turned up where
 // a value expression was required. Used only on the diagnostic path.
 @ __tok_label i tt s val → s {
@@ -6084,6 +6097,20 @@
     ^ `literal as a statement has no effect — its value is discarded. This usually means a prefix operator was given one operand too many (a dangling operand): e.g. '& x 255 0x40' parses as '& x 255' and silently drops the 0x40. Check the operator's arity.`
 }
 
+// The literal diagnostic's general sibling (critic A2): a bare
+// identifier / operator expression / cast / field read in statement
+// position whose value is discarded. WARN rather than die — unlike a
+// bare literal these shapes name real bindings, and the residual
+// prefix-arity cascade they catch (an operator short an argument
+// swallowed the next statement's leading token, leaving this dead
+// remainder) is otherwise completely silent. `line` is the dead
+// statement's own line — lex has already advanced to the next
+// statement when the block iterator fires this.
+@ __dead_value_msg i line → s {
+    ^ ( nurl_str_cat3 `the statement on line ` ( nurl_str_int line )
+    ` has no effect — it produces a value that is discarded. If it was meant as an operand, the prefix operator before it is short an argument (fixed arity, no closing bracket); otherwise bind the value (': T name …') or remove the statement.` )
+}
+
 @ gen_block_stmts i lex i syms i cg → v {
     : i bck_line ( nurl_lex_line lex )
     ( expect lex TT_LBRACE )
@@ -6093,6 +6120,7 @@
         // Every statement in a void block has its value discarded, so a
         // bare literal here is dead — reject it (dangling operand).
         ? != 0 g_stmt_bare_lit { ( die lex ( __dangling_operand_msg ) ) } {}
+        ? != 0 g_stmt_bare_value { ( warn lex ( __dead_value_msg g_stmt_bare_value ) ) } {}
     }
     ( expect lex TT_RBRACE )
     ( bck_block_exit )
@@ -6113,9 +6141,12 @@
         // A bare literal that is NOT the block's final expression (its
         // return value) has its value discarded — reject it as a dangling
         // operand. The final literal (next token `}`) is the legitimate
-        // block result and is left alone.
+        // block result and is left alone. Same tail exemption for the
+        // dead-value warning below.
         ? & != 0 g_stmt_bare_lit != ( nurl_lex_type lex ) TT_RBRACE
         { ( die lex ( __dangling_operand_msg ) ) } {}
+        ? & != 0 g_stmt_bare_value != ( nurl_lex_type lex ) TT_RBRACE
+        { ( warn lex ( __dead_value_msg g_stmt_bare_value ) ) } {}
     }
     ( expect lex TT_RBRACE )
     ( bck_block_exit )
@@ -7392,7 +7423,33 @@
     // their operands), so this is robust against nested blocks overwriting
     // the flag mid-parse. See g_stmt_bare_lit.
     = g_stmt_bare_lit ? | | == tt TT_INT == tt TT_FLOAT == tt TT_STR 1 0
+    // Flag a non-call value-producing statement for the block iterator's
+    // dead-value warning (see g_stmt_bare_value). Computed from this
+    // statement's own leading token + final last_type, overwriting
+    // whatever nested blocks set mid-parse. Calls (effects), `?`/`??`
+    // (their arms may be effectful calls), and the void-publishing
+    // statement forms (`:`/`=`/`~`/`;`) are excluded; literals carry
+    // their own harder diagnostic and are excluded to keep it single.
+    // The flag carries the dead statement's own LINE (not just 1): by
+    // the time the block iterator reads it, lex already points at the
+    // NEXT statement, so the diagnostic embeds the real line instead
+    // of blaming the innocent neighbour.
+    = g_stmt_bare_value ? ( __stmt_is_bare_value tt ( nurl_get_last_type ) ) bck_line 0
     gs_rv
+}
+
+// True when a statement with leading token `tt` whose generation left
+// `lt` in last_type is a dead value expression: not a declaration /
+// assignment / loop / defer / call / conditional / match / literal,
+// and the produced type is non-void.
+@ __stmt_is_bare_value i tt s lt → b {
+    ? | | | == tt TT_COLON == tt TT_EQ == tt TT_TILDE == tt TT_SEMICOL
+    { ^ F } {}
+    ? | | == tt TT_LPAREN == tt TT_QUEST == tt TT_QUESTQUEST
+    { ^ F } {}
+    ? | | == tt TT_INT == tt TT_FLOAT == tt TT_STR
+    { ^ F } {}
+    ^ ! ( seq lt `void` )
 }
 
 // Soft check for the same-line shadow pattern: a `:` binding declares

--- a/compiler/tests/outputs/should_warn_caret_xor.txt
+++ b/compiler/tests/outputs/should_warn_caret_xor.txt
@@ -3,6 +3,9 @@ WARNINGS
 compiler/tests/should_warn_caret_xor.nu:20:15: warning: '^' is the return operator; did you mean '^^' for XOR? (Two adjacent carets, no space between them)
     : i x ^ a b  // ← warns: `^` returns `a`, `b` is dead
               ^
+compiler/tests/should_warn_caret_xor.nu:21:5: warning: the statement on line 20 has no effect — it produces a value that is discarded. If it was meant as an operand, the prefix operator before it is short an argument (fixed arity, no closing bracket); otherwise bind the value (': T name …') or remove the statement.
+    ^ x
+    ^
 compiler/tests/should_warn_caret_xor.nu:25:9: warning: '^' is the return operator; did you mean '^^' for XOR? (Two adjacent carets, no space between them)
     ^ a b  // ← warns: `^` returns `a`, `b` is dead
         ^

--- a/compiler/tests/outputs/should_warn_dead_value.txt
+++ b/compiler/tests/outputs/should_warn_dead_value.txt
@@ -1,0 +1,19 @@
+COMPILE OK
+WARNINGS
+compiler/tests/should_warn_dead_value.nu:25:5: warning: the statement on line 22 has no effect — it produces a value that is discarded. If it was meant as an operand, the prefix operator before it is short an argument (fixed arity, no closing bracket); otherwise bind the value (': T name …') or remove the statement.
+    + a 1
+    ^
+compiler/tests/should_warn_dead_value.nu:28:5: warning: the statement on line 25 has no effect — it produces a value that is discarded. If it was meant as an operand, the prefix operator before it is short an argument (fixed arity, no closing bracket); otherwise bind the value (': T name …') or remove the statement.
+    # i8 a
+    ^
+compiler/tests/should_warn_dead_value.nu:31:5: warning: the statement on line 28 has no effect — it produces a value that is discarded. If it was meant as an operand, the prefix operator before it is short an argument (fixed arity, no closing bracket); otherwise bind the value (': T name …') or remove the statement.
+    . p x
+    ^
+compiler/tests/should_warn_dead_value.nu:34:5: warning: the statement on line 31 has no effect — it produces a value that is discarded. If it was meant as an operand, the prefix operator before it is short an argument (fixed arity, no closing bracket); otherwise bind the value (': T name …') or remove the statement.
+    : i b ? > a 0 { + a 10 } { 0 }
+    ^
+LINK OK
+EXIT 0
+OUTPUT
+15
+ok

--- a/compiler/tests/should_warn_dead_value.nu
+++ b/compiler/tests/should_warn_dead_value.nu
@@ -1,0 +1,40 @@
+// should_warn_dead_value.nu — critic A2: the last silent prefix-arity
+// cascade. A statement that produces a value without being a call or
+// control flow (bare local identifier, operator expression, `#` cast,
+// `.` field read) discards that value — under prefix notation this is
+// exactly the residue a fixed-arity operator leaves behind when it is
+// short an argument and swallows the next statement's leading token.
+// The bare-LITERAL flavor has always been a hard error (dangling
+// operand); these shapes name real bindings, so they warn.
+//
+// The golden locks BOTH directions: each dead statement below warns
+// exactly once, and the legitimate tail-value shapes (a value-block's
+// final expression, a `^` return operand) stay silent — the program
+// still compiles, links, runs, and prints its expected output.
+
+: Pt { i x i y }
+
+@ main → i {
+    : i a 5
+    : Pt p @ Pt { 1 2 }
+
+    // Dead bare identifier — the classic swallowed-remainder shape.
+    a
+
+    // Dead operator expression: computes a+1, discards it.
+    + a 1
+
+    // Dead cast.
+    # i8 a
+
+    // Dead field read.
+    . p x
+
+    // NOT warned: value-block tail — the block result feeds the binding.
+    : i b ? > a 0 { + a 10 } { 0 }
+    ( nurl_print_int b )
+
+    // NOT warned: call statement (effects) and `^` return operand.
+    ( nurl_print `ok\n` )
+    ^ 0
+}


### PR DESCRIPTION
## Summary

Closes critic A2. The undefined-identifier, statement-boundary, and within-statement `^`-swallow halves of the prefix-arity cascade are already hard errors; the one residual was a swallowed **bare value token that happens to typecheck** — fully silent. This adds the warning critic A2 prescribed: statement position, value produced, value unused, not a call.

## What warns

- bare local/param/const identifier as a statement
- operator expression (`+ a 1`)
- `#` cast, `.` field read, `@` aggregate literal

## What stays silent

- value-block **tail** expressions (the block result — same exemption the bare-literal die already had)
- calls (effects) and `?`/`??` statements (arms may be effectful calls)
- bare literals — they keep their existing **harder** diagnostic (dangling-operand die)

## Mechanism

`g_stmt_bare_value`, the general sibling of `g_stmt_bare_lit`: recomputed unconditionally at the end of every `gen_stmt` from the statement's own leading token + result type, so nested blocks parsed mid-statement can't leak a stale flag outward. The flag carries the dead statement's **own line** — the block iterators fire after the lexer has advanced to the next statement, so the message names the culprit ("the statement on line 22 has no effect…") instead of blaming the innocent neighbour.

## False-positive sweep

`nurlc.nu` self-compile + full stdlib + nurlapi + examples: **zero warnings tree-wide.**

## Verification

- Suite: **336 PASS · 0 FAIL · 0 MISSING · 0 ORPHAN**
- New lock `should_warn_dead_value.nu`: four dead shapes warn exactly once; tail/call/return silent; program still compiles, links, runs with expected output
- `should_warn_caret_xor.nu`'s golden now also catches the previously silent dead `b` in `: i x ^ a b` — the exact swallowed-remainder shape A2 described
- No codegen change: fixed point holds without a bootstrap refresh

With this, every half of the prefix-arity cascade family is diagnosed — the A3 closing-delimiter grammar decision can cite this as its mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)