### PR TITLE
release: 0.10.10 — local wasm builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.10] — 2026-07-03
+
+A **local wasm builds** release. The new `wasmbuilder` package turns a bare
+toolchain install into a complete NURL → wasm32-wasi compiler — no wasi-sdk,
+no Docker, no build service: the bundled `zig cc` (wasi-libc + wasm-ld
+built in) links what nurlc emits, and the wasm runtime object is compiled
+from the installed stdlib on first use. swarm-mcp compiles compute kernels
+locally on the strength of it, nurl-mcp grows a fully local
+`nurl_build_wasm` tool, and the Windows release now bundles zig like the
+Linux archives. The compiler fix underneath: enum payload slots are `i64`
+now, so f64 / >2³² payloads survive wasm32 bit-exactly — general-enum
+programs produce byte-identical output native vs wasm. Also in this
+release: swarm-mcp's GPU engine matured through v0.6.0 (runtime kernel
+params, GPU map + histogram) and v0.7.0 (distributed GPU compute over real
+uploaded datasets).
+
 ### Fixed
 
 - **Enum payload slots are now `i64`, not `ptr` — 64-bit payloads survive

--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ list and how to reproduce each locally:
 
 ---
 
+## Tooling
+
+One `curl | sh` installs the toolchain; `nurlpkg install <name>` fetches,
+builds, and installs programs from the registry at
+[reg.nurl-lang.org](https://reg.nurl-lang.org). Alongside the compiler you
+get `nurlfmt` (canonical formatter), `nurl-lsp` + a VS Code extension,
+`nurl-mcp` (drive the local toolchain from an LLM agent over MCP), and a
+wasm story that needs nothing extra: `nurlpkg install wasmbuilder` compiles
+NURL to wasm32-wasi locally, `nurlpkg install wasmtime` runs it with a
+pure-NURL runtime. Details: [`docs/TOOLING.md`](docs/TOOLING.md).
+
+---
+
 ## Documentation
 
 | Topic | Document |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-07-02 · Current release: **0.10.9** · Language: **Grammar
+_Last reviewed: 2026-07-03 · Current release: **0.10.10** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -3,7 +3,10 @@
 The build produces three host tools alongside the compiler: a formatter
 (`nurlfmt`), a language server (`nurl-lsp`), and a package manager
 (`nurlpkg`). An editor extension wires the LSP into VS Code / Cursor /
-Windsurf.
+Windsurf. On top of those, registry packages extend the toolchain itself:
+`nurl-mcp` (LLM agents drive the local compiler over MCP) and the wasm pair
+`wasmbuilder` / `wasmtime` (compile NURL to wasm32-wasi and run it, fully
+locally).
 
 ## Editor support
 
@@ -59,9 +62,11 @@ to the editors through the `tooling/vscode-nurl` extension.
 ## Package manager (`nurlpkg`)
 
 `./tools/nurlpkg/build.sh` produces `build/nurlpkg` — a Cargo-shaped package
-manager covering the full dependency lifecycle for path-based dependencies
-(registry-style version resolution is out of scope for v1). Manifests use a
-TOML subset compatible with the `stdlib/ext/toml.nu` parser.
+manager covering the full dependency lifecycle: path dependencies, registry
+dependencies resolved from [reg.nurl-lang.org](https://reg.nurl-lang.org),
+and hybrid path+registry declarations that work both in a repo checkout and
+from a published tarball. Manifests use a TOML subset compatible with the
+`stdlib/ext/toml.nu` parser.
 
 ```bash
 build/nurlpkg init demo-app                  # write nurl.toml skeleton
@@ -69,7 +74,41 @@ cd demo-app
 build/nurlpkg add http-router --path ../router --version 0.2.0
 build/nurlpkg install                        # symlink deps/, write nurl.lock
 build/nurlpkg verify                         # CI gate: exit 1 on lockfile drift
+
+nurlpkg install nq                           # cargo-install-shaped: fetch a
+                                             # registry package, build it, put
+                                             # the binary on $NURL_HOME/bin
+nurlpkg publish                              # pack + upload (token via
+                                             # `nurlpkg login`)
 ```
 
 Subcommands: `init`, `info`, `deps`, `add`, `remove`, `install`, `lock`,
-`verify`, `version`, `help`.
+`verify`, `publish`, `login`, `version`, `help`.
+
+## MCP server (`nurl-mcp`)
+
+`nurlpkg install nurl-mcp` — a local MCP server so an LLM agent can drive
+the installed toolchain: build, run, type-check, format, compile to
+wasm32-wasi (`nurl_build_wasm`), and read the installed stdlib. Stdio by
+default (`claude mcp add nurl -- nurl-mcp`); `--http` adds a
+token-authenticated network transport with code execution gated behind
+`--allow-run`, and `--read-only` strips everything but the analysis tools.
+
+## WebAssembly (`wasmbuilder` + `wasmtime`)
+
+The wasm toolchain is two registry packages away — no wasi-sdk, no build
+service:
+
+```bash
+nurlpkg install wasmbuilder     # NURL → wasm32-wasi, fully local
+nurlpkg install wasmtime        # pure-NURL wasm runtime
+
+wasmbuilder program.nu          # → program.wasm
+wt run program.wasm
+```
+
+`wasmbuilder` drives nurlc, retargets the emitted IR for wasm32-wasi, and
+links with the toolchain's bundled `zig cc` (wasi-libc + wasm-ld built in);
+`wasmbuilder --doctor` shows how everything resolves on your machine. `wt`
+runs wasm32-wasi modules (preopened dirs, `--allow-gpu` for the CUDA host
+bridge). Both packages' READMEs carry the full option surface.

--- a/packages/wasmbuilder/nurl.toml
+++ b/packages/wasmbuilder/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbuilder"
-version = "0.1.0"
+version = "0.1.1"
 description = "Compile NURL to wasm32-wasi locally — no wasi-sdk, no build service. Drives the installed toolchain end to end: nurlc emits LLVM IR, the production IR rewriter retargets it for wasm32-wasi (libc width shims, POSIX stubs, main rename), and the toolchain's bundled `zig cc` (wasi-libc + wasm-ld built in) links the .wasm. The NURL runtime is compiled from the installed stdlib's runtime.c on first use and cached by content hash, so it always matches your toolchain version. If no bundled zig is present (e.g. a Windows install), wasmbuilder downloads a pinned, sha256-verified zig into $NURL_HOME/zig once. Ships as both a CLI (`wasmbuilder file.nu -o file.wasm`, plus `--doctor` for setup diagnosis) and a library other packages embed to compile wasm in-process (swarm-mcp kernel builds, nurl-mcp). Optional: `--asyncify` for browser canvas programs (needs binaryen's wasm-opt). Run the result with the pure-NURL `wasmtime` package or any wasm runtime."
 license = "MIT OR Apache-2.0"
 

--- a/packages/wasmbuilder/src/main.nu
+++ b/packages/wasmbuilder/src/main.nu
@@ -23,7 +23,7 @@ $ `stdlib/std/args.nu`
 $ `stdlib/ext/env.nu`
 $ `build.nu`
 
-@ __wbc_version → s { ^ `wasmbuilder 0.1.0` }
+@ __wbc_version → s { ^ `wasmbuilder 0.1.1` }
 
 // --doctor: print every resolution step so a broken setup explains itself.
 @ __wbc_doctor → i {


### PR DESCRIPTION
## Summary

Release prep for **v0.10.10 — local wasm builds**, covering everything merged since the v0.10.9 tag.

- **CHANGELOG**: new `[0.10.10] — 2026-07-03` section with a release intro; contents = the Unreleased entries (wasmbuilder package + swarm-mcp v0.8.0 local kernel builds + nurl-mcp v0.3.0 `nurl_build_wasm` + Windows zig bundling + the enum-payload-slot `i64` fix + swarm-mcp v0.6.0/v0.7.0 GPU engine work).
- **ROADMAP**: current-release pointer 0.10.9 → 0.10.10.
- **README**: small new **Tooling** section — installer + registry, formatter/LSP/MCP, and the `wasmbuilder`/`wasmtime` wasm pair — details stay in [`docs/TOOLING.md`](docs/TOOLING.md).
- **docs/TOOLING.md** brought up to date with what actually ships: the live registry flow (`nurlpkg install <name>` / `publish` / `login` — the old text still claimed registry resolution was out of scope), plus short sections for `nurl-mcp` and the WebAssembly pair.
- **wasmbuilder 0.1.1** version bump (README refresh; already published to the registry).

After merge: tag `v0.10.10` to cut the release — the tag build ships the new `dist/job.nu` stdlib, which also unblocks `nurlpkg install swarm-mcp` from the registry, and produces the first Windows archive with a bundled zig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132PsC3u7nTQeapSKwmmfZf