### PR TITLE
nurlweb: auto-generate release facts + serve the installer

### DIFF
--- a/nurlweb/package.json
+++ b/nurlweb/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "wrangler dev",
+    "facts": "bash ../tools/gen-site-facts.sh",
+    "sync-installers": "cp ../tools/get-nurl.sh public/install.sh && cp ../tools/get-nurl.ps1 public/install.ps1",
+    "predeploy": "bash ../tools/gen-site-facts.sh && npm run sync-installers",
     "deploy": "wrangler deploy"
   },
   "devDependencies": {

--- a/nurlweb/public/index.html
+++ b/nurlweb/public/index.html
@@ -57,10 +57,10 @@
     </a>
   </div>
   <div class="stats">
-    <div class="stat"><strong>v0.9.9</strong><span>current release</span></div>
-    <div class="stat"><strong>16,501</strong><span>lines of NURL in the compiler</span></div>
-    <div class="stat"><strong>477</strong><span>compiler test programs</span></div>
-    <div class="stat"><strong>147</strong><span>stdlib modules</span></div>
+    <div class="stat"><strong data-fact="version">v0.9.10</strong><span>current release</span></div>
+    <div class="stat"><strong data-fact="compiler_lines">16,521</strong><span>lines of NURL in the compiler</span></div>
+    <div class="stat"><strong data-fact="tests">477</strong><span>compiler test programs</span></div>
+    <div class="stat"><strong data-fact="stdlib_modules">147</strong><span>stdlib modules</span></div>
     <div class="stat"><strong>10</strong><span>tested targets</span></div>
   </div>
   <p style="margin-top: 1.8rem; color: var(--fg-faint); font-size: 0.88rem;">
@@ -106,7 +106,7 @@
       <div class="card">
         <div class="icon">⟳</div>
         <h3>Self-hosting</h3>
-        <p>The compiler is 14,304 lines of NURL. The bootstrap compiles it with itself twice and requires byte-identical LLVM IR on both rounds before a build is accepted.</p>
+        <p>The compiler is <span data-fact="compiler_lines">16,521</span> lines of NURL. The bootstrap compiles it with itself twice and requires byte-identical LLVM IR on both rounds before a build is accepted.</p>
       </div>
     </div>
   </div>
@@ -299,7 +299,7 @@
 <section id="stdlib">
   <div class="container">
     <div class="section-head">
-      <h2>104 stdlib modules, batteries included</h2>
+      <h2><span data-fact="stdlib_modules">147</span> stdlib modules, batteries included</h2>
       <p>Not stubs — production-hardened modules with their own test programs, leak-checked under AddressSanitizer.</p>
     </div>
 
@@ -343,7 +343,7 @@
     <div class="grid">
       <div class="card">
         <h3>The compiler itself</h3>
-        <p>14,304 lines of NURL compile NURL. Every release must reproduce its own LLVM IR byte-for-byte through two self-compilation rounds — a fixed point, not a checksum.</p>
+        <p><span data-fact="compiler_lines">16,521</span> lines of NURL compile NURL. Every release must reproduce its own LLVM IR byte-for-byte through two self-compilation rounds — a fixed point, not a checksum.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/blob/main/compiler/nurlc.nu" target="_blank" rel="noopener">compiler/nurlc.nu</a></p>
       </div>
       <div class="card">
@@ -357,7 +357,7 @@
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/tree/main/nurlapi" target="_blank" rel="noopener">nurlapi/</a></p>
       </div>
       <div class="card">
-        <h3>77 examples</h3>
+        <h3><span data-fact="examples">64</span> examples</h3>
         <p>From an Enigma machine and Game of Life to a distributed Push-To-Talk voice app, an HTTP/2 client, MCP servers, a Claude-powered agent, and a C64 emulator.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/tree/main/examples" target="_blank" rel="noopener">examples/</a></p>
       </div>
@@ -370,7 +370,7 @@
   <div class="container">
     <div class="section-head">
       <h2>Start writing NURL</h2>
-      <p>Three paths, in order of friction.</p>
+      <p>Four paths, in order of friction.</p>
     </div>
 
     <div class="start-grid">
@@ -382,7 +382,17 @@
       </div>
 
       <div class="start-card">
-        <div class="step">Step 2 · Local build</div>
+        <div class="step">Step 2 · Install</div>
+        <h3>One-line install</h3>
+        <p>Download a prebuilt toolchain — compiler, package manager, and stdlib — for Linux (x86_64 / arm64) or Windows. No clang, no build. Then install programs straight from the registry.</p>
+<pre>curl -fsSL https://nurl-lang.org/install.sh | sh
+source ~/.nurl/env
+nurlpkg install argz-demo && argz-demo --shout hi</pre>
+        <a class="btn btn-secondary" href="https://github.com/nurl-lang/nurl/releases/latest" target="_blank" rel="noopener">Latest release</a>
+      </div>
+
+      <div class="start-card">
+        <div class="step">Step 3 · Local build</div>
         <h3>Clone and bootstrap</h3>
         <p>The only build dependency is clang (LLVM 14+) — no Python, no make, no cmake. The build script bootstraps the self-hosting compiler twice and verifies byte-identical IR.</p>
 <pre>git clone https://github.com/nurl-lang/nurl
@@ -393,7 +403,7 @@ cd nurl
       </div>
 
       <div class="start-card">
-        <div class="step">Step 3 · Editor</div>
+        <div class="step">Step 4 · Editor</div>
         <h3>Syntax highlighting + LSP</h3>
         <p>A VS Code / Windsurf extension lives under <code>tooling/vscode-nurl/</code>, backed by a real LSP server with diagnostics and references. The playground ships the same Monaco tokenizer.</p>
         <a class="btn btn-secondary" href="https://github.com/nurl-lang/nurl/tree/main/tooling/vscode-nurl" target="_blank" rel="noopener">Get the extension</a>
@@ -480,7 +490,7 @@ cd nurl
       </div>
       <div class="card">
         <h3>Changelog</h3>
-        <p>Every release documented in Keep-a-Changelog format with the reasoning behind each fix — currently at v0.9.9.</p>
+        <p>Every release documented in Keep-a-Changelog format with the reasoning behind each fix — currently at <span data-fact="version">v0.9.10</span>.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/blob/main/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG.md</a></p>
       </div>
       <div class="card">

--- a/nurlweb/public/install.ps1
+++ b/nurlweb/public/install.ps1
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  get-nurl.ps1 - one-line installer for the NURL toolchain on Windows.
+#
+#  Downloads the matching release archive from GitHub Releases, verifies
+#  its SHA-256, and unpacks the relocatable toolchain into $NURL_HOME
+#  (default %USERPROFILE%\.nurl). Then add %NURL_HOME%\bin to PATH.
+#
+#  Usage (PowerShell):
+#    irm https://nurl-lang.org/install.ps1 | iex
+#    & ([scriptblock]::Create((irm https://nurl-lang.org/install.ps1))) -Version v0.1.0
+#
+#  Params:
+#    -Version <tag>   release tag to install (default: latest)
+#    -Prefix  <dir>   install prefix (default: %USERPROFILE%\.nurl)
+# ============================================================
+param(
+    [string]$Version = $env:NURL_VERSION,
+    [string]$Prefix  = $(if ($env:NURL_HOME) { $env:NURL_HOME } else { Join-Path $env:USERPROFILE ".nurl" })
+)
+$ErrorActionPreference = "Stop"
+$repo = "nurl-lang/nurl"
+$target = "windows-x86_64"
+
+# ── Resolve version (latest release tag if unset) ──────────────────────
+if (-not $Version) {
+    Write-Host "resolving latest release..."
+    $rel = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest"
+    $Version = $rel.tag_name
+    if (-not $Version) { throw "could not determine the latest release tag; pass -Version vX.Y.Z." }
+}
+
+$archive = "nurl-$Version-$target.zip"
+$base = "https://github.com/$repo/releases/download/$Version"
+$tmp = Join-Path $env:TEMP ("nurl-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+
+try {
+    Write-Host "downloading $archive ($Version)..."
+    $zip = Join-Path $tmp $archive
+    Invoke-WebRequest "$base/$archive" -OutFile $zip
+
+    # ── Verify checksum (best-effort) ──────────────────────────────────
+    try {
+        $sumFile = "$zip.sha256"
+        Invoke-WebRequest "$base/$archive.sha256" -OutFile $sumFile
+        $want = ((Get-Content $sumFile) -split '\s+')[0].ToLower()
+        $got = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
+        if ($want -ne $got) { throw "checksum mismatch (expected $want, got $got)." }
+        Write-Host "checksum OK"
+    } catch {
+        Write-Host "warning: checksum verification skipped ($($_.Exception.Message))"
+    }
+
+    # ── Unpack (archive has a top-level nurl\ dir) ─────────────────────
+    Write-Host "installing to $Prefix..."
+    if (Test-Path $Prefix) { Remove-Item -Recurse -Force $Prefix }
+    New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
+    $unzipTmp = Join-Path $tmp "x"
+    Expand-Archive -Path $zip -DestinationPath $unzipTmp -Force
+    Copy-Item -Recurse -Force (Join-Path $unzipTmp "nurl\*") $Prefix
+
+    if (-not (Test-Path (Join-Path $Prefix "bin\nurl.bat"))) {
+        throw "install looks incomplete: $Prefix\bin\nurl.bat missing."
+    }
+
+    Write-Host ""
+    Write-Host "NURL $Version installed -> $Prefix"
+    Write-Host ""
+    Write-Host "Add it to this session:"
+    Write-Host "    `$env:Path = `"$Prefix\bin;`$env:Path`""
+    Write-Host "Make it permanent:"
+    Write-Host "    setx PATH `"$Prefix\bin;%PATH%`""
+    Write-Host "    setx NURL_STDLIB `"$Prefix`""
+    Write-Host ""
+    Write-Host "Then:  nurlc --version   ·   nurlpkg install argz-demo"
+}
+finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}

--- a/nurlweb/public/install.sh
+++ b/nurlweb/public/install.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env sh
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  get-nurl.sh — one-line installer for the NURL toolchain.
+#
+#  Detects your OS/arch, downloads the matching release archive from
+#  GitHub Releases, verifies its SHA-256, and unpacks the relocatable
+#  toolchain into $NURL_HOME (default ~/.nurl). Then add ~/.nurl/bin to
+#  PATH (the installer prints the exact line).
+#
+#  Usage:
+#    curl -fsSL https://nurl-lang.org/install.sh | sh
+#    curl -fsSL https://nurl-lang.org/install.sh | sh -s -- --version v0.1.0
+#
+#  Env:
+#    NURL_HOME     install prefix (default ~/.nurl)
+#    NURL_VERSION  release tag to install (default: latest)
+#
+#  POSIX sh — no bashisms; works under dash/ash/busybox.
+# ============================================================
+set -eu
+
+REPO="nurl-lang/nurl"
+PREFIX="${NURL_HOME:-$HOME/.nurl}"
+VERSION="${NURL_VERSION:-}"
+
+err() { printf 'error: %s\n' "$*" >&2; exit 1; }
+info() { printf '%s\n' "$*" >&2; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# ── Args ───────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version) VERSION="${2:-}"; shift 2 ;;
+        --version=*) VERSION="${1#--version=}"; shift ;;
+        --prefix) PREFIX="${2:-}"; shift 2 ;;
+        --prefix=*) PREFIX="${1#--prefix=}"; shift ;;
+        -h|--help)
+            sed -n '5,22p' "$0" 2>/dev/null | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *) err "unknown argument: $1 (try --help)" ;;
+    esac
+done
+
+# ── Detect target triple ───────────────────────────────────────────────
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os" in
+    Linux) ;;
+    Darwin) err "macOS packages are not published yet; build from source (see README)." ;;
+    *) err "unsupported OS '$os'. On Windows use the PowerShell installer (install.ps1)." ;;
+esac
+case "$arch" in
+    x86_64|amd64)  target="linux-x86_64-glibc" ;;
+    aarch64|arm64) target="linux-arm64-glibc" ;;
+    *) err "unsupported architecture '$arch'." ;;
+esac
+
+# ── Downloader ─────────────────────────────────────────────────────────
+if have curl; then
+    dl() { curl -fsSL "$1" -o "$2"; }
+    dl_stdout() { curl -fsSL "$1"; }
+elif have wget; then
+    dl() { wget -qO "$2" "$1"; }
+    dl_stdout() { wget -qO- "$1"; }
+else
+    err "need curl or wget on PATH."
+fi
+
+# ── Resolve version (latest release tag if unset) ──────────────────────
+if [ -z "$VERSION" ]; then
+    info "resolving latest release…"
+    VERSION="$(dl_stdout "https://api.github.com/repos/$REPO/releases/latest" \
+        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)"
+    [ -n "$VERSION" ] || err "could not determine the latest release tag; pass --version vX.Y.Z."
+fi
+
+archive="nurl-${VERSION}-${target}.tar.gz"
+# $NURL_INSTALL_BASE overrides the download base (internal mirror / test).
+base="${NURL_INSTALL_BASE:-https://github.com/$REPO/releases/download/$VERSION}"
+
+# ── Download + verify ──────────────────────────────────────────────────
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+info "downloading $archive ($VERSION)…"
+dl "$base/$archive" "$tmp/$archive" || err "download failed: $base/$archive"
+
+if dl "$base/$archive.sha256" "$tmp/$archive.sha256" 2>/dev/null; then
+    info "verifying checksum…"
+    want="$(awk '{print $1}' "$tmp/$archive.sha256")"
+    if have sha256sum; then
+        got="$(sha256sum "$tmp/$archive" | awk '{print $1}')"
+    elif have shasum; then
+        got="$(shasum -a 256 "$tmp/$archive" | awk '{print $1}')"
+    else
+        got=""; info "warning: no sha256sum/shasum — skipping checksum verification."
+    fi
+    [ -z "$got" ] || [ "$got" = "$want" ] || err "checksum mismatch (expected $want, got $got)."
+else
+    info "warning: no checksum file published — skipping verification."
+fi
+
+# ── Unpack (the archive has a top-level nurl/ dir) ─────────────────────
+info "installing to $PREFIX…"
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+tar xzf "$tmp/$archive" -C "$PREFIX" --strip-components=1
+
+[ -x "$PREFIX/bin/nurl" ] || err "install looks incomplete: $PREFIX/bin/nurl missing."
+
+# ── Done ───────────────────────────────────────────────────────────────
+info ""
+info "NURL $VERSION installed → $PREFIX"
+info ""
+info "Add it to your shell (and your ~/.bashrc / ~/.zshrc):"
+info "    source $PREFIX/env"
+info ""
+info "Or just add the bin dir to PATH:"
+info "    export PATH=\"$PREFIX/bin:\$PATH\""
+info ""
+info "Then:  nurlc --version   ·   nurlpkg install argz-demo"

