### PR TITLE
stdlib: arbitrary-precision fixed-point decimal (B14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Arbitrary-precision fixed-point decimal — `stdlib/std/decimal.nu`**
+  (critic B14, the last ROADMAP numeric gap). A `Decimal` is a `BigInt`
+  coefficient × 10^-scale, so it is *exact* — `0.1 + 0.2` is `0.3`, not
+  the binary-float `0.30000000000000004` — and never overflows. Exact
+  `dec_add` / `dec_sub` / `dec_mul`; `dec_div a b scale` with an explicit
+  result scale and **banker's rounding** (round half-to-even, the
+  financial default); scale-agnostic `dec_cmp`; `dec_round` / `dec_rescale`
+  / `dec_normalize`; `dec_from_string` (`"-12.340"`, `".5"`, `"42"`) and
+  `dec_to_string`. Builds on the `bigint` div/rem from PR #100. Lock:
+  `compiler/tests/decimal.nu` (exact `0.1+0.2==0.3`, the full
+  half-to-even rounding table incl. negatives, division + div-by-zero,
+  normalize, cross-scale compare; ASan+UBSan+LSan clean — every
+  intermediate `BigInt` freed).
+
 - **Playground: rendered stdlib API reference at `/stdlib-docs`**
   (`nurlapi`). The `nurldoc` library is now wired into the playground
   server: `/stdlib-docs` is an auto-generated index of every stdlib

