### PR TITLE
fix(diag): clearer errors for generic-call-without-[T] and unimported stdlib helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Clearer diagnostics for two call-site papercuts** (surfaced by the
+  v1.0-lock language sweep):
+  - A **generic function called without `[T …]` type arguments** now reports
+    *"generic function 'pick' needs explicit type argument(s): write
+    ( pick [T] … ) — NURL does not infer generic type arguments from value
+    arguments"* instead of the misleading *"call to unknown function 'pick'"*
+    (the same message a genuine typo gets). A truly-unknown name still gets the
+    unknown-function message. Lock `compiler/tests/should_fail_generic_no_typeargs.nu`.
+  - A **pure-NURL stdlib helper used without importing its module** —
+    `nurl_str_cat` / `_cat3` / `_cat4` / `_slice`, which are pre-registered for
+    cross-module typing but have no C body (unlike `nurl_str_int` / `_float` /
+    `read_*`) — now reports *"'nurl_str_cat' is defined in
+    stdlib/core/string.nu … add a '$' import of that file"* at the call site,
+    instead of leaking clang's *"use of undefined value '@nurl_str_cat'"* at
+    link. Safe because `scan_fn_sigs` is a complete whole-program pre-pass, so a
+    real definition anywhere sets `__arity` before any call is generated (no
+    false positive for cross-module callers). Lock
+    `compiler/tests/should_fail_stdlib_helper_no_import.nu`. Both are
+    diagnostic-only — the bootstrap fixed point holds.
+
 ### Fixed
 
 - **Mutable string globals (`: ~ s g …`) can now be reassigned.** The

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -4673,13 +4673,39 @@
     // diagnostic so the error lands on the call site instead. Runs
     // while the lexer still sits on the closing ')' so the caret
     // points at this call.
+    //
+    // A pure-NURL stdlib helper (`nurl_str_cat` / `_cat3` / `_cat4` /
+    // `_slice`) is pre-registered in init_syms for cross-module typing but
+    // has no C body — so if the program never imported its module it is
+    // undefined at link (clang: "use of undefined value '@nurl_str_cat'").
+    // It carries a `__needs_stdlib` marker but no `__arity` (scan_fn_sigs, a
+    // complete whole-program pre-pass, sets `__arity` for any real
+    // definition before any call is generated). Name the missing import at
+    // the call site instead of leaking the clang error.
+    ? & != 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat fname `__needs_stdlib` ) ) )
+    == 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat fname `__arity` ) ) )
+    { ( die lex ( nurl_str_cat3
+        ( nurl_str_cat3 `'` fname `' is defined in ` )
+        ( nurl_sym_get syms ( nurl_str_cat fname `__needs_stdlib` ) )
+        ` (a pure-NURL stdlib helper, not a runtime builtin) — add a '$' import of that file to use it.` ) ) }
+    {}
     ? & & & == 0 ( nurl_str_len ( nurl_sym_get syms call_name ) )
     == 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat fname `__ptr` ) ) )
     == 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat fname `__arity` ) ) )
     == 0 ( nurl_str_len ( nurl_sym_get g_impl_name_syms ( nurl_str_cat fname `__impl_seen` ) ) )
-    { ( die lex ( nurl_str_cat3
-        `call to unknown function '` fname
-        `' — it is not defined in this file, not in any '$'-imported file processed so far, and not a known FFI/builtin. Add the missing '$' import (or move it above this file's import in the program), or check the spelling.` ) ) }
+    {  // A GENERIC function called with no `[T …]` type arguments lands
+       // here — it carries `__tparams` but no `__arity` / mangled
+       // call_name (NURL does not infer type args from value args). Name
+       // the real cause instead of the misleading "unknown function".
+        : s __gtp ( nurl_sym_get g_generic_syms ( nurl_str_cat fname `__tparams` ) )
+        ? != 0 ( nurl_str_len __gtp )
+        { ( die lex ( nurl_str_cat3
+            ( nurl_str_cat3 `generic function '` fname `' needs explicit type argument(s): write ( ` )
+            ( nurl_str_cat3 fname ` [` ( nurl_str_cat __gtp `] … ) ` ) )
+            `— NURL does not infer generic type arguments from value arguments.` ) ) }
+        { ( die lex ( nurl_str_cat3
+            `call to unknown function '` fname
+            `' — it is not defined in this file, not in any '$'-imported file processed so far, and not a known FFI/builtin. Add the missing '$' import (or move it above this file's import in the program), or check the spelling.` ) ) } }
     {}
     // Call-arity check. scan_fn_sigs records every non-generic
     // @-function's declared parameter count as `<fname>__arity`. A call
@@ -14640,6 +14666,19 @@
     ( nurl_sym_def syms `nurl_str_int` `i8*` )
     ( nurl_sym_def syms `nurl_str_float` `i8*` )
     ( nurl_sym_def syms `nurl_str_slice` `i8*` )
+    // The four cat/slice helpers are PURE-NURL (defined in core/string.nu,
+    // NOT in runtime.o) — unlike nurl_str_int / _float / read_* which have C
+    // bodies and always link. The type pre-registration above keeps a
+    // cross-module caller typed, but if NO file in the program imports
+    // string.nu the symbol is undefined at link (clang: "use of undefined
+    // value '@nurl_str_cat'"). Mark them so gen_call can name the missing
+    // import at the call site instead. Safe: scan_fn_sigs is a COMPLETE
+    // pre-pass over the whole program (it follows `$` imports), so a real
+    // definition anywhere sets `<name>__arity` before any call is generated.
+    ( nurl_sym_def syms `nurl_str_cat__needs_stdlib` `stdlib/core/string.nu` )
+    ( nurl_sym_def syms `nurl_str_cat3__needs_stdlib` `stdlib/core/string.nu` )
+    ( nurl_sym_def syms `nurl_str_cat4__needs_stdlib` `stdlib/core/string.nu` )
+    ( nurl_sym_def syms `nurl_str_slice__needs_stdlib` `stdlib/core/string.nu` )
     // Mark allocating string runtime calls as returning OWNED str.
     // Gated on g_auto_drop_strings — off by default to keep the
     // compiler's own source compilable without false-positive

--- a/compiler/tests/outputs/should_fail_generic_no_typeargs.txt
+++ b/compiler/tests/outputs/should_fail_generic_no_typeargs.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_stdlib_helper_no_import.txt
+++ b/compiler/tests/outputs/should_fail_stdlib_helper_no_import.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_generic_no_typeargs.nu
+++ b/compiler/tests/should_fail_generic_no_typeargs.nu
@@ -1,0 +1,17 @@
+// should_fail_generic_no_typeargs.nu — a generic function called without
+// explicit `[T …]` type arguments must be diagnosed at the call site.
+//
+// NURL does not infer generic type arguments from value arguments, so
+// `( pick 7 9 )` cannot resolve `pick`'s `[T]`. This used to surface the
+// MISLEADING "call to unknown function 'pick'" error (the same message a
+// genuine typo gets), even though `pick` is defined right above. The
+// diagnostic now names the real cause and shows the fix:
+// `( pick [T] … )`. (Compile succeeds with explicit args — see the
+// frontend probe; this file pins the rejection of the inferred form.)
+
+@ pick [T] T x T y → T { ^ x }
+
+@ main → i {
+    ( nurl_print ( nurl_str_int ( pick 7 9 ) ) )
+    ^ 0
+}

--- a/compiler/tests/should_fail_stdlib_helper_no_import.nu
+++ b/compiler/tests/should_fail_stdlib_helper_no_import.nu
@@ -1,0 +1,14 @@
+// should_fail_stdlib_helper_no_import.nu — a pure-NURL stdlib helper
+// (nurl_str_cat / _cat3 / _cat4 / _slice) used WITHOUT importing its module
+// must be diagnosed at the call site.
+//
+// These are pre-registered in init_syms for cross-module typing but have no
+// C body (unlike nurl_str_int / _float / read_*), so with no `$` import of
+// stdlib/core/string.nu the symbol is undefined at link. The frontend now
+// names the missing import instead of leaking clang's
+// "use of undefined value '@nurl_str_cat'".
+
+@ main → i {
+    ( nurl_print ( nurl_str_cat `a` `b` ) )
+    ^ 0
+}


### PR DESCRIPTION
Two call-site diagnostic papercuts surfaced by the v1.0-lock language sweep. Both are **diagnostic-only** — the bootstrap fixed point holds.

## 1. Generic call without `[T …]`

A generic function called without explicit type arguments landed in the **"call to unknown function 'X'"** path — the same message a genuine typo gets — even though `X` is defined right there. NURL does not infer generic type args from value args, so `( pick 7 9 )` can't resolve `pick`'s `[T]`.

`gen_call` now checks the function's `__tparams` and reports the real cause:

```
generic function 'pick' needs explicit type argument(s): write ( pick [T] … )
— NURL does not infer generic type arguments from value arguments.
```

A truly-unknown name still gets the unknown-function message. Lock `should_fail_generic_no_typeargs.nu`.

## 2. Pure-NURL stdlib helper used without its import

`nurl_str_cat` / `_cat3` / `_cat4` / `_slice` are pre-registered in `init_syms` for cross-module typing but have **no C body** (unlike `nurl_str_int` / `_float` / `read_*`, which live in the runtime and always link). Used without a `$` import of `core/string.nu`, they leaked clang's **"use of undefined value '@nurl_str_cat'"** at link.

They now carry a `__needs_stdlib` marker, and `gen_call` names the missing import at the call site when the helper has no `__arity`:

```
'nurl_str_cat' is defined in stdlib/core/string.nu (a pure-NURL stdlib helper,
not a runtime builtin) — add a '$' import of that file to use it.
```

**Safe (no false positives):** `scan_fn_sigs` is a complete whole-program pre-pass that follows `$` imports, so a real definition anywhere in the program sets `__arity` before any call is generated — a cross-module caller whose sibling module imports `string.nu` is unaffected. Verified: `nurl_str_int` (runtime builtin) still callable without import; importing `string.nu` works. Lock `should_fail_stdlib_helper_no_import.nu`.

Suite 417/417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)