### PR TITLE
stdlib: std/floatbits — IEEE-754 bit reinterpretation + binary float I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`std/floatbits` — IEEE-754 bit reinterpretation + binary float I/O.** NURL's
+  `#` cast converts a float's *value*; this new module reinterprets its *bit
+  pattern* — the operation binary formats need, and previously impossible in the
+  stdlib (`bytes_push_float` only writes `%g` text). Backed by a zero-allocation
+  runtime bitcast (`memcpy`, correct for NaN/±Inf/subnormals): `f64_to_bits` /
+  `bits_to_f64`, `f32_to_bits` / `bits_to_f32`, and explicit-endian binary
+  helpers `bytes_push_f64_le/_be` · `bytes_read_f64_le/_be → ?f` (and `f32`
+  variants). For serialization (msgpack/protobuf/wasm/audio), float hashing,
+  random→float, and the pure-NURL wasm runtime. KAT-tested (`floatbits`).
+
 ### Changed
 
 - **`net/relay` frame limit raised from 128 KiB to 16 MiB.** A relayed message

--- a/compiler/tests/floatbits.nu
+++ b/compiler/tests/floatbits.nu
@@ -1,0 +1,41 @@
+// floatbits.nu — IEEE-754 bit reinterpretation + binary float I/O
+// (stdlib/std/floatbits.nu). Constants verified against struct.pack.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/floatbits.nu`
+
+@ pb s label b ok → v { ( nurl_print label ) ( nurl_print ? ok `YES\n` `NO\n` ) }
+
+@ main → i {
+    // f64 → bit pattern (exact, known constants)
+    ( pb `f64 0.0  bits==0:   ` == ( f64_to_bits 0.0 ) 0 )
+    ( pb `f64 1.0  bits:      ` == ( f64_to_bits 1.0 ) 4607182418800017408 )
+    ( pb `f64 2.0  bits:      ` == ( f64_to_bits 2.0 ) 4611686018427387904 )
+    ( pb `f64 0.5  bits:      ` == ( f64_to_bits 0.5 ) 4602678819172646912 )
+    ( pb `f64 -2.0 bits:      ` == ( f64_to_bits -2.0 ) -4611686018427387904 )
+    // f64 round-trips bit-exactly (covers any pattern)
+    ( pb `f64 roundtrip:      ` == ( f64_to_bits ( bits_to_f64 4614256650576692846 ) ) 4614256650576692846 )
+    // bits_to_f64 then arithmetic: 2.0 + 2.0 = 4.0
+    ( pb `bits_to_f64 arith:  ` == ( f64_to_bits + ( bits_to_f64 4611686018427387904 ) ( bits_to_f64 4611686018427387904 ) ) ( f64_to_bits 4.0 ) )
+    // f32 → bit pattern
+    ( pb `f32 1.0  bits:      ` == ( f32_to_bits # f32 1.0 ) 1065353216 )
+    ( pb `f32 2.0  bits:      ` == ( f32_to_bits # f32 2.0 ) 1073741824 )
+    ( pb `f32 roundtrip:      ` == ( f32_to_bits ( bits_to_f32 1065353216 ) ) 1065353216 )
+
+    // binary I/O: push 2.0 big-endian, first byte is 0x40 = 64
+    : ( Vec u ) be ( vec_new [u] )
+    ( bytes_push_f64_be be 2.0 )
+    ( pb `f64_be first byte:  ` == ?? ( vec_get [u] be 0 ) { T x → # i x F → -1 } 64 )
+    ( pb `f64_be read-back:   ` ?? ( bytes_read_f64_be be 0 ) { T x → == ( f64_to_bits x ) 4611686018427387904 F → F } )
+    // little-endian: last byte is 0x40
+    : ( Vec u ) le ( vec_new [u] )
+    ( bytes_push_f64_le le 2.0 )
+    ( pb `f64_le last byte:   ` == ?? ( vec_get [u] le 7 ) { T x → # i x F → -1 } 64 )
+    ( pb `f64_le read-back:   ` ?? ( bytes_read_f64_le le 0 ) { T x → == ( f64_to_bits x ) 4611686018427387904 F → F } )
+    // f32 binary round-trip
+    : ( Vec u ) f32b ( vec_new [u] )
+    ( bytes_push_f32_le f32b # f32 2.0 )
+    ( pb `f32_le read-back:   ` ?? ( bytes_read_f32_le f32b 0 ) { T x → == ( f32_to_bits x ) 1073741824 F → F } )
+    ^ 0
+}

--- a/compiler/tests/outputs/floatbits.txt
+++ b/compiler/tests/outputs/floatbits.txt
@@ -1,0 +1,19 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+f64 0.0  bits==0:   YES
+f64 1.0  bits:      YES
+f64 2.0  bits:      YES
+f64 0.5  bits:      YES
+f64 -2.0 bits:      YES
+f64 roundtrip:      YES
+bits_to_f64 arith:  YES
+f32 1.0  bits:      YES
+f32 2.0  bits:      YES
+f32 roundtrip:      YES
+f64_be first byte:  YES
+f64_be read-back:   YES
+f64_le last byte:   YES
+f64_le read-back:   YES
+f32_le read-back:   YES

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -434,6 +434,14 @@ const char* nurl_str_float(double d) {
     return strdup(buf);
 }
 
+/* IEEE-754 bit reinterpretation (memcpy = strict-aliasing-safe, zero-alloc).
+ * Exposed to NURL via stdlib/std/floatbits.nu. f32 patterns are returned
+ * zero-extended into the low 32 bits so they serialise as a plain u32. */
+long long nurl_f64_to_bits(double x) { long long b; memcpy(&b, &x, 8); return b; }
+double    nurl_bits_to_f64(long long b) { double x; memcpy(&x, &b, 8); return x; }
+long long nurl_f32_to_bits(float x) { unsigned int b; memcpy(&b, &x, 4); return (long long)b; }
+float     nurl_bits_to_f32(long long b) { unsigned int u = (unsigned int)b; float x; memcpy(&x, &u, 4); return x; }
+
 /* Fast decimal-float parser over a byte range (no NUL needed).
  * Recognises `-?digits(.digits)?(eE[+-]?digits)?`. Returns 0.0 for
  * empty/non-numeric. No locale, no NaN/Inf — use strtod when those

--- a/stdlib/std/floatbits.nu
+++ b/stdlib/std/floatbits.nu
@@ -1,0 +1,68 @@
+// stdlib/std/floatbits.nu — IEEE-754 bit reinterpretation and binary float I/O.
+//
+// NURL's `#` cast between `i` and `f` converts the VALUE (5 → 5.0); this module
+// reinterprets the BIT PATTERN — the operation binary formats need. Backed by a
+// zero-allocation runtime bitcast (memcpy, strict-aliasing-safe), correct for
+// every pattern including NaN, ±Inf and subnormals.
+//
+// Use cases: binary serialization (msgpack / protobuf / wasm / audio sample
+// formats), hashing float data, turning a random u64 into a float, and the
+// pure-NURL wasm runtime. Note `bytes_push_float` in std/bytes.nu writes the
+// `%g` TEXT of a float; the `_f64_`/`_f32_` helpers here write the 8-/4-byte
+// IEEE-754 BINARY encoding.
+//
+//   f64_to_bits / bits_to_f64        f64 ↔ its 64-bit pattern (in an `i`)
+//   f32_to_bits / bits_to_f32        f32 ↔ its 32-bit pattern (low 32 bits)
+//   bytes_push_f64_le/_be  bytes_read_f64_le/_be → ?f
+//   bytes_push_f32_le/_be  bytes_read_f32_le/_be → ?f32
+
+$ `stdlib/std/bytes.nu`
+
+// ── runtime bitcast bridge (memcpy in runtime.c) ─────────────────
+& `c` @ nurl_f64_to_bits f x → i
+
+& `c` @ nurl_bits_to_f64 i b → f
+
+& `c` @ nurl_f32_to_bits f32 x → i
+
+& `c` @ nurl_bits_to_f32 i b → f32
+
+// ── reinterpret ──────────────────────────────────────────────────
+
+// f64 → its 64-bit IEEE-754 pattern as a (signed) i.
+@ f64_to_bits f x → i { ^ ( nurl_f64_to_bits x ) }
+
+// 64-bit pattern → the f64 it encodes.
+@ bits_to_f64 i b → f { ^ ( nurl_bits_to_f64 b ) }
+
+// f32 → its 32-bit IEEE-754 pattern, zero-extended into the low 32 bits of an i.
+@ f32_to_bits f32 x → i { ^ ( nurl_f32_to_bits x ) }
+
+// Low 32 bits of `b` → the f32 they encode.
+@ bits_to_f32 i b → f32 { ^ ( nurl_bits_to_f32 b ) }
+
+// ── binary float I/O (IEEE-754, explicit endianness) ─────────────
+
+@ bytes_push_f64_be ( Vec u ) v f x → v { ( bytes_push_u64_be v # u64 ( f64_to_bits x ) ) }
+
+@ bytes_push_f64_le ( Vec u ) v f x → v { ( bytes_push_u64_le v # u64 ( f64_to_bits x ) ) }
+
+@ bytes_push_f32_be ( Vec u ) v f32 x → v { ( bytes_push_u32_be v # u32 ( f32_to_bits x ) ) }
+
+@ bytes_push_f32_le ( Vec u ) v f32 x → v { ( bytes_push_u32_le v # u32 ( f32_to_bits x ) ) }
+
+@ bytes_read_f64_be ( Vec u ) v i off → ?f {
+    ?? ( bytes_read_u64_be v off ) { T b → @ ?f { T ( bits_to_f64 # i b ) } F → @ ?f { F 0.0 } }
+}
+
+@ bytes_read_f64_le ( Vec u ) v i off → ?f {
+    ?? ( bytes_read_u64_le v off ) { T b → @ ?f { T ( bits_to_f64 # i b ) } F → @ ?f { F 0.0 } }
+}
+
+@ bytes_read_f32_be ( Vec u ) v i off → ?f32 {
+    ?? ( bytes_read_u32_be v off ) { T b → @ ?f32 { T ( bits_to_f32 # i b ) } F → @ ?f32 { F # f32 0.0 } }
+}
+
+@ bytes_read_f32_le ( Vec u ) v i off → ?f32 {
+    ?? ( bytes_read_u32_le v off ) { T b → @ ?f32 { T ( bits_to_f32 # i b ) } F → @ ?f32 { F # f32 0.0 } }
+}


### PR DESCRIPTION
## Summary

A general-purpose stdlib layer for **reinterpreting a float's bit pattern** — the operation binary formats need, and previously **impossible in the NURL stdlib**: `#` casts a float's *value* (`5 → 5.0`), and `bytes_push_float` only writes the `%g` *text*. There was no way to read/write an IEEE-754 binary float.

This came up building the pure-NURL `wasmtime` package (its float milestone needs `f64.const` / `f64.load` / `f64.reinterpret_i64`), but the need is general — so it's done at the stdlib level, "diamond".

## What's added

- **`runtime.c`** — a zero-allocation bitcast bridge via `memcpy` (strict-aliasing-safe, correct for NaN / ±Inf / subnormals): `nurl_f64_to_bits` / `nurl_bits_to_f64`, and `f32` equivalents (the f32 pattern is zero-extended into the low 32 bits so it serialises as a plain `u32`).
- **`std/floatbits.nu`**:
  - `f64_to_bits` / `bits_to_f64`, `f32_to_bits` / `bits_to_f32`
  - explicit-endian binary I/O: `bytes_push_f64_le/_be`, `bytes_read_f64_le/_be → ?f` (and `f32` variants), built on `bytes.nu`'s `u64`/`u32` helpers

## Use cases

Binary serialization (msgpack / protobuf / wasm / audio sample formats), hashing float data, turning a random `u64` into a float, and the pure-NURL wasm runtime.

## Tests

KAT (`compiler/tests/floatbits.nu`), constants cross-checked against Python's `struct.pack`: known bit patterns (`1.0 → 0x3FF0…`, `2.0`, `0.5`, `-2.0`), **bit-exact round-trips**, arithmetic on reinterpreted values (`2.0+2.0 == 4.0` via bits), and **LE/BE binary round-trips** including byte order. f32 path verified too (f32 FFI works). **Full corpus 499 PASS.**

(Runtime change → ships in the next toolchain release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)