### PR TITLE
feat(std): Lifeguard failure-detector resilience — LHM + scaled suspicion (§7.4 Phase 5)

### DIFF
--- a/compiler/tests/lifeguard.nu
+++ b/compiler/tests/lifeguard.nu
@@ -1,0 +1,60 @@
+// lifeguard.nu — offline test for stdlib/std/lifeguard.nu. Deterministic:
+// checks the Local Health Multiplier (penalize/award/cap/floor/scale) and
+// the confirmation-scaled suspicion timeout (max at 0 confirmations, min at
+// k, monotone decrease, expiry).
+
+$ `stdlib/std/lifeguard.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+@ pi s label i v → v { ( nurl_print label ) ( nurl_print_int v ) }
+
+@ main → i {
+    // ── Local Health Multiplier ──────────────────────────────────
+    : LocalHealth h0 ( local_health_new 8 )
+    ( pb `LHM starts healthy (0): ` == ( lh_value h0 ) 0 )
+    ( pb `award at floor stays 0: ` == ( lh_value ( lh_award h0 ) ) 0 )
+
+    : LocalHealth h1 ( lh_penalize h0 )
+    : LocalHealth h2 ( lh_penalize h1 )
+    ( pb `two penalties → 2: ` == ( lh_value h2 ) 2 )
+    ( pb `scale base 1000 by (1+2) = 3000: ` == ( lh_scale h2 1000 ) 3000 )
+    ( pb `award recovers to 1: ` == ( lh_value ( lh_award h2 ) ) 1 )
+
+    // penalize past the cap (10× on a max-8 health) clamps at 8
+    : ~ LocalHealth hc ( local_health_new 8 )
+    : ~ i k 0 ~ < k 10 { = hc ( lh_penalize hc ) = k + k 1 }
+    ( pb `penalty capped at max (8): ` == ( lh_value hc ) 8 )
+
+    // ── confirmation-scaled suspicion timeout ────────────────────
+    // min 1000, max 5000, k 3, start at t=0.
+    : Suspicion s0 ( suspicion_new 1000 5000 3 0 )
+    : i t0 ( suspicion_timeout_ns s0 )
+    ( pi `timeout @ 0 confirms: ` t0 ) ( nurl_print `\n` )
+    ( pb `0 confirms → max (5000): ` == t0 5000 )
+
+    // one confirmation: log(2)/log(4) = 0.5 → 5000 - 4000*0.5 = 3000
+    : Suspicion s1 ( suspicion_confirm s0 )
+    : i t1 ( suspicion_timeout_ns s1 )
+    ( pi `timeout @ 1 confirm: ` t1 ) ( nurl_print `\n` )
+    ( pb `1 confirm → 3000: ` == t1 3000 )
+
+    // two confirmations: strictly between t1 and the floor
+    : Suspicion s2 ( suspicion_confirm s1 )
+    : i t2 ( suspicion_timeout_ns s2 )
+    ( pb `2 confirms strictly between: ` & < t2 t1 > t2 1000 )
+
+    // three (== k) confirmations: floor (1000); further confirms clamp
+    : Suspicion s3 ( suspicion_confirm s2 )
+    : i t3 ( suspicion_timeout_ns s3 )
+    ( pb `k confirms → min (1000): ` == t3 1000 )
+    ( pb `confirms clamp at k: ` == ( suspicion_confirms ( suspicion_confirm s3 ) ) 3 )
+
+    // ── expiry ───────────────────────────────────────────────────
+    // lone suspicion (timeout 5000): not expired at 4000, expired at 6000.
+    ( pb `lone suspicion alive at t=4000: ` ! ( suspicion_expired s0 4000 ) )
+    ( pb `lone suspicion expired at t=6000: ` ( suspicion_expired s0 6000 ) )
+    // corroborated (timeout 1000): already expired at t=4000.
+    ( pb `corroborated expires fast (t=4000): ` ( suspicion_expired s3 4000 ) )
+
+    ^ 0
+}

--- a/compiler/tests/outputs/lifeguard.txt
+++ b/compiler/tests/outputs/lifeguard.txt
@@ -1,0 +1,22 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+LHM starts healthy (0): YES
+award at floor stays 0: YES
+two penalties → 2: YES
+scale base 1000 by (1+2) = 3000: YES
+award recovers to 1: YES
+penalty capped at max (8): YES
+timeout @ 0 confirms: 5000
+
+0 confirms → max (5000): YES
+timeout @ 1 confirm: 3000
+
+1 confirm → 3000: YES
+2 confirms strictly between: YES
+k confirms → min (1000): YES
+confirms clamp at k: YES
+lone suspicion alive at t=4000: YES
+lone suspicion expired at t=6000: YES
+corroborated expires fast (t=4000): YES

--- a/stdlib/std/lifeguard.nu
+++ b/stdlib/std/lifeguard.nu
@@ -1,0 +1,93 @@
+// stdlib/std/lifeguard.nu — Lifeguard failure-detector resilience (§7.4
+// Phase 5). The SWIM "Lifeguard" extensions cut false-positive failure
+// detections — the dominant problem when members run over flaky mobile /
+// NAT'd links (net/transport), where a slow or roaming node looks "dead"
+// when it is merely temporarily unreachable.
+//
+// Two pure mechanisms (no I/O — they parametrise a failure detector's
+// timers and accusations; wiring onto std/swim over net/transport is the
+// remaining Phase 5 step):
+//
+//   1. Local Health Multiplier (LHM). A node measures ITS OWN health: a
+//      probe that gets no ack (direct or indirect) is evidence that the
+//      LOCAL node's network is degraded as much as the remote's, so the
+//      node penalises itself, and a successful probe rewards it. Probe
+//      intervals AND suspicion timeouts are scaled by (1 + LHM): an
+//      unhealthy node both probes less aggressively and is slower to
+//      accuse others — so a node on a bad link stops generating false
+//      positives about everyone else.
+//
+//   2. Confirmation-scaled suspicion timeout (the "dogpile"). A suspected
+//      member is given a LONG timeout to refute the suspicion; each
+//      INDEPENDENT confirmation from another node shortens it, down to a
+//      floor once enough peers agree. Lone suspicions wait long (mobile
+//      blip); corroborated ones converge fast (genuine failure).
+//      timeout(c) = max - (max-min) · log(c+1)/log(k+1).
+
+$ `stdlib/std/float.nu`
+
+// ── Local Health Multiplier ──────────────────────────────────────
+
+: LocalHealth {
+    i lhm     // current multiplier, 0 (healthy) .. max
+    i max     // cap (memberlist uses 8)
+}
+
+@ local_health_new i max → LocalHealth { ^ @ LocalHealth { 0 max } }
+@ lh_value LocalHealth h → i { ^ . h lhm }
+
+// Successful probe → improve local health (decrement toward 0).
+@ lh_award LocalHealth h → LocalHealth {
+    : i nv ? > . h lhm 0 - . h lhm 1 0
+    ^ @ LocalHealth { nv . h max }
+}
+
+// Failed probe / self was suspected → worsen local health (increment, capped).
+@ lh_penalize LocalHealth h → LocalHealth {
+    : i nv ? < . h lhm . h max + . h lhm 1 . h max
+    ^ @ LocalHealth { nv . h max }
+}
+
+// Scale a base interval / timeout by (1 + LHM). An unhealthy node backs off.
+@ lh_scale LocalHealth h i base → i { ^ * base + 1 . h lhm }
+
+// ── confirmation-scaled suspicion timeout ────────────────────────
+
+: Suspicion {
+    i min_ns      // floor timeout once k confirmations are in
+    i max_ns      // initial timeout with zero confirmations
+    i k           // independent confirmations needed to reach the floor
+    i confirms    // confirmations received so far (0..k)
+    i start_ns    // monotonic time the suspicion began
+}
+
+@ suspicion_new i min_ns i max_ns i k i now_ns → Suspicion {
+    ^ @ Suspicion { min_ns max_ns k 0 now_ns }
+}
+@ suspicion_confirms Suspicion s → i { ^ . s confirms }
+
+// Register one independent confirmation from a distinct peer (capped at k).
+@ suspicion_confirm Suspicion s → Suspicion {
+    : i nc ? < . s confirms . s k + . s confirms 1 . s confirms
+    ^ @ Suspicion { . s min_ns . s max_ns . s k nc . s start_ns }
+}
+
+// Current timeout for the suspicion given confirmations received:
+//   max - (max-min) · log(c+1)/log(k+1)      (== max at c=0, == min at c=k)
+@ suspicion_timeout_ns Suspicion s → i {
+    ? <= . s k 0 { ^ . s min_ns } {}
+    : i c ? > . s confirms . s k . s k . s confirms
+    : i c1 + c 1
+    : i k1 + . s k 1
+    : f frac / ( log # f c1 ) ( log # f k1 )
+    : i diff - . s max_ns . s min_ns
+    : f prod * # f diff frac
+    : i delta # i prod
+    : i to - . s max_ns delta
+    ^ ? < to . s min_ns . s min_ns to
+}
+
+// Has the suspicion timed out at now_ns (→ declare the member dead)?
+@ suspicion_expired Suspicion s i now_ns → b {
+    ^ >= - now_ns . s start_ns ( suspicion_timeout_ns s )
+}


### PR DESCRIPTION
## Summary
First slice of **Phase 5**: the SWIM **Lifeguard** extensions that cut false-positive failure detections — the dominant problem once members run over flaky mobile / NAT'd links (`net/transport`), where a slow or roaming node looks *dead* when it is merely temporarily unreachable. `std/lifeguard.nu` provides two **pure** mechanisms (no I/O — they parametrise a failure detector's timers and accusations):

### 1. Local Health Multiplier (LHM)
A node measures **its own** health: a probe that gets no ack (direct or indirect) is evidence the *local* network is degraded too, so the node penalizes itself; a successful probe rewards it (range `0..max`). Probe intervals **and** suspicion timeouts scale by `(1 + LHM)`, so a node on a bad link both probes less aggressively and is slower to accuse — it stops generating false positives about everyone else.
`local_health_new` / `lh_award` / `lh_penalize` / `lh_scale` / `lh_value`.

### 2. Confirmation-scaled suspicion timeout (the "dogpile")
A suspected member gets a **long** timeout to refute; each *independent* confirmation from a distinct peer shortens it toward a floor:

```
timeout(c) = max − (max−min) · log(c+1)/log(k+1)     # == max at c=0, == min at c=k
```

Lone suspicions wait long (a mobile blip); corroborated ones converge fast (genuine failure).
`suspicion_new` / `suspicion_confirm` / `suspicion_timeout_ns` / `suspicion_expired`.

Both are exact (libm `log` via `std/float`).

## Testing
- **`compiler/tests/lifeguard.nu`** (+ golden) — LHM penalize/award/cap-at-max/floor-at-0/scale; suspicion timeout `5000@0 → 3000@1confirm → 1000@k`, strictly monotone in between, confirms clamped at `k`, and expiry (lone suspicion alive at t=4000 / dead at t=6000 vs corroborated dead already at t=4000). ASan-clean.
- Suite **377/377**, examples gate **75/75**. No compiler changes.

## Next
Wire these onto `std/swim` running over `net/transport` (member key `host:port` → pubkey) — the remaining Phase 5 step — and exercise it under the Phase 8 sim-NAT harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)