### PR TITLE
feat(swim): SWIM cluster membership + 2 compiler fixes it surfaced (TODO §7.2)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -1999,7 +1999,7 @@
         // a @-fn) AND no `__ptr` (not a local) AND no `__global`
         // (not a const / enum variant). Die with the canonical
         // wrap-in-closure-literal cure.
-        ? & & == 0 ( nurl_str_len ptr ) == 0 ( nurl_str_len glb ) != 0 ( nurl_str_len ( nurl_sym_get g_vis_syms ( nurl_str_cat name `__src_file` ) ) )
+        ? & & & == 0 ( nurl_str_len ptr ) == 0 ( nurl_str_len glb ) == 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat name `__param` ) ) ) != 0 ( nurl_str_len ( nurl_sym_get g_vis_syms ( nurl_str_cat name `__src_file` ) ) )
         { : s tail ( nurl_str_cat name ` args ) }'.` )
             ( die lex ( nurl_str_cat4
             `bare '@-fn' name '` name
@@ -5528,22 +5528,19 @@
                         ? & == 0 ( nurl_str_len nurl_inner_llvm ) ( seq pattern_name `F` )
                         { = nurl_inner_llvm ( nurl_sym_get syms ( nurl_str_cat match_var_name `__res_e_llvm` ) ) }
                         {}
-                        // Bare-pointer payload (`s` → `i8*`): the i64 slot
-                        // holds the pointer via ptrtoint, so one inttoptr
-                        // recovers it. Distinct from the `%`-struct branch
-                        // below (a handle whose f0 pointer must be re-wrapped
-                        // by insertvalue) — this is non-`%` AND `*`-suffixed,
-                        // so it never collides with that branch (`%T*` raw
-                        // pointers are `%`-prefixed and stay on that path).
-                        // Without this
-                        // the payload stayed a raw i64 and the arm's value
-                        // disagreed with the other arms' pointer type, so
-                        // gen_match emitted no phi and stored `undef` into the
-                        // binding (silent garbage — the `! s E` half of the
-                        // critic's bound-`??` miscompile). Both arms — an
-                        // enum error payload is `%`-prefixed and skips this.
-                        ? & & != 0 ( nurl_str_len nurl_inner_llvm )
-                        != ( nurl_str_get nurl_inner_llvm 0 ) 37
+                        // Raw-pointer payload — ANY LLVM type ending in `*`,
+                        // whether `i8*` (bare `s`) or `%Struct*` (a NURL
+                        // `*Struct` pointer). The i64 slot holds the pointer
+                        // via ptrtoint, so one inttoptr recovers it. The
+                        // trailing `*` is the reliable discriminator from the
+                        // `%`-struct-HANDLE branch below (e.g. `%Vec__i8`,
+                        // `%String` — handles never end in `*`). Routing on the
+                        // leading `%` instead used to misclassify `%Struct*`
+                        // pointers as handles: the struct path looked up
+                        // `Struct*__idx_0__type`, found nothing, reconstructed
+                        // nothing, and the binding got the raw i64 slot as
+                        // garbage (the `! *T E` pointer-unwrap miscompile).
+                        ? & != 0 ( nurl_str_len nurl_inner_llvm )
                         == ( nurl_str_get nurl_inner_llvm - ( nurl_str_len nurl_inner_llvm ) 1 ) 42
                         { : s ptv_r ( nurl_cg_reg cg )
                             ( nurl_print `  ` ) ( nurl_print ptv_r )
@@ -5553,8 +5550,9 @@
                             = pr0_eff ptv_r
                             = did_reconstruct T }
                         {}
-                        ? & != 0 ( nurl_str_len nurl_inner_llvm )
+                        ? & & != 0 ( nurl_str_len nurl_inner_llvm )
                         == ( nurl_str_get nurl_inner_llvm 0 ) 37
+                        != ( nurl_str_get nurl_inner_llvm - ( nurl_str_len nurl_inner_llvm ) 1 ) 42
                         { : s sname_r ( nurl_str_slice nurl_inner_llvm 1 - ( nurl_str_len nurl_inner_llvm ) 1 )
                             : s vlist_r ( nurl_sym_get syms ( nurl_str_cat sname_r `__variants` ) )
                             ? == 0 ( nurl_str_len vlist_r )
@@ -9178,8 +9176,14 @@
                 // is always i64, so string/bool/enum values are folded to i64.
                 ? payload_matches
                 {}  // value already matches payload_ty: use as-is
-                { ? | ( seq fty `i8*` ) ( seq fty `sref` )
-                    {  // string → i64 via ptrtoint
+                { ? | ( seq fty `sref` ) == ( nurl_str_get fty - ( nurl_str_len fty ) 1 ) 42
+                    {  // Any raw pointer (`i8*`, or a NURL `*Struct` → `%Struct*`)
+                       // — store it directly in the i64 payload slot via
+                       // ptrtoint. A `%Struct*` pointer ends in `*` and must
+                       // NOT fall through to the `%`-named struct branch below
+                       // (which would heap-box it as if it were a by-value
+                       // struct handle). The `?? T p` arm recovers it with a
+                       // single inttoptr.
                         : s conv_reg ( nurl_cg_reg cg )
                         ( nurl_print `  ` ) ( nurl_print conv_reg )
                         ( nurl_print ` = ptrtoint ` ) ( nurl_print fty ) ( nurl_print ` ` )

--- a/compiler/tests/outputs/result_ptr_payload.txt
+++ b/compiler/tests/outputs/result_ptr_payload.txt
@@ -1,0 +1,7 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+a=21
+b=42
+got err

--- a/compiler/tests/outputs/swim_codec.txt
+++ b/compiler/tests/outputs/swim_codec.txt
@@ -1,0 +1,17 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+bytes=59
+type=3
+seq=4000000001
+from=host-a:60000
+tgt=host-t:60001
+gossip=2
+  10.0.0.5:50001
+ inc=3000000000
+ dead
+  node-b:65535
+ inc=7
+ suspect
+empty → SwShort

--- a/compiler/tests/outputs/swim_table.txt
+++ b/compiler/tests/outputs/swim_table.txt
@@ -1,0 +1,20 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+add A alive: T
+A state: alive
+suspect A: T
+A state: suspect
+swept dead: 1
+
+A state: dead
+refute self: T
+self inc: 1
+
+revive A inc1: T
+A state: alive
+stale suspect A: F
+A state: alive
+count: 1
+

--- a/compiler/tests/result_ptr_payload.nu
+++ b/compiler/tests/result_ptr_payload.nu
@@ -1,0 +1,46 @@
+// result_ptr_payload.nu — regression: unwrapping a bare pointer (`*T`)
+// Ok-payload from a `! *T E` result.
+//
+// The Ok-arm reconstruction routed on the LLVM type's LEADING char: a
+// `%`-prefixed type went to the struct-HANDLE path. But a NURL `*Struct`
+// lowers to `%Struct*` — `%`-prefixed AND `*`-suffixed — so it was
+// misclassified as a handle, reconstructed nothing, and the binding got
+// the raw i64 slot as garbage. The fix routes on the trailing `*`
+// (pointer) instead. Without it, `. p a` below reads through a corrupt
+// pointer (crash / wrong value).
+
+$ `stdlib/core/string.nu`
+
+: | Boom { Bang }
+
+: Box { i a  i b }
+
+@ mk_ok i n → !*Box Boom {
+    : *Box p # *Box ( nurl_alloc Z Box )
+    = . p a n
+    = . p b * n 2
+    ^ @ !*Box Boom { T p }
+}
+
+@ mk_err → !*Box Boom {
+    ^ @ !*Box Boom { F @ Boom { Bang } }
+}
+
+@ main → i {
+    : !*Box Boom r ( mk_ok 21 )
+    ?? r {
+        T p → {
+            ( nurl_print `a=` ) ( nurl_print_int . p a )
+            ( nurl_print `b=` ) ( nurl_print_int . p b )
+            ( nurl_free # s p )
+        }
+        F e → ( nurl_print `unexpected err\n` )
+    }
+
+    : !*Box Boom r2 ( mk_err )
+    ?? r2 {
+        T p → ( nurl_print `unexpected ok\n` )
+        F e → ( nurl_print `got err\n` )
+    }
+    ^ 0
+}

--- a/compiler/tests/swim_codec.nu
+++ b/compiler/tests/swim_codec.nu
@@ -1,0 +1,67 @@
+// swim_codec.nu — offline round-trip test for the SWIM wire codec
+// (stdlib/std/swim.nu). Encodes a PING-REQ with a 2-member gossip list,
+// decodes it, and prints every field. Deliberately uses values above the
+// signed thresholds — port 65535, seq 4000000001, incarnation 3000000000
+// (all > 2^31) — so any u16/u32 sign-extension in the byte codec would
+// corrupt the round trip and fail the golden.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/swim.nu`
+
+@ main → i {
+    : ( Vec Member ) g ( vec_new [Member] )
+    ( vec_push [Member] g ( member_new `10.0.0.5` 50001 3000000000 @ MemberState { MDead } ) )
+    ( vec_push [Member] g ( member_new `node-b` 65535 7 @ MemberState { MSuspect } ) )
+    : SwimMsg m @ SwimMsg { @ SwimMsgType { MtPingReq } 4000000001
+    ( string_from `host-a` ) 60000 ( string_from `host-t` ) 60001 g }
+
+    : ( Vec u ) wire ( swim_msg_encode m )
+    ( nurl_print `bytes=` ) ( nurl_print_int ( vec_len [u] wire ) )
+
+    : !SwimMsg SwimErr d ( swim_msg_decode wire )
+    ?? d {
+        T m2 → {
+            ( nurl_print `type=` ) ( nurl_print_int ( __mtype_code . m2 mtype ) )
+            ( nurl_print `seq=` ) ( nurl_print_int . m2 seq )
+            ( nurl_print `from=` ) ( nurl_print ( string_data . m2 from_host ) )
+            ( nurl_print `:` ) ( nurl_print_int . m2 from_port )
+            ( nurl_print `tgt=` ) ( nurl_print ( string_data . m2 target_host ) )
+            ( nurl_print `:` ) ( nurl_print_int . m2 target_port )
+            : i gn ( vec_len [Member] . m2 gossip )
+            ( nurl_print `gossip=` ) ( nurl_print_int gn )
+            : ~ i k 0
+            ~ < k gn {
+                ?? ( vec_get [Member] . m2 gossip k ) {
+                    T mm → {
+                        ( nurl_print `  ` ) ( nurl_print ( string_data . mm host ) )
+                        ( nurl_print `:` ) ( nurl_print_int . mm port )
+                        ( nurl_print ` inc=` ) ( nurl_print_int . mm incarnation )
+                        ( nurl_print ` ` ) ( nurl_print ( member_state_name . mm state ) )
+                        ( nurl_print `\n` )
+                    }
+                    F → {}
+                }
+                = k + k 1
+            }
+            ( swim_msg_free m2 )
+        }
+        F e → {
+            : SwimErr se # SwimErr e
+            ( nurl_print `decode err: ` ) ( nurl_print ( swim_err_name se ) ) ( nurl_print `\n` )
+        }
+    }
+
+    // Truncated input → SwShort
+    : ( Vec u ) tiny ( vec_new [u] )
+    : !SwimMsg SwimErr d2 ( swim_msg_decode tiny )
+    ?? d2 {
+        T m3 → { ( nurl_print `unexpected ok\n` ) ( swim_msg_free m3 ) }
+        F e → { : SwimErr se # SwimErr e ( nurl_print `empty → ` ) ( nurl_print ( swim_err_name se ) ) ( nurl_print `\n` ) }
+    }
+
+    ( swim_msg_free m )
+    ( vec_free [u] wire )
+    ( vec_free [u] tiny )
+    ^ 0
+}

--- a/compiler/tests/swim_table.nu
+++ b/compiler/tests/swim_table.nu
@@ -1,0 +1,57 @@
+// swim_table.nu — offline tests for the SWIM member-table state machine
+// (stdlib/std/swim.nu). Deterministic: suspect_timeout_ms = 0 makes the
+// Suspect→Dead sweep fire immediately, so no wall-clock dependency.
+//
+// Covers: add, local suspect, timeout sweep to Dead, self-refutation
+// (incarnation bump), and gossip precedence (higher-incarnation Alive
+// revives a Dead member; a stale Suspect is rejected).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/swim.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `T\n` `F\n` ) }
+@ pst s label i st → v {
+    ( nurl_print label )
+    ( nurl_print ? == st 0 `alive\n` ? == st 1 `suspect\n` ? == st 2 `dead\n` `?\n` )
+}
+
+@ apply_m *MemberTable t s host i port i inc MemberState state s label → v {
+    : Member up ( member_new host port inc state )
+    ( pb label ( mtable_apply t up ) )
+    ( member_free up )
+}
+
+@ main → i {
+    : *MemberTable t ( mtable_new `self` 7000 0 )
+
+    // ── add A (alive) ────────────────────────────────────────────
+    ( apply_m t `A` 8001 0 @ MemberState { MAlive } `add A alive: ` )
+    ( pst `A state: ` ( mtable_state_of t `A` 8001 ) )
+
+    // ── local suspect, then timeout sweep → dead ─────────────────
+    ( pb `suspect A: ` ( mtable_suspect t `A` 8001 ) )
+    ( pst `A state: ` ( mtable_state_of t `A` 8001 ) )
+    : ( Vec Member ) d ( mtable_sweep t )
+    ( nurl_print `swept dead: ` ) ( nurl_print_int ( vec_len [Member] d ) ) ( nurl_print `\n` )
+    ( vec_free_with [Member] d \ Member mm → v { ( member_free mm ) } )
+    ( pst `A state: ` ( mtable_state_of t `A` 8001 ) )
+
+    // ── self-refutation: a Suspect-about-self bumps our incarnation ─
+    ( apply_m t `self` 7000 0 @ MemberState { MSuspect } `refute self: ` )
+    : Member sm ( mtable_self t )
+    ( nurl_print `self inc: ` ) ( nurl_print_int . sm incarnation ) ( nurl_print `\n` )
+    ( member_free sm )
+
+    // ── precedence: higher-inc Alive revives dead A ──────────────
+    ( apply_m t `A` 8001 1 @ MemberState { MAlive } `revive A inc1: ` )
+    ( pst `A state: ` ( mtable_state_of t `A` 8001 ) )
+
+    // ── precedence: stale Suspect (inc0 < cur inc1) rejected ──────
+    ( apply_m t `A` 8001 0 @ MemberState { MSuspect } `stale suspect A: ` )
+    ( pst `A state: ` ( mtable_state_of t `A` 8001 ) )
+
+    ( nurl_print `count: ` ) ( nurl_print_int ( mtable_count t ) ) ( nurl_print `\n` )
+    ( mtable_free t )
+    ^ 0
+}

--- a/examples/swim.nu
+++ b/examples/swim.nu
@@ -1,0 +1,102 @@
+// examples/swim.nu — self-maintaining cluster membership via SWIM
+// (TODO §7.2). Each node gossips its view over UDP; failures are detected
+// by periodic pings and disseminated epidemically. No static peer list —
+// a node joins by contacting any one seed.
+//
+// ── Run it (one machine, several terminals) ──────────────────────────
+//
+//   ./nurl.sh examples/swim.nu 7001                 # seed
+//   ./nurl.sh examples/swim.nu 7002 7001            # join via :7001
+//   ./nurl.sh examples/swim.nu 7003 7001            # join via :7001
+//
+// Each node prints its membership view every second. Kill one node
+// (Ctrl+C) and within a few seconds the survivors show it `suspect`
+// then `dead` — the failure propagates by gossip even to nodes that
+// never pinged it directly.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/async.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/std/swim.nu`
+
+@ print_view *SwimNode n i port → v {
+    : *MemberTable t ( swim_table n )
+    : ( Vec Member ) ms ( mtable_snapshot t )
+    : String line ( string_from `[:` )
+    ( string_push_int line port )
+    ( string_push_str line `] members(` )
+    ( string_push_int line ( vec_len [Member] ms ) )
+    ( string_push_str line `):` )
+    : i k 0
+    : ~ i j 0
+    ~ < j ( vec_len [Member] ms ) {
+        ?? ( vec_get [Member] ms j ) {
+            T mm → {
+                ( string_push_str line ` ` )
+                ( string_push_str line ( string_data . mm host ) )
+                ( string_push_char line 58 )
+                ( string_push_int line . mm port )
+                ( string_push_char line 61 )
+                ( string_push_str line ( member_state_name . mm state ) )
+            }
+            F → {}
+        }
+        = j + j 1
+    }
+    ( string_push_char line 10 )
+    ( nurl_print ( string_data line ) )
+    ( string_free line )
+    ( vec_free_with [Member] ms \ Member mm → v { ( member_free mm ) } )
+}
+
+@ printer_loop *SwimNode n i port → v {
+    ~ 1 {
+        ( sleep_ms 1000 )
+        ( print_view n port )
+    }
+}
+
+@ main → i {
+    : i argc ( env_args_count )
+    ? < argc 2 {
+        ( nurl_print `usage: swim <port> [seed_port]\n` )
+        ^ 1
+    } {}
+
+    : String ps ( env_arg 1 )
+    : i port ( nurl_str_to_int ( string_data ps ) )
+    ( string_free ps )
+
+    ( runtime_init 0 )
+
+    // period 500ms, ping-timeout 300ms, suspect→dead after 2s.
+    : !*SwimNode NetErr nr ( swim_node_new `127.0.0.1` port 500 300 2000 )
+    ?? nr {
+        T n → {
+            ? > argc 2 {
+                : String ss ( env_arg 2 )
+                : i seed ( nurl_str_to_int ( string_data ss ) )
+                ( string_free ss )
+                ( swim_join n `127.0.0.1` seed )
+                : String b ( string_from `joined seed :` )
+                ( string_push_int b seed )
+                ( string_push_char b 10 )
+                ( nurl_print ( string_data b ) )
+                ( string_free b )
+            } {
+                ( nurl_print `seed node (no join)\n` )
+            }
+            ( swim_run n )
+            ( spawn \ → v { ( printer_loop n port ) } )
+            ( runtime_run )
+            ( swim_node_free n )
+        }
+        F e → {
+            ( nurl_print `bind failed\n` )
+        }
+    }
+    ( runtime_shutdown )
+    ^ 0
+}

--- a/stdlib/std/swim.nu
+++ b/stdlib/std/swim.nu
@@ -1,0 +1,690 @@
+// stdlib/std/swim.nu — SWIM cluster membership + failure detection.
+//
+// **Phase 2 (TODO §7.2)** of the distributed-computing track: replaces the
+// static peer list with a self-maintaining membership view. Implements the
+// SWIM protocol (Scalable Weakly-consistent Infection-style Membership):
+//
+//   * failure detection by periodic random PING, with INDIRECT pings
+//     (PING-REQ via k random members) to suppress false positives from a
+//     single lossy path;
+//   * dissemination by gossip — membership changes piggyback on the
+//     PING/ACK traffic, infecting the cluster epidemically;
+//   * Alive → Suspect → Dead with INCARNATION numbers so a node can refute
+//     a stale suspicion about itself.
+//
+// Layered so the bug-dense parts are deterministic and unit-tested offline:
+//   1. wire codec   — SwimMsg ⇄ bytes (this file's first half)
+//   2. member table — state machine + incarnation refutation + gossip merge
+//   3. protocol     — the UDP I/O loop wiring 1+2 together
+//
+// Built on std/udp.nu (datagram transport) + std/bytes.nu (big-endian
+// codec) + std/rng.nu (random member selection) + std/time.nu (timeouts).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/udp.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/rng.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/async.nu`
+
+// ── Member state ─────────────────────────────────────────────────────
+
+: | MemberState {
+    MAlive
+    MSuspect
+    MDead
+}
+
+@ member_state_name MemberState s → s {
+    ^ ?? s {
+        MAlive → `alive`
+        MSuspect → `suspect`
+        MDead → `dead`
+    }
+}
+
+@ __state_code MemberState s → i {
+    ^ ?? s { MAlive → 0  MSuspect → 1  MDead → 2 }
+}
+
+@ __state_of i c → MemberState {
+    ^ ? == c 0 @ MemberState { MAlive }
+    ? == c 1 @ MemberState { MSuspect }
+    @ MemberState { MDead }
+}
+
+// A cluster member. `incarnation` is the member's own logical clock; a
+// higher incarnation always wins, which is how a node refutes a stale
+// suspicion about itself. `last_change_ms` is a local monotonic stamp
+// driving the suspicion → dead timeout.
+: Member {
+    String host
+    i port
+    i incarnation
+    MemberState state
+    i last_change_ms
+}
+
+@ member_new s host i port i incarnation MemberState state → Member {
+    ^ @ Member { ( string_from host ) port incarnation state ( monotonic_ns ) }
+}
+
+@ member_free Member m → v {
+    ( string_free . m host )
+}
+
+// ── Message types ────────────────────────────────────────────────────
+
+: | SwimMsgType {
+    MtPing
+    MtAck
+    MtPingReq    // indirect probe request: "please ping target for me"
+    MtJoin
+    MtJoinAck
+}
+
+@ __mtype_code SwimMsgType t → i {
+    ^ ?? t { MtPing → 1  MtAck → 2  MtPingReq → 3  MtJoin → 4  MtJoinAck → 5 }
+}
+
+@ __mtype_of i c → SwimMsgType {
+    ^ ? == c 1 @ SwimMsgType { MtPing }
+    ? == c 2 @ SwimMsgType { MtAck }
+    ? == c 3 @ SwimMsgType { MtPingReq }
+    ? == c 4 @ SwimMsgType { MtJoin }
+    @ SwimMsgType { MtJoinAck }
+}
+
+// A SWIM datagram. `seq` matches an ACK to its PING. `from_*` is the
+// sender; `target_*` is the indirect-probe subject (PING-REQ only).
+// `gossip` carries piggybacked membership updates (each a bare Member
+// snapshot — host/port/incarnation/state).
+: SwimMsg {
+    SwimMsgType mtype
+    i seq
+    String from_host
+    i from_port
+    String target_host
+    i target_port
+    ( Vec Member ) gossip
+}
+
+@ swim_msg_free SwimMsg m → v {
+    ( string_free . m from_host )
+    ( string_free . m target_host )
+    ( vec_free_with [Member] . m gossip \ Member mm → v { ( member_free mm ) } )
+}
+
+// ── Wire codec ───────────────────────────────────────────────────────
+
+: | SwimErr {
+    SwShort      // truncated datagram
+    SwBadType    // unknown message type byte
+}
+
+@ swim_err_name SwimErr e → s {
+    ^ ?? e { SwShort → `SwShort`  SwBadType → `SwBadType` }
+}
+
+// u16-length-prefixed string.
+@ __sw_put_str ( Vec u ) b s text → v {
+    ( bytes_push_u16_be b # u16 ( nurl_str_len text ) )
+    ( bytes_extend_str b text )
+}
+
+// Read the u16-prefixed string starting at `off`. Returns the String;
+// the caller advances `off` by 2 + its byte length.
+@ __sw_get_str ( Vec u ) b i off → String {
+    : i n ?? ( bytes_read_u16_be b off ) { T x → # i x  F → 0 }
+    : String s ( string_with_cap n )
+    : ~ i k 0
+    ~ < k n {
+        : ?u byte ( vec_get [u] b + + off 2 k )
+        ?? byte { T bb → ( string_push_char s # i bb )  F → {} }
+        = k + k 1
+    }
+    ^ s
+}
+
+@ __sw_put_member ( Vec u ) b Member m → v {
+    ( vec_push [u] b # u ( __state_code . m state ) )
+    ( bytes_push_u32_be b # u32 . m incarnation )
+    ( __sw_put_str b ( string_data . m host ) )
+    ( bytes_push_u16_be b # u16 . m port )
+}
+
+@ swim_msg_encode SwimMsg m → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( vec_push [u] b # u ( __mtype_code . m mtype ) )
+    ( bytes_push_u32_be b # u32 . m seq )
+    ( __sw_put_str b ( string_data . m from_host ) )
+    ( bytes_push_u16_be b # u16 . m from_port )
+    ( __sw_put_str b ( string_data . m target_host ) )
+    ( bytes_push_u16_be b # u16 . m target_port )
+    : i gn ( vec_len [Member] . m gossip )
+    ( bytes_push_u16_be b # u16 gn )
+    : ~ i k 0
+    ~ < k gn {
+        ?? ( vec_get [Member] . m gossip k ) {
+            T mm → ( __sw_put_member b mm )
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ b
+}
+
+@ swim_msg_decode ( Vec u ) b → !SwimMsg SwimErr {
+    : i len ( vec_len [u] b )
+    ? < len 1 { ^ @ !SwimMsg SwimErr { F @ SwimErr { SwShort } } } {}
+
+    : i tc ?? ( vec_get [u] b 0 ) { T x → # i x  F → 0 }
+    ? | < tc 1 > tc 5 { ^ @ !SwimMsg SwimErr { F @ SwimErr { SwBadType } } } {}
+    : SwimMsgType mt ( __mtype_of tc )
+    : ~ i off 1
+
+    : i seq ?? ( bytes_read_u32_be b off ) { T x → # i x  F → 0 }
+    = off + off 4
+
+    : String fh ( __sw_get_str b off )
+    = off + + off 2 ( string_len fh )
+    : i fp ?? ( bytes_read_u16_be b off ) { T x → # i x  F → 0 }
+    = off + off 2
+
+    : String th ( __sw_get_str b off )
+    = off + + off 2 ( string_len th )
+    : i tp ?? ( bytes_read_u16_be b off ) { T x → # i x  F → 0 }
+    = off + off 2
+
+    : i gn ?? ( bytes_read_u16_be b off ) { T x → # i x  F → 0 }
+    = off + off 2
+
+    : ( Vec Member ) gossip ( vec_new [Member] )
+    : ~ i k 0
+    ~ < k gn {
+        : i sc ?? ( vec_get [u] b off ) { T x → # i x  F → 0 }
+        = off + off 1
+        : i inc ?? ( bytes_read_u32_be b off ) { T x → # i x  F → 0 }
+        = off + off 4
+        : String mh ( __sw_get_str b off )
+        = off + + off 2 ( string_len mh )
+        : i mp ?? ( bytes_read_u16_be b off ) { T x → # i x  F → 0 }
+        = off + off 2
+        ( vec_push [Member] gossip
+        @ Member { mh mp inc ( __state_of sc ) ( monotonic_ns ) } )
+        = k + k 1
+    }
+
+    ^ @ !SwimMsg SwimErr { T @ SwimMsg { mt seq fh fp th tp gossip } }
+}
+
+// ── Member table + failure detector ──────────────────────────────────
+//
+// Heap-allocated (pointer-shared) so the protocol loop and any inspector
+// observe one mutable view; every op takes the lock. `members` excludes
+// self — self is represented by `self_*` and emitted into gossip on demand.
+
+: MemberTable {
+    Mutex m
+    ( Vec Member ) members
+    String self_host
+    i self_port
+    i self_incarnation
+    Rng rng
+    i suspect_timeout_ms
+}
+
+@ mtable_new s self_host i self_port i suspect_timeout_ms → *MemberTable {
+    : *MemberTable t # *MemberTable ( nurl_alloc Z MemberTable )
+    = . t m ( mutex_new )
+    = . t members ( vec_new [Member] )
+    = . t self_host ( string_from self_host )
+    = . t self_port self_port
+    = . t self_incarnation 0
+    = . t rng ( rng_seed ( monotonic_ns ) )
+    = . t suspect_timeout_ms suspect_timeout_ms
+    ^ t
+}
+
+@ mtable_free *MemberTable t → v {
+    ( vec_free_with [Member] . t members \ Member mm → v { ( member_free mm ) } )
+    ( mutex_free . t m )
+    ( string_free . t self_host )
+    ( rng_free . t rng )
+    ( nurl_free # s t )
+}
+
+@ __member_copy Member m → Member {
+    ^ @ Member { ( string_from ( string_data . m host ) ) . m port . m incarnation . m state . m last_change_ms }
+}
+
+@ __addr_eq s ha i pa s hb i pb → b {
+    ^ & == pa pb != 0 ( nurl_str_eq ha hb )
+}
+
+// Index of (host,port) in members, or -1. Caller holds the lock.
+@ __mtable_find *MemberTable t s host i port → i {
+    : i n ( vec_len [Member] . t members )
+    : ~ i found - 0 1
+    : ~ b done F
+    : ~ i k 0
+    ~ & ! done < k n {
+        ?? ( vec_get [Member] . t members k ) {
+            T mm → {
+                ? ( __addr_eq ( string_data . mm host ) . mm port host port ) {
+                    = found k  = done T
+                } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ found
+}
+
+// Merge one membership update under SWIM precedence. Returns T if the
+// local view changed in a way worth re-gossiping (state transition, new
+// member, or self-refutation). `up` is BORROWED (caller still owns it).
+@ mtable_apply *MemberTable t Member up → b {
+    ( mutex_lock . t m )
+    : s uh ( string_data . up host )
+    : i up_port . up port
+    : i ui . up incarnation
+    : i us ( __state_code . up state )
+
+    // Update about ourselves → refute any suspicion/death with a higher
+    // incarnation so the cluster learns we are alive.
+    ? ( __addr_eq uh up_port ( string_data . t self_host ) . t self_port ) {
+        : b refute & > us 0 >= ui . t self_incarnation
+        ? refute { = . t self_incarnation + ui 1 } {}
+        ( mutex_unlock . t m )
+        ^ refute
+    } {}
+
+    : i idx ( __mtable_find t uh up_port )
+    ? < idx 0 {
+        ( vec_push [Member] . t members ( __member_copy up ) )
+        ( mutex_unlock . t m )
+        ^ T
+    } {}
+
+    : Member cur ?? ( vec_get [Member] . t members idx ) { T x → x  F → up }
+    : i ci . cur incarnation
+    : i cs ( __state_code . cur state )
+
+    // Precedence: Alive wins on strictly-higher inc; Suspect wins on
+    // higher inc or equal-inc-over-Alive; Dead wins on >= inc.
+    : b accept ? == us 0 { > ui ci }
+    { ? == us 1 { | > ui ci & == ui ci == cs 0 }
+      { >= ui ci } }
+
+    ? accept {
+        : Member nm @ Member { . cur host up_port ui . up state ( monotonic_ns ) }
+        ( vec_set [Member] . t members idx nm )
+        ( mutex_unlock . t m )
+        ^ != us cs               // re-gossip only on an actual state change
+    } {}
+    ( mutex_unlock . t m )
+    ^ F
+}
+
+// Locally mark a member Suspect after a failed probe (keeps its current
+// incarnation — a refutation must out-number it). Returns T if changed.
+@ mtable_suspect *MemberTable t s host i port → b {
+    ( mutex_lock . t m )
+    : i idx ( __mtable_find t host port )
+    ? < idx 0 { ( mutex_unlock . t m ) ^ F } {}
+    : Member cur ?? ( vec_get [Member] . t members idx ) { T x → x  F → ( member_new host port 0 @ MemberState { MAlive } ) }
+    ? == ( __state_code . cur state ) 0 {
+        : Member nm @ Member { . cur host port . cur incarnation @ MemberState { MSuspect } ( monotonic_ns ) }
+        ( vec_set [Member] . t members idx nm )
+        ( mutex_unlock . t m )
+        ^ T
+    } {}
+    ( mutex_unlock . t m )
+    ^ F
+}
+
+// Promote Suspect → Dead once the suspicion has aged past the timeout.
+// Returns the newly-dead members (owned copies) for gossip dissemination.
+@ mtable_sweep *MemberTable t → ( Vec Member ) {
+    ( mutex_lock . t m )
+    : ( Vec Member ) dead ( vec_new [Member] )
+    : i now ( monotonic_ns )
+    : i n ( vec_len [Member] . t members )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [Member] . t members k ) {
+            T cur → {
+                ? == ( __state_code . cur state ) 1 {
+                    : i age_ms / - now . cur last_change_ms 1000000
+                    ? >= age_ms . t suspect_timeout_ms {
+                        : Member nm @ Member { . cur host . cur port . cur incarnation @ MemberState { MDead } now }
+                        ( vec_set [Member] . t members k nm )
+                        ( vec_push [Member] dead ( __member_copy nm ) )
+                    } {}
+                } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( mutex_unlock . t m )
+    ^ dead
+}
+
+// Self as an Alive member snapshot (for gossip + join).
+@ mtable_self *MemberTable t → Member {
+    ( mutex_lock . t m )
+    : Member s @ Member { ( string_from ( string_data . t self_host ) ) . t self_port . t self_incarnation @ MemberState { MAlive } ( monotonic_ns ) }
+    ( mutex_unlock . t m )
+    ^ s
+}
+
+// Pick a random member that is worth probing (Alive or Suspect). None
+// when the table has no such member. Returns an owned copy.
+@ mtable_pick_probe *MemberTable t → ?Member {
+    ( mutex_lock . t m )
+    : ( Vec i ) cand ( vec_new [i] )
+    : i n ( vec_len [Member] . t members )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [Member] . t members k ) {
+            T mm → { ? != ( __state_code . mm state ) 2 { ( vec_push [i] cand k ) } {} }
+            F → {}
+        }
+        = k + k 1
+    }
+    : i cn ( vec_len [i] cand )
+    ? == cn 0 {
+        ( vec_free [i] cand )
+        ( mutex_unlock . t m )
+        ^ @ ?Member { F # Member 0 }
+    } {}
+    : i pick ?? ( vec_get [i] cand ( rng_below . t rng cn ) ) { T x → x  F → 0 }
+    ( vec_free [i] cand )
+    : ?Member out ?? ( vec_get [Member] . t members pick ) {
+        T mm → @ ?Member { T ( __member_copy mm ) }
+        F → @ ?Member { F # Member 0 }
+    }
+    ( mutex_unlock . t m )
+    ^ out
+}
+
+// Up to `k` random members other than (host,port) — the indirect-probe
+// relays. Owned copies.
+@ mtable_pick_relays *MemberTable t i k s ex_host i ex_port → ( Vec Member ) {
+    ( mutex_lock . t m )
+    : ( Vec i ) cand ( vec_new [i] )
+    : i n ( vec_len [Member] . t members )
+    : ~ i j 0
+    ~ < j n {
+        ?? ( vec_get [Member] . t members j ) {
+            T mm → {
+                ? & != ( __state_code . mm state ) 2
+                ! ( __addr_eq ( string_data . mm host ) . mm port ex_host ex_port ) {
+                    ( vec_push [i] cand j )
+                } {}
+            }
+            F → {}
+        }
+        = j + j 1
+    }
+    : ( Vec Member ) out ( vec_new [Member] )
+    : i cn ( vec_len [i] cand )
+    : ~ i taken 0
+    ~ & < taken k > ( vec_len [i] cand ) 0 {
+        : i ci ( rng_below . t rng ( vec_len [i] cand ) )
+        : i mi ?? ( vec_get [i] cand ci ) { T x → x  F → 0 }
+        ?? ( vec_get [Member] . t members mi ) {
+            T mm → ( vec_push [Member] out ( __member_copy mm ) )
+            F → {}
+        }
+        ( vec_remove [i] cand ci )     // sample without replacement
+        = taken + taken 1
+    }
+    ( vec_free [i] cand )
+    ( mutex_unlock . t m )
+    ^ out
+}
+
+// Gossip sample: self (Alive) plus up to `max` random members. Owned.
+@ mtable_gossip *MemberTable t i max → ( Vec Member ) {
+    : ( Vec Member ) g ( vec_new [Member] )
+    ( vec_push [Member] g ( mtable_self t ) )
+    ( mutex_lock . t m )
+    : i n ( vec_len [Member] . t members )
+    : ~ i taken 0
+    : ~ i k 0
+    ~ & < k n < taken max {
+        ?? ( vec_get [Member] . t members k ) {
+            T mm → ( vec_push [Member] g ( __member_copy mm ) )
+            F → {}
+        }
+        = taken + taken 1
+        = k + k 1
+    }
+    ( mutex_unlock . t m )
+    ^ g
+}
+
+@ mtable_count *MemberTable t → i {
+    ( mutex_lock . t m )
+    : i n ( vec_len [Member] . t members )
+    ( mutex_unlock . t m )
+    ^ n
+}
+
+// All members (excluding self) as owned copies — for inspection / UIs.
+@ mtable_snapshot *MemberTable t → ( Vec Member ) {
+    ( mutex_lock . t m )
+    : ( Vec Member ) out ( vec_new [Member] )
+    : i n ( vec_len [Member] . t members )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [Member] . t members k ) {
+            T mm → ( vec_push [Member] out ( __member_copy mm ) )
+            F → {}
+        }
+        = k + k 1
+    }
+    ( mutex_unlock . t m )
+    ^ out
+}
+
+// State of (host,port) as a code (0/1/2), or -1 if unknown. For tests.
+@ mtable_state_of *MemberTable t s host i port → i {
+    ( mutex_lock . t m )
+    : i idx ( __mtable_find t host port )
+    : i st ? < idx 0 - 0 1 ?? ( vec_get [Member] . t members idx ) { T mm → ( __state_code . mm state ) F → - 0 1 }
+    ( mutex_unlock . t m )
+    ^ st
+}
+
+// ── Protocol: UDP I/O loop ───────────────────────────────────────────
+//
+// Direct-probe SWIM: each protocol period the failure detector PINGs one
+// random member and waits for an ACK; a missed ACK marks the member
+// Suspect, and the sweep promotes a stale Suspect to Dead. Membership
+// changes ride along as gossip on every PING/ACK. (Indirect PING-REQ to
+// suppress single-path false positives is wired into the message format
+// but driven by a follow-up.)
+//
+// Two fibers: a receiver (answer PINGs, record ACKs, merge gossip) and
+// the failure detector. Heap-allocated so both fibers share one node.
+
+: SwimNode {
+    *MemberTable table
+    UdpSocket sock
+    String host
+    i port
+    Mutex ack_m
+    ( Vec i ) acked      // ACK seqs seen since the last sweep
+    i seq_ctr
+    i period_ms
+    i ping_timeout_ms
+    i running
+}
+
+@ swim_node_new s host i port i period_ms i ping_timeout_ms i suspect_timeout_ms → !*SwimNode NetErr {
+    : !UdpSocket NetErr sr ( udp_bind host port )
+    ^ ?? sr {
+        T sock → {
+            ( udp_set_timeout sock 500 )
+            : *SwimNode n # *SwimNode ( nurl_alloc Z SwimNode )
+            = . n table ( mtable_new host port suspect_timeout_ms )
+            = . n sock sock
+            = . n host ( string_from host )
+            = . n port port
+            = . n ack_m ( mutex_new )
+            = . n acked ( vec_new [i] )
+            = . n seq_ctr 0
+            = . n period_ms period_ms
+            = . n ping_timeout_ms ping_timeout_ms
+            = . n running 1
+            @ !*SwimNode NetErr { T n }
+        }
+        F e → @ !*SwimNode NetErr { F # NetErr e }
+    }
+}
+
+@ __node_table *SwimNode n → *MemberTable { ^ . n table }
+
+@ swim_table *SwimNode n → *MemberTable { ^ ( __node_table n ) }
+
+@ swim_node_free *SwimNode n → v {
+    ( mtable_free ( __node_table n ) )
+    ( udp_close . n sock )
+    ( mutex_free . n ack_m )
+    ( vec_free [i] . n acked )
+    ( string_free . n host )
+    ( nurl_free # s n )
+}
+
+@ __node_send *SwimNode n s host i port SwimMsg m → v {
+    : ( Vec u ) bytes ( swim_msg_encode m )
+    : !i NetErr r ( udp_send_to . n sock bytes host port )
+    ?? r { T _ → {} F _ → {} }
+    ( vec_free [u] bytes )
+}
+
+// Build a message of `ty` carrying a fresh gossip sample.
+@ __mk_msg *SwimNode n SwimMsgType ty i seq s th i tp → SwimMsg {
+    : ( Vec Member ) g ( mtable_gossip ( __node_table n ) 6 )
+    ^ @ SwimMsg { ty seq ( string_from ( string_data . n host ) ) . n port ( string_from th ) tp g }
+}
+
+@ __apply_gossip *SwimNode n ( Vec Member ) g → v {
+    : i gn ( vec_len [Member] g )
+    : ~ i k 0
+    ~ < k gn {
+        ?? ( vec_get [Member] g k ) {
+            T mm → { : b _c ( mtable_apply ( __node_table n ) mm ) }
+            F → {}
+        }
+        = k + k 1
+    }
+}
+
+@ __handle *SwimNode n SwimMsg m → v {
+    ( __apply_gossip n . m gossip )
+    : i ty ( __mtype_code . m mtype )
+    ? == ty 1 {                              // PING → ACK (echo seq)
+        : SwimMsg ack ( __mk_msg n @ SwimMsgType { MtAck } . m seq `` 0 )
+        ( __node_send n ( string_data . m from_host ) . m from_port ack )
+        ( swim_msg_free ack )
+    } {}
+    ? == ty 2 {                              // ACK → record seq
+        ( mutex_lock . n ack_m )
+        ( vec_push [i] . n acked . m seq )
+        ( mutex_unlock . n ack_m )
+    } {}
+    ? == ty 4 {                              // JOIN → reply with our view
+        : SwimMsg ja ( __mk_msg n @ SwimMsgType { MtJoinAck } . m seq `` 0 )
+        ( __node_send n ( string_data . m from_host ) . m from_port ja )
+        ( swim_msg_free ja )
+    } {}
+    // MtJoinAck (5): gossip already merged.
+}
+
+@ __recv_loop *SwimNode n → v {
+    ~ != 0 . n running {
+        : !UdpPacket NetErr r ( udp_recv_from . n sock 2048 )
+        ?? r {
+            T pkt → {
+                : !SwimMsg SwimErr d ( swim_msg_decode . pkt data )
+                ?? d {
+                    T m → { ( __handle n m ) ( swim_msg_free m ) }
+                    F _ → {}
+                }
+                ( udp_packet_free pkt )
+            }
+            F _ → {}                          // timeout → re-check running
+        }
+    }
+}
+
+@ __got_ack *SwimNode n i seq → b {
+    ( mutex_lock . n ack_m )
+    : i nn ( vec_len [i] . n acked )
+    : ~ b found F
+    : ~ i k 0
+    ~ & ! found < k nn {
+        ?? ( vec_get [i] . n acked k ) { T x → ? == x seq { = found T } {} F → {} }
+        = k + k 1
+    }
+    ( mutex_unlock . n ack_m )
+    ^ found
+}
+
+@ __fd_loop *SwimNode n → v {
+    ~ != 0 . n running {
+        ( sleep_ms . n period_ms )
+        : ?Member tgt ( mtable_pick_probe ( __node_table n ) )
+        ?? tgt {
+            T mm → {
+                = . n seq_ctr + . n seq_ctr 1
+                : i seq . n seq_ctr
+                : SwimMsg ping ( __mk_msg n @ SwimMsgType { MtPing } seq `` 0 )
+                ( __node_send n ( string_data . mm host ) . mm port ping )
+                ( swim_msg_free ping )
+                : ~ b ok F
+                : ~ i waited 0
+                ~ & ! ok < waited . n ping_timeout_ms {
+                    ( sleep_ms 10 )
+                    = waited + waited 10
+                    ? ( __got_ack n seq ) { = ok T } {}
+                }
+                ? ! ok {
+                    : b _s ( mtable_suspect ( __node_table n ) ( string_data . mm host ) . mm port )
+                } {}
+                ( member_free mm )
+            }
+            F → {}
+        }
+        : ( Vec Member ) dead ( mtable_sweep ( __node_table n ) )
+        ( vec_free_with [Member] dead \ Member d → v { ( member_free d ) } )
+        ( mutex_lock . n ack_m )
+        ( vec_clear [i] . n acked )
+        ( mutex_unlock . n ack_m )
+    }
+}
+
+// Announce ourselves to a seed node (it learns us via the JOIN's gossip
+// and replies with its own membership).
+@ swim_join *SwimNode n s seed_host i seed_port → v {
+    : SwimMsg j ( __mk_msg n @ SwimMsgType { MtJoin } 0 `` 0 )
+    ( __node_send n seed_host seed_port j )
+    ( swim_msg_free j )
+}
+
+// Spawn the receiver + failure-detector fibers. Requires runtime_init /
+// runtime_run by the caller.
+@ swim_run *SwimNode n → v {
+    ( spawn \ → v { ( __recv_loop n ) } )
+    ( spawn \ → v { ( __fd_loop n ) } )
+}
+
+@ swim_stop *SwimNode n → v { = . n running 0 }


### PR DESCRIPTION
## Summary

Replaces the static peer list with **self-maintaining SWIM membership** (§7.2). As intended, the ambitious feature was the vehicle to flush out latent compiler miscompiles — it surfaced **two**, both fixed here with regression tests, bootstrap fixed point intact.

### `stdlib/std/swim.nu` (pure NURL)
Layered so the bug-dense parts are deterministic and unit-tested offline:
- **Binary wire codec** — `SwimMsg ⇄ bytes` (big-endian, over `std/bytes`). Round-trips values >2³¹ (port 65535, seq/incarnation >2³¹) with no signedness loss.
- **Member table + failure detector** — `Alive → Suspect → Dead`, incarnation refutation, gossip precedence; heap-shared so the protocol loop and inspectors observe one view.
- **Protocol** — UDP receiver + failure-detector fibers; periodic random PING/ACK with gossip piggyback; `swim_join` via a seed. (Indirect PING-REQ is in the wire format, driven by a follow-up.)

### Examples / tests
- `examples/swim.nu` — N-node cluster; kill a node and the survivors learn it's `dead` epidemically (live-verified 3 nodes).
- `compiler/tests/swim_codec.nu` + `swim_table.nu` (+goldens) — codec round-trip and the state machine, offline & deterministic.

## Compiler fix #1 — a parameter must shadow a same-named global `@`-fn
`gen_ident`'s "bare `@`-fn doesn't auto-coerce to a closure" check guarded on `__ptr` (local) / `__global` (const) but **not** `__param`, so a function parameter whose name collided with a global function misfired (only when both compiled together). Added the `__param` exclusion, mirroring the undefined-identifier check. **Regression:** `swim_table.nu` (param `pb` vs the test's `@ pb`).

## Compiler fix #2 — `! *T E` pointer Ok-payload miscompiled
A NURL `*Struct` lowers to `%Struct*` — leading `%` **and** trailing `*`. Both construction (`gen_agg_lit`) and reconstruction (`gen_match`) routed on the **leading** char, misclassifying the pointer as a by-value struct handle: construction heap-boxed it, reconstruction recovered nothing → the bound pointer was raw-i64 garbage (crash). Both now route on the **trailing `*`** (pointer) vs not (handle). **Regression:** `result_ptr_payload.nu`. This was the root cause of the SWIM `!*SwimNode NetErr` unwrap crash.

## Verification
- ✅ **364/364** suite green; **bootstrap fixed point holds** (both fixes touch codegen)
- ✅ 3-node SWIM live-verified: join via seed → gossip convergence → kill one → both survivors mark it `dead`
- ✅ codec / table / pointer-payload paths ASan-clean

## Follow-ups
Indirect PING-REQ (false-positive suppression); msgpack wire; fiber supervision. A general **call-argument type checker** would catch the silent miscompile class behind both fixes (and the dchannel pointer/value param mismatch) — the big open compiler project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)