### PR TITLE
swarm: distributed compute cluster package + relay/runtime fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Runtime failed to link on older-glibc targets (e.g. Raspberry Pi OS
+  aarch64): `undefined symbol: __isoc23_strtoul` / `__isoc23_strtol`.** When the
+  runtime is compiled with glibc ≥ 2.38 headers in C23 mode, `strtoul` /
+  `strtol` / `atoi` / `scanf` resolve to the versioned symbols
+  `__isoc23_strtoul` etc., which are baked into the shipped LTO runtime bitcode
+  and then undefined when linked against a target with an older glibc. The
+  runtime no longer calls any of them: a hand-rolled decimal parser
+  (`nurl__parse_ul`) replaces `strtoul`/`atoi`, and `nurl_read_int` is rebuilt
+  on `getchar`/`ungetc` instead of `scanf`. The runtime bitcode now references
+  none of the `__isoc23_*` symbols, so it links cleanly across every glibc/musl
+  version and target (verified by cross-linking for aarch64 against glibc 2.28).
+- **`net/relay` group multicast silently dropped any non-32-byte group id.**
+  `GJOIN`/`GLEAVE` carried the group id as a raw, variable-length body, but
+  `GSEND` reused the fixed 32-byte pubkey split — so a group id that was not
+  exactly 32 bytes was mis-parsed on the server (aliasing the payload) and the
+  fanout was silently skipped. Group sends are now length-delimited
+  (`[gidlen:2][gid][payload]`) via `relay_gsend_gid` / `relay_gsend_payload`, so
+  a group id of any length round-trips. Regression test added in
+  `relay_codec` (a 5-byte gid). Existing 32-byte users (`replicated_counter`,
+  `pttvoice`) are unaffected.
+
+### Added
+
+- **`net/relay` server verbose mode.** `relay_server_set_verbose(rs, 1)` (and a
+  new `RelayServer.verbose` field) logs each peer connect/disconnect as
+  `relay: + peer <id>` / `relay: - peer <id>`. `packages/swarm`'s relay exposes
+  it as `swarm relay <host> <port> --v` / `--verbose`, so cluster membership is
+  visible as workers come and go.
+- **`packages/swarm` — a distributed compute cluster you join by installing it.**
+  `nurlpkg install swarm` then `swarm worker <relay> <port>` makes a machine a
+  live compute node: it announces itself over the relay group (HELLO census),
+  every node folds it into the consistent-hash ring, and it takes its share of
+  work. `swarm submit … primes <lo> <hi>` / `sumsq <lo> <hi>` shards a real
+  numeric workload across the live workers (by key, via `dist/ring` + `dist/job`)
+  and sums the partial results — verified live (π(10⁶) = 78498) and by an
+  ASan-clean offline suite that pins exact sharding.
+
 ## [0.10.2] — 2026-06-28
 
 A **language-maturity** release. The static trait system reaches v1.0

--- a/compiler/tests/outputs/relay_codec.txt
+++ b/compiler/tests/outputs/relay_codec.txt
@@ -15,5 +15,7 @@ gjoin body == gid: YES
 gsend type: YES
 gsend gid split: YES
 gsend payload split: YES
+gsend short gid: YES
+gsend short payload: YES
 incomplete → None: YES
 oversize → None: YES

--- a/compiler/tests/relay_codec.nu
+++ b/compiler/tests/relay_codec.nu
@@ -94,8 +94,8 @@ $ `stdlib/net/relay.nu`
     ?? fg {
         T f → {
             ( pb `gsend type: ` == . f ftype ( relay_gsend ) )
-            : ( Vec u ) ggid ( relay_body_pk . f body )
-            : ( Vec u ) gpl ( relay_body_payload . f body )
+            : ( Vec u ) ggid ( relay_gsend_gid . f body )
+            : ( Vec u ) gpl ( relay_gsend_payload . f body )
             ( pb `gsend gid split: ` ( veq ggid gid ) )
             ( pb `gsend payload split: ` ( veq gpl data ) )
             ( vec_free [u] ggid ) ( vec_free [u] gpl )
@@ -103,6 +103,25 @@ $ `stdlib/net/relay.nu`
         }
         F → ( nurl_print `gsend parse failed\n` )
     }
+
+    // A group id that is NOT 32 bytes must still round-trip — the gid is
+    // length-delimited, not split at a fixed pubkey width. (Regression: a
+    // short gid used to alias the payload and silently drop the fanout.)
+    : ( Vec u ) sgid ( bytes 7 5 )  // "swarm"-sized 5-byte group id
+    : ( Vec u ) gs2 ( relay_build_group_send sgid data )
+    : ?RelayFrame fg2 ( relay_parse gs2 )
+    ?? fg2 {
+        T f → {
+            : ( Vec u ) ggid ( relay_gsend_gid . f body )
+            : ( Vec u ) gpl ( relay_gsend_payload . f body )
+            ( pb `gsend short gid: ` ( veq ggid sgid ) )
+            ( pb `gsend short payload: ` ( veq gpl data ) )
+            ( vec_free [u] ggid ) ( vec_free [u] gpl )
+            ( relay_frame_free f )
+        }
+        F → ( nurl_print `gsend short parse failed\n` )
+    }
+    ( vec_free [u] sgid ) ( vec_free [u] gs2 )
 
     // ── incomplete buffer ────────────────────────────────────────
     : ( Vec u ) partial ( vec_new [u] )

