### PR TITLE
md2html: Markdown → HTML package published to the registry

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -65,6 +65,30 @@ trailing `[]` to iterate an array/object (one result per line, optionally
 projecting `.field` from each), and the `| keys` / `| length` terminals.
 See [`nq/README.md`](nq/README.md) for the full grammar.
 
+## `md2html/` — Markdown → HTML (installable program **and** library)
+
+Renders Markdown to HTML. Ships both as an installable CLI (`md2html`,
+reading stdin or `--file`, with an optional `--full` styled page) and as a
+reusable renderer library (`src/markdown.nu`, one function `md_to_html`)
+that other packages can depend on. The renderer is the same one that powers
+the NURL playground's doc viewer, extracted into the registry. Depends on
+`argz` for flags; leak-clean under ASan/LSan.
+
+```
+nurlpkg install md2html
+md2html < README.md              # HTML fragment
+md2html -f README.md --full      # complete styled page
+
+# …or depend on the renderer library:
+#   [dependencies]
+#   md2html = "^0.1"
+#   $ `deps/md2html/src/markdown.nu`
+#   : String html ( md_to_html ( string_data src ) )
+```
+
+See [`md2html/README.md`](md2html/README.md) for the supported Markdown and
+the library API.
+
 ## The full loop
 
 ```bash

--- a/packages/md2html/README.md
+++ b/packages/md2html/README.md
@@ -1,0 +1,72 @@
+# `md2html` — Markdown → HTML, as a CLI and a library
+
+`md2html` renders Markdown to HTML. It ships both ways:
+
+- an **installable CLI** (`md2html`) that reads Markdown from stdin or a
+  file and writes HTML, optionally wrapped in a complete styled page; and
+- a **reusable renderer library** (`src/markdown.nu`, one function
+  `md_to_html`) that other packages can depend on.
+
+The renderer is the same one that powers the NURL playground's doc viewer,
+extracted into the registry so any project can use it.
+
+```
+nurlpkg install md2html
+md2html < README.md                 # HTML fragment to stdout
+md2html -f README.md --full         # complete styled HTML page
+md2html -f doc.md -t "My Doc" -F    # full page with a custom <title>
+```
+
+## CLI options
+
+| Option | Meaning |
+| ------ | ------- |
+| `-f`, `--file F`  | read Markdown from file `F` instead of stdin |
+| `-F`, `--full`    | emit a complete styled HTML document (not just a fragment) |
+| `-t`, `--title T` | document `<title>` when used with `--full` (default `Document`) |
+| `-h`, `--help`    | show help |
+
+## Using the renderer as a library
+
+Declare the dependency and import the renderer module:
+
+```toml
+[dependencies]
+md2html = "^0.1"
+```
+
+```
+$ `deps/md2html/src/markdown.nu`
+
+: String html ( md_to_html ( string_data my_markdown ) )
+// ... use html ...
+( string_free html )
+```
+
+`md_to_html` takes a Markdown source string and returns an owned HTML
+`String` (free it with `string_free`).
+
+## Supported Markdown
+
+- ATX headings (`#` … `######`)
+- Fenced code blocks (```` ```lang ````) with a language class
+- GitHub-style tables (`| a | b |` + a `|---|---|` delimiter row)
+- Blockquotes (`>`)
+- Unordered and ordered lists (`-` / `*` / `1.`)
+- Horizontal rules (`---`, `***`, `___`)
+- Inline: `` `code` ``, `**bold**`, `*em*`, `[text](url)`, `![alt](src)`,
+  and `<autolinks>`
+
+Raw text is HTML-escaped; existing entity references are left alone.
+
+Not supported (by design — they don't appear in typical READMEs): nested
+lists by indentation, definition lists, footnotes, reference-style links,
+setext headings, and raw HTML passthrough.
+
+## Quality
+
+The renderer is a verbatim extraction of the playground's doc renderer,
+and the CLI is leak-clean under AddressSanitizer/LeakSanitizer across its
+code paths (stdin, `--file`, `--full`, help, and the file-error branch).
+The end-to-end install-and-run loop is covered by
+`tools/nurlpkg/test-install-tool.sh`.

--- a/packages/md2html/nurl.toml
+++ b/packages/md2html/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "md2html"
+version = "0.1.0"
+description = "Render Markdown to HTML — a small CLI and reusable renderer library."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+argz = "^0.1"

--- a/packages/md2html/src/main.nu
+++ b/packages/md2html/src/main.nu
@@ -1,0 +1,125 @@
+// md2html — render Markdown to HTML from the command line.
+//
+// Reads Markdown from stdin (or --file) and writes HTML to stdout. With
+// --full it emits a complete, styled HTML document; otherwise it emits an
+// HTML fragment (just the rendered body), handy for embedding.
+//
+//   md2html < README.md                 # fragment to stdout
+//   md2html -f README.md --full         # full styled page
+//   md2html -f doc.md -t "My Doc" -F    # full page with a custom title
+//
+// Built on the `argz` registry package (flags) and this package's own
+// `markdown` renderer library.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+$ `deps/argz/src/argz.nu`
+$ `src/markdown.nu`
+
+// Wrap a rendered HTML body in a complete, self-contained document with a
+// clean, readable stylesheet.
+@ __full_page s title String body → String {
+    : String out ( string_with_cap + ( string_len body ) 2048 )
+    ( string_push_str out `<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8" />\n` )
+    ( string_push_str out `<meta name="viewport" content="width=device-width,initial-scale=1" />\n<title>` )
+    ( __html_escape_into title out )
+    ( string_push_str out `</title>\n<style>\n` )
+    ( string_push_str out `  body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;line-height:1.6;` )
+    ( string_push_str out `color:#1a1a1a;max-width:46rem;margin:2.5rem auto;padding:0 1.25rem}\n` )
+    ( string_push_str out `  h1,h2{border-bottom:1px solid #eee;padding-bottom:.25em}\n` )
+    ( string_push_str out `  a{color:#0b62d6}\n` )
+    ( string_push_str out `  code{background:#f4f4f4;padding:.1em .35em;border-radius:4px;font-size:.92em}\n` )
+    ( string_push_str out `  pre{background:#f4f4f4;padding:1rem;border-radius:6px;overflow:auto}\n` )
+    ( string_push_str out `  pre code{background:transparent;padding:0}\n` )
+    ( string_push_str out `  blockquote{border-left:3px solid #ddd;margin:1em 0;padding:.2rem 1rem;color:#555}\n` )
+    ( string_push_str out `  table{border-collapse:collapse;margin:1rem 0}\n` )
+    ( string_push_str out `  th,td{border:1px solid #ddd;padding:.4rem .7rem;text-align:left}\n` )
+    ( string_push_str out `  th{background:#f4f4f4}\n` )
+    ( string_push_str out `  hr{border:0;border-top:1px solid #e5e5e5;margin:2rem 0}\n` )
+    ( string_push_str out `  img{max-width:100%}\n` )
+    ( string_push_str out `</style>\n</head>\n<body>\n` )
+    ( string_push_str out ( string_data body ) )
+    ( string_push_str out `</body>\n</html>\n` )
+    ^ out
+}
+
+@ main → i {
+    : Argz p ( argz_new `md2html` `render Markdown to HTML` )
+    ( argz_flag p `full`  `F` `emit a complete styled HTML document (not just a fragment)` )
+    ( argz_flag p `help`  `h` `show this help` )
+    ( argz_opt  p `file`  `f` `read Markdown from FILE instead of stdin` )
+    ( argz_opt  p `title` `t` `document <title> when used with --full (default "Document")` )
+
+    : ( Vec String ) argv ( vec_new [String] )
+    : i ac ( env_args_count )
+    : ~ i ai 1
+    ~ < ai ac {
+        ( vec_push [String] argv ( env_arg ai ) )
+        = ai + ai 1
+    }
+
+    : ~ i rc 0
+    : !ArgzMatch ArgzErr r ( argz_parse p argv )
+    ?? r {
+        F e → {
+            ( nurl_eprint `md2html: ` ) ( nurl_eprintln ( argz_err_name e ) )
+            ( nurl_eprintln `try 'md2html --help'` )
+            = rc 2
+        }
+        T m → {
+            ? ( argz_has m `help` ) {
+                : String h ( argz_help p )
+                ( nurl_print `md2html — render Markdown to HTML\n\nUsage: md2html [OPTIONS]\n\n` )
+                ( nurl_print `Reads Markdown from stdin unless --file is given.\n\n` )
+                ( nurl_print ( string_data h ) )
+                ( string_free h )
+            } {
+                : b full ( argz_has m `full` )
+
+                // Input: --file, else stdin.
+                : ~ String input ( string_new )
+                : ~ b have_input T
+                ?? ( argz_value m `file` ) {
+                    T fv → {
+                        ?? ( read_file ( string_data fv ) ) {
+                            T txt → { ( string_free input ) = input txt }
+                            F _ → {
+                                ( nurl_eprint `md2html: cannot read file: ` )
+                                ( nurl_eprintln ( string_data fv ) )
+                                = rc 1
+                                = have_input F
+                            }
+                        }
+                    }
+                    F _ → {
+                        ( string_free input )
+                        = input ( read_all_stdin )
+                    }
+                }
+
+                ? have_input {
+                    : String body ( md_to_html ( string_data input ) )
+                    ? full {
+                        : ~ s title `Document`
+                        ?? ( argz_value m `title` ) { T tv → { = title ( string_data tv ) } F _ → {} }
+                        : String page ( __full_page title body )
+                        ( nurl_print ( string_data page ) )
+                        ( string_free page )
+                    } {
+                        ( nurl_print ( string_data body ) )
+                    }
+                    ( string_free body )
+                } {}
+                ( string_free input )
+            }
+            ( argz_match_free m )
+        }
+    }
+
+    ( argz_free p )
+    ( vec_free_with [String] argv \ String x → v { ( string_free x ) } )
+    ^ rc
+}

