### PR TITLE
fix(compiler): front-end type checking for the common static-error class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Front-end type checking for the common static-error class (adversarial
+  sweep #3).** A sharper probing pass found that a whole family of trivial type
+  errors was accepted by `nurlc` (rc 0, no diagnostic) and emitted IR that only
+  `clang` rejected — the "where is the type checker?" optics. All are now caught
+  at the source, with no implicit conversions introduced (NURL stays explicit):
+  - **Binary-operator operand mismatch** — mixing a float and a non-float in any
+    operator (`+ 1 1.0`, `* 2.0 3`, `== 1 1.0`), or a pointer/string and an
+    integer in an arithmetic op (`+ `a` 1`). `gen_binary` enforces the
+    "operands share a type" invariant it already documented. Pointer
+    comparisons (`== ptr 0`, ptr↔ptr) stay exempt via the existing ptrtoint
+    coercion. Locks `should_fail_binop_int_float`, `should_fail_binop_ptr_int`.
+  - **Binding initialiser / assignment mismatch** — `: i x 1.5`, `: i x `hi``,
+    `= n 1.5`. `coerce_store_val` now rejects the never-valid float/non-float
+    and pointer-into-non-pointer store clashes after its real coercions
+    (i1-widen, enum-wrap, single-handle, int-width) have had their say; the
+    null-as-`0` idiom (`: *T p 0`) stays valid. Locks
+    `should_fail_let_type_mismatch`, `should_fail_assign_type_mismatch`.
+  - **Return-value type mismatch** — `^ `hi`` / `^ 1.5` from a `→ i` function.
+    `gen_ret` checks the returned value's type against the declared return type
+    (same narrow never-valid directions). Locks
+    `should_fail_return_type_mismatch`.
+  - **Void/unit value (`v`) stored or bound** — `: i y v`, `= x v` (the bare
+    type keyword leaking into a value position). Locks `should_fail_store_void`;
+    the operator/complement/not sinks were already guarded.
+  - **Recursive struct of infinite size** — `: Node { i v  Node next }` (a
+    by-value self-reference, the classic missing-pointer mistake) is diagnosed
+    at the declaration with the "box it as `* Node`" cure, instead of a cryptic
+    `insertvalue operand and field disagree` IR error at first construction.
+    Locks `should_fail_recursive_struct`.
+  - **Closure return-type context** — `gen_ret` inside a closure body now sees
+    the *closure's* declared return type (the body scope shadows
+    `__fn_ret_ty__`), not the enclosing function's; this both enables the
+    return check above inside closures and corrects the pre-existing
+    void-return diagnostic there.
+
 ### Decided (toward 1.0 grammar lock)
 
 - **No grouping/closing delimiter — locked.** Fixed prefix arity with no

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -1827,6 +1827,24 @@
         ( die lex ( nurl_str_cat `return expression has no value (expected `
         ( nurl_str_cat ( llvm_to_nurl fn_rt ) hint ) ) ) }
     {}
+    // Return-type agreement (narrow, never-valid clashes only — mirrors the
+    // binary-operator check). NURL has no implicit conversions, so returning a
+    // float where a non-float is declared (or vice versa), or a pointer/string
+    // where a non-pointer scalar is declared, used to emit `ret i64 <double>` /
+    // `ret i64 i8* …` that nurlc accepted (rc 0) and only clang rejected
+    // ("value doesn't match function result type"). Only these two directions
+    // are flagged so the null-as-`0` idiom (`^ 0` from a `*T`-returning fn) and
+    // loose pointer-to-pointer returns stay valid.
+    ? & & != 0 ( nurl_str_len fn_rt ) ! ( seq lt `void` ) ! ( seq fn_rt `void` )
+    {   : b ret_vf | ( seq lt `double` ) ( seq lt `float` )
+        : b ret_df | ( seq fn_rt `double` ) ( seq fn_rt `float` )
+        ? | != ret_vf ret_df & ( is_ptr_ty lt ) ! ( is_ptr_ty fn_rt )
+        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+            `return value type '` lt `' does not match the declared return type '` fn_rt )
+            `' — NURL has no implicit conversions; return a value of the declared type or convert with '# T expr'` ) ) }
+        {}
+    }
+    {}
     : s dtop ( nurl_sym_get syms `__defer_top__` )
     // Determine which owned-slice binding (if any) is escaping as the return value.
     // Ownership transfers only when the return type is itself a slice AND the
