### PR TITLE
iforest: Isolation Forest anomaly detection package (CLI + library)

### DIFF
--- a/packages/iforest/README.md
+++ b/packages/iforest/README.md
@@ -1,0 +1,109 @@
+# `iforest` — Isolation Forest anomaly detection
+
+`iforest` finds the odd points in a dataset. It implements the **Isolation
+Forest** (Liu, Ting & Zhou, 2008): instead of modelling what "normal"
+looks like, it builds an ensemble of random binary trees that recursively
+split the data at random features and thresholds. Anomalies are *few and
+different*, so they get isolated near the root of each tree — their average
+path length is short — while normal points sit deep in crowded regions. The
+forest turns that path length into a score in `(0, 1]`.
+
+It ships both ways:
+
+- an **installable CLI** (`iforest`) that scores the rows of a numeric CSV;
+  and
+- a **reusable library** (`src/iforest.nu`) that trains a forest and scores
+  points from your own NURL code.
+
+```
+nurlpkg install iforest
+iforest < data.csv                 # one anomaly score per row, in order
+iforest -f data.csv --top 10       # the 10 most anomalous rows
+iforest -f data.csv -H -t 200 -S 7 # skip header, 200 trees, seed 7
+```
+
+## Scores
+
+The score `s(x)` maps a point's mean path length over the forest to `(0, 1]`:
+
+| Score        | Reading                                                 |
+| ------------ | ------------------------------------------------------- |
+| `≈ 1.0`      | almost certainly an anomaly (isolated very quickly)     |
+| `≈ 0.5`      | no clear signal — path length close to the average      |
+| `< 0.5`      | a normal, "crowded" point, isolated only deep in a tree |
+
+There is no universal cutoff; rank the rows (`--top`) or threshold on the
+score distribution for your data.
+
+## CLI options
+
+| Option | Meaning |
+| ------ | ------- |
+| `-f`, `--file F`   | read CSV from file `F` instead of stdin |
+| `-H`, `--header`   | skip the first line (treat it as a header) |
+| `-t`, `--trees N`  | number of trees in the forest (default `100`) |
+| `-s`, `--sample N` | subsample size per tree, ψ (default `256`) |
+| `-S`, `--seed N`   | PRNG seed for reproducible forests (default `42`) |
+| `-k`, `--top K`    | print only the K most anomalous rows as `index⇥score`, highest first |
+| `-d`, `--delim C`  | field delimiter (default `,`) |
+| `-h`, `--help`     | show help |
+
+Input is a numeric CSV: rows are samples, columns are features. The first
+data row fixes the column count; rows whose numeric-field count differs are
+skipped to keep the matrix rectangular. By default the tool prints one
+score per line in input order (paste it back as a new column); `--top K`
+prints the ranked anomalies instead.
+
+The forest is fully deterministic: a fixed `--seed` produces a
+byte-identical forest, and hence identical scores, on every platform and
+build.
+
+## Using the trainer as a library
+
+The library depends only on the standard library (`vec`, `float`, `rng`),
+not on `argz` — declare the dependency and import the module:
+
+```toml
+[dependencies]
+iforest = "^0.1"
+```
+
+```
+$ `deps/iforest/src/iforest.nu`
+
+// data is a row-major ( Vec f ) of n_rows * n_cols values.
+: IForest fo ( iforest_train data n_rows n_cols 100 256 42 )
+: f s ( iforest_score_row fo data 0 )   // score row 0 in place
+// ... or score an arbitrary point:
+: f s2 ( iforest_score fo my_point )     // my_point is a ( Vec f ) of n_cols
+( iforest_free fo )
+```
+
+### Surface
+
+| Function | Result |
+| -------- | ------ |
+| `( iforest_train data n_rows n_cols n_trees sample_size seed )` | `IForest` (caller owns it) |
+| `( iforest_score forest point )` | `f` — score of a `( Vec f )` of length `n_cols` |
+| `( iforest_score_row forest data row )` | `f` — score row `row` of a row-major matrix, no copy |
+| `( iforest_avg_path n )` | `f` — `c(n)`, the path-length normaliser (for custom thresholds) |
+| `( iforest_n_trees forest )` / `( iforest_sample_size forest )` | `i` |
+| `( iforest_free forest )` | `v` |
+
+`sample_size` (ψ) is clamped to `n_rows`; the per-tree height limit is
+`ceil(log2 ψ)`, the standard Isolation Forest setting.
+
+## Implementation notes
+
+All nodes of all trees live in one flat struct-of-arrays shared across the
+forest (a node arena plus a root index per tree): no recursive ADTs, no
+Vec-of-Vec, and scoring walks raw pointers. Random splits are driven by
+`std/rng`'s seedable xoshiro256\*\* generator, which is what makes the
+forest reproducible.
+
+## Quality
+
+The CLI is leak-clean under AddressSanitizer/LeakSanitizer across its code
+paths (stdin, `--file`, `--top`, help, the file-error branch, and empty
+input), and the end-to-end install-and-run loop is covered by
+`tools/nurlpkg/test-install-tool.sh`.

