### PR TITLE
web: add a Windows PowerShell one-liner to the install card

### DIFF
--- a/nurlweb/public/index.html
+++ b/nurlweb/public/index.html
@@ -385,11 +385,19 @@
         <div class="step">Step 2 · Install</div>
         <h3>One-line install</h3>
         <p>Download a prebuilt toolchain — compiler, package manager, and stdlib — for Linux (x86_64 / arm64), FreeBSD (x86_64) or Windows. No clang, no build. Then install programs straight from the registry.</p>
+        <div class="cmd-label">Linux / FreeBSD</div>
         <div class="cmd-block">
           <button class="copy-btn" data-copy-target="#install-cmd">Copy</button>
 <pre id="install-cmd">curl -fsSL https://nurl-lang.org/install.sh | sh
 export PATH="$HOME/.nurl/bin:$PATH"
 nurlpkg install argz-demo && argz-demo --shout hi</pre>
+        </div>
+        <div class="cmd-label">Windows (PowerShell)</div>
+        <div class="cmd-block">
+          <button class="copy-btn" data-copy-target="#install-cmd-win">Copy</button>
+<pre id="install-cmd-win">irm https://nurl-lang.org/install.ps1 | iex
+$env:Path = "$env:USERPROFILE\.nurl\bin;$env:Path"
+nurlpkg install argz-demo; argz-demo --shout hi</pre>
         </div>
         <a class="btn btn-secondary" href="https://github.com/nurl-lang/nurl/releases/latest" target="_blank" rel="noopener">Latest release</a>
       </div>

--- a/nurlweb/public/styles.css
+++ b/nurlweb/public/styles.css
@@ -334,6 +334,10 @@ section:last-of-type { border-bottom: none; }
 .cmd-block pre { margin: 0; padding-top: 2.5rem; }
 .cmd-block .copy-btn { position: absolute; top: 0.5rem; right: 0.55rem; margin-left: 0; }
 
+/* Small OS heading above each install command block. */
+.cmd-label { color: var(--fg-faint); font-size: 0.72rem; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase; margin: 0 0 0.4rem; }
+
 /* ── MCP section ──────────────────────────────────────────── */
 .mcp-url {
   display: flex; align-items: center; gap: 0.6rem;


### PR DESCRIPTION
## What

The install card on the landing page (`nurlweb/public/index.html`) mentioned Windows in the prose but only showed the Unix `curl | sh` command. This adds a labeled PowerShell one-liner next to it so Windows users get a copy-pasteable install:

```powershell
irm https://nurl-lang.org/install.ps1 | iex
$env:Path = "$env:USERPROFILE\.nurl\bin;$env:Path"
nurlpkg install argz-demo; argz-demo --shout hi
```

## Details

- `install.ps1` already routes to `tools/get-nurl.ps1` (see `RELEASING.md`), and `nurlweb/public/install.ps1` is in sync with it.
- The Windows release artifact that the one-liner downloads now builds (see #261 / issue #229), so the command is functional once a release with the `windows-x86_64` zip is published.
- Added a small `.cmd-label` heading style to distinguish the **Linux / FreeBSD** block from the **Windows (PowerShell)** block.
- The PowerShell `$env:Path` line matches what `get-nurl.ps1` itself prints (`%USERPROFILE%\.nurl\bin`).
- No JS change needed — the existing `data-copy-target` copy handler picks up the new `#install-cmd-win` block automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)