### PR TITLE
tools: nurlpkg test — user-facing test runner (C3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`nurlpkg test` — user-facing test runner** (critic C3). Ships the
+  compiler suite's per-test pattern as a tool: `nurlpkg test` discovers
+  `tests/*.nu`, compiles and runs each, and reports `PASS`/`FAIL` with a
+  summary (exit 0 iff every test passes). A test passes on exit 0; if a
+  `tests/outputs/<name>.txt` golden exists, the program's stdout must
+  match it byte-for-byte instead. Tests run in sorted order for
+  determinism. The build driver is `./nurl.sh` by default, overridable
+  via `$NURL_CC` (a command taking `<flags> <src> <outbin>`) for an
+  installed toolchain. Smoke-tested by
+  `compiler/tests/nurlpkg_test_smoke.sh` (all four verdict paths +
+  all-pass/any-fail exit codes + the empty-tree message).
+
 - **REPL — `tools/repl` (`nurl repl`)** (critic C1). An interactive
   read-eval-print loop on a process-per-eval model: top-level definitions
   (`@` functions, `&` FFI, `$` imports, and `:` types / enums / globals)

--- a/compiler/tests/nurlpkg_test_smoke.sh
+++ b/compiler/tests/nurlpkg_test_smoke.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  compiler/tests/nurlpkg_test_smoke.sh — end-to-end smoke test for
+#  `nurlpkg test` (the C3 user-facing test runner).
+#
+#  Builds a throwaway project with a tests/ tree exercising all four
+#  verdict paths and asserts the runner's report + exit code:
+#
+#    * exit-0, no golden            → PASS
+#    * golden matches stdout        → PASS
+#    * golden mismatches stdout     → FAIL (output mismatch)
+#    * nonzero exit, no golden      → FAIL (nonzero exit)
+#
+#  and that an all-passing tree exits 0 while any failure exits 1.
+#
+#  Fixtures use only the `nurl_print` builtin (no `$` imports) so they
+#  compile from any CWD; the build driver is the repo's ./nurl.sh,
+#  passed via $NURL_CC. Heavier than the .nu corpus (each fixture is
+#  compiled by nurl.sh), so it is a standalone script.
+#
+#  Exit codes: 0 ok · 1 assertion failed · 2 environment problem.
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+NURLPKG="$ROOT_DIR/build/nurlpkg"
+DRIVER="$ROOT_DIR/nurl.sh"
+
+if [[ ! -x "$NURLPKG" ]]; then
+    echo "building nurlpkg..." >&2
+    if ! "$ROOT_DIR/tools/nurlpkg/build.sh" >/dev/null 2>&1; then
+        echo "ERROR: could not build build/nurlpkg (run ./build.sh first)." >&2
+        exit 2
+    fi
+fi
+[[ -x "$DRIVER" ]] || { echo "ERROR: $DRIVER missing." >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mk_project() {
+    rm -rf "$WORK/proj"; mkdir -p "$WORK/proj/tests/outputs"
+    printf '@ main → i { ^ 0 }\n'                              > "$WORK/proj/tests/aaa_pass.nu"
+    printf '@ main → i { ( nurl_print `hello\\n` ) ^ 0 }\n'    > "$WORK/proj/tests/bbb_golden_ok.nu"
+    printf 'hello\n'                                           > "$WORK/proj/tests/outputs/bbb_golden_ok.txt"
+}
+
+fail() { echo "nurlpkg test smoke: FAIL — $1"; echo "── output ──"; cat "$WORK/out.txt"; exit 1; }
+
+# ── case 1: a mixed tree (2 pass, 2 fail) → exit 1 ──
+mk_project
+printf '@ main → i { ( nurl_print `actual\\n` ) ^ 0 }\n' > "$WORK/proj/tests/ccc_golden_bad.nu"
+printf 'expected\n'                                      > "$WORK/proj/tests/outputs/ccc_golden_bad.txt"
+printf '@ main → i { ^ 3 }\n'                            > "$WORK/proj/tests/ddd_fail_exit.nu"
+
+( cd "$WORK/proj" && NURL_CC="$DRIVER" "$NURLPKG" test ) >"$WORK/out.txt" 2>"$WORK/err.txt"
+RC=$?
+grep -q "PASS aaa_pass"                  "$WORK/out.txt" || fail "aaa_pass not PASS"
+grep -q "PASS bbb_golden_ok"             "$WORK/out.txt" || fail "golden match not PASS"
+grep -q "FAIL ccc_golden_bad (output mismatch)" "$WORK/out.txt" || fail "golden mismatch not flagged"
+grep -q "FAIL ddd_fail_exit (nonzero exit)"     "$WORK/out.txt" || fail "nonzero exit not flagged"
+grep -q "PASS 2 · FAIL 2"                "$WORK/out.txt" || fail "summary wrong"
+[[ $RC -eq 1 ]] || fail "mixed tree should exit 1 (got $RC)"
+
+# ── case 2: an all-passing tree → exit 0 ──
+mk_project
+( cd "$WORK/proj" && NURL_CC="$DRIVER" "$NURLPKG" test ) >"$WORK/out.txt" 2>"$WORK/err.txt"
+RC=$?
+grep -q "PASS 2 · FAIL 0" "$WORK/out.txt" || fail "all-pass summary wrong"
+[[ $RC -eq 0 ]] || fail "all-pass tree should exit 0 (got $RC)"
+
+# ── case 3: no tests/ dir → exit 1 with a clear message ──
+mkdir -p "$WORK/empty"
+( cd "$WORK/empty" && NURL_CC="$DRIVER" "$NURLPKG" test ) >"$WORK/out.txt" 2>"$WORK/err.txt"
+RC=$?
+[[ $RC -eq 1 ]] || fail "missing tests/ should exit 1 (got $RC)"
+grep -q "no tests" "$WORK/err.txt" || fail "missing tests/ message absent"
+
+echo "nurlpkg test smoke: OK (verdicts, goldens, exit codes, empty-tree all correct)"
+exit 0

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -34,6 +34,7 @@ $ `stdlib/core/vec.nu`
 $ `stdlib/std/cmp.nu`
 $ `stdlib/std/fs.nu`
 $ `stdlib/std/sort.nu`
+$ `stdlib/std/process.nu`
 $ `stdlib/ext/env.nu`
 $ `stdlib/ext/manifest.nu`
 $ `stdlib/ext/lockfile.nu`
@@ -168,6 +169,7 @@ $ `stdlib/std/bytes.nu`
     ( nurl_print `                         Add a dependency entry to nurl.toml.\n` )
     ( nurl_print `  nurlpkg remove <name>  Delete a dependency entry from nurl.toml.\n` )
     ( nurl_print `  nurlpkg verify         Check deps/ matches nurl.lock (names + versions); exit 1 if drift.\n` )
+    ( nurl_print `  nurlpkg test           Build + run every tests/*.nu (exit 0 = pass; optional tests/outputs/ goldens).\n` )
     ( nurl_print `  nurlpkg version        Print the nurlpkg version.\n` )
     ( nurl_print `  nurlpkg help           Show this message.\n` )
 }
@@ -1669,6 +1671,154 @@ $ `stdlib/std/bytes.nu`
     ^ rc
 }
 
