### PR TITLE
swarm-mcp: MCP-controlled distributed compute engine (phase 1)

### DIFF
--- a/packages/swarm-mcp/README.md
+++ b/packages/swarm-mcp/README.md
@@ -1,0 +1,146 @@
+# swarm-mcp — an MCP-controlled distributed compute engine
+
+`swarm-mcp` lets a **language model** drive a distributed compute cluster over
+the [Model Context Protocol](https://modelcontextprotocol.io). The model sets a
+workload — an integer **expression kernel** in the variable `x`, plus a range
+and a reduce op — and the cluster evaluates it map-reduce style across every
+live worker. The model submits tasks, lists running ones, and reads finished
+results, all through three MCP tools.
+
+It is built on the [`swarm`](../swarm) distributed stack: `net/relay` for reach,
+`net/transport` for the pubkey seam, `dist/ring` for key ownership, and
+`dist/job` for dispatch. A machine joins the cluster just by running
+`swarm-mcp worker`; the MCP server is a cluster coordinator that exposes the
+control surface.
+
+> **Requires NURL ≥ v0.10.3** (the relay verbose field; built from source
+> against your installed stdlib at install time).
+
+## The control surface (what the LLM sees)
+
+Three tools, with self-describing schemas so a model uses them without docs:
+
+| tool | arguments | does |
+|------|-----------|------|
+| `compute_submit` | `expr` (string), `lo` (int), `hi` (int), `reduce` (string, default `sum`) | shard + run the kernel over `[lo,hi)`; returns a `task_id` immediately |
+| `compute_list` | — | every task with status (`running`/`done`), kernel, range, reduce, result |
+| `compute_result` | `task_id` (int) | one task's status and, once finished, the reduced value |
+
+A submit returns at once with `status: running` (or `done` for tiny tasks);
+the model polls `compute_result` until it is `done`. Example exchange:
+
+```jsonc
+// → compute_submit
+{"expr":"x*x", "lo":1, "hi":1000000, "reduce":"sum"}
+// ← {"task_id":1, "status":"running", "kernel":"x*x", "reduce":"sum", "lo":1, "hi":1000000, "chunks":12}
+// → compute_result {"task_id":1}
+// ← {"task_id":1, "status":"done", ..., "result":333332833333500000}
+```
+
+## The kernel language
+
+A workload's *map* step is an integer expression in one variable `x`,
+deliberately small and regular:
+
+```
+operators   + - * / %          (truncated division; ÷0 and %0 yield 0)
+comparisons < <= > >= == !=     (yield 0 or 1)
+logical     & |                 (operate on 0/1; non-zero is "true")
+ternary     cond ? a : b
+functions   min(a,b)  max(a,b)  abs(a)
+variable    x        literals   integers
+```
+
+The *reduce* step folds the mapped values over the whole range:
+
+| reduce | result |
+|--------|--------|
+| `sum` | Σ map(x) |
+| `product` | Π map(x) |
+| `min` / `max` | min / max of map(x) |
+| `count` | how many x make map(x) non-zero |
+
+Examples the model can write directly:
+
+| goal | `expr` | `reduce` |
+|------|--------|----------|
+| sum of squares | `x*x` | `sum` |
+| count even numbers | `x%2==0` | `count` |
+| count in a sub-interval | `x>1000 & x<2000` | `count` |
+| largest value of a polynomial | `x*x-7*x` | `max` |
+| sum only where a condition holds | `x>100 ? x : 0` | `sum` |
+
+Every reduce op is associative, so sharding the range across workers and
+combining the partial folds is exact — the answer never depends on the worker
+count.
+
+## Quick start
+
+```sh
+nurlpkg install swarm-mcp
+
+# one relay (the meeting point), one per cluster
+swarm-mcp relay 0.0.0.0 47700           # add --v to log workers joining/leaving
+
+# any number of compute nodes — joining is just running this
+swarm-mcp worker <relay-host> 47700
+
+# the MCP server (stdio) — point your LLM client at this command
+swarm-mcp mcp <relay-host> 47700
+```
+
+A manual CLI submit (no MCP) is handy for testing:
+
+```sh
+swarm-mcp submit <relay-host> 47700 sum 1 1000000 'x*x'
+# → sum of (x*x) over [1,1000000) = 333332833333500000
+```
+
+## How it works
+
+1. **Join = announce.** A worker broadcasts a HELLO to the relay group
+   (`census.nu`); every node folds it into the consistent-hash ring. Each worker
+   registers one generic **kernel handler** (`work.nu`).
+2. **Submit = shard by key.** The MCP coordinator discovers the live workers,
+   splits `[lo,hi)` into chunks, and keys each so `dist/ring` routes it to its
+   owner; `dist/job` carries it over the transport.
+3. **Execute = interpret the kernel.** The owning worker parses the expression
+   once (`expr.nu`) and folds it over its sub-range, returning a partial result
+   recorded idempotently.
+4. **Aggregate.** The coordinator combines the partial folds with the reduce op
+   and reports the value back through the MCP tool.
+
+The coordinator drains cluster traffic on every tool call, so tasks make
+progress as the model polls — no background thread, single-process, robust.
+
+## Roadmap
+
+This is **phase 1**: the kernel is an interpreted integer expression — enough
+for any "normal-operations" workload. **Phase 2** keeps the exact same MCP
+surface but lets the model supply the kernel as **arbitrary NURL code compiled
+to a wasm module** shipped to the workers, so a task can be a full program, not
+just an expression.
+
+## Tests
+
+```sh
+# kernel language (parse + eval) and map-reduce + sharding — ASan-clean
+NURL_STDLIB=<repo> ../../nurl.sh tests/expr_test.nu /tmp/et && /tmp/et
+NURL_STDLIB=<repo> ../../nurl.sh tests/work_test.nu /tmp/wt && /tmp/wt
+
+# end-to-end: relay + workers + a CLI submit + a full MCP session
+./tests/live_smoke.sh
+```
+
+## Layout
+
+```
+src/expr.nu     the kernel language: tokenizer, parser (flat arena), evaluator
+src/work.nu     map-reduce: reduce ops, the kernel handler, sharding
+src/census.nu   HELLO membership gossip → consistent-hash ring
+src/main.nu     roles (relay | worker | submit | mcp) + the MCP server
+```
+
+## License
+
+MIT OR Apache-2.0.

--- a/packages/swarm-mcp/nurl.toml
+++ b/packages/swarm-mcp/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "swarm-mcp"
+version = "0.1.0"
+description = "An MCP-controlled distributed compute engine. A language model sets a workload over Model Context Protocol — an integer expression kernel in the variable x, plus a range and a reduce op (sum/product/min/max/count) — and the cluster evaluates it map-reduce style across every live worker; the model reads running tasks and finished results back. Built on the swarm distributed stack (relay/transport/ring/job): join a machine with `swarm-mcp worker`, drive it with `swarm-mcp mcp`. Phase 1 of an LLM-programmable compute mesh. Requires NURL >= v0.10.3."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/swarm-mcp/src/census.nu
+++ b/packages/swarm-mcp/src/census.nu
@@ -1,0 +1,108 @@
+// packages/swarm/src/census.nu — lightweight membership gossip for the swarm.
+//
+// The compute layer (dist/job over dist/ring) needs every node to agree on the
+// live worker set: a worker must know it owns a key, and the coordinator must
+// know which pubkeys to route to. The full SWIM table (net/membership.nu) is
+// the heavy, churn-hardened answer; this is the small one a compute cluster
+// actually needs — a HELLO announcement that feeds the consistent-hash ring.
+//
+//   * a node joins by broadcasting HELLO(role, want=1) to the relay group;
+//   * everyone who hears it adds the node to their ring (workers only) and, if
+//     `want`, replies with their own HELLO so the newcomer learns them too;
+//   * the ring converges, and "join the cluster" is literally "run the binary".
+//
+// Roles: a WORKER owns keys and executes handlers, so it joins everyone's ring;
+// a CLIENT (the coordinator) only submits, so it is never added to the ring —
+// otherwise it would own keys it has no handler for and silently drop results.
+//
+// The codec and the membership set are pure; only the pump touches transport.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/dist/ring.nu`
+
+@ census_hello_t → i { ^ 3 }
+
+@ role_client → i { ^ 0 }
+
+@ role_worker → i { ^ 1 }
+
+// HELLO wire: [3][id:8][role:1][want:1][pklen:2][pubkey…]
+@ hello_build i id i role i want ( Vec u ) pubkey → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( vec_push [u] b # u ( census_hello_t ) )
+    ( bytes_push_u64_be b # u64 id )
+    ( vec_push [u] b # u role )
+    ( vec_push [u] b # u want )
+    ( bytes_push_u16_be b # u16 ( vec_len [u] pubkey ) )
+    ( vec_extend [u] b pubkey )
+    ^ b
+}
+
+: Hello { i id i role i want ( Vec u ) pubkey }
+
+@ hello_free Hello h → v { ( vec_free [u] . h pubkey ) }
+
+@ hello_decode ( Vec u ) buf → Hello {
+    : i id ?? ( bytes_read_u64_be buf 1 ) { T x → # i x F → 0 }
+    : i role ?? ( vec_get [u] buf 9 ) { T x → # i x F → 0 }
+    : i want ?? ( vec_get [u] buf 10 ) { T x → # i x F → 0 }
+    : i pklen ?? ( bytes_read_u16_be buf 11 ) { T x → # i x F → 0 }
+    : ( Vec u ) pk ( vec_with_cap [u] pklen )
+    : ~ i k 0
+    ~ < k pklen { ?? ( vec_get [u] buf + 13 k ) { T x → ( vec_push [u] pk x ) F → {} } = k + k 1 }
+    ^ @ Hello { id role want pk }
+}
+
+// ── membership set: the pubkeys currently in the ring ──────────────
+// A node tracks the pubkeys it has folded into its ring so a re-heard HELLO is
+// idempotent (adding a member twice would double its ring points and skew load).
+
+: Member { ( Vec u ) pubkey i id }
+
+: Roster { ( Vec s ) members }  // *Member
+
+@ roster_new → *Roster {
+    : *Roster r # *Roster ( nurl_alloc Z Roster )
+    = . r members ( vec_new [s] )
+    ^ r
+}
+
+@ roster_free * Roster r → v {
+    : i n ( vec_len [s] . r members )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . r members k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *Member m # *Member pp ( vec_free [u] . m pubkey ) ( nurl_free # s m ) } {}
+        = k + k 1
+    }
+    ( vec_free [s] . r members )
+    ( nurl_free # s r )
+}
+
+@ roster_has * Roster r ( Vec u ) pubkey → b {
+    : i n ( vec_len [s] . r members )
+    : ~ b found F : ~ i k 0
+    ~ & ! found < k n {
+        : s pp ?? ( vec_get [s] . r members k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *Member m # *Member pp ? ( bytes_eq . m pubkey pubkey ) { = found T } {} } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+@ roster_count * Roster r → i { ^ ( vec_len [s] . r members ) }
+
+// Fold a worker into the roster + ring, once. Returns T if newly added.
+@ roster_add * Roster r * Ring ring ( Vec u ) pubkey i id i vnodes → b {
+    ? ( roster_has r pubkey ) { ^ F } {}
+    : *Member m # *Member ( nurl_alloc Z Member )
+    : ( Vec u ) cp ( vec_with_cap [u] ( vec_len [u] pubkey ) )
+    ( vec_extend [u] cp pubkey )
+    = . m pubkey cp
+    = . m id id
+    ( vec_push [s] . r members # s m )
+    ( ring_add_member ring pubkey vnodes )
+    ^ T
+}

--- a/packages/swarm-mcp/src/expr.nu
+++ b/packages/swarm-mcp/src/expr.nu
@@ -1,0 +1,292 @@
+// packages/swarm-mcp/src/expr.nu — the phase-1 "kernel": a small, regular
+// integer-expression language the cluster evaluates per element.
+//
+// A workload is a map-reduce: the coordinator ships an expression in one
+// variable `x` plus a range and a reduce op; each worker parses the expression
+// once, evaluates it for every x in its sub-range, and folds the results. The
+// language is deliberately small and regular so a language model can write it
+// without docs — and it is the natural precursor to phase 2, where the kernel
+// is arbitrary NURL compiled to wasm instead of interpreted here.
+//
+//   expr    := ternary
+//   ternary := logic ( '?' expr ':' ternary )?
+//   logic   := compare ( ('&'|'|') compare )*
+//   compare := addsub ( ('<'|'<='|'>'|'>='|'=='|'!=') addsub )?
+//   addsub  := muldiv ( ('+'|'-') muldiv )*
+//   muldiv  := unary  ( ('*'|'/'|'%') unary )*
+//   unary   := '-' unary | primary
+//   primary := INT | 'x' | '(' expr ')' | ('min'|'max') '(' expr ',' expr ')'
+//            | 'abs' '(' expr ')'
+//
+// All arithmetic is i64 (truncated division; division/mod by zero yields 0).
+// Comparisons and '&' '|' yield 0/1; any non-zero is "true".
+//
+// Tokens are kept in two parallel int vectors; the parser builds a flat
+// stride-4 node arena (tag,a,b,c) and returns the root index — the resp.nu
+// arena pattern, so nesting needs no per-node allocation.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+// ── token kinds ──────────────────────────────────────────────────
+// 0 END · 1 INT(val) · 2 X · 3 + · 4 - · 5 * · 6 / · 7 % · 8 < · 9 <= ·
+// 10 > · 11 >= · 12 == · 13 != · 14 & · 15 | · 16 ? · 17 : · 18 ( · 19 ) ·
+// 20 , · 21 min · 22 max · 23 abs · 99 ERROR
+// Binary-operator kinds 3..15 are chosen to equal their node tags below.
+
+// ── node tags ────────────────────────────────────────────────────
+// 0 INT(a=value) · 1 X · 2 NEG(a) · 3 ADD · 4 SUB · 5 MUL · 6 DIV · 7 MOD ·
+// 8 LT · 9 LE · 10 GT · 11 GE · 12 EQ · 13 NE · 14 AND · 15 OR ·
+// 16 TERN(a=cond,b=then,c=else) · 17 MIN(a,b) · 18 MAX(a,b) · 19 ABS(a)
+
+@ __is_digit i c → b { ^ & >= c 48 <= c 57 }
+
+@ __is_alpha i c → b { ^ & >= c 97 <= c 122 }
+
+@ __is_space i c → b { ^ | == c 32 | == c 9 | == c 13 == c 10 }
+
+// ── tokenizer ────────────────────────────────────────────────────
+// Fills tk (kinds) / tv (values). Returns F on an unrecognised character.
+
+@ expr_tokenize ( Vec u ) src ( Vec i ) tk ( Vec i ) tv → b {
+    : i n ( vec_len [u] src )
+    : ~ i i 0
+    : ~ b ok T
+    ~ & ok < i n {
+        : i c ?? ( vec_get [u] src i ) { T x → # i x F → 0 }
+        ? ( __is_space c ) { = i + i 1 } {
+            ? ( __is_digit c ) {
+                : ~ i v 0
+                ~ & < i n ( __is_digit ?? ( vec_get [u] src i ) { T x → # i x F → 0 } ) {
+                    : i d ?? ( vec_get [u] src i ) { T x → # i x F → 0 }
+                    = v + * v 10 - d 48
+                    = i + i 1
+                }
+                ( vec_push [i] tk 1 ) ( vec_push [i] tv v )
+            } {
+                ? ( __is_alpha c ) {
+                    : ( Vec u ) word ( vec_new [u] )
+                    ~ & < i n ( __is_alpha ?? ( vec_get [u] src i ) { T x → # i x F → 0 } ) {
+                        ( vec_push [u] word ?? ( vec_get [u] src i ) { T x → # i x F → 0 } )
+                        = i + i 1
+                    }
+                    : i wl ( vec_len [u] word )
+                    ? & == wl 1 == ?? ( vec_get [u] word 0 ) { T x → # i x F → 0 } 120 {
+                        ( vec_push [i] tk 2 ) ( vec_push [i] tv 0 )
+                    } {
+                        : i c0 ?? ( vec_get [u] word 0 ) { T x → # i x F → 0 }
+                        : i c1 ? > wl 1 ?? ( vec_get [u] word 1 ) { T x → # i x F → 0 } 0
+                        ? & == wl 3 & == c0 109 == c1 105 { ( vec_push [i] tk 21 ) ( vec_push [i] tv 0 ) } {  // min
+                            ? & == wl 3 & == c0 109 == c1 97 { ( vec_push [i] tk 22 ) ( vec_push [i] tv 0 ) } {  // max
+                                ? & == wl 3 == c0 97 { ( vec_push [i] tk 23 ) ( vec_push [i] tv 0 ) } {  // abs
+                                    = ok F
+                                } } }
+                    }
+                    ( vec_free [u] word )
+                } {
+                    // operators + punctuation
+                    : i c2 ? < + i 1 n ?? ( vec_get [u] src + i 1 ) { T x → # i x F → 0 } 0
+                    ? == c 43 { ( vec_push [i] tk 3 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                        ? == c 45 { ( vec_push [i] tk 4 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                            ? == c 42 { ( vec_push [i] tk 5 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                                ? == c 47 { ( vec_push [i] tk 6 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                                    ? == c 37 { ( vec_push [i] tk 7 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                                        ? == c 60 { ? == c2 61 { ( vec_push [i] tk 9 ) = i + i 2 } { ( vec_push [i] tk 8 ) = i + i 1 } ( vec_push [i] tv 0 ) } {
+                                            ? == c 62 { ? == c2 61 { ( vec_push [i] tk 11 ) = i + i 2 } { ( vec_push [i] tk 10 ) = i + i 1 } ( vec_push [i] tv 0 ) } {
+                                                ? == c 61 { ? == c2 61 { ( vec_push [i] tk 12 ) ( vec_push [i] tv 0 ) = i + i 2 } { = ok F } } {
+                                                    ? == c 33 { ? == c2 61 { ( vec_push [i] tk 13 ) ( vec_push [i] tv 0 ) = i + i 2 } { = ok F } } {
+                                                        ? == c 38 { ( vec_push [i] tk 14 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                                                            ? == c 124 { ( vec_push [i] tk 15 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                                                                ? == c 63 { ( vec_push [i] tk 16 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                                                                    ? == c 58 { ( vec_push [i] tk 17 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                                                                        ? == c 40 { ( vec_push [i] tk 18 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                                                                            ? == c 41 { ( vec_push [i] tk 19 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                                                                                ? == c 44 { ( vec_push [i] tk 20 ) ( vec_push [i] tv 0 ) = i + i 1 } {
+                                                                                    = ok F
+                                                                                } } } } } } } } } } } } } } } }
+                } } }
+    }
+    ( vec_push [i] tk 0 ) ( vec_push [i] tv 0 )  // END sentinel
+    ^ ok
+}
+
+// ── parser → flat node arena ─────────────────────────────────────
+
+: EParser {
+    ( Vec i ) tk
+    ( Vec i ) tv
+    i pos
+    ( Vec i ) arena  // stride-4: tag,a,b,c
+    b ok
+}
+
+@ __ep_kind * EParser p → i { ^ ?? ( vec_get [i] . p tk . p pos ) { T x → x F → 0 } }
+
+@ __ep_val * EParser p → i { ^ ?? ( vec_get [i] . p tv . p pos ) { T x → x F → 0 } }
+
+@ __ep_adv * EParser p → v { = . p pos + . p pos 1 }
+
+// Push a node, return its index.
+@ __ep_node * EParser p i tag i a i b i c → i {
+    : i idx / ( vec_len [i] . p arena ) 4
+    ( vec_push [i] . p arena tag )
+    ( vec_push [i] . p arena a )
+    ( vec_push [i] . p arena b )
+    ( vec_push [i] . p arena c )
+    ^ idx
+}
+
+// Expect+consume a token kind; flag an error if it is not there.
+@ __ep_expect * EParser p i kind → v {
+    ? == ( __ep_kind p ) kind { ( __ep_adv p ) } { = . p ok F }
+}
+
+@ __ep_primary * EParser p → i {
+    : i k ( __ep_kind p )
+    ? == k 1 { : i v ( __ep_val p ) ( __ep_adv p ) ^ ( __ep_node p 0 v 0 0 ) } {}  // INT
+    ? == k 2 { ( __ep_adv p ) ^ ( __ep_node p 1 0 0 0 ) } {}  // X
+    ? == k 18 {  // ( expr )
+        ( __ep_adv p )
+        : i e ( __ep_expr p )
+        ( __ep_expect p 19 )
+        ^ e
+    } {}
+    ? | == k 21 == k 22 {  // min(a,b) / max(a,b)
+        : i tag ? == k 21 17 18
+        ( __ep_adv p )
+        ( __ep_expect p 18 )
+        : i a ( __ep_expr p )
+        ( __ep_expect p 20 )
+        : i b ( __ep_expr p )
+        ( __ep_expect p 19 )
+        ^ ( __ep_node p tag a b 0 )
+    } {}
+    ? == k 23 {  // abs(a)
+        ( __ep_adv p )
+        ( __ep_expect p 18 )
+        : i a ( __ep_expr p )
+        ( __ep_expect p 19 )
+        ^ ( __ep_node p 19 a 0 0 )
+    } {}
+    = . p ok F
+    ^ 0
+}
+
+@ __ep_unary * EParser p → i {
+    ? == ( __ep_kind p ) 4 { ( __ep_adv p ) ^ ( __ep_node p 2 ( __ep_unary p ) 0 0 ) } {}  // -unary → NEG
+    ^ ( __ep_primary p )
+}
+
+@ __ep_muldiv * EParser p → i {
+    : ~ i a ( __ep_unary p )
+    ~ & . p ok | == ( __ep_kind p ) 5 | == ( __ep_kind p ) 6 == ( __ep_kind p ) 7 {
+        : i op ( __ep_kind p )
+        ( __ep_adv p )
+        : i b ( __ep_unary p )
+        = a ( __ep_node p op a b 0 )
+    }
+    ^ a
+}
+
+@ __ep_addsub * EParser p → i {
+    : ~ i a ( __ep_muldiv p )
+    ~ & . p ok | == ( __ep_kind p ) 3 == ( __ep_kind p ) 4 {
+        : i op ( __ep_kind p )
+        ( __ep_adv p )
+        : i b ( __ep_muldiv p )
+        = a ( __ep_node p op a b 0 )
+    }
+    ^ a
+}
+
+@ __ep_compare * EParser p → i {
+    : i a ( __ep_addsub p )
+    : i k ( __ep_kind p )
+    ? & . p ok & >= k 8 <= k 13 {
+        ( __ep_adv p )
+        : i b ( __ep_addsub p )
+        ^ ( __ep_node p k a b 0 )
+    } {}
+    ^ a
+}
+
+@ __ep_logic * EParser p → i {
+    : ~ i a ( __ep_compare p )
+    ~ & . p ok | == ( __ep_kind p ) 14 == ( __ep_kind p ) 15 {
+        : i op ( __ep_kind p )
+        ( __ep_adv p )
+        : i b ( __ep_compare p )
+        = a ( __ep_node p op a b 0 )
+    }
+    ^ a
+}
+
+@ __ep_expr * EParser p → i {
+    : i cond ( __ep_logic p )
+    ? & . p ok == ( __ep_kind p ) 16 {  // cond ? then : else
+        ( __ep_adv p )
+        : i then ( __ep_expr p )
+        ( __ep_expect p 17 )
+        : i els ( __ep_expr p )
+        ^ ( __ep_node p 16 cond then els )
+    } {}
+    ^ cond
+}
+
+// Parse `src` → (arena, root). On any error, ok=0; the caller checks it.
+// The arena is returned via the EParser; the root index via the return value.
+@ expr_parse ( Vec u ) src * EParser p → i {
+    = . p tk ( vec_new [i] )
+    = . p tv ( vec_new [i] )
+    = . p arena ( vec_new [i] )
+    = . p pos 0
+    = . p ok ( expr_tokenize src . p tk . p tv )
+    ? ! . p ok { ^ 0 } {}
+    : i root ( __ep_expr p )
+    // Must consume everything up to END.
+    ? != ( __ep_kind p ) 0 { = . p ok F } {}
+    ^ root
+}
+
+// Frees the parser's arena/token vectors AND the struct itself.
+@ eparser_free * EParser p → v {
+    ( vec_free [i] . p tk )
+    ( vec_free [i] . p tv )
+    ( vec_free [i] . p arena )
+    ( nurl_free # s p )
+}
+
+// ── evaluator ────────────────────────────────────────────────────
+// Reads the arena through the parser pointer (a borrow), so evaluating does
+// not move the arena field out of the parser — the worker evaluates the same
+// parsed expression for every x in its sub-range.
+
+@ __ar * EParser p i node i off → i { ^ ?? ( vec_get [i] . p arena + * node 4 off ) { T x → x F → 0 } }
+
+@ expr_eval * EParser p i node i x → i {
+    : i tag ( __ar p node 0 )
+    : i a ( __ar p node 1 )
+    : i b ( __ar p node 2 )
+    : i c ( __ar p node 3 )
+    ? == tag 0 { ^ a } {}
+    ? == tag 1 { ^ x } {}
+    ? == tag 2 { ^ - 0 ( expr_eval p a x ) } {}
+    ? == tag 3 { ^ + ( expr_eval p a x ) ( expr_eval p b x ) } {}
+    ? == tag 4 { ^ - ( expr_eval p a x ) ( expr_eval p b x ) } {}
+    ? == tag 5 { ^ * ( expr_eval p a x ) ( expr_eval p b x ) } {}
+    ? == tag 6 { : i d ( expr_eval p b x ) ? == d 0 { ^ 0 } { ^ / ( expr_eval p a x ) d } } {}
+    ? == tag 7 { : i d ( expr_eval p b x ) ? == d 0 { ^ 0 } { ^ % ( expr_eval p a x ) d } } {}
+    ? == tag 8 { ^ ? < ( expr_eval p a x ) ( expr_eval p b x ) 1 0 } {}
+    ? == tag 9 { ^ ? <= ( expr_eval p a x ) ( expr_eval p b x ) 1 0 } {}
+    ? == tag 10 { ^ ? > ( expr_eval p a x ) ( expr_eval p b x ) 1 0 } {}
+    ? == tag 11 { ^ ? >= ( expr_eval p a x ) ( expr_eval p b x ) 1 0 } {}
+    ? == tag 12 { ^ ? == ( expr_eval p a x ) ( expr_eval p b x ) 1 0 } {}
+    ? == tag 13 { ^ ? != ( expr_eval p a x ) ( expr_eval p b x ) 1 0 } {}
+    ? == tag 14 { ^ ? & != ( expr_eval p a x ) 0 != ( expr_eval p b x ) 0 1 0 } {}
+    ? == tag 15 { ^ ? | != ( expr_eval p a x ) 0 != ( expr_eval p b x ) 0 1 0 } {}
+    ? == tag 16 { ? != ( expr_eval p a x ) 0 { ^ ( expr_eval p b x ) } { ^ ( expr_eval p c x ) } } {}
+    ? == tag 17 { : i va ( expr_eval p a x ) : i vb ( expr_eval p b x ) ^ ? < va vb va vb } {}
+    ? == tag 18 { : i va ( expr_eval p a x ) : i vb ( expr_eval p b x ) ^ ? > va vb va vb } {}
+    ? == tag 19 { : i va ( expr_eval p a x ) ^ ? < va 0 - 0 va va } {}
+    ^ 0
+}

--- a/packages/swarm-mcp/src/main.nu
+++ b/packages/swarm-mcp/src/main.nu
@@ -1,0 +1,704 @@
+// packages/swarm-mcp/src/main.nu — swarm-mcp: an MCP-controlled distributed
+// compute engine. A language model sets a workload over MCP — an expression
+// kernel in `x` plus a range and a reduce op — and the cluster evaluates it
+// distributed; the model reads running tasks and finished results back.
+//
+//   swarm-mcp relay  0.0.0.0 47700 [--v]   # the meeting point (one per cluster)
+//   swarm-mcp worker <host> <port>         # join as a compute node
+//   swarm-mcp mcp    <host> <port>         # MCP server (stdio) → drives the cluster
+//   swarm-mcp submit <host> <port> <reduce> <lo> <hi> <expr>   # manual CLI submit
+//
+// The cluster layer (membership → ring → job dispatch) is the swarm package's;
+// here every worker registers ONE generic kernel handler (work.nu) that
+// interprets the submitted expression (expr.nu), so any normal-operation
+// workload runs without recompiling a worker. Phase 2 swaps the interpreter for
+// a NURL→wasm kernel; the protocol and MCP surface stay the same.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/random.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/mcp.nu`
+$ `stdlib/net/relay.nu`
+$ `stdlib/net/transport.nu`
+$ `stdlib/dist/ring.nu`
+$ `stdlib/dist/job.nu`
+$ `census.nu`
+$ `expr.nu`
+$ `work.nu`
+
+@ swarm_vnodes → i { ^ 64 }
+
+@ kind_kernel → i { ^ 1 }
+
+// Fixed 32-byte multicast group (the relay's documented contract).
+@ swarm_group_id → ( Vec u ) {
+    : ( Vec u ) g ( bytes_from_str `swarmc` )
+    ~ < ( vec_len [u] g ) 32 { ( vec_push [u] g # u 0 ) }
+    ^ g
+}
+
+// A 32-byte opaque routing pubkey derived deterministically from a node id.
+@ pk_from_id i id → ( Vec u ) {
+    : ( Vec u ) v ( vec_new [u] )
+    : ~ i s id
+    : ~ i k 0
+    ~ < k 32 {
+        = s + + * s 1103515245 12345 k
+        ( vec_push [u] v # u & >> s 16 255 )
+        = k + k 1
+    }
+    ^ v
+}
+
+// ── node bundle (the cluster coordinator/worker state) ───────────
+
+: Swarm {
+    s transport  // *Transport
+    s ring  // *Ring
+    s roster  // *Roster
+    s job  // *JobNode
+    ( Vec u ) self_pk
+    i self_id
+    i role
+    ( Vec u ) group
+}
+
+@ swarm_new RelayClient rc i id i role → *Swarm {
+    : ( Vec u ) me ( pk_from_id id )
+    : *Transport tr # *Transport ( transport_open # s 0 rc 1 )
+    : *Ring ring ( ring_new )
+    : *Roster roster ( roster_new )
+    : *JobNode jn ( job_node_new # s tr # s ring me id )
+    : *Swarm sw # *Swarm ( nurl_alloc Z Swarm )
+    = . sw transport # s tr
+    = . sw ring # s ring
+    = . sw roster # s roster
+    = . sw job # s jn
+    = . sw self_pk me
+    = . sw self_id id
+    = . sw role role
+    = . sw group ( swarm_group_id )
+    ? == role ( role_worker ) { ( roster_add roster ring me id ( swarm_vnodes ) ) } {}
+    ^ sw
+}
+
+@ swarm_free * Swarm sw → v {
+    ( job_node_free # *JobNode . sw job )
+    ( ring_free # *Ring . sw ring )
+    ( roster_free # *Roster . sw roster )
+    ( transport_free # *Transport . sw transport )
+    ( vec_free [u] . sw self_pk )
+    ( vec_free [u] . sw group )
+    ( nurl_free # s sw )
+}
+
+@ swarm_join_group * Swarm sw → v {
+    ?? ( transport_group_join # *Transport . sw transport . sw group ) { T _ → {} F _ → {} }
+}
+
+@ swarm_announce * Swarm sw i want → v {
+    : ( Vec u ) msg ( hello_build . sw self_id . sw role want . sw self_pk )
+    ?? ( transport_broadcast # *Transport . sw transport . sw group msg ) { T _ → {} F _ → {} }
+    ( vec_free [u] msg )
+}
+
+@ swarm_on_hello * Swarm sw Hello h → v {
+    ? == . h role ( role_worker ) {
+        ( roster_add # *Roster . sw roster # *Ring . sw ring . h pubkey . h id ( swarm_vnodes ) )
+        ( transport_add_peer # *Transport . sw transport . h pubkey )
+    } {}
+    ? & == . h want 1 ! ( bytes_eq . h pubkey . sw self_pk ) {
+        : ( Vec u ) reply ( hello_build . sw self_id . sw role 0 . sw self_pk )
+        ?? ( transport_send # *Transport . sw transport . h pubkey reply ) { T _ → {} F _ → {} }
+        ( vec_free [u] reply )
+    } {}
+}
+
+@ swarm_pump * Swarm sw i max → v {
+    : ~ b more T
+    ~ more {
+        ?? ( transport_recv # *Transport . sw transport max ) {
+            T tm → {
+                : i b0 ?? ( vec_get [u] . tm payload 0 ) { T x → # i x F → 255 }
+                ? == b0 ( census_hello_t ) {
+                    : Hello h ( hello_decode . tm payload )
+                    ( swarm_on_hello sw h )
+                    ( hello_free h )
+                } {
+                    : JobMsg m ( jobmsg_decode . tm payload )
+                    ? == . m mtype ( job_submit_t ) { ( job_on_submit # *JobNode . sw job m ) } {}
+                    ? == . m mtype ( job_result_t ) { ( job_on_result # *JobNode . sw job m ) } {}
+                    ( jobmsg_free m )
+                }
+                ( transport_msg_free tm )
+            }
+            F → { = more F }
+        }
+    }
+}
+
+@ swarm_discover * Swarm sw i rounds → v {
+    ( swarm_announce sw 1 )
+    : ~ i t 0
+    ~ < t rounds { ( swarm_pump sw 200 ) = t + t 1 }
+}
+
+// ── relay + worker roles ─────────────────────────────────────────
+
+@ run_relay s host i port i vflag → i {
+    ?? ( relay_server_start host port ) {
+        T rs → {
+            : *RelayServer p # *RelayServer ( nurl_alloc Z RelayServer )
+            = . p lst . rs lst
+            = . p clients . rs clients
+            = . p groups . rs groups
+            = . p verbose vflag
+            ( nurl_print `swarm-mcp relay listening on ` ) ( nurl_print host )
+            ( nurl_print `:` ) ( nurl_print_int port )
+            ? == vflag 1 { ( nurl_print ` (verbose)` ) } {}
+            ( nurl_print `\n` )
+            ( relay_server_run p )
+            ( relay_server_free p )
+            ^ 0
+        }
+        F e → { ( nurl_print `swarm-mcp: relay failed to bind\n` ) ^ 1 }
+    }
+}
+
+@ run_worker s host i port i id i rounds → i {
+    ?? ( relay_dial host port ) {
+        T rc → {
+            : ( Vec u ) reg ( pk_from_id id )
+            ?? ( relay_register rc reg ) { T _ → {} F _ → {} }
+            ( vec_free [u] reg )
+            ( relay_set_timeout rc 250 )
+            : *Swarm sw ( swarm_new rc id ( role_worker ) )
+            ( job_register # *JobNode . sw job ( kind_kernel ) ( kernel_handler ) )
+            ( swarm_join_group sw )
+            ( swarm_announce sw 1 )
+            ( nurl_print `swarm-mcp worker ` ) ( nurl_print_int id ) ( nurl_print ` ready\n` )
+            : ~ i t 0
+            ~ | <= rounds 0 < t rounds { ( swarm_pump sw 200 ) = t + t 1 }
+            ( swarm_free sw )
+            ( relay_close rc )
+            ^ 0
+        }
+        F e → { ( nurl_print `swarm-mcp: worker could not dial relay\n` ) ^ 1 }
+    }
+}
+
+// ── shared submit: shard an expr task across the cluster ──────────
+// Submits the kernel to the ring and returns the chunk task-ids. `expr` is the
+// raw kernel bytes; the caller owns it.
+
+@ cluster_submit * Swarm sw i op i lo i hi ( Vec u ) expr i nchunks → ( Vec i ) {
+    : ( Vec s ) chunks ( shard lo hi nchunks )
+    : ( Vec i ) tids ( vec_new [i] )
+    : ~ i i 0
+    ~ < i nchunks {
+        : s cp ?? ( vec_get [s] chunks i ) { T x → x F → # s 0 }
+        : *Chunk c # *Chunk cp
+        : ( Vec u ) key ( chunk_key i )
+        : ( Vec u ) payload ( chunk_payload op . c lo . c hi expr )
+        ( vec_push [i] tids ( job_submit # *JobNode . sw job ( kind_kernel ) key payload ) )
+        ( vec_free [u] key ) ( vec_free [u] payload )
+        = i + i 1
+    }
+    ( shard_free chunks )
+    ^ tids
+}
+
+// All chunk results present? (cluster job results are recorded by task-id.)
+@ tids_ready * Swarm sw ( Vec i ) tids → b {
+    : i n ( vec_len [i] tids )
+    : ~ b all T : ~ i k 0
+    ~ & all < k n {
+        ? ! ( job_has # *JobNode . sw job ?? ( vec_get [i] tids k ) { T x → x F → 0 } ) { = all F } {}
+        = k + k 1
+    }
+    ^ all
+}
+
+// Combine all chunk results with the reduce op (assumes ready).
+@ tids_combine * Swarm sw i op ( Vec i ) tids → i {
+    : i n ( vec_len [i] tids )
+    : ~ i acc ( red_id op )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( job_await # *JobNode . sw job ?? ( vec_get [i] tids k ) { T x → x F → 0 } ) {
+            T r → { = acc ( red_combine op acc ( result_decode r ) ) ( vec_free [u] r ) }
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ acc
+}
+
+@ nchunks_for i nworkers → i { ^ ? > * nworkers 4 256 256 ? > nworkers 0 * nworkers 4 4 }
+
+// ── submit role (manual CLI testing, no MCP) ─────────────────────
+
+@ run_submit s host i port i op i lo i hi s expr → i {
+    ?? ( relay_dial host port ) {
+        T rc → {
+            : i myid ( rand_u64 )
+            : ( Vec u ) reg ( pk_from_id myid )
+            ?? ( relay_register rc reg ) { T _ → {} F _ → {} }
+            ( vec_free [u] reg )
+            ( relay_set_timeout rc 250 )
+            : *Swarm sw ( swarm_new rc myid ( role_client ) )
+            ( swarm_join_group sw )
+            ( swarm_discover sw 8 )
+            : i nworkers ( roster_count # *Roster . sw roster )
+            ? == nworkers 0 {
+                ( nurl_print `swarm-mcp: no workers found\n` )
+                ( swarm_free sw ) ( relay_close rc ) ^ 1
+            } {}
+            : ( Vec u ) eb ( bytes_from_str expr )
+            : i nchunks ( nchunks_for nworkers )
+            : ( Vec i ) tids ( cluster_submit sw op lo hi eb nchunks )
+            : ~ i rnd 0
+            ~ & ! ( tids_ready sw tids ) < rnd 400 { ( swarm_pump sw 200 ) = rnd + rnd 1 }
+            : i total ( tids_combine sw op tids )
+            ( nurl_print ( reduce_op_name op ) ) ( nurl_print ` of (` ) ( nurl_print expr )
+            ( nurl_print `) over [` ) ( nurl_print_int lo ) ( nurl_print `,` ) ( nurl_print_int hi )
+            ( nurl_print `) = ` ) ( nurl_print_int total ) ( nurl_print `\n` )
+            ( vec_free [i] tids ) ( vec_free [u] eb )
+            ( swarm_free sw ) ( relay_close rc )
+            ^ 0
+        }
+        F e → { ( nurl_print `swarm-mcp: submit could not dial relay\n` ) ^ 1 }
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════
+//  MCP server — the LLM-facing control surface
+// ══════════════════════════════════════════════════════════════════
+
+: Task {
+    i id
+    ( Vec u ) expr  // kernel bytes
+    i lo
+    i hi
+    i op
+    i nchunks
+    ( Vec i ) tids
+    i done
+    i result
+}
+
+: McpState {
+    s swarm  // *Swarm coordinator
+    ( Vec s ) tasks  // *Task
+    i next_id
+}
+
+// Constructor: param names deliberately differ from the field names — a store
+// LHS `. t lo` whose value-name also matched the field would compile to an
+// array-index store, not a field store.
+@ task_new i tid ( Vec u ) ex i a i b i o i nc ( Vec i ) ts → *Task {
+    : *Task t # *Task ( nurl_alloc Z Task )
+    = . t id tid
+    = . t expr ex
+    = . t lo a
+    = . t hi b
+    = . t op o
+    = . t nchunks nc
+    = . t tids ts
+    = . t done 0
+    = . t result 0
+    ^ t
+}
+
+: ~ i g_mcp 0
+
+@ mcp_swarm → *Swarm { : *McpState st # *McpState g_mcp ^ # *Swarm . st swarm }
+
+@ mcp_pump i rounds → v {
+    : *Swarm sw ( mcp_swarm )
+    : ~ i k 0
+    ~ < k rounds { ( swarm_pump sw 150 ) = k + k 1 }
+}
+
+// Refresh one task's status; combine if every chunk has landed.
+@ task_refresh * Task t → v {
+    ? == . t done 1 { ^ v } {}
+    : *Swarm sw ( mcp_swarm )
+    ? ( tids_ready sw . t tids ) {
+        = . t result ( tids_combine sw . t op . t tids )
+        = . t done 1
+    } {}
+}
+
+@ task_find i id → s {
+    : *McpState st # *McpState g_mcp
+    : i n ( vec_len [s] . st tasks )
+    : ~ s found # s 0
+    : ~ i k 0
+    ~ & == # i found 0 < k n {
+        : s pp ?? ( vec_get [s] . st tasks k ) { T x → x F → # s 0 }
+        ? != # i pp 0 { : *Task t # *Task pp ? == . t id id { = found pp } {} } {}
+        = k + k 1
+    }
+    ^ found
+}
+
+// Build the JSON-as-text result body for one task (LLM-readable + parseable).
+@ task_to_json * Task t → Json {
+    : Json o ( json_obj_new )
+    ( json_obj_set o `task_id` ( json_int . t id ) )
+    ( json_obj_set o `status` ( json_str_lit ? == . t done 1 `done` `running` ) )
+    : String es ( bytes_to_str . t expr )
+    ( json_obj_set o `kernel` ( json_str_lit ( string_data es ) ) )
+    ( string_free es )
+    ( json_obj_set o `reduce` ( json_str_lit ( reduce_op_name . t op ) ) )
+    ( json_obj_set o `lo` ( json_int . t lo ) )
+    ( json_obj_set o `hi` ( json_int . t hi ) )
+    ( json_obj_set o `chunks` ( json_int . t nchunks ) )
+    ? == . t done 1 { ( json_obj_set o `result` ( json_int . t result ) ) } {}
+    ^ o
+}
+
+@ tool_result_json Json o → Json {
+    : String s ( json_stringify o )
+    : Json r ( mcp_tool_result_text ( string_data s ) )
+    ( string_free s )
+    ( json_free o )
+    ^ r
+}
+
+// ── tool: compute_submit ─────────────────────────────────────────
+
+@ tool_submit Json args → Json {
+    : ?Json ej ( json_obj_get args `expr` )
+    : ?Json lj ( json_obj_get args `lo` )
+    : ?Json hj ( json_obj_get args `hi` )
+    ? | ! ?? ej { T _ → T F → F } | ! ?? lj { T _ → T F → F } ! ?? hj { T _ → T F → F } {
+        ^ ( mcp_tool_result_error `compute_submit needs "expr" (string), "lo" (int), "hi" (int); "reduce" optional` )
+    } {}
+    : s expr ?? ej { T v → ( json_str_data v ) F → `` }
+    : i lo ?? lj { T v → ( json_as_int v ) F → 0 }
+    : i hi ?? hj { T v → ( json_as_int v ) F → 0 }
+    : i op ?? ( json_obj_get args `reduce` ) { T v → ( reduce_op_of ( json_str_data v ) 0 ) F → 0 }
+    ? >= lo hi { ^ ( mcp_tool_result_error `empty range: need lo < hi` ) } {}
+
+    // Validate the kernel parses before shipping it to workers.
+    : ( Vec u ) eb ( bytes_from_str expr )
+    : *EParser ep # *EParser ( nurl_alloc Z EParser )
+    : i root ( expr_parse eb ep )
+    : b okp . ep ok
+    ( eparser_free ep )
+    ? ! okp {
+        ( vec_free [u] eb )
+        ^ ( mcp_tool_result_error `could not parse kernel — operators: + - * / % < <= > >= == != & | ?: ; functions: min max abs ; variable: x` )
+    } {}
+
+    // Discover the live workers, then shard + submit.
+    : *Swarm sw ( mcp_swarm )
+    ( swarm_discover sw 6 )
+    : i nworkers ( roster_count # *Roster . sw roster )
+    ? == nworkers 0 {
+        ( vec_free [u] eb )
+        ^ ( mcp_tool_result_error `no workers in the cluster — start some with 'swarm-mcp worker'` )
+    } {}
+    : i nchunks ( nchunks_for nworkers )
+    : ( Vec i ) tids ( cluster_submit sw op lo hi eb nchunks )
+
+    : *McpState st # *McpState g_mcp
+    : *Task t ( task_new . st next_id eb lo hi op nchunks tids )
+    = . st next_id + . st next_id 1
+    ( vec_push [s] . st tasks # s t )
+
+    // Pump briefly so small tasks come back as "done" immediately.
+    ( mcp_pump 8 )
+    ( task_refresh t )
+    ^ ( tool_result_json ( task_to_json t ) )
+}
+
+// ── tool: compute_list ───────────────────────────────────────────
+
+@ tool_list Json args → Json {
+    ( mcp_pump 4 )
+    : *McpState st # *McpState g_mcp
+    : Json arr ( json_arr_new )
+    : i n ( vec_len [s] . st tasks )
+    : ~ i k 0
+    ~ < k n {
+        : s pp ?? ( vec_get [s] . st tasks k ) { T x → x F → # s 0 }
+        ? != # i pp 0 {
+            : *Task t # *Task pp
+            ( task_refresh t )
+            ( json_arr_push arr ( task_to_json t ) )
+        } {}
+        = k + k 1
+    }
+    : Json o ( json_obj_new )
+    ( json_obj_set o `tasks` arr )
+    ^ ( tool_result_json o )
+}
+
+// ── tool: compute_result ─────────────────────────────────────────
+
+@ tool_result Json args → Json {
+    : ?Json idj ( json_obj_get args `task_id` )
+    ? ! ?? idj { T _ → T F → F } { ^ ( mcp_tool_result_error `compute_result needs "task_id" (int)` ) } {}
+    : i id ?? idj { T v → ( json_as_int v ) F → 0 }
+    ( mcp_pump 4 )
+    : s tp ( task_find id )
+    ? == # i tp 0 { ^ ( mcp_tool_result_error `no such task_id` ) } {}
+    : *Task t # *Task tp
+    ( task_refresh t )
+    ^ ( tool_result_json ( task_to_json t ) )
+}
+
+// ── tool descriptors ─────────────────────────────────────────────
+
+@ ms_prop Json props s name s ty s desc → v {
+    : Json p ( json_obj_new )
+    ( json_obj_set p `type` ( json_str_lit ty ) )
+    ( json_obj_set p `description` ( json_str_lit desc ) )
+    ( json_obj_set props name p )
+}
+
+@ ms_schema_submit → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    : Json props ( json_obj_new )
+    ( ms_prop props `expr` `string` `Kernel: an integer expression in the variable x. Operators + - * / % (truncated div), comparisons < <= > >= == != (yield 0/1), logical & | , ternary cond ? a : b ; functions min(a,b) max(a,b) abs(a). Examples: "x*x" · "x%2==0" · "x>1 & x<100" · "x>5 ? x : 0".` )
+    ( ms_prop props `lo` `integer` `Range start (inclusive).` )
+    ( ms_prop props `hi` `integer` `Range end (exclusive). Must be > lo.` )
+    ( ms_prop props `reduce` `string` `How to fold the mapped values across the whole range: "sum" (default) · "product" · "min" · "max" · "count" (how many x make the kernel non-zero).` )
+    ( json_obj_set schema `properties` props )
+    : Json req ( json_arr_new )
+    ( json_arr_push req ( json_str_lit `expr` ) )
+    ( json_arr_push req ( json_str_lit `lo` ) )
+    ( json_arr_push req ( json_str_lit `hi` ) )
+    ( json_obj_set schema `required` req )
+    ^ schema
+}
+
+@ ms_schema_result → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    : Json props ( json_obj_new )
+    ( ms_prop props `task_id` `integer` `The id returned by compute_submit.` )
+    ( json_obj_set schema `properties` props )
+    : Json req ( json_arr_new )
+    ( json_arr_push req ( json_str_lit `task_id` ) )
+    ( json_obj_set schema `required` req )
+    ^ schema
+}
+
+@ ms_schema_empty → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    ^ schema
+}
+
+@ build_tools_list → ( Vec Json ) {
+    : ( Vec Json ) tools ( vec_new [Json] )
+    ( vec_push [Json] tools ( mcp_tool_descriptor `compute_submit`
+    `Run a distributed map-reduce on the cluster: evaluate the expression kernel for every integer x in [lo, hi) and fold the results with the reduce op. Sharded across all live workers and computed in parallel. Returns a task_id immediately; poll compute_result for the value. Example: {"expr":"x*x","lo":1,"hi":1000000,"reduce":"sum"} gives the sum of squares.`
+    ( ms_schema_submit ) ) )
+    ( vec_push [Json] tools ( mcp_tool_descriptor `compute_list`
+    `List every submitted task with its status (running|done), kernel, range, reduce op, and result if finished.`
+    ( ms_schema_empty ) ) )
+    ( vec_push [Json] tools ( mcp_tool_descriptor `compute_result`
+    `Get one task by task_id: its status and, once finished, the reduced result.`
+    ( ms_schema_result ) ) )
+    ^ tools
+}
+
+@ dispatch_tool s name Json args → Json {
+    ? != ( nurl_str_eq name `compute_submit` ) 0 { ^ ( tool_submit args ) } {}
+    ? != ( nurl_str_eq name `compute_list` ) 0 { ^ ( tool_list args ) } {}
+    ? != ( nurl_str_eq name `compute_result` ) 0 { ^ ( tool_result args ) } {}
+    ^ ( mcp_tool_result_error `unknown tool` )
+}
+
+// ── JSON-RPC method handlers ─────────────────────────────────────
+
+@ handle_initialize Json id → Json {
+    : Json result ( mcp_initialize_result `swarm-mcp` `0.1.0` )
+    ^ ( mcp_response_result id result )
+}
+
+@ handle_ping Json id → Json {
+    : Json empty ( json_obj_new )
+    ^ ( mcp_response_result id empty )
+}
+
+@ handle_tools_list Json id → Json {
+    : ( Vec Json ) tools ( build_tools_list )
+    : Json result ( mcp_tools_list_result tools )
+    ^ ( mcp_response_result id result )
+}
+
+@ handle_tools_call Json id Json params → Json {
+    : ?Json name_j ( json_obj_get params `name` )
+    ?? name_j {
+        T nv → {
+            : s name ( json_str_data nv )
+            : Json args ?? ( json_obj_get params `arguments` ) { T av → ( json_clone av ) F → ( json_obj_new ) }
+            : Json result ( dispatch_tool name args )
+            ( json_free args )
+            ^ ( mcp_response_result id result )
+        }
+        F → { ^ ( mcp_response_error id mcp_err_invalid_params `tools/call requires a "name"` ) }
+    }
+}
+
+@ handle_unknown Json id s method → Json {
+    : i mlen ( nurl_str_len method )
+    : String msg ( string_with_cap + 20 mlen )
+    ( string_push_str msg `unknown method: ` )
+    ( string_push_str msg method )
+    : Json err ( mcp_response_error id mcp_err_method_not_found ( string_data msg ) )
+    ( string_free msg )
+    ^ err
+}
+
+@ dispatch Json req → ?Json {
+    : ?Json method_j ( json_obj_get req `method` )
+    ?? method_j {
+        T mv → {
+            : s method ( json_str_data mv )
+            : ?Json id_opt ( json_obj_get req `id` )
+            ?? id_opt {
+                T id → {
+                    ? != ( nurl_str_eq method `initialize` ) 0 { ^ @ ?Json { T ( handle_initialize id ) } } {}
+                    ? != ( nurl_str_eq method `ping` ) 0 { ^ @ ?Json { T ( handle_ping id ) } } {}
+                    ? != ( nurl_str_eq method `tools/list` ) 0 { ^ @ ?Json { T ( handle_tools_list id ) } } {}
+                    ? != ( nurl_str_eq method `tools/call` ) 0 {
+                        : Json params ?? ( json_obj_get req `params` ) { T pv → ( json_clone pv ) F → ( json_obj_new ) }
+                        : Json out ( handle_tools_call id params )
+                        ( json_free params )
+                        ^ @ ?Json { T out }
+                    } {}
+                    ^ @ ?Json { T ( handle_unknown id method ) }
+                }
+                F → { ^ @ ?Json { F } }
+            }
+        }
+        F → { ^ @ ?Json { F } }
+    }
+}
+
+@ stdio_loop → v {
+    : ~ b running T
+    ~ running {
+        : ?Json msg ( mcp_read_request )
+        ?? msg {
+            T req → {
+                : ?Json reply ( dispatch req )
+                ( json_free req )
+                ?? reply {
+                    T resp → ( mcp_send_message resp )
+                    F empty → {}
+                }
+            }
+            F → { = running F }
+        }
+    }
+}
+
+@ run_mcp s host i port → i {
+    ?? ( relay_dial host port ) {
+        T rc → {
+            : i myid ( rand_u64 )
+            : ( Vec u ) reg ( pk_from_id myid )
+            ?? ( relay_register rc reg ) { T _ → {} F _ → {} }
+            ( vec_free [u] reg )
+            ( relay_set_timeout rc 150 )
+            : *Swarm sw ( swarm_new rc myid ( role_client ) )
+            ( swarm_join_group sw )
+            ( swarm_discover sw 6 )
+            : *McpState st # *McpState ( nurl_alloc Z McpState )
+            = . st swarm # s sw
+            = . st tasks ( vec_new [s] )
+            = . st next_id 1
+            = g_mcp # i st
+            ( mcp_log `swarm-mcp ready (cluster coordinator over relay)` )
+            ( stdio_loop )
+            ( swarm_free sw )
+            ( relay_close rc )
+            ^ 0
+        }
+        F e → { ( nurl_eprintln `swarm-mcp: mcp could not dial relay` ) ^ 1 }
+    }
+}
+
+// ── CLI ──────────────────────────────────────────────────────────
+
+@ usage → v {
+    ( nurl_print `swarm-mcp — MCP-controlled distributed compute engine\n\n` )
+    ( nurl_print `  swarm-mcp relay  <host> <port> [--v]\n` )
+    ( nurl_print `  swarm-mcp worker <host> <port> [id] [rounds]\n` )
+    ( nurl_print `  swarm-mcp mcp    <host> <port>            (MCP server over stdio)\n` )
+    ( nurl_print `  swarm-mcp submit <host> <port> <reduce> <lo> <hi> <expr>\n\n` )
+    ( nurl_print `The MCP server exposes compute_submit / compute_list / compute_result.\n` )
+    ( nurl_print `Kernel = an integer expression in x; reduce = sum|product|min|max|count.\n` )
+}
+
+@ arg_int i idx → i {
+    : String s ( env_arg idx )
+    : i v ( nurl_str_to_int ( string_data s ) )
+    ( string_free s )
+    ^ v
+}
+
+@ arg_eq i idx s lit → b {
+    : String s ( env_arg idx )
+    : b eq ? != 0 ( nurl_str_eq ( string_data s ) lit ) T F
+    ( string_free s )
+    ^ eq
+}
+
+@ main → i {
+    : i argc ( env_args_count )
+    ? < argc 2 { ( usage ) ^ 1 } {}
+    : ~ i rc 0
+    ? ( arg_eq 1 `relay` ) {
+        ? < argc 4 { ( nurl_print `usage: swarm-mcp relay <host> <port> [--v]\n` ) = rc 1 } {
+            : String host ( env_arg 2 )
+            : i vflag ? & > argc 5 ( arg_eq 4 `--v` ) 1 ? & > argc 5 ( arg_eq 4 `--verbose` ) 1 0
+            = rc ( run_relay ( string_data host ) ( arg_int 3 ) vflag )
+            ( string_free host )
+        }
+    } {
+        ? ( arg_eq 1 `worker` ) {
+            ? < argc 4 { ( nurl_print `usage: swarm-mcp worker <host> <port> [id] [rounds]\n` ) = rc 1 } {
+                : String host ( env_arg 2 )
+                : i id ? > argc 4 ( arg_int 4 ) ( rand_u64 )
+                : i rounds ? > argc 5 ( arg_int 5 ) 0
+                = rc ( run_worker ( string_data host ) ( arg_int 3 ) id rounds )
+                ( string_free host )
+            }
+        } {
+            ? ( arg_eq 1 `mcp` ) {
+                ? < argc 4 { ( nurl_print `usage: swarm-mcp mcp <host> <port>\n` ) = rc 1 } {
+                    : String host ( env_arg 2 )
+                    = rc ( run_mcp ( string_data host ) ( arg_int 3 ) )
+                    ( string_free host )
+                }
+            } {
+                ? ( arg_eq 1 `submit` ) {
+                    ? < argc 8 { ( nurl_print `usage: swarm-mcp submit <host> <port> <reduce> <lo> <hi> <expr>\n` ) = rc 1 } {
+                        : String host ( env_arg 2 )
+                        : String rs ( env_arg 4 )
+                        : i op ( reduce_op_of ( string_data rs ) 0 )
+                        : String es ( env_arg 7 )
+                        = rc ( run_submit ( string_data host ) ( arg_int 3 ) op ( arg_int 5 ) ( arg_int 6 ) ( string_data es ) )
+                        ( string_free host ) ( string_free rs ) ( string_free es )
+                    }
+                } {
+                    ( usage ) = rc 1
+                }
+            }
+        }
+    }
+    ^ rc
+}

--- a/packages/swarm-mcp/src/work.nu
+++ b/packages/swarm-mcp/src/work.nu
@@ -1,0 +1,147 @@
+// packages/swarm-mcp/src/work.nu — the distributed map-reduce the cluster runs.
+//
+// A task is: evaluate an expression kernel (expr.nu) over an integer range
+// [lo, hi) and fold the results with a reduce op. The coordinator shards the
+// range; dist/ring routes each chunk to its owning worker; the worker parses
+// the kernel once and folds it over its sub-range; the coordinator combines the
+// partial folds. Every reduce op is associative, so sharding is exact.
+//
+//   reduce op : 0 sum · 1 product · 2 min · 3 max · 4 count (of truthy map)
+//   chunk     : [op:1][lo:8 BE][hi:8 BE][expr bytes…]
+//   result    : [value:8 BE]
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `expr.nu`
+
+@ red_sum → i { ^ 0 }
+
+@ red_product → i { ^ 1 }
+
+@ red_min → i { ^ 2 }
+
+@ red_max → i { ^ 3 }
+
+@ red_count → i { ^ 4 }
+
+// The identity (empty-range) value for a reduce op.
+@ red_id i op → i {
+    ? == op 1 { ^ 1 } {}  // product
+    ? == op 2 { ^ 9223372036854775807 } {}  // min → +∞
+    ? == op 3 { ^ - 0 9223372036854775807 } {}  // max → −∞
+    ^ 0  // sum, count
+}
+
+// Fold one mapped value into the accumulator (per element).
+@ red_fold i op i acc i v → i {
+    ? == op 0 { ^ + acc v } {}  // sum
+    ? == op 1 { ^ * acc v } {}  // product
+    ? == op 2 { ^ ? < v acc v acc } {}  // min
+    ? == op 3 { ^ ? > v acc v acc } {}  // max
+    ? == op 4 { ^ ? != v 0 + acc 1 acc } {}  // count of truthy
+    ^ acc
+}
+
+// Combine two partial folds (across chunks). count combines by summing the
+// per-chunk counts; every other op combines like its element fold.
+@ red_combine i op i a i b → i {
+    ? == op 4 { ^ + a b } {}
+    ^ ( red_fold op a b )
+}
+
+// ── chunk + result codec ─────────────────────────────────────────
+
+@ chunk_payload i op i lo i hi ( Vec u ) expr → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( vec_push [u] b # u op )
+    ( bytes_push_u64_be b # u64 lo )
+    ( bytes_push_u64_be b # u64 hi )
+    ( vec_extend [u] b expr )
+    ^ b
+}
+
+@ result_encode i value → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( bytes_push_u64_be b # u64 value )
+    ^ b
+}
+
+@ result_decode ( Vec u ) p → i { ^ ?? ( bytes_read_u64_be p 0 ) { T x → # i x F → 0 } }
+
+// ── the generic kernel handler (opaque bytes → bytes) ────────────
+// Parses [op][lo][hi][expr], evaluates the kernel over [lo,hi), folds. A
+// malformed kernel yields the reduce identity (a no-op partial) rather than a
+// crash, so one bad task can't take a worker down.
+
+@ kernel_handler → ( @ ( Vec u ) ( Vec u ) ) {
+    ^ \ ( Vec u ) p → ( Vec u ) {
+        : i op ?? ( vec_get [u] p 0 ) { T x → # i x F → 0 }
+        : i lo ?? ( bytes_read_u64_be p 1 ) { T x → # i x F → 0 }
+        : i hi ?? ( bytes_read_u64_be p 9 ) { T x → # i x F → 0 }
+        : ( Vec u ) src ( bytes_slice p 17 ( vec_len [u] p ) )
+        : *EParser ep # *EParser ( nurl_alloc Z EParser )
+        : i root ( expr_parse src ep )
+        : ~ i acc ( red_id op )
+        ? . ep ok {
+            : ~ i xx lo
+            ~ < xx hi { = acc ( red_fold op acc ( expr_eval ep root xx ) ) = xx + xx 1 }
+        } {}
+        ( eparser_free ep )
+        ( vec_free [u] src )
+        ^ ( result_encode acc )
+    }
+}
+
+// ── sharding: split [lo, hi) into n contiguous chunks ─────────────
+
+: Chunk { i lo i hi }
+
+@ shard i lo i hi i n → ( Vec s ) {
+    : ( Vec s ) out ( vec_new [s] )
+    : i total ? > hi lo - hi lo 0
+    : i base / total n
+    : ~ i i 0
+    ~ < i n {
+        : i clo + lo * i base
+        : i chi ? == i - n 1 hi + lo * + i 1 base
+        : *Chunk c # *Chunk ( nurl_alloc Z Chunk )
+        = . c lo clo
+        = . c hi chi
+        ( vec_push [s] out # s c )
+        = i + i 1
+    }
+    ^ out
+}
+
+@ shard_free ( Vec s ) chunks → v {
+    : i n ( vec_len [s] chunks )
+    : ~ i k 0
+    ~ < k n { ?? ( vec_get [s] chunks k ) { T pp → ?!= # i pp 0 { ( nurl_free pp ) } {} F → {} } = k + k 1 }
+    ( vec_free [s] chunks )
+}
+
+// A ring key for chunk index i: distinct chunks hash to distinct ring points.
+@ chunk_key i idx → ( Vec u ) {
+    : ( Vec u ) b ( vec_new [u] )
+    ( bytes_push_u64_be b # u64 idx )
+    ^ b
+}
+
+// True for a recognised reduce-op name; sets *op. Keeps the MCP layer thin.
+@ reduce_op_of s name i fallback → i {
+    ? != 0 ( nurl_str_eq name `sum` ) { ^ 0 } {}
+    ? != 0 ( nurl_str_eq name `product` ) { ^ 1 } {}
+    ? != 0 ( nurl_str_eq name `min` ) { ^ 2 } {}
+    ? != 0 ( nurl_str_eq name `max` ) { ^ 3 } {}
+    ? != 0 ( nurl_str_eq name `count` ) { ^ 4 } {}
+    ^ fallback
+}
+
+@ reduce_op_name i op → s {
+    ? == op 1 { ^ `product` } {}
+    ? == op 2 { ^ `min` } {}
+    ? == op 3 { ^ `max` } {}
+    ? == op 4 { ^ `count` } {}
+    ^ `sum`
+}

--- a/packages/swarm-mcp/tests/expr_test.nu
+++ b/packages/swarm-mcp/tests/expr_test.nu
@@ -1,0 +1,53 @@
+// packages/swarm-mcp/tests/expr_test.nu — offline tests for the kernel language.
+// Run from the package root:
+//   NURL_STDLIB=<repo> ../../nurl.sh tests/expr_test.nu /tmp/et && /tmp/et
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `src/expr.nu`
+
+// Parse `src`, evaluate at x; -999999 marks a parse error.
+@ ev s src i x → i {
+    : ( Vec u ) b ( bytes_from_str src )
+    : *EParser p # *EParser ( nurl_alloc Z EParser )
+    : i root ( expr_parse b p )
+    : b okp . p ok
+    : ~ i r -999999
+    ? okp { = r ( expr_eval p root x ) } {}
+    ( eparser_free p ) ( vec_free [u] b )
+    ^ r
+}
+
+@ pi s label i a i b → v {
+    ( nurl_print label ) ( nurl_print_int a )
+    ( nurl_print ? == a b ` == ` ` != ` ) ( nurl_print_int b ) ( nurl_print `\n` )
+}
+
+@ main → i {
+    ( pi `x*x @5:        ` ( ev `x*x` 5 ) 25 )
+    ( pi `2+3*4:         ` ( ev `2+3*4` 0 ) 14 )
+    ( pi `(2+3)*4:       ` ( ev `(2+3)*4` 0 ) 20 )
+    ( pi `x*x-7*x @10:   ` ( ev `x*x-7*x` 10 ) 30 )
+    ( pi `x/3 @7:        ` ( ev `x/3` 7 ) 2 )
+    ( pi `x%2 @7:        ` ( ev `x%2` 7 ) 1 )
+    ( pi `x%2==0 @4:     ` ( ev `x%2==0` 4 ) 1 )
+    ( pi `x%2==0 @3:     ` ( ev `x%2==0` 3 ) 0 )
+    ( pi `-x @5:         ` ( ev `-x` 5 ) -5 )
+    ( pi `abs(-x) @5:    ` ( ev `abs(-x)` 5 ) 5 )
+    ( pi `min(x,10) @3:  ` ( ev `min(x,10)` 3 ) 3 )
+    ( pi `min(x,10) @20: ` ( ev `min(x,10)` 20 ) 10 )
+    ( pi `max(x,10) @20: ` ( ev `max(x,10)` 20 ) 20 )
+    ( pi `x>5?x:0 @7:    ` ( ev `x>5 ? x : 0` 7 ) 7 )
+    ( pi `x>5?x:0 @3:    ` ( ev `x>5 ? x : 0` 3 ) 0 )
+    ( pi `x>2 & x<9 @5:  ` ( ev `x>2 & x<9` 5 ) 1 )
+    ( pi `x>2 & x<9 @9:  ` ( ev `x>2 & x<9` 9 ) 0 )
+    ( pi `x==3 | x==7 @7:` ( ev `x==3 | x==7` 7 ) 1 )
+    ( pi `div0 x/0 @5:   ` ( ev `x/0` 5 ) 0 )
+    ( pi `nested @4:     ` ( ev `(x+1)*(x+1)` 4 ) 25 )
+    // parse errors → -999999
+    ( pi `err 'x*':      ` ( ev `x*` 0 ) -999999 )
+    ( pi `err 'x y':     ` ( ev `x y` 0 ) -999999 )
+    ( pi `err 'foo(x)':  ` ( ev `foo(x)` 0 ) -999999 )
+    ^ 0
+}

--- a/packages/swarm-mcp/tests/live_smoke.sh
+++ b/packages/swarm-mcp/tests/live_smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# packages/swarm-mcp/tests/live_smoke.sh — build swarm-mcp and exercise the full
+# path: a relay + workers, a manual CLI submit, and an MCP session (initialize →
+# tools/list → compute_submit → compute_result) over stdin JSON-RPC.
+#
+#   ./tests/live_smoke.sh
+#
+# Run from the package root. Loopback only; starts its own relay + workers.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+NURL_SH="$REPO/nurl.sh"
+export NURL_STDLIB="$REPO"
+
+PORT="${SWARM_PORT:-47880}"
+TMP="$(mktemp -d)"
+BIN="$TMP/swarm-mcp"
+pids=()
+cleanup() { for p in "${pids[@]:-}"; do kill "$p" 2>/dev/null || true; done; rm -rf "$TMP"; }
+trap cleanup EXIT
+
+echo "[smoke] building swarm-mcp"
+"$NURL_SH" "$HERE/src/main.nu" "$BIN" >/dev/null 2>&1
+
+echo "[smoke] starting relay + 3 workers on :$PORT"
+"$BIN" relay 127.0.0.1 "$PORT" >"$TMP/relay.log" 2>&1 &
+pids+=($!)
+sleep 0.6
+for i in 1 2 3; do
+    "$BIN" worker 127.0.0.1 "$PORT" "$i" 0 >"$TMP/w$i.log" 2>&1 &
+    pids+=($!)
+done
+sleep 1.0
+
+fail=0
+
+# 1. CLI submit: sum of x*x over [1,1000) = 332833500
+out="$("$BIN" submit 127.0.0.1 "$PORT" sum 1 1000 'x*x' 2>&1 | tr -d '\n')"
+if echo "$out" | grep -q "332833500"; then echo "[smoke] PASS cli sum x*x = 332833500"; else
+    echo "[smoke] FAIL cli sum — got: $out"; fail=1; fi
+
+# 2. MCP session: submit count of even numbers in [0,1000000) → 500000
+mcp_out="$( {
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
+    printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"compute_submit","arguments":{"expr":"x%2==0","lo":0,"hi":1000000,"reduce":"count"}}}'
+    sleep 2
+    printf '%s\n' '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"compute_result","arguments":{"task_id":1}}}'
+    sleep 1
+} | "$BIN" mcp 127.0.0.1 "$PORT" 2>/dev/null )"
+
+if echo "$mcp_out" | grep -q '"name":"compute_submit"'; then echo "[smoke] PASS mcp tools/list advertises compute_submit"; else
+    echo "[smoke] FAIL mcp tools/list"; fail=1; fi
+if echo "$mcp_out" | grep -q '500000'; then echo "[smoke] PASS mcp compute count = 500000"; else
+    echo "[smoke] FAIL mcp compute — output:"; echo "$mcp_out" | sed 's/^/    /'; fail=1; fi
+
+if [ "$fail" = 0 ]; then echo "[smoke] OK"; else echo "[smoke] FAILED"; exit 1; fi

--- a/packages/swarm-mcp/tests/work_test.nu
+++ b/packages/swarm-mcp/tests/work_test.nu
@@ -1,0 +1,59 @@
+// packages/swarm-mcp/tests/work_test.nu — offline tests for the map-reduce.
+// Verifies the kernel handler and that sharding reproduces the whole-range
+// answer for every reduce op. Run from the package root:
+//   NURL_STDLIB=<repo> ../../nurl.sh tests/work_test.nu /tmp/wt && /tmp/wt
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `src/expr.nu`
+$ `src/work.nu`
+
+// Shard [lo,hi) into n, run the kernel handler on each chunk, combine.
+@ shard_run i op i lo i hi s expr i n → i {
+    : ( @ ( Vec u ) ( Vec u ) ) h ( kernel_handler )
+    : ( Vec u ) eb ( bytes_from_str expr )
+    : ( Vec s ) cs ( shard lo hi n )
+    : ~ i acc ( red_id op )
+    : ~ i k 0
+    ~ < k n {
+        : *Chunk c # *Chunk ?? ( vec_get [s] cs k ) { T x → x F → # s 0 }
+        : ( Vec u ) pl ( chunk_payload op . c lo . c hi eb )
+        : ( Vec u ) r ( h pl )
+        = acc ( red_combine op acc ( result_decode r ) )
+        ( vec_free [u] r ) ( vec_free [u] pl )
+        = k + k 1
+    }
+    ( shard_free cs ) ( vec_free [u] eb )
+    : *u env # *u h 1
+    ? != # i env 0 { ( nurl_free # s env ) } {}
+    ^ acc
+}
+
+@ pi s label i a i b → v {
+    ( nurl_print label ) ( nurl_print_int a )
+    ( nurl_print ? == a b ` == ` ` != ` ) ( nurl_print_int b ) ( nurl_print `\n` )
+}
+
+@ main → i {
+    // whole-range answers
+    ( pi `sum x*x [1,11):       ` ( shard_run ( red_sum ) 1 11 `x*x` 1 ) 385 )
+    ( pi `count x%2==0 [0,10):  ` ( shard_run ( red_count ) 0 10 `x%2==0` 1 ) 5 )
+    ( pi `product x [1,6):      ` ( shard_run ( red_product ) 1 6 `x` 1 ) 120 )
+    ( pi `max x*x-7*x [0,11):   ` ( shard_run ( red_max ) 0 11 `x*x-7*x` 1 ) 30 )
+    ( pi `min x*x-7*x [0,11):   ` ( shard_run ( red_min ) 0 11 `x*x-7*x` 1 ) -12 )
+
+    // sharding must reproduce the whole-range answer for any chunk count
+    ( pi `sum sharded n=7:      ` ( shard_run ( red_sum ) 1 11 `x*x` 7 ) 385 )
+    ( pi `sum sharded n=64:     ` ( shard_run ( red_sum ) 1 11 `x*x` 64 ) 385 )
+    ( pi `count sharded n=4:    ` ( shard_run ( red_count ) 0 10 `x%2==0` 4 ) 5 )
+    ( pi `count sharded n=13:   ` ( shard_run ( red_count ) 0 10 `x%2==0` 13 ) 5 )
+    ( pi `product sharded n=3:  ` ( shard_run ( red_product ) 1 6 `x` 3 ) 120 )
+    ( pi `max sharded n=5:      ` ( shard_run ( red_max ) 0 11 `x*x-7*x` 5 ) 30 )
+    ( pi `min sharded n=5:      ` ( shard_run ( red_min ) 0 11 `x*x-7*x` 5 ) -12 )
+    ( pi `max sharded n>range:  ` ( shard_run ( red_max ) 0 11 `x*x-7*x` 40 ) 30 )
+
+    // a bigger sum to exercise real iteration: Σ x for x in [0,1000) = 499500
+    ( pi `sum x [0,1000) n=8:   ` ( shard_run ( red_sum ) 0 1000 `x` 8 ) 499500 )
+    ^ 0
+}


### PR DESCRIPTION
## Summary

A new package, **`packages/swarm-mcp`** — a distributed compute cluster a **language model drives over MCP**. The model sets a workload (an integer expression kernel in `x`, plus a range and a reduce op) and the cluster evaluates it map-reduce style across every live worker; the model submits tasks, lists running ones, and reads finished results.

Built on the `swarm` distributed stack (`net/relay` / `net/transport` / `dist/ring` / `dist/job`). A machine joins by running `swarm-mcp worker`; `swarm-mcp mcp` is the MCP server — a cluster coordinator exposing the control surface.

## The MCP control surface

Three tools with self-describing schemas (grammar + examples inline), so a model uses them without external docs:

- `compute_submit(expr, lo, hi, reduce)` → `task_id` — shard + run the kernel over `[lo,hi)`, reduce ∈ `sum|product|min|max|count`
- `compute_list()` — every task with status / kernel / range / result
- `compute_result(task_id)` — one task's status and, once finished, the reduced value

Submit returns immediately (`running`, or `done` for tiny tasks); the model polls `compute_result`.

## The kernel language (`src/expr.nu`)

A small, regular integer expression in `x`: `+ - * / %`, comparisons, `& |`, ternary `?:`, `min/max/abs`. Tokenized → parsed into a flat node arena → evaluated per element. Examples the model writes directly: `x*x` (sum) → sum of squares; `x%2==0` (count) → count of evens; `x*x-7*x` (max); `x>100 ? x : 0` (sum). Every reduce op is associative, so sharding is exact regardless of worker count (`src/work.nu`).

The MCP server (`src/main.nu`) keeps a task table and drains cluster traffic on each tool call — single-process, no background thread.

## Phase 2

Same MCP surface; the kernel becomes **arbitrary NURL compiled to a wasm module** shipped to the workers, instead of an interpreted expression.

## Tests

- `tests/expr_test.nu` (kernel parse+eval) and `tests/work_test.nu` (map-reduce + exact sharding) — **ASan-clean**.
- `tests/live_smoke.sh` — relay + workers + a CLI submit + a full MCP session (`initialize` → `tools/list` → `compute_submit` → `compute_result`). Verified live: sum of squares, and count-of-evens across 40M elements with the `running` → `done` poll transition.

## Notes

- Requires **NURL ≥ v0.10.3** (uses the relay verbose field; built from source against the installed stdlib at install time). Uses a 32-byte multicast group id for cross-toolchain portability.
- Hit the field-store/local-shadow footgun again (`= . t lo lo` silently compiled to an array-index store); worked around with a non-shadowing constructor and flagged for a possible compiler hardening follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)