### PR TITLE
stdlib: Unix domain sockets (std/unixsock.nu, B9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Unix domain sockets — `stdlib/std/unixsock.nu`** (critic B9). The
+  local-IPC sibling of `std/net.nu`'s TCP, same API shape but a
+  filesystem path instead of host:port — for Postgres-over-socket,
+  systemd-style services, container control planes. `unix_listen` /
+  `unix_accept` / `unix_connect` / `unix_socketpair` / `unix_read_chunk`
+  / `unix_write_all` / `unix_write_str` / `unix_close_conn` /
+  `unix_close_listener` (which unlinks the socket file). Pure libc FFI
+  (blocking SOCK_STREAM); `unix_listen` unlinks any stale path before
+  binding. Adds `AF_UNIX` / `SOCK_STREAM` / `EADDRINUSE` to the runtime's
+  `nurl_native_constant` table (POSIX-only; the module degrades to a
+  clean `UnixSocket` error on Win32/WASI). Lock:
+  `compiler/tests/unixsock.nu` — a deterministic `socketpair` round-trip
+  (both directions + EOF-after-close) plus a thread-driven
+  listen/accept/connect echo gated on `NURL_NET_TESTS`; ASan+UBSan+LSan
+  clean on both paths.
+
 - **CBOR (RFC 8949) — `stdlib/ext/cbor.nu`** (critic B16). The
   IETF-standard binary serialization (COSE / WebAuthn / CTAP), sibling of
   MessagePack, over the shared `Json` value: `cbor_encode Json →

--- a/compiler/tests/outputs/unixsock.txt
+++ b/compiler/tests/outputs/unixsock.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+err_names=UnixBind,UnixAddrInUse,UnixConnect
+pair a→b: ping
+pair b→a: pong!
+pair eof_after_close: T
+live unix round-trip skipped

--- a/compiler/tests/unixsock.nu
+++ b/compiler/tests/unixsock.nu
@@ -1,0 +1,153 @@
+// unixsock.nu — std/unixsock.nu acceptance.
+//
+// The deterministic core uses socketpair() — a pure syscall, no path /
+// bind / listen / accept / thread — to exercise the read/write/close
+// path both directions. The full listen+accept+connect round-trip (with
+// a server thread over a /tmp socket) is gated on NURL_NET_TESTS=1, the
+// same convention as the TCP/websocket live tests.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/unixsock.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/ext/env.nu`
+
+@ str_to_vec s in → ( Vec u ) {
+    : i n ( nurl_str_len in )
+    : ( Vec u ) out ( vec_with_cap [u] ? > n 0 n 1 )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] out # u ( nurl_str_get in k ) ) = k + k 1 }
+    ^ out
+}
+
+@ vec_to_str ( Vec u ) v → String {
+    : i n ( vec_len [u] v )
+    : *u p ( vec_data [u] v )
+    : String out ( string_with_cap + n 1 )
+    : ~ i k 0
+    ~ < k n { ( string_push_char out # i . p k ) = k + k 1 }
+    ^ out
+}
+
+@ main → i {
+    // ── error name table ──
+    ( nurl_print `err_names=` )
+    ( nurl_print ( unix_err_name # UnixErr UnixBind ) ) ( nurl_print `,` )
+    ( nurl_print ( unix_err_name # UnixErr UnixAddrInUse ) ) ( nurl_print `,` )
+    ( nurl_print ( unix_err_name # UnixErr UnixConnect ) ) ( nurl_print `\n` )
+
+    // ── socketpair round-trip (deterministic) ──
+    : !UnixPair UnixErr pr ( unix_socketpair )
+    ?? pr {
+        T pair → {
+            : UnixConn a . pair a
+            : UnixConn b . pair b
+            // a → b
+            : ( Vec u ) msg ( str_to_vec `ping` )
+            : !v UnixErr wr ( unix_write_all a msg )
+            ?? wr { T _ → {} F e → { ( nurl_print `write FAILED ` ) ( nurl_print ( unix_err_name # UnixErr e ) ) ( nurl_print `\n` ) } }
+            ( vec_free [u] msg )
+            : !( Vec u ) UnixErr rd ( unix_read_chunk b 64 )
+            ?? rd {
+                T got → {
+                    : String s ( vec_to_str got )
+                    ( nurl_print `pair a→b: ` ) ( nurl_print ( string_data s ) ) ( nurl_print `\n` )
+                    ( string_free s ) ( vec_free [u] got )
+                }
+                F _ → ( nurl_print `read FAILED\n` )
+            }
+            // b → a (other direction)
+            : ( Vec u ) msg2 ( str_to_vec `pong!` )
+            : !v UnixErr wr2 ( unix_write_all b msg2 )
+            ?? wr2 { T _ → {} F _ → {} }
+            ( vec_free [u] msg2 )
+            : !( Vec u ) UnixErr rd2 ( unix_read_chunk a 64 )
+            ?? rd2 {
+                T got → {
+                    : String s ( vec_to_str got )
+                    ( nurl_print `pair b→a: ` ) ( nurl_print ( string_data s ) ) ( nurl_print `\n` )
+                    ( string_free s ) ( vec_free [u] got )
+                }
+                F _ → ( nurl_print `read2 FAILED\n` )
+            }
+            // close one end, read on the other → EOF (empty Vec)
+            ( unix_close_conn a )
+            : !( Vec u ) UnixErr eofr ( unix_read_chunk b 64 )
+            ?? eofr {
+                T got → {
+                    ( nurl_print `pair eof_after_close: ` )
+                    ( nurl_print ? == 0 ( vec_len [u] got ) `T` `F` ) ( nurl_print `\n` )
+                    ( vec_free [u] got )
+                }
+                F _ → ( nurl_print `eof read err\n` )
+            }
+            ( unix_close_conn b )
+        }
+        F e → { ( nurl_print `socketpair FAILED ` ) ( nurl_print ( unix_err_name # UnixErr e ) ) ( nurl_print `\n` ) }
+    }
+
+    // ── full listen/accept/connect round-trip (gated) ──
+    : ?String gate ( env_get `NURL_NET_TESTS` )
+    ?? gate {
+        T g → {
+            ? == 1 ( nurl_str_eq ( string_data g ) `1` ) { ( __live_roundtrip ) } { ( nurl_print `live unix round-trip skipped\n` ) }
+            ( string_free g )
+        }
+        F → ( nurl_print `live unix round-trip skipped\n` )
+    }
+    ^ 0
+}
+
+// Server thread reads one chunk and echoes it back, then closes.
+: ~ i g_srv_path 0   // sym handle carrying the socket path to the thread
+: ~ i g_done 0
+
+@ __live_roundtrip → v {
+    : String path ( string_with_cap 48 )
+    ( string_push_str path `/tmp/nurl_unixsock_` )
+    ( string_push_str path ( nurl_str_int ( getpid ) ) )
+    ( string_push_str path `.sock` )
+    : !UnixListener UnixErr lr ( unix_listen ( string_data path ) )
+    ?? lr {
+        T listener → {
+            // server fiber: accept one conn, echo a chunk
+            : ( @ v ) server_fn \ → v {
+                : !UnixConn UnixErr ar ( unix_accept listener )
+                ?? ar {
+                    T conn → {
+                        : !( Vec u ) UnixErr rd ( unix_read_chunk conn 64 )
+                        ?? rd { T got → { : !v UnixErr _w ( unix_write_all conn got ) ?? _w { T _ → {} F _ → {} } ( vec_free [u] got ) } F _ → {} }
+                        ( unix_close_conn conn )
+                    }
+                    F _ → {}
+                }
+            }
+            : !Thread ThreadErr st ( thread_spawn server_fn )
+            ?? st {
+                T th → {
+                    : !UnixConn UnixErr cr ( unix_connect ( string_data path ) )
+                    ?? cr {
+                        T client → {
+                            : ( Vec u ) msg ( str_to_vec `hello-unix` )
+                            : !v UnixErr _w ( unix_write_all client msg )
+                            ?? _w { T _ → {} F _ → {} }
+                            ( vec_free [u] msg )
+                            : !( Vec u ) UnixErr echo ( unix_read_chunk client 64 )
+                            ?? echo {
+                                T got → { : String s ( vec_to_str got ) ( nurl_print `live echo: ` ) ( nurl_print ( string_data s ) ) ( nurl_print `\n` ) ( string_free s ) ( vec_free [u] got ) }
+                                F _ → ( nurl_print `live echo err\n` )
+                            }
+                            ( unix_close_conn client )
+                        }
+                        F _ → ( nurl_print `live connect err\n` )
+                    }
+                    : i _j ( thread_join th )
+                }
+                F _ → ( nurl_print `live thread spawn err\n` )
+            }
+            ( unix_close_listener listener )
+        }
+        F _ → ( nurl_print `live listen err\n` )
+    }
+    ( string_free path )
+}

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -938,6 +938,12 @@ long long nurl_native_constant(const char *name) {
     if (strcmp(name, "EWOULDBLOCK") == 0) return EWOULDBLOCK;
     if (strcmp(name, "EPIPE")       == 0) return EPIPE;
     if (strcmp(name, "ERANGE")      == 0) return ERANGE;
+    if (strcmp(name, "EADDRINUSE")  == 0) return EADDRINUSE;
+#if !defined(_WIN32) && !defined(__wasi__)
+    /* AF_UNIX / SOCK_STREAM for stdlib/std/unixsock.nu (local IPC). */
+    if (strcmp(name, "AF_UNIX")     == 0) return AF_UNIX;
+    if (strcmp(name, "SOCK_STREAM") == 0) return SOCK_STREAM;
+#endif
     /* CLOCK_* values differ per platform (CLOCK_MONOTONIC is 6 on
      * macOS, 1 elsewhere); wasi-libc spells them as pointer macros. */
 #ifdef CLOCK_REALTIME

--- a/stdlib/std/unixsock.nu
+++ b/stdlib/std/unixsock.nu
@@ -1,0 +1,216 @@
+// stdlib/std/unixsock.nu — Unix domain sockets (AF_UNIX, local IPC).
+//
+// The local-only sibling of std/net.nu's TCP, same API shape: a
+// filesystem-path rendezvous instead of host:port. Use it for
+// Postgres-over-socket, systemd-style services, container control
+// planes, or any same-host process-to-process channel — no TCP/IP
+// stack, no port, and the kernel enforces filesystem permissions on
+// the socket path.
+//
+// Pure libc FFI (socket/bind/listen/accept/connect/socketpair over
+// blocking SOCK_STREAM); no runtime bridge. POSIX only — the AF_UNIX /
+// SOCK_STREAM constants resolve to -1 on Win32/WASI, and every entry
+// point fails cleanly (UnixSocket) there.
+//
+//   ( unix_listen   s path )                 → ! UnixListener UnixErr
+//   ( unix_listen_with_backlog s path i n )   → ! UnixListener UnixErr
+//   ( unix_accept   UnixListener l )          → ! UnixConn UnixErr
+//   ( unix_connect  s path )                  → ! UnixConn UnixErr
+//   ( unix_socketpair )                       → ! UnixPair UnixErr
+//   ( unix_read_chunk UnixConn c i max )      → ! ( Vec u ) UnixErr  (empty = EOF)
+//   ( unix_write_all  UnixConn c ( Vec u ) )  → ! v UnixErr
+//   ( unix_write_str  UnixConn c s text )     → ! v UnixErr
+//   ( unix_close_conn UnixConn c )            → v
+//   ( unix_close_listener UnixListener l )    → v   (close + unlink the path)
+//
+// UnixListener / UnixConn own a raw fd; close them (close_conn /
+// close_listener). unix_listen unlinks any stale socket file at `path`
+// before binding, and close_listener unlinks it on the way out.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/posix.nu`   // read / write / close / posix_const / errno
+
+& `c` @ socket i32 domain i32 type i32 proto → i32
+& `c` @ bind i32 fd s addr i32 len → i32
+& `c` @ listen i32 fd i32 backlog → i32
+& `c` @ accept i32 fd s addr s addrlen → i32
+& `c` @ connect i32 fd s addr i32 len → i32
+& `c` @ socketpair i32 domain i32 type i32 proto s sv → i32
+& `c` @ unlink s path → i32
+
+: | UnixErr {
+    UnixSocket      // socket() failed (or AF_UNIX unsupported on this OS)
+    UnixBind        // bind() failed
+    UnixAddrInUse   // bind() failed with EADDRINUSE
+    UnixListen      // listen() failed
+    UnixAccept      // accept() failed
+    UnixConnect     // connect() failed
+    UnixRead        // read() failed
+    UnixWrite       // write() failed
+    UnixClosed      // peer closed mid-write
+    UnixOther
+}
+
+: UnixListener { i fd String path }
+: UnixConn { i fd }
+: UnixPair { UnixConn a UnixConn b }
+
+@ unix_err_name UnixErr e → s {
+    ^ ?? e {
+        UnixSocket → `UnixSocket`
+        UnixBind → `UnixBind`
+        UnixAddrInUse → `UnixAddrInUse`
+        UnixListen → `UnixListen`
+        UnixAccept → `UnixAccept`
+        UnixConnect → `UnixConnect`
+        UnixRead → `UnixRead`
+        UnixWrite → `UnixWrite`
+        UnixClosed → `UnixClosed`
+        UnixOther → `UnixOther`
+    }
+}
+
+// ── sockaddr_un ─────────────────────────────────────────────────────
+
+// Build a `struct sockaddr_un` { sun_family (2 bytes); sun_path[108] }
+// on the heap with family = AF_UNIX and the NUL-terminated `path`
+// copied in. Caller frees. The Linux sun_path ceiling is 108 bytes;
+// longer paths are truncated (bind will then fail cleanly).
+@ __un_addr s path → s {
+    : i af ( posix_const `AF_UNIX` )
+    : i pathlen ( nurl_str_len path )
+    : i cap ? > pathlen 107 107 pathlen
+    : s addr ( nurl_zalloc 110 )
+    : *u ap # *u addr
+    = . ap 0 # u & af 255
+    = . ap 1 # u & / af 256 255
+    : ~ i k 0
+    ~ < k cap { = . ap + 2 k # u ( nurl_str_get path k ) = k + k 1 }
+    ^ addr
+}
+
+// socklen for a path: offsetof(sun_path)=2 + path + NUL.
+@ __un_socklen s path → i {
+    : i pathlen ( nurl_str_len path )
+    : i cap ? > pathlen 107 107 pathlen
+    ^ + + 2 cap 1
+}
+
+// errno → UnixErr, with `dflt` for anything unmapped.
+@ __un_errno UnixErr dflt → UnixErr {
+    ? == ( nurl_errno_get ) ( posix_const `EADDRINUSE` ) { ^ # UnixErr UnixAddrInUse } {}
+    ^ dflt
+}
+
+// ── listener ────────────────────────────────────────────────────────
+
+@ unix_listen_with_backlog s path i backlog → !UnixListener UnixErr {
+    : i32 fd ( socket # i32 ( posix_const `AF_UNIX` ) # i32 ( posix_const `SOCK_STREAM` ) # i32 0 )
+    ? < # i fd 0 { ^ @ !UnixListener UnixErr { F UnixSocket } } {}
+    // clear any stale socket file (ignore result)
+    : i32 _u ( unlink path )
+    : s addr ( __un_addr path )
+    : i32 br ( bind fd addr # i32 ( __un_socklen path ) )
+    ( nurl_free addr )
+    ? < # i br 0 {
+        : i _c ( close # i fd )
+        ^ @ !UnixListener UnixErr { F ( __un_errno # UnixErr UnixBind ) }
+    } {}
+    : i32 lr ( listen fd # i32 backlog )
+    ? < # i lr 0 {
+        : i _c ( close # i fd )
+        ^ @ !UnixListener UnixErr { F UnixListen }
+    } {}
+    ^ @ !UnixListener UnixErr { T @ UnixListener { # i fd ( string_from path ) } }
+}
+
+@ unix_listen s path → !UnixListener UnixErr {
+    ^ ( unix_listen_with_backlog path 128 )
+}
+
+@ unix_accept UnixListener l → !UnixConn UnixErr {
+    : i32 cfd ( accept # i32 . l fd # s 0 # s 0 )
+    ? < # i cfd 0 { ^ @ !UnixConn UnixErr { F UnixAccept } } {}
+    ^ @ !UnixConn UnixErr { T @ UnixConn { # i cfd } }
+}
+
+@ unix_close_listener UnixListener l → v {
+    : i _c ( close . l fd )
+    : i32 _u ( unlink ( string_data . l path ) )
+    ( string_free . l path )
+}
+
+// ── connect / socketpair ────────────────────────────────────────────
+
+@ unix_connect s path → !UnixConn UnixErr {
+    : i32 fd ( socket # i32 ( posix_const `AF_UNIX` ) # i32 ( posix_const `SOCK_STREAM` ) # i32 0 )
+    ? < # i fd 0 { ^ @ !UnixConn UnixErr { F UnixSocket } } {}
+    : s addr ( __un_addr path )
+    : i32 cr ( connect fd addr # i32 ( __un_socklen path ) )
+    ( nurl_free addr )
+    ? < # i cr 0 {
+        : i _c ( close # i fd )
+        ^ @ !UnixConn UnixErr { F UnixConnect }
+    } {}
+    ^ @ !UnixConn UnixErr { T @ UnixConn { # i fd } }
+}
+
+@ unix_socketpair → !UnixPair UnixErr {
+    : s sv ( nurl_zalloc 8 )
+    : i32 r ( socketpair # i32 ( posix_const `AF_UNIX` ) # i32 ( posix_const `SOCK_STREAM` ) # i32 0 sv )
+    ? < # i r 0 {
+        ( nurl_free sv )
+        ^ @ !UnixPair UnixErr { F UnixSocket }
+    } {}
+    : *i32 sp # *i32 sv
+    : i fd0 # i . sp 0
+    : i fd1 # i . sp 1
+    ( nurl_free sv )
+    ^ @ !UnixPair UnixErr { T @ UnixPair { @ UnixConn { fd0 } @ UnixConn { fd1 } } }
+}
+
+// ── read / write ────────────────────────────────────────────────────
+
+@ unix_read_chunk UnixConn c i max → !( Vec u ) UnixErr {
+    ? <= max 0 { ^ @ !( Vec u ) UnixErr { T ( vec_new [u] ) } } {}
+    : ( Vec u ) buf ( vec_with_cap [u] max )
+    : *u dst ( vec_data [u] buf )
+    : i n ( read . c fd dst max )
+    ? < n 0 {
+        ( vec_free [u] buf )
+        ^ @ !( Vec u ) UnixErr { F UnixRead }
+    } {}
+    : b _ok ( vec_set_len [u] buf n )
+    ^ @ !( Vec u ) UnixErr { T buf }   // empty Vec ⇒ EOF
+}
+
+@ unix_write_all UnixConn c ( Vec u ) bytes → !v UnixErr {
+    : i total ( vec_len [u] bytes )
+    : *u data ( vec_data [u] bytes )
+    : ~ i off 0
+    ~ < off total {
+        : i n ( write . c fd # *u + # i data off - total off )
+        ? < n 0 { ^ @ !v UnixErr { F UnixWrite } } {}
+        ? == n 0 { ^ @ !v UnixErr { F UnixClosed } } {}
+        = off + off n
+    }
+    ^ @ !v UnixErr { T 0 }
+}
+
+@ unix_write_str UnixConn c s text → !v UnixErr {
+    : i len ( nurl_str_len text )
+    : ~ i off 0
+    : *u data # *u text
+    ~ < off len {
+        : i n ( write . c fd # *u + # i data off - len off )
+        ? < n 0 { ^ @ !v UnixErr { F UnixWrite } } {}
+        ? == n 0 { ^ @ !v UnixErr { F UnixClosed } } {}
+        = off + off n
+    }
+    ^ @ !v UnixErr { T 0 }
+}
+
+@ unix_close_conn UnixConn c → v {
+    : i _c ( close . c fd )
+}


### PR DESCRIPTION
## Summary

Closes critic.md **B9** — Unix domain sockets, the local-IPC sibling of `std/net.nu`'s TCP. Same API shape, but a filesystem path instead of host:port: for Postgres-over-socket, systemd-style local services, and container-side control planes.

## API (`stdlib/std/unixsock.nu`)

```
unix_listen   s path                 → ! UnixListener UnixErr   (backlog 128)
unix_listen_with_backlog s path i n   → ! UnixListener UnixErr
unix_accept   UnixListener l          → ! UnixConn UnixErr
unix_connect  s path                  → ! UnixConn UnixErr
unix_socketpair                       → ! UnixPair UnixErr       (connected fd pair, no path)
unix_read_chunk UnixConn c i max      → ! ( Vec u ) UnixErr      (empty Vec = EOF)
unix_write_all  UnixConn c ( Vec u )  → ! v UnixErr
unix_write_str  UnixConn c s text     → ! v UnixErr
unix_close_conn UnixConn c            → v
unix_close_listener UnixListener l    → v   (close + unlink the socket file)
```

Pure libc FFI over blocking `SOCK_STREAM` (`socket`/`bind`/`listen`/`accept`/`connect`/`socketpair`, `read`/`write`/`close` from `core/posix`); `unix_listen` unlinks any stale socket file before binding, `unix_close_listener` unlinks it on the way out. Shipped as its own self-contained module (own `UnixErr`, core + posix only) rather than bloating `net.nu`'s TCP/HTTP foundation.

Adds `AF_UNIX` / `SOCK_STREAM` / `EADDRINUSE` to the runtime's `nurl_native_constant` table (POSIX-only — the module returns a clean `UnixSocket` error on Win32/WASI where they resolve to -1). The constant addition is rebuilt by `build.sh` and does not touch the compiler bootstrap.

## Verification

- `./build.sh`: bootstrap fixed point + full suite **349 PASS** (runtime rebuilt with the new constants)
- **ASan + UBSan + LSan clean** on both the default and the live path
- `./tools/check_examples.sh`: **PASS 62**
- `nurlc --lint`: clean
- Lock: `compiler/tests/unixsock.nu` — a deterministic `socketpair()` round-trip (both directions + EOF-after-close, no path/bind/thread) is the golden core; the full listen+accept+connect echo runs over a `/tmp` socket with a server thread, gated on `NURL_NET_TESTS` like the TCP/websocket live tests. Live run prints `live echo: hello-unix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
