### PR TITLE
feat(gpu): packages/gpu v0.1.0 — GPU compute for NURL (CUDA backend)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ stdlib/runtime.wasm.o.bind
 /dist/
 vendor/
 stdlib/nurl_version_gen.h
+stdlib/runtime.cuda
+stdlib/runtime.nvrtc

--- a/build.sh
+++ b/build.sh
@@ -225,6 +225,30 @@ else
     log "[info] ALSA not found — pttvoice audio I/O unavailable"
 fi
 
+# ── CUDA driver + NVRTC detection ──────────────────────────
+# packages/gpu binds the CUDA Driver API (& `cuda` @ cu…) and NVRTC
+# (& `nvrtc` @ nvrtc…) directly — NO runtime.c bridge, so a GPU-less
+# build (e.g. MILK-V Duo) never grows a CUDA dependency. Drop the
+# sentinels the nurlc FFI-lib check looks for; nurl.sh auto-links
+# -lcuda / -lnvrtc only when those symbols actually appear AND the lib
+# probes link-able. libcuda ships with the NVIDIA driver (no toolkit
+# needed); libnvrtc ships with the CUDA toolkit and is optional — a
+# program that embeds pre-compiled PTX needs only -lcuda.
+if [ -e /usr/lib/x86_64-linux-gnu/libcuda.so ] || ldconfig -p 2>/dev/null | grep -q 'libcuda\.so '; then
+    echo 1 > stdlib/runtime.cuda
+    log "[info] CUDA driver (libcuda) detected — GPU compute FFI enabled"
+else
+    rm -f stdlib/runtime.cuda
+    log "[info] CUDA driver not found — packages/gpu unavailable"
+fi
+if pkg-config --exists nvrtc 2>/dev/null || [ -e /usr/lib/x86_64-linux-gnu/libnvrtc.so ] || ldconfig -p 2>/dev/null | grep -q 'libnvrtc\.so '; then
+    echo 1 > stdlib/runtime.nvrtc
+    log "[info] NVRTC detected — runtime CUDA-C→PTX kernel compilation enabled"
+else
+    rm -f stdlib/runtime.nvrtc
+    log "[info] NVRTC not found — runtime kernel compilation unavailable (embed PTX instead)"
+fi
+
 # ── Build stages ─────────────────────────────────────────────
 # `-flto` makes runtime.o emit LLVM bitcode so vec/string/io FFI calls
 # inline across the runtime ↔ user-code boundary at link time. The

--- a/nurl.sh
+++ b/nurl.sh
@@ -336,6 +336,28 @@ if grep -qE '@snd_pcm_[A-Za-z_]+\b' "$LLFILE"; then
     fi
 fi
 
+# Auto-link the CUDA Driver API (libcuda) and NVRTC (libnvrtc) when the
+# program references their FFI symbols (packages/gpu). Linked only when
+# actually used, so a non-GPU program never grows the dependency. The
+# Driver API exports `cu<Upper>` (cuInit, cuMemAlloc, cuLaunchKernel, …);
+# NVRTC exports `nvrtc<Upper>`. libcuda ships with the NVIDIA driver and
+# normally has an unversioned .so; fall back to the .so.1 soname (the
+# driver package ships that even when the -dev symlink is absent).
+if grep -qE '@cu[A-Z][A-Za-z0-9_]*\b' "$LLFILE"; then
+    if [ -e /usr/lib/x86_64-linux-gnu/libcuda.so ] || [ -e /usr/lib/libcuda.so ]; then
+        EXTRA_LIBS="$EXTRA_LIBS -lcuda"
+    else
+        EXTRA_LIBS="$EXTRA_LIBS -l:libcuda.so.1"
+    fi
+fi
+if grep -qE '@nvrtc[A-Z][A-Za-z0-9_]*\b' "$LLFILE"; then
+    if pkg-config --exists nvrtc 2>/dev/null; then
+        EXTRA_LIBS="$EXTRA_LIBS $(pkg-config --libs nvrtc)"
+    else
+        EXTRA_LIBS="$EXTRA_LIBS -lnvrtc"
+    fi
+fi
+
 # In --debug mode, drop -flto: the LTO link pipeline strips DWARF
 # debug info from .ll input when the matching runtime.o bitcode has
 # no DI counterpart (current build.sh compiles runtime.o without -g).

