### PR TITLE
release: v0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.8] — 2026-06-15
+
 ### Added
 
 - **NAT- and mobile-traversing distributed transport (§7.4).** A complete
@@ -4937,7 +4939,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.9.7...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.9.8...HEAD
+[0.9.8]: https://github.com/nurl-lang/nurl/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/nurl-lang/nurl/compare/v0.9.6...v0.9.7
 [0.9.6]: https://github.com/nurl-lang/nurl/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/nurl-lang/nurl/compare/v0.9.4...v0.9.5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-06-11 · Current release: **0.9.7** · Language: **Grammar
+_Last reviewed: 2026-06-15 · Current release: **0.9.8** · Language: **Grammar
 v2.2** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
Cuts the **v0.9.8** release.

## Headline
This cycle (since v0.9.7) landed two large bodies of work plus the voice apps:
- **§7.4 — NAT/mobile-traversing distributed transport**: securedgram → STUN/NAT/hole-punch → relay + group multicast → transport seam → rendezvous → SWIM membership + Lifeguard + failure detector → consistent-hash ring + CRDTs + scoped replicator.
- **§7.5 — The Crown (distributed computation)**: stable identity, the `dist/job` keystone, `dist/lease` fencing, liveness (self-refutation + dedicated-OS-thread heartbeat), and a deterministic chaos-simulation harness (5 scenarios) — which **caught and forced a real fix** (CRDT replica-id global consistency).
- **`pttvoice/`** — Push-To-Talk Opus voice over the overlay (unicast/group), with libopus/ALSA auto-link.
- **Playground 🎙️ PTT Chat** — a real multi-client voice demo over a **NURL WebSocket relay** (new `server_set_upgrade` hijack hook), with channels (`/pptchat/<id>`).
- Compiler fixes: struct-pointer field-name shadow, closure compound param/return types.

Full detail is the `[0.9.8]` section in [`CHANGELOG.md`](CHANGELOG.md).

## Changes in this PR
- `CHANGELOG.md` — promote `[Unreleased]` → `[0.9.8] — 2026-06-15`; fresh empty `[Unreleased]`; add the v0.9.8 compare link.
- `ROADMAP.md` — current release **0.9.8**, last reviewed 2026-06-15.

## Release steps (post-merge)
The deployed version pill and image tag derive from the **git tag** at release time (`api-deploy.yml` → `NURL_VERSION`), so no other in-repo bump is needed. After merge, tag `v0.9.8` on `main` to trigger the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)