### PR TITLE
feat(trace): distributed trace-id propagation via W3C traceparent (§7.2)

### DIFF
--- a/compiler/tests/outputs/trace.txt
+++ b/compiler/tests/outputs/trace.txt
@@ -1,0 +1,20 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+hex(255)=00000000000000ff
+tp=00-00000000000000000000000012345678-00000000beefcafe-01
+parsed ok=1
+ trace=305419896
+ span=3203386110
+
+round-trip: true
+active (fresh): false
+active (set): true
+cur trace=305419896
+
+active (cleared): false
+tp(big)=00-0000000000000000ffffffffffffffff-ffffffffffffffff-01
+high-bit round-trip: true
+bad ok=0
+

--- a/compiler/tests/trace.nu
+++ b/compiler/tests/trace.nu
@@ -1,0 +1,48 @@
+// trace.nu — offline tests for stdlib/std/trace.nu: the W3C traceparent
+// format/parse round trip, hex rendering, and the current-context globals.
+// Deterministic (fixed ids, no randomness).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/trace.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `true\n` `false\n` ) }
+
+@ main → i {
+    // ── hex rendering ────────────────────────────────────────────
+    : String hx ( trace_hex16 255 )
+    ( nurl_print `hex(255)=` ) ( nurl_print ( string_data hx ) ) ( nurl_print `\n` )
+    ( string_free hx )
+
+    // ── format → parse round trip ────────────────────────────────
+    : i tid 305419896          // 0x12345678
+    : i sid 3203386110         // 0xBEEFCAFE
+    : String tp ( traceparent_format tid sid )
+    ( nurl_print `tp=` ) ( nurl_print ( string_data tp ) ) ( nurl_print `\n` )
+    : TraceParsed p ( traceparent_parse ( string_data tp ) )
+    ( string_free tp )
+    ( nurl_print `parsed ok=` ) ( nurl_print_int . p ok )
+    ( nurl_print ` trace=` ) ( nurl_print_int . p trace )
+    ( nurl_print ` span=` ) ( nurl_print_int . p span ) ( nurl_print `\n` )
+    ( pb `round-trip: ` & == . p trace tid == . p span sid )
+
+    // ── current-context globals ──────────────────────────────────
+    ( pb `active (fresh): ` ( trace_active ) )
+    ( trace_set tid sid )
+    ( pb `active (set): ` ( trace_active ) )
+    ( nurl_print `cur trace=` ) ( nurl_print_int ( trace_current_trace ) ) ( nurl_print `\n` )
+    ( trace_clear )
+    ( pb `active (cleared): ` ( trace_active ) )
+
+    // ── high-bit-set id (a NEGATIVE i64) must still round-trip ───
+    : i big - 0 1              // 0xffffffffffffffff
+    : String tpb ( traceparent_format big big )
+    ( nurl_print `tp(big)=` ) ( nurl_print ( string_data tpb ) ) ( nurl_print `\n` )
+    : TraceParsed hp ( traceparent_parse ( string_data tpb ) )
+    ( string_free tpb )
+    ( pb `high-bit round-trip: ` & & == . hp ok 1 == . hp trace big == . hp span big )
+
+    // ── malformed header rejected ────────────────────────────────
+    : TraceParsed bp ( traceparent_parse `not-a-traceparent` )
+    ( nurl_print `bad ok=` ) ( nurl_print_int . bp ok ) ( nurl_print `\n` )
+    ^ 0
+}

