### PR TITLE
ci: deploy nurlweb on v* tags (site tracks each release)

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy nurlweb
+
+# Deploys the landing site (nurlweb/) to Cloudflare whenever a `v*` release
+# tag is pushed — so nurl-lang.org's release-coupled facts (version,
+# line/test/module counts) refresh in lockstep with the release instead of
+# lagging behind it.
+#
+# `npm run deploy` runs the `predeploy` hook first, which regenerates the
+# facts from the tagged repo state (tools/gen-site-facts.sh) and re-syncs
+# the installer scripts (sync-installers) before `wrangler deploy`. The page
+# stays 100% static at serve time; this just rebuilds it from the source of
+# truth at publish.
+#
+# Requires two GitHub Actions repo secrets (shared with the registry/API
+# deploys):
+#   CLOUDFLARE_API_TOKEN   — a token with Workers edit rights
+#   CLOUDFLARE_ACCOUNT_ID  — your Cloudflare account id
+# When the token is unset / still the REPLACE_ME placeholder (e.g. on forks)
+# every step skips and the job is a green no-op.
+#
+# Also runnable manually from the Actions tab (Run workflow) to redeploy
+# without cutting a tag.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # `secrets` can't be used in an `if:` directly, so derive a boolean in
+    # job-level `env` (which may read secrets) and gate each step on it.
+    env:
+      DEPLOY_ENABLED: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_API_TOKEN != 'REPLACE_ME' }}
+    defaults:
+      run:
+        working-directory: nurlweb
+    steps:
+      - if: env.DEPLOY_ENABLED == 'true'
+        uses: actions/checkout@v4
+        # gen-site-facts.sh falls back to `git tag` for the version, so make
+        # sure tags are present in the checkout (the triggering tag is, but
+        # fetch them explicitly for the workflow_dispatch path too).
+        with:
+          fetch-depth: 0
+      - if: env.DEPLOY_ENABLED == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - if: env.DEPLOY_ENABLED == 'true'
+        run: npm ci
+      # `deploy` runs the `predeploy` hook (gen-site-facts + sync-installers)
+      # automatically, then `wrangler deploy`.
+      - name: Deploy
+        if: env.DEPLOY_ENABLED == 'true'
+        run: npm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -81,6 +81,15 @@ work. Point:
 `raw.githubusercontent.com` path). `$NURL_INSTALL_BASE` overrides the
 download base for internal mirrors / air-gapped installs.
 
+Pushing a `v*` tag also fires `.github/workflows/web-deploy.yml`, which
+runs `npm run deploy` in `nurlweb/`. Its `predeploy` hook regenerates the
+landing-page facts (`tools/gen-site-facts.sh`, version sourced from the top
+`CHANGELOG.md` section) and re-syncs the installer scripts before
+`wrangler deploy`, so `nurl-lang.org` refreshes its version and counts in
+lockstep with each release. The job is a green no-op when
+`CLOUDFLARE_API_TOKEN` is unset (forks), and can also be run manually from
+the Actions tab.
+
 ## Status / caveats
 
 - The Linux client path (download → verify → unpack → run) is verified


### PR DESCRIPTION
Closes the loop behind "nurlweb didn't update with the release": after v0.9.11 the site still showed v0.9.10 because nothing redeploys it on a tag.

## What this adds

`.github/workflows/web-deploy.yml` — on a `v*` tag push (or manual dispatch) it runs `npm run deploy` in `nurlweb/`. The `deploy` script's `predeploy` hook:

1. regenerates the landing-page facts from the **tagged repo state** (`tools/gen-site-facts.sh` — version, compiler lines, test/stdlib/example counts), then
2. re-syncs `public/install.sh` / `install.ps1` from `tools/get-nurl.*`,

before `wrangler deploy`. So `nurl-lang.org` refreshes its version and counts **in lockstep with each release**, with no manual redeploy.

## Convention

Mirrors the existing `registry-deploy.yml` / `api-deploy.yml`:
- Gated on `DEPLOY_ENABLED = secrets.CLOUDFLARE_API_TOKEN != '' && != 'REPLACE_ME'`; every step is `if:`-gated so it's a **green no-op** when the secret is unset (forks).
- Uses the same `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` repo secrets already wired for the registry/API deploys.
- `fetch-depth: 0` so the version fallback to `git tag` has tags available.

Also documented in `RELEASING.md`.

## Note

Requires `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` to be set as repo Actions secrets (same as the registry/API workflows). If they're set, future `v*` tags deploy nurlweb automatically; if not, the job is a harmless no-op until they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrSVLma6iPMfozX6MT8mYL