### PR TITLE
feat(dist): CRDT gossip wiring — wire codecs + anti-entropy over transport (§7.4 Phase 6)

### DIFF
--- a/compiler/tests/dist_replicator.nu
+++ b/compiler/tests/dist_replicator.nu
@@ -1,0 +1,72 @@
+// dist_replicator.nu — offline test for stdlib/dist/replicator.nu. No sockets:
+// round-trips each CRDT through its wire codec, then exercises anti-entropy —
+// two divergent replicas that exchange ENCODED state converge (the gossip
+// semantics, deterministically).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/dist/crdt.nu`
+$ `stdlib/dist/replicator.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ main → i {
+    // ── PNCounter codec + anti-entropy ───────────────────────────
+    : *PNCounter a ( pncounter_new )
+    ( pncounter_inc a 0 5 ) ( pncounter_dec a 0 2 )   // value 3
+    : ( Vec u ) ab ( pncounter_encode a )
+    : *PNCounter a2 ( pncounter_decode ab )
+    ( pb `pncounter round-trips (3): ` == ( pncounter_value a2 ) 3 )
+    ( pncounter_free a2 ) ( vec_free [u] ab )
+
+    : *PNCounter b ( pncounter_new )
+    ( pncounter_inc b 1 10 )                           // value 10
+    // A learns B and B learns A by exchanging encoded state
+    : ( Vec u ) be ( pncounter_encode b )
+    ( pncounter_merge_bytes a be )                    // a += b  → 13
+    : ( Vec u ) ae ( pncounter_encode a )
+    ( pncounter_merge_bytes b ae )                    // b += a  → 13
+    ( pb `counter converged (a=13): ` == ( pncounter_value a ) 13 )
+    ( pb `counter converged (b=13): ` == ( pncounter_value b ) 13 )
+    ( vec_free [u] be ) ( vec_free [u] ae )
+    ( pncounter_free a ) ( pncounter_free b )
+
+    // ── LwwReg codec + merge-from-bytes ──────────────────────────
+    : LwwReg r ( lww_set ( lww_new ) 42 1000 0 )
+    : ( Vec u ) rb ( lww_encode r )
+    : LwwReg r2 ( lww_decode rb )
+    ( pb `lww round-trips (val 42, ts 1000): ` & == ( lww_value r2 ) 42 == ( lww_ts r2 ) 1000 )
+    ( vec_free [u] rb )
+    : LwwReg newer ( lww_set ( lww_new ) 99 2000 1 )
+    : ( Vec u ) nb ( lww_encode newer )
+    : LwwReg merged ( lww_merge_bytes r nb )
+    ( pb `lww merge-from-bytes takes newer (99): ` == ( lww_value merged ) 99 )
+    ( vec_free [u] nb )
+
+    // ── OrSet codec + anti-entropy add-wins ──────────────────────
+    : *OrSet sa ( orset_new )
+    ( orset_add sa 0 7 ) ( orset_add sa 0 8 )
+    : ( Vec u ) sab ( orset_encode sa )
+    : *OrSet sa2 ( orset_decode sab )
+    ( pb `orset round-trips (has 7): ` ( orset_contains sa2 7 ) )
+    ( pb `orset round-trips (has 8): ` ( orset_contains sa2 8 ) )
+    ( pb `orset round-trips (no 9): ` ! ( orset_contains sa2 9 ) )
+    ( orset_free sa2 ) ( vec_free [u] sab )
+
+    // anti-entropy add-wins: B observes A's 7, A removes 7, B re-adds 7
+    : *OrSet sb ( orset_new )
+    : ( Vec u ) e1 ( orset_encode sa )
+    ( orset_merge_bytes sb e1 ) ( vec_free [u] e1 )    // B sees {7,8}
+    ( orset_remove sa 7 )                               // A removes 7
+    ( orset_add sb 1 7 )                                // B re-adds 7 (new tag)
+    : ( Vec u ) e2 ( orset_encode sb )
+    ( orset_merge_bytes sa e2 ) ( vec_free [u] e2 )    // A merges B
+    : ( Vec u ) e3 ( orset_encode sa )
+    ( orset_merge_bytes sb e3 ) ( vec_free [u] e3 )    // B merges A
+    ( pb `add-wins over the wire (A has 7): ` ( orset_contains sa 7 ) )
+    ( pb `add-wins over the wire (B has 7): ` ( orset_contains sb 7 ) )
+    ( pb `converged on 8 too: ` & ( orset_contains sa 8 ) ( orset_contains sb 8 ) )
+    ( orset_free sa ) ( orset_free sb )
+
+    ^ 0
+}

--- a/compiler/tests/outputs/dist_replicator.txt
+++ b/compiler/tests/outputs/dist_replicator.txt
@@ -1,0 +1,15 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+pncounter round-trips (3): YES
+counter converged (a=13): YES
+counter converged (b=13): YES
+lww round-trips (val 42, ts 1000): YES
+lww merge-from-bytes takes newer (99): YES
+orset round-trips (has 7): YES
+orset round-trips (has 8): YES
+orset round-trips (no 9): YES
+add-wins over the wire (A has 7): YES
+add-wins over the wire (B has 7): YES
+converged on 8 too: YES

--- a/examples/replicated_counter.nu
+++ b/examples/replicated_counter.nu
@@ -1,0 +1,75 @@
+// examples/replicated_counter.nu — a PNCounter replicated across the group by
+// CRDT gossip over the overlay (TODO §7.4 Phase 6). Each node increments its
+// OWN replica slot, periodically broadcasts its encoded counter to the group
+// (transport_broadcast → relay multicast), and merges every counter it
+// receives. Because PNCounter.merge is a CRDT merge, all nodes converge to
+// the same total with no coordination.
+//
+//   ./nurl.sh examples/replicated_counter.nu <relay_host> <relay_port> <replica_id>
+//
+// Run a relay (examples/relay.nu) and several of these with distinct ids; the
+// printed value converges to the sum of everyone's increments.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/net/relay.nu`
+$ `stdlib/net/transport.nu`
+$ `stdlib/dist/crdt.nu`
+$ `stdlib/dist/replicator.nu`
+
+@ pk_for i id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + id k ) = k + k 1 } ^ v }
+@ group_id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + 200 k ) = k + k 1 } ^ v }
+
+@ main → i {
+    : i argc ( env_args_count )
+    : String host ? > argc 1 ( env_arg 1 ) ( string_from `127.0.0.1` )
+    : i port ? > argc 2 {
+        : String ps ( env_arg 2 ) : i p ( nurl_str_to_int ( string_data ps ) ) ( string_free ps ) p
+    } 47700
+    : i rid ? > argc 3 {
+        : String rs ( env_arg 3 ) : i r ( nurl_str_to_int ( string_data rs ) ) ( string_free rs ) r
+    } 0
+
+    ?? ( relay_dial ( string_data host ) port ) {
+        T rc → {
+            : ( Vec u ) self_pk ( pk_for + 1 rid )
+            ?? ( relay_register rc self_pk ) { T _ → {} F _ → {} }
+            ( relay_set_timeout rc 300 )
+            : *Transport tr # *Transport ( transport_open # s 0 rc 1 )
+            : ( Vec u ) g ( group_id )
+            ?? ( transport_group_join tr g ) { T _ → {} F _ → {} }
+
+            : *PNCounter ctr ( pncounter_new )
+
+            : ~ i round 0
+            ~ < round 5 {
+                ( pncounter_inc ctr rid 1 )            // count our own work
+                : ( Vec u ) wire ( pncounter_encode ctr )
+                ?? ( transport_broadcast tr g wire ) { T _ → {} F _ → {} }
+                ( vec_free [u] wire )
+                // drain inbound counters and merge them
+                : ~ b more T
+                ~ more {
+                    ?? ( transport_recv tr 100 ) {
+                        T m → { ( pncounter_merge_bytes ctr . m payload ) ( transport_msg_free m ) }
+                        F → { = more F }
+                    }
+                }
+                ( sleep_ms 200 )
+                = round + round 1
+            }
+
+            ( nurl_print `replica ` ) ( nurl_print_int rid )
+            ( nurl_print ` converged value = ` ) ( nurl_print_int ( pncounter_value ctr ) ) ( nurl_print `\n` )
+
+            ( pncounter_free ctr )
+            ( vec_free [u] self_pk ) ( vec_free [u] g )
+            ( transport_free tr ) ( relay_close rc )
+        }
+        F e → ( nurl_print `could not reach relay\n` )
+    }
+    ( string_free host )
+    ^ 0
+}