--- a/packages/md2html/src/markdown.nu
+++ b/packages/md2html/src/markdown.nu
@@ -1,0 +1,553 @@
+// md2html — a small Markdown → HTML renderer for NURL.
+//
+// Ported from the renderer that powers the NURL playground's doc viewer
+// (nurlapi's `/readme`, `/stdlib-docs`, …), extracted here as a reusable,
+// dependency-light registry library. Pure text → text: `md_to_html` takes
+// Markdown source and returns an owned HTML String.
+//
+// Supported:
+//   * ATX headings (# .. ######)
+//   * Fenced code blocks (```lang … ```) with a language class
+//   * GitHub-style tables (`| a | b |` + a `|---|---|` delimiter row)
+//   * Blockquotes (>)
+//   * Unordered + ordered lists (- / *  /  1. 2. …)
+//   * Horizontal rules (---, ***, ___)
+//   * Inline: `code`, **bold**, *em*, [text](url), ![alt](src), <autolink>
+//   * Raw text is HTML-escaped; entity refs are left alone.
+//
+// Not supported (by design — they don't appear in typical READMEs):
+//   nested lists by indent, definition lists, footnotes, reference-style
+//   links, setext headings, raw HTML passthrough.
+//
+// Surface:
+//   ( md_to_html s src )  → String   rendered HTML (caller owns it)
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+@ __html_escape_char String out i c → v {
+    ? == c 38 { ( string_push_str out `&amp;` ) } {
+        ? == c 60 { ( string_push_str out `&lt;` ) } {
+            ? == c 62 { ( string_push_str out `&gt;` ) } {
+                ? == c 34 { ( string_push_str out `&quot;` ) } {
+                    ( string_push_char out c )
+                }
+            }
+        }
+    }
+}
+
+@ __html_escape_into s src String out → v {
+    : i n ( nurl_str_len src )
+    : ~ i k 0
+    ~ < k n {
+        ( __html_escape_char out ( nurl_str_get src k ) )
+        = k + k 1
+    }
+}
+
+// Helper: get byte from a string buffer at idx (0 if past end).
+@ __md_byte s buf i n i idx → i {
+    ? | < idx 0 >= idx n { ^ 0 } {}
+    ^ ( nurl_str_get buf idx )
+}
+
+
+// Render inline elements from `buf[from..to)` into `out`. Inline grammar
+// is recursion-free: walks left→right, handles `` ` `` (code spans),
+// `**` (bold), `*` (em), `[txt](url)`, `<url>` autolinks. `to` is the
+// exclusive upper bound; `buf` is the underlying NUL-terminated buffer.
+@ __md_inline s buf i from i to String out → v {
+    : ~ i i from
+    ~ < i to {
+        : i c ( nurl_str_get buf i )
+        : i c1 ( __md_byte buf to + i 1 )
+
+        // Backslash-escape: consume next char verbatim.
+        ? == c 92 {
+            ? > c1 0 {
+                ( __html_escape_char out c1 )
+                = i + i 2
+            } {
+                ( string_push_char out c )
+                = i + i 1
+            }
+        } {
+
+            // Code span: `…`
+            ? == c 96 {
+                : ~ i end - 0 1
+                : ~ i j + i 1
+                ~ < j to {
+                    ? == ( nurl_str_get buf j ) 96 { = end j = j to } { = j + j 1 }
+                }
+                ? >= end 0 {
+                    ( string_push_str out `<code>` )
+                    : ~ i k + i 1
+                    ~ < k end {
+                        ( __html_escape_char out ( nurl_str_get buf k ) )
+                        = k + k 1
+                    }
+                    ( string_push_str out `</code>` )
+                    = i + end 1
+                } {
+                    ( __html_escape_char out c )
+                    = i + i 1
+                }
+            } {
+
+                // Bold: **…**
+                ? & == c 42 == c1 42 {
+                    : ~ i end - 0 1
+                    : ~ i j + i 2
+                    ~ < j - to 1 {
+                        ? & == ( nurl_str_get buf j ) 42 == ( nurl_str_get buf + j 1 ) 42 {
+                            = end j = j to
+                        } { = j + j 1 }
+                    }
+                    ? >= end 0 {
+                        ( string_push_str out `<strong>` )
+                        ( __md_inline buf + i 2 end out )
+                        ( string_push_str out `</strong>` )
+                        = i + end 2
+                    } {
+                        ( __html_escape_char out c )
+                        = i + i 1
+                    }
+                } {
+
+                    // Em: *…* (single, no nesting)
+                    ? == c 42 {
+                        : ~ i end - 0 1
+                        : ~ i j + i 1
+                        ~ < j to {
+                            ? == ( nurl_str_get buf j ) 42 { = end j = j to } { = j + j 1 }
+                        }
+                        ? >= end 0 {
+                            ( string_push_str out `<em>` )
+                            : ~ i k + i 1
+                            ~ < k end {
+                                ( __html_escape_char out ( nurl_str_get buf k ) )
+                                = k + k 1
+                            }
+                            ( string_push_str out `</em>` )
+                            = i + end 1
+                        } {
+                            ( __html_escape_char out c )
+                            = i + i 1
+                        }
+                    } {
+
+                        // Image: ![alt](url)
+                        ? & == c 33 == c1 91 {
+                            : ~ i mid - 0 1
+                            : ~ i close - 0 1
+                            : ~ i j + i 2
+                            ~ < j to {
+                                ? == ( nurl_str_get buf j ) 93 {
+                                    ? == ( __md_byte buf to + j 1 ) 40 { = mid j = close mid = j to } { = j to }
+                                } { = j + j 1 }
+                            }
+                            ? >= mid 0 {
+                                : ~ i k + mid 2
+                                ~ < k to {
+                                    ? == ( nurl_str_get buf k ) 41 { = close k = k to } { = k + k 1 }
+                                }
+                            } {}
+                            ? & >= mid 0 > close mid {
+                                ( string_push_str out `<img alt="` )
+                                : ~ i a + i 2
+                                ~ < a mid {
+                                    ( __html_escape_char out ( nurl_str_get buf a ) )
+                                    = a + a 1
+                                }
+                                ( string_push_str out `" src="` )
+                                : ~ i b + mid 2
+                                ~ < b close {
+                                    ( __html_escape_char out ( nurl_str_get buf b ) )
+                                    = b + b 1
+                                }
+                                ( string_push_str out `">` )
+                                = i + close 1
+                            } {
+                                ( __html_escape_char out c )
+                                = i + i 1
+                            }
+                        } {
+
+                            // Link: [text](url)
+                            ? == c 91 {
+                                : ~ i mid - 0 1
+                                : ~ i close - 0 1
+                                : ~ i j + i 1
+                                ~ < j to {
+                                    ? == ( nurl_str_get buf j ) 93 {
+                                        ? == ( __md_byte buf to + j 1 ) 40 { = mid j = close mid = j to } { = j to }
+                                    } { = j + j 1 }
+                                }
+                                ? >= mid 0 {
+                                    : ~ i k + mid 2
+                                    ~ < k to {
+                                        ? == ( nurl_str_get buf k ) 41 { = close k = k to } { = k + k 1 }
+                                    }
+                                } {}
+                                ? & >= mid 0 > close mid {
+                                    ( string_push_str out `<a href="` )
+                                    : ~ i b + mid 2
+                                    ~ < b close {
+                                        ( __html_escape_char out ( nurl_str_get buf b ) )
+                                        = b + b 1
+                                    }
+                                    ( string_push_str out `">` )
+                                    ( __md_inline buf + i 1 mid out )
+                                    ( string_push_str out `</a>` )
+                                    = i + close 1
+                                } {
+                                    ( __html_escape_char out c )
+                                    = i + i 1
+                                }
+                            } {
+
+                                // Autolink: <http://…> / <https://…>
+                                ? == c 60 {
+                                    : i p2 ( __md_byte buf to + i 1 )
+                                    : i p3 ( __md_byte buf to + i 2 )
+                                    : i p4 ( __md_byte buf to + i 3 )
+                                    : i p5 ( __md_byte buf to + i 4 )
+                                    : i p6 ( __md_byte buf to + i 5 )
+                                    : b is_url & & == p2 104 & == p3 116 & == p4 116 == p5 112 | == p6 58 == p6 115
+                                    ? is_url {
+                                        : ~ i end - 0 1
+                                        : ~ i j + i 1
+                                        ~ < j to {
+                                            ? == ( nurl_str_get buf j ) 62 { = end j = j to } { = j + j 1 }
+                                        }
+                                        ? >= end 0 {
+                                            ( string_push_str out `<a href="` )
+                                            : ~ i k + i 1
+                                            ~ < k end {
+                                                ( __html_escape_char out ( nurl_str_get buf k ) )
+                                                = k + k 1
+                                            }
+                                            ( string_push_str out `">` )
+                                            : ~ i k2 + i 1
+                                            ~ < k2 end {
+                                                ( __html_escape_char out ( nurl_str_get buf k2 ) )
+                                                = k2 + k2 1
+                                            }
+                                            ( string_push_str out `</a>` )
+                                            = i + end 1
+                                        } {
+                                            ( __html_escape_char out c )
+                                            = i + i 1
+                                        }
+                                    } {
+                                        ( __html_escape_char out c )
+                                        = i + i 1
+                                    }
+                                } {
+
+                                    ( __html_escape_char out c )
+                                    = i + i 1
+                                } } } } } } }
+    }
+}
+
+// Open / close block-level wrappers, closing whatever single open
+// block was previously active. `state` is a 1-element mutable Vec[i]
+// holding the active block kind (0=none, 1=p, 2=ul, 3=ol, 4=blockquote).
+@ __md_close_block ( Vec i ) state String out → v {
+    : i kind ?? ( vec_get [i] state 0 ) { T kv → kv F _ → 0 }
+    ? == kind 1 { ( string_push_str out `</p>\n` ) } {}
+    ? == kind 2 { ( string_push_str out `</ul>\n` ) } {}
+    ? == kind 3 { ( string_push_str out `</ol>\n` ) } {}
+    ? == kind 4 { ( string_push_str out `</blockquote>\n` ) } {}
+    ( vec_set [i] state 0 0 )
+}
+
+@ __md_open_block ( Vec i ) state i kind String out s tag → v {
+    : i cur ?? ( vec_get [i] state 0 ) { T cv → cv F _ → 0 }
+    ? != cur kind {
+        ( __md_close_block state out )
+        ( string_push_char out 60 )  // '<'
+        ( string_push_str out tag )
+        ( string_push_str out `>\n` )
+        ( vec_set [i] state 0 kind )
+    } {}
+}
+
+// Render fenced code-block lines. `info` is the optional language tag.
+@ __md_open_code String out s info → v {
+    : i ilen ( nurl_str_len info )
+    ? > ilen 0 {
+        ( string_push_str out `<pre><code class="language-` )
+        ( __html_escape_into info out )
+        ( string_push_str out `">` )
+    } {
+        ( string_push_str out `<pre><code>` )
+    }
+}
+
+// Convert `src` (markdown) to HTML. Returns an owned String.
+// ── GFM table support ────────────────────────────────────────────────
+
+// Index of the next '\n' at/after `pos`, or -1 if none.
+@ __md_nl_at s src i pos i n → i {
+    : ~ i scan pos
+    ~ < scan n { ? == ( nurl_str_get src scan ) 10 { ^ scan } { = scan + scan 1 } }
+    ^ - 0 1
+}
+
+// Start of the line after the one beginning at `pos`.
+@ __md_next_pos s src i pos i n → i {
+    : i nl ( __md_nl_at src pos n )
+    ^ ? >= nl 0 + nl 1 n
+}
+
+// The line beginning at `pos` as an owned String, sans trailing \r / \n.
+@ __md_read_line s src i pos i n → String {
+    : i nl ( __md_nl_at src pos n )
+    : i hard_end ? >= nl 0 nl n
+    : i line_end ? & > hard_end pos == ( nurl_str_get src - hard_end 1 ) 13 - hard_end 1 hard_end
+    : String line ( string_with_cap + - line_end pos 1 )
+    : ~ i k pos ~ < k line_end { ( string_push_char line ( nurl_str_get src k ) ) = k + k 1 }
+    ( __string_seal line )
+    ^ line
+}
+
+@ __md_has_pipe s line i n → b {
+    : ~ i i 0
+    ~ < i n { ? == ( nurl_str_get line i ) 124 { ^ T } {} = i + i 1 }
+    ^ F
+}
+
+// A GFM delimiter row: only `| - : space tab`, with at least one `-`.
+@ __md_is_table_delim s line i n → b {
+    ? == n 0 { ^ F } {}
+    : ~ b seen_dash F
+    : ~ i i 0
+    ~ < i n {
+        : i c ( nurl_str_get line i )
+        ? | | | | == c 124 == c 45 == c 58 == c 32 == c 9 {
+            ? == c 45 { = seen_dash T } {}
+        } { ^ F }
+        = i + i 1
+    }
+    ^ seen_dash
+}
+
+// Emit one `<tr>` of cells. `celltag` is "th" or "td". Splits on `|`,
+// dropping the empty segments a leading/trailing `|` produces, and trims
+// each cell before inline-formatting it.
+@ __md_table_row s line i n String out s celltag → v {
+    // Content range [s0, e0): skip outer whitespace + one outer pipe each end.
+    : ~ i s0 0
+    ~ & < s0 n | == ( nurl_str_get line s0 ) 32 == ( nurl_str_get line s0 ) 9 { = s0 + s0 1 }
+    ? & < s0 n == ( nurl_str_get line s0 ) 124 { = s0 + s0 1 } {}
+    : ~ i e0 n
+    ~ & > e0 s0 | == ( nurl_str_get line - e0 1 ) 32 == ( nurl_str_get line - e0 1 ) 9 { = e0 - e0 1 }
+    ? & > e0 s0 == ( nurl_str_get line - e0 1 ) 124 { = e0 - e0 1 } {}
+    // Walk cells between pipes in [s0, e0].
+    : ~ i cell_start s0
+    : ~ i i s0
+    ~ <= i e0 {
+        ? | == i e0 & < i e0 == ( nurl_str_get line i ) 124 {
+            // Trim [cell_start, i).
+            : ~ i cs cell_start
+            ~ & < cs i | == ( nurl_str_get line cs ) 32 == ( nurl_str_get line cs ) 9 { = cs + cs 1 }
+            : ~ i ce i
+            ~ & > ce cs | == ( nurl_str_get line - ce 1 ) 32 == ( nurl_str_get line - ce 1 ) 9 { = ce - ce 1 }
+            ( string_push_char out 60 ) ( string_push_str out celltag ) ( string_push_char out 62 )
+            ( __md_inline line cs ce out )
+            ( string_push_str out `</` ) ( string_push_str out celltag ) ( string_push_char out 62 )
+            = cell_start + i 1
+        } {}
+        = i + i 1
+    }
+}
+
+@ md_to_html s src → String {
+    : i n ( nurl_str_len src )
+    : String out ( string_with_cap n )
+    : ( Vec i ) state ( vec_new [i] ) ( vec_push [i] state 0 )
+
+    : ~ b in_code F
+
+    : ~ i pos 0
+    ~ < pos n {
+        // Find next newline.
+        : ~ i nl_at - 0 1
+        : ~ i scan pos
+        ~ < scan n {
+            ? == ( nurl_str_get src scan ) 10 { = nl_at scan = scan n } { = scan + scan 1 }
+        }
+        : i hard_end ? >= nl_at 0 nl_at n
+        : ~ i next_pos ? >= nl_at 0 + nl_at 1 n
+        : i line_end ? & > hard_end pos == ( nurl_str_get src - hard_end 1 ) 13 - hard_end 1 hard_end
+        : i line_len - line_end pos
+
+        : String line ( string_with_cap + line_len 1 )
+        : ~ i k pos
+        ~ < k line_end {
+            ( string_push_char line ( nurl_str_get src k ) )
+            = k + k 1
+        }
+        ( __string_seal line )
+
+        : s lp ( string_data line )
+
+        : b is_fence & & & >= line_len 3
+        == ( nurl_str_get lp 0 ) 96
+        == ( __md_byte lp line_len 1 ) 96
+        == ( __md_byte lp line_len 2 ) 96
+        ? in_code {
+            ? is_fence {
+                ( string_push_str out `</code></pre>\n` )
+                = in_code F
+            } {
+                ( __html_escape_into lp out )
+                ( string_push_char out 10 )
+            }
+        } {
+            ? == line_len 0 {
+                ( __md_close_block state out )
+            } {
+                ? is_fence {
+                    ( __md_close_block state out )
+                    : String info ( string_substr line 3 - line_len 3 )
+                    ( __md_open_code out ( string_data info ) )
+                    ( string_free info )
+                    = in_code T
+                } {
+                    // Heading?
+                    : ~ i hcount 0
+                    : ~ i hi 0
+                    ~ < hi line_len {
+                        ? & == ( nurl_str_get lp hi ) 35 < hi 6 { = hcount + hcount 1 = hi + hi 1 } { = hi line_len }
+                    }
+                    ? & > hcount 0 == ( __md_byte lp line_len hcount ) 32 {
+                        ( __md_close_block state out )
+                        ( string_push_str out `<h` )
+                        : String hn ( string_with_cap 2 ) ( string_push_char hn + 48 hcount ) ( __string_seal hn )
+                        ( string_push_str out ( string_data hn ) )
+                        ( string_push_char out 62 )
+                        : i htxt_start + hcount 1
+                        ( __md_inline lp htxt_start line_len out )
+                        ( string_push_str out `</h` )
+                        ( string_push_str out ( string_data hn ) )
+                        ( string_push_str out `>\n` )
+                        ( string_free hn )
+                    } {
+                        // Horizontal rule?
+                        ? ( __md_is_hr lp line_len ) {
+                            ( __md_close_block state out )
+                            ( string_push_str out `<hr />\n` )
+                        } {
+                            // Blockquote?
+                            ? & == ( nurl_str_get lp 0 ) 62 == ( __md_byte lp line_len 1 ) 32 {
+                                ( __md_open_block state 4 out `blockquote` )
+                                ( __md_inline lp 2 line_len out )
+                                ( string_push_char out 10 )
+                            } {
+                                // Unordered list item?
+                                ? & | == ( nurl_str_get lp 0 ) 45 == ( nurl_str_get lp 0 ) 42 == ( __md_byte lp line_len 1 ) 32 {
+                                    ( __md_open_block state 2 out `ul` )
+                                    ( string_push_str out `<li>` )
+                                    ( __md_inline lp 2 line_len out )
+                                    ( string_push_str out `</li>\n` )
+                                } {
+                                    // Ordered list item?
+                                    ? ( __md_starts_ol lp line_len ) {
+                                        ( __md_open_block state 3 out `ol` )
+                                        : i dot_idx ( __md_find_dot lp line_len )
+                                        : i text_idx + dot_idx 2
+                                        ( string_push_str out `<li>` )
+                                        ( __md_inline lp text_idx line_len out )
+                                        ( string_push_str out `</li>\n` )
+                                    } {
+                                        // GFM table? Current line has a `|` and
+                                        // the next line is a delimiter row.
+                                        : ~ b is_table F
+                                        ? ( __md_has_pipe lp line_len ) {
+                                            : String dline ( __md_read_line src next_pos n )
+                                            = is_table ( __md_is_table_delim ( string_data dline ) ( string_len dline ) )
+                                            ( string_free dline )
+                                        } {}
+                                        ? is_table {
+                                            ( __md_close_block state out )
+                                            ( string_push_str out `<table>\n<thead>\n<tr>` )
+                                            ( __md_table_row lp line_len out `th` )
+                                            ( string_push_str out `</tr>\n</thead>\n<tbody>\n` )
+                                            // Skip past the delimiter row, then
+                                            // consume contiguous `|`-bearing rows.
+                                            : ~ i tp ( __md_next_pos src next_pos n )
+                                            : ~ b done F
+                                            ~ & ! done < tp n {
+                                                : String row ( __md_read_line src tp n )
+                                                : i rl ( string_len row )
+                                                ? & > rl 0 ( __md_has_pipe ( string_data row ) rl ) {
+                                                    ( string_push_str out `<tr>` )
+                                                    ( __md_table_row ( string_data row ) rl out `td` )
+                                                    ( string_push_str out `</tr>\n` )
+                                                    = tp ( __md_next_pos src tp n )
+                                                } { = done T }
+                                                ( string_free row )
+                                            }
+                                            ( string_push_str out `</tbody>\n</table>\n` )
+                                            = next_pos tp
+                                        } {
+                                            // Paragraph
+                                            ( __md_open_block state 1 out `p` )
+                                            ( __md_inline lp 0 line_len out )
+                                            ( string_push_char out 32 )
+                                        }
+                                    } } } } }
+                } }
+        }
+
+        ( string_free line )
+        = pos next_pos
+    }
+    ( __md_close_block state out )
+    ? in_code { ( string_push_str out `</code></pre>\n` ) } {}
+    ( vec_free [i] state )
+    ^ out
+}
+
+// Horizontal rule detector: line is 3+ of one char from {-, *, _},
+// optionally with intervening spaces, and nothing else.
+@ __md_is_hr s line i n → b {
+    ? < n 3 { ^ F } {}
+    : i first ( nurl_str_get line 0 )
+    ? & != first 45 & != first 42 != first 95 { ^ F } {}
+    : ~ i k 0
+    : ~ i count 0
+    ~ < k n {
+        : i c ( nurl_str_get line k )
+        ? == c first { = count + count 1 } {
+            ? | == c 32 == c 9 {} { ^ F } }
+        = k + k 1
+    }
+    ^ >= count 3
+}
+
+// Detect ordered-list item prefix: digits followed by '.' and ' '.
+@ __md_starts_ol s line i n → b {
+    : ~ i k 0
+    : ~ i digits 0
+    ~ < k n {
+        : i c ( nurl_str_get line k )
+        ? & >= c 48 <= c 57 { = digits + digits 1 = k + k 1 } { = k n }
+    }
+    ? <= digits 0 { ^ F } {}
+    ? & < digits n == ( nurl_str_get line digits ) 46 {
+        ? & < + digits 1 n == ( nurl_str_get line + digits 1 ) 32 { ^ T } { ^ F }
+    } { ^ F }
+}
+
+@ __md_find_dot s line i n → i {
+    : ~ i k 0
+    ~ < k n { : i c ( nurl_str_get line k ) ? == c 46 { ^ k } {} = k + k 1 }
+    ^ - 0 1
+}
+

