### PR TITLE
Release v0.10.8 — dynamic trait objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.8] — 2026-07-02
+
+A **dynamic trait objects** release. NURL's trait system gains a second,
+opt-in dispatch path alongside the existing static one: `%Trait` boxes a
+concrete implementer behind a vtable fat pointer, so heterogeneous
+collections and plugin-style APIs can dispatch on the trait rather than the
+concrete type — no GC, and the existing monomorphised `impl` dispatch is
+unchanged. Diamond supertraits upcast through the same object, object safety
+is checked at compile time, and the box's `Drop` is synthesized so the
+single-owner memory model holds. A real leak in the (unrelated) static
+impl-method dispatch path, found while adding the feature, is fixed
+alongside it.
+
 ### Added
 
 - **Dynamic trait objects — `%Trait` (docs/spec.md §4.9).** A trait can now be

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-06-27 · Current release: **0.10.1** · Language: **Grammar
+_Last reviewed: 2026-07-02 · Current release: **0.10.8** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
## Summary
- Cuts CHANGELOG v0.10.8, folding the `[Unreleased]` entries (dynamic trait objects `%Trait` + `( dyn Trait v )`, diamond supertrait upcasting, object-safety checking, synthesized `Drop` for the boxed value, `nurlfmt` `%Trait` sigil support, `nurl_free_count()`, and the impl-method dispatch marker-propagation leak fix) into a dated release section.
- Bumps ROADMAP.md's "Current release" pointer to 0.10.8 (was stale at 0.10.1) and refreshes the review date.
- README.md and docs/ already state Grammar v2.3 / dynamic trait objects from the preceding docs commits, so no further changes were needed there.

## Test plan
- [ ] CI green (build + full test suite + bootstrap fixed point)
- [ ] `nurlfmt --check` clean
- [ ] Tag `v0.10.8` and cut the release per RELEASING.md once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTxirRQLtSbtdqafRNFsSx