### PR TITLE
stdlib: B-tree OrdMap, terminal control, ZIP, SMTP (B18/B10/B15/B17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **B-tree ordered map — `stdlib/std/btree.nu`** (critic B18). A
+  `BTree [K V]` with O(log n) insert / lookup / delete, replacing the
+  array-shift backing for large ordered maps. Classic CLRS proactive
+  split-on-descent and borrow/merge-on-descent (minimum degree 8, so up
+  to 15 keys per node) keep the tree balanced; each node also caches its
+  subtree size, which makes `btree_key_at` / `btree_val_at` order-
+  statistic queries (the *i*-th smallest key) O(log n) too. API:
+  `btree_new` / `btree_len` / `btree_is_empty` / `btree_get` /
+  `btree_contains` / `btree_set` / `btree_remove` / `btree_min_key` /
+  `btree_max_key` / `btree_key_at` / `btree_val_at` / `btree_each` /
+  `btree_free` / `btree_free_with`. Nodes are raw 6-slot blocks with
+  typed-pointer access (the same generic-container pattern as
+  `std/set.nu`). Lock: `compiler/tests/btree_basic.nu` — a 2000-key
+  scrambled fill with replace, remove-every-third churn, order-statistic
+  and ascending-iteration checks, and full drain; ASan+UBSan+LSan clean.
+
+- **Terminal control — `stdlib/std/term.nu`** (critic B10). The
+  prerequisite for a REPL and TUI examples: POSIX termios raw mode
+  (`term_raw_enable` / `term_raw_disable`, with `struct termios` sized
+  via `nurl_native_sizeof` so the platform layout never leaks into NURL),
+  `term_is_tty`, a full set of byte-exact ANSI builders (`ansi_reset` /
+  `ansi_sgr` / `ansi_fg` / `ansi_bg` / `ansi_clear` / `ansi_clear_line` /
+  `ansi_cursor_to` / `ansi_cursor_up`/`down`/`right`/`left`), and a
+  minimal raw-mode line editor (`term_read_line`) with printable insert,
+  backspace, ←/→, ↑/↓ history, Ctrl-A/E/K, and a clean not-a-tty None
+  fallback. Adds `TCSANOW` / `TCSAFLUSH` to the runtime's
+  `nurl_native_constant` table (POSIX-only; Win32/WASI return None from
+  raw mode while the ANSI builders still work — Windows Terminal speaks
+  VT). Lock: `compiler/tests/term_basic.nu` — the tty-independent surface
+  (None on a file fd, byte-exact ANSI hex); ASan+UBSan+LSan clean.
+
+- **ZIP archives — `stdlib/ext/zip.nu`** (critic B15). A reader and
+  writer for the ZIP format over the existing zlib FFI. Writer: `zip_new`
+  / `zip_add` (raw-deflate, windowBits −15, falling back to *store* when
+  deflate would not shrink the entry) / `zip_add_stored` / `zip_finish`,
+  emitting local headers, the central directory, and the EOCD with a
+  fixed DOS timestamp so archives are byte-deterministic. Reader:
+  `zip_open` (backward EOCD scan over the comment window, with zip64
+  rejected as unsupported) / `zip_count` / `zip_name_at` / `zip_size_at`
+  / `zip_extract` / `zip_extract_name` / `zip_close`, every extraction
+  CRC-32-validated. Lock: `compiler/tests/zip_basic.nu` — build (deflate
+  + store + a compressible 5000-byte entry), re-open, CRC-checked extract
+  of each entry, by-name extraction, missing-name and junk-archive
+  rejection; cross-checked against system `unzip -t`; ASan+UBSan+LSan
+  clean.
+
+- **SMTP client — `stdlib/ext/smtp.nu`** (critic B17). A mail-submission
+  client over the runtime's client-side TCP/TLS connect: `smtp_connect` /
+  `smtp_connect_tls`, EHLO capability discovery (`smtp_ehlo` /
+  `smtp_has_cap`), `smtp_starttls` (RFC 3207 — upgrades the live
+  plaintext fd to TLS and re-EHLOs), `smtp_auth_plain` / `smtp_auth_login`
+  (RFC 4954), the `smtp_mail_from` / `smtp_rcpt_to` / `smtp_data`
+  envelope (DATA dot-stuffs and terminates per RFC 5321 §4.5.2),
+  `smtp_quit` / `smtp_close`, plus a minimal RFC 5322 MIME builder
+  (`mime_build`), `smtp_dotstuff`, and `smtp_date_now`. STARTTLS needs to
+  upgrade an already-open fd, which the existing connect primitives could
+  not do, so this adds `nurl_tcp_starttls` to the runtime — the
+  client-handshake half of `nurl_tcp_connect_tls` applied in place. Lock:
+  `compiler/tests/smtp_basic.nu` — the offline surface (multiline reply
+  scanner/parser, AUTH PLAIN/LOGIN base64 tokens, dot-stuffing, MIME),
+  ASan+UBSan+LSan clean; `examples/smtp_send.nu` demonstrates the live
+  STARTTLS submission flow.
+
 - **Unix domain sockets — `stdlib/std/unixsock.nu`** (critic B9). The
   local-IPC sibling of `std/net.nu`'s TCP, same API shape but a
   filesystem path instead of host:port — for Postgres-over-socket,

--- a/compiler/tests/btree_basic.nu
+++ b/compiler/tests/btree_basic.nu
@@ -1,0 +1,174 @@
+// btree_basic.nu — std/btree.nu acceptance: B-tree ordered map.
+//
+// 2000 integer keys inserted in LCG-scrambled order (forces node splits
+// to depth ≥ 3 at t=8), full get/key_at verification, replace semantics,
+// removal of every key (exercising the borrow/merge paths and root
+// collapse), reinsertion after emptying, in-order traversal, and the
+// owned-element free_with discipline with String keys/values.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/btree.nu`
+
+: i N 2000
+
+@ main → i {
+    : ( @ i i i ) cmp \ i a i b → i { ^ - a b }
+    : ( BTree i i ) m ( btree_new [i i] )
+
+    // ── scrambled insert: k = (i*1103515245 + 12345) mod N walk ──
+    // visit each residue once via a full-period LCG over odd stride
+    : ~ i k 0
+    : ~ i ins_count 0
+    ~ < k N {
+        : i key % * + * k 7919 k 104729 N   // deterministic scramble, dupes possible
+        : ?i prev ( btree_set [i i] m key * key 7 cmp )
+        ?? prev { T _ → {} F _ → { = ins_count + ins_count 1 } }
+        = k + k 1
+    }
+    // fill any residues the scramble missed (dupes replaced, not added)
+    : ~ i k2 0
+    ~ < k2 N {
+        : ?i had ( btree_get [i i] m k2 cmp )
+        ?? had { T _ → {} F _ → {
+            : ?i p2 ( btree_set [i i] m k2 * k2 7 cmp )
+            ?? p2 { T _ → {} F _ → { = ins_count + ins_count 1 } }
+        } }
+        = k2 + k2 1
+    }
+    ( nurl_print `len_after_fill=` ) ( nurl_print ( nurl_str_int ( btree_len [i i] m ) ) )
+    ( nurl_print ` (expect ` ) ( nurl_print ( nurl_str_int N ) ) ( nurl_print `)\n` )
+
+    // ── full get + key_at order-statistic check ──
+    : ~ i bad_get 0
+    : ~ i bad_at 0
+    : ~ i j 0
+    ~ < j N {
+        : ?i g ( btree_get [i i] m j cmp )
+        ?? g { T v → { ? != v * j 7 { = bad_get + bad_get 1 } {} } F _ → { = bad_get + bad_get 1 } }
+        : ?i ka ( btree_key_at [i i] m j )
+        ?? ka { T kk → { ? != kk j { = bad_at + bad_at 1 } {} } F _ → { = bad_at + bad_at 1 } }
+        = j + j 1
+    }
+    ( nurl_print `bad_get=` ) ( nurl_print ( nurl_str_int bad_get ) )
+    ( nurl_print ` bad_key_at=` ) ( nurl_print ( nurl_str_int bad_at ) ) ( nurl_print `\n` )
+
+    // ── min/max + val_at ──
+    ( nurl_print `min=` ) ?? ( btree_min_key [i i] m ) { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `none` ) }
+    ( nurl_print ` max=` ) ?? ( btree_max_key [i i] m ) { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `none` ) }
+    ( nurl_print ` val_at(500)=` ) ?? ( btree_val_at [i i] m 500 ) { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `none` ) }
+    ( nurl_print `\n` )
+
+    // ── replace returns Some(prev) ──
+    : ?i rp ( btree_set [i i] m 1234 -1 cmp )
+    ( nurl_print `replace_prev=` ) ?? rp { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `none` ) }
+    ( nurl_print ` len_same=` ) ( nurl_print ? == ( btree_len [i i] m ) N `T` `F` ) ( nurl_print `\n` )
+    : ?i _rb ( btree_set [i i] m 1234 * 1234 7 cmp )
+    ?? _rb { T _ → {} F _ → {} }
+
+    // ── remove every 3rd key (borrow/merge churn) ──
+    : ~ i removed 0
+    : ~ i r 0
+    ~ < r N {
+        : ?i out ( btree_remove [i i] m r cmp )
+        ?? out { T v → { ? == v * r 7 { = removed + removed 1 } {} } F _ → {} }
+        = r + r 3
+    }
+    ( nurl_print `removed_3rds=` ) ( nurl_print ( nurl_str_int removed ) )
+    ( nurl_print ` len=` ) ( nurl_print ( nurl_str_int ( btree_len [i i] m ) ) ) ( nurl_print `\n` )
+
+    // survivors intact, removed gone, order statistics still consistent
+    : ~ i bad2 0
+    : ~ i s 0
+    ~ < s N {
+        : ?i g2 ( btree_get [i i] m s cmp )
+        : b should_have != 0 % s 3
+        ?? g2 {
+            T v → { ? | ! should_have != v * s 7 { = bad2 + bad2 1 } {} }
+            F _ → { ? should_have { = bad2 + bad2 1 } {} }
+        }
+        = s + s 1
+    }
+    // key_at over the survivor sequence
+    : ~ i want 1
+    : ~ i ord 0
+    : ~ i bad3 0
+    ~ < want N {
+        ? != 0 % want 3 {
+            : ?i ka2 ( btree_key_at [i i] m ord )
+            ?? ka2 { T kk → { ? != kk want { = bad3 + bad3 1 } {} } F _ → { = bad3 + bad3 1 } }
+            = ord + ord 1
+        } {}
+        = want + want 1
+    }
+    ( nurl_print `bad_after_remove=` ) ( nurl_print ( nurl_str_int bad2 ) )
+    ( nurl_print ` bad_keyat_after=` ) ( nurl_print ( nurl_str_int bad3 ) ) ( nurl_print `\n` )
+
+    // ── in-order each: count + ascending check ──
+    : s asc_state ( nurl_zalloc 24 )   // slot0 prev, slot1 count, slot2 ok
+    ( nurl_poke asc_state 0 -1 )
+    ( nurl_poke asc_state 2 1 )
+    : ( @ v i i ) visit \ i kk i vv → v {
+        ? <= kk ( nurl_peek asc_state 0 ) { ( nurl_poke asc_state 2 0 ) } {}
+        ( nurl_poke asc_state 0 kk )
+        ( nurl_poke asc_state 1 + ( nurl_peek asc_state 1 ) 1 )
+    }
+    ( btree_each [i i] m visit )
+    ( nurl_print `each_count=` ) ( nurl_print ( nurl_str_int ( nurl_peek asc_state 1 ) ) )
+    ( nurl_print ` ascending=` ) ( nurl_print ? == ( nurl_peek asc_state 2 ) 1 `T` `F` ) ( nurl_print `\n` )
+    ( nurl_free asc_state )
+    : *u visit_env # *u visit 1
+    ( nurl_free # s visit_env )
+
+    // ── drain to empty (root collapse) + reinsert ──
+    : ~ i d 0
+    ~ < d N {
+        : ?i _o ( btree_remove [i i] m d cmp )
+        ?? _o { T _ → {} F _ → {} }
+        = d + d 1
+    }
+    ( nurl_print `drained: len=` ) ( nurl_print ( nurl_str_int ( btree_len [i i] m ) ) )
+    ( nurl_print ` empty=` ) ( nurl_print ? ( btree_is_empty [i i] m ) `T` `F` )
+    ( nurl_print ` min=` ) ?? ( btree_min_key [i i] m ) { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `none` ) }
+    ( nurl_print `\n` )
+    : ?i _ri ( btree_set [i i] m 42 99 cmp )
+    ?? _ri { T _ → {} F _ → {} }
+    ( nurl_print `reinsert: len=` ) ( nurl_print ( nurl_str_int ( btree_len [i i] m ) ) )
+    ( nurl_print ` get42=` ) ?? ( btree_get [i i] m 42 cmp ) { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `none` ) }
+    ( nurl_print `\n` )
+    ( btree_free [i i] m )
+    : *u cmp_env # *u cmp 1
+    ( nurl_free # s cmp_env )
+
+    // ── owned String keys+vals via free_with ──
+    : ( @ i String String ) scmp \ String a String b → i { ^ ( nurl_str_cmp ( string_data a ) ( string_data b ) ) }
+    : ( BTree String String ) sm ( btree_new [String String] )
+    : ~ i t 0
+    ~ < t 40 {
+        : String key ( string_with_cap 8 )
+        ( string_push_str key `k` )
+        ( string_push_str key ( nurl_str_int + 100 t ) )
+        : String val ( string_with_cap 8 )
+        ( string_push_str val `v` )
+        ( string_push_str val ( nurl_str_int t ) )
+        : ?String pv ( btree_set [String String] sm key val scmp )
+        ?? pv { T old → ( string_free old ) F _ → {} }
+        = t + t 1
+    }
+    ( nurl_print `smap len=` ) ( nurl_print ( nurl_str_int ( btree_len [String String] sm ) ) )
+    : String probe ( string_with_cap 8 )
+    ( string_push_str probe `k123` )
+    ( nurl_print ` get(k123)=` )
+    ?? ( btree_get [String String] sm probe scmp ) { T v → ( nurl_print ( string_data v ) ) F _ → ( nurl_print `none` ) }
+    ( nurl_print `\n` )
+    ( string_free probe )
+    : ( @ v String ) dk \ String x → v { ( string_free x ) }
+    : ( @ v String ) dv \ String x → v { ( string_free x ) }
+    ( btree_free_with [String String] sm dk dv )
+    : *u scmp_env # *u scmp 1
+    ( nurl_free # s scmp_env )
+    : *u dk_env # *u dk 1
+    ( nurl_free # s dk_env )
+    : *u dv_env # *u dv 1
+    ( nurl_free # s dv_env )
+    ^ 0
+}

--- a/compiler/tests/outputs/btree_basic.txt
+++ b/compiler/tests/outputs/btree_basic.txt
@@ -1,0 +1,14 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+len_after_fill=2000 (expect 2000)
+bad_get=0 bad_key_at=0
+min=0 max=1999 val_at(500)=3500
+replace_prev=8638 len_same=T
+removed_3rds=667 len=1333
+bad_after_remove=0 bad_keyat_after=0
+each_count=1333 ascending=T
+drained: len=0 empty=T min=none
+reinsert: len=1 get42=99
+smap len=40 get(k123)=v23

--- a/compiler/tests/outputs/smtp_basic.txt
+++ b/compiler/tests/outputs/smtp_basic.txt
@@ -1,0 +1,27 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+errs=SmtpConnect,SmtpTls,SmtpAuth,SmtpNoStartTls
+auth_plain=AGFsaWNlQGV4YW1wbGUuY29tAHMzY3JldA==
+login_user=YWxpY2VAZXhhbXBsZS5jb20=
+login_pass=czNjcmV0
+multi end=74 code=250
+one end=11 code=220
+trail end=8 code=354
+part end=-1 code=220
+dotstuff: line one<CR><LF>
+..leading dot<CR><LF>
+...two dots<CR><LF>
+last
+mime: From: alice@example.com<CR><LF>
+To: bob@example.org<CR><LF>
+Subject: Hi there<CR><LF>
+Date: Mon, 02 Jan 2006 15:04:05 +0000<CR><LF>
+MIME-Version: 1.0<CR><LF>
+Content-Type: text/plain; charset=utf-8<CR><LF>
+Content-Transfer-Encoding: 8bit<CR><LF>
+<CR><LF>
+Hello,<LF>
+this is a test.<LF>
+

--- a/compiler/tests/outputs/term_basic.txt
+++ b/compiler/tests/outputs/term_basic.txt
@@ -1,0 +1,18 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+file_is_tty=F
+raw_on_file=none
+termios_sized=T
+reset=1b5b306d
+bold=1b5b316d
+fg196=1b5b33383b353b3139366d
+bg21=1b5b34383b353b32316d
+clear=1b5b324a1b5b48
+clear_line=1b5b324b0d
+cursor_to_5_10=1b5b353b313048
+up3=1b5b3341
+down2=1b5b3242
+right7=1b5b3743
+left1=1b5b3144

--- a/compiler/tests/outputs/zip_basic.txt
+++ b/compiler/tests/outputs/zip_basic.txt
@@ -1,0 +1,14 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+archive_bytes=356
+magic_PK=T
+count=3
+entry 0: greeting.txt size=16 extract_ok=T crc_len=16
+entry 1: tiny.txt size=1 extract_ok=T crc_len=1
+entry 2: dir/big.dat size=5000 extract_ok=T crc_len=5000
+by_name greeting.txt=hello, zip world
+big_roundtrip_len_ok=T
+missing=not-found
+junk=bad-archive

--- a/compiler/tests/smtp_basic.nu
+++ b/compiler/tests/smtp_basic.nu
@@ -1,0 +1,110 @@
+// smtp_basic.nu — ext/smtp.nu acceptance for the offline surface.
+//
+// The live conversation (connect/EHLO/AUTH/MAIL/RCPT/DATA) needs a
+// real server, so it is exercised by examples, not here. What IS
+// goldenable — and what carries the protocol's actual logic — is built
+// pure: the reply scanner/parser (multiline continuation handling),
+// AUTH PLAIN/LOGIN base64 tokens, dot-stuffing transparency, and the
+// MIME builder. CR/LF are rendered <CR>/<LF> so the golden stays
+// byte-exact and readable.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/smtp.nu`
+
+@ pshow s label String v → v {
+    ( nurl_print label ) ( nurl_print `: ` )
+    : i n ( string_len v )
+    : ~ i k 0
+    ~ < k n {
+        : i ch ( string_get v k )
+        ? == ch 13 { ( nurl_print `<CR>` ) } {
+        ? == ch 10 { ( nurl_print `<LF>\n` ) } {
+            : String c ( string_with_cap 2 )
+            ( string_push_char c ch )
+            ( nurl_print ( string_data c ) )
+            ( string_free c )
+        } }
+        = k + k 1
+    }
+    ( nurl_print `\n` )
+    ( string_free v )
+}
+
+@ vappend_str ( Vec u ) v s txt → v {
+    : i n ( nurl_str_len txt )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] v # u ( nurl_str_get txt k ) ) = k + k 1 }
+}
+
+@ vappend_crlf ( Vec u ) v → v {
+    ( vec_push [u] v # u 13 ) ( vec_push [u] v # u 10 )
+}
+
+@ scan_show s label ( Vec u ) buf → v {
+    ( nurl_print label )
+    ( nurl_print ` end=` ) ( nurl_print ( nurl_str_int ( __smtp_reply_scan buf ) ) )
+    ( nurl_print ` code=` ) ( nurl_print ( nurl_str_int ( __smtp_reply_code buf ) ) )
+    ( nurl_print `\n` )
+}
+
+@ main → i {
+    // ── error names ──
+    ( nurl_print `errs=` )
+    ( nurl_print ( smtp_err_name # SmtpErr SmtpConnect ) ) ( nurl_print `,` )
+    ( nurl_print ( smtp_err_name # SmtpErr SmtpTls ) ) ( nurl_print `,` )
+    ( nurl_print ( smtp_err_name # SmtpErr SmtpAuth ) ) ( nurl_print `,` )
+    ( nurl_print ( smtp_err_name # SmtpErr SmtpNoStartTls ) ) ( nurl_print `\n` )
+
+    // ── AUTH PLAIN / LOGIN tokens ──
+    : String ap ( __smtp_auth_plain_token `alice@example.com` `s3cret` )
+    ( nurl_print `auth_plain=` ) ( nurl_print ( string_data ap ) ) ( nurl_print `\n` )
+    ( string_free ap )
+    : String lu ( b64_encode `alice@example.com` )
+    : String lp ( b64_encode `s3cret` )
+    ( nurl_print `login_user=` ) ( nurl_print ( string_data lu ) ) ( nurl_print `\n` )
+    ( nurl_print `login_pass=` ) ( nurl_print ( string_data lp ) ) ( nurl_print `\n` )
+    ( string_free lu ) ( string_free lp )
+
+    // ── reply scanner ──
+    : ( Vec u ) multi ( vec_new [u] )
+    ( vappend_str multi `250-mail.example.com` ) ( vappend_crlf multi )
+    ( vappend_str multi `250-PIPELINING` ) ( vappend_crlf multi )
+    ( vappend_str multi `250-STARTTLS` ) ( vappend_crlf multi )
+    ( vappend_str multi `250 AUTH PLAIN LOGIN` ) ( vappend_crlf multi )
+    ( scan_show `multi` multi )
+    ( vec_free [u] multi )
+
+    : ( Vec u ) one ( vec_new [u] )
+    ( vappend_str one `220 ready` ) ( vappend_crlf one )
+    ( scan_show `one` one )
+    ( vec_free [u] one )
+
+    // complete reply with trailing bytes of the next one already buffered
+    : ( Vec u ) trail ( vec_new [u] )
+    ( vappend_str trail `354 go` ) ( vappend_crlf trail )
+    ( vappend_str trail `25` )
+    ( scan_show `trail` trail )
+    ( vec_free [u] trail )
+
+    // incomplete (no terminating LF yet)
+    : ( Vec u ) part ( vec_new [u] )
+    ( vappend_str part `220 partial` ) ( vec_push [u] part # u 13 )
+    ( scan_show `part` part )
+    ( vec_free [u] part )
+
+    // ── dot-stuffing transparency ──
+    : String body ( string_with_cap 64 )
+    ( string_push_str body `line one` ) ( string_push_char body 10 )
+    ( string_push_str body `.leading dot` ) ( string_push_char body 10 )
+    ( string_push_str body `..two dots` ) ( string_push_char body 13 ) ( string_push_char body 10 )
+    ( string_push_str body `last` )
+    : String ds ( smtp_dotstuff ( string_data body ) )
+    ( string_free body )
+    ( pshow `dotstuff` ds )
+
+    // ── MIME builder (fixed date → deterministic) ──
+    : String msg ( mime_build `alice@example.com` `bob@example.org` `Hi there` `Hello,\nthis is a test.\n` `Mon, 02 Jan 2006 15:04:05 +0000` )
+    ( pshow `mime` msg )
+    ^ 0
+}

--- a/compiler/tests/term_basic.nu
+++ b/compiler/tests/term_basic.nu
@@ -1,0 +1,65 @@
+// term_basic.nu — std/term.nu acceptance (the tty-independent surface).
+//
+// isatty / raw-enable are checked against a plain file fd (never a
+// tty → deterministic F / None in any environment, including CI). The
+// ANSI builders are byte-exact-checked via hex (ESC is unprintable).
+// The raw-mode toggle and line editor need a real pty — exercised
+// manually / by examples, not goldenable here; term_raw_enable's
+// not-a-tty None path IS covered, which is the contract callers
+// (REPL fallback) rely on.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/posix.nu`
+$ `stdlib/std/term.nu`
+
+@ phex String v → v {
+    : i n ( string_len v )
+    : ~ i k 0
+    ~ < k n {
+        : i b ( string_get v k )
+        : i hi / b 16
+        : i lo % b 16
+        : String c ( string_with_cap 3 )
+        ( string_push_char c ? < hi 10 + 48 hi + 87 hi )
+        ( string_push_char c ? < lo 10 + 48 lo + 87 lo )
+        ( nurl_print ( string_data c ) )
+        ( string_free c )
+        = k + k 1
+    }
+}
+
+@ show s label String v → v {
+    ( nurl_print label ) ( nurl_print `=` )
+    ( phex v )
+    ( nurl_print `\n` )
+    ( string_free v )
+}
+
+@ main → i {
+    // ── a regular file fd is never a tty ──
+    : i32 fd ( open `/dev/null` # i32 ( posix_const `O_RDONLY` ) # i32 0 )
+    ( nurl_print `file_is_tty=` ) ( nurl_print ? ( term_is_tty # i fd ) `T` `F` ) ( nurl_print `\n` )
+    : ?TermState rs ( term_raw_enable # i fd )
+    ( nurl_print `raw_on_file=` )
+    ?? rs { T st → { ( nurl_print `Some(BUG)` ) ( term_raw_disable st ) } F _ → ( nurl_print `none` ) }
+    ( nurl_print `\n` )
+    : i _c ( close # i fd )
+
+    // ── struct termios is sized (POSIX) ──
+    ( nurl_print `termios_sized=` )
+    ( nurl_print ? > ( nurl_native_sizeof `struct termios` ) 0 `T` `F` ) ( nurl_print `\n` )
+
+    // ── ANSI builders, byte-exact ──
+    ( show `reset` ( ansi_reset ) )            // 1b5b306d
+    ( show `bold` ( ansi_sgr 1 ) )             // 1b5b316d
+    ( show `fg196` ( ansi_fg 196 ) )           // 1b5b33383b353b3139366d
+    ( show `bg21` ( ansi_bg 21 ) )             // 1b5b34383b353b32316d
+    ( show `clear` ( ansi_clear ) )            // 1b5b324a 1b5b48
+    ( show `clear_line` ( ansi_clear_line ) )  // 1b5b324b0d
+    ( show `cursor_to_5_10` ( ansi_cursor_to 5 10 ) )  // 1b5b353b313048
+    ( show `up3` ( ansi_cursor_up 3 ) )        // 1b5b3341
+    ( show `down2` ( ansi_cursor_down 2 ) )    // 1b5b3242
+    ( show `right7` ( ansi_cursor_right 7 ) )  // 1b5b3743
+    ( show `left1` ( ansi_cursor_left 1 ) )    // 1b5b3144
+    ^ 0
+}

--- a/compiler/tests/zip_basic.nu
+++ b/compiler/tests/zip_basic.nu
@@ -1,0 +1,108 @@
+// zip_basic.nu — ext/zip.nu acceptance: build an archive, re-open it,
+// extract every entry (CRC-checked), and confirm store-vs-deflate
+// selection. The archive bytes are written to /tmp so an external
+// `unzip -t` cross-check can run out-of-band; the golden itself is the
+// in-NURL round-trip (deterministic: fixed DOS timestamp).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/zip.nu`
+
+@ mkbytes s in → ( Vec u ) {
+    : i n ( nurl_str_len in )
+    : ( Vec u ) out ( vec_with_cap [u] ? > n 0 n 1 )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] out # u ( nurl_str_get in k ) ) = k + k 1 }
+    ^ out
+}
+
+// 5000 bytes of highly-compressible data (forces deflate to win)
+@ big_data → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] 5000 )
+    : ~ i k 0
+    ~ < k 5000 { ( vec_push [u] v # u + 97 % k 4 ) = k + k 1 }
+    ^ v
+}
+
+@ vshow s label ( Vec u ) v → v {
+    ( nurl_print label ) ( nurl_print `=` )
+    : String s ( bytes_to_str v )
+    ( nurl_print ( string_data s ) ) ( nurl_print `\n` )
+    ( string_free s )
+}
+
+@ main → i {
+    // ── build ──
+    : Zip z ( zip_new )
+    : ( Vec u ) d1 ( mkbytes `hello, zip world` )
+    : !v ZipErr a1 ( zip_add z `greeting.txt` d1 )
+    ?? a1 { T _ → {} F _ → ( nurl_print `add1 ERR\n` ) }
+    ( vec_free [u] d1 )
+    : ( Vec u ) d2 ( mkbytes `x` )
+    : !v ZipErr a2 ( zip_add_stored z `tiny.txt` d2 )   // tiny → forced store
+    ?? a2 { T _ → {} F _ → ( nurl_print `add2 ERR\n` ) }
+    ( vec_free [u] d2 )
+    : ( Vec u ) d3 ( big_data )
+    : !v ZipErr a3 ( zip_add z `dir/big.dat` d3 )         // compressible → deflate
+    ?? a3 { T _ → {} F _ → ( nurl_print `add3 ERR\n` ) }
+    : i d3len ( vec_len [u] d3 )
+    ( vec_free [u] d3 )
+
+    : ( Vec u ) arc ( zip_finish z )
+    ( nurl_print `archive_bytes=` ) ( nurl_print ( nurl_str_int ( vec_len [u] arc ) ) ) ( nurl_print `\n` )
+    ( nurl_print `magic_PK=` )
+    : *u ap ( vec_data [u] arc )
+    ( nurl_print ? & == # i . ap 0 80 == # i . ap 1 75 `T` `F` ) ( nurl_print `\n` )
+
+    // write to /tmp for an external `unzip -t` cross-check (out of band)
+    : !v IoErr _w ( write_file_bytes `/tmp/nurl_ziptest.zip` arc )
+    ?? _w { T _ → {} F _ → {} }
+
+    // ── re-open + inspect ──
+    : !ZipArchive ZipErr oo ( zip_open arc )
+    ?? oo {
+        T za → {
+            ( nurl_print `count=` ) ( nurl_print ( nurl_str_int ( zip_count za ) ) ) ( nurl_print `\n` )
+            : ~ i e 0
+            ~ < e ( zip_count za ) {
+                ( nurl_print `entry ` ) ( nurl_print ( nurl_str_int e ) ) ( nurl_print `: ` )
+                ?? ( zip_name_at za e ) { T nm → { ( nurl_print ( string_data nm ) ) ( string_free nm ) } F _ → ( nurl_print `?` ) }
+                ( nurl_print ` size=` )
+                ?? ( zip_size_at za e ) { T sz → ( nurl_print ( nurl_str_int sz ) ) F _ → ( nurl_print `?` ) }
+                : !( Vec u ) ZipErr ex ( zip_extract za e )
+                ?? ex {
+                    T data → {
+                        ( nurl_print ` extract_ok=T crc_len=` ) ( nurl_print ( nurl_str_int ( vec_len [u] data ) ) )
+                        ( vec_free [u] data )
+                    }
+                    F er → { ( nurl_print ` extract_ERR=` ) ( nurl_print ( zip_err_name # ZipErr er ) ) }
+                }
+                ( nurl_print `\n` )
+                = e + e 1
+            }
+            // extract by name, content check
+            : !( Vec u ) ZipErr byn ( zip_extract_name za `greeting.txt` )
+            ?? byn { T data → { ( vshow `by_name greeting.txt` data ) ( vec_free [u] data ) } F _ → ( nurl_print `by_name ERR\n` ) }
+            // big entry must have deflated (csize < usize): verify via re-extract length == d3len
+            : !( Vec u ) ZipErr bigx ( zip_extract_name za `dir/big.dat` )
+            ?? bigx { T data → { ( nurl_print `big_roundtrip_len_ok=` ) ( nurl_print ? == ( vec_len [u] data ) d3len `T` `F` ) ( nurl_print `\n` ) ( vec_free [u] data ) } F _ → ( nurl_print `big ERR\n` ) }
+            // missing name → not-found
+            : !( Vec u ) ZipErr miss ( zip_extract_name za `nope.txt` )
+            ?? miss { T d → { ( vec_free [u] d ) ( nurl_print `missing=FOUND(BUG)\n` ) } F er → { ( nurl_print `missing=` ) ( nurl_print ( zip_err_name # ZipErr er ) ) ( nurl_print `\n` ) } }
+            ( zip_close za )
+        }
+        F er → { ( nurl_print `open ERR=` ) ( nurl_print ( zip_err_name # ZipErr er ) ) ( nurl_print `\n` ) }
+    }
+    ( vec_free [u] arc )
+
+    // ── reject a garbage archive ──
+    : ( Vec u ) junk ( mkbytes `not a zip file at all, no PK header anywhere here` )
+    : !ZipArchive ZipErr bad ( zip_open junk )
+    ?? bad { T za → { ( zip_close za ) ( nurl_print `junk=OPENED(BUG)\n` ) } F er → { ( nurl_print `junk=` ) ( nurl_print ( zip_err_name # ZipErr er ) ) ( nurl_print `\n` ) } }
+    ( vec_free [u] junk )
+    : !v IoErr _rm ( file_delete `/tmp/nurl_ziptest.zip` )
+    ?? _rm { T _ → {} F _ → {} }
+    ^ 0
+}

--- a/examples/smtp_send.nu
+++ b/examples/smtp_send.nu
@@ -1,0 +1,77 @@
+// smtp_send.nu — submit a mail over STARTTLS using ext/smtp.nu.
+//
+// Configuration comes from the environment so no secrets live in the
+// source:
+//
+//   SMTP_HOST   submission host         (default: localhost)
+//   SMTP_PORT   submission port         (default: 587)
+//   SMTP_USER   AUTH username
+//   SMTP_PASS   AUTH password
+//   SMTP_FROM   envelope + From: address
+//   SMTP_TO     envelope + To: address
+//
+//   $ SMTP_HOST=smtp.example.com SMTP_USER=me@example.com \
+//     SMTP_PASS=secret SMTP_FROM=me@example.com \
+//     SMTP_TO=you@example.org ./smtp_send
+//
+// The flow is the canonical RFC 5321 submission sequence: greeting,
+// EHLO, STARTTLS (upgrade + re-EHLO), AUTH PLAIN, MAIL FROM, RCPT TO,
+// DATA, QUIT. Each step propagates a typed SmtpErr.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/smtp.nu`
+
+@ die s ctx SmtpErr e → i {
+    ( nurl_print `error at ` ) ( nurl_print ctx )
+    ( nurl_print `: ` ) ( nurl_print ( smtp_err_name e ) ) ( nurl_print `\n` )
+    ^ 1
+}
+
+@ run s host i port s user s pass s from s to → i {
+    : !SmtpClient SmtpErr cc ( smtp_connect host port )
+    ^ ?? cc {
+        F e → ( die `connect` e )
+        T c → {
+            : !v SmtpErr e1 ( smtp_ehlo c host )
+            ?? e1 { T _ → {} F e → { ( smtp_close c ) ^ ( die `ehlo` e ) } }
+
+            : !v SmtpErr e2 ( smtp_starttls c host T )
+            ?? e2 { T _ → {} F e → { ( smtp_close c ) ^ ( die `starttls` e ) } }
+
+            : !v SmtpErr e3 ( smtp_auth_plain c user pass )
+            ?? e3 { T _ → {} F e → { ( smtp_close c ) ^ ( die `auth` e ) } }
+
+            : !v SmtpErr e4 ( smtp_mail_from c from )
+            ?? e4 { T _ → {} F e → { ( smtp_close c ) ^ ( die `mail from` e ) } }
+
+            : !v SmtpErr e5 ( smtp_rcpt_to c to )
+            ?? e5 { T _ → {} F e → { ( smtp_close c ) ^ ( die `rcpt to` e ) } }
+
+            : String date ( smtp_date_now )
+            : String msg ( mime_build from to `Hello from NURL` `This message was sent by the NURL smtp client.\n` ( string_data date ) )
+            : !v SmtpErr e6 ( smtp_data c ( string_data msg ) )
+            ( string_free msg )
+            ( string_free date )
+            ?? e6 { T _ → {} F e → { ( smtp_close c ) ^ ( die `data` e ) } }
+
+            ( smtp_quit c )
+            ( nurl_print `sent OK\n` )
+            ^ 0
+        }
+    }
+}
+
+@ main → i {
+    : String host ( env_var_or `SMTP_HOST` `localhost` )
+    : String ports ( env_var_or `SMTP_PORT` `587` )
+    : String user ( env_var_or `SMTP_USER` `` )
+    : String pass ( env_var_or `SMTP_PASS` `` )
+    : String from ( env_var_or `SMTP_FROM` `from@example.com` )
+    : String to ( env_var_or `SMTP_TO` `to@example.org` )
+    : i port ( nurl_str_to_int ( string_data ports ) )
+    : i rc ( run ( string_data host ) port ( string_data user ) ( string_data pass ) ( string_data from ) ( string_data to ) )
+    ( string_free host ) ( string_free ports ) ( string_free user )
+    ( string_free pass ) ( string_free from ) ( string_free to )
+    ^ rc
+}

--- a/stdlib/ext/smtp.nu
+++ b/stdlib/ext/smtp.nu
@@ -1,0 +1,430 @@
+// stdlib/ext/smtp.nu — SMTP client (RFC 5321 / 5322), B17.
+//
+// A submission client: dial a mail server, optionally upgrade the
+// plaintext connection to TLS with STARTTLS (RFC 3207), authenticate
+// (AUTH PLAIN / AUTH LOGIN, RFC 4954), and submit a message. Built on
+// the runtime's client-side TCP/TLS connect (net.nu's TcpConn for
+// read/write) plus a new `nurl_tcp_starttls` that upgrades an
+// already-open fd in place. A minimal MIME builder (`mime_build`)
+// produces a well-formed text/plain message; `smtp_dotstuff` applies
+// the transparency rules (RFC 5321 §4.5.2) the DATA phase requires.
+//
+//   ( smtp_connect       s host i port )                → ! SmtpClient SmtpErr
+//   ( smtp_connect_tls   s host i port b verify )       → ! SmtpClient SmtpErr  (implicit TLS, :465)
+//   ( smtp_ehlo          SmtpClient c s domain )        → ! v SmtpErr
+//   ( smtp_has_cap       SmtpClient c s name )          → b   (after EHLO)
+//   ( smtp_starttls      SmtpClient c s host b verify ) → ! v SmtpErr  (re-EHLOs)
+//   ( smtp_auth_plain    SmtpClient c s user s pass )   → ! v SmtpErr
+//   ( smtp_auth_login    SmtpClient c s user s pass )   → ! v SmtpErr
+//   ( smtp_mail_from     SmtpClient c s addr )          → ! v SmtpErr
+//   ( smtp_rcpt_to       SmtpClient c s addr )          → ! v SmtpErr
+//   ( smtp_data          SmtpClient c s message )       → ! v SmtpErr  (dot-stuffs + terminates)
+//   ( smtp_quit          SmtpClient c )                 → v   (QUIT + close)
+//   ( smtp_close         SmtpClient c )                 → v   (close without QUIT)
+//
+//   ( mime_build  s from s to s subject s body s date ) → String
+//   ( smtp_dotstuff s body )                            → String
+//   ( smtp_date_now )                                   → String  (RFC 2822, UTC)
+//
+// `verify` T checks the server certificate chain + hostname against the
+// system trust store; F still encrypts but skips verification (a test
+// server's `--insecure`). Leave it T over any untrusted network.
+//
+// Win32/WASI without OpenSSL: STARTTLS / implicit-TLS report SmtpTls.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/net.nu`     // TcpConn, tcp_read_chunk / tcp_write_str / tcp_close_conn
+$ `stdlib/std/encode.nu`  // b64_encode / b64_encode_vec
+$ `stdlib/std/time.nu`    // smtp_date_now
+
+// runtime.c §18 exports the client-connect primitives. nurl_tcp_close /
+// nurl_tcp_err_kind are nurlc builtins; the two connect calls and the
+// STARTTLS upgrade need `& `libc`` extern declarations.
+& `libc` @ nurl_tcp_connect s host i port → i
+& `libc` @ nurl_tcp_connect_tls s host i port i verify → i
+& `libc` @ nurl_tcp_starttls i conn s host i verify → i
+
+: | SmtpErr {
+    SmtpConnect      // TCP connect failed
+    SmtpTls          // TLS handshake / STARTTLS upgrade failed
+    SmtpProtocol     // unexpected reply code
+    SmtpAuth         // authentication rejected
+    SmtpWrite
+    SmtpRead
+    SmtpClosed
+    SmtpTimeout
+    SmtpNoStartTls   // STARTTLS requested but the server did not advertise it
+}
+
+@ smtp_err_name SmtpErr e → s {
+    ^ ?? e {
+        SmtpConnect → `SmtpConnect`
+        SmtpTls → `SmtpTls`
+        SmtpProtocol → `SmtpProtocol`
+        SmtpAuth → `SmtpAuth`
+        SmtpWrite → `SmtpWrite`
+        SmtpRead → `SmtpRead`
+        SmtpClosed → `SmtpClosed`
+        SmtpTimeout → `SmtpTimeout`
+        SmtpNoStartTls → `SmtpNoStartTls`
+    }
+}
+
+// `rxbuf` holds bytes pulled off the socket past a reply boundary;
+// `last_reply` is the full text of the most recent (possibly
+// multiline) reply — EHLO capability checks read it via smtp_has_cap.
+: SmtpClient {
+    TcpConn conn
+    ( Vec u ) rxbuf
+    String last_reply
+}
+
+@ __smtp_of_net NetErr e → SmtpErr {
+    ^ ?? e {
+        NetClosed → # SmtpErr SmtpClosed
+        NetRead → # SmtpErr SmtpRead
+        NetWrite → # SmtpErr SmtpWrite
+        NetTimeout → # SmtpErr SmtpTimeout
+        NetTlsCtxInit → # SmtpErr SmtpTls
+        NetTlsCertLoad → # SmtpErr SmtpTls
+        NetTlsKeyLoad → # SmtpErr SmtpTls
+        NetTlsHandshake → # SmtpErr SmtpTls
+        NetBind → # SmtpErr SmtpProtocol
+        NetAddrInUse → # SmtpErr SmtpConnect
+        NetAccept → # SmtpErr SmtpProtocol
+        NetOther → # SmtpErr SmtpProtocol
+    }
+}
+
+// Bounds-checked byte read: out-of-range → -1.
+@ __smtp_vget ( Vec u ) v i k → i {
+    ^ ?? ( vec_get [u] v k ) { T b → # i b F _ → -1 }
+}
+
+// ── reply parsing (pure — tested directly) ───────────────────────────
+
+// Scan `buf` for the end of one complete reply. A reply is a run of
+// CRLF lines; it ends at the first line whose 4th byte is NOT '-' (the
+// continuation marker), per RFC 5321 §4.2.1. Returns the byte index
+// just past the terminating LF, or -1 if no complete reply is buffered.
+@ __smtp_reply_scan ( Vec u ) buf → i {
+    : i n ( vec_len [u] buf )
+    : ~ i ls 0
+    : ~ i k 0
+    : ~ i result -1
+    : ~ i scanning 1
+    ~ & == scanning 1 < k n {
+        ? == ( __smtp_vget buf k ) 10 {
+            // line spans [ls, k]; "code SP/-" check on byte ls+3 (45 = '-')
+            ? | <= - k ls 3 != ( __smtp_vget buf + ls 3 ) 45 {
+                = result + k 1
+                = scanning 0
+            } {
+                = ls + k 1
+            }
+        } {}
+        = k + k 1
+    }
+    ^ result
+}
+
+// Parse the 3-digit status code at the front of a reply. -1 if the
+// first three bytes are not digits.
+@ __smtp_reply_code ( Vec u ) buf → i {
+    ? < ( vec_len [u] buf ) 3 { ^ -1 } {}
+    : i d0 ( __smtp_vget buf 0 )
+    : i d1 ( __smtp_vget buf 1 )
+    : i d2 ( __smtp_vget buf 2 )
+    ? | | ( __smtp_notdigit d0 ) ( __smtp_notdigit d1 ) ( __smtp_notdigit d2 ) { ^ -1 } {}
+    ^ + + * 100 - d0 48 * 10 - d1 48 - d2 48
+}
+
+@ __smtp_notdigit i c → b {
+    ^ | < c 48 > c 57
+}
+
+// ── low-level send / receive ─────────────────────────────────────────
+
+// Send `text` followed by CRLF (the SMTP command terminator).
+@ __smtp_write_crlf SmtpClient c s text → !v SmtpErr {
+    : String line ( string_with_cap + ( nurl_str_len text ) 2 )
+    ( string_push_str line text )
+    ( string_push_char line 13 )
+    ( string_push_char line 10 )
+    : !v NetErr w ( tcp_write_str . c conn ( string_data line ) )
+    ( string_free line )
+    ^ ?? w {
+        T _ → @ !v SmtpErr { T 0 }
+        F er → @ !v SmtpErr { F ( __smtp_of_net er ) }
+    }
+}
+
+// Read one complete reply into last_reply; return its status code.
+@ __smtp_read_reply SmtpClient c → !i SmtpErr {
+    : ~ i spin 0
+    ~ < spin 1000000 {
+        : i end ( __smtp_reply_scan . c rxbuf )
+        ? >= end 0 {
+            : i code ( __smtp_reply_code . c rxbuf )
+            ( string_clear . c last_reply )
+            : ~ i k 0
+            ~ < k end { ( string_push_char . c last_reply ( __smtp_vget . c rxbuf k ) ) = k + k 1 }
+            : i n ( vec_len [u] . c rxbuf )
+            : i rem - n end
+            = k 0
+            ~ < k rem {
+                ?? ( vec_get [u] . c rxbuf + end k ) { T b → { ( vec_set [u] . c rxbuf k b ) } F _ → {} }
+                = k + k 1
+            }
+            ( vec_set_len [u] . c rxbuf rem )
+            ^ @ !i SmtpErr { T code }
+        } {}
+        : !( Vec u ) NetErr rd ( tcp_read_chunk . c conn 4096 )
+        ?? rd {
+            T chunk → {
+                : i cn ( vec_len [u] chunk )
+                : ~ i j 0
+                ~ < j cn { ( vec_push [u] . c rxbuf # u ( __smtp_vget chunk j ) ) = j + j 1 }
+                ( vec_free [u] chunk )
+            }
+            F er → { ^ @ !i SmtpErr { F ( __smtp_of_net er ) } }
+        }
+        = spin + spin 1
+    }
+    ^ @ !i SmtpErr { F # SmtpErr SmtpProtocol }
+}
+
+// Send a command, read its reply, return the status code.
+@ __smtp_cmd SmtpClient c s text → !i SmtpErr {
+    : !v SmtpErr w ( __smtp_write_crlf c text )
+    ?? w { T _ → {} F er → { ^ @ !i SmtpErr { F er } } }
+    ^ ( __smtp_read_reply c )
+}
+
+// Send `text`, require the reply code to equal `want`, else `onfail`.
+@ __smtp_expect SmtpClient c s text i want SmtpErr onfail → !v SmtpErr {
+    : !i SmtpErr r ( __smtp_cmd c text )
+    ^ ?? r {
+        T code → ? == code want { @ !v SmtpErr { T 0 } } { @ !v SmtpErr { F onfail } }
+        F er → @ !v SmtpErr { F er }
+    }
+}
+
+// ── connection lifecycle ─────────────────────────────────────────────
+
+@ smtp_close SmtpClient c → v {
+    ( tcp_close_conn . c conn )
+    ( vec_free [u] . c rxbuf )
+    ( string_free . c last_reply )
+}
+
+@ __smtp_after_connect i craw → !SmtpClient SmtpErr {
+    ? == craw 0 { ^ @ !SmtpClient SmtpErr { F # SmtpErr SmtpConnect } } {}
+    : i ek ( nurl_tcp_err_kind craw )
+    ? != ek 0 {
+        ( nurl_tcp_close craw )
+        ^ @ !SmtpClient SmtpErr { F # SmtpErr SmtpConnect }
+    } {}
+    : s crp # s craw
+    : TcpConn conn @ TcpConn { crp }
+    : SmtpClient c @ SmtpClient { conn ( vec_new [u] ) ( string_with_cap 128 ) }
+    : !i SmtpErr g ( __smtp_read_reply c )
+    ^ ?? g {
+        T code → ? == code 220 { @ !SmtpClient SmtpErr { T c } } { ( smtp_close c ) @ !SmtpClient SmtpErr { F # SmtpErr SmtpProtocol } }
+        F er → { ( smtp_close c ) @ !SmtpClient SmtpErr { F er } }
+    }
+}
+
+@ smtp_connect s host i port → !SmtpClient SmtpErr {
+    ^ ( __smtp_after_connect ( nurl_tcp_connect host port ) )
+}
+
+@ smtp_connect_tls s host i port b verify → !SmtpClient SmtpErr {
+    ^ ( __smtp_after_connect ( nurl_tcp_connect_tls host port ? verify 1 0 ) )
+}
+
+@ smtp_ehlo SmtpClient c s domain → !v SmtpErr {
+    : String line ( string_with_cap 64 )
+    ( string_push_str line `EHLO ` )
+    ( string_push_str line domain )
+    : !v SmtpErr r ( __smtp_expect c ( string_data line ) 250 # SmtpErr SmtpProtocol )
+    ( string_free line )
+    ^ r
+}
+
+// Substring test against the most recent EHLO reply (capability names
+// are upper-case: "STARTTLS", "AUTH", "PIPELINING", …).
+@ smtp_has_cap SmtpClient c s name → b {
+    ^ ( string_contains . c last_reply name )
+}
+
+// EHLO must already have run (so smtp_has_cap is populated). Sends
+// STARTTLS, upgrades the live fd to TLS, and re-issues EHLO (RFC 3207
+// §4.2 requires discarding the pre-TLS capability list).
+@ smtp_starttls SmtpClient c s host b verify → !v SmtpErr {
+    ? ( smtp_has_cap c `STARTTLS` ) {} { ^ @ !v SmtpErr { F # SmtpErr SmtpNoStartTls } }
+    : !v SmtpErr r ( __smtp_expect c `STARTTLS` 220 # SmtpErr SmtpProtocol )
+    ?? r { T _ → {} F er → { ^ @ !v SmtpErr { F er } } }
+    : TcpConn cn . c conn
+    : i raw # i . cn raw
+    : i _h ( nurl_tcp_starttls raw host ? verify 1 0 )
+    : i ek ( nurl_tcp_err_kind raw )
+    ? != ek 0 { ^ @ !v SmtpErr { F # SmtpErr SmtpTls } } {}
+    ^ ( smtp_ehlo c host )
+}
+
+// ── authentication ───────────────────────────────────────────────────
+
+// base64( "\0" user "\0" pass ) — the AUTH PLAIN initial response
+// (RFC 4954 §4). Built over a Vec[u] so the NUL separators survive.
+@ __smtp_auth_plain_token s user s pass → String {
+    : ( Vec u ) b ( vec_new [u] )
+    ( vec_push [u] b # u 0 )
+    : i un ( nurl_str_len user )
+    : ~ i k 0
+    ~ < k un { ( vec_push [u] b # u ( nurl_str_get user k ) ) = k + k 1 }
+    ( vec_push [u] b # u 0 )
+    : i pn ( nurl_str_len pass )
+    = k 0
+    ~ < k pn { ( vec_push [u] b # u ( nurl_str_get pass k ) ) = k + k 1 }
+    : String tok ( b64_encode_vec b )
+    ( vec_free [u] b )
+    ^ tok
+}
+
+@ smtp_auth_plain SmtpClient c s user s pass → !v SmtpErr {
+    : String tok ( __smtp_auth_plain_token user pass )
+    : String line ( string_with_cap + ( string_len tok ) 12 )
+    ( string_push_str line `AUTH PLAIN ` )
+    ( string_push_str line ( string_data tok ) )
+    : !v SmtpErr r ( __smtp_expect c ( string_data line ) 235 # SmtpErr SmtpAuth )
+    ( string_free line )
+    ( string_free tok )
+    ^ r
+}
+
+@ smtp_auth_login SmtpClient c s user s pass → !v SmtpErr {
+    : !v SmtpErr r0 ( __smtp_expect c `AUTH LOGIN` 334 # SmtpErr SmtpAuth )
+    ?? r0 { T _ → {} F er → { ^ @ !v SmtpErr { F er } } }
+    : String ub ( b64_encode user )
+    : !v SmtpErr r1 ( __smtp_expect c ( string_data ub ) 334 # SmtpErr SmtpAuth )
+    ( string_free ub )
+    ?? r1 { T _ → {} F er → { ^ @ !v SmtpErr { F er } } }
+    : String pb ( b64_encode pass )
+    : !v SmtpErr r2 ( __smtp_expect c ( string_data pb ) 235 # SmtpErr SmtpAuth )
+    ( string_free pb )
+    ^ r2
+}
+
+// ── envelope + DATA ──────────────────────────────────────────────────
+
+@ smtp_mail_from SmtpClient c s addr → !v SmtpErr {
+    : String line ( string_with_cap + ( nurl_str_len addr ) 16 )
+    ( string_push_str line `MAIL FROM:<` )
+    ( string_push_str line addr )
+    ( string_push_char line 62 )   // '>'
+    : !v SmtpErr r ( __smtp_expect c ( string_data line ) 250 # SmtpErr SmtpProtocol )
+    ( string_free line )
+    ^ r
+}
+
+@ smtp_rcpt_to SmtpClient c s addr → !v SmtpErr {
+    : String line ( string_with_cap + ( nurl_str_len addr ) 16 )
+    ( string_push_str line `RCPT TO:<` )
+    ( string_push_str line addr )
+    ( string_push_char line 62 )
+    : !i SmtpErr r ( __smtp_cmd c ( string_data line ) )
+    ( string_free line )
+    ^ ?? r {
+        T code → ? | == code 250 == code 251 { @ !v SmtpErr { T 0 } } { @ !v SmtpErr { F # SmtpErr SmtpProtocol } }
+        F er → @ !v SmtpErr { F er }
+    }
+}
+
+// DATA phase: send the command (expect 354), then the message with
+// CRLF line endings, leading-dot stuffing, and the terminating
+// "<CRLF>.<CRLF>" (expect 250).
+@ smtp_data SmtpClient c s message → !v SmtpErr {
+    : !v SmtpErr r1 ( __smtp_expect c `DATA` 354 # SmtpErr SmtpProtocol )
+    ?? r1 { T _ → {} F er → { ^ @ !v SmtpErr { F er } } }
+    : String ds ( smtp_dotstuff message )
+    : i dn ( string_len ds )
+    ? | == dn 0 != ( string_get ds - dn 1 ) 10 { ( string_push_char ds 13 ) ( string_push_char ds 10 ) } {}
+    ( string_push_char ds 46 )                              // '.'
+    ( string_push_char ds 13 ) ( string_push_char ds 10 )
+    : !v NetErr w ( tcp_write_str . c conn ( string_data ds ) )
+    ( string_free ds )
+    ?? w { T _ → {} F er → { ^ @ !v SmtpErr { F ( __smtp_of_net er ) } } }
+    : !i SmtpErr r2 ( __smtp_read_reply c )
+    ^ ?? r2 {
+        T code → ? == code 250 { @ !v SmtpErr { T 0 } } { @ !v SmtpErr { F # SmtpErr SmtpProtocol } }
+        F er → @ !v SmtpErr { F er }
+    }
+}
+
+@ smtp_quit SmtpClient c → v {
+    : !v SmtpErr w ( __smtp_write_crlf c `QUIT` )
+    ?? w {
+        T _ → { : !i SmtpErr _r ( __smtp_read_reply c ) ?? _r { T _ → {} F _ → {} } }
+        F _ → {}
+    }
+    ( smtp_close c )
+}
+
+// ── message helpers (pure) ───────────────────────────────────────────
+
+@ __smtp_crlf String m → v { ( string_push_char m 13 ) ( string_push_char m 10 ) }
+
+@ __smtp_hdr String m s key s val → v {
+    ( string_push_str m key ) ( string_push_str m val ) ( __smtp_crlf m )
+}
+
+// Build a minimal RFC 5322 text/plain message (headers + body). The
+// body may use bare LF or CRLF; pass the result straight to smtp_data,
+// which normalises line endings and applies dot-stuffing.
+@ mime_build s from s to s subject s body s date → String {
+    : String m ( string_with_cap + ( nurl_str_len body ) 256 )
+    ( __smtp_hdr m `From: ` from )
+    ( __smtp_hdr m `To: ` to )
+    ( __smtp_hdr m `Subject: ` subject )
+    ( __smtp_hdr m `Date: ` date )
+    ( string_push_str m `MIME-Version: 1.0` ) ( __smtp_crlf m )
+    ( string_push_str m `Content-Type: text/plain; charset=utf-8` ) ( __smtp_crlf m )
+    ( string_push_str m `Content-Transfer-Encoding: 8bit` ) ( __smtp_crlf m )
+    ( __smtp_crlf m )   // blank line separates headers from body
+    ( string_push_str m body )
+    ^ m
+}
+
+// SMTP transparency (RFC 5321 §4.5.2): normalise every line break to
+// CRLF and double a '.' that begins a line. Returns a fresh String.
+@ smtp_dotstuff s body → String {
+    : i n ( nurl_str_len body )
+    : String out ( string_with_cap + n 16 )
+    : ~ i k 0
+    : ~ i atbol 1
+    ~ < k n {
+        : i ch ( nurl_str_get body k )
+        ? == ch 13 {
+            ? & < + k 1 n == ( nurl_str_get body + k 1 ) 10 { = k + k 1 } {}
+            ( string_push_char out 13 ) ( string_push_char out 10 )
+            = atbol 1
+        } {
+        ? == ch 10 {
+            ( string_push_char out 13 ) ( string_push_char out 10 )
+            = atbol 1
+        } {
+            ? & == atbol 1 == ch 46 { ( string_push_char out 46 ) } {}
+            ( string_push_char out ch )
+            = atbol 0
+        } }
+        = k + k 1
+    }
+    ^ out
+}
+
+// RFC 2822 Date for "now" in UTC: "Mon, 02 Jan 2006 15:04:05 +0000".
+@ smtp_date_now → String {
+    ^ ( time_format ( time_now ) `%a, %d %b %Y %H:%M:%S +0000` )
+}

--- a/stdlib/ext/zip.nu
+++ b/stdlib/ext/zip.nu
@@ -1,0 +1,389 @@
+// stdlib/ext/zip.nu — ZIP archive read/write (store + deflate).
+//
+// THE interchange container (xlsx / docx / epub / jar are all zip).
+// In-memory archives over ( Vec u ) — pair with read_file_bytes /
+// write_file_bytes for files. Compression rides the same `& `z``
+// zlib FFI ext/compress.nu declares, with raw windows (windowBits
+// −15: zip stores bare deflate streams, no zlib/gzip wrapper).
+//
+// Writer (builder):
+//   ( zip_new )                            → Zip
+//   ( zip_add Zip s name ( Vec u ) data )  → ! v ZipErr   deflate, or store
+//                                            when deflate isn't smaller
+//   ( zip_add_stored Zip s name ( Vec u ) data ) → ! v ZipErr   force store
+//   ( zip_finish Zip )                     → ( Vec u )    archive bytes;
+//                                            consumes the builder
+// Reader:
+//   ( zip_open ( Vec u ) bytes )           → ! ZipArchive ZipErr
+//       BORROWS `bytes` — keep them alive until zip_close.
+//   ( zip_count ZipArchive )               → i
+//   ( zip_name_at ZipArchive i )           → ? String     owned copy
+//   ( zip_size_at ZipArchive i )           → ? i          uncompressed size
+//   ( zip_extract ZipArchive i )           → ! ( Vec u ) ZipErr   crc-checked
+//   ( zip_extract_name ZipArchive s name ) → ! ( Vec u ) ZipErr
+//   ( zip_close ZipArchive )               → v
+//
+// Determinism: entries carry a fixed DOS timestamp (1980-01-01), so
+// identical inputs produce byte-identical archives.
+//
+// Out of scope: zip64 (>4 GiB / >65535 entries), encryption, data
+// descriptors (bit 3) on WRITE; on READ, descriptor-flagged entries
+// work because the central directory carries the real sizes/crc.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/compress.nu`   // & `z` deflate/inflate FFI + zlibVersion
+
+& `z` @ crc32 i crc *u buf i len → i
+
+: | ZipErr {
+    ZipBadArchive    // no/garbled end-of-central-directory or headers
+    ZipUnsupported   // zip64 / encrypted / unknown compression method
+    ZipCrc           // extracted bytes fail the stored CRC-32
+    ZipInflate       // deflate stream is corrupt
+    ZipDeflate       // compression failed
+    ZipNotFound      // zip_extract_name: no such entry
+    ZipTooLarge      // would need zip64
+}
+
+@ zip_err_name ZipErr e → s {
+    ^ ?? e {
+        ZipBadArchive → `bad-archive`
+        ZipUnsupported → `unsupported`
+        ZipCrc → `crc-mismatch`
+        ZipInflate → `inflate-error`
+        ZipDeflate → `deflate-error`
+        ZipNotFound → `not-found`
+        ZipTooLarge → `too-large`
+    }
+}
+
+// ── little-endian byte helpers ──────────────────────────────────────
+
+@ __zip_push_u16 ( Vec u ) out i v → v {
+    ( vec_push [u] out # u & v 255 )
+    ( vec_push [u] out # u & / v 256 255 )
+}
+
+@ __zip_push_u32 ( Vec u ) out i v → v {
+    ( vec_push [u] out # u & v 255 )
+    ( vec_push [u] out # u & / v 256 255 )
+    ( vec_push [u] out # u & / v 65536 255 )
+    ( vec_push [u] out # u & / v 16777216 255 )
+}
+
+@ __zip_rd_u16 *u p i off → i {
+    ^ + # i . p off * # i . p + off 1 256
+}
+
+@ __zip_rd_u32 *u p i off → i {
+    ^ + + + # i . p off * # i . p + off 1 256 * # i . p + off 2 65536 * # i . p + off 3 16777216
+}
+
+// ── raw deflate / inflate (windowBits −15) ──────────────────────────
+
+// Compress src → fresh Vec. None when deflate failed OR produced no
+// gain (caller stores instead).
+@ __zip_deflate ( Vec u ) src → ?( Vec u ) {
+    : i srclen ( vec_len [u] src )
+    : i zs_size ( nurl_native_sizeof `z_stream` )
+    ? <= zs_size 0 { ^ @ ?( Vec u ) { F } } {}
+    : i bound ( compressBound srclen )
+    : ( Vec u ) out ( vec_with_cap [u] + bound 1 )
+    : *u zs # *u ( nurl_zalloc zs_size )
+    ( nurl_z_setup zs ( vec_data [u] src ) srclen ( vec_data [u] out ) + bound 1 )
+    // level 6, method 8 (deflate), windowBits −15 (raw), memLevel 8
+    : i32 rc1 ( deflateInit2_ zs # i32 6 # i32 8 # i32 -15 # i32 8 # i32 0 ( zlibVersion ) # i32 zs_size )
+    ? != rc1 # i32 0 { ( nurl_free # s zs ) ( vec_free [u] out ) ^ @ ?( Vec u ) { F } } {}
+    : i32 rc2 ( deflate zs # i32 4 )   // Z_FINISH
+    : i produced ( nurl_z_total_out zs )
+    : i32 _e ( deflateEnd zs )
+    ( nurl_free # s zs )
+    ? != rc2 # i32 1 { ( vec_free [u] out ) ^ @ ?( Vec u ) { F } } {}   // != Z_STREAM_END
+    ? >= produced srclen { ( vec_free [u] out ) ^ @ ?( Vec u ) { F } } {}  // no gain → store
+    : b _ok ( vec_set_len [u] out produced )
+    ^ @ ?( Vec u ) { T out }
+}
+
+// Inflate exactly `usize` bytes out of src[off .. off+csize).
+@ __zip_inflate *u srcp i off i csize i usize → ?( Vec u ) {
+    : i zs_size ( nurl_native_sizeof `z_stream` )
+    ? <= zs_size 0 { ^ @ ?( Vec u ) { F } } {}
+    : ( Vec u ) out ( vec_with_cap [u] ? > usize 0 usize 1 )
+    : *u zs # *u ( nurl_zalloc zs_size )
+    ( nurl_z_setup zs # *u + # i srcp off csize ( vec_data [u] out ) ? > usize 0 usize 1 )
+    : i32 rc1 ( inflateInit2_ zs # i32 -15 ( zlibVersion ) # i32 zs_size )
+    ? != rc1 # i32 0 { ( nurl_free # s zs ) ( vec_free [u] out ) ^ @ ?( Vec u ) { F } } {}
+    : i32 rc2 ( inflate zs # i32 4 )
+    : i produced ( nurl_z_total_out zs )
+    : i32 _e ( inflateEnd zs )
+    ( nurl_free # s zs )
+    ? | != rc2 # i32 1 != produced usize { ( vec_free [u] out ) ^ @ ?( Vec u ) { F } } {}
+    : b _ok ( vec_set_len [u] out usize )
+    ^ @ ?( Vec u ) { T out }
+}
+
+// ── writer ──────────────────────────────────────────────────────────
+//
+// Zip builder: `body` accumulates local headers + file data as they
+// are added; `central` accumulates the matching central-directory
+// records; `count` in ctl slot 0. Offsets are byte positions in body.
+
+: Zip { s ctl ( Vec u ) body ( Vec u ) central }
+
+: i ZIP_DOSDATE 33   // 1980-01-01 → (0<<9)|(1<<5)|1
+
+@ zip_new → Zip {
+    ^ @ Zip { ( nurl_zalloc 8 ) ( vec_new [u] ) ( vec_new [u] ) }
+}
+
+// Shared add: method 8 with `comp` bytes, or method 0 when comp is None.
+@ __zip_add_entry Zip z s name ( Vec u ) data ?( Vec u ) comp → !v ZipErr {
+    : i namelen ( nurl_str_len name )
+    : i usize ( vec_len [u] data )
+    ? | > usize 4294967295 > namelen 65535 { ^ @ !v ZipErr { F ZipTooLarge } } {}
+    : i crc ( crc32 0 ( vec_data [u] data ) usize )
+    : i offset ( vec_len [u] . z body )
+    ? > offset 4294967295 { ^ @ !v ZipErr { F ZipTooLarge } } {}
+    : ~ i method 0
+    : ~ i csize usize
+    ?? comp { T c → { = method 8 = csize ( vec_len [u] c ) } F → {} }
+    // ── local file header ──
+    : ( Vec u ) b . z body
+    ( __zip_push_u32 b 0x04034b50 )
+    ( __zip_push_u16 b 20 )            // version needed
+    ( __zip_push_u16 b 0 )             // flags
+    ( __zip_push_u16 b method )
+    ( __zip_push_u16 b 0 )             // dos time
+    ( __zip_push_u16 b ZIP_DOSDATE )
+    ( __zip_push_u32 b crc )
+    ( __zip_push_u32 b csize )
+    ( __zip_push_u32 b usize )
+    ( __zip_push_u16 b namelen )
+    ( __zip_push_u16 b 0 )             // extra len
+    ( bytes_extend_str b name )
+    ?? comp {
+        T c → {
+            : i cn ( vec_len [u] c )
+            : *u cp ( vec_data [u] c )
+            : ~ i k 0
+            ~ < k cn { ( vec_push [u] b . cp k ) = k + k 1 }
+            ( vec_free [u] c )
+        }
+        F → {
+            : *u dp ( vec_data [u] data )
+            : ~ i k 0
+            ~ < k usize { ( vec_push [u] b . dp k ) = k + k 1 }
+        }
+    }
+    // ── central directory record ──
+    : ( Vec u ) cd . z central
+    ( __zip_push_u32 cd 0x02014b50 )
+    ( __zip_push_u16 cd 20 )           // version made by
+    ( __zip_push_u16 cd 20 )           // version needed
+    ( __zip_push_u16 cd 0 )            // flags
+    ( __zip_push_u16 cd method )
+    ( __zip_push_u16 cd 0 )            // dos time
+    ( __zip_push_u16 cd ZIP_DOSDATE )
+    ( __zip_push_u32 cd crc )
+    ( __zip_push_u32 cd csize )
+    ( __zip_push_u32 cd usize )
+    ( __zip_push_u16 cd namelen )
+    ( __zip_push_u16 cd 0 )            // extra
+    ( __zip_push_u16 cd 0 )            // comment
+    ( __zip_push_u16 cd 0 )            // disk start
+    ( __zip_push_u16 cd 0 )            // internal attrs
+    ( __zip_push_u32 cd 0 )            // external attrs
+    ( __zip_push_u32 cd offset )
+    ( bytes_extend_str cd name )
+    ( nurl_poke . z ctl 0 + ( nurl_peek . z ctl 0 ) 1 )
+    ^ @ !v ZipErr { T 0 }
+}
+
+@ zip_add Zip z s name ( Vec u ) data → !v ZipErr {
+    : ?( Vec u ) comp ( __zip_deflate data )
+    ^ ( __zip_add_entry z name data comp )
+}
+
+@ zip_add_stored Zip z s name ( Vec u ) data → !v ZipErr {
+    ^ ( __zip_add_entry z name data @ ?( Vec u ) { F } )
+}
+
+// Append the central directory + end record; returns the archive and
+// frees the builder.
+@ zip_finish Zip z → ( Vec u ) {
+    : ( Vec u ) out . z body
+    : i cd_off ( vec_len [u] out )
+    : i cd_len ( vec_len [u] . z central )
+    : i count ( nurl_peek . z ctl 0 )
+    : *u cp ( vec_data [u] . z central )
+    : ~ i k 0
+    ~ < k cd_len { ( vec_push [u] out . cp k ) = k + k 1 }
+    ( __zip_push_u32 out 0x06054b50 )  // EOCD
+    ( __zip_push_u16 out 0 )           // disk
+    ( __zip_push_u16 out 0 )           // cd disk
+    ( __zip_push_u16 out count )
+    ( __zip_push_u16 out count )
+    ( __zip_push_u32 out cd_len )
+    ( __zip_push_u32 out cd_off )
+    ( __zip_push_u16 out 0 )           // comment len
+    ( vec_free [u] . z central )
+    ( nurl_free . z ctl )
+    ^ out
+}
+
+// ── reader ──────────────────────────────────────────────────────────
+//
+// ZipArchive: ctl slot 0 = entry count, slot 1 = entries ptr, slot 2 =
+// source data ptr (borrowed), slot 3 = source len. Entries are a flat
+// i64 array, 7 slots each:
+//   0 name_off (into source)  1 name_len  2 method  3 csize
+//   4 usize    5 local_hdr_off            6 crc
+
+: ZipArchive { s ctl }
+
+@ zip_count ZipArchive a → i { ^ ( nurl_peek . a ctl 0 ) }
+
+@ __zip_entry ZipArchive a i idx i field → i {
+    : s ep # s ( nurl_peek . a ctl 1 )
+    ^ ( nurl_peek ep + * idx 7 field )
+}
+
+@ zip_open ( Vec u ) bytes → !ZipArchive ZipErr {
+    : i n ( vec_len [u] bytes )
+    ? < n 22 { ^ @ !ZipArchive ZipErr { F ZipBadArchive } } {}
+    : *u p ( vec_data [u] bytes )
+    // find EOCD: scan back from n-22 over the ≤64K comment window
+    : ~ i eocd -1
+    : ~ i scan - n 22
+    : i lo ? > - n 65557 0 - n 65557 0
+    ~ & >= scan lo < eocd 0 {
+        ? & & & == # i . p scan 80 == # i . p + scan 1 75 == # i . p + scan 2 5 == # i . p + scan 3 6 {
+            : i clen ( __zip_rd_u16 p + scan 20 )
+            ? == + + scan 22 clen n { = eocd scan } {}
+        } {}
+        = scan - scan 1
+    }
+    ? < eocd 0 { ^ @ !ZipArchive ZipErr { F ZipBadArchive } } {}
+    : i count ( __zip_rd_u16 p + eocd 10 )
+    : i cd_len ( __zip_rd_u32 p + eocd 12 )
+    : i cd_off ( __zip_rd_u32 p + eocd 16 )
+    ? > + cd_off cd_len eocd { ^ @ !ZipArchive ZipErr { F ZipBadArchive } } {}
+    // 0xFFFF entries / 0xFFFFFFFF offsets ⇒ zip64
+    ? | == count 65535 == cd_off 4294967295 { ^ @ !ZipArchive ZipErr { F ZipUnsupported } } {}
+    : s entries ( nurl_zalloc * count 56 )
+    : ~ i pos cd_off
+    : ~ i e 0
+    : ~ b bad F
+    ~ & < e count ! bad {
+        ? | > + pos 46 n != ( __zip_rd_u32 p pos ) 0x02014b50 { = bad T } {
+            : i method ( __zip_rd_u16 p + pos 10 )
+            : i crc ( __zip_rd_u32 p + pos 16 )
+            : i csize ( __zip_rd_u32 p + pos 20 )
+            : i usize ( __zip_rd_u32 p + pos 24 )
+            : i nlen ( __zip_rd_u16 p + pos 28 )
+            : i xlen ( __zip_rd_u16 p + pos 30 )
+            : i clen ( __zip_rd_u16 p + pos 32 )
+            : i lho ( __zip_rd_u32 p + pos 42 )
+            : i eoff * e 7
+            ( nurl_poke entries + eoff 0 + pos 46 )   // name_off
+            ( nurl_poke entries + eoff 1 nlen )
+            ( nurl_poke entries + eoff 2 method )
+            ( nurl_poke entries + eoff 3 csize )
+            ( nurl_poke entries + eoff 4 usize )
+            ( nurl_poke entries + eoff 5 lho )
+            ( nurl_poke entries + eoff 6 crc )
+            = pos + + + pos 46 nlen + xlen clen
+            = e + e 1
+        }
+    }
+    ? bad {
+        ( nurl_free entries )
+        ^ @ !ZipArchive ZipErr { F ZipBadArchive }
+    } {}
+    : s ctl ( nurl_zalloc 32 )
+    ( nurl_poke ctl 0 count )
+    ( nurl_poke ctl 1 # i entries )
+    ( nurl_poke ctl 2 # i ( vec_data [u] bytes ) )
+    ( nurl_poke ctl 3 n )
+    ^ @ !ZipArchive ZipErr { T @ ZipArchive { ctl } }
+}
+
+@ zip_name_at ZipArchive a i idx → ?String {
+    ? | < idx 0 >= idx ( zip_count a ) { ^ @ ?String { F } } {}
+    : *u p # *u ( nurl_peek . a ctl 2 )
+    : i off ( __zip_entry a idx 0 )
+    : i len ( __zip_entry a idx 1 )
+    ^ @ ?String { T ( string_from_bytes # *u + # i p off len ) }
+}
+
+@ zip_size_at ZipArchive a i idx → ?i {
+    ? | < idx 0 >= idx ( zip_count a ) { ^ @ ?i { F } } {}
+    ^ @ ?i { T ( __zip_entry a idx 4 ) }
+}
+
+@ zip_extract ZipArchive a i idx → !( Vec u ) ZipErr {
+    ? | < idx 0 >= idx ( zip_count a ) { ^ @ !( Vec u ) ZipErr { F ZipNotFound } } {}
+    : *u p # *u ( nurl_peek . a ctl 2 )
+    : i n ( nurl_peek . a ctl 3 )
+    : i method ( __zip_entry a idx 2 )
+    : i csize ( __zip_entry a idx 3 )
+    : i usize ( __zip_entry a idx 4 )
+    : i lho ( __zip_entry a idx 5 )
+    : i want_crc ( __zip_entry a idx 6 )
+    // skip the LOCAL header (its name/extra lens can differ from CD's)
+    ? | > + lho 30 n != ( __zip_rd_u32 p lho ) 0x04034b50 { ^ @ !( Vec u ) ZipErr { F ZipBadArchive } } {}
+    : i lnlen ( __zip_rd_u16 p + lho 26 )
+    : i lxlen ( __zip_rd_u16 p + lho 28 )
+    : i doff + + + lho 30 lnlen lxlen
+    ? > + doff csize n { ^ @ !( Vec u ) ZipErr { F ZipBadArchive } } {}
+    : ~ ?( Vec u ) got @ ?( Vec u ) { F }
+    ? == method 0 {
+        : ( Vec u ) out ( vec_with_cap [u] ? > usize 0 usize 1 )
+        ( nurl_memcpy ( vec_data [u] out ) # *u + # i p doff csize )
+        : b _ok ( vec_set_len [u] out csize )
+        = got @ ?( Vec u ) { T out }
+    } {
+        ? == method 8 {
+            = got ( __zip_inflate p doff csize usize )
+        } { ^ @ !( Vec u ) ZipErr { F ZipUnsupported } }
+    }
+    ?? got {
+        T out → {
+            : i have_crc ( crc32 0 ( vec_data [u] out ) ( vec_len [u] out ) )
+            ? != have_crc want_crc {
+                ( vec_free [u] out )
+                ^ @ !( Vec u ) ZipErr { F ZipCrc }
+            } {}
+            ^ @ !( Vec u ) ZipErr { T out }
+        }
+        F → { ^ @ !( Vec u ) ZipErr { F ZipInflate } }
+    }
+}
+
+@ zip_extract_name ZipArchive a s name → !( Vec u ) ZipErr {
+    : i nlen ( nurl_str_len name )
+    : *u p # *u ( nurl_peek . a ctl 2 )
+    : i count ( zip_count a )
+    : ~ i e 0
+    ~ < e count {
+        ? == ( __zip_entry a e 1 ) nlen {
+            : i noff ( __zip_entry a e 0 )
+            : ~ i k 0
+            : ~ b eq T
+            ~ & < k nlen eq {
+                ? != # i . p + noff k ( nurl_str_get name k ) { = eq F } {}
+                = k + k 1
+            }
+            ? eq { ^ ( zip_extract a e ) } {}
+        } {}
+        = e + e 1
+    }
+    ^ @ !( Vec u ) ZipErr { F ZipNotFound }
+}
+
+@ zip_close ZipArchive a → v {
+    ( nurl_free # s ( nurl_peek . a ctl 1 ) )
+    ( nurl_free . a ctl )
+}

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -828,6 +828,7 @@ int  poll(void *fds, unsigned long n, int timeout) {
 #  include <sys/wait.h>
 #  include <unistd.h>
 #  include <sys/mman.h>
+#  include <termios.h>
 #endif
 #ifdef NURL_HAVE_ZLIB
 #  include <zlib.h>
@@ -860,6 +861,7 @@ long long nurl_native_sizeof(const char *name) {
 #if !defined(_WIN32) && !defined(__wasi__)
     if (strcmp(name, "struct pollfd")       == 0) return (long long)sizeof(struct pollfd);
     if (strcmp(name, "pid_t")               == 0) return (long long)sizeof(pid_t);
+    if (strcmp(name, "struct termios")      == 0) return (long long)sizeof(struct termios);
 #endif
     if (strcmp(name, "int")                 == 0) return (long long)sizeof(int);
     if (strcmp(name, "long")                == 0) return (long long)sizeof(long);
@@ -943,6 +945,9 @@ long long nurl_native_constant(const char *name) {
     /* AF_UNIX / SOCK_STREAM for stdlib/std/unixsock.nu (local IPC). */
     if (strcmp(name, "AF_UNIX")     == 0) return AF_UNIX;
     if (strcmp(name, "SOCK_STREAM") == 0) return SOCK_STREAM;
+    /* termios actions for stdlib/std/term.nu (raw mode). */
+    if (strcmp(name, "TCSANOW")     == 0) return TCSANOW;
+    if (strcmp(name, "TCSAFLUSH")   == 0) return TCSAFLUSH;
 #endif
     /* CLOCK_* values differ per platform (CLOCK_MONOTONIC is 6 on
      * macOS, 1 elsewhere); wasi-libc spells them as pointer macros. */

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -3381,6 +3381,76 @@ long long nurl_tcp_connect_tls(const char *host, long long port,
 #endif
 }
 
+/* In-place TLS upgrade of an already-connected plaintext CONN handle —
+ * the STARTTLS pattern (SMTP RFC 3207, IMAP, POP3, XMPP, FTP). The
+ * caller has dialed plaintext with nurl_tcp_connect, exchanged the
+ * protocol's pre-TLS greeting (e.g. EHLO + STARTTLS, read the 220), and
+ * now drives the client handshake over the SAME fd. On success the
+ * handle becomes a TLS conn (read/write dispatch via libssl from here
+ * on); on failure the fd is closed and err_kind is set, exactly like a
+ * failed nurl_tcp_connect_tls. Returns the same handle (as i64) so the
+ * caller re-reads err_kind. `host` drives SNI + (when verify) hostname
+ * verification. A no-op error if the handle is already TLS. */
+long long nurl_tcp_starttls(long long conn, const char *host,
+                            long long verify) {
+    NurlTcp *h = (NurlTcp*)(uintptr_t)conn;
+    if (!h) return conn;
+#ifndef NURL_HAVE_OPENSSL
+    (void)host; (void)verify;
+    h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
+    return conn;
+#else
+    if (h->ssl) {                       /* already secured — refuse */
+        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
+        return conn;
+    }
+    if (h->fd == NURL_INVALID_SOCK) {
+        h->err_kind = NURL_NET_ERR_CLOSED;
+        return conn;
+    }
+
+    SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
+    if (!ctx) {
+        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
+        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
+        return conn;
+    }
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+    if (verify) {
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+        SSL_CTX_set_default_verify_paths(ctx);
+    } else {
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+    }
+
+    SSL *ssl = SSL_new(ctx);
+    if (!ssl) {
+        SSL_CTX_free(ctx);
+        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
+        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
+        return conn;
+    }
+    if (host && *host) {
+        SSL_set_tlsext_host_name(ssl, host);
+        if (verify) SSL_set1_host(ssl, host);
+    }
+    SSL_set_fd(ssl, (int)h->fd);
+
+    if (SSL_connect(ssl) != 1) {
+        SSL_free(ssl);
+        SSL_CTX_free(ctx);
+        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
+        h->err_kind = NURL_NET_ERR_TLS_HANDSHAKE;
+        return conn;
+    }
+
+    h->ssl      = ssl;
+    h->ssl_ctx  = ctx;
+    h->err_kind = NURL_NET_ERR_OK;
+    return conn;
+#endif
+}
+
 /* Client-side TLS connect WITH ALPN (RFC 7301) — required to speak
  * HTTP/2 ("h2") to real-world servers, which only switch to h2 when the
  * client offers it via ALPN (RFC 9113 §3.3). Identical to

--- a/stdlib/std/btree.nu
+++ b/stdlib/std/btree.nu
@@ -1,0 +1,625 @@
+// stdlib/std/btree.nu — owned generic ordered map, B-tree backed.
+//
+// The write-optimized sibling of std/ordmap.nu: same comparator
+// convention and API shape, but O(log n) insert/remove instead of the
+// flat map's O(n) shifts. Use OrdMap for small/medium maps (simpler,
+// cache-friendly); switch here when write volume on a large map is the
+// bottleneck. Per-node subtree sizes give O(log n) `key_at`/`val_at`
+// (order statistics), so ordered indexed iteration works exactly like
+// OrdMap's.
+//
+// Classic B-tree of minimum degree t = 8: every node holds 7..15 keys
+// (root 1..15) and leaf nodes sit at one depth. Insert splits full
+// nodes on the way down; remove borrows/merges under-full nodes on the
+// way down (CLRS shape), so neither ever backtracks.
+//
+// Ordering is decided by a key comparator `cmp : (@ i K K)` passed to
+// every keyed call (sort_by convention): `cmp a b` < 0 / 0 / > 0. Use
+// the SAME comparator for a map's whole lifetime.
+//
+//   ( btree_new       [K V] )              → ( BTree K V )
+//   ( btree_len       [K V] m )            → i
+//   ( btree_is_empty  [K V] m )            → b
+//   ( btree_get       [K V] m k cmp )      → ? V
+//   ( btree_set       [K V] m k v cmp )    → ? V   Some(prev) on replace
+//   ( btree_remove    [K V] m k cmp )      → ? V   Some(val) if removed
+//   ( btree_contains  [K V] m k cmp )      → b
+//   ( btree_key_at    [K V] m i )          → ? K   i-th smallest key
+//   ( btree_val_at    [K V] m i )          → ? V   its value
+//   ( btree_min_key   [K V] m )            → ? K
+//   ( btree_max_key   [K V] m )            → ? K
+//   ( btree_each      [K V] m f )          → v     f:(@ v K V), in order
+//   ( btree_free      [K V] m )            → v     trivial K/V
+//   ( btree_free_with [K V] m dk dv )      → v     dk:(@ v K) dv:(@ v V)
+//
+// Ownership: mirrors OrdMap. On btree_set REPLACE the existing equal
+// key is kept and the passed-in `k` is NOT stored — for owned keys the
+// caller still owns that `k`. btree_remove returns the value (caller
+// frees an owned V); the removed key's storage is bitwise-dropped, so
+// owned-key maps should prefer bulk teardown via btree_free_with.
+//
+// Node layout (heap block, 6 × i64 slots via nurl_peek/poke):
+//   slot 0: keys ptr   (*K, capacity 15)
+//   slot 1: vals ptr   (*V, capacity 15)
+//   slot 2: kids ptr   (*i, capacity 16 node pointers; leaf → unused)
+//   slot 3: nkeys
+//   slot 4: leaf flag  (1 = leaf)
+//   slot 5: size       (total entries in this subtree)
+// Tree control block (2 × i64): slot 0 root ptr (0 = empty), slot 1 len.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+: BTree [K V] { s ctl }
+
+: i BT_MAXK 15   // 2t-1 keys
+: i BT_MINK 7    // t-1
+: i BT_DEG 8     // t
+
+// ── node primitives ─────────────────────────────────────────────────
+
+@ __bt_node_new [K V] i leaf → s {
+    : s n ( nurl_zalloc 48 )
+    ( nurl_poke n 0 # i ( nurl_zalloc * Z K BT_MAXK ) )
+    ( nurl_poke n 1 # i ( nurl_zalloc * Z V BT_MAXK ) )
+    ? == leaf 1 {} { ( nurl_poke n 2 # i ( nurl_zalloc * 8 16 ) ) }
+    ( nurl_poke n 4 leaf )
+    ^ n
+}
+
+@ __bt_nkeys s n → i { ^ ( nurl_peek n 3 ) }
+@ __bt_leaf s n → b { ^ == ( nurl_peek n 4 ) 1 }
+@ __bt_size s n → i { ^ ( nurl_peek n 5 ) }
+@ __bt_kid s n i idx → s {
+    : *i kp # *i ( nurl_peek n 2 )
+    ^ # s . kp idx
+}
+@ __bt_set_kid s n i idx s child → v {
+    : *i kp # *i ( nurl_peek n 2 )
+    = . kp idx # i child
+}
+
+// Recompute slot 5 from nkeys + child sizes (used after split/merge).
+@ __bt_recount s n → v {
+    : ~ i total ( __bt_nkeys n )
+    ? ( __bt_leaf n ) {} {
+        : i nk ( __bt_nkeys n )
+        : ~ i c 0
+        ~ <= c nk { = total + total ( __bt_size ( __bt_kid n c ) ) = c + c 1 }
+    }
+    ( nurl_poke n 5 total )
+}
+
+// Free a node block (arrays + block). Entries must already be handled.
+@ __bt_node_free s n → v {
+    ( nurl_free # s ( nurl_peek n 0 ) )
+    ( nurl_free # s ( nurl_peek n 1 ) )
+    ? ( __bt_leaf n ) {} { ( nurl_free # s ( nurl_peek n 2 ) ) }
+    ( nurl_free n )
+}
+
+// ── construction / size ─────────────────────────────────────────────
+
+@ btree_new [K V] → ( BTree K V ) {
+    : s ctl ( nurl_zalloc 16 )
+    ^ @ ( BTree K V ) { ctl }
+}
+
+@ btree_len [K V] ( BTree K V ) m → i { ^ ( nurl_peek . m ctl 1 ) }
+@ btree_is_empty [K V] ( BTree K V ) m → b { ^ == ( btree_len [K V] m ) 0 }
+
+// ── search ──────────────────────────────────────────────────────────
+
+// Index of the first key in `n` that is >= k (0..nkeys).
+@ __bt_lower [K V] s n K k ( @ i K K ) cmp → i {
+    : *K kp # *K ( nurl_peek n 0 )
+    : i nk ( __bt_nkeys n )
+    : ~ i lo 0
+    : ~ i hi nk
+    ~ < lo hi {
+        : i mid / + lo hi 2
+        ? < ( cmp . kp mid k ) 0 { = lo + mid 1 } { = hi mid }
+    }
+    ^ lo
+}
+
+@ btree_get [K V] ( BTree K V ) m K k ( @ i K K ) cmp → ?V {
+    : ~ s n # s ( nurl_peek . m ctl 0 )
+    ~ != 0 # i n {
+        : i pos ( __bt_lower [K V] n k cmp )
+        : *K kp # *K ( nurl_peek n 0 )
+        ? & < pos ( __bt_nkeys n ) == ( cmp . kp pos k ) 0 {
+            : *V vp # *V ( nurl_peek n 1 )
+            ^ @ ?V { T . vp pos }
+        } {}
+        ? ( __bt_leaf n ) { ^ @ ?V { F } } {}
+        = n ( __bt_kid n pos )
+    }
+    ^ @ ?V { F }
+}
+
+@ btree_contains [K V] ( BTree K V ) m K k ( @ i K K ) cmp → b {
+    : ?V r ( btree_get [K V] m k cmp )
+    ^ ?? r { T _ → T F → F }
+}
+
+// ── insert ──────────────────────────────────────────────────────────
+
+// Split the full child `c` (at child index ci of parent `p`): median key
+// moves up into p, right half moves into a fresh sibling.
+@ __bt_split_child [K V] s p i ci s c → v {
+    : i leaf ? ( __bt_leaf c ) 1 0
+    : s right ( __bt_node_new [K V] leaf )
+    : *K ck # *K ( nurl_peek c 0 )
+    : *V cv # *V ( nurl_peek c 1 )
+    : *K rk # *K ( nurl_peek right 0 )
+    : *V rv # *V ( nurl_peek right 1 )
+    // right gets keys t..2t-2 (7 of them)
+    : ~ i j 0
+    ~ < j BT_MINK {
+        = . rk j . ck + j BT_DEG
+        = . rv j . cv + j BT_DEG
+        = j + j 1
+    }
+    ? == leaf 1 {} {
+        : ~ i j2 0
+        ~ <= j2 BT_MINK {
+            ( __bt_set_kid right j2 ( __bt_kid c + j2 BT_DEG ) )
+            = j2 + j2 1
+        }
+    }
+    ( nurl_poke right 3 BT_MINK )
+    ( nurl_poke c 3 BT_MINK )
+    // shift parent kids right of ci, insert `right` at ci+1
+    : i pn ( __bt_nkeys p )
+    : ~ i kk pn
+    ~ > kk ci {
+        ( __bt_set_kid p + kk 1 ( __bt_kid p kk ) )
+        = kk - kk 1
+    }
+    ( __bt_set_kid p + ci 1 right )
+    // shift parent keys/vals right of ci, lift c's median (index t-1)
+    : *K pk # *K ( nurl_peek p 0 )
+    : *V pv # *V ( nurl_peek p 1 )
+    : ~ i mm pn
+    ~ > mm ci {
+        = . pk mm . pk - mm 1
+        = . pv mm . pv - mm 1
+        = mm - mm 1
+    }
+    = . pk ci . ck BT_MINK
+    = . pv ci . cv BT_MINK
+    ( nurl_poke p 3 + pn 1 )
+    ( __bt_recount c )
+    ( __bt_recount right )
+}
+
+// Insert into the non-full subtree rooted at `n`. Returns Some(prev) on
+// replace, None on fresh insert (caller bumps len + path sizes).
+@ __bt_insert_nonfull [K V] s n K k V v ( @ i K K ) cmp → ?V {
+    : i pos ( __bt_lower [K V] n k cmp )
+    : *K kp # *K ( nurl_peek n 0 )
+    : *V vp # *V ( nurl_peek n 1 )
+    : i nk ( __bt_nkeys n )
+    ? & < pos nk == ( cmp . kp pos k ) 0 {
+        : V prev . vp pos
+        = . vp pos v
+        ^ @ ?V { T prev }
+    } {}
+    ? ( __bt_leaf n ) {
+        : ~ i j nk
+        ~ > j pos {
+            = . kp j . kp - j 1
+            = . vp j . vp - j 1
+            = j - j 1
+        }
+        = . kp pos k
+        = . vp pos v
+        ( nurl_poke n 3 + nk 1 )
+        ( nurl_poke n 5 + ( __bt_size n ) 1 )
+        ^ @ ?V { F }
+    } {}
+    : ~ i ci pos
+    : ~ s c ( __bt_kid n ci )
+    ? == ( __bt_nkeys c ) BT_MAXK {
+        ( __bt_split_child [K V] n ci c )
+        // after the lift, re-test against the lifted key
+        : *K kp2 # *K ( nurl_peek n 0 )
+        : i cr ( cmp . kp2 ci k )
+        ? == cr 0 {
+            : *V vp2 # *V ( nurl_peek n 1 )
+            : V prev . vp2 ci
+            = . vp2 ci v
+            ^ @ ?V { T prev }
+        } {}
+        ? < cr 0 { = ci + ci 1 } {}
+        = c ( __bt_kid n ci )
+    } {}
+    : ?V r ( __bt_insert_nonfull [K V] c k v cmp )
+    ?? r {
+        T prev → { ^ @ ?V { T prev } }
+        F _ → {
+            ( nurl_poke n 5 + ( __bt_size n ) 1 )
+            ^ @ ?V { F }
+        }
+    }
+}
+
+@ btree_set [K V] ( BTree K V ) m K k V v ( @ i K K ) cmp → ?V {
+    : s ctl . m ctl
+    : ~ s root # s ( nurl_peek ctl 0 )
+    ? == 0 # i root {
+        = root ( __bt_node_new [K V] 1 )
+        ( nurl_poke ctl 0 # i root )
+    } {}
+    ? == ( __bt_nkeys root ) BT_MAXK {
+        : s nr ( __bt_node_new [K V] 0 )
+        ( __bt_set_kid nr 0 root )
+        ( __bt_recount nr )
+        ( __bt_split_child [K V] nr 0 root )
+        ( nurl_poke ctl 0 # i nr )
+        = root nr
+    } {}
+    : ?V r ( __bt_insert_nonfull [K V] root k v cmp )
+    ?? r {
+        T prev → { ^ @ ?V { T prev } }
+        F _ → {
+            ( nurl_poke ctl 1 + ( nurl_peek ctl 1 ) 1 )
+            ^ @ ?V { F }
+        }
+    }
+}
+
+// ── order statistics / min / max ────────────────────────────────────
+
+@ btree_key_at [K V] ( BTree K V ) m i want → ?K {
+    ? | < want 0 >= want ( btree_len [K V] m ) { ^ @ ?K { F } } {}
+    : ~ s n # s ( nurl_peek . m ctl 0 )
+    : ~ i idx want
+    : ~ b going T
+    ~ going {
+        : *K kp # *K ( nurl_peek n 0 )
+        : i nk ( __bt_nkeys n )
+        ? ( __bt_leaf n ) { ^ @ ?K { T . kp idx } } {}
+        : ~ i c 0
+        : ~ b stepped F
+        ~ & <= c nk ! stepped {
+            : i csz ( __bt_size ( __bt_kid n c ) )
+            ? < idx csz { = n ( __bt_kid n c ) = stepped T } {
+                = idx - idx csz
+                ? & == stepped F < c nk {
+                    ? == idx 0 { ^ @ ?K { T . kp c } } {}
+                    = idx - idx 1
+                } {}
+                = c + c 1
+            }
+        }
+    }
+    ^ @ ?K { F }
+}
+
+@ btree_val_at [K V] ( BTree K V ) m i want → ?V {
+    ? | < want 0 >= want ( btree_len [K V] m ) { ^ @ ?V { F } } {}
+    : ~ s n # s ( nurl_peek . m ctl 0 )
+    : ~ i idx want
+    : ~ b going T
+    ~ going {
+        : *V vp # *V ( nurl_peek n 1 )
+        : i nk ( __bt_nkeys n )
+        ? ( __bt_leaf n ) { ^ @ ?V { T . vp idx } } {}
+        : ~ i c 0
+        : ~ b stepped F
+        ~ & <= c nk ! stepped {
+            : i csz ( __bt_size ( __bt_kid n c ) )
+            ? < idx csz { = n ( __bt_kid n c ) = stepped T } {
+                = idx - idx csz
+                ? & == stepped F < c nk {
+                    ? == idx 0 { ^ @ ?V { T . vp c } } {}
+                    = idx - idx 1
+                } {}
+                = c + c 1
+            }
+        }
+    }
+    ^ @ ?V { F }
+}
+
+@ btree_min_key [K V] ( BTree K V ) m → ?K { ^ ( btree_key_at [K V] m 0 ) }
+@ btree_max_key [K V] ( BTree K V ) m → ?K { ^ ( btree_key_at [K V] m - ( btree_len [K V] m ) 1 ) }
+
+// ── in-order traversal ──────────────────────────────────────────────
+
+@ __bt_each_node [K V] s n ( @ v K V ) f → v {
+    : *K kp # *K ( nurl_peek n 0 )
+    : *V vp # *V ( nurl_peek n 1 )
+    : i nk ( __bt_nkeys n )
+    : ~ i j 0
+    ~ < j nk {
+        ? ( __bt_leaf n ) {} { ( __bt_each_node [K V] ( __bt_kid n j ) f ) }
+        ( f . kp j . vp j )
+        = j + j 1
+    }
+    ? ( __bt_leaf n ) {} { ( __bt_each_node [K V] ( __bt_kid n nk ) f ) }
+}
+
+@ btree_each [K V] ( BTree K V ) m ( @ v K V ) f → v {
+    : s root # s ( nurl_peek . m ctl 0 )
+    ? == 0 # i root { ^ v } {}
+    ( __bt_each_node [K V] root f )
+}
+
+// ── remove (CLRS, proactive borrow/merge on the way down) ───────────
+
+// Merge kids[ci] + parent key ci + kids[ci+1] into kids[ci]. Both kids
+// hold exactly t-1 keys when called.
+@ __bt_merge [K V] s n i ci → v {
+    : s left ( __bt_kid n ci )
+    : s right ( __bt_kid n + ci 1 )
+    : *K lk # *K ( nurl_peek left 0 )
+    : *V lv # *V ( nurl_peek left 1 )
+    : *K rk # *K ( nurl_peek right 0 )
+    : *V rv # *V ( nurl_peek right 1 )
+    : *K nk2 # *K ( nurl_peek n 0 )
+    : *V nv2 # *V ( nurl_peek n 1 )
+    // parent separator drops into left[t-1]
+    = . lk BT_MINK . nk2 ci
+    = . lv BT_MINK . nv2 ci
+    : ~ i j 0
+    ~ < j BT_MINK {
+        = . lk + BT_DEG j . rk j
+        = . lv + BT_DEG j . rv j
+        = j + j 1
+    }
+    ? ( __bt_leaf left ) {} {
+        : ~ i j2 0
+        ~ <= j2 BT_MINK {
+            ( __bt_set_kid left + BT_DEG j2 ( __bt_kid right j2 ) )
+            = j2 + j2 1
+        }
+    }
+    ( nurl_poke left 3 BT_MAXK )
+    // close the gap in n
+    : i pn ( __bt_nkeys n )
+    : ~ i m ci
+    ~ < m - pn 1 {
+        = . nk2 m . nk2 + m 1
+        = . nv2 m . nv2 + m 1
+        ( __bt_set_kid n + m 1 ( __bt_kid n + m 2 ) )
+        = m + m 1
+    }
+    ( nurl_poke n 3 - pn 1 )
+    ( __bt_node_free right )
+    ( __bt_recount left )
+}
+
+// Ensure kids[ci] of `n` has at least t keys before descending: borrow
+// from a sibling with spare keys, else merge. Returns the (possibly
+// changed) child index to descend into.
+@ __bt_fixup [K V] s n i ci → i {
+    : s c ( __bt_kid n ci )
+    ? >= ( __bt_nkeys c ) BT_DEG { ^ ci } {}
+    : *K nk2 # *K ( nurl_peek n 0 )
+    : *V nv2 # *V ( nurl_peek n 1 )
+    : *K ck # *K ( nurl_peek c 0 )
+    : *V cv # *V ( nurl_peek c 1 )
+    : i cn ( __bt_nkeys c )
+    // borrow from left sibling
+    ? > ci 0 {
+        : s ls ( __bt_kid n - ci 1 )
+        ? > ( __bt_nkeys ls ) BT_MINK {
+            : *K lk # *K ( nurl_peek ls 0 )
+            : *V lv # *V ( nurl_peek ls 1 )
+            : i ln ( __bt_nkeys ls )
+            // shift c right one
+            : ~ i j cn
+            ~ > j 0 {
+                = . ck j . ck - j 1
+                = . cv j . cv - j 1
+                = j - j 1
+            }
+            ? ( __bt_leaf c ) {} {
+                : ~ i j2 + cn 1
+                ~ > j2 0 {
+                    ( __bt_set_kid c j2 ( __bt_kid c - j2 1 ) )
+                    = j2 - j2 1
+                }
+                ( __bt_set_kid c 0 ( __bt_kid ls ln ) )
+            }
+            = . ck 0 . nk2 - ci 1
+            = . cv 0 . nv2 - ci 1
+            = . nk2 - ci 1 . lk - ln 1
+            = . nv2 - ci 1 . lv - ln 1
+            ( nurl_poke c 3 + cn 1 )
+            ( nurl_poke ls 3 - ln 1 )
+            ( __bt_recount ls )
+            ( __bt_recount c )
+            ^ ci
+        } {}
+    } {}
+    // borrow from right sibling
+    ? < ci ( __bt_nkeys n ) {
+        : s rs ( __bt_kid n + ci 1 )
+        ? > ( __bt_nkeys rs ) BT_MINK {
+            : *K rk # *K ( nurl_peek rs 0 )
+            : *V rv # *V ( nurl_peek rs 1 )
+            : i rn ( __bt_nkeys rs )
+            = . ck cn . nk2 ci
+            = . cv cn . nv2 ci
+            ? ( __bt_leaf c ) {} {
+                ( __bt_set_kid c + cn 1 ( __bt_kid rs 0 ) )
+            }
+            = . nk2 ci . rk 0
+            = . nv2 ci . rv 0
+            // shift rs left one
+            : ~ i j 0
+            ~ < j - rn 1 {
+                = . rk j . rk + j 1
+                = . rv j . rv + j 1
+                = j + j 1
+            }
+            ? ( __bt_leaf rs ) {} {
+                : ~ i j2 0
+                ~ < j2 rn {
+                    ( __bt_set_kid rs j2 ( __bt_kid rs + j2 1 ) )
+                    = j2 + j2 1
+                }
+            }
+            ( nurl_poke c 3 + cn 1 )
+            ( nurl_poke rs 3 - rn 1 )
+            ( __bt_recount rs )
+            ( __bt_recount c )
+            ^ ci
+        } {}
+    } {}
+    // merge with a sibling
+    ? > ci 0 {
+        ( __bt_merge [K V] n - ci 1 )
+        ^ - ci 1
+    } {}
+    ( __bt_merge [K V] n ci )
+    ^ ci
+}
+
+// Remove k from the subtree at `n` (which has ≥ t keys unless root).
+// Returns Some(removed value).
+@ __bt_remove_rec [K V] s n K k ( @ i K K ) cmp → ?V {
+    : i pos ( __bt_lower [K V] n k cmp )
+    : *K kp # *K ( nurl_peek n 0 )
+    : *V vp # *V ( nurl_peek n 1 )
+    : i nk ( __bt_nkeys n )
+    : b here & < pos nk == ( cmp . kp pos k ) 0
+    ? ( __bt_leaf n ) {
+        ? here {} { ^ @ ?V { F } }
+        : V out . vp pos
+        : ~ i j pos
+        ~ < j - nk 1 {
+            = . kp j . kp + j 1
+            = . vp j . vp + j 1
+            = j + j 1
+        }
+        ( nurl_poke n 3 - nk 1 )
+        ( nurl_poke n 5 - ( __bt_size n ) 1 )
+        ^ @ ?V { T out }
+    } {}
+    ? here {
+        : V out . vp pos
+        : s lc ( __bt_kid n pos )
+        ? >= ( __bt_nkeys lc ) BT_DEG {
+            // replace with predecessor (max of left subtree), recurse
+            : ~ s pn lc
+            ~ ! ( __bt_leaf pn ) { = pn ( __bt_kid pn ( __bt_nkeys pn ) ) }
+            : *K pk # *K ( nurl_peek pn 0 )
+            : *V pv # *V ( nurl_peek pn 1 )
+            : K predk . pk - ( __bt_nkeys pn ) 1
+            : V predv . pv - ( __bt_nkeys pn ) 1
+            = . kp pos predk
+            = . vp pos predv
+            : ?V sub ( __bt_remove_rec [K V] lc predk cmp )
+            ?? sub { T _ → {} F _ → {} }
+            ( nurl_poke n 5 - ( __bt_size n ) 1 )
+            ^ @ ?V { T out }
+        } {}
+        : s rc ( __bt_kid n + pos 1 )
+        ? >= ( __bt_nkeys rc ) BT_DEG {
+            // replace with successor (min of right subtree)
+            : ~ s sn rc
+            ~ ! ( __bt_leaf sn ) { = sn ( __bt_kid sn 0 ) }
+            : *K sk # *K ( nurl_peek sn 0 )
+            : *V sv # *V ( nurl_peek sn 1 )
+            : K succk . sk 0
+            : V succv . sv 0
+            = . kp pos succk
+            = . vp pos succv
+            : ?V sub ( __bt_remove_rec [K V] rc succk cmp )
+            ?? sub { T _ → {} F _ → {} }
+            ( nurl_poke n 5 - ( __bt_size n ) 1 )
+            ^ @ ?V { T out }
+        } {}
+        // both kids minimal: merge them around the key, recurse into merge
+        ( __bt_merge [K V] n pos )
+        : ?V sub ( __bt_remove_rec [K V] ( __bt_kid n pos ) k cmp )
+        ?? sub {
+            T got → {
+                ( nurl_poke n 5 - ( __bt_size n ) 1 )
+                ^ @ ?V { T got }
+            }
+            F _ → { ^ @ ?V { F } }
+        }
+    } {}
+    // not in this node: descend (fix the child up first)
+    : i ci ( __bt_fixup [K V] n pos )
+    : ?V sub ( __bt_remove_rec [K V] ( __bt_kid n ci ) k cmp )
+    ?? sub {
+        T got → {
+            ( nurl_poke n 5 - ( __bt_size n ) 1 )
+            ^ @ ?V { T got }
+        }
+        F _ → { ^ @ ?V { F } }
+    }
+}
+
+@ btree_remove [K V] ( BTree K V ) m K k ( @ i K K ) cmp → ?V {
+    : s ctl . m ctl
+    : s root # s ( nurl_peek ctl 0 )
+    ? == 0 # i root { ^ @ ?V { F } } {}
+    : ?V r ( __bt_remove_rec [K V] root k cmp )
+    ?? r {
+        T got → {
+            ( nurl_poke ctl 1 - ( nurl_peek ctl 1 ) 1 )
+            // shrink the root: empty internal root → its sole child
+            : s root2 # s ( nurl_peek ctl 0 )
+            ? & == ( __bt_nkeys root2 ) 0 ! ( __bt_leaf root2 ) {
+                : s only ( __bt_kid root2 0 )
+                ( __bt_node_free root2 )
+                ( nurl_poke ctl 0 # i only )
+            } {
+                ? & == ( __bt_nkeys root2 ) 0 ( __bt_leaf root2 ) {
+                    ( __bt_node_free root2 )
+                    ( nurl_poke ctl 0 0 )
+                } {}
+            }
+            ^ @ ?V { T got }
+        }
+        F _ → { ^ @ ?V { F } }
+    }
+}
+
+// ── teardown ────────────────────────────────────────────────────────
+
+@ __bt_free_rec [K V] s n → v {
+    ? ( __bt_leaf n ) {} {
+        : i nk ( __bt_nkeys n )
+        : ~ i c 0
+        ~ <= c nk { ( __bt_free_rec [K V] ( __bt_kid n c ) ) = c + c 1 }
+    }
+    ( __bt_node_free n )
+}
+
+@ btree_free [K V] ( BTree K V ) m → v {
+    : s root # s ( nurl_peek . m ctl 0 )
+    ? == 0 # i root {} { ( __bt_free_rec [K V] root ) }
+    ( nurl_free . m ctl )
+}
+
+@ __bt_free_with_rec [K V] s n ( @ v K ) dk ( @ v V ) dv → v {
+    : *K kp # *K ( nurl_peek n 0 )
+    : *V vp # *V ( nurl_peek n 1 )
+    : i nk ( __bt_nkeys n )
+    : ~ i j 0
+    ~ < j nk {
+        ( dk . kp j )
+        ( dv . vp j )
+        = j + j 1
+    }
+    ? ( __bt_leaf n ) {} {
+        : ~ i c 0
+        ~ <= c nk { ( __bt_free_with_rec [K V] ( __bt_kid n c ) dk dv ) = c + c 1 }
+    }
+    ( __bt_node_free n )
+}
+
+@ btree_free_with [K V] ( BTree K V ) m ( @ v K ) dk ( @ v V ) dv → v {
+    : s root # s ( nurl_peek . m ctl 0 )
+    ? == 0 # i root {} { ( __bt_free_with_rec [K V] root dk dv ) }
+    ( nurl_free . m ctl )
+}

--- a/stdlib/std/term.nu
+++ b/stdlib/std/term.nu
@@ -1,0 +1,291 @@
+// stdlib/std/term.nu — terminal control: raw mode, isatty, ANSI, line editor.
+//
+// The prerequisite for a REPL (critic C1) and TUI examples. POSIX
+// termios via libc FFI (struct termios sized by nurl_native_sizeof, so
+// the platform layout never leaks into NURL); ANSI helpers are pure
+// string builders; the line editor is a minimal raw-mode loop with
+// history + cursor movement.
+//
+//   ( term_is_tty i fd )            → b
+//   ( term_raw_enable i fd )        → ? TermState   None: not a tty / failed
+//   ( term_raw_disable TermState )  → v             restore + free
+//
+//   ( ansi_reset )                  → String  ESC[0m
+//   ( ansi_sgr i code )             → String  ESC[<code>m   (1 bold, 4 underline…)
+//   ( ansi_fg i color )             → String  ESC[38;5;<n>m (256-color)
+//   ( ansi_bg i color )             → String  ESC[48;5;<n>m
+//   ( ansi_clear )                  → String  clear screen + home
+//   ( ansi_clear_line )             → String  erase line + CR
+//   ( ansi_cursor_to i row i col )  → String  1-based
+//   ( ansi_cursor_up/down/right/left i n ) → String
+//
+//   ( term_read_line s prompt ( Vec String ) history ) → ? String
+//       Raw-mode line editor on stdin/stdout: printable insert,
+//       backspace, ←/→ cursor, ↑/↓ history (borrowed, newest last),
+//       Ctrl-A/Ctrl-E home/end, Ctrl-K kill-to-end, Enter → Some(line),
+//       Ctrl-C (or Ctrl-D on an empty line) → None. Returns None
+//       immediately when stdin is not a tty — callers fall back to
+//       plain buffered reads.
+//
+// Win32/WASI: termios is absent — term_raw_enable returns None and the
+// ANSI builders still work (Windows Terminal/ConPTY understands VT).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/posix.nu`   // read / write / close / posix_const
+
+& `c` @ isatty i32 fd → i32
+& `c` @ tcgetattr i32 fd s buf → i32
+& `c` @ tcsetattr i32 fd i32 act s buf → i32
+& `c` @ cfmakeraw s buf → v
+
+: TermState { i fd s saved }
+
+@ term_is_tty i fd → b {
+    ^ == # i ( isatty # i32 fd ) 1
+}
+
+// Save the current termios for `fd`, switch it to raw (cfmakeraw:
+// no echo, no canonical buffering, no signal chars). None when fd is
+// not a tty, termios is unsupported on this platform, or any call
+// fails — the terminal is left untouched in every None case.
+@ term_raw_enable i fd → ?TermState {
+    ? ( term_is_tty fd ) {} { ^ @ ?TermState { F } }
+    : i sz ( nurl_native_sizeof `struct termios` )
+    ? <= sz 0 { ^ @ ?TermState { F } } {}
+    : s saved ( nurl_zalloc sz )
+    ? == # i ( tcgetattr # i32 fd saved ) 0 {} {
+        ( nurl_free saved )
+        ^ @ ?TermState { F }
+    }
+    : s raw ( nurl_zalloc sz )
+    ( nurl_memcpy # *u raw # *u saved sz )
+    ( cfmakeraw raw )
+    : i32 rc ( tcsetattr # i32 fd # i32 ( posix_const `TCSAFLUSH` ) raw )
+    ( nurl_free raw )
+    ? == # i rc 0 {} {
+        ( nurl_free saved )
+        ^ @ ?TermState { F }
+    }
+    ^ @ ?TermState { T @ TermState { fd saved } }
+}
+
+@ term_raw_disable TermState st → v {
+    : i32 _rc ( tcsetattr # i32 . st fd # i32 ( posix_const `TCSAFLUSH` ) . st saved )
+    ( nurl_free . st saved )
+}
+
+// ── ANSI builders (ESC = 0x1b cannot ride in a backtick literal) ────
+
+@ __ansi_csi → String {
+    : String s ( string_with_cap 8 )
+    ( string_push_char s 27 )
+    ( string_push_char s 91 )   // '['
+    ^ s
+}
+
+@ ansi_reset → String {
+    : String s ( __ansi_csi )
+    ( string_push_str s `0m` )
+    ^ s
+}
+
+@ ansi_sgr i code → String {
+    : String s ( __ansi_csi )
+    ( string_push_str s ( nurl_str_int code ) )
+    ( string_push_char s 109 )  // 'm'
+    ^ s
+}
+
+@ ansi_fg i color → String {
+    : String s ( __ansi_csi )
+    ( string_push_str s `38;5;` )
+    ( string_push_str s ( nurl_str_int color ) )
+    ( string_push_char s 109 )
+    ^ s
+}
+
+@ ansi_bg i color → String {
+    : String s ( __ansi_csi )
+    ( string_push_str s `48;5;` )
+    ( string_push_str s ( nurl_str_int color ) )
+    ( string_push_char s 109 )
+    ^ s
+}
+
+@ ansi_clear → String {
+    : String s ( __ansi_csi )
+    ( string_push_str s `2J` )
+    : String h ( __ansi_csi )
+    ( string_push_str h `H` )
+    ( string_push_str s ( string_data h ) )
+    ( string_free h )
+    ^ s
+}
+
+@ ansi_clear_line → String {
+    : String s ( __ansi_csi )
+    ( string_push_str s `2K` )
+    ( string_push_char s 13 )   // CR
+    ^ s
+}
+
+@ ansi_cursor_to i row i col → String {
+    : String s ( __ansi_csi )
+    ( string_push_str s ( nurl_str_int row ) )
+    ( string_push_char s 59 )   // ';'
+    ( string_push_str s ( nurl_str_int col ) )
+    ( string_push_char s 72 )   // 'H'
+    ^ s
+}
+
+@ __ansi_move i n i letter → String {
+    : String s ( __ansi_csi )
+    ( string_push_str s ( nurl_str_int n ) )
+    ( string_push_char s letter )
+    ^ s
+}
+
+@ ansi_cursor_up i n → String { ^ ( __ansi_move n 65 ) }     // 'A'
+@ ansi_cursor_down i n → String { ^ ( __ansi_move n 66 ) }   // 'B'
+@ ansi_cursor_right i n → String { ^ ( __ansi_move n 67 ) }  // 'C'
+@ ansi_cursor_left i n → String { ^ ( __ansi_move n 68 ) }   // 'D'
+
+// ── minimal line editor ─────────────────────────────────────────────
+
+// Read one byte from stdin; -1 on EOF/error.
+@ __term_getb → i {
+    : s buf ( nurl_zalloc 1 )
+    : i n ( read 0 # *u buf 1 )
+    : i c ? > n 0 ( nurl_peek buf 0 ) -1
+    ( nurl_free buf )
+    ^ & c 255
+}
+
+// Repaint: CR + erase line + prompt + buffer, then walk the cursor
+// back to `pos`.
+@ __term_repaint s prompt String buf i pos → v {
+    : String cl ( ansi_clear_line )
+    ( nurl_print ( string_data cl ) )
+    ( string_free cl )
+    ( nurl_print prompt )
+    ( nurl_print ( string_data buf ) )
+    : i tail - ( string_len buf ) pos
+    ? > tail 0 {
+        : String back ( ansi_cursor_left tail )
+        ( nurl_print ( string_data back ) )
+        ( string_free back )
+    } {}
+    ( nurl_flush_stdout )
+}
+
+// Replace buf's contents with `src` (used by history recall).
+@ __term_setbuf String buf s src → v {
+    ( string_clear buf )
+    ( string_push_str buf src )
+}
+
+// Remove the byte at `idx` (rebuild via substr — lines are short).
+@ __term_delete_at String buf i idx → v {
+    : i n ( string_len buf )
+    : String head ( string_substr buf 0 idx )
+    : String tail ( string_substr buf + idx 1 - n + idx 1 )
+    ( string_clear buf )
+    ( string_push_str buf ( string_data head ) )
+    ( string_push_str buf ( string_data tail ) )
+    ( string_free head )
+    ( string_free tail )
+}
+
+// Insert byte `c` at `idx`.
+@ __term_insert_at String buf i idx i c → v {
+    : i n ( string_len buf )
+    : String head ( string_substr buf 0 idx )
+    : String tail ( string_substr buf idx - n idx )
+    ( string_clear buf )
+    ( string_push_str buf ( string_data head ) )
+    ( string_push_char buf c )
+    ( string_push_str buf ( string_data tail ) )
+    ( string_free head )
+    ( string_free tail )
+}
+
+// Drop everything from `keep` onward (Ctrl-K).
+@ __term_truncate String buf i keep → v {
+    : String head ( string_substr buf 0 keep )
+    ( string_clear buf )
+    ( string_push_str buf ( string_data head ) )
+    ( string_free head )
+}
+
+@ term_read_line s prompt ( Vec String ) history → ?String {
+    : ?TermState rawst ( term_raw_enable 0 )
+    ^ ?? rawst {
+        T st → ( __term_edit st prompt history )
+        F _ → @ ?String { F }
+    }
+}
+
+// The raw-mode editing loop proper (st is consumed: disabled before
+// returning on every path).
+@ __term_edit TermState st s prompt ( Vec String ) history → ?String {
+    : String buf ( string_with_cap 64 )
+    : ~ i pos 0
+    : ~ i hidx ( vec_len [String] history )   // one past newest
+    : ~ i done 0    // 0 = editing, 1 = accepted, 2 = cancelled
+    ( __term_repaint prompt buf pos )
+    ~ == done 0 {
+        : i c ( __term_getb )
+        ? | == c 13 == c 10 { = done 1 } {
+        ? | == c 3 & == c 4 == ( string_len buf ) 0 { = done 2 } {
+        ? | == c 127 == c 8 {
+            ? > pos 0 {
+                ( __term_delete_at buf - pos 1 )
+                = pos - pos 1
+            } {}
+        } {
+        ? == c 1 { = pos 0 } {                  // Ctrl-A
+        ? == c 5 { = pos ( string_len buf ) } { // Ctrl-E
+        ? == c 11 {                              // Ctrl-K
+            ( __term_truncate buf pos )
+        } {
+        ? == c 27 {                              // ESC [ ...
+            : i c1 ( __term_getb )
+            ? == c1 91 {
+                : i c2 ( __term_getb )
+                ? & == c2 68 > pos 0 { = pos - pos 1 } {}                       // left
+                ? & == c2 67 < pos ( string_len buf ) { = pos + pos 1 } {}      // right
+                ? & == c2 65 > hidx 0 {                                          // up
+                    = hidx - hidx 1
+                    ?? ( vec_get [String] history hidx ) {
+                        T h → { ( __term_setbuf buf ( string_data h ) ) = pos ( string_len buf ) ( string_free h ) }
+                        F _ → {}
+                    }
+                } {}
+                ? & == c2 66 < hidx ( vec_len [String] history ) {               // down
+                    = hidx + hidx 1
+                    ? == hidx ( vec_len [String] history ) {
+                        ( __term_setbuf buf `` )
+                        = pos 0
+                    } {
+                        ?? ( vec_get [String] history hidx ) {
+                            T h → { ( __term_setbuf buf ( string_data h ) ) = pos ( string_len buf ) ( string_free h ) }
+                            F _ → {}
+                        }
+                    }
+                } {}
+            } {}
+        } {
+        ? & >= c 32 < c 127 {                    // printable insert
+            ( __term_insert_at buf pos c )
+            = pos + pos 1
+        } {}
+        } } } } } } }
+        ? == done 0 { ( __term_repaint prompt buf pos ) } {}
+    }
+    ( term_raw_disable st )
+    ( nurl_print `\n` )
+    ? == done 1 { ^ @ ?String { T buf } } {}
+    ( string_free buf )
+    ^ @ ?String { F }
+}


### PR DESCRIPTION
Four critic.md backlog features in one branch, each a stdlib module + a goldened `compiler/tests` lock, every test ASan+UBSan+LSan clean and `nurlc --lint` clean.

## B18 — B-tree ordered map (`std/btree.nu`)
`BTree [K V]` with O(log n) insert / lookup / delete (CLRS proactive split + borrow/merge, minimum degree 8). Each node caches its subtree size, so `btree_key_at` / `btree_val_at` order-statistic queries are O(log n) too. Raw 6-slot nodes with typed-pointer access (same generic-container pattern as `std/set.nu`).
Lock `btree_basic.nu`: 2000-key scrambled fill, replace, remove-every-third churn, order-statistic + ascending-iteration checks, full drain.

## B10 — terminal control (`std/term.nu`)
POSIX termios raw mode (`term_raw_enable`/`_disable`, `struct termios` sized via `nurl_native_sizeof` so the layout never leaks into NURL), `term_is_tty`, byte-exact ANSI builders, and a raw-mode line editor (`term_read_line`: insert, backspace, ←/→, ↑/↓ history, Ctrl-A/E/K, clean not-a-tty None fallback). Adds `TCSANOW`/`TCSAFLUSH` to `nurl_native_constant` (POSIX-only; Win32/WASI ANSI still works). Prerequisite for the C1 REPL.
Lock `term_basic.nu`: tty-independent surface (None on a file fd + byte-exact ANSI hex).

## B15 — ZIP archives (`ext/zip.nu`)
Reader + writer over the existing zlib FFI. Writer: `zip_new`/`zip_add` (raw-deflate windowBits −15, store-when-no-gain)/`zip_add_stored`/`zip_finish` (local headers + central dir + EOCD, fixed DOS timestamp → byte-deterministic). Reader: `zip_open` (backward EOCD scan, zip64 rejected)/`zip_count`/`zip_name_at`/`zip_size_at`/`zip_extract`/`zip_extract_name`/`zip_close`, every extract CRC-32-validated.
Lock `zip_basic.nu`: deflate + store + a compressible 5000-byte entry, re-open, CRC-checked extract, by-name, missing + junk rejection. **Cross-checked against system `unzip -t`.**

## B17 — SMTP client (`ext/smtp.nu`)
Mail submission over the runtime's client-side TCP/TLS connect: `smtp_connect`/`_tls`, EHLO capability discovery, `smtp_starttls` (RFC 3207 — upgrades the live plaintext fd and re-EHLOs), `smtp_auth_plain`/`_login` (RFC 4954), the MAIL/RCPT/DATA envelope (DATA dot-stuffs per RFC 5321 §4.5.2), plus a minimal RFC 5322 MIME builder, `smtp_dotstuff`, and `smtp_date_now`.
STARTTLS must upgrade an already-open fd, which the existing connect primitives could not do, so this adds **`nurl_tcp_starttls`** to the runtime — the client-handshake half of `nurl_tcp_connect_tls` applied in place.
Lock `smtp_basic.nu`: the offline surface (multiline reply scanner/parser, AUTH PLAIN/LOGIN base64 tokens, dot-stuffing, MIME). `examples/smtp_send.nu` demonstrates the live STARTTLS submission flow.

## Gates
- `./build.sh` — bootstrap fixed point + test corpus: **green** (353 PASS, MISSING 0 / ORPHAN 0).
- `./build.sh --san` + `run_san_tests.sh` — **SAN_FAIL 0** (the only non-PASS buckets are the deliberate `borrow_*` negative tests and the pre-existing `pub_trait_ffi_vis_mod` link-fail).
- `./tools/check_examples.sh` — **63 PASS / 0 FAIL** (includes `smtp_send.nu`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
