### PR TITLE
stdlib: LRU cache + bitset — closes B18 collections round-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Bitset — `stdlib/std/bitset.nu`** (critic B18, collections round-out).
+  A fixed-size bit array over 64-bit limbs: `bitset_set` / `bitset_clear`
+  / `bitset_flip` / `bitset_test` (all bounds-checked, so the unused high
+  bits of the last limb stay clear), `bitset_set_all` / `bitset_clear_all`,
+  a popcount-backed `bitset_count`, `bitset_any` / `bitset_all` /
+  `bitset_none`, the in-place combiners `bitset_and_with` / `bitset_or_with`
+  / `bitset_xor_with`, `bitset_clone`, and an ascending `bitset_each_set`.
+  Storage is a flat `nurl_zalloc` word buffer peeked/poked by limb. NURL
+  has no native XOR or NOT operator, so the module uses the exact,
+  carry-free identities `a ^ b = (a|b) - (a&b)` and `~m = -1 - m`. Lock:
+  `compiler/tests/bitset_basic.nu` — cross-limb set/clear/flip, out-of-
+  range no-ops, popcount, `all()` on a full set, the three combiners with
+  an XOR-identity bit check, and clone independence; ASan+UBSan+LSan clean.
+
+- **LRU cache — `stdlib/std/lru.nu`** (critic B18, collections round-out).
+  A fixed-capacity `LruCache [V]` over string keys, backed by a HashMap
+  (key → slot) plus an intrusive doubly-linked recency list over
+  preallocated slot arrays with a free list — so `lru_get` / `lru_put` /
+  `lru_contains` / `lru_remove` are all O(1) and a cache at capacity does
+  no further allocation. `lru_get` moves the key to MRU; `lru_peek` does
+  not; `lru_put` returns the displaced value (replaced or evicted), owned;
+  `lru_each` walks MRU→LRU; `lru_free_with` drops each value on teardown
+  (the owned-element discipline the deque/heap work established). The map's
+  hash/eq closures are non-capturing, so they allocate nothing per call.
+  Lock: `compiler/tests/lru_basic.nu` — eviction order, get-as-touch
+  survival, peek-without-reorder, replace-returns-old, remove, the MRU→LRU
+  walk, and the owned-String `free_with` path; ASan+UBSan+LSan clean. With
+  the B-tree and bitset, this **closes critic B18**.
+
 - **B-tree ordered map — `stdlib/std/btree.nu`** (critic B18). A
   `BTree [K V]` with O(log n) insert / lookup / delete, replacing the
   array-shift backing for large ordered maps. Classic CLRS proactive

--- a/compiler/tests/bitset_basic.nu
+++ b/compiler/tests/bitset_basic.nu
@@ -1,0 +1,77 @@
+// bitset_basic.nu — std/bitset.nu acceptance.
+//
+// Exercises set/clear/flip/test bounds, popcount, any/all/none, the
+// in-place &/|/^ combiners (verified via the XOR-without-an-operator
+// identity), clone independence, and ascending each_set iteration over
+// a 130-bit set that straddles three limbs.
+
+$ `stdlib/std/bitset.nu`
+
+@ main → i {
+    : Bitset bs ( bitset_new 130 )            // 3 limbs (64+64+2)
+    ( nurl_print `nbits=` ) ( nurl_print ( nurl_str_int ( bitset_nbits bs ) ) )
+    ( nurl_print ` words=` ) ( nurl_print ( nurl_str_int ( bitset_words bs ) ) ) ( nurl_print `\n` )
+    ( nurl_print `empty_none=` ) ( nurl_print ? ( bitset_none bs ) `T` `F` )
+    ( nurl_print ` any=` ) ( nurl_print ? ( bitset_any bs ) `T` `F` ) ( nurl_print `\n` )
+
+    // set a few across limb boundaries
+    ( bitset_set bs 0 ) ( bitset_set bs 63 ) ( bitset_set bs 64 ) ( bitset_set bs 129 )
+    ( bitset_set bs 200 )                     // out of range → no-op
+    ( bitset_set bs -1 )                      // out of range → no-op
+    ( nurl_print `count=` ) ( nurl_print ( nurl_str_int ( bitset_count bs ) ) ) ( nurl_print `\n` )
+    ( nurl_print `t0=` ) ( nurl_print ? ( bitset_test bs 0 ) `T` `F` )
+    ( nurl_print ` t63=` ) ( nurl_print ? ( bitset_test bs 63 ) `T` `F` )
+    ( nurl_print ` t64=` ) ( nurl_print ? ( bitset_test bs 64 ) `T` `F` )
+    ( nurl_print ` t129=` ) ( nurl_print ? ( bitset_test bs 129 ) `T` `F` )
+    ( nurl_print ` t1=` ) ( nurl_print ? ( bitset_test bs 1 ) `T` `F` )
+    ( nurl_print ` t200=` ) ( nurl_print ? ( bitset_test bs 200 ) `T` `F` ) ( nurl_print `\n` )
+
+    // clear + flip
+    ( bitset_clear bs 63 )
+    ( bitset_flip bs 64 )                     // was set → clears
+    ( bitset_flip bs 5 )                      // was clear → sets
+    ( nurl_print `set_idx=` )
+    : ( @ v i ) pf \ i bit → v { ( nurl_print ( nurl_str_int bit ) ) ( nurl_print ` ` ) }
+    ( bitset_each_set bs pf )
+    ( nurl_print `\n` )
+
+    // all() on a small full set
+    : Bitset full ( bitset_new 70 )
+    ( bitset_set_all full )
+    ( nurl_print `full_all=` ) ( nurl_print ? ( bitset_all full ) `T` `F` )
+    ( nurl_print ` full_count=` ) ( nurl_print ( nurl_str_int ( bitset_count full ) ) ) ( nurl_print `\n` )
+    ( bitset_clear full 37 )
+    ( nurl_print `after_clear_all=` ) ( nurl_print ? ( bitset_all full ) `T` `F` )
+    ( nurl_print ` count=` ) ( nurl_print ( nurl_str_int ( bitset_count full ) ) ) ( nurl_print `\n` )
+
+    // combiners on two 8-bit sets
+    : Bitset a ( bitset_new 8 )
+    : Bitset b ( bitset_new 8 )
+    ( bitset_set a 0 ) ( bitset_set a 1 ) ( bitset_set a 2 )       // a = 0b00000111
+    ( bitset_set b 1 ) ( bitset_set b 2 ) ( bitset_set b 3 )       // b = 0b00001110
+    : Bitset ax ( bitset_clone a )
+    : Bitset ao ( bitset_clone a )
+    ( bitset_and_with a b )                                        // 0b00000110 → count 2
+    ( bitset_xor_with ax b )                                       // 0b00001001 → count 2
+    ( bitset_or_with ao b )                                        // 0b00001111 → count 4
+    ( nurl_print `and=` ) ( nurl_print ( nurl_str_int ( bitset_count a ) ) )
+    ( nurl_print ` xor=` ) ( nurl_print ( nurl_str_int ( bitset_count ax ) ) )
+    ( nurl_print ` or=` ) ( nurl_print ( nurl_str_int ( bitset_count ao ) ) ) ( nurl_print `\n` )
+    ( nurl_print `xor_bits=` )
+    ( nurl_print ? ( bitset_test ax 0 ) `1` `0` )
+    ( nurl_print ? ( bitset_test ax 1 ) `1` `0` )
+    ( nurl_print ? ( bitset_test ax 2 ) `1` `0` )
+    ( nurl_print ? ( bitset_test ax 3 ) `1` `0` ) ( nurl_print `\n` )
+
+    // clone independence: mutating the clone leaves the original intact
+    : Bitset orig ( bitset_new 16 )
+    ( bitset_set orig 4 )
+    : Bitset cl ( bitset_clone orig )
+    ( bitset_set cl 9 )
+    ( nurl_print `orig_t9=` ) ( nurl_print ? ( bitset_test orig 9 ) `T` `F` )
+    ( nurl_print ` clone_t4=` ) ( nurl_print ? ( bitset_test cl 4 ) `T` `F` ) ( nurl_print `\n` )
+
+    ( bitset_free bs ) ( bitset_free full ) ( bitset_free a ) ( bitset_free b )
+    ( bitset_free ax ) ( bitset_free ao ) ( bitset_free orig ) ( bitset_free cl )
+    ^ 0
+}

