### PR TITLE
windows: make the shipped toolchain self-contained (bundle zlib/zstd) + fix nurlpkg install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ stdlib/runtime_debug.o
 stdlib/runtime_san.o
 stdlib/canvas.o
 stdlib/canvas.sdl2
+stdlib/winlib/
 
 # Test runner output. Per-test goldens live in compiler/tests/outputs/
 # and ARE tracked (they are the regression baseline). Everything the

--- a/build.bat
+++ b/build.bat
@@ -144,6 +144,34 @@ if defined WINLIBS (
     >>"%LOG%" echo [info] no vcpkg zlib/zstd - compress.nu / nurlpkg unavailable
 )
 
+REM ── Bundle the FFI libs for a SELF-CONTAINED, relocatable toolchain ───
+REM runtime.winlibs above points at the vcpkg lib dir on THIS machine — fine
+REM for building nurlpkg.exe here, but the shipped runtime.o is compiled with
+REM -DNURL_HAVE_ZLIB so it references deflate/inflate, meaning EVERY user link
+REM needs zlib. If only the build-machine vcpkg path is recorded, every link
+REM on a user box without vcpkg dies with "could not open 'zs.lib'". So copy
+REM the actual .lib files into stdlib\winlib\ and record a relocatable link
+REM fragment ($NURL_LIB$ placeholder) that nurl.bat resolves against the
+REM install prefix at link time. install-toolchain ships stdlib\winlib\
+REM verbatim; the build-time runtime.winlibs stays for build-time consumers
+REM (nurlpkg\build.bat, run_tests.ps1).
+if defined WINLIBS (
+    if not exist stdlib\winlib mkdir stdlib\winlib
+    set "RELOC="
+    if defined ZLIB_LIBNAME if exist "!ZLIB_LIBDIR!\!ZLIB_LIBNAME!.lib" (
+        copy /y "!ZLIB_LIBDIR!\!ZLIB_LIBNAME!.lib" "stdlib\winlib\!ZLIB_LIBNAME!.lib" >nul
+        set "RELOC=!RELOC! -l!ZLIB_LIBNAME!"
+    )
+    if defined ZSTD_LIBNAME if exist "!VCPKG_LIBDIR!\!ZSTD_LIBNAME!.lib" (
+        copy /y "!VCPKG_LIBDIR!\!ZSTD_LIBNAME!.lib" "stdlib\winlib\!ZSTD_LIBNAME!.lib" >nul
+        set "RELOC=!RELOC! -l!ZSTD_LIBNAME!"
+    )
+    > stdlib\winlib\winlibs.reloc echo  -L"$NURL_LIB$"!RELOC!
+    echo [info] bundled FFI libs -^> stdlib\winlib  reloc:!RELOC!
+) else (
+    if exist stdlib\winlib rmdir /s /q stdlib\winlib
+)
+
 REM ── canvas ──────────────────────────────────────────────────
 REM canvas.o is ALWAYS built. When SDL2 dev headers are available we
 REM compile the real SDL2 back-end (-DNURL_HAVE_SDL2); otherwise a

--- a/nurl.bat
+++ b/nurl.bat
@@ -203,15 +203,22 @@ if not errorlevel 1 (
     )
 )
 
