### PR TITLE
feat(dist): liveness heartbeat on a dedicated OS thread (§7.5 Phase 10 Tier 1)

### DIFF
--- a/compiler/tests/dist_heartbeat.nu
+++ b/compiler/tests/dist_heartbeat.nu
@@ -1,0 +1,44 @@
+// dist_heartbeat.nu — offline test for stdlib/dist/heartbeat.nu payload
+// construction (§7.5 Phase 10 Tier 1). The dedicated-thread firing is
+// live-verified separately; here we check the payload a heartbeat sends: a
+// gossip message carrying just this node's Alive self-fact at its current
+// (possibly refuted) incarnation.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/net/membership.nu`
+$ `stdlib/dist/heartbeat.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+@ mkpk i seed → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + seed k ) = k + k 1 } ^ v }
+@ veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a ) ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n { ? != ?? ( vec_get [u] a k ) { T t → # i t F → -1 } ?? ( vec_get [u] b k ) { T t → # i t F → -2 } { = e F } {} = k + k 1 }
+    ^ e
+}
+
+@ main → i {
+    : ( Vec u ) b ( mkpk 50 )
+    : *PkMemberTable t ( pktable_new b 1000 5000 3 8 )
+
+    : ( Vec u ) p0 ( heartbeat_payload t )
+    : PkMsg m0 ( pkmsg_decode p0 )
+    ( pb `heartbeat is one gossip fact: ` == ( vec_len [s] . m0 gossip ) 1 )
+    : s gp ?? ( vec_get [s] . m0 gossip 0 ) { T x → x F → # s 0 }
+    : *PkMember gm # *PkMember gp
+    ( pb `heartbeat = self alive @ inc 0: ` & & ( veq . gm pubkey b ) == . gm state ( pk_alive ) == . gm incarnation 0 )
+    ( pkmsg_free m0 ) ( vec_free [u] p0 )
+
+    // after refuting a suspicion, the heartbeat carries the bumped incarnation
+    ( pktable_refute t 5 )
+    : ( Vec u ) p1 ( heartbeat_payload t )
+    : PkMsg m1 ( pkmsg_decode p1 )
+    : s gp1 ?? ( vec_get [s] . m1 gossip 0 ) { T x → x F → # s 0 }
+    : *PkMember gm1 # *PkMember gp1
+    ( pb `heartbeat carries refuted incarnation 6: ` == . gm1 incarnation 6 )
+    ( pkmsg_free m1 ) ( vec_free [u] p1 )
+
+    ( pktable_free t ) ( vec_free [u] b )
+    ^ 0
+}

--- a/compiler/tests/outputs/dist_heartbeat.txt
+++ b/compiler/tests/outputs/dist_heartbeat.txt
@@ -1,0 +1,7 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+heartbeat is one gossip fact: YES
+heartbeat = self alive @ inc 0: YES
+heartbeat carries refuted incarnation 6: YES

--- a/stdlib/dist/heartbeat.nu
+++ b/stdlib/dist/heartbeat.nu
@@ -1,0 +1,96 @@
+// stdlib/dist/heartbeat.nu — liveness heartbeat on a DEDICATED OS THREAD
+// (§7.5 Phase 10, Tier 1). NURL fibers are cooperative: a compute handler
+// that never yields starves every fiber on its worker — including a
+// fiber-based failure detector — so a busy node can be wrongly declared dead.
+//
+// The fix is to put the ONE thing that must never starve — the "I am alive"
+// heartbeat — on a real OS thread. The runtime is M:N (worker threads + a
+// reactor thread), so the OS preempts threads: this heartbeat fires on its
+// timer even when every worker fiber is pinned in a tight loop. Combined with
+// net/membership's self-refutation, a node that is merely BUSY keeps its
+// place in the cluster.
+//
+// The thread gossips the node's Alive self-fact (at its current incarnation,
+// so it also carries any refutation) to the group over its OWN relay
+// connection — never contending with the data-plane transport. The membership
+// table is shared with the data plane under the caller-provided Mutex.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/net/membership.nu`
+$ `stdlib/net/relay.nu`
+
+& `c` @ nurl_atomic_i64_load *u p → i
+& `c` @ nurl_atomic_i64_inc *u p → i
+
+@ __hb_cpy ( Vec u ) v → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
+    ( vec_extend [u] o v )
+    ^ o
+}
+
+// Build the encoded heartbeat payload: a gossip message carrying just this
+// node's Alive self-fact at its current incarnation. Pure.
+@ heartbeat_payload *PkMemberTable t → ( Vec u ) {
+    : ( Vec s ) g ( vec_new [s] )
+    ( vec_push [s] g # s ( pktable_self_fact t ) )
+    : PkMsg m @ PkMsg { ( pk_ping ) 0 ( vec_new [u] ) g }
+    : ( Vec u ) bytes ( pkmsg_encode m )
+    ( pkmsg_free m )
+    ^ bytes
+}
+
+: Heartbeat {
+    Thread thr
+    *i stop      // atomic flag: 0 = run, >0 = stop
+    s env        // thread closure env, freed after join
+    i live
+}
+
+// Start the heartbeat thread. It broadcasts the self-alive payload to `group`
+// every `interval_ms`, reading the table under `mtx` (the caller must hold the
+// SAME mtx around its own table mutations). `rc` is the heartbeat's own relay
+// connection. Returns a *Heartbeat to stop later.
+@ heartbeat_start *PkMemberTable t RelayClient rc ( Vec u ) group i interval_ms Mutex mtx → *Heartbeat {
+    : *Heartbeat hb # *Heartbeat ( nurl_alloc Z Heartbeat )
+    : *i stop # *i ( nurl_alloc 8 )
+    = . stop 0 0
+    = . hb stop stop
+    = . hb live 0
+    : ( Vec u ) grp ( __hb_cpy group )
+
+    : ( @ v ) body \ → v {
+        ~ == ( nurl_atomic_i64_load # *u stop ) 0 {
+            ( sleep_ms interval_ms )
+            ? == ( nurl_atomic_i64_load # *u stop ) 0 {
+                ( mutex_lock mtx )
+                : ( Vec u ) payload ( heartbeat_payload t )
+                ( mutex_unlock mtx )
+                ?? ( relay_broadcast rc grp payload ) { T _ → {} F _ → {} }
+                ( vec_free [u] payload )
+            } {}
+        }
+        ( vec_free [u] grp )
+    }
+
+    : !Thread ThreadErr tr ( thread_spawn body )
+    ?? tr {
+        T th → { = . hb thr th = . hb env # s # *u body 1 = . hb live 1 }
+        F e → { ( vec_free [u] grp ) }
+    }
+    ^ hb
+}
+
+// Signal the heartbeat thread to stop, join it, and free its resources.
+@ heartbeat_stop *Heartbeat hb → v {
+    ? == . hb live 1 {
+        ( nurl_atomic_i64_inc # *u . hb stop )   // 0 → 1: stop after current sleep
+        ( thread_join . hb thr )
+        ? != # i . hb env 0 { ( nurl_free . hb env ) } {}
+        = . hb live 0
+    } {}
+    ( nurl_free # s . hb stop )
+    ( nurl_free # s hb )
+}


### PR DESCRIPTION
## Summary
Closes the **"a handler that never yields can't run the heartbeat"** gap left by the self-refutation work (#161). NURL fibers are cooperative, so a compute handler in a tight loop starves every fiber on its worker — including a fiber-based failure detector — and a busy node gets wrongly declared dead.

`dist/heartbeat.nu` puts the one signal that must never starve — *"I am alive"* — on a **real OS thread**. The runtime is **M:N** (worker threads + a reactor), so the OS preempts threads: the heartbeat fires on its timer **even when every worker fiber is pinned in a tight loop**. It gossips the node's Alive self-fact (at its current incarnation, so it also carries any refutation) to the group over its **own** relay connection, never contending with the data-plane transport. The membership table is shared under a caller-provided `Mutex`; the stop flag is an atomic so the thread exits cleanly on `heartbeat_stop` (signal + join + free).

This is the *correct architecture* for a liveness signal — a preemptive timer — not a workaround. It turns the Phase 10 caveat into a guarantee for the heartbeat path.

**API:** `heartbeat_payload(table)` (pure — the encoded self-alive gossip) / `heartbeat_start(table, relay_client, group, interval_ms, mutex) → *Heartbeat` / `heartbeat_stop`.

## Testing
- **`dist_heartbeat.nu`** (+ golden): the payload is a one-fact gossip carrying `{self, alive, incarnation}`, and after a refute it carries the bumped incarnation. ASan-clean.
- **Live** (relay + busy node + receiver, separate processes): the busy node starts the heartbeat thread, then pins its **main thread** in a 900M-iteration tight loop (no sleep, no yield); the receiver still counts **6 heartbeats** arriving during that window — the thread fired despite the CPU pin. ✅ *(This is the §7.5 Phase 10 "a node pinned at 100% CPU is not declared dead" guarantee, demonstrated.)*
- Suite **390/390**, examples gate **79/79**. No compiler changes.

Tier 2 (compiler loop-preemption to make *all* fibers preemptible) and the reactor recv-deadline gap remain tracked follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)