### PR TITLE
Bundle a zig backend so building works on any box (no system clang)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,28 @@ jobs:
           ./build.sh --no-tests
           ./tools/nurlpkg/build.sh
 
+      # Bundle a self-contained zig so the installed toolchain can build
+      # programs (and `nurlpkg install`) with no system clang and immune to
+      # the box's LLVM version. zig 0.13 ships LLVM 18; keep it >= the clang
+      # used above so `zig cc -flto` can read the shipped runtime.o bitcode.
+      - name: Fetch bundled zig backend
+        run: |
+          ZIG_VER=0.13.0
+          case "${{ matrix.target }}" in
+            linux-x86_64-glibc) ZA=x86_64 ;;
+            linux-arm64-glibc)  ZA=aarch64 ;;
+            *) echo "no zig mapping for ${{ matrix.target }}" >&2; exit 1 ;;
+          esac
+          url="https://ziglang.org/download/${ZIG_VER}/zig-linux-${ZA}-${ZIG_VER}.tar.xz"
+          echo "Downloading $url"
+          curl -fsSL "$url" -o /tmp/zig.tar.xz
+          mkdir -p vendor
+          tar -xf /tmp/zig.tar.xz -C vendor
+          mv "vendor/zig-linux-${ZA}-${ZIG_VER}" vendor/zig
+          vendor/zig/zig version
+
       - name: Assemble relocatable prefix
-        run: NURL_HOME="$PWD/dist/nurl" ./tools/install-toolchain.sh
+        run: NURL_HOME="$PWD/dist/nurl" NURL_BUNDLE_ZIG="$PWD/vendor/zig" ./tools/install-toolchain.sh
 
       - name: Smoke test the assembled toolchain
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ critic.md
 output.txt
 stdlib/runtime.wasm.o.bind
 /dist/
+vendor/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,26 +69,44 @@ least load) and, on a missing-shared-library loader error, prints the
 offending `.so` plus a package-manager hint instead of failing cryptically
 at first use.
 
-### Build-time dependency: an LLVM C compiler (clang)
+### Building a program: the bundled zig backend
 
 Running the toolchain (e.g. `nurlc`) needs nothing but libc, but *building*
-a program does: `nurlc` emits LLVM IR (`.ll`), which `clang` lowers to a
-native binary and links against `runtime.o`. gcc/cc cannot consume LLVM IR,
-so this step genuinely requires clang (or another LLVM-based `cc`). Because
-`nurlpkg install <tool>` compiles the package from source, it inherits this
-requirement.
+a program does: `nurlc` emits LLVM IR (`.ll`), which an LLVM compiler lowers
+to a native binary and links against `runtime.o`. gcc/cc cannot consume LLVM
+IR. Because `nurlpkg install <tool>` compiles the package from source, it
+inherits this requirement — and on a fresh box that hit three walls in a
+row: no `clang`; clang too old to parse nurlc's opaque-pointer IR; and clang
+unable to read the release's newer LLVM bitcode.
 
