### PR TITLE
nurlapi: link wasm with --no-gc-sections (bug #3, missed by PR #321 merge)

### DIFF
--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -926,7 +926,15 @@ s combined_stdout s combined_stderr → v {
                                 ?? re_aud { T ra → { = uses_audio ( regex_test ra ( string_data ir_fixed ) ) ( regex_free ra ) } F _ → {} }
 
                                 : ( Vec s ) clang_args ( vec_new [s] )
-                                ( vec_push [s] clang_args `--target=wasm32-wasi` ) ( vec_push [s] clang_args opt ) ( vec_push [s] clang_args `-Wno-override-module` ) ( vec_push [s] clang_args ( string_data ll_path ) )
+                                ( vec_push [s] clang_args `--target=wasm32-wasi` ) ( vec_push [s] clang_args opt ) ( vec_push [s] clang_args `-Wno-override-module` )
+                                // Keep dead-code elimination off: NURL closures take function
+                                // addresses (→ wasm function-table indices). --gc-sections
+                                // prunes/renumbers the table so a stored call_indirect index no
+                                // longer maps to its function, trapping at scale (e.g. nurlc.wasm
+                                // compiling >150-function programs). --no-gc-sections keeps the
+                                // table stable so indices stay valid.
+                                ( vec_push [s] clang_args `-Wl,--no-gc-sections` )
+                                ( vec_push [s] clang_args ( string_data ll_path ) )
                                 ( vec_push [s] clang_args ( string_data ( get_runtime_wasm_o ) ) )
                                 ? uses_canvas { ( vec_push [s] clang_args ( string_data ( get_canvas_wasm_o ) ) ) } {}
                                 ? uses_audio { ( vec_push [s] clang_args ( string_data ( get_audio_wasm_o ) ) ) } {}


### PR DESCRIPTION
## Summary

Follow-up to #321. The `--no-gc-sections` fix (the second commit on that branch) **did not land in the #321 merge** — only the `__tok_write` token-ABI fix did. This PR carries the missing change into `main`.

### The fix
NURL closures take function addresses, which become wasm function-table indices. wasm-ld's default `--gc-sections` prunes/renumbers the table, so a `call_indirect` index stored in a closure no longer maps to its function. Small programs survive; at scale it traps — `nurlc.wasm` compiling a >150-function program hit `call_indirect: index out of range`. Linking with `-Wl,--no-gc-sections` keeps the table stable.

### Why it matters
With #321 (`__tok_write`) + this, `nurlc.wasm` compiles the **full `nurlc.nu` byte-identical to native** (`--no-borrowck`; md5-verified, 2,422,149 bytes) — i.e. the NURL compiler self-hosts on wasm.

## Test plan
```sh
# rebuild nurlc.wasm via the API, then:
wasmtime run --dir . nurlc.wasm --no-borrowck nurlc.nu | md5sum   # == native nurlc output
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSkMtPrMAgvDvpmkeAkLSN