### PR TITLE
compiler: reject `^ value` from `→ v` functions; support bare `^` early return

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -1749,6 +1749,44 @@
     r1
 }
 
+// Emit the `ret` terminator (or branch to the defer chain) after owned-
+// resource drops. Shared by the normal return path and the bare-`^`
+// void early-return. A function declared `→ v` ALWAYS emits `ret void`;
+// `lt`/`val` are the returned value's LLVM type / SSA name (both empty
+// for a bare void return). Keeps the void/non-void `ret` choice keyed on
+// the FUNCTION's return type, not just the value type — so a stray value
+// can never lower to `ret i64 …` out of a `void` function.
+@ gen_ret_term i lex i syms i cg s lt s val s skip s skip_str_ptr s skip_user_ptr s skip_struct_ptr s ret_ident → v {
+    : s dtop ( nurl_sym_get syms `__defer_top__` )
+    : s fn_rt ( nurl_sym_get syms `__fn_ret_ty__` )
+    ? != 0 ( nurl_str_len dtop )
+    {  // defers active: store return value then branch to defer chain
+        ? ! ( seq lt `void` )
+        { : s rvp ( nurl_sym_get syms `__ret_val__` )
+            ( nurl_print `  store ` ) ( nurl_print lt ) ( nurl_print ` ` )
+            ( nurl_print val ) ( nurl_print `, ` ) ( nurl_print lt )
+            ( nurl_print `* ` ) ( nurl_print rvp ) ( nurl_print `\n` )
+        }
+        {}
+        ( nurl_print `  br label %` ) ( nurl_print dtop ) ( emit_dbg_eol )
+    }
+    {  // no defers: drop owned slices then direct return
+        ( mem_drop_owned syms cg skip )
+        ? != 0 g_auto_drop_strings
+        { ( mem_drop_owned_strings syms cg skip_str_ptr )
+            ( mem_drop_owned_struct_fields syms cg skip_struct_ptr )
+            ( mem_drop_user_drops syms cg skip_user_ptr )
+        }
+        {}
+        ( mem_own_closure_remove syms ret_ident )
+        ( mem_drop_closure_envs syms cg )
+        ? | ( seq lt `void` ) ( seq fn_rt `void` )
+        { ( emit_call_term `ret void` ) }
+        { ( nurl_print `  ret ` ) ( nurl_print lt )
+            ( nurl_print ` ` ) ( nurl_print val ) ( emit_dbg_eol ) }
+    }
+}
+
 @ gen_ret i lex i syms i cg → s {
     // Cascade guard: a `^` reached here while parsing a value operand
     // (g_ret_forbidden set by gen_operand / a `?`-condition / `??`-
@@ -1765,6 +1803,26 @@
     // Borrow checker: source line of the `^` token.
     : i bck_line ( nurl_lex_line lex )
     ( nurl_lex_advance lex )
+    // Bare `^` — a return with no value expression (the next token ends
+    // the statement/block). Legal ONLY in a `→ v` function, where it is
+    // an early return that emits `ret void`. In a value-returning
+    // function it is an error (the caller would get garbage), and is
+    // reported here rather than letting gen_operand fail with the
+    // generic "value expression required" cascade message.
+    : i __ret_nt ( nurl_lex_type lex )
+    ? | | == __ret_nt TT_RBRACE == __ret_nt TT_EOF == __ret_nt TT_SEMICOL
+    { : s __ret_frt ( nurl_sym_get syms `__fn_ret_ty__` )
+        ? ( seq __ret_frt `void` )
+        { ( bck_record `ret` `` bck_line )
+            ( gen_ret_term lex syms cg `void` `` `` `` `` `` `` )
+            ( nurl_set_last_type `void` )
+            = g_did_ret 1
+            ^ `` }
+        { ( die lex ( nurl_str_cat ( nurl_str_cat
+            `bare '^' (return) but this function returns '` ( llvm_to_nurl __ret_frt ) )
+            `' — a '^' here must be followed by a return value of that type` ) ) }
+    }
+    {}
     // The `^ ?? value { F e → {…} T m → {…} }` shape looks
     // like "return a match expression", but when ANY arm contains its
     // own `^`, the `??` becomes statement-form and yields `void`, so
@@ -1888,6 +1946,16 @@
         ( die lex ( nurl_str_cat `return expression has no value (expected `
         ( nurl_str_cat ( llvm_to_nurl fn_rt ) hint ) ) ) }
     {}
