### PR TITLE
feat(pttvoice): Push-To-Talk voice — Opus over the NURL overlay (p2p/group)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ stdlib/runtime.sqlite3
 stdlib/runtime.pq
 stdlib/runtime.z
 stdlib/runtime.zstd
+stdlib/runtime.opus
+stdlib/runtime.asound
 stdlib/runtime.wasm.o
 stdlib/runtime_debug.o
 stdlib/runtime_san.o

--- a/build.sh
+++ b/build.sh
@@ -245,6 +245,29 @@ else
     log "[info] libzstd not found — stdlib/ext/compress.nu's zstd_* will return CompressOther"
 fi
 
+# ── libopus detection ──────────────────────────────────────
+# pttvoice/opus.nu binds libopus directly (& `opus` @ …, no runtime.c bridge).
+# Drop the sentinel the nurlc FFI-lib check looks for; nurl.sh auto-links -lopus
+# when the symbols appear. libopus ships no unversioned .so on Debian, so accept
+# either pkg-config or the bare soname.
+if pkg-config --exists opus 2>/dev/null || [ -e /usr/lib/x86_64-linux-gnu/libopus.so.0 ] || [ -e /usr/lib/libopus.so.0 ]; then
+    echo 1 > stdlib/runtime.opus
+    log "[info] libopus detected — Opus codec FFI enabled"
+else
+    rm -f stdlib/runtime.opus
+    log "[info] libopus not found — pttvoice audio codec unavailable"
+fi
+
+# ── ALSA (libasound) detection ─────────────────────────────
+# pttvoice/audio.nu captures/plays PCM via the ALSA snd_pcm_* API.
+if pkg-config --exists alsa 2>/dev/null || [ -e /usr/lib/x86_64-linux-gnu/libasound.so.2 ] || [ -e /usr/lib/libasound.so.2 ]; then
+    echo 1 > stdlib/runtime.asound
+    log "[info] ALSA detected — pttvoice audio I/O enabled"
+else
+    rm -f stdlib/runtime.asound
+    log "[info] ALSA not found — pttvoice audio I/O unavailable"
+fi
+
 # ── Build stages ─────────────────────────────────────────────
 # `-flto` makes runtime.o emit LLVM bitcode so vec/string/io FFI calls
 # inline across the runtime ↔ user-code boundary at link time. The

--- a/nurl.sh
+++ b/nurl.sh
@@ -234,6 +234,29 @@ if [[ -f "$SCRIPT_DIR/stdlib/runtime.zstd" ]]; then
     fi
 fi
 
+# Auto-link libopus / ALSA when the program references their FFI symbols
+# (pttvoice and any audio app). Linked only when actually used, so other
+# programs don't grow a dependency. libopus ships no unversioned .so on
+# Debian/Ubuntu, so link the soname directly.
+if grep -qE '@opus_(encoder_create|encoder_destroy|encode|decoder_create|decoder_destroy|decode|strerror)\b' "$LLFILE"; then
+    if pkg-config --exists opus 2>/dev/null; then
+        # shellcheck disable=SC2046
+        EXTRA_LIBS+=( $(pkg-config --libs opus) )
+    elif [[ -e /usr/lib/x86_64-linux-gnu/libopus.so || -e /usr/lib/libopus.so ]]; then
+        EXTRA_LIBS+=( -lopus )
+    else
+        EXTRA_LIBS+=( -l:libopus.so.0 )
+    fi
+fi
+if grep -qE '@snd_pcm_[A-Za-z_]+\b' "$LLFILE"; then
+    if pkg-config --exists alsa 2>/dev/null; then
+        # shellcheck disable=SC2046
+        EXTRA_LIBS+=( $(pkg-config --libs alsa) )
+    else
+        EXTRA_LIBS+=( -lasound )
+    fi
+fi
+
 # In --debug mode, drop -flto: the LTO link pipeline strips DWARF
 # debug info from .ll input when the matching runtime.o bitcode has
 # no DI counterpart (current build.sh compiles runtime.o without -g).

--- a/pttvoice/.gitignore
+++ b/pttvoice/.gitignore
@@ -1,0 +1,5 @@
+# compiled NURL artifacts (binaries have no extension; .ll is codegen output)
+*.ll
+ptt
+test_opus_roundtrip
+test_pipeline

