### PR TITLE
runtime: fix wasm32-wasi build of nurl_read_password (no termios on WASI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **WASM build of the runtime.** `nurl_read_password` (added in 0.9.19)
+  included `<termios.h>` on every non-Windows target, which broke the
+  `wasm32-wasi` compile (no termios) used by the playground / API image. It
+  now uses a WASI fallback branch (echoed read) alongside the POSIX termios
+  and Windows console paths; native behaviour is unchanged.
+
 ## [0.9.19] — 2026-06-25
 
 A usability pass on the pure-NURL `psql` client: it gains a real psql-style

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -254,7 +254,8 @@ void nurl_enable_vt(void) {}
  * state afterwards. The prompt goes to stderr so it never lands in
  * redirected stdout. Returns a heap-owned string with the trailing
  * newline stripped (shares nurl_read_line); falls back to an echoed
- * read when echo cannot be toggled (e.g. stdin is not a console). */
+ * read when echo cannot be toggled (e.g. stdin is not a console, or the
+ * platform has no terminal API — WASI). */
 #ifdef _WIN32
 #  ifndef ENABLE_ECHO_INPUT
 #    define ENABLE_ECHO_INPUT 0x0004
@@ -269,6 +270,15 @@ const char* nurl_read_password(const char *prompt) {
     }
     const char *line = nurl_read_line();
     if (toggled) SetConsoleMode(h, mode);
+    fputs("\n", stderr); fflush(stderr);
+    return line;
+}
+#elif defined(__wasi__)
+/* WASI has no termios / console API — read with echo on (the prompt is
+ * meaningless in the wasm sandbox, but the symbol must exist to link). */
+const char* nurl_read_password(const char *prompt) {
+    if (prompt && *prompt) { fputs(prompt, stderr); fflush(stderr); }
+    const char *line = nurl_read_line();
     fputs("\n", stderr); fflush(stderr);
     return line;
 }


### PR DESCRIPTION
The playground / API deploy broke at the wasm step:

```
stdlib/runtime.c:276: fatal error: 'termios.h' file not found
```

`nurl_read_password` (added in v0.9.19) guarded only `_WIN32` vs everything-else, so the POSIX branch's `#include <termios.h>` was reached on `wasm32-wasi`, which has no termios.

**Fix:** add a dedicated `#elif defined(__wasi__)` fallback (prompt + echoed read, no console API) between the Windows and POSIX branches — matching the existing `!defined(_WIN32) && !defined(__wasi__)` termios guards elsewhere in the runtime. Native POSIX/Windows behaviour is unchanged.

Verified via the preprocessor: under `__wasi__` exactly one `nurl_read_password` is defined with **no** `tcsetattr` / termios include; natively the termios branch is active. Native `runtime.c` still compiles and exports the symbol.

No toolchain re-release needed — v0.9.19's native runtime is unaffected; this only unblocks the wasm build used by the playground/API image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YH7KtE5CDFzy2rNCatout