### PR TITLE
fix(compiler): diagnose bool/int operand mix and match-on-scalar payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two more fuzzer BAD_IR shapes diagnosed (bool/int mix, match on a scalar).**
+  - **A binary operator mixing a bool (i1) and a non-bool operand**, both
+    non-constant (`< flag n` with `n : i`), emitted a width-mismatched
+    `icmp i1 %flag, %n` that only clang/llvm-as rejected. `gen_binary` now
+    rejects it. A constant operand is still fine — it reinterprets to the other
+    side's width — so `== flag 0` (int literal fits i1) and `== v T` (bool
+    literal fits i64) keep compiling; only two disagreeing registers are
+    flagged.
+  - **Binding a payload while matching a non-aggregate scalar** (`?? n { T a →
+    … }` with `n : i`) emitted an `extractvalue` on the scalar. `gen_match` now
+    rejects payload binding unless the scrutinee is an enum / option / result;
+    integer-literal arms and bare tag matches are unaffected.
+  Locks `should_fail_binop_bool_int`, `should_fail_match_payload_scalar`. (One
+  deeply-contrived fuzz holdout remains: a mutation that makes a match
+  scrutinee's *declared* type claim an option/result while its actual SSA value
+  is a scalar — an inconsistency no real program produces.)
+
 - **Option / Result `??` arm payload arity is enforced (fuzz follow-up #3).** An
   Option (`? T`) or Result (`! T E`) match arm binds at most one payload — the
   T-arm value / Ok payload, or the F-arm error. Binding more (`?? o { T a b → …

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -2322,6 +2322,21 @@
         `', right is '` rt )
         `' — operator-level pointer arithmetic is not supported; index with '. ptr idx' or convert explicitly` ) ) }
     {}
+    // Bool (i1) vs non-bool. NURL has no implicit bool↔int conversion, so an
+    // operator with exactly one i1 operand emitted e.g. `icmp slt i1 %f, %n`
+    // (the other a wider integer) — IR only clang/llvm-as rejected. A CONSTANT
+    // operand is fine: it reinterprets to the other side's width (a bool
+    // literal `T`/`F` → 0/1 fits i64 in `== v T`; an int literal 0/1 fits i1 in
+    // `== flag 0`). The genuine bug is two NON-constant registers of disagreeing
+    // bool/int width — detected by both values being SSA registers (`%…`).
+    : b l_i1 ( seq lt `i1` )
+    : b r_i1 ( seq rt `i1` )
+    ? & != l_i1 r_i1 & == ( nurl_str_get lv 0 ) 37 == ( nurl_str_get rv 0 ) 37
+    { ( die lex ( nurl_str_cat ( nurl_str_cat4
+        `operator mixes a bool (i1) and a non-bool operand: left is '` lt
+        `', right is '` rt )
+        `' — NURL has no implicit bool↔int conversion; cast one side ('# i expr')` ) ) }
+    {}
     : ~ s cmp_ty lt
     ? & is_cmp | ( is_ptr_ty lt ) ( is_ptr_ty rt ) {
         ? ( is_ptr_ty lt ) {
@@ -5733,6 +5748,19 @@
             { ( die lex ( nurl_str_cat
                 ( nurl_str_cat3 `match arm binds ` ( nurl_str_int pvc ) ` payloads but an option/result '` )
                 ( nurl_str_cat pattern_name `' arm binds at most one (the T-arm value / Ok payload, or the F-arm error)` ) ) ) }
+            {}
+            // Payload binding requires an aggregate scrutinee — an enum (`%E`)
+            // or an option / result (`{ i1, … }`). Binding a payload while
+            // matching a non-aggregate scalar (`?? n { T a → … }` with `n : i`)
+            // emitted an `extractvalue` on the scalar that only clang/llvm-as
+            // rejected. Integer-literal arms (no payload) and bare tag matches
+            // (pvc 0) are unaffected.
+            ? > pvc 0
+            { ? != 0 ( nurl_str_len match_type )
+                { ? & != ( nurl_str_get match_type 0 ) 37 != ( nurl_str_get match_type 0 ) 123
+                    { ( die lex ( nurl_str_cat3 `cannot bind a payload when matching the non-aggregate type '` ( llvm_to_nurl match_type ) `' — only an enum, option, or result carries payloads` ) ) }
+                    {} }
+                {} }
             {}
 
             // Optional guard: `Pattern payloads ? <cond> → body`. The

--- a/compiler/tests/outputs/should_fail_binop_bool_int.txt
+++ b/compiler/tests/outputs/should_fail_binop_bool_int.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_match_payload_scalar.txt
+++ b/compiler/tests/outputs/should_fail_match_payload_scalar.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_binop_bool_int.nu
+++ b/compiler/tests/should_fail_binop_bool_int.nu
@@ -1,0 +1,5 @@
+// should_fail_binop_bool_int.nu — an operator with one bool (i1) and one
+// non-bool operand, both non-constant, used to emit a width-mismatched
+// `icmp i1 %f, %n`. A literal operand (e.g. `== flag 0`) stays valid; two
+// disagreeing registers are rejected.
+@ main → i { : b f T  : i n 5  : b r < f n  ^ 0 }

--- a/compiler/tests/should_fail_match_payload_scalar.nu
+++ b/compiler/tests/should_fail_match_payload_scalar.nu
@@ -1,0 +1,4 @@
+// should_fail_match_payload_scalar.nu — binding a payload while matching a
+// non-aggregate scalar (`?? n { T a → … }` with n : i) used to emit an
+// `extractvalue` on the scalar. Only enums / options / results carry payloads.
+@ main → i { : i n 5  ^ ?? n { T a → a  F → 0 } }


### PR DESCRIPTION
## Summary

The two remaining fuzzer **BAD_IR** shapes (nurlc returns 0; only clang/llvm-as rejects).

### 1. Bool (i1) vs non-bool operand
`< flag n` with `flag : b`, `n : i` emitted a width-mismatched `icmp slt i1 %flag, %n`. `gen_binary` now rejects an operator whose two operands are a bool and a non-bool — **but only when both are non-constant registers**. A constant operand reinterprets to the other side's width, so the everyday cases stay valid:
- `== flag 0` (int literal `0` fits i1)
- `== v T` (bool literal `T` → `1` fits i64)

(The narrowing to "both registers" was essential — an earlier blanket version broke `== v T` / `== kind 2` in the stdlib corpus.)

### 2. Payload binding when matching a non-aggregate scalar
`?? n { T a → … }` with `n : i` emitted an `extractvalue` on the scalar `n`. `gen_match` now rejects binding a payload unless the scrutinee is an enum / option / result. Integer-literal arms (`?? n { 1 → … _ → … }`) and bare tag matches (no payload) are unaffected.

## Verification

- Both shapes error cleanly; valid code is untouched: `== flag 0`, `== v T`, `== kind 2`, int-`??`, enum/option payload matches all compile.
- 5 of the 6 outstanding fuzzer findings now error; full suite passes, examples gate 80/0, bootstrap holds.
- 2 `should_fail` regressions (`binop_bool_int`, `match_payload_scalar`); no existing golden changed.

## Remaining holdout

One deeply-contrived fuzz case survives: a mutation makes a match scrutinee's *declared* type claim an option/result (`{ i1, … }`) while its actual SSA value is a scalar `i64`, so the (correct) aggregate check passes and a tag `extractvalue` is still emitted. Guarding this would require verifying every value's actual LLVM type against its believed type — an inconsistency no real program can produce. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)