### PR TITLE
nq: a jq-lite JSON query tool published to the registry

### DIFF
--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,0 +1,6 @@
+# Local-dev artifacts produced by `nurlpkg install` / a manual build inside
+# a package directory. The registry packages are sources only; `deps/` is
+# materialised by the package manager and the binary is built on install.
+*/deps/
+*/.nurl-bin
+*/nurl.lock

--- a/packages/README.md
+++ b/packages/README.md
@@ -45,6 +45,26 @@ the shipped stdlib (found via `$NURL_STDLIB`), and drops the binary in
 `$NURL_HOME/bin` (default `~/.nurl/bin`, which `install-toolchain.sh` puts
 on `$PATH`).
 
+## `nq/` — a jq-lite JSON query tool (installable program)
+
+A genuinely useful everyday utility: read JSON from stdin (or `--file`),
+apply a small jq-like filter, and print it pretty (default), compact
+(`-c`), or raw (`-r`). Like `argz-demo`, it declares `argz = "^0.1"` as a
+registry dependency for flag parsing; for the JSON itself it leans on the
+shipped `stdlib/ext/json`. Leak-clean under ASan/LSan across every path.
+
+```
+nurlpkg install nq
+echo '{"items":[{"id":1},{"id":2}]}' | nq '.items[].id'   # 1 / 2
+echo '{"user":{"name":"Ada"}}'       | nq -r .user.name   # Ada
+echo '{"a":1,"b":2}'                 | nq -c '. | keys'    # ["a","b"]
+```
+
+Supported filters: `.`, `.path.to.field` (with `.0` / `[0]` indexing), a
+trailing `[]` to iterate an array/object (one result per line, optionally
+projecting `.field` from each), and the `| keys` / `| length` terminals.
+See [`nq/README.md`](nq/README.md) for the full grammar.
+
 ## The full loop
 
 ```bash

--- a/packages/nq/README.md
+++ b/packages/nq/README.md
@@ -1,0 +1,80 @@
+# `nq` — a tiny jq-lite JSON query tool
+
+`nq` is the kind of utility every developer keeps within reach: it reads
+JSON from stdin (or a file), applies a small jq-like filter, and prints
+the result — pretty by default, compact or raw on request.
+
+It lives in the NURL **registry** (it is *not* part of the core stdlib).
+It also doubles as a worked example of the ecosystem: `nq` declares the
+[`argz`](../argz) registry package as a dependency for its flag parsing,
+and leans on the shipped `stdlib/ext/json` for parsing and printing.
+
+```
+nurlpkg install nq
+```
+
+## Usage
+
+```
+nq [OPTIONS] [FILTER]
+```
+
+`FILTER` is a jq-lite path; the default is `.`, the whole document. Input
+is read from stdin unless `--file` is given.
+
+| Option | Meaning |
+| ------ | ------- |
+| `-c`, `--compact` | compact, single-line output |
+| `-r`, `--raw`     | raw output for string results (no surrounding quotes) |
+| `-f`, `--file F`  | read JSON from file `F` instead of stdin |
+| `-h`, `--help`    | show help |
+
+## Filter grammar
+
+```
+filter := path [ '|' func ]
+func   := keys | length
+```
+
+| Filter | Result |
+| ------ | ------ |
+| `.` | the whole document |
+| `.user.name` | navigate objects/arrays (use `.0` for index 0, `[0]` also works) |
+| `.items[]` | iterate an array or object — one result per line |
+| `.items[].id` | project a field out of each iterated element |
+| `. \| keys` | object keys (or array indices) as an array |
+| `. \| length` | length of an array / object / string |
+
+A missing path yields `null` (like `jq`). Iterating a scalar, or applying
+`keys`/`length` to a value of the wrong type, is an error (exit code 1).
+
+## Examples
+
+```console
+$ echo '{"user":{"name":"Ada","age":36},"tags":["x","y","z"]}' | nq .user
+{
+  "name": "Ada",
+  "age": 36
+}
+
+$ echo '{"user":{"name":"Ada"}}' | nq -r .user.name
+Ada
+
+$ echo '{"items":[{"id":1},{"id":2},{"id":3}]}' | nq '.items[].id'
+1
+2
+3
+
+$ echo '{"a":1,"b":2,"c":3}' | nq -c '. | keys'
+["a","b","c"]
+
+$ echo '["x","y","z"]' | nq '. | length'
+3
+```
+
+## Quality
+
+`nq` is leak-clean under AddressSanitizer / LeakSanitizer across every
+code path (navigation, iteration, the `keys`/`length` terminals, and the
+error/parse-failure branches). The end-to-end install-and-run loop is
+covered by `tools/nurlpkg/test-install-tool.sh`.

--- a/packages/nq/nurl.toml
+++ b/packages/nq/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nq"
+version = "0.1.0"
+description = "A tiny jq-lite JSON query tool: navigate, iterate, and pretty-print JSON from the command line."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+argz = "^0.1"

--- a/packages/nq/src/main.nu
+++ b/packages/nq/src/main.nu
@@ -1,0 +1,385 @@
+// nq — a tiny, dependency-light JSON query tool for the command line.
+//
+// Think "jq, but small": read JSON from stdin (or a file), apply a
+// jq-lite filter, and print the result pretty (default), compact, or
+// raw. It is the kind of thing every developer reaches for daily, which
+// is exactly why it belongs in the NURL registry rather than the core
+// stdlib — it stitches the ecosystem together: the `argz` registry
+// package parses its flags, and the shipped `stdlib/ext/json` does the
+// parsing/printing.
+//
+//   nq                      pretty-print stdin
+//   nq .user.name           navigate into an object/array (.0 = index 0)
+//   nq '.items[]'           iterate an array/object, one result per line
+//   nq '.items[].id'        project a field out of each element
+//   nq '. | keys'           object keys (or array indices)
+//   nq '. | length'         length of an array / object / string
+//   nq -c .                 compact single-line output
+//   nq -r .user.name        raw string output (no surrounding quotes)
+//   nq -f data.json .       read from a file instead of stdin
+//
+// Filter grammar (v0.1), deliberately tiny:
+//
+//   filter      := path [ '|' func ]
+//   path        := '.' | '.' seg ( ('.' | '[' int ']') seg )* [ '[]' [ '.' seg … ] ]
+//   func        := 'keys' | 'length'
+//
+// A single trailing `[]` turns the result into a stream: the preceding
+// path must select an array or object, and the rest of the path is then
+// applied to each element, one line of output per element.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/char.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/cmp.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `deps/argz/src/argz.nu`
+
+// ── Output ────────────────────────────────────────────────────────────
+
+// Print one JSON value followed by a newline, honouring -c / -r.
+@ __nq_emit Json j b compact b raw → v {
+    ? & raw ( json_is_str j ) {
+        ( nurl_print ( json_str_data j ) )
+        ( nurl_print `\n` )
+    } {
+        ? compact {
+            : String out ( json_stringify j )
+            ( nurl_print ( string_data out ) ) ( nurl_print `\n` )
+            ( string_free out )
+        } {
+            : String out ( json_pretty j )
+            ( nurl_print ( string_data out ) ) ( nurl_print `\n` )
+            ( string_free out )
+        }
+    }
+}
+
+// ── Path normalisation ────────────────────────────────────────────────
+//
+// Turn a jq-ish path segment into the dotted form `json_get` expects:
+// `[N]` → `.N`, leading dots dropped, runs of `.` collapsed, trailing
+// `.` dropped. So `.items[0].name` → `items.0.name` and `.` → ``.
+@ __nq_norm s rawpath → String {
+    : i n ( nurl_str_len rawpath )
+    : String out ( string_with_cap n )
+    : ~ b any F        // emitted any real (non-dot) char yet?
+    : ~ b pending F    // a separator is pending, flush it before next char
+    : ~ i i 0
+    ~ < i n {
+        : i c ( nurl_str_get rawpath i )
+        ? == c 93 {                       // ']' — drop
+        } {
+            : ~ i cc c
+            ? == c 91 { = cc 46 } {}       // '[' → '.'
+            ? == cc 46 {
+                ? any { = pending T } {}   // ignore leading dots
+            } {
+                ? pending { ( string_push_char out 46 ) = pending F } {}
+                ( string_push_char out cc )
+                = any T
+            }
+        }
+        = i + i 1
+    }
+    ^ out
+}
+
+// Copy src[from, to) into a fresh String with surrounding spaces trimmed.
+@ __nq_substr_trim s src i from i to → String {
+    : ~ i a from
+    : ~ i b to
+    ~ & < a b == 1 ( is_space ( nurl_str_get src a ) ) { = a + a 1 }
+    ~ & < a b == 1 ( is_space ( nurl_str_get src - b 1 ) ) { = b - b 1 }
+    : String out ( string_with_cap - b a )
+    : ~ i i a
+    ~ < i b {
+        ( string_push_char out ( nurl_str_get src i ) )
+        = i + i 1
+    }
+    ^ out
+}
+
+// ── Terminal functions (`| keys`, `| length`) ─────────────────────────
+//
+// Returns an OWNED Json (caller frees with json_free) on success, or
+// `F` to signal "this function can't apply to a value of that type".
+@ __nq_apply_func s fname Json j → ?Json {
+    ? != 0 ( nurl_str_eq fname `keys` ) {
+        ? ( json_is_obj j ) {
+            : ( Vec String ) ks ( json_obj_keys j )
+            // Match jq's `keys`: sorted (its insertion-order form is `keys_unsorted`).
+            ( sort_by [String] ks \ String a String b → i { ^ ( cmp_string a b ) } )
+            : Json arr ( json_arr_new )
+            : i n ( vec_len [String] ks )
+            : ~ i k 0
+            ~ < k n {
+                ?? ( vec_get [String] ks k ) {
+                    T s → { ( json_arr_push arr @ Json { JStr s } ) }   // moves s into arr
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( vec_free [String] ks )   // shallow: the String handles now live in arr
+            ^ @ ?Json { T arr }
+        } {}
+        ? ( json_is_arr j ) {
+            : Json arr ( json_arr_new )
+            : i n ( json_arr_len j )
+            : ~ i k 0
+            ~ < k n { ( json_arr_push arr ( json_int k ) ) = k + k 1 }
+            ^ @ ?Json { T arr }
+        } {}
+        ^ @ ?Json { F @ Json { JNull } }
+    } {}
+    ? != 0 ( nurl_str_eq fname `length` ) {
+        ? ( json_is_arr j ) { ^ @ ?Json { T ( json_int ( json_arr_len j ) ) } } {}
+        ? ( json_is_obj j ) {
+            : ( Vec String ) ks ( json_obj_keys j )
+            : i n ( vec_len [String] ks )
+            ( vec_free_with [String] ks \ String s → v { ( string_free s ) } )
+            ^ @ ?Json { T ( json_int n ) }
+        } {}
+        ? ( json_is_str j ) { ^ @ ?Json { T ( json_int ( nurl_str_len ( json_str_data j ) ) ) } } {}
+        ? ( json_is_null j ) { ^ @ ?Json { T ( json_int 0 ) } } {}
+        ^ @ ?Json { F @ Json { JNull } }
+    } {}
+    // Unknown function name → treat as a non-applicable error.
+    ^ @ ?Json { F @ Json { JNull } }
+}
+
+// Emit one stream value, applying an optional terminal function first.
+// `func` is "" for "no function". Returns 0 on success, 1 on a type or
+// unknown-function error (already reported to stderr).
+@ __nq_out Json j s func b compact b raw → i {
+    ? == 0 ( nurl_str_len func ) {
+        ( __nq_emit j compact raw )
+        ^ 0
+    } {}
+    : ?Json res ( __nq_apply_func func j )
+    ?? res {
+        T rj → { ( __nq_emit rj compact raw ) ( json_free rj ) ^ 0 }
+        F _ → {
+            ( nurl_eprint `nq: ` ) ( nurl_eprint func )
+            ( nurl_eprint ` cannot be applied to ` ) ( nurl_eprint ( json_type_name j ) )
+            ( nurl_eprint `\n` )
+            ^ 1
+        }
+    }
+}
+
+// Navigate `elem` by `postnorm` (possibly empty = identity), then emit.
+@ __nq_emit_nav Json elem s postnorm s func b compact b raw → i {
+    : ?Json sub ( json_get elem postnorm )
+    : ~ i rc 0
+    ?? sub {
+        T sj → { = rc ( __nq_out sj func compact raw ) }
+        F _ → { = rc ( __nq_out ( json_null ) func compact raw ) }   // missing → null
+    }
+    ^ rc
+}
+
+// `path[]` iteration: select the container at `prenorm`, then apply
+// `postnorm` to each of its elements (array order / object value order).
+@ __nq_iter Json doc s prenorm s postnorm s func b compact b raw → i {
+    : ?Json cont ( json_get doc prenorm )
+    : ~ i rc 0
+    ?? cont {
+        F _ → {
+            ( nurl_eprint `nq: path not found\n` )
+            ^ 1
+        }
+        T c → {
+            ? ( json_is_arr c ) {
+                : i n ( json_arr_len c )
+                : ~ i k 0
+                ~ < k n {
+                    ?? ( json_arr_get c k ) {
+                        T e → {
+                            : i er ( __nq_emit_nav e postnorm func compact raw )
+                            ? > er rc { = rc er } {}
+                        }
+                        F _ → {}
+                    }
+                    = k + k 1
+                }
+            } {
+                ? ( json_is_obj c ) {
+                    : ( Vec String ) keys ( json_obj_keys c )
+                    : i n ( vec_len [String] keys )
+                    : ~ i k 0
+                    ~ < k n {
+                        ?? ( vec_get [String] keys k ) {
+                            T kk → {
+                                ?? ( json_obj_get c ( string_data kk ) ) {
+                                    T e → {
+                                        : i er ( __nq_emit_nav e postnorm func compact raw )
+                                        ? > er rc { = rc er } {}
+                                    }
+                                    F _ → {}
+                                }
+                            }
+                            F _ → {}
+                        }
+                        = k + k 1
+                    }
+                    ( vec_free_with [String] keys \ String s → v { ( string_free s ) } )
+                } {
+                    ( nurl_eprint `nq: cannot iterate over ` )
+                    ( nurl_eprint ( json_type_name c ) ) ( nurl_eprint `\n` )
+                    = rc 1
+                }
+            }
+        }
+    }
+    ^ rc
+}
+
+// Evaluate a whole filter (`path` or `path | func`) against `doc`.
+@ __nq_eval Json doc s filter b compact b raw → i {
+    : i flen ( nurl_str_len filter )
+    : i pipe ( nurl_str_find filter `|` )
+    : ~ String left ( string_new )
+    : ~ String func ( string_new )
+    ? >= pipe 0 {
+        ( string_free left ) = left ( __nq_substr_trim filter 0 pipe )
+        ( string_free func ) = func ( __nq_substr_trim filter + pipe 1 flen )
+    } {
+        ( string_free left ) = left ( __nq_substr_trim filter 0 flen )
+    }
+    : s lp ( string_data left )
+    : s fn ( string_data func )
+
+    : i br ( nurl_str_find lp `[]` )
+    : ~ i rc 0
+    ? >= br 0 {
+        : i llen ( nurl_str_len lp )
+        : String pre ( __nq_substr_trim lp 0 br )
+        : String post ( __nq_substr_trim lp + br 2 llen )
+        : String prenorm ( __nq_norm ( string_data pre ) )
+        : String postnorm ( __nq_norm ( string_data post ) )
+        = rc ( __nq_iter doc ( string_data prenorm ) ( string_data postnorm ) fn compact raw )
+        ( string_free prenorm ) ( string_free postnorm )
+        ( string_free pre ) ( string_free post )
+    } {
+        : String norm ( __nq_norm lp )
+        ?? ( json_get doc ( string_data norm ) ) {
+            T sj → { = rc ( __nq_out sj fn compact raw ) }
+            F _ → { = rc ( __nq_out ( json_null ) fn compact raw ) }
+        }
+        ( string_free norm )
+    }
+    ( string_free left )
+    ( string_free func )
+    ^ rc
+}
+
+// ── Help ──────────────────────────────────────────────────────────────
+
+@ __nq_usage Argz p → v {
+    ( nurl_print `nq — a tiny JSON query tool (jq-lite)\n\n` )
+    ( nurl_print `Usage: nq [OPTIONS] [FILTER]\n\n` )
+    ( nurl_print `FILTER is a jq-lite path; the default is '.', the whole document:\n` )
+    ( nurl_print `  .                whole document\n` )
+    ( nurl_print `  .user.name       navigate objects/arrays (use .0 for index 0)\n` )
+    ( nurl_print `  .items[]         iterate an array/object — one result per line\n` )
+    ( nurl_print `  .items[].id      project a field out of each element\n` )
+    ( nurl_print `  . | keys         object keys (or array indices)\n` )
+    ( nurl_print `  . | length       length of an array / object / string\n\n` )
+    ( nurl_print `Reads JSON from stdin unless --file is given.\n\n` )
+    : String h ( argz_help p )
+    ( nurl_print ( string_data h ) )
+    ( string_free h )
+}
+
+// ── Entry point ───────────────────────────────────────────────────────
+
+@ main → i {
+    : Argz p ( argz_new `nq` `a tiny JSON query tool (jq-lite)` )
+    ( argz_flag p `compact` `c` `compact single-line output` )
+    ( argz_flag p `raw`     `r` `raw output for string results (no quotes)` )
+    ( argz_flag p `help`    `h` `show this help` )
+    ( argz_opt  p `file`    `f` `read JSON from FILE instead of stdin` )
+
+    : ( Vec String ) argv ( vec_new [String] )
+    : i ac ( env_args_count )
+    : ~ i ai 1
+    ~ < ai ac {
+        ( vec_push [String] argv ( env_arg ai ) )
+        = ai + ai 1
+    }
+
+    : ~ i rc 0
+    : !ArgzMatch ArgzErr r ( argz_parse p argv )
+    ?? r {
+        F e → {
+            ( nurl_eprint `nq: ` ) ( nurl_eprintln ( argz_err_name e ) )
+            ( nurl_eprintln `try 'nq --help'` )
+            = rc 2
+        }
+        T m → {
+            ? ( argz_has m `help` ) {
+                ( __nq_usage p )
+            } {
+                : b compact ( argz_has m `compact` )
+                : b raw ( argz_has m `raw` )
+
+                // Filter: first positional, default ".".
+                : ( Vec String ) ps ( argz_positionals m )
+                : ~ s filter `.`
+                ? > ( vec_len [String] ps ) 0 {
+                    ?? ( vec_get [String] ps 0 ) {
+                        T f0 → { = filter ( string_data f0 ) }
+                        F _ → {}
+                    }
+                } {}
+
+                // Input: --file, else stdin.
+                : ~ String input ( string_new )
+                : ~ b have_input T
+                ?? ( argz_value m `file` ) {
+                    T fv → {
+                        ?? ( read_file ( string_data fv ) ) {
+                            T txt → { ( string_free input ) = input txt }
+                            F _ → {
+                                ( nurl_eprint `nq: cannot read file: ` )
+                                ( nurl_eprintln ( string_data fv ) )
+                                = rc 1
+                                = have_input F
+                            }
+                        }
+                    }
+                    F _ → {
+                        ( string_free input )
+                        = input ( read_all_stdin )
+                    }
+                }
+
+                ? have_input {
+                    ?? ( json_parse ( string_data input ) ) {
+                        F je → {
+                            : String em ( json_format_error je )
+                            ( nurl_eprint `nq: ` ) ( nurl_eprintln ( string_data em ) )
+                            ( string_free em )
+                            = rc 1
+                        }
+                        T doc → {
+                            = rc ( __nq_eval doc filter compact raw )
+                            ( json_free doc )
+                        }
+                    }
+                } {}
+                ( string_free input )
+            }
+            ( argz_match_free m )
+        }
+    }
+
+    ( argz_free p )
+    ( vec_free_with [String] argv \ String x → v { ( string_free x ) } )
+    ^ rc
+}

--- a/registry/DEPLOY.md
+++ b/registry/DEPLOY.md
@@ -3,11 +3,15 @@
 A Cloudflare Worker (`registry/src/index.ts`) backed by **R2** (the static
 read path: `index/*.json` + `pkgs/**/*.tar.gz`) and **D1** (users, tokens,
 package ownership, versions). The NURL client (`nurlpkg install` /
-`nurlpkg publish`) already drives this exact contract — proven end-to-end
-against this Worker running locally (see "Local testing" below), so the
-deploy is purely wiring the production account.
+`nurlpkg publish`) drives this exact contract.
 
-## What needs a real account (everything else is done + locally tested)
+**Status: LIVE in production at https://reg.nurl-lang.org.** It serves real
+packages today (e.g. `argz` and `argz-demo`, published 2026-06-20), and the
+default `nurlpkg install <name>` resolves against it. The sections below are
+the reference for *reproducing* or re-provisioning that deployment — the
+production instance is already wired.
+
+## Provisioning an instance (reference — production is already live)
 
 1. **A GitHub OAuth App** (https://github.com/settings/developers → *New OAuth App*)
    - Homepage URL: `https://reg.nurl-lang.org`

