### PR TITLE
feat(anomaly): streaming self-training anomaly-detection service (M1-M7, GPU-accelerated)

### DIFF
--- a/packages/anomaly/README.md
+++ b/packages/anomaly/README.md
@@ -1,0 +1,156 @@
+# anomaly — streaming anomaly detection, pure NURL
+
+Dynamic, automatically-trainable anomaly-detection **service** over
+Isolation Forests. Where the [`iforest`](../iforest) package is the kernel
+(numeric matrix in, scores out), `anomaly` is everything around it: named
+models that are **created on first use**, ingest one JSON point at a time,
+and **train themselves** once enough history has accumulated — no offline
+training step, no labels, no Python.
+
+```
+$ anomaly detect boiler temp=78.2 pressure=1.4 state=heating
+{"status":"collecting","min_data_points":50,"data_points":1}
+              ⋮            (50 points later the model has trained itself)
+$ anomaly detect boiler temp=78.4 pressure=1.4 state=heating
+{"status":"success","anomaly":false,"score":-0.012,"versions":{...},"data_points":73}
+$ anomaly detect boiler temp=712 pressure=9.9 state=fault
+{"status":"success","anomaly":true,"score":-0.31,"versions":{...},"data_points":74}
+```
+
+It is a NURL re-implementation of the anomaly-detection interface of a
+Flask + scikit-learn reference service (`model_training.py`), with the same
+HTTP routes and response shapes, so existing dashboards keep working.
+
+## What a model does
+
+- **Heterogeneous features, encoded automatically.** Numbers pass through;
+  strings become deterministic one-hot categoricals (categories kept
+  sorted); ISO-8601 strings expand to `hour/day/month/weekday` calendar
+  features (Python `weekday()` convention). Column types are detected on
+  first sight and frozen in metadata.
+- **Feature-order stability.** `feature_names` is snapshotted at each
+  train; scoring projects every point onto exactly that vector (missing
+  features → 0, unknown extras dropped), so one-hot columns never scramble
+  between retrains.
+- **Standardisation.** A persisted StandardScaler analogue (zero-mean /
+  unit-variance, zero-variance features pass through) is refit over the
+  full ring at each train and applied before the forest.
+- **A bounded raw-point ring.** The last 150 000 points, persisted as raw
+  JSON records (`data.jsonl`) — raw, so a retrain can pick up categories
+  and columns that appeared after the last train.
+- **Schedule-driven self-training.** Warm-up until 50 points (verdicts say
+  `collecting`), then a full retrain every 50 points — every 1000 once the
+  ring is full. `PUT /api/dynamic/<m>/schedule` / `model_set_schedule`
+  change the cadence.
+- **Multiple time-window versions.** Each model trains one forest per
+  enabled version — `short_term` (180 min), `daily` (24 h), `weekly`,
+  `seasonal` (90 d) and `timevector` (last 100 points) — so the same stream
+  is judged against several horizons at once. A point is anomalous if
+  **any** version flags it; the reported score is the most severe.
+- **sklearn decision conventions.** `score` is `decision_function`:
+  `-iforest_score − offset`, `offset = −0.5` for `contamination = "auto"`
+  (else the 100·c percentile of training scores). A version flags a point
+  when `score ≤ −decision_margin`; margins are read from live metadata, so
+  tuning applies without a retrain.
+- **Fine-tuning.** `model_finetune` sets each version's margin to 95 % of
+  the magnitude of the worst score observed over the ring — the most
+  anomalous point seen so far lands just inside the anomaly band.
+- **Persistence.** `metadata.json` (types, categories, feature order,
+  scaler, schedule, version configs) + one validated binary forest blob per
+  version, written atomically. Corrupt or truncated files load as errors,
+  never undefined behaviour. Models survive restarts.
+
+Scores were validated against scikit-learn's `IsolationForest` on identical
+deterministic data: `decision_function` values match within ~0.01 across
+normal and outlier points. A fixed seed (42, the reference's
+`random_state`) makes forests — and therefore scores — byte-identical
+across platforms and runs.
+
+## CLI
+
+```
+anomaly detect <model> key=val ...     # ingest one point → verdict JSON
+anomaly score  <model> key=val ...     # score only (never ingests/retrains)
+anomaly batch  [-f FILE] [-H] [-m M]   # stateless CSV scoring (index⇥score)
+anomaly train  <model>                 # force a retrain now
+anomaly reset  <model>                 # drop data+forests, keep the name
+anomaly rm     <model>                 # delete the model entirely
+anomaly ls / info <model>              # list models / dump metadata
+anomaly serve  [--addr HOST:PORT]      # run the HTTP/JSON service
+```
+
+The store defaults to `$ANOMALY_HOME`, else `~/.anomaly`; override per
+command with `--store DIR`.
+
+## HTTP service
+
+`anomaly serve` exposes the reference routes:
+
+| Route | Meaning |
+| --- | --- |
+| `POST /detect/<model>` | ingest one point, train if due, verdict (202 while warming) |
+| `POST /detect_only/<model>` | score only — no ingestion, no retrain, no writes |
+| `GET\|POST /force_train/<model>` | retrain now |
+| `POST /detect_anomalies` | batch-score a CSV file (`{"file_path": ..., "has_header": ...}`) |
+| `GET /models/dynamic` | list models with metadata |
+| `GET /models/dynamic/<m>/metadata` | model metadata |
+| `GET /models/dynamic/<m>/data?limit=N\|all` | recent raw points |
+| `POST /models/dynamic/<m>/reset` | drop data + forests, keep the name |
+| `DELETE\|GET /delete_model/<m>` | delete entirely |
+| `PUT /api/dynamic/<m>/schedule` | `{"below_max_retrain_frequency": .., "at_max_retrain_frequency": ..}` |
+| `POST /api/dynamic/<m>/finetune` | recalibrate decision margins |
+
+Model names must match `^[a-zA-Z0-9_]+$`. The router is a plain function
+over `HttpRequest` — the test suite drives every route without a socket.
+
+## Library
+
+```nurl
+$ `deps/anomaly/src/dynamic.nu`
+
+: Store st ( store_open `/var/lib/anomaly` )
+: *Model mo ( model_open st `boiler` )
+: !Verdict String vr ( model_ingest mo point_json )   // or model_detect_only
+```
+
+`model_open / model_ingest / model_detect_only / model_force_train /
+model_reset / model_delete / model_finetune / model_set_schedule /
+model_set_margin / model_metadata / model_free`, plus the layers beneath:
+preprocessing + scaler (`prep.nu`), the stateless version kernel over
+`iforest` (`model.nu`), persistence (`store.nu`), batch CSV (`csvdata.nu`)
+and the HTTP surface (`service.nu`). Every mutating entry point has an
+`_at` variant taking `now` in unix seconds — the injectable clock that
+makes window filtering reproducible in tests.
+
+## Known divergences from the Python reference
+
+Deliberate, all documented in the code:
+
+1. **Fine-tune implements the intent, not the bug.** The reference
+   initialises its accumulator to `-inf` and only updates on `score <
+   -inf`, so it never adjusts anything (and its "+5 % buffer" comment
+   belies a `* 0.95`). We track the true minimum and apply `0.95·|min|`,
+   in place (no `tune_<name>` clone).
+2. **One scaler per model**, fit over the full ring — the reference fits
+   one per version and silently keeps whichever trained last.
+3. **Retraining is keyed on the lifetime point counter**, so it keeps
+   working at ring capacity (the reference's count-based fallback arms a
+   threshold above the capped length; its per-version timers are what kept
+   it retraining).
+4. **`timevector` trains a forest on the last 100 points** rather than on
+   flattened 100-point sliding windows (which bypassed the scaler in the
+   reference).
+5. **`/detect_anomalies` self-trains on the file** — the reference's
+   separate "static model" family doesn't exist here; passing `model_name`
+   is a 400 rather than silently using a different model family.
+6. **Points store raw JSON lines** (`data.jsonl`), not a pickled array —
+   raw records are what let retrains learn new categories.
+
+## Tests
+
+`./tests/anomaly_test.sh` builds and runs the six unit suites (162 checks:
+preprocessing golden vectors, sklearn-parity decision maths, bit-exact
+blob round-trips, corrupt-file rejection, streaming mechanics, window
+routing, fine-tune, all HTTP routes), a CLI end-to-end pass, and a live
+served-over-curl smoke test. The whole suite is AddressSanitizer /
+LeakSanitizer-clean (`NURL_SAN=1 ./tests/anomaly_test.sh`).

--- a/packages/anomaly/README.md
+++ b/packages/anomaly/README.md
@@ -66,6 +66,29 @@ normal and outlier points. A fixed seed (42, the reference's
 `random_state`) makes forests — and therefore scores — byte-identical
 across platforms and runs.
 
+## GPU acceleration
+
+Bulk scoring (batch CSVs, the contamination percentile at training time,
+the fine-tune ring sweep) routes through the [`gpu`](../gpu) package when
+profitable (≥ 128 rows):
+
+- On a CUDA machine the forest walk runs as a CUDA kernel.
+- On a machine without a GPU, `gpu_open` falls back to the gpu package's
+  **CPU backend** — the same kernel compiled by the host C++ compiler and
+  parallelised with OpenMP.
+- With neither (no GPU, no C++ compiler), scoring silently stays on the
+  pure-NURL loop; the package behaves exactly like a pre-GPU build.
+
+The three paths are **bit-identical by construction**: the kernel only
+walks trees and accumulates f64 path lengths in the same order as the pure
+loop (per-leaf `c(size)` values are precomputed on the host by the same
+function the pure walker calls), and the nonlinear finish runs in NURL
+either way — so which engine ran can never change a verdict, and the test
+suite asserts element-for-element `==` across engines. Measured on 200 000
+rows × 300 trees: pure NURL 9.6 s, host C++ backend 1.1 s (~9×), RTX 4090
+213 ms (~45×). `ANOMALY_GPU=0` disables the accelerator; `NURL_GPU=cpu`
+forces the CPU backend on a CUDA machine.
+
 ## CLI
 
 ```
@@ -116,9 +139,10 @@ $ `deps/anomaly/src/dynamic.nu`
 `model_open / model_ingest / model_detect_only / model_force_train /
 model_reset / model_delete / model_finetune / model_set_schedule /
 model_set_margin / model_metadata / model_free`, plus the layers beneath:
-preprocessing + scaler (`prep.nu`), the stateless version kernel over
-`iforest` (`model.nu`), persistence (`store.nu`), batch CSV (`csvdata.nu`)
-and the HTTP surface (`service.nu`). Every mutating entry point has an
+preprocessing + scaler (`prep.nu`), the per-point decision core over
+`iforest` (`model.nu`), bulk/batch scoring + training with the GPU path
+(`score.nu`), persistence (`store.nu`), batch CSV (`csvdata.nu`) and the
+HTTP surface (`service.nu`). Every mutating entry point has an
 `_at` variant taking `now` in unix seconds — the injectable clock that
 makes window filtering reproducible in tests.
 
@@ -148,9 +172,9 @@ Deliberate, all documented in the code:
 
 ## Tests
 
-`./tests/anomaly_test.sh` builds and runs the six unit suites (162 checks:
+`./tests/anomaly_test.sh` builds and runs the seven unit suites (165+ checks:
 preprocessing golden vectors, sklearn-parity decision maths, bit-exact
 blob round-trips, corrupt-file rejection, streaming mechanics, window
-routing, fine-tune, all HTTP routes), a CLI end-to-end pass, and a live
-served-over-curl smoke test. The whole suite is AddressSanitizer /
+routing, fine-tune, all HTTP routes, GPU/CPU-backend bit-parity), a CLI
+end-to-end pass, and a live served-over-curl smoke test. The whole suite is AddressSanitizer /
 LeakSanitizer-clean (`NURL_SAN=1 ./tests/anomaly_test.sh`).

--- a/packages/anomaly/SPEC.md
+++ b/packages/anomaly/SPEC.md
@@ -1,7 +1,12 @@
 # `anomaly` — streaming anomaly-detection service (specification)
 
-Status: **draft / not yet implemented.** This document specifies the package;
-it does not describe existing code.
+Status: **implemented (M1–M6, v0.1.0).** §8's milestones M1–M6 are shipped
+and tested; M7 (autoencoder / GPU) remains open. Where the implementation
+deliberately diverges from this draft or from the Python reference, the
+divergence is listed in README.md ("Known divergences") — notably the
+point log is raw JSON lines (`data.jsonl`, §4.4) rather than a binary
+matrix, so retrains can learn categories that appeared after the last
+train.
 
 ## 1. Motivation
 
@@ -159,7 +164,10 @@ encodings aligned across retrains.
 ```
 <model_dir>/<name>/
   metadata.json            # §4.3
-  data.bin                 # ring of recent points, row-major f + timestamps
+  data.jsonl               # ring of recent RAW points, one JSON record per
+                           # line, each stamped with its ingest `timestamp`
+                           # (raw — not projected vectors — so a retrain can
+                           # pick up new categories/columns)
   version_<v>.forest       # one compact forest blob per enabled version
 ```
 
@@ -364,15 +372,20 @@ Matching the rest of the ecosystem:
 
 ## 11. Open questions
 
-- **Timestamp encoding.** The reference uses raw calendar fields
-  (`hour/day/month/weekday`); cyclical sin/cos encoding is better for the forest
-  but diverges from the reference. Ship raw first (M1), evaluate cyclical later.
-- **`contamination = auto`.** scikit-learn's `auto` sets the offset from the
-  training-score distribution. Decide the exact NURL equivalent in M2 and pin it
-  so scores are reproducible.
-- **Window filtering for versions (M5).** The reference filters points by wall
-  clock relative to *now*. For reproducible tests we need an injectable clock
-  (as `std/time` supports) rather than reading the real clock inside the model.
-- **Storage backend abstraction.** File backend is mandatory; confirm the
-  `store_*` interface is narrow enough that a Redis/`swarm` backend could be
-  added in a later package without breaking `Model`.
+- **Timestamp encoding.** RESOLVED (M1): raw calendar fields
+  (`hour/day/month/weekday`, Python weekday convention), matching the
+  reference. Cyclical sin/cos remains a possible later refinement.
+- **`contamination = auto`.** RESOLVED (M2): pinned to the sklearn
+  convention — `offset_ = -0.5` for `auto`, else the 100·c percentile
+  (numpy 'linear' interpolation) of the training set's score_samples;
+  `decision_function = -iforest_score - offset_`. Validated against
+  scikit-learn on identical data (agreement within ~0.01).
+- **Window filtering for versions (M5).** RESOLVED: every mutating entry
+  point has an `_at` variant taking `now` in unix seconds; the plain
+  variants read the wall clock. Window cutoffs and stamped timestamps are
+  fully injectable in tests.
+- **Storage backend abstraction.** File backend shipped; the `store_*`
+  surface (exists/list/save/load meta + forest, append/write/load points,
+  delete) is the interface a Redis/`swarm` backend would re-implement.
+  Still open: making `Model` carry the backend as a value rather than
+  calling `store_*` directly.

--- a/packages/anomaly/SPEC.md
+++ b/packages/anomaly/SPEC.md
@@ -1,0 +1,378 @@
+# `anomaly` — streaming anomaly-detection service (specification)
+
+Status: **draft / not yet implemented.** This document specifies the package;
+it does not describe existing code.
+
+## 1. Motivation
+
+The `iforest` package already ships the *core algorithm* — an Isolation Forest
+that turns a numeric matrix into per-row anomaly scores. That is the kernel, but
+it is not a usable anomaly-detection **service**: it has no notion of feature
+preprocessing, no persistent models, no streaming ingestion, no thresholding,
+and no way to ask "is *this single reading* anomalous, given everything I've
+seen so far?".
+
+This package fills that gap. It is a NURL re-implementation of the anomaly
+detection interface currently provided by the Python service in
+`~/dev/python-scripts-runner` (`model_training.py` + the Flask routes in
+`api.py`). That service exposes a small, well-defined contract:
+
+- named **dynamic models** that are *created on first use* and *train
+  themselves* once enough data has been collected;
+- **streaming ingestion** — you POST one data point at a time (sensor readings,
+  metrics, log-derived features) and get back an immediate verdict;
+- **heterogeneous features** — numeric, categorical (one-hot), and timestamp
+  columns are accepted and encoded automatically;
+- **multiple time-window versions** of each model (short-term, daily, weekly,
+  …) so the same stream is judged against several horizons at once;
+- **tunable thresholds** (contamination / decision margin) and a fine-tuning
+  pass that re-calibrates them against observed data;
+- **persistence** so a model survives a restart.
+
+`anomaly` provides the same contract from pure NURL: a reusable **library**, an
+installable **CLI**, and an optional **HTTP/JSON service** whose routes mirror
+the Python API so existing clients keep working.
+
+`anomaly` **depends on** and reuses `iforest` for the forest itself. It adds
+everything *around* the forest.
+
+## 2. Scope and non-goals
+
+### In scope
+
+- Feature preprocessing: numeric passthrough, categorical → deterministic
+  one-hot, ISO-8601 timestamp → cyclical/calendar features.
+- Per-feature **standardisation** (zero-mean / unit-variance), the NURL analogue
+  of scikit-learn's `StandardScaler`, persisted with the model.
+- **Model metadata**: column types, discovered categories, ordered feature
+  names, scaler parameters, training schedule, per-version config.
+- **Dynamic / streaming models**: create-on-first-use, a bounded in-memory (and
+  persisted) ring of recent points, and schedule-driven retraining.
+- **Multi-version models**: several time-windowed Isolation Forests per model,
+  aggregated into one verdict.
+- **Thresholding**: contamination and per-version `decision_margin`; the
+  `fine-tune` re-calibration pass.
+- **Persistence**: a documented on-disk layout (JSON metadata + a compact binary
+  forest blob), pluggable so a second backend can be added later.
+- **CLI** and **HTTP/JSON service** surfaces.
+
+### Out of scope (for this package)
+
+- ARIMA / multivariate *forecasting* endpoints (`/predict/arima`,
+  `/predict/multivariate`) — those are time-series prediction, not anomaly
+  detection, and belong elsewhere.
+- GPU acceleration. The forest is CPU-only here; a later milestone may route
+  training through the `gpu` package, but it is not required for correctness.
+- Redis storage backend. The storage layer is designed to be pluggable, but only
+  the file backend is specified as mandatory.
+- Authentication / TLS termination — the HTTP layer is expected to sit behind
+  the existing `swarm-mcp` / `net` machinery if exposed publicly.
+
+## 3. Reference: the Python interface being ported
+
+For traceability, this is the surface `anomaly` is modelled on. Endpoints marked
+† are ported; the rest are explicitly out of scope (§2).
+
+| Python route | Meaning | Ported |
+| --- | --- | --- |
+| `POST /detect/<model>` | ingest one point into a dynamic model, train if ready, return verdict | † |
+| `POST /detect_only/<model>` | score one point, **never** ingest or retrain | † |
+| `POST /force_train/<model>` | force an immediate retrain | † |
+| `POST /detect_anomalies` | batch-score every row of a CSV file with a model | † |
+| `GET  /models/dynamic` | list dynamic models | † |
+| `GET  /models/dynamic/<model>/metadata` | model metadata | † |
+| `GET  /models/dynamic/<model>/data` | recent data points | † |
+| `POST /models/dynamic/<model>/reset` | drop data + models, keep name | † |
+| `DELETE /delete_model/<model>` | delete a model entirely | † |
+| `PUT  /api/dynamic/<model>/schedule` | change retraining schedule | † |
+| `POST /api/dynamic/<model>/finetune` | re-calibrate decision margins | † |
+| `POST /train/autoencoder/<model>` | train the autoencoder version | † (M6, optional) |
+| `GET/POST /predict/arima/<model>` | ARIMA forecast | ✗ out of scope |
+| `GET/POST /predict/multivariate/<model>` | multivariate forecast | ✗ out of scope |
+
+Key defaults observed in the reference implementation (carried over verbatim):
+
+- `MIN_DATA_POINTS = 50` — no detection before this many points; everything is
+  "normal / warming up".
+- `MAX_DATA_POINTS = 150000` — ring capacity per model.
+- Retraining schedule: every `50` points below capacity, every `1000` points at
+  capacity.
+- Default model versions and their configs (`short_term` 180 min, `daily`
+  1440 min, `weekly` 10080 min, `seasonal` 90 days, `timevector` window 100),
+  each with `contamination = auto`, its own `decision_margin`, `n_estimators`,
+  `max_samples = 256`, `random_state = 42`.
+- Isolation Forest verdict convention: `predict == -1` ⇒ anomaly; `score` is the
+  signed `decision_function` value (below the margin ⇒ anomaly).
+
+## 4. Data model
+
+### 4.1 Feature encoding
+
+`preprocess_point(raw, meta) → (features, meta')` turns a record of named raw
+values into an ordered numeric feature vector, updating metadata as new columns
+or categories appear.
+
+- **numeric** — parsed as `f`; parse failure is a hard error.
+- **categorical** — value stringified; the column's category list is kept
+  **sorted** so ordering is deterministic; emitted as one-hot features named
+  `col_<category>`. New categories extend the vector (see §4.3 stability rule).
+- **timestamp** — ISO-8601 parsed via `std/time`; expands to
+  `col_hour`, `col_day`, `col_month`, `col_weekday` (float). (Cyclical
+  sin/cos encoding is a candidate refinement, tracked as an open question.)
+- Column type may be pinned in metadata (`numeric` / `categorical` /
+  `timestamp`) or `auto`-detected on first sight and then frozen.
+
+### 4.2 Standardisation
+
+A `Scaler` holds per-feature `mean` and `inv_std` (`( Vec f )` each). Fit over
+the training matrix; applied to every point before it reaches the forest and
+persisted in metadata. Zero-variance features get `inv_std = 1` (i.e. pass
+through) to avoid division blow-ups.
+
+### 4.3 Metadata
+
+Persisted as JSON (`std/ext/json`). Fields:
+
+```
+{
+  "name":            string,
+  "created":         iso8601,
+  "column_types":    { col: "numeric"|"categorical"|"timestamp" },
+  "categories":      { col: [sorted strings] },
+  "feature_names":   [ordered feature names],   // authoritative feature order
+  "scaler":          { "mean": [...], "std": [...] },
+  "schedule":        { "below_max": 50, "at_max": 1000 },
+  "versions":        { version_name: <version config>, ... },
+  "n_points_seen":   int,
+  "last_trained_at": int   // point count at last train
+}
+```
+
+**Feature-order stability rule.** `feature_names` is authoritative once a model
+is first trained. At scoring time a point is projected onto exactly that vector:
+missing features default to `0`, unknown extras are dropped. This mirrors the
+reference (`model_features` in metadata) and is what keeps categorical one-hot
+encodings aligned across retrains.
+
+### 4.4 On-disk layout (file backend)
+
+```
+<model_dir>/<name>/
+  metadata.json            # §4.3
+  data.bin                 # ring of recent points, row-major f + timestamps
+  version_<v>.forest       # one compact forest blob per enabled version
+```
+
+The forest blob is a straight serialisation of the `iforest` node arena (§the
+arena is already flat, so this is a length-prefixed dump of the SoA arrays plus
+the per-tree root indices). The storage API is an interface (`store_*` fns) so a
+non-file backend can be dropped in without touching callers.
+
+## 5. Library API surface (`src/anomaly.nu`)
+
+Signatures are indicative and follow the `iforest` house style (prefix calls,
+caller-owned handles, `( Vec f )` row-major matrices).
+
+### 5.1 Preprocessing & scaling
+
+| Function | Result |
+| --- | --- |
+| `( anomaly_preprocess raw meta )` | `( Features , Meta )` — encode one record |
+| `( scaler_fit data n_rows n_cols )` | `Scaler` |
+| `( scaler_apply scaler point )` | `( Vec f )` standardised in place |
+| `( scaler_free scaler )` | `v` |
+
+### 5.2 Model lifecycle (dynamic / streaming)
+
+| Function | Result |
+| --- | --- |
+| `( model_open store name )` | `Model` — create-on-first-use, load if present |
+| `( model_ingest model raw )` | `Verdict` — add point, retrain if scheduled, then score |
+| `( model_detect_only model raw )` | `Verdict` — score without ingesting/retraining |
+| `( model_force_train model )` | `i` — retrain now, return points used |
+| `( model_reset model )` | `v` — drop data + forests, keep name/schedule |
+| `( model_delete store name )` | `v` — remove everything |
+| `( model_finetune model )` | `FineTuneReport` — recalibrate margins |
+| `( model_set_schedule model below_max at_max )` | `v` |
+| `( model_metadata model )` | `Meta` |
+| `( model_free model )` | `v` |
+
+### 5.3 Batch (stateless) scoring
+
+| Function | Result |
+| --- | --- |
+| `( anomaly_score_csv path opts )` | `BatchReport` — score every CSV row |
+
+### 5.4 The `Verdict`
+
+```
+Verdict {
+  ready:      i1      // false while warming up (< MIN_DATA_POINTS)
+  anomaly:    i1      // aggregate decision across enabled versions
+  score:      f       // aggregate (max-severity) score
+  versions:   Vec VersionVerdict   // per-version { name, anomaly, score, margin }
+}
+```
+
+Aggregation: a point is anomalous if **any** enabled version flags it; the
+reported `score` is the most-severe version's score. (The reference checks all
+versions and surfaces each; §6 preserves that in the JSON.)
+
+## 6. HTTP/JSON service surface (`src/service.nu`, optional milestone)
+
+The routes mirror §3 (ported column). Request/response shapes match the Python
+service so existing dashboards and the `modelmanager` UI keep working:
+
+- `POST /detect/<model>` body = `{ col: value, ... }` (numeric/categorical/
+  timestamp), optional `timestamp`. Response = `Verdict` as JSON with the
+  `versions` map, `status`, `model`, echoed `data_point`.
+- `POST /detect_only/<model>` — same body, `Verdict`, no state change.
+- `POST /detect_anomalies` body = `{ file_path, model_name? }` → batch report:
+  `anomaly_count`, `anomaly_percentage`, `anomaly_indices`, `has_anomalies`,
+  `anomaly_details` (first 100).
+- model-name validation: `^[a-zA-Z0-9_]+$` (reject otherwise, mirrors reference).
+
+The service is thin: parse JSON → call the library → serialise. It is
+factored so it can be hosted directly (`std/net`) or registered as tools on the
+existing `swarm-mcp` node.
+
+## 7. CLI surface (`src/main.nu` → `anomaly`)
+
+```
+anomaly detect  <model> [--store DIR] key=val ...      # ingest + verdict
+anomaly score   <model> [--store DIR] key=val ...      # detect-only
+anomaly batch   [-f FILE] [-H] [--model M]             # score a CSV, like iforest but with a saved model
+anomaly train   <model> [--store DIR]                  # force retrain
+anomaly reset   <model> [--store DIR]
+anomaly rm      <model> [--store DIR]
+anomaly ls      [--store DIR]                          # list models
+anomaly info    <model> [--store DIR]                  # dump metadata
+anomaly serve   [--addr HOST:PORT] [--store DIR]       # run the HTTP service (M5)
+```
+
+`--store DIR` defaults to `$ANOMALY_HOME` or `~/.anomaly`. Verdicts print as
+one JSON object per invocation; `batch` prints `index⇥score` (compatible with
+`iforest`'s output so the two can be diffed).
+
+## 8. Milestones
+
+Each milestone is independently shippable, testable, and leaves the package in a
+usable state. Later milestones depend only on earlier ones.
+
+### M1 — Preprocessing & standardisation (foundation)
+
+- `anomaly_preprocess` for numeric / categorical / timestamp with deterministic
+  category ordering and the feature-order stability rule.
+- `Scaler` fit/apply/free.
+- Metadata struct + JSON round-trip (`std/ext/json`).
+- **Deliverable:** pure functions, no I/O. **Tests:** golden feature vectors
+  for mixed-type records; category-growth determinism; scaler
+  fit/apply/inverse identity; zero-variance passthrough; metadata JSON
+  round-trips byte-stably.
+- **Depends on:** stdlib only.
+
+### M2 — Single-version model over `iforest` (stateless core)
+
+- Wrap `iforest_train` / `iforest_score` behind `Scaler` + feature projection.
+- `decision_margin` thresholding: `score < margin ⇒ anomaly`, matching the
+  reference's `predict == -1` convention.
+- `anomaly_score_csv` batch path (the `iforest` CLI, but scaled + thresholded).
+- **Tests:** on a synthetic dataset with injected outliers, precision/recall vs.
+  a fixed expectation; determinism under fixed seed; parity of the batch report
+  fields with §6.
+- **Depends on:** M1, `iforest`.
+
+### M3 — Persistence & storage backend
+
+- Forest blob serialise/deserialise (dump/reload the `iforest` arena).
+- File backend: the §4.4 layout; `store_*` interface; `model_open` load path.
+- **Tests:** train → serialise → reload → identical scores (bit-exact);
+  metadata + forest survive a round-trip; corrupt/partial blob is rejected
+  cleanly (no UB), ASan/LSan-clean.
+- **Depends on:** M2.
+
+### M4 — Dynamic streaming model (the headline feature)
+
+- Bounded point ring (`MAX_DATA_POINTS`), create-on-first-use, warm-up gating
+  (`MIN_DATA_POINTS` → `ready = false`).
+- Schedule-driven retraining (below-max / at-max frequencies).
+- `model_ingest`, `model_detect_only`, `model_force_train`, `model_reset`,
+  `model_delete`, `model_set_schedule`.
+- **Tests:** feed a synthetic stream; assert warm-up window, retrain cadence,
+  that a step-change reading is flagged after enough history, ring eviction at
+  capacity, and that `detect_only` never mutates state.
+- **Depends on:** M3.
+
+### M5 — Multi-version models & fine-tuning
+
+- Several enabled versions per model (`short_term` … `timevector`), each a
+  window-filtered Isolation Forest with its own config.
+- Verdict aggregation (§5.4) and the per-version breakdown.
+- `model_finetune`: for each version, find the max observed score and lower the
+  margin so that point is (just) anomalous, +5 % buffer — matching the reference.
+- **Tests:** aggregation truth table (any-version-anomalous); per-window data
+  routing; fine-tune moves the margin monotonically and makes the previously
+  max-scoring point cross the threshold.
+- **Depends on:** M4.
+
+### M6 — HTTP/JSON service + CLI (interface parity)
+
+- `src/service.nu` routes from §6; model-name validation; JSON in/out shapes
+  matching the Python service.
+- `src/main.nu` CLI from §7; `anomaly serve`.
+- **Tests:** golden request/response fixtures captured from the Python service
+  replayed against the NURL service; CLI smoke test in
+  `tools/nurlpkg/test-install-tool.sh` style (`nurlpkg install anomaly`,
+  ingest a few points, assert a JSON verdict).
+- **Depends on:** M5.
+
+### M7 — (optional) Autoencoder version & GPU training
+
+- Reconstruction-error version: a small MLP autoencoder, `is_anomaly = mse >
+  reconstruction_threshold`, mirroring the Python `autoencoder` version.
+- Optionally route forest training / scoring through the `gpu` package for large
+  models, behind a feature flag, output identical to the CPU path.
+- **Tests:** reconstruction threshold behaviour on a synthetic manifold;
+  CPU/GPU score parity within tolerance.
+- **Depends on:** M5. Independent of M6.
+
+## 9. Dependencies
+
+```toml
+[dependencies]
+iforest = "^0.1"     # core Isolation Forest algorithm
+# stdlib: vec, float, rng, sort, time, fs, ext/csv, ext/json, net (service)
+```
+
+Only `iforest` is an external package dependency; everything else is stdlib.
+M7's GPU path adds an optional `gpu` dependency.
+
+## 10. Quality bar
+
+Matching the rest of the ecosystem:
+
+- Leak-clean under AddressSanitizer / LeakSanitizer across every code path
+  (ingest, detect-only, batch, serialise/reload, reset, delete, help,
+  error/empty-input branches).
+- Deterministic: a fixed seed yields byte-identical forests and hence identical
+  scores across platforms and builds (inherited from `iforest`).
+- Numerical parity with the reference where it is well-defined (batch scoring on
+  the same data and seed; documented tolerances where floating-point order
+  differs).
+- The end-to-end install-and-run loop covered by the shared
+  `tools/nurlpkg/test-install-tool.sh` harness.
+
+## 11. Open questions
+
+- **Timestamp encoding.** The reference uses raw calendar fields
+  (`hour/day/month/weekday`); cyclical sin/cos encoding is better for the forest
+  but diverges from the reference. Ship raw first (M1), evaluate cyclical later.
+- **`contamination = auto`.** scikit-learn's `auto` sets the offset from the
+  training-score distribution. Decide the exact NURL equivalent in M2 and pin it
+  so scores are reproducible.
+- **Window filtering for versions (M5).** The reference filters points by wall
+  clock relative to *now*. For reproducible tests we need an injectable clock
+  (as `std/time` supports) rather than reading the real clock inside the model.
+- **Storage backend abstraction.** File backend is mandatory; confirm the
+  `store_*` interface is narrow enough that a Redis/`swarm` backend could be
+  added in a later package without breaking `Model`.

--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,8 +1,9 @@
 [package]
 name = "anomaly"
-version = "0.1.0"
+version = "0.2.0"
 description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 iforest = { path = "../iforest", version = "0.1" }
+gpu = { path = "../gpu", version = "0.2.1" }

--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "anomaly"
+version = "0.1.0"
+description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+iforest = { path = "../iforest", version = "0.1" }

--- a/packages/anomaly/src/csvdata.nu
+++ b/packages/anomaly/src/csvdata.nu
@@ -1,0 +1,95 @@
+// anomaly/csvdata.nu — numeric CSV → row-major matrix (batch inputs).
+//
+// Same forgiving shape as the `iforest` CLI parser: split lines, split on
+// the delimiter, keep numeric fields; the first data row fixes the column
+// count, later rows with a different numeric-field count are skipped. With
+// `has_header`, the first line's names are captured (for batch reports
+// that echo column values by name) instead of being parsed as data.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+
+// Parsed matrix: `data` is row-major rows*cols; `headers` is empty when
+// the input had no header row.
+: AnomCsv {
+    ( Vec f ) data
+    i rows
+    i cols
+    ( Vec String ) headers
+}
+
+@ anom_csv_free AnomCsv ds → v {
+    ( vec_free [f] . ds data )
+    ( vec_free_with [String] . ds headers \ String x → v { ( string_free x ) } )
+}
+
+@ anom_parse_csv s input s delim b has_header → AnomCsv {
+    : String text ( string_from input )
+    : ( Vec String ) lines ( string_split text `\n` )
+    ( string_free text )
+
+    : ( Vec f ) data ( vec_new [f] )
+    : ( Vec String ) headers ( vec_new [String] )
+    : ~ i cols -1
+    : ~ i rows 0
+    : i nl ( vec_len [String] lines )
+    : ~ i li 0
+    ~ < li nl {
+        ?? ( vec_get [String] lines li ) {
+            T line → {
+                : String tl ( string_trim line )
+                ? > ( string_len tl ) 0 {
+                    ? & == li 0 has_header {
+                        : ( Vec String ) hfields ( string_split tl delim )
+                        : i nh ( vec_len [String] hfields )
+                        : ~ i hi 0
+                        ~ < hi nh {
+                            ?? ( vec_get [String] hfields hi ) {
+                                T h → { ( vec_push [String] headers ( string_trim h ) ) }
+                                F _ → {}
+                            }
+                            = hi + hi 1
+                        }
+                        ( vec_free_with [String] hfields \ String x → v { ( string_free x ) } )
+                    } {
+                        : ( Vec String ) fields ( string_split tl delim )
+                        : ( Vec f ) rowvals ( vec_new [f] )
+                        : i nf ( vec_len [String] fields )
+                        : ~ i fi 0
+                        ~ < fi nf {
+                            ?? ( vec_get [String] fields fi ) {
+                                T fld → {
+                                    : String ft ( string_trim fld )
+                                    ?? ( string_to_float ft ) {
+                                        T x → { ( vec_push [f] rowvals x ) }
+                                        F _ → {}
+                                    }
+                                    ( string_free ft )
+                                }
+                                F _ → {}
+                            }
+                            = fi + fi 1
+                        }
+                        ( vec_free_with [String] fields \ String x → v { ( string_free x ) } )
+
+                        : i nv ( vec_len [f] rowvals )
+                        ? > nv 0 {
+                            ? < cols 0 { = cols nv } {}
+                            ? == nv cols {
+                                ( vec_extend [f] data rowvals )
+                                = rows + rows 1
+                            } {}
+                        } {}
+                        ( vec_free [f] rowvals )
+                    }
+                } {}
+                ( string_free tl )
+            }
+            F _ → {}
+        }
+        = li + li 1
+    }
+    ( vec_free_with [String] lines \ String x → v { ( string_free x ) } )
+    ? < cols 0 { = cols 0 } {}
+    ^ @ AnomCsv { data rows cols headers }
+}

--- a/packages/anomaly/src/dynamic.nu
+++ b/packages/anomaly/src/dynamic.nu
@@ -500,6 +500,117 @@ $ `src/store.nu`
     }
 }
 
