### PR TITLE
packages/nurl-mcp: local MCP server for the toolchain (stdio + authenticated HTTP)

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -88,6 +88,25 @@ Modes: `spark` (sparkline), `bar` (one `<label> <value>` per line), `hist`
 (`--bins N`), and `line` (`--width`/`--height`). See
 [`chart/README.md`](chart/README.md) for the full CLI and library API.
 
+## `nurl-mcp/` — a local MCP server for the toolchain (installable program)
+
+The LLM-facing counterpart of `nurl-lsp`: a [Model Context
+Protocol](https://modelcontextprotocol.io) server (newline-delimited JSON-RPC
+over stdio) that exposes the *locally installed* compiler to an agent, so it can
+`nurl_build` / `nurl_run` / `nurl_check` / `nurl_fmt` NURL against the host's
+real files and read the installed stdlib (`nurl_list_stdlib` / `nurl_read_stdlib`).
+Unlike the cloud playground MCP, it drives *your* toolchain over *your* files,
+offline. Built on the `stdlib/ext/mcp.nu` primitives; libc-only.
+
+```
+nurlpkg install nurl-mcp
+claude mcp add nurl -- nurl-mcp     # wire into an MCP client (spawned over stdio)
+```
+
+`nurl_run` is real code execution with no sandbox, which is why the server is
+stdio-only (only its spawner can reach it); a token-authenticated `--http` mode
+is deferred. See [`nurl-mcp/README.md`](nurl-mcp/README.md).
+
 ## The full loop
 
 ```bash

--- a/packages/README.md
+++ b/packages/README.md
@@ -103,9 +103,11 @@ nurlpkg install nurl-mcp
 claude mcp add nurl -- nurl-mcp     # wire into an MCP client (spawned over stdio)
 ```
 
-`nurl_run` is real code execution with no sandbox, which is why the server is
-stdio-only (only its spawner can reach it); a token-authenticated `--http` mode
-is deferred. See [`nurl-mcp/README.md`](nurl-mcp/README.md).
+Stdio by default; an optional `--http` transport adds bearer-token auth
+(`--token`), a `--read-only` mode, and gates code execution behind `--allow-run`
+(a non-loopback bind refuses to start without a token). `nurl_run` is real code
+execution with no sandbox — hence those guards. See
+[`nurl-mcp/README.md`](nurl-mcp/README.md).
 
 ## The full loop
 