-This is *not* bundled (a full LLVM toolchain would dwarf the install). So:
+The archive therefore **bundles a self-contained `zig`** (`zig cc`) as the
+default backend — it carries its own modern LLVM (opaque pointers just
+work), its own `lld` linker, and libc headers, so building needs **no system
+compiler at all** and is immune to the box's LLVM version. The release
+workflow downloads the per-arch zig (`Fetch bundled zig backend`) and
+`install-toolchain.sh` stages it at `<prefix>/zig/`, exactly where
+`nurl.sh` looks. Keep the bundled zig's LLVM ≥ the clang that built the
+release (zig 0.13 → LLVM 18), so `zig cc -flto` can read the shipped
+`runtime.o` bitcode. (~45 MB compressed per arch — the size cost of "just
+works".)
 
-- `nurl.sh` honours `$CLANG`, otherwise probes `clang` / `clang-<N>` / a
-  clang-flavoured `cc`, and on absence exits with install guidance
-  (`apt install clang` / `dnf install clang` / `apk add clang` / …) instead
-  of a raw `clang: command not found`.
-- `get-nurl.sh` prints the same heads-up at install time when no `clang` is
-  on `PATH`, so the requirement is known before the first `nurlpkg install`.
+`nurl.sh`'s compiler selection:
 
-(A prebuilt-binary package channel — install a tool without a local
-compiler — is the future bombproofing here; see the registry roadmap.)
+- Prefer the bundled zig (`<prefix>/zig/zig`, or `$NURL_ZIG`).
+- Else fall back to a system clang: honour `$CLANG`, probe `clang` /
+  `clang-<N>` / a clang-flavoured `cc`; pass `-Xclang -opaque-pointers` on
+  clang 13/14; reject clang < 13; on no compiler at all, exit with install
+  guidance instead of a raw `clang: command not found`.
+
+`nurl.sh` also links a feature library (`-lcurl` / `-lssl` / `-lsqlite3` /
+`-lpq` / `-lz` / `-lzstd`) **only when the emitted IR actually references
+that back-end's symbols** — so a feature-free program (the common tool)
+links against libc only and never demands a library the box may lack
+(naming `-lpq` unconditionally previously made even a hello-world fail to
+link where libpq was absent).
+
+(A prebuilt-binary package channel — install a tool with no local compile at
+all — remains the future bombproofing; see the registry roadmap.)
 
 ## Front-door wiring (nurlweb)
 

--- a/nurl.sh
+++ b/nurl.sh
@@ -168,7 +168,39 @@ resolve_clang() {
     } >&2
     exit 1
 }
-resolve_clang
+
+# ── Pick the compiler: bundled zig (preferred) or system clang ──────────
+# A bundled `zig cc` carries its own modern LLVM (so nurlc's opaque-pointer
+# IR just parses), its own lld linker, and libc headers — so building needs
+# no system clang at all and is immune to the system's LLVM version (the
+# two walls a fresh distro hit: `clang: not found`, and clang 14 rejecting
+# opaque pointers / unable to read the shipped bitcode). Point at it with
+# $NURL_ZIG, or ship it at <prefix>/zig/zig. Fall back to a system clang.
+ZIG_BIN="${NURL_ZIG:-$SCRIPT_DIR/zig/zig}"
+OPAQUE_FLAGS=()
+if [[ -x "$ZIG_BIN" ]]; then
+    CC=("$ZIG_BIN" cc)
+else
+    resolve_clang
+    CC=("$CLANG")
+    # nurlc emits LLVM IR with opaque pointers (`ptr`) — the default since
+    # LLVM 15. clang 14 needs `-opaque-pointers`; 13 and earlier can't parse
+    # them. (zig's bundled LLVM never needs this.) 15+/17+ need nothing.
+    CLANG_MAJOR="$("$CLANG" --version 2>/dev/null | sed -nE 's/.*version ([0-9]+).*/\1/p' | head -1)"
+    if [[ -n "$CLANG_MAJOR" && "$CLANG_MAJOR" -lt 15 ]]; then
+        if [[ "$CLANG_MAJOR" -ge 13 ]]; then
+            OPAQUE_FLAGS=(-Xclang -opaque-pointers)
+        else
+            {
+                echo "ERROR: clang $CLANG_MAJOR is too old to build NURL programs."
+                echo "       nurlc emits LLVM IR with opaque pointers (needs LLVM 14+)."
+                echo "       Install a newer clang (e.g. clang-15) and set CLANG=clang-15,"
+                echo "       or use the bundled zig backend (set NURL_ZIG=/path/to/zig)."
+            } >&2
+            exit 1
+        fi
+    fi
+fi
 
 # Debug flag passthrough. Without `!dbg` metadata in the IR, `-g` yields
 # only crude line info from the inlined .ll filename; still useful in
@@ -185,7 +217,7 @@ fi
 # --emit-asm: stop after clang -S, skip linking (no runtime needed for .s).
 if [[ $EMIT_ASM -eq 1 ]]; then
     echo "[2/2] $LLFILE → $SFILE  ($OPT${DEBUG_FLAGS[*]:+ ${DEBUG_FLAGS[*]}} -S)"
-    "$CLANG" $OPT "${DEBUG_FLAGS[@]}" -S "$LLFILE" -o "$SFILE"
+    "${CC[@]}" $OPT "${DEBUG_FLAGS[@]}" "${OPAQUE_FLAGS[@]}" -S "$LLFILE" -o "$SFILE"
     echo ""
     echo "Done: $SFILE"
     exit 0
@@ -216,58 +248,33 @@ if grep -qE '@canvas_(open|present|sleep|should_close|close|mouse_x|mouse_y|mous
     fi
 fi
 
-# Auto-link libcurl / OpenSSL / sqlite3 / libpq when the runtime was
-# built with the matching feature (build.sh drops stdlib/runtime.<name>
-# sentinels). Programs that don't pull those modules still link cleanly
-# without them because the symbols only resolve at link time.
-if [[ -f "$SCRIPT_DIR/stdlib/runtime.curl" ]]; then
-    if pkg-config --exists libcurl 2>/dev/null; then
-        # shellcheck disable=SC2046
-        EXTRA_LIBS+=( $(pkg-config --libs libcurl) )
-    else
-        EXTRA_LIBS+=( -lcurl )
-    fi
-fi
-if [[ -f "$SCRIPT_DIR/stdlib/runtime.openssl" ]]; then
-    if pkg-config --exists openssl 2>/dev/null; then
-        # shellcheck disable=SC2046
-        EXTRA_LIBS+=( $(pkg-config --libs openssl) )
-    else
-        EXTRA_LIBS+=( -lssl -lcrypto )
-    fi
-fi
-if [[ -f "$SCRIPT_DIR/stdlib/runtime.sqlite3" ]]; then
-    if pkg-config --exists sqlite3 2>/dev/null; then
-        # shellcheck disable=SC2046
-        EXTRA_LIBS+=( $(pkg-config --libs sqlite3) )
-    else
-        EXTRA_LIBS+=( -lsqlite3 )
-    fi
-fi
-if [[ -f "$SCRIPT_DIR/stdlib/runtime.pq" ]]; then
-    if pkg-config --exists libpq 2>/dev/null; then
-        # shellcheck disable=SC2046
-        EXTRA_LIBS+=( $(pkg-config --libs libpq) )
-    else
-        EXTRA_LIBS+=( -lpq )
-    fi
-fi
-if [[ -f "$SCRIPT_DIR/stdlib/runtime.z" ]]; then
-    if pkg-config --exists zlib 2>/dev/null; then
-        # shellcheck disable=SC2046
-        EXTRA_LIBS+=( $(pkg-config --libs zlib) )
-    else
-        EXTRA_LIBS+=( -lz )
-    fi
-fi
-if [[ -f "$SCRIPT_DIR/stdlib/runtime.zstd" ]]; then
-    if pkg-config --exists libzstd 2>/dev/null; then
-        # shellcheck disable=SC2046
-        EXTRA_LIBS+=( $(pkg-config --libs libzstd) )
-    else
-        EXTRA_LIBS+=( -lzstd )
-    fi
-fi
+# Auto-link libcurl / OpenSSL / sqlite3 / libpq / zlib / zstd — but ONLY
+# when *this program* actually references the back-end's symbols (detected
+# in the emitted IR), not merely because the runtime was built with the
+# feature. Two reasons:
+#   * Leanness: a program that imports none of these links against none of
+#     them; with LTO the dead runtime code is stripped anyway, but naming
+#     `-lpq` on the command line still forces the linker to *find* libpq —
+#     so an unconditional `-lpq` made even a hello-world fail to link on a
+#     box without the Postgres client. Gating on use keeps such a program
+#     at libc only.
+#   * Correctness: a program that does use the feature still gets its lib;
+#     one that doesn't never demands a library the target box may lack.
+# Each is also gated on the runtime.<name> sentinel (the runtime must have
+# been built with the back-end for the symbols to resolve at all).
+add_feature_lib() {
+    # $1 sentinel basename, $2 IR symbol regex, $3.. the link flags.
+    local sentinel="$1" sym="$2"; shift 2
+    [[ -f "$SCRIPT_DIR/stdlib/$sentinel" ]] || return 0
+    grep -qE "$sym" "$LLFILE" || return 0
+    EXTRA_LIBS+=( "$@" )
+}
+add_feature_lib runtime.curl    '@nurl_curl_'                                 -lcurl
+add_feature_lib runtime.openssl '@(EVP_|HKDF_|SSL_|HMAC_|RAND_bytes|X25519_)' -lssl -lcrypto
+add_feature_lib runtime.sqlite3 '@sqlite3_'                                   -lsqlite3
+add_feature_lib runtime.pq      '@PQ[A-Za-z]'                                 -lpq
+add_feature_lib runtime.z       '@(deflate|inflate|compress2|uncompress|compressBound)' -lz
+add_feature_lib runtime.zstd    '@ZSTD_'                                      -lzstd
 
 # Auto-link libopus / ALSA when the program references their FFI symbols
 # (pttvoice and any audio app). Linked only when actually used, so other
