### PR TITLE
fix(compiler): signedness-aware generic monomorphisation (i vs u64, u32, …)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -351,7 +351,6 @@
             // no `)`) otherwise spins here on a no-op `nurl_lex_advance` at EOF.
             // The trailing `expect TT_RPAREN` reports a clean error.
             ~ & != ( nurl_lex_type lex ) TT_RPAREN != ( nurl_lex_type lex ) TT_EOF {
-                : ~ s ta_lty ``
                 : i ta_tt ( nurl_lex_type lex )
                 // A bare anonymous slice (`[ T`) is the one type shape the
                 // monomorphiser cannot mangle as a generic argument: the
@@ -363,18 +362,20 @@
                 { ( die lex `a slice type '[ T' cannot be a generic type argument — wrap it in a named struct (e.g. ': Buf [T] { [ T xs }') and instantiate that` ) }
                 {}
                 // Paren-compound and prefix (`?T` / `??T` / `*T`) args go
-                // through parse_type, which yields their LLVM type
-                // directly; a bare base name takes the single-token path.
+                // through parse_type, which yields their LLVM type directly
+                // (mangle by LLVM type). A bare base name takes the single-
+                // token path and is mangled SIGNEDNESS-AWARE via mangle_src_word
+                // so `( Vec u64 )` and `( Vec i )` stay distinct monomorphs.
                 ? | | == ta_tt TT_LPAREN == ta_tt TT_QUEST | == ta_tt TT_QUESTQUEST == ta_tt TT_STAR
-                { = ta_lty ( parse_type lex ) }
+                { : s ta_lty ( parse_type lex )
+                    = mangle_sfx ( nurl_str_cat mangle_sfx
+                    ( nurl_str_cat `__` ( mangle_type ta_lty ) ) ) }
                 { : s ta ( nurl_lex_val lex )
                     ( lint_note_used ta )
                     ( nurl_lex_advance lex )
                     ? ( is_tparam_like ta ) { = has_tparam_arg T } {}
-                    = ta_lty ( llvm_type ta )
-                }
-                = mangle_sfx ( nurl_str_cat mangle_sfx
-                ( nurl_str_cat `__` ( mangle_type ta_lty ) ) )
+                    = mangle_sfx ( nurl_str_cat mangle_sfx
+                    ( nurl_str_cat `__` ( mangle_src_word ta ) ) ) }
             }
             ( expect lex TT_RPAREN )
             // Unknown-generic check (critic A7): `( Vec i )` with no
@@ -4304,7 +4305,7 @@
             }
             = type_args ? == 0 ( nurl_str_len type_args ) ta
             ( nurl_str_cat type_args ( nurl_str_cat ` ` ta ) )
-            = mangle_sfx ( nurl_str_cat mangle_sfx ( nurl_str_cat `__` ( mangle_type ( nurl_src_to_llvm ta ) ) ) )
+            = mangle_sfx ( nurl_str_cat mangle_sfx ( nurl_str_cat `__` ( mangle_src_word ta ) ) )
         }
         ( expect lex TT_RBRACK )
         : s mangled ( nurl_str_cat fname mangle_sfx )
@@ -12376,6 +12377,15 @@
     ? ( seq mty `i1` ) ^ `i1`
     ? ( seq mty `str` ) ^ `i8*`
     ? ( seq mty `void` ) ^ `void`
+    // Signedness-aware unsigned-int leaf slugs (see mangle_src_word): they
+    // carry the NURL signedness the LLVM type can't, so the monomorphiser
+    // keeps `( Vec u64 )` and `( Vec i )` distinct. Recovering the LLVM type
+    // (for foreach element load etc.) maps them back to the same width; the
+    // element's unsignedness is not re-derived here (a separate concern).
+    ? ( seq mty `u64` ) ^ `i64`
+    ? ( seq mty `u32` ) ^ `i32`
+    ? ( seq mty `u16` ) ^ `i16`
+    ? ( seq mty `u8` ) ^ `i8`
     ? != 0 ( nurl_str_starts mty `opt_` )
     ^ ( nurl_str_cat `{ i1, ` ( nurl_str_cat ( demangle_type ( nurl_str_slice mty 4 - ( nurl_str_len mty ) 4 ) ) ` }` ) )
     {}
@@ -12391,6 +12401,29 @@
     ^ ( nurl_str_cat `%` ( nurl_str_slice mty el - ( nurl_str_len mty ) el ) )
     {}
     ( nurl_str_cat `%` mty )
