### PR TITLE
feat(supervisor): OTP restart strategies — one-for-all / rest-for-one (§7.2)

### DIFF
--- a/compiler/tests/outputs/supervisor_strategy.txt
+++ b/compiler/tests/outputs/supervisor_strategy.txt
@@ -1,0 +1,19 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+one-for-all : a=2
+ b=2
+ c=2
+ stable=T
+one-for-one : a=1
+ b=2
+ c=1
+ stable=T
+rest-for-one: a=1
+ b=2
+ c=2
+ stable=T
+one-for-one
+one-for-all
+rest-for-one

--- a/compiler/tests/supervisor_strategy.nu
+++ b/compiler/tests/supervisor_strategy.nu
@@ -1,0 +1,61 @@
+// supervisor_strategy.nu — offline tests for the OTP restart strategies
+// (stdlib/std/supervisor.nu supervisor_start). Three children A, B, C;
+// B crashes on its first run then succeeds, A and C always succeed. Each
+// child counts its own runs, so the run counts after the group stabilises
+// distinguish the strategies:
+//
+//   one-for-all : B's crash restarts the WHOLE group → A=2 B=2 C=2
+//   one-for-one : only B restarts                    → A=1 B=2 C=1
+//   rest-for-one: B and everything after it restart  → A=1 B=2 C=2
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/supervisor.nu`
+
+@ mk0 → *i {
+    : *i p # *i ( nurl_alloc Z i )
+    ( nurl_poke p 0 0 )
+    ^ p
+}
+
+@ run_strategy s label SupStrategy st → v {
+    : *i ca ( mk0 )
+    : *i cb ( mk0 )
+    : *i cc ( mk0 )
+    : Supervisor sup ( supervisor_new 10 100000 )
+    ( supervisor_set_strategy sup st )
+    ( supervisor_add sup `a` @ RestartPolicy { RTransient }
+        \ → v { ( nurl_poke ca 0 + 1 ( nurl_peek ca 0 ) ) } )
+    ( supervisor_add sup `b` @ RestartPolicy { RTransient }
+        \ → v {
+            : i n + 1 ( nurl_peek cb 0 )
+            ( nurl_poke cb 0 n )
+            ? == n 1 { ( panic `b first run` ) } {}
+        } )
+    ( supervisor_add sup `c` @ RestartPolicy { RTransient }
+        \ → v { ( nurl_poke cc 0 + 1 ( nurl_peek cc 0 ) ) } )
+
+    : b stable ( supervisor_start sup )
+
+    ( nurl_print label )
+    ( nurl_print `: a=` ) ( nurl_print_int ( nurl_peek ca 0 ) )
+    ( nurl_print ` b=` ) ( nurl_print_int ( nurl_peek cb 0 ) )
+    ( nurl_print ` c=` ) ( nurl_print_int ( nurl_peek cc 0 ) )
+    ( nurl_print ` stable=` ) ( nurl_print ? stable `T` `F` )
+    ( nurl_print `\n` )
+
+    ( supervisor_free sup )
+    ( nurl_free # s ca )
+    ( nurl_free # s cb )
+    ( nurl_free # s cc )
+}
+
+@ main → i {
+    ( run_strategy `one-for-all ` @ SupStrategy { OneForAll } )
+    ( run_strategy `one-for-one ` @ SupStrategy { OneForOne } )
+    ( run_strategy `rest-for-one` @ SupStrategy { RestForOne } )
+
+    ( nurl_print_str ( sup_strategy_name # SupStrategy OneForOne ) )
+    ( nurl_print_str ( sup_strategy_name # SupStrategy OneForAll ) )
+    ( nurl_print_str ( sup_strategy_name # SupStrategy RestForOne ) )
+    ^ 0
+}

--- a/examples/supervisor_strategy.nu
+++ b/examples/supervisor_strategy.nu
@@ -1,0 +1,52 @@
+// examples/supervisor_strategy.nu — OTP restart strategies (TODO §7.2).
+//
+// A supervisor brings up three init tasks. "config" fails the first time
+// it runs; under the one-for-all strategy that crash restarts the WHOLE
+// group, so "db" and "cache" run again too. (Under one-for-one only
+// "config" would re-run; under rest-for-one, "config" and everything
+// started after it.) Switch the strategy below to watch the difference.
+//
+//   ./nurl.sh examples/supervisor_strategy.nu
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/supervisor.nu`
+
+@ mk0 → *i {
+    : *i p # *i ( nurl_alloc Z i )
+    ( nurl_poke p 0 0 )
+    ^ p
+}
+
+@ say s who → v {
+    : String l ( string_from `  starting ` )
+    ( string_push_str l who )
+    ( string_push_char l 10 )
+    ( nurl_print ( string_data l ) )
+    ( string_free l )
+}
+
+@ main → i {
+    : *i fails ( mk0 )
+    : Supervisor sup ( supervisor_new 5 100000 )
+    ( supervisor_set_strategy sup @ SupStrategy { OneForAll } )
+
+    ( supervisor_add sup `db` @ RestartPolicy { RTransient }
+        \ → v { ( say `db` ) } )
+    ( supervisor_add sup `config` @ RestartPolicy { RTransient }
+        \ → v {
+            : i n + 1 ( nurl_peek fails 0 )
+            ( nurl_poke fails 0 n )
+            ? == n 1 { ( nurl_print `  config CRASHED — one-for-all restarts the group\n` ) ( panic `config` ) }
+            { ( say `config` ) }
+        } )
+    ( supervisor_add sup `cache` @ RestartPolicy { RTransient }
+        \ → v { ( say `cache` ) } )
+
+    ( nurl_print `bringing up the group (one-for-all)…\n` )
+    : b stable ( supervisor_start sup )
+    ( nurl_print ? stable `group is up.\n` `gave up (restart intensity exceeded).\n` )
+
+    ( supervisor_free sup )
+    ( nurl_free # s fails )
+    ^ 0
+}

--- a/stdlib/std/supervisor.nu
+++ b/stdlib/std/supervisor.nu
@@ -58,6 +58,28 @@ $ `stdlib/std/panic.nu`
     }
 }
 