--- a/tools/nurlpkg/test-install-tool.sh
+++ b/tools/nurlpkg/test-install-tool.sh
@@ -48,19 +48,23 @@ EOF
 ( cd "$ROOT" && ./nurl.sh "$WORK/pack.nu" "$WORK/pack" >/dev/null 2>&1 ) || { echo "packer build failed"; exit 2; }
 
 REGDIR="$WORK/registry"
-mkdir -p "$REGDIR/index" "$REGDIR/pkgs/argz" "$REGDIR/pkgs/argz-demo" "$REGDIR/pkgs/nq"
+mkdir -p "$REGDIR/index" "$REGDIR/pkgs/argz" "$REGDIR/pkgs/argz-demo" "$REGDIR/pkgs/nq" "$REGDIR/pkgs/md2html"
 "$WORK/pack" "$PKGS/argz"      "$REGDIR/pkgs/argz/argz-0.1.0.tar.gz"           || fail=1
 "$WORK/pack" "$PKGS/argz-demo" "$REGDIR/pkgs/argz-demo/argz-demo-0.1.0.tar.gz" || fail=1
 "$WORK/pack" "$PKGS/nq"        "$REGDIR/pkgs/nq/nq-0.1.0.tar.gz"               || fail=1
+"$WORK/pack" "$PKGS/md2html"   "$REGDIR/pkgs/md2html/md2html-0.1.0.tar.gz"     || fail=1
 SUM_ARGZ=$(sha256sum "$REGDIR/pkgs/argz/argz-0.1.0.tar.gz" | cut -d' ' -f1)
 SUM_DEMO=$(sha256sum "$REGDIR/pkgs/argz-demo/argz-demo-0.1.0.tar.gz" | cut -d' ' -f1)
 SUM_NQ=$(sha256sum "$REGDIR/pkgs/nq/nq-0.1.0.tar.gz" | cut -d' ' -f1)
