### PR TITLE
swarm-mcp: compute_submit_kernel wraps a bare kernel

### DIFF
--- a/packages/swarm-mcp/README.md
+++ b/packages/swarm-mcp/README.md
@@ -144,25 +144,26 @@ Example (either tool): a prime-counting kernel — a real trial-division loop,
 impossible as an expression — over `[1, 1000000)` with `reduce: "sum"` returns
 `78498` = π(10⁶), sharded across the workers.
 
+With `compute_submit_kernel` the model writes **only the per-element kernel** —
+no argv reading, no loop, no print. The server generates that boilerplate
+(reading `lo`/`hi`, folding `kernel(x)` over the range with the reduce op,
+printing the partial) around it:
+
+```
+@ is_prime i n → b { /* trial division */ }
+@ kernel i x → i { ? ( is_prime x ) 1 0 }
+// submit with reduce: "sum" → counts primes in [lo, hi)
+```
+
 ```sh
-# manual CLI equivalent (a pre-compiled module):
+# manual CLI equivalent (a pre-compiled full module):
 swarm-mcp runwasm <relay-host> 47700 sum 1 1000000 prime_counter.wasm
 # → sum (wasm kernel) over [1,1000000) = 78498
 ```
 
-The kernel module is a NURL program like:
-
-```
-$ `stdlib/core/string.nu`
-@ is_prime i n → b { /* trial division */ }
-@ main → i {
-    : i lo ( nurl_str_to_int ( nurl_argv_get 1 ) )
-    : i hi ( nurl_str_to_int ( nurl_argv_get 2 ) )
-    : ~ i c 0 : ~ i x lo
-    ~ < x hi { ? ( is_prime x ) { = c + c 1 } {} = x + x 1 }
-    ( nurl_print_int c ) ^ 0
-}
-```
+`compute_run_wasm` (and the `runwasm` CLI) take a **complete** module instead,
+whose `main` reads `lo`/`hi` from argv and prints the partial itself — full
+control, for when you compiled the module yourself.
 
 ## Tests
 

--- a/packages/swarm-mcp/src/buildwasm.nu
+++ b/packages/swarm-mcp/src/buildwasm.nu
@@ -18,6 +18,51 @@ $ `stdlib/ext/http_cli.nu`
 
 @ build_api_url → String { ^ ( env_var_or `NURL_BUILD_API` `https://play.nurl-lang.org` ) }
 