--- a/packages/gpu/README.md
+++ b/packages/gpu/README.md
@@ -1,0 +1,120 @@
+# gpu — GPU compute for NURL
+
+A backend-neutral GPU compute interface for NURL. **v0.1.0 is a
+proof-of-concept** with a single backend: **CUDA**. You write a kernel in
+CUDA-C, it is compiled to PTX *at runtime* (NVRTC) and run on the device
+through the CUDA **Driver API** — all bound directly from pure NURL, with
+no C bridge in the core runtime.
+
+```
+gpu            # run the PoC demo on device 0
+gpu <ordinal>  # run on a specific device
+```
+
+```
+CUDA devices: 2
+Using device 0: NVIDIA GeForce RTX 4090
+
+[vadd] c[i] = a[i] + b[i]
+  OK — 1000000 elems, spot c[7]=21 (=3*7)
+
+[saxpy] y[i] = alpha*x[i] + y[i],  alpha=2.5
+  OK — verified vs CPU
+
+All GPU kernels verified. ✓
+```
+
+## Design — why it stays out of the core
+
+NURL's core (`runtime.c`) installs unchanged on machines with **no GPU**
+(e.g. a MILK-V Duo). So this package touches none of it:
+
+- The CUDA Driver API (`& \`cuda\``) and NVRTC (`& \`nvrtc\``) are bound
+  with **inline FFI declarations in `src/cuda.nu`** — the only file that
+  imports anything external.
+- The toolchain auto-links `-lcuda` / `-lnvrtc` **only when a program
+  actually references those symbols** (the same mechanism used for opus /
+  ALSA / SDL2). A GPU-less program never grows the dependency.
+- `libcuda` ships with the **NVIDIA driver** — no CUDA *toolkit* needed at
+  runtime. Runtime kernel compilation needs **NVRTC** (`libnvrtc`, from
+  the toolkit); a program that embeds pre-built PTX needs only the driver.
+
+The only core addition is four generic, dependency-free typed-buffer
+accessors in `runtime.c` (`nurl_peek_f32` / `nurl_poke_f32` / `_i32`) —
+4-byte-stride access to the `float32` / `int32` arrays that are the native
+GPU element layout (the stock 8-byte `nurl_peek`/`poke` can't address
+them). They ship to every target and require no GPU.
+
+## API (`src/gpu.nu`)
+
+Backend-neutral types — `Gpu`, `GpuKernel`, `GpuBuffer` — so a future
+backend (ROCm/HIP, OpenCL, a CPU fallback) slots in behind the same names.
+
+| function | purpose |
+|---|---|
+| `gpu_device_count → i` | number of CUDA devices |
+| `gpu_open i ordinal → Gpu` | init driver, bind device, create context |
+| `gpu_ok Gpu → b` / `gpu_name Gpu → s` | status / device name |
+| `gpu_compile Gpu s src s name → GpuKernel` | NVRTC compile + load `extern "C" __global__` entry |
+| `gpu_alloc Gpu i bytes → GpuBuffer` | device allocation |
+| `gpu_host_alloc i bytes → *u` | host staging buffer (+ `gpu_host_{set,get}_{f32,i32}`) |
+| `gpu_upload GpuBuffer *u host → i` | host → device |
+| `gpu_download *u host GpuBuffer → i` | device → host |
+| `gpu_arg_buffer/_i32/_i64/_f32 → i` | encode one kernel argument |
+| `gpu_launch GpuKernel i grid i block (Vec i) args → i` | 1-D launch |
+| `gpu_grid i n i block → i` | ceil-div grid size |
+| `gpu_sync Gpu → i` | block until work completes |
+| `gpu_free` / `gpu_kernel_free` / `gpu_close` | release |
+
+## Example
+
+```
+$ `gpu.nu`
+
+@ main → i {
+    : Gpu g ( gpu_open 0 )
+    : GpuKernel k ( gpu_compile g
+        `extern "C" __global__ void vadd(const float* a, const float* b, float* c, int n){
+             int i = blockIdx.x*blockDim.x + threadIdx.x; if (i<n) c[i]=a[i]+b[i]; }`
+        `vadd` )
+
+    : i n 1024
+    : i bytes * n 4
+    : *u ha ( gpu_host_alloc bytes )      // fill ha, hb with gpu_host_set_f32 ...
+    : GpuBuffer da ( gpu_alloc g bytes )
+    ( gpu_upload da ha )                   // ... db, dc likewise
+
+    : ( Vec i ) args ( vec_new [i] )
+    ( vec_push [i] args ( gpu_arg_buffer da ) )   // a, b, c, then:
+    ( vec_push [i] args ( gpu_arg_i32 n ) )
+    ( gpu_launch k ( gpu_grid n 256 ) 256 args )
+    ( gpu_sync g )
+    ( gpu_download hc dc )
+    ( gpu_close g )
+    ^ 0
+}
+```
+
+## Kernel-argument ABI
+
+`gpu_launch` takes a `Vec i` of arguments built with the `gpu_arg_*`
+encoders. Each encodes one value into an `i64` cell; `gpu_launch` builds
+the `void**` array CUDA's `cuLaunchKernel` expects, pointing each entry at
+its cell. CUDA reads `sizeof(param)` bytes, so a 4-byte `int`/`float` in
+the low bytes of an 8-byte cell is correct on little-endian. **A `float`
+scalar must go through `gpu_arg_f32`** (it stores the 32-bit IEEE-754
+pattern); passing a raw double would mis-encode it.
+
+## Requirements
+
+- NVIDIA driver (`libcuda.so`) — for any GPU work.
+- NVRTC (`libnvrtc.so`, CUDA toolkit) — for `gpu_compile`. Embed PTX to
+  avoid it.
+- Tested against CUDA 13 driver / CUDA 12 toolkit on GTX 970 + RTX 4090.
+
+## Status & roadmap
+
+v0.1.0 is a PoC: 1-D launches, synchronous execution, f32/i32/pointer
+arguments. Not yet: streams/async, multi-dimensional grids beyond x,
+shared-memory configuration, a second backend. The interface is shaped to
+add them without breaking callers.

