### PR TITLE
feat(dist): distributed work dispatch — the keystone (§7.5 Phase 11)

### DIFF
--- a/compiler/tests/dist_job.nu
+++ b/compiler/tests/dist_job.nu
@@ -1,0 +1,106 @@
+// dist_job.nu — offline test for stdlib/dist/job.nu (§7.5 Phase 11 keystone).
+// Deterministic, no sockets (transport handle is 0; the owned-key path and all
+// pure logic never touch it): JobMsg codec, in-process submit→execute→await,
+// idempotent result recording, and owner recomputation across a ring change
+// (the re-home target).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/dist/ring.nu`
+$ `stdlib/dist/job.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+@ mkpk i seed → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + seed k ) = k + k 1 } ^ v }
+@ bytes4 i a i b i c i d → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) ( vec_push [u] v # u a ) ( vec_push [u] v # u b ) ( vec_push [u] v # u c ) ( vec_push [u] v # u d ) ^ v }
+@ veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a ) ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n { ? != ?? ( vec_get [u] a k ) { T t → # i t F → -1 } ?? ( vec_get [u] b k ) { T t → # i t F → -2 } { = e F } {} = k + k 1 }
+    ^ e
+}
+
+// task kind 0: result = (sum of payload bytes) & 255, as a 1-byte vector
+@ sum_handler → ( @ ( Vec u ) ( Vec u ) ) {
+    ^ \ ( Vec u ) p → ( Vec u ) {
+        : ~ i s 0
+        : i nn ( vec_len [u] p )
+        : ~ i k 0
+        ~ < k nn { = s + s ?? ( vec_get [u] p k ) { T x → # i x F → 0 } = k + k 1 }
+        : ( Vec u ) r ( vec_new [u] )
+        ( vec_push [u] r # u & s 255 )
+        ^ r
+    }
+}
+
+@ main → i {
+    : ( Vec u ) a ( mkpk 10 )
+
+    // ── JobMsg codec ─────────────────────────────────────────────
+    : ( Vec u ) sub ( mkpk 99 )
+    : ( Vec u ) key ( bytes4 7 7 7 7 )
+    : ( Vec u ) pl ( bytes4 1 2 3 4 )
+    : ( Vec u ) sm ( job_build_submit 4242 0 sub key pl )
+    : JobMsg dm ( jobmsg_decode sm )
+    ( pb `submit type/id/kind: ` & & == . dm mtype ( job_submit_t ) == . dm task_id 4242 == . dm kind 0 )
+    ( pb `submit submitter/key/payload: ` & & ( veq . dm submitter sub ) ( veq . dm key key ) ( veq . dm payload pl ) )
+    ( jobmsg_free dm ) ( vec_free [u] sm )
+
+    : ( Vec u ) rp ( bytes4 9 9 0 0 )
+    : ( Vec u ) rm ( job_build_result 4242 rp )
+    : JobMsg drm ( jobmsg_decode rm )
+    ( pb `result type/id/payload: ` & & == . drm mtype ( job_result_t ) == . drm task_id 4242 ( veq . drm payload rp ) )
+    ( jobmsg_free drm ) ( vec_free [u] rm )
+    ( vec_free [u] sub ) ( vec_free [u] rp )
+
+    // ── in-process submit → execute → await (node owns the key) ──
+    : *Ring ring ( ring_new )
+    ( ring_add_member ring a 32 )          // single member ⇒ owns every key
+    : *JobNode n ( job_node_new # s 0 # s ring a 0 )
+    ( job_register n 0 ( sum_handler ) )
+    ( pb `owns key (single-member ring): ` ( job_owns n key ) )
+    : i tid ( job_submit n 0 key pl )       // sum(1,2,3,4)=10
+    ( pb `result recorded after submit: ` ( job_has n tid ) )
+    : ( Vec u ) want ( bytes4 10 0 0 0 )    // 1-byte [10]; compare just elem 0
+    ( pb `awaited result is sum=10: ` ?? ( job_await n tid ) { T r → { : b ok == ?? ( vec_get [u] r 0 ) { T x → # i x F → -1 } 10 ( vec_free [u] r ) ok } F → F } )
+    ( pb `await unknown task → None: ` ?? ( job_await n 999999 ) { T r → { ( vec_free [u] r ) F } F → T } )
+    ( vec_free [u] want )
+
+    // ── idempotent result recording (at-least-once safe) ─────────
+    : ( Vec u ) p1 ( bytes4 1 0 0 0 )
+    : ( Vec u ) r1 ( job_build_result 555 p1 )
+    : JobMsg m1 ( jobmsg_decode r1 )
+    ( job_on_result n m1 )
+    ( jobmsg_free m1 ) ( vec_free [u] r1 ) ( vec_free [u] p1 )
+    : ( Vec u ) p2 ( bytes4 2 0 0 0 )   // duplicate task_id, different bytes
+    : ( Vec u ) r2 ( job_build_result 555 p2 )
+    : JobMsg m2 ( jobmsg_decode r2 )
+    ( job_on_result n m2 )
+    ( jobmsg_free m2 ) ( vec_free [u] r2 ) ( vec_free [u] p2 )
+    ( pb `duplicate delivery is idempotent (keeps first): ` ?? ( job_await n 555 ) { T r → { : b ok == ?? ( vec_get [u] r 0 ) { T x → # i x F → -1 } 1 ( vec_free [u] r ) ok } F → F } )
+
+    ( job_node_free n )
+    ( ring_free ring )
+
+    // ── owner recompute across a ring change (re-home target) ────
+    : ( Vec u ) b ( mkpk 80 )
+    : ( Vec u ) c ( mkpk 150 )
+    : *Ring r3 ( ring_new )
+    ( ring_add_member r3 a 32 ) ( ring_add_member r3 b 32 ) ( ring_add_member r3 c 32 )
+    : *JobNode n2 ( job_node_new # s 0 # s r3 a 1 )
+    : ( Vec u ) k2 ( bytes4 200 13 13 13 )
+    : ~ ( Vec u ) owner1 ( vec_new [u] )
+    ?? ( job_owner_pk n2 k2 ) { T o → { ( vec_free [u] owner1 ) = owner1 o } F → {} }
+    ( pb `key has an owner in 3-node ring: ` > ( vec_len [u] owner1 ) 0 )
+    ( ring_remove_member r3 owner1 )       // the owner leaves
+    : ~ ( Vec u ) owner2 ( vec_new [u] )
+    ?? ( job_owner_pk n2 k2 ) { T o → { ( vec_free [u] owner2 ) = owner2 o } F → {} }
+    ( pb `owner recomputes after removal (re-home): ` ! ( veq owner1 owner2 ) )
+    ( pb `new owner is a surviving member: ` > ( vec_len [u] owner2 ) 0 )
+    ( vec_free [u] owner1 ) ( vec_free [u] owner2 ) ( vec_free [u] k2 )
+    ( job_node_free n2 ) ( ring_free r3 )
+    ( vec_free [u] b ) ( vec_free [u] c )
+
+    ( vec_free [u] a ) ( vec_free [u] key ) ( vec_free [u] pl )
+    ^ 0
+}

--- a/compiler/tests/outputs/dist_job.txt
+++ b/compiler/tests/outputs/dist_job.txt
@@ -1,0 +1,15 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+submit type/id/kind: YES
+submit submitter/key/payload: YES
+result type/id/payload: YES
+owns key (single-member ring): YES
+result recorded after submit: YES
+awaited result is sum=10: YES
+await unknown task → None: YES
+duplicate delivery is idempotent (keeps first): YES
+key has an owner in 3-node ring: YES
+owner recomputes after removal (re-home): YES
+new owner is a surviving member: YES

--- a/examples/distributed_map.nu
+++ b/examples/distributed_map.nu
@@ -1,0 +1,157 @@
+// examples/distributed_map.nu — distributed map / word-count over the overlay
+// (TODO §7.5 Phase 11, the keystone in action). A coordinator shards a corpus
+// into chunks, each KEYED so dist/ring routes it to the worker that OWNS that
+// key; the owning worker runs the registered word-count handler and returns
+// the count; the coordinator awaits all and sums them. Real distributed
+// computation — no central executor, work placed by consistent hashing,
+// results flow back over net/transport and are recorded idempotently.
+//
+// Run as separate processes (a relay, two workers, one coordinator):
+//
+//   ./nurl.sh examples/relay.nu              0.0.0.0   47700
+//   ./nurl.sh examples/distributed_map.nu    worker    127.0.0.1 47700 1
+//   ./nurl.sh examples/distributed_map.nu    worker    127.0.0.1 47700 2
+//   ./nurl.sh examples/distributed_map.nu    map       127.0.0.1 47700
+//
+// The coordinator prints the aggregate word count (expected 17).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/net/relay.nu`
+$ `stdlib/net/transport.nu`
+$ `stdlib/dist/ring.nu`
+$ `stdlib/dist/job.nu`
+
+@ pk_for i id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + id k ) = k + k 1 } ^ v }
+@ key_for i id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) ( vec_push [u] v # u & id 255 ) ( vec_push [u] v # u & >> id 8 255 ) ( vec_push [u] v # u 200 ) ( vec_push [u] v # u 7 ) ^ v }
+
+@ chunk_text i id → String {
+    ^ ? == id 0 ( string_from `the quick brown fox` )
+    ? == id 1 ( string_from `jumps over the lazy dog` )
+    ? == id 2 ( string_from `a b c d e` )
+    ( string_from `one two three` )
+}
+
+@ str_bytes String s → ( Vec u ) {
+    : ( Vec u ) v ( vec_new [u] )
+    : s cs ( string_data s ) : i n ( string_len s ) : *u sp # *u cs
+    : ~ i k 0 ~ < k n { ( vec_push [u] v # u . sp k ) = k + k 1 }
+    ^ v
+}
+
+// word-count handler: payload = text bytes → result = 4-byte BE word count
+@ wordcount_handler → ( @ ( Vec u ) ( Vec u ) ) {
+    ^ \ ( Vec u ) p → ( Vec u ) {
+        : i n ( vec_len [u] p )
+        : ~ i words 0
+        : ~ i in_word 0
+        : ~ i k 0
+        ~ < k n {
+            : i ch ?? ( vec_get [u] p k ) { T x → # i x F → 32 }
+            ? == ch 32 { = in_word 0 } { ? == in_word 0 { = words + words 1 = in_word 1 } {} }
+            = k + k 1
+        }
+        : ( Vec u ) r ( vec_new [u] )
+        ( bytes_push_u32_be r # u32 words )
+        ^ r
+    }
+}
+
+@ make_ring → *Ring {
+    : *Ring r ( ring_new )
+    : ( Vec u ) w0 ( pk_for 1 ) : ( Vec u ) w1 ( pk_for 2 )
+    ( ring_add_member r w0 64 ) ( ring_add_member r w1 64 )
+    ( vec_free [u] w0 ) ( vec_free [u] w1 )
+    ^ r
+}
+
+@ run_worker s host i port i id → v {
+    ?? ( relay_dial host port ) {
+        T rc → {
+            : ( Vec u ) me ( pk_for id )
+            ?? ( relay_register rc me ) { T _ → {} F _ → {} }
+            ( relay_set_timeout rc 250 )
+            : *Transport tr # *Transport ( transport_open # s 0 rc 1 )
+            : *Ring ring ( make_ring )
+            : *JobNode jn ( job_node_new # s tr # s ring me id )
+            ( job_register jn 0 ( wordcount_handler ) )
+            ( nurl_print `worker ` ) ( nurl_print_int id ) ( nurl_print ` ready\n` )
+            // blocking pump (recv honours the socket timeout outside fibers)
+            : ~ i ticks 0
+            ~ < ticks 40 { ( job_pump jn 200 ) = ticks + ticks 1 }
+            ( job_node_free jn ) ( ring_free ring ) ( transport_free tr )
+            ( vec_free [u] me ) ( relay_close rc )
+        }
+        F e → ( nurl_print `worker dial failed\n` )
+    }
+}
+
+@ run_coordinator s host i port → v {
+    ?? ( relay_dial host port ) {
+        T rc → {
+            : ( Vec u ) me ( pk_for 99 )
+            ?? ( relay_register rc me ) { T _ → {} F _ → {} }
+            ( relay_set_timeout rc 250 )
+            : *Transport tr # *Transport ( transport_open # s 0 rc 1 )
+            : *Ring ring ( make_ring )
+            : *JobNode jn ( job_node_new # s tr # s ring me 99 )
+
+            : ( Vec i ) tids ( vec_new [i] )
+            : ~ i i 0
+            ~ < i 4 {
+                : ( Vec u ) key ( key_for i )
+                : String txt ( chunk_text i )
+                : ( Vec u ) payload ( str_bytes txt )
+                ( vec_push [i] tids ( job_submit jn 0 key payload ) )
+                ( vec_free [u] key ) ( string_free txt ) ( vec_free [u] payload )
+                = i + i 1
+            }
+
+            // collect: pump until all four results land (or give up)
+            : ~ i rounds 0
+            : ~ b done F
+            ~ & ! done < rounds 40 {
+                ( job_pump jn 200 )
+                : ~ b all T : ~ i j 0
+                ~ < j 4 { ? ! ( job_has jn ?? ( vec_get [i] tids j ) { T x → x F → 0 } ) { = all F } {} = j + j 1 }
+                = done all
+                = rounds + rounds 1
+            }
+
+            : ~ i total 0
+            : ~ i j 0
+            ~ < j 4 {
+                ?? ( job_await jn ?? ( vec_get [i] tids j ) { T x → x F → 0 } ) {
+                    T r → { = total + total ?? ( bytes_read_u32_be r 0 ) { T x → # i x F → 0 } ( vec_free [u] r ) }
+                    F → {}
+                }
+                = j + j 1
+            }
+            ( nurl_print `distributed word count total = ` ) ( nurl_print_int total ) ( nurl_print ` (expected 17)\n` )
+
+            ( vec_free [i] tids )
+            ( job_node_free jn ) ( ring_free ring ) ( transport_free tr )
+            ( vec_free [u] me ) ( relay_close rc )
+        }
+        F e → ( nurl_print `coordinator dial failed\n` )
+    }
+}
+
+@ main → i {
+    : i argc ( env_args_count )
+    ? < argc 3 { ( nurl_print `usage: distributed_map <worker|map> <host> <port> [id]\n` ) ^ 1 } {}
+    : String role ( env_arg 1 )
+    : String host ( env_arg 2 )
+    : String ps ( env_arg 3 ) : i port ( nurl_str_to_int ( string_data ps ) ) ( string_free ps )
+
+    ? != 0 ( nurl_str_eq ( string_data role ) `worker` ) {
+        : i id ? > argc 4 { : String is ( env_arg 4 ) : i v ( nurl_str_to_int ( string_data is ) ) ( string_free is ) v } 1
+        ( run_worker ( string_data host ) port id )
+    } {
+        ( run_coordinator ( string_data host ) port )
+    }
+    ( string_free role ) ( string_free host )
+    ^ 0
+}

--- a/stdlib/dist/job.nu
+++ b/stdlib/dist/job.nu
@@ -1,0 +1,357 @@
+// stdlib/dist/job.nu — distributed work dispatch (§7.5 Phase 11, THE KEYSTONE).
+//
+// Everything beneath this already exists: the consistent-hash ring decides who
+// owns a key, net/transport carries opaque bytes by pubkey, dist/crdt records
+// results idempotently, the cluster layer retries. This module is what turns
+// distributed STATE into distributed COMPUTATION.
+//
+// Model: submit a task keyed by `k`; `ring_owner(k)` executes it via a
+// registered handler; the result is returned to the submitter and recorded so
+// duplicate delivery is harmless.
+//
+//   * job_submit(key, kind, payload) → task_id  — routes to ring_owner(key);
+//     if this node owns the key it runs the handler locally.
+//   * the owner decodes → runs the kind's handler → replies a RESULT to the
+//     submitter; results are recorded by task_id (idempotent → at-least-once
+//     + retry stays safe).
+//   * job_pump drains inbound SUBMIT/RESULT; job_await(task_id) returns the
+//     recorded result.
+//   * OWNERSHIP MOVED MID-FLIGHT: a node that receives a SUBMIT for a key it
+//     no longer owns (the ring changed) FORWARDS it to the current owner
+//     rather than dropping or mis-executing it — so killing a worker re-homes
+//     its keys and the job still completes.
+//
+// Invariant (compute): a key is owned by exactly one node per epoch; a task
+// executes at-least-once; its effect is idempotent (pure handlers) or leased
+// (§7.5 Phase 12, dist/lease.nu — for side-effecting handlers).
+//
+// The protocol codec, handler registry, routing decision and result store are
+// pure; only job_submit / job_pump touch the transport.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/dist/ring.nu`
+$ `stdlib/net/transport.nu`
+
+@ job_submit_t → i { ^ 1 }
+@ job_result_t → i { ^ 2 }
+
+@ __job_cpy ( Vec u ) v → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
+    ( vec_extend [u] o v )
+    ^ o
+}
+@ __job_veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a )
+    ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n {
+        : i x ?? ( vec_get [u] a k ) { T t → # i t F → -1 }
+        : i y ?? ( vec_get [u] b k ) { T t → # i t F → -2 }
+        ? != x y { = e F } {}
+        = k + k 1
+    }
+    ^ e
+}
+
+// ── wire protocol ────────────────────────────────────────────────
+// SUBMIT: [1][task_id:8][kind:4][slen:2][submitter_pk][klen:2][key][payload…]
+// RESULT: [2][task_id:8][payload…]
+// payload runs to the end of the buffer (transport delivers whole messages).
+
+: JobMsg {
+    i mtype
+    i task_id
+    i kind
+    ( Vec u ) submitter
+    ( Vec u ) key
+    ( Vec u ) payload
+}
+@ jobmsg_free JobMsg m → v {
+    ( vec_free [u] . m submitter )
+    ( vec_free [u] . m key )
+    ( vec_free [u] . m payload )
+}
+
+@ __job_put_blob ( Vec u ) b ( Vec u ) blob → v {
+    ( bytes_push_u16_be b # u16 ( vec_len [u] blob ) )
+    ( vec_extend [u] b blob )
+}
+
+@ job_build_submit i task_id i kind ( Vec u ) submitter ( Vec u ) key ( Vec u ) payload → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( vec_push [u] b # u ( job_submit_t ) )
+    ( bytes_push_u64_be b # u64 task_id )
+    ( bytes_push_u32_be b # u32 kind )
+    ( __job_put_blob b submitter )
+    ( __job_put_blob b key )
+    ( vec_extend [u] b payload )
+    ^ b
+}
+@ job_build_result i task_id ( Vec u ) payload → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( vec_push [u] b # u ( job_result_t ) )
+    ( bytes_push_u64_be b # u64 task_id )
+    ( vec_extend [u] b payload )
+    ^ b
+}
+
+: JCur { ( Vec u ) buf  i off }
+@ __jc_u8 *JCur c → i { : i v ?? ( vec_get [u] . c buf . c off ) { T x → # i x F → 0 } = . c off + . c off 1 ^ v }
+@ __jc_u16 *JCur c → i { : i v ?? ( bytes_read_u16_be . c buf . c off ) { T x → # i x F → 0 } = . c off + . c off 2 ^ v }
+@ __jc_u32 *JCur c → i { : i v ?? ( bytes_read_u32_be . c buf . c off ) { T x → # i x F → 0 } = . c off + . c off 4 ^ v }
+@ __jc_u64 *JCur c → i { : i v ?? ( bytes_read_u64_be . c buf . c off ) { T x → # i x F → 0 } = . c off + . c off 8 ^ v }
+@ __jc_blob *JCur c i n → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] n )
+    : ~ i k 0
+    ~ < k n { ?? ( vec_get [u] . c buf + . c off k ) { T x → ( vec_push [u] o x ) F → {} } = k + k 1 }
+    = . c off + . c off n
+    ^ o
+}
+@ __jc_rest *JCur c → ( Vec u ) {
+    : i n ( vec_len [u] . c buf )
+    ^ ( __jc_blob c - n . c off )
+}
+
+@ jobmsg_decode ( Vec u ) buf → JobMsg {
+    : *JCur c # *JCur ( nurl_alloc Z JCur )
+    = . c buf buf
+    = . c off 0
+    : i mtype ( __jc_u8 c )
+    : i task_id ( __jc_u64 c )
+    : ~ i kind 0
+    : ~ ( Vec u ) submitter ( vec_new [u] )
+    : ~ ( Vec u ) key ( vec_new [u] )
+    ? == mtype ( job_submit_t ) {
+        = kind ( __jc_u32 c )
+        : i slen ( __jc_u16 c )
+        ( vec_free [u] submitter )
+        = submitter ( __jc_blob c slen )
+        : i klen ( __jc_u16 c )
+        ( vec_free [u] key )
+        = key ( __jc_blob c klen )
+    } {}
+    : ( Vec u ) payload ( __jc_rest c )
+    ( nurl_free # s c )
+    ^ @ JobMsg { mtype task_id kind submitter key payload }
+}
+
+// ── node: ring + transport + handler registry + result store ─────
+
+: JobHandler {
+    i kind
+    ( @ ( Vec u ) ( Vec u ) ) fn
+}
+: JobResult {
+    i task_id
+    ( Vec u ) result
+}
+: JobNode {
+    s transport       // *Transport (caller-owned; not freed here)
+    s ring            // *Ring     (caller-owned; not freed here)
+    ( Vec u ) self_pk
+    i replica         // this node's stable replica id → unique task ids
+    i next_task
+    ( Vec s ) handlers   // *JobHandler
+    ( Vec s ) results    // *JobResult (idempotent by task_id)
+}
+
+@ job_node_new s transport s ring ( Vec u ) self_pk i replica → *JobNode {
+    : *JobNode n # *JobNode ( nurl_alloc Z JobNode )
+    = . n transport transport
+    = . n ring ring
+    = . n self_pk ( __job_cpy self_pk )
+    = . n replica replica
+    = . n next_task 0
+    = . n handlers ( vec_new [s] )
+    = . n results ( vec_new [s] )
+    ^ n
+}
+
+@ job_node_free *JobNode n → v {
+    ( vec_free [u] . n self_pk )
+    : i hn ( vec_len [s] . n handlers )
+    : ~ i k 0
+    ~ < k hn {
+        : s pp ?? ( vec_get [s] . n handlers k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *JobHandler jh # *JobHandler pp
+            : ( @ ( Vec u ) ( Vec u ) ) hf . jh fn
+            : *u env # *u hf 1
+            ? != # i env 0 { ( nurl_free # s env ) } {}
+            ( nurl_free # s jh )
+        } {}
+        = k + k 1
+    }
+    ( vec_free [s] . n handlers )
+    : i rn ( vec_len [s] . n results )
+    : ~ i j 0
+    ~ < j rn {
+        : s pp ?? ( vec_get [s] . n results j ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *JobResult jr # *JobResult pp ( vec_free [u] . jr result ) ( nurl_free # s jr ) } {}
+        = j + j 1
+    }
+    ( vec_free [s] . n results )
+    ( nurl_free # s n )
+}
+
+// Register a handler for a task kind: payload bytes → result bytes.
+@ job_register *JobNode n i kind ( @ ( Vec u ) ( Vec u ) ) fn → v {
+    : *JobHandler jh # *JobHandler ( nurl_alloc Z JobHandler )
+    = . jh kind kind
+    = . jh fn fn
+    ( vec_push [s] . n handlers # s jh )
+}
+
+@ __job_handler *JobNode n i kind → s {
+    : i hn ( vec_len [s] . n handlers )
+    : ~ s found # s 0
+    : ~ i k 0
+    ~ & == # i found 0 < k hn {
+        : s pp ?? ( vec_get [s] . n handlers k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *JobHandler jh # *JobHandler pp ? == . jh kind kind { = found pp } {} } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+// Run the registered handler for a kind (empty Vec if none registered).
+@ __job_execute *JobNode n i kind ( Vec u ) payload → ( Vec u ) {
+    : s hp ( __job_handler n kind )
+    ? == # i hp 0 { ^ ( vec_new [u] ) } {}
+    : *JobHandler jh # *JobHandler hp
+    : ( @ ( Vec u ) ( Vec u ) ) h . jh fn
+    ^ ( h payload )
+}
+
+// Record a result by task_id, idempotently (a re-delivered RESULT is a no-op).
+@ __job_record *JobNode n i task_id ( Vec u ) result → v {
+    : i rn ( vec_len [s] . n results )
+    : ~ b have F : ~ i k 0
+    ~ & ! have < k rn {
+        : s pp ?? ( vec_get [s] . n results k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *JobResult jr # *JobResult pp ? == . jr task_id task_id { = have T } {} } {}
+        = k + k 1
+    }
+    ? have { ^ v } {}
+    : *JobResult jr # *JobResult ( nurl_alloc Z JobResult )
+    = . jr task_id task_id
+    = . jr result ( __job_cpy result )
+    ( vec_push [s] . n results # s jr )
+}
+
+// Has a result for this task_id been recorded?
+@ job_has *JobNode n i task_id → b {
+    : i rn ( vec_len [s] . n results )
+    : ~ b have F : ~ i k 0
+    ~ & ! have < k rn {
+        : s pp ?? ( vec_get [s] . n results k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *JobResult jr # *JobResult pp ? == . jr task_id task_id { = have T } {} } {}
+        = k + k 1
+    }
+    ^ have
+}
+
+// The recorded result for a task_id (copied), or None.
+@ job_await *JobNode n i task_id → ?( Vec u ) {
+    : i rn ( vec_len [s] . n results )
+    : ~ ?( Vec u ) out @ ?( Vec u ) { F # ( Vec u ) 0 }
+    : ~ b got F
+    : ~ i k 0
+    ~ & ! got < k rn {
+        : s pp ?? ( vec_get [s] . n results k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *JobResult jr # *JobResult pp
+            ? == . jr task_id task_id { = out @ ?( Vec u ) { T ( __job_cpy . jr result ) } = got T } {}
+        } {}
+        = k + k 1
+    }
+    ^ out
+}
+
+// The current owner pubkey for a key (from the live ring), copied or None.
+@ job_owner_pk *JobNode n ( Vec u ) key → ?( Vec u ) { ^ ( ring_owner_pk # *Ring . n ring key ) }
+
+// Does this node currently own `key`?
+@ job_owns *JobNode n ( Vec u ) key → b {
+    : ?( Vec u ) o ( ring_owner_pk # *Ring . n ring key )
+    ^ ?? o { T pk → { : b same ( __job_veq pk . n self_pk ) ( vec_free [u] pk ) same } F → F }
+}
+
+@ __job_unique *JobNode n → i {
+    : i id + * . n replica 1000000000 . n next_task
+    = . n next_task + . n next_task 1
+    ^ id
+}
+
+// ── dispatch (transport adapter) ─────────────────────────────────
+
+// Submit a task keyed by `key`. If this node owns the key it runs the handler
+// immediately and records the result locally; otherwise it routes a SUBMIT to
+// the current owner. Returns the task_id to await.
+@ job_submit *JobNode n i kind ( Vec u ) key ( Vec u ) payload → i {
+    : i tid ( __job_unique n )
+    ? ( job_owns n key ) {
+        : ( Vec u ) res ( __job_execute n kind payload )
+        ( __job_record n tid res )
+        ( vec_free [u] res )
+    } {
+        : ?( Vec u ) o ( ring_owner_pk # *Ring . n ring key )
+        ?? o {
+            T owner → {
+                : ( Vec u ) msg ( job_build_submit tid kind . n self_pk key payload )
+                ?? ( transport_send # *Transport . n transport owner msg ) { T _ → {} F _ → {} }
+                ( vec_free [u] msg )
+                ( vec_free [u] owner )
+            }
+            F → {}
+        }
+    }
+    ^ tid
+}
+
+// Owner side: a SUBMIT arrived. Execute if we own the key and reply a RESULT
+// to the submitter; otherwise FORWARD to the current owner (re-home).
+@ job_on_submit *JobNode n JobMsg m → v {
+    ? ( job_owns n . m key ) {
+        : ( Vec u ) res ( __job_execute n . m kind . m payload )
+        : ( Vec u ) reply ( job_build_result . m task_id res )
+        ?? ( transport_send # *Transport . n transport . m submitter reply ) { T _ → {} F _ → {} }
+        ( vec_free [u] res )
+        ( vec_free [u] reply )
+    } {
+        : ?( Vec u ) o ( ring_owner_pk # *Ring . n ring . m key )
+        ?? o {
+            T owner → {
+                ? ! ( __job_veq owner . n self_pk ) {
+                    : ( Vec u ) fwd ( job_build_submit . m task_id . m kind . m submitter . m key . m payload )
+                    ?? ( transport_send # *Transport . n transport owner fwd ) { T _ → {} F _ → {} }
+                    ( vec_free [u] fwd )
+                } {}
+                ( vec_free [u] owner )
+            }
+            F → {}
+        }
+    }
+}
+
+// Submitter side: a RESULT arrived → record it (idempotent).
+@ job_on_result *JobNode n JobMsg m → v { ( __job_record n . m task_id . m payload ) }
+
+// Drain inbound transport messages, dispatching SUBMIT / RESULT.
+@ job_pump *JobNode n i max → v {
+    : ~ b more T
+    ~ more {
+        ?? ( transport_recv # *Transport . n transport max ) {
+            T tm → {
+                : JobMsg m ( jobmsg_decode . tm payload )
+                ? == . m mtype ( job_submit_t ) { ( job_on_submit n m ) } {}
+                ? == . m mtype ( job_result_t ) { ( job_on_result n m ) } {}
+                ( jobmsg_free m )
+                ( transport_msg_free tm )
+            }
+            F → { = more F }
+        }
+    }
+}

--- a/stdlib/net/transport.nu
+++ b/stdlib/net/transport.nu
@@ -160,7 +160,15 @@ $ `stdlib/net/relay.nu`
 // Send an opaque payload to a peer over whichever leg is currently chosen.
 @ transport_send *Transport t ( Vec u ) pubkey ( Vec u ) payload → !v NetErr {
     : s pp ( __tp_find t pubkey )
-    ? == # i pp 0 { ^ @ !v NetErr { F # NetErr NetOther } } {}
+    // Unknown peer: no direct path is known (it was never added / no
+    // candidate), so reach it over the relay if one is configured. The seam's
+    // contract is "address ANY pubkey" — requiring transport_add_peer first
+    // would break sending to a peer learned at runtime (e.g. a job submitter
+    // replying to a result, or dispatch to a key's current owner).
+    ? == # i pp 0 {
+        ? == . t has_relay 1 { ^ ( relay_send . t relay pubkey payload ) } {}
+        ^ @ !v NetErr { F # NetErr NetOther }
+    } {}
     : *PeerPath p # *PeerPath pp
     : i leg ( transport_pick p . t has_relay )
     ? == leg 2 {


### PR DESCRIPTION
## Summary
**THE KEYSTONE.** `dist/job.nu` turns distributed *state* into distributed *computation*. Everything beneath it already existed — the consistent-hash ring decides who owns a key, `net/transport` carries opaque bytes by pubkey, the CRDT/result store records idempotently. This module is the dispatch.

**Model:** submit a task keyed by `k`; `ring_owner(k)` executes it via a registered closure handler; the result returns to the submitter over the transport and is recorded by `task_id`, so duplicate delivery is harmless (at-least-once + retry stay safe). A node that receives a SUBMIT for a key it **no longer owns** (the ring changed) **forwards** to the current owner — so killing a worker re-homes its keys and the job still completes.

**API:** `job_node_new` / `job_register(kind, handler)` / `job_submit(key, kind, payload) → task_id` / `job_pump` / `job_await(task_id) → ?result` / `job_has` / `job_owns` / `job_owner_pk` / `job_node_free`. Wire: `SUBMIT(task_id, kind, submitter_pk, key, payload)` / `RESULT(task_id, payload)`. Handlers are `( @ ( Vec u ) ( Vec u ) )` closures (bytes → bytes), the MCP-registry pattern.

### Seam fix the keystone exposed
`transport_send` to a pubkey that was never `transport_add_peer`'d returned `NetOther` instead of relaying. The seam's contract is "address **any** pubkey", so an unknown peer now falls back to the relay leg when one is configured — required for a result reply to a submitter, or dispatch to a key's current owner, both learned at runtime.

## Testing
- **`dist_job.nu`** (+ golden): JobMsg codec; in-process submit→execute→await; idempotent duplicate-delivery (keeps first); owner recompute across a ring change (the re-home target). **ASan-clean** — caught and fixed a real leak in `jobmsg_decode` (the initial empty `submitter`/`key` vecs were overwritten without being freed on a SUBMIT).
- **Live** (relay + 2 workers + coordinator, separate processes): a sharded word-count routes 4 chunks across the workers by key and aggregates to **17**. (`examples/distributed_map.nu`.)
- Suite **388/388**, examples gate **79/79**.

**Done-when** (§7.5 Phase 11): `examples/distributed_map.nu` runs a real computation across several nodes over a relay and returns a correct aggregate ✅. Re-home on owner change is covered by the deterministic test; the *live* worker-kill is part of the Phase 13 chaos harness.

The jewel is mounted. Remaining §7.5: Phase 10 (liveness under load), Phase 12 (leases for effectful tasks), Phase 13 (chaos harness — the running proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)