### PR TITLE
docs: record distributed stack + voice in CHANGELOG; sync DISTRIBUTED.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **NAT- and mobile-traversing distributed transport (§7.4).** A complete
+  pubkey-addressed overlay where a peer is a **public key, not an address** —
+  it reaches that key over a direct peer-to-peer path when it can and a relay
+  when it must, and never drops to zero reachability. Built bottom-up:
+  `net/securedgram.nu` (WireGuard-style encrypted UDP over Noise + a session
+  AEAD with a sliding replay window, plus endpoint **roaming** so a peer survives
+  a network change), `net/stun.nu` (RFC 8489 server-reflexive discovery),
+  `net/nat.nu` (candidate gathering, NAT-type classification, UDP hole punch),
+  `net/relay.nu` (DERP-style opaque forwarding **plus group multicast** —
+  broadcast to your own group), `net/rendezvous.nu` (signaling-only directory),
+  `net/transport.nu` (the flat seam: `transport_send`/`broadcast`/`recv`,
+  direct-when-possible/relay-when-forced with promote/demote), and SWIM
+  membership (`net/membership.nu`) hardened by **Lifeguard**
+  (`std/lifeguard.nu`) with a failure-detector control loop
+  (`net/failuredetector.nu`). On top sit the sharding + replicated-state
+  layers: a consistent-hash ring (`dist/ring.nu`), state-based CRDTs
+  (`dist/crdt.nu` — PN-Counter, LWW-Register, OR-Set) and their gossip wiring
+  (`dist/replicator.nu`, anti-entropy scoped to a key's replica set). Documented
+  end to end in [`docs/DISTRIBUTED.md`](docs/DISTRIBUTED.md).
+
+- **The Crown — distributed computation (§7.5).** Turns the distributed *state*
+  above into distributed *work*. `dist/identity.nu` gives each peer a replica
+  id; `dist/job.nu` is the keystone — submit a task keyed by `k`, the ring owner
+  executes it via a registered handler, the result is recorded idempotently, and
+  a key that re-homes mid-flight is **forwarded** to the new owner so the job
+  still completes. `dist/lease.nu` adds fencing tokens (epoch monotonicity +
+  idempotency keys) so a *side-effecting* task fires **at most once** across a
+  split-ownership window. Liveness under load is handled by SWIM
+  **self-refutation** plus a **heartbeat on a dedicated OS thread**
+  (`dist/heartbeat.nu`), so a 100%-CPU node is not falsely evicted. The whole
+  story is verified by a **deterministic chaos-simulation harness**
+  (`dist/sim.nu`): a virtual clock + in-process message bus with seeded fault
+  injection (drop, latency/jitter→reorder, partition/heal) drives the *real*
+  stdlib logic, with scenarios for converge-under-loss, keystone-across-
+  partition, at-most-once-side-effect, and CPU-pinned-not-evicted — all
+  byte-reproducible goldens, ASan-clean.
+
+- **Push-To-Talk voice app — `pttvoice/`.** A distributed PTT voice app on the
+  overlay: captures the microphone, **Opus**-encodes it (48 kHz mono, 20 ms
+  frames via a libopus FFI binding), and pushes a talkspurt either to one peer
+  (unicast — p2p when punchable, relayed otherwise) or to the whole group
+  (multicast); a receiver decodes and plays it. ALSA capture/playback
+  (`audio.nu`), the codec (`opus.nu`), the voice wire frame (`proto.nu`), and
+  the app (`ptt.nu`) live in a self-contained folder. Verified live over a
+  loopback relay (group broadcast and peer unicast). `build.sh` now detects
+  **libopus** and **ALSA** (dropping `stdlib/runtime.{opus,asound}` sentinels)
+  and `nurl.sh` auto-links `-lopus`/`-lasound` when those FFI symbols appear.
+
+- **Playground “🎙️ PTT Chat” demo with channels.** A new `/pptchat` tab: a
+  page with a microphone button and an **embedded NURL→WebAssembly module**
+  (`nurlapi/static/pptchat.nu` → `pptchat.wasm`) that reads the mic through the
+  `audio` FFI and paints a live VU meter + frequency spectrum, framing the
+  distributed voice tech. **Channels**: no id → the shared `public` channel;
+  **+ Create channel** mints a random id and navigates to `/pptchat/<id>`;
+  opening that URL joins the same channel (the URL is the invite, the future
+  shared-secret/QR), with a Copy-link button.
+
+- **Parallel sanitizer test suite.** `compiler/tests/run_san_tests.sh` now runs
+  AddressSanitizer/UBSan checks in parallel (`NURL_SAN_JOBS`, default = cores),
+  cutting the sanitized CI leg from minutes to under one — matching the already-
+  parallel functional runner.
+
 - **HTTP client cookie jar — `stdlib/ext/cookies.nu`** (critic B23). The
   server side writes `Set-Cookie` (ext/http_auth.nu); this is the missing
   client half. `cookie_jar_set` parses one `Set-Cookie` value (Domain,
@@ -320,6 +382,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the request target.
 
 ### Fixed
+
+- **CRDT replica ids must be globally stable** (`dist/crdt.nu`,
+  `dist/replicator.nu`, `dist/identity.nu`). The chaos-simulation harness
+  exposed silent state corruption: `PNCounter` stored increments in a dense
+  vector merged **by position**, while `identity_of` handed out ids in local
+  first-seen order, so every node called itself replica 0 — two distinct
+  replicas collided into one slot and the merge took `max(1,1)=1` instead of
+  summing to 2, converging to the *wrong value with no error*. Fixed deeply:
+  `identity_stable_id(pubkey)` derives a globally consistent id from the pubkey
+  (FNV-1a/64, no coordination); `PNCounter` is now sparse and **keyed by
+  replica id** (merge aligns by identity, not position); the wire carries the
+  id per slot and `pncounter_encode` emits slots in canonical ascending-id
+  order so equal states encode identically (required by the digest anti-entropy).
+
+- **Struct-pointer field access mis-resolved when the field name shadows a
+  variable** (`compiler/nurlc.nu`, `gen_field`). `. p field` on a struct
+  *pointer* resolved `field` as a same-named local integer and emitted a pointer
+  array-index instead of a field load — a silent miscompile only `clang` caught.
+  A struct field now always wins over a same-named variable on the field-load
+  path (the field-*store* `= . p name val` array-index form is unchanged and
+  intentional). Lock: `compiler/tests/ptr_field_name_shadow.nu`.
+
+- **Closure literals rejected parenthesised compound param/return types**
+  (`compiler/nurlc.nu`, `gen_backslash_expr`). `\ ( Vec u ) p → ( Vec u ) { … }`
+  failed with “undefined identifier 'u'” because `\ (` was only treated as a
+  closure when the next token was `@`; a compound type head fell through to the
+  try-expression path. `\ (` is now a closure whenever the next token introduces
+  a type (incl. the builtin `Vec`). Lock: `compiler/tests/closure_compound_param.nu`.
 
 - **`@ ?Enum { T Variant }` emitted invalid IR** (`compiler/nurlc.nu`,
   `gen_agg_lit`). Constructing `Some(variant)` of an option whose

--- a/docs/DISTRIBUTED.md
+++ b/docs/DISTRIBUTED.md
@@ -32,7 +32,7 @@ The whole design follows three invariants:
 ```
    COMPUTE      job.nu           submit→ring_owner executes→result (keystone)
    (The Crown)  lease.nu         fencing tokens for side-effecting tasks
-                identity.nu      stable, never-reused replica ids
+                identity.nu      pubkey-derived stable replica ids
                 sim.nu           deterministic chaos-simulation harness
    ────────────────────────────────────────────────────────────────
    dist/        ring.nu          consistent-hash key ownership
@@ -325,14 +325,20 @@ Replicas are small integer ids, supplied by `dist/identity` (below).
 
 ### `dist/identity.nu` — stable replica identity
 
-CRDT replica ids must never be **reused** under churn — a new pubkey inheriting
-a departed node's PNCounter slot or OR-Set `(replica, seq)` tag space silently
-corrupts the value (the merge stays valid, the data is wrong). This registry
-maps each peer's static pubkey to a **monotonic, never-reused** replica id:
-first sight → the next id; the same pubkey across leave→rejoin → the same id; a
-new pubkey never inherits a retired (tombstoned) id. Feed `dist/crdt` /
-`dist/replicator` from `identity_of(pubkey)`. `identity_new` / `identity_of` /
-`identity_pubkey` / `identity_retire` / `identity_is_live`.
+CRDT replica ids carry two distinct requirements, met by two functions:
+
+- **Globally consistent** — a CRDT merge aligns replica slots **by id**, so
+  every node must name a given pubkey the *same* way with no coordination, or
+  two replicas collide into one slot and the value silently corrupts.
+  `identity_stable_id(pubkey)` derives the id purely from the pubkey (FNV-1a/64),
+  identical on every node. **This is what feeds `dist/crdt` / `dist/replicator`.**
+- **Locally never-reused** — a registry (`identity_of`) maps a pubkey to a
+  monotonic local slot id (first sight → next id; leave→rejoin → same id; a new
+  pubkey never inherits a retired, tombstoned id), used for local bookkeeping,
+  liveness, and dense local tables — *not* across nodes.
+
+`identity_stable_id` / `identity_new` / `identity_of` / `identity_pubkey` /
+`identity_retire` / `identity_is_live`.
 
 ### `dist/replicator.nu` — CRDT gossip wiring, scoped to the ring
 
@@ -461,6 +467,13 @@ probe), [`relay.nu`](../examples/relay.nu) (a relay daemon),
 [`transport.nu`](../examples/transport.nu) (the seam in use),
 [`membership.nu`](../examples/membership.nu) (a SWIM node over the overlay).
 
+The largest consumer is [`pttvoice/`](../pttvoice/) — a Push-To-Talk voice app
+that captures the microphone, Opus-encodes it, and pushes a talkspurt to one
+peer (unicast, p2p when punchable) or to the whole group (multicast), exactly
+the group-broadcast-of-arbitrary-payload shape the relay was built for. A
+browser slice runs in the playground at `/pptchat` (an embedded NURL→wasm mic
+visualiser, with per-channel join URLs).
+
 ---
 
 ## How it is tested
@@ -489,13 +502,24 @@ listen sockets (so unit tests can't bind):
   the codecs, the ring, the CRDTs, the lease) — no sockets, no wall-clock, no
   flakiness. Faults (per-message drop, latency + jitter→reorder, partition,
   heal) are injected from a **seeded RNG before the logic sees anything**, so a
-  run is byte-reproducible and the headline assertions can genuinely fail. The
-  first scenario (`compiler/tests/sim_membership.nu`) asserts that a death fact
-  converges to every node *despite 30% packet loss and reorder* (and that
-  messages were actually dropped), then that a partition isolates a node from
-  the fact and `sim_heal_all` reconverges it. This is the
-  FoundationDB/TigerBeetle/madsim approach: catch the rare interleaving in CI,
-  deterministically, instead of waiting for it in production.
+  run is byte-reproducible and the headline assertions can genuinely fail. Five
+  scenarios cover the compute story end to end:
+    - `sim_membership.nu` — a death fact converges to every node *despite 30%
+      packet loss and reorder*, then a partition isolates a node and
+      `sim_heal_all` reconverges it.
+    - `sim_job.nu` — a keystone task **completes across packet loss** (retry +
+      idempotent execution) and across a **partition then heal**.
+    - `sim_lease.nu` — a side-effecting task fires **at most once** across a
+      split-ownership window, in both orderings (idempotency dedup / epoch
+      fence) and concurrently under loss.
+    - `sim_cpupin.nu` — a CPU-pinned-but-alive node that heartbeats + self-
+      refutes is **not evicted**, while an identically-silent dead node is — the
+      contrast proving the harness can evict.
+    - `sim_crdt.nu` — replicas that derive ids independently and meet peers in
+      different orders **converge** over a lossy + partitioned + healed bus
+      (the scenario that caught the replica-id corruption fixed below).
+  This is the FoundationDB/TigerBeetle/madsim approach: catch the rare
+  interleaving in CI, deterministically, instead of waiting for it in production.
 
 ---
 
@@ -507,16 +531,12 @@ plus Phases 3, 5, and 6 are in. On top of them the **Crown** compute layer is
 landed: stable replica identity (`dist/identity.nu`), self-refutation +
 dedicated-OS-thread heartbeat (`dist/heartbeat.nu`), the job-dispatch keystone
 (`dist/job.nu`), lease/fencing tokens (`dist/lease.nu`), and the deterministic
-chaos-simulation harness (`dist/sim.nu`) with its first converge-under-loss /
-partition-heal scenario. The stack is part of NURL's **post-1.0 direction**
-(see [`ROADMAP.md`](../ROADMAP.md)); what remains is more simulation coverage,
-tuning, and a few tracked deep follow-ups:
+chaos-simulation harness (`dist/sim.nu`) with its five scenarios
+(converge-under-loss, keystone-across-partition, at-most-once-side-effect,
+CPU-pinned-not-evicted, CRDT-converge). The stack is part of NURL's **post-1.0
+direction** (see [`ROADMAP.md`](../ROADMAP.md)); what remains is broader
+simulation coverage, tuning, and a couple of tracked deep follow-ups:
 
-- **More chaos scenarios** (Phase 13, ongoing) — beyond converge-under-loss and
-  partition-heal: a job completing across a partition + heal, *no double
-  side-effect* across split ownership (driving `dist/lease` over the sim bus),
-  and a CPU-pinned node that is heartbeating but skipping probes not getting
-  evicted.
 - **Sim-NAT chaos harness** (Phase 8) — extend the simulator with a NAT model
   (cone vs symmetric, configurable mapping timeout) and a simulated relay, so
   the *transport* layer's network-change behaviour is asserted end-to-end too.
@@ -526,11 +546,6 @@ tuning, and a few tracked deep follow-ups:
 
 Known deep follow-ups (no workarounds — these are tracked for a genuine fix):
 
-- **Cross-node replica-id consistency.** `dist/identity.nu` assigns CRDT replica
-  ids in local first-seen order, so two nodes can map the same pubkey to
-  different slots. Gossiping CRDTs over the sim will expose this; the fix is to
-  key CRDTs by pubkey (or derive the id deterministically from the pubkey)
-  rather than by local arrival order.
 - **Cooperative-scheduler liveness (Tier 2).** The heartbeat runs on a dedicated
   OS thread today (Tier 1), which keeps liveness independent of a long-running
   handler. A fuller fix is compiler-inserted loop back-edge preemption so even a


### PR DESCRIPTION
The `CHANGELOG.md` `[Unreleased]` section was missing **everything merged since v0.9.7** — the entire distributed effort plus the voice work. This adds it and brings `docs/DISTRIBUTED.md` up to date.

## CHANGELOG — added
- **§7.4 NAT/mobile-traversing distributed transport** — securedgram → STUN/NAT → relay + group multicast → transport seam → rendezvous → SWIM membership + Lifeguard + failure detector → consistent-hash ring + CRDTs + scoped replicator.
- **§7.5 The Crown — distributed computation** — identity, the `dist/job` keystone (re-home forwarding), `dist/lease` fencing (at-most-once side effects), liveness via self-refutation + dedicated-OS-thread heartbeat, and the deterministic chaos-simulation harness with five scenarios.
- **`pttvoice/`** — Push-To-Talk Opus voice app (unicast/group), plus `build.sh` libopus/ALSA detection and `nurl.sh` auto-link.
- **Playground 🎙️ PTT Chat tab** with channels (`/pptchat/<id>`).
- **Parallel sanitizer suite**.
- **Fixed**: CRDT replica-id global consistency (sparse, id-keyed, canonical wire), struct-pointer field-name shadow miscompile, closure compound param/return types.

## DISTRIBUTED.md — synced
- "How it is tested" now lists **all five** sim scenarios (membership / job / lease / cpupin / crdt), not just the first.
- Status: the Crown is **fully landed**; the *cross-node replica-id consistency* item is no longer an open follow-up — the sim **found it and it was fixed**.
- The `dist/identity.nu` section is corrected: CRDTs feed from **`identity_stable_id`** (pubkey-derived, globally consistent); `identity_of` is the *local* never-reused slot.
- Added `pttvoice/` + the playground `/pptchat` slice as the largest consumer.

Docs only; all referenced paths verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)