### PR TITLE
fix(compiler): enum f32 payload round-trips (construct from declared type)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -10586,17 +10586,48 @@
                     {  // Float payload → ptr slot. Bitcast the float to a
                         // same-width int (f32 widens i32→i64), then inttoptr.
                         // The match arm inverts this (emit_enum_float_extract).
+                        //
+                        // Pick the slot width from the variant's DECLARED payload
+                        // type, NOT the value's: a float LITERAL is always
+                        // `double`, so an `f32` payload (`@ N { F32 2.25 }`) would
+                        // otherwise bitcast the whole double to i64, while
+                        // emit_enum_float_extract reads the low 32 bits back as a
+                        // float → garbage (returned 0). The payload index is
+                        // idx-1 (idx 0 is the tag slot).
+                        : s decl_pt ? & != 0 ( nurl_str_len enum_vname ) >= idx 1
+                        ( nurl_sym_get syms ( nurl_str_cat3 enum_vname `__payload__` ( nurl_str_int - idx 1 ) ) )
+                        fty
                         : ~ s ibits ``
-                        ? ( seq fty `double` )
-                        { = ibits ( nurl_cg_reg cg )
-                            ( nurl_print `  ` ) ( nurl_print ibits )
-                            ( nurl_print ` = bitcast double ` ) ( nurl_print fval ) ( nurl_print ` to i64\n` ) }
-                        { : s b32 ( nurl_cg_reg cg )
+                        ? ( seq decl_pt `float` )
+                        {  // f32 slot: ensure the value is `float` (fptrunc a
+                            // double literal), then bitcast→i32, zext→i64.
+                            : ~ s fv32 fval
+                            ? ( seq fty `double` )
+                            { : s ftr ( nurl_cg_reg cg )
+                                ( nurl_print `  ` ) ( nurl_print ftr )
+                                ( nurl_print ` = fptrunc double ` ) ( nurl_print fval )
+                                ( nurl_print ` to float\n` )
+                                = fv32 ftr }
+                            {}
+                            : s b32 ( nurl_cg_reg cg )
                             ( nurl_print `  ` ) ( nurl_print b32 )
-                            ( nurl_print ` = bitcast float ` ) ( nurl_print fval ) ( nurl_print ` to i32\n` )
+                            ( nurl_print ` = bitcast float ` ) ( nurl_print fv32 ) ( nurl_print ` to i32\n` )
                             = ibits ( nurl_cg_reg cg )
                             ( nurl_print `  ` ) ( nurl_print ibits )
                             ( nurl_print ` = zext i32 ` ) ( nurl_print b32 ) ( nurl_print ` to i64\n` ) }
+                        {  // double slot: ensure the value is `double` (fpext an
+                            // f32 value), then bitcast→i64.
+                            : ~ s fv64 fval
+                            ? ( seq fty `float` )
+                            { : s fpe ( nurl_cg_reg cg )
+                                ( nurl_print `  ` ) ( nurl_print fpe )
+                                ( nurl_print ` = fpext float ` ) ( nurl_print fval )
+                                ( nurl_print ` to double\n` )
+                                = fv64 fpe }
+                            {}
+                            = ibits ( nurl_cg_reg cg )
+                            ( nurl_print `  ` ) ( nurl_print ibits )
+                            ( nurl_print ` = bitcast double ` ) ( nurl_print fv64 ) ( nurl_print ` to i64\n` ) }
                         : s conv_regf ( nurl_cg_reg cg )
                         ( nurl_print `  ` ) ( nurl_print conv_regf )
                         ( nurl_print ` = inttoptr i64 ` ) ( nurl_print ibits ) ( nurl_print ` to ptr\n` )

--- a/compiler/tests/enum_f32_payload.nu
+++ b/compiler/tests/enum_f32_payload.nu
@@ -1,0 +1,27 @@
+// enum_f32_payload.nu — an enum variant with an `f32` payload must round-trip.
+// Construction picked the slot width from the VALUE's type, but a float literal
+// is always `double`, so `@ N { F32 2.25 }` bitcast the whole double to i64
+// while the match arm (emit_enum_float_extract) read the LOW 32 bits back as a
+// float — a silent miscompile that returned 0. Construction now picks f32-vs-f
+// from the variant's DECLARED payload type and fptrunc's the literal to float.
+@ prf s l f v → v { ( nurl_print l ) ( nurl_print `=` ) ( nurl_print ( float_to_string v ) ) ( nurl_print `\n` ) }
+$ `stdlib/std/float.nu`
+
+: | NumA { F32 f32 }
+: | NumB { F64 f }
+: | P { Two f32 f32  Mix i f32 }   // f32 at payload index 0 and 1
+
+@ main → i {
+    : NumA a @ NumA { F32 2.25 }
+    ?? a { F32 q → ( prf `f32_single` # f q ) }          // 2.25
+
+    : NumB b @ NumB { F64 3.5 }
+    ?? b { F64 q → ( prf `f64_single` q ) }              // 3.5  (regression guard)
+
+    : P p @ P { Two 1.25 2.75 }
+    ?? p { Two x y → { ( prf `two_x` # f x ) ( prf `two_y` # f y ) }  Mix _ _ → {} }   // 1.25 / 2.75
+
+    : P m @ P { Mix 7 9.5 }
+    ?? m { Mix n z → ( prf `mix_z` # f z )  Two _ _ → {} }   // 9.5  (f32 at index 1, int at 0)
+    ^ 0
+}

--- a/compiler/tests/outputs/enum_f32_payload.txt
+++ b/compiler/tests/outputs/enum_f32_payload.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+f32_single=2.25
+f64_single=3.5
+two_x=1.25
+two_y=2.75
+mix_z=9.5


### PR DESCRIPTION
## Summary

A **silent miscompile** (the follow-up flagged in #213). An enum variant with an `f32` payload returned `0`:

```nurl
: | NumA { F32 f32 }
?? ( @ NumA { F32 2.25 } ) { F32 q → … }   // 0, should be 2.25
```

`gen_agg_lit` picked the payload slot's float width from the **value's** type, but a float literal is always `double`. So construction `bitcast double 2.25 → i64` stored the 64-bit double pattern, while the match arm (`emit_enum_float_extract`) reads the **low 32 bits** back as a `float` (`trunc i64→i32`, `bitcast i32→float`). The patterns don't line up → garbage (0). The f64 enum payload was fine (value-double == slot-double); only f32 broke.

## Fix

The enum float-payload construction now reads the variant's **declared** payload type (`<variant>__payload__<idx-1>`):
- f32 slot → `fptrunc double→float` (if the value is a double literal), then `bitcast float→i32`, `zext i32→i64` — matching the extraction.
- f slot → `fpext float→double` (if the value is an f32), then `bitcast double→i64`.

Covers single- and multi-payload variants and f32 at any payload position.

## Validation

- `@ NumA { F32 2.25 }` → `2.25`; `@ NumB { F64 3.5 }` → `3.5` (guard).
- Multi-payload `Two f32 f32` → `1.25`/`2.75`; `Mix i f32` → `9.5` (f32 at index 1).
- **454/454 tests pass**; bootstrap fixed point held.
- Regression: `compiler/tests/enum_f32_payload.nu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)