+// ── Fine-tuning ───────────────────────────────────────────────────────
+
+// One version's fine-tune outcome.
+: FtVer {
+    String ftname
+    f min_score
+    f old_margin
+    f new_margin
+}
+
+: FineTuneReport {
+    ( Vec FtVer ) items
+}
+
+@ finetune_free FineTuneReport rep → v {
+    ( vec_free_with [FtVer] . rep items \ FtVer x → v { ( string_free . x ftname ) } )
+}
+
+// The ring, read-only encoded, projected onto the current feature order and
+// standardised with the current scaler — the exact view scoring uses.
+// Returns a row-major matrix of (result length / nfeat) rows.
+@ __an_ring_scaled *Model mo → ( Vec f ) {
+    : *Meta mm . mo meta
+    : i nfeat ( vec_len [String] . mm feats )
+    : ( Vec f ) big ( vec_new [f] )
+    ? <= nfeat 0 { ^ big } {}
+    : i n ( vec_len [String] . mo lines )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] . mo lines k ) {
+            T l → {
+                : !Json JsonError jr ( json_parse ( string_data l ) )
+                ?? jr {
+                    T j → {
+                        : !EncPoint String er ( anomaly_preprocess_ro mm j )
+                        ?? er {
+                            T p → {
+                                : ( Vec f ) row ( anomaly_project p . mm feats )
+                                ( scaler_apply . mo sc row )
+                                ( vec_extend [f] big row )
+                                ( vec_free [f] row )
+                                ( enc_free p )
+                            }
+                            F e → { ( string_free e ) }
+                        }
+                        ( json_free j )
+                    }
+                    F _ → {}
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ big
+}
+
+// Recalibrate every trained version's decision margin against the observed
+// ring: margin becomes 95% of the magnitude of the most-negative
+// decision_function over the ring, so the most anomalous point seen so far
+// lands just inside the anomaly band. (This is the documented INTENT of the
+// reference's finetune — its own accumulator never updates due to an
+// inverted comparison against -inf, so it never adjusts anything; we
+// implement what the code meant, in place, per SPEC §5.2.) Margins are
+// persisted and take effect immediately. Returns per-version details.
+@ model_finetune *Model mo → FineTuneReport {
+    : ( Vec FtVer ) items ( vec_new [FtVer] )
+    : *Meta mm . mo meta
+    ? ( model_is_trained mo ) {} { ^ @ FineTuneReport { items } }
+
+    : i nfeat ( vec_len [String] . mm feats )
+    : ( Vec f ) big ( __an_ring_scaled mo )
+    : ~ i rows 0
+    ? > nfeat 0 { = rows / ( vec_len [f] big ) nfeat } {}
+    ? <= rows 0 {
+        ( vec_free [f] big )
+        ^ @ FineTuneReport { items }
+    } {}
+
+    : i nf ( vec_len [VerModel] . mo forests )
+    : ~ i k 0
+    ~ < k nf {
+        ?? ( vec_get [VerModel] . mo forests k ) {
+            T vm → {
+                : ~ f lowest 0.0
+                : ~ b first T
+                : ~ i r 0
+                ~ < r rows {
+                    : f df ( anom_decision_row vm big r )
+                    ? || first < df lowest { = lowest df } {}
+                    = first F
+                    = r + r 1
+                }
+                : f old ( __an_margin_of mm ( string_data . vm vname ) . vm margin )
+                : f adjusted * ( float_abs lowest ) 0.95
+                : b applied ( model_set_margin mo ( string_data . vm vname ) adjusted )
+                ( vec_push [FtVer] items @ FtVer {
+                    ( string_from ( string_data . vm vname ) )
+                    lowest
+                    old
+                    adjusted
+                } )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [f] big )
+    ^ @ FineTuneReport { items }
+}
+
 // ── Management ────────────────────────────────────────────────────────
 
 // Drop all data and trained forests but keep the model's name, schedule

--- a/packages/anomaly/src/dynamic.nu
+++ b/packages/anomaly/src/dynamic.nu
@@ -1,0 +1,587 @@
+// anomaly/dynamic.nu — dynamic streaming models (milestones M4 + M5).
+//
+// The headline feature: a named model that is created on first use, ingests
+// one raw JSON point at a time, and trains itself once enough history has
+// accumulated. Each model keeps:
+//
+//   - a bounded ring of raw points (`max_points`, default 150 000) persisted
+//     as data.jsonl — raw records, so retrains learn new categories;
+//   - schedule-driven retraining: whenever the lifetime point count
+//     (`n_seen`, monotonic — unaffected by ring eviction) reaches the next
+//     training mark, every enabled version retrains; the mark then advances
+//     by `schedule.below_max` (default 50) or, once the ring is full,
+//     `schedule.at_max` (default 1000);
+//   - one forest per enabled version (M5): each version trains on its own
+//     time window of the ring (`window_min` minutes back from "now", or the
+//     last `window_pts` points), falling back to the most recent
+//     `min_points` rows when the window is too thin;
+//   - one shared scaler, fit over the full ring at each train.
+//
+// Verdicts follow the reference service: a point is anomalous if ANY
+// enabled version flags it (decision_function <= -margin); the reported
+// score is the most severe (lowest) decision_function. Before `min_points`
+// points (default 50) the model is warming up: `ready = false`, no verdict.
+//
+// Every public entry point has an `_at` variant taking `now` in unix
+// seconds — the injectable clock that makes window filtering and stamped
+// timestamps reproducible in tests. The plain variants read the wall clock.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/json.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/store.nu`
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+// One version's slice of a verdict.
+: VerVerdict {
+    String vvname
+    b anomaly
+    f score
+    f margin
+}
+
+// The aggregate verdict for one point (SPEC §5.4).
+: Verdict {
+    b ready
+    b anomaly
+    f score
+    ( Vec VerVerdict ) versions
+}
+
+// A live dynamic model. Obtain with model_open, release with model_free.
+: Model {
+    Store store
+    String mname
+    *Meta meta
+    ( Vec String ) lines
+    ( Vec i ) times
+    ( Vec VerModel ) forests
+    Scaler sc
+    i next_train_at
+    i min_points
+    i max_points
+}
+
+@ verdict_free Verdict vd → v {
+    ( vec_free_with [VerVerdict] . vd versions \ VerVerdict vv → v { ( string_free . vv vvname ) } )
+}
+
+@ __an_vercfg_clone VerCfg vc → VerCfg {
+    ^ @ VerCfg {
+        ( string_from ( string_data . vc vname ) )
+        . vc window_min
+        . vc window_pts
+        . vc n_estimators
+        . vc max_samples
+        . vc contamination
+        . vc decision_margin
+        . vc enabled
+    }
+}
+
+// Ingest timestamp of a stored data.jsonl line (0 if unparsable).
+@ __an_line_ts s line → i {
+    : !Json JsonError r ( json_parse line )
+    ?? r {
+        T j → {
+            : i ts ( __an_jint j `timestamp` 0 )
+            ( json_free j )
+            ^ ts
+        }
+        F _ → { ^ 0 }
+    }
+}
+
+@ __an_free_forests *Model mo → v {
+    ( vec_free_with [VerModel] . mo forests \ VerModel vm → v { ( anom_vermodel_free vm ) } )
+    = . mo forests ( vec_new [VerModel] )
+}
+
+@ __an_free_lines ( Vec String ) xs → v {
+    ( vec_free_with [String] xs \ String x → v { ( string_free x ) } )
+}
+
+// The schedule step from the current ring fill: at capacity, retrain less.
+@ __an_sched_step *Model mo → i {
+    : *Meta mm . mo meta
+    ? >= ( vec_len [String] . mo lines ) . mo max_points { ^ . mm sched_at_max } {}
+    ^ . mm sched_below
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────
+
+// Open (or create) the named model in the store: load metadata, the point
+// ring, and every trained version's forest. Create-on-first-use: a missing
+// model is initialised with fresh metadata and persisted immediately.
+@ model_open_at Store st s name i now → *Model {
+    : *Model mo # *Model ( nurl_malloc Z Model )
+    = . mo store ( store_open ( string_data . st root ) )
+    = . mo mname ( string_from name )
+    = . mo forests ( vec_new [VerModel] )
+    = . mo min_points ANOM_MIN_POINTS
+    = . mo max_points ANOM_MAX_POINTS
+
+    : ~ b loaded F
+    ? ( store_exists st name ) {
+        : ?*Meta mload ( store_load_meta st name )
+        ?? mload {
+            T got → {
+                = . mo meta got
+                = loaded T
+            }
+            F _ → {}
+        }
+    } {}
+    ? loaded {} {
+        : Time t ( time_from_unix now )
+        : String iso ( time_format_iso t )
+        = . mo meta ( meta_new name ( string_data iso ) )
+        ( string_free iso )
+        ( store_save_meta . mo store name . mo meta )
+    }
+    : *Meta mm . mo meta
+
+    // Ring: adopt the stored lines wholesale, then stamp times from them.
+    : ( Vec String ) pts ( store_load_points . mo store name )
+    = . mo lines pts
+    = . mo times ( vec_new [i] )
+    : i np ( vec_len [String] pts )
+    : ~ i k 0
+    ~ < k np {
+        ?? ( vec_get [String] pts k ) {
+            T l → { ( vec_push [i] . mo times ( __an_line_ts ( string_data l ) ) ) }
+            F _ → {}
+        }
+        = k + k 1
+    }
+
+    // Trained versions: one forest blob per enabled version, if present.
+    : i nv ( vec_len [VerCfg] . mm versions )
+    : ~ i vi 0
+    ~ < vi nv {
+        ?? ( vec_get [VerCfg] . mm versions vi ) {
+            T vc → {
+                ? . vc enabled {
+                    : ?VerModel got ( store_load_forest . mo store name ( string_data . vc vname ) )
+                    ?? got {
+                        T vm → { ( vec_push [VerModel] . mo forests vm ) }
+                        F _ → {}
+                    }
+                } {}
+            }
+            F _ → {}
+        }
+        = vi + vi 1
+    }
+
+    // Scaler from persisted metadata (empty scaler if never trained).
+    = . mo sc ( meta_scaler mm )
+
+    // Next scheduled training mark, from the lifetime counter.
+    ? == ( vec_len [VerModel] . mo forests ) 0 {
+        = . mo next_train_at . mo min_points
+    } {
+        = . mo next_train_at + . mm n_seen ( __an_sched_step mo )
+    }
+    ^ mo
+}
+
+@ model_open Store st s name → *Model {
+    ^ ( model_open_at st name ( now_seconds ) )
+}
+
+@ model_free *Model mo → v {
+    ( __an_free_forests mo )
+    ( vec_free [VerModel] . mo forests )
+    ( __an_free_lines . mo lines )
+    ( vec_free [i] . mo times )
+    ( scaler_free . mo sc )
+    ( meta_free . mo meta )
+    ( string_free . mo mname )
+    ( store_free . mo store )
+    ( nurl_free mo )
+}
+
+// Test hook: shrink the warm-up / ring limits so eviction and scheduling
+// are exercisable without 150 000 points.
+@ model_set_limits *Model mo i min_pts i max_pts → v {
+    = . mo min_points min_pts
+    = . mo max_points max_pts
+    ? == ( vec_len [VerModel] . mo forests ) 0 {
+        = . mo next_train_at min_pts
+    } {}
+}
+
+@ model_metadata *Model mo → *Meta {
+    ^ . mo meta
+}
+
+@ model_n_points *Model mo → i {
+    ^ ( vec_len [String] . mo lines )
+}
+
+@ model_is_trained *Model mo → b {
+    ^ > ( vec_len [VerModel] . mo forests ) 0
+}
+
+// ── Scoring ───────────────────────────────────────────────────────────
+
+// The live decision margin of a version comes from the CURRENT metadata,
+// not from the forest blob — so margin changes (fine-tune, config PUT)
+// take effect immediately, without a retrain. The blob's stored margin is
+// only the fallback for versions no longer present in the metadata.
+@ __an_margin_of *Meta mm s vname f dflt → f {
+    : i nv ( vec_len [VerCfg] . mm versions )
+    : ~ i k 0
+    ~ < k nv {
+        ?? ( vec_get [VerCfg] . mm versions k ) {
+            T vc → {
+                ? == ( nurl_str_eq ( string_data . vc vname ) vname ) 1 {
+                    ^ . vc decision_margin
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ dflt
+}
+
+// Score an encoded point against every trained version. `ready` is false
+// until the model has trained at least once AND the ring holds min_points.
+@ __an_score_enc *Model mo EncPoint p → Verdict {
+    : ( Vec VerVerdict ) vvs ( vec_new [VerVerdict] )
+    : b warm >= ( vec_len [String] . mo lines ) . mo min_points
+    ? & ( model_is_trained mo ) warm {} {
+        ^ @ Verdict { F F 0.0 vvs }
+    }
+
+    : *Meta mm . mo meta
+    : ( Vec f ) x ( anomaly_project p . mm feats )
+    ( scaler_apply . mo sc x )
+
+    : ~ b any F
+    : ~ f worst 0.0
+    : ~ b first T
+    : i nf ( vec_len [VerModel] . mo forests )
+    : ~ i k 0
+    ~ < k nf {
+        ?? ( vec_get [VerModel] . mo forests k ) {
+            T vm → {
+                : f df ( anom_decision vm x )
+                : f margin ( __an_margin_of mm ( string_data . vm vname ) . vm margin )
+                : b hit <= df - 0.0 margin
+                ? hit { = any T } {}
+                ? || first < df worst { = worst df } {}
+                = first F
+                ( vec_push [VerVerdict] vvs @ VerVerdict {
+                    ( string_from ( string_data . vm vname ) )
+                    hit
+                    df
+                    margin
+                } )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [f] x )
+    ^ @ Verdict { T any worst vvs }
+}
+
+// ── Training ──────────────────────────────────────────────────────────
+
+// Retrain every enabled version from the ring, as of `now`. Re-encodes the
+// raw ring (so new categories/columns learned since the last train enter
+// the feature order), refreshes the authoritative feature order, refits the
+// shared scaler over the full ring, then trains each version on its window.
+// Returns the number of ring points used (0 = not enough data, no change).
+@ model_force_train_at *Model mo i now → i {
+    : *Meta mm . mo meta
+    : i n ( vec_len [String] . mo lines )
+    ? < n . mo min_points { ^ 0 } {}
+
+    // Pass 1: re-encode every raw point (learning), tracking timestamps.
+    : ( Vec EncPoint ) encs ( vec_new [EncPoint] )
+    : ( Vec i ) ets ( vec_new [i] )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] . mo lines k ) {
+            T l → {
+                : !Json JsonError jr ( json_parse ( string_data l ) )
+                ?? jr {
+                    T j → {
+                        : !EncPoint String er ( anomaly_preprocess mm j )
+                        ?? er {
+                            T p → {
+                                ( vec_push [EncPoint] encs p )
+                                : ~ i ts 0
+                                ?? ( vec_get [i] . mo times k ) { T t2 → { = ts t2 } F _ → {} }
+                                ( vec_push [i] ets ts )
+                            }
+                            F e → { ( string_free e ) }
+                        }
+                        ( json_free j )
+                    }
+                    F _ → {}
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    : i ne ( vec_len [EncPoint] encs )
+    ? < ne . mo min_points {
+        ( vec_free_with [EncPoint] encs \ EncPoint p → v { ( enc_free p ) } )
+        ( vec_free [i] ets )
+        ^ 0
+    } {}
+
+    // Freeze the (possibly grown) feature order, project the full matrix.
+    ( meta_refresh_feats mm )
+    : i nfeat ( vec_len [String] . mm feats )
+    ? <= nfeat 0 {
+        ( vec_free_with [EncPoint] encs \ EncPoint p → v { ( enc_free p ) } )
+        ( vec_free [i] ets )
+        ^ 0
+    } {}
+    : ( Vec f ) big ( vec_with_cap [f] * ne nfeat )
+    = k 0
+    ~ < k ne {
+        ?? ( vec_get [EncPoint] encs k ) {
+            T p → {
+                : ( Vec f ) row ( anomaly_project p . mm feats )
+                ( vec_extend [f] big row )
+                ( vec_free [f] row )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [EncPoint] encs \ EncPoint p → v { ( enc_free p ) } )
+
+    // Shared scaler over the whole ring; standardise in place.
+    : Scaler snew ( scaler_fit big ne nfeat )
+    ( meta_set_scaler mm snew )
+    ( scaler_free . mo sc )
+    = . mo sc snew
+    ( scaler_apply_matrix snew big ne nfeat )
+
+    // Per enabled version: pick window rows, train, persist.
+    ( __an_free_forests mo )
+    : *f bigp ( vec_data [f] big )
+    : *i etsp ( vec_data [i] ets )
+    : i nv ( vec_len [VerCfg] . mm versions )
+    : ~ i vi 0
+    ~ < vi nv {
+        ?? ( vec_get [VerCfg] . mm versions vi ) {
+            T vc → {
+                ? . vc enabled {
+                    // Window: time filter first, then point cap, then the
+                    // most-recent-min_points fallback.
+                    : ~ i from 0
+                    ? > . vc window_min 0 {
+                        : i cutoff - now * . vc window_min 60
+                        : ~ i j 0
+                        ~ & < j ne < . etsp j cutoff { = j + j 1 }
+                        = from j
+                    } {}
+                    ? > . vc window_pts 0 {
+                        : i tail - ne . vc window_pts
+                        ? > tail from { = from tail } {}
+                    } {}
+                    ? > - ne from . mo min_points {} {
+                        = from - ne . mo min_points
+                        ? < from 0 { = from 0 } {}
+                    }
+                    : i cnt - ne from
+
+                    : ( Vec f ) sub ( vec_with_cap [f] * cnt nfeat )
+                    : *f subp ( vec_data [f] sub )
+                    : ~ i r 0
+                    ~ < r cnt {
+                        : ~ i c 0
+                        ~ < c nfeat {
+                            = . subp + * r nfeat c . bigp + * + from r nfeat c
+                            = c + c 1
+                        }
+                        = r + r 1
+                    }
+                    ( vec_set_len [f] sub * cnt nfeat )
+
+                    : VerModel vm ( anom_train_version sub cnt nfeat vc )
+                    ( store_save_forest . mo store ( string_data . mo mname ) vm )
+                    ( vec_push [VerModel] . mo forests vm )
+                    ( vec_free [f] sub )
+                } {}
+            }
+            F _ → {}
+        }
+        = vi + vi 1
+    }
+    ( vec_free [f] big )
+    ( vec_free [i] ets )
+
+    = . mm last_trained . mm n_seen
+    ( store_save_meta . mo store ( string_data . mo mname ) mm )
+    = . mo next_train_at + . mm n_seen ( __an_sched_step mo )
+    ^ ne
+}
+
+@ model_force_train *Model mo → i {
+    ^ ( model_force_train_at mo ( now_seconds ) )
+}
+
+// ── Ingest / detect ───────────────────────────────────────────────────
+
+// Add one raw point: encode (learning), stamp `timestamp`, append to the
+// ring (evicting the oldest at capacity), persist, retrain if the schedule
+// says so, then score it. Errors (bad numeric / timestamp values) leave the
+// model completely untouched.
+@ model_ingest_at *Model mo Json raw i now → !Verdict String {
+    : *Meta mm . mo meta
+    : !EncPoint String er ( anomaly_preprocess mm raw )
+    ?? er {
+        T p → {
+            // Record the point: raw fields + server-side timestamp stamp.
+            : Json rec ( json_clone raw )
+            ( json_obj_set rec `timestamp` ( json_int now ) )
+            : String line ( json_stringify rec )
+            ( json_free rec )
+            ( store_append_point . mo store ( string_data . mo mname ) ( string_data line ) )
+            ( vec_push [String] . mo lines line )
+            ( vec_push [i] . mo times now )
+            = . mm n_seen + . mm n_seen 1
+
+            // Ring eviction: drop the oldest beyond capacity, rewrite log.
+            ? > ( vec_len [String] . mo lines ) . mo max_points {
+                ?? ( vec_remove [String] . mo lines 0 ) {
+                    T old → { ( string_free old ) }
+                    F _ → {}
+                }
+                ?? ( vec_remove [i] . mo times 0 ) { T _ → {} F _ → {} }
+                ( store_write_points . mo store ( string_data . mo mname ) . mo lines )
+            } {}
+            ( store_save_meta . mo store ( string_data . mo mname ) mm )
+
+            // Schedule: lifetime counter reaching the mark retrains all.
+            ? & >= . mm n_seen . mo next_train_at >= ( vec_len [String] . mo lines ) . mo min_points {
+                ( model_force_train_at mo now )
+            } {}
+
+            : Verdict vd ( __an_score_enc mo p )
+            ( enc_free p )
+            ^ @ !Verdict String { T vd }
+        }
+        F e → { ^ @ !Verdict String { F e } }
+    }
+}
+
+@ model_ingest *Model mo Json raw → !Verdict String {
+    ^ ( model_ingest_at mo raw ( now_seconds ) )
+}
+
+// Score without ingesting: no metadata learning, no ring append, no
+// retrain, no disk writes. Unknown columns/categories project to zeros.
+@ model_detect_only *Model mo Json raw → !Verdict String {
+    : !EncPoint String er ( anomaly_preprocess_ro . mo meta raw )
+    ?? er {
+        T p → {
+            : Verdict vd ( __an_score_enc mo p )
+            ( enc_free p )
+            ^ @ !Verdict String { T vd }
+        }
+        F e → { ^ @ !Verdict String { F e } }
+    }
+}
+
+// ── Management ────────────────────────────────────────────────────────
+
+// Drop all data and trained forests but keep the model's name, schedule
+// and version configs. Learned columns/categories/features/scaler reset.
+@ model_reset *Model mo → v {
+    : *Meta old . mo meta
+
+    // Fresh metadata, carrying over identity + configuration.
+    : *Meta fresh ( meta_new ( string_data . old name ) ( string_data . old created ) )
+    = . fresh sched_below . old sched_below
+    = . fresh sched_at_max . old sched_at_max
+    ( vec_free_with [VerCfg] . fresh versions \ VerCfg vc → v { ( __an_vercfg_free vc ) } )
+    = . fresh versions ( vec_new [VerCfg] )
+    : i nv ( vec_len [VerCfg] . old versions )
+    : ~ i vi 0
+    ~ < vi nv {
+        ?? ( vec_get [VerCfg] . old versions vi ) {
+            T vc → {
+                ( vec_push [VerCfg] . fresh versions ( __an_vercfg_clone vc ) )
+                // Remove the version's forest blob from disk as we go.
+                ( store_delete_forest . mo store ( string_data . mo mname ) ( string_data . vc vname ) )
+            }
+            F _ → {}
+        }
+        = vi + vi 1
+    }
+    ( meta_free old )
+    = . mo meta fresh
+
+    ( __an_free_forests mo )
+    ( __an_free_lines . mo lines )
+    = . mo lines ( vec_new [String] )
+    ( vec_free [i] . mo times )
+    = . mo times ( vec_new [i] )
+    ( scaler_free . mo sc )
+    = . mo sc ( meta_scaler fresh )
+    = . mo next_train_at . mo min_points
+
+    : ( Vec String ) none ( vec_new [String] )
+    ( store_write_points . mo store ( string_data . mo mname ) none )
+    ( vec_free [String] none )
+    ( store_save_meta . mo store ( string_data . mo mname ) fresh )
+}
+
+// Delete a model from the store entirely (the Model handle, if any, should
+// be freed separately with model_free).
+@ model_delete Store st s name → b {
+    ^ ( store_delete st name )
+}
+
+// Set one version's decision margin in the metadata (persisted, effective
+// immediately at scoring — no retrain needed). Returns F for an unknown
+// version name.
+@ model_set_margin *Model mo s vname f margin → b {
+    : *Meta mm . mo meta
+    : i nv ( vec_len [VerCfg] . mm versions )
+    : ~ i k 0
+    ~ < k nv {
+        ?? ( vec_get [VerCfg] . mm versions k ) {
+            T vc → {
+                ? == ( nurl_str_eq ( string_data . vc vname ) vname ) 1 {
+                    : ~ VerCfg upd vc
+                    = . upd decision_margin margin
+                    ( vec_set [VerCfg] . mm versions k upd )
+                    ( store_save_meta . mo store ( string_data . mo mname ) mm )
+                    ^ T
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ F
+}
+
+// Update the retraining schedule (persisted immediately).
+@ model_set_schedule *Model mo i below_max i at_max → v {
+    : *Meta mm . mo meta
+    ? > below_max 0 { = . mm sched_below below_max } {}
+    ? > at_max 0 { = . mm sched_at_max at_max } {}
+    ? ( model_is_trained mo ) {
+        = . mo next_train_at + . mm last_trained ( __an_sched_step mo )
+    } {}
+    ( store_save_meta . mo store ( string_data . mo mname ) mm )
+}

--- a/packages/anomaly/src/dynamic.nu
+++ b/packages/anomaly/src/dynamic.nu
@@ -33,6 +33,7 @@ $ `stdlib/std/time.nu`
 $ `stdlib/ext/json.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
+$ `src/score.nu`
 $ `src/store.nu`
 
 // ── Types ─────────────────────────────────────────────────────────────
@@ -584,15 +585,17 @@ $ `src/store.nu`
     ~ < k nf {
         ?? ( vec_get [VerModel] . mo forests k ) {
             T vm → {
+                : ( Vec f ) dfs ( anom_decisions vm big rows nfeat )
+                : *f dfp ( vec_data [f] dfs )
                 : ~ f lowest 0.0
                 : ~ b first T
                 : ~ i r 0
                 ~ < r rows {
-                    : f df ( anom_decision_row vm big r )
-                    ? || first < df lowest { = lowest df } {}
+                    ? || first < . dfp r lowest { = lowest . dfp r } {}
                     = first F
                     = r + r 1
                 }
+                ( vec_free [f] dfs )
                 : f old ( __an_margin_of mm ( string_data . vm vname ) . vm margin )
                 : f adjusted * ( float_abs lowest ) 0.95
                 : b applied ( model_set_margin mo ( string_data . vm vname ) adjusted )

--- a/packages/anomaly/src/main.nu
+++ b/packages/anomaly/src/main.nu
@@ -1,0 +1,452 @@
+// anomaly — streaming anomaly detection from the command line.
+//
+//   anomaly detect <model> key=val ...     ingest one point → verdict JSON
+//   anomaly score  <model> key=val ...     score only (no state change)
+//   anomaly batch  [-f FILE] [-H]          score a CSV (index<TAB>score)
+//   anomaly train  <model>                 force a retrain now
+//   anomaly reset  <model>                 drop data+forests, keep the name
+//   anomaly rm     <model>                 delete the model entirely
+//   anomaly ls                             list models in the store
+//   anomaly info   <model>                 dump model metadata (pretty JSON)
+//   anomaly serve  [--addr HOST:PORT]      run the HTTP/JSON service
+//
+// Values in key=val are auto-typed: numbers are numeric features, ISO-8601
+// strings are timestamps, anything else is categorical (one-hot). Verdicts
+// print as one JSON object per invocation. The store lives under --store
+// DIR (default $ANOMALY_HOME, else ~/.anomaly).
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/args.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/store.nu`
+$ `src/dynamic.nu`
+$ `src/csvdata.nu`
+$ `src/service.nu`
+
+@ __cli_store_root ArgParser p → String {
+    : ?String ov ( args_value p `store` )
+    ?? ov { T v → { ^ v } F junk → { ( string_free junk ) } }
+    : ?String ev ( env_get `ANOMALY_HOME` )
+    ?? ev { T v → { ^ v } F junk → { ( string_free junk ) } }
+    : String home ( env_var_or `HOME` `.` )
+    : String r ( path_join ( string_data home ) `.anomaly` )
+    ( string_free home )
+    ^ r
+}
+
+@ pline s x → v {
+    ( nurl_print x )
+    ( nurl_print `\n` )
+}
+
+// key=val positionals (from index `from`) → a JSON record. Numeric-looking
+// values become JSON numbers, everything else a JSON string (the library's
+// auto-typing takes it from there). None on a malformed argument.
+@ __cli_record ( Vec String ) pos i from → ?Json {
+    : Json o ( json_obj_new )
+    : i n ( vec_len [String] pos )
+    : ~ i k from
+    ~ < k n {
+        ?? ( vec_get [String] pos k ) {
+            T kv → {
+                : ?i eq ( string_index_of kv `=` )
+                ?? eq {
+                    T at → {
+                        ? <= at 0 {
+                            ( json_free o )
+                            ^ @ ?Json { F }
+                        } {}
+                        : String key ( string_new )
+                        : String val ( string_new )
+                        : i len ( string_len kv )
+                        : ~ i c 0
+                        ~ < c at {
+                            ( string_push_char key ( string_get kv c ) )
+                            = c + c 1
+                        }
+                        = c + at 1
+                        ~ < c len {
+                            ( string_push_char val ( string_get kv c ) )
+                            = c + c 1
+                        }
+                        : ?f fx ( string_to_float val )
+                        ?? fx {
+                            T x → { ( json_obj_set o ( string_data key ) ( json_float x ) ) }
+                            F _ → { ( json_obj_set o ( string_data key ) ( json_str_lit ( string_data val ) ) ) }
+                        }
+                        ( string_free key )
+                        ( string_free val )
+                    }
+                    F _ → {
+                        ( json_free o )
+                        ^ @ ?Json { F }
+                    }
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ @ ?Json { T o }
+}
+
+// Print a verdict as one compact JSON object.
+@ __cli_print_verdict *Model mo Verdict vd → v {
+    : Json o ( json_obj_new )
+    ? . vd ready {
+        ( json_obj_set o `status` ( json_str_lit `success` ) )
+        ( json_obj_set o `anomaly` ( json_bool . vd anomaly ) )
+        ( json_obj_set o `score` ( json_float . vd score ) )
+        : Json vers ( json_obj_new )
+        : i nv ( vec_len [VerVerdict] . vd versions )
+        : ~ i k 0
+        ~ < k nv {
+            ?? ( vec_get [VerVerdict] . vd versions k ) {
+                T vv → {
+                    : Json vo ( json_obj_new )
+                    ( json_obj_set vo `anomaly` ( json_bool . vv anomaly ) )
+                    ( json_obj_set vo `score` ( json_float . vv score ) )
+                    ( json_obj_set vo `margin` ( json_float . vv margin ) )
+                    ( json_obj_set vers ( string_data . vv vvname ) vo )
+                }
+                F _ → {}
+            }
+            = k + k 1
+        }
+        ( json_obj_set o `versions` vers )
+    } {
+        ( json_obj_set o `status` ( json_str_lit `collecting` ) )
+        ( json_obj_set o `min_data_points` ( json_int . mo min_points ) )
+    }
+    ( json_obj_set o `data_points` ( json_int ( model_n_points mo ) ) )
+    : String out ( json_stringify o )
+    ( pline ( string_data out ) )
+    ( string_free out )
+    ( json_free o )
+}
+
+// Print (or report the error of) one detect/score result. Exit code.
+@ __cli_report *Model mo !Verdict String vr → i {
+    ?? vr {
+        T vd → {
+            ( __cli_print_verdict mo vd )
+            ( verdict_free vd )
+            ^ 0
+        }
+        F e → {
+            ( nurl_eprint `anomaly: ` )
+            ( nurl_eprintln ( string_data e ) )
+            ( string_free e )
+            ^ 1
+        }
+    }
+}
+
+// detect / score shared path. Returns the exit code.
+@ __cli_detect ArgParser p ( Vec String ) pos b ingest → i {
+    ? < ( vec_len [String] pos ) 2 {
+        ( nurl_eprintln `anomaly: model name required` )
+        ^ 2
+    } {}
+    : ~ s mname ``
+    ?? ( vec_get [String] pos 1 ) { T m → { = mname ( string_data m ) } F _ → {} }
+    : ?Json ro ( __cli_record pos 2 )
+    ?? ro {
+        T rec → {
+            ? > ( json_arr_len rec ) 0 { } {}
+            : String root ( __cli_store_root p )
+            : Store st ( store_open ( string_data root ) )
+            ( string_free root )
+            : ~ i rc 0
+            ? & == ingest F == ( store_exists st mname ) F {
+                ( nurl_eprint `anomaly: model not found: ` )
+                ( nurl_eprintln mname )
+                = rc 1
+            } {
+                : *Model mo ( model_open st mname )
+                ? ingest {
+                    : !Verdict String vr ( model_ingest mo rec )
+                    = rc ( __cli_report mo vr )
+                } {
+                    : !Verdict String vr ( model_detect_only mo rec )
+                    = rc ( __cli_report mo vr )
+                }
+                ( model_free mo )
+            }
+            ( store_free st )
+            ( json_free rec )
+            ^ rc
+        }
+        F _ → {
+            ( nurl_eprintln `anomaly: arguments must be key=value pairs` )
+            ^ 2
+        }
+    }
+}
+
+// batch: stateless CSV scoring, one `index<TAB>score` line per row.
+@ __cli_batch ArgParser p → i {
+    : ~ String input ( string_new )
+    : ~ b have_input T
+    : ?String fo ( args_value p `file` )
+    ?? fo {
+        T fv → {
+            : !String IoErr r ( read_file ( string_data fv ) )
+            ?? r {
+                T txt → { ( string_free input ) = input txt }
+                F _ → {
+                    ( nurl_eprint `anomaly: cannot read file: ` )
+                    ( nurl_eprintln ( string_data fv ) )
+                    = have_input F
+                }
+            }
+            ( string_free fv )
+        }
+        F junk → {
+            ( string_free junk )
+            ( string_free input )
+            = input ( read_all_stdin )
+        }
+    }
+    ? have_input {} {
+        ( string_free input )
+        ^ 1
+    }
+    : b header ( args_present p `header` )
+    : AnomCsv ds ( anom_parse_csv ( string_data input ) `,` header )
+    ( string_free input )
+    ? || <= . ds rows 0 <= . ds cols 0 {
+        ( nurl_eprintln `anomaly: no numeric rows found in input` )
+        ( anom_csv_free ds )
+        ^ 1
+    } {}
+    : ~ f margin 0.0
+    : ?String mg ( args_value p `margin` )
+    ?? mg {
+        T mv → {
+            ?? ( string_to_float mv ) { T x → { = margin x } F _ → {} }
+            ( string_free mv )
+        }
+        F junk → { ( string_free junk ) }
+    }
+    : VerCfg cfg @ VerCfg { ( string_from `batch` ) 0 0 100 256 -1.0 margin T }
+    : BatchReport rep ( anomaly_batch . ds data . ds rows . ds cols cfg )
+    ( __an_vercfg_free cfg )
+
+    : String out ( string_with_cap * . ds rows 16 )
+    : ~ i r 0
+    ~ < r . ds rows {
+        ( string_push_int out r )
+        ( string_push_char out 9 )
+        ?? ( vec_get [f] . rep scores r ) {
+            T sc → { ( string_push_float out sc ) }
+            F _ → {}
+        }
+        ( string_push_char out 10 )
+        = r + r 1
+    }
+    ( nurl_print ( string_data out ) )
+    ( string_free out )
+    : String sm ( string_from `anomalies: ` )
+    ( string_push_int sm . rep anomaly_count )
+    ( string_push_str sm ` of ` )
+    ( string_push_int sm . rep total_rows )
+    ( nurl_eprintln ( string_data sm ) )
+    ( string_free sm )
+    ( anomaly_report_free rep )
+    ( anom_csv_free ds )
+    ^ 0
+}
+
+@ main → i {
+    : ArgParser p ( args_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` )
+    ( args_opt p `store` 115 `DIR` `model store (default: $ANOMALY_HOME, else ~/.anomaly)` )
+    ( args_opt p `file` 102 `FILE` `for batch: read CSV from FILE instead of stdin` )
+    ( args_opt p `margin` 109 `M` `for batch: decision margin (default 0 = predict==-1)` )
+    ( args_opt p `addr` 97 `HOST:PORT` `for serve: bind address (default 127.0.0.1:8811)` )
+    ( args_flag p `header` 72 `for batch: skip the first CSV line (header)` )
+    ( args_flag p `help` 104 `show this help` )
+    ( args_flag p `version` 0 `print the version` )
+
+    ? ( args_parse_argv p ) {} {
+        ( nurl_eprintln ( args_error p ) )
+        ( args_free p )
+        ^ 2
+    }
+    ? ( args_present p `help` ) {
+        : String u ( args_usage p )
+        ( nurl_print ( string_data u ) )
+        ( nurl_print `\ncommands:\n  detect <model> key=val ...   ingest one point, print the verdict\n  score  <model> key=val ...   score only (never ingests or retrains)\n  batch  [-f FILE] [-H]        score a CSV, one "index<TAB>score" per row\n  train  <model>               force a retrain now\n  reset  <model>               drop data + forests, keep the name\n  rm     <model>               delete the model entirely\n  ls                           list models\n  info   <model>               print model metadata\n  serve  [--addr HOST:PORT]    run the HTTP/JSON service\n` )
+        ( string_free u )
+        ( args_free p )
+        ^ 0
+    } {}
+    ? ( args_present p `version` ) {
+        ( pline `anomaly 0.1.0` )
+        ( args_free p )
+        ^ 0
+    } {}
+    ? < ( args_positional_count p ) 1 {
+        ( nurl_eprintln `usage: anomaly <detect|score|batch|train|reset|rm|ls|info|serve> ... (anomaly --help)` )
+        ( args_free p )
+        ^ 2
+    } {}
+
+    : ( Vec String ) pos ( args_positionals p )
+    : ~ s cmd ``
+    ?? ( vec_get [String] pos 0 ) { T c → { = cmd ( string_data c ) } F _ → {} }
+    : ~ s arg1 ``
+    ? >= ( args_positional_count p ) 2 {
+        ?? ( vec_get [String] pos 1 ) { T a → { = arg1 ( string_data a ) } F _ → {} }
+    } {}
+
+    : ~ i rc 0
+    : ~ b handled T
+    ? ( nurl_str_eq cmd `detect` ) {
+        = rc ( __cli_detect p pos T )
+    } {
+    ? ( nurl_str_eq cmd `score` ) {
+        = rc ( __cli_detect p pos F )
+    } {
+    ? ( nurl_str_eq cmd `batch` ) {
+        = rc ( __cli_batch p )
+    } {
+    ? ( nurl_str_eq cmd `serve` ) {
+        : ~ String addr ( string_from `127.0.0.1:8811` )
+        : ?String av ( args_value p `addr` )
+        ?? av {
+            T v → { ( string_free addr ) = addr v }
+            F junk → { ( string_free junk ) }
+        }
+        : ~ String host ( string_new )
+        : ~ i port 8811
+        : ?i colon ( string_index_of addr `:` )
+        ?? colon {
+            T at → {
+                : i n ( string_len addr )
+                : ~ i c 0
+                ~ < c at {
+                    ( string_push_char host ( string_get addr c ) )
+                    = c + c 1
+                }
+                : String ps ( string_new )
+                = c + at 1
+                ~ < c n {
+                    ( string_push_char ps ( string_get addr c ) )
+                    = c + c 1
+                }
+                ?? ( string_to_int ps ) { T x → { = port x } F _ → {} }
+                ( string_free ps )
+            }
+            F _ → {
+                ( string_free host )
+                = host ( string_from ( string_data addr ) )
+            }
+        }
+        : String root ( __cli_store_root p )
+        ( anomaly_service_set_root ( string_data root ) )
+        = rc ( anomaly_serve ( string_data host ) port )
+        ( string_free root )
+        ( string_free host )
+        ( string_free addr )
+    } {
+        // Store-backed single-model commands.
+        : String root ( __cli_store_root p )
+        : Store st ( store_open ( string_data root ) )
+        ( string_free root )
+        ? ( nurl_str_eq cmd `ls` ) {
+            : ( Vec String ) names ( store_list st )
+            : i n ( vec_len [String] names )
+            : ~ i k 0
+            ~ < k n {
+                ?? ( vec_get [String] names k ) {
+                    T nm → { ( pline ( string_data nm ) ) }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+        } {
+        ? ( nurl_str_eq cmd `info` ) {
+            : ?*Meta mload ( store_load_meta st arg1 )
+            ?? mload {
+                T mm → {
+                    : Json o ( meta_to_json mm )
+                    : String out ( json_pretty o )
+                    ( pline ( string_data out ) )
+                    ( string_free out )
+                    ( json_free o )
+                    ( meta_free mm )
+                }
+                F _ → {
+                    ( nurl_eprint `anomaly: model not found: ` )
+                    ( nurl_eprintln arg1 )
+                    = rc 1
+                }
+            }
+        } {
+        ? ( nurl_str_eq cmd `train` ) {
+            ? ( store_exists st arg1 ) {
+                : *Model mo ( model_open st arg1 )
+                : i used ( model_force_train mo )
+                ? > used 0 {
+                    : String msg ( string_from `trained on ` )
+                    ( string_push_int msg used )
+                    ( string_push_str msg ` points` )
+                    ( pline ( string_data msg ) )
+                    ( string_free msg )
+                } {
+                    ( nurl_eprintln `anomaly: not enough data to train` )
+                    = rc 1
+                }
+                ( model_free mo )
+            } {
+                ( nurl_eprint `anomaly: model not found: ` )
+                ( nurl_eprintln arg1 )
+                = rc 1
+            }
+        } {
+        ? ( nurl_str_eq cmd `reset` ) {
+            ? ( store_exists st arg1 ) {
+                : *Model mo ( model_open st arg1 )
+                ( model_reset mo )
+                ( model_free mo )
+                ( pline `reset` )
+            } {
+                ( nurl_eprint `anomaly: model not found: ` )
+                ( nurl_eprintln arg1 )
+                = rc 1
+            }
+        } {
+        ? ( nurl_str_eq cmd `rm` ) {
+            ? ( store_exists st arg1 ) {
+                : b okd ( model_delete st arg1 )
+                ? okd { ( pline `deleted` ) } {
+                    ( nurl_eprintln `anomaly: delete failed` )
+                    = rc 1
+                }
+            } {
+                ( nurl_eprint `anomaly: model not found: ` )
+                ( nurl_eprintln arg1 )
+                = rc 1
+            }
+        } {
+            ( nurl_eprint `anomaly: unknown command: ` )
+            ( nurl_eprintln cmd )
+            ( nurl_eprintln `try 'anomaly --help'` )
+            = rc 2
+        } } } } }
+        ( store_free st )
+    } } } }
+
+    ( args_free p )
+    ^ rc
+}

--- a/packages/anomaly/src/main.nu
+++ b/packages/anomaly/src/main.nu
@@ -26,6 +26,7 @@ $ `stdlib/ext/env.nu`
 $ `stdlib/ext/json.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
+$ `src/score.nu`
 $ `src/store.nu`
 $ `src/dynamic.nu`
 $ `src/csvdata.nu`
@@ -290,7 +291,7 @@ $ `src/service.nu`
         ^ 0
     } {}
     ? ( args_present p `version` ) {
-        ( pline `anomaly 0.1.0` )
+        ( pline `anomaly 0.2.0` )
         ( args_free p )
         ^ 0
     } {}

--- a/packages/anomaly/src/model.nu
+++ b/packages/anomaly/src/model.nu
@@ -1,0 +1,155 @@
+// anomaly/model.nu — the stateless scoring core (milestone M2).
+//
+// Wraps the `iforest` package's forest behind the M1 preprocessing layer
+// and the scikit-learn decision conventions the reference service uses:
+//
+//   score_samples(x)      = -iforest_score(x)          (more negative = worse)
+//   decision_function(x)  = score_samples(x) - offset_
+//   offset_               = -0.5                        for contamination "auto"
+//                         = percentile(score_samples of the training set,
+//                                      100 * contamination)   otherwise
+//   predict(x) == -1      ⇔ decision_function(x) < 0
+//   version verdict       : decision_function(x) <= -decision_margin
+//
+// A `VerModel` is one trained forest + its offset and margin — the unit that
+// M4/M5 instantiate per time window. `anomaly_batch` is the stateless batch
+// path: fit a scaler over a numeric matrix, train, and score every row.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/sort.nu`
+$ `src/prep.nu`
+$ `deps/iforest/src/iforest.nu`
+
+// The reference's fixed random_state: a given training set always yields a
+// byte-identical forest, hence identical scores, on every platform.
+: i ANOM_SEED 42
+
+// One trained model version: forest + decision offset + margin.
+: VerModel {
+    String vname
+    IForest forest
+    f offset
+    f margin
+    i n_cols
+    b trained
+}
+
+// Batch verdict over a matrix (see SPEC §6): anomaly ⇔ predict == -1,
+// i.e. decision_function < 0 (margin 0), matching the reference batch path.
+: BatchReport {
+    i total_rows
+    i anomaly_count
+    f anomaly_percentage
+    ( Vec i ) anomaly_indices
+    b has_anomalies
+    ( Vec f ) scores
+}
+
+// ── Percentile (numpy 'linear' interpolation, for contamination) ──────
+
+// q in [0,1] over an ASCENDING-sorted vector.
+@ __an_percentile ( Vec f ) sorted f q → f {
+    : i n ( vec_len [f] sorted )
+    ? <= n 0 { ^ 0.0 } {}
+    : *f dp ( vec_data [f] sorted )
+    ? <= n 1 { ^ . dp 0 } {}
+    : ~ f pos * q # f - n 1
+    ? < pos 0.0 { = pos 0.0 } {}
+    : ~ i lo # i ( float_floor pos )
+    ? >= lo - n 1 { ^ . dp - n 1 } {}
+    : f frac - pos # f lo
+    ^ + . dp lo * - . dp + lo 1 . dp lo frac
+}
+
+// ── Version training / scoring ────────────────────────────────────────
+
+// Train one version's forest over an ALREADY-STANDARDISED row-major matrix.
+// `cfg.max_samples` is clamped to the row count; contamination < 0 = "auto"
+// (offset pinned at -0.5), else offset_ is the 100*c percentile of the
+// training set's score_samples — so `predict == -1` flags ~c of training.
+@ anom_train_version ( Vec f ) scaled i n_rows i n_cols VerCfg cfg → VerModel {
+    : ~ i samp . cfg max_samples
+    ? > samp n_rows { = samp n_rows } {}
+    : IForest fo ( iforest_train scaled n_rows n_cols . cfg n_estimators samp ANOM_SEED )
+    : ~ f off -0.5
+    ? >= . cfg contamination 0.0 {
+        : ( Vec f ) ss ( vec_with_cap [f] n_rows )
+        : ~ i r 0
+        ~ < r n_rows {
+            ( vec_push [f] ss - 0.0 ( iforest_score_row fo scaled r ) )
+            = r + r 1
+        }
+        ( sort_by [f] ss \ f a f b → i {
+            ? < a b { ^ -1 } {}
+            ? > a b { ^ 1 } {}
+            ^ 0
+        } )
+        = off ( __an_percentile ss . cfg contamination )
+        ( vec_free [f] ss )
+    } {}
+    ^ @ VerModel {
+        ( string_from ( string_data . cfg vname ) )
+        fo
+        off
+        . cfg decision_margin
+        n_cols
+        T
+    }
+}
+
+// decision_function of an already-standardised point.
+@ anom_decision VerModel vm ( Vec f ) scaled_point → f {
+    ^ - - 0.0 ( iforest_score . vm forest scaled_point ) . vm offset
+}
+
+// decision_function of row `r` of an already-standardised matrix.
+@ anom_decision_row VerModel vm ( Vec f ) scaled i r → f {
+    ^ - - 0.0 ( iforest_score_row . vm forest scaled r ) . vm offset
+}
+
+// The per-version verdict convention: below (or at) the margin ⇒ anomaly.
+@ anom_is_anomaly VerModel vm f df → b {
+    ^ <= df - 0.0 . vm margin
+}
+
+@ anom_vermodel_free VerModel vm → v {
+    ( string_free . vm vname )
+    ( iforest_free . vm forest )
+}
+
+// ── Batch (stateless) scoring ─────────────────────────────────────────
+
+// Fit a scaler over the raw matrix, train one version on the standardised
+// copy, then score every row. Anomaly ⇔ decision_function <= -cfg.margin
+// (margin 0 reproduces the reference's predict == -1 batch rule).
+@ anomaly_batch ( Vec f ) data i n_rows i n_cols VerCfg cfg → BatchReport {
+    : Scaler sc ( scaler_fit data n_rows n_cols )
+    : ( Vec f ) scaled ( vec_clone [f] data )
+    ( scaler_apply_matrix sc scaled n_rows n_cols )
+    : VerModel vm ( anom_train_version scaled n_rows n_cols cfg )
+
+    : ( Vec f ) scores ( vec_with_cap [f] n_rows )
+    : ( Vec i ) hits ( vec_new [i] )
+    : ~ i r 0
+    ~ < r n_rows {
+        : f df ( anom_decision_row vm scaled r )
+        ( vec_push [f] scores df )
+        ? ( anom_is_anomaly vm df ) { ( vec_push [i] hits r ) } {}
+        = r + r 1
+    }
+    ( anom_vermodel_free vm )
+    ( vec_free [f] scaled )
+    ( scaler_free sc )
+
+    : i n_hits ( vec_len [i] hits )
+    : ~ f pct 0.0
+    ? > n_rows 0 { = pct / * # f n_hits 100.0 # f n_rows } {}
+    ^ @ BatchReport { n_rows n_hits pct hits > n_hits 0 scores }
+}
+
+@ anomaly_report_free BatchReport rep → v {
+    ( vec_free [i] . rep anomaly_indices )
+    ( vec_free [f] . rep scores )
+}

--- a/packages/anomaly/src/model.nu
+++ b/packages/anomaly/src/model.nu
@@ -1,4 +1,4 @@
-// anomaly/model.nu — the stateless scoring core (milestone M2).
+// anomaly/model.nu — the per-point scoring core (milestone M2).
 //
 // Wraps the `iforest` package's forest behind the M1 preprocessing layer
 // and the scikit-learn decision conventions the reference service uses:
@@ -12,8 +12,9 @@
 //   version verdict       : decision_function(x) <= -decision_margin
 //
 // A `VerModel` is one trained forest + its offset and margin — the unit that
-// M4/M5 instantiate per time window. `anomaly_batch` is the stateless batch
-// path: fit a scaler over a numeric matrix, train, and score every row.
+// M4/M5 instantiate per time window. Training and the bulk/batch scoring
+// paths (GPU-accelerated when available) live in src/score.nu; this file is
+// the small, dependency-light core they build on.
 
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
@@ -36,68 +37,7 @@ $ `deps/iforest/src/iforest.nu`
     b trained
 }
 
-// Batch verdict over a matrix (see SPEC §6): anomaly ⇔ predict == -1,
-// i.e. decision_function < 0 (margin 0), matching the reference batch path.
-: BatchReport {
-    i total_rows
-    i anomaly_count
-    f anomaly_percentage
-    ( Vec i ) anomaly_indices
-    b has_anomalies
-    ( Vec f ) scores
-}
-
-// ── Percentile (numpy 'linear' interpolation, for contamination) ──────
-
-// q in [0,1] over an ASCENDING-sorted vector.
-@ __an_percentile ( Vec f ) sorted f q → f {
-    : i n ( vec_len [f] sorted )
-    ? <= n 0 { ^ 0.0 } {}
-    : *f dp ( vec_data [f] sorted )
-    ? <= n 1 { ^ . dp 0 } {}
-    : ~ f pos * q # f - n 1
-    ? < pos 0.0 { = pos 0.0 } {}
-    : ~ i lo # i ( float_floor pos )
-    ? >= lo - n 1 { ^ . dp - n 1 } {}
-    : f frac - pos # f lo
-    ^ + . dp lo * - . dp + lo 1 . dp lo frac
-}
-
-// ── Version training / scoring ────────────────────────────────────────
-
-// Train one version's forest over an ALREADY-STANDARDISED row-major matrix.
-// `cfg.max_samples` is clamped to the row count; contamination < 0 = "auto"
-// (offset pinned at -0.5), else offset_ is the 100*c percentile of the
-// training set's score_samples — so `predict == -1` flags ~c of training.
-@ anom_train_version ( Vec f ) scaled i n_rows i n_cols VerCfg cfg → VerModel {
-    : ~ i samp . cfg max_samples
-    ? > samp n_rows { = samp n_rows } {}
-    : IForest fo ( iforest_train scaled n_rows n_cols . cfg n_estimators samp ANOM_SEED )
-    : ~ f off -0.5
-    ? >= . cfg contamination 0.0 {
-        : ( Vec f ) ss ( vec_with_cap [f] n_rows )
-        : ~ i r 0
-        ~ < r n_rows {
-            ( vec_push [f] ss - 0.0 ( iforest_score_row fo scaled r ) )
-            = r + r 1
-        }
-        ( sort_by [f] ss \ f a f b → i {
-            ? < a b { ^ -1 } {}
-            ? > a b { ^ 1 } {}
-            ^ 0
-        } )
-        = off ( __an_percentile ss . cfg contamination )
-        ( vec_free [f] ss )
-    } {}
-    ^ @ VerModel {
-        ( string_from ( string_data . cfg vname ) )
-        fo
-        off
-        . cfg decision_margin
-        n_cols
-        T
-    }
-}
+// ── Per-point scoring ─────────────────────────────────────────────────
 
 // decision_function of an already-standardised point.
 @ anom_decision VerModel vm ( Vec f ) scaled_point → f {
@@ -117,39 +57,4 @@ $ `deps/iforest/src/iforest.nu`
 @ anom_vermodel_free VerModel vm → v {
     ( string_free . vm vname )
     ( iforest_free . vm forest )
-}
-
-// ── Batch (stateless) scoring ─────────────────────────────────────────
-
-// Fit a scaler over the raw matrix, train one version on the standardised
-// copy, then score every row. Anomaly ⇔ decision_function <= -cfg.margin
-// (margin 0 reproduces the reference's predict == -1 batch rule).
-@ anomaly_batch ( Vec f ) data i n_rows i n_cols VerCfg cfg → BatchReport {
-    : Scaler sc ( scaler_fit data n_rows n_cols )
-    : ( Vec f ) scaled ( vec_clone [f] data )
-    ( scaler_apply_matrix sc scaled n_rows n_cols )
-    : VerModel vm ( anom_train_version scaled n_rows n_cols cfg )
-
-    : ( Vec f ) scores ( vec_with_cap [f] n_rows )
-    : ( Vec i ) hits ( vec_new [i] )
-    : ~ i r 0
-    ~ < r n_rows {
-        : f df ( anom_decision_row vm scaled r )
-        ( vec_push [f] scores df )
-        ? ( anom_is_anomaly vm df ) { ( vec_push [i] hits r ) } {}
-        = r + r 1
-    }
-    ( anom_vermodel_free vm )
-    ( vec_free [f] scaled )
-    ( scaler_free sc )
-
-    : i n_hits ( vec_len [i] hits )
-    : ~ f pct 0.0
-    ? > n_rows 0 { = pct / * # f n_hits 100.0 # f n_rows } {}
-    ^ @ BatchReport { n_rows n_hits pct hits > n_hits 0 scores }
-}
-
-@ anomaly_report_free BatchReport rep → v {
-    ( vec_free [i] . rep anomaly_indices )
-    ( vec_free [f] . rep scores )
 }

--- a/packages/anomaly/src/prep.nu
+++ b/packages/anomaly/src/prep.nu
@@ -1,0 +1,1003 @@
+// anomaly/prep.nu — feature preprocessing, standardisation, model metadata.
+//
+// This is milestone M1 of the `anomaly` package (see SPEC.md): the pure,
+// I/O-free foundation everything else builds on.
+//
+//   - A model's *metadata* (`*Meta`) records what it has learned about the
+//     shape of its input: which columns exist, their types (numeric /
+//     categorical / timestamp), the categories seen so far, the authoritative
+//     feature order, and the scaler parameters. It round-trips through JSON.
+//   - `anomaly_preprocess` turns one raw JSON record into named numeric
+//     features, updating the metadata as new columns / categories appear:
+//     numeric passthrough, categorical → deterministic one-hot (categories
+//     kept sorted), ISO-8601 timestamp → hour/day/month/weekday.
+//   - `anomaly_project` pins a named feature set onto the model's frozen
+//     feature order: missing features become 0, unknown extras are dropped.
+//     This is the feature-order stability rule that keeps one-hot columns
+//     aligned across retrains.
+//   - `Scaler` is the StandardScaler analogue: per-feature zero-mean /
+//     unit-variance, with zero-variance features passing through unscaled.
+//
+// Column types are detected once, on first sight, then frozen in metadata:
+// a value that parses as a number is numeric, else a value that parses as
+// ISO-8601 is a timestamp, else it is categorical (mirrors the Python
+// reference's float()/fromisoformat()/str fallback chain).
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/json.nu`
+
+// ── Column kinds ──────────────────────────────────────────────────────
+
+: i COL_NUMERIC 0
+: i COL_CATEGORICAL 1
+: i COL_TIMESTAMP 2
+
+// Reference defaults (carried over verbatim from the Python service).
+: i ANOM_MIN_POINTS 50
+: i ANOM_MAX_POINTS 150000
+: i ANOM_SCHED_BELOW 50
+: i ANOM_SCHED_AT_MAX 1000
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+// Config of one time-window model version. `window_min` filters training
+// data to the last N minutes (0 = no time filter); `window_pts` caps it to
+// the last N points (0 = no cap; used by `timevector`). `contamination`
+// < 0 means "auto" (offset pinned at -0.5, the sklearn convention).
+: VerCfg {
+    String vname
+    i window_min
+    i window_pts
+    i n_estimators
+    i max_samples
+    f contamination
+    f decision_margin
+    b enabled
+}
+
+// Everything a model knows about its input shape. Heap-allocated (`*Meta`)
+// so counters and handles can be updated through any reference. `cols` /
+// `kinds` / `cats` are parallel: cats[i] is the sorted category list of
+// column i (empty unless categorical). `feats` is the authoritative feature
+// order once non-empty (snapshotted at each train by meta_refresh_feats);
+// until then the model is "unfrozen" and the order is derived on demand.
+: Meta {
+    String name
+    String created
+    ( Vec String ) cols
+    ( Vec i ) kinds
+    ( Vec ( Vec String ) ) cats
+    ( Vec String ) feats
+    ( Vec f ) sc_mean
+    ( Vec f ) sc_std
+    i sched_below
+    i sched_at_max
+    i n_seen
+    i last_trained
+    ( Vec VerCfg ) versions
+}
+
+// One preprocessed record: parallel (feature name, value) pairs in
+// encounter order. Project onto a feature order with anomaly_project.
+: EncPoint {
+    ( Vec String ) names
+    ( Vec f ) vals
+}
+
+// Per-feature standardisation: y = (x - mean) * inv_std. Zero-variance
+// features store inv_std = 1 so they pass through centred but unscaled.
+: Scaler {
+    ( Vec f ) mean
+    ( Vec f ) inv_std
+}
+
+// ── Version defaults ──────────────────────────────────────────────────
+//
+// The five default versions of the reference service. `seasonal`'s 90 days
+// are expressed in minutes; `timevector` has no time window — it works on
+// the most recent `window_pts` points.
+
+@ __an_vc s vname i wmin i wpts i est i samp f margin → VerCfg {
+    ^ @ VerCfg { ( string_from vname ) wmin wpts est samp -1.0 margin T }
+}
+
+@ meta_default_versions → ( Vec VerCfg ) {
+    : ( Vec VerCfg ) vs ( vec_new [VerCfg] )
+    ( vec_push [VerCfg] vs ( __an_vc `short_term` 180    0   200 256 0.16 ) )
+    ( vec_push [VerCfg] vs ( __an_vc `daily`      1440   0   300 256 0.12 ) )
+    ( vec_push [VerCfg] vs ( __an_vc `weekly`     10080  0   350 256 0.06 ) )
+    ( vec_push [VerCfg] vs ( __an_vc `seasonal`   129600 0   400 256 0.08 ) )
+    ( vec_push [VerCfg] vs ( __an_vc `timevector` 0      100 200 256 0.10 ) )
+    ^ vs
+}
+
+@ __an_vercfg_free VerCfg vc → v {
+    ( string_free . vc vname )
+}
+
+// ── Meta lifecycle ────────────────────────────────────────────────────
+
+@ meta_new s name s created → *Meta {
+    : *Meta m # *Meta ( nurl_malloc Z Meta )
+    = . m name ( string_from name )
+    = . m created ( string_from created )
+    = . m cols ( vec_new [String] )
+    = . m kinds ( vec_new [i] )
+    = . m cats ( vec_new [( Vec String )] )
+    = . m feats ( vec_new [String] )
+    = . m sc_mean ( vec_new [f] )
+    = . m sc_std ( vec_new [f] )
+    = . m sched_below ANOM_SCHED_BELOW
+    = . m sched_at_max ANOM_SCHED_AT_MAX
+    = . m n_seen 0
+    = . m last_trained 0
+    = . m versions ( meta_default_versions )
+    ^ m
+}
+
+@ meta_free *Meta m → v {
+    ( string_free . m name )
+    ( string_free . m created )
+    ( vec_free_with [String] . m cols \ String x → v { ( string_free x ) } )
+    ( vec_free [i] . m kinds )
+    ( vec_free_with [( Vec String )] . m cats \ ( Vec String ) cv → v {
+        ( vec_free_with [String] cv \ String x → v { ( string_free x ) } )
+    } )
+    ( vec_free_with [String] . m feats \ String x → v { ( string_free x ) } )
+    ( vec_free [f] . m sc_mean )
+    ( vec_free [f] . m sc_std )
+    ( vec_free_with [VerCfg] . m versions \ VerCfg vc → v { ( __an_vercfg_free vc ) } )
+    ( nurl_free m )
+}
+
+// Index of column `name` in the metadata, or -1.
+@ __an_col_find *Meta m s name → i {
+    : i n ( vec_len [String] . m cols )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] . m cols k ) {
+            T c → { ? == ( nurl_str_eq ( string_data c ) name ) 1 { ^ k } {} }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ -1
+}
+
+// Column kind at index `ci` (COL_NUMERIC if somehow missing).
+@ __an_kind_at *Meta m i ci → i {
+    ?? ( vec_get [i] . m kinds ci ) { T k → { ^ k } F _ → { ^ COL_NUMERIC } }
+}
+
+// A model is "frozen" once it has an authoritative feature order (set at
+// first train). Before that, feature order is derived from the metadata.
+@ meta_is_frozen *Meta m → b {
+    ^ > ( vec_len [String] . m feats ) 0
+}
+
+// ── Value coercion ────────────────────────────────────────────────────
+
+// Kind of a column, judged from its first-seen value: number (or bool, or
+// numeric string) → numeric; ISO-8601 string → timestamp; else categorical.
+@ __an_detect_kind Json jv → i {
+    ? ( json_is_num jv ) { ^ COL_NUMERIC } {}
+    ? ( json_is_bool jv ) { ^ COL_NUMERIC } {}
+    ? ( json_is_str jv ) {
+        : String tmp ( string_from ( json_str_data jv ) )
+        : ?f fx ( string_to_float tmp )
+        ( string_free tmp )
+        ?? fx { T _ → { ^ COL_NUMERIC } F _ → {} }
+        : !i ParseErr r ( time_parse_iso ( json_str_data jv ) )
+        ?? r { T _ → { ^ COL_TIMESTAMP } F _ → {} }
+        ^ COL_CATEGORICAL
+    } {}
+    ^ COL_CATEGORICAL
+}
+
+// Numeric view of a JSON value: number, bool (1/0), or numeric string.
+@ __an_num_of Json jv → ?f {
+    ? ( json_is_num jv ) { ^ ( json_num_as_f jv ) } {}
+    ? ( json_is_bool jv ) {
+        ? ( json_bool_val jv ) { ^ @ ?f { T 1.0 } } { ^ @ ?f { T 0.0 } }
+    } {}
+    ? ( json_is_str jv ) {
+        : String tmp ( string_from ( json_str_data jv ) )
+        : ?f fx ( string_to_float tmp )
+        ( string_free tmp )
+        ^ fx
+    } {}
+    ^ @ ?f { F 0.0 }
+}
+
+// String view of a JSON value (categorical stringification): a JSON string
+// unquoted, anything else in its literal JSON spelling.
+@ __an_str_of Json jv → String {
+    ? ( json_is_str jv ) { ^ ( string_from ( json_str_data jv ) ) } {}
+    ^ ( json_stringify jv )
+}
+
+// Insert `val` into the sorted category list if new. Returns T if added.
+@ __an_cat_add ( Vec String ) cats s val → b {
+    : i n ( vec_len [String] cats )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] cats k ) {
+            T c → {
+                : i cmp ( nurl_str_cmp ( string_data c ) val )
+                ? == cmp 0 { ^ F } {}
+                ? > cmp 0 {
+                    ( vec_insert [String] cats k ( string_from val ) )
+                    ^ T
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_push [String] cats ( string_from val ) )
+    ^ T
+}
+
+// ── Feature naming ────────────────────────────────────────────────────
+
+// "<col>_<suffix>" as an owned String.
+@ __an_feat_name s col s suffix → String {
+    : String fname ( string_from col )
+    ( string_push_char fname 95 )
+    ( string_push_str fname suffix )
+    ^ fname
+}
+
+// Append column `ci`'s feature names (in canonical order) to `out`.
+@ __an_push_col_feats *Meta m i ci ( Vec String ) out → v {
+    ?? ( vec_get [String] . m cols ci ) {
+        T c → {
+            : s cn ( string_data c )
+            : i kind ( __an_kind_at m ci )
+            ? == kind COL_NUMERIC {
+                ( vec_push [String] out ( string_from cn ) )
+            } {}
+            ? == kind COL_CATEGORICAL {
+                ?? ( vec_get [( Vec String )] . m cats ci ) {
+                    T cv → {
+                        : i nc ( vec_len [String] cv )
+                        : ~ i k 0
+                        ~ < k nc {
+                            ?? ( vec_get [String] cv k ) {
+                                T cat → { ( vec_push [String] out ( __an_feat_name cn ( string_data cat ) ) ) }
+                                F _ → {}
+                            }
+                            = k + k 1
+                        }
+                    }
+                    F _ → {}
+                }
+            } {}
+            ? == kind COL_TIMESTAMP {
+                ( vec_push [String] out ( __an_feat_name cn `hour` ) )
+                ( vec_push [String] out ( __an_feat_name cn `day` ) )
+                ( vec_push [String] out ( __an_feat_name cn `month` ) )
+                ( vec_push [String] out ( __an_feat_name cn `weekday` ) )
+            } {}
+        }
+        F _ → {}
+    }
+}
+
+// The feature order implied by the current metadata: columns in first-seen
+// order, each expanded canonically (categoricals over their sorted
+// categories). Deterministic for a given metadata state. Owned result.
+@ meta_derived_feats *Meta m → ( Vec String ) {
+    : ( Vec String ) out ( vec_new [String] )
+    : i n ( vec_len [String] . m cols )
+    : ~ i k 0
+    ~ < k n {
+        ( __an_push_col_feats m k out )
+        = k + k 1
+    }
+    ^ out
+}
+
+// Snapshot the derived feature order as authoritative (called at train
+// time). From now on scoring projects onto exactly this vector.
+@ meta_refresh_feats *Meta m → v {
+    ( vec_free_with [String] . m feats \ String x → v { ( string_free x ) } )
+    = . m feats ( meta_derived_feats m )
+}
+
+// ── Preprocessing ─────────────────────────────────────────────────────
+
+@ enc_free EncPoint p → v {
+    ( vec_free_with [String] . p names \ String x → v { ( string_free x ) } )
+    ( vec_free [f] . p vals )
+}
+
+// Index of feature `name` in the encoded point, or -1.
+@ enc_find EncPoint p s name → i {
+    : i n ( vec_len [String] . p names )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] . p names k ) {
+            T c → { ? == ( nurl_str_eq ( string_data c ) name ) 1 { ^ k } {} }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ -1
+}
+
+// "Parameter '<col>' must be <what>." as an owned String.
+@ __an_err_param s col s what → String {
+    : String msg ( string_from `Parameter '` )
+    ( string_push_str msg col )
+    ( string_push_str msg `' must be ` )
+    ( string_push_str msg what )
+    ( string_push_char msg 46 )
+    ^ msg
+}
+
+// Encode one column's value into (names, vals), updating metadata for new
+// categories. Returns an error message, or an empty String on success.
+@ __an_encode_col *Meta m i ci s cn Json jv ( Vec String ) names ( Vec f ) vals → String {
+    : i kind ( __an_kind_at m ci )
+    ? == kind COL_NUMERIC {
+        : ?f fx ( __an_num_of jv )
+        ?? fx {
+            T x → {
+                ( vec_push [String] names ( string_from cn ) )
+                ( vec_push [f] vals x )
+            }
+            F _ → { ^ ( __an_err_param cn `a numeric value` ) }
+        }
+    } {}
+    ? == kind COL_CATEGORICAL {
+        : String sval ( __an_str_of jv )
+        ?? ( vec_get [( Vec String )] . m cats ci ) {
+            T cv → {
+                ( __an_cat_add cv ( string_data sval ) )
+                : i nc ( vec_len [String] cv )
+                : ~ i k 0
+                ~ < k nc {
+                    ?? ( vec_get [String] cv k ) {
+                        T cat → {
+                            : ~ f hot 0.0
+                            ? == ( nurl_str_eq ( string_data cat ) ( string_data sval ) ) 1 { = hot 1.0 } {}
+                            ( vec_push [String] names ( __an_feat_name cn ( string_data cat ) ) )
+                            ( vec_push [f] vals hot )
+                        }
+                        F _ → {}
+                    }
+                    = k + k 1
+                }
+            }
+            F _ → {}
+        }
+        ( string_free sval )
+    } {}
+    ? == kind COL_TIMESTAMP {
+        ? ( json_is_str jv ) {
+            : !i ParseErr r ( time_parse_iso ( json_str_data jv ) )
+            ?? r {
+                T secs → {
+                    : Time t ( time_from_unix secs )
+                    ( vec_push [String] names ( __an_feat_name cn `hour` ) )
+                    ( vec_push [f] vals # f . t hour )
+                    ( vec_push [String] names ( __an_feat_name cn `day` ) )
+                    ( vec_push [f] vals # f . t day )
+                    ( vec_push [String] names ( __an_feat_name cn `month` ) )
+                    ( vec_push [f] vals # f . t month )
+                    // Monday = 0 … Sunday = 6, like Python's weekday().
+                    ( vec_push [String] names ( __an_feat_name cn `weekday` ) )
+                    ( vec_push [f] vals # f % + . t wday 6 7 )
+                }
+                F _ → { ^ ( __an_err_param cn `a valid ISO timestamp` ) }
+            }
+        } {
+            ^ ( __an_err_param cn `a valid ISO timestamp` )
+        }
+    } {}
+    ^ ( string_new )
+}
+
+// Encode one raw JSON record into named numeric features, updating the
+// metadata as new columns / categories appear. The reserved key
+// `timestamp` is the point's own clock and is never a feature. Numeric
+// parse failure and bad timestamps are hard errors (owned message).
+@ anomaly_preprocess *Meta m Json raw → !EncPoint String {
+    : ( Vec String ) names ( vec_new [String] )
+    : ( Vec f ) vals ( vec_new [f] )
+    : ( Vec String ) keys ( json_obj_keys raw )
+    : i nk ( vec_len [String] keys )
+    : ~ String err ( string_new )
+    : ~ i ki 0
+    ~ & == ( string_len err ) 0 < ki nk {
+        ?? ( vec_get [String] keys ki ) {
+            T kstr → {
+                : s cn ( string_data kstr )
+                ? == ( nurl_str_eq cn `timestamp` ) 1 {} {
+                    ?? ( json_obj_get raw cn ) {
+                        T jv → {
+                            : ~ i ci ( __an_col_find m cn )
+                            ? < ci 0 {
+                                = ci ( vec_len [String] . m cols )
+                                ( vec_push [String] . m cols ( string_from cn ) )
+                                ( vec_push [i] . m kinds ( __an_detect_kind jv ) )
+                                ( vec_push [( Vec String )] . m cats ( vec_new [String] ) )
+                            } {}
+                            : String e2 ( __an_encode_col m ci cn jv names vals )
+                            ? > ( string_len e2 ) 0 {
+                                ( string_free err )
+                                = err e2
+                            } {
+                                ( string_free e2 )
+                            }
+                        }
+                        F _ → {}
+                    }
+                }
+            }
+            F _ → {}
+        }
+        = ki + ki 1
+    }
+    ( vec_free_with [String] keys \ String x → v { ( string_free x ) } )
+    ? > ( string_len err ) 0 {
+        ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+        ( vec_free [f] vals )
+        ^ @ !EncPoint String { F err }
+    } {}
+    ( string_free err )
+    ^ @ !EncPoint String { T @ EncPoint { names vals } }
+}
+
+// Project an encoded point onto an authoritative feature order: missing
+// features become 0, features not in `feats` are dropped. Owned result.
+@ anomaly_project EncPoint p ( Vec String ) feats → ( Vec f ) {
+    : i nf ( vec_len [String] feats )
+    : ( Vec f ) out ( vec_with_cap [f] nf )
+    : ~ i k 0
+    ~ < k nf {
+        : ~ f x 0.0
+        ?? ( vec_get [String] feats k ) {
+            T fname → {
+                : i at ( enc_find p ( string_data fname ) )
+                ? >= at 0 {
+                    ?? ( vec_get [f] . p vals at ) { T v2 → { = x v2 } F _ → {} }
+                } {}
+            }
+            F _ → {}
+        }
+        ( vec_push [f] out x )
+        = k + k 1
+    }
+    ^ out
+}
+
+// ── Standardisation ───────────────────────────────────────────────────
+
+// Fit per-feature mean and 1/std over a row-major matrix (population
+// variance, like sklearn's StandardScaler). Zero-variance features get
+// inv_std = 1 so they centre but never divide by ~0.
+@ scaler_fit ( Vec f ) data i n_rows i n_cols → Scaler {
+    : ( Vec f ) mean ( vec_with_cap [f] n_cols )
+    : ( Vec f ) inv ( vec_with_cap [f] n_cols )
+    ? <= n_rows 0 {
+        : ~ i c0 0
+        ~ < c0 n_cols {
+            ( vec_push [f] mean 0.0 )
+            ( vec_push [f] inv 1.0 )
+            = c0 + c0 1
+        }
+        ^ @ Scaler { mean inv }
+    } {}
+    : *f dp ( vec_data [f] data )
+    : ~ i c 0
+    ~ < c n_cols {
+        : ~ f total 0.0
+        : ~ i r 0
+        ~ < r n_rows {
+            = total + total . dp + * r n_cols c
+            = r + r 1
+        }
+        : f mu / total # f n_rows
+        : ~ f ss 0.0
+        = r 0
+        ~ < r n_rows {
+            : f d - . dp + * r n_cols c mu
+            = ss + ss * d d
+            = r + r 1
+        }
+        : f variance / ss # f n_rows
+        ( vec_push [f] mean mu )
+        ? > variance 0.0 {
+            ( vec_push [f] inv / 1.0 ( float_sqrt variance ) )
+        } {
+            ( vec_push [f] inv 1.0 )
+        }
+        = c + c 1
+    }
+    ^ @ Scaler { mean inv }
+}
+
+// Standardise one point in place: x → (x - mean) * inv_std.
+@ scaler_apply Scaler sc ( Vec f ) point → v {
+    : i n ( vec_len [f] point )
+    : i nm ( vec_len [f] . sc mean )
+    : *f pp ( vec_data [f] point )
+    : *f mp ( vec_data [f] . sc mean )
+    : *f ip ( vec_data [f] . sc inv_std )
+    : ~ i k 0
+    ~ & < k n < k nm {
+        = . pp k * - . pp k . mp k . ip k
+        = k + k 1
+    }
+}
+
+// Standardise a whole row-major matrix in place.
+@ scaler_apply_matrix Scaler sc ( Vec f ) data i n_rows i n_cols → v {
+    : i nm ( vec_len [f] . sc mean )
+    : *f dp ( vec_data [f] data )
+    : *f mp ( vec_data [f] . sc mean )
+    : *f ip ( vec_data [f] . sc inv_std )
+    : ~ i r 0
+    ~ < r n_rows {
+        : ~ i c 0
+        ~ & < c n_cols < c nm {
+            : i off + * r n_cols c
+            = . dp off * - . dp off . mp c . ip c
+            = c + c 1
+        }
+        = r + r 1
+    }
+}
+
+@ scaler_free Scaler sc → v {
+    ( vec_free [f] . sc mean )
+    ( vec_free [f] . sc inv_std )
+}
+
+// Persist a fitted scaler into metadata (stored as mean + std; zero
+// variance is stored as std = 1, matching its inv_std = 1).
+@ meta_set_scaler *Meta m Scaler sc → v {
+    ( vec_free [f] . m sc_mean )
+    ( vec_free [f] . m sc_std )
+    : i n ( vec_len [f] . sc mean )
+    : ( Vec f ) ms ( vec_with_cap [f] n )
+    : ( Vec f ) ss ( vec_with_cap [f] n )
+    : *f mp ( vec_data [f] . sc mean )
+    : *f ip ( vec_data [f] . sc inv_std )
+    : ~ i k 0
+    ~ < k n {
+        ( vec_push [f] ms . mp k )
+        ( vec_push [f] ss / 1.0 . ip k )
+        = k + k 1
+    }
+    = . m sc_mean ms
+    = . m sc_std ss
+}
+
+// Rebuild a usable Scaler from persisted metadata. Owned result.
+@ meta_scaler *Meta m → Scaler {
+    : i n ( vec_len [f] . m sc_mean )
+    : ( Vec f ) mean ( vec_with_cap [f] n )
+    : ( Vec f ) inv ( vec_with_cap [f] n )
+    : *f mp ( vec_data [f] . m sc_mean )
+    : *f sp ( vec_data [f] . m sc_std )
+    : ~ i k 0
+    ~ < k n {
+        ( vec_push [f] mean . mp k )
+        : ~ f sd . sp k
+        ? <= sd 0.0 { = sd 1.0 } {}
+        ( vec_push [f] inv / 1.0 sd )
+        = k + k 1
+    }
+    ^ @ Scaler { mean inv }
+}
+
+// ── Metadata ⇄ JSON ───────────────────────────────────────────────────
+
+@ __an_kind_str i kind → s {
+    ? == kind COL_CATEGORICAL { ^ `categorical` } {}
+    ? == kind COL_TIMESTAMP { ^ `timestamp` } {}
+    ^ `numeric`
+}
+
+@ __an_kind_parse s kstr → i {
+    ? == ( nurl_str_eq kstr `categorical` ) 1 { ^ COL_CATEGORICAL } {}
+    ? == ( nurl_str_eq kstr `timestamp` ) 1 { ^ COL_TIMESTAMP } {}
+    ? == ( nurl_str_eq kstr `numeric` ) 1 { ^ COL_NUMERIC } {}
+    ^ -1
+}
+
+// ( Vec f ) → JSON array of numbers.
+@ __an_jarr_of_floats ( Vec f ) xs → Json {
+    : Json a ( json_arr_new )
+    : i n ( vec_len [f] xs )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [f] xs k ) { T x → { ( json_arr_push a ( json_float x ) ) } F _ → {} }
+        = k + k 1
+    }
+    ^ a
+}
+
+// ( Vec String ) → JSON array of strings.
+@ __an_jarr_of_strs ( Vec String ) xs → Json {
+    : Json a ( json_arr_new )
+    : i n ( vec_len [String] xs )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] xs k ) { T x → { ( json_arr_push a ( json_str_lit ( string_data x ) ) ) } F _ → {} }
+        = k + k 1
+    }
+    ^ a
+}
+
+// JSON array of numbers → ( Vec f ); None if any element is not a number.
+@ __an_floats_of_jarr Json a → ?( Vec f ) {
+    ? ( json_is_arr a ) {} { ^ @ ?( Vec f ) { F ( vec_new [f] ) } }
+    : i n ( json_arr_len a )
+    : ( Vec f ) out ( vec_with_cap [f] n )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( json_arr_get a k ) {
+            T e → {
+                : ?f fx ( json_num_as_f e )
+                ?? fx {
+                    T x → { ( vec_push [f] out x ) }
+                    F _ → { ( vec_free [f] out ) ^ @ ?( Vec f ) { F ( vec_new [f] ) } }
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ @ ?( Vec f ) { T out }
+}
+
+// JSON array of strings → ( Vec String ); None if any element is not a string.
+@ __an_strs_of_jarr Json a → ?( Vec String ) {
+    ? ( json_is_arr a ) {} { ^ @ ?( Vec String ) { F ( vec_new [String] ) } }
+    : i n ( json_arr_len a )
+    : ( Vec String ) out ( vec_with_cap [String] n )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( json_arr_get a k ) {
+            T e → {
+                ? ( json_is_str e ) {
+                    ( vec_push [String] out ( string_from ( json_str_data e ) ) )
+                } {
+                    ( vec_free_with [String] out \ String x → v { ( string_free x ) } )
+                    ^ @ ?( Vec String ) { F ( vec_new [String] ) }
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ @ ?( Vec String ) { T out }
+}
+
+// Serialise metadata to an owned Json object (fixed field order, so the
+// same metadata always stringifies identically).
+@ meta_to_json *Meta m → Json {
+    : Json o ( json_obj_new )
+    ( json_obj_set o `name` ( json_str_lit ( string_data . m name ) ) )
+    ( json_obj_set o `created` ( json_str_lit ( string_data . m created ) ) )
+
+    : Json types ( json_obj_new )
+    : Json cats ( json_obj_new )
+    : i ncol ( vec_len [String] . m cols )
+    : ~ i k 0
+    ~ < k ncol {
+        ?? ( vec_get [String] . m cols k ) {
+            T c → {
+                : i kind ( __an_kind_at m k )
+                ( json_obj_set types ( string_data c ) ( json_str_lit ( __an_kind_str kind ) ) )
+                ? == kind COL_CATEGORICAL {
+                    ?? ( vec_get [( Vec String )] . m cats k ) {
+                        T cv → { ( json_obj_set cats ( string_data c ) ( __an_jarr_of_strs cv ) ) }
+                        F _ → {}
+                    }
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( json_obj_set o `column_types` types )
+    ( json_obj_set o `categories` cats )
+    ( json_obj_set o `feature_names` ( __an_jarr_of_strs . m feats ) )
+
+    : Json sc ( json_obj_new )
+    ( json_obj_set sc `mean` ( __an_jarr_of_floats . m sc_mean ) )
+    ( json_obj_set sc `std` ( __an_jarr_of_floats . m sc_std ) )
+    ( json_obj_set o `scaler` sc )
+
+    : Json sched ( json_obj_new )
+    ( json_obj_set sched `below_max` ( json_int . m sched_below ) )
+    ( json_obj_set sched `at_max` ( json_int . m sched_at_max ) )
+    ( json_obj_set o `schedule` sched )
+
+    : Json vers ( json_obj_new )
+    : i nv ( vec_len [VerCfg] . m versions )
+    : ~ i vi 0
+    ~ < vi nv {
+        ?? ( vec_get [VerCfg] . m versions vi ) {
+            T vc → {
+                : Json vo ( json_obj_new )
+                ( json_obj_set vo `window_minutes` ( json_int . vc window_min ) )
+                ( json_obj_set vo `window_points` ( json_int . vc window_pts ) )
+                ( json_obj_set vo `n_estimators` ( json_int . vc n_estimators ) )
+                ( json_obj_set vo `max_samples` ( json_int . vc max_samples ) )
+                ? < . vc contamination 0.0 {
+                    ( json_obj_set vo `contamination` ( json_str_lit `auto` ) )
+                } {
+                    ( json_obj_set vo `contamination` ( json_float . vc contamination ) )
+                }
+                ( json_obj_set vo `decision_margin` ( json_float . vc decision_margin ) )
+                ( json_obj_set vo `enabled` ( json_bool . vc enabled ) )
+                ( json_obj_set vers ( string_data . vc vname ) vo )
+            }
+            F _ → {}
+        }
+        = vi + vi 1
+    }
+    ( json_obj_set o `versions` vers )
+
+    ( json_obj_set o `n_points_seen` ( json_int . m n_seen ) )
+    ( json_obj_set o `last_trained_at` ( json_int . m last_trained ) )
+    ^ o
+}
+
+// Integer field of a JSON object, or `dflt` when absent/mistyped.
+@ __an_jint Json o s key i dflt → i {
+    ?? ( json_obj_get o key ) {
+        T e → {
+            : ?i r ( json_num_as_i e )
+            ?? r { T n → { ^ n } F _ → { ^ dflt } }
+        }
+        F _ → { ^ dflt }
+    }
+}
+
+// One version config out of its JSON object.
+@ __an_vercfg_of_json s vname Json vo → VerCfg {
+    : ~ f cont -1.0
+    ?? ( json_obj_get vo `contamination` ) {
+        T cj → {
+            ? ( json_is_num cj ) {
+                : ?f cf ( json_num_as_f cj )
+                ?? cf { T x → { = cont x } F _ → {} }
+            } {}
+        }
+        F _ → {}
+    }
+    : ~ f margin 0.0
+    ?? ( json_obj_get vo `decision_margin` ) {
+        T dj → {
+            : ?f df ( json_num_as_f dj )
+            ?? df { T x → { = margin x } F _ → {} }
+        }
+        F _ → {}
+    }
+    : ~ b on T
+    ?? ( json_obj_get vo `enabled` ) { T ej → { = on ( json_as_bool ej ) } F _ → {} }
+    ^ @ VerCfg {
+        ( string_from vname )
+        ( __an_jint vo `window_minutes` 0 )
+        ( __an_jint vo `window_points` 0 )
+        ( __an_jint vo `n_estimators` 100 )
+        ( __an_jint vo `max_samples` 256 )
+        cont
+        margin
+        on
+    }
+}
+
+// Parse metadata back from JSON. None on malformed shape (missing/mistyped
+// required fields); the partially-built Meta is freed on failure.
+@ meta_from_json Json j → ?*Meta {
+    ? ( json_is_obj j ) {} { ^ @ ?*Meta { F # *Meta 0 } }
+
+    : ~ b ok T
+    : ~ String mname ( string_new )
+    : ~ String mcreated ( string_new )
+    ?? ( json_obj_get j `name` ) {
+        T e → {
+            ? ( json_is_str e ) {
+                ( string_free mname )
+                = mname ( string_from ( json_str_data e ) )
+            } { = ok F }
+        }
+        F _ → { = ok F }
+    }
+    ?? ( json_obj_get j `created` ) {
+        T e → {
+            ? ( json_is_str e ) {
+                ( string_free mcreated )
+                = mcreated ( string_from ( json_str_data e ) )
+            } { = ok F }
+        }
+        F _ → { = ok F }
+    }
+    ? ok {} {
+        ( string_free mname )
+        ( string_free mcreated )
+        ^ @ ?*Meta { F # *Meta 0 }
+    }
+
+    : *Meta m ( meta_new ( string_data mname ) ( string_data mcreated ) )
+    ( string_free mname )
+    ( string_free mcreated )
+
+    // Columns: column_types drives order; categories fills categorical cols.
+    ?? ( json_obj_get j `column_types` ) {
+        T types → {
+            ? ( json_is_obj types ) {
+                : ( Vec String ) tkeys ( json_obj_keys types )
+                : i nk ( vec_len [String] tkeys )
+                : ~ i k 0
+                ~ & ok < k nk {
+                    ?? ( vec_get [String] tkeys k ) {
+                        T c → {
+                            : ~ i kind -1
+                            ?? ( json_obj_get types ( string_data c ) ) {
+                                T kv → {
+                                    ? ( json_is_str kv ) { = kind ( __an_kind_parse ( json_str_data kv ) ) } {}
+                                }
+                                F _ → {}
+                            }
+                            ? < kind 0 { = ok F } {
+                                : ~ ( Vec String ) colcats ( vec_new [String] )
+                                ? == kind COL_CATEGORICAL {
+                                    ?? ( json_obj_get j `categories` ) {
+                                        T catso → {
+                                            ?? ( json_obj_get catso ( string_data c ) ) {
+                                                T ca → {
+                                                    : ?( Vec String ) cs ( __an_strs_of_jarr ca )
+                                                    ?? cs {
+                                                        T got → {
+                                                            ( vec_free [String] colcats )
+                                                            = colcats got
+                                                        }
+                                                        F junk → { ( vec_free [String] junk ) = ok F }
+                                                    }
+                                                }
+                                                F _ → {}
+                                            }
+                                        }
+                                        F _ → {}
+                                    }
+                                } {}
+                                ( vec_push [String] . m cols ( string_from ( string_data c ) ) )
+                                ( vec_push [i] . m kinds kind )
+                                ( vec_push [( Vec String )] . m cats colcats )
+                            }
+                        }
+                        F _ → {}
+                    }
+                    = k + k 1
+                }
+                ( vec_free_with [String] tkeys \ String x → v { ( string_free x ) } )
+            } { = ok F }
+        }
+        F _ → {}
+    }
+
+    // Authoritative feature order (may be empty for an untrained model).
+    ?? ( json_obj_get j `feature_names` ) {
+        T fa → {
+            : ?( Vec String ) fs ( __an_strs_of_jarr fa )
+            ?? fs {
+                T got → {
+                    ( vec_free_with [String] . m feats \ String x → v { ( string_free x ) } )
+                    = . m feats got
+                }
+                F junk → { ( vec_free [String] junk ) = ok F }
+            }
+        }
+        F _ → {}
+    }
+
+    // Scaler (mean and std must be present together and equal length).
+    ?? ( json_obj_get j `scaler` ) {
+        T sc → {
+            ?? ( json_obj_get sc `mean` ) {
+                T ma → {
+                    : ?( Vec f ) mm ( __an_floats_of_jarr ma )
+                    ?? mm {
+                        T got → { ( vec_free [f] . m sc_mean ) = . m sc_mean got }
+                        F junk → { ( vec_free [f] junk ) = ok F }
+                    }
+                }
+                F _ → {}
+            }
+            ?? ( json_obj_get sc `std` ) {
+                T sa → {
+                    : ?( Vec f ) ssv ( __an_floats_of_jarr sa )
+                    ?? ssv {
+                        T got → { ( vec_free [f] . m sc_std ) = . m sc_std got }
+                        F junk → { ( vec_free [f] junk ) = ok F }
+                    }
+                }
+                F _ → {}
+            }
+            ? == ( vec_len [f] . m sc_mean ) ( vec_len [f] . m sc_std ) {} { = ok F }
+        }
+        F _ → {}
+    }
+
+    // Schedule.
+    ?? ( json_obj_get j `schedule` ) {
+        T sched → {
+            = . m sched_below ( __an_jint sched `below_max` ANOM_SCHED_BELOW )
+            = . m sched_at_max ( __an_jint sched `at_max` ANOM_SCHED_AT_MAX )
+        }
+        F _ → {}
+    }
+
+    // Versions: when present, replace the defaults entirely.
+    ?? ( json_obj_get j `versions` ) {
+        T vers → {
+            ? ( json_is_obj vers ) {
+                ( vec_free_with [VerCfg] . m versions \ VerCfg vc → v { ( __an_vercfg_free vc ) } )
+                = . m versions ( vec_new [VerCfg] )
+                : ( Vec String ) vkeys ( json_obj_keys vers )
+                : i nvk ( vec_len [String] vkeys )
+                : ~ i vk 0
+                ~ < vk nvk {
+                    ?? ( vec_get [String] vkeys vk ) {
+                        T vn → {
+                            ?? ( json_obj_get vers ( string_data vn ) ) {
+                                T vo → {
+                                    ? ( json_is_obj vo ) {
+                                        ( vec_push [VerCfg] . m versions ( __an_vercfg_of_json ( string_data vn ) vo ) )
+                                    } {}
+                                }
+                                F _ → {}
+                            }
+                        }
+                        F _ → {}
+                    }
+                    = vk + vk 1
+                }
+                ( vec_free_with [String] vkeys \ String x → v { ( string_free x ) } )
+            } {}
+        }
+        F _ → {}
+    }
+
+    = . m n_seen ( __an_jint j `n_points_seen` 0 )
+    = . m last_trained ( __an_jint j `last_trained_at` 0 )
+
+    ? ok {} {
+        ( meta_free m )
+        ^ @ ?*Meta { F # *Meta 0 }
+    }
+    ^ @ ?*Meta { T m }
+}
+
+// Convenience: metadata → compact JSON text (owned).
+@ meta_to_json_str *Meta m → String {
+    : Json o ( meta_to_json m )
+    : String out ( json_stringify o )
+    ( json_free o )
+    ^ out
+}
+
+// Convenience: JSON text → metadata; None on parse or shape errors.
+@ meta_from_json_str s src → ?*Meta {
+    : !Json JsonError r ( json_parse src )
+    ?? r {
+        T j → {
+            : ?*Meta mm ( meta_from_json j )
+            ( json_free j )
+            ^ mm
+        }
+        F _ → { ^ @ ?*Meta { F # *Meta 0 } }
+    }
+}

--- a/packages/anomaly/src/prep.nu
+++ b/packages/anomaly/src/prep.nu
@@ -339,9 +339,11 @@ $ `stdlib/ext/json.nu`
     ^ msg
 }
 
-// Encode one column's value into (names, vals), updating metadata for new
-// categories. Returns an error message, or an empty String on success.
-@ __an_encode_col *Meta m i ci s cn Json jv ( Vec String ) names ( Vec f ) vals → String {
+// Encode one column's value into (names, vals). When `learn` is set, new
+// categories are recorded in the metadata; otherwise an unseen category
+// just yields an all-zero one-hot. Returns an error message, or an empty
+// String on success.
+@ __an_encode_col *Meta m i ci s cn Json jv ( Vec String ) names ( Vec f ) vals b learn → String {
     : i kind ( __an_kind_at m ci )
     ? == kind COL_NUMERIC {
         : ?f fx ( __an_num_of jv )
@@ -357,7 +359,7 @@ $ `stdlib/ext/json.nu`
         : String sval ( __an_str_of jv )
         ?? ( vec_get [( Vec String )] . m cats ci ) {
             T cv → {
-                ( __an_cat_add cv ( string_data sval ) )
+                ? learn { ( __an_cat_add cv ( string_data sval ) ) } {}
                 : i nc ( vec_len [String] cv )
                 : ~ i k 0
                 ~ < k nc {
@@ -402,11 +404,7 @@ $ `stdlib/ext/json.nu`
     ^ ( string_new )
 }
 
-// Encode one raw JSON record into named numeric features, updating the
-// metadata as new columns / categories appear. The reserved key
-// `timestamp` is the point's own clock and is never a feature. Numeric
-// parse failure and bad timestamps are hard errors (owned message).
-@ anomaly_preprocess *Meta m Json raw → !EncPoint String {
+@ __an_preprocess *Meta m Json raw b learn → !EncPoint String {
     : ( Vec String ) names ( vec_new [String] )
     : ( Vec f ) vals ( vec_new [f] )
     : ( Vec String ) keys ( json_obj_keys raw )
@@ -421,13 +419,17 @@ $ `stdlib/ext/json.nu`
                     ?? ( json_obj_get raw cn ) {
                         T jv → {
                             : ~ i ci ( __an_col_find m cn )
-                            ? < ci 0 {
+                            ? & < ci 0 learn {
                                 = ci ( vec_len [String] . m cols )
                                 ( vec_push [String] . m cols ( string_from cn ) )
                                 ( vec_push [i] . m kinds ( __an_detect_kind jv ) )
                                 ( vec_push [( Vec String )] . m cats ( vec_new [String] ) )
                             } {}
-                            : String e2 ( __an_encode_col m ci cn jv names vals )
+                            : ~ String e2 ( string_new )
+                            ? >= ci 0 {
+                                ( string_free e2 )
+                                = e2 ( __an_encode_col m ci cn jv names vals learn )
+                            } {}
                             ? > ( string_len e2 ) 0 {
                                 ( string_free err )
                                 = err e2
@@ -451,6 +453,22 @@ $ `stdlib/ext/json.nu`
     } {}
     ( string_free err )
     ^ @ !EncPoint String { T @ EncPoint { names vals } }
+}
+
+// Encode one raw JSON record into named numeric features, updating the
+// metadata as new columns / categories appear. The reserved key
+// `timestamp` is the point's own clock and is never a feature. Numeric
+// parse failure and bad timestamps are hard errors (owned message).
+@ anomaly_preprocess *Meta m Json raw → !EncPoint String {
+    ^ ( __an_preprocess m raw T )
+}
+
+// Read-only encode: never touches the metadata. Unknown columns are
+// skipped, unseen categories one-hot to all-zeros — exactly what the
+// frozen-feature projection would do with them anyway. For detect-only
+// paths that must not mutate model state.
+@ anomaly_preprocess_ro *Meta m Json raw → !EncPoint String {
+    ^ ( __an_preprocess m raw F )
 }
 
 // Project an encoded point onto an authoritative feature order: missing

--- a/packages/anomaly/src/prep.nu
+++ b/packages/anomaly/src/prep.nu
@@ -638,7 +638,7 @@ $ `stdlib/ext/json.nu`
 
 // JSON array of numbers → ( Vec f ); None if any element is not a number.
 @ __an_floats_of_jarr Json a → ?( Vec f ) {
-    ? ( json_is_arr a ) {} { ^ @ ?( Vec f ) { F ( vec_new [f] ) } }
+    ? ( json_is_arr a ) {} { ^ @ ?( Vec f ) { F } }
     : i n ( json_arr_len a )
     : ( Vec f ) out ( vec_with_cap [f] n )
     : ~ i k 0
@@ -648,7 +648,7 @@ $ `stdlib/ext/json.nu`
                 : ?f fx ( json_num_as_f e )
                 ?? fx {
                     T x → { ( vec_push [f] out x ) }
-                    F _ → { ( vec_free [f] out ) ^ @ ?( Vec f ) { F ( vec_new [f] ) } }
+                    F _ → { ( vec_free [f] out ) ^ @ ?( Vec f ) { F } }
                 }
             }
             F _ → {}
@@ -660,7 +660,7 @@ $ `stdlib/ext/json.nu`
 
 // JSON array of strings → ( Vec String ); None if any element is not a string.
 @ __an_strs_of_jarr Json a → ?( Vec String ) {
-    ? ( json_is_arr a ) {} { ^ @ ?( Vec String ) { F ( vec_new [String] ) } }
+    ? ( json_is_arr a ) {} { ^ @ ?( Vec String ) { F } }
     : i n ( json_arr_len a )
     : ( Vec String ) out ( vec_with_cap [String] n )
     : ~ i k 0
@@ -671,7 +671,7 @@ $ `stdlib/ext/json.nu`
                     ( vec_push [String] out ( string_from ( json_str_data e ) ) )
                 } {
                     ( vec_free_with [String] out \ String x → v { ( string_free x ) } )
-                    ^ @ ?( Vec String ) { F ( vec_new [String] ) }
+                    ^ @ ?( Vec String ) { F }
                 }
             }
             F _ → {}
@@ -801,7 +801,7 @@ $ `stdlib/ext/json.nu`
 // Parse metadata back from JSON. None on malformed shape (missing/mistyped
 // required fields); the partially-built Meta is freed on failure.
 @ meta_from_json Json j → ?*Meta {
-    ? ( json_is_obj j ) {} { ^ @ ?*Meta { F # *Meta 0 } }
+    ? ( json_is_obj j ) {} { ^ @ ?*Meta { F } }
 
     : ~ b ok T
     : ~ String mname ( string_new )
@@ -827,7 +827,7 @@ $ `stdlib/ext/json.nu`
     ? ok {} {
         ( string_free mname )
         ( string_free mcreated )
-        ^ @ ?*Meta { F # *Meta 0 }
+        ^ @ ?*Meta { F }
     }
 
     : *Meta m ( meta_new ( string_data mname ) ( string_data mcreated ) )
@@ -976,7 +976,7 @@ $ `stdlib/ext/json.nu`
 
     ? ok {} {
         ( meta_free m )
-        ^ @ ?*Meta { F # *Meta 0 }
+        ^ @ ?*Meta { F }
     }
     ^ @ ?*Meta { T m }
 }
@@ -998,6 +998,6 @@ $ `stdlib/ext/json.nu`
             ( json_free j )
             ^ mm
         }
-        F _ → { ^ @ ?*Meta { F # *Meta 0 } }
+        F _ → { ^ @ ?*Meta { F } }
     }
 }

--- a/packages/anomaly/src/score.nu
+++ b/packages/anomaly/src/score.nu
@@ -1,0 +1,380 @@
+// anomaly/score.nu — bulk scoring, version training, and the stateless
+// batch path (milestones M2 + M7's GPU acceleration).
+//
+// Bulk scoring routes through the `gpu` package when profitable:
+//
+//   - `gpu_open` picks CUDA when a device is present, else the gpu
+//     package's CPU backend (the same kernel compiled by the host C++
+//     compiler and run under OpenMP). If neither is available — no GPU, no
+//     C++ compiler — scoring silently stays on the pure-NURL loop, so a
+//     bare machine behaves exactly like pre-GPU builds.
+//   - Output is BIT-IDENTICAL across all three paths, by construction: the
+//     kernel only walks the trees and accumulates f64 path lengths in the
+//     same order as the pure loop, using per-leaf c(size) values
+//     precomputed on the host by the very same `iforest_avg_path`; the
+//     nonlinear finish (2^(-avg/c), the offset subtraction) runs in NURL
+//     either way. IEEE-754 f64 adds in a fixed order give the same bits on
+//     every backend — so backend choice can never change a verdict.
+//
+// `ANOMALY_GPU=0` disables the accelerator outright; `NURL_GPU=cpu` (a gpu
+// package knob) forces its CPU backend on a CUDA machine. Batches under
+// ANOM_GPU_MIN_ROWS rows skip the accelerator — upload latency would beat
+// the win, and bit-equality makes the switch invisible.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/sort.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `deps/iforest/src/iforest.nu`
+$ `deps/gpu/src/gpu.nu`
+
+// Below this many rows the pure loop wins on latency. Bit-equality of the
+// paths makes the threshold unobservable in results.
+: i ANOM_GPU_MIN_ROWS 128
+
+// Batch verdict over a matrix (see SPEC §6): anomaly ⇔ predict == -1,
+// i.e. decision_function < 0 (margin 0), matching the reference batch path.
+: BatchReport {
+    i total_rows
+    i anomaly_count
+    f anomaly_percentage
+    ( Vec i ) anomaly_indices
+    b has_anomalies
+    ( Vec f ) scores
+}
+
+// ── GPU singleton ─────────────────────────────────────────────────────
+//
+// One device + one compiled kernel per process, probed lazily on first
+// bulk call. state: 0 = unprobed, 1 = ready, -1 = unavailable/disabled.
+
+: ~ i g_ag_state 0
+: ~ i g_ag_ord 0
+: ~ i g_ag_dev 0
+: ~ i g_ag_ctx 0
+: ~ i g_ag_kmod 0
+: ~ i g_ag_kfun 0
+
+// The path-walk kernel. One thread per row; per tree, descend by the same
+// comparison the pure walker uses and accumulate depth + c(leaf) — nothing
+// else, so the f64 sum is bit-identical to the host loop.
+@ __ag_kernel_src → s {
+    ^ `extern "C" __global__ void anomaly_paths(const double* xs, const long long* feat, const double* split, const long long* left, const long long* right, const double* cleaf, const long long* roots, long long n_rows, long long n_cols, long long n_trees, double* out)
+{
+    long long r = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= n_rows) return;
+    const double* x = xs + r * n_cols;
+    double total = 0.0;
+    for (long long t = 0; t < n_trees; t++) {
+        long long node = roots[t];
+        long long depth = 0;
+        while (feat[node] >= 0) {
+            node = (x[feat[node]] < split[node]) ? left[node] : right[node];
+            depth++;
+        }
+        total += (double)depth + cleaf[node];
+    }
+    out[r] = total;
+}
+`
+}
+
+@ __ag_env_off → b {
+    : s v ( getenv `ANOMALY_GPU` )
+    ? == # i v 0 { ^ F } {}
+    ^ == ( nurl_str_eq v `0` ) 1
+}
+
+// Probe once: open a device (CUDA, else the gpu package's CPU backend) and
+// compile the kernel. Any failure parks the accelerator for the process.
+@ __ag_ensure → b {
+    ? != g_ag_state 0 { ^ == g_ag_state 1 } {}
+    ? ( __ag_env_off ) {
+        = g_ag_state -1
+        ^ F
+    } {}
+    : Gpu g ( gpu_open 0 )
+    ? ( gpu_ok g ) {} {
+        = g_ag_state -1
+        ^ F
+    }
+    : GpuKernel k ( gpu_compile g ( __ag_kernel_src ) `anomaly_paths` )
+    ? ( gpu_kernel_ok k ) {} {
+        ( gpu_close g )
+        = g_ag_state -1
+        ^ F
+    }
+    = g_ag_ord . g ordinal
+    = g_ag_dev . g dev
+    = g_ag_ctx . g ctx
+    = g_ag_kmod . k module
+    = g_ag_kfun . k func
+    = g_ag_state 1
+    ^ T
+}
+
+@ __ag_handle → Gpu {
+    ^ @ Gpu { g_ag_ord g_ag_dev g_ag_ctx }
+}
+
+// Release the device + kernel (tests call this so leak checkers see a
+// closed shop; a long-running service just keeps the singleton).
+@ anom_gpu_close → v {
+    ? == g_ag_state 1 {
+        ( gpu_kernel_free @ GpuKernel { g_ag_kmod g_ag_kfun } )
+        ( gpu_close ( __ag_handle ) )
+    } {}
+    = g_ag_state 0
+    = g_ag_kmod 0
+    = g_ag_kfun 0
+    = g_ag_ctx 0
+}
+
+// Which engine bulk scoring would use right now: `cuda`, `cpu` (the gpu
+// package's host backend) or `none` (pure NURL loop).
+@ anom_gpu_engine → s {
+    ? ( __ag_ensure ) {
+        ? ( gpu_is_cpu ) { ^ `cpu` } {}
+        ^ `cuda`
+    } {}
+    ^ `none`
+}
+
+// ── Bulk raw scores ───────────────────────────────────────────────────
+
+// Pure-NURL reference path: iforest_score per row.
+@ anom_scores_cpu VerModel vm ( Vec f ) scaled i n_rows i n_cols → ( Vec f ) {
+    : ( Vec f ) out ( vec_with_cap [f] n_rows )
+    : ~ i r 0
+    ~ < r n_rows {
+        ( vec_push [f] out ( iforest_score_row . vm forest scaled r ) )
+        = r + r 1
+    }
+    ^ out
+}
+
+// Map a path-length total to the iforest score, matching __score_ptr's
+// arithmetic (and its degenerate branches) exactly.
+@ __ag_total_to_score f total i n_trees f c_psi → f {
+    ? <= n_trees 0 { ^ 0.0 } {}
+    ? <= c_psi 0.0 { ^ 0.5 } {}
+    : f avg / total # f n_trees
+    ^ ( float_pow 2.0 - 0.0 / avg c_psi )
+}
+
+// Accelerated path. None when the accelerator is unavailable or any step
+// fails (caller falls back; failures after a good probe are reported).
+@ anom_scores_gpu VerModel vm ( Vec f ) scaled i n_rows i n_cols → ?( Vec f ) {
+    ? ( __ag_ensure ) {} { ^ @ ?( Vec f ) { F } }
+    : IForest fo . vm forest
+    : i n_trees ( vec_len [i] . fo roots )
+    : i n_nodes ( vec_len [i] . fo feature )
+    ? || <= n_trees 0 <= n_nodes 0 { ^ @ ?( Vec f ) { F } } {}
+
+    // Per-node c(size), precomputed with the same host function the pure
+    // walker calls at each leaf — the kernel only ever adds these values.
+    : ( Vec f ) cleaf ( vec_with_cap [f] n_nodes )
+    : *i szp ( vec_data [i] . fo size )
+    : ~ i k 0
+    ~ < k n_nodes {
+        ( vec_push [f] cleaf ( iforest_avg_path . szp k ) )
+        = k + k 1
+    }
+
+    : Gpu g ( __ag_handle )
+    : GpuKernel kn @ GpuKernel { g_ag_kmod g_ag_kfun }
+    : GpuBuffer b_xs ( gpu_alloc g * * n_rows n_cols 8 )
+    : GpuBuffer b_feat ( gpu_alloc g * n_nodes 8 )
+    : GpuBuffer b_split ( gpu_alloc g * n_nodes 8 )
+    : GpuBuffer b_left ( gpu_alloc g * n_nodes 8 )
+    : GpuBuffer b_right ( gpu_alloc g * n_nodes 8 )
+    : GpuBuffer b_cleaf ( gpu_alloc g * n_nodes 8 )
+    : GpuBuffer b_roots ( gpu_alloc g * n_trees 8 )
+    : GpuBuffer b_out ( gpu_alloc g * n_rows 8 )
+
+    : ~ b ok T
+    ? || == . b_xs dptr 0 || == . b_feat dptr 0 || == . b_split dptr 0 || == . b_left dptr 0 || == . b_right dptr 0 || == . b_cleaf dptr 0 || == . b_roots dptr 0 == . b_out dptr 0 { = ok F } {}
+    ? ok {
+        ? == ( gpu_upload b_xs # *u ( vec_data [f] scaled ) ) 0 {} { = ok F }
+        ? == ( gpu_upload b_feat # *u ( vec_data [i] . fo feature ) ) 0 {} { = ok F }
+        ? == ( gpu_upload b_split # *u ( vec_data [f] . fo split ) ) 0 {} { = ok F }
+        ? == ( gpu_upload b_left # *u ( vec_data [i] . fo left ) ) 0 {} { = ok F }
+        ? == ( gpu_upload b_right # *u ( vec_data [i] . fo right ) ) 0 {} { = ok F }
+        ? == ( gpu_upload b_cleaf # *u ( vec_data [f] cleaf ) ) 0 {} { = ok F }
+        ? == ( gpu_upload b_roots # *u ( vec_data [i] . fo roots ) ) 0 {} { = ok F }
+    } {}
+
+    : ( Vec f ) totals ( vec_with_cap [f] n_rows )
+    ? ok {
+        : ( Vec i ) args ( vec_new [i] )
+        ( vec_push [i] args ( gpu_arg_buffer b_xs ) )
+        ( vec_push [i] args ( gpu_arg_buffer b_feat ) )
+        ( vec_push [i] args ( gpu_arg_buffer b_split ) )
+        ( vec_push [i] args ( gpu_arg_buffer b_left ) )
+        ( vec_push [i] args ( gpu_arg_buffer b_right ) )
+        ( vec_push [i] args ( gpu_arg_buffer b_cleaf ) )
+        ( vec_push [i] args ( gpu_arg_buffer b_roots ) )
+        ( vec_push [i] args ( gpu_arg_i64 n_rows ) )
+        ( vec_push [i] args ( gpu_arg_i64 n_cols ) )
+        ( vec_push [i] args ( gpu_arg_i64 n_trees ) )
+        ( vec_push [i] args ( gpu_arg_buffer b_out ) )
+        : i block 256
+        ? == ( gpu_launch kn ( gpu_grid n_rows block ) block args ) 0 {} { = ok F }
+        ( vec_free [i] args )
+    } {}
+    ? ok {
+        ? == ( gpu_sync g ) 0 {} { = ok F }
+    } {}
+    ? ok {
+        ? == ( gpu_download # *u ( vec_data [f] totals ) b_out ) 0 {
+            ( vec_set_len [f] totals n_rows )
+        } { = ok F }
+    } {}
+
+    ( gpu_free b_xs )
+    ( gpu_free b_feat )
+    ( gpu_free b_split )
+    ( gpu_free b_left )
+    ( gpu_free b_right )
+    ( gpu_free b_cleaf )
+    ( gpu_free b_roots )
+    ( gpu_free b_out )
+    ( vec_free [f] cleaf )
+
+    ? ok {} {
+        ( vec_free [f] totals )
+        ( nurl_eprintln `anomaly: gpu scoring failed, falling back to the pure path` )
+        ^ @ ?( Vec f ) { F }
+    }
+
+    // Finish on the host, byte-for-byte the pure walker's arithmetic.
+    : ( Vec f ) out ( vec_with_cap [f] n_rows )
+    : *f tp ( vec_data [f] totals )
+    : f cpsi . fo c_psi
+    : ~ i r 0
+    ~ < r n_rows {
+        ( vec_push [f] out ( __ag_total_to_score . tp r n_trees cpsi ) )
+        = r + r 1
+    }
+    ( vec_free [f] totals )
+    ^ @ ?( Vec f ) { T out }
+}
+
+// Raw iforest scores for every row of an already-standardised matrix,
+// through the best available engine. Bit-identical on all engines.
+@ anom_scores VerModel vm ( Vec f ) scaled i n_rows i n_cols → ( Vec f ) {
+    ? >= n_rows ANOM_GPU_MIN_ROWS {
+        : ?( Vec f ) got ( anom_scores_gpu vm scaled n_rows n_cols )
+        ?? got {
+            T out → { ^ out }
+            F _ → {}
+        }
+    } {}
+    ^ ( anom_scores_cpu vm scaled n_rows n_cols )
+}
+
+// decision_function for every row: -score - offset, same expression as
+// anom_decision.
+@ anom_decisions VerModel vm ( Vec f ) scaled i n_rows i n_cols → ( Vec f ) {
+    : ( Vec f ) ss ( anom_scores vm scaled n_rows n_cols )
+    : *f sp ( vec_data [f] ss )
+    : f off . vm offset
+    : ~ i r 0
+    ~ < r n_rows {
+        = . sp r - - 0.0 . sp r off
+        = r + r 1
+    }
+    ^ ss
+}
+
+// ── Percentile (numpy 'linear' interpolation, for contamination) ──────
+
+// q in [0,1] over an ASCENDING-sorted vector.
+@ __an_percentile ( Vec f ) sorted f q → f {
+    : i n ( vec_len [f] sorted )
+    ? <= n 0 { ^ 0.0 } {}
+    : *f dp ( vec_data [f] sorted )
+    ? <= n 1 { ^ . dp 0 } {}
+    : ~ f pos * q # f - n 1
+    ? < pos 0.0 { = pos 0.0 } {}
+    : ~ i lo # i ( float_floor pos )
+    ? >= lo - n 1 { ^ . dp - n 1 } {}
+    : f frac - pos # f lo
+    ^ + . dp lo * - . dp + lo 1 . dp lo frac
+}
+
+// ── Version training ──────────────────────────────────────────────────
+
+// Train one version's forest over an ALREADY-STANDARDISED row-major matrix.
+// `cfg.max_samples` is clamped to the row count; contamination < 0 = "auto"
+// (offset pinned at -0.5), else offset_ is the 100*c percentile of the
+// training set's score_samples — so `predict == -1` flags ~c of training.
+@ anom_train_version ( Vec f ) scaled i n_rows i n_cols VerCfg cfg → VerModel {
+    : ~ i samp . cfg max_samples
+    ? > samp n_rows { = samp n_rows } {}
+    : IForest fo ( iforest_train scaled n_rows n_cols . cfg n_estimators samp ANOM_SEED )
+    : ~ VerModel vm @ VerModel {
+        ( string_from ( string_data . cfg vname ) )
+        fo
+        -0.5
+        . cfg decision_margin
+        n_cols
+        T
+    }
+    ? >= . cfg contamination 0.0 {
+        : ( Vec f ) raw ( anom_scores vm scaled n_rows n_cols )
+        : ( Vec f ) ss ( vec_with_cap [f] n_rows )
+        : *f rp ( vec_data [f] raw )
+        : ~ i r 0
+        ~ < r n_rows {
+            ( vec_push [f] ss - 0.0 . rp r )
+            = r + r 1
+        }
+        ( vec_free [f] raw )
+        ( sort_by [f] ss \ f a f b → i {
+            ? < a b { ^ -1 } {}
+            ? > a b { ^ 1 } {}
+            ^ 0
+        } )
+        = . vm offset ( __an_percentile ss . cfg contamination )
+        ( vec_free [f] ss )
+    } {}
+    ^ vm
+}
+
+// ── Batch (stateless) scoring ─────────────────────────────────────────
+
+// Fit a scaler over the raw matrix, train one version on the standardised
+// copy, then score every row. Anomaly ⇔ decision_function <= -cfg.margin
+// (margin 0 reproduces the reference's predict == -1 batch rule).
+@ anomaly_batch ( Vec f ) data i n_rows i n_cols VerCfg cfg → BatchReport {
+    : Scaler sc ( scaler_fit data n_rows n_cols )
+    : ( Vec f ) scaled ( vec_clone [f] data )
+    ( scaler_apply_matrix sc scaled n_rows n_cols )
+    : VerModel vm ( anom_train_version scaled n_rows n_cols cfg )
+
+    : ( Vec f ) scores ( anom_decisions vm scaled n_rows n_cols )
+    : ( Vec i ) hits ( vec_new [i] )
+    : *f dfp ( vec_data [f] scores )
+    : ~ i r 0
+    ~ < r n_rows {
+        ? ( anom_is_anomaly vm . dfp r ) { ( vec_push [i] hits r ) } {}
+        = r + r 1
+    }
+    ( anom_vermodel_free vm )
+    ( vec_free [f] scaled )
+    ( scaler_free sc )
+
+    : i n_hits ( vec_len [i] hits )
+    : ~ f pct 0.0
+    ? > n_rows 0 { = pct / * # f n_hits 100.0 # f n_rows } {}
+    ^ @ BatchReport { n_rows n_hits pct hits > n_hits 0 scores }
+}
+
+@ anomaly_report_free BatchReport rep → v {
+    ( vec_free [i] . rep anomaly_indices )
+    ( vec_free [f] . rep scores )
+}

--- a/packages/anomaly/src/service.nu
+++ b/packages/anomaly/src/service.nu
@@ -1,0 +1,775 @@
+// anomaly/service.nu — HTTP/JSON service (milestone M6).
+//
+// Thin: parse JSON → call the library → serialise. The routes and the
+// request/response shapes mirror the Python reference service so existing
+// dashboards keep working:
+//
+//   POST   /detect/<model>                    ingest + verdict (202 warming)
+//   POST   /detect_only/<model>               score only, no state change
+//   GET|POST /force_train/<model>             retrain now
+//   POST   /detect_anomalies                  batch-score a CSV file
+//   GET    /models/dynamic                    list models + metadata
+//   GET    /models/dynamic/<model>/metadata   metadata
+//   GET    /models/dynamic/<model>/data       recent points (?limit=N|all)
+//   POST   /models/dynamic/<model>/reset      drop data+forests, keep name
+//   DELETE|GET /delete_model/<model>          delete entirely
+//   PUT    /api/dynamic/<model>/schedule      retraining schedule
+//   POST   /api/dynamic/<model>/finetune      recalibrate margins
+//
+// Model names must match ^[a-zA-Z0-9_]+$ (400 otherwise, same message as
+// the reference). Divergence from the reference: /detect_anomalies scores
+// the CSV with a self-trained stateless forest (the reference's separate
+// "static model" family doesn't exist here); passing model_name is a 400.
+//
+// The router is exposed separately from the socket (anomaly_service_router
+// + router_handle) so every route is testable without networking.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_router.nu`
+$ `stdlib/ext/http_server.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/store.nu`
+$ `src/dynamic.nu`
+$ `src/csvdata.nu`
+
+// Store root used by every handler; set once before serving.
+: ~ s g_an_root `.`
+
+@ anomaly_service_set_root s root → v {
+    = g_an_root root
+}
+
+// ── Small helpers ─────────────────────────────────────────────────────
+
+@ __an_name_ok s name → b {
+    : i n ( nurl_str_len name )
+    ? <= n 0 { ^ F } {}
+    : ~ i k 0
+    ~ < k n {
+        : i c ( nurl_str_get name k )
+        : ~ b good F
+        ? & >= c 48 <= c 57 { = good T } {}
+        ? & >= c 65 <= c 90 { = good T } {}
+        ? & >= c 97 <= c 122 { = good T } {}
+        ? == c 95 { = good T } {}
+        ? good {} { ^ F }
+        = k + k 1
+    }
+    ^ T
+}
+
+@ __an_json_err i status s msg → HttpResponse {
+    : Json o ( json_obj_new )
+    ( json_obj_set o `status` ( json_str_lit `error` ) )
+    ( json_obj_set o `message` ( json_str_lit msg ) )
+    : HttpResponse r ( response_json status o )
+    ( json_free o )
+    ^ r
+}
+
+@ __an_bad_name → HttpResponse {
+    ^ ( __an_json_err 400 `Invalid model name. Use only letters, numbers, and underscores.` )
+}
+
+@ __an_404_model s name → HttpResponse {
+    : String msg ( string_from `Model ` )
+    ( string_push_str msg name )
+    ( string_push_str msg ` not found` )
+    : HttpResponse r ( __an_json_err 404 ( string_data msg ) )
+    ( string_free msg )
+    ^ r
+}
+
+@ __an_ok_msg s msg → Json {
+    : Json o ( json_obj_new )
+    ( json_obj_set o `status` ( json_str_lit `success` ) )
+    ( json_obj_set o `message` ( json_str_lit msg ) )
+    ^ o
+}
+
+// The :model path capture (owned; empty String = missing).
+@ __an_param_model Params p → String {
+    ?? ( params_get p `model` ) {
+        T v → { ^ v }
+        F junk → { ^ junk }
+    }
+}
+
+// Request body as parsed JSON, or None.
+@ __an_body_json HttpRequest req → ?Json {
+    : String txt ( bytes_to_str . req body )
+    : !Json JsonError r ( json_parse ( string_data txt ) )
+    ( string_free txt )
+    ?? r {
+        T j → { ^ @ ?Json { T j } }
+        F _ → { ^ @ ?Json { F } }
+    }
+}
+
+// Integer query parameter (?key=N). `dflt` when missing/garbage; -1 for
+// the "everything" spellings (all / max / *).
+@ __an_query_int String q s key i dflt → i {
+    : String needle ( string_from key )
+    ( string_push_char needle 61 )
+    : ?i at0 ( string_index_of q ( string_data needle ) )
+    : i klen ( string_len needle )
+    ( string_free needle )
+    ?? at0 {
+        T at → {
+            : String val ( string_new )
+            : i n ( string_len q )
+            : ~ i k + at klen
+            : ~ b going T
+            ~ & going < k n {
+                : i c ( string_get q k )
+                ? == c 38 { = going F } {
+                    ( string_push_char val c )
+                    = k + k 1
+                }
+            }
+            : ~ i out dflt
+            : s vraw ( string_data val )
+            ? || == ( nurl_str_eq vraw `all` ) 1 || == ( nurl_str_eq vraw `max` ) 1 == ( nurl_str_eq vraw `*` ) 1 {
+                = out -1
+            } {
+                ?? ( string_to_int val ) {
+                    T x → { ? > x 0 { = out x } {} }
+                    F _ → {}
+                }
+            }
+            ( string_free val )
+            ^ out
+        }
+        F _ → { ^ dflt }
+    }
+}
+
+// ── Verdict → JSON ────────────────────────────────────────────────────
+
+@ __an_verdict_resp *Model mo s mname Json body Verdict vd → HttpResponse {
+    ? . vd ready {} {
+        : *Meta mm ( model_metadata mo )
+        : i n ( model_n_points mo )
+        : String msg ( string_from `Collecting data (` )
+        ( string_push_int msg n )
+        ( string_push_char msg 47 )
+        ( string_push_int msg . mo min_points )
+        ( string_push_str msg ` points).` )
+        : Json o ( json_obj_new )
+        ( json_obj_set o `status` ( json_str_lit `collecting` ) )
+        ( json_obj_set o `message` ( json_str_lit ( string_data msg ) ) )
+        ( json_obj_set o `data_points` ( json_int n ) )
+        ( json_obj_set o `min_data_points` ( json_int . mo min_points ) )
+        ( json_obj_set o `model_name` ( json_str_lit mname ) )
+        ( string_free msg )
+        : HttpResponse r ( response_json 202 o )
+        ( json_free o )
+        ^ r
+    }
+
+    : Json o ( json_obj_new )
+    ( json_obj_set o `status` ( json_str_lit `success` ) )
+    ( json_obj_set o `model` ( json_str_lit mname ) )
+    ( json_obj_set o `anomaly` ( json_bool . vd anomaly ) )
+    ( json_obj_set o `score` ( json_float . vd score ) )
+    ( json_obj_set o `data_points` ( json_int ( model_n_points mo ) ) )
+
+    : Json vers ( json_obj_new )
+    : i nv ( vec_len [VerVerdict] . vd versions )
+    : ~ i k 0
+    ~ < k nv {
+        ?? ( vec_get [VerVerdict] . vd versions k ) {
+            T vv → {
+                : Json vo ( json_obj_new )
+                ( json_obj_set vo `anomaly` ( json_bool . vv anomaly ) )
+                ( json_obj_set vo `score` ( json_float . vv score ) )
+                : Json ti ( json_obj_new )
+                ( json_obj_set ti `margin` ( json_float . vv margin ) )
+                ( json_obj_set vo `threshold_info` ti )
+                ( json_obj_set vers ( string_data . vv vvname ) vo )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( json_obj_set o `versions` vers )
+    ( json_obj_set o `data_point` ( json_clone body ) )
+
+    : HttpResponse r ( response_json 200 o )
+    ( json_free o )
+    ^ r
+}
+
+// ── Route handlers ────────────────────────────────────────────────────
+
+@ __an_h_detect HttpRequest req Params p b ingest → HttpResponse {
+    : String mname ( __an_param_model p )
+    ? ( __an_name_ok ( string_data mname ) ) {} {
+        ( string_free mname )
+        ^ ( __an_bad_name )
+    }
+    : ?Json bodyo ( __an_body_json req )
+    ?? bodyo {
+        T body → {
+            ? ( json_is_obj body ) {} {
+                ( json_free body )
+                ( string_free mname )
+                ^ ( __an_json_err 400 `No parameters provided. Need at least one numeric parameter.` )
+            }
+            : Store st ( store_open g_an_root )
+            ? ingest {} {
+                ? ( store_exists st ( string_data mname ) ) {} {
+                    : HttpResponse r404 ( __an_404_model ( string_data mname ) )
+                    ( store_free st )
+                    ( json_free body )
+                    ( string_free mname )
+                    ^ r404
+                }
+            }
+            : *Model mo ( model_open st ( string_data mname ) )
+            ? ingest {} {
+                ? ( model_is_trained mo ) {} {
+                    : String msg ( string_from `Model ` )
+                    ( string_push_str msg ( string_data mname ) )
+                    ( string_push_str msg ` exists but is not trained yet.` )
+                    : HttpResponse rr ( __an_json_err 400 ( string_data msg ) )
+                    ( string_free msg )
+                    ( model_free mo )
+                    ( store_free st )
+                    ( json_free body )
+                    ( string_free mname )
+                    ^ rr
+                }
+            }
+            : ~ HttpResponse resp ( response_status_only 500 )
+            ? ingest {
+                : !Verdict String vr ( model_ingest mo body )
+                ?? vr {
+                    T vd → {
+                        ( http_response_free resp )
+                        = resp ( __an_verdict_resp mo ( string_data mname ) body vd )
+                        ( verdict_free vd )
+                    }
+                    F e → {
+                        ( http_response_free resp )
+                        = resp ( __an_json_err 400 ( string_data e ) )
+                        ( string_free e )
+                    }
+                }
+            } {
+                : !Verdict String vr ( model_detect_only mo body )
+                ?? vr {
+                    T vd → {
+                        ( http_response_free resp )
+                        = resp ( __an_verdict_resp mo ( string_data mname ) body vd )
+                        ( verdict_free vd )
+                    }
+                    F e → {
+                        ( http_response_free resp )
+                        = resp ( __an_json_err 400 ( string_data e ) )
+                        ( string_free e )
+                    }
+                }
+            }
+            ( model_free mo )
+            ( store_free st )
+            ( json_free body )
+            ( string_free mname )
+            ^ resp
+        }
+        F _ → {
+            ( string_free mname )
+            ^ ( __an_json_err 400 `No parameters provided. Need at least one numeric parameter.` )
+        }
+    }
+}
+
+@ __an_h_force_train HttpRequest req Params p → HttpResponse {
+    : String mname ( __an_param_model p )
+    ? ( __an_name_ok ( string_data mname ) ) {} {
+        ( string_free mname )
+        ^ ( __an_bad_name )
+    }
+    : Store st ( store_open g_an_root )
+    ? ( store_exists st ( string_data mname ) ) {} {
+        : HttpResponse r404 ( __an_404_model ( string_data mname ) )
+        ( store_free st )
+        ( string_free mname )
+        ^ r404
+    }
+    : *Model mo ( model_open st ( string_data mname ) )
+    : i used ( model_force_train mo )
+    : ~ HttpResponse resp ( response_status_only 500 )
+    ? > used 0 {
+        : String msg ( string_from `Model ` )
+        ( string_push_str msg ( string_data mname ) )
+        ( string_push_str msg ` trained` )
+        : Json o ( __an_ok_msg ( string_data msg ) )
+        ( json_obj_set o `points_used` ( json_int used ) )
+        ( http_response_free resp )
+        = resp ( response_json 200 o )
+        ( json_free o )
+        ( string_free msg )
+    } {
+        ( http_response_free resp )
+        = resp ( __an_json_err 400 `Not enough data to train` )
+    }
+    ( model_free mo )
+    ( store_free st )
+    ( string_free mname )
+    ^ resp
+}
+
+@ __an_h_models HttpRequest req Params p → HttpResponse {
+    : Store st ( store_open g_an_root )
+    : Json models ( json_obj_new )
+    : ( Vec String ) names ( store_list st )
+    : i n ( vec_len [String] names )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] names k ) {
+            T nm → {
+                : ?*Meta mload ( store_load_meta st ( string_data nm ) )
+                ?? mload {
+                    T mm → {
+                        ( json_obj_set models ( string_data nm ) ( meta_to_json mm ) )
+                        ( meta_free mm )
+                    }
+                    F _ → {}
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+    : Json o ( json_obj_new )
+    ( json_obj_set o `status` ( json_str_lit `success` ) )
+    ( json_obj_set o `models` models )
+    ( json_obj_set o `min_data_points` ( json_int ANOM_MIN_POINTS ) )
+    ( json_obj_set o `max_data_points` ( json_int ANOM_MAX_POINTS ) )
+    : HttpResponse r ( response_json 200 o )
+    ( json_free o )
+    ( store_free st )
+    ^ r
+}
+
+@ __an_h_metadata HttpRequest req Params p → HttpResponse {
+    : String mname ( __an_param_model p )
+    ? ( __an_name_ok ( string_data mname ) ) {} {
+        ( string_free mname )
+        ^ ( __an_bad_name )
+    }
+    : Store st ( store_open g_an_root )
+    : ?*Meta mload ( store_load_meta st ( string_data mname ) )
+    : ~ HttpResponse resp ( response_status_only 500 )
+    ?? mload {
+        T mm → {
+            : Json o ( meta_to_json mm )
+            ( json_obj_set o `model_name` ( json_str_lit ( string_data mname ) ) )
+            ( http_response_free resp )
+            = resp ( response_json 200 o )
+            ( json_free o )
+            ( meta_free mm )
+        }
+        F _ → {
+            ( http_response_free resp )
+            = resp ( __an_404_model ( string_data mname ) )
+        }
+    }
+    ( store_free st )
+    ( string_free mname )
+    ^ resp
+}
+
+@ __an_h_data HttpRequest req Params p → HttpResponse {
+    : String mname ( __an_param_model p )
+    ? ( __an_name_ok ( string_data mname ) ) {} {
+        ( string_free mname )
+        ^ ( __an_bad_name )
+    }
+    : Store st ( store_open g_an_root )
+    ? ( store_exists st ( string_data mname ) ) {} {
+        : HttpResponse r404 ( __an_404_model ( string_data mname ) )
+        ( store_free st )
+        ( string_free mname )
+        ^ r404
+    }
+    : i limit ( __an_query_int . req query `limit` 100 )
+    : ( Vec String ) pts ( store_load_points st ( string_data mname ) )
+    : i total ( vec_len [String] pts )
+    : ~ i from 0
+    ? > limit 0 {
+        ? > total limit { = from - total limit } {}
+    } {}
+    : Json arr ( json_arr_new )
+    : ~ i k from
+    ~ < k total {
+        ?? ( vec_get [String] pts k ) {
+            T l → {
+                : !Json JsonError jr ( json_parse ( string_data l ) )
+                ?? jr {
+                    T j → { ( json_arr_push arr j ) }
+                    F _ → {}
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [String] pts \ String x → v { ( string_free x ) } )
+    : Json o ( json_obj_new )
+    ( json_obj_set o `status` ( json_str_lit `success` ) )
+    ( json_obj_set o `model_name` ( json_str_lit ( string_data mname ) ) )
+    ( json_obj_set o `data_points_count` ( json_int total ) )
+    ( json_obj_set o `data` arr )
+    : HttpResponse r ( response_json 200 o )
+    ( json_free o )
+    ( store_free st )
+    ( string_free mname )
+    ^ r
+}
+
+@ __an_h_reset HttpRequest req Params p → HttpResponse {
+    : String mname ( __an_param_model p )
+    ? ( __an_name_ok ( string_data mname ) ) {} {
+        ( string_free mname )
+        ^ ( __an_bad_name )
+    }
+    : Store st ( store_open g_an_root )
+    ? ( store_exists st ( string_data mname ) ) {} {
+        : HttpResponse r404 ( __an_404_model ( string_data mname ) )
+        ( store_free st )
+        ( string_free mname )
+        ^ r404
+    }
+    : *Model mo ( model_open st ( string_data mname ) )
+    ( model_reset mo )
+    ( model_free mo )
+    : String msg ( string_from `Model ` )
+    ( string_push_str msg ( string_data mname ) )
+    ( string_push_str msg ` reset` )
+    : Json o ( __an_ok_msg ( string_data msg ) )
+    : HttpResponse r ( response_json 200 o )
+    ( json_free o )
+    ( string_free msg )
+    ( store_free st )
+    ( string_free mname )
+    ^ r
+}
+
+@ __an_h_delete HttpRequest req Params p → HttpResponse {
+    : String mname ( __an_param_model p )
+    ? ( __an_name_ok ( string_data mname ) ) {} {
+        ( string_free mname )
+        ^ ( __an_bad_name )
+    }
+    : Store st ( store_open g_an_root )
+    ? ( store_exists st ( string_data mname ) ) {} {
+        : HttpResponse r404 ( __an_404_model ( string_data mname ) )
+        ( store_free st )
+        ( string_free mname )
+        ^ r404
+    }
+    : b okd ( store_delete st ( string_data mname ) )
+    : String msg ( string_from `Model ` )
+    ( string_push_str msg ( string_data mname ) )
+    ( string_push_str msg ` deleted successfully` )
+    : Json o ( __an_ok_msg ( string_data msg ) )
+    : HttpResponse r ( response_json 200 o )
+    ( json_free o )
+    ( string_free msg )
+    ( store_free st )
+    ( string_free mname )
+    ^ r
+}
+
+@ __an_h_schedule HttpRequest req Params p → HttpResponse {
+    : String mname ( __an_param_model p )
+    ? ( __an_name_ok ( string_data mname ) ) {} {
+        ( string_free mname )
+        ^ ( __an_bad_name )
+    }
+    : Store st ( store_open g_an_root )
+    ? ( store_exists st ( string_data mname ) ) {} {
+        : HttpResponse r404 ( __an_404_model ( string_data mname ) )
+        ( store_free st )
+        ( string_free mname )
+        ^ r404
+    }
+    : ?Json bodyo ( __an_body_json req )
+    ?? bodyo {
+        T body → {
+            : i below ( __an_jint body `below_max_retrain_frequency` 0 )
+            : i atmax ( __an_jint body `at_max_retrain_frequency` 0 )
+            ( json_free body )
+            ? || > below 0 > atmax 0 {} {
+                ( store_free st )
+                ( string_free mname )
+                ^ ( __an_json_err 400 `No training schedule parameters provided` )
+            }
+            : *Model mo ( model_open st ( string_data mname ) )
+            ( model_set_schedule mo below atmax )
+            : *Meta mm ( model_metadata mo )
+            : String msg ( string_from `Training schedule updated for model ` )
+            ( string_push_str msg ( string_data mname ) )
+            : Json o ( __an_ok_msg ( string_data msg ) )
+            : Json sched ( json_obj_new )
+            ( json_obj_set sched `below_max` ( json_int . mm sched_below ) )
+            ( json_obj_set sched `at_max` ( json_int . mm sched_at_max ) )
+            ( json_obj_set o `training_schedule` sched )
+            : HttpResponse r ( response_json 200 o )
+            ( json_free o )
+            ( string_free msg )
+            ( model_free mo )
+            ( store_free st )
+            ( string_free mname )
+            ^ r
+        }
+        F _ → {
+            ( store_free st )
+            ( string_free mname )
+            ^ ( __an_json_err 400 `No data provided` )
+        }
+    }
+}
+
+@ __an_h_finetune HttpRequest req Params p → HttpResponse {
+    : String mname ( __an_param_model p )
+    ? ( __an_name_ok ( string_data mname ) ) {} {
+        ( string_free mname )
+        ^ ( __an_bad_name )
+    }
+    : Store st ( store_open g_an_root )
+    ? ( store_exists st ( string_data mname ) ) {} {
+        : HttpResponse r404 ( __an_404_model ( string_data mname ) )
+        ( store_free st )
+        ( string_free mname )
+        ^ r404
+    }
+    : *Model mo ( model_open st ( string_data mname ) )
+    ? ( model_is_trained mo ) {} {
+        : String msg ( string_from `Model ` )
+        ( string_push_str msg ( string_data mname ) )
+        ( string_push_str msg ` exists but is not trained yet.` )
+        : HttpResponse rr ( __an_json_err 400 ( string_data msg ) )
+        ( string_free msg )
+        ( model_free mo )
+        ( store_free st )
+        ( string_free mname )
+        ^ rr
+    }
+    : FineTuneReport rep ( model_finetune mo )
+    : Json margins ( json_obj_new )
+    : Json scores ( json_obj_new )
+    : i ni ( vec_len [FtVer] . rep items )
+    : ~ i k 0
+    ~ < k ni {
+        ?? ( vec_get [FtVer] . rep items k ) {
+            T ft → {
+                ( json_obj_set margins ( string_data . ft ftname ) ( json_float . ft new_margin ) )
+                ( json_obj_set scores ( string_data . ft ftname ) ( json_float . ft min_score ) )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( finetune_free rep )
+    : String msg ( string_from `Successfully fine-tuned model ` )
+    ( string_push_str msg ( string_data mname ) )
+    : Json o ( __an_ok_msg ( string_data msg ) )
+    ( json_obj_set o `adjusted_margins` margins )
+    ( json_obj_set o `max_anomaly_scores` scores )
+    : HttpResponse r ( response_json 200 o )
+    ( json_free o )
+    ( string_free msg )
+    ( model_free mo )
+    ( store_free st )
+    ( string_free mname )
+    ^ r
+}
+
+@ __an_h_batch HttpRequest req Params p → HttpResponse {
+    : ?Json bodyo ( __an_body_json req )
+    ?? bodyo {
+        T body → {
+            ? ( json_obj_has body `model_name` ) {
+                ( json_free body )
+                ^ ( __an_json_err 400 `model_name is not supported: batch scoring trains a stateless forest on the file itself` )
+            } {}
+            : ~ String fpath ( string_new )
+            : ~ b have_path F
+            ?? ( json_obj_get body `file_path` ) {
+                T fp → {
+                    ? ( json_is_str fp ) {
+                        ( string_free fpath )
+                        = fpath ( string_from ( json_str_data fp ) )
+                        = have_path T
+                    } {}
+                }
+                F _ → {}
+            }
+            : ~ b header T
+            ?? ( json_obj_get body `has_header` ) {
+                T hh → { = header ( json_as_bool hh ) }
+                F _ → {}
+            }
+            ( json_free body )
+            ? have_path {} {
+                ( string_free fpath )
+                ^ ( __an_json_err 400 `file_path is required` )
+            }
+            : !String IoErr fr ( read_file ( string_data fpath ) )
+            ?? fr {
+                T text → {
+                    : AnomCsv ds ( anom_parse_csv ( string_data text ) `,` header )
+                    ( string_free text )
+                    ? || <= . ds rows 0 <= . ds cols 0 {
+                        ( anom_csv_free ds )
+                        ( string_free fpath )
+                        ^ ( __an_json_err 400 `No numeric rows found in file` )
+                    } {}
+                    : VerCfg cfg @ VerCfg { ( string_from `batch` ) 0 0 100 256 -1.0 0.0 T }
+                    : BatchReport rep ( anomaly_batch . ds data . ds rows . ds cols cfg )
+                    ( __an_vercfg_free cfg )
+
+                    : Json res ( json_obj_new )
+                    ( json_obj_set res `file_path` ( json_str_lit ( string_data fpath ) ) )
+                    ( json_obj_set res `model_used` ( json_str_lit `batch:iforest` ) )
+                    ( json_obj_set res `total_rows` ( json_int . rep total_rows ) )
+                    ( json_obj_set res `anomaly_count` ( json_int . rep anomaly_count ) )
+                    ( json_obj_set res `anomaly_percentage` ( json_float . rep anomaly_percentage ) )
+                    ( json_obj_set res `has_anomalies` ( json_bool . rep has_anomalies ) )
+                    : Json idxs ( json_arr_new )
+                    : i nh ( vec_len [i] . rep anomaly_indices )
+                    : ~ i k 0
+                    ~ < k nh {
+                        ?? ( vec_get [i] . rep anomaly_indices k ) {
+                            T idx → { ( json_arr_push idxs ( json_int idx ) ) }
+                            F _ → {}
+                        }
+                        = k + k 1
+                    }
+                    ( json_obj_set res `anomaly_indices` idxs )
+                    // First 100 anomalies with their scores (and named
+                    // column values when the CSV had a header row).
+                    : Json details ( json_arr_new )
+                    : ~ i d 0
+                    ~ & < d nh < d 100 {
+                        ?? ( vec_get [i] . rep anomaly_indices d ) {
+                            T idx → {
+                                : Json det ( json_obj_new )
+                                ( json_obj_set det `index` ( json_int idx ) )
+                                ?? ( vec_get [f] . rep scores idx ) {
+                                    T sc → { ( json_obj_set det `anomaly_score` ( json_float sc ) ) }
+                                    F _ → {}
+                                }
+                                : i nhead ( vec_len [String] . ds headers )
+                                : ~ i c 0
+                                ~ & < c nhead < c . ds cols {
+                                    ?? ( vec_get [String] . ds headers c ) {
+                                        T hname → {
+                                            ?? ( vec_get [f] . ds data + * idx . ds cols c ) {
+                                                T val → { ( json_obj_set det ( string_data hname ) ( json_float val ) ) }
+                                                F _ → {}
+                                            }
+                                        }
+                                        F _ → {}
+                                    }
+                                    = c + c 1
+                                }
+                                ( json_arr_push details det )
+                            }
+                            F _ → {}
+                        }
+                        = d + d 1
+                    }
+                    ( json_obj_set res `anomaly_details` details )
+                    ( anomaly_report_free rep )
+                    ( anom_csv_free ds )
+                    ( string_free fpath )
+
+                    : Json o ( __an_ok_msg `Anomaly detection completed` )
+                    ( json_obj_set o `result` res )
+                    : HttpResponse r ( response_json 200 o )
+                    ( json_free o )
+                    ^ r
+                }
+                F _ → {
+                    : String msg ( string_from `File not found: ` )
+                    ( string_push_str msg ( string_data fpath ) )
+                    : HttpResponse rr ( __an_json_err 404 ( string_data msg ) )
+                    ( string_free msg )
+                    ( string_free fpath )
+                    ^ rr
+                }
+            }
+        }
+        F _ → { ^ ( __an_json_err 400 `file_path is required` ) }
+    }
+}
+
+// ── Router assembly / server ──────────────────────────────────────────
+
+@ anomaly_service_router → Router {
+    : Router r ( router_new )
+    ( router_post r `/detect/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_detect req p T ) } )
+    ( router_post r `/detect_only/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_detect req p F ) } )
+    ( router_post r `/force_train/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_force_train req p ) } )
+    ( router_get r `/force_train/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_force_train req p ) } )
+    ( router_post r `/detect_anomalies` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_batch req p ) } )
+    ( router_get r `/models/dynamic` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_models req p ) } )
+    ( router_get r `/models/dynamic/:model/metadata` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_metadata req p ) } )
+    ( router_get r `/models/dynamic/:model/data` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_data req p ) } )
+    ( router_post r `/models/dynamic/:model/reset` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_reset req p ) } )
+    ( router_delete r `/delete_model/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_delete req p ) } )
+    ( router_get r `/delete_model/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_delete req p ) } )
+    ( router_put r `/api/dynamic/:model/schedule` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_schedule req p ) } )
+    ( router_post r `/api/dynamic/:model/finetune` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_finetune req p ) } )
+    ^ r
+}
+
+// Serve until the listener errors. Returns a process exit code.
+@ anomaly_serve s host i port → i {
+    : Router r ( anomaly_service_router )
+    : !TcpListener NetErr lr ( tcp_listen host port )
+    ?? lr {
+        T listener → {
+            : ( @ HttpResponse HttpRequest ) h \ HttpRequest req → HttpResponse { ^ ( router_handle r req ) }
+            : HttpServer srv ( server_new listener h )
+            ( nurl_eprint `anomaly: serving on ` )
+            ( nurl_eprint host )
+            ( nurl_eprint `:` )
+            : String ps ( string_new )
+            ( string_push_int ps port )
+            ( nurl_eprintln ( string_data ps ) )
+            ( string_free ps )
+            : !v NetErr rr ( server_run srv )
+            ( server_stop srv )
+            ( router_free r )
+            ?? rr {
+                T _ → { ^ 0 }
+                F e → {
+                    ( nurl_eprint `anomaly: server error: ` )
+                    ( nurl_eprintln ( net_err_name e ) )
+                    ^ 1
+                }
+            }
+        }
+        F e → {
+            ( router_free r )
+            ( nurl_eprint `anomaly: cannot bind ` )
+            ( nurl_eprintln host )
+            ^ 1
+        }
+    }
+}

--- a/packages/anomaly/src/service.nu
+++ b/packages/anomaly/src/service.nu
@@ -37,6 +37,7 @@ $ `stdlib/ext/http_router.nu`
 $ `stdlib/ext/http_server.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
+$ `src/score.nu`
 $ `src/store.nu`
 $ `src/dynamic.nu`
 $ `src/csvdata.nu`

--- a/packages/anomaly/src/store.nu
+++ b/packages/anomaly/src/store.nu
@@ -1,0 +1,492 @@
+// anomaly/store.nu — persistence (milestone M3).
+//
+// On-disk layout, one directory per model under the store root:
+//
+//   <root>/<name>/
+//     metadata.json            M1 metadata (feature order, scaler, versions…)
+//     data.jsonl               raw ingested points, one JSON record per line
+//                              (raw records — not projected vectors — so a
+//                              retrain can pick up new categories/columns)
+//     version_<v>.forest       one binary forest blob per trained version
+//
+// The forest blob ("ANOMFOR1") is a little-endian dump of the iforest node
+// arena plus the version's decision offset/margin. Loading re-validates
+// every structural invariant (lengths, index ranges, node-count caps), so a
+// corrupt or truncated blob comes back as None — never undefined behaviour.
+//
+// Writes are atomic: serialise to `<file>.tmp`, then rename(2) over the
+// final name, so a crash mid-write can't leave a half-written model.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/floatbits.nu`
+$ `stdlib/std/sort.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `deps/iforest/src/iforest.nu`
+
+// Refuse to load blobs claiming more than this many arena nodes / trees /
+// name bytes — bounds untrusted counts before any allocation.
+: i ANOM_BLOB_MAX_NODES 200000000
+: i ANOM_BLOB_MAX_TREES 100000
+: i ANOM_BLOB_MAX_NAME 4096
+
+// ── Bounded little-endian reader over an untrusted byte buffer ────────
+
+: BlobRd {
+    ( Vec u ) buf
+    i pos
+    b ok
+}
+
+@ __an_rd_new ( Vec u ) buf → *BlobRd {
+    : *BlobRd rd # *BlobRd ( nurl_malloc Z BlobRd )
+    = . rd buf buf
+    = . rd pos 0
+    = . rd ok T
+    ^ rd
+}
+
+@ __an_rd_u64 *BlobRd rd → i {
+    ?? ( bytes_read_u64_le . rd buf . rd pos ) {
+        T x → {
+            = . rd pos + . rd pos 8
+            ^ # i x
+        }
+        F _ → {
+            = . rd ok F
+            ^ 0
+        }
+    }
+}
+
+@ __an_rd_f64 *BlobRd rd → f {
+    ?? ( bytes_read_f64_le . rd buf . rd pos ) {
+        T x → {
+            = . rd pos + . rd pos 8
+            ^ x
+        }
+        F _ → {
+            = . rd ok F
+            ^ 0.0
+        }
+    }
+}
+
+// ── VerModel ⇄ bytes ──────────────────────────────────────────────────
+
+@ __an_blob_push_ivec ( Vec u ) out ( Vec i ) xs → v {
+    : i n ( vec_len [i] xs )
+    ( bytes_push_u64_le out # u64 n )
+    : *i dp ( vec_data [i] xs )
+    : ~ i k 0
+    ~ < k n {
+        ( bytes_push_u64_le out # u64 . dp k )
+        = k + k 1
+    }
+}
+
+@ __an_blob_push_fvec ( Vec u ) out ( Vec f ) xs → v {
+    : i n ( vec_len [f] xs )
+    ( bytes_push_u64_le out # u64 n )
+    : *f dp ( vec_data [f] xs )
+    : ~ i k 0
+    ~ < k n {
+        ( bytes_push_f64_le out . dp k )
+        = k + k 1
+    }
+}
+
+// Read `want` i64s (a count-prefixed vector whose count must equal `want`).
+@ __an_blob_read_ivec *BlobRd rd i want → ( Vec i ) {
+    : ( Vec i ) out ( vec_new [i] )
+    : i n ( __an_rd_u64 rd )
+    ? == n want {} { = . rd ok F ^ out }
+    ( vec_reserve [i] out n )
+    : ~ i k 0
+    ~ & . rd ok < k n {
+        ( vec_push [i] out ( __an_rd_u64 rd ) )
+        = k + k 1
+    }
+    ^ out
+}
+
+@ __an_blob_read_fvec *BlobRd rd i want → ( Vec f ) {
+    : ( Vec f ) out ( vec_new [f] )
+    : i n ( __an_rd_u64 rd )
+    ? == n want {} { = . rd ok F ^ out }
+    ( vec_reserve [f] out n )
+    : ~ i k 0
+    ~ & . rd ok < k n {
+        ( vec_push [f] out ( __an_rd_f64 rd ) )
+        = k + k 1
+    }
+    ^ out
+}
+
+// Serialise one trained version (forest + offset + margin) to owned bytes.
+@ vermodel_to_bytes VerModel vm → ( Vec u ) {
+    : ( Vec u ) out ( vec_new [u] )
+    ( bytes_extend_str out `ANOMFOR1` )
+    : i nlen ( string_len . vm vname )
+    ( bytes_push_u64_le out # u64 nlen )
+    ( bytes_extend_str out ( string_data . vm vname ) )
+    ( bytes_push_f64_le out . vm offset )
+    ( bytes_push_f64_le out . vm margin )
+
+    : IForest fo . vm forest
+    ( bytes_push_u64_le out # u64 . fo n_trees )
+    ( bytes_push_u64_le out # u64 . fo sample_size )
+    ( bytes_push_f64_le out . fo c_psi )
+    ( bytes_push_u64_le out # u64 . fo n_cols )
+    ( __an_blob_push_ivec out . fo roots )
+    : i n_nodes ( vec_len [i] . fo feature )
+    ( bytes_push_u64_le out # u64 n_nodes )
+    ( __an_blob_push_ivec out . fo feature )
+    ( __an_blob_push_fvec out . fo split )
+    ( __an_blob_push_ivec out . fo left )
+    ( __an_blob_push_ivec out . fo right )
+    ( __an_blob_push_ivec out . fo size )
+    ^ out
+}
+
+// Every node index in xs must lie in [-1, n_nodes).
+@ __an_blob_idx_ok ( Vec i ) xs i n_nodes → b {
+    : i n ( vec_len [i] xs )
+    : *i dp ( vec_data [i] xs )
+    : ~ i k 0
+    ~ < k n {
+        : i x . dp k
+        ? || < x -1 >= x n_nodes { ^ F } {}
+        = k + k 1
+    }
+    ^ T
+}
+
+// Parse a forest blob. None on any structural violation: bad magic, short
+// buffer, absurd counts, mismatched array lengths, out-of-range indices.
+@ vermodel_from_bytes ( Vec u ) buf → ?VerModel {
+    : ( Vec u ) magic ( bytes_from_str `ANOMFOR1` )
+    : b magic_ok ( bytes_starts_with buf magic )
+    ( vec_free [u] magic )
+    ? magic_ok {} { ^ @ ?VerModel { F } }
+
+    : *BlobRd rd ( __an_rd_new buf )
+    = . rd pos 8
+
+    : i nlen ( __an_rd_u64 rd )
+    ? || < nlen 0 > nlen ANOM_BLOB_MAX_NAME { = . rd ok F } {}
+    : ~ String vname ( string_new )
+    ? . rd ok {
+        : i n ( vec_len [u] buf )
+        ? > + . rd pos nlen n { = . rd ok F } {
+            : *u bp ( vec_data [u] buf )
+            : i base + # i bp . rd pos
+            ( string_free vname )
+            = vname ( string_from_bytes # *u base nlen )
+            = . rd pos + . rd pos nlen
+        }
+    } {}
+
+    : f off ( __an_rd_f64 rd )
+    : f margin ( __an_rd_f64 rd )
+    : i n_trees ( __an_rd_u64 rd )
+    : i sample_size ( __an_rd_u64 rd )
+    : f c_psi ( __an_rd_f64 rd )
+    : i n_cols ( __an_rd_u64 rd )
+    ? || < n_trees 0 > n_trees ANOM_BLOB_MAX_TREES { = . rd ok F } {}
+    ? || < sample_size 0 || < n_cols 0 > n_cols ANOM_BLOB_MAX_NODES { = . rd ok F } {}
+
+    : ( Vec i ) roots ( __an_blob_read_ivec rd n_trees )
+    : i n_nodes ( __an_rd_u64 rd )
+    ? || < n_nodes 0 > n_nodes ANOM_BLOB_MAX_NODES { = . rd ok F } {}
+    : ~ i safe_nodes n_nodes
+    ? . rd ok {} { = safe_nodes 0 }
+    : ( Vec i ) feature ( __an_blob_read_ivec rd safe_nodes )
+    : ( Vec f ) split ( __an_blob_read_fvec rd safe_nodes )
+    : ( Vec i ) left ( __an_blob_read_ivec rd safe_nodes )
+    : ( Vec i ) right ( __an_blob_read_ivec rd safe_nodes )
+    : ( Vec i ) size ( __an_blob_read_ivec rd safe_nodes )
+
+    // Trailing garbage after a well-formed body is also a corrupt file.
+    ? == . rd pos ( vec_len [u] buf ) {} { = . rd ok F }
+
+    : ~ b ok . rd ok
+    ( nurl_free rd )
+    ? ok {
+        ? ( __an_blob_idx_ok roots safe_nodes ) {} { = ok F }
+        ? ( __an_blob_idx_ok left safe_nodes ) {} { = ok F }
+        ? ( __an_blob_idx_ok right safe_nodes ) {} { = ok F }
+        // feature must be in [-1, n_cols); leaves (-1) have no split.
+        ? ( __an_blob_idx_ok feature n_cols ) {} { = ok F }
+    } {}
+
+    ? ok {} {
+        ( string_free vname )
+        ( vec_free [i] roots )
+        ( vec_free [i] feature )
+        ( vec_free [f] split )
+        ( vec_free [i] left )
+        ( vec_free [i] right )
+        ( vec_free [i] size )
+        ^ @ ?VerModel { F }
+    }
+    : IForest fo @ IForest { n_trees sample_size c_psi n_cols roots feature split left right size }
+    ^ @ ?VerModel { T @ VerModel { vname fo off margin n_cols T } }
+}
+
+// ── File store backend ────────────────────────────────────────────────
+
+: Store {
+    String root
+}
+
+@ store_open s root → Store {
+    ^ @ Store { ( string_from root ) }
+}
+
+@ store_free Store st → v {
+    ( string_free . st root )
+}
+
+@ __an_model_dir Store st s name → String {
+    : String p ( string_from ( string_data . st root ) )
+    ( string_push_char p 47 )
+    ( string_push_str p name )
+    ^ p
+}
+
+@ __an_model_file Store st s name s file → String {
+    : String p ( __an_model_dir st name )
+    ( string_push_char p 47 )
+    ( string_push_str p file )
+    ^ p
+}
+
+@ __an_forest_file Store st s name s vname → String {
+    : String p ( __an_model_dir st name )
+    ( string_push_str p `/version_` )
+    ( string_push_str p vname )
+    ( string_push_str p `.forest` )
+    ^ p
+}
+
+// Write bytes atomically: <path>.tmp, then rename over <path>.
+@ __an_write_atomic s path ( Vec u ) data → b {
+    : String tmp ( string_from path )
+    ( string_push_str tmp `.tmp` )
+    : !v IoErr wr ( write_file_bytes ( string_data tmp ) data )
+    : ~ b ok T
+    ?? wr { T _ → {} F _ → { = ok F } }
+    ? ok {
+        : !v IoErr mv ( fs_rename ( string_data tmp ) path )
+        ?? mv { T _ → {} F _ → { = ok F } }
+    } {}
+    ( string_free tmp )
+    ^ ok
+}
+
+// A model exists iff its metadata file does.
+@ store_exists Store st s name → b {
+    : String p ( __an_model_file st name `metadata.json` )
+    : b there ( file_exists ( string_data p ) )
+    ( string_free p )
+    ^ there
+}
+
+// Sorted names of every model in the store (dirs with a metadata.json).
+@ store_list Store st → ( Vec String ) {
+    : ( Vec String ) out ( vec_new [String] )
+    : !( Vec String ) IoErr r ( dir_list ( string_data . st root ) )
+    ?? r {
+        T entries → {
+            : i n ( vec_len [String] entries )
+            : ~ i k 0
+            ~ < k n {
+                ?? ( vec_get [String] entries k ) {
+                    T e → {
+                        ? ( store_exists st ( string_data e ) ) {
+                            ( vec_push [String] out ( string_from ( string_data e ) ) )
+                        } {}
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( vec_free_with [String] entries \ String x → v { ( string_free x ) } )
+        }
+        F _ → {}
+    }
+    ( sort_by [String] out \ String a String b → i { ( nurl_str_cmp ( string_data a ) ( string_data b ) ) } )
+    ^ out
+}
+
+// Persist metadata (creates the model directory as needed).
+@ store_save_meta Store st s name *Meta m → b {
+    : String d ( __an_model_dir st name )
+    : !v IoErr mk ( dir_create_all ( string_data d ) )
+    : ~ b ok T
+    ?? mk { T _ → {} F _ → { = ok F } }
+    ? ok {
+        : String txt ( meta_to_json_str m )
+        : ( Vec u ) data ( bytes_from_str ( string_data txt ) )
+        : String p ( __an_model_file st name `metadata.json` )
+        = ok ( __an_write_atomic ( string_data p ) data )
+        ( string_free p )
+        ( vec_free [u] data )
+        ( string_free txt )
+    } {}
+    ( string_free d )
+    ^ ok
+}
+
+@ store_load_meta Store st s name → ?*Meta {
+    : String p ( __an_model_file st name `metadata.json` )
+    : !String IoErr r ( read_file ( string_data p ) )
+    ( string_free p )
+    ?? r {
+        T txt → {
+            : ?*Meta m ( meta_from_json_str ( string_data txt ) )
+            ( string_free txt )
+            ^ m
+        }
+        F _ → { ^ @ ?*Meta { F } }
+    }
+}
+
+// Persist one trained version's forest blob.
+@ store_save_forest Store st s name VerModel vm → b {
+    : String d ( __an_model_dir st name )
+    : !v IoErr mk ( dir_create_all ( string_data d ) )
+    : ~ b ok T
+    ?? mk { T _ → {} F _ → { = ok F } }
+    ? ok {
+        : ( Vec u ) blob ( vermodel_to_bytes vm )
+        : String p ( __an_forest_file st name ( string_data . vm vname ) )
+        = ok ( __an_write_atomic ( string_data p ) blob )
+        ( string_free p )
+        ( vec_free [u] blob )
+    } {}
+    ( string_free d )
+    ^ ok
+}
+
+// Load one version's forest; None if absent or corrupt. The blob's
+// embedded version name must match the requested one — a renamed or
+// content-tampered file is treated as corrupt, not trusted.
+@ store_load_forest Store st s name s vname → ?VerModel {
+    : String p ( __an_forest_file st name vname )
+    : !( Vec u ) IoErr r ( read_file_bytes ( string_data p ) )
+    ( string_free p )
+    ?? r {
+        T blob → {
+            : ?VerModel vm ( vermodel_from_bytes blob )
+            ( vec_free [u] blob )
+            ?? vm {
+                T got → {
+                    ? == ( nurl_str_eq ( string_data . got vname ) vname ) 1 {
+                        ^ @ ?VerModel { T got }
+                    } {
+                        ( anom_vermodel_free got )
+                        ^ @ ?VerModel { F }
+                    }
+                }
+                F _ → { ^ @ ?VerModel { F } }
+            }
+        }
+        F _ → { ^ @ ?VerModel { F } }
+    }
+}
+
+// Remove a trained version's blob (used by reset). Missing file is fine.
+@ store_delete_forest Store st s name s vname → v {
+    : String p ( __an_forest_file st name vname )
+    : !v IoErr r ( file_delete ( string_data p ) )
+    ?? r { T _ → {} F _ → {} }
+    ( string_free p )
+}
+
+// Delete a model entirely (directory and everything in it).
+@ store_delete Store st s name → b {
+    : String d ( __an_model_dir st name )
+    : !v IoErr r ( dir_remove_all ( string_data d ) )
+    : ~ b ok T
+    ?? r { T _ → {} F _ → { = ok F } }
+    ( string_free d )
+    ^ ok
+}
+
+// ── Raw point log (data.jsonl) ────────────────────────────────────────
+//
+// One compact JSON record per line, in ingest order, each carrying its
+// server-side `timestamp` (unix seconds) alongside the raw client fields.
+// Stored raw so retraining can re-encode with newly-learned categories.
+
+// Append one line (the record's compact JSON, no newline).
+@ store_append_point Store st s name s line → b {
+    : String p ( __an_model_file st name `data.jsonl` )
+    : String txt ( string_from line )
+    ( string_push_char txt 10 )
+    : !v IoErr r ( append_file ( string_data p ) ( string_data txt ) )
+    : ~ b ok T
+    ?? r { T _ → {} F _ → { = ok F } }
+    ( string_free txt )
+    ( string_free p )
+    ^ ok
+}
+
+// Rewrite the whole log (ring eviction / reset).
+@ store_write_points Store st s name ( Vec String ) lines → b {
+    : String all ( string_new )
+    : i n ( vec_len [String] lines )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] lines k ) {
+            T l → {
+                ( string_push_str all ( string_data l ) )
+                ( string_push_char all 10 )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    : ( Vec u ) data ( bytes_from_str ( string_data all ) )
+    : String p ( __an_model_file st name `data.jsonl` )
+    : b ok ( __an_write_atomic ( string_data p ) data )
+    ( string_free p )
+    ( vec_free [u] data )
+    ( string_free all )
+    ^ ok
+}
+
+// Load the log as owned lines (empty vec if the file doesn't exist).
+@ store_load_points Store st s name → ( Vec String ) {
+    : ( Vec String ) out ( vec_new [String] )
+    : String p ( __an_model_file st name `data.jsonl` )
+    : !String IoErr r ( read_file ( string_data p ) )
+    ( string_free p )
+    ?? r {
+        T txt → {
+            : ( Vec String ) lines ( string_split txt `\n` )
+            : i n ( vec_len [String] lines )
+            : ~ i k 0
+            ~ < k n {
+                ?? ( vec_get [String] lines k ) {
+                    T l → {
+                        ? > ( string_len l ) 0 {
+                            ( vec_push [String] out ( string_from ( string_data l ) ) )
+                        } {}
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( vec_free_with [String] lines \ String x → v { ( string_free x ) } )
+            ( string_free txt )
+        }
+        F _ → {}
+    }
+    ^ out
+}

--- a/packages/anomaly/tests/anomaly_test.sh
+++ b/packages/anomaly/tests/anomaly_test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tests/anomaly_test.sh — the package's full test suite:
+#    1. unit suites  : prep (M1), model (M2), store (M3),
+#                      dynamic (M4), versions (M5), service (M6)
+#    2. CLI          : detect/score/train/ls/info/batch/reset/rm
+#    3. live HTTP    : `anomaly serve` + curl against the routes
+#
+#  Run from the package dir:  ./tests/anomaly_test.sh
+#  Env: NURL (build driver; defaults to ../../nurl.sh in a checkout)
+#       NURL_SAN=1 for an AddressSanitizer/UBSan build of everything
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t anomaly-test.XXXXXX)"
+SERVE_PID=""
+cleanup() { [ -n "$SERVE_PID" ] && kill "$SERVE_PID" 2>/dev/null; rm -rf "$WORK"; }
+trap cleanup EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+
+echo "[1/3] unit suites"
+for t in prep model store dynamic versions service; do
+    if ! $NURL "tests/${t}_test.nu" "$WORK/${t}_test" >/dev/null 2>"$WORK/build.err"; then
+        echo "FAIL: could not build ${t}_test:"; tail -5 "$WORK/build.err"; exit 1
+    fi
+    if (cd "$WORK" && ANOMALY_TEST_DIR="$WORK/store_$t" "./${t}_test" > "$WORK/$t.out" 2>&1); then
+        ok "${t}_test ($(tail -1 "$WORK/$t.out"))"
+    else
+        bad "${t}_test"; tail -8 "$WORK/$t.out"
+    fi
+done
+
+echo "[2/3] CLI"
+if ! $NURL src/main.nu "$WORK/anomaly" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build the anomaly CLI:"; tail -5 "$WORK/build.err"; exit 1
+fi
+A="$WORK/anomaly"
+export ANOMALY_HOME="$WORK/climodels"
+
+for i in $(seq 1 55); do
+    "$A" detect s1 "temp=2$((i%9)).5" "load=1.$((i%7))" >/dev/null 2>&1
+done
+V=$("$A" detect s1 temp=25.5 load=1.3)
+echo "$V" | grep -q '"status":"success"' && ok "CLI detect returns a verdict" || bad "CLI detect verdict: $V"
+O=$("$A" detect s1 temp=99 load=44)
+echo "$O" | grep -q '"anomaly":true' && ok "CLI detect flags an outlier" || bad "CLI outlier: $O"
+S=$("$A" score s1 temp=99 load=44)
+echo "$S" | grep -q '"anomaly":true' && ok "CLI score (detect-only)" || bad "CLI score: $S"
+[ "$("$A" ls)" = "s1" ] && ok "CLI ls" || bad "CLI ls"
+"$A" info s1 | grep -q '"name": "s1"' && ok "CLI info" || bad "CLI info"
+"$A" train s1 | grep -q 'trained on' && ok "CLI train" || bad "CLI train"
+B=$(printf 'a,b\n1,2\n1.1,2.1\n0.9,1.9\n50,50\n1,2\n1,2.2\n' | "$A" batch -H --margin 0.1 2>/dev/null)
+[ "$(echo "$B" | wc -l)" = 6 ] && ok "CLI batch scores every row" || bad "CLI batch rows"
+WORST=$(echo "$B" | sort -k2 -g | head -1 | cut -f1)
+[ "$WORST" = "3" ] && ok "CLI batch ranks the outlier row worst" || bad "CLI batch outlier row ($WORST)"
+"$A" reset s1 >/dev/null && "$A" rm s1 >/dev/null && [ -z "$("$A" ls)" ] && ok "CLI reset + rm" || bad "CLI reset/rm"
+
+echo "[3/3] live HTTP service"
+PORT=$((20000 + RANDOM % 20000))
+"$A" serve --addr "127.0.0.1:$PORT" --store "$WORK/svcmodels" 2>"$WORK/serve.err" &
+SERVE_PID=$!
+for _ in $(seq 1 50); do
+    curl -s -o /dev/null "http://127.0.0.1:$PORT/models/dynamic" 2>/dev/null && break
+    sleep 0.1
+done
+
+CODE=$(curl -s -o "$WORK/r1" -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/detect/live" -d '{"temp": 20.5}')
+[ "$CODE" = "202" ] && grep -q '"collecting"' "$WORK/r1" && ok "HTTP detect warms up (202)" || bad "HTTP warm-up ($CODE)"
+for i in $(seq 2 50); do
+    curl -s -o /dev/null -X POST "http://127.0.0.1:$PORT/detect/live" -d "{\"temp\": 2$((i%10)).5}"
+done
+CODE=$(curl -s -o "$WORK/r2" -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/detect_only/live" -d '{"temp": 99}')
+[ "$CODE" = "200" ] && grep -q '"anomaly":true' "$WORK/r2" && ok "HTTP detect_only flags an outlier" || bad "HTTP outlier ($CODE: $(cat "$WORK/r2"))"
+curl -s "http://127.0.0.1:$PORT/models/dynamic" | grep -q '"live"' && ok "HTTP model listing" || bad "HTTP listing"
+curl -s "http://127.0.0.1:$PORT/models/dynamic/live/metadata" | grep -q '"model_name":"live"' && ok "HTTP metadata" || bad "HTTP metadata"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/detect/bad!name" -d '{"a":1}')
+[ "$CODE" = "400" ] && ok "HTTP invalid name rejected" || bad "HTTP invalid name ($CODE)"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "http://127.0.0.1:$PORT/delete_model/live")
+[ "$CODE" = "200" ] && ok "HTTP delete" || bad "HTTP delete ($CODE)"
+
+kill "$SERVE_PID" 2>/dev/null; wait "$SERVE_PID" 2>/dev/null; SERVE_PID=""
+
+echo "== anomaly tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" = 0 ]

--- a/packages/anomaly/tests/anomaly_test.sh
+++ b/packages/anomaly/tests/anomaly_test.sh
@@ -29,7 +29,7 @@ ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
 bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
 
 echo "[1/3] unit suites"
-for t in prep model store dynamic versions service; do
+for t in prep model store dynamic versions service gpu; do
     if ! $NURL "tests/${t}_test.nu" "$WORK/${t}_test" >/dev/null 2>"$WORK/build.err"; then
         echo "FAIL: could not build ${t}_test:"; tail -5 "$WORK/build.err"; exit 1
     fi
@@ -39,6 +39,14 @@ for t in prep model store dynamic versions service; do
         bad "${t}_test"; tail -8 "$WORK/$t.out"
     fi
 done
+
+# The accelerated scorer must be bit-identical on the gpu package's CPU
+# (host C++) backend too — the path a GPU-less machine takes.
+if (cd "$WORK" && NURL_GPU=cpu ANOMALY_TEST_DIR="$WORK/store_gpu_cpu" ./gpu_test > "$WORK/gpu_cpu.out" 2>&1); then
+    ok "gpu_test on the CPU backend ($(grep 'engine =' "$WORK/gpu_cpu.out" | head -1 | sed 's/.*= //'))"
+else
+    bad "gpu_test on the CPU backend"; tail -8 "$WORK/gpu_cpu.out"
+fi
 
 echo "[2/3] CLI"
 if ! $NURL src/main.nu "$WORK/anomaly" >/dev/null 2>"$WORK/build.err"; then

--- a/packages/anomaly/tests/dynamic_test.nu
+++ b/packages/anomaly/tests/dynamic_test.nu
@@ -1,0 +1,281 @@
+// dynamic_test.nu — M4 tests: streaming dynamic model.
+//
+// Two scenarios:
+//   stream    — production limits (min 50, schedule 50/1000), a gaussian-ish
+//               deterministic stream: warm-up gating, no false alarms, a
+//               step change flagged. The margin 0.17 sits between our
+//               deterministic worst normal df (-0.1389) and the outlier df
+//               (-0.2080); the forest is seeded, so these never drift.
+//               (sklearn on the same data: -0.148 / -0.209 — same story.)
+//   mechanics — tiny limits: retrain cadence, ring eviction, lifetime
+//               counter, detect_only immutability, reopen-from-disk
+//               continuity, bad-value rejection, reset, delete.
+//
+// Store root: $ANOMALY_TEST_DIR (default ./anomaly_dyn_test).
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/store.nu`
+$ `src/dynamic.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+: i T0 1700000000
+: ~ i g_lcg 1
+
+@ pline s x → v {
+    ( nurl_print x )
+    ( nurl_print `\n` )
+}
+
+@ check b cond s label → v {
+    ? cond {
+        ( nurl_print `ok ` )
+        ( pline label )
+        = g_pass + g_pass 1
+    } {
+        ( nurl_print `FAIL ` )
+        ( pline label )
+        = g_fail + g_fail 1
+    }
+}
+
+// Deterministic uniform in [0,1): the classic LCG, same on every platform.
+@ lcg_u01 → f {
+    = g_lcg % + * g_lcg 1103515245 12345 2147483648
+    ^ / # f g_lcg 2147483648.0
+}
+
+// Gaussian-ish jitter (Irwin–Hall of 3 uniforms, centred, std ≈ 0.5).
+@ gauss3 → f {
+    ^ - + + ( lcg_u01 ) ( lcg_u01 ) ( lcg_u01 ) 1.5
+}
+
+: IngestOut {
+    b ok
+    b ready
+    b anomaly
+    f score
+    i n_versions
+}
+
+@ ingest_pt *Model mo f temp f load i idx → IngestOut {
+    : Json j ( json_obj_new )
+    ( json_obj_set j `temp` ( json_float temp ) )
+    ( json_obj_set j `load` ( json_float load ) )
+    : !Verdict String r ( model_ingest_at mo j + T0 * idx 60 )
+    ( json_free j )
+    ?? r {
+        T vd → {
+            : IngestOut out @ IngestOut { T . vd ready . vd anomaly . vd score ( vec_len [VerVerdict] . vd versions ) }
+            ( verdict_free vd )
+            ^ out
+        }
+        F e → {
+            ( string_free e )
+            ^ @ IngestOut { F F F 0.0 0 }
+        }
+    }
+}
+
+@ set_all_margins *Model mo f margin → v {
+    : b a ( model_set_margin mo `short_term` margin )
+    : b b2 ( model_set_margin mo `daily` margin )
+    : b c ( model_set_margin mo `weekly` margin )
+    : b d ( model_set_margin mo `seasonal` margin )
+    : b e ( model_set_margin mo `timevector` margin )
+}
+
+// ── Scenario A: statistical behaviour at production limits ────────────
+
+@ test_stream Store st → v {
+    = g_lcg 1
+    : *Model mo ( model_open_at st `stream` T0 )
+    ( check == ( store_exists st `stream` ) T `stream: created on first use` )
+    ( set_all_margins mo 0.17 )
+
+    : ~ b all_warming T
+    : ~ b any_false_alarm F
+    : ~ b ready_from_50 T
+    : ~ i k 1
+    ~ <= k 100 {
+        : f temp + 20.0 ( gauss3 )
+        : f load + 5.0 * ( gauss3 ) 0.5
+        : IngestOut o ( ingest_pt mo temp load k )
+        ? < k 50 {
+            ? & . o ok == . o ready F {} { = all_warming F }
+        } {
+            ? & . o ok . o ready {} { = ready_from_50 F }
+            ? . o anomaly { = any_false_alarm T } {}
+        }
+        = k + k 1
+    }
+    ( check all_warming `stream: points 1-49 warming up (ready=false)` )
+    ( check ready_from_50 `stream: ready from point 50 (first train)` )
+    ( check == any_false_alarm F `stream: no false alarms on 51 normal points` )
+    : *Meta mm ( model_metadata mo )
+    ( check == . mm last_trained 100 `stream: schedule retrained at 100` )
+
+    // The step change: extreme in both features, flagged immediately.
+    : IngestOut o101 ( ingest_pt mo 26.0 8.0 101 )
+    ( check . o101 anomaly `stream: step change flagged` )
+    ( check <= . o101 score -0.17 `stream: step change crosses the margin` )
+    ( check == . o101 n_versions 5 `stream: verdict carries all 5 versions` )
+
+    // detect_only sees the same outlier without touching anything.
+    : Json probe ( json_obj_new )
+    ( json_obj_set probe `temp` ( json_float 26.0 ) )
+    ( json_obj_set probe `load` ( json_float 8.0 ) )
+    : !Verdict String dr ( model_detect_only mo probe )
+    ( json_free probe )
+    ?? dr {
+        T vd → {
+            ( check . vd anomaly `stream: detect_only flags the outlier` )
+            ( verdict_free vd )
+        }
+        F e → { ( string_free e ) ( check F `stream: detect_only succeeds` ) }
+    }
+    ( model_free mo )
+}
+
+// ── Scenario B: streaming mechanics at tiny limits ────────────────────
+
+@ test_mechanics Store st → v {
+    : *Model mo ( model_open_at st `mech` T0 )
+    ( model_set_limits mo 10 30 )
+    ( model_set_schedule mo 10 20 )
+    ( check ( model_set_margin mo `weekly` 0.5 ) `mech: margin update accepted` )
+    ( check == ( model_set_margin mo `nosuch` 0.5 ) F `mech: unknown version margin rejected` )
+    ( set_all_margins mo 0.5 )
+    ( check == ( model_is_trained mo ) F `mech: starts untrained` )
+
+    : ~ b all_warming T
+    : ~ i k 1
+    ~ <= k 9 {
+        : IngestOut o ( ingest_pt mo + 20.0 ( gauss3 ) + 5.0 ( gauss3 ) k )
+        ? & . o ok == . o ready F {} { = all_warming F }
+        = k + k 1
+    }
+    ( check all_warming `mech: points 1-9 warming up` )
+
+    : IngestOut o10 ( ingest_pt mo + 20.0 ( gauss3 ) + 5.0 ( gauss3 ) 10 )
+    ( check . o10 ready `mech: point 10 trains and is ready` )
+    ( check ( model_is_trained mo ) `mech: trained after warm-up` )
+    : *Meta mm ( model_metadata mo )
+    ( check == . mm last_trained 10 `mech: last_trained = 10` )
+
+    = k 11
+    ~ <= k 25 {
+        : IngestOut o ( ingest_pt mo + 20.0 ( gauss3 ) + 5.0 ( gauss3 ) k )
+        = k + k 1
+    }
+    ( check == . mm last_trained 20 `mech: schedule retrained at 20` )
+
+    // detect_only mutates nothing: not metadata, not the ring, not disk.
+    : String meta_before ( meta_to_json_str mm )
+    : i pts_before ( model_n_points mo )
+    : Json probe ( json_obj_new )
+    ( json_obj_set probe `temp` ( json_float 1000.0 ) )
+    ( json_obj_set probe `newcol` ( json_float 5.0 ) )
+    ( json_obj_set probe `status` ( json_str_lit `newcat` ) )
+    : !Verdict String dr ( model_detect_only mo probe )
+    ( json_free probe )
+    ?? dr {
+        T vd → { ( verdict_free vd ) ( check T `mech: detect_only succeeds` ) }
+        F e → { ( string_free e ) ( check F `mech: detect_only succeeds` ) }
+    }
+    : String meta_after ( meta_to_json_str mm )
+    ( check ( string_eq meta_before meta_after ) `mech: detect_only leaves metadata untouched` )
+    ( check == ( model_n_points mo ) pts_before `mech: detect_only leaves the ring untouched` )
+    : ( Vec String ) disk_pts ( store_load_points st `mech` )
+    ( check == ( vec_len [String] disk_pts ) pts_before `mech: detect_only leaves disk untouched` )
+    ( vec_free_with [String] disk_pts \ String x → v { ( string_free x ) } )
+    ( string_free meta_before )
+    ( string_free meta_after )
+
+    // Ring eviction: cap is 30, lifetime counter keeps going.
+    = k 26
+    ~ <= k 40 {
+        : IngestOut o ( ingest_pt mo + 20.0 ( gauss3 ) + 5.0 ( gauss3 ) k )
+        = k + k 1
+    }
+    ( check == ( model_n_points mo ) 30 `mech: ring capped at 30` )
+    ( check == . mm n_seen 40 `mech: n_seen counts past the cap` )
+    ?? ( vec_get [i] . mo times 0 ) {
+        T t0 → { ( check > t0 T0 `mech: oldest point evicted` ) }
+        F _ → {}
+    }
+    : ( Vec String ) disk2 ( store_load_points st `mech` )
+    ( check == ( vec_len [String] disk2 ) 30 `mech: eviction persisted` )
+    ( vec_free_with [String] disk2 \ String x → v { ( string_free x ) } )
+
+    // Reopen from disk: trained state, counters, schedule survive.
+    ( model_free mo )
+    : *Model mo2 ( model_open_at st `mech` + T0 * 41 60 )
+    ( model_set_limits mo2 10 30 )
+    ( check ( model_is_trained mo2 ) `mech: reopened model is trained` )
+    ( check == ( model_n_points mo2 ) 30 `mech: reopened ring intact` )
+    : *Meta mm2 ( model_metadata mo2 )
+    ( check == . mm2 n_seen 40 `mech: reopened n_seen intact` )
+    ( check == . mm2 sched_below 10 `mech: reopened schedule intact` )
+
+    // Bad values are hard errors and leave no trace.
+    : i seen_before . mm2 n_seen
+    : Json badj ( json_obj_new )
+    ( json_obj_set badj `temp` ( json_str_lit `not-a-number` ) )
+    : !Verdict String br ( model_ingest_at mo2 badj + T0 * 42 60 )
+    ( json_free badj )
+    ?? br {
+        T vd → { ( verdict_free vd ) ( check F `mech: bad numeric rejected` ) }
+        F e → { ( string_free e ) ( check T `mech: bad numeric rejected` ) }
+    }
+    ( check == . mm2 n_seen seen_before `mech: rejected point not counted` )
+
+    // Reset: data and forests gone, identity/schedule kept.
+    ( model_reset mo2 )
+    ( check == ( model_n_points mo2 ) 0 `mech: reset drops the ring` )
+    ( check == ( model_is_trained mo2 ) F `mech: reset drops the forests` )
+    ( check == . ( model_metadata mo2 ) sched_below 10 `mech: reset keeps the schedule` )
+    ( check ( store_exists st `mech` ) `mech: reset keeps the model` )
+
+    // Delete: everything gone.
+    ( model_free mo2 )
+    ( check ( model_delete st `mech` ) `mech: delete` )
+    ( check == ( store_exists st `mech` ) F `mech: deleted model gone` )
+}
+
+@ main → i {
+    : ~ String root ( string_from `./anomaly_dyn_test` )
+    ?? ( env_get `ANOMALY_TEST_DIR` ) {
+        T d → { ( string_free root ) = root d }
+        F _ → {}
+    }
+    : !v IoErr junk ( dir_remove_all ( string_data root ) )
+    ?? junk { T _ → {} F _ → {} }
+    : Store st ( store_open ( string_data root ) )
+
+    ( test_stream st )
+    ( test_mechanics st )
+
+    ( store_free st )
+    : !v IoErr fin ( dir_remove_all ( string_data root ) )
+    ?? fin { T _ → {} F _ → {} }
+    ( string_free root )
+
+    : String summary ( string_from `dynamic_test: ` )
+    ( string_push_int summary g_pass )
+    ( string_push_str summary ` passed, ` )
+    ( string_push_int summary g_fail )
+    ( string_push_str summary ` failed` )
+    ( pline ( string_data summary ) )
+    ( string_free summary )
+    ? > g_fail 0 { ^ 1 } {}
+    ^ 0
+}

--- a/packages/anomaly/tests/dynamic_test.nu
+++ b/packages/anomaly/tests/dynamic_test.nu
@@ -22,6 +22,7 @@ $ `stdlib/ext/env.nu`
 $ `stdlib/ext/json.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
+$ `src/score.nu`
 $ `src/store.nu`
 $ `src/dynamic.nu`
 

--- a/packages/anomaly/tests/gpu_test.nu
+++ b/packages/anomaly/tests/gpu_test.nu
@@ -1,0 +1,163 @@
+// gpu_test.nu — M7 GPU-path tests: the accelerated scorer must be
+// BIT-IDENTICAL to the pure-NURL loop, element for element — on the CUDA
+// backend and on the gpu package's CPU (host C++) backend alike
+// (run twice: plain, and with NURL_GPU=cpu).
+//
+// On a machine with neither a GPU nor a C++ compiler the accelerator
+// probe fails; that is a supported configuration, reported as a skip —
+// the pure path is the reference and needs no comparison against itself.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/score.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+: ~ i g_lcg 1
+
+@ pline s x → v {
+    ( nurl_print x )
+    ( nurl_print `\n` )
+}
+
+@ check b cond s label → v {
+    ? cond {
+        ( nurl_print `ok ` )
+        ( pline label )
+        = g_pass + g_pass 1
+    } {
+        ( nurl_print `FAIL ` )
+        ( pline label )
+        = g_fail + g_fail 1
+    }
+}
+
+@ lcg_u01 → f {
+    = g_lcg % + * g_lcg 1103515245 12345 2147483648
+    ^ / # f g_lcg 2147483648.0
+}
+
+// n_rows × n_cols matrix: a mild cluster plus a sprinkle of far outliers.
+@ make_matrix i n_rows i n_cols → ( Vec f ) {
+    : ( Vec f ) data ( vec_with_cap [f] * n_rows n_cols )
+    : ~ i r 0
+    ~ < r n_rows {
+        : ~ f base 0.0
+        ? == % r 97 0 { = base 40.0 } {}
+        : ~ i c 0
+        ~ < c n_cols {
+            ( vec_push [f] data + base * ( lcg_u01 ) 4.0 )
+            = c + c 1
+        }
+        = r + r 1
+    }
+    ^ data
+}
+
+@ main → i {
+    : s engine ( anom_gpu_engine )
+    ( nurl_print `gpu_test: engine = ` )
+    ( pline engine )
+    ? == ( nurl_str_eq engine `none` ) 1 {
+        ( pline `gpu_test: no accelerator available (no GPU, no C++ compiler) — pure path is authoritative, skipping` )
+        ( pline `gpu_test: 0 failed (skipped)` )
+        ^ 0
+    } {}
+
+    : i ROWS 5000
+    : i COLS 8
+    : ( Vec f ) data ( make_matrix ROWS COLS )
+    : Scaler sc ( scaler_fit data ROWS COLS )
+    ( scaler_apply_matrix sc data ROWS COLS )
+    : VerCfg cfg @ VerCfg { ( string_from `gpu` ) 0 0 300 256 -1.0 0.1 T }
+    : VerModel vm ( anom_train_version data ROWS COLS cfg )
+
+    // 1. Raw scores: forced accelerator vs the pure loop, every element ==.
+    : ( Vec f ) ref ( anom_scores_cpu vm data ROWS COLS )
+    : ?( Vec f ) accel ( anom_scores_gpu vm data ROWS COLS )
+    ?? accel {
+        T got → {
+            : ~ b same T
+            : ~ i n_diff 0
+            : *f a ( vec_data [f] ref )
+            : *f b2 ( vec_data [f] got )
+            : ~ i r 0
+            ~ < r ROWS {
+                ? == . a r . b2 r {} {
+                    = same F
+                    = n_diff + n_diff 1
+                }
+                = r + r 1
+            }
+            ( check same `gpu: 5000 scores BIT-IDENTICAL to the pure loop` )
+            ? same {} {
+                : String msg ( string_from `gpu: differing rows: ` )
+                ( string_push_int msg n_diff )
+                ( pline ( string_data msg ) )
+                ( string_free msg )
+            }
+            ( vec_free [f] got )
+        }
+        F _ → { ( check F `gpu: accelerated scoring runs` ) }
+    }
+
+    // 2. The auto path (>= threshold rows routes to the accelerator) must
+    //    give the same decisions as composing the pure pieces by hand.
+    : ( Vec f ) dfs ( anom_decisions vm data ROWS COLS )
+    : ~ b dsame T
+    : *f dp ( vec_data [f] dfs )
+    : *f rp ( vec_data [f] ref )
+    : ~ i r 0
+    ~ < r ROWS {
+        ? == . dp r - - 0.0 . rp r . vm offset {} { = dsame F }
+        = r + r 1
+    }
+    ( check dsame `gpu: auto-path decisions bit-identical` )
+    ( vec_free [f] dfs )
+    ( vec_free [f] ref )
+
+    // 3. Contamination percentile (trains through the accelerated scorer at
+    //    this size) must equal a training run with the accelerator off.
+    : VerCfg cfg2 @ VerCfg { ( string_from `gpu2` ) 0 0 100 256 0.05 0.0 T }
+    : VerModel vm_a ( anom_train_version data ROWS COLS cfg2 )
+    : ( Vec f ) ref2 ( anom_scores_cpu vm_a data ROWS COLS )
+    // offset from the pure path, recomputed by hand:
+    : ( Vec f ) ss ( vec_with_cap [f] ROWS )
+    : *f r2 ( vec_data [f] ref2 )
+    = r 0
+    ~ < r ROWS {
+        ( vec_push [f] ss - 0.0 . r2 r )
+        = r + r 1
+    }
+    ( sort_by [f] ss \ f a f b → i {
+        ? < a b { ^ -1 } {}
+        ? > a b { ^ 1 } {}
+        ^ 0
+    } )
+    : f want_off ( __an_percentile ss 0.05 )
+    ( check == . vm_a offset want_off `gpu: contamination offset bit-identical` )
+    ( vec_free [f] ss )
+    ( vec_free [f] ref2 )
+    ( anom_vermodel_free vm_a )
+    ( __an_vercfg_free cfg2 )
+
+    ( anom_vermodel_free vm )
+    ( __an_vercfg_free cfg )
+    ( scaler_free sc )
+    ( vec_free [f] data )
+    ( anom_gpu_close )
+
+    : String summary ( string_from `gpu_test: ` )
+    ( string_push_int summary g_pass )
+    ( string_push_str summary ` passed, ` )
+    ( string_push_int summary g_fail )
+    ( string_push_str summary ` failed` )
+    ( pline ( string_data summary ) )
+    ( string_free summary )
+    ? > g_fail 0 { ^ 1 } {}
+    ^ 0
+}

--- a/packages/anomaly/tests/model_test.nu
+++ b/packages/anomaly/tests/model_test.nu
@@ -8,6 +8,7 @@ $ `stdlib/std/float.nu`
 $ `stdlib/std/rng.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
+$ `src/score.nu`
 
 : ~ i g_pass 0
 : ~ i g_fail 0

--- a/packages/anomaly/tests/model_test.nu
+++ b/packages/anomaly/tests/model_test.nu
@@ -1,0 +1,168 @@
+// model_test.nu — M2 unit tests: version kernel over iforest, decision
+// conventions, contamination pinning, batch report parity, determinism.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/rng.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+
+@ pline s x → v {
+    ( nurl_print x )
+    ( nurl_print `\n` )
+}
+
+@ check b cond s label → v {
+    ? cond {
+        ( nurl_print `ok ` )
+        ( pline label )
+        = g_pass + g_pass 1
+    } {
+        ( nurl_print `FAIL ` )
+        ( pline label )
+        = g_fail + g_fail 1
+    }
+}
+
+// 200 2-D points near the origin + 8 far-away outliers (deterministic).
+// Outliers occupy the LAST 8 row indices (200..207).
+@ make_data → ( Vec f ) {
+    : Rng g ( rng_seed 7 )
+    : ( Vec f ) data ( vec_with_cap [f] 416 )
+    : ~ i k 0
+    ~ < k 200 {
+        ( vec_push [f] data - * ( rng_u01 g ) 2.0 1.0 )
+        ( vec_push [f] data - * ( rng_u01 g ) 2.0 1.0 )
+        = k + k 1
+    }
+    = k 0
+    ~ < k 8 {
+        ( vec_push [f] data + 8.0 ( rng_u01 g ) )
+        ( vec_push [f] data + 8.0 ( rng_u01 g ) )
+        = k + k 1
+    }
+    ( rng_free g )
+    ^ data
+}
+
+@ test_cfg f contamination f margin → VerCfg {
+    ^ @ VerCfg { ( string_from `test` ) 0 0 100 256 contamination margin T }
+}
+
+// ── Outlier separation, margin rule, report parity ────────────────────
+
+@ test_batch_outliers → v {
+    : ( Vec f ) data ( make_data )
+    : VerCfg cfg ( test_cfg -1.0 0.1 )
+    : BatchReport rep ( anomaly_batch data 208 2 cfg )
+
+    ( check == . rep total_rows 208 `batch: total_rows` )
+
+    // Every injected outlier (rows 200..207) must be flagged...
+    : ~ i outliers_hit 0
+    : i nh ( vec_len [i] . rep anomaly_indices )
+    : ~ i k 0
+    ~ < k nh {
+        ?? ( vec_get [i] . rep anomaly_indices k ) {
+            T idx → { ? >= idx 200 { = outliers_hit + outliers_hit 1 } {} }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( check == outliers_hit 8 `batch: all 8 injected outliers flagged` )
+    // ...with few false positives (allow < 5% of the normals).
+    ( check < - . rep anomaly_count 8 10 `batch: few false positives` )
+    ( check . rep has_anomalies `batch: has_anomalies` )
+
+    // anomaly_percentage = count / total * 100.
+    : f want / * # f . rep anomaly_count 100.0 208.0
+    ( check < ( float_abs - . rep anomaly_percentage want ) 0.000001 `batch: percentage parity` )
+
+    // Outlier scores are far more negative than a typical normal score.
+    : ~ f df_norm 0.0
+    ?? ( vec_get [f] . rep scores 0 ) { T x → { = df_norm x } F _ → {} }
+    : ~ f df_out 0.0
+    ?? ( vec_get [f] . rep scores 207 ) { T x → { = df_out x } F _ → {} }
+    ( check < df_out df_norm `batch: outlier df below normal df` )
+    ( check <= df_out -0.1 `batch: outlier crosses the margin` )
+
+    ( anomaly_report_free rep )
+    ( __an_vercfg_free cfg )
+    ( vec_free [f] data )
+}
+
+// ── Determinism: fixed seed ⇒ identical scores ────────────────────────
+
+@ test_determinism → v {
+    : ( Vec f ) data ( make_data )
+    : VerCfg cfg1 ( test_cfg -1.0 0.1 )
+    : VerCfg cfg2 ( test_cfg -1.0 0.1 )
+    : BatchReport r1 ( anomaly_batch data 208 2 cfg1 )
+    : BatchReport r2 ( anomaly_batch data 208 2 cfg2 )
+    : ~ b same T
+    : i n ( vec_len [f] . r1 scores )
+    ? == n ( vec_len [f] . r2 scores ) {} { = same F }
+    : *f a ( vec_data [f] . r1 scores )
+    : *f b2 ( vec_data [f] . r2 scores )
+    : ~ i k 0
+    ~ < k n {
+        ? == . a k . b2 k {} { = same F }
+        = k + k 1
+    }
+    ( check same `determinism: two trainings give byte-identical scores` )
+    ( anomaly_report_free r1 )
+    ( anomaly_report_free r2 )
+    ( __an_vercfg_free cfg1 )
+    ( __an_vercfg_free cfg2 )
+    ( vec_free [f] data )
+}
+
+// ── Contamination pinning ─────────────────────────────────────────────
+//
+// With contamination = c and margin = 0, offset_ sits at the 100*c
+// percentile of training score_samples, so ~c of the training rows come
+// out with decision_function < 0.
+
+@ test_contamination → v {
+    : ( Vec f ) data ( make_data )
+    : VerCfg cfg ( test_cfg 0.05 0.0 )
+    : BatchReport rep ( anomaly_batch data 208 2 cfg )
+    // 5% of 208 ≈ 10.4 — allow slack for score ties around the cut.
+    ( check >= . rep anomaly_count 6 `contamination: >= 6 of 208 flagged` )
+    ( check <= . rep anomaly_count 16 `contamination: <= 16 of 208 flagged` )
+    ( anomaly_report_free rep )
+    ( __an_vercfg_free cfg )
+    ( vec_free [f] data )
+
+    // auto ⇒ offset pinned at exactly -0.5.
+    : ( Vec f ) data2 ( make_data )
+    : VerCfg cfg2 ( test_cfg -1.0 0.0 )
+    : Scaler sc ( scaler_fit data2 208 2 )
+    ( scaler_apply_matrix sc data2 208 2 )
+    : VerModel vm ( anom_train_version data2 208 2 cfg2 )
+    ( check == . vm offset -0.5 `contamination: auto offset = -0.5` )
+    ( anom_vermodel_free vm )
+    ( __an_vercfg_free cfg2 )
+    ( scaler_free sc )
+    ( vec_free [f] data2 )
+}
+
+@ main → i {
+    ( test_batch_outliers )
+    ( test_determinism )
+    ( test_contamination )
+    : String summary ( string_from `model_test: ` )
+    ( string_push_int summary g_pass )
+    ( string_push_str summary ` passed, ` )
+    ( string_push_int summary g_fail )
+    ( string_push_str summary ` failed` )
+    ( pline ( string_data summary ) )
+    ( string_free summary )
+    ? > g_fail 0 { ^ 1 } {}
+    ^ 0
+}

--- a/packages/anomaly/tests/prep_test.nu
+++ b/packages/anomaly/tests/prep_test.nu
@@ -1,0 +1,329 @@
+// prep_test.nu — M1 unit tests: preprocessing, projection, scaler,
+// metadata JSON round-trip. Prints one `ok`/`FAIL` line per check and
+// exits non-zero if anything failed. Run via tests/anomaly_test.sh.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/ext/json.nu`
+$ `src/prep.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+
+@ pline s x → v {
+    ( nurl_print x )
+    ( nurl_print `\n` )
+}
+
+@ check b cond s label → v {
+    ? cond {
+        ( nurl_print `ok ` )
+        ( pline label )
+        = g_pass + g_pass 1
+    } {
+        ( nurl_print `FAIL ` )
+        ( pline label )
+        = g_fail + g_fail 1
+    }
+}
+
+@ feq f a f b → b {
+    ^ < ( float_abs - a b ) 0.000000001
+}
+
+// Value of feature `name` in an encoded point, or NaN-ish sentinel.
+@ enc_val EncPoint p s name → f {
+    : i at ( enc_find p name )
+    ? < at 0 { ^ -999999.0 } {}
+    ?? ( vec_get [f] . p vals at ) { T x → { ^ x } F _ → { ^ -999999.0 } }
+}
+
+// Name of feature k in a ( Vec String ), as borrowed data (test-only).
+@ feat_eq ( Vec String ) fs i k s want → b {
+    ?? ( vec_get [String] fs k ) {
+        T x → { ^ == ( nurl_str_eq ( string_data x ) want ) 1 }
+        F _ → { ^ F }
+    }
+}
+
+// ── 1. Golden mixed-type record ───────────────────────────────────────
+
+@ test_golden → v {
+    : *Meta m ( meta_new `t1` `2026-07-03T00:00:00Z` )
+    : !Json JsonError r ( json_parse `{"temp": 21.5, "status": "ok", "when": "2026-07-03T12:34:56Z", "timestamp": "2026-07-03T12:00:00Z"}` )
+    ?? r {
+        T j → {
+            : !EncPoint String er ( anomaly_preprocess m j )
+            ?? er {
+                T p → {
+                    ( check == ( vec_len [f] . p vals ) 6 `golden: 6 features (timestamp key skipped)` )
+                    ( check ( feq ( enc_val p `temp` ) 21.5 ) `golden: numeric passthrough` )
+                    ( check ( feq ( enc_val p `status_ok` ) 1.0 ) `golden: one-hot fires` )
+                    ( check ( feq ( enc_val p `when_hour` ) 12.0 ) `golden: hour` )
+                    ( check ( feq ( enc_val p `when_day` ) 3.0 ) `golden: day` )
+                    ( check ( feq ( enc_val p `when_month` ) 7.0 ) `golden: month` )
+                    ( check ( feq ( enc_val p `when_weekday` ) 4.0 ) `golden: weekday (Fri=4, Python convention)` )
+                    ( enc_free p )
+                }
+                F e → {
+                    ( nurl_eprint `preprocess error: ` )
+                    ( nurl_eprintln ( string_data e ) )
+                    ( string_free e )
+                    ( check F `golden: preprocess succeeds` )
+                }
+            }
+            // Derived feature order: cols first-seen, canonical expansion.
+            : ( Vec String ) fs ( meta_derived_feats m )
+            ( check == ( vec_len [String] fs ) 6 `golden: derived feature count` )
+            ( check ( feat_eq fs 0 `temp` ) `golden: feat[0] temp` )
+            ( check ( feat_eq fs 1 `status_ok` ) `golden: feat[1] status_ok` )
+            ( check ( feat_eq fs 2 `when_hour` ) `golden: feat[2] when_hour` )
+            ( vec_free_with [String] fs \ String x → v { ( string_free x ) } )
+            ( json_free j )
+        }
+        F _ → { ( check F `golden: test json parses` ) }
+    }
+    ( meta_free m )
+}
+
+// ── 2. Category growth is deterministic and sorted ────────────────────
+
+@ test_categories → v {
+    : *Meta m ( meta_new `t2` `2026-07-03T00:00:00Z` )
+    : !Json JsonError r1 ( json_parse `{"status": "warn"}` )
+    : !Json JsonError r2 ( json_parse `{"status": "alert"}` )
+    ?? r1 {
+        T j1 → {
+            : !EncPoint String e1 ( anomaly_preprocess m j1 )
+            ?? e1 { T p → { ( enc_free p ) } F e → { ( string_free e ) } }
+            ( json_free j1 )
+        }
+        F _ → {}
+    }
+    ?? r2 {
+        T j2 → {
+            : !EncPoint String e2 ( anomaly_preprocess m j2 )
+            ?? e2 {
+                T p → {
+                    // Both categories known now; "alert" is hot.
+                    ( check ( feq ( enc_val p `status_alert` ) 1.0 ) `cats: new category hot` )
+                    ( check ( feq ( enc_val p `status_warn` ) 0.0 ) `cats: old category cold` )
+                    ( enc_free p )
+                }
+                F e → { ( string_free e ) ( check F `cats: preprocess succeeds` ) }
+            }
+            ( json_free j2 )
+        }
+        F _ → {}
+    }
+    // Sorted order: alert before warn regardless of arrival order.
+    : ( Vec String ) fs ( meta_derived_feats m )
+    ( check ( feat_eq fs 0 `status_alert` ) `cats: sorted feat[0] status_alert` )
+    ( check ( feat_eq fs 1 `status_warn` ) `cats: sorted feat[1] status_warn` )
+    ( vec_free_with [String] fs \ String x → v { ( string_free x ) } )
+    ( meta_free m )
+}
+
+// ── 3. Frozen projection: stability rule ──────────────────────────────
+
+@ test_projection → v {
+    : *Meta m ( meta_new `t3` `2026-07-03T00:00:00Z` )
+    : !Json JsonError r1 ( json_parse `{"a": 1, "status": "ok"}` )
+    ?? r1 {
+        T j1 → {
+            : !EncPoint String e1 ( anomaly_preprocess m j1 )
+            ?? e1 { T p → { ( enc_free p ) } F e → { ( string_free e ) } }
+            ( json_free j1 )
+        }
+        F _ → {}
+    }
+    ( meta_refresh_feats m )
+    ( check ( meta_is_frozen m ) `proj: frozen after refresh` )
+    : i nfroz ( vec_len [String] . m feats )
+    ( check == nfroz 2 `proj: frozen order has 2 features` )
+
+    // A later point brings a new column and a new category: the projected
+    // vector must keep exactly the frozen shape (extras dropped, missing 0).
+    : !Json JsonError r2 ( json_parse `{"status": "zzz", "extra": 9.0}` )
+    ?? r2 {
+        T j2 → {
+            : !EncPoint String e2 ( anomaly_preprocess m j2 )
+            ?? e2 {
+                T p → {
+                    : ( Vec f ) x ( anomaly_project p . m feats )
+                    ( check == ( vec_len [f] x ) 2 `proj: projected length = frozen length` )
+                    ?? ( vec_get [f] x 0 ) { T v0 → { ( check ( feq v0 0.0 ) `proj: missing numeric = 0` ) } F _ → {} }
+                    ?? ( vec_get [f] x 1 ) { T v1 → { ( check ( feq v1 0.0 ) `proj: unseen category = all-zero one-hot` ) } F _ → {} }
+                    ( vec_free [f] x )
+                    ( enc_free p )
+                }
+                F e → { ( string_free e ) ( check F `proj: preprocess succeeds` ) }
+            }
+            ( json_free j2 )
+        }
+        F _ → {}
+    }
+    // Metadata itself kept learning (new col + category recorded for the
+    // next retrain), even though the frozen order didn't move.
+    : ( Vec String ) fs ( meta_derived_feats m )
+    ( check == ( vec_len [String] fs ) 4 `proj: metadata still learns (4 derived feats)` )
+    ( vec_free_with [String] fs \ String x → v { ( string_free x ) } )
+    ( meta_free m )
+}
+
+// ── 4. Numeric parse failure is a hard error ──────────────────────────
+
+@ test_numeric_error → v {
+    : *Meta m ( meta_new `t4` `2026-07-03T00:00:00Z` )
+    : !Json JsonError r1 ( json_parse `{"temp": 1.0}` )
+    ?? r1 {
+        T j1 → {
+            : !EncPoint String e1 ( anomaly_preprocess m j1 )
+            ?? e1 { T p → { ( enc_free p ) } F e → { ( string_free e ) } }
+            ( json_free j1 )
+        }
+        F _ → {}
+    }
+    : !Json JsonError r2 ( json_parse `{"temp": "abc"}` )
+    ?? r2 {
+        T j2 → {
+            : !EncPoint String e2 ( anomaly_preprocess m j2 )
+            ?? e2 {
+                T p → { ( enc_free p ) ( check F `numerr: bad value rejected` ) }
+                F e → {
+                    : ?i at ( string_index_of e `must be a numeric value` )
+                    ?? at { T _ → { ( check T `numerr: bad value rejected` ) } F _ → { ( check F `numerr: message names the rule` ) } }
+                    ( string_free e )
+                }
+            }
+            ( json_free j2 )
+        }
+        F _ → {}
+    }
+    ( meta_free m )
+}
+
+// ── 5. Scaler: fit / apply / inverse / zero-variance ──────────────────
+
+@ test_scaler → v {
+    // 3 rows × 2 cols; col0 = 1,2,3 (varies), col1 = 5,5,5 (constant).
+    : ( Vec f ) data ( vec_new [f] )
+    ( vec_push [f] data 1.0 ) ( vec_push [f] data 5.0 )
+    ( vec_push [f] data 2.0 ) ( vec_push [f] data 5.0 )
+    ( vec_push [f] data 3.0 ) ( vec_push [f] data 5.0 )
+    : Scaler sc ( scaler_fit data 3 2 )
+
+    ?? ( vec_get [f] . sc mean 0 ) { T mu → { ( check ( feq mu 2.0 ) `scaler: mean` ) } F _ → {} }
+    ?? ( vec_get [f] . sc inv_std 1 ) { T iv → { ( check ( feq iv 1.0 ) `scaler: zero-variance inv_std = 1` ) } F _ → {} }
+
+    : ( Vec f ) pt ( vec_new [f] )
+    ( vec_push [f] pt 3.0 ) ( vec_push [f] pt 5.0 )
+    ( scaler_apply sc pt )
+    // population std of {1,2,3} = sqrt(2/3); (3-2)/sqrt(2/3) = sqrt(1.5)
+    ?? ( vec_get [f] pt 0 ) { T y0 → { ( check ( feq y0 ( float_sqrt 1.5 ) ) `scaler: standardises` ) } F _ → {} }
+    ?? ( vec_get [f] pt 1 ) { T y1 → { ( check ( feq y1 0.0 ) `scaler: constant col centres to 0` ) } F _ → {} }
+
+    // Inverse identity: x = y/inv + mean.
+    ?? ( vec_get [f] pt 0 ) {
+        T y0 → {
+            ?? ( vec_get [f] . sc inv_std 0 ) {
+                T iv0 → {
+                    ?? ( vec_get [f] . sc mean 0 ) {
+                        T mu0 → { ( check ( feq + / y0 iv0 mu0 3.0 ) `scaler: inverse identity` ) }
+                        F _ → {}
+                    }
+                }
+                F _ → {}
+            }
+        }
+        F _ → {}
+    }
+    ( vec_free [f] pt )
+    ( vec_free [f] data )
+
+    // Round-trip through metadata (mean/std persisted, rebuilt as inv_std).
+    : *Meta m ( meta_new `t5` `2026-07-03T00:00:00Z` )
+    ( meta_set_scaler m sc )
+    : Scaler sc2 ( meta_scaler m )
+    ?? ( vec_get [f] . sc inv_std 0 ) {
+        T a0 → {
+            ?? ( vec_get [f] . sc2 inv_std 0 ) {
+                T b0 → { ( check ( feq a0 b0 ) `scaler: survives metadata round-trip` ) }
+                F _ → {}
+            }
+        }
+        F _ → {}
+    }
+    ( scaler_free sc2 )
+    ( scaler_free sc )
+    ( meta_free m )
+}
+
+// ── 6. Metadata JSON round-trip is byte-stable ────────────────────────
+
+@ test_meta_roundtrip → v {
+    : *Meta m ( meta_new `t6` `2026-07-03T00:00:00Z` )
+    : !Json JsonError r1 ( json_parse `{"temp": 21.5, "status": "ok", "when": "2026-07-03T12:34:56Z"}` )
+    ?? r1 {
+        T j1 → {
+            : !EncPoint String e1 ( anomaly_preprocess m j1 )
+            ?? e1 { T p → { ( enc_free p ) } F e → { ( string_free e ) } }
+            ( json_free j1 )
+        }
+        F _ → {}
+    }
+    ( meta_refresh_feats m )
+    : ( Vec f ) data ( vec_new [f] )
+    ( vec_push [f] data 1.0 ) ( vec_push [f] data 2.0 )
+    ( vec_push [f] data 3.0 ) ( vec_push [f] data 4.0 )
+    : Scaler sc ( scaler_fit data 2 2 )
+    ( meta_set_scaler m sc )
+    ( scaler_free sc )
+    ( vec_free [f] data )
+    = . m n_seen 123
+    = . m last_trained 100
+
+    : String s1 ( meta_to_json_str m )
+    : ?*Meta m2o ( meta_from_json_str ( string_data s1 ) )
+    ?? m2o {
+        T m2 → {
+            : String s2 ( meta_to_json_str m2 )
+            ( check ( string_eq s1 s2 ) `meta: JSON round-trip byte-stable` )
+            ( check == . m2 n_seen 123 `meta: n_points_seen survives` )
+            ( check == . m2 sched_below 50 `meta: schedule default survives` )
+            ( check == ( vec_len [VerCfg] . m2 versions ) 5 `meta: 5 default versions survive` )
+            ( check == ( vec_len [String] . m2 feats ) 6 `meta: feature order survives` )
+            ( string_free s2 )
+            ( meta_free m2 )
+        }
+        F _ → { ( check F `meta: JSON parses back` ) }
+    }
+    ( string_free s1 )
+
+    // Corrupt / partial input is rejected cleanly, never UB.
+    : ?*Meta bad1 ( meta_from_json_str `{"name": 7}` )
+    ?? bad1 { T mb → { ( meta_free mb ) ( check F `meta: mistyped name rejected` ) } F _ → { ( check T `meta: mistyped name rejected` ) } }
+    : ?*Meta bad2 ( meta_from_json_str `not json at all` )
+    ?? bad2 { T mb → { ( meta_free mb ) ( check F `meta: garbage rejected` ) } F _ → { ( check T `meta: garbage rejected` ) } }
+    ( meta_free m )
+}
+
+@ main → i {
+    ( test_golden )
+    ( test_categories )
+    ( test_projection )
+    ( test_numeric_error )
+    ( test_scaler )
+    ( test_meta_roundtrip )
+    : String summary ( string_from `prep_test: ` )
+    ( string_push_int summary g_pass )
+    ( string_push_str summary ` passed, ` )
+    ( string_push_int summary g_fail )
+    ( string_push_str summary ` failed` )
+    ( pline ( string_data summary ) )
+    ( string_free summary )
+    ? > g_fail 0 { ^ 1 } {}
+    ^ 0
+}

--- a/packages/anomaly/tests/service_test.nu
+++ b/packages/anomaly/tests/service_test.nu
@@ -1,0 +1,305 @@
+// service_test.nu — M6 tests: every HTTP route golden-tested through
+// router_handle, no sockets involved. Store: $ANOMALY_TEST_DIR (default
+// ./anomaly_svc_test).
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_router.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/store.nu`
+$ `src/dynamic.nu`
+$ `src/csvdata.nu`
+$ `src/service.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+
+@ pline s x → v {
+    ( nurl_print x )
+    ( nurl_print `\n` )
+}
+
+@ check b cond s label → v {
+    ? cond {
+        ( nurl_print `ok ` )
+        ( pline label )
+        = g_pass + g_pass 1
+    } {
+        ( nurl_print `FAIL ` )
+        ( pline label )
+        = g_fail + g_fail 1
+    }
+}
+
+@ mk_req s method s path s query s body → HttpRequest {
+    ^ @ HttpRequest {
+        ( string_from method )
+        ( string_from path )
+        ( string_from query )
+        ( string_from `HTTP/1.1` )
+        ( vec_new [Header] )
+        ( bytes_from_str body )
+    }
+}
+
+// Fire one request; returns (status, parsed body Json or JNull).
+: SvcOut {
+    i status
+    Json body
+}
+
+@ fire Router r s method s path s query s body → SvcOut {
+    : HttpRequest req ( mk_req method path query body )
+    : HttpResponse resp ( router_handle r req )
+    : i status . resp status
+    : String txt ( bytes_to_str . resp body )
+    : ~ Json parsed ( json_null )
+    : !Json JsonError jr ( json_parse ( string_data txt ) )
+    ?? jr {
+        T j → { ( json_free parsed ) = parsed j }
+        F _ → {}
+    }
+    ( string_free txt )
+    ( http_response_free resp )
+    ( request_free req )
+    ^ @ SvcOut { status parsed }
+}
+
+// String field of a JSON object equals `want`.
+@ jstr_eq Json o s key s want → b {
+    ?? ( json_obj_get o key ) {
+        T e → { ^ == ( nurl_str_eq ( json_str_data e ) want ) 1 }
+        F _ → { ^ F }
+    }
+}
+
+@ jint_of Json o s key → i {
+    ?? ( json_obj_get o key ) {
+        T e → { ^ ( json_as_int e ) }
+        F _ → { ^ -1 }
+    }
+}
+
+@ jbool_of Json o s key → b {
+    ?? ( json_obj_get o key ) {
+        T e → { ^ ( json_as_bool e ) }
+        F _ → { ^ F }
+    }
+}
+
+@ main → i {
+    : ~ String root ( string_from `./anomaly_svc_test` )
+    ?? ( env_get `ANOMALY_TEST_DIR` ) {
+        T d → { ( string_free root ) = root d }
+        F _ → {}
+    }
+    : !v IoErr junk ( dir_remove_all ( string_data root ) )
+    ?? junk { T _ → {} F _ → {} }
+    ( anomaly_service_set_root ( string_data root ) )
+    : Router r ( anomaly_service_router )
+
+    // Invalid model name.
+    : SvcOut bad ( fire r `POST` `/detect/bad!name` `` `{"temp": 1}` )
+    ( check == . bad status 400 `svc: invalid name -> 400` )
+    ( check ( jstr_eq . bad body `status` `error` ) `svc: invalid name error body` )
+    ( json_free . bad body )
+
+    // First point: create-on-first-use + warming up (202).
+    : SvcOut first ( fire r `POST` `/detect/svc` `` `{"temp": 20.5}` )
+    ( check == . first status 202 `svc: first point -> 202 collecting` )
+    ( check ( jstr_eq . first body `status` `collecting` ) `svc: collecting status` )
+    ( check == ( jint_of . first body `data_points` ) 1 `svc: data_points 1` )
+    ( json_free . first body )
+
+    // 49 more points → trained, 200 success.
+    : ~ i k 2
+    : ~ i last_status 0
+    : ~ Json last_body ( json_null )
+    ~ <= k 50 {
+        : String body ( string_from `{"temp": 2` )
+        ( string_push_int body % k 10 )
+        ( string_push_str body `.5}` )
+        : SvcOut o ( fire r `POST` `/detect/svc` `` ( string_data body ) )
+        ( string_free body )
+        = last_status . o status
+        ( json_free last_body )
+        = last_body . o body
+        = k + k 1
+    }
+    ( check == last_status 200 `svc: point 50 -> 200 (trained)` )
+    ( check ( jstr_eq last_body `status` `success` ) `svc: success status` )
+    // (whether a quantized-grid point trips the tight default margins is
+    // small-sample statistics, covered by dynamic_test — here we only pin
+    // the response SHAPE)
+    : ~ b has_anomaly_field F
+    ?? ( json_obj_get last_body `anomaly` ) {
+        T e → { = has_anomaly_field ( json_is_bool e ) }
+        F _ → {}
+    }
+    ( check has_anomaly_field `svc: anomaly field present and boolean` )
+    : ~ b has_versions F
+    ?? ( json_obj_get last_body `versions` ) {
+        T vers → {
+            ?? ( json_obj_get vers `short_term` ) { T _ → { = has_versions T } F _ → {} }
+        }
+        F _ → {}
+    }
+    ( check has_versions `svc: per-version breakdown present` )
+    ( json_free last_body )
+
+    // detect_only: missing model 404; outlier flagged; garbage 400.
+    : SvcOut miss ( fire r `POST` `/detect_only/nosuch` `` `{"temp": 1}` )
+    ( check == . miss status 404 `svc: detect_only missing -> 404` )
+    ( json_free . miss body )
+    : SvcOut outl ( fire r `POST` `/detect_only/svc` `` `{"temp": 99}` )
+    ( check == . outl status 200 `svc: detect_only -> 200` )
+    ( check ( jbool_of . outl body `anomaly` ) `svc: outlier flagged` )
+    ( json_free . outl body )
+    : SvcOut garb ( fire r `POST` `/detect_only/svc` `` `not json` )
+    ( check == . garb status 400 `svc: garbage body -> 400` )
+    ( json_free . garb body )
+
+    // Listing + metadata + data.
+    : SvcOut lst ( fire r `GET` `/models/dynamic` `` `` )
+    ( check == . lst status 200 `svc: models list -> 200` )
+    : ~ b has_svc F
+    ?? ( json_obj_get . lst body `models` ) {
+        T ms → {
+            ?? ( json_obj_get ms `svc` ) { T _ → { = has_svc T } F _ → {} }
+        }
+        F _ → {}
+    }
+    ( check has_svc `svc: model in listing` )
+    ( check == ( jint_of . lst body `min_data_points` ) 50 `svc: listing min_data_points` )
+    ( json_free . lst body )
+
+    : SvcOut md ( fire r `GET` `/models/dynamic/svc/metadata` `` `` )
+    ( check == . md status 200 `svc: metadata -> 200` )
+    ( check ( jstr_eq . md body `model_name` `svc` ) `svc: metadata carries model_name` )
+    ( json_free . md body )
+    : SvcOut md4 ( fire r `GET` `/models/dynamic/nosuch/metadata` `` `` )
+    ( check == . md4 status 404 `svc: metadata missing -> 404` )
+    ( json_free . md4 body )
+
+    : SvcOut data ( fire r `GET` `/models/dynamic/svc/data` `limit=5` `` )
+    ( check == . data status 200 `svc: data -> 200` )
+    ( check == ( jint_of . data body `data_points_count` ) 50 `svc: data total count` )
+    : ~ i arr_len -1
+    ?? ( json_obj_get . data body `data` ) {
+        T arr → { = arr_len ( json_arr_len arr ) }
+        F _ → {}
+    }
+    ( check == arr_len 5 `svc: data respects limit` )
+    ( json_free . data body )
+
+    // Schedule.
+    : SvcOut sch ( fire r `PUT` `/api/dynamic/svc/schedule` `` `{"below_max_retrain_frequency": 25}` )
+    ( check == . sch status 200 `svc: schedule update -> 200` )
+    : ~ i below -1
+    ?? ( json_obj_get . sch body `training_schedule` ) {
+        T ts → { = below ( jint_of ts `below_max` ) }
+        F _ → {}
+    }
+    ( check == below 25 `svc: schedule below_max updated` )
+    ( json_free . sch body )
+    : SvcOut sch2 ( fire r `PUT` `/api/dynamic/svc/schedule` `` `{}` )
+    ( check == . sch2 status 400 `svc: empty schedule -> 400` )
+    ( json_free . sch2 body )
+
+    // Fine-tune.
+    : SvcOut ft ( fire r `POST` `/api/dynamic/svc/finetune` `` `{}` )
+    ( check == . ft status 200 `svc: finetune -> 200` )
+    : ~ b has_margin F
+    ?? ( json_obj_get . ft body `adjusted_margins` ) {
+        T ms → {
+            ?? ( json_obj_get ms `short_term` ) { T _ → { = has_margin T } F _ → {} }
+        }
+        F _ → {}
+    }
+    ( check has_margin `svc: finetune returns adjusted margins` )
+    ( json_free . ft body )
+
+    // Force train.
+    : SvcOut tr ( fire r `POST` `/force_train/svc` `` `` )
+    ( check == . tr status 200 `svc: force_train -> 200` )
+    ( check == ( jint_of . tr body `points_used` ) 50 `svc: force_train points_used` )
+    ( json_free . tr body )
+
+    // Batch CSV.
+    : String csv ( string_from `a,b\n1,2\n1.1,2.1\n0.9,1.9\n50,50\n1,2\n1,2.2\n` )
+    : String csvpath ( string_from ( string_data root ) )
+    ( string_push_str csvpath `/batch.csv` )
+    : !v IoErr wr ( write_file ( string_data csvpath ) ( string_data csv ) )
+    ?? wr { T _ → {} F _ → {} }
+    ( string_free csv )
+    : String breq ( string_from `{"file_path": "` )
+    ( string_push_str breq ( string_data csvpath ) )
+    ( string_push_str breq `", "has_header": true}` )
+    : SvcOut bat ( fire r `POST` `/detect_anomalies` `` ( string_data breq ) )
+    ( string_free breq )
+    ( check == . bat status 200 `svc: detect_anomalies -> 200` )
+    : ~ i bcount -1
+    : ~ b bhas F
+    : ~ i bidx -1
+    ?? ( json_obj_get . bat body `result` ) {
+        T res → {
+            = bcount ( jint_of res `anomaly_count` )
+            = bhas ( jbool_of res `has_anomalies` )
+            ?? ( json_obj_get res `anomaly_indices` ) {
+                T idxs → {
+                    ?? ( json_arr_get idxs 0 ) { T e → { = bidx ( json_as_int e ) } F _ → {} }
+                }
+                F _ → {}
+            }
+        }
+        F _ → {}
+    }
+    ( check == bcount 1 `svc: batch flags exactly the outlier row` )
+    ( check bhas `svc: batch has_anomalies` )
+    ( check == bidx 3 `svc: batch anomaly index 3` )
+    ( json_free . bat body )
+    : SvcOut batm ( fire r `POST` `/detect_anomalies` `` `{"file_path": "x.csv", "model_name": "svc"}` )
+    ( check == . batm status 400 `svc: batch model_name rejected` )
+    ( json_free . batm body )
+    ( string_free csvpath )
+
+    // Reset → not trained → detect_only 400.
+    : SvcOut rs ( fire r `POST` `/models/dynamic/svc/reset` `` `{}` )
+    ( check == . rs status 200 `svc: reset -> 200` )
+    ( json_free . rs body )
+    : SvcOut nt ( fire r `POST` `/detect_only/svc` `` `{"temp": 1}` )
+    ( check == . nt status 400 `svc: detect_only after reset -> 400 (not trained)` )
+    ( json_free . nt body )
+
+    // Delete (both verbs), then gone.
+    : SvcOut del ( fire r `DELETE` `/delete_model/svc` `` `` )
+    ( check == . del status 200 `svc: delete -> 200` )
+    ( json_free . del body )
+    : SvcOut md5 ( fire r `GET` `/models/dynamic/svc/metadata` `` `` )
+    ( check == . md5 status 404 `svc: deleted model metadata -> 404` )
+    ( json_free . md5 body )
+
+    ( router_free r )
+    : !v IoErr fin ( dir_remove_all ( string_data root ) )
+    ?? fin { T _ → {} F _ → {} }
+    ( string_free root )
+
+    : String summary ( string_from `service_test: ` )
+    ( string_push_int summary g_pass )
+    ( string_push_str summary ` passed, ` )
+    ( string_push_int summary g_fail )
+    ( string_push_str summary ` failed` )
+    ( pline ( string_data summary ) )
+    ( string_free summary )
+    ? > g_fail 0 { ^ 1 } {}
+    ^ 0
+}

--- a/packages/anomaly/tests/service_test.nu
+++ b/packages/anomaly/tests/service_test.nu
@@ -15,6 +15,7 @@ $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_router.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
+$ `src/score.nu`
 $ `src/store.nu`
 $ `src/dynamic.nu`
 $ `src/csvdata.nu`

--- a/packages/anomaly/tests/store_test.nu
+++ b/packages/anomaly/tests/store_test.nu
@@ -11,6 +11,7 @@ $ `stdlib/std/fs.nu`
 $ `stdlib/ext/env.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
+$ `src/score.nu`
 $ `src/store.nu`
 
 : ~ i g_pass 0

--- a/packages/anomaly/tests/store_test.nu
+++ b/packages/anomaly/tests/store_test.nu
@@ -1,0 +1,286 @@
+// store_test.nu — M3 unit tests: forest blob round-trip (bit-exact scores),
+// file store save/load/list/delete, corrupt/truncated blob rejection.
+// Uses the directory in $ANOMALY_TEST_DIR (default ./anomaly_store_test).
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/rng.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/store.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+
+@ pline s x → v {
+    ( nurl_print x )
+    ( nurl_print `\n` )
+}
+
+@ check b cond s label → v {
+    ? cond {
+        ( nurl_print `ok ` )
+        ( pline label )
+        = g_pass + g_pass 1
+    } {
+        ( nurl_print `FAIL ` )
+        ( pline label )
+        = g_fail + g_fail 1
+    }
+}
+
+@ make_data → ( Vec f ) {
+    : Rng g ( rng_seed 7 )
+    : ( Vec f ) data ( vec_with_cap [f] 416 )
+    : ~ i k 0
+    ~ < k 200 {
+        ( vec_push [f] data - * ( rng_u01 g ) 2.0 1.0 )
+        ( vec_push [f] data - * ( rng_u01 g ) 2.0 1.0 )
+        = k + k 1
+    }
+    = k 0
+    ~ < k 8 {
+        ( vec_push [f] data + 8.0 ( rng_u01 g ) )
+        ( vec_push [f] data + 8.0 ( rng_u01 g ) )
+        = k + k 1
+    }
+    ( rng_free g )
+    ^ data
+}
+
+@ train_one ( Vec f ) scaled → VerModel {
+    : VerCfg cfg @ VerCfg { ( string_from `short_term` ) 180 0 100 256 -1.0 0.1 T }
+    : VerModel vm ( anom_train_version scaled 208 2 cfg )
+    ( __an_vercfg_free cfg )
+    ^ vm
+}
+
+// ── 1. Blob round-trip is bit-exact ───────────────────────────────────
+
+@ test_blob_roundtrip → v {
+    : ( Vec f ) data ( make_data )
+    : Scaler sc ( scaler_fit data 208 2 )
+    ( scaler_apply_matrix sc data 208 2 )
+    : VerModel vm ( train_one data )
+
+    : ( Vec u ) blob ( vermodel_to_bytes vm )
+    ( check > ( vec_len [u] blob ) 64 `blob: non-trivial size` )
+    : ?VerModel back ( vermodel_from_bytes blob )
+    ?? back {
+        T vm2 → {
+            ( check == ( nurl_str_eq ( string_data . vm2 vname ) `short_term` ) 1 `blob: vname survives` )
+            ( check == . vm2 offset . vm offset `blob: offset bit-exact` )
+            ( check == . vm2 margin . vm margin `blob: margin bit-exact` )
+            // Every row scores bit-identically through the reloaded forest.
+            : ~ b same T
+            : ~ i r 0
+            ~ < r 208 {
+                ? == ( anom_decision_row vm data r ) ( anom_decision_row vm2 data r ) {} { = same F }
+                = r + r 1
+            }
+            ( check same `blob: all 208 scores bit-exact after reload` )
+            ( anom_vermodel_free vm2 )
+        }
+        F _ → { ( check F `blob: parses back` ) }
+    }
+    ( vec_free [u] blob )
+    ( anom_vermodel_free vm )
+    ( scaler_free sc )
+    ( vec_free [f] data )
+}
+
+// ── 2. Corrupt / truncated blobs are rejected cleanly ─────────────────
+
+@ test_blob_corruption → v {
+    : ( Vec f ) data ( make_data )
+    : Scaler sc ( scaler_fit data 208 2 )
+    ( scaler_apply_matrix sc data 208 2 )
+    : VerModel vm ( train_one data )
+    : ( Vec u ) blob ( vermodel_to_bytes vm )
+    : i blen ( vec_len [u] blob )
+
+    // Truncations at assorted depths (header, name, arrays, last byte).
+    : ~ i rejected 0
+    : ~ i tried 0
+    : ( Vec i ) cuts ( vec_new [i] )
+    ( vec_push [i] cuts 0 )
+    ( vec_push [i] cuts 4 )
+    ( vec_push [i] cuts 9 )
+    ( vec_push [i] cuts 40 )
+    ( vec_push [i] cuts / blen 2 )
+    ( vec_push [i] cuts - blen 1 )
+    : ~ i k 0
+    ~ < k ( vec_len [i] cuts ) {
+        ?? ( vec_get [i] cuts k ) {
+            T cut → {
+                : ( Vec u ) part ( bytes_slice blob 0 cut )
+                = tried + tried 1
+                : ?VerModel r ( vermodel_from_bytes part )
+                ?? r { T bad → { ( anom_vermodel_free bad ) } F _ → { = rejected + rejected 1 } }
+                ( vec_free [u] part )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( check == rejected tried `corrupt: every truncation rejected` )
+    ( vec_free [i] cuts )
+
+    // Flip one byte inside the node arrays: must be rejected (index check)
+    // — flip a root index high byte to shoot it out of range.
+    : ( Vec u ) mut ( vec_clone [u] blob )
+    // roots array starts at 8 (magic) + 8 (len) + 10 (name) + 16 + 32 = 74;
+    // +8 count prefix, second-highest byte of root[0]:
+    : i at + 74 14
+    ?? ( vec_get [u] mut at ) {
+        T old → { ( vec_set [u] mut at # u 255 ) }
+        F _ → {}
+    }
+    : ?VerModel r2 ( vermodel_from_bytes mut )
+    ?? r2 { T bad → { ( anom_vermodel_free bad ) ( check F `corrupt: out-of-range index rejected` ) } F _ → { ( check T `corrupt: out-of-range index rejected` ) } }
+    ( vec_free [u] mut )
+
+    // Trailing garbage after a valid body: rejected.
+    : ( Vec u ) padded ( vec_clone [u] blob )
+    ( vec_push [u] padded # u 0 )
+    : ?VerModel r3 ( vermodel_from_bytes padded )
+    ?? r3 { T bad → { ( anom_vermodel_free bad ) ( check F `corrupt: trailing garbage rejected` ) } F _ → { ( check T `corrupt: trailing garbage rejected` ) } }
+    ( vec_free [u] padded )
+
+    ( vec_free [u] blob )
+    ( anom_vermodel_free vm )
+    ( scaler_free sc )
+    ( vec_free [f] data )
+}
+
+// ── 3. File store: save / load / exists / list / delete ──────────────
+
+@ test_store → v {
+    : ~ String root ( string_from `./anomaly_store_test` )
+    ?? ( env_get `ANOMALY_TEST_DIR` ) {
+        T d → { ( string_free root ) = root d }
+        F _ → {}
+    }
+    : !v IoErr junk ( dir_remove_all ( string_data root ) )
+    ?? junk { T _ → {} F _ → {} }
+    : Store st ( store_open ( string_data root ) )
+
+    : ( Vec String ) empty ( store_list st )
+    ( check == ( vec_len [String] empty ) 0 `store: empty list on fresh root` )
+    ( vec_free_with [String] empty \ String x → v { ( string_free x ) } )
+
+    // Build a model: meta + one trained version.
+    : *Meta m ( meta_new `sensor_a` `2026-07-03T00:00:00Z` )
+    : ( Vec f ) data ( make_data )
+    : Scaler sc ( scaler_fit data 208 2 )
+    ( meta_set_scaler m sc )
+    ( scaler_apply_matrix sc data 208 2 )
+    : VerModel vm ( train_one data )
+
+    ( check ( store_save_meta st `sensor_a` m ) `store: meta saved` )
+    ( check ( store_save_forest st `sensor_a` vm ) `store: forest saved` )
+    ( check ( store_exists st `sensor_a` ) `store: exists` )
+    ( check == ( store_exists st `nope` ) F `store: missing model absent` )
+
+    : ( Vec String ) names ( store_list st )
+    ( check == ( vec_len [String] names ) 1 `store: list has 1 model` )
+    ?? ( vec_get [String] names 0 ) {
+        T n0 → { ( check == ( nurl_str_eq ( string_data n0 ) `sensor_a` ) 1 `store: listed name` ) }
+        F _ → {}
+    }
+    ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
+
+    // Reload: metadata equal, forest scores bit-exact.
+    : ?*Meta m2o ( store_load_meta st `sensor_a` )
+    ?? m2o {
+        T m2 → {
+            : String s1 ( meta_to_json_str m )
+            : String s2 ( meta_to_json_str m2 )
+            ( check ( string_eq s1 s2 ) `store: metadata survives round-trip` )
+            ( string_free s1 )
+            ( string_free s2 )
+            ( meta_free m2 )
+        }
+        F _ → { ( check F `store: metadata loads` ) }
+    }
+    : ?VerModel vm2o ( store_load_forest st `sensor_a` `short_term` )
+    ?? vm2o {
+        T vm2 → {
+            : ~ b same T
+            : ~ i r 0
+            ~ < r 208 {
+                ? == ( anom_decision_row vm data r ) ( anom_decision_row vm2 data r ) {} { = same F }
+                = r + r 1
+            }
+            ( check same `store: reloaded forest scores bit-exact` )
+            ( anom_vermodel_free vm2 )
+        }
+        F _ → { ( check F `store: forest loads` ) }
+    }
+    // Missing version → None.
+    : ?VerModel nov ( store_load_forest st `sensor_a` `daily` )
+    ?? nov { T bad → { ( anom_vermodel_free bad ) ( check F `store: missing version None` ) } F _ → { ( check T `store: missing version None` ) } }
+
+    // Point log: append, load, rewrite.
+    ( store_append_point st `sensor_a` `{"temp":1,"timestamp":100}` )
+    ( store_append_point st `sensor_a` `{"temp":2,"timestamp":101}` )
+    : ( Vec String ) pts ( store_load_points st `sensor_a` )
+    ( check == ( vec_len [String] pts ) 2 `store: point log appends + loads` )
+    ( vec_free_with [String] pts \ String x → v { ( string_free x ) } )
+    : ( Vec String ) one ( vec_new [String] )
+    ( vec_push [String] one ( string_from `{"temp":3,"timestamp":102}` ) )
+    ( store_write_points st `sensor_a` one )
+    ( vec_free_with [String] one \ String x → v { ( string_free x ) } )
+    : ( Vec String ) pts2 ( store_load_points st `sensor_a` )
+    ( check == ( vec_len [String] pts2 ) 1 `store: point log rewrite` )
+    ( vec_free_with [String] pts2 \ String x → v { ( string_free x ) } )
+
+    // Corrupt the forest file on disk: load returns None.
+    : String fpath ( string_from ( string_data root ) )
+    ( string_push_str fpath `/sensor_a/version_short_term.forest` )
+    : !( Vec u ) IoErr fraw ( read_file_bytes ( string_data fpath ) )
+    ?? fraw {
+        T fb → {
+            ( vec_set [u] fb 20 # u 254 )
+            : !v IoErr wr ( write_file_bytes ( string_data fpath ) fb )
+            ?? wr { T _ → {} F _ → {} }
+            ( vec_free [u] fb )
+            : ?VerModel cv ( store_load_forest st `sensor_a` `short_term` )
+            ?? cv { T bad → { ( anom_vermodel_free bad ) ( check F `store: on-disk corruption rejected` ) } F _ → { ( check T `store: on-disk corruption rejected` ) } }
+        }
+        F _ → { ( check F `store: forest file readable for tamper test` ) }
+    }
+    ( string_free fpath )
+
+    // Delete removes everything.
+    ( check ( store_delete st `sensor_a` ) `store: delete` )
+    ( check == ( store_exists st `sensor_a` ) F `store: gone after delete` )
+
+    ( anom_vermodel_free vm )
+    ( scaler_free sc )
+    ( vec_free [f] data )
+    ( meta_free m )
+    ( store_free st )
+    : !v IoErr fin ( dir_remove_all ( string_data root ) )
+    ?? fin { T _ → {} F _ → {} }
+    ( string_free root )
+}
+
+@ main → i {
+    ( test_blob_roundtrip )
+    ( test_blob_corruption )
+    ( test_store )
+    : String summary ( string_from `store_test: ` )
+    ( string_push_int summary g_pass )
+    ( string_push_str summary ` passed, ` )
+    ( string_push_int summary g_fail )
+    ( string_push_str summary ` failed` )
+    ( pline ( string_data summary ) )
+    ( string_free summary )
+    ? > g_fail 0 { ^ 1 } {}
+    ^ 0
+}

--- a/packages/anomaly/tests/versions_test.nu
+++ b/packages/anomaly/tests/versions_test.nu
@@ -18,6 +18,7 @@ $ `stdlib/ext/env.nu`
 $ `stdlib/ext/json.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
+$ `src/score.nu`
 $ `src/store.nu`
 $ `src/dynamic.nu`
 

--- a/packages/anomaly/tests/versions_test.nu
+++ b/packages/anomaly/tests/versions_test.nu
@@ -1,0 +1,261 @@
+// versions_test.nu — M5 tests: multi-version behaviour.
+//   routing   — versions train on their own time windows: after a step
+//               change, short_term (window 180 min) knows only the new
+//               regime while daily/seasonal remember the old one, so the
+//               same probe scores very differently per version.
+//   aggregate — the any-version-OR truth table, driven through margins.
+//   finetune  — margins recalibrate to 95% of the worst observed score;
+//               the worst ring point then crosses the threshold, normal
+//               points still don't.
+// Store root: $ANOMALY_TEST_DIR (default ./anomaly_ver_test).
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/store.nu`
+$ `src/dynamic.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+: i T0 1700000000
+: ~ i g_lcg 1
+
+@ pline s x → v {
+    ( nurl_print x )
+    ( nurl_print `\n` )
+}
+
+@ check b cond s label → v {
+    ? cond {
+        ( nurl_print `ok ` )
+        ( pline label )
+        = g_pass + g_pass 1
+    } {
+        ( nurl_print `FAIL ` )
+        ( pline label )
+        = g_fail + g_fail 1
+    }
+}
+
+@ lcg_u01 → f {
+    = g_lcg % + * g_lcg 1103515245 12345 2147483648
+    ^ / # f g_lcg 2147483648.0
+}
+
+@ gauss3 → f {
+    ^ - + + ( lcg_u01 ) ( lcg_u01 ) ( lcg_u01 ) 1.5
+}
+
+// Ingest a single-feature {"temp": t} point at absolute time `at`.
+@ ingest_temp *Model mo f temp i at → v {
+    : Json j ( json_obj_new )
+    ( json_obj_set j `temp` ( json_float temp ) )
+    : !Verdict String r ( model_ingest_at mo j at )
+    ( json_free j )
+    ?? r {
+        T vd → { ( verdict_free vd ) }
+        F e → { ( string_free e ) }
+    }
+}
+
+// detect_only a {"temp": t} probe; caller owns the returned Verdict.
+// (`ok` false means the call errored.)
+: ProbeOut {
+    b ok
+    b anomaly
+    f score
+    i hits
+    f df_short
+    f df_daily
+    f df_seasonal
+}
+
+@ probe_temp *Model mo f temp → ProbeOut {
+    : Json j ( json_obj_new )
+    ( json_obj_set j `temp` ( json_float temp ) )
+    : !Verdict String r ( model_detect_only mo j )
+    ( json_free j )
+    ?? r {
+        T vd → {
+            : ~ i hits 0
+            : ~ f dsh 999.0
+            : ~ f dda 999.0
+            : ~ f dse 999.0
+            : i nv ( vec_len [VerVerdict] . vd versions )
+            : ~ i k 0
+            ~ < k nv {
+                ?? ( vec_get [VerVerdict] . vd versions k ) {
+                    T vv → {
+                        ? . vv anomaly { = hits + hits 1 } {}
+                        : s vn ( string_data . vv vvname )
+                        ? == ( nurl_str_eq vn `short_term` ) 1 { = dsh . vv score } {}
+                        ? == ( nurl_str_eq vn `daily` ) 1 { = dda . vv score } {}
+                        ? == ( nurl_str_eq vn `seasonal` ) 1 { = dse . vv score } {}
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            : ProbeOut out @ ProbeOut { T . vd anomaly . vd score hits dsh dda dse }
+            ( verdict_free vd )
+            ^ out
+        }
+        F e → {
+            ( string_free e )
+            ^ @ ProbeOut { F F 0.0 0 999.0 999.0 999.0 }
+        }
+    }
+}
+
+// ── Scenario 1: per-window routing ────────────────────────────────────
+//
+// 20 points of an OLD regime (temp ≈ 20) six+ hours ago, then 10 points of
+// a NEW regime (temp ≈ 40) within the last few minutes. At the final train,
+// short_term's 180-minute window sees only the new regime; daily/seasonal
+// see both. A probe from the old regime is alien to short_term but familiar
+// to the long windows.
+
+@ test_routing Store st → v {
+    = g_lcg 1
+    : i NOW + T0 * 400 60
+    : *Model mo ( model_open_at st `routing` T0 )
+    ( model_set_limits mo 10 150000 )
+    ( model_set_schedule mo 10 1000 )
+
+    : ~ i k 1
+    ~ <= k 20 {
+        ( ingest_temp mo + 20.0 ( gauss3 ) + T0 * k 60 )
+        = k + k 1
+    }
+    : ~ i j 1
+    ~ <= j 10 {
+        ( ingest_temp mo + 40.0 ( gauss3 ) - NOW * - 10 j 60 )
+        = j + j 1
+    }
+    ( check ( model_is_trained mo ) `routing: trained` )
+    : *Meta mm ( model_metadata mo )
+    ( check == . mm last_trained 30 `routing: final train at 30` )
+
+    // Old-regime probe: alien to short_term, familiar to the long windows.
+    : ProbeOut p20 ( probe_temp mo 20.0 )
+    ( check . p20 ok `routing: probe scored` )
+    ( check < . p20 df_short - . p20 df_daily 0.05 `routing: short_term finds old regime alien (daily does not)` )
+    ( check < . p20 df_short - . p20 df_seasonal 0.05 `routing: short_term finds old regime alien (seasonal does not)` )
+    // New-regime probe: fine everywhere (short_term trained on it).
+    : ProbeOut p40 ( probe_temp mo 40.0 )
+    ( check > . p40 df_short -0.12 `routing: new regime familiar to short_term` )
+
+    ( model_free mo )
+}
+
+// ── Scenario 2: aggregation truth table + fine-tune ───────────────────
+
+@ test_aggregate_finetune Store st → v {
+    = g_lcg 7
+    : *Model mo ( model_open_at st `agg` T0 )
+    ( model_set_limits mo 10 150000 )
+    ( model_set_schedule mo 10 1000 )
+    : b m1 ( model_set_margin mo `short_term` 0.5 )
+    : b m2 ( model_set_margin mo `daily` 0.5 )
+    : b m3 ( model_set_margin mo `weekly` 0.5 )
+    : b m4 ( model_set_margin mo `seasonal` 0.5 )
+    : b m5 ( model_set_margin mo `timevector` 0.5 )
+
+    // 19 normal points (temp ≈ 20 ± .5) and one mild outlier (23.0).
+    : ~ i k 1
+    ~ <= k 20 {
+        : ~ f temp + 20.0 * ( gauss3 ) 0.5
+        ? == k 15 { = temp 23.0 } {}
+        ( ingest_temp mo temp + T0 * k 60 )
+        = k + k 1
+    }
+    ( check ( model_is_trained mo ) `agg: trained` )
+
+    // Truth table: margins decide, aggregate is OR over versions.
+    : ProbeOut loose ( probe_temp mo 23.0 )
+    ( check == . loose anomaly F `agg: all margins loose -> normal` )
+    ( check == . loose hits 0 `agg: 0 versions flag` )
+
+    : b t1 ( model_set_margin mo `short_term` 0.01 )
+    : ProbeOut one ( probe_temp mo 23.0 )
+    ( check . one anomaly `agg: one tight margin -> anomaly` )
+    ( check == . one hits 1 `agg: exactly 1 version flags` )
+
+    : b t2 ( model_set_margin mo `daily` 0.01 )
+    : b t3 ( model_set_margin mo `weekly` 0.01 )
+    : b t4 ( model_set_margin mo `seasonal` 0.01 )
+    : b t5 ( model_set_margin mo `timevector` 0.01 )
+    : ProbeOut all5 ( probe_temp mo 23.0 )
+    ( check == . all5 hits 5 `agg: all tight margins -> 5 versions flag` )
+    ( check <= . all5 score . all5 df_short `agg: aggregate score is the most severe` )
+
+    // Fine-tune from loose margins: the worst observed point must cross.
+    : b r1 ( model_set_margin mo `short_term` 0.5 )
+    : b r2 ( model_set_margin mo `daily` 0.5 )
+    : b r3 ( model_set_margin mo `weekly` 0.5 )
+    : b r4 ( model_set_margin mo `seasonal` 0.5 )
+    : b r5 ( model_set_margin mo `timevector` 0.5 )
+
+    : FineTuneReport rep ( model_finetune mo )
+    ( check == ( vec_len [FtVer] . rep items ) 5 `finetune: 5 versions tuned` )
+    : ~ b margins_tightened T
+    : ~ b formula_holds T
+    : i ni ( vec_len [FtVer] . rep items )
+    : ~ i q 0
+    ~ < q ni {
+        ?? ( vec_get [FtVer] . rep items q ) {
+            T ft → {
+                ? < . ft new_margin . ft old_margin {} { = margins_tightened F }
+                ? < ( float_abs - . ft new_margin * ( float_abs . ft min_score ) 0.95 ) 0.0000001 {} { = formula_holds F }
+            }
+            F _ → {}
+        }
+        = q + q 1
+    }
+    ( check margins_tightened `finetune: margins move toward the data` )
+    ( check formula_holds `finetune: margin = 0.95 * |worst score|` )
+
+    // The worst ring point (the 23.0 outlier) now crosses; normals don't.
+    : ProbeOut post ( probe_temp mo 23.0 )
+    ( check . post anomaly `finetune: worst observed point crosses the margin` )
+    : ProbeOut norm ( probe_temp mo 20.0 )
+    ( check == . norm anomaly F `finetune: normal point still normal` )
+
+    ( finetune_free rep )
+    ( model_free mo )
+}
+
+@ main → i {
+    : ~ String root ( string_from `./anomaly_ver_test` )
+    ?? ( env_get `ANOMALY_TEST_DIR` ) {
+        T d → { ( string_free root ) = root d }
+        F _ → {}
+    }
+    : !v IoErr junk ( dir_remove_all ( string_data root ) )
+    ?? junk { T _ → {} F _ → {} }
+    : Store st ( store_open ( string_data root ) )
+
+    ( test_routing st )
+    ( test_aggregate_finetune st )
+
+    ( store_free st )
+    : !v IoErr fin ( dir_remove_all ( string_data root ) )
+    ?? fin { T _ → {} F _ → {} }
+    ( string_free root )
+
+    : String summary ( string_from `versions_test: ` )
+    ( string_push_int summary g_pass )
+    ( string_push_str summary ` passed, ` )
+    ( string_push_int summary g_fail )
+    ( string_push_str summary ` failed` )
+    ( pline ( string_data summary ) )
+    ( string_free summary )
+    ? > g_fail 0 { ^ 1 } {}
+    ^ 0
+}

--- a/packages/gpu/nurl.toml
+++ b/packages/gpu/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpu"
-version = "0.2.0"
+version = "0.2.1"
 description = "GPU compute for NURL — a backend-neutral interface (Gpu / GpuKernel / GpuBuffer: open, compile, alloc, upload/download, launch, sync) with two backends: CUDA and CPU. The CUDA backend writes kernels in CUDA-C, compiles them to PTX at runtime via NVRTC, and runs them through the CUDA Driver API — bound directly from pure NURL with no runtime.c bridge. The CPU backend (v0.2.0) runs the very same CUDA-C kernels on the host: each is wrapped in a small CUDA-compatibility shim (blockIdx/threadIdx as thread-locals, __global__ etc. as no-op macros) plus a generated grid-loop, compiled by the system C++ compiler, dlopen'd, and run with OpenMP parallelising the grid across cores — so an onnx/YOLOE model runs with no GPU at all. gpu_open selects CUDA when a device is available, else falls back to CPU; NURL_GPU=cpu forces it. The neutral surface is unchanged, so callers (packages/onnx, objdet, yoloe) get CPU fallback for free. The toolchain auto-links -lcuda / -lnvrtc only when a program references those symbols; the CPU backend needs only a C++ compiler on PATH (the analogue of NVRTC). Verified: the tiny MLP and the full 267-node YOLOE-seg forward produce identical results on CPU and GPU."
 license = "MIT OR Apache-2.0"
 

--- a/packages/gpu/src/cpu.nu
+++ b/packages/gpu/src/cpu.nu
@@ -112,11 +112,16 @@ static __thread __nurl_dim3 blockIdx, threadIdx, blockDim, gridDim;
     ( string_push_char c 40 )
     ( string_push_str c ( string_data casts ) )
     ( string_push_str c `);\n}\n}\n` )
+    ( string_free casts )
 
     : String cpath ( __tmp_path name `.cc` )
     : String sopath ( __tmp_path name `.so` )
-    ? != 0 ( __write_file ( string_data cpath ) ( string_data c ) ) {
+    : i wr ( __write_file ( string_data cpath ) ( string_data c ) )
+    ( string_free c )
+    ? != 0 wr {
         ( nurl_eprint `[gpu/cpu] cannot write ` ) ( nurl_eprint ( string_data cpath ) ) ( nurl_eprint `\n` )
+        ( string_free cpath )
+        ( string_free sopath )
         ^ # *u 0
     } {}
 
@@ -135,12 +140,18 @@ static __thread __nurl_dim3 blockIdx, threadIdx, blockDim, gridDim;
     ( string_push_str omp ` 2>/tmp/nurlcpu_cc.log` )
     : ~ i rc ( system ( string_data omp ) )
     ? != rc 0 { = rc ( system ( string_data base ) ) } {}
+    ( string_free omp )
+    ( string_free base )
+    ( string_free cpath )
     ? != rc 0 {
         ( nurl_eprint `[gpu/cpu] host compile failed for ` ) ( nurl_eprint name )
         ( nurl_eprint ` (see /tmp/nurlcpu_cc.log; need a C++ compiler on PATH)\n` )
+        ( string_free sopath )
         ^ # *u 0
     } {}
-    ^ ( dlopen ( string_data sopath ) 2 )   // RTLD_NOW
+    : *u handle ( dlopen ( string_data sopath ) 2 )   // RTLD_NOW
+    ( string_free sopath )
+    ^ handle
 }
 
 // The generated grid-loop entry point in a compiled module (0 if absent).

--- a/packages/gpu/src/cuda.nu
+++ b/packages/gpu/src/cuda.nu
@@ -78,17 +78,23 @@ $ `stdlib/core/string.nu`
 @ cuda_device_count → i {
     : *u s ( __outslot )
     ( cuDeviceGetCount s )
-    ^ ( nurl_peek s 0 )
+    : i n ( nurl_peek s 0 )
+    ( nurl_free s )
+    ^ n
 }
 
 // Device ordinal → CUdevice (itself a small int handle). -1 on failure.
 @ cuda_device i ordinal → i {
     : *u s ( __outslot )
-    ? != # i ( cuDeviceGet s # i32 ordinal ) 0 { ^ - 0 1 } {}
-    ^ ( nurl_peek s 0 )
+    ? != # i ( cuDeviceGet s # i32 ordinal ) 0 { ( nurl_free s ) ^ - 0 1 } {}
+    : i dev ( nurl_peek s 0 )
+    ( nurl_free s )
+    ^ dev
 }
 
-// CUdevice → device name string (borrowed copy into a fresh buffer).
+// CUdevice → device name string in a fresh buffer. The CALLER owns the
+// returned buffer (free with nurl_free after use) — it cannot be a borrow,
+// there is nothing to borrow from.
 @ cuda_device_name i dev → s {
     : *u buf ( nurl_alloc 256 )
     ( nurl_poke buf 0 0 )
@@ -99,8 +105,10 @@ $ `stdlib/core/string.nu`
 // Create a context on a CUdevice → CUcontext handle (0 on failure).
 @ cuda_ctx_create i dev → i {
     : *u s ( __outslot )
-    ? != # i ( cuCtxCreate s 0 # i32 dev ) 0 { ^ 0 } {}
-    ^ ( nurl_peek s 0 )
+    ? != # i ( cuCtxCreate s 0 # i32 dev ) 0 { ( nurl_free s ) ^ 0 } {}
+    : i ctx ( nurl_peek s 0 )
+    ( nurl_free s )
+    ^ ctx
 }
 
 @ cuda_ctx_destroy i ctx → i { ^ # i ( cuCtxDestroy ctx ) }
@@ -114,6 +122,7 @@ $ `stdlib/core/string.nu`
     : *u ps ( __outslot )
     ? != # i ( nvrtcCreateProgram ps src name 0 0 0 ) 0 {
         ( nurl_eprint `[gpu/cuda] nvrtcCreateProgram failed\n` )
+        ( nurl_free ps )
         ^ # *u 0
     } {}
     : i prog ( nurl_peek ps 0 )
@@ -127,38 +136,49 @@ $ `stdlib/core/string.nu`
         ( nurl_eprint `[gpu/cuda] kernel compile failed:\n` )
         ( nurl_eprint # s log )
         ( nurl_eprint `\n` )
+        ( nurl_free log )
+        ( nurl_free ls )
         ( nvrtcDestroyProgram ps )
+        ( nurl_free ps )
         ^ # *u 0
     } {}
     : *u szs ( __outslot )
     ( nvrtcGetPTXSize prog szs )
     : i psz ( nurl_peek szs 0 )
+    ( nurl_free szs )
     : *u ptx ( nurl_alloc + psz 1 )
     ( nvrtcGetPTX prog ptx )
     ( nvrtcDestroyProgram ps )
+    ( nurl_free ps )
     ^ ptx
 }
 
 // ── module / function ─────────────────────────────────────────────
 @ cuda_module_load *u ptx → i {
     : *u s ( __outslot )
-    ? != # i ( cuModuleLoadData s ptx ) 0 { ^ 0 } {}
-    ^ ( nurl_peek s 0 )
+    ? != # i ( cuModuleLoadData s ptx ) 0 { ( nurl_free s ) ^ 0 } {}
+    : i module ( nurl_peek s 0 )
+    ( nurl_free s )
+    ^ module
 }
 
 @ cuda_module_unload i module → i { ^ # i ( cuModuleUnload module ) }
 
 @ cuda_function i module s name → i {
     : *u s ( __outslot )
-    ? != # i ( cuModuleGetFunction s module name ) 0 { ^ 0 } {}
-    ^ ( nurl_peek s 0 )
+    ? != # i ( cuModuleGetFunction s module name ) 0 { ( nurl_free s ) ^ 0 } {}
+    : i fn ( nurl_peek s 0 )
+    ( nurl_free s )
+    ^ fn
 }
 
 // ── device memory ─────────────────────────────────────────────────
 @ cuda_malloc i bytes → i {
     : *u s ( __outslot )
-    ? != # i ( cuMemAlloc s bytes ) 0 { ^ 0 } {}
-    ^ ( nurl_peek s 0 )
+    ? != # i ( cuMemAlloc s bytes ) 0 { ( nurl_free s ) ^ 0 } {}
+    : i dptr ( nurl_peek s 0 )
+    ( nurl_free s )
+    ^ dptr
 }
 
 @ cuda_free i dptr → i { ^ # i ( cuMemFree dptr ) }
@@ -175,8 +195,12 @@ $ `stdlib/core/string.nu`
 }
 
 // CUresult code → driver error-name string (e.g. "CUDA_ERROR_INVALID_VALUE").
+// The returned pointer is the driver's own static string — only the
+// out-slot is ours to release.
 @ cuda_error_name i code → s {
     : *u s ( __outslot )
-    ? != # i ( cuGetErrorName # i32 code s ) 0 { ^ `CUDA_ERROR_UNKNOWN` } {}
-    ^ # s ( nurl_peek s 0 )
+    ? != # i ( cuGetErrorName # i32 code s ) 0 { ( nurl_free s ) ^ `CUDA_ERROR_UNKNOWN` } {}
+    : i namep ( nurl_peek s 0 )
+    ( nurl_free s )
+    ^ # s namep
 }

--- a/stdlib/std/args.nu
+++ b/stdlib/std/args.nu
@@ -292,8 +292,10 @@ $ `stdlib/core/vec.nu`
     : ( Vec String ) toks ( vec_new [String] )
     : ~ i k 1
     ~ < k n {
+        // nurl_argv_get returns a heap COPY (runtime contract) — adopt it
+        // instead of copying again and leaking the original.
         : s raw ( nurl_argv_get k )
-        ( vec_push [String] toks ( string_from raw ) )
+        ( vec_push [String] toks ( string_from_take raw + ( nurl_str_len raw ) 1 ) )
         = k + k 1
     }
     : b ok ( args_parse p toks )


### PR DESCRIPTION
## packages/anomaly v0.2.0 — a complete pure-NURL anomaly-detection service

Where `iforest` is the kernel (matrix in, scores out), `anomaly` is the **service** around it: named dynamic models are **created on first use**, ingest one JSON point at a time over CLI or HTTP, and **train themselves** once enough history accumulates — no offline training step, no labels. A NURL port of the Flask + scikit-learn reference interface (`model_training.py`), same routes and response shapes.

### What's inside (one commit per SPEC milestone)

- **M1 — preprocessing & metadata** (`prep.nu`): numeric / sorted-one-hot categorical / ISO-8601→calendar features, the feature-order stability rule (frozen `feature_names` projection), StandardScaler analogue with zero-variance passthrough, byte-stable metadata JSON round-trip.
- **M2 — decision core** (`model.nu`, `score.nu`): sklearn conventions exactly — `decision_function = -iforest_score − offset_`, `offset_ = −0.5` for `contamination='auto'`, else the 100·c percentile (numpy-linear) of training scores; verdict at `df ≤ −margin`.
- **M3 — persistence** (`store.nu`): `metadata.json` + `data.jsonl` (raw records, so retrains learn new categories) + validated `ANOMFOR1` forest blobs; atomic tmp+rename writes; corrupt/truncated/renamed files load as errors, never UB.
- **M4 — dynamic streaming models** (`dynamic.nu`): bounded 150k ring, warm-up gating at 50 points, retraining keyed on the monotonic lifetime counter (50 below capacity / 1000 at it), `detect_only` provably mutates nothing, injectable clock via `_at` variants.
- **M5 — multi-version verdicts + fine-tune**: 5 time-window forests per model (`short_term`…`timevector`), any-version-OR aggregation, margins read from live metadata (tuning applies without retrain), `model_finetune` = 0.95·|worst observed score|.
- **M6 — CLI + HTTP service**: `anomaly detect/score/batch/train/reset/rm/ls/info/serve`; all reference routes with matching shapes/status codes; router built separately from the socket so every route is golden-tested without networking.
- **M7 — GPU acceleration** (`score.nu`): bulk scoring routes through `packages/gpu` — CUDA when present, the gpu package's CPU backend (host C++ + OpenMP) without one, pure NURL with neither. **Bit-identical on all three engines by construction** (the kernel only sums f64 path lengths in the pure walker's order; the nonlinear finish stays in NURL) — asserted element-for-element `==` in tests. Measured, 200k rows × 300 trees: pure 9.6 s → host C++ 1.1 s (~9×) → RTX 4090 213 ms (~45×).

### Validation

- **scikit-learn parity**: on identical deterministic data, our `decision_function` matches sklearn's within ~0.01 (worst normal −0.139 vs −0.148, outlier −0.208 vs −0.209).
- **Suite**: 23/23 — seven unit suites (165 checks), a CLI end-to-end pass, a live served-over-curl smoke, and the GPU parity test run on both engines. Zero findings under ASan/UBSan/LSan across everything.
- Deterministic: seed 42 ⇒ byte-identical forests and scores across platforms, engines and runs.

### Root-cause fixes that fell out (separate commits)

- **`stdlib/std/args.nu`**: `args_parse_argv` leaked every argv token in every CLI built on it (cas, nq, …) — `nurl_argv_get` returns a heap copy by contract; now adopted with `string_from_take`. Full bootstrap + corpus green.
- **`packages/gpu` v0.2.1**: `cuda.nu` leaked its 8-byte out-slot on every wrapper call (`cuda_malloc` leaked per device allocation — affected onnx/objdet/yoloe too), and `cpu_compile` leaked every working String it built. All freed at last use; `cuda_device_name`'s caller-owns contract documented. gpu's own tests pass on both backends.

Known deliberate divergences from the Python reference (e.g. its fine-tune is dead code — we ship the documented intent) are listed in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132PsC3u7nTQeapSKwmmfZf