--- a/packages/iforest/nurl.toml
+++ b/packages/iforest/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "iforest"
+version = "0.1.0"
+description = "Isolation Forest anomaly detection — a CLI and a reusable library."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+argz = "^0.1"

--- a/packages/iforest/src/iforest.nu
+++ b/packages/iforest/src/iforest.nu
@@ -1,0 +1,299 @@
+// iforest — Isolation Forest anomaly detection for NURL.
+//
+// An Isolation Forest (Liu, Ting & Zhou, 2008) detects anomalies by
+// *isolating* points rather than profiling normal data. It builds an
+// ensemble of random binary trees (iTrees); each tree repeatedly splits a
+// random feature at a random threshold until every point is isolated.
+// Anomalies — being few and different — sit in sparse regions and get
+// isolated near the root, so their average path length over the forest is
+// short. The score maps that path length to (0, 1]:
+//
+//   s(x) = 2 ^ ( -E[h(x)] / c(psi) )
+//
+//   ≈ 1.0   almost certainly an anomaly (isolated very quickly)
+//   ≈ 0.5   no clear signal (path length ≈ the average)
+//   < 0.5   deep in the tree — a normal, "crowded" point
+//
+// where E[h(x)] is the mean path length of x across the trees and c(psi)
+// is the expected path length of an unsuccessful BST search over a
+// subsample of size psi (the normalising constant).
+//
+// This package lives in the NURL registry (it is NOT part of the core
+// stdlib). It is pure NURL: a seedable PRNG (std/rng) drives the random
+// splits, so a fixed seed gives a byte-identical forest on every platform.
+//
+// Surface:
+//   ( iforest_train data n_rows n_cols n_trees sample_size seed ) → IForest
+//       `data` is a row-major ( Vec f ) of n_rows*n_cols values. Returns a
+//       trained forest (caller owns it → iforest_free).
+//   ( iforest_score forest point )   → f   anomaly score in (0, 1] for a
+//                                          ( Vec f ) of length n_cols.
+//   ( iforest_score_row forest data row ) → f   score row `row` of a
+//                                          row-major ( Vec f ) matrix.
+//   ( iforest_avg_path n )           → f   c(n), exported for thresholding.
+//   ( iforest_n_trees f ) / ( iforest_sample_size f ) → i   accessors.
+//   ( iforest_free forest )          → v
+//
+// The trees are stored as a flat struct-of-arrays shared across the whole
+// forest (one node arena, a root index per tree): no recursive ADTs, no
+// Vec-of-Vec, and scoring walks raw pointers for speed.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/rng.nu`
+
+// Euler–Mascheroni constant, for the harmonic-number approximation in c(n).
+: f GAMMA 0.5772156649015329
+
+// ── Types ─────────────────────────────────────────────────────────────
+//
+// Every node of every tree lives in the same parallel arrays. A node is
+// an index into them. Internal nodes carry a split (feature, threshold)
+// and two child indices; leaves carry feature = -1 and `size` = the number
+// of training points that reached them (used for the path-length estimate).
+
+: IForest {
+    i n_trees
+    i sample_size       // psi — points subsampled per tree (clamped to n_rows)
+    f c_psi             // c(psi): path-length normaliser, precomputed
+    i n_cols            // dimensionality of a point
+    ( Vec i ) roots     // roots[t] = node index of tree t's root
+    ( Vec i ) feature   // split feature, or -1 at a leaf
+    ( Vec f ) split     // split threshold (internal nodes only)
+    ( Vec i ) left      // left child index, or -1
+    ( Vec i ) right     // right child index, or -1
+    ( Vec i ) size      // subsample size that reached this node
+}
+
+// ── Path-length normaliser c(n) ───────────────────────────────────────
+//
+// c(n) = 2*H(n-1) - 2*(n-1)/n, the average path length of an unsuccessful
+// search in a binary search tree of n nodes, with H(i) ≈ ln(i) + γ. This
+// is both the per-leaf adjustment for the unbuilt subtree below a depth
+// cap and the forest-wide normaliser c(psi).
+@ iforest_avg_path i n → f {
+    ? <= n 1 { ^ 0.0 } {}
+    ? == n 2 { ^ 1.0 } {}
+    : f fn # f n
+    : f h + ( float_log - fn 1.0 ) GAMMA
+    ^ - * 2.0 h / * 2.0 - fn 1.0 fn
+}
+
+// Height cap for a single tree: ceil(log2(psi)). Past this depth a point
+// is treated as isolated and its remaining path estimated by c(leaf size).
+@ __height_limit i psi → i {
+    ? <= psi 1 { ^ 0 } {}
+    ^ # i ( float_ceil ( float_log2 # f psi ) )
+}
+
+// ── Node arena helpers ────────────────────────────────────────────────
+
+// Append a node to the shared arena and return its index.
+@ __push_node IForest fo i feature f split i left i right i size → i {
+    : i id ( vec_len [i] . fo feature )
+    ( vec_push [i] . fo feature feature )
+    ( vec_push [f] . fo split split )
+    ( vec_push [i] . fo left left )
+    ( vec_push [i] . fo right right )
+    ( vec_push [i] . fo size size )
+    ^ id
+}
+
+@ __push_leaf IForest fo i size → i {
+    ^ ( __push_node fo -1 0.0 -1 -1 size )
+}
+
+// ── Subsampling ───────────────────────────────────────────────────────
+//
+// Draw `psi` distinct row indices from [0, n) without replacement via a
+// partial Fisher–Yates shuffle, then truncate. Returns an owned ( Vec i ).
+@ __subsample Rng g i n i psi → ( Vec i ) {
+    : ( Vec i ) all ( vec_iota 0 n )
+    : ~ i m psi
+    ? > m n { = m n } {}
+    : ~ i k 0
+    ~ < k m {
+        : i j + k ( rng_below g - n k )   // pick from [k, n)
+        ( vec_swap [i] all k j )
+        = k + k 1
+    }
+    ( vec_set_len [i] all m )
+    ^ all
+}
+
+// ── Tree construction ─────────────────────────────────────────────────
+//
+// Build one subtree from the row indices `idx` (which this call OWNS and
+// frees) and return its node index. `dp` is the raw row-major data buffer;
+// reading feature q of row r is dp[r*n_cols + q].
+@ __build_node IForest fo *f dp i n_cols ( Vec i ) idx i depth i height_limit Rng g → i {
+    : i m ( vec_len [i] idx )
+
+    // Isolated (≤1 point) or hit the depth cap → leaf.
+    ? || >= depth height_limit <= m 1 {
+        : i leaf ( __push_leaf fo m )
+        ( vec_free [i] idx )
+        ^ leaf
+    } {}
+
+    : *i idxp ( vec_data [i] idx )
+    : i q ( rng_below g n_cols )
+
+    // Range of feature q over this subsample.
+    : i r0 . idxp 0
+    : i o0 + * r0 n_cols q
+    : ~ f mn . dp o0
+    : ~ f mx mn
+    : ~ i a 1
+    ~ < a m {
+        : i row . idxp a
+        : i off + * row n_cols q
+        : f v . dp off
+        ? < v mn { = mn v } {}
+        ? > v mx { = mx v } {}
+        = a + a 1
+    }
+
+    // Degenerate column (every value equal): nothing to split on → leaf.
+    ? == mn mx {
+        : i leaf ( __push_leaf fo m )
+        ( vec_free [i] idx )
+        ^ leaf
+    } {}
+
+    // Random threshold in [mn, mx), then partition the rows around it.
+    : f p + mn * ( rng_u01 g ) - mx mn
+    : ( Vec i ) li ( vec_new [i] )
+    : ( Vec i ) ri ( vec_new [i] )
+    : ~ i b 0
+    ~ < b m {
+        : i row . idxp b
+        : i off2 + * row n_cols q
+        : f v . dp off2
+        ? < v p { ( vec_push [i] li row ) } { ( vec_push [i] ri row ) }
+        = b + b 1
+    }
+
+    // Reserve this internal node (children patched in after recursion), then
+    // release the parent's index list before descending.
+    : i node ( __push_node fo q p -1 -1 m )
+    ( vec_free [i] idx )
+
+    : i d1 + depth 1
+    : i lc ( __build_node fo dp n_cols li d1 height_limit g )
+    : i rc ( __build_node fo dp n_cols ri d1 height_limit g )
+    ( vec_set [i] . fo left node lc )
+    ( vec_set [i] . fo right node rc )
+    ^ node
+}
+
+// ── Training ──────────────────────────────────────────────────────────
+
+@ iforest_train ( Vec f ) data i n_rows i n_cols i n_trees i sample_size i seed → IForest {
+    : ~ i psi sample_size
+    ? > psi n_rows { = psi n_rows } {}
+    ? < psi 1 { = psi 1 } {}
+
+    : IForest fo @ IForest {
+        n_trees
+        psi
+        ( iforest_avg_path psi )
+        n_cols
+        ( vec_new [i] )
+        ( vec_new [i] )
+        ( vec_new [f] )
+        ( vec_new [i] )
+        ( vec_new [i] )
+        ( vec_new [i] )
+    }
+
+    : i hlim ( __height_limit psi )
+    : Rng g ( rng_seed seed )
+    : *f dp ( vec_data [f] data )
+
+    : ~ i t 0
+    ~ < t n_trees {
+        : ( Vec i ) idx ( __subsample g n_rows psi )
+        : i root ( __build_node fo dp n_cols idx 0 hlim g )
+        ( vec_push [i] . fo roots root )
+        = t + t 1
+    }
+    ( rng_free g )
+    ^ fo
+}
+
+// ── Scoring ───────────────────────────────────────────────────────────
+//
+// Path length of `point` (raw *f, length n_cols) down one tree: walk from
+// `root` comparing the node's feature to its threshold, then add c(leaf
+// size) for the unbuilt subtree below where we stopped.
+@ __path_len IForest fo i root *f point → f {
+    : *i feat ( vec_data [i] . fo feature )
+    : *f spl ( vec_data [f] . fo split )
+    : *i lf ( vec_data [i] . fo left )
+    : *i rt ( vec_data [i] . fo right )
+    : *i sz ( vec_data [i] . fo size )
+
+    : ~ i node root
+    : ~ i depth 0
+    : ~ b going T
+    ~ going {
+        : i fq . feat node
+        ? < fq 0 {
+            = going F
+        } {
+            : f xv . point fq
+            ? < xv . spl node { = node . lf node } { = node . rt node }
+            = depth + depth 1
+        }
+    }
+    ^ + # f depth ( iforest_avg_path . sz node )
+}
+
+// Anomaly score in (0, 1] for a single point given as a ( Vec f ) of length
+// n_cols. Higher = more anomalous.
+@ iforest_score IForest fo ( Vec f ) point → f {
+    : *f pp ( vec_data [f] point )
+    ^ ( __score_ptr fo pp )
+}
+
+// Score row `row` of a row-major ( Vec f ) matrix without copying it out.
+@ iforest_score_row IForest fo ( Vec f ) data i row → f {
+    : *f dp ( vec_data [f] data )
+    : i base + # i dp * * row . fo n_cols 8
+    : *f pp # *f base
+    ^ ( __score_ptr fo pp )
+}
+
+// Mean path length over the forest → score. `point` is a raw *f of n_cols.
+@ __score_ptr IForest fo *f point → f {
+    : i nt ( vec_len [i] . fo roots )
+    ? <= nt 0 { ^ 0.0 } {}
+    : f cpsi . fo c_psi
+    ? <= cpsi 0.0 { ^ 0.5 } {}
+
+    : *i rts ( vec_data [i] . fo roots )
+    : ~ f total 0.0
+    : ~ i k 0
+    ~ < k nt {
+        = total + total ( __path_len fo . rts k point )
+        = k + k 1
+    }
+    : f avg / total # f nt
+    ^ ( float_pow 2.0 - 0.0 / avg cpsi )
+}
+
+// ── Accessors / cleanup ───────────────────────────────────────────────
+
+@ iforest_n_trees IForest fo → i { ^ . fo n_trees }
+
+@ iforest_sample_size IForest fo → i { ^ . fo sample_size }
+
+@ iforest_free IForest fo → v {
+    ( vec_free [i] . fo roots )
+    ( vec_free [i] . fo feature )
+    ( vec_free [f] . fo split )
+    ( vec_free [i] . fo left )
+    ( vec_free [i] . fo right )
+    ( vec_free [i] . fo size )
+}

