### PR TITLE
feat(dchannel): distributed Channel[A] — location transparency over RPC (TODO §7.2)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -11044,18 +11044,55 @@
     result
 }
 
+// __tok_src_text: faithful SOURCE text of the current token, for
+// reconstructing a generic template that will be re-lexed at each
+// instantiation. `nurl_lex_val` strips a string literal's surrounding
+// backticks AND decodes its escapes, so a naive reconstruction turns
+// `` `ok` `` into the bare identifier `ok` (which then fails to resolve in
+// the monomorphised body). Re-wrap TT_STR in backticks and re-introduce
+// the four escapes the lexer recognises (\n \t \r \\). A literal backtick
+// cannot occur in the decoded content — it terminates the string — so it
+// needs no escaping. Every other token type re-lexes verbatim from its val.
+@ __tok_src_text i lex → s {
+    : i tt ( nurl_lex_type lex )
+    : s val ( nurl_lex_val lex )
+    ? != tt TT_STR { ^ val } {}
+    : i n ( nurl_str_len val )
+    // Worst case: every byte escapes to two, plus two backticks + NUL.
+    : s buf # s ( malloc + + * n 2 2 1 )
+    : *u bp # *u buf
+    : *u vp # *u val
+    : ~ i blen 0
+    = . bp blen # u 96  = blen + blen 1          // opening `
+    : ~ i k 0
+    ~ < k n {
+        : i ch # i . vp k
+        ? == ch 10 { = . bp blen # u 92 = blen + blen 1 = . bp blen # u 110 = blen + blen 1 } {
+        ? == ch 9  { = . bp blen # u 92 = blen + blen 1 = . bp blen # u 116 = blen + blen 1 } {
+        ? == ch 13 { = . bp blen # u 92 = blen + blen 1 = . bp blen # u 114 = blen + blen 1 } {
+        ? == ch 92 { = . bp blen # u 92 = blen + blen 1 = . bp blen # u 92  = blen + blen 1 } {
+            = . bp blen # u ch = blen + blen 1
+        } } } }
+        = k + k 1
+    }
+    = . bp blen # u 96  = blen + blen 1          // closing `
+    = . bp blen # u 0
+    ^ buf
+}
+
 // collect_fn_body: collect tokens from current '{' through matching '}'.