--- a/compiler/tests/decimal.nu
+++ b/compiler/tests/decimal.nu
@@ -1,0 +1,94 @@
+// decimal.nu — std/decimal.nu acceptance: exact fixed-point arithmetic,
+// banker's rounding, division with explicit scale, parse/format, compare.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/decimal.nu`
+
+// parse "s", print its canonical form
+@ pp s label s in → v {
+    ( nurl_print label ) ( nurl_print `: ` )
+    : !Decimal ParseErr r ( dec_from_string in )
+    ?? r {
+        T d → { : String s ( dec_to_string d ) ( nurl_print ( string_data s ) ) ( string_free s ) ( dec_free d ) }
+        F _ → ( nurl_print `PARSE_ERR` )
+    }
+    ( nurl_print `\n` )
+}
+
+@ pd Decimal d → v { : String s ( dec_to_string d ) ( nurl_print ( string_data s ) ) ( string_free s ) }
+
+@ mk s in → Decimal {
+    : !Decimal ParseErr r ( dec_from_string in )
+    ^ ?? r { T d → d F _ → ( dec_zero ) }
+}
+
+@ main → i {
+    // ── parse + round-trip ──
+    ( pp `int` `42` )
+    ( pp `neg` `-12.340` )
+    ( pp `lt1` `.5` )
+    ( pp `negfrac` `-.001` )
+    ( pp `trailing_dot` `7.` )
+    ( pp `bad` `1.2.3` )
+    ( pp `empty` `` )
+    ( pp `garbage` `12x` )
+
+    // ── the canonical float failure: 0.1 + 0.2 == 0.3 exactly ──
+    : Decimal a ( mk `0.1` )
+    : Decimal b ( mk `0.2` )
+    : Decimal sum ( dec_add a b )
+    ( nurl_print `0.1+0.2=` ) ( pd sum )
+    : Decimal three ( mk `0.3` )
+    ( nurl_print ` ==0.3? ` ) ( nurl_print ? == 0 ( dec_cmp sum three ) `T` `F` ) ( nurl_print `\n` )
+    ( dec_free a ) ( dec_free b ) ( dec_free sum ) ( dec_free three )
+
+    // ── add/sub/mul with differing scales ──
+    : Decimal x ( mk `12.5` )
+    : Decimal y ( mk `0.025` )
+    : Decimal s1 ( dec_add x y )   ( nurl_print `12.5+0.025=` ) ( pd s1 ) ( nurl_print `\n` )
+    : Decimal s2 ( dec_sub x y )   ( nurl_print `12.5-0.025=` ) ( pd s2 ) ( nurl_print `\n` )
+    : Decimal s3 ( dec_mul x y )   ( nurl_print `12.5*0.025=` ) ( pd s3 ) ( nurl_print `\n` )
+    ( dec_free x ) ( dec_free y ) ( dec_free s1 ) ( dec_free s2 ) ( dec_free s3 )
+
+    // ── banker's rounding (round half to even) to 2 places ──
+    // 2.345 → 2.34 (4 even, half stays), 2.355 → 2.36 (5→6 even),
+    // 2.346 → 2.35 (>half up), -2.345 → -2.34 (toward even)
+    ( nurl_print `round 2.345→` ) : Decimal r1 ( mk `2.345` ) : Decimal rr1 ( dec_round r1 2 ) ( pd rr1 ) ( nurl_print `\n` )
+    ( nurl_print `round 2.355→` ) : Decimal r2 ( mk `2.355` ) : Decimal rr2 ( dec_round r2 2 ) ( pd rr2 ) ( nurl_print `\n` )
+    ( nurl_print `round 2.346→` ) : Decimal r3 ( mk `2.346` ) : Decimal rr3 ( dec_round r3 2 ) ( pd rr3 ) ( nurl_print `\n` )
+    ( nurl_print `round -2.345→` ) : Decimal r4 ( mk `-2.345` ) : Decimal rr4 ( dec_round r4 2 ) ( pd rr4 ) ( nurl_print `\n` )
+    ( nurl_print `round 0.125→` ) : Decimal r5 ( mk `0.125` ) : Decimal rr5 ( dec_round r5 2 ) ( pd rr5 ) ( nurl_print `\n` )  // →0.12 (even)
+    ( dec_free r1 ) ( dec_free r2 ) ( dec_free r3 ) ( dec_free r4 ) ( dec_free r5 )
+    ( dec_free rr1 ) ( dec_free rr2 ) ( dec_free rr3 ) ( dec_free rr4 ) ( dec_free rr5 )
+
+    // ── division (explicit scale, banker's) ──
+    ( nurl_print `1/3 @4=` ) : Decimal d1 ( mk `1` ) : Decimal d2 ( mk `3` )
+    : !Decimal DecErr q1 ( dec_div d1 d2 4 ) ?? q1 { T q → { ( pd q ) ( dec_free q ) } F _ → ( nurl_print `ERR` ) } ( nurl_print `\n` )
+    ( nurl_print `10/8 @2=` ) : Decimal d3 ( mk `10` ) : Decimal d4 ( mk `8` )
+    : !Decimal DecErr q2 ( dec_div d3 d4 2 ) ?? q2 { T q → { ( pd q ) ( dec_free q ) } F _ → ( nurl_print `ERR` ) } ( nurl_print `\n` )  // 1.25
+    ( nurl_print `1/0=` ) : Decimal d5 ( mk `1` ) : Decimal d6 ( mk `0` )
+    : !Decimal DecErr q3 ( dec_div d5 d6 2 ) ?? q3 { T q → { ( pd q ) ( dec_free q ) } F e → ( nurl_print ?? e { DecDivZero → `DivZero` } ) } ( nurl_print `\n` )
+    ( nurl_print `-7/2 @1=` ) : Decimal d7 ( mk `-7` ) : Decimal d8 ( mk `2` )
+    : !Decimal DecErr q4 ( dec_div d7 d8 1 ) ?? q4 { T q → { ( pd q ) ( dec_free q ) } F _ → ( nurl_print `ERR` ) } ( nurl_print `\n` )  // -3.5
+    ( dec_free d1 ) ( dec_free d2 ) ( dec_free d3 ) ( dec_free d4 ) ( dec_free d5 ) ( dec_free d6 ) ( dec_free d7 ) ( dec_free d8 )
+
+    // ── normalize (strip trailing fractional zeros) ──
+    ( nurl_print `normalize 1.2500→` ) : Decimal nz ( mk `1.2500` ) : Decimal nzn ( dec_normalize nz ) ( pd nzn ) ( nurl_print `\n` )
+    ( dec_free nz ) ( dec_free nzn )
+
+    // ── compare across scales ──
+    : Decimal c1 ( mk `1.5` ) : Decimal c2 ( mk `1.50` )
+    ( nurl_print `cmp 1.5 1.50=` ) ( nurl_print ( nurl_str_int ( dec_cmp c1 c2 ) ) )
+    : Decimal c3 ( mk `1.5` ) : Decimal c4 ( mk `1.49` )
+    ( nurl_print ` cmp 1.5 1.49=` ) ( nurl_print ( nurl_str_int ( dec_cmp c3 c4 ) ) ) ( nurl_print `\n` )
+    ( dec_free c1 ) ( dec_free c2 ) ( dec_free c3 ) ( dec_free c4 )
+
+    // ── a money sum: 0.10 × 3 ──
+    : Decimal price ( mk `0.10` )
+    : ~ Decimal acc ( dec_zero )
+    : ~ i k 0
+    ~ < k 3 { : Decimal nx ( dec_add acc price ) ( dec_free acc ) = acc nx = k + k 1 }
+    ( nurl_print `0.10*3 (repeated add)=` ) ( pd acc ) ( nurl_print `\n` )
+    ( dec_free price ) ( dec_free acc )
+    ^ 0
+}

