### PR TITLE
nurlweb: show v0.9.11 + track release version from CHANGELOG

### DIFF
--- a/nurlweb/public/index.html
+++ b/nurlweb/public/index.html
@@ -57,10 +57,10 @@
     </a>
   </div>
   <div class="stats">
-    <div class="stat"><strong data-fact="version">v0.9.10</strong><span>current release</span></div>
-    <div class="stat"><strong data-fact="compiler_lines">16,521</strong><span>lines of NURL in the compiler</span></div>
-    <div class="stat"><strong data-fact="tests">477</strong><span>compiler test programs</span></div>
-    <div class="stat"><strong data-fact="stdlib_modules">147</strong><span>stdlib modules</span></div>
+    <div class="stat"><strong data-fact="version">v0.9.11</strong><span>current release</span></div>
+    <div class="stat"><strong data-fact="compiler_lines">16,548</strong><span>lines of NURL in the compiler</span></div>
+    <div class="stat"><strong data-fact="tests">480</strong><span>compiler test programs</span></div>
+    <div class="stat"><strong data-fact="stdlib_modules">148</strong><span>stdlib modules</span></div>
     <div class="stat"><strong>10</strong><span>tested targets</span></div>
   </div>
   <p style="margin-top: 1.8rem; color: var(--fg-faint); font-size: 0.88rem;">
@@ -106,7 +106,7 @@
       <div class="card">
         <div class="icon">⟳</div>
         <h3>Self-hosting</h3>
-        <p>The compiler is <span data-fact="compiler_lines">16,521</span> lines of NURL. The bootstrap compiles it with itself twice and requires byte-identical LLVM IR on both rounds before a build is accepted.</p>
+        <p>The compiler is <span data-fact="compiler_lines">16,548</span> lines of NURL. The bootstrap compiles it with itself twice and requires byte-identical LLVM IR on both rounds before a build is accepted.</p>
       </div>
     </div>
   </div>
@@ -299,7 +299,7 @@
 <section id="stdlib">
   <div class="container">
     <div class="section-head">
-      <h2><span data-fact="stdlib_modules">147</span> stdlib modules, batteries included</h2>
+      <h2><span data-fact="stdlib_modules">148</span> stdlib modules, batteries included</h2>
       <p>Not stubs — production-hardened modules with their own test programs, leak-checked under AddressSanitizer.</p>
     </div>
 
@@ -343,7 +343,7 @@
     <div class="grid">
       <div class="card">
         <h3>The compiler itself</h3>
-        <p><span data-fact="compiler_lines">16,521</span> lines of NURL compile NURL. Every release must reproduce its own LLVM IR byte-for-byte through two self-compilation rounds — a fixed point, not a checksum.</p>
+        <p><span data-fact="compiler_lines">16,548</span> lines of NURL compile NURL. Every release must reproduce its own LLVM IR byte-for-byte through two self-compilation rounds — a fixed point, not a checksum.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/blob/main/compiler/nurlc.nu" target="_blank" rel="noopener">compiler/nurlc.nu</a></p>
       </div>
       <div class="card">
@@ -357,7 +357,7 @@
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/tree/main/nurlapi" target="_blank" rel="noopener">nurlapi/</a></p>
       </div>
       <div class="card">
-        <h3><span data-fact="examples">64</span> examples</h3>
+        <h3><span data-fact="examples">65</span> examples</h3>
         <p>From an Enigma machine and Game of Life to a distributed Push-To-Talk voice app, an HTTP/2 client, MCP servers, a Claude-powered agent, and a C64 emulator.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/tree/main/examples" target="_blank" rel="noopener">examples/</a></p>
       </div>
@@ -490,7 +490,7 @@ cd nurl
       </div>
       <div class="card">
         <h3>Changelog</h3>
-        <p>Every release documented in Keep-a-Changelog format with the reasoning behind each fix — currently at <span data-fact="version">v0.9.10</span>.</p>
+        <p>Every release documented in Keep-a-Changelog format with the reasoning behind each fix — currently at <span data-fact="version">v0.9.11</span>.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/blob/main/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG.md</a></p>
       </div>
       <div class="card">

--- a/tools/gen-site-facts.sh
+++ b/tools/gen-site-facts.sh
@@ -24,7 +24,14 @@ HTML="$ROOT/nurlweb/public/index.html"
 comma() { echo "$1" | sed -E ':a;s/([0-9])([0-9]{3})($|,)/\1,\2\3/;ta'; }
 
 # ── Compute the facts from the repo ────────────────────────────────────
-version="$(git -C "$ROOT" tag --sort=-version:refname 2>/dev/null | grep -E '^v[0-9]' | head -1)"
+# Version = the newest RELEASED section in CHANGELOG.md. The release PR
+# updates the changelog *before* the `v*` tag is cut, so sourcing the
+# version here means the site tracks a release in the same change instead
+# of lagging until the tag exists (which is what left nurlweb showing the
+# previous version). Fall back to the newest git tag, then v0.0.0.
+version="$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$ROOT/CHANGELOG.md" 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+[[ -n "$version" ]] && version="v$version"
+[[ -n "$version" ]] || version="$(git -C "$ROOT" tag --sort=-version:refname 2>/dev/null | grep -E '^v[0-9]' | head -1)"
 [[ -n "$version" ]] || version="v0.0.0"
 compiler_lines="$(comma "$(wc -l < "$ROOT/compiler/nurlc.nu")")"
 tests="$(comma "$(find "$ROOT/compiler/tests" -maxdepth 1 -name '*.nu' | wc -l | tr -d ' ')")"


### PR DESCRIPTION
After the v0.9.11 release, `nurl-lang.org` still showed **v0.9.10**.

## Why it lagged

The landing page carries release-coupled facts (`data-fact="version"`, line/test/module counts) generated by `tools/gen-site-facts.sh`. The version came from the newest **`git tag`** — but the release tag is cut *after* the release PR merges, so during the release the generator had no way to know the new version and kept emitting the previous one. The committed `index.html` is only regenerated at deploy (`predeploy` hook), so it stayed on v0.9.10.

## Fix

Source the site version from the **newest released section in `CHANGELOG.md`** (which the release PR updates in the same change), falling back to the newest git tag and then `v0.0.0`. Now the site tracks a release the moment its changelog entry lands — no waiting for the tag.

Regenerated `nurlweb/public/index.html` with the script:

| fact | before | after |
|---|---|---|
| version | v0.9.10 | **v0.9.11** |
| compiler_lines | 16,521 | 16,548 |
| tests | 477 | 480 |
| stdlib_modules | 147 | 148 |
| examples | 64 | 65 |

(The non-version counts are recomputed from the repo and had drifted; this keeps them honest too.)

The page stays 100% static at serve time — this only changes the committed source the `predeploy` hook would otherwise have produced. Deploy nurlweb to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrSVLma6iPMfozX6MT8mYL