--- a/packages/gpu/nurl.toml
+++ b/packages/gpu/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gpu"
+version = "0.1.0"
+description = "GPU compute for NURL — a backend-neutral interface (Gpu / GpuKernel / GpuBuffer: open, compile, alloc, upload/download, launch, sync) with one backend in v0.1.0: CUDA. Kernels are written in CUDA-C and compiled to PTX at runtime via NVRTC, then run on the device through the CUDA Driver API — all bound directly from pure NURL with no runtime.c bridge, so only this package pulls a GPU dependency and a GPU-less target (e.g. MILK-V Duo) is unaffected. The toolchain auto-links -lcuda / -lnvrtc only when a program references those symbols. Requires the NVIDIA driver (libcuda); runtime kernel compilation needs NVRTC (libnvrtc, CUDA toolkit) — programs that embed pre-built PTX need only the driver. v0.1.0 is a proof-of-concept: the demo runs and CPU-verifies vector-add and SAXPY (1e6 elements) on the GPU."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/gpu/src/cuda.nu
+++ b/packages/gpu/src/cuda.nu
@@ -1,0 +1,174 @@
+// packages/gpu/src/cuda.nu — the CUDA backend for packages/gpu.
+//
+// Binds the CUDA Driver API (libcuda, ships with the NVIDIA driver — no
+// toolkit needed) and NVRTC (libnvrtc, runtime CUDA-C → PTX compilation)
+// directly via NURL FFI. NO runtime.c bridge: the `& \`cuda\`` / `& \`nvrtc\``
+// symbols auto-link through nurl.sh ONLY when a program references them, so
+// a GPU-less target (e.g. MILK-V Duo) never grows a CUDA dependency.
+//
+// This file is the only place external GPU libraries are imported. The
+// neutral surface in gpu.nu delegates here; a future backend (ROCm/HIP,
+// OpenCL, a CPU fallback) would be a sibling file behind the same gpu.nu.
+//
+// Handle model: every opaque CUDA handle (CUcontext / CUmodule /
+// CUfunction) and every device address (CUdeviceptr, a u64) is carried as
+// a plain `i` (i64) in NURL and cast to `*u` at the FFI boundary. Result
+// codes (CUresult / nvrtcResult) are returned as `i`; 0 == success.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+
+// ── CUDA Driver API ───────────────────────────────────────────────
+& `cuda` @ cuInit i32 flags → i32
+& `cuda` @ cuDeviceGetCount *u count → i32
+& `cuda` @ cuDeviceGet *u device i32 ordinal → i32
+& `cuda` @ cuDeviceGetName *u name i32 len i32 dev → i32
+& `cuda` @ cuCtxCreate *u pctx i32 flags i32 dev → i32
+& `cuda` @ cuCtxDestroy *u ctx → i32
+& `cuda` @ cuCtxSynchronize → i32
+& `cuda` @ cuModuleLoadData *u module *u image → i32
+& `cuda` @ cuModuleUnload *u module → i32
+& `cuda` @ cuModuleGetFunction *u hfunc *u hmod s name → i32
+& `cuda` @ cuMemAlloc *u dptr i bytesize → i32
+& `cuda` @ cuMemFree i dptr → i32
+& `cuda` @ cuMemcpyHtoD i dst *u src i n → i32
+& `cuda` @ cuMemcpyDtoH *u dst i src i n → i32
+& `cuda` @ cuLaunchKernel *u f i32 gx i32 gy i32 gz i32 bx i32 by i32 bz i32 sh *u stream *u params *u extra → i32
+& `cuda` @ cuGetErrorName i32 err *u pstr → i32
+
+// ── NVRTC (runtime CUDA-C → PTX) ──────────────────────────────────
+& `nvrtc` @ nvrtcCreateProgram *u prog s src s name i32 nh *u headers *u incs → i32
+& `nvrtc` @ nvrtcCompileProgram *u prog i32 nopt *u opts → i32
+& `nvrtc` @ nvrtcGetPTXSize *u prog *u sz → i32
+& `nvrtc` @ nvrtcGetPTX *u prog *u ptx → i32
+& `nvrtc` @ nvrtcGetProgramLogSize *u prog *u sz → i32
+& `nvrtc` @ nvrtcGetProgramLog *u prog *u log → i32
+& `nvrtc` @ nvrtcDestroyProgram *u prog → i32
+
+// ── typed 4-byte buffer accessors (runtime.c, always linked) ──────
+// f32 / i32 arrays are the native GPU element layout; the stock 8-byte
+// nurl_peek/poke can't address them at their natural stride.
+& `c` @ nurl_peek_f32 *u base i idx → f
+& `c` @ nurl_poke_f32 *u base i idx f val → v
+& `c` @ nurl_peek_i32 *u base i idx → i
+& `c` @ nurl_poke_i32 *u base i idx i val → v
+
+// ── out-param helper ──────────────────────────────────────────────
+// Allocate a zeroed 8-byte slot for a `*` out-parameter. Zeroing matters
+// for 4-byte int out-params (cuDeviceGetCount writes only the low 4
+// bytes; malloc's upper-4 garbage would corrupt a full 8-byte read).
+@ __outslot → *u {
+    : *u p ( nurl_alloc 8 )
+    ( nurl_poke p 0 0 )
+    ^ p
+}
+
+// ── driver wrappers (return raw i64 handles / addresses) ──────────
+
+@ cuda_init → i { ^ # i ( cuInit 0 ) }
+
+@ cuda_device_count → i {
+    : *u s ( __outslot )
+    ( cuDeviceGetCount s )
+    ^ ( nurl_peek s 0 )
+}
+
+// Device ordinal → CUdevice (itself a small int handle). -1 on failure.
+@ cuda_device i ordinal → i {
+    : *u s ( __outslot )
+    ? != # i ( cuDeviceGet s # i32 ordinal ) 0 { ^ - 0 1 } {}
+    ^ ( nurl_peek s 0 )
+}
+
+// CUdevice → device name string (borrowed copy into a fresh buffer).
+@ cuda_device_name i dev → s {
+    : *u buf ( nurl_alloc 256 )
+    ( nurl_poke buf 0 0 )
+    ( cuDeviceGetName buf 256 # i32 dev )
+    ^ # s buf
+}
+
+// Create a context on a CUdevice → CUcontext handle (0 on failure).
+@ cuda_ctx_create i dev → i {
+    : *u s ( __outslot )
+    ? != # i ( cuCtxCreate s 0 # i32 dev ) 0 { ^ 0 } {}
+    ^ ( nurl_peek s 0 )
+}
+
+@ cuda_ctx_destroy i ctx → i { ^ # i ( cuCtxDestroy # *u ctx ) }
+
+@ cuda_sync → i { ^ # i ( cuCtxSynchronize ) }
+
+// ── NVRTC: compile CUDA-C source → PTX text buffer ────────────────
+// Returns a NUL-terminated PTX buffer (caller passes to cuda_module_load),
+// or 0 on a compile error after printing the NVRTC log to stderr.
+@ cuda_compile s src s name → *u {
+    : *u ps ( __outslot )
+    ? != # i ( nvrtcCreateProgram ps src name 0 0 0 ) 0 {
+        ( nurl_eprint `[gpu/cuda] nvrtcCreateProgram failed\n` )
+        ^ # *u 0
+    } {}
+    : *u prog # *u ( nurl_peek ps 0 )
+    : i cr # i ( nvrtcCompileProgram prog 0 0 )
+    ? != cr 0 {
+        : *u ls ( __outslot )
+        ( nvrtcGetProgramLogSize prog ls )
+        : i lsz ( nurl_peek ls 0 )
+        : *u log ( nurl_alloc + lsz 1 )
+        ( nvrtcGetProgramLog prog log )
+        ( nurl_eprint `[gpu/cuda] kernel compile failed:\n` )
+        ( nurl_eprint # s log )
+        ( nurl_eprint `\n` )
+        ( nvrtcDestroyProgram ps )
+        ^ # *u 0
+    } {}
+    : *u szs ( __outslot )
+    ( nvrtcGetPTXSize prog szs )
+    : i psz ( nurl_peek szs 0 )
+    : *u ptx ( nurl_alloc + psz 1 )
+    ( nvrtcGetPTX prog ptx )
+    ( nvrtcDestroyProgram ps )
+    ^ ptx
+}
+
+// ── module / function ─────────────────────────────────────────────
+@ cuda_module_load *u ptx → i {
+    : *u s ( __outslot )
+    ? != # i ( cuModuleLoadData s ptx ) 0 { ^ 0 } {}
+    ^ ( nurl_peek s 0 )
+}
+
+@ cuda_module_unload i module → i { ^ # i ( cuModuleUnload # *u module ) }
+
+@ cuda_function i module s name → i {
+    : *u s ( __outslot )
+    ? != # i ( cuModuleGetFunction s # *u module name ) 0 { ^ 0 } {}
+    ^ ( nurl_peek s 0 )
+}
+
+// ── device memory ─────────────────────────────────────────────────
+@ cuda_malloc i bytes → i {
+    : *u s ( __outslot )
+    ? != # i ( cuMemAlloc s bytes ) 0 { ^ 0 } {}
+    ^ ( nurl_peek s 0 )
+}
+
+@ cuda_free i dptr → i { ^ # i ( cuMemFree dptr ) }
+
+@ cuda_htod i dptr *u host i bytes → i { ^ # i ( cuMemcpyHtoD dptr host bytes ) }
+
+@ cuda_dtoh *u host i dptr i bytes → i { ^ # i ( cuMemcpyDtoH host dptr bytes ) }
+
+// ── launch ────────────────────────────────────────────────────────
+// `params` is a void** array of pointers to the argument values (built
+// by gpu.nu from a Vec of i64-encoded args). 1-D grid/block for now.
+@ cuda_launch i func i grid i block *u params → i {
+    ^ # i ( cuLaunchKernel # *u func # i32 grid 1 1 # i32 block 1 1 0 0 params 0 )
+}
+
+// CUresult code → driver error-name string (e.g. "CUDA_ERROR_INVALID_VALUE").
+@ cuda_error_name i code → s {
+    : *u s ( __outslot )
+    ? != # i ( cuGetErrorName # i32 code s ) 0 { ^ `CUDA_ERROR_UNKNOWN` } {}
+    ^ # s ( nurl_peek s 0 )
+}

--- a/packages/gpu/src/gpu.nu
+++ b/packages/gpu/src/gpu.nu
@@ -1,0 +1,137 @@
+// packages/gpu/src/gpu.nu — backend-neutral GPU compute interface.
+//
+// v0.1.0 ships ONE backend: CUDA (src/cuda.nu). This file is the surface
+// a program codes against — Gpu / GpuKernel / GpuBuffer plus open / compile
+// / alloc / upload / download / launch / sync. The CUDA specifics (driver
+// handles, NVRTC, the void** kernel-param ABI) stay in cuda.nu so a second
+// backend (ROCm/HIP, OpenCL, a CPU fallback) can slot in behind the same
+// names without touching callers.
+//
+// Handles are small value structs (by-value is fine — they wrap opaque
+// i64 device handles, no owned NURL heap state). Kernel arguments are
+// passed as a `Vec i` of i64-encoded values built with the gpu_arg_*
+// encoders; gpu_launch lays them out as the void** array CUDA expects.
+
+$ `stdlib/core/vec.nu`
+$ `cuda.nu`
+
+// f32 → its 32-bit IEEE-754 bit pattern (for scalar kernel args).
+// The C param is `float`, so it must be declared `f32` (not `f`/double)
+// or the double NURL passes lands in the register wrong (alpha → 0).
+& `c` @ nurl_f32_to_bits f32 x → i
+
+// ── handle types ──────────────────────────────────────────────────
+: Gpu { i ordinal  i dev  i ctx }       // an initialised device + context
+: GpuKernel { i module  i func }         // a compiled, loaded __global__ fn
+: GpuBuffer { i dptr  i bytes }          // a device-memory allocation
+
+// ── device lifecycle ──────────────────────────────────────────────
+
+// Number of CUDA-capable devices visible to the process.
+@ gpu_device_count → i {
+    ( cuda_init )
+    ^ ( cuda_device_count )
+}
+
+// Initialise the driver, bind device `ordinal`, and create a context.
+// Returns a Gpu with ctx == 0 on failure.
+@ gpu_open i ordinal → Gpu {
+    ( cuda_init )
+    : i dev ( cuda_device ordinal )
+    ? < dev 0 { ^ @ Gpu { ordinal - 0 1 0 } } {}
+    : i ctx ( cuda_ctx_create dev )
+    ^ @ Gpu { ordinal dev ctx }
+}
+
+@ gpu_ok Gpu g → b { ^ != . g ctx 0 }
+
+// Human-readable device name (e.g. "NVIDIA GeForce RTX 4090").
+@ gpu_name Gpu g → s { ^ ( cuda_device_name . g dev ) }
+
+@ gpu_close Gpu g → v { ( cuda_ctx_destroy . g ctx ) }
+
+// Block until all submitted work on the context completes. 0 == success.
+@ gpu_sync Gpu g → i { ^ ( cuda_sync ) }
+
+// ── kernels ───────────────────────────────────────────────────────
+
+// Compile CUDA-C `src` at runtime (NVRTC) and load entry point `name`.
+// The kernel must be declared `extern "C" __global__`. Returns a
+// GpuKernel with func == 0 on a compile/load error (log on stderr).
+@ gpu_compile Gpu g s src s name → GpuKernel {
+    : *u ptx ( cuda_compile src name )
+    ? == # i ptx 0 { ^ @ GpuKernel { 0 0 } } {}
+    : i mod ( cuda_module_load ptx )
+    ( nurl_free ptx )   // the module keeps its own copy of the PTX
+    ? == mod 0 { ^ @ GpuKernel { 0 0 } } {}
+    : i fn ( cuda_function mod name )
+    ^ @ GpuKernel { mod fn }
+}
+
+@ gpu_kernel_ok GpuKernel k → b { ^ != . k func 0 }
+
+@ gpu_kernel_free GpuKernel k → v { ( cuda_module_unload . k module ) }
+
+// ── host (pinned-free) staging buffers ────────────────────────────
+// Plain host memory to stage data for upload / receive on download.
+// f32 is the GPU-native element type; these address it at 4-byte stride.
+
+@ gpu_host_alloc i bytes → *u { ^ ( nurl_alloc bytes ) }
+@ gpu_host_free *u buf → v { ( nurl_free buf ) }
+@ gpu_host_set_f32 *u buf i idx f v → v { ( nurl_poke_f32 buf idx v ) }
+@ gpu_host_get_f32 *u buf i idx → f { ^ ( nurl_peek_f32 buf idx ) }
+@ gpu_host_set_i32 *u buf i idx i v → v { ( nurl_poke_i32 buf idx v ) }
+@ gpu_host_get_i32 *u buf i idx → i { ^ ( nurl_peek_i32 buf idx ) }
+
+// ── device memory ─────────────────────────────────────────────────
+
+@ gpu_alloc Gpu g i bytes → GpuBuffer {
+    : i dptr ( cuda_malloc bytes )
+    ^ @ GpuBuffer { dptr bytes }
+}
+
+@ gpu_free GpuBuffer b → v { ( cuda_free . b dptr ) }
+
+// Copy the buffer's worth of bytes host → device. 0 == success.
+@ gpu_upload GpuBuffer dst *u host → i {
+    ^ ( cuda_htod . dst dptr host . dst bytes )
+}
+
+// Copy the buffer's worth of bytes device → host. 0 == success.
+@ gpu_download *u host GpuBuffer src → i {
+    ^ ( cuda_dtoh host . src dptr . src bytes )
+}
+
+// ── kernel arguments ──────────────────────────────────────────────
+// Each gpu_arg_* encodes one argument as an i64 cell. gpu_launch points
+// a void** entry at each cell; CUDA reads sizeof(param) bytes from it, so
+// a 4-byte int/float occupying the low bytes of an 8-byte cell is correct
+// on little-endian.
+
+@ gpu_arg_buffer GpuBuffer b → i { ^ . b dptr }   // device pointer
+@ gpu_arg_i32 i v → i { ^ v }                          // 32-bit int scalar
+@ gpu_arg_i64 i v → i { ^ v }                          // 64-bit int scalar
+@ gpu_arg_f32 f v → i { ^ ( nurl_f32_to_bits # f32 v ) }  // 32-bit float scalar
+
+// ── launch ────────────────────────────────────────────────────────
+// 1-D launch: `grid` blocks of `block` threads. `args` is the Vec built
+// from gpu_arg_*; its contiguous i64 backing IS the argument-value array,
+// so we only build the pointer (void**) layer over it. 0 == success.
+@ gpu_launch GpuKernel k i grid i block ( Vec i ) args → i {
+    : i n ( vec_len [i] args )
+    : i vbase # i ( vec_data [i] args )
+    : *u params ( nurl_alloc * n 8 )
+    : ~ i idx 0
+    ~ < idx n {
+        ( nurl_poke params idx + vbase * idx 8 )
+        = idx + idx 1
+    }
+    // cuLaunchKernel copies the argument values during the call, so the
+    // void** layer is safe to reclaim as soon as it returns.
+    : i r ( cuda_launch . k func grid block params )
+    ( nurl_free params )
+    ^ r
+}
+
+// Convenience: ceil-divide for picking a grid size from N and block size.
+@ gpu_grid i n i block → i { ^ / + n - block 1 block }

--- a/packages/gpu/src/main.nu
+++ b/packages/gpu/src/main.nu
@@ -1,0 +1,190 @@
+// packages/gpu/src/main.nu — packages/gpu PoC demo.
+//
+// Proves GPU compute works from pure NURL: it lists the CUDA devices,
+// compiles two CUDA-C kernels at runtime (NVRTC), runs them on the GPU
+// over the neutral gpu.nu interface, and verifies the results against a
+// CPU reference. No CUDA toolkit calls in the program — just gpu.nu.
+//
+//   gpu            # run the demo on device 0
+//   gpu <ordinal>  # run on a specific device
+//
+// Build:  nurlpkg install gpu   (or ./nurl.sh packages/gpu/src/main.nu)
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/core/vec.nu`
+$ `gpu.nu`
+
+// ── kernels (CUDA-C, compiled at runtime) ─────────────────────────
+@ k_vadd → s {
+    ^ `extern "C" __global__ void vadd(const float* a, const float* b, float* c, int n){
+        int i = blockIdx.x*blockDim.x + threadIdx.x;
+        if (i < n) c[i] = a[i] + b[i];
+    }`
+}
+
+@ k_saxpy → s {
+    ^ `extern "C" __global__ void saxpy(float alpha, const float* x, float* y, int n){
+        int i = blockIdx.x*blockDim.x + threadIdx.x;
+        if (i < n) y[i] = alpha*x[i] + y[i];
+    }`
+}
+
+// ── helpers ───────────────────────────────────────────────────────
+@ approx f a f b → b {
+    : ~ f d - a b
+    ? < d 0.0 { = d - 0.0 d } {}
+    ^ < d 0.001
+}
+
+@ say s msg → v { ( nurl_print msg ) ( nurl_print `\n` ) }
+
+// ── demo: vector add  c = a + b ───────────────────────────────────
+@ demo_vadd Gpu g i n → i {
+    ( say `\n[vadd] c[i] = a[i] + b[i]` )
+    : GpuKernel k ( gpu_compile g ( k_vadd ) `vadd` )
+    ? ! ( gpu_kernel_ok k ) { ( say `  compile FAILED` ) ^ 1 } {}
+
+    : i bytes * n 4
+    : *u ha ( gpu_host_alloc bytes )
+    : *u hb ( gpu_host_alloc bytes )
+    : *u hc ( gpu_host_alloc bytes )
+    : ~ i i 0
+    ~ < i n {
+        ( gpu_host_set_f32 ha i # f i )
+        ( gpu_host_set_f32 hb i # f * 2 i )
+        = i + i 1
+    }
+
+    : GpuBuffer da ( gpu_alloc g bytes )
+    : GpuBuffer db ( gpu_alloc g bytes )
+    : GpuBuffer dc ( gpu_alloc g bytes )
+    ( gpu_upload da ha )
+    ( gpu_upload db hb )
+
+    : ( Vec i ) args ( vec_new [i] )
+    ( vec_push [i] args ( gpu_arg_buffer da ) )
+    ( vec_push [i] args ( gpu_arg_buffer db ) )
+    ( vec_push [i] args ( gpu_arg_buffer dc ) )
+    ( vec_push [i] args ( gpu_arg_i32 n ) )
+
+    : i block 256
+    : i r ( gpu_launch k ( gpu_grid n block ) block args )
+    ? != r 0 { ( say `  launch FAILED` ) ^ 1 } {}
+    ( gpu_sync g )
+    ( gpu_download hc dc )
+
+    : ~ i bad 0
+    : ~ i j 0
+    ~ < j n {
+        ? ! ( approx ( gpu_host_get_f32 hc j ) # f * 3 j ) { = bad + bad 1 } {}
+        = j + j 1
+    }
+    : i c7 # i ( gpu_host_get_f32 hc 7 )
+    ( gpu_free da ) ( gpu_free db ) ( gpu_free dc )
+    ( gpu_host_free ha ) ( gpu_host_free hb ) ( gpu_host_free hc )
+    ( gpu_kernel_free k )
+
+    ? == bad 0 {
+        ( nurl_print `  OK — ` ) ( nurl_print ( nurl_str_int n ) )
+        ( nurl_print ` elems, spot c[7]=` )
+        ( nurl_print ( nurl_str_int c7 ) ) ( nurl_print ` (=3*7)\n` )
+        ^ 0
+    } {
+        ( nurl_print `  MISMATCH: ` ) ( nurl_print ( nurl_str_int bad ) ) ( nurl_print ` wrong\n` )
+        ^ 1
+    }
+}
+
+// ── demo: SAXPY  y = alpha*x + y  (scalar float + int args) ───────
+@ demo_saxpy Gpu g i n → i {
+    ( say `\n[saxpy] y[i] = alpha*x[i] + y[i],  alpha=2.5` )
+    : GpuKernel k ( gpu_compile g ( k_saxpy ) `saxpy` )
+    ? ! ( gpu_kernel_ok k ) { ( say `  compile FAILED` ) ^ 1 } {}
+
+    : f alpha 2.5
+    : i bytes * n 4
+    : *u hx ( gpu_host_alloc bytes )
+    : *u hy ( gpu_host_alloc bytes )
+    : ~ i i 0
+    ~ < i n {
+        ( gpu_host_set_f32 hx i # f i )
+        ( gpu_host_set_f32 hy i 1.0 )
+        = i + i 1
+    }
+
+    : GpuBuffer dx ( gpu_alloc g bytes )
+    : GpuBuffer dy ( gpu_alloc g bytes )
+    ( gpu_upload dx hx )
+    ( gpu_upload dy hy )
+
+    : ( Vec i ) args ( vec_new [i] )
+    ( vec_push [i] args ( gpu_arg_f32 alpha ) )
+    ( vec_push [i] args ( gpu_arg_buffer dx ) )
+    ( vec_push [i] args ( gpu_arg_buffer dy ) )
+    ( vec_push [i] args ( gpu_arg_i32 n ) )
+
+    : i block 256
+    : i r ( gpu_launch k ( gpu_grid n block ) block args )
+    ? != r 0 { ( say `  launch FAILED` ) ^ 1 } {}
+    ( gpu_sync g )
+    ( gpu_download hy dy )
+
+    : ~ i bad 0
+    : ~ i j 0
+    ~ < j n {
+        : f want + * alpha # f j 1.0
+        ? ! ( approx ( gpu_host_get_f32 hy j ) want ) { = bad + bad 1 } {}
+        = j + j 1
+    }
+    ( gpu_free dx ) ( gpu_free dy )
+    ( gpu_host_free hx ) ( gpu_host_free hy )
+    ( gpu_kernel_free k )
+
+    ? == bad 0 {
+        ( say `  OK — verified vs CPU` )
+        ^ 0
+    } {
+        ( nurl_print `  MISMATCH: ` ) ( nurl_print ( nurl_str_int bad ) ) ( nurl_print ` wrong\n` )
+        ^ 1
+    }
+}
+
+@ main → i {
+    : ~ i ordinal 0
+    ? > ( env_args_count ) 1 {
+        : ( Vec String ) av ( env_args_list )
+        ?? ( vec_get [String] av 1 )
+        { T a → = ordinal ( nurl_str_to_int ( string_data a ) ) F _ → {} }
+    } {}
+
+    : i count ( gpu_device_count )
+    ? <= count 0 {
+        ( say `No CUDA devices found (is the NVIDIA driver loaded?).` )
+        ^ 1
+    } {}
+    ( nurl_print `CUDA devices: ` ) ( nurl_print ( nurl_str_int count ) ) ( nurl_print `\n` )
+
+    : Gpu g ( gpu_open ordinal )
+    ? ! ( gpu_ok g ) {
+        ( nurl_print `Failed to open device ` ) ( nurl_print ( nurl_str_int ordinal ) ) ( nurl_print `\n` )
+        ^ 1
+    } {}
+    ( nurl_print `Using device ` ) ( nurl_print ( nurl_str_int ordinal ) )
+    ( nurl_print `: ` ) ( nurl_print ( gpu_name g ) ) ( nurl_print `\n` )
+
+    : i n 1000000
+    : ~ i fails 0
+    = fails + fails ( demo_vadd g n )
+    = fails + fails ( demo_saxpy g n )
+
+    ( gpu_close g )
+    ? == fails 0 {
+        ( say `\nAll GPU kernels verified. ✓` )
+        ^ 0
+    } {
+        ( say `\nSome kernels failed. ✗` )
+        ^ 1
+    }
+}

--- a/packages/gpu/tests/gpu_test.nu
+++ b/packages/gpu/tests/gpu_test.nu
@@ -1,0 +1,96 @@
+// packages/gpu/tests/gpu_test.nu — tests for packages/gpu.
+//
+// Pure-CPU assertions always run (arg encoding, grid math). The on-device
+// section runs a real vector-add and verifies it — but SKIPS cleanly
+// (still exit 0) when no CUDA device is present, so the suite passes on a
+// GPU-less CI box. Run from the package root:
+//   NURL_STDLIB=<repo> ../../nurl.sh tests/gpu_test.nu /tmp/gt && /tmp/gt
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `src/gpu.nu`
+
+& `c` @ nurl_bits_to_f32 i b → f32
+
+: ~ i g_fail 0
+
+@ check b cond s name → v {
+    ? cond { ( nurl_print `  ok  ` ) } { ( nurl_print `  FAIL ` ) = g_fail + g_fail 1 }
+    ( nurl_print name ) ( nurl_print `\n` )
+}
+
+// ── pure-CPU: argument encoding round-trips ──────────────────────
+@ test_args → v {
+    ( nurl_print `[args]\n` )
+    // f32 encoder must reproduce the IEEE-754 bit pattern of 2.5f.
+    : i bits ( gpu_arg_f32 2.5 )
+    : f back # f ( nurl_bits_to_f32 bits )
+    ( check & > back 2.49 < back 2.51 `f32 arg round-trips 2.5` )
+    // int encoders are identity.
+    ( check == ( gpu_arg_i32 42 ) 42 `i32 arg is identity` )
+    // grid: ceil-div.
+    ( check == ( gpu_grid 1000 256 ) 4 `grid(1000,256)=4` )
+    ( check == ( gpu_grid 1024 256 ) 4 `grid(1024,256)=4` )
+    ( check == ( gpu_grid 1025 256 ) 5 `grid(1025,256)=5` )
+}
+
+// ── on-device: real vector add ───────────────────────────────────
+@ test_device → v {
+    ( nurl_print `[device]\n` )
+    : i count ( gpu_device_count )
+    ? <= count 0 {
+        ( nurl_print `  skip (no CUDA device)\n` )
+        ^ {}
+    } {}
+
+    : Gpu g ( gpu_open 0 )
+    ? ! ( gpu_ok g ) { ( check F `open device 0` ) ^ {} } {}
+
+    : i n 4096
+    : GpuKernel k ( gpu_compile g `extern "C" __global__ void vadd(const float* a, const float* b, float* c, int n){ int i=blockIdx.x*blockDim.x+threadIdx.x; if(i<n) c[i]=a[i]+b[i]; }` `vadd` )
+    ? ! ( gpu_kernel_ok k ) { ( check F `compile vadd` ) ( gpu_close g ) ^ {} } {}
+
+    : i bytes * n 4
+    : *u ha ( gpu_host_alloc bytes )
+    : *u hb ( gpu_host_alloc bytes )
+    : *u hc ( gpu_host_alloc bytes )
+    : ~ i i 0
+    ~ < i n { ( gpu_host_set_f32 ha i # f i ) ( gpu_host_set_f32 hb i # f * 10 i ) = i + i 1 }
+
+    : GpuBuffer da ( gpu_alloc g bytes )
+    : GpuBuffer db ( gpu_alloc g bytes )
+    : GpuBuffer dc ( gpu_alloc g bytes )
+    ( gpu_upload da ha )
+    ( gpu_upload db hb )
+
+    : ( Vec i ) args ( vec_new [i] )
+    ( vec_push [i] args ( gpu_arg_buffer da ) )
+    ( vec_push [i] args ( gpu_arg_buffer db ) )
+    ( vec_push [i] args ( gpu_arg_buffer dc ) )
+    ( vec_push [i] args ( gpu_arg_i32 n ) )
+    ( gpu_launch k ( gpu_grid n 256 ) 256 args )
+    ( gpu_sync g )
+    ( gpu_download hc dc )
+
+    : ~ i bad 0
+    : ~ i j 0
+    ~ < j n {
+        : ~ f d - ( gpu_host_get_f32 hc j ) # f * 11 j
+        ? < d 0.0 { = d - 0.0 d } {}
+        ? > d 0.001 { = bad + bad 1 } {}
+        = j + j 1
+    }
+    ( check == bad 0 `vadd 4096 elems == 11*i` )
+
+    ( gpu_free da ) ( gpu_free db ) ( gpu_free dc )
+    ( gpu_host_free ha ) ( gpu_host_free hb ) ( gpu_host_free hc )
+    ( gpu_kernel_free k )
+    ( gpu_close g )
+}
+
+@ main → i {
+    ( test_args )
+    ( test_device )
+    ? == g_fail 0 { ( nurl_print `\nALL PASS\n` ) ^ 0 }
+    { ( nurl_print `\n` ) ( nurl_print ( nurl_str_int g_fail ) ) ( nurl_print ` FAILED\n` ) ^ 1 }
+}

--- a/stdlib/runtime.c
+++ b/stdlib/runtime.c
@@ -795,6 +795,30 @@ void nurl_poke(void *base, long long idx, long long val) {
     ((long long*)base)[(size_t)idx] = val;
 }
 
+/* 4-byte-stride typed accessors for packed binary buffers (e.g. the
+ * float32 / int32 arrays that GPU kernels, image data, and wire formats
+ * use). The 8-byte nurl_peek/poke above can't address a 4-byte array at
+ * its natural stride; these can. Pure, dependency-free — they ship to
+ * every target (no GPU required). i32 reads sign-extend; f32 round-trips
+ * through the platform float so NURL's `f` (double) sees the widened
+ * value and stores narrow it back. NULL base is a safe no-op / 0. */
+int  nurl_peek_i32(const void *base, long long idx) {
+    if (!base) return 0;
+    return ((const int*)base)[(size_t)idx];
+}
+void nurl_poke_i32(void *base, long long idx, int val) {
+    if (!base) return;
+    ((int*)base)[(size_t)idx] = val;
+}
+double nurl_peek_f32(const void *base, long long idx) {
+    if (!base) return 0.0;
+    return (double)((const float*)base)[(size_t)idx];
+}
+void nurl_poke_f32(void *base, long long idx, double val) {
+    if (!base) return;
+    ((float*)base)[(size_t)idx] = (float)val;
+}
+
 /* Recursively reclaim a Vec/String backing store. `ctl` is the Vec
  * control block (slot 0 = data ptr, slot 1 = len, slot 2 = cap). When
  * `elem_drop` is non-NULL it is invoked on a POINTER to each live


### PR DESCRIPTION
## Summary

GPU support for NURL. `packages/gpu` is a **backend-neutral GPU compute interface** (`Gpu` / `GpuKernel` / `GpuBuffer`: open · compile · alloc · upload/download · launch · sync) with one backend in v0.1.0: **CUDA**. You write a kernel in CUDA-C; it is compiled to PTX **at runtime via NVRTC** and run on the device through the CUDA **Driver API** — all bound from pure NURL, with no bridge in the core runtime. A future backend (ROCm/HIP, OpenCL, a CPU fallback) slots in behind the same names.

**Verified live** on RTX 4090 + GTX 970: vector-add and SAXPY over 1e6 f32 elements, CPU-checked, exit 0. Tests pass and skip cleanly on GPU-less boxes.

```
CUDA devices: 2
Using device 0: NVIDIA GeForce RTX 4090

[vadd] c[i] = a[i] + b[i]
  OK — 1000000 elems, spot c[7]=21 (=3*7)

[saxpy] y[i] = alpha*x[i] + y[i],  alpha=2.5
  OK — verified vs CPU

All GPU kernels verified. ✓
```

## Keeping the core pure

`runtime.c` installs unchanged on machines with **no GPU** (e.g. a MILK-V Duo), so this PR keeps GPU concerns out of it:

- **External GPU libs are imported only in `packages/gpu/src/cuda.nu`** — inline FFI (`& \`cuda\``, `& \`nvrtc\``), no `runtime.c` bridge.
- **`build.sh`** detects `libcuda` / `libnvrtc` and drops `stdlib/runtime.{cuda,nvrtc}` sentinels (gitignored build artifacts; the nurlc FFI-lib check requires them). Same shape as the existing opus/ALSA detection.
- **`nurl.sh`** auto-links `-lcuda` / `-lnvrtc` **only when a program references `cu*` / `nvrtc*` symbols** — so a non-GPU program never grows the dependency.
- `libcuda` ships with the **NVIDIA driver** (no CUDA toolkit needed at runtime). NVRTC (`libnvrtc`, toolkit) is needed only for `gpu_compile`; embed pre-built PTX to avoid it.

The only core addition is **four generic, dependency-free typed-buffer accessors** in `runtime.c` — `nurl_peek_f32` / `nurl_poke_f32` / `_i32` — for 4-byte-stride access to the `float32` / `int32` arrays that are the native GPU element layout (the stock 8-byte `nurl_peek`/`poke` can't address them). They ship to every target and require no GPU.

## Contents

- `packages/gpu/src/cuda.nu` — CUDA Driver API + NVRTC FFI bindings (the only file importing external GPU libs).
- `packages/gpu/src/gpu.nu` — backend-neutral surface + `gpu_arg_*` encoders + host staging helpers.
- `packages/gpu/src/main.nu` — PoC demo (vadd + SAXPY, CPU-verified).
- `packages/gpu/tests/gpu_test.nu` — CPU-side assertions (always) + on-device vadd (skips with no GPU).
- `packages/gpu/{nurl.toml,README.md}`.

## Test plan

- [x] `./build.sh` passes (exit 0) with the new `runtime.c`; CUDA/NVRTC detected, sentinels created, `nurlc` rebuilt.
- [x] Demo runs and CPU-verifies vadd + SAXPY (1e6 f32) on both GPUs.
- [x] `tests/gpu_test.nu` — ALL PASS (arg-encoding round-trips, grid math, real on-device vadd).
- [x] No compiler changes needed; the borrow checker caught a real use-after-free during development.

## Notes

v0.1.0 is a PoC: 1-D launches, synchronous execution, f32/i32/pointer args. Not yet: streams/async, multi-dimensional grids, shared memory, a second backend — the interface is shaped to add them without breaking callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)