### PR TITLE
stdlib JWT: HS256 + EdDSA (B5), plus option-of-enum codegen fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **JSON Web Tokens — `stdlib/ext/jwt.nu`** (critic B5). HS256 (HMAC-
+  SHA256) and EdDSA (Ed25519) sign + verify over the existing crypto
+  block and base64url. `jwt_hs256_sign/verify`, `jwt_eddsa_sign/verify`,
+  a `…_verify_at` core taking an explicit epoch `now` (deterministic;
+  the wrapper uses the system clock), and `jwt_decode_unverified`.
+  Validates `exp`/`nbf` time claims; the HS256 signature comparison is
+  constant-time (`std/subtle.nu`). The HS256 path reproduces the
+  canonical jwt.io reference token exactly and EdDSA is goldened against
+  the RFC 8032 test key (Ed25519 signatures are deterministic) in
+  `compiler/tests/jwt_basic.nu`. Adds `b64_url_encode_vec` /
+  `b64_url_decode_vec` to `std/encode.nu` for binary, unpadded
+  base64url (the signature segment).
+
+### Fixed
+
+- **`@ ?Enum { T Variant }` emitted invalid IR** (`compiler/nurlc.nu`,
+  `gen_agg_lit`). Constructing `Some(variant)` of an option whose
+  payload is a no-payload (C-style) enum inserted the variant's bare
+  i64 tag into the option's `%Enum` aggregate slot, which clang
+  rejected (`insertvalue operand and field disagree in type`). The
+  Result form `! T E` always worked because its payload slot is i64;
+  only the option payload field carries the full `%Enum` type. The
+  coercion now wraps the tag with `insertvalue %Enum zeroinitializer,
+  i64 tag, 0`. Found while writing `ext/jwt.nu`. Lock:
+  `compiler/tests/option_enum_payload.nu`.
+
 - **Cryptography block — AEAD, signatures, key exchange, KDFs**
   (`stdlib/ext/crypto.nu`, critic B1–B3). Binds libcrypto's EVP layer
   through pure-NURL `` & `openssl` @ `` FFI (no C bridge, same sentinel

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -9328,7 +9328,32 @@
                             ( nurl_print `\n` )
                             = actual_fval __cv
                             = actual_fty payload_ty }
-                        {}  // equal width / non-int: use as-is
+                        {  // payload_ty is not an int. The one remaining
+                            // shape is an OPTION whose payload is a named
+                            // enum (`? E`, payload field `%E`) carrying a
+                            // bare no-payload variant — which evaluates to
+                            // its i64 tag here. The option slot wants the
+                            // whole `%E` aggregate, so wrap the tag with
+                            // `insertvalue %E zeroinitializer, i64 tag, 0`
+                            // (the inverse of the `! T E` tag-extract above;
+                            // a no-payload variant leaves every other enum
+                            // field zero). Without this `@ ?E { T A }`
+                            // emitted `insertvalue { i1, %E } …, i64 …, 1`
+                            // and clang rejected the type mismatch.
+                            ? & == ( nurl_str_get payload_ty 0 ) 37 ( seq fty `i64` )
+                            { : s __en ( nurl_str_slice payload_ty 1 - ( nurl_str_len payload_ty ) 1 )
+                                : s __ev ( nurl_sym_get syms ( nurl_str_cat __en `__variants` ) )
+                                ? != 0 ( nurl_str_len __ev )
+                                { : s __wrap ( nurl_cg_reg cg )
+                                    ( nurl_print `  ` ) ( nurl_print __wrap )
+                                    ( nurl_print ` = insertvalue ` ) ( nurl_print payload_ty )
+                                    ( nurl_print ` zeroinitializer, i64 ` ) ( nurl_print fval )
+                                    ( nurl_print `, 0\n` )
+                                    = actual_fval __wrap
+                                    = actual_fty payload_ty }
+                                {} }
+                            {}
+                        }
                     }
                 }
             }

--- a/compiler/tests/jwt_basic.nu
+++ b/compiler/tests/jwt_basic.nu
@@ -1,0 +1,165 @@
+// jwt_basic.nu — ext/jwt.nu acceptance.
+//
+// HS256 is checked against the canonical jwt.io reference token
+// (secret "your-256-bit-secret"). EdDSA uses the RFC 8032 §7.1 TEST 1
+// secret key — Ed25519 signatures are deterministic, so the whole
+// token is reproducible and goldened. Both algorithms also exercise
+// verify success, wrong-key / tamper rejection, and exp/nbf time
+// claims (via verify_at with explicit timestamps).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/jwt.nu`
+
+@ hx s h → ( Vec u ) {
+    : i n ( nurl_str_len h )
+    : ( Vec u ) out ( vec_with_cap [u] ? > n 1 / n 2 1 )
+    : ~ i k 0
+    ~ < + k 1 n {
+        : i hi ( nurl_str_get h k )
+        : i lo ( nurl_str_get h + k 1 )
+        : i hv ? <= hi 57 - hi 48 - hi 87
+        : i lv ? <= lo 57 - lo 48 - lo 87
+        ( vec_push [u] out # u + * hv 16 lv )
+        = k + k 2
+    }
+    ^ out
+}
+
+// Print "ok"/"BAD" for a verify result, plus the `sub` claim on success.
+@ show_verify s label !Json JwtErr r → v {
+    ( nurl_print label )
+    ?? r {
+        T payload → {
+            ( nurl_print `ok sub=` )
+            : ?Json subo ( json_obj_get payload `sub` )
+            ?? subo { T sj → ( nurl_print ( json_str_data sj ) ) F _ → ( nurl_print `<none>` ) }
+            ( nurl_print `\n` )
+            ( json_free payload )
+        }
+        F e → {
+            ( nurl_print `err=` )
+            ( nurl_print ?? e {
+                JwtMalformed → `Malformed`
+                JwtBadSignature → `BadSignature`
+                JwtExpired → `Expired`
+                JwtNotYetValid → `NotYetValid`
+                JwtUnsupportedAlg → `UnsupportedAlg`
+                JwtBadClaims → `BadClaims`
+            } )
+            ( nurl_print `\n` )
+        }
+    }
+}
+
+@ mk_claims → Json {
+    : Json p ( json_obj_new )
+    ( json_obj_set p `sub` ( json_str_lit `1234567890` ) )
+    ( json_obj_set p `name` ( json_str_lit `John Doe` ) )
+    ( json_obj_set p `iat` ( json_num_lit `1516239022` ) )
+    ^ p
+}
+
+@ main → i {
+    : s secret `your-256-bit-secret`
+
+    // ── HS256 sign → canonical jwt.io token ────────────────────────
+    : Json claims ( mk_claims )
+    : String tok ( jwt_hs256_sign secret claims )
+    ( nurl_print `hs256_token=` ) ( nurl_print ( string_data tok ) ) ( nurl_print `\n` )
+
+    // verify with the right secret (no exp/nbf → always valid)
+    ( show_verify `hs256_verify_ok: ` ( jwt_hs256_verify_at secret ( string_data tok ) 1516239022 ) )
+    // verify with the wrong secret → BadSignature
+    ( show_verify `hs256_verify_wrongkey: ` ( jwt_hs256_verify_at `wrong-secret` ( string_data tok ) 1516239022 ) )
+
+    // tamper: flip the last char of the signature segment
+    : i tlen ( string_len tok )
+    : String bad ( string_with_cap + tlen 1 )
+    : ~ i k 0
+    ~ < k tlen {
+        : i c ( nurl_str_get ( string_data tok ) k )
+        ( string_push_char bad ? == k - tlen 1 ? == c 99 100 99 c )
+        = k + k 1
+    }
+    ( show_verify `hs256_verify_tampered: ` ( jwt_hs256_verify_at secret ( string_data bad ) 1516239022 ) )
+    ( string_free bad )
+
+    // malformed (no dots)
+    ( show_verify `hs256_verify_malformed: ` ( jwt_hs256_verify_at secret `not-a-token` 0 ) )
+
+    ( string_free tok )
+    ( json_free claims )
+
+    // ── exp / nbf time claims (HS256) ──────────────────────────────
+    : Json ec ( json_obj_new )
+    ( json_obj_set ec `sub` ( json_str_lit `exp-test` ) )
+    ( json_obj_set ec `exp` ( json_num_lit `1000` ) )
+    : String etok ( jwt_hs256_sign secret ec )
+    ( show_verify `hs256_exp_valid(now=500): ` ( jwt_hs256_verify_at secret ( string_data etok ) 500 ) )
+    ( show_verify `hs256_exp_expired(now=2000): ` ( jwt_hs256_verify_at secret ( string_data etok ) 2000 ) )
+    ( string_free etok )
+    ( json_free ec )
+
+    : Json nc ( json_obj_new )
+    ( json_obj_set nc `sub` ( json_str_lit `nbf-test` ) )
+    ( json_obj_set nc `nbf` ( json_num_lit `1000` ) )
+    : String ntok ( jwt_hs256_sign secret nc )
+    ( show_verify `hs256_nbf_early(now=500): ` ( jwt_hs256_verify_at secret ( string_data ntok ) 500 ) )
+    ( show_verify `hs256_nbf_ok(now=1500): ` ( jwt_hs256_verify_at secret ( string_data ntok ) 1500 ) )
+    ( string_free ntok )
+    ( json_free nc )
+
+    // ── EdDSA (Ed25519, RFC 8032 §7.1 TEST 1 secret) ───────────────
+    : ( Vec u ) sk ( hx `9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60` )
+    : Json eclaims ( mk_claims )
+    : !String CryptoErr eso ( jwt_eddsa_sign sk eclaims )
+    ?? eso {
+        T etoken → {
+            ( nurl_print `eddsa_token=` ) ( nurl_print ( string_data etoken ) ) ( nurl_print `\n` )
+            : !( Vec u ) CryptoErr pko ( ed25519_pubkey sk )
+            ?? pko {
+                T pk → {
+                    ( show_verify `eddsa_verify_ok: ` ( jwt_eddsa_verify_at pk ( string_data etoken ) 1516239022 ) )
+                    // tamper the payload's last pre-dot char
+                    : i el ( string_len etoken )
+                    : String ebad ( string_with_cap + el 1 )
+                    : ~ i j 0
+                    ~ < j el {
+                        : i c ( nurl_str_get ( string_data etoken ) j )
+                        ( string_push_char ebad ? == j - el 1 ? == c 65 66 65 c )
+                        = j + j 1
+                    }
+                    ( show_verify `eddsa_verify_tampered: ` ( jwt_eddsa_verify_at pk ( string_data ebad ) 1516239022 ) )
+                    ( string_free ebad )
+                    ( vec_free [u] pk )
+                }
+                F _ → ( nurl_print `eddsa pubkey FAILED\n` )
+            }
+            ( string_free etoken )
+        }
+        F _ → ( nurl_print `eddsa sign FAILED\n` )
+    }
+    ( vec_free [u] sk )
+    ( json_free eclaims )
+
+    // ── decode_unverified ──────────────────────────────────────────
+    : Json dc ( mk_claims )
+    : String dtok ( jwt_hs256_sign secret dc )
+    : !Json JwtErr du ( jwt_decode_unverified ( string_data dtok ) )
+    ?? du {
+        T payload → {
+            : ?Json no ( json_obj_get payload `name` )
+            ( nurl_print `decode_unverified_name=` )
+            ?? no { T nj → ( nurl_print ( json_str_data nj ) ) F _ → ( nurl_print `<none>` ) }
+            ( nurl_print `\n` )
+            ( json_free payload )
+        }
+        F _ → ( nurl_print `decode_unverified FAILED\n` )
+    }
+    ( string_free dtok )
+    ( json_free dc )
+
+    ^ 0
+}

--- a/compiler/tests/option_enum_payload.nu
+++ b/compiler/tests/option_enum_payload.nu
@@ -1,0 +1,34 @@
+// option_enum_payload.nu — regression for option-of-enum construction.
+//
+// `@ ?E { T Variant }` where E is a no-payload (C-style) enum used to
+// emit `insertvalue { i1, %E } …, i64 tag, 1` — a bare variant
+// evaluates to its i64 tag, but the option's payload slot is the whole
+// `%E` aggregate, and clang rejected the type mismatch. gen_agg_lit now
+// wraps the tag with `insertvalue %E zeroinitializer, i64 tag, 0` (the
+// inverse of the `! T E` tag-extract path). The Result form `! T E`
+// always worked because its payload slot is i64; only the option form
+// was broken.
+
+: | Color { Red Green Blue }
+
+@ pick i x → ?Color {
+    ? == x 1 { ^ @ ?Color { T Red } } {}
+    ? == x 2 { ^ @ ?Color { T Green } } {}
+    ? == x 3 { ^ @ ?Color { T Blue } } {}
+    ^ @ ?Color { F }
+}
+
+@ name_of ?Color o → s {
+    ?? o {
+        T c → ?? c { Red → `red` Green → `green` Blue → `blue` }
+        F _ → `none`
+    }
+}
+
+@ main → i {
+    ( nurl_print ( name_of ( pick 1 ) ) ) ( nurl_print ` ` )
+    ( nurl_print ( name_of ( pick 2 ) ) ) ( nurl_print ` ` )
+    ( nurl_print ( name_of ( pick 3 ) ) ) ( nurl_print ` ` )
+    ( nurl_print ( name_of ( pick 9 ) ) ) ( nurl_print `\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs/jwt_basic.txt
+++ b/compiler/tests/outputs/jwt_basic.txt
@@ -1,0 +1,17 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+hs256_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+hs256_verify_ok: ok sub=1234567890
+hs256_verify_wrongkey: err=BadSignature
+hs256_verify_tampered: err=BadSignature
+hs256_verify_malformed: err=Malformed
+hs256_exp_valid(now=500): ok sub=exp-test
+hs256_exp_expired(now=2000): err=Expired
+hs256_nbf_early(now=500): err=NotYetValid
+hs256_nbf_ok(now=1500): ok sub=nbf-test
+eddsa_token=eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.vLeihDpjKFbZGE86WqTj7w1eeRh6p8kiUw3oDfW6IS1i79tAeUdaK4vodykBqybCjAa5P9250Ts6w1a9knr9Ag
+eddsa_verify_ok: ok sub=1234567890
+eddsa_verify_tampered: err=BadSignature
+decode_unverified_name=John Doe

--- a/compiler/tests/outputs/option_enum_payload.txt
+++ b/compiler/tests/outputs/option_enum_payload.txt
@@ -1,0 +1,5 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+red green blue none

--- a/stdlib/ext/jwt.nu
+++ b/stdlib/ext/jwt.nu
@@ -1,0 +1,330 @@
+// stdlib/ext/jwt.nu — JSON Web Tokens (RFC 7519), HS256 + EdDSA.
+//
+// A JWT is three base64url-unpadded segments joined by '.':
+//   base64url(header) . base64url(payload) . base64url(signature)
+// The signature covers the ASCII string `header_b64 . payload_b64`.
+// This module signs and verifies the two algorithms that matter in
+// practice: HS256 (HMAC-SHA256, shared secret) and EdDSA (Ed25519,
+// asymmetric). RS*/ES* are intentionally omitted — Ed25519 is the
+// modern asymmetric choice and avoids RSA's footguns.
+//
+// HS256 (symmetric — same secret signs and verifies):
+//   ( jwt_hs256_sign      s secret Json claims )          → String
+//   ( jwt_hs256_verify    s secret s token )              → !Json JwtErr
+//   ( jwt_hs256_verify_at s secret s token i now )        → !Json JwtErr
+//
+// EdDSA (asymmetric — 32-byte Ed25519 keys from ext/crypto.nu):
+//   ( jwt_eddsa_sign      ( Vec u ) sk Json claims )      → !String CryptoErr
+//   ( jwt_eddsa_verify    ( Vec u ) pk s token )          → !Json JwtErr
+//   ( jwt_eddsa_verify_at ( Vec u ) pk s token i now )    → !Json JwtErr
+//
+//   ( jwt_decode_unverified s token )                     → !Json JwtErr
+//       Decode the payload WITHOUT checking the signature or time
+//       claims. For reading `iss`/`sub`/`kid` to pick a key before
+//       verifying — never trust its contents until a verify succeeds.
+//
+// `claims` is a JSON object the caller owns (sign stringifies it; it is
+// NOT freed here). verify returns the parsed payload as an owned Json —
+// the caller frees it with json_free. The header is built internally per
+// algorithm, so the caller only supplies claims.
+//
+// Time claims: `verify` validates `exp` (reject once now ≥ exp) and
+// `nbf` (reject while now < nbf) when present, against the system clock.
+// `verify_at` takes an explicit epoch-seconds `now` — deterministic for
+// tests and for callers with their own time source. Both are no-ops when
+// the claim is absent or non-numeric. There is no built-in leeway; a
+// caller needing clock-skew tolerance passes a skewed `now` to
+// verify_at.
+//
+// The signature comparison is constant-time (std/subtle.nu) for HS256 —
+// a byte-at-a-time string compare on a MAC is a forgery oracle.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/subtle.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/crypto.nu`
+
+: | JwtErr {
+    JwtMalformed       // not three '.'-separated segments / bad base64url
+    JwtBadSignature    // signature did not verify
+    JwtExpired         // now ≥ exp
+    JwtNotYetValid     // now < nbf
+    JwtUnsupportedAlg  // header alg not the one this verifier expects
+    JwtBadClaims       // payload is not a JSON object
+}
+
+// ── Segment helpers ────────────────────────────────────────────────
+
+// Byte index of the n-th (0-based) '.' in `s`, or -1.
+@ __jwt_dot_at s str i n → i {
+    : i len ( nurl_str_len str )
+    : ~ i seen 0
+    : ~ i k 0
+    ~ < k len {
+        ? == ( nurl_str_get str k ) 46 {
+            ? == seen n { ^ k } {}
+            = seen + seen 1
+        } {}
+        = k + k 1
+    }
+    ^ -1
+}
+
+// Owned String slice [a, b) of `str`.
+@ __jwt_slice s str i a i b → String {
+    : String out ( string_with_cap ? > - b a 0 - b a 1 )
+    : ~ i k a
+    ~ < k b { ( string_push_char out ( nurl_str_get str k ) ) = k + k 1 }
+    ^ out
+}
+
+// The two '.' positions of a well-formed token, written into a 2-slot
+// scratch. Returns T iff exactly two dots exist and neither segment is
+// empty (header, payload, signature all non-zero length).
+@ __jwt_split s token s d0p s d1p → b {
+    : i len ( nurl_str_len token )
+    : i d0 ( __jwt_dot_at token 0 )
+    : i d1 ( __jwt_dot_at token 1 )
+    : i d2 ( __jwt_dot_at token 2 )
+    ? < d0 0 { ^ F } {}
+    ? < d1 0 { ^ F } {}
+    ? >= d2 0 { ^ F } {}        // a third dot ⇒ malformed
+    ? <= d0 0 { ^ F } {}        // empty header
+    ? <= - d1 d0 1 { ^ F } {}   // empty payload
+    ? >= + d1 1 len { ^ F } {}  // empty signature
+    ( nurl_poke # s d0p 0 d0 )
+    ( nurl_poke # s d1p 0 d1 )
+    ^ T
+}
+
+// String → owned Vec[u] (caller's text is NUL-free ASCII here).
+@ __jwt_bytes s str → ( Vec u ) {
+    ^ ( bytes_from_str str )
+}
+
+// Build `header_b64 . payload_b64` (the JWS signing input) for a given
+// compact header JSON + claims object. Returns an owned String.
+@ __jwt_signing_input s header_json Json claims → String {
+    : String payload_json ( json_stringify claims )
+    : String h64 ( b64_url_encode header_json )
+    : String p64 ( b64_url_encode ( string_data payload_json ) )
+    : String out ( string_with_cap + + ( string_len h64 ) ( string_len p64 ) 2 )
+    ( string_push_str out ( string_data h64 ) )
+    ( string_push_char out 46 )
+    ( string_push_str out ( string_data p64 ) )
+    ( string_free h64 )
+    ( string_free p64 )
+    ( string_free payload_json )
+    ^ out
+}
+
+// ── HS256 ──────────────────────────────────────────────────────────
+
+@ jwt_hs256_sign s secret Json claims → String {
+    : String signing ( __jwt_signing_input `{"alg":"HS256","typ":"JWT"}` claims )
+    : ( Vec u ) key ( __jwt_bytes secret )
+    : ( Vec u ) msg ( __jwt_bytes ( string_data signing ) )
+    : ( Vec u ) mac ( hmac_sha256_pure key msg )
+    : String sig64 ( b64_url_encode_vec mac )
+    : String token ( string_with_cap + ( string_len signing ) + ( string_len sig64 ) 1 )
+    ( string_push_str token ( string_data signing ) )
+    ( string_push_char token 46 )
+    ( string_push_str token ( string_data sig64 ) )
+    ( vec_free [u] key )
+    ( vec_free [u] msg )
+    ( vec_free [u] mac )
+    ( string_free sig64 )
+    ( string_free signing )
+    ^ token
+}
+
+// Decode the payload segment of `token` (segment 1) to its JSON object.
+// Shared by every verify path AFTER the signature has been accepted (or,
+// for jwt_decode_unverified, deliberately without one).
+@ __jwt_payload_json s token i d0 i d1 → !Json JwtErr {
+    : String p64 ( __jwt_slice token + d0 1 d1 )
+    : !String ParseErr pd ( b64_url_decode ( string_data p64 ) )
+    ( string_free p64 )
+    ?? pd {
+        T pjson → {
+            : !Json JsonError pj ( json_parse ( string_data pjson ) )
+            ( string_free pjson )
+            ?? pj {
+                T j → {
+                    ? ( __jwt_is_obj j ) { ^ @ !Json JwtErr { T j } }
+                    { ( json_free j ) ^ @ !Json JwtErr { F JwtBadClaims } }
+                }
+                F _ → { ^ @ !Json JwtErr { F JwtMalformed } }
+            }
+        }
+        F _ → { ^ @ !Json JwtErr { F JwtMalformed } }
+    }
+}
+
+// True iff `j` is a JSON object (probing for an unlikely-but-harmless
+// key returns Some only for objects; the cheap structural check is
+// json_obj_get on any key — but that always yields ?, so instead we
+// stringify-probe: an object renders starting with '{').
+@ __jwt_is_obj Json j → b {
+    : String s ( json_stringify j )
+    : b ok & > ( string_len s ) 0 == ( nurl_str_get ( string_data s ) 0 ) 123
+    ( string_free s )
+    ^ ok
+}
+
+// Validate exp / nbf against `now`. Some(err) when a time claim fails,
+// None when the claims pass (or are absent / non-numeric).
+@ __jwt_check_time Json payload i now → ?JwtErr {
+    : ?Json exp_o ( json_obj_get payload `exp` )
+    ?? exp_o {
+        T expj → {
+            : ?i exp_i ( json_num_as_i expj )
+            ?? exp_i {
+                T exp → { ? >= now exp { ^ @ ?JwtErr { T JwtExpired } } {} }
+                F _ → {}
+            }
+        }
+        F _ → {}
+    }
+    : ?Json nbf_o ( json_obj_get payload `nbf` )
+    ?? nbf_o {
+        T nbfj → {
+            : ?i nbf_i ( json_num_as_i nbfj )
+            ?? nbf_i {
+                T nbf → { ? < now nbf { ^ @ ?JwtErr { T JwtNotYetValid } } {} }
+                F _ → {}
+            }
+        }
+        F _ → {}
+    }
+    ^ @ ?JwtErr { F }
+}
+
+@ jwt_hs256_verify_at s secret s token i now → !Json JwtErr {
+    : s d0buf ( nurl_zalloc 8 )
+    : s d1buf ( nurl_zalloc 8 )
+    ? ( __jwt_split token d0buf d1buf ) {} {
+        ( nurl_free d0buf ) ( nurl_free d1buf )
+        ^ @ !Json JwtErr { F JwtMalformed }
+    }
+    : i d0 ( nurl_peek d0buf 0 )
+    : i d1 ( nurl_peek d1buf 0 )
+    ( nurl_free d0buf ) ( nurl_free d1buf )
+    // Recompute the MAC over segments [0..d1) and base64url-encode it,
+    // then constant-time compare to the presented signature segment.
+    : String signing ( __jwt_slice token 0 d1 )
+    : ( Vec u ) key ( __jwt_bytes secret )
+    : ( Vec u ) msg ( __jwt_bytes ( string_data signing ) )
+    : ( Vec u ) mac ( hmac_sha256_pure key msg )
+    : String want ( b64_url_encode_vec mac )
+    : i siglen - ( nurl_str_len token ) + d1 1
+    : String got ( __jwt_slice token + d1 1 ( nurl_str_len token ) )
+    : b sig_ok ( constant_time_eq ( string_data want ) ( string_data got ) )
+    ( vec_free [u] key ) ( vec_free [u] msg ) ( vec_free [u] mac )
+    ( string_free want ) ( string_free got ) ( string_free signing )
+    ? sig_ok {} { ^ @ !Json JwtErr { F JwtBadSignature } }
+    : !Json JwtErr pj ( __jwt_payload_json token d0 d1 )
+    ?? pj {
+        T payload → {
+            : ?JwtErr terr ( __jwt_check_time payload now )
+            ?? terr {
+                T e → { ( json_free payload ) ^ @ !Json JwtErr { F e } }
+                F _ → { ^ @ !Json JwtErr { T payload } }
+            }
+        }
+        F e → { ^ @ !Json JwtErr { F e } }
+    }
+}
+
+@ jwt_hs256_verify s secret s token → !Json JwtErr {
+    ^ ( jwt_hs256_verify_at secret token ( now_seconds ) )
+}
+
+// ── EdDSA (Ed25519) ────────────────────────────────────────────────
+
+@ jwt_eddsa_sign ( Vec u ) sk Json claims → !String CryptoErr {
+    : String signing ( __jwt_signing_input `{"alg":"EdDSA","typ":"JWT"}` claims )
+    : ( Vec u ) msg ( __jwt_bytes ( string_data signing ) )
+    : !( Vec u ) CryptoErr so ( ed25519_sign sk msg )
+    ( vec_free [u] msg )
+    ?? so {
+        T sig → {
+            : String sig64 ( b64_url_encode_vec sig )
+            : String token ( string_with_cap + ( string_len signing ) + ( string_len sig64 ) 1 )
+            ( string_push_str token ( string_data signing ) )
+            ( string_push_char token 46 )
+            ( string_push_str token ( string_data sig64 ) )
+            ( vec_free [u] sig )
+            ( string_free sig64 )
+            ( string_free signing )
+            ^ @ !String CryptoErr { T token }
+        }
+        F e → {
+            ( string_free signing )
+            ^ @ !String CryptoErr { F e }
+        }
+    }
+}
+
+@ jwt_eddsa_verify_at ( Vec u ) pk s token i now → !Json JwtErr {
+    : s d0buf ( nurl_zalloc 8 )
+    : s d1buf ( nurl_zalloc 8 )
+    ? ( __jwt_split token d0buf d1buf ) {} {
+        ( nurl_free d0buf ) ( nurl_free d1buf )
+        ^ @ !Json JwtErr { F JwtMalformed }
+    }
+    : i d0 ( nurl_peek d0buf 0 )
+    : i d1 ( nurl_peek d1buf 0 )
+    ( nurl_free d0buf ) ( nurl_free d1buf )
+    : String signing ( __jwt_slice token 0 d1 )
+    : String sig64 ( __jwt_slice token + d1 1 ( nurl_str_len token ) )
+    : !( Vec u ) ParseErr sd ( b64_url_decode_vec ( string_data sig64 ) )
+    ( string_free sig64 )
+    : ~ b sig_ok F
+    ?? sd {
+        T sig → {
+            : ( Vec u ) msg ( __jwt_bytes ( string_data signing ) )
+            = sig_ok ( ed25519_verify pk msg sig )
+            ( vec_free [u] msg )
+            ( vec_free [u] sig )
+        }
+        F _ → {}
+    }
+    ( string_free signing )
+    ? sig_ok {} { ^ @ !Json JwtErr { F JwtBadSignature } }
+    : !Json JwtErr pj ( __jwt_payload_json token d0 d1 )
+    ?? pj {
+        T payload → {
+            : ?JwtErr terr ( __jwt_check_time payload now )
+            ?? terr {
+                T e → { ( json_free payload ) ^ @ !Json JwtErr { F e } }
+                F _ → { ^ @ !Json JwtErr { T payload } }
+            }
+        }
+        F e → { ^ @ !Json JwtErr { F e } }
+    }
+}
+
+@ jwt_eddsa_verify ( Vec u ) pk s token → !Json JwtErr {
+    ^ ( jwt_eddsa_verify_at pk token ( now_seconds ) )
+}
+
+// ── Unverified decode ──────────────────────────────────────────────
+
+@ jwt_decode_unverified s token → !Json JwtErr {
+    : s d0buf ( nurl_zalloc 8 )
+    : s d1buf ( nurl_zalloc 8 )
+    ? ( __jwt_split token d0buf d1buf ) {} {
+        ( nurl_free d0buf ) ( nurl_free d1buf )
+        ^ @ !Json JwtErr { F JwtMalformed }
+    }
+    : i d0 ( nurl_peek d0buf 0 )
+    : i d1 ( nurl_peek d1buf 0 )
+    ( nurl_free d0buf ) ( nurl_free d1buf )
+    ^ ( __jwt_payload_json token d0 d1 )
+}

--- a/stdlib/std/encode.nu
+++ b/stdlib/std/encode.nu
@@ -156,6 +156,41 @@ $ `stdlib/core/errors.nu`
     ^ out
 }
 
+// URL-safe, UN-padded base64 over a binary Vec[u]. Unlike
+// `b64_url_encode`, the length comes from `vec_len`, not `strlen`, so
+// material with embedded 0x00 bytes (a raw HMAC tag or Ed25519
+// signature — exactly what JWT base64url-encodes) is encoded whole.
+// `__b64_emit` reads through a `*u` pointer, so the binary input is
+// never truncated.
+@ b64_url_encode_vec ( Vec u ) v → String {
+    : i len ( vec_len [u] v )
+    : s data # s ( vec_data [u] v )
+    : String out ( string_with_cap * 4 + 1 / len 3 )
+    ( __b64_emit out data len T F )
+    ^ out
+}
+
+// URL-safe base64 decode to a binary Vec[u] (tolerates missing padding,
+// as JWT segments are unpadded). The decoded bytes may contain 0x00, so
+// the result is a Vec, not a String — read it with the `. p k` indexed
+// load, never nurl_str_get.
+@ b64_url_decode_vec s str → !( Vec u ) ParseErr {
+    : !String ParseErr r ( b64_url_decode str )
+    ?? r {
+        T sv → {
+            : i n ( string_len sv )
+            : ( Vec u ) v ( vec_with_cap [u] ? > n 0 n 1 )
+            ? > n 0 {
+                ( nurl_memcpy ( vec_data [u] v ) # *u ( string_data sv ) n )
+                : b _ok ( vec_set_len [u] v n )
+            } {}
+            ( string_free sv )
+            ^ @ !( Vec u ) ParseErr { T v }
+        }
+        F e → { ^ @ !( Vec u ) ParseErr { F e } }
+    }
+}
+
 // Returns 0..63, or -1 on non-alphabet byte. `url` selects the URL-safe
 // alphabet (62 = '-', 63 = '_'). Padding `=` (61) returns -2.
 @ __b64_value i c b url → i {


### PR DESCRIPTION
## Summary

Closes critic.md **B5** — JSON Web Tokens. `stdlib/ext/jwt.nu` signs and verifies JWTs over the crypto block (PR #112) and existing base64url. Covers the two algorithms that matter: **HS256** (HMAC-SHA256, shared secret) and **EdDSA** (Ed25519, asymmetric). RS*/ES* are intentionally omitted — Ed25519 is the modern asymmetric choice without RSA's footguns.

## API

```
jwt_hs256_sign      s secret  Json claims          → String
jwt_hs256_verify    s secret  s token              → !Json JwtErr   (system clock)
jwt_hs256_verify_at s secret  s token i now        → !Json JwtErr   (explicit epoch)

jwt_eddsa_sign      (Vec u) sk Json claims          → !String CryptoErr
jwt_eddsa_verify    (Vec u) pk s token              → !Json JwtErr
jwt_eddsa_verify_at (Vec u) pk s token i now        → !Json JwtErr

jwt_decode_unverified s token                       → !Json JwtErr
```

- `verify` validates `exp` (reject once `now ≥ exp`) and `nbf` (reject while `now < nbf`) when present. `verify_at` takes an explicit `now` — deterministic for tests and callers with their own time source.
- HS256 signature comparison is **constant-time** (`std/subtle.nu`) — a byte-at-a-time compare on a MAC is a forgery oracle.
- `claims` is a caller-owned JSON object (not freed); `verify` returns the parsed payload as an owned `Json`.

## Correctness

`compiler/tests/jwt_basic.nu`:
- **HS256** reproduces the **canonical jwt.io reference token** byte-for-byte (secret `your-256-bit-secret`, the standard `{sub,name,iat}` payload → `…SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`).
- **EdDSA** is goldened against the **RFC 8032 §7.1 TEST 1** key — Ed25519 signatures are deterministic, so the whole token is reproducible.
- Both exercise verify success, wrong-key / tamper rejection (→ `JwtBadSignature`), malformed input (→ `JwtMalformed`), and `exp`/`nbf` (→ `JwtExpired` / `JwtNotYetValid`).

New in `std/encode.nu`: `b64_url_encode_vec` / `b64_url_decode_vec` — binary, unpadded URL-safe base64 for the signature segment (the string forms use `strlen` and would truncate a signature containing `0x00`).

## Compiler fix found en route

`@ ?Enum { T Variant }` for a no-payload enum emitted invalid IR: `insertvalue { i1, %E } …, i64 tag, 1`. A bare variant evaluates to its `i64` tag, but the **option** payload slot is the whole `%E` aggregate, and clang rejected the mismatch. The **Result** form `! T E` always worked — its payload slot is `i64` — so only the option path was broken. `gen_agg_lit` now wraps the tag with `insertvalue %E zeroinitializer, i64 tag, 0` (the inverse of the `! T E` tag-extract). Lock: `compiler/tests/option_enum_payload.nu`. `jwt.nu` dogfoods it (`__jwt_check_time → ?JwtErr`).

## Verification

- `./build.sh`: bootstrap fixed point + full suite **343 PASS** (codegen change holds the fixed point)
- `./build.sh --san` + `run_san_tests.sh`: `jwt_basic` / `option_enum_payload` / `crypto_evp` **PASS**, **SAN_FAIL 0**
- `./tools/check_examples.sh`: **PASS 62**
- `nurlc --lint`: clean on all new/changed files

Follow-up: the HTTP auth middleware can now swap static bearer-string checks for `jwt_hs256_verify` / `jwt_eddsa_verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