+    // Inverse of the above: the function is declared `→ v` (returns
+    // nothing) but `^` was handed a real value. Lowering it would emit
+    // `ret <ty> <val>` out of a `void` LLVM function — invalid IR that
+    // historically only clang caught (`ret i64 0` from `→ v`). Reject it
+    // here; the cure is a bare `^` (early return) or a non-void type.
+    ? & ! ( seq lt `void` ) ( seq fn_rt `void` )
+    { ( die lex ( nurl_str_cat ( nurl_str_cat
+        `this function is declared '→ v' (returns nothing) but '^' is given a value of type '` ( llvm_to_nurl lt ) )
+        `' to return — use a bare '^' to return early, or declare a return type` ) ) }
+    {}
     // Return-type agreement (narrow, never-valid clashes only — mirrors the
     // binary-operator check). NURL has no implicit conversions, so returning a
     // float where a non-float is declared (or vice versa), or a pointer/string
@@ -1906,7 +1974,6 @@
         {}
     }
     {}
-    : s dtop ( nurl_sym_get syms `__defer_top__` )
     // Determine which owned-slice binding (if any) is escaping as the return value.
     // Ownership transfers only when the return type is itself a slice AND the
     // returned expression resolved to a simple identifier load.
@@ -1956,34 +2023,7 @@
     ? != 0 ( nurl_str_len ( nurl_sym_get syms `__last_value_borrow__` ) )
     { ( nurl_sym_def syms `__fn_ret_borrow__` `1` ) }
     {}
-    ? != 0 ( nurl_str_len dtop )
-    {  // defers active: store return value then branch to defer chain
-        ? ! ( seq lt `void` )
-        { : s rvp ( nurl_sym_get syms `__ret_val__` )
-            ( nurl_print `  store ` ) ( nurl_print lt ) ( nurl_print ` ` )
-            ( nurl_print val ) ( nurl_print `, ` ) ( nurl_print lt )
-            ( nurl_print `* ` ) ( nurl_print rvp ) ( nurl_print `\n` )
-        }
-        {}
-        ( nurl_print `  br label %` ) ( nurl_print dtop ) ( emit_dbg_eol )
-    }
-    {  // no defers: drop owned slices then direct return
-        ( mem_drop_owned syms cg skip )
-        ? != 0 g_auto_drop_strings
-        { ( mem_drop_owned_strings syms cg skip_str_ptr )
-            ( mem_drop_owned_struct_fields syms cg skip_struct_ptr )
-            ( mem_drop_user_drops syms cg skip_user_ptr )
-        }
-        {}
-        // Return-escape: `^ f` hands f's closure (and its env) to the
-        // caller — do not free it here.
-        ( mem_own_closure_remove syms ret_ident )
-        ( mem_drop_closure_envs syms cg )
-        ? ( seq lt `void` )
-        { ( emit_call_term `ret void` ) }
-        { ( nurl_print `  ret ` ) ( nurl_print lt )
-            ( nurl_print ` ` ) ( nurl_print val ) ( emit_dbg_eol ) }
-    }
+    ( gen_ret_term lex syms cg lt val skip skip_str_ptr skip_user_ptr skip_struct_ptr ret_ident )
     ( nurl_set_last_type `void` )
     = g_did_ret 1
     val

--- a/compiler/tests/outputs/should_fail_bare_return_nonvoid.txt
+++ b/compiler/tests/outputs/should_fail_bare_return_nonvoid.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_void_return_value.txt
+++ b/compiler/tests/outputs/should_fail_void_return_value.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/void_return.txt
+++ b/compiler/tests/outputs/void_return.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+pos
+nonpos
+tail-pos
+tail-nonpos

--- a/compiler/tests/should_fail_bare_return_nonvoid.nu
+++ b/compiler/tests/should_fail_bare_return_nonvoid.nu
@@ -1,0 +1,5 @@
+// A bare `^` (no value) is only legal in a `→ v` function. In a
+// value-returning function it must be rejected, not silently return junk.
+@ f i x → i { ? > x 0 { ^ } {} ^ 0 }
+
+@ main → i { ^ ( f 5 ) }