--- a/compiler/tests/lru_basic.nu
+++ b/compiler/tests/lru_basic.nu
@@ -1,0 +1,91 @@
+// lru_basic.nu — std/lru.nu acceptance.
+//
+// Exercises eviction order (LRU dropped first), get-as-touch (a fetched
+// key survives the next eviction), replace-returns-old, remove, the
+// MRU→LRU each walk, and — with owned String values — the
+// lru_free_with drop discipline (ASan/LSan confirm no leak).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/lru.nu`
+
+@ mkstr s raw → String {
+    : String s ( string_with_cap 4 )
+    ( string_push_str s raw )
+    ^ s
+}
+
+@ getshow s label ( LruCache i ) c s key → v {
+    ( nurl_print label ) ( nurl_print `=` )
+    ?? ( lru_get [i] c key ) { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `MISS` ) }
+    ( nurl_print `\n` )
+}
+
+@ main → i {
+    : ( LruCache i ) c ( lru_new [i] 3 )
+    ( nurl_print `cap=` ) ( nurl_print ( nurl_str_int ( lru_cap [i] c ) ) )
+    ( nurl_print ` empty=` ) ( nurl_print ? ( lru_is_empty [i] c ) `T` `F` ) ( nurl_print `\n` )
+
+    // fill to capacity
+    : ?i e1 ( lru_put [i] c `a` 1 )
+    : ?i e2 ( lru_put [i] c `b` 2 )
+    : ?i e3 ( lru_put [i] c `c` 3 )
+    ?? e1 { T _ → ( nurl_print `bug1\n` ) F _ → {} }
+    ?? e2 { T _ → ( nurl_print `bug2\n` ) F _ → {} }
+    ?? e3 { T _ → ( nurl_print `bug3\n` ) F _ → {} }
+    ( nurl_print `len=` ) ( nurl_print ( nurl_str_int ( lru_len [i] c ) ) ) ( nurl_print `\n` )
+
+    // touch `a` so `b` becomes the LRU victim
+    ( getshow `touch_a` c `a` )
+
+    // insert `d` → evicts `b` (the least-recently-used), returns 2
+    : ?i ev ( lru_put [i] c `d` 4 )
+    ( nurl_print `evicted=` )
+    ?? ev { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `none` ) } ( nurl_print `\n` )
+    ( nurl_print `has_b=` ) ( nurl_print ? ( lru_contains [i] c `b` ) `T` `F` )
+    ( nurl_print ` has_a=` ) ( nurl_print ? ( lru_contains [i] c `a` ) `T` `F` )
+    ( nurl_print ` has_d=` ) ( nurl_print ? ( lru_contains [i] c `d` ) `T` `F` ) ( nurl_print `\n` )
+
+    // peek `c` (LRU now) must NOT reorder, so inserting `e` evicts `c`
+    ( nurl_print `peek_c=` )
+    ?? ( lru_peek [i] c `c` ) { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `MISS` ) } ( nurl_print `\n` )
+    : ?i ev2 ( lru_put [i] c `e` 5 )
+    ( nurl_print `evicted2=` )
+    ?? ev2 { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `none` ) } ( nurl_print `\n` )
+
+    // replace existing key returns old value, no eviction
+    : ?i old ( lru_put [i] c `d` 40 )
+    ( nurl_print `replace_d_old=` )
+    ?? old { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `none` ) } ( nurl_print `\n` )
+    ( getshow `d_now` c `d` )
+    ( nurl_print `len=` ) ( nurl_print ( nurl_str_int ( lru_len [i] c ) ) ) ( nurl_print `\n` )
+
+    // remove
+    : ?i rm ( lru_remove [i] c `a` )
+    ( nurl_print `remove_a=` )
+    ?? rm { T v → ( nurl_print ( nurl_str_int v ) ) F _ → ( nurl_print `none` ) }
+    ( nurl_print ` has_a=` ) ( nurl_print ? ( lru_contains [i] c `a` ) `T` `F` )
+    ( nurl_print ` len=` ) ( nurl_print ( nurl_str_int ( lru_len [i] c ) ) ) ( nurl_print `\n` )
+    : ?i rm2 ( lru_remove [i] c `zzz` )
+    ( nurl_print `remove_missing=` )
+    ?? rm2 { T _ → ( nurl_print `FOUND(bug)` ) F _ → ( nurl_print `none` ) } ( nurl_print `\n` )
+
+    // each MRU→LRU
+    ( nurl_print `order=` )
+    : ( @ v s i ) pr \ s k i v → v { ( nurl_print k ) ( nurl_print `:` ) ( nurl_print ( nurl_str_int v ) ) ( nurl_print ` ` ) }
+    ( lru_each [i] c pr )
+    ( nurl_print `\n` )
+    ( lru_free [i] c )
+
+    // ── owned-value path: lru_free_with must drop every String ──
+    : ( LruCache String ) sc ( lru_new [String] 2 )
+    : ?String s1 ( lru_put [String] sc `x` ( mkstr `xv` ) )
+    ?? s1 { T sv → ( string_free sv ) F _ → {} }
+    : ?String s2 ( lru_put [String] sc `y` ( mkstr `yv` ) )
+    ?? s2 { T sv → ( string_free sv ) F _ → {} }
+    // a 3rd insert evicts `x`; its value String comes back owned → free it
+    : ?String s3 ( lru_put [String] sc `z` ( mkstr `zv` ) )
+    ?? s3 { T sv → { ( nurl_print `evicted_val=` ) ( nurl_print ( string_data sv ) ) ( nurl_print `\n` ) ( string_free sv ) } F _ → {} }
+    : ( @ v String ) dropf \ String s → v { ( string_free s ) }
+    ( lru_free_with [String] sc dropf )
+    ^ 0
+}

--- a/compiler/tests/outputs/bitset_basic.txt
+++ b/compiler/tests/outputs/bitset_basic.txt
@@ -1,0 +1,14 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+nbits=130 words=3
+empty_none=T any=F
+count=4
+t0=T t63=T t64=T t129=T t1=F t200=F
+set_idx=0 5 129 
+full_all=T full_count=70
+after_clear_all=F count=69
+and=2 xor=2 or=4
+xor_bits=1001
+orig_t9=F clone_t4=T

