### PR TITLE
wasmtime: linear memory (load/store, memory.size/grow, data section)

### DIFF
--- a/packages/wasmtime/README.md
+++ b/packages/wasmtime/README.md
@@ -28,6 +28,9 @@ wasmtime run --invoke <export> <module.wasm> [int args…]
     (`add` … `shr_s`, `eq` … `ge_s`, `eqz`), with i32 results wrapped to 32 bits
   - `local.get/set/tee`, `drop`, `select`, `i32.wrap_i64`, `i64.extend_i32_*`
   - direct `call` (recursive frames; one shared value stack)
+  - **linear memory**: `i32`/`i64` `load`/`store` incl. sized 8/16/32-bit
+    signed/unsigned variants, `memory.size`/`memory.grow`, and the **data
+    section** (active segments copied into memory at load time)
 
 ```sh
 # add(i32,i32) → i32
@@ -47,8 +50,8 @@ verified against the real thing, and is ASan-clean.
 The integer core is the foundation; hosting real `wasm32-wasi` programs (such as
 the swarm-mcp kernels) needs, roughly in order:
 
-1. **Linear memory** + `i32`/`i64` load/store (and `memory.size`/`grow`), plus
-   the data section — most non-trivial modules touch memory.
+1. ~~**Linear memory** + `i32`/`i64` load/store (and `memory.size`/`grow`), plus
+   the data section.~~ **Done.**
 2. **Globals**, **tables** + `call_indirect`.
 3. **Floats** (`f32`/`f64`) and the numeric conversions.
 4. **Imports + the WASI surface**, starting with **`--dir`**: `proc_exit`,

--- a/packages/wasmtime/src/interp.nu
+++ b/packages/wasmtime/src/interp.nu
@@ -23,21 +23,53 @@ $ `module.nu`
 : Interp {
     s mod  // *Module
     ( Vec i ) vs  // value stack
+    ( Vec u ) mem  // linear memory (bytes)
+    i mem_pages  // current size in 64 KiB pages
     b trap
     ( Vec u ) trapmsg
 }
+
+@ __page → i { ^ 65536 }
 
 @ interp_new * Module m → *Interp {
     : *Interp it # *Interp ( nurl_alloc Z Interp )
     = . it mod # s m
     = . it vs ( vec_new [i] )
+    = . it mem ( vec_new [u] )
+    = . it mem_pages 0
     = . it trap F
     = . it trapmsg ( vec_new [u] )
+    ? == . m has_mem 1 {
+        : i bytes * . m mem_min ( __page )
+        : ~ i k 0
+        ~ < k bytes { ( vec_push [u] . it mem # u 0 ) = k + k 1 }
+        = . it mem_pages . m mem_min
+        // copy active data segments into memory
+        : i nd ( vec_len [s] . m datas )
+        : ~ i di 0
+        ~ < di nd {
+            : s dp ?? ( vec_get [s] . m datas di ) { T x → x F → # s 0 }
+            ? != # i dp 0 {
+                : *DataSeg ds # *DataSeg dp
+                : i dn ( vec_len [u] . ds bytes )
+                : ~ i bi 0
+                ~ < bi dn {
+                    : i tgt + . ds offset bi
+                    ? < tgt ( vec_len [u] . it mem ) {
+                        ( vec_set [u] . it mem tgt ?? ( vec_get [u] . ds bytes bi ) { T x → x F → # u 0 } )
+                    } {}
+                    = bi + bi 1
+                }
+            } {}
+            = di + di 1
+        }
+    } {}
     ^ it
 }
 
 @ interp_free * Interp it → v {
     ( vec_free [i] . it vs )
+    ( vec_free [u] . it mem )
     ( vec_free [u] . it trapmsg )
     ( nurl_free # s it )
 }
@@ -136,6 +168,79 @@ $ `module.nu`
 @ __idiv i a i b → i { ^ ? == b 0 0 / a b }
 
 @ __irem i a i b → i { ^ ? == b 0 0 % a b }
+
+// ── linear memory ────────────────────────────────────────────────
+// Read n bytes little-endian from mem[ea]; sign-extend when `signed` and n<8.
+@ __mem_load * Interp it i ea i n i signed → i {
+    ? | < ea 0 > + ea n ( vec_len [u] . it mem ) {
+        = . it trap T = . it trapmsg ( bytes_from_str `memory load out of bounds` ) ^ 0
+    } {}
+    : ~ i v 0
+    : ~ i k 0
+    ~ < k n {
+        : i byte ?? ( vec_get [u] . it mem + ea k ) { T x → # i x F → 0 }
+        = v | v << byte * 8 k
+        = k + k 1
+    }
+    ? & == signed 1 < n 8 {
+        : i bits * 8 n
+        ? != 0 & v << 1 - bits 1 { = v - v << 1 bits } {}
+    } {}
+    ^ v
+}
+
+// Write the low n bytes of val little-endian to mem[ea].
+@ __mem_store * Interp it i ea i n i val → v {
+    ? | < ea 0 > + ea n ( vec_len [u] . it mem ) {
+        = . it trap T = . it trapmsg ( bytes_from_str `memory store out of bounds` ) ^ v
+    } {}
+    : ~ i k 0
+    ~ < k n {
+        ( vec_set [u] . it mem + ea k # u & >> val * 8 k 255 )
+        = k + k 1
+    }
+}
+
+@ __mem_grow * Interp it i delta → v {
+    ? <= delta 0 { ^ v } {}
+    : i add * delta ( __page )
+    : ~ i k 0
+    ~ < k add { ( vec_push [u] . it mem # u 0 ) = k + k 1 }
+    = . it mem_pages + . it mem_pages delta
+}
+
+// Execute a memory instruction (0x28..0x40). memarg = align + offset ulebs.
+@ __exec_mem * Interp it * Wc c i op → v {
+    ? == op 63 { ( wc_u8 c ) ( __push it . it mem_pages ) ^ v } {}  // memory.size
+    ? == op 64 { ( wc_u8 c ) : i d ( __pop it ) : i old . it mem_pages ( __mem_grow it d ) ( __push it old ) ^ v } {}  // memory.grow
+    : i align ( wc_uleb c )
+    : i off ( wc_uleb c )
+    ? & >= op 54 <= op 62 {  // stores: pop value, then addr
+        : i val ( __pop it )
+        : i ea + & ( __pop it ) 4294967295 off
+        ? == op 54 { ( __mem_store it ea 4 val ) } {}  // i32.store
+        ? == op 55 { ( __mem_store it ea 8 val ) } {}  // i64.store
+        ? == op 58 { ( __mem_store it ea 1 val ) } {}  // i32.store8
+        ? == op 59 { ( __mem_store it ea 2 val ) } {}  // i32.store16
+        ? == op 60 { ( __mem_store it ea 1 val ) } {}  // i64.store8
+        ? == op 61 { ( __mem_store it ea 2 val ) } {}  // i64.store16
+        ? == op 62 { ( __mem_store it ea 4 val ) } {}  // i64.store32
+        ^ v
+    } {}
+    : i ea + & ( __pop it ) 4294967295 off
+    ? == op 40 { ( __push it ( __w32 ( __mem_load it ea 4 0 ) ) ) } {}  // i32.load
+    ? == op 41 { ( __push it ( __mem_load it ea 8 0 ) ) } {}  // i64.load
+    ? == op 44 { ( __push it ( __w32 ( __mem_load it ea 1 1 ) ) ) } {}  // i32.load8_s
+    ? == op 45 { ( __push it ( __mem_load it ea 1 0 ) ) } {}  // i32.load8_u
+    ? == op 46 { ( __push it ( __w32 ( __mem_load it ea 2 1 ) ) ) } {}  // i32.load16_s
+    ? == op 47 { ( __push it ( __mem_load it ea 2 0 ) ) } {}  // i32.load16_u
+    ? == op 48 { ( __push it ( __mem_load it ea 1 1 ) ) } {}  // i64.load8_s
+    ? == op 49 { ( __push it ( __mem_load it ea 1 0 ) ) } {}  // i64.load8_u
+    ? == op 50 { ( __push it ( __mem_load it ea 2 1 ) ) } {}  // i64.load16_s
+    ? == op 51 { ( __push it ( __mem_load it ea 2 0 ) ) } {}  // i64.load16_u
+    ? == op 52 { ( __push it ( __mem_load it ea 4 1 ) ) } {}  // i64.load32_s
+    ? == op 53 { ( __push it ( __mem_load it ea 4 0 ) ) } {}  // i64.load32_u
+}
 
 // ── control-stack helpers ────────────────────────────────────────
 
@@ -267,6 +372,8 @@ $ `module.nu`
     // ── constants ──
     ? == op 65 { ( __push it ( __w32 ( wc_sleb c ) ) ) ^ v } {}  // i32.const
     ? == op 66 { ( __push it ( wc_sleb c ) ) ^ v } {}  // i64.const
+    // ── linear memory (loads/stores, size/grow) ──
+    ? & >= op 40 <= op 64 { ( __exec_mem it c op ) ^ v } {}
     // ── the rest: numeric ops ──
     ( __exec_num it c op )
 }

--- a/packages/wasmtime/src/module.nu
+++ b/packages/wasmtime/src/module.nu
@@ -79,12 +79,19 @@ $ `stdlib/std/bytes.nu`
 
 : WExport { ( Vec u ) name i kind i index }
 
+// An active data segment: raw bytes to copy into linear memory at `offset`.
+: DataSeg { i offset ( Vec u ) bytes }
+
 : Module {
     ( Vec s ) types  // *FuncType
     ( Vec i ) functypes  // type index per defined function
     ( Vec s ) funcs  // *WFunc
     ( Vec s ) exports  // *WExport
     ( Vec u ) code  // the whole module byte image (functions index into it)
+    i has_mem
+    i mem_min  // initial pages (64 KiB each)
+    i mem_max  // 0 if unbounded
+    ( Vec s ) datas  // *DataSeg
     b ok
     ( Vec u ) err
 }
@@ -105,6 +112,10 @@ $ `stdlib/std/bytes.nu`
     : ~ i e 0
     ~ < e en { ?? ( vec_get [s] . m exports e ) { T pp → ?!= # i pp 0 { : *WExport x # *WExport pp ( vec_free [u] . x name ) ( nurl_free # s x ) } {} F → {} } = e + e 1 }
     ( vec_free [s] . m exports )
+    : i dn ( vec_len [s] . m datas )
+    : ~ i d 0
+    ~ < d dn { ?? ( vec_get [s] . m datas d ) { T pp → ?!= # i pp 0 { : *DataSeg ds # *DataSeg pp ( vec_free [u] . ds bytes ) ( nurl_free # s ds ) } {} F → {} } = d + d 1 }
+    ( vec_free [s] . m datas )
     ( vec_free [u] . m code )
     ( vec_free [u] . m err )
     ( nurl_free # s m )
@@ -159,6 +170,45 @@ $ `stdlib/std/bytes.nu`
     }
 }
 
+// Memory section: limits (flag, min [, max]). Records the first memory.
+@ __decode_mem_sec * Wc c * Module m → v {
+    : i n ( wc_uleb c )
+    : ~ i k 0
+    ~ < k n {
+        : i flag ( wc_u8 c )
+        : i mn ( wc_uleb c )
+        : i mx ? == flag 1 ( wc_uleb c ) 0
+        ? == k 0 { = . m has_mem 1 = . m mem_min mn = . m mem_max mx } {}
+        = k + k 1
+    }
+}
+
+// Data section: active segments (flag 0/2) carry an i32.const offset expr then
+// raw bytes; passive segments (flag 1) carry bytes only (offset 0, ignored).
+@ __decode_data_sec * Wc c * Module m → v {
+    : i n ( wc_uleb c )
+    : ~ i k 0
+    ~ < k n {
+        : i flag ( wc_uleb c )
+        ? == flag 2 { ( wc_uleb c ) } {}  // explicit memidx
+        : ~ i offset 0
+        ? != flag 1 {
+            : i op0 ( wc_u8 c )
+            ? == op0 65 { = offset ( wc_sleb c ) } {}  // i32.const
+            ~ != ( wc_u8 c ) 11 {}  // consume the rest of the const expr up to `end`
+        } {}
+        : i blen ( wc_uleb c )
+        : ( Vec u ) bytes ( vec_with_cap [u] blen )
+        : ~ i bi 0
+        ~ < bi blen { ( vec_push [u] bytes ( wc_u8 c ) ) = bi + bi 1 }
+        : *DataSeg ds # *DataSeg ( nurl_alloc Z DataSeg )
+        = . ds offset offset
+        = . ds bytes bytes
+        ( vec_push [s] . m datas ds )
+        = k + k 1
+    }
+}
+
 // Code section: for each function, parse local declarations and record the
 // [start,end) byte range of its instruction stream (ending at the final `end`).
 @ __decode_code_sec * Wc c * Module m → v {
@@ -197,6 +247,10 @@ $ `stdlib/std/bytes.nu`
     = . m funcs ( vec_new [s] )
     = . m exports ( vec_new [s] )
     = . m code bytes
+    = . m has_mem 0
+    = . m mem_min 0
+    = . m mem_max 0
+    = . m datas ( vec_new [s] )
     = . m ok T
     = . m err ( vec_new [u] )
     : *Wc c ( wc_new bytes )
@@ -212,8 +266,10 @@ $ `stdlib/std/bytes.nu`
         : i sec_end + . c pos size
         ? == id 1 { ( __decode_type_sec c m ) } {
             ? == id 3 { ( __decode_func_sec c m ) } {
-                ? == id 7 { ( __decode_export_sec c m ) } {
-                    ? == id 10 { ( __decode_code_sec c m ) } {} } } }
+                ? == id 5 { ( __decode_mem_sec c m ) } {
+                    ? == id 7 { ( __decode_export_sec c m ) } {
+                        ? == id 10 { ( __decode_code_sec c m ) } {
+                            ? == id 11 { ( __decode_data_sec c m ) } {} } } } } }
         = . c pos sec_end  // robust against partially-read / skipped sections
     }
     ( wc_free c )

--- a/packages/wasmtime/tests/mem_test.nu
+++ b/packages/wasmtime/tests/mem_test.nu
@@ -1,0 +1,71 @@
+// packages/wasmtime/tests/mem_test.nu — offline tests for linear memory:
+// load/store round-trips, sized byte access, the data section, and memory.size.
+// Hand-encoded modules, expected results cross-checked against real wasmtime.
+//   NURL_STDLIB=<repo> ../../nurl.sh tests/mem_test.nu /tmp/mt && /tmp/mt
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `src/module.nu`
+$ `src/interp.nu`
+
+// roundtrip(i32)->i32 { i32.store(0,v); i32.load(0) }
+@ wasm_round → s { ^ `0061736d0100000001060160017f017f030201000503010001070d0109726f756e647472697000000a10010e004100200036020041002802000b` }
+// sumdata()->i32 { data [1..5]@0 ; Σ load8_u }
+@ wasm_data → s { ^ `0061736d010000000105016000017f030201000503010001070b010773756d6461746100000a21011f0041002d000041002d00016a41002d00026a41002d00036a41002d00046a0b0b0b010041000b050102030405` }
+// bytepoke(i32)->i32 { i32.store8(5,v); i32.load8_u(5) }  → v & 255
+@ wasm_poke → s { ^ `0061736d0100000001060160017f017f030201000503010001070c010862797465706f6b6500000a10010e00410520003a000041052d00000b` }
+// memsize()->i32 { memory.size }  (min 3 pages)
+@ wasm_msize → s { ^ `0061736d010000000105016000017f030201000503010003070b01076d656d73697a6500000a060104003f000b` }
+
+@ ev s hex s export ( Vec i ) args → i {
+    : !( Vec u ) ParseErr dr ( bytes_from_hex hex )
+    : ~ i r -999999
+    ?? dr {
+        T bytes → {
+            : *Module m ( module_decode bytes )
+            ? . m ok {
+                : i fidx ( module_export_func m export )
+                ? >= fidx 0 {
+                    : *Interp it ( interp_new m )
+                    : i na ( vec_len [i] args )
+                    : ~ i k 0
+                    ~ < k na { ( vec_push [i] . it vs ?? ( vec_get [i] args k ) { T x → x F → 0 } ) = k + k 1 }
+                    ( exec_func it fidx )
+                    ? ! . it trap {
+                        : i n ( vec_len [i] . it vs )
+                        ? > n 0 { = r ?? ( vec_get [i] . it vs - n 1 ) { T x → x F → 0 } } {}
+                    } {}
+                    ( interp_free it )
+                } {}
+            } {}
+            ( module_free m )
+        }
+        F → {}
+    }
+    ^ r
+}
+
+@ run0 s hex s export → i {
+    : ( Vec i ) a ( vec_new [i] ) : i r ( ev hex export a ) ( vec_free [i] a ) ^ r
+}
+
+@ run1 s hex s export i x → i {
+    : ( Vec i ) a ( vec_new [i] ) ( vec_push [i] a x ) : i r ( ev hex export a ) ( vec_free [i] a ) ^ r
+}
+
+@ pi s label i a i b → v {
+    ( nurl_print label ) ( nurl_print_int a )
+    ( nurl_print ? == a b ` == ` ` != ` ) ( nurl_print_int b ) ( nurl_print `\n` )
+}
+
+@ main → i {
+    ( pi `roundtrip 1234:  ` ( run1 ( wasm_round ) `roundtrip` 1234 ) 1234 )
+    ( pi `roundtrip 0:     ` ( run1 ( wasm_round ) `roundtrip` 0 ) 0 )
+    ( pi `roundtrip -5:    ` ( run1 ( wasm_round ) `roundtrip` -5 ) -5 )
+    ( pi `sumdata:         ` ( run0 ( wasm_data ) `sumdata` ) 15 )
+    ( pi `bytepoke 700:    ` ( run1 ( wasm_poke ) `bytepoke` 700 ) 188 )
+    ( pi `bytepoke 65:     ` ( run1 ( wasm_poke ) `bytepoke` 65 ) 65 )
+    ( pi `memsize:         ` ( run0 ( wasm_msize ) `memsize` ) 3 )
+    ^ 0
+}


### PR DESCRIPTION
## Summary

**Milestone 2** of the pure-NURL WebAssembly runtime ([#315](https://github.com/nurl-lang/nurl/pull/315) was the integer core): **linear memory**.

- **`src/module.nu`** — decode the **memory section** (limits) and the **data section** (active segments: an `i32.const` offset expr + raw bytes). `Module` gains `has_mem` / `mem_min` / `mem_max` / `datas`.
- **`src/interp.nu`** — `Interp` gets a byte-vector linear memory; `interp_new` allocates `mem_min × 64 KiB` and copies active data segments in. New ops:
  - `i32`/`i64` `load`/`store`, including the sized **8/16/32-bit signed/unsigned** variants — little-endian, **bounds-checked** (trap on OOB)
  - `memory.size` / `memory.grow`

## Verified against the reference wasmtime

| module | result |
|--------|--------|
| `roundtrip(v)` — `i32.store`→`i32.load` | the input (1234, 0, −5) |
| `bytepoke(700)` — `i32.store8`→`i32.load8_u` | `188` (700 & 255) |
| `sumdata()` — data segment `[1..5]` summed via `load8_u` | `15` |
| `memsize()` — `memory.size`, min 3 pages | `3` |

`tests/mem_test.nu` — 7 assertions, **ASan-clean**; the integer-core tests stay green.

## Roadmap

1. ~~Linear memory + load/store + data section.~~ **Done (this PR).**
2. Globals, tables + `call_indirect`.
3. Floats + numeric conversions.
4. Imports + WASI, starting with **`--dir`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)