### PR TITLE
Release v0.10.7 — CPU inference + GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.7] — 2026-07-01
+
+A **CPU inference + GUI** release. The GPU/ML stack from 0.10.6 gains two big
+things: models now run **with no GPU at all** (a CPU backend in `packages/gpu`
+that runs the same CUDA-C kernels on the host), and the `yoloe` webcam demo can
+draw its live segmentation into a **real X11 window** — or the terminal.
+
+### Added
+
+- **CPU backend for `packages/gpu` (0.1.0 → 0.2.0).** `gpu_open` uses CUDA when
+  a device is present and otherwise falls back to a CPU backend that runs the
+  *same* CUDA-C kernels on the host: each kernel is wrapped in a small
+  CUDA-compatibility shim (`blockIdx`/`threadIdx`/`blockDim`/`gridDim` as
+  thread-locals, `__global__` etc. as no-op macros) plus a generated grid-loop,
+  compiled by the system C++ compiler, `dlopen`'d, and run with **OpenMP**
+  across cores. `gpu_launch`'s `void**` argument array is byte-for-byte what
+  CUDA passes, so the neutral surface is unchanged and every caller (`onnx`,
+  `objdet`, `yoloe`) gets the fallback for free. `NURL_GPU=cpu` forces it.
+  Verified identical CPU vs GPU on the onnx MLP and the full 267-node YOLOE-seg
+  forward.
+- **Driverless linking.** A program that references `packages/gpu` no longer
+  hard-requires libcuda/libnvrtc to load: `nurl.sh` links small stub objects
+  (`stdlib/{cuda,nvrtc}_stubs.o`, built by `build.sh`) in place of `-lcuda` /
+  `-lnvrtc` when those libraries are absent — the binary links, loads, and
+  auto-falls-back to the CPU backend. `NURL_GPU_STUBS=1` forces the stubs to
+  build a portable CPU-only binary on a GPU host. `runtime.c` gains one tiny
+  generic thunk, `nurl_cpu_launch`, so the backend can call the `dlsym`'d
+  kernel entry.
+- **X11 GUI-window support.** `build.sh` writes a `runtime.X11` sentinel when
+  libX11 is present and `nurl.sh` auto-links `-lX11` only when `@XOpenDisplay`
+  appears — the same opt-in-by-symbol pattern as libcuda/libopus, so headless
+  programs are unaffected. Used by `packages/yoloe`'s new window preview.
+- **`yoloe` — a real webcam segmentation tool.** The `yoloe` command is now a
+  flag-driven, self-documenting CLI with three sub-commands — `detect`, `seg`,
+  and `cam` — and `cam` shows the **live** segmented feed either in a **real
+  X11 window** (full webcam resolution, pure NURL via libX11) or in the
+  terminal (area-averaged 24-bit half-blocks, works over SSH). `--boxes` /
+  `--mask` pick what to draw, `--frames` bounds the run (omit ⇒ until Ctrl-C),
+  `--out` saves frames, `--device` / `--gpu` select the camera / CUDA device.
+
+### Fixed
+
+- **`nurlpkg` `{ path, version }` hybrid dependencies** are published + resolved
+  correctly end-to-end (carried over from 0.10.6); the `gpu`/`onnx`/`yoloe`
+  packages were republished with the correct dependency edges so a registry
+  install resolves the whole chain.
+
 ## [0.10.6] — 2026-06-30
 
 A **GPU compute + ML inference** release. NURL gains the ability to run real

--- a/packages/objdet/nurl.toml
+++ b/packages/objdet/nurl.toml
@@ -1,8 +1,8 @@
 [package]
 name = "objdet"
-version = "0.2.0"
+version = "0.2.1"
 description = "Object detection from pure NURL, GPU-accelerated, using any tiny-YOLOv2-style ONNX model. Reads an image or a sequence of video frames (binary PPM), runs the detector on the GPU through the onnx package (every Conv/BatchNorm/MaxPool/LeakyRelu kernel compiled to PTX at runtime via NVRTC, no external inference engine), decodes the YOLO grid into labelled boxes (anchors, sigmoid/softmax, non-max suppression), prints the detections, and writes an annotated image. Verified against onnxruntime on the ONNX model-zoo tinyyolov2-8.onnx: identical class scores and boxes (dog 0.76, car 0.76 on the classic dog photo). Pure NURL end to end — protobuf parsing, the CNN, image I/O, decoding, and drawing; the only native dependency (the CUDA driver + NVRTC) lives in the gpu package, so a GPU-less host is unaffected. ffmpeg/ImageMagick convert to/from PPM for arbitrary formats and video."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-onnx = { path = "../onnx", version = "0.3.0" }
+onnx = { path = "../onnx", version = "0.4.2" }

--- a/packages/onnx/nurl.toml
+++ b/packages/onnx/nurl.toml
@@ -1,8 +1,8 @@
 [package]
 name = "onnx"