--- a/packages/iforest/src/main.nu
+++ b/packages/iforest/src/main.nu
@@ -1,0 +1,274 @@
+// iforest — score the rows of a numeric CSV for anomalousness.
+//
+// Reads a numeric CSV (rows = samples, columns = features) from stdin or a
+// file, trains an Isolation Forest, and prints an anomaly score in (0, 1]
+// for each row — higher means more anomalous. By default one score per
+// line, in input order (paste it back as a new column); with --top K it
+// prints the K most anomalous rows as `index<TAB>score`, highest first.
+//
+//   iforest < data.csv                  # one score per row
+//   iforest -f data.csv --top 10        # 10 most anomalous rows
+//   iforest -f data.csv -H -t 200 -S 7  # skip header, 200 trees, seed 7
+//
+// Built on the `argz` registry package (flags) and this package's own
+// `iforest` library.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/ext/env.nu`
+$ `deps/argz/src/argz.nu`
+$ `src/iforest.nu`
+
+// A parsed numeric matrix: `data` is row-major (rows*cols), owned by caller.
+: Dataset {
+    ( Vec f ) data
+    i rows
+    i cols
+}
+
+// One row's score, for the --top ranking. NB: the index field is `row`,
+// not `idx` — a field named `idx` would collide with the generic vec.nu
+// helpers' own `idx` parameter, so `. data idx` inside vec_get[ScoreRow]
+// would resolve as a field access instead of an array index.
+: ScoreRow {
+    i row
+    f score
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+// Value of an integer option, or `dflt` if it was not supplied.
+@ __opt_int ArgzMatch m s name i dflt → i {
+    ?? ( argz_value m name ) {
+        T v → { ^ ( nurl_str_to_int ( string_data v ) ) }
+        F _ → { ^ dflt }
+    }
+}
+
+// Append a float and a newline to `out`.
+@ __push_score_line String out f x → v {
+    ( string_push_float out x )
+    ( string_push_char out 10 )
+}
+
+// Drop helper for a ( Vec String ).
+@ __free_strvec ( Vec String ) v → v {
+    ( vec_free_with [String] v \ String s → v { ( string_free s ) } )
+}
+
+// Descending by score (so sort_by yields most-anomalous first).
+@ __cmp_score_desc ScoreRow a ScoreRow b → i {
+    ? > . a score . b score { ^ -1 } {}
+    ? < . a score . b score { ^ 1 } {}
+    ^ 0
+}
+
+// ── CSV → matrix ──────────────────────────────────────────────────────
+//
+// Splits on newlines, then on `delim`. Non-numeric / empty fields are
+// dropped; the first data row fixes the column count and later rows whose
+// numeric-field count differs are skipped (keeping the matrix rectangular).
+@ __parse_csv s input s delim b skip_header → Dataset {
+    : String text ( string_from input )
+    : ( Vec String ) lines ( string_split text `\n` )
+    ( string_free text )
+
+    : ( Vec f ) data ( vec_new [f] )
+    : ~ i cols -1
+    : ~ i rows 0
+    : i nl ( vec_len [String] lines )
+    : ~ i li 0
+    ~ < li nl {
+        ?? ( vec_get [String] lines li ) {
+            T line → {
+                ? & == li 0 skip_header { } {
+                    : String tl ( string_trim line )
+                    ? > ( string_len tl ) 0 {
+                        : ( Vec String ) fields ( string_split tl delim )
+                        : ( Vec f ) rowvals ( vec_new [f] )
+                        : i nf ( vec_len [String] fields )
+                        : ~ i fi 0
+                        ~ < fi nf {
+                            ?? ( vec_get [String] fields fi ) {
+                                T fld → {
+                                    : String ft ( string_trim fld )
+                                    ?? ( string_to_float ft ) {
+                                        T x → { ( vec_push [f] rowvals x ) }
+                                        F _ → {}
+                                    }
+                                    ( string_free ft )
+                                }
+                                F _ → {}
+                            }
+                            = fi + fi 1
+                        }
+                        ( __free_strvec fields )
+
+                        : i nv ( vec_len [f] rowvals )
+                        ? > nv 0 {
+                            ? < cols 0 { = cols nv } {}
+                            ? == nv cols {
+                                ( vec_extend [f] data rowvals )
+                                = rows + rows 1
+                            } {}
+                        } {}
+                        ( vec_free [f] rowvals )
+                    } {}
+                    ( string_free tl )
+                }
+            }
+            F _ → {}
+        }
+        = li + li 1
+    }
+    ( __free_strvec lines )
+    ? < cols 0 { = cols 0 } {}
+    ^ @ Dataset { data rows cols }
+}
+
+// ── Output ────────────────────────────────────────────────────────────
+
+// One score per line, in input order.
+@ __emit_all IForest fo Dataset ds → v {
+    : String out ( string_with_cap * . ds rows 12 )
+    : ~ i r 0
+    ~ < r . ds rows {
+        ( __push_score_line out ( iforest_score_row fo . ds data r ) )
+        = r + r 1
+    }
+    ( nurl_print ( string_data out ) )
+    ( string_free out )
+}
+
+// The `k` most anomalous rows, as `index<TAB>score`, highest first.
+@ __emit_top IForest fo Dataset ds i k → v {
+    : ( Vec ScoreRow ) rank ( vec_with_cap [ScoreRow] . ds rows )
+    : ~ i r 0
+    ~ < r . ds rows {
+        : f sc ( iforest_score_row fo . ds data r )
+        ( vec_push [ScoreRow] rank @ ScoreRow { r sc } )
+        = r + r 1
+    }
+    ( sort_by [ScoreRow] rank \ ScoreRow a ScoreRow b → i { ( __cmp_score_desc a b ) } )
+
+    : ~ i lim k
+    ? > lim . ds rows { = lim . ds rows } {}
+    ? < lim 0 { = lim 0 } {}
+
+    : String out ( string_with_cap * lim 16 )
+    : ~ i j 0
+    ~ < j lim {
+        ?? ( vec_get [ScoreRow] rank j ) {
+            T sr → {
+                ( string_push_int out . sr row )
+                ( string_push_char out 9 )
+                ( string_push_float out . sr score )
+                ( string_push_char out 10 )
+            }
+            F _ → {}
+        }
+        = j + j 1
+    }
+    ( nurl_print ( string_data out ) )
+    ( string_free out )
+    ( vec_free [ScoreRow] rank )
+}
+
+// ── Entry point ───────────────────────────────────────────────────────
+
+@ main → i {
+    : Argz p ( argz_new `iforest` `Isolation Forest anomaly detection over a numeric CSV` )
+    ( argz_flag p `help`   `h` `show this help` )
+    ( argz_flag p `header` `H` `skip the first line (treat it as a header)` )
+    ( argz_opt  p `file`   `f` `read CSV from FILE instead of stdin` )
+    ( argz_opt  p `trees`  `t` `number of trees in the forest (default 100)` )
+    ( argz_opt  p `sample` `s` `subsample size per tree (default 256)` )
+    ( argz_opt  p `seed`   `S` `PRNG seed for reproducible forests (default 42)` )
+    ( argz_opt  p `top`    `k` `print only the K most anomalous rows (index<TAB>score, desc)` )
+    ( argz_opt  p `delim`  `d` `field delimiter (default ",")` )
+
+    : ( Vec String ) argv ( vec_new [String] )
+    : i ac ( env_args_count )
+    : ~ i ai 1
+    ~ < ai ac {
+        ( vec_push [String] argv ( env_arg ai ) )
+        = ai + ai 1
+    }
+
+    : ~ i rc 0
+    : !ArgzMatch ArgzErr r ( argz_parse p argv )
+    ?? r {
+        F e → {
+            ( nurl_eprint `iforest: ` ) ( nurl_eprintln ( argz_err_name e ) )
+            ( nurl_eprintln `try 'iforest --help'` )
+            = rc 2
+        }
+        T m → {
+            ? ( argz_has m `help` ) {
+                : String h ( argz_help p )
+                ( nurl_print `iforest — Isolation Forest anomaly detection\n\n` )
+                ( nurl_print `Reads a numeric CSV (rows = samples, columns = features) from stdin\n` )
+                ( nurl_print `unless --file is given, and prints an anomaly score in (0, 1] per row\n` )
+                ( nurl_print `(higher = more anomalous).\n\n` )
+                ( nurl_print ( string_data h ) )
+                ( string_free h )
+            } {
+                : i trees  ( __opt_int m `trees`  100 )
+                : i sample ( __opt_int m `sample` 256 )
+                : i seed   ( __opt_int m `seed`   42 )
+                : ~ i topk -1
+                ? ( argz_has m `top` ) { = topk ( __opt_int m `top` 10 ) } {}
+                : ~ s delim `,`
+                ?? ( argz_value m `delim` ) { T dv → { = delim ( string_data dv ) } F _ → {} }
+                : b skip_header ( argz_has m `header` )
+
+                // Input: --file, else stdin.
+                : ~ String input ( string_new )
+                : ~ b have_input T
+                ?? ( argz_value m `file` ) {
+                    T fv → {
+                        ?? ( read_file ( string_data fv ) ) {
+                            T txt → { ( string_free input ) = input txt }
+                            F _ → {
+                                ( nurl_eprint `iforest: cannot read file: ` )
+                                ( nurl_eprintln ( string_data fv ) )
+                                = rc 1
+                                = have_input F
+                            }
+                        }
+                    }
+                    F _ → {
+                        ( string_free input )
+                        = input ( read_all_stdin )
+                    }
+                }
+
+                ? have_input {
+                    : Dataset ds ( __parse_csv ( string_data input ) delim skip_header )
+                    ? || <= . ds rows 0 <= . ds cols 0 {
+                        ( nurl_eprintln `iforest: no numeric rows found in input` )
+                        = rc 1
+                    } {
+                        : IForest fo ( iforest_train . ds data . ds rows . ds cols trees sample seed )
+                        ? < topk 0 {
+                            ( __emit_all fo ds )
+                        } {
+                            ( __emit_top fo ds topk )
+                        }
+                        ( iforest_free fo )
+                    }
+                    ( vec_free [f] . ds data )
+                } {}
+                ( string_free input )
+            }
+            ( argz_match_free m )
+        }
+    }
+
+    ( argz_free p )
+    ( vec_free_with [String] argv \ String x → v { ( string_free x ) } )
+    ^ rc
+}

--- a/tools/nurlpkg/test-install-tool.sh
+++ b/tools/nurlpkg/test-install-tool.sh
@@ -48,15 +48,17 @@ EOF
 ( cd "$ROOT" && ./nurl.sh "$WORK/pack.nu" "$WORK/pack" >/dev/null 2>&1 ) || { echo "packer build failed"; exit 2; }
 
 REGDIR="$WORK/registry"
-mkdir -p "$REGDIR/index" "$REGDIR/pkgs/argz" "$REGDIR/pkgs/argz-demo" "$REGDIR/pkgs/nq" "$REGDIR/pkgs/md2html"
+mkdir -p "$REGDIR/index" "$REGDIR/pkgs/argz" "$REGDIR/pkgs/argz-demo" "$REGDIR/pkgs/nq" "$REGDIR/pkgs/md2html" "$REGDIR/pkgs/iforest"
 "$WORK/pack" "$PKGS/argz"      "$REGDIR/pkgs/argz/argz-0.1.1.tar.gz"           || fail=1
 "$WORK/pack" "$PKGS/argz-demo" "$REGDIR/pkgs/argz-demo/argz-demo-0.1.1.tar.gz" || fail=1
 "$WORK/pack" "$PKGS/nq"        "$REGDIR/pkgs/nq/nq-0.1.0.tar.gz"               || fail=1
 "$WORK/pack" "$PKGS/md2html"   "$REGDIR/pkgs/md2html/md2html-0.1.0.tar.gz"     || fail=1
+"$WORK/pack" "$PKGS/iforest"   "$REGDIR/pkgs/iforest/iforest-0.1.0.tar.gz"     || fail=1
 SUM_ARGZ=$(sha256sum "$REGDIR/pkgs/argz/argz-0.1.1.tar.gz" | cut -d' ' -f1)
 SUM_DEMO=$(sha256sum "$REGDIR/pkgs/argz-demo/argz-demo-0.1.1.tar.gz" | cut -d' ' -f1)
 SUM_NQ=$(sha256sum "$REGDIR/pkgs/nq/nq-0.1.0.tar.gz" | cut -d' ' -f1)
 SUM_MD=$(sha256sum "$REGDIR/pkgs/md2html/md2html-0.1.0.tar.gz" | cut -d' ' -f1)
+SUM_IF=$(sha256sum "$REGDIR/pkgs/iforest/iforest-0.1.0.tar.gz" | cut -d' ' -f1)
 printf '{"name":"argz","versions":[{"version":"0.1.1","checksum":"%s","yanked":false,"deps":[]}]}\n' \
     "$SUM_ARGZ" > "$REGDIR/index/argz.json"
 printf '{"name":"argz-demo","versions":[{"version":"0.1.1","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
@@ -65,6 +67,8 @@ printf '{"name":"nq","versions":[{"version":"0.1.0","checksum":"%s","yanked":fal
     "$SUM_NQ" > "$REGDIR/index/nq.json"
 printf '{"name":"md2html","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
     "$SUM_MD" > "$REGDIR/index/md2html.json"
+printf '{"name":"iforest","versions":[{"version":"0.1.0","checksum":"%s","yanked":false,"deps":[{"name":"argz","req":"^0.1"}]}]}\n' \
+    "$SUM_IF" > "$REGDIR/index/iforest.json"
 
 # ── 2. Serve the static registry ──────────────────────────────────────────
 say "serve registry"
@@ -137,6 +141,26 @@ MD_OUT=$(env -i HOME="$WORK" PATH=/usr/bin:/bin bash -c "
 echo "$MD_OUT"
 echo "$MD_OUT" | grep -q '<h1>Hi</h1>' && echo "  heading: OK" || { echo "  heading: FAILED"; fail=1; }
 echo "$MD_OUT" | grep -q '<strong>bold</strong>' && echo "  bold: OK" || { echo "  bold: FAILED"; fail=1; }
+
+# ── 8. A fourth tool from the same registry: `iforest` (also depends on argz) ──
+say "nurlpkg install iforest"
+OUT=$(env -i HOME="$WORK" PATH=/usr/bin:/bin bash -c "
+    source '$PREFIX/env'
+    export NURL_REGISTRY='$REG'
+    nurlpkg install iforest 2>&1
+")
+echo "$OUT"
+echo "$OUT" | grep -q 'Installed iforest' && echo "install: OK" || { echo "install: FAILED"; fail=1; }
+
+say "run installed iforest"
+# A 2-D cluster near the origin plus one obvious outlier on the last row;
+# --top 1 must surface that outlier (row index 8).
+IF_OUT=$(env -i HOME="$WORK" PATH=/usr/bin:/bin bash -c "
+    source '$PREFIX/env'
+    printf '0,0\n0.1,0\n0,0.1\n0.1,0.1\n0.2,0.1\n0.1,0.2\n0.05,0.15\n0.15,0.05\n9,9\n' | iforest --top 1
+")
+echo "$IF_OUT"
+echo "$IF_OUT" | cut -f1 | grep -qx '8' && echo "  outlier ranked first: OK" || { echo "  outlier: FAILED"; fail=1; }
 
 say "RESULT"
 [[ $fail -eq 0 ]] && echo "PASS" || echo "FAIL"


### PR DESCRIPTION
## Summary

Adds `packages/iforest/`, a fifth NURL registry package providing **Isolation Forest** (Liu, Ting & Zhou, 2008) anomaly detection. Built the same way as `md2html`: both a reusable library and an installable CLI.

### Library — `src/iforest.nu` (deps: stdlib `vec`/`float`/`rng` only)

| Function | Result |
| -------- | ------ |
| `iforest_train data n_rows n_cols n_trees sample_size seed` | `IForest` |
| `iforest_score forest point` | `f` — score a `( Vec f )` of `n_cols` |
| `iforest_score_row forest data row` | `f` — score a matrix row, no copy |
| `iforest_avg_path n` | `f` — `c(n)` normaliser (custom thresholds) |
| `iforest_free` / accessors | — |

The score maps mean path length over the forest to `(0, 1]`: `≈1` anomaly, `≈0.5` no signal, `<0.5` normal/crowded.

All trees live in **one flat struct-of-arrays node arena** with a per-tree root index — no recursive ADTs, no Vec-of-Vec; scoring walks raw `*f`/`*i`. Random splits are driven by `std/rng`'s seedable xoshiro256\*\*, so a fixed `--seed` produces a **byte-identical** forest on every platform.

### CLI — `src/main.nu` (deps: `argz`)

Scores the rows of a numeric CSV from stdin or `--file`:

```
iforest < data.csv                 # one anomaly score per row, in order
iforest -f data.csv --top 10       # the 10 most anomalous rows (index⇥score)
iforest -f data.csv -H -t 200 -S 7 # skip header, 200 trees, seed 7
```

Flags: `-f/--file`, `-H/--header`, `-t/--trees`, `-s/--sample`, `-S/--seed`, `-k/--top`, `-d/--delim`, `-h/--help`.

## Testing

- Library + CLI compile and run; on a 2-D cluster + planted outliers the outliers rank cleanly at the top, and output is deterministic for a fixed seed.
- **Leak-clean under ASan/LSan** across every CLI path (stdin, `--file`, `--top`, help, file-error, empty input).
- Wired into `tools/nurlpkg/test-install-tool.sh`: the full install loop now installs + runs `iforest` too (asserts a planted outlier ranks first). Whole suite **PASS** (argz-demo, nq, md2html, iforest).

Not published — publishing is user-only (NURL_TOKEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)