### PR TITLE
feat(dist): deterministic chaos-simulation harness + first scenario (§7.5 Phase 13)

### DIFF
--- a/compiler/tests/outputs/sim_membership.txt
+++ b/compiler/tests/outputs/sim_membership.txt
@@ -1,0 +1,11 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+before gossip only node 0 knows 3 dead: YES
+lossy gossip converged 3-dead on node 1: YES
+lossy gossip converged 3-dead on node 2: YES
+some messages were actually dropped: YES
+partition: nodes 0,1 learn 3 dead: YES
+partition: isolated node 2 does NOT: YES
+after heal node 2 reconverges 3 dead: YES

--- a/compiler/tests/sim_membership.nu
+++ b/compiler/tests/sim_membership.nu
@@ -1,0 +1,116 @@
+// sim_membership.nu — first §7.5 Phase 13 chaos-harness scenario. Drives the
+// REAL net/membership tables + gossip codec over dist/sim's deterministic bus:
+//   (1) a death fact converges to every node despite 30% packet loss + reorder;
+//   (2) a partition isolates a node from the fact, and healing reconverges it.
+// Seeded → byte-reproducible; the assertions can genuinely fail.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/net/membership.nu`
+$ `stdlib/dist/sim.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+@ pk i id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + id k ) = k + k 1 } ^ v }
+@ node ( Vec s ) tables i i → *PkMemberTable { ^ # *PkMemberTable ?? ( vec_get [s] tables i ) { T x → x F → # s 0 } }
+
+// build a node's gossip snapshot and submit it to a peer over the bus
+@ send_gossip *SimNet net i src *PkMemberTable t i peer i now → v {
+    : ( Vec s ) g ( pktable_gossip t 16 )
+    : PkMsg m @ PkMsg { ( pk_ping ) 0 ( vec_new [u] ) g }
+    : ( Vec u ) bytes ( pkmsg_encode m )
+    ( sim_send net src peer bytes now )
+    ( pkmsg_free m ) ( vec_free [u] bytes )
+}
+
+// deliver every due message, applying its gossip to the destination table
+@ deliver_due *SimNet net ( Vec s ) tables i now → v {
+    : ( Vec s ) due ( sim_due net now )
+    : i dn ( vec_len [s] due )
+    : ~ i k 0
+    ~ < k dn {
+        : s mp ?? ( vec_get [s] due k ) { T x → x F → # s 0 }
+        ? != # i mp 0 {
+            : *SimMsg msg # *SimMsg mp
+            : PkMsg pm ( pkmsg_decode . msg bytes )
+            ( pktable_apply_gossip ( node tables . msg dst ) pm now )
+            ( pkmsg_free pm )
+            ( sim_msg_free msg )
+        } {}
+        = k + k 1
+    }
+    ( vec_free [s] due )
+}
+
+// run `rounds` gossip ticks; node `dead_idx` is gone (never gossips)
+@ run_rounds *SimNet net ( Vec s ) tables i rounds i dead_idx i now0 → i {
+    : ~ i now now0
+    : ~ i r 0
+    ~ < r rounds {
+        = now + now 1
+        : ~ i i 0
+        ~ < i 4 {
+            ? != i dead_idx {
+                : i peer % ( __sim_rand net ) 4
+                ? != peer i { ( send_gossip net i ( node tables i ) peer now ) } {}
+            } {}
+            = i + i 1
+        }
+        ( deliver_due net tables now )
+        = r + r 1
+    }
+    ^ now
+}
+
+@ knows_dead ( Vec s ) tables i idx ( Vec u ) deadpk → b { ^ == ( pktable_state_of ( node tables idx ) deadpk ) ( pk_dead ) }
+
+@ make_tables → ( Vec s ) {
+    : ( Vec s ) tables ( vec_new [s] )
+    : ~ i i 0
+    ~ < i 4 {
+        : ( Vec u ) selfpk ( pk i )
+        : *PkMemberTable t ( pktable_new selfpk 1000 5000 3 8 )
+        ( vec_free [u] selfpk )
+        // bootstrap: every node knows the other three, alive @ incarnation 1
+        : ~ i j 0
+        ~ < j 4 { ? != j i { : ( Vec u ) p ( pk j ) ( pktable_apply t p ( pk_alive ) 1 0 ) ( vec_free [u] p ) } {} = j + j 1 }
+        ( vec_push [s] tables # s t )
+        = i + i 1
+    }
+    ^ tables
+}
+@ free_tables ( Vec s ) tables → v {
+    : ~ i i 0 ~ < i 4 { ( pktable_free ( node tables i ) ) = i + i 1 }
+    ( vec_free [s] tables )
+}
+
+@ main → i {
+    : ( Vec u ) dead3 ( pk 3 )
+
+    // ── (1) convergence under 30% loss + reorder ─────────────────
+    : *SimNet net ( sim_net_new 4 12345 30 1 3 )
+    : ( Vec s ) tables ( make_tables )
+    // node 0 detects node 3 dead (incarnation 2 outranks the bootstrap alive)
+    ( pktable_apply ( node tables 0 ) dead3 ( pk_dead ) 2 0 )
+    ( pb `before gossip only node 0 knows 3 dead: ` & ( knows_dead tables 0 dead3 ) ! ( knows_dead tables 1 dead3 ) )
+    : i now1 ( run_rounds net tables 60 3 0 )
+    ( pb `lossy gossip converged 3-dead on node 1: ` ( knows_dead tables 1 dead3 ) )
+    ( pb `lossy gossip converged 3-dead on node 2: ` ( knows_dead tables 2 dead3 ) )
+    ( pb `some messages were actually dropped: ` > ( sim_dropped net ) 0 )
+    ( free_tables tables ) ( sim_net_free net )
+
+    // ── (2) partition isolates node 2, heal reconverges ──────────
+    : *SimNet net2 ( sim_net_new 4 777 0 1 0 )      // no random drop; clean partition
+    ( sim_partition net2 2 0 ) ( sim_partition net2 2 1 ) ( sim_partition net2 2 3 )
+    : ( Vec s ) tb ( make_tables )
+    ( pktable_apply ( node tb 0 ) dead3 ( pk_dead ) 2 0 )
+    : i now2 ( run_rounds net2 tb 25 3 0 )
+    ( pb `partition: nodes 0,1 learn 3 dead: ` & ( knows_dead tb 0 dead3 ) ( knows_dead tb 1 dead3 ) )
+    ( pb `partition: isolated node 2 does NOT: ` ! ( knows_dead tb 2 dead3 ) )
+    ( sim_heal_all net2 )
+    : i now3 ( run_rounds net2 tb 25 3 now2 )
+    ( pb `after heal node 2 reconverges 3 dead: ` ( knows_dead tb 2 dead3 ) )
+    ( free_tables tb ) ( sim_net_free net2 )
+
+    ( vec_free [u] dead3 )
+    ^ 0
+}

--- a/stdlib/dist/sim.nu
+++ b/stdlib/dist/sim.nu
@@ -1,0 +1,136 @@
+// stdlib/dist/sim.nu — deterministic discrete-event network simulator for the
+// distributed stack (§7.5 Phase 13, the chaos harness). Because every layer
+// is a pure, time-injected state machine (fd_tick(now), pktable_sweep(now),
+// suspicion_expired(s, now), the codecs, the ring, the CRDTs, the lease), the
+// real stdlib logic can be driven inside a fully simulated world: a virtual
+// clock the harness advances, and an in-process message bus the harness fully
+// controls. No sockets, no wall-clock, no flakiness — a seeded RNG makes every
+// run byte-reproducible, and faults (drop, latency/jitter→reorder, partition,
+// heal) are injected BEFORE the logic sees anything, so the headline assertions
+// can genuinely fail.
+//
+// Nodes are integer indices 0..n-1. Messages carry opaque bytes (the real
+// PkMsg / JobMsg / CRDT encodings). The harness routes a node's real encoded
+// output through this bus instead of a socket.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+@ __sim_cpy ( Vec u ) v → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ( vec_len [u] v ) )
+    ( vec_extend [u] o v )
+    ^ o
+}
+
+: SimMsg {
+    i src
+    i dst
+    i at          // virtual delivery time
+    ( Vec u ) bytes
+}
+@ sim_msg_free *SimMsg m → v { ( vec_free [u] . m bytes ) ( nurl_free # s m ) }
+
+: SimNet {
+    ( Vec s ) inflight   // *SimMsg, not yet delivered
+    i n                  // node count
+    i seed               // LCG state (deterministic RNG)
+    i drop_pct           // 0..100 per-message drop probability
+    i latency            // base delivery delay (virtual ticks)
+    i jitter             // extra random delay 0..jitter (causes reorder)
+    ( Vec i ) reach      // n*n reachability matrix; 1 = link up, 0 = partitioned
+    i delivered          // counter (messages actually delivered)
+    i dropped            // counter (dropped or partitioned away)
+}
+
+@ sim_net_new i n i seed i drop_pct i latency i jitter → *SimNet {
+    : *SimNet net # *SimNet ( nurl_alloc Z SimNet )
+    = . net inflight ( vec_new [s] )
+    = . net n n
+    = . net seed seed
+    = . net drop_pct drop_pct
+    = . net latency latency
+    = . net jitter jitter
+    = . net delivered 0
+    = . net dropped 0
+    : ( Vec i ) reach ( vec_new [i] )
+    : i tot * n n
+    : ~ i k 0
+    ~ < k tot { ( vec_push [i] reach 1 ) = k + k 1 }
+    = . net reach reach
+    ^ net
+}
+
+@ sim_net_free *SimNet net → v {
+    : i m ( vec_len [s] . net inflight )
+    : ~ i k 0
+    ~ < k m { : s pp ?? ( vec_get [s] . net inflight k ) { T x → x F → # s 0 } ? != # i pp 0 { ( sim_msg_free # *SimMsg pp ) } {} = k + k 1 }
+    ( vec_free [s] . net inflight )
+    ( vec_free [i] . net reach )
+    ( nurl_free # s net )
+}
+
+// LCG (Knuth MMIX constants); wraps in i64. Returns a non-negative pseudo-int.
+@ __sim_rand *SimNet net → i {
+    = . net seed + * . net seed 6364136223846793005 1442695040888963407
+    : i r . net seed
+    ^ ? < r 0 - 0 r r
+}
+@ __sim_chance *SimNet net i pct → b { ^ < % ( __sim_rand net ) 100 pct }
+
+@ sim_reachable *SimNet net i a i b → b {
+    ^ == ?? ( vec_get [i] . net reach + * a . net n b ) { T x → x F → 0 } 1
+}
+@ sim_partition *SimNet net i a i b → v {
+    ( vec_set [i] . net reach + * a . net n b 0 )
+    ( vec_set [i] . net reach + * b . net n a 0 )
+}
+@ sim_heal *SimNet net i a i b → v {
+    ( vec_set [i] . net reach + * a . net n b 1 )
+    ( vec_set [i] . net reach + * b . net n a 1 )
+}
+// Heal every link (e.g. after a full partition scenario).
+@ sim_heal_all *SimNet net → v {
+    : i tot * . net n . net n
+    : ~ i k 0
+    ~ < k tot { ( vec_set [i] . net reach k 1 ) = k + k 1 }
+}
+
+// Submit a message src→dst at virtual time `now`. Silently lost if the link is
+// partitioned or it loses the drop roll; otherwise scheduled for now + latency
+// + a random jitter (which reorders deliveries). Bytes are copied.
+@ sim_send *SimNet net i src i dst ( Vec u ) bytes i now → v {
+    ? ! ( sim_reachable net src dst ) { = . net dropped + . net dropped 1 ^ v } {}
+    ? & > . net drop_pct 0 ( __sim_chance net . net drop_pct ) { = . net dropped + . net dropped 1 ^ v } {}
+    : i extra ? > . net jitter 0 % ( __sim_rand net ) . net jitter 0
+    : *SimMsg m # *SimMsg ( nurl_alloc Z SimMsg )
+    = . m src src
+    = . m dst dst
+    = . m at + + now . net latency extra
+    = . m bytes ( __sim_cpy bytes )
+    ( vec_push [s] . net inflight # s m )
+}
+
+// Pop all messages whose delivery time has arrived (at <= now). Caller owns
+// the returned *SimMsg list — read src/dst/bytes, then free each with
+// sim_msg_free and the container with vec_free [s].
+@ sim_due *SimNet net i now → ( Vec s ) {
+    : ( Vec s ) due ( vec_new [s] )
+    : ( Vec s ) keep ( vec_new [s] )
+    : i m ( vec_len [s] . net inflight )
+    : ~ i k 0
+    ~ < k m {
+        : s pp ?? ( vec_get [s] . net inflight k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *SimMsg msg # *SimMsg pp
+            ? <= . msg at now { ( vec_push [s] due pp ) = . net delivered + . net delivered 1 } { ( vec_push [s] keep pp ) }
+        } {}
+        = k + k 1
+    }
+    ( vec_free [s] . net inflight )
+    = . net inflight keep
+    ^ due
+}
+
+@ sim_inflight_count *SimNet net → i { ^ ( vec_len [s] . net inflight ) }
+@ sim_delivered *SimNet net → i { ^ . net delivered }
+@ sim_dropped *SimNet net → i { ^ . net dropped }


### PR DESCRIPTION
## How you *really* test a distributed system
Not flaky multi-process socket runs — you can't assert "no double side-effect across a partition" by hoping the timing lines up. You run the **real logic inside a fully controlled simulated world**, the way FoundationDB / TigerBeetle / `madsim` do. Every layer of this stack was built as a **pure, time-injected state machine** precisely so this works.

### `dist/sim.nu` — deterministic discrete-event network simulator
- **virtual clock** — the harness advances time; no wall-clock, no `sleep`;
- an in-process **message bus** carrying opaque bytes (the real `PkMsg` / `JobMsg` / CRDT encodings) between integer node indices;
- **fault injection applied before the logic sees anything**: seeded per-message **drop**, **latency + jitter** (→ reorder), **partition / heal / heal_all** via an n×n reachability matrix;
- a **seeded LCG RNG** so every run is byte-reproducible, plus delivered/dropped counters so a scenario can assert faults actually occurred.

API: `sim_net_new` / `sim_send` / `sim_due` / `sim_partition` / `sim_heal[_all]` / `sim_reachable` / `sim_delivered` / `sim_dropped` / `sim_net_free`.

### First scenario — `sim_membership.nu`
Drives the **real** `net/membership` tables + gossip codec over the bus:
1. a death fact **converges to every node despite 30% packet loss + reorder** (and asserts messages were genuinely dropped — the chaos is real);
2. a **partition** isolates a node from the fact, and **heal** reconverges it.

This is the assertion shape for the rest of Phase 13 — job completes across partition+heal, no double side-effect across split ownership, CPU-pinned node not evicted — each a deterministic golden the code can actually fail.

## Testing
- **`sim_membership.nu`** (+ golden), ASan-clean (caught a test leak en route: a `( pk i )` self-pubkey temp passed inline to `pktable_new`, which copies it — bound + freed).
- Suite green, examples gate **79/79**. No compiler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)