### PR TITLE
fix(registry): cross-line README links + monorepo sibling-package refs

### DIFF
--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -285,6 +285,10 @@ async function handlePackageDetail(env: Env, name: string): Promise<Response> {
         const base = `/files/${name}/${latest.version}/`;
         const resolve = (u: string): string => {
           if (/^[a-z][a-z0-9+.-]*:/i.test(u) || u.startsWith("/") || u.startsWith("#")) return u;
+          // A monorepo sibling-package reference (`../onnx`, common in these
+          // READMEs) maps to that package's page, not a file in the tarball.
+          const sib = u.match(/^\.\.\/([a-z0-9][a-z0-9_-]*)\/?$/i);
+          if (sib) return `/packages/${sib[1].toLowerCase()}`;
           const norm = normalizeRelPath(u);
           return norm ? base + norm : u;
         };

--- a/registry/src/markdown.ts
+++ b/registry/src/markdown.ts
@@ -120,16 +120,23 @@ export function renderMarkdown(src: string, resolve: UrlResolver = identity): st
   const lines = src.replace(/\r\n?/g, "\n").split("\n");
   const out: string[] = [];
   let open: Block = null;
+  // Raw lines of the current paragraph / blockquote. Inline formatting is
+  // applied to the JOINED text, so links and other spans that wrap across
+  // source lines (`[text\n](url)`) are reassembled before parsing.
+  let buf: string[] = [];
 
   const close = () => {
-    if (open === "p") out.push("</p>\n");
+    if (open === "p") out.push(`<p>${inline(buf.join(" "), resolve)}</p>\n`);
+    else if (open === "bq") out.push(`<blockquote>${inline(buf.join(" "), resolve)}</blockquote>\n`);
     else if (open === "ul") out.push("</ul>\n");
     else if (open === "ol") out.push("</ol>\n");
-    else if (open === "bq") out.push("</blockquote>\n");
+    buf = [];
     open = null;
   };
+  // openTag is emitted immediately for list blocks; paragraph / blockquote
+  // text is buffered and rendered on close(), so pass "" for those.
   const ensure = (b: Block, openTag: string) => {
-    if (open !== b) { close(); out.push(openTag); open = b; }
+    if (open !== b) { close(); if (openTag) out.push(openTag); open = b; }
   };
 
   for (let i = 0; i < lines.length; i++) {
@@ -160,7 +167,7 @@ export function renderMarkdown(src: string, resolve: UrlResolver = identity): st
 
     // Blockquote.
     const bq = line.match(/^>\s?(.*)$/);
-    if (bq) { ensure("bq", "<blockquote>"); out.push(inline(bq[1], resolve) + " "); continue; }
+    if (bq) { ensure("bq", ""); buf.push(bq[1]); continue; }
 
     // GFM table (current line has a pipe, next line is a delimiter row).
     if (line.includes("|") && i + 1 < lines.length && isDelimRow(lines[i + 1])) {
@@ -177,9 +184,9 @@ export function renderMarkdown(src: string, resolve: UrlResolver = identity): st
     const ol = line.match(/^\s*\d+\.\s+(.*)$/);
     if (ol) { ensure("ol", "<ol>\n"); out.push(`<li>${inline(ol[1], resolve)}</li>\n`); continue; }
 
-    // Paragraph (consecutive plain lines join with a space).
-    ensure("p", "<p>");
-    out.push(inline(line.trim(), resolve) + " ");
+    // Paragraph (consecutive plain lines join with a space, then inline).
+    ensure("p", "");
+    buf.push(line.trim());
   }
 
   close();

--- a/registry/test-readme.ts
+++ b/registry/test-readme.ts
@@ -21,9 +21,9 @@ has(renderMarkdown("# Title"), "<h1>Title</h1>", "h1");
 has(renderMarkdown("### Sub"), "<h3>Sub</h3>", "h3");
 has(renderMarkdown("- a\n- b"), "<ul>\n<li>a</li>\n<li>b</li>\n</ul>", "ul");
 has(renderMarkdown("1. x\n2. y"), "<ol>\n<li>x</li>\n<li>y</li>\n</ol>", "ol");
-has(renderMarkdown("> quoted"), "<blockquote>quoted </blockquote>", "blockquote");
+has(renderMarkdown("> quoted"), "<blockquote>quoted</blockquote>", "blockquote");
 has(renderMarkdown("---"), "<hr />", "hr");
-has(renderMarkdown("one\ntwo"), "<p>one two </p>", "paragraph join");
+has(renderMarkdown("one\ntwo"), "<p>one two</p>", "paragraph join");
 has(renderMarkdown("```sh\nls -l\n```"), `<pre><code class="language-sh">ls -l</code></pre>`, "fenced code w/ lang");
 has(renderMarkdown("```\nx<y\n```"), "x&lt;y", "code block escapes html");
 
@@ -34,6 +34,10 @@ has(renderMarkdown("see [docs](https://x.io)"), `<a href="https://x.io" rel="noo
 // code span content must not be re-processed as emphasis
 has(renderMarkdown("`a*b*c`"), "<code>a*b*c</code>", "no emphasis inside code");
 absent(renderMarkdown("`a*b*c`"), "<em>", "no <em> inside code span");
+
+// ── inline spans that wrap across source lines (paragraph re-join) ─────
+has(renderMarkdown("see [the\ndocs](https://x.io)"), `<a href="https://x.io" rel="noopener nofollow">the docs</a>`, "link wrapped across two lines");
+has(renderMarkdown("a **bo\nld** word"), "<strong>bo ld</strong>", "bold wrapped across two lines");
 
 // ── images ────────────────────────────────────────────────────────────
 const idResolve = (u: string) =>


### PR DESCRIPTION
Two README-rendering bugs on package pages (reported on `yoloe`):

### 1. Links that wrap across source lines rendered as plain text
`A NURL port of YOLOE ([THU-MIG, "…", ICCV` / `2025](https://github.com/THU-MIG/yoloe))` showed as literal text — no `<a>`. The block renderer ran `inline()` on each source line **before** joining the paragraph, so the link regex never saw a complete `[...](...)`. **Fix:** buffer a paragraph/blockquote's raw lines and apply inline formatting to the **joined** text, so links/emphasis reassemble across line breaks. (Also removes the stray trailing space these blocks used to emit.)

### 2. Monorepo sibling-package links 404'd
`[packages/onnx](../onnx)` kept its `../onnx` href, which resolves against `/packages/` to `/onnx` → "Invalid package name." **Fix:** the package-page URL resolver maps `../<name>` to that package's page, `/packages/<name>`.

Verified on the real `yoloe` README: the THU-MIG link, the `../onnx`/`../gpu` sibling links, and the `docs/*.png` images all resolve; no leftover `../` hrefs, no unparsed `](url)` text.

`test-readme.ts`: +cross-line link & bold cases; updated the two trailing-space expectations. **46 passed**, `tsc` clean.

Takes effect after `wrangler deploy` (registry/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSkMtPrMAgvDvpmkeAkLSN