### PR TITLE
feat(cluster): msgpack binary wire — content-negotiated, opt-in (TODO §7.2)

### DIFF
--- a/compiler/tests/cluster_msgpack.nu
+++ b/compiler/tests/cluster_msgpack.nu
@@ -1,0 +1,75 @@
+// cluster_msgpack.nu — offline test for the msgpack wire format of
+// stdlib/ext/cluster.nu. No sockets: drives the full envelope path
+// (request → msgpack → dispatch → response → msgpack) in process. Uses a
+// value above 2^31 (3000000000) so any signedness error in the binary
+// int codec corrupts the round trip and fails the golden.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/cluster.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `true\n` `false\n` ) }
+
+@ main → i {
+    // ── wire toggle ──────────────────────────────────────────────
+    ( pb `default msgpack: ` ( cluster_wire_is_msgpack ) )
+    ( cluster_use_msgpack T )
+    ( pb `after toggle: ` ( cluster_wire_is_msgpack ) )
+
+    // ── registry with an echo handler ────────────────────────────
+    : Registry reg ( registry_new )
+    ( registry_register reg `echo`
+    \ Json a → !Json ClusterErr { ^ @ !Json ClusterErr { T ( json_clone a ) } } )
+
+    // ── request envelope { fn: echo, args: 3000000000 } ──────────
+    : Json req ( json_obj_new )
+    ( json_obj_set req `fn` ( json_str_lit `echo` ) )
+    ( json_obj_set req `args` ( json_int 3000000000 ) )
+
+    // request → msgpack → decode (the wire the server receives)
+    : !( Vec u ) MsgpackErr renc ( msgpack_encode req )
+    ( json_free req )
+    ?? renc {
+        T rbytes → {
+            ( nurl_print `req wire bytes: ` ) ( nurl_print_int ( vec_len [u] rbytes ) )
+            : !Json MsgpackErr rdec ( msgpack_decode rbytes )
+            ( vec_free [u] rbytes )
+            ?? rdec {
+                T reqj → {
+                    // dispatch → response envelope { ok, result }
+                    : Json env ( rpc_dispatch reg reqj )
+                    ( json_free reqj )
+                    // response → msgpack → decode (the wire the client receives)
+                    : !( Vec u ) MsgpackErr eenc ( msgpack_encode env )
+                    ( json_free env )
+                    ?? eenc {
+                        T ebytes → {
+                            : !Json MsgpackErr edec ( msgpack_decode ebytes )
+                            ( vec_free [u] ebytes )
+                            ?? edec {
+                                T env2 → {
+                                    : ?Json rj ( json_obj_get env2 `result` )
+                                    ?? rj {
+                                        T rv → {
+                                            ( nurl_print `result: ` )
+                                            ( nurl_print_int ( json_as_int rv ) )
+                                        }
+                                        F → ( nurl_print `no result\n` )
+                                    }
+                                    ( json_free env2 )
+                                }
+                                F → ( nurl_print `resp decode err\n` )
+                            }
+                        }
+                        F → ( nurl_print `resp encode err\n` )
+                    }
+                }
+                F → ( nurl_print `req decode err\n` )
+            }
+        }
+        F → ( nurl_print `req encode err\n` )
+    }
+
+    ( registry_free reg )
+    ^ 0
+}

--- a/compiler/tests/outputs/cluster_msgpack.txt
+++ b/compiler/tests/outputs/cluster_msgpack.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+default msgpack: false
+after toggle: true
+req wire bytes: 23
+result: 3000000000

--- a/examples/cluster_rpc.nu
+++ b/examples/cluster_rpc.nu
@@ -147,6 +147,7 @@ $ `stdlib/ext/cluster.nu`
     ( nurl_print `usage:\n` )
     ( nurl_print `  cluster_rpc server <port>\n` )
     ( nurl_print `  cluster_rpc client <port> [port ...]\n` )
+    ( nurl_print `  cluster_rpc client-mp <port> [port ...]   (binary msgpack wire)\n` )
     ^ 1
 }
 