--- a/pttvoice/README.md
+++ b/pttvoice/README.md
@@ -1,0 +1,63 @@
+# pttvoice — Push-To-Talk voice over the NURL overlay
+
+A small distributed voice app built on NURL's pubkey-addressed transport
+(`stdlib/net/*`). It captures microphone audio, encodes it with **Opus**, and
+pushes a talkspurt either to **one chosen peer** (unicast — peer-to-peer when the
+transport can punch a direct path, relayed otherwise) or to **every member of a
+group** (broadcast → relay multicast). A receiver decodes each frame and plays
+it back. Audio is 48 kHz mono in 20 ms Opus frames.
+
+> This folder is intentionally self-contained so it can later move to its own
+> repository. It depends on the in-tree NURL stdlib (`stdlib/...`) and two system
+> libraries, **libopus** and **ALSA (libasound)**, which `nurl.sh` auto-links when
+> the FFI symbols appear and which `build.sh` detects (dropping the
+> `stdlib/runtime.opus` / `stdlib/runtime.asound` sentinels).
+
+## Files
+
+| file | role |
+|------|------|
+| `opus.nu`  | libopus FFI + thin encode/decode wrappers; PCM helpers (signed-16 LE in a `Vec u`) |
+| `audio.nu` | ALSA capture/playback; no-ops to silence when there is no sound device (headless) |
+| `proto.nu` | the voice wire frame `['P''V'][type][seq:u32][opus…]` + decode |
+| `ptt.nu`   | the app: relay dial, group join, capture→encode→send, recv→decode→play |
+| `test_opus_roundtrip.nu` | offline: synth PCM → Opus encode → decode, checks a full energetic frame |
+| `test_pipeline.nu`       | offline: PCM → Opus → proto frame → decode → Opus → PCM, seq + energy |
+
+## Build & run
+
+```sh
+# from the repo root (build.sh must have been run once so the sentinels exist)
+./nurl.sh pttvoice/ptt.nu
+
+# 1) a relay (any reachable host)
+./nurl.sh examples/relay.nu 127.0.0.1 47811
+
+# 2) a listener
+./pttvoice/ptt 127.0.0.1 47811 2 listen
+
+# 3) a talker — broadcast a ~1 s talkspurt to the whole group
+./pttvoice/ptt 127.0.0.1 47811 1 group
+
+# …or unicast a talkspurt to node 2 (peer-to-peer if possible)
+./pttvoice/ptt 127.0.0.1 47811 1 peer 2
+```
+
+```
+./pttvoice/ptt <relay_host> <relay_port> <self_id> <mode> [target_id] [frames]
+  mode = group | peer | listen
+  frames = number of 20 ms frames to transmit (default 50 ≈ 1 s)
+```
+
+On a host with no sound card (CI, a headless server) capture yields a synth tone
+and playback is a silent sink, so the network path still runs end to end — which
+is how the live loopback above is verified without audio hardware.
+
+## Offline tests (no relay, no audio)
+
+```sh
+./nurl.sh pttvoice/test_opus_roundtrip.nu && ./pttvoice/test_opus_roundtrip
+./nurl.sh pttvoice/test_pipeline.nu       && ./pttvoice/test_pipeline
+```
+
+Both run leak-free under `NURL_SAN=1`.

