### PR TITLE
stdlib: CBOR (RFC 8949) in ext/cbor.nu (B16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CBOR (RFC 8949) — `stdlib/ext/cbor.nu`** (critic B16). The
+  IETF-standard binary serialization (COSE / WebAuthn / CTAP), sibling of
+  MessagePack, over the shared `Json` value: `cbor_encode Json →
+  !( Vec u ) CborErr` and `cbor_decode ( Vec u ) → !Json CborErr`. Encode
+  is canonical-ish — integers and lengths use the shortest head, floats
+  are float64 — so equal documents serialize to equal bytes. Decode is
+  liberal: every definite-length head, signed/unsigned integers at all
+  widths, and **float16 / float32 / float64** (the half-float decoder
+  handles zero / subnormal / normal / inf / NaN). Byte strings, tags,
+  indefinite-length items, and exotic simple values are rejected as
+  `CborUnsupported`; `undefined` (0xf7) → `JNull`. Lock:
+  `compiler/tests/cbor.nu` — Json round-trip with canonical-byte check,
+  the RFC 8949 Appendix A decode vectors (integer boundaries, negatives,
+  nested array/map, all three float widths), and every documented
+  rejection; ASan+UBSan+LSan clean (error paths free the partial tree).
+
 - **Arbitrary-precision fixed-point decimal — `stdlib/std/decimal.nu`**
   (critic B14, the last ROADMAP numeric gap). A `Decimal` is a `BigInt`
   coefficient × 10^-scale, so it is *exact* — `0.1 + 0.2` is `0.3`, not

--- a/compiler/tests/cbor.nu
+++ b/compiler/tests/cbor.nu
@@ -1,0 +1,127 @@
+// cbor.nu — ext/cbor.nu acceptance (RFC 8949).
+//
+// (1) Round-trips a representative Json document Json→CBOR→Json and
+//     checks the bytes are the canonical shortest-head encoding.
+// (2) Decodes raw RFC 8949 Appendix A vectors, including the integer
+//     size boundaries, negatives, nested array/map, and float16/32/64.
+// (3) Checks the documented rejections (byte string, tag, indefinite,
+//     non-text map key, trailing bytes).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/cbor.nu`
+
+// hex string → Vec[u]
+@ hx s h → ( Vec u ) {
+    : i n ( nurl_str_len h )
+    : ( Vec u ) out ( vec_with_cap [u] ? > n 1 / n 2 1 )
+    : ~ i k 0
+    ~ < + k 1 n {
+        : i hi ( nurl_str_get h k )
+        : i lo ( nurl_str_get h + k 1 )
+        : i hv ? <= hi 57 - hi 48 - hi 87
+        : i lv ? <= lo 57 - lo 48 - lo 87
+        ( vec_push [u] out # u + * hv 16 lv )
+        = k + k 2
+    }
+    ^ out
+}
+
+// Vec[u] → lowercase hex (binary-safe: indexed *u read)
+@ tohex ( Vec u ) v → String {
+    : i n ( vec_len [u] v )
+    : *u p ( vec_data [u] v )
+    : String out ( string_with_cap + * n 2 1 )
+    : ~ i k 0
+    ~ < k n {
+        : i b # i . p k
+        : i hi / b 16
+        : i lo % b 16
+        ( string_push_char out ? < hi 10 + 48 hi + 87 hi )
+        ( string_push_char out ? < lo 10 + 48 lo + 87 lo )
+        = k + k 1
+    }
+    ^ out
+}
+
+// decode a hex CBOR vector and print its JSON form (or the error name)
+@ dec s label s hexv → v {
+    ( nurl_print label ) ( nurl_print `: ` )
+    : ( Vec u ) bytes ( hx hexv )
+    : !Json CborErr r ( cbor_decode bytes )
+    ?? r {
+        T j → { : String s ( json_stringify j ) ( nurl_print ( string_data s ) ) ( string_free s ) ( json_free j ) }
+        F e → ( nurl_print ( cbor_err_name # CborErr e ) )
+    }
+    ( vec_free [u] bytes )
+    ( nurl_print `\n` )
+}
+
+@ main → i {
+    // ── (1) round-trip + canonical encoding ──
+    : !Json JsonError pj ( json_parse `{"id":42,"name":"NURL","ok":true,"tags":[1,2,3],"pi":3.5,"neg":-7,"nil":null}` )
+    ?? pj {
+        T doc → {
+            : !( Vec u ) CborErr er ( cbor_encode doc )
+            ?? er {
+                T bytes → {
+                    : String hexs ( tohex bytes )
+                    ( nurl_print `encode_hex=` ) ( nurl_print ( string_data hexs ) ) ( nurl_print `\n` )
+                    ( string_free hexs )
+                    : !Json CborErr dr ( cbor_decode bytes )
+                    ?? dr {
+                        T back → {
+                            : String s ( json_stringify back )
+                            ( nurl_print `roundtrip=` ) ( nurl_print ( string_data s ) ) ( nurl_print `\n` )
+                            ( string_free s ) ( json_free back )
+                        }
+                        F _ → ( nurl_print `roundtrip DECODE ERR\n` )
+                    }
+                    ( vec_free [u] bytes )
+                }
+                F _ → ( nurl_print `encode ERR\n` )
+            }
+            ( json_free doc )
+        }
+        F _ → ( nurl_print `parse ERR\n` )
+    }
+
+    // ── (2) RFC 8949 Appendix A decode vectors ──
+    ( dec `u0` `00` )                 // 0
+    ( dec `u23` `17` )                // 23
+    ( dec `u24` `1818` )              // 24 (1-byte arg)
+    ( dec `u255` `18ff` )             // 255
+    ( dec `u256` `190100` )           // 256 (2-byte)
+    ( dec `u65535` `19ffff` )         // 65535
+    ( dec `u1m` `1a000f4240` )        // 1000000 (4-byte)
+    ( dec `neg1` `20` )               // -1
+    ( dec `neg100` `3863` )           // -100
+    ( dec `neg1000` `3903e7` )        // -1000
+    ( dec `str` `6449455446` )        // "IETF"
+    ( dec `emptystr` `60` )           // ""
+    ( dec `arr` `83010203` )          // [1,2,3]
+    ( dec `nested` `8301820203820405` ) // [1,[2,3],[4,5]]
+    ( dec `map` `a26161016162820203` ) // {"a":1,"b":[2,3]}
+    ( dec `false` `f4` )
+    ( dec `true` `f5` )
+    ( dec `null` `f6` )
+    ( dec `undef` `f7` )              // → null
+    // floats: half / single / double
+    ( dec `half_1.0` `f93c00` )       // 1.0
+    ( dec `half_1.5` `f93e00` )       // 1.5
+    ( dec `half_neg4` `f9c400` )      // -4.0
+    ( dec `half_0` `f90000` )         // 0.0
+    ( dec `single_100000` `fa47c35000` ) // 100000.0
+    ( dec `double_1.1` `fb3ff199999999999a` ) // 1.1
+    ( dec `double_pi` `fb400921fb54442d18` )   // 3.141592653589793
+
+    // ── (3) documented rejections ──
+    ( dec `bytestring` `4401020304` )  // major 2 → unsupported
+    ( dec `tag` `c074323031332d30332d3231` ) // tag 0 (datetime) → unsupported
+    ( dec `indefinite_arr` `9f00ff` )  // → unsupported
+    ( dec `intkey_map` `a1010a` )      // {1:10} non-text key → bad-map-key
+    ( dec `trailing` `0000` )          // 0 then a stray byte → trailing-bytes
+    ( dec `truncated` `19ff` )         // 2-byte head, 1 byte present → truncated
+    ^ 0
+}

--- a/compiler/tests/outputs/cbor.txt
+++ b/compiler/tests/outputs/cbor.txt
@@ -1,0 +1,38 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+encode_hex=a7626964182a646e616d65644e55524c626f6bf5647461677383010203627069fb400c000000000000636e656726636e696cf6
+roundtrip={"id":42,"name":"NURL","ok":true,"tags":[1,2,3],"pi":3.5,"neg":-7,"nil":null}
+u0: 0
+u23: 23
+u24: 24
+u255: 255
+u256: 256
+u65535: 65535
+u1m: 1000000
+neg1: -1
+neg100: -100
+neg1000: -1000
+str: "IETF"
+emptystr: ""
+arr: [1,2,3]
+nested: [1,[2,3],[4,5]]
+map: {"a":1,"b":[2,3]}
+false: false
+true: true
+null: null
+undef: null
+half_1.0: 1
+half_1.5: 1.5
+half_neg4: -4
+half_0: 0
+single_100000: 100000
+double_1.1: 1.1
+double_pi: 3.14159
+bytestring: unsupported
+tag: unsupported
+indefinite_arr: unsupported
+intkey_map: bad-map-key
+trailing: trailing-bytes
+truncated: truncated

--- a/stdlib/ext/cbor.nu
+++ b/stdlib/ext/cbor.nu
@@ -1,0 +1,352 @@
+// stdlib/ext/cbor.nu — CBOR (RFC 8949) over the shared Json value.
+//
+// The IETF-standard binary serialization (used by COSE / WebAuthn / CTAP /
+// many IoT protocols), the sibling of MessagePack. Like ext/msgpack.nu it
+// works on the `Json` value, so every `json_*` accessor / `json_free` /
+// `json_stringify` operates on a decoded document:
+//
+//   ( cbor_encode Json j )       → !( Vec u ) CborErr
+//   ( cbor_decode ( Vec u ) v )  → !Json CborErr
+//
+// Value mapping (both directions):
+//   JNull ↔ 0xf6        JBool ↔ 0xf4/0xf5
+//   JNum (integral) ↔ major 0 (unsigned) / major 1 (negative), shortest head
+//   JNum (real)     → 0xfb float64 on encode; decode accepts float16/32/64
+//   JStr ↔ major 3 (UTF-8 text)
+//   JArr ↔ major 4    JObj ↔ major 5 (keys are text strings)
+//
+// Encode is canonical-ish: integers and lengths use the shortest head, so
+// equal documents serialize to equal bytes (no indefinite-length items,
+// no float64 where the value is integral). Decode is liberal: it accepts
+// every definite-length head and all three float widths.
+//
+// Out of scope (each → CborUnsupported on decode): byte strings (major 2 —
+// no Json mapping), tags (major 6), indefinite-length items, and simple
+// values other than false/true/null. CBOR `undefined` (0xf7) decodes to
+// JNull.
+
+$ `stdlib/ext/json.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+
+& `c` @ nurl_f64_bits f x → i
+& `c` @ nurl_f64_from_bits i bits → f
+& `c` @ nurl_f32_from_bits i bits → f
+
+: | CborErr {
+    CborDepth        // nested past CBOR_MAX_DEPTH
+    CborTruncated    // ran off the end of the buffer
+    CborBadHead      // reserved additional-info (28..30)
+    CborUnsupported  // byte string / tag / indefinite / exotic simple
+    CborBadType      // non-text map key
+    CborTrailing     // bytes left after one complete value
+    CborOther
+}
+
+: i CBOR_MAX_DEPTH 256
+
+@ cbor_err_name CborErr e → s {
+    ^ ?? e {
+        CborDepth → `depth-exceeded`
+        CborTruncated → `truncated`
+        CborBadHead → `bad-head`
+        CborUnsupported → `unsupported`
+        CborBadType → `bad-map-key`
+        CborTrailing → `trailing-bytes`
+        CborOther → `other`
+    }
+}
+
+// ── encoder ─────────────────────────────────────────────────────────
+
+// Emit a head: (major << 5) | argument, with the shortest length form.
+@ __cbor_head ( Vec u ) out i major i arg → v {
+    : i m << major 5
+    ? < arg 24 { ( vec_push [u] out # u | m arg ) } {
+        ? <= arg 255 {
+            ( vec_push [u] out # u | m 24 )
+            ( vec_push [u] out # u arg )
+        } {
+            ? <= arg 65535 {
+                ( vec_push [u] out # u | m 25 )
+                ( bytes_push_u16_be out # u16 arg )
+            } {
+                ? <= arg 4294967295 {
+                    ( vec_push [u] out # u | m 26 )
+                    ( bytes_push_u32_be out # u32 arg )
+                } {
+                    ( vec_push [u] out # u | m 27 )
+                    ( bytes_push_u64_be out # u64 arg )
+                }
+            }
+        }
+    }
+}
+
+@ cbor_encode Json j → !( Vec u ) CborErr {
+    : ( Vec u ) out ( vec_new [u] )
+    : i rc ( __cbor_enc j out 0 )
+    ? != rc 0 {
+        ( vec_free [u] out )
+        ^ @ !( Vec u ) CborErr { F @ CborErr { CborDepth } }
+    } {}
+    ^ @ !( Vec u ) CborErr { T out }
+}
+
+// Append the encoding of `j`. Returns 0 on success, 1 on depth overflow.
+@ __cbor_enc Json j ( Vec u ) out i depth → i {
+    ? > depth CBOR_MAX_DEPTH { ^ 1 } {}
+    ^ ?? j {
+        JNull → { ( vec_push [u] out # u 246 ) 0 }      // 0xf6
+        JBool bv → {
+            ? bv { ( vec_push [u] out # u 245 ) } { ( vec_push [u] out # u 244 ) }  // f5 / f4
+            0
+        }
+        JNum s → { ( __cbor_enc_num s out ) 0 }
+        JStr s → {
+            : i len ( string_len s )
+            ( __cbor_head out 3 len )
+            ( __cbor_push_bytes out ( string_data s ) len )
+            0
+        }
+        JArr v → {
+            ( __cbor_head out 4 ( vec_len [Json] v ) )
+            ( __cbor_enc_elems v out depth )
+        }
+        JObj v → {
+            ( __cbor_head out 5 / ( vec_len [Json] v ) 2 )
+            ( __cbor_enc_elems v out depth )
+        }
+    }
+}
+
+@ __cbor_push_bytes ( Vec u ) out s data i len → v {
+    : *u bp # *u data
+    : ~ i k 0
+    ~ < k len { ( vec_push [u] out . bp k ) = k + k 1 }
+}
+
+@ __cbor_enc_elems ( Vec Json ) v ( Vec u ) out i depth → i {
+    : i n ( vec_len [Json] v )
+    : ~ i k 0
+    : ~ i rc 0
+    ~ & < k n == rc 0 {
+        ?? ( vec_get [Json] v k ) { T e → { = rc ( __cbor_enc e out + depth 1 ) } F → {} }
+        = k + k 1
+    }
+    ^ rc
+}
+
+// A JNum carries the number as decimal text — integral → major 0/1,
+// otherwise a float64.
+@ __cbor_enc_num String s ( Vec u ) out → v {
+    ? ( __cbor_num_is_int s ) {
+        ?? ( string_to_int s ) {
+            T n → {
+                ? >= n 0 { ( __cbor_head out 0 n ) }
+                { ( __cbor_head out 1 - - 0 n 1 ) }     // major 1, arg = -1-n
+            }
+            F → ( __cbor_enc_f64_str s out )
+        }
+    } {
+        ( __cbor_enc_f64_str s out )
+    }
+}
+
+@ __cbor_num_is_int String s → b {
+    : i n ( string_len s )
+    : ~ i k 0
+    : ~ b isint T
+    ~ & < k n isint {
+        : i c ( string_get s k )
+        ? | | == c 46 == c 101 == c 69 { = isint F } {}   // . e E
+        = k + k 1
+    }
+    ^ isint
+}
+
+@ __cbor_enc_f64_str String s ( Vec u ) out → v {
+    : f x ?? ( string_to_float s ) { T fv → fv F → 0.0 }
+    ( vec_push [u] out # u 251 )                         // 0xfb float64
+    ( bytes_push_u64_be out # u64 ( nurl_f64_bits x ) )
+}
+
+// ── decoder ─────────────────────────────────────────────────────────
+
+: CborDec { s data i len i pos }
+
+@ __cd_new ( Vec u ) v → *CborDec {
+    : *CborDec p # *CborDec ( nurl_alloc Z CborDec )
+    = . p data # s ( vec_data [u] v )
+    = . p len ( vec_len [u] v )
+    = . p pos 0
+    ^ p
+}
+
+@ __cd_free * CborDec p → v { ( nurl_free # s p ) }
+@ __cd_remaining * CborDec p → i { ^ - . p len . p pos }
+
+@ __cd_u8 * CborDec p → i {
+    : *u d # *u . p data
+    : i idx . p pos
+    : i bb & 255 # i . d idx
+    = . p pos + idx 1
+    ^ bb
+}
+
+// Read `nbytes` big-endian into an unsigned i64 accumulator.
+@ __cd_be * CborDec p i nbytes → i {
+    : ~ i val 0
+    : ~ i k 0
+    ~ < k nbytes { = val + * val 256 ( __cd_u8 p ) = k + k 1 }
+    ^ val
+}
+
+// Decode the head argument for additional-info `ai` (majors 0–5). 24→1,
+// 25→2, 26→4, 27→8 length bytes; 28–30 reserved; 31 indefinite.
+@ __cd_arg * CborDec p i ai → !i CborErr {
+    ? < ai 24 { ^ @ !i CborErr { T ai } } {}
+    : i nbytes ? == ai 24 1 ? == ai 25 2 ? == ai 26 4 ? == ai 27 8 -1
+    ? < nbytes 0 {
+        ? == ai 31 { ^ @ !i CborErr { F @ CborErr { CborUnsupported } } } {}
+        ^ @ !i CborErr { F @ CborErr { CborBadHead } }
+    } {}
+    ? < ( __cd_remaining p ) nbytes { ^ @ !i CborErr { F @ CborErr { CborTruncated } } } {}
+    ^ @ !i CborErr { T ( __cd_be p nbytes ) }
+}
+
+@ cbor_decode ( Vec u ) v → !Json CborErr {
+    : *CborDec p ( __cd_new v )
+    : !Json CborErr r ( __cd_value p 0 )
+    ?? r {
+        T jv → {
+            ? > ( __cd_remaining p ) 0 {
+                ( json_free jv ) ( __cd_free p )
+                ^ @ !Json CborErr { F @ CborErr { CborTrailing } }
+            } {}
+            ( __cd_free p )
+            ^ @ !Json CborErr { T jv }
+        }
+        F e → { ( __cd_free p ) ^ @ !Json CborErr { F e } }
+    }
+}
+
+@ __cd_value * CborDec p i depth → !Json CborErr {
+    ? > depth CBOR_MAX_DEPTH { ^ @ !Json CborErr { F @ CborErr { CborDepth } } } {}
+    ? < ( __cd_remaining p ) 1 { ^ @ !Json CborErr { F @ CborErr { CborTruncated } } } {}
+    : i b ( __cd_u8 p )
+    : i major / b 32
+    : i ai & b 31
+    ? == major 7 { ^ ( __cd_simple p ai ) } {}
+    : !i CborErr ar ( __cd_arg p ai )
+    ?? ar {
+        T arg → {
+            ? == major 0 { ^ @ !Json CborErr { T ( json_int arg ) } } {}
+            ? == major 1 { ^ @ !Json CborErr { T ( json_int - - 0 arg 1 ) } } {}
+            ? == major 3 { ^ ( __cd_text p arg ) } {}
+            ? == major 4 { ^ ( __cd_array p arg depth ) } {}
+            ? == major 5 { ^ ( __cd_map p arg depth ) } {}
+            // major 2 (byte string) and 6 (tag) have no Json mapping.
+            ^ @ !Json CborErr { F @ CborErr { CborUnsupported } }
+        }
+        F e → { ^ @ !Json CborErr { F e } }
+    }
+}
+
+// Read `n` UTF-8 bytes as a JStr.
+@ __cd_text * CborDec p i n → !Json CborErr {
+    ? < ( __cd_remaining p ) n { ^ @ !Json CborErr { F @ CborErr { CborTruncated } } } {}
+    : String s ( string_with_cap + n 1 )
+    : ~ i k 0
+    ~ < k n { ( string_push_char s ( __cd_u8 p ) ) = k + k 1 }
+    : Json j ( json_str_lit ( string_data s ) )
+    ( string_free s )
+    ^ @ !Json CborErr { T j }
+}
+
+@ __cd_array * CborDec p i n i depth → !Json CborErr {
+    : Json arr ( json_arr_new )
+    : ~ i k 0
+    ~ < k n {
+        : !Json CborErr ev ( __cd_value p + depth 1 )
+        ?? ev {
+            T e → { : b _ok ( json_arr_push arr e ) }
+            F er → { ( json_free arr ) ^ @ !Json CborErr { F er } }
+        }
+        = k + k 1
+    }
+    ^ @ !Json CborErr { T arr }
+}
+
+@ __cd_map * CborDec p i n i depth → !Json CborErr {
+    : Json obj ( json_obj_new )
+    : ~ i k 0
+    ~ < k n {
+        : !Json CborErr kv ( __cd_value p + depth 1 )
+        ?? kv {
+            T key → {
+                ? ( json_is_str key ) {} {
+                    ( json_free key ) ( json_free obj )
+                    ^ @ !Json CborErr { F @ CborErr { CborBadType } }
+                }
+                : !Json CborErr vv ( __cd_value p + depth 1 )
+                ?? vv {
+                    T val → { : b _ok ( json_obj_set obj ( json_str_data key ) val ) ( json_free key ) }
+                    F er → { ( json_free key ) ( json_free obj ) ^ @ !Json CborErr { F er } }
+                }
+            }
+            F er → { ( json_free obj ) ^ @ !Json CborErr { F er } }
+        }
+        = k + k 1
+    }
+    ^ @ !Json CborErr { T obj }
+}
+
+// Major 7: false/true/null, undefined→null, and float16/32/64.
+@ __cd_simple * CborDec p i ai → !Json CborErr {
+    ? == ai 20 { ^ @ !Json CborErr { T ( json_bool F ) } } {}
+    ? == ai 21 { ^ @ !Json CborErr { T ( json_bool T ) } } {}
+    ? == ai 22 { ^ @ !Json CborErr { T ( json_null ) } } {}
+    ? == ai 23 { ^ @ !Json CborErr { T ( json_null ) } } {}   // undefined → null
+    ? == ai 25 {
+        ? < ( __cd_remaining p ) 2 { ^ @ !Json CborErr { F @ CborErr { CborTruncated } } } {}
+        ^ @ !Json CborErr { T ( json_float ( __cbor_half_to_f64 ( __cd_be p 2 ) ) ) }
+    } {}
+    ? == ai 26 {
+        ? < ( __cd_remaining p ) 4 { ^ @ !Json CborErr { F @ CborErr { CborTruncated } } } {}
+        ^ @ !Json CborErr { T ( json_float ( nurl_f32_from_bits ( __cd_be p 4 ) ) ) }
+    } {}
+    ? == ai 27 {
+        ? < ( __cd_remaining p ) 8 { ^ @ !Json CborErr { F @ CborErr { CborTruncated } } } {}
+        ^ @ !Json CborErr { T ( json_float ( nurl_f64_from_bits ( __cd_be p 8 ) ) ) }
+    } {}
+    // simple value 0..19 / 24 / break (31) — no Json mapping
+    ^ @ !Json CborErr { F @ CborErr { CborUnsupported } }
+}
+
+// IEEE half (16-bit) → f64, via the f32 bit pattern (handles zero,
+// subnormal, normal, inf, NaN).
+@ __cbor_half_to_f64 i h → f {
+    : i sign << & / h 32768 1 31           // f32 sign bit
+    : i exp & / h 1024 31
+    : i mant & h 1023
+    : ~ i bits 0
+    ? == exp 0 {
+        ? == mant 0 { = bits sign } {
+            // subnormal half → normalize into an f32 normal
+            : ~ i e -1
+            : ~ i m mant
+            ~ == 0 & m 1024 { = m << m 1 = e - e 1 }
+            = m & m 1023
+            = bits | sign | << + e 127 23 << m 13
+        }
+    } {
+        ? == exp 31 {
+            = bits | sign | << 255 23 << mant 13          // inf / NaN
+        } {
+            = bits | sign | << + - exp 15 127 23 << mant 13   // normal
+        }
+    }
+    ^ ( nurl_f32_from_bits bits )
+}


### PR DESCRIPTION
## Summary

Closes critic.md **B16** — CBOR (RFC 8949), the IETF-standard binary serialization used by COSE / WebAuthn / CTAP and the sibling of MessagePack. Like `ext/msgpack.nu` it works over the shared `Json` value, so every `json_*` accessor / `json_free` / `json_stringify` operates on a decoded document.

```
cbor_encode Json j      → !( Vec u ) CborErr
cbor_decode ( Vec u ) v → !Json CborErr
```

## Encode (canonical) / decode (liberal)

- **Encode** uses the shortest head for every integer and length, and `float64` for reals — so equal documents serialize to equal bytes (no indefinite-length items).
- **Decode** accepts every definite-length head, signed/unsigned integers at all widths, and **all three float widths** — float16, float32, float64. The half-float decoder handles zero / subnormal / normal / inf / NaN by reconstructing the f32 bit pattern.

Value map: `JNull ↔ 0xf6`, `JBool ↔ 0xf4/0xf5`, integral `JNum ↔ major 0/1`, real `JNum → 0xfb`, `JStr ↔ major 3`, `JArr ↔ major 4`, `JObj ↔ major 5`.

Out of scope → `CborUnsupported`: byte strings (no Json type), tags, indefinite-length items, exotic simple values. `undefined` (0xf7) → `JNull`; a non-text map key → `CborBadType`; leftover bytes → `CborTrailing`.

## Correctness — what the test pins

`compiler/tests/cbor.nu`:
- A representative document round-trips `Json → CBOR → Json` and the bytes are checked to be the canonical shortest-head encoding.
- The **RFC 8949 Appendix A** decode vectors: integer size boundaries (0, 23, 24, 255, 256, 65535, 1000000), negatives (-1, -100, -1000), strings, nested `[1,[2,3],[4,5]]` and `{"a":1,"b":[2,3]}`, false/true/null/undefined, and floats `f93c00`→1.0, `f93e00`→1.5, `f9c400`→-4.0, `fa47c35000`→100000, `fb3ff199999999999a`→1.1, `fb400921fb54442d18`→π.
- Every documented rejection: byte string, tag, indefinite array, int-keyed map, trailing bytes, truncated head.

## Verification

- `./build.sh`: bootstrap fixed point + full suite **350 PASS**
- **ASan + UBSan + LSan clean** — the error paths free the partially built tree (the rejection vectors exercise them)
- `./tools/check_examples.sh`: **PASS 62**
- `nurlc --lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
