### PR TITLE
packages: add psql — pure-NURL PostgreSQL client (no libpq, no OpenSSL)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -14231,9 +14231,20 @@
     // redefinition of function" error, so skip the emit — the symbol is
     // still registered above so callers resolve correctly.
     : b is_prelude_cfn | | | ( seq fname `malloc` ) ( seq fname `free` ) ( seq fname `puts` ) ( seq fname `printf` )
-    ? is_prelude_cfn
+    // Dedupe `declare`s by symbol name across the whole compilation: two
+    // imported modules may legitimately declare the same libc/runtime
+    // extern (e.g. `nurl_rand_fill` in both std/random.nu and tls.nu), and
+    // re-emitting an identical `declare` makes LLVM reject the module with
+    // "invalid redefinition of function". The symbol is still registered
+    // above (the `fname` / `__ffi` entries) so callers in every file
+    // resolve correctly — only the duplicate IR line is suppressed. This
+    // generalises the prelude-symbol skip.
+    : s emitkey ( nurl_str_cat fname `__ffi_emitted` )
+    : b already != 0 ( nurl_str_len ( nurl_sym_get syms emitkey ) )
+    ? | is_prelude_cfn already
     {}
-    { ( nurl_print `declare ` ) ( nurl_print ret_ty )
+    { ( nurl_sym_def syms emitkey `1` )
+        ( nurl_print `declare ` ) ( nurl_print ret_ty )
         ( nurl_print ` @` ) ( nurl_print fname )
         ( nurl_print `(` ) ( nurl_print params_str ) ( nurl_print `)\n\n` )
     }

--- a/compiler/tests/outputs/p256_ecdh_vectors.txt
+++ b/compiler/tests/outputs/p256_ecdh_vectors.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+keygen1: PASS
+keygen2: PASS
+keygen256: PASS
+ecdh_symmetry: PASS
+p256_ecdh: all vectors PASS

--- a/compiler/tests/outputs/pbkdf2_vectors.txt
+++ b/compiler/tests/outputs/pbkdf2_vectors.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+c1: PASS
+c2: PASS
+c4096: PASS
+c2_dk40: PASS
+pbkdf2: all vectors PASS

--- a/compiler/tests/p256_ecdh_vectors.nu
+++ b/compiler/tests/p256_ecdh_vectors.nu
@@ -1,0 +1,63 @@
+// p256_ecdh_vectors.nu — known-answer tests for the NIST P-256 (secp256r1)
+// ECDH used by the TLS client. keygen(k) must equal k·G (cross-checked
+// against a pure-Python P-256), and the exchange must be symmetric:
+// a·(b·G) == b·(a·G).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/ecdsa_p256.nu`
+
+// 32-byte big-endian scalar with low byte `lo` and second-low byte `hi`.
+@ scalar i hi i lo → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] 32 )
+    : ~ i k 0
+    ~ < k 30 { ( vec_push [u] v # u 0 ) = k + k 1 }
+    ( vec_push [u] v # u hi )
+    ( vec_push [u] v # u lo )
+    ^ v
+}
+
+@ check s label ( Vec u ) got s want → i {
+    : String gh ( bytes_to_hex got )
+    ? ( nurl_str_eq ( string_data gh ) want ) {
+        ( nurl_print label ) ( nurl_print `: PASS\n` )
+        ( string_free gh )
+        ^ 0
+    } {
+        ( nurl_print label ) ( nurl_print `: FAIL got ` )
+        ( nurl_print ( string_data gh ) ) ( nurl_print ` want ` )
+        ( nurl_print want ) ( nurl_print `\n` )
+        ( string_free gh )
+        ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i fails 0
+
+    // keygen(1) = the generator G (uncompressed)
+    = fails + fails ( check `keygen1` ( p256_ecdh_keygen ( scalar 0 1 ) )
+    `046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5` )
+
+    // keygen(2) = 2G
+    = fails + fails ( check `keygen2` ( p256_ecdh_keygen ( scalar 0 2 ) )
+    `047cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997807775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d1` )
+
+    // keygen(256) = 256G — exercises multi-byte (big-endian) scalars
+    = fails + fails ( check `keygen256` ( p256_ecdh_keygen ( scalar 1 0 ) )
+    `0434a2d4a3b009165987ffd1528603ed61190d0b710d6a564c2db2e35f12d0441bbeaaed6a53a1e3c22bca71046e777fc0e7d766b9deddd81db424e7845e93b146` )
+
+    // ECDH symmetry: a·(b·G) == b·(a·G)
+    : ( Vec u ) a ( scalar 3 7 )
+    : ( Vec u ) b ( scalar 9 11 )
+    : ( Vec u ) A ( p256_ecdh_keygen a )
+    : ( Vec u ) B ( p256_ecdh_keygen b )
+    : ( Vec u ) sab ( p256_ecdh_shared a B )
+    : ( Vec u ) sba ( p256_ecdh_shared b A )
+    : String sab_h ( bytes_to_hex sab )
+    = fails + fails ( check `ecdh_symmetry` sba ( string_data sab_h ) )
+
+    ? == fails 0 { ( nurl_print `p256_ecdh: all vectors PASS\n` ) } { ( nurl_print `p256_ecdh: FAILURES\n` ) }
+    ^ fails
+}

--- a/compiler/tests/pbkdf2_vectors.nu
+++ b/compiler/tests/pbkdf2_vectors.nu
@@ -1,0 +1,48 @@
+// pbkdf2_vectors.nu — known-answer tests for PBKDF2-HMAC-SHA-256
+// (the SHA-256 analogues of RFC 6070, cross-checked against Python's
+// hashlib.pbkdf2_hmac). Validates the iteration/XOR accumulation used by
+// SCRAM-SHA-256.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/pbkdf2.nu`
+
+@ sv s raw → ( Vec u ) {
+    : ( Vec u ) v ( vec_new [u] )
+    : i n ( nurl_str_len raw )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] v # u ( nurl_str_get raw k ) ) = k + k 1 }
+    ^ v
+}
+
+@ check s label ( Vec u ) got s want → i {
+    : String gh ( bytes_to_hex got )
+    ? ( nurl_str_eq ( string_data gh ) want ) {
+        ( nurl_print label ) ( nurl_print `: PASS\n` )
+        ( string_free gh )
+        ^ 0
+    } {
+        ( nurl_print label ) ( nurl_print `: FAIL got ` )
+        ( nurl_print ( string_data gh ) ) ( nurl_print ` want ` )
+        ( nurl_print want ) ( nurl_print `\n` )
+        ( string_free gh )
+        ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i fails 0
+    : ( Vec u ) p ( sv `password` )
+    : ( Vec u ) s ( sv `salt` )
+
+    = fails + fails ( check `c1` ( pbkdf2_hmac_sha256 p s 1 32 ) `120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b` )
+    = fails + fails ( check `c2` ( pbkdf2_hmac_sha256 p s 2 32 ) `ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43` )
+    = fails + fails ( check `c4096` ( pbkdf2_hmac_sha256 p s 4096 32 ) `c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a` )
+
+    // dkLen spanning two HMAC blocks (40 bytes)
+    = fails + fails ( check `c2_dk40` ( pbkdf2_hmac_sha256 p s 2 40 ) `ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43830651afcb5c862f` )
+
+    ? == fails 0 { ( nurl_print `pbkdf2: all vectors PASS\n` ) } { ( nurl_print `pbkdf2: FAILURES\n` ) }
+    ^ fails
+}

--- a/packages/psql/README.md
+++ b/packages/psql/README.md
@@ -1,0 +1,106 @@
+# psql — a pure-NURL PostgreSQL client
+
+A PostgreSQL client written entirely in NURL: the **version-3 wire
+protocol**, the **authentication** (trust / cleartext / MD5 /
+SCRAM-SHA-256) and the **TLS transport** are all implemented from scratch,
+with **no libpq and no OpenSSL**. A secure, authenticated connection works
+on a machine that has nothing installed — the produced binary links
+`libc` only, on Linux, macOS, the BSDs and Windows.
+
+It builds on the [`tls`](../tls) package (a pure-NURL TLS 1.3 / 1.2 client)
+and the stdlib crypto, so the TLS handshake — X25519 **and** NIST P-256
+key exchange, ChaCha20-Poly1305 / AES-GCM, the certificate verification —
+needs nothing from the host either.
+
+## What's implemented
+
+* **Connection** — TCP, with PostgreSQL's `SSLRequest` negotiation to
+  upgrade the same socket to TLS before the startup message.
+* **TLS** — opt-in per `sslmode`, over the pure-NURL TLS client. The key
+  exchange offers both X25519 and **secp256r1 (P-256)**, so it interoperates
+  with the common PostgreSQL/OpenSSL default (`ssl_ecdh_curve = prime256v1`).
+* **Authentication**
+  * **SCRAM-SHA-256** (RFC 7677) — the modern default, channel-binding-less
+    (`SCRAM-SHA-256`, matching libpq's default), built on a pure-NURL
+    PBKDF2-HMAC-SHA-256;
+  * **MD5** (`md5(md5(password‖user)‖salt)`);
+  * **cleartext** and **trust**.
+* **Queries** — the simple query protocol (`Query` → `RowDescription` /
+  `DataRow` / `CommandComplete`), with text-format decoding, NULL handling
+  and backend `ErrorResponse` surfaced with its SQLSTATE and message.
+
+## sslmode
+
+| mode          | code | behaviour                                            |
+|---------------|------|------------------------------------------------------|
+| `disable`     | 0    | plaintext only                                        |
+| `prefer`      | 1    | TLS if the server offers it, no certificate check (default) |
+| `require`     | 2    | TLS mandatory, no certificate check                   |
+| `verify-full` | 3    | TLS mandatory + chain & hostname verified against the system trust store |
+
+## Use as a command
+
+```
+nurlpkg install psql
+
+psql -h localhost -p 5432 -U me -d mydb -c "select 1"
+psql --sslmode require -U me -d mydb -c "select * from t"
+psql "postgres://me:secret@db.example.com:5432/mydb?sslmode=verify-full" -c "select now()"
+```
+
+The password is read from `$PGPASSWORD`; `-h/-p/-U/-d` fall back to
+`$PGHOST/$PGPORT/$PGUSER/$PGDATABASE`. With no `-c`, statements are read
+one-per-line from stdin.
+
+## Use as a library
+
+```
+nurlpkg add psql
+```
+
+```
+$ `deps/psql/src/pg.nu`
+
+@ main → i {
+    ?? ( pg_connect `localhost` 5432 `me` `secret` `mydb` 3 ) {
+        F e → { ( nurl_eprint `connect failed\n` ) ^ 1 }
+        T c → {
+            ?? ( pg_query c `select id, name from t` ) {
+                T r → {
+                    // r.ncols / r.nrows; ( pg_result_cell r row col ),
+                    // ( pg_result_is_null r row col ), ( pg_result_col r col )
+                    ( pg_result_free r )
+                }
+                F _ → { ( nurl_eprint `query failed\n` ) }
+            }
+            ( pg_close c )
+            ^ 0
+        }
+    }
+}
+```
+
+API:
+
+```
+( pg_connect host port user password database sslmode ) → !*PgConn PgErr
+( pg_query conn sql )                                    → !PgResult PgErr
+( pg_result_col r col )                                  → String   // column name
+( pg_result_cell r row col )                             → String   // text value
+( pg_result_is_null r row col )                          → b
+( pg_result_free r )                                     → v
+( pg_close conn )                                        → v
+```
+
+On a `PgServerError` / `PgQuery` failure the backend message text is left
+on `conn.lasterr`.
+
+## Limitations
+
+* Simple query protocol only (no prepared-statement / parameter binding
+  yet); values are returned in their text representation.
+* `SCRAM-SHA-256-PLUS` (channel binding) is not offered; SASLprep is the
+  identity map (fine for the ASCII passwords used in practice).
+* No connection pooling, `COPY`, `LISTEN`/`NOTIFY`, or binary result format.
+* TLS inherits the `tls` package's scope: TLS 1.3 (and 1.2 fallback), ECDHE
+  over X25519 / P-256, RSA + ECDSA P-256/P-384 certificate chains.

--- a/packages/psql/nurl.toml
+++ b/packages/psql/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "psql"
+version = "0.1.0"
+description = "Pure-NURL PostgreSQL client — v3 wire protocol, SCRAM-SHA-256 / MD5 auth, and TLS (pure-NURL, X25519 + P-256) with no libpq and no OpenSSL. Connects securely from a host with nothing installed."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+tls = "^0.1"

--- a/packages/psql/src/main.nu
+++ b/packages/psql/src/main.nu
@@ -1,0 +1,267 @@
+// packages/psql/src/main.nu — the `psql` command: a pure-NURL PostgreSQL
+// client. Connects over the v3 wire protocol with optional TLS (pure-NURL,
+// no libpq / no OpenSSL needed on the target), authenticates with
+// trust / cleartext / MD5 / SCRAM-SHA-256, runs queries and prints an
+// aligned table.
+//
+//   psql [flags] ["postgres://user:pass@host:port/db?sslmode=..."]
+//     -h HOST        host (default $PGHOST or localhost)
+//     -p PORT        port (default $PGPORT or 5432)
+//     -U USER        user (default $PGUSER or postgres)
+//     -d DB          database (default $PGDATABASE or the user)
+//     -c SQL         run one command and exit; otherwise read from stdin
+//     --sslmode M    disable | prefer | require | verify-full (default prefer)
+//   Password is taken from $PGPASSWORD.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+$ `pg.nu`
+
+@ __sslmode_code s m → i {
+    ? ( nurl_str_eq m `disable` ) { ^ 0 } {}
+    ? ( nurl_str_eq m `prefer` ) { ^ 1 } {}
+    ? ( nurl_str_eq m `require` ) { ^ 2 } {}
+    ? ( nurl_str_eq m `verify-full` ) { ^ 3 } {}
+    ^ 1
+}
+
+@ __atoi s str → i {
+    : i n ( nurl_str_len str )
+    : ~ i v 0
+    : ~ i k 0
+    ~ < k n {
+        : i c ( nurl_str_get str k )
+        ? & >= c 48 <= c 57 { = v + * v 10 - c 48 } {}
+        = k + k 1
+    }
+    ^ v
+}
+
+// Display width of a String (byte length; assumes single-width chars).
+@ __dw String s → i { ^ ( string_len s ) }
+
+@ __pad String dst String s i width → v {
+    ( string_push_str dst ( string_data s ) )
+    : ~ i k ( string_len s )
+    ~ < k width { ( string_push_char dst 32 ) = k + k 1 }
+}
+
+@ __repeat i c i n → String {
+    : String out ( string_with_cap n )
+    : ~ i k 0
+    ~ < k n { ( string_push_char out c ) = k + k 1 }
+    ^ out
+}
+
+// Render a PgResult as an aligned table to stdout.
+@ __print_result PgResult r → v {
+    : i nc . r ncols
+    : i nr . r nrows
+    ? == nc 0 {
+        ( nurl_print ( string_data . r tag ) ) ( nurl_print `\n` )
+    } {
+        // column widths = max(header, cells)
+        : ( Vec u ) widths ( vec_with_cap [u] nc )
+        : ~ i c 0
+        ~ < c nc {
+            : ~ i w ( __dw ( pg_result_col r c ) )
+            : ~ i rr 0
+            ~ < rr nr {
+                : i cw ? ( pg_result_is_null r rr c ) 6 ( __dw ( pg_result_cell r rr c ) )
+                ? > cw w { = w cw } {}
+                = rr + rr 1
+            }
+            ( vec_push [u] widths # u ? > w 255 255 w )
+            = c + c 1
+        }
+        // header
+        = c 0
+        ~ < c nc {
+            : i w ?? ( vec_get [u] widths c ) { T x → # i x F _ → 0 }
+            ? > c 0 { ( nurl_print ` | ` ) } {}
+            : String h ( string_with_cap + w 1 )
+            ( __pad h ( pg_result_col r c ) w )
+            ( nurl_print ( string_data h ) )
+            = c + c 1
+        }
+        ( nurl_print `\n` )
+        // separator
+        = c 0
+        ~ < c nc {
+            : i w ?? ( vec_get [u] widths c ) { T x → # i x F _ → 0 }
+            ? > c 0 { ( nurl_print `-+-` ) } {}
+            ( nurl_print ( string_data ( __repeat 45 w ) ) )
+            = c + c 1
+        }
+        ( nurl_print `\n` )
+        // rows
+        : ~ i rr 0
+        ~ < rr nr {
+            = c 0
+            ~ < c nc {
+                : i w ?? ( vec_get [u] widths c ) { T x → # i x F _ → 0 }
+                ? > c 0 { ( nurl_print ` | ` ) } {}
+                : String cell ? ( pg_result_is_null r rr c ) ( string_from `(null)` ) ( pg_result_cell r rr c )
+                : String padded ( string_with_cap + w 1 )
+                ( __pad padded cell w )
+                ( nurl_print ( string_data padded ) )
+                = c + c 1
+            }
+            ( nurl_print `\n` )
+            = rr + rr 1
+        }
+        : String foot ( string_with_cap 16 )
+        ( string_push_str foot `(` )
+        ( string_push_int foot nr )
+        ( string_push_str foot ? == nr 1 ` row)` ` rows)` )
+        ( nurl_print ( string_data foot ) ) ( nurl_print `\n` )
+    }
+}
+
+@ __run_one * PgConn c s sql → v {
+    ?? ( pg_query c sql ) {
+        T r → { ( __print_result r ) ( pg_result_free r ) }
+        F e → {
+            ( nurl_eprint `error: ` ) ( nurl_eprint ( pg_err_name e ) )
+            ( nurl_eprint `: ` ) ( nurl_eprint ( string_data . c lasterr ) ) ( nurl_eprint `\n` )
+        }
+    }
+}
+
+// Parse postgres://[user[:pass]@]host[:port][/db][?sslmode=M] into the
+// mutable refs via return of a small struct.
+: ConnInfo {
+    String host
+    i port
+    String user
+    String password
+    String database
+    i sslmode
+    b has_url
+}
+
+@ __parse_url s url ConnInfo ci → ConnInfo {
+    : ~ ConnInfo c ci
+    : i n ( nurl_str_len url )
+    // strip scheme
+    : ~ i p 0
+    ? ( nurl_str_starts url `postgres://` ) { = p 11 } {}
+    ? ( nurl_str_starts url `postgresql://` ) { = p 13 } {}
+    = . c has_url T
+    // userinfo @ — find '@' before the first '/'
+    : ~ i at -1
+    : ~ i slash -1
+    : ~ i k p
+    ~ < k n {
+        : i ch ( nurl_str_get url k )
+        ? & == ch 64 == at -1 { = at k } {}
+        ? & == ch 47 == slash -1 { = slash k } {}
+        = k + k 1
+    }
+    : ~ i hoststart p
+    ? & != at -1 | == slash -1 < at slash {
+        // userinfo present
+        : String ui ( string_substr ( string_from url ) p - at p )
+        : ?i colon ( string_index_of ui `:` )
+        ?? colon {
+            T ci2 → {
+                = . c user ( string_substr ui 0 ci2 )
+                = . c password ( string_substr ui + ci2 1 - ( string_len ui ) + ci2 1 )
+            }
+            F _ → { = . c user ui }
+        }
+        = hoststart + at 1
+    } {}
+    // host[:port] up to slash or ?
+    : ~ i hostend ? != slash -1 slash n
+    : ~ i q -1
+    = k hoststart
+    ~ < k n { ? & == ( nurl_str_get url k ) 63 == q -1 { = q k } {} = k + k 1 }
+    ? & != q -1 | == slash -1 < q hostend { = hostend q } {}
+    : String hostport ( string_substr ( string_from url ) hoststart - hostend hoststart )
+    : ?i pc ( string_index_of hostport `:` )
+    ?? pc {
+        T pci → {
+            = . c host ( string_substr hostport 0 pci )
+            = . c port ( __atoi ( string_data ( string_substr hostport + pci 1 - ( string_len hostport ) + pci 1 ) ) )
+        }
+        F _ → { = . c host hostport }
+    }
+    // database between slash and ?
+    ? != slash -1 {
+        : i dbend ? != q -1 q n
+        = . c database ( string_substr ( string_from url ) + slash 1 - dbend + slash 1 )
+    } {}
+    // query: sslmode
+    ? != q -1 {
+        : String qs ( string_substr ( string_from url ) + q 1 - n + q 1 )
+        : ?i si ( string_index_of qs `sslmode=` )
+        ?? si {
+            T sidx → { = . c sslmode ( __sslmode_code ( string_data ( string_substr qs + sidx 8 - ( string_len qs ) + sidx 8 ) ) ) }
+            F _ → {}
+        }
+    } {}
+    ^ c
+}
+
+@ main → i {
+    : ( Vec String ) args ( env_args_list )
+    : i argc ( vec_len [String] args )
+
+    : ~ ConnInfo ci @ ConnInfo {
+        ( env_var_or `PGHOST` `localhost` )
+        ( __atoi ( string_data ( env_var_or `PGPORT` `5432` ) ) )
+        ( env_var_or `PGUSER` `postgres` )
+        ( env_var_or `PGPASSWORD` `` )
+        ( env_var_or `PGDATABASE` `` )
+        1
+        F
+    }
+    : ~ String sql ( string_new )
+    : ~ b have_c F
+
+    : ~ i ai 1
+    ~ < ai argc {
+        : String a ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_new ) }
+        : s as ( string_data a )
+        ? ( nurl_str_eq as `-h` ) { = ai + ai 1 = . ci host ?? ( vec_get [String] args ai ) { T x → x F _ → . ci host } } {
+            ? ( nurl_str_eq as `-p` ) { = ai + ai 1 = . ci port ( __atoi ( string_data ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_from `5432` ) } ) ) } {
+                ? ( nurl_str_eq as `-U` ) { = ai + ai 1 = . ci user ?? ( vec_get [String] args ai ) { T x → x F _ → . ci user } } {
+                    ? ( nurl_str_eq as `-d` ) { = ai + ai 1 = . ci database ?? ( vec_get [String] args ai ) { T x → x F _ → . ci database } } {
+                        ? ( nurl_str_eq as `-c` ) { = ai + ai 1 = sql ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_new ) } = have_c T } {
+                            ? ( nurl_str_eq as `--sslmode` ) { = ai + ai 1 = . ci sslmode ( __sslmode_code ( string_data ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_from `prefer` ) } ) ) } {
+                                ? | ( nurl_str_starts as `postgres://` ) ( nurl_str_starts as `postgresql://` ) { = ci ( __parse_url as ci ) } {
+                                    ( nurl_eprint `psql: unknown argument: ` ) ( nurl_eprint as ) ( nurl_eprint `\n` )
+                                } } } } } } }
+        = ai + ai 1
+    }
+
+    // database defaults to the user name if unset
+    ? == ( string_len . ci database ) 0 { = . ci database . ci user } {}
+
+    : !*PgConn PgErr cr ( pg_connect ( string_data . ci host ) . ci port ( string_data . ci user ) ( string_data . ci password ) ( string_data . ci database ) . ci sslmode )
+    ?? cr {
+        F e → {
+            ( nurl_eprint `psql: connection failed: ` ) ( nurl_eprint ( pg_err_name e ) ) ( nurl_eprint `\n` )
+            ^ 1
+        }
+        T c → {
+            ? have_c {
+                ( __run_one c ( string_data sql ) )
+            } {
+                // read statements (one per line) from stdin
+                : ~ b eof F
+                ~ ! eof {
+                    : String line ( read_line )
+                    ? ( stdin_eof ) { = eof T } {
+                        ? > ( string_len line ) 0 { ( __run_one c ( string_data line ) ) } {}
+                    }
+                }
+            }
+            ( pg_close c )
+            ^ 0
+        }
+    }
+}

--- a/packages/psql/src/pg.nu
+++ b/packages/psql/src/pg.nu
@@ -1,0 +1,561 @@
+// packages/psql/src/pg.nu — PostgreSQL frontend/backend protocol v3 in pure
+// NURL. No libpq: the wire protocol, the authentication (trust / cleartext /
+// MD5 / SCRAM-SHA-256) and the optional TLS upgrade (PostgreSQL's SSLRequest,
+// then the pure-NURL TLS client) are all implemented here, so a secure
+// connection works on a host with nothing installed.
+//
+//   ( pg_connect host port user password database sslmode ) → !*PgConn PgErr
+//   ( pg_query conn sql )                                    → !PgResult PgErr
+//   ( pg_close conn )                                        → v
+//
+// sslmode: 0 disable · 1 prefer (TLS if offered, no verify) · 2 require
+// (TLS mandatory, no cert check) · 3 verify-full (TLS + chain/hostname).
+//
+// PgResult is a flat row-major cell table (see the accessors at the bottom):
+// nested Vecs are avoided for robustness; NULLs are tracked in a parallel
+// flag array.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/hash_md5.nu`
+$ `stdlib/std/random.nu`
+$ `scram.nu`
+$ `deps/tls/src/tls.nu`
+
+// SSLRequest magic (1234 << 16 | 5679) and the protocol-3.0 version word.
+: | PgErr {
+    PgConnFail  // could not open the TCP socket
+    PgTls  // TLS upgrade failed (refused, or handshake/cert error)
+    PgProtocol  // malformed/unexpected backend message
+    PgAuth  // authentication failed or unsupported method
+    PgServerError  // backend ErrorResponse — see . conn lasterr
+    PgQuery  // query-time failure — see . conn lasterr
+}
+
+@ pg_err_name PgErr e → s {
+    ^ ?? e {
+        PgConnFail → `PgConnFail`
+        PgTls → `PgTls`
+        PgProtocol → `PgProtocol`
+        PgAuth → `PgAuth`
+        PgServerError → `PgServerError`
+        PgQuery → `PgQuery`
+    }
+}
+
+: PgConn {
+    i tls  // 0 plaintext, 1 TLS
+    i raw  // raw socket handle (plaintext reads; fd the TLS layer took over)
+    TcpConn tcp  // plaintext transport (writes via tcp_write_all)
+    * TlsConn tc  // TLS transport (when tls = 1)
+    ( Vec u ) rxbuf  // backend bytes not yet split into messages
+    String lasterr  // last ErrorResponse / failure text
+    i be_pid
+    i be_key
+}
+
+: PgMsg {
+    i mtype
+    ( Vec u ) payload
+}
+
+// Row-major result table. cell(r,c) lives at index r*ncols+c.
+: PgResult {
+    i ncols
+    i nrows
+    ( Vec String ) colnames
+    ( Vec String ) cells  // NULL rendered as empty String; see nulls
+    ( Vec u ) nulls  // 1 = SQL NULL
+    String tag  // CommandComplete tag (e.g. "SELECT 3")
+}
+
+// ── byte helpers ──────────────────────────────────────────────────
+@ __bget ( Vec u ) v i k → i {
+    ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ 0 }
+}
+
+@ __rd16 ( Vec u ) v i off → i {
+    ^ | << ( __bget v off ) 8 ( __bget v + off 1 )
+}
+
+@ __rd32 ( Vec u ) v i off → i {
+    : ~ i acc 0
+    : ~ i k 0
+    ~ < k 4 { = acc | << acc 8 ( __bget v + off k ) = k + k 1 }
+    ^ acc
+}
+
+// Signed 32-bit big-endian read. DataRow column lengths use -1
+// (0xFFFFFFFF) to mark a SQL NULL, so they must be sign-extended.
+@ __rd32s ( Vec u ) v i off → i {
+    : i u ( __rd32 v off )
+    ? >= u 2147483648 { ^ - u 4294967296 } { ^ u }
+}
+
+@ __push16 ( Vec u ) v i n → v {
+    ( vec_push [u] v # u & >> n 8 255 )
+    ( vec_push [u] v # u & n 255 )
+}
+
+@ __push32 ( Vec u ) v i n → v {
+    ( vec_push [u] v # u & >> n 24 255 )
+    ( vec_push [u] v # u & >> n 16 255 )
+    ( vec_push [u] v # u & >> n 8 255 )
+    ( vec_push [u] v # u & n 255 )
+}
+
+@ __push_raw ( Vec u ) v s raw → v {
+    : i n ( nurl_str_len raw )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] v # u ( nurl_str_get raw k ) ) = k + k 1 }
+}
+
+@ __push_cstr ( Vec u ) v s raw → v {
+    ( __push_raw v raw )
+    ( vec_push [u] v # u 0 )
+}
+
+@ __push_strv ( Vec u ) v String s → v {
+    ( __push_raw v ( string_data s ) )
+}
+
+// Bytes [from,to) of a Vec u as a heap String.
+@ __slice_str ( Vec u ) v i from i to → String {
+    : String out ( string_with_cap ? > - to from 0 - to from 1 )
+    : ~ i k from
+    ~ < k to { ( string_push_char out ( __bget v k ) ) = k + k 1 }
+    ^ out
+}
+
+// ── transport ─────────────────────────────────────────────────────
+@ __pg_write * PgConn c ( Vec u ) bytes → i {
+    ? == . c tls 1 {
+        ?? ( tls_write . c tc bytes ) { T _ → ^ 1 F _ → ^ 0 }
+    } {
+        ?? ( tcp_write_all . c tcp bytes ) { T _ → ^ 1 F _ → ^ 0 }
+    }
+}
+
+// Read one chunk into rxbuf. Returns 1 on progress, 0 on EOF/error.
+@ __pg_fill * PgConn c → i {
+    ? == . c tls 1 {
+        ?? ( tls_read . c tc 16384 ) {
+            T v → {
+                ? == ( vec_len [u] v ) 0 { ( vec_free [u] v ) ^ 0 } {}
+                ( __cat . c rxbuf v )
+                ( vec_free [u] v )
+                ^ 1
+            }
+            F _ → ^ 0
+        }
+    } {
+        : ( Vec u ) tmp ( vec_with_cap [u] 16384 )
+        : i got ( nurl_tcp_read . c raw # s ( vec_data [u] tmp ) 16384 )
+        ? <= got 0 { ( vec_free [u] tmp ) ^ 0 } {}
+        : b _ok ( vec_set_len [u] tmp got )
+        ( __cat . c rxbuf tmp )
+        ( vec_free [u] tmp )
+        ^ 1
+    }
+}
+
+@ __pg_ensure * PgConn c i n → i {
+    ~ < ( vec_len [u] . c rxbuf ) n {
+        ? == ( __pg_fill c ) 0 { ^ 0 } {}
+    }
+    ^ 1
+}
+
+// Pull the next backend message (type byte + length-framed payload).
+@ __pg_next * PgConn c → !PgMsg PgErr {
+    ? == ( __pg_ensure c 5 ) 0 { ^ @ !PgMsg PgErr { F # PgErr PgProtocol } } {}
+    : i mtype ( __bget . c rxbuf 0 )
+    : i len ( __rd32 . c rxbuf 1 )
+    : i total + 1 len
+    ? == ( __pg_ensure c total ) 0 { ^ @ !PgMsg PgErr { F # PgErr PgProtocol } } {}
+    : ( Vec u ) payload ( bytes_slice . c rxbuf 5 total )
+    : i have ( vec_len [u] . c rxbuf )
+    : ( Vec u ) rest ( bytes_slice . c rxbuf total have )
+    ( vec_free [u] . c rxbuf )
+    = . c rxbuf rest
+    ^ @ !PgMsg PgErr { T @ PgMsg { mtype payload } }
+}
+
+// Frame and send a typed frontend message.
+@ __pg_send_typed * PgConn c i mtype ( Vec u ) payload → i {
+    : ( Vec u ) msg ( vec_with_cap [u] + ( vec_len [u] payload ) 5 )
+    ( vec_push [u] msg # u mtype )
+    ( __push32 msg + 4 ( vec_len [u] payload ) )
+    ( __cat msg payload )
+    : i ok ( __pg_write c msg )
+    ( vec_free [u] msg )
+    ^ ok
+}
+
+// ── ErrorResponse / NoticeResponse parsing ────────────────────────
+// Fields: 1-byte code, NUL-terminated value, terminated by a 0 code.
+// We surface the human-readable "M" (message) and "C" (SQLSTATE).
+@ __pg_error_text ( Vec u ) payload → String {
+    : i n ( vec_len [u] payload )
+    : ~ String msg ( string_with_cap 64 )
+    : ~ String code ( string_with_cap 8 )
+    : ~ i k 0
+    ~ < k n {
+        : i field ( __bget payload k )
+        ? == field 0 { = k n } {
+            = k + k 1
+            : ~ i start k
+            ~ & < k n != ( __bget payload k ) 0 { = k + k 1 }
+            : String val ( __slice_str payload start k )
+            ? == field 77 { = msg val } {}
+            ? == field 67 { = code val } {}
+            = k + k 1
+        }
+    }
+    : String out ( string_with_cap + 16 ( string_len msg ) )
+    ( string_push_str out `[` )
+    ( string_push_str out ( string_data code ) )
+    ( string_push_str out `] ` )
+    ( string_push_str out ( string_data msg ) )
+    ^ out
+}
+
+// ── authentication ────────────────────────────────────────────────
+// MD5: "md5" + md5_hex( md5_hex(password ++ user) ++ salt )
+@ __pg_md5_auth * PgConn c s user s password ( Vec u ) salt → i {
+    : ( Vec u ) inner ( vec_new [u] )
+    ( __push_raw inner password )
+    ( __push_raw inner user )
+    : ( Vec u ) inner_d ( md5_pure inner )
+    : String inner_hex ( bytes_to_hex inner_d )
+
+    : ( Vec u ) outer ( vec_new [u] )
+    ( __push_strv outer inner_hex )
+    ( __cat outer salt )
+    : ( Vec u ) outer_d ( md5_pure outer )
+    : String outer_hex ( bytes_to_hex outer_d )
+
+    : ( Vec u ) payload ( vec_new [u] )
+    ( __push_raw payload `md5` )
+    ( __push_strv payload outer_hex )
+    ( vec_push [u] payload # u 0 )
+    : i ok ( __pg_send_typed c 112 payload )
+
+    ( vec_free [u] inner ) ( vec_free [u] inner_d ) ( vec_free [u] outer )
+    ( vec_free [u] outer_d ) ( vec_free [u] payload )
+    ^ ok
+}
+
+// SCRAM-SHA-256 exchange. Returns 1 on the messages being sent OK; the
+// final server-signature check happens when SASLFinal arrives.
+@ __pg_scram_init * PgConn c String cfb → i {
+    : String full ( string_with_cap + 8 ( string_len cfb ) )
+    ( string_push_str full `n,,` )
+    ( string_push_str full ( string_data cfb ) )
+    : ( Vec u ) payload ( vec_new [u] )
+    ( __push_cstr payload `SCRAM-SHA-256` )
+    ( __push32 payload ( string_len full ) )
+    ( __push_strv payload full )
+    : i ok ( __pg_send_typed c 112 payload )
+    ( vec_free [u] payload )
+    ( string_free full )
+    ^ ok
+}
+
+// Run the whole startup→auth→ReadyForQuery sequence.
+@ __pg_authenticate * PgConn c s user s password → !v PgErr {
+    : ( Vec u ) pwbytes ( vec_new [u] )
+    ( __push_raw pwbytes password )
+
+    : String scram_nonce ( rand_hex_str 18 )
+    : String scram_cfb ( scram_client_first_bare ( string_data scram_nonce ) )
+    : ~ String scram_expect ( string_with_cap 0 )
+
+    : ~ i done 0
+    : ~ i rc 0
+    ~ == done 0 {
+        : !PgMsg PgErr mr ( __pg_next c )
+        : PgMsg m ?? mr { T x → x F _ → { = done 1 = rc 1 @ PgMsg { 0 ( vec_new [u] ) } } }
+        ? == done 1 {} {
+            : i t . m mtype
+            : ( Vec u ) pl . m payload
+            ? == t 82 {
+                // AuthenticationRequest
+                : i sub ( __rd32 pl 0 )
+                ? == sub 0 {} {}  // AuthenticationOk: keep reading until Z
+                ? == sub 3 {
+                    : ( Vec u ) pw ( vec_new [u] )
+                    ( __push_cstr pw password )
+                    : i _o ( __pg_send_typed c 112 pw )
+                    ( vec_free [u] pw )
+                } {}
+                ? == sub 5 {
+                    : ( Vec u ) salt ( bytes_slice pl 4 ( vec_len [u] pl ) )
+                    : i _o ( __pg_md5_auth c user password salt )
+                    ( vec_free [u] salt )
+                } {}
+                ? == sub 10 {
+                    : i _o ( __pg_scram_init c scram_cfb )
+                } {}
+                ? == sub 11 {
+                    // SASLContinue: payload is the server-first message
+                    : String sf ( __slice_str pl 4 ( vec_len [u] pl ) )
+                    : ScramResult sres ( scram_compute pwbytes scram_cfb sf )
+                    ( string_free sf )
+                    ? == . sres ok 0 {
+                        ( string_free . sres client_final ) ( string_free . sres server_sig )
+                        = done 1 = rc 2
+                    } {
+                        : ( Vec u ) cf ( vec_new [u] )
+                        ( __push_strv cf . sres client_final )
+                        : i _o ( __pg_send_typed c 112 cf )
+                        ( vec_free [u] cf )
+                        ( string_free . sres client_final )
+                        ( string_free scram_expect )
+                        = scram_expect . sres server_sig
+                    }
+                } {}
+                ? == sub 12 {
+                    // SASLFinal: payload "v=<base64 server signature>"
+                    : String got ( __slice_str pl 6 ( vec_len [u] pl ) )
+                    ? ( string_eq got scram_expect ) {} { = done 1 = rc 2 }
+                    ( string_free got )
+                } {}
+                ? & & & & != sub 0 != sub 3 != sub 5 != sub 10 & != sub 11 != sub 12 {
+                    = done 1 = rc 2
+                } {}
+            } {
+                ? == t 69 {
+                    = . c lasterr ( __pg_error_text pl )
+                    = done 1 = rc 3
+                } {
+                    ? == t 83 {} {}  // ParameterStatus
+                    ? == t 75 {
+                        = . c be_pid ( __rd32 pl 0 )
+                        = . c be_key ( __rd32 pl 4 )
+                    } {}
+                    ? == t 78 {} {}  // NoticeResponse
+                    ? == t 90 { = done 1 = rc 0 } {}  // ReadyForQuery
+                }
+            }
+            ( vec_free [u] pl )
+        }
+    }
+    ( vec_free [u] pwbytes )
+    ( string_free scram_nonce ) ( string_free scram_cfb ) ( string_free scram_expect )
+    ? == rc 0 { ^ @ !v PgErr { T 0 } } {
+        ? == rc 3 { ^ @ !v PgErr { F # PgErr PgServerError } } {
+            ? == rc 1 { ^ @ !v PgErr { F # PgErr PgProtocol } } { ^ @ !v PgErr { F # PgErr PgAuth } }
+        }
+    }
+}
+
+// ── connection ────────────────────────────────────────────────────
+// Try the SSLRequest negotiation on the raw socket. Returns 'S'(83) if
+// the server agrees to TLS, 'N'(78) if not, <0 on I/O failure.
+@ __pg_ssl_request i raw → i {
+    : ( Vec u ) req ( vec_new [u] )
+    ( __push32 req 8 )
+    ( __push32 req 80877103 )
+    : TcpConn t @ TcpConn { # s raw }
+    ?? ( tcp_write_all t req ) { T _ → {} F _ → { ( vec_free [u] req ) ^ -1 } }
+    ( vec_free [u] req )
+    : ( Vec u ) one ( vec_with_cap [u] 1 )
+    : i got ( nurl_tcp_read raw # s ( vec_data [u] one ) 1 )
+    ? <= got 0 { ( vec_free [u] one ) ^ -1 } {}
+    : b _ok ( vec_set_len [u] one got )
+    : i r ( __bget one 0 )
+    ( vec_free [u] one )
+    ^ r
+}
+
+@ pg_connect s host i port s user s password s database i sslmode → !*PgConn PgErr {
+    : i rawfd ( nurl_tcp_connect host port )
+    ? != ( nurl_tcp_err_kind rawfd ) 0 { ^ @ !*PgConn PgErr { F # PgErr PgConnFail } } {}
+
+    : *PgConn c # *PgConn ( nurl_alloc Z PgConn )
+    = . c tls 0
+    = . c raw rawfd
+    = . c tcp @ TcpConn { # s rawfd }
+    = . c tc # *TlsConn 0
+    = . c rxbuf ( vec_new [u] )
+    = . c lasterr ( string_with_cap 0 )
+    = . c be_pid 0
+    = . c be_key 0
+
+    // ── optional TLS upgrade (SSLRequest → pure-NURL TLS) ──
+    ? > sslmode 0 {
+        : i resp ( __pg_ssl_request rawfd )
+        ? == resp 83 {
+            : !*TlsConn TlsErr tr ? >= sslmode 3 ( tls_attach_verify rawfd host ) ( tls_attach rawfd host )
+            ?? tr {
+                T tc → { = . c tls 1 = . c tc tc }
+                F _ → {
+                    ( nurl_tcp_close rawfd )
+                    ( vec_free [u] . c rxbuf ) ( string_free . c lasterr ) ( nurl_free # s c )
+                    ^ @ !*PgConn PgErr { F # PgErr PgTls }
+                }
+            }
+        } {
+            // server declined TLS
+            ? >= sslmode 2 {
+                ( nurl_tcp_close rawfd )
+                ( vec_free [u] . c rxbuf ) ( string_free . c lasterr ) ( nurl_free # s c )
+                ^ @ !*PgConn PgErr { F # PgErr PgTls }
+            } {}
+        }
+    } {}
+
+    // ── StartupMessage ──
+    : ( Vec u ) startup ( vec_new [u] )
+    ( __push32 startup 196608 )  // protocol 3.0
+    ( __push_cstr startup `user` )
+    ( __push_cstr startup user )
+    ? > ( nurl_str_len database ) 0 {
+        ( __push_cstr startup `database` )
+        ( __push_cstr startup database )
+    } {}
+    ( __push_cstr startup `client_encoding` )
+    ( __push_cstr startup `UTF8` )
+    ( vec_push [u] startup # u 0 )  // trailing terminator
+
+    : ( Vec u ) frame ( vec_new [u] )
+    ( __push32 frame + 4 ( vec_len [u] startup ) )
+    ( __cat frame startup )
+    : i wok ( __pg_write c frame )
+    ( vec_free [u] startup ) ( vec_free [u] frame )
+    ? == wok 0 { ( pg_close c ) ^ @ !*PgConn PgErr { F # PgErr PgConnFail } } {}
+
+    : !v PgErr ar ( __pg_authenticate c user password )
+    ?? ar {
+        T _ → { ^ @ !*PgConn PgErr { T c } }
+        F e → { ^ @ !*PgConn PgErr { F e } }
+    }
+}
+
+// ── simple query ──────────────────────────────────────────────────
+@ pg_query * PgConn c s sql → !PgResult PgErr {
+    : ( Vec u ) payload ( vec_new [u] )
+    ( __push_cstr payload sql )
+    : i wok ( __pg_send_typed c 81 payload )
+    ( vec_free [u] payload )
+    ? == wok 0 { ^ @ !PgResult PgErr { F # PgErr PgQuery } } {}
+
+    : ~ i ncols 0
+    : ~ ( Vec String ) colnames ( vec_new [String] )
+    : ~ ( Vec String ) cells ( vec_new [String] )
+    : ~ ( Vec u ) nulls ( vec_new [u] )
+    : ~ i nrows 0
+    : ~ String tag ( string_with_cap 0 )
+
+    : ~ i done 0
+    : ~ i rc 0
+    ~ == done 0 {
+        : !PgMsg PgErr mr ( __pg_next c )
+        : PgMsg m ?? mr { T x → x F _ → { = done 1 = rc 1 @ PgMsg { 0 ( vec_new [u] ) } } }
+        ? == done 1 {} {
+            : i t . m mtype
+            : ( Vec u ) pl . m payload
+            ? == t 84 {
+                // RowDescription
+                = ncols ( __rd16 pl 0 )
+                ( vec_free_with [String] colnames \ String s → v { ( string_free s ) } )
+                = colnames ( vec_new [String] )
+                : ~ i off 2
+                : ~ i fi 0
+                ~ < fi ncols {
+                    : ~ i e off
+                    ~ != ( __bget pl e ) 0 { = e + e 1 }
+                    ( vec_push [String] colnames ( __slice_str pl off e ) )
+                    = off + e 1
+                    = off + off 18  // tableoid(4) colno(2) typeoid(4) typelen(2) typmod(4) format(2)
+                    = fi + fi 1
+                }
+            } {
+                ? == t 68 {
+                    // DataRow
+                    : i nf ( __rd16 pl 0 )
+                    : ~ i off 2
+                    : ~ i ci 0
+                    ~ < ci nf {
+                        : i flen ( __rd32s pl off )
+                        = off + off 4
+                        ? == flen -1 {
+                            ( vec_push [String] cells ( string_with_cap 0 ) )
+                            ( vec_push [u] nulls # u 1 )
+                        } {
+                            ( vec_push [String] cells ( __slice_str pl off + off flen ) )
+                            ( vec_push [u] nulls # u 0 )
+                            = off + off flen
+                        }
+                        = ci + ci 1
+                    }
+                    = nrows + nrows 1
+                } {
+                    ? == t 67 {
+                        // CommandComplete
+                        : ~ i e 0
+                        ~ != ( __bget pl e ) 0 { = e + e 1 }
+                        = tag ( __slice_str pl 0 e )
+                    } {
+                        ? == t 69 {
+                            = . c lasterr ( __pg_error_text pl )
+                            = done 1 = rc 3
+                        } {
+                            ? == t 90 { = done 1 } {}  // ReadyForQuery
+                            // 'I' EmptyQuery, 'N' Notice, 'S' ParameterStatus → ignore
+                        }
+                    }
+                }
+            }
+            ( vec_free [u] pl )
+        }
+    }
+
+    ? == rc 0 {
+        ^ @ !PgResult PgErr { T @ PgResult { ncols nrows colnames cells nulls tag } }
+    } {
+        ( vec_free_with [String] colnames \ String s → v { ( string_free s ) } )
+        ( vec_free_with [String] cells \ String s → v { ( string_free s ) } )
+        ( vec_free [u] nulls )
+        ? == rc 3 { ^ @ !PgResult PgErr { F # PgErr PgServerError } } { ^ @ !PgResult PgErr { F # PgErr PgQuery } }
+    }
+}
+
+// ── result accessors ──────────────────────────────────────────────
+@ pg_result_col PgResult r i idx → String {
+    ?? ( vec_get [String] . r colnames idx ) { T s → ^ s F _ → ^ ( string_with_cap 0 ) }
+}
+
+@ pg_result_is_null PgResult r i row i col → b {
+    : i idx + * row . r ncols col
+    ^ == ( __bget . r nulls idx ) 1
+}
+
+@ pg_result_cell PgResult r i row i col → String {
+    : i idx + * row . r ncols col
+    ?? ( vec_get [String] . r cells idx ) { T s → ^ s F _ → ^ ( string_with_cap 0 ) }
+}
+
+@ pg_result_free PgResult r → v {
+    ( vec_free_with [String] . r colnames \ String s → v { ( string_free s ) } )
+    ( vec_free_with [String] . r cells \ String s → v { ( string_free s ) } )
+    ( vec_free [u] . r nulls )
+    ( string_free . r tag )
+}
+
+// ── teardown ──────────────────────────────────────────────────────
+@ pg_close * PgConn c → v {
+    // Best-effort Terminate ('X') then close the transport.
+    : ( Vec u ) term ( vec_new [u] )
+    : i _o ( __pg_send_typed c 88 term )
+    ( vec_free [u] term )
+    ? == . c tls 1 { ( tls_close . c tc ) } { ( nurl_tcp_close . c raw ) }
+    ( vec_free [u] . c rxbuf )
+    ( string_free . c lasterr )
+    ( nurl_free # s c )
+}

--- a/packages/psql/src/scram.nu
+++ b/packages/psql/src/scram.nu
@@ -1,0 +1,162 @@
+// packages/psql/src/scram.nu — SCRAM-SHA-256 client (RFC 5802 / RFC 7677),
+// the SASL mechanism PostgreSQL uses for password authentication.
+//
+// Pure NURL on top of the stdlib crypto (SHA-256 / HMAC / PBKDF2 / base64).
+// Channel binding is not used ("n,," / "c=biws"), matching libpq's default
+// SCRAM-SHA-256 (not the -PLUS variant).
+//
+//   ( scram_client_first_bare nonce )                 → String  "n=,r=<nonce>"
+//   ( scram_compute password cfb server_first )       → ScramResult
+//
+// `password` is the raw password bytes (SASLprep is the identity map for
+// the ASCII passwords overwhelmingly used in practice). `cfb` is the
+// client-first-bare returned above; `server_first` is the server's
+// SASLContinue payload. The result carries the client-final message to
+// send and the base64 server signature to check against the SASLFinal.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/pbkdf2.nu`
+$ `stdlib/std/encode.nu`
+
+: ScramResult {
+    b ok
+    String client_final
+    String server_sig
+}
+
+// raw C-string → byte vector
+@ __sc_raw_bytes s raw → ( Vec u ) {
+    : ( Vec u ) v ( vec_new [u] )
+    : i n ( nurl_str_len raw )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] v # u ( nurl_str_get raw k ) ) = k + k 1 }
+    ^ v
+}
+
+// String → byte vector
+@ __sc_str_bytes String s → ( Vec u ) {
+    ^ ( __sc_raw_bytes ( string_data s ) )
+}
+
+@ __sc_bget ( Vec u ) v i k → i {
+    ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ 0 }
+}
+
+// XOR two equal-length byte vectors.
+@ __sc_xor ( Vec u ) a ( Vec u ) b → ( Vec u ) {
+    : i n ( vec_len [u] a )
+    : ( Vec u ) out ( vec_with_cap [u] n )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] out # u & ^^ ( __sc_bget a k ) ( __sc_bget b k ) 255 ) = k + k 1 }
+    ^ out
+}
+
+// Does String `s` start with raw prefix `p`?
+@ __sc_starts String s s p → b {
+    : i pn ( nurl_str_len p )
+    ? < ( string_len s ) pn { ^ F } {}
+    : s sd ( string_data s )
+    : ~ i k 0
+    ~ < k pn {
+        ? != ( nurl_str_get sd k ) ( nurl_str_get p k ) { ^ F } {}
+        = k + k 1
+    }
+    ^ T
+}
+
+// Parse a non-negative decimal from a String.
+@ __sc_atoi String s → i {
+    : s d ( string_data s )
+    : i n ( string_len s )
+    : ~ i v 0
+    : ~ i k 0
+    ~ < k n {
+        : i c ( nurl_str_get d k )
+        ? & >= c 48 <= c 57 { = v + * v 10 - c 48 } {}
+        = k + k 1
+    }
+    ^ v
+}
+
+// client-first-bare: PostgreSQL ignores the SCRAM username (it uses the
+// startup username), so we send an empty `n=`.
+@ scram_client_first_bare s nonce → String {
+    : String out ( string_with_cap + 8 ( nurl_str_len nonce ) )
+    ( string_push_str out `n=,r=` )
+    ( string_push_str out nonce )
+    ^ out
+}
+
+@ scram_compute ( Vec u ) password String cfb String server_first → ScramResult {
+    // ── parse server-first: r=<combined nonce>, s=<salt b64>, i=<iters> ──
+    : ( Vec String ) parts ( string_split server_first `,` )
+    : ~ String combined ( string_with_cap 0 )
+    : ~ String salt_b64 ( string_with_cap 0 )
+    : ~ i iters 0
+    : i np ( vec_len [String] parts )
+    : ~ i pi 0
+    ~ < pi np {
+        : String f ?? ( vec_get [String] parts pi ) { T x → x F _ → ( string_with_cap 0 ) }
+        : i fl ( string_len f )
+        ? ( __sc_starts f `r=` ) { = combined ( string_substr f 2 - fl 2 ) } {}
+        ? ( __sc_starts f `s=` ) { = salt_b64 ( string_substr f 2 - fl 2 ) } {}
+        ? ( __sc_starts f `i=` ) { = iters ( __sc_atoi ( string_substr f 2 - fl 2 ) ) } {}
+        = pi + pi 1
+    }
+
+    ? | == ( string_len combined ) 0 == iters 0 {
+        ( vec_free_with [String] parts \ String s → v { ( string_free s ) } )
+        ( string_free combined ) ( string_free salt_b64 )
+        ^ @ ScramResult { F ( string_with_cap 0 ) ( string_with_cap 0 ) }
+    } {}
+
+    : ( Vec u ) salt ?? ( b64_decode_vec ( string_data salt_b64 ) ) { T v → v F _ → ( vec_new [u] ) }
+
+    // ── SCRAM key derivation (RFC 5802 §3) ──
+    : ( Vec u ) salted ( pbkdf2_hmac_sha256 password salt iters 32 )
+    : ( Vec u ) ck_lbl ( __sc_raw_bytes `Client Key` )
+    : ( Vec u ) sk_lbl ( __sc_raw_bytes `Server Key` )
+    : ( Vec u ) client_key ( hmac_sha256_pure salted ck_lbl )
+    : ( Vec u ) stored_key ( sha256_pure client_key )
+
+    // client-final-without-proof
+    : String cfwop ( string_with_cap + 16 ( string_len combined ) )
+    ( string_push_str cfwop `c=biws,r=` )
+    ( string_push_str cfwop ( string_data combined ) )
+
+    // AuthMessage = client-first-bare , server-first , client-final-without-proof
+    : String am_s ( string_with_cap + + ( string_len cfb ) ( string_len server_first ) ( string_len cfwop ) )
+    ( string_push_str am_s ( string_data cfb ) )
+    ( string_push_char am_s 44 )
+    ( string_push_str am_s ( string_data server_first ) )
+    ( string_push_char am_s 44 )
+    ( string_push_str am_s ( string_data cfwop ) )
+    : ( Vec u ) am ( __sc_str_bytes am_s )
+
+    : ( Vec u ) client_sig ( hmac_sha256_pure stored_key am )
+    : ( Vec u ) proof ( __sc_xor client_key client_sig )
+    : String proof_b64 ( b64_encode_vec proof )
+
+    : String client_final ( string_with_cap + + ( string_len cfwop ) 3 ( string_len proof_b64 ) )
+    ( string_push_str client_final ( string_data cfwop ) )
+    ( string_push_str client_final `,p=` )
+    ( string_push_str client_final ( string_data proof_b64 ) )
+
+    : ( Vec u ) server_key ( hmac_sha256_pure salted sk_lbl )
+    : ( Vec u ) server_sig ( hmac_sha256_pure server_key am )
+    : String server_sig_b64 ( b64_encode_vec server_sig )
+
+    // free scratch byte vectors
+    ( vec_free [u] salt ) ( vec_free [u] salted ) ( vec_free [u] ck_lbl ) ( vec_free [u] sk_lbl )
+    ( vec_free [u] client_key ) ( vec_free [u] stored_key ) ( vec_free [u] am )
+    ( vec_free [u] client_sig ) ( vec_free [u] proof ) ( vec_free [u] server_key ) ( vec_free [u] server_sig )
+    // free scratch strings (client_final + server_sig_b64 are returned)
+    ( vec_free_with [String] parts \ String s → v { ( string_free s ) } )
+    ( string_free combined ) ( string_free salt_b64 ) ( string_free cfwop )
+    ( string_free am_s ) ( string_free proof_b64 )
+
+    ^ @ ScramResult { T client_final server_sig_b64 }
+}

--- a/packages/tls/src/tls.nu
+++ b/packages/tls/src/tls.nu
@@ -28,6 +28,7 @@ $ `stdlib/std/net.nu`
 $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/hkdf.nu`
 $ `stdlib/std/x25519.nu`
+$ `stdlib/std/ecdsa_p256.nu`
 $ `stdlib/std/chacha20poly1305.nu`
 $ `stdlib/std/aes_gcm.nu`
 $ `verify.nu`
@@ -88,6 +89,7 @@ $ `verify.nu`
     i cv_scheme  // CertificateVerify SignatureScheme
     i cipher  // 0 = ChaCha20-Poly1305, 1 = AES-128-GCM
     i version  // 13 = TLS 1.3, 12 = TLS 1.2
+    ( Vec u ) kx_p256  // P-256 ephemeral private key (empty if X25519 chosen)
 }
 
 // ── small helpers ─────────────────────────────────────────────────
@@ -342,7 +344,7 @@ $ `verify.nu`
 }
 
 // ── ClientHello ───────────────────────────────────────────────────
-@ __build_client_hello s host ( Vec u ) pubkey ( Vec u ) random ( Vec u ) sessid → ( Vec u ) {
+@ __build_client_hello s host ( Vec u ) pubkey ( Vec u ) p256pub ( Vec u ) random ( Vec u ) sessid → ( Vec u ) {
     : ( Vec u ) body ( vec_new [u] )
     ( __u16 body 771 )  // legacy_version 0x0303
     ( __cat body random )  // 32-byte random
@@ -378,10 +380,13 @@ $ `verify.nu`
     ( __blk16 ext sni )
     ( vec_free [u] sni )
 
-    // supported_groups (0x000a): x25519 (0x001d)
+    // supported_groups (0x000a): x25519 (0x001d) + secp256r1 (0x0017).
+    // Both are offered so the server can pick whichever it is configured
+    // for — PostgreSQL/OpenSSL servers commonly default to P-256.
     : ( Vec u ) grp ( vec_new [u] )
-    ( __u16 grp 2 )
-    ( __u16 grp 29 )
+    ( __u16 grp 4 )
+    ( __u16 grp 29 )  // x25519
+    ( __u16 grp 23 )  // secp256r1
     ( __u16 ext 10 )
     ( __blk16 ext grp )
     ( vec_free [u] grp )
@@ -418,12 +423,17 @@ $ `verify.nu`
     ( __blk16 ext epf )
     ( vec_free [u] epf )
 
-    // key_share (0x0033): x25519 + 32-byte pubkey
+    // key_share (0x0033): both an x25519 (32-byte) and a secp256r1
+    // (65-byte uncompressed) entry, so whichever group the server selects
+    // we already supplied a matching public key — no HelloRetryRequest.
     : ( Vec u ) ks ( vec_new [u] )
     : ( Vec u ) entry ( vec_new [u] )
     ( __u16 entry 29 )  // group x25519
     ( __u16 entry 32 )  // key_exchange length
     ( __cat entry pubkey )
+    ( __u16 entry 23 )  // group secp256r1
+    ( __u16 entry ( vec_len [u] p256pub ) )  // 65
+    ( __cat entry p256pub )
     ( __u16 ks ( vec_len [u] entry ) )
     ( __cat ks entry )
     ( __u16 ext 51 )
@@ -549,6 +559,16 @@ $ `verify.nu`
 // verifier.
 @ tls_connect_insecure s host i port s server_name → !*TlsConn TlsErr {
     : i raw ( nurl_tcp_connect host port )
+    ^ ( tls_attach raw server_name )
+}
+
+// Run the TLS handshake over a socket that is ALREADY connected (a raw
+// libc fd handle as returned by `nurl_tcp_connect`). This is what
+// STARTTLS-style protocols need — PostgreSQL's SSLRequest, SMTP STARTTLS,
+// IMAP/FTP — where the plaintext leg must exchange a few bytes before the
+// channel is upgraded to TLS on the same socket. No certificate
+// verification (see `tls_attach_verify` for the secure variant).
+@ tls_attach i raw s server_name → !*TlsConn TlsErr {
     : i ek ( nurl_tcp_err_kind raw )
     ? != ek 0 { ^ @ !*TlsConn TlsErr { F # TlsErr TlsConnect } } {}
     : s rp # s raw
@@ -579,10 +599,15 @@ $ `verify.nu`
     = . c cv_scheme 0
     = . c cipher 0
     = . c version 13
+    = . c kx_p256 ( vec_new [u] )
 
     // ── key share ──
     : ( Vec u ) priv ( __rand_bytes 32 )
     : ( Vec u ) cpub ( x25519_base priv )
+    : ( Vec u ) p256priv ( __rand_bytes 32 )
+    : ( Vec u ) p256pub ( p256_ecdh_keygen p256priv )
+    ( vec_free [u] . c kx_p256 )
+    = . c kx_p256 p256priv
     : ( Vec u ) random ( __rand_bytes 32 )
     : ( Vec u ) sessid ( __rand_bytes 32 )
 
@@ -590,7 +615,8 @@ $ `verify.nu`
     : ~ ( Vec u ) tr ( vec_new [u] )
 
     // ── ClientHello ──
-    : ( Vec u ) ch ( __build_client_hello server_name cpub random sessid )
+    : ( Vec u ) ch ( __build_client_hello server_name cpub p256pub random sessid )
+    ( vec_free [u] p256pub )
     ( __cat tr ch )
     : !v TlsErr sw ( __send_plain c 22 ch )
     ?? sw { T _ → {} F e → { ^ ( __fail c priv cpub random sessid ch tr e ) } }
@@ -612,7 +638,9 @@ $ `verify.nu`
     : ( Vec u ) spub ?? spkr { T k → k F e → { ( vec_free [u] sh ) ^ ( __fail c priv cpub random sessid ch tr e ) } }
 
     // ── key schedule (handshake) ──
-    : ( Vec u ) ecdhe ( x25519 priv spub )
+    // Distinguish the negotiated group by the server key-exchange length:
+    // X25519 is 32 bytes, secp256r1 an uncompressed point is 65.
+    : ( Vec u ) ecdhe ? == ( vec_len [u] spub ) 65 ( p256_ecdh_shared . c kx_p256 spub ) ( x25519 priv spub )
     : ( Vec u ) zeros ( __rand_bytes 0 )
     : ( Vec u ) z32 ( vec_with_cap [u] 32 )
     : ~ i zk 0
@@ -731,6 +759,21 @@ $ `verify.nu`
 
 @ tls_connect s host i port s server_name → !*TlsConn TlsErr {
     : !*TlsConn TlsErr r ( tls_connect_insecure host port server_name )
+    ^ ( __verify_conn r server_name )
+}
+
+// Verifying counterpart of `tls_attach`: upgrade an already-connected
+// socket to TLS and verify the chain / hostname against the system trust
+// store (the secure default for STARTTLS-style upgrades).
+@ tls_attach_verify i raw s server_name → !*TlsConn TlsErr {
+    : !*TlsConn TlsErr r ( tls_attach raw server_name )
+    ^ ( __verify_conn r server_name )
+}
+
+// Shared post-handshake verification used by both tls_connect and
+// tls_attach_verify: check the certificate (TLS 1.3 CertificateVerify or
+// TLS 1.2 ServerKeyExchange sig + chain + hostname) and close on failure.
+@ __verify_conn ! * TlsConn TlsErr r s server_name → !*TlsConn TlsErr {
     ?? r {
         F e → { ^ @ !*TlsConn TlsErr { F e } }
         T c → {
@@ -865,6 +908,7 @@ $ `verify.nu`
     ( vec_free [u] . c cert_msg )
     ( vec_free [u] . c cv_sig )
     ( vec_free [u] . c th_cert )
+    ( vec_free [u] . c kx_p256 )
     ( nurl_free # s c )
 }
 

--- a/stdlib/std/ecdsa_p256.nu
+++ b/stdlib/std/ecdsa_p256.nu
@@ -217,6 +217,62 @@ $ `stdlib/std/bigint.nu`
     ^ x
 }
 
+// Affine y-coordinate of a Jacobian point: Y / Z^3 mod p.
+@ __jaffine_y Jac q BigInt p → BigInt {
+    : BigInt zsq ( __fsqr . q z p )
+    : BigInt zcb ( __fmul zsq . q z p )
+    : BigInt zinv ( __finv zcb p )
+    : BigInt y ( __fmul . q y zinv p )
+    ( bigint_free zsq )
+    ( bigint_free zcb )
+    ( bigint_free zinv )
+    ^ y
+}
+
+// ── ECDHE over NIST P-256 (secp256r1) ─────────────────────────────
+// The TLS 1.3 secp256r1 group (RFC 8446 §4.2.8.2 / RFC 8422): the
+// public key is an uncompressed point 0x04 || X(32) || Y(32), and the
+// shared secret is the 32-byte big-endian X of scalar·peer. `scalar` is
+// the 32-byte ephemeral private key. Reuses the curve arithmetic above.
+
+// Private scalar → 65-byte uncompressed public point.
+@ p256_ecdh_keygen ( Vec u ) scalar → ( Vec u ) {
+    : BigInt p ( __p256_p )
+    : Jac G @ Jac { ( __p256_gx ) ( __p256_gy ) ( bigint_from_i 1 ) F }
+    : Jac Q ( __jmul scalar G p )
+    : BigInt x ( __jaffine_x Q p )
+    : BigInt y ( __jaffine_y Q p )
+    : ( Vec u ) xb ( bigint_to_bytes_be x 32 )
+    : ( Vec u ) yb ( bigint_to_bytes_be y 32 )
+    : ( Vec u ) out ( vec_with_cap [u] 65 )
+    ( vec_push [u] out # u 4 )
+    : ~ i k 0
+    ~ < k 32 { ( vec_push [u] out ?? ( vec_get [u] xb k ) { T b → b F _ → # u 0 } ) = k + k 1 }
+    = k 0
+    ~ < k 32 { ( vec_push [u] out ?? ( vec_get [u] yb k ) { T b → b F _ → # u 0 } ) = k + k 1 }
+    ( bigint_free p ) ( __jfree G ) ( __jfree Q )
+    ( bigint_free x ) ( bigint_free y ) ( vec_free [u] xb ) ( vec_free [u] yb )
+    ^ out
+}
+
+// scalar · peer-point → 32-byte shared X. Returns [] on a malformed peer.
+@ p256_ecdh_shared ( Vec u ) scalar ( Vec u ) peer → ( Vec u ) {
+    ? != ( vec_len [u] peer ) 65 { ^ ( vec_new [u] ) } {}
+    ? != ?? ( vec_get [u] peer 0 ) { T x → # i x F _ → 0 } 4 { ^ ( vec_new [u] ) } {}
+    : ( Vec u ) qxb ( bytes_slice peer 1 33 )
+    : ( Vec u ) qyb ( bytes_slice peer 33 65 )
+    : BigInt qx ( bigint_from_bytes_be qxb )
+    : BigInt qy ( bigint_from_bytes_be qyb )
+    : BigInt p ( __p256_p )
+    : Jac Q @ Jac { qx qy ( bigint_from_i 1 ) F }
+    : Jac R ( __jmul scalar Q p )
+    : BigInt rx ( __jaffine_x R p )
+    : ( Vec u ) out ( bigint_to_bytes_be rx 32 )
+    ( vec_free [u] qxb ) ( vec_free [u] qyb )
+    ( bigint_free p ) ( __jfree Q ) ( __jfree R ) ( bigint_free rx )
+    ^ out
+}
+
 // ── verify ────────────────────────────────────────────────────────
 // Both NIST P-256 and P-384 use a = -3, so the Jacobian point ops above
 // are curve-independent; this core takes the curve constants and the

--- a/stdlib/std/pbkdf2.nu
+++ b/stdlib/std/pbkdf2.nu
@@ -1,0 +1,69 @@
+// stdlib/std/pbkdf2.nu — PBKDF2-HMAC-SHA-256 (RFC 8018 §5.2) in pure NURL.
+//
+//   ( pbkdf2_hmac_sha256 password salt iters dklen ) → ( Vec u )  dklen bytes
+//
+// `password` and `salt` are ( Vec u ); `iters` is the iteration count and
+// `dklen` the desired derived-key length in bytes. Built on the pure-NURL
+// HMAC-SHA-256 — no OpenSSL/FFI. This is the key-stretching primitive used
+// by SCRAM-SHA-256 (RFC 7677), where dklen is 32 (one HMAC block).
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/hash_sha256.nu`
+
+@ __pb_bget ( Vec u ) v i k → i {
+    ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ 0 }
+}
+
+// One PBKDF2 block F(P, S, c, i) = U_1 ^ U_2 ^ ... ^ U_c, each U_n a
+// 32-byte HMAC-SHA-256. U_1 = HMAC(P, S || INT32-BE(i)); U_n = HMAC(P, U_{n-1}).
+@ __pb_block ( Vec u ) password ( Vec u ) salt i iters i blockidx → ( Vec u ) {
+    : i slen ( vec_len [u] salt )
+    : ( Vec u ) seed ( vec_with_cap [u] + slen 4 )
+    : ~ i si 0
+    ~ < si slen { ( vec_push [u] seed # u ( __pb_bget salt si ) ) = si + si 1 }
+    ( vec_push [u] seed # u & >> blockidx 24 255 )
+    ( vec_push [u] seed # u & >> blockidx 16 255 )
+    ( vec_push [u] seed # u & >> blockidx 8 255 )
+    ( vec_push [u] seed # u & blockidx 255 )
+
+    : ~ ( Vec u ) u ( hmac_sha256_pure password seed )
+    ( vec_free [u] seed )
+
+    // accumulator t starts as a copy of U_1
+    : ( Vec u ) t ( vec_with_cap [u] 32 )
+    : ~ i ti 0
+    ~ < ti 32 { ( vec_push [u] t # u ( __pb_bget u ti ) ) = ti + ti 1 }
+
+    : ~ i n 1
+    ~ < n iters {
+        : ( Vec u ) un ( hmac_sha256_pure password u )
+        ( vec_free [u] u )
+        = u un
+        : ~ i xi 0
+        ~ < xi 32 {
+            : i cur ?? ( vec_get [u] t xi ) { T x → # i x F _ → 0 }
+            ( vec_set [u] t xi # u & ^^ cur ( __pb_bget u xi ) 255 )
+            = xi + xi 1
+        }
+        = n + n 1
+    }
+    ( vec_free [u] u )
+    ^ t
+}
+
+@ pbkdf2_hmac_sha256 ( Vec u ) password ( Vec u ) salt i iters i dklen → ( Vec u ) {
+    : ( Vec u ) out ( vec_with_cap [u] ? > dklen 0 dklen 1 )
+    : ~ i blockidx 1
+    : ~ i generated 0
+    ~ < generated dklen {
+        : ( Vec u ) blk ( __pb_block password salt iters blockidx )
+        : i take ? > - dklen generated 32 32 - dklen generated
+        : ~ i bi 0
+        ~ < bi take { ( vec_push [u] out # u ( __pb_bget blk bi ) ) = bi + bi 1 }
+        ( vec_free [u] blk )
+        = generated + generated take
+        = blockidx + blockidx 1
+    }
+    ^ out
+}


### PR DESCRIPTION
## What

A **pure-NURL PostgreSQL client**: the v3 wire protocol, authentication (trust / cleartext / MD5 / **SCRAM-SHA-256**) and the **TLS transport** are all implemented in NURL — **no libpq, no OpenSSL**. A secure, authenticated connection works on a host with nothing installed; the produced binary's `NEEDED` is **`libc.so.6` only**. Installable with `nurlpkg install psql`, and usable as a library (`pg_connect` / `pg_query`).

```
psql --sslmode require -U me -d mydb -c "select * from t"
psql "postgres://me:secret@db:5432/mydb?sslmode=verify-full" -c "select now()"
```

## New stdlib crypto (KAT-golden, ASan-clean)

- **`std/pbkdf2.nu`** — PBKDF2-HMAC-SHA-256 (RFC 8018), the key-stretch SCRAM needs. Matches RFC / `hashlib` vectors (`pbkdf2_vectors`).
- **`std/ecdsa_p256.nu`** — P-256 ECDH (`p256_ecdh_keygen` / `p256_ecdh_shared`) reusing the existing Jacobian curve arithmetic. `keygen(k) == k·G` cross-checked against a pure-Python P-256; the exchange is symmetric (`p256_ecdh_vectors`).

## `packages/tls` — handshake-over-socket + P-256

- **`tls_attach` / `tls_attach_verify`** run the handshake on an already-connected fd (refactored out of `tls_connect`) — what STARTTLS-style upgrades need: PostgreSQL's `SSLRequest`, SMTP STARTTLS, IMAP.
- The ClientHello now offers **both X25519 and secp256r1** (`key_share` + `supported_groups`), and the key schedule selects the curve by the server key-exchange length. Stock PostgreSQL/OpenSSL commonly defaults to P-256 (`ssl_ecdh_curve = prime256v1`), which the X25519-only client could not reach — **TLS to stock PostgreSQL now works**.

## `packages/psql`

- **`src/scram.nu`** — SCRAM-SHA-256 client; reproduces the RFC 7677 proof exactly.
- **`src/pg.nu`** — wire protocol: `SSLRequest`→`tls_attach` upgrade, startup, auth dispatch, simple query, text decode, NULL handling, backend `ErrorResponse` surfaced with SQLSTATE.
- **`src/main.nu`** — the `psql` CLI (flags + `postgres://` URL, `-c`, `--sslmode`, aligned table output).

## Compiler fix (root cause, not a workaround)

`gen_ffi_decl` now **dedupes `declare`s by symbol name** across the whole compilation. Two imported modules may legitimately declare the same libc/runtime extern (e.g. `nurl_rand_fill` in both `std/random.nu` and `tls.nu`); re-emitting an identical `declare` made LLVM reject the module with *"invalid redefinition of function"*. This generalises the existing prelude-symbol skip and is purely additive — it only fires when a duplicate would otherwise error, so the bootstrap stays byte-identical.

## Verification

- End-to-end against a live **PostgreSQL 16**: TLS+SCRAM (P-256 ECDHE), TLS+MD5, plaintext+SCRAM all succeed; **verify-full correctly rejects** a self-signed cert; bad password rejected.
- `tlsget` still verifies + connects to example.com / google.com / cloudflare.com (X25519 path unaffected by the dual key_share).
- **Full corpus: 467 PASS / 0 FAIL** (incl. the two new crypto goldens). Bootstrap fixed point holds.
- ASan/UBSan: **no corruption / no UAF**; the library hot-path is leak-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YH7KtE5CDFzy2rNCatout