-version = "0.4.1"
+version = "0.4.2"
 description = "Run ONNX neural-network models from pure NURL, GPU-accelerated. The model's protobuf is decoded by a pure-NURL wire-format reader (no protoc, no external protobuf library) into an in-memory graph; inference runs on the GPU through the `gpu` package — each operator is a CUDA-C kernel compiled to PTX at runtime via NVRTC and launched over the CUDA Driver API, with every weight and activation resident on the device. v0.1.0 is a proof-of-concept covering feed-forward MLPs (Gemm + Relu); the demo loads a model and input, runs it on the GPU, and matches onnxruntime's output (max abs error ~1e-6). Requires the NVIDIA driver (libcuda) and NVRTC (libnvrtc); a GPU-less host is unaffected since the CUDA dependency lives entirely in the `gpu` package."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-gpu = { path = "../gpu", version = "0.1.0" }
+gpu = { path = "../gpu", version = "0.2.0" }

--- a/packages/yoloe/nurl.toml
+++ b/packages/yoloe/nurl.toml
@@ -1,8 +1,8 @@
 [package]
 name = "yoloe"
-version = "0.4.0"
+version = "0.4.1"
 description = "Promptable, open-vocabulary object detection AND instance segmentation from pure NURL on the GPU — a NURL port of YOLOE (THU-MIG, 'Real-Time Seeing Anything', ICCV 2025), including live masking straight off a webcam. You name the classes you want ('dog', 'bicycle', 'a person on a bike') and the model finds them — drawing both boxes and per-object segmentation masks — without a fixed label set. The whole network runs on the GPU through the onnx package (every layer a CUDA-C kernel compiled at runtime via NVRTC — no external inference engine), including the YOLOE-seg mask-prototype branch (ConvTranspose 2× upsample) and the mask decode (coefficients · prototypes → threshold → overlay), all verified numerically against onnxruntime (proto max abs err ~6e-5). Promptability comes from YOLOE's region-text contrastive head, which scores each region's visual embedding against the text embeddings of the prompt words, with the MobileCLIP text path also in pure NURL. The webcam feed is captured in pure NURL via Video4Linux2 (open/ioctl/mmap, YUYV→RGB) — no ffmpeg, no OpenCV. Requires the NVIDIA driver + NVRTC (via the gpu package); a GPU-less host is unaffected."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-onnx = { path = "../onnx", version = "0.4.1" }
+onnx = { path = "../onnx", version = "0.4.2" }


### PR DESCRIPTION
Release **v0.10.7**. Updates `CHANGELOG.md` and cascades the package dependency bumps that propagate the new CPU backend through the registry install chain. Cut the tag from `main` after merge (the toolchain version is derived from `git describe`).

## Highlights

### Run models with no GPU — CPU backend for `packages/gpu` (0.1.0 → 0.2.0)
`gpu_open` falls back to a CPU backend that runs the **same CUDA-C kernels** on the host (CUDA-compat shim + generated grid-loop, compiled by the system C++ compiler, `dlopen`'d, OpenMP across cores). The neutral surface is unchanged, so `onnx` / `objdet` / `yoloe` get it for free. `NURL_GPU=cpu` forces it. Verified identical CPU vs GPU on the onnx MLP and the full 267-node YOLOE-seg forward.

### Driverless linking
`nurl.sh` links stub objects (`stdlib/{cuda,nvrtc}_stubs.o`) in place of `-lcuda`/`-lnvrtc` when those libraries are absent, so a `packages/gpu` program links + loads on a machine with no NVIDIA driver and auto-falls-back to the CPU. `NURL_GPU_STUBS=1` builds a portable CPU-only binary. `runtime.c` gains a tiny `nurl_cpu_launch` thunk.

### X11 GUI window + the `yoloe` webcam CLI
`build.sh`/`nurl.sh` gain opt-in-by-symbol libX11 linking. The `yoloe` command is now a flag-driven CLI (`detect` / `seg` / `cam`); `cam` shows the live segmentation in a **real X11 window** or the terminal, with `--boxes` / `--mask` / `--frames` / `--out` / `--device` / `--gpu`.

## Package dependency cascade (for the registry)
```
gpu    0.1.0 -> 0.2.0   (CPU backend)
onnx   0.4.1 -> 0.4.2   (dep gpu 0.2.0)
objdet 0.2.0 -> 0.2.1   (dep onnx 0.4.2)
yoloe  0.4.0 -> 0.4.1   (dep onnx 0.4.2)
```
These are published to reg.nurl-lang.org alongside this release so `nurlpkg install yoloe` (with a v0.10.7 toolchain) resolves the whole chain and links the CPU backend.

## Note
After merge + tag, the installed toolchain must be rebuilt/reinstalled (new `runtime.o` with `nurl_cpu_launch`, `nurl.sh` stub-link logic, and the stub `.o`s) for the registry-installed packages to link the CPU backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)