### PR TITLE
Pure-NURL TLS 1.3: certificate verification (verify-full) + AES-128-GCM

### DIFF
--- a/compiler/tests/aes_gcm_vectors.nu
+++ b/compiler/tests/aes_gcm_vectors.nu
@@ -1,0 +1,48 @@
+// aes_gcm_vectors.nu — AES-128-GCM against the McGrew/NIST GCM test
+// vectors (Test Case 3: no AAD; Test Case 4: with AAD), plus roundtrip
+// and tamper-rejection.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/aes_gcm.nu`
+
+@ hx s raw → ( Vec u ) { ?? ( bytes_from_hex raw ) { T v → ^ v F _ → ^ ( vec_new [u] ) } }
+
+@ check s label ( Vec u ) got s want → i {
+    : String gh ( bytes_to_hex got )
+    ? ( nurl_str_eq ( string_data gh ) want ) { ( nurl_print label ) ( nurl_print `: PASS\n` ) ( string_free gh ) ^ 0 }
+    { ( nurl_print label ) ( nurl_print `: FAIL got ` ) ( nurl_print ( string_data gh ) ) ( nurl_print `\n` ) ( string_free gh ) ^ 1 }
+}
+
+@ main → i {
+    : ~ i fails 0
+    : ( Vec u ) key ( hx `feffe9928665731c6d6a8f9467308308` )
+    : ( Vec u ) iv ( hx `cafebabefacedbaddecaf888` )
+    : ( Vec u ) empty ( vec_new [u] )
+
+    // Test Case 3 — no AAD, full 64-byte plaintext.
+    : ( Vec u ) p3 ( hx `d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255` )
+    : ( Vec u ) s3 ( aes128_gcm_encrypt key iv empty p3 )
+    = fails + fails ( check `tc3` s3 `42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091473f59854d5c2af327cd64a62cf35abd2ba6fab4` )
+
+    // Test Case 4 — with AAD, 60-byte plaintext.
+    : ( Vec u ) p4 ( hx `d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39` )
+    : ( Vec u ) aad ( hx `feedfacedeadbeeffeedfacedeadbeefabaddad2` )
+    : ( Vec u ) s4 ( aes128_gcm_encrypt key iv aad p4 )
+    = fails + fails ( check `tc4` s4 `42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e0915bc94fbc3221a5db94fae95ae7121a47` )
+
+    // Roundtrip + tamper.
+    ?? ( aes128_gcm_decrypt key iv aad s4 ) {
+        T pt → { = fails + fails ( check `tc4_open` pt `d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39` ) ( vec_free [u] pt ) }
+        F _ → { ( nurl_print `tc4_open: FAIL rejected\n` ) = fails + fails 1 }
+    }
+    ( vec_set [u] s4 0 # u ^^ 255 ?? ( vec_get [u] s4 0 ) { T x → # i x F _ → 0 } )
+    ?? ( aes128_gcm_decrypt key iv aad s4 ) {
+        T bad → { ( nurl_print `tamper: FAIL accepted\n` ) = fails + fails 1 ( vec_free [u] bad ) }
+        F _ → ( nurl_print `tamper: PASS\n` )
+    }
+
+    ? == fails 0 { ( nurl_print `aes-gcm: all vectors PASS\n` ) } { ( nurl_print `aes-gcm: FAILURES\n` ) }
+    ^ fails
+}

--- a/compiler/tests/ecdsa_p256_verify.nu
+++ b/compiler/tests/ecdsa_p256_verify.nu
@@ -5,7 +5,9 @@ $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/ecdsa_p256.nu`
+
 @ hx s raw → ( Vec u ) { ?? ( bytes_from_hex raw ) { T v → ^ v F _ → ^ ( vec_new [u] ) } }
+
 @ main → i {
     : ~ i fails 0
     : ( Vec u ) pt ( hx `045b4078962b22f9395b3dde209c6b9eab16bc66fd8731ab3c62278766225a80a81e169229d9b5b3585e5f3bc38b14e99493d85f69c5d03077112f2cdfa8135cde` )

--- a/compiler/tests/ecdsa_p256_verify.nu
+++ b/compiler/tests/ecdsa_p256_verify.nu
@@ -1,0 +1,21 @@
+// ecdsa_p256_verify.nu — ECDSA on NIST P-256 against an OpenSSL-generated
+// signature (positive + wrong-digest rejection).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/ecdsa_p256.nu`
+@ hx s raw → ( Vec u ) { ?? ( bytes_from_hex raw ) { T v → ^ v F _ → ^ ( vec_new [u] ) } }
+@ main → i {
+    : ~ i fails 0
+    : ( Vec u ) pt ( hx `045b4078962b22f9395b3dde209c6b9eab16bc66fd8731ab3c62278766225a80a81e169229d9b5b3585e5f3bc38b14e99493d85f69c5d03077112f2cdfa8135cde` )
+    : ( Vec u ) r ( hx `8564a96c6285bb5154953500b18b030df4b993e6b61300b3bc55fd7a1e68c8b1` )
+    : ( Vec u ) s ( hx `38ac70268e39cd217027f5dc4a9ad2101757e53774192d2d37745a0038a2d043` )
+    : ( Vec u ) h ( hx `24f0df4544ca02d5abc50e047de3bb7b64cdc2290a601b078ae90ce3a259f0b9` )
+    : ( Vec u ) wrong ( hx `1111111111111111111111111111111111111111111111111111111111111111` )
+    ? ( ecdsa_p256_verify pt r s h ) { ( nurl_print `valid: PASS\n` ) } { ( nurl_print `valid: FAIL\n` ) = fails + fails 1 }
+    ? ( ecdsa_p256_verify pt r s wrong ) { ( nurl_print `wronghash: FAIL\n` ) = fails + fails 1 } { ( nurl_print `wronghash: PASS\n` ) }
+    ? ( ecdsa_p256_verify pt s r h ) { ( nurl_print `swapped_rs: FAIL\n` ) = fails + fails 1 } { ( nurl_print `swapped_rs: PASS\n` ) }
+    ? == fails 0 { ( nurl_print `ecdsa-p256: all checks PASS\n` ) } { ( nurl_print `ecdsa-p256: FAILURES\n` ) }
+    ^ fails
+}

--- a/compiler/tests/outputs/aes_gcm_vectors.txt
+++ b/compiler/tests/outputs/aes_gcm_vectors.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+tc3: PASS
+tc4: PASS
+tc4_open: PASS
+tamper: PASS
+aes-gcm: all vectors PASS

--- a/compiler/tests/outputs/ecdsa_p256_verify.txt
+++ b/compiler/tests/outputs/ecdsa_p256_verify.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+valid: PASS
+wronghash: PASS
+swapped_rs: PASS
+ecdsa-p256: all checks PASS

--- a/compiler/tests/outputs/rsa_verify.txt
+++ b/compiler/tests/outputs/rsa_verify.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+pkcs1_valid: PASS
+pkcs1_wronghash: PASS
+pss_valid: PASS
+pss_wronghash: PASS
+crossuse: PASS
+rsa: all checks PASS

--- a/compiler/tests/outputs/x509_parse.txt
+++ b/compiler/tests/outputs/x509_parse.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+rsa.ok=yes sig_alg=1 key_alg=1 n=256 sans=2
+rsa.selfsig=yes
+host localhost=yes a.example.com=yes evil=no
+ec.ok=yes key_alg=2 curve=256 point=65 ec.sig_alg=4

--- a/compiler/tests/rsa_verify.nu
+++ b/compiler/tests/rsa_verify.nu
@@ -1,0 +1,29 @@
+// rsa_verify.nu — RSASSA PKCS#1 v1.5 and PSS verification against
+// OpenSSL-generated RSA-2048 signatures (positive + negative cases).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/rsa.nu`
+
+@ hx s raw → ( Vec u ) { ?? ( bytes_from_hex raw ) { T v → ^ v F _ → ^ ( vec_new [u] ) } }
+
+@ main → i {
+    : ~ i fails 0
+    : ( Vec u ) n ( hx `ab1e5059185c2bc5c47ca2eae06e8e403ee787e98aad8d15d80d2346625adfa6404ae6cac58510ce3e40b917fde5dcd56e915851862733591ec8c9d375fb0ef5927fd0bad6f151c380a49d4dd9578106a8ade03f468b37905a9d6096b167f03b5d11ed737673cd6566a0f506b9c38811bc2d7854873dfb1ab8cdd15f4e053c256b3895c140c89fac7b930b90d165d40ee79ac54bc935aa9355a0a8ee0cfed79a96df1c306dd1b36d4d8d47e9b9a3ae41807e7551778c758c4b79fb4ee65c40817e5a40ffb98e19259d2ed4b0068d126c5a60a9aac1bd143c8ed29bb347ab321a12e365ed35c4ba9150fbcd3e36275a350fdaf5cb4b797e637b56bbd994288145` )
+    : ( Vec u ) e ( hx `010001` )
+    : ( Vec u ) sigp ( hx `644f4bab3d85f7971bdf0d212097535562e7fcefde00c7575b28f23cd6fe2156f931c01f71618d03ad68e4cb05903e4a4b1fdd80be5235ee3dc76816d7ccfff05f0501dba24cbae4925793378f49aeaafc9d1216614400279e734820a6dfb7b1868cd751a4b5f2b01f4d542e8d9f37646b7ee33cf2523e03a13b104fb74ca08cb7dab00771167107d95dbbf297bb49716a75dc47519eb18045f51d69120bb59cc310c56cd9fbcea114aee982aabf6fbad13dd84361b87c419e1c02745e0a44c3d7531358377b328c4f171c06eeb3bb73a57e2c80d30b9bdc38d35f5c89edf9dd5415d01a5e2b7fbec631847d217fd907f8b473058016fb47c99bce209635b2d1` )
+    : ( Vec u ) sigpss ( hx `4821e780268e95ac996bd7c18c7e1ac76935408a618fcfd305761ad9c7a23e1ee1dfd62afeb19cd7629e119d87fe2f64c83cf3869b819ff5c50ba1f16528098b8359fe00633624214eeeb0571bfa03f4c5434b2dbdb4e0546ceafb28e043b09f1ac67c387f3d9ecac5522ac08da4676eb7fd971a987036cc7c848aab7e00be5677cf0aea462094e6aee5a219d254a9022a73d647417efadd470f9cc2d3c5e49a46bef9b0ce079b28840c8d30297c7820441071bed7b074bebff735fb3b2beb39fa36587641529a2e1c771000e0cf834d576d8cb75f9dfa694817995b8d79b9e7bf5b194575e01507a388886c5f1c2a7bf95f338e21afcf83739a0a7abd73ba99` )
+    : ( Vec u ) digest ( hx `1031770a16d99b47df8643467958ecaa4c86ea2668c231b39cf7f9153a4f3640` )
+    : ( Vec u ) wrong ( hx `0000000000000000000000000000000000000000000000000000000000000000` )
+
+    ? ( rsa_pkcs1_verify_sha256 n e sigp digest ) { ( nurl_print `pkcs1_valid: PASS\n` ) } { ( nurl_print `pkcs1_valid: FAIL\n` ) = fails + fails 1 }
+    ? ( rsa_pkcs1_verify_sha256 n e sigp wrong ) { ( nurl_print `pkcs1_wronghash: FAIL\n` ) = fails + fails 1 } { ( nurl_print `pkcs1_wronghash: PASS\n` ) }
+    ? ( rsa_pss_verify_sha256 n e sigpss digest ) { ( nurl_print `pss_valid: PASS\n` ) } { ( nurl_print `pss_valid: FAIL\n` ) = fails + fails 1 }
+    ? ( rsa_pss_verify_sha256 n e sigpss wrong ) { ( nurl_print `pss_wronghash: FAIL\n` ) = fails + fails 1 } { ( nurl_print `pss_wronghash: PASS\n` ) }
+    // PSS sig must not verify under PKCS1 and vice-versa
+    ? ( rsa_pkcs1_verify_sha256 n e sigpss digest ) { ( nurl_print `crossuse: FAIL\n` ) = fails + fails 1 } { ( nurl_print `crossuse: PASS\n` ) }
+
+    ? == fails 0 { ( nurl_print `rsa: all checks PASS\n` ) } { ( nurl_print `rsa: FAILURES\n` ) }
+    ^ fails
+}

--- a/compiler/tests/x509_parse.nu
+++ b/compiler/tests/x509_parse.nu
@@ -9,6 +9,7 @@ $ `stdlib/std/rsa.nu`
 $ `stdlib/std/x509.nu`
 
 @ hx s raw → ( Vec u ) { ?? ( bytes_from_hex raw ) { T v → v F _ → ( vec_new [u] ) } }
+
 @ yn b x → s { ^ ? x `yes` `no` }
 
 @ main → i {

--- a/compiler/tests/x509_parse.nu
+++ b/compiler/tests/x509_parse.nu
@@ -1,0 +1,36 @@
+// x509_parse.nu — parse real X.509 certs (RSA + EC), verify the RSA
+// self-signature end-to-end, extract SANs, and check hostname matching.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/rsa.nu`
+$ `stdlib/std/x509.nu`
+
+@ hx s raw → ( Vec u ) { ?? ( bytes_from_hex raw ) { T v → v F _ → ( vec_new [u] ) } }
+@ yn b x → s { ^ ? x `yes` `no` }
+
+@ main → i {
+    : ( Vec u ) rder ( hx `3082033030820218a003020102021408443275eea77cc6cf519599f5a6af454ae8218a300d06092a864886f70d01010b050030143112301006035504030c096c6f63616c686f73743020170d3236303632343038353333375a180f32313236303533313038353333375a30143112301006035504030c096c6f63616c686f737430820122300d06092a864886f70d01010105000382010f003082010a0282010100adea46eb48765035841cf647c034586fe8834ee3a99518768a190475f6a380716a5b3477b9ea8e5ee0dcf04c0873a71a98fe8a2d8cc2d49c2d36aaef5e7a21aa1aef01bea0b6ae1ddf046e2076b30de9b283313b72f76c1616dbd88cf73612e874356601027188e7b23553ae12da5a74f15433790c085f5a37927f05070ddebcb16f7122a8133ddf5f9f31bb215614d6e4c2888a4515149a178b2d2c39fa6d0db436b0144342049f0362197baab3a0f2080bd2daa59f6945b18c598e90f9100ac372a7aa488732ea0c717647462111f2328336352696807043a5cde308a8ac01041414777e0356d408ac114eb56dd64f6a4fbb9df478b7cde9453556ba22c38d0203010001a3783076301d0603551d0e041604141ede9ccd5f694435d7214bfea720dcfbbe46ea5d301f0603551d230418301680141ede9ccd5f694435d7214bfea720dcfbbe46ea5d300f0603551d130101ff040530030101ff30230603551d11041c301a82096c6f63616c686f7374820d2a2e6578616d706c652e636f6d300d06092a864886f70d01010b05000382010100ac5a830fa8edd89154e708cbe2b02b9f334f3a2d8c83d22414b81f3d2131a19d71b6479a49c70c5fc78ae93439bb264a3f118c83893195446cb63f252a0a595a6c16bfafc38d690ab234bbf18da0a237feeced5f7e5f351e8b731dbe52f95b1a8920f972818cac7b23cdc21e6dbe50f2d8ca322e14879b336aea1fcea2041d4bdb68cdc8e32fe76df521a5dd09ec208416c3e070a5ecec5415d49fedb8af782e45794bce6ee7caa66045df30348632e2a525ed9d3f2310c1af144b89a3e7053aa6d0af9d1016f531e5d28c06a90daf29d211901dce7b7983d0a04960e0d9c31085317b5e589032835a54730e1866157acd78cd769058dc36f0063cc56c148218` )
+    : X509 rc ( x509_parse rder )
+    ( nurl_print `rsa.ok=` ) ( nurl_print ( yn . rc ok ) )
+    ( nurl_print ` sig_alg=` ) ( nurl_print ( nurl_str_int . rc sig_alg ) )
+    ( nurl_print ` key_alg=` ) ( nurl_print ( nurl_str_int . rc key_alg ) )
+    ( nurl_print ` n=` ) ( nurl_print ( nurl_str_int ( vec_len [u] . rc rsa_n ) ) )
+    ( nurl_print ` sans=` ) ( nurl_print ( nurl_str_int ( vec_len [String] . rc sans ) ) ) ( nurl_print `\n` )
+    : ( Vec u ) h ( sha256_pure . rc tbs )
+    ( nurl_print `rsa.selfsig=` ) ( nurl_print ( yn ( rsa_pkcs1_verify_sha256 . rc rsa_n . rc rsa_e . rc sig h ) ) ) ( nurl_print `\n` )
+    ( nurl_print `host localhost=` ) ( nurl_print ( yn ( x509_matches_host rc `localhost` ) ) )
+    ( nurl_print ` a.example.com=` ) ( nurl_print ( yn ( x509_matches_host rc `a.example.com` ) ) )
+    ( nurl_print ` evil=` ) ( nurl_print ( yn ( x509_matches_host rc `evil.com` ) ) ) ( nurl_print `\n` )
+
+    : ( Vec u ) eder ( hx `308201933082013aa0030201020214331665148f1889428ab097358b7077448c26cf92300a06082a8648ce3d0403023011310f300d06035504030c0665636e6f64653020170d3236303632343038353333375a180f32313236303533313038353333375a3011310f300d06035504030c0665636e6f64653059301306072a8648ce3d020106082a8648ce3d030107034200045b4078962b22f9395b3dde209c6b9eab16bc66fd8731ab3c62278766225a80a81e169229d9b5b3585e5f3bc38b14e99493d85f69c5d03077112f2cdfa8135cdea36e306c301d0603551d0e04160414a454b68b35fb34e3f62b8cd65650a8638ca47a41301f0603551d23041830168014a454b68b35fb34e3f62b8cd65650a8638ca47a41300f0603551d130101ff040530030101ff30190603551d1104123010820e65632e6578616d706c652e636f6d300a06082a8648ce3d040302034700304402201b788ef3e526c476931d33872049df70dfe7750170d5070a58925a1bcbbeb93802201f780ee19f28573a95fc3e2c49607f20b190af373c0daf6a7b103a1ed050a0e4` )
+    : X509 ec ( x509_parse eder )
+    ( nurl_print `ec.ok=` ) ( nurl_print ( yn . ec ok ) )
+    ( nurl_print ` key_alg=` ) ( nurl_print ( nurl_str_int . ec key_alg ) )
+    ( nurl_print ` curve=` ) ( nurl_print ( nurl_str_int . ec ec_curve ) )
+    ( nurl_print ` point=` ) ( nurl_print ( nurl_str_int ( vec_len [u] . ec ec_point ) ) )
+    ( nurl_print ` ec.sig_alg=` ) ( nurl_print ( nurl_str_int . ec sig_alg ) ) ( nurl_print `\n` )
+    ^ 0
+}

--- a/packages/tls/README.md
+++ b/packages/tls/README.md
@@ -1,14 +1,15 @@
 # tls — a pure-NURL TLS 1.3 client
 
 A TLS 1.3 client (RFC 8446) written entirely in NURL, with **no OpenSSL
-and no FFI beyond the libc TCP socket**. Every cryptographic primitive in
-the handshake and record layer is implemented from scratch in pure NURL,
-so an encrypted connection works on a machine that has nothing installed
-— Linux, macOS, the BSDs, Windows.
+and no FFI beyond the libc TCP socket**. Every cryptographic primitive —
+the handshake, the record layer, **and full certificate verification** —
+is implemented from scratch in pure NURL, so an authenticated, encrypted
+connection works on a machine that has nothing installed: Linux, macOS,
+the BSDs, Windows.
 
 It speaks the `TLS_CHACHA20_POLY1305_SHA256` cipher suite with the X25519
-key-exchange group, which is accepted by essentially every modern TLS 1.3
-server (OpenSSL, BoringSSL, nginx, and the large CDNs).
+key-exchange group, which is accepted by the large majority of modern
+TLS 1.3 servers (OpenSSL, BoringSSL, nginx, and the big CDNs).
 
 ## What's implemented
 
@@ -18,49 +19,54 @@ server (OpenSSL, BoringSSL, nginx, and the large CDNs).
   (RFC 5869, RFC 8446 §7.1) over pure HMAC-SHA-256.
 * **Handshake** — ClientHello (SNI, supported_versions, supported_groups,
   signature_algorithms, key_share), ServerHello parsing, the full
-  handshake/application key schedule, decryption of the server flight
-  (EncryptedExtensions, Certificate, CertificateVerify, Finished),
+  handshake/application key schedule, decryption of the server flight,
   verification of the server Finished MAC, and the client Finished.
-* **Application data** — encrypted `tls_write` / `tls_read`, transparently
-  consuming post-handshake messages (session tickets, key updates).
+* **Certificate verification (verify-full, the default)** —
+  * the server's **CertificateVerify** signature over the handshake
+    transcript;
+  * the presented **certificate chain** (each cert signed by the next);
+  * an **anchor** in the system trust store (matched by trusted
+    subject+key, or by issuer with a verified signature);
+  * the **validity window** (notBefore/notAfter);
+  * **hostname** matching against the leaf SANs (RFC 6125 `*.` wildcards).
+  * Signature algorithms: RSA PKCS#1 v1.5 (SHA-256/384/512), RSA-PSS
+    (SHA-256), ECDSA P-256/SHA-256 and P-384/SHA-384 — the algorithms used
+    by essentially all real RSA and ECDSA certificate chains.
+* **Application data** — encrypted `tls_write` / `tls_read`.
 
-Each of the crypto primitives is validated against its RFC's published
-known-answer vectors (`compiler/tests/x25519_vectors`,
-`chacha20poly1305_vectors`, `hkdf_vectors`), and the end-to-end handshake
-has been verified against both an OpenSSL `s_server` and Cloudflare's
-production endpoint.
-
-## ⚠ Security status — read this
-
-This release establishes an **encrypted** channel but does **not yet
-verify the server's certificate chain**. That means it protects against
-passive eavesdropping but **not** against an active man-in-the-middle —
-it is at the level of `sslmode=require`, not `verify-full`.
-
-The handshake captures the server's leaf certificate
-(`conn.server_cert`, DER) so that a certificate-verification layer
-(ASN.1/X.509 parsing, RSA/ECDSA/Ed25519 signature checking, chain
-building against the system trust store, and hostname matching) can be
-added on top. Until that lands, do not rely on this for authenticating a
-remote server over an untrusted network.
+Every crypto primitive is validated against its RFC's published
+known-answer vectors (`x25519_vectors`, `chacha20poly1305_vectors`,
+`hkdf_vectors`, `rsa_verify`, `ecdsa_p256_verify`, `x509_parse`). The
+end-to-end client has been verified against OpenSSL and, with full
+certificate verification, against live `example.com` and `cloudflare.com`
+(accepted) and self-signed / wrong-hostname cases (rejected).
 
 ## API
 
 ```
-( tls_connect host port server_name ) → !*TlsConn TlsErr
-( tls_write conn ( Vec u ) bytes )     → !v TlsErr
-( tls_read conn max )                  → !( Vec u ) TlsErr   // [] at EOF
-( tls_close conn )                     → v
+( tls_connect host port server_name )          → !*TlsConn TlsErr  // verify-full
+( tls_connect_insecure host port server_name ) → !*TlsConn TlsErr  // no cert check
+( tls_write conn ( Vec u ) bytes )             → !v TlsErr
+( tls_read conn max )                          → !( Vec u ) TlsErr // [] at EOF
+( tls_close conn )                             → v
 ```
+
+`tls_connect` is secure by default: it fails with `TlsBadCert` unless the
+chain verifies. `tls_connect_insecure` skips verification (pinned /
+self-signed / testing only) — encrypted but not authenticated.
+
+## Limitations
+
+* **One cipher suite** — `TLS_CHACHA20_POLY1305_SHA256` only. Servers that
+  do not offer ChaCha20 (some AES-only configurations) are not yet
+  supported; AES-128-GCM is the planned next addition.
+* No TLS 1.2, no client certificates, no session resumption, no OCSP /
+  CRL revocation checking. Ed25519 and P-521 certificate signatures are
+  not yet verified (rare in practice).
 
 ## Demo
 
-`src/https_get.nu` is a minimal HTTPS client:
-
 ```
 ./nurl.sh packages/tls/src/https_get.nu https_get
-./https_get cloudflare.com 443 /
+./https_get example.com 443 /
 ```
-
-It completes the TLS 1.3 handshake and prints the (decrypted) HTTP
-response.

--- a/packages/tls/README.md
+++ b/packages/tls/README.md
@@ -7,14 +7,16 @@ is implemented from scratch in pure NURL, so an authenticated, encrypted
 connection works on a machine that has nothing installed: Linux, macOS,
 the BSDs, Windows.
 
-It speaks the `TLS_CHACHA20_POLY1305_SHA256` cipher suite with the X25519
-key-exchange group, which is accepted by the large majority of modern
-TLS 1.3 servers (OpenSSL, BoringSSL, nginx, and the big CDNs).
+It speaks both the `TLS_AES_128_GCM_SHA256` and
+`TLS_CHACHA20_POLY1305_SHA256` cipher suites with the X25519 key-exchange
+group — between them accepted by essentially every modern TLS 1.3 server
+(OpenSSL, BoringSSL, nginx, and the big CDNs).
 
 ## What's implemented
 
 * **Key exchange** — X25519 (RFC 7748), constant-time Montgomery ladder.
-* **Record protection** — ChaCha20-Poly1305 AEAD (RFC 8439).
+* **Record protection** — ChaCha20-Poly1305 AEAD (RFC 8439) and
+  AES-128-GCM (NIST SP 800-38D), negotiated per the server's choice.
 * **Key schedule** — HKDF-Extract/Expand + HKDF-Expand-Label / Derive-Secret
   (RFC 5869, RFC 8446 §7.1) over pure HMAC-SHA-256.
 * **Handshake** — ClientHello (SNI, supported_versions, supported_groups,
@@ -57,12 +59,11 @@ self-signed / testing only) — encrypted but not authenticated.
 
 ## Limitations
 
-* **One cipher suite** — `TLS_CHACHA20_POLY1305_SHA256` only. Servers that
-  do not offer ChaCha20 (some AES-only configurations) are not yet
-  supported; AES-128-GCM is the planned next addition.
-* No TLS 1.2, no client certificates, no session resumption, no OCSP /
-  CRL revocation checking. Ed25519 and P-521 certificate signatures are
-  not yet verified (rare in practice).
+* **TLS 1.3 only** — no TLS 1.2 fallback (so TLS-1.2-only servers are out
+  of reach).
+* No client certificates, no session resumption / 0-RTT, no OCSP / CRL
+  revocation checking. Ed25519 and P-521 certificate signatures are not
+  yet verified (rare in practice).
 
 ## Demo
 

--- a/packages/tls/src/tls.nu
+++ b/packages/tls/src/tls.nu
@@ -10,14 +10,16 @@
 // server (OpenSSL, BoringSSL, nginx, the big CDNs).
 //
 // Surface:
-//   ( tls_connect host port server_name ) → !*TlsConn TlsErr   (no cert check)
-//   ( tls_write conn bytes )              → !v TlsErr
-//   ( tls_read conn max )                 → !( Vec u ) TlsErr   ([] at EOF)
-//   ( tls_close conn )                    → v
+//   ( tls_connect host port server_name )          → !*TlsConn TlsErr  (verify-full)
+//   ( tls_connect_insecure host port server_name ) → !*TlsConn TlsErr  (no cert check)
+//   ( tls_write conn bytes )                       → !v TlsErr
+//   ( tls_read conn max )                          → !( Vec u ) TlsErr  ([] at EOF)
+//   ( tls_close conn )                             → v
 //
-// Certificate verification is handled by a separate layer (the server's
-// certificate is captured into `conn` for the verifier to inspect); this
-// module establishes the encrypted channel and the handshake transcript.
+// `tls_connect` is secure by default: it completes the handshake and then
+// verifies the server certificate chain (see verify.nu) against the system
+// trust store, failing with TlsBadCert otherwise. `tls_connect_insecure`
+// is the encrypted-but-unauthenticated escape hatch.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -27,10 +29,11 @@ $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/hkdf.nu`
 $ `stdlib/std/x25519.nu`
 $ `stdlib/std/chacha20poly1305.nu`
+$ `packages/tls/src/verify.nu`
 
 & `libc` @ nurl_tcp_connect s host i port → i
-& `c` @ nurl_rand_fill * u buf i n → i
 
+& `c` @ nurl_rand_fill *u buf i n → i
 
 : | TlsErr {
     TlsConnect
@@ -43,6 +46,7 @@ $ `stdlib/std/chacha20poly1305.nu`
     TlsProtocol
     TlsBadCipher
     TlsHRR
+    TlsBadCert
 }
 
 @ tls_err_name TlsErr e → s {
@@ -57,6 +61,7 @@ $ `stdlib/std/chacha20poly1305.nu`
         TlsProtocol → `TlsProtocol`
         TlsBadCipher → `TlsBadCipher`
         TlsHRR → `TlsHRR`
+        TlsBadCert → `TlsBadCert`
     }
 }
 
@@ -64,19 +69,22 @@ $ `stdlib/std/chacha20poly1305.nu`
 // (handshake → application) and as buffers are consumed.
 : TlsConn {
     TcpConn tcp
-    ( Vec u ) rxbuf       // raw socket bytes not yet split into records
-    ( Vec u ) hsbuf       // decrypted handshake bytes not yet a full message
-    ( Vec u ) appbuf      // decrypted application bytes for the caller
+    ( Vec u ) rxbuf  // raw socket bytes not yet split into records
+    ( Vec u ) hsbuf  // decrypted handshake bytes not yet a full message
+    ( Vec u ) appbuf  // decrypted application bytes for the caller
     ( Vec u ) s_key
     ( Vec u ) s_iv
     ( Vec u ) c_key
     ( Vec u ) c_iv
     i s_seq
     i c_seq
-    i enc_read           // 1 once server records are encrypted
+    i enc_read  // 1 once server records are encrypted
     i established
     i closed
-    ( Vec u ) server_cert // first cert in the server's chain (DER), for the verifier
+    ( Vec u ) cert_msg  // raw Certificate handshake message (full chain)
+    ( Vec u ) cv_sig  // CertificateVerify signature
+    ( Vec u ) th_cert  // transcript hash through Certificate (for CertVerify)
+    i cv_scheme  // CertificateVerify SignatureScheme
 }
 
 // ── small helpers ─────────────────────────────────────────────────
@@ -322,8 +330,8 @@ $ `stdlib/std/chacha20poly1305.nu`
 // ── ClientHello ───────────────────────────────────────────────────
 @ __build_client_hello s host ( Vec u ) pubkey ( Vec u ) random ( Vec u ) sessid → ( Vec u ) {
     : ( Vec u ) body ( vec_new [u] )
-    ( __u16 body 771 )            // legacy_version 0x0303
-    ( __cat body random )         // 32-byte random
+    ( __u16 body 771 )  // legacy_version 0x0303
+    ( __cat body random )  // 32-byte random
     ( vec_push [u] body # u 32 )  // session id length
     ( __cat body sessid )
     // cipher_suites: TLS_CHACHA20_POLY1305_SHA256 (0x1303)
@@ -339,8 +347,8 @@ $ `stdlib/std/chacha20poly1305.nu`
     // server_name (0x0000)
     : ( Vec u ) sni ( vec_new [u] )
     : i hl ( nurl_str_len host )
-    ( __u16 sni + hl 3 )          // ServerNameList length
-    ( vec_push [u] sni # u 0 )    // name_type host_name
+    ( __u16 sni + hl 3 )  // ServerNameList length
+    ( vec_push [u] sni # u 0 )  // name_type host_name
     ( __u16 sni hl )
     : ~ i k 0
     ~ < k hl { ( vec_push [u] sni # u ( nurl_str_get host k ) ) = k + k 1 }
@@ -358,15 +366,15 @@ $ `stdlib/std/chacha20poly1305.nu`
 
     // signature_algorithms (0x000d)
     : ( Vec u ) sa ( vec_new [u] )
-    ( __u16 sa 16 )               // list length (8 algs × 2)
-    ( __u16 sa 1027 )             // ecdsa_secp256r1_sha256 0x0403
-    ( __u16 sa 2052 )             // rsa_pss_rsae_sha256    0x0804
-    ( __u16 sa 1025 )             // rsa_pkcs1_sha256       0x0401
-    ( __u16 sa 1283 )             // ecdsa_secp384r1_sha384 0x0503
-    ( __u16 sa 2053 )             // rsa_pss_rsae_sha384    0x0805
-    ( __u16 sa 2054 )             // rsa_pss_rsae_sha512    0x0806
-    ( __u16 sa 2055 )             // ed25519                0x0807
-    ( __u16 sa 1281 )             // rsa_pkcs1_sha384       0x0501
+    ( __u16 sa 16 )  // list length (8 algs × 2)
+    ( __u16 sa 1027 )  // ecdsa_secp256r1_sha256 0x0403
+    ( __u16 sa 2052 )  // rsa_pss_rsae_sha256    0x0804
+    ( __u16 sa 1025 )  // rsa_pkcs1_sha256       0x0401
+    ( __u16 sa 1283 )  // ecdsa_secp384r1_sha384 0x0503
+    ( __u16 sa 2053 )  // rsa_pss_rsae_sha384    0x0805
+    ( __u16 sa 2054 )  // rsa_pss_rsae_sha512    0x0806
+    ( __u16 sa 2055 )  // ed25519                0x0807
+    ( __u16 sa 1281 )  // rsa_pkcs1_sha384       0x0501
     ( __u16 ext 13 )
     ( __blk16 ext sa )
     ( vec_free [u] sa )
@@ -382,8 +390,8 @@ $ `stdlib/std/chacha20poly1305.nu`
     // key_share (0x0033): x25519 + 32-byte pubkey
     : ( Vec u ) ks ( vec_new [u] )
     : ( Vec u ) entry ( vec_new [u] )
-    ( __u16 entry 29 )            // group x25519
-    ( __u16 entry 32 )            // key_exchange length
+    ( __u16 entry 29 )  // group x25519
+    ( __u16 entry 32 )  // key_exchange length
     ( __cat entry pubkey )
     ( __u16 ks ( vec_len [u] entry ) )
     ( __cat ks entry )
@@ -411,14 +419,14 @@ $ `stdlib/std/chacha20poly1305.nu`
     : ~ i p 4
     // HelloRetryRequest detection: random == special constant.
     ? ( __is_hrr msg ) { ^ @ !( Vec u ) TlsErr { F # TlsErr TlsHRR } } {}
-    = p + p 2            // skip legacy_version
-    = p + p 32           // skip random
+    = p + p 2  // skip legacy_version
+    = p + p 32  // skip random
     : i sidlen ( __t_bget msg p )
     = p + + p 1 sidlen
     : i cipher ( __rdint msg p 2 )
     = p + p 2
     ? != cipher 4867 { ^ @ !( Vec u ) TlsErr { F # TlsErr TlsBadCipher } } {}
-    = p + p 1            // skip compression method
+    = p + p 1  // skip compression method
     : i extlen ( __rdint msg p 2 )
     = p + p 2
     : i extend + p extlen
@@ -484,21 +492,13 @@ $ `stdlib/std/chacha20poly1305.nu`
     ^ mac
 }
 
-// Extract the leaf certificate DER from a Certificate handshake message.
-@ __extract_cert ( Vec u ) msg → ( Vec u ) {
-    // type(1) len(3) ctx_len(1) ctx... certlist_len(3) [cert_len(3) cert ext(2)]...
-    : i ctxlen ( __t_bget msg 4 )
-    : ~ i p + 5 ctxlen        // skip context
-    = p + p 3                 // skip certificate_list length
-    : i clen ( __rdint msg p 3 )
-    : ( Vec u ) der ( bytes_slice msg + p 3 + + p 3 clen )
-    ^ der
-}
-
-// Establish a TLS 1.3 connection. `server_name` drives SNI (use the
-// host). Certificate verification is NOT performed here — inspect
-// conn.server_cert afterward. Returns an established TlsConn.
-@ tls_connect s host i port s server_name → !*TlsConn TlsErr {
+// Establish a TLS 1.3 connection WITHOUT verifying the server
+// certificate — encrypted but not authenticated (MITM-able). Use only
+// for pinned/self-signed/testing cases. `tls_connect` (below) is the
+// secure, verifying entry point. The presented chain, CertificateVerify
+// signature and transcript hash are captured on the conn for the
+// verifier.
+@ tls_connect_insecure s host i port s server_name → !*TlsConn TlsErr {
     : i raw ( nurl_tcp_connect host port )
     : i ek ( nurl_tcp_err_kind raw )
     ? != ek 0 { ^ @ !*TlsConn TlsErr { F # TlsErr TlsConnect } } {}
@@ -507,7 +507,7 @@ $ `stdlib/std/chacha20poly1305.nu`
 
     // Heap-allocate the connection so field mutations (key rotation,
     // buffer consumption) in the helpers persist across calls.
-    : * TlsConn c # * TlsConn ( nurl_alloc Z TlsConn )
+    : *TlsConn c # *TlsConn ( nurl_alloc Z TlsConn )
     = . c tcp tcp
     = . c rxbuf ( vec_new [u] )
     = . c hsbuf ( vec_new [u] )
@@ -521,7 +521,10 @@ $ `stdlib/std/chacha20poly1305.nu`
     = . c enc_read 0
     = . c established 0
     = . c closed 0
-    = . c server_cert ( vec_new [u] )
+    = . c cert_msg ( vec_new [u] )
+    = . c cv_sig ( vec_new [u] )
+    = . c th_cert ( vec_new [u] )
+    = . c cv_scheme 0
 
     // ── key share ──
     : ( Vec u ) priv ( __rand_bytes 32 )
@@ -587,9 +590,19 @@ $ `stdlib/std/chacha20poly1305.nu`
                     = done 1
                 } {
                     ? == t 11 {
-                        : ( Vec u ) der ( __extract_cert msg )
-                        ( vec_free [u] . c server_cert )
-                        = . c server_cert der
+                        ( vec_free [u] . c cert_msg )
+                        = . c cert_msg ( bytes_slice msg 0 ( vec_len [u] msg ) )
+                    } {}
+                    ? == t 15 {
+                        // CertificateVerify: capture transcript-through-Certificate
+                        // (before appending this message) and the scheme + signature.
+                        : ( Vec u ) thc ( sha256_pure tr )
+                        ( vec_free [u] . c th_cert )
+                        = . c th_cert thc
+                        = . c cv_scheme ( __rdint msg 4 2 )
+                        : i siglen ( __rdint msg 6 2 )
+                        ( vec_free [u] . c cv_sig )
+                        = . c cv_sig ( bytes_slice msg 8 + 8 siglen )
                     } {}
                     ( __cat tr msg )
                 }
@@ -635,6 +648,27 @@ $ `stdlib/std/chacha20poly1305.nu`
     ( vec_free [u] master ) ( vec_free [u] th_sf ) ( vec_free [u] c_ap ) ( vec_free [u] s_ap )
     ( vec_free [u] cfin ) ( vec_free [u] finmsg )
     ^ @ !*TlsConn TlsErr { T c }
+}
+
+// Establish a verified TLS 1.3 connection (the secure default): complete
+// the handshake, then verify the server's CertificateVerify signature,
+// the certificate chain up to the system trust store, the validity
+// window, and that `server_name` matches the leaf SANs. On any failure
+// the connection is closed and TlsBadCert is returned.
+@ tls_connect s host i port s server_name → !*TlsConn TlsErr {
+    : !*TlsConn TlsErr r ( tls_connect_insecure host port server_name )
+    ?? r {
+        F e → { ^ @ !*TlsConn TlsErr { F e } }
+        T c → {
+            : i rc ( tls_cert_verify . c cert_msg . c cv_scheme . c cv_sig . c th_cert server_name )
+            ? == rc 0 {
+                ^ @ !*TlsConn TlsErr { T c }
+            } {
+                ( tls_close c )
+                ^ @ !*TlsConn TlsErr { F # TlsErr TlsBadCert }
+            }
+        }
+    }
 }
 
 // Compare a Finished message's verify_data (bytes 4..36) against expected.
@@ -735,6 +769,8 @@ $ `stdlib/std/chacha20poly1305.nu`
     ( vec_free [u] . c appbuf )
     ( vec_free [u] . c s_key ) ( vec_free [u] . c s_iv )
     ( vec_free [u] . c c_key ) ( vec_free [u] . c c_iv )
-    ( vec_free [u] . c server_cert )
+    ( vec_free [u] . c cert_msg )
+    ( vec_free [u] . c cv_sig )
+    ( vec_free [u] . c th_cert )
     ( nurl_free # s c )
 }

--- a/packages/tls/src/tls.nu
+++ b/packages/tls/src/tls.nu
@@ -5,9 +5,9 @@
 // program can open an authenticated, encrypted TLS 1.3 connection on a
 // host with nothing installed — Linux, macOS, the BSDs, Windows.
 //
-// Cipher suite: TLS_CHACHA20_POLY1305_SHA256 with the X25519 group.
-// That single suite is accepted by essentially every modern TLS 1.3
-// server (OpenSSL, BoringSSL, nginx, the big CDNs).
+// Cipher suites: TLS_AES_128_GCM_SHA256 and TLS_CHACHA20_POLY1305_SHA256
+// with the X25519 group — between them accepted by essentially every
+// modern TLS 1.3 server (OpenSSL, BoringSSL, nginx, the big CDNs).
 //
 // Surface:
 //   ( tls_connect host port server_name )          → !*TlsConn TlsErr  (verify-full)
@@ -29,6 +29,7 @@ $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/hkdf.nu`
 $ `stdlib/std/x25519.nu`
 $ `stdlib/std/chacha20poly1305.nu`
+$ `stdlib/std/aes_gcm.nu`
 $ `packages/tls/src/verify.nu`
 
 & `libc` @ nurl_tcp_connect s host i port → i
@@ -85,6 +86,7 @@ $ `packages/tls/src/verify.nu`
     ( Vec u ) cv_sig  // CertificateVerify signature
     ( Vec u ) th_cert  // transcript hash through Certificate (for CertVerify)
     i cv_scheme  // CertificateVerify SignatureScheme
+    i cipher  // 0 = ChaCha20-Poly1305, 1 = AES-128-GCM
 }
 
 // ── small helpers ─────────────────────────────────────────────────
@@ -194,6 +196,17 @@ $ `packages/tls/src/verify.nu`
     ^ n
 }
 
+// AEAD dispatch on the negotiated cipher suite.
+@ __aead_seal i cipher ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) pt → ( Vec u ) {
+    ? == cipher 1 { ^ ( aes128_gcm_encrypt key nonce aad pt ) } {}
+    ^ ( aead_encrypt key nonce aad pt )
+}
+
+@ __aead_open i cipher ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) ct → ?( Vec u ) {
+    ? == cipher 1 { ^ ( aes128_gcm_decrypt key nonce aad ct ) } {}
+    ^ ( aead_decrypt key nonce aad ct )
+}
+
 // AEAD-decrypt one application_data record body (ct‖tag) → inner plaintext.
 @ __decrypt_record * TlsConn c ( Vec u ) body → ?( Vec u ) {
     : i blen ( vec_len [u] body )
@@ -203,7 +216,7 @@ $ `packages/tls/src/verify.nu`
     ( vec_push [u] aad # u 3 )
     ( __u16 aad blen )
     : ( Vec u ) nonce ( __nonce . c s_iv . c s_seq )
-    : ?( Vec u ) pt ( aead_decrypt . c s_key nonce aad body )
+    : ?( Vec u ) pt ( __aead_open . c cipher . c s_key nonce aad body )
     ( vec_free [u] aad )
     ( vec_free [u] nonce )
     = . c s_seq + . c s_seq 1
@@ -233,7 +246,7 @@ $ `packages/tls/src/verify.nu`
     ( vec_push [u] aad # u 3 )
     ( __u16 aad total )
     : ( Vec u ) nonce ( __nonce . c c_iv . c c_seq )
-    : ( Vec u ) sealed ( aead_encrypt . c c_key nonce aad inner )
+    : ( Vec u ) sealed ( __aead_seal . c cipher . c c_key nonce aad inner )
     : ( Vec u ) rec ( vec_with_cap [u] + total 5 )
     ( vec_push [u] rec # u 23 )
     ( vec_push [u] rec # u 3 )
@@ -334,8 +347,11 @@ $ `packages/tls/src/verify.nu`
     ( __cat body random )  // 32-byte random
     ( vec_push [u] body # u 32 )  // session id length
     ( __cat body sessid )
-    // cipher_suites: TLS_CHACHA20_POLY1305_SHA256 (0x1303)
-    ( __u16 body 2 )
+    // cipher_suites: TLS_AES_128_GCM_SHA256 (0x1301) +
+    // TLS_CHACHA20_POLY1305_SHA256 (0x1303) — both use the SHA-256 key
+    // schedule, so either keeps the rest of the handshake unchanged.
+    ( __u16 body 4 )
+    ( __u16 body 4865 )
     ( __u16 body 4867 )
     // compression methods
     ( vec_push [u] body # u 1 )
@@ -425,7 +441,7 @@ $ `packages/tls/src/verify.nu`
     = p + + p 1 sidlen
     : i cipher ( __rdint msg p 2 )
     = p + p 2
-    ? != cipher 4867 { ^ @ !( Vec u ) TlsErr { F # TlsErr TlsBadCipher } } {}
+    ? & != cipher 4867 != cipher 4865 { ^ @ !( Vec u ) TlsErr { F # TlsErr TlsBadCipher } } {}
     = p + p 1  // skip compression method
     : i extlen ( __rdint msg p 2 )
     = p + p 2
@@ -450,6 +466,13 @@ $ `packages/tls/src/verify.nu`
     ^ @ !( Vec u ) TlsErr { T found }
 }
 
+// The cipher the server selected, as our cipher code (0 ChaCha20 / 1 AES).
+@ __sh_cipher ( Vec u ) msg → i {
+    : i sidlen ( __t_bget msg 38 )
+    : i cs ( __rdint msg + 39 sidlen 2 )
+    ^ ? == cs 4865 1 0
+}
+
 @ __is_hrr ( Vec u ) msg → b {
     // SHA-256("HelloRetryRequest") in the ServerHello random field.
     : i a ( __t_bget msg 6 )
@@ -464,7 +487,8 @@ $ `packages/tls/src/verify.nu`
 // given direction. dir 0 = server-read, 1 = client-write.
 @ __set_keys * TlsConn c i dir ( Vec u ) secret → v {
     : ( Vec u ) emptyc ( vec_new [u] )
-    : ( Vec u ) key ( hkdf_expand_label secret `key` emptyc 32 )
+    : i klen ? == . c cipher 1 16 32
+    : ( Vec u ) key ( hkdf_expand_label secret `key` emptyc klen )
     : ( Vec u ) iv ( hkdf_expand_label secret `iv` emptyc 12 )
     ( vec_free [u] emptyc )
     ? == dir 0 {
@@ -525,6 +549,7 @@ $ `packages/tls/src/verify.nu`
     = . c cv_sig ( vec_new [u] )
     = . c th_cert ( vec_new [u] )
     = . c cv_scheme 0
+    = . c cipher 0
 
     // ── key share ──
     : ( Vec u ) priv ( __rand_bytes 32 )
@@ -547,6 +572,7 @@ $ `packages/tls/src/verify.nu`
     ( __cat tr sh )
     : !( Vec u ) TlsErr spkr ( __parse_server_hello sh )
     : ( Vec u ) spub ?? spkr { T k → k F e → { ( vec_free [u] sh ) ^ ( __fail c priv cpub random sessid ch tr e ) } }
+    = . c cipher ( __sh_cipher sh )
 
     // ── key schedule (handshake) ──
     : ( Vec u ) ecdhe ( x25519 priv spub )

--- a/packages/tls/src/verify.nu
+++ b/packages/tls/src/verify.nu
@@ -1,0 +1,343 @@
+// packages/tls/src/verify.nu — TLS 1.3 certificate verification.
+//
+// Ties the pure-NURL X.509 parser and RSA/ECDSA verifiers into a real
+// "verify-full": it checks the server's CertificateVerify signature,
+// walks the presented chain (each cert signed by the next), anchors the
+// top to a certificate in the system trust store, enforces the validity
+// window, and matches the hostname against the leaf SANs. No OpenSSL.
+//
+//   ( tls_cert_verify cert_msg cv_scheme cv_sig th_cert hostname ) → i
+//     0 ok · 1 no certs · 2 parse · 3 CertVerify · 4 chain link
+//     5 no trust anchor · 6 anchor sig · 7 hostname · 8 expired
+//     9 unsupported algorithm
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/hash_sha512.nu`
+$ `stdlib/std/rsa.nu`
+$ `stdlib/std/ecdsa_p256.nu`
+$ `stdlib/std/x509.nu`
+
+@ __v_bget ( Vec u ) v i k → i {
+    ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ -1 }
+}
+
+// Big-endian integer of n bytes.
+@ __v_int ( Vec u ) v i off i n → i {
+    : ~ i acc 0
+    : ~ i k 0
+    ~ < k n { = acc | << acc 8 ( __v_bget v + off k ) = k + k 1 }
+    ^ acc
+}
+
+// Strip leading zeros, then left-pad to `n` bytes (for ECDSA r/s).
+@ __v_leftn ( Vec u ) v i width → ( Vec u ) {
+    : i n ( vec_len [u] v )
+    : ~ i s 0
+    ~ & < s n == ( __v_bget v s ) 0 { = s + s 1 }
+    : i mag - n s
+    : ( Vec u ) out ( vec_with_cap [u] width )
+    : ~ i pad - width mag
+    ~ > pad 0 { ( vec_push [u] out # u 0 ) = pad - pad 1 }
+    : ~ i i s
+    ~ < i n { ( vec_push [u] out # u ( __v_bget v i ) ) = i + i 1 }
+    ^ out
+}
+
+// Parse an ECDSA DER signature SEQ{ INTEGER r, INTEGER s } → r||s, each
+// left-padded to `clen` bytes (2*clen total). Empty on malformed input.
+@ __v_ecdsa_rs_n ( Vec u ) sig i clen → ( Vec u ) {
+    : DerTlv seq ( der_at sig 0 )
+    ? != . seq ok 1 { ^ ( vec_new [u] ) } {}
+    : DerTlv ri ( der_at sig . seq start )
+    : DerTlv si ( der_at sig + . ri start . ri len )
+    ? | != . ri ok 1 != . si ok 1 { ^ ( vec_new [u] ) } {}
+    : ( Vec u ) rraw ( bytes_slice sig . ri start + . ri start . ri len )
+    : ( Vec u ) sraw ( bytes_slice sig . si start + . si start . si len )
+    : ( Vec u ) rp ( __v_leftn rraw clen )
+    : ( Vec u ) sp ( __v_leftn sraw clen )
+    : ( Vec u ) out ( vec_with_cap [u] * 2 clen )
+    ( bytes_extend_bytes out rp )
+    ( bytes_extend_bytes out sp )
+    ( vec_free [u] rraw ) ( vec_free [u] sraw ) ( vec_free [u] rp ) ( vec_free [u] sp )
+    ^ out
+}
+
+@ __v_ecdsa_rs ( Vec u ) sig → ( Vec u ) { ^ ( __v_ecdsa_rs_n sig 32 ) }
+
+@ __v_ecdsa_rs96 ( Vec u ) sig → ( Vec u ) { ^ ( __v_ecdsa_rs_n sig 48 ) }
+
+// Verify `sig` over `msg` using issuer `iss` and the given algorithm code
+// (1 rsa_pkcs1_sha256 · 4 ecdsa_p256_sha256 · 6 rsa_pss_sha256).
+// alg codes match x509 sig_alg: 1 rsa_pkcs1_sha256 · 2 _sha384 · 3 _sha512
+// · 4 ecdsa_p256_sha256 · 5 ecdsa_p384_sha384 · 6 rsa_pss_sha256.
+@ __v_sig_check X509 iss i alg ( Vec u ) sig ( Vec u ) msg → b {
+    : ~ b ok F
+    // RSA PKCS#1 v1.5, hash per alg.
+    ? & == . iss key_alg 1 == alg 1 {
+        : ( Vec u ) h ( sha256_pure msg )
+        : ( Vec u ) di ( rsa_di_sha256 )
+        = ok ( rsa_pkcs1_verify . iss rsa_n . iss rsa_e sig di h )
+        ( vec_free [u] h ) ( vec_free [u] di )
+    } {}
+    ? & == . iss key_alg 1 == alg 2 {
+        : ( Vec u ) h ( sha384_pure msg )
+        : ( Vec u ) di ( rsa_di_sha384 )
+        = ok ( rsa_pkcs1_verify . iss rsa_n . iss rsa_e sig di h )
+        ( vec_free [u] h ) ( vec_free [u] di )
+    } {}
+    ? & == . iss key_alg 1 == alg 3 {
+        : ( Vec u ) h ( sha512_pure msg )
+        : ( Vec u ) di ( rsa_di_sha512 )
+        = ok ( rsa_pkcs1_verify . iss rsa_n . iss rsa_e sig di h )
+        ( vec_free [u] h ) ( vec_free [u] di )
+    } {}
+    ? & == . iss key_alg 1 == alg 6 {
+        : ( Vec u ) h ( sha256_pure msg )
+        = ok ( rsa_pss_verify_sha256 . iss rsa_n . iss rsa_e sig h )
+        ( vec_free [u] h )
+    } {}
+    // ECDSA P-256/SHA-256 and P-384/SHA-384.
+    ? & == . iss key_alg 2 == alg 4 {
+        : ( Vec u ) h ( sha256_pure msg )
+        : ( Vec u ) rs ( __v_ecdsa_rs sig )
+        ? == ( vec_len [u] rs ) 64 {
+            : ( Vec u ) r ( bytes_slice rs 0 32 )
+            : ( Vec u ) s ( bytes_slice rs 32 64 )
+            = ok ( ecdsa_p256_verify . iss ec_point r s h )
+            ( vec_free [u] r ) ( vec_free [u] s )
+        } {}
+        ( vec_free [u] rs ) ( vec_free [u] h )
+    } {}
+    ? & == . iss key_alg 2 == alg 5 {
+        : ( Vec u ) h ( sha384_pure msg )
+        : ( Vec u ) rs ( __v_ecdsa_rs96 sig )
+        ? == ( vec_len [u] rs ) 96 {
+            : ( Vec u ) r ( bytes_slice rs 0 48 )
+            : ( Vec u ) s ( bytes_slice rs 48 96 )
+            = ok ( ecdsa_p384_verify . iss ec_point r s h )
+            ( vec_free [u] r ) ( vec_free [u] s )
+        } {}
+        ( vec_free [u] rs ) ( vec_free [u] h )
+    } {}
+    ^ ok
+}
+
+// Map a TLS 1.3 SignatureScheme to our algorithm code (0 = unsupported).
+@ __v_scheme_alg i scheme → i {
+    ? == scheme 2052 { ^ 6 } {}  // 0x0804 rsa_pss_rsae_sha256
+    ? == scheme 1027 { ^ 4 } {}  // 0x0403 ecdsa_secp256r1_sha256
+    ? == scheme 1025 { ^ 1 } {}  // 0x0401 rsa_pkcs1_sha256
+    ^ 0
+}
+
+// Current time as YYYYMMDDHHMMSS (matches x509 not_before/not_after).
+@ __v_now → i {
+    : Time t ( time_now )
+    ^ + + + + + * . t year 10000000000 * . t month 100000000 * . t day 1000000 * . t hour 10000 * . t min 100 . t sec
+}
+
+// Build the TLS 1.3 server CertificateVerify signed content:
+// 64×0x20 || "TLS 1.3, server CertificateVerify" || 0x00 || transcript-hash.
+@ __v_cv_content ( Vec u ) th → ( Vec u ) {
+    : ( Vec u ) m ( vec_with_cap [u] 130 )
+    : ~ i i 0
+    ~ < i 64 { ( vec_push [u] m # u 32 ) = i + i 1 }
+    ( bytes_extend_str m `TLS 1.3, server CertificateVerify` )
+    ( vec_push [u] m # u 0 )
+    ( bytes_extend_bytes m th )
+    ^ m
+}
+
+// Collect (start,len) of each certificate DER inside a Certificate
+// handshake message into parallel arrays. Returns the count.
+@ __v_certlist ( Vec u ) msg ( Vec i ) starts ( Vec i ) lens → i {
+    // [0]type [1..4]len [4]ctxlen ctx... [.]list_len(3) entries
+    : i ctxlen ( __v_bget msg 4 )
+    : ~ i p + 5 ctxlen
+    : i listend + + p 3 ( __v_int msg p 3 )
+    = p + p 3
+    : ~ i count 0
+    ~ < p listend {
+        : i clen ( __v_int msg p 3 )
+        ( vec_push [i] starts + p 3 )
+        ( vec_push [i] lens clen )
+        = count + count 1
+        : i extlen ( __v_int msg + + p 3 clen 2 )
+        = p + + + p 3 clen + 2 extlen
+    }
+    ^ count
+}
+
+// Two certs share the same public key (same trust anchor identity)?
+@ __v_pubkey_eq X509 a X509 b → b {
+    ? != . a key_alg . b key_alg { ^ F } {}
+    ? == . a key_alg 1 { ^ & ( bytes_eq . a rsa_n . b rsa_n ) ( bytes_eq . a rsa_e . b rsa_e ) } {}
+    ? == . a key_alg 2 { ^ ( bytes_eq . a ec_point . b ec_point ) } {}
+    ? == . a key_alg 3 { ^ ( bytes_eq . a ec_point . b ec_point ) } {}
+    ^ F
+}
+
+// Is the top presented cert anchored to the system trust store? True when
+// some store cert either (a) shares `top`'s subject + public key (top is
+// a trusted root, possibly a cross-signed variant), or (b) has subject ==
+// top.issuer and validly signed `top` (root not sent in the chain). Scans
+// the PEM bundle once.
+@ __v_anchor_ok X509 top → b {
+    : ( Vec u ) bundle ( __v_load_bundle )
+    : i n ( vec_len [u] bundle )
+    : i beglen ( nurl_str_len `-----BEGIN CERTIFICATE-----` )
+    : i endlen ( nurl_str_len `-----END CERTIFICATE-----` )
+    : ~ i p 0
+    : ~ b ok F
+    : ~ b done F
+    ~ & ! done < p n {
+        : i bs ( __v_find_str bundle p `-----BEGIN CERTIFICATE-----` )
+        ? < bs 0 { = done T } {
+            : i b64start + bs beglen
+            : i es ( __v_find_str bundle b64start `-----END CERTIFICATE-----` )
+            ? < es 0 { = done T } {
+                : ( Vec u ) der ( __v_pem_block bundle b64start es )
+                : X509 c ( x509_parse der )
+                ? . c ok {
+                    ? & ( bytes_eq . c subject . top subject ) ( __v_pubkey_eq c top ) {
+                        = ok T = done T
+                    } {
+                        ? & ( bytes_eq . c subject . top issuer ) ( __v_in_validity c ) {
+                            ? ( __v_sig_check c . top sig_alg . top sig . top tbs ) { = ok T = done T } {}
+                        } {}
+                    }
+                } {}
+                ( x509_free c )
+                ( vec_free [u] der )
+                = p + es endlen
+            }
+        }
+    }
+    ( vec_free [u] bundle )
+    ^ ok
+}
+
+// Decode the base64 between two PEM markers into DER.
+@ __v_pem_block ( Vec u ) bundle i b64start i end → ( Vec u ) {
+    : String b64 ( string_new )
+    : ~ i i b64start
+    ~ < i end {
+        : i ch ( __v_bget bundle i )
+        ? & != ch 10 != ch 13 { ( string_push_char b64 ch ) } {}
+        = i + i 1
+    }
+    : ( Vec u ) der ?? ( b64_decode_vec ( string_data b64 ) ) { T v → v F _ → ( vec_new [u] ) }
+    ( string_free b64 )
+    ^ der
+}
+
+// First index of literal `needle` in `hay` at/after `from`, or -1.
+@ __v_find_str ( Vec u ) hay i from s needle → i {
+    : i hn ( vec_len [u] hay )
+    : i nn ( nurl_str_len needle )
+    ? == nn 0 { ^ from } {}
+    : ~ i i from
+    ~ <= + i nn hn {
+        : ~ b m T
+        : ~ i j 0
+        ~ & m < j nn { ? != ( __v_bget hay + i j ) ( nurl_str_get needle j ) { = m F } {} = j + j 1 }
+        ? m { ^ i } {}
+        = i + i 1
+    }
+    ^ -1
+}
+
+// Read the system CA bundle (first existing well-known path).
+@ __v_load_bundle → ( Vec u ) {
+    : ( Vec u ) r1 ( __v_read_or_empty `/etc/ssl/certs/ca-certificates.crt` )
+    ? > ( vec_len [u] r1 ) 0 { ^ r1 } {}
+    ( vec_free [u] r1 )
+    : ( Vec u ) r2 ( __v_read_or_empty `/etc/pki/tls/certs/ca-bundle.crt` )
+    ? > ( vec_len [u] r2 ) 0 { ^ r2 } {}
+    ( vec_free [u] r2 )
+    : ( Vec u ) r3 ( __v_read_or_empty `/etc/ssl/cert.pem` )
+    ^ r3
+}
+
+@ __v_read_or_empty s path → ( Vec u ) {
+    ^ ?? ( read_file_bytes path ) { T v → v F _ → ( vec_new [u] ) }
+}
+
+@ __v_in_validity X509 c → b {
+    : i now ( __v_now )
+    ^ & >= now . c not_before <= now . c not_after
+}
+
+// Top-level certificate verification (see header for return codes).
+@ tls_cert_verify ( Vec u ) cert_msg i cv_scheme ( Vec u ) cv_sig ( Vec u ) th_cert s hostname → i {
+    : ( Vec i ) starts ( vec_new [i] )
+    : ( Vec i ) lens ( vec_new [i] )
+    : i count ( __v_certlist cert_msg starts lens )
+    ? == count 0 { ( vec_free [i] starts ) ( vec_free [i] lens ) ^ 1 } {}
+
+    : ~ i rc 0
+
+    // Leaf certificate.
+    : i ls ?? ( vec_get [i] starts 0 ) { T x → x F _ → 0 }
+    : i ll ?? ( vec_get [i] lens 0 ) { T x → x F _ → 0 }
+    : ( Vec u ) leafder ( bytes_slice cert_msg ls + ls ll )
+    : X509 leaf ( x509_parse leafder )
+    ? ! . leaf ok { = rc 2 } {}
+
+    // 1. CertificateVerify over the leaf public key.
+    ? == rc 0 {
+        : i alg ( __v_scheme_alg cv_scheme )
+        ? == alg 0 { = rc 9 } {
+            : ( Vec u ) content ( __v_cv_content th_cert )
+            ? ! ( __v_sig_check leaf alg cv_sig content ) { = rc 3 } {}
+            ( vec_free [u] content )
+        }
+    } {}
+
+    // 2. Hostname + leaf validity.
+    ? == rc 0 { ? ! ( x509_matches_host leaf hostname ) { = rc 7 } {} } {}
+    ? == rc 0 { ? ! ( __v_in_validity leaf ) { = rc 8 } {} } {}
+
+    // 3. Chain links: cert[i] signed by cert[i+1].
+    : ~ i li 0
+    ~ & == rc 0 < li - count 1 {
+        : i cs ?? ( vec_get [i] starts li ) { T x → x F _ → 0 }
+        : i cl ?? ( vec_get [i] lens li ) { T x → x F _ → 0 }
+        : i is2 ?? ( vec_get [i] starts + li 1 ) { T x → x F _ → 0 }
+        : i il ?? ( vec_get [i] lens + li 1 ) { T x → x F _ → 0 }
+        : ( Vec u ) cder ( bytes_slice cert_msg cs + cs cl )
+        : ( Vec u ) ider ( bytes_slice cert_msg is2 + is2 il )
+        : X509 child ( x509_parse cder )
+        : X509 issuer ( x509_parse ider )
+        ? | ! . child ok ! . issuer ok { = rc 2 } {
+            ? ! ( __v_in_validity issuer ) { = rc 8 } {}
+            ? & == rc 0 ! ( __v_sig_check issuer . child sig_alg . child sig . child tbs ) { = rc 4 } {}
+        }
+        ( x509_free child ) ( x509_free issuer )
+        ( vec_free [u] cder ) ( vec_free [u] ider )
+        = li + li 1
+    }
+
+    // 4. Anchor the top cert to the system trust store.
+    ? == rc 0 {
+        : i ts ?? ( vec_get [i] starts - count 1 ) { T x → x F _ → 0 }
+        : i tl ?? ( vec_get [i] lens - count 1 ) { T x → x F _ → 0 }
+        : ( Vec u ) tder ( bytes_slice cert_msg ts + ts tl )
+        : X509 top ( x509_parse tder )
+        ? ! ( __v_anchor_ok top ) { = rc 5 } {}
+        ( x509_free top )
+        ( vec_free [u] tder )
+    } {}
+
+    ( x509_free leaf )
+    ( vec_free [u] leafder )
+    ( vec_free [i] starts )
+    ( vec_free [i] lens )
+    ^ rc
+}

--- a/stdlib/std/aes_gcm.nu
+++ b/stdlib/std/aes_gcm.nu
@@ -1,0 +1,310 @@
+// stdlib/std/aes_gcm.nu — pure-NURL AES-128-GCM AEAD (NIST SP 800-38D),
+// no OpenSSL. This is the TLS_AES_128_GCM_SHA256 record protection — the
+// mandatory-to-implement TLS 1.3 cipher — so the client can talk to
+// servers that only offer AES.
+//
+//   ( aes128_gcm_encrypt key nonce aad pt )     → ( Vec u )  ct||tag
+//   ( aes128_gcm_decrypt key nonce aad ct_tag ) → ?( Vec u )  None if forged
+//
+//   key = 16 bytes, nonce = 12 bytes.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+
+@ __aes_bget ( Vec u ) v i k → i {
+    ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ 0 }
+}
+
+@ __aes_sbox → ( Vec u ) {
+    ^ ?? ( bytes_from_hex `637c777bf26b6fc53001672bfed7ab76ca82c97dfa5947f0add4a2af9ca472c0b7fd9326363ff7cc34a5e5f171d8311504c723c31896059a071280e2eb27b27509832c1a1b6e5aa0523bd6b329e32f8453d100ed20fcb15b6acbbe394a4c58cfd0efaafb434d338545f9027f503c9fa851a3408f929d38f5bcb6da2110fff3d2cd0c13ec5f974417c4a77e3d645d197360814fdc222a908846eeb814de5e0bdbe0323a0a4906245cc2d3ac629195e479e7c8376d8dd54ea96c56f4ea657aae08ba78252e1ca6b4c6e8dd741f4bbd8b8a703eb5664803f60e613557b986c11d9ee1f8981169d98e949b1e87e9ce5528df8ca1890dbfe6426841992d0fb054bb16` ) {
+        T v → v
+        F _ → ( vec_new [u] )
+    }
+}
+
+@ __xtime i x → i {
+    : i s << x 1
+    ^ & ? != 0 & x 128 ^^ s 27 s 255
+}
+
+// AES-128 key expansion → 176 bytes (11 round keys).
+@ __aes128_expand ( Vec u ) key ( Vec u ) sbox → ( Vec u ) {
+    : ( Vec u ) w ( vec_with_cap [u] 176 )
+    : ~ i i 0
+    ~ < i 16 { ( vec_push [u] w # u ( __aes_bget key i ) ) = i + i 1 }
+    : ( Vec u ) rcon ?? ( bytes_from_hex `01020408102040801b36` ) { T v → v F _ → ( vec_new [u] ) }
+    : ~ i n 16
+    : ~ i rc 0
+    ~ < n 176 {
+        : ~ i t0 ( __aes_bget w - n 4 )
+        : ~ i t1 ( __aes_bget w - n 3 )
+        : ~ i t2 ( __aes_bget w - n 2 )
+        : ~ i t3 ( __aes_bget w - n 1 )
+        ? == % n 16 0 {
+            // RotWord + SubWord + Rcon
+            : i a ( __aes_bget sbox t1 )
+            : i b ( __aes_bget sbox t2 )
+            : i c ( __aes_bget sbox t3 )
+            : i d ( __aes_bget sbox t0 )
+            = t0 ^^ a ( __aes_bget rcon rc )
+            = t1 b
+            = t2 c
+            = t3 d
+            = rc + rc 1
+        } {}
+        ( vec_push [u] w # u ^^ ( __aes_bget w - n 16 ) t0 )
+        ( vec_push [u] w # u ^^ ( __aes_bget w - n 15 ) t1 )
+        ( vec_push [u] w # u ^^ ( __aes_bget w - n 14 ) t2 )
+        ( vec_push [u] w # u ^^ ( __aes_bget w - n 13 ) t3 )
+        = n + n 4
+    }
+    ( vec_free [u] rcon )
+    ^ w
+}
+
+// Encrypt one 16-byte block `in` at offset `off` → 16-byte ( Vec u ).
+@ __aes_encrypt_block ( Vec u ) inb i off ( Vec u ) rk ( Vec u ) sbox → ( Vec u ) {
+    : ( Vec u ) s ( vec_with_cap [u] 16 )
+    : ~ i i 0
+    ~ < i 16 { ( vec_push [u] s # u ^^ ( __aes_bget inb + off i ) ( __aes_bget rk i ) ) = i + i 1 }
+    : ~ i round 1
+    ~ < round 10 {
+        ( __aes_sub_shift s sbox )
+        ( __aes_mixcolumns s )
+        ( __aes_addroundkey s rk * round 16 )
+        = round + round 1
+    }
+    ( __aes_sub_shift s sbox )
+    ( __aes_addroundkey s rk 160 )
+    ^ s
+}
+
+@ __aes_addroundkey ( Vec u ) s ( Vec u ) rk i off → v {
+    : ~ i i 0
+    ~ < i 16 { ( vec_set [u] s i # u ^^ ( __aes_bget s i ) ( __aes_bget rk + off i ) ) = i + i 1 }
+}
+
+// SubBytes + ShiftRows combined (state is column-major: s[r + 4c]).
+@ __aes_sub_shift ( Vec u ) s ( Vec u ) sbox → v {
+    : ( Vec u ) t ( vec_with_cap [u] 16 )
+    : ~ i i 0
+    ~ < i 16 { ( vec_push [u] t # u ( __aes_bget s i ) ) = i + i 1 }
+    : ~ i c 0
+    ~ < c 4 {
+        : ~ i r 0
+        ~ < r 4 {
+            // ShiftRows: row r takes element from column (c+r)
+            : i src + r * 4 % + c r 4
+            ( vec_set [u] s + r * 4 c # u ( __aes_bget sbox ( __aes_bget t src ) ) )
+            = r + r 1
+        }
+        = c + c 1
+    }
+    ( vec_free [u] t )
+}
+
+@ __aes_mixcolumns ( Vec u ) s → v {
+    : ~ i c 0
+    ~ < c 4 {
+        : i b0 ( __aes_bget s + 0 * 4 c )
+        : i b1 ( __aes_bget s + 1 * 4 c )
+        : i b2 ( __aes_bget s + 2 * 4 c )
+        : i b3 ( __aes_bget s + 3 * 4 c )
+        ( vec_set [u] s + 0 * 4 c # u ^^ ^^ ^^ ( __xtime b0 ) ^^ ( __xtime b1 ) b1 b2 b3 )
+        ( vec_set [u] s + 1 * 4 c # u ^^ ^^ ^^ b0 ( __xtime b1 ) ^^ ( __xtime b2 ) b2 b3 )
+        ( vec_set [u] s + 2 * 4 c # u ^^ ^^ ^^ b0 b1 ( __xtime b2 ) ^^ ( __xtime b3 ) b3 )
+        ( vec_set [u] s + 3 * 4 c # u ^^ ^^ ^^ ^^ ( __xtime b0 ) b0 b1 b2 ( __xtime b3 ) )
+        = c + c 1
+    }
+}
+
+// ── GHASH over GF(2^128) ──────────────────────────────────────────
+// Z ^= X then Z = Z·H, accumulating one 16-byte block.
+@ __ghash_mul ( Vec u ) x ( Vec u ) h → ( Vec u ) {
+    : ( Vec u ) z ( vec_with_cap [u] 16 )
+    : ~ i zi 0
+    ~ < zi 16 { ( vec_push [u] z # u 0 ) = zi + zi 1 }
+    : ( Vec u ) v ( vec_with_cap [u] 16 )
+    : ~ i vi 0
+    ~ < vi 16 { ( vec_push [u] v # u ( __aes_bget h vi ) ) = vi + vi 1 }
+    : ~ i bit 0
+    ~ < bit 128 {
+        : i byte >> bit 3
+        : i mask >> 128 & bit 7
+        ? != 0 & ( __aes_bget x byte ) mask {
+            : ~ i k 0
+            ~ < k 16 { ( vec_set [u] z k # u ^^ ( __aes_bget z k ) ( __aes_bget v k ) ) = k + k 1 }
+        } {}
+        // V >>= 1 (across 16 bytes); if LSB was set, XOR R = 0xe1||0^120.
+        : i lsb & ( __aes_bget v 15 ) 1
+        : ~ i j 15
+        ~ > j 0 {
+            ( vec_set [u] v j # u | >> ( __aes_bget v j ) 1 << & ( __aes_bget v - j 1 ) 1 7 )
+            = j - j 1
+        }
+        ( vec_set [u] v 0 # u >> ( __aes_bget v 0 ) 1 )
+        ? != 0 lsb { ( vec_set [u] v 0 # u ^^ ( __aes_bget v 0 ) 225 ) } {}
+        = bit + bit 1
+    }
+    ( vec_free [u] v )
+    ^ z
+}
+
+// GHASH `data` (zero-padded to blocks) starting from accumulator `y`.
+// Returns a fresh accumulator; does NOT consume `y` (the caller owns it).
+@ __ghash ( Vec u ) y ( Vec u ) h ( Vec u ) data → ( Vec u ) {
+    : ~ ( Vec u ) acc ( vec_with_cap [u] 16 )
+    : ~ i ci 0
+    ~ < ci 16 { ( vec_push [u] acc # u ( __aes_bget y ci ) ) = ci + ci 1 }
+    : i n ( vec_len [u] data )
+    : ~ i off 0
+    ~ < off n {
+        : ( Vec u ) blk ( vec_with_cap [u] 16 )
+        : ~ i i 0
+        ~ < i 16 {
+            ? < + off i n { ( vec_push [u] blk # u ( __aes_bget data + off i ) ) } { ( vec_push [u] blk # u 0 ) }
+            = i + i 1
+        }
+        : ~ i k 0
+        ~ < k 16 { ( vec_set [u] blk k # u ^^ ( __aes_bget blk k ) ( __aes_bget acc k ) ) = k + k 1 }
+        : ( Vec u ) nz ( __ghash_mul blk h )
+        ( vec_free [u] acc )
+        ( vec_free [u] blk )
+        = acc nz
+        = off + off 16
+    }
+    ^ acc
+}
+
+@ __ctr_block ( Vec u ) j0 i counter ( Vec u ) rk ( Vec u ) sbox → ( Vec u ) {
+    : ( Vec u ) cb ( vec_with_cap [u] 16 )
+    : ~ i i 0
+    ~ < i 12 { ( vec_push [u] cb # u ( __aes_bget j0 i ) ) = i + i 1 }
+    ( vec_push [u] cb # u & >> counter 24 255 )
+    ( vec_push [u] cb # u & >> counter 16 255 )
+    ( vec_push [u] cb # u & >> counter 8 255 )
+    ( vec_push [u] cb # u & counter 255 )
+    : ( Vec u ) ks ( __aes_encrypt_block cb 0 rk sbox )
+    ( vec_free [u] cb )
+    ^ ks
+}
+
+@ __u64be ( Vec u ) v i n → v {
+    : ~ i k 0
+    ~ < k 8 { ( vec_push [u] v # u & >> n * 8 - 7 k 255 ) = k + k 1 }
+}
+
+// Core GCM: returns ciphertext (or recovered plaintext) and writes the
+// 16-byte tag into `tag_out`. CTR mode is symmetric, so the same routine
+// serves encrypt and decrypt; the caller compares/produces the tag.
+@ __gcm_core ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) input ( Vec u ) tag_out → ( Vec u ) {
+    : ( Vec u ) sbox ( __aes_sbox )
+    : ( Vec u ) rk ( __aes128_expand key sbox )
+    : ( Vec u ) zero ( vec_with_cap [u] 16 )
+    : ~ i zz 0
+    ~ < zz 16 { ( vec_push [u] zero # u 0 ) = zz + zz 1 }
+    : ( Vec u ) h ( __aes_encrypt_block zero 0 rk sbox )
+
+    // J0 = nonce || 0x00000001
+    : ( Vec u ) j0 ( vec_with_cap [u] 12 )
+    : ~ i ni 0
+    ~ < ni 12 { ( vec_push [u] j0 # u ( __aes_bget nonce ni ) ) = ni + ni 1 }
+
+    // CTR over the input, counter from 2 (J0 uses counter 1).
+    : i n ( vec_len [u] input )
+    : ( Vec u ) out ( vec_with_cap [u] ? > n 0 n 1 )
+    : ~ i off 0
+    : ~ i ctr 2
+    ~ < off n {
+        : ( Vec u ) ks ( __ctr_block j0 ctr rk sbox )
+        : ~ i j 0
+        ~ & < j 16 < + off j n {
+            ( vec_push [u] out # u ^^ ( __aes_bget input + off j ) ( __aes_bget ks j ) )
+            = j + j 1
+        }
+        ( vec_free [u] ks )
+        = off + off 16
+        = ctr + ctr 1
+    }
+
+    // For auth, GHASH covers the CIPHERTEXT. On encrypt that's `out`; on
+    // decrypt the ciphertext is the `input`. The caller passes plaintext
+    // on encrypt / ciphertext on decrypt — so GHASH the ciphertext: it is
+    // `out` when encrypting and `input` when decrypting. We always GHASH
+    // the data that travels on the wire — handled by __gcm_tag below.
+    ( vec_free [u] sbox )
+    ( vec_free [u] rk )
+    ( vec_free [u] zero )
+    ( vec_free [u] h )
+    ( vec_free [u] j0 )
+    ^ out
+}
+
+// Compute the GCM tag over aad + ciphertext.
+@ __gcm_tag ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) ct → ( Vec u ) {
+    : ( Vec u ) sbox ( __aes_sbox )
+    : ( Vec u ) rk ( __aes128_expand key sbox )
+    : ( Vec u ) zero ( vec_with_cap [u] 16 )
+    : ~ i zz 0
+    ~ < zz 16 { ( vec_push [u] zero # u 0 ) = zz + zz 1 }
+    : ( Vec u ) h ( __aes_encrypt_block zero 0 rk sbox )
+    : ( Vec u ) y ( vec_with_cap [u] 16 )
+    : ~ i yi 0
+    ~ < yi 16 { ( vec_push [u] y # u 0 ) = yi + yi 1 }
+    : ( Vec u ) y1 ( __ghash y h aad )
+    : ( Vec u ) y2 ( __ghash y1 h ct )
+    // length block: [len(aad)*8]_64 || [len(ct)*8]_64
+    : ( Vec u ) lenblk ( vec_with_cap [u] 16 )
+    ( __u64be lenblk * ( vec_len [u] aad ) 8 )
+    ( __u64be lenblk * ( vec_len [u] ct ) 8 )
+    : ( Vec u ) y3 ( __ghash y2 h lenblk )
+    // tag = E_K(J0) XOR GHASH
+    : ( Vec u ) j0 ( vec_with_cap [u] 12 )
+    : ~ i ni 0
+    ~ < ni 12 { ( vec_push [u] j0 # u ( __aes_bget nonce ni ) ) = ni + ni 1 }
+    : ( Vec u ) ekj0 ( __ctr_block j0 1 rk sbox )
+    : ( Vec u ) tag ( vec_with_cap [u] 16 )
+    : ~ i ti 0
+    ~ < ti 16 { ( vec_push [u] tag # u ^^ ( __aes_bget y3 ti ) ( __aes_bget ekj0 ti ) ) = ti + ti 1 }
+    ( vec_free [u] sbox ) ( vec_free [u] rk ) ( vec_free [u] zero ) ( vec_free [u] h )
+    ( vec_free [u] y1 ) ( vec_free [u] y2 ) ( vec_free [u] lenblk ) ( vec_free [u] y3 )
+    ( vec_free [u] j0 ) ( vec_free [u] ekj0 ) ( vec_free [u] y )
+    ^ tag
+}
+
+// AES-128-GCM seal: returns ciphertext with the 16-byte tag appended.
+@ aes128_gcm_encrypt ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) pt → ( Vec u ) {
+    : ( Vec u ) dummy ( vec_new [u] )
+    : ( Vec u ) ct ( __gcm_core key nonce aad pt dummy )
+    ( vec_free [u] dummy )
+    : ( Vec u ) tag ( __gcm_tag key nonce aad ct )
+    : ~ i ti 0
+    ~ < ti 16 { ( vec_push [u] ct # u ( __aes_bget tag ti ) ) = ti + ti 1 }
+    ( vec_free [u] tag )
+    ^ ct
+}
+
+@ __ct_eq ( Vec u ) a i aoff ( Vec u ) b → b {
+    : ~ i diff 0
+    : ~ i k 0
+    ~ < k 16 { = diff | diff ^^ ( __aes_bget a + aoff k ) ( __aes_bget b k ) = k + k 1 }
+    ^ == diff 0
+}
+
+// AES-128-GCM open: ct_tag is ciphertext followed by its 16-byte tag.
+// None on tag mismatch.
+@ aes128_gcm_decrypt ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) ct_tag → ?( Vec u ) {
+    : i total ( vec_len [u] ct_tag )
+    ? < total 16 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    : i ctlen - total 16
+    : ( Vec u ) ct ( bytes_slice ct_tag 0 ctlen )
+    : ( Vec u ) tag ( __gcm_tag key nonce aad ct )
+    : b ok ( __ct_eq ct_tag ctlen tag )
+    ( vec_free [u] tag )
+    ? ! ok { ( vec_free [u] ct ) ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    : ( Vec u ) dummy ( vec_new [u] )
+    : ( Vec u ) pt ( __gcm_core key nonce aad ct dummy )
+    ( vec_free [u] dummy )
+    ( vec_free [u] ct )
+    ^ @ ?( Vec u ) { T pt }
+}

--- a/stdlib/std/bigint.nu
+++ b/stdlib/std/bigint.nu
@@ -518,3 +518,83 @@ $ `stdlib/core/vec.nu`
     : b fneg & neg > ( vec_len [i] mag ) 0
     ^ @ !BigInt ParseErr { T @ BigInt { fneg mag } }
 }
+
+// ── byte I/O + modular exponentiation (RSA / DH support) ──────────
+// These let BigInt carry cryptographic integers (moduli, signatures)
+// to and from their big-endian wire form and do s^e mod n.
+
+// Big-endian bytes → non-negative BigInt.
+@ bigint_from_bytes_be ( Vec u ) b → BigInt {
+    : i n ( vec_len [u] b )
+    : ( Vec i ) limbs ( vec_new [i] )
+    : ~ i i - n 1
+    ~ >= i 0 {
+        : i lo ?? ( vec_get [u] b i ) { T x → # i x F _ → 0 }
+        : ~ i hi 0
+        ? > i 0 { = hi ?? ( vec_get [u] b - i 1 ) { T x → # i x F _ → 0 } } {}
+        ( vec_push [i] limbs | lo << hi 8 )
+        = i - i 2
+    }
+    ( __norm limbs )
+    ^ @ BigInt { F limbs }
+}
+
+// Non-negative BigInt → big-endian bytes, left-padded with zeros to at
+// least `minlen` (use 0 for the minimal encoding). RSA wants the result
+// padded to the modulus byte-length.
+@ bigint_to_bytes_be BigInt x i minlen → ( Vec u ) {
+    : ( Vec i ) limbs . x limbs
+    : i nl ( vec_len [i] limbs )
+    : ( Vec u ) le ( vec_new [u] )
+    : ~ i k 0
+    ~ < k nl {
+        : i v ( __limb limbs k )
+        ( vec_push [u] le # u & v 255 )
+        ( vec_push [u] le # u & >> v 8 255 )
+        = k + k 1
+    }
+    : ~ i len ( vec_len [u] le )
+    ~ & > len 0 == ?? ( vec_get [u] le - len 1 ) { T b → # i b F _ → 0 } 0 { = len - len 1 }
+    : i outlen ? > minlen len minlen len
+    : ( Vec u ) out ( vec_with_cap [u] ? > outlen 0 outlen 1 )
+    : ~ i pad - outlen len
+    ~ > pad 0 { ( vec_push [u] out # u 0 ) = pad - pad 1 }
+    : ~ i j - len 1
+    ~ >= j 0 {
+        ( vec_push [u] out ?? ( vec_get [u] le j ) { T b → b F _ → # u 0 } )
+        = j - j 1
+    }
+    ( vec_free [u] le )
+    ^ out
+}
+
+// base^exp mod m, all non-negative. Square-and-multiply over exp's bits.
+@ bigint_modpow BigInt base BigInt exp BigInt m → BigInt {
+    : ~ BigInt result ( bigint_from_i 1 )
+    : BigInt two ( bigint_from_i 2 )
+    : ~ BigInt b ( bigint_rem base m )
+    : ~ BigInt e ( bigint_clone exp )
+    ~ ! ( bigint_is_zero e ) {
+        : BigInt r ( bigint_rem e two )
+        ? ! ( bigint_is_zero r ) {
+            : BigInt t ( bigint_mul result b )
+            : BigInt t2 ( bigint_rem t m )
+            ( bigint_free result )
+            ( bigint_free t )
+            = result t2
+        } {}
+        ( bigint_free r )
+        : BigInt bb ( bigint_mul b b )
+        : BigInt bb2 ( bigint_rem bb m )
+        ( bigint_free b )
+        ( bigint_free bb )
+        = b bb2
+        : BigInt e2 ( bigint_div e two )
+        ( bigint_free e )
+        = e e2
+    }
+    ( bigint_free b )
+    ( bigint_free e )
+    ( bigint_free two )
+    ^ result
+}

--- a/stdlib/std/ecdsa_p256.nu
+++ b/stdlib/std/ecdsa_p256.nu
@@ -20,10 +20,22 @@ $ `stdlib/std/bigint.nu`
     ( vec_free [u] v )
     ^ r
 }
+
 @ __p256_p → BigInt { ^ ( __hx `ffffffff00000001000000000000000000000000ffffffffffffffffffffffff` ) }
+
 @ __p256_n → BigInt { ^ ( __hx `ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551` ) }
+
 @ __p256_gx → BigInt { ^ ( __hx `6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296` ) }
+
 @ __p256_gy → BigInt { ^ ( __hx `4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5` ) }
+
+@ __p384_p → BigInt { ^ ( __hx `fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff` ) }
+
+@ __p384_n → BigInt { ^ ( __hx `ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973` ) }
+
+@ __p384_gx → BigInt { ^ ( __hx `aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7` ) }
+
+@ __p384_gy → BigInt { ^ ( __hx `3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f` ) }
 
 // ── field arithmetic mod p ────────────────────────────────────────
 @ __fmul BigInt a BigInt b BigInt p → BigInt {
@@ -32,12 +44,14 @@ $ `stdlib/std/bigint.nu`
     ( bigint_free t )
     ^ r
 }
+
 @ __fadd BigInt a BigInt b BigInt p → BigInt {
     : BigInt t ( bigint_add a b )
     : BigInt r ( bigint_rem t p )
     ( bigint_free t )
     ^ r
 }
+
 @ __fsub BigInt a BigInt b BigInt p → BigInt {
     : BigInt t1 ( bigint_add a p )
     : BigInt t2 ( bigint_sub t1 b )
@@ -46,20 +60,25 @@ $ `stdlib/std/bigint.nu`
     ( bigint_free t2 )
     ^ r
 }
+
 @ __fsqr BigInt a BigInt p → BigInt { ^ ( __fmul a a p ) }
+
 @ __f2 BigInt a BigInt p → BigInt { ^ ( __fadd a a p ) }
+
 @ __f3 BigInt a BigInt p → BigInt {
     : BigInt d ( __f2 a p )
     : BigInt r ( __fadd d a p )
     ( bigint_free d )
     ^ r
 }
+
 @ __f4 BigInt a BigInt p → BigInt {
     : BigInt d ( __f2 a p )
     : BigInt r ( __f2 d p )
     ( bigint_free d )
     ^ r
 }
+
 @ __f8 BigInt a BigInt p → BigInt {
     : BigInt d ( __f4 a p )
     : BigInt r ( __f2 d p )
@@ -82,11 +101,13 @@ $ `stdlib/std/bigint.nu`
 @ __jinf → Jac {
     ^ @ Jac { ( bigint_from_i 1 ) ( bigint_from_i 1 ) ( bigint_from_i 0 ) T }
 }
+
 @ __jfree Jac q → v {
     ( bigint_free . q x )
     ( bigint_free . q y )
     ( bigint_free . q z )
 }
+
 @ __jclone Jac q → Jac {
     ^ @ Jac { ( bigint_clone . q x ) ( bigint_clone . q y ) ( bigint_clone . q z ) . q inf }
 }
@@ -197,14 +218,21 @@ $ `stdlib/std/bigint.nu`
 }
 
 // ── verify ────────────────────────────────────────────────────────
-@ ecdsa_p256_verify ( Vec u ) point ( Vec u ) r ( Vec u ) s ( Vec u ) hash → b {
-    ? != ( vec_len [u] point ) 65 { ^ F } {}
-    ? != ?? ( vec_get [u] point 0 ) { T x → # i x F _ → 0 } 4 { ^ F } {}
-    : BigInt p ( __p256_p )
-    : BigInt nn ( __p256_n )
+// Both NIST P-256 and P-384 use a = -3, so the Jacobian point ops above
+// are curve-independent; this core takes the curve constants and the
+// coordinate byte length. It consumes p / nn / gx / gy.
+@ __ecdsa_verify BigInt p BigInt nn BigInt gx BigInt gy i clen ( Vec u ) point ( Vec u ) r ( Vec u ) s ( Vec u ) hash → b {
+    ? != ( vec_len [u] point ) + 1 * 2 clen {
+        ( bigint_free p ) ( bigint_free nn ) ( bigint_free gx ) ( bigint_free gy )
+        ^ F
+    } {}
+    ? != ?? ( vec_get [u] point 0 ) { T x → # i x F _ → 0 } 4 {
+        ( bigint_free p ) ( bigint_free nn ) ( bigint_free gx ) ( bigint_free gy )
+        ^ F
+    } {}
 
-    : ( Vec u ) qxb ( bytes_slice point 1 33 )
-    : ( Vec u ) qyb ( bytes_slice point 33 65 )
+    : ( Vec u ) qxb ( bytes_slice point 1 + 1 clen )
+    : ( Vec u ) qyb ( bytes_slice point + 1 clen + 1 * 2 clen )
     : BigInt qx ( bigint_from_bytes_be qxb )
     : BigInt qy ( bigint_from_bytes_be qyb )
     ( vec_free [u] qxb )
@@ -225,7 +253,7 @@ $ `stdlib/std/bigint.nu`
     : ~ b result F
     ? ok {
         : BigInt zr ( bigint_rem z nn )
-        : BigInt w ( __finv bs nn )            // s^-1 mod n
+        : BigInt w ( __finv bs nn )  // s^-1 mod n
         : BigInt u1m ( bigint_mul zr w )
         : BigInt u1 ( bigint_rem u1m nn )
         : BigInt u2m ( bigint_mul br w )
@@ -233,7 +261,7 @@ $ `stdlib/std/bigint.nu`
         : ( Vec u ) u1b ( bigint_to_bytes_be u1 0 )
         : ( Vec u ) u2b ( bigint_to_bytes_be u2 0 )
 
-        : Jac G @ Jac { ( __p256_gx ) ( __p256_gy ) ( bigint_from_i 1 ) F }
+        : Jac G @ Jac { gx gy ( bigint_from_i 1 ) F }
         : Jac Q @ Jac { qx qy ( bigint_from_i 1 ) F }
         : Jac p1 ( __jmul u1b G p )
         : Jac p2 ( __jmul u2b Q p )
@@ -251,8 +279,18 @@ $ `stdlib/std/bigint.nu`
     } {
         ( bigint_free qx )
         ( bigint_free qy )
+        ( bigint_free gx )
+        ( bigint_free gy )
     }
     ( bigint_free p ) ( bigint_free nn ) ( bigint_free br ) ( bigint_free bs )
     ( bigint_free z ) ( bigint_free one )
     ^ result
+}
+
+@ ecdsa_p256_verify ( Vec u ) point ( Vec u ) r ( Vec u ) s ( Vec u ) hash → b {
+    ^ ( __ecdsa_verify ( __p256_p ) ( __p256_n ) ( __p256_gx ) ( __p256_gy ) 32 point r s hash )
+}
+
+@ ecdsa_p384_verify ( Vec u ) point ( Vec u ) r ( Vec u ) s ( Vec u ) hash → b {
+    ^ ( __ecdsa_verify ( __p384_p ) ( __p384_n ) ( __p384_gx ) ( __p384_gy ) 48 point r s hash )
 }

--- a/stdlib/std/ecdsa_p256.nu
+++ b/stdlib/std/ecdsa_p256.nu
@@ -1,0 +1,258 @@
+// stdlib/std/ecdsa_p256.nu — pure-NURL ECDSA verification on the NIST
+// P-256 (secp256r1) curve. No OpenSSL. Built on BigInt; points are held
+// in Jacobian coordinates so the double-and-add ladder needs only one
+// field inversion at the very end.
+//
+//   ( ecdsa_p256_verify point r s hash ) → b
+//
+// point = 65-byte uncompressed public key (0x04 || X || Y).
+// r, s   = signature integers (big-endian bytes).
+// hash   = the message digest (SHA-256 → 32 bytes).
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/bigint.nu`
+
+// ── curve constants (hex → BigInt) ────────────────────────────────
+@ __hx s h → BigInt {
+    : ( Vec u ) v ?? ( bytes_from_hex h ) { T x → x F _ → ( vec_new [u] ) }
+    : BigInt r ( bigint_from_bytes_be v )
+    ( vec_free [u] v )
+    ^ r
+}
+@ __p256_p → BigInt { ^ ( __hx `ffffffff00000001000000000000000000000000ffffffffffffffffffffffff` ) }
+@ __p256_n → BigInt { ^ ( __hx `ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551` ) }
+@ __p256_gx → BigInt { ^ ( __hx `6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296` ) }
+@ __p256_gy → BigInt { ^ ( __hx `4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5` ) }
+
+// ── field arithmetic mod p ────────────────────────────────────────
+@ __fmul BigInt a BigInt b BigInt p → BigInt {
+    : BigInt t ( bigint_mul a b )
+    : BigInt r ( bigint_rem t p )
+    ( bigint_free t )
+    ^ r
+}
+@ __fadd BigInt a BigInt b BigInt p → BigInt {
+    : BigInt t ( bigint_add a b )
+    : BigInt r ( bigint_rem t p )
+    ( bigint_free t )
+    ^ r
+}
+@ __fsub BigInt a BigInt b BigInt p → BigInt {
+    : BigInt t1 ( bigint_add a p )
+    : BigInt t2 ( bigint_sub t1 b )
+    : BigInt r ( bigint_rem t2 p )
+    ( bigint_free t1 )
+    ( bigint_free t2 )
+    ^ r
+}
+@ __fsqr BigInt a BigInt p → BigInt { ^ ( __fmul a a p ) }
+@ __f2 BigInt a BigInt p → BigInt { ^ ( __fadd a a p ) }
+@ __f3 BigInt a BigInt p → BigInt {
+    : BigInt d ( __f2 a p )
+    : BigInt r ( __fadd d a p )
+    ( bigint_free d )
+    ^ r
+}
+@ __f4 BigInt a BigInt p → BigInt {
+    : BigInt d ( __f2 a p )
+    : BigInt r ( __f2 d p )
+    ( bigint_free d )
+    ^ r
+}
+@ __f8 BigInt a BigInt p → BigInt {
+    : BigInt d ( __f4 a p )
+    : BigInt r ( __f2 d p )
+    ( bigint_free d )
+    ^ r
+}
+// a^(p-2) mod p — multiplicative inverse.
+@ __finv BigInt a BigInt p → BigInt {
+    : BigInt two ( bigint_from_i 2 )
+    : BigInt pm2 ( bigint_sub p two )
+    : BigInt r ( bigint_modpow a pm2 p )
+    ( bigint_free two )
+    ( bigint_free pm2 )
+    ^ r
+}
+
+// ── Jacobian point ────────────────────────────────────────────────
+: Jac { BigInt x BigInt y BigInt z b inf }
+
+@ __jinf → Jac {
+    ^ @ Jac { ( bigint_from_i 1 ) ( bigint_from_i 1 ) ( bigint_from_i 0 ) T }
+}
+@ __jfree Jac q → v {
+    ( bigint_free . q x )
+    ( bigint_free . q y )
+    ( bigint_free . q z )
+}
+@ __jclone Jac q → Jac {
+    ^ @ Jac { ( bigint_clone . q x ) ( bigint_clone . q y ) ( bigint_clone . q z ) . q inf }
+}
+
+// Point doubling (a = -3 form).
+@ __jdouble Jac q BigInt p → Jac {
+    ? . q inf { ^ ( __jclone q ) } {}
+    ? ( bigint_is_zero . q y ) { ^ ( __jinf ) } {}
+    : BigInt A ( __fsqr . q y p )
+    : BigInt xa ( __fmul . q x A p )
+    : BigInt B ( __f4 xa p )
+    : BigInt a2 ( __fsqr A p )
+    : BigInt C ( __f8 a2 p )
+    : BigInt zsq ( __fsqr . q z p )
+    : BigInt xm ( __fsub . q x zsq p )
+    : BigInt xp ( __fadd . q x zsq p )
+    : BigInt dm ( __fmul xm xp p )
+    : BigInt D ( __f3 dm p )
+    : BigInt dsq ( __fsqr D p )
+    : BigInt b2 ( __f2 B p )
+    : BigInt X3 ( __fsub dsq b2 p )
+    : BigInt bx ( __fsub B X3 p )
+    : BigInt dbx ( __fmul D bx p )
+    : BigInt Y3 ( __fsub dbx C p )
+    : BigInt yz ( __fmul . q y . q z p )
+    : BigInt Z3 ( __f2 yz p )
+    ( bigint_free A ) ( bigint_free xa ) ( bigint_free B ) ( bigint_free a2 )
+    ( bigint_free C ) ( bigint_free zsq ) ( bigint_free xm ) ( bigint_free xp )
+    ( bigint_free dm ) ( bigint_free D ) ( bigint_free dsq ) ( bigint_free b2 )
+    ( bigint_free bx ) ( bigint_free dbx ) ( bigint_free yz )
+    ^ @ Jac { X3 Y3 Z3 F }
+}
+
+// Point addition (general Jacobian + Jacobian).
+@ __jadd Jac p1 Jac p2 BigInt p → Jac {
+    ? . p1 inf { ^ ( __jclone p2 ) } {}
+    ? . p2 inf { ^ ( __jclone p1 ) } {}
+    : BigInt z1sq ( __fsqr . p1 z p )
+    : BigInt z2sq ( __fsqr . p2 z p )
+    : BigInt u1 ( __fmul . p1 x z2sq p )
+    : BigInt u2 ( __fmul . p2 x z1sq p )
+    : BigInt z2cu ( __fmul . p2 z z2sq p )
+    : BigInt z1cu ( __fmul . p1 z z1sq p )
+    : BigInt s1 ( __fmul . p1 y z2cu p )
+    : BigInt s2 ( __fmul . p2 y z1cu p )
+    : i ucmp ( bigint_cmp u1 u2 )
+    : i scmp ( bigint_cmp s1 s2 )
+    ? == ucmp 0 {
+        ( bigint_free z1sq ) ( bigint_free z2sq ) ( bigint_free u1 ) ( bigint_free u2 )
+        ( bigint_free z2cu ) ( bigint_free z1cu ) ( bigint_free s1 ) ( bigint_free s2 )
+        ? == scmp 0 { ^ ( __jdouble p1 p ) } { ^ ( __jinf ) }
+    } {}
+    : BigInt H ( __fsub u2 u1 p )
+    : BigInt R ( __fsub s2 s1 p )
+    : BigInt hsq ( __fsqr H p )
+    : BigInt hcu ( __fmul H hsq p )
+    : BigInt u1hsq ( __fmul u1 hsq p )
+    : BigInt rsq ( __fsqr R p )
+    : BigInt t1 ( __fsub rsq hcu p )
+    : BigInt u1hsq2 ( __f2 u1hsq p )
+    : BigInt X3 ( __fsub t1 u1hsq2 p )
+    : BigInt t2 ( __fsub u1hsq X3 p )
+    : BigInt rt2 ( __fmul R t2 p )
+    : BigInt s1hcu ( __fmul s1 hcu p )
+    : BigInt Y3 ( __fsub rt2 s1hcu p )
+    : BigInt z1z2 ( __fmul . p1 z . p2 z p )
+    : BigInt Z3 ( __fmul H z1z2 p )
+    ( bigint_free z1sq ) ( bigint_free z2sq ) ( bigint_free u1 ) ( bigint_free u2 )
+    ( bigint_free z2cu ) ( bigint_free z1cu ) ( bigint_free s1 ) ( bigint_free s2 )
+    ( bigint_free H ) ( bigint_free R ) ( bigint_free hsq ) ( bigint_free hcu )
+    ( bigint_free u1hsq ) ( bigint_free rsq ) ( bigint_free t1 ) ( bigint_free u1hsq2 )
+    ( bigint_free t2 ) ( bigint_free rt2 ) ( bigint_free s1hcu ) ( bigint_free z1z2 )
+    ^ @ Jac { X3 Y3 Z3 F }
+}
+
+// k · P over the bits of k (big-endian byte view), MSB to LSB.
+@ __jmul ( Vec u ) k Jac base BigInt p → Jac {
+    : ~ Jac acc ( __jinf )
+    : i n ( vec_len [u] k )
+    : ~ i bi 0
+    ~ < bi n {
+        : i byte ?? ( vec_get [u] k bi ) { T x → # i x F _ → 0 }
+        : ~ i bit 7
+        ~ >= bit 0 {
+            : Jac d ( __jdouble acc p )
+            ( __jfree acc )
+            = acc d
+            ? != 0 & >> byte bit 1 {
+                : Jac a ( __jadd acc base p )
+                ( __jfree acc )
+                = acc a
+            } {}
+            = bit - bit 1
+        }
+        = bi + bi 1
+    }
+    ^ acc
+}
+
+// Affine x-coordinate of a Jacobian point: X / Z^2 mod p.
+@ __jaffine_x Jac q BigInt p → BigInt {
+    : BigInt zsq ( __fsqr . q z p )
+    : BigInt zinv ( __finv zsq p )
+    : BigInt x ( __fmul . q x zinv p )
+    ( bigint_free zsq )
+    ( bigint_free zinv )
+    ^ x
+}
+
+// ── verify ────────────────────────────────────────────────────────
+@ ecdsa_p256_verify ( Vec u ) point ( Vec u ) r ( Vec u ) s ( Vec u ) hash → b {
+    ? != ( vec_len [u] point ) 65 { ^ F } {}
+    ? != ?? ( vec_get [u] point 0 ) { T x → # i x F _ → 0 } 4 { ^ F } {}
+    : BigInt p ( __p256_p )
+    : BigInt nn ( __p256_n )
+
+    : ( Vec u ) qxb ( bytes_slice point 1 33 )
+    : ( Vec u ) qyb ( bytes_slice point 33 65 )
+    : BigInt qx ( bigint_from_bytes_be qxb )
+    : BigInt qy ( bigint_from_bytes_be qyb )
+    ( vec_free [u] qxb )
+    ( vec_free [u] qyb )
+
+    : BigInt br ( bigint_from_bytes_be r )
+    : BigInt bs ( bigint_from_bytes_be s )
+    : BigInt z ( bigint_from_bytes_be hash )
+    : BigInt one ( bigint_from_i 1 )
+
+    : ~ b ok T
+    // r,s must be in [1, n-1]
+    ? < ( bigint_cmp br one ) 0 { = ok F } {}
+    ? < ( bigint_cmp bs one ) 0 { = ok F } {}
+    ? >= ( bigint_cmp br nn ) 0 { = ok F } {}
+    ? >= ( bigint_cmp bs nn ) 0 { = ok F } {}
+
+    : ~ b result F
+    ? ok {
+        : BigInt zr ( bigint_rem z nn )
+        : BigInt w ( __finv bs nn )            // s^-1 mod n
+        : BigInt u1m ( bigint_mul zr w )
+        : BigInt u1 ( bigint_rem u1m nn )
+        : BigInt u2m ( bigint_mul br w )
+        : BigInt u2 ( bigint_rem u2m nn )
+        : ( Vec u ) u1b ( bigint_to_bytes_be u1 0 )
+        : ( Vec u ) u2b ( bigint_to_bytes_be u2 0 )
+
+        : Jac G @ Jac { ( __p256_gx ) ( __p256_gy ) ( bigint_from_i 1 ) F }
+        : Jac Q @ Jac { qx qy ( bigint_from_i 1 ) F }
+        : Jac p1 ( __jmul u1b G p )
+        : Jac p2 ( __jmul u2b Q p )
+        : Jac R ( __jadd p1 p2 p )
+        ? . R inf { = result F } {
+            : BigInt rx ( __jaffine_x R p )
+            : BigInt rxn ( bigint_rem rx nn )
+            = result == ( bigint_cmp rxn br ) 0
+            ( bigint_free rx )
+            ( bigint_free rxn )
+        }
+        ( __jfree G ) ( __jfree Q ) ( __jfree p1 ) ( __jfree p2 ) ( __jfree R )
+        ( bigint_free zr ) ( bigint_free w ) ( bigint_free u1m ) ( bigint_free u1 )
+        ( bigint_free u2m ) ( bigint_free u2 ) ( vec_free [u] u1b ) ( vec_free [u] u2b )
+    } {
+        ( bigint_free qx )
+        ( bigint_free qy )
+    }
+    ( bigint_free p ) ( bigint_free nn ) ( bigint_free br ) ( bigint_free bs )
+    ( bigint_free z ) ( bigint_free one )
+    ^ result
+}

--- a/stdlib/std/hash_sha512.nu
+++ b/stdlib/std/hash_sha512.nu
@@ -194,8 +194,6 @@ $ `stdlib/std/bytes.nu`
 // ── Public entry — bytes-in, 64-byte digest out. ──────────────────
 
 @ sha512_pure ( Vec u ) data → ( Vec u ) {
-    : ( Vec u64 ) K ( __sha512_K )
-
     : ( Vec u64 ) state ( vec_with_cap [u64] 8 )
     ( vec_push [u64] state # u64 7640891576956012808 )
     ( vec_push [u64] state # u64 -4942790177534073029 )
@@ -205,7 +203,27 @@ $ `stdlib/std/bytes.nu`
     ( vec_push [u64] state # u64 -7276294671716946913 )
     ( vec_push [u64] state # u64 2270897969802886507 )
     ( vec_push [u64] state # u64 6620516959819538809 )
+    ^ ( __sha512_finish data state 64 )
+}
 
+// SHA-384 — SHA-512 with a distinct IV, truncated to 48 bytes.
+@ sha384_pure ( Vec u ) data → ( Vec u ) {
+    : ( Vec u64 ) state ( vec_with_cap [u64] 8 )
+    ( vec_push [u64] state # u64 -3766243637369397544 )
+    ( vec_push [u64] state # u64 7105036623409894663 )
+    ( vec_push [u64] state # u64 -7973340178411365097 )
+    ( vec_push [u64] state # u64 1526699215303891257 )
+    ( vec_push [u64] state # u64 7436329637833083697 )
+    ( vec_push [u64] state # u64 -8163818279084223215 )
+    ( vec_push [u64] state # u64 -2662702644619276377 )
+    ( vec_push [u64] state # u64 5167115440072839076 )
+    ^ ( __sha512_finish data state 48 )
+}
+
+// Shared SHA-512/384 finaliser: pad, transform, and serialise the state
+// to `outlen` bytes. Consumes `state`.
+@ __sha512_finish ( Vec u ) data ( Vec u64 ) state i outlen → ( Vec u ) {
+    : ( Vec u64 ) K ( __sha512_K )
     : i n ( vec_len [u] data )
 
     // Process complete 128-byte blocks straight from the input.
@@ -278,6 +296,7 @@ $ `stdlib/std/bytes.nu`
 
     ( vec_free [u64] state )
     ( vec_free [u64] K )
+    : b _t ( vec_set_len [u] out outlen )
     ^ out
 }
 

--- a/stdlib/std/rsa.nu
+++ b/stdlib/std/rsa.nu
@@ -1,0 +1,180 @@
+// stdlib/std/rsa.nu — pure-NURL RSA signature verification (RSASSA
+// PKCS#1 v1.5 and PSS), built on the BigInt modular exponentiation.
+// No OpenSSL. Verification only — enough to check X.509 / TLS 1.3
+// certificate signatures.
+//
+//   ( rsa_pkcs1_verify n e sig di_prefix digest ) → b
+//   ( rsa_pss_verify_sha256 n e sig mhash )        → b
+//
+// n / e / sig are big-endian byte vectors (the modulus, public exponent,
+// and signature). `digest` is the raw hash of the signed data; di_prefix
+// is the DigestInfo ASN.1 prefix for that hash (see the rsa_di_* helpers).
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/bigint.nu`
+$ `stdlib/std/hash_sha256.nu`
+
+@ __rsa_bget ( Vec u ) v i k → i {
+    ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ -1 }
+}
+
+// Recover the encoded message EM = sig^e mod n, padded to the modulus
+// length (k bytes).
+@ __rsa_em ( Vec u ) n ( Vec u ) e ( Vec u ) sig → ( Vec u ) {
+    : BigInt bn ( bigint_from_bytes_be n )
+    : BigInt be ( bigint_from_bytes_be e )
+    : BigInt bs ( bigint_from_bytes_be sig )
+    : BigInt m ( bigint_modpow bs be bn )
+    : ( Vec u ) em ( bigint_to_bytes_be m ( vec_len [u] n ) )
+    ( bigint_free bn )
+    ( bigint_free be )
+    ( bigint_free bs )
+    ( bigint_free m )
+    ^ em
+}
+
+// DigestInfo ASN.1 prefixes (RFC 8017 §9.2 notes).
+@ rsa_di_sha256 → ( Vec u ) {
+    ^ ?? ( bytes_from_hex `3031300d060960864801650304020105000420` ) { T v → v F _ → ( vec_new [u] ) }
+}
+
+@ rsa_di_sha384 → ( Vec u ) {
+    ^ ?? ( bytes_from_hex `3041300d060960864801650304020205000430` ) { T v → v F _ → ( vec_new [u] ) }
+}
+
+@ rsa_di_sha512 → ( Vec u ) {
+    ^ ?? ( bytes_from_hex `3051300d060960864801650304020305000440` ) { T v → v F _ → ( vec_new [u] ) }
+}
+
+// RSASSA-PKCS1-v1.5 verify. EM must be 0x00 0x01 [0xFF…] 0x00 || T,
+// where T = di_prefix || digest (RFC 8017 §9.2). Constant work over the
+// recovered EM; the comparison is structural, not secret-dependent.
+@ rsa_pkcs1_verify ( Vec u ) n ( Vec u ) e ( Vec u ) sig ( Vec u ) di_prefix ( Vec u ) digest → b {
+    : i k ( vec_len [u] n )
+    ? < k 11 { ^ F } {}
+    : ( Vec u ) em ( __rsa_em n e sig )
+    : i tlen + ( vec_len [u] di_prefix ) ( vec_len [u] digest )
+    // PS length = k - tlen - 3, must be >= 8
+    : i pslen - - - k tlen 3 0
+    : ~ b ok T
+    ? < pslen 8 { = ok F } {}
+    ? != ( __rsa_bget em 0 ) 0 { = ok F } {}
+    ? != ( __rsa_bget em 1 ) 1 { = ok F } {}
+    : ~ i i 2
+    : i psend + 2 pslen
+    ~ < i psend { ? != ( __rsa_bget em i ) 255 { = ok F } {} = i + i 1 }
+    ? != ( __rsa_bget em psend ) 0 { = ok F } {}
+    : i tstart + psend 1
+    : i dplen ( vec_len [u] di_prefix )
+    : ~ i j 0
+    ~ < j dplen {
+        ? != ( __rsa_bget em + tstart j ) ( __rsa_bget di_prefix j ) { = ok F } {}
+        = j + j 1
+    }
+    : i dlen ( vec_len [u] digest )
+    : ~ i d 0
+    ~ < d dlen {
+        ? != ( __rsa_bget em + + tstart dplen d ) ( __rsa_bget digest d ) { = ok F } {}
+        = d + d 1
+    }
+    ( vec_free [u] em )
+    ^ ok
+}
+
+// Convenience for the common SHA-256 case.
+@ rsa_pkcs1_verify_sha256 ( Vec u ) n ( Vec u ) e ( Vec u ) sig ( Vec u ) digest → b {
+    : ( Vec u ) di ( rsa_di_sha256 )
+    : b r ( rsa_pkcs1_verify n e sig di digest )
+    ( vec_free [u] di )
+    ^ r
+}
+
+// ── RSASSA-PSS verify (MGF1-SHA-256, salt length = hash length) ───
+// This is the RSA signature scheme TLS 1.3 mandates for RSA certs in
+// CertificateVerify (rsa_pss_rsae_sha256) and many CAs use for chains.
+
+// MGF1 with SHA-256: stretch `seed` to `len` bytes.
+@ __mgf1_sha256 ( Vec u ) seed i len → ( Vec u ) {
+    : ( Vec u ) out ( vec_with_cap [u] ? > len 0 len 1 )
+    : ~ i counter 0
+    ~ < ( vec_len [u] out ) len {
+        : ( Vec u ) inb ( vec_with_cap [u] + ( vec_len [u] seed ) 4 )
+        : ~ i si 0
+        ~ < si ( vec_len [u] seed ) { ( vec_push [u] inb # u ( __rsa_bget seed si ) ) = si + si 1 }
+        ( vec_push [u] inb # u & >> counter 24 255 )
+        ( vec_push [u] inb # u & >> counter 16 255 )
+        ( vec_push [u] inb # u & >> counter 8 255 )
+        ( vec_push [u] inb # u & counter 255 )
+        : ( Vec u ) blk ( sha256_pure inb )
+        : ~ i bi 0
+        ~ & < bi 32 < ( vec_len [u] out ) len { ( vec_push [u] out # u ( __rsa_bget blk bi ) ) = bi + bi 1 }
+        ( vec_free [u] inb )
+        ( vec_free [u] blk )
+        = counter + counter 1
+    }
+    ^ out
+}
+
+// Bit length of a big-endian magnitude (for emBits = modBits - 1).
+@ __rsa_bitlen ( Vec u ) n → i {
+    : i len ( vec_len [u] n )
+    : ~ i i 0
+    ~ & < i len == ( __rsa_bget n i ) 0 { = i + i 1 }
+    ? >= i len { ^ 0 } {}
+    : i top ( __rsa_bget n i )
+    : ~ i bits * 8 - - len i 1
+    : ~ i t top
+    : ~ i extra 0
+    ~ > t 0 { = extra + extra 1 = t >> t 1 }
+    ^ + bits extra
+}
+
+// RSASSA-PSS-VERIFY with SHA-256 and salt length = 32 (RFC 8017 §9.1.2,
+// specialised to the TLS 1.3 rsa_pss_rsae_sha256 parameters). `mhash` is
+// SHA-256 of the signed data.
+@ rsa_pss_verify_sha256 ( Vec u ) n ( Vec u ) e ( Vec u ) sig ( Vec u ) mhash → b {
+    : i hlen 32
+    : i slen 32
+    : i k ( vec_len [u] n )
+    : i embits - ( __rsa_bitlen n ) 1
+    : i emlen / + embits 7 8
+    ? < emlen + + hlen slen 2 { ^ F } {}
+    : ( Vec u ) emfull ( __rsa_em n e sig )
+    // emfull is k bytes; EM is its low emLen bytes (right-aligned).
+    : ( Vec u ) em ( bytes_slice emfull - k emlen k )
+    ( vec_free [u] emfull )
+    : ~ b ok T
+    ? != ( __rsa_bget em - emlen 1 ) 188 { = ok F } {}   // trailer 0xbc
+    : i dblen - - emlen hlen 1
+    : ( Vec u ) maskeddb ( bytes_slice em 0 dblen )
+    : ( Vec u ) h ( bytes_slice em dblen + dblen hlen )
+    : ( Vec u ) dbmask ( __mgf1_sha256 h dblen )
+    : ( Vec u ) db ( vec_with_cap [u] dblen )
+    : ~ i i 0
+    ~ < i dblen { ( vec_push [u] db # u ^^ ( __rsa_bget maskeddb i ) ( __rsa_bget dbmask i ) ) = i + i 1 }
+    // Clear the leftmost (8*emLen - emBits) bits of DB[0].
+    : i clearbits - * 8 emlen embits
+    : i mask0 & >> 255 clearbits 255
+    ( vec_set [u] db 0 # u & ( __rsa_bget db 0 ) mask0 )
+    // DB must be 0x00.. 0x01 || salt.
+    : i psend - - dblen slen 1
+    : ~ i p 0
+    ~ < p psend { ? != ( __rsa_bget db p ) 0 { = ok F } {} = p + p 1 }
+    ? != ( __rsa_bget db psend ) 1 { = ok F } {}
+    : ( Vec u ) salt ( bytes_slice db + psend 1 dblen )
+    // H' = SHA-256( 0x00*8 || mHash || salt ).
+    : ( Vec u ) mprime ( vec_with_cap [u] + + 8 hlen slen )
+    : ~ i z 0
+    ~ < z 8 { ( vec_push [u] mprime # u 0 ) = z + z 1 }
+    : ~ i mi 0
+    ~ < mi hlen { ( vec_push [u] mprime # u ( __rsa_bget mhash mi ) ) = mi + mi 1 }
+    : ~ i sj 0
+    ~ < sj ( vec_len [u] salt ) { ( vec_push [u] mprime # u ( __rsa_bget salt sj ) ) = sj + sj 1 }
+    : ( Vec u ) hprime ( sha256_pure mprime )
+    : ~ i c 0
+    ~ < c hlen { ? != ( __rsa_bget hprime c ) ( __rsa_bget h c ) { = ok F } {} = c + c 1 }
+    ( vec_free [u] em ) ( vec_free [u] maskeddb ) ( vec_free [u] h ) ( vec_free [u] dbmask )
+    ( vec_free [u] db ) ( vec_free [u] salt ) ( vec_free [u] mprime ) ( vec_free [u] hprime )
+    ^ ok
+}

--- a/stdlib/std/rsa.nu
+++ b/stdlib/std/rsa.nu
@@ -145,7 +145,7 @@ $ `stdlib/std/hash_sha256.nu`
     : ( Vec u ) em ( bytes_slice emfull - k emlen k )
     ( vec_free [u] emfull )
     : ~ b ok T
-    ? != ( __rsa_bget em - emlen 1 ) 188 { = ok F } {}   // trailer 0xbc
+    ? != ( __rsa_bget em - emlen 1 ) 188 { = ok F } {}  // trailer 0xbc
     : i dblen - - emlen hlen 1
     : ( Vec u ) maskeddb ( bytes_slice em 0 dblen )
     : ( Vec u ) h ( bytes_slice em dblen + dblen hlen )

--- a/stdlib/std/x509.nu
+++ b/stdlib/std/x509.nu
@@ -19,7 +19,7 @@ $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 
-@ __x_bget ( Vec u ) v i k → i {
+@ __x509_bget ( Vec u ) v i k → i {
     ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ -1 }
 }
 
@@ -30,8 +30,8 @@ $ `stdlib/std/bytes.nu`
 @ der_at ( Vec u ) b i pos → DerTlv {
     : i n ( vec_len [u] b )
     ? > + pos 2 n { ^ @ DerTlv { 0 0 0 0 0 } } {}
-    : i tag ( __x_bget b pos )
-    : i l0 ( __x_bget b + pos 1 )
+    : i tag ( __x509_bget b pos )
+    : i l0 ( __x509_bget b + pos 1 )
     ? < l0 128 {
         : i start + pos 2
         ? > + start l0 n { ^ @ DerTlv { 0 0 0 0 0 } } {}
@@ -41,7 +41,7 @@ $ `stdlib/std/bytes.nu`
     ? | == nb 0 > nb 4 { ^ @ DerTlv { 0 0 0 0 0 } } {}
     : ~ i len 0
     : ~ i k 0
-    ~ < k nb { = len | << len 8 ( __x_bget b + + pos 2 k ) = k + k 1 }
+    ~ < k nb { = len | << len 8 ( __x509_bget b + + pos 2 k ) = k + k 1 }
     : i hdr + 2 nb
     : i start + pos hdr
     ? > + start len n { ^ @ DerTlv { 0 0 0 0 0 } } {}
@@ -69,7 +69,7 @@ $ `stdlib/std/bytes.nu`
 @ __der_uint ( Vec u ) b DerTlv t → ( Vec u ) {
     : ~ i s . t start
     : i end + . t start . t len
-    ~ & < s - end 1 == ( __x_bget b s ) 0 { = s + s 1 }
+    ~ & < s - end 1 == ( __x509_bget b s ) 0 { = s + s 1 }
     ^ ( bytes_slice b s end )
 }
 
@@ -80,7 +80,7 @@ $ `stdlib/std/bytes.nu`
     ? != . t len wl { ( vec_free [u] want ) ^ F } {}
     : ~ b eq T
     : ~ i i 0
-    ~ < i wl { ? != ( __x_bget b + . t start i ) ( __x_bget want i ) { = eq F } {} = i + i 1 }
+    ~ < i wl { ? != ( __x509_bget b + . t start i ) ( __x509_bget want i ) { = eq F } {} = i + i 1 }
     ( vec_free [u] want )
     ^ eq
 }
@@ -130,21 +130,21 @@ $ `stdlib/std/bytes.nu`
     : ~ i year 0
     ? == tag 23 {
         // UTCTime YY -> 2000+YY (or 1900+YY if YY>=50)
-        : i yy + * 10 - ( __x_bget b p ) 48 - ( __x_bget b + p 1 ) 48
+        : i yy + * 10 - ( __x509_bget b p ) 48 - ( __x509_bget b + p 1 ) 48
         = year ? >= yy 50 + 1900 yy + 2000 yy
         = p + p 2
     } {
         // GeneralizedTime YYYY
         : ~ i y 0
         : ~ i k 0
-        ~ < k 4 { = y + * y 10 - ( __x_bget b + p k ) 48 = k + k 1 }
+        ~ < k 4 { = y + * y 10 - ( __x509_bget b + p k ) 48 = k + k 1 }
         = year y
         = p + p 4
     }
     : ~ i acc year
     : ~ i f 0
     ~ < f 5 {
-        : i d + * 10 - ( __x_bget b p ) 48 - ( __x_bget b + p 1 ) 48
+        : i d + * 10 - ( __x509_bget b p ) 48 - ( __x509_bget b + p 1 ) 48
         = acc + * acc 100 d
         = p + p 2
         = f + f 1
@@ -156,7 +156,7 @@ $ `stdlib/std/bytes.nu`
 @ __x509_sans ( Vec u ) b DerTlv san_seq ( Vec String ) out → v {
     : ~ DerTlv e ( __der_child b san_seq )
     ~ == . e ok 1 {
-        ? == . e tag 130 {   // [2] dNSName, IA5String
+        ? == . e tag 130 {  // [2] dNSName, IA5String
             : ( Vec u ) nm ( __der_content b e )
             ( vec_push [String] out ( bytes_to_str nm ) )
             ( vec_free [u] nm )
@@ -177,14 +177,14 @@ $ `stdlib/std/bytes.nu`
         ? | is_san is_bc {
             // value is the last child (OCTET STRING), after optional critical BOOLEAN
             : ~ DerTlv nxt ( __der_next b oid )
-            ? == . nxt tag 1 { = nxt ( __der_next b nxt ) } {}   // skip critical
+            ? == . nxt tag 1 { = nxt ( __der_next b nxt ) } {}  // skip critical
             // nxt = OCTET STRING extnValue; its content is inner DER
             : DerTlv inner ( der_at b . nxt start )
             ? is_san { ( __x509_sans b inner . out sans ) } {}
             ? is_bc {
                 : DerTlv c0 ( __der_child b inner )
                 ? & == . c0 ok 1 == . c0 tag 1 {
-                    ? != ( __x_bget b . c0 start ) 0 { = . out is_ca T } {}
+                    ? != ( __x509_bget b . c0 start ) 0 { = . out is_ca T } {}
                 } {}
             } {}
         } {}
@@ -200,6 +200,7 @@ $ `stdlib/std/bytes.nu`
 
     : DerTlv tbs ( __der_child der cert )
     ? != . tbs ok 1 { ^ out } {}
+    ( vec_free [u] . out tbs )
     = . out tbs ( __der_elem_bytes der tbs )
 
     // signatureAlgorithm + signatureValue (siblings of tbs)
@@ -208,23 +209,26 @@ $ `stdlib/std/bytes.nu`
     : DerTlv sigbits ( __der_next der sigalg )
     ? == . sigbits tag 3 {
         // BIT STRING: skip the leading "unused bits" byte
+        ( vec_free [u] . out sig )
         = . out sig ( bytes_slice der + . sigbits start 1 + . sigbits start . sigbits len )
     } {}
 
     // Walk TBS children.
     : ~ DerTlv c ( __der_child der tbs )
     ? & == . c ok 1 == . c tag 160 { = c ( __der_next der c ) } {}  // skip [0] version
-    = c ( __der_next der c )   // skip serialNumber
-    = c ( __der_next der c )   // skip signature alg
+    = c ( __der_next der c )  // skip serialNumber
+    = c ( __der_next der c )  // skip signature alg
+    ( vec_free [u] . out issuer )
     = . out issuer ( __der_elem_bytes der c )
-    = c ( __der_next der c )   // validity
+    = c ( __der_next der c )  // validity
     : DerTlv nb ( __der_child der c )
     : DerTlv na ( __der_next der nb )
     = . out not_before ( __x509_time der nb )
     = . out not_after ( __x509_time der na )
     = c ( __der_next der c )
+    ( vec_free [u] . out subject )
     = . out subject ( __der_elem_bytes der c )
-    = c ( __der_next der c )   // subjectPublicKeyInfo
+    = c ( __der_next der c )  // subjectPublicKeyInfo
 
     : DerTlv keyalg ( __der_child der c )
     : DerTlv keyoid ( __der_child der keyalg )
@@ -235,7 +239,9 @@ $ `stdlib/std/bytes.nu`
         : DerTlv rsaseq ( der_at der + . keybits start 1 )
         : DerTlv ni ( __der_child der rsaseq )
         : DerTlv ei ( __der_next der ni )
+        ( vec_free [u] . out rsa_n )
         = . out rsa_n ( __der_uint der ni )
+        ( vec_free [u] . out rsa_e )
         = . out rsa_e ( __der_uint der ei )
     } {
         ? ( __der_oid_is der keyoid `2a8648ce3d0201` ) {
@@ -246,10 +252,12 @@ $ `stdlib/std/bytes.nu`
             ? ( __der_oid_is der curve `2a8648ce3d030107` ) { = cc 256 } {}
             ? ( __der_oid_is der curve `2b81040022` ) { = cc 384 } {}
             = . out ec_curve cc
+            ( vec_free [u] . out ec_point )
             = . out ec_point ( bytes_slice der + . keybits start 1 + . keybits start . keybits len )
         } {
             ? ( __der_oid_is der keyoid `2b6570` ) {
                 = . out key_alg 3
+                ( vec_free [u] . out ec_point )
                 = . out ec_point ( bytes_slice der + . keybits start 1 + . keybits start . keybits len )
             } {}
         }
@@ -288,7 +296,7 @@ $ `stdlib/std/bytes.nu`
     ? & > pl 1 == ( nurl_str_get pattern 0 ) 42 {
         // "*.rest" — host must end with ".rest" and have no dot in the
         // matched first label.
-        : s rest ( nurl_str_slice pattern 1 - pl 1 )   // ".example.com"
+        : s rest ( nurl_str_slice pattern 1 - pl 1 )  // ".example.com"
         : i rl - pl 1
         ? <= hl rl { ^ F } {}
         : i off - hl rl

--- a/stdlib/std/x509.nu
+++ b/stdlib/std/x509.nu
@@ -1,0 +1,326 @@
+// stdlib/std/x509.nu — a focused pure-NURL X.509 / DER parser.
+//
+// Not a general ASN.1 library: it walks a DER-encoded certificate and
+// pulls out exactly what certificate-chain verification needs — the raw
+// TBSCertificate bytes (what the issuer signed), the signature algorithm
+// and value, the subject public key (RSA modulus/exponent or EC point),
+// validity window, subject/issuer names, the SAN dNSNames, and the CA
+// flag. No OpenSSL.
+//
+//   ( x509_parse der ) → X509      (.ok = F on malformed input)
+//
+// Signature/key algorithm codes (sig_alg / key_alg):
+//   sig_alg: 1 rsa_pkcs1_sha256  2 _sha384  3 _sha512
+//            4 ecdsa_sha256      5 ecdsa_sha384
+//            6 rsa_pss           7 ed25519     0 unknown
+//   key_alg: 1 RSA  2 EC  3 Ed25519  0 unknown
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+
+@ __x_bget ( Vec u ) v i k → i {
+    ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ -1 }
+}
+
+// A DER element: tag, header length, content length, content start. The
+// element spans [pos, start+len).
+: DerTlv { i tag i hdr i len i start i ok }
+
+@ der_at ( Vec u ) b i pos → DerTlv {
+    : i n ( vec_len [u] b )
+    ? > + pos 2 n { ^ @ DerTlv { 0 0 0 0 0 } } {}
+    : i tag ( __x_bget b pos )
+    : i l0 ( __x_bget b + pos 1 )
+    ? < l0 128 {
+        : i start + pos 2
+        ? > + start l0 n { ^ @ DerTlv { 0 0 0 0 0 } } {}
+        ^ @ DerTlv { tag 2 l0 start 1 }
+    } {}
+    : i nb & l0 127
+    ? | == nb 0 > nb 4 { ^ @ DerTlv { 0 0 0 0 0 } } {}
+    : ~ i len 0
+    : ~ i k 0
+    ~ < k nb { = len | << len 8 ( __x_bget b + + pos 2 k ) = k + k 1 }
+    : i hdr + 2 nb
+    : i start + pos hdr
+    ? > + start len n { ^ @ DerTlv { 0 0 0 0 0 } } {}
+    ^ @ DerTlv { tag hdr len start 1 }
+}
+
+// First child of a constructed element.
+@ __der_child ( Vec u ) b DerTlv t → DerTlv { ^ ( der_at b . t start ) }
+
+// Next sibling after element `t`.
+@ __der_next ( Vec u ) b DerTlv t → DerTlv { ^ ( der_at b + . t start . t len ) }
+
+// Raw bytes of the whole element (tag..end).
+@ __der_elem_bytes ( Vec u ) b DerTlv t → ( Vec u ) {
+    ^ ( bytes_slice b - . t start . t hdr + . t start . t len )
+}
+
+// Content bytes of the element.
+@ __der_content ( Vec u ) b DerTlv t → ( Vec u ) {
+    ^ ( bytes_slice b . t start + . t start . t len )
+}
+
+// INTEGER content as an unsigned magnitude: drop DER's leading sign
+// byte(s) so the byte length equals the true modulus/exponent size.
+@ __der_uint ( Vec u ) b DerTlv t → ( Vec u ) {
+    : ~ i s . t start
+    : i end + . t start . t len
+    ~ & < s - end 1 == ( __x_bget b s ) 0 { = s + s 1 }
+    ^ ( bytes_slice b s end )
+}
+
+// Compare an OID element's content bytes to a hex literal.
+@ __der_oid_is ( Vec u ) b DerTlv t s hexoid → b {
+    : ( Vec u ) want ?? ( bytes_from_hex hexoid ) { T v → v F _ → ( vec_new [u] ) }
+    : i wl ( vec_len [u] want )
+    ? != . t len wl { ( vec_free [u] want ) ^ F } {}
+    : ~ b eq T
+    : ~ i i 0
+    ~ < i wl { ? != ( __x_bget b + . t start i ) ( __x_bget want i ) { = eq F } {} = i + i 1 }
+    ( vec_free [u] want )
+    ^ eq
+}
+
+: X509 {
+    ( Vec u ) tbs
+    i sig_alg
+    ( Vec u ) sig
+    i key_alg
+    ( Vec u ) rsa_n
+    ( Vec u ) rsa_e
+    ( Vec u ) ec_point
+    i ec_curve
+    ( Vec u ) subject
+    ( Vec u ) issuer
+    ( Vec String ) sans
+    i not_before
+    i not_after
+    b is_ca
+    b ok
+}
+
+@ __x509_empty → X509 {
+    ^ @ X509 {
+        ( vec_new [u] ) 0 ( vec_new [u] ) 0 ( vec_new [u] ) ( vec_new [u] )
+        ( vec_new [u] ) 0 ( vec_new [u] ) ( vec_new [u] ) ( vec_new [String] ) 0 0 F F
+    }
+}
+
+// Map an AlgorithmIdentifier SEQ (at `alg`) to a sig_alg code.
+@ __x509_sigalg ( Vec u ) b DerTlv alg → i {
+    : DerTlv oid ( __der_child b alg )
+    ? ( __der_oid_is b oid `2a864886f70d01010b` ) { ^ 1 } {}
+    ? ( __der_oid_is b oid `2a864886f70d01010c` ) { ^ 2 } {}
+    ? ( __der_oid_is b oid `2a864886f70d01010d` ) { ^ 3 } {}
+    ? ( __der_oid_is b oid `2a8648ce3d040302` ) { ^ 4 } {}
+    ? ( __der_oid_is b oid `2a8648ce3d040303` ) { ^ 5 } {}
+    ? ( __der_oid_is b oid `2a864886f70d01010a` ) { ^ 6 } {}
+    ? ( __der_oid_is b oid `2b6570` ) { ^ 7 } {}
+    ^ 0
+}
+
+// Parse YYMMDD…/YYYYMMDD… time content → YYYYMMDDHHMMSS as an integer.
+@ __x509_time ( Vec u ) b DerTlv t → i {
+    : i tag . t tag
+    : ~ i p . t start
+    : ~ i year 0
+    ? == tag 23 {
+        // UTCTime YY -> 2000+YY (or 1900+YY if YY>=50)
+        : i yy + * 10 - ( __x_bget b p ) 48 - ( __x_bget b + p 1 ) 48
+        = year ? >= yy 50 + 1900 yy + 2000 yy
+        = p + p 2
+    } {
+        // GeneralizedTime YYYY
+        : ~ i y 0
+        : ~ i k 0
+        ~ < k 4 { = y + * y 10 - ( __x_bget b + p k ) 48 = k + k 1 }
+        = year y
+        = p + p 4
+    }
+    : ~ i acc year
+    : ~ i f 0
+    ~ < f 5 {
+        : i d + * 10 - ( __x_bget b p ) 48 - ( __x_bget b + p 1 ) 48
+        = acc + * acc 100 d
+        = p + p 2
+        = f + f 1
+    }
+    ^ acc
+}
+
+// Pull dNSName entries (context tag 0x82) out of a SAN extnValue.
+@ __x509_sans ( Vec u ) b DerTlv san_seq ( Vec String ) out → v {
+    : ~ DerTlv e ( __der_child b san_seq )
+    ~ == . e ok 1 {
+        ? == . e tag 130 {   // [2] dNSName, IA5String
+            : ( Vec u ) nm ( __der_content b e )
+            ( vec_push [String] out ( bytes_to_str nm ) )
+            ( vec_free [u] nm )
+        } {}
+        = e ( __der_next b e )
+    }
+}
+
+// Walk extensions to capture SANs and the CA flag.
+@ __x509_extensions ( Vec u ) b DerTlv exts X509 out → v {
+    // exts is [3] EXPLICIT; its child is the SEQUENCE OF Extension.
+    : DerTlv seq ( __der_child b exts )
+    : ~ DerTlv ext ( __der_child b seq )
+    ~ == . ext ok 1 {
+        : DerTlv oid ( __der_child b ext )
+        : b is_san ( __der_oid_is b oid `551d11` )
+        : b is_bc ( __der_oid_is b oid `551d13` )
+        ? | is_san is_bc {
+            // value is the last child (OCTET STRING), after optional critical BOOLEAN
+            : ~ DerTlv nxt ( __der_next b oid )
+            ? == . nxt tag 1 { = nxt ( __der_next b nxt ) } {}   // skip critical
+            // nxt = OCTET STRING extnValue; its content is inner DER
+            : DerTlv inner ( der_at b . nxt start )
+            ? is_san { ( __x509_sans b inner . out sans ) } {}
+            ? is_bc {
+                : DerTlv c0 ( __der_child b inner )
+                ? & == . c0 ok 1 == . c0 tag 1 {
+                    ? != ( __x_bget b . c0 start ) 0 { = . out is_ca T } {}
+                } {}
+            } {}
+        } {}
+        = ext ( __der_next b ext )
+    }
+}
+
+@ x509_parse ( Vec u ) der → X509 {
+    : X509 out ( __x509_empty )
+    : DerTlv cert ( der_at der 0 )
+    ? != . cert ok 1 { ^ out } {}
+    ? != . cert tag 48 { ^ out } {}
+
+    : DerTlv tbs ( __der_child der cert )
+    ? != . tbs ok 1 { ^ out } {}
+    = . out tbs ( __der_elem_bytes der tbs )
+
+    // signatureAlgorithm + signatureValue (siblings of tbs)
+    : DerTlv sigalg ( __der_next der tbs )
+    = . out sig_alg ( __x509_sigalg der sigalg )
+    : DerTlv sigbits ( __der_next der sigalg )
+    ? == . sigbits tag 3 {
+        // BIT STRING: skip the leading "unused bits" byte
+        = . out sig ( bytes_slice der + . sigbits start 1 + . sigbits start . sigbits len )
+    } {}
+
+    // Walk TBS children.
+    : ~ DerTlv c ( __der_child der tbs )
+    ? & == . c ok 1 == . c tag 160 { = c ( __der_next der c ) } {}  // skip [0] version
+    = c ( __der_next der c )   // skip serialNumber
+    = c ( __der_next der c )   // skip signature alg
+    = . out issuer ( __der_elem_bytes der c )
+    = c ( __der_next der c )   // validity
+    : DerTlv nb ( __der_child der c )
+    : DerTlv na ( __der_next der nb )
+    = . out not_before ( __x509_time der nb )
+    = . out not_after ( __x509_time der na )
+    = c ( __der_next der c )
+    = . out subject ( __der_elem_bytes der c )
+    = c ( __der_next der c )   // subjectPublicKeyInfo
+
+    : DerTlv keyalg ( __der_child der c )
+    : DerTlv keyoid ( __der_child der keyalg )
+    : DerTlv keybits ( __der_next der keyalg )
+    ? ( __der_oid_is der keyoid `2a864886f70d010101` ) {
+        // RSA: BIT STRING content (after unused-bits byte) is SEQ{n,e}
+        = . out key_alg 1
+        : DerTlv rsaseq ( der_at der + . keybits start 1 )
+        : DerTlv ni ( __der_child der rsaseq )
+        : DerTlv ei ( __der_next der ni )
+        = . out rsa_n ( __der_uint der ni )
+        = . out rsa_e ( __der_uint der ei )
+    } {
+        ? ( __der_oid_is der keyoid `2a8648ce3d0201` ) {
+            // EC: namedCurve param + uncompressed point in the BIT STRING
+            = . out key_alg 2
+            : DerTlv curve ( __der_next der keyoid )
+            : ~ i cc 0
+            ? ( __der_oid_is der curve `2a8648ce3d030107` ) { = cc 256 } {}
+            ? ( __der_oid_is der curve `2b81040022` ) { = cc 384 } {}
+            = . out ec_curve cc
+            = . out ec_point ( bytes_slice der + . keybits start 1 + . keybits start . keybits len )
+        } {
+            ? ( __der_oid_is der keyoid `2b6570` ) {
+                = . out key_alg 3
+                = . out ec_point ( bytes_slice der + . keybits start 1 + . keybits start . keybits len )
+            } {}
+        }
+    }
+
+    // optional extensions [3]
+    = c ( __der_next der c )
+    ? & == . c ok 1 == . c tag 163 { ( __x509_extensions der c out ) } {}
+
+    = . out ok T
+    ^ out
+}
+
+// Case-insensitive hostname match against the certificate SANs, honoring
+// a single leading "*." wildcard label (RFC 6125).
+@ x509_matches_host X509 cert s host → b {
+    : ( Vec String ) sans . cert sans
+    : i n ( vec_len [String] sans )
+    : ~ i i 0
+    : ~ b ok F
+    ~ & ! ok < i n {
+        ?? ( vec_get [String] sans i ) {
+            T sv → { ? ( __host_match ( string_data sv ) host ) { = ok T } {} }
+            F _ → {}
+        }
+        = i + i 1
+    }
+    ^ ok
+}
+
+// Match `pattern` (a SAN dNSName, possibly "*.example.com") against host,
+// ASCII-case-insensitively. The wildcard matches exactly one left label.
+@ __host_match s pattern s host → b {
+    : i pl ( nurl_str_len pattern )
+    : i hl ( nurl_str_len host )
+    ? & > pl 1 == ( nurl_str_get pattern 0 ) 42 {
+        // "*.rest" — host must end with ".rest" and have no dot in the
+        // matched first label.
+        : s rest ( nurl_str_slice pattern 1 - pl 1 )   // ".example.com"
+        : i rl - pl 1
+        ? <= hl rl { ^ F } {}
+        : i off - hl rl
+        // the matched prefix host[0..off) must contain no dot
+        : ~ i k 0
+        ~ < k off { ? == ( nurl_str_get host k ) 46 { ^ F } {} = k + k 1 }
+        : s tail ( nurl_str_slice host off rl )
+        ^ ( __ci_eq tail rest )
+    } {}
+    ^ ( __ci_eq pattern host )
+}
+
+@ __ci_eq s a s b → b {
+    : i la ( nurl_str_len a )
+    ? != la ( nurl_str_len b ) { ^ F } {}
+    : ~ i i 0
+    ~ < i la {
+        ? != ( __lower ( nurl_str_get a i ) ) ( __lower ( nurl_str_get b i ) ) { ^ F } {}
+        = i + i 1
+    }
+    ^ T
+}
+
+@ __lower i c → i { ^ ? & >= c 65 <= c 90 + c 32 c }
+
+@ x509_free X509 c → v {
+    ( vec_free [u] . c tbs )
+    ( vec_free [u] . c sig )
+    ( vec_free [u] . c rsa_n )
+    ( vec_free [u] . c rsa_e )
+    ( vec_free [u] . c ec_point )
+    ( vec_free [u] . c subject )
+    ( vec_free [u] . c issuer )
+    ( vec_free_with [String] . c sans \ String s → v { ( string_free s ) } )
+}


### PR DESCRIPTION
## Summary

Builds on the pure-NURL TLS 1.3 client (#268) to make it **secure by
default and broadly interoperable** — still no OpenSSL, no FFI beyond the
libc TCP socket. Two things land:

1. **Full certificate verification (verify-full).** `tls_connect` now
   completes the handshake *and* verifies the server before returning,
   failing closed with `TlsBadCert` otherwise. `tls_connect_insecure`
   keeps the old encrypted-but-unauthenticated behaviour.
2. **AES-128-GCM** alongside ChaCha20-Poly1305, so the client reaches the
   AES-only TLS 1.3 servers that don't offer ChaCha20.

## New pure crypto (stdlib, each with a KAT golden test)

- **bigint**: `from_bytes_be` / `to_bytes_be` / `modpow`.
- **rsa**: RSASSA-PKCS1-v1.5 (SHA-256/384/512) and PSS (SHA-256) verify.
- **ecdsa_p256**: ECDSA verify on NIST **P-256 and P-384** (Jacobian
  point arithmetic over BigInt; both curves share a = -3).
- **aes_gcm**: AES-128-GCM AEAD (byte-oriented AES + GHASH + GCM).
- **x509**: a focused DER / X.509 parser (TBS, signature alg+value,
  RSA/EC public key, validity, SAN dNSNames, CA flag) + RFC 6125
  hostname matching with `*.` wildcards.
- **hash_sha512**: `sha384_pure` (shared finaliser).

Validated against RFC / NIST / OpenSSL vectors:
`rsa_verify`, `ecdsa_p256_verify`, `x509_parse`, `aes_gcm_vectors`
(McGrew GCM TC3/TC4) — all green, all leak-clean under ASan/LSan.

## Verification layer (`packages/tls/src/verify.nu`)

Ties it together: checks the server **CertificateVerify** signature over
the transcript, walks the presented **chain** (each cert signed by the
next), **anchors** the top to the system CA bundle (by trusted
subject+key, or by issuer with a verified signature), enforces the
**validity** window, and matches the **hostname** against the leaf SANs.
Covers RSA (PKCS#1 + PSS) and ECDSA P-256/P-384 chains — the algorithms
behind essentially all real-world certificates.

## End-to-end results (live, with full verification)

- **Accepted:** `example.com` (ChaCha20) and `google.com` (AES-128-GCM),
  both HTTP 200 — real chains verified against the system trust store.
- **Rejected:** self-signed (no trust anchor) and wrong-hostname, both
  `TlsBadCert`; plus wrong-digest / swapped-(r,s) at the primitive level.

## Tests / regression

Full corpus **465 PASS · 0 FAIL · 22 SKIP**; bootstrap fixed point green.

## Limitations (documented)

TLS 1.3 only (no 1.2 fallback); no client certs / resumption / OCSP;
Ed25519 and P-521 certificate signatures not yet verified (rare).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YH7KtE5CDFzy2rNCatout