### PR TITLE
fix(codegen): float (f / f32) enum payloads now compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Float (`f` / `f32`) enum payloads now compile.** An enum's payload slot
+  is uniformly pointer-typed; construction coerced `i1` / integer / string /
+  struct payloads into it, but had no branch for `double` / `float`, so a
+  float payload emitted `insertvalue %E …, double X, 1` into a `ptr` field
+  and clang rejected it (`operand and field disagree in type`). The match
+  side had the symmetric gap. Any sum type with a floating-point payload —
+  a numeric AST, a real-valued JSON, a geometry variant — was uncompilable,
+  although the grammar permits it. Fixed in `gen_agg_lit` (bitcast the float
+  to a same-width int, f32 widens i32→i64, then `inttoptr` into the slot) and
+  `emit_enum_float_extract` (the inverse on the match arm). Verified across
+  payload slots 0/1/2, a mixed float+pointer recursive enum, and a genuine
+  `f32` value; the bootstrap fixed point holds (no existing code used float
+  enum payloads, so emitted IR is unchanged). Regression
+  `compiler/tests/enum_float_payload.nu`; surfaced by the
+  `examples/chaotic-showcase.nu` grammar stress test (recursive symbolic
+  autodiff). An *implicit* double-literal → `f32` narrowing in an enum
+  literal still needs an explicit `# f32` cast, exactly as struct
+  construction requires.
+
 ## [0.9.8] — 2026-06-15
 
 ### Added

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5896,7 +5896,9 @@
                 : s cv0 ? did_reconstruct pr0_eff
                 ? pt0_is_opt_bool pr0 ( nurl_cg_reg cg )
                 ? pt0_is_opt_bool {} {
-                    ? & > ( int_width pt0 ) 0 < ( int_width pt0 ) 64 {
+                    ? ( is_float_ty pt0 )
+                    { ( emit_enum_float_extract cv0 pt0 pr0 cg ) }
+                    { ? & > ( int_width pt0 ) 0 < ( int_width pt0 ) 64 {
                         // Narrow integer payload (i1 / i8 / i16 / i32, incl.
                         // the unsigned u/u16/u32): the value rode the ptr slot
                         // widened to i64 (gen_agg_lit), so ptrtoint back to i64
@@ -5948,6 +5950,7 @@
                             ? ( seq pt0 `i64` )
                             { ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr0 ) ( nurl_print ` to i64\n` ) }
                             { ( nurl_print ` = bitcast ptr ` ) ( nurl_print pr0 ) ( nurl_print ` to i8*\n` ) } }
+                    }
                     }
                 }
                 : s vp0 ( nurl_cg_reg cg )
@@ -6011,7 +6014,9 @@
                 ( nurl_print ` = extractvalue ` ) ( nurl_print match_type )
                 ( nurl_print ` ` ) ( nurl_print match_val ) ( nurl_print `, 2\n` )
                 : s cv1 ( nurl_cg_reg cg )
-                ? & > ( int_width pt1 ) 0 < ( int_width pt1 ) 64 {
+                ? ( is_float_ty pt1 )
+                { ( emit_enum_float_extract cv1 pt1 pr1 cg ) }
+                { ? & > ( int_width pt1 ) 0 < ( int_width pt1 ) 64 {
                     : s t64 ( nurl_cg_reg cg )
                     ( nurl_print `  ` ) ( nurl_print t64 )
                     ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr1 ) ( nurl_print ` to i64\n` )
@@ -6057,6 +6062,7 @@
                         { ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr1 ) ( nurl_print ` to i64\n` ) }
                         { ( nurl_print ` = bitcast ptr ` ) ( nurl_print pr1 ) ( nurl_print ` to i8*\n` ) } }
                 }
+                }
                 : s vp1 ( nurl_cg_reg cg )
                 ( nurl_print `  ` ) ( nurl_print vp1 )
                 ( nurl_print ` = alloca ` ) ( nurl_print pt1 ) ( nurl_print `\n` )
@@ -6085,7 +6091,9 @@
                 ( nurl_print ` = extractvalue ` ) ( nurl_print match_type )
                 ( nurl_print ` ` ) ( nurl_print match_val ) ( nurl_print `, 3\n` )
                 : s cv2 ( nurl_cg_reg cg )
