### PR TITLE
release: v0.9.14 — FreeBSD toolchain + bash-free install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,21 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.14] — 2026-06-23
 
 ### Added
 
+- **Prebuilt FreeBSD toolchain.** The release pipeline now publishes
+  `nurl-<tag>-freebsd-x86_64.tar.gz`, built on FreeBSD 14 in CI, so the
+  one-line installer works on FreeBSD out of the box
+  (`curl -fsSL https://nurl-lang.org/install.sh | sh`). The shipped binaries
+  depend on `libc.so.7` only; FreeBSD's base clang drives `nurlpkg install`,
+  so no compiler is bundled. `get-nurl.sh` detects FreeBSD via `uname -s`.
+  Validated end-to-end on real hardware: `nurlpkg install argz-demo &&
+  argz-demo --shout hi`.
+- **FreeBSD CI.** A FreeBSD VM job builds the compiler, checks the
+  self-hosting fixed point, and runs the test corpus on genuine FreeBSD — the
+  gate that caught the two FreeBSD bugs fixed below.
 - **`nurlc --version` / `nurlpkg --version` / `nurl --version`.** The version
   is derived at build time by `tools/version.sh` (`git describe` → `v0.9.14`
   on a release tag, `v0.9.13-2-gabc-dirty` on a dev checkout; falls back to
@@ -19,6 +30,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local builds. Because the string lives in `runtime.o` and not in
   `nurlc.nu`'s IR, the self-hosting fixed point and the committed bootstrap
   snapshot are unaffected by a version bump.
+
+### Fixed
+
+- **The installed toolchain no longer requires bash.** The shipped wrapper
+  scripts (`nurl.sh` and the `nurl` / `nurlc` / `nurlpkg` shims) were
+  `#!/usr/bin/env bash`, so on a stock FreeBSD / Alpine / busybox box — where
+  the binaries are libc-only but bash is absent — the first build died with
+  `env: bash: No such file or directory`. They are now POSIX `sh`, validated
+  under dash on Linux and end-to-end on a bash-less FreeBSD 14.3 box.
+- **Async fibers run on FreeBSD.** The M:N stackful-fiber runtime was gated to
+  glibc/macOS, so on FreeBSD (which has full `ucontext`) it silently fell back
+  to a no-op stub and fibers never ran. Now enabled on
+  FreeBSD / NetBSD / DragonFly.
+- **Empty URL is `HttpInvalidUrl` on a no-libcurl build** (was `HttpOther`),
+  matching the libcurl and WinHTTP backends — input validation that no longer
+  depends on which HTTP backend is compiled in.
+- **`z_stream` ABI helpers decoupled from the zlib build flag**, so a runtime
+  linked against libz without `zlib.h` at compile time still reports the
+  correct struct size (an ABI replica pinned by `_Static_assert`).
+- **Test/example harness portability.** `run_tests.sh` no longer uses GNU
+  `sed -i` (mis-parsed by BSD sed); FFI-dependent tests and examples now
+  self-skip when their optional library (sqlite3 / libpq / …) is absent
+  instead of failing the suite.
+
+### Changed
+
+- **Setup no longer needs `source ~/.nurl/env`.** The shims self-locate the
+  stdlib, so `export PATH="$HOME/.nurl/bin:$PATH"` is the whole setup and works
+  in any shell. The website one-line install is updated to match and gains a
+  Copy button.
 
 ## [0.9.13] — 2026-06-23
 
@@ -5459,7 +5500,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.9.13...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.9.14...HEAD
+[0.9.14]: https://github.com/nurl-lang/nurl/compare/v0.9.13...v0.9.14
 [0.9.13]: https://github.com/nurl-lang/nurl/compare/v0.9.12...v0.9.13
 [0.9.12]: https://github.com/nurl-lang/nurl/compare/v0.9.11...v0.9.12
 [0.9.11]: https://github.com/nurl-lang/nurl/compare/v0.9.10...v0.9.11

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,6 +24,7 @@ git push origin v0.1.0
 |---|---|---|
 | `linux-x86_64-glibc` | `ubuntu-latest` | `nurl-<tag>-linux-x86_64-glibc.tar.gz` |
 | `linux-arm64-glibc`  | `ubuntu-24.04-arm` | `nurl-<tag>-linux-arm64-glibc.tar.gz` |
+| `freebsd-x86_64`     | `ubuntu-latest` (FreeBSD 14 VM) | `nurl-<tag>-freebsd-x86_64.tar.gz` |
 | `windows-x86_64`     | `windows-latest` | `nurl-<tag>-windows-x86_64.zip` |
 
 Each job builds `nurlc` + `nurlpkg`, assembles the prefix with

--- a/nurlweb/public/index.html
+++ b/nurlweb/public/index.html
@@ -57,7 +57,7 @@
     </a>
   </div>
   <div class="stats">
-    <div class="stat"><strong data-fact="version">v0.9.11</strong><span>current release</span></div>
+    <div class="stat"><strong data-fact="version">v0.9.14</strong><span>current release</span></div>
     <div class="stat"><strong data-fact="compiler_lines">16,548</strong><span>lines of NURL in the compiler</span></div>
     <div class="stat"><strong data-fact="tests">480</strong><span>compiler test programs</span></div>
     <div class="stat"><strong data-fact="stdlib_modules">148</strong><span>stdlib modules</span></div>
@@ -384,7 +384,7 @@
       <div class="start-card">
         <div class="step">Step 2 · Install</div>
         <h3>One-line install</h3>
-        <p>Download a prebuilt toolchain — compiler, package manager, and stdlib — for Linux (x86_64 / arm64) or Windows. No clang, no build. Then install programs straight from the registry.</p>
+        <p>Download a prebuilt toolchain — compiler, package manager, and stdlib — for Linux (x86_64 / arm64), FreeBSD (x86_64) or Windows. No clang, no build. Then install programs straight from the registry.</p>
         <div class="cmd-block">
           <button class="copy-btn" data-copy-target="#install-cmd">Copy</button>
 <pre id="install-cmd">curl -fsSL https://nurl-lang.org/install.sh | sh
@@ -493,7 +493,7 @@ cd nurl
       </div>
       <div class="card">
         <h3>Changelog</h3>
-        <p>Every release documented in Keep-a-Changelog format with the reasoning behind each fix — currently at <span data-fact="version">v0.9.11</span>.</p>
+        <p>Every release documented in Keep-a-Changelog format with the reasoning behind each fix — currently at <span data-fact="version">v0.9.14</span>.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/blob/main/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG.md</a></p>
       </div>
       <div class="card">


### PR DESCRIPTION
Release prep for **v0.9.14**.

## Highlights (this release's arc)
- **Prebuilt FreeBSD x86_64 toolchain** — the one-line installer now works on FreeBSD (validated end-to-end on real OPNsense 14.3 hardware: `nurlpkg install argz-demo && argz-demo --shout hi`).
- **FreeBSD CI** — VM job builds the compiler, checks the self-hosting fixed point, and runs the corpus on genuine FreeBSD.
- **Bash-free install** — wrapper scripts ported to POSIX `sh`; the toolchain installs on stock FreeBSD / Alpine / busybox where the libc-only binaries run but bash is absent.
- **Two FreeBSD bugs fixed** — async fibers were silently no-op'd; `z_stream` ABI helpers were wrongly gated on the zlib build flag.
- **`http_request` empty-URL → `HttpInvalidUrl`** on no-libcurl builds (backend-independent input validation).
- **Harness portability** — no GNU `sed -i`; FFI tests/examples self-skip when their optional lib is absent.
- **Install UX** — `export PATH="$HOME/.nurl/bin:$PATH"` replaces `source ~/.nurl/env`; website one-liner updated with a Copy button.

## Files
- `CHANGELOG.md` — `[Unreleased]` → `[0.9.14]` + comparison links.
- `RELEASING.md` — `freebsd-x86_64` target row.
- `nurlweb/public/index.html` — version → v0.9.14, FreeBSD in the install card.

Tag `v0.9.14` after merge triggers `release.yml` (builds + publishes all archives incl. FreeBSD) and `web-deploy.yml` (gen-site-facts injects the version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)