### PR TITLE
feat(compiler): call-argument type checking — reject *T vs T value mismatch

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -3976,6 +3976,25 @@
     ^ res
 }
 
+// The arg_idx-th entry of a `;`-joined param-type-source list (empty when
+// out of range).
+@ __ptypes_nth s lst i idx → s {
+    : ~ s cur lst
+    : ~ i k 0
+    ~ < k idx { = cur ( seplist_rest cur ) = k + k 1 }
+    ^ ( seplist_first cur )
+}
+
+// A one-level pointer-depth mismatch on an identical base — `%X` vs `%X*`
+// (or `i8` vs `i8*`). This is exactly the "passed `*T` where a `T` value is
+// expected, or vice versa" miscompile class (the dchannel / SWIM family);
+// it has zero false positives because the bases must be byte-identical
+// apart from the single trailing `*`.
+@ __arg_ptr_depth_mismatch s at s pt → b {
+    ? | == 0 ( nurl_str_len at ) == 0 ( nurl_str_len pt ) { ^ F } {}
+    ^ | ( seq at ( nurl_str_cat pt `*` ) ) ( seq pt ( nurl_str_cat at `*` ) )
+}
+
 @ gen_call i lex i syms i cg → s {
     ( nurl_lex_advance lex )
     : s fname ( nurl_lex_val lex )
@@ -4315,6 +4334,32 @@
         ? & == arg_idx 0 ( seq fname `string_len` )
         { ? ( seq at `i8*` )
             { ( die lex `string_len expects %String, got 'i8*' (raw C-string). Use 'nurl_str_len' for raw C-string pointers.` ) }
+            {} }
+        {}
+        // General pointer-vs-value argument check. For a non-generic @-fn
+        // call (call_name == fname), compare this by-value argument's LLVM
+        // type against the declared parameter type (recorded as source in
+        // the pre-pass). Only a one-level pointer-depth mismatch on an
+        // identical base is flagged — `*T` passed where a `T` value is
+        // expected, or vice versa — the silent-miscompile class behind the
+        // dchannel / SWIM bugs. `inout` args legitimately pass `<T>*` and
+        // are skipped; generic callees (call_name ≠ fname) carry tparam
+        // sources and are skipped too.
+        ? & & ( seq call_name fname ) ! is_inout_arg
+        != 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat fname `__ptypes_src` ) ) )
+        { : s __psrc ( __ptypes_nth ( nurl_sym_get syms ( nurl_str_cat fname `__ptypes_src` ) ) arg_idx )
+            : b __at_ptr & > ( nurl_str_len at ) 0
+            == ( nurl_str_get at - ( nurl_str_len at ) 1 ) 42
+            : b __ps_ptr & > ( nurl_str_len __psrc ) 0 == ( nurl_str_get __psrc 0 ) 42
+            ? & != 0 ( nurl_str_len __psrc ) | __at_ptr __ps_ptr
+            { : i __plx ( nurl_lex_new __psrc `<param>` )
+                : s __pllvm ( parse_type __plx )
+                ? ( __arg_ptr_depth_mismatch at __pllvm )
+                { ( die lex ( nurl_str_cat3
+                    ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
+                    ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
+                    `' — pointer-vs-value mismatch (a '*T' was passed where a 'T' value is expected, or vice versa)` ) ) }
+                {} }
             {} }
         {}
         // Escape analysis (docs/MEMORY.md §2.3). If this
@@ -14329,6 +14374,11 @@
                                 : ~ b saw_inout F
                                 : ~ i pcount 0
                                 : ~ b pc_ok T
+                                // Per-parameter type SOURCE spans (`;`-joined),
+                                // captured here in the pre-pass so a forward call
+                                // can be argument-type-checked. Parsing to LLVM is
+                                // deferred to the call site (types resolved there).
+                                : ~ s ptypes_src ``
                                 ~ & & pc_ok != ( nurl_lex_type lex ) TT_ARROW
                                 != ( nurl_lex_type lex ) TT_EOF
                                 { ? & ( is_ident_tok ( nurl_lex_type lex ) )
@@ -14337,9 +14387,14 @@
                                         { = saw_inout T } {}
                                         ( nurl_lex_advance lex ) }
                                     {}
