### PR TITLE
fix(compiler): stop nurlc hanging on unterminated declaration bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Compiler no longer hangs on an unterminated declaration body (fuzz sweep).**
+  A corpus-seeded mutation fuzzer (36k + 15k mutants over `build/nurlc`; oracle:
+  never crash, never hang, and rc 0 ⇒ the IR assembles) found **zero crashes**
+  but a class of infinite loops: several body-parsing loops checked only for
+  their closing token (`}` / `)` / `]`) and not for end-of-input, so an
+  unterminated construct spun forever on a no-op `nurl_lex_advance` at EOF
+  instead of erroring. A playground user mid-keystroke (or any truncated file)
+  could wedge the compiler. Fixed by adding an EOF guard to every such loop and
+  letting the trailing `expect` report a clean "expected '}' / ')' / ']' but
+  found end of input":
+  - enum-variant loop (`: | E { A`),
+  - trait/impl scan + gen loops and the method-signature skip
+    (`% Shape { @ area i s → i`, `% Shape i { …`),
+  - the `[T]` type-param skip, and
+  - `parse_type_paren`'s generic-application and closure-type argument loops
+    (`( Vec i`, reachable in any type position).
+  Struct / match / block / call-argument bodies already terminated (their inner
+  sub-parsers hit EOF first) and were left unchanged. 15k post-fix mutants
+  produce no hangs and no crashes. Locks `should_fail_unterminated_enum`,
+  `_trait`, `_impl`, `_type_paren`.
+
 - **Front-end type checking for the common static-error class (adversarial
   sweep #3).** A sharper probing pass found that a whole family of trivial type
   errors was accepted by `nurlc` (rc 0, no diagnostic) and emitted IR that only

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -321,7 +321,7 @@
     { ( nurl_lex_advance lex )  // consume '@'
         : s ret ( parse_type lex )
         : ~ s params ``
-        ~ != ( nurl_lex_type lex ) TT_RPAREN {
+        ~ & != ( nurl_lex_type lex ) TT_RPAREN != ( nurl_lex_type lex ) TT_EOF {
             : s p ( parse_type lex )
             = params ? == 0 ( nurl_str_len params )
             p
@@ -346,7 +346,11 @@
             ( nurl_lex_advance lex )
             : ~ s mangle_sfx ``
             : ~ b has_tparam_arg F
-            ~ != ( nurl_lex_type lex ) TT_RPAREN {
+            // EOF guard: an unterminated type application `( Name a b …` (which
+            // can be reached as an enum payload type, e.g. a stray `( foo` with
+            // no `)`) otherwise spins here on a no-op `nurl_lex_advance` at EOF.
+            // The trailing `expect TT_RPAREN` reports a clean error.
+            ~ & != ( nurl_lex_type lex ) TT_RPAREN != ( nurl_lex_type lex ) TT_EOF {
                 : ~ s ta_lty ``
                 : i ta_tt ( nurl_lex_type lex )
                 // A bare anonymous slice (`[ T`) is the one type shape the
@@ -14165,7 +14169,15 @@
     : ~ i tag 0
     : ~ i max_payloads 0
     : ~ s variants_str ``
-    ~ != ( nurl_lex_type lex ) TT_RBRACE {
+    // Stop at '}' OR end-of-input. Without the EOF guard an unterminated enum
+    // body (`: | E { A`, or a stray `//` comment eating the closing brace on a
+    // single-line source) spun this loop forever: `nurl_lex_advance` is a
+    // no-op at EOF, so the loop kept minting empty variants and never
+    // progressed — nurlc hung instead of erroring. The trailing
+    // `expect TT_RBRACE` then reports a clean "expected '}' but found end of
+    // input" at the EOF. (Struct / match / block bodies already terminate
+    // because their inner sub-parsers hit EOF first.)
+    ~ & != ( nurl_lex_type lex ) TT_RBRACE != ( nurl_lex_type lex ) TT_EOF {
         : s vname ( nurl_lex_val lex )
         ( nurl_lex_advance lex )
         = variants_str ? == 0 ( nurl_str_len variants_str )
@@ -15082,7 +15094,10 @@
     // when a consumer impls it / calls its methods.
     ( lint_note_def tname )
     ( expect lex TT_LBRACE )
-    ~ != ( nurl_lex_type lex ) TT_RBRACE {
+    // EOF guards on both loops: an unterminated trait body (`% T {`, or a
+    // method header with no following `{`/`@`/`}` at EOF) otherwise spins on
+    // no-op `nurl_lex_advance` forever — nurlc hung instead of erroring.
+    ~ & != ( nurl_lex_type lex ) TT_RBRACE != ( nurl_lex_type lex ) TT_EOF {
         ? == ( nurl_lex_type lex ) TT_AT
         { ( nurl_lex_advance lex )  // skip '@'
             ? ( is_ident_tok ( nurl_lex_type lex ) )
@@ -15092,9 +15107,10 @@
                 : i sig_start ( nurl_lex_cur_start lex )
                 // Skip params / → / ret_ty until we hit '{' (body), next '@',
                 // or '}' (end of trait).
-                ~ & & != ( nurl_lex_type lex ) TT_LBRACE
+                ~ & & & != ( nurl_lex_type lex ) TT_LBRACE
                 != ( nurl_lex_type lex ) TT_AT
-                != ( nurl_lex_type lex ) TT_RBRACE {
+                != ( nurl_lex_type lex ) TT_RBRACE
+                != ( nurl_lex_type lex ) TT_EOF {
                     ( nurl_lex_advance lex )
                 }
                 ? == ( nurl_lex_type lex ) TT_LBRACE
@@ -15118,7 +15134,7 @@
         }
         { ( nurl_lex_advance lex ) }
     }
-    ( nurl_lex_advance lex )  // consume '}'
+    ( expect lex TT_RBRACE )  // consume '}' — clean error if unterminated at EOF
 }
 
 // trait_default_ret: given a default method's substituted source
@@ -15194,8 +15210,8 @@
         ? | ( is_ident_tok tpt ) == tpt TT_BOOL
         { = tparam ( nurl_lex_val lex ) }
         {}
-        ~ != ( nurl_lex_type lex ) TT_RBRACK { ( nurl_lex_advance lex ) }
-        ( nurl_lex_advance lex )  // ']'
+        ~ & != ( nurl_lex_type lex ) TT_RBRACK != ( nurl_lex_type lex ) TT_EOF { ( nurl_lex_advance lex ) }
+        ( expect lex TT_RBRACK )  // ']'
     }
     {}
     // Disambiguate: '{' → trait_decl, else → impl_decl
@@ -15213,7 +15229,7 @@
         ( nurl_sym_def g_trait_syms ( nurl_str_cat3 tname `##` impl_llvm ) `1` )
         ( expect lex TT_LBRACE )
         : ~ s provided ``
-        ~ != ( nurl_lex_type lex ) TT_RBRACE {
+        ~ & != ( nurl_lex_type lex ) TT_RBRACE != ( nurl_lex_type lex ) TT_EOF {
             ? == ( nurl_lex_type lex ) TT_AT
             { ( nurl_lex_advance lex )  // skip '@'
                 ? ( is_ident_tok ( nurl_lex_type lex ) )
@@ -15246,7 +15262,7 @@
             }
             { ( nurl_lex_advance lex ) }
         }
-        ( nurl_lex_advance lex )  // consume '}'
+        ( expect lex TT_RBRACE )  // consume '}' — clean error if unterminated at EOF
         // After the impl's explicit methods, synthesize dispatch entries for
         // any of the trait's defaults that this impl did not override.
         ? != 0 ( nurl_str_len impl_nurl )
@@ -15298,8 +15314,8 @@
     // Skip optional type params [T] (already captured during scan)
     ? == ( nurl_lex_type lex ) TT_LBRACK
     { ( nurl_lex_advance lex )
-        ~ != ( nurl_lex_type lex ) TT_RBRACK { ( nurl_lex_advance lex ) }
-        ( nurl_lex_advance lex )  // ']'
+        ~ & != ( nurl_lex_type lex ) TT_RBRACK != ( nurl_lex_type lex ) TT_EOF { ( nurl_lex_advance lex ) }
+        ( expect lex TT_RBRACK )  // ']'
     }
     {}
     // Disambiguate: '{' → trait_decl (no IR), else → impl_decl
@@ -15311,7 +15327,7 @@
         : s impl_mangle ( mangle_type impl_llvm )
         ( expect lex TT_LBRACE )
         : ~ s provided ``
-        ~ != ( nurl_lex_type lex ) TT_RBRACE {
+        ~ & != ( nurl_lex_type lex ) TT_RBRACE != ( nurl_lex_type lex ) TT_EOF {
             ? == ( nurl_lex_type lex ) TT_AT
             { ( nurl_lex_advance lex )  // skip '@'
                 ? ( is_ident_tok ( nurl_lex_type lex ) )
@@ -15355,7 +15371,7 @@
             }
             { ( nurl_lex_advance lex ) }
         }
-        ( nurl_lex_advance lex )  // consume '}'
+        ( expect lex TT_RBRACE )  // consume '}' — clean error if unterminated at EOF
         // Synthesize trait-default copies for any method the impl omitted.
         ? != 0 ( nurl_str_len impl_nurl )
         { ( emit_missing_defaults tname impl_nurl impl_mangle provided syms cg ) }

--- a/compiler/tests/outputs/should_fail_unterminated_enum.txt
+++ b/compiler/tests/outputs/should_fail_unterminated_enum.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_unterminated_impl.txt
+++ b/compiler/tests/outputs/should_fail_unterminated_impl.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_unterminated_trait.txt
+++ b/compiler/tests/outputs/should_fail_unterminated_trait.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_unterminated_type_paren.txt
+++ b/compiler/tests/outputs/should_fail_unterminated_type_paren.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_unterminated_enum.nu
+++ b/compiler/tests/should_fail_unterminated_enum.nu
@@ -1,0 +1,3 @@
+// should_fail_unterminated_enum.nu — an unterminated enum body must error,
+// not hang. The enum-variant loop used to spin on a no-op advance at EOF.
+: | Event { Click i

--- a/compiler/tests/should_fail_unterminated_impl.nu
+++ b/compiler/tests/should_fail_unterminated_impl.nu
@@ -1,0 +1,3 @@
+// should_fail_unterminated_impl.nu — an unterminated impl body used to hang
+// both the scan pass and the gen pass.
+% Shape i { @ area i s → i

--- a/compiler/tests/should_fail_unterminated_trait.nu
+++ b/compiler/tests/should_fail_unterminated_trait.nu
@@ -1,0 +1,3 @@
+// should_fail_unterminated_trait.nu — an unterminated trait body (here a
+// method header with no following body/`}`) used to hang the scan pass.
+% Shape { @ area i s → i

--- a/compiler/tests/should_fail_unterminated_type_paren.nu
+++ b/compiler/tests/should_fail_unterminated_type_paren.nu
@@ -1,0 +1,4 @@
+// should_fail_unterminated_type_paren.nu — an unterminated type application
+// `( Name …` (reachable in any type position) used to spin parse_type_paren
+// on a no-op advance at EOF.
+: S { ( Vec i


### PR DESCRIPTION
## Summary

Round 3 switched from hand-crafted probing to **mutation fuzzing**: a corpus-seeded fuzzer mutates the existing `examples/` + `stdlib/` + `compiler/tests/` programs (token swap/dup/delete, splice, truncate, delimiter/number tweaks) and runs each mutant through `build/nurlc`. The oracle is cheap and reliable for the threat model that matters most — *the compiler itself must never crash, never hang, and if it returns 0 the IR must assemble* (`llvm-as`).

**Result over ~51k mutants: zero crashes (no segfaults), and one class of infinite loops** — the worst playground/"angry-redditor" optics, since any incomplete or truncated source could wedge `nurlc`.

## The bug

Several declaration-body parsing loops checked only for their closing token (`}` / `)` / `]`) and **not** for end-of-input. At EOF, `nurl_lex_advance` is a no-op, so an unterminated construct spun the loop forever instead of erroring. Minimal repros that used to hang:

```
: | E { A                    // unterminated enum
% Shape { @ area i s → i      // unterminated trait
% Shape i { @ area i s → i    // unterminated impl
: S { ( Vec i                 // unterminated generic type application
```

## Fix

An EOF guard on each affected loop, with the trailing `expect` now reporting a clean *"expected '}' / ')' / ']' but found end of input"*:

- `gen_enum_decl` enum-variant loop
- `scan_trait_body` outer loop + method-signature skip loop
- `scan_impl_decl` / `gen_trait_or_impl` impl-method loops
- the `[T]` type-param skip loops
- `parse_type_paren` generic-application and closure-type argument loops (reachable in any type position — this was the last straggler, hit when a mutated enum payload contained a `(`)

Struct / match / block / call-argument bodies already terminated (their inner sub-parsers hit EOF first) and are left unchanged.

## Verification

- All 6 original fuzzer hang findings now error in <1s.
- A **clean** post-fix re-fuzz (15k mutants, no concurrent load): **0 hangs, 0 crashes**. (An earlier re-fuzz showed false "hangs" that were slow-compiles under CPU contention — none reproduce single-threaded.)
- 4 new `should_fail_*` regressions: `unterminated_enum`, `_trait`, `_impl`, `_type_paren`.
- Bootstrap fixed point holds; full suite **432 pass / 0 fail**.

## Not in this PR

The fuzzer also flagged a handful of `BAD_IR` cases (nurlc emits clang-rejected IR — undefined type name, invalid cast/extractvalue, undefined value) on heavily-mutated input. These are the broader "front-end doesn't type-check every codegen path" class, need contrived input, and are deferred to a future round rather than patched piecemeal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)