### PR TITLE
fix(gameboy): halt-bug replay leaked into interrupt handlers — Tobu's deterministic ~90 s crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (examples)
+
+- **Game Boy emulator: deterministic ~90 s crash on Tobu Tobu Girl's
+  title screen** (`examples/gameboy/core.nu`). Root cause was a
+  halt-bug emulation error, found by stack forensics on an
+  instruction trace: `EI` + `HALT` with a timer IRQ landing inside
+  HALT's own 4-cycle window set `g_halt_bug`, the EI delay then raised
+  IME and the interrupt dispatched immediately — and the stale
+  halt-bug flag replayed the HANDLER's first instruction (PC failed to
+  advance once inside the handler). Tobu's handler starts with
+  `PUSH HL`, so SP skewed by 2 and `RETI` returned into WRAM data —
+  the screen froze and execution fell into a RST 38 loop (the gray
+  bars + hang seen on the playground). Two-part fix per Pan Docs:
+  (1) `EI` immediately before `HALT` with a pending interrupt is NOT
+  the halt bug — the interrupt is serviced with the HALT's own address
+  as the return address; (2) invariant: an interrupt dispatch always
+  clears the halt-bug replay (it applies to the next sequential fetch
+  only, never the handler's). Verified: Blargg `cpu_instrs` 11/11 +
+  `02-interrupts` + `instr_timing` still pass, dmg-acid2 renders, and
+  a 40 000-frame idle soak (vs the ~2 918-frame crash) runs ASan-clean
+  with a live framebuffer. Also: migrated `examples/gameboy` to the
+  enforced `:` immutability (97 declarations — it sits outside the
+  test suite, so the tree-wide migration missed it; all gameboy
+  targets compile again, playground build regenerated), and fixed
+  `gbtrace.nu --trace` to drive the real `cpu_advance` path (its
+  hand-rolled step loop was a stale copy that never woke from HALT).
+
 ### Added
 
 - **Enum payload residuals diagnosed — ghost variants and unsized

--- a/examples/gameboy/README.md
+++ b/examples/gameboy/README.md
@@ -11,6 +11,16 @@ CB-prefix instruction, exact Z/N/H/C flag semantics, DAA, the EI/DI/IME
 interrupt-enable delay, HALT (and the HALT bug), and the DIV/TIMA timer
 are implemented and externally verified.
 
+HALT-bug edges (Pan Docs): the PC-replay applies to the next
+*sequential* fetch only — an interrupt dispatch cancels it (it must
+never replay the handler's first instruction). And `EI` immediately
+before `HALT` with an interrupt already pending is *not* the halt bug:
+the interrupt is serviced normally with the HALT's own address as the
+return address. Getting these wrong skewed SP by 2 once per ~3000 idle
+frames in Tobu Tobu Girl (a timer IRQ landing in HALT's own 4-cycle
+window after `EI`) — the deterministic "crashes after ~90 s on the
+title screen" bug.
+
 ```
 01-special              Passed      07-jr,jp,call,ret,rst   Passed
 02-interrupts           Passed      08-misc instrs          Passed

--- a/examples/gameboy/core.nu
+++ b/examples/gameboy/core.nu
@@ -9,78 +9,78 @@ $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 
 // ── Machine state (single instance — module globals) ──────────────
-: s g_mem 0            // 64 KiB flat address space (*u, held as s)
-: i ra 0
-: i rf 0
-: i rb 0
-: i rc 0
-: i rd 0
-: i re 0
-: i rh 0
-: i rl 0
-: i sp 0
-: i pc 0
-: i g_ime 0           // interrupt master enable
-: i g_ime_next 0      // EI enables IME after the FOLLOWING instruction
-: i g_halt 0
-: i g_halt_bug 0      // HALT with IME=0 and a pending interrupt
-: i g_div 0           // internal 16-bit divider; DIV is its high byte
-: i g_cycles 0
-: String g_serial 0   // captured serial output
+: ~ s g_mem 0            // 64 KiB flat address space (*u, held as s)
+: ~ i ra 0
+: ~ i rf 0
+: ~ i rb 0
+: ~ i rc 0
+: ~ i rd 0
+: ~ i re 0
+: ~ i rh 0
+: ~ i rl 0
+: ~ i sp 0
+: ~ i pc 0
+: ~ i g_ime 0           // interrupt master enable
+: ~ i g_ime_next 0      // EI enables IME after the FOLLOWING instruction
+: ~ i g_halt 0
+: ~ i g_halt_bug 0      // HALT with IME=0 and a pending interrupt
+: ~ i g_div 0           // internal 16-bit divider; DIV is its high byte
+: ~ i g_cycles 0
+: ~ String g_serial 0   // captured serial output
 
 // ── Cartridge / MBC state ────────────────────────────────────────
-: s g_rom 0           // full cartridge ROM (*u, all banks)
-: i g_romsize 0       // ROM size in bytes (a power of two)
-: s g_eram 0          // external cartridge RAM (*u, up to 128 KiB)
-: i g_mbc 0           // mapper: 0 none, 1 MBC1, 3 MBC3, 5 MBC5
-: i g_rombank 1       // current 0x4000-0x7FFF ROM bank
-: i g_rambank 0       // current 0xA000-0xBFFF RAM bank
-: i g_ram_en 0        // external RAM enabled
-: i g_mode 0          // MBC1 banking mode (0 ROM, 1 RAM)
-: i g_joyp 0          // joypad button state (1 = pressed), bits below
-: i g_joysel 0        // last write to JOYP select bits (P14/P15)
+: ~ s g_rom 0           // full cartridge ROM (*u, all banks)
+: ~ i g_romsize 0       // ROM size in bytes (a power of two)
+: ~ s g_eram 0          // external cartridge RAM (*u, up to 128 KiB)
+: ~ i g_mbc 0           // mapper: 0 none, 1 MBC1, 3 MBC3, 5 MBC5
+: ~ i g_rombank 1       // current 0x4000-0x7FFF ROM bank
+: ~ i g_rambank 0       // current 0xA000-0xBFFF RAM bank
+: ~ i g_ram_en 0        // external RAM enabled
+: ~ i g_mode 0          // MBC1 banking mode (0 ROM, 1 RAM)
+: ~ i g_joyp 0          // joypad button state (1 = pressed), bits below
+: ~ i g_joysel 0        // last write to JOYP select bits (P14/P15)
 
 // ── APU (sound) state ────────────────────────────────────────────
 // Four channels mixed to a packed-stereo i64 ring (low16=L, bits16-31=R)
 // the host drains each frame into Web Audio. Output sample rate is fixed
 // (g_smp_rate); the frame sequencer ticks at 512 Hz (every 8192 T-cycles).
-: i g_apu_on 0        // NR52 bit7 (master power)
-: i g_nr50 0          // master volume + VIN select (FF24)
-: i g_nr51 0          // channel→L/R panning (FF25)
-: i g_fs_acc 0        // frame-sequencer T-cycle accumulator
-: i g_fs_step 0       // frame-sequencer step 0..7
-: i g_smp_acc 0       // resampling accumulator (adds rate/cycle; emit at 4194304)
+: ~ i g_apu_on 0        // NR52 bit7 (master power)
+: ~ i g_nr50 0          // master volume + VIN select (FF24)
+: ~ i g_nr51 0          // channel→L/R panning (FF25)
+: ~ i g_fs_acc 0        // frame-sequencer T-cycle accumulator
+: ~ i g_fs_step 0       // frame-sequencer step 0..7
+: ~ i g_smp_acc 0       // resampling accumulator (adds rate/cycle; emit at 4194304)
 : i g_smp_rate 48000  // output sample rate (Hz)
-: s g_audio 0         // *i stereo sample ring
-: i g_audio_len 0     // samples written since the last host drain
-: i g_audio_cap 0     // ring capacity (samples)
-: i g_hp_l 0          // DC estimate for the L high-pass (DMG capacitor)
-: i g_hp_r 0          // DC estimate for the R high-pass
+: ~ s g_audio 0         // *i stereo sample ring
+: ~ i g_audio_len 0     // samples written since the last host drain
+: ~ i g_audio_cap 0     // ring capacity (samples)
+: ~ i g_hp_l 0          // DC estimate for the L high-pass (DMG capacitor)
+: ~ i g_hp_r 0          // DC estimate for the R high-pass
 
 // Channel 1 — square + frequency sweep
-: i c1_en 0   : i c1_dac 0   : i c1_freq 0  : i c1_tmr 0
-: i c1_duty 0 : i c1_dpos 0  : i c1_len 0   : i c1_lenen 0
-: i c1_vol 0  : i c1_envdir 0 : i c1_envper 0 : i c1_envtmr 0
-: i c1_swper 0 : i c1_swdir 0 : i c1_swsh 0 : i c1_swtmr 0 : i c1_swen 0 : i c1_shadow 0
+: ~ i c1_en 0   : ~ i c1_dac 0   : ~ i c1_freq 0  : ~ i c1_tmr 0
+: ~ i c1_duty 0 : ~ i c1_dpos 0  : ~ i c1_len 0   : ~ i c1_lenen 0
+: ~ i c1_vol 0  : ~ i c1_envdir 0 : ~ i c1_envper 0 : ~ i c1_envtmr 0
+: ~ i c1_swper 0 : ~ i c1_swdir 0 : ~ i c1_swsh 0 : ~ i c1_swtmr 0 : ~ i c1_swen 0 : ~ i c1_shadow 0
 // Channel 2 — square
-: i c2_en 0   : i c2_dac 0   : i c2_freq 0  : i c2_tmr 0
-: i c2_duty 0 : i c2_dpos 0  : i c2_len 0   : i c2_lenen 0
-: i c2_vol 0  : i c2_envdir 0 : i c2_envper 0 : i c2_envtmr 0
+: ~ i c2_en 0   : ~ i c2_dac 0   : ~ i c2_freq 0  : ~ i c2_tmr 0
+: ~ i c2_duty 0 : ~ i c2_dpos 0  : ~ i c2_len 0   : ~ i c2_lenen 0
+: ~ i c2_vol 0  : ~ i c2_envdir 0 : ~ i c2_envper 0 : ~ i c2_envtmr 0
 // Channel 3 — wave (32×4-bit samples from wave RAM 0xFF30..0xFF3F)
-: i c3_en 0   : i c3_dac 0   : i c3_freq 0  : i c3_tmr 0
-: i c3_pos 0  : i c3_len 0   : i c3_lenen 0 : i c3_volcode 0 : i c3_sample 0
+: ~ i c3_en 0   : ~ i c3_dac 0   : ~ i c3_freq 0  : ~ i c3_tmr 0
+: ~ i c3_pos 0  : ~ i c3_len 0   : ~ i c3_lenen 0 : ~ i c3_volcode 0 : ~ i c3_sample 0
 // Channel 4 — noise (LFSR)
-: i c4_en 0   : i c4_dac 0   : i c4_tmr 0   : i c4_lfsr 0
-: i c4_len 0  : i c4_lenen 0 : i c4_width 0 : i c4_div 0 : i c4_shift 0
-: i c4_vol 0  : i c4_envdir 0 : i c4_envper 0 : i c4_envtmr 0
+: ~ i c4_en 0   : ~ i c4_dac 0   : ~ i c4_tmr 0   : ~ i c4_lfsr 0
+: ~ i c4_len 0  : ~ i c4_lenen 0 : ~ i c4_width 0 : ~ i c4_div 0 : ~ i c4_shift 0
+: ~ i c4_vol 0  : ~ i c4_envdir 0 : ~ i c4_envper 0 : ~ i c4_envtmr 0
 
 // ── PPU state ────────────────────────────────────────────────────
-: s g_fb 0            // 160×144 framebuffer of shades (0=white..3=black)
-: s g_bgidx 0         // per-scanline BG colour indices (for sprite priority)
-: s g_spr 0           // scratch: OAM indices of the ≤10 sprites on a line
-: i g_dot 0           // dot counter within the current scanline
-: i g_wly 0           // window internal line counter (advances only when drawn)
-: i g_frames 0        // completed frames (incremented at vblank)
+: ~ s g_fb 0            // 160×144 framebuffer of shades (0=white..3=black)
+: ~ s g_bgidx 0         // per-scanline BG colour indices (for sprite priority)
+: ~ s g_spr 0           // scratch: OAM indices of the ≤10 sprites on a line
+: ~ i g_dot 0           // dot counter within the current scanline
+: ~ i g_wly 0           // window internal line counter (advances only when drawn)
+: ~ i g_frames 0        // completed frames (incremented at vblank)
 
 // ── Flag register helpers (F = Z N H C 0 0 0 0) ──────────────────
 @ set_flags i z i n i h i c → v {
@@ -445,6 +445,11 @@ $ `stdlib/core/vec.nu`
     ( wr8 0xFF0F & iflag ^^ bit 0xFF )
     ( push16 pc )
     = pc vec
+    // Invariant: the halt bug's "PC fails to advance once" applies to
+    // the next SEQUENTIAL fetch. An interrupt dispatch replaces that
+    // fetch with the handler's — the replay must never leak into the
+    // handler (it would double its first instruction and skew SP).
+    = g_halt_bug 0
     ^ 20
 }
 
@@ -756,7 +761,33 @@ $ `stdlib/core/vec.nu`
         ? == op 0x76 {
             = g_halt 1
             ? == g_ime 0 {
-                ? != 0 & & ( rd8 0xFF0F ) ( rd8 0xFFFF ) 0x1F { = g_halt_bug 1  = g_halt 0 } {}
+                ? != 0 & & ( rd8 0xFF0F ) ( rd8 0xFFFF ) 0x1F {
+                    ? != ime_apply 0 {
+                        // EI immediately before HALT with an interrupt
+                        // already pending: NOT the halt bug (Pan Docs).
+                        // IME rises right after this instruction, the
+                        // interrupt is serviced normally, and the pushed
+                        // return address is the HALT itself — the handler
+                        // returns to the HALT, which then sleeps with the
+                        // interrupt already consumed. Rewind PC onto the
+                        // HALT so service_interrupts pushes its address.
+                        //
+                        // The previous behaviour set g_halt_bug here; the
+                        // flag then survived the interrupt dispatch and
+                        // replayed the HANDLER's first instruction (PC
+                        // failed to advance once inside the handler). For
+                        // Tobu Tobu Girl that doubled the handler's
+                        // PUSH HL, skewing the stack by 2 — RETI returned
+                        // into WRAM data and the game crashed to a RST 38
+                        // loop. The race (IF rising in HALT's own 4-cycle
+                        // window after EI) hits ~once per 3000 idle
+                        // frames, the observed deterministic ~90 s hang.
+                        = g_halt 0
+                        = pc & - pc 1 0xFFFF
+                    } {
+                        = g_halt_bug 1  = g_halt 0
+                    }
+                } {}
             } {}
         } {
             ( set_r & >> op 3 7 ( get_r & op 7 ) )

--- a/examples/gameboy/gb_wasm_full.nu
+++ b/examples/gameboy/gb_wasm_full.nu
@@ -9,78 +9,78 @@ $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 
 // ── Machine state (single instance — module globals) ──────────────
-: s g_mem 0            // 64 KiB flat address space (*u, held as s)
-: i ra 0
-: i rf 0
-: i rb 0
-: i rc 0
-: i rd 0
-: i re 0
-: i rh 0
-: i rl 0
-: i sp 0
-: i pc 0
-: i g_ime 0           // interrupt master enable
-: i g_ime_next 0      // EI enables IME after the FOLLOWING instruction
-: i g_halt 0
-: i g_halt_bug 0      // HALT with IME=0 and a pending interrupt
-: i g_div 0           // internal 16-bit divider; DIV is its high byte
-: i g_cycles 0
-: String g_serial 0   // captured serial output
+: ~ s g_mem 0            // 64 KiB flat address space (*u, held as s)
+: ~ i ra 0
+: ~ i rf 0
+: ~ i rb 0
+: ~ i rc 0
+: ~ i rd 0
+: ~ i re 0
+: ~ i rh 0
+: ~ i rl 0
+: ~ i sp 0
+: ~ i pc 0
+: ~ i g_ime 0           // interrupt master enable
+: ~ i g_ime_next 0      // EI enables IME after the FOLLOWING instruction
+: ~ i g_halt 0
+: ~ i g_halt_bug 0      // HALT with IME=0 and a pending interrupt
+: ~ i g_div 0           // internal 16-bit divider; DIV is its high byte
+: ~ i g_cycles 0
+: ~ String g_serial 0   // captured serial output
 
 // ── Cartridge / MBC state ────────────────────────────────────────
-: s g_rom 0           // full cartridge ROM (*u, all banks)
-: i g_romsize 0       // ROM size in bytes (a power of two)
-: s g_eram 0          // external cartridge RAM (*u, up to 128 KiB)
-: i g_mbc 0           // mapper: 0 none, 1 MBC1, 3 MBC3, 5 MBC5
-: i g_rombank 1       // current 0x4000-0x7FFF ROM bank
-: i g_rambank 0       // current 0xA000-0xBFFF RAM bank
-: i g_ram_en 0        // external RAM enabled
-: i g_mode 0          // MBC1 banking mode (0 ROM, 1 RAM)
-: i g_joyp 0          // joypad button state (1 = pressed), bits below
-: i g_joysel 0        // last write to JOYP select bits (P14/P15)
+: ~ s g_rom 0           // full cartridge ROM (*u, all banks)
+: ~ i g_romsize 0       // ROM size in bytes (a power of two)
+: ~ s g_eram 0          // external cartridge RAM (*u, up to 128 KiB)
+: ~ i g_mbc 0           // mapper: 0 none, 1 MBC1, 3 MBC3, 5 MBC5
+: ~ i g_rombank 1       // current 0x4000-0x7FFF ROM bank
+: ~ i g_rambank 0       // current 0xA000-0xBFFF RAM bank
+: ~ i g_ram_en 0        // external RAM enabled
+: ~ i g_mode 0          // MBC1 banking mode (0 ROM, 1 RAM)
+: ~ i g_joyp 0          // joypad button state (1 = pressed), bits below
+: ~ i g_joysel 0        // last write to JOYP select bits (P14/P15)
 
 // ── APU (sound) state ────────────────────────────────────────────
 // Four channels mixed to a packed-stereo i64 ring (low16=L, bits16-31=R)
 // the host drains each frame into Web Audio. Output sample rate is fixed
 // (g_smp_rate); the frame sequencer ticks at 512 Hz (every 8192 T-cycles).
-: i g_apu_on 0        // NR52 bit7 (master power)
-: i g_nr50 0          // master volume + VIN select (FF24)
-: i g_nr51 0          // channel→L/R panning (FF25)
-: i g_fs_acc 0        // frame-sequencer T-cycle accumulator
-: i g_fs_step 0       // frame-sequencer step 0..7
-: i g_smp_acc 0       // resampling accumulator (adds rate/cycle; emit at 4194304)
+: ~ i g_apu_on 0        // NR52 bit7 (master power)
+: ~ i g_nr50 0          // master volume + VIN select (FF24)
+: ~ i g_nr51 0          // channel→L/R panning (FF25)
+: ~ i g_fs_acc 0        // frame-sequencer T-cycle accumulator
+: ~ i g_fs_step 0       // frame-sequencer step 0..7
+: ~ i g_smp_acc 0       // resampling accumulator (adds rate/cycle; emit at 4194304)
 : i g_smp_rate 48000  // output sample rate (Hz)
-: s g_audio 0         // *i stereo sample ring
-: i g_audio_len 0     // samples written since the last host drain
-: i g_audio_cap 0     // ring capacity (samples)
-: i g_hp_l 0          // DC estimate for the L high-pass (DMG capacitor)
-: i g_hp_r 0          // DC estimate for the R high-pass
+: ~ s g_audio 0         // *i stereo sample ring
+: ~ i g_audio_len 0     // samples written since the last host drain
+: ~ i g_audio_cap 0     // ring capacity (samples)
+: ~ i g_hp_l 0          // DC estimate for the L high-pass (DMG capacitor)
+: ~ i g_hp_r 0          // DC estimate for the R high-pass
 
 // Channel 1 — square + frequency sweep
-: i c1_en 0   : i c1_dac 0   : i c1_freq 0  : i c1_tmr 0
-: i c1_duty 0 : i c1_dpos 0  : i c1_len 0   : i c1_lenen 0
-: i c1_vol 0  : i c1_envdir 0 : i c1_envper 0 : i c1_envtmr 0
-: i c1_swper 0 : i c1_swdir 0 : i c1_swsh 0 : i c1_swtmr 0 : i c1_swen 0 : i c1_shadow 0
+: ~ i c1_en 0   : ~ i c1_dac 0   : ~ i c1_freq 0  : ~ i c1_tmr 0
+: ~ i c1_duty 0 : ~ i c1_dpos 0  : ~ i c1_len 0   : ~ i c1_lenen 0
+: ~ i c1_vol 0  : ~ i c1_envdir 0 : ~ i c1_envper 0 : ~ i c1_envtmr 0
+: ~ i c1_swper 0 : ~ i c1_swdir 0 : ~ i c1_swsh 0 : ~ i c1_swtmr 0 : ~ i c1_swen 0 : ~ i c1_shadow 0
 // Channel 2 — square
-: i c2_en 0   : i c2_dac 0   : i c2_freq 0  : i c2_tmr 0
-: i c2_duty 0 : i c2_dpos 0  : i c2_len 0   : i c2_lenen 0
-: i c2_vol 0  : i c2_envdir 0 : i c2_envper 0 : i c2_envtmr 0
+: ~ i c2_en 0   : ~ i c2_dac 0   : ~ i c2_freq 0  : ~ i c2_tmr 0
+: ~ i c2_duty 0 : ~ i c2_dpos 0  : ~ i c2_len 0   : ~ i c2_lenen 0
+: ~ i c2_vol 0  : ~ i c2_envdir 0 : ~ i c2_envper 0 : ~ i c2_envtmr 0
 // Channel 3 — wave (32×4-bit samples from wave RAM 0xFF30..0xFF3F)
-: i c3_en 0   : i c3_dac 0   : i c3_freq 0  : i c3_tmr 0
-: i c3_pos 0  : i c3_len 0   : i c3_lenen 0 : i c3_volcode 0 : i c3_sample 0
+: ~ i c3_en 0   : ~ i c3_dac 0   : ~ i c3_freq 0  : ~ i c3_tmr 0
+: ~ i c3_pos 0  : ~ i c3_len 0   : ~ i c3_lenen 0 : ~ i c3_volcode 0 : ~ i c3_sample 0
 // Channel 4 — noise (LFSR)
-: i c4_en 0   : i c4_dac 0   : i c4_tmr 0   : i c4_lfsr 0
-: i c4_len 0  : i c4_lenen 0 : i c4_width 0 : i c4_div 0 : i c4_shift 0
-: i c4_vol 0  : i c4_envdir 0 : i c4_envper 0 : i c4_envtmr 0
+: ~ i c4_en 0   : ~ i c4_dac 0   : ~ i c4_tmr 0   : ~ i c4_lfsr 0
+: ~ i c4_len 0  : ~ i c4_lenen 0 : ~ i c4_width 0 : ~ i c4_div 0 : ~ i c4_shift 0
+: ~ i c4_vol 0  : ~ i c4_envdir 0 : ~ i c4_envper 0 : ~ i c4_envtmr 0
 
 // ── PPU state ────────────────────────────────────────────────────
-: s g_fb 0            // 160×144 framebuffer of shades (0=white..3=black)
-: s g_bgidx 0         // per-scanline BG colour indices (for sprite priority)
-: s g_spr 0           // scratch: OAM indices of the ≤10 sprites on a line
-: i g_dot 0           // dot counter within the current scanline
-: i g_wly 0           // window internal line counter (advances only when drawn)
-: i g_frames 0        // completed frames (incremented at vblank)
+: ~ s g_fb 0            // 160×144 framebuffer of shades (0=white..3=black)
+: ~ s g_bgidx 0         // per-scanline BG colour indices (for sprite priority)
+: ~ s g_spr 0           // scratch: OAM indices of the ≤10 sprites on a line
+: ~ i g_dot 0           // dot counter within the current scanline
+: ~ i g_wly 0           // window internal line counter (advances only when drawn)
+: ~ i g_frames 0        // completed frames (incremented at vblank)
 
 // ── Flag register helpers (F = Z N H C 0 0 0 0) ──────────────────
 @ set_flags i z i n i h i c → v {
@@ -445,6 +445,11 @@ $ `stdlib/core/vec.nu`
     ( wr8 0xFF0F & iflag ^^ bit 0xFF )
     ( push16 pc )
     = pc vec
+    // Invariant: the halt bug's "PC fails to advance once" applies to
+    // the next SEQUENTIAL fetch. An interrupt dispatch replaces that
+    // fetch with the handler's — the replay must never leak into the
+    // handler (it would double its first instruction and skew SP).
+    = g_halt_bug 0
     ^ 20
 }
 
@@ -756,7 +761,33 @@ $ `stdlib/core/vec.nu`
         ? == op 0x76 {
             = g_halt 1
             ? == g_ime 0 {
-                ? != 0 & & ( rd8 0xFF0F ) ( rd8 0xFFFF ) 0x1F { = g_halt_bug 1  = g_halt 0 } {}
+                ? != 0 & & ( rd8 0xFF0F ) ( rd8 0xFFFF ) 0x1F {
+                    ? != ime_apply 0 {
+                        // EI immediately before HALT with an interrupt
+                        // already pending: NOT the halt bug (Pan Docs).
+                        // IME rises right after this instruction, the
+                        // interrupt is serviced normally, and the pushed
+                        // return address is the HALT itself — the handler
+                        // returns to the HALT, which then sleeps with the
+                        // interrupt already consumed. Rewind PC onto the
+                        // HALT so service_interrupts pushes its address.
+                        //
+                        // The previous behaviour set g_halt_bug here; the
+                        // flag then survived the interrupt dispatch and
+                        // replayed the HANDLER's first instruction (PC
+                        // failed to advance once inside the handler). For
+                        // Tobu Tobu Girl that doubled the handler's
+                        // PUSH HL, skewing the stack by 2 — RETI returned
+                        // into WRAM data and the game crashed to a RST 38
+                        // loop. The race (IF rising in HALT's own 4-cycle
+                        // window after EI) hits ~once per 3000 idle
+                        // frames, the observed deterministic ~90 s hang.
+                        = g_halt 0
+                        = pc & - pc 1 0xFFFF
+                    } {
+                        = g_halt_bug 1  = g_halt 0
+                    }
+                } {}
             } {}
         } {
             ( set_r & >> op 3 7 ( get_r & op 7 ) )

--- a/examples/gameboy/gbtrace.nu
+++ b/examples/gameboy/gbtrace.nu
@@ -156,12 +156,11 @@ $ `stdlib/ext/env.nu`
         ( string_push_str ln ` SP=` ) ( ls_pushhex4 ln sp )
         ( string_push_char ln 10 ) ( nurl_print ( string_data ln ) )
         ( string_free ln )
-        : ~ i used 4
-        ? == g_halt 0 { = used ( step ) } {}
-        ( tick_timer used )
-        ( tick_ppu used )
-        : i ic ( service_interrupts )
-        ? != ic 0 { ( tick_timer ic ) ( tick_ppu ic ) } {}
+        // Drive the REAL execution path. The previous hand-rolled
+        // step/tick_timer/tick_ppu sequence here was a stale copy of an
+        // older cpu_advance — it diverged (HALT never woke), so traces
+        // didn't reflect actual emulator behaviour.
+        ( cpu_advance )
         = k + k 1
     }
     ^ 0


### PR DESCRIPTION
## Summary

Tobu Tobu Girl crashed deterministically after ~90 s idle on the playground (gray vertical bars, execution frozen). Reproduced natively in a headless harness mirroring the browser loop: framebuffer checksum freezes at frame ~2 918 with the CPU stuck in a RST 38 loop (SP free-falling).

## Root cause (found via stack forensics on an instruction trace)

```
[86110] PC=34c3 OP=fb (EI)      I0
[86111] PC=34c4 OP=76 (HALT)    I0 IF=00
[86112] PC=0050 OP=e5 (PUSH HL) SP=dff0 ST=34c5   ← timer IRQ dispatched
[86113] PC=0050 OP=e5           SP=dfee ST=c0b5   ← PUSH HL executed, PC did NOT advance
[86114] PC=0051                 SP=dfec           ← PUSH HL again → double push
```

`EI`+`HALT`, with the timer IRQ's IF rising inside HALT's own 4-cycle window (`cpu_advance` clocks before stepping). The HALT path saw IME=0 (EI's one-instruction delay) + pending → set `g_halt_bug`. The EI delay then raised IME, the interrupt dispatched immediately — and the stale halt-bug flag **replayed the handler's first instruction**. Tobu's handler opens with `PUSH HL` → SP skewed by 2 → `RETI` returned into WRAM data (HL=c0b5) → NOP slide → RST 38 loop.

The 4/70 224-per-frame race window explains both the deterministic ~2 918-frame idle crash (~90 s at playground frame rate) and why playing the game perturbs it away.

## Fix (per Pan Docs)

1. **`EI` immediately before `HALT` with a pending interrupt is not the halt bug**: the interrupt is serviced with the HALT's own address as the return address (PC rewound onto the HALT) — the handler returns to the HALT, which then sleeps with the interrupt consumed.
2. **Invariant**: `service_interrupts` clears `g_halt_bug` on dispatch — the replay applies to the next *sequential* fetch only and must never leak into a handler.

## Also in this change

- `examples/gameboy` migrated to enforced `:` immutability (97 declarations) — the tree-wide migration missed it since gameboy is outside the test suite; all targets compile again and `gb_wasm_full.nu` is regenerated for the playground.
- `gbtrace.nu --trace` now drives the real `cpu_advance` path — its hand-rolled step loop was a stale copy that never woke from HALT.
- README documents the two halt-bug edges.

## Verification

- Blargg `cpu_instrs` **11/11**, `02-interrupts`, `instr_timing`: pass
- dmg-acid2 renders
- **40 000-frame idle soak** (vs the ~2 918-frame crash) ASan-clean, framebuffer live throughout
- pyboy state-injection lockstep stays byte-synced 40+ frames from the pre-crash state
- Full `examples/` compile smoke: 0 failures

No compiler gaps surfaced in this hunt — the crash was pure emulator logic; the compile break was the missed immutability migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)