+                                    : i __pty_s ( nurl_lex_cur_start lex )
                                     ? == 0 ( scan_skip_type lex )
                                     { = pc_ok F }
-                                    { ? ( is_ident_tok ( nurl_lex_type lex ) )
+                                    { : i __pty_e ( nurl_lex_cur_start lex )
+                                        : s __pty ( nurl_lex_src_slice lex __pty_s - __pty_e __pty_s )
+                                        = ptypes_src ? == 0 ( nurl_str_len ptypes_src )
+                                        __pty ( nurl_str_cat3 ptypes_src `;` __pty )
+                                        ? ( is_ident_tok ( nurl_lex_type lex ) )
                                         { : s pnm ( nurl_lex_val lex )
                                             ( nurl_lex_advance lex )
                                             ( nurl_sym_def syms ( __kw_key fname `pn` pcount ) pnm )
@@ -14368,6 +14423,7 @@
                                 {}
                                 ? pc_ok
                                 { ( nurl_sym_def syms ( nurl_str_cat fname `__kw_n` ) ( nurl_str_int pcount ) )
+                                    ( nurl_sym_def syms ( nurl_str_cat fname `__ptypes_src` ) ptypes_src )
                                     : s ar_key ( nurl_str_cat fname `__arity` )
                                     : s ar_prev ( nurl_sym_get syms ar_key )
                                     : s ar_new ( nurl_str_int pcount )

--- a/compiler/tests/outputs/should_fail_ptr_value_arg.txt
+++ b/compiler/tests/outputs/should_fail_ptr_value_arg.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_ptr_value_arg.nu
+++ b/compiler/tests/should_fail_ptr_value_arg.nu
@@ -1,0 +1,14 @@
+// should_fail_ptr_value_arg.nu — the argument type checker must reject a
+// `*T` pointer passed where a `T` value parameter is expected (the
+// dchannel / SWIM silent-miscompile class). Without the check this
+// compiled to garbage (the callee read fields off the pointer's bits).
+
+: Box { i v }
+
+@ take Box b → i { ^ . b v }
+
+@ main → i {
+    : *Box p # *Box ( nurl_alloc Z Box )
+    = . p v 5
+    ^ ( take p )
+}


### PR DESCRIPTION
## Summary

nurlc did **no** argument-vs-parameter type checking — which is exactly why pointer/value confusions miscompiled **silently** (the dchannel `*T`-passed-where-a-value-param-was-expected hang, and the class generally). This adds the first stage of a real argument checker: a **pointer-depth check**, now a hard compile error.

### Mechanism
- **`scan_fn_sigs` pre-pass** records each `@`-fn's parameter **type source spans** into `<fname>__ptypes_src` (persists to call sites, so **forward calls** are covered). Parsing to LLVM is deferred to the call site where types are resolved.
- **`gen_call`** compares each by-value argument's LLVM type against the declared parameter type. Only a **one-level pointer-depth mismatch on a byte-identical base** is flagged — `%X` vs `%X*` (either direction) — the exact silent-miscompile class. **Zero false positives by construction.**
- **Guards:** skips generic callees (their param sources carry tparams) and `inout` args (which legitimately pass `<T>*`).

### Diagnostic
```
argument 1 to 'take': value of type '%Box*' passed where parameter expects '%Box' — pointer-vs-value mismatch (a '*T' was passed where a 'T' value is expected, or vice versa)
```
Regression test: `should_fail_ptr_value_arg.nu`.

## Verification
- ✅ **365/365** corpus green → **zero false positives** across the whole stdlib + tests + examples, and no pre-existing ptr-depth bugs (already fixed in earlier PRs)
- ✅ **Bootstrap fixed point holds** — nurlc compiles itself with the checker active (its own code is clean)
- ✅ Correct ptr→ptr and value→value passing is untouched (the pointer-heavy cluster/dchannel/swim code still compiles)

## Follow-up (deliberately separate — each needs its own WARN-mode FP-triage cycle)
- distinct named-struct handles by value (`%A` vs `%B`)
- `i8*` vs `%String` in general (currently only the `nurl_str_len`/`string_len` footgun is special-cased)
- **generic-callee** arg checking (needs tparam substitution — would catch the *actual* dchannel instance, which was a generic helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)