### PR TITLE
fix(dist): CRDT replica ids must be globally stable — pubkey-derived, id-keyed merge (Phase 13)

### DIFF
--- a/compiler/tests/outputs/sim_crdt.txt
+++ b/compiler/tests/outputs/sim_crdt.txt
@@ -1,0 +1,12 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+each node's own count before gossip (=1): 1
+during partition, node 0 value (sees 0+1 only, =2): 2
+during partition, node 2 is isolated (value 1): YES
+after heal node 0 value: 3
+after heal node 1 value: 3
+after heal node 2 value: 3
+CONVERGED to 3 on every node (no id collision): YES
+messages were actually dropped: YES

--- a/compiler/tests/sim_crdt.nu
+++ b/compiler/tests/sim_crdt.nu
@@ -1,0 +1,115 @@
+// sim_crdt.nu — §7.5 Phase 13 chaos-harness scenario for CRDT gossip. Drives
+// the REAL dist/crdt + dist/replicator codecs over dist/sim's bus, with each
+// node deriving its replica id INDEPENDENTLY (no coordination — the whole point
+// of CRDTs). This is the scenario that exposes cross-node replica-id
+// consistency: if two nodes can disagree on which id names which replica, a
+// positional/colliding merge silently corrupts the value.
+//
+//   3 nodes, each increments its OWN PNCounter once, then they anti-entropy
+//   their encoded state over a lossy + partitioned + healed bus. The cluster
+//   must converge to value 3 (three distinct +1s) on every node. It can only do
+//   so if every node names its replica by a GLOBALLY STABLE id — here the
+//   pubkey-derived identity_stable_id — so distinct replicas land in distinct
+//   slots and the merge sums them instead of max-colliding.
+//
+// Seeded → byte-reproducible; "converged to 3 everywhere" can genuinely fail.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/dist/crdt.nu`
+$ `stdlib/dist/replicator.nu`
+$ `stdlib/dist/identity.nu`
+$ `stdlib/dist/sim.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+@ pi s label i v → v { ( nurl_print label ) ( nurl_print_int v ) }
+@ pk i id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + id k ) = k + k 1 } ^ v }
+@ ctr ( Vec s ) cs i i → *PNCounter { ^ # *PNCounter ?? ( vec_get [s] cs i ) { T x → x F → # s 0 } }
+
+// each node broadcasts its encoded counter to every other node
+@ gossip_all *SimNet net ( Vec s ) cs i n i now → v {
+    : ~ i i 0
+    ~ < i n {
+        : ( Vec u ) bytes ( pncounter_encode ( ctr cs i ) )
+        : ~ i j 0
+        ~ < j n { ? != j i { ( sim_send net i j bytes now ) } {} = j + j 1 }
+        ( vec_free [u] bytes )
+        = i + i 1
+    }
+}
+// deliver due deltas, merging each into the destination node's counter
+@ deliver_all *SimNet net ( Vec s ) cs i now → v {
+    : ( Vec s ) due ( sim_due net now )
+    : i dn ( vec_len [s] due )
+    : ~ i k 0
+    ~ < k dn {
+        : s mp ?? ( vec_get [s] due k ) { T x → x F → # s 0 }
+        ? != # i mp 0 {
+            : *SimMsg sm # *SimMsg mp
+            ( pncounter_merge_bytes ( ctr cs . sm dst ) . sm bytes )
+            ( sim_msg_free sm )
+        } {}
+        = k + k 1
+    }
+    ( vec_free [s] due )
+}
+
+@ main → i {
+    : i n 3
+
+    // Each node has its OWN identity registry and sees the peers in a DIFFERENT
+    // order (its own pubkey first). With a local-first-seen id every node would
+    // call itself replica 0 — a universal collision. identity_stable_id derives
+    // the id from the pubkey, so the registries agree without coordination.
+    : ( Vec s ) cs ( vec_new [s] )
+    : ~ i i 0
+    ~ < i n {
+        : *PNCounter c ( pncounter_new )
+        : *IdRegistry reg ( identity_new )
+        // register peers in rotated order (self first) to provoke divergence
+        : ~ i d 0
+        ~ < d n {
+            : i who % + i d n
+            : ( Vec u ) ppk ( pk who )
+            ( identity_of reg ppk )            // would hand out 0,1,2 in THIS order
+            ( vec_free [u] ppk )
+            = d + d 1
+        }
+        : ( Vec u ) selfpk ( pk i )
+        : i rid ( identity_stable_id selfpk )   // GLOBALLY stable id for this node
+        ( pncounter_inc c rid 1 )               // each node does exactly one +1
+        ( vec_free [u] selfpk )
+        ( identity_free reg )
+        ( vec_push [s] cs # s c )
+        = i + i 1
+    }
+
+    ( pi `each node's own count before gossip (=1): ` ( pncounter_value ( ctr cs 0 ) ) )
+
+    // ── anti-entropy over a lossy bus, with a partition then a heal ──
+    : *SimNet net ( sim_net_new n 9001 25 1 2 )
+    : ~ i now 0
+    // phase 1: node 2 partitioned away from 0 and 1
+    ( sim_partition net 2 0 ) ( sim_partition net 2 1 )
+    : ~ i r 0
+    ~ < r 20 { = now + now 1 ( gossip_all net cs n now ) ( deliver_all net cs now ) = r + r 1 }
+    ( pi `during partition, node 0 value (sees 0+1 only, =2): ` ( pncounter_value ( ctr cs 0 ) ) )
+    ( pb `during partition, node 2 is isolated (value 1): ` == ( pncounter_value ( ctr cs 2 ) ) 1 )
+    // phase 2: heal — everyone must reach 3
+    ( sim_heal_all net )
+    : ~ i r2 0
+    ~ < r2 30 { = now + now 1 ( gossip_all net cs n now ) ( deliver_all net cs now ) = r2 + r2 1 }
+
+    ( pi `after heal node 0 value: ` ( pncounter_value ( ctr cs 0 ) ) )
+    ( pi `after heal node 1 value: ` ( pncounter_value ( ctr cs 1 ) ) )
+    ( pi `after heal node 2 value: ` ( pncounter_value ( ctr cs 2 ) ) )
+    ( pb `CONVERGED to 3 on every node (no id collision): ` & & == ( pncounter_value ( ctr cs 0 ) ) 3 == ( pncounter_value ( ctr cs 1 ) ) 3 == ( pncounter_value ( ctr cs 2 ) ) 3 )
+    ( pb `messages were actually dropped: ` > ( sim_dropped net ) 0 )
+
+    : ~ i fi 0
+    ~ < fi n { ( pncounter_free ( ctr cs fi ) ) = fi + fi 1 }
+    ( vec_free [s] cs )
+    ( sim_net_free net )
+    ^ 0
+}

