### PR TITLE
Relink shipped nurlc/nurlpkg against an old glibc floor (run on old distros)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,21 @@ jobs:
           mv "vendor/zig-linux-${ZA}-${ZIG_VER}" vendor/zig
           vendor/zig/zig version
 
+      # The CI runner's glibc (2.39) is newer than many target boxes (e.g.
+      # Raspberry Pi OS bullseye = 2.31), and glibc is not forward-compatible
+      # — so a binary built here fails to start there with
+      # `GLIBC_2.34 not found`. Relink the shipped nurlc + nurlpkg with the
+      # bundled zig against an old glibc floor (zig provides the versioned
+      # stubs), so they run on old distros too. Brings the floor to ~2.14.
+      - name: Relink toolchain for old-glibc portability
+        run: |
+          case "${{ matrix.target }}" in
+            linux-x86_64-glibc) A=x86_64 ;;
+            linux-arm64-glibc)  A=aarch64 ;;
+            *) echo "no arch mapping for ${{ matrix.target }}" >&2; exit 1 ;;
+          esac
+          NURL_BUNDLE_ZIG="$PWD/vendor/zig" ./tools/relink-toolchain-portable.sh "$A"
+
       - name: Assemble relocatable prefix
         run: NURL_HOME="$PWD/dist/nurl" NURL_BUNDLE_ZIG="$PWD/vendor/zig" ./tools/install-toolchain.sh
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -108,6 +108,23 @@ link where libpq was absent).
 (A prebuilt-binary package channel — install a tool with no local compile at
 all — remains the future bombproofing; see the registry roadmap.)
 
+### glibc floor: the shipped binaries run on old distros too
+
+The release runners have a recent glibc (2.39), and glibc is backward- but
+**not** forward-compatible — so a `nurlc`/`nurlpkg` built there fails to
+start on an older box (e.g. Raspberry Pi OS bullseye, glibc 2.31) with
+`libc.so.6: version 'GLIBC_2.34' not found` (2.34 is where pthread folded
+into libc). The release therefore **relinks** the shipped `nurlc` + `nurlpkg`
+with the bundled zig against an **old glibc floor**
+(`tools/relink-toolchain-portable.sh`, `zig cc -target <arch>-linux-gnu.2.17`)
+— zig supplies the versioned glibc stubs, so we build on the modern runner
+yet target ~glibc 2.14. This is possible because `nurlc` is libc-only and
+`nurlpkg` adds only static zlib/zstd (ancient symbols). A successful relink
+*caps* the floor at the target (the link fails outright if any code needs a
+newer symbol), so portability is guaranteed by construction. The bundled
+zig and the user programs it builds target the box's *native* glibc, so
+those are unaffected.
+
 ## Front-door wiring (nurlweb)
 
 `nurl-lang.org` should serve the two installer scripts so the one-liners

