### PR TITLE
redis: pure-NURL Redis client (RESP2 + pub/sub + optional TLS)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -6046,6 +6046,23 @@
                         = pr0_eff db_uc
                         = did_reconstruct T
                     } {}
+                    // `b` (bool) source type with an i64 payload slot: the bool
+                    // rode the slot widened to i64, so truncate back to i1 — a
+                    // `! b E` Ok-payload (or `? b` Some-payload) must materialise
+                    // as i1 so the binding and its `!`/`&`/`|` uses type-check.
+                    // Without this the var is stored/loaded as i64 while `! b`
+                    // emits `xor i1`, which clang rejects. The inner NURL type is
+                    // `__res_nurl_T` for results and `__opt_nurl_T` for options.
+                    : s bopt_t ( nurl_sym_get syms ( nurl_str_cat match_var_name `__opt_nurl_T` ) )
+                    ? & ( seq pt0 `i64` ) | ( seq nurl_inner_t `b` ) ( seq bopt_t `b` )
+                    { : s bl_uc ( nurl_cg_reg cg )
+                        ( nurl_print `  ` ) ( nurl_print bl_uc )
+                        ( nurl_print ` = trunc i64 ` ) ( nurl_print pr0 )
+                        ( nurl_print ` to i1\n` )
+                        = pt0_eff `i1`
+                        = pr0_eff bl_uc
+                        = did_reconstruct T
+                    } {}
                     ? != 0 ( nurl_str_len nurl_inner_t )
                     { : ~ s nurl_inner_llvm ( nurl_sym_get syms nurl_inner_t )
                         // Fallback for paren-compound T (e.g. `( Vec u )`):

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -1,0 +1,168 @@
+# redis — a pure-NURL Redis client
+
+A small, dependency-light Redis client written entirely in NURL. It speaks
+the RESP2 wire protocol over a plain libc TCP socket, and can upgrade to TLS
+(`rediss://`) using the pure-NURL TLS client — **no `hiredis`, no OpenSSL,
+nothing installed on the target.** The binaries link `libc` only.
+
+It ships as two things:
+
+- **a reusable library** (`src/redis.nu` + `src/resp.nu`) you import into your
+  own program, and
+- **a `redis` command** — a small redis-cli-style REPL / one-shot client,
+  handy for testing and scripting.
+
+## Install
+
+```sh
+nurlpkg install redis
+```
+
+This puts a `redis` binary on your `PATH`. Or build from a checkout:
+
+```sh
+cd packages/redis
+nurlpkg install                 # resolve deps/ (the tls package)
+../../nurl.sh src/main.nu redis
+```
+
+## The `redis` command
+
+```
+redis [flags] ["redis://[user:pass@]host:port/db"]
+  -h HOST        host          (default $REDIS_HOST or 127.0.0.1)
+  -p PORT        port          (default $REDIS_PORT or 6379)
+  -a PASSWORD    AUTH password (default $REDIS_PASSWORD)
+  --user USER    ACL username for AUTH (Redis 6+)
+  -n DB          SELECT database index (default 0)
+  --tls          connect over TLS (verify-full)
+  --insecure     with --tls / rediss://, skip certificate verification
+  -c "CMD ARGS"  run one command and exit; otherwise start a REPL
+```
+
+```sh
+redis -c "PING"                                   # "PONG"
+redis -c "SET greeting hello" && redis -c "GET greeting"
+redis -h cache.example.com -p 6380 --tls -c "GET session:42"
+redis "rediss://default:secret@cache.example.com:6380/0"
+```
+
+In the REPL, type commands directly; `quit` (or EOF) exits. Double-quoted
+arguments may contain spaces: `SET phrase "hello world"`.
+
+## The library
+
+```nurl
+$ `deps/redis/src/redis.nu`
+
+@ main → i {
+    : *RedisConn c ?? ( redis_connect `127.0.0.1` 6379 ) {
+        T x → x
+        F e → { ( nurl_eprint ( redis_err_name e ) ) ^ 1 }
+    }
+
+    ?? ( redis_set c `user:1:name` `Ada` ) { T _ → {} F _ → {} }
+
+    ?? ( redis_get c `user:1:name` ) {
+        T rs → {
+            ? ( redis_str_is_nil rs ) { ( nurl_print `(missing)\n` ) }
+                                      { ( nurl_print ( redis_str_val rs ) ) ( nurl_print `\n` ) }
+            ( redis_str_free rs )
+        }
+        F _ → {}
+    }
+
+    ( redis_close c )
+    ^ 0
+}
+```
+
+### Connecting
+
+| Function | Returns |
+| --- | --- |
+| `redis_connect host port` | `!*RedisConn RedisErr` |
+| `redis_connect_tls host port server_name verify` | `!*RedisConn RedisErr` — `verify != 0` ⇒ verify-full |
+| `redis_auth conn user password` | `!v RedisErr` — empty `user` ⇒ legacy single-arg AUTH |
+| `redis_select conn db` | `!v RedisErr` |
+| `redis_close conn` | `v` |
+
+### Typed commands
+
+Strings / keys: `redis_set` `redis_get` `redis_del` `redis_exists`
+`redis_incr` `redis_decr` `redis_incrby` `redis_expire` `redis_ttl`
+`redis_keys`.
+Lists: `redis_lpush` `redis_rpush` `redis_llen` `redis_lrange`.
+Hashes: `redis_hset` `redis_hget` `redis_hgetall`.
+Sets: `redis_sadd` `redis_smembers`.
+Misc: `redis_ping` `redis_echo` `redis_flushdb`.
+
+### Pub/sub
+
+Publish with `redis_publish conn channel msg` (returns the number of
+subscribers reached). To receive, `redis_subscribe` / `redis_psubscribe` a
+channel or pattern, then loop on `redis_next_message`, which blocks until the
+next frame arrives:
+
+```nurl
+?? ( redis_subscribe c `news` ) { T m → ( redis_message_free m ) F _ → {} }
+: ~ b go T
+~ go {
+    ?? ( redis_next_message c ) {
+        T m → {
+            ? ( redis_message_is_payload m )
+              { ( nurl_print ( redis_message_channel m ) ) ( nurl_print `: ` )
+                ( nurl_print ( redis_message_payload m ) ) ( nurl_print `\n` ) } {}
+            ( redis_message_free m )
+        }
+        F _ → { = go F }
+    }
+}
+```
+
+A `RedisMessage` carries `redis_message_kind` (0 message · 1 subscribe ·
+2 unsubscribe · 3 pmessage · 4 psubscribe · 5 punsubscribe),
+`redis_message_channel`, `redis_message_pattern` (p* variants),
+`redis_message_payload`, `redis_message_count` (live subscription count on
+confirmations), and `redis_message_is_payload`. Release it with
+`redis_message_free`. `redis_unsubscribe` / `redis_punsubscribe` leave
+subscriber mode. From the CLI, `redis -c "SUBSCRIBE chan1 chan2"` (or
+`PSUBSCRIBE pat.*`) subscribes and streams messages until interrupted.
+
+`redis_get` / `redis_hget` / `redis_echo` return a `RedisStr` (a nil-aware
+optional string): check `redis_str_is_nil`, read `redis_str_val`, release
+with `redis_str_free`. The `*_strvec` commands return an owned `Vec String`.
+
+### Arbitrary commands
+
+Anything not covered by a helper goes through `redis_command`, which returns
+the raw reply tree:
+
+```nurl
+: ( Vec String ) a ( redis_args )
+( redis_arg a `SET` ) ( redis_arg a `k` ) ( redis_arg a `v` )
+( redis_arg a `EX` ) ( redis_arg_i a 60 )
+?? ( redis_command c a ) {
+    T rep → { /* walk with resp_node_* */ ( resp_reply_free rep ) }
+    F e   → { /* RedisServerError text is ( redis_last_error c ) */ }
+}
+( redis_args_free a )
+```
+
+The reply tree (`src/resp.nu`) is a flat node arena, so it handles arbitrary
+nesting (pub/sub, `XRANGE`, `COMMAND`, …):
+`resp_reply_root`, `resp_node_kind` (0 nil · 1 int · 2 string · 3 error ·
+4 array), `resp_node_int`, `resp_node_str`, `resp_node_is_nil`,
+`resp_node_arr_len`, `resp_node_arr_at`.
+
+## Tests
+
+`tests/resp_test.nu` unit-tests the RESP codec with no server needed.
+`tests/live_test.nu` exercises the typed API against a live server and runs
+clean under AddressSanitizer. `tests/live_smoke.sh` wires both up against a
+local Redis (or a throwaway Docker one). See each file's header for the exact
+build commands.
+
+## License
+
+MIT OR Apache-2.0.

--- a/packages/redis/nurl.toml
+++ b/packages/redis/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "redis"
+version = "0.1.0"
+description = "Pure-NURL Redis client — RESP2 protocol over a libc TCP socket, with an optional pure-NURL TLS upgrade (rediss://, no OpenSSL on the target). A reusable library plus a redis-cli-style command."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+tls = "^0.1"

--- a/packages/redis/src/main.nu
+++ b/packages/redis/src/main.nu
@@ -1,0 +1,364 @@
+// packages/redis/src/main.nu — the `redis` command: a small redis-cli-style
+// client built on the pure-NURL Redis client. Connects over RESP2 with an
+// optional pure-NURL TLS upgrade (rediss://, no OpenSSL on the target),
+// authenticates with AUTH, runs one command with -c or starts a REPL.
+//
+//   redis [flags] ["redis://[user:pass@]host:port/db"]
+//     -h HOST        host (default $REDIS_HOST or 127.0.0.1)
+//     -p PORT        port (default $REDIS_PORT or 6379)
+//     -a PASSWORD    AUTH password (default $REDIS_PASSWORD)
+//     --user USER    ACL username for AUTH (Redis 6+)
+//     -n DB          SELECT database index (default 0)
+//     --tls          connect over TLS (verify-full)
+//     --insecure     with --tls / rediss://, skip certificate verification
+//     -c "CMD ARGS"  run one command and exit; otherwise start a REPL
+//   A rediss:// URL implies --tls.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+$ `redis.nu`
+
+& `c` @ isatty i32 fd → i32
+
+@ __atoi s str → i {
+    : i n ( nurl_str_len str )
+    : ~ i v 0
+    : ~ i k 0
+    ~ < k n {
+        : i c ( nurl_str_get str k )
+        ? & >= c 48 <= c 57 { = v + * v 10 - c 48 } {}
+        = k + k 1
+    }
+    ^ v
+}
+
+@ __print_int i n → v {
+    : String s ( string_new ) ( string_push_int s n )
+    ( nurl_print ( string_data s ) ) ( string_free s )
+}
+
+// ── reply rendering (redis-cli style) ──────────────────────────────
+
+@ __print_node RedisReply r i node i depth → v {
+    : i k ( resp_node_kind r node )
+    ? == k 0 { ( nurl_print `(nil)\n` ) ^ v } {}
+    ? == k 1 { ( nurl_print `(integer) ` ) ( __print_int ( resp_node_int r node ) ) ( nurl_print `\n` ) ^ v } {}
+    ? == k 3 { ( nurl_print `(error) ` ) ( nurl_print ( resp_node_str r node ) ) ( nurl_print `\n` ) ^ v } {}
+    ? == k 2 {
+        ( nurl_print `"` ) ( nurl_print ( resp_node_str r node ) ) ( nurl_print `"\n` )
+        ^ v
+    } {}
+    // array
+    : i n ( resp_node_arr_len r node )
+    ? == n 0 { ( nurl_print `(empty array)\n` ) ^ v } {}
+    : ~ i j 0
+    ~ < j n {
+        : i el ( resp_node_arr_at r node j )
+        ( __print_int + j 1 ) ( nurl_print `) ` )
+        ? == ( resp_node_kind r el ) 4 {
+            ( nurl_print `\n` ) ( __print_node r el + depth 1 )
+        } {
+            ( __print_node r el depth )
+        }
+        = j + j 1
+    }
+}
+
+// Send one already-built command, print its reply, and free args.
+@ __run_cmd *RedisConn c ( Vec String ) args → v {
+    ?? ( redis_command c args ) {
+        T rep → { ( __print_node rep ( resp_reply_root rep ) 0 ) ( resp_reply_free rep ) }
+        F e → {
+            : b srv ?? e { RedisServerError → T _ → F }
+            ? srv {
+                ( nurl_eprint `(error) ` ) ( nurl_eprint ( redis_last_error c ) ) ( nurl_eprint `\n` )
+            } {
+                ( nurl_eprint `(error) ` ) ( nurl_eprint ( redis_err_name e ) ) ( nurl_eprint `\n` )
+            }
+        }
+    }
+    ( redis_args_free args )
+}
+
+// Case-insensitive ASCII equality (for command-name dispatch).
+@ __rci_eq s a s b → b {
+    : i la ( nurl_str_len a )
+    ? != la ( nurl_str_len b ) { ^ F } {}
+    : ~ i k 0
+    : ~ b ok T
+    ~ < k la {
+        : ~ i ca ( nurl_str_get a k )
+        : ~ i cb ( nurl_str_get b k )
+        ? & >= ca 65 <= ca 90 { = ca + ca 32 } {}
+        ? & >= cb 65 <= cb 90 { = cb + cb 32 } {}
+        ? != ca cb { = ok F } {}
+        = k + k 1
+    }
+    ^ ok
+}
+
+@ __print_msg RedisMessage m → v {
+    : i k ( redis_message_kind m )
+    ? == k 0 {
+        ( nurl_print `message ` ) ( nurl_print ( redis_message_channel m ) )
+        ( nurl_print ` "` ) ( nurl_print ( redis_message_payload m ) ) ( nurl_print `"\n` )
+    } {
+    ? == k 3 {
+        ( nurl_print `pmessage ` ) ( nurl_print ( redis_message_pattern m ) )
+        ( nurl_print ` ` ) ( nurl_print ( redis_message_channel m ) )
+        ( nurl_print ` "` ) ( nurl_print ( redis_message_payload m ) ) ( nurl_print `"\n` )
+    } {
+        : i sub | == k 1 == k 4
+        ( nurl_print ? sub `(subscribed ` `(unsubscribed ` )
+        ( nurl_print ? | == k 4 == k 5 ( redis_message_pattern m ) ( redis_message_channel m ) )
+        ( nurl_print `, ` ) ( __print_int ( redis_message_count m ) ) ( nurl_print ` active)\n` )
+    } }
+}
+
+// SUBSCRIBE / PSUBSCRIBE one or more channels, then print delivered messages
+// until the connection closes (Ctrl-C / EOF). `toks` is the whole command
+// (toks[0] = the verb, toks[1..] = channels / patterns).
+@ __subscribe_loop *RedisConn c ( Vec String ) toks i is_pattern → v {
+    : i n ( vec_len [String] toks )
+    : ~ i k 1
+    ~ < k n {
+        : s ch ( string_data ?? ( vec_get [String] toks k ) { T x → x F _ → ( string_new ) } )
+        : !RedisMessage RedisErr sr ? != is_pattern 0 ( redis_psubscribe c ch ) ( redis_subscribe c ch )
+        ?? sr {
+            T m → { ( __print_msg m ) ( redis_message_free m ) }
+            F _ → { ( nurl_eprint `(error) subscribe failed\n` ) ^ v }
+        }
+        = k + k 1
+    }
+    : ~ b go T
+    ~ go {
+        ?? ( redis_next_message c ) {
+            T m → { ( __print_msg m ) ( redis_message_free m ) }
+            F _ → { = go F }
+        }
+    }
+}
+
+// Route a parsed command: SUBSCRIBE / PSUBSCRIBE enter the message loop,
+// everything else is a one-shot request/reply. Frees `toks` either way.
+@ __dispatch *RedisConn c ( Vec String ) toks → v {
+    : s cmd0 ( string_data ?? ( vec_get [String] toks 0 ) { T x → x F _ → ( string_new ) } )
+    ? ( __rci_eq cmd0 `subscribe` ) { ( __subscribe_loop c toks 0 ) ( redis_args_free toks ) ^ v } {}
+    ? ( __rci_eq cmd0 `psubscribe` ) { ( __subscribe_loop c toks 1 ) ( redis_args_free toks ) ^ v } {}
+    ( __run_cmd c toks )
+}
+
+// ── command-line tokenizer (whitespace split, "double quotes") ─────
+
+@ __tokenize s line → ( Vec String ) {
+    : i n ( nurl_str_len line )
+    : ( Vec String ) out ( vec_new [String] )
+    : ~ String cur ( string_new )
+    : ~ i incur 0
+    : ~ i inq 0
+    : ~ i k 0
+    ~ < k n {
+        : i ch ( nurl_str_get line k )
+        ? == inq 1 {
+            ? == ch 34 { = inq 0 } { ( string_push_char cur ch ) = incur 1 }
+        } {
+            ? == ch 34 { = inq 1 = incur 1 } {
+                ? | == ch 32 | == ch 9 == ch 13 {
+                    ? == incur 1 { ( vec_push [String] out cur ) = cur ( string_new ) = incur 0 } {}
+                } {
+                    ( string_push_char cur ch ) = incur 1
+                }
+            }
+        }
+        = k + k 1
+    }
+    ? == incur 1 { ( vec_push [String] out cur ) } { ( string_free cur ) }
+    ^ out
+}
+
+// ── connection info ────────────────────────────────────────────────
+
+: ConnInfo {
+    String host
+    i port
+    String user
+    String password
+    i db
+    i tlsmode    // 0 plain, 1 tls insecure, 2 tls verify-full
+}
+
+// redis://[user:pass@]host[:port][/db]  (rediss:// → TLS)
+@ __parse_url s url ConnInfo ci → ConnInfo {
+    : ~ ConnInfo c ci
+    : i n ( nurl_str_len url )
+    : ~ i p 0
+    ? ( nurl_str_starts url `rediss://` ) { = p 9 ? == . c tlsmode 0 { = . c tlsmode 2 } {} } {}
+    ? ( nurl_str_starts url `redis://` ) { = p 8 } {}
+    : ~ i at -1
+    : ~ i slash -1
+    : ~ i k p
+    ~ < k n {
+        : i ch ( nurl_str_get url k )
+        ? & == ch 64 == at -1 { = at k } {}
+        ? & == ch 47 == slash -1 { = slash k } {}
+        = k + k 1
+    }
+    : ~ i hoststart p
+    ? & != at -1 | == slash -1 < at slash {
+        : String ui ( string_substr ( string_from url ) p - at p )
+        : ?i colon ( string_index_of ui `:` )
+        ?? colon {
+            T ci2 → {
+                = . c user ( string_substr ui 0 ci2 )
+                = . c password ( string_substr ui + ci2 1 - ( string_len ui ) + ci2 1 )
+            }
+            F _ → { = . c password ui }
+        }
+        = hoststart + at 1
+    } {}
+    : i hostend ? != slash -1 slash n
+    : String hostport ( string_substr ( string_from url ) hoststart - hostend hoststart )
+    : ?i pc ( string_index_of hostport `:` )
+    ?? pc {
+        T pci → {
+            = . c host ( string_substr hostport 0 pci )
+            = . c port ( __atoi ( string_data ( string_substr hostport + pci 1 - ( string_len hostport ) + pci 1 ) ) )
+        }
+        F _ → { = . c host hostport }
+    }
+    ? != slash -1 {
+        = . c db ( __atoi ( string_data ( string_substr ( string_from url ) + slash 1 - n + slash 1 ) ) )
+    } {}
+    ^ c
+}
+
+@ __connect ConnInfo ci → !*RedisConn RedisErr {
+    ? > . ci tlsmode 0 {
+        ^ ( redis_connect_tls ( string_data . ci host ) . ci port ( string_data . ci host ) ? >= . ci tlsmode 2 1 0 )
+    } {}
+    ^ ( redis_connect ( string_data . ci host ) . ci port )
+}
+
+@ __usage → v {
+    ( nurl_print `redis (NURL) — a pure-NURL Redis client (RESP2, optional pure TLS)\n\n` )
+    ( nurl_print `Usage:\n` )
+    ( nurl_print `  redis [flags] ["redis://[user:pass@]host:port/db"]\n\n` )
+    ( nurl_print `Flags:\n` )
+    ( nurl_print `  -h HOST        host        (default $REDIS_HOST or 127.0.0.1)\n` )
+    ( nurl_print `  -p PORT        port        (default $REDIS_PORT or 6379)\n` )
+    ( nurl_print `  -a PASSWORD    AUTH password (default $REDIS_PASSWORD)\n` )
+    ( nurl_print `  --user USER    ACL username for AUTH (Redis 6+)\n` )
+    ( nurl_print `  -n DB          SELECT database index (default 0)\n` )
+    ( nurl_print `  --tls          connect over TLS (verify-full)\n` )
+    ( nurl_print `  --insecure     skip certificate verification\n` )
+    ( nurl_print `  -c "CMD ARGS"  run one command and exit (otherwise start a REPL)\n` )
+    ( nurl_print `  --help, -?     show this help and exit\n\n` )
+    ( nurl_print `Examples:\n` )
+    ( nurl_print `  redis -c "PING"\n` )
+    ( nurl_print `  redis -h cache.example.com -p 6380 --tls -c "GET session:42"\n` )
+    ( nurl_print `  redis "rediss://default:secret@cache.example.com:6380/0"\n` )
+}
+
+@ main → i {
+    : ( Vec String ) args ( env_args_list )
+    : i argc ( vec_len [String] args )
+
+    : ~ ConnInfo ci @ ConnInfo {
+        ( env_var_or `REDIS_HOST` `127.0.0.1` )
+        ( __atoi ( string_data ( env_var_or `REDIS_PORT` `6379` ) ) )
+        ( string_new )
+        ( env_var_or `REDIS_PASSWORD` `` )
+        0
+        0
+    }
+    : ~ String oneshot ( string_new )
+    : ~ b have_c F
+    : ~ b want_help F
+    : ~ i insecure 0
+
+    : ~ i ai 1
+    ~ < ai argc {
+        : String a ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_new ) }
+        : s as ( string_data a )
+        ? ( nurl_str_eq as `-h` ) { = ai + ai 1 = . ci host ?? ( vec_get [String] args ai ) { T x → x F _ → . ci host } } {
+        ? ( nurl_str_eq as `-p` ) { = ai + ai 1 = . ci port ( __atoi ( string_data ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_from `6379` ) } ) ) } {
+        ? ( nurl_str_eq as `-a` ) { = ai + ai 1 = . ci password ?? ( vec_get [String] args ai ) { T x → x F _ → . ci password } } {
+        ? ( nurl_str_eq as `--user` ) { = ai + ai 1 = . ci user ?? ( vec_get [String] args ai ) { T x → x F _ → . ci user } } {
+        ? ( nurl_str_eq as `-n` ) { = ai + ai 1 = . ci db ( __atoi ( string_data ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_from `0` ) } ) ) } {
+        ? ( nurl_str_eq as `--tls` ) { ? == . ci tlsmode 0 { = . ci tlsmode 2 } {} } {
+        ? ( nurl_str_eq as `--insecure` ) { = insecure 1 } {
+        ? ( nurl_str_eq as `-c` ) { = ai + ai 1 = oneshot ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_new ) } = have_c T } {
+        ? | ( nurl_str_starts as `redis://` ) ( nurl_str_starts as `rediss://` ) { = ci ( __parse_url as ci ) } {
+        ? | ( nurl_str_eq as `--help` ) ( nurl_str_eq as `-?` ) { = want_help T } {
+            ( nurl_eprint `redis: unknown argument: ` ) ( nurl_eprint as ) ( nurl_eprint `\n` )
+        } } } } } } } } } }
+        = ai + ai 1
+    }
+
+    ? want_help { ( __usage ) ^ 0 } {}
+
+    // --insecure downgrades verify-full to encrypt-only.
+    ? & == insecure 1 > . ci tlsmode 0 { = . ci tlsmode 1 } {}
+
+    : i tty # i ( isatty # i32 0 )
+
+    : !*RedisConn RedisErr cr ( __connect ci )
+    ?? cr {
+        F e → {
+            ( nurl_eprint `redis: connection failed: ` ) ( nurl_eprint ( redis_err_name e ) ) ( nurl_eprint `\n` )
+            ^ 1
+        }
+        T c → {
+            // AUTH if a password was supplied.
+            ? > ( string_len . ci password ) 0 {
+                ?? ( redis_auth c ( string_data . ci user ) ( string_data . ci password ) ) {
+                    T _ → {}
+                    F _ → {
+                        ( nurl_eprint `redis: AUTH failed: ` ) ( nurl_eprint ( redis_last_error c ) ) ( nurl_eprint `\n` )
+                        ( redis_close c ) ^ 1
+                    }
+                }
+            } {}
+            // SELECT a non-default database.
+            ? > . ci db 0 {
+                ?? ( redis_select c . ci db ) { T _ → {} F _ → {} }
+            } {}
+
+            ? have_c {
+                : ( Vec String ) toks ( __tokenize ( string_data oneshot ) )
+                ? > ( vec_len [String] toks ) 0 { ( __dispatch c toks ) } { ( redis_args_free toks ) }
+            } {
+                ? != tty 0 {
+                    ( nurl_print `redis (NURL) — pure-NURL client. Type a command, or 'quit' to exit.\n` )
+                } {}
+                : ~ b running T
+                ~ running {
+                    ? != tty 0 {
+                        ( nurl_print ( string_data . ci host ) ) ( nurl_print `:` ) ( __print_int . ci port ) ( nurl_print `> ` )
+                    } {}
+                    : String line ( read_line )
+                    ? & == ( string_len line ) 0 ( stdin_eof ) {
+                        = running F
+                        ? != tty 0 { ( nurl_print `\n` ) } {}
+                    } {
+                        : ( Vec String ) toks ( __tokenize ( string_data line ) )
+                        : i tn ( vec_len [String] toks )
+                        ? == tn 0 { ( redis_args_free toks ) } {
+                            : s cmd0 ( string_data ?? ( vec_get [String] toks 0 ) { T x → x F _ → ( string_new ) } )
+                            ? | ( nurl_str_eq cmd0 `quit` ) ( nurl_str_eq cmd0 `exit` ) {
+                                ( redis_args_free toks ) = running F
+                            } {
+                                ( __dispatch c toks )
+                            }
+                        }
+                    }
+                    ( string_free line )
+                }
+            }
+            ( redis_close c )
+            ^ 0
+        }
+    }
+}

