### PR TITLE
feat(match): bind N payloads per arm — lift the 3-payload destructuring limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Pattern matching now binds N payloads per arm (was capped at 3).** The
+  enum type and construction already supported any number of payload slots;
+  only the match side was limited — the parser stored just three binding
+  names and the emitter had three hand-unrolled slot blocks, so a 4th+ payload
+  was silently dropped (`use of undefined identifier`), forcing a post-match
+  `.` extraction. The parser now collects overflow payload names/literals and
+  the emitter binds slots 1..N-1 through one `emit_enum_payload_bind` helper in
+  a loop (slot 0 keeps its option/result-aware reconstruction); literal
+  constraints on slots 3+ loop the same way. Verified for 4- and 5-payload
+  variants across mixed payload types (int / float / string / pointer /
+  struct), a literal constraint on slot 3, and a guard reading a slot-3
+  binding. The bootstrap fixed point holds without a refresh. Regression
+  `compiler/tests/match_payload_n.nu`. Removes the `docs/LIMITATIONS.md` Enums
+  limitation (CRITIC A6).
+
 ### Fixed
 
 - **Float (`f` / `f32`) enum payloads now compile.** An enum's payload slot

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5516,9 +5516,12 @@
             : ~ s pv0 ``
             : ~ s pv1 ``
             : ~ s pv2 ``
+            : ~ s pv_over ``
             : ~ s lit0 ``
             : ~ s lit1 ``
             : ~ s lit2 ``
+            : ~ s lit_over ``
+            : ~ i over_has_lit 0
             : ~ i pvc 0
             ~ & & ! is_int_pat != ( nurl_lex_type lex ) TT_ARROW != ( nurl_lex_type lex ) TT_QUEST {
                 : i pst ( nurl_lex_type lex )
@@ -5526,6 +5529,10 @@
                     ? == pvc 0 { = pv0 ( nurl_lex_val lex ) } {}
                     ? == pvc 1 { = pv1 ( nurl_lex_val lex ) } {}
                     ? == pvc 2 { = pv2 ( nurl_lex_val lex ) } {}
+                    ? >= pvc 3 {
+                        = pv_over ? == 0 ( nurl_str_len pv_over ) ( nurl_lex_val lex ) ( nurl_str_cat3 pv_over ` ` ( nurl_lex_val lex ) )
+                        = lit_over ? == 0 ( nurl_str_len lit_over ) `_` ( nurl_str_cat lit_over ` _` )
+                    } {}
                     = pvc + pvc 1
                     ( nurl_lex_advance lex )
                 } {
@@ -5536,6 +5543,11 @@
                         ? == pvc 0 { = lit0 ival } {}
                         ? == pvc 1 { = lit1 ival } {}
                         ? == pvc 2 { = lit2 ival } {}
+                        ? >= pvc 3 {
+                            = lit_over ? == 0 ( nurl_str_len lit_over ) ival ( nurl_str_cat3 lit_over ` ` ival )
+                            = pv_over ? == 0 ( nurl_str_len pv_over ) `_` ( nurl_str_cat pv_over ` _` )
+                            = over_has_lit 1
+                        } {}
                         = pvc + pvc 1
                         ( nurl_lex_advance lex )
                     } {
@@ -5543,9 +5555,10 @@
                     }
                 }
             }
-            : b has_lit | | != 0 ( nurl_str_len lit0 )
+            : b has_lit | | | != 0 ( nurl_str_len lit0 )
             != 0 ( nurl_str_len lit1 )
             != 0 ( nurl_str_len lit2 )
+            != 0 over_has_lit
 
             // Payload-arity check (critic A7, ghost-variant half). When
             // the pattern names a DECLARED enum variant (it has a
@@ -5711,6 +5724,15 @@
                         ( emit_lit_check cg syms match_val match_type pattern_name 0 lit0 next_label )
                         ( emit_lit_check cg syms match_val match_type pattern_name 1 lit1 next_label )
                         ( emit_lit_check cg syms match_val match_type pattern_name 2 lit2 next_label )
+                        // Literal constraints on payload slots 3+ (rare).
+                        : ~ s lc_rest lit_over
+                        : ~ i lc_idx 3
+                        ~ != 0 ( nurl_str_len lc_rest ) {
+                            : s lc_tok ( str_first_word lc_rest )
+                            = lc_rest ( str_skip_word lc_rest )
+                            ? ! ( seq lc_tok `_` ) { ( emit_lit_check cg syms match_val match_type pattern_name lc_idx lc_tok next_label ) } {}
+                            = lc_idx + lc_idx 1
+                        }
                         ( nurl_print `  br label %` ) ( nurl_print arm_label ) ( emit_dbg_eol )
                     } {}
                 } }
