### PR TITLE
stdlib+tools: benchmark harness (std/bench.nu + nurlpkg bench) — C4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Benchmark harness — `stdlib/std/bench.nu` + `nurlpkg bench`** (critic
+  C4). `std/bench.nu` times a no-arg closure over many iterations and
+  reports **ns/op** (via the monotonic clock) and **allocations/op**.
+  `bench_run name iters body` runs a short untimed warmup then a timed
+  loop; `bench_auto name body` auto-scales the iteration count until a
+  pass clears ~50 ms, for stable numbers on sub-microsecond operations.
+  `bench_report` prints one line; `bench_result_*` accessors expose the
+  raw numbers. The allocation metric is backed by a new runtime hook,
+  `nurl_alloc_count` (a relaxed-atomic counter on every
+  `nurl_alloc`/`nurl_zalloc` — which is what stdlib vec/string/struct
+  blocks route through), snapshotted around the timed loop so warmup is
+  excluded. `nurlpkg bench` discovers `benches/*.nu`, compiles each at
+  `-O2`, runs it, and streams its report (no goldens — wall time is
+  machine-dependent; a bench fails only on a compile error or nonzero
+  exit). Ships `bench/stdlib_hotpath.nu` (string build / vec push / sort
+  micro-benches). Locks: `compiler/tests/bench_basic.nu` (deterministic
+  surface — report formatting, the alloc counter on a vec cycle vs a
+  no-op body, iteration bookkeeping) and
+  `compiler/tests/nurlpkg_bench_smoke.sh` (runner discovery / streaming /
+  summary / exit codes).
+
 - **`nurlpkg test` — user-facing test runner** (critic C3). Ships the
   compiler suite's per-test pattern as a tool: `nurlpkg test` discovers
   `tests/*.nu`, compiles and runs each, and reports `PASS`/`FAIL` with a

--- a/bench/stdlib_hotpath.nu
+++ b/bench/stdlib_hotpath.nu
@@ -1,0 +1,49 @@
+// bench/stdlib_hotpath.nu — micro-benchmarks for a few stdlib hot
+// paths, driven by std/bench.nu. Run directly (`./nurl.sh -O2
+// bench/stdlib_hotpath.nu bench && ./bench`) or via `nurlpkg bench`
+// from a project whose benches/ links here. Reports ns/op and the
+// NURL-level allocations/op for each.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/std/cmp.nu`
+$ `stdlib/std/bench.nu`
+
+@ main → i {
+    ( nurl_print `stdlib hot-path benchmarks (ns/op, allocs/op):\n\n` )
+
+    // 1. String building: 16 push_char into a pre-sized buffer.
+    : ( @ v ) b_str \ → v {
+        : String s ( string_with_cap 16 )
+        : ~ i k 0
+        ~ < k 16 { ( string_push_char s + 97 % k 26 ) = k + k 1 }
+        ( string_free s )
+    }
+    : BenchResult r1 ( bench_auto `string_build_16` b_str )
+    ( bench_report r1 ) ( bench_result_free r1 )
+
+    // 2. Vec push: 64 i64s into a growing vector (amortised reallocs).
+    : ( @ v ) b_vec \ → v {
+        : ( Vec i ) v ( vec_new [i] )
+        : ~ i k 0
+        ~ < k 64 { ( vec_push [i] v * k k ) = k + k 1 }
+        ( vec_free [i] v )
+    }
+    : BenchResult r2 ( bench_auto `vec_push_64` b_vec )
+    ( bench_report r2 ) ( bench_result_free r2 )
+
+    // 3. Sort: 32 descending i64s back to ascending each op.
+    : ( @ i i i ) ci \ i a i b → i { ^ ( cmp_int a b ) }
+    : ( @ v ) b_sort \ → v {
+        : ( Vec i ) v ( vec_with_cap [i] 32 )
+        : ~ i k 0
+        ~ < k 32 { ( vec_push [i] v - 32 k ) = k + k 1 }
+        ( sort_by [i] v ci )
+        ( vec_free [i] v )
+    }
+    : BenchResult r3 ( bench_auto `sort_32_desc` b_sort )
+    ( bench_report r3 ) ( bench_result_free r3 )
+
+    ^ 0
+}

--- a/compiler/tests/bench_basic.nu
+++ b/compiler/tests/bench_basic.nu
@@ -1,0 +1,31 @@
+// bench_basic.nu — std/bench.nu acceptance for its deterministic
+// surface. Wall-time (ns/op) is machine-dependent, so the golden checks
+// only: the report formatting (pure), the allocation counter (a
+// vec_new+free cycle allocates a fixed amount per op; a no-op body
+// allocates none), iteration bookkeeping, and that ns/op is non-negative.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bench.nu`
+
+@ main → i {
+    // pure formatting
+    : String f ( __bench_fmt `demo` 1000 42 3 )
+    ( nurl_print ( string_data f ) ) ( nurl_print `\n` )
+    ( string_free f )
+
+    // vec_new + vec_free allocates a fixed number of NURL blocks per op
+    : ( @ v ) alloc_body \ → v { : ( Vec i ) v ( vec_new [i] ) ( vec_free [i] v ) }
+    : BenchResult r1 ( bench_run `vec_cycle` 1000 alloc_body )
+    ( nurl_print `vec_allocs_per_op=` ) ( nurl_print ( nurl_str_int ( bench_result_allocs_per_op r1 ) ) ) ( nurl_print `\n` )
+    ( nurl_print `iters=` ) ( nurl_print ( nurl_str_int ( bench_result_iters r1 ) ) ) ( nurl_print `\n` )
+    ( nurl_print `ns_nonneg=` ) ( nurl_print ? >= ( bench_result_ns_per_op r1 ) 0 `T` `F` ) ( nurl_print `\n` )
+    ( bench_result_free r1 )
+
+    // a body that allocates nothing → 0 allocs/op
+    : ( @ v ) noalloc \ → v { : i _x + 1 2 }
+    : BenchResult r2 ( bench_run `noop` 1000 noalloc )
+    ( nurl_print `noop_allocs_per_op=` ) ( nurl_print ( nurl_str_int ( bench_result_allocs_per_op r2 ) ) ) ( nurl_print `\n` )
+    ( bench_result_free r2 )
+    ^ 0
+}

--- a/compiler/tests/nurlpkg_bench_smoke.sh
+++ b/compiler/tests/nurlpkg_bench_smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  compiler/tests/nurlpkg_bench_smoke.sh — end-to-end smoke test for
+#  `nurlpkg bench` (the C4 bench runner half).
+#
+#  Asserts the runner discovers benches/*.nu, compiles + runs each,
+#  streams its stdout, prints a `ran N · failed M` summary, and exits
+#  0 iff every bench compiled and exited 0. std/bench.nu itself is
+#  covered separately by the bench_basic.nu corpus golden, so these
+#  fixtures are import-free (CWD-independent).
+#
+#  Exit codes: 0 ok · 1 assertion failed · 2 environment problem.
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+NURLPKG="$ROOT_DIR/build/nurlpkg"
+DRIVER="$ROOT_DIR/nurl.sh"
+
+if [[ ! -x "$NURLPKG" ]]; then
+    echo "building nurlpkg..." >&2
+    "$ROOT_DIR/tools/nurlpkg/build.sh" >/dev/null 2>&1 || { echo "ERROR: build nurlpkg first (./build.sh)." >&2; exit 2; }
+fi
+[[ -x "$DRIVER" ]] || { echo "ERROR: $DRIVER missing." >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "nurlpkg bench smoke: FAIL — $1"; echo "── stdout ──"; cat "$WORK/out.txt"; echo "── stderr ──"; cat "$WORK/err.txt"; exit 1; }
+
+# ── case 1: two healthy benches → streamed output + exit 0 ──
+mkdir -p "$WORK/proj/benches"
+printf '@ main → i { ( nurl_print `ALPHA_MARK\\n` ) ^ 0 }\n' > "$WORK/proj/benches/alpha.nu"
+printf '@ main → i { ( nurl_print `BETA_MARK\\n` ) ^ 0 }\n'  > "$WORK/proj/benches/beta.nu"
+
+( cd "$WORK/proj" && NURL_CC="$DRIVER" "$NURLPKG" bench ) >"$WORK/out.txt" 2>"$WORK/err.txt"
+RC=$?
+grep -q "ALPHA_MARK" "$WORK/out.txt" || fail "alpha output not streamed"
+grep -q "BETA_MARK"  "$WORK/out.txt" || fail "beta output not streamed"
+grep -q "ran 2 · failed 0" "$WORK/out.txt" || fail "summary wrong"
+[[ $RC -eq 0 ]] || fail "healthy benches should exit 0 (got $RC)"
+
+# ── case 2: one bench exits nonzero → failed 1, exit 1 ──
+printf '@ main → i { ( nurl_print `GAMMA_MARK\\n` ) ^ 2 }\n' > "$WORK/proj/benches/gamma.nu"
+( cd "$WORK/proj" && NURL_CC="$DRIVER" "$NURLPKG" bench ) >"$WORK/out.txt" 2>"$WORK/err.txt"
+RC=$?
+grep -q "ran 2 · failed 1" "$WORK/out.txt" || fail "nonzero-exit bench not counted as failure"
+[[ $RC -eq 1 ]] || fail "a failing bench should exit 1 (got $RC)"
+
+# ── case 3: no benches/ dir → message + exit 1 ──
+mkdir -p "$WORK/empty"
+( cd "$WORK/empty" && NURL_CC="$DRIVER" "$NURLPKG" bench ) >"$WORK/out.txt" 2>"$WORK/err.txt"
+RC=$?
+[[ $RC -eq 1 ]] || fail "missing benches/ should exit 1 (got $RC)"
+grep -q "no benchmarks\|no benches" "$WORK/err.txt" || fail "missing benches/ message absent"
+
+echo "nurlpkg bench smoke: OK (discovery, streaming, summary, exit codes correct)"
+exit 0

