### PR TITLE
Fix arm64 portable relink: drop LTO + robust lib search

### DIFF
--- a/tools/relink-toolchain-portable.sh
+++ b/tools/relink-toolchain-portable.sh
@@ -32,9 +32,15 @@ ZIG="${NURL_BUNDLE_ZIG:-$ROOT/vendor/zig}/zig"
 [[ -f "$ROOT/build/nurlpkg.ll" ]]     || { echo "ERROR: build/nurlpkg.ll missing — run ./tools/nurlpkg/build.sh first" >&2; exit 1; }
 [[ -f "$ROOT/stdlib/runtime.o" ]]     || { echo "ERROR: stdlib/runtime.o missing — run ./build.sh first" >&2; exit 1; }
 
+# ThinLTO (not monolithic -flto): same result, far lower peak memory. Full
+# LTO of nurlc's large module OOM-killed the arm64 release runner (the link
+# died silently after ~30s); ThinLTO summarises per-module and stays within
+# the runner's RAM.
+LTO=-flto=thin
+
 # nurlc is libc-only — relink straight to the old floor.
 echo "Relinking nurlc → $TARGET"
-"$ZIG" cc -O2 -flto -target "$TARGET" -Wl,--as-needed \
+"$ZIG" cc -O2 "$LTO" -target "$TARGET" -Wl,--as-needed \
     "$ROOT/build/nurlc_self2.ll" "$ROOT/stdlib/runtime.o" -lm -lpthread \
     -o "$ROOT/build/nurlc"
 
@@ -47,7 +53,7 @@ for n in libz.a libzstd.a; do
     [[ -n "$p" ]] && ZA+=("$p")
 done
 echo "Relinking nurlpkg → $TARGET (static: ${ZA[*]:-none found})"
-"$ZIG" cc -O2 -flto -target "$TARGET" -Wl,--as-needed \
+"$ZIG" cc -O2 "$LTO" -target "$TARGET" -Wl,--as-needed \
     "$ROOT/build/nurlpkg.ll" "$ROOT/stdlib/runtime.o" -lm -lpthread "${ZA[@]}" \
     -o "$ROOT/build/nurlpkg"
 

--- a/tools/relink-toolchain-portable.sh
+++ b/tools/relink-toolchain-portable.sh
@@ -13,8 +13,16 @@
 #  glibc is backward- but not forward-compatible, so the fix is to build
 #  against a LOW glibc floor. zig ships versioned glibc stubs, so we can
 #  build on the modern runner yet target an old floor — no old container,
-#  no old clang. nurlc is libc-only and nurlpkg adds only static zlib/zstd
-#  (whose symbols are ancient), so a low floor is achievable.
+#  no old clang.
+#
+#  We deliberately DON'T use `-flto` here: monolithic/thin LTO of nurlc's
+#  large module fails on the arm64 release runner (silent exit after the
+#  frontend). Instead we recompile runtime.c from source with zig at the
+#  old target and link without LTO. To stay lean without LTO's dead-code
+#  elimination, nurlpkg's runtime is built with ONLY the zlib/zstd back-ends
+#  it actually uses (not curl/openssl/sqlite/pq), and nurlc's with none —
+#  so each links against just what it needs. Floor lands ~glibc 2.25
+#  (getrandom), which still covers the Pi (2.31) and beyond.
 #
 #  Usage:  relink-toolchain-portable.sh <x86_64|aarch64> [glibc_version]
 #  Env:    NURL_BUNDLE_ZIG  dir containing the `zig` binary (default vendor/zig)
@@ -23,44 +31,51 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ARCH="${1:?usage: relink-toolchain-portable.sh <x86_64|aarch64> [glibc_version]}"
-GLIBC_VER="${2:-2.17}"   # 2.17 = manylinux2014 floor; covers ~everything since 2014
+GLIBC_VER="${2:-2.28}"   # >= 2.25 (runtime uses getrandom); 2.28 covers Pi/ODROID with margin
 TARGET="${ARCH}-linux-gnu.${GLIBC_VER}"
