### PR TITLE
feat(net): failure-detector control loop — SWIM probing over the overlay (§7.4 Phase 5)

### DIFF
--- a/compiler/tests/membership_fd.nu
+++ b/compiler/tests/membership_fd.nu
@@ -1,0 +1,93 @@
+// membership_fd.nu — offline scenario test for stdlib/net/failuredetector.nu.
+// Deterministic, time-injected, no sockets: drives the probe state machine
+// through a healthy probe, an escalation to ping-req → suspect → dead, and
+// the key mobile case — a LATE direct ack (a wifi↔cellular roam) keeps a
+// member alive instead of letting it be declared dead.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/net/membership.nu`
+$ `stdlib/net/failuredetector.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+@ mkpk i seed → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + seed k ) = k + k 1 } ^ v }
+@ veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a ) ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n { ? != ?? ( vec_get [u] a k ) { T t → # i t F → -1 } ?? ( vec_get [u] b k ) { T t → # i t F → -2 } { = e F } {} = k + k 1 }
+    ^ e
+}
+
+@ main → i {
+    : ( Vec u ) me ( mkpk 0 )
+    : ( Vec u ) b ( mkpk 50 )
+    : ( Vec u ) c ( mkpk 90 )
+
+    // ── healthy probe: ping then ack ─────────────────────────────
+    : *PkMemberTable t1 ( pktable_new me 1000 5000 3 8 )
+    ( pktable_apply t1 b ( pk_alive ) 1 0 )
+    ( pktable_apply t1 c ( pk_alive ) 1 0 )
+    // fd: period 1000, direct-timeout 300, total-timeout 600, k 2
+    : *FdState fd1 ( fd_new # s t1 1000 300 600 2 )
+    : FdAction a1 ( fd_tick fd1 0 )
+    ( pb `t=0 emits ping: ` == . a1 kind ( fd_do_ping ) )
+    ( pb `ping target is a member: ` | ( veq . a1 target b ) ( veq . a1 target c ) )
+    : i probed_seq . a1 seq
+    ( pb `probing in flight: ` == ( fd_probing fd1 ) 1 )
+    ( fd_action_free a1 )
+    ( pb `direct ack clears probe: ` ( fd_on_ack fd1 probed_seq 50 ) )
+    ( pb `probe cleared: ` == ( fd_probing fd1 ) 0 )
+    ( fd_free fd1 ) ( pktable_free t1 )
+
+    // ── escalate ping → ping-req → suspect → dead ────────────────
+    : *PkMemberTable t2 ( pktable_new me 1000 5000 3 8 )
+    ( pktable_apply t2 b ( pk_alive ) 1 0 )
+    ( pktable_apply t2 c ( pk_alive ) 1 0 )
+    : *FdState fd2 ( fd_new # s t2 1000 300 600 2 )
+    : FdAction p0 ( fd_tick fd2 0 )           // ping target X
+    : ( Vec u ) tgt ( vec_with_cap [u] 32 ) ( vec_extend [u] tgt . p0 target )
+    ( fd_action_free p0 )
+    // no ack; at direct-timeout → ping-req
+    : FdAction p1 ( fd_tick fd2 300 )
+    ( pb `direct-timeout escalates to ping-req: ` == . p1 kind ( fd_do_preq ) )
+    ( pb `ping-req re-targets same member: ` ( veq . p1 target tgt ) )
+    ( pb `ping-req picks a relay: ` == ( vec_len [s] . p1 relays ) 1 )
+    ( fd_action_free p1 )
+    // still no ack; at total-timeout → suspect (no action)
+    : FdAction p2 ( fd_tick fd2 600 )
+    ( pb `total-timeout emits no action: ` == . p2 kind ( fd_none ) )
+    ( fd_action_free p2 )
+    ( pb `member now suspected: ` == ( pktable_state_of t2 tgt ) ( pk_suspect ) )
+    ( pb `failed probe bumped LHM: ` == ( lh_value_of t2 ) 1 )
+    // sweep: lone suspicion, LHM 1 → ceiling 5000*2 = 10000 from t=600
+    : ( Vec s ) sd0 ( fd_sweep fd2 5000 )
+    ( pb `not dead before scaled ceiling: ` == ( vec_len [s] sd0 ) 0 )
+    ( __pk_dead_free sd0 )
+    : ( Vec s ) sd1 ( fd_sweep fd2 11000 )
+    ( pb `dead after scaled ceiling: ` & == ( vec_len [s] sd1 ) 1 == ( pktable_state_of t2 tgt ) ( pk_dead ) )
+    ( __pk_dead_free sd1 )
+    ( vec_free [u] tgt )
+    ( fd_free fd2 ) ( pktable_free t2 )
+
+    // ── forced network change: a LATE ack keeps the member alive ─
+    : *PkMemberTable t3 ( pktable_new me 1000 5000 3 8 )
+    ( pktable_apply t3 b ( pk_alive ) 1 0 )
+    : *FdState fd3 ( fd_new # s t3 1000 300 600 2 )
+    : FdAction q0 ( fd_tick fd3 0 )           // ping b, seq known
+    : i bseq . q0 seq
+    ( fd_action_free q0 )
+    : FdAction q1 ( fd_tick fd3 300 )         // escalate to ping-req (b slow)
+    ( pb `roam: escalated to ping-req: ` == . q1 kind ( fd_do_preq ) )
+    ( fd_action_free q1 )
+    // ack finally arrives at t=500 (< total-timeout 600): roam recovered
+    ( pb `late ack accepted: ` ( fd_on_ack fd3 bseq 500 ) )
+    : FdAction q2 ( fd_tick fd3 600 )         // would-be suspect time
+    ( fd_action_free q2 )
+    : ( Vec s ) sd2 ( fd_sweep fd3 50000 )
+    ( pb `member stayed ALIVE across the roam: ` & == ( vec_len [s] sd2 ) 0 == ( pktable_state_of t3 b ) ( pk_alive ) )
+    ( __pk_dead_free sd2 )
+    ( fd_free fd3 ) ( pktable_free t3 )
+
+    ( vec_free [u] me ) ( vec_free [u] b ) ( vec_free [u] c )
+    ^ 0
+}

--- a/compiler/tests/outputs/membership_fd.txt
+++ b/compiler/tests/outputs/membership_fd.txt
@@ -1,0 +1,20 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+t=0 emits ping: YES
+ping target is a member: YES
+probing in flight: YES
+direct ack clears probe: YES
+probe cleared: YES
+direct-timeout escalates to ping-req: YES
+ping-req re-targets same member: YES
+ping-req picks a relay: YES
+total-timeout emits no action: YES
+member now suspected: YES
+failed probe bumped LHM: YES
+not dead before scaled ceiling: YES
+dead after scaled ceiling: YES
+roam: escalated to ping-req: YES
+late ack accepted: YES
+member stayed ALIVE across the roam: YES

--- a/examples/membership.nu
+++ b/examples/membership.nu
@@ -1,0 +1,105 @@
+// examples/membership.nu — a SWIM membership node over the pubkey overlay
+// (TODO §7.4 Phase 5): net/failuredetector drives net/membership, and every
+// probe/ack/gossip rides net/transport addressed by PUBLIC KEY (direct via
+// securedgram when possible, relayed otherwise). This is the adapter that
+// turns the pure FD step machine into a live detector.
+//
+//   ./nurl.sh examples/membership.nu <relay_host> <relay_port>
+//
+// (Illustrative wiring — run a relay with examples/relay.nu and several of
+// these; each learns the others via net/rendezvous in a full deployment.)
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/async.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/net/relay.nu`
+$ `stdlib/net/transport.nu`
+$ `stdlib/net/membership.nu`
+$ `stdlib/net/failuredetector.nu`
+
+@ my_pk → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + 1 k ) = k + k 1 } ^ v }
+
+// Send a membership message (PING/ACK/PING-REQ + gossip) to a peer pubkey
+// over the transport — direct or relayed, the FD neither knows nor cares.
+@ send_msg *Transport tr ( Vec u ) dst i mtype i seq *PkMemberTable tbl → v {
+    : ( Vec s ) g ( pktable_gossip tbl 6 )
+    : PkMsg m @ PkMsg { mtype seq ( vec_new [u] ) g }
+    : ( Vec u ) wire ( pkmsg_encode m )
+    ?? ( transport_send tr dst wire ) { T _ → {} F _ → {} }
+    ( pkmsg_free m ) ( vec_free [u] wire )
+}
+
+// Perform one FD action on the wire.
+@ do_action *Transport tr FdAction a *PkMemberTable tbl → v {
+    ? == . a kind ( fd_do_ping ) { ( send_msg tr . a target ( pk_ping ) . a seq tbl ) } {}
+    ? == . a kind ( fd_do_preq ) {
+        // ask each relay to probe the target on our behalf
+        : i n ( vec_len [s] . a relays )
+        : ~ i k 0
+        ~ < k n {
+            : s pp ?? ( vec_get [s] . a relays k ) { T x → x F → # s 0 }
+            ? != # i pp 0 { : *PkMember rm # *PkMember pp ( send_msg tr . rm pubkey ( pk_pingreq ) . a seq tbl ) } {}
+            = k + k 1
+        }
+    } {}
+}
+
+// Drain inbound messages, feeding acks/gossip to the FD and answering pings.
+@ pump *Transport tr *FdState fd *PkMemberTable tbl ( Vec u ) self_pk i now → v {
+    : ~ b more T
+    ~ more {
+        ?? ( transport_recv tr 50 ) {
+            T msg → {
+                : PkMsg m ( pkmsg_decode . msg payload )
+                ( fd_on_gossip fd m now )
+                ? == . m mtype ( pk_ack ) { ( fd_on_ack fd . m seq now ) } {}
+                ? == . m mtype ( pk_ping ) { ( send_msg tr . msg src ( pk_ack ) . m seq tbl ) } {}
+                ( pkmsg_free m )
+                ( transport_msg_free msg )
+            }
+            F → { = more F }
+        }
+    }
+}
+
+@ main → i {
+    : i argc ( env_args_count )
+    : String host ? > argc 1 ( env_arg 1 ) ( string_from `127.0.0.1` )
+    : i port ? > argc 2 {
+        : String ps ( env_arg 2 ) : i p ( nurl_str_to_int ( string_data ps ) ) ( string_free ps ) p
+    } 47700
+
+    ?? ( relay_dial ( string_data host ) port ) {
+        T rc → {
+            : ( Vec u ) self_pk ( my_pk )
+            ?? ( relay_register rc self_pk ) { T _ → {} F _ → {} }
+            ( relay_set_timeout rc 200 )
+            : *Transport tr # *Transport ( transport_open # s 0 rc 1 )
+            : *PkMemberTable tbl ( pktable_new self_pk 2000000000 8000000000 3 8 )
+            // ( transport_add_peer + pktable_apply for each known peer … )
+            : *FdState fd ( fd_new # s tbl 1000000000 300000000 2000000000 3 )
+
+            : ~ i ticks 0
+            ~ < ticks 3 {
+                : i now ( monotonic_ns )
+                : FdAction a ( fd_tick fd now )
+                ( do_action tr a tbl )
+                ( fd_action_free a )
+                ( pump tr fd tbl self_pk now )
+                : ( Vec s ) dead ( fd_sweep fd now )
+                ( __pk_dead_free dead )
+                ( sleep_ms 200 )
+                = ticks + ticks 1
+            }
+            ( nurl_print `membership node ran (members: ` ) ( nurl_print_int ( pktable_count tbl ) ) ( nurl_print `)\n` )
+
+            ( fd_free fd ) ( pktable_free tbl ) ( transport_free tr )
+            ( vec_free [u] self_pk ) ( relay_close rc )
+        }
+        F e → ( nurl_print `could not reach relay\n` )
+    }
+    ( string_free host )
+    ^ 0
+}

--- a/stdlib/net/failuredetector.nu
+++ b/stdlib/net/failuredetector.nu
@@ -1,0 +1,147 @@
+// stdlib/net/failuredetector.nu — SWIM failure-detector control loop over
+// net/membership (§7.4 Phase 5). This is the PROBE STATE MACHINE that turns
+// the membership table into a live detector:
+//
+//   every `period`  → probe a member (direct PING);
+//   no ack by `direct_timeout` → escalate to an indirect PING-REQ via k
+//     relays (over net/transport this maps onto the relay alternate path —
+//     if A can't reach B directly, a relay can);
+//   no ack at all by `total_timeout` → suspect the member (Lifeguard
+//     confirmation- + local-health-scaled suspicion then sweeps it to dead);
+//   a direct ack (even a LATE one, e.g. after a wifi↔cellular roam) → the
+//     member stays / returns alive and local health improves.
+//
+// The control logic is PURE and time-injected: fd_tick(now) returns the next
+// FdAction (none / ping / ping-req) and mutates only the detector's own probe
+// bookkeeping + the membership table; fd_on_ack / fd_on_gossip feed events
+// in. The actual transport I/O (perform the action, read replies) is a thin
+// adapter the caller writes — so the whole "is the cluster stable across a
+// forced network change?" question is a deterministic scenario test here, not
+// a live-socket guess.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/net/membership.nu`
+$ `stdlib/std/lifeguard.nu`
+
+@ fd_none    → i { ^ 0 }
+@ fd_do_ping → i { ^ 1 }
+@ fd_do_preq → i { ^ 2 }
+
+@ __fd_cpy ( Vec u ) v → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
+    ( vec_extend [u] o v )
+    ^ o
+}
+
+// What the caller should put on the wire this tick.
+: FdAction {
+    i kind            // 0 none, 1 ping, 2 ping-req
+    ( Vec u ) target  // pubkey to probe (owned copy; empty for none)
+    i seq
+    ( Vec s ) relays  // ping-req: borrowed *PkMember relays (table-owned)
+}
+@ fd_action_free FdAction a → v { ( vec_free [u] . a target ) ( vec_free [s] . a relays ) }
+@ __fd_none → FdAction { ^ @ FdAction { ( fd_none ) ( vec_new [u] ) 0 ( vec_new [s] ) } }
+
+: FdState {
+    s table              // *PkMemberTable
+    i period_ns
+    i direct_timeout_ns  // direct-ack window before escalating to ping-req
+    i total_timeout_ns   // total window before suspecting
+    i k_indirect         // relays for a ping-req
+    i next_seq
+    i probing            // 1 = a probe is in flight
+    ( Vec u ) probe_target
+    i probe_seq
+    i probe_start_ns
+    i probe_indirect     // 1 = ping-req already escalated for this probe
+    i last_probe_ns
+}
+
+@ fd_new s table i period_ns i direct_timeout_ns i total_timeout_ns i k_indirect → *FdState {
+    : *FdState fd # *FdState ( nurl_alloc Z FdState )
+    = . fd table table
+    = . fd period_ns period_ns
+    = . fd direct_timeout_ns direct_timeout_ns
+    = . fd total_timeout_ns total_timeout_ns
+    = . fd k_indirect k_indirect
+    = . fd next_seq 1
+    = . fd probing 0
+    = . fd probe_target ( vec_new [u] )
+    = . fd probe_seq 0
+    = . fd probe_start_ns 0
+    = . fd probe_indirect 0
+    = . fd last_probe_ns - 0 period_ns   // eligible to probe immediately
+    ^ fd
+}
+@ fd_free *FdState fd → v { ( vec_free [u] . fd probe_target ) ( nurl_free # s fd ) }
+@ fd_probing *FdState fd → i { ^ . fd probing }
+
+// Advance the detector. Returns at most one action; the caller performs it.
+@ fd_tick *FdState fd i now → FdAction {
+    : *PkMemberTable t # *PkMemberTable . fd table
+    ? == . fd probing 1 {
+        : i elapsed - now . fd probe_start_ns
+        ? >= elapsed . fd total_timeout_ns {
+            ( pktable_suspect t . fd probe_target now )
+            ( pktable_on_probe_fail t )
+            = . fd probing 0
+            = . fd last_probe_ns now
+            ^ ( __fd_none )
+        } {}
+        ? & == . fd probe_indirect 0 >= elapsed . fd direct_timeout_ns {
+            = . fd probe_indirect 1
+            : ( Vec s ) relays ( pktable_pick_relays t . fd k_indirect . fd probe_target )
+            ^ @ FdAction { ( fd_do_preq ) ( __fd_cpy . fd probe_target ) . fd probe_seq relays }
+        } {}
+        ^ ( __fd_none )
+    } {}
+    ? >= - now . fd last_probe_ns . fd period_ns {
+        : ?( Vec u ) tgt ( pktable_pick_probe t )
+        : FdAction out ?? tgt {
+            T pk → {
+                = . fd probing 1
+                = . fd probe_indirect 0
+                = . fd probe_seq . fd next_seq
+                = . fd next_seq + . fd next_seq 1
+                = . fd probe_start_ns now
+                = . fd last_probe_ns now
+                ( vec_free [u] . fd probe_target )
+                = . fd probe_target ( __fd_cpy pk )
+                : FdAction a @ FdAction { ( fd_do_ping ) ( __fd_cpy pk ) . fd probe_seq ( vec_new [s] ) }
+                ( vec_free [u] pk )
+                a
+            }
+            F → ( __fd_none )
+        }
+        ^ out
+    } {}
+    ^ ( __fd_none )
+}
+
+// A direct ack for the in-flight probe arrived (possibly late, after a roam):
+// the member is alive, local health improves, the probe completes.
+@ fd_on_ack *FdState fd i seq i now → b {
+    ? & == . fd probing 1 == seq . fd probe_seq {
+        : *PkMemberTable t # *PkMemberTable . fd table
+        ( pktable_observe_alive t . fd probe_target now )
+        ( pktable_on_probe_ok t )
+        = . fd probing 0
+        ^ T
+    } {}
+    ^ F
+}
+
+// Merge a peer's piggybacked gossip into the table.
+@ fd_on_gossip *FdState fd PkMsg m i now → v {
+    : *PkMemberTable t # *PkMemberTable . fd table
+    ( pktable_apply_gossip t m now )
+}
+
+// Promote expired suspicions to dead (caller runs each tick); returns the
+// newly-dead as borrowed *PkMember (free the container with __pk_dead_free).
+@ fd_sweep *FdState fd i now → ( Vec s ) {
+    : *PkMemberTable t # *PkMemberTable . fd table
+    ^ ( pktable_sweep t now )
+}

--- a/stdlib/net/membership.nu
+++ b/stdlib/net/membership.nu
@@ -186,6 +186,24 @@ $ `stdlib/std/lifeguard.nu`
     ^ ( pktable_apply t pk ( pk_alive ) inc now_ns )
 }
 
+// A first-hand observation that a member is alive (we got a direct ack from
+// it). Authoritative for suspect→alive locally without needing a higher
+// incarnation; does NOT revive a dead member (that requires gossip carrying
+// a higher incarnation). Returns T if the member was revived from suspect.
+@ pktable_observe_alive *PkMemberTable t ( Vec u ) pk i now_ns → b {
+    : s pp ( __pk_find t pk )
+    ? == # i pp 0 { ^ F } {}
+    : *PkMember m # *PkMember pp
+    = . m last_ns now_ns
+    ? == . m state 1 {
+        = . m state 0
+        = . m susp_start_ns 0
+        = . m susp_confirms 0
+        ^ T
+    } {}
+    ^ F
+}
+
 // The effective suspicion deadline for a member, with the Lifeguard
 // confirmation scaling AND this node's local-health scaling applied.
 @ __pk_suspicion *PkMemberTable t *PkMember m → Suspicion {
@@ -247,6 +265,23 @@ $ `stdlib/std/lifeguard.nu`
             } {}
         } {}
         = tries + tries 1
+    }
+    ^ out
+}
+
+// Pick up to k alive members (excluding `exclude`) to relay an indirect
+// ping-req through. Returns BORROWED *PkMember pointers into the table.
+@ pktable_pick_relays *PkMemberTable t i k ( Vec u ) exclude → ( Vec s ) {
+    : ( Vec s ) out ( vec_new [s] )
+    : i n ( vec_len [s] . t members )
+    : ~ i idx 0
+    ~ & < idx n < ( vec_len [s] out ) k {
+        : s pp ?? ( vec_get [s] . t members idx ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *PkMember m # *PkMember pp
+            ? & == . m state 0 ! ( __pk_veq . m pubkey exclude ) { ( vec_push [s] out pp ) } {}
+        } {}
+        = idx + idx 1
     }
     ^ out
 }