--- a/examples/cluster_trace.nu
+++ b/examples/cluster_trace.nu
@@ -1,0 +1,71 @@
+// examples/cluster_trace.nu — distributed trace-id propagation (TODO §7.2).
+//
+// The server registers `trace_echo`, a handler that returns the trace id
+// it is CURRENTLY running under — i.e. the id the client put in the
+// outgoing W3C `traceparent` header. The client starts a trace, calls the
+// server, and checks the id it gets back equals its own: proof the trace
+// propagated across the hop (the basis for correlating logs across a
+// fan-out without a central collector).
+//
+//   ./nurl.sh examples/cluster_trace.nu server 9700
+//   ./nurl.sh examples/cluster_trace.nu client 9700
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/async.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/std/trace.nu`
+$ `stdlib/ext/cluster.nu`
+
+@ run_server i port → i {
+    : Registry reg ( registry_new )
+    // Echo back the trace id this handler runs under (set from the
+    // incoming traceparent by registry_handler).
+    ( registry_register reg `trace_echo`
+    \ Json a → !Json ClusterErr { ^ @ !Json ClusterErr { T ( json_int ( trace_current_trace ) ) } } )
+    ( nurl_print `trace server on 127.0.0.1:` ) ( nurl_print_int port ) ( nurl_print `\n` )
+    : !v NetErr sr ( cluster_serve `127.0.0.1` port reg )
+    ?? sr { T _ → {} F _ → {} }
+    ( registry_free reg )
+    ^ 0
+}
+
+@ run_client i port → i {
+    ( trace_start )
+    : i mine ( trace_current_trace )
+    : String mh ( trace_hex16 mine )
+    ( nurl_print `client trace = ` ) ( nurl_print ( string_data mh ) ) ( nurl_print `\n` )
+    ( string_free mh )
+
+    : Node n ( node_new `127.0.0.1` port )
+    : !Json ClusterErr r ( call_remote n `trace_echo` ( json_null ) )
+    : i rc ?? r {
+        T res → {
+            : i seen ( json_as_int res )
+            ( json_free res )
+            : String sh ( trace_hex16 seen )
+            ( nurl_print `server saw  = ` ) ( nurl_print ( string_data sh ) ) ( nurl_print `\n` )
+            ( string_free sh )
+            ( nurl_print `propagated: ` )
+            ( nurl_print ? == seen mine `YES\n` `NO\n` )
+            0
+        }
+        F e → { ( nurl_print `call failed\n` ) 1 }
+    }
+    ( node_free n )
+    ^ rc
+}
+
+@ main → i {
+    : i argc ( env_args_count )
+    ? < argc 3 { ( nurl_print `usage: cluster_trace server|client <port>\n` ) ^ 1 } {}
+    : String mode ( env_arg 1 )
+    : String ps ( env_arg 2 )
+    : i port ( nurl_str_to_int ( string_data ps ) )
+    ( string_free ps )
+    : i rc ? != 0 ( nurl_str_eq ( string_data mode ) `server` )
+    ( run_server port )
+    ( run_client port )
+    ( string_free mode )
+    ^ rc
+}

--- a/stdlib/ext/cluster.nu
+++ b/stdlib/ext/cluster.nu
@@ -70,6 +70,7 @@ $ `stdlib/std/bytes.nu`
 $ `stdlib/std/net.nu`
 $ `stdlib/std/time.nu`
 $ `stdlib/std/rng.nu`
+$ `stdlib/std/trace.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/msgpack.nu`
 $ `stdlib/ext/http.nu`
@@ -306,11 +307,30 @@ $ `stdlib/ext/http_server.nu`
     ^ ( response_json status env )
 }
 
+// Adopt an incoming W3C traceparent (if present) as the current trace, so
+// any call the handler makes propagates the same trace id.
+@ __apply_incoming_trace HttpRequest req → v {
+    : ?String tph ( header_get . req headers `traceparent` )
+    ?? tph {
+        T h → {
+            : TraceParsed p ( traceparent_parse ( string_data h ) )
+            ( string_free h )
+            ? != 0 . p ok { ( trace_set . p trace . p span ) } {}
+        }
+        F h → { ( string_free h ) }
+    }
+}
+
 @ registry_handler Registry r → ( @ HttpResponse HttpRequest ) {
     ^ \ HttpRequest req → HttpResponse {
+        // Save + adopt the incoming trace context; restore it after dispatch
+        // so the worker fiber's trace state doesn't leak between requests.
+        : i __st ( trace_current_trace )
+        : i __ss ( trace_current_span )
+        ( __apply_incoming_trace req )
         : b mp ( __req_is_msgpack req )
         : ?Json reqj ( __req_decode mp req )
-        ^ ?? reqj {
+        : HttpResponse resp ?? reqj {
             T rj → {
                 : Json env ( rpc_dispatch r rj )
                 ( json_free rj )
@@ -325,6 +345,8 @@ $ `stdlib/ext/http_server.nu`
                 rp
             }
         }
+        ( trace_set __st __ss )
+        ^ resp
     }
 }
 
@@ -528,18 +550,39 @@ $ `stdlib/ext/http_server.nu`
 @ cluster_use_msgpack b on → v { = g_cluster_wire ? on 1 0 }
 @ cluster_wire_is_msgpack → b { ^ != g_cluster_wire 0 }
 
+// Build the request headers blob: Content-Type, plus a W3C `traceparent`
+// carrying the current trace id (a fresh child span per call) when a trace
+// is active — so a fan-out's hops share one trace id for log correlation.
+@ __rpc_headers s content_type → String {
+    : String h ( string_from `Content-Type: ` )
+    ( string_push_str h content_type )
+    ( string_push_str h `\r\n` )
+    ? ( trace_active ) {
+        ( string_push_str h `traceparent: ` )
+        : String tp ( traceparent_format ( trace_current_trace ) ( trace_new_span ) )
+        ( string_push_str h ( string_data tp ) )
+        ( string_free tp )
+        ( string_push_str h `\r\n` )
+    } {}
+    ^ h
+}
+
 @ __rpc_send_json s url s body → !Response HttpErr {
-    ^ ( http_request_to `POST` url body `Content-Type: application/json\r\n`
+    : String hdr ( __rpc_headers `application/json` )
+    : !Response HttpErr r ( http_request_to `POST` url body ( string_data hdr )
     ( __cluster_timeout_ms ) ( __cluster_connect_ms ) )
+    ( string_free hdr )
+    ^ r
 }
 
 @ __rpc_send_mp s url Json req → !Response HttpErr {
     : !( Vec u ) MsgpackErr enc ( msgpack_encode req )
     ^ ?? enc {
         T body → {
+            : String hdr ( __rpc_headers `application/msgpack` )
             : !Response HttpErr r2 ( http_request_bytes_to `POST` url body
-            `Content-Type: application/msgpack\r\n`
-            ( __cluster_timeout_ms ) ( __cluster_connect_ms ) )
+            ( string_data hdr ) ( __cluster_timeout_ms ) ( __cluster_connect_ms ) )
+            ( string_free hdr )
             ( vec_free [u] body )
             r2
         }

--- a/stdlib/std/trace.nu
+++ b/stdlib/std/trace.nu
@@ -1,0 +1,142 @@
+// stdlib/std/trace.nu — distributed tracing context (W3C traceparent).
+//
+// **Phase 2 (TODO §7.2) observability:** propagate a trace id across RPC
+// hops so logs from every node in a fan-out can be correlated — without a
+// collector like Jaeger. A node sets a "current" trace; ext/cluster.nu
+// injects it into outgoing calls as a W3C `traceparent` header and, on the
+// server, restores it for the handler's duration so nested calls carry the
+// SAME trace id (with fresh child spans).
+//
+// Ids are 64-bit here (rendered as the low half of a 128-bit W3C trace id;
+// the high half is zero-padded), kept in process-global i64s so there is no
+// String-global to manage. NOTE the current context is process-wide — fine
+// for a worker handling one request at a time; per-fiber context is a
+// follow-up.
+//
+//   ( trace_start )                 → v    begin a fresh root trace
+//   ( trace_set i tid i sid )       → v    adopt an (incoming) context
+//   ( trace_clear )                 → v
+//   ( trace_active )                → b
+//   ( trace_current_trace )         → i
+//   ( trace_current_span )          → i
+//   ( trace_new_span )              → i    a fresh span id (for one hop)
+//   ( trace_hex16 i v )             → String   16 lowercase hex digits
+//   ( traceparent_format i t i s )  → String   "00-<32hex>-<16hex>-01"
+//   ( traceparent_parse s hdr )     → TraceParsed
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/random.nu`
+
+: ~ i g_cur_trace 0
+: ~ i g_cur_span 0
+
+@ trace_active → b { ^ != g_cur_trace 0 }
+@ trace_current_trace → i { ^ g_cur_trace }
+@ trace_current_span → i { ^ g_cur_span }
+@ trace_new_span → i { ^ ( rand_u64 ) }
+
+@ trace_start → v {
+    = g_cur_trace ( rand_u64 )
+    = g_cur_span ( rand_u64 )
+}
+
+@ trace_set i tid i sid → v {
+    = g_cur_trace tid
+    = g_cur_span sid
+}
+
+@ trace_clear → v {
+    = g_cur_trace 0
+    = g_cur_span 0
+}
+
+@ __tr_hex_digit i n → i {
+    ? < n 10 { ^ + 48 n } {}
+    ^ + 87 n
+}
+
+// 16 lowercase hex digits of `v` (treated as a 64-bit pattern — the shift
+// is on u64 so a set top bit zero-fills instead of sign-extending).
+@ trace_hex16 i v → String {
+    : u64 uv # u64 v
+    : String s ( string_with_cap 16 )
+    : ~ i shift 60
+    ~ >= shift 0 {
+        : i nib # i & >> uv shift 15
+        ( string_push_char s ( __tr_hex_digit nib ) )
+        = shift - shift 4
+    }
+    ^ s
+}
+
+// W3C traceparent value: 00-<32hex trace-id>-<16hex span-id>-01. The
+// trace-id's high 64 bits are zero (we carry a 64-bit id in the low half).
+@ traceparent_format i tid i sid → String {
+    : String s ( string_from `00-0000000000000000` )
+    : String th ( trace_hex16 tid )
+    ( string_push_str s ( string_data th ) )
+    ( string_free th )
+    ( string_push_char s 45 )                // '-'
+    : String sh ( trace_hex16 sid )
+    ( string_push_str s ( string_data sh ) )
+    ( string_free sh )
+    ( string_push_str s `-01` )
+    ^ s
+}
+
+: TraceParsed {
+    i ok
+    i trace
+    i span
+}
+
+@ __tr_hex_val i c → i {
+    ? & >= c 48 <= c 57 { ^ - c 48 } {}        // 0-9
+    ? & >= c 97 <= c 102 { ^ - c 87 } {}       // a-f
+    ? & >= c 65 <= c 70 { ^ - c 55 } {}        // A-F
+    ^ - 0 1
+}
+
+@ __tr_is_hex i c → b {
+    ^ | | & >= c 48 <= c 57 & >= c 97 <= c 102 & >= c 65 <= c 70
+}
+
+// Are the `n` bytes of `src` from `off` all hex digits?
+@ __tr_all_hex s src i off i n → b {
+    : *u p # *u src
+    : ~ b ok T
+    : ~ i k 0
+    ~ & ok < k n {
+        ? ! ( __tr_is_hex # i . p + off k ) { = ok F } {}
+        = k + k 1
+    }
+    ^ ok
+}
+
+// Parse `n` hex digits of `src` from `off` → value. Assumes the span is
+// already validated as hex (the result may legitimately be a NEGATIVE i64
+// when the top bit is set — a 64-bit id, NOT an error; that is why parse
+// validity is checked separately, never via the sign).
+@ __tr_hex_parse s src i off i n → i {
+    : *u p # *u src
+    : ~ i v 0
+    : ~ i k 0
+    ~ < k n {
+        = v + * v 16 ( __tr_hex_val # i . p + off k )
+        = k + k 1
+    }
+    ^ v
+}
+
+// Parse a W3C traceparent header. Expects "00-<32hex>-<16hex>-01" (≥ 55
+// bytes); reads the trace id's LOW 16 hex (offset 19) and the 16-hex span
+// (offset 36). ok=0 when malformed (length or non-hex fields).
+@ traceparent_parse s hdr → TraceParsed {
+    : i n ( nurl_str_len hdr )
+    ? < n 55 { ^ @ TraceParsed { 0 0 0 } } {}
+    ? ! ( __tr_all_hex hdr 19 16 ) { ^ @ TraceParsed { 0 0 0 } } {}
+    ? ! ( __tr_all_hex hdr 36 16 ) { ^ @ TraceParsed { 0 0 0 } } {}
+    : i tid ( __tr_hex_parse hdr 19 16 )
+    : i sid ( __tr_hex_parse hdr 36 16 )
+    ^ @ TraceParsed { 1 tid sid }
+}


### PR DESCRIPTION
## Summary

Adds the observability item from §7.2: a **trace id propagates across cluster RPC hops**, so logs from every node in a fan-out can be correlated — Jaeger-free distributed tracing.

### `stdlib/std/trace.nu`
- Process-global current trace/span (i64): `trace_start` / `trace_set` / `trace_clear` / `trace_active` / `trace_current_*` / `trace_new_span`.
- `trace_hex16` (i64 → 16 hex via a u64 shift so a set top bit zero-fills), W3C `traceparent_format` (`00-<32hex>-<16hex>-01`, 64-bit id carried in the low half) and `traceparent_parse` → `TraceParsed`.

### `ext/cluster.nu`
- The **client** injects a `traceparent` header (current trace + a fresh child span) on every call when a trace is active.
- `registry_handler` saves the trace, **adopts the incoming `traceparent`**, dispatches, then restores it — so any call the handler makes carries the **same trace id**.

### Examples / tests
- `examples/cluster_trace.nu` — self-checking demo: the server echoes the trace id it ran under; the client starts a trace, calls, and confirms the returned id equals its own (**live-verified: propagated**).
- `compiler/tests/trace.nu` (+golden) — format/parse/hex/globals, including a **high-bit-set (negative i64) round trip**.

## The bug I hit (mine, fixed properly)
`traceparent_parse` rejected a valid 64-bit id whose top bit is set — it reads as a *negative* i64, and I'd overloaded "negative = error" (same `-1` the hex parser returned for a bad digit). curl with a small positive id worked; a random high-bit id from a NURL client gave `ok=0`. Fix: validate the hex digits separately (`__tr_all_hex`), then parse **any** bit pattern — never sign-check. (Helpers are `__tr_*`-prefixed to avoid colliding with `http_request.nu` / `encode.nu` hex helpers — global @-fn names.)

## Verification
- ✅ **369/369** suite; trace test ASan-clean
- ✅ Live NURL client→server: trace propagated (server saw the client's id)

## Follow-ups
One-for-all / rest-for-one supervision; SWIM false-positive-suppression demo (needs packet-loss simulation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)