--- a/packages/nurl-mcp/README.md
+++ b/packages/nurl-mcp/README.md
@@ -1,0 +1,70 @@
+# `nurl-mcp` — a local MCP server for the NURL toolchain
+
+`nurl-mcp` exposes the **locally installed** NURL toolchain to an LLM agent over
+the [Model Context Protocol](https://modelcontextprotocol.io). It is the
+LLM-facing counterpart of `nurl-lsp`: where `nurl-lsp` serves editors over LSP,
+`nurl-mcp` serves an agent over MCP so it can build, run, type-check, and format
+NURL on the host — against the real filesystem and the exact compiler + stdlib
+you have installed.
+
+This is deliberately **not** the broad playground MCP at
+<https://play.nurl-lang.org/mcp> (sandboxed cloud builds, cross-compile to every
+target). `nurl-mcp` is small, local, and offline: its value is that it drives
+*your* toolchain over *your* files — something a remote server cannot do.
+
+It is written in NURL and itself built on the `stdlib/ext/mcp.nu` primitives
+(the same library the playground server uses), so it stays libc-only.
+
+## Install
+
+```sh
+nurlpkg install nurl-mcp        # → ~/.nurl/bin/nurl-mcp
+```
+
+It shells out to `nurl`, `nurlc`, and `nurlfmt`, which the toolchain installer
+(`tools/install-toolchain.sh`) puts on `$PATH` along with `$NURL_STDLIB`. Make
+sure those are present (`nurlc --version`-style smoke test: `echo '@ main → i { ^ 0 }' | …`).
+
+## Wire it into a client
+
+The transport is newline-delimited JSON-RPC 2.0 over **stdio** — the transport
+every MCP client supports. The client spawns the binary and talks to it over the
+pipe; nothing listens on the network.
+
+```sh
+# Claude Code
+claude mcp add nurl -- nurl-mcp
+```
+
+For any other client, configure an MCP server whose `command` is `nurl-mcp`
+(no arguments).
+
+## Tools
+
+| Tool | Arguments | Does |
+|---|---|---|
+| `nurl_build` | `source` *or* `path` | Compile with the local toolchain; report success or compiler diagnostics. Does not run the program. |
+| `nurl_run` | `source` *or* `path` | Compile **and** run; return the program's exit code, stdout, and stderr. |
+| `nurl_check` | `source` *or* `path` | Front-end only — type-check + borrow-check, no binary. Fast. |
+| `nurl_fmt` | `source` *or* `path` | Format to canonical form (`nurlfmt`); return the formatted source. |
+| `nurl_list_stdlib` | — | List the `.nu` modules in the installed stdlib (`$NURL_STDLIB`). |
+| `nurl_read_stdlib` | `name` | Read one stdlib module by path relative to the stdlib root (e.g. `core/string.nu`). |
+
+`source` is inline NURL; `path` is a `.nu` file on the host. Inline source is
+written to a unique temp file that is deleted after the call (build artifacts
+too — the server leaves nothing behind).
+
+## Security
+
+`nurl_run` is **arbitrary code execution**: NURL programs link libc and can make
+any syscall — there is no sandbox (unlike the playground's container). Over
+stdio this is safe, because only the process that spawned the server can talk to
+it. A network transport (`--http`, with token auth and a `--read-only` mode that
+omits `run`) is intentionally **deferred to a later version**; this one is
+stdio-only by design.
+
+## Status
+
+v0.1.0 — first cut. Not yet bundled with the toolchain; install it explicitly.
+Possible follow-ups: the `--http`/token network mode; serving the grammar / spec
+/ examples once the installer ships them; a `nurl_doc` tool.

--- a/packages/nurl-mcp/README.md
+++ b/packages/nurl-mcp/README.md
@@ -54,7 +54,53 @@ For any other client, configure an MCP server whose `command` is `nurl-mcp`
 written to a unique temp file that is deleted after the call (build artifacts
 too — the server leaves nothing behind).
 
+## Transports
+
+**stdio** (default) — described above; the client spawns the binary and talks
+over the pipe. Nothing listens on the network.
+
+**HTTP** (`--http`) — Streamable-HTTP-style `POST /mcp` (JSON-RPC in, JSON-RPC
+out), for clients that speak MCP over HTTP or when the agent runs elsewhere.
+
+```
+nurl-mcp --http [--host ADDR] [--port N] [--token TOK] [--read-only] [--allow-run]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--http` | off (stdio) | Serve over HTTP instead of stdio. |
+| `--host ADDR` | `127.0.0.1` | Bind address. |
+| `--port N` | `8080` | Bind port. |
+| `--token TOK` | none | Require `Authorization: Bearer TOK` on every request (401 otherwise). |
+| `--read-only` | off | Expose only `nurl_check`, `nurl_fmt`, `nurl_list_stdlib`, `nurl_read_stdlib` — no build, no run. |
+| `--allow-run` | off | Allow `nurl_run` over HTTP (see Security). |
+
+```
+# loopback dev server, run enabled, no auth (warns):
+nurl-mcp --http --allow-run
+
+# exposed on the LAN — token is mandatory:
+nurl-mcp --http --host 0.0.0.0 --port 8080 --token "$(head -c32 /dev/urandom | base64)" --allow-run
+```
+
 ## Security
+
+`nurl_run` is **arbitrary code execution**: NURL programs link libc and can make
+any syscall — there is no sandbox (unlike the playground's container).
+
+- **stdio:** `nurl_run` is always available — only the process that spawned the
+  server can reach it.
+- **HTTP:** `nurl_run` is **disabled by default** and must be turned on with
+  `--allow-run`. It is not even advertised in `tools/list` until then.
+- **Non-loopback binds require a token.** `--http --host 0.0.0.0` (anything that
+  isn't `127.0.0.1` / `::1` / `localhost`) **refuses to start** without
+  `--token`. A loopback HTTP server with no token starts but warns.
+- **`--read-only`** removes `nurl_build` and `nurl_run` entirely (on any
+  transport), leaving only analysis/read tools — the mode to expose when you
+  only want the agent to inspect, not execute.
+
+Tool availability is enforced twice: disabled tools are omitted from
+`tools/list` *and* refused (with an explanatory error) if called directly.
 
 `nurl_run` is **arbitrary code execution**: NURL programs link libc and can make
 any syscall — there is no sandbox (unlike the playground's container). Over
@@ -65,6 +111,7 @@ stdio-only by design.
 
 ## Status
 
-v0.1.0 — first cut. Not yet bundled with the toolchain; install it explicitly.
-Possible follow-ups: the `--http`/token network mode; serving the grammar / spec
-/ examples once the installer ships them; a `nurl_doc` tool.
+v0.2.0 — stdio + token-authenticated HTTP transport. Not yet bundled with the
+toolchain; install it explicitly. Possible follow-ups: serving the grammar /
+spec / examples once the installer ships them (a `nurl_doc` tool); a continuous
+SSE notification stream; per-session state.

--- a/packages/nurl-mcp/nurl.toml
+++ b/packages/nurl-mcp/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "nurl-mcp"
+version = "0.1.0"
+description = "Local MCP server for the NURL toolchain — exposes the installed compiler over Model Context Protocol (stdio) so an LLM agent on the host can build, run, type-check, and format NURL, and read the installed stdlib. The editor-facing counterpart of nurl-lsp, for LLMs."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/nurl-mcp/nurl.toml
+++ b/packages/nurl-mcp/nurl.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nurl-mcp"
-version = "0.1.0"
-description = "Local MCP server for the NURL toolchain — exposes the installed compiler over Model Context Protocol (stdio) so an LLM agent on the host can build, run, type-check, and format NURL, and read the installed stdlib. The editor-facing counterpart of nurl-lsp, for LLMs."
+version = "0.2.0"
+description = "Local MCP server for the NURL toolchain — exposes the installed compiler over Model Context Protocol so an LLM agent on the host can build, run, type-check, and format NURL, and read the installed stdlib. Stdio by default; an optional token-authenticated HTTP transport (--http) gates code execution behind --allow-run. The editor-facing counterpart of nurl-lsp, for LLMs."
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/packages/nurl-mcp/src/main.nu
+++ b/packages/nurl-mcp/src/main.nu
@@ -1,0 +1,565 @@
+// nurl-mcp — a local MCP (Model Context Protocol) server for the NURL
+// toolchain. The LLM-facing counterpart of nurl-lsp: where nurl-lsp serves
+// editors over LSP, nurl-mcp serves an LLM agent over MCP so it can drive the
+// *locally installed* compiler — build, run, type-check, format NURL, and read
+// the installed standard library — against the host's real filesystem.
+//
+// Transport: newline-delimited JSON-RPC 2.0 over stdin/stdout (the transport
+// every MCP client supports). Logs go to stderr; stdout is protocol-only.
+// Wire it into an MCP client by pointing its `command` at the built binary,
+// e.g.  `claude mcp add nurl -- nurl-mcp`.
+//
+// The build/run/check/fmt tools shell out to `nurl` / `nurlc` / `nurlfmt`
+// (found on $PATH — the installed toolchain shims export $NURL_STDLIB so the
+// compiler resolves stdlib imports). Running NURL is full code execution
+// (libc FFI, no sandbox); over stdio that is safe because only the process
+// that spawned this server talks to it. A network (`--http`) transport with
+// token auth is intentionally deferred to a later version.
+
+$ `stdlib/ext/mcp.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/process.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/core/posix.nu`
+
+// ── Temp-file plumbing ──────────────────────────────────────────────
+//
+// Inline `source` is written to a unique temp .nu so the file-oriented
+// compiler can read it. `nm_input_temp` records whether the resolved path is
+// such a temp (so we delete it afterward) vs. a user-supplied `path` (left
+// untouched). Single-threaded stdio server ⇒ the global is race-free.
+
+: ~ i nm_input_temp 0
+: ~ i nm_seq 0
+
+@ nm_tmp_path s suffix → String {
+    : String dir ( env_var_or `TMPDIR` `/tmp` )
+    : String p ( string_with_cap 96 )
+    ( string_push_str p ( string_data dir ) )
+    ( string_push_str p `/nurl-mcp-` )
+    ( string_push_int p ( getpid ) )
+    ( string_push_str p `-` )
+    ( string_push_int p nm_seq )
+    ( string_push_str p suffix )
+    = nm_seq + nm_seq 1
+    ( string_free dir )
+    ^ p
+}
+
+@ nm_unlink s path → v {
+    : !Output ProcessErr r ( process_run2 `rm` `-f` path )
+    ?? r {
+        T o → ( output_free o )
+        F e → {}
+    }
+}
+
+// Remove a build's artifacts: the binary `base` and the `base.ll` IR that the
+// build driver leaves beside it.
+@ nm_unlink_artifacts s base → v {
+    ( nm_unlink base )
+    : String ll ( string_from base )
+    ( string_push_str ll `.ll` )
+    ( nm_unlink ( string_data ll ) )
+    ( string_free ll )
+}
+
+// Resolve a tool's input to a .nu file path (owned String) the compiler can
+// read. Prefers an explicit `path`; otherwise writes inline `source` to a
+// temp file. Returns None when neither argument is present.
+@ nm_input_path Json args → ?String {
+    = nm_input_temp 0
+    : ?Json pj ( json_obj_get args `path` )
+    ?? pj {
+        T pv → { ^ @ ?String { T ( string_from ( json_str_data pv ) ) } }
+        F → {}
+    }
+    : ?Json sj ( json_obj_get args `source` )
+    ?? sj {
+        T sv → {
+            : String tmp ( nm_tmp_path `.nu` )
+            : !v IoErr wr ( write_file ( string_data tmp ) ( json_str_data sv ) )
+            ?? wr {
+                T → { = nm_input_temp 1 ^ @ ?String { T tmp } }
+                F e → { ( string_free tmp ) ^ @ ?String { F } }
+            }
+        }
+        F → {}
+    }
+    ^ @ ?String { F }
+}
+
+// ── Result-shaping helpers ──────────────────────────────────────────
+
+// Turn a non-zero-exit Output into an MCP error result carrying the exit code
+// and captured diagnostics. `with_stdout` folds stdout in too (the build
+// driver prints some diagnostics there; the front-end check prints IR there,
+// so check passes F).
+@ nm_fail_from_output s prefix Output o b with_stdout → Json {
+    : String msg ( string_with_cap 256 )
+    ( string_push_str msg prefix )
+    ( string_push_str msg ` (exit ` )
+    ( string_push_int msg ( output_exit_code o ) )
+    ( string_push_str msg `)` )
+    ? > ( output_stderr_len o ) 0 {
+        ( string_push_str msg `\n` )
+        ( string_push_str msg ( output_stderr o ) )
+    } {}
+    ? & with_stdout > ( output_stdout_len o ) 0 {
+        ( string_push_str msg `\n` )
+        ( string_push_str msg ( output_stdout o ) )
+    } {}
+    : Json j ( mcp_tool_result_error ( string_data msg ) )
+    ( string_free msg )
+    ^ j
+}
+
+@ nm_proc_err ProcessErr e → Json {
+    : String m ( string_from `could not launch the NURL toolchain: ` )
+    ( string_push_str m ( process_err_name e ) )
+    ( string_push_str m ` — is "nurl"/"nurlc"/"nurlfmt" on $PATH? (install via tools/install-toolchain.sh)` )
+    : Json j ( mcp_tool_result_error ( string_data m ) )
+    ( string_free m )
+    ^ j
+}
+
+@ nm_missing_input → Json {
+    ^ ( mcp_tool_result_error `provide "source" (inline NURL) or "path" (a .nu file)` )
+}
+
+// ── Tool: nurl_check (front-end type + borrow check, no binary) ──────
+
+@ nm_tool_check Json args → Json {
+    : ?String po ( nm_input_path args )
+    ?? po {
+        T p → {
+            : i temp nm_input_temp
+            : !Output ProcessErr r ( process_run1 `nurlc` ( string_data p ) )
+            ? != temp 0 { ( nm_unlink ( string_data p ) ) } {}
+            ( string_free p )
+            ?? r {
+                T o → {
+                    ? ( output_success o ) {
+                        ( output_free o )
+                        ^ ( mcp_tool_result_text `OK — type-checks and passes the borrow checker.` )
+                    } {
+                        : Json j ( nm_fail_from_output `type / borrow check failed` o F )
+                        ( output_free o )
+                        ^ j
+                    }
+                }
+                F e → { ^ ( nm_proc_err e ) }
+            }
+        }
+        F → {}
+    }
+    ^ ( nm_missing_input )
+}
+
+// ── Tool: nurl_build (compile to a binary, do not run) ──────────────
+
+@ nm_tool_build Json args → Json {
+    : ?String po ( nm_input_path args )
+    ?? po {
+        T p → {
+            : i temp nm_input_temp
+            : String outp ( nm_tmp_path `-bin` )
+            : !Output ProcessErr r ( process_run2 `nurl` ( string_data p ) ( string_data outp ) )
+            ? != temp 0 { ( nm_unlink ( string_data p ) ) } {}
+            ( string_free p )
+            ( nm_unlink_artifacts ( string_data outp ) )
+            ( string_free outp )
+            ?? r {
+                T o → {
+                    ? ( output_success o ) {
+                        ( output_free o )
+                        ^ ( mcp_tool_result_text `OK — compiled successfully.` )
+                    } {
+                        : Json j ( nm_fail_from_output `build failed` o T )
+                        ( output_free o )
+                        ^ j
+                    }
+                }
+                F e → { ^ ( nm_proc_err e ) }
+            }
+        }
+        F → {}
+    }
+    ^ ( nm_missing_input )
+}
+
+// ── Tool: nurl_run (compile then execute, capture output) ───────────
+
+@ nm_run_result Output o → Json {
+    : String body ( string_with_cap 256 )
+    ( string_push_str body `[exit ` )
+    ( string_push_int body ( output_exit_code o ) )
+    ( string_push_str body `]\n` )
+    ? > ( output_stdout_len o ) 0 { ( string_push_str body ( output_stdout o ) ) } {}
+    ? > ( output_stderr_len o ) 0 {
+        ( string_push_str body `\n[stderr]\n` )
+        ( string_push_str body ( output_stderr o ) )
+    } {}
+    : Json j ( mcp_tool_result_text ( string_data body ) )
+    ( string_free body )
+    ^ j
+}
+
+@ nm_tool_run Json args → Json {
+    : ?String po ( nm_input_path args )
+    ?? po {
+        T p → {
+            : i temp nm_input_temp
+            : String outp ( nm_tmp_path `-bin` )
+            : !Output ProcessErr br ( process_run2 `nurl` ( string_data p ) ( string_data outp ) )
+            ? != temp 0 { ( nm_unlink ( string_data p ) ) } {}
+            ( string_free p )
+            ?? br {
+                T bo → {
+                    ? ! ( output_success bo ) {
+                        : Json j ( nm_fail_from_output `build failed` bo T )
+                        ( output_free bo )
+                        ( nm_unlink_artifacts ( string_data outp ) )
+                        ( string_free outp )
+                        ^ j
+                    } {}
+                    ( output_free bo )
+                    : !Output ProcessErr rr ( process_run0 ( string_data outp ) )
+                    ( nm_unlink_artifacts ( string_data outp ) )
+                    ( string_free outp )
+                    ?? rr {
+                        T ro → {
+                            : Json j ( nm_run_result ro )
+                            ( output_free ro )
+                            ^ j
+                        }
+                        F e → { ^ ( nm_proc_err e ) }
+                    }
+                }
+                F e → {
+                    ( string_free outp )
+                    ^ ( nm_proc_err e )
+                }
+            }
+        }
+        F → {}
+    }
+    ^ ( nm_missing_input )
+}
+
+// ── Tool: nurl_fmt (canonical formatting via nurlfmt) ───────────────
+
+@ nm_tool_fmt Json args → Json {
+    : ?Json sj ( json_obj_get args `source` )
+    ?? sj {
+        T sv → {
+            : ( Vec s ) a ( vec_new [s] )
+            ( vec_push [s] a `--stdin` )
+            : !Output ProcessErr r ( process_run `nurlfmt` a ( json_str_data sv ) )
+            ( vec_free [s] a )
+            ?? r {
+                T o → {
+                    ? ( output_success o ) {
+                        : Json j ( mcp_tool_result_text ( output_stdout o ) )
+                        ( output_free o )
+                        ^ j
+                    } {
+                        : Json j ( nm_fail_from_output `format failed` o F )
+                        ( output_free o )
+                        ^ j
+                    }
+                }
+                F e → { ^ ( nm_proc_err e ) }
+            }
+        }
+        F → {}
+    }
+    : ?Json pj ( json_obj_get args `path` )
+    ?? pj {
+        T pv → {
+            : !Output ProcessErr r ( process_run1 `nurlfmt` ( json_str_data pv ) )
+            ?? r {
+                T o → {
+                    ? ( output_success o ) {
+                        : Json j ( mcp_tool_result_text ( output_stdout o ) )
+                        ( output_free o )
+                        ^ j
+                    } {
+                        : Json j ( nm_fail_from_output `format failed` o F )
+                        ( output_free o )
+                        ^ j
+                    }
+                }
+                F e → { ^ ( nm_proc_err e ) }
+            }
+        }
+        F → {}
+    }
+    ^ ( nm_missing_input )
+}
+
+// ── Tool: nurl_list_stdlib ──────────────────────────────────────────
+
+@ nm_tool_list_stdlib Json args → Json {
+    : String root ( env_var_or `NURL_STDLIB` `` )
+    ? == ( string_len root ) 0 {
+        ( string_free root )
+        ^ ( mcp_tool_result_error `NURL_STDLIB is not set — run via the installed toolchain shims, or export it manually` )
+    } {}
+    : !Output ProcessErr r ( process_run3 `find` ( string_data root ) `-name` `*.nu` )
+    ( string_free root )
+    ?? r {
+        T o → {
+            ? ( output_success o ) {
+                : Json j ( mcp_tool_result_text ( output_stdout o ) )
+                ( output_free o )
+                ^ j
+            } {
+                : Json j ( nm_fail_from_output `listing failed` o T )
+                ( output_free o )
+                ^ j
+            }
+        }
+        F e → { ^ ( nm_proc_err e ) }
+    }
+    ^ ( mcp_tool_result_error `internal` )
+}
+
+// ── Tool: nurl_read_stdlib ──────────────────────────────────────────
+
+@ nm_has_dotdot s p → b {
+    : i n ( nurl_str_len p )
+    ? < n 2 { ^ F } {}
+    : ~ i i 0
+    ~ < i - n 1 {
+        ? & == ( nurl_str_get p i ) 46 == ( nurl_str_get p + i 1 ) 46 { ^ T } {}
+        = i + i 1
+    }
+    ^ F
+}
+
+@ nm_tool_read_stdlib Json args → Json {
+    : ?Json nj ( json_obj_get args `name` )
+    ?? nj {
+        T nv → {
+            : s name ( json_str_data nv )
+            ? ( nm_has_dotdot name ) {
+                ^ ( mcp_tool_result_error `invalid name: must not contain ".."` )
+            } {}
+            : String root ( env_var_or `NURL_STDLIB` `` )
+            ? == ( string_len root ) 0 {
+                ( string_free root )
+                ^ ( mcp_tool_result_error `NURL_STDLIB is not set` )
+            } {}
+            : String full ( string_with_cap 160 )
+            ? != ( nurl_str_starts name `/` ) 0 {
+                ( string_push_str full name )
+            } {
+                ( string_push_str full ( string_data root ) )
+                ( string_push_str full `/` )
+                ( string_push_str full name )
+            }
+            ? == ( nurl_str_starts ( string_data full ) ( string_data root ) ) 0 {
+                ( string_free full )
+                ( string_free root )
+                ^ ( mcp_tool_result_error `path escapes the stdlib root` )
+            } {}
+            : !String IoErr rd ( read_file ( string_data full ) )
+            ( string_free full )
+            ( string_free root )
+            ?? rd {
+                T contents → {
+                    : Json j ( mcp_tool_result_text ( string_data contents ) )
+                    ( string_free contents )
+                    ^ j
+                }
+                F e → { ^ ( mcp_tool_result_error `could not read that stdlib file` ) }
+            }
+        }
+        F → {}
+    }
+    ^ ( mcp_tool_result_error `provide a "name" (path under the stdlib root, e.g. core/string.nu)` )
+}
+
+// ── Tool descriptors ────────────────────────────────────────────────
+
+@ nm_prop Json props s name s desc → v {
+    : Json p ( json_obj_new )
+    ( json_obj_set p `type` ( json_str_lit `string` ) )
+    ( json_obj_set p `description` ( json_str_lit desc ) )
+    ( json_obj_set props name p )
+}
+
+@ nm_schema_src_path → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    : Json props ( json_obj_new )
+    ( nm_prop props `source` `Inline NURL source. Provide this OR "path".` )
+    ( nm_prop props `path` `Path to a .nu file on the host. Provide this OR "source".` )
+    ( json_obj_set schema `properties` props )
+    ^ schema
+}
+
+@ nm_schema_name → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    : Json props ( json_obj_new )
+    ( nm_prop props `name` `Path under the stdlib root, e.g. "core/string.nu".` )
+    ( json_obj_set schema `properties` props )
+    : Json req ( json_arr_new )
+    ( json_arr_push req ( json_str_lit `name` ) )
+    ( json_obj_set schema `required` req )
+    ^ schema
+}
+
+@ nm_schema_empty → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    ^ schema
+}
+
+@ build_tools_list → ( Vec Json ) {
+    : ( Vec Json ) tools ( vec_new [Json] )
+    ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_build`
+    `Compile NURL (inline "source" or a "path") with the local toolchain; reports success or compiler diagnostics. Does not run the program.`
+    ( nm_schema_src_path ) ) )
+    ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_run`
+    `Compile AND run NURL with the local toolchain; returns the program's exit code, stdout, and stderr.`
+    ( nm_schema_src_path ) ) )
+    ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_check`
+    `Front-end only: type-check and borrow-check NURL without producing a binary. Fast. Reports diagnostics.`
+    ( nm_schema_src_path ) ) )
+    ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_fmt`
+    `Format NURL to canonical form with nurlfmt; returns the formatted source.`
+    ( nm_schema_src_path ) ) )
+    ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_list_stdlib`
+    `List the .nu modules in the installed standard library (under $NURL_STDLIB).`
+    ( nm_schema_empty ) ) )
+    ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_read_stdlib`
+    `Read one module from the installed standard library by relative path.`
+    ( nm_schema_name ) ) )
+    ^ tools
+}
+
+@ dispatch_tool s name Json args → Json {
+    ? != ( nurl_str_eq name `nurl_build` ) 0 { ^ ( nm_tool_build args ) } {}
+    ? != ( nurl_str_eq name `nurl_run` ) 0 { ^ ( nm_tool_run args ) } {}
+    ? != ( nurl_str_eq name `nurl_check` ) 0 { ^ ( nm_tool_check args ) } {}
+    ? != ( nurl_str_eq name `nurl_fmt` ) 0 { ^ ( nm_tool_fmt args ) } {}
+    ? != ( nurl_str_eq name `nurl_list_stdlib` ) 0 { ^ ( nm_tool_list_stdlib args ) } {}
+    ? != ( nurl_str_eq name `nurl_read_stdlib` ) 0 { ^ ( nm_tool_read_stdlib args ) } {}
+    ^ ( mcp_tool_result_error `unknown tool` )
+}
+
+// ── JSON-RPC method handlers (shape from examples/mcp_echo_server.nu) ─
+
+@ handle_initialize Json id → v {
+    : Json result ( mcp_initialize_result `nurl-mcp` `0.1.0` )
+    ( mcp_send_message ( mcp_response_result id result ) )
+}
+
+@ handle_ping Json id → v {
+    : Json empty ( json_obj_new )
+    ( mcp_send_message ( mcp_response_result id empty ) )
+}
+
+@ handle_tools_list Json id → v {
+    : ( Vec Json ) tools ( build_tools_list )
+    : Json result ( mcp_tools_list_result tools )
+    ( mcp_send_message ( mcp_response_result id result ) )
+}
+
+@ handle_tools_call Json id Json params → v {
+    : ?Json name_j ( json_obj_get params `name` )
+    ?? name_j {
+        T nv → {
+            : s name ( json_str_data nv )
+            : ?Json args_j ( json_obj_get params `arguments` )
+            : Json args ?? args_j {
+                T av → ( json_clone av )
+                F → ( json_obj_new )
+            }
+            : Json result ( dispatch_tool name args )
+            ( json_free args )
+            ( mcp_send_message ( mcp_response_result id result ) )
+        }
+        F → {
+            ( mcp_send_message
+            ( mcp_response_error id mcp_err_invalid_params
+            `tools/call requires a "name" parameter` ) )
+        }
+    }
+}
+
+@ handle_unknown_method Json id s method → v {
+    : i mlen ( nurl_str_len method )
+    : String msg ( string_with_cap + 32 mlen )
+    ( string_push_str msg `unknown method: ` )
+    ( string_push_str msg method )
+    ( mcp_send_message
+    ( mcp_response_error id mcp_err_method_not_found ( string_data msg ) ) )
+    ( string_free msg )
+}
+
+@ handle Json req → v {
+    : ?Json method_j ( json_obj_get req `method` )
+    ?? method_j {
+        T mv → {
+            : s method ( json_str_data mv )
+            : ?Json id_opt ( json_obj_get req `id` )
+            ?? id_opt {
+                T id → {
+                    ? != ( nurl_str_eq method `initialize` ) 0 {
+                        ( handle_initialize id )
+                    } {
+                        ? != ( nurl_str_eq method `ping` ) 0 {
+                            ( handle_ping id )
+                        } {
+                            ? != ( nurl_str_eq method `tools/list` ) 0 {
+                                ( handle_tools_list id )
+                            } {
+                                ? != ( nurl_str_eq method `tools/call` ) 0 {
+                                    : ?Json params_j ( json_obj_get req `params` )
+                                    : Json params ?? params_j {
+                                        T pv → ( json_clone pv )
+                                        F → ( json_obj_new )
+                                    }
+                                    ( handle_tools_call id params )
+                                    ( json_free params )
+                                } {
+                                    ( handle_unknown_method id method )
+                                } } } }
+                }
+                F → {
+                    ? != ( nurl_str_eq method `notifications/initialized` ) 0 {
+                        ( mcp_log `client initialized` )
+                    } {}
+                }
+            }
+        }
+        F → {
+            ( mcp_log `request without method, ignoring` )
+        }
+    }
+}
+
+@ main → i {
+    ( mcp_log `nurl-mcp 0.1.0 ready (stdio)` )
+    : ~ b running T
+    ~ running {
+        : ?Json msg ( mcp_read_request )
+        ?? msg {
+            T req → {
+                ( handle req )
+                ( json_free req )
+            }
+            F → {
+                = running F
+            }
+        }
+    }
+    ( mcp_log `bye` )
+    ^ 0
+}