@@ -322,7 +329,7 @@ if [[ "${NURL_SAN:-0}" == "1" ]]; then
             fi
         done
         # shellcheck disable=SC2086
-        "$CLANG" $CFLAGS_SAN -c "$SCRIPT_DIR/stdlib/runtime.c" -o "$SAN_RUNTIME"
+        "${CC[@]}" $CFLAGS_SAN -c "$SCRIPT_DIR/stdlib/runtime.c" -o "$SAN_RUNTIME"
     fi
     RUNTIME_TO_LINK="$SAN_RUNTIME"
 elif [[ $DEBUG_INFO -eq 1 ]]; then
@@ -338,7 +345,7 @@ elif [[ $DEBUG_INFO -eq 1 ]]; then
             fi
         done
         # shellcheck disable=SC2086
-        "$CLANG" $CFLAGS_DBG -c "$SCRIPT_DIR/stdlib/runtime.c" -o "$DBG_RUNTIME"
+        "${CC[@]}" $CFLAGS_DBG -c "$SCRIPT_DIR/stdlib/runtime.c" -o "$DBG_RUNTIME"
     fi
     RUNTIME_TO_LINK="$DBG_RUNTIME"
 fi
@@ -354,7 +361,7 @@ echo "[2/2] $LLFILE → $OUTBASE  ($OPT${LTO_FLAG:+ $LTO_FLAG}${DEBUG_FLAGS[*]:+
 # that imports nothing DB-related never inherits libpq/libsqlite3 just
 # because the build machine had them. Positional: it must precede the
 # `-l` libraries to govern them.
-"$CLANG" $OPT $LTO_FLAG -Wl,--as-needed "${DEBUG_FLAGS[@]}" "${SAN_LINK_FLAGS[@]}" "$LLFILE" "$RUNTIME_TO_LINK" "${EXTRA_OBJS[@]}" -o "$OUTBASE" -lm -lpthread "${EXTRA_LIBS[@]}"
+"${CC[@]}" $OPT $LTO_FLAG -Wl,--as-needed "${OPAQUE_FLAGS[@]}" "${DEBUG_FLAGS[@]}" "${SAN_LINK_FLAGS[@]}" "$LLFILE" "$RUNTIME_TO_LINK" "${EXTRA_OBJS[@]}" -o "$OUTBASE" -lm -lpthread "${EXTRA_LIBS[@]}"
 
 echo ""
 echo "Done: $OUTBASE"

--- a/nurlweb/public/install.sh
+++ b/nurlweb/public/install.sh
@@ -156,13 +156,15 @@ info ""
 info "Then:  nurlc --version   ·   nurlpkg install argz-demo"
 
 # Building a program (and therefore `nurlpkg install <tool>`, which compiles
-# the package from source) needs an LLVM C compiler — `nurlc` emits LLVM IR
-# that clang lowers to a native binary; gcc/cc cannot. The toolchain itself
-# runs without it, so this is a heads-up, not a failure.
-if ! command -v clang >/dev/null 2>&1; then
+# the package from source) needs an LLVM compiler. The archive bundles a
+# self-contained `zig` for exactly this, so normally nothing is required.
+# Only if that bundle is somehow absent does the toolchain fall back to a
+# system clang — warn about it then, as a heads-up, not a failure.
+if [ ! -x "$PREFIX/zig/zig" ] && ! command -v clang >/dev/null 2>&1; then
     info ""
