### PR TITLE
install-toolchain: POSIX-sh-safe env + ship (and relink) nurlfmt

### DIFF
--- a/tools/install-toolchain.bat
+++ b/tools/install-toolchain.bat
@@ -57,6 +57,16 @@ REM Compiler + package manager.
 copy /y "%ROOT%\build\nurlc.exe"   "%PREFIX%\build\nurlc.exe"   >nul
 copy /y "%ROOT%\build\nurlpkg.exe" "%PREFIX%\build\nurlpkg.exe" >nul
 
+REM Formatter (best-effort: installed when present; without it nurlfmt and the
+REM nurl-mcp nurl_fmt tool are unavailable).
+set "HAVE_NURLFMT=0"
+if exist "%ROOT%\build\nurlfmt.exe" (
+  copy /y "%ROOT%\build\nurlfmt.exe" "%PREFIX%\build\nurlfmt.exe" >nul
+  set "HAVE_NURLFMT=1"
+) else (
+  echo Note: build\nurlfmt.exe absent - skipping ^(run build.bat to build it^).
+)
+
 REM Stdlib tree (incl. runtime.o, runtime.<feature> link sentinels, canvas.o).
 xcopy /e /i /y /q "%ROOT%\stdlib" "%PREFIX%\stdlib" >nul
 
@@ -87,6 +97,14 @@ REM from any directory. The nurlpkg shim also points NURL at the driver.
   echo if not defined NURL set "NURL=%%NURL_PREFIX%%\bin\nurl.bat"
   echo "%%NURL_PREFIX%%\build\nurlpkg.exe" %%*
 )
