### PR TITLE
feat(cluster): resilience layer — backoff + circuit breaker (TODO §7.2)

### DIFF
--- a/compiler/tests/cluster_resilience.nu
+++ b/compiler/tests/cluster_resilience.nu
@@ -1,0 +1,56 @@
+// cluster_resilience.nu — offline tests for the resilience layer of
+// stdlib/ext/cluster.nu (RetryPolicy backoff + CircuitBreaker).
+//
+// No network, no real sleeping: exercises the pure backoff math and the
+// breaker state machine directly. Timing-deterministic (long cooldown
+// never elapses within a test; cooldown=0 is the half-open boundary).
+//
+// Exercises:
+//   * retry_backoff_ms — geometric growth capped at max_delay_ms
+//   * circuit breaker — threshold open, success reset, half-open probe
+//   * cluster_err_name / cluster_err_retryable for ClCircuitOpen
+
+$ `stdlib/ext/cluster.nu`
+
+@ pb b v → v { ( nurl_print ? v `true\n` `false\n` ) }
+
+@ main → i {
+    // ── Backoff: base 100ms, ×2, capped 1000ms ───────────────────
+    : RetryPolicy p ( retry_new 5 100 1000 200 F )
+    ( nurl_print `backoff:\n` )
+    : ~ i k 0
+    ~ < k 5 {
+        ( nurl_print_int ( retry_backoff_ms p k ) )
+        = k + k 1
+    }
+    // expect 100, 200, 400, 800, 1000 (1600 capped)
+
+    // ── Circuit breaker: threshold 2, long cooldown ──────────────
+    : CircuitBreaker cb ( cb_new 2 100000 )
+    ( nurl_print `allow fresh: ` )     ( pb ( cb_allow cb ) )      // true
+    ( cb_record_failure cb )
+    ( nurl_print `open after 1: ` )    ( pb ( cb_is_open cb ) )    // false
+    ( cb_record_failure cb )
+    ( nurl_print `open after 2: ` )    ( pb ( cb_is_open cb ) )    // true
+    ( nurl_print `allow open: ` )      ( pb ( cb_allow cb ) )      // false (cooldown)
+    ( nurl_print `fails: ` )           ( nurl_print_int ( cb_fails cb ) )  // 2
+    ( cb_record_success cb )
+    ( nurl_print `allow recovered: ` ) ( pb ( cb_allow cb ) )      // true
+    ( nurl_print `open recovered: ` )  ( pb ( cb_is_open cb ) )    // false
+    ( cb_free cb )
+
+    // ── Half-open: cooldown 0 → immediate probe allowed ──────────
+    : CircuitBreaker cb2 ( cb_new 1 0 )
+    ( cb_record_failure cb2 )
+    ( nurl_print `cb2 open: ` )         ( pb ( cb_is_open cb2 ) )   // true
+    ( nurl_print `cb2 halfopen allow: ` ) ( pb ( cb_allow cb2 ) )   // true
+    ( cb_free cb2 )
+
+    // ── Error classification ─────────────────────────────────────
+    ( nurl_print_str ( cluster_err_name # ClusterErr ClCircuitOpen ) )
+    ( nurl_print `net retryable: ` )     ( pb ( cluster_err_retryable # ClusterErr ClNet ) )         // true
+    ( nurl_print `badresp retryable: ` ) ( pb ( cluster_err_retryable # ClusterErr ClBadResp ) )     // false
+    ( nurl_print `circuit retryable: ` ) ( pb ( cluster_err_retryable # ClusterErr ClCircuitOpen ) ) // false
+
+    ^ 0
+}

--- a/compiler/tests/outputs/cluster_resilience.txt
+++ b/compiler/tests/outputs/cluster_resilience.txt
@@ -1,0 +1,23 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+backoff:
+100
+200
+400
+800
+1000
+allow fresh: true
+open after 1: false
+open after 2: true
+allow open: false
+fails: 2
+allow recovered: true
+open recovered: false
+cb2 open: true
+cb2 halfopen allow: true
+ClCircuitOpen
+net retryable: true
+badresp retryable: false
+circuit retryable: false

--- a/examples/cluster_rpc.nu
+++ b/examples/cluster_rpc.nu
@@ -66,12 +66,26 @@ $ `stdlib/ext/cluster.nu`
 }
 
 // ── Client: scatter 1..10 across the peers, gather the sum ────────────
+//
+// Each peer gets its own CircuitBreaker (open after 2 consecutive
+// failures, 2s cooldown). A dead peer trips its breaker after two slow
+// retried failures; every later task routed to it then fails FAST with
+// ClCircuitOpen instead of burning the full retry+backoff budget.
 @ run_client ( Vec i ) ports → i {
     : i npeers ( vec_len [i] ports )
     ? == npeers 0 {
         ( nurl_print `client: no peer ports given\n` )
         ^ 1
     } {}
+
+    // One breaker per peer.
+    : ( Vec CircuitBreaker ) breakers ( vec_new [CircuitBreaker] )
+    : ~ i bi 0
+    ~ < bi npeers {
+        ( vec_push [CircuitBreaker] breakers ( cb_new 2 2000 ) )
+        = bi + bi 1
+    }
+    : RetryPolicy pol ( retry_default )
 
     : ~ i sum 0
     : ~ i ok 0
@@ -80,9 +94,11 @@ $ `stdlib/ext/cluster.nu`
         // round-robin task → peer
         : i pidx % - task 1 npeers
         : i port ?? ( vec_get [i] ports pidx ) { T p → p F → 0 }
+        : CircuitBreaker cb ?? ( vec_get [CircuitBreaker] breakers pidx )
+        { T c → c F → ( cb_new 1 0 ) }
         : Node n ( node_new `127.0.0.1` port )
 
-        : !Json ClusterErr rr ( call_remote n `square` ( json_int task ) )
+        : !Json ClusterErr rr ( call_remote_cb n `square` ( json_int task ) pol cb )
         ?? rr {
             T result → {
                 : i v ( json_as_int result )
@@ -121,6 +137,9 @@ $ `stdlib/ext/cluster.nu`
     ( string_push_char summary 10 )
     ( nurl_print ( string_data summary ) )
     ( string_free summary )
+
+    ( vec_free_with [CircuitBreaker] breakers
+    \ CircuitBreaker c → v { ( cb_free c ) } )
     ^ 0
 }
 

--- a/stdlib/ext/cluster.nu
+++ b/stdlib/ext/cluster.nu
@@ -46,12 +46,30 @@
 //   ( node_new s host i port )                        → Node
 //   ( call_remote Node n s fn_id Json args )          → !Json ClusterErr
 //        — MOVE: consumes `args`. Ok arm is a fresh owned Json the
-//          caller frees with json_free.
+//          caller frees with json_free. Uses retry_default.
+//   ( call_remote_with Node n s fn_id Json args RetryPolicy pol )
+//                                                      → !Json ClusterErr
+//        — as above with an explicit backoff/retry policy.
+//   ( call_remote_cb … RetryPolicy pol CircuitBreaker cb )
+//                                                      → !Json ClusterErr
+//        — guarded by a breaker; ClCircuitOpen when open (args still
+//          consumed). Records success/failure on the breaker.
+//
+// ── Resilience API ───────────────────────────────────────────────────
+//
+//   ( retry_default ) / ( retry_none )                → RetryPolicy
+//   ( retry_new max base_ms max_ms mult_pct jitter )  → RetryPolicy
+//   ( retry_backoff_ms RetryPolicy pol i attempt )    → i  (no jitter)
+//   ( cb_new i threshold i cooldown_ms )              → CircuitBreaker
+//   ( cb_free / cb_allow / cb_record_success /
+//     cb_record_failure / cb_is_open / cb_fails )
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/net.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/rng.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
@@ -67,6 +85,7 @@ $ `stdlib/ext/http_server.nu`
     ClBadResp     // malformed / unexpected response envelope
     ClRemote      // remote handler returned an error
     ClSerialize   // local (de)serialization failure
+    ClCircuitOpen // breaker open — call short-circuited, never sent
 }
 
 @ cluster_err_name ClusterErr e → s {
@@ -77,6 +96,18 @@ $ `stdlib/ext/http_server.nu`
         ClBadResp → `ClBadResp`
         ClRemote → `ClRemote`
         ClSerialize → `ClSerialize`
+        ClCircuitOpen → `ClCircuitOpen`
+    }
+}
+
+// Which ClusterErrs are worth another attempt — transport failures only.
+// ClBadResp / ClRemote / ClNoSuchFn / ClSerialize are deterministic and
+// retrying them just wastes round-trips.
+@ cluster_err_retryable ClusterErr e → b {
+    ^ ?? e {
+        ClNet → T
+        ClTimeout → T
+        _ → F
     }
 }
 
@@ -279,6 +310,124 @@ $ `stdlib/ext/http_server.nu`
     }
 }
 
+// ── Retry policy (exponential backoff + jitter) ──────────────────────
+//
+// Controls call_remote_with's retry loop. Delays grow geometrically:
+// base · (multiplier_pct/100)^k, capped at max_delay_ms. `jitter` adds
+// full-jitter (uniform [0, delay]) to spread thundering-herd retries.
+// Only transport errors (cluster_err_retryable) are retried.
+
+: RetryPolicy {
+    i max_attempts     // total tries incl. the first (clamped ≥ 1)
+    i base_delay_ms    // delay before the 1st retry
+    i max_delay_ms     // cap on any single backoff
+    i multiplier_pct   // geometric growth per retry, percent (200 = ×2)
+    b jitter           // full-jitter the slept delay
+}
+
+@ retry_new i max_attempts i base_delay_ms i max_delay_ms i multiplier_pct b jitter → RetryPolicy {
+    ^ @ RetryPolicy { max_attempts base_delay_ms max_delay_ms multiplier_pct jitter }
+}
+
+// Sensible default: 3 tries, 100ms → 200ms backoff, capped 5s, jittered.
+@ retry_default → RetryPolicy {
+    ^ @ RetryPolicy { 3 100 5000 200 T }
+}
+
+// A single attempt, no backoff — for callers that want fail-fast.
+@ retry_none → RetryPolicy {
+    ^ @ RetryPolicy { 1 0 0 200 F }
+}
+
+@ __grow_delay i d RetryPolicy pol → i {
+    : i nd / * d . pol multiplier_pct 100
+    ? > nd . pol max_delay_ms { ^ . pol max_delay_ms } {}
+    ^ nd
+}
+
+// Deterministic backoff (no jitter) for the delay BEFORE retry `attempt`
+// (0-based). Exposed so callers/tests can reason about timing.
+@ retry_backoff_ms RetryPolicy pol i attempt → i {
+    : ~ i d . pol base_delay_ms
+    : ~ i k 0
+    ~ < k attempt {
+        = d ( __grow_delay d pol )
+        = k + k 1
+    }
+    ^ d
+}
+
+@ __jitter i delay → i {
+    ? <= delay 0 { ^ 0 } {}
+    : Rng g ( rng_seed ( monotonic_ns ) )
+    : i j ( rng_below g + delay 1 )
+    ( rng_free g )
+    ^ j
+}
+
+// ── Circuit breaker ──────────────────────────────────────────────────
+//
+// Per-endpoint failure gate. After `threshold` consecutive failures the
+// breaker OPENS and cb_allow returns F (fail fast) until `cooldown_ms`
+// elapses, after which it goes HALF-OPEN (one probe allowed). A probe
+// success closes it; a probe failure re-opens it. State lives in a heap
+// cell so every holder of the CircuitBreaker shares one counter.
+
+: CbImpl {
+    i threshold
+    i cooldown_ms
+    i fails
+    i opened_at_ns    // -1 when closed
+}
+
+: CircuitBreaker { s ctl }
+
+@ cb_new i threshold i cooldown_ms → CircuitBreaker {
+    : *CbImpl impl # *CbImpl ( nurl_alloc Z CbImpl )
+    = . impl threshold threshold
+    = . impl cooldown_ms cooldown_ms
+    = . impl fails 0
+    = . impl opened_at_ns - 0 1
+    ^ @ CircuitBreaker { # s impl }
+}
+
+@ cb_free CircuitBreaker cb → v {
+    ( nurl_free . cb ctl )
+}
+
+// True if a call may proceed: closed, or open-but-cooled-down (half-open).
+@ cb_allow CircuitBreaker cb → b {
+    : *CbImpl impl # *CbImpl . cb ctl
+    ? < . impl opened_at_ns 0 { ^ T } {}
+    : i elapsed_ms / - ( monotonic_ns ) . impl opened_at_ns 1000000
+    ^ >= elapsed_ms . impl cooldown_ms
+}
+
+@ cb_record_success CircuitBreaker cb → v {
+    : *CbImpl impl # *CbImpl . cb ctl
+    = . impl fails 0
+    = . impl opened_at_ns - 0 1
+}
+
+@ cb_record_failure CircuitBreaker cb → v {
+    : *CbImpl impl # *CbImpl . cb ctl
+    = . impl fails + . impl fails 1
+    ? >= . impl fails . impl threshold {
+        = . impl opened_at_ns ( monotonic_ns )
+    } {}
+}
+
+// Introspection (tests / metrics): consecutive failure count + open flag.
+@ cb_fails CircuitBreaker cb → i {
+    : *CbImpl impl # *CbImpl . cb ctl
+    ^ . impl fails
+}
+
+@ cb_is_open CircuitBreaker cb → b {
+    : *CbImpl impl # *CbImpl . cb ctl
+    ^ >= . impl opened_at_ns 0
+}
+
 // ── Client ───────────────────────────────────────────────────────────
 
 : Node {
@@ -294,10 +443,10 @@ $ `stdlib/ext/http_server.nu`
     ( string_free . n host )
 }
 
-// Per-call total / connect budgets (ms) and retry cap.
+// Per-call total / connect budgets (ms). Retry cadence is the caller's
+// RetryPolicy (see call_remote_with / retry_default).
 @ __cluster_timeout_ms → i { ^ 30000 }
 @ __cluster_connect_ms → i { ^ 5000 }
-@ __cluster_max_attempts → i { ^ 3 }
 
 @ __node_url Node n → String {
     : String u ( string_from `http://` )
@@ -365,7 +514,10 @@ $ `stdlib/ext/http_server.nu`
     }
 }
 
-@ call_remote Node n s fn_id Json args → !Json ClusterErr {
+// Full RPC with an explicit RetryPolicy. MOVES `args`. Retries transient
+// transport errors (cluster_err_retryable) with exponential backoff +
+// optional jitter between attempts; terminal errors stop immediately.
+@ call_remote_with Node n s fn_id Json args RetryPolicy pol → !Json ClusterErr {
     // Build + serialize the request envelope; this MOVES `args` (it is
     // consumed into `req`, then `req` is freed once on the wire).
     : Json req ( json_obj_new )
@@ -376,13 +528,13 @@ $ `stdlib/ext/http_server.nu`
 
     : String url ( __node_url n )
 
-    // at-least-once: retry transient failures up to the attempt cap.
-    : i max ( __cluster_max_attempts )
+    : i max ? > . pol max_attempts 1 . pol max_attempts 1
     : ~ i k 0
     : ~ b done F
     : ~ ClusterErr last @ ClusterErr { ClNet }
     : ~ Json result ( json_null )
     : ~ b have_result F
+    : ~ i delay . pol base_delay_ms
     ~ & ! done < k max {
         : !Json ClusterErr ar ( __rpc_attempt ( string_data url ) ( string_data body ) )
         ?? ar {
@@ -394,10 +546,16 @@ $ `stdlib/ext/http_server.nu`
             F e → {
                 : ClusterErr ce # ClusterErr e
                 = last ce
-                // Only ClNet / ClTimeout are worth another attempt;
-                // ClBadResp / ClRemote are terminal.
-                : b retry ?? ce { ClNet → T ClTimeout → T _ → F }
-                ? ! retry { = done T } {}
+                ? ! ( cluster_err_retryable ce ) {
+                    = done T
+                } {
+                    // Backoff before the next attempt (if any remain).
+                    ? < + k 1 max {
+                        : i d ? . pol jitter ( __jitter delay ) delay
+                        ( sleep_ms d )
+                        = delay ( __grow_delay delay pol )
+                    } {}
+                }
             }
         }
         = k + k 1
@@ -410,4 +568,31 @@ $ `stdlib/ext/http_server.nu`
         ^ @ !Json ClusterErr { T result }
     } {}
     ^ @ !Json ClusterErr { F last }
+}
+
+// Convenience: call_remote_with the default retry policy. MOVES `args`.
+@ call_remote Node n s fn_id Json args → !Json ClusterErr {
+    ^ ( call_remote_with n fn_id args ( retry_default ) )
+}
+
+// call_remote_with guarded by a CircuitBreaker. When the breaker is open
+// (and not yet cooled down) the call short-circuits with ClCircuitOpen —
+// but still CONSUMES `args` to honour the move contract. Otherwise the
+// breaker records the outcome (success closes it, failure trips it).
+@ call_remote_cb Node n s fn_id Json args RetryPolicy pol CircuitBreaker cb → !Json ClusterErr {
+    ? ! ( cb_allow cb ) {
+        ( json_free args )
+        ^ @ !Json ClusterErr { F @ ClusterErr { ClCircuitOpen } }
+    } {}
+    : !Json ClusterErr r ( call_remote_with n fn_id args pol )
+    ?? r {
+        T result → {
+            ( cb_record_success cb )
+            ^ @ !Json ClusterErr { T result }
+        }
+        F e → {
+            ( cb_record_failure cb )
+            ^ @ !Json ClusterErr { F # ClusterErr e }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Hardens the Phase 1 RPC MVP (#129) with configurable retry and a per-endpoint circuit breaker. Builds on the distributed-computing track; all pure NURL.

### `stdlib/ext/cluster.nu`
- **`RetryPolicy`** — exponential backoff (geometric, capped) + full-jitter. `retry_default` (3 tries, 100ms → ×2, cap 5s, jittered), `retry_none` (fail-fast), `retry_new(...)`, and `retry_backoff_ms(pol, attempt)` for the deterministic (no-jitter) delay schedule.
- **`CircuitBreaker`** — opens after `threshold` consecutive failures, fails fast until `cooldown_ms` elapses, then half-open (one probe; success closes, failure re-opens). State lives in a heap cell so every holder shares one counter. `cb_new`/`cb_free`/`cb_allow`/`cb_record_success`/`cb_record_failure`/`cb_is_open`/`cb_fails`.
- **`call_remote_with(pol)`** — retry loop with backoff; only transport errors (`cluster_err_retryable`) are retried. `call_remote` now delegates to it with `retry_default` (back-compat). **`call_remote_cb(pol, cb)`** guards the call; returns `ClCircuitOpen` when open (args still consumed — move contract).
- New `ClusterErr::ClCircuitOpen`.

### Example
`examples/cluster_rpc.nu` — client now keeps a `CircuitBreaker` per peer; a dead peer trips after 2 failures and later tasks to it fail fast.

### Tests
`compiler/tests/cluster_resilience.nu` (+ golden) — deterministic offline tests for the backoff math and the breaker state machine (long cooldown = stays open; cooldown 0 = half-open boundary). No network, no real sleeps.

## Verification
- ✅ **359/359** suite green
- ✅ Live demo: one peer up (:9301), one dead (:9302) → dead peer fails `ClNet` ×2, trips breaker, then tasks 6/8/10 fail fast with `ClCircuitOpen`; whole run 0.33s
- ✅ ASan-clean (breaker heap alloc/free + resilience path)

## Follow-ups
Full fiber/actor **supervision** (restart) + stack-wide rollout remain open under §7.2. Other §7.2 levers untouched: distributed `Channel[A]`, SWIM membership, msgpack wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)