### PR TITLE
feat(dist): stable replica identity registry (§7.5 Phase 9.1)

### DIFF
--- a/compiler/tests/dist_identity.nu
+++ b/compiler/tests/dist_identity.nu
@@ -1,0 +1,75 @@
+// dist_identity.nu — offline test for stdlib/dist/identity.nu (§7.5 Phase 9.1).
+// Deterministic: monotonic never-reused replica ids, rejoin resumes the same
+// slot, a new pubkey never inherits a retired id, and — the headline — feeding
+// dist/crdt from the registry survives churn with ZERO slot corruption.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/dist/identity.nu`
+$ `stdlib/dist/crdt.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+@ mkpk i seed → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + seed k ) = k + k 1 } ^ v }
+@ veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a ) ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n { ? != ?? ( vec_get [u] a k ) { T t → # i t F → -1 } ?? ( vec_get [u] b k ) { T t → # i t F → -2 } { = e F } {} = k + k 1 }
+    ^ e
+}
+
+@ main → i {
+    : ( Vec u ) a ( mkpk 10 )
+    : ( Vec u ) b ( mkpk 80 )
+    : ( Vec u ) c ( mkpk 150 )
+
+    : *IdRegistry reg ( identity_new )
+
+    // ── monotonic, stable, never-reused ──────────────────────────
+    : i ida ( identity_of reg a )
+    : i idb ( identity_of reg b )
+    ( pb `first ids are 0,1: ` & == ida 0 == idb 1 )
+    ( pb `identity_of is stable: ` == ( identity_of reg a ) ida )
+    ( pb `reverse lookup resolves: ` ?? ( identity_pubkey reg ida ) { T pk → { : b ok ( veq pk a ) ( vec_free [u] pk ) ok } F → F } )
+    ( pb `known reports true: ` ( identity_known reg a ) )
+    ( pb `unknown C reports false: ` ! ( identity_known reg c ) )
+
+    // ── retire A, then a NEW pubkey must NOT inherit A's id ───────
+    ( identity_retire reg a )
+    ( pb `retired id not live: ` ! ( identity_is_live reg ida ) )
+    : i idc ( identity_of reg c )
+    ( pb `new pubkey gets fresh id (2, not 0): ` == idc 2 )
+    ( pb `retired id still resolves (tombstone): ` ?? ( identity_pubkey reg ida ) { T pk → { : b ok ( veq pk a ) ( vec_free [u] pk ) ok } F → F } )
+
+    // ── A rejoins → resumes its OWN slot, revived ────────────────
+    : i ida2 ( identity_of reg a )
+    ( pb `rejoin resumes same id: ` == ida2 ida )
+    ( pb `rejoin revives liveness: ` ( identity_is_live reg ida ) )
+    ( pb `three distinct entries: ` == ( identity_count reg ) 3 )
+
+    // ── headline: CRDT fed from the registry survives churn ──────
+    // A and B both increment via their registry ids; merge; value correct.
+    : *PNCounter ca ( pncounter_new )
+    ( pncounter_inc ca ( identity_of reg a ) 5 )
+    : *PNCounter cb ( pncounter_new )
+    ( pncounter_inc cb ( identity_of reg b ) 7 )
+    ( pncounter_merge ca cb )
+    ( pb `crdt via stable ids merges to 12: ` == ( pncounter_value ca ) 12 )
+
+    // Now B leaves and a NEW node D joins. With naive id reuse D would inherit
+    // B's slot 1 and clobber B's 7. With the registry, D gets a fresh id, so a
+    // late merge of B's old counter does NOT corrupt D's contribution.
+    ( identity_retire reg b )
+    : ( Vec u ) d ( mkpk 200 )
+    : i idd ( identity_of reg d )
+    ( pb `D does NOT inherit B slot: ` & != idd idb == idd 3 )
+    : *PNCounter cd ( pncounter_new )
+    ( pncounter_inc cd idd 4 )
+    ( pncounter_merge ca cd )          // ca now has A=5, B=7, D=4
+    ( pncounter_merge ca cb )          // re-merge B's old state: idempotent, no clobber
+    ( pb `no slot corruption after churn (16): ` == ( pncounter_value ca ) 16 )
+
+    ( pncounter_free ca ) ( pncounter_free cb ) ( pncounter_free cd )
+    ( identity_free reg )
+    ( vec_free [u] a ) ( vec_free [u] b ) ( vec_free [u] c ) ( vec_free [u] d )
+    ^ 0
+}

--- a/compiler/tests/outputs/dist_identity.txt
+++ b/compiler/tests/outputs/dist_identity.txt
@@ -1,0 +1,18 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+first ids are 0,1: YES
+identity_of is stable: YES
+reverse lookup resolves: YES
+known reports true: YES
+unknown C reports false: YES
+retired id not live: YES
+new pubkey gets fresh id (2, not 0): YES
+retired id still resolves (tombstone): YES
+rejoin resumes same id: YES
+rejoin revives liveness: YES
+three distinct entries: YES
+crdt via stable ids merges to 12: YES
+D does NOT inherit B slot: YES
+no slot corruption after churn (16): YES

--- a/stdlib/dist/identity.nu
+++ b/stdlib/dist/identity.nu
@@ -1,0 +1,151 @@
+// stdlib/dist/identity.nu — stable replica identity (§7.5 Phase 9.1).
+//
+// dist/crdt replicas are keyed by a small integer id. If those ids are handed
+// out naively (e.g. "position in the member list") then churn SILENTLY
+// corrupts state: a departed node's id gets reused by a new pubkey, and that
+// new node inherits the retired node's PNCounter slot or its OR-Set
+// `(replica, seq)` tag space. The merge stays mathematically valid but the
+// VALUES are wrong, with no error anywhere.
+//
+// This registry removes that hazard. It maps each peer's static public key to
+// a MONOTONIC, NEVER-REUSED replica id:
+//
+//   * a pubkey seen for the first time gets the next id (a high-water mark
+//     that only ever increases);
+//   * the same pubkey across leave → rejoin resolves to the SAME id (it
+//     resumes its own slot);
+//   * a new pubkey NEVER inherits a retired id.
+//
+// Retired ids are tombstoned (kept, marked not-live) so stale gossip that
+// still references a dead replica can be interpreted, and so a rejoin revives
+// the original binding. Feed `dist/crdt.nu` / `dist/replicator.nu` from
+// `identity_of(pubkey)` instead of raw caller-assigned ints.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+@ __id_veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a )
+    ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n {
+        : i x ?? ( vec_get [u] a k ) { T t → # i t F → -1 }
+        : i y ?? ( vec_get [u] b k ) { T t → # i t F → -2 }
+        ? != x y { = e F } {}
+        = k + k 1
+    }
+    ^ e
+}
+@ __id_cpy ( Vec u ) v → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
+    ( vec_extend [u] o v )
+    ^ o
+}
+
+: IdEntry {
+    ( Vec u ) pubkey
+    i id
+    i live       // 1 = active, 0 = retired (tombstone; id still bound here)
+}
+
+: IdRegistry {
+    ( Vec s ) entries   // *IdEntry
+    i next_id           // monotonic high-water mark — never decreases
+}
+
+@ identity_new → *IdRegistry {
+    : *IdRegistry r # *IdRegistry ( nurl_alloc Z IdRegistry )
+    = . r entries ( vec_new [s] )
+    = . r next_id 0
+    ^ r
+}
+
+@ identity_free *IdRegistry r → v {
+    : i n ( vec_len [s] . r entries )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . r entries k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *IdEntry e # *IdEntry pp ( vec_free [u] . e pubkey ) ( nurl_free # s e ) } {}
+        = k + k 1
+    }
+    ( vec_free [s] . r entries )
+    ( nurl_free # s r )
+}
+
+@ identity_count *IdRegistry r → i { ^ ( vec_len [s] . r entries ) }
+
+@ __id_find *IdRegistry r ( Vec u ) pubkey → s {
+    : i n ( vec_len [s] . r entries )
+    : ~ s found # s 0
+    : ~ i k 0
+    ~ & == # i found 0 < k n {
+        : s pp ?? ( vec_get [s] . r entries k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *IdEntry e # *IdEntry pp
+            ? ( __id_veq . e pubkey pubkey ) { = found pp } {}
+        } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+// The stable replica id for a pubkey. Allocates the next id on first sight;
+// a known pubkey (even a retired one) returns its existing id and is marked
+// live again (a rejoin resumes its own slot). A new pubkey never reuses a
+// retired id — next_id only grows.
+@ identity_of *IdRegistry r ( Vec u ) pubkey → i {
+    : s pp ( __id_find r pubkey )
+    ? != # i pp 0 {
+        : *IdEntry e # *IdEntry pp
+        = . e live 1
+        ^ . e id
+    } {}
+    : *IdEntry e # *IdEntry ( nurl_alloc Z IdEntry )
+    = . e pubkey ( __id_cpy pubkey )
+    = . e id . r next_id
+    = . e live 1
+    = . r next_id + . r next_id 1
+    ( vec_push [s] . r entries # s e )
+    ^ . e id
+}
+
+// Has this pubkey ever been assigned an id (without allocating one)?
+@ identity_known *IdRegistry r ( Vec u ) pubkey → b { ^ != # i ( __id_find r pubkey ) 0 }
+
+// Reverse lookup: the pubkey bound to a replica id (copied), or None. Resolves
+// retired (tombstoned) ids too, so stale gossip remains interpretable.
+@ identity_pubkey *IdRegistry r i id → ?( Vec u ) {
+    : i n ( vec_len [s] . r entries )
+    : ~ ?( Vec u ) out @ ?( Vec u ) { F # ( Vec u ) 0 }
+    : ~ b got F
+    : ~ i k 0
+    ~ & ! got < k n {
+        : s pp ?? ( vec_get [s] . r entries k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *IdEntry e # *IdEntry pp
+            ? == . e id id { = out @ ?( Vec u ) { T ( __id_cpy . e pubkey ) } = got T } {}
+        } {}
+        = k + k 1
+    }
+    ^ out
+}
+
+// Retire a pubkey's slot (it left). The binding is kept as a tombstone — the
+// id is never reassigned, and a later identity_of on the same pubkey revives
+// it. No-op for an unknown pubkey.
+@ identity_retire *IdRegistry r ( Vec u ) pubkey → v {
+    : s pp ( __id_find r pubkey )
+    ? != # i pp 0 { : *IdEntry e # *IdEntry pp = . e live 0 } {}
+}
+
+// Is the id currently live (not retired)? Unknown ids report not-live.
+@ identity_is_live *IdRegistry r i id → b {
+    : i n ( vec_len [s] . r entries )
+    : ~ b live F : ~ i k 0
+    ~ & ! live < k n {
+        : s pp ?? ( vec_get [s] . r entries k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *IdEntry e # *IdEntry pp ? & == . e id id == . e live 1 { = live T } {} } {}
+        = k + k 1
+    }
+    ^ live
+}


### PR DESCRIPTION
## Summary
First step of **The Crown** (§7.5) — the foundation that stops **silent CRDT-slot corruption** under churn, which must land before compute load makes it frequent.

CRDT replicas are keyed by a small integer id. If those ids are reused (e.g. "position in the member list"), a new pubkey inherits a departed node's PNCounter slot or its OR-Set `(replica, seq)` tag space. The merge stays mathematically valid but the **values are wrong**, with no error anywhere.

`dist/identity.nu` removes that hazard by mapping each peer's static public key to a **monotonic, never-reused** replica id:
- first sight → the next id (a high-water mark that only ever increases);
- the same pubkey across leave → rejoin → the **same** id (it resumes its own slot);
- a new pubkey **never** inherits a retired id.

Retired ids are **tombstoned** (kept, marked not-live) so stale gossip referencing a dead replica stays interpretable and a rejoin revives the binding. Feed `dist/crdt` / `dist/replicator` from `identity_of(pubkey)` instead of raw caller-assigned ints.

**API:** `identity_new` · `identity_of` · `identity_pubkey` (reverse, resolves tombstones) · `identity_retire` · `identity_is_live` · `identity_known` · `identity_count` · `identity_free`.

## Testing
- **`dist_identity.nu`** (+ golden): monotonic `0,1`; stable; reverse lookup; after retiring A a new pubkey gets id `2` (not `0`); the tombstone still resolves; a rejoin resumes the same id and revives liveness; and the **headline** — a `PNCounter` fed from the registry across a *B-leaves / D-joins* churn shows **zero slot corruption** (D never inherits B's slot; a late re-merge of B's old state doesn't clobber). ASan-clean.
- Suite **385/385**. No compiler changes.

**Done-when** (from §7.5 Phase 9.1): a churn test shows zero counter/set corruption, and a rejoining pubkey resumes its own slot. ✅

Next on the critical path: **9.2 ownership-scoped anti-entropy** (route deltas to `ring_owners(key, R)` instead of broadcasting), then the **Phase 11 keystone** `dist/job.nu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)