### PR TITLE
WebSocket permessage-deflate (RFC 7692), server and client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **WebSocket `permessage-deflate` (RFC 7692), server and client.** Per-message
+  compression negotiated over `Sec-WebSocket-Extensions`, with both context-
+  takeover directions and peer-imposed window bounds honoured. New surface in
+  `stdlib/ext/websocket.nu`: extension negotiation (`ws_deflate_parse_extensions`,
+  `ws_deflate_offer_header`, `ws_deflate_response_header`), a `WsDeflate` context
+  (`ws_deflate_make` / `ws_deflate_free`), deflate-aware messaging
+  (`ws_send_text_deflate` / `ws_send_binary_deflate` / `ws_read_message_deflate`
+  / `ws_serve_messages_deflate` and their `ws_client_*` mirrors), and one-shot
+  handshake helpers (`ws_perform_handshake_deflate`, `ws_connect_deflate`). The
+  frame reader now surfaces the RSV1 compressed bit (`WsFrame.rsv1`,
+  `WsMessage.compressed`) — still rejected on the non-deflate readers, so the
+  change is fully backward-compatible. Decompression is capped against
+  `WsLimits.max_message_bytes` (a decompression-bomb guard) and text payloads
+  are UTF-8-validated *after* inflation.
+- **Raw-DEFLATE streaming codec in `stdlib/ext/compress.nu`** (the engine the
+  above rides on): `raw_deflate_*` / `raw_inflate_*` drive a *persistent*
+  `z_stream` with raw (header-less) DEFLATE via negative `windowBits`,
+  `Z_SYNC_FLUSH`, sliding-window context takeover, and `*_reset`. Four new
+  layout-absorbing `nurl_z_*` accessors in `runtime.c` let the NURL-side loop
+  rebind input/output across the persistent stream. Regression tests
+  `compress_rawdeflate.nu` and `ws_permessage_deflate.nu`.
+
 ## [0.9.10] — 2026-06-20
 
 The "NURL becomes an ecosystem" release: the toolchain is now installable,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,7 +114,8 @@ platform-specific shims.
   metrics, DoS caps, graceful shutdown, per-request timeouts, panic recovery),
   HTTP client (with cookie jar), **TLS** (SNI + ALPN + mTLS + live cert reload), **HTTP/2**
   (RFC 9113 + HPACK, **server and client**), **WebSocket** (RFC 6455, **server
-  and client**), reverse proxy with binary-safe streaming. The stack has had a
+  and client**, with **permessage-deflate** compression — RFC 7692),
+  reverse proxy with binary-safe streaming. The stack has had a
   dedicated security-hardening pass (path-traversal, SSRF, request-smuggling,
   HTTP/2 CONTINUATION-flood + stream-accounting, and clean cross-thread
   listener shutdown) with regression tests.