--- a/compiler/tests/outputs/lru_basic.txt
+++ b/compiler/tests/outputs/lru_basic.txt
@@ -1,0 +1,18 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+cap=3 empty=T
+len=3
+touch_a=1
+evicted=2
+has_b=F has_a=T has_d=T
+peek_c=3
+evicted2=3
+replace_d_old=4
+d_now=40
+len=3
+remove_a=1 has_a=F len=2
+remove_missing=none
+order=d:40 e:5 
+evicted_val=xv

--- a/stdlib/std/bitset.nu
+++ b/stdlib/std/bitset.nu
@@ -1,0 +1,207 @@
+// stdlib/std/bitset.nu — a fixed-size bit array over 64-bit limbs.
+//
+// A `Bitset` is created with a bit count and never resizes; bits outside
+// [0, nbits) are rejected (set/clear/flip) or read as 0 (test), so the
+// unused high bits of the last limb stay clear and `bitset_count` /
+// `bitset_all` can treat every stored word at face value. Storage is a
+// flat `nurl_zalloc` buffer of `ceil(nbits/64)` words, peeked/poked by
+// word index. No element ownership — `bitset_free` is the whole story.
+//
+//   ( bitset_new      i nbits )          → Bitset
+//   ( bitset_nbits    Bitset bs )        → i
+//   ( bitset_words    Bitset bs )        → i   limb count
+//   ( bitset_set      Bitset bs i bit )  → v
+//   ( bitset_clear    Bitset bs i bit )  → v
+//   ( bitset_flip     Bitset bs i bit )  → v
+//   ( bitset_test     Bitset bs i bit )  → b
+//   ( bitset_set_all  Bitset bs )        → v
+//   ( bitset_clear_all Bitset bs )       → v
+//   ( bitset_count    Bitset bs )        → i   set bits (popcount)
+//   ( bitset_any      Bitset bs )        → b
+//   ( bitset_all      Bitset bs )        → b
+//   ( bitset_none     Bitset bs )        → b
+//   ( bitset_and_with Bitset a Bitset b ) → v  a &= b   (over min limbs)
+//   ( bitset_or_with  Bitset a Bitset b ) → v  a |= b
+//   ( bitset_xor_with Bitset a Bitset b ) → v  a ^= b
+//   ( bitset_clone    Bitset bs )        → Bitset
+//   ( bitset_each_set Bitset bs ( @ v i ) f ) → v   set indices, ascending
+//   ( bitset_free     Bitset bs )        → v
+//
+// NURL has no native XOR or NOT operator, so this module uses the
+// identities  a^b = (a|b) - (a&b)  and  ~m = -1 - m  (two's complement),
+// both exact and carry-free per bit.
+
+: Bitset { s words i nbits i nwords }
+
+@ bitset_new i nbits → Bitset {
+    : i nb ? > nbits 0 nbits 0
+    : i nw / + nb 63 64
+    : s w ? > nw 0 ( nurl_zalloc * nw 8 ) # s 0
+    ^ @ Bitset { w nb nw }
+}
+
+@ bitset_nbits Bitset bs → i { ^ . bs nbits }
+@ bitset_words Bitset bs → i { ^ . bs nwords }
+
+@ __bit_inrange Bitset bs i bit → b {
+    ^ & >= bit 0 < bit . bs nbits
+}
+
+@ bitset_set Bitset bs i bit → v {
+    ? ( __bit_inrange bs bit ) {
+        : s w . bs words
+        : i limb / bit 64
+        : i mask << 1 % bit 64
+        ( nurl_poke w limb | ( nurl_peek w limb ) mask )
+    } {}
+}
+
+@ bitset_clear Bitset bs i bit → v {
+    ? ( __bit_inrange bs bit ) {
+        : s w . bs words
+        : i limb / bit 64
+        : i mask << 1 % bit 64
+        ( nurl_poke w limb & ( nurl_peek w limb ) - -1 mask )   // &= ~mask
+    } {}
+}
+
+@ bitset_flip Bitset bs i bit → v {
+    ? ( __bit_inrange bs bit ) {
+        : s w . bs words
+        : i limb / bit 64
+        : i mask << 1 % bit 64
+        : i cur ( nurl_peek w limb )
+        ( nurl_poke w limb - | cur mask & cur mask )            // ^= mask
+    } {}
+}
+
+@ bitset_test Bitset bs i bit → b {
+    ? ( __bit_inrange bs bit ) {} { ^ F }
+    : s w . bs words
+    : i limb / bit 64
+    : i mask << 1 % bit 64
+    ^ != & ( nurl_peek w limb ) mask 0
+}
+
+@ bitset_clear_all Bitset bs → v {
+    : s w . bs words
+    : ~ i k 0
+    ~ < k . bs nwords { ( nurl_poke w k 0 ) = k + k 1 }
+}
+
+// Set every in-range bit; the unused high bits of the last limb are
+// left clear so the count / all invariants hold.
+@ bitset_set_all Bitset bs → v {
+    : s w . bs words
+    : i nw . bs nwords
+    : i rem % . bs nbits 64
+    : ~ i k 0
+    ~ < k nw {
+        ? & == k - nw 1 != rem 0
+        { ( nurl_poke w k - << 1 rem 1 ) }   // last partial word: low `rem` bits
+        { ( nurl_poke w k -1 ) }             // full word: all ones
+        = k + k 1
+    }
+}
+
+// Kernighan popcount of a 64-bit word (works on the sign bit too — the
+// loop clears the lowest set bit each step and ends at zero).
+@ __popcount64 i x → i {
+    : ~ i v x
+    : ~ i c 0
+    ~ != v 0 { = v & v - v 1 = c + c 1 }
+    ^ c
+}
+
+@ bitset_count Bitset bs → i {
+    : s w . bs words
+    : ~ i total 0
+    : ~ i k 0
+    ~ < k . bs nwords { = total + total ( __popcount64 ( nurl_peek w k ) ) = k + k 1 }
+    ^ total
+}
+
+@ bitset_any Bitset bs → b {
+    : s w . bs words
+    : ~ i k 0
+    ~ < k . bs nwords {
+        ? != ( nurl_peek w k ) 0 { ^ T } {}
+        = k + k 1
+    }
+    ^ F
+}
+
+@ bitset_none Bitset bs → b { ^ ? ( bitset_any bs ) F T }
+
+@ bitset_all Bitset bs → b {
+    : s w . bs words
+    : i nw . bs nwords
+    ? == . bs nbits 0 { ^ T } {}
+    : i rem % . bs nbits 64
+    : ~ i k 0
+    ~ < k nw {
+        ? & == k - nw 1 != rem 0 {
+            : i expect - << 1 rem 1
+            ? == & ( nurl_peek w k ) expect expect {} { ^ F }
+        } {
+            ? == ( nurl_peek w k ) -1 {} { ^ F }
+        }
+        = k + k 1
+    }
+    ^ T
+}
+
+@ __bitset_min i a i b → i { ^ ? < a b a b }
+
+@ bitset_and_with Bitset a Bitset b → v {
+    : s wa . a words
+    : s wb . b words
+    : i n ( __bitset_min . a nwords . b nwords )
+    : ~ i k 0
+    ~ < k n { ( nurl_poke wa k & ( nurl_peek wa k ) ( nurl_peek wb k ) ) = k + k 1 }
+    // limbs of `a` beyond `b` AND with 0
+    ~ < k . a nwords { ( nurl_poke wa k 0 ) = k + k 1 }
+}
+
+@ bitset_or_with Bitset a Bitset b → v {
+    : s wa . a words
+    : s wb . b words
+    : i n ( __bitset_min . a nwords . b nwords )
+    : ~ i k 0
+    ~ < k n { ( nurl_poke wa k | ( nurl_peek wa k ) ( nurl_peek wb k ) ) = k + k 1 }
+}
+
+@ bitset_xor_with Bitset a Bitset b → v {
+    : s wa . a words
+    : s wb . b words
+    : i n ( __bitset_min . a nwords . b nwords )
+    : ~ i k 0
+    ~ < k n {
+        : i x ( nurl_peek wa k )
+        : i y ( nurl_peek wb k )
+        ( nurl_poke wa k - | x y & x y )
+        = k + k 1
+    }
+}
+
+@ bitset_clone Bitset bs → Bitset {
+    : Bitset out ( bitset_new . bs nbits )
+    : s src . bs words
+    : s dst . out words
+    : ~ i k 0
+    ~ < k . bs nwords { ( nurl_poke dst k ( nurl_peek src k ) ) = k + k 1 }
+    ^ out
+}
+
+@ bitset_each_set Bitset bs ( @ v i ) f → v {
+    : i nb . bs nbits
+    : ~ i bit 0
+    ~ < bit nb {
+        ? ( bitset_test bs bit ) { ( f bit ) } {}
+        = bit + bit 1
+    }
+}
+
+@ bitset_free Bitset bs → v {
+    ? != 0 # i . bs words { ( nurl_free . bs words ) } {}
+}