--- a/examples/replicated_counter.nu
+++ b/examples/replicated_counter.nu
@@ -18,6 +18,7 @@ $ `stdlib/net/relay.nu`
 $ `stdlib/net/transport.nu`
 $ `stdlib/dist/crdt.nu`
 $ `stdlib/dist/replicator.nu`
+$ `stdlib/dist/identity.nu`
 
 @ pk_for i id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + id k ) = k + k 1 } ^ v }
 @ group_id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + 200 k ) = k + k 1 } ^ v }
@@ -35,6 +36,10 @@ $ `stdlib/dist/replicator.nu`
     ?? ( relay_dial ( string_data host ) port ) {
         T rc → {
             : ( Vec u ) self_pk ( pk_for + 1 rid )
+            // The CRDT replica id comes from the PUBKEY, not the CLI arg: every
+            // node derives the same id for a given pubkey with no coordination,
+            // so distinct replicas never collide into one counter slot.
+            : i crep ( identity_stable_id self_pk )
             ?? ( relay_register rc self_pk ) { T _ → {} F _ → {} }
             ( relay_set_timeout rc 300 )
             : *Transport tr # *Transport ( transport_open # s 0 rc 1 )
@@ -45,7 +50,7 @@ $ `stdlib/dist/replicator.nu`
 
             : ~ i round 0
             ~ < round 5 {
-                ( pncounter_inc ctr rid 1 )            // count our own work
+                ( pncounter_inc ctr crep 1 )           // count our own work (pubkey-stable slot)
                 : ( Vec u ) wire ( pncounter_encode ctr )
                 ?? ( transport_broadcast tr g wire ) { T _ → {} F _ → {} }
                 ( vec_free [u] wire )

--- a/stdlib/dist/crdt.nu
+++ b/stdlib/dist/crdt.nu
@@ -9,63 +9,82 @@
 //   LwwReg       — last-writer-wins register (value + timestamp + replica).
 //   OrSet        — observed-remove set: concurrent add wins over remove.
 //
-// Replicas are identified by a small integer id (the caller maps node pubkey
-// → replica id). Merge is the gossip primitive: on receiving a peer's CRDT,
-// merge it into the local one.
+// Replicas are identified by a GLOBALLY STABLE integer id derived from the node
+// pubkey (dist/identity.nu's identity_stable_id) — NOT by local arrival order.
+// This matters: the merge aligns replica slots BY ID, so every node must name a
+// replica the same way without coordination, or distinct replicas collide into
+// one slot and the value silently corrupts. Merge is the gossip primitive: on
+// receiving a peer's CRDT, merge it into the local one.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 
 // ════════════════════════════════════════════════════════════════
 // PNCounter — per-replica increments and decrements; value = Σinc − Σdec.
-// merge = element-wise max of both vectors (a grow-only counter each).
+// Stored SPARSELY as (replica-id, amount) pairs and merged by matching id
+// (each replica's per-id total is a grow-only counter → merge = max per id).
+// Keying by id rather than vector position is what makes convergence correct
+// when replicas are discovered in different orders on different nodes.
 // ════════════════════════════════════════════════════════════════
 
 : PNCounter {
-    ( Vec i ) inc   // inc[r] = total increments by replica r
-    ( Vec i ) dec   // dec[r] = total decrements by replica r
+    ( Vec i ) inc_id    // replica ids that have incremented
+    ( Vec i ) inc_amt   // inc_amt[k] = total increments by replica inc_id[k]
+    ( Vec i ) dec_id
+    ( Vec i ) dec_amt
 }
 
 @ pncounter_new → *PNCounter {
     : *PNCounter c # *PNCounter ( nurl_alloc Z PNCounter )
-    = . c inc ( vec_new [i] )
-    = . c dec ( vec_new [i] )
+    = . c inc_id ( vec_new [i] )
+    = . c inc_amt ( vec_new [i] )
+    = . c dec_id ( vec_new [i] )
+    = . c dec_amt ( vec_new [i] )
     ^ c
 }
-@ pncounter_free *PNCounter c → v { ( vec_free [i] . c inc ) ( vec_free [i] . c dec ) ( nurl_free # s c ) }
+@ pncounter_free *PNCounter c → v {
+    ( vec_free [i] . c inc_id ) ( vec_free [i] . c inc_amt )
+    ( vec_free [i] . c dec_id ) ( vec_free [i] . c dec_amt )
+    ( nurl_free # s c )
+}
 
-@ __pn_ensure ( Vec i ) v i idx → v { ~ <= ( vec_len [i] v ) idx { ( vec_push [i] v 0 ) } }
 @ __pn_at ( Vec i ) v i idx → i { ^ ?? ( vec_get [i] v idx ) { T x → x F → 0 } }
 @ __pn_sum ( Vec i ) v → i {
     : i n ( vec_len [i] v ) : ~ i s 0 : ~ i k 0
     ~ < k n { = s + s ( __pn_at v k ) = k + k 1 }
     ^ s
 }
-
-@ pncounter_inc *PNCounter c i replica i amt → v {
-    ( __pn_ensure . c inc replica )
-    ( vec_set [i] . c inc replica + ( __pn_at . c inc replica ) amt )
+// index of replica `id` in `ids`, or -1
+@ __pn_idx ( Vec i ) ids i id → i {
+    : i n ( vec_len [i] ids ) : ~ i found -1 : ~ i k 0
+    ~ & == found -1 < k n { ? == ?? ( vec_get [i] ids k ) { T x → x F → 0 } id { = found k } {} = k + k 1 }
+    ^ found
 }
-@ pncounter_dec *PNCounter c i replica i amt → v {
-    ( __pn_ensure . c dec replica )
-    ( vec_set [i] . c dec replica + ( __pn_at . c dec replica ) amt )
+// add `amt` to replica `id`'s grow-only slot (append if first seen)
+@ __pn_bump ( Vec i ) ids ( Vec i ) amts i id i amt → v {
+    : i j ( __pn_idx ids id )
+    ? >= j 0 { ( vec_set [i] amts j + ( __pn_at amts j ) amt ) } { ( vec_push [i] ids id ) ( vec_push [i] amts amt ) }
 }
-@ pncounter_value *PNCounter c → i { ^ - ( __pn_sum . c inc ) ( __pn_sum . c dec ) }
 
-@ __pn_max_into ( Vec i ) dst ( Vec i ) src → v {
-    : i ns ( vec_len [i] src )
-    ~ < ( vec_len [i] dst ) ns { ( vec_push [i] dst 0 ) }
-    : ~ i k 0
+@ pncounter_inc *PNCounter c i replica i amt → v { ( __pn_bump . c inc_id . c inc_amt replica amt ) }
+@ pncounter_dec *PNCounter c i replica i amt → v { ( __pn_bump . c dec_id . c dec_amt replica amt ) }
+@ pncounter_value *PNCounter c → i { ^ - ( __pn_sum . c inc_amt ) ( __pn_sum . c dec_amt ) }
+
+// merge src (ids,amts) into dst, taking the max per replica id (insert if new)
+@ __pn_max_into ( Vec i ) dids ( Vec i ) damts ( Vec i ) sids ( Vec i ) samts → v {
+    : i ns ( vec_len [i] sids ) : ~ i k 0
     ~ < k ns {
-        : i sv ( __pn_at src k )
-        ? > sv ( __pn_at dst k ) { ( vec_set [i] dst k sv ) } {}
+        : i id ?? ( vec_get [i] sids k ) { T x → x F → 0 }
+        : i sv ( __pn_at samts k )
+        : i j ( __pn_idx dids id )
+        ? >= j 0 { ? > sv ( __pn_at damts j ) { ( vec_set [i] damts j sv ) } {} } { ( vec_push [i] dids id ) ( vec_push [i] damts sv ) }
         = k + k 1
     }
 }
 // Merge a peer's counter into this one (idempotent, commutative).
 @ pncounter_merge *PNCounter a *PNCounter b → v {
-    ( __pn_max_into . a inc . b inc )
-    ( __pn_max_into . a dec . b dec )
+    ( __pn_max_into . a inc_id . a inc_amt . b inc_id . b inc_amt )
+    ( __pn_max_into . a dec_id . a dec_amt . b dec_id . b dec_amt )
 }
 
 // ════════════════════════════════════════════════════════════════

--- a/stdlib/dist/identity.nu
+++ b/stdlib/dist/identity.nu
@@ -18,8 +18,17 @@
 //
 // Retired ids are tombstoned (kept, marked not-live) so stale gossip that
 // still references a dead replica can be interpreted, and so a rejoin revives
-// the original binding. Feed `dist/crdt.nu` / `dist/replicator.nu` from
-// `identity_of(pubkey)` instead of raw caller-assigned ints.
+// the original binding.
+//
+// IMPORTANT — two different "ids" with two different jobs:
+//   * identity_of(pubkey)        — a LOCAL, monotonic, never-reused slot id for
+//     this node's bookkeeping (liveness, tombstones, dense local tables). It is
+//     assigned in arrival order, so it is NOT comparable across nodes.
+//   * identity_stable_id(pubkey) — a GLOBALLY consistent id derived purely from
+//     the pubkey (FNV-1a/64), identical on every node with no coordination.
+//     Feed dist/crdt.nu / dist/replicator.nu REPLICA IDS FROM THIS: a CRDT
+//     merge aligns replicas by id, so two nodes that meet peers in different
+//     orders must still agree on each replica's id or the value corrupts.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -73,6 +82,26 @@ $ `stdlib/core/vec.nu`
 }
 
 @ identity_count *IdRegistry r → i { ^ ( vec_len [s] . r entries ) }
+
+// A globally STABLE replica id derived purely from the pubkey (FNV-1a/64). No
+// registry, no coordination: every node computes the SAME id for a given
+// pubkey, so CRDT replicas land in the same slot everywhere and merges align by
+// identity instead of by local arrival order. Collision probability ~ n²/2^65 —
+// negligible for any real cluster, and the same FNV-1a/64 identity hash
+// dist/ring already trusts for ownership. This is what dist/crdt replica ids
+// should come from (NOT identity_of, which is a local arrival-ordered slot).
+@ identity_stable_id ( Vec u ) pubkey → i {
+    : ~ i h 0xcbf29ce484222325
+    : i n ( vec_len [u] pubkey )
+    : ~ i k 0
+    ~ < k n {
+        : i bj ?? ( vec_get [u] pubkey k ) { T x → # i x F → 0 }
+        = h ^^ h & bj 255
+        = h * h 0x100000001b3
+        = k + k 1
+    }
+    ^ h
+}
 
 @ __id_find *IdRegistry r ( Vec u ) pubkey → s {
     : i n ( vec_len [s] . r entries )

--- a/stdlib/dist/replicator.nu
+++ b/stdlib/dist/replicator.nu
@@ -11,10 +11,12 @@
 //
 // Wire: integers are 8-byte big-endian (i64 bit pattern via u64), counts are
 // 2-byte big-endian.
-//   PNCounter : u16 ninc, i64*ninc, u16 ndec, i64*ndec
+//   PNCounter : u16 ninc, (i64 id, i64 amt)*ninc, u16 ndec, (i64 id, i64 amt)*ndec
 //   LwwReg    : i64 value, i64 ts, i64 replica
 //   OrSet     : tags(adds) ++ tags(tombs);  tags = u16 n, (i64 elem,
 //               i64 replica, i64 seq)*n
+// PNCounter slots carry their replica id on the wire so a receiver merges by
+// id, not by position — replicas discovered in different orders still converge.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -27,34 +29,53 @@ $ `stdlib/dist/ring.nu`
 @ __rc_u64 *RcCur c → i { : i v ?? ( bytes_read_u64_be . c buf . c off ) { T x → # i x F → 0 } = . c off + . c off 8 ^ v }
 
 // ── PNCounter ────────────────────────────────────────────────────
-@ __pn_put ( Vec u ) b ( Vec i ) v → v {
-    : i n ( vec_len [i] v )
+// Emit the sparse (id, amt) slots in ASCENDING id order so the encoding is
+// CANONICAL: two replicas holding the same logical state (possibly inserted in
+// different orders) produce byte-identical output, which is what makes the
+// crdt_digest anti-entropy compare equal when they are in sync.
+@ __pn_put ( Vec u ) b ( Vec i ) ids ( Vec i ) amts → v {
+    : i n ( vec_len [i] ids )
     ( bytes_push_u16_be b # u16 n )
-    : ~ i k 0
-    ~ < k n {
-        : i x ?? ( vec_get [i] v k ) { T t → t F → 0 }
-        ( bytes_push_u64_be b # u64 x )
-        = k + k 1
+    : ( Vec i ) used ( vec_new [i] )
+    : ~ i u 0
+    ~ < u n { ( vec_push [i] used 0 ) = u + u 1 }
+    : ~ i out 0
+    ~ < out n {
+        : ~ i best - 0 1
+        : ~ i bid 0
+        : ~ i k 0
+        ~ < k n {
+            ? == ?? ( vec_get [i] used k ) { T x → x F → 1 } 0 {
+                : i idk ?? ( vec_get [i] ids k ) { T x → x F → 0 }
+                ? | == best - 0 1 < idk bid { = best k = bid idk } {}
+            } {}
+            = k + k 1
+        }
+        ( vec_set [i] used best 1 )
+        ( bytes_push_u64_be b # u64 ?? ( vec_get [i] ids best ) { T t → t F → 0 } )
+        ( bytes_push_u64_be b # u64 ?? ( vec_get [i] amts best ) { T t → t F → 0 } )
+        = out + out 1
     }
+    ( vec_free [i] used )
 }
 @ pncounter_encode *PNCounter c → ( Vec u ) {
     : ( Vec u ) b ( vec_new [u] )
-    ( __pn_put b . c inc )
-    ( __pn_put b . c dec )
+    ( __pn_put b . c inc_id . c inc_amt )
+    ( __pn_put b . c dec_id . c dec_amt )
     ^ b
 }
-@ __pn_get *RcCur cur ( Vec i ) into → v {
+@ __pn_get *RcCur cur ( Vec i ) ids ( Vec i ) amts → v {
     : i n ( __rc_u16 cur )
     : ~ i k 0
-    ~ < k n { ( vec_push [i] into ( __rc_u64 cur ) ) = k + k 1 }
+    ~ < k n { ( vec_push [i] ids ( __rc_u64 cur ) ) ( vec_push [i] amts ( __rc_u64 cur ) ) = k + k 1 }
 }
 @ pncounter_decode ( Vec u ) buf → *PNCounter {
     : *PNCounter c ( pncounter_new )
     : *RcCur cur # *RcCur ( nurl_alloc Z RcCur )
     = . cur buf buf
     = . cur off 0
-    ( __pn_get cur . c inc )
-    ( __pn_get cur . c dec )
+    ( __pn_get cur . c inc_id . c inc_amt )
+    ( __pn_get cur . c dec_id . c dec_amt )
     ( nurl_free # s cur )
     ^ c
 }


### PR DESCRIPTION
The §7.5 **Phase 13** CRDT-gossip-over-sim scenario surfaced a **real, silent corruption** in the distributed state layer — exactly the kind of cross-node bug the deterministic simulator is built to catch. Fixed deeply (no workaround).

## The bug
`PNCounter` stored increments in a **dense vector indexed by replica id** and merged by **vector position**. `dist/identity`'s `identity_of` hands out ids in **local first-seen order**, so every node calls *itself* replica 0 — a universal collision. Two distinct replicas' self-increments both land in slot 0, and the merge takes `max(1,1)=1` instead of summing to `2`. Convergence "succeeds" to the **wrong value with no error anywhere**.

Demonstrated minimal repro (two replicas each `+1` → merged value `1`, want `2`).

## The fix
- **`dist/identity.nu`** — add `identity_stable_id(pubkey)`: a globally consistent replica id derived purely from the pubkey (FNV-1a/64, the same identity hash `dist/ring` already trusts), computed identically on every node with **no coordination**. `identity_of` stays as the *local* arrival-ordered slot (liveness/tombstones); the doc now draws the line clearly.
- **`dist/crdt.nu`** — `PNCounter` is now **sparse and keyed by replica id**: `(id, amount)` pairs, merged by matching id (max per id). Merge aligns by *identity*, not position → replicas discovered in different orders converge correctly.
- **`dist/replicator.nu`** — the wire carries the replica id per slot, and `pncounter_encode` emits slots in **ascending id order** so equal logical states encode byte-identically (canonical form). This is required for the `crdt_digest` anti-entropy to compare equal when replicas are in sync — a subtlety the sparse rep introduced and that `dist_scope` immediately caught.
- **`examples/replicated_counter.nu`** — derive the counter's replica id from the pubkey via `identity_stable_id`, demonstrating the coordination-free pattern.

## Regression
`compiler/tests/sim_crdt.nu`: 3 nodes derive ids independently and **meet peers in different orders**, increment once each, and anti-entropy over a **lossy + partitioned + healed** bus → must converge to **3** on every node (and stay isolated at 1 during the partition). Seeded → byte-reproducible; "converged to 3 everywhere" can genuinely fail.

## Verification
- Bootstrap fixed point **held** (stdlib-only change, compiler unaffected).
- Suite **396/396**; the four CRDT-touching tests (`dist_crdt`, `dist_replicator`, `dist_scope`, `dist_identity`) + `sim_crdt` all **ASan-clean**.
- Examples gate green.

This closes the cross-node replica-id consistency item that was flagged when `dist/identity` first landed. With this, the Phase 13 chaos harness has caught and fixed its first real distributed bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)