### PR TITLE
windows: fix release build by resolving the real vcpkg zlib static lib name (issue #229)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,14 +184,14 @@ jobs:
   # it up (issue #229) by detecting the vcpkg x64-windows-static install
   # below: it compiles runtime.c with -DNURL_HAVE_ZLIB, drops the
   # stdlib\runtime.z sentinel, and records the link fragment that
-  # tools\nurlpkg\build.bat consumes. Still best-effort (continue-on-error)
-  # until a `workflow_dispatch` dry run confirms the job is green; once it
-  # is, drop continue-on-error here and add `windows` to the release job's
-  # `needs`.
+  # tools\nurlpkg\build.bat consumes. A `workflow_dispatch` dry run on
+  # branch fix/windows-zlib-lib-resolve (run 28044986105) is green — the
+  # vcpkg zlib 1.3.2 static lib is `zs.lib`, now resolved by build.bat's
+  # lib-name probe — so this job is no longer best-effort: a Windows break
+  # now fails the run instead of being silently swallowed.
   windows:
     runs-on: windows-latest
     timeout-minutes: 40
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -237,18 +237,19 @@ jobs:
 
   # ── Publish the GitHub Release ───────────────────────────────────────
   release:
-    # WAIT for every build job (incl. the slow FreeBSD VM and the best-effort
-    # Windows job) before publishing — listing only `linux` here previously let
+    # WAIT for every build job (incl. the slow FreeBSD VM and the Windows
+    # native job) before publishing — listing only `linux` here previously let
     # this job race ahead and publish before the FreeBSD artifact was uploaded,
     # so the freebsd archive was silently dropped from the release. With all
     # three in `needs` + the `if` below, release runs after they all COMPLETE,
     # then attaches whatever each produced via the artifact glob.
     needs: [linux, freebsd, windows]
     runs-on: ubuntu-latest
-    # Linux is mandatory; freebsd/windows are best-effort (continue-on-error),
-    # so don't require their success — just that they finished. `!cancelled()`
-    # lets us run after a best-effort job fails; still only for a real pushed
-    # tag, not a workflow_dispatch dry run.
+    # Linux gates publishing; freebsd stays best-effort (continue-on-error) and
+    # windows is now a required-to-build job (its failure reds the run) but is
+    # not a hard publish gate — don't require their `result`, just that they
+    # finished. `!cancelled()` lets us publish after a best-effort job fails;
+    # still only for a real pushed tag, not a workflow_dispatch dry run.
     if: ${{ !cancelled() && needs.linux.result == 'success' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - uses: actions/download-artifact@v4

--- a/build.bat
+++ b/build.bat
@@ -85,14 +85,16 @@ if not defined ZLIB_INC if exist "C:\zlib\include\zlib.h" (
 )
 REM Resolve the ACTUAL static-lib basename present in the lib dir. `-l<name>`
 REM needs <name>.lib to exist or the linker dies with LNK1181 "cannot open
-REM input file '<name>.lib'" (issue #229). vcpkg has shipped zlib's release
-REM lib under different names across versions (zlib.lib vs zlibstatic.lib), so
-REM never assume — probe for the file and derive the -l name from it. Enable
-REM zlib ONLY when zlib.h AND a matching .lib are both present; a header with
-REM no linkable lib was exactly the trap behind the failed Windows release.
+REM input file '<name>.lib'" (issue #229). vcpkg ships zlib's release static
+REM lib under DIFFERENT names across versions: 1.3.1 produced zlib.lib, but
+REM 1.3.2#1 adopted zlib's new CMake (-DZLIB_BUILD_STATIC) and renames the
+REM Windows static lib to zs.lib (its zlib.pc is rewritten -lz -> -lzs) — the
+REM exact mismatch that broke the Windows release. Never assume the name:
+REM probe for the file and derive the -l name from it. Enable zlib ONLY when
+REM zlib.h AND a matching .lib are both present.
 set "ZLIB_LIBNAME="
 if defined ZLIB_INC (
-    for %%N in (zlib zlibstatic z libz) do (
+    for %%N in (zlib zlibstatic zs z libz) do (
         if not defined ZLIB_LIBNAME if exist "!ZLIB_LIBDIR!\%%N.lib" set "ZLIB_LIBNAME=%%N"
     )
     echo [diag] zlib: ZLIB_LIBDIR="!ZLIB_LIBDIR!" *.lib:

--- a/build.bat
+++ b/build.bat
@@ -83,24 +83,46 @@ if not defined ZLIB_INC if exist "C:\zlib\include\zlib.h" (
     set "ZLIB_INC=C:\zlib\include"
     set "ZLIB_LIBDIR=C:\zlib\lib"
 )
+REM Resolve the ACTUAL static-lib basename present in the lib dir. `-l<name>`
+REM needs <name>.lib to exist or the linker dies with LNK1181 "cannot open
+REM input file '<name>.lib'" (issue #229). vcpkg has shipped zlib's release
+REM lib under different names across versions (zlib.lib vs zlibstatic.lib), so
+REM never assume — probe for the file and derive the -l name from it. Enable
+REM zlib ONLY when zlib.h AND a matching .lib are both present; a header with
+REM no linkable lib was exactly the trap behind the failed Windows release.
+set "ZLIB_LIBNAME="
 if defined ZLIB_INC (
-    set "ZLIB_LIBNAME=zlib"
-    if exist "!ZLIB_LIBDIR!\zlibstatic.lib" set "ZLIB_LIBNAME=zlibstatic"
+    for %%N in (zlib zlibstatic z libz) do (
+        if not defined ZLIB_LIBNAME if exist "!ZLIB_LIBDIR!\%%N.lib" set "ZLIB_LIBNAME=%%N"
+    )
+    echo [diag] zlib: ZLIB_LIBDIR="!ZLIB_LIBDIR!" *.lib:
+    dir /b "!ZLIB_LIBDIR!\*.lib" 2>nul
+)
+if defined ZLIB_LIBNAME (
     set ZLIB_CFLAGS=-DNURL_HAVE_ZLIB -I"!ZLIB_INC!"
     > stdlib\runtime.z echo 1
     set WINLIBS=!WINLIBS! -L"!ZLIB_LIBDIR!" -l!ZLIB_LIBNAME!
+    echo [info] zlib enabled: -l!ZLIB_LIBNAME! from "!ZLIB_LIBDIR!"
 ) else (
     if exist stdlib\runtime.z del /q stdlib\runtime.z
+    if defined ZLIB_INC echo [warn] zlib.h at "!ZLIB_INC!" but no zlib*.lib in "!ZLIB_LIBDIR!" - zlib disabled
 )
 
-REM zstd — pure-NURL FFI: sentinel + link only.
-set "HAVE_ZSTD="
-if defined VCPKG_INC if exist "!VCPKG_INC!\zstd.h" set "HAVE_ZSTD=1"
-if defined HAVE_ZSTD (
+REM zstd — pure-NURL FFI: sentinel + link only. Same name-probe discipline as
+REM zlib so a header-without-lib can't sneak a dangling -lzstd into the link.
+set "ZSTD_LIBNAME="
+if defined VCPKG_INC if exist "!VCPKG_INC!\zstd.h" (
+    for %%N in (zstd zstd_static libzstd) do (
+        if not defined ZSTD_LIBNAME if exist "!VCPKG_LIBDIR!\%%N.lib" set "ZSTD_LIBNAME=%%N"
+    )
+)
+if defined ZSTD_LIBNAME (
     > stdlib\runtime.zstd echo 1
-    set WINLIBS=!WINLIBS! -L"!VCPKG_LIBDIR!" -lzstd
+    set WINLIBS=!WINLIBS! -L"!VCPKG_LIBDIR!" -l!ZSTD_LIBNAME!
+    echo [info] zstd enabled: -l!ZSTD_LIBNAME! from "!VCPKG_LIBDIR!"
 ) else (
     if exist stdlib\runtime.zstd del /q stdlib\runtime.zstd
+    if defined VCPKG_INC if exist "!VCPKG_INC!\zstd.h" echo [warn] zstd.h at "!VCPKG_INC!" but no zstd*.lib in "!VCPKG_LIBDIR!" - zstd disabled
 )
 
 REM ── runtime ──────────────────────────────────────────────────
@@ -114,6 +136,7 @@ REM Persist the accumulated link fragment for the FFI consumers.
 if defined WINLIBS (
     > stdlib\runtime.winlibs echo !WINLIBS!
     >>"%LOG%" echo [info] FFI libs detected -!WINLIBS!
+    echo [info] runtime.winlibs =!WINLIBS!
 ) else (
     if exist stdlib\runtime.winlibs del /q stdlib\runtime.winlibs
     >>"%LOG%" echo [info] no vcpkg zlib/zstd - compress.nu / nurlpkg unavailable

--- a/tools/nurlpkg/build.bat
+++ b/tools/nurlpkg/build.bat
@@ -66,6 +66,7 @@ REM resolved link fragment in stdlib\runtime.winlibs when they were
 REM detected (issue #229).
 set "WINLIBS="
 if exist "%ROOT_DIR%\stdlib\runtime.winlibs" set /p WINLIBS=<"%ROOT_DIR%\stdlib\runtime.winlibs"
+echo [diag] linking with WINLIBS=!WINLIBS!
 
 echo [2/2] build\nurlpkg.ll -^> build\nurlpkg.exe
 "%CLANG%" -O2 "%ROOT_DIR%\build\nurlpkg.ll" "%RUNTIME%" -lwinhttp !WINLIBS! -o "%ROOT_DIR%\build\nurlpkg.exe"


### PR DESCRIPTION
## Problem

The `release.yml` Windows job failed at `tools\nurlpkg\build.bat` with:

```
LINK : fatal error LNK1181: cannot open input file 'zlib.lib'
```

`build.bat` wrote the `-lzlib` link fragment whenever `zlib.h` was present, without ever verifying that a matching `.lib` actually existed or was named correctly.

## Root cause

The vcpkg zlib **static** library name is version-dependent:

- zlib **1.3.1** → `zlib.lib` → `-lzlib` links fine (this is what local dev boxes have, so it only broke in CI)
- zlib **1.3.2#1** (the CI runner) adopted zlib's new CMake (`-DZLIB_BUILD_STATIC`) and names the Windows static release lib **`zs.lib`** — its `zlib.pc` is rewritten `-lz` → `-lzs`

So CI emitted `-lzlib` while the only file present was `zs.lib`, and the linker couldn't open `zlib.lib`. zstd 1.5.7 still ships `zstd.lib`, so it was unaffected.

## Fix

- **`build.bat` / `tools\nurlpkg\build.bat`** — probe the lib dir for `{zlib, zlibstatic, zs, z, libz}.lib`, derive `-l<name>` from the file that's actually present, and enable zlib only when both `zlib.h` and a linkable `.lib` exist (same name-probe discipline for zstd). Added stdout diagnostics that print the resolved lib name and the final `winlibs` fragment so the release log shows the wiring.
- **`release.yml`** — dropped `continue-on-error` from the Windows job now that the dry run is green, so a future Windows break fails the run instead of being silently swallowed. Linux still gates publishing; freebsd stays best-effort.

## Verification

- **Locally**: staged a vcpkg-static prefix where zlib is named `zs.lib`; detection resolved `-lzs`, `nurlpkg.exe` linked and ran. Also confirmed the normal `zlib.lib` path still resolves `-lzlib`.
- **In CI**: `workflow_dispatch` dry run on this branch (run 28044986105) is green — all Windows steps pass, the build log shows `[info] zlib enabled: -lzs ...`, `Done: ...\build\nurlpkg.exe`, and the `windows-x86_64` artifact uploads.

Closes #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)