--- a/stdlib/std/lru.nu
+++ b/stdlib/std/lru.nu
@@ -1,0 +1,267 @@
+// stdlib/std/lru.nu — a fixed-capacity LRU (least-recently-used) cache.
+//
+// String keys → generic values `[V]`, backed by a HashMap (key → slot)
+// plus an intrusive doubly-linked recency list over preallocated slot
+// arrays. get / put / contains / remove are all O(1): the map locates
+// the slot, the list moves it to the front (MRU) or drops the tail
+// (LRU) on overflow. Slots are recycled through a free list, so a cache
+// at capacity does no further allocation.
+//
+//   ( lru_new      [V] i cap )            → ( LruCache V )   cap >= 1
+//   ( lru_len      [V] c )                → i
+//   ( lru_cap      [V] c )                → i
+//   ( lru_is_empty [V] c )                → b
+//   ( lru_contains [V] c s key )          → b        (no reorder)
+//   ( lru_peek     [V] c s key )          → ?V       borrow, no reorder
+//   ( lru_get      [V] c s key )          → ?V       borrow, moves to MRU
+//   ( lru_put      [V] c s key V val )    → ?V       displaced value (replaced
+//                                                    or evicted), owned; None
+//   ( lru_remove   [V] c s key )          → ?V       owned, or None
+//   ( lru_each     [V] c f )              → v        f:(@ v s V), MRU→LRU
+//   ( lru_free     [V] c )                → v        POD values
+//   ( lru_free_with[V] c drop )           → v        drop:(@ v V) each value
+//
+// The cache OWNS a private copy of each key (duplicated on insert) and
+// each value handed to `lru_put`. `lru_get`/`lru_peek` return a BORROW
+// of the stored value — do not free it, and treat it as invalid after a
+// later `lru_put` that may evict it. For owned value types use
+// `lru_free_with` to drop each value on teardown.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/hashmap.nu`   // HashMap, map_*, hash_string, eq_string
+
+// ctl is a 3-word scalar block (boxed so mutations survive the value-
+// passed struct): [0]=head slot, [1]=tail slot (both -1 when empty),
+// [2]=live count. The collections (keys/vals/prev/nxt) are slot-indexed
+// arrays of length `cap`; `freelist` is a stack of unused slot indices.
+: LruCache [V] {
+    s ctl
+    i cap
+    ( HashMap s i ) index
+    ( Vec String ) keys
+    ( Vec V ) vals
+    ( Vec i ) prev
+    ( Vec i ) nxt
+    ( Vec i ) freelist
+}
+
+@ __lru_head s ctl → i { ^ ( nurl_peek ctl 0 ) }
+@ __lru_tail s ctl → i { ^ ( nurl_peek ctl 1 ) }
+@ __lru_count s ctl → i { ^ ( nurl_peek ctl 2 ) }
+@ __lru_set_head s ctl i v → v { ( nurl_poke ctl 0 v ) }
+@ __lru_set_tail s ctl i v → v { ( nurl_poke ctl 1 v ) }
+@ __lru_set_count s ctl i v → v { ( nurl_poke ctl 2 v ) }
+
+@ __lru_gi ( Vec i ) v i idx → i {
+    ^ ?? ( vec_get [i] v idx ) { T x → x F _ → -1 }
+}
+
+// ── index (HashMap) wrappers: the map key is the slot's owned-key
+// bytes; hash/eq closures are non-capturing so creating them per call
+// does not allocate. ──────────────────────────────────────────────────
+
+@ __lru_idx_get ( HashMap s i ) index s key → ?i {
+    : ( @ i s ) hf \ s str → i { ^ ( hash_string str ) }
+    : ( @ b s s ) ef \ s a s b → b { ^ ( eq_string a b ) }
+    ^ ( map_get [s i] index key hf ef )
+}
+
+@ __lru_idx_set ( HashMap s i ) index s key i slot → v {
+    : ( @ i s ) hf \ s str → i { ^ ( hash_string str ) }
+    : ( @ b s s ) ef \ s a s b → b { ^ ( eq_string a b ) }
+    : ?i _old ( map_set [s i] index key slot hf ef )
+    ?? _old { T _ → {} F _ → {} }
+}
+
+@ __lru_idx_remove ( HashMap s i ) index s key → v {
+    : ( @ i s ) hf \ s str → i { ^ ( hash_string str ) }
+    : ( @ b s s ) ef \ s a s b → b { ^ ( eq_string a b ) }
+    : ?i _old ( map_remove [s i] index key hf ef )
+    ?? _old { T _ → {} F _ → {} }
+}
+
+// ── intrusive list ────────────────────────────────────────────────────
+
+@ __lru_detach [V] ( LruCache V ) c i slot → v {
+    : s ctl . c ctl
+    : i p ( __lru_gi . c prev slot )
+    : i n ( __lru_gi . c nxt slot )
+    ? >= p 0 { : b _a ( vec_set [i] . c nxt p n ) {} } { ( __lru_set_head ctl n ) }
+    ? >= n 0 { : b _b ( vec_set [i] . c prev n p ) {} } { ( __lru_set_tail ctl p ) }
+}
+
+@ __lru_push_front [V] ( LruCache V ) c i slot → v {
+    : s ctl . c ctl
+    : i h ( __lru_head ctl )
+    : b _a ( vec_set [i] . c prev slot -1 )
+    : b _b ( vec_set [i] . c nxt slot h )
+    ? >= h 0 { : b _c ( vec_set [i] . c prev h slot ) {} } {}
+    ( __lru_set_head ctl slot )
+    ? < ( __lru_tail ctl ) 0 { ( __lru_set_tail ctl slot ) } {}
+}
+
+@ __lru_touch [V] ( LruCache V ) c i slot → v {
+    ? == ( __lru_head . c ctl ) slot {} {
+        ( __lru_detach [V] c slot )
+        ( __lru_push_front [V] c slot )
+    }
+}
+
+// ── construction / inspection ─────────────────────────────────────────
+
+@ lru_new [V] i cap → ( LruCache V ) {
+    : i c ? > cap 0 cap 1
+    : s ctl ( nurl_zalloc 24 )
+    ( nurl_poke ctl 0 -1 )
+    ( nurl_poke ctl 1 -1 )
+    ( nurl_poke ctl 2 0 )
+    : ( Vec String ) keys ( vec_with_cap [String] c )
+    : ( Vec V ) vals ( vec_with_cap [V] c )
+    : ( Vec i ) prev ( vec_with_cap [i] c )
+    : ( Vec i ) nxt ( vec_with_cap [i] c )
+    : b _k ( vec_set_len [String] keys c )
+    : b _v ( vec_set_len [V] vals c )
+    : b _p ( vec_set_len [i] prev c )
+    : b _n ( vec_set_len [i] nxt c )
+    : ( Vec i ) fl ( vec_with_cap [i] c )
+    : ~ i k 0
+    ~ < k c { ( vec_push [i] fl k ) = k + k 1 }
+    : ( HashMap s i ) index ( map_new [s i] )
+    ^ @ ( LruCache V ) { ctl c index keys vals prev nxt fl }
+}
+
+@ lru_len [V] ( LruCache V ) c → i { ^ ( __lru_count . c ctl ) }
+@ lru_cap [V] ( LruCache V ) c → i { ^ . c cap }
+@ lru_is_empty [V] ( LruCache V ) c → b { ^ == ( __lru_count . c ctl ) 0 }
+
+@ lru_contains [V] ( LruCache V ) c s key → b {
+    ^ ?? ( __lru_idx_get . c index key ) { T _ → T F _ → F }
+}
+
+@ lru_peek [V] ( LruCache V ) c s key → ?V {
+    ^ ?? ( __lru_idx_get . c index key ) {
+        T slot → ( vec_get [V] . c vals slot )
+        F _ → @ ?V { F }
+    }
+}
+
+@ lru_get [V] ( LruCache V ) c s key → ?V {
+    ^ ?? ( __lru_idx_get . c index key ) {
+        T slot → {
+            ( __lru_touch [V] c slot )
+            ( vec_get [V] . c vals slot )
+        }
+        F _ → @ ?V { F }
+    }
+}
+
+// Insert a brand-new key: evict the LRU entry first if at capacity,
+// then claim a free slot. Returns the evicted value (owned) or None.
+@ __lru_insert_new [V] ( LruCache V ) c s key V val → ?V {
+    : s ctl . c ctl
+    : ~ ?V evicted @ ?V { F }
+    ? >= ( __lru_count ctl ) . c cap {
+        : i t ( __lru_tail ctl )
+        ? >= t 0 {
+            ?? ( vec_get [String] . c keys t ) {
+                T tkey → { ( __lru_idx_remove . c index ( string_data tkey ) ) ( string_free tkey ) }
+                F _ → {}
+            }
+            ?? ( vec_get [V] . c vals t ) { T tv → { = evicted @ ?V { T tv } } F _ → {} }
+            ( __lru_detach [V] c t )
+            ( vec_push [i] . c freelist t )
+            ( __lru_set_count ctl - ( __lru_count ctl ) 1 )
+        } {}
+    } {}
+    : i sl ?? ( vec_pop [i] . c freelist ) { T fs → fs F _ → -1 }
+    ? >= sl 0 {
+        : String kc ( string_from key )
+        : b _sk ( vec_set [String] . c keys sl kc )
+        : b _sv ( vec_set [V] . c vals sl val )
+        ( __lru_idx_set . c index ( string_data kc ) sl )
+        ( __lru_push_front [V] c sl )
+        ( __lru_set_count ctl + ( __lru_count ctl ) 1 )
+    } {}
+    ^ evicted
+}
+
+@ lru_put [V] ( LruCache V ) c s key V val → ?V {
+    ^ ?? ( __lru_idx_get . c index key ) {
+        T slot → {
+            : ?V old ( vec_get [V] . c vals slot )
+            : b _s ( vec_set [V] . c vals slot val )
+            ( __lru_touch [V] c slot )
+            old
+        }
+        F _ → ( __lru_insert_new [V] c key val )
+    }
+}
+
+@ lru_remove [V] ( LruCache V ) c s key → ?V {
+    : s ctl . c ctl
+    ^ ?? ( __lru_idx_get . c index key ) {
+        T slot → {
+            ?? ( vec_get [String] . c keys slot ) {
+                T k → { ( __lru_idx_remove . c index ( string_data k ) ) ( string_free k ) }
+                F _ → {}
+            }
+            : ?V val ( vec_get [V] . c vals slot )
+            ( __lru_detach [V] c slot )
+            ( vec_push [i] . c freelist slot )
+            ( __lru_set_count ctl - ( __lru_count ctl ) 1 )
+            val
+        }
+        F _ → @ ?V { F }
+    }
+}
+
+// Visit live entries most-recent first.
+@ lru_each [V] ( LruCache V ) c ( @ v s V ) f → v {
+    : ~ i cur ( __lru_head . c ctl )
+    ~ >= cur 0 {
+        : i nextc ( __lru_gi . c nxt cur )
+        ?? ( vec_get [String] . c keys cur ) {
+            T k → {
+                ?? ( vec_get [V] . c vals cur ) { T v → ( f ( string_data k ) v ) F _ → {} }
+            }
+            F _ → {}
+        }
+        = cur nextc
+    }
+}
+
+@ __lru_free_keys [V] ( LruCache V ) c → v {
+    : ~ i cur ( __lru_head . c ctl )
+    ~ >= cur 0 {
+        : i nx ( __lru_gi . c nxt cur )
+        ?? ( vec_get [String] . c keys cur ) { T k → ( string_free k ) F _ → {} }
+        = cur nx
+    }
+}
+
+@ __lru_free_arrays [V] ( LruCache V ) c → v {
+    ( vec_free [String] . c keys )
+    ( vec_free [V] . c vals )
+    ( vec_free [i] . c prev )
+    ( vec_free [i] . c nxt )
+    ( vec_free [i] . c freelist )
+    ( map_free [s i] . c index )
+    ( nurl_free . c ctl )
+}
+
+@ lru_free [V] ( LruCache V ) c → v {
+    ( __lru_free_keys [V] c )
+    ( __lru_free_arrays [V] c )
+}
+
+@ lru_free_with [V] ( LruCache V ) c ( @ v V ) drop → v {
+    : ~ i cur ( __lru_head . c ctl )
+    ~ >= cur 0 {
+        : i nx ( __lru_gi . c nxt cur )
+        ?? ( vec_get [String] . c keys cur ) { T k → ( string_free k ) F _ → {} }
+        ?? ( vec_get [V] . c vals cur ) { T v → ( drop v ) F _ → {} }
+        = cur nx
+    }
+    ( __lru_free_arrays [V] c )
+}


