### PR TITLE
windows: fix FFI sentinel resolution + version baking (root-cause fixes)

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -127,6 +127,18 @@ if defined ZSTD_LIBNAME (
     if defined VCPKG_INC if exist "!VCPKG_INC!\zstd.h" echo [warn] zstd.h at "!VCPKG_INC!" but no zstd*.lib in "!VCPKG_LIBDIR!" - zstd disabled
 )
 
+REM ── version header (mirrors build.sh) ────────────────────────
+REM Bake the toolchain version into runtime.o so `nurlc --version` /
+REM `nurlpkg --version` report the real version instead of "unknown".
+REM Single source of truth: tools\version.bat (git describe / CHANGELOG).
+REM The header is git-ignored and rebuilt every run; it lives in runtime.o,
+REM not nurlc.nu's IR, so the bootstrap fixed point never churns on a bump.
+set "NURL_VER="
+for /f "delims=" %%v in ('call "%SCRIPT_DIR%\tools\version.bat" 2^>nul') do set "NURL_VER=%%v"
+if not defined NURL_VER set "NURL_VER=v0.0.0"
+> stdlib\nurl_version_gen.h echo #define NURL_VERSION "!NURL_VER!"
+echo [info] version: !NURL_VER!
+
 REM ── runtime ──────────────────────────────────────────────────
 set "LABEL=runtime"
 >>"%LOG%" echo.

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -14147,7 +14147,13 @@
         : b in_whitelist | | is_sys is_thr is_brg
         ? in_whitelist {} {
             : s sentinel ( nurl_str_cat `stdlib/runtime.` norm )
-            ? == ( nurl_file_exists sentinel ) 1 {} {
+            // Resolve the sentinel the SAME way as `$`-imports (__norm_import_path):
+            // CWD-relative first — keeps the in-tree build / bootstrap byte-identical —
+            // then $NURL_STDLIB, so an INSTALLED toolchain compiling from an arbitrary
+            // directory (or a registry package) finds the shipped sentinel. A bare
+            // CWD-relative check here meant a user building a compress.nu-importing
+            // program outside the stdlib tree got a bogus "no build-time sentinel" error.
+            ? == ( nurl_file_exists ( __norm_import_path sentinel ) ) 1 {} {
                 : s msg ( nurl_str_cat4
                 `FFI library '` lib `' is required but no build-time sentinel '`
                 ( nurl_str_cat sentinel `' found - install lib` ) )

--- a/compiler/tests/outputs-windows/should_warn_byval_capture_assign.txt
+++ b/compiler/tests/outputs-windows/should_warn_byval_capture_assign.txt
@@ -1,7 +1,7 @@
 COMPILE OK
 WARNINGS
 compiler/tests/should_warn_byval_capture_assign.nu:12:21: warning: assignment to 'n' is discarded when the closure returns — it was captured by value (a snapshot), so writes do not persist across invocations or reach the captured binding. For shared mutable state use a ': ~' multi-field struct captured by reference (which cannot escape the defining frame); an escaping mutable-state closure is not supported.
-    ^ \ → i { = n + n 1  ^ n }
+    ^ \ → i { = n + n 1 ^ n }
                     ^
 LINK OK
 EXIT 0

--- a/tools/version.bat
+++ b/tools/version.bat
@@ -1,0 +1,32 @@
+@echo off
+REM Copyright (c) 2026 The NURL Project Developers
+REM SPDX-License-Identifier: MIT OR Apache-2.0
+REM ============================================================
+REM  version.bat - print the NURL toolchain version. Windows
+REM  counterpart of tools/version.sh; SAME resolution order so
+REM  `nurlc --version` matches across platforms.
+REM
+REM  Resolution order:
+REM    1. `git describe --tags --always --dirty` (exact tag on a
+REM       release, else <tag>-<n>-g<sha>[-dirty] on a dev checkout).
+REM    2. newest released CHANGELOG.md section (source tarball, no git).
+REM    3. v0.0.0.
+REM ============================================================
+setlocal
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+set "ROOT=%SCRIPT_DIR%\.."
+
+set "VER="
+for /f "delims=" %%v in ('git -C "%ROOT%" describe --tags --always --dirty 2^>nul') do set "VER=%%v"
+if not defined VER (
+    REM No git (source tarball): fall back to the newest CHANGELOG.md entry,
+    REM e.g. `## [0.9.16] - ...` -> v0.9.16. tokens=2 delims=[] picks the
+    REM bracketed version; `if not defined` keeps only the first (newest).
+    for /f "tokens=2 delims=[]" %%a in ('findstr /r /c:"^## \[[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\]" "%ROOT%\CHANGELOG.md" 2^>nul') do (
+        if not defined VER set "VER=v%%a"
+    )
+)
+if not defined VER set "VER=v0.0.0"
+echo %VER%
+endlocal


### PR DESCRIPTION
Follow-up to #264. Three genuinely-rooted bugs that left the installed Windows toolchain only partly usable — fixed at the source, no workarounds.

## 1. FFI sentinel check was CWD-relative → compress.nu programs couldn't compile

`__ffi_lib_check` (`compiler/nurlc.nu`) tested the build-time sentinel `stdlib/runtime.<lib>` with a bare CWD-relative `nurl_file_exists`. So a user compiling a program that imports `stdlib/ext/compress.nu` from anywhere but the stdlib tree got a bogus `no build-time sentinel 'stdlib/runtime.z' found` error.

**Fix:** route the sentinel through the existing canonical resolver `__norm_import_path`, which already does **CWD-first** (keeps the in-tree build and the self-host bootstrap byte-identical) then **`$NURL_STDLIB`** — exactly how `$`-imports resolve. An installed toolchain now finds its shipped sentinel from any directory. The change is in a control-flow check (error-or-not), not emitted IR, so the bootstrap fixed point is unaffected.

## 2. `nurlc --version` reported `unknown` on Windows

`build.sh` bakes the version into `runtime.o` via `stdlib/nurl_version_gen.h` (single source of truth: `tools/version.sh`), but `build.bat` never generated it.

**Fix:** add `tools/version.bat` (Windows counterpart of `version.sh`: `git describe` → newest CHANGELOG entry → `v0.0.0`) and have `build.bat` write the header before compiling `runtime.c`. The string lives in `runtime.o`, not `nurlc.nu`'s IR, so a version bump never churns the bootstrap snapshot.

## 3. Stale Windows golden

`should_warn_byval_capture_assign`'s golden still carried the pre-`nurlfmt` double space (`1  ^ n`); the source is single-spaced now and the compiler echoes it verbatim. This mismatches on `main` already (independent of this branch). Regenerated the golden.

## Verification (Windows)

- Bootstrap reaches its fixed point; full suite green: **PASS 447 / FAIL 0**.
- `nurlc --version` / `nurlpkg --version` → real version (e.g. `v0.9.15-2-gffea944-dirty`).
- A `compress.nu`-importing program compiles from an arbitrary dir against a freshly-assembled prefix; zlib + zstd round-trips pass at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)