@@ -163,7 +164,10 @@ $ `stdlib/ext/cluster.nu`
         ( string_free ps )
         ( run_server port )
     } {
-        ? != 0 ( nurl_str_eq m `client` ) {
+        ? | != 0 ( nurl_str_eq m `client` ) != 0 ( nurl_str_eq m `client-mp` ) {
+            // `client-mp` opts into the binary msgpack wire; the server
+            // auto-detects the Content-Type and replies in kind.
+            ? != 0 ( nurl_str_eq m `client-mp` ) { ( cluster_use_msgpack T ) } {}
             : ( Vec i ) ports ( vec_new [i] )
             : ~ i k 2
             ~ < k argc {

--- a/stdlib/ext/cluster.nu
+++ b/stdlib/ext/cluster.nu
@@ -71,6 +71,7 @@ $ `stdlib/std/net.nu`
 $ `stdlib/std/time.nu`
 $ `stdlib/std/rng.nu`
 $ `stdlib/ext/json.nu`
+$ `stdlib/ext/msgpack.nu`
 $ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
@@ -267,27 +268,63 @@ $ `stdlib/ext/http_server.nu`
 
 // ── HTTP glue ────────────────────────────────────────────────────────
 
+// Does the request carry a msgpack Content-Type?
+@ __req_is_msgpack HttpRequest req → b {
+    : ?String ct ( header_get . req headers `Content-Type` )
+    : ~ b mp F
+    ?? ct {
+        T cs → { = mp ( string_contains cs `msgpack` ) ( string_free cs ) }
+        F cs → { ( string_free cs ) }
+    }
+    ^ mp
+}
+
+// Decode the request body as Json per its Content-Type. None on failure.
+@ __req_decode b mp HttpRequest req → ?Json {
+    ? mp {
+        : !Json MsgpackErr d ( msgpack_decode . req body )
+        ^ ?? d { T j → @ ?Json { T j }  F _ → @ ?Json { F # Json 0 } }
+    } {}
+    : String bs ( bytes_to_str . req body )
+    : !Json JsonError d ( json_parse ( string_data bs ) )
+    ( string_free bs )
+    ^ ?? d { T j → @ ?Json { T j }  F _ → @ ?Json { F # Json 0 } }
+}
+
+// Build a response carrying `env` in the negotiated wire format.
+@ __resp_send b mp i status Json env → HttpResponse {
+    ? mp {
+        : HttpResponse r ( response_new status )
+        : !( Vec u ) MsgpackErr enc ( msgpack_encode env )
+        ?? enc {
+            T body → { ( response_set_body_bytes r body ) ( vec_free [u] body ) }
+            F _ → {}
+        }
+        ( response_set_header r `Content-Type` `application/msgpack` )
+        ^ r
+    } {}
+    ^ ( response_json status env )
+}
+
 @ registry_handler Registry r → ( @ HttpResponse HttpRequest ) {
     ^ \ HttpRequest req → HttpResponse {
-        : String bs ( bytes_to_str . req body )
-        : !Json JsonError pr ( json_parse ( string_data bs ) )
-        : HttpResponse resp ?? pr {
-            T reqj → {
-                : Json env ( rpc_dispatch r reqj )
-                ( json_free reqj )
-                : HttpResponse rp ( response_json 200 env )
+        : b mp ( __req_is_msgpack req )
+        : ?Json reqj ( __req_decode mp req )
+        ^ ?? reqj {
+            T rj → {
+                : Json env ( rpc_dispatch r rj )
+                ( json_free rj )
+                : HttpResponse rp ( __resp_send mp 200 env )
                 ( json_free env )
                 rp
             }
-            F _ → {
-                : Json env ( __rpc_err_env `bad request json` )
-                : HttpResponse rp ( response_json 400 env )
+            F → {
+                : Json env ( __rpc_err_env `bad request` )
+                : HttpResponse rp ( __resp_send mp 400 env )
                 ( json_free env )
                 rp
             }
         }
-        ( string_free bs )
-        ^ resp
     }
 }
 
@@ -480,11 +517,56 @@ $ `stdlib/ext/http_server.nu`
     }
 }
 
-// One transport attempt. `body` is BORROWED (reused across retries).
-@ __rpc_attempt s url s body → !Json ClusterErr {
-    : !Response HttpErr rr ( http_request_to `POST` url body
-    `Content-Type: application/json\r\n`
+// ── Wire format ──────────────────────────────────────────────────────
+//
+// JSON (text) by default; msgpack (binary) when opted in. Process-wide —
+// set once at startup before issuing calls. Only the CLIENT opts in: the
+// server auto-detects each request's Content-Type and replies in kind, so
+// a msgpack client and a JSON client can share one server.
+: ~ i g_cluster_wire 0
+
+@ cluster_use_msgpack b on → v { = g_cluster_wire ? on 1 0 }
+@ cluster_wire_is_msgpack → b { ^ != g_cluster_wire 0 }
+
+@ __rpc_send_json s url s body → !Response HttpErr {
+    ^ ( http_request_to `POST` url body `Content-Type: application/json\r\n`
     ( __cluster_timeout_ms ) ( __cluster_connect_ms ) )
+}
+
+@ __rpc_send_mp s url Json req → !Response HttpErr {
+    : !( Vec u ) MsgpackErr enc ( msgpack_encode req )
+    ^ ?? enc {
+        T body → {
+            : !Response HttpErr r2 ( http_request_bytes_to `POST` url body
+            `Content-Type: application/msgpack\r\n`
+            ( __cluster_timeout_ms ) ( __cluster_connect_ms ) )
+            ( vec_free [u] body )
+            r2
+        }
+        F _ → @ !Response HttpErr { F @ HttpErr { HttpOther } }
+    }
+}
+
+// Decode a response body as Json per the wire format. None on failure.
+@ __rpc_decode_resp b mp Response resp → ?Json {
+    ? mp {
+        : ( Vec u ) bb ( http_body_bytes resp )
+        : !Json MsgpackErr d ( msgpack_decode bb )
+        ( vec_free [u] bb )
+        ^ ?? d { T j → @ ?Json { T j }  F _ → @ ?Json { F # Json 0 } }
+    } {}
+    : !Json JsonError d ( json_parse ( http_body_str resp ) )
+    ^ ?? d { T j → @ ?Json { T j }  F _ → @ ?Json { F # Json 0 } }
+}
+
+// One transport attempt. `req` is BORROWED (re-serialized per retry).
+@ __rpc_attempt s url Json req → !Json ClusterErr {
+    : b mp ( cluster_wire_is_msgpack )
+    : String jbody ? mp ( string_new ) ( json_stringify req )
+    : ~ !Response HttpErr rr @ !Response HttpErr { F @ HttpErr { HttpOther } }
+    ? mp { = rr ( __rpc_send_mp url req ) }
+    { = rr ( __rpc_send_json url ( string_data jbody ) ) }
+    ( string_free jbody )
     ^ ?? rr {
         T resp → {
             : i st ( http_status resp )
@@ -492,14 +574,14 @@ $ `stdlib/ext/http_server.nu`
                 ( response_free resp )
                 @ !Json ClusterErr { F @ ClusterErr { ClBadResp } }
             } {
-                : !Json JsonError pr ( json_parse ( http_body_str resp ) )
-                : !Json ClusterErr out ?? pr {
+                : ?Json envo ( __rpc_decode_resp mp resp )
+                : !Json ClusterErr out ?? envo {
                     T env → {
                         : !Json ClusterErr r2 ( __rpc_extract_result env )
                         ( json_free env )
                         r2
                     }
-                    F _ → @ !Json ClusterErr { F @ ClusterErr { ClBadResp } }
+                    F → @ !Json ClusterErr { F @ ClusterErr { ClBadResp } }
                 }
                 ( response_free resp )
                 out
@@ -523,8 +605,6 @@ $ `stdlib/ext/http_server.nu`
     : Json req ( json_obj_new )
     ( json_obj_set req `fn` ( json_str_lit fn_id ) )
     ( json_obj_set req `args` args )
-    : String body ( json_stringify req )
-    ( json_free req )
 
     : String url ( __node_url n )
 
@@ -536,7 +616,7 @@ $ `stdlib/ext/http_server.nu`
     : ~ b have_result F
     : ~ i delay . pol base_delay_ms
     ~ & ! done < k max {
-        : !Json ClusterErr ar ( __rpc_attempt ( string_data url ) ( string_data body ) )
+        : !Json ClusterErr ar ( __rpc_attempt ( string_data url ) req )
         ?? ar {
             T r → {
                 = result r
@@ -562,7 +642,7 @@ $ `stdlib/ext/http_server.nu`
     }
 
     ( string_free url )
-    ( string_free body )
+    ( json_free req )
 
     ? have_result {
         ^ @ !Json ClusterErr { T result }


### PR DESCRIPTION
## Summary

Adds the binary-serialization option from §7.2 ("vaihda RPC-payloadit `ext/msgpack`iin"). The cluster RPC — and `dchannel`, which rides on it — can now speak **msgpack** instead of JSON on the wire: more compact, faster to parse.

### `stdlib/ext/cluster.nu`
- **Wire toggle** (process-wide): `cluster_use_msgpack(T)` / `cluster_wire_is_msgpack`. Only the **client** opts in.
- **Client:** `__rpc_attempt` re-serializes the request envelope per attempt and sends JSON (text, `http_request_to`) or msgpack (binary, `http_request_bytes_to`) with the matching `Content-Type`; the response is decoded per wire (`http_body_bytes`+`msgpack_decode` vs `http_body_str`+`json_parse`).
- **Server:** `registry_handler` is now **content-negotiated** — it detects the request's `Content-Type` and replies in the same format, so a msgpack client and a JSON client can share one server.

### Examples / tests
- `examples/cluster_rpc.nu` gains a `client-mp` mode (binary wire).
- `compiler/tests/cluster_msgpack.nu` (+golden) round-trips an envelope with a **>2³¹ value (3000000000) through msgpack twice** (request + response) — proving the binary int codec has no signedness corruption.

## Verification
- ✅ **367/367** suite green
- ✅ Live: one auto-detecting server served both the JSON `client` and the `client-mp` fan-out (both sum=385)
- ✅ ASan-clean
- ✅ Backward compatible — JSON remains the default

## Follow-ups
SWIM indirect ping-req; distributed trace-ID propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)