### PR TITLE
feat(supervisor): OTP-style fiber supervision (TODO §7.2)

### DIFF
--- a/compiler/tests/outputs/supervisor.txt
+++ b/compiler/tests/outputs/supervisor.txt
@@ -1,0 +1,16 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+transient: counter=4
+ restarts=3
+
+temporary: counter=1
+ restarts=0
+
+intensity: counter=3
+ restarts=3
+
+permanent
+transient
+temporary

--- a/compiler/tests/supervisor.nu
+++ b/compiler/tests/supervisor.nu
@@ -1,0 +1,78 @@
+// supervisor.nu — offline tests for stdlib/std/supervisor.nu.
+//
+// Deterministic: runs each child's supervision loop synchronously
+// (supervise_one, no fibers), with backoff 0 (no sleeping). Each child
+// captures a heap counter that survives restarts (the supervisor re-invokes
+// the same closure), so we can assert exactly how many times it ran and how
+// many restarts happened.
+//
+//   1. Transient child panics 3× then returns → restarted 3×, then stops.
+//   2. Temporary child panics → never restarted.
+//   3. Always-panicking child hits the restart-intensity cap → supervisor
+//      gives up after max_restarts.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/supervisor.nu`
+
+@ make_counter → *i {
+    : *i p # *i ( nurl_alloc Z i )
+    ( nurl_poke p 0 0 )
+    ^ p
+}
+
+@ report s label *i ctr Supervisor s2 → v {
+    ( nurl_print label )
+    ( nurl_print `counter=` ) ( nurl_print_int ( nurl_peek ctr 0 ) )
+    ( nurl_print ` restarts=` ) ( nurl_print_int ( child_restarts s2 0 ) )
+    ( nurl_print `\n` )
+}
+
+@ main → i {
+    // ── 1. Transient: panic until the 4th run, then succeed ──────
+    : *i c1 ( make_counter )
+    : Supervisor s1 ( supervisor_new 10 100000 )
+    ( supervisor_add s1 `flaky` @ RestartPolicy { RTransient }
+        \ → v {
+            : i n + 1 ( nurl_peek c1 0 )
+            ( nurl_poke c1 0 n )
+            ? < n 4 { ( panic `boom` ) } {}
+        } )
+    ( supervise_one s1 0 )
+    ( report `transient: ` c1 s1 )
+    ( supervisor_free s1 )
+    ( nurl_free # s c1 )
+
+    // ── 2. Temporary: a single panic is terminal ─────────────────
+    : *i c2 ( make_counter )
+    : Supervisor s2 ( supervisor_new 10 100000 )
+    ( supervisor_add s2 `oneshot` @ RestartPolicy { RTemporary }
+        \ → v {
+            : i n + 1 ( nurl_peek c2 0 )
+            ( nurl_poke c2 0 n )
+            ( panic `nope` )
+        } )
+    ( supervise_one s2 0 )
+    ( report `temporary: ` c2 s2 )
+    ( supervisor_free s2 )
+    ( nurl_free # s c2 )
+
+    // ── 3. Always crashes → restart-intensity cap (max 2) ────────
+    : *i c3 ( make_counter )
+    : Supervisor s3 ( supervisor_new 2 100000 )
+    ( supervisor_add s3 `hopeless` @ RestartPolicy { RPermanent }
+        \ → v {
+            : i n + 1 ( nurl_peek c3 0 )
+            ( nurl_poke c3 0 n )
+            ( panic `again` )
+        } )
+    ( supervise_one s3 0 )
+    ( report `intensity: ` c3 s3 )
+    ( supervisor_free s3 )
+    ( nurl_free # s c3 )
+
+    // ── policy names ─────────────────────────────────────────────
+    ( nurl_print_str ( restart_policy_name # RestartPolicy RPermanent ) )
+    ( nurl_print_str ( restart_policy_name # RestartPolicy RTransient ) )
+    ( nurl_print_str ( restart_policy_name # RestartPolicy RTemporary ) )
+    ^ 0
+}

--- a/examples/supervisor.nu
+++ b/examples/supervisor.nu
@@ -1,0 +1,68 @@
+// examples/supervisor.nu — OTP-style fiber supervision (TODO §7.2).
+//
+// Two worker fibers run under a one-for-one supervisor. "beta" panics on
+// its first attempt; the supervisor catches the crash and restarts it
+// (Transient policy), and the restarted run completes. "alpha" just runs
+// to completion. When both children have stopped, we print how many times
+// each was restarted.
+//
+//   ./nurl.sh examples/supervisor.nu
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/async.nu`
+$ `stdlib/std/supervisor.nu`
+
+@ make_counter → *i {
+    : *i p # *i ( nurl_alloc Z i )
+    ( nurl_poke p 0 0 )
+    ^ p
+}
+
+@ say s who s msg → v {
+    : String line ( string_from `  [` )
+    ( string_push_str line who )
+    ( string_push_str line `] ` )
+    ( string_push_str line msg )
+    ( string_push_char line 10 )
+    ( nurl_print ( string_data line ) )
+    ( string_free line )
+}
+
+@ main → i {
+    ( runtime_init 0 )
+    : Supervisor sup ( supervisor_new 5 100000 )
+
+    // alpha: runs once, cleanly.
+    ( supervisor_add sup `alpha` @ RestartPolicy { RTransient }
+        \ → v { ( say `alpha` `working… done` ) } )
+
+    // beta: crashes the first time, succeeds when restarted.
+    : *i bc ( make_counter )
+    ( supervisor_add sup `beta` @ RestartPolicy { RTransient }
+        \ → v {
+            : i n + 1 ( nurl_peek bc 0 )
+            ( nurl_poke bc 0 n )
+            ? == n 1 {
+                ( say `beta` `crashing on first attempt!` )
+                ( panic `beta failed` )
+            } {
+                ( say `beta` `recovered, working… done` )
+            }
+        } )
+
+    ( nurl_print `supervisor starting children…\n` )
+    ( supervisor_run sup )
+    ( runtime_run )
+
+    : String summary ( string_from `restarts — alpha: ` )
+    ( string_push_int summary ( child_restarts sup 0 ) )
+    ( string_push_str summary `, beta: ` )
+    ( string_push_int summary ( child_restarts sup 1 ) )
+    ( string_push_char summary 10 )
+    ( nurl_print ( string_data summary ) )
+
+    ( supervisor_free sup )
+    ( nurl_free # s bc )
+    ( runtime_shutdown )
+    ^ 0
+}

--- a/stdlib/std/supervisor.nu
+++ b/stdlib/std/supervisor.nu
@@ -1,0 +1,206 @@
+// stdlib/std/supervisor.nu — OTP-style fiber supervision.
+//
+// **Phase 2 (TODO §7.2)** resilience capstone — the missing piece of
+// "supervisointi + reconnect + backoff + circuit breaker" (backoff +
+// circuit breaker shipped with the cluster resilience layer). Modelled on
+// Erlang/OTP, which the roadmap notes is philosophically closest to NURL's
+// fibers-as-actors.
+//
+// A supervisor restarts child tasks that crash (panic) or, for permanent
+// children, that simply return. Each child is a `( @ v )` start closure;
+// the supervisor runs it under `recover`, and on a crash restarts it per
+// its RestartPolicy, with exponential backoff and a restart-intensity
+// limit (give up if a child restarts more than `max_restarts` times within
+// `window_ms`, so a hopeless child can't spin forever).
+//
+//   RPermanent — always restart (on crash AND on normal return)
+//   RTransient — restart only on a crash; a clean return stops it
+//   RTemporary — never restart
+//
+// Strategy: one-for-one (each child supervised independently). One-for-all
+// / rest-for-one are a follow-up.
+//
+// ── Child closures are RE-INVOKED on restart ─────────────────────────
+//
+// Unlike std/panic.nu's `recover` (which frees the closure env after one
+// call), the supervisor keeps the child's closure alive across restarts —
+// so a child MAY hold captured state that persists between restarts (e.g.
+// a retry counter, a connection handle). The env is released once, at
+// `supervisor_free`. A child body must therefore be safe to run more than
+// once.
+//
+// ── API ──────────────────────────────────────────────────────────────
+//
+//   ( supervisor_new i max_restarts i window_ms )      → Supervisor
+//   ( supervisor_add Supervisor s s name RestartPolicy p ( @ v ) start ) → v
+//   ( supervisor_run Supervisor s )                    → v   (spawns a fiber per child)
+//   ( supervise_one  Supervisor s i idx )              → v   (run one child's loop synchronously)
+//   ( child_restarts Supervisor s i idx )              → i
+//   ( supervisor_free Supervisor s )                   → v
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/async.nu`
+$ `stdlib/std/panic.nu`
+
+: | RestartPolicy {
+    RPermanent
+    RTransient
+    RTemporary
+}
+
+@ restart_policy_name RestartPolicy p → s {
+    ^ ?? p {
+        RPermanent → `permanent`
+        RTransient → `transient`
+        RTemporary → `temporary`
+    }
+}
+
+: ChildImpl {
+    String name
+    ( @ v ) start
+    RestartPolicy policy
+    i restarts
+}
+
+: ChildSpec { s ctl }
+
+: SupImpl {
+    ( Vec ChildSpec ) children
+    i max_restarts
+    i window_ms
+    i base_backoff_ms
+    i max_backoff_ms
+}
+
+: Supervisor { s ctl }
+
+@ supervisor_new i max_restarts i window_ms → Supervisor {
+    : *SupImpl sup # *SupImpl ( nurl_alloc Z SupImpl )
+    = . sup children ( vec_new [ChildSpec] )
+    = . sup max_restarts max_restarts
+    = . sup window_ms window_ms
+    = . sup base_backoff_ms 0
+    = . sup max_backoff_ms 1000
+    ^ @ Supervisor { # s sup }
+}
+
+// Tune the per-restart backoff (default 0 = restart immediately).
+@ supervisor_set_backoff Supervisor s i base_ms i max_ms → v {
+    : *SupImpl sup # *SupImpl . s ctl
+    = . sup base_backoff_ms base_ms
+    = . sup max_backoff_ms max_ms
+}
+
+@ supervisor_add Supervisor s s name RestartPolicy policy ( @ v ) start → v {
+    : *SupImpl sup # *SupImpl . s ctl
+    : *ChildImpl child # *ChildImpl ( nurl_alloc Z ChildImpl )
+    = . child name ( string_from name )
+    = . child start start
+    = . child policy policy
+    = . child restarts 0
+    ( vec_push [ChildSpec] . sup children @ ChildSpec { # s child } )
+}
+
+@ __child_at *SupImpl sup i idx → *ChildImpl {
+    ^ ?? ( vec_get [ChildSpec] . sup children idx ) {
+        T c → # *ChildImpl . c ctl
+        F → # *ChildImpl 0
+    }
+}
+
+// Run a child closure under panic recovery WITHOUT freeing its env — the
+// supervisor re-invokes the same closure on the next restart. (std/panic.nu's
+// `recover` frees the env, which would dangle on restart.)
+@ __sup_recover ( @ v ) closure → !v PanicInfo {
+    : *u fnp # *u closure 0
+    : *u env # *u closure 1
+    : i rv ( nurl_recover fnp env )
+    ? == rv 0 { ^ @ !v PanicInfo { T 0 } } {}
+    : String msg ( string_from ( nurl_panic_last_msg ) )
+    ^ @ !v PanicInfo { F @ PanicInfo { msg } }
+}
+
+@ __sup_grow i delay i cap → i {
+    : i n ? <= delay 0 1 * delay 2
+    ? > n cap { ^ cap } {}
+    ^ n
+}
+
+// Supervise one child: run → on stop, decide restart per policy + intensity.
+// Blocks until the child is no longer restarted.
+@ __supervise_loop *SupImpl sup *ChildImpl child → v {
+    : ~ b done F
+    : ~ i delay . sup base_backoff_ms
+    : ~ i win_start ( monotonic_ns )
+    : ~ i win_count 0
+    ~ ! done {
+        : ( @ v ) st . child start
+        : !v PanicInfo r ( __sup_recover st )
+        : ~ b crashed F
+        ?? r {
+            T _ → {}
+            F pi → { = crashed T ( panic_info_free pi ) }
+        }
+        : b restart_on_crash ?? . child policy { RTemporary → F  _ → T }
+        : b restart_on_exit  ?? . child policy { RPermanent → T  _ → F }
+        : b want_restart ? crashed restart_on_crash restart_on_exit
+        ? ! want_restart {
+            = done T
+        } {
+            = . child restarts + . child restarts 1
+            // Restart-intensity window: too many restarts too fast → give up.
+            : i now ( monotonic_ns )
+            ? > / - now win_start 1000000 . sup window_ms
+            { = win_start now  = win_count 0 } {}
+            = win_count + win_count 1
+            ? > win_count . sup max_restarts
+            { = done T }
+            { ( sleep_ms delay )
+                = delay ( __sup_grow delay . sup max_backoff_ms ) }
+        }
+    }
+}
+
+// Run one child's supervision loop synchronously (no fiber). Useful for
+// tests and single-child supervisors.
+@ supervise_one Supervisor s i idx → v {
+    : *SupImpl sup # *SupImpl . s ctl
+    : *ChildImpl child ( __child_at sup idx )
+    ( __supervise_loop sup child )
+}
+
+// Spawn a supervising fiber per child. Requires runtime_init / runtime_run
+// by the caller.
+@ supervisor_run Supervisor s → v {
+    : *SupImpl sup # *SupImpl . s ctl
+    : i n ( vec_len [ChildSpec] . sup children )
+    : ~ i k 0
+    ~ < k n {
+        : *ChildImpl child ( __child_at sup k )
+        ( spawn \ → v { ( __supervise_loop sup child ) } )
+        = k + k 1
+    }
+}
+
+@ child_restarts Supervisor s i idx → i {
+    : *SupImpl sup # *SupImpl . s ctl
+    : *ChildImpl child ( __child_at sup idx )
+    ^ . child restarts
+}
+
+@ supervisor_free Supervisor s → v {
+    : *SupImpl sup # *SupImpl . s ctl
+    : ( @ v ChildSpec ) freeing \ ChildSpec c → v {
+        : *ChildImpl ci # *ChildImpl . c ctl
+        ( string_free . ci name )
+        : ( @ v ) st . ci start
+        ( nurl_free # s # *u st 1 )
+        ( nurl_free # s ci )
+    }
+    ( vec_free_with [ChildSpec] . sup children freeing )
+    ( nurl_free # s # *u freeing 1 )
+    ( nurl_free # s sup )
+}


### PR DESCRIPTION
## Summary

Completes the §7.2 resilience item ("supervisointi + reconnect + backoff + circuit breaker" — backoff + circuit breaker shipped in #130; this adds **supervision**). A one-for-one supervisor restarts child tasks that crash, modelled on Erlang/OTP (which the roadmap notes is philosophically closest to NURL's fibers-as-actors).

### `stdlib/std/supervisor.nu`
- **`RestartPolicy`**: `RPermanent` (restart on crash AND clean return), `RTransient` (restart only on crash), `RTemporary` (never).
- `supervisor_new` / `supervisor_add` / `supervisor_run` (a supervising fiber per child) / `supervisor_free`; `supervise_one` (run one child's loop synchronously); `child_restarts`; `supervisor_set_backoff`.
- Failure handling via **`__sup_recover`** — like `std/panic.nu` `recover`, but it does **not** free the closure env, so a crashed child is **re-invoked** on restart with its captured state intact (env released once at `supervisor_free`).
- **Exponential backoff** between restarts + a **restart-intensity window**: give up if a child restarts more than `max_restarts` within `window_ms` (so a hopeless child can't spin forever).

### Examples / tests
- `examples/supervisor.nu` — two supervised worker fibers; "beta" panics on its first attempt and the supervisor catches it **inside the fiber** and restarts it (confirming `recover` works under the async runtime). Output: `restarts — alpha: 0, beta: 1`.
- `compiler/tests/supervisor.nu` (+golden) — deterministic offline coverage: Transient panics 3×→succeeds (restarts=3), Temporary single panic (restarts=0), always-panic hits the intensity cap (gives up).

## Verification
- ✅ **366/366** suite green
- ✅ Live: `recover` works inside spawned fibers (panic caught + child restarted)
- ✅ supervisor paths ASan-clean

## Leak fix found en route
A capture-less closure passed **inline** to `vec_free_with` still allocates an env that `vec_free_with` doesn't free — bind the closure and free its env afterward (`nurl_free # s # *u c 1`). Likely a latent pattern at other inline-`vec_free_with` sites (not chased here).

## Follow-ups
One-for-all / rest-for-one strategies; msgpack wire; SWIM indirect ping-req; trace-ID propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)