--- a/compiler/tests/should_fail_void_return_value.nu
+++ b/compiler/tests/should_fail_void_return_value.nu
@@ -1,0 +1,6 @@
+// A function declared `→ v` (returns nothing) must reject `^ <value>`:
+// it would lower to `ret i64 …` out of a void LLVM function (invalid IR
+// that historically only clang caught). The cure is a bare `^`.
+@ f i x → v { ? > x 0 { ^ 0 } {} ( nurl_print `end\n` ) }
+
+@ main → i { ( f 5 ) ^ 0 }

--- a/compiler/tests/void_return.nu
+++ b/compiler/tests/void_return.nu
@@ -1,0 +1,21 @@
+// Returning from a `→ v` function: a bare `^` is an early return
+// (emits `ret void`), and `^ ( void_call )` tail-returns a void call.
+@ note s tag → v { ( nurl_print tag ) ( nurl_print `\n` ) }
+
+@ early i x → v {
+    ? > x 0 { ( note `pos` ) ^ } {}
+    ( note `nonpos` )
+}
+
+@ tail_void i x → v {
+    ? > x 0 { ^ ( note `tail-pos` ) } {}
+    ( note `tail-nonpos` )
+}
+
+@ main → i {
+    ( early 5 )
+    ( early -1 )
+    ( tail_void 5 )
+    ( tail_void -1 )
+    ^ 0
+}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -676,6 +676,13 @@ semantics*, §9).
 `^` is the **return** operator and is strictly unary: `^ expr` returns
 `expr` from the enclosing function.
 
+In a function declared `→ v` (returns nothing) a **bare `^`** — with no
+following value expression — is a valid early return (it emits
+`ret void`). The converse is rejected: giving `^` a value in a `→ v`
+function (`^ 0`) is a compile error, as is a bare `^` in a
+value-returning function (`^` with no expr where a return value is
+required). `^ ( void_call )` is permitted — it tail-returns a `v` call.
+
 `^^` (two adjacent carets, no whitespace) is the **XOR** operator and
 is strictly binary: `^^ a b`. On integer operands it is bitwise XOR; on
 `b` (i1) operands it is logical XOR (no short-circuit — `xor` cannot).


### PR DESCRIPTION
Follow-up to the libssl-removal PR (#287), where I hit this defect while writing net.nu.

## The defect
A function declared `→ v` (returns nothing) **silently accepted** `^ <value>` (e.g. `^ 0`) at typecheck, then lowered it to `ret i64 0` out of a `void` LLVM function — invalid IR that only **clang** rejected, at link time:

```
error: value doesn't match function result type 'void'
  ret i64 0
```

Root cause: `gen_ret`'s final emit branched on the **returned value's** type, not the **function's declared** return type.

A related gap: a **bare `^`** (no value) failed to compile *at all*, so a `→ v` function had **no early-return idiom**.

## Fix (`gen_ret`)
- The `ret void` vs `ret <ty> <val>` choice is now keyed on the function's return type (factored into `gen_ret_term`) — a value can never lower to `ret <ty>` out of a void function.
- `^ <value>` in a `→ v` function is now a **clear compile error** (`declared '→ v' … but '^' is given a value … use a bare '^'`).
- A **bare `^`** is now a valid early return in a `→ v` function (emits `ret void`). A bare `^` in a value-returning function stays an error, with a targeted message.
- `^ ( void_call )` still tail-returns a void call (unchanged).

## Behavior matrix
| code | `→ v` function | value-returning function |
|---|---|---|
| `^` (bare) | ✅ `ret void` (early return) | ❌ error: needs a value |
| `^ 0` | ❌ error: void fn given a value | ✅ returns `0` |
| `^ ( void_call )` | ✅ tail `ret void` | (type-checked as before) |

## Verification
- **Bootstrap fixed point holds** — the new behavior isn't exercised by `nurlc.nu`'s own code, so its emitted IR is byte-identical.
- Corpus **474 PASS**, examples **89 PASS**, nurlfmt clean.
- 3 regression tests added: `void_return` (positive: bare `^` + `^ (void_call)`), `should_fail_void_return_value`, `should_fail_bare_return_nonvoid`.
- Documented in `docs/spec.md` §6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yovb87eAvBUYmd1UEGCPR