### PR TITLE
argz, argz-demo: add READMEs and publish 0.1.1

### DIFF
--- a/packages/argz-demo/README.md
+++ b/packages/argz-demo/README.md
@@ -1,0 +1,29 @@
+# `argz-demo` — a friendly greeter built on `argz`
+
+`argz-demo` is a tiny installable CLI that demonstrates the full NURL
+package ecosystem end to end. It declares [`argz`](../argz) as a registry
+dependency (see `nurl.toml`) and ships a `src/main.nu` entry point, so
+`nurlpkg install argz-demo` fetches `argz`, resolves it into `./deps/`,
+compiles the program against the installed stdlib, and drops a `argz-demo`
+binary on `$PATH`.
+
+```
+nurlpkg install argz-demo
+
+argz-demo --name World            # Hello, World!
+argz-demo --name World --shout    # HELLO, WORLD!
+argz-demo alice bob               # Hello, alice! / Hello, bob!
+argz-demo --help                  # usage, rendered by argz
+```
+
+## What it shows
+
+- **Dependency resolution** — `argz = "^0.1"` is fetched from the registry
+  and linked under `deps/argz/` at install time.
+- **The `argz` API in practice** — boolean flags (`--shout`), value options
+  (`--name`), positional arguments, and the auto-generated `--help`.
+- **The install loop** — fetch → resolve deps → compile against the shipped
+  stdlib → binary on `$PATH`.
+
+The interesting code is just one file, [`src/main.nu`](src/main.nu). For the
+argument-parser API itself, see [`argz`](../argz).

--- a/packages/argz-demo/nurl.toml
+++ b/packages/argz-demo/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argz-demo"
-version = "0.1.0"
+version = "0.1.1"
 description = "Friendly greeter CLI demonstrating the argz package."
 license = "MIT OR Apache-2.0"
 

--- a/packages/argz/README.md
+++ b/packages/argz/README.md
@@ -1,0 +1,82 @@
+# `argz` — a tiny command-line argument parser
+
+`argz` is a small, **dependency-free** argument parser for NURL CLIs.
+Clap-shaped but deliberately tiny: boolean flags, value options
+(`--name X` and `--name=X`), short aliases (`-n`), a `--` end-of-options
+separator, positional arguments, and an auto-generated `--help` body.
+
+It lives in the NURL registry (it is *not* part of the core stdlib): every
+CLI wants argument parsing, but the shape of a parser is opinionated enough
+that it belongs to the ecosystem, not the language. It is leak-clean under
+AddressSanitizer/LeakSanitizer.
+
+```toml
+[dependencies]
+argz = "^0.1"
+```
+
+```
+$ `deps/argz/src/argz.nu`
+```
+
+## API
+
+```
+( argz_new prog about )                  → Argz
+( argz_flag p long short help )          → v        boolean flag  (--long / -short)
+( argz_opt  p long short help )          → v        value option  (--long V / --long=V)
+( argz_parse p argv )                    → ! ArgzMatch ArgzErr
+( argz_has   m long )                    → b        flag/option present?
+( argz_value m long )                    → ?String  value of an option (borrows)
+( argz_positionals m )                   → ( Vec String )  positionals, in order (borrows)
+( argz_help  p )                         → String   rendered usage text
+( argz_err_name e )                      → s        name of an ArgzErr
+( argz_free p ) / ( argz_match_free m )  → v        free the parser / the match
+```
+
+`short` may be empty (`""`), meaning the spec has no short alias. Option
+values and positionals returned by the accessors **borrow** the match's
+storage — do not free them; `argz_match_free` owns the whole match.
+
+`argz_parse` fails with an `ArgzErr` of either `ArgzUnknownFlag` (a
+`--flag` / `-f` not registered) or `ArgzMissingValue` (a value option with
+no value after it).
+
+## Example
+
+```
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+$ `deps/argz/src/argz.nu`
+
+@ main → i {
+    : Argz p ( argz_new `greet` `a friendly greeter` )
+    ( argz_flag p `shout` `s` `upper-case the greeting` )
+    ( argz_opt  p `name`  `n` `who to greet` )
+
+    : ( Vec String ) argv ( vec_new [String] )
+    : i ac ( env_args_count )
+    : ~ i i 1
+    ~ < i ac { ( vec_push [String] argv ( env_arg i ) ) = i + i 1 }
+
+    : ~ i rc 0
+    ?? ( argz_parse p argv ) {
+        F e → { ( nurl_eprintln ( argz_err_name e ) ) = rc 2 }
+        T m → {
+            ?? ( argz_value m `name` ) {
+                T nv → { ( nurl_print `Hello, ` ) ( nurl_print ( string_data nv ) ) ( nurl_print `!\n` ) }
+                F _ → { ( nurl_print `Hello, World!\n` ) }
+            }
+            ( argz_match_free m )
+        }
+    }
+    ( argz_free p )
+    ( vec_free_with [String] argv \ String x → v { ( string_free x ) } )
+    ^ rc
+}
+```
+
+See [`argz-demo`](../argz-demo) for a complete installable program built on
+`argz`.

