### PR TITLE
stdlib diamond pass: 180 stale imports out, unused-import lint + unknown-callee diagnostics in nurlc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,14 @@ jobs:
         # the relevant diff so we don't need extra grep here.
         run: ./build.sh
 
+      - name: examples corpus frontend gate
+        # Frontend-compiles every examples/ + bench/ + duo/ program.
+        # Examples have rotted silently twice (immutability-migration
+        # misses in gameboy + c64) because nothing compiled them on
+        # PR; this catches parse/type/import regressions without
+        # linking or running anything.
+        run: ./tools/check_examples.sh
+
   sanitizers:
     name: AddressSanitizer + UndefinedBehaviorSanitizer
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`nurlc --lint` detects unused imports** (`compiler/nurlc.nu`). A
+  top-file `$` import none of whose defined symbols (functions, FFI
+  externs, types, constants — generic templates included) is referenced
+  by the top file itself now warns `unused import: no symbol from
+  '<path>' is referenced in this file`. References count from calls,
+  identifier reads, and type positions; uses recorded while re-parsing
+  generic template bodies during the instantiation flush are attributed
+  to the template's defining file, so stdlib internals never mask a top
+  file's dead import. Pure aggregator files (only `$` directives, no
+  decls of their own — e.g. `stdlib/ext/http_full.nu`) are exempt both
+  as importer and as import target: re-exporting is their purpose. The
+  LSP server (v0.6.0) now surfaces these straight from `nurlc --lint`
+  and drops its former text-heuristic duplicate (~190 LOC removed) —
+  one source of truth for the diagnostic.
+
+- **Unknown callees are compile errors now** (`compiler/nurlc.nu`). A
+  call to a name with no registered return type — not an `@`-fn, FFI
+  extern, builtin, impl method, or local closure — previously fell
+  through as an assumed-`i64` call to an undeclared symbol: invalid IR
+  that clang rejected far from the source, or worse, code that linked
+  by accident when the defining file happened to be imported later in
+  the unit *and* the return type happened to be i64. Now dies at the
+  call site: `call to unknown function 'X' — … add the missing '$'
+  import … or check the spelling.` Same treatment for a generic call
+  whose template is nowhere in the import closure (was: opaque
+  `expected '->' but found end of input` inside the synthetic
+  `<generic …>` source). En route this surfaced — and forced fixing —
+  nine runtime builtins that were header-declared but missing from the
+  compiler's symbol table (`nurl_peek`, `nurl_init`, `nurl_memset`,
+  `nurl_vec_drop`, `nurl_argc`, `nurl_argv_count`, `nurl_read_int`,
+  `puts`, `printf`), all silently riding the i64 default.
+
+### Fixed
+
+- **180 stale `$` imports removed tree-wide** (88 stdlib, 92
+  tests/examples/tools). Several masked real latent bugs, now fixed
+  with explicit imports: `stdlib/ext/csv.nu` used `opt_unwrap_or`
+  without importing `stdlib/core/option.nu` (rode on `sort.nu`'s own
+  stale import), `stdlib/ext/http2_hpack.nu` called
+  `h2_default_header_table_size` without importing
+  `stdlib/ext/http2_frame.nu`, and `stdlib/std/bufio.nu` called
+  `nurl_file_open`/`nurl_file_close` without importing
+  `stdlib/std/fs.nu` — each compiled only when every consumer
+  happened to import the missing file first. `stdlib/std/set.nu` no
+  longer imports `hashmap.nu` for its callers' convenience; import it
+  alongside (the stock `hash_*`/`eq_*` helpers live there).
+
 ## [0.9.7] — 2026-06-11
 
 ### Added

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -242,6 +242,9 @@
 @ parse_type_base i lex → s {
     ? ( is_ident_tok ( nurl_lex_type lex ) )
     { : s v ( nurl_lex_val lex )
+        // Lint: a type name in type position is a reference — an
+        // import supplying only types must count as used.
+        ( lint_note_used v )
         ( nurl_lex_advance lex )
         // Side-channel: stash the NURL-source name of the base type so
         // callers (let-stmt, gen_fn_param) can decide signedness for
@@ -268,6 +271,7 @@
     ( nurl_lex_advance lex )  // consume '|'
     ? ( is_ident_tok ( nurl_lex_type lex ) )
     { : s v ( nurl_lex_val lex )
+        ( lint_note_used v )
         ( nurl_lex_advance lex )
         ^ ( nurl_str_cat `%` v )
     }
@@ -318,6 +322,7 @@
         // word so the outer mangle composes deterministically.
         ? ( is_ident_tok ( nurl_lex_type lex ) )
         { : s sname ( nurl_lex_val lex )
+            ( lint_note_used sname )
             ( nurl_lex_advance lex )
             : ~ s mangle_sfx ``
             : ~ b has_tparam_arg F
@@ -330,6 +335,7 @@
                 ? | | == ta_tt TT_LPAREN == ta_tt TT_QUEST | == ta_tt TT_QUESTQUEST == ta_tt TT_STAR
                 { = ta_lty ( parse_type lex ) }
                 { : s ta ( nurl_lex_val lex )
+                    ( lint_note_used ta )
                     ( nurl_lex_advance lex )
                     ? ( is_tparam_like ta ) { = has_tparam_arg T } {}
                     = ta_lty ( llvm_type ta )
@@ -1085,6 +1091,7 @@
 // into strict-mode. Called from gen_fn_decl (after fname is read)
 // and from scan_fn_sigs's @ branch.
 @ vis_record_fn s fname b was_pub → v {
+    ( lint_note_def fname )
     : s sf ( vis_current_src_file )
     ( nurl_sym_def g_vis_syms ( nurl_str_cat fname `__src_file` ) sf )
     ? was_pub
@@ -1100,6 +1107,7 @@
 // at the use site reads `<sname>__src_file` + `<sname>__pub` + the
 // file's `__strict` marker. Mirrors vis_record_fn's shape.
 @ vis_record_type s sname b was_pub → v {
+    ( lint_note_def sname )
     : s sf ( vis_current_src_file )
     ( nurl_sym_def g_vis_syms ( nurl_str_cat sname `__src_file` ) sf )
     ? was_pub
@@ -1113,6 +1121,7 @@
 // constant (or `: ~` mutable global). Identical bookkeeping shape
 // as vis_record_type — the use site reads via the same lookup.
 @ vis_record_const s cname b was_pub → v {
+    ( lint_note_def cname )
     : s sf ( vis_current_src_file )
     ( nurl_sym_def g_vis_syms ( nurl_str_cat cname `__src_file` ) sf )
     ? was_pub
@@ -1177,10 +1186,118 @@
     ( nurl_str_cat4 `:` ( nurl_str_int col ) `: warning: ` msg ) ) )
 }
 
-// Record that `name` was referenced (called via gen_call or read via
-// gen_ident) anywhere in the program. Drives the unused-function check.
+// Record that `name` was referenced (called via gen_call, read via
+// gen_ident, or named as a type via parse_type) anywhere in the
+// program. Drives the unused-function check (global key) and the
+// unused-import check (file-scoped `<file> <name>` key: an import is
+// justified only by references in the importing file itself, not by
+// uses from elsewhere in the unit).
 @ lint_note_used s name → v {
-    ? != g_lint 0 { ( nurl_sym_def g_lint_used name `1` ) } {}
+    ? != g_lint 0
+    { ( nurl_sym_def g_lint_used name `1` )
+        // During the instantiation flush, attribute uses to the
+        // generic template's defining file (g_lint_syms `use_file`,
+        // set by emit_one_instantiation) — vis_current_src_file has
+        // already unwound to the top file by then.
+        : s uf ( nurl_sym_get g_lint_syms `use_file` )
+        : s sf ? != 0 ( nurl_str_len uf ) uf ( vis_current_src_file )
+        ( nurl_sym_def g_lint_used ( nurl_str_cat3 sf ` ` name ) `1` ) }
+    {}
+}
+
+// Record one top-level decl `name` as belonging to the file being
+// parsed right now. Builds the per-file `defs:<file>` roster the
+// unused-import lint reads. Called from vis_record_fn / _type /
+// _const (which see every @-fn, struct, enum, and const in every
+// file) and from gen_ffi_decl for `&` externs. Deduped because the
+// scan and parse passes both register the same decls.
+// Explicit-file variant: the generic-struct template scan walks `$`
+// imports recursively WITHOUT updating vis_current_src_file, so the
+// defining file must come from the active lexer's filename there.
+@ lint_note_def_at s name s sf → v {
+    ? != g_lint 0
+    { : s seenkey ( nurl_str_cat4 `defseen:` sf `\t` name )
+        ? != 0 ( nurl_str_len ( nurl_sym_get g_lint_syms seenkey ) ) {}
+        { ( nurl_sym_def g_lint_syms seenkey `1` )
+            : s key ( nurl_str_cat `defs:` sf )
+            : s cur ( nurl_sym_get g_lint_syms key )
+            ( nurl_sym_def g_lint_syms key ( nurl_str_cat3 cur name `\t` ) ) }
+    }
+    {}
+}
+
+// Gated on g_lint_recording: the instantiation flush re-enters
+// gen_fn_decl for synthetic monomorphisations (`vec_push__i64` …)
+// with vis_current_src_file unwound to the TOP file — without the
+// gate those mangled names land in the top file's def roster and a
+// pure-aggregator top file stops looking like one. (The _at variant
+// above stays ungated: the generic-struct pre-scan runs before
+// recording starts and carries the true file in its lexer.)
+@ lint_note_def s name → v {
+    ? & != g_lint 0 != g_lint_recording 0
+    { : s sf ( vis_current_src_file )
+        : s seenkey ( nurl_str_cat4 `defseen:` sf `\t` name )
+        ? != 0 ( nurl_str_len ( nurl_sym_get g_lint_syms seenkey ) ) {}
+        { ( nurl_sym_def g_lint_syms seenkey `1` )
+            : s key ( nurl_str_cat `defs:` sf )
+            : s cur ( nurl_sym_get g_lint_syms key )
+            ( nurl_sym_def g_lint_syms key ( nurl_str_cat3 cur name `\t` ) ) }
+    }
+    {}
+}
+
+// Record a top-file `$` import directive (path + position of the `$`
+// token) for the unused-import report. Imports inside transitively
+// imported files are not recorded — the lint only judges the file the
+// user is editing, same as every other unused-symbol lint here.
+// Note a type-arg source word (`Header`, `?u`, `*T`, …) as a type
+// reference: strip the `?` / `*` / `!` prefix sigils, then record the
+// root name. Builtins (`i`, `u8`, …) record harmlessly — they are in
+// no file's def roster, so the import check never sees them.
+@ lint_note_used_type_word s w → v {
+    ? == g_lint 0 { ^ v } {}
+    : i n ( nurl_str_len w )
+    : ~ i k 0
+    ~ & < k n | | == ( nurl_str_get w k ) 63 == ( nurl_str_get w k ) 42 == ( nurl_str_get w k ) 33
+    { = k + k 1 }
+    ? < k n { ( lint_note_used ( nurl_str_slice w k - n k ) ) } {}
+}
+
+// Explicit-file variant of lint_note_used (same reasons as
+// lint_note_def_at — callers whose vis_current_src_file is stale).
+@ lint_note_used_at s name s sf → v {
+    ? != g_lint 0
+    { ( nurl_sym_def g_lint_used name `1` )
+        ( nurl_sym_def g_lint_used ( nurl_str_cat3 sf ` ` name ) `1` ) }
+    {}
+}
+
+// Conservatively mark every identifier token in a stored generic
+// template source as referenced by `file`. Template bodies are parsed
+// only at instantiation — possibly NEVER when linting a library file
+// standalone — yet `( Pair K V )` inside `map_iter [K V]`'s body is a
+// real reference in hashmap.nu. Lexer-based, so strings and comments
+// are skipped; over-marking (locals, tparams) is harmless — unknown
+// names are in no def roster.
+@ lint_note_template_src s src s file → v {
+    ? == g_lint 0 { ^ v } {}
+    : i lx ( nurl_lex_new src `<lint-template>` )
+    ~ != ( nurl_lex_type lx ) TT_EOF {
+        ? ( is_ident_tok ( nurl_lex_type lx ) )
+        { ( lint_note_used_at ( nurl_lex_val lx ) file ) }
+        {}
+        ( nurl_lex_advance lx )
+    }
+}
+
+@ lint_note_import s path i line i col → v {
+    ? & & != g_lint 0 != g_lint_recording 0 ( lint_in_top_file )
+    { : s row ( nurl_str_cat
+        ( nurl_str_cat3 path `\t` ( nurl_str_int line ) )
+        ( nurl_str_cat3 `\t` ( nurl_str_int col ) `\n` ) )
+        : s cur ( nurl_sym_get g_lint_syms `imports` )
+        ( nurl_sym_def g_lint_syms `imports` ( nurl_str_cat cur row ) ) }
+    {}
 }
 
 // Record an identifier read in the current function. Recorded for
@@ -1316,6 +1433,63 @@
             = rest ? < nl 0 `` ( nurl_str_slice rest + nl 1 - rl + nl 1 )
             ( lint_check_fn row )
         }
+    }
+}
+
+// Parse one "path\tline\tcol" import row; warn when none of the
+// symbols the imported file defines is referenced (file-scoped key in
+// g_lint_used) by the top file itself.
+@ lint_check_import s top s row → v {
+    : i t1 ( nurl_str_find row `\t` )
+    ? < t1 0 { ^ v } {}
+    : i rl ( nurl_str_len row )
+    : s path ( nurl_str_slice row 0 t1 )
+    : s tail ( nurl_str_slice row + t1 1 - rl + t1 1 )
+    : i t2 ( nurl_str_find tail `\t` )
+    ? < t2 0 { ^ v } {}
+    : i tl ( nurl_str_len tail )
+    : s ln ( nurl_str_slice tail 0 t2 )
+    : s cl ( nurl_str_slice tail + t2 1 - tl + t2 1 )
+    : s defs ( nurl_sym_get g_lint_syms ( nurl_str_cat `defs:` path ) )
+    // No recorded decls → pure aggregator (re-export surface like
+    // stdlib/ext/http_full.nu) or unreadable path; never warn (same
+    // exemption as the LSP).
+    ? == 0 ( nurl_str_len defs ) { ^ v } {}
+    : ~ s drest defs
+    : ~ b used F
+    ~ & != 0 ( nurl_str_len drest ) ! used {
+        : i dt ( nurl_str_find drest `\t` )
+        : i dl ( nurl_str_len drest )
+        : s nm ? < dt 0 drest ( nurl_str_slice drest 0 dt )
+        = drest ? < dt 0 `` ( nurl_str_slice drest + dt 1 - dl + dt 1 )
+        ? == 0 ( nurl_str_len nm ) {}
+        { ? != 0 ( nurl_str_len ( nurl_sym_get g_lint_used
+            ( nurl_str_cat3 top ` ` nm ) ) )
+            { = used T } {} }
+    }
+    ? used {} {
+        ( lint_warn top ( nurl_str_to_int ln ) ( nurl_str_to_int cl )
+        ( nurl_str_cat3 `unused import: no symbol from '` path
+        `' is referenced in this file` ) )
+    }
+}
+
+// After the whole program is compiled, walk the recorded top-file
+// `$` imports and report the unused ones. A top file that defines no
+// symbols of its own is a pure aggregator — its imports exist to be
+// re-exported, so the report is skipped entirely (LSP parity).
+@ lint_report_unused_imports → v {
+    ? == g_lint 0 { ^ v } {}
+    : s top ( nurl_sym_get g_lint_syms `top` )
+    ? == 0 ( nurl_str_len ( nurl_sym_get g_lint_syms ( nurl_str_cat `defs:` top ) ) )
+    { ^ v } {}
+    : ~ s rest ( nurl_sym_get g_lint_syms `imports` )
+    ~ != 0 ( nurl_str_len rest ) {
+        : i nl ( nurl_str_find rest `\n` )
+        : i rl ( nurl_str_len rest )
+        : s row ? < nl 0 rest ( nurl_str_slice rest 0 nl )
+        = rest ? < nl 0 `` ( nurl_str_slice rest + nl 1 - rl + nl 1 )
+        ( lint_check_import top row )
     }
 }
 
@@ -3877,6 +4051,10 @@
               // it substitutes whole into the generic body; nurl_lex_val
               // alone would grab only the leading `?` / `*`.
                 = ta ( capture_type_arg_src lex )
+                // Lint: `vec_len [Header] …` references the Header
+                // type — this path bypasses parse_type, so note it
+                // here or a types-only import looks unused.
+                ( lint_note_used_type_word ta )
             }
             = type_args ? == 0 ( nurl_str_len type_args ) ta
             ( nurl_str_cat type_args ( nurl_str_cat ` ` ta ) )
