### PR TITLE
feat(cluster): distributed RPC MVP — call_remote + registry dispatch (TODO §7.1)

### DIFF
--- a/compiler/tests/cluster_rpc.nu
+++ b/compiler/tests/cluster_rpc.nu
@@ -1,0 +1,94 @@
+// cluster_rpc.nu — offline tests for stdlib/ext/cluster.nu.
+//
+// No sockets: exercises the registry + the pure `rpc_dispatch` path
+// (request envelope → response envelope) end to end, plus the error
+// name table. The HTTP transport is covered by examples/cluster_rpc.nu.
+//
+// Exercises:
+//   * registry_register + registry_count
+//   * rpc_dispatch hit  → { ok: true,  result: 49 }   (square of 7)
+//   * rpc_dispatch miss → { ok: false, error: "no such fn" }
+//   * cluster_err_name renders every variant
+
+$ `stdlib/ext/cluster.nu`
+
+// A registered handler: receives a BORROWED args Json (a number),
+// returns an OWNED Json carrying its square.
+@ h_square Json args → !Json ClusterErr {
+    : ?i ni ( json_num_as_i args )
+    ^ ?? ni {
+        T n → @ !Json ClusterErr { T ( json_int * n n ) }
+        F → @ !Json ClusterErr { F @ ClusterErr { ClSerialize } }
+    }
+}
+
+@ print_ok Json env → v {
+    : ?Json okj ( json_obj_get env `ok` )
+    ?? okj {
+        T b → ( nurl_print ? ( json_bool_val b ) `true` `false` )
+        F → ( nurl_print `?` )
+    }
+}
+
+@ main → i {
+    : Registry reg ( registry_new )
+    ( registry_register reg `square`
+    \ Json a → !Json ClusterErr { ^ ( h_square a ) } )
+
+    ( nurl_print `count: ` )
+    ( nurl_print_int ( registry_count reg ) )
+    ( nurl_print `\n` )
+
+    // ── 1. Hit: square of 7 → 49 ─────────────────────────────────
+    : Json req ( json_obj_new )
+    ( json_obj_set req `fn` ( json_str_lit `square` ) )
+    ( json_obj_set req `args` ( json_int 7 ) )
+    : Json env ( rpc_dispatch reg req )
+    ( json_free req )
+
+    ( nurl_print `ok: ` )
+    ( print_ok env )
+    ( nurl_print `\n` )
+    : ?Json resj ( json_obj_get env `result` )
+    ?? resj {
+        T rj → {
+            ( nurl_print `result: ` )
+            ( nurl_print_int ( json_as_int rj ) )
+        }
+        F → {}
+    }
+    ( nurl_print `\n` )
+    ( json_free env )
+
+    // ── 2. Miss: unknown fn → ok:false, error ────────────────────
+    : Json req2 ( json_obj_new )
+    ( json_obj_set req2 `fn` ( json_str_lit `nope` ) )
+    ( json_obj_set req2 `args` ( json_null ) )
+    : Json env2 ( rpc_dispatch reg req2 )
+    ( json_free req2 )
+
+    ( nurl_print `miss ok: ` )
+    ( print_ok env2 )
+    ( nurl_print `\n` )
+    : ?Json errj ( json_obj_get env2 `error` )
+    ?? errj {
+        T ej → {
+            ( nurl_print `err: ` )
+            ( nurl_print ( json_as_str ej ) )
+        }
+        F → {}
+    }
+    ( nurl_print `\n` )
+    ( json_free env2 )
+
+    // ── 3. cluster_err_name renders every variant ────────────────
+    ( nurl_print_str ( cluster_err_name # ClusterErr ClNet ) )
+    ( nurl_print_str ( cluster_err_name # ClusterErr ClTimeout ) )
+    ( nurl_print_str ( cluster_err_name # ClusterErr ClNoSuchFn ) )
+    ( nurl_print_str ( cluster_err_name # ClusterErr ClBadResp ) )
+    ( nurl_print_str ( cluster_err_name # ClusterErr ClRemote ) )
+    ( nurl_print_str ( cluster_err_name # ClusterErr ClSerialize ) )
+
+    ( registry_free reg )
+    ^ 0
+}

--- a/compiler/tests/outputs/cluster_rpc.txt
+++ b/compiler/tests/outputs/cluster_rpc.txt
@@ -1,0 +1,17 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+count: 1
+
+ok: true
+result: 49
+
+miss ok: false
+err: no such fn
+ClNet
+ClTimeout
+ClNoSuchFn
+ClBadResp
+ClRemote
+ClSerialize

--- a/examples/cluster_rpc.nu
+++ b/examples/cluster_rpc.nu
@@ -1,0 +1,166 @@
+// examples/cluster_rpc.nu — distributed fan-out / fan-in over the
+// stdlib/ext/cluster.nu RPC primitive (Phase 1 MVP of the distributed-
+// computing track). Demonstrates the "agentic NURL" shape: scatter a
+// batch of tasks across a cluster of worker nodes, gather the results.
+//
+// This demo distributes a trivial compute (square a number) so it needs
+// no API keys and runs anywhere. To turn it into the LLM fan-out demo,
+// swap the `square` handler body for a call into `stdlib/ext/anthropic.nu`
+// (`claude_messages …`) — the cluster plumbing is identical.
+//
+// ── Run it (one machine, three terminals) ────────────────────────────
+//
+//   ./nurl.sh examples/cluster_rpc.nu server 9101
+//   ./nurl.sh examples/cluster_rpc.nu server 9102
+//   ./nurl.sh examples/cluster_rpc.nu client 9101 9102
+//
+// The client scatters squares of 1..10 across the worker ports it was
+// given (round-robin) and prints the gathered sum — 385.
+//
+// Worker semantics: at-least-once with retry (see call_remote). Bring a
+// worker down mid-run and the client's retries ride over a transient
+// blip; kill it for good and you get a ClNet on that task.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/int.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/cluster.nu`
+
+// ── Worker handler ───────────────────────────────────────────────────
+//
+// Receives a BORROWED args Json (a number), returns an OWNED Json with
+// its square. Replace this body with an LLM / DB / GPU call to make the
+// cluster do real work.
+@ h_square Json args → !Json ClusterErr {
+    : ?i ni ( json_num_as_i args )
+    ^ ?? ni {
+        T n → @ !Json ClusterErr { T ( json_int * n n ) }
+        F → @ !Json ClusterErr { F @ ClusterErr { ClSerialize } }
+    }
+}
+
+@ run_server i port → i {
+    : Registry reg ( registry_new )
+    ( registry_register reg `square`
+    \ Json a → !Json ClusterErr { ^ ( h_square a ) } )
+
+    : String banner ( string_from `worker listening on 127.0.0.1:` )
+    ( string_push_int banner port )
+    ( string_push_str banner ` (fn: square)\n` )
+    ( nurl_print ( string_data banner ) )
+    ( string_free banner )
+
+    : !v NetErr sr ( cluster_serve `127.0.0.1` port reg )
+    ?? sr {
+        T _ → {}
+        F e → {
+            ( nurl_print `serve error: ` )
+            ( nurl_print ( net_err_name e ) )
+            ( nurl_print `\n` )
+        }
+    }
+    ( registry_free reg )
+    ^ 0
+}
+
+// ── Client: scatter 1..10 across the peers, gather the sum ────────────
+@ run_client ( Vec i ) ports → i {
+    : i npeers ( vec_len [i] ports )
+    ? == npeers 0 {
+        ( nurl_print `client: no peer ports given\n` )
+        ^ 1
+    } {}
+
+    : ~ i sum 0
+    : ~ i ok 0
+    : ~ i task 1
+    ~ <= task 10 {
+        // round-robin task → peer
+        : i pidx % - task 1 npeers
+        : i port ?? ( vec_get [i] ports pidx ) { T p → p F → 0 }
+        : Node n ( node_new `127.0.0.1` port )
+
+        : !Json ClusterErr rr ( call_remote n `square` ( json_int task ) )
+        ?? rr {
+            T result → {
+                : i v ( json_as_int result )
+                ( json_free result )
+                = sum + sum v
+                = ok + ok 1
+                : String line ( string_from `  square(` )
+                ( string_push_int line task )
+                ( string_push_str line `) = ` )
+                ( string_push_int line v )
+                ( string_push_str line ` @ :` )
+                ( string_push_int line port )
+                ( string_push_char line 10 )
+                ( nurl_print ( string_data line ) )
+                ( string_free line )
+            }
+            F e → {
+                : ClusterErr ce # ClusterErr e
+                : String line ( string_from `  task ` )
+                ( string_push_int line task )
+                ( string_push_str line ` failed: ` )
+                ( string_push_str line ( cluster_err_name ce ) )
+                ( string_push_char line 10 )
+                ( nurl_print ( string_data line ) )
+                ( string_free line )
+            }
+        }
+        ( node_free n )
+        = task + task 1
+    }
+
+    : String summary ( string_from `gathered ` )
+    ( string_push_int summary ok )
+    ( string_push_str summary `/10 results; sum = ` )
+    ( string_push_int summary sum )
+    ( string_push_char summary 10 )
+    ( nurl_print ( string_data summary ) )
+    ( string_free summary )
+    ^ 0
+}
+
+@ usage → i {
+    ( nurl_print `usage:\n` )
+    ( nurl_print `  cluster_rpc server <port>\n` )
+    ( nurl_print `  cluster_rpc client <port> [port ...]\n` )
+    ^ 1
+}
+
+@ main → i {
+    : i argc ( env_args_count )
+    ? < argc 3 { ^ ( usage ) } {}
+
+    : String mode ( env_arg 1 )
+    : s m ( string_data mode )
+
+    : i rc ? != 0 ( nurl_str_eq m `server` ) {
+        : String ps ( env_arg 2 )
+        : i port ( nurl_str_to_int ( string_data ps ) )
+        ( string_free ps )
+        ( run_server port )
+    } {
+        ? != 0 ( nurl_str_eq m `client` ) {
+            : ( Vec i ) ports ( vec_new [i] )
+            : ~ i k 2
+            ~ < k argc {
+                : String ps ( env_arg k )
+                ( vec_push [i] ports ( nurl_str_to_int ( string_data ps ) ) )
+                ( string_free ps )
+                = k + k 1
+            }
+            : i r ( run_client ports )
+            ( vec_free [i] ports )
+            r
+        } {
+            ( usage )
+        }
+    }
+
+    ( string_free mode )
+    ^ rc
+}

--- a/stdlib/ext/cluster.nu
+++ b/stdlib/ext/cluster.nu
@@ -1,0 +1,413 @@
+// stdlib/ext/cluster.nu — minimal RPC for distributed NURL.
+//
+// **Phase 1 MVP** of the distributed-computing track (TODO §7.1). One
+// coordinator, NO consensus, NO discovery — the smallest thing that
+// proves the idea on top of machinery NURL already has (ext/http for the
+// transport, ext/json for serialization). Everything here is pure NURL.
+//
+// Design decisions (TODO §7.3), locked 2026-06-13:
+//
+//   * `call_remote` is a MOVE: the caller's local `args` value is
+//     CONSUMED — serialized onto the wire and freed. "Move to another
+//     address space." The result comes back as a fresh owned value.
+//   * Dispatch is a RUNTIME REGISTRY keyed by `fn_id` (no compile-time
+//     stub codegen), mirroring the ext/mcp dispatch-closure model.
+//
+// Wire protocol (JSON over HTTP/1.1 POST to `/__rpc`):
+//
+//   request   { "fn": "<name>", "args": <any json> }
+//   response  { "ok": true,  "result": <any json> }
+//          or { "ok": false, "error":  "<message>" }
+//
+// Delivery semantics: at-least-once. `call_remote` retries transient
+// transport failures (connect / dns / timeout / other) up to
+// `__cluster_max_attempts` times. Exactly-once and backoff are Phase 2.
+//
+// ── Server API ───────────────────────────────────────────────────────
+//
+//   ( registry_new )                                  → Registry
+//   ( registry_free Registry r )                      → v
+//   ( registry_register Registry r s name handler )   → v
+//        handler :: ( @ !Json ClusterErr Json )
+//        — receives a BORROWED args Json (do NOT free it), returns an
+//          OWNED Json on success or a ClusterErr on failure.
+//   ( registry_count Registry r )                     → i
+//   ( rpc_dispatch Registry r Json req )              → Json
+//        — pure: maps a request envelope to an owned response envelope.
+//          Network-free, so the whole dispatch path is unit-testable.
+//   ( registry_handler Registry r )                   → ( @ HttpResponse HttpRequest )
+//        — wraps the registry as an HTTP handler for http_server /
+//          http2_server. Captures the registry by reference.
+//   ( cluster_serve s host i port Registry r )        → !v NetErr
+//        — convenience: bind + async accept loop serving the registry.
+//
+// ── Client API ───────────────────────────────────────────────────────
+//
+//   ( node_new s host i port )                        → Node
+//   ( call_remote Node n s fn_id Json args )          → !Json ClusterErr
+//        — MOVE: consumes `args`. Ok arm is a fresh owned Json the
+//          caller frees with json_free.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/http.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_server.nu`
+
+// ── Errors ───────────────────────────────────────────────────────────
+
+: | ClusterErr {
+    ClNet         // transport connect / I/O failure
+    ClTimeout     // request budget exceeded
+    ClNoSuchFn    // remote has no handler registered under that fn_id
+    ClBadResp     // malformed / unexpected response envelope
+    ClRemote      // remote handler returned an error
+    ClSerialize   // local (de)serialization failure
+}
+
+@ cluster_err_name ClusterErr e → s {
+    ^ ?? e {
+        ClNet → `ClNet`
+        ClTimeout → `ClTimeout`
+        ClNoSuchFn → `ClNoSuchFn`
+        ClBadResp → `ClBadResp`
+        ClRemote → `ClRemote`
+        ClSerialize → `ClSerialize`
+    }
+}
+
+@ __cluster_map_http HttpErr e → ClusterErr {
+    ^ ?? e {
+        HttpTimeout → @ ClusterErr { ClTimeout }
+        HttpConnect → @ ClusterErr { ClNet }
+        HttpTls → @ ClusterErr { ClNet }
+        HttpDns → @ ClusterErr { ClNet }
+        HttpInvalidUrl → @ ClusterErr { ClNet }
+        HttpOther → @ ClusterErr { ClNet }
+    }
+}
+
+// ── Registry ─────────────────────────────────────────────────────────
+//
+// A registered handler lives in a heap RpcImpl so the Vec can hold a
+// stable cell; the public Registry just owns the Vec of pointer-wrappers
+// (same shape as http_router's Route → RouteImpl).
+
+: RpcImpl {
+    String name
+    ( @ !Json ClusterErr Json ) handler
+}
+
+: RpcEntry { s ctl }
+
+: Registry { ( Vec RpcEntry ) entries }
+
+@ registry_new → Registry {
+    ^ @ Registry { ( vec_new [RpcEntry] ) }
+}
+
+@ __rpc_entry_free RpcEntry e → v {
+    : *RpcImpl impl # *RpcImpl . e ctl
+    ( string_free . impl name )
+    // The closure value is a by-value { fn_ptr, env_ptr } pair; only the
+    // env is heap-allocated (NULL for capture-less lambdas) and closures
+    // have no auto-drop, so release it here (router/recover convention).
+    : ( @ !Json ClusterErr Json ) h . impl handler
+    ( nurl_free # s # *u h 1 )
+    ( nurl_free # s impl )
+}
+
+@ registry_free Registry r → v {
+    ( vec_free_with [RpcEntry] . r entries
+    \ RpcEntry e → v { ( __rpc_entry_free e ) } )
+}
+
+@ registry_register Registry r s name ( @ !Json ClusterErr Json ) handler → v {
+    : *RpcImpl impl # *RpcImpl ( nurl_alloc Z RpcImpl )
+    = . impl name ( string_from name )
+    = . impl handler handler
+    : RpcEntry e @ RpcEntry { # s impl }
+    ( vec_push [RpcEntry] . r entries e )
+}
+
+@ registry_count Registry r → i {
+    ^ ( vec_len [RpcEntry] . r entries )
+}
+
+// Linear scan for a handler by name → index, or -1 if absent.
+@ __registry_find Registry r s name → i {
+    : i n ( vec_len [RpcEntry] . r entries )
+    : ~ i found - 0 1
+    : ~ b done F
+    : ~ i k 0
+    ~ & ! done < k n {
+        : ?RpcEntry ek ( vec_get [RpcEntry] . r entries k )
+        ?? ek {
+            T e → {
+                : *RpcImpl impl # *RpcImpl . e ctl
+                ? != 0 ( nurl_str_eq ( string_data . impl name ) name ) {
+                    = found k
+                    = done T
+                } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ found
+}
+
+@ __registry_handler_at Registry r i idx → ( @ !Json ClusterErr Json ) {
+    // Unreachable fallback (callers gate on __registry_find ≥ 0); kept so
+    // the None arm typechecks without an `^` inside the match.
+    : ( @ !Json ClusterErr Json ) miss \ Json a → !Json ClusterErr {
+        ^ @ !Json ClusterErr { F @ ClusterErr { ClNoSuchFn } }
+    }
+    : ?RpcEntry ek ( vec_get [RpcEntry] . r entries idx )
+    ^ ?? ek {
+        T e → {
+            : *RpcImpl impl # *RpcImpl . e ctl
+            . impl handler
+        }
+        F → miss
+    }
+}
+
+// ── Envelope builders ────────────────────────────────────────────────
+
+@ __rpc_ok_env Json result → Json {
+    : Json env ( json_obj_new )
+    ( json_obj_set env `ok` ( json_bool T ) )
+    ( json_obj_set env `result` result )   // MOVES result into env
+    ^ env
+}
+
+@ __rpc_err_env s msg → Json {
+    : Json env ( json_obj_new )
+    ( json_obj_set env `ok` ( json_bool F ) )
+    ( json_obj_set env `error` ( json_str_lit msg ) )
+    ^ env
+}
+
+// Call a handler with a BORROWED args Json and wrap its outcome into an
+// owned response envelope.
+@ __rpc_invoke ( @ !Json ClusterErr Json ) h Json args → Json {
+    : !Json ClusterErr rr ( h args )
+    ^ ?? rr {
+        T result → ( __rpc_ok_env result )
+        F e → {
+            : ClusterErr ce # ClusterErr e
+            ( __rpc_err_env ( cluster_err_name ce ) )
+        }
+    }
+}
+
+// ── Dispatch (pure, network-free) ────────────────────────────────────
+
+@ rpc_dispatch Registry r Json req → Json {
+    : ?Json fnj ( json_obj_get req `fn` )      // borrow
+    ^ ?? fnj {
+        T fj → {
+            : s name ( json_as_str fj )
+            : i idx ( __registry_find r name )
+            ? < idx 0 {
+                ( __rpc_err_env `no such fn` )
+            } {
+                : ( @ !Json ClusterErr Json ) h ( __registry_handler_at r idx )
+                : ?Json argsj ( json_obj_get req `args` )   // borrow
+                ?? argsj {
+                    T a → ( __rpc_invoke h a )
+                    F → {
+                        : Json a ( json_null )
+                        : Json env ( __rpc_invoke h a )
+                        ( json_free a )
+                        env
+                    }
+                }
+            }
+        }
+        F → ( __rpc_err_env `missing fn field` )
+    }
+}
+
+// ── HTTP glue ────────────────────────────────────────────────────────
+
+@ registry_handler Registry r → ( @ HttpResponse HttpRequest ) {
+    ^ \ HttpRequest req → HttpResponse {
+        : String bs ( bytes_to_str . req body )
+        : !Json JsonError pr ( json_parse ( string_data bs ) )
+        : HttpResponse resp ?? pr {
+            T reqj → {
+                : Json env ( rpc_dispatch r reqj )
+                ( json_free reqj )
+                : HttpResponse rp ( response_json 200 env )
+                ( json_free env )
+                rp
+            }
+            F _ → {
+                : Json env ( __rpc_err_env `bad request json` )
+                : HttpResponse rp ( response_json 400 env )
+                ( json_free env )
+                rp
+            }
+        }
+        ( string_free bs )
+        ^ resp
+    }
+}
+
+@ __cluster_accept_loop TcpListener listener Registry r → v {
+    : ( @ HttpResponse HttpRequest ) h ( registry_handler r )
+    : HttpServer srv ( server_new listener h )
+    : !v NetErr rr ( server_run srv )
+    ?? rr { T _ → {} F _ → {} }
+}
+
+@ cluster_serve s host i port Registry r → !v NetErr {
+    : !TcpListener NetErr lr ( tcp_listen host port )
+    ^ ?? lr {
+        T listener → {
+            ( __cluster_accept_loop listener r )
+            ( tcp_close_listener listener )
+            @ !v NetErr { T 0 }
+        }
+        F e → @ !v NetErr { F # NetErr e }
+    }
+}
+
+// ── Client ───────────────────────────────────────────────────────────
+
+: Node {
+    String host
+    i port
+}
+
+@ node_new s host i port → Node {
+    ^ @ Node { ( string_from host ) port }
+}
+
+@ node_free Node n → v {
+    ( string_free . n host )
+}
+
+// Per-call total / connect budgets (ms) and retry cap.
+@ __cluster_timeout_ms → i { ^ 30000 }
+@ __cluster_connect_ms → i { ^ 5000 }
+@ __cluster_max_attempts → i { ^ 3 }
+
+@ __node_url Node n → String {
+    : String u ( string_from `http://` )
+    ( string_push_str u ( string_data . n host ) )
+    ( string_push_char u 58 )              // ':'
+    ( string_push_int u . n port )
+    ( string_push_str u `/__rpc` )
+    ^ u
+}
+
+// Pull a fresh owned `result` Json out of a borrowed response envelope
+// by round-tripping through text (no detach primitive on Json yet).
+@ __rpc_extract_result Json env → !Json ClusterErr {
+    : ?Json okj ( json_obj_get env `ok` )      // borrow
+    : b ok ?? okj { T b → ( json_bool_val b ) F → F }
+    ? ! ok {
+        ^ @ !Json ClusterErr { F @ ClusterErr { ClRemote } }
+    } {}
+    : ?Json resj ( json_obj_get env `result` )  // borrow
+    ^ ?? resj {
+        T rb → {
+            : String rs ( json_stringify rb )
+            : !Json JsonError rp ( json_parse ( string_data rs ) )
+            ( string_free rs )
+            ?? rp {
+                T owned → @ !Json ClusterErr { T owned }
+                F _ → @ !Json ClusterErr { F @ ClusterErr { ClBadResp } }
+            }
+        }
+        F → @ !Json ClusterErr { F @ ClusterErr { ClBadResp } }
+    }
+}
+
+// One transport attempt. `body` is BORROWED (reused across retries).
+@ __rpc_attempt s url s body → !Json ClusterErr {
+    : !Response HttpErr rr ( http_request_to `POST` url body
+    `Content-Type: application/json\r\n`
+    ( __cluster_timeout_ms ) ( __cluster_connect_ms ) )
+    ^ ?? rr {
+        T resp → {
+            : i st ( http_status resp )
+            ? != st 200 {
+                ( response_free resp )
+                @ !Json ClusterErr { F @ ClusterErr { ClBadResp } }
+            } {
+                : !Json JsonError pr ( json_parse ( http_body_str resp ) )
+                : !Json ClusterErr out ?? pr {
+                    T env → {
+                        : !Json ClusterErr r2 ( __rpc_extract_result env )
+                        ( json_free env )
+                        r2
+                    }
+                    F _ → @ !Json ClusterErr { F @ ClusterErr { ClBadResp } }
+                }
+                ( response_free resp )
+                out
+            }
+        }
+        F e → {
+            // Map to a ClusterErr; call_remote's loop decides whether to
+            // retry (ClNet / ClTimeout) or give up (others).
+            : HttpErr he # HttpErr e
+            @ !Json ClusterErr { F ( __cluster_map_http he ) }
+        }
+    }
+}
+
+@ call_remote Node n s fn_id Json args → !Json ClusterErr {
+    // Build + serialize the request envelope; this MOVES `args` (it is
+    // consumed into `req`, then `req` is freed once on the wire).
+    : Json req ( json_obj_new )
+    ( json_obj_set req `fn` ( json_str_lit fn_id ) )
+    ( json_obj_set req `args` args )
+    : String body ( json_stringify req )
+    ( json_free req )
+
+    : String url ( __node_url n )
+
+    // at-least-once: retry transient failures up to the attempt cap.
+    : i max ( __cluster_max_attempts )
+    : ~ i k 0
+    : ~ b done F
+    : ~ ClusterErr last @ ClusterErr { ClNet }
+    : ~ Json result ( json_null )
+    : ~ b have_result F
+    ~ & ! done < k max {
+        : !Json ClusterErr ar ( __rpc_attempt ( string_data url ) ( string_data body ) )
+        ?? ar {
+            T r → {
+                = result r
+                = have_result T
+                = done T
+            }
+            F e → {
+                : ClusterErr ce # ClusterErr e
+                = last ce
+                // Only ClNet / ClTimeout are worth another attempt;
+                // ClBadResp / ClRemote are terminal.
+                : b retry ?? ce { ClNet → T ClTimeout → T _ → F }
+                ? ! retry { = done T } {}
+            }
+        }
+        = k + k 1
+    }
+
+    ( string_free url )
+    ( string_free body )
+
+    ? have_result {
+        ^ @ !Json ClusterErr { T result }
+    } {}
+    ^ @ !Json ClusterErr { F last }
+}

--- a/stdlib/ext/env.nu
+++ b/stdlib/ext/env.nu
@@ -48,8 +48,11 @@ $ `stdlib/core/posix.nu`  // posix_const + nurl_errno_get
 }
 
 @ env_arg i idx → String {
+    // nurl_argv_get returns a strdup'd heap copy the caller OWNS;
+    // string_from copies the bytes, so free the raw cstr afterwards.
     : s raw ( nurl_argv_get idx )
     : String out ( string_from raw )
+    ( nurl_free raw )
     ^ out
 }
 
@@ -60,6 +63,7 @@ $ `stdlib/core/posix.nu`  // posix_const + nurl_errno_get
     ~ < i n {
         : s raw ( nurl_argv_get i )
         ( vec_push [String] out ( string_from raw ) )
+        ( nurl_free raw )
         = i + i 1
     }
     ^ out


### PR DESCRIPTION
## Summary

First slice of the **distributed-computing track** (TODO §7.1 Phase 1 MVP): a minimal RPC primitive built entirely on machinery already in the tree (`ext/json`, `ext/http`, `http_server`). One coordinator, no consensus, no discovery — the smallest thing that proves the idea.

### `stdlib/ext/cluster.nu` (pure NURL)
- **Client:** `call_remote(Node, fn_id, Json args) → !Json ClusterErr` — **MOVE** semantics (args consumed onto the wire, result returns fresh-owned); at-least-once with per-call timeout + retry (ClNet/ClTimeout, max 3).
- **Server:** `Registry` / `registry_register` / `rpc_dispatch` (pure, network-free → unit-testable) / `registry_handler` / `cluster_serve`.
- **Wire:** serde-JSON over HTTP/1.1 POST `/__rpc`; `{fn,args}` → `{ok,result}` | `{ok,error}`.

### Design decisions locked (TODO §7.3, 2 of 4)
- **MOVE** at the RPC boundary — caller's local value is consumed; server handler borrows the deserialized args, returns an owned result.
- **Runtime registry** dispatch (`ext/mcp` model), not compile-time stub codegen.

### Examples / tests
- `examples/cluster_rpc.nu` — fan-out/fan-in across worker processes (`server`/`client` modes); documents the `ext/anthropic` swap for the LLM fan-out demo.
- `compiler/tests/cluster_rpc.nu` (+ golden) — offline dispatch test (no sockets), ASan-clean.

### Root-cause fix found en route
`env_arg`/`env_args_list` never freed `nurl_argv_get`'s strdup'd (caller-owned) copy — this PR is the first ASan argv consumer to surface it. Fixed in `stdlib/ext/env.nu` (precedent: `core/io.nu:104`).

## Verification
- ✅ **358/358** compiler suite green
- ✅ Live loopback: 2 worker processes, round-robin fan-out, sum = 385; dead-peer case retries → `ClNet`, others succeed
- ✅ ASan-clean on dispatch + client transport paths

## Follow-ups (not in this PR)
Phase 2 MLP — distributed `Channel[A]`, SWIM membership, msgpack wire, backpressure; §7.3 wire-versioning policy. h2 multiplexing is the Phase 2 transport perf lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)