--- a/tools/gen-site-facts.sh
+++ b/tools/gen-site-facts.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  gen-site-facts.sh — keep the landing page's numbers honest.
+#
+#  The site (nurlweb/public/index.html) carries release-coupled facts
+#  (version, compiler size, test/stdlib/example counts) that drift and
+#  even contradict each other when hand-edited. This script computes them
+#  from the repo — the single source of truth — and writes them into every
+#  element carrying a matching `data-fact="<key>"` attribute.
+#
+#  The page stays 100% static at serve time (no JS, no API); it just can't
+#  fall behind, because `nurlweb`'s `predeploy` hook runs this first. Run
+#  it by hand anytime to refresh:  ./tools/gen-site-facts.sh
+# ============================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HTML="$ROOT/nurlweb/public/index.html"
+[[ -f "$HTML" ]] || { echo "gen-site-facts: $HTML not found" >&2; exit 1; }
+
+# Insert thousands separators: 16521 -> 16,521.
+comma() { echo "$1" | sed -E ':a;s/([0-9])([0-9]{3})($|,)/\1,\2\3/;ta'; }
+
+# ── Compute the facts from the repo ────────────────────────────────────
+version="$(git -C "$ROOT" tag --sort=-version:refname 2>/dev/null | grep -E '^v[0-9]' | head -1)"
+[[ -n "$version" ]] || version="v0.0.0"
+compiler_lines="$(comma "$(wc -l < "$ROOT/compiler/nurlc.nu")")"
+tests="$(comma "$(find "$ROOT/compiler/tests" -maxdepth 1 -name '*.nu' | wc -l | tr -d ' ')")"
+stdlib_modules="$(find "$ROOT/stdlib" -name '*.nu' | wc -l | tr -d ' ')"
+examples="$(find "$ROOT/examples" -maxdepth 1 -name '*.nu' | wc -l | tr -d ' ')"
+
+# ── Inject into every data-fact="<key>" element ────────────────────────
+# Replaces the text content between `data-fact="key"…>` and the next `<`,
+# globally, so a key used in several places stays consistent.
+inject() {
+    local key="$1" val="$2"
+    perl -0777 -i -pe "s/(data-fact=\"\Q$key\E\"[^>]*>)[^<]*/\${1}$val/g" "$HTML"
+}
+
+inject version        "$version"
+inject compiler_lines "$compiler_lines"
+inject tests          "$tests"
+inject stdlib_modules "$stdlib_modules"
+inject examples       "$examples"
+
+echo "site facts → $HTML"
+echo "  version=$version  compiler_lines=$compiler_lines  tests=$tests  stdlib_modules=$stdlib_modules  examples=$examples"


