### PR TITLE
fix(compiler): Result Ok-arm payload inherits T's unsigned type

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -6256,9 +6256,15 @@
                 // instead of zext for high-bit-set bytes (bit us in
                 // bytes_to_hex over SHA-1 digests printing the wrong
                 // nibbles).
+                // Both `? T` (opt_nurl_T) and `! T E` (res_nurl_T) carry the
+                // payload's NURL type; the Ok/Some arm binds T, so an unsigned
+                // T must tag the binding. Without the res_nurl_T branch a
+                // `?? r { T v → … }` over an `! u64 E` treated v as signed
+                // (srem/sdiv/sext on the high half of the u64 range).
                 ? & pt0_is_opt_bool & ( seq pattern_name `T` ) != 0 ( nurl_str_len match_var_name )
                 { : s opt_t ( nurl_sym_get syms ( nurl_str_cat match_var_name `__opt_nurl_T` ) )
-                    ? ( nurl_type_is_unsigned opt_t )
+                    : s res_t ( nurl_sym_get syms ( nurl_str_cat match_var_name `__res_nurl_T` ) )
+                    ? | ( nurl_type_is_unsigned opt_t ) ( nurl_type_is_unsigned res_t )
                     { ( nurl_sym_def syms ( nurl_str_cat pv0 `__unsigned` ) `1` ) }
                     {} }
                 {}

--- a/compiler/tests/outputs/result_payload_unsigned.txt
+++ b/compiler/tests/outputs/result_payload_unsigned.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+res_mod10=5
+res_gt=true
+res_direct_mod10=5
+opt_mod10=5

--- a/compiler/tests/result_payload_unsigned.nu
+++ b/compiler/tests/result_payload_unsigned.nu
@@ -1,0 +1,28 @@
+// result_payload_unsigned.nu — the Ok/T arm of a `?? ` over a Result `! T E`
+// must bind its payload with T's signedness, exactly as the Option `? T` arm
+// already did. The match bound the Result payload by LLVM type only, so a
+// `! u64 E` payload was treated as SIGNED: `% v 10` emitted `srem`, `# i v`
+// sign-extended, comparisons used `icmp s*`. (Option `? u64` was already
+// correct; only Result regressed.)
+@ pr  s l i v → v { ( nurl_print l ) ( nurl_print `=` ) ( nurl_print ( nurl_str_int v ) ) ( nurl_print `\n` ) }
+@ prb s l b v → v { ( nurl_print l ) ( nurl_print `=` ) ( nurl_print ? v `true` `false` ) ( nurl_print `\n` ) }
+
+@ mk_res → ! u64 i { ^ @ ! u64 i { T 18446744073709551615 } }   // all-ones
+@ mk_opt → ? u64 { ^ @ ? u64 { T 18446744073709551615 } }
+
+@ main → i {
+    // bound Result
+    : ! u64 i r ( mk_res )
+    ?? r { T v → {
+        ( pr  `res_mod10` # i % v 10 )      // 5  (urem, not srem -> -1)
+        ( prb `res_gt`    > v 1000 )        // true (unsigned)
+    } F e → {} }
+
+    // direct-call Result
+    ?? ( mk_res ) { T v → ( pr `res_direct_mod10` # i % v 10 )  F e → {} }   // 5
+
+    // Option still correct (regression guard)
+    : ? u64 o ( mk_opt )
+    ?? o { T v → ( pr `opt_mod10` # i % v 10 )  F → {} }   // 5
+    ^ 0
+}


### PR DESCRIPTION
## Summary

Seventh **silent miscompile** of the hardening sweep. A `?? ` over a Result `! T E` bound its Ok/T-arm payload by **LLVM type only**, so an unsigned `T` was treated as **signed** in the arm body. The Option `? T` arm already propagated signedness (via `__opt_nurl_T`); Result (whose T lives in `__res_nurl_T`) did not.

```nurl
: ! u64 i r ( mk_res )            // payload = all-ones
?? r { T v → # i % v 10 … }       // srem(all-ones,10) = -1, should be 5 (urem)
```

`% v` used `srem`, `# i v` sign-extended, `< > <= >=` used signed `icmp` — valid IR, wrong at runtime.

## Fix

The opt/res Ok-arm signedness block now also consults `__res_nurl_T`, so an unsigned `T` tags the payload binding `<v>__unsigned` (same mechanism the Option arm uses). Covers both bound (`: ! u64 i r …`) and direct-call (`?? ( mk_res ) …`) matches. Option behaviour is unchanged.

## Validation

- `! u64 E` Ok payload: `% v 10` → `urem` (5), `> v 1000` unsigned (true), `# i v` zext.
- Direct-call Result match: correct.
- Option `? u64` (regression guard): still correct.
- **451/451 tests pass**; bootstrap fixed point held.
- Regression: `compiler/tests/result_payload_unsigned.nu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)