### PR TITLE
feat(dist): consistent-hash ring over pubkey members (§7.4 Phase 6)

### DIFF
--- a/compiler/tests/dist_ring.nu
+++ b/compiler/tests/dist_ring.nu
@@ -1,0 +1,114 @@
+// dist_ring.nu — offline test for stdlib/dist/ring.nu. Deterministic: builds
+// a consistent-hash ring of 3 members (64 vnodes each), checks ownership is
+// well-defined + stable, load is spread across all members, replica sets are
+// distinct, and — the consistent-hashing property — removing a member only
+// re-homes the keys it owned.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/dist/ring.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+@ mkpk i seed → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + seed k ) = k + k 1 } ^ v }
+@ veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a ) ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n { ? != ?? ( vec_get [u] a k ) { T t → # i t F → -1 } ?? ( vec_get [u] b k ) { T t → # i t F → -2 } { = e F } {} = k + k 1 }
+    ^ e
+}
+// distinct key bytes per i (4-byte LE)
+@ mkkey i x → ( Vec u ) {
+    : ( Vec u ) v ( vec_new [u] )
+    ( vec_push [u] v # u & x 255 )
+    ( vec_push [u] v # u & >> x 8 255 )
+    ( vec_push [u] v # u & >> x 16 255 )
+    ( vec_push [u] v # u & >> x 24 255 )
+    ^ v
+}
+@ owner_seed *Ring r ( Vec u ) key ( Vec u ) a ( Vec u ) b ( Vec u ) c → i {
+    ^ ?? ( ring_owner_pk r key ) {
+        T pk → { : i s ? ( veq pk a ) 1 ? ( veq pk b ) 2 ? ( veq pk c ) 3 0 ( vec_free [u] pk ) s }
+        F → 0
+    }
+}
+
+@ main → i {
+    : ( Vec u ) a ( mkpk 10 )
+    : ( Vec u ) b ( mkpk 80 )
+    : ( Vec u ) c ( mkpk 150 )
+
+    : *Ring r ( ring_new )
+    ( ring_add_member r a 64 )
+    ( ring_add_member r b 64 )
+    ( ring_add_member r c 64 )
+    ( pb `ring has 192 points (3 x 64): ` == ( ring_point_count r ) 192 )
+
+    // ownership well-defined + deterministic
+    : ( Vec u ) k0 ( mkkey 12345 )
+    : i o1 ( owner_seed r k0 a b c )
+    : i o2 ( owner_seed r k0 a b c )
+    ( pb `key has a valid owner: ` > o1 0 )
+    ( pb `ownership deterministic: ` == o1 o2 )
+    ( vec_free [u] k0 )
+
+    // load spread: across 300 keys every member owns some, none orphaned
+    : ~ i ca 0 : ~ i cb 0 : ~ i cc 0 : ~ i bad 0
+    : ~ i i 0
+    ~ < i 300 {
+        : ( Vec u ) key ( mkkey * i 2654435761 )
+        : i s ( owner_seed r key a b c )
+        ? == s 1 { = ca + ca 1 } { ? == s 2 { = cb + cb 1 } { ? == s 3 { = cc + cc 1 } { = bad + bad 1 } } }
+        ( vec_free [u] key )
+        = i + i 1
+    }
+    ( pb `no key unowned: ` == bad 0 )
+    ( pb `all 3 members carry load: ` & & > ca 0 > cb 0 > cc 0 )
+    ( pb `total accounted: ` == + + ca cb cc 300 )
+
+    // replica set: 2 distinct owners
+    : ( Vec u ) rk ( mkkey 999983 )
+    : ( Vec s ) reps ( ring_owners r rk 2 )
+    ( pb `replica set size 2: ` == ( vec_len [s] reps ) 2 )
+    : s r0 ?? ( vec_get [s] reps 0 ) { T x → x F → # s 0 }
+    : s r1 ?? ( vec_get [s] reps 1 ) { T x → x F → # s 0 }
+    : *RingPoint rp0 # *RingPoint r0
+    : *RingPoint rp1 # *RingPoint r1
+    ( pb `replicas distinct: ` ! ( veq . rp0 owner . rp1 owner ) )
+    ( vec_free [s] reps )
+    ( vec_free [u] rk )
+
+    // consistent hashing: removing C only re-homes C's keys
+    : ~ i stable 0 : ~ i remapped 0 : ~ i was_c 0
+    // snapshot owners, then remove c, re-check
+    ( ring_remove_member r c )
+    ( pb `ring now 128 points: ` == ( ring_point_count r ) 128 )
+    : ~ i j 0
+    ~ < j 300 {
+        : ( Vec u ) key ( mkkey * j 2654435761 )
+        : i after ( owner_seed r key a b c )
+        // recompute what it WAS by rebuilding owner on a fresh 3-node ring
+        ( vec_free [u] key )
+        = j + j 1
+    }
+    // rebuild a reference 3-node ring to compare pre/post removal
+    : *Ring ref ( ring_new )
+    ( ring_add_member ref a 64 ) ( ring_add_member ref b 64 ) ( ring_add_member ref c 64 )
+    : ~ i m 0
+    ~ < m 300 {
+        : ( Vec u ) key ( mkkey * m 2654435761 )
+        : i before ( owner_seed ref key a b c )
+        : i after ( owner_seed r key a b c )
+        ? == before 3 { = was_c + was_c 1 }
+        { ? == before after { = stable + stable 1 } { = remapped + remapped 1 } }
+        ( vec_free [u] key )
+        = m + m 1
+    }
+    ( pb `non-C keys kept their owner after C left: ` == remapped 0 )
+    ( pb `some keys were owned by C (and re-homed): ` > was_c 0 )
+    ( pb `stable + was_c == 300: ` == + stable was_c 300 )
+    ( ring_free ref )
+
+    ( ring_free r )
+    ( vec_free [u] a ) ( vec_free [u] b ) ( vec_free [u] c )
+    ^ 0
+}

--- a/compiler/tests/outputs/dist_ring.txt
+++ b/compiler/tests/outputs/dist_ring.txt
@@ -1,0 +1,16 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+ring has 192 points (3 x 64): YES
+key has a valid owner: YES
+ownership deterministic: YES
+no key unowned: YES
+all 3 members carry load: YES
+total accounted: YES
+replica set size 2: YES
+replicas distinct: YES
+ring now 128 points: YES
+non-C keys kept their owner after C left: YES
+some keys were owned by C (and re-homed): YES
+stable + was_c == 300: YES

--- a/stdlib/dist/ring.nu
+++ b/stdlib/dist/ring.nu
@@ -1,0 +1,197 @@
+// stdlib/dist/ring.nu — consistent-hash ring over pubkey-addressed members
+// (§7.4 Phase 6). Maps keys to the live member that OWNS them — the basis for
+// sharding distributed work/state across the SWIM cluster (net/membership)
+// with minimal disruption on churn.
+//
+// Each member is placed at `vnodes` pseudo-random points on a 64-bit ring
+// (virtual nodes → even load + smooth rebalancing). A key hashes onto the
+// ring and is owned by the next member clockwise; the n distinct members
+// clockwise are its replica set. Removing a member only re-homes the keys it
+// owned (the consistent-hashing property), not the whole keyspace.
+//
+// Hashing is FNV-1a/64 over raw bytes (native `^^` XOR + wrapping `*`),
+// deterministic and well-distributed; ring points are kept sorted so lookup
+// is a binary search. Pure + offline-testable; the caller rebuilds the ring
+// from membership on join/leave (hysteresis to damp churn is a follow-up).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/sort.nu`
+
+@ __ring_cpy ( Vec u ) v → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
+    ( vec_extend [u] o v )
+    ^ o
+}
+@ __ring_veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a )
+    ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n {
+        : i x ?? ( vec_get [u] a k ) { T t → # i t F → -1 }
+        : i y ?? ( vec_get [u] b k ) { T t → # i t F → -2 }
+        ? != x y { = e F } {}
+        = k + k 1
+    }
+    ^ e
+}
+
+// FNV-1a 64-bit over a byte vector (wraps in i64 two's complement).
+@ __ring_hash ( Vec u ) data → i {
+    : ~ i h 0xcbf29ce484222325
+    : i n ( vec_len [u] data )
+    : ~ i k 0
+    ~ < k n {
+        : i bj ?? ( vec_get [u] data k ) { T x → # i x F → 0 }
+        = h ^^ h & bj 255
+        = h * h 0x100000001b3
+        = k + k 1
+    }
+    ^ h
+}
+
+// Distinct ring position for member `pubkey`'s vnode `v`.
+@ __ring_point_hash ( Vec u ) pubkey i v → i {
+    : ( Vec u ) buf ( vec_with_cap [u] + ( vec_len [u] pubkey ) 4 )
+    ( vec_extend [u] buf pubkey )
+    ( bytes_push_u32_be buf # u32 v )
+    : i h ( __ring_hash buf )
+    ( vec_free [u] buf )
+    ^ h
+}
+
+: RingPoint {
+    i hash
+    ( Vec u ) owner
+}
+
+: Ring {
+    ( Vec s ) points   // *RingPoint, sorted ascending by signed hash
+}
+
+@ ring_new → *Ring {
+    : *Ring r # *Ring ( nurl_alloc Z Ring )
+    = . r points ( vec_new [s] )
+    ^ r
+}
+
+@ ring_free *Ring r → v {
+    : i n ( vec_len [s] . r points )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . r points k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *RingPoint p # *RingPoint pp ( vec_free [u] . p owner ) ( nurl_free # s p ) } {}
+        = k + k 1
+    }
+    ( vec_free [s] . r points )
+    ( nurl_free # s r )
+}
+
+@ ring_point_count *Ring r → i { ^ ( vec_len [s] . r points ) }
+
+@ __ring_sort *Ring r → v {
+    ( sort_by [s] . r points \ s a s b → i {
+        : *RingPoint pa # *RingPoint a
+        : *RingPoint pb # *RingPoint b
+        : i ha . pa hash
+        : i hb . pb hash
+        ? < ha hb { ^ - 0 1 } {}
+        ? > ha hb { ^ 1 } {}
+        ^ 0
+    } )
+}
+
+// Place a member at `vnodes` points on the ring.
+@ ring_add_member *Ring r ( Vec u ) pubkey i vnodes → v {
+    : ~ i v 0
+    ~ < v vnodes {
+        : *RingPoint p # *RingPoint ( nurl_alloc Z RingPoint )
+        = . p hash ( __ring_point_hash pubkey v )
+        = . p owner ( __ring_cpy pubkey )
+        ( vec_push [s] . r points # s p )
+        = v + v 1
+    }
+    ( __ring_sort r )
+}
+
+// Remove all of a member's points (keys it owned re-home clockwise).
+@ ring_remove_member *Ring r ( Vec u ) pubkey → v {
+    : ( Vec s ) keep ( vec_new [s] )
+    : i n ( vec_len [s] . r points )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . r points k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *RingPoint p # *RingPoint pp
+            ? ( __ring_veq . p owner pubkey ) { ( vec_free [u] . p owner ) ( nurl_free # s p ) } { ( vec_push [s] keep pp ) }
+        } {}
+        = k + k 1
+    }
+    ( vec_free [s] . r points )
+    = . r points keep
+}
+
+// First point index with hash >= kh (binary search), wrapping to 0.
+@ __ring_first_idx *Ring r i kh → i {
+    : i n ( vec_len [s] . r points )
+    : ~ i lo 0
+    : ~ i hi n
+    ~ < lo hi {
+        : i mid + lo / - hi lo 2
+        : s mp ?? ( vec_get [s] . r points mid ) { T x → x F → # s 0 }
+        : *RingPoint pm # *RingPoint mp
+        ? < . pm hash kh { = lo + mid 1 } { = hi mid }
+    }
+    ^ ? >= lo n 0 lo
+}
+
+// The *RingPoint owning `key` (0 on an empty ring). Borrowed (ring-owned).
+@ ring_owner *Ring r ( Vec u ) key → s {
+    : i n ( vec_len [s] . r points )
+    ? == n 0 { ^ # s 0 } {}
+    : i kh ( __ring_hash key )
+    : i idx ( __ring_first_idx r kh )
+    ^ ?? ( vec_get [s] . r points idx ) { T x → x F → # s 0 }
+}
+
+// Owner pubkey for `key`, copied (caller frees). None on an empty ring.
+@ ring_owner_pk *Ring r ( Vec u ) key → ?( Vec u ) {
+    : s pp ( ring_owner r key )
+    ? == # i pp 0 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    : *RingPoint p # *RingPoint pp
+    ^ @ ?( Vec u ) { T ( __ring_cpy . p owner ) }
+}
+
+@ __owners_has ( Vec s ) acc ( Vec u ) pk → b {
+    : i n ( vec_len [s] acc )
+    : ~ b found F : ~ i k 0
+    ~ & ! found < k n {
+        : s pp ?? ( vec_get [s] acc k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *RingPoint p # *RingPoint pp ? ( __ring_veq . p owner pk ) { = found T } {} } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+// The replica set for `key`: up to `nrep` DISTINCT owners clockwise from the
+// primary. Returns borrowed *RingPoint pointers (ring-owned); free only the
+// container with vec_free [s].
+@ ring_owners *Ring r ( Vec u ) key i nrep → ( Vec s ) {
+    : ( Vec s ) out ( vec_new [s] )
+    : i n ( vec_len [s] . r points )
+    ? == n 0 { ^ out } {}
+    : i kh ( __ring_hash key )
+    : i start ( __ring_first_idx r kh )
+    : ~ i steps 0
+    ~ & < steps n < ( vec_len [s] out ) nrep {
+        : i idx % + start steps n
+        : s pp ?? ( vec_get [s] . r points idx ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *RingPoint p # *RingPoint pp
+            ? ! ( __owners_has out . p owner ) { ( vec_push [s] out pp ) } {}
+        } {}
+        = steps + steps 1
+    }
+    ^ out
+}


### PR DESCRIPTION
## Summary
First piece of **Phase 6** (`dist/*` — the distributed-compute payoff). `dist/ring.nu` maps keys to the live member that **owns** them — the basis for sharding work/state across the SWIM cluster (`net/membership`) with minimal disruption on churn.

- Each member sits at `vnodes` pseudo-random points on a 64-bit ring (**virtual nodes** → even load + smooth rebalance).
- A key hashes onto the ring and is owned by the next member **clockwise**; `ring_owners` returns the n **distinct** members clockwise (the replica set).
- Removing a member only re-homes the keys **it** owned — the consistent-hashing property — not the whole keyspace.

Hashing is **FNV-1a/64** over raw bytes (native `^^` XOR + wrapping `*`), deterministic and well-distributed; points are kept sorted (`sort_by`) so lookup is a **binary search** (`__ring_first_idx`, wrapping clockwise).

API: `ring_new` / `ring_add_member` / `ring_remove_member` / `ring_owner` (→ borrowed `*RingPoint`) / `ring_owner_pk` (→ copied pubkey) / `ring_owners` (→ borrowed replica set) / `ring_point_count` / `ring_free`.

## Testing
- **`dist_ring.nu`** (+ golden): 3 members × 64 vnodes = 192 points; ownership well-defined + deterministic; a 300-key sample spreads across all 3 members with **none orphaned**; a replica set of 2 distinct owners; and the key property — after removing C, **every non-C key kept its owner** (`0 remapped`) while C's keys re-homed. ASan-clean.
- Suite **382/382**. No compiler changes.

Hysteresis / weighted vnodes to further damp churn is a follow-up. Next: `dist/crdt.nu` (delta-state counter / OR-set / LWW-register, gossip-spread — no Raft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)