+// ── kernel wrapping ──────────────────────────────────────────────
+// The caller supplies just a per-element kernel `@ kernel i x → i { … }`
+// (plus any imports/helpers). wrap_kernel generates the rest of the program:
+// a main that reads lo/hi from argv, folds `kernel(x)` over [lo, hi) with the
+// reduce op, and prints the partial — the same map-reduce shape as the
+// expression path, so the model never writes argv/loop/print boilerplate.
+
+@ __red_identity_src i op → s {
+    ? == op 1 { ^ `1` } {}  // product
+    ? == op 2 { ^ `9223372036854775807` } {}  // min → +∞
+    ? == op 3 { ^ `- 0 9223372036854775807` } {}  // max → −∞
+    ^ `0`  // sum, count
+}
+
+// acc-update for one mapped value `kv` (must match work.nu's red_fold).
+@ __red_combine_src i op → s {
+    ? == op 1 { ^ `* acc kv` } {}  // product
+    ? == op 2 { ^ `? < kv acc kv acc` } {}  // min
+    ? == op 3 { ^ `? > kv acc kv acc` } {}  // max
+    ? == op 4 { ^ `? != kv 0 + acc 1 acc` } {}  // count of truthy
+    ^ `+ acc kv`  // sum
+}
+
+// Wrap a bare kernel into a complete wasm-ready program for reduce op `op`.
+@ wrap_kernel s source i op → String {
+    : String w ( string_new )
+    // `$ `stdlib/core/string.nu`` — backticks emitted by code (can't nest in a
+    // backtick literal). nurlc dedups this if the kernel imports it too.
+    ( string_push_str w `$ ` ) ( string_push_char w 96 )
+    ( string_push_str w `stdlib/core/string.nu` ) ( string_push_char w 96 )
+    ( string_push_str w `\n` )
+    ( string_push_str w source )
+    ( string_push_str w `\n@ __swarmk_main → i {\n` )
+    ( string_push_str w `  : i argc ( nurl_argv_count )\n` )
+    ( string_push_str w `  ? < argc 3 { ^ 1 } {}\n` )
+    ( string_push_str w `  : i lo ( nurl_str_to_int ( nurl_argv_get 1 ) )\n` )
+    ( string_push_str w `  : i hi ( nurl_str_to_int ( nurl_argv_get 2 ) )\n` )
+    ( string_push_str w `  : ~ i acc ` ) ( string_push_str w ( __red_identity_src op ) ) ( string_push_str w `\n` )
+    ( string_push_str w `  : ~ i x lo\n` )
+    ( string_push_str w `  ~ < x hi { : i kv ( kernel x ) = acc ` ) ( string_push_str w ( __red_combine_src op ) ) ( string_push_str w ` = x + x 1 }\n` )
+    ( string_push_str w `  ( nurl_print_int acc )\n  ^ 0\n}\n` )
+    ( string_push_str w `@ main → i { ^ ( __swarmk_main ) }\n` )
+    ^ w
+}
+
 // wasm magic: 00 61 73 6d
 @ __is_wasm ( Vec u ) v → b {
     ? < ( vec_len [u] v ) 4 { ^ F } {}

--- a/packages/swarm-mcp/src/main.nu
+++ b/packages/swarm-mcp/src/main.nu
@@ -552,7 +552,11 @@ $ `buildwasm.nu`
     : i hi ?? hj { T v → ( json_as_int v ) F → 0 }
     : i op ?? ( json_obj_get args `reduce` ) { T v → ( reduce_op_of ( json_str_data v ) 0 ) F → 0 }
     ? >= lo hi { ^ ( mcp_tool_result_error `empty range: need lo < hi` ) } {}
-    : !( Vec u ) String cr ( compile_to_wasm source )
+    // Wrap the bare kernel (`@ kernel i x → i`) into a full program: a main that
+    // reads lo/hi from argv and folds kernel(x) over the range with the op.
+    : String wrapped ( wrap_kernel source op )
+    : !( Vec u ) String cr ( compile_to_wasm ( string_data wrapped ) )
+    ( string_free wrapped )
     ?? cr {
         F msg → {
             : String em ( string_concat ( string_from `kernel did not compile: ` ) msg )
@@ -665,7 +669,7 @@ $ `buildwasm.nu`
     : Json schema ( json_obj_new )
     ( json_obj_set schema `type` ( json_str_lit `object` ) )
     : Json props ( json_obj_new )
-    ( ms_prop props `source` `string` `A complete NURL program. Its main reads two integers lo and hi from argv (nurl_argv_get 1 / 2), folds your kernel over x in [lo, hi), and prints the partial result as a decimal integer. You may import stdlib, define helpers, loop — anything NURL can do. Example: a program whose main counts primes in [lo, hi) by trial division and prints the count. The server compiles this to wasm and runs it on the cluster.` )
+    ( ms_prop props `source` `string` `NURL source defining a per-element kernel: @ kernel i x → i { … } — it takes one integer x and returns one integer. You may also import stdlib and define helper functions; do NOT define main (the server generates it). The cluster evaluates kernel(x) for every x in [lo, hi) and folds the results with the reduce op. Example (counts primes): @ is_prime i n → b { … }  @ kernel i x → i { ? ( is_prime x ) 1 0 }. The server compiles this to wasm and runs it sharded across the workers.` )
     ( ms_prop props `lo` `integer` `Range start (inclusive).` )
     ( ms_prop props `hi` `integer` `Range end (exclusive). Must be > lo.` )
     ( ms_prop props `reduce` `string` `How to combine the per-worker partials: "sum" (default), "product", "min", "max", or "count". Must match what your main reduces with.` )
@@ -684,7 +688,7 @@ $ `buildwasm.nu`
     `Run a distributed map-reduce on the cluster: evaluate the expression kernel for every integer x in [lo, hi) and fold the results with the reduce op. Sharded across all live workers and computed in parallel. Returns a task_id immediately; poll compute_result for the value. Example: {"expr":"x*x","lo":1,"hi":1000000,"reduce":"sum"} gives the sum of squares.`
     ( ms_schema_submit ) ) )
     ( vec_push [Json] tools ( mcp_tool_descriptor `compute_submit_kernel`
-    `Run an arbitrary NURL kernel on the cluster for workloads the compute_submit expression language cannot express (loops, helper functions, anything). Provide the kernel as NURL SOURCE — a complete program whose main reads lo and hi from argv, folds the kernel over [lo, hi), and prints the partial. The server compiles it to wasm itself (via the NURL build service) and runs it sharded across the workers, combining the partials with the reduce op. Compile errors are returned to you. Returns a task_id; poll compute_result. (Use compute_run_wasm instead if you already have a compiled module.)`
+    `Run an arbitrary NURL kernel on the cluster for workloads the compute_submit expression language cannot express (loops, helper functions, anything). Provide just the per-element kernel as NURL source — @ kernel i x → i { … } plus any imports/helpers; no main needed, the server generates the argv-reading, fold, and print boilerplate. The server compiles the wrapped program to wasm itself (via the NURL build service) and runs it sharded across the workers, folding kernel(x) over [lo, hi) with the reduce op. Compile errors are returned to you. Returns a task_id; poll compute_result. (Use compute_run_wasm if you already have a compiled module.)`
     ( ms_schema_submit_kernel ) ) )
     ( vec_push [Json] tools ( mcp_tool_descriptor `compute_run_wasm`
     `Like compute_submit_kernel but you provide an already-compiled wasm32-wasi module (base64) instead of NURL source — e.g. one built with the nurl_build_wasm tool. The module's main reads lo and hi from argv, folds the kernel over [lo, hi), and prints the partial. Returns a task_id; poll compute_result.`


### PR DESCRIPTION
## Summary

Recovers an orphaned commit (`fc6d5e5`) that was pushed to this branch **after** PR #314 merged and never landed in main. It's a UX improvement to `compute_submit_kernel`.

Before (in main, from #314): the model had to supply a **complete** NURL program — its own `main` reading `lo`/`hi` from argv, looping over the range, and printing the partial.

After: the model supplies **only the per-element kernel** `@ kernel i x → i { … }` (plus any imports/helpers). The server generates the boilerplate — `wrap_kernel` emits a `main` that reads `lo`/`hi`, folds `kernel(x)` over `[lo, hi)` with the reduce op, and prints the partial. `__red_identity_src`/`__red_combine_src` produce the op-specific fold (sum/product/min/max/count), matching `work.nu`'s `red_fold`. The MCP tool description and README are updated to the no-`main` shape.

This matches the expression-kernel UX (the model never writes argv/loop/print). `compute_run_wasm` still takes a complete pre-compiled module for full control.

## Notes
- Touches only `packages/swarm-mcp/` (README, `src/buildwasm.nu`, `src/main.nu`).
- Merges cleanly onto current main (merge-base is this commit's parent, already in main; verified 0 conflicts). Does not touch the wasmtime work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSkMtPrMAgvDvpmkeAkLSN