### PR TITLE
feat(net): liveness under load — self-refutation + heartbeat (§7.5 Phase 10)

### DIFF
--- a/compiler/tests/dist_liveness.nu
+++ b/compiler/tests/dist_liveness.nu
@@ -1,0 +1,72 @@
+// dist_liveness.nu — offline test for §7.5 Phase 10 self-refutation. A node
+// suspected while busy (it missed pings) bumps its incarnation on hearing the
+// suspicion, and the Alive heartbeat it then gossips — carrying the higher
+// incarnation — reinstates it on its peers. Deterministic, no sockets.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/net/membership.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+@ mkpk i seed → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + seed k ) = k + k 1 } ^ v }
+@ cpy ( Vec u ) v → ( Vec u ) { : ( Vec u ) o ( vec_new [u] ) ( vec_extend [u] o v ) ^ o }
+
+// a one-member gossip message: {pk, state, inc}
+@ gossip1 ( Vec u ) pk i st i inc → PkMsg {
+    : ( Vec s ) g ( vec_new [s] )
+    : *PkMember m # *PkMember ( nurl_alloc Z PkMember )
+    = . m pubkey ( cpy pk )
+    = . m state st = . m incarnation inc
+    = . m last_ns 0 = . m susp_start_ns 0 = . m susp_confirms 0
+    ( vec_push [s] g # s m )
+    ^ @ PkMsg { ( pk_ping ) 0 ( vec_new [u] ) g }
+}
+// gossip carrying a node's self-heartbeat fact
+@ heartbeat_of *PkMemberTable t → PkMsg {
+    : ( Vec s ) g ( vec_new [s] )
+    ( vec_push [s] g # s ( pktable_self_fact t ) )
+    ^ @ PkMsg { ( pk_ping ) 0 ( vec_new [u] ) g }
+}
+
+@ main → i {
+    : ( Vec u ) bpk ( mkpk 50 )
+    : ( Vec u ) apk ( mkpk 10 )
+
+    // ── B refutes a suspicion of itself ──────────────────────────
+    : *PkMemberTable bt ( pktable_new bpk 1000 5000 3 8 )
+    ( pb `B starts at incarnation 0: ` == ( pktable_self_incarnation bt ) 0 )
+    // a peer's gossip says B is SUSPECT at inc 0 → B must refute
+    : PkMsg sus ( gossip1 bpk ( pk_suspect ) 0 )
+    ( pktable_apply_gossip bt sus 0 )
+    ( pkmsg_free sus )
+    ( pb `B bumped incarnation on self-suspicion: ` == ( pktable_self_incarnation bt ) 1 )
+    // gossip that B is alive at inc 0 does NOT bump (no false escalation)
+    : PkMsg ok ( gossip1 bpk ( pk_alive ) 9 )
+    ( pktable_apply_gossip bt ok 0 )
+    ( pkmsg_free ok )
+    ( pb `alive-self gossip does not bump: ` == ( pktable_self_incarnation bt ) 1 )
+    // refute is monotonic: a lower observed inc is ignored, a higher bumps past
+    ( pb `refute ignores stale inc: ` ! ( pktable_refute bt 0 ) )
+    ( pb `refute bumps past higher inc: ` ( pktable_refute bt 7 ) )
+    ( pb `incarnation now 8: ` == ( pktable_self_incarnation bt ) 8 )
+
+    // ── A had B suspected; B's heartbeat reinstates it ───────────
+    : *PkMemberTable at ( pktable_new apk 1000 5000 3 8 )
+    ( pktable_apply at bpk ( pk_alive ) 0 0 )
+    ( pktable_suspect at bpk 0 )
+    ( pb `A locally suspects B: ` == ( pktable_state_of at bpk ) ( pk_suspect ) )
+    // B (now at a high incarnation) gossips its alive heartbeat to A
+    : PkMsg hb ( heartbeat_of bt )
+    ( pktable_apply_gossip at hb 100 )
+    ( pkmsg_free hb )
+    ( pb `B's heartbeat reinstates B as alive on A: ` == ( pktable_state_of at bpk ) ( pk_alive ) )
+    // a STALE suspicion at the old incarnation can't re-suspect the reinstated B
+    : PkMsg stale ( gossip1 bpk ( pk_suspect ) 0 )
+    ( pktable_apply_gossip at stale 200 )
+    ( pkmsg_free stale )
+    ( pb `stale suspicion (old inc) is ignored: ` == ( pktable_state_of at bpk ) ( pk_alive ) )
+
+    ( pktable_free bt ) ( pktable_free at )
+    ( vec_free [u] bpk ) ( vec_free [u] apk )
+    ^ 0
+}

--- a/compiler/tests/outputs/dist_liveness.txt
+++ b/compiler/tests/outputs/dist_liveness.txt
@@ -1,0 +1,13 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+B starts at incarnation 0: YES
+B bumped incarnation on self-suspicion: YES
+alive-self gossip does not bump: YES
+refute ignores stale inc: YES
+refute bumps past higher inc: YES
+incarnation now 8: YES
+A locally suspects B: YES
+B's heartbeat reinstates B as alive on A: YES
+stale suspicion (old inc) is ignored: YES

--- a/stdlib/net/membership.nu
+++ b/stdlib/net/membership.nu
@@ -204,6 +204,43 @@ $ `stdlib/std/lifeguard.nu`
     ^ F
 }
 
+// ── self liveness & refutation (§7.5 Phase 10) ──────────────────
+// The non-obvious mobile/compute failure mode: a CPU-bound node misses pings,
+// a peer suspects it, and the node doing real work gets ejected. Lifeguard's
+// LHM protects the ACCUSER; these protect the busy ACCUSED. (Caveat per
+// ASYNC.md: NURL fibers are cooperative — a handler that NEVER yields cannot
+// run the heartbeat at all; the executor must yield between tasks. What this
+// guarantees is that a node which yields even occasionally always wins back
+// its liveness against a stale suspicion.)
+
+@ pktable_self_incarnation *PkMemberTable t → i { ^ . t self_incarnation }
+
+// Refute a suspicion of THIS node: bump our incarnation past `observed_inc`
+// so the Alive fact our next heartbeat carries strictly outranks the stale
+// Suspect/Dead and reinstates us everywhere. T if a bump happened.
+@ pktable_refute *PkMemberTable t i observed_inc → b {
+    ? >= observed_inc . t self_incarnation {
+        = . t self_incarnation + observed_inc 1
+        ^ T
+    } {}
+    ^ F
+}
+
+// Proactive "alive-but-busy" heartbeat fact: an Alive self-fact at our
+// current incarnation, to gossip so peers refresh our liveness without
+// probing us (and, after a refute, to carry the higher incarnation that wins
+// us back). Caller owns the returned *PkMember.
+@ pktable_self_fact *PkMemberTable t → *PkMember {
+    : *PkMember m # *PkMember ( nurl_alloc Z PkMember )
+    = . m pubkey ( __pk_cpy . t self_pk )
+    = . m state ( pk_alive )
+    = . m incarnation . t self_incarnation
+    = . m last_ns 0
+    = . m susp_start_ns 0
+    = . m susp_confirms 0
+    ^ m
+}
+
 // The effective suspicion deadline for a member, with the Lifeguard
 // confirmation scaling AND this node's local-health scaling applied.
 @ __pk_suspicion *PkMemberTable t *PkMember m → Suspicion {
@@ -409,7 +446,14 @@ $ `stdlib/std/lifeguard.nu`
         : s pp ?? ( vec_get [s] . m gossip k ) { T x → x F → # s 0 }
         ? != # i pp 0 {
             : *PkMember mm # *PkMember pp
-            ( pktable_apply t . mm pubkey . mm state . mm incarnation now_ns )
+            ? ( __pk_veq . mm pubkey . t self_pk ) {
+                // Gossip about US. If a peer thinks we're suspect/dead (e.g. it
+                // missed our pings while we were CPU-bound), REFUTE: bump our
+                // incarnation past theirs so our next heartbeat reinstates us.
+                ? != . mm state ( pk_alive ) { ( pktable_refute t . mm incarnation ) } {}
+            } {
+                ( pktable_apply t . mm pubkey . mm state . mm incarnation now_ns )
+            }
         } {}
         = k + k 1
     }


### PR DESCRIPTION
## Summary
The non-obvious compute/mobile failure mode: a CPU-bound node misses pings → a peer suspects it → the node *doing real work* gets ejected mid-job. Lifeguard's Local Health Multiplier (#147) protects the **accuser**; this protects the busy **accused**.

`net/membership` gains SWIM **self-refutation**: when a node sees gossip claiming **it** is suspect/dead (a peer that missed its pings), it bumps its own incarnation past the accuser's, so the Alive fact its next heartbeat carries strictly outranks the stale Suspect/Dead and reinstates it everywhere.

- `pktable_refute(observed_inc)` — bump self incarnation past `observed` (T if bumped); monotonic, ignores stale lower incarnations.
- `pktable_self_incarnation` / `pktable_self_fact` — the proactive **"alive-but-busy" heartbeat** fact to gossip without waiting to be probed.
- `pktable_apply_gossip` now detects facts about self: a non-alive one triggers a refute instead of being dropped.

### Honest caveat (verified against `ASYNC.md`)
NURL fibers are **cooperative** — a handler that *never* yields cannot run the heartbeat at all, so the executor must yield between tasks. What this guarantees is that a node which yields even occasionally always wins its liveness back against a stale suspicion. The full *"a node pinned at 100% past the suspect timeout is not declared dead"* end-to-end assertion lands in the **Phase 13 chaos harness**.

## Testing
- **`dist_liveness.nu`** (+ golden): B refutes a self-suspicion (incarnation 0→1); an alive-self gossip does **not** falsely bump; refute is monotonic; and A — which had B suspected — reinstates B as alive on receiving B's higher-incarnation heartbeat, after which a stale suspicion at the *old* incarnation is ignored. ASan-clean.
- Suite **389/389**, examples gate **79/79**. No compiler changes.

Remaining §7.5: **Phase 12** (`dist/lease.nu` — epoch fence for effectful tasks), **Phase 13** (chaos harness — the running proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)