### PR TITLE
feat(dist): fencing leases for side-effecting tasks (§7.5 Phase 12)

### DIFF
--- a/compiler/tests/dist_lease.nu
+++ b/compiler/tests/dist_lease.nu
@@ -1,0 +1,56 @@
+// dist_lease.nu — offline test for stdlib/dist/lease.nu (§7.5 Phase 12).
+// Deterministic: the fence (epoch monotonicity) + idempotency key give
+// at-most-once for a side effect across a split-ownership window in BOTH
+// orderings, while distinct effects and pure tasks are unaffected.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/dist/lease.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+@ mkkey i id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) ( vec_push [u] v # u id ) ( vec_push [u] v # u 9 ) ^ v }
+
+// run the effect iff admitted; bump the shared effect counter via a *i cell
+@ effect *LeaseTable t ( Vec u ) key i epoch i idem *i log → v {
+    ? ( lease_admit t key epoch idem ) { = . log 0 + . log 0 1 } {}
+}
+
+@ main → i {
+    : ( Vec u ) k ( mkkey 1 )
+
+    // ── split ownership, NEW owner acts first (token 2 then stale 1) ──
+    : *LeaseTable t1 ( lease_new )
+    : *i log1 # *i ( nurl_alloc 8 ) = . log1 0 0
+    // task idem=100. B (new owner, epoch 2) acts; then A (old owner, epoch 1)
+    ( effect t1 k 2 100 log1 )    // B: admitted → effect
+    ( effect t1 k 1 100 log1 )    // A: epoch 1 < 2 → fenced out
+    ( pb `new-first: effect ran exactly once: ` == . log1 0 1 )
+    ( vec_free [u] k ) ( nurl_free # s log1 ) ( lease_free t1 )
+
+    // ── split ownership, OLD owner acts first (token 1 then 2) ──────
+    : ( Vec u ) k2 ( mkkey 1 )
+    : *LeaseTable t2 ( lease_new )
+    : *i log2 # *i ( nurl_alloc 8 ) = . log2 0 0
+    ( effect t2 k2 1 100 log2 )   // A: admitted (first) → effect
+    ( effect t2 k2 2 100 log2 )   // B: epoch 2 >= 1 advances, but idem 100 already applied → deduped
+    ( pb `old-first: effect ran exactly once: ` == . log2 0 1 )
+    // the fence advanced to the higher epoch even though the effect was deduped
+    ( pb `fence advanced to epoch 2: ` == ( lease_token t2 k2 ) 2 )
+
+    // a genuinely DIFFERENT task (idem 200) under the current epoch still runs
+    ( effect t2 k2 2 200 log2 )
+    ( pb `distinct effect still admitted: ` == . log2 0 2 )
+    // a stale-epoch execution is refused even for a new idem (fenced owner)
+    ( effect t2 k2 1 300 log2 )
+    ( pb `stale-epoch refused even for new idem: ` == . log2 0 2 )
+    ( vec_free [u] k2 ) ( nurl_free # s log2 ) ( lease_free t2 )
+
+    // ── pure path is unaffected: never touches the lease table ──────
+    : *LeaseTable t3 ( lease_new )
+    // (a pure handler simply does not call lease_admit — the table stays empty)
+    : ( Vec u ) k7 ( mkkey 7 )
+    ( pb `pure tasks leave the lease table empty: ` == ( lease_token t3 k7 ) 0 )
+    ( vec_free [u] k7 ) ( lease_free t3 )
+
+    ^ 0
+}

--- a/compiler/tests/outputs/dist_lease.txt
+++ b/compiler/tests/outputs/dist_lease.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+new-first: effect ran exactly once: YES
+old-first: effect ran exactly once: YES
+fence advanced to epoch 2: YES
+distinct effect still admitted: YES
+stale-epoch refused even for new idem: YES
+pure tasks leave the lease table empty: YES

--- a/stdlib/dist/lease.nu
+++ b/stdlib/dist/lease.nu
@@ -1,0 +1,126 @@
+// stdlib/dist/lease.nu — fencing for side-effecting tasks (§7.5 Phase 12).
+//
+// During membership convergence two nodes can BRIEFLY both believe they own a
+// key. For CRDT state that's harmless — merges commute. But an external side
+// effect (write a file, call an API, charge money) executed twice is not.
+//
+// The fix is the standard fencing-token discipline, enforced at the resource:
+//
+//   * Ownership EPOCHS — a monotonic epoch per key, bumped on every ring
+//     change; a dispatched task carries the epoch it was issued under.
+//   * FENCE — the resource remembers the highest epoch it has admitted for a
+//     key and REFUSES any execution carrying a lower (stale) epoch. So an old
+//     owner that kept dispatching under a stale epoch is fenced out once the
+//     new owner (higher epoch) has acted.
+//   * IDEMPOTENCY KEYS — the resource also dedups by the task's idempotency
+//     key (its task_id), so the SAME task can't fire its effect twice even
+//     when the old owner happened to act first and the new owner retries.
+//
+// Fence (epoch monotonicity) + idempotency (task_id) together give AT-MOST-ONCE
+// across a split-ownership window in either ordering. Pure (no side effect)
+// handlers never call this and pay zero overhead — they declare themselves
+// pure to the job executor.
+//
+// Idempotency keys are i64 (dist/job task_ids are i64); resource keys are
+// opaque bytes (the same key dist/ring shards on). Pure + deterministic.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+@ __ls_veq ( Vec u ) a ( Vec u ) b → b {
+    : i n ( vec_len [u] a )
+    ? != n ( vec_len [u] b ) { ^ F } {}
+    : ~ b e T : ~ i k 0
+    ~ & e < k n {
+        : i x ?? ( vec_get [u] a k ) { T t → # i t F → -1 }
+        : i y ?? ( vec_get [u] b k ) { T t → # i t F → -2 }
+        ? != x y { = e F } {}
+        = k + k 1
+    }
+    ^ e
+}
+@ __ls_cpy ( Vec u ) v → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
+    ( vec_extend [u] o v )
+    ^ o
+}
+
+: LeaseEntry {
+    ( Vec u ) key       // resource key
+    i token             // highest epoch admitted for this key
+    ( Vec i ) applied   // idempotency keys (task_ids) already admitted
+}
+
+: LeaseTable {
+    ( Vec s ) entries   // *LeaseEntry
+}
+
+@ lease_new → *LeaseTable {
+    : *LeaseTable t # *LeaseTable ( nurl_alloc Z LeaseTable )
+    = . t entries ( vec_new [s] )
+    ^ t
+}
+@ lease_free *LeaseTable t → v {
+    : i n ( vec_len [s] . t entries )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . t entries k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *LeaseEntry e # *LeaseEntry pp ( vec_free [u] . e key ) ( vec_free [i] . e applied ) ( nurl_free # s e ) } {}
+        = k + k 1
+    }
+    ( vec_free [s] . t entries )
+    ( nurl_free # s t )
+}
+
+@ __lease_find *LeaseTable t ( Vec u ) key → s {
+    : i n ( vec_len [s] . t entries )
+    : ~ s found # s 0
+    : ~ i k 0
+    ~ & == # i found 0 < k n {
+        : s pp ?? ( vec_get [s] . t entries k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *LeaseEntry e # *LeaseEntry pp ? ( __ls_veq . e key key ) { = found pp } {} } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+@ __applied_has ( Vec i ) v i idem → b {
+    : i n ( vec_len [i] v )
+    : ~ b has F : ~ i k 0
+    ~ & ! has < k n { ? == ?? ( vec_get [i] v k ) { T x → x F → -1 } idem { = has T } {} = k + k 1 }
+    ^ has
+}
+
+// The current (highest admitted) epoch for a key; 0 if never seen.
+@ lease_token *LeaseTable t ( Vec u ) key → i {
+    : s pp ( __lease_find t key )
+    ? == # i pp 0 { ^ 0 } {}
+    : *LeaseEntry e # *LeaseEntry pp
+    ^ . e token
+}
+
+// Admit a side-effecting execution for (key, epoch) with idempotency key
+// `idem`. Returns T iff the effect should be performed:
+//   * REFUSE if `epoch` is older than the highest epoch admitted for the key
+//     (a stale owner, fenced out by a newer one);
+//   * else advance the key's epoch to `epoch`, and REFUSE if `idem` was
+//     already admitted (duplicate delivery / the same task already ran);
+//   * else record `idem` and admit (T).
+@ lease_admit *LeaseTable t ( Vec u ) key i epoch i idem → b {
+    : s pp ( __lease_find t key )
+    ? == # i pp 0 {
+        : *LeaseEntry e # *LeaseEntry ( nurl_alloc Z LeaseEntry )
+        = . e key ( __ls_cpy key )
+        = . e token epoch
+        = . e applied ( vec_new [i] )
+        ( vec_push [i] . e applied idem )
+        ( vec_push [s] . t entries # s e )
+        ^ T
+    } {}
+    : *LeaseEntry e # *LeaseEntry pp
+    ? < epoch . e token { ^ F } {}        // stale epoch — fenced out
+    = . e token epoch                     // advance (epoch >= token)
+    ? ( __applied_has . e applied idem ) { ^ F } {}   // duplicate — already ran
+    ( vec_push [i] . e applied idem )
+    ^ T
+}


### PR DESCRIPTION
## Summary
During membership convergence two nodes can **briefly both believe they own a key**. CRDT state is safe (merges commute); an external side effect run twice is not (write a file, call an API, charge money). `dist/lease.nu` enforces the standard **fencing-token** discipline at the resource:

- **ownership EPOCH** per key (bumped on ring change); a dispatched task carries the epoch it was issued under;
- **FENCE** — the resource remembers the highest epoch admitted for a key and **refuses** any execution at a lower (stale) epoch, so an old owner that keeps dispatching under a stale epoch is fenced out once the new owner acts;
- **IDEMPOTENCY KEY** — the resource also dedups by the task's idempotency key (its `task_id`), so the same task can't fire twice even when the old owner acted first and the new owner retries.

Fence (epoch monotonicity) + idempotency together give **at-most-once across a split-ownership window in either ordering**. Pure handlers never call this and pay zero overhead — they declare themselves pure to the executor.

**API:** `lease_new` / `lease_admit(key, epoch, idem) → b` (T = perform the effect) / `lease_token(key)` / `lease_free`. Idempotency keys are `i64` (dist/job `task_id`s); resource keys are the opaque bytes `dist/ring` shards on.

## Testing
- **`dist_lease.nu`** (+ golden): split ownership with the **new** owner acting first (stale epoch fenced) **and** with the **old** owner acting first (new epoch advances the fence but the duplicate idem is deduped) both run the effect **exactly once**; a distinct task under the current epoch still runs; a stale-epoch execution is refused even for a fresh idem; and a pure path leaves the lease table empty.
- ASan-clean. Suite **391/391**. No compiler changes.

**Done-when** (§7.5 Phase 12): a deliberately induced split-ownership window produces no double side-effect, while pure tasks are unaffected ✅.

Wiring epoch + effectful-flag through `dist/job` dispatch is the integration step, exercised end-to-end in the **Phase 13 chaos harness**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)