### PR TITLE
tooling: nurldoc — Markdown API-doc generator (C2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`nurldoc` — Markdown API-doc generator** (critic C2). The stdlib's
+  `//`-header + doc-comment discipline (90+ modules) was unrenderable;
+  `nurldoc` extracts each module's header block, top-level declaration
+  signatures (functions trimmed at their `{` body; types/enums/consts
+  keep their full definition), and the doc comment above each, into
+  Markdown. The render logic is an importable library
+  (`stdlib/ext/nurldoc.nu`, `nurldoc_render content title → String`,
+  brace-depth-aware so `:` locals inside bodies are never picked up);
+  `tools/nurldoc/main.nu` is a thin CLI — `nurldoc <file.nu>` to stdout,
+  or `nurldoc <src-dir> <out-dir>` to walk the tree with `fs_glob` and
+  write one `.md` per module. Lock: `compiler/tests/nurldoc.nu`.
+
 - **HTTP-date / RFC 2822 date parsing — `stdlib/std/time.nu`** (critic
   B13). The server formatted HTTP dates (`time_format_http`) but could
   not parse them; `http_date_parse` now accepts all three forms RFC 7231

--- a/compiler/tests/nurldoc.nu
+++ b/compiler/tests/nurldoc.nu
@@ -1,0 +1,43 @@
+// nurldoc.nu — ext/nurldoc.nu acceptance: render a fixture module's doc
+// surface to Markdown. Exercises: module-header block → prose, doc
+// comment above a decl → description, signature trimmed at `{`, FFI / `:`
+// const / struct / enum decls, and that `:` locals inside a function body
+// (brace depth > 0) are NOT picked up.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/ext/nurldoc.nu`
+
+@ main → i {
+    : String src ( string_with_cap 512 )
+    // ── fixture module ──
+    ( string_push_str src `// demo.nu — a tiny module.\n` )
+    ( string_push_str src `// Second header line.\n` )
+    ( string_push_str src `\n` )
+    ( string_push_str src `$ ` ) ( string_push_char src 96 )
+    ( string_push_str src `stdlib/core/string.nu` ) ( string_push_char src 96 )
+    ( string_push_str src `\n` )
+    ( string_push_str src `\n` )
+    ( string_push_str src `// Add two ints.\n` )
+    ( string_push_str src `@ add i a i b → i {\n` )
+    ( string_push_str src `    : i sum + a b\n` )       // local `:` at depth 1 — must be ignored
+    ( string_push_str src `    ^ sum\n` )
+    ( string_push_str src `}\n` )
+    ( string_push_str src `\n` )
+    ( string_push_str src `// A point.\n` )
+    ( string_push_str src `: Point { i x i y }\n` )
+    ( string_push_str src `\n` )
+    ( string_push_str src `: | Color { Red Green Blue }\n` )   // no doc comment
+    ( string_push_str src `\n` )
+    ( string_push_str src `// Process id.\n` )
+    ( string_push_str src `& ` ) ( string_push_char src 96 )
+    ( string_push_str src `c` ) ( string_push_char src 96 )
+    ( string_push_str src ` @ getpid → i\n` )
+    ( string_push_str src `\n` )
+    ( string_push_str src `: i MAX 100\n` )                    // const, no doc
+
+    : String md ( nurldoc_render ( string_data src ) `demo` )
+    ( nurl_print ( string_data md ) )
+    ( string_free md )
+    ( string_free src )
+    ^ 0
+}

--- a/compiler/tests/outputs/nurldoc.txt
+++ b/compiler/tests/outputs/nurldoc.txt
@@ -1,0 +1,27 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+# demo
+
+demo.nu — a tiny module.
+Second header line.
+
+## API
+
+### `@ add i a i b → i`
+
+Add two ints.
+
+### `: Point { i x i y }`
+
+A point.
+
+### `: | Color { Red Green Blue }`
+
+### `& `c` @ getpid → i`
+
+Process id.
+
+### `: i MAX 100`
+

--- a/stdlib/ext/nurldoc.nu
+++ b/stdlib/ext/nurldoc.nu
@@ -1,0 +1,212 @@
+// stdlib/ext/nurldoc.nu — render a NURL module's doc surface to Markdown.
+//
+// NURL's stdlib follows a consistent discipline — a `//` module-header
+// block at the top of each file, top-level declarations, and `//` doc
+// comments immediately above them — but that's invisible to anyone not
+// reading source. `nurldoc_render` turns one module's text into Markdown:
+// the header block as prose, then each top-level declaration's signature
+// (the line up to its `{` body) with any preceding doc comment.
+//
+//   ( nurldoc_render s content s title )  → String   Markdown for one module
+//
+// What counts as a documentable top-level declaration (brace depth 0,
+// so `:` locals inside function bodies are never picked up):
+//   @ name … / pub @ name …      functions
+//   & `lib` @ name …             FFI externs
+//   : Name { … } / : ~ Name …    structs + mutable globals
+//   : | Name { … }               enums
+//   : TYPE name …                constants
+//   % Trait … / % Trait ( T )    trait decls + impls
+//
+// The renderer is pure (text → text); the `nurldoc` CLI tool walks a
+// directory with fs_glob and writes one `.md` per module on top of it.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+// ── line helpers ────────────────────────────────────────────────────
+
+// Index of the first non-(space/tab) byte at/after `from` within
+// [from,end); returns `end` when the run is all whitespace.
+@ __nd_skip_ws s p i from i end → i {
+    : ~ i k from
+    ~ & < k end | == ( nurl_str_get p k ) 32 == ( nurl_str_get p k ) 9 { = k + k 1 }
+    ^ k
+}
+
+// True iff p[st..en) begins with the literal `pre`.
+@ __nd_starts_with s p i st i en s pre → b {
+    : i pn ( nurl_str_len pre )
+    ? > + st pn en { ^ F } {}
+    : ~ i k 0
+    ~ < k pn { ? != ( nurl_str_get p + st k ) ( nurl_str_get pre k ) { ^ F } {} = k + k 1 }
+    ^ T
+}
+
+// Net brace delta of one line, counting `{`/`}` only in code (outside
+// a `//` comment and outside backtick strings). Used to track top-level
+// depth across lines.
+@ __nd_brace_delta s p i st i en → i {
+    : ~ i k st
+    : ~ i depth 0
+    : ~ i in_str 0
+    ~ < k en {
+        : i c ( nurl_str_get p k )
+        ? != in_str 0 {
+            ? == c 96 { = in_str 0 } {}
+        } {
+            ? == c 96 { = in_str 1 } {
+                ? & == c 47 & < + k 1 en == ( nurl_str_get p + k 1 ) 47 { ^ depth } {}  // `//` → rest is comment
+                ? == c 123 { = depth + depth 1 } {}
+                ? == c 125 { = depth - depth 1 } {}
+            }
+        }
+        = k + k 1
+    }
+    ^ depth
+}
+
+// Append the comment text of a `//` line (with the leading `// ` or `//`
+// stripped) to `out`, plus a newline.
+@ __nd_push_comment_body String out s p i st i en → v {
+    : ~ i k + st 2                            // past `//`
+    ? & < k en == ( nurl_str_get p k ) 32 { = k + k 1 } {}  // one optional space
+    ~ < k en { ( string_push_char out ( nurl_str_get p k ) ) = k + k 1 }
+    ( string_push_char out 10 )
+}
+
+// Append the declaration signature in p[st..en) to `out`, trailing
+// whitespace trimmed. Functions (`cut_brace` true) stop at the `{` body
+// open; types/enums/consts/impls keep the whole line so their `{ … }`
+// definition shows.
+@ __nd_push_signature String out s p i st i en b cut_brace → v {
+    : ~ i brace en
+    ? cut_brace {
+        : ~ i k st
+        : ~ i in_str 0
+        : ~ b found F
+        ~ & < k en ! found {
+            : i c ( nurl_str_get p k )
+            ? != in_str 0 { ? == c 96 { = in_str 0 } {} } {
+                ? == c 96 { = in_str 1 } {
+                    ? == c 123 { = brace k = found T } {}
+                }
+            }
+            = k + k 1
+        }
+    } {}
+    // trim trailing whitespace before the cut point
+    : ~ i e brace
+    ~ & > e st | | == ( nurl_str_get p - e 1 ) 32 == ( nurl_str_get p - e 1 ) 9 == ( nurl_str_get p - e 1 ) 10 { = e - e 1 }
+    : ~ i j st
+    ~ < j e { ( string_push_char out ( nurl_str_get p j ) ) = j + j 1 }
+}
+
+// First declaration byte at/after `sp`, skipping a leading `pub `, or 0
+// when there is none. Shared by __nd_is_decl / __nd_is_fn.
+@ __nd_decl_char s p i sp i en → i {
+    : ~ i k sp
+    ? ( __nd_starts_with p k en `pub ` ) { = k ( __nd_skip_ws p + k 4 en ) } {}
+    ? >= k en { ^ 0 } {}
+    ^ ( nurl_str_get p k )
+}
+
+// Does the line starting at `sp` (first non-ws index) begin a top-level
+// declaration? Recognises `@`, `& `, `: `, `% `, and a leading `pub `.
+@ __nd_is_decl s p i sp i en → b {
+    : i c ( __nd_decl_char p sp en )
+    ? | | | == c 64 == c 38 == c 37 == c 58 { ^ T } {}  // @ & % :
+    ^ F
+}
+
+// Is this decl a function (`@` or `& `-FFI)? Functions hide their `{`
+// body in the rendered signature; everything else keeps the full line.
+@ __nd_is_fn s p i sp i en → b {
+    : i c ( __nd_decl_char p sp en )
+    ^ | == c 64 == c 38
+}
+
+// ── renderer ────────────────────────────────────────────────────────
+
+@ nurldoc_render s content s title → String {
+    : i n ( nurl_str_len content )
+    : String out ( string_with_cap + n 256 )
+    ( string_push_str out `# ` )
+    ( string_push_str out title )
+    ( string_push_str out `\n\n` )
+
+    : String header ( string_with_cap 256 )   // top `//` block (module prose)
+    : ~ String pending ( string_with_cap 256 )   // doc comment(s) above next decl
+    : String body ( string_with_cap + n 256 )  // accumulated "## API" entries
+
+    : ~ i pos 0
+    : ~ i depth 0
+    : ~ b header_done F   // true once we leave the leading comment block
+    : ~ b any_decl F
+    : ~ i pending_n 0
+
+    ~ < pos n {
+        // line bounds [ls, le); advance pos past the newline
+        : i ls pos
+        : ~ i le pos
+        ~ & < le n != ( nurl_str_get content le ) 10 { = le + le 1 }
+        : i sp ( __nd_skip_ws content ls le )
+        : b blank == sp le
+        : b is_comment & ! blank ( __nd_starts_with content sp le `//` )
+
+        ? == depth 0 {
+            ? is_comment {
+                ? header_done {
+                    ( __nd_push_comment_body pending content sp le )
+                    = pending_n + pending_n 1
+                } {
+                    ( __nd_push_comment_body header content sp le )
+                }
+            } {
+                ? blank {
+                    // blank line ends a pending doc block (and the header)
+                    = header_done T
+                    ( string_free pending )
+                    = pending ( string_with_cap 256 )
+                    = pending_n 0
+                } {
+                    = header_done T
+                    ? ( __nd_is_decl content sp le ) {
+                        = any_decl T
+                        ( string_push_str body `### ` )
+                        ( string_push_char body 96 )           // markdown `
+                        ( __nd_push_signature body content sp le ( __nd_is_fn content sp le ) )
+                        ( string_push_char body 96 )
+                        ( string_push_str body `\n\n` )
+                        ? > pending_n 0 {
+                            ( string_push_str body ( string_data pending ) )
+                            ( string_push_char body 10 )
+                        } {}
+                    } {}
+                    // any non-decl code line clears the pending doc
+                    ( string_free pending )
+                    = pending ( string_with_cap 256 )
+                    = pending_n 0
+                }
+            }
+        } {}
+
+        = depth + depth ( __nd_brace_delta content ls le )
+        ? < depth 0 { = depth 0 } {}
+        = pos ? < le n + le 1 le
+    }
+
+    ? > ( string_len header ) 0 {
+        ( string_push_str out ( string_data header ) )
+        ( string_push_char out 10 )
+    } {}
+    ? any_decl {
+        ( string_push_str out `## API\n\n` )
+        ( string_push_str out ( string_data body ) )
+    } {}
+
+    ( string_free header )
+    ( string_free pending )
+    ( string_free body )
+    ^ out
+}

--- a/tools/nurldoc/build.sh
+++ b/tools/nurldoc/build.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/nurldoc/build.sh — build the nurldoc package manager
+#  binary.
+#
+#  Stage:
+#    1. Compile tools/nurldoc/main.nu to LLVM IR using ./build/nurlc
+#    2. Link with stdlib/runtime.o → ./build/nurldoc
+#
+#  Requires that ./build.sh has already run.
+# ============================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT_DIR"
+
+NURLC="$ROOT_DIR/build/nurlc"
+RUNTIME="$ROOT_DIR/stdlib/runtime.o"
+SRC="$ROOT_DIR/tools/nurldoc/main.nu"
+
+if [[ ! -x "$NURLC" ]]; then
+    echo "ERROR: $NURLC not found." >&2
+    echo "       Run ./build.sh first to bootstrap the compiler." >&2
+    exit 1
+fi
+if [[ ! -f "$RUNTIME" ]]; then
+    echo "ERROR: $RUNTIME not found." >&2
+    echo "       Run ./build.sh first to compile the runtime." >&2
+    exit 1
+fi
+
+CLANG="${CLANG:-clang}"
+if ! command -v "$CLANG" >/dev/null 2>&1; then
+    echo "ERROR: clang not on PATH (set CLANG=/path/to/clang to override)." >&2
+    exit 1
+fi
+
+mkdir -p "$ROOT_DIR/build"
+
+echo "[1/2] $SRC → build/nurldoc.ll"
+"$NURLC" "$SRC" > "$ROOT_DIR/build/nurldoc.ll"
+
+# Match the central build.sh runtime link line — runtime.o was built
+# with whichever back-ends were detected at build time, and the
+# linker needs the same libraries.
+EXTRA_LIBS=()
+if [[ -f "$ROOT_DIR/stdlib/runtime.curl" ]]; then
+    if pkg-config --exists libcurl 2>/dev/null; then
+        # shellcheck disable=SC2207
+        EXTRA_LIBS+=( $(pkg-config --libs libcurl) )
+    else
+        EXTRA_LIBS+=( -lcurl )
+    fi
+fi
+if [[ -f "$ROOT_DIR/stdlib/runtime.openssl" ]]; then
+    if pkg-config --exists openssl 2>/dev/null; then
+        # shellcheck disable=SC2207
+        EXTRA_LIBS+=( $(pkg-config --libs openssl) )
+    else
+        EXTRA_LIBS+=( -lssl -lcrypto )
+    fi
+fi
+if [[ -f "$ROOT_DIR/stdlib/runtime.sqlite3" ]]; then
+    if pkg-config --exists sqlite3 2>/dev/null; then
+        # shellcheck disable=SC2207
+        EXTRA_LIBS+=( $(pkg-config --libs sqlite3) )
+    else
+        EXTRA_LIBS+=( -lsqlite3 )
+    fi
+fi
+if [[ -f "$ROOT_DIR/stdlib/runtime.pq" ]]; then
+    if pkg-config --exists libpq 2>/dev/null; then
+        # shellcheck disable=SC2207
+        EXTRA_LIBS+=( $(pkg-config --libs libpq) )
+    else
+        EXTRA_LIBS+=( -lpq )
+    fi
+fi
+if [[ -f "$ROOT_DIR/stdlib/runtime.z" ]]; then
+    if pkg-config --exists zlib 2>/dev/null; then
+        # shellcheck disable=SC2207
+        EXTRA_LIBS+=( $(pkg-config --libs zlib) )
+    else
+        EXTRA_LIBS+=( -lz )
+    fi
+fi
+if [[ -f "$ROOT_DIR/stdlib/runtime.zstd" ]]; then
+    if pkg-config --exists libzstd 2>/dev/null; then
+        # shellcheck disable=SC2207
+        EXTRA_LIBS+=( $(pkg-config --libs libzstd) )
+    else
+        EXTRA_LIBS+=( -lzstd )
+    fi
+fi
+
+echo "[2/2] build/nurldoc.ll → build/nurldoc"
+"$CLANG" -O2 -flto "$ROOT_DIR/build/nurldoc.ll" "$RUNTIME" -lm -lpthread "${EXTRA_LIBS[@]}" -o "$ROOT_DIR/build/nurldoc"
+
+echo ""
+echo "Done: $ROOT_DIR/build/nurldoc"

--- a/tools/nurldoc/main.nu
+++ b/tools/nurldoc/main.nu
@@ -1,0 +1,132 @@
+// tools/nurldoc/main.nu — generate Markdown API docs from NURL source.
+//
+// Usage:
+//   nurldoc <file.nu>            render one module to stdout
+//   nurldoc <src-dir> <out-dir>  render every *.nu under src-dir to
+//                                out-dir/<name>.md (recursive, via fs_glob)
+//
+// The rendering lives in stdlib/ext/nurldoc.nu (nurldoc_render); this is
+// a thin CLI that handles argv, file discovery, and output.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/std/cmp.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/nurldoc.nu`
+
+// Basename of a path with the `.nu` extension dropped (`a/b/vec.nu` →
+// `vec`). Used as the doc title and output filename stem.
+@ __stem s path → String {
+    : i n ( nurl_str_len path )
+    : ~ i slash -1
+    : ~ i k 0
+    ~ < k n { ? == ( nurl_str_get path k ) 47 { = slash k } {} = k + k 1 }
+    : i start + slash 1
+    : ~ i end n
+    ? & >= n 3 ( __ends_nu path n ) { = end - n 3 } {}
+    : String out ( string_with_cap + - end start 1 )
+    : ~ i j start
+    ~ < j end { ( string_push_char out ( nurl_str_get path j ) ) = j + j 1 }
+    ^ out
+}
+
+@ __ends_nu s path i n → b {
+    ^ & & == ( nurl_str_get path - n 3 ) 46 == ( nurl_str_get path - n 2 ) 110 == ( nurl_str_get path - n 1 ) 117
+}
+
+// Render one source file to Markdown (owned String); empty on read error.
+@ __render_file s path → String {
+    : !String IoErr r ( read_file path )
+    ^ ?? r {
+        T content → {
+            : String stem ( __stem path )
+            : String md ( nurldoc_render ( string_data content ) ( string_data stem ) )
+            ( string_free stem )
+            ( string_free content )
+            ^ md
+        }
+        F _ → ( string_with_cap 1 )
+    }
+}
+
+@ __cmp_str s a s b → i { ^ ( nurl_str_cmp a b ) }
+
+@ main → i {
+    : i argc ( env_args_count )
+    ? < argc 2 {
+        ( nurl_eprintln `usage: nurldoc <file.nu> | nurldoc <src-dir> <out-dir>` )
+        ^ 1
+    } {}
+    : String a1 ( env_arg 1 )
+    : s src ( string_data a1 )
+
+    // Single-file mode: one arg that is a regular file → stdout.
+    ? & < argc 3 == 1 ( nurl_path_type src ) {
+        : String md ( __render_file src )
+        ( nurl_print ( string_data md ) )
+        ( string_free md )
+        ( string_free a1 )
+        ^ 0
+    } {}
+
+    ? < argc 3 {
+        ( nurl_eprintln `nurldoc: directory mode needs an <out-dir>` )
+        ( string_free a1 )
+        ^ 1
+    } {}
+    : String a2 ( env_arg 2 )
+    : s out_dir ( string_data a2 )
+
+    : !v IoErr _mk ( dir_create_all out_dir )
+    ?? _mk { T _ → {} F _ → {} }
+
+    // Glob `<src>/**/*.nu`, render each, write `<out>/<stem>.md`.
+    : String pat ( string_with_cap + ( nurl_str_len src ) 8 )
+    ( string_push_str pat src )
+    ( string_push_str pat `/**/*.nu` )
+    : !( Vec String ) IoErr gr ( fs_glob ( string_data pat ) )
+    ( string_free pat )
+    : ~ i count 0
+    ?? gr {
+        T files → {
+            : i nf ( vec_len [String] files )
+            // stable order
+            : ( @ i String String ) cmp \ String x String y → i { ^ ( __cmp_str ( string_data x ) ( string_data y ) ) }
+            ( sort_by [String] files cmp )
+            : ~ i k 0
+            ~ < k nf {
+                : ?String fo ( vec_get [String] files k )
+                ?? fo {
+                    T f → {
+                        : String md ( __render_file ( string_data f ) )
+                        : String stem ( __stem ( string_data f ) )
+                        : String opath ( string_with_cap + + ( nurl_str_len out_dir ) ( string_len stem ) 5 )
+                        ( string_push_str opath out_dir )
+                        ( string_push_char opath 47 )
+                        ( string_push_str opath ( string_data stem ) )
+                        ( string_push_str opath `.md` )
+                        : !v IoErr wr ( write_file ( string_data opath ) ( string_data md ) )
+                        ?? wr {
+                            T _ → { = count + count 1 }
+                            F _ → ( nurl_eprintln ( string_data opath ) )
+                        }
+                        ( string_free opath ) ( string_free stem ) ( string_free md )
+                        ( string_free f )
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( vec_free [String] files )
+        }
+        F _ → ( nurl_eprintln `nurldoc: glob failed` )
+    }
+    ( nurl_print `nurldoc: wrote ` )
+    ( nurl_print ( nurl_str_int count ) )
+    ( nurl_print ` files\n` )
+    ( string_free a2 )
+    ( string_free a1 )
+    ^ 0
+}


### PR DESCRIPTION
## Summary

Closes critic.md **C2**. The stdlib's `//`-header + doc-comment discipline (90+ modules) was consistent but unrenderable to anyone not reading source. `nurldoc` turns a module's text into Markdown.

## Library + CLI

The render logic is an **importable library** so it's unit-testable and reusable:

```
stdlib/ext/nurldoc.nu :  nurldoc_render s content s title → String
```

- module-header `//` block → prose
- each top-level declaration (brace depth 0, so `:` locals inside function bodies are **never** picked up) → its signature with the immediately-preceding `//` doc comment as the description
- functions (`@` / `& `-FFI) are trimmed at their `{` body; types / enums / consts / impls keep the full line so their `{ … }` definition shows

`tools/nurldoc/main.nu` is a thin CLI (with a `build.sh` matching `nurlpkg`'s):

```
nurldoc <file.nu>            → Markdown to stdout
nurldoc <src-dir> <out-dir>  → walk the tree with fs_glob, write one <stem>.md per module
```

Dogfoods `fs_glob` (PR #115). Example output for `std/subtle.nu`:

```markdown
# subtle

stdlib/std/subtle.nu — constant-time comparisons for secret material.
…

## API

### `@ constant_time_eq_n s a s b i n → b`

### `@ constant_time_eq s a s b → b`
…
```

A directory smoke-run renders `stdlib/core` (14 modules) cleanly.

## Verification

- `./build.sh`: bootstrap fixed point + full suite **348 PASS**
- **ASan + UBSan + LSan clean** on `nurldoc` — no leaks
- `./tools/check_examples.sh`: **PASS 62**
- `nurlc --lint`: clean
- Lock: `compiler/tests/nurldoc.nu` feeds a fixture module and checks the rendered Markdown — header → prose, a function with its doc comment, a struct and enum keeping their bodies, an FFI decl, a const, and a `:` local at depth > 1 that is correctly skipped.

Markdown only (HTML left out — markdown renders on GitHub / the registry already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
