### PR TITLE
nurlweb: add FreeBSD target box, merge macOS into one

### DIFF
--- a/nurlweb/public/index.html
+++ b/nurlweb/public/index.html
@@ -9,7 +9,7 @@
 
 <meta property="og:type" content="website" />
 <meta property="og:title" content="NURL — A Programming Language for Language Models" />
-<meta property="og:description" content="Self-hosting, LLVM-based, Rust-class performance. Tested on Linux, Windows, macOS, WebAssembly, Milk-V Duo and ESP32. Try it in the browser playground." />
+<meta property="og:description" content="Self-hosting, LLVM-based, Rust-class performance. Tested on Linux, Windows, macOS, FreeBSD, WebAssembly, Milk-V Duo and ESP32. Try it in the browser playground." />
 <meta property="og:url" content="https://nurl-lang.org/" />
 <meta name="twitter:card" content="summary" />
 
@@ -266,8 +266,8 @@
     <div class="targets">
       <div class="target"><span class="dot"></span><span class="name">Linux x86_64</span><span class="meta">native · CI every push</span></div>
       <div class="target"><span class="dot"></span><span class="name">Windows x86_64</span><span class="meta">.exe · playground</span></div>
-      <div class="target"><span class="dot"></span><span class="name">macOS x86_64</span><span class="meta">tested · playground</span></div>
-      <div class="target"><span class="dot"></span><span class="name">macOS ARM64</span><span class="meta">tested · playground</span></div>
+      <div class="target"><span class="dot"></span><span class="name">macOS (x64 + ARM64)</span><span class="meta">Mach-O · tested · playground</span></div>
+      <div class="target"><span class="dot"></span><span class="name">FreeBSD x86_64</span><span class="meta">FreeBSD 14 VM · release archive</span></div>
       <div class="target"><span class="dot"></span><span class="name">WebAssembly</span><span class="meta">wasm32-wasi · in-browser</span></div>
       <div class="target"><span class="dot"></span><span class="name">Linux ARM64</span><span class="meta">musl + glibc · playground</span></div>
       <div class="target"><span class="dot"></span><span class="name">Linux RISC-V 64</span><span class="meta">static musl · playground</span></div>


### PR DESCRIPTION
## nurlweb: give FreeBSD a target box; merge the two macOS boxes

The platform grid on the landing page had **no FreeBSD entry**, even though the
toolchain ships a verified **FreeBSD x86_64** release archive — built and
smoke-tested in a real FreeBSD 14 VM (vmactions), and already offered in the
page's own download section.

Changes:
- **Add** a `FreeBSD x86_64` box (`FreeBSD 14 VM · release archive`).
- **Merge** the separate `macOS x86_64` + `macOS ARM64` boxes into one
  `macOS (x64 + ARM64)` (`Mach-O · tested · playground`).
- Net box count stays **10**, so the "10 tested targets" copy still holds.
- Add FreeBSD to the `og:description` platform list.

The playground cross-compile paragraph is intentionally left unchanged —
FreeBSD is built natively in a VM, not produced by the playground's
`/build_target` cross-compiler, so it correctly stays off that list. The
targets grid is hand-authored HTML (not touched by `gen-site-facts.sh`, which
only refreshes version/size/count facts), so this edit is deploy-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yovb87eAvBUYmd1UEGCPR