+}
+
+// mangle_src_word: signedness-aware mangle of a generic type-ARGUMENT source
+// word (as produced by capture_type_arg_src / nurl_lex_val: a base type kw, a
+// named type, a `%`-stripped compound `Name__…`, or a prefix phrase `*u64`).
+//
+// `mangle_type` keys on the LLVM type, which DROPS signedness: `i` and `u64`
+// both lower to i64, `u`/`i8`, `u16`/`i16`, `u32`/`i32` likewise. Without this
+// the monomorphiser collapses `( gdiv [u64] )` and `( gdiv [i] )` onto ONE
+// body and picks the wrong div/rem/shr/cmp signedness (a silent miscompile).
+// Unsigned-int LEAVES get distinct slugs; everything else (signed ints,
+// floats, bool/string/void, named structs, compound names, and prefix
+// `*`/`?`/`??` phrases) delegates to the existing LLVM-keyed path UNCHANGED,
+// so every generic-arg funnel stays byte-for-byte consistent. Nested generics
+// (`( Box ( Vec u64 ) )`) are covered because their leaf passes through a base
+// case too. Residual: an unsigned int DIRECTLY behind a `*`/`?` prefix as a
+// generic arg (`[ * u64 ]`) still shares a slug with `[ * i ]`.
+@ mangle_src_word s w → s {
+    ? ( seq w `u` )   ^ `u8`
+    ? ( seq w `u16` ) ^ `u16`
+    ? ( seq w `u32` ) ^ `u32`
+    ? ( seq w `u64` ) ^ `u64`
+    ^ ( mangle_type ( nurl_src_to_llvm w ) )
 }
 
 // subst_source: replace whole-word occurrences of 'from' with 'to' in src.
@@ -12787,7 +12820,7 @@
                 : s ta ( str_first_word ta_r )
                 = ta_r ( str_skip_word ta_r )
                 = mangled ( nurl_str_cat mangled
-                ( nurl_str_cat `__` ( mangle_type ( nurl_src_to_llvm ta ) ) ) )
+                ( nurl_str_cat `__` ( mangle_src_word ta ) ) )
             }
             // Dedupe — each distinct instantiation emitted at most once.
             : s done_key ( nurl_str_cat mangled `__done` )
@@ -15601,20 +15634,14 @@
     : ~ s mangle_sfx ``
     ~ & != ( nurl_lex_type lex ) TT_RPAREN != ( nurl_lex_type lex ) TT_EOF {
         : ~ s ta_word ``
-        : ~ s ta_lty ``
         ? == ( nurl_lex_type lex ) TT_LPAREN
-        { : s inner ( scan_compound_ta_inner lex syms )
-            = ta_word inner
-            = ta_lty ( nurl_str_cat `%` inner )
-        }
-        { = ta_word ( capture_type_arg_src lex )
-            = ta_lty ( nurl_src_to_llvm ta_word )
-        }
+        { = ta_word ( scan_compound_ta_inner lex syms ) }
+        { = ta_word ( capture_type_arg_src lex ) }
         = ta_list ? == 0 ( nurl_str_len ta_list )
         ta_word
         ( nurl_str_cat3 ta_list ` ` ta_word )
         = mangle_sfx ( nurl_str_cat mangle_sfx
-        ( nurl_str_cat `__` ( mangle_type ta_lty ) ) )
+        ( nurl_str_cat `__` ( mangle_src_word ta_word ) ) )
     }
     ? == ( nurl_lex_type lex ) TT_RPAREN { ( nurl_lex_advance lex ) } {}
     : s tparams ( nurl_sym_get g_generic_struct_syms ( nurl_str_cat sname `__stparams` ) )

