### PR TITLE
nurl.sh: a failed feature-lib probe must not abort the build (set -e)

### DIFF
--- a/nurl.sh
+++ b/nurl.sh
@@ -272,7 +272,16 @@ add_feature_lib() {
     # $1 sentinel basename, $2.. the link flags (e.g. -lssl -lcrypto).
     local sentinel="$1"; shift
     [[ -f "$SCRIPT_DIR/stdlib/$sentinel" ]] || return 0
-    "${CC[@]}" "$__probe_c" "$@" -o "$__probe_o" >/dev/null 2>&1 && EXTRA_LIBS+=( "$@" )
+    # A FAILED probe (lib absent — common: the runtime .so.N is present but
+    # the -dev `.so` linker symlink is not) means "don't link it". Use an
+    # `if`, never `probe && add`: the latter makes this function return the
+    # probe's non-zero exit, which under the caller's `set -e` aborts the
+    # whole build at the first unavailable library. `return 0` keeps the
+    # function total regardless.
+    if "${CC[@]}" "$__probe_c" "$@" -o "$__probe_o" >/dev/null 2>&1; then
+        EXTRA_LIBS+=( "$@" )
+    fi
+    return 0
 }
 add_feature_lib runtime.curl    -lcurl
 add_feature_lib runtime.openssl -lssl -lcrypto


### PR DESCRIPTION
v0.9.12 **installs and runs** on a Raspberry Pi 4 / ODROID (the glibc-floor fix worked), but every build — including `nurlpkg install <tool>` — died with a bare `compile failed:`.

## Cause

The feature-lib availability probe (#249) ended each helper with `probe && EXTRA_LIBS+=(...)`. When a probe **fails** (library absent), that line returns the probe's non-zero exit → `add_feature_lib` returns non-zero → at the call site the script's `set -e` **aborts the entire build at the first unavailable library**.

On a fresh Pi this fires immediately: the box has the *runtime* `libcurl.so.4` but not the `-dev` `libcurl.so` linker symlink, so `-lcurl` (and openssl/sqlite/pq/zstd) won't link — every probe exits 1, and the build dies before the link step.

## Fix

Use an explicit `if` (never `probe && add`) and `return 0`, so a failed probe just skips that library:

```bash
if "${CC[@]}" "$__probe_c" "$@" -o "$__probe_o" >/dev/null 2>&1; then
    EXTRA_LIBS+=( "$@" )
fi
return 0
```

A feature-free program links against what's available; one that truly needs an absent lib still fails later with a clear undefined-symbol error.

## Verified on real hardware

Copied the fixed `nurl.sh` onto each box, then:

```
$ nurlpkg install argz-demo && argz-demo --shout hi
…
Installed argz-demo → ~/.nurl/bin/argz-demo
HELLO, HI!
```

— on **both a Raspberry Pi 4** (glibc 2.31) **and an ODROID**.

## After merge

Cut **v0.9.13** (v0.9.12's published build driver has this bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrSVLma6iPMfozX6MT8mYL