-// Returns space-separated token text. String literals lack their backtick
-// delimiters and will not re-lex correctly; avoid them in generic bodies.
+// Returns space-separated, source-faithful token text (string literals
+// keep their backticks via __tok_src_text), so the result re-lexes to the
+// identical token stream — safe for generic template bodies.
 @ collect_fn_body i lex → s {
-    : ~ s result ( nurl_str_cat ( nurl_lex_val lex ) ` ` )
+    : ~ s result ( nurl_str_cat ( __tok_src_text lex ) ` ` )
     ( nurl_lex_advance lex )
     : ~ i depth 1
     ~ != depth 0 {
         : i tt2 ( nurl_lex_type lex )
         ? == tt2 TT_LBRACE { = depth + depth 1 } {}
         ? == tt2 TT_RBRACE { = depth - depth 1 } {}
-        = result ( nurl_str_cat result ( nurl_str_cat ( nurl_lex_val lex ) ` ` ) )
+        = result ( nurl_str_cat result ( nurl_str_cat ( __tok_src_text lex ) ` ` ) )
         ( nurl_lex_advance lex )
     }
     result
@@ -11171,7 +11208,7 @@
     // Collect params/return/body tokens until EOF
     : ~ s src ``
     ~ & != ( nurl_lex_type lex ) TT_LBRACE != ( nurl_lex_type lex ) TT_EOF {
-        = src ( nurl_str_cat src ( nurl_str_cat ( nurl_lex_val lex ) ` ` ) )
+        = src ( nurl_str_cat src ( nurl_str_cat ( __tok_src_text lex ) ` ` ) )
         ( nurl_lex_advance lex )
     }
     ? != ( nurl_lex_type lex ) TT_EOF

--- a/compiler/tests/dchannel.nu
+++ b/compiler/tests/dchannel.nu
@@ -1,0 +1,116 @@
+// dchannel.nu — offline tests for stdlib/ext/dchannel.nu.
+//
+// No sockets: drives the server-side channel store through rpc_dispatch
+// in-process (the same path the HTTP handler would take), so the full
+// send/recv/full/closed/len state machine is exercised deterministically.
+// The networked client path is covered by examples/dchannel.nu.
+//
+// Channel "q" has capacity 2:
+//   send 10 → ok, send 20 → ok, send 30 → full (cap reached)
+//   len → 2
+//   recv → 10, recv → 20, recv → empty (FIFO drained)
+//   close, then recv → closed, send → closed
+
+$ `stdlib/ext/dchannel.nu`
+
+// Dispatch one RPC against the registry; returns the owned response env.
+@ disp Registry r s fn Json args → Json {
+    : Json req ( json_obj_new )
+    ( json_obj_set req `fn` ( json_str_lit fn ) )
+    ( json_obj_set req `args` args )
+    : Json env ( rpc_dispatch r req )
+    ( json_free req )
+    ^ env
+}
+
+@ result_field_str Json env s key → s {
+    : ?Json rj ( json_obj_get env `result` )
+    ^ ?? rj {
+        T r → {
+            : ?Json fj ( json_obj_get r key )
+            ?? fj { T x → ( json_as_str x ) F → `` }
+        }
+        F → `?`
+    }
+}
+
+@ result_field_int Json env s key → i {
+    : ?Json rj ( json_obj_get env `result` )
+    ^ ?? rj {
+        T r → {
+            : ?Json fj ( json_obj_get r key )
+            ?? fj { T x → ( json_as_int x ) F → - 0 1 }
+        }
+        F → - 0 1
+    }
+}
+
+// Build {ch:"q", v:n}
+@ send_args i n → Json {
+    : Json a ( json_obj_new )
+    ( json_obj_set a `ch` ( json_str_lit `q` ) )
+    ( json_obj_set a `v` ( json_int n ) )
+    ^ a
+}
+
+@ name_args → Json {
+    : Json a ( json_obj_new )
+    ( json_obj_set a `ch` ( json_str_lit `q` ) )
+    ^ a
+}
+
+@ pstatus s label Json env → v {
+    ( nurl_print label )
+    ( nurl_print ( result_field_str env `status` ) )
+    ( nurl_print `\n` )
+}
+
+@ main → i {
+    : DStore store ( dstore_new 8 )
+    ( dstore_declare store `q` 2 )       // capacity 2
+    : Registry reg ( registry_new )
+    ( dchan_register store reg )
+
+    // ── fill to capacity ─────────────────────────────────────────
+    : Json e1 ( disp reg `dchan/send` ( send_args 10 ) )
+    ( pstatus `send 10: ` e1 ) ( json_free e1 )
+    : Json e2 ( disp reg `dchan/send` ( send_args 20 ) )
+    ( pstatus `send 20: ` e2 ) ( json_free e2 )
+    : Json e3 ( disp reg `dchan/send` ( send_args 30 ) )
+    ( pstatus `send 30: ` e3 ) ( json_free e3 )    // full
+
+    // ── depth ────────────────────────────────────────────────────
+    : Json el ( disp reg `dchan/len` ( name_args ) )
+    ( nurl_print `len: ` ) ( nurl_print_int ( result_field_int el `len` ) )
+    ( json_free el )
+
+    // ── drain (FIFO) ─────────────────────────────────────────────
+    : Json r1 ( disp reg `dchan/recv` ( name_args ) )
+    ( nurl_print `recv: ` ) ( nurl_print ( result_field_str r1 `status` ) )
+    ( nurl_print ` v=` ) ( nurl_print_int ( result_field_int r1 `v` ) )
+    ( json_free r1 )
+    : Json r2 ( disp reg `dchan/recv` ( name_args ) )
+    ( nurl_print `recv: ` ) ( nurl_print ( result_field_str r2 `status` ) )
+    ( nurl_print ` v=` ) ( nurl_print_int ( result_field_int r2 `v` ) )
+    ( json_free r2 )
+    : Json r3 ( disp reg `dchan/recv` ( name_args ) )
+    ( pstatus `recv: ` r3 ) ( json_free r3 )       // empty
+
+    // ── close + post-close behaviour ─────────────────────────────
+    : Json ec ( disp reg `dchan/close` ( name_args ) )
+    ( pstatus `close: ` ec ) ( json_free ec )
+    : Json r4 ( disp reg `dchan/recv` ( name_args ) )
+    ( pstatus `recv after close: ` r4 ) ( json_free r4 )   // closed
+    : Json e4 ( disp reg `dchan/send` ( send_args 40 ) )
+    ( pstatus `send after close: ` e4 ) ( json_free e4 )   // closed
+
+    // ── DSend variant names ──────────────────────────────────────
+    ( nurl_print_str ( dsend_name # DSend DSendOk ) )
+    ( nurl_print_str ( dsend_name # DSend DSendFull ) )
+    ( nurl_print_str ( dsend_name # DSend DSendClosed ) )
+    ( nurl_print_str ( dsend_name # DSend DSendErr ) )
+
+    ( registry_free reg )
+    ( dstore_free store )
+    ^ 0
+}

--- a/compiler/tests/generic_string_literal.nu
+++ b/compiler/tests/generic_string_literal.nu
@@ -1,0 +1,26 @@
+// generic_string_literal.nu — regression: string literals inside a
+// GENERIC function body must survive monomorphisation.
+//
+// A generic template is stored as reconstructed source text and re-lexed
+// at each instantiation. Before the fix, `nurl_lex_val` stripped a string
+// literal's backticks (and decoded its escapes), so `` `hit` `` came back
+// as the bare identifier `hit` — "use of undefined identifier 'hit'" at
+// the instantiation. __tok_src_text now re-wraps + re-escapes TT_STR.
+
+$ `stdlib/core/string.nu`
+
+// String literal in a generic body + an escape sequence to exercise the
+// re-escaping path (\n \t \\).
+@ classify [A] A x s label → s {
+    ^ ? != 0 ( nurl_str_eq label `hit` ) { `match` } { `no\tmatch\n` }
+}
+
+@ main → i {
+    ( nurl_print ( classify [i] 1 `hit` ) )
+    ( nurl_print `\n` )
+    ( nurl_print ( classify [i] 1 `nope` ) )
+    // Distinct instantiation (A = s) shares the same template source.
+    ( nurl_print ( classify [s] `q` `hit` ) )
+    ( nurl_print `\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs/dchannel.txt
+++ b/compiler/tests/outputs/dchannel.txt
@@ -1,0 +1,18 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+send 10: ok
+send 20: ok
+send 30: full
+len: 2
+recv: ok v=10
+recv: ok v=20
+recv: empty
+close: ok
+recv after close: closed
+send after close: closed
+DSendOk
+DSendFull
+DSendClosed
+DSendErr

--- a/compiler/tests/outputs/generic_string_literal.txt
+++ b/compiler/tests/outputs/generic_string_literal.txt
@@ -1,0 +1,7 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+match
+no	match
+match

--- a/examples/dchannel.nu
+++ b/examples/dchannel.nu
@@ -1,0 +1,149 @@
+// examples/dchannel.nu — distributed Channel[A] producer/consumer across
+// processes (TODO §7.2). The producer SENDS integers on a channel hosted
+// on another process; the consumer RECEIVES them and sums. The values
+// move out of the producer's address space and into the consumer's —
+// the same send/recv shape you'd write for a local std/channel.nu Channel.
+//
+// The hosted channel "nums" has capacity 4, so a producer that outruns a
+// slow consumer BLOCKS on send until space frees up (end-to-end
+// backpressure) — exactly like a bounded local channel.
+//
+// ── Run it (one machine, three terminals) ────────────────────────────
+//
+//   ./nurl.sh examples/dchannel.nu server  9400
+//   ./nurl.sh examples/dchannel.nu consume 9400
+//   ./nurl.sh examples/dchannel.nu produce 9400 10
+//
+// The producer sends 1..10 then closes; the consumer drains them, prints
+// each, and reports the sum (55). To make it a distributed channel of
+// your own type A, swap the three int codecs below for A↔Json closures.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/int.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/cluster.nu`
+$ `stdlib/ext/dchannel.nu`
+
+@ println s text → v { ( nurl_print text ) ( nurl_print `\n` ) }
+
+@ print_kv s label i n → v {
+    : String line ( string_from label )
+    ( string_push_int line n )
+    ( string_push_char line 10 )
+    ( nurl_print ( string_data line ) )
+    ( string_free line )
+}
+
+// Open the shared "nums" channel of i (int) with JSON int codecs.
+@ open_int_chan i port → ( DChannel i ) {
+    : Node node ( node_new `127.0.0.1` port )
+    ^ ( dchan_open [i] node `nums` ( retry_default ) 20
+        \ i x → Json { ^ ( json_int x ) }          // enc: i → Json
+        \ Json j → i { ^ ( json_as_int j ) }       // dec: Json → i
+        \ i x → v {} )                              // drop: scalar, no-op
+}
+
+// ── Server: host the bounded channel ─────────────────────────────────
+@ run_server i port → i {
+    : DStore store ( dstore_new 8 )
+    ( dstore_declare store `nums` 4 )       // capacity 4 → backpressure
+    : String banner ( string_from `dchannel server on 127.0.0.1:` )
+    ( string_push_int banner port )
+    ( string_push_str banner ` (channel "nums", cap 4)\n` )
+    ( nurl_print ( string_data banner ) )
+    ( string_free banner )
+
+    : !v NetErr sr ( dchan_serve `127.0.0.1` port store )
+    ?? sr {
+        T _ → {}
+        F e → ( println `serve error: ` )
+    }
+    ( dstore_free store )
+    ^ 0
+}
+
+// ── Producer: send 1..n, then close ──────────────────────────────────
+@ run_produce i port i n → i {
+    : ( DChannel i ) ch ( open_int_chan port )
+    : ~ i k 1
+    ~ <= k n {
+        : b okk ( dchan_send [i] ch k )
+        ? okk { ( print_kv `  sent ` k ) }
+        { ( print_kv `  send failed (closed) at ` k ) }
+        = k + k 1
+    }
+    ( dchan_close [i] ch )
+    ( println `producer done; channel closed` )
+    ( dchan_free [i] ch )
+    ^ 0
+}
+
+// ── Consumer: recv until the channel is closed AND drained ────────────
+@ run_consume i port → i {
+    : ( DChannel i ) ch ( open_int_chan port )
+    : ~ i sum 0
+    : ~ i cnt 0
+    : ~ b done F
+    ~ ! done {
+        : ?i got ( dchan_recv [i] ch )
+        ?? got {
+            T v → {
+                = sum + sum v
+                = cnt + cnt 1
+                ( print_kv `  recv ` v )
+            }
+            F → { = done T }
+        }
+    }
+    : String line ( string_from `consumed ` )
+    ( string_push_int line cnt )
+    ( string_push_str line ` items; sum = ` )
+    ( string_push_int line sum )
+    ( string_push_char line 10 )
+    ( nurl_print ( string_data line ) )
+    ( string_free line )
+    ( dchan_free [i] ch )
+    ^ 0
+}
+
+@ usage → i {
+    ( println `usage:` )
+    ( println `  dchannel server  <port>` )
+    ( println `  dchannel produce <port> <n>` )
+    ( println `  dchannel consume <port>` )
+    ^ 1
+}
+
+@ main → i {
+    : i argc ( env_args_count )
+    ? < argc 3 { ^ ( usage ) } {}
+
+    : String mode ( env_arg 1 )
+    : s m ( string_data mode )
+    : String ps ( env_arg 2 )
+    : i port ( nurl_str_to_int ( string_data ps ) )
+    ( string_free ps )
+
+    : i rc ? != 0 ( nurl_str_eq m `server` ) {
+        ( run_server port )
+    } {
+        ? != 0 ( nurl_str_eq m `produce` ) {
+            ? < argc 4 { ( usage ) } {
+                : String ns ( env_arg 3 )
+                : i n ( nurl_str_to_int ( string_data ns ) )
+                ( string_free ns )
+                ( run_produce port n )
+            }
+        } {
+            ? != 0 ( nurl_str_eq m `consume` ) {
+                ( run_consume port )
+            } {
+                ( usage )
+            }
+        }
+    }
+
+    ( string_free mode )
+    ^ rc
+}

--- a/stdlib/ext/dchannel.nu
+++ b/stdlib/ext/dchannel.nu
@@ -1,0 +1,558 @@
+// stdlib/ext/dchannel.nu — DChannel[A]: a distributed channel that
+// mirrors the local std/channel.nu API across an address-space boundary.
+//
+// **Phase 2 (TODO §7.2)** of the distributed-computing track. The headline
+// "location transparency" feature: the same send/recv shape as a local
+// Channel[A], except the two ends live in different processes / hosts.
+//
+// ── The idea: move to another address space ──────────────────────────
+//
+// Sending a value on a DChannel is a MOVE. The value is serialized onto
+// the wire, materialized in the *remote* process's queue, and released
+// locally — it genuinely ceases to exist here and begins to exist there.
+// Receiving materializes a fresh owned value out of the wire. This is the
+// single-owner model extended over the network, which is unusually clean
+// to express because NURL already tracks ownership locally.
+//
+// Built on ext/cluster.nu, so it inherits the resilience layer for free:
+// each operation is a `call_remote_with` carrying a RetryPolicy (transport
+// retry + backoff). Backpressure rides on top — a bounded remote queue
+// makes a blocking send wait for space.
+//
+// ── Codecs ───────────────────────────────────────────────────────────
+//
+// DChannel[A] is generic over the element type A. Because the wire is
+// JSON, the channel carries three closures fixing A's (de)serialization
+// and ownership, supplied once at open:
+//
+//   enc  :: ( @ Json A )   — BORROW A, return an owned JSON snapshot
+//                            (must NOT free A; the channel frees it)
+//   dec  :: ( @ A Json )   — BORROW a JSON value, return a fresh owned A
+//   drop :: ( @ v A )      — release an A (no-op for scalars)
+//
+// `dchan_open_json` supplies identity codecs for A = Json.
+//
+// ── Ownership contract (mirrors local chan_send, with one twist) ──────
+//
+//   dchan_send   — blocking; on Ok the value is CONSUMED (drop'd). On a
+//                  closed channel returns F and the caller KEEPS the value
+//                  (same as local). A full remote queue blocks (waits).
+//   dchan_try_send — non-blocking; DSendOk consumes, DSendFull/Closed/Err
+//                  leave the value with the caller.
+//   dchan_recv   — blocking; None only when the remote channel is closed
+//                  AND drained (same as local).
+//   dchan_try_recv — non-blocking; None when momentarily empty.
+//
+// ── API ──────────────────────────────────────────────────────────────
+//
+//   Server (host the queues):
+//     ( dstore_new i default_cap )                    → DStore
+//     ( dstore_declare DStore s s name i cap )         → v
+//     ( dstore_free DStore s )                         → v
+//     ( dchan_register DStore s Registry r )           → v
+//     ( dchan_serve s host i port DStore s )           → !v NetErr
+//
+//   Client (generic over A):
+//     ( dchan_open [A] Node node s name RetryPolicy pol i poll_ms
+//                      ( @ Json A ) enc ( @ A Json ) dec ( @ v A ) drop ) → ( DChannel A )
+//     ( dchan_open_json Node node s name RetryPolicy pol i poll_ms )      → ( DChannel Json )
+//     ( dchan_free   [A] ( DChannel A ) ch )           → v
+//     ( dchan_send   [A] ( DChannel A ) ch A v )       → b
+//     ( dchan_try_send [A] ( DChannel A ) ch A v )     → DSend
+//     ( dchan_recv   [A] ( DChannel A ) ch )           → ?A
+//     ( dchan_try_recv [A] ( DChannel A ) ch )         → ?A
+//     ( dchan_close  [A] ( DChannel A ) ch )           → v
+//     ( dchan_len    [A] ( DChannel A ) ch )           → i
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/cluster.nu`
+
+// Wire fn-ids registered on the cluster Registry.
+@ __wire_send  → s { ^ `dchan/send` }
+@ __wire_recv  → s { ^ `dchan/recv` }
+@ __wire_close → s { ^ `dchan/close` }
+@ __wire_len   → s { ^ `dchan/len` }
+
+// ── Server: bounded, thread-safe per-name Json queues ────────────────
+//
+// A DQueue is heap-allocated and referenced by pointer from the store's
+// entry Vec, so its scalar `closed` flag is shared by every accessor
+// (a by-value copy would not propagate the mutation). `cap` 0 = unbounded.
+
+: DQueue {
+    Mutex m
+    ( Vec Json ) items
+    i cap
+    i closed
+}
+
+: DStoreEntry {
+    String name
+    s q            // *DQueue
+}
+
+: DStore {
+    Mutex m
+    ( Vec DStoreEntry ) entries
+    i default_cap
+}
+
+@ dstore_new i default_cap → DStore {
+    ^ @ DStore { ( mutex_new ) ( vec_new [DStoreEntry] ) default_cap }
+}
+
+@ __dq_new i cap → *DQueue {
+    : *DQueue q # *DQueue ( nurl_alloc Z DQueue )
+    = . q m ( mutex_new )
+    = . q items ( vec_new [Json] )
+    = . q cap cap
+    = . q closed 0
+    ^ q
+}
+
+// Find an entry index by name. Caller must hold the store mutex.
+@ __dstore_find DStore s s name → i {
+    : i n ( vec_len [DStoreEntry] . s entries )
+    : ~ i found - 0 1
+    : ~ b done F
+    : ~ i k 0
+    ~ & ! done < k n {
+        : ?DStoreEntry ek ( vec_get [DStoreEntry] . s entries k )
+        ?? ek {
+            T e → {
+                ? != 0 ( nurl_str_eq ( string_data . e name ) name ) {
+                    = found k
+                    = done T
+                } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ found
+}
+
+// Return the (heap) DQueue for `name`, creating it at the store's default
+// capacity if absent. Caller must hold the store mutex.
+@ __dstore_get_or_create DStore s s name → *DQueue {
+    : i idx ( __dstore_find s name )
+    ? >= idx 0 {
+        : ?DStoreEntry ek ( vec_get [DStoreEntry] . s entries idx )
+        ^ ?? ek {
+            T e → # *DQueue . e q
+            F → ( __dq_new . s default_cap )   // unreachable
+        }
+    } {}
+    : *DQueue q ( __dq_new . s default_cap )
+    : DStoreEntry e @ DStoreEntry { ( string_from name ) # s q }
+    ( vec_push [DStoreEntry] . s entries e )
+    ^ q
+}
+
+// Pre-create a channel with an explicit capacity (otherwise channels are
+// created lazily at default_cap on first use).
+@ dstore_declare DStore s s name i cap → v {
+    ( mutex_lock . s m )
+    ? < ( __dstore_find s name ) 0 {
+        : DStoreEntry e @ DStoreEntry { ( string_from name ) # s ( __dq_new cap ) }
+        ( vec_push [DStoreEntry] . s entries e )
+    } {}
+    ( mutex_unlock . s m )
+}
+
+@ __dq_free *DQueue q → v {
+    ( vec_free_with [Json] . q items \ Json j → v { ( json_free j ) } )
+    ( mutex_free . q m )
+    ( nurl_free # s q )
+}
+
+@ dstore_free DStore s → v {
+    ( vec_free_with [DStoreEntry] . s entries
+    \ DStoreEntry e → v {
+        ( string_free . e name )
+        ( __dq_free # *DQueue . e q )
+    } )
+    ( mutex_free . s m )
+}
+
+// ── Server: result-envelope helpers ──────────────────────────────────
+
+@ __status_env s status → Json {
+    : Json r ( json_obj_new )
+    ( json_obj_set r `status` ( json_str_lit status ) )
+    ^ r
+}
+
+// ── Server: the four handlers ────────────────────────────────────────
+
+@ __dchan_h_send DStore store Json args → !Json ClusterErr {
+    : ?Json chj ( json_obj_get args `ch` )      // borrow
+    : s name ?? chj { T x → ( json_as_str x ) F → `` }
+    : ?Json vj ( json_obj_get args `v` )         // borrow
+
+    ( mutex_lock . store m )
+    : *DQueue q ( __dstore_get_or_create store name )
+    ( mutex_unlock . store m )
+
+    ( mutex_lock . q m )
+    : Json res ? != 0 . q closed {
+        ( __status_env `closed` )
+    } {
+        ? & > . q cap 0 >= ( vec_len [Json] . q items ) . q cap {
+            ( __status_env `full` )
+        } {
+            // Materialize the value in this address space (deep copy out
+            // of the borrowed args), then enqueue.
+            : Json owned ?? vj { T v → ( json_clone v ) F → ( json_null ) }
+            ( vec_push [Json] . q items owned )
+            ( __status_env `ok` )
+        }
+    }
+    ( mutex_unlock . q m )
+    ^ @ !Json ClusterErr { T res }
+}
+
+@ __dchan_h_recv DStore store Json args → !Json ClusterErr {
+    : ?Json chj ( json_obj_get args `ch` )
+    : s name ?? chj { T x → ( json_as_str x ) F → `` }
+
+    ( mutex_lock . store m )
+    : *DQueue q ( __dstore_get_or_create store name )
+    ( mutex_unlock . store m )
+
+    ( mutex_lock . q m )
+    : Json res ? > ( vec_len [Json] . q items ) 0 {
+        : Json env ( __status_env `ok` )
+        : ?Json popped ( vec_remove [Json] . q items 0 )    // owned
+        ?? popped {
+            T pv → { ( json_obj_set env `v` pv ) }           // move into env
+            F → {}
+        }
+        env
+    } {
+        ? != 0 . q closed { ( __status_env `closed` ) } { ( __status_env `empty` ) }
+    }
+    ( mutex_unlock . q m )
+    ^ @ !Json ClusterErr { T res }
+}
+
+@ __dchan_h_close DStore store Json args → !Json ClusterErr {
+    : ?Json chj ( json_obj_get args `ch` )
+    : s name ?? chj { T x → ( json_as_str x ) F → `` }
+
+    ( mutex_lock . store m )
+    : *DQueue q ( __dstore_get_or_create store name )
+    ( mutex_unlock . store m )
+
+    ( mutex_lock . q m )
+    = . q closed 1
+    ( mutex_unlock . q m )
+    ^ @ !Json ClusterErr { T ( __status_env `ok` ) }
+}
+
+@ __dchan_h_len DStore store Json args → !Json ClusterErr {
+    : ?Json chj ( json_obj_get args `ch` )
+    : s name ?? chj { T x → ( json_as_str x ) F → `` }
+
+    ( mutex_lock . store m )
+    : *DQueue q ( __dstore_get_or_create store name )
+    ( mutex_unlock . store m )
+
+    ( mutex_lock . q m )
+    : i n ( vec_len [Json] . q items )
+    ( mutex_unlock . q m )
+    : Json r ( json_obj_new )
+    ( json_obj_set r `len` ( json_int n ) )
+    ^ @ !Json ClusterErr { T r }
+}
+
+// Register the four channel handlers on a cluster Registry. The DStore is
+// captured by reference (its mutex + entries Vec are shared handles).
+@ dchan_register DStore store Registry r → v {
+    ( registry_register r ( __wire_send )
+    \ Json a → !Json ClusterErr { ^ ( __dchan_h_send store a ) } )
+    ( registry_register r ( __wire_recv )
+    \ Json a → !Json ClusterErr { ^ ( __dchan_h_recv store a ) } )
+    ( registry_register r ( __wire_close )
+    \ Json a → !Json ClusterErr { ^ ( __dchan_h_close store a ) } )
+    ( registry_register r ( __wire_len )
+    \ Json a → !Json ClusterErr { ^ ( __dchan_h_len store a ) } )
+}
+
+// Convenience: stand up a channel server (blocking accept loop).
+@ dchan_serve s host i port DStore store → !v NetErr {
+    : Registry r ( registry_new )
+    ( dchan_register store r )
+    : !v NetErr rr ( cluster_serve host port r )
+    ( registry_free r )
+    ^ rr
+}
+
+// ── Client: send outcome ─────────────────────────────────────────────
+
+: | DSend {
+    DSendOk
+    DSendFull
+    DSendClosed
+    DSendErr      // transport failure (channel unreachable)
+}
+
+@ dsend_name DSend d → s {
+    ^ ?? d {
+        DSendOk → `DSendOk`
+        DSendFull → `DSendFull`
+        DSendClosed → `DSendClosed`
+        DSendErr → `DSendErr`
+    }
+}
+
+// ── Client: the generic handle ───────────────────────────────────────
+
+: DChannelImpl [A] {
+    Node node
+    String name
+    RetryPolicy pol
+    i poll_ms
+    ( @ Json A ) enc
+    ( @ A Json ) dec
+    ( @ v A ) drop
+}
+
+: DChannel [A] { s ctl }
+
+@ dchan_open [A] Node node s name RetryPolicy pol i poll_ms
+( @ Json A ) enc ( @ A Json ) dec ( @ v A ) drop → ( DChannel A ) {
+    : *( DChannelImpl A ) impl # *( DChannelImpl A ) ( nurl_alloc Z ( DChannelImpl A ) )
+    = . impl node node
+    = . impl name ( string_from name )
+    = . impl pol pol
+    = . impl poll_ms ? > poll_ms 0 poll_ms 20
+    = . impl enc enc
+    = . impl dec dec
+    = . impl drop drop
+    ^ @ ( DChannel A ) { # s impl }
+}
+
+// Identity codecs for A = Json (the wire's native type).
+@ dchan_open_json Node node s name RetryPolicy pol i poll_ms → ( DChannel Json ) {
+    ^ ( dchan_open [Json] node name pol poll_ms
+        \ Json v → Json { ^ ( json_clone v ) }
+        \ Json j → Json { ^ ( json_clone j ) }
+        \ Json j → v { ( json_free j ) } )
+}
+
+@ dchan_free [A] ( DChannel A ) ch → v {
+    : *( DChannelImpl A ) impl # *( DChannelImpl A ) . ch ctl
+    ( node_free . impl node )
+    ( string_free . impl name )
+    : ( @ Json A ) e . impl enc
+    ( nurl_free # s # *u e 1 )
+    : ( @ A Json ) d . impl dec
+    ( nurl_free # s # *u d 1 )
+    : ( @ v A ) dr . impl drop
+    ( nurl_free # s # *u dr 1 )
+    ( nurl_free . ch ctl )
+}
+
+@ __poll_grow i w → i {
+    : i n * w 2
+    ? > n 250 { ^ 250 } {}
+    ^ n
+}
+
+// Build the {ch, v} args for a send. `payload` is BORROWED (cloned in).
+@ __send_args s name Json payload → Json {
+    : Json a ( json_obj_new )
+    ( json_obj_set a `ch` ( json_str_lit name ) )
+    ( json_obj_set a `v` ( json_clone payload ) )
+    ^ a
+}
+
+@ __name_args s name → Json {
+    : Json a ( json_obj_new )
+    ( json_obj_set a `ch` ( json_str_lit name ) )
+    ^ a
+}
+
+// Read the `status` string out of a borrowed response envelope.
+@ __res_status Json res → s {
+    : ?Json sj ( json_obj_get res `status` )
+    ^ ?? sj { T x → ( json_as_str x ) F → `` }
+}
+
+// One send RPC. Returns a DSend; never consumes the caller's value.
+@ __send_once [A] *( DChannelImpl A ) impl Json payload → DSend {
+    : Json args ( __send_args ( string_data . impl name ) payload )
+    : !Json ClusterErr rr ( call_remote_with . impl node ( __wire_send ) args . impl pol )
+    ^ ?? rr {
+        T res → {
+            : s st ( __res_status res )
+            : DSend d ? != 0 ( nurl_str_eq st `ok` ) { @ DSend { DSendOk } } {
+                ? != 0 ( nurl_str_eq st `closed` ) { @ DSend { DSendClosed } } {
+                    @ DSend { DSendFull }
+                }
+            }
+            ( json_free res )
+            d
+        }
+        F _ → @ DSend { DSendErr }
+    }
+}
+
+// Blocking send with backpressure. Consumes v (drop) on success; on a
+// closed channel returns F and the caller keeps v; a full remote queue
+// makes us wait and retry.
+@ dchan_send [A] ( DChannel A ) ch A v → b {
+    : *( DChannelImpl A ) impl # *( DChannelImpl A ) . ch ctl
+    : ( @ Json A ) e . impl enc
+    : Json payload ( e v )                       // BORROWS v
+
+    : ~ b done F
+    : ~ b ok F
+    : ~ i wait . impl poll_ms
+    ~ ! done {
+        : DSend d ( __send_once [A] impl payload )
+        ?? d {
+            DSendOk → { = ok T = done T }
+            DSendClosed → { = done T }
+            DSendErr → { = done T }
+            DSendFull → {
+                ( sleep_ms wait )
+                = wait ( __poll_grow wait )
+            }
+        }
+    }
+    ( json_free payload )
+    ? ok {
+        : ( @ v A ) dr . impl drop
+        ( dr v )
+    } {}
+    ^ ok
+}
+
+// Non-blocking send. DSendOk consumes v; every other outcome leaves v
+// with the caller.
+@ dchan_try_send [A] ( DChannel A ) ch A v → DSend {
+    : *( DChannelImpl A ) impl # *( DChannelImpl A ) . ch ctl
+    : ( @ Json A ) e . impl enc
+    : Json payload ( e v )
+    : DSend d ( __send_once [A] impl payload )
+    ( json_free payload )
+    ?? d {
+        DSendOk → {
+            : ( @ v A ) dr . impl drop
+            ( dr v )
+        }
+        _ → {}
+    }
+    ^ d
+}
+
+// Result of one recv RPC. `tag`: 0 empty, 1 closed, 2 ok, 3 transport
+// error. `val` is a fresh owned A — the real value when tag==2, otherwise
+// a placeholder the caller must drop.
+: RecvOut [A] {
+    i tag
+    A val
+}
+
+@ __recv_once [A] *( DChannelImpl A ) impl → ( RecvOut A ) {
+    : Json args ( __name_args ( string_data . impl name ) )
+    : !Json ClusterErr rr ( call_remote_with . impl node ( __wire_recv ) args . impl pol )
+    : ( @ A Json ) dec . impl dec
+    ^ ?? rr {
+        T res → {
+            : s st ( __res_status res )
+            : ( RecvOut A ) out ? != 0 ( nurl_str_eq st `ok` ) {
+                : ?Json vj ( json_obj_get res `v` )       // borrow
+                : A val ?? vj { T x → ( dec x ) F → ( __dec_null [A] impl ) }
+                @ ( RecvOut A ) { 2 val }
+            } {
+                : i tg ? != 0 ( nurl_str_eq st `closed` ) 1 0
+                @ ( RecvOut A ) { tg ( __dec_null [A] impl ) }
+            }
+            ( json_free res )
+            out
+        }
+        F _ → @ ( RecvOut A ) { 3 ( __dec_null [A] impl ) }
+    }
+}
+
+// A throwaway A produced via dec(null) — placeholder for non-ok recvs and
+// for initialising mutable bindings. Always paired with a drop.
+@ __dec_null [A] *( DChannelImpl A ) impl → A {
+    : ( @ A Json ) dec . impl dec
+    : Json n ( json_null )
+    : A a ( dec n )
+    ( json_free n )
+    ^ a
+}
+
+// Blocking recv. None only when the remote channel is closed AND drained.
+@ dchan_recv [A] ( DChannel A ) ch → ?A {
+    : *( DChannelImpl A ) impl # *( DChannelImpl A ) . ch ctl
+    : ( @ v A ) dr . impl drop
+
+    : ~ b done F
+    : ~ b have F
+    : ~ A result ( __dec_null [A] impl )
+    : ~ i wait . impl poll_ms
+    ~ ! done {
+        : ( RecvOut A ) ro ( __recv_once [A] impl )
+        ? == . ro tag 2 {
+            ( dr result )            // release the prior placeholder
+            = result . ro val
+            = have T
+            = done T
+        } {
+            ( dr . ro val )          // discard placeholder
+            ? == . ro tag 0 {
+                ( sleep_ms wait )
+                = wait ( __poll_grow wait )
+            } { = done T }           // closed or transport error → give up
+        }
+    }
+    ? have {
+        ^ @ ?A { T result }
+    } {}
+    ( dr result )                    // discard the unused placeholder
+    ^ @ ?A { F # A 0 }
+}
+
+// Non-blocking recv: one shot, None on empty/closed/error.
+@ dchan_try_recv [A] ( DChannel A ) ch → ?A {
+    : *( DChannelImpl A ) impl # *( DChannelImpl A ) . ch ctl
+    : ( @ v A ) dr . impl drop
+    : ( RecvOut A ) ro ( __recv_once [A] impl )
+    ? == . ro tag 2 {
+        ^ @ ?A { T . ro val }
+    } {}
+    ( dr . ro val )
+    ^ @ ?A { F # A 0 }
+}
+
+@ dchan_close [A] ( DChannel A ) ch → v {
+    : *( DChannelImpl A ) impl # *( DChannelImpl A ) . ch ctl
+    : Json args ( __name_args ( string_data . impl name ) )
+    : !Json ClusterErr rr ( call_remote_with . impl node ( __wire_close ) args . impl pol )
+    ?? rr { T res → ( json_free res ) F _ → {} }
+}
+
+@ dchan_len [A] ( DChannel A ) ch → i {
+    : *( DChannelImpl A ) impl # *( DChannelImpl A ) . ch ctl
+    : Json args ( __name_args ( string_data . impl name ) )
+    : !Json ClusterErr rr ( call_remote_with . impl node ( __wire_len ) args . impl pol )
+    ^ ?? rr {
+        T res → {
+            : ?Json lj ( json_obj_get res `len` )
+            : i n ?? lj { T x → ( json_as_int x ) F → 0 }
+            ( json_free res )
+            n
+        }
+        F _ → 0
+    }
+}


### PR DESCRIPTION
## Summary

The headline **Phase 2 (§7.2)** feature of the distributed-computing track: a distributed channel that mirrors the local `std/channel.nu` API across an address-space boundary. Sending is a **MOVE** — the value is serialized onto the wire, materialized in the *remote* process's queue, and released locally. Built on `ext/cluster.nu` (#129/#130), so it inherits the resilience layer for free.

### `stdlib/ext/dchannel.nu`
- **Generic `DChannel[A]`** with three codecs fixed at open: `enc` (A→Json, borrow), `dec` (Json→A), `drop` (release A). `dchan_open_json` supplies identity codecs for `A = Json`.
- **MOVE ownership** mirroring local `chan_send`: `dchan_send` consumes the value on Ok, the caller keeps it on a closed channel. A bounded remote queue makes a blocking send **wait for space — end-to-end backpressure**. Also `dchan_try_send`→`DSend`, `dchan_recv` (blocking long-poll; `None` only when closed **and** drained), `dchan_try_recv`, `dchan_close`, `dchan_len`.
- **Server:** `DStore` of heap `*DQueue` (bounded, mutex-guarded JSON FIFOs); `dstore_new`/`declare`/`free`, `dchan_register` (4 wire handlers on a cluster `Registry`), `dchan_serve`.

### Examples / tests
- `examples/dchannel.nu` — producer/consumer over separate processes (move + backpressure + close propagation).
- `compiler/tests/dchannel.nu` (+golden) — offline state machine via `rpc_dispatch` (the harness kills loopback sockets, so the networked path is verified manually, not in CI).

## Two root-cause fixes found en route

1. **Compiler:** string literals were **lost when a generic function was monomorphised** — the template was rebuilt from `nurl_lex_val`, which strips a `TT_STR`'s backticks and decodes its escapes, so `` `foo` `` re-lexed as the bare identifier `foo` (*"undefined identifier"*). New `__tok_src_text` re-wraps + re-escapes (`\n \t \r \\`). Regression test `compiler/tests/generic_string_literal.nu`. Bootstrap fixed point holds.
2. **dchannel:** a `*( DChannelImpl A )` pointer was passed to internal helpers declared with a `( DChannelImpl A )` *value* param — nurlc doesn't diagnose the mismatch, so the helpers read fields off the pointer's bits → garbage `Node` → connect-timeout hang / segfault. Fixed by declaring the helper params as pointers.

## Verification
- ✅ **361/361** suite green (incl. bootstrap fixed point after the nurlc change)
- ✅ Live producer/consumer over two processes: `sum=55`, FIFO order, backpressure when the cap-4 queue fills, clean close/drain
- ✅ Client paths (producer + consumer) ASan-clean

## Follow-ups
A nurlc **diagnostic for pointer-vs-value param mismatch** at call sites would catch the (nasty, silent) bug class behind fix #2. Remaining §7.2: SWIM membership, msgpack wire, fiber supervision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)