### PR TITLE
fix(codegen): mutable string globals (: ~ s g) can be reassigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mutable string globals (`: ~ s g …`) can now be reassigned.** The
+  declaration was accepted and emitted as writable `global i8*` storage, but
+  `gen_const_decl`'s string branch never recorded the `__mutable` flag (the
+  `i` / `u` / `f` / `b` branches all did), so a later `= g …` was wrongly
+  rejected with *"cannot assign to immutable global"* — even though the
+  grammar lists `s` as an updatable mutable-global type. The string branch now
+  sets the flag like the other scalar branches. Reassignment to a constant or
+  a heap-allocated (`nurl_str_cat`) string both work. The bootstrap fixed
+  point holds (no in-tree code could use a mutable string global, since the
+  bug rejected them, so emitted IR is unchanged). Regression
+  `compiler/tests/mutable_string_global.nu`. Surfaced by an adversarial
+  language-probing sweep for grammar/spec-vs-compiler gaps before the v1.0
+  lock.
+
 ### Changed
 
 - **Pattern matching now binds N payloads per arm (was capped at 3).** The

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -13450,6 +13450,14 @@
             ( nurl_print strname ) ( nurl_print `, i64 0, i64 0)\n\n` )
             ( nurl_sym_def syms cname `i8*` )
             ( nurl_sym_def syms ( nurl_str_cat cname `__global` ) `1` )
+            // String globals are emitted as `global i8*` (writable storage),
+            // so a `: ~ s g` must record the mutable flag like the i/f/b
+            // branches above — without it, `= g …` was wrongly rejected as an
+            // assignment to an immutable global (the grammar lists `s` as an
+            // updatable mutable-global type).
+            ? is_mutable
+            { ( nurl_sym_def syms ( nurl_str_cat cname `__mutable` ) `1` ) }
+            {}
         }
         // Integer const-expression RHS (operator-led): fold to a single
         // value at compile time. Gated on an integer LLVM type wider

--- a/compiler/tests/mutable_string_global.nu
+++ b/compiler/tests/mutable_string_global.nu
@@ -1,0 +1,30 @@
+// mutable_string_global.nu — regression for mutable STRING globals.
+//
+// Bug: `: ~ s g …` declared a mutable string global, but gen_const_decl's
+// TT_STR branch never recorded the `<name>__mutable` flag (the i / u / f / b
+// branches all did). So a later `= g …` was wrongly rejected with
+// "cannot assign to immutable global", even though the grammar explicitly
+// lists `s` as an updatable mutable-global type and the storage is emitted as
+// a writable `global i8*`. `: ~ i/u/f/b` globals were unaffected.
+//
+// Fix: the TT_STR branch now sets `<name>__mutable` when `is_mutable`, exactly
+// like the other scalar branches. Verified: reassignment to another constant
+// string and to a heap-allocated (`nurl_str_cat`) string both work.
+
+$ `stdlib/core/string.nu`
+
+: ~ s g_msg `start`
+
+@ main → i {
+    ( nurl_print g_msg ) ( nurl_print `\n` )
+
+    = g_msg `middle`
+    ( nurl_print g_msg ) ( nurl_print `\n` )
+
+    // Reassign to a heap-allocated string. The global keeps it reachable for
+    // the rest of the run (globals are not auto-dropped), so it stays
+    // LeakSanitizer-clean (still reachable, not lost).
+    = g_msg ( nurl_str_cat g_msg `-end` )
+    ( nurl_print g_msg ) ( nurl_print `\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs/mutable_string_global.txt
+++ b/compiler/tests/outputs/mutable_string_global.txt
@@ -1,0 +1,7 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+start
+middle
+middle-end


### PR DESCRIPTION
## Summary

`: ~ s g …` declares a mutable string global. The declaration was accepted and emitted as **writable `global i8*` storage** — but `gen_const_decl`'s `TT_STR` branch never recorded the `<name>__mutable` flag that the `i` / `u` / `f` / `b` branches all set. So a later `= g …` was wrongly rejected with **"cannot assign to immutable global"**, even though the grammar (`spec/grammar.ebnf`, `const_decl`) explicitly lists `s` as an updatable mutable-global type. `: ~ i/u/f/b` globals were unaffected.

```
: ~ s g `a`
@ main → i { = g `b` ( nurl_print g ) ^ 0 }   // was: error — cannot assign to immutable global
```

## Fix

The `TT_STR` branch now sets `<name>__mutable` when `is_mutable`, exactly like the other scalar branches. Verified for reassignment to another constant string and to a heap-allocated (`nurl_str_cat`) string.

The **bootstrap fixed point holds without a refresh** — no in-tree code could use a mutable string global (the bug rejected them), so emitted IR is unchanged.

## Test

Regression `compiler/tests/mutable_string_global.nu`, suite **415/415**, ASan/UBSan/LSan-clean.

Surfaced by an adversarial language-probing sweep for grammar / spec-vs-compiler gaps ahead of the v1.0 grammar lock. That sweep otherwise found **no lock-critical grammar or semantic gaps**: argument/aggregate evaluation order is left-to-right, integer div/mod is truncated (dividend-signed remainder), shifts are arithmetic, signed overflow wraps (two's complement), `&`/`|` short-circuit, and every overloaded-token disambiguation (`~` foreach/while/complement, `[` slice/type/generic, `?`/`??`, `^`/`^^`, negative-literal vs binary minus, `::`) resolves correctly — alongside trait dispatch, generics-over-generics, nested/returned closures, recursive types, default + named args, variadic FFI, and `inout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)