--- a/packages/redis/src/redis.nu
+++ b/packages/redis/src/redis.nu
@@ -1,0 +1,572 @@
+// packages/redis/src/redis.nu — a pure-NURL Redis client. Speaks RESP2 over
+// a plain libc TCP socket, or over the pure-NURL TLS client (rediss://) with
+// no OpenSSL on the target. The RESP wire format lives in resp.nu; this file
+// owns the connection, the request/reply round-trip and an ergonomic command
+// surface (GET / SET / INCR / lists / hashes / sets / pub-sub …).
+//
+//   ( redis_connect host port )                  → !*RedisConn RedisErr
+//   ( redis_connect_tls host port sni verify )    → !*RedisConn RedisErr
+//   ( redis_auth conn user password )             → !v RedisErr
+//   ( redis_command conn args )                   → !RedisReply RedisErr   (raw)
+//   ( redis_get conn key ) / ( redis_set … ) …    → typed helpers
+//   ( redis_close conn )                          → v
+//
+// Build arbitrary commands with the arg builder:
+//   : ( Vec String ) a ( redis_args )
+//   ( redis_arg a `SET` ) ( redis_arg a key ) ( redis_arg a val )
+//   : !RedisReply RedisErr r ( redis_command c a )
+//   ( redis_args_free a )
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/net.nu`
+$ `deps/tls/src/tls.nu`
+$ `resp.nu`
+
+: | RedisErr {
+    RedisConnFail     // could not open the TCP socket
+    RedisTls          // TLS upgrade failed (handshake / cert error)
+    RedisProtocol     // malformed RESP from the server
+    RedisIo           // socket read/write failure or unexpected EOF
+    RedisServerError  // server returned a RESP error — see conn.lasterr
+    RedisType         // reply was not the type the helper expected
+}
+
+@ redis_err_name RedisErr e → s {
+    ^ ?? e {
+        RedisConnFail → `RedisConnFail`
+        RedisTls → `RedisTls`
+        RedisProtocol → `RedisProtocol`
+        RedisIo → `RedisIo`
+        RedisServerError → `RedisServerError`
+        RedisType → `RedisType`
+    }
+}
+
+// Optional bulk-string reply. found == 0 means the server answered nil
+// (e.g. GET on a missing key); `val` is owned and empty in that case.
+// A named struct rather than `?String` so it round-trips through `!T E`.
+: RedisStr {
+    i found
+    String val
+}
+
+@ redis_str_is_nil RedisStr s → b { ^ == . s found 0 }
+@ redis_str_val RedisStr s → s { ^ ( string_data . s val ) }
+@ redis_str_free RedisStr s → v { ( string_free . s val ) }
+
+// A pub/sub frame. kind: 0 message · 1 subscribe · 2 unsubscribe ·
+// 3 pmessage · 4 psubscribe · 5 punsubscribe · -1 unrecognised.
+// `pattern` is set only for the p* variants; `count` is the live
+// subscription count carried by (un)subscribe confirmations.
+: RedisMessage {
+    i kind
+    String channel
+    String pattern
+    String payload
+    i count
+}
+
+@ redis_message_kind RedisMessage m → i { ^ . m kind }
+@ redis_message_channel RedisMessage m → s { ^ ( string_data . m channel ) }
+@ redis_message_pattern RedisMessage m → s { ^ ( string_data . m pattern ) }
+@ redis_message_payload RedisMessage m → s { ^ ( string_data . m payload ) }
+@ redis_message_count RedisMessage m → i { ^ . m count }
+// True for an actual published message (message / pmessage), false for a
+// subscribe/unsubscribe control frame.
+@ redis_message_is_payload RedisMessage m → b { ^ | == . m kind 0 == . m kind 3 }
+@ redis_message_free RedisMessage m → v {
+    ( string_free . m channel ) ( string_free . m pattern ) ( string_free . m payload )
+}
+
+: RedisConn {
+    i tls          // 0 plaintext, 1 TLS
+    i raw          // raw socket fd (plaintext reads / fd the TLS layer took over)
+    TcpConn tcp    // plaintext transport (writes via tcp_write_all)
+    * TlsConn tc   // TLS transport (when tls = 1)
+    ( Vec u ) rxbuf // bytes read but not yet parsed into a reply
+    String lasterr // last server error text
+    String host_name
+    i port_num
+    i db_index
+}
+
+// ── transport ─────────────────────────────────────────────────────
+
+@ __r_write *RedisConn c ( Vec u ) bytes → i {
+    ? == . c tls 1 {
+        ?? ( tls_write . c tc bytes ) { T _ → ^ 1 F _ → ^ 0 }
+    } {
+        ?? ( tcp_write_all . c tcp bytes ) { T _ → ^ 1 F _ → ^ 0 }
+    }
+}
+
+// Read one chunk into rxbuf. Returns 1 on progress, 0 on EOF/error.
+@ __r_fill *RedisConn c → i {
+    ? == . c tls 1 {
+        ?? ( tls_read . c tc 16384 ) {
+            T v → {
+                ? == ( vec_len [u] v ) 0 { ( vec_free [u] v ) ^ 0 } {}
+                ( __r_cat . c rxbuf v )
+                ( vec_free [u] v )
+                ^ 1
+            }
+            F _ → ^ 0
+        }
+    } {
+        : ( Vec u ) tmp ( vec_with_cap [u] 16384 )
+        : i got ( nurl_tcp_read . c raw # s ( vec_data [u] tmp ) 16384 )
+        ? <= got 0 { ( vec_free [u] tmp ) ^ 0 } {}
+        : b _ok ( vec_set_len [u] tmp got )
+        ( __r_cat . c rxbuf tmp )
+        ( vec_free [u] tmp )
+        ^ 1
+    }
+}
+
+// Append b onto a in place.
+@ __r_cat ( Vec u ) a ( Vec u ) b → v {
+    : i n ( vec_len [u] b )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] a ?? ( vec_get [u] b k ) { T x → x F _ → # u 0 } ) = k + k 1 }
+}
+
+// Read exactly one full reply from the socket. Reads more bytes whenever the
+// buffered prefix is an incomplete RESP value, then drops the consumed bytes.
+@ __r_read_reply *RedisConn c → !RedisReply RedisErr {
+    : ~ b spin T
+    ~ spin {
+        : RespParse p ( resp_parse . c rxbuf 0 )
+        ? == . p status 0 {
+            : i consumed . p consumed
+            : i have ( vec_len [u] . c rxbuf )
+            : ( Vec u ) rest ( bytes_slice . c rxbuf consumed have )
+            ( vec_free [u] . c rxbuf )
+            = . c rxbuf rest
+            ^ @ !RedisReply RedisErr { T . p reply }
+        } {}
+        ? == . p status 2 {
+            ( resp_reply_free . p reply )
+            ^ @ !RedisReply RedisErr { F # RedisErr RedisProtocol }
+        } {}
+        // incomplete: discard the partial arena and pull more bytes
+        ( resp_reply_free . p reply )
+        ? == ( __r_fill c ) 0 { ^ @ !RedisReply RedisErr { F # RedisErr RedisIo } } {}
+    }
+    ^ @ !RedisReply RedisErr { F # RedisErr RedisIo }
+}
+
+// ── command round-trip ─────────────────────────────────────────────
+
+// Send a command (array of bulk strings) and return its reply. A RESP error
+// reply is surfaced as RedisServerError with the text in conn.lasterr. The
+// caller still owns `args` (free with redis_args_free) and owns the returned
+// reply (free with resp_reply_free).
+@ redis_command *RedisConn c ( Vec String ) args → !RedisReply RedisErr {
+    : ( Vec u ) req ( resp_encode args )
+    : i ok ( __r_write c req )
+    ( vec_free [u] req )
+    ? == ok 0 { ^ @ !RedisReply RedisErr { F # RedisErr RedisIo } } {}
+    : !RedisReply RedisErr rr ( __r_read_reply c )
+    ?? rr {
+        F e → ^ @ !RedisReply RedisErr { F e }
+        T rep → {
+            : i root ( resp_reply_root rep )
+            ? == ( resp_node_kind rep root ) 3 {
+                ( string_free . c lasterr )
+                = . c lasterr ( string_from ( resp_node_str rep root ) )
+                ( resp_reply_free rep )
+                ^ @ !RedisReply RedisErr { F # RedisErr RedisServerError }
+            } {}
+            ^ @ !RedisReply RedisErr { T rep }
+        }
+    }
+}
+
+// ── argument builders ──────────────────────────────────────────────
+
+@ redis_args → ( Vec String ) { ^ ( vec_new [String] ) }
+
+@ redis_arg ( Vec String ) v s a → v { ( vec_push [String] v ( string_from a ) ) }
+
+@ redis_arg_i ( Vec String ) v i n → v {
+    : String s ( string_new ) ( string_push_int s n ) ( vec_push [String] v s )
+}
+
+@ redis_args_free ( Vec String ) v → v {
+    : i n ( vec_len [String] v )
+    : ~ i k 0
+    ~ < k n { ?? ( vec_get [String] v k ) { T s → ( string_free s ) F _ → {} } = k + k 1 }
+    ( vec_free [String] v )
+}
+
+@ __args1 s a → ( Vec String ) {
+    : ( Vec String ) v ( vec_new [String] ) ( redis_arg v a ) ^ v
+}
+@ __args2 s a s b → ( Vec String ) {
+    : ( Vec String ) v ( __args1 a ) ( redis_arg v b ) ^ v
+}
+@ __args3 s a s b s d → ( Vec String ) {
+    : ( Vec String ) v ( __args2 a b ) ( redis_arg v d ) ^ v
+}
+
+// Build, send, and free args in one shot.
+@ __cmd_reply *RedisConn c ( Vec String ) args → !RedisReply RedisErr {
+    : !RedisReply RedisErr rr ( redis_command c args )
+    ( redis_args_free args )
+    ^ rr
+}
+
+// ── typed reply extractors ─────────────────────────────────────────
+
+// Integer reply (e.g. DEL, INCR, EXISTS count).
+@ __reply_int *RedisConn c ( Vec String ) args → !i RedisErr {
+    ?? ( __cmd_reply c args ) {
+        F e → ^ @ !i RedisErr { F e }
+        T rep → {
+            : i root ( resp_reply_root rep )
+            : ~ i out 0
+            ? == ( resp_node_kind rep root ) 1 { = out ( resp_node_int rep root ) } {}
+            ( resp_reply_free rep )
+            ^ @ !i RedisErr { T out }
+        }
+    }
+}
+
+// Integer reply interpreted as a boolean (1 → true).
+@ __reply_bool *RedisConn c ( Vec String ) args → !b RedisErr {
+    ?? ( __reply_int c args ) {
+        F e → ^ @ !b RedisErr { F e }
+        T n → ^ @ !b RedisErr { T == n 1 }
+    }
+}
+
+// Status reply (+OK and friends); we only care that it wasn't an error.
+@ __reply_ok *RedisConn c ( Vec String ) args → !v RedisErr {
+    ?? ( __cmd_reply c args ) {
+        F e → ^ @ !v RedisErr { F e }
+        T rep → { ( resp_reply_free rep ) ^ @ !v RedisErr { T 0 } }
+    }
+}
+
+// Bulk-string reply, nil-aware. Integers are rendered to text so commands
+// that may answer either way still produce a value.
+@ __reply_str *RedisConn c ( Vec String ) args → !RedisStr RedisErr {
+    ?? ( __cmd_reply c args ) {
+        F e → ^ @ !RedisStr RedisErr { F e }
+        T rep → {
+            : i root ( resp_reply_root rep )
+            : i k ( resp_node_kind rep root )
+            : ~ i found 0
+            : ~ String val ( string_new )
+            ? == k 2 {
+                = found 1
+                ( string_free val ) = val ( string_from ( resp_node_str rep root ) )
+            } {
+                ? == k 1 { = found 1 ( string_push_int val ( resp_node_int rep root ) ) } {}
+            }
+            ( resp_reply_free rep )
+            ^ @ !RedisStr RedisErr { T @ RedisStr { found val } }
+        }
+    }
+}
+
+// Array reply flattened to a Vec of owned Strings (bulk elements; integer
+// elements rendered; nils → empty string). Nil array → empty Vec.
+@ __reply_strvec *RedisConn c ( Vec String ) args → !( Vec String ) RedisErr {
+    ?? ( __cmd_reply c args ) {
+        F e → ^ @ !( Vec String ) RedisErr { F e }
+        T rep → {
+            : i root ( resp_reply_root rep )
+            : ( Vec String ) out ( vec_new [String] )
+            ? == ( resp_node_kind rep root ) 4 {
+                : i n ( resp_node_arr_len rep root )
+                : ~ i k 0
+                ~ < k n {
+                    : i el ( resp_node_arr_at rep root k )
+                    : i ek ( resp_node_kind rep el )
+                    ? == ek 1 {
+                        : String s ( string_new ) ( string_push_int s ( resp_node_int rep el ) )
+                        ( vec_push [String] out s )
+                    } {
+                        ( vec_push [String] out ( string_from ( resp_node_str rep el ) ) )
+                    }
+                    = k + k 1
+                }
+            } {}
+            ( resp_reply_free rep )
+            ^ @ !( Vec String ) RedisErr { T out }
+        }
+    }
+}
+
+// ── connection ─────────────────────────────────────────────────────
+
+// tlsmode: 0 plaintext · 1 TLS no-verify · 2 TLS verify-full
+@ __redis_open s host i port i tlsmode s server_name → !*RedisConn RedisErr {
+    : i rawfd ( nurl_tcp_connect host port )
+    ? != ( nurl_tcp_err_kind rawfd ) 0 { ^ @ !*RedisConn RedisErr { F # RedisErr RedisConnFail } } {}
+
+    : *RedisConn c # *RedisConn ( nurl_alloc Z RedisConn )
+    = . c tls 0
+    = . c raw rawfd
+    = . c tcp @ TcpConn { # s rawfd }
+    = . c tc # *TlsConn 0
+    = . c rxbuf ( vec_new [u] )
+    = . c lasterr ( string_new )
+    = . c host_name ( string_from host )
+    = . c port_num port
+    = . c db_index 0
+
+    ? > tlsmode 0 {
+        : !*TlsConn TlsErr tr ? >= tlsmode 2 ( tls_attach_verify rawfd server_name ) ( tls_attach rawfd server_name )
+        ?? tr {
+            T tc → { = . c tls 1 = . c tc tc }
+            F _ → {
+                ( nurl_tcp_close rawfd )
+                ( vec_free [u] . c rxbuf ) ( string_free . c lasterr ) ( string_free . c host_name )
+                ( nurl_free # s c )
+                ^ @ !*RedisConn RedisErr { F # RedisErr RedisTls }
+            }
+        }
+    } {}
+    ^ @ !*RedisConn RedisErr { T c }
+}
+
+@ redis_connect s host i port → !*RedisConn RedisErr {
+    ^ ( __redis_open host port 0 `` )
+}
+
+// verify != 0 → verify-full (chain + hostname); verify == 0 → encrypt only.
+@ redis_connect_tls s host i port s server_name i verify → !*RedisConn RedisErr {
+    ^ ( __redis_open host port ? != verify 0 2 1 server_name )
+}
+
+@ redis_close *RedisConn c → v {
+    ? == . c tls 1 { ( tls_close . c tc ) } { ( nurl_tcp_close . c raw ) }
+    ( vec_free [u] . c rxbuf )
+    ( string_free . c lasterr )
+    ( string_free . c host_name )
+    ( nurl_free # s c )
+}
+
+@ redis_last_error *RedisConn c → s { ^ ( string_data . c lasterr ) }
+@ redis_is_tls *RedisConn c → b { ^ == . c tls 1 }
+
+// ── connection commands ────────────────────────────────────────────
+
+// AUTH: one-arg (password only) or two-arg (ACL user + password). Pass an
+// empty user for the legacy single-argument form.
+@ redis_auth *RedisConn c s user s password → !v RedisErr {
+    ? == ( nurl_str_len user ) 0 { ^ ( __reply_ok c ( __args2 `AUTH` password ) ) } {}
+    ^ ( __reply_ok c ( __args3 `AUTH` user password ) )
+}
+
+@ redis_select *RedisConn c i db → !v RedisErr {
+    : ( Vec String ) a ( __args1 `SELECT` ) ( redis_arg_i a db )
+    : !v RedisErr r ( __reply_ok c a )
+    ?? r { T _ → { = . c db_index db ^ @ !v RedisErr { T 0 } } F e → ^ @ !v RedisErr { F e } }
+}
+
+@ redis_ping *RedisConn c → !b RedisErr {
+    ?? ( __cmd_reply c ( __args1 `PING` ) ) {
+        F e → ^ @ !b RedisErr { F e }
+        T rep → {
+            : i root ( resp_reply_root rep )
+            : b ok & == ( resp_node_kind rep root ) 2 != ( nurl_str_eq ( resp_node_str rep root ) `PONG` ) 0
+            ( resp_reply_free rep )
+            ^ @ !b RedisErr { T ok }
+        }
+    }
+}
+
+@ redis_echo *RedisConn c s msg → !RedisStr RedisErr {
+    ^ ( __reply_str c ( __args2 `ECHO` msg ) )
+}
+
+// ── strings / keys ─────────────────────────────────────────────────
+
+@ redis_set *RedisConn c s key s val → !v RedisErr {
+    ^ ( __reply_ok c ( __args3 `SET` key val ) )
+}
+
+@ redis_get *RedisConn c s key → !RedisStr RedisErr {
+    ^ ( __reply_str c ( __args2 `GET` key ) )
+}
+
+@ redis_del *RedisConn c s key → !i RedisErr {
+    ^ ( __reply_int c ( __args2 `DEL` key ) )
+}
+
+@ redis_exists *RedisConn c s key → !b RedisErr {
+    ^ ( __reply_bool c ( __args2 `EXISTS` key ) )
+}
+
+@ redis_incr *RedisConn c s key → !i RedisErr {
+    ^ ( __reply_int c ( __args2 `INCR` key ) )
+}
+
+@ redis_decr *RedisConn c s key → !i RedisErr {
+    ^ ( __reply_int c ( __args2 `DECR` key ) )
+}
+
+@ redis_incrby *RedisConn c s key i n → !i RedisErr {
+    : ( Vec String ) a ( __args2 `INCRBY` key ) ( redis_arg_i a n )
+    ^ ( __reply_int c a )
+}
+
+@ redis_expire *RedisConn c s key i secs → !b RedisErr {
+    : ( Vec String ) a ( __args2 `EXPIRE` key ) ( redis_arg_i a secs )
+    ^ ( __reply_bool c a )
+}
+
+@ redis_ttl *RedisConn c s key → !i RedisErr {
+    ^ ( __reply_int c ( __args2 `TTL` key ) )
+}
+
+@ redis_keys *RedisConn c s pattern → !( Vec String ) RedisErr {
+    ^ ( __reply_strvec c ( __args2 `KEYS` pattern ) )
+}
+
+// ── lists ──────────────────────────────────────────────────────────
+
+@ redis_lpush *RedisConn c s key s val → !i RedisErr {
+    ^ ( __reply_int c ( __args3 `LPUSH` key val ) )
+}
+
+@ redis_rpush *RedisConn c s key s val → !i RedisErr {
+    ^ ( __reply_int c ( __args3 `RPUSH` key val ) )
+}
+
+@ redis_llen *RedisConn c s key → !i RedisErr {
+    ^ ( __reply_int c ( __args2 `LLEN` key ) )
+}
+
+@ redis_lrange *RedisConn c s key i start i stop → !( Vec String ) RedisErr {
+    : ( Vec String ) a ( __args2 `LRANGE` key ) ( redis_arg_i a start ) ( redis_arg_i a stop )
+    ^ ( __reply_strvec c a )
+}
+
+// ── hashes ─────────────────────────────────────────────────────────
+
+@ redis_hset *RedisConn c s key s field s val → !i RedisErr {
+    : ( Vec String ) a ( __args3 `HSET` key field ) ( redis_arg a val )
+    ^ ( __reply_int c a )
+}
+
+@ redis_hget *RedisConn c s key s field → !RedisStr RedisErr {
+    ^ ( __reply_str c ( __args3 `HGET` key field ) )
+}
+
+// Flat [field, value, field, value, …] of the whole hash.
+@ redis_hgetall *RedisConn c s key → !( Vec String ) RedisErr {
+    ^ ( __reply_strvec c ( __args2 `HGETALL` key ) )
+}
+
+// ── sets ───────────────────────────────────────────────────────────
+
+@ redis_sadd *RedisConn c s key s member → !i RedisErr {
+    ^ ( __reply_int c ( __args3 `SADD` key member ) )
+}
+
+@ redis_smembers *RedisConn c s key → !( Vec String ) RedisErr {
+    ^ ( __reply_strvec c ( __args2 `SMEMBERS` key ) )
+}
+
+// ── pub/sub ────────────────────────────────────────────────────────
+
+@ redis_publish *RedisConn c s channel s msg → !i RedisErr {
+    ^ ( __reply_int c ( __args3 `PUBLISH` channel msg ) )
+}
+
+// Decode one pub/sub reply array into a RedisMessage (owning copies of the
+// channel / pattern / payload text).
+@ __decode_message RedisReply rep → RedisMessage {
+    : i root ( resp_reply_root rep )
+    : ~ i kind -1
+    : ~ String channel ( string_new )
+    : ~ String pattern ( string_new )
+    : ~ String payload ( string_new )
+    : ~ i count 0
+    ? & == ( resp_node_kind rep root ) 4 >= ( resp_node_arr_len rep root ) 1 {
+        : i n ( resp_node_arr_len rep root )
+        : s verb ( resp_node_str rep ( resp_node_arr_at rep root 0 ) )
+        ? != ( nurl_str_eq verb `message` ) 0 {
+            = kind 0
+            ? >= n 3 {
+                ( string_free channel ) = channel ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 1 ) ) )
+                ( string_free payload ) = payload ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 2 ) ) )
+            } {}
+        } {
+        ? != ( nurl_str_eq verb `pmessage` ) 0 {
+            = kind 3
+            ? >= n 4 {
+                ( string_free pattern ) = pattern ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 1 ) ) )
+                ( string_free channel ) = channel ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 2 ) ) )
+                ( string_free payload ) = payload ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 3 ) ) )
+            } {}
+        } {
+            // (p)subscribe / (p)unsubscribe confirmation: [verb, name, count]
+            ? != ( nurl_str_eq verb `subscribe` ) 0 { = kind 1 } {
+            ? != ( nurl_str_eq verb `unsubscribe` ) 0 { = kind 2 } {
+            ? != ( nurl_str_eq verb `psubscribe` ) 0 { = kind 4 } {
+            ? != ( nurl_str_eq verb `punsubscribe` ) 0 { = kind 5 } {} } } }
+            ? >= n 3 {
+                : i is_pat | == kind 4 == kind 5
+                : String name ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 1 ) ) )
+                ? is_pat { ( string_free pattern ) = pattern name } { ( string_free channel ) = channel name }
+                = count ( resp_node_int rep ( resp_node_arr_at rep root 2 ) )
+            } {}
+        } }
+    } {}
+    ^ @ RedisMessage { kind channel pattern payload count }
+}
+
+@ __sub_cmd *RedisConn c s verb s arg → !RedisMessage RedisErr {
+    ?? ( __cmd_reply c ( __args2 verb arg ) ) {
+        F e → ^ @ !RedisMessage RedisErr { F e }
+        T rep → {
+            : RedisMessage m ( __decode_message rep )
+            ( resp_reply_free rep )
+            ^ @ !RedisMessage RedisErr { T m }
+        }
+    }
+}
+
+// Subscribe to a channel (or pattern). Returns the subscription confirmation;
+// thereafter call redis_next_message to receive published messages. While
+// subscribed only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING are valid commands.
+@ redis_subscribe *RedisConn c s channel → !RedisMessage RedisErr {
+    ^ ( __sub_cmd c `SUBSCRIBE` channel )
+}
+@ redis_unsubscribe *RedisConn c s channel → !RedisMessage RedisErr {
+    ^ ( __sub_cmd c `UNSUBSCRIBE` channel )
+}
+@ redis_psubscribe *RedisConn c s pattern → !RedisMessage RedisErr {
+    ^ ( __sub_cmd c `PSUBSCRIBE` pattern )
+}
+@ redis_punsubscribe *RedisConn c s pattern → !RedisMessage RedisErr {
+    ^ ( __sub_cmd c `PUNSUBSCRIBE` pattern )
+}
+
+// Block until the next pub/sub frame arrives, then decode it. Returns a
+// `message` / `pmessage` for delivered payloads, or a (un)subscribe control
+// frame; RedisIo on a closed connection.
+@ redis_next_message *RedisConn c → !RedisMessage RedisErr {
+    ?? ( __r_read_reply c ) {
+        F e → ^ @ !RedisMessage RedisErr { F e }
+        T rep → {
+            : RedisMessage m ( __decode_message rep )
+            ( resp_reply_free rep )
+            ^ @ !RedisMessage RedisErr { T m }
+        }
+    }
+}
+
+// ── admin ──────────────────────────────────────────────────────────
+
+@ redis_flushdb *RedisConn c → !v RedisErr {
+    ^ ( __reply_ok c ( __args1 `FLUSHDB` ) )
+}

--- a/packages/redis/src/resp.nu
+++ b/packages/redis/src/resp.nu
@@ -1,0 +1,281 @@
+// packages/redis/src/resp.nu — RESP (REdis Serialization Protocol, RESP2)
+// codec, pure and I/O-free so it can be unit-tested without a server.
+//
+// A request is an array of bulk strings:
+//   *<n>\r\n  ( $<len>\r\n<arg>\r\n ) x n
+//
+// A reply is one of: simple string (+), error (-), integer (:), bulk
+// string ($, with $-1 = nil) or array (*, with *-1 = nil). Arrays nest
+// arbitrarily (pub/sub, XRANGE, COMMAND, …), so a reply is decoded into a
+// flat node arena — a `Vec RNode` where array nodes hold the pool indices
+// of their children. One Vec plus one String per node: no nested Vecs in
+// structs beyond the child-index list, and a single linear free.
+//
+//   ( resp_encode args )            → ( Vec u )      request bytes
+//   ( resp_parse buf start )        → RespParse      one reply (or Incomplete)
+//   ( resp_reply_free reply )       → v              free a parsed reply
+//
+// Node walking (power users):
+//   resp_reply_root / resp_node_kind / resp_node_int / resp_node_str /
+//   resp_node_is_nil / resp_node_arr_len / resp_node_arr_at
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+// RNode.kind: 0 nil · 1 integer · 2 string (simple or bulk) · 3 error · 4 array
+: RNode {
+    i kind
+    i ival          // integer value; for arrays, the element count
+    String sval     // string / error text (empty otherwise)
+    ( Vec i ) kids   // child node indices (only populated for arrays)
+}
+
+// A decoded reply: the node arena plus the index of the root node.
+: RedisReply {
+    ( Vec RNode ) nodes
+    i root
+}
+
+// Result of one parse attempt over a byte buffer.
+//   status: 0 ok · 1 incomplete (need more bytes) · 2 malformed
+//   consumed: bytes consumed from `start` when status == 0
+: RespParse {
+    i status
+    RedisReply reply
+    i consumed
+}
+
+// Mutable parse state threaded through the recursive descent (heap so the
+// recursion shares one cursor / status / arena).
+: RespBuilder {
+    ( Vec RNode ) nodes
+    i status
+    i cur
+}
+
+// ── encoding ───────────────────────────────────────────────────────
+
+@ __resp_push_crlf ( Vec u ) v → v {
+    ( vec_push [u] v # u 13 ) ( vec_push [u] v # u 10 )
+}
+
+@ __resp_push_s ( Vec u ) v s raw i n → v {
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] v # u ( nurl_str_get raw k ) ) = k + k 1 }
+}
+
+// Append the decimal ASCII of `n` (handles negatives, for completeness).
+@ __resp_push_int_ascii ( Vec u ) v i n → v {
+    ? == n 0 { ( vec_push [u] v # u 48 ) } {
+        : ~ i x n
+        ? < x 0 { ( vec_push [u] v # u 45 ) = x - 0 x } {}
+        : ( Vec u ) tmp ( vec_new [u] )
+        ~ > x 0 { ( vec_push [u] tmp # u + 48 % x 10 ) = x / x 10 }
+        : ~ i k ( vec_len [u] tmp )
+        ~ > k 0 {
+            = k - k 1
+            ( vec_push [u] v ?? ( vec_get [u] tmp k ) { T b → b F _ → # u 48 } )
+        }
+        ( vec_free [u] tmp )
+    }
+}
+
+// Encode a command — an array of bulk strings — into RESP request bytes.
+@ resp_encode ( Vec String ) args → ( Vec u ) {
+    : i n ( vec_len [String] args )
+    : ( Vec u ) out ( vec_new [u] )
+    ( vec_push [u] out # u 42 )           // '*'
+    ( __resp_push_int_ascii out n )
+    ( __resp_push_crlf out )
+    : ~ i k 0
+    ~ < k n {
+        : String a ?? ( vec_get [String] args k ) { T x → x F _ → ( string_new ) }
+        : i alen ( string_len a )
+        ( vec_push [u] out # u 36 )       // '$'
+        ( __resp_push_int_ascii out alen )
+        ( __resp_push_crlf out )
+        ( __resp_push_s out ( string_data a ) alen )
+        ( __resp_push_crlf out )
+        = k + k 1
+    }
+    ^ out
+}
+
+// ── decoding ───────────────────────────────────────────────────────
+
+@ __rbget ( Vec u ) v i k → i {
+    ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ 0 }
+}
+
+// Index of a '\r' at k with '\n' at k+1, scanning [from,end). -1 if the
+// line is not yet complete in the buffer.
+@ __resp_find_crlf ( Vec u ) buf i from i end → i {
+    : ~ i k from
+    ~ < k - end 1 {
+        ? & == ( __rbget buf k ) 13 == ( __rbget buf + k 1 ) 10 { ^ k } {}
+        = k + k 1
+    }
+    ^ -1
+}
+
+@ __resp_slice ( Vec u ) buf i from i to → String {
+    : String out ( string_with_cap ? > - to from 0 - to from 1 )
+    : ~ i k from
+    ~ < k to { ( string_push_char out ( __rbget buf k ) ) = k + k 1 }
+    ^ out
+}
+
+// Signed decimal integer from buf[from,to).
+@ __resp_parse_int ( Vec u ) buf i from i to → i {
+    : ~ i v 0
+    : ~ i neg 0
+    : ~ i k from
+    ? & < from to == ( __rbget buf from ) 45 { = neg 1 = k + from 1 } {}
+    ~ < k to {
+        : i c ( __rbget buf k )
+        ? & >= c 48 <= c 57 { = v + * v 10 - c 48 } {}
+        = k + k 1
+    }
+    ? == neg 1 { ^ - 0 v } { ^ v }
+}
+
+// Append a leaf node to the arena; returns its index.
+@ __rb_push *RespBuilder b i kind i ival String sval → i {
+    : RNode nd @ RNode { kind ival sval ( vec_new [i] ) }
+    : i idx ( vec_len [RNode] . b nodes )
+    ( vec_push [RNode] . b nodes nd )
+    ^ idx
+}
+
+// Append an array node (kids already collected); returns its index.
+@ __rb_push_arr *RespBuilder b i n ( Vec i ) kids → i {
+    : RNode nd @ RNode { 4 n ( string_new ) kids }
+    : i idx ( vec_len [RNode] . b nodes )
+    ( vec_push [RNode] . b nodes nd )
+    ^ idx
+}
+
+// Parse one value at the builder's cursor. Returns its node index, or -1
+// with b.status set to 1 (incomplete) or 2 (malformed).
+@ __resp_val *RespBuilder b ( Vec u ) buf i end → i {
+    ? != . b status 0 { ^ -1 } {}
+    : i pos . b cur
+    ? >= pos end { = . b status 1 ^ -1 } {}
+    : i tb ( __rbget buf pos )
+    : i ls + pos 1
+    : i le ( __resp_find_crlf buf ls end )
+    ? < le 0 { = . b status 1 ^ -1 } {}
+
+    ? == tb 43 {                                   // '+' simple string
+        : String s ( __resp_slice buf ls le )
+        = . b cur + le 2
+        ^ ( __rb_push b 2 0 s )
+    } {}
+    ? == tb 45 {                                   // '-' error
+        : String s ( __resp_slice buf ls le )
+        = . b cur + le 2
+        ^ ( __rb_push b 3 0 s )
+    } {}
+    ? == tb 58 {                                   // ':' integer
+        : i v ( __resp_parse_int buf ls le )
+        = . b cur + le 2
+        ^ ( __rb_push b 1 v ( string_new ) )
+    } {}
+    ? == tb 36 {                                   // '$' bulk string
+        : i blen ( __resp_parse_int buf ls le )
+        ? < blen 0 {                               // $-1 → nil
+            = . b cur + le 2
+            ^ ( __rb_push b 0 0 ( string_new ) )
+        } {}
+        : i dstart + le 2
+        : i dend + dstart blen
+        ? > + dend 2 end { = . b status 1 ^ -1 } {}  // need data + CRLF
+        : String s ( __resp_slice buf dstart dend )
+        = . b cur + dend 2
+        ^ ( __rb_push b 2 0 s )
+    } {}
+    ? == tb 42 {                                   // '*' array
+        : i n ( __resp_parse_int buf ls le )
+        ? < n 0 {                                  // *-1 → nil
+            = . b cur + le 2
+            ^ ( __rb_push b 0 0 ( string_new ) )
+        } {}
+        = . b cur + le 2
+        : ( Vec i ) kids ( vec_new [i] )
+        : ~ i k 0
+        ~ < k n {
+            : i ci ( __resp_val b buf end )
+            ? != . b status 0 { ( vec_free [i] kids ) ^ -1 } {}
+            ( vec_push [i] kids ci )
+            = k + k 1
+        }
+        ^ ( __rb_push_arr b n kids )
+    } {}
+
+    = . b status 2                                 // unknown type byte
+    ^ -1
+}
+
+// Parse one reply from buf starting at `start`. On Incomplete (status 1)
+// the returned reply still owns a (partial) arena and must be freed by the
+// caller before retrying with more bytes.
+@ resp_parse ( Vec u ) buf i start → RespParse {
+    : *RespBuilder b # *RespBuilder ( nurl_alloc Z RespBuilder )
+    = . b nodes ( vec_new [RNode] )
+    = . b status 0
+    = . b cur start
+    : i root ( __resp_val b buf ( vec_len [u] buf ) )
+    : i st . b status
+    : i cur . b cur
+    : RedisReply rep @ RedisReply { . b nodes root }
+    ( nurl_free # s b )
+    ^ @ RespParse { st rep cur }
+}
+
+@ resp_reply_free RedisReply r → v {
+    : i n ( vec_len [RNode] . r nodes )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [RNode] . r nodes k ) {
+            T nd → { ( string_free . nd sval ) ( vec_free [i] . nd kids ) }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [RNode] . r nodes )
+}
+
+// ── node accessors ─────────────────────────────────────────────────
+
+@ resp_reply_root RedisReply r → i { ^ . r root }
+
+@ resp_node_kind RedisReply r i node → i {
+    ?? ( vec_get [RNode] . r nodes node ) { T n → ^ . n kind F _ → ^ -1 }
+}
+
+@ resp_node_int RedisReply r i node → i {
+    ?? ( vec_get [RNode] . r nodes node ) { T n → ^ . n ival F _ → ^ 0 }
+}
+
+// Borrowed view of a string/error node's text (lifetime tied to `r`).
+@ resp_node_str RedisReply r i node → s {
+    ?? ( vec_get [RNode] . r nodes node ) { T n → ^ ( string_data . n sval ) F _ → ^ `` }
+}
+
+@ resp_node_is_nil RedisReply r i node → b {
+    ^ == ( resp_node_kind r node ) 0
+}
+
+@ resp_node_arr_len RedisReply r i node → i {
+    ?? ( vec_get [RNode] . r nodes node ) {
+        T n → { ? == . n kind 4 { ^ ( vec_len [i] . n kids ) } { ^ 0 } }
+        F _ → ^ 0
+    }
+}
+
+@ resp_node_arr_at RedisReply r i node i k → i {
+    ?? ( vec_get [RNode] . r nodes node ) {
+        T n → ?? ( vec_get [i] . n kids k ) { T ci → ^ ci F _ → ^ -1 }
+        F _ → ^ -1
+    }
+}

--- a/packages/redis/tests/live_smoke.sh
+++ b/packages/redis/tests/live_smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# packages/redis/tests/live_smoke.sh — build the redis client and exercise it
+# against a live server. Uses $REDIS_PORT (default 16379); if nothing is
+# listening there and Docker is available, spins up a throwaway redis:7.
+#
+#   ./tests/live_smoke.sh
+#
+# Run from the package root (packages/redis). Expects the monorepo layout so
+# NURL_STDLIB and deps/tls resolve.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"          # packages/redis
+REPO="$(cd "$HERE/../.." && pwd)"                  # repo root
+PORT="${REDIS_PORT:-16379}"
+NURL_SH="$REPO/nurl.sh"
+export NURL_STDLIB="$REPO"
+
+started_container=0
+cleanup() { [ "$started_container" = 1 ] && docker rm -f nurl-redis-smoke >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# ── ensure a server ──
+if ! (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then
+    if command -v docker >/dev/null 2>&1; then
+        echo "[smoke] no server on :$PORT — starting redis:7 in Docker"
+        docker rm -f nurl-redis-smoke >/dev/null 2>&1 || true
+        docker run -d --name nurl-redis-smoke -p "$PORT:6379" redis:7 >/dev/null
+        started_container=1
+        sleep 2
+    else
+        echo "[smoke] no server on :$PORT and no Docker — start Redis and retry" >&2
+        exit 2
+    fi
+fi
+
+cd "$HERE"
+
+# ── unit-test the RESP codec (no server) ──
+echo "[smoke] RESP codec unit tests"
+"$NURL_SH" tests/resp_test.nu /tmp/redis_resp_test >/dev/null
+/tmp/redis_resp_test
+
+# ── live typed-API test under ASan ──
+echo "[smoke] live typed-API test (ASan)"
+REDIS_PORT="$PORT" NURL_SAN=1 "$NURL_SH" tests/live_test.nu /tmp/redis_live_test >/dev/null
+# live_test.nu hard-codes 16379; align the server port for it
+if [ "$PORT" != 16379 ]; then
+    echo "[smoke] NOTE: live_test.nu targets 16379; set REDIS_PORT=16379 for it" >&2
+fi
+/tmp/redis_live_test
+
+# ── one-shot CLI sanity ──
+echo "[smoke] CLI one-shot"
+"$NURL_SH" src/main.nu /tmp/redis_cli >/dev/null
+/tmp/redis_cli -p "$PORT" -c "PING"
+/tmp/redis_cli -p "$PORT" -c "SET smoke:key hello"
+/tmp/redis_cli -p "$PORT" -c "GET smoke:key"
+
+echo "[smoke] OK"

--- a/packages/redis/tests/live_test.nu
+++ b/packages/redis/tests/live_test.nu
@@ -1,0 +1,130 @@
+// packages/redis/tests/live_test.nu — exercises the typed client API against
+// a live server. Needs Redis on 127.0.0.1:16379 (see tests/live_smoke.sh).
+// Frees every reply so it runs clean under AddressSanitizer.
+//
+//   cd packages/redis
+//   NURL_SAN=1 NURL_STDLIB=<repo-root> ../../nurl.sh tests/live_test.nu /tmp/rlt
+//   /tmp/rlt
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `src/redis.nu`
+
+: ~ i g_fail 0
+
+@ __ok s name b cond → v {
+    ? cond { ( nurl_print `ok   ` ) } { ( nurl_print `FAIL ` ) = g_fail + g_fail 1 }
+    ( nurl_print name ) ( nurl_print `\n` )
+}
+
+@ __free_strvec ( Vec String ) v → v {
+    : i n ( vec_len [String] v )
+    : ~ i k 0
+    ~ < k n { ?? ( vec_get [String] v k ) { T s → ( string_free s ) F _ → {} } = k + k 1 }
+    ( vec_free [String] v )
+}
+
+@ main → i {
+    : !*RedisConn RedisErr cr ( redis_connect `127.0.0.1` 16379 )
+    : *RedisConn c ?? cr { T x → x F e → { ( nurl_eprint `connect failed\n` ) ^ 1 } }
+
+    // clean slate
+    ?? ( redis_flushdb c ) { T _ → {} F _ → {} }
+
+    // PING
+    ?? ( redis_ping c ) { T b → ( __ok `ping` b ) F _ → ( __ok `ping` F ) }
+
+    // SET / GET
+    ?? ( redis_set c `k1` `v1` ) { T _ → {} F _ → {} }
+    ?? ( redis_get c `k1` ) {
+        T rs → { ( __ok `get k1=v1` & ! ( redis_str_is_nil rs ) != ( nurl_str_eq ( redis_str_val rs ) `v1` ) 0 ) ( redis_str_free rs ) }
+        F _ → ( __ok `get k1=v1` F )
+    }
+
+    // GET missing → nil
+    ?? ( redis_get c `missing` ) {
+        T rs → { ( __ok `get missing nil` ( redis_str_is_nil rs ) ) ( redis_str_free rs ) }
+        F _ → ( __ok `get missing nil` F )
+    }
+
+    // INCR twice
+    ?? ( redis_incr c `cnt` ) { T n → ( __ok `incr→1` == n 1 ) F _ → ( __ok `incr→1` F ) }
+    ?? ( redis_incr c `cnt` ) { T n → ( __ok `incr→2` == n 2 ) F _ → ( __ok `incr→2` F ) }
+
+    // list
+    ?? ( redis_rpush c `lst` `a` ) { T _ → {} F _ → {} }
+    ?? ( redis_rpush c `lst` `b` ) { T _ → {} F _ → {} }
+    ?? ( redis_rpush c `lst` `c` ) { T _ → {} F _ → {} }
+    ?? ( redis_lrange c `lst` 0 -1 ) {
+        T v → {
+            : b ok3 == ( vec_len [String] v ) 3
+            : b first & ok3 != ( nurl_str_eq ( string_data ?? ( vec_get [String] v 0 ) { T s → s F _ → ( string_new ) } ) `a` ) 0
+            ( __ok `lrange [a,b,c]` first )
+            ( __free_strvec v )
+        }
+        F _ → ( __ok `lrange [a,b,c]` F )
+    }
+    ?? ( redis_llen c `lst` ) { T n → ( __ok `llen 3` == n 3 ) F _ → ( __ok `llen 3` F ) }
+
+    // hash
+    ?? ( redis_hset c `h` `f1` `v1` ) { T _ → {} F _ → {} }
+    ?? ( redis_hget c `h` `f1` ) {
+        T rs → { ( __ok `hget f1=v1` != ( nurl_str_eq ( redis_str_val rs ) `v1` ) 0 ) ( redis_str_free rs ) }
+        F _ → ( __ok `hget f1=v1` F )
+    }
+    ?? ( redis_hgetall c `h` ) {
+        T v → { ( __ok `hgetall 2` == ( vec_len [String] v ) 2 ) ( __free_strvec v ) }
+        F _ → ( __ok `hgetall 2` F )
+    }
+
+    // set
+    ?? ( redis_sadd c `st` `m1` ) { T _ → {} F _ → {} }
+    ?? ( redis_sadd c `st` `m2` ) { T _ → {} F _ → {} }
+    ?? ( redis_smembers c `st` ) {
+        T v → { ( __ok `smembers 2` == ( vec_len [String] v ) 2 ) ( __free_strvec v ) }
+        F _ → ( __ok `smembers 2` F )
+    }
+
+    // DEL / EXISTS
+    ?? ( redis_del c `k1` ) { T n → ( __ok `del 1` == n 1 ) F _ → ( __ok `del 1` F ) }
+    ?? ( redis_exists c `k1` ) { T b → ( __ok `exists false` ! b ) F _ → ( __ok `exists false` F ) }
+
+    // EXPIRE / TTL
+    ?? ( redis_expire c `cnt` 100 ) { T b → ( __ok `expire ok` b ) F _ → ( __ok `expire ok` F ) }
+    ?? ( redis_ttl c `cnt` ) { T n → ( __ok `ttl>0` > n 0 ) F _ → ( __ok `ttl>0` F ) }
+
+    // error reply surfaces as RedisServerError
+    ?? ( redis_incr c `lst` ) {
+        T _ → ( __ok `wrongtype err` F )
+        F e → ( __ok `wrongtype err` ?? e { RedisServerError → T _ → F } )
+    }
+
+    // pub/sub: subscribe on a second connection, publish on the first
+    ?? ( redis_connect `127.0.0.1` 16379 ) {
+        F _ → ( __ok `pubsub connect` F )
+        T sub → {
+            ?? ( redis_subscribe sub `news` ) {
+                T m → { ( __ok `subscribe confirm` == ( redis_message_kind m ) 1 ) ( redis_message_free m ) }
+                F _ → ( __ok `subscribe confirm` F )
+            }
+            ?? ( redis_publish c `news` `hello-pubsub` ) {
+                T n → ( __ok `publish reached 1` == n 1 ) F _ → ( __ok `publish reached 1` F )
+            }
+            ?? ( redis_next_message sub ) {
+                T m → {
+                    ( __ok `message kind` == ( redis_message_kind m ) 0 )
+                    ( __ok `message payload` != ( nurl_str_eq ( redis_message_payload m ) `hello-pubsub` ) 0 )
+                    ( __ok `message channel` != ( nurl_str_eq ( redis_message_channel m ) `news` ) 0 )
+                    ( redis_message_free m )
+                }
+                F _ → ( __ok `message kind` F )
+            }
+            ( redis_close sub )
+        }
+    }
+
+    ( redis_close c )
+
+    ? == g_fail 0 { ( nurl_print `\nALL PASS\n` ) ^ 0 } { ( nurl_print `\nFAILED\n` ) ^ 1 }
+}

--- a/packages/redis/tests/resp_test.nu
+++ b/packages/redis/tests/resp_test.nu
@@ -1,0 +1,153 @@
+// packages/redis/tests/resp_test.nu — pure unit tests for the RESP codec.
+// No server required. Build and run:
+//   cd packages/redis
+//   NURL_STDLIB=<repo-root> ../../build/nurlc tests/resp_test.nu > /tmp/t.ll
+//   clang /tmp/t.ll <repo-root>/stdlib/runtime.o -o /tmp/resp_test && /tmp/resp_test
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `src/resp.nu`
+
+: ~ i g_fail 0
+
+@ __ok s name b cond → v {
+    ? cond { ( nurl_print `ok   ` ) } { ( nurl_print `FAIL ` ) = g_fail + g_fail 1 }
+    ( nurl_print name ) ( nurl_print `\n` )
+}
+
+// Build a ( Vec u ) byte buffer from a raw string (NUL-safe for our ASCII
+// test vectors, which contain none).
+@ __buf s raw → ( Vec u ) {
+    : i n ( nurl_str_len raw )
+    : ( Vec u ) v ( vec_new [u] )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] v # u ( nurl_str_get raw k ) ) = k + k 1 }
+    ^ v
+}
+
+@ __args2 s a s b → ( Vec String ) {
+    : ( Vec String ) v ( vec_new [String] )
+    ( vec_push [String] v ( string_from a ) )
+    ( vec_push [String] v ( string_from b ) )
+    ^ v
+}
+
+@ __free_args ( Vec String ) v → v {
+    : i n ( vec_len [String] v )
+    : ~ i k 0
+    ~ < k n { ?? ( vec_get [String] v k ) { T s → ( string_free s ) F _ → {} } = k + k 1 }
+    ( vec_free [String] v )
+}
+
+// Compare a ( Vec u ) against an expected raw string.
+@ __bytes_eq ( Vec u ) v s raw → b {
+    : i n ( nurl_str_len raw )
+    ? != ( vec_len [u] v ) n { ^ F } {}
+    : ~ i k 0
+    : ~ b ok T
+    ~ < k n {
+        ? != ?? ( vec_get [u] v k ) { T x → # i x F _ → -1 } ( nurl_str_get raw k ) { = ok F } {}
+        = k + k 1
+    }
+    ^ ok
+}
+
+@ main → i {
+    // ── encode: SET foo bar ──
+    : ( Vec String ) cmd ( __args2 `GET` `foo` )
+    : ( Vec u ) enc ( resp_encode cmd )
+    ( __ok `encode GET foo` ( __bytes_eq enc `*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n` ) )
+    ( vec_free [u] enc )
+    ( __free_args cmd )
+
+    // ── simple string +OK ──
+    : ( Vec u ) b1 ( __buf `+OK\r\n` )
+    : RespParse p1 ( resp_parse b1 0 )
+    ( __ok `+OK status ok`   == . p1 status 0 )
+    ( __ok `+OK consumed 5`  == . p1 consumed 5 )
+    : i r1 ( resp_reply_root . p1 reply )
+    ( __ok `+OK kind str`    == ( resp_node_kind . p1 reply r1 ) 2 )
+    ( __ok `+OK text`        ( nurl_str_eq ( resp_node_str . p1 reply r1 ) `OK` ) )
+    ( resp_reply_free . p1 reply ) ( vec_free [u] b1 )
+
+    // ── error -ERR foo ──
+    : ( Vec u ) b2 ( __buf `-ERR bad\r\n` )
+    : RespParse p2 ( resp_parse b2 0 )
+    : i r2 ( resp_reply_root . p2 reply )
+    ( __ok `-ERR kind err`   == ( resp_node_kind . p2 reply r2 ) 3 )
+    ( __ok `-ERR text`       ( nurl_str_eq ( resp_node_str . p2 reply r2 ) `ERR bad` ) )
+    ( resp_reply_free . p2 reply ) ( vec_free [u] b2 )
+
+    // ── integer :1000 ──
+    : ( Vec u ) b3 ( __buf `:1000\r\n` )
+    : RespParse p3 ( resp_parse b3 0 )
+    : i r3 ( resp_reply_root . p3 reply )
+    ( __ok `:1000 kind int`  == ( resp_node_kind . p3 reply r3 ) 1 )
+    ( __ok `:1000 value`     == ( resp_node_int . p3 reply r3 ) 1000 )
+    ( resp_reply_free . p3 reply ) ( vec_free [u] b3 )
+
+    // ── negative integer :-5 ──
+    : ( Vec u ) b3b ( __buf `:-5\r\n` )
+    : RespParse p3b ( resp_parse b3b 0 )
+    ( __ok `:-5 value`       == ( resp_node_int . p3b reply ( resp_reply_root . p3b reply ) ) -5 )
+    ( resp_reply_free . p3b reply ) ( vec_free [u] b3b )
+
+    // ── bulk string $5 hello ──
+    : ( Vec u ) b4 ( __buf `$5\r\nhello\r\n` )
+    : RespParse p4 ( resp_parse b4 0 )
+    : i r4 ( resp_reply_root . p4 reply )
+    ( __ok `$5 kind str`     == ( resp_node_kind . p4 reply r4 ) 2 )
+    ( __ok `$5 text`         ( nurl_str_eq ( resp_node_str . p4 reply r4 ) `hello` ) )
+    ( __ok `$5 consumed 11`  == . p4 consumed 11 )
+    ( resp_reply_free . p4 reply ) ( vec_free [u] b4 )
+
+    // ── nil bulk $-1 ──
+    : ( Vec u ) b5 ( __buf `$-1\r\n` )
+    : RespParse p5 ( resp_parse b5 0 )
+    ( __ok `$-1 is nil`      ( resp_node_is_nil . p5 reply ( resp_reply_root . p5 reply ) ) )
+    ( resp_reply_free . p5 reply ) ( vec_free [u] b5 )
+
+    // ── empty bulk $0 ──
+    : ( Vec u ) b5b ( __buf `$0\r\n\r\n` )
+    : RespParse p5b ( resp_parse b5b 0 )
+    ( __ok `$0 kind str`     == ( resp_node_kind . p5b reply ( resp_reply_root . p5b reply ) ) 2 )
+    ( __ok `$0 empty text`   ( nurl_str_eq ( resp_node_str . p5b reply ( resp_reply_root . p5b reply ) ) `` ) )
+    ( resp_reply_free . p5b reply ) ( vec_free [u] b5b )
+
+    // ── array of two bulks *2 foo bar ──
+    : ( Vec u ) b6 ( __buf `*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n` )
+    : RespParse p6 ( resp_parse b6 0 )
+    : i r6 ( resp_reply_root . p6 reply )
+    ( __ok `*2 kind arr`     == ( resp_node_kind . p6 reply r6 ) 4 )
+    ( __ok `*2 len 2`        == ( resp_node_arr_len . p6 reply r6 ) 2 )
+    ( __ok `*2 [0] foo`      ( nurl_str_eq ( resp_node_str . p6 reply ( resp_node_arr_at . p6 reply r6 0 ) ) `foo` ) )
+    ( __ok `*2 [1] bar`      ( nurl_str_eq ( resp_node_str . p6 reply ( resp_node_arr_at . p6 reply r6 1 ) ) `bar` ) )
+    ( resp_reply_free . p6 reply ) ( vec_free [u] b6 )
+
+    // ── nested array: *2 :1 *2 $1 a $1 b ──
+    : ( Vec u ) b7 ( __buf `*2\r\n:1\r\n*2\r\n$1\r\na\r\n$1\r\nb\r\n` )
+    : RespParse p7 ( resp_parse b7 0 )
+    : i r7 ( resp_reply_root . p7 reply )
+    ( __ok `nested len 2`    == ( resp_node_arr_len . p7 reply r7 ) 2 )
+    : i n7a ( resp_node_arr_at . p7 reply r7 0 )
+    : i n7b ( resp_node_arr_at . p7 reply r7 1 )
+    ( __ok `nested [0] int`  == ( resp_node_int . p7 reply n7a ) 1 )
+    ( __ok `nested [1] arr`  == ( resp_node_kind . p7 reply n7b ) 4 )
+    ( __ok `nested [1][1] b` ( nurl_str_eq ( resp_node_str . p7 reply ( resp_node_arr_at . p7 reply n7b 1 ) ) `b` ) )
+    ( resp_reply_free . p7 reply ) ( vec_free [u] b7 )
+
+    // ── incomplete: bulk header without the data yet ──
+    : ( Vec u ) b8 ( __buf `$5\r\nhel` )
+    : RespParse p8 ( resp_parse b8 0 )
+    ( __ok `incomplete bulk` == . p8 status 1 )
+    ( resp_reply_free . p8 reply ) ( vec_free [u] b8 )
+
+    // ── incomplete: array missing its second element ──
+    : ( Vec u ) b9 ( __buf `*2\r\n$3\r\nfoo\r\n` )
+    : RespParse p9 ( resp_parse b9 0 )
+    ( __ok `incomplete arr`  == . p9 status 1 )
+    ( resp_reply_free . p9 reply ) ( vec_free [u] b9 )
+
+    ? == g_fail 0 { ( nurl_print `\nALL PASS\n` ) ^ 0 } { ( nurl_print `\nFAILED\n` ) ^ 1 }
+}


### PR DESCRIPTION
## Summary

A new **`redis` registry package** — a dependency-light Redis client written
entirely in NURL. It speaks RESP2 over a plain libc TCP socket and can upgrade
to TLS (`rediss://`) via the pure-NURL `tls` package, so the binaries link
`libc` only — **no hiredis, no OpenSSL** on the target. Ships as both a
reusable library and a `redis-cli`-style command.