-                ? & > ( int_width pt2 ) 0 < ( int_width pt2 ) 64 {
+                ? ( is_float_ty pt2 )
+                { ( emit_enum_float_extract cv2 pt2 pr2 cg ) }
+                { ? & > ( int_width pt2 ) 0 < ( int_width pt2 ) 64 {
                     : s t64 ( nurl_cg_reg cg )
                     ( nurl_print `  ` ) ( nurl_print t64 )
                     ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr2 ) ( nurl_print ` to i64\n` )
@@ -6123,6 +6131,7 @@
                         ? ( seq pt2 `i64` )
                         { ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr2 ) ( nurl_print ` to i64\n` ) }
                         { ( nurl_print ` = bitcast ptr ` ) ( nurl_print pr2 ) ( nurl_print ` to i8*\n` ) } }
+                }
                 }
                 : s vp2 ( nurl_cg_reg cg )
                 ( nurl_print `  ` ) ( nurl_print vp2 )
@@ -9117,6 +9126,28 @@
 // ── Cast # type expr ───────────────────────────────────────────────
 
 // int_width: LLVM integer type string → bit width, or 0 if not iN.
+// Reconstruct a float (`double` / f32 `float`) enum payload out of the
+// uniformly-pointer enum slot. The construction side (gen_agg_lit) bitcast
+// the float to a same-width int and `inttoptr`'d it into the slot; this is
+// the exact inverse: `ptrtoint` the slot back to i64, then bitcast (an f32
+// first truncs to i32). `cv` is the already-allocated destination register.
+@ emit_enum_float_extract s cv s pt s pr i cg → v {
+    : s bits ( nurl_cg_reg cg )
+    ( nurl_print `  ` ) ( nurl_print bits )
+    ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pr ) ( nurl_print ` to i64\n` )
+    ? ( seq pt `double` )
+    { ( nurl_print `  ` ) ( nurl_print cv )
+        ( nurl_print ` = bitcast i64 ` ) ( nurl_print bits ) ( nurl_print ` to double\n` ) }
+    { : s b32 ( nurl_cg_reg cg )
+        ( nurl_print `  ` ) ( nurl_print b32 )
+        ( nurl_print ` = trunc i64 ` ) ( nurl_print bits ) ( nurl_print ` to i32\n` )
+        ( nurl_print `  ` ) ( nurl_print cv )
+        ( nurl_print ` = bitcast i32 ` ) ( nurl_print b32 ) ( nurl_print ` to float\n` ) }
+}
+
+// True iff an LLVM type string is a float type (`double` or f32 `float`).
+@ is_float_ty s ty → b { ^ | ( seq ty `double` ) ( seq ty `float` ) }
+
 @ int_width s ty → i {
     ? ( seq ty `i1` ) 1
     ? ( seq ty `i8` ) 8
@@ -10118,6 +10149,27 @@
                         ( nurl_print `  ` ) ( nurl_print conv_reg2 )
                         ( nurl_print ` = inttoptr i64 ` ) ( nurl_print conv_reg1 ) ( nurl_print ` to ptr\n` )
                         = actual_fval conv_reg2
+                        = actual_fty `ptr`
+                    }
+                    ? ( is_float_ty fty )
+                    {  // Float payload → ptr slot. Bitcast the float to a
+                        // same-width int (f32 widens i32→i64), then inttoptr.
+                        // The match arm inverts this (emit_enum_float_extract).
+                        : ~ s ibits ``
+                        ? ( seq fty `double` )
+                        { = ibits ( nurl_cg_reg cg )
+                            ( nurl_print `  ` ) ( nurl_print ibits )
+                            ( nurl_print ` = bitcast double ` ) ( nurl_print fval ) ( nurl_print ` to i64\n` ) }
+                        { : s b32 ( nurl_cg_reg cg )
+                            ( nurl_print `  ` ) ( nurl_print b32 )
+                            ( nurl_print ` = bitcast float ` ) ( nurl_print fval ) ( nurl_print ` to i32\n` )
+                            = ibits ( nurl_cg_reg cg )
+                            ( nurl_print `  ` ) ( nurl_print ibits )
+                            ( nurl_print ` = zext i32 ` ) ( nurl_print b32 ) ( nurl_print ` to i64\n` ) }
+                        : s conv_regf ( nurl_cg_reg cg )
+                        ( nurl_print `  ` ) ( nurl_print conv_regf )
+                        ( nurl_print ` = inttoptr i64 ` ) ( nurl_print ibits ) ( nurl_print ` to ptr\n` )
+                        = actual_fval conv_regf
                         = actual_fty `ptr`
                     }
                     ? & > ( int_width fty ) 0 ! ( seq fty `i1` )

