### PR TITLE
Release v0.9.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.19] — 2026-06-25
+
+A usability pass on the pure-NURL `psql` client: it gains a real psql-style
+front end — aligned result tables, a multi-line REPL, and backslash
+meta-commands — and now **prompts for a password** when the server requires
+one, so it connects to password-protected servers out of the box instead of
+failing with an opaque error. The cross-platform hidden password entry is
+provided by a new runtime helper, `nurl_read_password`.
 
 ### Added
 


### PR DESCRIPTION
Release **v0.9.19** — changelog only; the code (pure-NURL psql front end, password prompt, `nurl_read_password` runtime helper) already merged via #278.

Highlights since v0.9.18:
- **psql** becomes a real psql-style front end (aligned tables, multi-line REPL, backslash meta-commands) and **prompts for a password** when the server requires one, so it connects to password-protected servers out of the box.
- **Runtime: `nurl_read_password`** — cross-platform hidden password entry (termios on POSIX, `SetConsoleMode` on Windows).
- Fixes a per-query leak and an auth-failure connection leak in the psql backend.

Merging this, then tagging `v0.9.19`, triggers the release build (all platforms) so the toolchain ships `nurl_read_password`. psql 0.2.2 will be published to the registry once the release is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YH7KtE5CDFzy2rNCatout