### PR TITLE
Release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3] — 2026-06-28
+
+A **portability + distributed-stack** release. The runtime drops its last
+glibc-version-specific symbols so the toolchain builds and links on older-glibc
+targets again (notably **Raspberry Pi OS aarch64**), a silent `net/relay`
+group-multicast bug is fixed, and the new **`packages/swarm`** package turns the
+distributed stack into a compute cluster you join by installing it.
+
 ### Fixed
 
 - **Runtime failed to link on older-glibc targets (e.g. Raspberry Pi OS


### PR DESCRIPTION
Promotes the `[Unreleased]` CHANGELOG entries to a **`[0.10.3]`** release section. No code changes — the fixes landed in #309; this is the release-prep doc commit (same pattern as #308 for v0.10.2).

## What's in v0.10.3

A **portability + distributed-stack** release.

### Fixed
- **Runtime: aarch64 / old-glibc link failure (Raspberry Pi OS).** The runtime no longer calls `strtoul`/`atoi`/`scanf`, so the shipped LTO bitcode references none of the glibc-2.38+ `__isoc23_*` symbols — it links cleanly across every glibc/musl version. This is what unblocks `nurlpkg install swarm` on aarch64.
- **`net/relay` group multicast silently dropped any non-32-byte group id** — GSEND is now length-delimited.

### Added
- **`net/relay` verbose server mode** (`relay_server_set_verbose` / `RelayServer.verbose`; `swarm relay … --v|--verbose`).
- **`packages/swarm`** — a distributed compute cluster you join by installing it.

## After merge

Tag `v0.10.3` and push it — that's the release trigger (version comes from `git describe`). Once the toolchain release is out:
- The Raspberry Pi can `nurlpkg install swarm` (it gets the fixed runtime).
- `swarm 0.2.0` (with `--verbose`) can be published to the registry — it depends on the new `RelayServer.verbose` field and must not be built against an older stdlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)