--- a/compiler/tests/outputs/bench_basic.txt
+++ b/compiler/tests/outputs/bench_basic.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+demo: 42 ns/op  (1000 iters, 3 allocs/op)
+vec_allocs_per_op=1
+iters=1000
+ns_nonneg=T
+noop_allocs_per_op=0

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -544,8 +544,16 @@ long long nurl_path_type(const char *path) {
 
 /* ── §9  Memory allocation ─────────────────────────────────────── */
 
-void* nurl_alloc(long long bytes)              { return malloc((size_t)bytes); }
-void* nurl_zalloc(long long bytes)             { return calloc(1, (size_t)bytes); }
+/* Process-wide count of NURL-level allocations (every nurl_alloc /
+ * nurl_zalloc — which is what stdlib vec/string/struct ctl blocks route
+ * through). Exposed via nurl_alloc_count() for std/bench.nu's per-op
+ * allocation metric. A relaxed atomic so the increment is correct under
+ * threads while costing nothing measurable next to the malloc itself. */
+static unsigned long long g_nurl_alloc_count = 0;
+
+void* nurl_alloc(long long bytes)              { __atomic_fetch_add(&g_nurl_alloc_count, 1, __ATOMIC_RELAXED); return malloc((size_t)bytes); }
+void* nurl_zalloc(long long bytes)             { __atomic_fetch_add(&g_nurl_alloc_count, 1, __ATOMIC_RELAXED); return calloc(1, (size_t)bytes); }
+long long nurl_alloc_count(void)               { return (long long)__atomic_load_n(&g_nurl_alloc_count, __ATOMIC_RELAXED); }
 void* nurl_realloc(void *ptr, long long bytes) { return realloc(ptr, (size_t)bytes); }
 void  nurl_free(void *ptr)                     { free(ptr); }
 void  nurl_memcpy(void *dst, const void *src, long long bytes) {

--- a/stdlib/std/bench.nu
+++ b/stdlib/std/bench.nu
@@ -1,0 +1,100 @@
+// stdlib/std/bench.nu — a micro-benchmark harness.
+//
+// Time a closure over many iterations and report ns/op plus the
+// NURL-level allocations/op (vec/string/struct ctl blocks all route
+// through nurl_alloc, which the runtime counts). Wall time comes from
+// the monotonic clock (`monotonic_ns`), so it is immune to NTP slew.
+//
+//   ( bench_run  s name i iters ( @ v ) body )  → BenchResult
+//   ( bench_auto s name ( @ v ) body )           → BenchResult
+//       auto-scales iters until a timed run clears ~50 ms, for stable
+//       ns/op on cheap operations.
+//   ( bench_report BenchResult r )               → v   one line to stdout
+//   ( bench_result_ns_per_op  BenchResult r )    → i
+//   ( bench_result_allocs_per_op BenchResult r ) → i
+//   ( bench_result_free BenchResult r )          → v
+//
+// Each run does a short untimed warmup first (caches/branch predictor),
+// then snapshots the allocation counter and clock around the timed
+// loop, so warmup work is excluded from both metrics. `body` takes no
+// arguments and returns nothing — capture inputs/outputs in its
+// environment (a `~`-mutable accumulator defeats dead-code elimination
+// of the work being measured).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/time.nu`
+
+// Runtime allocation counter (stdlib/runtime.c §9). Monotonic, process-
+// wide; subtract two snapshots for a delta.
+& `libc` @ nurl_alloc_count → i
+
+: BenchResult { String name i iters i total_ns i ns_per_op i allocs_per_op }
+
+@ bench_result_name BenchResult r → s { ^ ( string_data . r name ) }
+@ bench_result_iters BenchResult r → i { ^ . r iters }
+@ bench_result_total_ns BenchResult r → i { ^ . r total_ns }
+@ bench_result_ns_per_op BenchResult r → i { ^ . r ns_per_op }
+@ bench_result_allocs_per_op BenchResult r → i { ^ . r allocs_per_op }
+
+@ bench_result_free BenchResult r → v { ( string_free . r name ) }
+
+// Run `body` `iters` times (after a short warmup) and measure.
+@ bench_run s name i iters ( @ v ) body → BenchResult {
+    : i n ? > iters 0 iters 1
+    // warmup: ~1% of iters, at least 1, capped so it stays cheap
+    : i warm ? > / n 100 0 / n 100 1
+    : ~ i w 0
+    ~ < w warm { ( body ) = w + w 1 }
+
+    : i a0 ( nurl_alloc_count )
+    : i t0 ( monotonic_ns )
+    : ~ i k 0
+    ~ < k n { ( body ) = k + k 1 }
+    : i t1 ( monotonic_ns )
+    : i a1 ( nurl_alloc_count )
+
+    : i total ? > - t1 t0 0 - t1 t0 0
+    : String nm ( string_with_cap + ( nurl_str_len name ) 1 )
+    ( string_push_str nm name )
+    ^ @ BenchResult { nm n total / total n / - a1 a0 n }
+}
+
+// Auto-scale iters until a timed pass clears ~50 ms, so ns/op is stable
+// even for sub-microsecond operations. Caps the ramp so a slow body
+// cannot run away.
+@ bench_auto s name ( @ v ) body → BenchResult {
+    : ~ i iters 1
+    : ~ b done F
+    : ~ BenchResult best ( bench_run name 1 body )
+    ~ ! done {
+        ( bench_result_free best )
+        = best ( bench_run name iters body )
+        ? | >= ( bench_result_total_ns best ) 50000000 >= iters 100000000 {
+            = done T
+        } {
+            = iters * iters 4
+        }
+    }
+    ^ best
+}
+
+// "name: 12 ns/op  (1000000 iters, 0 allocs/op)"
+@ __bench_fmt s name i iters i ns_per_op i allocs_per_op → String {
+    : String out ( string_with_cap 64 )
+    ( string_push_str out name )
+    ( string_push_str out `: ` )
+    ( string_push_str out ( nurl_str_int ns_per_op ) )
+    ( string_push_str out ` ns/op  (` )
+    ( string_push_str out ( nurl_str_int iters ) )
+    ( string_push_str out ` iters, ` )
+    ( string_push_str out ( nurl_str_int allocs_per_op ) )
+    ( string_push_str out ` allocs/op)` )
+    ^ out
+}
+
+@ bench_report BenchResult r → v {
+    : String line ( __bench_fmt ( string_data . r name ) . r iters . r ns_per_op . r allocs_per_op )
+    ( nurl_print ( string_data line ) )
+    ( nurl_print `\n` )
+    ( string_free line )
+}

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -170,6 +170,7 @@ $ `stdlib/std/bytes.nu`
     ( nurl_print `  nurlpkg remove <name>  Delete a dependency entry from nurl.toml.\n` )
     ( nurl_print `  nurlpkg verify         Check deps/ matches nurl.lock (names + versions); exit 1 if drift.\n` )
     ( nurl_print `  nurlpkg test           Build + run every tests/*.nu (exit 0 = pass; optional tests/outputs/ goldens).\n` )
+    ( nurl_print `  nurlpkg bench          Build + run every benches/*.nu and stream their std/bench.nu reports.\n` )
     ( nurl_print `  nurlpkg version        Print the nurlpkg version.\n` )
     ( nurl_print `  nurlpkg help           Show this message.\n` )
 }
@@ -1819,6 +1820,98 @@ $ `stdlib/std/bytes.nu`
     }
 }
 
