### PR TITLE
tls: P-256 ECDHE in the TLS 1.2 fallback (fixes TLS-1.2 + P-256 servers)

### DIFF
--- a/packages/tls/README.md
+++ b/packages/tls/README.md
@@ -15,7 +15,9 @@ HTTPS server in use.
 
 ## What's implemented
 
-* **Key exchange** — X25519 (RFC 7748), constant-time Montgomery ladder.
+* **Key exchange** — X25519 (RFC 7748, constant-time Montgomery ladder)
+  and NIST P-256 (secp256r1) ECDHE, negotiated per the server's choice, in
+  both TLS 1.3 and the TLS 1.2 fallback.
 * **Record protection** — ChaCha20-Poly1305 AEAD (RFC 8439) and
   AES-128-GCM (NIST SP 800-38D), negotiated per the server's choice.
 * **Key schedule** — HKDF-Extract/Expand + HKDF-Expand-Label / Derive-Secret
@@ -61,7 +63,8 @@ self-signed / testing only) — encrypted but not authenticated.
 ## Limitations
 
 * TLS 1.3 and 1.2 only (no SSLv3 / TLS 1.0 / 1.1 — long obsolete).
-* ECDHE key exchange over X25519 only (no static-RSA or P-256/P-384 ECDHE).
+* ECDHE key exchange over X25519 and P-256 only (no static-RSA, no P-384
+  ECDHE).
 * No client certificates, no session resumption / 0-RTT, no OCSP / CRL
   revocation checking. Ed25519 and P-521 certificate signatures are not
   yet verified (rare in practice).

--- a/packages/tls/nurl.toml
+++ b/packages/tls/nurl.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tls"
-version = "0.1.0"
-description = "Pure-NURL TLS 1.3 client (RFC 8446) — X25519 + ChaCha20-Poly1305, no OpenSSL, runs on a host with nothing installed."
+version = "0.1.1"
+description = "Pure-NURL TLS 1.3 + 1.2 client (RFC 8446) — X25519 & P-256, ChaCha20-Poly1305 & AES-GCM, verify-full, no OpenSSL, runs on a host with nothing installed."
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/packages/tls/src/tls.nu
+++ b/packages/tls/src/tls.nu
@@ -1077,6 +1077,7 @@ $ `verify.nu`
 
     // ── server flight 1: Certificate, ServerKeyExchange, ServerHelloDone ──
     : ~ ( Vec u ) spub ( vec_new [u] )
+    : ~ i kx_curve 29  // named_curve from ServerKeyExchange: 29 x25519, 23 secp256r1
     : ~ i err 0
     : ~ i done 0
     ~ & == done 0 == err 0 {
@@ -1091,6 +1092,7 @@ $ `verify.nu`
                 } {}
                 ? == t 12 {
                     // ServerKeyExchange: curve_type(1) curve(2) pklen(1) pk sig_scheme(2) siglen(2) sig
+                    = kx_curve ( __rdint msg 5 2 )
                     : i pklen ( __t_bget msg 7 )
                     ( vec_free [u] spub )
                     = spub ( bytes_slice msg 8 + 8 pklen )
@@ -1121,7 +1123,12 @@ $ `verify.nu`
     } {}
 
     // ── ECDHE + master secret ──
-    : ( Vec u ) pms ( x25519 priv spub )
+    // Curve chosen by the server's ServerKeyExchange: secp256r1 (P-256,
+    // 23) or x25519 (29). Stock TLS-1.2 servers (e.g. OpenSSL with the
+    // default ssl_ecdh_curve=prime256v1) pick P-256, so both are handled.
+    : i is_p256 == kx_curve 23
+    : ( Vec u ) ckpub ? is_p256 ( p256_ecdh_keygen . c kx_p256 ) cpub
+    : ( Vec u ) pms ? is_p256 ( p256_ecdh_shared . c kx_p256 spub ) ( x25519 priv spub )
     : ( Vec u ) cs_seed ( vec_new [u] )
     ( bytes_extend_bytes cs_seed random )
     ( bytes_extend_bytes cs_seed srand )
@@ -1130,11 +1137,16 @@ $ `verify.nu`
     ( __tls12_setkeys c master random srand )
 
     // ── ClientKeyExchange (plaintext handshake) ──
-    : ( Vec u ) cke ( vec_with_cap [u] 38 )
+    // body = pubkey_len(1) || pubkey ; handshake length = 1 + len(pubkey)
+    : i cklen ( vec_len [u] ckpub )
+    : ( Vec u ) cke ( vec_with_cap [u] + cklen 5 )
     ( vec_push [u] cke # u 16 )
-    ( __u24 cke 33 )
-    ( vec_push [u] cke # u 32 )
-    ( __cat cke cpub )
+    ( __u24 cke + cklen 1 )
+    ( vec_push [u] cke # u cklen )
+    ( __cat cke ckpub )
+    // ckpub is a fresh P-256 point we own; the x25519 case aliases cpub
+    // (freed with the other handshake scratch later), so only free P-256.
+    ? is_p256 { ( vec_free [u] ckpub ) } {}
     : !v TlsErr ckw ( __send_plain c 22 cke )
     ?? ckw { T _ → {} F _ → {} }
     ( __cat tr cke )


### PR DESCRIPTION
## Problem

A field install showed `tlsget https://httpbin.org/get` → `TlsHandshake` (on x86_64 too, not host flakiness). `httpbin.org` speaks **TLS 1.2 with ECDHE-RSA-AES128-GCM over prime256v1 (P-256)**, and our TLS 1.2 fallback only handled **X25519** key exchange — the 1.3 path gained P-256 in #273, the 1.2 `ServerKeyExchange` path did not. Stock OpenSSL servers default to `ssl_ecdh_curve=prime256v1`, so this affected any TLS-1.2 + P-256 endpoint. (TLS 1.3 hosts like example.com/cloudflare/github were fine.)

## Fix

Make the TLS 1.2 handshake curve-aware:
- read the `named_curve` from the `ServerKeyExchange` (23 = secp256r1, 29 = x25519);
- branch the ECDHE secret and the `ClientKeyExchange` on it, reusing the pure-NURL `p256_ecdh_keygen` / `p256_ecdh_shared` and the ephemeral P-256 key already on the connection;
- the `ClientKeyExchange` length-prefixes whichever public key the chosen curve needs (32-byte X25519 or 65-byte uncompressed P-256).

The SKE signature verification already covered the full ECDHE params, so it's curve-agnostic and unchanged.

## Verified

- `httpbin.org` now returns **200**.
- Local OpenSSL `s_server -tls1_2` returns 200 over **both X25519 and P-256**.
- TLS 1.3 hosts (example.com / cloudflare.com / github.com) unaffected.
- ASan/UBSan clean — no corruption; leak profile identical to the untouched 1.3 path.

Bumped `tls` to **0.1.1** for republish (0.1.0 immutable). `psql` depends on `tls = "^0.1"`, so it picks this up with no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YH7KtE5CDFzy2rNCatout