### PR TITLE
fix(compiler): Result Err-arm payload inherits E's unsigned type

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -6268,6 +6268,17 @@
                     { ( nurl_sym_def syms ( nurl_str_cat pv0 `__unsigned` ) `1` ) }
                     {} }
                 {}
+                // The Err arm (`F e`) of `! T E` binds the ERROR payload E, so an
+                // unsigned E must tag the binding too — same hazard as the Ok arm
+                // above, via `__res_nurl_E` (set by gen_let_or_struct / the
+                // direct-call synthesis). Without this `?? r { F e → % e 10 }`
+                // over an `! T u64` treated e as signed.
+                ? & pt0_is_opt_bool & ( seq pattern_name `F` ) != 0 ( nurl_str_len match_var_name )
+                { : s res_e ( nurl_sym_get syms ( nurl_str_cat match_var_name `__res_nurl_E` ) )
+                    ? ( nurl_type_is_unsigned res_e )
+                    { ( nurl_sym_def syms ( nurl_str_cat pv0 `__unsigned` ) `1` ) }
+                    {} }
+                {}
             } {}
             // Bind second payload variable (enum field 2)
             ? != 0 ( nurl_str_len pv1 ) {

--- a/compiler/tests/outputs/result_err_arm_unsigned.txt
+++ b/compiler/tests/outputs/result_err_arm_unsigned.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+err_mod10=5
+err_direct_mod10=5
+err_gt=1
+ok_mod10=5

--- a/compiler/tests/result_err_arm_unsigned.nu
+++ b/compiler/tests/result_err_arm_unsigned.nu
@@ -1,0 +1,21 @@
+// result_err_arm_unsigned.nu — the Err arm (`F e`) of a `?? ` over `! T E` binds
+// the ERROR payload E and must carry E's signedness, just as the Ok arm binds T
+// (fixed earlier). An `! T u64` error treated `e` as SIGNED: `% e 10` emitted
+// `srem`, `# i e` sign-extended, etc.
+@ pr s l i v → v { ( nurl_print l ) ( nurl_print `=` ) ( nurl_print ( nurl_str_int v ) ) ( nurl_print `\n` ) }
+
+@ mk_err → ! i u64 { ^ @ ! i u64 { F 18446744073709551615 } }   // Err(all-ones)
+@ mk_ok  → ! u64 i { ^ @ ! u64 i { T 18446744073709551615 } }   // Ok(all-ones)
+
+@ main → i {
+    // Err arm, unsigned E (bound + direct)
+    : ! i u64 r ( mk_err )
+    ?? r { T v → {}  F e → ( pr `err_mod10` # i % e 10 ) }                   // 5
+    ?? ( mk_err ) { T v → {}  F e → ( pr `err_direct_mod10` # i % e 10 ) }   // 5
+    ?? r { T v → {}  F e → ( pr `err_gt` ? > e 1000 1 0 ) }                  // 1 (unsigned)
+
+    // Ok arm, unsigned T (regression guard for #211)
+    : ! u64 i k ( mk_ok )
+    ?? k { T v → ( pr `ok_mod10` # i % v 10 )  F e → {} }                    // 5
+    ^ 0
+}


### PR DESCRIPTION
## Summary

The dual of #211. The **Err arm** (`F e`) of a `?? ` over a Result `! T E` binds the error payload `E` but didn't carry `E`'s signedness (only the Ok arm was fixed). An `! T u64` error treated `e` as **signed**:

```nurl
?? r { T v → …  F e → # i % e 10 }   // srem(all-ones,10) = -1, should be 5 (urem)
```

`% e` used `srem`, `# i e` sign-extended, `< > <= >=` used signed `icmp` — valid IR, wrong at runtime.

## Fix

The match unsigned block now also handles the `F` arm, tagging the payload binding from `__res_nurl_E` (set for bound, direct-call, and param matches). Covers both forms; the Ok-arm (`__res_nurl_T`) path is unchanged.

## Validation

- `! i u64` Err payload: `% e 10` → `urem` (5), `> e 1000` unsigned (1); bound and direct-call.
- `! u64 i` Ok payload (regression guard for #211): still correct.
- **455/455 tests pass**; bootstrap fixed point held.
- Regression: `compiler/tests/result_err_arm_unsigned.nu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)