### PR TITLE
fix(compiler): foreach element inherits the container's unsigned element type

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -236,6 +236,19 @@
     ^ F
 }
 
+// __slug_is_unsigned: is a mangle SLUG (mangle_src_word output) an unsigned
+// integer leaf? The byte type `u` mangles to `u8`, so this differs from
+// nurl_type_is_unsigned (which speaks NURL source tokens, where the byte is
+// `u`). Used by gen_foreach to recover a Vec element's signedness from the
+// `%Vec__<slug>` carrier suffix.
+@ __slug_is_unsigned s slug → b {
+    ? ( seq slug `u8` ) { ^ T } {}
+    ? ( seq slug `u16` ) { ^ T } {}
+    ? ( seq slug `u32` ) { ^ T } {}
+    ? ( seq slug `u64` ) { ^ T } {}
+    ^ F
+}
+
 @ parse_type i lex → s {
     : i tt ( nurl_lex_type lex )
     ? == tt TT_STAR { ^ ( parse_type_ptr lex ) } {}
@@ -6594,6 +6607,15 @@
     : s fe_cont ? ( is_ident_tok ( nurl_lex_type lex ) ) ( nurl_lex_val lex ) ``
     : s slice_val ( gen_expr lex syms cg )
     : s slice_ty ( nurl_get_last_type )
+    // Snapshot the iterated container's element signedness NOW, before the
+    // ptr/len extraction below runs. For a bound slice (`: [ u64 xs …`) the
+    // let recorded `xs__unsigned` from the element's NURL type, and gen_ident
+    // re-asserted it onto `__last_unsigned__` when it loaded the slice above —
+    // so this snapshot is true exactly when the element is an unsigned integer.
+    // (The Vec carrier instead encodes signedness in its `%Vec__<slug>` suffix,
+    // handled below.) Used to tag the loop element binding so signed-sensitive
+    // ops (`/ % >> < > <= >=`) and `# i` widening on the element are unsigned.
+    : s fe_elem_uns_snap ( nurl_last_unsigned )
     // Two carrier shapes feed `~ x xs { ... }`:
     //
     //   Slice  `[T`        →  slice_ty = "{ T*, i64 }"
@@ -6666,6 +6688,16 @@
     ( nurl_print ` = alloca ` ) ( nurl_print elem_ty ) ( nurl_print `\n` )
     ( nurl_sym_def syms var_name elem_ty )
     ( nurl_sym_def syms ( nurl_str_cat var_name `__ptr` ) elem_ptr )
+    // Propagate the element's unsignedness onto the loop binding (see the
+    // snapshot above): a Vec recovers it from the signedness-aware suffix, a
+    // slice from the snapshot. Without this an unsigned-slice element loaded in
+    // the body defaulted to signed → wrong icmp/udiv/urem/shr and `# i` sext.
+    : b fe_elem_unsigned ? is_vec
+    ( __slug_is_unsigned ( nurl_str_slice slice_ty 6 - ( nurl_str_len slice_ty ) 6 ) )
+    != 0 ( nurl_str_len fe_elem_uns_snap )
+    ? fe_elem_unsigned
+    { ( nurl_sym_def syms ( nurl_str_cat var_name `__unsigned` ) `1` ) }
+    {}
     // Labels
     : s lc ( nurl_cg_lbl cg `foreach_check` )
     : s lb ( nurl_cg_lbl cg `foreach_body` )

--- a/compiler/tests/foreach_unsigned_element.nu
+++ b/compiler/tests/foreach_unsigned_element.nu
@@ -1,0 +1,32 @@
+// foreach_unsigned_element.nu — the element binding of `~ x slice { … }` must
+// inherit the container's element signedness. An unsigned element used with a
+// signed-sensitive operator (`/ % >> < > <= >=`) or widened with `# i` was
+// silently treated as SIGNED: gen_foreach bound the element only by its LLVM
+// type (i8/i16/i32/i64), which can't carry signedness.
+//
+// E.g. iterating a `[ u …` byte slice and testing `> by 127` used `icmp sgt`,
+// so any byte ≥ 128 (a negative i8) tested false — wrong for every UTF-8 /
+// binary parser. Fixed: gen_foreach tags the loop binding unsigned from the
+// Vec `%Vec__<slug>` suffix or the bound slice's recorded element flag.
+@ pr s l i v → v { ( nurl_print l ) ( nurl_print `=` ) ( nurl_print ( nurl_str_int v ) ) ( nurl_print `\n` ) }
+
+@ main → i {
+    // byte slice (u = unsigned i8): high-bit bytes must compare/​widen unsigned
+    : [ u bytes [ u | 65 200 130 10 ]
+    : ~ i hi 0
+    ~ by bytes { ? > by 127 { = hi + hi 1 } {} }
+    ( pr `high_bytes` hi )                            // 2  (200,130 > 127)
+    : ~ i bsum 0
+    ~ by bytes { = bsum + bsum # i by }
+    ( pr `byte_sum` bsum )                            // 405 (zext, not sign-extended)
+
+    // u64 slice with the high bit set
+    : [ u64 xs [ u64 | 18446744073709551615 200 ]
+    : ~ i big 0
+    ~ el xs { ? > el 1000 { = big + big 1 } {} }
+    ( pr `gt1000` big )                               // 1  (all-ones > 1000 unsigned)
+    : ~ i msum 0
+    ~ el xs { = msum + msum # i % el 7 }
+    ( pr `mod7_sum` msum )                            // 5  (urem: 1 + 4)
+    ^ 0
+}

--- a/compiler/tests/outputs/foreach_unsigned_element.txt
+++ b/compiler/tests/outputs/foreach_unsigned_element.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+high_bytes=2
+byte_sum=405
+gt1000=1
+mod7_sum=5


### PR DESCRIPTION
## Summary

Another **silent miscompile** found while probing loops over unsigned containers. `~ x slice { … }` bound the loop element only by its **LLVM** type (`i8`/`i16`/`i32`/`i64`), which can't carry signedness — so an unsigned element used with a signed-sensitive operator (`/ % >> < > <= >=`) or widened with `# i` was silently treated as **signed**.

```nurl
: [ u bytes [ u | 65 200 130 10 ]
: ~ i hi 0
~ by bytes { ? > by 127 { = hi + hi 1 } {} }   // emitted icmp sgt
( pr `high_bytes` hi )                          // got 0, should be 2
```

Every byte `>= 128` (a negative `i8`) tested false — wrong for any binary/UTF-8 parser. Likewise `% el 7` over a `[ u64` slice used `srem`, and `# i el` sign-extended. Valid IR, clang-accepted, wrong at runtime.

## Fix

`gen_foreach` now tags the loop binding `<x>__unsigned` from the element's NURL signedness:
- **Vec** — from the `%Vec__<slug>` carrier suffix (signedness-aware since the monomorphisation fixes).
- **slice** — from the unsigned flag the bound slice already carries onto `__last_unsigned__` when `gen_ident` loads it (the `let` records `<slice>__unsigned` from a `[ uXX` element type).

New helper `__slug_is_unsigned` recognises `u8`/`u16`/`u32`/`u64` slugs.

## Validation

- Byte slice: `> by 127` → `icmp ugt i8`, `# i by` → `zext i8`; counts/sums correct.
- `u64` slice: `% el 7` → `urem`, `> el 1000` unsigned.
- **449/449 tests pass**; bootstrap fixed point held.
- Regression: `compiler/tests/foreach_unsigned_element.nu`.

## Residual

A foreach directly over an anonymous unsigned slice produced by a **call** (`~ x ( f ) { … }`, no binding) still defaults to signed — the call result carries no element-signedness side-channel. Bound slices and Vecs (the common cases) are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)