### PR TITLE
feat(dist): CRDTs — PN-Counter, LWW-Register, OR-Set (§7.4 Phase 6)

### DIFF
--- a/compiler/tests/dist_crdt.nu
+++ b/compiler/tests/dist_crdt.nu
@@ -1,0 +1,67 @@
+// dist_crdt.nu — offline test for stdlib/dist/crdt.nu. Deterministic: checks
+// the CRDT laws — PNCounter convergence + idempotence + commutativity, LWW
+// timestamp/replica tie-break, and the OR-Set add-wins property under a
+// concurrent add/remove.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/dist/crdt.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ main → i {
+    // ── PNCounter ────────────────────────────────────────────────
+    : *PNCounter a ( pncounter_new )
+    ( pncounter_inc a 0 5 ) ( pncounter_dec a 0 2 )      // replica 0: +5 -2
+    : *PNCounter b ( pncounter_new )
+    ( pncounter_inc b 1 10 )                              // replica 1: +10
+    ( pb `a value = 3: ` == ( pncounter_value a ) 3 )
+    ( pb `b value = 10: ` == ( pncounter_value b ) 10 )
+    ( pncounter_merge a b )
+    ( pb `merged value = 13: ` == ( pncounter_value a ) 13 )
+    ( pncounter_merge a b )
+    ( pb `merge idempotent (still 13): ` == ( pncounter_value a ) 13 )
+    // commutativity: merge the other direction from fresh copies
+    : *PNCounter c ( pncounter_new )
+    ( pncounter_inc c 1 10 )
+    : *PNCounter d ( pncounter_new )
+    ( pncounter_inc d 0 5 ) ( pncounter_dec d 0 2 )
+    ( pncounter_merge c d )
+    ( pb `merge commutative (= 13): ` == ( pncounter_value c ) 13 )
+    ( pncounter_free a ) ( pncounter_free b ) ( pncounter_free c ) ( pncounter_free d )
+
+    // ── LwwReg ───────────────────────────────────────────────────
+    : LwwReg r1 ( lww_set ( lww_new ) 7 100 0 )
+    : LwwReg r2 ( lww_set ( lww_new ) 9 200 1 )
+    ( pb `higher ts wins (9): ` == ( lww_value ( lww_merge r1 r2 ) ) 9 )
+    ( pb `lww merge commutative: ` == ( lww_value ( lww_merge r2 r1 ) ) 9 )
+    : LwwReg t1 ( lww_set ( lww_new ) 7 100 0 )
+    : LwwReg t2 ( lww_set ( lww_new ) 9 100 1 )    // same ts → higher replica wins
+    ( pb `ts tie → higher replica (9): ` == ( lww_value ( lww_merge t1 t2 ) ) 9 )
+    ( pb `tie-break commutative: ` == ( lww_value ( lww_merge t2 t1 ) ) 9 )
+
+    // ── OrSet: plain add / remove ────────────────────────────────
+    : *OrSet x ( orset_new )
+    ( orset_add x 0 7 )
+    ( pb `added → present: ` ( orset_contains x 7 ) )
+    ( orset_remove x 7 )
+    ( pb `removed → absent: ` ! ( orset_contains x 7 ) )
+    ( orset_free x )
+
+    // ── OrSet: concurrent add wins over remove ───────────────────
+    : *OrSet sa ( orset_new )
+    ( orset_add sa 0 5 )            // A adds 5  (tag 5,0,0)
+    : *OrSet sb ( orset_new )
+    ( orset_merge sb sa )           // B observes A's add
+    ( orset_remove sa 5 )           // A removes 5 (tombstones 5,0,0)
+    ( orset_add sb 1 5 )            // B concurrently re-adds 5 (tag 5,1,0)
+    // bidirectional merge → converge
+    ( orset_merge sa sb )
+    ( orset_merge sb sa )
+    ( pb `add-wins on A: ` ( orset_contains sa 5 ) )
+    ( pb `add-wins on B: ` ( orset_contains sb 5 ) )
+    ( pb `replicas converged: ` == ( orset_contains sa 5 ) ( orset_contains sb 5 ) )
+    ( orset_free sa ) ( orset_free sb )
+
+    ^ 0
+}

--- a/compiler/tests/outputs/dist_crdt.txt
+++ b/compiler/tests/outputs/dist_crdt.txt
@@ -1,0 +1,18 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+a value = 3: YES
+b value = 10: YES
+merged value = 13: YES
+merge idempotent (still 13): YES
+merge commutative (= 13): YES
+higher ts wins (9): YES
+lww merge commutative: YES
+ts tie → higher replica (9): YES
+tie-break commutative: YES
+added → present: YES
+removed → absent: YES
+add-wins on A: YES
+add-wins on B: YES
+replicas converged: YES

