### PR TITLE
Actionable error when clang is missing (the build-step dependency)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,6 +69,27 @@ least load) and, on a missing-shared-library loader error, prints the
 offending `.so` plus a package-manager hint instead of failing cryptically
 at first use.
 
+### Build-time dependency: an LLVM C compiler (clang)
+
+Running the toolchain (e.g. `nurlc`) needs nothing but libc, but *building*
+a program does: `nurlc` emits LLVM IR (`.ll`), which `clang` lowers to a
+native binary and links against `runtime.o`. gcc/cc cannot consume LLVM IR,
+so this step genuinely requires clang (or another LLVM-based `cc`). Because
+`nurlpkg install <tool>` compiles the package from source, it inherits this
+requirement.
+
+This is *not* bundled (a full LLVM toolchain would dwarf the install). So:
+
+- `nurl.sh` honours `$CLANG`, otherwise probes `clang` / `clang-<N>` / a
+  clang-flavoured `cc`, and on absence exits with install guidance
+  (`apt install clang` / `dnf install clang` / `apk add clang` / …) instead
+  of a raw `clang: command not found`.
+- `get-nurl.sh` prints the same heads-up at install time when no `clang` is
+  on `PATH`, so the requirement is known before the first `nurlpkg install`.
+
+(A prebuilt-binary package channel — install a tool without a local
+compiler — is the future bombproofing here; see the registry roadmap.)
+
 ## Front-door wiring (nurlweb)
 
 `nurl-lang.org` should serve the two installer scripts so the one-liners

--- a/nurl.sh
+++ b/nurl.sh
@@ -135,6 +135,41 @@ else
     OPT="${NURL_OPT:--O2}"
 fi
 
+# Resolve an LLVM C compiler to lower nurlc's LLVM IR (.ll) into a native
+# binary. This step *requires* clang (or another LLVM-based `cc`): nurlc
+# emits LLVM IR, which gcc/cc cannot consume. Honour an explicit $CLANG,
+# then probe `clang` and a few versioned names, and otherwise fail with
+# install guidance instead of a raw "clang: command not found".
+resolve_clang() {
+    if [[ -n "${CLANG:-}" ]] && command -v "$CLANG" >/dev/null 2>&1; then
+        return 0
+    fi
+    local c
+    for c in clang clang-20 clang-19 clang-18 clang-17 clang-16 clang-15 clang-14 cc; do
+        # `cc` is accepted only if it is actually clang (it can be gcc).
+        if command -v "$c" >/dev/null 2>&1; then
+            if [[ "$c" == cc ]] && ! "$c" --version 2>/dev/null | grep -qi clang; then
+                continue
+            fi
+            CLANG="$c"
+            return 0
+        fi
+    done
+    {
+        echo "ERROR: NURL needs an LLVM C compiler (clang) to build a program."
+        echo "       nurlc emits LLVM IR, which clang lowers to a native binary;"
+        echo "       gcc/cc cannot do this. Install clang and re-run:"
+        echo "         Debian/Ubuntu:  sudo apt-get install -y clang"
+        echo "         Fedora/RHEL:    sudo dnf install -y clang"
+        echo "         Alpine:         sudo apk add clang"
+        echo "         Arch:           sudo pacman -S clang"
+        echo "         macOS:          xcode-select --install   # or: brew install llvm"
+        echo "       Or set CLANG=/path/to/clang if it is installed under another name."
+    } >&2
+    exit 1
+}
+resolve_clang
+
 # Debug flag passthrough. Without `!dbg` metadata in the IR, `-g` yields
 # only crude line info from the inlined .ll filename; still useful in
 # debuggers for frame isolation and symbol demangling.
@@ -150,7 +185,7 @@ fi
 # --emit-asm: stop after clang -S, skip linking (no runtime needed for .s).
 if [[ $EMIT_ASM -eq 1 ]]; then
     echo "[2/2] $LLFILE → $SFILE  ($OPT${DEBUG_FLAGS[*]:+ ${DEBUG_FLAGS[*]}} -S)"
