### PR TITLE
feat(net): net/transport — flat pubkey-addressed overlay seam (§7.4 Phase 4)

### DIFF
--- a/compiler/tests/outputs/transport_policy.txt
+++ b/compiler/tests/outputs/transport_policy.txt
@@ -1,0 +1,13 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+starts relayed: YES
+promoted to direct: YES
+direct_known set: YES
+stays direct while active: YES
+still direct after 1 idle: YES
+demoted to relay after idle_limit: YES
+direct_known cleared: YES
+re-promote after demotion: YES
+no relay + no direct → none: YES

--- a/compiler/tests/transport_policy.nu
+++ b/compiler/tests/transport_policy.nu
@@ -1,0 +1,57 @@
+// transport_policy.nu — offline test for stdlib/net/transport.nu path-policy
+// state machine. Deterministic, no sockets: drives a PeerPath through the
+// start-relayed → promote-to-direct → demote-when-quiet lifecycle and checks
+// transport_pick at each step.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/net/transport.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ new_path i mode → s {
+    : *PeerPath p # *PeerPath ( nurl_alloc Z PeerPath )
+    = . p pubkey ( vec_new [u] )
+    = . p mode mode
+    = . p direct_known 0
+    = . p idle 0
+    ^ # s p
+}
+@ free_path s pp → v { : *PeerPath p # *PeerPath pp ( vec_free [u] . p pubkey ) ( nurl_free # s p ) }
+
+@ main → i {
+    // peer starts on the relay leg (has_relay = 1)
+    : s pp ( new_path ( mode_relay ) )
+    : *PeerPath p # *PeerPath pp
+    ( pb `starts relayed: ` == ( transport_pick p 1 ) ( mode_relay ) )
+
+    // a direct datagram arrives → promote to direct
+    ( transport_note_direct p )
+    ( pb `promoted to direct: ` == ( transport_pick p 1 ) ( mode_direct ) )
+    ( pb `direct_known set: ` == . p direct_known 1 )
+
+    // direct traffic keeps it direct
+    ( transport_tick p 1 3 )
+    ( pb `stays direct while active: ` == ( transport_pick p 1 ) ( mode_direct ) )
+
+    // three silent ticks (idle_limit = 3) → demote back to relay
+    ( transport_tick p 0 3 )
+    ( pb `still direct after 1 idle: ` == ( transport_pick p 1 ) ( mode_direct ) )
+    ( transport_tick p 0 3 )
+    ( transport_tick p 0 3 )
+    ( pb `demoted to relay after idle_limit: ` == ( transport_pick p 1 ) ( mode_relay ) )
+    ( pb `direct_known cleared: ` == . p direct_known 0 )
+
+    // re-promote works after a later direct datagram
+    ( transport_note_direct p )
+    ( pb `re-promote after demotion: ` == ( transport_pick p 1 ) ( mode_direct ) )
+
+    // a peer with no relay configured and no direct path picks 'none'
+    : s qq ( new_path ( mode_none ) )
+    : *PeerPath q # *PeerPath qq
+    ( pb `no relay + no direct → none: ` == ( transport_pick q 0 ) ( mode_none ) )
+
+    ( free_path pp )
+    ( free_path qq )
+    ^ 0
+}

--- a/examples/transport.nu
+++ b/examples/transport.nu
@@ -1,0 +1,67 @@
+// examples/transport.nu — the pubkey-addressed overlay in use (TODO §7.4
+// Phase 4). A group-broadcast client: it opens a transport over a relay,
+// joins a group, broadcasts one opaque payload to the whole group (the
+// shape a group-audio sender uses — one uplink, the relay fans out), and
+// receives messages from peers. Addressing is by public key only; the
+// transport hides direct-vs-relay, NAT and roaming.
+//
+//   ./nurl.sh examples/transport.nu <relay_host> <relay_port>
+//
+// Run a relay with examples/relay.nu. The payload here is just text; a real
+// app puts a distributed-compute task or an Opus audio frame there,
+// E2E-encrypted with the group key.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/net/relay.nu`
+$ `stdlib/net/transport.nu`
+
+@ my_pubkey → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + 7 k ) = k + k 1 } ^ v }
+@ group_id  → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + 200 k ) = k + k 1 } ^ v }
+
+@ frame s text i n → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : *u sp # *u text : ~ i k 0 ~ < k n { ( vec_push [u] v # u . sp k ) = k + k 1 } ^ v }
+
+@ main → i {
+    : i argc ( env_args_count )
+    : String host ? > argc 1 ( env_arg 1 ) ( string_from `127.0.0.1` )
+    : i port ? > argc 2 {
+        : String ps ( env_arg 2 ) : i p ( nurl_str_to_int ( string_data ps ) ) ( string_free ps ) p
+    } 47700
+
+    ?? ( relay_dial ( string_data host ) port ) {
+        T rc → {
+            : ( Vec u ) me ( my_pubkey )
+            ?? ( relay_register rc me ) { T _ → {} F _ → {} }
+            ( relay_set_timeout rc 3000 )
+
+            // relay-only transport (no direct UDP leg in this demo)
+            : *Transport t # *Transport ( transport_open # s 0 rc 1 )
+
+            : ( Vec u ) g ( group_id )
+            ?? ( transport_group_join t g ) { T _ → {} F _ → {} }
+
+            : ( Vec u ) payload ( frame `hello-group` 11 )
+            ?? ( transport_broadcast t g payload ) {
+                T _ → ( nurl_print `broadcast to group sent\n` )
+                F _ → ( nurl_print `broadcast failed\n` )
+            }
+
+            // receive whatever peers send back
+            ?? ( transport_recv t 3000 ) {
+                T m → {
+                    ( nurl_print `recv ` ) ( nurl_print_int ( vec_len [u] . m payload ) ) ( nurl_print ` bytes from a peer\n` )
+                    ( transport_msg_free m )
+                }
+                F → ( nurl_print `no message this round\n` )
+            }
+
+            ( vec_free [u] me ) ( vec_free [u] g ) ( vec_free [u] payload )
+            ( transport_free t )
+            ( relay_close rc )
+        }
+        F e → ( nurl_print `could not reach relay\n` )
+    }
+    ( string_free host )
+    ^ 0
+}