--- a/tools/nurlpkg/test-install-tool.sh
+++ b/tools/nurlpkg/test-install-tool.sh
@@ -48,15 +48,19 @@ EOF
 ( cd "$ROOT" && ./nurl.sh "$WORK/pack.nu" "$WORK/pack" >/dev/null 2>&1 ) || { echo "packer build failed"; exit 2; }
 
 REGDIR="$WORK/registry"
-mkdir -p "$REGDIR/index" "$REGDIR/pkgs/argz" "$REGDIR/pkgs/argz-demo"
+mkdir -p "$REGDIR/index" "$REGDIR/pkgs/argz" "$REGDIR/pkgs/argz-demo" "$REGDIR/pkgs/nq"
 "$WORK/pack" "$PKGS/argz"      "$REGDIR/pkgs/argz/argz-0.1.0.tar.gz"           || fail=1
 "$WORK/pack" "$PKGS/argz-demo" "$REGDIR/pkgs/argz-demo/argz-demo-0.1.0.tar.gz" || fail=1
+"$WORK/pack" "$PKGS/nq"        "$REGDIR/pkgs/nq/nq-0.1.0.tar.gz"               || fail=1
 SUM_ARGZ=$(sha256sum "$REGDIR/pkgs/argz/argz-0.1.0.tar.gz" | cut -d' ' -f1)
 SUM_DEMO=$(sha256sum "$REGDIR/pkgs/argz-demo/argz-demo-0.1.0.tar.gz" | cut -d' ' -f1)