+// Restart strategy (OTP). When a child crashes, which children restart:
+//   OneForOne  — just that child.
+//   OneForAll  — the whole group (all children are terminated + restarted).
+//   RestForOne — that child plus every child started AFTER it (start order).
+: | SupStrategy {
+    OneForOne
+    OneForAll
+    RestForOne
+}
+
+@ sup_strategy_name SupStrategy s → s {
+    ^ ?? s {
+        OneForOne → `one-for-one`
+        OneForAll → `one-for-all`
+        RestForOne → `rest-for-one`
+    }
+}
+
+@ __strategy_code SupStrategy s → i {
+    ^ ?? s { OneForOne → 0  OneForAll → 1  RestForOne → 2 }
+}
+
 : ChildImpl {
     String name
     ( @ v ) start
@@ -73,6 +95,7 @@ $ `stdlib/std/panic.nu`
     i window_ms
     i base_backoff_ms
     i max_backoff_ms
+    i strategy           // SupStrategy code (0/1/2); used by supervisor_start
 }
 
 : Supervisor { s ctl }
@@ -84,7 +107,13 @@ $ `stdlib/std/panic.nu`
     = . sup window_ms window_ms
     = . sup base_backoff_ms 0
     = . sup max_backoff_ms 1000
+    = . sup strategy 0
     ^ @ Supervisor { # s sup }
+}
+
+@ supervisor_set_strategy Supervisor s SupStrategy st → v {
+    : *SupImpl sup # *SupImpl . s ctl
+    = . sup strategy ( __strategy_code st )
 }
 
 // Tune the per-restart backoff (default 0 = restart immediately).
@@ -170,6 +199,106 @@ $ `stdlib/std/panic.nu`
     : *SupImpl sup # *SupImpl . s ctl
     : *ChildImpl child ( __child_at sup idx )
     ( __supervise_loop sup child )