-REM Auto-link the FFI libs build.bat detected (issue #229). The resolved
-REM link fragment (-L"<dir>" -lzlib -lzstd) was recorded in runtime.winlibs.
-REM Programs importing stdlib\ext\compress.nu (gzip/zlib + zstd FFI) —
-REM nurlpkg among them — need these at link time; other programs link fine
-REM since the symbols only resolve when referenced.
-if exist "%SCRIPTDIR%stdlib\runtime.winlibs" (
+REM Auto-link the FFI libs build.bat detected (issue #229). runtime.o is built
+REM with -DNURL_HAVE_ZLIB, so it references zlib's deflate/inflate and EVERY
+REM program needs zlib (zstd too for compress.nu users) at link time.
+REM   - A shipped toolchain carries the static libs in stdlib\winlib\ plus a
+REM     relocatable fragment (winlibs.reloc) whose $NURL_LIB$ placeholder is
+REM     resolved against THIS prefix — self-contained, no vcpkg on the box.
+REM   - An in-repo build with no winlib\ falls back to the build-time
+REM     runtime.winlibs (its vcpkg -L"<dir>" paths are valid locally).
+set "WINLIBS="
+if exist "%SCRIPTDIR%stdlib\winlib\winlibs.reloc" (
+    set /p WINLIBS=<"%SCRIPTDIR%stdlib\winlib\winlibs.reloc"
+    set "WINLIBS=!WINLIBS:$NURL_LIB$=%SCRIPTDIR%stdlib\winlib!"
+) else if exist "%SCRIPTDIR%stdlib\runtime.winlibs" (
     set /p WINLIBS=<"%SCRIPTDIR%stdlib\runtime.winlibs"
-    set "EXTRA_LIBS=!EXTRA_LIBS! !WINLIBS!"
 )
+if defined WINLIBS set "EXTRA_LIBS=!EXTRA_LIBS! !WINLIBS!"
 
 REM The runtime's HTTP client uses WinHTTP on Windows (stdlib/runtime.c §14),
 REM so every program linked against runtime.o needs winhttp.lib even if it

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -1624,7 +1624,14 @@ $ `stdlib/std/bytes.nu`
     ? == rc 0 {
         // 3. Install the freshly built binary onto $PATH. On Windows an
         //    executable needs the .exe extension to be runnable by name.
-        : String outbin ( string_concat ( string_from pkgdir ) ( string_from `/.nurl-bin` ) )
+        // The build driver names the output `.nurl-bin`, but on Windows
+        // nurl.bat appends `.exe` (EXEFILE=%OUTBASE%.exe) — so the file to
+        // copy is `.nurl-bin.exe` there. Mismatch here silently became
+        // "failed to install binary" on Windows.
+        : String outbin ( string_with_cap 96 )
+        ( string_push_str outbin pkgdir )
+        ( string_push_str outbin `/.nurl-bin` )
+        ? win { ( string_push_str outbin `.exe` ) } {}
         : String dest ( string_with_cap 96 )
         ( string_push_str dest ( string_data bindir ) )
         ( string_push_char dest 47 )


### PR DESCRIPTION
The v0.9.15 Windows toolchain installed but was **unusable**: `nurlpkg install <pkg>` died with `lld-link: error: could not open 'zs.lib'`, and after that with `failed to install binary`. Two Windows-only bugs.

## 1. FFI libs weren't bundled → `could not open 'zs.lib'`

The shipped `runtime.o` is built with `-DNURL_HAVE_ZLIB`, so it references zlib's `deflate`/`inflate` and **every** user-program link needs zlib. But `runtime.winlibs` recorded the **CI build machine's** absolute vcpkg path (`C:\vcpkg\installed\x64-windows-static\lib\zs.lib`), which doesn't exist on a user's box — so every link failed.

**Fix:** `build.bat` copies the resolved static libs into `stdlib\winlib\` and writes a relocatable fragment `winlibs.reloc` (`-L"$NURL_LIB$" -lzs -lzstd`). `nurl.bat` prefers it and substitutes `$NURL_LIB$` with `%SCRIPTDIR%stdlib\winlib` (the install prefix), so the toolchain links against its own bundled libs — no vcpkg on the box. An in-repo build with no `winlib\` falls back to the build-time `runtime.winlibs` (vcpkg paths valid locally). `install-toolchain.bat` already ships the whole `stdlib\` tree, so `winlib\` rides along unchanged.

## 2. Binary name mismatch → `failed to install binary`

nurlpkg copied the built binary from `pkgdir/.nurl-bin`, but on Windows `nurl.bat` emits `.nurl-bin.exe` (`EXEFILE=%OUTBASE%.exe`) — so `fs_copy_file` silently failed. `tools/nurlpkg/main.nu` now appends `.exe` to the source path on Windows.

## Verification (Windows, freshly assembled prefix, **no vcpkg on PATH**)

```
nurlpkg install argz-demo   →  Installed argz-demo → ~/.nurl/bin/argz-demo.exe
argz-demo --shout hi        →  HELLO, HI!
```
`md2html`, `nq`, `iforest` also install; the link line resolves against `<prefix>\stdlib\winlib`, not vcpkg. In-repo `./nurl.bat` still works via the reloc path.

## Not in scope (separate, pre-existing)

nurlc's FFI sentinel check (`__ffi_lib_check`, `compiler/nurlc.nu`) tests a **CWD-relative** `stdlib/runtime.z`, so programs that *import compress.nu* fail to compile unless run from a dir containing the sentinel. Fixing it touches `nurlc.nu` (IR) and needs a bootstrap-snapshot refresh — its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)