--- a/packages/swarm/README.md
+++ b/packages/swarm/README.md
@@ -1,0 +1,93 @@
+# swarm — a distributed compute cluster you join by installing it
+
+`swarm` turns a set of ordinary machines into a compute cluster for
+embarrassingly-parallel numeric work. A new member joins the cluster **just by
+running the binary** — no member list, no config, no recompile:
+
+```sh
+nurlpkg install swarm           # drops the `swarm` binary on $PATH
+swarm worker <relay-host> <port>   # ← that's the join. it now takes work.
+```
+
+It is built entirely on NURL's standard distributed stack (see
+[`docs/DISTRIBUTED.md`](../../docs/DISTRIBUTED.md)): `net/relay` for reach
+through NATs, `net/transport` for the pubkey-addressed seam, `dist/ring` for
+consistent-hash key ownership, and `dist/job` for the submit → owner → result
+dispatch. `swarm` is the thin application on top: membership-by-arrival, two
+real workloads, and a CLI.
+
+## Quick start
+
+One machine runs a relay (the meeting point — one per cluster):
+
+```sh
+swarm relay 0.0.0.0 47700
+```
+
+Any number of machines join as workers (this is the whole "add a node" story):
+
+```sh
+swarm worker <relay-host> 47700        # auto-assigns a node id
+swarm worker <relay-host> 47700 7      # or pin an id
+```
+
+From anywhere, place a **real** workload — it is sharded across the live
+workers by key, each worker does genuine CPU work on its share, and the
+partial results are summed:
+
+```sh
+swarm submit <relay-host> 47700 primes 1 1000000   # → result = 78498  (π(10^6))
+swarm submit <relay-host> 47700 sumsq  0 1000       # → result = 332833500
+```
+
+Start more workers and submit again — the new workers take their share of the
+keyspace on the next submit. Kill a worker and its keys re-home to the
+survivors (`dist/job` forwards a submit for a key whose owner moved).
+
+## How it works
+
+1. **Join = announce.** A worker broadcasts a `HELLO` to the relay group
+   (`census.nu`). Every node that hears it folds the worker's pubkey into its
+   consistent-hash ring, and replies so the newcomer learns the existing
+   members. The ring converges with no central coordinator.
+2. **Submit = shard by key.** The coordinator discovers the live workers the
+   same way, splits the requested range into many chunks, and keys each chunk
+   so `dist/ring` routes it to its owning worker (`dist/job` carries it over
+   the transport). More chunks than workers → even load.
+3. **Execute = registered handler.** Each worker has registered a handler per
+   workload kind (`work.nu`); it runs the honest computation on its chunk
+   (primes are *counted by trial division*, not looked up) and returns the
+   partial result, recorded idempotently by task id.
+4. **Aggregate.** The coordinator awaits every chunk and sums them.
+
+## Workloads
+
+| kind     | `submit … <kind> <lo> <hi>`        | result                              |
+|----------|------------------------------------|-------------------------------------|
+| `primes` | count primes in `[lo, hi)`         | e.g. `primes 1 1000000` → `78498`   |
+| `sumsq`  | Σ k² for k in `[lo, hi)` (i64)     | e.g. `sumsq 0 1000` → `332833500`   |
+
+Both are verifiable by a closed form, which is exactly what the test suite
+pins. Adding a workload is one handler in `work.nu` plus a kind constant.
+
+## Tests
+
+```sh
+# pure logic (workloads, exact sharding, codecs) — deterministic, ASan-clean
+NURL_STDLIB=<repo> ../../nurl.sh tests/work_test.nu /tmp/wt && /tmp/wt
+
+# end-to-end over a local relay + worker set
+./tests/live_smoke.sh
+```
+
+## Layout
+
+```
+src/main.nu     CLI (relay | worker | submit) + the node bundle and pump loop
+src/census.nu   HELLO membership gossip → consistent-hash ring
+src/work.nu     the real workloads: handlers, sharding, aggregation
+```
+
+## License
+
+MIT OR Apache-2.0.