+if "%HAVE_NURLFMT%"=="1" (
+  > "%PREFIX%\bin\nurlfmt.bat" (
+    echo @echo off
+    echo for %%%%I in ^("%%~dp0.."^) do set "NURL_PREFIX=%%%%~fI"
+    echo if not defined NURL_STDLIB set "NURL_STDLIB=%%NURL_PREFIX%%"
+    echo "%%NURL_PREFIX%%\build\nurlfmt.exe" %%*
+  )
+)
 
 REM ── Sourceable session env (RELOCATABLE) ──────────────────────
 > "%PREFIX%\env.bat" (
@@ -98,7 +116,11 @@ REM ── Sourceable session env (RELOCATABLE) ──────────�
 
 echo Done.
 echo.
-echo   installed:  nurl, nurlc, nurlpkg  -^> %PREFIX%\bin
+if "%HAVE_NURLFMT%"=="1" (
+  echo   installed:  nurl, nurlc, nurlpkg, nurlfmt  -^> %PREFIX%\bin
+) else (
+  echo   installed:  nurl, nurlc, nurlpkg  -^> %PREFIX%\bin
+)
 echo   stdlib:     %%NURL_STDLIB%%        -^> %PREFIX%\stdlib
 echo.
 echo Activate it in this shell:

--- a/tools/install-toolchain.sh
+++ b/tools/install-toolchain.sh
@@ -52,6 +52,17 @@ mkdir -p "$PREFIX/bin" "$PREFIX/build" "$PREFIX/stdlib"
 install -m755 "$ROOT/build/nurlc"   "$PREFIX/build/nurlc"
 install -m755 "$ROOT/build/nurlpkg" "$PREFIX/build/nurlpkg"
 
+# Formatter. build.sh builds nurlfmt best-effort, so install it when present
+# (a box where it didn't build still gets the rest of the toolchain). Without
+# it, `nurlfmt` and the nurl-mcp `nurl_fmt` tool are unavailable.
+HAVE_NURLFMT=0
+if [[ -x "$ROOT/build/nurlfmt" ]]; then
+    install -m755 "$ROOT/build/nurlfmt" "$PREFIX/build/nurlfmt"
+    HAVE_NURLFMT=1
+else
+    echo "Note: build/nurlfmt absent — skipping (run ./build.sh to build it; nurl_fmt tooling will be unavailable)."
+fi
+
 # Stdlib tree — including runtime.o, the runtime.<feature> link sentinels
 # nurl.sh consults, and any canvas.o. Copy the whole directory so the
 # installed driver links exactly like the in-tree one.
@@ -117,25 +128,54 @@ EOF
 
 chmod +x "$PREFIX/bin/nurl" "$PREFIX/bin/nurlc" "$PREFIX/bin/nurlpkg"
 
-# ── Sourceable env (RELOCATABLE) ───────────────────────────────────────
-# Resolves its own directory when sourced, so a moved/extracted tree still
-# points NURL_HOME / NURL_STDLIB / PATH at the right place.
-cat > "$PREFIX/env" <<'EOF'
-# NURL toolchain environment — source this from your shell rc.
-__nurl_here="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [[ "$HAVE_NURLFMT" == "1" ]]; then
+    cat > "$PREFIX/bin/nurlfmt" <<'EOF'
+#!/bin/sh
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+export NURL_STDLIB="${NURL_STDLIB:-$HERE}"
+exec "$HERE/build/nurlfmt" "$@"
+EOF
+    chmod +x "$PREFIX/bin/nurlfmt"
+fi
+
+# ── Sourceable env (bash / zsh / POSIX sh) ─────────────────────────────
+# bash and zsh can self-locate the sourced file (so a moved/extracted tree
+# still resolves) — but POSIX sh (dash/ash, FreeBSD /bin/sh) has no portable
+# way to find a sourced file's path, and the old `${BASH_SOURCE[0]}` form is a
+# bash-array reference that makes those shells abort with "Bad substitution".
+# So: bash/zsh resolve dynamically; every other shell falls back to the path
+# baked in at install time. The relocatable PATH shims (nurl/nurlc/…) self-
+# locate regardless, so a moved tree still works from the shims even when this
+# fallback is stale. Baked line written unquoted; the rest is a quoted heredoc.
+{
+    printf '# NURL toolchain environment — source from your shell rc (bash/zsh/sh).\n'
+    printf '__nurl_default=%s\n' "$PREFIX"
+    cat <<'EOF'
+if [ -n "${BASH_SOURCE:-}" ]; then
+    __nurl_here="$(cd "$(dirname "$BASH_SOURCE")" && pwd)"
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    __nurl_here="$(cd "$(dirname "$0")" && pwd)"
+else
+    __nurl_here="$__nurl_default"
+fi
 export NURL_HOME="$__nurl_here"
 export NURL_STDLIB="$__nurl_here"
 case ":$PATH:" in
     *":$__nurl_here/bin:"*) ;;
     *) export PATH="$__nurl_here/bin:$PATH" ;;
 esac
-unset __nurl_here
+unset __nurl_here __nurl_default
 EOF
+} > "$PREFIX/env"
 
 echo "Done."
 echo
-echo "  installed:  nurl, nurlc, nurlpkg  → $PREFIX/bin"
-echo "  stdlib:     \$NURL_STDLIB          → $PREFIX/stdlib"
+if [[ "$HAVE_NURLFMT" == "1" ]]; then
+    echo "  installed:  nurl, nurlc, nurlpkg, nurlfmt  → $PREFIX/bin"
+else
+    echo "  installed:  nurl, nurlc, nurlpkg  → $PREFIX/bin"
+fi
+echo "  stdlib:     \$NURL_STDLIB                  → $PREFIX/stdlib"
 echo
 echo "Activate it in this shell and future ones:"
 echo "    source $PREFIX/env"

--- a/tools/relink-toolchain-portable.sh
+++ b/tools/relink-toolchain-portable.sh
@@ -78,9 +78,29 @@ done
     "$ROOT/build/nurlpkg.ll" "$TMP/rt-nurlpkg.o" -lm -lpthread "${ZA[@]}" \
     -o "$ROOT/build/nurlpkg"
 
