### PR TITLE
fix(compiler): diagnose type/field misuse at the source (fuzz follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **More front-end checks for type/field misuse (fuzz follow-up #2).** The
+  mutation fuzzer's remaining `BAD_IR` shapes (nurlc rc 0, only clang/llvm-as
+  rejecting) were turned into source diagnostics — and one of the new checks
+  caught a genuine latent bug in the corpus:
+  - **A function / FFI symbol name used where a type is expected** now reports
+    *"unknown type 'X'"*. The earlier unknown-type check accepted any name in
+    scope; it now requires a `%`-type, so `@ f rand x → i` (using the FFI symbol
+    `rand` as a parameter type) is rejected too.
+  - **`.` field/element access on a non-aggregate scalar** (`. n x` with `n : i`)
+    is rejected — it used to emit `extractvalue i64 …`.
+  - **An out-of-range integer index into an aggregate** (`. p 9` on a 2-field
+    struct) is rejected — it used to emit an invalid `extractvalue …, 9`.
+  - **Accessing a field a struct does not have** (`. p nope`) now reports
+    *"type 'P' has no field 'nope'"* instead of silently reading field 0 (a
+    miscompile) — this exposed and fixed a real `. pho req` typo in
+    `compiler/tests/websocket_client.nu` that had been reading the right field
+    (`head`, index 0) only by luck.
+  - **An FFI declaration whose `@` is not followed by an identifier**
+    (`& "lib" @ @ foo`) is rejected with *"expected the C function name …"*.
+  Locks `should_fail_{type_is_fn_name, member_on_scalar, member_index_oob,
+  unknown_field, ffi_no_name}`. (Remaining, deferred: a `??` arm that binds more
+  payloads than its variant/option has still emits an out-of-range
+  `extractvalue` — a `gen_match` concern for a future round.)
+
 - **Unknown type names are diagnosed at the source (fuzz follow-up).** An
   undeclared type identifier in a type position — an FFI parameter/return type,
   a function parameter/return type, or a struct field type — used to leak into

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -415,6 +415,36 @@
     `i64`
 }
 
+// agg_field_count: number of fields in an aggregate LLVM type, or -1 when
+// unknown (so the caller skips range-checking rather than risk a false
+// positive). A named struct `%T` reads its registered `<T>__field_count`; an
+// inline aggregate `{ … }` counts the top-level comma separators (depth-aware,
+// so nested `{ }` / `( )` don't inflate the count). Used by gen_member to
+// reject an out-of-range `. agg INT` before it emits an invalid extractvalue.
+@ agg_field_count i syms s ot → i {
+    : i n ( nurl_str_len ot )
+    ? == 0 n { ^ -1 } {}
+    ? == ( nurl_str_get ot 0 ) 37
+    { : s nm ( nurl_str_slice ot 1 - n 1 )
+        : s fc ( nurl_sym_get syms ( nurl_str_cat nm `__field_count` ) )
+        ? != 0 ( nurl_str_len fc ) { ^ ( nurl_str_to_int fc ) } { ^ -1 } }
+    {}
+    ? == ( nurl_str_get ot 0 ) 123
+    { : ~ i depth 0
+        : ~ i count 1
+        : ~ i i 0
+        ~ < i n {
+            : i c ( nurl_str_get ot i )
+            ? | == c 123 == c 40 { = depth + depth 1 } {}
+            ? | == c 125 == c 41 { = depth - depth 1 } {}
+            ? & == depth 1 == c 44 { = count + count 1 } {}
+            = i + i 1
+        }
+        ^ count }
+    {}
+    -1
+}
+
 // ? T  →  { i1, T }
 // Side-channel: "__last_opt_nurl_t__" stashes T's NURL source token
 // (e.g. "u" / "i32" / "String") so gen_let_or_struct can propagate
@@ -9886,7 +9916,18 @@
             }
         }
     }
-    {  // Non-pointer type: handle struct field access or aggregate indexing
+    {  // Non-pointer type: handle struct field access or aggregate indexing.
+        // A field / element access requires an aggregate: a named struct/enum
+        // (`%T`), or an opt / res / slice / closure record (`{ … }`). A scalar
+        // primitive (i64 / double / i1 / i8 / …) has no fields — `. n x` or
+        // `. n 0` on an `i` binding used to emit `extractvalue i64 …`, IR that
+        // nurlc accepted (rc 0) and only clang / llvm-as rejected ("extractvalue
+        // operand must be aggregate type"). Reject it at the source.
+        ? != 0 ( nurl_str_len ot )
+        { ? & != ( nurl_str_get ot 0 ) 123 != ( nurl_str_get ot 0 ) 37
+            { ( die lex ( nurl_str_cat3 `cannot access a field or element of '` ( llvm_to_nurl ot ) `' — it is not a struct, enum, slice, or pointer` ) ) }
+            {} }
+        {}
         ? == ( nurl_lex_type lex ) TT_INT
         {  // Integer literal index for aggregate types
             : i idx ( nurl_lex_inum lex )
@@ -9902,7 +9943,17 @@
                 ( nurl_set_last_type ot )
                 ^ ov
             }
-            {  // Extractvalue for specific field (idx > 0) or primitive types
+            {  // Extractvalue for specific field (idx > 0) or primitive types.
+                // Range-check first: `. agg N` with N past the last field used
+                // to emit `extractvalue … , N` that only clang/llvm-as rejected
+                // ("invalid indices for extractvalue").
+                : i fcount ( agg_field_count syms ot )
+                ? & >= fcount 0 >= idx fcount
+                { ( die lex ( nurl_str_cat
+                    ( nurl_str_cat3 `index ` ( nurl_str_int idx ) ` is out of range for type '` )
+                    ( nurl_str_cat ( llvm_to_nurl ot )
+                    ( nurl_str_cat3 `' — it has ` ( nurl_str_int fcount ) ` field(s)` ) ) ) ) }
+                {}
                 : s ft ( compound_field_type ot idx )
                 : s res ( nurl_cg_reg cg )
                 ( nurl_print `  ` ) ( nurl_print res )
@@ -9994,6 +10045,14 @@
                     // Strip '%' to get struct name  e.g. "%Node" → "Node"
                     : s sname ( nurl_str_slice ot 1 - otlen 1 )
                     : s fidx_s ( nurl_sym_get syms ( nurl_str_cat sname ( nurl_str_cat `__` ( nurl_str_cat fname `__idx` ) ) ) )
+                    // No such field: the lookup is empty, and the old code fed
+                    // `nurl_str_to_int ""` = 0 into `extractvalue %T v, 0` —
+                    // silently reading the WRONG field (a miscompile), or
+                    // emitting a malformed index. Reject the typo at the source.
+                    ? == 0 ( nurl_str_len fidx_s )
+                    { ( die lex ( nurl_str_cat3 `type '` ( llvm_to_nurl ot )
+                        ( nurl_str_cat3 `' has no field '` fname `'` ) ) ) }
+                    {}
                     : s ftype ( nurl_sym_get syms ( nurl_str_cat sname ( nurl_str_cat `__` ( nurl_str_cat fname `__type` ) ) ) )
                     : i fidx ( nurl_str_to_int fidx_s )
                     : s res ( nurl_cg_reg cg )
@@ -12576,11 +12635,20 @@
             ? != 0 ( nurl_str_len name )
             { ? ( is_tparam_like name ) {}
                 { ? ( __has_dunder name ) {}
-                    { ? == 0 ( nurl_str_len ( nurl_sym_get syms name ) )
+                    {  // A declared struct/enum maps to `%Name` in syms (set by
+                       // the pre-scan + gen_struct/enum_decl). A bare non-empty
+                       // value that does NOT start with '%' means the name is in
+                       // scope as something else — an @-fn / FFI symbol / const
+                       // whose value is its return/value type — and is NOT a
+                       // type. Require the `%`-type form so `@ f rand x → i`
+                       // (using the FFI symbol `rand` as a parameter type) is
+                       // rejected too, not just a wholly-unknown name.
+                        : s sv ( nurl_sym_get syms name )
+                        ? & != 0 ( nurl_str_len sv ) == ( nurl_str_get sv 0 ) 37
+                        {}
                         { ( die lex ( nurl_str_cat
                             ( nurl_str_cat3 `unknown type '` name `' in ` )
-                            ( nurl_str_cat ctx ` — no struct or enum with this name is declared (a typo, or a missing '$' import?)` ) ) ) }
-                        {} } } }
+                            ( nurl_str_cat ctx ` — no struct or enum with this name is declared (a typo, or a missing '$' import?)` ) ) ) } } } }
             {}
             = i j
         }
@@ -12879,7 +12947,6 @@
             ( nurl_str_cat3 sink_acc ` ` ( nurl_str_int pct ) ) }
         {}
         = params_str ( nurl_get_last_type )
-        ( check_type_known lex syms params_str `a parameter type` )
         = pct + pct 1
     }
     // Publish this function's inout / sink
@@ -13256,6 +13323,7 @@
     ( nurl_sym_def g_res_type_syms `__last_res_err_llvm__` `` )
     ( nurl_sym_def g_res_type_syms `__last_opt_nurl_t__` `` )
     : s lt ( parse_type lex )
+    ( check_type_known lex syms lt `a parameter type` )
     : s p_nurl_type ( nurl_sym_get g_res_type_syms `__last_nurl_type__` )
     // Capture the `! T E` / `? T` payload metadata for this parameter so a
     // `?? <param> { T x → … }` match can reconstruct a struct / pointer
@@ -13787,6 +13855,13 @@
     ( __ffi_lib_check lex lib )
     ( nurl_lex_advance lex )  // skip library STR
     ( expect lex TT_AT )  // consume '@'
+    // The C symbol name must be an identifier. A malformed header (`& "lib" @ @
+    // foo`, a stray operator) otherwise took whatever token followed as the
+    // name and emitted `declare T @<garbage>(…)` — IR only clang/llvm-as
+    // rejected ("expected function name").
+    ? ! ( is_ident_tok ( nurl_lex_type lex ) )
+    { ( die lex `expected the C function name (an identifier) after '@' in an FFI declaration` ) }
+    {}
     : s fname ( nurl_lex_val lex )
     // Lint: `&` externs belong to the declaring file's def roster so
     // an import used only for its FFI surface is not flagged unused.

--- a/compiler/tests/outputs/should_fail_ffi_no_name.txt
+++ b/compiler/tests/outputs/should_fail_ffi_no_name.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_member_index_oob.txt
+++ b/compiler/tests/outputs/should_fail_member_index_oob.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_member_on_scalar.txt
+++ b/compiler/tests/outputs/should_fail_member_on_scalar.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_type_is_fn_name.txt
+++ b/compiler/tests/outputs/should_fail_type_is_fn_name.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_unknown_field.txt
+++ b/compiler/tests/outputs/should_fail_unknown_field.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_ffi_no_name.nu
+++ b/compiler/tests/should_fail_ffi_no_name.nu
@@ -1,0 +1,4 @@
+// should_fail_ffi_no_name.nu — an FFI declaration whose `@` is not followed
+// by an identifier name used to emit `declare T @<garbage>(…)`.
+& `libc` @ @ foo → i
+@ main → i { ^ 0 }

--- a/compiler/tests/should_fail_member_index_oob.nu
+++ b/compiler/tests/should_fail_member_index_oob.nu
@@ -1,0 +1,4 @@
+// should_fail_member_index_oob.nu — an out-of-range integer index into an
+// aggregate used to emit an invalid `extractvalue …, N`.
+: P { i x  i y }
+@ main → i { : P p @ P { 1 2 }  ^ . p 9 }

--- a/compiler/tests/should_fail_member_on_scalar.nu
+++ b/compiler/tests/should_fail_member_on_scalar.nu
@@ -1,0 +1,3 @@
+// should_fail_member_on_scalar.nu — `.` field/element access on a scalar
+// (non-aggregate) used to emit `extractvalue i64 …`. Rejected at the source.
+@ main → i { : i n 5  : i z . n x  ^ 0 }

--- a/compiler/tests/should_fail_type_is_fn_name.nu
+++ b/compiler/tests/should_fail_type_is_fn_name.nu
@@ -1,0 +1,6 @@
+// should_fail_type_is_fn_name.nu — using a function / FFI symbol name where a
+// TYPE is expected leaked an undefined `%name`; a name in scope that is not a
+// `%`-type is now reported as an unknown type.
+& `libc` @ rand → i
+@ f rand x → i { ^ 0 }
+@ main → i { ^ 0 }

--- a/compiler/tests/should_fail_unknown_field.nu
+++ b/compiler/tests/should_fail_unknown_field.nu
@@ -1,0 +1,4 @@
+// should_fail_unknown_field.nu — accessing a field a struct does not have
+// used to silently read field 0 (a miscompile) or emit a malformed index.
+: P { i x  i y }
+@ main → i { : P p @ P { 1 2 }  : i z . p nope  ^ 0 }

--- a/compiler/tests/websocket_client.nu
+++ b/compiler/tests/websocket_client.nu
@@ -163,7 +163,7 @@ $ `stdlib/ext/websocket.nu`
     : !ParsedHeadOk HttpReqErr ph ( __read_request_head conn carry lim )
     ?? ph {
         T pho → {
-            : HttpRequest req . pho req
+            : HttpRequest req . pho head
             ? ( ws_is_upgrade req ) {
                 : !v WsErr hr ( ws_perform_handshake conn req )
                 ?? hr {

--- a/examples/ws_echo.nu
+++ b/examples/ws_echo.nu
@@ -49,7 +49,7 @@ $ `stdlib/ext/websocket.nu`
     : !ParsedHeadOk HttpReqErr ph ( __read_request_head conn carry lim )
     ?? ph {
         T pho → {
-            : HttpRequest req . pho req
+            : HttpRequest req . pho head
             ? ( ws_is_upgrade req ) {
                 : !v WsErr hr ( ws_perform_handshake conn req )
                 ?? hr {


### PR DESCRIPTION
## Summary

Continuing the fuzzer work on the **BAD_IR** class (nurlc returns 0 but emits IR `clang`/`llvm-as` rejects). This round converts the remaining realistic shapes into clean source diagnostics — and one of the new checks **caught a genuine latent bug** in the existing corpus.

Over ~64k more mutants: still **0 crashes, 0 hangs**.

## Fixes

| Input | Before (rc 0 → clang/llvm-as) | After (nurlc) |
|---|---|---|
| `@ f rand x → i` (FFI symbol `rand` used as a type) | `use of undefined type named 'rand'` | `unknown type 'rand' …` |
| `. n x` where `n : i` | `extractvalue i64 …` | `cannot access a field or element of 'i' …` |
| `. p 9` (2-field struct) | `invalid indices for extractvalue` | `index 9 is out of range for type 'P' — it has 2 field(s)` |
| `. p nope` (no such field) | **silently read field 0** (miscompile) | `type 'P' has no field 'nope'` |
| `& "lib" @ @ foo` | `expected function name` | `expected the C function name (an identifier) after '@' …` |

### Real bug found
The new "unknown field" check fired on `compiler/tests/websocket_client.nu:166`: `. pho req` — but `ParsedHeadOk` has fields `head` / `consumed`, no `req`. The old codegen silently extracted **field 0** (`head`), which happened to be the value the code wanted, so it "worked". Fixed to `. pho head` (identical runtime value; golden output unchanged). This is exactly the kind of silent miscompile the stricter check is meant to prevent.

## Implementation notes

- `check_type_known` now requires the in-scope name to map to a `%`-type, not merely to exist (an `@`-fn/FFI symbol maps to its return type, not `%name`).
- New `agg_field_count` returns an aggregate's field count (named struct via `<T>__field_count`; inline `{ … }` by depth-aware comma count, `-1` when unknown so the range check is skipped rather than risk a false positive).
- `gen_member` rejects access on a non-aggregate, an out-of-range integer index, and an unknown field name. The param-type check was moved into `gen_fn_param` (using the `parse_type` result `lt`, not the call-site `nurl_get_last_type`, which isn't the clean param type — a self-compile false positive on `@ die i lex …` caught this during development).

## Verification

- All synthetic cases produce clean diagnostics; valid code (struct/opt/slice/nested field access, generics, primitive + struct-returning FFI) compiles unchanged.
- No false positives across the corpus: **441 pass / 0 fail**, bootstrap holds.
- 5 `should_fail_*` regressions; the only changed golden is none (the websocket source fix kept identical output).

## Deferred

A `??` arm that binds **more payloads than its variant/option has** (e.g. `T a b` on a 1-payload option) still emits an out-of-range `extractvalue` — that's a `gen_match` payload-arity check, left for a focused future round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)