### PR TITLE
wasmtime: globals + tables / call_indirect

### DIFF
--- a/packages/wasmtime/README.md
+++ b/packages/wasmtime/README.md
@@ -31,6 +31,8 @@ wasmtime run --invoke <export> <module.wasm> [int args…]
   - **linear memory**: `i32`/`i64` `load`/`store` incl. sized 8/16/32-bit
     signed/unsigned variants, `memory.size`/`memory.grow`, and the **data
     section** (active segments copied into memory at load time)
+  - **globals** (`global.get`/`global.set`, const-initialised) and **tables**
+    + **`call_indirect`** (element segments populate the function table)
 
 ```sh
 # add(i32,i32) → i32
@@ -52,7 +54,7 @@ the swarm-mcp kernels) needs, roughly in order:
 
 1. ~~**Linear memory** + `i32`/`i64` load/store (and `memory.size`/`grow`), plus
    the data section.~~ **Done.**
-2. **Globals**, **tables** + `call_indirect`.
+2. ~~**Globals**, **tables** + `call_indirect`.~~ **Done.**
 3. **Floats** (`f32`/`f64`) and the numeric conversions.
 4. **Imports + the WASI surface**, starting with **`--dir`**: `proc_exit`,
    `fd_write` (stdout), `args_*`, `environ_*`, and the preopened-directory file

--- a/packages/wasmtime/src/interp.nu
+++ b/packages/wasmtime/src/interp.nu
@@ -25,6 +25,7 @@ $ `module.nu`
     ( Vec i ) vs  // value stack
     ( Vec u ) mem  // linear memory (bytes)
     i mem_pages  // current size in 64 KiB pages
+    ( Vec i ) globals  // mutable global values
     b trap
     ( Vec u ) trapmsg
 }
@@ -37,8 +38,13 @@ $ `module.nu`
     = . it vs ( vec_new [i] )
     = . it mem ( vec_new [u] )
     = . it mem_pages 0
+    = . it globals ( vec_new [i] )
     = . it trap F
     = . it trapmsg ( vec_new [u] )
+    // copy global initial values
+    : i ng ( vec_len [i] . m global_init )
+    : ~ i gi 0
+    ~ < gi ng { ( vec_push [i] . it globals ?? ( vec_get [i] . m global_init gi ) { T x → x F → 0 } ) = gi + gi 1 }
     ? == . m has_mem 1 {
         : i bytes * . m mem_min ( __page )
         : ~ i k 0
@@ -70,6 +76,7 @@ $ `module.nu`
 @ interp_free * Interp it → v {
     ( vec_free [i] . it vs )
     ( vec_free [u] . it mem )
+    ( vec_free [i] . it globals )
     ( vec_free [u] . it trapmsg )
     ( nurl_free # s it )
 }
@@ -363,12 +370,27 @@ $ `module.nu`
     ? == op 13 { : i lbl ( wc_uleb c ) : i cond ( __pop it ) ? != cond 0 { ( __do_branch it ctrl c lbl ) } {} ^ v } {}  // br_if
     ? == op 15 { ^ v } {}  // return (handled by caller loop)
     ? == op 16 { : i fi ( wc_uleb c ) ( exec_func it fi ) ^ v } {}  // call
+    ? == op 17 {  // call_indirect typeidx tableidx
+        : i typeidx ( wc_uleb c )
+        : i tblidx ( wc_uleb c )
+        : i ei & ( __pop it ) 4294967295
+        ? | < ei 0 >= ei ( vec_len [i] . m table ) {
+            = . it trap T = . it trapmsg ( bytes_from_str `call_indirect: index out of range` ) ^ v
+        } {}
+        : i fi ?? ( vec_get [i] . m table ei ) { T x → x F → -1 }
+        ? < fi 0 { = . it trap T = . it trapmsg ( bytes_from_str `call_indirect: null table element` ) ^ v } {}
+        ( exec_func it fi )
+        ^ v
+    } {}
     ? == op 26 { ( __pop it ) ^ v } {}  // drop
     ? == op 27 { : i cc ( __pop it ) : i b2 ( __pop it ) : i a2 ( __pop it ) ( __push it ? != cc 0 a2 b2 ) ^ v } {}  // select
     // ── locals ──
     ? == op 32 { : i li ( wc_uleb c ) ( __push it ?? ( vec_get [i] locals li ) { T x → x F → 0 } ) ^ v } {}
     ? == op 33 { : i li ( wc_uleb c ) ( vec_set [i] locals li ( __pop it ) ) ^ v } {}
     ? == op 34 { : i li ( wc_uleb c ) : i tv ?? ( vec_get [i] . it vs - ( vec_len [i] . it vs ) 1 ) { T x → x F → 0 } ( vec_set [i] locals li tv ) ^ v } {}  // local.tee
+    // ── globals ──
+    ? == op 35 { : i gi ( wc_uleb c ) ( __push it ?? ( vec_get [i] . it globals gi ) { T x → x F → 0 } ) ^ v } {}  // global.get
+    ? == op 36 { : i gi ( wc_uleb c ) ( vec_set [i] . it globals gi ( __pop it ) ) ^ v } {}  // global.set
     // ── constants ──
     ? == op 65 { ( __push it ( __w32 ( wc_sleb c ) ) ) ^ v } {}  // i32.const
     ? == op 66 { ( __push it ( wc_sleb c ) ) ^ v } {}  // i64.const

--- a/packages/wasmtime/src/module.nu
+++ b/packages/wasmtime/src/module.nu
@@ -1,10 +1,10 @@
 // packages/wasmtime/src/module.nu — WebAssembly binary decoder (pure NURL).
 //
 // Decodes a wasm32 module's structure: the magic/version header and the
-// sections this runtime understands so far (type, function, export, code).
-// Imports, tables, globals, data, etc. are skipped for now — enough to load
-// and run a self-contained compute module. The byte cursor + LEB128 readers
-// here are reused by the interpreter (interp.nu) to walk instruction streams.
+// sections this runtime understands (type, function, table, memory, global,
+// export, element, code, data). Imports and the custom/start sections are
+// skipped. The byte cursor + LEB128 readers here are reused by the interpreter
+// (interp.nu) to walk instruction streams.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -92,6 +92,10 @@ $ `stdlib/std/bytes.nu`
     i mem_min  // initial pages (64 KiB each)
     i mem_max  // 0 if unbounded
     ( Vec s ) datas  // *DataSeg
+    ( Vec i ) global_init  // initial value per global
+    ( Vec i ) global_mut  // 1 if mutable
+    i has_table
+    ( Vec i ) table  // function indices (−1 = empty slot)
     b ok
     ( Vec u ) err
 }
@@ -116,9 +120,23 @@ $ `stdlib/std/bytes.nu`
     : ~ i d 0
     ~ < d dn { ?? ( vec_get [s] . m datas d ) { T pp → ?!= # i pp 0 { : *DataSeg ds # *DataSeg pp ( vec_free [u] . ds bytes ) ( nurl_free # s ds ) } {} F → {} } = d + d 1 }
     ( vec_free [s] . m datas )
+    ( vec_free [i] . m global_init )
+    ( vec_free [i] . m global_mut )
+    ( vec_free [i] . m table )
     ( vec_free [u] . m code )
     ( vec_free [u] . m err )
     ( nurl_free # s m )
+}
+
+// Evaluate a constant init expr (i32/i64.const N … end); global.get is treated
+// as 0 (imported globals unsupported). Consumes through the trailing `end`.
+@ __const_expr * Wc c → i {
+    : i op0 ( wc_u8 c )
+    : ~ i val 0
+    ? | == op0 65 == op0 66 { = val ( wc_sleb c ) } {
+        ? == op0 35 { ( wc_uleb c ) } {} }
+    ~ != ( wc_u8 c ) 11 {}
+    ^ val
 }
 
 // ── section decoders ─────────────────────────────────────────────
@@ -191,12 +209,7 @@ $ `stdlib/std/bytes.nu`
     ~ < k n {
         : i flag ( wc_uleb c )
         ? == flag 2 { ( wc_uleb c ) } {}  // explicit memidx
-        : ~ i offset 0
-        ? != flag 1 {
-            : i op0 ( wc_u8 c )
-            ? == op0 65 { = offset ( wc_sleb c ) } {}  // i32.const
-            ~ != ( wc_u8 c ) 11 {}  // consume the rest of the const expr up to `end`
-        } {}
+        : i offset ? != flag 1 ( __const_expr c ) 0
         : i blen ( wc_uleb c )
         : ( Vec u ) bytes ( vec_with_cap [u] blen )
         : ~ i bi 0
@@ -205,6 +218,59 @@ $ `stdlib/std/bytes.nu`
         = . ds offset offset
         = . ds bytes bytes
         ( vec_push [s] . m datas ds )
+        = k + k 1
+    }
+}
+
+// Global section: each global = valtype, mutability, const init expr.
+@ __decode_global_sec * Wc c * Module m → v {
+    : i n ( wc_uleb c )
+    : ~ i k 0
+    ~ < k n {
+        ( wc_u8 c )  // valtype
+        : i mut ( wc_u8 c )
+        ( vec_push [i] . m global_init ( __const_expr c ) )
+        ( vec_push [i] . m global_mut mut )
+        = k + k 1
+    }
+}
+
+// Table section: allocate the first table (size = min, slots empty = −1).
+@ __decode_table_sec * Wc c * Module m → v {
+    : i n ( wc_uleb c )
+    : ~ i k 0
+    ~ < k n {
+        ( wc_u8 c )  // elemtype (0x70 funcref)
+        : i flag ( wc_u8 c )
+        : i mn ( wc_uleb c )
+        ? == flag 1 { ( wc_uleb c ) } {}  // max
+        ? == k 0 {
+            = . m has_table 1
+            : ~ i j 0
+            ~ < j mn { ( vec_push [i] . m table -1 ) = j + j 1 }
+        } {}
+        = k + k 1
+    }
+}
+
+// Element section: active segments (flag 0) fill the table with function indices
+// at a const offset.
+@ __decode_elem_sec * Wc c * Module m → v {
+    : i n ( wc_uleb c )
+    : ~ i k 0
+    ~ < k n {
+        : i flag ( wc_uleb c )
+        ? == flag 0 {
+            : i off ( __const_expr c )
+            : i cnt ( wc_uleb c )
+            : ~ i j 0
+            ~ < j cnt {
+                : i fi ( wc_uleb c )
+                : i tgt + off j
+                ? & >= tgt 0 < tgt ( vec_len [i] . m table ) { ( vec_set [i] . m table tgt fi ) } {}
+                = j + j 1
+            }
+        } {}
         = k + k 1
     }
 }
@@ -251,6 +317,10 @@ $ `stdlib/std/bytes.nu`
     = . m mem_min 0
     = . m mem_max 0
     = . m datas ( vec_new [s] )
+    = . m global_init ( vec_new [i] )
+    = . m global_mut ( vec_new [i] )
+    = . m has_table 0
+    = . m table ( vec_new [i] )
     = . m ok T
     = . m err ( vec_new [u] )
     : *Wc c ( wc_new bytes )
@@ -266,10 +336,13 @@ $ `stdlib/std/bytes.nu`
         : i sec_end + . c pos size
         ? == id 1 { ( __decode_type_sec c m ) } {
             ? == id 3 { ( __decode_func_sec c m ) } {
-                ? == id 5 { ( __decode_mem_sec c m ) } {
-                    ? == id 7 { ( __decode_export_sec c m ) } {
-                        ? == id 10 { ( __decode_code_sec c m ) } {
-                            ? == id 11 { ( __decode_data_sec c m ) } {} } } } } }
+                ? == id 4 { ( __decode_table_sec c m ) } {
+                    ? == id 5 { ( __decode_mem_sec c m ) } {
+                        ? == id 6 { ( __decode_global_sec c m ) } {
+                            ? == id 7 { ( __decode_export_sec c m ) } {
+                                ? == id 9 { ( __decode_elem_sec c m ) } {
+                                    ? == id 10 { ( __decode_code_sec c m ) } {
+                                        ? == id 11 { ( __decode_data_sec c m ) } {} } } } } } } } }
         = . c pos sec_end  // robust against partially-read / skipped sections
     }
     ( wc_free c )

--- a/packages/wasmtime/tests/table_test.nu
+++ b/packages/wasmtime/tests/table_test.nu
@@ -1,0 +1,69 @@
+// packages/wasmtime/tests/table_test.nu — offline tests for globals and
+// call_indirect (tables + element segments). Hand-encoded modules, expected
+// results cross-checked against the reference wasmtime.
+//   NURL_STDLIB=<repo> ../../nurl.sh tests/table_test.nu /tmp/tt && /tmp/tt
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `src/module.nu`
+$ `src/interp.nu`
+
+// bump()->i32 : mutable global g=10; g+=1; return g
+@ wasm_bump → s { ^ `0061736d010000000105016000017f030201000606017f01410a0b0708010462756d7000000a0d010b00230041016a240023000b` }
+// dispatch(sel,a,b)->i32 : table[sel](a,b); table=[add,sub]  (call_indirect)
+@ wasm_disp → s { ^ `0061736d01000000010e0260027f7f017f60037f7f7f017f030403000001040401700002070c0108646973706174636800020908010041000b0200010a1d030700200020016a0b0700200020016b0b0b002001200220001100000b` }
+
+@ ev s hex s export ( Vec i ) args → i {
+    : !( Vec u ) ParseErr dr ( bytes_from_hex hex )
+    : ~ i r -999999
+    ?? dr {
+        T bytes → {
+            : *Module m ( module_decode bytes )
+            ? . m ok {
+                : i fidx ( module_export_func m export )
+                ? >= fidx 0 {
+                    : *Interp it ( interp_new m )
+                    : i na ( vec_len [i] args )
+                    : ~ i k 0
+                    ~ < k na { ( vec_push [i] . it vs ?? ( vec_get [i] args k ) { T x → x F → 0 } ) = k + k 1 }
+                    ( exec_func it fidx )
+                    ? ! . it trap {
+                        : i n ( vec_len [i] . it vs )
+                        ? > n 0 { = r ?? ( vec_get [i] . it vs - n 1 ) { T x → x F → 0 } } {}
+                    } {}
+                    ( interp_free it )
+                } {}
+            } {}
+            ( module_free m )
+        }
+        F → {}
+    }
+    ^ r
+}
+
+@ run0 s hex s export → i {
+    : ( Vec i ) a ( vec_new [i] ) : i r ( ev hex export a ) ( vec_free [i] a ) ^ r
+}
+
+@ run3 s hex s export i x i y i z → i {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a x ) ( vec_push [i] a y ) ( vec_push [i] a z )
+    : i r ( ev hex export a ) ( vec_free [i] a ) ^ r
+}
+
+@ pi s label i a i b → v {
+    ( nurl_print label ) ( nurl_print_int a )
+    ( nurl_print ? == a b ` == ` ` != ` ) ( nurl_print_int b ) ( nurl_print `\n` )
+}
+
+@ main → i {
+    // global.get / global.set + const init
+    ( pi `bump:           ` ( run0 ( wasm_bump ) `bump` ) 11 )
+    // call_indirect through the table: table[0]=add, table[1]=sub
+    ( pi `dispatch 0 7 3:  ` ( run3 ( wasm_disp ) `dispatch` 0 7 3 ) 10 )
+    ( pi `dispatch 1 7 3:  ` ( run3 ( wasm_disp ) `dispatch` 1 7 3 ) 4 )
+    ( pi `dispatch 0 20 5: ` ( run3 ( wasm_disp ) `dispatch` 0 20 5 ) 25 )
+    ( pi `dispatch 1 20 5: ` ( run3 ( wasm_disp ) `dispatch` 1 20 5 ) 15 )
+    ^ 0
+}


### PR DESCRIPTION
## Summary

**Milestone 3** of the pure-NURL WebAssembly runtime (after the integer core #315 and linear memory #316): **globals and indirect calls**.

- **`src/module.nu`** — decode the **global section** (valtype, mutability, const init expr), the **table section** (allocate the function table; empty slots = −1), and the **element section** (active segments fill the table at a const offset). A shared `__const_expr` helper evaluates `i32`/`i64.const` init/offset expressions (now also used by the data section). `Module` gains `global_init` / `global_mut` / `has_table` / `table`.
- **`src/interp.nu`** — `Interp` holds the mutable global values (copied from the module's inits at instantiation). New ops:
  - `global.get` / `global.set`
  - **`call_indirect`** — pop the table index, resolve the function (trap on out-of-range or null slot), then call

## Verified against the reference wasmtime

| module | result |
|--------|--------|
| `bump()` — mutable global `g=10`; `g+=1`; return `g` | `11` |
| `dispatch(0,7,3)` — `table[0]=add` via `call_indirect` | `10` |
| `dispatch(1,7,3)` — `table[1]=sub` via `call_indirect` | `4` |

`tests/table_test.nu` — 5 assertions, **ASan-clean**; the integer-core and memory tests stay green.

## Roadmap

1. ~~Linear memory.~~ **Done.**
2. ~~Globals, tables + `call_indirect`.~~ **Done (this PR).**
3. Floats + numeric conversions.
4. Imports + WASI, starting with **`--dir`** — after which `swarm-mcp` workers can drop the external `wasmtime` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)