+# nurlfmt is libc-only like nurlc (a source formatter, no FFI back-ends).
+# Best-effort: build.sh builds it best-effort, so it may be absent — only
+# relink it when its IR is present, otherwise install-toolchain.sh ships
+# whatever build/nurlfmt exists (or nothing). Without this, a nurlfmt shipped
+# in the release tarball would carry the CI runner's high glibc floor and fail
+# on the same old distros the relink exists to support.
+HAVE_NURLFMT=0
+if [[ -f "$ROOT/build/nurlfmt.ll" ]]; then
+    echo "Relinking nurlfmt → $TARGET"
+    "$ZIG" cc -O2 -target "$TARGET" -c "$ROOT/stdlib/runtime.c" -o "$TMP/rt-nurlfmt.o"
+    "$ZIG" cc -O2 -target "$TARGET" -Wl,--as-needed \
+        "$ROOT/build/nurlfmt.ll" "$TMP/rt-nurlfmt.o" -lm -lpthread \
+        -o "$ROOT/build/nurlfmt"
+    HAVE_NURLFMT=1
+else
+    echo "Note: build/nurlfmt.ll absent — not relinking nurlfmt."
+fi
+
 # Report the resulting glibc floor (highest versioned symbol referenced).
 echo "Resulting glibc floors:"
-for b in nurlc nurlpkg; do
+RELINKED="nurlc nurlpkg"
+[[ "$HAVE_NURLFMT" == "1" ]] && RELINKED="$RELINKED nurlfmt"
+for b in $RELINKED; do
     v="$(readelf -V "$ROOT/build/$b" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -V | tail -1)"
     echo "  $b: ${v:-none}"
 done


### PR DESCRIPTION
## Summary

Three issues surfaced while installing and running the toolchain on **FreeBSD 14.3** (during the nurl-mcp end-to-end test) and tracing where `nurlfmt` comes from in a release.

### 1. The `env` file broke under POSIX `/bin/sh`
The generated `~/.nurl/env` self-located with `${BASH_SOURCE[0]:-$0}` — a bash-array reference. Sourcing it under a POSIX shell (FreeBSD/Alpine `/bin/sh`, dash, ash) aborts with **`Bad substitution`**, the exact shells the toolchain advertises support for. Rewritten to self-locate under **bash** (`$BASH_SOURCE`) and **zsh** (`$0`) and fall back to the **install-time prefix** on every other shell. The relocatable PATH shims already self-locate, so a moved tree still works via them.

*Verified:* the new `env` sources cleanly under both `dash` and `bash` (sets `NURL_HOME`/`NURL_STDLIB`, prepends `bin` to `PATH`).

### 2. `nurlfmt` was never installed
Only `nurl`/`nurlc`/`nurlpkg` were installed, so the `nurlfmt` binary — and the nurl-mcp `nurl_fmt` tool that shells out to it — were unavailable on a stock install. Now installed with a self-locating shim, **best-effort** (matching how `build.sh` builds it: a box where it didn't build still gets the rest of the toolchain).

*Verified:* a scratch `install-toolchain.sh` produced `bin/{nurl,nurlc,nurlfmt,nurlpkg}` and the shim formats via `nurlfmt --stdin`.

### 3. Shipped `nurlfmt` would fail on old glibc
The release relinks `nurlc` + `nurlpkg` against a low glibc floor (zig) so the Linux tarballs run on old distros — but not `nurlfmt`. Now that `nurlfmt` rides into the tarball (build.sh → `install-toolchain.sh`), it would carry the CI runner's high glibc floor and fail on exactly those boxes. `relink-toolchain-portable.sh` now relinks `nurlfmt` too (libc-only, mirroring `nurlc`), best-effort when `build/nurlfmt.ll` is present.

## Where `nurlfmt` comes from (the original question)
It is **not** prebuilt into a registry package. `build.sh` compiles it on top of the freshly-bootstrapped `nurlc`; in a release, `install-toolchain.sh` stages `build/nurlfmt` into the tarball that `get-nurl.sh` downloads. So it ships prebuilt **in the release tarball** (relinked for portability), and is built from source when installing from a clone. nurl-mcp itself depends on `nurlfmt` being on `$PATH` at runtime — which these fixes now guarantee.

Both the POSIX `.sh` and Windows `.bat` installers are updated for parity. The many other `${BASH_SOURCE[0]}` usages in the repo are all in real `#!/usr/bin/env bash` scripts (correct there) and are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)