--- a/compiler/tests/compress_rawdeflate.nu
+++ b/compiler/tests/compress_rawdeflate.nu
@@ -1,0 +1,184 @@
+// compress_rawdeflate.nu — raw-DEFLATE streaming codec in
+// stdlib/ext/compress.nu (RFC 1951 bare blocks, persistent z_stream with
+// Z_SYNC_FLUSH + context takeover). This is the engine RFC 7692 WebSocket
+// permessage-deflate rides on, so it is exercised in isolation here.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/compress.nu`
+
+@ vec_eq_bytes ( Vec u ) a ( Vec u ) b → b {
+    : i na ( vec_len [u] a )
+    : i nb ( vec_len [u] b )
+    ? != na nb { ^ F } {}
+    : *u pa ( vec_data [u] a )
+    : *u pb ( vec_data [u] b )
+    : ~ i k 0
+    ~ < k na {
+        ? != # i . pa k # i . pb k { ^ F } {}
+        = k + k 1
+    }
+    ^ T
+}
+
+@ make_input s sample i reps → ( Vec u ) {
+    : ( Vec u ) buf ( vec_with_cap [u] 1024 )
+    : ~ i k 0
+    ~ < k reps {
+        ( bytes_extend_str buf sample )
+        = k + k 1
+    }
+    ^ buf
+}
+
+// permessage-deflate sender: compress, then strip the trailing
+// `00 00 FF FF` the sync flush appends (RFC 7692 §7.2.1).
+@ pmce_compress ZDeflate d ( Vec u ) input → ( Vec u ) {
+    : !( Vec u ) CompressErr r ( raw_deflate_block d input )
+    ^ ?? r {
+        T comp → {
+            : i cn ( vec_len [u] comp )
+            ? >= cn 4 {
+                : *u cp ( vec_data [u] comp )
+                ? & & & == # i . cp - cn 4 0 == # i . cp - cn 3 0
+                == # i . cp - cn 2 255 == # i . cp - cn 1 255 {
+                    : b _t ( vec_set_len [u] comp - cn 4 )
+                } {}
+            } {}
+            comp
+        }
+        F _ → ( vec_new [u] )
+    }
+}
+
+// permessage-deflate receiver: re-append the `00 00 FF FF` tail, inflate.
+@ pmce_decompress ZInflate d ( Vec u ) comp → ( Vec u ) {
+    : ( Vec u ) framed ( vec_new [u] )
+    ( vec_extend [u] framed comp )
+    ( vec_push [u] framed # u 0 )
+    ( vec_push [u] framed # u 0 )
+    ( vec_push [u] framed # u 255 )
+    ( vec_push [u] framed # u 255 )
+    : !( Vec u ) CompressErr r ( raw_inflate_block d framed 0 )
+    ( vec_free [u] framed )
+    ^ ?? r {
+        T plain → { plain }
+        F _ → ( vec_new [u] )
+    }
+}
+
+@ main → i {
+    // ── §A round-trip with context takeover across 3 messages ───────
+    : !ZDeflate CompressErr dn ( raw_deflate_new 15 6 )
+    : !ZInflate CompressErr in ( raw_inflate_new 15 )
+    ?? dn {
+        T deflater → {
+            ?? in {
+                T inflater → {
+                    : ( Vec u ) m1 ( make_input `the quick brown fox jumps over the lazy dog. ` 8 )
+                    : ( Vec u ) m2 ( make_input `the quick brown fox jumps over the lazy dog. ` 8 )
+                    : ( Vec u ) m3 ( make_input `NURL permessage-deflate over RFC 7692. ` 12 )
+
+                    : ( Vec u ) c1 ( pmce_compress deflater m1 )
+                    : ( Vec u ) p1 ( pmce_decompress inflater c1 )
+                    // Second identical message must compress SMALLER because
+                    // the sliding window survived (context takeover proof).
+                    : ( Vec u ) c2 ( pmce_compress deflater m2 )
+                    : ( Vec u ) p2 ( pmce_decompress inflater c2 )
+                    : ( Vec u ) c3 ( pmce_compress deflater m3 )
+                    : ( Vec u ) p3 ( pmce_decompress inflater c3 )
+
+                    ( nurl_print `m1 round_trip=` )
+                    ( nurl_print ? ( vec_eq_bytes m1 p1 ) `T` `F` )
+                    ( nurl_print ` compressed_smaller=` )
+                    ( nurl_print ? < ( vec_len [u] c1 ) ( vec_len [u] m1 ) `T` `F` )
+                    ( nurl_print `\n` )
+                    ( nurl_print `m2 round_trip=` )
+                    ( nurl_print ? ( vec_eq_bytes m2 p2 ) `T` `F` )
+                    ( nurl_print ` takeover_shrinks=` )
+                    ( nurl_print ? < ( vec_len [u] c2 ) ( vec_len [u] c1 ) `T` `F` )
+                    ( nurl_print `\n` )
+                    ( nurl_print `m3 round_trip=` )
+                    ( nurl_print ? ( vec_eq_bytes m3 p3 ) `T` `F` )
+                    ( nurl_print `\n` )
+
+                    ( vec_free [u] m1 ) ( vec_free [u] m2 ) ( vec_free [u] m3 )
+                    ( vec_free [u] c1 ) ( vec_free [u] c2 ) ( vec_free [u] c3 )
+                    ( vec_free [u] p1 ) ( vec_free [u] p2 ) ( vec_free [u] p3 )
+                    ( raw_inflate_free inflater )
+                }
+                F _ → { ( nurl_print `inflate_new failed\n` ) ( raw_inflate_free in ) }
+            }
+            ( raw_deflate_free deflater )
+        }
+        F _ → { ( nurl_print `deflate_new failed\n` ) ( raw_deflate_free dn ) }
+    }
+
+    // ── §B no-context-takeover: reset between messages ──────────────
+    // Two identical messages each compressed from a fresh window must
+    // produce IDENTICAL output (deterministic, no carried state).
+    : !ZDeflate CompressErr dn2 ( raw_deflate_new 15 6 )
+    ?? dn2 {
+        T deflater → {
+            : ( Vec u ) a ( make_input `reset me between every websocket message. ` 6 )
+            : ( Vec u ) b ( make_input `reset me between every websocket message. ` 6 )
+            : ( Vec u ) ca ( pmce_compress deflater a )
+            ( raw_deflate_reset deflater )
+            : ( Vec u ) cb ( pmce_compress deflater b )
+            ( nurl_print `no_takeover_identical=` )
+            ( nurl_print ? ( vec_eq_bytes ca cb ) `T` `F` )
+            ( nurl_print `\n` )
+            ( vec_free [u] a ) ( vec_free [u] b )
+            ( vec_free [u] ca ) ( vec_free [u] cb )
+            ( raw_deflate_free deflater )
+        }
+        F _ → ( nurl_print `dn2 failed\n` )
+    }
+
+    // ── §C empty message round-trips ────────────────────────────────
+    : !ZDeflate CompressErr dn3 ( raw_deflate_new 15 6 )
+    : !ZInflate CompressErr in3 ( raw_inflate_new 15 )
+    ?? dn3 {
+        T deflater → {
+            ?? in3 {
+                T inflater → {
+                    : ( Vec u ) empty ( vec_new [u] )
+                    : ( Vec u ) ce ( pmce_compress deflater empty )
+                    : ( Vec u ) pe ( pmce_decompress inflater ce )
+                    ( nurl_print `empty round_trip=` )
+                    ( nurl_print ? == ( vec_len [u] pe ) 0 `T` `F` )
+                    ( nurl_print `\n` )
+                    ( vec_free [u] empty ) ( vec_free [u] ce ) ( vec_free [u] pe )
+                    ( raw_inflate_free inflater )
+                }
+                F _ → { ( nurl_print `in3 failed\n` ) ( raw_inflate_free in3 ) }
+            }
+            ( raw_deflate_free deflater )
+        }
+        F _ → { ( nurl_print `dn3 failed\n` ) ( raw_deflate_free dn3 ) }
+    }
+
+    // ── §D corrupt compressed input is rejected ─────────────────────
+    : !ZInflate CompressErr in4 ( raw_inflate_new 15 )
+    ?? in4 {
+        T inflater → {
+            : ( Vec u ) garbage ( vec_with_cap [u] 8 )
+            ( vec_push [u] garbage # u 255 )
+            ( vec_push [u] garbage # u 255 )
+            ( vec_push [u] garbage # u 255 )
+            ( vec_push [u] garbage # u 255 )
+            : !( Vec u ) CompressErr r ( raw_inflate_block inflater garbage 0 )
+            ?? r {
+                T v → { ( nurl_print `garbage: unexpected ok\n` ) ( vec_free [u] v ) }
+                F e → {
+                    ( nurl_print `garbage rejected=` )
+                    ( nurl_print ( compress_err_name e ) ) ( nurl_print `\n` )
+                }
+            }
+            ( vec_free [u] garbage )
+            ( raw_inflate_free inflater )
+        }
+        F _ → ( nurl_print `in4 failed\n` )
+    }
+    ^ 0
+}

--- a/compiler/tests/outputs/compress_rawdeflate.txt
+++ b/compiler/tests/outputs/compress_rawdeflate.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+m1 round_trip=T compressed_smaller=T
+m2 round_trip=T takeover_shrinks=T
+m3 round_trip=T
+no_takeover_identical=T
+empty round_trip=T
+garbage rejected=CompressData

--- a/compiler/tests/outputs/ws_permessage_deflate.txt
+++ b/compiler/tests/outputs/ws_permessage_deflate.txt
@@ -1,0 +1,27 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+--- A negotiation ---
+offer_default=permessage-deflate
+offer_params=permessage-deflate; client_no_context_takeover; server_max_window_bits=10
+parse_enabled=T
+parse_snto=T
+parse_cnto=F
+parse_cwb=12
+parse_swb=15
+clamp_swb8=9
+response=permessage-deflate; server_no_context_takeover
+--- B decline ---
+no_pmce=T
+empty_none=T
+--- C round-trip ---
+client_active=T
+m1_round_trip=T
+m1_smaller=T
+m2_round_trip=T
+m2_takeover_shrinks=T
+--- D validation ---
+utf8_text_err=WsInvalidUtf8
+binary_ok=T
+bomb_capped=WsMessageTooLarge

--- a/compiler/tests/ws_permessage_deflate.nu
+++ b/compiler/tests/ws_permessage_deflate.nu
@@ -1,0 +1,234 @@
+// ws_permessage_deflate.nu — RFC 7692 permessage-deflate for
+// stdlib/ext/websocket.nu. All offline:
+//   §A  Extension-header negotiation (offer / parse / response / clamp)
+//   §B  Decline cases (no permessage-deflate offered)
+//   §C  Cross-context message round-trip (client compresses, server
+//       decompresses) incl. context takeover across messages
+//   §D  Text UTF-8 validated AFTER inflation; decompression-bomb cap
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/compress.nu`
+$ `stdlib/ext/websocket.nu`
+
+@ pl s tag s v → v {
+    ( nurl_print tag ) ( nurl_print `=` ) ( nurl_print v ) ( nurl_print `\n` )
+}
+
+@ pb s tag b v → v { ( pl tag ? v `T` `F` ) }
+
+@ vec_eq ( Vec u ) a ( Vec u ) b → b {
+    : i na ( vec_len [u] a )
+    ? != na ( vec_len [u] b ) { ^ F } {}
+    : *u pa ( vec_data [u] a )
+    : *u pb ( vec_data [u] b )
+    : ~ i k 0
+    ~ < k na {
+        ? != # i . pa k # i . pb k { ^ F } {}
+        = k + k 1
+    }
+    ^ T
+}
+
+@ make_text s sample i reps → ( Vec u ) {
+    : ( Vec u ) buf ( vec_with_cap [u] 256 )
+    : ~ i k 0
+    ~ < k reps { ( bytes_extend_str buf sample ) = k + k 1 }
+    ^ buf
+}
+
+// Mirror the sender: compress through a context's deflater, strip the
+// Z_SYNC_FLUSH tail (and reset if no-context-takeover).
+@ compress_msg WsDeflate d ( Vec u ) payload → ( Vec u ) {
+    : !( Vec u ) CompressErr cr ( raw_deflate_block . d deflater payload )
+    ^ ?? cr {
+        T comp → {
+            ? . d deflate_no_takeover { ( raw_deflate_reset . d deflater ) } {}
+            ( __ws_strip_deflate_tail comp )
+            comp
+        }
+        F _ → ( vec_new [u] )
+    }
+}
+
+@ section_a → v {
+    ( nurl_print `--- A negotiation ---\n` )
+    // Default offer is the bare extension token.
+    : String o1 ( ws_deflate_offer_header ( ws_deflate_default_config ) )
+    ( pl `offer_default` ( string_data o1 ) )
+    ( string_free o1 )
+
+    // Offer with params.
+    : WsDeflateConfig c2 @ WsDeflateConfig { T F T 10 15 }
+    : String o2 ( ws_deflate_offer_header c2 )
+    ( pl `offer_params` ( string_data o2 ) )
+    ( string_free o2 )
+
+    // Parse a client offer (browser-style).
+    : ?WsDeflateConfig p1 ( ws_deflate_parse_extensions `permessage-deflate; client_max_window_bits=12; server_no_context_takeover` )
+    ?? p1 {
+        T c → {
+            ( pb `parse_enabled` . c enabled )
+            ( pb `parse_snto` . c server_no_context_takeover )
+            ( pb `parse_cnto` . c client_no_context_takeover )
+            ( pl `parse_cwb` ( nurl_str_int . c client_max_window_bits ) )
+            ( pl `parse_swb` ( nurl_str_int . c server_max_window_bits ) )
+        }
+        F _ → ( nurl_print `parse_offer_none\n` )
+    }
+
+    // window_bits = 8 clamps to 9 (libz raw constraint).
+    : ?WsDeflateConfig p2 ( ws_deflate_parse_extensions `permessage-deflate; server_max_window_bits=8` )
+    ?? p2 {
+        T c → ( pl `clamp_swb8` ( nurl_str_int . c server_max_window_bits ) )
+        F _ → ( nurl_print `clamp_none\n` )
+    }
+
+    // Server response header echoes agreed params.
+    : WsDeflateConfig agreed @ WsDeflateConfig { T T F 15 15 }
+    : String resp ( ws_deflate_response_header agreed )
+    ( pl `response` ( string_data resp ) )
+    ( string_free resp )
+}
+
+@ section_b → v {
+    ( nurl_print `--- B decline ---\n` )
+    : ?WsDeflateConfig p ( ws_deflate_parse_extensions `x-custom-ext; q=1` )
+    ?? p {
+        T c → { ( nurl_print `unexpected_some\n` ) }
+        F _ → ( nurl_print `no_pmce=T\n` )
+    }
+    // Empty header → None.
+    : ?WsDeflateConfig p2 ( ws_deflate_parse_extensions `` )
+    ?? p2 {
+        T c → { ( nurl_print `unexpected_some2\n` ) }
+        F _ → ( nurl_print `empty_none=T\n` )
+    }
+}
+
+@ section_c → v {
+    ( nurl_print `--- C round-trip ---\n` )
+    : WsDeflateConfig cfg ( ws_deflate_default_config )
+    : !WsDeflate WsErr cm ( ws_deflate_make cfg F )  // client side
+    : !WsDeflate WsErr sm ( ws_deflate_make cfg T )  // server side
+    ?? cm {
+        F _ → ( nurl_print `client_ctx_fail\n` )
+        T client → {
+            ?? sm {
+                F _ → { ( nurl_print `server_ctx_fail\n` ) ( ws_deflate_free client ) }
+                T server → {
+                    ( pb `client_active` ( ws_deflate_active client ) )
+
+                    : WsLimits lim ( ws_default_limits )
+                    : ( Vec u ) m1 ( make_text `permessage-deflate compresses repetitive frames well. ` 8 )
+                    : ( Vec u ) m2 ( make_text `permessage-deflate compresses repetitive frames well. ` 8 )
+
+                    // Client compresses; server decompresses.
+                    : ( Vec u ) c1 ( compress_msg client m1 )
+                    : i c1len ( vec_len [u] c1 )
+                    : WsMessage msg1 @ WsMessage { 1 T c1 }
+                    : !WsMessage WsErr r1 ( __ws_inflate_message server lim msg1 )
+                    ?? r1 {
+                        T out → {
+                            ( pb `m1_round_trip` ( vec_eq m1 . out payload ) )
+                            ( pb `m1_smaller` < c1len ( vec_len [u] m1 ) )
+                            ( ws_message_free out )
+                        }
+                        F e → ( pl `m1_err` ( ws_err_name e ) )
+                    }
+
+                    // Second identical message: context takeover means the
+                    // server inflater must keep state to decode it.
+                    : ( Vec u ) c2 ( compress_msg client m2 )
+                    : i c2len ( vec_len [u] c2 )
+                    : WsMessage msg2 @ WsMessage { 1 T c2 }
+                    : !WsMessage WsErr r2 ( __ws_inflate_message server lim msg2 )
+                    ?? r2 {
+                        T out → {
+                            ( pb `m2_round_trip` ( vec_eq m2 . out payload ) )
+                            ( pb `m2_takeover_shrinks` < c2len c1len )
+                            ( ws_message_free out )
+                        }
+                        F e → ( pl `m2_err` ( ws_err_name e ) )
+                    }
+
+                    ( vec_free [u] m1 ) ( vec_free [u] m2 )
+                    ( ws_deflate_free server )
+                }
+            }
+            ( ws_deflate_free client )
+        }
+    }
+}
+
+@ section_d → v {
+    ( nurl_print `--- D validation ---\n` )
+    : WsDeflateConfig cfg ( ws_deflate_default_config )
+    : !WsDeflate WsErr cm ( ws_deflate_make cfg F )
+    : !WsDeflate WsErr sm ( ws_deflate_make cfg T )
+    ?? cm {
+        F _ → ( nurl_print `ctx_fail\n` )
+        T client → {
+            ?? sm {
+                F _ → { ( nurl_print `ctx_fail2\n` ) ( ws_deflate_free client ) }
+                T server → {
+                    // Invalid UTF-8 in a TEXT message must be rejected
+                    // AFTER inflation.
+                    : ( Vec u ) bad ( vec_new [u] )
+                    ( vec_push [u] bad # u 255 )  // lone 0xFF = invalid UTF-8
+                    ( vec_push [u] bad # u 254 )
+                    : ( Vec u ) cbad ( compress_msg client bad )
+                    : WsLimits lim ( ws_default_limits )
+                    : WsMessage mb @ WsMessage { 1 T cbad }
+                    : !WsMessage WsErr rb ( __ws_inflate_message server lim mb )
+                    ?? rb {
+                        T out → { ( nurl_print `utf8_not_rejected\n` ) ( ws_message_free out ) }
+                        F e → ( pl `utf8_text_err` ( ws_err_name e ) )
+                    }
+                    ( vec_free [u] bad )
+
+                    // The same bytes as BINARY (opcode 2) are fine.
+                    : ( Vec u ) bin ( vec_new [u] )
+                    ( vec_push [u] bin # u 255 )
+                    ( vec_push [u] bin # u 254 )
+                    : ( Vec u ) cbin ( compress_msg client bin )
+                    : WsMessage mn @ WsMessage { 2 T cbin }
+                    : !WsMessage WsErr rn ( __ws_inflate_message server lim mn )
+                    ?? rn {
+                        T out → {
+                            ( pb `binary_ok` ( vec_eq bin . out payload ) )
+                            ( ws_message_free out )
+                        }
+                        F e → ( pl `binary_err` ( ws_err_name e ) )
+                    }
+                    ( vec_free [u] bin )
+
+                    // Decompression-bomb cap: a large payload with a tiny
+                    // max_message_bytes must fail WsMessageTooLarge.
+                    : ( Vec u ) big ( make_text `AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA` 4096 )
+                    : ( Vec u ) cbig ( compress_msg client big )
+                    : WsLimits tiny @ WsLimits { 16777216 1024 60000 128 }
+                    : WsMessage mg @ WsMessage { 2 T cbig }
+                    : !WsMessage WsErr rg ( __ws_inflate_message server tiny mg )
+                    ?? rg {
+                        T out → { ( nurl_print `bomb_not_capped\n` ) ( ws_message_free out ) }
+                        F e → ( pl `bomb_capped` ( ws_err_name e ) )
+                    }
+                    ( vec_free [u] big )
+
+                    ( ws_deflate_free server )
+                }
+            }
+            ( ws_deflate_free client )
+        }
+    }
+}
+
+@ main → i {
+    ( section_a )
+    ( section_b )
+    ( section_c )
+    ( section_d )
+    ^ 0
+}

--- a/examples/ws_deflate_echo.nu
+++ b/examples/ws_deflate_echo.nu
@@ -1,0 +1,110 @@
+// examples/ws_deflate_echo.nu — WebSocket echo server with
+// permessage-deflate (RFC 7692) negotiation.
+//
+// Identical in shape to examples/ws_echo.nu, but the handshake offers
+// permessage-deflate and, when the client accepts, every echoed message
+// is compressed. Browsers (Chrome / Firefox / Safari) offer
+// permessage-deflate by default, so a page doing
+//
+//   const ws = new WebSocket("ws://127.0.0.1:9002/");
+//   ws.onopen = () => ws.send("hello".repeat(100));
+//   ws.onmessage = (e) => console.log(e.data);
+//
+// exchanges compressed frames over the wire transparently.
+//
+// Run:
+//   ./nurl.sh examples/ws_deflate_echo.nu /tmp/ws_deflate_echo && /tmp/ws_deflate_echo
+//
+// Shutdown: Ctrl+C (SIGINT) — the listener closes and the accept loop exits.
+
+$ `stdlib/std/net.nu`
+$ `stdlib/std/signal.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_server.nu`
+$ `stdlib/ext/websocket.nu`
+
+@ serve_one_connection TcpConn conn → v {
+    : ( Vec u ) carry ( vec_new [u] )
+    : HttpLimits lim ( http_default_limits )
+    : !ParsedHeadOk HttpReqErr ph ( __read_request_head conn carry lim )
+    ?? ph {
+        T pho → {
+            : HttpRequest req . pho head
+            ? ( ws_is_upgrade req ) {
+                // Negotiate permessage-deflate (default policy: enabled,
+                // full window, context takeover both directions).
+                : !WsDeflate WsErr hr ( ws_perform_handshake_deflate conn req @ ?String { F } ( ws_deflate_default_config ) )
+                ?? hr {
+                    T dctx → {
+                        : WsLimits wlim ( ws_default_limits )
+                        ? ( ws_deflate_active dctx ) {
+                            // Compressed session: echo each message back
+                            // compressed, preserving its text/binary opcode.
+                            : !v WsErr sr ( ws_serve_messages_deflate dctx conn wlim
+                            \ WsMessage msg → !v WsErr {
+                                ^ ( __ws_send_message_deflate dctx conn . msg opcode . msg payload F )
+                            } )
+                            ?? sr { T _ → {} F _ → {} }
+                        } {
+                            // Client declined the extension: plain echo.
+                            : !v WsErr sr ( ws_serve_messages conn wlim
+                            \ WsMessage msg → !v WsErr {
+                                ^ ( ws_write_frame conn T . msg opcode . msg payload )
+                            } )
+                            ?? sr { T _ → {} F _ → {} }
+                        }
+                        ( ws_deflate_free dctx )
+                    }
+                    F _ → {}
+                }
+            } {
+                : HttpResponse r400 ( response_text 400 `Not a WebSocket upgrade\n` )
+                : ( Vec u ) wire ( response_serialize r400 )
+                : !v NetErr _ww ( tcp_write_all conn wire )
+                ?? _ww { T _ → {} F _ → {} }
+                ( vec_free [u] wire )
+                ( http_response_free r400 )
+            }
+            ( request_free req )
+        }
+        F _ → {}
+    }
+    ( vec_free [u] carry )
+}
+
+@ main → i {
+    : !TcpListener NetErr lr ( tcp_listen `127.0.0.1` 9002 )
+    ?? lr {
+        T listener → {
+            ( signal_install_shutdown listener )
+            ( nurl_print `ws permessage-deflate echo server on 127.0.0.1:9002\n` )
+            : ~ b done F
+            ~ ! done {
+                : !TcpConn NetErr ar ( tcp_accept listener )
+                ?? ar {
+                    T conn → {
+                        ( tcp_set_timeout conn 30000 )
+                        ( serve_one_connection conn )
+                        ( tcp_close_conn conn )
+                    }
+                    F e → {
+                        : s nm ( net_err_name e )
+                        ? | != 0 ( nurl_str_eq nm `NetClosed` ) != 0 ( nurl_str_eq nm `NetAccept` ) {
+                            = done T
+                        } {
+                            ( nurl_print `accept err: ` ) ( nurl_print nm ) ( nurl_print `\n` )
+                            = done T
+                        }
+                    }
+                }
+            }
+            ( tcp_close_listener listener )
+        }
+        F e → {
+            ( nurl_print `bind failed: ` ) ( nurl_print ( net_err_name e ) ) ( nurl_print `\n` )
+            ^ 1
+        }
+    }
+    ^ 0
+}

--- a/stdlib/ext/compress.nu
+++ b/stdlib/ext/compress.nu
@@ -426,3 +426,237 @@ $ `stdlib/core/cell.nu`  // nurl_native_sizeof for z_stream alloc
     : b _r ( vec_set_len [u] out rc )
     ^ @ !( Vec u ) CompressErr { T out }
 }
+
+// ── Raw-DEFLATE streaming codec (RFC 1951, no zlib/gzip wrapper) ────
+//
+// The `zlib_*` / `gzip_*` helpers above are ONE-SHOT: each call spins up
+// a fresh `z_stream`, runs to Z_FINISH, and tears it down. RFC 7692
+// WebSocket permessage-deflate instead needs a PERSISTENT stream that
+// survives across many messages so the LZ77 sliding window carries over
+// ("context takeover"), and each message is flushed with Z_SYNC_FLUSH
+// rather than ended with Z_FINISH. This section exposes exactly that as
+// a reusable raw-DEFLATE codec — raw because permessage-deflate frames
+// carry bare DEFLATE blocks with no 2-byte zlib header / 4-byte Adler-32
+// trailer (achieved via libz's NEGATIVE windowBits).
+//
+//   ( raw_deflate_new   i window_bits i level ) → ! ZDeflate CompressErr
+//   ( raw_deflate_block ZDeflate d ( Vec u ) in ) → ! ( Vec u ) CompressErr
+//   ( raw_deflate_reset ZDeflate d )               → v   // drop the window
+//   ( raw_deflate_free  ZDeflate d )               → v
+//   ( raw_inflate_new   i window_bits )            → ! ZInflate CompressErr
+//   ( raw_inflate_block ZInflate d ( Vec u ) in i max_out )
+//                                                  → ! ( Vec u ) CompressErr
+//   ( raw_inflate_reset ZInflate d )               → v
+//   ( raw_inflate_free  ZInflate d )               → v
+//
+// `window_bits` is clamped to [9, 15]. libz changes a raw-deflate
+// windowBits of 8 to 9 internally (and 8 is unusable for raw inflate),
+// so 8 is treated as 9; callers needing a true 256-byte window are out
+// of scope. A deflater and the matching inflater MUST agree the encoder
+// never exceeds the inflater's window — inflating at 15 (the max) is
+// always safe regardless of the encoder's choice.
+//
+// Memory: ZDeflate / ZInflate own a heap `z_stream`; there is no
+// auto-Drop for the raw `*u` handle, so callers MUST pair every
+// successful `*_new` with a `*_free`.
+
+& `z` @ deflateReset *u zs → i32
+
+& `z` @ inflateReset *u zs → i32
+
+& `c` @ nurl_z_set_in *u zs *u in i avail_in → v
+
+& `c` @ nurl_z_set_out *u zs *u out i avail_out → v
+
+& `c` @ nurl_z_avail_in *u zs → i
+
+& `c` @ nurl_z_avail_out *u zs → i
+
+: ZDeflate {
+    *u zs  // heap z_stream; 0 once freed
+}
+
+: ZInflate {
+    *u zs
+}
+
+@ __raw_clamp_wbits i window_bits → i {
+    ? < window_bits 9 { ^ 9 } {}
+    ? > window_bits 15 { ^ 15 } {}
+    ^ window_bits
+}
+
+// Initialise a persistent raw-DEFLATE compressor. `level` is 0..9
+// (6 is a good default). Z_DEFLATED = 8, memLevel = 8, strategy = 0.
+@ raw_deflate_new i window_bits i level → !ZDeflate CompressErr {
+    : i wb ( __raw_clamp_wbits window_bits )
+    : i zs_size ( nurl_native_sizeof `z_stream` )
+    ? <= zs_size 0 { ^ @ !ZDeflate CompressErr { F CompressOther } } {}
+    : *u zs # *u ( nurl_zalloc zs_size )
+    ? == 0 # i zs { ^ @ !ZDeflate CompressErr { F CompressMemory } } {}
+    : i nwb - 0 wb
+    : i32 rc ( deflateInit2_ zs # i32 level # i32 8 # i32 nwb # i32 8 # i32 0
+    ( zlibVersion ) # i32 zs_size )
+    ? != rc # i32 0 {
+        ( nurl_free # s zs )
+        ^ @ !ZDeflate CompressErr { F ( __zlib_map_err # i rc ) }
+    } {}
+    ^ @ !ZDeflate CompressErr { T @ ZDeflate { zs } }
+}
+
+// Compress one message: feed `input` through the live stream and flush
+// with Z_SYNC_FLUSH, returning every byte produced this round (which
+// always ends with the 4-byte `00 00 FF FF` empty-block marker the
+// sync flush appends — RFC 7692 §7.2.1 strips those before framing).
+// The sliding window is RETAINED for the next call unless raw_deflate_reset
+// is invoked between messages.
+@ raw_deflate_block ZDeflate d ( Vec u ) input → !( Vec u ) CompressErr {
+    : *u zs . d zs
+    ? == 0 # i zs { ^ @ !( Vec u ) CompressErr { F CompressOther } } {}
+    : i n ( vec_len [u] input )
+    : ( Vec u ) out ( vec_new [u] )
+    : *u srcp ( vec_data [u] input )
+    ( nurl_z_set_in zs srcp n )
+    : i chunk 16384
+    : ~ b done F
+    : ~ b ok F
+    : ~ CompressErr last CompressOther
+    ~ ! done {
+        : ( Vec u ) scratch ( vec_with_cap [u] chunk )
+        ( vec_reserve [u] scratch chunk )
+        : *u dp ( vec_data [u] scratch )
+        : i before ( nurl_z_total_out zs )
+        ( nurl_z_set_out zs dp chunk )
+        : i32 rc ( deflate zs # i32 2 )  // Z_SYNC_FLUSH
+        : i after ( nurl_z_total_out zs )
+        : i got - after before
+        ? > got 0 {
+            : b _s ( vec_set_len [u] scratch got )
+            ( vec_extend [u] out scratch )
+        } {}
+        ( vec_free [u] scratch )
+        : i rci # i rc
+        ? == rci 0 {
+            // Z_OK. Free output space remaining ⇒ the flush is complete
+            // (deflate fills avail_out before returning while work remains).
+            ? > ( nurl_z_avail_out zs ) 0 { = ok T = done T } {}
+        } {
+            = last ( __zlib_map_err rci )
+            = done T
+        }
+    }
+    ? ok {
+        ^ @ !( Vec u ) CompressErr { T out }
+    } {
+        ( vec_free [u] out )
+        ^ @ !( Vec u ) CompressErr { F last }
+    }
+}
+
+@ raw_deflate_reset ZDeflate d → v {
+    ? != 0 # i . d zs { : i32 _ ( deflateReset . d zs ) } {}
+}
+
+@ raw_deflate_free ZDeflate d → v {
+    ? != 0 # i . d zs {
+        : i32 _ ( deflateEnd . d zs )
+        ( nurl_free # s . d zs )
+    } {}
+}
+
+// Initialise a persistent raw-INFLATE decompressor. Inflating at the
+// maximum window (15) accepts any encoder window ≤ 15, so passing 15 is
+// always interoperable.
+@ raw_inflate_new i window_bits → !ZInflate CompressErr {
+    : i wb ( __raw_clamp_wbits window_bits )
+    : i zs_size ( nurl_native_sizeof `z_stream` )
+    ? <= zs_size 0 { ^ @ !ZInflate CompressErr { F CompressOther } } {}
+    : *u zs # *u ( nurl_zalloc zs_size )
+    ? == 0 # i zs { ^ @ !ZInflate CompressErr { F CompressMemory } } {}
+    : i nwb - 0 wb
+    : i32 rc ( inflateInit2_ zs # i32 nwb ( zlibVersion ) # i32 zs_size )
+    ? != rc # i32 0 {
+        ( nurl_free # s zs )
+        ^ @ !ZInflate CompressErr { F ( __zlib_map_err # i rc ) }
+    } {}
+    ^ @ !ZInflate CompressErr { T @ ZInflate { zs } }
+}
+
+// Decompress one message. The caller appends the 4-byte `00 00 FF FF`
+// tail RFC 7692 §7.2.2 mandates before calling, so a complete message
+// inflates to Z_OK with all input consumed. Output size is unknown up
+// front, so this grows a result Vec a chunk at a time. `max_out` caps the
+// decompressed size — exceeding it fails with CompressBufTooSmall (a
+// decompression-bomb guard); pass 0 for no limit.
+@ raw_inflate_block ZInflate d ( Vec u ) input i max_out → !( Vec u ) CompressErr {
+    : *u zs . d zs
+    ? == 0 # i zs { ^ @ !( Vec u ) CompressErr { F CompressOther } } {}
+    : i n ( vec_len [u] input )
+    ? <= n 0 { ^ @ !( Vec u ) CompressErr { T ( vec_new [u] ) } } {}
+    : ( Vec u ) out ( vec_new [u] )
+    : *u srcp ( vec_data [u] input )
+    ( nurl_z_set_in zs srcp n )
+    : i chunk 16384
+    : ~ b done F
+    : ~ b ok F
+    : ~ CompressErr last CompressOther
+    ~ ! done {
+        : ( Vec u ) scratch ( vec_with_cap [u] chunk )
+        ( vec_reserve [u] scratch chunk )
+        : *u dp ( vec_data [u] scratch )
+        : i before ( nurl_z_total_out zs )
+        ( nurl_z_set_out zs dp chunk )
+        : i32 rc ( inflate zs # i32 2 )  // Z_SYNC_FLUSH
+        : i after ( nurl_z_total_out zs )
+        : i got - after before
+        ? > got 0 {
+            : b _s ( vec_set_len [u] scratch got )
+            ( vec_extend [u] out scratch )
+        } {}
+        ( vec_free [u] scratch )
+        : i rci # i rc
+        ? & > max_out 0 > ( vec_len [u] out ) max_out {
+            = last CompressBufTooSmall
+            = done T
+        } {
+            ? == rci 1 { = ok T = done T } {  // Z_STREAM_END
+                ? == rci 0 {  // Z_OK
+                    // Output space remaining ⇒ all available input consumed
+                    // and everything flushed (input is a complete message).
+                    ? > ( nurl_z_avail_out zs ) 0 { = ok T = done T } {}
+                } {
+                    ? == rci -5 {  // Z_BUF_ERROR
+                        // No progress: for a complete message this means the
+                        // input is fully consumed (clean end), else truncated.
+                        ? == ( nurl_z_avail_in zs ) 0 {
+                            = ok T = done T
+                        } {
+                            = last CompressData
+                            = done T
+                        }
+                    } {
+                        = last ( __zlib_map_err rci )
+                        = done T
+                    }
+                }
+            }
+        }
+    }
+    ? ok {
+        ^ @ !( Vec u ) CompressErr { T out }
+    } {
+        ( vec_free [u] out )
+        ^ @ !( Vec u ) CompressErr { F last }
+    }
+}
+
+@ raw_inflate_reset ZInflate d → v {
+    ? != 0 # i . d zs { : i32 _ ( inflateReset . d zs ) } {}
+}
+
+@ raw_inflate_free ZInflate d → v {
+    ? != 0 # i . d zs {
+        : i32 _ ( inflateEnd . d zs )
+        ( nurl_free # s . d zs )
+    } {}
+}

--- a/stdlib/ext/websocket.nu
+++ b/stdlib/ext/websocket.nu
@@ -84,6 +84,7 @@ $ `stdlib/std/net.nu`
 $ `stdlib/std/url.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/compress.nu`
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -110,11 +111,13 @@ $ `stdlib/ext/http_response.nu`
 : WsFrame {
     i opcode  // 0,1,2,8,9,10
     b fin
+    b rsv1  // RFC 7692: per-message-compressed bit (only on a message's first frame)
     ( Vec u ) payload  // OWNED
 }
 
 : WsMessage {
     i opcode  // 1 (text) or 2 (binary)
+    b compressed  // RFC 7692: payload is still permessage-deflate compressed
     ( Vec u ) payload  // OWNED, assembled across continuation frames
 }
 
@@ -565,10 +568,11 @@ $ `stdlib/ext/http_response.nu`
 //     with the 4-byte key that follows the length.
 //   * client = T (client reading server frames): the MASK bit MUST be 0;
 //     a masked frame → WsProtocolMasked. Payload is read verbatim.
-@ __ws_read_frame_ex TcpConn conn WsLimits lim b client → !WsFrame WsErr {
+@ __ws_read_frame_ex TcpConn conn WsLimits lim b client b allow_rsv1 → !WsFrame WsErr {
     : !( Vec u ) WsErr hdr_r ( __ws_read_exact conn 2 )
     : ~ b ok F
     : ~ b fin F
+    : ~ b rsv1 F
     : ~ i opcode 0
     : ~ b masked F
     : ~ i len7 0
@@ -578,9 +582,13 @@ $ `stdlib/ext/http_response.nu`
             : *u hp ( vec_data [u] hdr )
             : i b0 # i . hp 0
             : i b1 # i . hp 1
-            // RSV1/RSV2/RSV3 MUST be 0 (no extension negotiated in v1).
-            ? != 0 & b0 112 { = err WsProtocolReservedBit }
+            // RSV2/RSV3 (0x30) MUST always be 0. RSV1 (0x40) MUST be 0
+            // unless permessage-deflate was negotiated (allow_rsv1) — then
+            // it marks a per-message-compressed message (RFC 7692 §6).
+            : b rsv_bad | != 0 & b0 48 & ! allow_rsv1 != 0 & b0 64
+            ? rsv_bad { = err WsProtocolReservedBit }
             { = fin != 0 & b0 128
+                = rsv1 != 0 & b0 64
                 = opcode & b0 15
                 = masked != 0 & b1 128
                 = len7 & b1 127
@@ -662,20 +670,22 @@ $ `stdlib/ext/http_response.nu`
     ( __ws_read_masked_payload conn payload_len )
     ?? ppr {
         T payload → {
-            ^ @ !WsFrame WsErr { T @ WsFrame { opcode fin payload } }
+            ^ @ !WsFrame WsErr { T @ WsFrame { opcode fin rsv1 payload } }
         }
         F e → { ^ @ !WsFrame WsErr { F e } }
     }
 }
 
 // Server-side frame reader (client → server frames MUST be masked).
+// RSV1 is rejected (no extension); the deflate-aware readers below
+// pass allow_rsv1=T after a permessage-deflate handshake.
 @ ws_read_frame TcpConn conn WsLimits lim → !WsFrame WsErr {
-    ^ ( __ws_read_frame_ex conn lim F )
+    ^ ( __ws_read_frame_ex conn lim F F )
 }
 
 // Client-side frame reader (server → client frames MUST NOT be masked).
 @ ws_client_read_frame TcpConn conn WsLimits lim → !WsFrame WsErr {
-    ^ ( __ws_read_frame_ex conn lim T )
+    ^ ( __ws_read_frame_ex conn lim T F )
 }
 
 // Bitwise XOR of two byte-sized ints. NURL has no infix XOR operator
@@ -963,12 +973,13 @@ $ `stdlib/ext/http_response.nu`
 // per logical message, including control frames interleaved between
 // fragments — a malicious peer cannot stall the server with infinite
 // pings between continuation frames.
-@ __ws_read_message_ex TcpConn conn WsLimits lim b client → !WsMessage WsErr {
+@ __ws_read_message_ex TcpConn conn WsLimits lim b client b allow_compressed → !WsMessage WsErr {
     : ~ ( Vec u ) acc ( vec_new [u] )
     : ~ i kind 0  // 0 = no fragment in progress, 1 = text, 2 = binary
     : ~ i frame_count 0
     : ~ b done F
     : ~ b have_message F
+    : ~ b compressed F  // RFC 7692: first frame of this message had RSV1
     : ~ WsErr err WsOther
     : ~ ( Vec u ) msg_payload ( vec_new [u] )
     ~ ! done {
@@ -978,13 +989,22 @@ $ `stdlib/ext/http_response.nu`
             = done T
         } {
             : !WsFrame WsErr fr ? client
-            ( ws_client_read_frame conn lim )
-            ( ws_read_frame conn lim )
+            ( __ws_read_frame_ex conn lim T allow_compressed )
+            ( __ws_read_frame_ex conn lim F allow_compressed )
             ?? fr {
                 T frm → {
                     : i op . frm opcode
                     : b fin . frm fin
+                    : b rsv1f . frm rsv1
                     : ( Vec u ) pl . frm payload
+                    // RFC 7692 §6: the compressed bit is valid ONLY on the
+                    // first frame of a data message. RSV1 on a control frame
+                    // or on a continuation frame is a protocol error.
+                    ? & rsv1f | ( __ws_opcode_is_control op ) == op 0 {
+                        ( vec_free [u] pl )
+                        = err WsProtocolReservedBit
+                        = done T
+                    } {
                     ? ( __ws_opcode_is_control op ) {
                         // Control frame: handle in-band
                         ? == op 9 {
@@ -1101,8 +1121,10 @@ $ `stdlib/ext/http_response.nu`
                                     = done T
                                 } {
                                     ? fin {
-                                        // Validate UTF-8 if text
-                                        ? & == kind 1 ! ( ws_validate_utf8 acc ) {
+                                        // Validate UTF-8 if text. Skip when
+                                        // compressed — validation happens
+                                        // after permessage-deflate inflation.
+                                        ? & & == kind 1 ! compressed ! ( ws_validate_utf8 acc ) {
                                             = err WsInvalidUtf8
                                             = done T
                                         } {
@@ -1116,15 +1138,19 @@ $ `stdlib/ext/http_response.nu`
                                 }
                             }
                         } {
-                            // Text or binary opener
+                            // Text or binary opener — first frame of a
+                            // message carries the RSV1 compressed bit.
                             ? != kind 0 {
                                 ( vec_free [u] pl )
                                 = err WsProtocolBadFragmentation
                                 = done T
                             } {
+                                = compressed rsv1f
                                 ? fin {
-                                    // One-shot complete message
-                                    ? & == op 1 ! ( ws_validate_utf8 pl ) {
+                                    // One-shot complete message. Skip UTF-8
+                                    // validation when compressed (validated
+                                    // post-inflation by the deflate reader).
+                                    ? & & == op 1 ! rsv1f ! ( ws_validate_utf8 pl ) {
                                         ( vec_free [u] pl )
                                         = err WsInvalidUtf8
                                         = done T
@@ -1148,6 +1174,7 @@ $ `stdlib/ext/http_response.nu`
                             }
                         }
                     }
+                    }
                 }
                 F we → { = err we = done T }
             }
@@ -1155,22 +1182,23 @@ $ `stdlib/ext/http_response.nu`
     }
     ( vec_free [u] acc )
     ? have_message {
-        ^ @ !WsMessage WsErr { T @ WsMessage { kind msg_payload } }
+        ^ @ !WsMessage WsErr { T @ WsMessage { kind compressed msg_payload } }
     } {
         ( vec_free [u] msg_payload )
         ^ @ !WsMessage WsErr { F err }
     }
 }
 
-// Server-side message reader (auto-pongs unmasked).
+// Server-side message reader (auto-pongs unmasked). RSV1 rejected — for a
+// permessage-deflate session use ws_read_message_deflate.
 @ ws_read_message TcpConn conn WsLimits lim → !WsMessage WsErr {
-    ^ ( __ws_read_message_ex conn lim F )
+    ^ ( __ws_read_message_ex conn lim F F )
 }
 
 // Client-side message reader: reads UNmasked server frames and auto-pongs
 // with a MASKED pong frame.
 @ ws_client_read_message TcpConn conn WsLimits lim → !WsMessage WsErr {
-    ^ ( __ws_read_message_ex conn lim T )
+    ^ ( __ws_read_message_ex conn lim T F )
 }
 
 // ── Serve loop ────────────────────────────────────────────────────────
@@ -1720,5 +1748,680 @@ $ `stdlib/ext/http_response.nu`
             }
         }
         F _ → { ^ @ !WsClient WsErr { F WsBadUrl } }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// permessage-deflate (RFC 7692) — per-message compression, server + client
+// ═══════════════════════════════════════════════════════════════════════
+//
+// permessage-deflate compresses each WebSocket message with raw DEFLATE
+// (RFC 1951) and flags the first frame of a compressed message with the
+// RSV1 bit. The negotiated parameters (RFC 7692 §7.1) control whether the
+// LZ77 sliding window carries between messages ("context takeover") and an
+// upper bound on the window size:
+//
+//   * server_no_context_takeover / client_no_context_takeover — the named
+//     side resets its compressor before every message (cheaper memory,
+//     worse ratio). We honour both directions.
+//   * server_max_window_bits / client_max_window_bits — the named side's
+//     compressor uses a window of at most 2^N bytes (N in 8..15). We honour
+//     a peer-imposed bound on OUR compressor and always decompress at the
+//     maximum window (15), which accepts any encoder window.
+//
+// On the wire (RFC 7692 §7.2): the sender DEFLATEs the payload with
+// Z_SYNC_FLUSH and strips the trailing `00 00 FF FF`; the receiver appends
+// it back before inflating. Both are handled by the raw-DEFLATE streaming
+// codec in stdlib/ext/compress.nu (raw_deflate_*/raw_inflate_*).
+//
+//   API surface:
+//     Negotiation (pure, offline-testable):
+//       ( ws_deflate_default_config )                  → WsDeflateConfig
+//       ( ws_deflate_offer_header    WsDeflateConfig )  → String
+//       ( ws_deflate_response_header WsDeflateConfig )  → String
+//       ( ws_deflate_parse_extensions s value )         → ?WsDeflateConfig
+//     Context lifecycle (owns two heap z_streams — free it):
+//       ( ws_deflate_make WsDeflateConfig cfg b is_server ) → ! WsDeflate WsErr
+//       ( ws_deflate_free WsDeflate d )                     → v
+//     Server-side messaging:
+//       ( ws_send_text_deflate   WsDeflate TcpConn s )           → ! v WsErr
+//       ( ws_send_binary_deflate WsDeflate TcpConn ( Vec u ) )   → ! v WsErr
+//       ( ws_read_message_deflate WsDeflate TcpConn WsLimits )   → ! WsMessage WsErr
+//       ( ws_serve_messages_deflate WsDeflate TcpConn WsLimits h)→ ! v WsErr
+//       ( ws_perform_handshake_deflate TcpConn HttpRequest
+//                       ?String sub WsDeflateConfig policy )     → !WsDeflate WsErr
+//     Client-side messaging (masked):
+//       ( ws_client_send_text_deflate   WsDeflate TcpConn s )         → ! v WsErr
+//       ( ws_client_send_binary_deflate WsDeflate TcpConn ( Vec u ) ) → ! v WsErr
+//       ( ws_client_read_message_deflate WsDeflate TcpConn WsLimits ) → ! WsMessage WsErr
+//       ( ws_client_serve_messages_deflate WsDeflate TcpConn WsLimits h) → ! v WsErr
+//       ( ws_connect_deflate s url ?String sub WsDeflateConfig )      → ! WsDeflateConn WsErr
+
+: WsDeflateConfig {
+    b enabled
+    b server_no_context_takeover
+    b client_no_context_takeover
+    i server_max_window_bits  // 8..15 (default 15)
+    i client_max_window_bits  // 8..15 (default 15)
+}
+
+// Default: enabled, both directions keep context, full 32 KiB windows —
+// the maximum-ratio configuration browsers default to.
+@ ws_deflate_default_config → WsDeflateConfig {
+    ^ @ WsDeflateConfig { T F F 15 15 }
+}
+
+// A persistent permessage-deflate context. Owns one raw-DEFLATE
+// compressor (our outbound direction) and one raw-INFLATE decompressor
+// (inbound). MUST be freed with ws_deflate_free.
+: WsDeflate {
+    ZDeflate deflater
+    ZInflate inflater
+    b deflate_no_takeover  // reset our compressor each message
+    b inflate_no_takeover  // reset our decompressor each message
+    i min_size  // payloads below this are sent uncompressed
+    b active  // F when the extension was NOT negotiated (null streams)
+}
+
+// True iff this context was actually negotiated (vs. a placeholder
+// returned when the peer declined permessage-deflate).
+@ ws_deflate_active WsDeflate d → b { ^ . d active }
+
+// A connected, handshaken client plus the negotiated permessage-deflate
+// context (if any). `have_deflate` is F when the server declined the
+// extension — in that case `deflate` is unused.
+: WsDeflateConn {
+    WsClient client
+    b have_deflate
+    WsDeflate deflate
+}
+
+// ── Extension header negotiation ──────────────────────────────────────
+
+@ __ws_lc i c → i {
+    ? & >= c 65 <= c 90 { ^ + c 32 } {}
+    ^ c
+}
+
+// Case-insensitive search for `needle` in `hay` (a NUL-terminated `s`)
+// starting at `from`. Returns the index or -1.
+@ __ws_ci_find s hay s needle i from → i {
+    : i hl ( nurl_str_len hay )
+    : i nl ( nurl_str_len needle )
+    ? == nl 0 { ^ -1 } {}
+    ? > nl hl { ^ -1 } {}
+    : ~ i i ? < from 0 0 from
+    : ~ i found -1
+    : i last - hl nl
+    ~ & == found -1 <= i last {
+        : ~ i j 0
+        : ~ b match T
+        ~ & match < j nl {
+            ? != ( __ws_lc ( nurl_str_get hay + i j ) ) ( __ws_lc ( nurl_str_get needle j ) ) {
+                = match F
+            } {}
+            = j + j 1
+        }
+        ? match { = found i } {}
+        = i + i 1
+    }
+    ^ found
+}
+
+// Index of the next ',' at or after `from` in `hay`, else its length.
+@ __ws_seg_end s hay i from → i {
+    : i hl ( nurl_str_len hay )
+    : ~ i k from
+    ~ < k hl {
+        ? == ( nurl_str_get hay k ) 44 { ^ k } {}
+        = k + k 1
+    }
+    ^ hl
+}
+
+// Parse an optional `=<digits>` (RFC 7692 quotes the value optionally)
+// starting at `pos`, bounded by `segend`. Returns the integer or -1 when
+// the parameter carried no value.
+@ __ws_window_after s hay i pos i segend → i {
+    : ~ i k pos
+    ~ & < k segend | == ( nurl_str_get hay k ) 32 == ( nurl_str_get hay k ) 9 { = k + k 1 }
+    ? >= k segend { ^ -1 } {}
+    ? != ( nurl_str_get hay k ) 61 { ^ -1 } {}  // '='
+    = k + k 1
+    ~ & < k segend | == ( nurl_str_get hay k ) 32 == ( nurl_str_get hay k ) 9 { = k + k 1 }
+    ? & < k segend == ( nurl_str_get hay k ) 34 { = k + k 1 } {}  // optional '"'
+    : ~ i val 0
+    : ~ b any F
+    ~ & < k segend & >= ( nurl_str_get hay k ) 48 <= ( nurl_str_get hay k ) 57 {
+        = val + * val 10 - ( nurl_str_get hay k ) 48
+        = any T
+        = k + k 1
+    }
+    ? ! any { ^ -1 } {}
+    ^ val
+}
+
+// Clamp a negotiated window-bits value to the codec-usable [9, 15] range
+// (libz cannot do raw windowBits 8 — see compress.nu). A missing value
+// (-1) or out-of-range value falls back to 15.
+@ __ws_clamp_window i v → i {
+    ? < v 8 { ^ 15 } {}
+    ? > v 15 { ^ 15 } {}
+    ? < v 9 { ^ 9 } {}
+    ^ v
+}
+
+// Parse a `Sec-WebSocket-Extensions` value, returning the permessage-deflate
+// parameters if the (first) permessage-deflate offer/response is present,
+// else None. Shared by both the server (parsing the client offer) and the
+// client (parsing the server response): the four parameters carry the same
+// shape on the wire; `ws_deflate_make` interprets them per side.
+@ ws_deflate_parse_extensions s value → ?WsDeflateConfig {
+    : i p ( __ws_ci_find value `permessage-deflate` 0 )
+    ? < p 0 { ^ @ ?WsDeflateConfig { F # WsDeflateConfig 0 } } {}
+    : i segend ( __ws_seg_end value p )
+    : i snto ( __ws_ci_find value `server_no_context_takeover` p )
+    : i cnto ( __ws_ci_find value `client_no_context_takeover` p )
+    : b snto_on & >= snto 0 < snto segend
+    : b cnto_on & >= cnto 0 < cnto segend
+    : i swbp ( __ws_ci_find value `server_max_window_bits` p )
+    : i cwbp ( __ws_ci_find value `client_max_window_bits` p )
+    : i swb ? & >= swbp 0 < swbp segend
+    ( __ws_clamp_window ( __ws_window_after value + swbp 22 segend ) )
+    15
+    : i cwb ? & >= cwbp 0 < cwbp segend
+    ( __ws_clamp_window ( __ws_window_after value + cwbp 22 segend ) )
+    15
+    ^ @ ?WsDeflateConfig { T @ WsDeflateConfig { T snto_on cnto_on swb cwb } }
+}
+
+// Append "; <name>" / "; <name>=<n>" to a header String being built.
+@ __ws_append_param String h s name → v {
+    ( string_push_str h `; ` )
+    ( string_push_str h name )
+}
+
+@ __ws_append_param_n String h s name i n → v {
+    ( string_push_str h `; ` )
+    ( string_push_str h name )
+    ( string_push_char h 61 )  // '='
+    ( string_push_int h n )
+}
+
+// Build the `Sec-WebSocket-Extensions` value a CLIENT offers. Window-bits
+// params are emitted with a value only when the config asks for < 15.
+@ ws_deflate_offer_header WsDeflateConfig cfg → String {
+    : String h ( string_from `permessage-deflate` )
+    ? . cfg client_no_context_takeover { ( __ws_append_param h `client_no_context_takeover` ) } {}
+    ? . cfg server_no_context_takeover { ( __ws_append_param h `server_no_context_takeover` ) } {}
+    ? < . cfg client_max_window_bits 15 { ( __ws_append_param_n h `client_max_window_bits` . cfg client_max_window_bits ) } {}
+    ? < . cfg server_max_window_bits 15 { ( __ws_append_param_n h `server_max_window_bits` . cfg server_max_window_bits ) } {}
+    ^ h
+}
+
+// Build the `Sec-WebSocket-Extensions` value a SERVER returns to confirm
+// the agreed parameters.
+@ ws_deflate_response_header WsDeflateConfig cfg → String {
+    ^ ( ws_deflate_offer_header cfg )
+}
+
+// ── Context lifecycle ─────────────────────────────────────────────────
+
+// Build a live permessage-deflate context from the negotiated config.
+// `is_server` selects which direction is OUR compressor: a server
+// compresses with the server_* parameters, a client with the client_*.
+// We always decompress at the maximum window (15).
+@ ws_deflate_make WsDeflateConfig cfg b is_server → !WsDeflate WsErr {
+    : i dwin ? is_server . cfg server_max_window_bits . cfg client_max_window_bits
+    : b dnto ? is_server . cfg server_no_context_takeover . cfg client_no_context_takeover
+    : b into ? is_server . cfg client_no_context_takeover . cfg server_no_context_takeover
+    : !ZDeflate CompressErr dn ( raw_deflate_new dwin 6 )
+    ?? dn {
+        F _ → { ^ @ !WsDeflate WsErr { F WsOther } }
+        T deflater → {
+            : !ZInflate CompressErr inr ( raw_inflate_new 15 )
+            ?? inr {
+                F _ → {
+                    ( raw_deflate_free deflater )
+                    ^ @ !WsDeflate WsErr { F WsOther }
+                }
+                T inflater → {
+                    ^ @ !WsDeflate WsErr { T @ WsDeflate { deflater inflater dnto into 64 T } }
+                }
+            }
+        }
+    }
+}
+
+@ ws_deflate_free WsDeflate d → v {
+    ( raw_deflate_free . d deflater )
+    ( raw_inflate_free . d inflater )
+}
+
+@ __ws_compresserr_to_wserr CompressErr e → WsErr {
+    ^ ?? e {
+        CompressBufTooSmall → @ WsErr { WsMessageTooLarge }
+        _ → @ WsErr { WsOther }
+    }
+}
+
+// ── Send path ─────────────────────────────────────────────────────────
+
+// OR the RSV1 (0x40) compressed-message bit into a serialized frame's
+// first byte. Position is identical for masked + unmasked frames.
+@ __ws_set_rsv1 ( Vec u ) frame → v {
+    ? > ( vec_len [u] frame ) 0 {
+        : *u p ( vec_data [u] frame )
+        = . p 0 # u | & 255 # i . p 0 64
+    } {}
+}
+
+// Drop the trailing `00 00 FF FF` Z_SYNC_FLUSH marker (RFC 7692 §7.2.1).
+// If that empties the payload, emit a single 0x00 (an empty
+// non-compressed DEFLATE block) so the frame still carries data.
+@ __ws_strip_deflate_tail ( Vec u ) comp → v {
+    : i cn ( vec_len [u] comp )
+    ? >= cn 4 {
+        : *u p ( vec_data [u] comp )
+        ? & & & == # i . p - cn 4 0 == # i . p - cn 3 0
+        == # i . p - cn 2 255 == # i . p - cn 1 255 {
+            : b _t ( vec_set_len [u] comp - cn 4 )
+        } {}
+    } {}
+    ? == ( vec_len [u] comp ) 0 { ( vec_push [u] comp # u 0 ) } {}
+}
+
+// Write a single compressed frame (fin=1, RSV1=1) to `conn`, masked for a
+// client, unmasked for a server.
+@ __ws_write_deflated_frame TcpConn conn i opcode ( Vec u ) comp b client → !v WsErr {
+    : !( Vec u ) WsErr sr ? client
+    ( __ws_serialize_masked_random opcode comp )
+    ( ws_serialize_frame T opcode comp )
+    ?? sr {
+        F e → { ^ @ !v WsErr { F e } }
+        T out → {
+            ( __ws_set_rsv1 out )
+            : !v NetErr wr ( tcp_write_all conn out )
+            ( vec_free [u] out )
+            ?? wr {
+                T _ → { ^ @ !v WsErr { T 0 } }
+                F _ → { ^ @ !v WsErr { F WsWriteFailed } }
+            }
+        }
+    }
+}
+
+// Serialize a masked client frame with a fresh CSPRNG masking key (the
+// same key discipline as ws_client_write_frame, RFC 6455 §10.3).
+@ __ws_serialize_masked_random i opcode ( Vec u ) payload → !( Vec u ) WsErr {
+    : i r ( rand_u64 )
+    : i m0 & 255 r
+    : i m1 & 255 >> r 8
+    : i m2 & 255 >> r 16
+    : i m3 & 255 >> r 24
+    ^ ( ws_serialize_frame_masked T opcode payload m0 m1 m2 m3 )
+}
+
+// Compress + send one message. Payloads below `min_size` are sent
+// uncompressed (RSV1=0) since tiny inputs usually grow under DEFLATE.
+@ __ws_send_message_deflate WsDeflate d TcpConn conn i opcode ( Vec u ) payload b client → !v WsErr {
+    : i n ( vec_len [u] payload )
+    ? < n . d min_size {
+        ^ ? client
+        ( ws_client_write_frame conn T opcode payload )
+        ( ws_write_frame conn T opcode payload )
+    } {}
+    : !( Vec u ) CompressErr cr ( raw_deflate_block . d deflater payload )
+    ?? cr {
+        F e → { ^ @ !v WsErr { F ( __ws_compresserr_to_wserr e ) } }
+        T comp → {
+            ? . d deflate_no_takeover { ( raw_deflate_reset . d deflater ) } {}
+            ( __ws_strip_deflate_tail comp )
+            : !v WsErr r ( __ws_write_deflated_frame conn opcode comp client )
+            ( vec_free [u] comp )
+            ^ r
+        }
+    }
+}
+
+@ ws_send_text_deflate WsDeflate d TcpConn conn s text → !v WsErr {
+    : ( Vec u ) buf ( bytes_from_str text )
+    : !v WsErr r ( __ws_send_message_deflate d conn ( ws_opcode_text ) buf F )
+    ( vec_free [u] buf )
+    ^ r
+}
+
+@ ws_send_binary_deflate WsDeflate d TcpConn conn ( Vec u ) data → !v WsErr {
+    ^ ( __ws_send_message_deflate d conn ( ws_opcode_binary ) data F )
+}
+
+@ ws_client_send_text_deflate WsDeflate d TcpConn conn s text → !v WsErr {
+    : ( Vec u ) buf ( bytes_from_str text )
+    : !v WsErr r ( __ws_send_message_deflate d conn ( ws_opcode_text ) buf T )
+    ( vec_free [u] buf )
+    ^ r
+}
+
+@ ws_client_send_binary_deflate WsDeflate d TcpConn conn ( Vec u ) data → !v WsErr {
+    ^ ( __ws_send_message_deflate d conn ( ws_opcode_binary ) data T )
+}
+
+// ── Receive path ──────────────────────────────────────────────────────
+
+// Inflate a compressed WsMessage in place, validating UTF-8 for text after
+// decompression. The decompressed size is capped at lim.max_message_bytes
+// (decompression-bomb guard). Frees the original compressed payload.
+@ __ws_inflate_message WsDeflate d WsLimits lim WsMessage msg → !WsMessage WsErr {
+    ? ! . msg compressed { ^ @ !WsMessage WsErr { T msg } } {}
+    : i op . msg opcode
+    : ( Vec u ) comp . msg payload
+    : ( Vec u ) framed ( vec_new [u] )
+    ( vec_extend [u] framed comp )
+    ( vec_push [u] framed # u 0 )
+    ( vec_push [u] framed # u 0 )
+    ( vec_push [u] framed # u 255 )
+    ( vec_push [u] framed # u 255 )
+    : !( Vec u ) CompressErr ir ( raw_inflate_block . d inflater framed . lim max_message_bytes )
+    ( vec_free [u] framed )
+    ? . d inflate_no_takeover { ( raw_inflate_reset . d inflater ) } {}
+    ?? ir {
+        F e → {
+            ( vec_free [u] comp )
+            ^ @ !WsMessage WsErr { F ( __ws_compresserr_to_wserr e ) }
+        }
+        T plain → {
+            ( vec_free [u] comp )
+            ? & == op 1 ! ( ws_validate_utf8 plain ) {
+                ( vec_free [u] plain )
+                ^ @ !WsMessage WsErr { F WsInvalidUtf8 }
+            } {}
+            ^ @ !WsMessage WsErr { T @ WsMessage { op F plain } }
+        }
+    }
+}
+
+@ ws_read_message_deflate WsDeflate d TcpConn conn WsLimits lim → !WsMessage WsErr {
+    : !WsMessage WsErr mr ( __ws_read_message_ex conn lim F T )
+    ?? mr {
+        F e → { ^ @ !WsMessage WsErr { F e } }
+        T msg → { ^ ( __ws_inflate_message d lim msg ) }
+    }
+}
+
+@ ws_client_read_message_deflate WsDeflate d TcpConn conn WsLimits lim → !WsMessage WsErr {
+    : !WsMessage WsErr mr ( __ws_read_message_ex conn lim T T )
+    ?? mr {
+        F e → { ^ @ !WsMessage WsErr { F e } }
+        T msg → { ^ ( __ws_inflate_message d lim msg ) }
+    }
+}
+
+// ── Serve loops (deflate-aware) ───────────────────────────────────────
+
+@ __ws_serve_messages_deflate WsDeflate d TcpConn conn WsLimits lim ( @ !v WsErr WsMessage ) handler b client → !v WsErr {
+    : ~ b done F
+    : ~ b clean_close F
+    : ~ WsErr last WsOther
+    ~ ! done {
+        : !WsMessage WsErr mr ? client
+        ( ws_client_read_message_deflate d conn lim )
+        ( ws_read_message_deflate d conn lim )
+        ?? mr {
+            T msg → {
+                : !v WsErr hr ( handler msg )
+                ( ws_message_free msg )
+                ?? hr {
+                    T _ → {}
+                    F he → { = last he = done T }
+                }
+            }
+            F we → {
+                = last we
+                = done T
+                ?? we {
+                    WsClosedByPeer → { = clean_close T }
+                    _ → {}
+                }
+            }
+        }
+    }
+    // Close frames are never compressed (RFC 7692 §6).
+    : i code ? clean_close 1000 ( __ws_err_to_close last )
+    : !v WsErr _cr ? client
+    ( ws_client_send_close conn code `` )
+    ( ws_send_close conn code `` )
+    ?? _cr { T _ → {} F _ → {} }
+    ? clean_close {
+        ^ @ !v WsErr { T 0 }
+    } {
+        ^ @ !v WsErr { F last }
+    }
+}
+
+@ ws_serve_messages_deflate WsDeflate d TcpConn conn WsLimits lim ( @ !v WsErr WsMessage ) handler → !v WsErr {
+    ^ ( __ws_serve_messages_deflate d conn lim handler F )
+}
+
+@ ws_client_serve_messages_deflate WsDeflate d TcpConn conn WsLimits lim ( @ !v WsErr WsMessage ) handler → !v WsErr {
+    ^ ( __ws_serve_messages_deflate d conn lim handler T )
+}
+
+// ── Server handshake convenience ──────────────────────────────────────
+
+// Negotiate permessage-deflate (if the client offered it and `policy`
+// enables it), write the 101 response with the agreed
+// `Sec-WebSocket-Extensions` header, and return the context. The result is
+// always a WsDeflate; check `ws_deflate_active` (F ⇒ the extension was not
+// negotiated and the connection is a plain, uncompressed WebSocket). Either
+// way ws_deflate_free is safe. `policy` gates the feature and may tighten
+// the server's own compressor (force no-context-takeover, lower its window).
+@ ws_perform_handshake_deflate TcpConn conn HttpRequest req ? String subprotocol WsDeflateConfig policy → !WsDeflate WsErr {
+    : !HttpResponse WsErr rr ( ws_handshake_response_for req subprotocol )
+    ?? rr {
+        F e → { ^ @ !WsDeflate WsErr { F e } }
+        T resp → {
+            : ~ b negotiated F
+            : ~ WsDeflateConfig agreed ( ws_deflate_default_config )
+            ? . policy enabled {
+                : ?String ext ( header_get . req headers `Sec-WebSocket-Extensions` )
+                ?? ext {
+                    T ev → {
+                        : ?WsDeflateConfig pc ( ws_deflate_parse_extensions ( string_data ev ) )
+                        ?? pc {
+                            T cfg → {
+                                : b snto ? . policy server_no_context_takeover T . cfg server_no_context_takeover
+                                : b cnto . cfg client_no_context_takeover
+                                : i swb ? < . policy server_max_window_bits . cfg server_max_window_bits . policy server_max_window_bits . cfg server_max_window_bits
+                                = agreed @ WsDeflateConfig { T snto cnto swb . cfg client_max_window_bits }
+                                = negotiated T
+                            }
+                            F _ → {}
+                        }
+                        ( string_free ev )
+                    }
+                    F _ → {}
+                }
+            } {}
+            ? negotiated {
+                : String hv ( ws_deflate_response_header agreed )
+                ( response_set_header resp `Sec-WebSocket-Extensions` ( string_data hv ) )
+                ( string_free hv )
+            } {}
+            : ( Vec u ) wire ( response_serialize resp )
+            : !v NetErr wr ( tcp_write_all conn wire )
+            ( vec_free [u] wire )
+            ( http_response_free resp )
+            ?? wr {
+                F _ → { ^ @ !WsDeflate WsErr { F WsHandshakeWriteFailed } }
+                T _ → {
+                    ? negotiated {
+                        ^ ( ws_deflate_make agreed T )
+                    } {
+                        : ZDeflate nd @ ZDeflate { # *u 0 }
+                        : ZInflate ni @ ZInflate { # *u 0 }
+                        ^ @ !WsDeflate WsErr { T @ WsDeflate { nd ni F F 64 F } }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Client handshake + connect convenience ────────────────────────────
+
+// Client handshake that offers permessage-deflate and parses the server's
+// response. Returns the negotiated config — its `enabled` field is F when
+// the server declined. Mirrors ws_client_handshake but adds the
+// Sec-WebSocket-Extensions offer and inspects the response head.
+@ ws_client_handshake_deflate TcpConn conn s host s path ? String subprotocol WsDeflateConfig cfg → !WsDeflateConfig WsErr {
+    : ( Vec u ) nonce ( vec_with_cap [u] 16 )
+    : i r0 ( rand_u64 )
+    : i r1 ( rand_u64 )
+    : ~ i bi 0
+    ~ < bi 8 {
+        ( vec_push [u] nonce # u & 255 >> r0 * bi 8 )
+        = bi + bi 1
+    }
+    = bi 0
+    ~ < bi 8 {
+        ( vec_push [u] nonce # u & 255 >> r1 * bi 8 )
+        = bi + bi 1
+    }
+    : String key64 ( b64_encode_vec nonce )
+    ( vec_free [u] nonce )
+    : ( Vec u ) req ( vec_new [u] )
+    ( bytes_extend_str req `GET ` )
+    ( bytes_extend_str req path )
+    ( bytes_extend_str req ` HTTP/1.1\r\nHost: ` )
+    ( bytes_extend_str req host )
+    ( bytes_extend_str req `\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: ` )
+    ( bytes_extend_str req ( string_data key64 ) )
+    ( bytes_extend_str req `\r\nSec-WebSocket-Version: 13\r\n` )
+    : String offer ( ws_deflate_offer_header cfg )
+    ( bytes_extend_str req `Sec-WebSocket-Extensions: ` )
+    ( bytes_extend_str req ( string_data offer ) )
+    ( bytes_extend_str req `\r\n` )
+    ( string_free offer )
+    ?? subprotocol {
+        T sp → {
+            ( bytes_extend_str req `Sec-WebSocket-Protocol: ` )
+            ( bytes_extend_str req ( string_data sp ) )
+            ( bytes_extend_str req `\r\n` )
+        }
+        F _ → {}
+    }
+    ( bytes_extend_str req `\r\n` )
+    : !v NetErr wr ( tcp_write_all conn req )
+    ( vec_free [u] req )
+    ?? wr {
+        T _ → {}
+        F _ → {
+            ( string_free key64 )
+            ^ @ !WsDeflateConfig WsErr { F WsConnectFailed }
+        }
+    }
+    : !( Vec u ) WsErr hr ( __ws_read_http_head conn )
+    ?? hr {
+        F e → {
+            ( string_free key64 )
+            ^ @ !WsDeflateConfig WsErr { F e }
+        }
+        T head → {
+            ? ! ( __ws_status_101 head ) {
+                ( vec_free [u] head )
+                ( string_free key64 )
+                ^ @ !WsDeflateConfig WsErr { F WsClientBadStatus }
+            } {}
+            : String expect ( ws_accept_key ( string_data key64 ) )
+            ( string_free key64 )
+            : ?String got ( __ws_head_get_value head `Sec-WebSocket-Accept` )
+            : ~ b accept_ok F
+            ?? got {
+                T gv → {
+                    = accept_ok != 0 ( nurl_str_eq ( string_data gv ) ( string_data expect ) )
+                    ( string_free gv )
+                }
+                F _ → {}
+            }
+            ( string_free expect )
+            ? ! accept_ok {
+                ( vec_free [u] head )
+                ^ @ !WsDeflateConfig WsErr { F WsClientBadAccept }
+            } {}
+            : ?String ext ( __ws_head_get_value head `Sec-WebSocket-Extensions` )
+            ( vec_free [u] head )
+            : ~ WsDeflateConfig result @ WsDeflateConfig { F F F 15 15 }
+            ?? ext {
+                T ev → {
+                    : ?WsDeflateConfig pc ( ws_deflate_parse_extensions ( string_data ev ) )
+                    ?? pc {
+                        T c → { = result c }
+                        F _ → {}
+                    }
+                    ( string_free ev )
+                }
+                F _ → {}
+            }
+            ^ @ !WsDeflateConfig WsErr { T result }
+        }
+    }
+}
+
+// Dial + handshake offering permessage-deflate in one shot. On success the
+// returned WsDeflateConn carries the live client and, if the server agreed,
+// a permessage-deflate context (`have_deflate`). When declined the context
+// is null and ws_deflate_free is a no-op, so the teardown is uniform:
+// ws_deflate_free the context, then ws_client_close the client.
+@ ws_connect_deflate s url ? String subprotocol WsDeflateConfig cfg → !WsDeflateConn WsErr {
+    : ?WsUrl pu ( __ws_parse_url url )
+    ?? pu {
+        F _ → { ^ @ !WsDeflateConn WsErr { F WsBadUrl } }
+        T u → {
+            : i craw ? . u tls
+            ( nurl_tcp_connect_tls ( string_data . u host ) . u port 1 )
+            ( nurl_tcp_connect ( string_data . u host ) . u port )
+            ? == craw 0 {
+                ( ws_url_free u )
+                ^ @ !WsDeflateConn WsErr { F WsConnectFailed }
+            } {}
+            : i ek ( nurl_tcp_err_kind craw )
+            ? != ek 0 {
+                ( nurl_tcp_close craw )
+                ( ws_url_free u )
+                ^ @ !WsDeflateConn WsErr { F WsConnectFailed }
+            } {}
+            : s crp # s craw
+            : TcpConn conn @ TcpConn { crp }
+            : !WsDeflateConfig WsErr hsr ( ws_client_handshake_deflate conn ( string_data . u host ) ( string_data . u path ) subprotocol cfg )
+            ( ws_url_free u )
+            ?? hsr {
+                F e → {
+                    ( tcp_close_conn conn )
+                    ^ @ !WsDeflateConn WsErr { F e }
+                }
+                T ncfg → {
+                    : WsClient client @ WsClient { conn }
+                    ? . ncfg enabled {
+                        : !WsDeflate WsErr mk ( ws_deflate_make ncfg F )
+                        ?? mk {
+                            T dctx → {
+                                ^ @ !WsDeflateConn WsErr { T @ WsDeflateConn { client T dctx } }
+                            }
+                            F e → {
+                                ( tcp_close_conn conn )
+                                ^ @ !WsDeflateConn WsErr { F e }
+                            }
+                        }
+                    } {
+                        // Server declined: carry a null context. Its streams
+                        // are 0, so ws_deflate_free is a safe no-op and the
+                        // caller need not special-case it.
+                        : ZDeflate nd @ ZDeflate { # *u 0 }
+                        : ZInflate ni @ ZInflate { # *u 0 }
+                        ^ @ !WsDeflateConn WsErr { T @ WsDeflateConn { client F @ WsDeflate { nd ni F F 64 F } } }
+                    }
+                }
+            }
+        }
     }
 }

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -5564,12 +5564,39 @@ void nurl_z_setup(void *zs, void *in, long long avail_in,
 long long nurl_z_total_out(const void *zs) {
     return (long long)((const z_stream*)zs)->total_out;
 }
+
+/* Granular input/output rebinders + counters for a PERSISTENT z_stream
+ * driven across many deflate/inflate calls (the gzip path above is
+ * one-shot; permessage-deflate keeps the stream alive for context
+ * takeover, so the NURL-side loop must repoint next_out into a grown
+ * buffer without disturbing zlib's internally-advanced next_in/avail_in).
+ * Each absorbs the platform field layout in C, mirroring nurl_z_setup. */
+void nurl_z_set_in(void *zs, void *in, long long avail_in) {
+    z_stream *s = (z_stream*)zs;
+    s->next_in  = (Bytef*)in;
+    s->avail_in = (uInt)avail_in;
+}
+void nurl_z_set_out(void *zs, void *out, long long avail_out) {
+    z_stream *s = (z_stream*)zs;
+    s->next_out  = (Bytef*)out;
+    s->avail_out = (uInt)avail_out;
+}
+long long nurl_z_avail_in(const void *zs)  { return (long long)((const z_stream*)zs)->avail_in; }
+long long nurl_z_avail_out(const void *zs) { return (long long)((const z_stream*)zs)->avail_out; }
 #else
 void nurl_z_setup(void *zs, void *in, long long avail_in,
                   void *out, long long avail_out) {
     (void)zs; (void)in; (void)avail_in; (void)out; (void)avail_out;
 }
 long long nurl_z_total_out(const void *zs) { (void)zs; return 0; }
+void nurl_z_set_in(void *zs, void *in, long long avail_in) {
+    (void)zs; (void)in; (void)avail_in;
+}
+void nurl_z_set_out(void *zs, void *out, long long avail_out) {
+    (void)zs; (void)out; (void)avail_out;
+}
+long long nurl_z_avail_in(const void *zs)  { (void)zs; return 0; }
+long long nurl_z_avail_out(const void *zs) { (void)zs; return 0; }
 #endif
 
 


### PR DESCRIPTION
## What

Adds **per-message compression** to the WebSocket stack — RFC 7692
`permessage-deflate` — negotiated over `Sec-WebSocket-Extensions`, for
**both the server and the client**. This closes the last open stdlib
capability in the WebSocket area (tracked under *Stdlib gaps & polish*).

It is fully **opt-in and backward-compatible**: the existing
`ws_read_message` / `ws_serve_messages` / `ws_connect` paths still reject
the RSV1 bit exactly as before. Compression only kicks in through the new
`*_deflate` entry points after a successful extension handshake.

## How — three layers

**1. `stdlib/runtime.c`** — four tiny layout-absorbing `z_stream`
accessors (`nurl_z_set_in` / `set_out` / `avail_in` / `avail_out`). The
existing gzip path is one-shot; permessage-deflate keeps a `z_stream`
alive across messages (context takeover), so the NURL-side loop has to
rebind `next_out` into a grown buffer without disturbing zlib's
internally-advanced `next_in`.

**2. `stdlib/ext/compress.nu`** — a reusable **raw-DEFLATE streaming
codec** (`raw_deflate_*` / `raw_inflate_*`): a persistent `z_stream` with
raw (header-less) DEFLATE via negative `windowBits`, `Z_SYNC_FLUSH`,
sliding-window **context takeover**, and `*_reset` for the
no-context-takeover mode. `raw_inflate_block` caps output (a
decompression-bomb guard).

**3. `stdlib/ext/websocket.nu`** — the RFC 7692 layer:
- **Negotiation** (pure, offline-testable): `ws_deflate_parse_extensions`,
  `ws_deflate_offer_header`, `ws_deflate_response_header`.
- `WsFrame.rsv1` + an `allow_rsv1` reader flag; `WsMessage.compressed`.
- **Per-message deflate messaging** for server and client:
  `ws_send_text_deflate` / `ws_send_binary_deflate` /
  `ws_read_message_deflate` / `ws_serve_messages_deflate` and their
  `ws_client_*` mirrors.
- A `WsDeflate` context (`ws_deflate_make` / `ws_deflate_free`) and
  one-shot handshake helpers (`ws_perform_handshake_deflate`,
  `ws_connect_deflate`).

Honours `server_no_context_takeover` / `client_no_context_takeover` in
both directions and a peer-imposed window bound on our compressor; always
decompresses at window 15 (which accepts any encoder window ≤ 15).
`windowBits` 8 is treated as 9 (a libz raw-deflate limitation), documented
inline. Text payloads are UTF-8-validated **after** inflation;
decompression is capped at `WsLimits.max_message_bytes`.

## Tests & verification

- `compiler/tests/compress_rawdeflate.nu` — round-trip, context-takeover
  shrink, no-takeover determinism, empty, garbage rejection.
- `compiler/tests/ws_permessage_deflate.nu` — negotiation / window clamp /
  decline, cross-context round-trip with takeover, UTF-8-after-inflate,
  decompression-bomb cap.
- **Live loopback** (server thread + client): handshake negotiation →
  compressed echo → context takeover, verified end-to-end over real
  sockets.
- `examples/ws_deflate_echo.nu` showcases a compression-enabled echo
  server (browsers offer permessage-deflate by default).

Full build green with the **byte-identical bootstrap fixed point held**;
sanitized suite **SAN_FAIL 0** (ASan / UBSan / LSan clean, no leaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)