### PR TITLE
stdlib: one RFC 3986 URL parser (std/url.nu), consolidate ws/h2 parsers (B12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **One URL parser — `stdlib/std/url.nu`** (critic B12). RFC 3986
+  `scheme://[userinfo@]host[:port][/path][?query][#fragment]` into an
+  owned `Url`, with bracketed-IPv6 hosts, `url_default_port` /
+  `url_port_or_default` (http/https/ws/wss/ftp/redis/postgres),
+  `url_request_target` (path?query for the request line), a percent
+  codec (`url_percent_encode`/`_decode`), and `url_query_decode` →
+  `Vec[UrlParam]` (form-urlencoded `+`→space, `%xx`). Lives in `std/`
+  with core-only deps so `ext/` layers on it without a cycle. Locked
+  against RFC 3986 component-split vectors in
+  `compiler/tests/url_parse.nu`.
+
 - **JSON Web Tokens — `stdlib/ext/jwt.nu`** (critic B5). HS256 (HMAC-
   SHA256) and EdDSA (Ed25519) sign + verify over the existing crypto
   block and base64url. `jwt_hs256_sign/verify`, `jwt_eddsa_sign/verify`,
@@ -22,6 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `compiler/tests/jwt_basic.nu`. Adds `b64_url_encode_vec` /
   `b64_url_decode_vec` to `std/encode.nu` for binary, unpadded
   base64url (the signature segment).
+
+### Changed
+
+- **`ext/websocket.nu` and `ext/http2_client.nu` delegate URL parsing to
+  `std/url.nu`** (critic B12 consolidation). Both hand-rolled
+  scheme/host/port/path splitting; their `__ws_parse_url` /
+  `__h2_parse_url` are now thin wrappers over `url_parse` that enforce
+  the ws/wss and http/https schemes and map to the existing `WsUrl` /
+  `H2Url` types — same public API, one parser underneath. The new parser
+  also correctly stops the authority at `?`/`#` (the old scanners folded
+  a query into the host when no path was present) and keeps the query in
+  the request target.
 
 ### Fixed
 

--- a/compiler/tests/outputs/url_parse.txt
+++ b/compiler/tests/outputs/url_parse.txt
@@ -1,0 +1,17 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+https://example.com/path/to/page?a=1&b=2#section => scheme=https user= host=example.com port=-1 eff=443 path=/path/to/page query=a=1&b=2 frag=section target=/path/to/page?a=1&b=2
+http://example.com => scheme=http user= host=example.com port=-1 eff=80 path= query= frag= target=/
+https://user:pass@host.example.org:8443/secure?token=abc => scheme=https user=user:pass host=host.example.org port=8443 eff=8443 path=/secure query=token=abc frag= target=/secure?token=abc
+ws://localhost:9001/chat => scheme=ws user= host=localhost port=9001 eff=9001 path=/chat query= frag= target=/chat
+wss://stream.example.com/feed => scheme=wss user= host=stream.example.com port=-1 eff=443 path=/feed query= frag= target=/feed
+https://[2001:db8::1]:8080/v6 => scheme=https user= host=2001:db8::1 port=8080 eff=8080 path=/v6 query= frag= target=/v6
+http://[::1]/loopback => scheme=http user= host=::1 port=-1 eff=80 path=/loopback query= frag= target=/loopback
+postgres://db.internal/mydb => scheme=postgres user= host=db.internal port=-1 eff=5432 path=/mydb query= frag= target=/mydb
+not-a-url => NONE
+ftp://files.example.com/pub/ => scheme=ftp user= host=files.example.com port=-1 eff=21 path=/pub/ query= frag= target=/pub/
+encode='a b/c?d=e&f' => a%20b%2Fc%3Fd%3De%26f
+decode roundtrip => a b/c?d=e&f
+query pairs: [name=John Doe] [q=a b] [flag=] [x=1]

--- a/compiler/tests/url_parse.nu
+++ b/compiler/tests/url_parse.nu
@@ -1,0 +1,70 @@
+// url_parse.nu — std/url.nu acceptance: RFC 3986 component split,
+// scheme defaults, request-target reconstruction, percent + query
+// codecs, IPv6 and userinfo edge cases.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/url.nu`
+
+@ show s url → v {
+    ( nurl_print url ) ( nurl_print ` => ` )
+    : ?Url p ( url_parse url )
+    ?? p {
+        T u → {
+            ( nurl_print `scheme=` ) ( nurl_print ( string_data . u scheme ) )
+            ( nurl_print ` user=` ) ( nurl_print ( string_data . u userinfo ) )
+            ( nurl_print ` host=` ) ( nurl_print ( string_data . u host ) )
+            ( nurl_print ` port=` ) ( nurl_print ( nurl_str_int . u port ) )
+            ( nurl_print ` eff=` ) ( nurl_print ( nurl_str_int ( url_port_or_default u ) ) )
+            ( nurl_print ` path=` ) ( nurl_print ( string_data . u path ) )
+            ( nurl_print ` query=` ) ( nurl_print ( string_data . u query ) )
+            ( nurl_print ` frag=` ) ( nurl_print ( string_data . u fragment ) )
+            : String tgt ( url_request_target u )
+            ( nurl_print ` target=` ) ( nurl_print ( string_data tgt ) )
+            ( string_free tgt )
+            ( nurl_print `\n` )
+            ( url_free u )
+        }
+        F _ → ( nurl_print `NONE\n` )
+    }
+}
+
+@ main → i {
+    ( show `https://example.com/path/to/page?a=1&b=2#section` )
+    ( show `http://example.com` )
+    ( show `https://user:pass@host.example.org:8443/secure?token=abc` )
+    ( show `ws://localhost:9001/chat` )
+    ( show `wss://stream.example.com/feed` )
+    ( show `https://[2001:db8::1]:8080/v6` )
+    ( show `http://[::1]/loopback` )
+    ( show `postgres://db.internal/mydb` )
+    ( show `not-a-url` )
+    ( show `ftp://files.example.com/pub/` )
+
+    // percent codec
+    : String enc ( url_percent_encode `a b/c?d=e&f` )
+    ( nurl_print `encode='a b/c?d=e&f' => ` ) ( nurl_print ( string_data enc ) ) ( nurl_print `\n` )
+    : String dec ( url_percent_decode ( string_data enc ) )
+    ( nurl_print `decode roundtrip => ` ) ( nurl_print ( string_data dec ) ) ( nurl_print `\n` )
+    ( string_free enc ) ( string_free dec )
+
+    // query decode (form-urlencoded '+' → space, %xx)
+    : ( Vec UrlParam ) ps ( url_query_decode `name=John+Doe&q=a%20b&flag&x=1` )
+    ( nurl_print `query pairs:` )
+    : i np ( vec_len [UrlParam] ps )
+    : ~ i k 0
+    ~ < k np {
+        : ?UrlParam pp ( vec_get [UrlParam] ps k )
+        ?? pp {
+            T p → {
+                ( nurl_print ` [` ) ( nurl_print ( string_data . p key ) )
+                ( nurl_print `=` ) ( nurl_print ( string_data . p val ) ) ( nurl_print `]` )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( nurl_print `\n` )
+    ( url_params_free ps )
+    ^ 0
+}

--- a/stdlib/ext/http2_client.nu
+++ b/stdlib/ext/http2_client.nu
@@ -61,6 +61,7 @@
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/net.nu`
+$ `stdlib/std/url.nu`
 $ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http2_frame.nu`
@@ -1011,71 +1012,29 @@ $ `stdlib/ext/http2_hpack.nu`
     ( string_free . u path )
 }
 
-// Case-insensitive prefix test (`pre` is assumed lowercase).
-@ __h2_prefix_ci s str s pre → b {
-    : i lp ( nurl_str_len pre )
-    : i ls ( nurl_str_len str )
-    ? < ls lp { ^ F } {}
-    : ~ i k 0
-    : ~ b ok T
-    ~ & ok < k lp {
-        : ~ i a ( nurl_str_get str k )
-        : i b ( nurl_str_get pre k )
-        ? & >= a 65 <= a 90 { = a + a 32 } {}
-        ? != a b { = ok F } {}
-        = k + k 1
-    }
-    ^ ok
-}
-
-// Parse "https://host[:port][/path]" or "http://…". Default port
+// Parse "https://host[:port][/path]" or "http://...". Default port
 // 443 (https) / 80 (http); default path "/". None on bad scheme / host.
+// Delegates the RFC 3986 split to std/url.nu; this wrapper enforces the
+// http/https scheme and maps to H2Url, preserving the request target
+// (path?query) for the :path pseudo-header.
 @ __h2_parse_url s url → ?H2Url {
-    : i n ( nurl_str_len url )
-    : ~ b tls F
-    : ~ i pos 0
-    ? ( __h2_prefix_ci url `https://` ) {
-        = tls T
-        = pos 8
-    } {
-        ? ( __h2_prefix_ci url `http://` ) {
-            = tls F
-            = pos 7
-        } {
-            ^ @ ?H2Url { F # H2Url 0 }
+    : ?Url pu ( url_parse url )
+    ^ ?? pu {
+        T u → {
+            : s sch ( string_data . u scheme )
+            : ~ b tls F
+            : ~ b ok F
+            ? == 1 ( nurl_str_eq sch `https` ) { = tls T = ok T } {}
+            ? == 1 ( nurl_str_eq sch `http` ) { = tls F = ok T } {}
+            ? ! ok { ( url_free u ) ^ @ ?H2Url { F # H2Url 0 } } {}
+            : i port ( url_port_or_default u )
+            : String host ( string_from ( string_data . u host ) )
+            : String path ( url_request_target u )
+            ( url_free u )
+            ^ @ ?H2Url { T @ H2Url { tls host port path } }
         }
+        F _ → @ ?H2Url { F # H2Url 0 }
     }
-    : String host ( string_new )
-    ~ & < pos n & != ( nurl_str_get url pos ) 58 != ( nurl_str_get url pos ) 47 {
-        ( string_push_char host ( nurl_str_get url pos ) )
-        = pos + pos 1
-    }
-    ? == 0 ( string_len host ) {
-        ( string_free host )
-        ^ @ ?H2Url { F # H2Url 0 }
-    } {}
-    : ~ i port ? tls 443 80
-    ? & < pos n == ( nurl_str_get url pos ) 58 {
-        = pos + pos 1
-        : ~ i pv 0
-        : ~ b anyd F
-        ~ & < pos n & >= ( nurl_str_get url pos ) 48 <= ( nurl_str_get url pos ) 57 {
-            = pv + * pv 10 - ( nurl_str_get url pos ) 48
-            = anyd T
-            = pos + pos 1
-        }
-        ? anyd { = port pv } {}
-    } {}
-    : String path ( string_new )
-    ? & < pos n == ( nurl_str_get url pos ) 47 {
-        ~ < pos n {
-            ( string_push_char path ( nurl_str_get url pos ) )
-            = pos + pos 1
-        }
-    } {
-        ( string_push_char path 47 )
-    }
-    ^ @ ?H2Url { T @ H2Url { tls host port path } }
 }
 
 // One request over a fresh connection. TAKES OWNERSHIP of `body`;

--- a/stdlib/ext/websocket.nu
+++ b/stdlib/ext/websocket.nu
@@ -81,6 +81,7 @@ $ `stdlib/std/hash.nu`
 $ `stdlib/std/encode.nu`
 $ `stdlib/std/random.nu`
 $ `stdlib/std/net.nu`
+$ `stdlib/std/url.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 
@@ -1443,23 +1444,6 @@ $ `stdlib/ext/http_response.nu`
 
 // ── Client handshake (RFC 6455 §4.1) ──────────────────────────────────
 
-// Case-insensitive ASCII prefix test: does raw `s` begin with `pfx`?
-@ __ws_prefix_ci s str s pfx → b {
-    : i pl ( nurl_str_len pfx )
-    : i sl ( nurl_str_len str )
-    ? < sl pl { ^ F } {}
-    : ~ i k 0
-    ~ < k pl {
-        : ~ i a ( nurl_str_get str k )
-        : ~ i b ( nurl_str_get pfx k )
-        ? & >= a 65 <= a 90 { = a + a 32 } {}
-        ? & >= b 65 <= b 90 { = b + b 32 } {}
-        ? != a b { ^ F } {}
-        = k + k 1
-    }
-    ^ T
-}
-
 // True iff the response status line carries a 101 status code. The status
 // line is "HTTP/1.x 101 ..."; we skip to the first SP and read the three
 // digits that follow.
@@ -1677,53 +1661,27 @@ $ `stdlib/ext/http_response.nu`
 
 // Parse "ws://host[:port][/path]" or "wss://host[:port][/path]". Default
 // port is 80 (ws) / 443 (wss); default path is "/". None on a bad scheme
-// or empty host.
+// or empty host. Delegates the RFC 3986 split to std/url.nu (url_parse);
+// this wrapper only enforces the ws/wss scheme and maps to WsUrl, with
+// the request target (path?query) preserved for the handshake line.
 @ __ws_parse_url s url → ?WsUrl {
-    : i n ( nurl_str_len url )
-    : ~ b tls F
-    : ~ i pos 0
-    ? ( __ws_prefix_ci url `wss://` ) {
-        = tls T
-        = pos 6
-    } {
-        ? ( __ws_prefix_ci url `ws://` ) {
-            = tls F
-            = pos 5
-        } {
-            ^ @ ?WsUrl { F # WsUrl 0 }
+    : ?Url pu ( url_parse url )
+    ^ ?? pu {
+        T u → {
+            : s sch ( string_data . u scheme )
+            : ~ b tls F
+            : ~ b ok F
+            ? == 1 ( nurl_str_eq sch `wss` ) { = tls T = ok T } {}
+            ? == 1 ( nurl_str_eq sch `ws` ) { = tls F = ok T } {}
+            ? ! ok { ( url_free u ) ^ @ ?WsUrl { F # WsUrl 0 } } {}
+            : i port ( url_port_or_default u )
+            : String host ( string_from ( string_data . u host ) )
+            : String path ( url_request_target u )
+            ( url_free u )
+            ^ @ ?WsUrl { T @ WsUrl { tls host port path } }
         }
+        F _ → @ ?WsUrl { F # WsUrl 0 }
     }
-    : String host ( string_new )
-    ~ & < pos n & != ( nurl_str_get url pos ) 58 != ( nurl_str_get url pos ) 47 {
-        ( string_push_char host ( nurl_str_get url pos ) )
-        = pos + pos 1
-    }
-    ? == 0 ( string_len host ) {
-        ( string_free host )
-        ^ @ ?WsUrl { F # WsUrl 0 }
-    } {}
-    : ~ i port ? tls 443 80
-    ? & < pos n == ( nurl_str_get url pos ) 58 {
-        = pos + pos 1
-        : ~ i pv 0
-        : ~ b anyd F
-        ~ & < pos n & >= ( nurl_str_get url pos ) 48 <= ( nurl_str_get url pos ) 57 {
-            = pv + * pv 10 - ( nurl_str_get url pos ) 48
-            = anyd T
-            = pos + pos 1
-        }
-        ? anyd { = port pv } {}
-    } {}
-    : String path ( string_new )
-    ? & < pos n == ( nurl_str_get url pos ) 47 {
-        ~ < pos n {
-            ( string_push_char path ( nurl_str_get url pos ) )
-            = pos + pos 1
-        }
-    } {
-        ( string_push_char path 47 )
-    }
-    ^ @ ?WsUrl { T @ WsUrl { tls host port path } }
 }
 
 // Dial + handshake in one shot, no subprotocol. wss:// verifies the

--- a/stdlib/std/url.nu
+++ b/stdlib/std/url.nu
@@ -1,0 +1,345 @@
+// stdlib/std/url.nu — one RFC 3986 URL parser.
+//
+// websocket.nu, http2_client.nu (and the http client stack) each
+// hand-rolled scheme/host/port/path splitting. This is the single
+// parser they delegate to. Lives in std/ with core-only dependencies,
+// so ext/ modules can layer on it without a cycle.
+//
+// Grammar (RFC 3986, the subset URLs in the wild actually use):
+//
+//   scheme "://" [ userinfo "@" ] host [ ":" port ] path [ "?" query ] [ "#" fragment ]
+//
+// The "//" authority form is what every network scheme uses; this
+// parser requires it (a bare `mailto:` style opaque URI is out of
+// scope — the callers are all network clients). Host may be a name,
+// IPv4, or a `[...]`-bracketed IPv6 literal.
+//
+//   ( url_parse s in )                 → ?Url      None on malformed / no scheme
+//   ( url_free Url u )                 → v
+//   ( url_default_port s scheme )      → i         80/443/21/… or -1 if unknown
+//   ( url_port_or_default Url u )      → i         u.port if given, else scheme default
+//   ( url_request_target Url u )       → String    "path[?query]" for the request line
+//   ( url_percent_decode s in )        → String    %xx → byte; '+' kept literal
+//   ( url_percent_encode s in )        → String    non-unreserved → %XX (upper)
+//   ( url_query_decode s query )       → ( Vec UrlParam )  '&'/'='-split, %-decoded, '+'→' '
+//   ( url_params_free ( Vec UrlParam ) ps ) → v
+//
+// Field conventions on the returned Url (all String fields OWNED):
+//   scheme    lowercased; "" only when parse fails (then None anyway)
+//   userinfo  "" when absent
+//   host      "" only on parse failure; bracketed IPv6 keeps no brackets
+//   port      explicit port, or -1 when absent (use url_port_or_default)
+//   path      "" when absent (callers default to "/")
+//   query     raw, without '?'; "" when absent
+//   fragment  raw, without '#'; "" when absent
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+: Url {
+    String scheme
+    String userinfo
+    String host
+    i port
+    String path
+    String query
+    String fragment
+}
+
+: UrlParam { String key String val }
+
+@ url_free Url u → v {
+    ( string_free . u scheme )
+    ( string_free . u userinfo )
+    ( string_free . u host )
+    ( string_free . u path )
+    ( string_free . u query )
+    ( string_free . u fragment )
+}
+
+@ url_params_free ( Vec UrlParam ) ps → v {
+    : i n ( vec_len [UrlParam] ps )
+    : ~ i k 0
+    ~ < k n {
+        : ?UrlParam p ( vec_get [UrlParam] ps k )
+        ?? p {
+            T pp → { ( string_free . pp key ) ( string_free . pp val ) }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [UrlParam] ps )
+}
+
+// ── ASCII helpers ──────────────────────────────────────────────────
+
+@ __url_lower i c → i { ? & >= c 65 <= c 90 { ^ + c 32 } { ^ c } }
+
+@ __url_hex_val i c → i {
+    ? & >= c 48 <= c 57 { ^ - c 48 } {}
+    ? & >= c 97 <= c 102 { ^ + 10 - c 97 } {}
+    ? & >= c 65 <= c 70 { ^ + 10 - c 65 } {}
+    ^ -1
+}
+
+@ __url_hex_digit i n → i { ? < n 10 { ^ + 48 n } { ^ + 55 n } }  // 0-9, A-F
+
+@ __url_is_unreserved i c → b {
+    ? & >= c 65 <= c 90 { ^ T } {}
+    ? & >= c 97 <= c 122 { ^ T } {}
+    ? & >= c 48 <= c 57 { ^ T } {}
+    ? | | == c 45 == c 95 == c 46 { ^ T } {}  // - _ .
+    ? == c 126 { ^ T } {}                       // ~
+    ^ F
+}
+
+// ── Percent codec ──────────────────────────────────────────────────
+//
+// Decode treats '+' literally (RFC 3986 — '+' is not a space in the
+// path/generic component). url_query_decode handles the
+// form-urlencoded '+'→space rule for query strings.
+
+@ url_percent_decode s in → String {
+    : i n ( nurl_str_len in )
+    : String out ( string_with_cap + n 1 )
+    : ~ i k 0
+    ~ < k n {
+        : i c ( nurl_str_get in k )
+        ? & == c 37 <= + k 2 - n 1 {
+            : i hi ( __url_hex_val ( nurl_str_get in + k 1 ) )
+            : i lo ( __url_hex_val ( nurl_str_get in + k 2 ) )
+            ? & >= hi 0 >= lo 0 {
+                ( string_push_char out + * hi 16 lo )
+                = k + k 3
+            } {
+                ( string_push_char out c )
+                = k + k 1
+            }
+        } {
+            ( string_push_char out c )
+            = k + k 1
+        }
+    }
+    ^ out
+}
+
+@ url_percent_encode s in → String {
+    : i n ( nurl_str_len in )
+    : String out ( string_with_cap + n 1 )
+    : ~ i k 0
+    ~ < k n {
+        : i c & 255 ( nurl_str_get in k )
+        ? ( __url_is_unreserved c ) {
+            ( string_push_char out c )
+        } {
+            ( string_push_char out 37 )                       // '%'
+            ( string_push_char out ( __url_hex_digit / c 16 ) )
+            ( string_push_char out ( __url_hex_digit % c 16 ) )
+        }
+        = k + k 1
+    }
+    ^ out
+}
+
+// ── Scheme defaults ────────────────────────────────────────────────
+
+@ url_default_port s scheme → i {
+    ? == 1 ( nurl_str_eq scheme `http` ) { ^ 80 } {}
+    ? == 1 ( nurl_str_eq scheme `https` ) { ^ 443 } {}
+    ? == 1 ( nurl_str_eq scheme `ws` ) { ^ 80 } {}
+    ? == 1 ( nurl_str_eq scheme `wss` ) { ^ 443 } {}
+    ? == 1 ( nurl_str_eq scheme `ftp` ) { ^ 21 } {}
+    ? == 1 ( nurl_str_eq scheme `redis` ) { ^ 6379 } {}
+    ? == 1 ( nurl_str_eq scheme `postgres` ) { ^ 5432 } {}
+    ? == 1 ( nurl_str_eq scheme `postgresql` ) { ^ 5432 } {}
+    ^ -1
+}
+
+@ url_port_or_default Url u → i {
+    ? >= . u port 0 { ^ . u port } { ^ ( url_default_port ( string_data . u scheme ) ) }
+}
+
+// ── Parser ─────────────────────────────────────────────────────────
+
+@ url_parse s in → ?Url {
+    : i n ( nurl_str_len in )
+    // scheme: letters/digits/+/-/. up to "://"
+    : ~ i pos 0
+    : String scheme ( string_with_cap 8 )
+    : ~ b ok_scheme F
+    ~ & < pos n != ( nurl_str_get in pos ) 58 {
+        : i c ( nurl_str_get in pos )
+        // scheme char = ALPHA / DIGIT / '+' / '-' / '.'  (RFC 3986 §3.1)
+        : b sc | ( __url_is_alpha c ) | ( __url_is_digit c ) | == c 43 | == c 45 == c 46
+        ? sc {
+            ( string_push_char scheme ( __url_lower c ) )
+            = pos + pos 1
+        } {
+            // illegal scheme char before ':' → not a scheme-prefixed URL
+            ( string_free scheme )
+            ^ @ ?Url { F # Url 0 }
+        }
+    }
+    // require "://"
+    ? & & < + pos 2 n == ( nurl_str_get in pos ) 58
+    & == ( nurl_str_get in + pos 1 ) 47 == ( nurl_str_get in + pos 2 ) 47
+    { = pos + pos 3 = ok_scheme T } {}
+    ? ! ok_scheme { ( string_free scheme ) ^ @ ?Url { F # Url 0 } } {}
+    ? == 0 ( string_len scheme ) { ( string_free scheme ) ^ @ ?Url { F # Url 0 } } {}
+
+    // authority = [userinfo "@"] host [":" port], up to '/' '?' '#'
+    : i auth_start pos
+    : ~ i auth_end pos
+    ~ & < auth_end n & != ( nurl_str_get in auth_end ) 47
+    & != ( nurl_str_get in auth_end ) 63 != ( nurl_str_get in auth_end ) 35 {
+        = auth_end + auth_end 1
+    }
+    // userinfo: split on the LAST '@' within the authority
+    : ~ i at -1
+    : ~ i scan auth_start
+    ~ < scan auth_end {
+        ? == ( nurl_str_get in scan ) 64 { = at scan } {}
+        = scan + scan 1
+    }
+    : String userinfo ( string_with_cap 1 )
+    : ~ i host_start auth_start
+    ? >= at 0 {
+        : ~ i ui auth_start
+        ~ < ui at { ( string_push_char userinfo ( nurl_str_get in ui ) ) = ui + ui 1 }
+        = host_start + at 1
+    } {}
+    // host: bracketed IPv6 [..]  OR  up to ':' (port) / authority end
+    : String host ( string_with_cap 16 )
+    : ~ i hp host_start
+    ? & < hp auth_end == ( nurl_str_get in hp ) 91 {
+        // [IPv6] — copy inside the brackets, skip past ']'
+        = hp + hp 1
+        ~ & < hp auth_end != ( nurl_str_get in hp ) 93 {
+            ( string_push_char host ( nurl_str_get in hp ) )
+            = hp + hp 1
+        }
+        ? & < hp auth_end == ( nurl_str_get in hp ) 93 { = hp + hp 1 } {}
+    } {
+        ~ & < hp auth_end != ( nurl_str_get in hp ) 58 {
+            ( string_push_char host ( nurl_str_get in hp ) )
+            = hp + hp 1
+        }
+    }
+    ? == 0 ( string_len host ) {
+        ( string_free scheme ) ( string_free userinfo ) ( string_free host )
+        ^ @ ?Url { F # Url 0 }
+    } {}
+    // optional :port
+    : ~ i port -1
+    ? & < hp auth_end == ( nurl_str_get in hp ) 58 {
+        = hp + hp 1
+        : ~ i pv 0
+        : ~ b anyd F
+        ~ & < hp auth_end ( __url_is_digit ( nurl_str_get in hp ) ) {
+            = pv + * pv 10 - ( nurl_str_get in hp ) 48
+            = anyd T
+            = hp + hp 1
+        }
+        ? anyd { = port pv } {}
+    } {}
+    = pos auth_end
+
+    // path: up to '?' or '#'
+    : String path ( string_with_cap 16 )
+    ~ & < pos n & != ( nurl_str_get in pos ) 63 != ( nurl_str_get in pos ) 35 {
+        ( string_push_char path ( nurl_str_get in pos ) )
+        = pos + pos 1
+    }
+    // query: '?' up to '#'
+    : String query ( string_with_cap 8 )
+    ? & < pos n == ( nurl_str_get in pos ) 63 {
+        = pos + pos 1
+        ~ & < pos n != ( nurl_str_get in pos ) 35 {
+            ( string_push_char query ( nurl_str_get in pos ) )
+            = pos + pos 1
+        }
+    } {}
+    // fragment: '#' to end
+    : String fragment ( string_with_cap 8 )
+    ? & < pos n == ( nurl_str_get in pos ) 35 {
+        = pos + pos 1
+        ~ < pos n { ( string_push_char fragment ( nurl_str_get in pos ) ) = pos + pos 1 }
+    } {}
+
+    ^ @ ?Url { T @ Url { scheme userinfo host port path query fragment } }
+}
+
+@ __url_is_alpha i c → b { ^ | & >= c 65 <= c 90 & >= c 97 <= c 122 }
+@ __url_is_digit i c → b { ^ & >= c 48 <= c 57 }
+
+// "path[?query]" for the HTTP request line. Path defaults to "/" when
+// empty; the fragment is client-only and never sent.
+@ url_request_target Url u → String {
+    : String out ( string_with_cap + + ( string_len . u path ) ( string_len . u query ) 2 )
+    ? == 0 ( string_len . u path ) { ( string_push_char out 47 ) }
+    { ( string_push_str out ( string_data . u path ) ) }
+    ? > ( string_len . u query ) 0 {
+        ( string_push_char out 63 )
+        ( string_push_str out ( string_data . u query ) )
+    } {}
+    ^ out
+}
+
+// ── Query string codec ─────────────────────────────────────────────
+//
+// Split `query` on '&', each item on the first '='. Both halves are
+// percent-decoded with the form-urlencoded '+'→space rule. A bare key
+// (`a&b=1`) yields an empty value. Returns an OWNED Vec[UrlParam];
+// free with url_params_free.
+
+@ __url_form_decode s in → String {
+    // like url_percent_decode but '+' → space (form-urlencoded)
+    : i n ( nurl_str_len in )
+    : String out ( string_with_cap + n 1 )
+    : ~ i k 0
+    ~ < k n {
+        : i c ( nurl_str_get in k )
+        ? == c 43 { ( string_push_char out 32 ) = k + k 1 } {
+            ? & == c 37 <= + k 2 - n 1 {
+                : i hi ( __url_hex_val ( nurl_str_get in + k 1 ) )
+                : i lo ( __url_hex_val ( nurl_str_get in + k 2 ) )
+                ? & >= hi 0 >= lo 0 { ( string_push_char out + * hi 16 lo ) = k + k 3 }
+                { ( string_push_char out c ) = k + k 1 }
+            } { ( string_push_char out c ) = k + k 1 }
+        }
+    }
+    ^ out
+}
+
+@ url_query_decode s query → ( Vec UrlParam ) {
+    : ( Vec UrlParam ) out ( vec_new [UrlParam] )
+    : i n ( nurl_str_len query )
+    : ~ i start 0
+    ~ <= start n {
+        // find next '&' or end
+        : ~ i e start
+        ~ & < e n != ( nurl_str_get query e ) 38 { = e + e 1 }
+        ? > - e start 0 {
+            // split [start,e) on first '='
+            : ~ i eq start
+            : ~ b has_eq F
+            ~ & < eq e ! has_eq {
+                ? == ( nurl_str_get query eq ) 61 { = has_eq T } { = eq + eq 1 }
+            }
+            : String kraw ( string_with_cap + - eq start 1 )
+            : ~ i ki start
+            ~ < ki eq { ( string_push_char kraw ( nurl_str_get query ki ) ) = ki + ki 1 }
+            : String vraw ( string_with_cap 8 )
+            ? has_eq {
+                : ~ i vi + eq 1
+                ~ < vi e { ( string_push_char vraw ( nurl_str_get query vi ) ) = vi + vi 1 }
+            } {}
+            : String key ( __url_form_decode ( string_data kraw ) )
+            : String val ( __url_form_decode ( string_data vraw ) )
+            ( string_free kraw ) ( string_free vraw )
+            ( vec_push [UrlParam] out @ UrlParam { key val } )
+        } {}
+        = start + e 1
+    }
+    ^ out
+}


### PR DESCRIPTION
## Summary

Closes critic.md **B12** — one URL parser. `websocket.nu` and `http2_client.nu` each hand-rolled scheme/host/port/path splitting (verified); `std/url.nu` is the single RFC 3986 parser they now delegate to.

## `stdlib/std/url.nu`

Std-layer, **core-only dependencies**, so `ext/` modules layer on it without a cycle.

```
url_parse           s in        → ?Url     scheme/userinfo/host/port/path/query/fragment
url_free            Url u        → v
url_default_port    s scheme     → i        http/https/ws/wss/ftp/redis/postgres, else -1
url_port_or_default Url u        → i
url_request_target  Url u        → String   "path[?query]" for the request line
url_percent_encode  s in         → String
url_percent_decode  s in         → String
url_query_decode    s query      → ( Vec UrlParam )   form-urlencoded '+'→space, %xx
url_params_free     (Vec UrlParam) ps → v
```

Handles bracketed-IPv6 hosts (`[2001:db8::1]:8080` → host `2001:db8::1`, port `8080`), userinfo (`user:pass@`), scheme-default ports, and stops the authority at `/`/`?`/`#`. The public codec is uniquely named (`url_percent_encode/decode`) so it never collides with `http_request`'s `percent_encode/decode` — both are reachable from ws/h2 through transitive imports.

## Consolidation

`__ws_parse_url` / `__h2_parse_url` are now thin wrappers over `url_parse` that enforce the ws/wss and http/https schemes and map to the existing `WsUrl` / `H2Url` types — **public API unchanged**. Their bespoke scanners plus the `__ws_prefix_ci` / `__h2_prefix_ci` helpers are deleted (net −122 lines in those two files against +the shared parser).

The shared parser also fixes a latent bug in the old scanners: a query with no path (`https://host?q`) folded the query into the host, because they only stopped at `:` or `/`. `url_parse` stops the authority at `?`/`#` and keeps the query in the request target.

`http_request.nu` keeps its own request-target splitter (`parse_url`) and percent codec — that's the canonical codec for the http stack and a different concern (splitting a request target, not parsing a full URL); unifying it would touch 10 files for no behavioral gain.

## Verification

- `./build.sh`: bootstrap fixed point + full suite. The existing `websocket_client` and `http2_client` tests unit-test `__ws_parse_url`/`__h2_parse_url` against concrete host/port/path expectations and still pass — behavior preserved.
- `./build.sh --san` + `run_san_tests.sh`: `url_parse` / `websocket_client` / `http2_client` **PASS**, **SAN_FAIL 0**.
- `./tools/check_examples.sh`: **PASS 62**.
- `nurlc --lint`: clean.
- Lock: `compiler/tests/url_parse.nu` (RFC 3986 component-split vectors: full URL with query+fragment, userinfo, IPv6, scheme defaults, request-target, percent + query codecs, reject `not-a-url`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