--- a/packages/argz/nurl.toml
+++ b/packages/argz/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argz"
-version = "0.1.0"
+version = "0.1.1"
 description = "A tiny, dependency-free command-line argument parser."
 license = "MIT OR Apache-2.0"
 

--- a/tools/nurlpkg/test-install-tool.sh
+++ b/tools/nurlpkg/test-install-tool.sh
@@ -49,17 +49,17 @@ EOF
 
 REGDIR="$WORK/registry"
 mkdir -p "$REGDIR/index" "$REGDIR/pkgs/argz" "$REGDIR/pkgs/argz-demo" "$REGDIR/pkgs/nq" "$REGDIR/pkgs/md2html"
-"$WORK/pack" "$PKGS/argz"      "$REGDIR/pkgs/argz/argz-0.1.0.tar.gz"           || fail=1
-"$WORK/pack" "$PKGS/argz-demo" "$REGDIR/pkgs/argz-demo/argz-demo-0.1.0.tar.gz" || fail=1
+"$WORK/pack" "$PKGS/argz"      "$REGDIR/pkgs/argz/argz-0.1.1.tar.gz"           || fail=1
+"$WORK/pack" "$PKGS/argz-demo" "$REGDIR/pkgs/argz-demo/argz-demo-0.1.1.tar.gz" || fail=1
 "$WORK/pack" "$PKGS/nq"        "$REGDIR/pkgs/nq/nq-0.1.0.tar.gz"               || fail=1
 "$WORK/pack" "$PKGS/md2html"   "$REGDIR/pkgs/md2html/md2html-0.1.0.tar.gz"     || fail=1
-SUM_ARGZ=$(sha256sum "$REGDIR/pkgs/argz/argz-0.1.0.tar.gz" | cut -d' ' -f1)
-SUM_DEMO=$(sha256sum "$REGDIR/pkgs/argz-demo/argz-demo-0.1.0.tar.gz" | cut -d' ' -f1)
+SUM_ARGZ=$(sha256sum "$REGDIR/pkgs/argz/argz-0.1.1.tar.gz" | cut -d' ' -f1)
+SUM_DEMO=$(sha256sum "$REGDIR/pkgs/argz-demo/argz-demo-0.1.1.tar.gz" | cut -d' ' -f1)
 SUM_NQ=$(sha256sum "$REGDIR/pkgs/nq/nq-0.1.0.tar.gz" | cut -d' ' -f1)
 SUM_MD=$(sha256sum "$REGDIR/pkgs/md2html/md2html-0.1.0.tar.gz" | cut -d' ' -f1)
-printf '{"name":"argz","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[]}]}\n' \
+printf '{"name":"argz","versions":[{"version":"0.1.1","checksum":"%s","yanked":false,"deps":[]}]}\n' \
     "$SUM_ARGZ" > "$REGDIR/index/argz.json"
-printf '{"name":"argz-demo","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
+printf '{"name":"argz-demo","versions":[{"version":"0.1.1","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
     "$SUM_DEMO" > "$REGDIR/index/argz-demo.json"
 printf '{"name":"nq","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
     "$SUM_NQ" > "$REGDIR/index/nq.json"


### PR DESCRIPTION
## Summary

The registry now renders package READMEs, but `argz` and `argz-demo` shipped without one — so their pages were name-only. This adds a README to each and publishes a patch version.

Published versions are immutable, so a `0.1.0` republish isn't possible; the READMEs ride a **`0.1.1`** bump (README-only, no code change, so anything depending on `argz = "^0.1"` is unaffected).

**Both `0.1.1` versions are already published and live at https://reg.nurl-lang.org** — their package pages now render the README, and a clean install from prod resolves `argz 0.1.1` and runs.

## Changes

- **`packages/argz/README.md`** — documents the full parser API (`argz_new`/`flag`/`opt`/`parse`/`has`/`value`/`positionals`/`help`/`free`), the borrow rules, the `ArgzErr` cases, and a complete worked example.
- **`packages/argz-demo/README.md`** — explains what the greeter demonstrates (dependency resolution, the `argz` API in practice, the install loop).
- Bump `argz` + `argz-demo` to **0.1.1**.
- **`tools/nurlpkg/test-install-tool.sh`** — track the 0.1.1 tarball names and index versions for argz/argz-demo (nq/md2html stay 0.1.0).

## Test plan

- [x] Durable install-and-run harness → PASS (argz 0.1.1 resolves; argz-demo + nq + md2html all install/run)
- [x] Published argz 0.1.1 + argz-demo 0.1.1 to prod
- [x] Registry pages for argz and argz-demo render the README
- [x] Clean install from prod resolves argz 0.1.1 → `argz-demo --name Prod --shout` → `HELLO, PROD!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)