### PR TITLE
fix(compiler): float != uses unordered compare (IEEE NaN semantics)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -2542,7 +2542,12 @@
     ? == tt TT_LT ? isf `fcmp olt` ? isu `icmp ult` `icmp slt`
     ? == tt TT_GT ? isf `fcmp ogt` ? isu `icmp ugt` `icmp sgt`
     ? == tt TT_EQEQ ? isf `fcmp oeq` `icmp eq`
-    ? == tt TT_NE ? isf `fcmp one` `icmp ne`
+    // Float `!=` must be UNORDERED-or-not-equal (`une`), not ordered (`one`):
+    // IEEE 754 requires `x != y` to be TRUE when either operand is NaN, so the
+    // canonical NaN check `!= x x` works. `une` matches C's `!=` and is
+    // identical to `one` for non-NaN operands. (`==` stays `oeq` — NaN == NaN
+    // is false, also matching C.)
+    ? == tt TT_NE ? isf `fcmp une` `icmp ne`
     ? == tt TT_LE ? isf `fcmp ole` ? isu `icmp ule` `icmp sle`
     ? == tt TT_GE ? isf `fcmp oge` ? isu `icmp uge` `icmp sge`
     `add`

--- a/compiler/tests/float_ne_nan.nu
+++ b/compiler/tests/float_ne_nan.nu
@@ -1,0 +1,19 @@
+// float_ne_nan.nu — float `!=` must follow IEEE 754: `x != y` is TRUE when
+// either operand is NaN. The compiler emitted `fcmp one` (ORDERED not-equal),
+// which is false for NaN operands, so `NaN != NaN` was false and the canonical
+// NaN check `x != x` never detected a NaN. Fixed to `fcmp une` (matches C's
+// `!=`; identical to `one` for non-NaN). `==` stays `fcmp oeq` (NaN == NaN is
+// false, as IEEE requires).
+@ prb s l b v → v { ( nurl_print l ) ( nurl_print `=` ) ( nurl_print ? v `true` `false` ) ( nurl_print `\n` ) }
+
+@ main → i {
+    : f nan / 0.0 0.0
+    : f x 5.0
+    ( prb `nan_ne_nan` != nan nan )   // true  (IEEE)
+    ( prb `nan_eq_nan` == nan nan )   // false
+    ( prb `nan_ne_x`   != nan x )     // true
+    ( prb `x_ne_x`     != x x )       // false (x is not NaN)
+    ( prb `x_ne_3`     != x 3.0 )     // true
+    ( prb `x_eq_x`     == x x )       // true
+    ^ 0
+}

--- a/compiler/tests/outputs/float_ne_nan.txt
+++ b/compiler/tests/outputs/float_ne_nan.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+nan_ne_nan=true
+nan_eq_nan=false
+nan_ne_x=true
+x_ne_x=false
+x_ne_3=true
+x_eq_x=true


### PR DESCRIPTION
## Summary

Another **silent miscompile**, this time in float comparison. `!=` on floats lowered to `fcmp one` (**ordered**, not-equal), which is `false` whenever either operand is NaN. IEEE 754 (and C) require `x != y` to be **true** when either operand is NaN.

```nurl
: f nan / 0.0 0.0
!= nan nan      // was false, must be true
!= x x          // canonical NaN check — was ALWAYS false, never detected NaN
```

Valid IR, clang-accepted, wrong at runtime for any code comparing possibly-NaN floats or using the `x != x` NaN idiom.

## Fix

Emit `fcmp une` (unordered-or-not-equal) for float `!=`. It matches C's `!=` and is **identical to `one` for non-NaN operands**, so nothing else changes. `==` stays `fcmp oeq` (NaN == NaN is false, as IEEE requires); the ordering operators stay ordered (`olt`/`ogt`/`ole`/`oge`, matching C).

## Validation

- `!= nan nan` → true; `== nan nan` → false; `!= nan 5.0` → true; `!= 5.0 5.0` → false; `!= 5.0 3.0` → true.
- **450/450 tests pass**; bootstrap fixed point held.
- Regression: `compiler/tests/float_ne_nan.nu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)