### PR TITLE
fix(compiler): coerce float literals to f32 struct/aggregate fields

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -10744,6 +10744,28 @@
             = actual_fval cv
             = actual_fty decl_fty }
         {}
+        // Float-width coercion (mirrors the int-width block). A float LITERAL is
+        // always emitted as `double`, so placing one in an `f32` (LLVM `float`)
+        // field needs `fptrunc`; an `f32` value in an `f` field needs `fpext`.
+        // Without this `@ Vec3 { 1.5 2.5 3.5 }` inserted a `double` into a
+        // `float` field — IR nurlc accepted but clang rejected ("insertvalue
+        // operand and field disagree in type: 'double' instead of 'float'").
+        // Enum / opt-res payloads have no `__idx_N__type` roster (decl_fty
+        // empty) and ran their own coercion above, so they are unaffected.
+        ? & ( seq decl_fty `float` ) ( seq actual_fty `double` )
+        { : s cvf ( nurl_cg_reg cg )
+            ( nurl_print `  ` ) ( nurl_print cvf ) ( nurl_print ` = fptrunc double ` )
+            ( nurl_print actual_fval ) ( nurl_print ` to float\n` )
+            = actual_fval cvf
+            = actual_fty `float` }
+        {}
+        ? & ( seq decl_fty `double` ) ( seq actual_fty `float` )
+        { : s cvd ( nurl_cg_reg cg )
+            ( nurl_print `  ` ) ( nurl_print cvd ) ( nurl_print ` = fpext float ` )
+            ( nurl_print actual_fval ) ( nurl_print ` to double\n` )
+            = actual_fval cvd
+            = actual_fty `double` }
+        {}
 
         : s r ( nurl_cg_reg cg )
         ( nurl_print `  ` ) ( nurl_print r )

--- a/compiler/tests/f32_struct_field_literal.nu
+++ b/compiler/tests/f32_struct_field_literal.nu
@@ -1,0 +1,20 @@
+// f32_struct_field_literal.nu — an `f32` (LLVM `float`) struct/aggregate field
+// initialised from a float LITERAL must be coerced. A float literal is always
+// emitted as `double`, and gen_agg_lit only coerced INTEGER field widths — so
+// `@ Vec3 { 1.5 2.5 3.5 }` inserted a `double` into a `float` field, which
+// nurlc accepted (rc 0) but clang rejected: "insertvalue operand and field
+// disagree in type: 'double' instead of 'float'". gen_agg_lit now fptrunc's
+// double→float (and fpext's float→double) using the field's declared type.
+@ pr s l i v → v { ( nurl_print l ) ( nurl_print `=` ) ( nurl_print ( nurl_str_int v ) ) ( nurl_print `\n` ) }
+: Vec3 { f32 x  f32 y  f32 z }
+: Mixed { f d  f32 g }
+
+@ main → i {
+    : Vec3 v @ Vec3 { 1.5 2.5 4.0 }
+    ( pr `x_plus_y` # i + . v x . v y )     // 4   (1.5 + 2.5)
+    ( pr `z`        # i . v z )             // 4
+    ( pr `dot_ish`  # i + + * . v x . v x * . v y . v y * . v z . v z )  // 2.25+6.25+16 = 24
+    : Mixed m @ Mixed { 10.0 7.0 }
+    ( pr `d_plus_f` # i + . m d # f . m g )  // 17  (f64 + f32-widened)
+    ^ 0
+}

--- a/compiler/tests/outputs/f32_struct_field_literal.txt
+++ b/compiler/tests/outputs/f32_struct_field_literal.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+x_plus_y=4
+z=4
+dot_ish=24
+d_plus_f=17


### PR DESCRIPTION
## Summary

f32 aggregates were unusable with literals. A float literal is always emitted as `double`, and `gen_agg_lit` only coerced **integer** field widths, so an `f32` (LLVM `float`) field initialised from a literal got a `double` inserted:

```nurl
: Vec3 { f32 x  f32 y  f32 z }
@ Vec3 { 1.5 2.5 3.5 }
```

nurlc accepted it (rc 0); **clang rejected** with `insertvalue operand and field disagree in type: 'double' instead of 'float'`. (A typed `f32` binding as the field value worked, so this was literal-specific.)

## Fix

Alongside the existing int-width coercion, `gen_agg_lit` now coerces **float widths** against the field's declared type: `fptrunc double → float` for an `f32` field, `fpext float → double` for an `f` field. Enum / opt-res payloads have no `__idx_N__type` roster and run their own coercion, so they're unaffected.

## Validation

- `: Vec3 { f32 … }` with literal components: arithmetic and field reads correct (`1.5+2.5=4`, dot-product `24`).
- `: Mixed { f d  f32 g }` mixing `f` and `f32` fields: correct.
- **453/453 tests pass**; bootstrap fixed point held.
- Regression: `compiler/tests/f32_struct_field_literal.nu`.

## Follow-up (separate, found alongside)

Enum f32 **payloads** (`@ Num { F32 2.25 }` then `?? n { F32 q → … }`) are a *separate, silent* bug — construction bitcasts the `double` bits to i64 while extraction reads the low i32 as float, so the value comes back as `0`. Will fix in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)