### PR TITLE
swarm 0.2.0: verbose relay + min-toolchain note

### DIFF
--- a/packages/swarm/README.md
+++ b/packages/swarm/README.md
@@ -9,6 +9,12 @@ nurlpkg install swarm           # drops the `swarm` binary on $PATH
 swarm worker <relay-host> <port>   # ← that's the join. it now takes work.
 ```
 
+> **Requires NURL ≥ v0.10.3.** `swarm` is built from source against your
+> installed stdlib at install time, and the verbose relay uses a relay-server
+> field added in v0.10.3 (`RelayServer.verbose`). On an older toolchain that
+> field does not exist, so `swarm relay` would miscompile — update with
+> `get-nurl.sh` (or rebuild the toolchain from source) before installing.
+
 It is built entirely on NURL's standard distributed stack (see
 [`docs/DISTRIBUTED.md`](../../docs/DISTRIBUTED.md)): `net/relay` for reach
 through NATs, `net/transport` for the pubkey-addressed seam, `dist/ring` for
@@ -21,7 +27,7 @@ real workloads, and a CLI.
 One machine runs a relay (the meeting point — one per cluster):
 
 ```sh
-swarm relay 0.0.0.0 47700
+swarm relay 0.0.0.0 47700            # add --verbose to log peers joining/leaving
 ```
 
 Any number of machines join as workers (this is the whole "add a node" story):

--- a/packages/swarm/nurl.toml
+++ b/packages/swarm/nurl.toml
@@ -1,7 +1,7 @@
 [package]
 name = "swarm"
-version = "0.1.0"
-description = "A distributed compute cluster you join by installing it. Run `swarm worker <relay> <port>` on any machine and it announces itself over the relay group, every node folds it into the consistent-hash ring, and it starts taking its share of real work. `swarm submit` shards a genuine numeric workload (prime counting, sum-of-squares) across the live workers and sums the partial results. Built entirely on the standard distributed stack (net/relay, net/transport, dist/ring, dist/job) — no external frameworks."
+version = "0.2.0"
+description = "A distributed compute cluster you join by installing it. Run `swarm worker <relay> <port>` on any machine and it announces itself over the relay group, every node folds it into the consistent-hash ring, and it starts taking its share of real work. `swarm submit` shards a genuine numeric workload (prime counting, sum-of-squares) across the live workers and sums the partial results, and `swarm relay --verbose` logs peers as they join and leave. Built entirely on the standard distributed stack (net/relay, net/transport, dist/ring, dist/job) — no external frameworks. Requires NURL >= v0.10.3."
 license = "MIT OR Apache-2.0"
 
 [dependencies]


### PR DESCRIPTION
Bumps `packages/swarm` to **0.2.0**:

- Surfaces the relay verbose mode (`swarm relay <host> <port> --v|--verbose`, shipped in NURL v0.10.3) in the manifest description and README.
- Documents the **NURL ≥ v0.10.3** requirement: the verbose path uses the new `RelayServer.verbose` field, so building against an older stdlib would miscompile the `relay` subcommand (the `worker`/`submit` paths are unaffected).

Verified: builds and runs against the repo stdlib (= v0.10.3) — smoke test green (π(100000)=9592, Σk²[0,1000)=332833500), verbose relay logs peer connect/disconnect.

Registry publish is a separate step (done with `nurlpkg publish` once the publish token is available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)