-    clang $OPT "${DEBUG_FLAGS[@]}" -S "$LLFILE" -o "$SFILE"
+    "$CLANG" $OPT "${DEBUG_FLAGS[@]}" -S "$LLFILE" -o "$SFILE"
     echo ""
     echo "Done: $SFILE"
     exit 0
@@ -287,7 +322,7 @@ if [[ "${NURL_SAN:-0}" == "1" ]]; then
             fi
         done
         # shellcheck disable=SC2086
-        clang $CFLAGS_SAN -c "$SCRIPT_DIR/stdlib/runtime.c" -o "$SAN_RUNTIME"
+        "$CLANG" $CFLAGS_SAN -c "$SCRIPT_DIR/stdlib/runtime.c" -o "$SAN_RUNTIME"
     fi
     RUNTIME_TO_LINK="$SAN_RUNTIME"
 elif [[ $DEBUG_INFO -eq 1 ]]; then
@@ -303,7 +338,7 @@ elif [[ $DEBUG_INFO -eq 1 ]]; then
             fi
         done
         # shellcheck disable=SC2086
-        clang $CFLAGS_DBG -c "$SCRIPT_DIR/stdlib/runtime.c" -o "$DBG_RUNTIME"
+        "$CLANG" $CFLAGS_DBG -c "$SCRIPT_DIR/stdlib/runtime.c" -o "$DBG_RUNTIME"
     fi
     RUNTIME_TO_LINK="$DBG_RUNTIME"
 fi
@@ -319,7 +354,7 @@ echo "[2/2] $LLFILE → $OUTBASE  ($OPT${LTO_FLAG:+ $LTO_FLAG}${DEBUG_FLAGS[*]:+
 # that imports nothing DB-related never inherits libpq/libsqlite3 just
 # because the build machine had them. Positional: it must precede the
 # `-l` libraries to govern them.
-clang $OPT $LTO_FLAG -Wl,--as-needed "${DEBUG_FLAGS[@]}" "${SAN_LINK_FLAGS[@]}" "$LLFILE" "$RUNTIME_TO_LINK" "${EXTRA_OBJS[@]}" -o "$OUTBASE" -lm -lpthread "${EXTRA_LIBS[@]}"
+"$CLANG" $OPT $LTO_FLAG -Wl,--as-needed "${DEBUG_FLAGS[@]}" "${SAN_LINK_FLAGS[@]}" "$LLFILE" "$RUNTIME_TO_LINK" "${EXTRA_OBJS[@]}" -o "$OUTBASE" -lm -lpthread "${EXTRA_LIBS[@]}"
 
 echo ""
 echo "Done: $OUTBASE"

--- a/nurlweb/public/install.sh
+++ b/nurlweb/public/install.sh
@@ -154,3 +154,17 @@ info "Or just add the bin dir to PATH:"
 info "    export PATH=\"$PREFIX/bin:\$PATH\""
 info ""
 info "Then:  nurlc --version   ·   nurlpkg install argz-demo"
+
+# Building a program (and therefore `nurlpkg install <tool>`, which compiles
+# the package from source) needs an LLVM C compiler — `nurlc` emits LLVM IR
+# that clang lowers to a native binary; gcc/cc cannot. The toolchain itself
+# runs without it, so this is a heads-up, not a failure.
+if ! command -v clang >/dev/null 2>&1; then
+    info ""
+    info "Heads-up: to build programs or 'nurlpkg install' a tool you also need"
+    info "clang (an LLVM C compiler) on PATH. Install it with, e.g.:"
+    info "    Debian/Ubuntu:  sudo apt-get install -y clang"
+    info "    Fedora/RHEL:    sudo dnf install -y clang"
+    info "    Alpine:         sudo apk add clang"
+    info "    Arch:           sudo pacman -S clang"
+fi

