### PR TITLE
stdlib: HTTP-date + RFC 2822 date parsing (B13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **HTTP-date / RFC 2822 date parsing — `stdlib/std/time.nu`** (critic
+  B13). The server formatted HTTP dates (`time_format_http`) but could
+  not parse them; `http_date_parse` now accepts all three forms RFC 7231
+  §7.1.1.1 requires — IMF-fixdate (`Sun, 06 Nov 1994 08:49:37 GMT`),
+  obsolete RFC 850 (`Sunday, 06-Nov-94 08:49:37 GMT`, 2-digit year via
+  the POSIX <70 pivot), and asctime (`Sun Nov  6 08:49:37 1994`) — for
+  `If-Modified-Since` / `If-Unmodified-Since` / cookie `Expires`.
+  `rfc2822_parse` handles the email `Date:` form with numeric `±HHMM`
+  zones (`Mon, 02 Jan 2006 15:04:05 -0700`). Both return UTC seconds in
+  the `!i ParseErr` shape (pair with `time_from_unix`), matching
+  `time_parse_iso`. Lock: `compiler/tests/http_date.nu` — the three
+  RFC 7231 spellings agree on the spec's own example (784111777), the
+  RFC 2822 `-0700` case equals Go's canonical reference instant, plus
+  round-trip and rejects.
+
 - **JWT bearer-auth middleware — `stdlib/ext/http_jwt.nu`** (B5
   follow-through). `with_jwt_hs256 secret inner` / `with_jwt_eddsa
   pubkey inner` wrap a claims-aware handler

--- a/compiler/tests/http_date.nu
+++ b/compiler/tests/http_date.nu
@@ -1,0 +1,76 @@
+// http_date.nu — std/time.nu §12c HTTP-date / RFC 2822 parsing.
+//
+// RFC 7231 §7.1.1.1 gives the three equivalent spellings of the same
+// instant (Sun, 06 Nov 1994 08:49:37 GMT = 784111777). All three must
+// parse to that value. RFC 2822 adds a numeric zone. Also checks a
+// round-trip against time_format_http and a few rejects.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/time.nu`
+
+@ show s label s input → v {
+    ( nurl_print label ) ( nurl_print `: ` )
+    : !i ParseErr r ( http_date_parse input )
+    ?? r {
+        T secs → ( nurl_print ( nurl_str_int secs ) )
+        F _ → ( nurl_print `PARSE_ERR` )
+    }
+    ( nurl_print `\n` )
+}
+
+@ show2822 s label s input → v {
+    ( nurl_print label ) ( nurl_print `: ` )
+    : !i ParseErr r ( rfc2822_parse input )
+    ?? r {
+        T secs → ( nurl_print ( nurl_str_int secs ) )
+        F _ → ( nurl_print `PARSE_ERR` )
+    }
+    ( nurl_print `\n` )
+}
+
+@ main → i {
+    // RFC 7231 §7.1.1.1 — the three forms of 784111777
+    ( show `imf` `Sun, 06 Nov 1994 08:49:37 GMT` )
+    ( show `rfc850` `Sunday, 06-Nov-94 08:49:37 GMT` )
+    ( show `asctime` `Sun Nov  6 08:49:37 1994` )
+
+    // Epoch + a modern date
+    ( show `epoch` `Thu, 01 Jan 1970 00:00:00 GMT` )
+    ( show `modern` `Wed, 06 May 2026 17:30:45 GMT` )
+
+    // RFC 2822 email Date with numeric zones
+    ( show2822 `utc_off` `Mon, 02 Jan 2006 15:04:05 +0000` )
+    ( show2822 `neg_off` `Mon, 02 Jan 2006 15:04:05 -0700` )   // == 22:04:05 UTC
+    ( show2822 `pos_off` `Mon, 02 Jan 2006 15:04:05 +0530` )
+    ( show2822 `no_dow` `2 Jan 2006 15:04:05 GMT` )            // day-of-week optional
+
+    // round-trip: parse → format → must equal input
+    : !i ParseErr rt ( http_date_parse `Fri, 31 Dec 1999 23:59:59 GMT` )
+    ?? rt {
+        T secs → {
+            : Time t ( time_from_unix secs )
+            : String back ( time_format_http t )
+            ( nurl_print `roundtrip: ` ) ( nurl_print ( string_data back ) )
+            ( nurl_print ` == ` )
+            ( nurl_print ? ( __seq ( string_data back ) `Fri, 31 Dec 1999 23:59:59 GMT` ) `T` `F` )
+            ( nurl_print `\n` )
+            ( string_free back )
+        }
+        F _ → ( nurl_print `roundtrip PARSE_ERR\n` )
+    }
+
+    // rejects
+    ( show `bad_month` `Sun, 06 Xyz 1994 08:49:37 GMT` )       // bad month → ERR
+    ( show `garbage` `not a date at all` )
+    ( show2822 `missing_zone` `Mon, 02 Jan 2006 15:04:05` )    // RFC 2822 needs a zone
+
+    ^ 0
+}
+
+@ __seq s a s b → b {
+    : i la ( nurl_str_len a )
+    ? != la ( nurl_str_len b ) { ^ F } {}
+    : ~ i k 0
+    ~ < k la { ? != ( nurl_str_get a k ) ( nurl_str_get b k ) { ^ F } {} = k + k 1 }
+    ^ T
+}

--- a/compiler/tests/outputs/http_date.txt
+++ b/compiler/tests/outputs/http_date.txt
@@ -1,0 +1,17 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+imf: 784111777
+rfc850: 784111777
+asctime: 784111777
+epoch: 0
+modern: 1778088645
+utc_off: 1136214245
+neg_off: 1136239445
+pos_off: 1136194445
+no_dow: 1136214245
+roundtrip: Fri, 31 Dec 1999 23:59:59 GMT == T
+bad_month: PARSE_ERR
+garbage: PARSE_ERR
+missing_zone: PARSE_ERR

--- a/stdlib/std/time.nu
+++ b/stdlib/std/time.nu
@@ -596,6 +596,216 @@ $ `stdlib/std/async_ffi.nu`
     ^ @ !i ParseErr { T unix_utc }
 }
 
