### PR TITLE
playground: self-heal the container Worker when the server wedges

### DIFF
--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "test:recovery": "node --test test-recovery.ts",
     "cf-typegen": "wrangler types"
   },
   "dependencies": {

--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -1,4 +1,37 @@
 import { Container, getContainer } from "@cloudflare/containers";
+import { decideAction } from "./recovery";
+
+// ── Why this file has a custom fetch override ─────────────────────────────
+//
+// The playground container occasionally wedges: the nurlapi server process is
+// still *alive* (so the Durable Object's view stays `running` + `'healthy'`)
+// but is no longer accepting connections on port 8000 — e.g. after a heavy
+// compile burst, an OOM that took a worker rather than PID 1, or a soft
+// deadlock. In that state the @cloudflare/containers runtime never recovers
+// on its own:
+//
+//   • startAndWaitForPorts() early-returns WITHOUT re-checking the port when
+//     `state.status === 'healthy' && container.running` (container.ts), so it
+//     never notices the server stopped listening; and
+//   • containerFetch() catches the proxy failure and returns a 500 whose body
+//     is "Error proxying request to container: The container is not listening
+//     in the TCP address 10.0.0.1:8000" — but it does NOT mark the instance
+//     unhealthy or restart it.
+//
+// So every subsequent request repeats the same failure forever, and since
+// continuous traffic keeps renewActivityTimeout() alive the instance never
+// even sleeps to recycle. A clean crash/OOM of PID 1 *does* self-heal (the DO
+// sees `!running` and cold-starts), which is exactly why the stuck state is a
+// hang, not a crash.
+//
+// The fix: detect that wedged-proxy 500, force-destroy the instance (so the
+// next start spins up a fresh container), and replay the request. This makes
+// any server-side wedge self-heal within a single request instead of becoming
+// a sticky outage.
+
+// How many times to recycle+retry before giving up and surfacing the error.
+// (The classification policy lives in ./recovery, kept pure for unit testing.)
+const MAX_RECYCLES = 2;
 
 export class NurlContainer extends Container<Env> {
   defaultPort = 8000;
@@ -7,12 +40,83 @@ export class NurlContainer extends Container<Env> {
   envVars = {
     NURL_API_URL: this.env.NURL_API_URL,
   };
+
+  // The default onError rethrows; rethrowing from a lifecycle callback (e.g.
+  // the one destroy() triggers) can poison the DO. Log and swallow instead.
+  override onError(error: unknown): void {
+    console.error("[nurl-container] lifecycle error:", error);
+  }
+
+  // Self-healing proxy — see the file header for the failure it recovers from.
+  override async fetch(request: Request): Promise<Response> {
+    // WebSocket upgrades (the /pptws voice relay) can't be buffered or
+    // replayed — proxy them straight through with no retry.
+    if ((request.headers.get("Upgrade") ?? "").toLowerCase() === "websocket") {
+      return super.fetch(request);
+    }
+
+    // Buffer the body once so the request can be replayed after a recycle.
+    // Compile requests (POST /build*) carry the user's source and must
+    // survive a retry; their bodies are small.
+    const hasBody = request.method !== "GET" && request.method !== "HEAD";
+    const bodyBuf = hasBody ? await request.arrayBuffer() : undefined;
+    const replay = (): Request =>
+      new Request(request.url, {
+        method: request.method,
+        headers: request.headers,
+        body: bodyBuf,
+      });
+
+    for (let attempt = 0; ; attempt++) {
+      let res: Response;
+      try {
+        res = await super.fetch(replay());
+      } catch (e) {
+        // The base fetch normally returns a 500 rather than throwing, but a
+        // thrown error is just as much a proxy failure — recycle and retry.
+        if (attempt >= MAX_RECYCLES) {
+          const msg = e instanceof Error ? e.message : String(e);
+          return new Response(`container unavailable after recovery: ${msg}\n`, {
+            status: 502,
+          });
+        }
+        await this.recycle("threw: " + (e instanceof Error ? e.message : String(e)));
+        continue;
+      }
+
+      // Cheap exits first; only read the body for an unresolved 500.
+      if (res.status !== 500 || attempt >= MAX_RECYCLES) return res;
+
+      const action = decideAction(res.status, await res.clone().text(), attempt, MAX_RECYCLES);
+      if (action === "return") return res; // a real 500 from nurlapi — pass through.
+      if (action === "recycle") {
+        // Alive-but-not-listening: the DO won't re-check the port on its own,
+        // so tear the instance down — the retry's start spins a fresh one.
+        await this.recycle("proxy reported container not listening");
+      }
+      // "retry" → the instance is already restarting; just re-issue.
+    }
+  }
+
+  // Force-destroy the current instance so the next containerFetch starts a
+  // fresh one. Never throws (destroy() routes through our swallowing onError,
+  // but guard anyway so a failed teardown can't abort the retry loop).
+  private async recycle(reason: string): Promise<void> {
+    console.warn(`[nurl-container] recycling instance: ${reason}`);
+    try {
+      await this.destroy();
+    } catch (e) {
+      console.error("[nurl-container] destroy() during recycle failed:", e);
+    }
+  }
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    // Singleton: one container instance routes all requests.
-    // For horizontal scaling use getRandom / idFromName with a key.
+    // Singleton: one container instance routes all requests. The fetch
+    // override above makes that instance self-heal, so a wedge recovers
+    // within a request instead of becoming a sticky outage. For horizontal
+    // scaling swap to getRandom(env.NURL_CONTAINER, N) (uses max_instances).
     const container = getContainer(env.NURL_CONTAINER);
     return container.fetch(request);
   },

--- a/cloudflare/src/recovery.ts
+++ b/cloudflare/src/recovery.ts
@@ -1,0 +1,57 @@
+// recovery.ts — pure recovery policy for the container proxy.
+//
+// Deliberately free of any `cloudflare:workers` / `@cloudflare/containers`
+// import so it can be unit-tested under plain Node (the Container subclass in
+// index.ts can't be imported outside the Workers runtime). index.ts owns the
+// I/O (fetch / destroy / request buffering); this module owns the decision.
+//
+// Background: when the nurlapi process is alive but no longer listening on its
+// port, the @cloudflare/containers proxy returns a 500 whose body names the
+// cause but never recycles the instance, so the wedge is permanent. We read
+// that body to tell the recoverable proxy failures apart from a genuine 500
+// emitted by the nurlapi app itself.
+
+// Substrings (matched case-insensitively) in a 500 body.
+//   wedged    — instance reachable but server not accepting on the port; the
+//               DO won't re-check on its own, so the instance must be torn down
+//               ("The container is not listening in the TCP address …").
+//   transient — instance is mid-restart; a plain retry suffices.
+export const WEDGE_MARKERS: readonly string[] = [
+  "is not listening",
+  "not listening in the tcp address",
+];
+export const TRANSIENT_MARKERS: readonly string[] = [
+  "network connection lost",
+  "suddenly disconnected",
+  "failed to start container",
+];
+
+export type ProxyVerdict = "wedged" | "transient" | "app";
+
+// Classify a 500 body. "app" = a real 500 from nurlapi (pass through); the
+// others come from the container proxy layer and are recoverable.
+export function classifyError(body: string): ProxyVerdict {
+  const b = body.toLowerCase();
+  if (WEDGE_MARKERS.some((m) => b.includes(m))) return "wedged";
+  if (TRANSIENT_MARKERS.some((m) => b.includes(m))) return "transient";
+  return "app";
+}
+
+export type RecoveryAction = "return" | "retry" | "recycle";
+
+// Decide what the fetch loop should do after one proxy attempt.
+//   return  — hand `res` back to the caller (success, app 500, or retries spent)
+//   recycle — destroy the wedged instance, then retry on a fresh one
+//   retry   — re-issue the request without a teardown (transient restart)
+export function decideAction(
+  status: number,
+  body: string,
+  attempt: number,
+  maxRecycles: number,
+): RecoveryAction {
+  if (status !== 500 || attempt >= maxRecycles) return "return";
+  const verdict = classifyError(body);
+  if (verdict === "app") return "return";
+  if (verdict === "wedged") return "recycle";
+  return "retry";
+}

--- a/cloudflare/test-recovery.ts
+++ b/cloudflare/test-recovery.ts
@@ -1,0 +1,59 @@
+// test-recovery.ts — unit tests for the container-proxy recovery policy.
+// Run with: npm run test:recovery  (Node 24 executes .ts natively)
+//
+// Covers the exact 500 body the @cloudflare/containers proxy returns for the
+// production wedge, plus the transient and genuine-app cases, and the
+// per-attempt action decision the fetch loop in src/index.ts is built on.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyError, decideAction } from "./src/recovery.ts";
+
+// The literal string the user observed at https://play.nurl-lang.org/.
+const PROD_WEDGE =
+  "Error proxying request to container: The container is not listening in the TCP address 10.0.0.1:8000";
+
+test("classifyError: the production wedge body → 'wedged'", () => {
+  assert.equal(classifyError(PROD_WEDGE), "wedged");
+});
+
+test("classifyError: case-insensitive marker match", () => {
+  assert.equal(classifyError("THE CONTAINER IS NOT LISTENING ..."), "wedged");
+});
+
+test("classifyError: mid-restart bodies → 'transient'", () => {
+  assert.equal(classifyError("Container suddenly disconnected, try again"), "transient");
+  assert.equal(
+    classifyError("Error proxying request to container: Network connection lost."),
+    "transient",
+  );
+  assert.equal(classifyError("Failed to start container: boom"), "transient");
+});
+
+test("classifyError: a genuine nurlapi 500 → 'app'", () => {
+  assert.equal(classifyError("internal error: handler panicked\n"), "app");
+  assert.equal(classifyError("{\"error\":\"compile failed\"}"), "app");
+});
+
+const MAX = 2;
+
+test("decideAction: success and non-proxy statuses pass through", () => {
+  assert.equal(decideAction(200, "ok", 0, MAX), "return");
+  assert.equal(decideAction(404, "nope", 0, MAX), "return");
+  assert.equal(decideAction(503, "no instance", 0, MAX), "return");
+});
+
+test("decideAction: wedged 500 recycles until retries are spent", () => {
+  assert.equal(decideAction(500, PROD_WEDGE, 0, MAX), "recycle");
+  assert.equal(decideAction(500, PROD_WEDGE, 1, MAX), "recycle");
+  // Out of retries → surface the error instead of looping forever.
+  assert.equal(decideAction(500, PROD_WEDGE, MAX, MAX), "return");
+});
+
+test("decideAction: transient 500 retries without a teardown", () => {
+  assert.equal(decideAction(500, "Network connection lost.", 0, MAX), "retry");
+});
+
+test("decideAction: a genuine app 500 is never recycled", () => {
+  assert.equal(decideAction(500, "internal error: handler panicked\n", 0, MAX), "return");
+});


### PR DESCRIPTION
## The problem

https://play.nurl-lang.org/ occasionally gets stuck returning:

```
Error proxying request to container: The container is not listening in the TCP address 10.0.0.1:8000
```

and stays that way until manual intervention.

## Root cause (in `@cloudflare/containers`)

When the `nurlapi` server process is alive but no longer accepting on port 8000 — a **hang**, not a crash (a clean crash/OOM of PID 1 already self-heals, because the DO sees `!running` and cold-starts) — the Durable Object's view stays `running` + `'healthy'`. Then:

- `startAndWaitForPorts()` **early-returns without re-checking the port** (`container.ts`: `if (state.status === 'healthy' && this.container.running) return`), so it never notices the server stopped listening; and
- `containerFetch()` catches the proxy failure and returns a 500 with that message — but **never marks the instance unhealthy or restarts it**.

So every subsequent request repeats the same failure, and because continuous traffic keeps `renewActivityTimeout()` alive, the instance never even sleeps to recycle. Permanent outage.

## The fix (Worker only — no image rebuild)

Override `NurlContainer.fetch` to **self-heal**: detect the wedged-proxy 500, force `this.destroy()` so the next start spins up a fresh instance, and replay the request. A hang now recovers within a single request instead of becoming a sticky outage.

- The request body is buffered so `POST /build*` (the user's source) survives the retry; WebSocket upgrades (`/pptws`) pass straight through (can't be replayed).
- `onError` is overridden to log-and-swallow instead of rethrow, so a teardown can't poison the DO.
- Bounded to `MAX_RECYCLES = 2`, then the original error is surfaced — no infinite loop.

The classification policy (`wedged` → recycle · transient restart → retry · genuine `nurlapi` 500 → pass through) lives in `src/recovery.ts`, kept free of any `cloudflare:workers` import so it's unit-testable under plain Node.

## Testing

- `npm run test:recovery` → **8/8** (Node 24 native `.ts`), asserting the **exact** production error string classifies as `wedged` and the per-attempt action decision (recycle until retries spent, transient → retry, app-500 → pass through).
- `tsc --noEmit` clean; `wrangler deploy --dry-run` bundles cleanly with bindings intact.

## Deploying

This is a Worker-side change; it ships via `cloudflare/Dockerfile` (a thin `FROM nurllang/nurl:<ver>`) without rebuilding the heavy toolchain image. Deploy via the **Deploy playground API** workflow (manual `workflow_dispatch`) or `cd cloudflare && npx wrangler deploy`. A fresh deploy also recycles the currently-wedged instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)