@@ -6153,6 +6175,18 @@
                 }
                 {}
             } {}
+
+            // Bind payload slots 3+ (slot 0 is handled inline above with its
+            // opt/res-aware reconstruction; slots 1/2 just above). One helper
+            // call per slot lifts the former 3-payload destructuring limit.
+            : ~ s pb_rest pv_over
+            : ~ i pb_idx 3
+            ~ != 0 ( nurl_str_len pb_rest ) {
+                : s pb_tok ( str_first_word pb_rest )
+                = pb_rest ( str_skip_word pb_rest )
+                ? ! ( seq pb_tok `_` ) { ( emit_enum_payload_bind pb_tok pb_idx pattern_name match_type match_val syms cg ) } {}
+                = pb_idx + pb_idx 1
+            }
 
             // Guard test (after payload binding so it sees the bound
             // payloads): replay the recorded guard expression, branch to
@@ -9161,6 +9195,82 @@
 // `i8*`, `%Foo*`, `i8**`). Used by comparison codegen to coerce
 // pointer operands to i64 before `icmp`, so `== ptr 0` / `!= ptr 0`
 // null-checks and pointer↔pointer compares emit valid IR.
+// Bind ONE enum payload slot (`pidx` ≥ 1; slot 0 keeps its own opt/res-bool
+// reconstruction inline in gen_match). The payload rode the uniformly-`ptr`
+// enum slot; reconstruct it as the exact inverse of gen_agg_lit's boxing —
+// float via emit_enum_float_extract, a narrow int via ptrtoint+trunc, a
+// single-pointer struct handle via insertvalue, a multi-field struct / enum /
+// anon aggregate via a load through the heap-box pointer, i64 via ptrtoint,
+// else a bare pointer. Then alloca + store + register the binding (with its
+// `__ptr` / `__unsigned` metadata and any user-`Drop`). One call per slot,
+// driven by a loop in gen_match, generalises the former hand-unrolled slot-1 /
+// slot-2 blocks to N payloads — lifting the 3-payload destructuring limit.
+@ emit_enum_payload_bind s pvi i pidx s pattern_name s match_type s match_val i syms i cg → v {
+    : s pkey ( nurl_str_cat3 pattern_name `__payload__` ( nurl_str_int pidx ) )
+    : s pti ( nurl_sym_get syms pkey )
+    : s pri ( nurl_cg_reg cg )
+    ( nurl_print `  ` ) ( nurl_print pri )
+    ( nurl_print ` = extractvalue ` ) ( nurl_print match_type )
+    ( nurl_print ` ` ) ( nurl_print match_val )
+    ( nurl_print `, ` ) ( nurl_print ( nurl_str_int + pidx 1 ) ) ( nurl_print `\n` )
+    : s cvi ( nurl_cg_reg cg )
+    ? ( is_float_ty pti )
+    { ( emit_enum_float_extract cvi pti pri cg ) }
+    { ? & > ( int_width pti ) 0 < ( int_width pti ) 64 {
+        : s t64 ( nurl_cg_reg cg )
+        ( nurl_print `  ` ) ( nurl_print t64 )
+        ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pri ) ( nurl_print ` to i64\n` )
+        ( nurl_print `  ` ) ( nurl_print cvi )
+        ( nurl_print ` = trunc i64 ` ) ( nurl_print t64 ) ( nurl_print ` to ` ) ( nurl_print pti ) ( nurl_print `\n` )
+    } {
+        : ~ b is_sh F
+        : ~ s f0ty ``
+        ? == ( nurl_str_get pti 0 ) 37
+        { : s snamei ( nurl_str_slice pti 1 - ( nurl_str_len pti ) 1 )
+            : s vlisti ( nurl_sym_get syms ( nurl_str_cat snamei `__variants` ) )
+            ? == 0 ( nurl_str_len vlisti )
+            { = f0ty ( nurl_sym_get syms ( nurl_str_cat3 snamei `__idx_0` `__type` ) )
+                ? & != 0 ( nurl_str_len f0ty )
+                == ( nurl_str_get f0ty - ( nurl_str_len f0ty ) 1 ) 42
+                { = is_sh T } {} }
+            {} }
+        {}
+        ? is_sh
+        { ( nurl_print `  ` ) ( nurl_print cvi )
+            ( nurl_print ` = insertvalue ` ) ( nurl_print pti )
+            ( nurl_print ` undef, ` ) ( nurl_print f0ty )
+            ( nurl_print ` ` ) ( nurl_print pri ) ( nurl_print `, 0\n` ) }
+        { ( nurl_print `  ` ) ( nurl_print cvi )
+            ? | == ( nurl_str_get pti 0 ) 123
+            & == ( nurl_str_get pti 0 ) 37
+            != ( nurl_str_get pti - ( nurl_str_len pti ) 1 ) 42
+            { ( nurl_print ` = load ` ) ( nurl_print pti )
+                ( nurl_print `, ptr ` ) ( nurl_print pri ) ( nurl_print `\n` ) }
+            ? ( seq pti `i64` )
+            { ( nurl_print ` = ptrtoint ptr ` ) ( nurl_print pri ) ( nurl_print ` to i64\n` ) }
+            { ( nurl_print ` = bitcast ptr ` ) ( nurl_print pri ) ( nurl_print ` to i8*\n` ) } }
+    } }
+    : s vpi ( nurl_cg_reg cg )
+    ( nurl_print `  ` ) ( nurl_print vpi )
+    ( nurl_print ` = alloca ` ) ( nurl_print pti ) ( nurl_print `\n` )
+    ( nurl_print `  store ` ) ( nurl_print pti )
+    ( nurl_print ` ` ) ( nurl_print cvi )
+    ( nurl_print `, ` ) ( nurl_print pti )
+    ( nurl_print `* ` ) ( nurl_print vpi ) ( nurl_print `\n` )
+    ( nurl_sym_def syms pvi pti )
+    ( nurl_sym_def syms ( nurl_str_cat pvi `__ptr` ) vpi )
+    ( nurl_sym_def syms ( nurl_str_cat pvi `__unsigned` )
+    ( nurl_sym_get syms ( nurl_str_cat pkey `__unsigned` ) ) )
+    ? != 0 g_auto_drop_strings
+    { : s akey ( nurl_str_cat `drop##` pti )
+        ? & != 0 ( nurl_str_len ( nurl_sym_get g_impl_name_syms akey ) )
+        == 0 ( nurl_str_len ( nurl_sym_get g_impl_name_syms ( nurl_str_cat `autodrop##` pti ) ) )
+        { ( mem_own_add_user_drop syms vpi pti ) }
+        {}
+    }
+    {}
+}
+
 @ is_ptr_ty s ty → b {
     : i n ( nurl_str_len ty )
     ? == n 0 { ^ F } {}

--- a/compiler/tests/match_payload_n.nu
+++ b/compiler/tests/match_payload_n.nu
@@ -1,0 +1,78 @@
+// match_payload_n.nu — regression for the 3-payload match-destructuring
+// limit (CRITIC A6 / docs/LIMITATIONS → Enums).
+//
+// Bug: an enum's type + construction already supported N payload slots
+// (`%E = { i64, ptr, ptr, ptr, ptr }`, with all insertvalues emitted), but
+// the MATCH side capped binding at 3 — the parser stored only pv0/pv1/pv2
+// and the emitter had three hand-unrolled slot blocks. A 4th+ payload was
+// silently dropped (`use of undefined identifier 'd'`), forcing a post-match
+// `.` extraction workaround.
+//
+// Fix: the parser now collects overflow payload names/literals (pv_over /
+// lit_over, space-joined parallel lists), and the emitter binds slots 1..N-1
+// through one `emit_enum_payload_bind` helper driven by a loop (slot 0 keeps
+// its opt/res-aware reconstruction inline). Literal constraints on slots 3+
+// loop through `emit_lit_check` the same way. Verified for 4- and 5-payload
+// variants across mixed payload types (int / float / string / pointer), a
+// literal constraint on slot 3, and a guard reading a slot-3 binding.
+
+$ `stdlib/std/float.nu`
+
+: Pt { i px  i py }
+
+: | E {
+    Quad i i i i
+    Five i f s i i
+    WithPtr i i i *Pt
+    Leaf
+}
+
+@ ck b ok s label → v {
+    ( nurl_print label ) ( nurl_print ? ok ` ok\n` ` FAIL\n` )
+}
+
+@ main → i {
+    // 4 int payloads, slot 3 bound
+    : E q @ E { Quad 10 20 30 40 }
+    ?? q {
+        Quad a b c d → { ( ck & & & == a 10 == b 20 == c 30 == d 40 `quad_4bind` ) }
+        Five p w x y z → {}  WithPtr a b c r → {}  Leaf → {}
+    }
+
+    // 5 payloads, mixed int / float / string across slots 0..4
+    : E f @ E { Five 7 2.5 `hi` 99 123 }
+    ?? f {
+        Quad a b c d → {}
+        Five p w x y z → {
+            ( ck & & & & == p 7 == # i w 2 != 0 ( nurl_str_eq x `hi` ) == y 99 == z 123 `five_mixed` )
+        }
+        WithPtr a b c r → {}  Leaf → {}
+    }
+
+    // pointer payload at slot 3
+    : *Pt pp # *Pt ( nurl_alloc Z Pt )
+    = . pp px 8
+    : E w @ E { WithPtr 1 2 3 pp }
+    ?? w {
+        Quad a b c d → {}  Five p ww x y z → {}
+        WithPtr a b c r → { ( ck & & == a 1 == c 3 == . r px 8 `withptr_slot3` ) }
+        Leaf → {}
+    }
+    ( nurl_free # s pp )
+
+    // literal constraint on slot 3 (4th payload)
+    ?? q {
+        Quad a b c 40 → { ( ck T `quad_slot3_lit` ) }
+        Quad a b c d → { ( ck F `quad_slot3_lit` ) }
+        Five p ww x y z → {}  WithPtr a b c r → {}  Leaf → {}
+    }
+
+    // guard that reads a slot-3 binding (guard runs AFTER payload binding)
+    ?? q {
+        Quad a b c d ? == d 40 → { ( ck T `quad_guard_slot3` ) }
+        Quad a b c d → { ( ck F `quad_guard_slot3` ) }
+        Five p ww x y z → {}  WithPtr a b c r → {}  Leaf → {}
+    }
+
+    ^ 0
+}

--- a/compiler/tests/outputs/match_payload_n.txt
+++ b/compiler/tests/outputs/match_payload_n.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+quad_4bind ok
+five_mixed ok
+withptr_slot3 ok
+quad_slot3_lit ok
+quad_guard_slot3 ok

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -31,12 +31,6 @@ and the borrow checker's not-yet-checked list live in
 | Closures capture by value (snapshot at construction) by default. The `: ~` mutable-struct byref capture path (`stdlib/std/panic.nu` recover-with-typed-result) shares the caller's alloca — see [`docs/MEMORY.md` §2.3](MEMORY.md) for the lifetime rule | Use `: ~ MultiFieldStruct` for shared-mutation closures; for value semantics keep the binding immutable |
 | A `sink` parameter takes a manually-managed handle (`Vec`, single-pointer struct) that the callee frees explicitly. A *compiler-auto-dropped* value (an owned string, owned slice, `Drop` value, or struct with owned fields) is **rejected at the call site by design** — its auto-drop obligation can't be transferred without risking a double-free across `?`/`??`/loop scope restores (see [`docs/MEMORY.md` §1](MEMORY.md)) | Wrap it in a handle (`{ s data }` / `Vec`), or pass it by value as an ordinary parameter and let the caller's scope drop it |
 
-## Enums
-
-| Limitation | Workaround |
-|---|---|
-| Pattern matching binds at most 3 payload variables per arm — variants with 4+ payloads cannot fully destructure in a single arm | Access additional payload fields via separate `.` extraction after matching |
-
 ## Imports
 
 | Limitation | Workaround |


### PR DESCRIPTION
## Summary

Pattern matching previously bound **at most 3 payloads per arm** (CRITIC A6 / `docs/LIMITATIONS.md` → Enums). The enum *type* and *construction* already supported any number of payload slots (`%E = { i64, ptr×N }`, with every `insertvalue` emitted) — only the **match side** was capped: the parser stored just `pv0`/`pv1`/`pv2` and the emitter had three hand-unrolled slot blocks. A 4th+ payload was silently dropped (`use of undefined identifier 'd'`), forcing a post-match `.` extraction workaround.

## Fix

- **Parser**: collect overflow payload names + literals into `pv_over` / `lit_over` — space-joined parallel lists, one token per overflow slot with a `_` placeholder for the non-applicable kind, walked with `str_first_word` / `str_skip_word`. `over_has_lit` feeds `has_lit`.
- **Emitter**: bind slots `1..N-1` through one new helper `emit_enum_payload_bind` driven by a loop. Slot 0 keeps its option/result-aware reconstruction inline (that path is opt/res-only and single-payload). Literal constraints on slots 3+ loop through `emit_lit_check` the same way.

Slots 1/2 are left inline and untouched, so existing behaviour is byte-identical; the helper is the general path for slots ≥3.

## Verification

- 4- and 5-payload variants, **mixed payload types** (int / float / string / pointer / struct), a **literal constraint on slot 3**, and a **guard reading a slot-3 binding** — all correct.
- Regression `compiler/tests/match_payload_n.nu`, **ASan/UBSan/LSan-clean**, full suite **414/414**.
- **Bootstrap fixed point holds without a refresh** — no in-tree match binds 4+ payloads (that was the limit), so emitted IR is unchanged.

Removes the `docs/LIMITATIONS.md` → Enums limitation row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)