+// ── test runner (C3) ──────────────────────────────────────────────
+//
+// `nurlpkg test` ships the compiler-suite pattern as a user-facing tool:
+// every `tests/*.nu` is compiled and run; exit 0 = pass. If
+// `tests/outputs/<name>.txt` exists, its bytes must match the program's
+// stdout exactly (a golden); otherwise the exit code alone decides.
+//
+// The build driver is `./nurl.sh` by default; override with $NURL_CC
+// (a command taking `<flags> <src> <outbin>`), e.g. a wrapper around an
+// installed `nurl`. Test binaries land in /tmp.
+
+@ __test_basename s path → String {
+    : i n ( nurl_str_len path )
+    : ~ i start 0
+    : ~ i k 0
+    ~ < k n { ? == ( nurl_str_get path k ) 47 { = start + k 1 } {} = k + k 1 }   // '/'
+    : ~ i end n
+    ? & >= - n start 3 & == ( nurl_str_get path - n 3 ) 46 & == ( nurl_str_get path - n 2 ) 110 == ( nurl_str_get path - n 1 ) 117 { = end - n 3 } {}   // ".nu"
+    : String out ( string_with_cap + - end start 1 )
+    = k start
+    ~ < k end { ( string_push_char out ( nurl_str_get path k ) ) = k + k 1 }
+    ^ out
+}
+
+@ __test_driver → String {
+    ^ ?? ( env_get `NURL_CC` ) {
+        T v → v
+        F _ → { : String d ( string_with_cap 16 ) ( string_push_str d `./nurl.sh` ) d }
+    }
+}
+
+@ __test_report String name s status s detail → v {
+    ( nurl_print `  ` ) ( nurl_print status ) ( nurl_print ` ` ) ( nurl_print ( string_data name ) )
+    ? > ( nurl_str_len detail ) 0 { ( nurl_print ` ` ) ( nurl_print detail ) } {}
+    ( nurl_print `\n` )
+}
+
+// True iff the golden file's bytes equal stdout[0..outlen).
+@ __golden_match s goldp s out i outlen → b {
+    : ~ b ok F
+    ?? ( read_file goldp ) {
+        T g → {
+            ? == ( string_len g ) outlen { = ok == ( memcmp ( string_data g ) out outlen ) 0 } {}
+            ( string_free g )
+        }
+        F _ → {}
+    }
+    ^ ok
+}
+
+// Compile + run one test. Returns 0 on pass.
+@ __run_one s src s driver → i {
+    : String name ( __test_basename src )
+    : String bin ( string_with_cap 64 )
+    ( string_push_str bin `/tmp/nurlpkg_test_` )
+    ( string_push_str bin ( string_data name ) )
+
+    : String ccmd ( string_with_cap 128 )
+    ( string_push_str ccmd driver )
+    ( string_push_str ccmd ` -O0 ` )
+    ( string_push_str ccmd src )
+    ( string_push_char ccmd 32 )
+    ( string_push_str ccmd ( string_data bin ) )
+
+    : ~ i result 1
+    : ~ b compiled F
+    ?? ( process_run_shell ( string_data ccmd ) ) {
+        T out → {
+            ? ( output_success out ) { = compiled T } {
+                ( __test_report name `FAIL` `(compile error)` )
+                ( nurl_eprint ( output_stderr out ) )
+            }
+            ( output_free out )
+        }
+        F _ → { ( __test_report name `FAIL` `(could not launch compiler)` ) }
+    }
+    ( string_free ccmd )
+
+    ? compiled {
+        ?? ( process_run_shell ( string_data bin ) ) {
+            T out → {
+                : i ec ( output_exit_code out )
+                : String goldp ( string_with_cap 64 )
+                ( string_push_str goldp `tests/outputs/` )
+                ( string_push_str goldp ( string_data name ) )
+                ( string_push_str goldp `.txt` )
+                ? ( file_exists ( string_data goldp ) ) {
+                    ? ( __golden_match ( string_data goldp ) ( output_stdout out ) ( output_stdout_len out ) ) {
+                        ( __test_report name `PASS` `` ) = result 0
+                    } {
+                        ( __test_report name `FAIL` `(output mismatch)` )
+                    }
+                } {
+                    ? == ec 0 { ( __test_report name `PASS` `` ) = result 0 } { ( __test_report name `FAIL` `(nonzero exit)` ) }
+                }
+                ( string_free goldp )
+                ( output_free out )
+            }
+            F _ → { ( __test_report name `FAIL` `(could not run)` ) }
+        }
+    } {}
+
+    ( string_free bin )
+    ( string_free name )
+    ^ result
+}
+
+// Owns `files` (the fs_glob result): runs each, frees them, reports.
+@ __run_tests ( Vec String ) files → i {
+    : ( @ i String String ) cs \ String a String b → i { ^ ( cmp_string a b ) }
+    ( sort_by [String] files cs )
+    : String driver ( __test_driver )
+    : ~ i pass 0
+    : ~ i fail 0
+    : ~ i k 0
+    ~ < k ( vec_len [String] files ) {
+        ?? ( vec_get [String] files k ) {
+            T src → {
+                ? == ( __run_one ( string_data src ) ( string_data driver ) ) 0 { = pass + pass 1 } { = fail + fail 1 }
+                ( string_free src )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [String] files )
+    ( string_free driver )
+    ( nurl_print `\n` )
+    ( nurl_print `PASS ` ) ( nurl_print ( nurl_str_int pass ) )
+    ( nurl_print ` · FAIL ` ) ( nurl_print ( nurl_str_int fail ) ) ( nurl_print `\n` )
+    ^ ? == fail 0 0 1
+}
+
+@ __cmd_test → i {
+    ^ ?? ( fs_glob `tests/*.nu` ) {
+        F _ → { ( nurl_eprintln `nurlpkg: no tests/ directory (expected tests/*.nu)` ) 1 }
+        T files → {
+            ? == ( vec_len [String] files ) 0 {
+                ( nurl_eprintln `nurlpkg: no tests found (expected tests/*.nu)` )
+                ( vec_free [String] files )
+                1
+            } {
+                ( __run_tests files )
+            }
+        }
+    }
+}
+
 // ── dispatch ─────────────────────────────────────────────────────
 
 @ main → i {
@@ -1797,6 +1947,10 @@ $ `stdlib/std/bytes.nu`
     ? != 0 ( nurl_str_eq s_sub `verify` ) {
         ( string_free sub )
         ^ ( __cmd_verify )
+    } {}
+    ? != 0 ( nurl_str_eq s_sub `test` ) {
+        ( string_free sub )
+        ^ ( __cmd_test )
     } {}
     ? != 0 ( nurl_str_eq s_sub `version` ) {
         ( string_free sub )


### PR DESCRIPTION
Implements critic **C3 — `nurlpkg test`**, the user-facing `cargo test` equivalent. The per-test golden runner in `compiler/tests/` was internal-only; this ships the same pattern as a tool.

## Behaviour
`nurlpkg test`:
- discovers `tests/*.nu` (sorted for determinism),
- compiles + runs each via `./nurl.sh` (override with `$NURL_CC`, a command taking `<flags> <src> <outbin>`),
- a test **passes on exit 0**, or — when `tests/outputs/<name>.txt` exists — on a **byte-exact stdout match** with that golden,
- prints per-test `PASS`/`FAIL` (with a reason) and a `PASS n · FAIL m` summary,
- exits 0 iff every test passes.

```
$ nurlpkg test
  PASS aaa_pass
  PASS bbb_golden_ok
  FAIL ccc_golden_bad (output mismatch)
  FAIL ddd_fail_exit (nonzero exit)

PASS 2 · FAIL 2
```

## Tests
`compiler/tests/nurlpkg_test_smoke.sh` builds a throwaway project and asserts all four verdict paths (exit-0 pass, golden match, golden mismatch, nonzero exit), the all-pass→exit-0 / any-fail→exit-1 codes, and the no-`tests/` message.

## Gates
- `./build.sh` — bootstrap fixed point + corpus: **green** (MISSING 0 / ORPHAN 0).
- `./tools/check_examples.sh` — **63 PASS / 0 FAIL**.
- `nurlpkg_test_smoke.sh` — **OK** (fresh `nurlpkg` build).
- `nurlc --lint` clean on the new code.

Tool-only change — adds a `test` subcommand to `tools/nurlpkg` (plus `std/process.nu` import); no stdlib / runtime / compiler edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