+MULTIARCH="${ARCH}-linux-gnu"
 
 ZIG="${NURL_BUNDLE_ZIG:-$ROOT/vendor/zig}/zig"
 [[ -x "$ZIG" ]] || { echo "ERROR: zig not found at $ZIG (set NURL_BUNDLE_ZIG)" >&2; exit 1; }
 [[ -f "$ROOT/build/nurlc_self2.ll" ]] || { echo "ERROR: build/nurlc_self2.ll missing — run ./build.sh first" >&2; exit 1; }
 [[ -f "$ROOT/build/nurlpkg.ll" ]]     || { echo "ERROR: build/nurlpkg.ll missing — run ./tools/nurlpkg/build.sh first" >&2; exit 1; }
-[[ -f "$ROOT/stdlib/runtime.o" ]]     || { echo "ERROR: stdlib/runtime.o missing — run ./build.sh first" >&2; exit 1; }
+[[ -f "$ROOT/stdlib/runtime.c" ]]     || { echo "ERROR: stdlib/runtime.c missing" >&2; exit 1; }
 
-# ThinLTO (not monolithic -flto): same result, far lower peak memory. Full
-# LTO of nurlc's large module OOM-killed the arm64 release runner (the link
-# died silently after ~30s); ThinLTO summarises per-module and stays within
-# the runner's RAM.
-LTO=-flto=thin
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 
-# nurlc is libc-only — relink straight to the old floor.
+# nurlc is libc-only: recompile runtime.c with no back-end defines, link
+# without LTO straight to the old floor.
 echo "Relinking nurlc → $TARGET"
-"$ZIG" cc -O2 "$LTO" -target "$TARGET" -Wl,--as-needed \
-    "$ROOT/build/nurlc_self2.ll" "$ROOT/stdlib/runtime.o" -lm -lpthread \
+"$ZIG" cc -O2 -target "$TARGET" -c "$ROOT/stdlib/runtime.c" -o "$TMP/rt-nurlc.o"
+"$ZIG" cc -O2 -target "$TARGET" -Wl,--as-needed \
+    "$ROOT/build/nurlc_self2.ll" "$TMP/rt-nurlc.o" -lm -lpthread \
     -o "$ROOT/build/nurlc"
 
-# nurlpkg additionally links static zlib + zstd. zig does not search system
-# library directories in target mode, so pass the archives by full path;
-# they only reference ancient libc symbols, so they don't raise the floor.
+# nurlpkg uses zlib + zstd (gzip/zstd of package tarballs) and nothing else
+# native. Build its runtime with ONLY those back-ends so the link stays lean
+# (no curl/openssl/sqlite/pq) without needing LTO's DCE. zig ignores system
+# libc headers by default; `-idirafter` only supplies the missing zlib.h /
+# zstd.h, without overriding zig's own target libc headers. zlib + zstd are
+# linked statically (full path — zig doesn't search system lib dirs in target
+# mode); their symbols are ancient, so they don't raise the floor.
+echo "Relinking nurlpkg → $TARGET"
+"$ZIG" cc -O2 -target "$TARGET" -DNURL_HAVE_ZLIB -DNURL_HAVE_ZSTD \
+    -idirafter /usr/include -idirafter "/usr/include/$MULTIARCH" \
+    -c "$ROOT/stdlib/runtime.c" -o "$TMP/rt-nurlpkg.o"
 ZA=()
 for n in libz.a libzstd.a; do
     p="$(find /usr/lib /usr/lib64 /lib -name "$n" 2>/dev/null | head -1)"
     [[ -n "$p" ]] && ZA+=("$p")
 done
-echo "Relinking nurlpkg → $TARGET (static: ${ZA[*]:-none found})"
-"$ZIG" cc -O2 "$LTO" -target "$TARGET" -Wl,--as-needed \
-    "$ROOT/build/nurlpkg.ll" "$ROOT/stdlib/runtime.o" -lm -lpthread "${ZA[@]}" \
+"$ZIG" cc -O2 -target "$TARGET" -Wl,--as-needed \
+    "$ROOT/build/nurlpkg.ll" "$TMP/rt-nurlpkg.o" -lm -lpthread "${ZA[@]}" \
     -o "$ROOT/build/nurlpkg"
 
 # Report the resulting glibc floor (highest versioned symbol referenced).
 echo "Resulting glibc floors:"
 for b in nurlc nurlpkg; do