@@ -4233,6 +4411,28 @@
             = arg_idx + arg_idx 1
         }
     }
+    {}
+    // Unknown callee: nothing registered a return type for this name —
+    // not an @-fn seen by scan_fn_sigs (this file or any '$'-import
+    // processed so far), not an FFI extern, not a runtime builtin from
+    // the register_builtins table, not an impl method (dispatched
+    // below via g_impl_name_syms — exempted through `__impl_seen`),
+    // and not a local closure / fn-pointer binding (no `__ptr`).
+    // The legacy fallthrough assumed `i64` and emitted a call to an
+    // undeclared symbol — invalid IR that surfaced as a clang error far
+    // from the source, or (worse) linked-by-accident when the defining
+    // file happened to be imported later in the unit AND the return
+    // type happened to be i64. Mirror gen_ident's undefined-identifier
+    // diagnostic so the error lands on the call site instead. Runs
+    // while the lexer still sits on the closing ')' so the caret
+    // points at this call.
+    ? & & & == 0 ( nurl_str_len ( nurl_sym_get syms call_name ) )
+    == 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat fname `__ptr` ) ) )
+    == 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat fname `__arity` ) ) )
+    == 0 ( nurl_str_len ( nurl_sym_get g_impl_name_syms ( nurl_str_cat fname `__impl_seen` ) ) )
+    { ( die lex ( nurl_str_cat3
+        `call to unknown function '` fname
+        `' — it is not defined in this file, not in any '$'-imported file processed so far, and not a known FFI/builtin. Add the missing '$' import (or move it above this file's import in the program), or check the spelling.` ) ) }
     {}
     // Call-arity check. scan_fn_sigs records every non-generic
     // @-function's declared parameter count as `<fname>__arity`. A call
