### PR TITLE
§8 P4 Stage 3+4: migrate TLS consumers to pure stack, remove libssl/libcrypto

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -148,23 +148,16 @@ rm -f stdlib/runtime.curl
 CURL_CFLAGS=""
 CURL_LIBS=""
 
-# ── libssl detection ─────────────────────────────────────────
-# Same pattern as libcurl. With openssl present, the runtime's
-# tcp_listen_tls / accept-with-handshake / SSL_read / SSL_write
-# paths compile in; without it, the symbols still exist but every
-# call returns NetErr::TLS_CONTEXT_INIT and the link line skips
-# -lssl -lcrypto.
+# ── libssl: REMOVED (§8 P4) ──────────────────────────────────
+# All TLS — client AND server, handshake + record layer + X.509 — is
+# now pure NURL (stdlib/std/tls.nu, tls_server.nu, and the crypto in
+# stdlib/std/*). The runtime no longer touches OpenSSL, so the default
+# build links neither -lssl nor -lcrypto and NURL_HAVE_OPENSSL is never
+# defined. The dead #ifdef NURL_HAVE_OPENSSL blocks in runtime.c are
+# retained only as historical reference and compile out unconditionally.
 OPENSSL_CFLAGS=""
 OPENSSL_LIBS=""
-if pkg-config --exists openssl 2>/dev/null; then
-    OPENSSL_CFLAGS="-DNURL_HAVE_OPENSSL $(pkg-config --cflags openssl)"
-    OPENSSL_LIBS="$(pkg-config --libs openssl)"
-    echo 1 > stdlib/runtime.openssl
-    log "[info] openssl detected — TLS transport enabled (server-side)"
-else
-    rm -f stdlib/runtime.openssl
-    log "[info] openssl not found — tcp_listen_tls will return NetErr::TLS_CONTEXT_INIT"
-fi
+rm -f stdlib/runtime.openssl
 
 # ── libsqlite3 detection ─────────────────────────────────────
 # Same pattern as libcurl / openssl. With sqlite3 present, the

--- a/nurl.sh
+++ b/nurl.sh
@@ -313,7 +313,6 @@ add_feature_lib() {
     fi
     return 0
 }
-add_feature_lib runtime.openssl -lssl -lcrypto
 add_feature_lib runtime.sqlite3 -lsqlite3
 add_feature_lib runtime.pq      -lpq
 add_feature_lib runtime.zstd    -lzstd
@@ -363,7 +362,7 @@ if [ "${NURL_SAN:-0}" = "1" ]; then
     if [ ! -f "$SAN_RUNTIME" ] || [ "$SCRIPT_DIR/stdlib/runtime.c" -nt "$SAN_RUNTIME" ]; then
         echo "[runtime-san] rebuilding stdlib/runtime_san.o (non-LTO, with ASan+UBSan)"
         CFLAGS_SAN="-O1 -g -fsanitize=address,undefined -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-sanitize-recover=all"
-        for sentinel_flag in NURL_HAVE_OPENSSL:openssl NURL_HAVE_SQLITE3:sqlite3; do
+        for sentinel_flag in NURL_HAVE_SQLITE3:sqlite3; do
             d="${sentinel_flag%%:*}"; p="${sentinel_flag##*:}"
             if pkg-config --exists "$p" 2>/dev/null; then
                 CFLAGS_SAN="$CFLAGS_SAN -D$d $(pkg-config --cflags "$p")"
@@ -379,7 +378,7 @@ elif [ $DEBUG_INFO -eq 1 ]; then
     if [ ! -f "$DBG_RUNTIME" ] || [ "$SCRIPT_DIR/stdlib/runtime.c" -nt "$DBG_RUNTIME" ]; then
         echo "[runtime-debug] rebuilding stdlib/runtime_debug.o (non-LTO, with -g)"
         CFLAGS_DBG="-O0 -g"
-        for sentinel_flag in NURL_HAVE_OPENSSL:openssl NURL_HAVE_SQLITE3:sqlite3; do
+        for sentinel_flag in NURL_HAVE_SQLITE3:sqlite3; do
             d="${sentinel_flag%%:*}"; p="${sentinel_flag##*:}"
             if pkg-config --exists "$p" 2>/dev/null; then
                 CFLAGS_DBG="$CFLAGS_DBG -D$d $(pkg-config --cflags "$p")"

--- a/stdlib/ext/http2_client.nu
+++ b/stdlib/ext/http2_client.nu
@@ -67,14 +67,10 @@ $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http2_frame.nu`
 $ `stdlib/ext/http2_hpack.nu`
 
-// Client-side connect primitives. nurl_tcp_connect / *_tls_alpn are NOT
-// in the compiler's runtime symbol table (unlike nurl_tcp_close /
-// nurl_tcp_err_kind / nurl_tcp_alpn_selected), so we declare them here
-// the same way websocket.nu does. nurl_tcp_connect_tls_alpn was added
-// to stdlib/runtime.c alongside the existing connect helpers.
+// Plaintext connect primitive (nurl_tcp_connect is not in the compiler's
+// runtime symbol table, so declare it here). TLS-with-ALPN now goes
+// through net.nu's pure tcp_connect_tls_alpn — no runtime SSL.
 & `libc` @ nurl_tcp_connect s host i port → i
-
-& `libc` @ nurl_tcp_connect_tls_alpn s host i port i verify s alpn → i
 
 // ── Errors ────────────────────────────────────────────────────────────
 
@@ -475,18 +471,10 @@ $ `stdlib/ext/http2_hpack.nu`
 
 @ h2_client_connect_tls s host i port b verify → !H2Client H2ClientErr {
     : i v ? verify 1 0
-    : i craw ( nurl_tcp_connect_tls_alpn host port v `h2` )
-    ? == craw 0 {
-        ^ @ !H2Client H2ClientErr { F # H2ClientErr H2CConnect }
-    } {}
-    : i ek ( nurl_tcp_err_kind craw )
-    ? != ek 0 {
-        ( nurl_tcp_close craw )
-        : H2ClientErr e ? == ek 12 # H2ClientErr H2CTls # H2ClientErr H2CConnect
-        ^ @ !H2Client H2ClientErr { F e }
-    } {}
-    : s rp # s craw
-    : TcpConn conn @ TcpConn { rp 0 0 }
+    : TcpConn conn ?? ( tcp_connect_tls_alpn host port host v `h2` ) {
+        F e → ^ @ !H2Client H2ClientErr { F ?? e { NetTlsHandshake → # H2ClientErr H2CTls _ → # H2ClientErr H2CConnect } }
+        T c → c
+    }
     // Confirm ALPN actually selected h2 — otherwise the peer would speak
     // HTTP/1.1 and our framing would be garbage.
     : String proto ( tcp_alpn_protocol conn )

--- a/stdlib/ext/mqtt.nu
+++ b/stdlib/ext/mqtt.nu
@@ -139,29 +139,21 @@ $ `stdlib/ext/websocket.nu`
     ^ # MqttErr MqttRefused
 }
 
-// ── client-side connect (runtime.c §18b/§18c) ────────────────────────
+// ── client-side connect ──────────────────────────────────────────────
 //
-// runtime.o exports `nurl_tcp_connect` / `nurl_tcp_connect_tls` (both
-// return a CONN-kind handle as i64; err_kind != 0 means the connect /
-// TLS handshake failed). Their `& `libc`` extern declarations come in
-// via the websocket.nu import above — declaring them again here would be
-// a duplicate symbol in the merged module, so we rely on that one copy.
+// Plaintext connect uses runtime.o's `nurl_tcp_connect` (declared via the
+// websocket.nu import above). TLS goes through net.nu's pure
+// `tcp_connect_tls` — no runtime SSL.
 
 // Open a TLS client connection. `verify` T = check the broker cert
 // chain + hostname against the system trust store; F = encrypt but
 // don't validate the chain (an MQTT client's `--insecure`).
 @ __mqtt_connect_tls s host i port b verify → !TcpConn MqttErr {
-    : i vflag ? verify 1 0
-    : i craw ( nurl_tcp_connect_tls host port vflag )
-    ? == craw 0 { ^ @ !TcpConn MqttErr { F # MqttErr MqttTransport } } {}
-    : i ek ( nurl_tcp_err_kind craw )
-    ? != ek 0 {
-        ( nurl_tcp_close craw )
-        ^ @ !TcpConn MqttErr { F ( __mqtt_of_net ( __net_err_of ek ) ) }
-    } {}
-    : s crp # s craw
-    : TcpConn c @ TcpConn { crp 0 0 }
-    ^ @ !TcpConn MqttErr { T c }
+    // Pure TLS via net.nu (SNI = host); cert verification on unless verify=F.
+    ?? ( tcp_connect_tls host port host ? verify 1 0 ) {
+        F e → ^ @ !TcpConn MqttErr { F ( __mqtt_of_net e ) }
+        T c → ^ @ !TcpConn MqttErr { T c }
+    }
 }
 
 // Open a plain (unencrypted) TCP client connection — port 1883.

--- a/stdlib/ext/smtp.nu
+++ b/stdlib/ext/smtp.nu
@@ -3,9 +3,10 @@
 // A submission client: dial a mail server, optionally upgrade the
 // plaintext connection to TLS with STARTTLS (RFC 3207), authenticate
 // (AUTH PLAIN / AUTH LOGIN, RFC 4954), and submit a message. Built on
-// the runtime's client-side TCP/TLS connect (net.nu's TcpConn for
-// read/write) plus a new `nurl_tcp_starttls` that upgrades an
-// already-open fd in place. A minimal MIME builder (`mime_build`)
+// net.nu's polymorphic TcpConn for read/write, with the pure-NURL TLS
+// stack underneath: `tcp_connect_tls` for implicit TLS and
+// `tcp_starttls` to upgrade an already-open fd in place (no OpenSSL).
+// A minimal MIME builder (`mime_build`)
 // produces a well-formed text/plain message; `smtp_dotstuff` applies
 // the transparency rules (RFC 5321 §4.5.2) the DATA phase requires.
 //
@@ -42,10 +43,6 @@ $ `stdlib/std/time.nu`  // smtp_date_now
 // nurl_tcp_err_kind are nurlc builtins; the two connect calls and the
 // STARTTLS upgrade need `& `libc`` extern declarations.
 & `libc` @ nurl_tcp_connect s host i port → i
-
-& `libc` @ nurl_tcp_connect_tls s host i port i verify → i
-
-& `libc` @ nurl_tcp_starttls i conn s host i verify → i
 
 : | SmtpErr {
     SmtpConnect  // TCP connect failed
@@ -221,15 +218,9 @@ $ `stdlib/std/time.nu`  // smtp_date_now
     ( string_free . c last_reply )
 }
 
-@ __smtp_after_connect i craw → !SmtpClient SmtpErr {
-    ? == craw 0 { ^ @ !SmtpClient SmtpErr { F # SmtpErr SmtpConnect } } {}
-    : i ek ( nurl_tcp_err_kind craw )
-    ? != ek 0 {
-        ( nurl_tcp_close craw )
-        ^ @ !SmtpClient SmtpErr { F # SmtpErr SmtpConnect }
-    } {}
-    : s crp # s craw
-    : TcpConn conn @ TcpConn { crp 0 0 }
+// Wrap a connected (plain or TLS) TcpConn into an SmtpClient and read
+// the server's 220 greeting.
+@ __smtp_greet TcpConn conn → !SmtpClient SmtpErr {
     : SmtpClient c @ SmtpClient { conn ( vec_new [u] ) ( string_with_cap 128 ) }
     : !i SmtpErr g ( __smtp_read_reply c )
     ^ ?? g {
@@ -239,11 +230,21 @@ $ `stdlib/std/time.nu`  // smtp_date_now
 }
 
 @ smtp_connect s host i port → !SmtpClient SmtpErr {
-    ^ ( __smtp_after_connect ( nurl_tcp_connect host port ) )
+    : i craw ( nurl_tcp_connect host port )
+    ? == craw 0 { ^ @ !SmtpClient SmtpErr { F # SmtpErr SmtpConnect } } {}
+    : i ek ( nurl_tcp_err_kind craw )
+    ? != ek 0 {
+        ( nurl_tcp_close craw )
+        ^ @ !SmtpClient SmtpErr { F # SmtpErr SmtpConnect }
+    } {}
+    ^ ( __smtp_greet @ TcpConn { # s craw 0 0 } )
 }
 
 @ smtp_connect_tls s host i port b verify → !SmtpClient SmtpErr {
-    ^ ( __smtp_after_connect ( nurl_tcp_connect_tls host port ? verify 1 0 ) )
+    ?? ( tcp_connect_tls host port host ? verify 1 0 ) {
+        F _ → ^ @ !SmtpClient SmtpErr { F # SmtpErr SmtpConnect }
+        T conn → ^ ( __smtp_greet conn )
+    }
 }
 
 @ smtp_ehlo SmtpClient c s domain → !v SmtpErr {
@@ -268,11 +269,10 @@ $ `stdlib/std/time.nu`  // smtp_date_now
     ? ( smtp_has_cap c `STARTTLS` ) {} { ^ @ !v SmtpErr { F # SmtpErr SmtpNoStartTls } }
     : !v SmtpErr r ( __smtp_expect c `STARTTLS` 220 # SmtpErr SmtpProtocol )
     ?? r { T _ → {} F er → { ^ @ !v SmtpErr { F er } } }
-    : TcpConn cn . c conn
-    : i raw # i . cn raw
-    : i _h ( nurl_tcp_starttls raw host ? verify 1 0 )
-    : i ek ( nurl_tcp_err_kind raw )
-    ? != ek 0 { ^ @ !v SmtpErr { F # SmtpErr SmtpTls } } {}
+    ?? ( tcp_starttls . c conn host verify ) {
+        F _ → ^ @ !v SmtpErr { F # SmtpErr SmtpTls }
+        T _ → {}
+    }
     ^ ( smtp_ehlo c host )
 }
 

--- a/stdlib/ext/websocket.nu
+++ b/stdlib/ext/websocket.nu
@@ -1293,8 +1293,6 @@ $ `stdlib/ext/compress.nu`
 
 & `libc` @ nurl_tcp_connect s host i port → i
 
-& `libc` @ nurl_tcp_connect_tls s host i port i verify → i
-
 // A connected, handshaken client. Wraps the underlying TcpConn so the
 // frame API can be reached via `( ws_client_conn c )` and the link torn
 // down with `ws_client_close`.
@@ -1718,32 +1716,38 @@ $ `stdlib/ext/compress.nu`
     ^ ( ws_connect_with url @ ?String { F } )
 }
 
+// Open the WS transport: pure TLS (wss) via net.nu's tcp_connect_tls, or
+// a plain TCP conn (ws). Returns a polymorphic TcpConn or None on failure.
+@ __ws_open_conn WsUrl u → ?TcpConn {
+    ? . u tls {
+        ?? ( tcp_connect_tls ( string_data . u host ) . u port ( string_data . u host ) 1 ) {
+            F _ → ^ @ ?TcpConn { F # TcpConn 0 }
+            T c → ^ @ ?TcpConn { T c }
+        }
+    } {}
+    : i craw ( nurl_tcp_connect ( string_data . u host ) . u port )
+    ? == craw 0 { ^ @ ?TcpConn { F # TcpConn 0 } } {}
+    : i ek ( nurl_tcp_err_kind craw )
+    ? != ek 0 { ( nurl_tcp_close craw ) ^ @ ?TcpConn { F # TcpConn 0 } } {}
+    ^ @ ?TcpConn { T @ TcpConn { # s craw 0 0 } }
+}
+
 @ ws_connect_with s url ? String subprotocol → !WsClient WsErr {
     : ?WsUrl pu ( __ws_parse_url url )
     ?? pu {
         T u → {
-            : i craw ? . u tls
-            ( nurl_tcp_connect_tls ( string_data . u host ) . u port 1 )
-            ( nurl_tcp_connect ( string_data . u host ) . u port )
-            ? == craw 0 {
-                ( ws_url_free u )
-                ^ @ !WsClient WsErr { F WsConnectFailed }
-            } {}
-            : i ek ( nurl_tcp_err_kind craw )
-            ? != ek 0 {
-                ( nurl_tcp_close craw )
-                ( ws_url_free u )
-                ^ @ !WsClient WsErr { F WsConnectFailed }
-            } {}
-            : s crp # s craw
-            : TcpConn conn @ TcpConn { crp 0 0 }
-            : !v WsErr hsr ( ws_client_handshake conn ( string_data . u host ) ( string_data . u path ) subprotocol )
-            ( ws_url_free u )
-            ?? hsr {
-                T _ → { ^ @ !WsClient WsErr { T @ WsClient { conn } } }
-                F e → {
-                    ( tcp_close_conn conn )
-                    ^ @ !WsClient WsErr { F e }
+            ?? ( __ws_open_conn u ) {
+                F _ → { ( ws_url_free u ) ^ @ !WsClient WsErr { F WsConnectFailed } }
+                T conn → {
+                    : !v WsErr hsr ( ws_client_handshake conn ( string_data . u host ) ( string_data . u path ) subprotocol )
+                    ( ws_url_free u )
+                    ?? hsr {
+                        T _ → { ^ @ !WsClient WsErr { T @ WsClient { conn } } }
+                        F e → {
+                            ( tcp_close_conn conn )
+                            ^ @ !WsClient WsErr { F e }
+                        }
+                    }
                 }
             }
         }
@@ -2377,21 +2381,12 @@ $ `stdlib/ext/compress.nu`
     ?? pu {
         F _ → { ^ @ !WsDeflateConn WsErr { F WsBadUrl } }
         T u → {
-            : i craw ? . u tls
-            ( nurl_tcp_connect_tls ( string_data . u host ) . u port 1 )
-            ( nurl_tcp_connect ( string_data . u host ) . u port )
-            ? == craw 0 {
+            : ?TcpConn copt ( __ws_open_conn u )
+            ? ?? copt { T _ → 0 F _ → 1 } {
                 ( ws_url_free u )
                 ^ @ !WsDeflateConn WsErr { F WsConnectFailed }
             } {}
-            : i ek ( nurl_tcp_err_kind craw )
-            ? != ek 0 {
-                ( nurl_tcp_close craw )
-                ( ws_url_free u )
-                ^ @ !WsDeflateConn WsErr { F WsConnectFailed }
-            } {}
-            : s crp # s craw
-            : TcpConn conn @ TcpConn { crp 0 0 }
+            : TcpConn conn ?? copt { T c → c F _ → @ TcpConn { # s 0 0 0 } }
             : !WsDeflateConfig WsErr hsr ( ws_client_handshake_deflate conn ( string_data . u host ) ( string_data . u path ) subprotocol cfg )
             ( ws_url_free u )
             ?? hsr {

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -2079,165 +2079,6 @@ long long nurl_rand_fill(unsigned char *buf, long long n) {
 #define NURL_NET_ERR_TLS_KEY_LOAD   11
 #define NURL_NET_ERR_TLS_HANDSHAKE  12
 
-#ifdef NURL_HAVE_OPENSSL
-#include <openssl/ssl.h>
-#include <openssl/err.h>
-
-/* OpenSSL is resolved entirely at runtime via dlopen/dlsym, so runtime.o
- * carries ZERO link-time references to libssl/libcrypto. Every NURL program
- * therefore links libc-only regardless of whether the linker dead-strips
- * the unused TLS code — LTO dead-code elimination behaves differently
- * across clang/lld and the bundled-zig cross builds (relying on it left
- * undefined SSL_* symbols when building, e.g., the pure-NURL `tls` package
- * on arm64, because importing net.nu pulls in the runtime's TLS server
- * functions and they were not stripped). libssl is loaded lazily the first
- * time a TLS connection is created; if it is absent the TLS entry points
- * fail cleanly with TLS_CTX_INIT instead of the whole program failing to
- * link or run.
- *
- * Each pointer is typed with __typeof__ of the real prototype declared by
- * the headers above, so the signatures are always exact — including the
- * functions reached through OpenSSL's own macros (SSL_ctrl, SSL_CTX_ctrl,
- * SSL_CTX_callback_ctrl, SSL_get1_peer_certificate, CRYPTO_free). The
- * #define block after the loader redirects each name to its pointer, so the
- * call sites below stay byte-for-byte unchanged. */
-#include <dlfcn.h>
-
-#define NURL__SSL_PTR(name) static __typeof__(name) *nurl__p_##name = 0;
-NURL__SSL_PTR(SSL_CTX_new)
-NURL__SSL_PTR(SSL_CTX_free)
-NURL__SSL_PTR(SSL_CTX_ctrl)
-NURL__SSL_PTR(SSL_CTX_callback_ctrl)
-NURL__SSL_PTR(SSL_CTX_check_private_key)
-NURL__SSL_PTR(SSL_CTX_load_verify_locations)
-NURL__SSL_PTR(SSL_CTX_set_alpn_select_cb)
-NURL__SSL_PTR(SSL_CTX_set_client_CA_list)
-NURL__SSL_PTR(SSL_CTX_set_default_verify_paths)
-NURL__SSL_PTR(SSL_CTX_set_verify)
-NURL__SSL_PTR(SSL_CTX_use_PrivateKey_file)
-NURL__SSL_PTR(SSL_CTX_use_certificate_chain_file)
-NURL__SSL_PTR(SSL_new)
-NURL__SSL_PTR(SSL_free)
-NURL__SSL_PTR(SSL_ctrl)
-NURL__SSL_PTR(SSL_accept)
-NURL__SSL_PTR(SSL_connect)
-NURL__SSL_PTR(SSL_get0_alpn_selected)
-NURL__SSL_PTR(SSL_get1_peer_certificate)
-NURL__SSL_PTR(SSL_get_error)
-NURL__SSL_PTR(SSL_get_servername)
-NURL__SSL_PTR(SSL_load_client_CA_file)
-NURL__SSL_PTR(SSL_read)
-NURL__SSL_PTR(SSL_write)
-NURL__SSL_PTR(SSL_select_next_proto)
-NURL__SSL_PTR(SSL_set1_host)
-NURL__SSL_PTR(SSL_set_SSL_CTX)
-NURL__SSL_PTR(SSL_set_alpn_protos)
-NURL__SSL_PTR(SSL_set_fd)
-NURL__SSL_PTR(SSL_shutdown)
-NURL__SSL_PTR(TLS_client_method)
-NURL__SSL_PTR(TLS_server_method)
-NURL__SSL_PTR(X509_NAME_oneline)
-NURL__SSL_PTR(X509_free)
-NURL__SSL_PTR(X509_get_subject_name)
-NURL__SSL_PTR(CRYPTO_free)
-#undef NURL__SSL_PTR
-
-static int nurl__ssl_ready = 0;  /* 0 unloaded, 1 loaded, -1 unavailable */
-
-static int nurl__ssl_load(void) {
-    if (nurl__ssl_ready) return nurl__ssl_ready > 0;
-    void *s = dlopen("libssl.so.3", RTLD_NOW | RTLD_GLOBAL);
-    if (!s) s = dlopen("libssl.so", RTLD_NOW | RTLD_GLOBAL);
-    if (!s) s = dlopen("libssl.so.1.1", RTLD_NOW | RTLD_GLOBAL);
-    if (!s) { nurl__ssl_ready = -1; return 0; }
-    void *c = dlopen("libcrypto.so.3", RTLD_NOW | RTLD_GLOBAL);
-    if (!c) c = dlopen("libcrypto.so", RTLD_NOW | RTLD_GLOBAL);
-    if (!c) c = dlopen("libcrypto.so.1.1", RTLD_NOW | RTLD_GLOBAL);
-    if (!c) c = s;  /* libssl pulls libcrypto in; RTLD_GLOBAL exposes it */
-#define NURL__SSL_SYM(name, lib) \
-    nurl__p_##name = (__typeof__(nurl__p_##name))dlsym(lib, #name); \
-    if (!nurl__p_##name) { nurl__ssl_ready = -1; return 0; }
-    NURL__SSL_SYM(SSL_CTX_new, s)
-    NURL__SSL_SYM(SSL_CTX_free, s)
-    NURL__SSL_SYM(SSL_CTX_ctrl, s)
-    NURL__SSL_SYM(SSL_CTX_callback_ctrl, s)
-    NURL__SSL_SYM(SSL_CTX_check_private_key, s)
-    NURL__SSL_SYM(SSL_CTX_load_verify_locations, s)
-    NURL__SSL_SYM(SSL_CTX_set_alpn_select_cb, s)
-    NURL__SSL_SYM(SSL_CTX_set_client_CA_list, s)
-    NURL__SSL_SYM(SSL_CTX_set_default_verify_paths, s)
-    NURL__SSL_SYM(SSL_CTX_set_verify, s)
-    NURL__SSL_SYM(SSL_CTX_use_PrivateKey_file, s)
-    NURL__SSL_SYM(SSL_CTX_use_certificate_chain_file, s)
-    NURL__SSL_SYM(SSL_new, s)
-    NURL__SSL_SYM(SSL_free, s)
-    NURL__SSL_SYM(SSL_ctrl, s)
-    NURL__SSL_SYM(SSL_accept, s)
-    NURL__SSL_SYM(SSL_connect, s)
-    NURL__SSL_SYM(SSL_get0_alpn_selected, s)
-    NURL__SSL_SYM(SSL_get1_peer_certificate, s)
-    NURL__SSL_SYM(SSL_get_error, s)
-    NURL__SSL_SYM(SSL_get_servername, s)
-    NURL__SSL_SYM(SSL_load_client_CA_file, s)
-    NURL__SSL_SYM(SSL_read, s)
-    NURL__SSL_SYM(SSL_write, s)
-    NURL__SSL_SYM(SSL_select_next_proto, s)
-    NURL__SSL_SYM(SSL_set1_host, s)
-    NURL__SSL_SYM(SSL_set_SSL_CTX, s)
-    NURL__SSL_SYM(SSL_set_alpn_protos, s)
-    NURL__SSL_SYM(SSL_set_fd, s)
-    NURL__SSL_SYM(SSL_shutdown, s)
-    NURL__SSL_SYM(TLS_client_method, s)
-    NURL__SSL_SYM(TLS_server_method, s)
-    NURL__SSL_SYM(X509_NAME_oneline, c)
-    NURL__SSL_SYM(X509_free, c)
-    NURL__SSL_SYM(X509_get_subject_name, c)
-    NURL__SSL_SYM(CRYPTO_free, c)
-#undef NURL__SSL_SYM
-    nurl__ssl_ready = 1;
-    return 1;
-}
-
-/* Redirect every OpenSSL name to its dlopen'd pointer. Names reached only
- * through OpenSSL macros (SSL_set_tlsext_host_name → SSL_ctrl, etc.) work
- * because the underlying symbol they expand to is redirected here. */
-#define SSL_CTX_new                       nurl__p_SSL_CTX_new
-#define SSL_CTX_free                      nurl__p_SSL_CTX_free
-#define SSL_CTX_ctrl                      nurl__p_SSL_CTX_ctrl
-#define SSL_CTX_callback_ctrl             nurl__p_SSL_CTX_callback_ctrl
-#define SSL_CTX_check_private_key         nurl__p_SSL_CTX_check_private_key
-#define SSL_CTX_load_verify_locations     nurl__p_SSL_CTX_load_verify_locations
-#define SSL_CTX_set_alpn_select_cb        nurl__p_SSL_CTX_set_alpn_select_cb
-#define SSL_CTX_set_client_CA_list        nurl__p_SSL_CTX_set_client_CA_list
-#define SSL_CTX_set_default_verify_paths  nurl__p_SSL_CTX_set_default_verify_paths
-#define SSL_CTX_set_verify                nurl__p_SSL_CTX_set_verify
-#define SSL_CTX_use_PrivateKey_file       nurl__p_SSL_CTX_use_PrivateKey_file
-#define SSL_CTX_use_certificate_chain_file nurl__p_SSL_CTX_use_certificate_chain_file
-#define SSL_new                           nurl__p_SSL_new
-#define SSL_free                          nurl__p_SSL_free
-#define SSL_ctrl                          nurl__p_SSL_ctrl
-#define SSL_accept                        nurl__p_SSL_accept
-#define SSL_connect                       nurl__p_SSL_connect
-#define SSL_get0_alpn_selected            nurl__p_SSL_get0_alpn_selected
-#define SSL_get1_peer_certificate         nurl__p_SSL_get1_peer_certificate
-#define SSL_get_error                     nurl__p_SSL_get_error
-#define SSL_get_servername                nurl__p_SSL_get_servername
-#define SSL_load_client_CA_file           nurl__p_SSL_load_client_CA_file
-#define SSL_read                          nurl__p_SSL_read
-#define SSL_write                         nurl__p_SSL_write
-#define SSL_select_next_proto             nurl__p_SSL_select_next_proto
-#define SSL_set1_host                     nurl__p_SSL_set1_host
-#define SSL_set_SSL_CTX                   nurl__p_SSL_set_SSL_CTX
-#define SSL_set_alpn_protos               nurl__p_SSL_set_alpn_protos
-#define SSL_set_fd                        nurl__p_SSL_set_fd
-#define SSL_shutdown                      nurl__p_SSL_shutdown
-#define TLS_client_method                 nurl__p_TLS_client_method
-#define TLS_server_method                 nurl__p_TLS_server_method
-#define X509_NAME_oneline                 nurl__p_X509_NAME_oneline
-#define X509_free                         nurl__p_X509_free
-#define X509_get_subject_name             nurl__p_X509_get_subject_name
-#define CRYPTO_free                       nurl__p_CRYPTO_free
-#endif
 
 #define NURL_TCP_KIND_LISTENER  0
 #define NURL_TCP_KIND_CONN      1
@@ -2263,15 +2104,6 @@ typedef int nurl_sockfd_t;
 #    define nurl_close_sock(fd) close(fd)
 #  endif
 
-#ifdef NURL_HAVE_OPENSSL
-/* One SNI registry entry: owned hostname + owned SSL_CTX (added via
- * nurl_tcp_tls_add_sni, freed via SSL_CTX_free which is refcounted so
- * in-flight conns survive a reload). */
-typedef struct NurlSniEntry {
-    char    *hostname;
-    SSL_CTX *ctx;
-} NurlSniEntry;
-#endif
 
 typedef struct NurlTcp {
     nurl_sockfd_t fd;
@@ -2297,31 +2129,6 @@ typedef struct NurlTcp {
      * server_stop from another thread) defers the struct free until the
      * parked accept fiber has resumed and stopped touching the handle. */
     int           refcount;
-#ifdef NURL_HAVE_OPENSSL
-    /* TLS state — non-NULL fields turn the handle into a TLS variant.
-     *   ssl_ctx is on a LISTENER from nurl_tcp_listen_tls; accept()
-     *     spins up a per-conn SSL stored in the new conn handle.
-     *   ssl is on a CONN whose handshake completed; read/write then
-     *     dispatch via SSL_read/SSL_write. */
-    SSL_CTX      *ssl_ctx;
-    SSL          *ssl;
-    /* ALPN wire-format list (RFC 7301): length-prefixed entries like
-     * "\x02h2\x08http/1.1". NULL ⇒ no ALPN configured. */
-    unsigned char *alpn_wire;
-    size_t         alpn_wire_len;
-    /* SNI registry — empty on listeners serving only the default ctx. */
-    NurlSniEntry  *sni_entries;
-    size_t         sni_count;
-    size_t         sni_cap;
-    /* Protects ssl_ctx swap + sni_entries growth during live cert
-     * reload. Lazy-init — plain TCP listeners never pay the cost. */
-  #ifdef _WIN32
-    CRITICAL_SECTION tls_lock;
-  #else
-    pthread_mutex_t  tls_lock;
-  #endif
-    int             tls_lock_init;
-#endif
 } NurlTcp;
 
 /* Wake the async reactor (if running) so it re-polls. Called after a fd is
@@ -2332,74 +2139,6 @@ typedef struct NurlTcp {
  * the reactor; a no-op stub covers WASI/Windows. */
 void nurl__reactor_wake_if_started(void);
 
-#ifdef NURL_HAVE_OPENSSL
-static void nurl__tls_lock_ensure(NurlTcp *h) {
-    if (!h || h->tls_lock_init) return;
-  #ifdef _WIN32
-    InitializeCriticalSection(&h->tls_lock);
-  #else
-    pthread_mutex_init(&h->tls_lock, NULL);
-  #endif
-    h->tls_lock_init = 1;
-}
-static void nurl__tls_lock(NurlTcp *h) {
-    if (!h || !h->tls_lock_init) return;
-  #ifdef _WIN32
-    EnterCriticalSection(&h->tls_lock);
-  #else
-    pthread_mutex_lock(&h->tls_lock);
-  #endif
-}
-static void nurl__tls_unlock(NurlTcp *h) {
-    if (!h || !h->tls_lock_init) return;
-  #ifdef _WIN32
-    LeaveCriticalSection(&h->tls_lock);
-  #else
-    pthread_mutex_unlock(&h->tls_lock);
-  #endif
-}
-static void nurl__tls_lock_destroy(NurlTcp *h) {
-    if (!h || !h->tls_lock_init) return;
-  #ifdef _WIN32
-    DeleteCriticalSection(&h->tls_lock);
-  #else
-    pthread_mutex_destroy(&h->tls_lock);
-  #endif
-    h->tls_lock_init = 0;
-}
-
-/* Case-insensitive ASCII strcmp for SNI hostname lookup. */
-static int nurl__hostname_ieq(const char *a, const char *b) {
-    if (!a || !b) return 0;
-    while (*a && *b) {
-        unsigned char ca = (unsigned char)*a++;
-        unsigned char cb = (unsigned char)*b++;
-        if (ca >= 'A' && ca <= 'Z') ca = (unsigned char)(ca + 32);
-        if (cb >= 'A' && cb <= 'Z') cb = (unsigned char)(cb + 32);
-        if (ca != cb) return 0;
-    }
-    return *a == 0 && *b == 0;
-}
-
-/* SNI callback (RFC 6066 §3) — match client-sent servername against
- * listener's sni_entries; no-match falls through to the default ctx. */
-static int nurl__sni_select_cb(SSL *ssl, int *al, void *arg) {
-    (void)al;
-    NurlTcp *listener = (NurlTcp*)arg;
-    if (!listener) return SSL_TLSEXT_ERR_OK;
-    const char *name = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
-    if (!name) return SSL_TLSEXT_ERR_OK;
-    nurl__tls_lock(listener);
-    for (size_t i = 0; i < listener->sni_count; i++) {
-        if (nurl__hostname_ieq(listener->sni_entries[i].hostname, name)) {
-            SSL_set_SSL_CTX(ssl, listener->sni_entries[i].ctx);
-            break;
-        }
-    }
-    nurl__tls_unlock(listener);
-    return SSL_TLSEXT_ERR_OK;
-}
-#endif
 
 /* errno/WSAGetLastError → NetErr; call sites override when needed. */
 #ifdef _WIN32
@@ -2719,136 +2458,38 @@ long long nurl_tcp_accept(long long listener) {
         setsockopt(c->fd, IPPROTO_TCP, TCP_NODELAY,
                    (const char*)&one, (socklen_t)sizeof(one));
     }
-#ifdef NURL_HAVE_OPENSSL
-    /* TLS listener — spin up per-conn SSL and run the handshake here.
-     * Handshake failure → TLS_HANDSHAKE + close fd (no half-open leak). */
-    if (l->ssl_ctx) {
-        SSL *s = SSL_new(l->ssl_ctx);
-        if (!s) {
-            nurl_close_sock(c->fd);
-            c->fd = NURL_INVALID_SOCK;
-            c->err_kind = NURL_NET_ERR_TLS_HANDSHAKE;
-            return (long long)(uintptr_t)c;
-        }
-        if (SSL_set_fd(s, (int)c->fd) != 1) {
-            SSL_free(s);
-            nurl_close_sock(c->fd);
-            c->fd = NURL_INVALID_SOCK;
-            c->err_kind = NURL_NET_ERR_TLS_HANDSHAKE;
-            return (long long)(uintptr_t)c;
-        }
-        int rv = SSL_accept(s);
-        if (rv != 1) {
-            SSL_free(s);
-            nurl_close_sock(c->fd);
-            c->fd = NURL_INVALID_SOCK;
-            c->err_kind = NURL_NET_ERR_TLS_HANDSHAKE;
-            return (long long)(uintptr_t)c;
-        }
-        c->ssl = s;
-    }
-#endif
     return (long long)(uintptr_t)c;
 }
 
-/* Server-side ALPN (RFC 7301) — required by HTTP/2-over-TLS. The NURL
- * API takes a server-preference list like "h2 http/1.1"; we convert
- * once at listen time to the wire-format "\x02h2\x08http/1.1" and the
- * callback below picks the first server-preferred match. Gated on
- * NURL_HAVE_OPENSSL. */
-#ifdef NURL_HAVE_OPENSSL
-
-/* "h2 http/1.1" → "\x02h2\x08http/1.1" (heap-owned). NULL on OOM or a
- * token longer than 255 bytes (ALPN length prefix is u8). */
-static unsigned char *nurl__alpn_pack(const char *spec, size_t *out_len) {
-    if (!spec) { *out_len = 0; return NULL; }
-    size_t cap = strlen(spec) + 1;
-    unsigned char *buf = (unsigned char*)malloc(cap);
-    if (!buf) { *out_len = 0; return NULL; }
-    size_t w = 0;
-    const char *p = spec;
-    while (*p) {
-        while (*p == ' ') p++;
-        if (!*p) break;
-        const char *tok = p;
-        while (*p && *p != ' ') p++;
-        size_t tlen = (size_t)(p - tok);
-        if (tlen == 0 || tlen > 255) { free(buf); *out_len = 0; return NULL; }
-        buf[w++] = (unsigned char)tlen;
-        memcpy(buf + w, tok, tlen);
-        w += tlen;
-    }
-    *out_len = w;
-    return buf;
-}
-
-static int nurl__alpn_select_cb(SSL *ssl, const unsigned char **out,
-                                unsigned char *outlen,
-                                const unsigned char *in, unsigned int inlen,
-                                void *arg) {
-    (void)ssl;
-    NurlTcp *listener = (NurlTcp*)arg;
-    if (!listener || !listener->alpn_wire || listener->alpn_wire_len == 0) {
-        return SSL_TLSEXT_ERR_NOACK;
-    }
-    /* Cast strips const because OpenSSL's prototype is mutable; the
-     * data isn't actually written. */
-    int rv = SSL_select_next_proto((unsigned char **)out, outlen,
-                                   listener->alpn_wire,
-                                   (unsigned int)listener->alpn_wire_len,
-                                   in, inlen);
-    if (rv == OPENSSL_NPN_NEGOTIATED) return SSL_TLSEXT_ERR_OK;
-    return SSL_TLSEXT_ERR_NOACK;
-}
-
-#endif
+/* ════════════════════════════════════════════════════════════════════
+ * TLS transport: INERT STUBS (§8 P4 — libssl/libcrypto removed)
+ *
+ * ALL TLS — client and server, handshake + record layer + X.509 + the
+ * crypto — is now PURE NURL: stdlib/std/tls.nu (client), tls_server.nu
+ * (server), and the primitives in stdlib/std/{x25519,p256,chacha,aesgcm,
+ * sha256,hkdf,ecdsa_p256,rsa,x509,...}.nu. net.nu drives them directly
+ * over plain sockets (nurl_tcp_connect/read/write below) — see
+ * tcp_connect_tls / tcp_starttls / tcp_listen_tls in net.nu.
+ *
+ * These nurl_tcp_*_tls* C functions are no longer reached by any .nu
+ * code; the compiler's runtime-FFI prelude still emits `declare`s for a
+ * few of them (listen_tls, listen_tls_alpn, alpn_selected,
+ * peer_cert_subject), so they survive here as inert stubs that set
+ * err_kind = TLS_CTX_INIT / return empty. The OpenSSL implementations
+ * (dlopen vtable + SSL_* call sites) were deleted wholesale. The
+ * doc-comments below still describe the old OpenSSL semantics for
+ * historical context only — the bodies do nothing.
+ * ════════════════════════════════════════════════════════════════════ */
 
 long long nurl_tcp_listen_tls(const char *host, long long port,
                               long long backlog,
                               const char *cert_path, const char *key_path) {
-#ifndef NURL_HAVE_OPENSSL
     (void)host; (void)port; (void)backlog;
     (void)cert_path; (void)key_path;
     NurlTcp *h = nurl__tcp_new_handle(NURL_TCP_KIND_LISTENER);
     if (!h) return 0;
     h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
     return (long long)(uintptr_t)h;
-#else
-    long long lh = nurl_tcp_listen(host, port, backlog);
-    NurlTcp *h = (NurlTcp*)(uintptr_t)lh;
-    if (!h || h->err_kind != NURL_NET_ERR_OK) return lh;
-    SSL_CTX *ctx = nurl__ssl_load() ? SSL_CTX_new(TLS_server_method()) : NULL;
-    if (!ctx) {
-        nurl_close_sock(h->fd);
-        h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return lh;
-    }
-    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
-    if (SSL_CTX_use_certificate_chain_file(ctx, cert_path) != 1) {
-        SSL_CTX_free(ctx);
-        nurl_close_sock(h->fd);
-        h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_CERT_LOAD;
-        return lh;
-    }
-    if (SSL_CTX_use_PrivateKey_file(ctx, key_path, SSL_FILETYPE_PEM) != 1) {
-        SSL_CTX_free(ctx);
-        nurl_close_sock(h->fd);
-        h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_KEY_LOAD;
-        return lh;
-    }
-    if (SSL_CTX_check_private_key(ctx) != 1) {
-        SSL_CTX_free(ctx);
-        nurl_close_sock(h->fd);
-        h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_KEY_LOAD;
-        return lh;
-    }
-    h->ssl_ctx = ctx;
-    return lh;
-#endif
 }
 
 /* Client-side TLS connect — plain connect + client handshake. Resulting
@@ -2858,56 +2499,11 @@ long long nurl_tcp_listen_tls(const char *host, long long port,
  * (the MQTT `--insecure` choice). SNI is always sent. */
 long long nurl_tcp_connect_tls(const char *host, long long port,
                                long long verify) {
-#ifndef NURL_HAVE_OPENSSL
     (void)host; (void)port; (void)verify;
     NurlTcp *h = nurl__tcp_new_handle(NURL_TCP_KIND_CONN);
     if (!h) return 0;
     h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
     return (long long)(uintptr_t)h;
-#else
-    long long ch = nurl_tcp_connect(host, port);
-    NurlTcp *h = (NurlTcp*)(uintptr_t)ch;
-    if (!h || h->err_kind != NURL_NET_ERR_OK) return ch;
-
-    SSL_CTX *ctx = nurl__ssl_load() ? SSL_CTX_new(TLS_client_method()) : NULL;
-    if (!ctx) {
-        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return ch;
-    }
-    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
-    if (verify) {
-        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
-        SSL_CTX_set_default_verify_paths(ctx);
-    } else {
-        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
-    }
-
-    SSL *ssl = SSL_new(ctx);
-    if (!ssl) {
-        SSL_CTX_free(ctx);
-        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return ch;
-    }
-    /* SNI — most multi-tenant brokers require it. */
-    SSL_set_tlsext_host_name(ssl, host);
-    if (verify) SSL_set1_host(ssl, host);
-    SSL_set_fd(ssl, (int)h->fd);
-
-    if (SSL_connect(ssl) != 1) {
-        SSL_free(ssl);
-        SSL_CTX_free(ctx);
-        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_HANDSHAKE;
-        return ch;
-    }
-
-    h->ssl      = ssl;
-    h->ssl_ctx  = ctx;
-    h->err_kind = NURL_NET_ERR_OK;
-    return ch;
-#endif
 }
 
 /* In-place TLS upgrade of an already-connected plaintext CONN handle —
@@ -2924,60 +2520,9 @@ long long nurl_tcp_starttls(long long conn, const char *host,
                             long long verify) {
     NurlTcp *h = (NurlTcp*)(uintptr_t)conn;
     if (!h) return conn;
-#ifndef NURL_HAVE_OPENSSL
     (void)host; (void)verify;
     h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
     return conn;
-#else
-    if (h->ssl) {                       /* already secured — refuse */
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return conn;
-    }
-    if (h->fd == NURL_INVALID_SOCK) {
-        h->err_kind = NURL_NET_ERR_CLOSED;
-        return conn;
-    }
-
-    SSL_CTX *ctx = nurl__ssl_load() ? SSL_CTX_new(TLS_client_method()) : NULL;
-    if (!ctx) {
-        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return conn;
-    }
-    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
-    if (verify) {
-        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
-        SSL_CTX_set_default_verify_paths(ctx);
-    } else {
-        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
-    }
-
-    SSL *ssl = SSL_new(ctx);
-    if (!ssl) {
-        SSL_CTX_free(ctx);
-        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return conn;
-    }
-    if (host && *host) {
-        SSL_set_tlsext_host_name(ssl, host);
-        if (verify) SSL_set1_host(ssl, host);
-    }
-    SSL_set_fd(ssl, (int)h->fd);
-
-    if (SSL_connect(ssl) != 1) {
-        SSL_free(ssl);
-        SSL_CTX_free(ctx);
-        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_HANDSHAKE;
-        return conn;
-    }
-
-    h->ssl      = ssl;
-    h->ssl_ctx  = ctx;
-    h->err_kind = NURL_NET_ERR_OK;
-    return conn;
-#endif
 }
 
 /* Client-side TLS connect WITH ALPN (RFC 7301) — required to speak
@@ -2992,70 +2537,11 @@ long long nurl_tcp_starttls(long long conn, const char *host,
 long long nurl_tcp_connect_tls_alpn(const char *host, long long port,
                                     long long verify,
                                     const char *alpn_protocols) {
-#ifndef NURL_HAVE_OPENSSL
     (void)host; (void)port; (void)verify; (void)alpn_protocols;
     NurlTcp *h = nurl__tcp_new_handle(NURL_TCP_KIND_CONN);
     if (!h) return 0;
     h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
     return (long long)(uintptr_t)h;
-#else
-    long long ch = nurl_tcp_connect(host, port);
-    NurlTcp *h = (NurlTcp*)(uintptr_t)ch;
-    if (!h || h->err_kind != NURL_NET_ERR_OK) return ch;
-
-    SSL_CTX *ctx = nurl__ssl_load() ? SSL_CTX_new(TLS_client_method()) : NULL;
-    if (!ctx) {
-        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return ch;
-    }
-    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
-    if (verify) {
-        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
-        SSL_CTX_set_default_verify_paths(ctx);
-    } else {
-        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
-    }
-
-    SSL *ssl = SSL_new(ctx);
-    if (!ssl) {
-        SSL_CTX_free(ctx);
-        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return ch;
-    }
-    /* SNI — multi-tenant servers require it. */
-    SSL_set_tlsext_host_name(ssl, host);
-    if (verify) SSL_set1_host(ssl, host);
-
-    /* Offer ALPN. SSL_set_alpn_protos returns 0 on success; a non-zero
-     * return (OOM / malformed list) is non-fatal — we just handshake
-     * without ALPN and the caller's post-handshake "h2" check fails
-     * cleanly. */
-    if (alpn_protocols && *alpn_protocols) {
-        size_t wlen = 0;
-        unsigned char *wire = nurl__alpn_pack(alpn_protocols, &wlen);
-        if (wire && wlen > 0) {
-            SSL_set_alpn_protos(ssl, wire, (unsigned int)wlen);
-        }
-        free(wire);
-    }
-
-    SSL_set_fd(ssl, (int)h->fd);
-
-    if (SSL_connect(ssl) != 1) {
-        SSL_free(ssl);
-        SSL_CTX_free(ctx);
-        nurl_close_sock(h->fd); h->fd = NURL_INVALID_SOCK;
-        h->err_kind = NURL_NET_ERR_TLS_HANDSHAKE;
-        return ch;
-    }
-
-    h->ssl      = ssl;
-    h->ssl_ctx  = ctx;
-    h->err_kind = NURL_NET_ERR_OK;
-    return ch;
-#endif
 }
 
 /* TLS listener + ALPN. alpn_protocols is a space-separated server-
@@ -3066,59 +2552,15 @@ long long nurl_tcp_listen_tls_alpn(const char *host, long long port,
                                    long long backlog,
                                    const char *cert_path, const char *key_path,
                                    const char *alpn_protocols) {
-#ifndef NURL_HAVE_OPENSSL
     (void)host; (void)port; (void)backlog;
     (void)cert_path; (void)key_path; (void)alpn_protocols;
     NurlTcp *h = nurl__tcp_new_handle(NURL_TCP_KIND_LISTENER);
     if (!h) return 0;
     h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
     return (long long)(uintptr_t)h;
-#else
-    long long lh = nurl_tcp_listen_tls(host, port, backlog, cert_path, key_path);
-    NurlTcp *h = (NurlTcp*)(uintptr_t)lh;
-    if (!h || h->err_kind != NURL_NET_ERR_OK || !h->ssl_ctx) return lh;
-    size_t wlen = 0;
-    unsigned char *wire = nurl__alpn_pack(alpn_protocols, &wlen);
-    if (!wire || wlen == 0) {
-        /* Empty/malformed list — skip ALPN, listener still works. */
-        free(wire);
-        return lh;
-    }
-    h->alpn_wire = wire;
-    h->alpn_wire_len = wlen;
-    SSL_CTX_set_alpn_select_cb(h->ssl_ctx, nurl__alpn_select_cb, h);
-    return lh;
-#endif
 }
 
 /* Build SSL_CTX with cert+key. NULL + sets h->err_kind on failure. */
-#ifdef NURL_HAVE_OPENSSL
-static SSL_CTX *nurl__tls_build_ctx(NurlTcp *h, const char *cert_path,
-                                    const char *key_path) {
-    SSL_CTX *ctx = nurl__ssl_load() ? SSL_CTX_new(TLS_server_method()) : NULL;
-    if (!ctx) {
-        if (h) h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return NULL;
-    }
-    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
-    if (SSL_CTX_use_certificate_chain_file(ctx, cert_path) != 1) {
-        SSL_CTX_free(ctx);
-        if (h) h->err_kind = NURL_NET_ERR_TLS_CERT_LOAD;
-        return NULL;
-    }
-    if (SSL_CTX_use_PrivateKey_file(ctx, key_path, SSL_FILETYPE_PEM) != 1) {
-        SSL_CTX_free(ctx);
-        if (h) h->err_kind = NURL_NET_ERR_TLS_KEY_LOAD;
-        return NULL;
-    }
-    if (SSL_CTX_check_private_key(ctx) != 1) {
-        SSL_CTX_free(ctx);
-        if (h) h->err_kind = NURL_NET_ERR_TLS_KEY_LOAD;
-        return NULL;
-    }
-    return ctx;
-}
-#endif
 
 /* Register an SNI hostname → cert/key on a TLS listener. The default
  * ctx is used on no-SNI or no-match (RFC 6066 §3 fallback). Idempotent
@@ -3128,58 +2570,9 @@ long long nurl_tcp_tls_add_sni(long long handle, const char *hostname,
                                const char *cert_path, const char *key_path) {
     NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
     if (!h) return NURL_NET_ERR_OTHER;
-#ifdef NURL_HAVE_OPENSSL
-    if (!h->ssl_ctx) {
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return NURL_NET_ERR_TLS_CTX_INIT;
-    }
-    if (!hostname || !*hostname) {
-        h->err_kind = NURL_NET_ERR_OTHER;
-        return NURL_NET_ERR_OTHER;
-    }
-    SSL_CTX *ctx = nurl__tls_build_ctx(h, cert_path, key_path);
-    if (!ctx) return h->err_kind;
-    nurl__tls_lock_ensure(h);
-    nurl__tls_lock(h);
-    int replaced = 0;
-    for (size_t i = 0; i < h->sni_count; i++) {
-        if (nurl__hostname_ieq(h->sni_entries[i].hostname, hostname)) {
-            SSL_CTX *old = h->sni_entries[i].ctx;
-            h->sni_entries[i].ctx = ctx;
-            SSL_CTX_free(old);
-            replaced = 1;
-            break;
-        }
-    }
-    if (!replaced) {
-        if (h->sni_count == h->sni_cap) {
-            size_t newcap = h->sni_cap ? h->sni_cap * 2 : 4;
-            NurlSniEntry *grown = (NurlSniEntry*)realloc(h->sni_entries,
-                newcap * sizeof(NurlSniEntry));
-            if (!grown) {
-                SSL_CTX_free(ctx);
-                nurl__tls_unlock(h);
-                h->err_kind = NURL_NET_ERR_OTHER;
-                return NURL_NET_ERR_OTHER;
-            }
-            h->sni_entries = grown;
-            h->sni_cap = newcap;
-        }
-        h->sni_entries[h->sni_count].hostname = strdup(hostname);
-        h->sni_entries[h->sni_count].ctx = ctx;
-        h->sni_count++;
-    }
-    /* SNI callback install is idempotent. */
-    SSL_CTX_set_tlsext_servername_callback(h->ssl_ctx, nurl__sni_select_cb);
-    SSL_CTX_set_tlsext_servername_arg(h->ssl_ctx, h);
-    nurl__tls_unlock(h);
-    h->err_kind = NURL_NET_ERR_OK;
-    return NURL_NET_ERR_OK;
-#else
     (void)hostname; (void)cert_path; (void)key_path;
     h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
     return NURL_NET_ERR_TLS_CTX_INIT;
-#endif
 }
 
 /* Live cert reload. hostname NULL/"" → swap the default ctx; otherwise
@@ -3189,50 +2582,9 @@ long long nurl_tcp_tls_reload(long long handle, const char *hostname,
                               const char *cert_path, const char *key_path) {
     NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
     if (!h) return NURL_NET_ERR_OTHER;
-#ifdef NURL_HAVE_OPENSSL
-    if (!h->ssl_ctx) {
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return NURL_NET_ERR_TLS_CTX_INIT;
-    }
-    SSL_CTX *new_ctx = nurl__tls_build_ctx(h, cert_path, key_path);
-    if (!new_ctx) return h->err_kind;
-    nurl__tls_lock_ensure(h);
-    nurl__tls_lock(h);
-    if (!hostname || !*hostname) {
-        SSL_CTX *old = h->ssl_ctx;
-        h->ssl_ctx = new_ctx;
-        /* Re-install ALPN + SNI hooks — they're per-ctx. */
-        if (h->alpn_wire && h->alpn_wire_len > 0) {
-            SSL_CTX_set_alpn_select_cb(new_ctx, nurl__alpn_select_cb, h);
-        }
-        if (h->sni_count > 0) {
-            SSL_CTX_set_tlsext_servername_callback(new_ctx, nurl__sni_select_cb);
-            SSL_CTX_set_tlsext_servername_arg(new_ctx, h);
-        }
-        SSL_CTX_free(old);
-        nurl__tls_unlock(h);
-        h->err_kind = NURL_NET_ERR_OK;
-        return NURL_NET_ERR_OK;
-    }
-    for (size_t i = 0; i < h->sni_count; i++) {
-        if (nurl__hostname_ieq(h->sni_entries[i].hostname, hostname)) {
-            SSL_CTX *old = h->sni_entries[i].ctx;
-            h->sni_entries[i].ctx = new_ctx;
-            SSL_CTX_free(old);
-            nurl__tls_unlock(h);
-            h->err_kind = NURL_NET_ERR_OK;
-            return NURL_NET_ERR_OK;
-        }
-    }
-    SSL_CTX_free(new_ctx);
-    nurl__tls_unlock(h);
-    h->err_kind = NURL_NET_ERR_OTHER;
-    return NURL_NET_ERR_OTHER;
-#else
     (void)hostname; (void)cert_path; (void)key_path;
     h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
     return NURL_NET_ERR_TLS_CTX_INIT;
-#endif
 }
 
 /* Require client-cert auth (mTLS). ca_bundle_path is a PEM file with
@@ -3244,28 +2596,9 @@ long long nurl_tcp_tls_require_client_cert(long long handle,
                                             long long strict) {
     NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
     if (!h) return NURL_NET_ERR_OTHER;
-#ifdef NURL_HAVE_OPENSSL
-    if (!h->ssl_ctx) {
-        h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
-        return NURL_NET_ERR_TLS_CTX_INIT;
-    }
-    if (SSL_CTX_load_verify_locations(h->ssl_ctx, ca_bundle_path, NULL) != 1) {
-        h->err_kind = NURL_NET_ERR_TLS_CERT_LOAD;
-        return NURL_NET_ERR_TLS_CERT_LOAD;
-    }
-    int mode = SSL_VERIFY_PEER;
-    if (strict) mode |= SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
-    SSL_CTX_set_verify(h->ssl_ctx, mode, NULL);
-    /* Client-CA list in CertificateRequest helps multi-cert clients pick. */
-    STACK_OF(X509_NAME) *list = SSL_load_client_CA_file(ca_bundle_path);
-    if (list) SSL_CTX_set_client_CA_list(h->ssl_ctx, list);
-    h->err_kind = NURL_NET_ERR_OK;
-    return NURL_NET_ERR_OK;
-#else
     (void)ca_bundle_path; (void)strict;
     h->err_kind = NURL_NET_ERR_TLS_CTX_INIT;
     return NURL_NET_ERR_TLS_CTX_INIT;
-#endif
 }
 
 /* Peer-cert subject DN (OpenSSL one-line). Owned NUL-terminated string;
@@ -3273,25 +2606,7 @@ long long nurl_tcp_tls_require_client_cert(long long handle,
 const char *nurl_tcp_peer_cert_subject(long long handle) {
     NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
     if (!h) return strdup("");
-#ifdef NURL_HAVE_OPENSSL
-    if (!h->ssl) return strdup("");
-    X509 *cert = SSL_get_peer_certificate(h->ssl);
-    if (!cert) return strdup("");
-    X509_NAME *subj = X509_get_subject_name(cert);
-    if (!subj) { X509_free(cert); return strdup(""); }
-    char *line = X509_NAME_oneline(subj, NULL, 0);
-    char *out;
-    if (line) {
-        out = strdup(line);
-        OPENSSL_free(line);
-    } else {
-        out = strdup("");
-    }
-    X509_free(cert);
-    return out ? out : strdup("");
-#else
     return strdup("");
-#endif
 }
 
 /* Negotiated ALPN protocol ("h2" / "http/1.1" / ...). Owned string,
@@ -3299,20 +2614,7 @@ const char *nurl_tcp_peer_cert_subject(long long handle) {
 const char *nurl_tcp_alpn_selected(long long handle) {
     NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
     if (!h) return strdup("");
-#ifdef NURL_HAVE_OPENSSL
-    if (!h->ssl) return strdup("");
-    const unsigned char *data = NULL;
-    unsigned int len = 0;
-    SSL_get0_alpn_selected(h->ssl, &data, &len);
-    if (!data || len == 0) return strdup("");
-    char *out = (char*)malloc((size_t)len + 1);
-    if (!out) return strdup("");
-    memcpy(out, data, len);
-    out[len] = '\0';
-    return out;
-#else
     return strdup("");
-#endif
 }
 
 long long nurl_tcp_read(long long handle, const char *buf, long long n) {
@@ -3327,27 +2629,6 @@ long long nurl_tcp_read(long long handle, const char *buf, long long n) {
         h->err_kind = NURL_NET_ERR_READ;
         return -1;
     }
-#ifdef NURL_HAVE_OPENSSL
-    if (h->ssl) {
-        int max = n > 0x40000000 ? 0x40000000 : (int)n;
-        int rd = SSL_read(h->ssl, (void*)buf, max);
-        if (rd > 0) { h->err_kind = NURL_NET_ERR_OK; return (long long)rd; }
-        int err = SSL_get_error(h->ssl, rd);
-        if (err == SSL_ERROR_ZERO_RETURN) {
-            /* clean TLS close_notify */
-            return 0;
-        }
-        /* WANT_READ / WANT_WRITE after a blocking SSL_read with a fd
-         * that has SO_RCVTIMEO set surfaces here as well; map to
-         * timeout so the keep-alive loop's idle-timeout path triggers. */
-        if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
-            h->err_kind = NURL_NET_ERR_TIMEOUT;
-            return -1;
-        }
-        h->err_kind = NURL_NET_ERR_READ;
-        return -1;
-    }
-#endif
 #ifdef _WIN32
     int rd = recv(h->fd, (char*)buf, (n > 0x40000000 ? 0x40000000 : (int)n), 0);
 #else
@@ -3382,23 +2663,6 @@ long long nurl_tcp_write(long long handle, const char *buf, long long n) {
         h->err_kind = NURL_NET_ERR_WRITE;
         return -1;
     }
-#ifdef NURL_HAVE_OPENSSL
-    if (h->ssl) {
-        long long total = 0;
-        while (total < n) {
-            long long want = n - total;
-            int chunk = (int)(want > 0x40000000 ? 0x40000000 : want);
-            int wn = SSL_write(h->ssl, buf + total, chunk);
-            if (wn <= 0) {
-                h->err_kind = NURL_NET_ERR_WRITE;
-                return -1;
-            }
-            total += (long long)wn;
-        }
-        h->err_kind = NURL_NET_ERR_OK;
-        return total;
-    }
-#endif
     long long total = 0;
     while (total < n) {
         long long want = n - total;
@@ -3461,33 +2725,6 @@ void nurl_tcp_set_nonblock(long long handle, long long on) {
  * async accept fiber still references defer it until that fiber's ref is
  * released (see nurl_tcp_close / nurl_tcp_ref). */
 static void nurl__tcp_destroy(NurlTcp *h) {
-#ifdef NURL_HAVE_OPENSSL
-    /* Best-effort one-way SSL_shutdown (skip bidirectional close — keeps
-     * workers fast). SSL_free does not close the underlying fd. */
-    if (h->ssl) {
-        SSL_shutdown(h->ssl);
-        SSL_free(h->ssl);
-        h->ssl = NULL;
-    }
-    if (h->ssl_ctx) {
-        SSL_CTX_free(h->ssl_ctx);
-        h->ssl_ctx = NULL;
-    }
-    free(h->alpn_wire);
-    h->alpn_wire = NULL;
-    h->alpn_wire_len = 0;
-    if (h->sni_entries) {
-        for (size_t i = 0; i < h->sni_count; i++) {
-            free(h->sni_entries[i].hostname);
-            if (h->sni_entries[i].ctx) SSL_CTX_free(h->sni_entries[i].ctx);
-        }
-        free(h->sni_entries);
-        h->sni_entries = NULL;
-        h->sni_count = 0;
-        h->sni_cap = 0;
-    }
-    nurl__tls_lock_destroy(h);
-#endif
     if (h->fd != NURL_INVALID_SOCK) {
         nurl_close_sock(h->fd);
         h->fd = NURL_INVALID_SOCK;

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -245,10 +245,13 @@ $ `stdlib/std/pkey.nu`
     ^ ( tcp_listen_tls_with_backlog host port backlog cert_path key_path )
 }
 
-// Read the negotiated ALPN protocol off an accepted TLS conn. The pure
-// stack does not negotiate ALPN yet, so this returns "".
+// Read the negotiated ALPN protocol off a TLS conn (client kind 1 or a
+// STARTTLS upgrade). Returns "" for plaintext conns or when no ALPN was
+// negotiated. Server-side ALPN is not parsed yet.
 @ tcp_alpn_protocol TcpConn c → String {
-    ^ ( string_new )
+    : i tp ( __conn_tlsptr c )
+    ? == tp 0 { ^ ( string_new ) } {}
+    ^ ( tls_alpn_selected # *TlsConn tp )
 }
 
 // Open a verified (or, with verify = 0, encrypted-only) pure-TLS client
@@ -264,58 +267,45 @@ $ `stdlib/std/pkey.nu`
     }
 }
 
+// As tcp_connect_tls, but offers a single ALPN protocol (e.g. "h2").
+// After connecting, the negotiated protocol is read with
+// tcp_alpn_protocol — empty if the server declined ALPN. With verify the
+// chain is validated AND the ALPN handshake runs; on TLS 1.2 servers the
+// pure stack does not parse ALPN, so callers requiring h2 should check.
+@ tcp_connect_tls_alpn s host i port s server_name i verify s alpn → !TcpConn NetErr {
+    : i raw ( nurl_tcp_connect host port )
+    ? <= raw 0 { ^ @ !TcpConn NetErr { F # NetErr NetTlsHandshake } } {}
+    : !*TlsConn TlsErr r ? != verify 0 ( tls_attach_alpn_verify raw server_name alpn ) ( tls_attach_alpn raw server_name alpn )
+    ?? r {
+        F _ → ^ @ !TcpConn NetErr { F # NetErr NetTlsHandshake }
+        T tc → ^ @ !TcpConn NetErr { T @ TcpConn { # s 0 1 # i tc } }
+    }
+}
+
 // Register a per-hostname cert/key pair on a TLS listener for Server
-// Name Indication (RFC 6066 §3). The cert presented to the client is
-// selected at handshake time based on the client's SNI extension:
-// matching hostname → its dedicated SSL_CTX; no match → falls through
-// to the listener's default cert. May be called repeatedly; in-flight
-// connections are unaffected. Idempotent on re-add (replaces the
-// stored cert/key for an existing hostname). Required for multi-tenant
-// HTTPS where one listener serves several virtual hosts.
+// Name Indication (RFC 6066 §3). NOT YET SUPPORTED on the pure-NURL TLS
+// server (tls_server.nu serves a single default cert) — returns NetOther
+// so callers can detect the gap rather than silently serving the wrong
+// cert. (The old OpenSSL-backed multi-cert SNI path was removed with
+// libssl.) TODO: per-SNI cert selection in tls_accept.
 @ tcp_tls_add_sni TcpListener l s hostname s cert_path s key_path → !v NetErr {
-    : s rp . l raw
-    : i raw # i rp
-    : i rc ( nurl_tcp_tls_add_sni raw hostname cert_path key_path )
-    ? != 0 rc {
-        ^ @ !v NetErr { F ( __net_err_of rc ) }
-    } {}
-    ^ @ !v NetErr { T 0 }
+    ^ @ !v NetErr { F # NetErr NetOther }
 }
 
-// Reload the cert/key on a live TLS listener without dropping pending
-// connections. `hostname` selects the target:
-//   * empty string → the listener's DEFAULT cert (set at listen time)
-//   * any other value → the matching SNI entry (Err if not registered)
-// Implementation: build a fresh SSL_CTX from the new cert/key, swap
-// it in atomically under a per-listener mutex, and SSL_CTX_free the
-// old one. OpenSSL refcounts SSL_CTX internally, so any in-flight
-// SSL_read / SSL_write on the old ctx survives until close. Standard
-// use case: Let's Encrypt cert rotation triggered from a control
-// endpoint or SIGHUP handler.
+// Reload the cert/key on a live TLS listener. NOT YET SUPPORTED on the
+// pure-NURL TLS server — returns NetOther. (Was OpenSSL SSL_CTX hot-swap;
+// removed with libssl.) TODO: atomic cert reload for the pure listener.
 @ tcp_tls_reload TcpListener l s hostname s cert_path s key_path → !v NetErr {
-    : s rp . l raw
-    : i raw # i rp
-    : i rc ( nurl_tcp_tls_reload raw hostname cert_path key_path )
-    ? != 0 rc {
-        ^ @ !v NetErr { F ( __net_err_of rc ) }
-    } {}
-    ^ @ !v NetErr { T 0 }
+    ^ @ !v NetErr { F # NetErr NetOther }
 }
 
-// Require (mTLS) or request (opportunistic) client-cert authentication.
-// `ca_bundle_path` points to a PEM file with the trust roots used to
-// verify peer certificates. When `strict` is true, the handshake fails
-// outright if the client doesn't present a cert; when false, the
-// handshake completes regardless and the application reads
-// `tcp_peer_cert_subject` to decide what to do.
+// Require/request client-cert (mTLS) authentication. NOT YET SUPPORTED on
+// the pure-NURL TLS server — returns NetOther DELIBERATELY: silently
+// returning Ok would let a caller believe mTLS is enforced when it is not
+// (a security footgun). (Was OpenSSL client-cert verification; removed
+// with libssl.) TODO: client-cert request + verify in tls_accept.
 @ tcp_tls_require_client_cert TcpListener l s ca_bundle_path b strict → !v NetErr {
-    : s rp . l raw
-    : i raw # i rp
-    : i rc ( nurl_tcp_tls_require_client_cert raw ca_bundle_path ? strict 1 0 )
-    ? != 0 rc {
-        ^ @ !v NetErr { F ( __net_err_of rc ) }
-    } {}
-    ^ @ !v NetErr { T 0 }
+    ^ @ !v NetErr { F # NetErr NetOther }
 }
 
 // Read the peer's certificate Distinguished Name (OpenSSL one-line
@@ -354,11 +344,85 @@ $ `stdlib/std/pkey.nu`
 
 // ── Connection acceptance ──────────────────────────────────────────
 
+// ── STARTTLS registry ──────────────────────────────────────────────
+//
+// An in-place TLS upgrade (tcp_starttls) attaches a *TlsConn to an
+// ALREADY-connected fd (SMTP STARTTLS, etc). A TcpConn is passed BY
+// VALUE, so the upgraded `tlsh`/`kind` can't be written back into the
+// caller's copy. Because the fd is the stable identity across the
+// upgrade, the fd→*TlsConn mapping lives here instead and is consulted
+// by the read/write/close dispatch. The whole thing is gated on
+// g_st_n: a process that never calls tcp_starttls does ZERO lookups.
+//
+// Storage is a malloc'd i64 array of (fd, ptr) pairs (2 words each),
+// grown by doubling. nurl_peek/poke are word-indexed (8-byte cells).
+: ~ i g_st_base 0
+: ~ i g_st_cap 0
+: ~ i g_st_n 0
+
+@ __starttls_grow → v {
+    : i newcap ? == g_st_cap 0 8 * g_st_cap 2
+    : s nb # s ( malloc * newcap 16 )
+    ? != g_st_base 0 {
+        ( nurl_memcpy # *u nb # *u g_st_base * g_st_n 16 )
+        ( nurl_free # s g_st_base )
+    } {}
+    = g_st_base # i nb
+    = g_st_cap newcap
+}
+
+@ __starttls_register i fd i ptr → v {
+    ? >= g_st_n g_st_cap { ( __starttls_grow ) } {}
+    : s b # s g_st_base
+    ( nurl_poke b * g_st_n 2 fd )
+    ( nurl_poke b + * g_st_n 2 1 ptr )
+    = g_st_n + g_st_n 1
+}
+
+@ __starttls_lookup i fd → i {
+    ? == g_st_n 0 { ^ 0 } {}
+    : s b # s g_st_base
+    : ~ i k 0
+    ~ < k g_st_n {
+        ? == ( nurl_peek b * k 2 ) fd { ^ ( nurl_peek b + * k 2 1 ) } {}
+        = k + k 1
+    }
+    ^ 0
+}
+
+@ __starttls_unregister i fd → v {
+    ? != g_st_n 0 {
+        : s b # s g_st_base
+        : ~ i k 0
+        : ~ i found 0
+        ~ & == found 0 < k g_st_n {
+            ? == ( nurl_peek b * k 2 ) fd {
+                : i last - g_st_n 1
+                ( nurl_poke b * k 2 ( nurl_peek b * last 2 ) )
+                ( nurl_poke b + * k 2 1 ( nurl_peek b + * last 2 1 ) )
+                = g_st_n last
+                = found 1
+            } {}
+            = k + k 1
+        }
+    } {}
+}
+
+// Resolve a TcpConn's *TlsConn (as i64), or 0 if the conn is plaintext.
+// kinds 1/2 carry it inline in `tlsh`; a STARTTLS-upgraded kind-0 conn
+// is found via the fd registry.
+@ __conn_tlsptr TcpConn c → i {
+    ? != . c tlsh 0 { ^ . c tlsh } {}
+    ? == . c kind 0 { ^ ( __starttls_lookup # i . c raw ) } {}
+    ^ 0
+}
+
 // The fd backing a TcpConn — the runtime handle for plaintext, or the
-// pure TLS conn's socket fd for kinds 1/2.
+// pure TLS conn's socket fd for TLS (kinds 1/2 or STARTTLS-upgraded).
 @ __conn_fd TcpConn c → i {
-    ? != . c kind 0 {
-        : *TlsConn tc # *TlsConn . c tlsh
+    : i tp ( __conn_tlsptr c )
+    ? != tp 0 {
+        : *TlsConn tc # *TlsConn tp
         ^ . tc fd
     } {}
     ^ # i . c raw
@@ -396,7 +460,32 @@ $ `stdlib/std/pkey.nu`
 }
 
 @ tcp_close_conn TcpConn c → v {
-    ? != . c kind 0 { ( tls_close # *TlsConn . c tlsh ) } { ( nurl_tcp_close # i . c raw ) }
+    : i tp ( __conn_tlsptr c )
+    ? != tp 0 {
+        ( __starttls_unregister # i . c raw )
+        ( tls_close # *TlsConn tp )
+    } { ( nurl_tcp_close # i . c raw ) }
+}
+
+// In-place STARTTLS upgrade: run a pure TLS 1.3 handshake over an
+// already-connected plaintext TcpConn's fd, registering the resulting
+// *TlsConn against that fd so subsequent read/write/close on the SAME
+// (by-value) conn transparently go through TLS. `server_name` drives
+// SNI + (when verify) certificate validation. Used by SMTP STARTTLS,
+// IMAP/POP STLS, etc. The conn keeps its identity — no new TcpConn is
+// returned, so callers holding the conn by value see the upgrade.
+@ tcp_starttls TcpConn c s server_name b verify → !v NetErr {
+    : i tp ( __conn_tlsptr c )
+    ? != tp 0 { ^ @ !v NetErr { T 0 } } {}
+    : i fd # i . c raw
+    : !*TlsConn TlsErr r ? verify ( tls_attach_verify fd server_name ) ( tls_attach fd server_name )
+    ?? r {
+        F _ → ^ @ !v NetErr { F # NetErr NetTlsHandshake }
+        T tc → {
+            ( __starttls_register fd # i tc )
+            ^ @ !v NetErr { T 0 }
+        }
+    }
 }
 
 @ tcp_peer_addr TcpConn c → s {
@@ -414,7 +503,7 @@ $ `stdlib/std/pkey.nu`
 // Pure-TLS read dispatch (kind 1 = client, kind 2 = server). Clean EOF
 // (tls_read returns []) is surfaced as NetClosed to match the plain path.
 @ __tls_read_net TcpConn c i max → !( Vec u ) NetErr {
-    : *TlsConn tc # *TlsConn . c tlsh
+    : *TlsConn tc # *TlsConn ( __conn_tlsptr c )
     : !( Vec u ) TlsErr r ? == . c kind 2 ( tls_server_read tc max ) ( tls_read tc max )
     ?? r {
         F e → {
@@ -432,14 +521,14 @@ $ `stdlib/std/pkey.nu`
 }
 
 @ __tls_write_net TcpConn c ( Vec u ) bytes → !v NetErr {
-    : *TlsConn tc # *TlsConn . c tlsh
+    : *TlsConn tc # *TlsConn ( __conn_tlsptr c )
     : !v TlsErr r ? == . c kind 2 ( tls_server_write tc bytes ) ( tls_write tc bytes )
     ?? r { T _ → ^ @ !v NetErr { T 0 } F _ → ^ @ !v NetErr { F # NetErr NetWrite } }
 }
 
 // with a clean peer shutdown. Caller frees the Vec on the Ok path.
 @ tcp_read_chunk TcpConn c i max → !( Vec u ) NetErr {
-    ? != . c kind 0 { ^ ( __tls_read_net c max ) } {}
+    ? != ( __conn_tlsptr c ) 0 { ^ ( __tls_read_net c max ) } {}
     // Context-aware dispatch — see tcp_accept's note.
     : i fcur ( nurl_fiber_current )
     ? != fcur 0 { ^ ( tcp_read_chunk_async c max ) } {}
@@ -469,7 +558,7 @@ $ `stdlib/std/pkey.nu`
 // ── Writing ────────────────────────────────────────────────────────
 
 @ tcp_write_all TcpConn c ( Vec u ) bytes → !v NetErr {
-    ? != . c kind 0 { ^ ( __tls_write_net c bytes ) } {}
+    ? != ( __conn_tlsptr c ) 0 { ^ ( __tls_write_net c bytes ) } {}
     // Context-aware dispatch — see tcp_accept's note.
     : i fcur ( nurl_fiber_current )
     ? != fcur 0 { ^ ( tcp_write_all_async c bytes ) } {}
@@ -491,7 +580,7 @@ $ `stdlib/std/pkey.nu`
 // status-line case). The bytes [0..len) are sent — the trailing NUL is
 // NOT transmitted.
 @ tcp_write_str TcpConn c s text → !v NetErr {
-    ? != . c kind 0 {
+    ? != ( __conn_tlsptr c ) 0 {
         : ( Vec u ) b ( bytes_from_str text )
         : !v NetErr r ( __tls_write_net c b )
         ( vec_free [u] b )

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -106,6 +106,7 @@ $ `stdlib/std/tls_verify.nu`
     i cipher  // 0 = ChaCha20-Poly1305, 1 = AES-128-GCM
     i version  // 13 = TLS 1.3, 12 = TLS 1.2
     ( Vec u ) kx_p256  // P-256 ephemeral private key (empty if X25519 chosen)
+    ( Vec u ) alpn_sel  // ALPN protocol the server selected (empty if none)
 }
 
 // ── small helpers ─────────────────────────────────────────────────
@@ -359,7 +360,7 @@ $ `stdlib/std/tls_verify.nu`
 }
 
 // ── ClientHello ───────────────────────────────────────────────────
-@ __build_client_hello s host ( Vec u ) pubkey ( Vec u ) p256pub ( Vec u ) random ( Vec u ) sessid → ( Vec u ) {
+@ __build_client_hello s host ( Vec u ) pubkey ( Vec u ) p256pub ( Vec u ) random ( Vec u ) sessid s alpn → ( Vec u ) {
     : ( Vec u ) body ( vec_new [u] )
     ( __tls_u16 body 771 )  // legacy_version 0x0303
     ( __tls_cat body random )  // 32-byte random
@@ -455,6 +456,21 @@ $ `stdlib/std/tls_verify.nu`
     ( __blk16 ext ks )
     ( vec_free [u] entry )
     ( vec_free [u] ks )
+
+    // application_layer_protocol_negotiation (0x0010), one protocol
+    // (RFC 7301). Only emitted when a protocol was requested (e.g. "h2");
+    // otherwise the ext is omitted and the connect behaves exactly as before.
+    : i al ( nurl_str_len alpn )
+    ? > al 0 {
+        : ( Vec u ) alp ( vec_new [u] )
+        ( __tls_u16 alp + al 1 )  // ProtocolNameList length
+        ( vec_push [u] alp # u al )  // protocol name length
+        : ~ i ak 0
+        ~ < ak al { ( vec_push [u] alp # u ( nurl_str_get alpn ak ) ) = ak + ak 1 }
+        ( __tls_u16 ext 16 )
+        ( __blk16 ext alp )
+        ( vec_free [u] alp )
+    } {}
 
     ( __blk16 body ext )
     ( vec_free [u] ext )
@@ -583,7 +599,43 @@ $ `stdlib/std/tls_verify.nu`
 // IMAP/FTP — where the plaintext leg must exchange a few bytes before the
 // channel is upgraded to TLS on the same socket. No certificate
 // verification (see `tls_attach_verify` for the secure variant).
-@ tls_attach i raw s server_name → !*TlsConn TlsErr {
+// Extract the server-selected ALPN protocol from an EncryptedExtensions
+// handshake message (type 8). Returns the protocol bytes (e.g. "h2"), or
+// an empty Vec if the server sent no ALPN extension. Message layout:
+// [type:1][len:3][exts_len:2] then exts; ALPN ext (0x0010) data is
+// [list_len:2][name_len:1][name…].
+@ __ee_alpn ( Vec u ) msg → ( Vec u ) {
+    : ( Vec u ) out ( vec_new [u] )
+    : i n ( vec_len [u] msg )
+    ? < n 6 { ^ out } {}
+    : i extlen ( __rdint msg 4 2 )
+    : i end ? > + 6 extlen n n + 6 extlen
+    : ~ i p 6
+    ~ < p end {
+        ? > + p 4 end { ^ out } {}
+        : i et ( __rdint msg p 2 )
+        : i elen ( __rdint msg + p 2 2 )
+        : i edata + p 4
+        ? == et 16 {
+            ? >= elen 3 {
+                : i nl ( __t_bget msg + edata 2 )
+                : ~ i j 0
+                ~ < j nl {
+                    ( vec_push [u] out # u ( __t_bget msg + + edata 3 j ) )
+                    = j + j 1
+                }
+            } {}
+            ^ out
+        } {}
+        = p + + p 4 elen
+    }
+    ^ out
+}
+
+// Core client handshake. `alpn` is a single ALPN protocol to offer (e.g.
+// "h2"); empty means no ALPN extension is sent. The negotiated protocol
+// (from the server's EncryptedExtensions) is stored in `c.alpn_sel`.
+@ __tls_handshake i raw s server_name s alpn → !*TlsConn TlsErr {
     : i ek ( nurl_tcp_err_kind raw )
     ? != ek 0 { ^ @ !*TlsConn TlsErr { F # TlsErr TlsConnect } } {}
     // Read timeout so an unresponsive/dead peer fails the handshake
@@ -613,6 +665,7 @@ $ `stdlib/std/tls_verify.nu`
     = . c cipher 0
     = . c version 13
     = . c kx_p256 ( vec_new [u] )
+    = . c alpn_sel ( vec_new [u] )
 
     // ── key share ──
     : ( Vec u ) priv ( __rand_bytes 32 )
@@ -628,7 +681,7 @@ $ `stdlib/std/tls_verify.nu`
     : ~ ( Vec u ) tr ( vec_new [u] )
 
     // ── ClientHello ──
-    : ( Vec u ) ch ( __build_client_hello server_name cpub p256pub random sessid )
+    : ( Vec u ) ch ( __build_client_hello server_name cpub p256pub random sessid alpn )
     ( vec_free [u] p256pub )
     ( __tls_cat tr ch )
     : !v TlsErr sw ( __send_plain c 22 ch )
@@ -708,6 +761,14 @@ $ `stdlib/std/tls_verify.nu`
                         ( vec_free [u] . c cv_sig )
                         = . c cv_sig ( bytes_slice msg 8 + 8 siglen )
                     } {}
+                    ? == t 8 {
+                        // EncryptedExtensions — pick up the negotiated ALPN.
+                        : ( Vec u ) sel ( __ee_alpn msg )
+                        ? > ( vec_len [u] sel ) 0 {
+                            ( vec_free [u] . c alpn_sel )
+                            = . c alpn_sel sel
+                        } { ( vec_free [u] sel ) }
+                    } {}
                     ( __tls_cat tr msg )
                 }
                 ( vec_free [u] msg )
@@ -754,6 +815,31 @@ $ `stdlib/std/tls_verify.nu`
     ^ @ !*TlsConn TlsErr { T c }
 }
 
+// Upgrade an already-connected fd to TLS (no ALPN). Insecure: does not
+// verify the certificate (see tls_attach_verify).
+@ tls_attach i raw s server_name → !*TlsConn TlsErr {
+    ^ ( __tls_handshake raw server_name `` )
+}
+
+// Like tls_attach but offers a single ALPN protocol (e.g. "h2"). After a
+// successful handshake the negotiated protocol is readable via
+// tls_alpn_selected (empty if the server declined ALPN). Insecure variant.
+@ tls_attach_alpn i raw s server_name s alpn → !*TlsConn TlsErr {
+    ^ ( __tls_handshake raw server_name alpn )
+}
+
+// The ALPN protocol the server selected, as an owned String ("" if none).
+@ tls_alpn_selected * TlsConn c → String {
+    : String s ( string_new )
+    : i n ( vec_len [u] . c alpn_sel )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [u] . c alpn_sel k ) { T b → ( string_push_char s # i b ) F _ → {} }
+        = k + k 1
+    }
+    ^ s
+}
+
 // Establish a verified TLS 1.3 connection (the secure default): complete
 // the handshake, then verify the server's CertificateVerify signature,
 // the certificate chain up to the system trust store, the validity
@@ -780,6 +866,14 @@ $ `stdlib/std/tls_verify.nu`
 // store (the secure default for STARTTLS-style upgrades).
 @ tls_attach_verify i raw s server_name → !*TlsConn TlsErr {
     : !*TlsConn TlsErr r ( tls_attach raw server_name )
+    ^ ( __verify_conn r server_name )
+}
+
+// Verifying counterpart of tls_attach_alpn: offer an ALPN protocol AND
+// verify the chain / hostname. The negotiated protocol is then readable
+// with tls_alpn_selected.
+@ tls_attach_alpn_verify i raw s server_name s alpn → !*TlsConn TlsErr {
+    : !*TlsConn TlsErr r ( tls_attach_alpn raw server_name alpn )
     ^ ( __verify_conn r server_name )
 }
 
@@ -922,6 +1016,7 @@ $ `stdlib/std/tls_verify.nu`
     ( vec_free [u] . c cv_sig )
     ( vec_free [u] . c th_cert )
     ( vec_free [u] . c kx_p256 )
+    ( vec_free [u] . c alpn_sel )
     ( nurl_free # s c )
 }
 

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -228,6 +228,7 @@ $ `stdlib/std/aes_gcm.nu`
     = . c cert_msg ( vec_new [u] ) = . c cv_sig ( vec_new [u] ) = . c th_cert ( vec_new [u] )
     = . c cv_scheme 0 = . c version 13
     = . c kx_p256 ( vec_new [u] )
+    = . c alpn_sel ( vec_new [u] )
 
     : ( Vec u ) tr ( vec_new [u] )
 


### PR DESCRIPTION
Completes the OpenSSL removal (TODO.md §8 P4). All TLS — client **and** server, handshake + record layer + X.509 + crypto — is now pure NURL. The runtime links neither `libssl` nor `libcrypto`, and the default `./build.sh` produces **libc-only** binaries.

## Stage 3 — migrate client-TLS consumers off the runtime SSL entrypoints
- **mqtt / websocket / smtp / http2_client** now route through net.nu's pure `tcp_connect_tls` / `tcp_connect_tls_alpn` / `tcp_starttls` instead of `nurl_tcp_connect_tls[_alpn]` / `nurl_tcp_starttls`.
- **ALPN** added to the pure TLS client (`tls.nu`): ClientHello extension `0x0010` + EncryptedExtensions parse → `TlsConn.alpn_sel`; default-off so existing connects stay byte-identical. New `tls_attach_alpn[_verify]`, `tls_alpn_selected`; net.nu `tcp_connect_tls_alpn` + `tcp_alpn_protocol`. **LIVE: `h2` negotiated vs Cloudflare.**
- **STARTTLS** in-place upgrade (`tcp_starttls`): a by-value `TcpConn` can't carry the post-upgrade `*TlsConn` back to the caller, so net.nu keeps an `fd→*TlsConn` registry (gated on a counter — plaintext-only processes pay nothing) consulted by the read/write/close dispatch. smtp STARTTLS rewired onto it. Validated by a pure-NURL client+server loopback.
- `tcp_tls_add_sni` / `tcp_tls_reload` / `tcp_tls_require_client_cert` now return `NetOther` (unsupported on the pure server) — notably `require_client_cert` **refuses** rather than silently faking mTLS.

## Stage 4 — delete the SSL code from runtime.c + drop the link flags
- Removed the dlopen vtable + all `SSL_*` call sites (`−801` lines); the `nurl_tcp_*_tls*` functions remain as inert stubs (the compiler prelude still declares a few).
- build.sh / nurl.sh: dropped `-lssl -lcrypto`, the openssl pkg-config detection, `NURL_HAVE_OPENSSL`, and the `runtime.openssl` sentinel.

## Correctness
- Fixed a latent **UAF** surfaced by ASan: `TlsConn` gained an `alpn_sel` Vec field; the server's `tls_accept` didn't initialize it, so `tls_close` freed an uninitialized field. Both `TlsConn` alloc sites now init it.

## Verification
- `nurlc` + pure-TLS binaries: `NEEDED = libc.so.6` only.
- HTTPS LIVE vs example.com; STARTTLS loopback + ALPN `h2` ASan/UBSan-clean.
- Sanitized corpus **SAN_FAIL 0**; bootstrap fixed point holds; nurlfmt gate clean.
- `grep -cE 'SSL_CTX_new\(|SSL_new\(|SSL_read\(|dlopen\("libssl|#include <openssl' runtime.c` = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yovb87eAvBUYmd1UEGCPR