-    info "Heads-up: to build programs or 'nurlpkg install' a tool you also need"
-    info "clang (an LLVM C compiler) on PATH. Install it with, e.g.:"
+    info "Heads-up: this archive has no bundled zig backend, so to build"
+    info "programs or 'nurlpkg install' a tool you need clang (an LLVM C"
+    info "compiler) on PATH. Install it with, e.g.:"
     info "    Debian/Ubuntu:  sudo apt-get install -y clang"
     info "    Fedora/RHEL:    sudo dnf install -y clang"
     info "    Alpine:         sudo apk add clang"

--- a/tools/get-nurl.sh
+++ b/tools/get-nurl.sh
@@ -156,13 +156,15 @@ info ""
 info "Then:  nurlc --version   ·   nurlpkg install argz-demo"
 
 # Building a program (and therefore `nurlpkg install <tool>`, which compiles
-# the package from source) needs an LLVM C compiler — `nurlc` emits LLVM IR
-# that clang lowers to a native binary; gcc/cc cannot. The toolchain itself
-# runs without it, so this is a heads-up, not a failure.
-if ! command -v clang >/dev/null 2>&1; then
+# the package from source) needs an LLVM compiler. The archive bundles a
+# self-contained `zig` for exactly this, so normally nothing is required.
+# Only if that bundle is somehow absent does the toolchain fall back to a
+# system clang — warn about it then, as a heads-up, not a failure.
+if [ ! -x "$PREFIX/zig/zig" ] && ! command -v clang >/dev/null 2>&1; then
     info ""
-    info "Heads-up: to build programs or 'nurlpkg install' a tool you also need"
-    info "clang (an LLVM C compiler) on PATH. Install it with, e.g.:"
+    info "Heads-up: this archive has no bundled zig backend, so to build"
+    info "programs or 'nurlpkg install' a tool you need clang (an LLVM C"
+    info "compiler) on PATH. Install it with, e.g.:"
     info "    Debian/Ubuntu:  sudo apt-get install -y clang"
     info "    Fedora/RHEL:    sudo dnf install -y clang"
     info "    Alpine:         sudo apk add clang"

--- a/tools/install-toolchain.sh
+++ b/tools/install-toolchain.sh
@@ -33,7 +33,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PREFIX="${NURL_HOME:-$HOME/.nurl}"
 
 if [[ "${1:-}" == "--uninstall" ]]; then
-    rm -rf "$PREFIX/bin" "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/nurl.sh" "$PREFIX/env"
+    rm -rf "$PREFIX/bin" "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/zig" "$PREFIX/nurl.sh" "$PREFIX/env"
     echo "Removed NURL toolchain from $PREFIX"
     echo "(You may want to drop the 'source $PREFIX/env' line from your shell rc.)"
     exit 0
@@ -59,6 +59,27 @@ cp -a "$ROOT/stdlib/." "$PREFIX/stdlib/"
 
 # Build driver (resolves build/nurlc + stdlib/runtime.o relative to itself).
 install -m755 "$ROOT/nurl.sh" "$PREFIX/nurl.sh"
+
+# ── Bundle a self-contained zig backend (optional but recommended) ─────
+# `nurl.sh` prefers a bundled `zig cc` over a system clang: zig carries its
+# own modern LLVM (parses nurlc's opaque-pointer IR), its own lld linker
+# and libc headers, so *building* a program — and therefore
+# `nurlpkg install <tool>` — needs no system compiler and is immune to the
+# box's LLVM version. Point $NURL_BUNDLE_ZIG at an extracted zig dist (the
+# directory containing the `zig` binary and its `lib/`); the release
+# workflow downloads the per-arch dist and sets it. Copied to
+# $PREFIX/zig/, which is exactly where nurl.sh looks ($SCRIPT_DIR/zig/zig).
+ZIG_SRC="${NURL_BUNDLE_ZIG:-$ROOT/vendor/zig}"
+if [[ -x "$ZIG_SRC/zig" ]]; then
+    echo "Bundling zig backend from $ZIG_SRC"
+    rm -rf "$PREFIX/zig"
+    mkdir -p "$PREFIX/zig"
+    cp -a "$ZIG_SRC/." "$PREFIX/zig/"
+    chmod +x "$PREFIX/zig/zig"
+else
+    echo "Note: no bundled zig ($ZIG_SRC/zig absent) — the installed toolchain"
+    echo "      will fall back to a system clang to build programs."
+fi
 
 # ── PATH shims (RELOCATABLE) ───────────────────────────────────────────
 # Each shim resolves the prefix from its OWN location at runtime, so the


