### PR TITLE
registry: render each package's README on its detail page

### DIFF
--- a/registry/package.json
+++ b/registry/package.json
@@ -6,6 +6,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
+    "test:readme": "node test-readme.ts",
     "migrate:local": "wrangler d1 migrations apply REG_DB --local",
     "migrate:remote": "wrangler d1 migrations apply REG_DB --remote"
   },

--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -21,6 +21,9 @@
 // against a static python registry). It runs locally under `wrangler dev`
 // (miniflare simulates R2 + D1) — no Cloudflare account needed to test.
 
+import { renderMarkdown } from "./markdown.ts";
+import { extractReadme } from "./readme.ts";
+
 export interface Env {
   REG_BUCKET: R2Bucket;
   REG_DB: D1Database;
@@ -162,10 +165,29 @@ async function handlePublish(req: Request, env: Env): Promise<Response> {
 
 // ── GitHub OAuth (token bootstrap) ────────────────────────────────────
 
+const PAGE_STYLE =
+  `body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;max-width:48rem;` +
+    `margin:3rem auto;padding:0 1rem;line-height:1.6;color:#1a1a1a}` +
+  `a{color:#0b62d6}` +
+  `h1{margin-bottom:.2em}` +
+  `code{background:#f4f4f4;padding:.1em .35em;border-radius:4px;font-size:.92em}` +
+  `pre{background:#f4f4f4;padding:1rem;border-radius:6px;overflow:auto}` +
+  `pre code{background:transparent;padding:0}` +
+  `.readme{border-top:1px solid #e5e5e5;margin-top:2.5rem;padding-top:.5rem}` +
+  `.readme img{max-width:100%}` +
+  `.readme table{border-collapse:collapse;margin:1rem 0}` +
+  `.readme th,.readme td{border:1px solid #ddd;padding:.4rem .7rem;text-align:left}` +
+  `.readme th{background:#f4f4f4}` +
+  `.readme blockquote{border-left:3px solid #ddd;margin:1em 0;padding:.2rem 1rem;color:#555}` +
+  `.readme h1,.readme h2{border-bottom:1px solid #eee;padding-bottom:.2em}` +
+  `.readme hr{border:0;border-top:1px solid #e5e5e5;margin:2rem 0}`;
+
 function htmlPage(title: string, bodyHtml: string, status = 200): Response {
   return new Response(
     `<!doctype html><meta charset=utf-8><title>${title}</title>` +
-      `<body style="font-family:system-ui;max-width:42rem;margin:3rem auto;padding:0 1rem">${bodyHtml}</body>`,
+      `<meta name=viewport content="width=device-width,initial-scale=1">` +
+      `<style>${PAGE_STYLE}</style>` +
+      `<body>${bodyHtml}</body>`,
     { status, headers: { "content-type": "text/html; charset=utf-8" } },
   );
 }
@@ -219,12 +241,25 @@ async function handlePackageDetail(env: Env, name: string): Promise<Response> {
         `<li><a href="/packages/${esc(d.name)}">${esc(d.name)}</a> <code>${esc(d.req)}</code></li>`).join("")}</ul>`
     : `<p>None.</p>`;
   const reqStr = latest ? `^${latest.version}` : "*";
+
+  // README of the latest published version, rendered from its tarball.
+  // Never let a missing/odd archive break the page.
+  let readmeHtml = "";
+  if (latest) {
+    try {
+      const md = await extractReadme(env.REG_BUCKET, name, latest.version);
+      if (md && md.length <= 512 * 1024) {
+        readmeHtml = `<div class="readme">${renderMarkdown(md)}</div>`;
+      }
+    } catch { /* fall through with no README */ }
+  }
+
   return htmlPage(name,
     `<p><a href="/">← all packages</a></p><h1>${esc(name)}</h1>` +
-    `<h3>Install</h3><pre style="background:#f4f4f4;padding:1rem;border-radius:6px">` +
-      `[dependencies]\n${esc(name)} = "${esc(reqStr)}"</pre>` +
+    `<h3>Install</h3><pre>[dependencies]\n${esc(name)} = "${esc(reqStr)}"</pre>` +
     `<h3>Versions</h3><ul>${versionsHtml}</ul>` +
-    `<h3>Dependencies (latest)</h3>${depsHtml}`);
+    `<h3>Dependencies (latest)</h3>${depsHtml}` +
+    readmeHtml);
 }
 
 async function handleSearch(url: URL, env: Env): Promise<Response> {

--- a/registry/src/markdown.ts
+++ b/registry/src/markdown.ts
@@ -1,0 +1,172 @@
+// A small, dependency-free, XSS-safe Markdown -> HTML renderer.
+//
+// Scope: the subset that package READMEs actually use -- ATX headings,
+// fenced code blocks, blockquotes, unordered/ordered lists, GFM tables,
+// horizontal rules, paragraphs, and inline code / bold / italic / links.
+// It is NOT a full CommonMark implementation; it is deliberately tiny and
+// predictable.
+//
+// Security: this renders untrusted input (any package author's README), so
+// every run of literal text is HTML-escaped, raw HTML in the source is
+// never passed through, and link targets are restricted to a safe scheme
+// allowlist (no javascript: / data:).
+
+function esc(s: string): string {
+  return s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]!));
+}
+
+// Validate a link target. `url` arrives already HTML-escaped, so attribute
+// injection is impossible here; we only need to reject dangerous schemes.
+// Allowed: http(s), mailto, and same-document / relative links.
+function safeUrl(url: string): string | null {
+  const u = url.trim();
+  if (u === "") return null;
+  // A scheme is letters/digits/+/-/. followed by ':'. If there is no scheme
+  // before the path, it is a relative URL -- allow it.
+  const scheme = u.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  if (scheme) {
+    const s = scheme[1].toLowerCase();
+    if (s !== "http" && s !== "https" && s !== "mailto") return null;
+  }
+  return u;
+}
+
+// A Private-Use-Area codepoint that cannot appear in escaped README text,
+// used as a collision-free placeholder for already-rendered code spans.
+const SENTINEL = String.fromCharCode(0xe000);
+
+// Inline formatting for a single run of text.
+function inline(raw: string): string {
+  let s = esc(raw);
+
+  // Pull code spans out first so their contents are never re-processed by
+  // the emphasis / link passes below.
+  const codes: string[] = [];
+  s = s.replace(/`([^`]+)`/g, (_m, c: string) => {
+    codes.push(`<code>${c}</code>`);
+    return `${SENTINEL}${codes.length - 1}${SENTINEL}`;
+  });
+
+  s = s.replace(/\*\*([^*\n]+)\*\*/g, "<strong>$1</strong>");
+  s = s.replace(/__([^_\n]+)__/g, "<strong>$1</strong>");
+  s = s.replace(/(^|[^*])\*([^*\n]+)\*/g, "$1<em>$2</em>");
+  s = s.replace(/(^|[^_\w])_([^_\n]+)_/g, "$1<em>$2</em>");
+
+  s = s.replace(/\[([^\]]*)\]\(([^)\s]+)\)/g, (_m, text: string, url: string) => {
+    const safe = safeUrl(url);
+    return safe
+      ? `<a href="${safe}" rel="noopener nofollow">${text}</a>`
+      : `[${text}](${url})`;
+  });
+
+  const restore = new RegExp(`${SENTINEL}(\\d+)${SENTINEL}`, "g");
+  s = s.replace(restore, (_m, n: string) => codes[+n]);
+  return s;
+}
+
+// ── GFM table helpers ─────────────────────────────────────────────────
+
+// Split a table row on unescaped `|`, dropping the optional leading/
+// trailing pipe, and unescape `\|` inside each cell.
+function splitRow(line: string): string[] {
+  let t = line.trim();
+  t = t.replace(/^\|/, "").replace(/\|$/, "");
+  return t.split(/(?<!\\)\|/).map((c) => c.replace(/\\\|/g, "|").trim());
+}
+
+// A delimiter row is `---|:--:|--` style: each cell only `-`, `:`, spaces,
+// with at least one `-`.
+function isDelimRow(line: string): boolean {
+  const t = line.trim().replace(/^\|/, "").replace(/\|$/, "");
+  if (!t.includes("-")) return false;
+  return t.split(/(?<!\\)\|/).every((c) => /^\s*:?-+:?\s*$/.test(c));
+}
+
+function renderTable(lines: string[], start: number, out: string[]): number {
+  out.push("<table>\n<thead>\n<tr>");
+  for (const c of splitRow(lines[start])) out.push(`<th>${inline(c)}</th>`);
+  out.push("</tr>\n</thead>\n<tbody>\n");
+  let i = start + 2; // skip header + delimiter row
+  while (i < lines.length && lines[i].includes("|") && lines[i].trim() !== "") {
+    out.push("<tr>");
+    for (const c of splitRow(lines[i])) out.push(`<td>${inline(c)}</td>`);
+    out.push("</tr>\n");
+    i++;
+  }
+  out.push("</tbody>\n</table>\n");
+  return i - 1; // caller's loop does i++
+}
+
+// ── Block renderer ────────────────────────────────────────────────────
+
+type Block = "p" | "ul" | "ol" | "bq" | null;
+
+export function renderMarkdown(src: string): string {
+  const lines = src.replace(/\r\n?/g, "\n").split("\n");
+  const out: string[] = [];
+  let open: Block = null;
+
+  const close = () => {
+    if (open === "p") out.push("</p>\n");
+    else if (open === "ul") out.push("</ul>\n");
+    else if (open === "ol") out.push("</ol>\n");
+    else if (open === "bq") out.push("</blockquote>\n");
+    open = null;
+  };
+  const ensure = (b: Block, openTag: string) => {
+    if (open !== b) { close(); out.push(openTag); open = b; }
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Fenced code block.
+    const fence = line.match(/^\s*```(.*)$/);
+    if (fence) {
+      close();
+      const lang = fence[1].trim();
+      out.push(`<pre><code${lang ? ` class="language-${esc(lang)}"` : ""}>`);
+      i++;
+      const buf: string[] = [];
+      while (i < lines.length && !/^\s*```/.test(lines[i])) { buf.push(esc(lines[i])); i++; }
+      out.push(buf.join("\n"));
+      out.push("</code></pre>\n");
+      continue; // i sits on the closing fence (or past end); loop ++ advances
+    }
+
+    if (line.trim() === "") { close(); continue; }
+
+    // ATX heading.
+    const h = line.match(/^(#{1,6})\s+(.*?)\s*#*\s*$/);
+    if (h) { close(); const n = h[1].length; out.push(`<h${n}>${inline(h[2])}</h${n}>\n`); continue; }
+
+    // Horizontal rule.
+    if (/^ {0,3}([-*_])\s*(\1\s*){2,}$/.test(line)) { close(); out.push("<hr />\n"); continue; }
+
+    // Blockquote.
+    const bq = line.match(/^>\s?(.*)$/);
+    if (bq) { ensure("bq", "<blockquote>"); out.push(inline(bq[1]) + " "); continue; }
+
+    // GFM table (current line has a pipe, next line is a delimiter row).
+    if (line.includes("|") && i + 1 < lines.length && isDelimRow(lines[i + 1])) {
+      close();
+      i = renderTable(lines, i, out);
+      continue;
+    }
+
+    // Unordered list item.
+    const ul = line.match(/^\s*[-*+]\s+(.*)$/);
+    if (ul) { ensure("ul", "<ul>\n"); out.push(`<li>${inline(ul[1])}</li>\n`); continue; }
+
+    // Ordered list item.
+    const ol = line.match(/^\s*\d+\.\s+(.*)$/);
+    if (ol) { ensure("ol", "<ol>\n"); out.push(`<li>${inline(ol[1])}</li>\n`); continue; }
+
+    // Paragraph (consecutive plain lines join with a space).
+    ensure("p", "<p>");
+    out.push(inline(line.trim()) + " ");
+  }
+
+  close();
+  return out.join("");
+}

--- a/registry/src/readme.ts
+++ b/registry/src/readme.ts
@@ -1,0 +1,62 @@
+// Extract a package's README from its published tarball.
+//
+// Packages are stored in R2 as `pkgs/<name>/<name>-<version>.tar.gz`: a
+// gzip-compressed USTAR archive whose members are top-level relative paths
+// (e.g. `README.md`, `nurl.toml`, `src/main.nu`). We gunzip with the
+// platform `DecompressionStream` and walk the 512-byte tar blocks to find
+// the README, without any third-party tar/gzip dependency.
+
+const BLOCK = 512;
+
+function readCStr(buf: Uint8Array, off: number, max: number): string {
+  let end = off;
+  const lim = Math.min(off + max, buf.length);
+  while (end < lim && buf[end] !== 0) end++;
+  return new TextDecoder().decode(buf.subarray(off, end));
+}
+
+function isZeroBlock(buf: Uint8Array, off: number): boolean {
+  for (let i = off; i < off + BLOCK && i < buf.length; i++) if (buf[i] !== 0) return false;
+  return true;
+}
+
+function isReadmeName(path: string): boolean {
+  const base = path.split("/").pop()!.toLowerCase();
+  return base === "readme.md" || base === "readme.markdown" || base === "readme";
+}
+
+// Find and decode the README in an uncompressed tar image. Returns the
+// file's text, or null if the archive has no README member.
+export function findReadmeInTar(buf: Uint8Array): string | null {
+  let pos = 0;
+  while (pos + BLOCK <= buf.length) {
+    if (isZeroBlock(buf, pos)) break; // end-of-archive marker
+    const name = readCStr(buf, pos, 100);
+    // Size: octal in the 12-byte field at offset 124 (may be space/NUL padded).
+    const sizeRaw = readCStr(buf, pos + 124, 12).trim();
+    const size = parseInt(sizeRaw.replace(/[^0-7]/g, "") || "0", 8);
+    const typeflag = buf[pos + 156];
+    const dataStart = pos + BLOCK;
+    // typeflag '0' (0x30) or NUL (0) is a regular file.
+    if ((typeflag === 0x30 || typeflag === 0) && name && isReadmeName(name)) {
+      return new TextDecoder().decode(buf.subarray(dataStart, dataStart + size));
+    }
+    pos = dataStart + Math.ceil(size / BLOCK) * BLOCK;
+  }
+  return null;
+}
+
+// Fetch + gunzip + extract the README for one published version. Returns
+// null if the tarball is missing or carries no README. Never throws on a
+// well-formed-but-readmeless archive; callers should still guard against
+// network/decompression errors.
+export async function extractReadme(
+  bucket: R2Bucket,
+  name: string,
+  version: string,
+): Promise<string | null> {
+  const obj = await bucket.get(`pkgs/${name}/${name}-${version}.tar.gz`);
+  if (!obj || !obj.body) return null;
+  const ab = await new Response(obj.body.pipeThrough(new DecompressionStream("gzip"))).arrayBuffer();
+  return findReadmeInTar(new Uint8Array(ab));
+}

--- a/registry/test-local.sh
+++ b/registry/test-local.sh
@@ -43,6 +43,21 @@ for i in $(seq 1 60); do curl -sf "$REG" >/dev/null 2>&1 && break; sleep 0.5; do
 mkdir -p "$WORK/foo/src"
 printf '[package]\nname = "foo"\nversion = "1.0.0"\n' > "$WORK/foo/nurl.toml"
 printf '@ answer -> i { ^ 42 }\n' > "$WORK/foo/src/lib.nu"
+# A README that exercises the renderer: heading, code, table, link, and a
+# script-injection attempt that must be neutralised.
+cat > "$WORK/foo/README.md" <<'MD'
+# foo
+
+The `answer` function returns **42**.
+
+| Name | Returns |
+| ---- | ------- |
+| answer | `42` |
+
+See [the docs](https://nurl-lang.org).
+
+<script>alert('xss')</script>
+MD
 
 say "publish"
 ( cd "$WORK/foo" && NURL_REGISTRY="$REG" NURL_TOKEN="$TOKEN" "$NURLPKG" publish ) || fail=1
@@ -53,6 +68,17 @@ printf '[package]\nname = "app"\nversion = "0.1.0"\n\n[dependencies]\nfoo = "^1.
 ( cd "$WORK/app" && NURL_REGISTRY="$REG" "$NURLPKG" install ) || fail=1
 [[ -f "$WORK/app/deps/foo/nurl.toml" && -f "$WORK/app/deps/foo/src/lib.nu" ]] && echo "deps/foo: OK" || { echo "deps/foo: MISSING"; fail=1; }
 grep -q 'checksum =' "$WORK/app/nurl.lock" && echo "lock checksum: OK" || { echo "lock checksum: MISSING"; fail=1; }
+
+say "package page renders README"
+PAGE=$(curl -sf "${REG}packages/foo" || true)
+check_page() { echo "$PAGE" | grep -qF "$1" && echo "  $2: OK" || { echo "  $2: MISSING"; fail=1; }; }
+check_page "<h1>foo</h1>"                  "heading"
+check_page "<code>answer</code>"           "inline code"
+check_page "<strong>42</strong>"           "bold"
+check_page "<table>"                       "table"
+check_page '<a href="https://nurl-lang.org"' "link"
+check_page "&lt;script&gt;"                "script escaped as text"
+if echo "$PAGE" | grep -qF "<script>alert"; then echo "  xss: LEAKED"; fail=1; else echo "  xss: neutralised"; fi
 
 say "republish -> 409"
 ( cd "$WORK/foo" && NURL_REGISTRY="$REG" NURL_TOKEN="$TOKEN" "$NURLPKG" publish ) && { echo "expected failure"; fail=1; } || echo "rejected (correct)"

--- a/registry/test-readme.ts
+++ b/registry/test-readme.ts
@@ -1,0 +1,90 @@
+// Unit tests for the README pipeline (markdown rendering + tar extraction).
+// Run with: node test-readme.ts   (Node >= 22 strips the TS types natively).
+import { readFileSync } from "node:fs";
+import { gzipSync } from "node:zlib";
+import { renderMarkdown } from "./src/markdown.ts";
+import { findReadmeInTar } from "./src/readme.ts";
+
+let pass = 0, fail = 0;
+function ok(cond: boolean, msg: string) {
+  if (cond) { pass++; } else { fail++; console.log(`FAIL: ${msg}`); }
+}
+function has(hay: string, needle: string, msg: string) {
+  ok(hay.includes(needle), `${msg} (missing: ${JSON.stringify(needle)})`);
+}
+function absent(hay: string, needle: string, msg: string) {
+  ok(!hay.includes(needle), `${msg} (should not contain: ${JSON.stringify(needle)})`);
+}
+
+// ── markdown: blocks ──────────────────────────────────────────────────
+has(renderMarkdown("# Title"), "<h1>Title</h1>", "h1");
+has(renderMarkdown("### Sub"), "<h3>Sub</h3>", "h3");
+has(renderMarkdown("- a\n- b"), "<ul>\n<li>a</li>\n<li>b</li>\n</ul>", "ul");
+has(renderMarkdown("1. x\n2. y"), "<ol>\n<li>x</li>\n<li>y</li>\n</ol>", "ol");
+has(renderMarkdown("> quoted"), "<blockquote>quoted </blockquote>", "blockquote");
+has(renderMarkdown("---"), "<hr />", "hr");
+has(renderMarkdown("one\ntwo"), "<p>one two </p>", "paragraph join");
+has(renderMarkdown("```sh\nls -l\n```"), `<pre><code class="language-sh">ls -l</code></pre>`, "fenced code w/ lang");
+has(renderMarkdown("```\nx<y\n```"), "x&lt;y", "code block escapes html");
+
+// ── markdown: inline ──────────────────────────────────────────────────
+has(renderMarkdown("a `b` c"), "<code>b</code>", "inline code");
+has(renderMarkdown("**bold**"), "<strong>bold</strong>", "bold");
+has(renderMarkdown("see [docs](https://x.io)"), `<a href="https://x.io" rel="noopener nofollow">docs</a>`, "link");
+// code span content must not be re-processed as emphasis
+has(renderMarkdown("`a*b*c`"), "<code>a*b*c</code>", "no emphasis inside code");
+absent(renderMarkdown("`a*b*c`"), "<em>", "no <em> inside code span");
+
+// ── GFM table (with escaped pipes, like nq's README) ──────────────────
+const tbl = renderMarkdown("| A | B |\n| - | - |\n| 1 | x \\| y |");
+has(tbl, "<table>", "table open");
+has(tbl, "<th>A</th>", "table header cell");
+has(tbl, "<td>x | y</td>", "escaped pipe in cell");
+
+// ── XSS safety ────────────────────────────────────────────────────────
+absent(renderMarkdown("<script>alert(1)</script>"), "<script>", "raw html escaped");
+has(renderMarkdown("<script>alert(1)</script>"), "&lt;script&gt;", "raw html shown as text");
+absent(renderMarkdown("[x](javascript:alert(1))"), 'href="javascript', "javascript: link rejected");
+absent(renderMarkdown("[x](data:text/html,evil)"), 'href="data:', "data: link rejected");
+ok(!/<[^>]*\sonerror=/.test(renderMarkdown('![x](" onerror=alert(1) src=x)')), "no attribute injection");
+// a sneaky sentinel collision attempt: plain " 0 " text must survive intact
+has(renderMarkdown("value is 0 here"), "value is 0 here", "no placeholder collision on bare digits");
+
+// ── tar extraction ────────────────────────────────────────────────────
+function tarWith(name: string, body: string): Uint8Array {
+  const data = new TextEncoder().encode(body);
+  const blocks = Math.ceil(data.length / 512);
+  const buf = new Uint8Array(512 + blocks * 512 + 1024); // header + data + 2 zero blocks
+  const enc = new TextEncoder();
+  buf.set(enc.encode(name), 0);                        // name @ 0
+  buf.set(enc.encode("0000644\0"), 100);               // mode
+  buf.set(enc.encode(data.length.toString(8).padStart(11, "0") + "\0"), 124); // size (octal)
+  buf[156] = 0x30;                                      // typeflag '0'
+  buf.set(enc.encode("ustar\0"), 257);                 // magic
+  buf.set(enc.encode("00"), 263);                      // version
+  buf.set(data, 512);                                  // file data
+  return buf;
+}
+ok(findReadmeInTar(tarWith("README.md", "# Hi\n")) === "# Hi\n", "extract README.md");
+ok(findReadmeInTar(tarWith("src/main.nu", "x")) === null, "no README -> null");
+// nested-path README is found by basename
+ok(findReadmeInTar(tarWith("nq/README.md", "# nq\n")) === "# nq\n", "README under a dir");
+
+// ── round-trip: real nq README renders without throwing ───────────────
+try {
+  const nq = readFileSync(new URL("../packages/nq/README.md", import.meta.url), "utf8");
+  const html = renderMarkdown(nq);
+  has(html, "<h1>", "nq README has an h1");
+  has(html, "<table>", "nq README table renders");
+  has(html, "<code>nq</code>", "nq README inline code renders");
+  absent(html, "<script", "nq README produces no script tag");
+  // gzip+tar round-trip shape check (decompress happens in the Worker via
+  // DecompressionStream; here we just confirm our tar reader finds it).
+  const gz = gzipSync(Buffer.from(tarWith("README.md", nq)));
+  ok(gz.length > 0, "gzip of tar produced bytes");
+} catch (e) {
+  fail++; console.log(`FAIL: nq README round-trip threw: ${e}`);
+}
+
+console.log(`\n==== ${pass} passed, ${fail} failed ====`);
+process.exit(fail ? 1 : 0);

--- a/registry/tsconfig.json
+++ b/registry/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2022",
     "module": "es2022",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "lib": ["es2022"],
     "types": ["@cloudflare/workers-types"],
     "strict": true,


### PR DESCRIPTION
## Summary

A package's detail page on **reg.nurl-lang.org** previously showed only the name, an install snippet, versions, and dependencies — it didn't tell you what the package *is*. This PR renders the package's **README** on that page, fetched straight from the published tarball.

The registry stays **100% TypeScript** (no NURL in the Worker), per the constraint that we don't mix languages in the registry.

## What's new

- **`src/markdown.ts`** — a small, dependency-free, **XSS-safe** Markdown → HTML renderer covering the subset READMEs use: ATX headings, fenced code, blockquotes, ordered/unordered lists, GFM tables (incl. escaped `\|`), horizontal rules, paragraphs, and inline code/bold/italic/links. Security: all literal text is HTML-escaped, raw HTML is never passed through, and link targets are restricted to a safe scheme allowlist (`http`/`https`/`mailto`/relative — no `javascript:`/`data:`).
- **`src/readme.ts`** — fetches `pkgs/<name>/<name>-<ver>.tar.gz` from R2, gunzips via the platform `DecompressionStream`, and walks the 512-byte USTAR blocks to extract `README.md`. No third-party tar/gzip dependency, and it works for **already-published** packages (no re-publish needed).
- **`index.ts`** — renders the latest version's README into the page (guarded by `try/catch` + a 512 KiB cap so a missing/odd archive never breaks the page), plus a small stylesheet for headings/code/tables/blockquotes.

## Testing

- **`npm run test:readme`** (`test-readme.ts`): 31 unit tests for the renderer (blocks, inline, GFM tables, and XSS vectors like `javascript:` links, `<script>`, attribute-injection) and the tar extractor, including a round-trip over the real `nq` README. The full gunzip+extract path is also verified against a real tarball through `DecompressionStream`.
- **`test-local.sh`**: the end-to-end `wrangler dev` harness now publishes a package *with* a README and asserts the rendered page — heading, inline code, bold, table, and link all present; the embedded `<script>` is neutralised. Result: **PASS** (alongside the existing publish/install/409/401 checks).
- **`npm run typecheck`**: clean (`allowImportingTsExtensions` added for the new `.ts` imports).

## Deploy note

This is a Worker code change; it goes live via `wrangler deploy` (Cloudflare account), which I have **not** run. Once deployed, every existing package page (argz, argz-demo, nq) gets its README with no re-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)