@@ -10890,6 +11090,10 @@
 // Called when '[' is seen after the function name in gen_fn_decl.
 // Stores source template in g_generic_syms; emits no IR.
 @ gen_generic_fn_store i lex i syms s fname → v {
+    // Lint: generic fn templates are decls of the current file (the
+    // scan_fn_sigs @-branch also records them, but belt-and-braces —
+    // the dedup in lint_note_def makes the second call free).
+    ( lint_note_def fname )
     // DWARF Phase 7: snapshot the declaration line BEFORE consuming
     // template tokens so every later instantiation can attach its
     // !DISubprogram to the original source location, not the line
@@ -10897,6 +11101,13 @@
     : i src_line ( nurl_lex_line lex )
     ( nurl_sym_def g_generic_syms
     ( nurl_str_cat fname `__src_line` ) ( nurl_str_int src_line ) )
+    // Defining file of the template. The instantiation flush re-parses
+    // template bodies AFTER the per-file import walk has unwound, so
+    // without this record the lint would attribute every symbol a
+    // stdlib template's body touches to the TOP file — masking the
+    // top file's own unused imports.
+    ( nurl_sym_def g_generic_syms
+    ( nurl_str_cat fname `__src_file` ) ( vis_current_src_file ) )
     ( expect lex TT_LBRACK )
     : ~ s tparams ``
     ~ != ( nurl_lex_type lex ) TT_RBRACK {
@@ -10931,6 +11142,10 @@
     {}
     ( nurl_sym_def g_generic_syms ( nurl_str_cat fname `__tparams` ) tparams )
     ( nurl_sym_def g_generic_syms ( nurl_str_cat fname `__gsrc` ) src )
+    // Lint: names inside the stored template are references in THIS
+    // file even if no instantiation ever happens (library files
+    // linted standalone instantiate nothing).
+    ( lint_note_template_src src ( vis_current_src_file ) )
     ( nurl_sym_def syms ( nurl_str_cat fname `__generic` ) `1` )
     // Record this generic function's `inout` / `sink`
     // parameter index sets (keyed by the generic name) so a call site
@@ -12101,6 +12316,9 @@
     ( nurl_lex_advance lex )  // skip library STR
     ( expect lex TT_AT )  // consume '@'
     : s fname ( nurl_lex_val lex )
+    // Lint: `&` externs belong to the declaring file's def roster so
+    // an import used only for its FFI surface is not flagged unused.
+    ( lint_note_def fname )
     ( nurl_lex_advance lex )
     : ~ s params_str ``
     : ~ i pct 0
@@ -12804,8 +13022,13 @@
 }
 
 @ gen_import_decl i lex i syms i cg → v {
+    // Lint: capture the `$` token's position before consuming it so
+    // the unused-import warning points at the directive itself.
+    : i __li_line ( nurl_lex_line lex )
+    : i __li_col ( nurl_lex_col lex )
     ( nurl_lex_advance lex )  // consume '$'
     : s path ( __norm_import_path ( nurl_lex_val lex ) )
+    ( lint_note_import path __li_line __li_col )
     ( nurl_lex_advance lex )  // consume path STR
     : ~ s alias ``
     ? ( is_ident_tok ( nurl_lex_type lex ) )
@@ -12852,6 +13075,22 @@
 @ emit_one_instantiation s fname s mangled s type_args s caller_file s caller_line i syms i cg → v {
     : s tparams ( nurl_sym_get g_generic_syms ( nurl_str_cat fname `__tparams` ) )
     : s gsrc ( nurl_sym_get g_generic_syms ( nurl_str_cat fname `__gsrc` ) )
+    // No stored template for this name: the call site referenced a
+    // generic function whose defining file is not in the import
+    // closure. Without this guard the empty source below re-lexes as
+    // `@ <mangled> ` and dies with an opaque `expected '->' but found
+    // end of input` pointing at synthetic `<generic …>:1` — useless
+    // for finding the actual problem (a missing `$` import).
+    ? == 0 ( nurl_str_len gsrc )
+    { : s loc ? != 0 ( nurl_str_len caller_file )
+        ( nurl_str_cat4 caller_file `:` caller_line `: ` )
+        ``
+        ( nurl_eprintln ( nurl_str_cat3 loc
+        ( nurl_str_cat3 `error: call to generic function '` fname `' but no generic of that name is defined in this file or any '$'-imported file` )
+        ` — add the '$' import for the file that defines it` ) )
+        ( nurl_exit 1 )
+    }
+    {}
     : ~ s subst_src gsrc
     : ~ s tp_rest tparams
     : ~ s ta_rest type_args
@@ -12882,7 +13121,18 @@
     ? != 0 ( nurl_str_len sl_s )
     { = g_dbg_override_line ( nurl_str_to_int sl_s ) }
     {}
-    ( gen_fn_decl lex2 syms cg )
+    // Lint: re-parsing the substituted body records symbol uses; key
+    // them to the template's defining file, not the top file (see
+    // lint_note_used). Saved/restored around the recursive
+    // gen_fn_decl because nested instantiations re-enter here.
+    ? != g_lint 0
+    { : s saved_uf ( nurl_sym_get g_lint_syms `use_file` )
+        ( nurl_sym_def g_lint_syms `use_file`
+        ( nurl_sym_get g_generic_syms ( nurl_str_cat fname `__src_file` ) ) )
+        ( gen_fn_decl lex2 syms cg )
+        ( nurl_sym_def g_lint_syms `use_file` saved_uf )
+    }
+    { ( gen_fn_decl lex2 syms cg ) }
     = g_dbg_override_line saved_override
 }
 
@@ -13334,6 +13584,23 @@
     ( nurl_sym_def syms `nurl_print_buf_reset` `void` )
     // lexer position save/restore
     // nurl_lex_cur_start / _src_slice / _set_pos — pure-NURL @-fns (Phase 10).
+    // Header-declared builtins that were MISSING from this table.
+    // They compiled anyway only via gen_call's silent i64 default —
+    // correct for the i64-returning ones by luck, invalid IR for the
+    // rest. The unknown-callee diagnostic (gen_call) now rejects any
+    // unregistered name, so this table must cover every `declare` that
+    // emit_header writes. Keep the two in sync.
+    ( nurl_sym_def syms `nurl_peek` `i64` )
+    ( nurl_sym_def syms `nurl_init` `void` )
+    ( nurl_sym_def syms `nurl_memset` `void` )
+    ( nurl_sym_def syms `nurl_vec_drop` `void` )
+    ( nurl_sym_def syms `nurl_argc` `i64` )
+    ( nurl_sym_def syms `nurl_argv_count` `i64` )
+    ( nurl_sym_def syms `nurl_read_int` `i64` )
+    ( nurl_sym_def syms `puts` `i32` )
+    ( nurl_sym_def syms `printf` `i32` )
+    ( nurl_sym_def syms `printf__variadic` `1` )
+    ( nurl_sym_def syms `printf__variadic_fixed` `1` )
 }
 
 // ── Signature pre-scan (first pass) ──────────────────────────────
@@ -13367,12 +13634,17 @@
 // sequences) for each default method via nurl_lex_src_slice so the
 // template can be re-lexed later even when the body uses string literals.
 @ scan_trait_body i lex s tname → v {
+    // Lint: the trait and its method names are decls of this file —
+    // an import supplying only a trait must not be flagged unused
+    // when a consumer impls it / calls its methods.
+    ( lint_note_def tname )
     ( expect lex TT_LBRACE )
     ~ != ( nurl_lex_type lex ) TT_RBRACE {
         ? == ( nurl_lex_type lex ) TT_AT
         { ( nurl_lex_advance lex )  // skip '@'
             ? ( is_ident_tok ( nurl_lex_type lex ) )
             { : s mname ( nurl_lex_val lex )
+                ( lint_note_def mname )
                 ( nurl_lex_advance lex )  // consume method name
                 : i sig_start ( nurl_lex_cur_start lex )
                 // Skip params / → / ret_ty until we hit '{' (body), next '@',
@@ -13442,6 +13714,9 @@
             : s key ( nurl_str_cat mname ( nurl_str_cat `##` impl_llvm ) )
             ( nurl_sym_def g_impl_ret_syms key ret_ty )
             ( nurl_sym_def g_impl_name_syms key impl_mangle )
+            // Mark the bare method name as impl-backed so gen_call's
+            // unknown-callee check lets it through to impl dispatch.
+            ( nurl_sym_def g_impl_name_syms ( nurl_str_cat mname `__impl_seen` ) `1` )
             : s mangled ( nurl_str_cat mname ( nurl_str_cat `__` impl_mangle ) )
             ( nurl_sym_def syms mangled ret_ty )
         }
@@ -13514,6 +13789,10 @@
                         : s key ( nurl_str_cat mname ( nurl_str_cat `##` impl_llvm ) )
                         ( nurl_sym_def g_impl_ret_syms key ret_ty )
                         ( nurl_sym_def g_impl_name_syms key impl_mangle )
+                        // Mark the bare method name as impl-backed so
+                        // gen_call's unknown-callee check lets it
+                        // through to impl dispatch.
+                        ( nurl_sym_def g_impl_name_syms ( nurl_str_cat mname `__impl_seen` ) `1` )
                         : s mangled ( nurl_str_cat mname ( nurl_str_cat `__` impl_mangle ) )
                         ( nurl_sym_def syms mangled ret_ty )
                     }
@@ -13568,6 +13847,10 @@
     ( vis_take_pending_pub )
     ( nurl_lex_advance lex )  // skip '%'
     : s tname ( nurl_lex_val lex )
+    // Lint: naming a trait here (decl or impl) references it — an
+    // `% Trait ( Type )` impl justifies the import of the trait's
+    // defining file by itself.
+    ( lint_note_used tname )
     ( nurl_lex_advance lex )  // skip trait name
     // Skip optional type params [T] (already captured during scan)
     ? == ( nurl_lex_type lex ) TT_LBRACK
@@ -13710,6 +13993,15 @@
                         : s body ( collect_fn_body lex )
                         ( nurl_sym_def g_generic_struct_syms ( nurl_str_cat sname `__stparams` ) tparams )
                         ( nurl_sym_def g_generic_struct_syms ( nurl_str_cat sname `__sbody` ) body )
+                        // Lint: generic struct templates never reach
+                        // vis_record_type, so register the name here.
+                        // This scan recurses into imports without
+                        // touching vis_current_src_file — the lexer's
+                        // filename is the real defining file. Field
+                        // types inside the body (`( Vec A ) data`) are
+                        // references in that file too.
+                        ( lint_note_def_at sname ( nurl_lex_filename lex ) )
+                        ( lint_note_template_src body ( nurl_lex_filename lex ) )
                     } {}
                 } {}
             } {}
@@ -14290,6 +14582,7 @@
     // instantiations) has now been seen, so report the unused private
     // functions of the top-level file. No-op unless --lint is set.
     ( lint_report_unused_fns )
+    ( lint_report_unused_imports )
     // Borrow-checker diagnostics are errors, not warnings. We let
     // parse_program walk every function so every violation surfaces
     // in one run, then exit non-zero here if any were recorded. A