--- a/stdlib/dist/crdt.nu
+++ b/stdlib/dist/crdt.nu
@@ -1,0 +1,195 @@
+// stdlib/dist/crdt.nu — conflict-free replicated data types (§7.4 Phase 6).
+// State-based CRDTs whose `merge` is commutative, associative and idempotent,
+// so replicas converge by exchanging state over gossip — eventual
+// consistency with NO coordination and NO consensus (no Raft/Paxos), which is
+// what a churning mobile mesh needs. (Delta-state — gossiping only recent
+// changes instead of full state — is an optimization over the same merge.)
+//
+//   PNCounter    — increment/decrement counter (per-replica G-counters).
+//   LwwReg       — last-writer-wins register (value + timestamp + replica).
+//   OrSet        — observed-remove set: concurrent add wins over remove.
+//
+// Replicas are identified by a small integer id (the caller maps node pubkey
+// → replica id). Merge is the gossip primitive: on receiving a peer's CRDT,
+// merge it into the local one.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+// ════════════════════════════════════════════════════════════════
+// PNCounter — per-replica increments and decrements; value = Σinc − Σdec.
+// merge = element-wise max of both vectors (a grow-only counter each).
+// ════════════════════════════════════════════════════════════════
+
+: PNCounter {
+    ( Vec i ) inc   // inc[r] = total increments by replica r
+    ( Vec i ) dec   // dec[r] = total decrements by replica r
+}
+
+@ pncounter_new → *PNCounter {
+    : *PNCounter c # *PNCounter ( nurl_alloc Z PNCounter )
+    = . c inc ( vec_new [i] )
+    = . c dec ( vec_new [i] )
+    ^ c
+}
+@ pncounter_free *PNCounter c → v { ( vec_free [i] . c inc ) ( vec_free [i] . c dec ) ( nurl_free # s c ) }
+
+@ __pn_ensure ( Vec i ) v i idx → v { ~ <= ( vec_len [i] v ) idx { ( vec_push [i] v 0 ) } }
+@ __pn_at ( Vec i ) v i idx → i { ^ ?? ( vec_get [i] v idx ) { T x → x F → 0 } }
+@ __pn_sum ( Vec i ) v → i {
+    : i n ( vec_len [i] v ) : ~ i s 0 : ~ i k 0
+    ~ < k n { = s + s ( __pn_at v k ) = k + k 1 }
+    ^ s
+}
+
+@ pncounter_inc *PNCounter c i replica i amt → v {
+    ( __pn_ensure . c inc replica )
+    ( vec_set [i] . c inc replica + ( __pn_at . c inc replica ) amt )
+}
+@ pncounter_dec *PNCounter c i replica i amt → v {
+    ( __pn_ensure . c dec replica )
+    ( vec_set [i] . c dec replica + ( __pn_at . c dec replica ) amt )
+}
+@ pncounter_value *PNCounter c → i { ^ - ( __pn_sum . c inc ) ( __pn_sum . c dec ) }
+
+@ __pn_max_into ( Vec i ) dst ( Vec i ) src → v {
+    : i ns ( vec_len [i] src )
+    ~ < ( vec_len [i] dst ) ns { ( vec_push [i] dst 0 ) }
+    : ~ i k 0
+    ~ < k ns {
+        : i sv ( __pn_at src k )
+        ? > sv ( __pn_at dst k ) { ( vec_set [i] dst k sv ) } {}
+        = k + k 1
+    }
+}
+// Merge a peer's counter into this one (idempotent, commutative).
+@ pncounter_merge *PNCounter a *PNCounter b → v {
+    ( __pn_max_into . a inc . b inc )
+    ( __pn_max_into . a dec . b dec )
+}
+
+// ════════════════════════════════════════════════════════════════
+// LwwReg — last-writer-wins register. Higher timestamp wins; ties broken
+// deterministically by replica id so all replicas pick the same winner.
+// ════════════════════════════════════════════════════════════════
+
+: LwwReg {
+    i value
+    i ts
+    i replica
+}
+
+@ lww_new → LwwReg { ^ @ LwwReg { 0 0 - 0 1 } }   // ts 0, replica -1 = "unset"
+@ lww_set LwwReg r i value i ts i replica → LwwReg { ^ @ LwwReg { value ts replica } }
+@ lww_value LwwReg r → i { ^ . r value }
+@ lww_ts LwwReg r → i { ^ . r ts }
+
+@ lww_merge LwwReg a LwwReg b → LwwReg {
+    ? > . a ts . b ts { ^ a } {}
+    ? > . b ts . a ts { ^ b } {}
+    ? >= . a replica . b replica { ^ a } {}
+    ^ b
+}
+
+// ════════════════════════════════════════════════════════════════
+// OrSet — observed-remove set. Each add carries a unique tag (replica,seq);
+// remove tombstones the tags it has OBSERVED. An element is present iff it has
+// an add-tag with no tombstone → a concurrent add WINS over a remove.
+// merge = union of adds ∪ union of tombs. Elements are integers (caller maps).
+// ════════════════════════════════════════════════════════════════
+
+: OrTag {
+    i elem
+    i replica
+    i seq
+}
+
+: OrSet {
+    ( Vec s ) adds    // *OrTag
+    ( Vec s ) tombs   // *OrTag
+    i next_seq        // this replica's local tag counter
+}
+
+@ orset_new → *OrSet {
+    : *OrSet s # *OrSet ( nurl_alloc Z OrSet )
+    = . s adds ( vec_new [s] )
+    = . s tombs ( vec_new [s] )
+    = . s next_seq 0
+    ^ s
+}
+@ __orset_free_vec ( Vec s ) v → v {
+    : i n ( vec_len [s] v ) : ~ i k 0
+    ~ < k n { : s pp ?? ( vec_get [s] v k ) { T x → x F → # s 0 } ? != # i pp 0 { ( nurl_free pp ) } {} = k + k 1 }
+    ( vec_free [s] v )
+}
+@ orset_free *OrSet s → v { ( __orset_free_vec . s adds ) ( __orset_free_vec . s tombs ) ( nurl_free # s s ) }
+
+@ __tag_in ( Vec s ) v i elem i replica i seq → b {
+    : i n ( vec_len [s] v ) : ~ b found F : ~ i k 0
+    ~ & ! found < k n {
+        : s pp ?? ( vec_get [s] v k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *OrTag t # *OrTag pp
+            ? & & == . t elem elem == . t replica replica == . t seq seq { = found T } {}
+        } {}
+        = k + k 1
+    }
+    ^ found
+}
+@ __tag_push ( Vec s ) v i elem i replica i seq → v {
+    : *OrTag t # *OrTag ( nurl_alloc Z OrTag )
+    = . t elem elem = . t replica replica = . t seq seq
+    ( vec_push [s] v # s t )
+}
+
+// Add an element under this replica's id (gets a fresh unique tag).
+@ orset_add *OrSet s i replica i elem → v {
+    ( __tag_push . s adds elem replica . s next_seq )
+    = . s next_seq + . s next_seq 1
+}
+
+// Remove an element: tombstone every currently-observed add-tag for it.
+@ orset_remove *OrSet s i elem → v {
+    : i n ( vec_len [s] . s adds ) : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . s adds k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *OrTag t # *OrTag pp
+            ? & == . t elem elem ! ( __tag_in . s tombs . t elem . t replica . t seq ) {
+                ( __tag_push . s tombs . t elem . t replica . t seq )
+            } {}
+        } {}
+        = k + k 1
+    }
+}
+
+// Present iff some add-tag for the element is not tombstoned.
+@ orset_contains *OrSet s i elem → b {
+    : i n ( vec_len [s] . s adds ) : ~ b found F : ~ i k 0
+    ~ & ! found < k n {
+        : s pp ?? ( vec_get [s] . s adds k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *OrTag t # *OrTag pp
+            ? & == . t elem elem ! ( __tag_in . s tombs . t elem . t replica . t seq ) { = found T } {}
+        } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+@ __merge_tags ( Vec s ) dst ( Vec s ) src → v {
+    : i n ( vec_len [s] src ) : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] src k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *OrTag t # *OrTag pp
+            ? ! ( __tag_in dst . t elem . t replica . t seq ) { ( __tag_push dst . t elem . t replica . t seq ) } {}
+        } {}
+        = k + k 1
+    }
+}
+// Merge a peer's set (union adds, union tombs) — idempotent, commutative.
+@ orset_merge *OrSet a *OrSet b → v {
+    ( __merge_tags . a adds . b adds )
+    ( __merge_tags . a tombs . b tombs )
+}


### PR DESCRIPTION
## Summary
`dist/crdt.nu` — **state-based CRDTs** whose `merge` is commutative, associative and idempotent, so replicas converge by exchanging state over gossip: eventual consistency with **no coordination and no consensus** (no Raft/Paxos), which is what a churning mobile mesh needs. (Delta-state — gossiping only recent changes instead of full state — is an optimization over the same merge.)

- **PNCounter** — per-replica inc/dec G-counters; value = Σinc − Σdec; merge = element-wise max. `pncounter_new` / `inc` / `dec` / `value` / `merge` / `free`.
- **LwwReg** — last-writer-wins register; higher timestamp wins, ties broken deterministically by replica id (so all replicas pick the same winner). `lww_new` / `set` / `value` / `ts` / `merge`.
- **OrSet** — observed-remove set; each add carries a unique `(replica,seq)` tag, remove tombstones the tags it has *observed*, an element is present iff it has a non-tombstoned add-tag → a concurrent **add wins** over a remove. merge = union adds ∪ union tombs. `orset_new` / `add` / `remove` / `contains` / `merge` / `free`.

Replicas are small integer ids (the caller maps node pubkey → id); `merge` is the gossip primitive — merge a received peer CRDT into the local one.

## Testing
- **`dist_crdt.nu`** (+ golden): PNCounter convergence + idempotence + commutativity (= 13 both merge directions); LWW higher-ts and ts-tie→higher-replica, both commutative; OR-Set plain add/remove, and the **add-wins** property under a concurrent add‖remove with bidirectional merge converging to *present* on both replicas. ASan-clean.
- Suite **383/383**. No compiler changes.

Together with `dist/ring` (#152) this gives idempotent, at-least-once distributed state: the ring says **who owns** a key; CRDTs let the owner + replicas **converge** without locks. That's the §7.4 Phase 6 payoff. Remaining: gossip/anti-entropy wiring of CRDTs over `net/transport` + the Phase 8 sim-NAT chaos harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)