### PR DESCRIPTION
Third and final wall in the "bombproof install" series. After the libc-only toolchain (#242) and the clang-missing error (#246), the ODROID (Ubuntu 22.04 / clang 14) installed clang and then still couldn't build:

```
slice_test.ll:64:43: error: expected type
declare void @nurl_journal_push_drop(i8*, ptr)
```

Three stacked walls, all from the dev/CI toolchain being built with a much newer LLVM than a fresh distro ships:

1. **Opaque pointers** — nurlc's IR uses `ptr` (LLVM 15 default); clang 14 rejects it.
2. **Bitcode version** — the shipped `runtime.o` is LLVM-18 bitcode; clang 14 can't read it for the `-flto` link (the next error behind #1).
3. **Feature libs** — `nurl.sh` named `-lcurl … -lpq` unconditionally from build-machine sentinels, so a feature-free hello-world fails to link on a box without, say, libpq.

## Fix: bundle a self-contained `zig`, use `zig cc` as the build backend

`zig cc` carries its own modern LLVM (opaque pointers parse), its own `lld` linker, and libc headers — so building a program (and `nurlpkg install <tool>`) needs **no system compiler at all** and is immune to the box's LLVM version. Walls #1 and #2 vanish.

**Proven end to end locally:**

```
$ NURL_HOME=/tmp/nurltest NURL_BUNDLE_ZIG=/tmp/zig-… install-toolchain.sh   # bundles zig → <prefix>/zig/
$ /tmp/nurltest/bin/nurl hello.nu hello     # no system clang involved
$ readelf -d hello | grep NEEDED            # libc.so.6 only
```

### Changes

- **`nurl.sh`** — prefer a bundled zig (`<prefix>/zig/zig` or `$NURL_ZIG`); else fall back to system clang (probe + `$CLANG`, `-Xclang -opaque-pointers` on clang 13/14, reject < 13). Bitcode runtime + `-flto` kept (lean via DCE); zig's LLVM reads it.
- **`nurl.sh`** — link a feature lib (curl/openssl/sqlite3/pq/zlib/zstd) **only when the emitted IR references that back-end** (wall #3). Side benefit: the clang path is now lean too — a hello-world dropped from 7 `NEEDED` libs to just `libc`.
- **`install-toolchain.sh`** — stage `$NURL_BUNDLE_ZIG` into `<prefix>/zig/`.
- **`release.yml`** — download the per-arch zig (0.13.0 / LLVM 18) and pass it to the assemble step. ~45 MB compressed per arch — the size cost of "just works".
- **`get-nurl.sh` / `install.sh`** — only warn about clang when neither the bundled zig nor a system clang is present.
- **`.gitignore`** — `vendor/` (CI zig staging).
- **`RELEASING.md`** — documents the bundled-zig backend, the version constraint, and per-program feature libs.

### Verified

- Both engines build + run fizzbuzz / enigma / wordcount / http_basic (clang and `NURL_ZIG=zig`).
- Feature-free program → libc only on both engines; a libcurl program correctly links `libcurl.so.4`.
- The test runner is unaffected (it links directly, not via `nurl.sh`).

### Needs CI verification

The release-side bundling (download per-arch zig, package it) runs only in `release.yml`; like the other deploy jobs it should be exercised with a `workflow_dispatch` dry run before the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrSVLma6iPMfozX6MT8mYL