### PR DESCRIPTION
Closes critic **B18 (collections round-out)** — the two parts left after the B-tree (PR #123): an LRU cache and a bitset. Both pure NURL, each with the `_free_with` owned-element discipline, each goldened and ASan+UBSan+LSan clean.

## `std/lru.nu` — fixed-capacity LRU cache
`LruCache [V]` over string keys: a HashMap (key → slot) plus an intrusive doubly-linked recency list over preallocated slot arrays with a free list, so `lru_get` / `lru_put` / `lru_contains` / `lru_remove` are all O(1) and a cache at capacity does no further allocation.

- `lru_get` moves the key to MRU; `lru_peek` does not.
- `lru_put` returns the displaced value (replaced **or** evicted), owned by the caller.
- `lru_each` walks MRU→LRU; `lru_free_with` drops each value on teardown.
- The map's hash/eq closures are non-capturing, so they allocate nothing per call.

Lock `lru_basic.nu`: eviction order (LRU dropped first), get-as-touch survival, peek-without-reorder, replace-returns-old, remove, the MRU→LRU walk, and the owned-String `free_with` path.

## `std/bitset.nu` — fixed-size u64-limb bitset
`bitset_set`/`clear`/`flip`/`test` (bounds-checked, so the unused high bits of the last limb stay clear), `set_all`/`clear_all`, popcount-backed `bitset_count`, `any`/`all`/`none`, in-place `and_with`/`or_with`/`xor_with`, `clone`, ascending `each_set`. Flat `nurl_zalloc` word buffer peeked/poked by limb.

NURL has no native XOR or NOT operator, so the module uses the exact, carry-free identities `a ^ b = (a|b) - (a&b)` and `~m = -1 - m`.

Lock `bitset_basic.nu`: cross-limb set/clear/flip, out-of-range no-ops, popcount, `all()` on a full set, the three combiners with an XOR-identity bit check, and clone independence.

## Gates
- `./build.sh` — bootstrap fixed point + corpus: **green** (MISSING 0 / ORPHAN 0).
- `./build.sh --san` + `run_san_tests.sh` — **SAN_FAIL 0** (377 total; only the deliberate `borrow_*` negative tests and the pre-existing `pub_trait_ffi_vis_mod` link-fail are non-PASS).
- `./tools/check_examples.sh` — **63 PASS / 0 FAIL**.
- `nurlc --lint` clean on both modules and both tests.

No runtime.c changes — both modules are pure NURL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