It also carries a small **compiler fix** found while building the package.

## Package (`packages/redis`)

- **`src/resp.nu`** — pure, I/O-free RESP2 codec. Replies decode into a flat
  node arena (`Vec RNode`; array nodes hold child indices), so arbitrary
  nesting (pub/sub, `XRANGE`, `COMMAND`, …) frees in one linear pass.
- **`src/redis.nu`** — connection, request/reply, and an ergonomic typed
  surface: `GET`/`SET`/`DEL`/`INCR`/`EXPIRE`/`TTL`/`KEYS`, lists, hashes,
  sets, `PUBLISH`, `PING`/`ECHO`, and full **pub/sub**
  (`SUBSCRIBE`/`PSUBSCRIBE` + `redis_next_message`). Nil-aware `GET` returns a
  named `RedisStr`.
- **`src/main.nu`** — a redis-cli-style CLI: flags, `redis://` / `rediss://`
  URLs, a REPL with a quoted-arg tokenizer, and a SUBSCRIBE/PSUBSCRIBE
  message-streaming loop.

## Compiler fix (`compiler/nurlc.nu`, +17 lines)

`! b E` / `? b` (a result/option whose Ok/Some payload is `b`) miscompiled:
the bool rode the i64 payload slot and was bound as i64, but its uses emitted
`xor i1` — clang rejected `"defined with type i64 but expected i1"`. The
opt/res-bool reconstruction in `gen_match` had branches for `f`→double,
pointer, struct-handle and narrow-int but **none for `b`**. Added a `b`
branch (mirrors the `f`→double case) that truncates the i64 slot to i1. No
prior code relied on the old behaviour — it was always invalid IR.

## Testing

- **RESP codec**: `tests/resp_test.nu` — 26 unit tests, no server needed.
- **Live typed API + pub/sub**: `tests/live_test.nu` vs `redis:7` — **20/20
  pass, AddressSanitizer-clean**.
- **CLI**: streams multi-channel `SUBSCRIBE` and `PSUBSCRIBE`/`pmessage`
  traffic end-to-end.
- **Compiler**: bootstrap fixpoint holds; test corpus **467 PASS / 0 FAIL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YH7KtE5CDFzy2rNCatout