### PR TITLE
Release pipeline + curl|sh installer for the toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,145 @@
+name: release
+
+# Build and publish the NURL toolchain (compiler + package manager +
+# stdlib) as relocatable install packages whenever a `v*` tag is pushed.
+#
+# Targets:
+#   - linux-x86_64-glibc   (ubuntu-latest, native)
+#   - linux-arm64-glibc    (ubuntu-24.04-arm, native — free for public repos)
+#   - windows-x86_64       (windows-latest, native)
+#
+# Each job assembles the prefix with tools/install-toolchain.{sh,bat}
+# (relocatable shims) and packages it. The final `release` job attaches
+# every archive + its .sha256 to the GitHub Release. The curl|sh front
+# door (tools/get-nurl.sh / .ps1, served from nurl-lang.org) downloads
+# these by target triple.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.1.0); for a dry run without a real tag'
+        required: true
+
+permissions:
+  contents: write    # create releases + upload assets
+
+env:
+  NURL_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+
+jobs:
+  # ── Linux (x86_64 + arm64), native per-arch runners ──────────────────
+  linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x86_64-glibc
+            runner: ubuntu-latest
+          - target: linux-arm64-glibc
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps (clang + FFI libs)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            clang pkg-config \
+            libcurl4-openssl-dev libssl-dev libsqlite3-dev \
+            libpq-dev zlib1g-dev libzstd-dev
+          clang --version
+
+      - name: Build toolchain (nurlc + nurlpkg)
+        run: |
+          ./build.sh --no-tests
+          ./tools/nurlpkg/build.sh
+
+      - name: Assemble relocatable prefix
+        run: NURL_HOME="$PWD/dist/nurl" ./tools/install-toolchain.sh
+
+      - name: Smoke test the assembled toolchain
+        run: |
+          printf '$ `stdlib/core/io.nu`\n@ main \xe2\x86\x92 i { ( nurl_print `ok\\n` ) ^ 0 }\n' > /tmp/s.nu
+          ./dist/nurl/bin/nurl /tmp/s.nu /tmp/s && /tmp/s
+
+      - name: Package
+        run: |
+          PKG="nurl-${NURL_TAG}-${{ matrix.target }}.tar.gz"
+          tar czf "$PKG" -C dist nurl
+          sha256sum "$PKG" > "$PKG.sha256"
+          echo "PKG=$PKG" >> "$GITHUB_ENV"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            ${{ env.PKG }}
+            ${{ env.PKG }}.sha256
+          if-no-files-found: error
+
+  # ── Windows (native) ─────────────────────────────────────────────────
+  windows:
+    runs-on: windows-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install LLVM/clang
+        run: choco install llvm -y --no-progress
+        shell: pwsh
+
+      - name: Build toolchain (nurlc + nurlpkg)
+        shell: cmd
+        run: |
+          call build.bat
+          call tools\nurlpkg\build.bat
+
+      - name: Assemble relocatable prefix
+        shell: cmd
+        run: |
+          set "NURL_HOME=%CD%\dist\nurl"
+          call tools\install-toolchain.bat
+
+      - name: Package
+        shell: pwsh
+        run: |
+          $pkg = "nurl-$env:NURL_TAG-windows-x86_64.zip"
+          Compress-Archive -Path dist\nurl -DestinationPath $pkg
+          (Get-FileHash $pkg -Algorithm SHA256).Hash.ToLower() + "  " + $pkg | Out-File "$pkg.sha256" -Encoding ascii
+          "PKG=$pkg" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-x86_64
+          path: |
+            ${{ env.PKG }}
+            ${{ env.PKG }}.sha256
+          if-no-files-found: error
+
+  # ── Publish the GitHub Release ───────────────────────────────────────
+  release:
+    needs: [linux, windows]
+    runs-on: ubuntu-latest
+    # Only publish for a real pushed tag, not a workflow_dispatch dry run.
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: NURL ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.zip
+            artifacts/*.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ TODO.md
 critic.md
 output.txt
 stdlib/runtime.wasm.o.bind
+/dist/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,74 @@
+# Releasing the NURL toolchain
+
+Distribution model (the rustup / Zig / Bun shape):
+
+- **GitHub Releases** is the artifact store — one relocatable archive per
+  target plus its `.sha256`.
+- **`tools/get-nurl.sh` / `get-nurl.ps1`** is the front door, served from
+  `nurl-lang.org` so users run `curl -fsSL https://nurl-lang.org/install.sh | sh`.
+  It detects OS/arch, downloads the matching archive, verifies the
+  checksum, and unpacks the toolchain into `~/.nurl`.
+- **`reg.nurl-lang.org`** stays the *package* registry (libraries and
+  programs). It does **not** distribute the toolchain — separate concern.
+
+## Cutting a release
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+`.github/workflows/release.yml` then builds, on a `v*` tag:
+
+| Target | Runner | Archive |
+|---|---|---|
+| `linux-x86_64-glibc` | `ubuntu-latest` | `nurl-<tag>-linux-x86_64-glibc.tar.gz` |
+| `linux-arm64-glibc`  | `ubuntu-24.04-arm` | `nurl-<tag>-linux-arm64-glibc.tar.gz` |
+| `windows-x86_64`     | `windows-latest` | `nurl-<tag>-windows-x86_64.zip` |
+
+Each job builds `nurlc` + `nurlpkg`, assembles the prefix with
+`tools/install-toolchain.{sh,bat}` (relocatable shims), packages it, and
+the final `release` job attaches every archive + `.sha256` to the GitHub
+Release. Use the `workflow_dispatch` input for a dry run that builds the
+artifacts without publishing.
+
+An archive is just the `~/.nurl` layout (`bin/`, `build/`, `stdlib/`,
+`nurl.{sh,bat}`, `env`) with shims that resolve their own location, so it
+works wherever it is unpacked.
+
+## Runtime dependencies (dynamic linking)
+
+The shipped binaries link a few system libraries dynamically. `glibc`
+targets assume a normal desktop/server distro where these are present:
+
+- **`nurlpkg`** needs **libcurl** + **OpenSSL** for registry HTTPS on Linux
+  (Windows uses WinHTTP, no extra deps).
+- A user program links additional libraries only when it imports the
+  matching module (`nurl.sh`/`nurl.bat` add them on demand from the
+  `stdlib/runtime.<feature>` sentinels shipped in the archive).
+
+A fully self-contained (statically linked) build is a possible follow-up.
+
+## Front-door wiring (nurlweb)
+
+`nurl-lang.org` should serve the two installer scripts so the one-liners
+work. Point:
+
+- `https://nurl-lang.org/install.sh`  → `tools/get-nurl.sh`
+- `https://nurl-lang.org/install.ps1` → `tools/get-nurl.ps1`
+
+(either a static copy in the nurlweb deploy, or a redirect to the repo's
+`raw.githubusercontent.com` path). `$NURL_INSTALL_BASE` overrides the
+download base for internal mirrors / air-gapped installs.
+
+## Status / caveats
+
+- The Linux client path (download → verify → unpack → run) is verified
+  end to end against a local mirror; the relocatable prefix is verified by
+  moving it after install.
+- The **Windows job is unverified on a real runner** — `build.bat` +
+  `tools/nurlpkg/build.bat` + `install-toolchain.bat` exist but the
+  toolchain has not yet been cut on `windows-latest`; exercise it with the
+  `workflow_dispatch` dry run before announcing Windows support.
+- macOS is not built yet (the installer rejects it with a clear message);
+  add a `macos-14` (arm64) / `macos-13` (x86_64) matrix when wanted.

--- a/tools/get-nurl.ps1
+++ b/tools/get-nurl.ps1
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  get-nurl.ps1 - one-line installer for the NURL toolchain on Windows.
+#
+#  Downloads the matching release archive from GitHub Releases, verifies
+#  its SHA-256, and unpacks the relocatable toolchain into $NURL_HOME
+#  (default %USERPROFILE%\.nurl). Then add %NURL_HOME%\bin to PATH.
+#
+#  Usage (PowerShell):
+#    irm https://nurl-lang.org/install.ps1 | iex
+#    & ([scriptblock]::Create((irm https://nurl-lang.org/install.ps1))) -Version v0.1.0
+#
+#  Params:
+#    -Version <tag>   release tag to install (default: latest)
+#    -Prefix  <dir>   install prefix (default: %USERPROFILE%\.nurl)
+# ============================================================
+param(
+    [string]$Version = $env:NURL_VERSION,
+    [string]$Prefix  = $(if ($env:NURL_HOME) { $env:NURL_HOME } else { Join-Path $env:USERPROFILE ".nurl" })
+)
+$ErrorActionPreference = "Stop"
+$repo = "nurl-lang/nurl"
+$target = "windows-x86_64"
+
+# ── Resolve version (latest release tag if unset) ──────────────────────
+if (-not $Version) {
+    Write-Host "resolving latest release..."
+    $rel = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest"
+    $Version = $rel.tag_name
+    if (-not $Version) { throw "could not determine the latest release tag; pass -Version vX.Y.Z." }
+}
+
+$archive = "nurl-$Version-$target.zip"
+$base = "https://github.com/$repo/releases/download/$Version"
+$tmp = Join-Path $env:TEMP ("nurl-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+
+try {
+    Write-Host "downloading $archive ($Version)..."
+    $zip = Join-Path $tmp $archive
+    Invoke-WebRequest "$base/$archive" -OutFile $zip
+
+    # ── Verify checksum (best-effort) ──────────────────────────────────
+    try {
+        $sumFile = "$zip.sha256"
+        Invoke-WebRequest "$base/$archive.sha256" -OutFile $sumFile
+        $want = ((Get-Content $sumFile) -split '\s+')[0].ToLower()
+        $got = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
+        if ($want -ne $got) { throw "checksum mismatch (expected $want, got $got)." }
+        Write-Host "checksum OK"
+    } catch {
+        Write-Host "warning: checksum verification skipped ($($_.Exception.Message))"
+    }
+
+    # ── Unpack (archive has a top-level nurl\ dir) ─────────────────────
+    Write-Host "installing to $Prefix..."
+    if (Test-Path $Prefix) { Remove-Item -Recurse -Force $Prefix }
+    New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
+    $unzipTmp = Join-Path $tmp "x"
+    Expand-Archive -Path $zip -DestinationPath $unzipTmp -Force
+    Copy-Item -Recurse -Force (Join-Path $unzipTmp "nurl\*") $Prefix
+
+    if (-not (Test-Path (Join-Path $Prefix "bin\nurl.bat"))) {
+        throw "install looks incomplete: $Prefix\bin\nurl.bat missing."
+    }
+
+    Write-Host ""
+    Write-Host "NURL $Version installed -> $Prefix"
+    Write-Host ""
+    Write-Host "Add it to this session:"
+    Write-Host "    `$env:Path = `"$Prefix\bin;`$env:Path`""
+    Write-Host "Make it permanent:"
+    Write-Host "    setx PATH `"$Prefix\bin;%PATH%`""
+    Write-Host "    setx NURL_STDLIB `"$Prefix`""
+    Write-Host ""
+    Write-Host "Then:  nurlc --version   ·   nurlpkg install argz-demo"
+}
+finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}

--- a/tools/get-nurl.sh
+++ b/tools/get-nurl.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env sh
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  get-nurl.sh — one-line installer for the NURL toolchain.
+#
+#  Detects your OS/arch, downloads the matching release archive from
+#  GitHub Releases, verifies its SHA-256, and unpacks the relocatable
+#  toolchain into $NURL_HOME (default ~/.nurl). Then add ~/.nurl/bin to
+#  PATH (the installer prints the exact line).
+#
+#  Usage:
+#    curl -fsSL https://nurl-lang.org/install.sh | sh
+#    curl -fsSL https://nurl-lang.org/install.sh | sh -s -- --version v0.1.0
+#
+#  Env:
+#    NURL_HOME     install prefix (default ~/.nurl)
+#    NURL_VERSION  release tag to install (default: latest)
+#
+#  POSIX sh — no bashisms; works under dash/ash/busybox.
+# ============================================================
+set -eu
+
+REPO="nurl-lang/nurl"
+PREFIX="${NURL_HOME:-$HOME/.nurl}"
+VERSION="${NURL_VERSION:-}"
+
+err() { printf 'error: %s\n' "$*" >&2; exit 1; }
+info() { printf '%s\n' "$*" >&2; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# ── Args ───────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version) VERSION="${2:-}"; shift 2 ;;
+        --version=*) VERSION="${1#--version=}"; shift ;;
+        --prefix) PREFIX="${2:-}"; shift 2 ;;
+        --prefix=*) PREFIX="${1#--prefix=}"; shift ;;
+        -h|--help)
+            sed -n '5,22p' "$0" 2>/dev/null | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *) err "unknown argument: $1 (try --help)" ;;
+    esac
+done
+
+# ── Detect target triple ───────────────────────────────────────────────
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os" in
+    Linux) ;;
+    Darwin) err "macOS packages are not published yet; build from source (see README)." ;;
+    *) err "unsupported OS '$os'. On Windows use the PowerShell installer (install.ps1)." ;;
+esac
+case "$arch" in
+    x86_64|amd64)  target="linux-x86_64-glibc" ;;
+    aarch64|arm64) target="linux-arm64-glibc" ;;
+    *) err "unsupported architecture '$arch'." ;;
+esac
+
+# ── Downloader ─────────────────────────────────────────────────────────
+if have curl; then
+    dl() { curl -fsSL "$1" -o "$2"; }
+    dl_stdout() { curl -fsSL "$1"; }
+elif have wget; then
+    dl() { wget -qO "$2" "$1"; }
+    dl_stdout() { wget -qO- "$1"; }
+else
+    err "need curl or wget on PATH."
+fi
+
+# ── Resolve version (latest release tag if unset) ──────────────────────
+if [ -z "$VERSION" ]; then
+    info "resolving latest release…"
+    VERSION="$(dl_stdout "https://api.github.com/repos/$REPO/releases/latest" \
+        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)"
+    [ -n "$VERSION" ] || err "could not determine the latest release tag; pass --version vX.Y.Z."
+fi
+
+archive="nurl-${VERSION}-${target}.tar.gz"
+# $NURL_INSTALL_BASE overrides the download base (internal mirror / test).
+base="${NURL_INSTALL_BASE:-https://github.com/$REPO/releases/download/$VERSION}"
+
+# ── Download + verify ──────────────────────────────────────────────────
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+info "downloading $archive ($VERSION)…"
+dl "$base/$archive" "$tmp/$archive" || err "download failed: $base/$archive"
+
+if dl "$base/$archive.sha256" "$tmp/$archive.sha256" 2>/dev/null; then
+    info "verifying checksum…"
+    want="$(awk '{print $1}' "$tmp/$archive.sha256")"
+    if have sha256sum; then
+        got="$(sha256sum "$tmp/$archive" | awk '{print $1}')"
+    elif have shasum; then
+        got="$(shasum -a 256 "$tmp/$archive" | awk '{print $1}')"
+    else
+        got=""; info "warning: no sha256sum/shasum — skipping checksum verification."
+    fi
+    [ -z "$got" ] || [ "$got" = "$want" ] || err "checksum mismatch (expected $want, got $got)."
+else
+    info "warning: no checksum file published — skipping verification."
+fi
+
+# ── Unpack (the archive has a top-level nurl/ dir) ─────────────────────
+info "installing to $PREFIX…"
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+tar xzf "$tmp/$archive" -C "$PREFIX" --strip-components=1
+
+[ -x "$PREFIX/bin/nurl" ] || err "install looks incomplete: $PREFIX/bin/nurl missing."
+
+# ── Done ───────────────────────────────────────────────────────────────
+info ""
+info "NURL $VERSION installed → $PREFIX"
+info ""
+info "Add it to your shell (and your ~/.bashrc / ~/.zshrc):"
+info "    source $PREFIX/env"
+info ""
+info "Or just add the bin dir to PATH:"
+info "    export PATH=\"$PREFIX/bin:\$PATH\""
+info ""
+info "Then:  nurlc --version   ·   nurlpkg install argz-demo"

--- a/tools/install-toolchain.bat
+++ b/tools/install-toolchain.bat
@@ -63,33 +63,37 @@ xcopy /e /i /y /q "%ROOT%\stdlib" "%PREFIX%\stdlib" >nul
 REM Build driver (resolves build\nurlc.exe + stdlib\runtime.o relative to itself).
 copy /y "%ROOT%\nurl.bat" "%PREFIX%\nurl.bat" >nul
 
-REM ── PATH shims ────────────────────────────────────────────────
-REM Each shim defaults NURL_STDLIB to the prefix so the compiler finds the
-REM shipped stdlib from any directory. The nurlpkg shim also points NURL at
-REM the installed driver so `nurlpkg install <name>` builds with it.
+REM ── PATH shims (RELOCATABLE) ──────────────────────────────────
+REM Each shim resolves the prefix from its OWN location (%%~dp0..) at
+REM runtime, so the extracted tree works wherever it lands. It defaults
+REM NURL_STDLIB to the prefix so the compiler finds the shipped stdlib
+REM from any directory. The nurlpkg shim also points NURL at the driver.
 > "%PREFIX%\bin\nurl.bat" (
   echo @echo off
-  echo if not defined NURL_STDLIB set "NURL_STDLIB=%PREFIX%"
-  echo call "%PREFIX%\nurl.bat" %%*
+  echo for %%%%I in ^("%%~dp0.."^) do set "NURL_PREFIX=%%%%~fI"
+  echo if not defined NURL_STDLIB set "NURL_STDLIB=%%NURL_PREFIX%%"
+  echo call "%%NURL_PREFIX%%\nurl.bat" %%*
 )
 > "%PREFIX%\bin\nurlc.bat" (
   echo @echo off
-  echo if not defined NURL_STDLIB set "NURL_STDLIB=%PREFIX%"
-  echo "%PREFIX%\build\nurlc.exe" %%*
+  echo for %%%%I in ^("%%~dp0.."^) do set "NURL_PREFIX=%%%%~fI"
+  echo if not defined NURL_STDLIB set "NURL_STDLIB=%%NURL_PREFIX%%"
+  echo "%%NURL_PREFIX%%\build\nurlc.exe" %%*
 )
 > "%PREFIX%\bin\nurlpkg.bat" (
   echo @echo off
-  echo if not defined NURL_STDLIB set "NURL_STDLIB=%PREFIX%"
-  echo if not defined NURL set "NURL=%PREFIX%\bin\nurl.bat"
-  echo "%PREFIX%\build\nurlpkg.exe" %%*
+  echo for %%%%I in ^("%%~dp0.."^) do set "NURL_PREFIX=%%%%~fI"
+  echo if not defined NURL_STDLIB set "NURL_STDLIB=%%NURL_PREFIX%%"
+  echo if not defined NURL set "NURL=%%NURL_PREFIX%%\bin\nurl.bat"
+  echo "%%NURL_PREFIX%%\build\nurlpkg.exe" %%*
 )
 
-REM ── Sourceable session env ────────────────────────────────────
+REM ── Sourceable session env (RELOCATABLE) ──────────────────────
 > "%PREFIX%\env.bat" (
   echo @echo off
-  echo set "NURL_HOME=%PREFIX%"
-  echo set "NURL_STDLIB=%PREFIX%"
-  echo set "PATH=%PREFIX%\bin;%%PATH%%"
+  echo for %%%%I in ^("%%~dp0"^) do set "NURL_HOME=%%%%~fI"
+  echo set "NURL_STDLIB=%%NURL_HOME%%"
+  echo set "PATH=%%NURL_HOME%%\bin;%%PATH%%"
 )
 
 echo Done.

--- a/tools/install-toolchain.sh
+++ b/tools/install-toolchain.sh
@@ -60,42 +60,52 @@ cp -a "$ROOT/stdlib/." "$PREFIX/stdlib/"
 # Build driver (resolves build/nurlc + stdlib/runtime.o relative to itself).
 install -m755 "$ROOT/nurl.sh" "$PREFIX/nurl.sh"
 
-# ── PATH shims ─────────────────────────────────────────────────────────
-# Each shim defaults $NURL_STDLIB to the prefix so the compiler finds the
-# shipped stdlib from any working directory, even if the user never
-# sourced env. The nurlpkg shim additionally points $NURL / $NURLPKG at
-# the installed driver so `nurlpkg install <name>` builds with them.
-cat > "$PREFIX/bin/nurl" <<EOF
+# ── PATH shims (RELOCATABLE) ───────────────────────────────────────────
+# Each shim resolves the prefix from its OWN location at runtime, so the
+# whole tree can be moved/extracted anywhere (this is what lets the
+# release tarball be unpacked to any path). It defaults $NURL_STDLIB to
+# the prefix so the compiler finds the shipped stdlib from any working
+# directory, even if the user never sourced env. The nurlpkg shim also
+# points $NURL / $NURLPKG at the installed driver so `nurlpkg install
+# <name>` builds with them. Quoted heredoc → no install-time expansion.
+cat > "$PREFIX/bin/nurl" <<'EOF'
 #!/usr/bin/env bash
-export NURL_STDLIB="\${NURL_STDLIB:-$PREFIX}"
-exec "$PREFIX/nurl.sh" "\$@"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export NURL_STDLIB="${NURL_STDLIB:-$HERE}"
+exec "$HERE/nurl.sh" "$@"
 EOF
 
-cat > "$PREFIX/bin/nurlc" <<EOF
+cat > "$PREFIX/bin/nurlc" <<'EOF'
 #!/usr/bin/env bash
-export NURL_STDLIB="\${NURL_STDLIB:-$PREFIX}"
-exec "$PREFIX/build/nurlc" "\$@"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export NURL_STDLIB="${NURL_STDLIB:-$HERE}"
+exec "$HERE/build/nurlc" "$@"
 EOF
 
-cat > "$PREFIX/bin/nurlpkg" <<EOF
+cat > "$PREFIX/bin/nurlpkg" <<'EOF'
 #!/usr/bin/env bash
-export NURL_STDLIB="\${NURL_STDLIB:-$PREFIX}"
-export NURL="\${NURL:-$PREFIX/bin/nurl}"
-export NURLPKG="\${NURLPKG:-$PREFIX/bin/nurlpkg}"
-exec "$PREFIX/build/nurlpkg" "\$@"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export NURL_STDLIB="${NURL_STDLIB:-$HERE}"
+export NURL="${NURL:-$HERE/bin/nurl}"
+export NURLPKG="${NURLPKG:-$HERE/bin/nurlpkg}"
+exec "$HERE/build/nurlpkg" "$@"
 EOF
 
 chmod +x "$PREFIX/bin/nurl" "$PREFIX/bin/nurlc" "$PREFIX/bin/nurlpkg"
 
-# ── Sourceable env ─────────────────────────────────────────────────────
-cat > "$PREFIX/env" <<EOF
+# ── Sourceable env (RELOCATABLE) ───────────────────────────────────────
+# Resolves its own directory when sourced, so a moved/extracted tree still
+# points NURL_HOME / NURL_STDLIB / PATH at the right place.
+cat > "$PREFIX/env" <<'EOF'
 # NURL toolchain environment — source this from your shell rc.
-export NURL_HOME="$PREFIX"
-export NURL_STDLIB="$PREFIX"
-case ":\$PATH:" in
-    *":$PREFIX/bin:"*) ;;
-    *) export PATH="$PREFIX/bin:\$PATH" ;;
+__nurl_here="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+export NURL_HOME="$__nurl_here"
+export NURL_STDLIB="$__nurl_here"
+case ":$PATH:" in
+    *":$__nurl_here/bin:"*) ;;
+    *) export PATH="$__nurl_here/bin:$PATH" ;;
 esac
+unset __nurl_here
 EOF
 
 echo "Done."


### PR DESCRIPTION
## Summary

Distribute the NURL toolchain (compiler + package manager + stdlib) as install packages on **`v*` tags**, the rustup / Zig / Bun way. Builds on the installable ecosystem from #224.

**Distribution model** — three layers, not alternatives:
- **GitHub Releases** = artifact store (one relocatable archive per target + `.sha256`).
- **`tools/get-nurl.sh` / `.ps1`** = the front door, served from `nurl-lang.org` so users run `curl -fsSL https://nurl-lang.org/install.sh | sh`.
- **`reg.nurl-lang.org`** stays the *package* registry — it does **not** distribute the toolchain.

## What's in it

### `.github/workflows/release.yml`
On a `v*` tag, build `nurlc` + `nurlpkg` + stdlib **natively** for each target, assemble the prefix with `install-toolchain.{sh,bat}`, package + checksum, and attach everything to the GitHub Release.

| Target | Runner | Archive |
|---|---|---|
| `linux-x86_64-glibc` | `ubuntu-latest` | `nurl-<tag>-linux-x86_64-glibc.tar.gz` |
| `linux-arm64-glibc`  | `ubuntu-24.04-arm` | `nurl-<tag>-linux-arm64-glibc.tar.gz` |
| `windows-x86_64`     | `windows-latest` | `nurl-<tag>-windows-x86_64.zip` |

`workflow_dispatch` gives a publish-free dry run.

### Relocatable `install-toolchain.{sh,bat}`
Shims and `env` now resolve the prefix from **their own location** instead of a baked-in absolute path, so a downloaded archive works wherever it is unpacked. Verified by installing, then **moving** the prefix, then compiling with it. (Also improves the local install.)

### `tools/get-nurl.sh` / `get-nurl.ps1`
The `curl|sh` / `irm|iex` front door: detect OS/arch → resolve latest (or `--version` pinned) release → download the matching archive → verify SHA-256 → unpack to `$NURL_HOME` (`~/.nurl`). `$NURL_INSTALL_BASE` overrides the download base for internal mirrors / air-gapped installs.

### `RELEASING.md`
How to cut a release, runtime deps (dynamic `libcurl`/OpenSSL on glibc targets; Windows uses WinHTTP), the nurlweb wiring, and the Windows/macOS caveats.

## Verification

The full **Linux client path** is verified end to end against a local mirror: a workflow-shaped tarball is downloaded, checksum-verified, unpacked, and the relocatable toolchain compiles a program from a clean shell. Relocatability is proven by moving the installed prefix. The existing `test-install-tool.sh` still passes with the relocatable shims.

## Caveats / follow-ups

- **The Windows job is unverified on a real runner** — `build.bat` + `tools/nurlpkg/build.bat` + `install-toolchain.bat` exist, but the toolchain has not been cut on `windows-latest`. Exercise it with the `workflow_dispatch` dry run before announcing Windows support.
- **macOS is not built yet** (the installer rejects it with a clear message); add a `macos-14`/`macos-13` matrix when wanted.
- **nurlweb wiring is manual**: `nurl-lang.org/install.sh` and `/install.ps1` need to serve (or redirect to) `tools/get-nurl.sh` / `.ps1`.
- A fully static (zero runtime deps) build is a possible later step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)