--- a/compiler/tests/generic_signedness_mono.nu
+++ b/compiler/tests/generic_signedness_mono.nu
@@ -1,0 +1,27 @@
+// generic_signedness_mono.nu — a generic body's signed-sensitive operators
+// (/ % >> and comparisons) must use the signedness of the CONCRETE type
+// argument, not whichever instantiation was emitted first.
+//
+// Regression for a silent miscompile: `mangle_type` keys on the LLVM type,
+// where `i` and `u64` (also `u`/i8, `u16`/i16, `u32`/i32) both lower to the
+// same width. So `( gdiv [u64] )` and `( gdiv [i] )` collapsed onto ONE
+// monomorph; the u64 one (encountered first) used `udiv`, so `gdiv [i] -7 2`
+// computed udiv(-7,2) = 9223372036854775804 instead of -3. mangle_src_word now
+// gives unsigned leaves distinct slugs so the monomorphs stay separate.
+@ gdiv [T] T a T b → T { ^ / a b }
+@ gmod [T] T a T b → T { ^ % a b }
+@ gshr [T] T a → T { ^ >> a 1 }
+
+@ main → i {
+    // Instantiate the UNSIGNED monomorphs FIRST so a regression would poison
+    // the signed bodies below.
+    ( nurl_print ( nurl_str_int # i ( gdiv [u64] 200 100 ) ) ) ( nurl_print `\n` )  // 2
+    ( nurl_print ( nurl_str_int # i ( gmod [u64] 200 100 ) ) ) ( nurl_print `\n` )  // 0
+    ( nurl_print ( nurl_str_int # i ( gshr [u64] 64 ) ) )      ( nurl_print `\n` )  // 32
+
+    // Signed bodies: must use sdiv / srem / ashr regardless of emit order.
+    ( nurl_print ( nurl_str_int ( gdiv [i] -7 2 ) ) ) ( nurl_print `\n` )           // -3
+    ( nurl_print ( nurl_str_int ( gmod [i] -7 2 ) ) ) ( nurl_print `\n` )           // -1
+    ( nurl_print ( nurl_str_int ( gshr [i] -8 ) ) )   ( nurl_print `\n` )           // -4
+    ^ 0
+}

--- a/compiler/tests/outputs/generic_signedness_mono.txt
+++ b/compiler/tests/outputs/generic_signedness_mono.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+2
+0
+32
+-3
+-1
+-4


### PR DESCRIPTION
## Summary

Continuing the compiler-hardening hunt. This closes the **residual** flagged in #204: generic monomorphisation was keyed on the **LLVM** type, which drops NURL signedness (`i` and `u64` both lower to `i64`; likewise `u`/i8, `u16`/i16, `u32`/i32). Two distinct instantiations therefore collapsed onto one monomorphisation and the **first emitted won** — so a generic body's signed-sensitive operators (`/`, `%`, `>>`, and the ordering comparisons) used the wrong signedness.

### Repro (silent miscompile — no diagnostic, valid IR, wrong at runtime)

```nurl
@ gdiv [T] T a T b → T { ^ / a b }

( gdiv [u64] 200 100 )   // emits @gdiv__i64 using `udiv`
( gdiv [i]   -7  2  )    // reuses it -> udiv(-7,2) = 9223372036854775804
                         //              should be -3
```

## Fix

`mangle_src_word` mangles a generic type **argument** from its source word: unsigned-int leaves get distinct slugs (`u8`/`u16`/`u32`/`u64`); everything else (signed ints, floats, bool/string/void, named structs, compound names, `*`/`?` prefix phrases) delegates to the existing LLVM-keyed `mangle_type` path **unchanged**, so all four generic-arg funnels stay byte-for-byte consistent:

- call-site `( f [ … ] … )`
- struct type position (`parse_type`)
- struct pre-scan (`scan_compound_ta_inner`)
- instantiation emitter (`ensure_struct_instantiated`)

Nested generics (`( Box ( Vec u64 ) )`) are covered automatically because the leaf passes through a base case. `demangle_type` maps the new slugs back to their LLVM width for foreach element recovery.

## Validation

- `gdiv [u64]` → `@gdiv__u64` (`udiv`); `gdiv [i]` → `@gdiv__i64` (`sdiv`, gives `-3`).
- `gmax [u32]` now uses `icmp ugt`.
- **446/446 tests pass**; bootstrap fixed point held (no `--refresh-bootstrap`).
- `chaotic-aggressor` / `chaotic-showcase` still build and run.
- New regression: `compiler/tests/generic_signedness_mono.nu` (div/mod/shr, unsigned instantiated first).

## Known residuals (documented, separate from this change)

1. An unsigned int **directly** behind a `*`/`?` prefix as a generic arg (`[ * u64 ]`) still shares a slug with `[ * i ]` — the prefix path mangles by LLVM type.
2. `# i` of an unsigned **call result** sign-extends (call-result signedness isn't propagated to the cast). Surfaced while testing; orthogonal to mangling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)