### PR TITLE
feat(registry): render README images from the package tarball

### DIFF
--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -22,7 +22,7 @@
 // (miniflare simulates R2 + D1) — no Cloudflare account needed to test.
 
 import { renderMarkdown } from "./markdown.ts";
-import { extractReadme } from "./readme.ts";
+import { extractReadme, extractFile, normalizeRelPath } from "./readme.ts";
 
 export interface Env {
   REG_BUCKET: R2Bucket;
@@ -118,6 +118,36 @@ async function serveR2(env: Env, key: string, contentType: string): Promise<Resp
   // Tarballs are content-addressed + immutable; index is small + mutable.
   headers.set("cache-control", key.startsWith("pkgs/") ? "public, max-age=31536000, immutable" : "public, max-age=60");
   return new Response(obj.body, { headers });
+}
+
+// Image MIME types we serve from package tarballs (README assets). Limiting
+// to images keeps the asset route from doubling as a general file host.
+const ASSET_MIME: Record<string, string> = {
+  png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", gif: "image/gif",
+  webp: "image/webp", svg: "image/svg+xml", ico: "image/x-icon",
+  bmp: "image/bmp", avif: "image/avif",
+};
+
+// GET /files/<name>/<version>/<relpath> — extract a README-referenced image
+// straight from the published tarball. Version-pinned, so immutable-cacheable.
+async function handleFile(env: Env, name: string, version: string, rel: string): Promise<Response> {
+  if (!NAME_RE.test(name) || !VERSION_RE.test(version)) return json({ error: "bad_path" }, 400);
+  const safe = normalizeRelPath(rel);
+  if (!safe) return json({ error: "bad_path" }, 400);
+  const ext = safe.includes(".") ? safe.split(".").pop()!.toLowerCase() : "";
+  const mime = ASSET_MIME[ext];
+  if (!mime) return json({ error: "unsupported_type" }, 415);
+  let data: Uint8Array | null = null;
+  try { data = await extractFile(env.REG_BUCKET, name, version, safe); }
+  catch { return json({ error: "extract_failed" }, 500); }
+  if (!data) return json({ error: "not_found" }, 404);
+  const headers = new Headers();
+  headers.set("content-type", mime);
+  headers.set("cache-control", "public, max-age=31536000, immutable");
+  headers.set("x-content-type-options", "nosniff");
+  // Neutralise any script an SVG might carry, even on direct navigation.
+  headers.set("content-security-policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox");
+  return new Response(data, { headers });
 }
 
 async function handlePublish(req: Request, env: Env): Promise<Response> {
@@ -249,7 +279,16 @@ async function handlePackageDetail(env: Env, name: string): Promise<Response> {
     try {
       const md = await extractReadme(env.REG_BUCKET, name, latest.version);
       if (md && md.length <= 512 * 1024) {
-        readmeHtml = `<div class="readme">${renderMarkdown(md)}</div>`;
+        // Point the README's relative targets (e.g. `docs/demo.png`) at the
+        // tarball-asset route so embedded images resolve; leave absolute /
+        // scheme / fragment URLs untouched.
+        const base = `/files/${name}/${latest.version}/`;
+        const resolve = (u: string): string => {
+          if (/^[a-z][a-z0-9+.-]*:/i.test(u) || u.startsWith("/") || u.startsWith("#")) return u;
+          const norm = normalizeRelPath(u);
+          return norm ? base + norm : u;
+        };
+        readmeHtml = `<div class="readme">${renderMarkdown(md, resolve)}</div>`;
       }
     } catch { /* fall through with no README */ }
   }
@@ -386,6 +425,17 @@ export default {
         const name = path.slice("/index/".length, -".json".length).toLowerCase();
         if (!NAME_RE.test(name)) return json({ error: "invalid_name" }, 400);
         return serveR2(env, `index/${name}.json`, "application/json");
+      }
+      if (path.startsWith("/files/")) {
+        // /files/<name>/<version>/<relpath> — a README image from the tarball.
+        const rest = path.slice("/files/".length);
+        const s1 = rest.indexOf("/");
+        const s2 = s1 < 0 ? -1 : rest.indexOf("/", s1 + 1);
+        if (s1 < 0 || s2 < 0) return json({ error: "bad_path" }, 400);
+        const fname = decodeURIComponent(rest.slice(0, s1)).toLowerCase();
+        const fver = decodeURIComponent(rest.slice(s1 + 1, s2));
+        const frel = decodeURIComponent(rest.slice(s2 + 1));
+        return handleFile(env, fname, fver, frel);
       }
       if (path.startsWith("/pkgs/")) {
         // pkgs/<name>/<file>.tar.gz — reject traversal.

--- a/registry/src/markdown.ts
+++ b/registry/src/markdown.ts
@@ -35,8 +35,15 @@ function safeUrl(url: string): string | null {
 // used as a collision-free placeholder for already-rendered code spans.
 const SENTINEL = String.fromCharCode(0xe000);
 
+// A URL rewriter for relative targets (e.g. a README's `docs/demo.png`):
+// given a validated target, returns the URL to actually use. Default:
+// identity. The package page passes one that points relative paths at the
+// tarball-asset route so images and intra-package links resolve.
+export type UrlResolver = (url: string) => string;
+const identity: UrlResolver = (u) => u;
+
 // Inline formatting for a single run of text.
-function inline(raw: string): string {
+function inline(raw: string, resolve: UrlResolver = identity): string {
   let s = esc(raw);
 
   // Pull code spans out first so their contents are never re-processed by
@@ -52,10 +59,18 @@ function inline(raw: string): string {
   s = s.replace(/(^|[^*])\*([^*\n]+)\*/g, "$1<em>$2</em>");
   s = s.replace(/(^|[^_\w])_([^_\n]+)_/g, "$1<em>$2</em>");
 
+  // Images first (`![alt](src)`) so the link pass below doesn't swallow the
+  // inner `[alt](src)`. Relative `src` is resolved (e.g. to the tarball-asset
+  // route); the scheme allowlist still rejects `javascript:` / `data:`.
+  s = s.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (m, alt: string, url: string) => {
+    const safe = safeUrl(url);
+    return safe ? `<img src="${resolve(safe)}" alt="${alt}" loading="lazy" />` : m;
+  });
+
   s = s.replace(/\[([^\]]*)\]\(([^)\s]+)\)/g, (_m, text: string, url: string) => {
     const safe = safeUrl(url);
     return safe
-      ? `<a href="${safe}" rel="noopener nofollow">${text}</a>`
+      ? `<a href="${resolve(safe)}" rel="noopener nofollow">${text}</a>`
       : `[${text}](${url})`;
   });
 
@@ -82,14 +97,14 @@ function isDelimRow(line: string): boolean {
   return t.split(/(?<!\\)\|/).every((c) => /^\s*:?-+:?\s*$/.test(c));
 }
 
-function renderTable(lines: string[], start: number, out: string[]): number {
+function renderTable(lines: string[], start: number, out: string[], resolve: UrlResolver = identity): number {
   out.push("<table>\n<thead>\n<tr>");
-  for (const c of splitRow(lines[start])) out.push(`<th>${inline(c)}</th>`);
+  for (const c of splitRow(lines[start])) out.push(`<th>${inline(c, resolve)}</th>`);
   out.push("</tr>\n</thead>\n<tbody>\n");
   let i = start + 2; // skip header + delimiter row
   while (i < lines.length && lines[i].includes("|") && lines[i].trim() !== "") {
     out.push("<tr>");
-    for (const c of splitRow(lines[i])) out.push(`<td>${inline(c)}</td>`);
+    for (const c of splitRow(lines[i])) out.push(`<td>${inline(c, resolve)}</td>`);
     out.push("</tr>\n");
     i++;
   }
@@ -101,7 +116,7 @@ function renderTable(lines: string[], start: number, out: string[]): number {
 
 type Block = "p" | "ul" | "ol" | "bq" | null;
 
-export function renderMarkdown(src: string): string {
+export function renderMarkdown(src: string, resolve: UrlResolver = identity): string {
   const lines = src.replace(/\r\n?/g, "\n").split("\n");
   const out: string[] = [];
   let open: Block = null;
@@ -138,33 +153,33 @@ export function renderMarkdown(src: string): string {
 
     // ATX heading.
     const h = line.match(/^(#{1,6})\s+(.*?)\s*#*\s*$/);
-    if (h) { close(); const n = h[1].length; out.push(`<h${n}>${inline(h[2])}</h${n}>\n`); continue; }
+    if (h) { close(); const n = h[1].length; out.push(`<h${n}>${inline(h[2], resolve)}</h${n}>\n`); continue; }
 
     // Horizontal rule.
     if (/^ {0,3}([-*_])\s*(\1\s*){2,}$/.test(line)) { close(); out.push("<hr />\n"); continue; }
 
     // Blockquote.
     const bq = line.match(/^>\s?(.*)$/);
-    if (bq) { ensure("bq", "<blockquote>"); out.push(inline(bq[1]) + " "); continue; }
+    if (bq) { ensure("bq", "<blockquote>"); out.push(inline(bq[1], resolve) + " "); continue; }
 
     // GFM table (current line has a pipe, next line is a delimiter row).
     if (line.includes("|") && i + 1 < lines.length && isDelimRow(lines[i + 1])) {
       close();
-      i = renderTable(lines, i, out);
+      i = renderTable(lines, i, out, resolve);
       continue;
     }
 
     // Unordered list item.
     const ul = line.match(/^\s*[-*+]\s+(.*)$/);
-    if (ul) { ensure("ul", "<ul>\n"); out.push(`<li>${inline(ul[1])}</li>\n`); continue; }
+    if (ul) { ensure("ul", "<ul>\n"); out.push(`<li>${inline(ul[1], resolve)}</li>\n`); continue; }
 
     // Ordered list item.
     const ol = line.match(/^\s*\d+\.\s+(.*)$/);
-    if (ol) { ensure("ol", "<ol>\n"); out.push(`<li>${inline(ol[1])}</li>\n`); continue; }
+    if (ol) { ensure("ol", "<ol>\n"); out.push(`<li>${inline(ol[1], resolve)}</li>\n`); continue; }
 
     // Paragraph (consecutive plain lines join with a space).
     ensure("p", "<p>");
-    out.push(inline(line.trim()) + " ");
+    out.push(inline(line.trim(), resolve) + " ");
   }
 
   close();

--- a/registry/src/readme.ts
+++ b/registry/src/readme.ts
@@ -25,9 +25,12 @@ function isReadmeName(path: string): boolean {
   return base === "readme.md" || base === "readme.markdown" || base === "readme";
 }
 
-// Find and decode the README in an uncompressed tar image. Returns the
-// file's text, or null if the archive has no README member.
-export function findReadmeInTar(buf: Uint8Array): string | null {
+// Walk an uncompressed tar image, returning the first regular-file member
+// whose path satisfies `match`, as a view into `buf` (no copy). null if none.
+function findInTar(
+  buf: Uint8Array,
+  match: (path: string) => boolean,
+): { path: string; data: Uint8Array } | null {
   let pos = 0;
   while (pos + BLOCK <= buf.length) {
     if (isZeroBlock(buf, pos)) break; // end-of-archive marker
@@ -38,12 +41,28 @@ export function findReadmeInTar(buf: Uint8Array): string | null {
     const typeflag = buf[pos + 156];
     const dataStart = pos + BLOCK;
     // typeflag '0' (0x30) or NUL (0) is a regular file.
-    if ((typeflag === 0x30 || typeflag === 0) && name && isReadmeName(name)) {
-      return new TextDecoder().decode(buf.subarray(dataStart, dataStart + size));
+    if ((typeflag === 0x30 || typeflag === 0) && name && match(name)) {
+      return { path: name, data: buf.subarray(dataStart, dataStart + size) };
     }
     pos = dataStart + Math.ceil(size / BLOCK) * BLOCK;
   }
   return null;
+}
+
+// Find and decode the README in an uncompressed tar image. Returns the
+// file's text, or null if the archive has no README member.
+export function findReadmeInTar(buf: Uint8Array): string | null {
+  const hit = findInTar(buf, isReadmeName);
+  return hit ? new TextDecoder().decode(hit.data) : null;
+}
+
+// Normalise a README-relative path to a tar member path: drop a leading
+// `./`, collapse repeated slashes, and reject traversal / absolute paths.
+// Returns null if the path is unsafe.
+export function normalizeRelPath(rel: string): string | null {
+  const p = rel.replace(/^\.\//, "").replace(/\/{2,}/g, "/");
+  if (p === "" || p.startsWith("/") || p.split("/").some((seg) => seg === "..")) return null;
+  return p;
 }
 
 // Fetch + gunzip + extract the README for one published version. Returns
@@ -59,4 +78,20 @@ export async function extractReadme(
   if (!obj || !obj.body) return null;
   const ab = await new Response(obj.body.pipeThrough(new DecompressionStream("gzip"))).arrayBuffer();
   return findReadmeInTar(new Uint8Array(ab));
+}
+
+// Fetch + gunzip a published tarball and return the bytes of the member at
+// the exact relative path `rel` (e.g. `docs/demo.png`), or null if missing.
+// Used to serve README-referenced assets (images) straight from the tarball.
+export async function extractFile(
+  bucket: R2Bucket,
+  name: string,
+  version: string,
+  rel: string,
+): Promise<Uint8Array | null> {
+  const obj = await bucket.get(`pkgs/${name}/${name}-${version}.tar.gz`);
+  if (!obj || !obj.body) return null;
+  const ab = await new Response(obj.body.pipeThrough(new DecompressionStream("gzip"))).arrayBuffer();
+  const hit = findInTar(new Uint8Array(ab), (p) => p.replace(/^\.\//, "") === rel);
+  return hit ? hit.data : null;
 }

--- a/registry/test-readme.ts
+++ b/registry/test-readme.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { gzipSync } from "node:zlib";
 import { renderMarkdown } from "./src/markdown.ts";
-import { findReadmeInTar } from "./src/readme.ts";
+import { findReadmeInTar, normalizeRelPath } from "./src/readme.ts";
 
 let pass = 0, fail = 0;
 function ok(cond: boolean, msg: string) {
@@ -34,6 +34,26 @@ has(renderMarkdown("see [docs](https://x.io)"), `<a href="https://x.io" rel="noo
 // code span content must not be re-processed as emphasis
 has(renderMarkdown("`a*b*c`"), "<code>a*b*c</code>", "no emphasis inside code");
 absent(renderMarkdown("`a*b*c`"), "<em>", "no <em> inside code span");
+
+// ── images ────────────────────────────────────────────────────────────
+const idResolve = (u: string) =>
+  /^[a-z]+:/i.test(u) || u.startsWith("/") || u.startsWith("#") ? u : "/files/yoloe/0.1.0/" + u;
+has(renderMarkdown("![dog](docs/demo.png)"), `<img src="docs/demo.png" alt="dog" loading="lazy" />`, "image renders as <img>");
+has(renderMarkdown("![dog](docs/demo.png)", idResolve), `<img src="/files/yoloe/0.1.0/docs/demo.png"`, "relative image src rewritten");
+has(renderMarkdown("![x](https://e.org/a.png)", idResolve), `src="https://e.org/a.png"`, "absolute image src untouched");
+has(renderMarkdown("![a](x.png) then [b](https://y.io)"), `<img src="x.png"`, "image beside link: image ok");
+has(renderMarkdown("![a](x.png) then [b](https://y.io)"), `<a href="https://y.io"`, "image beside link: link ok");
+absent(renderMarkdown("![x](javascript:alert(1))"), "<img", "javascript: image rejected");
+absent(renderMarkdown("![x](javascript:alert(1))"), 'src="javascript', "javascript: not emitted as an image src");
+// underscores in a filename must not be italicised
+has(renderMarkdown("![p](docs/demo_promptable.png)"), `src="docs/demo_promptable.png"`, "underscores in image path survive");
+
+// ── relative-path normalisation (asset route safety) ──────────────────
+ok(normalizeRelPath("docs/demo.png") === "docs/demo.png", "normalize keeps clean path");
+ok(normalizeRelPath("./docs/x.png") === "docs/x.png", "normalize strips leading ./");
+ok(normalizeRelPath("../secret") === null, "normalize rejects ..");
+ok(normalizeRelPath("a/../../b") === null, "normalize rejects embedded ..");
+ok(normalizeRelPath("/etc/passwd") === null, "normalize rejects absolute");
 
 // ── GFM table (with escaped pipes, like nq's README) ──────────────────
 const tbl = renderMarkdown("| A | B |\n| - | - |\n| 1 | x \\| y |");


### PR DESCRIPTION
## Problem

Package-page READMEs showed **broken images**. The markdown renderer had no `![alt](src)` support, so an image fell through to the link pass and rendered as `!<a href="docs/demo.png">` — and the relative `href` resolved against `/packages/`, landing on `/packages/docs/demo.png` → **"Invalid package name."** (exactly what the screenshot showed for `yoloe`'s demo images).

## Fix

- **`markdown.ts`** — parse `![alt](src)` into `<img loading="lazy">` (before the link pass so it isn't swallowed); thread an optional `UrlResolver` through `inline` / `renderTable` / `renderMarkdown` to rewrite relative targets.
- **`readme.ts`** — generalise the tar walker; add `extractFile` (pull any member's bytes from a published tarball) and `normalizeRelPath` (strip `./`, reject `..` / absolute).
- **`index.ts`** — serve README assets straight from the tarball at `GET /files/<name>/<version>/<relpath>`: image-MIME allowlist, immutable cache (version-pinned URL), `X-Content-Type-Options: nosniff`, and a `default-src 'none'; sandbox` CSP to neutralise any script an SVG might carry. The package page passes a resolver that points relative README paths at this route; absolute / scheme / fragment URLs are left untouched.

## Tests

`test-readme.ts` +9 cases — image rendering, resolver rewrite, absolute-URL passthrough, `javascript:` rejection, intra-filename underscores, and path-safety (`..`/absolute rejected). **44 passed**, `tsc --noEmit` clean.

## Deploy

Takes effect after `wrangler deploy` (registry/) against the Cloudflare account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSkMtPrMAgvDvpmkeAkLSN