### PR TITLE
compiler: reject String-vs-`s` (i8*) argument mismatch at the call site

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -4356,6 +4356,18 @@
     ^ | ( seq at ( nurl_str_cat pt `*` ) ) ( seq pt ( nurl_str_cat at `*` ) )
 }
 
+// A `String` value (`%String`, a headered/managed string) and a raw
+// C-string (`s`, i8* — the bare char data pointer, e.g. from string_data)
+// are DISTINCT types. They are ABI-compatible enough that clang accepts a
+// call passing one where the other is declared, but reinterpreting a
+// String's payload pointer as a managed String (or vice versa) is silent
+// UB — a wild-pointer crash the moment the callee reads the "other"
+// representation. Flag the confusion in either direction at call time.
+@ __arg_str_cstr_mismatch s at s pt → b {
+    ^ | & ( seq at `i8*` ) ( seq pt `%String` )
+    & ( seq at `%String` ) ( seq pt `i8*` )
+}
+
 @ gen_call i lex i syms i cg → s {
     ( nurl_lex_advance lex )
     : s fname ( nurl_lex_val lex )
@@ -4786,7 +4798,7 @@
             : b __at_ptr & > ( nurl_str_len at ) 0
             == ( nurl_str_get at - ( nurl_str_len at ) 1 ) 42
             : b __ps_ptr & > ( nurl_str_len __psrc ) 0 == ( nurl_str_get __psrc 0 ) 42
-            ? & != 0 ( nurl_str_len __psrc ) | __at_ptr __ps_ptr
+            ? & != 0 ( nurl_str_len __psrc ) | | __at_ptr __ps_ptr ( seq at `%String` )
             { : i __plx ( nurl_lex_new __psrc `<param>` )
                 : s __pllvm ( parse_type __plx )
                 ? ( __arg_ptr_depth_mismatch at __pllvm )
@@ -4794,6 +4806,12 @@
                     ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
                     ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
                     `' — pointer-vs-value mismatch (a '*T' was passed where a 'T' value is expected, or vice versa)` ) ) }
+                {}
+                ? ( __arg_str_cstr_mismatch at __pllvm )
+                { ( die lex ( nurl_str_cat3
+                    ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
+                    ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
+                    `' — String vs raw C-string mismatch: 'String' is a managed string, 's' (i8*) a bare char pointer; convert with 'string_data' (String→s) or 'string_from' (s→String)` ) ) }
                 {} }
             {} }
         {}

--- a/compiler/tests/outputs/should_fail_arg_cstr_for_string.txt
+++ b/compiler/tests/outputs/should_fail_arg_cstr_for_string.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_arg_string_for_cstr.txt
+++ b/compiler/tests/outputs/should_fail_arg_string_for_cstr.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_arg_cstr_for_string.nu
+++ b/compiler/tests/should_fail_arg_cstr_for_string.nu
@@ -1,0 +1,11 @@
+// Passing a raw C-string `s` (i8*) where a `String` (managed) parameter is
+// declared is silent UB (ABI-compatible, wrong representation) — must be a
+// compile error. Convert with `string_from`.
+$ `stdlib/core/string.nu`
+
+@ takes_string String s → i { ^ ( string_len s ) }
+
+@ main → i {
+    : String x ( string_from `hello` )
+    ^ ( takes_string ( string_data x ) )
+}

--- a/compiler/tests/should_fail_arg_string_for_cstr.nu
+++ b/compiler/tests/should_fail_arg_string_for_cstr.nu
@@ -1,0 +1,10 @@
+// The converse: passing a `String` where a raw C-string `s` (i8*) is
+// declared must also be rejected. Convert with `string_data`.
+$ `stdlib/core/string.nu`
+
+@ takes_cstr s p → i { ^ ( nurl_str_len p ) }
+
+@ main → i {
+    : String x ( string_from `hello` )
+    ^ ( takes_cstr x )
+}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -280,6 +280,15 @@ Variadic FFI calls auto-promote `f32 → double` via `fpext` and narrow
 integers (`i1` / `i8` / `i16`, sign-aware) → `i32` via `sext` / `zext`
 per ISO C §6.5.2.2 (grammar v1.9).
 
+`s` (a raw `i8*` C-string) and the stdlib `String` (a managed,
+length-headered string, LLVM `%String`) are **distinct types** despite
+both being pointer-shaped. They are ABI-compatible enough that a call
+passing one where the other is declared would assemble and link, but
+reinterpreting one representation as the other is silent
+wild-pointer UB — so the compiler **rejects it at the call site**
+(in either direction). Convert explicitly: `string_data` (`String → s`)
+or `string_from` (`s → String`).
+
 ### 4.2 Pointer types
 
 `*T` is a raw pointer to T. `*void` is rewritten to `i8*` in the IR


### PR DESCRIPTION
The defect found during the RSA TLS work (#289): passing a raw C-string `s` (i8\*) where a `String` parameter is declared — or vice versa — type-checked clean and assembled (the two are ABI-shaped alike), but reinterpreting a managed `String`'s payload pointer as a bare char pointer (or the reverse) is **silent wild-pointer UB**. It surfaced as a SEGV in `net.nu`'s `__net_cert_chain` (an `s` param handed to `string_substr`, which wants `String`).

## Fix
The call-time argument checker already flagged the **pointer-depth** class (`*T` vs `T`) and had one-off special cases for `nurl_str_len` / `string_len`. This generalises it:

- New `__arg_str_cstr_mismatch` flags `i8*` ↔ `%String` in **either direction** for any `@`-fn call, with a fix-it message (`string_data` for String→s, `string_from` for s→String).
- The guard is widened so the `String`→`s` direction (where neither side is pointer-syntax) is also checked.

## Behavior
| call | result |
|---|---|
| `s` where `String` expected | ❌ compile error (was SEGV at runtime) |
| `String` where `s` expected | ❌ compile error |
| `s`→`s`, `String`→`String` | ✅ compiles |

## Verification
- **Diagnostic-only** — IR for valid programs is byte-identical, so the **bootstrap fixed point holds**. The whole corpus + stdlib compile unchanged (no latent offenders existed).
- Corpus **477 PASS** (+2 new `should_fail_*` tests), examples **89 PASS**, nurlfmt clean.
- Documented in `docs/spec.md` §4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yovb87eAvBUYmd1UEGCPR