### PR TITLE
stdlib: HTTP client cookie jar (ext/cookies.nu) — B23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **HTTP client cookie jar — `stdlib/ext/cookies.nu`** (critic B23). The
+  server side writes `Set-Cookie` (ext/http_auth.nu); this is the missing
+  client half. `cookie_jar_set` parses one `Set-Cookie` value (Domain,
+  Path, Expires, Max-Age, Secure — Max-Age wins over Expires, an
+  already-expired cookie deletes its stored match) defaulting Domain/Path
+  from the request host/path; `cookie_jar_header` returns the `Cookie:`
+  value for a request, applying RFC 6265 domain matching (§5.1.3,
+  host-only vs subdomain), path matching (§5.1.4), Secure gating, and
+  expiry, longest-path-first. Pure string-in/string-out — decoupled from
+  the HTTP client types, so it round-trips a session over HTTP/1.1, h2,
+  or any header source. `now` (unix seconds) is passed explicitly for
+  deterministic expiry. Lock: `compiler/tests/cookies_basic.nu`
+  (host-only vs Domain, path ordering, Secure, Max-Age/Expires expiry,
+  replacement, Max-Age=0 deletion, malformed rejection); ASan+UBSan+LSan
+  clean.
+
 - **Benchmark harness — `stdlib/std/bench.nu` + `nurlpkg bench`** (critic
   C4). `std/bench.nu` times a no-arg closure over many iterations and
   reports **ns/op** (via the monotonic clock) and **allocations/op**.

--- a/compiler/tests/cookies_basic.nu
+++ b/compiler/tests/cookies_basic.nu
@@ -1,0 +1,80 @@
+// cookies_basic.nu — ext/cookies.nu (HTTP client cookie jar) acceptance.
+//
+// Deterministic: `now` is passed explicitly so Max-Age / Expires resolve
+// the same everywhere. Covers host-only vs Domain matching, path
+// matching + longest-path-first ordering, Secure gating, Max-Age and
+// Expires expiry, replacement, and Max-Age=0 deletion.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/ext/cookies.nu`
+
+@ show s label CookieJar j s host s path b secure i now → v {
+    : String h ( cookie_jar_header j host path secure now )
+    ( nurl_print label ) ( nurl_print `=[` ) ( nurl_print ( string_data h ) ) ( nurl_print `]\n` )
+    ( string_free h )
+}
+
+@ setok s label CookieJar j s sc s host s path i now → v {
+    ( nurl_print label ) ( nurl_print `=` )
+    ( nurl_print ? ( cookie_jar_set j sc host path now ) `ok` `bad` ) ( nurl_print `\n` )
+}
+
+@ main → i {
+    // ── host-only vs Domain ──
+    : CookieJar j1 ( cookie_jar_new )
+    ( setok `set_sid` j1 `sid=abc123` `example.com` `/` 1000 )
+    ( setok `set_dom` j1 `pref=dark; Domain=example.com` `www.example.com` `/` 1000 )
+    ( show `exact` j1 `example.com` `/` F 1000 )           // sid (host-only) + pref (domain)
+    ( show `www_sub` j1 `www.example.com` `/` F 1000 )     // only pref (sid is host-only to example.com)
+    ( show `other` j1 `evil.com` `/` F 1000 )              // none
+    ( nurl_print `count1=` ) ( nurl_print ( nurl_str_int ( cookie_jar_count j1 ) ) ) ( nurl_print `\n` )
+    ( cookie_jar_free j1 )
+
+    // ── path matching + longest-path-first ──
+    : CookieJar j2 ( cookie_jar_new )
+    ( setok `set_root` j2 `p=root; Path=/` `ex.com` `/` 1000 )
+    ( setok `set_deep` j2 `q=deep; Path=/a/b` `ex.com` `/a/b` 1000 )
+    ( show `at_deep` j2 `ex.com` `/a/b` F 1000 )           // q then p (longer path first)
+    ( show `at_root` j2 `ex.com` `/` F 1000 )              // only p
+    ( show `at_a` j2 `ex.com` `/a` F 1000 )                // only p (/a/b doesn't match /a)
+    ( cookie_jar_free j2 )
+
+    // ── Secure gating ──
+    : CookieJar j3 ( cookie_jar_new )
+    ( setok `set_sec` j3 `t=tok; Secure` `ex.com` `/` 1000 )
+    ( show `insecure` j3 `ex.com` `/` F 1000 )             // empty
+    ( show `secure` j3 `ex.com` `/` T 1000 )               // t=tok
+    ( cookie_jar_free j3 )
+
+    // ── Max-Age expiry + deletion ──
+    : CookieJar j4 ( cookie_jar_new )
+    ( setok `set_ma` j4 `e=5; Max-Age=100` `ex.com` `/` 1000 )
+    ( show `before_exp` j4 `ex.com` `/` F 1050 )           // e=5
+    ( show `after_exp` j4 `ex.com` `/` F 1200 )            // empty (expired)
+    ( setok `set_again` j4 `e=5; Max-Age=100` `ex.com` `/` 1000 )
+    ( setok `delete_e` j4 `e=; Max-Age=0` `ex.com` `/` 1000 )
+    ( nurl_print `count4=` ) ( nurl_print ( nurl_str_int ( cookie_jar_count j4 ) ) ) ( nurl_print `\n` )  // 0
+    ( cookie_jar_free j4 )
+
+    // ── replacement keeps one entry ──
+    : CookieJar j5 ( cookie_jar_new )
+    ( setok `set_v1` j5 `s=v1` `ex.com` `/` 1000 )
+    ( setok `set_v2` j5 `s=v2` `ex.com` `/` 1000 )
+    ( show `replaced` j5 `ex.com` `/` F 1000 )             // s=v2
+    ( nurl_print `count5=` ) ( nurl_print ( nurl_str_int ( cookie_jar_count j5 ) ) ) ( nurl_print `\n` )  // 1
+    ( cookie_jar_free j5 )
+
+    // ── Expires (HTTP-date) ──
+    : CookieJar j6 ( cookie_jar_new )
+    ( setok `set_exp` j6 `g=6; Expires=Wed, 09 Jun 2021 10:18:14 GMT` `ex.com` `/` 0 )
+    ( show `pre2021` j6 `ex.com` `/` F 0 )                 // g=6 (now=0 is before 2021)
+    ( show `post2021` j6 `ex.com` `/` F 2000000000 )       // empty (now in 2033)
+    ( cookie_jar_free j6 )
+
+    // ── malformed → bad, nothing stored ──
+    : CookieJar j7 ( cookie_jar_new )
+    ( setok `set_bad` j7 `=novalue` `ex.com` `/` 1000 )
+    ( nurl_print `count7=` ) ( nurl_print ( nurl_str_int ( cookie_jar_count j7 ) ) ) ( nurl_print `\n` )  // 0
+    ( cookie_jar_free j7 )
+    ^ 0
+}

--- a/compiler/tests/outputs/cookies_basic.txt
+++ b/compiler/tests/outputs/cookies_basic.txt
@@ -1,0 +1,33 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+set_sid=ok
+set_dom=ok
+exact=[sid=abc123; pref=dark]
+www_sub=[pref=dark]
+other=[]
+count1=2
+set_root=ok
+set_deep=ok
+at_deep=[q=deep; p=root]
+at_root=[p=root]
+at_a=[p=root]
+set_sec=ok
+insecure=[]
+secure=[t=tok]
+set_ma=ok
+before_exp=[e=5]
+after_exp=[]
+set_again=ok
+delete_e=ok
+count4=0
+set_v1=ok
+set_v2=ok
+replaced=[s=v2]
+count5=1
+set_exp=ok
+pre2021=[g=6]
+post2021=[]
+set_bad=bad
+count7=0

--- a/stdlib/ext/cookies.nu
+++ b/stdlib/ext/cookies.nu
@@ -1,0 +1,350 @@
+// stdlib/ext/cookies.nu — an HTTP client cookie jar (RFC 6265).
+//
+// The server side of the stack writes Set-Cookie (ext/http_auth.nu); the
+// client had no way to round-trip a session short of hand-building
+// `Cookie:` headers. This is the missing half: feed each Set-Cookie
+// response header to the jar, then ask the jar for the `Cookie:` value
+// to send on the next request. Pure string in / string out — decoupled
+// from the HTTP client types, so it is fully offline-testable and works
+// with HTTP/1.1, h2, or anything else that hands you header strings.
+//
+//   ( cookie_jar_new )                                   → CookieJar
+//   ( cookie_jar_set    CookieJar j s setcookie s host s path i now ) → b
+//        Parse + store one Set-Cookie value. Defaults Domain/Path from
+//        the request host/path; Max-Age (relative to `now`) wins over
+//        Expires; a cookie that resolves as already-expired DELETES any
+//        stored match. Returns F on a malformed header (nothing stored).
+//   ( cookie_jar_header CookieJar j s host s path b secure i now ) → String
+//        The `Cookie:` header value for a request — matching cookies
+//        (domain + path + Secure + unexpired), longest path first,
+//        "a=1; b=2" — or "" when none apply. Caller owns the String.
+//   ( cookie_jar_count  CookieJar j )                    → i
+//   ( cookie_jar_free   CookieJar j )                    → v
+//
+// `now` is unix seconds (e.g. from time_now → unix); pass it explicitly
+// so expiry is deterministic and testable. Session cookies (no Expires
+// / Max-Age) live until cookie_jar_free. Domain matching follows RFC
+// 6265 §5.1.3 (host-only vs subdomain) and path matching §5.1.4.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/time.nu`
+
+// expires: -1 = session (no expiry). host_only T = exact-host only
+// (no Domain attribute was sent). Strings are owned by the jar.
+: Cookie { String name String value String domain String path i expires b host_only b secure }
+
+: CookieJar { ( Vec Cookie ) cookies }
+
+@ cookie_jar_new → CookieJar {
+    ^ @ CookieJar { ( vec_new [Cookie] ) }
+}
+
+@ cookie_jar_count CookieJar j → i { ^ ( vec_len [Cookie] . j cookies ) }
+
+@ __cookie_free Cookie c → v {
+    ( string_free . c name )
+    ( string_free . c value )
+    ( string_free . c domain )
+    ( string_free . c path )
+}
+
+@ cookie_jar_free CookieJar j → v {
+    : ~ i k 0
+    ~ < k ( vec_len [Cookie] . j cookies ) {
+        ?? ( vec_get [Cookie] . j cookies k ) { T c → ( __cookie_free c ) F _ → {} }
+        = k + k 1
+    }
+    ( vec_free [Cookie] . j cookies )
+}
+
+@ __free_str_vec ( Vec String ) v → v {
+    : ~ i k 0
+    ~ < k ( vec_len [String] v ) {
+        ?? ( vec_get [String] v k ) { T s → ( string_free s ) F _ → {} }
+        = k + k 1
+    }
+    ( vec_free [String] v )
+}
+
+// ── small string helpers ─────────────────────────────────────────────
+
+// Compare a String against a raw `s` literal (string_eq is String×String;
+// attribute keys are matched against bare literals).
+@ __keyeq String k s lit → b { ^ == ( strcmp ( string_data k ) lit ) 0 }
+
+// substring before / after the first occurrence of `ch` (a 1-char
+// needle). When `ch` is absent: before = whole, after = "".
+@ __cut_before String s s ch → String {
+    ^ ?? ( string_index_of s ch ) {
+        T i → ( string_substr s 0 i )
+        F _ → { : String out ( string_with_cap + ( string_len s ) 1 ) ( string_push_str out ( string_data s ) ) out }
+    }
+}
+
+@ __cut_after String s s ch → String {
+    ^ ?? ( string_index_of s ch ) {
+        T i → ( string_substr s + i 1 - ( string_len s ) + i 1 )
+        F _ → ( string_with_cap 1 )
+    }
+}
+
+// default-path (RFC 6265 §5.1.4): up to and excluding the last '/';
+// "/" when the path is empty, relative, or has a single leading slash.
+@ __default_path s reqpath → String {
+    : String p ( string_with_cap 8 )
+    : i n ( nurl_str_len reqpath )
+    ? | == n 0 != ( nurl_str_get reqpath 0 ) 47 {            // empty or not absolute
+        ( string_push_char p 47 )
+        ^ p
+    } {}
+    : ~ i last 0
+    : ~ i k 0
+    ~ < k n { ? == ( nurl_str_get reqpath k ) 47 { = last k } {} = k + k 1 }
+    ? == last 0 { ( string_push_char p 47 ) } {
+        : ~ i j 0
+        ~ < j last { ( string_push_char p ( nurl_str_get reqpath j ) ) = j + j 1 }
+    }
+    ^ p
+}
+
+// ── matching (RFC 6265 §5.1.3 / §5.1.4) ──────────────────────────────
+
+@ __domain_match s host s domain b host_only → b {
+    : String h ( string_with_cap 8 ) ( string_push_str h host )
+    : String hl ( string_to_lower h ) ( string_free h )
+    : String d ( string_with_cap 8 ) ( string_push_str d domain )
+    : String dl ( string_to_lower d ) ( string_free d )
+    : i hn ( string_len hl )
+    : i dn ( string_len dl )
+    : ~ b ok F
+    ? ( string_eq hl dl ) { = ok T } {
+        ? host_only {} {
+            // subdomain: host ends with domain AND the char before is '.'
+            ? & ( string_ends_with hl ( string_data dl ) ) & > hn dn == ( string_get hl - - hn dn 1 ) 46 { = ok T } {}
+        }
+    }
+    ( string_free hl )
+    ( string_free dl )
+    ^ ok
+}
+
+@ __path_match s reqpath s cookiepath → b {
+    : String r ( string_with_cap 8 ) ( string_push_str r reqpath )
+    : String cp ( string_with_cap 8 ) ( string_push_str cp cookiepath )
+    : i rn ( string_len r )
+    : i cn ( string_len cp )
+    : ~ b ok F
+    ? ( string_eq r cp ) { = ok T } {
+        ? ( string_starts_with r cookiepath ) {
+            // prefix: ok if cookie-path ends in '/' or the next req char is '/'
+            ? > cn 0 {
+                ? == ( string_get cp - cn 1 ) 47 { = ok T } {
+                    ? & < cn rn == ( string_get r cn ) 47 { = ok T } {}
+                }
+            } {}
+        } {}
+    }
+    ( string_free r )
+    ( string_free cp )
+    ^ ok
+}
+
+// ── parse one Set-Cookie value ───────────────────────────────────────
+
+// Returns a freshly-owned Cookie (None on a malformed pair). `now` is
+// used to resolve Max-Age to an absolute expiry.
+@ cookie_parse s setcookie s host s path i now → ?Cookie {
+    : String sc ( string_with_cap + ( nurl_str_len setcookie ) 1 )
+    ( string_push_str sc setcookie )
+    : ( Vec String ) parts ( string_split sc `;` )
+    ( string_free sc )
+    ? == ( vec_len [String] parts ) 0 { ( vec_free [String] parts ) ^ @ ?Cookie { F } } {}
+
+    // first part: name=value
+    : ~ String nm ( string_with_cap 4 )
+    : ~ String val ( string_with_cap 4 )
+    ?? ( vec_get [String] parts 0 ) {
+        T p0 → {
+            : String t ( string_trim p0 )
+            ( string_free nm ) ( string_free val )
+            : String nraw ( __cut_before t `=` )
+            = nm ( string_trim nraw ) ( string_free nraw )
+            : String vraw ( __cut_after t `=` )
+            = val ( string_trim vraw ) ( string_free vraw )
+            ( string_free t )
+        }
+        F _ → {}
+    }
+    ? == ( string_len nm ) 0 {
+        ( string_free nm ) ( string_free val )
+        ( __free_str_vec parts )
+        ^ @ ?Cookie { F }
+    } {}
+
+    // defaults
+    : String hl0 ( string_with_cap 8 ) ( string_push_str hl0 host )
+    : ~ String dom ( string_to_lower hl0 ) ( string_free hl0 )
+    : ~ String cpath ( __default_path path )
+    : ~ i expires -1
+    : ~ b host_only T
+    : ~ b secure F
+    : ~ i seen_maxage 0
+
+    : ~ i pi 1
+    ~ < pi ( vec_len [String] parts ) {
+        ?? ( vec_get [String] parts pi ) {
+            T pp → {
+                : String seg ( string_trim pp )
+                : String kraw ( __cut_before seg `=` )
+                : String ktrim ( string_trim kraw ) ( string_free kraw )
+                : String key ( string_to_lower ktrim ) ( string_free ktrim )
+                : String vraw ( __cut_after seg `=` )
+                : String aval ( string_trim vraw ) ( string_free vraw )
+
+                ? ( __keyeq key `domain` ) {
+                    // strip a leading '.', lowercase
+                    : i dn0 ( string_len aval )
+                    : String stripped ? & > dn0 0 == ( string_get aval 0 ) 46 ( string_substr aval 1 - dn0 1 ) ( __cut_before aval `;` )
+                    : String low ( string_to_lower stripped ) ( string_free stripped )
+                    ? > ( string_len low ) 0 {
+                        ( string_free dom ) = dom low = host_only F
+                    } { ( string_free low ) }
+                } {
+                ? ( __keyeq key `path` ) {
+                    ? & > ( string_len aval ) 0 == ( string_get aval 0 ) 47 {
+                        ( string_free cpath )
+                        = cpath ( string_with_cap + ( string_len aval ) 1 )
+                        ( string_push_str cpath ( string_data aval ) )
+                    } {}
+                } {
+                ? ( __keyeq key `max-age` ) {
+                    = seen_maxage 1
+                    = expires + now ( nurl_str_to_int ( string_data aval ) )
+                } {
+                ? ( __keyeq key `expires` ) {
+                    ? == seen_maxage 0 {
+                        ?? ( http_date_parse ( string_data aval ) ) { T t → { = expires t } F _ → {} }
+                    } {}
+                } {
+                ? ( __keyeq key `secure` ) { = secure T } {}
+                } } } }
+
+                ( string_free seg ) ( string_free key ) ( string_free aval )
+            }
+            F _ → {}
+        }
+        = pi + pi 1
+    }
+    ( __free_str_vec parts )
+
+    : Cookie c @ Cookie { nm val dom cpath expires host_only secure }
+    ^ @ ?Cookie { T c }
+}
+
+// ── jar mutation + query ─────────────────────────────────────────────
+
+@ __vget_i ( Vec i ) v i k → i {
+    ^ ?? ( vec_get [i] v k ) { T x → x F _ → 0 }
+}
+
+// Drop any stored cookie with the same (name, domain, path) as `c`
+// (RFC 6265 identity). The jar holds at most one such, so we stop at
+// the first hit; removal is swap-with-last (order is not significant —
+// cookie_jar_header sorts on its own).
+@ __jar_remove CookieJar j Cookie c → v {
+    : ~ i k 0
+    ~ < k ( vec_len [Cookie] . j cookies ) {
+        : ~ b hit F
+        ?? ( vec_get [Cookie] . j cookies k ) {
+            T e → {
+                ? & & ( string_eq . e name . c name ) ( string_eq . e domain . c domain ) ( string_eq . e path . c path ) {
+                    ( __cookie_free e )
+                    = hit T
+                } {}
+            }
+            F _ → {}
+        }
+        ? hit {
+            : i last - ( vec_len [Cookie] . j cookies ) 1
+            ? > last k {
+                ?? ( vec_get [Cookie] . j cookies last ) { T lc → { : b _s ( vec_set [Cookie] . j cookies k lc ) } F _ → {} }
+            } {}
+            : b _t ( vec_set_len [Cookie] . j cookies last )
+            = k ( vec_len [Cookie] . j cookies )   // unique → done
+        } { = k + k 1 }
+    }
+}
+
+@ cookie_jar_set CookieJar j s setcookie s host s path i now → b {
+    ^ ?? ( cookie_parse setcookie host path now ) {
+        F _ → F
+        T c → {
+            ( __jar_remove j c )
+            ? & != . c expires -1 <= . c expires now {
+                ( __cookie_free c )                    // already expired → deletion only
+            } {
+                ( vec_push [Cookie] . j cookies c )
+            }
+            T
+        }
+    }
+}
+
+@ __cookie_path_len CookieJar j i idx → i {
+    ^ ?? ( vec_get [Cookie] . j cookies idx ) { T c → ( string_len . c path ) F _ → 0 }
+}
+
+// Insertion sort of `idxs` by cookie path length, longest first
+// (RFC 6265 §5.4: more specific paths sort earlier). Stable on ties.
+@ __sort_by_path_desc CookieJar j ( Vec i ) idxs → v {
+    : i n ( vec_len [i] idxs )
+    : ~ i i 1
+    ~ < i n {
+        : i cur ( __vget_i idxs i )
+        : i curlen ( __cookie_path_len j cur )
+        : ~ i jx - i 1
+        ~ & >= jx 0 < ( __cookie_path_len j ( __vget_i idxs jx ) ) curlen {
+            : b _s ( vec_set [i] idxs + jx 1 ( __vget_i idxs jx ) )
+            = jx - jx 1
+        }
+        : b _t ( vec_set [i] idxs + jx 1 cur )
+        = i + i 1
+    }
+}
+
+@ cookie_jar_header CookieJar j s host s path b secure i now → String {
+    : ( Vec i ) idxs ( vec_new [i] )
+    : ~ i k 0
+    ~ < k ( vec_len [Cookie] . j cookies ) {
+        ?? ( vec_get [Cookie] . j cookies k ) {
+            T c → {
+                : ~ b keep T
+                ? & != . c expires -1 <= . c expires now { = keep F } {}
+                ? & . c secure ! secure { = keep F } {}
+                ? keep { ? ( __domain_match host ( string_data . c domain ) . c host_only ) {} { = keep F } } {}
+                ? keep { ? ( __path_match path ( string_data . c path ) ) {} { = keep F } } {}
+                ? keep { ( vec_push [i] idxs k ) } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( __sort_by_path_desc j idxs )
+    : String out ( string_with_cap 64 )
+    : ~ i m 0
+    ~ < m ( vec_len [i] idxs ) {
+        ?? ( vec_get [Cookie] . j cookies ( __vget_i idxs m ) ) {
+            T c → {
+                ? > m 0 { ( string_push_str out `; ` ) } {}
+                ( string_push_str out ( string_data . c name ) )
+                ( string_push_char out 61 )                // '='
+                ( string_push_str out ( string_data . c value ) )
+            }
+            F _ → {}
+        }
+        = m + m 1
+    }
+    ( vec_free [i] idxs )
+    ^ out
+}


### PR DESCRIPTION
Implements critic **B23 — HTTP client cookie jar** (`ext/cookies.nu`). The server side writes `Set-Cookie` (`ext/http_auth.nu`); the client had no way to round-trip a session short of hand-building `Cookie:` headers. This is the missing half.

## API
- `cookie_jar_set jar setcookie host path now` — parse one `Set-Cookie` value and store it. Handles **Domain**, **Path**, **Expires**, **Max-Age** (wins over Expires), **Secure**; defaults Domain/Path from the request host/path; a cookie that resolves as already-expired **deletes** its stored match. Returns F on a malformed pair.
- `cookie_jar_header jar host path secure now` → the `Cookie:` value for a request — matching cookies only (RFC 6265 domain §5.1.3 host-only-vs-subdomain, path §5.1.4, Secure gating, unexpired), **longest path first**, `"a=1; b=2"`, or `""`.
- `cookie_jar_count`, `cookie_jar_free`, plus `cookie_parse` for one-shot parsing.

Pure string-in/string-out — decoupled from the HTTP client types, so it works with HTTP/1.1, h2, or any header source. `now` (unix seconds) is passed explicitly so expiry is deterministic and testable.

## Test
`compiler/tests/cookies_basic.nu` covers host-only vs Domain matching, path matching + longest-path-first ordering, Secure gating, Max-Age and Expires (HTTP-date) expiry, replacement, Max-Age=0 deletion, and malformed rejection.

## Gates
- `./build.sh` — fixed point + corpus (incl. `cookies_basic`): **green** (MISSING 0 / ORPHAN 0).
- `./tools/check_examples.sh` — **64 PASS / 0 FAIL**.
- ASan+UBSan+LSan clean on the test; `nurlc --lint` clean.

Pure-NURL stdlib addition — no runtime/compiler edits.

### Note (separate follow-up)
The test surfaced a typing gap: `string_eq` (declared `String × String`) silently accepted a raw `s` literal argument and compared garbage. Worked around correctly here with a `String`-vs-`s` comparator (`strcmp` on `string_data`); a compiler diagnostic for `String`/`s` coercion in call arguments is worth a separate A-item (noted in critic.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
