### PR TITLE
docs: fix factual errors — verified against the running compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NURL — Neural Unified Representation Language
 
-> A small systems language with a regular prefix-arity grammar, single-owner memory with an opt-in static borrow checker, deterministic compilation, and LLVM-based codegen.
+> A small systems language with a regular prefix-arity grammar, single-owner memory with a default-on static borrow checker, deterministic compilation, and LLVM-based codegen.
 
 **Project site:** <https://nurl-lang.org> · **Live playground & MCP endpoint:** <https://play.nurl-lang.org>
 
@@ -15,7 +15,7 @@ NURL takes a few design positions that are uncommon together:
 - **Regular prefix-arity grammar** — every operator has a fixed arity, no infix, no precedence cliffs. The grammar fits on a single page and is LL(k≤4) — recursive-descent with up to 4 tokens of lookahead.
 - **Local semantics** — a construct's meaning is derivable from a short window of surrounding tokens. No long-range dependencies.
 - **Deterministic compiler** — the same source always produces identical output. No UB, no platform-dependent behaviour. The self-hosted compiler reaches a byte-identical fixed point on its own source.
-- **Single-owner memory + opt-in static borrow checker** — auto-drop at scope exit, plus a diagnostic pass that catches use-after-move, alias-double-free, escaping closure-captures, and iterator invalidation as hard errors.
+- **Single-owner memory + default-on static borrow checker** — auto-drop at scope exit, plus a diagnostic pass (on by default, `--no-borrowck` to disable) that catches use-after-move, alias-double-free, escaping closure-captures, and iterator invalidation as hard errors.
 - **LLVM-based codegen, broad platform reach** — one pipeline targets Linux, macOS, Windows, wasm32-wasi, RISC-V, and ARM64.
 
 | Metric | Python | C | NURL |
@@ -123,11 +123,11 @@ reference** (lexical structure, types, statements, expressions, casts) is
 
 Single-owner memory with compiler-inserted auto-drop at scope exit — no GC,
 no hidden boxing. Bindings are immutable by default (`: i x 0`; opt into
-mutation with `: ~`). An **opt-in static borrow checker** (on by default,
-`--no-borrowck` to disable) catches use-after-move, alias-double-free,
-escaping closure-captures, and iterator invalidation as hard compile errors,
-without ever changing generated code. Full model and the not-yet-checked
-list: [`docs/MEMORY.md`](docs/MEMORY.md).
+mutation with `: ~`). A **static borrow checker** — on by default,
+`--no-borrowck` to disable, `--strict-borrowck` to tighten — catches
+use-after-move, alias-double-free, escaping closure-captures, and iterator
+invalidation as hard compile errors, without ever changing generated code.
+Full model and the not-yet-checked list: [`docs/MEMORY.md`](docs/MEMORY.md).
 
 The type system is strong, static, inferred, algebraic (sum types `|`,
 product types via structs), with no subtyping and no implicit conversions.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@ What is solid today:
   and `f32`), tail-call optimization, and
   **variadic FFI** (the `printf` family callable directly).
 - **Memory & safety.** Single-owner memory with compiler-inserted auto-drop at
-  scope exit — no GC, no hidden boxing. An **opt-in static borrow checker, on
+  scope exit — no GC, no hidden boxing. A **static borrow checker, on
   by default** (`--no-borrowck` to disable, `--strict-borrowck` to tighten),
   catches use-after-move, alias double-free, escaping closure captures, and
   iterator invalidation as hard errors without changing generated code.

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -144,8 +144,10 @@ diagnostics and never lowers anything, a borrow-clean program produces
 the exact same IR either way — the bootstrap fixed point is
 unaffected.
 
-All five rules emit `error:`. Use `--no-borrowck` for the escape
-hatch if a corner case slips through.
+All eight rules below (§2.1–§2.8) emit `error:`. Use `--no-borrowck`
+for the escape hatch if a corner case slips through, and
+`--strict-borrowck` (off by default) to add two opt-in checks on top —
+see §2.9.
 
 ### 2.1 Move checking — use-after-move
 
@@ -375,6 +377,28 @@ has depth 0. Boundaries that remain: a parameter returned through a
 closure *capture* (`^ \ → … cb …`) rather than a struct field, and
 forward / generic calls, are not yet summarised.
 
+### 2.9 `--strict-borrowck` — two opt-in checks
+
+The eight rules above run by default. `--strict-borrowck` (off by
+default) adds two further checks, both diagnostic-only and both emitting
+`error:` like the rest:
+
+1. **Aliased mutation through a field argument.** §2.4 flags an `inout`
+   binding aliased by another *bare-identifier* argument of the same
+   call. Strict mode generalises this to a `. obj field` argument — a
+   nested field read of the same object passed alongside its `inout`
+   borrow is reported too.
+2. **`# *T` raw-pointer escape.** A raw pointer taken (`# *T …`) from an
+   owned binding whose pointer may outlive that binding's drop is
+   reported — a narrow check on the otherwise-untracked `*T` surface
+   (§3).
+
+It is **off by default** because the extension has a meaningful
+false-positive rate against existing stdlib code; it is a tightening
+knob for auditing a specific module, not part of the standard contract.
+The default-on eight rules remain the guarantee everything else in this
+document refers to.
+
 ## 3. What is NOT checked
 
 The borrow checker targets the bug classes that ordinary NURL code
@@ -382,7 +406,9 @@ hits in practice. It deliberately does **not** cover:
 
 - **`*T` raw pointers.** `*T` is the FFI ABI escape hatch — NURL's
   `unsafe`. A `*T` taken of a local, stored, returned, or captured
-  is *not* checked. Treat `*T` lifetimes as your responsibility.
+  is *not* checked by default. Treat `*T` lifetimes as your
+  responsibility. (`--strict-borrowck` adds one narrow exception — a
+  `# *T` escape from an owned binding, §2.9.)
 - **Aliased mutation beyond a single call.** The exclusive-access
   check (§2.4) covers a binding aliased among one call's arguments.
   A binding read through a *nested* sub-expression argument, and

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -155,7 +155,10 @@ declaration is one of:
 | `('pub')? % Name [T]? { ... }` | trait |
 | `('pub')? % Trait [T]? type { methods }` | impl |
 
-There is exactly one entry point: a `@ main → i { ... }` returning `i`.
+There is exactly one entry point, `main`. It returns either `i` — the
+value becomes the process exit code, truncated to 32 bits — or `v`, in
+which case the process exits `0`. (The reference compiler's own `main`
+returns `v`.)
 
 ### 3.2 `$`-imports
 