--- a/tools/get-nurl.sh
+++ b/tools/get-nurl.sh
@@ -154,3 +154,17 @@ info "Or just add the bin dir to PATH:"
 info "    export PATH=\"$PREFIX/bin:\$PATH\""
 info ""
 info "Then:  nurlc --version   ·   nurlpkg install argz-demo"
+
+# Building a program (and therefore `nurlpkg install <tool>`, which compiles
+# the package from source) needs an LLVM C compiler — `nurlc` emits LLVM IR
+# that clang lowers to a native binary; gcc/cc cannot. The toolchain itself
+# runs without it, so this is a heads-up, not a failure.
+if ! command -v clang >/dev/null 2>&1; then
+    info ""
+    info "Heads-up: to build programs or 'nurlpkg install' a tool you also need"
+    info "clang (an LLVM C compiler) on PATH. Install it with, e.g.:"
+    info "    Debian/Ubuntu:  sudo apt-get install -y clang"
+    info "    Fedora/RHEL:    sudo dnf install -y clang"
+    info "    Alpine:         sudo apk add clang"
+    info "    Arch:           sudo pacman -S clang"
+fi


### PR DESCRIPTION
Follow-up to the libc-only toolchain fix. On the ODROID, v0.9.11 now installs and `nurlpkg install argz-demo` resolves + downloads deps fine — then the **build** step failed:

```
nurlpkg: compile failed:
/home/odroid/.nurl/nurl.sh: line 322: clang: command not found
```

## Why

`nurlpkg install <tool>` compiles the package from source, and NURL's pipeline is `nurlc → LLVM IR (.ll) → clang → native binary`. `clang` (or another LLVM-based `cc`) is genuinely required — **gcc/cc cannot consume LLVM IR**, so there's no non-LLVM fallback. We don't bundle a full LLVM toolchain (it would dwarf the install), so the right move is to fail *clearly* and tell the user how to get clang.

## Changes

- **`nurl.sh`** — new `resolve_clang`: honours `$CLANG`, else probes `clang` / `clang-<N>` / a clang-flavoured `cc`; on absence prints install guidance and exits, instead of a raw `command not found`. All clang invocations now route through `"$CLANG"`. The probe runs only on the build/link path, so `--emit-ir` (IR only) still needs no compiler.

  ```
  ERROR: NURL needs an LLVM C compiler (clang) to build a program.
         nurlc emits LLVM IR, which clang lowers to a native binary;
         gcc/cc cannot do this. Install clang and re-run:
           Debian/Ubuntu:  sudo apt-get install -y clang
           Fedora/RHEL:    sudo dnf install -y clang
           Alpine:         sudo apk add clang
           Arch:           sudo pacman -S clang
           macOS:          xcode-select --install   # or: brew install llvm
         Or set CLANG=/path/to/clang if it is installed under another name.
  ```
  This message flows up through `nurlpkg`'s build spawn, so `nurlpkg install` shows it directly.

- **`get-nurl.sh`** — when no `clang` is on `PATH`, prints the same heads-up *at install time*, so the requirement is known before the first build. The toolchain itself runs without clang, so this is a note, not a failure. Re-synced `nurlweb/public/install.sh`.

- **`RELEASING.md`** — documents clang as the build-time dependency, and notes that a prebuilt-binary package channel is the future bombproofing for compiler-less installs.

## Verified

- Happy path (clang present): builds + runs.
- Missing-compiler path (empty `PATH`): clean actionable error, exit 1 — verified locally.
- `--emit-ir` still works with no compiler (probe is build-path only).

## Note on direction

This is the agreed baseline (clear error + docs). Making `nurlpkg install <tool>` work on a compiler-less box entirely — prebuilt binaries served from the registry, cargo-binstall style — is the larger follow-up and is left for a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrSVLma6iPMfozX6MT8mYL