-    v="$(objdump -T "$ROOT/build/$b" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -V | tail -1)"
-    echo "  $b: ${v:-none (static?)}"
+    v="$(readelf -V "$ROOT/build/$b" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -V | tail -1)"
+    echo "  $b: ${v:-none}"
 done
 echo "Done."

--- a/tools/relink-toolchain-portable.sh
+++ b/tools/relink-toolchain-portable.sh
@@ -63,9 +63,15 @@ echo "Relinking nurlpkg → $TARGET"
 "$ZIG" cc -O2 -target "$TARGET" -DNURL_HAVE_ZLIB -DNURL_HAVE_ZSTD \
     -idirafter /usr/include -idirafter "/usr/include/$MULTIARCH" \
     -c "$ROOT/stdlib/runtime.c" -o "$TMP/rt-nurlpkg.o"
+# Search only directories that exist: on arm64 there is no /usr/lib64, and
+# `find` over a missing dir exits non-zero — which under `set -o pipefail`
+# + `set -e` would kill this script *silently* (the bug that made every
+# arm64 attempt die here). `|| true` is a second guard.
 ZA=()
+search_dirs=()
+for d in /usr/lib /usr/lib64 /lib /lib64; do [[ -d "$d" ]] && search_dirs+=("$d"); done
 for n in libz.a libzstd.a; do
-    p="$(find /usr/lib /usr/lib64 /lib -name "$n" 2>/dev/null | head -1)"
+    p="$(find "${search_dirs[@]}" -name "$n" 2>/dev/null | head -1 || true)"
     [[ -n "$p" ]] && ZA+=("$p")
 done
 "$ZIG" cc -O2 -target "$TARGET" -Wl,--as-needed \


### PR DESCRIPTION
Makes the old-glibc relink (#248) actually succeed on the **arm64** release runner, so the Pi-compatible binaries can ship. Two stacked causes, both arm64-only:

1. **arm64 LTO choke.** Monolithic `-flto` — and `-flto=thin` too — of nurlc's large module died silently on the arm64 runner after the frontend (x86_64 was fine). Not memory (ThinLTO failed identically). So drop LTO entirely: recompile `runtime.c` from source with zig at the old glibc target and link without LTO. To stay lean without LTO's dead-code elimination, `nurlpkg`'s runtime is compiled with **only** the zlib/zstd backends it uses (not curl/openssl/sqlite/pq), and `nurlc`'s with none. `-idirafter` supplies just `zlib.h`/`zstd.h` without overriding zig's target libc.

2. **The silent killer:** `find /usr/lib /usr/lib64 /lib …` for the static `libz.a`/`libzstd.a`. arm64 (Debian/Ubuntu multiarch) has **no `/usr/lib64`**, so `find` exits non-zero → under `set -o pipefail` + `set -e` the command-substitution aborted the script with **zero output**. x86_64 has `/usr/lib64`, so it always passed there. Fixed by searching only existing dirs + a `|| true` guard.

The `zig`-as-cross-compiler trick cracked #2 — building the aarch64 binaries from an x86_64 box showed both nurlpkg compile steps succeed, ruling out codegen and pointing at the shell.

## Verified

Release **dry-run** (`workflow_dispatch`, publish gated off) on this branch — both arches green:

```
linux-arm64-glibc  → Relink ✓  Smoke test ✓  Package ✓   floors: nurlc/nurlpkg = GLIBC_2.25
linux-x86_64-glibc → Relink ✓  Smoke test ✓  Package ✓   floors: nurlc/nurlpkg = GLIBC_2.25
```

GLIBC_2.25 is below the Raspberry Pi OS bullseye floor (2.31), so the Pi will run these once published. (2.25 vs LTO's theoretical 2.14 is because `getrandom` isn't dead-stripped without LTO — still amply portable.)

## After merge

Merge #249 (playground lib-probe fix) too, then re-cut the tag so the release rebuilds with both fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrSVLma6iPMfozX6MT8mYL