@@ -2244,6 +2262,32 @@
     // uniformly. ptrtoint is a no-op at the machine level, so this is
     // free. Arithmetic ops are untouched.
     : b is_cmp | & >= tt TT_LT <= tt TT_GE | == tt TT_EQEQ == tt TT_NE
+    // Operand-type agreement. NURL has NO implicit numeric conversions, so the
+    // two operands of an operator must already share a type (the "lt == rt for
+    // arithmetic operands" invariant noted above). Mixing an int and a float
+    // (`+ 1 1.0`, `* 2.0 3`, `== 1 1.0`), or a pointer/string and an integer in
+    // an arithmetic op (`+ `a` 1`), used to emit `add i64 1, 1.0` / `add i64
+    // i8* …` — IR nurlc accepted (rc 0) and only clang rejected ("floating
+    // point constant invalid for type" / "integer constant must have integer
+    // type"). Reject at the source. (Comparison ops stay exempt for the
+    // pointer cases — the ptrtoint coercion below compares `== ptr 0` and
+    // ptr↔ptr in i64; only the float/non-float split is enforced for them.)
+    : b lf | ( seq lt `double` ) ( seq lt `float` )
+    : b rf | ( seq rt `double` ) ( seq rt `float` )
+    ? != lf rf
+    { ( die lex ( nurl_str_cat ( nurl_str_cat4
+        `operator mixes a float and a non-float operand: left is '` lt
+        `', right is '` rt )
+        `' — NURL has no implicit numeric conversions; make both the same type (cast with '# f expr' or '# i expr')` ) ) }
+    {}
+    : b lp ( is_ptr_ty lt )
+    : b rp ( is_ptr_ty rt )
+    ? & ! is_cmp != lp rp
+    { ( die lex ( nurl_str_cat ( nurl_str_cat4
+        `arithmetic operator mixes a pointer/string and a non-pointer operand: left is '` lt
+        `', right is '` rt )
+        `' — operator-level pointer arithmetic is not supported; index with '. ptr idx' or convert explicitly` ) ) }
+    {}
     : ~ s cmp_ty lt
     ? & is_cmp | ( is_ptr_ty lt ) ( is_ptr_ty rt ) {
         ? ( is_ptr_ty lt ) {
@@ -8805,7 +8849,7 @@
 
                 // Widen i1 short-circuit / comparison results to the declared
                 // integer width before storing (`: i can_l & …` etc.).
-                : s widened_val ( coerce_store_val val vt ptype syms cg )
+                : s widened_val ( coerce_store_val lex val vt ptype syms cg )
                 // Handle closure to function pointer conversion
                 : s store_val ( convert_closure_arg widened_val vt ptype cg )
 
@@ -8987,7 +9031,7 @@
         // Widen i1 short-circuit / comparison results to the LHS's
         // declared integer width, so `= myi64 & a b` stores cleanly.
         : s rhs_ty ( nurl_get_last_type )
-        : s store_val ( coerce_store_val val rhs_ty vt syms cg )
+        : s store_val ( coerce_store_val lex val rhs_ty vt syms cg )
         ? != 0 ( nurl_str_len ptr )
         { ( nurl_print `  store ` ) ( nurl_print vt ) ( nurl_print ` ` )
             ( nurl_print store_val ) ( nurl_print `, ` ) ( nurl_print vt )
@@ -10726,7 +10770,10 @@
 // source is i1 and the destination is a non-i1 integer type, and is a
 // no-op in every other case. Placed here so both the let-binding and
 // `=`-assign paths can share it.
-@ coerce_store_val s val s from_ty s to_ty i syms i cg → s {
+@ coerce_store_val i lex s val s from_ty s to_ty i syms i cg → s {
+    // The void/unit value (a bare type keyword `v`) is never storable —
+    // `: i y v` / `= x v` used to emit `store i64 void`. Reject at the source.
+    ( die_if_void lex val `initialiser / assignment` )
     ? & ( seq from_ty `i1` ) ! ( seq to_ty `i1` )
     { : s r ( nurl_cg_reg cg )
         ( nurl_print `  ` ) ( nurl_print r )
@@ -10817,6 +10864,25 @@
             ( nurl_print from_ty ) ( nurl_print ` ` ) ( nurl_print val )
             ( nurl_print ` to ` ) ( nurl_print to_ty ) ( nurl_print `\n` )
             ^ r } }
+    {}
+    // No coercion above bridged from_ty → to_ty. If they are a never-valid
+    // mix — a float and a non-float, or a pointer/string stored into a
+    // non-pointer scalar — the caller would emit `store <to_ty> <val>` with
+    // disagreeing types: IR nurlc accepted (rc 0) and only clang rejected.
+    // Reject at the source (covers `: i x 1.5`, `: i x `hi``, `= n 1.5`).
+    // Equal types and every coercion above (i1-widen, enum-wrap, single-handle,
+    // int-width; closure→fn-ptr happens next in convert_closure_arg) never
+    // reach here as a clash. The reverse pointer direction (`: *T p 0`,
+    // null-as-0) is intentionally allowed.
+    ? & ! ( seq from_ty to_ty ) != 0 ( nurl_str_len to_ty )
+    {   : b csv_sf | ( seq from_ty `double` ) ( seq from_ty `float` )
+        : b csv_tf | ( seq to_ty `double` ) ( seq to_ty `float` )
+        ? | != csv_sf csv_tf & ( is_ptr_ty from_ty ) ! ( is_ptr_ty to_ty )
+        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+            `value of type '` from_ty `' cannot initialise / assign a binding of type '` to_ty )
+            `' — NURL has no implicit conversions; use a matching value or convert with '# T expr'` ) ) }
+        {}
+    }
     {}
     val
 }
@@ -11252,6 +11318,13 @@
     // exist in this lifted function). Restored on sym_pop (§7.4).
     ( nurl_sym_def body_syms `__owned_closure_envs__` `` )
     ( nurl_sym_def body_syms `__in_call_arg__` `` )
+    // The closure body's `^` returns from the CLOSURE, not the enclosing
+    // function — shadow the return-type key with the closure's own return
+    // type so gen_ret's return-value diagnostics (void-return and the
+    // return-type-agreement check) compare against the right type. Restored
+    // on sym_pop. Without this, `^ msg` in `\ → s { ^ msg }` was checked
+    // against the enclosing fn's return type.
+    ( nurl_sym_def body_syms `__fn_ret_ty__` ret_type )
 
     // Register closure parameters
     : ~ s bp_types param_types
@@ -13365,6 +13438,16 @@
     : ~ i fidx 0
     ~ != ( nurl_lex_type lex ) TT_RBRACE {
         : s flt ( parse_type lex )
+        // A field whose type is the struct itself BY VALUE makes the struct
+        // infinitely sized (`: Node { i v  Node next }`). LLVM only rejects the
+        // recursive value type later, at an `insertvalue` / `store` use site,
+        // with a cryptic "operand and field disagree in type". Catch it at the
+        // declaration with the canonical cure: box the field as a pointer.
+        ? ( seq flt ( nurl_str_cat `%` sname ) )
+        { ( die lex ( nurl_str_cat ( nurl_str_cat3
+            `recursive struct '` sname `' has infinite size — a field holds the struct itself by value. Box it as a pointer: '* ` )
+            ( nurl_str_cat sname `'` ) ) ) }
+        {}
         ? ( is_ident_tok ( nurl_lex_type lex ) )
         { : s fname ( nurl_lex_val lex )
             ( nurl_lex_advance lex )

--- a/compiler/tests/outputs/should_fail_assign_type_mismatch.txt
+++ b/compiler/tests/outputs/should_fail_assign_type_mismatch.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_binop_int_float.txt
+++ b/compiler/tests/outputs/should_fail_binop_int_float.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_binop_ptr_int.txt
+++ b/compiler/tests/outputs/should_fail_binop_ptr_int.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_let_type_mismatch.txt
+++ b/compiler/tests/outputs/should_fail_let_type_mismatch.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_recursive_struct.txt
+++ b/compiler/tests/outputs/should_fail_recursive_struct.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_return_type_mismatch.txt
+++ b/compiler/tests/outputs/should_fail_return_type_mismatch.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_store_void.txt
+++ b/compiler/tests/outputs/should_fail_store_void.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_assign_type_mismatch.nu
+++ b/compiler/tests/should_fail_assign_type_mismatch.nu
@@ -1,0 +1,3 @@
+// should_fail_assign_type_mismatch.nu — assigning a float to an int binding
+// (`= n 1.5`). Same store-clash guard as the let path.
+@ main → i { : ~ i n 0  = n 1.5  ^ 0 }

--- a/compiler/tests/should_fail_binop_int_float.nu
+++ b/compiler/tests/should_fail_binop_int_float.nu
@@ -1,0 +1,4 @@
+// should_fail_binop_int_float.nu — mixing an int and a float in one operator.
+// NURL has no implicit numeric conversions; `+ 1 1.0` used to emit
+// `add i64 1, 1.0` that only clang rejected. gen_binary now rejects it.
+@ main → i { : f x + 1 1.0  ^ 0 }

--- a/compiler/tests/should_fail_binop_ptr_int.nu
+++ b/compiler/tests/should_fail_binop_ptr_int.nu
@@ -1,0 +1,4 @@
+// should_fail_binop_ptr_int.nu — arithmetic mixing a string/pointer and an
+// integer (`+ `a` 1`). Operator-level pointer arithmetic is unsupported and
+// used to emit `add i64 i8* …`. gen_binary now rejects it.
+@ main → i { : s x + `a` 1  ^ 0 }

--- a/compiler/tests/should_fail_let_type_mismatch.nu
+++ b/compiler/tests/should_fail_let_type_mismatch.nu
@@ -1,0 +1,4 @@
+// should_fail_let_type_mismatch.nu — an annotated binding initialised from a
+// value of an incompatible type (`: i x 1.5`). coerce_store_val now rejects
+// the never-valid float/non-float and pointer/non-pointer store clashes.
+@ main → i { : i x 1.5  ^ 0 }

--- a/compiler/tests/should_fail_recursive_struct.nu
+++ b/compiler/tests/should_fail_recursive_struct.nu
@@ -1,0 +1,6 @@
+// should_fail_recursive_struct.nu — a struct that contains itself by value
+// has infinite size (`: Node { i v  Node next }`). gen_struct_decl now
+// diagnoses it at the declaration with the box-it-as-a-pointer cure, instead
+// of a cryptic insertvalue IR error at the first construction.
+: Node { i v  Node next }
+@ main → i { ^ 0 }

--- a/compiler/tests/should_fail_return_type_mismatch.nu
+++ b/compiler/tests/should_fail_return_type_mismatch.nu
@@ -1,0 +1,5 @@
+// should_fail_return_type_mismatch.nu — returning a value whose type clashes
+// with the declared return type (`^ `hi`` from a `→ i` function). gen_ret now
+// rejects the never-valid float/non-float and pointer/non-pointer cases.
+@ f → i { ^ `hi` }
+@ main → i { ^ ( f ) }

--- a/compiler/tests/should_fail_store_void.nu
+++ b/compiler/tests/should_fail_store_void.nu
@@ -1,0 +1,4 @@
+// should_fail_store_void.nu — the void/unit value (a bare type keyword `v`)
+// cannot initialise a binding (`: i y v`). Rejected at the source instead of
+// emitting `store i64 void`.
+@ main → i { : i y v  ^ 0 }


### PR DESCRIPTION
## Summary

A sharper second adversarial sweep (deeper, meaner inputs — the "angry redditor in 5 minutes" threat model) found that a whole family of **trivial type errors** was accepted by `nurlc` with rc 0 and **no diagnostic**, emitting IR that only `clang` later rejected. These are the worst optics for a pre-1.0 language — they read as "there is no type checker."

All are now rejected at the source with a clear NURL diagnostic. **No implicit conversions are introduced** — NURL stays explicit; the fixes only reject what was already invalid. Full suite: **428 pass / 0 fail**, bootstrap fixed point holds.

## Fixes

| Input | Before | After |
|---|---|---|
| `+ 1 1.0`, `* 2.0 3`, `== 1 1.0` | `add i64 1, 1.0` → clang error | `operator mixes a float and a non-float operand …` |
| `+ \`a\` 1` | `add i64 i8* …` → clang error | `arithmetic operator mixes a pointer/string and a non-pointer operand …` |
| `: i x 1.5`, `: i x \`hi\`` | `store i64 <double>` → clang error | `value of type 'double' cannot initialise … a binding of type 'i64' …` |
| `= n 1.5` | same | same store-clash guard |
| `^ \`hi\`` / `^ 1.5` from `→ i` | `ret i64 <…>` → clang error | `return value type '…' does not match the declared return type 'i64' …` |
| `: i y v`, `= x v` | `store i64 void` → clang error | `… operand is the void/unit value 'v' …` |
| `: Node { i v  Node next }` | cryptic `insertvalue operand and field disagree` at first use | `recursive struct 'Node' has infinite size … Box it as a pointer: '* Node'` |

### Where the checks live
- **`gen_binary`** — enforces the "operands share a type" invariant it already documented. Float-vs-non-float is rejected for every operator; pointer-vs-integer only for arithmetic ops (comparisons keep the existing `ptrtoint` coercion for `== ptr 0` / ptr↔ptr).
- **`coerce_store_val`** (the shared let-init + assignment + store chokepoint) — rejects never-valid float/non-float and pointer-into-non-pointer clashes *after* its real coercions (i1-widen, enum-wrap, single-handle, int-width) have run. The null-as-`0` idiom (`: *T p 0`) stays valid. Threaded a `lex` param through its two callers for the diagnostic location.
- **`gen_ret`** — checks returned-value type vs declared return type (same narrow never-valid directions).
- **`gen_struct_decl`** — flags a by-value self-referential field at declaration.
- **`gen_closure_expr`** — the closure body scope now shadows `__fn_ret_ty__` with the closure's own return type, so `gen_ret`'s checks compare against the right type inside closures (also corrects the pre-existing void-return diagnostic there).

## Design notes

- The checks are deliberately **narrow** — only the *never-valid* type combinations (float ↔ non-float, pointer/string → non-pointer scalar) are flagged, plus the void literal and direct struct self-reference. Loose-but-valid behaviour the compiler already supports (int-width widening `: i32 w 5`, null-as-`0`, pointer↔pointer returns, enum/handle store wrapping) is untouched. This is why the full suite passes with zero changes to existing golden output.
- `: f y 5` is now (correctly) rejected: an `i64` literal does not implicitly become `double`. Consistent with NURL's no-implicit-conversion rule; write `5.0` or `# f 5`.

## Tests

7 new `should_fail_*` regressions: `binop_int_float`, `binop_ptr_int`, `let_type_mismatch`, `assign_type_mismatch`, `return_type_mismatch`, `recursive_struct`, `store_void`. No existing golden output changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)