+// ── §12c HTTP-date / RFC 2822 date parsing ───────────────────────────
+//
+// The server FORMATS HTTP dates (time_format_http) but until now could
+// not PARSE them — needed for `If-Modified-Since`, `If-Unmodified-Since`
+// and cookie `Expires`. RFC 7231 §7.1.1.1 requires a recipient to accept
+// all three historical forms, and email `Date:` (RFC 5322/2822) adds a
+// numeric zone. All return UTC seconds since the Unix epoch in the
+// `!i ParseErr` shape (pair with `time_from_unix` for fields), so they
+// drop in next to `time_parse_iso`:
+//
+//   IMF-fixdate (preferred):  Sun, 06 Nov 1994 08:49:37 GMT
+//   RFC 850 (obsolete):       Sunday, 06-Nov-94 08:49:37 GMT
+//   asctime (obsolete):       Sun Nov  6 08:49:37 1994
+//   RFC 2822 (email Date):    Mon, 02 Jan 2006 15:04:05 -0700
+//
+//   ( http_date_parse s )   → !i ParseErr   the three RFC 7231 forms (GMT)
+//   ( rfc2822_parse   s )   → !i ParseErr   email Date, numeric / GMT zone
+//
+// A 2-digit RFC 850 year uses the POSIX sliding pivot: YY < 70 → 20YY,
+// else 19YY. Obsolete alphabetic US zones (EST/PDT/…) in RFC 2822 are
+// not resolved (their offset is ambiguous by the RFC's own admission) —
+// only GMT/UT/UTC/Z (= +0000) and numeric ±HHMM offsets are accepted.
+
+// Month abbreviation at p[off..off+3] → 1..12, or -1.
+@ __month3_at s p i off i n → i {
+    ? > + off 3 n { ^ -1 } {}
+    : i c0 ( nurl_str_get p off )
+    : i c1 ( nurl_str_get p + off 1 )
+    : i c2 ( nurl_str_get p + off 2 )
+    // J: Jan/Jun/Jul · F: Feb · M: Mar/May · A: Apr/Aug · S: Sep · O: Oct
+    // N: Nov · D: Dec  (compare the 2nd/3rd letters to disambiguate)
+    ? == c0 74 {                                  // 'J'
+        ? & == c1 97 == c2 110 { ^ 1 } {}         // Jan
+        ? & == c1 117 == c2 110 { ^ 6 } {}        // Jun
+        ? & == c1 117 == c2 108 { ^ 7 } {}        // Jul
+        ^ -1
+    } {}
+    ? & & == c0 70 == c1 101 == c2 98 { ^ 2 } {}  // Feb
+    ? == c0 77 {                                  // 'M'
+        ? & == c1 97 == c2 114 { ^ 3 } {}         // Mar
+        ? & == c1 97 == c2 121 { ^ 5 } {}         // May
+        ^ -1
+    } {}
+    ? == c0 65 {                                  // 'A'
+        ? & == c1 112 == c2 114 { ^ 4 } {}        // Apr
+        ? & == c1 117 == c2 103 { ^ 8 } {}        // Aug
+        ^ -1
+    } {}
+    ? & & == c0 83 == c1 101 == c2 112 { ^ 9 } {}  // Sep
+    ? & & == c0 79 == c1 99 == c2 116 { ^ 10 } {}  // Oct
+    ? & & == c0 78 == c1 111 == c2 118 { ^ 11 } {} // Nov
+    ? & & == c0 68 == c1 101 == c2 99 { ^ 12 } {}  // Dec
+    ^ -1
+}
+
+// One token = a maximal run of non-(space/comma) bytes. Writes the
+// token's [start,end) into a 2-slot scratch and returns the index just
+// past it; -1 when no token remains from `from`.
+@ __hd_token s p i n i from s out_start s out_end → i {
+    : ~ i k from
+    ~ & < k n | == ( nurl_str_get p k ) 32 == ( nurl_str_get p k ) 44 { = k + k 1 }
+    ? >= k n { ^ -1 } {}
+    : i st k
+    ~ & < k n & != ( nurl_str_get p k ) 32 != ( nurl_str_get p k ) 44 { = k + k 1 }
+    ( nurl_poke # s out_start 0 st )
+    ( nurl_poke # s out_end 0 k )
+    ^ k
+}
+
+@ __hd_all_digits s p i st i en → b {
+    : ~ i k st
+    : ~ b ok > en st
+    ~ & ok < k en {
+        : i c ( nurl_str_get p k )
+        ? & >= c 48 <= c 57 {} { = ok F }
+        = k + k 1
+    }
+    ^ ok
+}
+
+@ __hd_index_of s p i st i en i ch → i {
+    : ~ i k st
+    ~ < k en { ? == ( nurl_str_get p k ) ch { ^ k } {} = k + k 1 }
+    ^ -1
+}
+
+// Shared flexible parser for every form above. Tokenizes on space/comma,
+// classifies each token (month name / `HH:MM:SS` / `DD-Mon-YY` / number /
+// zone), then folds to UTC seconds. `require_zone` makes a missing zone
+// an error (RFC 2822 mandates one; HTTP forms always end in GMT).
+@ __parse_date_flex s p b require_zone → !i ParseErr {
+    : i n ( nurl_str_len p )
+    ? == n 0 { ^ @ !i ParseErr { F @ ParseErr { Empty } } } {}
+    : s ts ( nurl_zalloc 8 )
+    : s te ( nurl_zalloc 8 )
+    : ~ i pos 0
+    : ~ i day -1
+    : ~ i mon -1
+    : ~ i year -1
+    : ~ i hh -1
+    : ~ i mm 0
+    : ~ i ss 0
+    : ~ i off_min 0
+    : ~ b have_zone F
+    : ~ b bad F
+    : ~ b going T
+    ~ & going ! bad {
+        : i nxt ( __hd_token p n pos ts te )
+        ? < nxt 0 { = going F } {
+            = pos nxt
+            : i st ( nurl_peek ts 0 )
+            : i en ( nurl_peek te 0 )
+            : i len - en st
+            : i m3 ( __month3_at p st n )
+            : i colon ( __hd_index_of p st en 58 )
+            : i dash ( __hd_index_of p st en 45 )
+            : i c0 ( nurl_str_get p st )
+            ? >= m3 0 {
+                // bare month name token
+                ? < mon 0 { = mon m3 } {}
+            } {
+                ? >= colon 0 {
+                    // HH:MM[:SS]
+                    : i h ( __take_ndigits p st 2 n )
+                    : i m2c ( __hd_index_of p + colon 1 en 58 )
+                    : i mi ( __take_ndigits p + colon 1 2 n )
+                    ? | < h 0 < mi 0 { = bad T } {
+                        = hh h = mm mi
+                        ? >= m2c 0 {
+                            : i se ( __take_ndigits p + m2c 1 2 n )
+                            ? < se 0 { = bad T } { = ss se }
+                        } {}
+                    }
+                } {
+                    ? & >= dash 0 >= ( __month3_at p + dash 1 n ) 0 {
+                        // RFC 850 DD-Mon-YY
+                        : i d ( __take_ndigits p st 2 n )
+                        : i mn ( __month3_at p + dash 1 n )
+                        : i dash2 ( __hd_index_of p + dash 1 en 45 )
+                        ? | | < d 0 < mn 0 < dash2 0 { = bad T } {
+                            : i yy ( __take_ndigits p + dash2 1 2 n )
+                            ? < yy 0 { = bad T } {
+                                = day d = mon mn
+                                = year ? < yy 70 + 2000 yy + 1900 yy
+                            }
+                        }
+                    } {
+                        ? | | == c0 43 == c0 45 & ( __hd_all_digits p + st 1 en ) >= len 5 {
+                            // numeric zone ±HHMM
+                            : i sign ? == c0 45 -1 1
+                            : i oh ( __take_ndigits p + st 1 2 n )
+                            : i om ( __take_ndigits p + st 3 2 n )
+                            ? | < oh 0 < om 0 { = bad T } {
+                                = off_min * sign + * oh 60 om = have_zone T
+                            }
+                        } {
+                            ? ( __hd_all_digits p st en ) {
+                                // a number: 4 digits → year, else day
+                                : i v ( __take_ndigits p st len n )
+                                ? < v 0 { = bad T } {
+                                    ? & == len 4 < year 0 { = year v } {
+                                        ? < day 0 { = day v } {
+                                            ? < year 0 { = year v } {}
+                                        }
+                                    }
+                                }
+                            } {
+                                // alphabetic zone: GMT/UT/UTC/Z → 0; any
+                                // other word (e.g. the weekday "Sun") is
+                                // simply ignored. An alpha zone resolves
+                                // only for the UTC set.
+                                ? ( __hd_zone_is_utc p st en )
+                                { = have_zone T } {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ( nurl_free # s ts )
+    ( nurl_free # s te )
+    ? bad { ^ @ !i ParseErr { F @ ParseErr { BadFormat } } } {}
+    ? | | | < day 0 < mon 0 < year 0 < hh 0 { ^ @ !i ParseErr { F @ ParseErr { BadFormat } } } {}
+    ? & require_zone ! have_zone { ^ @ !i ParseErr { F @ ParseErr { BadFormat } } } {}
+    : !i ParseErr civ ( time_make year mon day hh mm ss )
+    ^ ?? civ {
+        T unix_local → @ !i ParseErr { T - unix_local * off_min 60 }
+        F e → @ !i ParseErr { F e }
+    }
+}
+
+// True iff p[st..en) is GMT / UT / UTC / Z / Z-as-+0000 (all = UTC).
+@ __hd_zone_is_utc s p i st i en → b {
+    : i len - en st
+    ? & == len 1 == ( nurl_str_get p st ) 90 { ^ T } {}   // Z
+    ? & & == len 2 == ( nurl_str_get p st ) 85 == ( nurl_str_get p + st 1 ) 84 { ^ T } {}  // UT
+    ? & & & == len 3 == ( nurl_str_get p st ) 71 == ( nurl_str_get p + st 1 ) 77 == ( nurl_str_get p + st 2 ) 84 { ^ T } {}  // GMT
+    ? & & & == len 3 == ( nurl_str_get p st ) 85 == ( nurl_str_get p + st 1 ) 84 == ( nurl_str_get p + st 2 ) 67 { ^ T } {}  // UTC
+    ^ F
+}
+
+@ http_date_parse s p → !i ParseErr {
+    ^ ( __parse_date_flex p F )
+}
+
+@ rfc2822_parse s p → !i ParseErr {
+    ^ ( __parse_date_flex p T )
+}
+
 // ── §12b Timezones / DST — POSIX TZ-string rules ─────────────────────
 //
 // Local-time conversion with daylight-saving transitions, driven by a


### PR DESCRIPTION
## Summary

Closes critic.md **B13**. The HTTP stack formatted dates (`time_format_http`) but couldn't parse them — `std/time.nu` §12c adds the parsers needed for `If-Modified-Since` / `If-Unmodified-Since` / cookie `Expires`, plus the email `Date:` form.

## API

```
http_date_parse s → !i ParseErr      // UTC seconds; the 3 RFC 7231 forms
rfc2822_parse   s → !i ParseErr      // UTC seconds; email Date with ±HHMM
```

Both return UTC seconds in the `!i ParseErr` shape (pair with `time_from_unix` for fields), matching the existing `time_parse_iso`.

`http_date_parse` accepts **all three** spellings RFC 7231 §7.1.1.1 requires a recipient to handle:
- IMF-fixdate (preferred): `Sun, 06 Nov 1994 08:49:37 GMT`
- RFC 850 (obsolete): `Sunday, 06-Nov-94 08:49:37 GMT` — 2-digit year via the POSIX `<70 → 20YY` pivot
- asctime (obsolete): `Sun Nov  6 08:49:37 1994`

`rfc2822_parse` handles `Mon, 02 Jan 2006 15:04:05 -0700` with numeric `±HHMM` zones (and `GMT`/`UT`/`UTC`/`Z`); the optional leading day-of-week is allowed; alphabetic US zones (EST/PDT/…) are intentionally not resolved (ambiguous per the RFC).

## Implementation

A shared tokenizer-based core (`__parse_date_flex`) splits on space/comma, classifies each token (month name / `HH:MM:SS` / `DD-Mon-YY` / number / zone), and folds to UTC via the existing `time_make` (which validates the civil fields). Month-name → number is `__month3_at`, the inverse of the existing `__month_name`.

## Verification

- `./build.sh`: bootstrap fixed point + full suite **347 PASS**
- **ASan + UBSan + LSan clean** — `http_date` + `time_basic` + `tz_basic` + `calendar_time` (the shared `time.nu` change disturbs nothing)
- `./tools/check_examples.sh`: **PASS 62**
- `nurlc --lint`: clean
- Lock: `compiler/tests/http_date.nu` — the three RFC 7231 forms agree on the spec's own example (`784111777`); the RFC 2822 `-0700` case equals Go's canonical reference instant (`1136239445`); round-trip through `time_format_http`; bad-month / garbage / missing-zone rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