+SUM_MD=$(sha256sum "$REGDIR/pkgs/md2html/md2html-0.1.0.tar.gz" | cut -d' ' -f1)
 printf '{"name":"argz","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[]}]}\n' \
     "$SUM_ARGZ" > "$REGDIR/index/argz.json"
 printf '{"name":"argz-demo","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
     "$SUM_DEMO" > "$REGDIR/index/argz-demo.json"
 printf '{"name":"nq","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
     "$SUM_NQ" > "$REGDIR/index/nq.json"
+printf '{"name":"md2html","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
+    "$SUM_MD" > "$REGDIR/index/md2html.json"
 
 # ── 2. Serve the static registry ──────────────────────────────────────────
 say "serve registry"
@@ -113,6 +117,26 @@ NQ_OUT=$(env -i HOME="$WORK" PATH=/usr/bin:/bin bash -c "
 echo "$NQ_OUT"
 NQ_WANT=$'1\n2\n3\nEcosystem'
 [[ "$NQ_OUT" == "$NQ_WANT" ]] && echo "run: OK" || { echo "run: FAILED (got '$NQ_OUT')"; fail=1; }
+
+# ── 7. A third tool from the same registry: `md2html` (also depends on argz) ──
+say "nurlpkg install md2html"
+OUT=$(env -i HOME="$WORK" PATH=/usr/bin:/bin bash -c "
+    source '$PREFIX/env'
+    export NURL_REGISTRY='$REG'
+    nurlpkg install md2html 2>&1
+")
+echo "$OUT"
+echo "$OUT" | grep -q 'Installed md2html' && echo "install: OK" || { echo "install: FAILED"; fail=1; }
+
+say "run installed md2html"
+# Render a tiny Markdown doc and assert the key rendered tags.
+MD_OUT=$(env -i HOME="$WORK" PATH=/usr/bin:/bin bash -c "
+    source '$PREFIX/env'
+    printf '# Hi\n\nA **bold** word.\n' | md2html
+")
+echo "$MD_OUT"
+echo "$MD_OUT" | grep -q '<h1>Hi</h1>' && echo "  heading: OK" || { echo "  heading: FAILED"; fail=1; }
+echo "$MD_OUT" | grep -q '<strong>bold</strong>' && echo "  bold: OK" || { echo "  bold: FAILED"; fail=1; }
 
 say "RESULT"
 [[ $fail -eq 0 ]] && echo "PASS" || echo "FAIL"


### PR DESCRIPTION
## Summary

Extracts the renderer that powers the NURL playground's doc viewer (nurlapi's `md_to_html`) into a standalone **registry package** — the fourth in the ecosystem, alongside `argz`, `argz-demo`, and `nq`.

`md2html` ships **two ways**:
- an **installable CLI** (`md2html`) — reads Markdown from stdin or `--file`, writes HTML, optionally as a complete styled page (`--full` / `--title`); and
- a **reusable renderer library** (`src/markdown.nu`, one function `md_to_html`) that other packages can depend on (`md2html = "^0.1"`).

**`md2html 0.1.0` is already published and live at https://reg.nurl-lang.org** — it installs cleanly from prod (resolving `argz`), and its package page renders its own README via the markdown feature from the previous PR.

## CLI

| Option | Meaning |
| ------ | ------- |
| `-f`, `--file F`  | read Markdown from file `F` instead of stdin |
| `-F`, `--full`    | emit a complete styled HTML document (not just a fragment) |
| `-t`, `--title T` | `<title>` when used with `--full` (default `Document`) |
| `-h`, `--help`    | show help |

## Renderer

A verbatim extraction of the playground's renderer: ATX headings, fenced code blocks (with language class), GitHub tables, blockquotes, ordered/unordered lists, horizontal rules, and inline `` `code` `` / `**bold**` / `*em*` / `[text](url)` / `![alt](src)` / `<autolink>`. Raw text is HTML-escaped. The only changes from the source were dropping the dead `__md_skip_ws` helper and adding the stdlib imports.

## Quality

- **Leak-clean under ASan/LSan** across the CLI paths (stdin, `--file`, `--full`, help, file-error).
- Verified across every Markdown construct; renders the real `nq` README into a full styled page.
- **Durable install-and-run harness** (`tools/nurlpkg/test-install-tool.sh`) now also packs `md2html`, registers it with its `argz` dependency, installs it from a local static registry, and asserts the rendered output → **PASS**.

## Test plan

- [x] Compiles via the dev driver and the installed toolchain
- [x] ASan/LSan clean across all CLI paths
- [x] All Markdown constructs render correctly (headings, code, tables, lists, blockquotes, hr, links, images, autolinks)
- [x] `tools/nurlpkg/test-install-tool.sh` → PASS (argz-demo + nq + md2html)
- [x] Clean install from prod `reg.nurl-lang.org` → builds + renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)