### PR TITLE
ci: publish release on Linux success; Windows best-effort (zlib)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,9 +83,14 @@ jobs:
           if-no-files-found: error
 
   # ── Windows (native) ─────────────────────────────────────────────────
+  # Best-effort for now: nurlpkg needs zlib (gunzip) and the Windows build
+  # does not yet wire it up, so this job can fail without blocking the
+  # Linux release. Tracked separately; flip continue-on-error off once the
+  # Windows toolchain links zlib.
   windows:
     runs-on: windows-latest
     timeout-minutes: 40
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -123,7 +128,9 @@ jobs:
 
   # ── Publish the GitHub Release ───────────────────────────────────────
   release:
-    needs: [linux, windows]
+    # Publish once Linux succeeds; Windows is best-effort (above) and is
+    # included automatically when it starts producing an archive.
+    needs: [linux]
     runs-on: ubuntu-latest
     # Only publish for a real pushed tag, not a workflow_dispatch dry run.
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
The v0.9.10 release builds cleanly on both Linux targets (`linux-x86_64-glibc` 2m13s, `linux-arm64-glibc` 1m59s). The Windows job builds `nurlc.exe` fine but fails compiling `nurlpkg.exe`:

```
stdlib/ext/compress.nu:92:3: FFI library 'z' is required but no build-time
sentinel 'stdlib/runtime.z' found — install libz-dev (or equivalent)
```

`nurlpkg` needs **zlib** (gunzip for registry tarballs). `build.sh` wires it up (`-DNURL_HAVE_ZLIB` + `stdlib/runtime.z` sentinel + `-lz`); `build.bat` does not, so `nurlpkg.exe` can't compile on `windows-latest`. That's a separate piece of Windows-runtime work.

## This PR — ship Linux now, Windows separately
- **`windows` job**: `continue-on-error` so it doesn't block the workflow.
- **`release` job**: `needs: [linux]` only, so the GitHub Release publishes the Linux archives. Windows archives are picked up automatically once that job starts producing one.

## Follow-up (tracked separately)
Wire zlib into the Windows toolchain: compile `runtime.c` with `-DNURL_HAVE_ZLIB`, drop the `stdlib/runtime.z` sentinel, and link zlib in `tools/nurlpkg/build.bat` + `nurl.bat` (e.g. vcpkg `zlib:x64-windows-static`).

After merge: re-point `v0.9.10` to the new `main` head to publish the Linux release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)