--- a/tools/relink-toolchain-portable.sh
+++ b/tools/relink-toolchain-portable.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  relink-toolchain-portable.sh — relink the shipped nurlc + nurlpkg
+#  against an OLD glibc baseline using the bundled zig.
+#
+#  The release binaries are built on a modern CI runner (e.g. glibc 2.39),
+#  so they reference recent versioned symbols (notably GLIBC_2.34, where
+#  pthread folded into libc) and refuse to start on an older distro — e.g.
+#  Raspberry Pi OS bullseye (glibc 2.31):
+#      libc.so.6: version `GLIBC_2.34' not found (required by .../nurlpkg)
+#  glibc is backward- but not forward-compatible, so the fix is to build
+#  against a LOW glibc floor. zig ships versioned glibc stubs, so we can
+#  build on the modern runner yet target an old floor — no old container,
+#  no old clang. nurlc is libc-only and nurlpkg adds only static zlib/zstd
+#  (whose symbols are ancient), so a low floor is achievable.
+#
+#  Usage:  relink-toolchain-portable.sh <x86_64|aarch64> [glibc_version]
+#  Env:    NURL_BUNDLE_ZIG  dir containing the `zig` binary (default vendor/zig)
+# ============================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARCH="${1:?usage: relink-toolchain-portable.sh <x86_64|aarch64> [glibc_version]}"
+GLIBC_VER="${2:-2.17}"   # 2.17 = manylinux2014 floor; covers ~everything since 2014
+TARGET="${ARCH}-linux-gnu.${GLIBC_VER}"
+
+ZIG="${NURL_BUNDLE_ZIG:-$ROOT/vendor/zig}/zig"
+[[ -x "$ZIG" ]] || { echo "ERROR: zig not found at $ZIG (set NURL_BUNDLE_ZIG)" >&2; exit 1; }
+[[ -f "$ROOT/build/nurlc_self2.ll" ]] || { echo "ERROR: build/nurlc_self2.ll missing — run ./build.sh first" >&2; exit 1; }
+[[ -f "$ROOT/build/nurlpkg.ll" ]]     || { echo "ERROR: build/nurlpkg.ll missing — run ./tools/nurlpkg/build.sh first" >&2; exit 1; }
+[[ -f "$ROOT/stdlib/runtime.o" ]]     || { echo "ERROR: stdlib/runtime.o missing — run ./build.sh first" >&2; exit 1; }
+
+# nurlc is libc-only — relink straight to the old floor.
+echo "Relinking nurlc → $TARGET"
+"$ZIG" cc -O2 -flto -target "$TARGET" -Wl,--as-needed \
+    "$ROOT/build/nurlc_self2.ll" "$ROOT/stdlib/runtime.o" -lm -lpthread \
+    -o "$ROOT/build/nurlc"
+
+# nurlpkg additionally links static zlib + zstd. zig does not search system
+# library directories in target mode, so pass the archives by full path;
+# they only reference ancient libc symbols, so they don't raise the floor.
+ZA=()
+for n in libz.a libzstd.a; do
+    p="$(find /usr/lib /usr/lib64 /lib -name "$n" 2>/dev/null | head -1)"
+    [[ -n "$p" ]] && ZA+=("$p")
+done
+echo "Relinking nurlpkg → $TARGET (static: ${ZA[*]:-none found})"
+"$ZIG" cc -O2 -flto -target "$TARGET" -Wl,--as-needed \
+    "$ROOT/build/nurlpkg.ll" "$ROOT/stdlib/runtime.o" -lm -lpthread "${ZA[@]}" \
+    -o "$ROOT/build/nurlpkg"
+
+# Report the resulting glibc floor (highest versioned symbol referenced).
+echo "Resulting glibc floors:"
+for b in nurlc nurlpkg; do
+    v="$(objdump -T "$ROOT/build/$b" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -V | tail -1)"
+    echo "  $b: ${v:-none (static?)}"
+done
+echo "Done."


### PR DESCRIPTION
The v0.9.11 toolchain now installs + runs on the ODROID (`HELLO, HI!` 🎉), but a **Raspberry Pi 4** (Raspberry Pi OS bullseye, glibc 2.31) can't start the binaries:

```
nurlpkg: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found
nurlpkg: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found
```

## Why

The release runners ship glibc 2.39, and glibc is backward- but **not** forward-compatible. So binaries built there reference recent versioned symbols — notably `GLIBC_2.34`, where `pthread_*` folded into libc and every `-lpthread` binary picks up the 2.34-versioned symbols — which an older distro like the Pi (2.31) doesn't have.

## Fix

Relink the shipped `nurlc` + `nurlpkg` with the **bundled zig** against an **old glibc floor**:

```
zig cc -target <arch>-linux-gnu.2.17 …   # zig ships the versioned glibc stubs
```

We build on the modern runner but *target* an old floor — no old container, no old clang. This is possible because the earlier work made `nurlc` libc-only and `nurlpkg` adds only static zlib/zstd (whose symbols are ancient). A successful relink **caps** the floor at the target (the link fails outright if any code needs a newer symbol), so portability is guaranteed by construction.

Verified locally (x86_64): both binaries relink to a **GLIBC_2.14** floor and still compile / run — that covers essentially every Linux since ~2011 (the Pi's 2.31, the ODROID's 2.35, …).

## Changes

- **`tools/relink-toolchain-portable.sh`** — relink both from their IR (`build/nurlc_self2.ll`, `build/nurlpkg.ll`) + `runtime.o`, passing static `libz.a`/`libzstd.a` by full path for nurlpkg (zig doesn't search system lib dirs in target mode).
- **`release.yml`** — run it per-arch after fetching zig, before assembling the prefix.
- **`RELEASING.md`** — documents the glibc-floor relink.

The bundled zig itself, and the user programs it builds on the box, target the box's *native* glibc — so those are unaffected.

## Needs CI verification

The arm64 relink runs only in `release.yml`; like the rest of the release job it should be confirmed on a `workflow_dispatch` dry run (or the next tag). After merge, re-cut the tag to rebuild the artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrSVLma6iPMfozX6MT8mYL