--- a/compiler/tests/arc_basic.nu
+++ b/compiler/tests/arc_basic.nu
@@ -1,7 +1,6 @@
 // arc_basic.nu — Arc[T] atomic refcount on a single thread.
 // Threaded sharing is exercised in arc_threads.nu.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/std/arc.nu`
 
 @ main → i {

--- a/compiler/tests/arena_basic.nu
+++ b/compiler/tests/arena_basic.nu
@@ -1,4 +1,3 @@
-$ `stdlib/core/string.nu`
 $ `stdlib/std/arena.nu`
 
 @ main → i {

--- a/compiler/tests/arena_growing.nu
+++ b/compiler/tests/arena_growing.nu
@@ -18,7 +18,6 @@
 //
 // main returns the number of failed checks (0 = all pass).
 
-$ `stdlib/core/string.nu`
 $ `stdlib/std/arena.nu`
 
 : Pt { i x i y }

--- a/compiler/tests/async_basic.nu
+++ b/compiler/tests/async_basic.nu
@@ -19,7 +19,6 @@
 
 $ `stdlib/std/async.nu`
 $ `stdlib/std/thread.nu`
-$ `stdlib/core/string.nu`
 
 : ~ i total_yields 0
 : ~ i finished 0

--- a/compiler/tests/async_chan.nu
+++ b/compiler/tests/async_chan.nu
@@ -16,7 +16,6 @@
 
 $ `stdlib/std/async.nu`
 $ `stdlib/std/channel.nu`
-$ `stdlib/core/string.nu`
 
 : ~ i a_count 0
 : ~ i b_count 0

--- a/compiler/tests/async_mn.nu
+++ b/compiler/tests/async_mn.nu
@@ -17,7 +17,6 @@
 
 $ `stdlib/std/async.nu`
 $ `stdlib/std/thread.nu`
-$ `stdlib/core/string.nu`
 
 : ~ i counter 0
 : ~ i joined 0

--- a/compiler/tests/async_sleep.nu
+++ b/compiler/tests/async_sleep.nu
@@ -17,7 +17,6 @@
 
 $ `stdlib/std/async.nu`
 $ `stdlib/std/thread.nu`
-$ `stdlib/core/string.nu`
 $ `stdlib/std/time.nu`
 
 : ~ i done_count 0

--- a/compiler/tests/borrow_double_free.nu
+++ b/compiler/tests/borrow_double_free.nu
@@ -4,7 +4,6 @@
 // afterwards uses the moved-from binding — the silent-alias double
 // free. Expect one warning, at the vec_free of `a`.
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 
 @ main → i {
     : ( Vec i ) a ( vec_new [i] )

--- a/compiler/tests/borrow_escape_vec.nu
+++ b/compiler/tests/borrow_escape_vec.nu
@@ -13,7 +13,6 @@
 //
 // Two negative controls confirm the warning is stack-reference-only.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/thread.nu`
 

--- a/compiler/tests/borrow_iter_invalidation.nu
+++ b/compiler/tests/borrow_iter_invalidation.nu
@@ -13,9 +13,7 @@
 //
 // Two positive cases (both warn) + two negative controls (no warning).
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 
 @ main → i {
     : ( Vec i ) xs ( vec_new [i] )

--- a/compiler/tests/borrow_sink_use_after.nu
+++ b/compiler/tests/borrow_sink_use_after.nu
@@ -10,9 +10,7 @@
 //
 // One positive case (warns) + one negative control (no warning).
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 
 @ give_away sink ( Vec i ) g → v {
     ( vec_free [i] g )

--- a/compiler/tests/borrow_use_after_move.nu
+++ b/compiler/tests/borrow_use_after_move.nu
@@ -3,7 +3,6 @@
 // the diagnostic in the baseline. `v` is consumed by vec_free, then
 // read again by vec_len: a use-after-move. Expect one warning.
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 
 @ main → i {
     : ( Vec i ) v ( vec_new [i] )

--- a/compiler/tests/box_basic.nu
+++ b/compiler/tests/box_basic.nu
@@ -2,7 +2,6 @@
 // raw-pointer borrow. Covers the integer payload — the simplest case
 // where the read-by-value path is safe.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/box.nu`
 
 @ main → i {

--- a/compiler/tests/box_drop_trait.nu
+++ b/compiler/tests/box_drop_trait.nu
@@ -12,7 +12,6 @@
 // leak if the trait dispatch ever silently breaks; here we just
 // verify the drop side-effect (print) fires.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/box.nu`
 
 % Drop ( Box i ) {

--- a/compiler/tests/box_struct.nu
+++ b/compiler/tests/box_struct.nu
@@ -4,7 +4,6 @@
 // address. The point: a single allocation, multiple call sites
 // reading and writing fields through `box_ptr`.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/box.nu`
 
 : Counters {

--- a/compiler/tests/calendar_time.nu
+++ b/compiler/tests/calendar_time.nu
@@ -20,7 +20,6 @@
 $ `stdlib/std/time.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/errors.nu`
-$ `stdlib/core/io.nu`
 
 @ println_str s prefix s value → v {
     ( nurl_print prefix )

--- a/compiler/tests/cell_basic.nu
+++ b/compiler/tests/cell_basic.nu
@@ -1,6 +1,5 @@
 // cell_basic.nu — Cell byte-buffer round-trip + native_sizeof.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/cell.nu`
 
 @ main → i {

--- a/compiler/tests/cell_pthread.nu
+++ b/compiler/tests/cell_pthread.nu
@@ -5,7 +5,6 @@
 // whose size comes from `nurl_native_sizeof("pthread_mutex_t")`.
 // No C-side `nurl_mutex_*` helper involved.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/cell.nu`
 
 // Direct pthread FFI. `pthread_mutex_init`'s second arg is a

--- a/compiler/tests/closure_capture_aggregate.nu
+++ b/compiler/tests/closure_capture_aggregate.nu
@@ -6,6 +6,7 @@
 // the env with its native LLVM type.
 
 $ `stdlib/std/set.nu`
+$ `stdlib/std/hashmap.nu`
 $ `stdlib/core/vec.nu`
 
 @ main → i {

--- a/compiler/tests/compress_basic.nu
+++ b/compiler/tests/compress_basic.nu
@@ -1,7 +1,6 @@
 // compress_basic.nu — round-trip + error coverage for the zlib + zstd
 // bindings shipped in stdlib/ext/compress.nu.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/ext/compress.nu`

--- a/compiler/tests/compress_gzip.nu
+++ b/compiler/tests/compress_gzip.nu
@@ -2,7 +2,6 @@
 // helpers in stdlib/ext/compress.nu (RFC 1952 file format via the
 // runtime.c §22 bridge over libz's streaming API).
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/ext/compress.nu`

--- a/compiler/tests/csv_arena.nu
+++ b/compiler/tests/csv_arena.nu
@@ -14,7 +14,6 @@
 // All tests print compact tags so correct.txt diffs are obvious.
 
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 $ `stdlib/ext/csv.nu`
 
 @ load_table s csv → *CSVTable {

--- a/compiler/tests/http2_client.nu
+++ b/compiler/tests/http2_client.nu
@@ -15,7 +15,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/std/net.nu`
 $ `stdlib/std/thread.nu`
 $ `stdlib/ext/env.nu`

--- a/compiler/tests/http2_continuation_flood.nu
+++ b/compiler/tests/http2_continuation_flood.nu
@@ -15,10 +15,8 @@
 $ `stdlib/std/net.nu`
 $ `stdlib/std/thread.nu`
 $ `stdlib/ext/env.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http2_frame.nu`

--- a/compiler/tests/http2_hpack_bomb.nu
+++ b/compiler/tests/http2_hpack_bomb.nu
@@ -15,7 +15,6 @@
 
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/ext/http2_frame.nu`
 $ `stdlib/ext/http2_hpack.nu`
 
 // HPACK integer with an N-bit prefix where 2^N-1 == `prefix_max`

--- a/compiler/tests/http_extras.nu
+++ b/compiler/tests/http_extras.nu
@@ -22,7 +22,6 @@ $ `stdlib/ext/http_static.nu`
 $ `stdlib/ext/http_auth.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/ext/http.nu`

--- a/compiler/tests/http_middleware.nu
+++ b/compiler/tests/http_middleware.nu
@@ -21,11 +21,8 @@
 $ `stdlib/ext/http_middleware.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
-$ `stdlib/ext/http_router.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/ext/http.nu`
 
 @ println_str s prefix s value → v {
     ( nurl_print prefix )

--- a/compiler/tests/http_response_builder.nu
+++ b/compiler/tests/http_response_builder.nu
@@ -18,9 +18,7 @@
 // pure-builder pattern, see run_tests.sh). ASan-clean.
 
 $ `stdlib/ext/http_response.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/json.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 

--- a/compiler/tests/http_router.nu
+++ b/compiler/tests/http_router.nu
@@ -23,10 +23,8 @@
 $ `stdlib/ext/http_router.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/ext/http.nu`
 
 @ println_str s prefix s value → v {
     ( nurl_print prefix )

--- a/compiler/tests/http_server_chunked.nu
+++ b/compiler/tests/http_server_chunked.nu
@@ -21,7 +21,6 @@ $ `stdlib/ext/env.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`

--- a/compiler/tests/http_server_dos.nu
+++ b/compiler/tests/http_server_dos.nu
@@ -13,9 +13,7 @@ $ `stdlib/std/process.nu`
 $ `stdlib/std/thread.nu`
 $ `stdlib/std/time.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 $ `stdlib/ext/env.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`

--- a/compiler/tests/http_server_limits.nu
+++ b/compiler/tests/http_server_limits.nu
@@ -17,11 +17,8 @@
 $ `stdlib/std/net.nu`
 $ `stdlib/std/process.nu`
 $ `stdlib/std/time.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 $ `stdlib/ext/env.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`

--- a/compiler/tests/http_server_panic.nu
+++ b/compiler/tests/http_server_panic.nu
@@ -23,7 +23,6 @@ $ `stdlib/std/process.nu`
 $ `stdlib/std/panic.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/ext/env.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`

--- a/compiler/tests/http_server_pipelined.nu
+++ b/compiler/tests/http_server_pipelined.nu
@@ -22,11 +22,9 @@
 
 $ `stdlib/std/net.nu`
 $ `stdlib/std/process.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/ext/env.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`

--- a/compiler/tests/http_server_seq.nu
+++ b/compiler/tests/http_server_seq.nu
@@ -20,10 +20,8 @@
 
 $ `stdlib/std/net.nu`
 $ `stdlib/std/process.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`

--- a/compiler/tests/http_server_tls.nu
+++ b/compiler/tests/http_server_tls.nu
@@ -21,11 +21,8 @@
 
 $ `stdlib/std/net.nu`
 $ `stdlib/std/process.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 $ `stdlib/ext/env.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`

--- a/compiler/tests/http_server_tls_extras.nu
+++ b/compiler/tests/http_server_tls_extras.nu
@@ -18,9 +18,7 @@ $ `stdlib/std/process.nu`
 $ `stdlib/std/thread.nu`
 $ `stdlib/std/time.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 $ `stdlib/ext/env.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`

--- a/compiler/tests/http_static_traversal.nu
+++ b/compiler/tests/http_static_traversal.nu
@@ -21,8 +21,6 @@
 $ `stdlib/std/fs.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/std/bytes.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_static.nu`

--- a/compiler/tests/match_bind_call_handle.nu
+++ b/compiler/tests/match_bind_call_handle.nu
@@ -24,7 +24,6 @@
 // Each line is deterministic so the output is baselined.
 
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/result.nu`
 
 @ make_vec i n → ! ( Vec u ) s {
     ? < n 0 { ^ @ ! ( Vec u ) s { F `negative` } } {}

--- a/compiler/tests/match_guards_or.nu
+++ b/compiler/tests/match_guards_or.nu
@@ -11,7 +11,6 @@
 //
 // Determinism: pure, no clock/socket/env. ASan-clean.
 
-$ `stdlib/core/option.nu`
 
 : | Dir { North South East West Up Down }
 

--- a/compiler/tests/match_int_literal.nu
+++ b/compiler/tests/match_int_literal.nu
@@ -6,7 +6,6 @@
 //   * wildcard catches the residual
 //   * arms returning different kinds of values (string here)
 
-$ `stdlib/core/string.nu`
 
 @ classify i n → s {
     ^ ?? n {

--- a/compiler/tests/match_param_payload.nu
+++ b/compiler/tests/match_param_payload.nu
@@ -15,7 +15,6 @@
 //
 // Each printed line is deterministic so the output is baselined.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 
 : S { s name }

--- a/compiler/tests/math_basic.nu
+++ b/compiler/tests/math_basic.nu
@@ -5,7 +5,6 @@
 // Float results are rounded to integers (or compared by sign / threshold)
 // to keep stdout byte-deterministic across libm implementations.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/errors.nu`
 $ `stdlib/std/float.nu`
 $ `stdlib/std/int.nu`

--- a/compiler/tests/mcp_client.nu
+++ b/compiler/tests/mcp_client.nu
@@ -15,7 +15,6 @@
 
 $ `stdlib/ext/mcp_client.nu`
 $ `stdlib/ext/json.nu`
-$ `stdlib/core/string.nu`
 
 @ println_str s prefix s value → v {
     ( nurl_print prefix )

--- a/compiler/tests/mcp_completion.nu
+++ b/compiler/tests/mcp_completion.nu
@@ -8,9 +8,7 @@
 // No sockets — pure dispatcher exercise (mirrors mcp_registry.nu).
 
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 $ `stdlib/ext/json.nu`
-$ `stdlib/ext/mcp.nu`
 $ `stdlib/ext/mcp_registry.nu`
 
 @ print_label s tag s value → v {

--- a/compiler/tests/mcp_hardening.nu
+++ b/compiler/tests/mcp_hardening.nu
@@ -15,7 +15,6 @@
 // main returns the failure count (0 = pass).
 
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 $ `stdlib/std/panic.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/mcp.nu`

--- a/compiler/tests/mcp_registry.nu
+++ b/compiler/tests/mcp_registry.nu
@@ -6,7 +6,6 @@
 // exercises.
 
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/mcp.nu`
 $ `stdlib/ext/mcp_registry.nu`

--- a/compiler/tests/mcp_resource_subscribe.nu
+++ b/compiler/tests/mcp_resource_subscribe.nu
@@ -5,7 +5,6 @@
 
 $ `stdlib/ext/mcp_session.nu`
 $ `stdlib/ext/json.nu`
-$ `stdlib/ext/mcp.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 

--- a/compiler/tests/mcp_stdio_basic.nu
+++ b/compiler/tests/mcp_stdio_basic.nu
@@ -15,7 +15,6 @@
 
 $ `stdlib/ext/mcp_stdio.nu`
 $ `stdlib/ext/json.nu`
-$ `stdlib/core/string.nu`
 
 @ println s line → v {
     ( nurl_print line )

--- a/compiler/tests/mqtt_codec.nu
+++ b/compiler/tests/mqtt_codec.nu
@@ -11,7 +11,6 @@
 
 $ `stdlib/ext/mqtt.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/std/bytes.nu`
 
 // Print a labelled byte buffer as `tag [len] b0 b1 ...`.
 @ dump s tag ( Vec u ) v → v {

--- a/compiler/tests/net_basic.nu
+++ b/compiler/tests/net_basic.nu
@@ -6,7 +6,6 @@
 // `net_loopback.nu`, gated behind NURL_NET_TESTS=1.
 
 $ `stdlib/std/net.nu`
-$ `stdlib/core/string.nu`
 
 @ print_label_str s label s value → v {
     ( nurl_print label )

--- a/compiler/tests/nurl_poke_slot_index.nu
+++ b/compiler/tests/nurl_poke_slot_index.nu
@@ -23,8 +23,6 @@
 // regular `./build.sh` run the test is a fast no-op that confirms
 // the slot-indexed accessor pair is consistent.
 
-$ `stdlib/core/mem.nu`
-$ `stdlib/core/string.nu`
 
 @ main → i {
     : i n 32

--- a/compiler/tests/outputs/borrow_double_free.txt
+++ b/compiler/tests/outputs/borrow_double_free.txt
@@ -1,4 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_double_free.nu:13: error: use of moved value 'a' - it was consumed at line 12 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_double_free.nu:12: error: use of moved value 'a' - it was consumed at line 11 (pass a fresh value or rebind it before reuse)
 error: compilation aborted - 1 borrow-checker violations (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_escape_vec.txt
+++ b/compiler/tests/outputs/borrow_escape_vec.txt
@@ -1,4 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_escape_vec.nu:28: error: passing a value that references a stack binding by pointer to 'thread_spawn' - it escapes the current stack frame and dangles (move it to a heap-backed handle)
+compiler/tests/borrow_escape_vec.nu:27: error: passing a value that references a stack binding by pointer to 'thread_spawn' - it escapes the current stack frame and dangles (move it to a heap-backed handle)
 error: compilation aborted - 1 borrow-checker violations (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_iter_invalidation.txt
+++ b/compiler/tests/outputs/borrow_iter_invalidation.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_iter_invalidation.nu:29: error: cannot mutate 'xs' while iterating over it - the '~' loop holds a borrow of the container; move the mutation out of the loop body
-compiler/tests/borrow_iter_invalidation.nu:34: error: cannot mutate 'xs' while iterating over it - the '~' loop holds a borrow of the container; move the mutation out of the loop body
+compiler/tests/borrow_iter_invalidation.nu:27: error: cannot mutate 'xs' while iterating over it - the '~' loop holds a borrow of the container; move the mutation out of the loop body
+compiler/tests/borrow_iter_invalidation.nu:32: error: cannot mutate 'xs' while iterating over it - the '~' loop holds a borrow of the container; move the mutation out of the loop body
 error: compilation aborted - 2 borrow-checker violations (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_sink_use_after.txt
+++ b/compiler/tests/outputs/borrow_sink_use_after.txt
@@ -1,4 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_sink_use_after.nu:26: error: use of moved value 'xs' - it was consumed at line 25 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_sink_use_after.nu:24: error: use of moved value 'xs' - it was consumed at line 23 (pass a fresh value or rebind it before reuse)
 error: compilation aborted - 1 borrow-checker violations (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_use_after_move.txt
+++ b/compiler/tests/outputs/borrow_use_after_move.txt
@@ -1,4 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_use_after_move.nu:12: error: use of moved value 'v' - it was consumed at line 11 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_use_after_move.nu:11: error: use of moved value 'v' - it was consumed at line 10 (pass a fresh value or rebind it before reuse)
 error: compilation aborted - 1 borrow-checker violations (re-run with --no-borrowck to bypass)

--- a/compiler/tests/pkg_install_e2e.nu
+++ b/compiler/tests/pkg_install_e2e.nu
@@ -19,7 +19,6 @@ $ `stdlib/std/time.nu`
 $ `stdlib/std/fs.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/hash_sha256.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_server.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_request.nu`
@@ -27,7 +26,6 @@ $ `stdlib/ext/compress.nu`
 $ `stdlib/ext/tar.nu`
 $ `stdlib/ext/manifest.nu`
 $ `stdlib/ext/lockfile.nu`
-$ `stdlib/ext/registry_index.nu`
 $ `stdlib/ext/resolver.nu`
 $ `stdlib/ext/pkg_fetch.nu`
 $ `stdlib/core/string.nu`

--- a/compiler/tests/posix_fork_exec.nu
+++ b/compiler/tests/posix_fork_exec.nu
@@ -7,7 +7,6 @@
 // backend to NURL) has the primitives it needs.
 
 $ `stdlib/core/posix.nu`
-$ `stdlib/core/string.nu`
 $ `stdlib/core/cell.nu`
 
 @ main → i {

--- a/compiler/tests/postgres_basic.nu
+++ b/compiler/tests/postgres_basic.nu
@@ -17,7 +17,6 @@
 //
 // Default (gate unset) prints the skip notice.
 
-$ `stdlib/std/process.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/ext/env.nu`

--- a/compiler/tests/process_basic.nu
+++ b/compiler/tests/process_basic.nu
@@ -6,7 +6,6 @@
 // so these resolve regardless of layout.
 
 $ `stdlib/std/process.nu`
-$ `stdlib/core/string.nu`
 
 @ print_int_line s label i n → v {
     ( nurl_print label )

--- a/compiler/tests/process_spawn_basic.nu
+++ b/compiler/tests/process_spawn_basic.nu
@@ -8,7 +8,6 @@
 
 $ `stdlib/std/process.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 
 @ println s line → v {
     ( nurl_print line )

--- a/compiler/tests/rc_basic.nu
+++ b/compiler/tests/rc_basic.nu
@@ -1,6 +1,5 @@
 // rc_basic.nu — Rc[T] shared-ownership semantics.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/std/rc.nu`
 
 @ main → i {

--- a/compiler/tests/rng_seedable.nu
+++ b/compiler/tests/rng_seedable.nu
@@ -16,7 +16,6 @@
 // generators, one seed → identical streams); rng_below bounds + zero
 // guard; rng_range inverted-range guard.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/std/rng.nu`
 
 // Compare; print a line and return 1 on mismatch, 0 on match.

--- a/compiler/tests/set_generic.nu
+++ b/compiler/tests/set_generic.nu
@@ -9,6 +9,7 @@
 //   • cap grows on first insert (lazy alloc through HashMap)
 
 $ `stdlib/std/set.nu`
+$ `stdlib/std/hashmap.nu`
 
 @ main → i {
     : ( @ i s ) hs \ s str → i { ^ ( hash_string str ) }

--- a/compiler/tests/set_ops.nu
+++ b/compiler/tests/set_ops.nu
@@ -1,5 +1,6 @@
 // Test: stdlib/std/set.nu — set_union / set_intersect / set_diff
 $ `stdlib/std/set.nu`
+$ `stdlib/std/hashmap.nu`
 
 @ count_via_fold ( Set i ) st → i {
     : ( @ i i i ) inc \ i acc i _x → i { ^ + acc 1 }

--- a/compiler/tests/signal_basic.nu
+++ b/compiler/tests/signal_basic.nu
@@ -29,7 +29,6 @@ $ `stdlib/std/thread.nu`
 $ `stdlib/std/time.nu`
 $ `stdlib/ext/env.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/core/io.nu`
 
 // Top-level mutable observed from inside the SIGUSR1 closure.
 : ~ i usr1_count 0

--- a/compiler/tests/sink_basic.nu
+++ b/compiler/tests/sink_basic.nu
@@ -9,9 +9,7 @@
 // as moved). Here `sum_and_free` consumes a Vec, sums it, and frees
 // it — `main` hands the Vec off and never touches it again.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 
 // Consumes the Vec: sums its elements, then frees it.
 @ sum_and_free sink ( Vec i ) g → i {

--- a/compiler/tests/slice_basic.nu
+++ b/compiler/tests/slice_basic.nu
@@ -1,4 +1,3 @@
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/slice.nu`
 

--- a/compiler/tests/sort_cmp.nu
+++ b/compiler/tests/sort_cmp.nu
@@ -4,7 +4,6 @@
 // generic, sort_by ascending + descending + by-key, sort on empty /
 // singleton / pre-sorted Vec, binary_search hit / miss / empty.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/std/cmp.nu`
 $ `stdlib/std/sort.nu`
 

--- a/compiler/tests/sqlite_tier34.nu
+++ b/compiler/tests/sqlite_tier34.nu
@@ -13,8 +13,6 @@
 //
 // Every handle is a scope-local match-arm binding → auto-dropped.
 
-$ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 $ `stdlib/ext/sqlite.nu`
 
 @ fail s tag SqliteErr e → v {

--- a/compiler/tests/time_basic.nu
+++ b/compiler/tests/time_basic.nu
@@ -11,7 +11,6 @@
 //                                                   schedulers can be slow)
 
 $ `stdlib/std/time.nu`
-$ `stdlib/core/string.nu`
 
 @ pb b v s label → v {
     ( nurl_print label ) ( nurl_print `=` )

--- a/compiler/tests/toml_basic.nu
+++ b/compiler/tests/toml_basic.nu
@@ -18,7 +18,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 $ `stdlib/ext/toml.nu`
 
 @ show_str s label TomlValue v → v {

--- a/compiler/tests/toml_serde.nu
+++ b/compiler/tests/toml_serde.nu
@@ -27,7 +27,6 @@ $ `stdlib/ext/serde.nu`
 $ `stdlib/ext/toml.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/errors.nu`
 
 @ say s label b cond → v {
     ? cond {

--- a/compiler/tests/volatile_mmio.nu
+++ b/compiler/tests/volatile_mmio.nu
@@ -9,7 +9,6 @@
 // (the load stays inside the loop in the optimized IR); this test pins
 // the functional read-modify-write semantics.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/hal/mmio.nu`
 
 @ main → i {

--- a/compiler/tests/websocket_client.nu
+++ b/compiler/tests/websocket_client.nu
@@ -17,9 +17,7 @@ $ `stdlib/std/bytes.nu`
 $ `stdlib/std/net.nu`
 $ `stdlib/std/thread.nu`
 $ `stdlib/ext/env.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
-$ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`
 $ `stdlib/ext/websocket.nu`
 

--- a/compiler/tests/xml_basic.nu
+++ b/compiler/tests/xml_basic.nu
@@ -5,7 +5,6 @@
 
 $ `stdlib/ext/xml.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 
 // Compare an owned ?String to an expected literal; frees the payload.
 @ chk ?String got s want s label → i {

--- a/examples/async_http_server.nu
+++ b/examples/async_http_server.nu
@@ -25,7 +25,6 @@
 
 $ `stdlib/std/async.nu`
 $ `stdlib/ext/http_full.nu`
-$ `stdlib/std/fs.nu`
 
 @ health_handler HttpRequest req Params params → HttpResponse {
     ^ ( response_text 200 `{"status":"ok"}\n` )

--- a/examples/claude_agent.nu
+++ b/examples/claude_agent.nu
@@ -34,8 +34,6 @@ $ `stdlib/std/process.nu`
 $ `stdlib/std/fs.nu`
 $ `stdlib/core/io.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/core/option.nu`
-$ `stdlib/core/result.nu`
 $ `stdlib/core/errors.nu`
 $ `stdlib/core/vec.nu`
 

--- a/examples/csv_demo.nu
+++ b/examples/csv_demo.nu
@@ -1,5 +1,4 @@
 $ `stdlib/core/string.nu`
-$ `stdlib/std/fs.nu`
 $ `stdlib/std/time.nu`
 $ `stdlib/ext/csv.nu`
 

--- a/examples/gameboy/core.nu
+++ b/examples/gameboy/core.nu
@@ -6,7 +6,6 @@
 // which add their own ROM source, output, and run loop.
 
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 
 // ── Machine state (single instance — module globals) ──────────────
 : ~ s g_mem 0            // 64 KiB flat address space (*u, held as s)

--- a/examples/gameboy/gb_wasm_full.nu
+++ b/examples/gameboy/gb_wasm_full.nu
@@ -6,7 +6,6 @@
 // which add their own ROM source, output, and run loop.
 
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 
 // ── Machine state (single instance — module globals) ──────────────
 : ~ s g_mem 0            // 64 KiB flat address space (*u, held as s)

--- a/examples/h2_client.nu
+++ b/examples/h2_client.nu
@@ -11,10 +11,10 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/std/net.nu`
 $ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http2_client.nu`
+$ `stdlib/std/async.nu`  // runtime_init
 
 @ print_resp s label HttpResponse r → v {
     ( nurl_print label )

--- a/examples/jira_manager.nu
+++ b/examples/jira_manager.nu
@@ -25,7 +25,6 @@
 //   nurl jira_manager.nu search "project = HAL AND status = 'In Progress'"
 
 $ `stdlib/core/string.nu`
-$ `stdlib/core/vec.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/http.nu`
 $ `stdlib/std/encode.nu`

--- a/examples/math_basic.nu
+++ b/examples/math_basic.nu
@@ -5,7 +5,6 @@
 // Float results are rounded to integers (or compared by sign / threshold)
 // to keep stdout byte-deterministic across libm implementations.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/errors.nu`
 $ `stdlib/std/float.nu`
 $ `stdlib/std/int.nu`

--- a/examples/time_basic.nu
+++ b/examples/time_basic.nu
@@ -11,7 +11,6 @@
 //                                                   schedulers can be slow)
 
 $ `stdlib/std/time.nu`
-$ `stdlib/core/string.nu`
 
 @ pb b v s label → v {
     ( nurl_print label ) ( nurl_print `=` )

--- a/examples/ws_client.nu
+++ b/examples/ws_client.nu
@@ -13,7 +13,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/std/net.nu`
 $ `stdlib/ext/env.nu`
 $ `stdlib/ext/websocket.nu`

--- a/examples/ws_echo.nu
+++ b/examples/ws_echo.nu
@@ -18,7 +18,6 @@
 
 $ `stdlib/std/net.nu`
 $ `stdlib/std/signal.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`

--- a/stdlib/core/box.nu
+++ b/stdlib/core/box.nu
@@ -81,7 +81,6 @@
 //   ( do_work s )                     // s is a single handle, address stable
 //   ( box_free_with s @ DosState d → v { ( map_free . d table ) } )
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/mem.nu`
 
 : Box [T] { s ptr }

--- a/stdlib/core/cell.nu
+++ b/stdlib/core/cell.nu
@@ -58,8 +58,6 @@
 //     via a typed lens. This is the right shape for `pthread_mutex_t`
 //     and friends, whose internal layout we don't want to mirror.
 
-$ `stdlib/core/string.nu`
-$ `stdlib/core/mem.nu`
 
 // FFI: the runtime-side platform-sizeof thunk. Defined in stdlib/runtime.c.
 // Returns sizeof(<name>) for known C-level types, -1 for unknown.

--- a/stdlib/core/posix.nu
+++ b/stdlib/core/posix.nu
@@ -34,7 +34,6 @@
 //     `*u`. Decode via `nurl_wait_is_exited` / `_exit_status` /
 //     `_is_signaled` / `_term_sig`.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/cell.nu`
 
 // ── Native constants + errno ──────────────────────────────────────

--- a/stdlib/core/slice.nu
+++ b/stdlib/core/slice.nu
@@ -31,9 +31,7 @@
 //
 // Slices do not own; never free them — let them go out of scope.
 
-$ `stdlib/core/option.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/mem.nu`
 
 : Slice [A] { * A data i len }
 

--- a/stdlib/core/vec.nu
+++ b/stdlib/core/vec.nu
@@ -99,7 +99,6 @@
 // owns heap storage; pass a closure that returns an independently-owned
 // element (e.g. wrap `string_clone` in a `\`).
 
-$ `stdlib/core/mem.nu`
 
 : Vec [A] { s ctl }
 

--- a/stdlib/ext/anthropic.nu
+++ b/stdlib/ext/anthropic.nu
@@ -178,8 +178,6 @@
 // edit those two literals — the rest of the wrapper is generic.
 
 $ `stdlib/core/string.nu`
-$ `stdlib/core/option.nu`
-$ `stdlib/core/result.nu`
 $ `stdlib/core/errors.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/int.nu`

--- a/stdlib/ext/compress.nu
+++ b/stdlib/ext/compress.nu
@@ -51,9 +51,7 @@
 //     value passes through libz unchanged via `compress2`).
 //   * zstd: -22 (fast negative levels) … 22 (max). Default 3.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/mem.nu`
 $ `stdlib/core/cell.nu`  // nurl_native_sizeof for z_stream alloc
 
 : | CompressErr {

--- a/stdlib/ext/csv.nu
+++ b/stdlib/ext/csv.nu
@@ -42,6 +42,7 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
+$ `stdlib/core/option.nu`
 $ `stdlib/std/fs.nu`
 $ `stdlib/std/sort.nu`
 $ `stdlib/std/cmp.nu`

--- a/stdlib/ext/http.nu
+++ b/stdlib/ext/http.nu
@@ -96,7 +96,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/errors.nu`
 $ `stdlib/std/bytes.nu`
 
 // HttpErr tags — see stdlib/runtime.c §14 NURL_HTTP_ERR_*.

--- a/stdlib/ext/http2_client.nu
+++ b/stdlib/ext/http2_client.nu
@@ -60,8 +60,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/mem.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/std/net.nu`
 $ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_response.nu`

--- a/stdlib/ext/http2_conn.nu
+++ b/stdlib/ext/http2_conn.nu
@@ -52,8 +52,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/mem.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/std/net.nu`
 $ `stdlib/std/panic.nu`
 $ `stdlib/ext/http.nu`

--- a/stdlib/ext/http2_frame.nu
+++ b/stdlib/ext/http2_frame.nu
@@ -25,7 +25,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/mem.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/net.nu`
 

--- a/stdlib/ext/http2_hpack.nu
+++ b/stdlib/ext/http2_hpack.nu
@@ -25,9 +25,9 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/mem.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/ext/http.nu`
+$ `stdlib/ext/http2_frame.nu`
 
 // ── Errors ────────────────────────────────────────────────────────────
 

--- a/stdlib/ext/http2_server.nu
+++ b/stdlib/ext/http2_server.nu
@@ -26,7 +26,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/std/net.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`

--- a/stdlib/ext/http_multipart.nu
+++ b/stdlib/ext/http_multipart.nu
@@ -72,12 +72,8 @@
 //   * Quoted boundary parameters (`boundary="my bound"`) are honoured;
 //     `boundary` parameters with embedded `;` or escaped quotes are not.
 
-$ `stdlib/std/net.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 
 // ── MultipartPart struct + lifecycle ─────────────────────────────────

--- a/stdlib/ext/http_proxy.nu
+++ b/stdlib/ext/http_proxy.nu
@@ -79,10 +79,8 @@
 //   * No HTTP/1.1 `Expect: 100-continue` upstream signalling.
 
 $ `stdlib/std/net.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/errors.nu`
 $ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`

--- a/stdlib/ext/http_request.nu
+++ b/stdlib/ext/http_request.nu
@@ -77,7 +77,6 @@
 //   http_req_body_default_max    → 10 MiB
 
 $ `stdlib/std/net.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/errors.nu`

--- a/stdlib/ext/http_router.nu
+++ b/stdlib/ext/http_router.nu
@@ -74,11 +74,8 @@
 //     `with_*` combinators are the v1 substitute — caller composes
 //     middleware around the handler closure they pass to the server.
 
-$ `stdlib/std/net.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 

--- a/stdlib/ext/http_server.nu
+++ b/stdlib/ext/http_server.nu
@@ -93,14 +93,12 @@
 //   * No HTTP/2, no TLS — Phase 9.
 
 $ `stdlib/std/net.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/std/thread.nu`
 $ `stdlib/std/dos.nu`
 $ `stdlib/std/time.nu`
 $ `stdlib/std/panic.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 

--- a/stdlib/ext/http_static.nu
+++ b/stdlib/ext/http_static.nu
@@ -47,7 +47,6 @@ $ `stdlib/std/fs.nu`
 $ `stdlib/std/path.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/std/bytes.nu`
 
 // ── mime_for_ext ─────────────────────────────────────────────────────
 //

--- a/stdlib/ext/json.nu
+++ b/stdlib/ext/json.nu
@@ -120,8 +120,6 @@
 $ `stdlib/core/errors.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
-$ `stdlib/core/result.nu`
 
 // memchr — glibc's SIMD-vectorised byte search. Used in
 // `__jp_parse_string`'s fast path to find the closing quote and (in

--- a/stdlib/ext/manifest.nu
+++ b/stdlib/ext/manifest.nu
@@ -41,7 +41,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 $ `stdlib/ext/toml.nu`
 
 : Dep {

--- a/stdlib/ext/mcp.nu
+++ b/stdlib/ext/mcp.nu
@@ -109,7 +109,6 @@
 //   client requests, as long as it's a revision the server supports).
 
 $ `stdlib/core/string.nu`
-$ `stdlib/core/option.nu`
 $ `stdlib/core/io.nu`
 $ `stdlib/ext/json.nu`
 

--- a/stdlib/ext/mcp_client.nu
+++ b/stdlib/ext/mcp_client.nu
@@ -52,7 +52,6 @@
 //     and `mcp_response_error_code/message` to read server errors.
 
 $ `stdlib/ext/http.nu`
-$ `stdlib/ext/http_json.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/mcp.nu`
 $ `stdlib/std/time.nu`

--- a/stdlib/ext/mcp_http.nu
+++ b/stdlib/ext/mcp_http.nu
@@ -109,7 +109,6 @@ $ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`
-$ `stdlib/ext/http_router.nu`
 $ `stdlib/std/net.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/core/string.nu`

--- a/stdlib/ext/mcp_registry.nu
+++ b/stdlib/ext/mcp_registry.nu
@@ -37,11 +37,9 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/mem.nu`
 $ `stdlib/std/panic.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/mcp.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 

--- a/stdlib/ext/msgpack.nu
+++ b/stdlib/ext/msgpack.nu
@@ -39,7 +39,6 @@
 $ `stdlib/ext/json.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/errors.nu`
 $ `stdlib/std/bytes.nu`
 
 // IEEE-754 bit access (runtime.c) — `#` casts convert numeric value, not

--- a/stdlib/ext/regex.nu
+++ b/stdlib/ext/regex.nu
@@ -49,8 +49,6 @@
 $ `stdlib/core/errors.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
-$ `stdlib/core/result.nu`
 
 // ── State kinds ─────────────────────────────────────────────────────
 // 0 = Match  (accept; out1/out2 unused)

--- a/stdlib/ext/sqlite.nu
+++ b/stdlib/ext/sqlite.nu
@@ -77,7 +77,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/cell.nu`
 
 // ── libsqlite3 FFI ────────────────────────────────────────────────
 //

--- a/stdlib/ext/toml.nu
+++ b/stdlib/ext/toml.nu
@@ -25,7 +25,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 
 : TomlEntry {
     String key

--- a/stdlib/ext/uuid.nu
+++ b/stdlib/ext/uuid.nu
@@ -10,7 +10,6 @@
 $ `stdlib/core/string.nu`
 $ `stdlib/std/random.nu`
 $ `stdlib/std/time.nu`
-$ `stdlib/std/bytes.nu`
 
 // Helper: push n hex nibbles of val to out (most significant first)
 @ __uuid_push_hex String out i val i nibbles → v {

--- a/stdlib/ext/websocket.nu
+++ b/stdlib/ext/websocket.nu
@@ -76,13 +76,11 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/mem.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/hash.nu`
 $ `stdlib/std/encode.nu`
 $ `stdlib/std/random.nu`
 $ `stdlib/std/net.nu`
-$ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 

--- a/stdlib/ext/yaml.nu
+++ b/stdlib/ext/yaml.nu
@@ -45,7 +45,6 @@
 $ `stdlib/ext/json.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 
 : | YamlErr { YamlSyntax YamlBadIndent YamlUnterminated YamlOther }
 

--- a/stdlib/std/arc.nu
+++ b/stdlib/std/arc.nu
@@ -59,8 +59,6 @@
 //   pointers. For thread-safe owned-T sharing use Arc[Mutex<…>]
 //   plus deep-clone whenever a copy is needed.
 
-$ `stdlib/core/string.nu`
-$ `stdlib/core/mem.nu`
 
 // FFI: atomic refcount primitives (stdlib/runtime.c).
 //   nurl_atomic_i64_inc(p)       → old value (fetch-add 1)

--- a/stdlib/std/arena.nu
+++ b/stdlib/std/arena.nu
@@ -78,8 +78,6 @@
 //   }
 //   ( arena_free scratch )
 
-$ `stdlib/core/string.nu`
-$ `stdlib/core/mem.nu`
 
 // One contiguous buffer + its bump cursor. A GROWING arena links these
 // into a list (`next` points at the previously-current chunk); a FIXED

--- a/stdlib/std/bigint.nu
+++ b/stdlib/std/bigint.nu
@@ -44,7 +44,6 @@ $ `stdlib/core/errors.nu`
 $ `stdlib/std/panic.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 
 : BigInt {
     b neg

--- a/stdlib/std/bufio.nu
+++ b/stdlib/std/bufio.nu
@@ -55,6 +55,7 @@
 $ `stdlib/core/string.nu`
 $ `stdlib/core/errors.nu`
 $ `stdlib/core/posix.nu`  // errno_kind
+$ `stdlib/std/fs.nu`      // nurl_file_open / nurl_file_close
 
 // ── libc bridges (pure-NURL FFI) ────────────────────────────────────
 // fread is declared globally in nurlc's preamble (Phase 7, 2026-05-23);

--- a/stdlib/std/deque.nu
+++ b/stdlib/std/deque.nu
@@ -28,7 +28,6 @@
 //   ( deque_free       [A] d )            → v
 //   ( deque_free_with  [A] d drop )       → v   drop : (@ v A)
 
-$ `stdlib/core/mem.nu`
 
 : Deque [A] { s ctl }
 

--- a/stdlib/std/dns.nu
+++ b/stdlib/std/dns.nu
@@ -34,7 +34,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/errors.nu`
 $ `stdlib/std/net.nu`
 
 // ── Runtime FFI bridge (§18c) ──────────────────────────────────────

--- a/stdlib/std/fmt.nu
+++ b/stdlib/std/fmt.nu
@@ -34,7 +34,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 
 // ── Core engine ────────────────────────────────────────────────────
 

--- a/stdlib/std/hash.nu
+++ b/stdlib/std/hash.nu
@@ -38,7 +38,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/mem.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/hash_md5.nu`
 $ `stdlib/std/hash_sha1.nu`

--- a/stdlib/std/hash_blake3.nu
+++ b/stdlib/std/hash_blake3.nu
@@ -15,7 +15,6 @@
 //
 // Wrapped by stdlib/std/hash.nu as `blake3_bytes` / `blake3_hex`.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 
 // ── word helpers ──────────────────────────────────────────────────

--- a/stdlib/std/hash_md5.nu
+++ b/stdlib/std/hash_md5.nu
@@ -11,7 +11,6 @@
 // `stdlib/std/hash.nu`'s `md5_bytes` calls this directly; the public
 // surface is unchanged.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 

--- a/stdlib/std/hash_sha1.nu
+++ b/stdlib/std/hash_sha1.nu
@@ -8,7 +8,6 @@
 // API:
 //   ( sha1_pure ( Vec u ) data ) → ( Vec u )   20-byte digest (owned)
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 

--- a/stdlib/std/hash_sha256.nu
+++ b/stdlib/std/hash_sha256.nu
@@ -5,7 +5,6 @@
 //   ( hmac_sha256_pure ( Vec u ) key
 //                       ( Vec u ) msg )   → ( Vec u )   32-byte HMAC
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 

--- a/stdlib/std/hash_sha512.nu
+++ b/stdlib/std/hash_sha512.nu
@@ -12,7 +12,6 @@
 // literal lexer caps at LLONG_MAX). `# u64 -N` is a zero-cost
 // reinterpretation of the i64 bit pattern as u64.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 

--- a/stdlib/std/hashmap.nu
+++ b/stdlib/std/hashmap.nu
@@ -62,7 +62,6 @@
 //   ( hash_int x )         → i        Knuth multiplicative hash
 //   ( eq_int a b )         → b        ==
 
-$ `stdlib/core/mem.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/pair.nu`
 $ `stdlib/core/string.nu`

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -70,7 +70,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/errors.nu`
 
 : | NetErr {
     NetBind

--- a/stdlib/std/random.nu
+++ b/stdlib/std/random.nu
@@ -21,7 +21,6 @@
 // directly.
 
 $ `stdlib/core/string.nu`
-$ `stdlib/std/int.nu`
 
 // Single syscall-shaped runtime bridge. Returns 1 on success, 0 on a
 // total entropy failure (which the degraded /dev/urandom-or-PRNG fallback

--- a/stdlib/std/rc.nu
+++ b/stdlib/std/rc.nu
@@ -73,8 +73,6 @@
 //   // each rc_clone'd recipient also calls rc_free_with on shutdown;
 //   // the last one runs the drop closure.
 
-$ `stdlib/core/string.nu`
-$ `stdlib/core/mem.nu`
 
 : RcImpl [T] {
     i count

--- a/stdlib/std/rng.nu
+++ b/stdlib/std/rng.nu
@@ -41,8 +41,6 @@
 //   : i b ( rng_next g )          // a != b; stream is deterministic
 //   ( rng_free g )
 
-$ `stdlib/core/string.nu`
-$ `stdlib/core/mem.nu`
 
 // ── State ────────────────────────────────────────────────────────────
 

--- a/stdlib/std/set.nu
+++ b/stdlib/std/set.nu
@@ -41,10 +41,8 @@
 //   ( set_free_with [E] s drop ) drop : (@ v E)            → v   (drop each element first)
 //
 // Use the same stock hash/eq as HashMap (`hash_string`/`eq_string`,
-// `hash_int`/`eq_int` from stdlib/std/hashmap.nu).
-
-$ `stdlib/core/mem.nu`
-$ `stdlib/std/hashmap.nu`
+// `hash_int`/`eq_int`) — import `stdlib/std/hashmap.nu` alongside this
+// file to get them; set.nu itself does not depend on it.
 
 : Set [E] { s ctl }
 

--- a/stdlib/std/sort.nu
+++ b/stdlib/std/sort.nu
@@ -11,7 +11,6 @@
 // loop on larger" optimization to guarantee O(log N) stack depth.
 
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/option.nu`
 
 // ── Internal helpers ───────────────────────────────────────────────
 

--- a/stdlib/std/thread.nu
+++ b/stdlib/std/thread.nu
@@ -57,7 +57,6 @@
 //   * On WASI, every entry degrades to a no-op stub; `thread_spawn`
 //     surfaces `ThreadCreate` so callers can fall back to a serial path.
 
-$ `stdlib/core/string.nu`
 $ `stdlib/core/cell.nu`
 
 // FFI: direct libpthread surface. On Linux/macOS these are libc; on

--- a/stdlib/std/udp.nu
+++ b/stdlib/std/udp.nu
@@ -59,7 +59,6 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
-$ `stdlib/core/errors.nu`
 $ `stdlib/std/net.nu`
 $ `stdlib/std/async_ffi.nu`
 

--- a/tools/check_examples.sh
+++ b/tools/check_examples.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ============================================================
+#  tools/check_examples.sh — frontend compile gate for the
+#  examples corpus (plus bench/ and duo/, which are example-
+#  shaped programs outside compiler/tests).
+#
+#  Usage:  ./tools/check_examples.sh        (from the repo root)
+#
+#  Runs `build/nurlc <file> > /dev/null` on every .nu file in
+#  examples/, bench/ and duo/. This exercises the full frontend —
+#  parse, imports, typecheck, borrowck, IR gen — which is exactly
+#  the layer where examples have silently rotted twice before
+#  (the gameboy/c64 immutability-migration misses) and where
+#  missing-import landmines live. Linking and running are NOT
+#  exercised; that keeps the gate < ~1 min and free of network /
+#  display / device dependencies.
+#
+#  The gate is wired into .github/workflows/ci.yml after
+#  ./build.sh, and can be run locally any time build/nurlc is
+#  fresh.
+# ============================================================
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+NURLC=build/nurlc
+if [[ ! -x "$NURLC" ]]; then
+    echo "ERROR: $NURLC not built. Run ./build.sh first." >&2
+    exit 2
+fi
+
+pass=0
+fail=0
+failed_files=()
+
+for f in examples/*.nu examples/*/*.nu bench/*.nu duo/*.nu; do
+    [[ -f "$f" ]] || continue
+    if "$NURLC" "$f" > /dev/null 2>/tmp/check_examples_err.$$; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        failed_files+=("$f")
+        echo "── FAIL: $f ─────────────────────────────"
+        cat /tmp/check_examples_err.$$
+    fi
+done
+rm -f /tmp/check_examples_err.$$
+
+echo
+echo "examples gate: PASS $pass · FAIL $fail"
+if [[ $fail -gt 0 ]]; then
+    printf 'failed: %s\n' "${failed_files[@]}"
+    exit 1
+fi
+exit 0

--- a/tools/nurl-lsp/main.nu
+++ b/tools/nurl-lsp/main.nu
@@ -14,7 +14,6 @@
 //      * Transitively walks `$`-imports starting from each didOpen
 //        file so cross-file jumps land in the right place.
 
-$ `stdlib/core/io.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/symtab.nu`
 $ `stdlib/std/fs.nu`
@@ -96,7 +95,7 @@ $ `tools/nurl-lsp/jsonrpc.nu`
 @ __build_server_info → Json {
     : Json info ( json_obj_new )
     ( json_obj_set info `name` ( json_str_lit `nurl-lsp` ) )
-    ( json_obj_set info `version` ( json_str_lit `0.5.0` ) )
+    ( json_obj_set info `version` ( json_str_lit `0.6.0` ) )
     ^ info
 }
 
@@ -786,10 +785,10 @@ $ `tools/nurl-lsp/jsonrpc.nu`
 @ __recompile_and_publish s uri → v {
     : s text ( nurl_sym_get g_docs uri )
     : Json diags ( __compile_diagnostics text )
-    // Merge in unused-import warnings (computed from the symbol index,
-    // not the compiler — the compiler never sees which file a symbol
-    // came from once it is in scope).
-    ( __unused_import_diags text diags )
+    // Unused-import warnings arrive from `nurlc --lint` itself (it
+    // attributes every decl to its defining file and tracks which file
+    // references what), so no LSP-side text heuristic is layered on
+    // top — one source of truth, no duplicate diagnostics.
     ( __publish_diagnostics uri diags )
 }
 
@@ -1671,44 +1670,6 @@ $ `tools/nurl-lsp/jsonrpc.nu`
     ^ eq
 }
 
-// True when `name` occurs as a whole-word identifier in `content`,
-// skipping backtick strings and `//` comments so a match inside a
-// string literal (e.g. an import-path token) never counts as a use.
-@ __name_referenced s content s name → b {
-    : i n ( nurl_str_len content )
-    : ~ i pos 0
-    : ~ i in_str 0
-    : ~ i in_com 0
-    : ~ b found F
-    ~ & < pos n ! found {
-        : i c ( nurl_str_get content pos )
-        ? != in_str 0 {
-            ? == c 96 { = in_str 0 } {}
-            = pos + pos 1
-        } {
-            ? != in_com 0 {
-                ? == c 10 { = in_com 0 } {}
-                = pos + pos 1
-            } {
-                ? == c 96 { = in_str 1 = pos + pos 1 } {
-                    ? & & == c 47 < + pos 1 n == ( nurl_str_get content + pos 1 ) 47 {
-                        = in_com 1 = pos + pos 2
-                    } {
-                        ? ( __is_ident_start c ) {
-                            : i st pos
-                            ~ & < pos n ( __is_ident_byte ( nurl_str_get content pos ) ) { = pos + pos 1 }
-                            ? ( __slice_eq content st - pos st name ) { = found T } {}
-                        } {
-                            = pos + pos 1
-                        }
-                    }
-                }
-            }
-        }
-    }
-    ^ found
-}
-
 // Append a Location for every whole-word occurrence of `name` in one
 // document's content, skipping strings + comments. Positions are
 // emitted 0-based (LSP coordinates) directly.
@@ -1848,115 +1809,6 @@ $ `tools/nurl-lsp/jsonrpc.nu`
         ( string_push_str acc uri )
         ( nurl_sym_def g_doc_uris `list` ( string_data acc ) )
         ( string_free acc )
-    }
-}
-
-// ── Unused-import diagnostics ───────────────────────────────────────
-//
-// An `$ `path`` import is unused when NONE of the top-level symbols the
-// imported file defines (per the symbol index, g_defs_by_uri) is
-// referenced anywhere in the importing file. Conservative by design:
-// any whole-word match — even one inside an unrelated expression —
-// counts as "used", so we never warn on a genuinely-needed import. If
-// the imported file was not indexed (path not found), we skip silently.
-
-// True when any decl name listed in `defs` is referenced in `content`.
-// `defs` is g_defs_by_uri's flat tab-separated stream of (name, line,
-// kind) triplets — `name\tline\tkind\tname\tline\tkind\t…`, NOT newline
-// per row — so the name fields are the ones whose field index ≡ 0 mod 3.
-// Stops at the first referenced name.
-@ __any_def_referenced s defs s content → b {
-    : i n ( nurl_str_len defs )
-    : ~ i pos 0
-    : ~ i fieldidx 0
-    : ~ b used F
-    ~ & < pos n ! used {
-        : i tab ( __index_of_byte defs pos n 9 )
-        : i end ? < tab 0 n tab
-        ? == 0 % fieldidx 3 {
-            ? > - end pos 0 {
-                : String nm ( __substr defs pos end )
-                ? ( __name_referenced content ( string_data nm ) ) { = used T } {}
-                ( string_free nm )
-            } {}
-        } {}
-        = fieldidx + fieldidx 1
-        = pos ? < tab 0 n + tab 1
-    }
-    ^ used
-}
-
-// Check one import; append an unused-import Warning at (line,col)
-// (0-based) when none of its symbols are referenced in `content`.
-@ __check_one_import s path i line i col s content Json diags → v {
-    : String abs ( __resolve_import_path path )
-    : String uri ( __path_to_uri ( string_data abs ) )
-    : s defs ( nurl_sym_get g_defs_by_uri ( string_data uri ) )
-    ? > ( nurl_str_len defs ) 0 {
-        ? ( __any_def_referenced defs content ) {} {
-            : String msg ( string_with_cap 96 )
-            ( string_push_str msg `unused import: no symbol from '` )
-            ( string_push_str msg path )
-            ( string_push_str msg `' is referenced in this file` )
-            // __build_diagnostic converts 1-based → 0-based, so feed it
-            // the 1-based form of our 0-based scan coordinates.
-            ( json_arr_push diags ( __build_diagnostic + line 1 + col 1 2 ( string_data msg ) ) )
-            ( string_free msg )
-        }
-    } {}
-    ( string_free uri )
-    ( string_free abs )
-}
-
-// Walk `content`, find every `$ `path`` import (tracking its line/col),
-// and append an unused-import diagnostic for each unused one.
-@ __unused_import_diags s content Json diags → v {
-    : i n ( nurl_str_len content )
-    : ~ i pos 0
-    : ~ i line 0
-    : ~ i line_start 0
-    : ~ i in_str 0
-    : ~ i in_com 0
-    : ~ i prev_dollar 0
-    : ~ i d_line 0
-    : ~ i d_col 0
-    ~ < pos n {
-        : i c ( nurl_str_get content pos )
-        ? == c 10 { = line + line 1 = pos + pos 1 = line_start pos = in_com 0 = prev_dollar 0 } {
-            ? != in_str 0 {
-                ? == c 96 { = in_str 0 } {}
-                = pos + pos 1
-            } {
-                ? != in_com 0 { = pos + pos 1 } {
-                    ? == c 96 {
-                        ? != prev_dollar 0 {
-                            : ~ i ep + pos 1
-                            ~ & < ep n != ( nurl_str_get content ep ) 96 { = ep + ep 1 }
-                            ? < ep n {
-                                : String path ( __substr content + pos 1 ep )
-                                ( __check_one_import ( string_data path ) d_line d_col content diags )
-                                ( string_free path )
-                                = pos + ep 1
-                            } { = pos n }
-                            = prev_dollar 0
-                        } {
-                            = in_str 1
-                            = pos + pos 1
-                        }
-                    } {
-                        ? & & == c 47 < + pos 1 n == ( nurl_str_get content + pos 1 ) 47 {
-                            = in_com 1 = pos + pos 2 = prev_dollar 0
-                        } {
-                            ? == c 36 { = prev_dollar 1 = d_line line = d_col - pos line_start = pos + pos 1 } {
-                                ? ( __is_space c ) { = pos + pos 1 } {
-                                    = prev_dollar 0 = pos + pos 1
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -37,7 +37,6 @@ $ `stdlib/std/sort.nu`
 $ `stdlib/ext/env.nu`
 $ `stdlib/ext/manifest.nu`
 $ `stdlib/ext/lockfile.nu`
-$ `stdlib/ext/semver.nu`
 $ `stdlib/ext/registry_index.nu`
 $ `stdlib/ext/resolver.nu`
 $ `stdlib/ext/pkg_fetch.nu`


### PR DESCRIPTION
## Summary

The LSP's `unused import: no symbol from 'stdlib/core/option.nu' is referenced in this file` warning was the tip of an iceberg: **180 stale `$` imports tree-wide** (88 in stdlib, 92 in tests/examples/tools), three of which were masking real latent bugs. This PR removes all of them, root-causes why the class could accumulate, and replaces every heuristic involved with one semantic implementation in the compiler.

## Stale imports removed (180)

Removal surfaced three **latent missing-import landmines** — files calling symbols whose defining file arrived only through *someone else's* stale import:

- `stdlib/ext/csv.nu` used `opt_unwrap_or` without importing `stdlib/core/option.nu` (rode on `sort.nu`'s stale import; broke with a garbled `<generic …>: expected '->'` error once that was removed)
- `stdlib/ext/http2_hpack.nu` called `h2_default_header_table_size` without importing `stdlib/ext/http2_frame.nu` (broke at **link** time: `use of undefined value`)
- `stdlib/std/bufio.nu` called `nurl_file_open`/`nurl_file_close` without importing `stdlib/std/fs.nu`

Each now imports what it uses. `stdlib/std/set.nu` no longer imports `hashmap.nu` on its callers' behalf (the three dependents import it directly; doc updated). `stdlib/ext/http_full.nu` (deliberate aggregator) and `compiler/tests/import_dedup.nu` (the unused import IS the fixture) are intentionally untouched.

## Compiler: two new diagnostics (the deep fixes)

1. **Unknown callee → compile error.** `gen_call` silently assumed `i64` for any unregistered name and emitted a call to an undeclared symbol — invalid IR rejected by clang far from the source, or *worse*, code that linked by accident when the defining file happened to be imported later AND the return type happened to be i64. Now it dies at the call site with the missing-import hint. En route this exposed **nine runtime builtins declared in `emit_header` but absent from the compiler's symbol table** (`nurl_peek`, `nurl_init`, `nurl_memset`, `nurl_vec_drop`, `nurl_argc`, `nurl_argv_count`, `nurl_read_int`, `puts`, `printf`) — all silently riding the i64 fallback. Registered, with a comment pinning the two lists in sync.

2. **Unknown generic template → clean error.** A generic call whose template is nowhere in the import closure used to die with `<generic opt_unwrap_or__Vec__String …>: expected '->' but found end of input`. Now: `call to generic function 'X' but no generic of that name is defined … add the '$' import`.

Both are diagnostics-only: bootstrap fixed point holds (stage1 ≡ stage2 ≡ stage3).

## `nurlc --lint`: unused-import detection (the gate)

The class accumulated because only the LSP — interactively, via a text heuristic — ever flagged it. Now `nurlc --lint` warns semantically: per-file def rosters (functions, FFI externs, types, consts, traits + methods, generic fn/struct templates) × file-scoped reference tracking (calls, ident reads, type positions, call-site `[T]` args, `% Trait` impl heads). Generic-template bodies re-parsed during the instantiation flush attribute their uses to the template's defining file, so stdlib internals can't mask a dead import in the user's file. Pure aggregators are exempt in both directions.

False-positive sweep: **zero warnings across the entire tree** (stdlib + 347 tests + 62 examples + tools) except the intentional `import_dedup` fixture.

## LSP v0.6.0: heuristic deleted

The LSP's ~190-LOC text-scan duplicate (`__unused_import_diags` + helpers) is gone; diagnostics now come from its existing `nurlc --lint` pass-through. One source of truth, no double warnings.

## Examples CI gate

`tools/check_examples.sh` frontend-compiles every `examples/` + `bench/` + `duo/` program (PASS 62 · FAIL 0) and is wired into `ci.yml` — examples have rotted silently twice before (gameboy/c64 immutability misses); missing-import landmines are exactly the class this catches.

## Verification

- `./build.sh`: bootstrap fixed point + full per-test golden suite green
- 5 borrow-checker goldens regolded (import removal shifts line numbers; verified line-number-only diffs via normalization before regolding)
- `./tools/check_examples.sh`: PASS 62 · FAIL 0
- Tree-wide `--lint` sweep: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
