### PR TITLE
runtime: enable the stackful fiber runtime on FreeBSD/NetBSD/DragonFly

### DIFF
--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -5671,10 +5671,15 @@ void      nurl_runtime_init(long long worker_count);
 void      nurl_runtime_run(void);
 void      nurl_runtime_shutdown(void);
 
-/* musl omits ucontext (linker errors on include), so gate the stackful
- * implementation on glibc/macOS. Other POSIX-ish targets fall through
- * to the stub block. macOS gates ucontext behind _XOPEN_SOURCE. */
-#if !defined(__wasi__) && !defined(_WIN32) && (defined(__GLIBC__) || defined(__APPLE__))
+/* The stackful fiber runtime needs ucontext (getcontext/makecontext/
+ * swapcontext). musl omits it (linker errors on include) and has no
+ * detection macro, so we ALLOWLIST the libcs that ship a working
+ * ucontext rather than blocklist musl: glibc, macOS, and the BSDs that
+ * keep makecontext/swapcontext (FreeBSD / NetBSD / DragonFly — NOT
+ * OpenBSD, which removed swapcontext). Everything else (musl, wasi,
+ * Win32) falls through to the stub block. macOS gates ucontext behind
+ * _XOPEN_SOURCE. Keep the twin gate below (§reactor) in sync. */
+#if !defined(__wasi__) && !defined(_WIN32) && (defined(__GLIBC__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__))
 #if defined(__APPLE__) && !defined(_XOPEN_SOURCE)
 #  define _XOPEN_SOURCE 600
 #endif
@@ -6260,7 +6265,7 @@ long long nurl_reactor_wait_write(long long fd, long long timeout_ms);
 long long nurl_fiber_sleep_ms(long long ms);
 
 /* Same platform guard as §24 — needs the fiber primitives. */
-#if !defined(__wasi__) && !defined(_WIN32) && (defined(__GLIBC__) || defined(__APPLE__))
+#if !defined(__wasi__) && !defined(_WIN32) && (defined(__GLIBC__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__))
 #include <poll.h>
 #include <fcntl.h>
 #include <errno.h>


### PR DESCRIPTION
A genuine bug found by a **FreeBSD proof-of-concept**.

## The bug

NURL's async runtime (M:N work-stealing over stackful fibers) needs a working ucontext (`getcontext`/`makecontext`/`swapcontext`). musl omits ucontext and has no detection macro, so the gate **allowlists** libcs known to ship it — but the allowlist was only `__GLIBC__ || __APPLE__`:

```c
#if !defined(__wasi__) && !defined(_WIN32) && (defined(__GLIBC__) || defined(__APPLE__))
```

FreeBSD has full ucontext, but isn't on the list — so on FreeBSD the **entire async runtime silently fell through to the no-op stub**. Programs ran and exited 0, but no fiber ever executed (`async_basic` on FreeBSD: `total_yields=0 / finished=0` instead of `100000 / 100`).

## The fix

Add the BSDs that keep `makecontext`/`swapcontext` — **FreeBSD, NetBSD, DragonFly** — to both twin gates (the §24 fiber impl and the §reactor primitives). **Not** OpenBSD, which removed `swapcontext`. The change is purely additive: glibc / macOS / musl / wasi / Win32 are unchanged.

## How it was found & verified

Built `nurlc` + the runtime **natively on a FreeBSD 14.3 amd64 box** (clang + headers present, 7.6 GB RAM) and ran a batch of the test corpus:
- `runtime.c` compiled **clean** (zero warnings) — the POSIX runtime is FreeBSD-portable.
- **42 feature-free tests passed, zero crashes.** The only failures were the four async tests — all from this gate.
- After the fix: `async_basic` / `async_chan` / `async_mn` / `async_sleep` all **PASS on FreeBSD**.
- Host unaffected: **458/458**, bootstrap fixed point held.

So with this PR, NURL's compiler, runtime, and async fibers all work on FreeBSD. (No release artifact yet — native build only; cross-compile from Linux still needs a FreeBSD sysroot since zig doesn't bundle FreeBSD libc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrSVLma6iPMfozX6MT8mYL