--- a/compiler/tests/enum_float_payload.nu
+++ b/compiler/tests/enum_float_payload.nu
@@ -1,0 +1,107 @@
+// enum_float_payload.nu — regression for a codegen hole where a FLOAT
+// (`f` / `f32`) value carried as an enum payload emitted invalid IR.
+//
+// Bug: an enum's payload slot is uniformly pointer-typed. Construction
+// (gen_agg_lit) coerced i1 / integer / string / struct payloads into the
+// `ptr` slot, but had NO branch for `double` / `float`, so a float payload
+// emitted `insertvalue %E …, double X, 1` into a `ptr` field — clang
+// rejected (`operand and field disagree in type: 'double' instead of
+// 'ptr'`). The match/unbox side had the symmetric gap (a `double` payload
+// fell through to the `bitcast ptr … to i8*` catch-all). ANY sum type with
+// a float payload — a numeric AST, a real-valued JSON, a geometry variant —
+// was uncompilable, even though the grammar permits it
+// (`enum_variant = IDENT type*`, and `type` includes `f`).
+//
+// Fix: gen_agg_lit bitcasts the float to a same-width int (f32 widens
+// i32→i64) and `inttoptr`s it into the slot; the match arm inverts it via
+// `emit_enum_float_extract` (ptrtoint → bitcast, f32 truncs first). Verified
+// across payload slots 0/1/2, a mixed float+pointer recursive enum, and a
+// genuine `f32` value. (An IMPLICIT double-literal → `f32` narrowing still
+// needs an explicit `# f32` cast, exactly as struct construction requires —
+// out of scope here.)
+
+: | E {
+    Num f
+    Pair f f
+    Triple f f f
+    Boxed *E
+    F32 f32
+}
+
+@ ck b ok s label → v {
+    ( nurl_print label ) ( nurl_print ? ok ` ok\n` ` FAIL\n` )
+}
+
+@ main → i {
+    // slot 0 (double)
+    : E a @ E { Num 3.5 }
+    ?? a {
+        Num c     → { ( ck == c 3.5 `num_slot0` ) }
+        Pair x y  → {}
+        Triple x y z → {}
+        Boxed p   → {}
+        F32 v     → {}
+    }
+
+    // slots 0 + 1 (double)
+    : E b @ E { Pair 1.25 6.5 }
+    ?? b {
+        Num c     → {}
+        Pair x y  → { ( ck & == x 1.25 == y 6.5 `pair_slots01` ) }
+        Triple x y z → {}
+        Boxed p   → {}
+        F32 v     → {}
+    }
+
+    // slot 2 (double)
+    : E t @ E { Triple 1.0 2.0 9.75 }
+    ?? t {
+        Num c     → {}
+        Pair x y  → {}
+        Triple x y z → { ( ck & & == x 1.0 == y 2.0 == z 9.75 `triple_slots012` ) }
+        Boxed p   → {}
+        F32 v     → {}
+    }
+
+    // mixed float + pointer recursive enum: Boxed holds a *E whose Num is float
+    : *E inner ( box_e @ E { Num 4.25 } )
+    : E w @ E { Boxed inner }
+    ?? w {
+        Num c     → {}
+        Pair x y  → {}
+        Triple x y z → {}
+        Boxed p   → {
+            : E ie . p 0
+            ?? ie {
+                Num c2    → { ( ck == c2 4.25 `boxed_float_child` ) }
+                Pair x y  → {}
+                Triple x y z → {}
+                Boxed q   → {}
+                F32 v     → {}
+            }
+        }
+        F32 v     → {}
+    }
+
+    // genuine f32 value round-trip (explicit cast)
+    : f32 fv # f32 2.5
+    : E g @ E { F32 fv }
+    ?? g {
+        Num c     → {}
+        Pair x y  → {}
+        Triple x y z → {}
+        Boxed p   → {}
+        F32 v     → { ( ck == # f v 2.5 `f32_roundtrip` ) }
+    }
+
+    ( nurl_free # s inner )
+    ^ 0
+}
+
+@ box_e E e → *E {
+    : *E p ( my_alloc )
+    = . p 0 e
+    ^ p
+}
+
+@ my_alloc → *E { ^ # *E ( nurl_alloc Z E ) }

--- a/compiler/tests/outputs/enum_float_payload.txt
+++ b/compiler/tests/outputs/enum_float_payload.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+num_slot0 ok
+pair_slots01 ok
+triple_slots012 ok
+boxed_float_child ok
+f32_roundtrip ok

--- a/examples/chaotic-showcase.nu
+++ b/examples/chaotic-showcase.nu
@@ -1,0 +1,302 @@
+// ============================================================
+// chaotic-showcase.nu — an ADVERSARIAL grammar stress test.
+//
+// Purpose (pre-1.0 grammar lock): the existing example/stdlib corpus is
+// broad but structurally narrow — systems/byte-codec code, cellular
+// automata, emulators, agents. None of it pushes three corners of the
+// language at once. This single file deliberately combines all three to
+// see whether Grammar v2.2 is genuinely complete or whether something
+// needs to change before the v1.0 lock:
+//
+//   (A) FLOAT / VECTOR prefix-arithmetic DENSITY — deeply nested
+//       prefix `+ * - / .` over a Vec3 type. This is the worst case for
+//       fixed prefix arity with no closing token (the open A3 question).
+//   (B) DEEP RECURSIVE ADT + multi-payload PATTERN MATCHING — a symbolic
+//       expression tree (`Expr`) with `*Expr` children, differentiated
+//       and simplified by recursive `??` match. No recursive enum exists
+//       anywhere else in the tree.
+//   (C) HIGHER-ORDER PARSER COMBINATORS — a parser is a closure
+//       `(@ ?*Expr *PState)`; `p_chainl` RETURNS a closure that CAPTURES
+//       two other closures + a scalar. Closures-capturing-closures is the
+//       hardest case for type-dependent capture + escape analysis.
+//
+// The pipeline: parse a formula string into an Expr tree (C), symbolically
+// differentiate + simplify it (B), then evaluate both over Vec3 math (A).
+// ============================================================
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/mem.nu`
+$ `stdlib/std/float.nu`
+
+// ── Axis A: Vec3 + dense prefix float arithmetic ────────────────────
+
+: Vec3 { f x  f y  f z }
+
+@ v3 f x f y f z → Vec3 { ^ @ Vec3 { x y z } }
+
+@ v3_add Vec3 a Vec3 b → Vec3 {
+    ^ @ Vec3 { + . a x . b x  + . a y . b y  + . a z . b z }
+}
+
+@ v3_scale Vec3 a f s → Vec3 {
+    ^ @ Vec3 { * . a x s  * . a y s  * . a z s }
+}
+
+@ v3_dot Vec3 a Vec3 b → f {
+    // + (+ (ax*bx) (ay*by)) (az*bz) — fully nested, no grouping tokens.
+    ^ + + * . a x . b x * . a y . b y * . a z . b z
+}
+
+@ v3_cross Vec3 a Vec3 b → Vec3 {
+    ^ @ Vec3 {
+        - * . a y . b z * . a z . b y
+        - * . a z . b x * . a x . b z
+        - * . a x . b y * . a y . b x
+    }
+}
+
+@ v3_len Vec3 a → f { ^ ( float_sqrt ( v3_dot a a ) ) }
+
+@ v3_norm Vec3 a → Vec3 { : f l ( v3_len a ) ^ ( v3_scale a / 1.0 l ) }
+
+// ── Axis B: a recursive symbolic-expression ADT ─────────────────────
+//
+// Children are boxed as `*Expr` (raw pointer payloads). This is the only
+// recursive enum in the codebase.
+
+: | Expr {
+    Num f
+    Var
+    Add *Expr *Expr
+    Mul *Expr *Expr
+    Neg *Expr
+    Sin *Expr
+    Cos *Expr
+}
+
+@ ebox Expr e → *Expr {
+    : *Expr p ( alloc [Expr] 1 )
+    = . p 0 e
+    ^ p
+}
+
+@ e_num f x   → *Expr { ^ ( ebox @ Expr { Num x } ) }
+@ e_var       → *Expr { ^ ( ebox @ Expr { Var } ) }
+@ e_add *Expr a *Expr b → *Expr { ^ ( ebox @ Expr { Add a b } ) }
+@ e_mul *Expr a *Expr b → *Expr { ^ ( ebox @ Expr { Mul a b } ) }
+@ e_neg *Expr a → *Expr { ^ ( ebox @ Expr { Neg a } ) }
+@ e_sin *Expr a → *Expr { ^ ( ebox @ Expr { Sin a } ) }
+@ e_cos *Expr a → *Expr { ^ ( ebox @ Expr { Cos a } ) }
+
+// Evaluate the tree at x = xv. Recursive match with 2-payload binding.
+@ e_eval *Expr p f xv → f {
+    : Expr e . p 0
+    ?? e {
+        Num c   → c
+        Var     → xv
+        Add a b → + ( e_eval a xv ) ( e_eval b xv )
+        Mul a b → * ( e_eval a xv ) ( e_eval b xv )
+        Neg a   → - 0.0 ( e_eval a xv )
+        Sin a   → ( float_sin ( e_eval a xv ) )
+        Cos a   → ( float_cos ( e_eval a xv ) )
+    }
+}
+
+// Symbolic differentiation d/dx — the autodiff core. Each arm rebuilds a
+// fresh subtree from the recursive results.
+@ e_diff *Expr p → *Expr {
+    : Expr e . p 0
+    ?? e {
+        Num c   → ( e_num 0.0 )
+        Var     → ( e_num 1.0 )
+        Add a b → ( e_add ( e_diff a ) ( e_diff b ) )
+        Mul a b → ( e_add ( e_mul ( e_diff a ) b ) ( e_mul a ( e_diff b ) ) )
+        Neg a   → ( e_neg ( e_diff a ) )
+        Sin a   → ( e_mul ( e_cos a ) ( e_diff a ) )
+        Cos a   → ( e_neg ( e_mul ( e_sin a ) ( e_diff a ) ) )
+    }
+}
+
+// Constant-folding + identity simplification. Nested `??` inside arms —
+// pattern-matching depth stress.
+@ e_simplify *Expr p → *Expr {
+    : Expr e . p 0
+    ?? e {
+        Add a b → {
+            : *Expr sa ( e_simplify a )
+            : *Expr sb ( e_simplify b )
+            : Expr ea . sa 0
+            : Expr eb . sb 0
+            ?? ea {
+                Num x → ?? eb {
+                    Num y → ( e_num + x y )
+                    _     → ( e_add sa sb )
+                }
+                _ → ( e_add sa sb )
+            }
+        }
+        Mul a b → {
+            : *Expr sa ( e_simplify a )
+            : *Expr sb ( e_simplify b )
+            : Expr ea . sa 0
+            : Expr eb . sb 0
+            ?? ea {
+                Num x → ?? eb {
+                    Num y → ( e_num * x y )
+                    _     → ( e_mul sa sb )
+                }
+                _ → ( e_mul sa sb )
+            }
+        }
+        _ → ( ebox e )
+    }
+}
+
+// ── Axis C: parser combinators (closures returning closures) ────────
+
+: PState { s text  i len  i pos }
+
+@ ps_new s input → *PState {
+    : *PState ps ( alloc [PState] 1 )
+    = . ps text input
+    = . ps len ( nurl_str_len input )
+    = . ps pos 0
+    ^ ps
+}
+
+@ p_peek *PState ps i ch → b {
+    ? >= . ps pos . ps len { ^ F } {}
+    ^ == ( nurl_str_get . ps text . ps pos ) ch
+}
+
+@ p_advance *PState ps → v { = . ps pos + . ps pos 1 }
+
+@ p_skip_ws *PState ps → v { ~ ( p_peek ps 32 ) { ( p_advance ps ) } }
+
+@ p_digit *PState ps → b {
+    ? >= . ps pos . ps len { ^ F } {}
+    : i c ( nurl_str_get . ps text . ps pos )
+    ^ & >= c 48 <= c 57
+}
+
+@ p_number *PState ps → ?*Expr {
+    : ~ f val 0.0
+    : ~ i any 0
+    ~ ( p_digit ps ) {
+        : i d - ( nurl_str_get . ps text . ps pos ) 48
+        = val + * val 10.0 # f d
+        ( p_advance ps )
+        = any 1
+    }
+    ? == any 0 { ^ @ ?*Expr { F } } {}
+    ? ( p_peek ps 46 ) {
+        ( p_advance ps )
+        : ~ f scale 0.1
+        ~ ( p_digit ps ) {
+            : i d - ( nurl_str_get . ps text . ps pos ) 48
+            = val + val * scale # f d
+            = scale * scale 0.1
+            ( p_advance ps )
+        }
+    } {}
+    ^ @ ?*Expr { T ( e_num val ) }
+}
+
+// atom := 'x' | number | '(' expr ')' | '-' atom | 's' atom | 'c' atom
+@ p_atom *PState ps → ?*Expr {
+    ( p_skip_ws ps )
+    ? ( p_peek ps 120 ) { ( p_advance ps ) ^ @ ?*Expr { T ( e_var ) } } {}
+    ? ( p_peek ps 40 ) {
+        ( p_advance ps )
+        : ?*Expr inner ( p_expr ps )
+        ( p_skip_ws ps )
+        ? ( p_peek ps 41 ) { ( p_advance ps ) } {}
+        ^ inner
+    } {}
+    ? ( p_peek ps 45 ) {
+        ( p_advance ps )
+        : ?*Expr a ( p_atom ps )
+        ^ ?? a { T e → @ ?*Expr { T ( e_neg e ) }  F → @ ?*Expr { F } }
+    } {}
+    ? ( p_peek ps 115 ) {
+        ( p_advance ps )
+        : ?*Expr a ( p_atom ps )
+        ^ ?? a { T e → @ ?*Expr { T ( e_sin e ) }  F → @ ?*Expr { F } }
+    } {}
+    ? ( p_peek ps 99 ) {
+        ( p_advance ps )
+        : ?*Expr a ( p_atom ps )
+        ^ ?? a { T e → @ ?*Expr { T ( e_cos e ) }  F → @ ?*Expr { F } }
+    } {}
+    ^ ( p_number ps )
+}
+
+// The combinator: left-associative chain of `sub` separated by `opch`,
+// folded with `build`. RETURNS a closure that CAPTURES sub, opch, build.
+@ p_chainl ( @ ?*Expr *PState ) sub i opch ( @ *Expr *Expr *Expr ) build → ( @ ?*Expr *PState ) {
+    ^ \ *PState ps → ?*Expr {
+        : ?*Expr first ( sub ps )
+        ?? first {
+            F → @ ?*Expr { F }
+            T lhs → {
+                : ~ *Expr acc lhs
+                ( p_skip_ws ps )
+                ~ ( p_peek ps opch ) {
+                    ( p_advance ps )
+                    : ?*Expr r ( sub ps )
+                    ?? r { T rhs → { = acc ( build acc rhs ) }  F → {} }
+                    ( p_skip_ws ps )
+                }
+                @ ?*Expr { T acc }
+            }
+        }
+    }
+}
+
+// term := atom (('*') atom)*   — built via the combinator.
+@ p_term *PState ps → ?*Expr {
+    : ( @ ?*Expr *PState ) mulp ( p_chainl
+        \ *PState s → ?*Expr { ( p_atom s ) }
+        42
+        \ *Expr a *Expr b → *Expr { ( e_mul a b ) } )
+    ^ ( mulp ps )
+}
+
+// expr := term (('+') term)*   — also via the combinator.
+@ p_expr *PState ps → ?*Expr {
+    : ( @ ?*Expr *PState ) addp ( p_chainl
+        \ *PState s → ?*Expr { ( p_term s ) }
+        43
+        \ *Expr a *Expr b → *Expr { ( e_add a b ) } )
+    ^ ( addp ps )
+}
+
+@ pf f x → v { ( nurl_print ( float_to_string x ) ) }
+
+@ main → i {
+    // ── Axis A: dense vector math ──────────────────────────────
+    : Vec3 a ( v3 1.0 2.0 3.0 )
+    : Vec3 b ( v3 4.0 5.0 6.0 )
+    ( nurl_print `dot=`   ) ( pf ( v3_dot a b ) ) ( nurl_print `\n` )
+    ( nurl_print `len=`   ) ( pf ( v3_len a ) )   ( nurl_print `\n` )
+    : Vec3 c ( v3_cross a b )
+    ( nurl_print `cross=` ) ( pf . c x ) ( nurl_print ` ` ) ( pf . c y ) ( nurl_print ` ` ) ( pf . c z ) ( nurl_print `\n` )
+    : Vec3 d ( v3_add a ( v3_scale b 2.0 ) )
+    ( nurl_print `a+2b.x=` ) ( pf . d x ) ( nurl_print `\n` )
+
+    // ── Axis C: parse a formula ───────────────────────────────
+    : s formula `x*x + 3.0*x + s(x)`
+    : *PState ps ( ps_new formula )
+    : ?*Expr parsed ( p_expr ps )
+    ?? parsed {
+        F → { ( nurl_print `parse failed\n` ) ^ 1 }
+        T tree → {
+            // ── Axis B: differentiate + simplify + eval ───────
+            : *Expr dtree ( e_simplify ( e_diff tree ) )
+            ( nurl_print `f(2)=`  ) ( pf ( e_eval tree  2.0 ) ) ( nurl_print `\n` )
+            ( nurl_print `f'(2)=` ) ( pf ( e_eval dtree 2.0 ) ) ( nurl_print `\n` )
+            ( nurl_print `f(0)=`  ) ( pf ( e_eval tree  0.0 ) ) ( nurl_print `\n` )
+        }
+    }
+    ^ 0
+}


### PR DESCRIPTION
## Summary

An enum's payload slot is uniformly pointer-typed. `gen_agg_lit` coerced `i1` / integer / string / struct payloads into it, but had **no branch for `double` / `float`**, so a float payload emitted `insertvalue %E …, double X, 1` into a `ptr` field and clang rejected it (`operand and field disagree in type: 'double' instead of 'ptr'`). The match/unbox side had the symmetric gap (a `double` payload fell through to the `bitcast ptr … to i8*` catch-all).

Any sum type with a floating-point payload — a numeric AST, a real-valued JSON, a geometry variant — was **uncompilable**, even though the grammar permits it (`enum_variant = IDENT type*`, and `type` includes `f`). No recursive enum existed anywhere in the tree, so the whole family was silently impossible.

## Fix

- New `emit_enum_float_extract` + `is_float_ty` helpers (next to `int_width`).
- **Construction** (`gen_agg_lit`): bitcast the float to a same-width int (f32 widens i32→i64), then `inttoptr` into the `ptr` slot.
- **Extraction** (`gen_match`, payload slots 0/1/2): the inverse — `ptrtoint` back to i64, then bitcast (f32 truncs to i32 first).

5 edits: 1 construction site + 3 match slots + the two helpers.

## Verification

- Round-trips across payload **slots 0/1/2** (double), a **mixed float+pointer recursive enum**, and a **genuine `f32`** value.
- Regression `compiler/tests/enum_float_payload.nu` — **ASan/UBSan/LSan-clean**, full suite **413/413**.
- **Bootstrap fixed point holds without a refresh**: no existing code used float enum payloads, so emitted IR is byte-identical.

## How it was found

Surfaced by `examples/chaotic-showcase.nu`, an adversarial grammar stress test built to probe **grammar v2.2 completeness before the v1.0 lock**. It combines three corners the corpus never hits at once: (A) dense prefix vec3/float arithmetic, (B) a recursive `Expr` ADT with symbolic autodiff + simplify via deep `??` match, (C) parser combinators where `p_chainl` returns a closure capturing two closures + a scalar. Pipeline: parse a formula → differentiate → evaluate. The closure-capturing-closure axis (C) compiled and ran correctly; (B) is what exposed this bug.

## Known edge (documented)

An *implicit* double-literal → `f32` narrowing in an enum literal still needs an explicit `# f32` cast — exactly as struct construction requires (it rejects the same mismatch). That's the general implicit-float-narrowing class, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)