### PR TITLE
feat(net): transport session — counter nonce + sliding replay window (§7.4 Phase 0)

### DIFF
--- a/compiler/tests/noise_session.nu
+++ b/compiler/tests/noise_session.nu
@@ -1,0 +1,106 @@
+// noise_session.nu — offline test for stdlib/net/session.nu. Keys come from a
+// real (random) Noise handshake, so we assert outcomes (accept/reject,
+// plaintext match), which are deterministic regardless of the key bytes:
+//   * in-order messages decrypt to the original plaintext
+//   * a replayed datagram is rejected (sliding-window dedup)
+//   * out-of-order delivery within the window is accepted
+//   * a tampered ciphertext fails authentication
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/crypto.nu`
+$ `stdlib/net/noise.nu`
+$ `stdlib/net/session.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a )
+    ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n {
+        : i x ?? ( vec_get [u] a k ) { T t → # i t F → -1 }
+        : i y ?? ( vec_get [u] b k ) { T t → # i t F → -2 }
+        ? != x y { = e F } {}
+        = k + k 1
+    }
+    ^ e
+}
+
+@ mkpt s text → ( Vec u ) {
+    : ( Vec u ) v ( vec_new [u] )
+    ( bytes_extend_str v text )
+    ^ v
+}
+
+@ k32 i b → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] 32 )
+    : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u b ) = k + k 1 }
+    ^ v
+}
+
+// open + check accept AND plaintext == expected; frees the result.
+@ open_eq *NoiseSession rx i ctr ( Vec u ) ad Sealed s ( Vec u ) expect → b {
+    : ?( Vec u ) r ( session_open rx ctr ad . s ct )
+    ^ ?? r { T pt → { : b ok ( veq pt expect ) ( vec_free [u] pt ) ok } F → F }
+}
+
+@ open_rejected *NoiseSession rx i ctr ( Vec u ) ad ( Vec u ) ct → b {
+    : ?( Vec u ) r ( session_open rx ctr ad ct )
+    ^ ?? r { T pt → { ( vec_free [u] pt ) F } F → T }   // T = correctly rejected
+}
+
+@ main → i {
+    // establish keys via a real handshake
+    : CryptoKeypair rkp ?? ( x25519_keygen ) { T k → k F _ → @ CryptoKeypair { ( vec_new [u] ) ( vec_new [u] ) } }
+    : CryptoKeypair ikp ?? ( x25519_keygen ) { T k → k F _ → @ CryptoKeypair { ( vec_new [u] ) ( vec_new [u] ) } }
+    : ( Vec u ) psk ( k32 9 )
+    : *Handshake ih ( noise_init T ikp . rkp pk psk )
+    : *Handshake rh ( noise_init F rkp . rkp pk psk )
+    : ( Vec u ) m1 ( noise_write_msg1 ih )
+    : !v NoiseErr _r1 ( noise_read_msg1 rh m1 )
+    : ( Vec u ) m2 ( noise_write_msg2 rh )
+    : !v NoiseErr _r2 ( noise_read_msg2 ih m2 )
+    : NoiseKeys ik ( noise_split ih )
+    : NoiseKeys rk ( noise_split rh )
+
+    : *NoiseSession tx ( session_new ik )    // initiator sends
+    : *NoiseSession rx ( session_new rk )    // responder receives
+    : ( Vec u ) ad ( vec_new [u] )
+
+    : ( Vec u ) p0 ( mkpt `frame-0` )
+    : ( Vec u ) p1 ( mkpt `frame-1` )
+    : ( Vec u ) p2 ( mkpt `frame-2` )
+    : ( Vec u ) p3 ( mkpt `frame-3` )
+
+    : Sealed s0 ( session_seal tx ad p0 )
+    : Sealed s1 ( session_seal tx ad p1 )
+    : Sealed s2 ( session_seal tx ad p2 )
+    : Sealed s3 ( session_seal tx ad p3 )
+
+    ( pb `in-order 0: ` ( open_eq rx . s0 counter ad s0 p0 ) )
+    ( pb `in-order 1: ` ( open_eq rx . s1 counter ad s1 p1 ) )
+    ( pb `replay 0 rejected: ` ( open_rejected rx . s0 counter ad . s0 ct ) )
+
+    // out-of-order within window: deliver 3 before 2
+    ( pb `reorder 3 then 2: ` & ( open_eq rx . s3 counter ad s3 p3 ) ( open_eq rx . s2 counter ad s2 p2 ) )
+
+    // tampered ciphertext (flip first byte) fails auth
+    : ( Vec u ) p4 ( mkpt `frame-4` )
+    : Sealed s4 ( session_seal tx ad p4 )
+    : ( Vec u ) bad ( vec_new [u] )
+    ( vec_extend [u] bad . s4 ct )
+    ?? ( vec_get [u] bad 0 ) { T b0 → ( vec_set [u] bad 0 # u + & # i b0 1 1 ) F → {} }
+    ( pb `tamper rejected: ` ( open_rejected rx . s4 counter ad bad ) )
+
+    ( vec_free [u] m1 ) ( vec_free [u] m2 )
+    ( noise_keys_free ik ) ( noise_keys_free rk )
+    ( noise_free ih ) ( noise_free rh )
+    ( session_free tx ) ( session_free rx )
+    ( sealed_free s0 ) ( sealed_free s1 ) ( sealed_free s2 ) ( sealed_free s3 ) ( sealed_free s4 )
+    ( vec_free [u] ad ) ( vec_free [u] psk ) ( vec_free [u] bad )
+    ( vec_free [u] p0 ) ( vec_free [u] p1 ) ( vec_free [u] p2 ) ( vec_free [u] p3 ) ( vec_free [u] p4 )
+    ( vec_free [u] . rkp sk ) ( vec_free [u] . rkp pk )
+    ( vec_free [u] . ikp sk ) ( vec_free [u] . ikp pk )
+    ^ 0
+}

--- a/compiler/tests/outputs/noise_session.txt
+++ b/compiler/tests/outputs/noise_session.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+in-order 0: YES
+in-order 1: YES
+replay 0 rejected: YES
+reorder 3 then 2: YES
+tamper rejected: YES

--- a/stdlib/net/noise.nu
+++ b/stdlib/net/noise.nu
@@ -63,7 +63,7 @@ $ `stdlib/ext/crypto.nu`
 
 // 12-byte ChaChaPoly nonce per Noise: 4 zero bytes then the 64-bit counter
 // little-endian.
-@ __noise_nonce i n → ( Vec u ) {
+@ noise_nonce i n → ( Vec u ) {
     : ( Vec u ) v ( vec_with_cap [u] 12 )
     : ~ i z 0
     ~ < z 4 { ( vec_push [u] v # u 0 ) = z + z 1 }
@@ -156,7 +156,7 @@ $ `stdlib/ext/crypto.nu`
         ( __sym_mix_hash s pt )
         ^ ( __slice pt 0 ( vec_len [u] pt ) )
     } {}
-    : ( Vec u ) nonce ( __noise_nonce . s nonce )
+    : ( Vec u ) nonce ( noise_nonce . s nonce )
     : ( Vec u ) ct ?? ( chacha20poly1305_encrypt . s k nonce . s h pt )
     { T x → x  F _ → ( vec_new [u] ) }
     ( vec_free [u] nonce )
@@ -171,7 +171,7 @@ $ `stdlib/ext/crypto.nu`
         ( __sym_mix_hash s ct )
         ^ @ !( Vec u ) NoiseErr { T ( __slice ct 0 ( vec_len [u] ct ) ) }
     } {}
-    : ( Vec u ) nonce ( __noise_nonce . s nonce )
+    : ( Vec u ) nonce ( noise_nonce . s nonce )
     : !( Vec u ) CryptoErr dr ( chacha20poly1305_decrypt . s k nonce . s h ct )
     ( vec_free [u] nonce )
     ^ ?? dr {

--- a/stdlib/net/session.nu
+++ b/stdlib/net/session.nu
@@ -1,0 +1,101 @@
+// stdlib/net/session.nu — post-handshake transport session.
+//
+// **Phase 0 of TODO §7.4**, on top of net/noise.nu. After the Noise
+// handshake yields a send/recv key pair, a NoiseSession encrypts/decrypts
+// datagrams with a per-direction 64-bit counter nonce and rejects replays
+// + duplicates via a WireGuard-style sliding window (accepts reordering
+// within the window — important on lossy/mobile UDP).
+//
+//   ( session_new NoiseKeys k )                  → *NoiseSession  (copies keys)
+//   ( session_seal *NoiseSession (Vec u) ad (Vec u) pt ) → Sealed { counter, ct }
+//   ( session_open *NoiseSession i counter (Vec u) ad (Vec u) ct ) → ?(Vec u)
+//        None = AEAD auth failure OR replay/duplicate/too-old.
+//   ( session_free *NoiseSession )               → v
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/crypto.nu`
+$ `stdlib/net/noise.nu`
+
+: NoiseSession {
+    ( Vec u ) send_key
+    ( Vec u ) recv_key
+    i send_n
+    i recv_max     // highest accepted recv counter (-1 = none yet)
+    i recv_mask    // 64-bit window; bit 0 = recv_max, bit k = recv_max-k
+}
+
+@ __vcopy ( Vec u ) v → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
+    ( vec_extend [u] o v )
+    ^ o
+}
+
+@ session_new NoiseKeys k → *NoiseSession {
+    : *NoiseSession s # *NoiseSession ( nurl_alloc Z NoiseSession )
+    = . s send_key ( __vcopy . k send )
+    = . s recv_key ( __vcopy . k recv )
+    = . s send_n 0
+    = . s recv_max - 0 1
+    = . s recv_mask 0
+    ^ s
+}
+
+@ session_free *NoiseSession s → v {
+    ( vec_free [u] . s send_key )
+    ( vec_free [u] . s recv_key )
+    ( nurl_free # s s )
+}
+
+: Sealed {
+    i counter
+    ( Vec u ) ct
+}
+
+@ sealed_free Sealed s → v { ( vec_free [u] . s ct ) }
+
+@ session_seal *NoiseSession s ( Vec u ) ad ( Vec u ) pt → Sealed {
+    : i ctr . s send_n
+    : ( Vec u ) nonce ( noise_nonce ctr )
+    : ( Vec u ) ct ?? ( chacha20poly1305_encrypt . s send_key nonce ad pt )
+    { T x → x  F _ → ( vec_new [u] ) }
+    ( vec_free [u] nonce )
+    = . s send_n + . s send_n 1
+    ^ @ Sealed { ctr ct }
+}
+
+// Sliding-window replay check + commit. Returns T (accept) only for a
+// counter not already seen and not older than the 64-wide window. Mutates
+// the window on accept. Call ONLY after a successful AEAD decrypt.
+@ __replay_ok *NoiseSession s i c → b {
+    : i mx . s recv_max
+    ? > c mx {
+        : i shift - c mx
+        ? >= shift 64 { = . s recv_mask 1 }
+        { = . s recv_mask | << . s recv_mask shift 1 }
+        = . s recv_max c
+        ^ T
+    } {}
+    : i diff - mx c
+    ? >= diff 64 { ^ F } {}
+    : i bit << 1 diff
+    ? != 0 & . s recv_mask bit { ^ F } {}
+    = . s recv_mask | . s recv_mask bit
+    ^ T
+}
+
+@ session_open *NoiseSession s i counter ( Vec u ) ad ( Vec u ) ct → ?( Vec u ) {
+    : ( Vec u ) nonce ( noise_nonce counter )
+    : !( Vec u ) CryptoErr dr ( chacha20poly1305_decrypt . s recv_key nonce ad ct )
+    ( vec_free [u] nonce )
+    ^ ?? dr {
+        T pt → {
+            ? ( __replay_ok s counter ) {
+                @ ?( Vec u ) { T pt }
+            } {
+                ( vec_free [u] pt )
+                @ ?( Vec u ) { F # ( Vec u ) 0 }
+            }
+        }
+        F _ → @ ?( Vec u ) { F # ( Vec u ) 0 }
+    }
+}


### PR DESCRIPTION
## Summary

Second Phase-0 piece of the NAT/mobile transport (§7.4), on top of `net/noise.nu`. `stdlib/net/session.nu` turns the handshake's send/recv keys into a datagram **transport session**:

- **`session_seal`** → ChaCha20-Poly1305 with a 64-bit **counter nonce** (reuses `noise_nonce`, now public), bumping the send counter; returns `Sealed{counter, ct}`.
- **`session_open`** → decrypts, then a **WireGuard-style 64-bit sliding window** rejects replays / duplicates / too-old counters while **accepting reordering** within the window (important on lossy mobile UDP). The window is committed only after a successful AEAD decrypt.

## Verification
`compiler/tests/noise_session.nu` — keys come from a real (random) Noise handshake, so it asserts **outcomes**:
- ✅ in-order frames decrypt to the original plaintext
- ✅ a replayed datagram is rejected
- ✅ out-of-order delivery within the window is accepted
- ✅ a tampered ciphertext fails authentication
- ✅ ASan-clean; **372/372** suite

## Notes
- `noise_nonce` was made public in `net/noise.nu` so the session builds the same 12-byte ChaCha nonce.
- Test naming gotcha: the runner skips `net_*` tests (network-dependent convention); this pure-crypto test is `noise_session.nu`.

## Next Phase-0
`Peer{pubkey, endpoint}` table + the roaming rule + the UDP `send_to(pubkey)`/`recv()` API (`net/securedgram.nu`), wiring noise + session over `std/udp` — live-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)