--- a/packages/nurl-mcp/src/main.nu
+++ b/packages/nurl-mcp/src/main.nu
@@ -23,6 +23,26 @@ $ `stdlib/std/process.nu`
 $ `stdlib/std/fs.nu`
 $ `stdlib/ext/env.nu`
 $ `stdlib/core/posix.nu`
+$ `stdlib/std/args.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_server.nu`
+
+// ── Policy (set once in main, read by the dispatcher) ───────────────
+//
+// g_read_only : 1 ⇒ expose only the read/analysis tools (check, fmt,
+//               list_stdlib, read_stdlib) — no build, no run.
+// g_run_allowed : 1 ⇒ nurl_run is available. Defaults to 1 over stdio
+//               (only the spawning process can reach the server); over
+//               HTTP it is 0 unless --allow-run is passed, because run
+//               is unsandboxed code execution.
+// g_token     : non-empty ⇒ HTTP requests must carry
+//               `Authorization: Bearer <g_token>`.
+: ~ i g_read_only 0
+: ~ i g_run_allowed 1
+: ~ s g_token ``
 
 // ── Temp-file plumbing ──────────────────────────────────────────────
 //
@@ -31,8 +51,21 @@ $ `stdlib/core/posix.nu`
 // such a temp (so we delete it afterward) vs. a user-supplied `path` (left
 // untouched). Single-threaded stdio server ⇒ the global is race-free.
 