+// ── bench runner (C4) ─────────────────────────────────────────────
+//
+// `nurlpkg bench` compiles + runs every `benches/*.nu` and streams its
+// stdout (each bench program prints its own std/bench.nu report). No
+// goldens — wall time is machine-dependent. A bench "fails" only if it
+// won't compile or exits nonzero. Build driver as for `test` ($NURL_CC,
+// default ./nurl.sh).
+
+@ __run_bench_one s src s driver → i {
+    : String name ( __test_basename src )
+    : String bin ( string_with_cap 64 )
+    ( string_push_str bin `/tmp/nurlpkg_bench_` )
+    ( string_push_str bin ( string_data name ) )
+
+    : String ccmd ( string_with_cap 128 )
+    ( string_push_str ccmd driver )
+    ( string_push_str ccmd ` -O2 ` )
+    ( string_push_str ccmd src )
+    ( string_push_char ccmd 32 )
+    ( string_push_str ccmd ( string_data bin ) )
+
+    : ~ i result 1
+    : ~ b compiled F
+    ?? ( process_run_shell ( string_data ccmd ) ) {
+        T out → {
+            ? ( output_success out ) { = compiled T } {
+                ( nurl_print `── ` ) ( nurl_print ( string_data name ) ) ( nurl_print ` (compile error)\n` )
+                ( nurl_eprint ( output_stderr out ) )
+            }
+            ( output_free out )
+        }
+        F _ → { ( nurl_print `── ` ) ( nurl_print ( string_data name ) ) ( nurl_print ` (could not launch compiler)\n` ) }
+    }
+    ( string_free ccmd )
+
+    ? compiled {
+        ( nurl_print `── ` ) ( nurl_print ( string_data name ) ) ( nurl_print `\n` )
+        ?? ( process_run_shell ( string_data bin ) ) {
+            T out → {
+                : i olen ( output_stdout_len out )
+                ? > olen 0 { : i _w ( write 1 # *u ( output_stdout out ) olen ) } {}
+                ? == ( output_exit_code out ) 0 { = result 0 } {}
+                ( output_free out )
+            }
+            F _ → { ( nurl_print `(could not run)\n` ) }
+        }
+    } {}
+
+    ( string_free bin )
+    ( string_free name )
+    ^ result
+}
+
+@ __run_benches ( Vec String ) files → i {
+    : ( @ i String String ) cs \ String a String b → i { ^ ( cmp_string a b ) }
+    ( sort_by [String] files cs )
+    : String driver ( __test_driver )
+    : ~ i ran 0
+    : ~ i failed 0
+    : ~ i k 0
+    ~ < k ( vec_len [String] files ) {
+        ?? ( vec_get [String] files k ) {
+            T src → {
+                ? == ( __run_bench_one ( string_data src ) ( string_data driver ) ) 0 { = ran + ran 1 } { = failed + failed 1 }
+                ( string_free src )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [String] files )
+    ( string_free driver )
+    ( nurl_print `\nran ` ) ( nurl_print ( nurl_str_int ran ) )
+    ( nurl_print ` · failed ` ) ( nurl_print ( nurl_str_int failed ) ) ( nurl_print `\n` )
+    ^ ? == failed 0 0 1
+}
+
+@ __cmd_bench → i {
+    ^ ?? ( fs_glob `benches/*.nu` ) {
+        F _ → { ( nurl_eprintln `nurlpkg: no benches/ directory (expected benches/*.nu)` ) 1 }
+        T files → {
+            ? == ( vec_len [String] files ) 0 {
+                ( nurl_eprintln `nurlpkg: no benchmarks found (expected benches/*.nu)` )
+                ( vec_free [String] files )
+                1
+            } {
+                ( __run_benches files )
+            }
+        }
+    }
+}
+
 // ── dispatch ─────────────────────────────────────────────────────
 
 @ main → i {
@@ -1951,6 +2044,10 @@ $ `stdlib/std/bytes.nu`
     ? != 0 ( nurl_str_eq s_sub `test` ) {
         ( string_free sub )
         ^ ( __cmd_test )
+    } {}
+    ? != 0 ( nurl_str_eq s_sub `bench` ) {
+        ( string_free sub )
+        ^ ( __cmd_bench )
     } {}
     ? != 0 ( nurl_str_eq s_sub `version` ) {
         ( string_free sub )


### PR DESCRIPTION
Implements critic **C4 — benchmark harness**: a `std/bench.nu` library plus a `nurlpkg bench` runner, continuing the evaluator-tooling track (C1 REPL → C2 nurldoc → C3 test → **C4 bench**).

## `std/bench.nu`
Times a no-arg closure over many iterations and reports **ns/op** (monotonic clock) and **allocations/op**.
- `bench_run name iters body` — short untimed warmup, then a timed loop.
- `bench_auto name body` — auto-scales the iteration count until a pass clears ~50 ms (stable numbers for sub-µs ops).
- `bench_report` prints one line; `bench_result_*` accessors expose the raw numbers.

The allocation metric is backed by a **new runtime hook, `nurl_alloc_count`** — a relaxed-atomic counter incremented on every `nurl_alloc`/`nurl_zalloc` (which is exactly what stdlib vec/string/struct ctl blocks route through). Snapshotted around the timed loop, so warmup allocations are excluded. The increment is a `__ATOMIC_RELAXED` add — correct under threads, immeasurable next to the `malloc` itself.

## `nurlpkg bench`
Discovers `benches/*.nu`, compiles each at `-O2` (driver `./nurl.sh`, override `$NURL_CC`), runs it, and streams its report. No goldens — wall time is machine-dependent; a bench fails only on a compile error or nonzero exit. Prints a `ran N · failed M` summary.

## Benches
`bench/stdlib_hotpath.nu` — string build / vec push / sort micro-benches. Sample run:
```
string_build_16: 56 ns/op  (1048576 iters, 1 allocs/op)
vec_push_64: 247 ns/op  (262144 iters, 1 allocs/op)
sort_32_desc: 705 ns/op  (262144 iters, 1 allocs/op)
```

## Tests
- `compiler/tests/bench_basic.nu` (corpus golden) — the deterministic surface: report formatting, the alloc counter (vec-cycle = 1/op, no-op body = 0/op), iteration bookkeeping, ns/op non-negativity.
- `compiler/tests/nurlpkg_bench_smoke.sh` — runner discovery / streaming / summary / exit codes.

## Gates
- `./build.sh` — fixed point + corpus (incl. `bench_basic`): **green**.
- `./build.sh --san` + `run_san_tests.sh` — **SAN_FAIL 0** (378 total; the runtime alloc hook is clean under ASan/UBSan/LSan).
- `./tools/check_examples.sh` — **64 PASS / 0 FAIL** (incl. `bench/stdlib_hotpath.nu`).
- `nurlpkg` test + bench smokes and the REPL smoke all pass on fresh tool builds.

Not done: the self-host-compile bench (timing nurlc compiling itself) — left as a follow-up; the harness + stdlib hot-path benches are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
