### PR TITLE
docs+ci: document host platforms & CI gates; promote FreeBSD to a hard gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,9 @@ jobs:
     # http tests use the no-backend path; both classes self-skip via the
     # sentinel-aware harness when their lib is absent.
     #
-    # Best-effort (continue-on-error) until a real run is confirmed green;
-    # drop continue-on-error and add `freebsd` to any required-check set
-    # once it is.
-    continue-on-error: true
+    # Promoted to a hard gate 2026-06-27 after a confirmed-green run on main
+    # (run 28295173147): a FreeBSD failure now fails CI. Add `freebsd` to the
+    # branch-protection required-check set so it blocks merges too.
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ product types via structs), with no subtyping and no implicit conversions.
 
 ---
 
+## Testing & CI
+
+Every push and PR runs the bootstrap fixed point and the full test corpus on
+**Linux and FreeBSD** (a real 14.2 VM), an `examples/` frontend gate, a
+`nurlfmt` canonical-format gate, and the whole corpus under AddressSanitizer +
+UndefinedBehaviorSanitizer. The second OS keeps the toolchain honest — the
+shipped `nurlc` / `nurlpkg` binaries link only libc and `nurl.sh` is POSIX
+`sh`, so the toolchain runs unmodified on glibc, musl / Alpine, and BSD. Gate
+list and how to reproduce each locally:
+[`docs/BUILDING.md`](docs/BUILDING.md#continuous-integration).
+
+---
+
 ## Documentation
 
 | Topic | Document |
@@ -149,7 +162,7 @@ product types via structs), with no subtyping and no implicit conversions.
 | Cryptography & TLS (pure-NURL, no OpenSSL) | [`docs/CRYPTO.md`](docs/CRYPTO.md) |
 | Distributed stack (NAT traversal, overlay, SWIM, CRDTs) | [`docs/DISTRIBUTED.md`](docs/DISTRIBUTED.md) |
 | HTTP API, playground & MCP server | [`docs/PLAYGROUND.md`](docs/PLAYGROUND.md) |
-| Target platforms | [`docs/PLATFORMS.md`](docs/PLATFORMS.md) |
+| Platforms — codegen targets & host OSes (incl. FreeBSD) | [`docs/PLATFORMS.md`](docs/PLATFORMS.md) |
 | Known limitations | [`docs/LIMITATIONS.md`](docs/LIMITATIONS.md) |
 | Gotchas (compiler-diagnosed) | [`docs/GOTCHAS.md`](docs/GOTCHAS.md) |
 | Examples catalogue | [`examples/README.md`](examples/README.md) |

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -29,6 +29,11 @@ PowerShell, or Git Bash all work.
 export PATH="$(brew --prefix llvm)/bin:$PATH"   # add to ~/.zshrc to persist
 ```
 
+**FreeBSD** — the base system already ships `clang`; `build.sh` needs `bash`
+(`pkg install -y bash`), plus `pkgconf` + `sqlite3` for the SQLite FFI tests.
+The toolchain binaries themselves link only libc, so they also run on
+musl/Alpine without extra packages (see [`PLATFORMS.md`](PLATFORMS.md)).
+
 ## Step 1 — Build the C runtime (once)
 
 ```sh
@@ -133,3 +138,19 @@ no other-language toolchain is required.
 Snapshot refresh: `./build.sh --refresh-bootstrap` (re-runs the existing
 `build/nurlc` on the current `nurlc.nu` and overwrites both `.nu` and `.ll`;
 commit them together).
