### PR TITLE
§8 P2: make ext/crypto.nu pure — drop the OpenSSL EVP layer

### DIFF
--- a/compiler/tests/outputs/scrypt_vectors.txt
+++ b/compiler/tests/outputs/scrypt_vectors.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+scrypt N=16,r=1,p=1: PASS
+scrypt N=1024,r=8,p=16: PASS
+pbkdf2-sha512 c=1: PASS
+pbkdf2-sha512 c=4096: PASS
+scrypt/pbkdf2: all vectors PASS

--- a/compiler/tests/scrypt_vectors.nu
+++ b/compiler/tests/scrypt_vectors.nu
@@ -1,0 +1,53 @@
+// scrypt_vectors.nu — pure-NURL scrypt against the RFC 7914 §12 test vectors,
+// plus PBKDF2-HMAC-SHA-512 against reference vectors.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/scrypt.nu`
+$ `stdlib/std/pbkdf2.nu`
+
+@ sv s raw → ( Vec u ) {
+    : i n ( nurl_str_len raw )
+    : ( Vec u ) v ( vec_with_cap [u] ? > n 0 n 1 )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] v # u ( nurl_str_get raw k ) ) = k + k 1 }
+    ^ v
+}
+
+@ check s label ( Vec u ) got s want → i {
+    : String gh ( bytes_to_hex got )
+    ? ( nurl_str_eq ( string_data gh ) want ) { ( nurl_print label ) ( nurl_print `: PASS\n` ) ( string_free gh ) ^ 0 }
+    { ( nurl_print label ) ( nurl_print `: FAIL got ` ) ( nurl_print ( string_data gh ) ) ( nurl_print `\n` ) ( string_free gh ) ^ 1 }
+}
+
+@ main → i {
+    : ~ i fails 0
+
+    // RFC 7914 §12, vector 1: scrypt("", "", 16, 1, 1, 64)
+    : ( Vec u ) e ( sv `` )
+    : ( Vec u ) s1 ( scrypt_pure e e 16 1 1 64 )
+    = fails + fails ( check `scrypt N=16,r=1,p=1` s1 `77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906` )
+    ( vec_free [u] s1 )
+
+    // RFC 7914 §12, vector 2: scrypt("password", "NaCl", 1024, 8, 16, 64)
+    : ( Vec u ) pw ( sv `password` )
+    : ( Vec u ) na ( sv `NaCl` )
+    : ( Vec u ) s2 ( scrypt_pure pw na 1024 8 16 64 )
+    = fails + fails ( check `scrypt N=1024,r=8,p=16` s2 `fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640` )
+    ( vec_free [u] s2 )
+
+    // PBKDF2-HMAC-SHA-512
+    : ( Vec u ) sa ( sv `salt` )
+    : ( Vec u ) k1 ( pbkdf2_hmac_sha512 pw sa 1 64 )
+    = fails + fails ( check `pbkdf2-sha512 c=1` k1 `867f70cf1ade02cff3752599a3a53dc4af34c7a669815ae5d513554e1c8cf252c02d470a285a0501bad999bfe943c08f050235d7d68b1da55e63f73b60a57fce` )
+    ( vec_free [u] k1 )
+    : ( Vec u ) k2 ( pbkdf2_hmac_sha512 pw sa 4096 32 )
+    = fails + fails ( check `pbkdf2-sha512 c=4096` k2 `d197b1b33db0143e018b12f3d1d1479e6cdebdcc97c5c0f87f6902e072f457b5` )
+    ( vec_free [u] k2 )
+
+    ( vec_free [u] e ) ( vec_free [u] pw ) ( vec_free [u] na ) ( vec_free [u] sa )
+
+    ? == fails 0 { ( nurl_print `scrypt/pbkdf2: all vectors PASS\n` ) } { ( nurl_print `scrypt/pbkdf2: FAILURES\n` ) }
+    ^ fails
+}

--- a/stdlib/ext/crypto.nu
+++ b/stdlib/ext/crypto.nu
@@ -1,14 +1,11 @@
 // stdlib/ext/crypto.nu — AEAD ciphers, signatures, key exchange, KDFs.
 //
-// Binds libcrypto's EVP layer the same way sqlite.nu binds libsqlite3:
-// pure NURL `& `openssl` @ …` declarations, no C bridge. The `openssl`
-// library token routes the build-time sentinel check to
-// stdlib/runtime.openssl (created by build.sh when libssl-dev is
-// installed), so a missing dev package fails at compile time with an
-// install hint instead of at link time. Hashing (SHA-2, BLAKE3, HMAC)
-// stays pure NURL in std/hash*.nu — this module covers what genuinely
-// needs vetted cipher implementations: AEAD encryption, Ed25519/X25519,
-// and password/key derivation.
+// PURE NURL — no OpenSSL, no FFI beyond libc's CSPRNG (nurl_rand_fill). This
+// is a thin, uniform façade over the pure primitives in std/: AES-256-GCM and
+// ChaCha20-Poly1305 AEAD, Ed25519 signing, X25519 key exchange, and the
+// PBKDF2 / HKDF / scrypt KDFs. The public surface (and the CryptoErr /
+// CryptoKeypair types) is unchanged, so net/* , jwt and other callers are
+// untouched; only the implementation moved off libcrypto.
 //
 // AEAD (key 32 B; nonce 12 B; returns ciphertext with the 16-byte tag
 // APPENDED — split or feed back whole, decrypt expects ct||tag):
@@ -43,13 +40,23 @@
 //   PBKDF2/scrypt are for passwords (slow on purpose); HKDF is for
 //   stretching already-strong keys (X25519 output, session secrets).
 //
-// Errors: CryptoArg (bad length/parameter, caught before any FFI),
-// CryptoInit (context/key setup failed), CryptoOp (cipher/derive step
-// failed), CryptoVerify (AEAD tag rejected). Compare derived MACs/keys
+// Errors: CryptoArg (bad length/parameter), CryptoInit / CryptoOp
+// (reserved), CryptoVerify (AEAD tag rejected). Compare derived MACs/keys
 // with constant_time_eq_vec (std/subtle.nu), never vec-wise ==.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
+$ `stdlib/std/aes_gcm.nu`
+$ `stdlib/std/chacha20poly1305.nu`
+$ `stdlib/std/ed25519.nu`
+$ `stdlib/std/x25519.nu`
+$ `stdlib/std/hkdf.nu`
+$ `stdlib/std/pbkdf2.nu`
+$ `stdlib/std/scrypt.nu`
+
+// OS CSPRNG (getrandom / arc4random / BCryptGenRandom / urandom) — the one
+// libc dependency, shared with std/random.nu (FFI declarations dedupe).
+& `c` @ nurl_rand_fill *u buf i n → i
 
 : | CryptoErr { CryptoArg CryptoInit CryptoOp CryptoVerify }
 
