### PR TITLE
fix(compiler): diagnose unknown type names instead of emitting undefined %Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Unknown type names are diagnosed at the source (fuzz follow-up).** An
+  undeclared type identifier in a type position — an FFI parameter/return type,
+  a function parameter/return type, or a struct field type — used to leak into
+  the IR as an undefined `%Name` that `nurlc` emitted with status 0 and only
+  `clang` / `llvm-as` rejected ("use of undefined type named 'X'", or the
+  cryptic "cannot allocate unsized type"). A typo'd type name or a missing `$`
+  import now produces *"unknown type 'X' … (a typo, or a missing '$' import?)"*
+  pointing at the use. The new `check_type_known` scans the emitted LLVM type
+  for `%Name` references and verifies each against the pre-scan type registry;
+  generic type variables (tparam-like, substituted at monomorphisation) and
+  compiler-mangled names (containing `__`, e.g. a `%Vec__i64` instantiation or
+  an aliased import) are accepted unchanged, so generics and imports are
+  unaffected. Locks `should_fail_unknown_type_{ffi,param,return,field}`.
+
 - **Compiler no longer hangs on an unterminated declaration body (fuzz sweep).**
   A corpus-seeded mutation fuzzer (36k + 15k mutants over `build/nurlc`; oracle:
   never crash, never hang, and rc 0 ⇒ the IR assembles) found **zero crashes**

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -12542,6 +12542,52 @@
     ? & >= c1 48 <= c1 57 { ^ T } { ^ F }
 }
 
+// __has_dunder: true if `str` contains "__" — the mark of a compiler-mangled
+// name (a generic instantiation like `Vec__i64`, an aliased import). Such
+// names are always compiler-produced, never a user-typed type name.
+@ __has_dunder s str → b {
+    : i n ( nurl_str_len str )
+    : ~ i i 0
+    ~ < i - n 1 {
+        ? & == ( nurl_str_get str i ) 95 == ( nurl_str_get str + i 1 ) 95 { ^ T } {}
+        = i + i 1
+    }
+    F
+}
+
+// check_type_known: scan an emitted LLVM type string for `%Name` references
+// and reject any that names no declared type. A bare unknown type name (a
+// typo, or a missing `$` import) otherwise leaks into the IR as an undefined
+// `%Name` that nurlc emits with status 0 and only clang / llvm-as rejects
+// ("use of undefined type named 'X'", or the cryptic "cannot allocate unsized
+// type"). Accepted silently: generic type variables (tparam-like — substituted
+// during monomorphisation) and compiler-mangled names (contain `__`, e.g. a
+// `%Vec__i64` instantiation). `syms` carries every declared struct/enum from
+// the pre-scan, so the registry lookup is reliable regardless of declaration
+// order. `ctx` names the position for the diagnostic.
+@ check_type_known i lex i syms s llvm_ty s ctx → v {
+    : i n ( nurl_str_len llvm_ty )
+    : ~ i i 0
+    ~ < i n {
+        ? == ( nurl_str_get llvm_ty i ) 37   // '%'
+        { : ~ i j + i 1
+            ~ & < j n ( __is_ident_char ( nurl_str_get llvm_ty j ) ) { = j + j 1 }
+            : s name ( nurl_str_slice llvm_ty + i 1 - j + i 1 )
+            ? != 0 ( nurl_str_len name )
+            { ? ( is_tparam_like name ) {}
+                { ? ( __has_dunder name ) {}
+                    { ? == 0 ( nurl_str_len ( nurl_sym_get syms name ) )
+                        { ( die lex ( nurl_str_cat
+                            ( nurl_str_cat3 `unknown type '` name `' in ` )
+                            ( nurl_str_cat ctx ` — no struct or enum with this name is declared (a typo, or a missing '$' import?)` ) ) ) }
+                        {} } } }
+            {}
+            = i j
+        }
+        { = i + i 1 }
+    }
+}
+
 // Unknown-generic check for parse_type_paren (critic A7). Defined here
 // (after the g_generic_struct_syms / g_struct_inst_syms globals) and
 // forward-called from the parser: globals cannot be forward-referenced,
@@ -12833,6 +12879,7 @@
             ( nurl_str_cat3 sink_acc ` ` ( nurl_str_int pct ) ) }
         {}
         = params_str ( nurl_get_last_type )
+        ( check_type_known lex syms params_str `a parameter type` )
         = pct + pct 1
     }
     // Publish this function's inout / sink
@@ -12848,6 +12895,7 @@
     ( nurl_sym_def g_res_type_syms `__last_res_err_llvm__` `` )
     ( nurl_sym_def g_res_type_syms `__last_opt_nurl_t__` `` )
     : s ret_ty ( parse_type lex )
+    ( check_type_known lex syms ret_ty `the return type` )
     : s nurl_ret ( nurl_sym_get g_res_type_syms `__last_res_nurl__` )
     // LLVM type of the Ok-payload T (e.g. `%Vec__i8` for `! ( Vec u ) s`,
     // `i8*` for `! s E`). Recorded per-function — mirrors `<fname>__nurl_ret`
@@ -13452,6 +13500,7 @@
             `recursive struct '` sname `' has infinite size — a field holds the struct itself by value. Box it as a pointer: '* ` )
             ( nurl_str_cat sname `'` ) ) ) }
         {}
+        ( check_type_known lex syms flt `a struct field type` )
         ? ( is_ident_tok ( nurl_lex_type lex ) )
         { : s fname ( nurl_lex_val lex )
             ( nurl_lex_advance lex )
@@ -13760,6 +13809,7 @@
             ( nurl_sym_def syms ( nurl_str_cat fname `__variadic_sig` ) params_str )
         }
         { : s lt ( parse_type lex )
+            ( check_type_known lex syms lt `an FFI parameter type` )
             ? ( is_ident_tok ( nurl_lex_type lex ) ) { ( nurl_lex_advance lex ) } {}
             ? == pct 0
             { = params_str lt }
@@ -13769,6 +13819,7 @@
     }
     ( expect lex TT_ARROW )
     : s ret_ty ( parse_type lex )
+    ( check_type_known lex syms ret_ty `the FFI return type` )
     ( nurl_sym_def syms fname ret_ty )
     // Mark this name as a callable FFI symbol. gen_stmt's bare-ident-
     // as-statement check (critic v0.9.0 §1) uses this to die on

--- a/compiler/tests/outputs/should_fail_unknown_type_ffi.txt
+++ b/compiler/tests/outputs/should_fail_unknown_type_ffi.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_unknown_type_field.txt
+++ b/compiler/tests/outputs/should_fail_unknown_type_field.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_unknown_type_param.txt
+++ b/compiler/tests/outputs/should_fail_unknown_type_param.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_unknown_type_return.txt
+++ b/compiler/tests/outputs/should_fail_unknown_type_return.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_unknown_type_ffi.nu
+++ b/compiler/tests/should_fail_unknown_type_ffi.nu
@@ -1,0 +1,5 @@
+// should_fail_unknown_type_ffi.nu — an FFI declaration whose return type
+// names no declared type used to leak `%Zorp` into the IR (only clang/llvm-as
+// rejected it). check_type_known now reports it at the source.
+& `libc` @ foo → Zorp
+@ main → i { ^ 0 }

--- a/compiler/tests/should_fail_unknown_type_field.nu
+++ b/compiler/tests/should_fail_unknown_type_field.nu
@@ -1,0 +1,3 @@
+// should_fail_unknown_type_field.nu — a struct field of an undeclared type.
+: S { Zorp x }
+@ main → i { ^ 0 }

--- a/compiler/tests/should_fail_unknown_type_param.nu
+++ b/compiler/tests/should_fail_unknown_type_param.nu
@@ -1,0 +1,4 @@
+// should_fail_unknown_type_param.nu — a function parameter of an undeclared
+// type. Caught at the source instead of emitting an undefined `%Zorp`.
+@ f Zorp x → i { ^ 0 }
+@ main → i { ^ 0 }

--- a/compiler/tests/should_fail_unknown_type_return.nu
+++ b/compiler/tests/should_fail_unknown_type_return.nu
@@ -1,0 +1,4 @@
+// should_fail_unknown_type_return.nu — a function return type that names no
+// declared type.
+@ f i x → Zorp { ^ 0 }
+@ main → i { ^ 0 }


### PR DESCRIPTION
## Summary

Continuing the fuzzer work. After round 3 eliminated the hang class, the fuzzer's remaining signal is the **BAD_IR** class (nurlc returns 0 but emits IR `clang`/`llvm-as` rejects). The most common and most *realistic* of these — the only one that maps to an everyday user mistake rather than deeply-corrupted input — is an **unknown type name**.

An undeclared type identifier in a type position leaked into the IR as an undefined `%Name`:

```
& `libc` @ foo → Zorp      // FFI return
@ f Zorp x → i { … }       // parameter
@ f i x → Zorp { … }       // return
: S { Zorp x }             // struct field
```

`nurlc` accepted all of these (rc 0); only `clang`/`llvm-as` later rejected them with *"use of undefined type named 'Zorp'"* or the cryptic *"cannot allocate unsized type"*. A typo'd struct name or a forgotten `$` import would hit this.

## Fix

New `check_type_known lex syms llvm_ty ctx` scans an emitted LLVM type string for `%Name` references and verifies each names a declared type, reporting *"unknown type 'X' … (a typo, or a missing '$' import?)"* at the use site. Wired at the FFI, function (param + return), and struct-field declaration sites.

Accepted **without** complaint, so generics and imports are unaffected:
- **generic type variables** — `is_tparam_like` (the `T`/`K`/`V`/`A1` shape); they're substituted at monomorphisation.
- **compiler-mangled names** — anything containing `__` (a `%Vec__i64` instantiation, an aliased import `mod__name`); always compiler-produced, never a user typo.

The pre-scan registers every struct/enum name into `syms` before any decl is emitted, so the registry lookup is reliable regardless of declaration order (forward references and self-references work).

## Verification

- All four positions now produce a clean `nurlc` diagnostic; the original fuzzer finding (`& … @ … → canvas_open` after a mutation) now errors cleanly.
- No false positives: generic functions/structs, real structs, primitive FFI, and the whole existing corpus compile unchanged — **436 pass / 0 fail**, bootstrap holds.
- 4 `should_fail_*` regressions; no existing golden output changed.

## Scope

Runtime semantics are unchanged — this only moves a clang-stage error to a nurlc-stage diagnostic. The other (rarer, contrived-input) BAD_IR shapes the fuzzer found — invalid cast/extractvalue, undefined value — are deeper per-codegen-path type-soundness gaps left for a future round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)