### PR TITLE
feat(net): DERP-style relay — opaque pubkey-addressed forwarding (§7.4 Phase 2)

### DIFF
--- a/compiler/tests/outputs/relay_codec.txt
+++ b/compiler/tests/outputs/relay_codec.txt
@@ -1,0 +1,14 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+register frame len: 37
+register type: YES
+register body == pubkey: YES
+forward type: YES
+forward dest pk split: YES
+forward payload split: YES
+deliver type: YES
+deliver src pk split: YES
+incomplete → None: YES
+oversize → None: YES

--- a/compiler/tests/relay_codec.nu
+++ b/compiler/tests/relay_codec.nu
@@ -1,0 +1,95 @@
+// relay_codec.nu — offline test for stdlib/net/relay.nu frame codec.
+// Deterministic, no sockets: builds REGISTER / FORWARD / DELIVER frames and
+// parses them back, checks the pubkey/payload split, and that an incomplete
+// or oversize buffer parses to None.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/relay.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ bytes i seed i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_new [u] )
+    : ~ i k 0 ~ < k n { ( vec_push [u] v # u + seed k ) = k + k 1 }
+    ^ v
+}
+
+@ veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a )
+    ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n {
+        : i x ?? ( vec_get [u] a k ) { T t → # i t F → -1 }
+        : i y ?? ( vec_get [u] b k ) { T t → # i t F → -2 }
+        ? != x y { = e F } {}
+        = k + k 1
+    }
+    ^ e
+}
+
+@ main → i {
+    : ( Vec u ) pk   ( bytes 100 32 )    // a 32-byte pubkey
+    : ( Vec u ) data ( bytes 1 40 )      // opaque payload
+
+    // ── REGISTER ─────────────────────────────────────────────────
+    : ( Vec u ) reg ( relay_build_register pk )
+    ( nurl_print `register frame len: ` ) ( nurl_print_int ( vec_len [u] reg ) )   // 1+4+32 = 37
+    : ?RelayFrame rf ( relay_parse reg )
+    ?? rf {
+        T f → {
+            ( pb `register type: ` == . f ftype ( relay_reg ) )
+            ( pb `register body == pubkey: ` ( veq . f body pk ) )
+            ( relay_frame_free f )
+        }
+        F → ( nurl_print `register parse failed\n` )
+    }
+
+    // ── FORWARD ──────────────────────────────────────────────────
+    : ( Vec u ) fwd ( relay_build_forward pk data )
+    : ?RelayFrame ff ( relay_parse fwd )
+    ?? ff {
+        T f → {
+            ( pb `forward type: ` == . f ftype ( relay_fwd ) )
+            : ( Vec u ) dpk ( relay_body_pk . f body )
+            : ( Vec u ) dpl ( relay_body_payload . f body )
+            ( pb `forward dest pk split: ` ( veq dpk pk ) )
+            ( pb `forward payload split: ` ( veq dpl data ) )
+            ( vec_free [u] dpk ) ( vec_free [u] dpl )
+            ( relay_frame_free f )
+        }
+        F → ( nurl_print `forward parse failed\n` )
+    }
+
+    // ── DELIVER ──────────────────────────────────────────────────
+    : ( Vec u ) del ( relay_build_deliver pk data )
+    : ?RelayFrame fd ( relay_parse del )
+    ?? fd {
+        T f → {
+            ( pb `deliver type: ` == . f ftype ( relay_del ) )
+            : ( Vec u ) spk ( relay_body_pk . f body )
+            ( pb `deliver src pk split: ` ( veq spk pk ) )
+            ( vec_free [u] spk )
+            ( relay_frame_free f )
+        }
+        F → ( nurl_print `deliver parse failed\n` )
+    }
+
+    // ── incomplete buffer ────────────────────────────────────────
+    : ( Vec u ) partial ( vec_new [u] )
+    ( vec_push [u] partial # u 2 )                    // type
+    ( bytes_push_u32_be partial # u32 999 )          // claims 999 bytes, none follow
+    ( pb `incomplete → None: ` ?? ( relay_parse partial ) { T f → { ( relay_frame_free f ) F } F → T } )
+
+    // ── oversize length rejected ─────────────────────────────────
+    : ( Vec u ) huge ( vec_new [u] )
+    ( vec_push [u] huge # u 2 )
+    ( bytes_push_u32_be huge # u32 2000000 )         // > __relay_max
+    ( pb `oversize → None: ` ?? ( relay_parse huge ) { T f → { ( relay_frame_free f ) F } F → T } )
+
+    ( vec_free [u] pk ) ( vec_free [u] data )
+    ( vec_free [u] reg ) ( vec_free [u] fwd ) ( vec_free [u] del )
+    ( vec_free [u] partial ) ( vec_free [u] huge )
+    ^ 0
+}

--- a/examples/relay.nu
+++ b/examples/relay.nu
@@ -1,0 +1,47 @@
+// examples/relay.nu — a deployable DERP-style relay daemon (TODO §7.4
+// Phase 2). NAT'd peers that can't open a direct path dial out to a relay,
+// register their public key, and exchange opaque (already E2E-encrypted)
+// datagrams addressed by the *destination's* pubkey. The relay never
+// decrypts — it just forwards by pubkey.
+//
+//   ./nurl.sh examples/relay.nu [host] [port]      # default 0.0.0.0:47700
+//
+// A peer uses the client API (stdlib/net/relay.nu):
+//
+//     : !RelayClient NetErr d ( relay_dial relay_host relay_port )
+//     ?? d { T rc → {
+//         ( relay_register rc my_pubkey )            // announce identity
+//         ( relay_send rc dest_pubkey opaque_bytes ) // forward to a peer
+//         ?? ( relay_recv rc ) {                     // {src_pubkey, payload}
+//             T m → { /* . m src, . m payload */ ( relay_msg_free m ) }
+//             F → {} }
+//         ( relay_close rc )
+//     } F e → {} }
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/net/relay.nu`
+
+@ main → i {
+    : i argc ( env_args_count )
+    : String host ? > argc 1 ( env_arg 1 ) ( string_from `0.0.0.0` )
+    : i port ? > argc 2 {
+        : String ps ( env_arg 2 ) : i p ( nurl_str_to_int ( string_data ps ) ) ( string_free ps ) p
+    } 47700
+
+    ?? ( relay_server_start ( string_data host ) port ) {
+        T rs → {
+            : *RelayServer p # *RelayServer ( nurl_alloc Z RelayServer )
+            = . p lst . rs lst
+            = . p clients . rs clients
+            ( nurl_print `relay listening on ` ) ( nurl_print ( string_data host ) )
+            ( nurl_print `:` ) ( nurl_print_int port )
+            ( relay_server_run p )   // blocks until the listener is closed
+            ( relay_server_free p )
+        }
+        F e → ( nurl_print `relay failed to bind\n` )
+    }
+    ( string_free host )
+    ^ 0
+}

--- a/stdlib/net/relay.nu
+++ b/stdlib/net/relay.nu
@@ -1,0 +1,383 @@
+// stdlib/net/relay.nu — DERP-style dumb relay for §7.4 Phase 2.
+//
+// When two peers can't open a direct path (symmetric NAT / CGNAT — see
+// net/nat.nu's probe), they reach each other through a relay. The relay is
+// deliberately DUMB: Phase 0 (net/securedgram) already encrypts end-to-end,
+// so the relay only forwards OPAQUE datagrams addressed by the destination's
+// public key — it never decrypts, and never needs the session keys.
+//
+// Both peers DIAL OUT to the relay over a long-lived TCP connection (a NAT'd
+// peer can't accept inbound, but it can hold a connection open), register
+// their pubkey, then send/receive {peer_pubkey, opaque_bytes} frames. The
+// relay keeps a pubkey → connection table and forwards.
+//
+// Wire framing (length-prefixed, binary):
+//   [type:1][len:4 BE][body]
+//     type 1 REGISTER  body = pubkey(32)                  peer → relay
+//     type 2 FORWARD   body = dest_pubkey(32) ++ payload  peer → relay
+//     type 3 DELIVER   body = src_pubkey(32)  ++ payload  relay → peer
+//     type 4 KEEPALIVE body = (empty)                     either way
+//
+// The frame codec is pure and deterministic (offline-testable). The
+// server/client wrappers add TCP I/O; the per-conn handler runs as a fiber
+// (tcp_read_chunk / tcp_write_all are reactor-aware), matching the
+// server_run_async idiom in ext/http_server.nu. Path-upgrade (start relayed,
+// punch in the background, promote to direct, demote when direct goes quiet)
+// is wired at the transport seam in Phase 4 — this module is the relay leg.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/async.nu`
+
+// runtime client dial (the listen/accept/read/write/close ops are nurlc
+// builtins reached via std/net.nu; only the dial needs an extern decl).
+& `libc` @ nurl_tcp_connect s host i port → i
+
+// ── frame types ──────────────────────────────────────────────────
+@ relay_reg → i { ^ 1 }
+@ relay_fwd → i { ^ 2 }
+@ relay_del → i { ^ 3 }
+@ relay_ka  → i { ^ 4 }
+
+@ __relay_max → i { ^ 131072 }   // reject frames larger than this (DoS guard)
+
+@ __cpy ( Vec u ) v → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
+    ( vec_extend [u] o v )
+    ^ o
+}
+
+@ __veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a )
+    ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n {
+        : i x ?? ( vec_get [u] a k ) { T t → # i t F → -1 }
+        : i y ?? ( vec_get [u] b k ) { T t → # i t F → -2 }
+        ? != x y { = e F } {}
+        = k + k 1
+    }
+    ^ e
+}
+
+// ── frame codec ──────────────────────────────────────────────────
+
+: RelayFrame {
+    i ftype
+    ( Vec u ) body
+}
+@ relay_frame_free RelayFrame fr → v { ( vec_free [u] . fr body ) }
+
+@ __frame i ftype ( Vec u ) body → ( Vec u ) {
+    : ( Vec u ) f ( vec_new [u] )
+    ( vec_push [u] f # u ftype )
+    ( bytes_push_u32_be f # u32 ( vec_len [u] body ) )
+    ( vec_extend [u] f body )
+    ^ f
+}
+
+@ relay_build_register ( Vec u ) pubkey → ( Vec u ) { ^ ( __frame ( relay_reg ) pubkey ) }
+@ relay_build_keepalive → ( Vec u ) {
+    : ( Vec u ) empty ( vec_new [u] )
+    : ( Vec u ) f ( __frame ( relay_ka ) empty )
+    ( vec_free [u] empty )
+    ^ f
+}
+
+@ __frame_addressed i ftype ( Vec u ) pk ( Vec u ) payload → ( Vec u ) {
+    : ( Vec u ) body ( vec_new [u] )
+    ( vec_extend [u] body pk )
+    ( vec_extend [u] body payload )
+    : ( Vec u ) f ( __frame ftype body )
+    ( vec_free [u] body )
+    ^ f
+}
+@ relay_build_forward ( Vec u ) dest_pk ( Vec u ) payload → ( Vec u ) { ^ ( __frame_addressed ( relay_fwd ) dest_pk payload ) }
+@ relay_build_deliver ( Vec u ) src_pk ( Vec u ) payload → ( Vec u ) { ^ ( __frame_addressed ( relay_del ) src_pk payload ) }
+
+// First 32 bytes of a FORWARD/DELIVER body = the peer pubkey.
+@ relay_body_pk ( Vec u ) body → ( Vec u ) {
+    : ( Vec u ) pk ( vec_with_cap [u] 32 )
+    : ~ i k 0
+    ~ < k 32 { ?? ( vec_get [u] body k ) { T b → ( vec_push [u] pk b ) F → {} } = k + k 1 }
+    ^ pk
+}
+// Remaining bytes = the opaque payload.
+@ relay_body_payload ( Vec u ) body → ( Vec u ) {
+    : i n ( vec_len [u] body )
+    : ( Vec u ) pl ( vec_new [u] )
+    : ~ i k 32
+    ~ < k n { ?? ( vec_get [u] body k ) { T b → ( vec_push [u] pl b ) F → {} } = k + k 1 }
+    ^ pl
+}
+
+// Parse one frame from the front of a buffer. None if incomplete / oversize.
+@ relay_parse ( Vec u ) buf → ?RelayFrame {
+    : i n ( vec_len [u] buf )
+    ? < n 5 { ^ @ ?RelayFrame { F # RelayFrame 0 } } {}
+    : i ftype ?? ( vec_get [u] buf 0 ) { T x → # i x F → -1 }
+    : i len ?? ( bytes_read_u32_be buf 1 ) { T x → # i x F → -1 }
+    ? > len ( __relay_max ) { ^ @ ?RelayFrame { F # RelayFrame 0 } } {}
+    ? < n + 5 len { ^ @ ?RelayFrame { F # RelayFrame 0 } } {}
+    : ( Vec u ) body ( vec_with_cap [u] len )
+    : ~ i k 0
+    ~ < k len { ?? ( vec_get [u] buf + 5 k ) { T b → ( vec_push [u] body b ) F → {} } = k + k 1 }
+    ^ @ ?RelayFrame { T @ RelayFrame { ftype body } }
+}
+
+// ── streaming frame reader (TcpConn) ─────────────────────────────
+
+@ __read_exact TcpConn c i n → ?( Vec u ) {
+    : ( Vec u ) buf ( vec_with_cap [u] n )
+    : ~ b fail F
+    : ~ i got 0
+    ~ & ! fail < got n {
+        : !( Vec u ) NetErr r ( tcp_read_chunk c - n got )
+        ?? r {
+            T chunk → {
+                : i cn ( vec_len [u] chunk )
+                ? == cn 0 { = fail T } { ( vec_extend [u] buf chunk ) = got + got cn }
+                ( vec_free [u] chunk )
+            }
+            F _ → { = fail T }
+        }
+    }
+    ? fail { ( vec_free [u] buf ) ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    ^ @ ?( Vec u ) { T buf }
+}
+
+@ relay_read_frame TcpConn c → ?RelayFrame {
+    : ~ ?RelayFrame out @ ?RelayFrame { F # RelayFrame 0 }
+    : ?( Vec u ) hdr ( __read_exact c 5 )
+    ?? hdr {
+        T h → {
+            : i ftype ?? ( vec_get [u] h 0 ) { T x → # i x F → -1 }
+            : i len ?? ( bytes_read_u32_be h 1 ) { T x → # i x F → -1 }
+            ( vec_free [u] h )
+            ? & >= len 0 <= len ( __relay_max ) {
+                : ?( Vec u ) bd ( __read_exact c len )
+                ?? bd {
+                    T body → { = out @ ?RelayFrame { T @ RelayFrame { ftype body } } }
+                    F → {}
+                }
+            } {}
+        }
+        F → {}
+    }
+    ^ out
+}
+
+// ════════════════════════════════════════════════════════════════
+// Relay SERVER — pubkey → connection table, opaque forwarding.
+// ════════════════════════════════════════════════════════════════
+
+: RelayEntry {
+    ( Vec u ) pubkey
+    TcpConn conn
+    i live       // 1 = registered + connected, 0 = gone
+    i sending    // 1 = a forward write to this conn is in flight (write lock)
+}
+
+: RelayServer {
+    TcpListener lst
+    ( Vec s ) clients   // *RelayEntry
+}
+
+@ relay_server_start s host i port → !RelayServer NetErr {
+    : !TcpListener NetErr lr ( tcp_listen host port )
+    : !RelayServer NetErr out ?? lr {
+        T l → @ !RelayServer NetErr { T @ RelayServer { l ( vec_new [s] ) } }
+        F e → @ !RelayServer NetErr { F e }
+    }
+    ^ out
+}
+
+@ __relay_register_conn *RelayServer rs TcpConn c ( Vec u ) pk → s {
+    : *RelayEntry e # *RelayEntry ( nurl_alloc Z RelayEntry )
+    = . e pubkey ( __cpy pk )
+    = . e conn c
+    = . e live 1
+    = . e sending 0
+    ( vec_push [s] . rs clients # s e )
+    ^ # s e
+}
+
+@ __relay_find *RelayServer rs ( Vec u ) pk → s {
+    : i n ( vec_len [s] . rs clients )
+    : ~ s found # s 0
+    : ~ i k 0
+    ~ & == # i found 0 < k n {
+        : s pp ?? ( vec_get [s] . rs clients k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *RelayEntry e # *RelayEntry pp
+            ? & == . e live 1 ( __veq . e pubkey pk ) { = found pp } {}
+        } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+// Serialized write to a destination conn: under cooperative scheduling the
+// check-and-set is atomic (no yield between), and tcp_write_all may park —
+// other forwarders to the same conn spin-yield until the lock clears, so
+// frames never interleave on a shared destination.
+@ __relay_send_locked *RelayEntry de ( Vec u ) frame → v {
+    ~ == . de sending 1 { ( yield ) }
+    = . de sending 1
+    ?? ( tcp_write_all . de conn frame ) { T _ → {} F _ → { = . de live 0 } }
+    = . de sending 0
+}
+
+@ __relay_handle_conn *RelayServer rs TcpConn c → v {
+    : ~ s self_entry # s 0
+    : ~ b done F
+    ~ ! done {
+        : ?RelayFrame fr ( relay_read_frame c )
+        ?? fr {
+            T f → {
+                : i ft . f ftype
+                ? == ft ( relay_reg ) {
+                    = self_entry ( __relay_register_conn rs c . f body )
+                } {}
+                ? == ft ( relay_fwd ) {
+                    ? != # i self_entry 0 {
+                        : *RelayEntry se # *RelayEntry self_entry
+                        : ( Vec u ) dst ( relay_body_pk . f body )
+                        : ( Vec u ) pl ( relay_body_payload . f body )
+                        : s dp ( __relay_find rs dst )
+                        ? != # i dp 0 {
+                            : *RelayEntry de # *RelayEntry dp
+                            : ( Vec u ) out ( relay_build_deliver . se pubkey pl )
+                            ( __relay_send_locked de out )
+                            ( vec_free [u] out )
+                        } {}
+                        ( vec_free [u] dst )
+                        ( vec_free [u] pl )
+                    } {}
+                } {}
+                ( relay_frame_free f )
+            }
+            F → { = done T }
+        }
+    }
+    ? != # i self_entry 0 { : *RelayEntry se # *RelayEntry self_entry = . se live 0 } {}
+    ( tcp_close_conn c )
+}
+
+@ __relay_accept_loop *RelayServer rs → v {
+    : TcpListener lst . rs lst
+    : ~ b done F
+    ~ ! done {
+        : !TcpConn NetErr cr ( tcp_accept lst )
+        ?? cr {
+            T c → { ( spawn \ → v { ( __relay_handle_conn rs c ) } ) }
+            F e → { = done T }
+        }
+    }
+}
+
+// Run the relay: one accept fiber, a handler fiber per connection. Blocks
+// in runtime_run until the listener is closed (relay_server_stop) and every
+// in-flight conn fiber drains.
+@ relay_server_run *RelayServer rs → v {
+    ( tcp_listener_retain . rs lst )
+    : ( @ v ) accept_fiber \ → v { ( __relay_accept_loop rs ) }
+    ( spawn accept_fiber )
+    ( runtime_run )
+    ( tcp_listener_release . rs lst )
+    : *u accept_env # *u accept_fiber 1
+    ( nurl_free # s accept_env )
+}
+
+@ relay_server_stop *RelayServer rs → v { ( tcp_close_listener . rs lst ) }
+
+@ relay_server_free *RelayServer rs → v {
+    : i n ( vec_len [s] . rs clients )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . rs clients k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *RelayEntry e # *RelayEntry pp
+            ( vec_free [u] . e pubkey )
+            ( nurl_free # s e )
+        } {}
+        = k + k 1
+    }
+    ( vec_free [s] . rs clients )
+    ( nurl_free # s rs )
+}
+
+// ════════════════════════════════════════════════════════════════
+// Relay CLIENT — dial, register, send/recv opaque datagrams.
+// ════════════════════════════════════════════════════════════════
+
+: RelayClient {
+    TcpConn conn
+}
+
+: RelayMsg {
+    ( Vec u ) src
+    ( Vec u ) payload
+}
+@ relay_msg_free RelayMsg m → v { ( vec_free [u] . m src ) ( vec_free [u] . m payload ) }
+
+@ relay_dial s host i port → !RelayClient NetErr {
+    : i raw ( nurl_tcp_connect host port )
+    ? == raw 0 { ^ @ !RelayClient NetErr { F # NetErr NetOther } } {}
+    : i ek ( nurl_tcp_err_kind raw )
+    ? != ek 0 {
+        ( nurl_tcp_close raw )
+        ^ @ !RelayClient NetErr { F ( __net_err_of ek ) }
+    } {}
+    : TcpConn c @ TcpConn { # s raw }
+    ^ @ !RelayClient NetErr { T @ RelayClient { c } }
+}
+
+@ relay_register RelayClient rc ( Vec u ) pubkey → !v NetErr {
+    : ( Vec u ) f ( relay_build_register pubkey )
+    : !v NetErr r ( tcp_write_all . rc conn f )
+    ( vec_free [u] f )
+    ^ r
+}
+
+@ relay_send RelayClient rc ( Vec u ) dest_pk ( Vec u ) payload → !v NetErr {
+    : ( Vec u ) f ( relay_build_forward dest_pk payload )
+    : !v NetErr r ( tcp_write_all . rc conn f )
+    ( vec_free [u] f )
+    ^ r
+}
+
+@ relay_keepalive RelayClient rc → !v NetErr {
+    : ( Vec u ) f ( relay_build_keepalive )
+    : !v NetErr r ( tcp_write_all . rc conn f )
+    ( vec_free [u] f )
+    ^ r
+}
+
+// Block until a DELIVER frame arrives; returns its {src_pubkey, payload}.
+// Non-DELIVER frames (keepalive echoes) are skipped. None on disconnect.
+@ relay_recv RelayClient rc → ?RelayMsg {
+    : ~ ?RelayMsg out @ ?RelayMsg { F # RelayMsg 0 }
+    : ~ b done F
+    ~ ! done {
+        : ?RelayFrame fr ( relay_read_frame . rc conn )
+        ?? fr {
+            T f → {
+                ? == . f ftype ( relay_del ) {
+                    : ( Vec u ) src ( relay_body_pk . f body )
+                    : ( Vec u ) pl ( relay_body_payload . f body )
+                    = out @ ?RelayMsg { T @ RelayMsg { src pl } }
+                    = done T
+                } {}
+                ( relay_frame_free f )
+            }
+            F → { = done T }
+        }
+    }
+    ^ out
+}
+
+@ relay_set_timeout RelayClient rc i ms → v { ( tcp_set_timeout . rc conn ms ) }
+@ relay_close RelayClient rc → v { ( tcp_close_conn . rc conn ) }


### PR DESCRIPTION
## Summary
**Phase 2** of the §7.4 NAT/mobile transport plan. When two peers can't open a direct path (symmetric NAT / CGNAT — see `net/nat.nu`'s probe from #143), they reach each other through a **dumb relay**. Phase 0 (`net/securedgram`) already encrypts end-to-end, so the relay only forwards **opaque** datagrams addressed by the destination's public key — it never decrypts and never needs the session keys. Both peers **dial out** to the relay over a long-lived TCP connection (a NAT'd peer can't accept inbound, but it can hold a connection open).

### Wire framing — `[type:1][len:4 BE][body]`
| type | name | body |
|------|------|------|
| 1 | REGISTER | `pubkey(32)` |
| 2 | FORWARD | `dest_pubkey(32) ++ payload` |
| 3 | DELIVER | `src_pubkey(32) ++ payload` |
| 4 | KEEPALIVE | *(empty)* |

Pure codec (`relay_build_*` / `relay_parse` / `relay_read_frame`); oversize (`> 128 KiB`) and incomplete frames parse to `None`.

### Server
Pubkey → connection table; one accept fiber + a per-conn handler fiber (matches the `server_run_async` idiom in `ext/http_server.nu`, `tcp_read_chunk`/`tcp_write_all` are reactor-aware). Forwards opaque payloads by dest pubkey. **Per-conn write lock** serializes concurrent forwards to a shared destination so frames can't interleave under cooperative scheduling; a failed write marks the entry gone. Entries are never freed mid-run (freed at `relay_server_free`), so forwarder pointers can't dangle.

### Client
`relay_dial` / `relay_register` / `relay_send` / `relay_recv` (→ `{src_pubkey, payload}`) / `relay_keepalive` / `relay_close`.

Path-upgrade (start relayed for instant connectivity, punch in the background, promote to direct, demote when direct goes quiet) lands at the Phase 4 transport seam — this PR is the relay leg.

## Testing
- **`compiler/tests/relay_codec.nu`** (+ golden) — REGISTER/FORWARD/DELIVER round-trip, pubkey/payload split, incomplete + oversize rejection. ASan-clean.
- **Live** (loopback, relay server process + client process with two fibers): peer A's opaque payload `hello-through-relay` routed to peer B purely by pubkey through the relay; B sees the correct payload **and** correct `src = A`.
- Full suite **375/375**, examples gate **74/74**. No compiler changes.

Next (Phase 3 / Phase 4): `net/rendezvous` (signaling-only control plane) and `net/transport` (the flat pubkey-addressed seam that hides direct-vs-relay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)