--- a/stdlib/net/relay.nu
+++ b/stdlib/net/relay.nu
@@ -57,13 +57,13 @@ $ `stdlib/std/async.nu`
 
 @ __relay_max → i { ^ 131072 }   // reject frames larger than this (DoS guard)
 
-@ __cpy ( Vec u ) v → ( Vec u ) {
+@ __rcpy ( Vec u ) v → ( Vec u ) {
     : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
     ( vec_extend [u] o v )
     ^ o
 }
 
-@ __veq ( Vec u ) a ( Vec u ) b → b {
+@ __rveq ( Vec u ) a ( Vec u ) b → b {
     : i n ( vec_len [u] a )
     ? != n ( vec_len [u] b ) { ^ F } {}
     : ~ b e T : ~ i k 0
@@ -220,7 +220,7 @@ $ `stdlib/std/async.nu`
 
 @ __relay_register_conn *RelayServer rs TcpConn c ( Vec u ) pk → s {
     : *RelayEntry e # *RelayEntry ( nurl_alloc Z RelayEntry )
-    = . e pubkey ( __cpy pk )
+    = . e pubkey ( __rcpy pk )
     = . e conn c
     = . e live 1
     = . e sending 0
@@ -236,7 +236,7 @@ $ `stdlib/std/async.nu`
         : s pp ?? ( vec_get [s] . rs clients k ) { T x → x F → # s 0 }
         ? != # i pp 0 {
             : *RelayEntry e # *RelayEntry pp
-            ? & == . e live 1 ( __veq . e pubkey pk ) { = found pp } {}
+            ? & == . e live 1 ( __rveq . e pubkey pk ) { = found pp } {}
         } {}
         = k + k 1
     }
@@ -264,7 +264,7 @@ $ `stdlib/std/async.nu`
         : s pp ?? ( vec_get [s] . rs groups k ) { T x → x F → # s 0 }
         ? != # i pp 0 {
             : *GroupEntry g # *GroupEntry pp
-            ? ( __veq . g gid gid ) { = found pp } {}
+            ? ( __rveq . g gid gid ) { = found pp } {}
         } {}
         = k + k 1
     }
@@ -275,7 +275,7 @@ $ `stdlib/std/async.nu`
     : s ex ( __relay_group_find rs gid )
     ? != # i ex 0 { ^ ex } {}
     : *GroupEntry g # *GroupEntry ( nurl_alloc Z GroupEntry )
-    = . g gid ( __cpy gid )
+    = . g gid ( __rcpy gid )
     = . g members ( vec_new [s] )
     ( vec_push [s] . rs groups # s g )
     ^ # s g

--- a/stdlib/net/transport.nu
+++ b/stdlib/net/transport.nu
@@ -1,0 +1,236 @@
+// stdlib/net/transport.nu — the flat pubkey-addressed overlay (§7.4 Phase 4).
+//
+// THE SEAM. Everything above (SWIM, dchannel, cluster-RPC, a group-audio
+// app) addresses peers by their static public key and calls:
+//
+//     transport_send(t, peer_pubkey, payload)     unicast
+//     transport_broadcast(t, group_id, payload)   broadcast to a group
+//     transport_recv(t, max) → (src_pubkey, payload)
+//
+// …with no knowledge of NAT, relays, endpoints, or roaming. The payload is
+// arbitrary opaque bytes — a distributed-compute task or an Opus audio
+// packet — already E2E-encrypted by the layers below.
+//
+// Underneath, each peer rides one of two legs:
+//   • DIRECT  — net/securedgram (encrypted UDP, roams across wifi↔cellular)
+//   • RELAY   — net/relay (DERP-style dumb forwarder, opaque by pubkey)
+//
+// PATH POLICY (per peer): start RELAYED for instant connectivity, try a
+// direct path in the background (hole punch + securedgram handshake), PROMOTE
+// to direct the moment direct data arrives, and DEMOTE back to relay if the
+// direct path goes quiet for too long (a mobile path dropped). That policy is
+// a pure state machine (transport_note_direct / transport_tick / transport_pick)
+// — deterministically testable — and the I/O wrappers just dispatch on it.
+//
+// Broadcast uses the relay's group multicast (one uplink → N downlinks), the
+// bandwidth shape group audio needs.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/crypto.nu`
+$ `stdlib/net/securedgram.nu`
+$ `stdlib/net/relay.nu`
+
+// ── path modes ───────────────────────────────────────────────────
+@ mode_none   → i { ^ 0 }
+@ mode_relay  → i { ^ 1 }
+@ mode_direct → i { ^ 2 }
+
+@ __tcpy ( Vec u ) v → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
+    ( vec_extend [u] o v )
+    ^ o
+}
+
+@ __tveq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a )
+    ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n {
+        : i x ?? ( vec_get [u] a k ) { T t → # i t F → -1 }
+        : i y ?? ( vec_get [u] b k ) { T t → # i t F → -2 }
+        ? != x y { = e F } {}
+        = k + k 1
+    }
+    ^ e
+}
+
+// ── per-peer path state ──────────────────────────────────────────
+
+: PeerPath {
+    ( Vec u ) pubkey
+    i mode          // 0 none, 1 relay, 2 direct
+    i direct_known  // 1 once a direct session has delivered data
+    i idle          // consecutive direct-idle ticks
+}
+
+// ── pure path-policy state machine (deterministically testable) ──
+
+// A direct datagram from this peer arrived → promote to direct, reset idle.
+@ transport_note_direct *PeerPath pp → v {
+    = . pp direct_known 1
+    = . pp mode 2
+    = . pp idle 0
+}
+
+// One policy tick. `saw_direct` = 1 if direct traffic was seen since the last
+// tick. After `idle_limit` silent ticks on a direct path, demote to relay —
+// the direct (often mobile) path has gone quiet; relay re-establishes reach.
+@ transport_tick *PeerPath pp i saw_direct i idle_limit → v {
+    ? == . pp mode 2 {
+        ? == saw_direct 1 { = . pp idle 0 } {
+            = . pp idle + . pp idle 1
+            ? >= . pp idle idle_limit {
+                = . pp mode 1
+                = . pp direct_known 0
+                = . pp idle 0
+            } {}
+        }
+    } {}
+}
+
+// Which leg to send on right now (given whether a relay is configured).
+@ transport_pick *PeerPath pp i has_relay → i {
+    ? == . pp mode 2 { ^ 2 } {}
+    ? == has_relay 1 { ^ 1 } {}
+    ^ 0
+}
+
+// ── transport handle ─────────────────────────────────────────────
+
+: Transport {
+    s node            // *SecureNode for the direct leg, or 0 if direct disabled
+    RelayClient relay // relay client (valid only when has_relay == 1)
+    i has_relay
+    ( Vec s ) peers   // *PeerPath
+}
+
+: TransportMsg {
+    ( Vec u ) src
+    ( Vec u ) payload
+}
+@ transport_msg_free TransportMsg m → v { ( vec_free [u] . m src ) ( vec_free [u] . m payload ) }
+
+// Open over both legs. `node` may be 0 (relay-only peer with no UDP path).
+@ transport_open s node RelayClient relay i has_relay → s {
+    : *Transport t # *Transport ( nurl_alloc Z Transport )
+    = . t node node
+    = . t relay relay
+    = . t has_relay has_relay
+    = . t peers ( vec_new [s] )
+    ^ # s t
+}
+
+@ __tp_find *Transport t ( Vec u ) pk → s {
+    : i n ( vec_len [s] . t peers )
+    : ~ s found # s 0
+    : ~ i k 0
+    ~ & == # i found 0 < k n {
+        : s pp ?? ( vec_get [s] . t peers k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *PeerPath p # *PeerPath pp
+            ? ( __tveq . p pubkey pk ) { = found pp } {}
+        } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+// Register a peer; it starts on the relay leg (or none if no relay).
+@ transport_add_peer *Transport t ( Vec u ) pubkey → v {
+    ? != # i ( __tp_find t pubkey ) 0 { ^ v } {}
+    : *PeerPath p # *PeerPath ( nurl_alloc Z PeerPath )
+    = . p pubkey ( __tcpy pubkey )
+    = . p mode ? == . t has_relay 1 1 0
+    = . p direct_known 0
+    = . p idle 0
+    ( vec_push [s] . t peers # s p )
+}
+
+// Begin a direct path to a peer at a known endpoint (e.g. a candidate from
+// the rendezvous service): register it with securedgram and start the
+// handshake. Stays on relay until the first direct datagram promotes it.
+@ transport_try_direct *Transport t ( Vec u ) pubkey s host i port → !v NetErr {
+    ? == # i . t node 0 { ^ @ !v NetErr { F # NetErr NetOther } } {}
+    : *SecureNode node # *SecureNode . t node
+    ( securedgram_add_peer node pubkey host port )
+    ^ ( securedgram_connect node pubkey )
+}
+
+// Send an opaque payload to a peer over whichever leg is currently chosen.
+@ transport_send *Transport t ( Vec u ) pubkey ( Vec u ) payload → !v NetErr {
+    : s pp ( __tp_find t pubkey )
+    ? == # i pp 0 { ^ @ !v NetErr { F # NetErr NetOther } } {}
+    : *PeerPath p # *PeerPath pp
+    : i leg ( transport_pick p . t has_relay )
+    ? == leg 2 {
+        : *SecureNode node # *SecureNode . t node
+        ^ ( securedgram_send node pubkey payload )
+    } {}
+    ? == leg 1 { ^ ( relay_send . t relay pubkey payload ) } {}
+    ^ @ !v NetErr { F # NetErr NetOther }
+}
+
+// Broadcast to a group via the relay's multicast fanout (one uplink → N).
+@ transport_broadcast *Transport t ( Vec u ) group_id ( Vec u ) payload → !v NetErr {
+    ? == . t has_relay 1 { ^ ( relay_broadcast . t relay group_id payload ) } {}
+    ^ @ !v NetErr { F # NetErr NetOther }
+}
+
+// Join / leave a multicast group on the relay.
+@ transport_group_join *Transport t ( Vec u ) group_id → !v NetErr {
+    ? == . t has_relay 1 { ^ ( relay_group_join . t relay group_id ) } {}
+    ^ @ !v NetErr { F # NetErr NetOther }
+}
+@ transport_group_leave *Transport t ( Vec u ) group_id → !v NetErr {
+    ? == . t has_relay 1 { ^ ( relay_group_leave . t relay group_id ) } {}
+    ^ @ !v NetErr { F # NetErr NetOther }
+}
+
+// Receive one message, polling the direct leg first (promoting the peer's
+// path on direct data) then the relay leg. None if neither had a message
+// this round — callers loop.
+@ transport_recv *Transport t i max → ?TransportMsg {
+    : ~ ?TransportMsg out @ ?TransportMsg { F # TransportMsg 0 }
+    : ~ b got F
+    ? != # i . t node 0 {
+        : *SecureNode node # *SecureNode . t node
+        ?? ( securedgram_recv node max ) {
+            T rd → {
+                : s pp ( __tp_find t . rd peer_pubkey )
+                ? != # i pp 0 { : *PeerPath p # *PeerPath pp ( transport_note_direct p ) } {}
+                = out @ ?TransportMsg { T @ TransportMsg { ( __tcpy . rd peer_pubkey ) ( __tcpy . rd data ) } }
+                = got T
+                ( recvdata_free rd )
+            }
+            F → {}
+        }
+    } {}
+    ? & ! got == . t has_relay 1 {
+        ?? ( relay_recv . t relay ) {
+            T rm → {
+                = out @ ?TransportMsg { T @ TransportMsg { ( __tcpy . rm src ) ( __tcpy . rm payload ) } }
+                = got T
+                ( relay_msg_free rm )
+            }
+            F → {}
+        }
+    } {}
+    ^ out
+}
+
+@ transport_free *Transport t → v {
+    : i n ( vec_len [s] . t peers )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . t peers k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *PeerPath p # *PeerPath pp
+            ( vec_free [u] . p pubkey )
+            ( nurl_free # s p )
+        } {}
+        = k + k 1
+    }
+    ( vec_free [s] . t peers )
+    ( nurl_free # s t )
+}


### PR DESCRIPTION
## Summary
**Phase 4 — THE SEAM.** Everything above (SWIM, dchannel, cluster-RPC, a group-audio app) addresses peers by their static public key and calls:

```
transport_send(t, peer_pubkey, payload)     # unicast
transport_broadcast(t, group_id, payload)   # broadcast to a group
transport_recv(t, max) → (src_pubkey, payload)
```

…with **no knowledge of NAT, relays, endpoints or roaming**. The payload is arbitrary opaque bytes — a distributed-compute task or an Opus audio packet, already E2E-encrypted below.

Underneath, each peer rides one of two legs:
- **DIRECT** — `net/securedgram` (encrypted UDP, roams across wifi↔cellular)
- **RELAY** — `net/relay` (DERP-style dumb forwarder; group multicast gives broadcast its one-uplink-N-downlinks shape)

### Path policy (pure, per peer)
Start **RELAYED** for instant connectivity → **promote to DIRECT** the moment direct data arrives → **demote back to relay** after `idle_limit` silent ticks (a mobile direct path went quiet). `transport_note_direct` / `transport_tick` / `transport_pick` are a deterministic state machine; the I/O wrappers just dispatch on it. `transport_try_direct` is the hook a candidate from Phase 3 rendezvous drives to begin a direct path (securedgram add_peer + handshake).

### API
`transport_open` / `add_peer` / `try_direct` / `send` / `broadcast` / `group_join` / `group_leave` / `recv` (polls the direct leg first, promoting on direct data, then the relay leg) / `free`.

### Incidental
Renamed `relay.nu`'s private `__cpy`/`__veq` → `__rcpy`/`__rveq` so `transport.nu` can import **both** `securedgram` and `relay` — both had identically-named helpers. nurlc accepts the duplicate but **clang link rejects it**, so `check.sh` alone (nurlc-only) misses cross-file symbol clashes; caught with a full build.

## Testing
- **`transport_policy.nu`** (+ golden) — start-relayed → promote → stays-direct-while-active → demote-after-`idle_limit` → re-promote; `none` when no relay and no direct. ASan-clean.
- **Live** (loopback, relay leg): unicast A→B and broadcast A→{B,C}, both through the transport API, correct `src`.
- Full suite **376/376**, examples gate **75/75**. No compiler changes.

The critical path `0 → 1 → 2 → 4` is now closed: a working pubkey-addressed overlay with guaranteed reachability (direct when possible, relay when not) and group broadcast. Next: **Phase 5** (wire SWIM/dchannel/RPC onto `net/transport`) and **Phase 3** `net/rendezvous` (candidate exchange to actually drive `transport_try_direct`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)