### PR TITLE
compiler: reject wrong named-struct-by-value argument at the call site

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -4368,6 +4368,23 @@
     & ( seq at `%String` ) ( seq pt `i8*` )
 }
 
+// A NAMED aggregate LLVM type: `%Name` (a struct / enum handle), NOT a
+// pointer (`…*`) and NOT a bare scalar (i64/double/i1/i8 carry no `%`).
+@ __is_named_agg s t → b {
+    ? == 0 ( nurl_str_len t ) { ^ F } {}
+    ? != ( nurl_str_get t 0 ) 37 { ^ F } {}  // leading '%'
+    ^ != ( nurl_str_get t - ( nurl_str_len t ) 1 ) 42  // not a pointer
+}
+
+// Two DIFFERENT named aggregates passed by value — e.g. a `B` value where
+// an `A` is declared. clang silently coerces the call (reads the foreign
+// struct's leading fields as the declared type), a silent miscompile.
+// Both sides must be `%`-named aggregates so scalars/pointers and the
+// enum↔i64 / numeric-width coercions are never touched.
+@ __arg_named_struct_mismatch s at s pt → b {
+    ^ & & ( __is_named_agg at ) ( __is_named_agg pt ) ! ( seq at pt )
+}
+
 @ gen_call i lex i syms i cg → s {
     ( nurl_lex_advance lex )
     : s fname ( nurl_lex_val lex )
@@ -4798,7 +4815,7 @@
             : b __at_ptr & > ( nurl_str_len at ) 0
             == ( nurl_str_get at - ( nurl_str_len at ) 1 ) 42
             : b __ps_ptr & > ( nurl_str_len __psrc ) 0 == ( nurl_str_get __psrc 0 ) 42
-            ? & != 0 ( nurl_str_len __psrc ) | | __at_ptr __ps_ptr ( seq at `%String` )
+            ? & != 0 ( nurl_str_len __psrc ) | | | __at_ptr __ps_ptr ( seq at `%String` ) ( __is_named_agg at )
             { : i __plx ( nurl_lex_new __psrc `<param>` )
                 : s __pllvm ( parse_type __plx )
                 ? ( __arg_ptr_depth_mismatch at __pllvm )
@@ -4812,6 +4829,12 @@
                     ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
                     ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
                     `' — String vs raw C-string mismatch: 'String' is a managed string, 's' (i8*) a bare char pointer; convert with 'string_data' (String→s) or 'string_from' (s→String)` ) ) }
+                {}
+                ? ( __arg_named_struct_mismatch at __pllvm )
+                { ( die lex ( nurl_str_cat3
+                    ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
+                    ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
+                    `' — wrong struct type passed by value (a value of one named type where a different one is declared); the call would silently reinterpret its fields` ) ) }
                 {} }
             {} }
         {}

--- a/compiler/tests/outputs/should_fail_arg_wrong_struct.txt
+++ b/compiler/tests/outputs/should_fail_arg_wrong_struct.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_arg_wrong_struct.nu
+++ b/compiler/tests/should_fail_arg_wrong_struct.nu
@@ -1,0 +1,16 @@
+// Passing a value of one named struct type where a DIFFERENT named struct
+// is declared by-value compiles (clang coerces, reading the foreign
+// struct's leading fields) — a silent miscompile. Must be a call-site
+// error. Only by-value named aggregates are checked, so scalars / enums
+// (i64) / pointers are untouched.
+$ `stdlib/core/string.nu`
+
+: A { i x i y }
+: B { i p i q i r }
+
+@ takes_a A a → i { ^ . a x }
+
+@ main → i {
+    : B b @ B { 1 2 3 }
+    ^ ( takes_a b )
+}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -289,6 +289,15 @@ wild-pointer UB — so the compiler **rejects it at the call site**
 (in either direction). Convert explicitly: `string_data` (`String → s`)
 or `string_from` (`s → String`).
 
+More generally, the call-site argument check rejects three silent-coercion
+classes for calls to non-generic functions: a pointer-vs-value mismatch
+(`*T` where a `T` value is declared, or vice versa), the `String`/`s`
+confusion above, and **passing one named struct value where a different
+named struct is declared** (`%A` vs `%B` by value — clang would otherwise
+coerce the call and reinterpret the foreign struct's leading fields).
+Scalars (including enums, which are `i64`) and pointers are untouched by
+the struct check.
+
 ### 4.2 Pointer types
 
 `*T` is a raw pointer to T. `*void` is rewritten to `i8*` in the IR


### PR DESCRIPTION
Continues the call-site argument type-checker hardening (#290). The last untouched silent-coercion class: passing a value of one **named struct** type where a **different** named struct is declared by value.

```nurl
: A { i x i y }
: B { i p i q i r }
@ takes_a A a → i { ^ . a x }
@ main → i { : B b @ B { 1 2 3 }  ^ ( takes_a b ) }   // was: silently compiles → exit 1
```

clang coerces `call @takes_a(%B …)` into the `%A` param and reads B's leading fields as A — a silent miscompile. Now a compile error.

## Fix
- `__arg_named_struct_mismatch` — fires only when **both** sides are `%`-named aggregates that differ; `__is_named_agg` excludes pointers and bare scalars.
- Run in `gen_call` alongside the existing pointer-depth and String/`s` checks; the entry guard is widened so by-value named-aggregate args reach it.

## Deliberately narrow
Scalars, **enums (which lower to `i64`)**, and pointers are excluded — so the `enum↔i64` / numeric-width coercions that earlier broadening surveys flagged as a false-positive risk stay valid. (Cross-enum confusion is a separate, harder problem — enums share `i64` — and is intentionally not touched here.)

## Verification
- **Diagnostic-only** → IR for valid programs byte-identical, **bootstrap fixed point holds**; the whole corpus + stdlib compile unchanged (no latent offenders).
- Corpus **478 PASS** (+`should_fail_arg_wrong_struct`), examples **89 PASS**, nurlfmt clean.
- `docs/spec.md` §4.1 now documents all three call-site checks (pointer-vs-value, String/`s`, named-struct).

This closes item (b) and most of item (a) from the long-standing arg-typecheck follow-up list; generic-callee arg checking (c) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yovb87eAvBUYmd1UEGCPR