+
+## Continuous integration
+
+Every push and pull request runs [`.github/workflows/ci.yml`](../.github/workflows/ci.yml):
+
+| Job | What it checks |
+|---|---|
+| build + bootstrap fixed point + test corpus | `build.sh` on Linux x86_64 — stage1 ≡ stage2 byte-identical IR, then the snapshot test suite |
+| examples corpus frontend gate | every program under `examples/` compiles (`tools/check_examples.sh`) |
+| `nurlfmt --check` | the whole tree is in canonical format (no drift) |
+| AddressSanitizer + UndefinedBehaviorSanitizer | `build.sh --san` + the corpus under ASan/UBSan/LSan |
+| FreeBSD (VM) | full build + bootstrap + corpus on a real FreeBSD 14.2 guest (`vmactions/freebsd-vm`); the second OS that keeps libc/`sh`-portability honest — it once caught a regression Linux could not (async fibers silently no-op'd on FreeBSD). A hard gate: a FreeBSD failure fails CI. |
+
+A local `./build.sh` reproduces the first two gates; `./build.sh --san` then
+`./compiler/tests/run_san_tests.sh` reproduces the sanitizer gate; and
+`./compiler/tests/nurlfmt_check.sh` reproduces the format gate.

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -1,4 +1,9 @@
-# Target platforms
+# Platforms
+
+Two distinct axes: where compiled NURL programs **run** (codegen targets) and
+where the **toolchain itself** builds and runs (host platforms).
+
+## Codegen targets (where compiled programs run)
 
 The compiler emits LLVM IR and delegates native codegen to `clang`, so any
 target clang supports is reachable in principle. NURL's IR carries no target
@@ -23,3 +28,23 @@ build scripts; the rest are produced through the
 
 Unsigned macOS binaries: clear the Gatekeeper quarantine attribute with
 `xattr -d com.apple.quarantine <bin>` before running.
+
+## Host platforms (where the toolchain runs)
+
+The shipped `nurlc` / `nurlpkg` binaries link **libc only** (optional FFI
+libraries are pulled in `--as-needed`, so a program that uses none stays
+libc-only), and the `nurl.sh` wrapper is POSIX `sh` — no bash, no make, no
+Python. The toolchain therefore runs unmodified on glibc, musl (Alpine), and
+BSD libc.
+
+| Host | Status |
+|---|---|
+| Linux x86_64 (glibc) | primary dev host — `build.sh` + full corpus + sanitizers, every push/PR |
+| Windows x86_64 | `build.bat` runs the same bootstrap + snapshot suite |
+| FreeBSD x86_64 | built + bootstrapped + corpus run on a real FreeBSD 14.2 VM in CI (`.github/workflows/ci.yml`) — a **hard gate**: a FreeBSD failure fails CI. The base system's clang/openssl/zlib cover those FFI tests; `build.sh` needs `bash`. |
+| Alpine / musl | libc-only binaries run; exercised via the static-`musl` cross builds above |
+| macOS | host build works with Homebrew LLVM on `PATH` (see [`BUILDING.md`](BUILDING.md)) |
+
+The FreeBSD job exists because it once caught a real regression the Linux gate
+could not — async fibers silently no-op'd on FreeBSD. CI detail:
+[`BUILDING.md`](BUILDING.md#continuous-integration).


### PR DESCRIPTION
## Summary

The README and docs documented codegen *targets* but never where the **toolchain itself** runs, and **FreeBSD** — already a real CI job (full build + bootstrap fixed point + corpus on a FreeBSD 14.2 VM) — was undocumented. The toolchain's libc-only, POSIX-`sh` portability story was also missing. This makes the documentation match reality and promotes the FreeBSD job from best-effort to a hard gate.

## Changes

- **`docs/PLATFORMS.md`** — split into **Codegen targets (where compiled programs run)** vs a new **Host platforms (where the toolchain runs)** section. The host table covers Linux/Windows/FreeBSD/Alpine-musl/macOS and states the `nurlc`/`nurlpkg` binaries link only libc and `nurl.sh` is POSIX `sh`, so the toolchain runs unmodified on glibc, musl, and BSD. Includes the FreeBSD regression story (async fibers once silently no-op'd there).
- **`docs/BUILDING.md`** — FreeBSD prerequisites + a new **Continuous integration** section: a job table (Linux bootstrap+corpus, `examples/` frontend gate, `nurlfmt --check`, ASan/UBSan, FreeBSD VM) and how to reproduce each gate locally.
- **`README.md`** — a compact **Testing & CI** section surfacing the FreeBSD VM, sanitizers, format gate, and libc-only portability (links to `BUILDING.md`); relabeled the docs-table Platforms row.
- **`.github/workflows/ci.yml`** — drop `continue-on-error` on the `freebsd` job, promoting it to a **hard gate** (confirmed green on main, run `28295173147`).

## Follow-up (needs repo admin, can't be done in-tree)

Add `FreeBSD (build + bootstrap fixed point + tests, in a VM)` to the branch-protection **required status checks** for `main` so a FreeBSD failure also blocks merges (dropping `continue-on-error` makes it fail the workflow; branch protection makes it block the merge button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)