--- a/pttvoice/audio.nu
+++ b/pttvoice/audio.nu
@@ -1,0 +1,72 @@
+// pttvoice/audio.nu — ALSA capture/playback for 48 kHz mono signed-16 PCM, the
+// raw audio the Opus codec consumes/produces. Thin FFI over snd_pcm_*; every
+// op is a no-op (or silence) when the handle is 0, so a host with no sound
+// device (CI, a headless server) still runs the app — it just hears/sends
+// silence. The app substitutes a synth source there.
+//
+// Self-contained for the future standalone project; nurl.sh auto-links
+// -lasound when these symbols appear.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+// ── ALSA FFI ─────────────────────────────────────────────────────
+// snd_pcm_open's first arg is snd_pcm_t** (out); name is a C string; format/
+// access are enums; writei/readi take a frame count and return frames or -errno.
+& `asound` @ snd_pcm_open *u pcmp s name i stream i mode → i
+& `asound` @ snd_pcm_set_params s pcm i format i access i channels i rate i soft_resample i latency → i
+& `asound` @ snd_pcm_writei s pcm *u buffer i size → i
+& `asound` @ snd_pcm_readi s pcm *u buffer i size → i
+& `asound` @ snd_pcm_recover s pcm i err i silent → i
+& `asound` @ snd_pcm_prepare s pcm → i
+& `asound` @ snd_pcm_drain s pcm → i
+& `asound` @ snd_pcm_close s pcm → i
+
+@ __snd_stream_playback → i { ^ 0 }
+@ __snd_stream_capture  → i { ^ 1 }
+@ __snd_format_s16_le   → i { ^ 2 }    // SND_PCM_FORMAT_S16_LE
+@ __snd_access_rw_inter → i { ^ 3 }    // SND_PCM_ACCESS_RW_INTERLEAVED
+@ audio_rate            → i { ^ 48000 }
+@ audio_channels        → i { ^ 1 }
+
+@ __aud_open i stream → s {
+    : ( Vec u ) hp ( vec_with_cap [u] 8 )
+    : ~ i z 0 ~ < z 8 { ( vec_push [u] hp # u 0 ) = z + z 1 }
+    : i rc ( snd_pcm_open ( vec_data [u] hp ) `default` stream 0 )
+    ? < rc 0 { ( vec_free [u] hp ) ^ # s 0 } {}
+    : s pcm # s ( nurl_peek # s ( vec_data [u] hp ) 0 )
+    ( vec_free [u] hp )
+    ? == # i pcm 0 { ^ # s 0 } {}
+    // 100 ms target latency, soft-resample on
+    ? < ( snd_pcm_set_params pcm ( __snd_format_s16_le ) ( __snd_access_rw_inter ) ( audio_channels ) ( audio_rate ) 1 100000 ) 0 {
+        ( snd_pcm_close pcm ) ^ # s 0
+    } {}
+    ^ pcm
+}
+
+// Open the default playback / capture device, or 0 if none (headless).
+@ audio_play_open    → s { ^ ( __aud_open ( __snd_stream_playback ) ) }
+@ audio_capture_open → s { ^ ( __aud_open ( __snd_stream_capture ) ) }
+
+@ audio_close s pcm → v { ? != # i pcm 0 { ( snd_pcm_drain pcm ) ( snd_pcm_close pcm ) } {} }
+
+// Play one PCM frame (Vec u of LE int16). No-op on a null handle.
+@ audio_play s pcm ( Vec u ) frame → v {
+    ? == # i pcm 0 { ^ v } {}
+    : i frames / ( vec_len [u] frame ) 2
+    ? <= frames 0 { ^ v } {}
+    : i n ( snd_pcm_writei pcm ( vec_data [u] frame ) frames )
+    ? < n 0 { ( snd_pcm_recover pcm n 1 ) } {}
+}
+
+// Capture `frames` samples → PCM (Vec u, 2*frames bytes). Empty on null handle
+// (the app fills synth audio in that case) or on a short read.
+@ audio_capture s pcm i frames → ( Vec u ) {
+    ? == # i pcm 0 { ^ ( vec_new [u] ) } {}
+    : ( Vec u ) buf ( vec_with_cap [u] * frames 2 )
+    : ~ i z 0 ~ < z * frames 2 { ( vec_push [u] buf # u 0 ) = z + z 1 }
+    : i n ( snd_pcm_readi pcm ( vec_data [u] buf ) frames )
+    ? < n 0 { ( snd_pcm_recover pcm n 1 ) ( vec_free [u] buf ) ^ ( vec_new [u] ) } {}
+    : b _ok ( vec_set_len [u] buf * n 2 )
+    ^ buf
+}

--- a/pttvoice/opus.nu
+++ b/pttvoice/opus.nu
@@ -1,0 +1,93 @@
+// pttvoice/opus.nu — minimal libopus binding for the PTT voice app. Mono VoIP
+// at 48 kHz, 20 ms frames (960 samples). PCM is carried as a (Vec u) of
+// little-endian signed 16-bit samples; an encoded frame is an opaque (Vec u).
+//
+// This folder is self-contained so it can move to its own project later; it
+// FFIs libopus directly (nurl.sh auto-links -lopus when these symbols appear).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+// ── libopus FFI ──────────────────────────────────────────────────
+// int* error / opus_int16* pcm / unsigned char* data are all passed as raw
+// buffer pointers (*u); opus reads them at the right width.
+& `opus` @ opus_encoder_create i Fs i channels i application *u error → s
+& `opus` @ opus_encoder_destroy s st → v
+& `opus` @ opus_encode s st *u pcm i frame_size *u data i max_data_bytes → i
+& `opus` @ opus_decoder_create i Fs i channels *u error → s
+& `opus` @ opus_decoder_destroy s st → v
+& `opus` @ opus_decode s st *u data i len *u pcm i frame_size i decode_fec → i
+
+@ opus_rate          → i { ^ 48000 }   // VoIP sample rate (Hz)
+@ opus_channels      → i { ^ 1 }       // mono
+@ opus_frame_samples → i { ^ 960 }     // 20 ms @ 48 kHz
+@ __opus_app_voip    → i { ^ 2048 }    // OPUS_APPLICATION_VOIP
+@ __opus_max_packet  → i { ^ 4000 }    // generous per-frame ceiling
+
+// a zero-filled byte buffer of length n (n>=1)
+@ __obuf i n → ( Vec u ) {
+    : ( Vec u ) b ( vec_with_cap [u] ? > n 0 n 1 )
+    : ~ i k 0 ~ < k n { ( vec_push [u] b # u 0 ) = k + k 1 }
+    ^ b
+}
+
+// ── encoder ──────────────────────────────────────────────────────
+@ opus_enc_new → s {
+    : ( Vec u ) err ( __obuf 8 )
+    : s enc ( opus_encoder_create ( opus_rate ) ( opus_channels ) ( __opus_app_voip ) ( vec_data [u] err ) )
+    ( vec_free [u] err )
+    ^ enc
+}
+@ opus_enc_free s enc → v { ? != # i enc 0 { ( opus_encoder_destroy enc ) } {} }
+
+// Encode one frame of PCM (2*frame_samples bytes) → opaque packet bytes.
+// Empty (Vec u) on failure.
+@ opus_encode_frame s enc ( Vec u ) pcm → ( Vec u ) {
+    : ( Vec u ) out ( __obuf ( __opus_max_packet ) )
+    : i n ( opus_encode enc ( vec_data [u] pcm ) ( opus_frame_samples ) ( vec_data [u] out ) ( __opus_max_packet ) )
+    ? < n 1 { ( vec_free [u] out ) ^ ( vec_new [u] ) } {}
+    : b _ok ( vec_set_len [u] out n )
+    ^ out
+}
+
+// ── decoder ──────────────────────────────────────────────────────
+@ opus_dec_new → s {
+    : ( Vec u ) err ( __obuf 8 )
+    : s dec ( opus_decoder_create ( opus_rate ) ( opus_channels ) ( vec_data [u] err ) )
+    ( vec_free [u] err )
+    ^ dec
+}
+@ opus_dec_free s dec → v { ? != # i dec 0 { ( opus_decoder_destroy dec ) } {} }
+
+// Decode one packet → PCM (2*samples bytes). Empty (Vec u) on failure.
+@ opus_decode_frame s dec ( Vec u ) packet → ( Vec u ) {
+    : i fs ( opus_frame_samples )
+    : ( Vec u ) pcm ( __obuf * fs 2 )
+    : i ns ( opus_decode dec ( vec_data [u] packet ) ( vec_len [u] packet ) ( vec_data [u] pcm ) fs 0 )
+    ? < ns 0 { ( vec_free [u] pcm ) ^ ( vec_new [u] ) } {}
+    : b _ok ( vec_set_len [u] pcm * ns 2 )
+    ^ pcm
+}
+
+// ── PCM helpers (signed 16-bit LE in a Vec u) ────────────────────
+// push one signed sample (two's-complement, no shift ops needed)
+@ pcm_push ( Vec u ) buf i sample → v {
+    : i vm & sample 0xffff
+    ( vec_push [u] buf # u % vm 256 )
+    ( vec_push [u] buf # u / vm 256 )
+}
+// read sample k (signed) from a PCM buffer
+@ pcm_get ( Vec u ) buf i k → i {
+    : i lo ?? ( vec_get [u] buf * k 2 ) { T x → # i x F → 0 }
+    : i hi ?? ( vec_get [u] buf + * k 2 1 ) { T x → # i x F → 0 }
+    : i v + lo * hi 256
+    ^ ? >= v 32768 - v 65536 v
+}
+@ pcm_samples ( Vec u ) buf → i { ^ / ( vec_len [u] buf ) 2 }
+// total absolute energy (0 for silence) — used by tests
+@ pcm_energy ( Vec u ) buf → i {
+    : i n ( pcm_samples buf )
+    : ~ i e 0 : ~ i k 0
+    ~ < k n { : i v ( pcm_get buf k ) = e + e ? < v 0 - 0 v v = k + k 1 }
+    ^ e
+}

--- a/pttvoice/proto.nu
+++ b/pttvoice/proto.nu
@@ -1,0 +1,51 @@
+// pttvoice/proto.nu — the PTT voice wire frame that rides a transport payload
+// (transport_send to one peer, or transport_broadcast to a group). The body is
+// an Opus packet; a small header lets the receiver order frames and ignore
+// anything that isn't a voice frame.
+//
+//   [ 'P' 'V' ][ type:1 ][ seq:u32 BE ][ opus bytes … ]
+//   type 1 = VOICE.  (transport delivers whole messages, so the opus packet is
+//   simply the rest of the buffer.)
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+
+@ proto_type_voice → i { ^ 1 }
+@ __pv_magic0 → i { ^ 80 }   // 'P'
+@ __pv_magic1 → i { ^ 86 }   // 'V'
+
+: VoiceMsg {
+    i mtype
+    i seq
+    ( Vec u ) opus
+}
+@ voicemsg_free VoiceMsg m → v { ( vec_free [u] . m opus ) }
+
+// Build a VOICE frame carrying `opus` at sequence `seq`.
+@ proto_voice_encode i seq ( Vec u ) opus → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( vec_push [u] b # u ( __pv_magic0 ) )
+    ( vec_push [u] b # u ( __pv_magic1 ) )
+    ( vec_push [u] b # u ( proto_type_voice ) )
+    ( bytes_push_u32_be b # u32 seq )
+    ( vec_extend [u] b opus )
+    ^ b
+}
+
+// Decode a transport payload into a VoiceMsg, or None if it is not a valid
+// PTT voice frame (wrong magic / too short / unknown type).
+@ proto_decode ( Vec u ) buf → ?VoiceMsg {
+    : i n ( vec_len [u] buf )
+    ? < n 7 { ^ @ ?VoiceMsg { F # VoiceMsg 0 } } {}
+    : i m0 ?? ( vec_get [u] buf 0 ) { T x → # i x F → 0 }
+    : i m1 ?? ( vec_get [u] buf 1 ) { T x → # i x F → 0 }
+    ? | != m0 ( __pv_magic0 ) != m1 ( __pv_magic1 ) { ^ @ ?VoiceMsg { F # VoiceMsg 0 } } {}
+    : i ty ?? ( vec_get [u] buf 2 ) { T x → # i x F → 0 }
+    ? != ty ( proto_type_voice ) { ^ @ ?VoiceMsg { F # VoiceMsg 0 } } {}
+    : i seq # i ?? ( bytes_read_u32_be buf 3 ) { T x → x F → # u32 0 }
+    : ( Vec u ) opus ( vec_with_cap [u] ? > - n 7 0 - n 7 1 )
+    : ~ i k 7
+    ~ < k n { ?? ( vec_get [u] buf k ) { T x → ( vec_push [u] opus x ) F → {} } = k + k 1 }
+    ^ @ ?VoiceMsg { T @ VoiceMsg { ( proto_type_voice ) seq opus } }
+}

--- a/pttvoice/ptt.nu
+++ b/pttvoice/ptt.nu
@@ -1,0 +1,141 @@
+// pttvoice/ptt.nu — Push-To-Talk voice over the NURL overlay. Captures mic
+// audio, Opus-encodes it, and pushes it either to ONE chosen peer (unicast,
+// p2p when the transport can punch through, relayed otherwise) or to EVERY
+// member of the group (broadcast → relay multicast). A receiver decodes each
+// frame and plays it back. Audio is 48 kHz mono, 20 ms Opus frames.
+//
+// Usage:
+//   ./nurl.sh pttvoice/ptt.nu <relay_host> <relay_port> <self_id> <mode> [target_id] [frames]
+//     mode = group   broadcast a talkspurt to the whole group
+//          = peer    unicast a talkspurt to <target_id>
+//          = listen  receive and play whatever arrives
+//   frames = number of 20 ms frames to transmit (default 50 ≈ 1 s)
+//
+// On a host with no sound card (CI / headless) capture yields a synth tone and
+// playback is a silent sink, so the network path still runs end to end.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/net/relay.nu`
+$ `stdlib/net/transport.nu`
+$ `pttvoice/opus.nu`
+$ `pttvoice/audio.nu`
+$ `pttvoice/proto.nu`
+
+@ pk_for i id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + id k ) = k + k 1 } ^ v }
+@ group_id → ( Vec u ) { : ( Vec u ) v ( vec_new [u] ) : ~ i k 0 ~ < k 32 { ( vec_push [u] v # u + 200 k ) = k + k 1 } ^ v }
+
+// A synth talkspurt frame (sawtooth) for hosts with no microphone, so a
+// headless sender still transmits real, decodable audio.
+@ synth_frame i phase → ( Vec u ) {
+    : ( Vec u ) pcm ( vec_new [u] )
+    : i fs ( opus_frame_samples )
+    : ~ i k 0
+    ~ < k fs { ( pcm_push pcm - * % + phase k 120 160 9600 ) = k + k 1 }
+    ^ pcm
+}
+
+// Drain + play every inbound voice frame currently available. Returns how many
+// frames were played.
+@ pump_playback *Transport tr s dec s play → i {
+    : ~ i played 0
+    : ~ b more T
+    ~ more {
+        ?? ( transport_recv tr 4000 ) {
+            T m → {
+                ?? ( proto_decode . m payload ) {
+                    T vm → {
+                        : ( Vec u ) pcm ( opus_decode_frame dec . vm opus )
+                        ? > ( vec_len [u] pcm ) 0 { ( audio_play play pcm ) = played + played 1 } {}
+                        ( vec_free [u] pcm )
+                        ( voicemsg_free vm )
+                    }
+                    F → {}
+                }
+                ( transport_msg_free m )
+            }
+            F → { = more F }
+        }
+    }
+    ^ played
+}
+
+@ main → i {
+    : i argc ( env_args_count )
+    : String host ? > argc 1 ( env_arg 1 ) ( string_from `127.0.0.1` )
+    : i port ? > argc 2 { : String ps ( env_arg 2 ) : i p ( nurl_str_to_int ( string_data ps ) ) ( string_free ps ) p } 47700
+    : i sid ? > argc 3 { : String ss ( env_arg 3 ) : i s ( nurl_str_to_int ( string_data ss ) ) ( string_free ss ) s } 1
+    : String mode ? > argc 4 ( env_arg 4 ) ( string_from `group` )
+    : i tid ? > argc 5 { : String ts ( env_arg 5 ) : i t ( nurl_str_to_int ( string_data ts ) ) ( string_free ts ) t } 2
+    : i frames ? > argc 6 { : String fs2 ( env_arg 6 ) : i f ( nurl_str_to_int ( string_data fs2 ) ) ( string_free fs2 ) f } 50
+
+    : b is_listen != ( nurl_str_eq ( string_data mode ) `listen` ) 0
+    : b is_peer != ( nurl_str_eq ( string_data mode ) `peer` ) 0
+
+    ?? ( relay_dial ( string_data host ) port ) {
+        T rc → {
+            : ( Vec u ) self_pk ( pk_for + 1 sid )
+            ?? ( relay_register rc self_pk ) { T _ → {} F _ → {} }
+            ( relay_set_timeout rc 200 )
+            : *Transport tr # *Transport ( transport_open # s 0 rc 1 )
+            : ( Vec u ) g ( group_id )
+            ?? ( transport_group_join tr g ) { T _ → {} F _ → {} }
+            : ( Vec u ) target ( pk_for + 1 tid )
+
+            : s enc ( opus_enc_new )
+            : s dec ( opus_dec_new )
+            : s cap ( audio_capture_open )
+            : s play ( audio_play_open )
+            ( nurl_print `ptt node ` ) ( nurl_print_int sid )
+            ( nurl_print ` mode=` ) ( nurl_print ( string_data mode ) )
+            ( nurl_print ? == # i cap 0 ` (no mic → synth)` `` )
+            ( nurl_print ? == # i play 0 ` (no speaker → silent)` `` ) ( nurl_print `\n` )
+
+            : ~ i sent 0
+            : ~ i recvd 0
+
+            ? is_listen {
+                // receive-only: pump playback for ~frames*20 ms
+                : ~ i r 0
+                ~ < r frames { = recvd + recvd ( pump_playback tr dec play ) ( sleep_ms 20 ) = r + r 1 }
+            } {
+                // transmit a talkspurt; also play anything that arrives (duplex)
+                : ~ i seq 0
+                ~ < seq frames {
+                    : ( Vec u ) pcm ? == # i cap 0 ( synth_frame * seq 7 ) ( audio_capture cap ( opus_frame_samples ) )
+                    : ( Vec u ) use ? > ( vec_len [u] pcm ) 0 pcm ( synth_frame * seq 7 )
+                    : ( Vec u ) opus ( opus_encode_frame enc use )
+                    ? > ( vec_len [u] opus ) 0 {
+                        : ( Vec u ) wire ( proto_voice_encode seq opus )
+                        ? is_peer {
+                            ?? ( transport_send tr target wire ) { T _ → { = sent + sent 1 } F _ → {} }
+                        } {
+                            ?? ( transport_broadcast tr g wire ) { T _ → { = sent + sent 1 } F _ → {} }
+                        }
+                        ( vec_free [u] wire )
+                    } {}
+                    ( vec_free [u] opus )
+                    // `use` aliases `pcm` unless a synth frame replaced an empty
+                    // capture; free once when aliased, both when distinct.
+                    ? == # i use # i pcm { ( vec_free [u] pcm ) } { ( vec_free [u] use ) ( vec_free [u] pcm ) }
+                    = recvd + recvd ( pump_playback tr dec play )
+                    ( sleep_ms 20 )
+                    = seq + seq 1
+                }
+            }
+
+            ( nurl_print `frames sent=` ) ( nurl_print_int sent )
+            ( nurl_print ` frames played=` ) ( nurl_print_int recvd ) ( nurl_print `\n` )
+
+            ( opus_enc_free enc ) ( opus_dec_free dec )
+            ( audio_close cap ) ( audio_close play )
+            ( vec_free [u] self_pk ) ( vec_free [u] g ) ( vec_free [u] target )
+            ( transport_free tr ) ( relay_close rc )
+        }
+        F _ → { ( nurl_print `could not reach relay at ` ) ( nurl_print ( string_data host ) ) ( nurl_print `\n` ) }
+    }
+    ( string_free host ) ( string_free mode )
+    ^ 0
+}

--- a/pttvoice/test_opus_roundtrip.nu
+++ b/pttvoice/test_opus_roundtrip.nu
@@ -1,0 +1,53 @@
+// pttvoice/test_opus_roundtrip.nu — exercises the libopus FFI offline: synth a
+// sawtooth PCM signal, encode each 20 ms frame, decode it back, and confirm the
+// codec produced a non-empty packet and a full lossy-but-energetic frame. No
+// audio hardware needed — this is pure codec, so it runs headless.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `pttvoice/opus.nu`
+
+// one 960-sample frame of a sawtooth (period 100 samples, ±10000)
+@ make_frame i phase0 → ( Vec u ) {
+    : ( Vec u ) pcm ( vec_new [u] )
+    : i fs ( opus_frame_samples )
+    : ~ i k 0
+    ~ < k fs {
+        : i ph % + phase0 k 100
+        : i saw - * ph 200 10000
+        ( pcm_push pcm saw )
+        = k + k 1
+    }
+    ^ pcm
+}
+
+@ yn s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ main → i {
+    : s enc ( opus_enc_new )
+    : s dec ( opus_dec_new )
+    ( yn `encoder created: ` != # i enc 0 )
+    ( yn `decoder created: ` != # i dec 0 )
+
+    : ~ i last_samples 0
+    : ~ i last_energy 0
+    : ~ i last_pkt 0
+    : ~ i f 0
+    ~ < f 6 {
+        : ( Vec u ) pcm ( make_frame * f 7 )
+        : ( Vec u ) pkt ( opus_encode_frame enc pcm )
+        : ( Vec u ) out ( opus_decode_frame dec pkt )
+        = last_pkt ( vec_len [u] pkt )
+        = last_samples ( pcm_samples out )
+        = last_energy ( pcm_energy out )
+        ( vec_free [u] pcm ) ( vec_free [u] pkt ) ( vec_free [u] out )
+        = f + f 1
+    }
+
+    ( yn `encoded packet is non-empty: ` > last_pkt 0 )
+    ( yn `decoded a full 960-sample frame: ` == last_samples 960 )
+    ( yn `decoded frame carries energy (lossy roundtrip): ` > last_energy 0 )
+
+    ( opus_enc_free enc ) ( opus_dec_free dec )
+    ^ 0
+}

--- a/pttvoice/test_pipeline.nu
+++ b/pttvoice/test_pipeline.nu
@@ -1,0 +1,57 @@
+// pttvoice/test_pipeline.nu — the full send→receive payload pipeline minus the
+// network: synth PCM → Opus encode → proto VOICE frame → proto decode → Opus
+// decode → PCM. Confirms a frame survives the wire framing with its sequence
+// intact and still carries audio energy. Headless (pure codec + framing).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `pttvoice/opus.nu`
+$ `pttvoice/proto.nu`
+
+@ yn s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ make_frame i phase0 → ( Vec u ) {
+    : ( Vec u ) pcm ( vec_new [u] )
+    : i fs ( opus_frame_samples )
+    : ~ i k 0
+    ~ < k fs { ( pcm_push pcm - * % + phase0 k 100 200 10000 ) = k + k 1 }
+    ^ pcm
+}
+
+@ main → i {
+    : s enc ( opus_enc_new )
+    : s dec ( opus_dec_new )
+
+    : ~ b all_ok T
+    : ~ i frames_ok 0
+    : ~ i f 0
+    ~ < f 5 {
+        // sender side: capture → encode → frame
+        : ( Vec u ) pcm ( make_frame * f 11 )
+        : ( Vec u ) opus ( opus_encode_frame enc pcm )
+        : ( Vec u ) wire ( proto_voice_encode + 1000 f opus )
+        // receiver side: parse frame → decode → play
+        ?? ( proto_decode wire ) {
+            T vm → {
+                : b seq_ok == . vm seq + 1000 f
+                : ( Vec u ) out ( opus_decode_frame dec . vm opus )
+                : b frame_ok & & seq_ok == ( pcm_samples out ) ( opus_frame_samples ) > ( pcm_energy out ) 0
+                ? frame_ok { = frames_ok + frames_ok 1 } { = all_ok F }
+                ( vec_free [u] out )
+                ( voicemsg_free vm )
+            }
+            F → { = all_ok F }
+        }
+        ( vec_free [u] pcm ) ( vec_free [u] opus ) ( vec_free [u] wire )
+        = f + f 1
+    }
+
+    : ( Vec u ) empty ( vec_new [u] )
+    ( yn `non-voice payload rejected by proto_decode: ` ?? ( proto_decode empty ) { T vm → { ( voicemsg_free vm ) F } F → T } )
+    ( vec_free [u] empty )
+    ( nurl_print `frames that survived encode→frame→decode→pcm: ` ) ( nurl_print_int frames_ok )
+    ( yn `all 5 frames round-tripped (seq + energy): ` & all_ok == frames_ok 5 )
+
+    ( opus_enc_free enc ) ( opus_dec_free dec )
+    ^ 0
+}


### PR DESCRIPTION
A distributed **Push-To-Talk voice app** on NURL's pubkey-addressed transport. Built as a real application to exercise the whole stack (transport, group multicast, FFI) and surface bugs.

It captures mic audio, **Opus**-encodes it, and pushes a talkspurt either to **one peer** (unicast — peer-to-peer when the transport can punch a direct path, relayed otherwise) or to the **whole group** (broadcast → relay multicast). A receiver decodes each frame and plays it back. 48 kHz mono, 20 ms Opus frames. Self-contained in `pttvoice/` so it can move to its own project later.

## Components
| file | role |
|------|------|
| `opus.nu`  | libopus FFI + encode/decode wrappers; PCM helpers (s16 LE in a `Vec u`) |
| `audio.nu` | ALSA capture/playback; silent no-op when there's no sound card (headless/CI) |
| `proto.nu` | voice wire frame `['P''V'][type][seq:u32][opus…]` + decode |
| `ptt.nu`   | the app: relay dial, group join, capture→encode→send, recv→decode→play |
| `test_opus_roundtrip.nu`, `test_pipeline.nu` | offline codec/framing tests (ASan-clean) |

## Toolchain integration (mirrors the libcurl/zstd pattern)
- **`build.sh`** detects libopus + ALSA and drops `stdlib/runtime.{opus,asound}` sentinels — the nurlc FFI-lib check requires a sentinel per `& \`lib\``.
- **`nurl.sh`** auto-links `-lopus` / `-lasound` only when those FFI symbols appear in the IR, so other programs grow no dependency. libopus ships no unversioned `.so` on Debian → falls back to `-l:libopus.so.0`.

## Verification
- **Live over a loopback relay** (headless host, synth audio substituted for the absent mic): group broadcast **50/50** frames delivered + decoded; peer unicast **40/40**.
- Offline `test_opus_roundtrip` and `test_pipeline` pass and are **ASan-clean** (caught + fixed one test-side leak: a `Vec` passed inline to `proto_decode`, which correctly does not free its input).
- Full bootstrap + suite green with the `build.sh` / `nurl.sh` changes.

## Bugs/friction surfaced (the point of the exercise)
- The FFI-lib **sentinel requirement** is undocumented friction for a new `& \`lib\`` — handled by extending `build.sh` detection (the intended mechanism).
- `seq` (string-equality) is compiler-internal, not a user builtin → use `nurl_str_eq`.
- No further compiler bugs: the Opus buffer/pointer FFI (raw `*u` via `vec_data`, `nurl_peek`/`poke`) worked first try.

Not wired into the main test suite/examples gate on purpose — it depends on optional system libs and is destined for its own repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)