### PR TITLE
feat(net): net/rendezvous — signaling-only candidate directory (§7.4 Phase 3)

### DIFF
--- a/compiler/tests/outputs/rendezvous_codec.txt
+++ b/compiler/tests/outputs/rendezvous_codec.txt
@@ -1,0 +1,21 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+record codec:
+  pubkey matches: YES
+  relay host: YES
+  2 endpoints: YES
+  ep0 = 192.0.2.1:5000: YES
+  ep1 = 198.51.100.7:41000: YES
+register type: YES
+register record:
+  pubkey matches: YES
+  relay host: YES
+  2 endpoints: YES
+  ep0 = 192.0.2.1:5000: YES
+  ep1 = 198.51.100.7:41000: YES
+lookup type: YES
+lookup body == pubkey: YES
+record(found) flag: YES
+record(notfound) flag: YES

--- a/compiler/tests/rendezvous_codec.nu
+++ b/compiler/tests/rendezvous_codec.nu
@@ -1,0 +1,97 @@
+// rendezvous_codec.nu — offline test for stdlib/net/rendezvous.nu. No
+// sockets: builds a PeerRecord (pubkey + 2 candidate endpoints + relay),
+// round-trips it through the record codec, and through REGISTER / LOOKUP /
+// RECORD(found|notfound) frames.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/rendezvous.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ mkpk i seed → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + seed k ) = k + k 1 } ^ v }
+
+@ veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a ) ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n { ? != ?? ( vec_get [u] a k ) { T t → # i t F → -1 } ?? ( vec_get [u] b k ) { T t → # i t F → -2 } { = e F } {} = k + k 1 }
+    ^ e
+}
+
+@ ep_host s pp → s { : *Endpoint e # *Endpoint pp ^ ( string_data . e host ) }
+@ ep_port s pp → i { : *Endpoint e # *Endpoint pp ^ . e port }
+
+@ check_record s rp ( Vec u ) wantpk → v {
+    : *PeerRecord r # *PeerRecord rp
+    ( pb `  pubkey matches: ` ( veq . r pubkey wantpk ) )
+    ( pb `  relay host: ` & != 0 ( nurl_str_eq ( string_data . r relay_host ) `relay.example` ) == . r relay_port 8443 )
+    ( pb `  2 endpoints: ` == ( vec_len [s] . r endpoints ) 2 )
+    : s e0 ?? ( vec_get [s] . r endpoints 0 ) { T x → x F → # s 0 }
+    : s e1 ?? ( vec_get [s] . r endpoints 1 ) { T x → x F → # s 0 }
+    ( pb `  ep0 = 192.0.2.1:5000: ` & != 0 ( nurl_str_eq ( ep_host e0 ) `192.0.2.1` ) == ( ep_port e0 ) 5000 )
+    ( pb `  ep1 = 198.51.100.7:41000: ` & != 0 ( nurl_str_eq ( ep_host e1 ) `198.51.100.7` ) == ( ep_port e1 ) 41000 )
+}
+
+@ main → i {
+    : ( Vec u ) pk ( mkpk 100 )
+    : s rp ( peer_record_new pk `relay.example` 8443 )
+    : *PeerRecord r # *PeerRecord rp
+    ( peer_record_add_endpoint r `192.0.2.1` 5000 )
+    ( peer_record_add_endpoint r `198.51.100.7` 41000 )
+
+    // ── record codec round trip ──────────────────────────────────
+    ( nurl_print `record codec:\n` )
+    : ( Vec u ) enc ( rz_record_encode r )
+    : s dp ( rz_record_decode enc )
+    ( check_record dp pk )
+    ( peer_record_free # *PeerRecord dp )
+    ( vec_free [u] enc )
+
+    // ── REGISTER frame carries the record ────────────────────────
+    : ( Vec u ) reg ( rz_build_register r )
+    ?? ( rz_parse reg ) {
+        T f → {
+            ( pb `register type: ` == . f ftype ( rz_register ) )
+            : s d2 ( rz_record_decode . f body )
+            ( nurl_print `register record:\n` ) ( check_record d2 pk )
+            ( peer_record_free # *PeerRecord d2 )
+            ( rz_frame_free f )
+        }
+        F → ( nurl_print `register parse failed\n` )
+    }
+
+    // ── LOOKUP frame carries the pubkey ──────────────────────────
+    : ( Vec u ) lk ( rz_build_lookup pk )
+    ?? ( rz_parse lk ) {
+        T f → {
+            ( pb `lookup type: ` == . f ftype ( rz_lookup ) )
+            ( pb `lookup body == pubkey: ` ( veq . f body pk ) )
+            ( rz_frame_free f )
+        }
+        F → ( nurl_print `lookup parse failed\n` )
+    }
+
+    // ── RECORD found / notfound ──────────────────────────────────
+    : ( Vec u ) rf ( rz_build_record_found r )
+    ?? ( rz_parse rf ) {
+        T f → {
+            ( pb `record(found) flag: ` == ?? ( vec_get [u] . f body 0 ) { T x → # i x F → -1 } 1 )
+            ( rz_frame_free f )
+        }
+        F → ( nurl_print `record parse failed\n` )
+    }
+    : ( Vec u ) rn ( rz_build_record_notfound )
+    ?? ( rz_parse rn ) {
+        T f → {
+            ( pb `record(notfound) flag: ` == ?? ( vec_get [u] . f body 0 ) { T x → # i x F → -1 } 0 )
+            ( rz_frame_free f )
+        }
+        F → ( nurl_print `record parse failed\n` )
+    }
+
+    ( peer_record_free r )
+    ( vec_free [u] pk ) ( vec_free [u] reg ) ( vec_free [u] lk )
+    ( vec_free [u] rf ) ( vec_free [u] rn )
+    ^ 0
+}

--- a/examples/rendezvous.nu
+++ b/examples/rendezvous.nu
@@ -1,0 +1,46 @@
+// examples/rendezvous.nu — a deployable rendezvous (signaling) server for
+// TODO §7.4 Phase 3. Peers REGISTER their pubkey → candidate endpoints +
+// chosen relay; any peer LOOKs another up by pubkey to learn where to try a
+// direct path (and the relay fallback). NO application data flows here.
+//
+//   ./nurl.sh examples/rendezvous.nu [host] [port]      # default 0.0.0.0:47703
+//
+// A peer uses the client API (stdlib/net/rendezvous.nu):
+//
+//     ?? ( rz_client_connect rz_host rz_port ) { T rc → {
+//         : s rp ( peer_record_new my_pubkey my_relay_host my_relay_port )
+//         : *PeerRecord r # *PeerRecord rp
+//         ( peer_record_add_endpoint r host_cand_ip host_cand_port )   // from net/nat
+//         ( peer_record_add_endpoint r srflx_ip srflx_port )
+//         ( rz_register_self rc r )                       // publish
+//         : s peer ( rz_lookup_peer rc other_pubkey )     // discover a peer
+//         // → feed peer's endpoints to transport_try_direct, relay as fallback
+//     } F e → {} }
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/net/rendezvous.nu`
+
+@ main → i {
+    : i argc ( env_args_count )
+    : String host ? > argc 1 ( env_arg 1 ) ( string_from `0.0.0.0` )
+    : i port ? > argc 2 {
+        : String ps ( env_arg 2 ) : i p ( nurl_str_to_int ( string_data ps ) ) ( string_free ps ) p
+    } 47703
+
+    ?? ( rz_server_start ( string_data host ) port ) {
+        T rs → {
+            : *RzServer p # *RzServer ( nurl_alloc Z RzServer )
+            = . p lst . rs lst
+            = . p records . rs records
+            ( nurl_print `rendezvous listening on ` ) ( nurl_print ( string_data host ) )
+            ( nurl_print `:` ) ( nurl_print_int port )
+            ( rz_server_run p )
+            ( rz_server_free p )
+        }
+        F e → ( nurl_print `rendezvous failed to bind\n` )
+    }
+    ( string_free host )
+    ^ 0
+}

--- a/stdlib/net/rendezvous.nu
+++ b/stdlib/net/rendezvous.nu
@@ -1,0 +1,476 @@
+// stdlib/net/rendezvous.nu — signaling-only control plane (§7.4 Phase 3).
+//
+// Peers are addressed by static public key, but to open a DIRECT path a peer
+// must learn WHERE another peer currently is (its gathered candidates from
+// net/nat) and which relay it falls back to. The rendezvous service is that
+// directory: a peer REGISTERs (pubkey → candidate endpoints + chosen relay),
+// and any peer can LOOKUP another's record by pubkey. The looked-up endpoints
+// feed transport_try_direct (hole punch + securedgram handshake); the relay
+// is the guaranteed fallback.
+//
+// This is CONTROL plane only — NO application data, NO media ever flows here.
+// It is the offer/answer of endpoints (not SDP); the data plane is
+// net/transport (direct via securedgram, relayed via net/relay).
+//
+// Wire framing (length-prefixed, binary):
+//   [type:1][len:4 BE][body]
+//     1 REGISTER  body = record                 peer → server
+//     2 LOOKUP    body = pubkey(32)             peer → server
+//     3 OK        body = (empty)                server → peer   (register ack)
+//     4 RECORD    body = found(1) [++ record]   server → peer   (lookup reply)
+//
+//   record = pubkey(32)
+//            ++ str(relay_host) ++ u16(relay_port)
+//            ++ u16(n_endpoints) ++ [ str(host) ++ u16(port) ]*
+//   str    = u16(len) ++ bytes
+//
+// The record codec is pure and deterministic (offline-testable); the
+// server/client add TCP I/O (the per-conn handler runs as a fiber, like
+// ext/http_server's server_run_async).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/async.nu`
+
+& `libc` @ nurl_tcp_connect s host i port → i
+
+@ rz_register → i { ^ 1 }
+@ rz_lookup  → i { ^ 2 }
+@ rz_ok      → i { ^ 3 }
+@ rz_record  → i { ^ 4 }
+
+@ __rz_max → i { ^ 65536 }
+
+// ── data model ───────────────────────────────────────────────────
+
+: Endpoint {
+    String host
+    i port
+}
+
+: PeerRecord {
+    ( Vec u ) pubkey
+    ( Vec s ) endpoints   // *Endpoint
+    String relay_host
+    i relay_port
+}
+
+@ endpoint_free *Endpoint e → v { ( string_free . e host ) ( nurl_free # s e ) }
+
+@ peer_record_new ( Vec u ) pubkey s relay_host i relay_port → s {
+    : *PeerRecord r # *PeerRecord ( nurl_alloc Z PeerRecord )
+    : ( Vec u ) pk ( vec_with_cap [u] ( vec_len [u] pubkey ) )
+    ( vec_extend [u] pk pubkey )
+    = . r pubkey pk
+    = . r endpoints ( vec_new [s] )
+    = . r relay_host ( string_from relay_host )
+    = . r relay_port relay_port
+    ^ # s r
+}
+
+@ peer_record_add_endpoint *PeerRecord r s host i port → v {
+    : *Endpoint e # *Endpoint ( nurl_alloc Z Endpoint )
+    = . e host ( string_from host )
+    = . e port port
+    ( vec_push [s] . r endpoints # s e )
+}
+
+@ peer_record_free *PeerRecord r → v {
+    ( vec_free [u] . r pubkey )
+    : i n ( vec_len [s] . r endpoints )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . r endpoints k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { ( endpoint_free # *Endpoint pp ) } {}
+        = k + k 1
+    }
+    ( vec_free [s] . r endpoints )
+    ( string_free . r relay_host )
+    ( nurl_free # s r )
+}
+
+// ── record codec ─────────────────────────────────────────────────
+
+@ __rz_put_str ( Vec u ) b String s → v {
+    : i n ( string_len s )
+    ( bytes_push_u16_be b # u16 n )
+    : s cs ( string_data s )
+    : *u sp # *u cs
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] b # u . sp k ) = k + k 1 }
+}
+
+@ rz_record_encode *PeerRecord r → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( vec_extend [u] b . r pubkey )
+    ( __rz_put_str b . r relay_host )
+    ( bytes_push_u16_be b # u16 . r relay_port )
+    : i n ( vec_len [s] . r endpoints )
+    ( bytes_push_u16_be b # u16 n )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . r endpoints k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *Endpoint e # *Endpoint pp
+            ( __rz_put_str b . e host )
+            ( bytes_push_u16_be b # u16 . e port )
+        } {}
+        = k + k 1
+    }
+    ^ b
+}
+
+// cursor-based reader (advances an offset through a buffer)
+: RzCursor {
+    ( Vec u ) buf
+    i off
+}
+@ __rz_u8 *RzCursor c → i {
+    : i v ?? ( vec_get [u] . c buf . c off ) { T x → # i x F → 0 }
+    = . c off + . c off 1
+    ^ v
+}
+@ __rz_u16 *RzCursor c → i {
+    : i v ?? ( bytes_read_u16_be . c buf . c off ) { T x → # i x F → 0 }
+    = . c off + . c off 2
+    ^ v
+}
+@ __rz_take *RzCursor c i n → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] n )
+    : ~ i k 0
+    ~ < k n { ?? ( vec_get [u] . c buf + . c off k ) { T b → ( vec_push [u] o b ) F → {} } = k + k 1 }
+    = . c off + . c off n
+    ^ o
+}
+@ __rz_str *RzCursor c → String {
+    : i n ( __rz_u16 c )
+    : String s ( string_with_cap n )
+    : ~ i k 0
+    ~ < k n { ( string_push_char s ( __rz_u8 c ) ) = k + k 1 }
+    ^ s
+}
+
+// Decode a record from a cursor; returns *PeerRecord.
+@ __rz_get_record *RzCursor c → s {
+    : *PeerRecord r # *PeerRecord ( nurl_alloc Z PeerRecord )
+    = . r pubkey ( __rz_take c 32 )
+    = . r relay_host ( __rz_str c )
+    = . r relay_port ( __rz_u16 c )
+    : i n ( __rz_u16 c )
+    = . r endpoints ( vec_new [s] )
+    : ~ i k 0
+    ~ < k n {
+        : *Endpoint e # *Endpoint ( nurl_alloc Z Endpoint )
+        = . e host ( __rz_str c )
+        = . e port ( __rz_u16 c )
+        ( vec_push [s] . r endpoints # s e )
+        = k + k 1
+    }
+    ^ # s r
+}
+
+// Decode a standalone record buffer (whole buffer is one record).
+@ rz_record_decode ( Vec u ) buf → s {
+    : *RzCursor c # *RzCursor ( nurl_alloc Z RzCursor )
+    = . c buf buf
+    = . c off 0
+    : s r ( __rz_get_record c )
+    ( nurl_free # s c )
+    ^ r
+}
+
+// ── frame codec ──────────────────────────────────────────────────
+
+: RzFrame {
+    i ftype
+    ( Vec u ) body
+}
+@ rz_frame_free RzFrame fr → v { ( vec_free [u] . fr body ) }
+
+@ __rz_frame i ftype ( Vec u ) body → ( Vec u ) {
+    : ( Vec u ) f ( vec_new [u] )
+    ( vec_push [u] f # u ftype )
+    ( bytes_push_u32_be f # u32 ( vec_len [u] body ) )
+    ( vec_extend [u] f body )
+    ^ f
+}
+
+@ rz_build_register *PeerRecord r → ( Vec u ) {
+    : ( Vec u ) body ( rz_record_encode r )
+    : ( Vec u ) f ( __rz_frame ( rz_register ) body )
+    ( vec_free [u] body )
+    ^ f
+}
+@ rz_build_lookup ( Vec u ) pubkey → ( Vec u ) { ^ ( __rz_frame ( rz_lookup ) pubkey ) }
+@ rz_build_ok → ( Vec u ) {
+    : ( Vec u ) empty ( vec_new [u] )
+    : ( Vec u ) f ( __rz_frame ( rz_ok ) empty )
+    ( vec_free [u] empty )
+    ^ f
+}
+@ rz_build_record_found *PeerRecord r → ( Vec u ) {
+    : ( Vec u ) body ( vec_new [u] )
+    ( vec_push [u] body # u 1 )
+    : ( Vec u ) rec ( rz_record_encode r )
+    ( vec_extend [u] body rec )
+    ( vec_free [u] rec )
+    : ( Vec u ) f ( __rz_frame ( rz_record ) body )
+    ( vec_free [u] body )
+    ^ f
+}
+@ rz_build_record_notfound → ( Vec u ) {
+    : ( Vec u ) body ( vec_new [u] )
+    ( vec_push [u] body # u 0 )
+    : ( Vec u ) f ( __rz_frame ( rz_record ) body )
+    ( vec_free [u] body )
+    ^ f
+}
+
+@ rz_parse ( Vec u ) buf → ?RzFrame {
+    : i n ( vec_len [u] buf )
+    ? < n 5 { ^ @ ?RzFrame { F # RzFrame 0 } } {}
+    : i ftype ?? ( vec_get [u] buf 0 ) { T x → # i x F → -1 }
+    : i len ?? ( bytes_read_u32_be buf 1 ) { T x → # i x F → -1 }
+    ? > len ( __rz_max ) { ^ @ ?RzFrame { F # RzFrame 0 } } {}
+    ? < n + 5 len { ^ @ ?RzFrame { F # RzFrame 0 } } {}
+    : ( Vec u ) body ( vec_with_cap [u] len )
+    : ~ i k 0
+    ~ < k len { ?? ( vec_get [u] buf + 5 k ) { T b → ( vec_push [u] body b ) F → {} } = k + k 1 }
+    ^ @ ?RzFrame { T @ RzFrame { ftype body } }
+}
+
+// ── streaming frame reader (TcpConn) ─────────────────────────────
+
+@ __rz_read_exact TcpConn c i n → ?( Vec u ) {
+    : ( Vec u ) buf ( vec_with_cap [u] n )
+    : ~ b fail F
+    : ~ i got 0
+    ~ & ! fail < got n {
+        : !( Vec u ) NetErr r ( tcp_read_chunk c - n got )
+        ?? r {
+            T chunk → {
+                : i cn ( vec_len [u] chunk )
+                ? == cn 0 { = fail T } { ( vec_extend [u] buf chunk ) = got + got cn }
+                ( vec_free [u] chunk )
+            }
+            F _ → { = fail T }
+        }
+    }
+    ? fail { ( vec_free [u] buf ) ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    ^ @ ?( Vec u ) { T buf }
+}
+
+@ rz_read_frame TcpConn c → ?RzFrame {
+    : ~ ?RzFrame out @ ?RzFrame { F # RzFrame 0 }
+    : ?( Vec u ) hdr ( __rz_read_exact c 5 )
+    ?? hdr {
+        T h → {
+            : i ftype ?? ( vec_get [u] h 0 ) { T x → # i x F → -1 }
+            : i len ?? ( bytes_read_u32_be h 1 ) { T x → # i x F → -1 }
+            ( vec_free [u] h )
+            ? & >= len 0 <= len ( __rz_max ) {
+                : ?( Vec u ) bd ( __rz_read_exact c len )
+                ?? bd {
+                    T body → { = out @ ?RzFrame { T @ RzFrame { ftype body } } }
+                    F → {}
+                }
+            } {}
+        }
+        F → {}
+    }
+    ^ out
+}
+
+// ════════════════════════════════════════════════════════════════
+// Rendezvous SERVER — pubkey → PeerRecord directory.
+// ════════════════════════════════════════════════════════════════
+
+: RzServer {
+    TcpListener lst
+    ( Vec s ) records   // *PeerRecord
+}
+
+@ rz_server_start s host i port → !RzServer NetErr {
+    : !TcpListener NetErr lr ( tcp_listen host port )
+    : !RzServer NetErr out ?? lr {
+        T l → @ !RzServer NetErr { T @ RzServer { l ( vec_new [s] ) } }
+        F e → @ !RzServer NetErr { F e }
+    }
+    ^ out
+}
+
+@ __rz_veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a )
+    ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n {
+        : i x ?? ( vec_get [u] a k ) { T t → # i t F → -1 }
+        : i y ?? ( vec_get [u] b k ) { T t → # i t F → -2 }
+        ? != x y { = e F } {}
+        = k + k 1
+    }
+    ^ e
+}
+
+@ __rz_find *RzServer rs ( Vec u ) pk → s {
+    : i n ( vec_len [s] . rs records )
+    : ~ s found # s 0
+    : ~ i k 0
+    ~ & == # i found 0 < k n {
+        : s pp ?? ( vec_get [s] . rs records k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *PeerRecord r # *PeerRecord pp
+            ? ( __rz_veq . r pubkey pk ) { = found pp } {}
+        } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+// Insert or replace the record for a pubkey (latest registration wins).
+@ __rz_upsert *RzServer rs s newrec → v {
+    : *PeerRecord nr # *PeerRecord newrec
+    : s old ( __rz_find rs . nr pubkey )
+    ? != # i old 0 {
+        : i n ( vec_len [s] . rs records )
+        : ~ i k 0
+        ~ < k n {
+            : s pp ?? ( vec_get [s] . rs records k ) { T x → x F → # s 0 }
+            ? == # i pp old { ( vec_set [s] . rs records k newrec ) } {}
+            = k + k 1
+        }
+        ( peer_record_free # *PeerRecord old )
+    } { ( vec_push [s] . rs records newrec ) }
+}
+
+@ __rz_handle_conn *RzServer rs TcpConn c → v {
+    : ~ b done F
+    ~ ! done {
+        : ?RzFrame fr ( rz_read_frame c )
+        ?? fr {
+            T f → {
+                ? == . f ftype ( rz_register ) {
+                    : s nr ( rz_record_decode . f body )
+                    ( __rz_upsert rs nr )
+                    : ( Vec u ) ack ( rz_build_ok )
+                    ?? ( tcp_write_all c ack ) { T _ → {} F _ → { = done T } }
+                    ( vec_free [u] ack )
+                } {}
+                ? == . f ftype ( rz_lookup ) {
+                    : s found ( __rz_find rs . f body )
+                    : ( Vec u ) resp ? != # i found 0 ( rz_build_record_found # *PeerRecord found ) ( rz_build_record_notfound )
+                    ?? ( tcp_write_all c resp ) { T _ → {} F _ → { = done T } }
+                    ( vec_free [u] resp )
+                } {}
+                ( rz_frame_free f )
+            }
+            F → { = done T }
+        }
+    }
+    ( tcp_close_conn c )
+}
+
+@ __rz_accept_loop *RzServer rs → v {
+    : TcpListener lst . rs lst
+    : ~ b done F
+    ~ ! done {
+        : !TcpConn NetErr cr ( tcp_accept lst )
+        ?? cr {
+            T c → { ( spawn \ → v { ( __rz_handle_conn rs c ) } ) }
+            F e → { = done T }
+        }
+    }
+}
+
+@ rz_server_run *RzServer rs → v {
+    ( tcp_listener_retain . rs lst )
+    : ( @ v ) accept_fiber \ → v { ( __rz_accept_loop rs ) }
+    ( spawn accept_fiber )
+    ( runtime_run )
+    ( tcp_listener_release . rs lst )
+    : *u accept_env # *u accept_fiber 1
+    ( nurl_free # s accept_env )
+}
+
+@ rz_server_stop *RzServer rs → v { ( tcp_close_listener . rs lst ) }
+
+@ rz_server_free *RzServer rs → v {
+    : i n ( vec_len [s] . rs records )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . rs records k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { ( peer_record_free # *PeerRecord pp ) } {}
+        = k + k 1
+    }
+    ( vec_free [s] . rs records )
+    ( nurl_free # s rs )
+}
+
+// ════════════════════════════════════════════════════════════════
+// Rendezvous CLIENT — register self, look up peers.
+// ════════════════════════════════════════════════════════════════
+
+: RzClient {
+    TcpConn conn
+}
+
+@ rz_client_connect s host i port → !RzClient NetErr {
+    : i raw ( nurl_tcp_connect host port )
+    ? == raw 0 { ^ @ !RzClient NetErr { F # NetErr NetOther } } {}
+    : i ek ( nurl_tcp_err_kind raw )
+    ? != ek 0 { ( nurl_tcp_close raw ) ^ @ !RzClient NetErr { F ( __net_err_of ek ) } } {}
+    : TcpConn c @ TcpConn { # s raw }
+    ^ @ !RzClient NetErr { T @ RzClient { c } }
+}
+
+// Publish our record; waits for the server's OK.
+@ rz_register_self RzClient rc *PeerRecord r → !v NetErr {
+    : ( Vec u ) f ( rz_build_register r )
+    : !v NetErr wr ( tcp_write_all . rc conn f )
+    ( vec_free [u] f )
+    : !v NetErr out ?? wr {
+        T _ → {
+            ?? ( rz_read_frame . rc conn ) {
+                T fr → { : i ok ? == . fr ftype ( rz_ok ) 1 0 ( rz_frame_free fr ) ? == ok 1 @ !v NetErr { T 0 } @ !v NetErr { F # NetErr NetOther } }
+                F → @ !v NetErr { F # NetErr NetClosed }
+            }
+        }
+        F e → @ !v NetErr { F e }
+    }
+    ^ out
+}
+
+// Look up a peer's record by pubkey; returns *PeerRecord (0 = not found /
+// error). Caller owns it → peer_record_free when done.
+@ rz_lookup_peer RzClient rc ( Vec u ) pubkey → s {
+    : ( Vec u ) f ( rz_build_lookup pubkey )
+    : ~ s out # s 0
+    ?? ( tcp_write_all . rc conn f ) {
+        T _ → {
+            ?? ( rz_read_frame . rc conn ) {
+                T fr → {
+                    ? == . fr ftype ( rz_record ) {
+                        : i found ?? ( vec_get [u] . fr body 0 ) { T x → # i x F → 0 }
+                        ? == found 1 {
+                            // record body sits after the 1-byte found flag
+                            : *RzCursor cur # *RzCursor ( nurl_alloc Z RzCursor )
+                            = . cur buf . fr body
+                            = . cur off 1
+                            = out ( __rz_get_record cur )
+                            ( nurl_free # s cur )
+                        } {}
+                    } {}
+                    ( rz_frame_free fr )
+                }
+                F → {}
+            }
+        }
+        F _ → {}
+    }
+    ( vec_free [u] f )
+    ^ out
+}
+
+@ rz_client_close RzClient rc → v { ( tcp_close_conn . rc conn ) }


### PR DESCRIPTION
## Summary
**Phase 3** of the §7.4 plan (parallelizable, now done). Peers are addressed by static public key, but to open a **direct** path a peer must learn *where another currently is*. `net/rendezvous` is that directory: a peer **REGISTERs** (pubkey → candidate endpoints from `net/nat` + chosen relay) and any peer **LOOKs** another up by pubkey. The looked-up endpoints feed `transport_try_direct` (hole punch + securedgram handshake); the relay is the guaranteed fallback.

**Control plane only** — no application data or media ever flows here. It is the offer/answer of endpoints (not SDP); the data plane is `net/transport` (direct via securedgram, relayed via `net/relay`).

### Wire — `[type:1][len:4 BE][body]`
| type | name | body |
|------|------|------|
| 1 | REGISTER | `record` |
| 2 | LOOKUP | `pubkey(32)` |
| 3 | OK | *(empty)* — register ack |
| 4 | RECORD | `found(1) [++ record]` — lookup reply |

`record = pubkey(32) ++ str(relay_host) ++ u16(relay_port) ++ u16(n) ++ [str(host) ++ u16(port)]*`, `str = u16(len) ++ bytes`. Pure record + frame codec with an oversize guard; a cursor-based decoder (`RzCursor` advances an offset).

### Server / Client
- **Server** keeps a `pubkey → PeerRecord` directory (latest registration wins); accept fiber + per-conn handler fiber (the `server_run_async` idiom).
- **Client**: `rz_client_connect` / `rz_register_self` (waits for OK) / `rz_lookup_peer` (→ `*PeerRecord`, caller-owned) / `rz_client_close`.

## Testing
- **`rendezvous_codec.nu`** (+ golden) — a `PeerRecord` (pubkey + 2 candidate endpoints + relay) round-trips through the record codec and through REGISTER / LOOKUP / RECORD(found|notfound) frames. ASan-clean.
- **Live** (loopback): A registers its candidates+relay, B looks A up by pubkey and gets the same endpoints+relay back.
- Suite **378/378**, examples gate **76/76**. No compiler changes.

With this, the §7.4 control + data planes are both in place: rendezvous (discover) → `transport_try_direct` (punch + direct) with relay fallback. Remaining: the SWIM rekey to pubkey-over-transport (Phase 5 core) and the Phase 8 sim-NAT harness to prove stability across a forced network change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)