### PR TITLE
fix(nurlpkg): resolve { path, version } hybrid deps transitively

### DIFF
--- a/stdlib/ext/manifest.nu
+++ b/stdlib/ext/manifest.nu
@@ -96,6 +96,16 @@ $ `stdlib/ext/toml.nu`
     ^ == ( string_len . d path ) 0
 }
 
+// A dependency carries a registry version requirement. Cargo-style
+// `{ path = "...", version = "..." }` hybrids set BOTH: `path` is a
+// local-development override, `version` is the requirement used when the
+// package is published or installed from the registry (i.e. when the
+// local path is unavailable). Such hybrids are `dep_is_path` (a path is
+// set) yet still registry-publishable / registry-resolvable.
+@ dep_has_version Dep d → b {
+    ^ > ( string_len . d version ) 0
+}
+
 @ manifest_free Manifest m → v {
     ( string_free . m name )
     ( string_free . m version )

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -93,22 +93,69 @@ $ `stdlib/std/bytes.nu`
     ^ ( creds_get registry )
 }
 
-@ __count_registry ( Vec Dep ) deps → i {
-    : i n ( vec_len [Dep] deps )
-    : ~ i c 0
+// Free a Dep vector built by __registry_roots (each Dep + the vector).
+@ __deps_free_vec ( Vec Dep ) v → v {
+    : i n ( vec_len [Dep] v )
     : ~ i k 0
     ~ < k n {
-        : ?Dep dk ( vec_get [Dep] deps k )
-        ?? dk { T d → { ? ( dep_is_registry d ) { = c + c 1 } {} } F → {} }
+        : ?Dep dk ( vec_get [Dep] v k )
+        ?? dk { T d → ( dep_free d ) F _ → {} }
         = k + k 1
     }
-    ^ c
+    ( vec_free [Dep] v )
+}
+
+// Dependencies that must be resolved from the registry at install time:
+//   * pure registry deps (no path), and
+//   * `{ path, version }` hybrids whose local path target is ABSENT — e.g.
+//     a registry install (`nurlpkg install <name>`) extracts the package
+//     into a temp dir where the sibling `../onnx` path doesn't exist, so
+//     the dep falls back to its registry `version`.
+// Hybrids whose path IS present on disk are left to the path-dep BFS and
+// excluded here (no double install). Returned hybrids have their `path`
+// cleared so `resolve_registry` seeds them as registry roots. Caller owns
+// the returned vector (free each Dep).
+@ __registry_roots Manifest m s cwd → ( Vec Dep ) {
+    : ( Vec Dep ) out ( vec_new [Dep] )
+    : i n ( vec_len [Dep] . m dependencies )
+    : ~ i k 0
+    ~ < k n {
+        : ?Dep dk ( vec_get [Dep] . m dependencies k )
+        ?? dk {
+            T d → {
+                : ~ b take F
+                : ~ b clearpath F
+                ? ( dep_is_registry d ) { = take T } {
+                    ? ( dep_has_version d ) {
+                        : String tgt ( __abs_join cwd ( string_data . d path ) )
+                        ? ! ( __dep_has_manifest ( string_data tgt ) ) { = take T = clearpath T } {}
+                        ( string_free tgt )
+                    } {}
+                }
+                ? take {
+                    : String p ? clearpath ( string_new ) ( string_from ( string_data . d path ) )
+                    ( vec_push [Dep] out @ Dep {
+                        ( string_from ( string_data . d name ) )
+                        p
+                        ( string_from ( string_data . d version ) )
+                        ( string_from ( string_data . d registry ) )
+                    } )
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ out
 }
 
 // Build the X-Nurl-Deps JSON array of { name, req } from a manifest's
-// REGISTRY dependencies (path deps are local and not part of the published
-// package's index entry). Names/reqs are simple tokens (no JSON-special
-// chars), so a direct build is safe. Empty deps → "[]".
+// dependencies that carry a registry version requirement. A Cargo-style
+// `{ path = "...", version = "..." }` hybrid IS published (its `version`
+// is the requirement a downstream consumer resolves from the registry —
+// the `path` is only a local-dev override). Pure path deps (no version)
+// are local-only and excluded. Names/reqs are simple tokens (no
+// JSON-special chars), so a direct build is safe. Empty deps → "[]".
 @ __deps_json Manifest m → String {
     : String out ( string_with_cap 64 )
     ( string_push_char out 91 )  // [
@@ -119,7 +166,7 @@ $ `stdlib/std/bytes.nu`
         : ?Dep dk ( vec_get [Dep] . m dependencies k )
         ?? dk {
             T d → {
-                ? ( dep_is_registry d ) {
+                ? ( dep_has_version d ) {
                     ? == first 0 { ( string_push_char out 44 ) } {}  // ,
                     = first 0
                     ( string_push_str out `{"name":"` )
@@ -717,6 +764,15 @@ $ `stdlib/std/bytes.nu`
         ^ 0
     } {}
     ? ! ( __dep_has_manifest target_s ) {
+        // Local path absent. If the dep also carries a registry version
+        // (`{ path, version }` hybrid), the registry pass will fetch it —
+        // not an error. Otherwise it's a genuinely missing local dep.
+        ? ( dep_has_version d ) {
+            ( nurl_print `  ` ) ( nurl_print name )
+            ( nurl_print ` (local path absent; resolving from registry)\n` )
+            ( string_free target )
+            ^ 0
+        } {}
         ( nurl_eprint `  ` )
         ( nurl_eprint name )
         ( nurl_eprint `: skip (no nurl.toml at ` )
@@ -1191,15 +1247,19 @@ $ `stdlib/std/bytes.nu`
 // `out` for each SUCCESSFULLY installed package, so the lockfile reflects
 // exactly what landed on disk. Returns 0 on full success, 1 if resolution
 // or any package install failed (so `nurlpkg install` exits non-zero).
-@ __install_registry Manifest m ( Vec LockPkg ) out → i {
-    ? == ( __count_registry . m dependencies ) 0 { ^ 0 } {}
+@ __install_registry Manifest m s cwd ( Vec LockPkg ) out → i {
+    : ( Vec Dep ) roots ( __registry_roots m cwd )
+    ? == ( vec_len [Dep] roots ) 0 {
+        ( __deps_free_vec roots )
+        ^ 0
+    } {}
     : String reg ( __registry_url m )
     ( nurl_print `resolving registry dependencies against ` )
     ( nurl_print ( string_data reg ) )
     ( nurl_print `\n` )
     : ( @ String s ) fetch \ s nm → String { ^ ( pkg_fetch_index ( string_data reg ) nm ) }
     : ~ i rc 0
-    : !( Vec LockPkg ) ResolveErr rr ( resolve_registry . m dependencies ( string_data reg ) fetch )
+    : !( Vec LockPkg ) ResolveErr rr ( resolve_registry roots ( string_data reg ) fetch )
     ?? rr {
         F e → {
             ( nurl_eprint `nurlpkg: registry resolution failed (` )
@@ -1241,6 +1301,7 @@ $ `stdlib/std/bytes.nu`
         }
     }
     ( string_free reg )
+    ( __deps_free_vec roots )
     ^ rc
 }
 
@@ -1866,7 +1927,7 @@ $ `stdlib/std/bytes.nu`
             // Registry pass: resolve + download + verify + unpack the
             // registry deps (path deps were handled by the BFS above).
             : ( Vec LockPkg ) regpkgs ( vec_new [LockPkg] )
-            : i reg_rc ( __install_registry root regpkgs )
+            : i reg_rc ( __install_registry root cwd_s regpkgs )
             ? != reg_rc 0 { = rc 1 } {}
             ( manifest_free root )
             // Regenerate the lockfile from the resulting deps/ tree. We do


### PR DESCRIPTION
## Problem

`nurlpkg install <name>` could not resolve transitive dependencies. The published registry index for packages like `onnx` showed `"deps": []` even though `onnx` declares `gpu` — so the dependency chain (`yoloe → onnx → gpu`) was invisible to the installer.

Root cause: a Cargo-style `{ path = "../onnx", version = "0.3.0" }` dependency was classified **path-only** by the binary `dep_is_registry` (path-empty) check, so it was:
1. **dropped from the published index** (`__deps_json` only emitted path-empty deps), and
2. **never resolved from the registry** on an install where the sibling path doesn't exist (e.g. the temp pkgdir of `nurlpkg install <name>`).

## Fix

Treat the `version` as the registry requirement and the `path` as a local-dev override (exactly Cargo's `{ path, version }` semantics):

- **`manifest.nu`**: add `dep_has_version` (a versioned dep, incl. hybrids).
- **publish**: `__deps_json` records any versioned dep in the `X-Nurl-Deps` index entry, so the dep graph is actually published.
- **install**: `__install_one` defers a hybrid to the registry pass (no error) when its local path is absent; `__registry_roots` normalises such hybrids into registry roots (path cleared) so `resolve_registry` fetches them transitively. Path-present hybrids stay on the path BFS — no double install.

## Verification

- Local monorepo install: links `onnx`/`gpu` via path, no double install.
- Isolated-dir install (path absent): **resolves and fetches `gpu 0.1.0` from the registry**.
- Full compiler corpus: **499 PASS, 0 FAIL**.

## Follow-up (not in this PR)

For `nurlpkg install yoloe` to pull the whole chain from the registry end-to-end, `onnx` (0.3.0), `objdet`, and `yoloe` must be **re-published with this fixed nurlpkg** (the existing `gpu`/`onnx` indexes still carry empty deps from the old tool). Publishing is owner-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSkMtPrMAgvDvpmkeAkLSN