### PR TITLE
wasmtime: GPU host-import bridge (CUDA/NVRTC) — run GPU wasm modules on real hardware

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5094,6 +5094,28 @@
             = at ( variadic_promoted_type at )
         }
         {}
+        // FFI arg width coercion (fixed positions only; vararg positions are
+        // promoted above). If the callee is an FFI symbol and this argument's
+        // integer width differs from the declared parameter type, emit the
+        // trunc/sext so the emitted call type matches the `declare` — required
+        // for a correct wasm import (see gen_ffi_decl's `ptypes` note).
+        ? ! & is_variadic >= arg_idx fixed_count {
+            : s __ffp ( nurl_sym_get syms ( nurl_str_cat fname `__ffi_params` ) )
+            ? != 0 ( nurl_str_len __ffp ) {
+                : s __want ( __nth_sep __ffp arg_idx )
+                : i __ww ( int_width __want )
+                : i __hw ( int_width at )
+                ? & & & > __ww 0 > __hw 0 != __ww __hw ! ( seq at __want ) {
+                    : s __nv ( nurl_cg_reg cg )
+                    ( nurl_print `  ` ) ( nurl_print __nv )
+                    ( nurl_print ? > __hw __ww ` = trunc ` ` = sext ` )
+                    ( nurl_print at ) ( nurl_print ` ` ) ( nurl_print av )
+                    ( nurl_print ` to ` ) ( nurl_print __want ) ( nurl_print `\n` )
+                    = av __nv
+                    = at __want
+                } {}
+            } {}
+        } {}
         ? & & != 0 g_auto_drop_strings
         ( seq at `i8*` )
         ( seq ( nurl_sym_get syms `__last_call_ret_owned__` ) `str` )
@@ -12318,6 +12340,15 @@
 // `{ T*, i64 }`, result, nested closure) contains its own spaces and
 // commas — `str_first_word` would truncate it at the first space. ';'
 // never appears in an LLVM type string, so it is a safe field delimiter.
+// The n-th (0-based) element of a `;`-separated list, or `` if out of range.
+@ __nth_sep s list i n → s {
+    : ~ s rest list
+    : ~ i k 0
+    ~ < k n { = rest ( seplist_rest rest ) = k + k 1 }
+    ? == 0 ( nurl_str_len rest ) { ^ `` } {}
+    ^ ( seplist_first rest )
+}
+
 @ seplist_first s str → s {
     : i n ( nurl_str_len str )
     : ~ i i 0
@@ -14763,6 +14794,14 @@
     ( lint_note_def fname )
     ( nurl_lex_advance lex )
     : ~ s params_str ``
+    // `;`-joined LLVM param types, consulted by gen_call to coerce each
+    // argument to its declared FFI parameter width. Native LLVM silently
+    // tolerates a width-mismatched call arg (e.g. an i64 integer literal
+    // passed to an i32 parameter — high bits ignored in the ABI register),
+    // but wasm is strict: the call's inferred function type then differs
+    // from the import's declared type and wasm-ld replaces the callee with
+    // an `unreachable` stub. Coercing at the call site fixes both targets.
+    : ~ s ptypes ``
     : ~ i pct 0
     ~ & != ( nurl_lex_type lex ) TT_ARROW != ( nurl_lex_type lex ) TT_EOF {
         ? == ( nurl_lex_type lex ) TT_ELLIPSIS
@@ -14782,8 +14821,9 @@
             ( check_type_known lex syms lt `an FFI parameter type` )
             ? ( is_ident_tok ( nurl_lex_type lex ) ) { ( nurl_lex_advance lex ) } {}
             ? == pct 0
-            { = params_str lt }
-            { = params_str ( nurl_str_cat params_str ( nurl_str_cat `, ` lt ) ) }
+            { = params_str lt = ptypes lt }
+            { = params_str ( nurl_str_cat params_str ( nurl_str_cat `, ` lt ) )
+                = ptypes ( nurl_str_cat3 ptypes `;` lt ) }
             = pct + pct 1
         }
     }
@@ -14798,6 +14838,8 @@
     // by vis_record_fn, which FFI decls deliberately do not get
     // (FFI symbols are linker-level ABI globals, not NURL sources).
     ( nurl_sym_def syms ( nurl_str_cat fname `__ffi` ) `1` )
+    // Per-parameter LLVM types for call-site width coercion (see `ptypes`).
+    ( nurl_sym_def syms ( nurl_str_cat fname `__ffi_params` ) ptypes )
     // emit_header already emits `declare` lines for a small set of libc
     // symbols (malloc, free, puts, printf). If the user FFI-declares any of
     // those, re-emitting the same `declare` would trigger LLVM's "invalid

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5105,14 +5105,39 @@
                 : s __want ( __nth_sep __ffp arg_idx )
                 : i __ww ( int_width __want )
                 : i __hw ( int_width at )
-                ? & & & > __ww 0 > __hw 0 != __ww __hw ! ( seq at __want ) {
-                    : s __nv ( nurl_cg_reg cg )
-                    ( nurl_print `  ` ) ( nurl_print __nv )
-                    ( nurl_print ? > __hw __ww ` = trunc ` ` = sext ` )
-                    ( nurl_print at ) ( nurl_print ` ` ) ( nurl_print av )
-                    ( nurl_print ` to ` ) ( nurl_print __want ) ( nurl_print `\n` )
-                    = av __nv
-                    = at __want
+                : b __wp ( is_ptr_ty __want )
+                : b __hp ( is_ptr_ty at )
+                ? & != 0 ( nurl_str_len __want ) ! ( seq at __want ) {
+                    ? & & > __ww 0 > __hw 0 != __ww __hw {
+                        // int → narrower/wider int: trunc / sext
+                        : s __nv ( nurl_cg_reg cg )
+                        ( nurl_print `  ` ) ( nurl_print __nv )
+                        ( nurl_print ? > __hw __ww ` = trunc ` ` = sext ` )
+                        ( nurl_print at ) ( nurl_print ` ` ) ( nurl_print av )
+                        ( nurl_print ` to ` ) ( nurl_print __want ) ( nurl_print `\n` )
+                        = av __nv = at __want
+                    } {
+                        ? & __wp > __hw 0 {
+                            // integer arg (e.g. a bare `0` / a handle held as i64)
+                            // to a pointer parameter: inttoptr. A wasm call
+                            // otherwise needs a function-signature bitcast, which
+                            // is invalid → wasm-ld emits a trapping stub.
+                            : s __nv ( nurl_cg_reg cg )
+                            ( nurl_print `  ` ) ( nurl_print __nv )
+                            ( nurl_print ` = inttoptr ` ) ( nurl_print at ) ( nurl_print ` ` ) ( nurl_print av )
+                            ( nurl_print ` to ` ) ( nurl_print __want ) ( nurl_print `\n` )
+                            = av __nv = at __want
+                        } {
+                            ? & > __ww 0 __hp {
+                                // pointer arg to an integer parameter: ptrtoint
+                                : s __nv ( nurl_cg_reg cg )
+                                ( nurl_print `  ` ) ( nurl_print __nv )
+                                ( nurl_print ` = ptrtoint ` ) ( nurl_print at ) ( nurl_print ` ` ) ( nurl_print av )
+                                ( nurl_print ` to ` ) ( nurl_print __want ) ( nurl_print `\n` )
+                                = av __nv = at __want
+                            } {}
+                        }
+                    }
                 } {}
             } {}
         } {}
@@ -17701,12 +17726,29 @@
                         ? ( is_ident_tok ( nurl_lex_type lex ) )
                         { : s fname ( nurl_lex_val lex )
                             ( nurl_lex_advance lex )
+                            // Parse the parameter types here too (not just skip
+                            // tokens) so __ffi_params is registered in the
+                            // pre-pass — a FORWARD call to this FFI symbol (the
+                            // callee declared LATER in the same file) must still
+                            // get its args width-coerced at the call site, or the
+                            // wasm call type won't match the declare. Mirrors
+                            // gen_ffi_decl's param loop exactly to stay in sync.
+                            : ~ s ptypes ``
+                            : ~ i pct 0
                             ~ & != ( nurl_lex_type lex ) TT_ARROW != ( nurl_lex_type lex ) TT_EOF
-                            { ( nurl_lex_advance lex ) }
+                            { ? == ( nurl_lex_type lex ) TT_ELLIPSIS
+                                { ( nurl_lex_advance lex ) }
+                                { : s lt ( parse_type lex )
+                                    ? ( is_ident_tok ( nurl_lex_type lex ) ) { ( nurl_lex_advance lex ) } {}
+                                    = ptypes ? == pct 0 lt ( nurl_str_cat3 ptypes `;` lt )
+                                    = pct + pct 1
+                                }
+                            }
                             ? == ( nurl_lex_type lex ) TT_ARROW
                             { ( nurl_lex_advance lex )
                                 : s ret_ty ( parse_type lex )
                                 ( nurl_sym_def syms fname ret_ty )
+                                ( nurl_sym_def syms ( nurl_str_cat fname `__ffi_params` ) ptypes )
                             }
                             {}
                         }

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -704,6 +704,13 @@
 // unaffected). All borrowck_* state below is untouched when the flag
 // is 0.
 : ~ i g_borrowck 1  // 0 when --no-borrowck passed on the CLI
+// g_ffi_host_imports is 1 when `--ffi-host-imports` is passed: external
+// `&`-FFI libraries are then satisfied by the RUN-TIME host (wasm imports
+// resolved by the embedder) rather than by a native link line, so the
+// build-time `stdlib/runtime.<lib>` sentinel gate is skipped. Set by the
+// wasm build path (nurlapi) — a wasm module's undefined FFI symbols become
+// imports the host runtime (e.g. packages/wasmtime) provides.
+: ~ i g_ffi_host_imports 0
 // `--strict-borrowck` (off by default) enables two additional checks:
 // (1) aliased mutation through `. obj field` arguments at the same
 // call site — a generalisation of the bare-identifier-only check, and
@@ -14691,6 +14698,9 @@
 // `libc` / `m` / `pthread` / `dl` are always linked (default link
 // line in `build.sh` / `run_tests.sh`) and skip the check.
 @ __ffi_lib_check i lex s lib → v {
+    // Host-imports mode (wasm): external FFI libs are resolved by the run-time
+    // embedder as imports, not linked natively — skip the native sentinel gate.
+    ? != g_ffi_host_imports 0 { ^ v } {}
     : i llen ( nurl_str_len lib )
     ? > llen 0 {
         // Strip a leading `lib` prefix if present (`libcurl` → `curl`).
@@ -17823,11 +17833,13 @@
                         { = g_borrowck 0 }
                         { ? ( seq a `--strict-borrowck` )
                             { = g_borrowck 1 = g_strict_borrowck 1 }
-                            { = path a } } } } } }
+                            { ? ( seq a `--ffi-host-imports` )
+                                { = g_ffi_host_imports 1 }
+                                { = path a } } } } } } }
         = ai + ai 1
     }
     ? == 0 ( nurl_str_len path )
-    { ( nurl_eprintln `usage: nurlc [--version] [--g] [--lint] [--no-borrowck | --strict-borrowck] <file.nu>` ) ( nurl_exit 1 ) }
+    { ( nurl_eprintln `usage: nurlc [--version] [--g] [--lint] [--no-borrowck | --strict-borrowck] [--ffi-host-imports] <file.nu>` ) ( nurl_exit 1 ) }
     {}
     ? != g_lint 0 { ( lint_init path ) } {}
     : s src ( nurl_read_file path )

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -228,7 +228,14 @@ $ `nurlapi/pptws.nu`
     // fread/fwrite/fseek/ftell/lseek added 2026-05-27 — find_clone /
     // csv_demo / claude_agent stdio path. wasi-libc has all of these
     // with i32-flavored size_t/long; NURL emits the i64 variants.
-    : s list `malloc:p:s,calloc:p:ss,realloc:p:ps,puts:i:p,putchar:i:i,getchar:i:,strlen:s:p,strcmp:i:pp,strncmp:i:pps,strcpy:p:pp,strncpy:p:pps,strcat:p:pp,strdup:p:p,memcpy:p:pps,memmove:p:pps,memset:p:pis,memcmp:i:pps,memchr:p:pis,memmem:p:psps,strchr:p:pi,strrchr:p:pi,atoi:i:p,abs:i:i,exit:v:i,rand:i:,srand:v:s,system:i:p,write:i:ips,read:i:ips,open:i:pii,close:i:i,getcwd:p:ps,fread:s:psps,fwrite:s:psps,fseek:i:pii,ftell:i:p,lseek:i:iii`
+    // NOTE: lseek is deliberately NOT shimmed. Its offset and return are
+    // off_t, which is 64-bit on wasm32-wasi too — so NURL's i64 declaration
+    // (posix.nu: `lseek i32 fd i offset i32 whence → i`) already matches
+    // wasi-libc. Narrowing it here produced a signature mismatch and an
+    // `unreachable` stub (breaking every fs.nu file-size probe on wasm).
+    // Only libc functions whose wasm32 ABI genuinely uses a 32-bit long /
+    // size_t where NURL emits i64 belong below (fseek's `long`, ftell, …).
+    : s list `malloc:p:s,calloc:p:ss,realloc:p:ps,puts:i:p,putchar:i:i,getchar:i:,strlen:s:p,strcmp:i:pp,strncmp:i:pps,strcpy:p:pp,strncpy:p:pps,strcat:p:pp,strdup:p:p,memcpy:p:pps,memmove:p:pps,memset:p:pis,memcmp:i:pps,memchr:p:pis,memmem:p:psps,strchr:p:pi,strrchr:p:pi,atoi:i:p,abs:i:i,exit:v:i,rand:i:,srand:v:s,system:i:p,write:i:ips,read:i:ips,open:i:pii,close:i:i,getcwd:p:ps,fread:s:pssp,fwrite:s:pssp,fseek:i:piw,ftell:s:p`
     : String slist ( string_from list )
     : ( Vec String ) entries ( string_split slist `,` )
 
@@ -348,15 +355,20 @@ $ `nurlapi/pptws.nu`
                                 // → `unreachable` trap; nurl_str_eq→strcmp hits this.)
                                 ( string_push_str shims ? == r_char 112 `i8*` ? == r_char 118 `void` ? == r_char 105 `i32` `i64` )
                                 ( string_push_str shims ` @__nurl_` ) ( string_push_str shims ( string_data name ) ) ( string_push_str shims `_shim(` )
-                                : ~ i k2 0 ~ < k2 ( string_len pms ) { ? > k2 0 { ( string_push_str shims `, ` ) } {} : i p ( string_get pms k2 ) ( string_push_str shims ? == p 112 `i8* %a` `i64 %a` ) ( string_push_int shims k2 ) = k2 + k2 1 }
+                                // Param char: 'p' = i8* (pointer, pass through), 'w' = i32
+                                // (a param nurlc already emits as i32 — e.g. fseek's `whence`
+                                // — so the wrapper must accept i32, NOT i64, or the call type
+                                // won't match and wasm-ld stubs it), any other = i64 narrowed
+                                // to i32 for the wasi call.
+                                : ~ i k2 0 ~ < k2 ( string_len pms ) { ? > k2 0 { ( string_push_str shims `, ` ) } {} : i p ( string_get pms k2 ) ( string_push_str shims ? == p 112 `i8* %a` ? == p 119 `i32 %a` `i64 %a` ) ( string_push_int shims k2 ) = k2 + k2 1 }
                                 ( string_push_str shims `) {\n` )
-                                : ~ i k3 0 ~ < k3 ( string_len pms ) { : i p ( string_get pms k3 ) ? != p 112 { ( string_push_str shims `  %t` ) ( string_push_int shims k3 ) ( string_push_str shims ` = trunc i64 %a` ) ( string_push_int shims k3 ) ( string_push_str shims ` to i32\n` ) } {} = k3 + k3 1 }
+                                : ~ i k3 0 ~ < k3 ( string_len pms ) { : i p ( string_get pms k3 ) ? & != p 112 != p 119 { ( string_push_str shims `  %t` ) ( string_push_int shims k3 ) ( string_push_str shims ` = trunc i64 %a` ) ( string_push_int shims k3 ) ( string_push_str shims ` to i32\n` ) } {} = k3 + k3 1 }
                                 ( string_push_str shims `  %r = tail call ` )
                                 ( string_push_str shims ? == r_char 112 `i8*` ? == r_char 118 `void` `i32` )
                                 ( string_push_str shims ` @` ) ( string_push_str shims ( string_data name ) ) ( string_push_char shims 40 )
                                 : ~ i k4 0 ~ < k4 ( string_len pms ) {
                                     ? > k4 0 { ( string_push_str shims `, ` ) } {}
-                                    : i p ( string_get pms k4 ) ? == p 112 { ( string_push_str shims `i8* %a` ) ( string_push_int shims k4 ) } { ( string_push_str shims `i32 %t` ) ( string_push_int shims k4 ) }
+                                    : i p ( string_get pms k4 ) ? == p 112 { ( string_push_str shims `i8* %a` ) ( string_push_int shims k4 ) } { ? == p 119 { ( string_push_str shims `i32 %a` ) ( string_push_int shims k4 ) } { ( string_push_str shims `i32 %t` ) ( string_push_int shims k4 ) } }
                                     = k4 + k4 1
                                 }
                                 ( string_push_str shims `)\n` )
@@ -902,14 +914,48 @@ s combined_stdout s combined_stderr → v {
                     // GPU package's cuda/nvrtc symbols) are resolved as wasm
                     // IMPORTS by the host runtime, not linked natively — so the
                     // native build-time sentinel gate must be skipped here.
-                    : ( Vec s ) nurlc_args ( vec_new [s] ) ( vec_push [s] nurlc_args ( string_data nu_path ) ) ( vec_push [s] nurlc_args `--ffi-host-imports` )
-                    : !Output ProcessErr nurlc_res ( process_run ( string_data ( get_nurlc_path ) ) nurlc_args `` ) ( vec_free [s] nurlc_args )
-
-                    ?? nurlc_res {
-                        T n_out → {
-                            : i n_rc ( output_exit_code n_out )
-                            ? ( output_success n_out ) {
-                                : String ir ( string_from ( output_stdout n_out ) )
+                    // The IR source is either a caller-supplied `ir` field
+                    // (a host nurlc already resolved the package's $-imports —
+                    // the only way to wasm-build a MULTI-FILE package, whose deps
+                    // don't exist in this container) or produced by running
+                    // nurlc on the single uploaded source. The rewrite + link
+                    // tail is shared. --ffi-host-imports skips the native FFI
+                    // sentinel gate (cuda/nvrtc become wasm imports).
+                    : s provided_ir ( get_common_json root `ir` `` )
+                    : ~ String ir ( string_new )
+                    : ~ String n_se_s ( string_new )
+                    : ~ i n_rc 0
+                    : ~ b nok F
+                    : ~ b proc_ok T
+                    ? != 0 ( nurl_str_len provided_ir ) {
+                        ( string_free ir ) = ir ( string_from provided_ir ) = nok T
+                    } {
+                        : ( Vec s ) nurlc_args ( vec_new [s] ) ( vec_push [s] nurlc_args ( string_data nu_path ) ) ( vec_push [s] nurlc_args `--ffi-host-imports` )
+                        : !Output ProcessErr nurlc_res ( process_run ( string_data ( get_nurlc_path ) ) nurlc_args `` ) ( vec_free [s] nurlc_args )
+                        ?? nurlc_res {
+                            T n_out → {
+                                = n_rc ( output_exit_code n_out )
+                                = nok ( output_success n_out )
+                                ( string_free n_se_s ) = n_se_s ( string_from ( output_stderr n_out ) )
+                                ? nok { ( string_free ir ) = ir ( string_from ( output_stdout n_out ) ) } {}
+                                ( output_free n_out )
+                            }
+                            F _ → { = proc_ok F }
+                        }
+                    }
+                    ? ! proc_ok {
+                        ( string_free ir ) ( string_free n_se_s ) ( json_free root )
+                        ( string_free nu_path ) ( string_free ll_path ) ( string_free wasm_path )
+                        ( string_free build_id ) ( string_free build_dir ) ( string_free body_str )
+                        ^ ( response_text 500 `{"error":"nurlc process failed"}\n` )
+                    } {}
+                    ? ! nok {
+                        : HttpResponse hr_err ( nurlc_failure_response filename n_rc ( string_data n_se_s ) 0 )
+                        ( string_free ir ) ( string_free n_se_s ) ( json_free root )
+                        ( string_free nu_path ) ( string_free ll_path ) ( string_free wasm_path )
+                        ( string_free build_id ) ( string_free build_dir ) ( string_free body_str )
+                        ^ hr_err
+                    } {}
                                 : String ir_fixed ( prepare_ir_for_wasi ir )
                                 ( write_file ( string_data ll_path ) ( string_data ir_fixed ) )
                                 ( string_free ir )
@@ -956,7 +1002,7 @@ s combined_stdout s combined_stderr → v {
                                     T c_out → {
                                         : ~ i c_rc ( output_exit_code c_out )
                                         : s c_se ( output_stderr c_out )
-                                        : s n_se ( output_stderr n_out )
+                                        : s n_se ( string_data n_se_s )
                                         : String combined_stderr ( combine_stderr n_se c_se )
 
                                         // ── Asyncify wrap for canvas programs ──────────────────
@@ -1047,21 +1093,13 @@ s combined_stdout s combined_stderr → v {
                                         ( response_set_header hr `Content-Type` `application/json` )
 
                                         ( string_free b64 ) ( string_free wasm_url ) ( string_free combined_stderr ) ( json_free res ) ( string_free ir_fixed )
-                                        ( output_free n_out ) ( output_free c_out ) ( json_free root )
+                                        ( string_free n_se_s ) ( output_free c_out ) ( json_free root )
                                         ( string_free nu_path ) ( string_free ll_name ) ( string_free ll_path ) ( string_free wasm_name ) ( string_free wasm_path )
                                         ( string_free build_id ) ( string_free build_dir ) ( string_free body_str ) ( string_free body )
                                         ^ hr
                                     }
-                                    F ce → { ( string_free ir_fixed ) ^ ( response_text 500 `{"error":"wasi-clang failed"}\n` ) }
+                                    F ce → { ( string_free ir_fixed ) ( string_free n_se_s ) ^ ( response_text 500 `{"error":"wasi-clang failed"}\n` ) }
                                 }
-                            } {
-                                : HttpResponse hr_err ( nurlc_failure_response filename ( output_exit_code n_out ) ( output_stderr n_out ) ( nurl_str_len ( output_stdout n_out ) ) )
-                                ( output_free n_out ) ( json_free root ) ( string_free nu_path ) ( string_free ll_path ) ( string_free wasm_path ) ( string_free build_id ) ( string_free build_dir ) ( string_free body_str )
-                                ^ hr_err
-                            }
-                        }
-                        F _ → { ^ ( response_text 500 `{"error":"nurlc failed"}\n` ) }
-                    }
                 }
                 F _ → { ^ ( response_text 500 `{"error":"could not create build dir"}\n` ) }
             }

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -898,7 +898,11 @@ s combined_stdout s combined_stderr → v {
                     : b uses_canvas >= ( nurl_str_find source `stdlib/ext/canvas.nu` ) 0
                     : b uses_audio >= ( nurl_str_find source `stdlib/ext/audio.nu` ) 0
 
-                    : ( Vec s ) nurlc_args ( vec_new [s] ) ( vec_push [s] nurlc_args ( string_data nu_path ) )
+                    // --ffi-host-imports: external `&`-FFI libraries (e.g. the
+                    // GPU package's cuda/nvrtc symbols) are resolved as wasm
+                    // IMPORTS by the host runtime, not linked natively — so the
+                    // native build-time sentinel gate must be skipped here.
+                    : ( Vec s ) nurlc_args ( vec_new [s] ) ( vec_push [s] nurlc_args ( string_data nu_path ) ) ( vec_push [s] nurlc_args `--ffi-host-imports` )
                     : !Output ProcessErr nurlc_res ( process_run ( string_data ( get_nurlc_path ) ) nurlc_args `` ) ( vec_free [s] nurlc_args )
 
                     ?? nurlc_res {
@@ -934,11 +938,16 @@ s combined_stdout s combined_stderr → v {
                                 // compiling >150-function programs). --no-gc-sections keeps the
                                 // table stable so indices stay valid.
                                 ( vec_push [s] clang_args `-Wl,--no-gc-sections` )
+                                // Undefined symbols become wasm IMPORTS the host
+                                // runtime resolves (WASI, and — via the GPU
+                                // package's cuda/nvrtc FFI — a CUDA host bridge).
+                                // A genuinely missing symbol then traps at run
+                                // time with its name, under our wasmtime.
+                                ( vec_push [s] clang_args `-Wl,--allow-undefined` )
                                 ( vec_push [s] clang_args ( string_data ll_path ) )
                                 ( vec_push [s] clang_args ( string_data ( get_runtime_wasm_o ) ) )
                                 ? uses_canvas { ( vec_push [s] clang_args ( string_data ( get_canvas_wasm_o ) ) ) } {}
                                 ? uses_audio { ( vec_push [s] clang_args ( string_data ( get_audio_wasm_o ) ) ) } {}
-                                ? | uses_canvas uses_audio { ( vec_push [s] clang_args `-Wl,--allow-undefined` ) } {}
                                 ( vec_push [s] clang_args `-o` ) ( vec_push [s] clang_args ( string_data wasm_path ) ) ( vec_push [s] clang_args `-lm` )
 
                                 : !Output ProcessErr clang_res ( process_run ( string_data ( get_wasi_clang ) ) clang_args `` ) ( vec_free [s] clang_args )

--- a/packages/gpu/src/cpu.nu
+++ b/packages/gpu/src/cpu.nu
@@ -21,8 +21,8 @@ $ `stdlib/std/fs.nu`
 & `c` @ dlsym *u handle s name → *u
 & `c` @ dlclose *u handle → i
 & `c` @ system s cmd → i
-& `c` @ nurl_peek_i32 *u base i idx → i
-& `c` @ nurl_poke_i32 *u base i idx i val → v
+& `c` @ nurl_peek_i32 *u base i idx → i32
+& `c` @ nurl_poke_i32 *u base i idx i32 val → v
 & `c` @ nurl_cpu_launch *u fn *u params i grid i block → v
 
 // ── CUDA-C → host source generation ───────────────────────────────

--- a/packages/gpu/src/cuda.nu
+++ b/packages/gpu/src/cuda.nu
@@ -37,12 +37,16 @@ $ `stdlib/core/string.nu`
 & `cuda` @ cuGetErrorName i32 err *u pstr → i32
 
 // ── NVRTC (runtime CUDA-C → PTX) ──────────────────────────────────
+// nvrtcCreateProgram / nvrtcDestroyProgram take nvrtcProgram* (a pointer to
+// the handle slot) → *u out-slot offset. The rest take the nvrtcProgram
+// handle BY VALUE → i (i64), portable across native/wasm (see the driver
+// handles above); their remaining *u are genuine out/data offsets.
 & `nvrtc` @ nvrtcCreateProgram *u prog s src s name i32 nh *u headers *u incs → i32
-& `nvrtc` @ nvrtcCompileProgram *u prog i32 nopt *u opts → i32
-& `nvrtc` @ nvrtcGetPTXSize *u prog *u sz → i32
-& `nvrtc` @ nvrtcGetPTX *u prog *u ptx → i32
-& `nvrtc` @ nvrtcGetProgramLogSize *u prog *u sz → i32
-& `nvrtc` @ nvrtcGetProgramLog *u prog *u log → i32
+& `nvrtc` @ nvrtcCompileProgram i prog i32 nopt *u opts → i32
+& `nvrtc` @ nvrtcGetPTXSize i prog *u sz → i32
+& `nvrtc` @ nvrtcGetPTX i prog *u ptx → i32
+& `nvrtc` @ nvrtcGetProgramLogSize i prog *u sz → i32
+& `nvrtc` @ nvrtcGetProgramLog i prog *u log → i32
 & `nvrtc` @ nvrtcDestroyProgram *u prog → i32
 
 // ── typed 4-byte buffer accessors (runtime.c, always linked) ──────
@@ -108,7 +112,7 @@ $ `stdlib/core/string.nu`
         ( nurl_eprint `[gpu/cuda] nvrtcCreateProgram failed\n` )
         ^ # *u 0
     } {}
-    : *u prog # *u ( nurl_peek ps 0 )
+    : i prog ( nurl_peek ps 0 )
     : i cr # i ( nvrtcCompileProgram prog 0 0 )
     ? != cr 0 {
         : *u ls ( __outslot )

--- a/packages/gpu/src/cuda.nu
+++ b/packages/gpu/src/cuda.nu
@@ -54,8 +54,12 @@ $ `stdlib/core/string.nu`
 // nurl_peek/poke can't address them at their natural stride.
 & `c` @ nurl_peek_f32 *u base i idx → f
 & `c` @ nurl_poke_f32 *u base i idx f val → v
-& `c` @ nurl_peek_i32 *u base i idx → i
-& `c` @ nurl_poke_i32 *u base i idx i val → v
+// nurl_peek_i32 returns a C `int` and nurl_poke_i32 takes a C `int` value —
+// both 32-bit. Declaring them with i64 (`i`) worked on LP64 native (the ABI
+// register ignores the high bits) but is a hard signature mismatch on wasm,
+// where wasm-ld then replaces the caller with an `unreachable` stub.
+& `c` @ nurl_peek_i32 *u base i idx → i32
+& `c` @ nurl_poke_i32 *u base i idx i32 val → v
 
 // ── out-param helper ──────────────────────────────────────────────
 // Allocate a zeroed 8-byte slot for a `*` out-parameter. Zeroing matters

--- a/packages/gpu/src/cuda.nu
+++ b/packages/gpu/src/cuda.nu
@@ -24,16 +24,16 @@ $ `stdlib/core/string.nu`
 & `cuda` @ cuDeviceGet *u device i32 ordinal → i32
 & `cuda` @ cuDeviceGetName *u name i32 len i32 dev → i32
 & `cuda` @ cuCtxCreate *u pctx i32 flags i32 dev → i32
-& `cuda` @ cuCtxDestroy *u ctx → i32
+& `cuda` @ cuCtxDestroy i ctx → i32
 & `cuda` @ cuCtxSynchronize → i32
 & `cuda` @ cuModuleLoadData *u module *u image → i32
-& `cuda` @ cuModuleUnload *u module → i32
-& `cuda` @ cuModuleGetFunction *u hfunc *u hmod s name → i32
+& `cuda` @ cuModuleUnload i module → i32
+& `cuda` @ cuModuleGetFunction *u hfunc i hmod s name → i32
 & `cuda` @ cuMemAlloc *u dptr i bytesize → i32
 & `cuda` @ cuMemFree i dptr → i32
 & `cuda` @ cuMemcpyHtoD i dst *u src i n → i32
 & `cuda` @ cuMemcpyDtoH *u dst i src i n → i32
-& `cuda` @ cuLaunchKernel *u f i32 gx i32 gy i32 gz i32 bx i32 by i32 bz i32 sh *u stream *u params *u extra → i32
+& `cuda` @ cuLaunchKernel i f i32 gx i32 gy i32 gz i32 bx i32 by i32 bz i32 sh i stream *u params i extra → i32
 & `cuda` @ cuGetErrorName i32 err *u pstr → i32
 
 // ── NVRTC (runtime CUDA-C → PTX) ──────────────────────────────────
@@ -95,7 +95,7 @@ $ `stdlib/core/string.nu`
     ^ ( nurl_peek s 0 )
 }
 
-@ cuda_ctx_destroy i ctx → i { ^ # i ( cuCtxDestroy # *u ctx ) }
+@ cuda_ctx_destroy i ctx → i { ^ # i ( cuCtxDestroy ctx ) }
 
 @ cuda_sync → i { ^ # i ( cuCtxSynchronize ) }
 
@@ -138,11 +138,11 @@ $ `stdlib/core/string.nu`
     ^ ( nurl_peek s 0 )
 }
 
-@ cuda_module_unload i module → i { ^ # i ( cuModuleUnload # *u module ) }
+@ cuda_module_unload i module → i { ^ # i ( cuModuleUnload module ) }
 
 @ cuda_function i module s name → i {
     : *u s ( __outslot )
-    ? != # i ( cuModuleGetFunction s # *u module name ) 0 { ^ 0 } {}
+    ? != # i ( cuModuleGetFunction s module name ) 0 { ^ 0 } {}
     ^ ( nurl_peek s 0 )
 }
 
@@ -163,7 +163,7 @@ $ `stdlib/core/string.nu`
 // `params` is a void** array of pointers to the argument values (built
 // by gpu.nu from a Vec of i64-encoded args). 1-D grid/block for now.
 @ cuda_launch i func i grid i block *u params → i {
-    ^ # i ( cuLaunchKernel # *u func # i32 grid 1 1 # i32 block 1 1 0 0 params 0 )
+    ^ # i ( cuLaunchKernel func # i32 grid 1 1 # i32 block 1 1 0 0 params 0 )
 }
 
 // CUresult code → driver error-name string (e.g. "CUDA_ERROR_INVALID_VALUE").

--- a/packages/gpu/src/gpu.nu
+++ b/packages/gpu/src/gpu.nu
@@ -115,7 +115,7 @@ $ `cpu.nu`
 @ gpu_host_set_f32 *u buf i idx f v → v { ( nurl_poke_f32 buf idx v ) }
 @ gpu_host_get_f32 *u buf i idx → f { ^ ( nurl_peek_f32 buf idx ) }
 @ gpu_host_set_i32 *u buf i idx i v → v { ( nurl_poke_i32 buf idx v ) }
-@ gpu_host_get_i32 *u buf i idx → i { ^ ( nurl_peek_i32 buf idx ) }
+@ gpu_host_get_i32 *u buf i idx → i { ^ # i ( nurl_peek_i32 buf idx ) }
 
 // ── device memory ─────────────────────────────────────────────────
 

--- a/packages/onnx/src/pb.nu
+++ b/packages/onnx/src/pb.nu
@@ -176,4 +176,4 @@ $ `stdlib/std/bytes.nu`
 }
 
 // 4-byte typed store (runtime.c accessor; runtime.o is always linked).
-& `c` @ nurl_poke_i32 *u base i idx i val → v
+& `c` @ nurl_poke_i32 *u base i idx i32 val → v

--- a/packages/wasmtime/README.md
+++ b/packages/wasmtime/README.md
@@ -91,6 +91,43 @@ thing, and is ASan-clean. `tests/wasi_test.nu` covers the import path: a module
 that writes via `fd_write` and exits via `proc_exit`, matching reference output
 and exit code.
 
+## GPU host imports (CUDA / NVRTC)
+
+A wasm module built from a GPU-using NURL package (`packages/gpu` →
+[`onnx`](../onnx) → [`objdet`](../objdet)) imports the CUDA driver + NVRTC
+symbols under module `env`. This runtime resolves them to the real
+`libcuda` / `libnvrtc` on the host, marshalling guest linear memory ↔ host:
+
+- a `*u` (pointer) FFI parameter is a guest linear-memory offset → the host
+  address is `vec_data(mem) + offset`; libcuda reads/writes guest memory in
+  place, so `cuMemcpyHtoD` / `cuMemcpyDtoH` and every out-slot are zero-copy;
+- opaque handles (`CUcontext` / `CUmodule` / `CUfunction` / `nvrtcProgram`)
+  and `CUdeviceptr` travel as raw `i64` values (the portable handle model in
+  `packages/gpu`, so nothing truncates on wasm's 32-bit pointers);
+- `cuLaunchKernel`'s guest `void**` argument array is reconstructed as a host
+  `void**` with each entry translated to its host address.
+
+`nurl.sh` auto-links `libcuda`/`libnvrtc` when these symbols appear and links
+stub objects on a GPU-less host, so `wasmtime` always builds; a guest then
+just sees non-zero `CUresult` codes.
+
+```sh
+# a GPU wasm module runs its kernels on the real device through this runtime
+wasmtime run --dir . infer.wasm          # onnx forward pass on the GPU
+```
+
+Verified on an RTX 4090: a self-contained vector-add (NVRTC compile → module
+load → alloc → HtoD → launch → DtoH) and the `onnx` package's inference test
+(a full GPU forward pass) both run through this runtime with output
+**identical to native** — the `onnx` test even matches its onnxruntime
+reference. See the top-level PR for the toolchain path (compile a GPU package
+to wasm with FFI symbols as host imports).
+
+> Security note: raw host handles / device pointers are visible to the guest,
+> exactly as in native NURL — safe for trusted compute (your own kernels). An
+> untrusted-guest deployment would add an id↔pointer handle table in the
+> bridge; the seam is a single `__gpu_ptr` / handle-passthrough boundary.
+
 ## Roadmap
 
 The integer + float core and the WASI command surface are done; hosting larger

--- a/packages/wasmtime/nurl.toml
+++ b/packages/wasmtime/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime"
-version = "0.4.0"
+version = "0.5.0"
 description = "A WebAssembly runtime written in pure NURL — load a wasm module and run it, with no external runtime. It decodes a wasm binary (all standard sections incl. the name section) and interprets the full MVP instruction set with spec-correct semantics — trapping division/truncation, NaN-correct comparisons and min/max, checked call_indirect — plus the multi-value, bulk-memory (memory.init/copy/fill, passive segments), reference-types (table.*, ref.null/func, typed select) and sign-extension proposals. Execution runs on an explicit frame stack (guest recursion never grows the host stack; 1M-deep recursion verified), with optional --fuel metering and wasm backtraces on trap. It hosts real wasm32-wasi command modules: proc_exit, fd_write/read/seek/tell/pread/pwrite/sync/readdir, args_*/environ_* (--env), real clock/random, repeatable --dir preopens with path_open/create/remove/unlink/rename/filestat. The NURL compiler itself runs on it: nurlc.wasm self-compiles byte-identically to the native compiler. 33 edge-case semantics tests, every expectation produced by the reference wasmtime. No dependencies."
 license = "MIT OR Apache-2.0"
 

--- a/packages/wasmtime/src/interp.nu
+++ b/packages/wasmtime/src/interp.nu
@@ -31,6 +31,37 @@ $ `module.nu`
 // unlink(2): path_unlink_file must NOT remove directories (remove(3) would).
 & `c` @ unlink s path → i32
 
+// ── CUDA driver + NVRTC (the GPU host-import bridge) ──────────────
+// A wasm module built from a GPU-using NURL package (packages/gpu →
+// onnx → objdet) imports these under module "env"; wasmtime resolves them
+// to the real libcuda/libnvrtc here, marshalling guest linear memory ↔
+// host. nurl.sh auto-links libcuda/libnvrtc when these symbols appear, and
+// links stub objects on a GPU-less host (so wasmtime always builds; the
+// guest then just sees nonzero CUresult codes). Handle types match the
+// portable i64 model in packages/gpu/src/cuda.nu.
+& `cuda` @ cuInit i32 flags → i32
+& `cuda` @ cuDeviceGetCount *u count → i32
+& `cuda` @ cuDeviceGet *u device i32 ordinal → i32
+& `cuda` @ cuDeviceGetName *u name i32 len i32 dev → i32
+& `cuda` @ cuCtxCreate *u pctx i32 flags i32 dev → i32
+& `cuda` @ cuCtxDestroy i ctx → i32
+& `cuda` @ cuCtxSynchronize → i32
+& `cuda` @ cuModuleLoadData *u module *u image → i32
+& `cuda` @ cuModuleUnload i module → i32
+& `cuda` @ cuModuleGetFunction *u hfunc i hmod s name → i32
+& `cuda` @ cuMemAlloc *u dptr i bytesize → i32
+& `cuda` @ cuMemFree i dptr → i32
+& `cuda` @ cuMemcpyHtoD i dst *u src i n → i32
+& `cuda` @ cuMemcpyDtoH *u dst i src i n → i32
+& `cuda` @ cuLaunchKernel i f i32 gx i32 gy i32 gz i32 bx i32 by i32 bz i32 sh i stream *u params i extra → i32
+& `nvrtc` @ nvrtcCreateProgram *u prog s src s name i32 nh *u headers *u incs → i32
+& `nvrtc` @ nvrtcCompileProgram i prog i32 nopt *u opts → i32
+& `nvrtc` @ nvrtcGetPTXSize i prog *u sz → i32
+& `nvrtc` @ nvrtcGetPTX i prog *u ptx → i32
+& `nvrtc` @ nvrtcGetProgramLogSize i prog *u sz → i32
+& `nvrtc` @ nvrtcGetProgramLog i prog *u log → i32
+& `nvrtc` @ nvrtcDestroyProgram *u prog → i32
+
 // ── value + control stacks ───────────────────────────────────────
 
 : Arg { ( Vec u ) bytes }
@@ -1817,7 +1848,221 @@ $ `module.nu`
     = . it trapmsg msg
 }
 
+// ── GPU host bridge (CUDA driver + NVRTC) ─────────────────────────
+// Guest imports (module "env") are hand-bridged to the real libcuda /
+// libnvrtc. Marshalling rule, matching packages/gpu/src/cuda.nu's ABI:
+//   • a `*u` parameter is a GUEST linear-memory OFFSET → host address is
+//     (host base of guest memory) + offset; NULL(0) stays NULL. libcuda
+//     reads/writes guest memory in place — data copies are zero-copy.
+//   • an `i` handle (CUcontext/CUmodule/CUfunction/nvrtcProgram) or a
+//     CUdeviceptr is a raw 64-bit value → passed straight through.
+// NOTE: raw host handles/device pointers are visible to the guest, exactly
+// as in native NURL. Safe for trusted compute (our own kernels); an
+// untrusted-guest deployment would add an id↔pointer handle table here.
+
+// Host base address of the guest linear memory (recomputed per call — a
+// memory.grow between host calls may relocate the backing).
+@ __gpu_base * Interp it → i { ^ # i ( vec_data [u] . it mem ) }
+
+// Guest offset → host pointer (NULL stays NULL).
+@ __gpu_ptr * Interp it i off → *u {
+    : i o & off 4294967295
+    ? == o 0 { ^ # *u 0 } {}
+    ^ # *u + ( __gpu_base it ) o
+}
+
+@ __cu_init * Interp it → v {
+    : i flags ( __pop it )
+    ( __push it # i ( cuInit # i32 flags ) )
+}
+@ __cu_device_get_count * Interp it → v {
+    : i count ( __pop it )
+    ( __push it # i ( cuDeviceGetCount ( __gpu_ptr it count ) ) )
+}
+@ __cu_device_get * Interp it → v {
+    : i ordinal ( __pop it )
+    : i device ( __pop it )
+    ( __push it # i ( cuDeviceGet ( __gpu_ptr it device ) # i32 ordinal ) )
+}
+@ __cu_device_get_name * Interp it → v {
+    : i dev ( __pop it )
+    : i len ( __pop it )
+    : i name ( __pop it )
+    ( __push it # i ( cuDeviceGetName ( __gpu_ptr it name ) # i32 len # i32 dev ) )
+}
+@ __cu_ctx_create * Interp it → v {
+    : i dev ( __pop it )
+    : i flags ( __pop it )
+    : i pctx ( __pop it )
+    ( __push it # i ( cuCtxCreate ( __gpu_ptr it pctx ) # i32 flags # i32 dev ) )
+}
+@ __cu_ctx_destroy * Interp it → v {
+    : i ctx ( __pop it )
+    ( __push it # i ( cuCtxDestroy ctx ) )
+}
+@ __cu_ctx_sync * Interp it → v { ( __push it # i ( cuCtxSynchronize ) ) }
+@ __cu_module_load * Interp it → v {
+    : i image ( __pop it )
+    : i module ( __pop it )
+    ( __push it # i ( cuModuleLoadData ( __gpu_ptr it module ) ( __gpu_ptr it image ) ) )
+}
+@ __cu_module_unload * Interp it → v {
+    : i module ( __pop it )
+    ( __push it # i ( cuModuleUnload module ) )
+}
+@ __cu_module_get_function * Interp it → v {
+    : i name ( __pop it )
+    : i hmod ( __pop it )
+    : i hfunc ( __pop it )
+    ( __push it # i ( cuModuleGetFunction ( __gpu_ptr it hfunc ) hmod # s ( __gpu_ptr it name ) ) )
+}
+@ __cu_mem_alloc * Interp it → v {
+    : i bytesize ( __pop it )
+    : i dptr ( __pop it )
+    ( __push it # i ( cuMemAlloc ( __gpu_ptr it dptr ) bytesize ) )
+}
+@ __cu_mem_free * Interp it → v {
+    : i dptr ( __pop it )
+    ( __push it # i ( cuMemFree dptr ) )
+}
+@ __cu_memcpy_htod * Interp it → v {
+    : i n ( __pop it )
+    : i src ( __pop it )
+    : i dst ( __pop it )
+    ( __push it # i ( cuMemcpyHtoD dst ( __gpu_ptr it src ) n ) )
+}
+@ __cu_memcpy_dtoh * Interp it → v {
+    : i n ( __pop it )
+    : i src ( __pop it )
+    : i dst ( __pop it )
+    ( __push it # i ( cuMemcpyDtoH ( __gpu_ptr it dst ) src n ) )
+}
+// cuLaunchKernel's `params` is a guest void** — an array of guest pointers,
+// each addressing an 8-byte argument cell in guest memory. CUDA needs a
+// HOST void** whose entries are host addresses. Since the arg cells live in
+// guest memory, translate each entry to (base + entry). The kernel's own
+// parameter count bounds how many entries CUDA reads; the guest builds the
+// array contiguously and each entry points at base_args + i*8, so the region
+// is contiguous — reconstruct a host copy the same length as the guest array
+// implies. We don't know the exact count here, so we translate a bounded run
+// (up to __GPU_MAX_ARGS) of entries; CUDA reads only the real count and
+// ignores the rest, and each translated entry is a valid host address.
+@ __GPU_MAX_ARGS → i { ^ 64 }
+@ __cu_launch_kernel * Interp it → v {
+    : i extra ( __pop it )
+    : i params ( __pop it )
+    : i stream ( __pop it )
+    : i sh ( __pop it )
+    : i bz ( __pop it )
+    : i by ( __pop it )
+    : i bx ( __pop it )
+    : i gz ( __pop it )
+    : i gy ( __pop it )
+    : i gx ( __pop it )
+    : i f ( __pop it )
+    : i base ( __gpu_base it )
+    : i poff & params 4294967295
+    // Build a host void** by translating each guest entry (guest ptr → host
+    // ptr) into a fresh host buffer. Entry i lives at guest offset poff+i*8.
+    : *u hostp ( nurl_alloc * ( __GPU_MAX_ARGS ) 8 )
+    : i memlen ( vec_len [u] . it mem )
+    : ~ i k 0
+    ~ & < k ( __GPU_MAX_ARGS ) <= + + poff * k 8 8 memlen {
+        : i ent & ( __mem_load it + poff * k 8 8 0 ) 4294967295
+        ( nurl_poke hostp k ? == ent 0 0 + base ent )
+        = k + k 1
+    }
+    : i rc # i ( cuLaunchKernel f # i32 gx # i32 gy # i32 gz # i32 bx # i32 by # i32 bz # i32 sh stream hostp extra )
+    ( nurl_free # s hostp )
+    ( __push it rc )
+}
+@ __cu_get_error_name * Interp it → v {
+    // Writes a HOST const char* into the guest out-slot — unusable as a guest
+    // offset. Write NULL so cuda_error_name falls back to a static string;
+    // diagnostics only, never on the compute path.
+    : i pstr ( __pop it )
+    : i err ( __pop it )
+    ( __mem_store it & pstr 4294967295 8 0 )
+    ( __push it 0 )
+}
+@ __nvrtc_create * Interp it → v {
+    : i incs ( __pop it )
+    : i headers ( __pop it )
+    : i nh ( __pop it )
+    : i name ( __pop it )
+    : i src ( __pop it )
+    : i prog ( __pop it )
+    ( __push it # i ( nvrtcCreateProgram ( __gpu_ptr it prog ) # s ( __gpu_ptr it src ) # s ( __gpu_ptr it name ) # i32 nh ( __gpu_ptr it headers ) ( __gpu_ptr it incs ) ) )
+}
+@ __nvrtc_compile * Interp it → v {
+    : i opts ( __pop it )
+    : i nopt ( __pop it )
+    : i prog ( __pop it )
+    ( __push it # i ( nvrtcCompileProgram prog # i32 nopt ( __gpu_ptr it opts ) ) )
+}
+@ __nvrtc_ptx_size * Interp it → v {
+    : i sz ( __pop it )
+    : i prog ( __pop it )
+    ( __push it # i ( nvrtcGetPTXSize prog ( __gpu_ptr it sz ) ) )
+}
+@ __nvrtc_get_ptx * Interp it → v {
+    : i ptx ( __pop it )
+    : i prog ( __pop it )
+    ( __push it # i ( nvrtcGetPTX prog ( __gpu_ptr it ptx ) ) )
+}
+@ __nvrtc_log_size * Interp it → v {
+    : i sz ( __pop it )
+    : i prog ( __pop it )
+    ( __push it # i ( nvrtcGetProgramLogSize prog ( __gpu_ptr it sz ) ) )
+}
+@ __nvrtc_get_log * Interp it → v {
+    : i log ( __pop it )
+    : i prog ( __pop it )
+    ( __push it # i ( nvrtcGetProgramLog prog ( __gpu_ptr it log ) ) )
+}
+@ __nvrtc_destroy * Interp it → v {
+    : i prog ( __pop it )
+    ( __push it # i ( nvrtcDestroyProgram ( __gpu_ptr it prog ) ) )
+}
+
+// GPU host-import dispatch (module "env"). Returns T if handled.
+@ __gpu_dispatch * Interp it ( Vec u ) field → b {
+    ? ( __feq field `cuInit` ) { ( __cu_init it ) ^ T } {}
+    ? ( __feq field `cuDeviceGetCount` ) { ( __cu_device_get_count it ) ^ T } {}
+    ? ( __feq field `cuDeviceGet` ) { ( __cu_device_get it ) ^ T } {}
+    ? ( __feq field `cuDeviceGetName` ) { ( __cu_device_get_name it ) ^ T } {}
+    ? ( __feq field `cuCtxCreate` ) { ( __cu_ctx_create it ) ^ T } {}
+    ? ( __feq field `cuCtxCreate_v2` ) { ( __cu_ctx_create it ) ^ T } {}
+    ? ( __feq field `cuCtxDestroy` ) { ( __cu_ctx_destroy it ) ^ T } {}
+    ? ( __feq field `cuCtxSynchronize` ) { ( __cu_ctx_sync it ) ^ T } {}
+    ? ( __feq field `cuModuleLoadData` ) { ( __cu_module_load it ) ^ T } {}
+    ? ( __feq field `cuModuleUnload` ) { ( __cu_module_unload it ) ^ T } {}
+    ? ( __feq field `cuModuleGetFunction` ) { ( __cu_module_get_function it ) ^ T } {}
+    ? ( __feq field `cuMemAlloc` ) { ( __cu_mem_alloc it ) ^ T } {}
+    ? ( __feq field `cuMemAlloc_v2` ) { ( __cu_mem_alloc it ) ^ T } {}
+    ? ( __feq field `cuMemFree` ) { ( __cu_mem_free it ) ^ T } {}
+    ? ( __feq field `cuMemFree_v2` ) { ( __cu_mem_free it ) ^ T } {}
+    ? ( __feq field `cuMemcpyHtoD` ) { ( __cu_memcpy_htod it ) ^ T } {}
+    ? ( __feq field `cuMemcpyHtoD_v2` ) { ( __cu_memcpy_htod it ) ^ T } {}
+    ? ( __feq field `cuMemcpyDtoH` ) { ( __cu_memcpy_dtoh it ) ^ T } {}
+    ? ( __feq field `cuMemcpyDtoH_v2` ) { ( __cu_memcpy_dtoh it ) ^ T } {}
+    ? ( __feq field `cuLaunchKernel` ) { ( __cu_launch_kernel it ) ^ T } {}
+    ? ( __feq field `cuGetErrorName` ) { ( __cu_get_error_name it ) ^ T } {}
+    ? ( __feq field `nvrtcCreateProgram` ) { ( __nvrtc_create it ) ^ T } {}
+    ? ( __feq field `nvrtcCompileProgram` ) { ( __nvrtc_compile it ) ^ T } {}
+    ? ( __feq field `nvrtcGetPTXSize` ) { ( __nvrtc_ptx_size it ) ^ T } {}
+    ? ( __feq field `nvrtcGetPTX` ) { ( __nvrtc_get_ptx it ) ^ T } {}
+    ? ( __feq field `nvrtcGetProgramLogSize` ) { ( __nvrtc_log_size it ) ^ T } {}
+    ? ( __feq field `nvrtcGetProgramLog` ) { ( __nvrtc_get_log it ) ^ T } {}
+    ? ( __feq field `nvrtcDestroyProgram` ) { ( __nvrtc_destroy it ) ^ T } {}
+    ^ F
+}
+
 @ __wasi_dispatch * Interp it ( Vec u ) mod ( Vec u ) field → v {
+    ? ( __feq mod `env` ) {
+        ? ( __gpu_dispatch it field ) { ^ v } {}
+        ( __trap_named it `unsupported env import: ` field ) ^ v
+    } {}
     ? ! ( __feq mod `wasi_snapshot_preview1` ) {
         ( __trap_named it `unsupported import module: ` mod ) ^ v } {}
     ? ( __feq field `proc_exit` ) { ( __wasi_proc_exit it ) ^ v } {}

--- a/packages/yoloe/src/display.nu
+++ b/packages/yoloe/src/display.nu
@@ -14,8 +14,8 @@ $ `stdlib/core/string.nu`
 $ `image.nu`
 
 & `c` @ ioctl i fd i req *u argp → i
-& `c` @ nurl_poke_i32 *u base i idx i val → v
-& `c` @ nurl_peek_i32 *u base i idx → i
+& `c` @ nurl_poke_i32 *u base i idx i32 val → v
+& `c` @ nurl_peek_i32 *u base i idx → i32
 
 @ __TIOCGWINSZ → i { ^ 21523 }   // 0x5413; struct winsize { u16 row, col, xpx, ypx }
 

--- a/packages/yoloe/src/v4l2.nu
+++ b/packages/yoloe/src/v4l2.nu
@@ -22,8 +22,8 @@ $ `stdlib/core/string.nu`
 & `c` @ ioctl i fd i req *u argp → i
 & `c` @ mmap *u addr i length i prot i flags i fd i offset → *u
 & `c` @ munmap *u addr i length → i
-& `c` @ nurl_peek_i32 *u base i idx → i
-& `c` @ nurl_poke_i32 *u base i idx i val → v
+& `c` @ nurl_peek_i32 *u base i idx → i32
+& `c` @ nurl_poke_i32 *u base i idx i32 val → v
 
 // A streaming webcam: fd, frame geometry, and the mmap'd buffer ring.
 : Camera { i fd  i w  i h  i nbuf  ( Vec i ) bufptr  ( Vec i ) buflen  i ok }

--- a/packages/yoloe/src/window.nu
+++ b/packages/yoloe/src/window.nu
@@ -29,8 +29,8 @@ $ `image.nu`
 & `X11` @ XInternAtom *u dpy s name i only → i
 & `X11` @ XSetWMProtocols *u dpy i win *u protocols i count → i
 & `X11` @ XCloseDisplay *u dpy → i
-& `c` @ nurl_poke_i32 *u base i idx i val → v
-& `c` @ nurl_peek_i32 *u base i idx → i
+& `c` @ nurl_poke_i32 *u base i idx i32 val → v
+& `c` @ nurl_peek_i32 *u base i idx → i32
 
 // Pointers (Display*, GC, XImage*, data) carried as i64; w/h the frame size.
 : XWin { i dpy  i win  i gc  i img  i data  i w  i h  i ok }


### PR DESCRIPTION
## Summary

Gives `packages/wasmtime` (the pure-NURL WebAssembly runtime) **GPU support**: a wasm module built from a GPU-using NURL package runs its CUDA kernels on the real device *through* this runtime. Verified end to end on an RTX 4090 — the `onnx` package's inference test (a full GPU forward pass: Gemm/Relu compiled to PTX by NVRTC) runs through `wasmtime` and **matches its onnxruntime reference**, and the multi-file `objdet` package compiles to a valid, runnable wasm module.

Getting there surfaced and fixed a cluster of real, general toolchain bugs (several long-latent — the "fread unreachable" in project memory is one of them).

## What's new

**wasmtime — CUDA/NVRTC host bridge** (`src/interp.nu`)
A GPU wasm module imports the driver + NVRTC symbols under module `env`; the runtime resolves them to the real `libcuda`/`libnvrtc`, marshalling guest linear memory ↔ host:
- a `*u` (pointer) FFI parameter is a guest linear-memory offset → host address `vec_data(mem) + offset`; libcuda reads/writes guest memory in place, so `cuMemcpyHtoD`/`cuMemcpyDtoH` and out-slots are **zero-copy**;
- opaque handles (`CUcontext`/`CUmodule`/`CUfunction`/`nvrtcProgram`) and `CUdeviceptr` travel as raw `i64` (no truncation on wasm's 32-bit pointers);
- `cuLaunchKernel`'s guest `void**` argument array is reconstructed as a host `void**`.
`nurl.sh` auto-links `libcuda`/`libnvrtc` when the symbols appear and stubs them on a GPU-less host, so `wasmtime` always builds.

**Toolchain — compile a GPU package to wasm**
- `nurlc --ffi-host-imports`: external `&`-FFI libraries are satisfied by the run-time embedder (wasm imports) instead of a native link line, skipping the build-time sentinel gate.
- `nurlapi` wasm build passes that flag and links `-Wl,--allow-undefined` so cuda/nvrtc become `env` imports; a new `ir` field lets a host-side nurlc resolve a multi-file package's `$`-imports and hand the container just the IR to rewrite + link.

**Compiler — FFI call-site argument coercion** (the root of the wasm `unreachable` stubs)
An integer/pointer argument whose type differed from the FFI parameter was emitted verbatim (`i64 0` to an `i32`/`i8*` parameter, etc.). Native LLVM tolerates it; wasm is strict, so wasm-ld replaced the callee with a trapping `unreachable` stub. `nurlc` now coerces every fixed-position FFI argument (trunc/sext for int width, inttoptr/ptrtoint across the int↔pointer boundary) to match the `declare` — and registers the parameter types in the pre-pass too, so a **forward-referenced** FFI call (callee declared later in the same file) is coerced as well.

**Portability fixes**
- `packages/gpu`: opaque handles passed back in (`cuCtxDestroy`, `cuModuleGetFunction`, `cuLaunchKernel`, the NVRTC program handle) carry `i` (i64), not `*u` (which truncates on wasm); `nurl_peek_i32`/`nurl_poke_i32` declared 32-bit (they're a C `int`) in gpu/onnx/yoloe.
- `nurlapi` libc width shims: `lseek` removed (its `off_t` is 64-bit on wasm32, so NURL's declaration already matches wasi); a new `w` shim-param char for an i32 parameter nurlc emits as i32 (`fseek`'s `whence`); `ftell` returns i64; `fread`/`fwrite` param layout corrected (`pssp`). These had broken `fs.nu`'s `fopen`/`fread` file path on wasm.

## Test plan

- [x] `./build.sh` — bootstrap + full corpus pass after every compiler change
- [x] `packages/gpu` test passes on the RTX 4090 (native) after the handle/i32 ABI changes
- [x] `packages/wasmtime` suite (interp/mem/table/float/wasi/semantics) still passes
- [x] A self-contained vector-add (NVRTC compile → module load → alloc → HtoD → launch → DtoH) compiled to wasm runs through `wasmtime` on the GPU, output identical to native (`vadd OK: c[7]=77`)
- [x] `packages/onnx` inference test compiled to wasm runs a **full GPU forward pass** through `wasmtime` → `ALL PASS`, "GPU output matches onnxruntime reference"
- [x] `packages/objdet` (multi-file: objdet → onnx → gpu) compiles to a valid wasm module that runs under `wasmtime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTxirRQLtSbtdqafRNFsSx