### PR TITLE
fix(compiler): enforce Option/Result match-arm payload arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Option / Result `??` arm payload arity is enforced (fuzz follow-up #3).** An
+  Option (`? T`) or Result (`! T E`) match arm binds at most one payload — the
+  T-arm value / Ok payload, or the F-arm error. Binding more (`?? o { T a b → …
+  }`) used to emit an out-of-range `extractvalue { i1, T } v, 2` that nurlc
+  accepted (rc 0) and only clang/llvm-as rejected. `gen_match` now reports
+  *"match arm binds N payloads but an option/result 'T' arm binds at most
+  one …"*. (Enum variants already validated per-variant payload arity; this
+  closes the opt/res case, completing the in-`??` out-of-range-extractvalue
+  class.) Locks `should_fail_match_opt_overbind`.
+
 - **More front-end checks for type/field misuse (fuzz follow-up #2).** The
   mutation fuzzer's remaining `BAD_IR` shapes (nurlc rc 0, only clang/llvm-as
   rejecting) were turned into source diagnostics — and one of the new checks

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5627,6 +5627,10 @@
             //     exhaustiveness tracking, and enum-variant lookup paths;
             //     a wildcard arm is required to cover the residual.
             : b is_int_pat == pat_tt TT_INT
+            // A BOOL pattern (`T` / `F`) matches an Option (`? T`) or Result
+            // (`! T E`): the T-arm binds the single value / Ok-payload, the
+            // F-arm binds the error (or nothing). Either way at most ONE slot.
+            : b is_bool_pat == pat_tt TT_BOOL
             // For an integer-literal pattern normalise the spelling so a
             // `0x…` / `0b…` literal doesn't reach the `icmp` constant as
             // raw text (LLVM would read `0x…` as a hex float). Decimal
@@ -5721,6 +5725,14 @@
                 ( nurl_str_cat3 `match arm binds ` ( nurl_str_int pvc ) ` payload(s) but variant '` )
                 pattern_name
                 ( nurl_str_cat3 `' declares only ` __pc_s ` — if a CamelCase name in the enum declaration was meant as this variant's payload TYPE, note that an unknown/unimported type name parses as a SEPARATE variant; define or import the type before the enum.` ) ) ) }
+            {}
+            // Option / Result T-or-F arm: at most one payload slot. Binding
+            // more (`?? o { T a b → … }`) used to emit an out-of-range
+            // `extractvalue { i1, T } v, 2` that only clang/llvm-as rejected.
+            ? & is_bool_pat > pvc 1
+            { ( die lex ( nurl_str_cat
+                ( nurl_str_cat3 `match arm binds ` ( nurl_str_int pvc ) ` payloads but an option/result '` )
+                ( nurl_str_cat pattern_name `' arm binds at most one (the T-arm value / Ok payload, or the F-arm error)` ) ) ) }
             {}
 
             // Optional guard: `Pattern payloads ? <cond> → body`. The

--- a/compiler/tests/outputs/should_fail_match_opt_overbind.txt
+++ b/compiler/tests/outputs/should_fail_match_opt_overbind.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_match_opt_overbind.nu
+++ b/compiler/tests/should_fail_match_opt_overbind.nu
@@ -1,0 +1,6 @@
+// should_fail_match_opt_overbind.nu — an Option/Result `??` arm may bind at
+// most one payload (the T-arm value / Ok payload, or the F-arm error). Binding
+// more (`T a b`) used to emit an out-of-range `extractvalue { i1, T } v, 2`
+// that only clang/llvm-as rejected. (Enums already validate per-variant
+// payload arity; this closes the opt/res case.)
+@ main → i { : ?i o @ ?i { T 5 }  ^ ?? o { T a b → a  F → 0 } }


### PR DESCRIPTION
## Summary

The deferred `gen_match` item from the previous fuzz round. An **Option (`? T`) or Result (`! T E`) match arm binds at most one payload** — the T-arm value / Ok payload, or the F-arm error. Binding more:

```
?? o { T a b → a   F → 0 }     // o : ?i
```

used to emit an out-of-range `extractvalue { i1, T } v, 2` that `nurlc` accepted (rc 0) and only `clang`/`llvm-as` rejected ("invalid indices for extractvalue"). `gen_match` now reports *"match arm binds N payloads but an option/result 'T' arm binds at most one …"* at the source.

Enum variants already validated per-variant payload arity (via `__paycount`); this closes the Option/Result case, **completing the in-`??` out-of-range-extractvalue class**.

## Implementation

A one-line classifier (`is_bool_pat == pat_tt TT_BOOL`) plus a cap check next to the existing enum arity check: a `T`/`F` pattern with more than one payload slot is rejected. Literal-constrained single slots (`T 5 → …`) and the normal `T v` / `F e` bindings are unaffected.

## Verification

- `?? o { T a b → … }` and the Result equivalent now error cleanly; valid 0/1-payload arms, literal-constrained arms, and `F e` error bindings compile unchanged.
- 4 of the 6 outstanding fuzzer BAD_IR findings now error; full suite passes, examples gate 80/0, bootstrap holds.
- 1 `should_fail` regression (`match_opt_overbind`); no existing golden changed.

## Remaining (deferred)

Two contrived fuzz-only shapes survive, both distinct from the extractvalue class:
- an **i1-vs-i64 binary comparison** (`< boolval intval` → `icmp slt i1, i64`) — the batch-2 operand check deliberately excluded the bool case to keep `== flag 0` valid; catching this safely needs constant-aware handling.
- a **match payload-extract on a non-aggregate scrutinee** (`?? n { T a → … }` with `n : i`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)