@@ -794,10 +797,14 @@ signal handlers) the raw fn-ptr / env-ptr pair.
 Z type
 ```
 
-Byte size of *type* as an `i64`. Base types fold to a compile-time
-constant (`0` for `v`, `8` for `i`/`u`/`f`/`s`/any pointer, `1` for
-`b`). Named or aggregate types use a `getelementptr null` trick so LLVM
-computes the size at emission time.
+Byte size of *type* as an `i64`. The fold is keyed on the *LLVM* type:
+a type lowering to `void` (`0`), `i64` (`8` — `i` and `u64`), `double`
+(`8` — `f`), `i1` (`1` — `b`), or any pointer (`8` — `s`, `*T`) folds to
+a compile-time constant. Every other type uses a `getelementptr null`
+trick so LLVM computes the size at emission time, yielding the natural
+width: `u` 1, `i8` 1, `i16` / `u16` 2, `i32` / `u32` 4, `f32` 4, and any
+named or aggregate type. **`Z u` is therefore 1, not 8** — `u` is a
+single byte.
 
 ### 6.9 Aggregate / slice literals
 
@@ -983,11 +990,13 @@ spawning a thread that holds it).
 ## 9. Borrow checker
 
 The borrow checker is a static analysis pass over the parsed program.
-It is **on by default**; `--no-borrowck` disables it. Diagnostics are
-**hard errors** as of grammar v2.1 (2026-05-25); the compiler exits
-non-zero with a count of violations after walking the whole program.
-The checker is **diagnostic-only** — emitted IR is byte-identical with
-or without `--borrowck`.
+It is **on by default**; `--no-borrowck` disables it, and
+`--strict-borrowck` (off by default) adds two opt-in checks on top
+(see [`docs/MEMORY.md` §2.9](MEMORY.md)). Diagnostics are **hard
+errors** as of grammar v2.1 (2026-05-25); the compiler exits non-zero
+with a count of violations after walking the whole program. The checker
+is **diagnostic-only** — emitted IR is byte-identical whether it runs or
+not.
 
 Eight rules are enforced. The semantic level is summarised here; for
 exact phrasing and the soundness contract see
@@ -1078,10 +1087,13 @@ a *fresh* value is not a passthrough and stays legal.
 
 ### 9.9 What is NOT checked
 
-- `*T` raw pointer lifetimes (the FFI escape hatch).
+- `*T` raw pointer lifetimes (the FFI escape hatch) — except the one
+  narrow `# *T`-escape check `--strict-borrowck` adds (§9 intro).
 - Aliased mutation beyond a single call (longer-range "exclusive
   reference" analysis is not currently implemented), and a binding read
-  through a *nested* sub-expression argument (§6.2).
+  through a *nested* sub-expression argument (§6.2) — though
+  `--strict-borrowck` does flag aliased mutation through a `. obj field`
+  argument.
 - A *pure forward chain* of escaping helpers (§9.7) and a parameter
   returned through a closure *capture* rather than a struct field (§9.8) —
   the residual interprocedural gaps. Both degrade the *diagnostic* only,

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -460,10 +460,12 @@ try_expr = '\\' expr ;
 closure_expr = '\\' param* '→' type block ;
 
 (* Z type  — byte size of type as i64
-   Base types fold to a constant (0 for v, 8 for i/u/f/s/any pointer,
-   1 for b). Named/aggregate types use a getelementptr-null trick so
-   LLVM computes the size at emission time.
-   Example:  Z i  →  8    Z Point  →  sizeof(Point) *)
+   The fold is keyed on the LLVM type: void→0, i64→8 (i, u64),
+   double→8 (f), i1→1 (b), any pointer→8 (s, *T) fold to a constant.
+   Every other type (u→1, i8→1, i16/u16→2, i32/u32→4, f32→4, and
+   named/aggregate types) uses a getelementptr-null trick so LLVM
+   computes the size at emission time.
+   Example:  Z i  →  8    Z u  →  1    Z Point  →  sizeof(Point) *)
 sizeof_expr = 'Z' type ;
 
 (* ? cond then else  — ternary conditional


### PR DESCRIPTION
Follow-up to #188. A second accuracy pass; **every claim below was checked against `compiler/nurlc.nu` or a compiled-and-run probe**, not prose. Triggered by the "opt-in borrow checker" contradiction.

## Errors fixed

| Claim (was) | Reality (verified) | Where |
|---|---|---|
| "**opt-in** static borrow checker" | **on by default** — `g_borrowck` defaults to `1`, `--no-borrowck` turns it off (`nurlc.nu:550`); "opt-in" + "on by default" was a self-contradiction | README ×3, ROADMAP ×1 |
| MEMORY.md "All **five** rules" | **eight** (§2.1–§2.8, the §5 table) | MEMORY.md §2 |
| `--strict-borrowck` undocumented | real flag adding two checks (field-arg aliased mutation; `# *T` escape) | added MEMORY.md §2.9; noted in spec §9 & made the `*T`/nested-arg "not checked" claims accurate |
| "`main` **must return `i`**" | `emit_main_wrapper` accepts `v` (exit 0) or `i` (truncated exit code); the reference compiler's own `main` is `→ v` (`nurlc.nu:13047`) | spec §3.1 |
| "`Z u` = **8**" | **1** — `gen_sizeof` folds only i64/double/i1/pointer/void; `u`(=i8) falls through to the GEP trick. Verified: `Z u`→1, `Z i`→8, `Z i32`→4, `Z u64`→8 | spec §6.8 **and** the `grammar.ebnf` comment (same error in two places) |

The legitimate "opt-in" uses — `: ~` mutation, `pub` strict-mode, `--strict-borrowck`, rc/arc library types — were left untouched.

## Verification

```
Z u   → 1     Z i  → 8     Z b  → 1
Z i32 → 4     Z u16 → 2    Z u32 → 4   Z u64 → 8   Z f32 → 4
~ 0   → -1    -5 lexes as a literal    `a\db` passes \d through
```
Run with the in-tree `build/nurlc_self`. Pure documentation / grammar-comment changes — no code or grammar production changed, bootstrap fixed point untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)