@@ -57,489 +64,131 @@ $ `stdlib/core/vec.nu`
 // and X25519.
 : CryptoKeypair { ( Vec u ) sk ( Vec u ) pk }
 
-// ── libcrypto FFI ───────────────────────────────────────────────────
-//
-// Opaque pointers (EVP_CIPHER_CTX*, EVP_PKEY*, EVP_MD*, …) travel as
-// `s`. Out-parameters (int*/size_t*) are 8-byte nurl_zalloc'd slots
-// read back via nurl_peek — libcrypto writes 4 bytes into int* slots,
-// the zeroed high half keeps the i64 read exact on little-endian.
+// ── helpers ─────────────────────────────────────────────────────────
 
-& `openssl` @ EVP_CIPHER_CTX_new → s
+// `n` cryptographically-random bytes (nonces, keys, salts).
+@ rand_fill_vec i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] ? > n 0 n 1 )
+    ? > n 0 { ( nurl_rand_fill # *u ( vec_data [u] v ) n ) } {}
+    : b _o ( vec_set_len [u] v ? > n 0 n 0 )
+    ^ v
+}
 
-& `openssl` @ EVP_CIPHER_CTX_free s ctx → v
-
-& `openssl` @ EVP_CIPHER_CTX_ctrl s ctx i cmd i arg *u ptr → i
-
-& `openssl` @ EVP_aes_256_gcm → s
-
-& `openssl` @ EVP_chacha20_poly1305 → s
-
-& `openssl` @ EVP_EncryptInit_ex s ctx s cipher *u engine s key s iv → i
-
-& `openssl` @ EVP_EncryptUpdate s ctx s out *u outl s in i inl → i
-
-& `openssl` @ EVP_EncryptFinal_ex s ctx s out *u outl → i
-
-& `openssl` @ EVP_DecryptInit_ex s ctx s cipher *u engine s key s iv → i
-
-& `openssl` @ EVP_DecryptUpdate s ctx s out *u outl s in i inl → i
-
-& `openssl` @ EVP_DecryptFinal_ex s ctx s out *u outl → i
-
-& `openssl` @ EVP_PKEY_new_raw_private_key i type *u engine s key i keylen → s
-
-& `openssl` @ EVP_PKEY_new_raw_public_key i type *u engine s key i keylen → s
-
-& `openssl` @ EVP_PKEY_get_raw_private_key s pkey s out *u outlen → i
-
-& `openssl` @ EVP_PKEY_get_raw_public_key s pkey s out *u outlen → i
-
-& `openssl` @ EVP_PKEY_free s pkey → v
-
-& `openssl` @ EVP_PKEY_CTX_new s pkey *u engine → s
-
-& `openssl` @ EVP_PKEY_CTX_new_id i id *u engine → s
-
-& `openssl` @ EVP_PKEY_CTX_free s ctx → v
-
-& `openssl` @ EVP_PKEY_CTX_ctrl_str s ctx s type s value → i
-
-& `openssl` @ EVP_PKEY_keygen_init s ctx → i
-
-& `openssl` @ EVP_PKEY_keygen s ctx *u out_pkey → i
-
-& `openssl` @ EVP_PKEY_derive_init s ctx → i
-
-& `openssl` @ EVP_PKEY_derive_set_peer s ctx s peer → i
-
-& `openssl` @ EVP_PKEY_derive s ctx s out *u outlen → i
-
-& `openssl` @ EVP_MD_CTX_new → s
-
-& `openssl` @ EVP_MD_CTX_free s ctx → v
-
-& `openssl` @ EVP_DigestSignInit s ctx *u pctx *u md *u engine s pkey → i
-
-& `openssl` @ EVP_DigestSign s ctx s sig *u siglen s msg i msglen → i
-
-& `openssl` @ EVP_DigestVerifyInit s ctx *u pctx *u md *u engine s pkey → i
-
-& `openssl` @ EVP_DigestVerify s ctx s sig i siglen s msg i msglen → i
-
-& `openssl` @ EVP_sha256 → s
-
-& `openssl` @ EVP_sha512 → s
-
-& `openssl` @ PKCS5_PBKDF2_HMAC s pass i passlen s salt i saltlen i iter s md i keylen s out → i
-
-& `openssl` @ EVP_PBE_scrypt s pass i passlen s salt i saltlen i n i r i p i maxmem s out i keylen → i
-
-// EVP_CIPHER_CTX_ctrl commands (stable ABI constants since 1.0; the
-// AEAD aliases EVP_CTRL_AEAD_* equal the GCM originals).
-: i __EVP_CTRL_AEAD_SET_IVLEN 0x9
-: i __EVP_CTRL_AEAD_GET_TAG 0x10
-: i __EVP_CTRL_AEAD_SET_TAG 0x11
-// EVP_PKEY id NIDs (stable libcrypto object ids).
-: i __NID_X25519 1034
-: i __NID_ED25519 1087
-: i __NID_HKDF 1036
-
-: i __AEAD_KEYLEN 32
-: i __AEAD_NONCELEN 12
-: i __AEAD_TAGLEN 16
-
-// ── Internal helpers ───────────────────────────────────────────────
-
-// Hex of a Vec[u] for EVP_PKEY_CTX_ctrl_str's hex* controls. encode.nu's
-// hex_encode walks a NUL-terminated `s` and would truncate binary
-// material at the first zero byte; this walks the explicit length.
-@ __hex_of_vec ( Vec u ) v → String {
-    : i n ( vec_len [u] v )
-    : String out ( string_with_cap + * n 2 1 )
-    : *u p ( vec_data [u] v )
+@ __cr_str_vec s str → ( Vec u ) {
+    : i n ( nurl_str_len str )
+    : ( Vec u ) v ( vec_with_cap [u] ? > n 0 n 1 )
     : ~ i k 0
-    ~ < k n {
-        // `. p k` is the indexed byte load. nurl_str_get must NOT be
-        // used here: it is a NUL-bounded C-string read, so binary
-        // material with an embedded (or leading) 0x00 byte would read
-        // as zero past that point — exactly the bug that made HKDF
-        // ignore an all-low-byte salt.
-        : i b # i . p k
-        : i hi / b 16
-        : i lo % b 16
-        ( string_push_char out ? < hi 10 + 48 hi + 87 hi )
-        ( string_push_char out ? < lo 10 + 48 lo + 87 lo )
-        = k + k 1
-    }
-    ^ out
+    ~ < k n { ( vec_push [u] v # u ( nurl_str_get str k ) ) = k + k 1 }
+    ^ v
 }
 
-// Owned Vec[u] of the first n bytes at p.
-@ __vec_of_bytes s p i n → ( Vec u ) {
-    : ( Vec u ) out ( vec_with_cap [u] ? > n 0 n 1 )
-    ( nurl_memcpy ( vec_data [u] out ) # *u p n )
-    : b _ok ( vec_set_len [u] out n )
-    ^ out
-}
-
-// ── AEAD ───────────────────────────────────────────────────────────
-
-// Shared one-shot AEAD encrypt: ct||tag on success. `cipher` is the
-// EVP_CIPHER* from EVP_aes_256_gcm / EVP_chacha20_poly1305 — both use
-// 32-byte keys, 12-byte nonces, 16-byte tags.
-@ __aead_encrypt s cipher ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) pt → !( Vec u ) CryptoErr {
-    ? != ( vec_len [u] key ) __AEAD_KEYLEN { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    ? != ( vec_len [u] nonce ) __AEAD_NONCELEN { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    : s ctx ( EVP_CIPHER_CTX_new )
-    ? == # i ctx 0 { ^ @ !( Vec u ) CryptoErr { F CryptoInit } } {}
-    : s lenbuf ( nurl_zalloc 8 )
-    : ~ i ok 1
-    // Init cipher first (key/iv NULL), set the 12-byte IV length, then
-    // load key + nonce — the canonical EVP AEAD call order.
-    ? == ( EVP_EncryptInit_ex ctx cipher # *u 0 # s 0 # s 0 ) 1 {} { = ok 0 }
-    ? & == ok 1 != ( EVP_CIPHER_CTX_ctrl ctx __EVP_CTRL_AEAD_SET_IVLEN __AEAD_NONCELEN # *u 0 ) 1 { = ok 0 } {}
-    ? & == ok 1 != ( EVP_EncryptInit_ex ctx # s 0 # *u 0 # s ( vec_data [u] key ) # s ( vec_data [u] nonce ) ) 1 { = ok 0 } {}
-    // AAD pass: out = NULL.
-    : i aadn ( vec_len [u] aad )
-    ? & == ok 1 > aadn 0 {
-        ? == ( EVP_EncryptUpdate ctx # s 0 # *u lenbuf # s ( vec_data [u] aad ) aadn ) 1 {} { = ok 0 }
-    } {}
-    : i ptn ( vec_len [u] pt )
-    : ( Vec u ) out ( vec_with_cap [u] + ptn __AEAD_TAGLEN )
-    : ~ i written 0
-    ? & == ok 1 > ptn 0 {
-        ? == ( EVP_EncryptUpdate ctx # s ( vec_data [u] out ) # *u lenbuf # s ( vec_data [u] pt ) ptn ) 1
-        { = written ( nurl_peek # s lenbuf 0 ) }
-        { = ok 0 }
-    } {}
-    ? == ok 1 {
-        ? == ( EVP_EncryptFinal_ex ctx # s + # i ( vec_data [u] out ) written # *u lenbuf ) 1
-        { = written + written ( nurl_peek # s lenbuf 0 ) }
-        { = ok 0 }
-    } {}
-    ? == ok 1 {
-        ? == ( EVP_CIPHER_CTX_ctrl ctx __EVP_CTRL_AEAD_GET_TAG __AEAD_TAGLEN # *u + # i ( vec_data [u] out ) written ) 1
-        { = written + written __AEAD_TAGLEN }
-        { = ok 0 }
-    } {}
-    ( nurl_free # s lenbuf )
-    ( EVP_CIPHER_CTX_free ctx )
-    ? == ok 1 {
-        : b _ok ( vec_set_len [u] out written )
-        ^ @ !( Vec u ) CryptoErr { T out }
-    } {
-        ( vec_free [u] out )
-        ^ @ !( Vec u ) CryptoErr { F CryptoOp }
-    }
-}
-
-// Shared one-shot AEAD decrypt of ct||tag. Tag rejection (the ONLY
-// authentication signal) surfaces as CryptoVerify.
-@ __aead_decrypt s cipher ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) ct_and_tag → !( Vec u ) CryptoErr {
-    ? != ( vec_len [u] key ) __AEAD_KEYLEN { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    ? != ( vec_len [u] nonce ) __AEAD_NONCELEN { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    : i total ( vec_len [u] ct_and_tag )
-    ? < total __AEAD_TAGLEN { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    : i ctn - total __AEAD_TAGLEN
-    : s ctx ( EVP_CIPHER_CTX_new )
-    ? == # i ctx 0 { ^ @ !( Vec u ) CryptoErr { F CryptoInit } } {}
-    : s lenbuf ( nurl_zalloc 8 )
-    : ~ i ok 1
-    ? == ( EVP_DecryptInit_ex ctx cipher # *u 0 # s 0 # s 0 ) 1 {} { = ok 0 }
-    ? & == ok 1 != ( EVP_CIPHER_CTX_ctrl ctx __EVP_CTRL_AEAD_SET_IVLEN __AEAD_NONCELEN # *u 0 ) 1 { = ok 0 } {}
-    ? & == ok 1 != ( EVP_DecryptInit_ex ctx # s 0 # *u 0 # s ( vec_data [u] key ) # s ( vec_data [u] nonce ) ) 1 { = ok 0 } {}
-    : i aadn ( vec_len [u] aad )
-    ? & == ok 1 > aadn 0 {
-        ? == ( EVP_DecryptUpdate ctx # s 0 # *u lenbuf # s ( vec_data [u] aad ) aadn ) 1 {} { = ok 0 }
-    } {}
-    : ( Vec u ) out ( vec_with_cap [u] ? > ctn 0 ctn 1 )
-    : ~ i written 0
-    ? & == ok 1 > ctn 0 {
-        ? == ( EVP_DecryptUpdate ctx # s ( vec_data [u] out ) # *u lenbuf # s ( vec_data [u] ct_and_tag ) ctn ) 1
-        { = written ( nurl_peek # s lenbuf 0 ) }
-        { = ok 0 }
-    } {}
-    // Hand the trailing 16 bytes to the cipher as the expected tag,
-    // then Final performs the authenticated check.
-    : ~ i verified 0
-    ? == ok 1 {
-        ? == ( EVP_CIPHER_CTX_ctrl ctx __EVP_CTRL_AEAD_SET_TAG __AEAD_TAGLEN # *u + # i ( vec_data [u] ct_and_tag ) ctn ) 1 {} { = ok 0 }
-    } {}
-    ? == ok 1 {
-        ? == ( EVP_DecryptFinal_ex ctx # s + # i ( vec_data [u] out ) written # *u lenbuf ) 1
-        { = verified 1 = written + written ( nurl_peek # s lenbuf 0 ) }
-        {}
-    } {}
-    ( nurl_free # s lenbuf )
-    ( EVP_CIPHER_CTX_free ctx )
-    ? == verified 1 {
-        : b _ok ( vec_set_len [u] out written )
-        ^ @ !( Vec u ) CryptoErr { T out }
-    } {
-        ( vec_free [u] out )
-        ^ @ !( Vec u ) CryptoErr { F ? == ok 1 CryptoVerify CryptoOp }
-    }
-}
+// ── AEAD ────────────────────────────────────────────────────────────
 
 @ aes256gcm_encrypt ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) pt → !( Vec u ) CryptoErr {
-    ^ ( __aead_encrypt ( EVP_aes_256_gcm ) key nonce aad pt )
+    ? | != ( vec_len [u] key ) 32 != ( vec_len [u] nonce ) 12 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    ^ @ !( Vec u ) CryptoErr { T ( aes256_gcm_encrypt key nonce aad pt ) }
 }
 
 @ aes256gcm_decrypt ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) ct_and_tag → !( Vec u ) CryptoErr {
-    ^ ( __aead_decrypt ( EVP_aes_256_gcm ) key nonce aad ct_and_tag )
+    ? | != ( vec_len [u] key ) 32 != ( vec_len [u] nonce ) 12 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    ?? ( aes256_gcm_decrypt key nonce aad ct_and_tag ) {
+        T pt → ^ @ !( Vec u ) CryptoErr { T pt }
+        F _ → ^ @ !( Vec u ) CryptoErr { F CryptoVerify }
+    }
 }
 
 @ chacha20poly1305_encrypt ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) pt → !( Vec u ) CryptoErr {
-    ^ ( __aead_encrypt ( EVP_chacha20_poly1305 ) key nonce aad pt )
+    ? | != ( vec_len [u] key ) 32 != ( vec_len [u] nonce ) 12 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    ^ @ !( Vec u ) CryptoErr { T ( aead_encrypt key nonce aad pt ) }
 }
 
 @ chacha20poly1305_decrypt ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) ct_and_tag → !( Vec u ) CryptoErr {
-    ^ ( __aead_decrypt ( EVP_chacha20_poly1305 ) key nonce aad ct_and_tag )
-}
-
-// ── Ed25519 / X25519 ───────────────────────────────────────────────
-
-// Extract 32-byte raw secret + public keys out of a freshly generated
-// EVP_PKEY. Frees the pkey.
-@ __keypair_of_pkey s pkey → !CryptoKeypair CryptoErr {
-    : s skbuf ( nurl_zalloc 32 )
-    : s pkbuf ( nurl_zalloc 32 )
-    : s lenbuf ( nurl_zalloc 8 )
-    ( nurl_poke lenbuf 0 32 )
-    : ~ i ok ( EVP_PKEY_get_raw_private_key pkey skbuf # *u lenbuf )
-    ( nurl_poke lenbuf 0 32 )
-    ? == ok 1 { = ok ( EVP_PKEY_get_raw_public_key pkey pkbuf # *u lenbuf ) } {}
-    ( EVP_PKEY_free pkey )
-    ( nurl_free # s lenbuf )
-    ? == ok 1 {
-        : ( Vec u ) sk ( __vec_of_bytes skbuf 32 )
-        : ( Vec u ) pk ( __vec_of_bytes pkbuf 32 )
-        ( nurl_free skbuf )
-        ( nurl_free pkbuf )
-        ^ @ !CryptoKeypair CryptoErr { T @ CryptoKeypair { sk pk } }
-    } {
-        ( nurl_free skbuf )
-        ( nurl_free pkbuf )
-        ^ @ !CryptoKeypair CryptoErr { F CryptoOp }
+    ? | != ( vec_len [u] key ) 32 != ( vec_len [u] nonce ) 12 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    ?? ( aead_decrypt key nonce aad ct_and_tag ) {
+        T pt → ^ @ !( Vec u ) CryptoErr { T pt }
+        F _ → ^ @ !( Vec u ) CryptoErr { F CryptoVerify }
     }
 }
 
-// Generate a keypair for a raw-key NID (Ed25519 / X25519).
-@ __raw_keygen i nid → !CryptoKeypair CryptoErr {
-    : s pctx ( EVP_PKEY_CTX_new_id nid # *u 0 )
-    ? == # i pctx 0 { ^ @ !CryptoKeypair CryptoErr { F CryptoInit } } {}
-    : ~ i ok ( EVP_PKEY_keygen_init pctx )
-    : s outbuf ( nurl_zalloc 8 )
-    ? == ok 1 { = ok ( EVP_PKEY_keygen pctx # *u outbuf ) } {}
-    : s pkey # s ( nurl_peek outbuf 0 )
-    ( nurl_free # s outbuf )
-    ( EVP_PKEY_CTX_free pctx )
-    ? & == ok 1 != # i pkey 0 { ^ ( __keypair_of_pkey pkey ) }
-    { ^ @ !CryptoKeypair CryptoErr { F CryptoOp } }
-}
+// ── Ed25519 / X25519 ────────────────────────────────────────────────
 
 @ ed25519_keygen → !CryptoKeypair CryptoErr {
-    ^ ( __raw_keygen __NID_ED25519 )
+    : ( Vec u ) sk ( rand_fill_vec 32 )
+    : ( Vec u ) pk ( ed25519_pubkey_pure sk )
+    ^ @ !CryptoKeypair CryptoErr { T @ CryptoKeypair { sk pk } }
 }
 
 @ x25519_keygen → !CryptoKeypair CryptoErr {
-    ^ ( __raw_keygen __NID_X25519 )
-}
-
-// Public key for a 32-byte secret key (works for both NIDs — kept
-// per-algorithm in the API so call sites stay self-documenting).
-@ __raw_pubkey i nid ( Vec u ) sk → !( Vec u ) CryptoErr {
-    ? != ( vec_len [u] sk ) 32 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    : s pkey ( EVP_PKEY_new_raw_private_key nid # *u 0 # s ( vec_data [u] sk ) 32 )
-    ? == # i pkey 0 { ^ @ !( Vec u ) CryptoErr { F CryptoInit } } {}
-    : s pkbuf ( nurl_zalloc 32 )
-    : s lenbuf ( nurl_zalloc 8 )
-    ( nurl_poke lenbuf 0 32 )
-    : i ok ( EVP_PKEY_get_raw_public_key pkey pkbuf # *u lenbuf )
-    ( EVP_PKEY_free pkey )
-    ( nurl_free # s lenbuf )
-    ? == ok 1 {
-        : ( Vec u ) pk ( __vec_of_bytes pkbuf 32 )
-        ( nurl_free pkbuf )
-        ^ @ !( Vec u ) CryptoErr { T pk }
-    } {
-        ( nurl_free pkbuf )
-        ^ @ !( Vec u ) CryptoErr { F CryptoOp }
-    }
+    : ( Vec u ) sk ( rand_fill_vec 32 )
+    : ( Vec u ) pk ( x25519_base sk )
+    ^ @ !CryptoKeypair CryptoErr { T @ CryptoKeypair { sk pk } }
 }
 
 @ ed25519_pubkey ( Vec u ) sk → !( Vec u ) CryptoErr {
-    ^ ( __raw_pubkey __NID_ED25519 sk )
+    ? != ( vec_len [u] sk ) 32 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    ^ @ !( Vec u ) CryptoErr { T ( ed25519_pubkey_pure sk ) }
 }
 
 @ x25519_pubkey ( Vec u ) sk → !( Vec u ) CryptoErr {
-    ^ ( __raw_pubkey __NID_X25519 sk )
+    ? != ( vec_len [u] sk ) 32 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    ^ @ !( Vec u ) CryptoErr { T ( x25519_base sk ) }
 }
 
-// Detached Ed25519 signature (64 bytes) over msg with a 32-byte secret
-// key. Ed25519 is "pure": the message itself is signed, no pre-hash —
-// EVP_DigestSign with a NULL md is the correct call shape.
+// Detached Ed25519 signature (64 bytes) over msg with a 32-byte seed.
 @ ed25519_sign ( Vec u ) sk ( Vec u ) msg → !( Vec u ) CryptoErr {
     ? != ( vec_len [u] sk ) 32 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    : s pkey ( EVP_PKEY_new_raw_private_key __NID_ED25519 # *u 0 # s ( vec_data [u] sk ) 32 )
-    ? == # i pkey 0 { ^ @ !( Vec u ) CryptoErr { F CryptoInit } } {}
-    : s mdctx ( EVP_MD_CTX_new )
-    : s sigbuf ( nurl_zalloc 64 )
-    : s lenbuf ( nurl_zalloc 8 )
-    ( nurl_poke lenbuf 0 64 )
-    : ~ i ok ( EVP_DigestSignInit mdctx # *u 0 # *u 0 # *u 0 pkey )
-    ? == ok 1 {
-        = ok ( EVP_DigestSign mdctx sigbuf # *u lenbuf # s ( vec_data [u] msg ) ( vec_len [u] msg ) )
-    } {}
-    ( EVP_MD_CTX_free mdctx )
-    ( EVP_PKEY_free pkey )
-    ( nurl_free # s lenbuf )
-    ? == ok 1 {
-        : ( Vec u ) sig ( __vec_of_bytes sigbuf 64 )
-        ( nurl_free sigbuf )
-        ^ @ !( Vec u ) CryptoErr { T sig }
-    } {
-        ( nurl_free sigbuf )
-        ^ @ !( Vec u ) CryptoErr { F CryptoOp }
-    }
+    ^ @ !( Vec u ) CryptoErr { T ( ed25519_sign_pure sk msg ) }
 }
 
-// True iff sig (64 B) is a valid Ed25519 signature over msg under pk
-// (32 B). Malformed inputs simply verify false — a boolean is the
-// whole contract here, no error channel to confuse with "invalid".
+// True iff sig (64 B) is valid over msg under pk (32 B). Malformed inputs
+// simply verify false.
 @ ed25519_verify ( Vec u ) pk ( Vec u ) msg ( Vec u ) sig → b {
     ? != ( vec_len [u] pk ) 32 { ^ F } {}
     ? != ( vec_len [u] sig ) 64 { ^ F } {}
-    : s pkey ( EVP_PKEY_new_raw_public_key __NID_ED25519 # *u 0 # s ( vec_data [u] pk ) 32 )
-    ? == # i pkey 0 { ^ F } {}
-    : s mdctx ( EVP_MD_CTX_new )
-    : ~ i ok ( EVP_DigestVerifyInit mdctx # *u 0 # *u 0 # *u 0 pkey )
-    ? == ok 1 {
-        = ok ( EVP_DigestVerify mdctx # s ( vec_data [u] sig ) 64 # s ( vec_data [u] msg ) ( vec_len [u] msg ) )
-    } {}
-    ( EVP_MD_CTX_free mdctx )
-    ( EVP_PKEY_free pkey )
-    ^ == ok 1
+    ^ ( ed25519_verify_pure pk msg sig )
 }
 
-// X25519 ECDH: 32-byte shared secret from our secret key + peer's
-// public key. Pass the result through hkdf_sha256 before keying a
-// cipher — the raw output is a curve point coordinate, not a
-// uniformly random key.
+// X25519 ECDH: 32-byte shared secret from our secret key + peer's public
+// key. Pass the result through hkdf_sha256 before keying a cipher.
 @ x25519_derive ( Vec u ) sk ( Vec u ) peer_pk → !( Vec u ) CryptoErr {
-    ? != ( vec_len [u] sk ) 32 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    ? != ( vec_len [u] peer_pk ) 32 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    : s pkey ( EVP_PKEY_new_raw_private_key __NID_X25519 # *u 0 # s ( vec_data [u] sk ) 32 )
-    ? == # i pkey 0 { ^ @ !( Vec u ) CryptoErr { F CryptoInit } } {}
-    : s peer ( EVP_PKEY_new_raw_public_key __NID_X25519 # *u 0 # s ( vec_data [u] peer_pk ) 32 )
-    ? == # i peer 0 {
-        ( EVP_PKEY_free pkey )
-        ^ @ !( Vec u ) CryptoErr { F CryptoInit }
-    } {}
-    : s pctx ( EVP_PKEY_CTX_new pkey # *u 0 )
-    : ~ i ok ? == # i pctx 0 0 1
-    ? == ok 1 { = ok ( EVP_PKEY_derive_init pctx ) } {}
-    ? == ok 1 { = ok ( EVP_PKEY_derive_set_peer pctx peer ) } {}
-    : s outbuf ( nurl_zalloc 32 )
-    : s lenbuf ( nurl_zalloc 8 )
-    ( nurl_poke lenbuf 0 32 )
-    ? == ok 1 { = ok ( EVP_PKEY_derive pctx outbuf # *u lenbuf ) } {}
-    ? != # i pctx 0 { ( EVP_PKEY_CTX_free pctx ) } {}
-    ( EVP_PKEY_free peer )
-    ( EVP_PKEY_free pkey )
-    ( nurl_free # s lenbuf )
-    ? == ok 1 {
-        : ( Vec u ) secret ( __vec_of_bytes outbuf 32 )
-        ( nurl_free outbuf )
-        ^ @ !( Vec u ) CryptoErr { T secret }
-    } {
-        ( nurl_free outbuf )
-        ^ @ !( Vec u ) CryptoErr { F CryptoOp }
-    }
+    ? | != ( vec_len [u] sk ) 32 != ( vec_len [u] peer_pk ) 32 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    ^ @ !( Vec u ) CryptoErr { T ( x25519 sk peer_pk ) }
 }
 
-// ── Key derivation ─────────────────────────────────────────────────
-
-@ __pbkdf2 s pass ( Vec u ) salt i iters i keylen s md → !( Vec u ) CryptoErr {
-    ? | <= iters 0 <= keylen 0 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    : ( Vec u ) out ( vec_with_cap [u] keylen )
-    : i ok ( PKCS5_PBKDF2_HMAC pass ( nurl_str_len pass )
-    # s ( vec_data [u] salt ) ( vec_len [u] salt )
-    iters md keylen # s ( vec_data [u] out ) )
-    ? == ok 1 {
-        : b _ok ( vec_set_len [u] out keylen )
-        ^ @ !( Vec u ) CryptoErr { T out }
-    } {
-        ( vec_free [u] out )
-        ^ @ !( Vec u ) CryptoErr { F CryptoOp }
-    }
-}
+// ── Key derivation ──────────────────────────────────────────────────
 
 @ pbkdf2_sha256 s pass ( Vec u ) salt i iters i keylen → !( Vec u ) CryptoErr {
-    ^ ( __pbkdf2 pass salt iters keylen ( EVP_sha256 ) )
+    ? | <= iters 0 <= keylen 0 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    : ( Vec u ) pw ( __cr_str_vec pass )
+    : ( Vec u ) dk ( pbkdf2_hmac_sha256 pw salt iters keylen )
+    ( vec_free [u] pw )
+    ^ @ !( Vec u ) CryptoErr { T dk }
 }
 
 @ pbkdf2_sha512 s pass ( Vec u ) salt i iters i keylen → !( Vec u ) CryptoErr {
-    ^ ( __pbkdf2 pass salt iters keylen ( EVP_sha512 ) )
+    ? | <= iters 0 <= keylen 0 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    : ( Vec u ) pw ( __cr_str_vec pass )
+    : ( Vec u ) dk ( pbkdf2_hmac_sha512 pw salt iters keylen )
+    ( vec_free [u] pw )
+    ^ @ !( Vec u ) CryptoErr { T dk }
 }
 
-// HKDF-SHA256 (RFC 5869, extract-and-expand). Parameters go in via
-// EVP_PKEY_CTX_ctrl_str's hex* controls — real exported functions with
-// a stable contract across OpenSSL 1.1/3.x, unlike the raw ctrl-macro
-// constants, and hex transport keeps binary salt/ikm/info NUL-safe.
-// Empty salt = RFC's "zero-length salt" path; empty info is valid.
+// HKDF-SHA256 (RFC 5869, extract-and-expand). Empty salt = RFC's
+// zero-length-salt path; empty IKM and empty info are valid.
 @ hkdf_sha256 ( Vec u ) ikm ( Vec u ) salt ( Vec u ) info i keylen → !( Vec u ) CryptoErr {
-    // Empty IKM is valid (RFC 5869 — e.g. Noise's Split derives transport
-    // keys with HKDF(ck, "")). Only a non-positive output length is invalid.
     ? <= keylen 0 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    : s pctx ( EVP_PKEY_CTX_new_id __NID_HKDF # *u 0 )
-    ? == # i pctx 0 { ^ @ !( Vec u ) CryptoErr { F CryptoInit } } {}
-    : ~ i ok ( EVP_PKEY_derive_init pctx )
-    ? == ok 1 { = ok ( EVP_PKEY_CTX_ctrl_str pctx `md` `SHA256` ) } {}
-    ? == ok 1 {
-        : String hexkey ( __hex_of_vec ikm )
-        = ok ( EVP_PKEY_CTX_ctrl_str pctx `hexkey` ( string_data hexkey ) )
-        ( string_free hexkey )
-    } {}
-    ? & == ok 1 > ( vec_len [u] salt ) 0 {
-        : String hexsalt ( __hex_of_vec salt )
-        = ok ( EVP_PKEY_CTX_ctrl_str pctx `hexsalt` ( string_data hexsalt ) )
-        ( string_free hexsalt )
-    } {}
-    ? & == ok 1 > ( vec_len [u] info ) 0 {
-        : String hexinfo ( __hex_of_vec info )
-        = ok ( EVP_PKEY_CTX_ctrl_str pctx `hexinfo` ( string_data hexinfo ) )
-        ( string_free hexinfo )
-    } {}
-    : ( Vec u ) out ( vec_with_cap [u] keylen )
-    : s lenbuf ( nurl_zalloc 8 )
-    ( nurl_poke lenbuf 0 keylen )
-    ? == ok 1 { = ok ( EVP_PKEY_derive pctx # s ( vec_data [u] out ) # *u lenbuf ) } {}
-    ( nurl_free # s lenbuf )
-    ( EVP_PKEY_CTX_free pctx )
-    ? == ok 1 {
-        : b _ok ( vec_set_len [u] out keylen )
-        ^ @ !( Vec u ) CryptoErr { T out }
-    } {
-        ( vec_free [u] out )
-        ^ @ !( Vec u ) CryptoErr { F CryptoOp }
-    }
+    : ( Vec u ) prk ( hkdf_extract salt ikm )
+    : ( Vec u ) okm ( hkdf_expand prk info keylen )
+    ( vec_free [u] prk )
+    ^ @ !( Vec u ) CryptoErr { T okm }
 }
 
-// scrypt (RFC 7914). n must be a power of two > 1; maxmem 0 keeps
-// libcrypto's default cap (~32 MiB), which fits the interactive
-// baseline n=16384 r=8 p=1.
+// scrypt (RFC 7914). n must be a power of two > 1.
 @ scrypt_kdf s pass ( Vec u ) salt i n i r i p i keylen → !( Vec u ) CryptoErr {
-    ? | | <= n 1 <= r 0 | <= p 0 <= keylen 0 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
-    : ( Vec u ) out ( vec_with_cap [u] keylen )
-    : i ok ( EVP_PBE_scrypt pass ( nurl_str_len pass )
-    # s ( vec_data [u] salt ) ( vec_len [u] salt )
-    n r p 0 # s ( vec_data [u] out ) keylen )
-    ? == ok 1 {
-        : b _ok ( vec_set_len [u] out keylen )
-        ^ @ !( Vec u ) CryptoErr { T out }
-    } {
-        ( vec_free [u] out )
-        ^ @ !( Vec u ) CryptoErr { F CryptoOp }
-    }
+    ? | | | <= n 1 <= r 0 <= p 0 <= keylen 0 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    ? != & n - n 1 0 { ^ @ !( Vec u ) CryptoErr { F CryptoArg } } {}
+    : ( Vec u ) pw ( __cr_str_vec pass )
+    : ( Vec u ) dk ( scrypt_pure pw salt n r p keylen )
+    ( vec_free [u] pw )
+    ^ @ !( Vec u ) CryptoErr { T dk }
 }

--- a/stdlib/std/pbkdf2.nu
+++ b/stdlib/std/pbkdf2.nu
@@ -10,6 +10,7 @@
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/hash_sha512.nu`
 
 @ __pb_bget ( Vec u ) v i k → i {
     ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ 0 }
@@ -59,6 +60,57 @@ $ `stdlib/std/hash_sha256.nu`
     ~ < generated dklen {
         : ( Vec u ) blk ( __pb_block password salt iters blockidx )
         : i take ? > - dklen generated 32 32 - dklen generated
+        : ~ i bi 0
+        ~ < bi take { ( vec_push [u] out # u ( __pb_bget blk bi ) ) = bi + bi 1 }
+        ( vec_free [u] blk )
+        = generated + generated take
+        = blockidx + blockidx 1
+    }
+    ^ out
+}
+
+// ── PBKDF2-HMAC-SHA-512 (RFC 8018, 64-byte HMAC blocks) ────────────
+@ __pb_block512 ( Vec u ) password ( Vec u ) salt i iters i blockidx → ( Vec u ) {
+    : i slen ( vec_len [u] salt )
+    : ( Vec u ) seed ( vec_with_cap [u] + slen 4 )
+    : ~ i si 0
+    ~ < si slen { ( vec_push [u] seed # u ( __pb_bget salt si ) ) = si + si 1 }
+    ( vec_push [u] seed # u & >> blockidx 24 255 )
+    ( vec_push [u] seed # u & >> blockidx 16 255 )
+    ( vec_push [u] seed # u & >> blockidx 8 255 )
+    ( vec_push [u] seed # u & blockidx 255 )
+
+    : ~ ( Vec u ) u ( hmac_sha512_pure password seed )
+    ( vec_free [u] seed )
+
+    : ( Vec u ) t ( vec_with_cap [u] 64 )
+    : ~ i ti 0
+    ~ < ti 64 { ( vec_push [u] t # u ( __pb_bget u ti ) ) = ti + ti 1 }
+
+    : ~ i n 1
+    ~ < n iters {
+        : ( Vec u ) un ( hmac_sha512_pure password u )
+        ( vec_free [u] u )
+        = u un
+        : ~ i xi 0
+        ~ < xi 64 {
+            : i cur ?? ( vec_get [u] t xi ) { T x → # i x F _ → 0 }
+            ( vec_set [u] t xi # u & ^^ cur ( __pb_bget u xi ) 255 )
+            = xi + xi 1
+        }
+        = n + n 1
+    }
+    ( vec_free [u] u )
+    ^ t
+}
+
+@ pbkdf2_hmac_sha512 ( Vec u ) password ( Vec u ) salt i iters i dklen → ( Vec u ) {
+    : ( Vec u ) out ( vec_with_cap [u] ? > dklen 0 dklen 1 )
+    : ~ i blockidx 1
+    : ~ i generated 0
+    ~ < generated dklen {
+        : ( Vec u ) blk ( __pb_block512 password salt iters blockidx )
+        : i take ? > - dklen generated 64 64 - dklen generated
         : ~ i bi 0
         ~ < bi take { ( vec_push [u] out # u ( __pb_bget blk bi ) ) = bi + bi 1 }
         ( vec_free [u] blk )

--- a/stdlib/std/scrypt.nu
+++ b/stdlib/std/scrypt.nu
@@ -1,0 +1,160 @@
+// stdlib/std/scrypt.nu — pure-NURL scrypt (RFC 7914), no OpenSSL. The
+// Salsa20/8 core, BlockMix and ROMix are implemented here; the surrounding
+// key stretching reuses pbkdf2_hmac_sha256.
+//
+//   ( scrypt_pure password salt N r p dklen ) → ( Vec u )   dklen bytes
+//
+// N must be a power of two > 1. password / salt are ( Vec u ).
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/pbkdf2.nu`
+
+@ __sc_bget ( Vec u ) v i k → i { ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ 0 } }
+
+@ __scg ( Vec i ) v i k → i { ?? ( vec_get [i] v k ) { T x → ^ x F _ → ^ 0 } }
+
+@ __scs ( Vec i ) v i k i val → v { : b _o ( vec_set [i] v k val ) }
+
+@ __sc_zeros_u i n → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ? > n 0 n 1 )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] o # u 0 ) = k + k 1 }
+    ^ o
+}
+
+// little-endian 32-bit load / store
+@ __sc_ld ( Vec u ) v i off → i {
+    ^ & | | | ( __sc_bget v off ) << ( __sc_bget v + off 1 ) 8 << ( __sc_bget v + off 2 ) 16 << ( __sc_bget v + off 3 ) 24 4294967295
+}
+
+@ __sc_st ( Vec u ) v i off i w → v {
+    ( vec_set [u] v off # u & w 255 )
+    ( vec_set [u] v + off 1 # u & >> w 8 255 )
+    ( vec_set [u] v + off 2 # u & >> w 16 255 )
+    ( vec_set [u] v + off 3 # u & >> w 24 255 )
+}
+
+// rotate-left a 32-bit word
+@ __sc_rotl i x i b → i {
+    ^ & | & << x b 4294967295 >> & x 4294967295 - 32 b 4294967295
+}
+
+// copy n bytes of src starting at off into a fresh Vec
+@ __sc_slice_n ( Vec u ) src i off i n → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ? > n 0 n 1 )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] o # u ( __sc_bget src + off k ) ) = k + k 1 }
+    ^ o
+}
+// copy n bytes of src into dst starting at off
+@ __sc_put_n ( Vec u ) dst i off ( Vec u ) src i n → v {
+    : ~ i k 0
+    ~ < k n { ( vec_set [u] dst + off k # u ( __sc_bget src k ) ) = k + k 1 }
+}
+// fresh Vec of a[0..n] XOR b[boff..boff+n]
+@ __sc_xor_n ( Vec u ) a ( Vec u ) b i boff i n → ( Vec u ) {
+    : ( Vec u ) o ( vec_with_cap [u] ? > n 0 n 1 )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] o # u & ^^ ( __sc_bget a k ) ( __sc_bget b + boff k ) 255 ) = k + k 1 }
+    ^ o
+}
+
+// ── Salsa20/8 core on a 64-byte block ──────────────────────────────
+// x[d] ^= rotl(x[a] + x[b], s)
+@ __sc_qr ( Vec i ) x i d i a i b i s → v {
+    : i v & + ( __scg x a ) ( __scg x b ) 4294967295
+    ( __scs x d ^^ ( __scg x d ) ( __sc_rotl v s ) )
+}
+
+@ __salsa20_8 ( Vec u ) inb → ( Vec u ) {
+    : ( Vec i ) x ( vec_with_cap [i] 16 )
+    : ~ i i 0
+    ~ < i 16 { ( vec_push [i] x ( __sc_ld inb * i 4 ) ) = i + i 1 }
+    : ( Vec i ) orig ( vec_with_cap [i] 16 )
+    = i 0
+    ~ < i 16 { ( vec_push [i] orig ( __scg x i ) ) = i + i 1 }
+
+    : ~ i round 0
+    ~ < round 4 {
+        ( __sc_qr x 4 0 12 7 ) ( __sc_qr x 8 4 0 9 ) ( __sc_qr x 12 8 4 13 ) ( __sc_qr x 0 12 8 18 )
+        ( __sc_qr x 9 5 1 7 ) ( __sc_qr x 13 9 5 9 ) ( __sc_qr x 1 13 9 13 ) ( __sc_qr x 5 1 13 18 )
+        ( __sc_qr x 14 10 6 7 ) ( __sc_qr x 2 14 10 9 ) ( __sc_qr x 6 2 14 13 ) ( __sc_qr x 10 6 2 18 )
+        ( __sc_qr x 3 15 11 7 ) ( __sc_qr x 7 3 15 9 ) ( __sc_qr x 11 7 3 13 ) ( __sc_qr x 15 11 7 18 )
+        ( __sc_qr x 1 0 3 7 ) ( __sc_qr x 2 1 0 9 ) ( __sc_qr x 3 2 1 13 ) ( __sc_qr x 0 3 2 18 )
+        ( __sc_qr x 6 5 4 7 ) ( __sc_qr x 7 6 5 9 ) ( __sc_qr x 4 7 6 13 ) ( __sc_qr x 5 4 7 18 )
+        ( __sc_qr x 11 10 9 7 ) ( __sc_qr x 8 11 10 9 ) ( __sc_qr x 9 8 11 13 ) ( __sc_qr x 10 9 8 18 )
+        ( __sc_qr x 12 15 14 7 ) ( __sc_qr x 13 12 15 9 ) ( __sc_qr x 14 13 12 13 ) ( __sc_qr x 15 14 13 18 )
+        = round + round 1
+    }
+
+    : ( Vec u ) out ( __sc_zeros_u 64 )
+    = i 0
+    ~ < i 16 { ( __sc_st out * i 4 & + ( __scg x i ) ( __scg orig i ) 4294967295 ) = i + i 1 }
+    ( vec_free [i] x ) ( vec_free [i] orig )
+    ^ out
+}
+
+// ── BlockMix over 2r 64-byte blocks (128r bytes) ───────────────────
+@ __blockmix ( Vec u ) b i r → ( Vec u ) {
+    : i blocks * 2 r
+    : ~ ( Vec u ) x ( __sc_slice_n b * - blocks 1 64 64 )
+    : ( Vec u ) out ( __sc_zeros_u * blocks 64 )
+    : ~ i i 0
+    ~ < i blocks {
+        : ( Vec u ) t ( __sc_xor_n x b * i 64 64 )
+        : ( Vec u ) nx ( __salsa20_8 t )
+        ( vec_free [u] t ) ( vec_free [u] x )
+        = x nx
+        : i pos ? == % i 2 0 / i 2 + r / - i 1 2
+        ( __sc_put_n out * pos 64 x 64 )
+        = i + i 1
+    }
+    ( vec_free [u] x )
+    ^ out
+}
+
+// ── ROMix over a 128r-byte block ───────────────────────────────────
+@ __sc_integerify ( Vec u ) x i blen → i { ^ ( __sc_ld x - blen 64 ) }
+
+@ __romix ( Vec u ) b i n i r → ( Vec u ) {
+    : i blen * 128 r
+    : ~ ( Vec u ) x ( __sc_slice_n b 0 blen )
+    : ( Vec u ) v ( __sc_zeros_u * n blen )
+    : ~ i i 0
+    ~ < i n {
+        ( __sc_put_n v * i blen x blen )
+        : ( Vec u ) nx ( __blockmix x r )
+        ( vec_free [u] x )
+        = x nx
+        = i + i 1
+    }
+    = i 0
+    ~ < i n {
+        : i j & ( __sc_integerify x blen ) - n 1
+        : ( Vec u ) t ( __sc_xor_n x v * j blen blen )
+        : ( Vec u ) nx ( __blockmix t r )
+        ( vec_free [u] t ) ( vec_free [u] x )
+        = x nx
+        = i + i 1
+    }
+    ( vec_free [u] v )
+    ^ x
+}
+
+// ── scrypt ─────────────────────────────────────────────────────────
+@ scrypt_pure ( Vec u ) password ( Vec u ) salt i n i r i p i dklen → ( Vec u ) {
+    : i blen * 128 r
+    : ( Vec u ) b ( pbkdf2_hmac_sha256 password salt 1 * p blen )
+    : ~ i i 0
+    ~ < i p {
+        : ( Vec u ) bi ( __sc_slice_n b * i blen blen )
+        : ( Vec u ) mixed ( __romix bi n r )
+        ( __sc_put_n b * i blen mixed blen )
+        ( vec_free [u] bi ) ( vec_free [u] mixed )
+        = i + i 1
+    }
+    : ( Vec u ) dk ( pbkdf2_hmac_sha256 password b 1 dklen )
+    ( vec_free [u] b )
+    ^ dk
+}


### PR DESCRIPTION
Third phase of the pure-NURL dependency-removal effort (TODO.md §8). Removes
OpenSSL from `stdlib/ext/crypto.nu` entirely.

## What changes

`ext/crypto.nu` is rewritten as a thin façade over the pure `std/` primitives
— **zero `& \`openssl\`` declarations** (was ~35 EVP FFI calls). The public
surface and the `CryptoErr` / `CryptoKeypair` types are unchanged, so every
caller (`net/noise`, `net/session`, `jwt`, `http_jwt`) is untouched.

| API | now routes to |
| --- | --- |
| `aes256gcm_*` | `std/aes_gcm.nu` (AES-256-GCM, from P1) |
| `chacha20poly1305_*` | `std/chacha20poly1305.nu` `aead_*` |
| `ed25519_*` | `std/ed25519.nu` (from P1) |
| `x25519_*` | `std/x25519.nu` |
| `hkdf_sha256` | `std/hkdf.nu` extract + expand |
| `pbkdf2_sha256/512` | `std/pbkdf2.nu` |
| `scrypt_kdf` | `std/scrypt.nu` |
| keygen randomness | `nurl_rand_fill` (libc CSPRNG) |

Two new pure primitives fill the last gaps:
- **`pbkdf2_hmac_sha512`** (`std/pbkdf2.nu`) — 64-byte-block PBKDF2.
- **`std/scrypt.nu`** — RFC 7914 scrypt (Salsa20/8, BlockMix, ROMix on top of
  `pbkdf2_hmac_sha256`), validated against the RFC 7914 §12 vectors.

## Validation

- The three existing ext/crypto corpus tests — `crypto_evp`,
  `noise_handshake`, `noise_session` — produce **byte-identical output** with
  the pure implementation (AEAD ciphertexts, signatures, X25519 ECDH and the
  KDFs all match what libcrypto produced).
- New `compiler/tests/scrypt_vectors.nu` (RFC 7914 + PBKDF2-SHA512) is
  ASan/LSan-clean.
- ext/crypto programs no longer pull in libssl (`--as-needed` drops it when
  server-side TLS is unused). The remaining libssl lives in `runtime.c`'s
  TLS-server path → **P4**.
- `./build.sh` → **BUILD SUCCESS & TESTS PASSED** (bootstrap + full corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YH7KtE5CDFzy2rNCatout