--- a/compiler/tests/outputs/decimal.txt
+++ b/compiler/tests/outputs/decimal.txt
@@ -1,0 +1,28 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+int: 42
+neg: -12.340
+lt1: 0.5
+negfrac: -0.001
+trailing_dot: 7
+bad: PARSE_ERR
+empty: PARSE_ERR
+garbage: PARSE_ERR
+0.1+0.2=0.3 ==0.3? T
+12.5+0.025=12.525
+12.5-0.025=12.475
+12.5*0.025=0.3125
+round 2.345→2.34
+round 2.355→2.36
+round 2.346→2.35
+round -2.345→-2.34
+round 0.125→0.12
+1/3 @4=0.3333
+10/8 @2=1.25
+1/0=DivZero
+-7/2 @1=-3.5
+normalize 1.2500→1.25
+cmp 1.5 1.50=0 cmp 1.5 1.49=1
+0.10*3 (repeated add)=0.30

--- a/stdlib/std/decimal.nu
+++ b/stdlib/std/decimal.nu
@@ -1,0 +1,279 @@
+// stdlib/std/decimal.nu — arbitrary-precision fixed-point decimal.
+//
+// A `Decimal` is an exact base-10 number: an arbitrary-precision integer
+// coefficient (`BigInt`, from std/bigint.nu) times a power of ten given
+// by an explicit non-negative `scale`:
+//
+//     value = coeff × 10^(-scale)        e.g.  12345 × 10^-2 = 123.45
+//
+// This is what money math needs — `0.1 + 0.2` is exactly `0.3`, never the
+// binary-float `0.30000000000000004` — and it never overflows, since the
+// coefficient grows as large as the value demands. Division (the only
+// inexact operation) takes an explicit result scale and rounds
+// **half-to-even** (banker's rounding), the IEEE 754 / financial default
+// that avoids the upward bias of round-half-up.
+//
+// Ownership: a Decimal owns its BigInt coefficient — `dec_free` it (or
+// the values it was built from). Every operation returns a fresh owned
+// Decimal; inputs are borrowed and untouched.
+//
+//   ( dec_from_i n )                  → Decimal          n × 10^0
+//   ( dec_from_string s )             → !Decimal ParseErr "-12.340", ".5", "42"
+//   ( dec_zero )                      → Decimal
+//   ( dec_clone d ) / ( dec_free d )
+//   ( dec_scale d )                   → i                fractional digit count
+//   ( dec_is_zero d )                 → b
+//   ( dec_neg d )                     → Decimal
+//   ( dec_add a b ) ( dec_sub a b ) ( dec_mul a b ) → Decimal   (exact)
+//   ( dec_div a b scale )             → !Decimal DecErr  banker's-rounded
+//   ( dec_cmp a b )                   → i                -1 / 0 / 1, scale-agnostic
+//   ( dec_round d places )            → Decimal          half-to-even to `places`
+//   ( dec_rescale d scale )           → Decimal          change scale (round if fewer)
+//   ( dec_normalize d )               → Decimal          drop trailing fractional zeros
+//   ( dec_to_string d )               → String
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/errors.nu`
+$ `stdlib/std/bigint.nu`
+
+: Decimal { BigInt coeff i scale }
+
+: | DecErr { DecDivZero }
+
+@ dec_free Decimal d → v { ( bigint_free . d coeff ) }
+@ dec_clone Decimal d → Decimal { ^ @ Decimal { ( bigint_clone . d coeff ) . d scale } }
+@ dec_scale Decimal d → i { ^ . d scale }
+@ dec_is_zero Decimal d → b { ^ ( bigint_is_zero . d coeff ) }
+@ dec_zero → Decimal { ^ @ Decimal { ( bigint_zero ) 0 } }
+@ dec_from_i i n → Decimal { ^ @ Decimal { ( bigint_from_i n ) 0 } }
+@ dec_neg Decimal d → Decimal { ^ @ Decimal { ( bigint_neg . d coeff ) . d scale } }
+
+// ── internal bigint helpers ─────────────────────────────────────────
+
+// 10^d as a BigInt (d ≥ 0).
+@ __dec_pow10 i d → BigInt {
+    : ~ BigInt acc ( bigint_from_i 1 )
+    : BigInt ten ( bigint_from_i 10 )
+    : ~ i k 0
+    ~ < k d {
+        : BigInt nx ( bigint_mul acc ten )
+        ( bigint_free acc )
+        = acc nx
+        = k + k 1
+    }
+    ( bigint_free ten )
+    ^ acc
+}
+
+// `c × 10^delta` as a fresh BigInt (delta ≥ 0). delta == 0 still returns
+// a fresh copy, so callers can always free the source.
+@ __dec_scaleup BigInt c i delta → BigInt {
+    : BigInt p ( __dec_pow10 delta )
+    : BigInt r ( bigint_mul c p )
+    ( bigint_free p )
+    ^ r
+}
+
+// True iff non-negative `x` is odd.
+@ __bigint_is_odd BigInt x → b {
+    : BigInt two ( bigint_from_i 2 )
+    : BigInt r ( bigint_rem x two )
+    : b odd ! ( bigint_is_zero r )
+    ( bigint_free two ) ( bigint_free r )
+    ^ odd
+}
+
+// round-half-to-even( num / den ), both NON-NEGATIVE, den > 0. Returns a
+// fresh non-negative BigInt.
+@ __dec_round_div BigInt num BigInt den → BigInt {
+    : BigInt q ( bigint_div num den )
+    : BigInt r ( bigint_rem num den )
+    : BigInt twor ( bigint_add r r )           // 2·remainder
+    : i c ( bigint_cmp twor den )
+    ( bigint_free r ) ( bigint_free twor )
+    // 2r > den → round up; 2r < den → round down (keep q);
+    // 2r == den (exactly half) → round to even.
+    : ~ b bump F
+    ? > c 0 { = bump T } {
+        ? == c 0 { ? ( __bigint_is_odd q ) { = bump T } {} } {}
+    }
+    ? bump {
+        : BigInt one ( bigint_from_i 1 )
+        : BigInt res ( bigint_add q one )
+        ( bigint_free one ) ( bigint_free q )
+        ^ res
+    } {}
+    ^ q
+}
+
+// ── add / sub / mul / cmp ───────────────────────────────────────────
+
+@ __dec_max_scale Decimal a Decimal b → i {
+    ^ ? > . a scale . b scale . a scale . b scale
+}
+
+@ dec_add Decimal a Decimal b → Decimal {
+    : i s ( __dec_max_scale a b )
+    : BigInt ca ( __dec_scaleup . a coeff - s . a scale )
+    : BigInt cb ( __dec_scaleup . b coeff - s . b scale )
+    : BigInt sum ( bigint_add ca cb )
+    ( bigint_free ca ) ( bigint_free cb )
+    ^ @ Decimal { sum s }
+}
+
+@ dec_sub Decimal a Decimal b → Decimal {
+    : i s ( __dec_max_scale a b )
+    : BigInt ca ( __dec_scaleup . a coeff - s . a scale )
+    : BigInt cb ( __dec_scaleup . b coeff - s . b scale )
+    : BigInt diff ( bigint_sub ca cb )
+    ( bigint_free ca ) ( bigint_free cb )
+    ^ @ Decimal { diff s }
+}
+
+@ dec_mul Decimal a Decimal b → Decimal {
+    : BigInt c ( bigint_mul . a coeff . b coeff )
+    ^ @ Decimal { c + . a scale . b scale }
+}
+
+@ dec_cmp Decimal a Decimal b → i {
+    : i s ( __dec_max_scale a b )
+    : BigInt ca ( __dec_scaleup . a coeff - s . a scale )
+    : BigInt cb ( __dec_scaleup . b coeff - s . b scale )
+    : i c ( bigint_cmp ca cb )
+    ( bigint_free ca ) ( bigint_free cb )
+    ^ c
+}
+
+// ── rescale / round / normalize ─────────────────────────────────────
+
+@ dec_rescale Decimal d i target → Decimal {
+    ? == target . d scale { ^ ( dec_clone d ) } {}
+    ? > target . d scale {
+        : BigInt c ( __dec_scaleup . d coeff - target . d scale )
+        ^ @ Decimal { c target }
+    } {}
+    // fewer digits: drop (scale - target) with banker's rounding.
+    : i drop - . d scale target
+    : BigInt div ( __dec_pow10 drop )
+    : BigInt c0 . d coeff
+    : b neg & ! ( bigint_is_zero c0 ) . c0 neg
+    : BigInt mag ? neg ( bigint_neg c0 ) ( bigint_clone c0 )
+    : BigInt rq ( __dec_round_div mag div )
+    : BigInt coeff ? neg ( bigint_neg rq ) ( bigint_clone rq )
+    ( bigint_free div ) ( bigint_free mag ) ( bigint_free rq )
+    ^ @ Decimal { coeff target }
+}
+
+@ dec_round Decimal d i places → Decimal { ^ ( dec_rescale d places ) }
+
+@ dec_normalize Decimal d → Decimal {
+    : ~ BigInt c ( bigint_clone . d coeff )
+    : ~ i s . d scale
+    : BigInt ten ( bigint_from_i 10 )
+    : ~ b going T
+    ~ & going > s 0 {
+        : BigInt r ( bigint_rem c ten )
+        : b divisible ( bigint_is_zero r )
+        ( bigint_free r )
+        ? divisible {
+            : BigInt q ( bigint_div c ten )
+            ( bigint_free c )
+            = c q
+            = s - s 1
+        } { = going F }
+    }
+    ( bigint_free ten )
+    ^ @ Decimal { c s }
+}
+
+// ── division (banker's rounding to `scale` places) ──────────────────
+
+@ dec_div Decimal a Decimal b i scale → !Decimal DecErr {
+    ? ( bigint_is_zero . b coeff ) { ^ @ !Decimal DecErr { F DecDivZero } } {}
+    // result = (a.coeff·10^(scale+b.scale)) / (b.coeff·10^a.scale)
+    : BigInt num ( __dec_scaleup . a coeff + scale . b scale )
+    : BigInt den ( __dec_scaleup . b coeff . a scale )
+    : b negN & ! ( bigint_is_zero num ) . num neg
+    : b negD & ! ( bigint_is_zero den ) . den neg
+    : BigInt aN ? negN ( bigint_neg num ) ( bigint_clone num )
+    : BigInt aD ? negD ( bigint_neg den ) ( bigint_clone den )
+    : BigInt q ( __dec_round_div aN aD )
+    : b rneg != negN negD
+    : BigInt coeff ? rneg ( bigint_neg q ) ( bigint_clone q )
+    ( bigint_free num ) ( bigint_free den )
+    ( bigint_free aN ) ( bigint_free aD ) ( bigint_free q )
+    ^ @ !Decimal DecErr { T @ Decimal { coeff scale } }
+}
+
+// ── string I/O ──────────────────────────────────────────────────────
+
+@ dec_to_string Decimal d → String {
+    : String signed ( bigint_to_string . d coeff )
+    : s ss ( string_data signed )
+    : b neg & > ( nurl_str_len ss ) 0 == ( nurl_str_get ss 0 ) 45
+    : i dstart ? neg 1 0
+    : i dlen - ( nurl_str_len ss ) dstart   // count of magnitude digits
+    : i scale . d scale
+    : String out ( string_with_cap + + dlen scale 4 )
+    ? neg { ( string_push_char out 45 ) } {}
+    ? == scale 0 {
+        : ~ i k dstart
+        ~ < k ( nurl_str_len ss ) { ( string_push_char out ( nurl_str_get ss k ) ) = k + k 1 }
+        ( string_free signed )
+        ^ out
+    } {}
+    ? > dlen scale {
+        // integer part has (dlen - scale) digits
+        : i split + dstart - dlen scale
+        : ~ i k dstart
+        ~ < k split { ( string_push_char out ( nurl_str_get ss k ) ) = k + k 1 }
+        ( string_push_char out 46 )            // '.'
+        = k split
+        ~ < k ( nurl_str_len ss ) { ( string_push_char out ( nurl_str_get ss k ) ) = k + k 1 }
+    } {
+        // |value| < 1 : "0." then (scale - dlen) leading zeros then digits
+        ( string_push_char out 48 )            // '0'
+        ( string_push_char out 46 )            // '.'
+        : ~ i z 0
+        ~ < z - scale dlen { ( string_push_char out 48 ) = z + z 1 }
+        : ~ i k dstart
+        ~ < k ( nurl_str_len ss ) { ( string_push_char out ( nurl_str_get ss k ) ) = k + k 1 }
+    }
+    ( string_free signed )
+    ^ out
+}
+
+@ dec_from_string s str → !Decimal ParseErr {
+    : i n ( nurl_str_len str )
+    ? == n 0 { ^ @ !Decimal ParseErr { F @ ParseErr { Empty } } } {}
+    : ~ i pos 0
+    : String digits ( string_with_cap + n 1 )   // sign + all coefficient digits
+    : i c0 ( nurl_str_get str 0 )
+    ? | == c0 45 == c0 43 {
+        ? == c0 45 { ( string_push_char digits 45 ) } {}
+        = pos 1
+    } {}
+    : ~ i int_digits 0
+    : ~ i frac_digits 0
+    : ~ b seen_dot F
+    : ~ b bad F
+    ~ & < pos n ! bad {
+        : i c ( nurl_str_get str pos )
+        ? & >= c 48 <= c 57 {
+            ( string_push_char digits c )
+            ? seen_dot { = frac_digits + frac_digits 1 } { = int_digits + int_digits 1 }
+        } {
+            ? & == c 46 ! seen_dot { = seen_dot T } { = bad T }
+        }
+        = pos + pos 1
+    }
+    ? bad { ( string_free digits ) ^ @ !Decimal ParseErr { F @ ParseErr { BadFormat } } } {}
+    ? == 0 + int_digits frac_digits { ( string_free digits ) ^ @ !Decimal ParseErr { F @ ParseErr { Empty } } } {}
+    : !BigInt ParseErr cr ( bigint_from_string ( string_data digits ) )
+    ( string_free digits )
+    ^ ?? cr {
+        T coeff → @ !Decimal ParseErr { T @ Decimal { coeff frac_digits } }
+        F e → @ !Decimal ParseErr { F e }
+    }
+}


### PR DESCRIPTION
## Summary

Closes critic.md **B14** — the last numeric gap the ROADMAP still lists. A `Decimal` is an arbitrary-precision `BigInt` coefficient times a power of ten (an explicit, non-negative `scale`):

```
value = coeff × 10^-scale          12345 × 10^-2 = 123.45
```

So it is **exact** — `0.1 + 0.2` is `0.3`, never the binary-float `0.30000000000000004` — and never overflows, because the coefficient grows as large as the value demands. This is what money / payments / CSV-finance math needs.

## API

```
dec_from_i / dec_from_string / dec_zero / dec_clone / dec_free / dec_scale / dec_is_zero
dec_neg
dec_add  dec_sub  dec_mul                    exact
dec_div a b scale → !Decimal DecErr          explicit result scale, banker's rounding, DecDivZero on /0
dec_cmp                                       scale-agnostic (-1/0/1)
dec_round / dec_rescale / dec_normalize
dec_to_string
```

Division — the only inexact operation — takes an explicit result scale and rounds **half-to-even** (banker's rounding, the IEEE 754 / financial default that avoids the upward bias of round-half-up). The shared `__dec_round_div` compares `2·remainder` to the divisor and, on an exact half, bumps the quotient only when it is odd; all sign handling is done on magnitudes.

Builds on the `bigint` add/sub/mul/div/rem/cmp (div/rem from PR #100).

## Correctness — what the test pins

```
0.1+0.2=0.3 ==0.3? T            ← the headline
round 2.345→2.34   round 2.355→2.36   round 2.346→2.35
round -2.345→-2.34 round 0.125→0.12   ← full half-to-even table, incl. negatives
1/3 @4=0.3333   10/8 @2=1.25   1/0=DivZero   -7/2 @1=-3.5
normalize 1.2500→1.25   cmp 1.5 1.50=0   cmp 1.5 1.49=1
```

## Verification

- `./build.sh`: bootstrap fixed point + full suite **349 PASS**
- **ASan + UBSan + LSan clean** — every intermediate `BigInt` is freed despite the heavy allocation (the diamond bit)
- `./tools/check_examples.sh`: **PASS 62**
- `nurlc --lint`: clean
- Lock: `compiler/tests/decimal.nu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