+}
+
+// ── Strategy-driven synchronous group start ──────────────────────────
+//
+// supervisor_start runs all children to a stable state, applying the
+// supervisor's RestartStrategy when one crashes. Each "run" invokes a
+// child's start closure once (under recover); a child that returns is up,
+// a child that panics is down. On a crash the strategy decides which
+// children re-run on the next pass — OneForOne re-runs just the crashed
+// ones, OneForAll the whole group, RestForOne the crashed-and-after. This
+// is the model for supervising finite/startup tasks (init order, batch
+// workers); long-running children use supervisor_run (concurrent fibers).
+// Returns T once the group is stable, F if the restart-intensity cap
+// (max_restarts passes) is exceeded.
+
+// Run child `idx` once under panic recovery. Returns T on clean return,
+// F on a crash (and bumps the child's restart counter).
+@ __run_child_once *SupImpl sup i idx → b {
+    : *ChildImpl child ( __child_at sup idx )
+    : ( @ v ) cl . child start
+    : !v PanicInfo r ( __sup_recover cl )
+    ^ ?? r {
+        T _ → T
+        F pi → {
+            ( panic_info_free pi )
+            = . child restarts + . child restarts 1
+            F
+        }
+    }
+}
+
+@ __min_idx ( Vec i ) v → i {
+    : i n ( vec_len [i] v )
+    : ~ i lo ?? ( vec_get [i] v 0 ) { T x → x  F → 0 }
+    : ~ i k 1
+    ~ < k n {
+        ?? ( vec_get [i] v k ) { T x → ? < x lo { = lo x } {} F → {} }
+        = k + k 1
+    }
+    ^ lo
+}
+
+// The set of children to (re)run next, given the crashed set + strategy.
+@ __next_runset i st ( Vec i ) crashed i n → ( Vec i ) {
+    : ( Vec i ) out ( vec_new [i] )
+    ? == st 1 {                          // OneForAll → whole group
+        : ~ i k 0
+        ~ < k n { ( vec_push [i] out k ) = k + k 1 }
+    } {
+        ? == st 2 {                      // RestForOne → min(crashed)..n
+            : ~ i k ( __min_idx crashed )
+            ~ < k n { ( vec_push [i] out k ) = k + k 1 }
+        } {                              // OneForOne → just the crashed
+            : i cn ( vec_len [i] crashed )
+            : ~ i k 0
+            ~ < k cn {
+                ?? ( vec_get [i] crashed k ) { T x → ( vec_push [i] out x ) F → {} }
+                = k + k 1
+            }
+        }
+    }
+    ^ out
+}
+
+@ supervisor_start Supervisor s → b {
+    : *SupImpl sup # *SupImpl . s ctl
+    : i n ( vec_len [ChildSpec] . sup children )
+
+    : ~ ( Vec i ) runset ( vec_new [i] )
+    : ~ i init 0
+    ~ < init n { ( vec_push [i] runset init ) = init + init 1 }
+
+    : ~ i passes 0
+    : ~ b stable F
+    : ~ b ok T
+    ~ ! stable {
+        : ( Vec i ) crashed ( vec_new [i] )
+        : ~ i ri 0
+        ~ < ri ( vec_len [i] runset ) {
+            : i idx ?? ( vec_get [i] runset ri ) { T x → x  F → 0 }
+            ? ! ( __run_child_once sup idx ) { ( vec_push [i] crashed idx ) } {}
+            = ri + ri 1
+        }
+        ? == ( vec_len [i] crashed ) 0 {
+            = stable T
+        } {
+            = passes + passes 1
+            ? > passes . sup max_restarts {
+                = stable T
+                = ok F
+            } {
+                : ( Vec i ) nxt ( __next_runset . sup strategy crashed n )
+                ( vec_free [i] runset )
+                = runset nxt
+            }
+        }
+        ( vec_free [i] crashed )
+    }
+    ( vec_free [i] runset )
+    ^ ok
 }
 
 // Spawn a supervising fiber per child. Requires runtime_init / runtime_run


### PR DESCRIPTION
## Summary

Adds the OTP restart **strategies** to the supervisor — the per-child one-for-one fiber path shipped in #134; this adds the group-coordinated strategies.

### `stdlib/std/supervisor.nu`
- `SupStrategy { OneForOne, OneForAll, RestForOne }` + `sup_strategy_name`; `supervisor_set_strategy`.
- **`supervisor_start Supervisor → b`** — a synchronous, strategy-driven group start for finite / startup tasks (init order, batch workers). Runs every child in the current runset once (under `recover`); on crashes, the strategy picks who re-runs next:
  - **OneForOne** — just the crashed child(ren)
  - **OneForAll** — the whole group
  - **RestForOne** — the crashed child and everything started after it

  Repeats until the group is stable, or gives up after `max_restarts` passes (returns `F`).

**Design note:** NURL fibers are cooperative (no preemption), so faithfully *terminating a healthy running sibling* isn't possible concurrently. Hence strategies use a synchronous run-to-stable model — each pass re-invokes the runset, so "the rest" is meaningful and the three strategies are genuinely distinct. Long-running children keep using the concurrent `supervisor_run` (one-for-one fibers).

### Examples / tests
- `compiler/tests/supervisor_strategy.nu` (+golden) — children A, B, C with B crashing once; the run counts distinguish the strategies cleanly: **one-for-all 2/2/2, one-for-one 1/2/1, rest-for-one 1/2/2**.
- `examples/supervisor_strategy.nu` — one-for-all demo (no sockets): a config task crashes, the whole group restarts.

## Verification
- ✅ suite green; `supervisor_strategy` ASan-clean
- ✅ All three strategies deterministically distinguished

## Follow-ups
Cooperative-stop for concurrent strategy supervision of long-running children; §7.3 wire-protocol versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)