--- a/packages/swarm/nurl.toml
+++ b/packages/swarm/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "swarm"
+version = "0.1.0"
+description = "A distributed compute cluster you join by installing it. Run `swarm worker <relay> <port>` on any machine and it announces itself over the relay group, every node folds it into the consistent-hash ring, and it starts taking its share of real work. `swarm submit` shards a genuine numeric workload (prime counting, sum-of-squares) across the live workers and sums the partial results. Built entirely on the standard distributed stack (net/relay, net/transport, dist/ring, dist/job) — no external frameworks."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/swarm/src/census.nu
+++ b/packages/swarm/src/census.nu
@@ -1,0 +1,108 @@
+// packages/swarm/src/census.nu — lightweight membership gossip for the swarm.
+//
+// The compute layer (dist/job over dist/ring) needs every node to agree on the
+// live worker set: a worker must know it owns a key, and the coordinator must
+// know which pubkeys to route to. The full SWIM table (net/membership.nu) is
+// the heavy, churn-hardened answer; this is the small one a compute cluster
+// actually needs — a HELLO announcement that feeds the consistent-hash ring.
+//
+//   * a node joins by broadcasting HELLO(role, want=1) to the relay group;
+//   * everyone who hears it adds the node to their ring (workers only) and, if
+//     `want`, replies with their own HELLO so the newcomer learns them too;
+//   * the ring converges, and "join the cluster" is literally "run the binary".
+//
+// Roles: a WORKER owns keys and executes handlers, so it joins everyone's ring;
+// a CLIENT (the coordinator) only submits, so it is never added to the ring —
+// otherwise it would own keys it has no handler for and silently drop results.
+//
+// The codec and the membership set are pure; only the pump touches transport.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/dist/ring.nu`
+
+@ census_hello_t → i { ^ 3 }
+
+@ role_client → i { ^ 0 }
+
+@ role_worker → i { ^ 1 }
+
+// HELLO wire: [3][id:8][role:1][want:1][pklen:2][pubkey…]
+@ hello_build i id i role i want ( Vec u ) pubkey → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( vec_push [u] b # u ( census_hello_t ) )
+    ( bytes_push_u64_be b # u64 id )
+    ( vec_push [u] b # u role )
+    ( vec_push [u] b # u want )
+    ( bytes_push_u16_be b # u16 ( vec_len [u] pubkey ) )
+    ( vec_extend [u] b pubkey )
+    ^ b
+}
+
+: Hello { i id i role i want ( Vec u ) pubkey }
+
+@ hello_free Hello h → v { ( vec_free [u] . h pubkey ) }
+
+@ hello_decode ( Vec u ) buf → Hello {
+    : i id ?? ( bytes_read_u64_be buf 1 ) { T x → # i x F → 0 }
+    : i role ?? ( vec_get [u] buf 9 ) { T x → # i x F → 0 }
+    : i want ?? ( vec_get [u] buf 10 ) { T x → # i x F → 0 }
+    : i pklen ?? ( bytes_read_u16_be buf 11 ) { T x → # i x F → 0 }
+    : ( Vec u ) pk ( vec_with_cap [u] pklen )
+    : ~ i k 0
+    ~ < k pklen { ?? ( vec_get [u] buf + 13 k ) { T x → ( vec_push [u] pk x ) F → {} } = k + k 1 }
+    ^ @ Hello { id role want pk }
+}
+
+// ── membership set: the pubkeys currently in the ring ──────────────
+// A node tracks the pubkeys it has folded into its ring so a re-heard HELLO is
+// idempotent (adding a member twice would double its ring points and skew load).
+
+: Member { ( Vec u ) pubkey i id }
+
+: Roster { ( Vec s ) members }  // *Member
+
+@ roster_new → *Roster {
+    : *Roster r # *Roster ( nurl_alloc Z Roster )
+    = . r members ( vec_new [s] )
+    ^ r
+}
+
+@ roster_free * Roster r → v {
+    : i n ( vec_len [s] . r members )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . r members k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *Member m # *Member pp ( vec_free [u] . m pubkey ) ( nurl_free # s m ) } {}
+        = k + k 1
+    }
+    ( vec_free [s] . r members )
+    ( nurl_free # s r )
+}
+
+@ roster_has * Roster r ( Vec u ) pubkey → b {
+    : i n ( vec_len [s] . r members )
+    : ~ b found F : ~ i k 0
+    ~ & ! found < k n {
+        : s pp ?? ( vec_get [s] . r members k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *Member m # *Member pp ? ( bytes_eq . m pubkey pubkey ) { = found T } {} } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+@ roster_count * Roster r → i { ^ ( vec_len [s] . r members ) }
+
+// Fold a worker into the roster + ring, once. Returns T if newly added.
+@ roster_add * Roster r * Ring ring ( Vec u ) pubkey i id i vnodes → b {
+    ? ( roster_has r pubkey ) { ^ F } {}
+    : *Member m # *Member ( nurl_alloc Z Member )
+    : ( Vec u ) cp ( vec_with_cap [u] ( vec_len [u] pubkey ) )
+    ( vec_extend [u] cp pubkey )
+    = . m pubkey cp
+    = . m id id
+    ( vec_push [s] . r members # s m )
+    ( ring_add_member ring pubkey vnodes )
+    ^ T
+}

--- a/packages/swarm/src/main.nu
+++ b/packages/swarm/src/main.nu
@@ -1,0 +1,373 @@
+// packages/swarm/src/main.nu — swarm: a distributed compute cluster you join by
+// installing it.
+//
+//   nurlpkg install swarm           # drops the `swarm` binary on $PATH
+//   swarm relay   0.0.0.0 47700     # the meeting point (one per cluster)
+//   swarm worker  <host> <port>     # join as a compute node — that's the join
+//   swarm submit  <host> <port> primes 1 1000000     # place a real workload
+//
+// A worker needs no recompile and no member list: it announces itself over the
+// relay group, every node folds it into the consistent-hash ring (census.nu),
+// and from then on it owns its share of the keyspace and runs the registered
+// handlers (work.nu). The coordinator discovers the live workers the same way,
+// shards a real numeric range across them by key (dist/ring → dist/job), and
+// sums the partial results. Add a worker → it takes load on the next submit.
+//
+// Built entirely on the standard distributed stack: net/relay (reach),
+// net/transport (the pubkey seam), dist/ring (ownership), dist/job (dispatch).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/random.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/net/relay.nu`
+$ `stdlib/net/transport.nu`
+$ `stdlib/dist/ring.nu`
+$ `stdlib/dist/job.nu`
+$ `census.nu`
+$ `work.nu`
+
+@ swarm_vnodes → i { ^ 64 }
+
+// The relay multicast group every node joins. It is a fixed 32 bytes on
+// purpose: the relay's documented group-id contract is 32 bytes, and a 32-byte
+// id round-trips correctly under every shipped relay framing — so a worker
+// built against any toolchain release still finds the cluster. ("swarm" + zero
+// padding keeps it recognisable on the wire.)
+@ swarm_group_id → ( Vec u ) {
+    : ( Vec u ) g ( bytes_from_str `swarm` )
+    ~ < ( vec_len [u] g ) 32 { ( vec_push [u] g # u 0 ) }
+    ^ g
+}
+
+// A 32-byte opaque routing pubkey derived deterministically from a node id.
+// Over the relay leg the pubkey is just the address the relay forwards by, so a
+// spread-out deterministic value is all the routing needs (the real X25519
+// identity belongs to the direct securedgram leg, not used here).
+@ pk_from_id i id → ( Vec u ) {
+    : ( Vec u ) v ( vec_new [u] )
+    : ~ i s id
+    : ~ i k 0
+    ~ < k 32 {
+        = s + + * s 1103515245 12345 k
+        ( vec_push [u] v # u & >> s 16 255 )
+        = k + k 1
+    }
+    ^ v
+}
+
+// ── node bundle ───────────────────────────────────────────────────
+
+: Swarm {
+    s transport  // *Transport
+    s ring  // *Ring
+    s roster  // *Roster
+    s job  // *JobNode
+    ( Vec u ) self_pk
+    i self_id
+    i role
+    ( Vec u ) group
+}
+
+@ swarm_new RelayClient rc i id i role → *Swarm {
+    : ( Vec u ) me ( pk_from_id id )
+    : *Transport tr # *Transport ( transport_open # s 0 rc 1 )
+    : *Ring ring ( ring_new )
+    : *Roster roster ( roster_new )
+    : *JobNode jn ( job_node_new # s tr # s ring me id )
+    : *Swarm sw # *Swarm ( nurl_alloc Z Swarm )
+    = . sw transport # s tr
+    = . sw ring # s ring
+    = . sw roster # s roster
+    = . sw job # s jn
+    = . sw self_pk me
+    = . sw self_id id
+    = . sw role role
+    = . sw group ( swarm_group_id )
+    // A worker is itself a ring member; the coordinator (client) never is.
+    ? == role ( role_worker ) { ( roster_add roster ring me id ( swarm_vnodes ) ) } {}
+    ^ sw
+}
+
+@ swarm_free * Swarm sw → v {
+    ( job_node_free # *JobNode . sw job )
+    ( ring_free # *Ring . sw ring )
+    ( roster_free # *Roster . sw roster )
+    ( transport_free # *Transport . sw transport )
+    ( vec_free [u] . sw self_pk )
+    ( vec_free [u] . sw group )
+    ( nurl_free # s sw )
+}
+
+@ swarm_join_group * Swarm sw → v {
+    ?? ( transport_group_join # *Transport . sw transport . sw group ) { T _ → {} F _ → {} }
+}
+
+// Announce ourselves to the group. `want` asks hearers to reply so a newcomer
+// learns the existing members.
+@ swarm_announce * Swarm sw i want → v {
+    : ( Vec u ) msg ( hello_build . sw self_id . sw role want . sw self_pk )
+    ?? ( transport_broadcast # *Transport . sw transport . sw group msg ) { T _ → {} F _ → {} }
+    ( vec_free [u] msg )
+}
+
+@ swarm_on_hello * Swarm sw Hello h → v {
+    // Only workers join the ring; a client announcing itself is reachable but
+    // owns no keys.
+    ? == . h role ( role_worker ) {
+        ( roster_add # *Roster . sw roster # *Ring . sw ring . h pubkey . h id ( swarm_vnodes ) )
+        ( transport_add_peer # *Transport . sw transport . h pubkey )
+    } {}
+    // Reply to a discovery request unless it is our own broadcast echoed back.
+    ? & == . h want 1 ! ( bytes_eq . h pubkey . sw self_pk ) {
+        : ( Vec u ) reply ( hello_build . sw self_id . sw role 0 . sw self_pk )
+        ?? ( transport_send # *Transport . sw transport . h pubkey reply ) { T _ → {} F _ → {} }
+        ( vec_free [u] reply )
+    } {}
+}
+
+// Drain inbound transport messages, dispatching census HELLO and job traffic.
+@ swarm_pump * Swarm sw i max → v {
+    : ~ b more T
+    ~ more {
+        ?? ( transport_recv # *Transport . sw transport max ) {
+            T tm → {
+                : i b0 ?? ( vec_get [u] . tm payload 0 ) { T x → # i x F → 255 }
+                ? == b0 ( census_hello_t ) {
+                    : Hello h ( hello_decode . tm payload )
+                    ( swarm_on_hello sw h )
+                    ( hello_free h )
+                } {
+                    : JobMsg m ( jobmsg_decode . tm payload )
+                    ? == . m mtype ( job_submit_t ) { ( job_on_submit # *JobNode . sw job m ) } {}
+                    ? == . m mtype ( job_result_t ) { ( job_on_result # *JobNode . sw job m ) } {}
+                    ( jobmsg_free m )
+                }
+                ( transport_msg_free tm )
+            }
+            F → { = more F }
+        }
+    }
+}
+
+// ── roles ─────────────────────────────────────────────────────────
+
+@ run_relay s host i port i vflag → i {
+    ?? ( relay_server_start host port ) {
+        T rs → {
+            : *RelayServer p # *RelayServer ( nurl_alloc Z RelayServer )
+            = . p lst . rs lst
+            = . p clients . rs clients
+            = . p groups . rs groups
+            // `vflag` (not `verbose`): a store LHS `. p verbose` whose value-name
+            // also matched the field would be parsed as an array-index store.
+            = . p verbose vflag
+            ( nurl_print `swarm relay listening on ` ) ( nurl_print host )
+            ( nurl_print `:` ) ( nurl_print_int port )
+            ? == vflag 1 { ( nurl_print ` (verbose: logging peer connect/disconnect)` ) } {}
+            ( nurl_print `\n` )
+            ( relay_server_run p )
+            ( relay_server_free p )
+            ^ 0
+        }
+        F e → { ( nurl_print `swarm: relay failed to bind\n` ) ^ 1 }
+    }
+}
+
+@ swarm_register_handlers * Swarm sw → v {
+    ( job_register # *JobNode . sw job ( kind_primes ) ( primes_handler ) )
+    ( job_register # *JobNode . sw job ( kind_sumsq ) ( sumsq_handler ) )
+}
+
+@ run_worker s host i port i id i rounds → i {
+    ?? ( relay_dial host port ) {
+        T rc → {
+            : ( Vec u ) reg ( pk_from_id id )
+            ?? ( relay_register rc reg ) { T _ → {} F _ → {} }
+            ( vec_free [u] reg )
+            ( relay_set_timeout rc 250 )
+            : *Swarm sw ( swarm_new rc id ( role_worker ) )
+            ( swarm_register_handlers sw )
+            ( swarm_join_group sw )
+            ( swarm_announce sw 1 )  // "I'm here — existing members, identify yourselves"
+            ( nurl_print `swarm worker ` ) ( nurl_print_int id ) ( nurl_print ` ready (` )
+            ( nurl_print_int ( roster_count # *Roster . sw roster ) ) ( nurl_print ` known)\n` )
+            // Daemon loop. rounds<=0 means run until killed.
+            : ~ i t 0
+            ~ | <= rounds 0 < t rounds { ( swarm_pump sw 200 ) = t + t 1 }
+            ( swarm_free sw )
+            ( relay_close rc )
+            ^ 0
+        }
+        F e → { ( nurl_print `swarm: worker could not dial relay\n` ) ^ 1 }
+    }
+}
+
+// Discover the live workers: announce, then pump a short window collecting the
+// HELLO replies that fold workers into the ring.
+@ swarm_discover * Swarm sw i rounds → v {
+    ( swarm_announce sw 1 )
+    : ~ i t 0
+    ~ < t rounds { ( swarm_pump sw 200 ) = t + t 1 }
+}
+
+@ run_submit s host i port i kind i lo i hi → i {
+    ?? ( relay_dial host port ) {
+        T rc → {
+            : i myid ( rand_u64 )
+            : ( Vec u ) reg ( pk_from_id myid )
+            ?? ( relay_register rc reg ) { T _ → {} F _ → {} }
+            ( vec_free [u] reg )
+            ( relay_set_timeout rc 250 )
+            : *Swarm sw ( swarm_new rc myid ( role_client ) )
+            ( swarm_join_group sw )
+            ( swarm_discover sw 8 )
+
+            : i nworkers ( roster_count # *Roster . sw roster )
+            ? == nworkers 0 {
+                ( nurl_print `swarm: no workers found — start some with 'swarm worker'\n` )
+                ( swarm_free sw ) ( relay_close rc )
+                ^ 1
+            } {}
+
+            : i nchunks ? > * nworkers 4 256 256 * nworkers 4
+            ( nurl_print `swarm: ` ) ( nurl_print_int nworkers ) ( nurl_print ` worker(s), ` )
+            ( nurl_print_int nchunks ) ( nurl_print ` chunk(s)\n` )
+
+            : ( Vec s ) chunks ( shard lo hi nchunks )
+            : ( Vec i ) tids ( vec_new [i] )
+            : ~ i i 0
+            ~ < i nchunks {
+                : s cp ?? ( vec_get [s] chunks i ) { T x → x F → # s 0 }
+                : *Chunk c # *Chunk cp
+                : ( Vec u ) key ( chunk_key i )
+                : ( Vec u ) payload ( chunk_payload . c lo . c hi )
+                ( vec_push [i] tids ( job_submit # *JobNode . sw job kind key payload ) )
+                ( vec_free [u] key ) ( vec_free [u] payload )
+                = i + i 1
+            }
+
+            // Collect until every task has landed or we give up.
+            : ~ i rnd 0
+            : ~ b done F
+            ~ & ! done < rnd 400 {
+                ( swarm_pump sw 200 )
+                : ~ b all T : ~ i j 0
+                ~ < j nchunks {
+                    ? ! ( job_has # *JobNode . sw job ?? ( vec_get [i] tids j ) { T x → x F → 0 } ) { = all F } {}
+                    = j + j 1
+                }
+                = done all
+                = rnd + rnd 1
+            }
+
+            : ~ i total 0
+            : ~ i got 0
+            : ~ i j 0
+            ~ < j nchunks {
+                ?? ( job_await # *JobNode . sw job ?? ( vec_get [i] tids j ) { T x → x F → 0 } ) {
+                    T r → { = total + total ( result_decode r ) = got + got 1 ( vec_free [u] r ) }
+                    F → {}
+                }
+                = j + j 1
+            }
+
+            ( nurl_print `result = ` ) ( nurl_print_int total )
+            ( nurl_print `  (` ) ( nurl_print_int got ) ( nurl_print `/` ) ( nurl_print_int nchunks )
+            ( nurl_print ` chunks returned)\n` )
+            ? ! done { ( nurl_print `swarm: warning — some chunks did not return in time\n` ) } {}
+
+            ( vec_free [i] tids )
+            ( shard_free chunks )
+            ( swarm_free sw )
+            ( relay_close rc )
+            ^ ? done 0 1
+        }
+        F e → { ( nurl_print `swarm: submit could not dial relay\n` ) ^ 1 }
+    }
+}
+
+// ── CLI ───────────────────────────────────────────────────────────
+
+@ usage → v {
+    ( nurl_print `swarm — distributed compute cluster\n\n` )
+    ( nurl_print `  swarm relay  <host> <port> [--v|--verbose]\n` )
+    ( nurl_print `  swarm worker <host> <port> [id] [rounds]\n` )
+    ( nurl_print `  swarm submit <host> <port> <primes|sumsq> <lo> <hi>\n\n` )
+    ( nurl_print `A worker joins the cluster just by running; submit shards a real\n` )
+    ( nurl_print `numeric range across the live workers and sums the partial results.\n` )
+    ( nurl_print `--v / --verbose makes the relay log each peer connect/disconnect.\n` )
+}
+
+@ arg_int i idx → i {
+    : String s ( env_arg idx )
+    : i v ( nurl_str_to_int ( string_data s ) )
+    ( string_free s )
+    ^ v
+}
+
+@ arg_eq i idx s lit → b {
+    : String s ( env_arg idx )
+    : b eq ? != 0 ( nurl_str_eq ( string_data s ) lit ) T F
+    ( string_free s )
+    ^ eq
+}
+
+// True if arg `idx` is the verbose flag in either spelling.
+@ arg_is_verbose i idx → b {
+    : String s ( env_arg idx )
+    : b f ? != 0 ( nurl_str_eq ( string_data s ) `--v` ) T ? != 0 ( nurl_str_eq ( string_data s ) `--verbose` ) T F
+    ( string_free s )
+    ^ f
+}
+
+@ main → i {
+    : i argc ( env_args_count )
+    ? < argc 2 { ( usage ) ^ 1 } {}
+
+    : ~ i rc 0
+    ? ( arg_eq 1 `relay` ) {
+        // Scan args after the subcommand: the verbose flag may appear anywhere;
+        // host and port are the first two non-flag positionals.
+        : ~ i vflag 0
+        : ~ String host ( string_new )
+        : ~ i port 0
+        : ~ i seen 0
+        : ~ i ai 2
+        ~ < ai argc {
+            ? ( arg_is_verbose ai ) { = vflag 1 } {
+                ? == seen 0 { ( string_free host ) = host ( env_arg ai ) = seen 1 } {
+                    ? == seen 1 { = port ( arg_int ai ) = seen 2 } {}
+                }
+            }
+            = ai + ai 1
+        }
+        ? < seen 2 { ( nurl_print `usage: swarm relay <host> <port> [--v|--verbose]\n` ) = rc 1 } {
+            = rc ( run_relay ( string_data host ) port vflag )
+        }
+        ( string_free host )
+    } {
+        ? ( arg_eq 1 `worker` ) {
+            ? < argc 4 { ( nurl_print `usage: swarm worker <host> <port> [id] [rounds]\n` ) = rc 1 } {
+                : String host ( env_arg 2 )
+                : i id ? > argc 4 ( arg_int 4 ) ( rand_u64 )
+                : i rounds ? > argc 5 ( arg_int 5 ) 0
+                = rc ( run_worker ( string_data host ) ( arg_int 3 ) id rounds )
+                ( string_free host )
+            }
+        } {
+            ? ( arg_eq 1 `submit` ) {
+                ? < argc 6 { ( nurl_print `usage: swarm submit <host> <port> <primes|sumsq> <lo> <hi>\n` ) = rc 1 } {
+                    : String host ( env_arg 2 )
+                    : i kind ? ( arg_eq 4 `sumsq` ) ( kind_sumsq ) ( kind_primes )
+                    = rc ( run_submit ( string_data host ) ( arg_int 3 ) kind ( arg_int 5 ) ( arg_int 6 ) )
+                    ( string_free host )
+                }
+            } {
+                ( usage ) = rc 1
+            }
+        }
+    }
+    ^ rc
+}

--- a/packages/swarm/src/work.nu
+++ b/packages/swarm/src/work.nu
@@ -1,0 +1,131 @@
+// packages/swarm/src/work.nu — the real workloads the cluster runs.
+//
+// A workload is a pure function over a numeric range that the coordinator
+// shards into many independent chunks; dist/ring routes each chunk to its
+// owning worker, the worker runs the registered handler, and the coordinator
+// sums the partial results. The work is genuine CPU — primes are counted by
+// trial division, not looked up — so a bigger range is a bigger real load, and
+// adding workers measurably shares it.
+//
+// Two kinds, both verifiable by a closed form so a test can pin the answer:
+//   * PRIMES   count of primes in [lo, hi)         (π(10^6) = 78498)
+//   * SUMSQ    Σ k² for k in [lo, hi), wrapping i64 (n(n+1)(2n+1)/6 closed form)
+//
+// chunk payload : [lo:8 BE][hi:8 BE]
+// result        : [value:8 BE]
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+
+@ kind_primes → i { ^ 10 }
+
+@ kind_sumsq → i { ^ 11 }
+
+// Is n prime? Trial division to √n — deliberately the honest O(√n) work.
+@ is_prime i n → b {
+    ? < n 2 { ^ F } {}
+    ? == n 2 { ^ T } {}
+    ? == 0 % n 2 { ^ F } {}
+    : ~ i d 3
+    : ~ b prime T
+    ~ & prime <= * d d n {
+        ? == 0 % n d { = prime F } {}
+        = d + d 2
+    }
+    ^ prime
+}
+
+// Count primes in [lo, hi).
+@ count_primes i lo i hi → i {
+    : ~ i c 0
+    : ~ i k lo
+    ~ < k hi { ? ( is_prime k ) { = c + c 1 } {} = k + k 1 }
+    ^ c
+}
+
+// Σ k² for k in [lo, hi), wrapping (matches the i64 the closed form is taken mod).
+@ sum_squares i lo i hi → i {
+    : ~ i acc 0
+    : ~ i k lo
+    ~ < k hi { = acc + acc * k k = k + k 1 }
+    ^ acc
+}
+
+// ── chunk codec ───────────────────────────────────────────────────
+
+@ chunk_payload i lo i hi → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( bytes_push_u64_be b # u64 lo )
+    ( bytes_push_u64_be b # u64 hi )
+    ^ b
+}
+
+@ chunk_lo ( Vec u ) p → i { ^ ?? ( bytes_read_u64_be p 0 ) { T x → # i x F → 0 } }
+
+@ chunk_hi ( Vec u ) p → i { ^ ?? ( bytes_read_u64_be p 8 ) { T x → # i x F → 0 } }
+
+@ result_encode i value → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( bytes_push_u64_be b # u64 value )
+    ^ b
+}
+
+@ result_decode ( Vec u ) p → i { ^ ?? ( bytes_read_u64_be p 0 ) { T x → # i x F → 0 } }
+
+// ── handlers (opaque bytes → bytes), the shape dist/job registers ──
+
+@ primes_handler → ( @ ( Vec u ) ( Vec u ) ) {
+    ^ \ ( Vec u ) p → ( Vec u ) {
+        : i lo ( chunk_lo p )
+        : i hi ( chunk_hi p )
+        ^ ( result_encode ( count_primes lo hi ) )
+    }
+}
+
+@ sumsq_handler → ( @ ( Vec u ) ( Vec u ) ) {
+    ^ \ ( Vec u ) p → ( Vec u ) {
+        : i lo ( chunk_lo p )
+        : i hi ( chunk_hi p )
+        ^ ( result_encode ( sum_squares lo hi ) )
+    }
+}
+
+// ── sharding: split [lo, hi) into n contiguous chunks ─────────────
+// Chunk i is [lo + i·base, …); the last chunk absorbs the remainder. Empty
+// chunks (range smaller than n) are produced as lo==hi and the handler returns
+// 0, so the aggregate stays correct regardless of n.
+
+: Chunk { i lo i hi }
+
+@ shard i lo i hi i n → ( Vec s ) {
+    : ( Vec s ) out ( vec_new [s] )
+    : i total ? > hi lo - hi lo 0
+    : i base / total n
+    : ~ i i 0
+    ~ < i n {
+        : i clo + lo * i base
+        : i chi ? == i - n 1 hi + lo * + i 1 base
+        : *Chunk c # *Chunk ( nurl_alloc Z Chunk )
+        = . c lo clo
+        = . c hi chi
+        ( vec_push [s] out # s c )
+        = i + i 1
+    }
+    ^ out
+}
+
+@ shard_free ( Vec s ) chunks → v {
+    : i n ( vec_len [s] chunks )
+    : ~ i k 0
+    ~ < k n { ?? ( vec_get [s] chunks k ) { T pp → ?!= # i pp 0 { ( nurl_free pp ) } {} F → {} } = k + k 1 }
+    ( vec_free [s] chunks )
+}
+
+// A ring key for chunk index i: 8 BE bytes so distinct chunks hash to distinct
+// ring points (FNV-1a/64 in ring_owner) and spread across the worker set.
+@ chunk_key i idx → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( bytes_push_u64_be b # u64 idx )
+    ^ b
+}

--- a/packages/swarm/tests/live_smoke.sh
+++ b/packages/swarm/tests/live_smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# packages/swarm/tests/live_smoke.sh — build the swarm binary and run a real
+# distributed workload across a local relay + worker set, end to end.
+#
+#   ./tests/live_smoke.sh
+#
+# Run from the package root (packages/swarm). Expects the monorepo layout so
+# NURL_STDLIB resolves. Starts its own relay and workers on a high port; needs
+# no network beyond loopback.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"          # packages/swarm
+REPO="$(cd "$HERE/../.." && pwd)"                  # repo root
+NURL_SH="$REPO/nurl.sh"
+export NURL_STDLIB="$REPO"
+
+PORT="${SWARM_PORT:-47780}"
+WORKERS="${SWARM_WORKERS:-3}"
+TMP="$(mktemp -d)"
+BIN="$TMP/swarm"
+pids=()
+cleanup() { for p in "${pids[@]:-}"; do kill "$p" 2>/dev/null || true; done; rm -rf "$TMP"; }
+trap cleanup EXIT
+
+echo "[smoke] building swarm"
+"$NURL_SH" "$HERE/src/main.nu" "$BIN" >/dev/null 2>&1
+
+echo "[smoke] starting relay on :$PORT"
+"$BIN" relay 127.0.0.1 "$PORT" >"$TMP/relay.log" 2>&1 &
+pids+=($!)
+sleep 0.6
+
+echo "[smoke] starting $WORKERS workers"
+for i in $(seq 1 "$WORKERS"); do
+    "$BIN" worker 127.0.0.1 "$PORT" "$i" 0 >"$TMP/w$i.log" 2>&1 &
+    pids+=($!)
+done
+sleep 1.0
+
+fail=0
+check() {  # <label> <expected> <output>
+    local label="$1" want="$2" out="$3"
+    if echo "$out" | grep -q "result = $want"; then
+        echo "[smoke] PASS $label (= $want)"
+    else
+        echo "[smoke] FAIL $label — wanted $want, got:"; echo "$out" | sed 's/^/    /'
+        fail=1
+    fi
+}
+
+# π(100000) = 9592 — a genuine distributed prime count, sharded by key.
+out="$("$BIN" submit 127.0.0.1 "$PORT" primes 1 100000 2>&1)"
+check "primes 1..100000" 9592 "$out"
+
+# Σ k² for k in [0,1000) = 999·1000·1999/6 = 332833500.
+out="$("$BIN" submit 127.0.0.1 "$PORT" sumsq 0 1000 2>&1)"
+check "sumsq 0..1000" 332833500 "$out"
+
+if [ "$fail" = 0 ]; then echo "[smoke] OK"; else echo "[smoke] FAILED"; exit 1; fi

--- a/packages/swarm/tests/work_test.nu
+++ b/packages/swarm/tests/work_test.nu
@@ -1,0 +1,108 @@
+// packages/swarm/tests/work_test.nu — offline tests for the pure compute core.
+//
+// Everything the cluster relies on for a CORRECT distributed answer is pure and
+// checkable without a socket: the workloads themselves, and — critically — that
+// sharding partitions a range exactly (no gap, no overlap) so the sum of the
+// chunk results equals the whole-range result. Run from the package root:
+//
+//   NURL_STDLIB=<repo> ./nurl.sh tests/work_test.nu /tmp/wt && /tmp/wt
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/dist/ring.nu`
+$ `src/work.nu`
+$ `src/census.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ pi s label i a i b → v {
+    ( nurl_print label ) ( nurl_print_int a )
+    ( nurl_print ? == a b ` == ` ` != ` ) ( nurl_print_int b ) ( nurl_print `\n` )
+}
+
+// Sum a workload over a sharded range — the exact thing the coordinator does.
+@ shard_sum_primes i lo i hi i n → i {
+    : ( Vec s ) cs ( shard lo hi n )
+    : ~ i total 0
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] cs k ) { T x → x F → # s 0 }
+        : *Chunk c # *Chunk pp
+        = total + total ( count_primes . c lo . c hi )
+        = k + k 1
+    }
+    ( shard_free cs )
+    ^ total
+}
+
+@ shard_sum_sumsq i lo i hi i n → i {
+    : ( Vec s ) cs ( shard lo hi n )
+    : ~ i total 0
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] cs k ) { T x → x F → # s 0 }
+        : *Chunk c # *Chunk pp
+        = total + total ( sum_squares . c lo . c hi )
+        = k + k 1
+    }
+    ( shard_free cs )
+    ^ total
+}
+
+@ pk_demo i seed → ( Vec u ) {
+    : ( Vec u ) v ( vec_new [u] )
+    : ~ i k 0
+    ~ < k 32 { ( vec_push [u] v # u + seed k ) = k + k 1 }
+    ^ v
+}
+
+@ main → i {
+    // ── workloads vs known closed forms ──────────────────────────
+    ( pi `pi(100):  ` ( count_primes 1 100 ) 25 )
+    ( pi `pi(1000): ` ( count_primes 1 1000 ) 168 )
+    ( pi `sumsq[1,11): ` ( sum_squares 1 11 ) 385 )
+
+    // ── sharding partitions a range EXACTLY ──────────────────────
+    // Any chunk count must reproduce the whole-range answer.
+    ( pb `primes shard n=1:  ` == ( shard_sum_primes 1 1000 1 ) 168 )
+    ( pb `primes shard n=7:  ` == ( shard_sum_primes 1 1000 7 ) 168 )
+    ( pb `primes shard n=64: ` == ( shard_sum_primes 1 1000 64 ) 168 )
+    ( pb `primes shard n>range: ` == ( shard_sum_primes 1 50 200 ) ( count_primes 1 50 ) )
+    ( pb `sumsq shard n=8:  ` == ( shard_sum_sumsq 0 100 8 ) ( sum_squares 0 100 ) )
+    ( pb `sumsq shard n=13: ` == ( shard_sum_sumsq 0 100 13 ) ( sum_squares 0 100 ) )
+
+    // ── chunk + result codecs round-trip ─────────────────────────
+    : ( Vec u ) cp ( chunk_payload 1234 5678 )
+    ( pb `chunk lo: ` == ( chunk_lo cp ) 1234 )
+    ( pb `chunk hi: ` == ( chunk_hi cp ) 5678 )
+    ( vec_free [u] cp )
+    : ( Vec u ) rb ( result_encode 999999 )
+    ( pb `result rt: ` == ( result_decode rb ) 999999 )
+    ( vec_free [u] rb )
+
+    // ── census HELLO codec round-trips ───────────────────────────
+    : ( Vec u ) pk ( pk_demo 3 )
+    : ( Vec u ) hb ( hello_build 42 ( role_worker ) 1 pk )
+    : Hello h ( hello_decode hb )
+    ( pb `hello id:   ` == . h id 42 )
+    ( pb `hello role: ` == . h role ( role_worker ) )
+    ( pb `hello want: ` == . h want 1 )
+    ( pb `hello pk:   ` ( bytes_eq . h pubkey pk ) )
+    ( hello_free h )
+    ( vec_free [u] hb )
+
+    // ── roster folds a worker once (idempotent ring membership) ──
+    : *Ring ring ( ring_new )
+    : *Roster r ( roster_new )
+    : b first ( roster_add r ring pk 42 64 )
+    : b dup ( roster_add r ring pk 42 64 )
+    ( pb `roster add first: ` first )
+    ( pb `roster dedup:     ` ! dup )
+    ( pb `roster count==1:  ` == ( roster_count r ) 1 )
+    ( roster_free r )
+    ( ring_free ring )
+    ( vec_free [u] pk )
+
+    ^ 0
+}

--- a/stdlib/net/relay.nu
+++ b/stdlib/net/relay.nu
@@ -125,7 +125,40 @@ $ `stdlib/std/async.nu`
 
 @ relay_build_group_leave ( Vec u ) group_id → ( Vec u ) { ^ ( __frame ( relay_gleave ) group_id ) }
 
-@ relay_build_group_send ( Vec u ) group_id ( Vec u ) payload → ( Vec u ) { ^ ( __frame_addressed ( relay_gsend ) group_id payload ) }
+// A GROUP-SEND body is length-delimited: [gidlen:2 BE][gid][payload]. Group
+// ids are variable length — GJOIN/GLEAVE carry the raw id as the whole body —
+// so unlike a FORWARD/DELIVER pubkey (a fixed 32 bytes), the gid here must be
+// framed explicitly. The previous encoding reused the 32-byte pubkey split,
+// which silently dropped the fanout for any gid that was not exactly 32 bytes.
+@ relay_build_group_send ( Vec u ) group_id ( Vec u ) payload → ( Vec u ) {
+    : ( Vec u ) body ( vec_new [u] )
+    ( bytes_push_u16_be body # u16 ( vec_len [u] group_id ) )
+    ( vec_extend [u] body group_id )
+    ( vec_extend [u] body payload )
+    : ( Vec u ) f ( __frame ( relay_gsend ) body )
+    ( vec_free [u] body )
+    ^ f
+}
+
+// gid of a length-delimited GROUP-SEND body.
+@ relay_gsend_gid ( Vec u ) body → ( Vec u ) {
+    : i glen ?? ( bytes_read_u16_be body 0 ) { T x → # i x F → 0 }
+    : ( Vec u ) gid ( vec_with_cap [u] glen )
+    : ~ i k 0
+    ~ < k glen { ?? ( vec_get [u] body + 2 k ) { T b → ( vec_push [u] gid b ) F → {} } = k + k 1 }
+    ^ gid
+}
+
+// payload of a length-delimited GROUP-SEND body (everything past the gid).
+@ relay_gsend_payload ( Vec u ) body → ( Vec u ) {
+    : i glen ?? ( bytes_read_u16_be body 0 ) { T x → # i x F → 0 }
+    : i start + 2 glen
+    : i n ( vec_len [u] body )
+    : ( Vec u ) pl ( vec_new [u] )
+    : ~ i k start
+    ~ < k n { ?? ( vec_get [u] body k ) { T b → ( vec_push [u] pl b ) F → {} } = k + k 1 }
+    ^ pl
+}
 
 // First 32 bytes of a FORWARD/DELIVER body = the peer pubkey.
 @ relay_body_pk ( Vec u ) body → ( Vec u ) {
@@ -219,15 +252,30 @@ $ `stdlib/std/async.nu`
     TcpListener lst
     ( Vec s ) clients  // *RelayEntry
     ( Vec s ) groups  // *GroupEntry
+    i verbose  // 1 = log peer connect/disconnect to stdout
 }
 
 @ relay_server_start s host i port → !RelayServer NetErr {
     : !TcpListener NetErr lr ( tcp_listen host port )
     : !RelayServer NetErr out ?? lr {
-        T l → @ !RelayServer NetErr { T @ RelayServer { l ( vec_new [s] ) ( vec_new [s] ) } }
+        T l → @ !RelayServer NetErr { T @ RelayServer { l ( vec_new [s] ) ( vec_new [s] ) 0 } }
         F e → @ !RelayServer NetErr { F e }
     }
     ^ out
+}
+
+// Enable/disable connect/disconnect logging (off by default).
+@ relay_server_set_verbose * RelayServer rs i v → v { = . rs verbose v }
+
+// Log a short, readable peer id (first 4 pubkey bytes as hex) with a sign.
+@ __relay_log s sign ( Vec u ) pk → v {
+    : i n ? < ( vec_len [u] pk ) 4 ( vec_len [u] pk ) 4
+    : ( Vec u ) head ( bytes_slice pk 0 n )
+    : String hex ( bytes_to_hex head )
+    ( nurl_print `relay: ` ) ( nurl_print sign ) ( nurl_print ` peer ` )
+    ( nurl_print ( string_data hex ) ) ( nurl_print `\n` )
+    ( string_free hex )
+    ( vec_free [u] head )
 }
 
 @ __relay_register_conn * RelayServer rs TcpConn c ( Vec u ) pk → s {
@@ -372,6 +420,7 @@ $ `stdlib/std/async.nu`
                 : i ft . f ftype
                 ? == ft ( relay_reg ) {
                     = self_entry ( __relay_register_conn rs c . f body )
+                    ? == . rs verbose 1 { ( __relay_log `+` . f body ) } {}
                 } {}
                 ? == ft ( relay_fwd ) {
                     ? != # i self_entry 0 {
@@ -393,8 +442,8 @@ $ `stdlib/std/async.nu`
                 ? == ft ( relay_gleave ) { ( __relay_group_leave rs self_entry . f body ) } {}
                 ? == ft ( relay_gsend ) {
                     ? != # i self_entry 0 {
-                        : ( Vec u ) gid ( relay_body_pk . f body )
-                        : ( Vec u ) pl ( relay_body_payload . f body )
+                        : ( Vec u ) gid ( relay_gsend_gid . f body )
+                        : ( Vec u ) pl ( relay_gsend_payload . f body )
                         ( __relay_group_fanout rs self_entry gid pl )
                         ( vec_free [u] gid )
                         ( vec_free [u] pl )
@@ -409,6 +458,7 @@ $ `stdlib/std/async.nu`
         : *RelayEntry se # *RelayEntry self_entry
         = . se live 0
         ( __relay_drop_from_groups rs self_entry )
+        ? == . rs verbose 1 { ( __relay_log `-` . se pubkey ) } {}
     } {}
     ( tcp_close_conn c )
 }

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -171,10 +171,25 @@ void nurl_print_int(long long n)  { printf("%lld\n", n); }
 void nurl_print_str(const char *s){ puts(s); }
 void nurl_print_bool(int b)       { puts(b ? "true" : "false"); }
 
+/* Read an integer from stdin, equivalent to scanf("%lld") but built from
+ * getchar/ungetc so it does not pull in scanf — whose glibc >= 2.38 C23
+ * redirect (__isoc23_scanf) is undefined when the LTO runtime bitcode is
+ * linked against an older-glibc target (see nurl__parse_ul). Skips leading
+ * whitespace, takes an optional sign, accumulates digits, and pushes the
+ * first non-digit back so the next read sees it — exactly as scanf leaves it.
+ * Returns 0 when no digits are present. */
 long long nurl_read_int(void) {
+    int c;
+    do { c = getchar(); } while (c == ' ' || c == '\t' || c == '\n' ||
+                                 c == '\r' || c == '\f' || c == '\v');
+    int neg = 0;
+    if (c == '+' || c == '-') { neg = (c == '-'); c = getchar(); }
     long long n = 0;
-    if (scanf("%lld", &n) != 1) n = 0;
-    return n;
+    int any = 0;
+    while (c >= '0' && c <= '9') { n = n * 10 + (c - '0'); c = getchar(); any = 1; }
+    if (c != EOF) ungetc(c, stdin);
+    if (!any) return 0;
+    return neg ? -n : n;
 }
 
 /* Read a line from stdin, strip trailing '\n'. Always returns a heap-owned
@@ -3341,6 +3356,23 @@ static int nurl__parse_numeric_addr(const char *s, int *out_family,
     return 0;
 }
 
+/* Portable non-negative decimal parser. Deliberately avoids strtoul/strtol/
+ * atoi: on glibc >= 2.38 those resolve (in C23 translation mode) to the
+ * versioned symbols __isoc23_strtoul / __isoc23_strtol, which are baked into
+ * the shipped, LTO-distributed runtime bitcode and then fail to link against
+ * an OLDER-glibc target (e.g. Raspberry Pi OS aarch64: "undefined symbol:
+ * __isoc23_strtoul"). Parsing digits by hand keeps the runtime libc-only and
+ * portable across every glibc/musl version and target. Leading blanks are
+ * skipped; *end (if non-NULL) points past the last digit consumed, so callers
+ * can detect trailing garbage exactly as strtoul's `end` did. */
+static unsigned long nurl__parse_ul(const char *s, const char **end) {
+    while (*s == ' ' || *s == '\t') s++;
+    unsigned long v = 0;
+    while (*s >= '0' && *s <= '9') { v = v * 10UL + (unsigned long)(*s - '0'); s++; }
+    if (end) *end = s;
+    return v;
+}
+
 /* iface argument convention (intentionally minimal — no if_nametoindex
  * to keep Win32 builds free of -liphlpapi):
  *   ""                           default interface (INADDR_ANY / 0)
@@ -3386,9 +3418,9 @@ static long long nurl__udp_mcast_op(long long handle, const char *group,
         mr.ipv6mr_multiaddr = ((struct sockaddr_in6*)&gsa)->sin6_addr;
         unsigned ifidx = 0;
         if (iface && *iface) {
-            char *end = NULL;
-            unsigned long v = strtoul(iface, &end, 10);
-            if (!end || *end != 0) {
+            const char *end = NULL;
+            unsigned long v = nurl__parse_ul(iface, &end);
+            if (!end || end == iface || *end != 0) {
                 h->err_kind = NURL_NET_ERR_OTHER;
                 return -1;
             }
@@ -4706,7 +4738,7 @@ void nurl_runtime_init(long long worker_count) {
     int wc = (int)worker_count;
     if (wc <= 0) {
         const char *env = getenv("NURL_WORKERS");
-        if (env && *env) wc = atoi(env);
+        if (env && *env) wc = (int)nurl__parse_ul(env, NULL);
         if (wc <= 0) {
             long n = sysconf(_SC_NPROCESSORS_ONLN);
             wc = (n > 0) ? (int)n : 2;


### PR DESCRIPTION
## Summary

Adds **`packages/swarm`** — a distributed compute cluster you join by installing it — and fixes three issues in the underlying stack that surfaced while building it.

```sh
nurlpkg install swarm                 # drops the `swarm` binary on $PATH
swarm relay  0.0.0.0 47700 --v        # the meeting point (one per cluster)
swarm worker <relay> 47700            # ← that's the join; it now takes work
swarm submit <relay> 47700 primes 1 1000000   # → result = 78498 (π(10^6))
```

A worker needs no recompile and no member list: it announces itself over the relay group (HELLO census, `src/census.nu`), every node folds it into the consistent-hash ring, and from then on it owns its share of the keyspace and runs the registered handlers (`src/work.nu`). The coordinator discovers the live workers the same way, shards a real numeric range across them by key (`dist/ring` → `dist/job`), and sums the partial results. Built entirely on the standard distributed stack — `net/relay`, `net/transport`, `dist/ring`, `dist/job`.

Two real workloads, both verifiable by a closed form: `primes <lo> <hi>` (honest trial division) and `sumsq <lo> <hi>` (Σk²).

## Stack fixes

- **Runtime: aarch64 / old-glibc link failure (Raspberry Pi).** `nurlpkg install swarm` on Raspberry Pi OS died with `undefined symbol: __isoc23_strtoul` / `__isoc23_strtol`. `runtime.c` called `strtoul`/`atoi`/`scanf`, which glibc-2.38+ headers redirect (in C23 mode) to versioned `__isoc23_*` symbols baked into the shipped LTO bitcode — undefined when linked against an older-glibc target. The runtime no longer calls any of them: a hand-rolled `nurl__parse_ul` replaces `strtoul`/`atoi`, and `nurl_read_int` is rebuilt on `getchar`/`ungetc` instead of `scanf`. The runtime bitcode now references **zero** `strtol`/`scanf`/`isoc23` symbols (`llvm-nm`-verified); cross-linking swarm for `aarch64-linux-gnu.2.28` is clean.

- **`net/relay`: group multicast silently dropped any non-32-byte group id.** GJOIN/GLEAVE carry the raw variable-length gid, but GSEND reused the fixed 32-byte pubkey split, so a non-32-byte gid was mis-parsed server-side and the fanout was skipped with **no error**. GSEND is now length-delimited (`[gidlen:2][gid][payload]`) via `relay_gsend_gid`/`relay_gsend_payload`. `relay_codec` golden updated + a 5-byte-gid regression added.

- **`net/relay`: verbose server mode.** `RelayServer.verbose` + `relay_server_set_verbose` log each peer connect/disconnect; swarm exposes it as `swarm relay <host> <port> --v|--verbose`.

## Tests

- Full corpus **497 PASS / 0 FAIL**; `nurlfmt` idempotent.
- `packages/swarm/tests/work_test.nu` — pure logic (workloads, exact sharding, codecs), ASan-clean.
- `packages/swarm/tests/live_smoke.sh` — relay + workers + submit end to end.
- Live: π(10^6)=78498 across 4 workers; verified end-to-end via a registry `nurlpkg install` against the released stdlib.

## Release sequencing

`swarm` uses a 32-byte group id so the **published swarm 0.1.0 works on the current released toolchain**. The relay-gid fix and the verbose mode reference new stdlib, so they ship for the **next toolchain release** — after which the Pi can `nurlpkg install swarm` (it needs the fixed runtime) and a swarm 0.2.0 with `--verbose` can be published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)