### PR DESCRIPTION
## The problem

The landing page's release-coupled numbers were hand-edited, so they drifted **and contradicted each other**:

| Fact | Page said | Reality |
|---|---|---|
| version | v0.9.9 | v0.9.10 |
| compiler lines | 16,501 **and** 14,304 | 16,521 |
| stdlib modules | 147 **and** 104 | 147 |
| examples | 77 | 64 |
| tests | 477 | 477 ✓ |

## Approach — static at serve time, generated at deploy time

The recommendation (from the discussion): don't reduce the precise numbers (they're what make the page credible), and don't fetch them at runtime (a landing page should stay static — no JS/API dependency, no "blank if API down" failure). Instead, **compute them from the repo — the single source of truth — at deploy time.**

- **`tools/gen-site-facts.sh`** reads the version (latest tag), compiler line count, and test/stdlib/example counts, then injects them into every element carrying a matching `data-fact="<key>"` attribute. Idempotent.
- **`index.html`**: `data-fact` markers on all nine fact spots; the contradictions reconciled to one key per fact; values refreshed to v0.9.10.
- **`package.json`**: a `predeploy` hook runs the generator, so `npm run deploy` can never ship stale numbers. The page is 100% static when served.

## Also: wire the distribution front door

The toolchain is installable now (#225), so:
- **`public/install.sh` + `install.ps1`** (copies of `tools/get-nurl.{sh,ps1}`, kept in sync by `predeploy`) are served as static assets → `curl -fsSL https://nurl-lang.org/install.sh | sh` works.
- A new **"Step 2 · Install"** card advertises the one-liner.

## Verification
Generator is idempotent; all nine fact spots are consistent; `install.{sh,ps1}` match their `tools/` sources; HTML `<div>` tags balanced (98/98). Deploy with `cd nurlweb && npm run deploy` (predeploy refreshes facts + installers first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)