### PR TITLE
Release v0.10.0 — self-sufficiency (libc-only) + clang 15+ minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,130 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-06-26
+
+The **self-sufficiency** release. NURL no longer depends on any third-party
+C library at its core: the entire external-library surface — `libcurl`,
+`libssl`/`libcrypto`, `libpq`, and `libz` — has been removed from the
+runtime and replaced with pure-NURL implementations in the standard library.
+A default `./build.sh` now links **`libc` only** (plus `libm`). The same
+self-contained stdlib provides TLS 1.3 (client *and* server), cryptography,
+HTTP/1.1, and DEFLATE/gzip/zlib — written in NURL, byte-for-byte verified
+against the libraries they replace, and clean under AddressSanitizer.
+
+Alongside the dependency purge: a new pure-NURL `redis` client, a compiler
+type-checking sweep that converts several silent miscompiles into clear
+compile-time errors, and an `O(n²) → O(1)` symbol-table speedup that keeps
+whole-program compilation fast now that HTTP pulls in the full TLS+crypto
+closure.
+
+**Toolchain requirement:** the minimum supported compiler is now
+**clang / LLVM 15+** (was 14+). LLVM 15 emits opaque-pointer IR by default,
+so the build no longer needs the `-opaque-pointers` shim for older clangs.
+
+### Added
+
+- **Pure-NURL TLS 1.3 client in the stdlib** (`std/tls.nu`,
+  `std/tls_verify.nu`) — promoted from the `tls` package so stdlib HTTP/TLS
+  consumers (`anthropic`, `mcp_http`/`mcp_client`, `cluster`, `http_json`,
+  `http2_client`) can build on it. The `tls` package is now a thin
+  re-export facade for backward compatibility. (§8 P0)
+- **Pure-NURL TLS 1.3 server** (`std/tls_server.nu`) — full
+  ServerHello / EncryptedExtensions / Certificate /
+  CertificateVerify (ECDSA P-256) / Finished handshake over `tcp_accept`,
+  EC P-256 private-key PEM loading, ALPN (`h2`) negotiation, and an
+  in-place STARTTLS upgrade. `net.nu`'s `TcpConn` is now polymorphic
+  (plain / TLS-client / TLS-server) so `http_server` gets clean HTTPS.
+  (§8 P4)
+- **RSA leaf-certificate support for the pure TLS server** — RSA-PSS
+  signing (`rsa_pss_sign_sha256`), PKCS#1/#8 key parsing
+  (`rsa_priv_from_pem`), cert-chain transmission, and `tls_accept_rsa`;
+  `net.nu` auto-detects EC vs RSA and frames `fullchain.pem`. (PR #289)
+- **Pure-NURL crypto** filling the gaps left by the OpenSSL removal:
+  AES-256-GCM (`std/aes_gcm.nu`), **Ed25519** sign/verify
+  (`std/ed25519.nu`, a TweetNaCl port reusing the x25519 field
+  arithmetic), **scrypt** (`std/scrypt.nu`, RFC 7914), PBKDF2-HMAC-SHA512,
+  and ECDSA P-256 signing (RFC 6979). All KAT-verified, ASan/LSan-clean.
+  (§8 P1/P2/P4)
+- **Pure-NURL HTTP/1.1 client** (`ext/http_pure.nu`) over the stdlib TLS —
+  one transport+parser driving both the buffered `http_request`/`http_get`
+  family and the pull-based `http_stream_*` API: incremental chunked
+  decoder (live SSE streaming), Content-Length, redirects (301/302/303/
+  307/308), all methods, binary bodies. (§8 P3)
+- **Pure-NURL DEFLATE/inflate/gzip/zlib** (`std/deflate.nu`) — RFC 1951
+  inflate (puff.c port) + greedy-LZ77 deflate, `crc32`/`adler32`, and
+  streaming `inflate_stream` / `deflate_block_dict` for permessage-deflate
+  context takeover. `ext/compress.nu` is rewritten over it
+  (`zlib_*`/`gzip_*`/`raw_deflate_*`). (§8 P6)
+- **`redis` package** — a pure-NURL Redis client speaking RESP2 over a
+  libc TCP socket, with optional TLS (`rediss://`) via the pure `tls`
+  package, so the binary links `libc` only. Flat-arena RESP2 codec
+  (`src/resp.nu`), a typed surface (strings/lists/hashes/sets, `INCR`/
+  `EXPIRE`/`TTL`/`KEYS`, full pub/sub), and a `redis-cli`-style CLI with a
+  REPL and `SUBSCRIBE`/`PSUBSCRIBE` streaming. Validated live against
+  redis:7 (20/20, ASan-clean).
+
+### Changed
+
+- **`ext/crypto.nu` is now a thin facade** over the pure crypto modules —
+  the OpenSSL EVP FFI layer (~35 bindings) is gone; the public API and
+  `CryptoErr`/`CryptoKeypair` types are unchanged, so `noise`/`session`/
+  `jwt`/`http_jwt` consumers compile untouched. (§8 P2)
+- **All client-TLS consumers** (`mqtt`, `websocket`, `http2`, `smtp`) now
+  route through `net.nu`'s pure `tcp_connect_tls[_alpn]` / `tcp_starttls`
+  instead of the OpenSSL-backed runtime helpers. (§8 P4)
+- **Compiler: the symbol table is hash-indexed** (FNV-1a buckets) —
+  `nurl_sym_get` was a backward linear scan over an append-only table, so
+  whole-program compilation was `O(n²)`. Now `O(1)` average lookups with
+  identical semantics (byte-identical IR, bootstrap fixed point holds).
+  Effect: compiling `examples/http_basic.nu` 11.0s → 0.59s, the examples
+  sweep 8m11s → 25s, the corpus stage 7m13s → 1m11s.
+- **Minimum toolchain is clang / LLVM 15+** (was 14+). The build scripts
+  reject older clangs with install guidance; the `-opaque-pointers` shim
+  for clang 13/14 is removed.
+
+### Removed
+
+- **`libcurl`** — the entire C HTTP-client backend (libcurl bridge +
+  WinHTTP + stubs, ~850 lines) is deleted from `runtime.c`; `-lcurl` and
+  its detection are gone from the build. (§8 P3)
+- **`libssl` / `libcrypto`** — all SSL code (the dlopen vtable + ~250
+  `SSL_*` call sites, −801 lines) is deleted from `runtime.c`; `-lssl
+  -lcrypto` and `NURL_HAVE_OPENSSL` are gone from the build. (§8 P4)
+- **`libpq`** — `ext/postgres.nu` (47 FFI bindings) and its examples/test
+  are removed; the pure-NURL `psql` package is the replacement. (§8 P5)
+- **`libz`** — `nurl_z_*` + the `z_stream` ABI are deleted from
+  `runtime.c`; `-lz` and `NURL_HAVE_ZLIB` are gone from the build. (§8 P6)
+- Net effect: the default `./build.sh` produces binaries whose `NEEDED` is
+  `libc.so.6` only (plus `libm`). `libzstd` and `libsqlite3` remain
+  **optional**, behind runtime sentinels and `-Wl,--as-needed`, so a
+  program that does not use them still links `libc` only. (§8 P7)
+
 ### Fixed
 
+- **Compiler type-check sweep** — a focused pass that turns a class of
+  "`nurlc` accepts → `clang` rejects late (or silently miscompiles)" gaps
+  into clear compile-time errors. Diagnostic-only: IR for valid programs is
+  byte-identical and the bootstrap fixed point holds.
+  - **`String` vs `s` (`i8*`) argument mismatch** — passing a raw C-string
+    where a `String` parameter is declared (or vice versa) was silent
+    wild-pointer UB (it surfaced as a SEGV in `net.nu`'s cert-chain code).
+    Now rejected at the call site with a fix-it (`string_data` / `string_from`).
+  - **Wrong named struct by value** — passing a `B` where an `A` is
+    declared by value type-checked clean and let the callee read the
+    foreign struct's leading fields. Now rejected at the call site, in
+    return position (`^ b` from a `→ A` fn), and in struct literals (bad
+    field type or too many fields).
+  - **`^ value` from a `→ v` (void) function** — silently lowered to
+    `ret i64 …` out of a `void` LLVM function. Now a clear error, and a
+    **bare `^`** is supported as an early return in void functions.
+  - **Reassignment and field stores** (`= name v`, `= . obj field v`) — a
+    float-into-`i`, wrong-struct, or `String`-vs-`s` store emitted a
+    type-mismatched `store` that only clang caught. Now rejected (integer
+    width / signedness / pointer-stash coercions stay legal).
+  - **`!b` / `?b` bool payloads** in result/option matches were extracted
+    as `i64` but used as `i1` (`clang` rejected the IR); a `b` branch now
+    truncates the payload back to `i1`.
 - **WASM build of the runtime.** `nurl_read_password` (added in 0.9.19)
   included `<termios.h>` on every non-Windows target, which broke the
   `wasm32-wasi` compile (no termios) used by the playground / API image. It
@@ -5733,7 +5855,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.9.14...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/nurl-lang/nurl/compare/v0.9.19...v0.10.0
 [0.9.14]: https://github.com/nurl-lang/nurl/compare/v0.9.13...v0.9.14
 [0.9.13]: https://github.com/nurl-lang/nurl/compare/v0.9.12...v0.9.13
 [0.9.12]: https://github.com/nurl-lang/nurl/compare/v0.9.11...v0.9.12

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ clang -c stdlib/runtime.c -o stdlib/runtime.o
 ./build.sh
 ```
 
-Requirements: clang/LLVM 14+. Nothing else — Python was removed
+Requirements: clang/LLVM 15+. Nothing else — Python was removed
 from the build path 2026-05-23; the bootstrap snapshot now lives
 as committed LLVM IR (`compiler/nurlc_lastgood.ll`) that clang
 links directly into a working boot compiler. Windows users have

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ clang -c stdlib/runtime.c -o stdlib/runtime.o   # once (already checked in)
 ./nurl.sh examples/fizzbuzz.nu && ./fizzbuzz     # compile & run a program
 ```
 
-The only build-time dependency is **clang / LLVM 14+**. `./install.sh` also
+The only build-time dependency is **clang / LLVM 15+**. `./install.sh` also
 sets up the editor extension and language server in one step. Full instructions
 — prerequisites per OS, manual bootstrap, DWARF debugging — are in
 [`docs/BUILDING.md`](docs/BUILDING.md); editor/LSP/formatter setup is in

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -95,9 +95,9 @@ works".)
 
 - Prefer the bundled zig (`<prefix>/zig/zig`, or `$NURL_ZIG`).
 - Else fall back to a system clang: honour `$CLANG`, probe `clang` /
-  `clang-<N>` / a clang-flavoured `cc`; pass `-Xclang -opaque-pointers` on
-  clang 13/14; reject clang < 13; on no compiler at all, exit with install
-  guidance instead of a raw `clang: command not found`.
+  `clang-<N>` / a clang-flavoured `cc`; reject clang < 15 (the minimum —
+  LLVM 15 emits opaque-pointer IR by default); on no compiler at all, exit
+  with install guidance instead of a raw `clang: command not found`.
 
 `nurl.sh` also links a feature library (`-lcurl` / `-lssl` / `-lsqlite3` /
 `-lpq` / `-lz` / `-lzstd`) **only when the emitted IR actually references

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-06-22 · Current release: **0.9.10** · Language: **Grammar
+_Last reviewed: 2026-06-26 · Current release: **0.10.0** · Language: **Grammar
 v2.2** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---
@@ -17,7 +17,7 @@ v2.2** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 NURL is a small systems language with a regular prefix-arity grammar, a
 self-hosted compiler written in NURL, and an LLVM backend. The compiler
 bootstraps to a **byte-identical fixed point** on its own source (stage1 ≡
-stage2). The only build dependency is clang / LLVM 14+.
+stage2). The only build dependency is clang / LLVM 15+.
 
 What is solid today:
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,6 +1,6 @@
 # Building NURL
 
-The only build-time dependency is **clang / LLVM 14+**. No Python, no make,
+The only build-time dependency is **clang / LLVM 15+**. No Python, no make,
 no language-specific package manager. Clone the repo and run `./build.sh`
 (or `build.bat` on Windows). The committed `compiler/nurlc_lastgood.ll`
 snapshot is the only thing that boots the self-hosted chain.
@@ -14,7 +14,7 @@ degrades with a clear diagnostic when absent. See
 
 | Tool | Purpose |
 |---|---|
-| clang / LLVM 14+ | Compile LLVM IR (`.ll`) to a native binary; the only required build-time dependency |
+| clang / LLVM 15+ | Compile LLVM IR (`.ll`) to a native binary; the only required build-time dependency |
 
 **Windows** — install LLVM from [llvm.org/releases](https://llvm.org/releases/)
 (the Windows installer adds `clang.exe` to `PATH`). Command Prompt,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1258,7 +1258,7 @@ build is a three-stage fixed point:
 1. **Stage 0.** `clang` links the committed
    `compiler/nurlc_lastgood.ll` (target-triple-agnostic LLVM IR text)
    plus `stdlib/runtime.o` into a `nurlc_lastgood.bin`. Only build-time
-   dependency is `clang/LLVM 14+`.
+   dependency is `clang/LLVM 15+`.
 2. **Stage 1.** `nurlc_lastgood.bin` compiles `compiler/nurlc.nu` →
    `build/nurlc_self.ll` → `build/nurlc_self`.
 3. **Stage 2.** `nurlc_self` compiles `compiler/nurlc.nu` again →

--- a/nurl.sh
+++ b/nurl.sh
@@ -202,21 +202,18 @@ else
     resolve_clang
     cc_run() { "$CLANG" "$@"; }
     # nurlc emits LLVM IR with opaque pointers (`ptr`) — the default since
-    # LLVM 15. clang 14 needs `-opaque-pointers`; 13 and earlier can't parse
-    # them. (zig's bundled LLVM never needs this.) 15+/17+ need nothing.
+    # LLVM 15, which is NURL's minimum supported clang. Older clangs (13/14
+    # behind `-opaque-pointers`) are no longer supported. (zig's bundled
+    # LLVM never needs this.)
     CLANG_MAJOR="$("$CLANG" --version 2>/dev/null | sed -nE 's/.*version ([0-9]+).*/\1/p' | head -1)"
     if [ -n "$CLANG_MAJOR" ] && [ "$CLANG_MAJOR" -lt 15 ]; then
-        if [ "$CLANG_MAJOR" -ge 13 ]; then
-            OPAQUE_FLAGS="-Xclang -opaque-pointers"
-        else
-            {
-                echo "ERROR: clang $CLANG_MAJOR is too old to build NURL programs."
-                echo "       nurlc emits LLVM IR with opaque pointers (needs LLVM 14+)."
-                echo "       Install a newer clang (e.g. clang-15) and set CLANG=clang-15,"
-                echo "       or use the bundled zig backend (set NURL_ZIG=/path/to/zig)."
-            } >&2
-            exit 1
-        fi
+        {
+            echo "ERROR: clang $CLANG_MAJOR is too old to build NURL programs."
+            echo "       nurlc emits LLVM IR with opaque pointers (needs clang/LLVM 15+)."
+            echo "       Install a newer clang (e.g. clang-15) and set CLANG=clang-15,"
+            echo "       or use the bundled zig backend (set NURL_ZIG=/path/to/zig)."
+        } >&2
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
## Summary

Cuts the **v0.10.0** release: documents everything that landed since `v0.9.19` and bumps the toolchain minimum to **clang / LLVM 15+** (was 14+).

The headline is **§8 complete** — NURL no longer depends on any third-party C library at its core. `libcurl`, `libssl`/`libcrypto`, `libpq`, and `libz` are removed from the runtime and replaced with pure-NURL stdlib implementations. A default `./build.sh` now links **`libc` only** (+ `libm`); `libzstd`/`libsqlite3` stay optional behind sentinels + `--as-needed`.

## What's in the release (CHANGELOG `[0.10.0]`)

- **Removed libs:** libcurl (C HTTP backend, ~850 LOC), libssl/libcrypto (~250 `SSL_` call sites, −801 LOC), libpq (`ext/postgres.nu`), libz (`nurl_z_*` + `z_stream` ABI).
- **Added pure-NURL:** TLS 1.3 client (`std/tls.nu`) + server (`std/tls_server.nu`, incl. RSA leaf certs), crypto (AES-256-GCM, Ed25519, scrypt, PBKDF2-HMAC-SHA512, ECDSA P-256), HTTP/1.1 client (`ext/http_pure.nu`), DEFLATE/gzip/zlib (`std/deflate.nu`), and a `redis` package (RESP2 + pub/sub + optional `rediss://` TLS).
- **Compiler:** symbol table hash-indexed `O(n²)→O(1)` (examples sweep 8m11s→25s); type-check sweep rejecting silent miscompiles (`String` vs `s`, wrong named-struct by value, `^ value` from `→ v`, reassignment/field-store clashes, `!b`/`?b` bool payloads).
- **WASM:** `nurl_read_password` WASI fallback (no termios).

## Toolchain bump (clang 15+ everywhere)

`clang/LLVM 14+ → 15+` in README, CONTRIBUTING, ROADMAP, docs/BUILDING.md, docs/spec.md, RELEASING.md; `nurl.sh` now rejects clang < 15 (LLVM 15 emits opaque-pointer IR by default, so the `-opaque-pointers` shim for clang 13/14 is dropped). The historical CHANGELOG entry mentioning 14+ is left as-is.

## Notes

- Docs + build-gate change only; no compiler/runtime source touched.
- Verified the clang-15 gate accepts the local clang 18 and that `nurl.sh` parses (`bash -n`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)