### PR TITLE
§8 P4: polymorphic pure-TLS net.nu (pure HTTPS server/client) + compiler fix (struct-in-Result)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -6162,9 +6162,11 @@
                                 //       heap-box pointer — inttoptr → %T* →
                                 //       load → free.
                                 : s ni_f0_ty ( nurl_sym_get syms ( nurl_str_cat3 sname_r `__idx_0` `__type` ) )
+                                : s ni_fc ( nurl_sym_get syms ( nurl_str_cat sname_r `__field_count` ) )
+                                : b ni_single & != 0 ( nurl_str_len ni_fc ) == ( nurl_str_to_int ni_fc ) 1
                                 : b ni_f0_is_ptr & != 0 ( nurl_str_len ni_f0_ty )
                                 == ( nurl_str_get ni_f0_ty - ( nurl_str_len ni_f0_ty ) 1 ) 42
-                                ? ni_f0_is_ptr
+                                ? & ni_single ni_f0_is_ptr
                                 { : s pcv_r ( nurl_cg_reg cg )
                                     ( nurl_print `  ` ) ( nurl_print pcv_r )
                                     ( nurl_print ` = inttoptr i64 ` ) ( nurl_print pr0 )
@@ -10480,9 +10482,16 @@
                         : s vlist_a ( nurl_sym_get syms ( nurl_str_cat sname2 `__variants` ) )
                         ? == 0 ( nurl_str_len vlist_a ) {
                             : s f0_ty ( nurl_sym_get syms ( nurl_str_cat3 sname2 `__idx_0` `__type` ) )
+                            // Inline-f0 is correct ONLY for a SINGLE-field
+                            // pointer-handle struct (Vec/String/Response). A
+                            // multi-field struct whose f0 happens to be a
+                            // pointer (e.g. TcpListener { s raw i is_tls … })
+                            // must be heap-boxed, or fields 1.. are dropped.
+                            : s fc_a ( nurl_sym_get syms ( nurl_str_cat sname2 `__field_count` ) )
+                            : b single_a & != 0 ( nurl_str_len fc_a ) == ( nurl_str_to_int fc_a ) 1
                             : b f0_is_ptr & != 0 ( nurl_str_len f0_ty )
                             == ( nurl_str_get f0_ty - ( nurl_str_len f0_ty ) 1 ) 42
-                            ? f0_is_ptr
+                            ? & single_a f0_is_ptr
                             {  // Single-pointer-handle struct (Vec, String,
                                 // Response, ...): extract f0 + ptrtoint into
                                 // the i64 payload slot.

--- a/compiler/tests/outputs/result_struct_payload.txt
+++ b/compiler/tests/outputs/result_struct_payload.txt
@@ -1,0 +1,7 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+result: PASS
+option: PASS
+ALL PASS

--- a/compiler/tests/result_struct_payload.nu
+++ b/compiler/tests/result_struct_payload.nu
@@ -1,0 +1,41 @@
+// result_struct_payload.nu — a multi-field value struct carried through a
+// Result (`! T E`) must round-trip ALL fields, not just field 0.
+//
+// Regression: the `! T E` payload-store discriminated on "is field 0 a
+// pointer?" to choose between storing f0 inline vs heap-boxing the struct.
+// A multi-field struct whose f0 is a pointer (e.g. `{ s raw i a i b … }`,
+// like net.nu's TcpListener) wrongly took the f0-inline path, so fields
+// 1.. were dropped and read back as garbage / field 0's value. The fix
+// keys on field COUNT (== 1) instead. Option already round-tripped these.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+: | E { Bad }
+// f0 is a pointer (s), but there are more fields — the tricky case.
+: Rec { s raw i a i b i c i d i e }
+
+@ mk_res → !Rec E {
+    : s rp # s 777
+    ^ @ !Rec E { T @ Rec { rp 11 22 33 44 55 } }
+}
+
+@ mk_opt → ?Rec {
+    : s rp # s 777
+    ^ @ ?Rec { T @ Rec { rp 11 22 33 44 55 } }
+}
+
+@ __show s tag Rec g → i {
+    : b ok & & & & == # i . g raw 777 == . g a 11 == . g b 22 == . g c 33 == . g e 55
+    ( nurl_print tag )
+    ( nurl_print ? ok `: PASS\n` `: FAIL\n` )
+    ^ ? ok 0 1
+}
+
+@ main → i {
+    : ~ i fails 0
+    ?? ( mk_res ) { T g → { = fails + fails ( __show `result` g ) } F _ → { = fails + fails 1 } }
+    ?? ( mk_opt ) { T g → { = fails + fails ( __show `option` g ) } F _ → { = fails + fails 1 } }
+    ( nurl_print ? == fails 0 `ALL PASS\n` `SOME FAILED\n` )
+    ^ 0
+}

--- a/packages/psql/src/pg.nu
+++ b/packages/psql/src/pg.nu
@@ -152,7 +152,7 @@ $ `deps/tls/src/tls.nu`
         ?? ( tls_read . c tc 16384 ) {
             T v → {
                 ? == ( vec_len [u] v ) 0 { ( vec_free [u] v ) ^ 0 } {}
-                ( __cat . c rxbuf v )
+                ( bytes_extend_bytes . c rxbuf v )
                 ( vec_free [u] v )
                 ^ 1
             }
@@ -163,7 +163,7 @@ $ `deps/tls/src/tls.nu`
         : i got ( nurl_tcp_read . c raw # s ( vec_data [u] tmp ) 16384 )
         ? <= got 0 { ( vec_free [u] tmp ) ^ 0 } {}
         : b _ok ( vec_set_len [u] tmp got )
-        ( __cat . c rxbuf tmp )
+        ( bytes_extend_bytes . c rxbuf tmp )
         ( vec_free [u] tmp )
         ^ 1
     }
@@ -196,7 +196,7 @@ $ `deps/tls/src/tls.nu`
     : ( Vec u ) msg ( vec_with_cap [u] + ( vec_len [u] payload ) 5 )
     ( vec_push [u] msg # u mtype )
     ( __push32 msg + 4 ( vec_len [u] payload ) )
-    ( __cat msg payload )
+    ( bytes_extend_bytes msg payload )
     : i ok ( __pg_write c msg )
     ( vec_free [u] msg )
     ^ ok
@@ -241,7 +241,7 @@ $ `deps/tls/src/tls.nu`
 
     : ( Vec u ) outer ( vec_new [u] )
     ( __push_strv outer inner_hex )
-    ( __cat outer salt )
+    ( bytes_extend_bytes outer salt )
     : ( Vec u ) outer_d ( md5_pure outer )
     : String outer_hex ( bytes_to_hex outer_d )
 
@@ -389,7 +389,7 @@ $ `deps/tls/src/tls.nu`
     : ( Vec u ) req ( vec_new [u] )
     ( __push32 req 8 )
     ( __push32 req 80877103 )
-    : TcpConn t @ TcpConn { # s raw }
+    : TcpConn t @ TcpConn { # s raw 0 0 }
     ?? ( tcp_write_all t req ) { T _ → {} F _ → { ( vec_free [u] req ) ^ -1 } }
     ( vec_free [u] req )
     : ( Vec u ) one ( vec_with_cap [u] 1 )
@@ -408,7 +408,7 @@ $ `deps/tls/src/tls.nu`
     : *PgConn c # *PgConn ( nurl_alloc Z PgConn )
     = . c tls 0
     = . c raw rawfd
-    = . c tcp @ TcpConn { # s rawfd }
+    = . c tcp @ TcpConn { # s rawfd 0 0 }
     = . c tc # *TlsConn 0
     = . c rxbuf ( vec_new [u] )
     = . c lasterr ( string_with_cap 0 )
@@ -429,9 +429,9 @@ $ `deps/tls/src/tls.nu`
                 F _ → {
                     ( nurl_tcp_close rawfd )
                     ( vec_free [u] . c rxbuf ) ( string_free . c lasterr )
-                ( string_free . c srv_ver ) ( string_free . c db_name )
-                ( string_free . c user_name ) ( string_free . c host_name )
-                ( nurl_free # s c )
+                    ( string_free . c srv_ver ) ( string_free . c db_name )
+                    ( string_free . c user_name ) ( string_free . c host_name )
+                    ( nurl_free # s c )
                     ^ @ !*PgConn PgErr { F # PgErr PgTls }
                 }
             }
@@ -463,7 +463,7 @@ $ `deps/tls/src/tls.nu`
 
     : ( Vec u ) frame ( vec_new [u] )
     ( __push32 frame + 4 ( vec_len [u] startup ) )
-    ( __cat frame startup )
+    ( bytes_extend_bytes frame startup )
     : i wok ( __pg_write c frame )
     ( vec_free [u] startup ) ( vec_free [u] frame )
     ? == wok 0 { ( pg_close c ) ^ @ !*PgConn PgErr { F # PgErr PgConnFail } } {}

--- a/packages/redis/src/redis.nu
+++ b/packages/redis/src/redis.nu
@@ -26,12 +26,12 @@ $ `deps/tls/src/tls.nu`
 $ `resp.nu`
 
 : | RedisErr {
-    RedisConnFail     // could not open the TCP socket
-    RedisTls          // TLS upgrade failed (handshake / cert error)
-    RedisProtocol     // malformed RESP from the server
-    RedisIo           // socket read/write failure or unexpected EOF
+    RedisConnFail  // could not open the TCP socket
+    RedisTls  // TLS upgrade failed (handshake / cert error)
+    RedisProtocol  // malformed RESP from the server
+    RedisIo  // socket read/write failure or unexpected EOF
     RedisServerError  // server returned a RESP error — see conn.lasterr
-    RedisType         // reply was not the type the helper expected
+    RedisType  // reply was not the type the helper expected
 }
 
 @ redis_err_name RedisErr e → s {
@@ -54,7 +54,9 @@ $ `resp.nu`
 }
 
 @ redis_str_is_nil RedisStr s → b { ^ == . s found 0 }
+
 @ redis_str_val RedisStr s → s { ^ ( string_data . s val ) }
+
 @ redis_str_free RedisStr s → v { ( string_free . s val ) }
 
 // A pub/sub frame. kind: 0 message · 1 subscribe · 2 unsubscribe ·
@@ -70,24 +72,29 @@ $ `resp.nu`
 }
 
 @ redis_message_kind RedisMessage m → i { ^ . m kind }
+
 @ redis_message_channel RedisMessage m → s { ^ ( string_data . m channel ) }
+
 @ redis_message_pattern RedisMessage m → s { ^ ( string_data . m pattern ) }
+
 @ redis_message_payload RedisMessage m → s { ^ ( string_data . m payload ) }
+
 @ redis_message_count RedisMessage m → i { ^ . m count }
 // True for an actual published message (message / pmessage), false for a
 // subscribe/unsubscribe control frame.
 @ redis_message_is_payload RedisMessage m → b { ^ | == . m kind 0 == . m kind 3 }
+
 @ redis_message_free RedisMessage m → v {
     ( string_free . m channel ) ( string_free . m pattern ) ( string_free . m payload )
 }
 
 : RedisConn {
-    i tls          // 0 plaintext, 1 TLS
-    i raw          // raw socket fd (plaintext reads / fd the TLS layer took over)
-    TcpConn tcp    // plaintext transport (writes via tcp_write_all)
-    * TlsConn tc   // TLS transport (when tls = 1)
-    ( Vec u ) rxbuf // bytes read but not yet parsed into a reply
-    String lasterr // last server error text
+    i tls  // 0 plaintext, 1 TLS
+    i raw  // raw socket fd (plaintext reads / fd the TLS layer took over)
+    TcpConn tcp  // plaintext transport (writes via tcp_write_all)
+    * TlsConn tc  // TLS transport (when tls = 1)
+    ( Vec u ) rxbuf  // bytes read but not yet parsed into a reply
+    String lasterr  // last server error text
     String host_name
     i port_num
     i db_index
@@ -95,7 +102,7 @@ $ `resp.nu`
 
 // ── transport ─────────────────────────────────────────────────────
 
-@ __r_write *RedisConn c ( Vec u ) bytes → i {
+@ __r_write * RedisConn c ( Vec u ) bytes → i {
     ? == . c tls 1 {
         ?? ( tls_write . c tc bytes ) { T _ → ^ 1 F _ → ^ 0 }
     } {
@@ -104,7 +111,7 @@ $ `resp.nu`
 }
 
 // Read one chunk into rxbuf. Returns 1 on progress, 0 on EOF/error.
-@ __r_fill *RedisConn c → i {
+@ __r_fill * RedisConn c → i {
     ? == . c tls 1 {
         ?? ( tls_read . c tc 16384 ) {
             T v → {
@@ -135,7 +142,7 @@ $ `resp.nu`
 
 // Read exactly one full reply from the socket. Reads more bytes whenever the
 // buffered prefix is an incomplete RESP value, then drops the consumed bytes.
-@ __r_read_reply *RedisConn c → !RedisReply RedisErr {
+@ __r_read_reply * RedisConn c → !RedisReply RedisErr {
     : ~ b spin T
     ~ spin {
         : RespParse p ( resp_parse . c rxbuf 0 )
@@ -164,7 +171,7 @@ $ `resp.nu`
 // reply is surfaced as RedisServerError with the text in conn.lasterr. The
 // caller still owns `args` (free with redis_args_free) and owns the returned
 // reply (free with resp_reply_free).
-@ redis_command *RedisConn c ( Vec String ) args → !RedisReply RedisErr {
+@ redis_command * RedisConn c ( Vec String ) args → !RedisReply RedisErr {
     : ( Vec u ) req ( resp_encode args )
     : i ok ( __r_write c req )
     ( vec_free [u] req )
@@ -205,15 +212,17 @@ $ `resp.nu`
 @ __args1 s a → ( Vec String ) {
     : ( Vec String ) v ( vec_new [String] ) ( redis_arg v a ) ^ v
 }
+
 @ __args2 s a s b → ( Vec String ) {
     : ( Vec String ) v ( __args1 a ) ( redis_arg v b ) ^ v
 }
+
 @ __args3 s a s b s d → ( Vec String ) {
     : ( Vec String ) v ( __args2 a b ) ( redis_arg v d ) ^ v
 }
 
 // Build, send, and free args in one shot.
-@ __cmd_reply *RedisConn c ( Vec String ) args → !RedisReply RedisErr {
+@ __cmd_reply * RedisConn c ( Vec String ) args → !RedisReply RedisErr {
     : !RedisReply RedisErr rr ( redis_command c args )
     ( redis_args_free args )
     ^ rr
@@ -222,7 +231,7 @@ $ `resp.nu`
 // ── typed reply extractors ─────────────────────────────────────────
 
 // Integer reply (e.g. DEL, INCR, EXISTS count).
-@ __reply_int *RedisConn c ( Vec String ) args → !i RedisErr {
+@ __reply_int * RedisConn c ( Vec String ) args → !i RedisErr {
     ?? ( __cmd_reply c args ) {
         F e → ^ @ !i RedisErr { F e }
         T rep → {
@@ -236,7 +245,7 @@ $ `resp.nu`
 }
 
 // Integer reply interpreted as a boolean (1 → true).
-@ __reply_bool *RedisConn c ( Vec String ) args → !b RedisErr {
+@ __reply_bool * RedisConn c ( Vec String ) args → !b RedisErr {
     ?? ( __reply_int c args ) {
         F e → ^ @ !b RedisErr { F e }
         T n → ^ @ !b RedisErr { T == n 1 }
@@ -244,7 +253,7 @@ $ `resp.nu`
 }
 
 // Status reply (+OK and friends); we only care that it wasn't an error.
-@ __reply_ok *RedisConn c ( Vec String ) args → !v RedisErr {
+@ __reply_ok * RedisConn c ( Vec String ) args → !v RedisErr {
     ?? ( __cmd_reply c args ) {
         F e → ^ @ !v RedisErr { F e }
         T rep → { ( resp_reply_free rep ) ^ @ !v RedisErr { T 0 } }
@@ -253,7 +262,7 @@ $ `resp.nu`
 
 // Bulk-string reply, nil-aware. Integers are rendered to text so commands
 // that may answer either way still produce a value.
-@ __reply_str *RedisConn c ( Vec String ) args → !RedisStr RedisErr {
+@ __reply_str * RedisConn c ( Vec String ) args → !RedisStr RedisErr {
     ?? ( __cmd_reply c args ) {
         F e → ^ @ !RedisStr RedisErr { F e }
         T rep → {
@@ -275,7 +284,7 @@ $ `resp.nu`
 
 // Array reply flattened to a Vec of owned Strings (bulk elements; integer
 // elements rendered; nils → empty string). Nil array → empty Vec.
-@ __reply_strvec *RedisConn c ( Vec String ) args → !( Vec String ) RedisErr {
+@ __reply_strvec * RedisConn c ( Vec String ) args → !( Vec String ) RedisErr {
     ?? ( __cmd_reply c args ) {
         F e → ^ @ !( Vec String ) RedisErr { F e }
         T rep → {
@@ -312,7 +321,7 @@ $ `resp.nu`
     : *RedisConn c # *RedisConn ( nurl_alloc Z RedisConn )
     = . c tls 0
     = . c raw rawfd
-    = . c tcp @ TcpConn { # s rawfd }
+    = . c tcp @ TcpConn { # s rawfd 0 0 }
     = . c tc # *TlsConn 0
     = . c rxbuf ( vec_new [u] )
     = . c lasterr ( string_new )
@@ -344,7 +353,7 @@ $ `resp.nu`
     ^ ( __redis_open host port ? != verify 0 2 1 server_name )
 }
 
-@ redis_close *RedisConn c → v {
+@ redis_close * RedisConn c → v {
     ? == . c tls 1 { ( tls_close . c tc ) } { ( nurl_tcp_close . c raw ) }
     ( vec_free [u] . c rxbuf )
     ( string_free . c lasterr )
@@ -352,25 +361,26 @@ $ `resp.nu`
     ( nurl_free # s c )
 }
 
-@ redis_last_error *RedisConn c → s { ^ ( string_data . c lasterr ) }
-@ redis_is_tls *RedisConn c → b { ^ == . c tls 1 }
+@ redis_last_error * RedisConn c → s { ^ ( string_data . c lasterr ) }
+
+@ redis_is_tls * RedisConn c → b { ^ == . c tls 1 }
 
 // ── connection commands ────────────────────────────────────────────
 
 // AUTH: one-arg (password only) or two-arg (ACL user + password). Pass an
 // empty user for the legacy single-argument form.
-@ redis_auth *RedisConn c s user s password → !v RedisErr {
+@ redis_auth * RedisConn c s user s password → !v RedisErr {
     ? == ( nurl_str_len user ) 0 { ^ ( __reply_ok c ( __args2 `AUTH` password ) ) } {}
     ^ ( __reply_ok c ( __args3 `AUTH` user password ) )
 }
 
-@ redis_select *RedisConn c i db → !v RedisErr {
+@ redis_select * RedisConn c i db → !v RedisErr {
     : ( Vec String ) a ( __args1 `SELECT` ) ( redis_arg_i a db )
     : !v RedisErr r ( __reply_ok c a )
     ?? r { T _ → { = . c db_index db ^ @ !v RedisErr { T 0 } } F e → ^ @ !v RedisErr { F e } }
 }
 
-@ redis_ping *RedisConn c → !b RedisErr {
+@ redis_ping * RedisConn c → !b RedisErr {
     ?? ( __cmd_reply c ( __args1 `PING` ) ) {
         F e → ^ @ !b RedisErr { F e }
         T rep → {
@@ -382,102 +392,102 @@ $ `resp.nu`
     }
 }
 
-@ redis_echo *RedisConn c s msg → !RedisStr RedisErr {
+@ redis_echo * RedisConn c s msg → !RedisStr RedisErr {
     ^ ( __reply_str c ( __args2 `ECHO` msg ) )
 }
 
 // ── strings / keys ─────────────────────────────────────────────────
 
-@ redis_set *RedisConn c s key s val → !v RedisErr {
+@ redis_set * RedisConn c s key s val → !v RedisErr {
     ^ ( __reply_ok c ( __args3 `SET` key val ) )
 }
 
-@ redis_get *RedisConn c s key → !RedisStr RedisErr {
+@ redis_get * RedisConn c s key → !RedisStr RedisErr {
     ^ ( __reply_str c ( __args2 `GET` key ) )
 }
 
-@ redis_del *RedisConn c s key → !i RedisErr {
+@ redis_del * RedisConn c s key → !i RedisErr {
     ^ ( __reply_int c ( __args2 `DEL` key ) )
 }
 
-@ redis_exists *RedisConn c s key → !b RedisErr {
+@ redis_exists * RedisConn c s key → !b RedisErr {
     ^ ( __reply_bool c ( __args2 `EXISTS` key ) )
 }
 
-@ redis_incr *RedisConn c s key → !i RedisErr {
+@ redis_incr * RedisConn c s key → !i RedisErr {
     ^ ( __reply_int c ( __args2 `INCR` key ) )
 }
 
-@ redis_decr *RedisConn c s key → !i RedisErr {
+@ redis_decr * RedisConn c s key → !i RedisErr {
     ^ ( __reply_int c ( __args2 `DECR` key ) )
 }
 
-@ redis_incrby *RedisConn c s key i n → !i RedisErr {
+@ redis_incrby * RedisConn c s key i n → !i RedisErr {
     : ( Vec String ) a ( __args2 `INCRBY` key ) ( redis_arg_i a n )
     ^ ( __reply_int c a )
 }
 
-@ redis_expire *RedisConn c s key i secs → !b RedisErr {
+@ redis_expire * RedisConn c s key i secs → !b RedisErr {
     : ( Vec String ) a ( __args2 `EXPIRE` key ) ( redis_arg_i a secs )
     ^ ( __reply_bool c a )
 }
 
-@ redis_ttl *RedisConn c s key → !i RedisErr {
+@ redis_ttl * RedisConn c s key → !i RedisErr {
     ^ ( __reply_int c ( __args2 `TTL` key ) )
 }
 
-@ redis_keys *RedisConn c s pattern → !( Vec String ) RedisErr {
+@ redis_keys * RedisConn c s pattern → !( Vec String ) RedisErr {
     ^ ( __reply_strvec c ( __args2 `KEYS` pattern ) )
 }
 
 // ── lists ──────────────────────────────────────────────────────────
 
-@ redis_lpush *RedisConn c s key s val → !i RedisErr {
+@ redis_lpush * RedisConn c s key s val → !i RedisErr {
     ^ ( __reply_int c ( __args3 `LPUSH` key val ) )
 }
 
-@ redis_rpush *RedisConn c s key s val → !i RedisErr {
+@ redis_rpush * RedisConn c s key s val → !i RedisErr {
     ^ ( __reply_int c ( __args3 `RPUSH` key val ) )
 }
 
-@ redis_llen *RedisConn c s key → !i RedisErr {
+@ redis_llen * RedisConn c s key → !i RedisErr {
     ^ ( __reply_int c ( __args2 `LLEN` key ) )
 }
 
-@ redis_lrange *RedisConn c s key i start i stop → !( Vec String ) RedisErr {
+@ redis_lrange * RedisConn c s key i start i stop → !( Vec String ) RedisErr {
     : ( Vec String ) a ( __args2 `LRANGE` key ) ( redis_arg_i a start ) ( redis_arg_i a stop )
     ^ ( __reply_strvec c a )
 }
 
 // ── hashes ─────────────────────────────────────────────────────────
 
-@ redis_hset *RedisConn c s key s field s val → !i RedisErr {
+@ redis_hset * RedisConn c s key s field s val → !i RedisErr {
     : ( Vec String ) a ( __args3 `HSET` key field ) ( redis_arg a val )
     ^ ( __reply_int c a )
 }
 
-@ redis_hget *RedisConn c s key s field → !RedisStr RedisErr {
+@ redis_hget * RedisConn c s key s field → !RedisStr RedisErr {
     ^ ( __reply_str c ( __args3 `HGET` key field ) )
 }
 
 // Flat [field, value, field, value, …] of the whole hash.
-@ redis_hgetall *RedisConn c s key → !( Vec String ) RedisErr {
+@ redis_hgetall * RedisConn c s key → !( Vec String ) RedisErr {
     ^ ( __reply_strvec c ( __args2 `HGETALL` key ) )
 }
 
 // ── sets ───────────────────────────────────────────────────────────
 
-@ redis_sadd *RedisConn c s key s member → !i RedisErr {
+@ redis_sadd * RedisConn c s key s member → !i RedisErr {
     ^ ( __reply_int c ( __args3 `SADD` key member ) )
 }
 
-@ redis_smembers *RedisConn c s key → !( Vec String ) RedisErr {
+@ redis_smembers * RedisConn c s key → !( Vec String ) RedisErr {
     ^ ( __reply_strvec c ( __args2 `SMEMBERS` key ) )
 }
 
 // ── pub/sub ────────────────────────────────────────────────────────
 
-@ redis_publish *RedisConn c s channel s msg → !i RedisErr {
+@ redis_publish * RedisConn c s channel s msg → !i RedisErr {
     ^ ( __reply_int c ( __args3 `PUBLISH` channel msg ) )
 }
 
@@ -500,31 +510,31 @@ $ `resp.nu`
                 ( string_free payload ) = payload ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 2 ) ) )
             } {}
         } {
-        ? != ( nurl_str_eq verb `pmessage` ) 0 {
-            = kind 3
-            ? >= n 4 {
-                ( string_free pattern ) = pattern ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 1 ) ) )
-                ( string_free channel ) = channel ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 2 ) ) )
-                ( string_free payload ) = payload ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 3 ) ) )
-            } {}
-        } {
-            // (p)subscribe / (p)unsubscribe confirmation: [verb, name, count]
-            ? != ( nurl_str_eq verb `subscribe` ) 0 { = kind 1 } {
-            ? != ( nurl_str_eq verb `unsubscribe` ) 0 { = kind 2 } {
-            ? != ( nurl_str_eq verb `psubscribe` ) 0 { = kind 4 } {
-            ? != ( nurl_str_eq verb `punsubscribe` ) 0 { = kind 5 } {} } } }
-            ? >= n 3 {
-                : i is_pat | == kind 4 == kind 5
-                : String name ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 1 ) ) )
-                ? is_pat { ( string_free pattern ) = pattern name } { ( string_free channel ) = channel name }
-                = count ( resp_node_int rep ( resp_node_arr_at rep root 2 ) )
-            } {}
-        } }
+            ? != ( nurl_str_eq verb `pmessage` ) 0 {
+                = kind 3
+                ? >= n 4 {
+                    ( string_free pattern ) = pattern ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 1 ) ) )
+                    ( string_free channel ) = channel ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 2 ) ) )
+                    ( string_free payload ) = payload ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 3 ) ) )
+                } {}
+            } {
+                // (p)subscribe / (p)unsubscribe confirmation: [verb, name, count]
+                ? != ( nurl_str_eq verb `subscribe` ) 0 { = kind 1 } {
+                    ? != ( nurl_str_eq verb `unsubscribe` ) 0 { = kind 2 } {
+                        ? != ( nurl_str_eq verb `psubscribe` ) 0 { = kind 4 } {
+                            ? != ( nurl_str_eq verb `punsubscribe` ) 0 { = kind 5 } {} } } }
+                ? >= n 3 {
+                    : i is_pat | == kind 4 == kind 5
+                    : String name ( string_from ( resp_node_str rep ( resp_node_arr_at rep root 1 ) ) )
+                    ? is_pat { ( string_free pattern ) = pattern name } { ( string_free channel ) = channel name }
+                    = count ( resp_node_int rep ( resp_node_arr_at rep root 2 ) )
+                } {}
+            } }
     } {}
     ^ @ RedisMessage { kind channel pattern payload count }
 }
 
-@ __sub_cmd *RedisConn c s verb s arg → !RedisMessage RedisErr {
+@ __sub_cmd * RedisConn c s verb s arg → !RedisMessage RedisErr {
     ?? ( __cmd_reply c ( __args2 verb arg ) ) {
         F e → ^ @ !RedisMessage RedisErr { F e }
         T rep → {
@@ -538,23 +548,26 @@ $ `resp.nu`
 // Subscribe to a channel (or pattern). Returns the subscription confirmation;
 // thereafter call redis_next_message to receive published messages. While
 // subscribed only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING are valid commands.
-@ redis_subscribe *RedisConn c s channel → !RedisMessage RedisErr {
+@ redis_subscribe * RedisConn c s channel → !RedisMessage RedisErr {
     ^ ( __sub_cmd c `SUBSCRIBE` channel )
 }
-@ redis_unsubscribe *RedisConn c s channel → !RedisMessage RedisErr {
+
+@ redis_unsubscribe * RedisConn c s channel → !RedisMessage RedisErr {
     ^ ( __sub_cmd c `UNSUBSCRIBE` channel )
 }
-@ redis_psubscribe *RedisConn c s pattern → !RedisMessage RedisErr {
+
+@ redis_psubscribe * RedisConn c s pattern → !RedisMessage RedisErr {
     ^ ( __sub_cmd c `PSUBSCRIBE` pattern )
 }
-@ redis_punsubscribe *RedisConn c s pattern → !RedisMessage RedisErr {
+
+@ redis_punsubscribe * RedisConn c s pattern → !RedisMessage RedisErr {
     ^ ( __sub_cmd c `PUNSUBSCRIBE` pattern )
 }
 
 // Block until the next pub/sub frame arrives, then decode it. Returns a
 // `message` / `pmessage` for delivered payloads, or a (un)subscribe control
 // frame; RedisIo on a closed connection.
-@ redis_next_message *RedisConn c → !RedisMessage RedisErr {
+@ redis_next_message * RedisConn c → !RedisMessage RedisErr {
     ?? ( __r_read_reply c ) {
         F e → ^ @ !RedisMessage RedisErr { F e }
         T rep → {
@@ -567,6 +580,6 @@ $ `resp.nu`
 
 // ── admin ──────────────────────────────────────────────────────────
 
-@ redis_flushdb *RedisConn c → !v RedisErr {
+@ redis_flushdb * RedisConn c → !v RedisErr {
     ^ ( __reply_ok c ( __args1 `FLUSHDB` ) )
 }

--- a/stdlib/ext/http2_client.nu
+++ b/stdlib/ext/http2_client.nu
@@ -461,7 +461,7 @@ $ `stdlib/ext/http2_hpack.nu`
         ^ @ !H2Client H2ClientErr { F # H2ClientErr H2CConnect }
     } {}
     : s rp # s craw
-    : TcpConn conn @ TcpConn { rp }
+    : TcpConn conn @ TcpConn { rp 0 0 }
     ( tcp_set_timeout conn 30000 )
     : !H2Client H2ClientErr hr ( __h2_client_handshake conn )
     ?? hr {
@@ -486,7 +486,7 @@ $ `stdlib/ext/http2_hpack.nu`
         ^ @ !H2Client H2ClientErr { F e }
     } {}
     : s rp # s craw
-    : TcpConn conn @ TcpConn { rp }
+    : TcpConn conn @ TcpConn { rp 0 0 }
     // Confirm ALPN actually selected h2 — otherwise the peer would speak
     // HTTP/1.1 and our framing would be garbage.
     : String proto ( tcp_alpn_protocol conn )

--- a/stdlib/ext/mqtt.nu
+++ b/stdlib/ext/mqtt.nu
@@ -150,7 +150,7 @@ $ `stdlib/ext/websocket.nu`
 // Open a TLS client connection. `verify` T = check the broker cert
 // chain + hostname against the system trust store; F = encrypt but
 // don't validate the chain (an MQTT client's `--insecure`).
-@ tcp_connect_tls s host i port b verify → !TcpConn MqttErr {
+@ __mqtt_connect_tls s host i port b verify → !TcpConn MqttErr {
     : i vflag ? verify 1 0
     : i craw ( nurl_tcp_connect_tls host port vflag )
     ? == craw 0 { ^ @ !TcpConn MqttErr { F # MqttErr MqttTransport } } {}
@@ -160,7 +160,7 @@ $ `stdlib/ext/websocket.nu`
         ^ @ !TcpConn MqttErr { F ( __mqtt_of_net ( __net_err_of ek ) ) }
     } {}
     : s crp # s craw
-    : TcpConn c @ TcpConn { crp }
+    : TcpConn c @ TcpConn { crp 0 0 }
     ^ @ !TcpConn MqttErr { T c }
 }
 
@@ -174,7 +174,7 @@ $ `stdlib/ext/websocket.nu`
         ^ @ !TcpConn MqttErr { F ( __mqtt_of_net ( __net_err_of ek ) ) }
     } {}
     : s crp # s craw
-    : TcpConn c @ TcpConn { crp }
+    : TcpConn c @ TcpConn { crp 0 0 }
     ^ @ !TcpConn MqttErr { T c }
 }
 
@@ -597,7 +597,7 @@ $ `stdlib/ext/websocket.nu`
 // (MqttBadAuth / MqttNotAuthorized / MqttRefused); the Ok value is a
 // live, authenticated client.
 @ mqtt_connect_cfg s host i port MqttConfig cfg → !MqttClient MqttErr {
-    : !TcpConn MqttErr cr ( tcp_connect_tls host port . cfg tls_verify )
+    : !TcpConn MqttErr cr ( __mqtt_connect_tls host port . cfg tls_verify )
     ?? cr {
         T conn → {
             ( tcp_set_timeout conn 15000 )
@@ -1021,7 +1021,7 @@ $ `stdlib/ext/websocket.nu`
 @ mqtt_reconnect MqttClient cl s host i port MqttConfig cfg → !v MqttErr {
     ? . cl ws { ^ @ !v MqttErr { F # MqttErr MqttTransport } } {}
     ( tcp_close_conn . cl conn )
-    : !TcpConn MqttErr cr ( tcp_connect_tls host port . cfg tls_verify )
+    : !TcpConn MqttErr cr ( __mqtt_connect_tls host port . cfg tls_verify )
     ?? cr {
         T nc → {
             ( tcp_set_timeout nc 15000 )

--- a/stdlib/ext/smtp.nu
+++ b/stdlib/ext/smtp.nu
@@ -229,7 +229,7 @@ $ `stdlib/std/time.nu`  // smtp_date_now
         ^ @ !SmtpClient SmtpErr { F # SmtpErr SmtpConnect }
     } {}
     : s crp # s craw
-    : TcpConn conn @ TcpConn { crp }
+    : TcpConn conn @ TcpConn { crp 0 0 }
     : SmtpClient c @ SmtpClient { conn ( vec_new [u] ) ( string_with_cap 128 ) }
     : !i SmtpErr g ( __smtp_read_reply c )
     ^ ?? g {

--- a/stdlib/ext/websocket.nu
+++ b/stdlib/ext/websocket.nu
@@ -1736,7 +1736,7 @@ $ `stdlib/ext/compress.nu`
                 ^ @ !WsClient WsErr { F WsConnectFailed }
             } {}
             : s crp # s craw
-            : TcpConn conn @ TcpConn { crp }
+            : TcpConn conn @ TcpConn { crp 0 0 }
             : !v WsErr hsr ( ws_client_handshake conn ( string_data . u host ) ( string_data . u path ) subprotocol )
             ( ws_url_free u )
             ?? hsr {
@@ -2391,7 +2391,7 @@ $ `stdlib/ext/compress.nu`
                 ^ @ !WsDeflateConn WsErr { F WsConnectFailed }
             } {}
             : s crp # s craw
-            : TcpConn conn @ TcpConn { crp }
+            : TcpConn conn @ TcpConn { crp 0 0 }
             : !WsDeflateConfig WsErr hsr ( ws_client_handshake_deflate conn ( string_data . u host ) ( string_data . u path ) subprotocol cfg )
             ( ws_url_free u )
             ?? hsr {

--- a/stdlib/net/relay.nu
+++ b/stdlib/net/relay.nu
@@ -492,7 +492,7 @@ $ `stdlib/std/async.nu`
         ( nurl_tcp_close raw )
         ^ @ !RelayClient NetErr { F ( __net_err_of ek ) }
     } {}
-    : TcpConn c @ TcpConn { # s raw }
+    : TcpConn c @ TcpConn { # s raw 0 0 }
     ^ @ !RelayClient NetErr { T @ RelayClient { c } }
 }
 

--- a/stdlib/net/rendezvous.nu
+++ b/stdlib/net/rendezvous.nu
@@ -433,7 +433,7 @@ $ `stdlib/std/async.nu`
     ? == raw 0 { ^ @ !RzClient NetErr { F # NetErr NetOther } } {}
     : i ek ( nurl_tcp_err_kind raw )
     ? != ek 0 { ( nurl_tcp_close raw ) ^ @ !RzClient NetErr { F ( __net_err_of ek ) } } {}
-    : TcpConn c @ TcpConn { # s raw }
+    : TcpConn c @ TcpConn { # s raw 0 0 }
     ^ @ !RzClient NetErr { T @ RzClient { c } }
 }
 

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -70,6 +70,11 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/tls.nu`
+$ `stdlib/std/tls_server.nu`
+$ `stdlib/std/pkey.nu`
 
 : | NetErr {
     NetBind
@@ -89,8 +94,17 @@ $ `stdlib/core/vec.nu`
 // Listener and connection are intentionally distinct types — the
 // compiler refuses to mix them at call sites, which catches the
 // classic "passed listener to read" mistake at type-check time.
-: TcpListener { s raw }
-: TcpConn { s raw }
+// A TLS listener carries the loaded leaf-cert DER + EC P-256 private
+// scalar so each accept can run the pure handshake (is_tls = 1). They are
+// held as raw malloc'd (ptr, len) pairs — NOT Vec fields — because a
+// value struct returned with owned-Vec fields is auto-dropped at the
+// constructing function's exit (a borrowck escape gap), which would free
+// the buffers out from under the listener.
+: TcpListener { s raw i is_tls i certp i certlen i privp i privlen }
+// kind: 0 = plaintext (raw is the runtime socket handle), 1 = pure TLS
+// client, 2 = pure TLS server. For kinds 1/2 `tlsh` is the *TlsConn (as
+// i64) and reads/writes dispatch to the pure stack.
+: TcpConn { s raw i kind i tlsh }
 
 // Render a NetErr variant name as a raw `s` for log lines.
 @ net_err_name NetErr e → s {
@@ -141,8 +155,24 @@ $ `stdlib/core/vec.nu`
         ^ @ !TcpListener NetErr { F ( __net_err_of ek ) }
     } {}
     : s rp # s raw
-    : TcpListener l @ TcpListener { rp }
+    : TcpListener l @ TcpListener { rp 0 0 0 0 0 }
     ^ @ !TcpListener NetErr { T l }
+}
+
+// malloc a copy of `v`'s bytes; returns the pointer as i64 (0 if empty).
+@ __net_dup ( Vec u ) v → i {
+    : i n ( vec_len [u] v )
+    ? <= n 0 { ^ 0 } {}
+    : s buf # s ( malloc n )
+    ( nurl_memcpy # *u buf ( vec_data [u] v ) n )
+    ^ # i buf
+}
+
+// Build a fresh Vec view over a raw (ptr, len) cert/key blob.
+@ __net_vecview i ptr i len → ( Vec u ) {
+    : ( Vec u ) v ( vec_new [u] )
+    ? > len 0 { ( bytes_extend_raw v # s ptr len ) } {}
+    ^ v
 }
 
 // Convenience: same as tcp_listen_with_backlog with backlog = 128.
@@ -161,50 +191,77 @@ $ `stdlib/core/vec.nu`
 //
 // Build-time dependency: openssl detected via pkg-config in build.sh.
 // When absent, every call here returns NetTlsCtxInit unconditionally.
+// Load the leaf-cert DER + EC P-256 private scalar from PEM files for a
+// pure-TLS listener. The cert PEM's first block is taken as the leaf.
+@ __load_tls_creds s cert_path s key_path ( Vec u ) cert_out ( Vec u ) priv_out → i {
+    : !( Vec u ) ParseErr cr ?? ( read_file cert_path ) {
+        T pem → ( pem_to_der ( string_data pem ) )
+        F _ → @ !( Vec u ) ParseErr { F @ ParseErr { BadFormat } }
+    }
+    ?? cr { T der → { ( bytes_extend_bytes cert_out der ) ( vec_free [u] der ) } F _ → ^ 10 }
+    : !( Vec u ) ParseErr kr ?? ( read_file key_path ) {
+        T pem → ( ec_p256_priv_from_pem ( string_data pem ) )
+        F _ → @ !( Vec u ) ParseErr { F @ ParseErr { BadFormat } }
+    }
+    ?? kr { T sc → { ( bytes_extend_bytes priv_out sc ) ( vec_free [u] sc ) } F _ → ^ 11 }
+    ^ 0
+}
+
 @ tcp_listen_tls_with_backlog s host i port i backlog s cert_path s key_path → !TcpListener NetErr {
-    : i raw ( nurl_tcp_listen_tls host port backlog cert_path key_path )
-    ? == raw 0 { ^ @ !TcpListener NetErr { F # NetErr NetOther } } {}
+    : ( Vec u ) cert ( vec_new [u] )
+    : ( Vec u ) priv ( vec_new [u] )
+    : i lr ( __load_tls_creds cert_path key_path cert priv )
+    ? != lr 0 {
+        ( vec_free [u] cert ) ( vec_free [u] priv )
+        ^ @ !TcpListener NetErr { F ( __net_err_of lr ) }
+    } {}
+    : i raw ( nurl_tcp_listen host port backlog )
+    ? == raw 0 { ( vec_free [u] cert ) ( vec_free [u] priv ) ^ @ !TcpListener NetErr { F # NetErr NetOther } } {}
     : i ek ( nurl_tcp_err_kind raw )
     ? != ek 0 {
-        ( nurl_tcp_close raw )
+        ( nurl_tcp_close raw ) ( vec_free [u] cert ) ( vec_free [u] priv )
         ^ @ !TcpListener NetErr { F ( __net_err_of ek ) }
     } {}
+    // Copy cert/key into raw heap buffers, then drop the Vecs.
+    : i certp ( __net_dup cert )
+    : i certlen ( vec_len [u] cert )
+    : i privp ( __net_dup priv )
+    : i privlen ( vec_len [u] priv )
+    ( vec_free [u] cert )
+    ( vec_free [u] priv )
     : s rp # s raw
-    : TcpListener l @ TcpListener { rp }
-    ^ @ !TcpListener NetErr { T l }
+    ^ @ !TcpListener NetErr { T @ TcpListener { rp 1 certp certlen privp privlen } }
 }
 
 @ tcp_listen_tls s host i port s cert_path s key_path → !TcpListener NetErr {
     ^ ( tcp_listen_tls_with_backlog host port 128 cert_path key_path )
 }
 
-// TLS listener WITH ALPN (Application-Layer Protocol Negotiation, RFC 7301).
-// `alpn_protocols` is a space-separated list in server-preference order,
-// e.g. "h2 http/1.1". HTTP/2 over TLS (h2) REQUIRES ALPN per RFC 9113
-// §3.3 — without it h2-aware clients (curl, Chrome, …) fall back to
-// HTTP/1.1 silently. Pair with `tcp_alpn_protocol` post-accept to learn
-// what the peer agreed to.
+// TLS listener with ALPN. The pure handshake does not yet advertise ALPN,
+// so the protocol list is accepted for source compatibility but ignored
+// (clients negotiate nothing → fall back to HTTP/1.1). ALPN is a planned
+// addition to the pure stack.
 @ tcp_listen_tls_with_alpn s host i port i backlog s cert_path s key_path s alpn_protocols → !TcpListener NetErr {
-    : i raw ( nurl_tcp_listen_tls_alpn host port backlog cert_path key_path alpn_protocols )
-    : i ek ( nurl_tcp_err_kind raw )
-    ? != 0 ek {
-        ( nurl_tcp_close raw )
-        ^ @ !TcpListener NetErr { F ( __net_err_of ek ) }
-    } {}
-    : TcpListener l @ TcpListener { # s raw }
-    ^ @ !TcpListener NetErr { T l }
+    ^ ( tcp_listen_tls_with_backlog host port backlog cert_path key_path )
 }
 
-// Read the negotiated ALPN protocol off an accepted TLS conn. Returns
-// the empty string for non-TLS conns or when ALPN was not negotiated
-// (peer didn't offer any protocol from the listener's list).
+// Read the negotiated ALPN protocol off an accepted TLS conn. The pure
+// stack does not negotiate ALPN yet, so this returns "".
 @ tcp_alpn_protocol TcpConn c → String {
-    : s rp . c raw
-    : i raw # i rp
-    : s sel ( nurl_tcp_alpn_selected raw )
-    : String out ( string_from sel )
-    ( nurl_free sel )
-    ^ out
+    ^ ( string_new )
+}
+
+// Open a verified (or, with verify = 0, encrypted-only) pure-TLS client
+// connection. Returns a polymorphic TcpConn (kind 1) whose reads/writes
+// dispatch to the pure client stack.
+@ tcp_connect_tls s host i port s server_name i verify → !TcpConn NetErr {
+    : i raw ( nurl_tcp_connect host port )
+    ? <= raw 0 { ^ @ !TcpConn NetErr { F # NetErr NetTlsHandshake } } {}
+    : !*TlsConn TlsErr r ? != verify 0 ( tls_attach_verify raw server_name ) ( tls_attach raw server_name )
+    ?? r {
+        F _ → ^ @ !TcpConn NetErr { F # NetErr NetTlsHandshake }
+        T tc → ^ @ !TcpConn NetErr { T @ TcpConn { # s 0 1 # i tc } }
+    }
 }
 
 // Register a per-hostname cert/key pair on a TLS listener for Server
@@ -266,19 +323,19 @@ $ `stdlib/core/vec.nu`
 // TLS conn. Empty when no cert was presented OR the conn is non-TLS.
 // Caller compares against an expected allow-list — this is the
 // primary identity hook for mTLS-authenticated requests.
+// Peer certificate subject. The pure TLS stack verifies the chain during
+// the handshake but does not expose the subject string, so this returns
+// "" (client-cert inspection is not supported on the pure path).
 @ tcp_peer_cert_subject TcpConn c → String {
-    : s rp . c raw
-    : i raw # i rp
-    : s sub ( nurl_tcp_peer_cert_subject raw )
-    : String out ( string_from sub )
-    ( nurl_free sub )
-    ^ out
+    ^ ( string_new )
 }
 
 @ tcp_close_listener TcpListener l → v {
-    : s rp . l raw
-    : i raw # i rp
-    ( nurl_tcp_close raw )
+    ( nurl_tcp_close # i . l raw )
+    ? != . l is_tls 0 {
+        ? != . l certp 0 { ( nurl_free # s . l certp ) } {}
+        ? != . l privp 0 { ( nurl_free # s . l privp ) } {}
+    } {}
 }
 
 // Soft-shutdown: close the underlying socket but KEEP the handle's
@@ -297,15 +354,25 @@ $ `stdlib/core/vec.nu`
 
 // ── Connection acceptance ──────────────────────────────────────────
 
+// The fd backing a TcpConn — the runtime handle for plaintext, or the
+// pure TLS conn's socket fd for kinds 1/2.
+@ __conn_fd TcpConn c → i {
+    ? != . c kind 0 {
+        : *TlsConn tc # *TlsConn . c tlsh
+        ^ . tc fd
+    } {}
+    ^ # i . c raw
+}
+
 @ tcp_accept TcpListener l → !TcpConn NetErr {
-    // Context-aware: on a fiber, dispatch to the async path so the
-    // worker pthread stays free while we wait for an incoming
-    // connection. From outside any fiber, fall through to the
-    // blocking POSIX accept.
-    : i fcur ( nurl_fiber_current )
-    ? != fcur 0 { ^ ( tcp_accept_async l ) } {}
-    : s lrp . l raw
-    : i lraw # i lrp
+    // Context-aware: on a fiber, dispatch to the async path so the worker
+    // pthread stays free while we wait. TLS listeners take the blocking
+    // path (the pure handshake is synchronous).
+    ? == . l is_tls 0 {
+        : i fcur ( nurl_fiber_current )
+        ? != fcur 0 { ^ ( tcp_accept_async l ) } {}
+    } {}
+    : i lraw # i . l raw
     : i craw ( nurl_tcp_accept lraw )
     ? == craw 0 { ^ @ !TcpConn NetErr { F # NetErr NetOther } } {}
     : i ek ( nurl_tcp_err_kind craw )
@@ -313,35 +380,66 @@ $ `stdlib/core/vec.nu`
         ( nurl_tcp_close craw )
         ^ @ !TcpConn NetErr { F ( __net_err_of ek ) }
     } {}
-    : s crp # s craw
-    : TcpConn c @ TcpConn { crp }
+    ? != . l is_tls 0 {
+        : ( Vec u ) cert ( __net_vecview . l certp . l certlen )
+        : ( Vec u ) priv ( __net_vecview . l privp . l privlen )
+        : !*TlsConn TlsErr r ( tls_accept craw cert priv )
+        ( vec_free [u] cert )
+        ( vec_free [u] priv )
+        ?? r {
+            F _ → ^ @ !TcpConn NetErr { F # NetErr NetTlsHandshake }
+            T tc → ^ @ !TcpConn NetErr { T @ TcpConn { # s 0 2 # i tc } }
+        }
+    } {}
+    : TcpConn c @ TcpConn { # s craw 0 0 }
     ^ @ !TcpConn NetErr { T c }
 }
 
 @ tcp_close_conn TcpConn c → v {
-    : s rp . c raw
-    : i raw # i rp
-    ( nurl_tcp_close raw )
+    ? != . c kind 0 { ( tls_close # *TlsConn . c tlsh ) } { ( nurl_tcp_close # i . c raw ) }
 }
 
 @ tcp_peer_addr TcpConn c → s {
-    : s rp . c raw
-    : i raw # i rp
-    ^ ( nurl_tcp_peer_addr raw )
+    ^ ( nurl_tcp_peer_addr ( __conn_fd c ) )
 }
 
 @ tcp_set_timeout TcpConn c i ms → v {
-    : s rp . c raw
-    : i raw # i rp
-    ( nurl_tcp_set_timeout raw ms )
+    ( nurl_tcp_set_timeout ( __conn_fd c ) ms )
 }
 
 // ── Reading ────────────────────────────────────────────────────────
 
 // Issue ONE recv(2). The returned Vec[u] holds 0..max bytes. EOF is
 // surfaced as `Err(NetClosed)` so empty Ok-vectors are never confused
+// Pure-TLS read dispatch (kind 1 = client, kind 2 = server). Clean EOF
+// (tls_read returns []) is surfaced as NetClosed to match the plain path.
+@ __tls_read_net TcpConn c i max → !( Vec u ) NetErr {
+    : *TlsConn tc # *TlsConn . c tlsh
+    : !( Vec u ) TlsErr r ? == . c kind 2 ( tls_server_read tc max ) ( tls_read tc max )
+    ?? r {
+        F e → {
+            : NetErr ne ?? e { TlsClosed → # NetErr NetClosed _ → # NetErr NetRead }
+            ^ @ !( Vec u ) NetErr { F ne }
+        }
+        T v → {
+            ? == ( vec_len [u] v ) 0 {
+                ( vec_free [u] v )
+                ^ @ !( Vec u ) NetErr { F # NetErr NetClosed }
+            } {}
+            ^ @ !( Vec u ) NetErr { T v }
+        }
+    }
+}
+
+@ __tls_write_net TcpConn c ( Vec u ) bytes → !v NetErr {
+    : *TlsConn tc # *TlsConn . c tlsh
+    : !v TlsErr r ? == . c kind 2 ( tls_server_write tc bytes ) ( tls_write tc bytes )
+    ?? r { T _ → ^ @ !v NetErr { T 0 } F _ → ^ @ !v NetErr { F # NetErr NetWrite } }
+}
+
 // with a clean peer shutdown. Caller frees the Vec on the Ok path.
 @ tcp_read_chunk TcpConn c i max → !( Vec u ) NetErr {
+    ? != . c kind 0 { ^ ( __tls_read_net c max ) } {}
     // Context-aware dispatch — see tcp_accept's note.
     : i fcur ( nurl_fiber_current )
     ? != fcur 0 { ^ ( tcp_read_chunk_async c max ) } {}
@@ -371,6 +469,7 @@ $ `stdlib/core/vec.nu`
 // ── Writing ────────────────────────────────────────────────────────
 
 @ tcp_write_all TcpConn c ( Vec u ) bytes → !v NetErr {
+    ? != . c kind 0 { ^ ( __tls_write_net c bytes ) } {}
     // Context-aware dispatch — see tcp_accept's note.
     : i fcur ( nurl_fiber_current )
     ? != fcur 0 { ^ ( tcp_write_all_async c bytes ) } {}
@@ -392,6 +491,12 @@ $ `stdlib/core/vec.nu`
 // status-line case). The bytes [0..len) are sent — the trailing NUL is
 // NOT transmitted.
 @ tcp_write_str TcpConn c s text → !v NetErr {
+    ? != . c kind 0 {
+        : ( Vec u ) b ( bytes_from_str text )
+        : !v NetErr r ( __tls_write_net c b )
+        ( vec_free [u] b )
+        ^ r
+    } {}
     : s rp . c raw
     : i raw # i rp
     : i n ( nurl_str_len text )
@@ -475,7 +580,7 @@ $ `stdlib/std/async_ffi.nu`
         : i ek ( nurl_tcp_err_kind craw )
         ? == ek 0 {
             : s crp # s craw
-            : TcpConn c @ TcpConn { crp }
+            : TcpConn c @ TcpConn { crp 0 0 }
             ^ @ !TcpConn NetErr { T c }
         } {
             ( nurl_tcp_close craw )

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -24,7 +24,6 @@
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
-$ `stdlib/std/net.nu`
 $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/hkdf.nu`
 $ `stdlib/std/x25519.nu`
@@ -34,6 +33,23 @@ $ `stdlib/std/aes_gcm.nu`
 $ `stdlib/std/tls_verify.nu`
 
 & `libc` @ nurl_tcp_connect s host i port → i
+
+// Write all of `data` to the raw socket fd. Returns F on any error. tls.nu
+// is deliberately self-contained over the libc socket (nurl_tcp_* are
+// compiler builtins) so it carries no dependency on stdlib/std/net.nu —
+// that lets net.nu import THIS module and dispatch its polymorphic TcpConn
+// reads/writes to the pure TLS stack without an import cycle.
+@ __tls_sock_write i fd ( Vec u ) data → b {
+    : *u dp ( vec_data [u] data )
+    : i n ( vec_len [u] data )
+    : ~ i off 0
+    ~ < off n {
+        : i wn ( nurl_tcp_write fd # s + # i dp off - n off )
+        ? <= wn 0 { ^ F } {}
+        = off + off wn
+    }
+    ^ T
+}
 
 & `c` @ nurl_rand_fill *u buf i n → i
 
@@ -70,7 +86,7 @@ $ `stdlib/std/tls_verify.nu`
 // Live connection state. Vec fields are reassigned as keys rotate
 // (handshake → application) and as buffers are consumed.
 : TlsConn {
-    TcpConn tcp
+    i fd
     ( Vec u ) rxbuf  // raw socket bytes not yet split into records
     ( Vec u ) hsbuf  // decrypted handshake bytes not yet a full message
     ( Vec u ) appbuf  // decrypted application bytes for the caller
@@ -143,8 +159,7 @@ $ `stdlib/std/tls_verify.nu`
 // parks with no reactor to wake it in a plain program; the raw blocking
 // read is what a synchronous client wants.
 @ __fill * TlsConn c i n → !i TlsErr {
-    : TcpConn tc . c tcp
-    : i raw # i . tc raw
+    : i raw . c fd
     ~ < ( vec_len [u] . c rxbuf ) n {
         : ( Vec u ) tmp ( vec_with_cap [u] 16384 )
         : *u p ( vec_data [u] tmp )
@@ -256,14 +271,14 @@ $ `stdlib/std/tls_verify.nu`
     ( vec_push [u] rec # u 3 )
     ( __u16 rec total )
     ( __cat rec sealed )
-    : !v NetErr w ( tcp_write_all . c tcp rec )
+    : b w ( __tls_sock_write . c fd rec )
     ( vec_free [u] inner )
     ( vec_free [u] aad )
     ( vec_free [u] nonce )
     ( vec_free [u] sealed )
     ( vec_free [u] rec )
     = . c c_seq + . c c_seq 1
-    ^ ?? w { T _ → @ !v TlsErr { T 0 } F _ → @ !v TlsErr { F # TlsErr TlsWrite } }
+    ^ ? w @ !v TlsErr { T 0 } @ !v TlsErr { F # TlsErr TlsWrite }
 }
 
 // Write a plaintext record straight to the socket.
@@ -276,9 +291,9 @@ $ `stdlib/std/tls_verify.nu`
     ( vec_push [u] rec # u 3 )
     ( __u16 rec ( vec_len [u] body ) )
     ( __cat rec body )
-    : !v NetErr w ( tcp_write_all . c tcp rec )
+    : b w ( __tls_sock_write . c fd rec )
     ( vec_free [u] rec )
-    ^ ?? w { T _ → @ !v TlsErr { T 0 } F _ → @ !v TlsErr { F # TlsErr TlsWrite } }
+    ^ ? w @ !v TlsErr { T 0 } @ !v TlsErr { F # TlsErr TlsWrite }
 }
 
 // ── handshake-message reader ──────────────────────────────────────
@@ -571,16 +586,14 @@ $ `stdlib/std/tls_verify.nu`
 @ tls_attach i raw s server_name → !*TlsConn TlsErr {
     : i ek ( nurl_tcp_err_kind raw )
     ? != ek 0 { ^ @ !*TlsConn TlsErr { F # TlsErr TlsConnect } } {}
-    : s rp # s raw
-    : TcpConn tcp @ TcpConn { rp }
     // Read timeout so an unresponsive/dead peer fails the handshake
     // cleanly instead of blocking the client forever.
-    ( tcp_set_timeout tcp 20000 )
+    ( nurl_tcp_set_timeout raw 20000 )
 
     // Heap-allocate the connection so field mutations (key rotation,
     // buffer consumption) in the helpers persist across calls.
     : *TlsConn c # *TlsConn ( nurl_alloc Z TlsConn )
-    = . c tcp tcp
+    = . c fd raw
     = . c rxbuf ( vec_new [u] )
     = . c hsbuf ( vec_new [u] )
     = . c appbuf ( vec_new [u] )
@@ -899,7 +912,7 @@ $ `stdlib/std/tls_verify.nu`
         } {}
         = . c closed 1
     } {}
-    ( tcp_close_conn . c tcp )
+    ( nurl_tcp_close . c fd )
     ( vec_free [u] . c rxbuf )
     ( vec_free [u] . c hsbuf )
     ( vec_free [u] . c appbuf )
@@ -1003,12 +1016,12 @@ $ `stdlib/std/tls_verify.nu`
     ( vec_push [u] rec # u 3 )
     ( __u16 rec ( vec_len [u] body ) )
     ( __cat rec body )
-    : !v NetErr w ( tcp_write_all . c tcp rec )
+    : b w ( __tls_sock_write . c fd rec )
     ( vec_free [u] aad )
     ( vec_free [u] body )
     ( vec_free [u] rec )
     = . c c_seq + . c c_seq 1
-    ^ ?? w { T _ → @ !v TlsErr { T 0 } F _ → @ !v TlsErr { F # TlsErr TlsWrite } }
+    ^ ? w @ !v TlsErr { T 0 } @ !v TlsErr { F # TlsErr TlsWrite }
 }
 
 // Decrypt a TLS 1.2 record body (real type `rtype`) → plaintext.

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -113,7 +113,7 @@ $ `stdlib/std/tls_verify.nu`
     ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ 0 }
 }
 
-@ __u16 ( Vec u ) v i n → v {
+@ __tls_u16 ( Vec u ) v i n → v {
     ( vec_push [u] v # u & >> n 8 255 )
     ( vec_push [u] v # u & n 255 )
 }
@@ -124,7 +124,7 @@ $ `stdlib/std/tls_verify.nu`
     ( vec_push [u] v # u & n 255 )
 }
 
-@ __cat ( Vec u ) dst ( Vec u ) src → v {
+@ __tls_cat ( Vec u ) dst ( Vec u ) src → v {
     : i n ( vec_len [u] src )
     : ~ i k 0
     ~ < k n { ( vec_push [u] dst # u ( __t_bget src k ) ) = k + k 1 }
@@ -132,8 +132,8 @@ $ `stdlib/std/tls_verify.nu`
 
 // Append a 2-byte length prefix + the block bytes.
 @ __blk16 ( Vec u ) dst ( Vec u ) sub → v {
-    ( __u16 dst ( vec_len [u] sub ) )
-    ( __cat dst sub )
+    ( __tls_u16 dst ( vec_len [u] sub ) )
+    ( __tls_cat dst sub )
 }
 
 // Read a big-endian integer of `n` bytes from `v` at `off`.
@@ -168,7 +168,7 @@ $ `stdlib/std/tls_verify.nu`
         ? < got 0 { ( vec_free [u] tmp ) ^ @ !i TlsErr { F # TlsErr TlsRead } } {}
         ? == got 0 { ( vec_free [u] tmp ) ^ @ !i TlsErr { F # TlsErr TlsClosed } } {}
         : b _ok ( vec_set_len [u] tmp got )
-        ( __cat . c rxbuf tmp )
+        ( __tls_cat . c rxbuf tmp )
         ( vec_free [u] tmp )
     }
     ^ @ !i TlsErr { T 1 }
@@ -232,7 +232,7 @@ $ `stdlib/std/tls_verify.nu`
     ( vec_push [u] aad # u 23 )
     ( vec_push [u] aad # u 3 )
     ( vec_push [u] aad # u 3 )
-    ( __u16 aad blen )
+    ( __tls_u16 aad blen )
     : ( Vec u ) nonce ( __nonce . c s_iv . c s_seq )
     : ?( Vec u ) pt ( __aead_open . c cipher . c s_key nonce aad body )
     ( vec_free [u] aad )
@@ -255,22 +255,22 @@ $ `stdlib/std/tls_verify.nu`
 // Encrypt + send one record of `content` under the client keys.
 @ __send_encrypted * TlsConn c i content_type ( Vec u ) content → !v TlsErr {
     : ( Vec u ) inner ( vec_with_cap [u] + ( vec_len [u] content ) 1 )
-    ( __cat inner content )
+    ( __tls_cat inner content )
     ( vec_push [u] inner # u content_type )
     : i total + ( vec_len [u] inner ) 16
     : ( Vec u ) aad ( vec_with_cap [u] 5 )
     ( vec_push [u] aad # u 23 )
     ( vec_push [u] aad # u 3 )
     ( vec_push [u] aad # u 3 )
-    ( __u16 aad total )
+    ( __tls_u16 aad total )
     : ( Vec u ) nonce ( __nonce . c c_iv . c c_seq )
     : ( Vec u ) sealed ( __aead_seal . c cipher . c c_key nonce aad inner )
     : ( Vec u ) rec ( vec_with_cap [u] + total 5 )
     ( vec_push [u] rec # u 23 )
     ( vec_push [u] rec # u 3 )
     ( vec_push [u] rec # u 3 )
-    ( __u16 rec total )
-    ( __cat rec sealed )
+    ( __tls_u16 rec total )
+    ( __tls_cat rec sealed )
     : b w ( __tls_sock_write . c fd rec )
     ( vec_free [u] inner )
     ( vec_free [u] aad )
@@ -289,8 +289,8 @@ $ `stdlib/std/tls_verify.nu`
     // record except the initial ClientHello, where 0x0303 is also valid).
     ( vec_push [u] rec # u 3 )
     ( vec_push [u] rec # u 3 )
-    ( __u16 rec ( vec_len [u] body ) )
-    ( __cat rec body )
+    ( __tls_u16 rec ( vec_len [u] body ) )
+    ( __tls_cat rec body )
     : b w ( __tls_sock_write . c fd rec )
     ( vec_free [u] rec )
     ^ ? w @ !v TlsErr { T 0 } @ !v TlsErr { F # TlsErr TlsWrite }
@@ -328,7 +328,7 @@ $ `stdlib/std/tls_verify.nu`
                                 ( vec_free [u] . rec body )
                                 : i ct ( __inner_type inner )
                                 ? == ct 22 {
-                                    ( __cat . c hsbuf inner )
+                                    ( __tls_cat . c hsbuf inner )
                                     ( vec_free [u] inner )
                                 } {
                                     ( vec_free [u] inner )
@@ -344,7 +344,7 @@ $ `stdlib/std/tls_verify.nu`
                     } {
                         // plaintext handshake (ServerHello stage) or alert
                         ? == . rec rtype 22 {
-                            ( __cat . c hsbuf . rec body )
+                            ( __tls_cat . c hsbuf . rec body )
                             ( vec_free [u] . rec body )
                         } {
                             ( vec_free [u] . rec body )
@@ -361,21 +361,21 @@ $ `stdlib/std/tls_verify.nu`
 // ── ClientHello ───────────────────────────────────────────────────
 @ __build_client_hello s host ( Vec u ) pubkey ( Vec u ) p256pub ( Vec u ) random ( Vec u ) sessid → ( Vec u ) {
     : ( Vec u ) body ( vec_new [u] )
-    ( __u16 body 771 )  // legacy_version 0x0303
-    ( __cat body random )  // 32-byte random
+    ( __tls_u16 body 771 )  // legacy_version 0x0303
+    ( __tls_cat body random )  // 32-byte random
     ( vec_push [u] body # u 32 )  // session id length
-    ( __cat body sessid )
+    ( __tls_cat body sessid )
     // cipher_suites: TLS_AES_128_GCM_SHA256 (0x1301) +
     // TLS_CHACHA20_POLY1305_SHA256 (0x1303) — both use the SHA-256 key
     // schedule, so either keeps the rest of the handshake unchanged.
     // 1.3 suites first, then the TLS 1.2 ECDHE suites for fallback.
-    ( __u16 body 12 )
-    ( __u16 body 4865 )  // 0x1301 TLS_AES_128_GCM_SHA256
-    ( __u16 body 4867 )  // 0x1303 TLS_CHACHA20_POLY1305_SHA256
-    ( __u16 body 49195 )  // 0xc02b ECDHE-ECDSA-AES128-GCM-SHA256
-    ( __u16 body 49199 )  // 0xc02f ECDHE-RSA-AES128-GCM-SHA256
-    ( __u16 body 52393 )  // 0xcca9 ECDHE-ECDSA-CHACHA20-POLY1305
-    ( __u16 body 52392 )  // 0xcca8 ECDHE-RSA-CHACHA20-POLY1305
+    ( __tls_u16 body 12 )
+    ( __tls_u16 body 4865 )  // 0x1301 TLS_AES_128_GCM_SHA256
+    ( __tls_u16 body 4867 )  // 0x1303 TLS_CHACHA20_POLY1305_SHA256
+    ( __tls_u16 body 49195 )  // 0xc02b ECDHE-ECDSA-AES128-GCM-SHA256
+    ( __tls_u16 body 49199 )  // 0xc02f ECDHE-RSA-AES128-GCM-SHA256
+    ( __tls_u16 body 52393 )  // 0xcca9 ECDHE-ECDSA-CHACHA20-POLY1305
+    ( __tls_u16 body 52392 )  // 0xcca8 ECDHE-RSA-CHACHA20-POLY1305
     // compression methods
     ( vec_push [u] body # u 1 )
     ( vec_push [u] body # u 0 )
@@ -386,12 +386,12 @@ $ `stdlib/std/tls_verify.nu`
     // server_name (0x0000)
     : ( Vec u ) sni ( vec_new [u] )
     : i hl ( nurl_str_len host )
-    ( __u16 sni + hl 3 )  // ServerNameList length
+    ( __tls_u16 sni + hl 3 )  // ServerNameList length
     ( vec_push [u] sni # u 0 )  // name_type host_name
-    ( __u16 sni hl )
+    ( __tls_u16 sni hl )
     : ~ i k 0
     ~ < k hl { ( vec_push [u] sni # u ( nurl_str_get host k ) ) = k + k 1 }
-    ( __u16 ext 0 )
+    ( __tls_u16 ext 0 )
     ( __blk16 ext sni )
     ( vec_free [u] sni )
 
@@ -399,34 +399,34 @@ $ `stdlib/std/tls_verify.nu`
     // Both are offered so the server can pick whichever it is configured
     // for — PostgreSQL/OpenSSL servers commonly default to P-256.
     : ( Vec u ) grp ( vec_new [u] )
-    ( __u16 grp 4 )
-    ( __u16 grp 29 )  // x25519
-    ( __u16 grp 23 )  // secp256r1
-    ( __u16 ext 10 )
+    ( __tls_u16 grp 4 )
+    ( __tls_u16 grp 29 )  // x25519
+    ( __tls_u16 grp 23 )  // secp256r1
+    ( __tls_u16 ext 10 )
     ( __blk16 ext grp )
     ( vec_free [u] grp )
 
     // signature_algorithms (0x000d)
     : ( Vec u ) sa ( vec_new [u] )
-    ( __u16 sa 16 )  // list length (8 algs × 2)
-    ( __u16 sa 1027 )  // ecdsa_secp256r1_sha256 0x0403
-    ( __u16 sa 2052 )  // rsa_pss_rsae_sha256    0x0804
-    ( __u16 sa 1025 )  // rsa_pkcs1_sha256       0x0401
-    ( __u16 sa 1283 )  // ecdsa_secp384r1_sha384 0x0503
-    ( __u16 sa 2053 )  // rsa_pss_rsae_sha384    0x0805
-    ( __u16 sa 2054 )  // rsa_pss_rsae_sha512    0x0806
-    ( __u16 sa 2055 )  // ed25519                0x0807
-    ( __u16 sa 1281 )  // rsa_pkcs1_sha384       0x0501
-    ( __u16 ext 13 )
+    ( __tls_u16 sa 16 )  // list length (8 algs × 2)
+    ( __tls_u16 sa 1027 )  // ecdsa_secp256r1_sha256 0x0403
+    ( __tls_u16 sa 2052 )  // rsa_pss_rsae_sha256    0x0804
+    ( __tls_u16 sa 1025 )  // rsa_pkcs1_sha256       0x0401
+    ( __tls_u16 sa 1283 )  // ecdsa_secp384r1_sha384 0x0503
+    ( __tls_u16 sa 2053 )  // rsa_pss_rsae_sha384    0x0805
+    ( __tls_u16 sa 2054 )  // rsa_pss_rsae_sha512    0x0806
+    ( __tls_u16 sa 2055 )  // ed25519                0x0807
+    ( __tls_u16 sa 1281 )  // rsa_pkcs1_sha384       0x0501
+    ( __tls_u16 ext 13 )
     ( __blk16 ext sa )
     ( vec_free [u] sa )
 
     // supported_versions (0x002b): TLS 1.3 (0x0304) then TLS 1.2 (0x0303)
     : ( Vec u ) sv ( vec_new [u] )
     ( vec_push [u] sv # u 4 )
-    ( __u16 sv 772 )
-    ( __u16 sv 771 )
-    ( __u16 ext 43 )
+    ( __tls_u16 sv 772 )
+    ( __tls_u16 sv 771 )
+    ( __tls_u16 ext 43 )
     ( __blk16 ext sv )
     ( vec_free [u] sv )
 
@@ -434,7 +434,7 @@ $ `stdlib/std/tls_verify.nu`
     : ( Vec u ) epf ( vec_new [u] )
     ( vec_push [u] epf # u 1 )
     ( vec_push [u] epf # u 0 )
-    ( __u16 ext 11 )
+    ( __tls_u16 ext 11 )
     ( __blk16 ext epf )
     ( vec_free [u] epf )
 
@@ -443,15 +443,15 @@ $ `stdlib/std/tls_verify.nu`
     // we already supplied a matching public key — no HelloRetryRequest.
     : ( Vec u ) ks ( vec_new [u] )
     : ( Vec u ) entry ( vec_new [u] )
-    ( __u16 entry 29 )  // group x25519
-    ( __u16 entry 32 )  // key_exchange length
-    ( __cat entry pubkey )
-    ( __u16 entry 23 )  // group secp256r1
-    ( __u16 entry ( vec_len [u] p256pub ) )  // 65
-    ( __cat entry p256pub )
-    ( __u16 ks ( vec_len [u] entry ) )
-    ( __cat ks entry )
-    ( __u16 ext 51 )
+    ( __tls_u16 entry 29 )  // group x25519
+    ( __tls_u16 entry 32 )  // key_exchange length
+    ( __tls_cat entry pubkey )
+    ( __tls_u16 entry 23 )  // group secp256r1
+    ( __tls_u16 entry ( vec_len [u] p256pub ) )  // 65
+    ( __tls_cat entry p256pub )
+    ( __tls_u16 ks ( vec_len [u] entry ) )
+    ( __tls_cat ks entry )
+    ( __tls_u16 ext 51 )
     ( __blk16 ext ks )
     ( vec_free [u] entry )
     ( vec_free [u] ks )
@@ -463,7 +463,7 @@ $ `stdlib/std/tls_verify.nu`
     : ( Vec u ) hs ( vec_with_cap [u] + ( vec_len [u] body ) 4 )
     ( vec_push [u] hs # u 1 )
     ( __u24 hs ( vec_len [u] body ) )
-    ( __cat hs body )
+    ( __tls_cat hs body )
     ( vec_free [u] body )
     ^ hs
 }
@@ -630,14 +630,14 @@ $ `stdlib/std/tls_verify.nu`
     // ── ClientHello ──
     : ( Vec u ) ch ( __build_client_hello server_name cpub p256pub random sessid )
     ( vec_free [u] p256pub )
-    ( __cat tr ch )
+    ( __tls_cat tr ch )
     : !v TlsErr sw ( __send_plain c 22 ch )
     ?? sw { T _ → {} F e → { ^ ( __fail c priv cpub random sessid ch tr e ) } }
 
     // ── ServerHello ──
     : !( Vec u ) TlsErr shr ( __next_hs c )
     : ( Vec u ) sh ?? shr { T m → m F e → { ^ ( __fail c priv cpub random sessid ch tr e ) } }
-    ( __cat tr sh )
+    ( __tls_cat tr sh )
     : i suite ( __sh_suite sh )
     = . c version ( __suite_version suite )
     = . c cipher ( __suite_cipher suite )
@@ -689,7 +689,7 @@ $ `stdlib/std/tls_verify.nu`
                     : b okfin ( __cmp_finished msg expect )
                     ( vec_free [u] th_cv )
                     ( vec_free [u] expect )
-                    ( __cat tr msg )
+                    ( __tls_cat tr msg )
                     ? okfin {} { = flighterr 1 }
                     = done 1
                 } {
@@ -708,7 +708,7 @@ $ `stdlib/std/tls_verify.nu`
                         ( vec_free [u] . c cv_sig )
                         = . c cv_sig ( bytes_slice msg 8 + 8 siglen )
                     } {}
-                    ( __cat tr msg )
+                    ( __tls_cat tr msg )
                 }
                 ( vec_free [u] msg )
             }
@@ -728,7 +728,7 @@ $ `stdlib/std/tls_verify.nu`
     : ( Vec u ) finmsg ( vec_with_cap [u] 36 )
     ( vec_push [u] finmsg # u 20 )
     ( __u24 finmsg 32 )
-    ( __cat finmsg cfin )
+    ( __tls_cat finmsg cfin )
     // change_cipher_spec for middlebox compatibility
     : ( Vec u ) ccs ( vec_with_cap [u] 1 )
     ( vec_push [u] ccs # u 1 )
@@ -856,7 +856,7 @@ $ `stdlib/std/tls_verify.nu`
                         ?? ( __decrypt_record_12 c . rec rtype . rec body ) {
                             T inner → {
                                 ( vec_free [u] . rec body )
-                                ? == . rec rtype 23 { ( __cat . c appbuf inner ) } {
+                                ? == . rec rtype 23 { ( __tls_cat . c appbuf inner ) } {
                                     ? == . rec rtype 21 { = . c closed 1 } {}
                                     // type 22 (post-handshake, e.g. tickets): ignore
                                 }
@@ -873,7 +873,7 @@ $ `stdlib/std/tls_verify.nu`
                                 ( vec_free [u] . rec body )
                                 : i ct ( __inner_type inner )
                                 ? == ct 23 {
-                                    ( __cat . c appbuf inner )
+                                    ( __tls_cat . c appbuf inner )
                                 } {
                                     ? == ct 21 { = . c closed 1 } {}
                                     // ct == 22 → post-handshake (ticket/key update): ignore
@@ -961,7 +961,7 @@ $ `stdlib/std/tls_verify.nu`
     ( vec_push [u] a # u rtype )
     ( vec_push [u] a # u 3 )
     ( vec_push [u] a # u 3 )
-    ( __u16 a ptlen )
+    ( __tls_u16 a ptlen )
     ^ a
 }
 
@@ -1000,13 +1000,13 @@ $ `stdlib/std/tls_verify.nu`
         // explicit nonce (= seq) is prepended on the wire
         : ~ i b 0
         ~ < b 8 { ( vec_push [u] body # u & >> . c c_seq * 8 - 7 b 255 ) = b + b 1 }
-        ( __cat body sealed )
+        ( __tls_cat body sealed )
         ( vec_free [u] nonce )
         ( vec_free [u] sealed )
     } {
         : ( Vec u ) nonce ( __nonce12_chacha . c c_iv . c c_seq )
         : ( Vec u ) sealed ( aead_encrypt . c c_key nonce aad content )
-        ( __cat body sealed )
+        ( __tls_cat body sealed )
         ( vec_free [u] nonce )
         ( vec_free [u] sealed )
     }
@@ -1014,8 +1014,8 @@ $ `stdlib/std/tls_verify.nu`
     ( vec_push [u] rec # u rtype )
     ( vec_push [u] rec # u 3 )
     ( vec_push [u] rec # u 3 )
-    ( __u16 rec ( vec_len [u] body ) )
-    ( __cat rec body )
+    ( __tls_u16 rec ( vec_len [u] body ) )
+    ( __tls_cat rec body )
     : b w ( __tls_sock_write . c fd rec )
     ( vec_free [u] aad )
     ( vec_free [u] body )
@@ -1119,13 +1119,13 @@ $ `stdlib/std/tls_verify.nu`
                     ( bytes_extend_bytes signed random )
                     ( bytes_extend_bytes signed srand )
                     : ( Vec u ) eparams ( bytes_slice msg 4 + 8 pklen )
-                    ( __cat signed eparams )
+                    ( __tls_cat signed eparams )
                     ( vec_free [u] eparams )
                     ( vec_free [u] . c th_cert )
                     = . c th_cert signed
                 } {}
                 ? == t 14 { = done 1 } {}
-                ( __cat tr msg )
+                ( __tls_cat tr msg )
                 ( vec_free [u] msg )
             }
         }
@@ -1156,13 +1156,13 @@ $ `stdlib/std/tls_verify.nu`
     ( vec_push [u] cke # u 16 )
     ( __u24 cke + cklen 1 )
     ( vec_push [u] cke # u cklen )
-    ( __cat cke ckpub )
+    ( __tls_cat cke ckpub )
     // ckpub is a fresh P-256 point we own; the x25519 case aliases cpub
     // (freed with the other handshake scratch later), so only free P-256.
     ? is_p256 { ( vec_free [u] ckpub ) } {}
     : !v TlsErr ckw ( __send_plain c 22 cke )
     ?? ckw { T _ → {} F _ → {} }
-    ( __cat tr cke )
+    ( __tls_cat tr cke )
 
     // ── ChangeCipherSpec + client Finished (encrypted) ──
     : ( Vec u ) ccs ( vec_with_cap [u] 1 )
@@ -1177,11 +1177,11 @@ $ `stdlib/std/tls_verify.nu`
     : ( Vec u ) finmsg ( vec_with_cap [u] 16 )
     ( vec_push [u] finmsg # u 20 )
     ( __u24 finmsg 12 )
-    ( __cat finmsg cfin_vd )
+    ( __tls_cat finmsg cfin_vd )
     ( vec_free [u] cfin_vd )
     : !v TlsErr fw ( __send_record_12 c 22 finmsg )
     ?? fw { T _ → {} F _ → {} }
-    ( __cat tr finmsg )
+    ( __tls_cat tr finmsg )
     ( vec_free [u] finmsg )
 
     // ── server ChangeCipherSpec + Finished ──

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -24,7 +24,6 @@
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
-$ `stdlib/std/net.nu`
 $ `stdlib/std/tls.nu`
 $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/hkdf.nu`
@@ -56,14 +55,14 @@ $ `stdlib/std/aes_gcm.nu`
     ( vec_push [u] rec # u 3 )
     ( __u16 rec total )
     ( __cat rec sealed )
-    : !v NetErr w ( tcp_write_all . c tcp rec )
+    : b w ( __tls_sock_write . c fd rec )
     ( vec_free [u] inner )
     ( vec_free [u] aad )
     ( vec_free [u] nonce )
     ( vec_free [u] sealed )
     ( vec_free [u] rec )
     = . c s_seq + . c s_seq 1
-    ^ ?? w { T _ → @ !v TlsErr { T 0 } F _ → @ !v TlsErr { F # TlsErr TlsWrite } }
+    ^ ? w @ !v TlsErr { T 0 } @ !v TlsErr { F # TlsErr TlsWrite }
 }
 
 // AEAD-decrypt one record body under the CLIENT write keys (c_key/c_iv/c_seq).
@@ -218,7 +217,7 @@ $ `stdlib/std/aes_gcm.nu`
 @ tls_accept i raw ( Vec u ) cert_chain ( Vec u ) priv → !*TlsConn TlsErr {
     ? <= raw 0 { ^ @ !*TlsConn TlsErr { F # TlsErr TlsConnect } } {}
     : *TlsConn c ( nurl_alloc Z TlsConn )
-    = . c tcp @ TcpConn { # s raw }
+    = . c fd raw
     = . c rxbuf ( vec_new [u] )
     = . c hsbuf ( vec_new [u] )
     = . c appbuf ( vec_new [u] )

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -39,22 +39,22 @@ $ `stdlib/std/aes_gcm.nu`
 // Encrypt + send one record under the SERVER write keys (s_key/s_iv/s_seq).
 @ __srv_send_enc * TlsConn c i content_type ( Vec u ) content → !v TlsErr {
     : ( Vec u ) inner ( vec_with_cap [u] + ( vec_len [u] content ) 1 )
-    ( __cat inner content )
+    ( __tls_cat inner content )
     ( vec_push [u] inner # u content_type )
     : i total + ( vec_len [u] inner ) 16
     : ( Vec u ) aad ( vec_with_cap [u] 5 )
     ( vec_push [u] aad # u 23 )
     ( vec_push [u] aad # u 3 )
     ( vec_push [u] aad # u 3 )
-    ( __u16 aad total )
+    ( __tls_u16 aad total )
     : ( Vec u ) nonce ( __nonce . c s_iv . c s_seq )
     : ( Vec u ) sealed ( __aead_seal . c cipher . c s_key nonce aad inner )
     : ( Vec u ) rec ( vec_with_cap [u] + total 5 )
     ( vec_push [u] rec # u 23 )
     ( vec_push [u] rec # u 3 )
     ( vec_push [u] rec # u 3 )
-    ( __u16 rec total )
-    ( __cat rec sealed )
+    ( __tls_u16 rec total )
+    ( __tls_cat rec sealed )
     : b w ( __tls_sock_write . c fd rec )
     ( vec_free [u] inner )
     ( vec_free [u] aad )
@@ -72,7 +72,7 @@ $ `stdlib/std/aes_gcm.nu`
     ( vec_push [u] aad # u 23 )
     ( vec_push [u] aad # u 3 )
     ( vec_push [u] aad # u 3 )
-    ( __u16 aad blen )
+    ( __tls_u16 aad blen )
     : ( Vec u ) nonce ( __nonce . c c_iv . c c_seq )
     : ?( Vec u ) pt ( __aead_open . c cipher . c c_key nonce aad body )
     ( vec_free [u] aad )
@@ -111,7 +111,7 @@ $ `stdlib/std/aes_gcm.nu`
                                 ( vec_free [u] . rec body )
                                 : i ct ( __inner_type inner )
                                 ? == ct 22 {
-                                    ( __cat . c hsbuf inner )
+                                    ( __tls_cat . c hsbuf inner )
                                     ( vec_free [u] inner )
                                 } {
                                     ( vec_free [u] inner )
@@ -126,7 +126,7 @@ $ `stdlib/std/aes_gcm.nu`
                         }
                     } {
                         ? == . rec rtype 22 {
-                            ( __cat . c hsbuf . rec body )
+                            ( __tls_cat . c hsbuf . rec body )
                             ( vec_free [u] . rec body )
                         } {
                             ( vec_free [u] . rec body )
@@ -162,7 +162,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) hs ( vec_with_cap [u] + ( vec_len [u] body ) 4 )
     ( vec_push [u] hs # u htype )
     ( __u24 hs ( vec_len [u] body ) )
-    ( __cat hs body )
+    ( __tls_cat hs body )
     ^ hs
 }
 
@@ -190,7 +190,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) out ( vec_with_cap [u] + ( vec_len [u] inner ) 2 )
     ( vec_push [u] out # u 48 )
     ( vec_push [u] out # u ( vec_len [u] inner ) )
-    ( __cat out inner )
+    ( __tls_cat out inner )
     ( vec_free [u] r ) ( vec_free [u] sv ) ( vec_free [u] inner )
     ^ out
 }
@@ -203,7 +203,7 @@ $ `stdlib/std/aes_gcm.nu`
     ~ < k 64 { ( vec_push [u] m # u 32 ) = k + k 1 }
     ( bytes_extend_str m `TLS 1.3, server CertificateVerify` )
     ( vec_push [u] m # u 0 )
-    ( __cat m th )
+    ( __tls_cat m th )
     ^ m
 }
 
@@ -238,7 +238,7 @@ $ `stdlib/std/aes_gcm.nu`
         ( vec_free [u] ch ) ( vec_free [u] tr ) ( nurl_free # s c )
         ^ ( __srv_fail raw )
     } {}
-    ( __cat tr ch )
+    ( __tls_cat tr ch )
 
     : ( Vec u ) crand ( bytes_slice ch 6 38 )
     : i sidlen ( __t_bget ch 38 )
@@ -296,7 +296,7 @@ $ `stdlib/std/aes_gcm.nu`
     // ── ServerHello ──
     : ( Vec u ) srand ( __srv_rand 32 )
     : ( Vec u ) sh ( __srv_build_sh srand ch sidlen suite grp spub )
-    ( __cat tr sh )
+    ( __tls_cat tr sh )
     : !v TlsErr shw ( __send_plain c 22 sh )
     ?? shw { T _ → {} F _ → {
             ( __srv_cleanup_accept ch crand cpub eph spub ecdhe srand sh tr )
@@ -328,9 +328,9 @@ $ `stdlib/std/aes_gcm.nu`
 
     // ── EncryptedExtensions (empty) ──
     : ( Vec u ) eebody ( vec_new [u] )
-    ( __u16 eebody 0 )
+    ( __tls_u16 eebody 0 )
     : ( Vec u ) ee ( __srv_hs_wrap 8 eebody )
-    ( __cat tr ee )
+    ( __tls_cat tr ee )
     : !v TlsErr eew ( __srv_send_enc c 22 ee )
     ?? eew { T _ → {} F _ → {} }
     ( vec_free [u] eebody )
@@ -340,12 +340,12 @@ $ `stdlib/std/aes_gcm.nu`
     ( vec_push [u] certbody # u 0 )  // certificate_request_context = empty
     : ( Vec u ) clist ( vec_new [u] )
     ( __u24 clist ( vec_len [u] cert_chain ) )
-    ( __cat clist cert_chain )
-    ( __u16 clist 0 )  // per-cert extensions = empty
+    ( __tls_cat clist cert_chain )
+    ( __tls_u16 clist 0 )  // per-cert extensions = empty
     ( __u24 certbody ( vec_len [u] clist ) )
-    ( __cat certbody clist )
+    ( __tls_cat certbody clist )
     : ( Vec u ) certmsg ( __srv_hs_wrap 11 certbody )
-    ( __cat tr certmsg )
+    ( __tls_cat tr certmsg )
     : !v TlsErr cw ( __srv_send_enc c 22 certmsg )
     ?? cw { T _ → {} F _ → {} }
     ( vec_free [u] clist ) ( vec_free [u] certbody )
@@ -357,11 +357,11 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) rs ( ecdsa_p256_sign priv cvdig )
     : ( Vec u ) der ( __srv_der_ecdsa rs )
     : ( Vec u ) cvbody ( vec_new [u] )
-    ( __u16 cvbody 1027 )  // ecdsa_secp256r1_sha256 = 0x0403
-    ( __u16 cvbody ( vec_len [u] der ) )
-    ( __cat cvbody der )
+    ( __tls_u16 cvbody 1027 )  // ecdsa_secp256r1_sha256 = 0x0403
+    ( __tls_u16 cvbody ( vec_len [u] der ) )
+    ( __tls_cat cvbody der )
     : ( Vec u ) cvmsg ( __srv_hs_wrap 15 cvbody )
-    ( __cat tr cvmsg )
+    ( __tls_cat tr cvmsg )
     : !v TlsErr cvw ( __srv_send_enc c 22 cvmsg )
     ?? cvw { T _ → {} F _ → {} }
     ( vec_free [u] th_cert ) ( vec_free [u] cvc ) ( vec_free [u] cvdig )
@@ -371,7 +371,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) th_cv ( sha256_pure tr )
     : ( Vec u ) sfin ( __finished_mac s_hs th_cv )
     : ( Vec u ) sfmsg ( __srv_hs_wrap 20 sfin )
-    ( __cat tr sfmsg )
+    ( __tls_cat tr sfmsg )
     : !v TlsErr sfw ( __srv_send_enc c 22 sfmsg )
     ?? sfw { T _ → {} F _ → {} }
     ( vec_free [u] th_cv )
@@ -437,23 +437,23 @@ $ `stdlib/std/aes_gcm.nu`
 // Build the ServerHello handshake message.
 @ __srv_build_sh ( Vec u ) srand ( Vec u ) ch i sidlen i suite i grp ( Vec u ) spub → ( Vec u ) {
     : ( Vec u ) body ( vec_new [u] )
-    ( __u16 body 771 )  // legacy_version 0x0303
-    ( __cat body srand )  // 32-byte random
+    ( __tls_u16 body 771 )  // legacy_version 0x0303
+    ( __tls_cat body srand )  // 32-byte random
     ( vec_push [u] body # u sidlen )  // echo legacy session id
     : ~ i k 0
     ~ < k sidlen { ( vec_push [u] body # u ( __t_bget ch + 39 k ) ) = k + k 1 }
-    ( __u16 body suite )  // cipher suite
+    ( __tls_u16 body suite )  // cipher suite
     ( vec_push [u] body # u 0 )  // compression = null
     // extensions: supported_versions (0x002b)=0x0304 + key_share (0x0033)
     : ( Vec u ) ext ( vec_new [u] )
-    ( __u16 ext 43 )
-    ( __u16 ext 2 )
-    ( __u16 ext 772 )  // 0x0304 TLS 1.3
-    ( __u16 ext 51 )
-    ( __u16 ext + 4 ( vec_len [u] spub ) )
-    ( __u16 ext grp )
-    ( __u16 ext ( vec_len [u] spub ) )
-    ( __cat ext spub )
+    ( __tls_u16 ext 43 )
+    ( __tls_u16 ext 2 )
+    ( __tls_u16 ext 772 )  // 0x0304 TLS 1.3
+    ( __tls_u16 ext 51 )
+    ( __tls_u16 ext + 4 ( vec_len [u] spub ) )
+    ( __tls_u16 ext grp )
+    ( __tls_u16 ext ( vec_len [u] spub ) )
+    ( __tls_cat ext spub )
     ( __blk16 body ext )
     ( vec_free [u] ext )
     : ( Vec u ) hs ( __srv_hs_wrap 2 body )
@@ -485,7 +485,7 @@ $ `stdlib/std/aes_gcm.nu`
                         T inner → {
                             ( vec_free [u] . rec body )
                             : i ct ( __inner_type inner )
-                            ? == ct 23 { ( __cat . c appbuf inner ) } {
+                            ? == ct 23 { ( __tls_cat . c appbuf inner ) } {
                                 ? == ct 21 { = . c closed 1 } {}
                             }
                             ( vec_free [u] inner )


### PR DESCRIPTION
Wires the pure TLS stack into `net.nu` so `TcpConn` transparently does pure TLS — `http_server` and anything on `TcpConn` now gets **pure HTTPS with no source change**. Along the way it fixes a real compiler bug. This is the infrastructure stage of removing libssl (the legacy client-TLS consumers still use the runtime OpenSSL FFI and keep working; migrating them + deleting `SSL_*` from `runtime.c` is the next stage).

## Compiler fix — multi-field struct through a `Result`
A multi-field value struct returned via `! T E` dropped every field after field 0. The `! T E` payload store/reconstruct chose between "store field 0 inline" (for single-pointer handles like `Vec`/`String`/`Response`) and "heap-box the whole struct" by asking **is field 0 a pointer?** — so a multi-field struct whose f0 is a pointer (e.g. `{ s raw i a i b … }`) wrongly took the inline path and lost fields 1.. Fix: discriminate on **field count == 1** in both `gen_match` reconstruction and the payload-store coercion. (`Option` already round-tripped these.)
- New corpus test `result_struct_payload.nu`; semantics-preserving for the single-field cases, so the bootstrap fixed point holds.

## net.nu — polymorphic pure TLS
- Stage 1: `tls.nu` / `tls_server.nu` made self-contained over the libc socket (raw `nurl_tcp_*`), dropping their `net.nu` import — this breaks the `net↔tls` cycle so `net.nu` can import them.
- `TcpConn` gains `kind` (0 plain / 1 TLS-client / 2 TLS-server) + a `*TlsConn`; `tcp_read_chunk`/`tcp_write_all`/`tcp_write_str`/`tcp_close_conn` dispatch to the pure stack.
- `tcp_listen_tls` loads the PEM cert+key purely (`std/pkey`) and `tcp_accept` runs the pure handshake → kind-2 conn. New `tcp_connect_tls` → pure verify-full/insecure client → kind-1.
- ALPN / SNI / peer-cert-subject degrade to no-op on the pure path for now (planned follow-ups).

### Live validation
- A net.nu HTTPS server (`tcp_listen_tls` → `tcp_accept` → `tcp_read`/`write`) served `curl` → `net.nu pure!`.
- `tcp_connect_tls` fetched `https://example.com` → 200 OK (verify-full).
- Full corpus green, examples gate green (89), bootstrap fixed point holds; psql + redis packages compile against the new net.nu.

### Housekeeping
Renamed `tls.nu`'s generic `__cat`/`__u16` → `__tls_cat`/`__tls_u16` (collided with `net/noise.nu` + `net/stun.nu` once net.nu pulled tls.nu) and repointed `psql/pg.nu` (which had leaked onto tls.nu's `__cat`) to public `bytes_extend_bytes`; renamed mqtt's local `tcp_connect_tls` → `__mqtt_connect_tls`.

## Next (to actually drop `-lssl -lcrypto`)
Migrate smtp / mqtt / websocket / http2_client onto `tcp_connect_tls` (+ ALPN on the pure client for `h2`), then delete the `SSL_*` / dlopen-vtable from `runtime.c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yovb87eAvBUYmd1UEGCPR