### PR TITLE
fix(compiler): monomorphised generic struct field carries its unsigned type

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -12964,6 +12964,11 @@
                 : ~ i fidx 0
                 ~ & != ( nurl_lex_type lex2 ) TT_RBRACE != ( nurl_lex_type lex2 ) TT_EOF {
                     : s flt ( parse_type lex2 )
+                    // Capture the SUBSTITUTED field's NURL signedness now (the
+                    // monomorphised LLVM type i8/i16/i32 can't carry it). Mirrors
+                    // gen_struct_decl — without it a `( Pair u64 i )` field load
+                    // defaulted to signed (srem/sdiv/sext/icmp s* on the u64).
+                    : b flt_uns ( nurl_type_is_unsigned ( nurl_sym_get g_res_type_syms `__last_nurl_type__` ) )
                     ? ( is_ident_tok ( nurl_lex_type lex2 ) )
                     { : s fname ( nurl_lex_val lex2 )
                         ( nurl_lex_advance lex2 )
@@ -12979,6 +12984,12 @@
                         ( nurl_sym_def syms
                         ( nurl_str_cat3 mangled `__idx_` ( nurl_str_cat ( nurl_str_int fidx ) `__name` ) )
                         fname )
+                        ( nurl_sym_def syms
+                        ( nurl_str_cat3 mangled `__idx_` ( nurl_str_cat ( nurl_str_int fidx ) `__unsigned` ) )
+                        ? flt_uns `1` `` )
+                        ( nurl_sym_def syms
+                        ( nurl_str_cat mangled ( nurl_str_cat `__` ( nurl_str_cat fname `__unsigned` ) ) )
+                        ? flt_uns `1` `` )
                     }
                     {}
                     ? != first 0

--- a/compiler/tests/generic_struct_field_unsigned.nu
+++ b/compiler/tests/generic_struct_field_unsigned.nu
@@ -1,0 +1,23 @@
+// generic_struct_field_unsigned.nu — a monomorphised generic struct's field
+// must carry the signedness of its CONCRETE field type. ensure_struct_
+// instantiated recorded each field's index/type/name but not its `__unsigned`
+// flag (gen_struct_decl does for concrete structs), so `( Pair u64 i )`'s u64
+// field was treated as SIGNED on access: `% . p first 10` emitted `srem`,
+// `> . p first n` used `icmp sgt`, `# i . p first` sign-extended.
+@ pr s l i v → v { ( nurl_print l ) ( nurl_print `=` ) ( nurl_print ( nurl_str_int v ) ) ( nurl_print `\n` ) }
+
+: Pair [A B] { A first  B second }
+@ mk [A B] A a B b → ( Pair A B ) { ^ @ ( Pair A B ) { a b } }
+
+@ main → i {
+    : ( Pair u64 i ) p ( mk [u64 i] 18446744073709551615 -7 )
+    ( pr `first_mod10` # i % . p first 10 )       // 5   (urem, not srem -> -1)
+    ( pr `first_gt`    ? > . p first 1000 1 0 )   // 1   (unsigned compare)
+    ( pr `first_widen` # i / . p first 2 )        // 9223372036854775807 (udiv)
+    ( pr `second_div`  / . p second 2 )           // -3  (signed field unchanged)
+
+    // unsigned field in the SECOND slot too (different width)
+    : ( Pair i u32 ) q ( mk [i u32] -1 4000000000 )
+    ( pr `q_second`    # i . q second )           // 4000000000 (zext)
+    ^ 0
+}

--- a/compiler/tests/outputs/generic_struct_field_unsigned.txt
+++ b/compiler/tests/outputs/generic_struct_field_unsigned.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+first_mod10=5
+first_gt=1
+first_widen=9223372036854775807
+second_div=-3
+q_second=4000000000


### PR DESCRIPTION
## Summary

Eighth **silent miscompile** of the hardening sweep. `ensure_struct_instantiated` recorded each monomorphised field's index/type/name but **not its `__unsigned` flag** (which `gen_struct_decl` records for concrete structs). So a generic struct's unsigned field was treated as **signed** on access:

```nurl
: Pair [A B] { A first  B second }
: ( Pair u64 i ) p ( mk [u64 i] 18446744073709551615 -7 )
% . p first 10      // srem -> -1, should be 5 (urem)
> . p first 1000    // icmp sgt (wrong), should be ugt
# i . p first       // sext, should be zext
```

Concrete structs (`: Rec { u64 big }`) were already correct — only generic monomorphisation dropped it.

## Fix

Capture the substituted field's NURL signedness from `__last_nurl_type__` right after `parse_type` (mirroring `gen_struct_decl`) and record both `<mangled>__idx_N__unsigned` and `<mangled>__<field>__unsigned`.

## Validation

- `( Pair u64 i )`: `first` field → `urem`/`icmp ugt`/`udiv`/`zext`; `second` (i) → `sdiv` (unchanged).
- `( Pair i u32 )`: `second` field widens with `zext`.
- **452/452 tests pass**; bootstrap fixed point held.
- Regression: `compiler/tests/generic_struct_field_unsigned.nu`.

## Context

This completes the signedness side-channel sweep across binding sites: let, param, struct field (concrete), **generic struct field (this PR)**, enum payload, foreach (#209), call-result (#207), option-arm, and result-arm (#211). Root cause throughout: NURL signedness isn't carried by the LLVM type, so each binding site must record it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)