### PR DESCRIPTION
## Summary
`net/failuredetector.nu` is the probe state machine that turns `net/membership` (#149) into a **live SWIM detector**, completing Phase 5's detection path:

| when | action |
|------|--------|
| every `period` | probe a member (direct **PING**) |
| no ack by `direct_timeout` | escalate to an indirect **PING-REQ** via `k` relays — over `net/transport` this maps onto the relay alternate path (if A can't reach B directly, a relay can) |
| no ack by `total_timeout` | **suspect** (Lifeguard confirmation- + local-health-scaled suspicion, then sweeps to **dead**) |
| a direct ack — *even a late one after a wifi↔cellular roam* | member stays / returns **alive**, local health improves |

The control logic is **pure and time-injected**: `fd_tick(now)` returns the next `FdAction` (none / ping / ping-req) and mutates only the detector's probe bookkeeping + the membership table; `fd_on_ack` / `fd_on_gossip` / `fd_sweep` feed events in. The transport I/O is a thin adapter (`examples/membership.nu` wires `fd_tick`→`transport_send`, `transport_recv`→`fd_on_ack` over a relay), so **cluster stability is a deterministic scenario test**, not a live-socket guess.

Additions to `net/membership`:
- **`pktable_observe_alive`** — a direct ack authoritatively revives a *suspected* member without needing a higher incarnation (does not revive *dead*).
- **`pktable_pick_relays`** — k alive relays excluding the probe target.

## Testing
- **`membership_fd.nu`** (+ golden) — healthy ping→ack; full escalation ping → ping-req → suspect → dead with the LHM-scaled ceiling; and the mobile case: a **late ack across a roam keeps the member alive**. ASan-clean.
- Suite **381/381**, examples gate **77/77**. No compiler changes.

This is the §7.4 completion criterion in deterministic form — "membership stays stable across a forced network change." The remaining Phase 8 sim-NAT harness turns this into an end-to-end multi-node chaos test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)