-: ~ i nm_input_temp 0
 : ~ i nm_seq 0
+
+// A resolved input path is a temp we own iff it sits under the
+// "<tmpdir>/nurl-mcp-" prefix nm_tmp_path mints. Path-based (not a shared
+// mutable flag) so it stays correct if requests are ever served on
+// concurrent fibers.
+@ nm_is_temp s path → b {
+    : String dir ( env_var_or `TMPDIR` `/tmp` )
+    : String pref ( string_from ( string_data dir ) )
+    ( string_push_str pref `/nurl-mcp-` )
+    : b r ? != ( nurl_str_starts path ( string_data pref ) ) 0 T F
+    ( string_free dir )
+    ( string_free pref )
+    ^ r
+}
 
 @ nm_tmp_path s suffix → String {
     : String dir ( env_var_or `TMPDIR` `/tmp` )
@@ -70,7 +103,6 @@ $ `stdlib/core/posix.nu`
 // read. Prefers an explicit `path`; otherwise writes inline `source` to a
 // temp file. Returns None when neither argument is present.
 @ nm_input_path Json args → ?String {
-    = nm_input_temp 0
     : ?Json pj ( json_obj_get args `path` )
     ?? pj {
         T pv → { ^ @ ?String { T ( string_from ( json_str_data pv ) ) } }
@@ -82,7 +114,7 @@ $ `stdlib/core/posix.nu`
             : String tmp ( nm_tmp_path `.nu` )
             : !v IoErr wr ( write_file ( string_data tmp ) ( json_str_data sv ) )
             ?? wr {
-                T → { = nm_input_temp 1 ^ @ ?String { T tmp } }
+                T → { ^ @ ?String { T tmp } }
                 F e → { ( string_free tmp ) ^ @ ?String { F } }
             }
         }
@@ -135,9 +167,8 @@ $ `stdlib/core/posix.nu`
     : ?String po ( nm_input_path args )
     ?? po {
         T p → {
-            : i temp nm_input_temp
             : !Output ProcessErr r ( process_run1 `nurlc` ( string_data p ) )
-            ? != temp 0 { ( nm_unlink ( string_data p ) ) } {}
+            ? ( nm_is_temp ( string_data p ) ) { ( nm_unlink ( string_data p ) ) } {}
             ( string_free p )
             ?? r {
                 T o → {
@@ -164,10 +195,9 @@ $ `stdlib/core/posix.nu`
     : ?String po ( nm_input_path args )
     ?? po {
         T p → {
-            : i temp nm_input_temp
             : String outp ( nm_tmp_path `-bin` )
             : !Output ProcessErr r ( process_run2 `nurl` ( string_data p ) ( string_data outp ) )
-            ? != temp 0 { ( nm_unlink ( string_data p ) ) } {}
+            ? ( nm_is_temp ( string_data p ) ) { ( nm_unlink ( string_data p ) ) } {}
             ( string_free p )
             ( nm_unlink_artifacts ( string_data outp ) )
             ( string_free outp )
@@ -211,10 +241,9 @@ $ `stdlib/core/posix.nu`
     : ?String po ( nm_input_path args )
     ?? po {
         T p → {
-            : i temp nm_input_temp
             : String outp ( nm_tmp_path `-bin` )
             : !Output ProcessErr br ( process_run2 `nurl` ( string_data p ) ( string_data outp ) )
-            ? != temp 0 { ( nm_unlink ( string_data p ) ) } {}
+            ? ( nm_is_temp ( string_data p ) ) { ( nm_unlink ( string_data p ) ) } {}
             ( string_free p )
             ?? br {
                 T bo → {
@@ -420,14 +449,22 @@ $ `stdlib/core/posix.nu`
     ^ schema
 }
 
+// Policy predicates (read the globals set in main).
+@ nm_build_ok → b { ^ ? == g_read_only 0 T F }
+@ nm_run_ok → b { ^ ? & == g_read_only 0 != g_run_allowed 0 T F }
+
 @ build_tools_list → ( Vec Json ) {
     : ( Vec Json ) tools ( vec_new [Json] )
-    ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_build`
-    `Compile NURL (inline "source" or a "path") with the local toolchain; reports success or compiler diagnostics. Does not run the program.`
-    ( nm_schema_src_path ) ) )
-    ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_run`
-    `Compile AND run NURL with the local toolchain; returns the program's exit code, stdout, and stderr.`
-    ( nm_schema_src_path ) ) )
+    ? ( nm_build_ok ) {
+        ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_build`
+        `Compile NURL (inline "source" or a "path") with the local toolchain; reports success or compiler diagnostics. Does not run the program.`
+        ( nm_schema_src_path ) ) )
+    } {}
+    ? ( nm_run_ok ) {
+        ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_run`
+        `Compile AND run NURL with the local toolchain; returns the program's exit code, stdout, and stderr.`
+        ( nm_schema_src_path ) ) )
+    } {}
     ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_check`
     `Front-end only: type-check and borrow-check NURL without producing a binary. Fast. Reports diagnostics.`
     ( nm_schema_src_path ) ) )
@@ -444,8 +481,14 @@ $ `stdlib/core/posix.nu`
 }
 
 @ dispatch_tool s name Json args → Json {
-    ? != ( nurl_str_eq name `nurl_build` ) 0 { ^ ( nm_tool_build args ) } {}
-    ? != ( nurl_str_eq name `nurl_run` ) 0 { ^ ( nm_tool_run args ) } {}
+    ? != ( nurl_str_eq name `nurl_build` ) 0 {
+        ? ( nm_build_ok ) { ^ ( nm_tool_build args ) }
+        { ^ ( mcp_tool_result_error `nurl_build is disabled (--read-only)` ) }
+    } {}
+    ? != ( nurl_str_eq name `nurl_run` ) 0 {
+        ? ( nm_run_ok ) { ^ ( nm_tool_run args ) }
+        { ^ ( mcp_tool_result_error `nurl_run is disabled — it is unsandboxed code execution; over HTTP pass --allow-run to enable it (and it is off entirely under --read-only)` ) }
+    } {}
     ? != ( nurl_str_eq name `nurl_check` ) 0 { ^ ( nm_tool_check args ) } {}
     ? != ( nurl_str_eq name `nurl_fmt` ) 0 { ^ ( nm_tool_fmt args ) } {}
     ? != ( nurl_str_eq name `nurl_list_stdlib` ) 0 { ^ ( nm_tool_list_stdlib args ) } {}
@@ -453,25 +496,26 @@ $ `stdlib/core/posix.nu`
     ^ ( mcp_tool_result_error `unknown tool` )
 }
 
-// ── JSON-RPC method handlers (shape from examples/mcp_echo_server.nu) ─
+// ── JSON-RPC method handlers (return-style: shape from
+// examples/mcp_echo_server_http.nu, used by both transports) ─────────
 
-@ handle_initialize Json id → v {
-    : Json result ( mcp_initialize_result `nurl-mcp` `0.1.0` )
-    ( mcp_send_message ( mcp_response_result id result ) )
+@ handle_initialize Json id → Json {
+    : Json result ( mcp_initialize_result `nurl-mcp` `0.2.0` )
+    ^ ( mcp_response_result id result )
 }
 
-@ handle_ping Json id → v {
+@ handle_ping Json id → Json {
     : Json empty ( json_obj_new )
-    ( mcp_send_message ( mcp_response_result id empty ) )
+    ^ ( mcp_response_result id empty )
 }
 
-@ handle_tools_list Json id → v {
+@ handle_tools_list Json id → Json {
     : ( Vec Json ) tools ( build_tools_list )
     : Json result ( mcp_tools_list_result tools )
-    ( mcp_send_message ( mcp_response_result id result ) )
+    ^ ( mcp_response_result id result )
 }
 
-@ handle_tools_call Json id Json params → v {
+@ handle_tools_call Json id Json params → Json {
     : ?Json name_j ( json_obj_get params `name` )
     ?? name_j {
         T nv → {
@@ -483,27 +527,28 @@ $ `stdlib/core/posix.nu`
             }
             : Json result ( dispatch_tool name args )
             ( json_free args )
-            ( mcp_send_message ( mcp_response_result id result ) )
+            ^ ( mcp_response_result id result )
         }
         F → {
-            ( mcp_send_message
-            ( mcp_response_error id mcp_err_invalid_params
-            `tools/call requires a "name" parameter` ) )
+            ^ ( mcp_response_error id mcp_err_invalid_params
+            `tools/call requires a "name" parameter` )
         }
     }
 }
 
-@ handle_unknown_method Json id s method → v {
+@ handle_unknown_method Json id s method → Json {
     : i mlen ( nurl_str_len method )
     : String msg ( string_with_cap + 32 mlen )
     ( string_push_str msg `unknown method: ` )
     ( string_push_str msg method )
-    ( mcp_send_message
-    ( mcp_response_error id mcp_err_method_not_found ( string_data msg ) ) )
+    : Json err ( mcp_response_error id mcp_err_method_not_found ( string_data msg ) )
     ( string_free msg )
+    ^ err
 }
 
-@ handle Json req → v {
+// Transport-agnostic dispatcher: request Json → Some(response) for a
+// request, or None for a notification (the caller drops it / replies 202).
+@ dispatch Json req → ?Json {
     : ?Json method_j ( json_obj_get req `method` )
     ?? method_j {
         T mv → {
@@ -512,54 +557,240 @@ $ `stdlib/core/posix.nu`
             ?? id_opt {
                 T id → {
                     ? != ( nurl_str_eq method `initialize` ) 0 {
-                        ( handle_initialize id )
-                    } {
-                        ? != ( nurl_str_eq method `ping` ) 0 {
-                            ( handle_ping id )
-                        } {
-                            ? != ( nurl_str_eq method `tools/list` ) 0 {
-                                ( handle_tools_list id )
-                            } {
-                                ? != ( nurl_str_eq method `tools/call` ) 0 {
-                                    : ?Json params_j ( json_obj_get req `params` )
-                                    : Json params ?? params_j {
-                                        T pv → ( json_clone pv )
-                                        F → ( json_obj_new )
-                                    }
-                                    ( handle_tools_call id params )
-                                    ( json_free params )
-                                } {
-                                    ( handle_unknown_method id method )
-                                } } } }
+                        ^ @ ?Json { T ( handle_initialize id ) }
+                    } {}
+                    ? != ( nurl_str_eq method `ping` ) 0 {
+                        ^ @ ?Json { T ( handle_ping id ) }
+                    } {}
+                    ? != ( nurl_str_eq method `tools/list` ) 0 {
+                        ^ @ ?Json { T ( handle_tools_list id ) }
+                    } {}
+                    ? != ( nurl_str_eq method `tools/call` ) 0 {
+                        : ?Json params_j ( json_obj_get req `params` )
+                        : Json params ?? params_j {
+                            T pv → ( json_clone pv )
+                            F → ( json_obj_new )
+                        }
+                        : Json out ( handle_tools_call id params )
+                        ( json_free params )
+                        ^ @ ?Json { T out }
+                    } {}
+                    ^ @ ?Json { T ( handle_unknown_method id method ) }
                 }
                 F → {
                     ? != ( nurl_str_eq method `notifications/initialized` ) 0 {
                         ( mcp_log `client initialized` )
                     } {}
+                    ^ @ ?Json { F }
                 }
             }
         }
         F → {
             ( mcp_log `request without method, ignoring` )
+            ^ @ ?Json { F }
         }
     }
 }
 
-@ main → i {
-    ( mcp_log `nurl-mcp 0.1.0 ready (stdio)` )
+// ── stdio transport ─────────────────────────────────────────────────
+
+@ stdio_loop → v {
     : ~ b running T
     ~ running {
         : ?Json msg ( mcp_read_request )
         ?? msg {
             T req → {
-                ( handle req )
+                : ?Json reply ( dispatch req )
                 ( json_free req )
+                ?? reply {
+                    T resp → ( mcp_send_message resp )
+                    F empty → ( json_free empty )
+                }
             }
-            F → {
-                = running F
-            }
+            F → { = running F }
         }
     }
-    ( mcp_log `bye` )
-    ^ 0
+}
+
+// ── HTTP transport (POST /mcp, bearer-token auth, permissive CORS) ───
+
+@ nm_cors HttpResponse r → v {
+    ( response_set_header r `Access-Control-Allow-Origin` `*` )
+    ( response_set_header r `Access-Control-Allow-Headers` `Content-Type, Authorization, Mcp-Session-Id` )
+    ( response_set_header r `Access-Control-Allow-Methods` `POST, OPTIONS` )
+}
+
+@ nm_authed HttpRequest req → b {
+    ? == ( nurl_str_len g_token ) 0 { ^ T } {}
+    : ?String av ( header_get . req headers `Authorization` )
+    ?? av {
+        T s → {
+            : String expect ( string_from `Bearer ` )
+            ( string_push_str expect g_token )
+            : b ok ? != ( nurl_str_eq ( string_data s ) ( string_data expect ) ) 0 T F
+            ( string_free expect )
+            ( string_free s )
+            ^ ok
+        }
+        F → { ^ F }
+    }
+    ^ F
+}
+
+@ http_handler HttpRequest req → HttpResponse {
+    : s rm ( string_data . req method )
+    ? != ( nurl_str_eq rm `OPTIONS` ) 0 {
+        : HttpResponse pre ( response_status_only 204 )
+        ( nm_cors pre )
+        ^ pre
+    } {}
+    ? != ( nurl_str_eq rm `POST` ) 0 {} {
+        : HttpResponse r ( response_text 405 `Method Not Allowed\n` )
+        ( response_set_header r `Allow` `POST, OPTIONS` )
+        ( nm_cors r )
+        ^ r
+    }
+    ? ! ( nm_authed req ) {
+        : HttpResponse r ( response_text 401 `Unauthorized\n` )
+        ( response_set_header r `WWW-Authenticate` `Bearer` )
+        ( nm_cors r )
+        ^ r
+    } {}
+    : i bn ( vec_len [u] . req body )
+    ? <= bn 0 {
+        : HttpResponse r ( response_text 400 `empty request body\n` )
+        ( nm_cors r )
+        ^ r
+    } {}
+    : String body_str ( bytes_to_str . req body )
+    : !Json JsonError pj ( json_parse ( string_data body_str ) )
+    ( string_free body_str )
+    ?? pj {
+        T jreq → {
+            : ?Json reply ( dispatch jreq )
+            ( json_free jreq )
+            ?? reply {
+                T resp → {
+                    : HttpResponse r ( response_json 200 resp )
+                    ( json_free resp )
+                    ( nm_cors r )
+                    ^ r
+                }
+                F empty → {
+                    ( json_free empty )
+                    : HttpResponse r ( response_status_only 202 )
+                    ( nm_cors r )
+                    ^ r
+                }
+            }
+        }
+        F e → {
+            : HttpResponse r ( response_text 400 `request body is not valid JSON\n` )
+            ( nm_cors r )
+            ^ r
+        }
+    }
+    : HttpResponse r ( response_text 500 `internal\n` )
+    ( nm_cors r )
+    ^ r
+}
+
+@ nm_is_loopback s host → b {
+    ? != ( nurl_str_eq host `127.0.0.1` ) 0 { ^ T } {}
+    ? != ( nurl_str_eq host `::1` ) 0 { ^ T } {}
+    ? != ( nurl_str_eq host `localhost` ) 0 { ^ T } {}
+    ^ F
+}
+
+@ run_http s host i port → i {
+    : !TcpListener NetErr lr ( tcp_listen host port )
+    ?? lr {
+        T listener → {
+            : ( @ HttpResponse HttpRequest ) h \ HttpRequest req → HttpResponse { ^ ( http_handler req ) }
+            : HttpServer srv ( server_new listener h )
+            : !v NetErr rr ( server_run srv )
+            ( server_stop srv )
+            ?? rr {
+                T → { ^ 0 }
+                F e → {
+                    ( nurl_eprint `[mcp] server error: ` )
+                    ( nurl_eprint ( net_err_name e ) )
+                    ( nurl_eprint `\n` )
+                    ^ 1
+                }
+            }
+        }
+        F e → {
+            ( nurl_eprint `[mcp] cannot bind ` )
+            ( nurl_eprint host )
+            ( nurl_eprint `: ` )
+            ( nurl_eprint ( net_err_name e ) )
+            ( nurl_eprint `\n` )
+            ^ 1
+        }
+    }
+    ^ 1
+}
+
+@ main → i {
+    : ArgParser p ( args_new `nurl-mcp` `Local MCP server for the NURL toolchain (stdio by default; --http to serve over HTTP).` )
+    ( args_flag p `http` 0 `Serve over HTTP instead of stdio` )
+    ( args_opt p `host` 0 `ADDR` `HTTP bind address (default 127.0.0.1)` )
+    ( args_opt p `port` 0 `N` `HTTP port (default 8080)` )
+    ( args_opt p `token` 0 `TOK` `Require "Authorization: Bearer TOK" on HTTP requests` )
+    ( args_flag p `read-only` 0 `Expose only read/check/fmt tools (no build, no run)` )
+    ( args_flag p `allow-run` 0 `Allow nurl_run over HTTP (off by default; stdio always allows it)` )
+    : b ok ( args_parse_argv p )
+    ? ! ok {
+        : String u ( args_usage p )
+        ( nurl_eprint ( string_data u ) )
+        ( string_free u )
+        ( args_free p )
+        ^ 2
+    } {}
+
+    : b want_http ( args_present p `http` )
+    : b read_only ( args_present p `read-only` )
+    : b allow_run ( args_present p `allow-run` )
+    : String host ( args_value_or p `host` `127.0.0.1` )
+    : String ports ( args_value_or p `port` `8080` )
+    : String token ( args_value_or p `token` `` )
+    : i port ( nurl_str_to_int ( string_data ports ) )
+
+    = g_read_only ? read_only 1 0
+    ? want_http {
+        = g_run_allowed ? & ! read_only allow_run 1 0
+    } {
+        = g_run_allowed ? read_only 0 1
+    }
+    = g_token ( string_data token )
+
+    : ~ i rc 0
+    ? want_http {
+        ? & ! ( nm_is_loopback ( string_data host ) ) == ( string_len token ) 0 {
+            ( nurl_eprint `[mcp] refusing to bind a non-loopback address without --token (HTTP build/run is unsandboxed code execution)\n` )
+            = rc 2
+        } {
+            ? == ( string_len token ) 0 {
+                ( mcp_log `WARNING: serving HTTP with no --token — any local client can drive the toolchain` )
+            } {}
+            ? ( nm_run_ok ) {
+                ( mcp_log `nurl-mcp 0.2.0 ready (http) — nurl_run ENABLED` )
+            } {
+                ( mcp_log `nurl-mcp 0.2.0 ready (http) — nurl_run disabled (pass --allow-run to enable)` )
+            }
+            = rc ( run_http ( string_data host ) port )
+        }
+    } {
+        ( mcp_log `nurl-mcp 0.2.0 ready (stdio)` )
+        ( stdio_loop )
+        ( mcp_log `bye` )
+        = rc 0
+    }
+
+    ( args_free p )
+    ( string_free host )
+    ( string_free ports )
+    ( string_free token )
+    ^ rc
 }


### PR DESCRIPTION
## Summary

A new registry package: **`nurl-mcp`**, the LLM-facing counterpart of `nurl-lsp`. Where `nurl-lsp` serves editors over LSP, `nurl-mcp` serves an LLM agent over the [Model Context Protocol](https://modelcontextprotocol.io) so it can drive the **locally installed** compiler — build, run, type-check, and format NURL against the host's real files, and read the installed stdlib. Unlike the sandboxed cloud playground MCP, it operates on *your* toolchain over *your* files, offline.

Written in NURL on the `stdlib/ext/mcp.nu` primitives (the same library the playground server uses), so it stays libc-only. Published to the registry as `nurl-mcp 0.2.0`.

```
nurlpkg install nurl-mcp
claude mcp add nurl -- nurl-mcp
```

## Tools

`nurl_build`, `nurl_run`, `nurl_check`, `nurl_fmt`, `nurl_list_stdlib`, `nurl_read_stdlib` — each takes inline `source` or a file `path`. Inline source and all build artifacts go to temp and are cleaned up.

## Transports & security

`nurl_run` is unsandboxed code execution (NURL links libc), so the transport choice carries the security posture:

- **stdio** (default) — only the spawning process can reach it; run always available.
- **HTTP** (`--http`, `--host`, `--port`) — `POST /mcp` JSON-RPC. `nurl_run` is **disabled by default** (not even advertised) until `--allow-run`. `--token TOK` requires `Authorization: Bearer TOK` (401 otherwise). A **non-loopback bind refuses to start without `--token`**; loopback-without-token starts but warns. `--read-only` drops build+run on any transport.

Gating is enforced twice: disabled tools are omitted from `tools/list` *and* refused with an explanatory error if called directly.

## Implementation notes

- One transport-agnostic `dispatch (Json → ?Json)` shared by the stdio loop and a hand-rolled authed HTTP handler (POST + bearer check + CORS), calling the top-level `dispatch` directly to avoid the closure-in-closure capture bug.
- Temp cleanup keys off the `<tmpdir>/nurl-mcp-` path prefix (not a mutable flag), so it stays correct if requests are ever served on concurrent fibers.
- Frees the response `Json` after `response_json` (the builder stringifies but does not consume it — verified against the stdlib's own `__mcp_http_response_for_json`).

## Verification

- Compiles clean with the local toolchain.
- Full stdio MCP session (initialize → tools/list → every tool, incl. a deliberately broken check returning the real compiler diagnostic).
- HTTP matrix: default gates `nurl_run`; `--allow-run` enables + executes it; `--token` → 401/200; `--host 0.0.0.0` without token refuses to start (exit 2); `--read-only` → analysis tools only.
- Shared dispatch core ASan/UBSan/LSan-clean; zero temp-file residue.

Two focused commits: stdio v1, then the HTTP transport (v0.2.0). Not bundled with the toolchain and no `install-toolchain.sh` wiring — installed explicitly via `nurlpkg install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)