+SUM_NQ=$(sha256sum "$REGDIR/pkgs/nq/nq-0.1.0.tar.gz" | cut -d' ' -f1)
 printf '{"name":"argz","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[]}]}\n' \
     "$SUM_ARGZ" > "$REGDIR/index/argz.json"
 printf '{"name":"argz-demo","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
     "$SUM_DEMO" > "$REGDIR/index/argz-demo.json"
+printf '{"name":"nq","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
+    "$SUM_NQ" > "$REGDIR/index/nq.json"
 
 # ── 2. Serve the static registry ──────────────────────────────────────────
 say "serve registry"
@@ -87,6 +91,28 @@ GREET=$(env -i HOME="$WORK" PATH=/usr/bin:/bin bash -c "
 ")
 echo "$GREET"
 [[ "$GREET" == "HELLO, ECOSYSTEM!" ]] && echo "run: OK" || { echo "run: FAILED (got '$GREET')"; fail=1; }
+
+# ── 6. A second tool from the same registry: `nq` (also depends on argz) ──
+say "nurlpkg install nq"
+OUT=$(env -i HOME="$WORK" PATH=/usr/bin:/bin bash -c "
+    source '$PREFIX/env'
+    export NURL_REGISTRY='$REG'
+    nurlpkg install nq 2>&1
+")
+echo "$OUT"
+echo "$OUT" | grep -q 'Installed nq' && echo "install: OK" || { echo "install: FAILED"; fail=1; }
+
+say "run installed nq"
+# Feed a small document and exercise navigation + array iteration + a raw
+# string projection — the everyday jq-lite path.
+NQ_OUT=$(env -i HOME="$WORK" PATH=/usr/bin:/bin bash -c "
+    source '$PREFIX/env'
+    printf '%s' '{\"items\":[{\"id\":1},{\"id\":2},{\"id\":3}],\"who\":\"Ecosystem\"}' | nq -r '.items[].id'
+    printf '%s' '{\"items\":[{\"id\":1},{\"id\":2},{\"id\":3}],\"who\":\"Ecosystem\"}' | nq -r .who
+")
+echo "$NQ_OUT"
+NQ_WANT=$'1\n2\n3\nEcosystem'
+[[ "$NQ_OUT" == "$NQ_WANT" ]] && echo "run: OK" || { echo "run: FAILED (got '$NQ_OUT')"; fail=1; }
 
 say "RESULT"
 [[ $fail -eq 0 ]] && echo "PASS" || echo "FAIL"


### PR DESCRIPTION
## Summary

Adds **`nq`**, the third package in the NURL registry: a small, daily-useful JSON query CLI ("jq, but tiny"). It reads JSON from stdin (or `--file`), applies a jq-lite filter, and prints the result pretty (default), compact (`-c`), or raw (`-r`).

Like `argz-demo`, `nq` exercises the whole ecosystem end to end: it declares `argz = "^0.1"` as a registry dependency for flag parsing, and leans on the shipped `stdlib/ext/json` for parsing/printing.

**`nq 0.1.0` is already published and live at https://reg.nurl-lang.org** — it installs cleanly from prod, resolving `argz` from the registry.

## Filter grammar (v0.1)

| Filter | Result |
| ------ | ------ |
| `.` | the whole document |
| `.a.b` / `.0` / `[0]` | object/array navigation |
| `.items[]` | iterate an array/object, one result per line |
| `.items[].id` | project a field out of each element |
| `. \| keys` | object keys (sorted, matching jq) or array indices |
| `. \| length` | length of an array / object / string |

Flags: `-c/--compact`, `-r/--raw`, `-f/--file`, `-h/--help`. A missing path yields `null` (like jq); iterating a scalar or applying `keys`/`length` to the wrong type is an error (exit 1).

## Quality

- **Leak-clean under AddressSanitizer/LeakSanitizer** on every path — navigation, `[]` iteration (incl. the string-move in `keys`), the `keys`/`length` terminals, and the error/parse-failure branches.
- **Differentially tested against `jq 1.7`.** Caught and fixed one real divergence: `keys` now sorts to match jq (jq's insertion-order form is `keys_unsorted`). The remaining `jq` diffs are intentional and not bugs — `nq` preserves a JSON number's source text where jq reformats it, and `nq` supports `.1` as index shorthand where jq's lexer reads bare `.1` as the number `0.1` (the jq-compatible `[1]` form matches jq).
- **Durable install-and-run harness** (`tools/nurlpkg/test-install-tool.sh`) now also packs `nq`, registers it with its `argz` dependency, installs it from a local static registry, and asserts its output → **PASS**.

## Also in this PR

- `packages/.gitignore`: ignore local-dev artifacts (`deps/`, `.nurl-bin`, `nurl.lock`) so a manual build inside a package dir never gets staged.
- `registry/DEPLOY.md`: correct stale "not yet deployed / purely wiring the account" framing — the registry is **LIVE in production** at https://reg.nurl-lang.org (serving `argz`, `argz-demo`, and now `nq`).
- `packages/README.md`: document the `nq` package.

## Test plan

- [x] `nq` compiles via the dev driver and the installed toolchain
- [x] ASan/LSan clean across all code paths
- [x] 30+ behavioral cases + exit codes + unicode/escapes + file input
- [x] Differential vs `jq 1.7`
- [x] `tools/nurlpkg/test-install-tool.sh` → PASS (local registry)
- [x] Clean install from prod `reg.nurl-lang.org` into a throwaway prefix → builds + runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)