--- a/stdlib/dist/replicator.nu
+++ b/stdlib/dist/replicator.nu
@@ -1,0 +1,141 @@
+// stdlib/dist/replicator.nu — CRDT gossip wiring (§7.4 Phase 6). Turns the
+// dist/crdt types into something that travels: each CRDT serializes to an
+// opaque byte payload that rides net/transport (transport_send to a peer or
+// transport_broadcast to the group), and `*_merge_bytes` decodes a received
+// payload and merges it into the local replica. Because the merge is a CRDT
+// merge, repeated anti-entropy exchanges converge with no coordination.
+//
+// Pure (no transport import) so the codecs + convergence are deterministically
+// testable; the live loop is a thin adapter (gossip local state on a timer,
+// merge_bytes on receipt — see examples/replicated_counter.nu).
+//
+// Wire: integers are 8-byte big-endian (i64 bit pattern via u64), counts are
+// 2-byte big-endian.
+//   PNCounter : u16 ninc, i64*ninc, u16 ndec, i64*ndec
+//   LwwReg    : i64 value, i64 ts, i64 replica
+//   OrSet     : tags(adds) ++ tags(tombs);  tags = u16 n, (i64 elem,
+//               i64 replica, i64 seq)*n
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/dist/crdt.nu`
+
+: RcCur { ( Vec u ) buf  i off }
+@ __rc_u16 *RcCur c → i { : i v ?? ( bytes_read_u16_be . c buf . c off ) { T x → # i x F → 0 } = . c off + . c off 2 ^ v }
+@ __rc_u64 *RcCur c → i { : i v ?? ( bytes_read_u64_be . c buf . c off ) { T x → # i x F → 0 } = . c off + . c off 8 ^ v }
+
+// ── PNCounter ────────────────────────────────────────────────────
+@ __pn_put ( Vec u ) b ( Vec i ) v → v {
+    : i n ( vec_len [i] v )
+    ( bytes_push_u16_be b # u16 n )
+    : ~ i k 0
+    ~ < k n {
+        : i x ?? ( vec_get [i] v k ) { T t → t F → 0 }
+        ( bytes_push_u64_be b # u64 x )
+        = k + k 1
+    }
+}
+@ pncounter_encode *PNCounter c → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( __pn_put b . c inc )
+    ( __pn_put b . c dec )
+    ^ b
+}
+@ __pn_get *RcCur cur ( Vec i ) into → v {
+    : i n ( __rc_u16 cur )
+    : ~ i k 0
+    ~ < k n { ( vec_push [i] into ( __rc_u64 cur ) ) = k + k 1 }
+}
+@ pncounter_decode ( Vec u ) buf → *PNCounter {
+    : *PNCounter c ( pncounter_new )
+    : *RcCur cur # *RcCur ( nurl_alloc Z RcCur )
+    = . cur buf buf
+    = . cur off 0
+    ( __pn_get cur . c inc )
+    ( __pn_get cur . c dec )
+    ( nurl_free # s cur )
+    ^ c
+}
+// Decode a peer's encoded counter and merge it into this one.
+@ pncounter_merge_bytes *PNCounter c ( Vec u ) buf → v {
+    : *PNCounter o ( pncounter_decode buf )
+    ( pncounter_merge c o )
+    ( pncounter_free o )
+}
+
+// ── LwwReg ───────────────────────────────────────────────────────
+@ lww_encode LwwReg r → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( bytes_push_u64_be b # u64 . r value )
+    ( bytes_push_u64_be b # u64 . r ts )
+    ( bytes_push_u64_be b # u64 . r replica )
+    ^ b
+}
+@ lww_decode ( Vec u ) buf → LwwReg {
+    : *RcCur cur # *RcCur ( nurl_alloc Z RcCur )
+    = . cur buf buf
+    = . cur off 0
+    : i v ( __rc_u64 cur )
+    : i ts ( __rc_u64 cur )
+    : i rep ( __rc_u64 cur )
+    ( nurl_free # s cur )
+    ^ @ LwwReg { v ts rep }
+}
+@ lww_merge_bytes LwwReg r ( Vec u ) buf → LwwReg { ^ ( lww_merge r ( lww_decode buf ) ) }
+
+// ── OrSet ────────────────────────────────────────────────────────
+@ __ortags_put ( Vec u ) b ( Vec s ) tags → v {
+    : i n ( vec_len [s] tags )
+    ( bytes_push_u16_be b # u16 n )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] tags k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *OrTag t # *OrTag pp
+            ( bytes_push_u64_be b # u64 . t elem )
+            ( bytes_push_u64_be b # u64 . t replica )
+            ( bytes_push_u64_be b # u64 . t seq )
+        } {}
+        = k + k 1
+    }
+}
+@ orset_encode *OrSet s → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( __ortags_put b . s adds )
+    ( __ortags_put b . s tombs )
+    ^ b
+}
+@ __ortags_get *RcCur cur ( Vec s ) into → v {
+    : i n ( __rc_u16 cur )
+    : ~ i k 0
+    ~ < k n {
+        // NB: locals must NOT shadow OrTag field names — on the field-STORE
+        // path a local int var of a field's name is (intentionally) read as
+        // an array index, not a field (see core/vec.nu's `= . data idx x`).
+        : i ev ( __rc_u64 cur )
+        : i rv ( __rc_u64 cur )
+        : i sv ( __rc_u64 cur )
+        : *OrTag t # *OrTag ( nurl_alloc Z OrTag )
+        = . t elem ev
+        = . t replica rv
+        = . t seq sv
+        ( vec_push [s] into # s t )
+        = k + k 1
+    }
+}
+@ orset_decode ( Vec u ) buf → *OrSet {
+    : *OrSet s ( orset_new )
+    : *RcCur cur # *RcCur ( nurl_alloc Z RcCur )
+    = . cur buf buf
+    = . cur off 0
+    ( __ortags_get cur . s adds )
+    ( __ortags_get cur . s tombs )
+    ( nurl_free # s cur )
+    ^ s
+}
+@ orset_merge_bytes *OrSet s ( Vec u ) buf → v {
+    : *OrSet o ( orset_decode buf )
+    ( orset_merge s o )
+    ( orset_free o )
+}


### PR DESCRIPTION
## Summary
`dist/replicator.nu` is the CRDT **gossip wiring**: it turns the `dist/crdt` types into something that travels. Each CRDT serializes to an opaque byte payload that rides `net/transport` (`transport_send` to a peer or `transport_broadcast` to the group), and `*_merge_bytes` decodes a received payload and merges it into the local replica. Because the operation is a CRDT merge, repeated anti-entropy exchanges **converge with no coordination**.

- `pncounter_encode` / `decode` / `merge_bytes`
- `lww_encode` / `decode` / `merge_bytes`
- `orset_encode` / `decode` / `merge_bytes`

Wire format: 8-byte big-endian integers (i64 bit pattern via u64), 2-byte big-endian counts. The module is **pure** (no transport import) so the codecs + convergence are deterministically testable; the live loop is a thin adapter.

## Testing
- **`dist_replicator.nu`** (+ golden): each CRDT round-trips its codec, and anti-entropy converges **over the wire** — two divergent PNCounters exchange encoded state → both reach 13; LWW `merge_bytes` takes the newer; OR-Set add-wins survives a serialize/merge round (A removes, B re-adds, exchange → both present). ASan-clean.
- **`examples/replicated_counter.nu`**: each node increments its own replica, broadcasts its encoded PNCounter to the group, merges what it receives. **Live-verified over a relay** — two replicas (5 increments each) both converge to **10**.
- Suite **384/384**. No compiler changes.

## NURL note
A store-LHS local must not share a struct field's name: on the field-**store** path a local int var of a field's name is (intentionally) read as an array index — the `= . data idx x` idiom `core/vec.nu` relies on. Param shadows resolve to the field, and field-**reads** resolve to the field (PR #150). Renamed the OrTag decode locals accordingly; no compiler change needed.

This completes the §7.4 Phase 6 data path: `dist/ring` says **who owns** a key, `dist/crdt` lets replicas **converge**, and `dist/replicator` **carries** that convergence over the overlay. Remaining: the Phase 8 sim-NAT chaos harness (end-to-end multi-node under simulated NAT + forced network change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
