### PR TITLE
feat(anomaly): serve a self-contained web dashboard from `anomaly serve`

### DIFF
--- a/packages/anomaly/README.md
+++ b/packages/anomaly/README.md
@@ -99,7 +99,8 @@ anomaly train  <model>                 # force a retrain now
 anomaly reset  <model>                 # drop data+forests, keep the name
 anomaly rm     <model>                 # delete the model entirely
 anomaly ls / info <model>              # list models / dump metadata
-anomaly serve  [--addr HOST:PORT]      # run the HTTP/JSON service
+anomaly serve  [--addr HOST:PORT]      # run the HTTP/JSON service + dashboard
+               [--webroot DIR]
 ```
 
 The store defaults to `$ANOMALY_HOME`, else `~/.anomaly`; override per
@@ -125,6 +126,24 @@ command with `--store DIR`.
 
 Model names must match `^[a-zA-Z0-9_]+$`. The router is a plain function
 over `HttpRequest` — the test suite drives every route without a socket.
+
+## Dashboard
+
+`anomaly serve` also serves a small self-contained web dashboard (no CDN, no
+build step — plain HTML/CSS/JS that talks to the routes above):
+
+| Page | What it does |
+| --- | --- |
+| `/` · `/modelmanager.html` | list models, train / finetune / reset / delete, edit retrain schedule, inspect metadata |
+| `/modeltrainer.html` | feed points (`/detect`) one at a time or in bulk (paste JSON lines / generate synthetic), force-train |
+| `/visualize.html` | plot any numeric feature of a model's stored points over time |
+| `/anomalies.html` | re-score stored points via `/detect_only` and highlight the anomalies (chart + table with the flagging versions) |
+
+The HTML lives in `static/` next to the package. `serve` locates it via, in
+order: `--webroot DIR`, `$ANOMALY_WEBROOT`, `<exe-dir>/static`,
+`<exe-dir>/../share/anomaly/static`, then `./static`. If none exists the
+server runs API-only (dashboard routes return 404) and logs which web root it
+picked on startup.
 
 ## Library
 

--- a/packages/anomaly/src/main.nu
+++ b/packages/anomaly/src/main.nu
@@ -8,7 +8,8 @@
 //   anomaly rm     <model>                 delete the model entirely
 //   anomaly ls                             list models in the store
 //   anomaly info   <model>                 dump model metadata (pretty JSON)
-//   anomaly serve  [--addr HOST:PORT]      run the HTTP/JSON service
+//   anomaly serve  [--addr HOST:PORT]      run the HTTP/JSON service + dashboard
+//                  [--webroot DIR]         (dashboard HTML dir; auto-located)
 //
 // Values in key=val are auto-typed: numbers are numeric features, ISO-8601
 // strings are timestamps, anything else is categorical (one-hot). Verdicts
@@ -46,6 +47,43 @@ $ `src/service.nu`
 @ pline s x → v {
     ( nurl_print x )
     ( nurl_print `\n` )
+}
+
+// Resolve the directory that holds the dashboard HTML for `serve`. Order:
+//   --webroot DIR  →  $ANOMALY_WEBROOT  →  <exe-dir>/static  →
+//   <exe-dir>/../share/anomaly/static  →  ./static.
+// Returns the first candidate that exists; empty String disables the
+// dashboard (API-only serving still works).
+@ __cli_webroot ArgParser p → String {
+    : ?String ov ( args_value p `webroot` )
+    ?? ov { T v → { ^ v } F junk → { ( string_free junk ) } }
+    : ?String ev ( env_get `ANOMALY_WEBROOT` )
+    ?? ev {
+        T v → {
+            ? ( file_exists ( string_data v ) ) { ^ v } { ( string_free v ) }
+        }
+        F junk → { ( string_free junk ) }
+    }
+    // Candidates derived from the executable location.
+    : !String IoErr exe ( fs_readlink `/proc/self/exe` )
+    ?? exe {
+        T ep → {
+            : String bindir ( path_dirname ( string_data ep ) )
+            ( string_free ep )
+            : String c1 ( path_join ( string_data bindir ) `static` )
+            ? ( file_exists ( string_data c1 ) ) {
+                ( string_free bindir )
+                ^ c1
+            } { ( string_free c1 ) }
+            : String share ( path_join ( string_data bindir ) `../share/anomaly/static` )
+            ( string_free bindir )
+            ? ( file_exists ( string_data share ) ) { ^ share } { ( string_free share ) }
+        }
+        F _ → {}
+    }
+    // Last resort: ./static relative to the current directory.
+    ? ( file_exists `static` ) { ^ ( string_from `static` ) } {}
+    ^ ( string_new )
 }
 
 // key=val positionals (from index `from`) → a JSON record. Numeric-looking
@@ -273,6 +311,7 @@ $ `src/service.nu`
     ( args_opt p `file` 102 `FILE` `for batch: read CSV from FILE instead of stdin` )
     ( args_opt p `margin` 109 `M` `for batch: decision margin (default 0 = predict==-1)` )
     ( args_opt p `addr` 97 `HOST:PORT` `for serve: bind address (default 127.0.0.1:8811)` )
+    ( args_opt p `webroot` 119 `DIR` `for serve: dashboard HTML dir (default: <exe>/static, $ANOMALY_WEBROOT)` )
     ( args_flag p `header` 72 `for batch: skip the first CSV line (header)` )
     ( args_flag p `help` 104 `show this help` )
     ( args_flag p `version` 0 `print the version` )
@@ -285,7 +324,7 @@ $ `src/service.nu`
     ? ( args_present p `help` ) {
         : String u ( args_usage p )
         ( nurl_print ( string_data u ) )
-        ( nurl_print `\ncommands:\n  detect <model> key=val ...   ingest one point, print the verdict\n  score  <model> key=val ...   score only (never ingests or retrains)\n  batch  [-f FILE] [-H]        score a CSV, one "index<TAB>score" per row\n  train  <model>               force a retrain now\n  reset  <model>               drop data + forests, keep the name\n  rm     <model>               delete the model entirely\n  ls                           list models\n  info   <model>               print model metadata\n  serve  [--addr HOST:PORT]    run the HTTP/JSON service\n` )
+        ( nurl_print `\ncommands:\n  detect <model> key=val ...   ingest one point, print the verdict\n  score  <model> key=val ...   score only (never ingests or retrains)\n  batch  [-f FILE] [-H]        score a CSV, one "index<TAB>score" per row\n  train  <model>               force a retrain now\n  reset  <model>               drop data + forests, keep the name\n  rm     <model>               delete the model entirely\n  ls                           list models\n  info   <model>               print model metadata\n  serve  [--addr H:P] [--webroot DIR]  HTTP/JSON service + web dashboard\n` )
         ( string_free u )
         ( args_free p )
         ^ 0
@@ -354,7 +393,16 @@ $ `src/service.nu`
         }
         : String root ( __cli_store_root p )
         ( anomaly_service_set_root ( string_data root ) )
+        : String webroot ( __cli_webroot p )
+        ( anomaly_service_set_webroot ( string_data webroot ) )
+        ? > ( string_len webroot ) 0 {
+            ( nurl_eprint `anomaly: dashboard web root: ` )
+            ( nurl_eprintln ( string_data webroot ) )
+        } {
+            ( nurl_eprintln `anomaly: no dashboard web root found (API-only)` )
+        }
         = rc ( anomaly_serve ( string_data host ) port )
+        ( string_free webroot )
         ( string_free root )
         ( string_free host )
         ( string_free addr )

--- a/packages/anomaly/src/service.nu
+++ b/packages/anomaly/src/service.nu
@@ -21,6 +21,14 @@
 // the CSV with a self-trained stateless forest (the reference's separate
 // "static model" family doesn't exist here); passing model_name is a 400.
 //
+// When a web root is configured (anomaly_service_set_webroot), the router
+// also serves the self-contained dashboard pages from disk:
+//
+//   GET /  |  /modelmanager.html  |  /modeltrainer.html
+//       |  /visualize.html        |  /anomalies.html
+//
+// With no web root these routes 404 and the service is API-only.
+//
 // The router is exposed separately from the socket (anomaly_service_router
 // + router_handle) so every route is testable without networking.
 
@@ -28,6 +36,7 @@ $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/std/float.nu`
 $ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
 $ `stdlib/std/net.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/ext/json.nu`
@@ -47,6 +56,69 @@ $ `src/csvdata.nu`
 
 @ anomaly_service_set_root s root → v {
     = g_an_root root
+}
+
+// Directory holding the dashboard HTML (modelmanager.html, etc). Empty =
+// static serving disabled (API-only). Set once before serving.
+: ~ s g_an_webroot ``
+
+@ anomaly_service_set_webroot s root → v {
+    = g_an_webroot root
+}
+
+// ── Static dashboard serving ──────────────────────────────────────────
+
+// Content-Type for a filename by extension (only the handful the dashboard
+// actually ships; everything else is served as octet-stream).
+@ __an_content_type s name → s {
+    : i n ( nurl_str_len name )
+    ? ( __an_ends_with name `.html` ) { ^ `text/html; charset=utf-8` } {}
+    ? ( __an_ends_with name `.css` ) { ^ `text/css; charset=utf-8` } {}
+    ? ( __an_ends_with name `.js` ) { ^ `application/javascript; charset=utf-8` } {}
+    ? ( __an_ends_with name `.json` ) { ^ `application/json; charset=utf-8` } {}
+    ? ( __an_ends_with name `.svg` ) { ^ `image/svg+xml` } {}
+    ? ( __an_ends_with name `.ico` ) { ^ `image/x-icon` } {}
+    ^ `application/octet-stream`
+}
+
+@ __an_ends_with s hay s suf → b {
+    : i hn ( nurl_str_len hay )
+    : i sn ( nurl_str_len suf )
+    ? > sn hn { ^ F } {}
+    : ~ i k 0
+    ~ < k sn {
+        ? == ( nurl_str_get hay + - hn sn k ) ( nurl_str_get suf k ) {} { ^ F }
+        = k + k 1
+    }
+    ^ T
+}
+
+// Serve `<g_an_webroot>/<relfile>`. 404 when the webroot is unset or the
+// file is missing. `relfile` is a trusted constant (never request-derived),
+// so no path-traversal scrubbing is needed here.
+@ __an_serve_file s relfile → HttpResponse {
+    ? > ( nurl_str_len g_an_webroot ) 0 {} {
+        ^ ( __an_json_err 404 `Dashboard is not available (no web root configured)` )
+    }
+    : String path ( path_join g_an_webroot relfile )
+    : !String IoErr fr ( read_file ( string_data path ) )
+    ( string_free path )
+    ?? fr {
+        T text → {
+            : HttpResponse r ( response_new 200 )
+            ( response_set_header r `Content-Type` ( __an_content_type relfile ) )
+            ( response_set_body_str r ( string_data text ) )
+            ( string_free text )
+            ^ r
+        }
+        F _ → {
+            : String msg ( string_from `File not found: ` )
+            ( string_push_str msg relfile )
+            : HttpResponse rr ( __an_json_err 404 ( string_data msg ) )
+            ( string_free msg )
+            ^ rr
+        }
+    }
 }
 
 // ── Small helpers ─────────────────────────────────────────────────────
@@ -723,6 +795,12 @@ $ `src/csvdata.nu`
 
 @ anomaly_service_router → Router {
     : Router r ( router_new )
+    // Dashboard pages (served from g_an_webroot; 404 when unset).
+    ( router_get r `/` \ HttpRequest req Params p → HttpResponse { ^ ( __an_serve_file `modelmanager.html` ) } )
+    ( router_get r `/modelmanager.html` \ HttpRequest req Params p → HttpResponse { ^ ( __an_serve_file `modelmanager.html` ) } )
+    ( router_get r `/anomalies.html` \ HttpRequest req Params p → HttpResponse { ^ ( __an_serve_file `anomalies.html` ) } )
+    ( router_get r `/modeltrainer.html` \ HttpRequest req Params p → HttpResponse { ^ ( __an_serve_file `modeltrainer.html` ) } )
+    ( router_get r `/visualize.html` \ HttpRequest req Params p → HttpResponse { ^ ( __an_serve_file `visualize.html` ) } )
     ( router_post r `/detect/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_detect req p T ) } )
     ( router_post r `/detect_only/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_detect req p F ) } )
     ( router_post r `/force_train/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_force_train req p ) } )

--- a/packages/anomaly/static/anomalies.html
+++ b/packages/anomaly/static/anomalies.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Anomalies · anomaly</title>
+<style>
+  :root {
+    --bg: #0e1116; --panel: #161b22; --panel2: #1c2230; --border: #2a3242;
+    --fg: #e6edf3; --muted: #8b98a9; --accent: #4c9aff; --accent2: #6ee7b7;
+    --danger: #ff6b6b; --warn: #f6c344; --ok: #56d364; --radius: 10px; --grid: #212836;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--fg); font-family: var(--sans); font-size: 14px; }
+  a { color: var(--accent); text-decoration: none; }
+  header { display: flex; align-items: center; gap: 20px; padding: 14px 24px; background: var(--panel);
+           border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 10; }
+  header h1 { font-size: 16px; margin: 0; font-weight: 600; }
+  header .brand { color: var(--accent2); font-family: var(--mono); }
+  nav { display: flex; gap: 4px; margin-left: auto; }
+  nav a { padding: 6px 12px; border-radius: 8px; color: var(--muted); font-weight: 500; }
+  nav a:hover { background: var(--panel2); color: var(--fg); }
+  nav a.active { background: var(--accent); color: #06122b; }
+  main { max-width: 1200px; margin: 0 auto; padding: 24px; }
+  .controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-bottom: 18px; }
+  select, input[type=number] { font-family: var(--mono); font-size: 13px; background: var(--bg); color: var(--fg);
+    border: 1px solid var(--border); border-radius: 8px; padding: 7px 10px; }
+  select:focus { outline: none; border-color: var(--accent); }
+  button { font-family: var(--sans); font-size: 13px; border: 1px solid var(--border); background: var(--panel2);
+           color: var(--fg); padding: 7px 12px; border-radius: 8px; cursor: pointer; font-weight: 500; }
+  button:hover { border-color: var(--accent); }
+  button.primary { background: var(--accent); border-color: var(--accent); color: #06122b; }
+  button:disabled { opacity: .5; cursor: default; }
+  label.lbl { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .4px; margin-right: 4px; }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 18px; margin-bottom: 20px; }
+  .card h2 { font-size: 12px; text-transform: uppercase; letter-spacing: .6px; color: var(--muted); margin: 0 0 14px; font-weight: 600; }
+  canvas { width: 100%; display: block; }
+  .stat-row { display: flex; gap: 20px; flex-wrap: wrap; margin-bottom: 18px; }
+  .stat { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 12px 16px; min-width: 120px; }
+  .stat .n { font-size: 22px; font-weight: 700; font-family: var(--mono); font-variant-numeric: tabular-nums; }
+  .stat .n.danger { color: var(--danger); } .stat .n.ok { color: var(--ok); }
+  .stat .l { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .4px; }
+  .muted { color: var(--muted); }
+  .bar { height: 6px; background: var(--panel2); border-radius: 3px; overflow: hidden; flex: 1; min-width: 120px; }
+  .bar > i { display: block; height: 100%; background: var(--accent); width: 0; transition: width .15s; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  thead th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .5px; color: var(--muted);
+             padding: 8px 12px; border-bottom: 1px solid var(--border); }
+  tbody td { padding: 8px 12px; border-bottom: 1px solid var(--border); font-family: var(--mono);
+             font-variant-numeric: tabular-nums; }
+  tbody tr:hover { background: var(--panel2); }
+  .score { color: var(--danger); font-weight: 600; }
+  .vtags { display: flex; gap: 4px; flex-wrap: wrap; }
+  .vtag { font-size: 10px; padding: 1px 6px; border-radius: 999px; border: 1px solid rgba(255,107,107,.4);
+          color: var(--danger); background: rgba(255,107,107,.08); }
+  .empty { text-align: center; padding: 40px; color: var(--muted); }
+  #tip { position: fixed; pointer-events: none; background: var(--panel2); border: 1px solid var(--border);
+         border-radius: 6px; padding: 6px 9px; font-family: var(--mono); font-size: 12px; display: none;
+         box-shadow: 0 6px 18px rgba(0,0,0,.5); z-index: 50; white-space: nowrap; }
+</style>
+</head>
+<body>
+<header>
+  <h1><span class="brand">anomaly</span> · Anomalies</h1>
+  <nav>
+    <a href="/modelmanager.html">Models</a>
+    <a href="/modeltrainer.html">Trainer</a>
+    <a href="/visualize.html">Visualize</a>
+    <a href="/anomalies.html" class="active">Anomalies</a>
+  </nav>
+</header>
+
+<main>
+  <div class="controls">
+    <span><label class="lbl">Model</label><select id="model"></select></span>
+    <span><label class="lbl">Feature</label><select id="feature"></select></span>
+    <span><label class="lbl">Max points</label>
+      <input type="number" id="cap" value="500" min="10" max="5000" style="width:90px"></span>
+    <button class="primary" id="run" onclick="run()">Scan for anomalies</button>
+    <div class="bar" id="barWrap" style="display:none"><i id="bar"></i></div>
+    <span class="muted" id="prog"></span>
+  </div>
+
+  <div class="stat-row" id="stats" style="display:none"></div>
+
+  <div class="card" id="chartCard" style="display:none">
+    <h2 id="chartTitle">Series with anomalies</h2>
+    <canvas id="chart" height="360"></canvas>
+  </div>
+
+  <div class="card" id="listCard" style="display:none">
+    <h2>Flagged points</h2>
+    <div id="list"></div>
+  </div>
+
+  <div class="empty" id="hint">Pick a model and scan. Each stored point is re-scored via
+    <code>/detect_only</code> and anomalies are highlighted.</div>
+</main>
+<div id="tip"></div>
+
+<script>
+"use strict";
+const $ = (id) => document.getElementById(id);
+const enc = encodeURIComponent;
+let DATA = [], NUMKEYS = [], RESULTS = [];
+
+async function api(method, url, body) {
+  const opt = { method, headers: {} };
+  if (body !== undefined) { opt.headers["Content-Type"] = "application/json"; opt.body = JSON.stringify(body); }
+  const r = await fetch(url, opt);
+  let d = null; try { d = await r.json(); } catch (e) {}
+  return { ok: r.ok, status: r.status, data: d };
+}
+function esc(s) { return String(s).replace(/[&<>"]/g, c => ({ "&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;" }[c])); }
+function fmtNum(x) {
+  if (typeof x !== "number") return esc(x);
+  if (!isFinite(x)) return "–";
+  return Math.abs(x) < 1e-4 && x !== 0 ? x.toExponential(2) : +x.toFixed(5) + "";
+}
+function getVar(n) { return getComputedStyle(document.documentElement).getPropertyValue(n).trim(); }
+
+async function loadModels(preselect) {
+  const r = await api("GET", "/models/dynamic");
+  const names = Object.keys((r.data && r.data.models) || {}).sort();
+  $("model").innerHTML = names.length
+    ? names.map(n => '<option value="' + esc(n) + '">' + esc(n) + "</option>").join("")
+    : '<option>(no models)</option>';
+  if (preselect && names.includes(preselect)) $("model").value = preselect;
+  $("model").onchange = loadFeatures;
+  await loadFeatures();
+}
+
+async function loadFeatures() {
+  const name = $("model").value;
+  if (!name || name === "(no models)") { DATA = []; NUMKEYS = []; $("feature").innerHTML = ""; return; }
+  const r = await api("GET", "/models/dynamic/" + enc(name) + "/data?limit=all");
+  DATA = (r.data && r.data.data) || [];
+  const keys = {};
+  for (const rec of DATA) if (rec && typeof rec === "object")
+    for (const k of Object.keys(rec)) if (typeof rec[k] === "number") keys[k] = true;
+  NUMKEYS = Object.keys(keys);
+  $("feature").innerHTML = NUMKEYS.length
+    ? NUMKEYS.map(k => '<option value="' + esc(k) + '">' + esc(k) + "</option>").join("")
+    : '<option>(none)</option>';
+  $("prog").textContent = DATA.length + " stored points";
+}
+
+async function run() {
+  const name = $("model").value;
+  if (!name || name === "(no models)") return;
+  if (!DATA.length) { $("prog").textContent = "no stored data for this model"; return; }
+  const cap = Math.max(10, Math.min(5000, parseInt($("cap").value, 10) || 500));
+  const pts = DATA.slice(Math.max(0, DATA.length - cap));   // most recent `cap`
+  const baseIdx = DATA.length - pts.length;
+
+  $("run").disabled = true;
+  $("barWrap").style.display = "block";
+  RESULTS = [];
+  let warming = false;
+  for (let i = 0; i < pts.length; i++) {
+    const r = await api("POST", "/detect_only/" + enc(name), pts[i]);
+    if (r.status === 202) { warming = true; break; }
+    if (r.ok && r.data && r.data.status === "success") {
+      const flagged = [];
+      const vs = r.data.versions || {};
+      for (const vn of Object.keys(vs)) if (vs[vn].anomaly) flagged.push(vn);
+      RESULTS.push({ idx: baseIdx + i, rec: pts[i], score: r.data.score,
+                     anomaly: !!r.data.anomaly, versions: flagged });
+    }
+    $("bar").style.width = Math.round((i+1)/pts.length*100) + "%";
+    $("prog").textContent = (i+1) + "/" + pts.length + " scored";
+  }
+  $("run").disabled = false;
+  $("barWrap").style.display = "none";
+
+  if (warming) {
+    $("prog").textContent = "model is still warming up — not enough data to score";
+    $("hint").style.display = "block"; $("hint").textContent = "Model warming up: feed more data or force-train it first.";
+    $("stats").style.display = $("chartCard").style.display = $("listCard").style.display = "none";
+    return;
+  }
+  renderAll();
+}
+
+function renderAll() {
+  $("hint").style.display = "none";
+  const total = RESULTS.length;
+  const anoms = RESULTS.filter(r => r.anomaly);
+  const pct = total ? (anoms.length/total*100) : 0;
+  $("stats").style.display = "flex";
+  $("stats").innerHTML = [
+    ['<span class="n">' + total + "</span>", "scored"],
+    ['<span class="n ' + (anoms.length?"danger":"ok") + '">' + anoms.length + "</span>", "anomalies"],
+    ['<span class="n">' + pct.toFixed(1) + "%</span>", "rate"],
+  ].map(([n,l]) => '<div class="stat">' + n + '<div class="l">' + l + "</div></div>").join("");
+  drawChart();
+  renderList(anoms);
+}
+
+function drawChart() {
+  $("chartCard").style.display = "block";
+  const feat = $("feature").value;
+  const cv = $("chart");
+  const pts = RESULTS.map(r => ({ idx: r.idx, x: (r.rec && typeof r.rec[feat]==="number") ? r.rec[feat] : null,
+                                  score: r.score, anomaly: r.anomaly }));
+  const valid = pts.filter(p => p.x !== null);
+  $("chartTitle").textContent = feat + " — anomalies in red";
+  if (!valid.length) { cv.style.display = "none"; return; }
+  cv.style.display = "block";
+
+  const dpr = window.devicePixelRatio || 1, W = cv.clientWidth, H = 360;
+  cv.width = W*dpr; cv.height = H*dpr;
+  const g = cv.getContext("2d"); g.scale(dpr, dpr); g.clearRect(0,0,W,H);
+  const pad = { l: 54, r: 14, t: 14, b: 26 }, iw = W-pad.l-pad.r, ih = H-pad.t-pad.b;
+  const xs = valid.map(p=>p.x);
+  let mn = Math.min(...xs), mx = Math.max(...xs); if (mn===mx){mn-=1;mx+=1;}
+  const py=(mx-mn)*0.08; mn-=py; mx+=py;
+  const N = pts.length;
+  const X = (i)=> pad.l + (N<=1?iw/2:(i/(N-1))*iw);
+  const Y = (v)=> pad.t + ih - ((v-mn)/(mx-mn))*ih;
+
+  g.strokeStyle = getVar("--grid"); g.fillStyle = getVar("--muted");
+  g.font = "11px " + getVar("--mono"); g.lineWidth = 1;
+  for (let t=0;t<=4;t++){ const yv=mn+(mx-mn)*t/4, y=Y(yv);
+    g.beginPath(); g.moveTo(pad.l,y); g.lineTo(W-pad.r,y); g.stroke(); g.fillText(fmtNum(yv),6,y+3); }
+  for (let t=0;t<=4;t++){ const i=Math.round((N-1)*t/4);
+    g.fillText(String(pts[i] ? pts[i].idx : ""), X(i)-8, H-8); }
+
+  // line through valid points
+  g.beginPath(); let started=false;
+  pts.forEach((p,i)=>{ if(p.x===null) return; const x=X(i),y=Y(p.x);
+    if(!started){g.moveTo(x,y);started=true;} else g.lineTo(x,y); });
+  g.strokeStyle = getVar("--accent"); g.lineWidth = 1.6; g.stroke();
+
+  // markers
+  pts.forEach((p,i)=>{ if(p.x===null) return; const x=X(i), y=Y(p.x);
+    g.beginPath(); g.arc(x,y, p.anomaly?4:2, 0, 7);
+    g.fillStyle = p.anomaly ? getVar("--danger") : getVar("--accent"); g.fill();
+    if (p.anomaly){ g.beginPath(); g.arc(x,y,7,0,7); g.strokeStyle="rgba(255,107,107,.5)"; g.lineWidth=1.5; g.stroke(); }
+  });
+
+  cv._pts = pts; cv._X = X; cv._Y = Y; cv._N = N; cv._pad = pad; cv._feat = feat;
+}
+
+$("chart").addEventListener("mousemove", (e) => {
+  const cv = $("chart"); if (!cv._pts) return;
+  const rect = cv.getBoundingClientRect(), mx = e.clientX-rect.left;
+  const N=cv._N, pad=cv._pad, iw=cv.clientWidth-pad.l-pad.r;
+  let i = Math.round(((mx-pad.l)/iw)*(N-1)); i=Math.max(0,Math.min(N-1,i));
+  const p = cv._pts[i]; if(!p) return;
+  const tip=$("tip"); tip.style.display="block";
+  tip.style.left=(e.clientX+12)+"px"; tip.style.top=(e.clientY+12)+"px";
+  tip.innerHTML = "#" + p.idx + " · " + cv._feat + "=" + fmtNum(p.x) + " · score=" + fmtNum(p.score) +
+    (p.anomaly ? ' · <span style="color:var(--danger)">ANOMALY</span>' : "");
+});
+$("chart").addEventListener("mouseleave", ()=> $("tip").style.display="none");
+window.addEventListener("resize", ()=> { if (RESULTS.length) drawChart(); });
+
+function renderList(anoms) {
+  $("listCard").style.display = "block";
+  if (!anoms.length) { $("list").innerHTML = '<div class="empty">No anomalies found 🎉</div>'; return; }
+  const feat = $("feature").value;
+  const keys = NUMKEYS.slice(0, 4);
+  let head = "<tr><th>#</th><th>score</th><th>versions</th>" +
+    keys.map(k=>"<th>"+esc(k)+"</th>").join("") + "</tr>";
+  let rows = anoms.slice(0, 200).map(a =>
+    "<tr><td>" + a.idx + '</td><td class="score">' + fmtNum(a.score) + "</td>" +
+    '<td><div class="vtags">' + a.versions.map(v=>'<span class="vtag">'+esc(v)+"</span>").join("") + "</div></td>" +
+    keys.map(k => "<td>" + (a.rec && typeof a.rec[k]==="number" ? fmtNum(a.rec[k]) : "–") + "</td>").join("") +
+    "</tr>").join("");
+  $("list").innerHTML = "<table><thead>" + head + "</thead><tbody>" + rows + "</tbody></table>" +
+    (anoms.length > 200 ? '<div class="muted" style="padding:8px 12px">…' + (anoms.length-200) + " more</div>" : "");
+}
+
+const qp = new URLSearchParams(location.search);
+loadModels(qp.get("model")).then(() => {
+  // Arriving with ?model= (e.g. the "Anomalies →" deep link) means intent
+  // to scan — kick it off automatically.
+  if (qp.get("model") && DATA.length) run();
+}).catch(e => $("prog").textContent = e.message);
+</script>
+</body>
+</html>

--- a/packages/anomaly/static/modelmanager.html
+++ b/packages/anomaly/static/modelmanager.html
@@ -1,0 +1,387 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Model Manager · anomaly</title>
+<style>
+  :root {
+    --bg: #0e1116; --panel: #161b22; --panel2: #1c2230; --border: #2a3242;
+    --fg: #e6edf3; --muted: #8b98a9; --accent: #4c9aff; --accent2: #6ee7b7;
+    --danger: #ff6b6b; --warn: #f6c344; --ok: #56d364; --radius: 10px;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--fg); font-family: var(--sans);
+         font-size: 14px; line-height: 1.5; }
+  a { color: var(--accent); text-decoration: none; }
+  header { display: flex; align-items: center; gap: 20px; padding: 14px 24px;
+           background: var(--panel); border-bottom: 1px solid var(--border);
+           position: sticky; top: 0; z-index: 10; }
+  header h1 { font-size: 16px; margin: 0; font-weight: 600; letter-spacing: .2px; }
+  header .brand { color: var(--accent2); font-family: var(--mono); }
+  nav { display: flex; gap: 4px; margin-left: auto; }
+  nav a { padding: 6px 12px; border-radius: 8px; color: var(--muted); font-weight: 500; }
+  nav a:hover { background: var(--panel2); color: var(--fg); }
+  nav a.active { background: var(--accent); color: #06122b; }
+  main { max-width: 1200px; margin: 0 auto; padding: 24px; }
+  .toolbar { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; flex-wrap: wrap; }
+  .toolbar .spacer { flex: 1; }
+  .stat { display: flex; gap: 18px; color: var(--muted); font-size: 13px; }
+  .stat b { color: var(--fg); font-variant-numeric: tabular-nums; }
+  button, .btn { font-family: var(--sans); font-size: 13px; border: 1px solid var(--border);
+          background: var(--panel2); color: var(--fg); padding: 6px 12px; border-radius: 8px;
+          cursor: pointer; transition: .12s; font-weight: 500; }
+  button:hover { border-color: var(--accent); }
+  button:disabled { opacity: .5; cursor: default; }
+  button.primary { background: var(--accent); border-color: var(--accent); color: #06122b; }
+  button.danger { color: var(--danger); }
+  button.danger:hover { border-color: var(--danger); background: rgba(255,107,107,.1); }
+  button.small { padding: 3px 8px; font-size: 12px; }
+  input[type=text], input[type=number], select {
+    font-family: var(--mono); font-size: 13px; background: var(--bg); color: var(--fg);
+    border: 1px solid var(--border); border-radius: 8px; padding: 6px 10px; }
+  input:focus, select:focus { outline: none; border-color: var(--accent); }
+  table { width: 100%; border-collapse: collapse; background: var(--panel);
+          border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
+  thead th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .6px;
+             color: var(--muted); padding: 10px 14px; border-bottom: 1px solid var(--border);
+             font-weight: 600; background: var(--panel2); }
+  tbody td { padding: 11px 14px; border-bottom: 1px solid var(--border);
+             font-variant-numeric: tabular-nums; }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr:hover { background: var(--panel2); }
+  tbody tr.selected { background: rgba(76,154,255,.08); }
+  .name { font-family: var(--mono); font-weight: 600; color: var(--fg); cursor: pointer; }
+  .name:hover { color: var(--accent); }
+  .pill { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 11px;
+          font-weight: 600; border: 1px solid var(--border); }
+  .pill.trained { color: var(--ok); border-color: rgba(86,211,100,.4); background: rgba(86,211,100,.08); }
+  .pill.warming { color: var(--warn); border-color: rgba(246,195,68,.4); background: rgba(246,195,68,.08); }
+  .actions { display: flex; gap: 6px; justify-content: flex-end; }
+  .muted { color: var(--muted); }
+  .empty { text-align: center; padding: 60px 20px; color: var(--muted); }
+  .empty svg { opacity: .3; }
+  /* detail drawer */
+  .drawer { position: fixed; top: 0; right: 0; height: 100vh; width: min(560px, 92vw);
+            background: var(--panel); border-left: 1px solid var(--border); z-index: 40;
+            transform: translateX(100%); transition: transform .22s ease; overflow-y: auto;
+            box-shadow: -20px 0 40px rgba(0,0,0,.4); }
+  .drawer.open { transform: translateX(0); }
+  .drawer-head { display: flex; align-items: center; gap: 12px; padding: 16px 20px;
+                 border-bottom: 1px solid var(--border); position: sticky; top: 0;
+                 background: var(--panel); }
+  .drawer-head h2 { margin: 0; font-size: 15px; font-family: var(--mono); }
+  .drawer-body { padding: 20px; }
+  .drawer-close { margin-left: auto; }
+  .section { margin-bottom: 22px; }
+  .section h3 { font-size: 11px; text-transform: uppercase; letter-spacing: .6px;
+                color: var(--muted); margin: 0 0 10px; font-weight: 600; }
+  .kv { display: grid; grid-template-columns: 130px 1fr; gap: 4px 12px; font-size: 13px; }
+  .kv dt { color: var(--muted); }
+  .kv dd { margin: 0; font-family: var(--mono); word-break: break-word; }
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip { font-family: var(--mono); font-size: 12px; background: var(--panel2);
+          border: 1px solid var(--border); border-radius: 6px; padding: 2px 8px; }
+  .chip .t { color: var(--accent2); }
+  .vtable { width: 100%; font-size: 12px; }
+  .vtable th, .vtable td { padding: 5px 8px; text-align: right; }
+  .vtable th:first-child, .vtable td:first-child { text-align: left; font-family: var(--mono); }
+  .sched-form { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
+  .field { display: flex; flex-direction: column; gap: 4px; }
+  .field label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .4px; }
+  .field input { width: 110px; }
+  .backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.5); z-index: 30;
+              opacity: 0; pointer-events: none; transition: opacity .2s; }
+  .backdrop.open { opacity: 1; pointer-events: auto; }
+  /* toasts */
+  #toasts { position: fixed; bottom: 20px; right: 20px; z-index: 100; display: flex;
+            flex-direction: column; gap: 10px; }
+  .toast { background: var(--panel2); border: 1px solid var(--border); border-left: 3px solid var(--accent);
+           padding: 12px 16px; border-radius: 8px; min-width: 240px; max-width: 380px;
+           box-shadow: 0 8px 24px rgba(0,0,0,.4); animation: slidein .2s; font-size: 13px; }
+  .toast.ok { border-left-color: var(--ok); }
+  .toast.err { border-left-color: var(--danger); }
+  .toast .th { font-weight: 600; margin-bottom: 2px; }
+  @keyframes slidein { from { transform: translateX(30px); opacity: 0; } }
+  .spin { display: inline-block; width: 13px; height: 13px; border: 2px solid var(--border);
+          border-top-color: var(--accent); border-radius: 50%; animation: rot .7s linear infinite;
+          vertical-align: -2px; }
+  @keyframes rot { to { transform: rotate(360deg); } }
+</style>
+</head>
+<body>
+<header>
+  <h1><span class="brand">anomaly</span> · Model Manager</h1>
+  <nav>
+    <a href="/modelmanager.html" class="active">Models</a>
+    <a href="/modeltrainer.html">Trainer</a>
+    <a href="/visualize.html">Visualize</a>
+    <a href="/anomalies.html">Anomalies</a>
+  </nav>
+</header>
+
+<main>
+  <div class="toolbar">
+    <button class="primary" onclick="load()">↻ Refresh</button>
+    <label class="muted" style="display:flex;align-items:center;gap:6px;font-size:13px;">
+      <input type="checkbox" id="auto"> auto (5s)
+    </label>
+    <div class="spacer"></div>
+    <div class="stat">
+      <span><b id="statCount">0</b> models</span>
+      <span>min pts <b id="statMin">–</b></span>
+      <span>max pts <b id="statMax">–</b></span>
+    </div>
+  </div>
+
+  <table id="tbl">
+    <thead>
+      <tr>
+        <th>Model</th>
+        <th>Status</th>
+        <th style="text-align:right">Points seen</th>
+        <th>Created</th>
+        <th>Last trained</th>
+        <th>Versions</th>
+        <th style="text-align:right">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="rows"></tbody>
+  </table>
+  <div id="empty" class="empty" style="display:none">
+    <div style="font-size:15px;margin-bottom:6px">No models yet</div>
+    <div>Feed data via the <a href="/modeltrainer.html">Trainer</a> or <code>POST /detect/&lt;model&gt;</code>.</div>
+  </div>
+</main>
+
+<div class="backdrop" id="backdrop" onclick="closeDrawer()"></div>
+<div class="drawer" id="drawer">
+  <div class="drawer-head">
+    <h2 id="dTitle">model</h2>
+    <button class="small drawer-close" onclick="closeDrawer()">✕ Close</button>
+  </div>
+  <div class="drawer-body" id="dBody"></div>
+</div>
+
+<div id="toasts"></div>
+
+<script>
+"use strict";
+const $ = (id) => document.getElementById(id);
+let MODELS = {};      // name -> meta
+let SELECTED = null;
+let autoTimer = null;
+
+function toast(msg, kind, title) {
+  const t = document.createElement("div");
+  t.className = "toast " + (kind || "");
+  t.innerHTML = (title ? '<div class="th">' + esc(title) + "</div>" : "") + esc(msg);
+  $("toasts").appendChild(t);
+  setTimeout(() => { t.style.opacity = "0"; t.style.transition = "opacity .3s";
+                     setTimeout(() => t.remove(), 300); }, kind === "err" ? 5000 : 2800);
+}
+function esc(s) {
+  return String(s).replace(/[&<>"]/g, c => ({ "&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;" }[c]));
+}
+async function api(method, url, body) {
+  const opt = { method, headers: {} };
+  if (body !== undefined) { opt.headers["Content-Type"] = "application/json"; opt.body = JSON.stringify(body); }
+  const r = await fetch(url, opt);
+  let data = null;
+  try { data = await r.json(); } catch (e) {}
+  if (!r.ok) throw new Error((data && data.message) || (r.status + " " + r.statusText));
+  return data;
+}
+
+// `last_trained_at` is a point counter (n_seen at the last retrain), not a
+// clock time — render it as a point mark.
+function fmtTrained(n) {
+  if (!n || n <= 0) return '<span class="muted">never</span>';
+  return '@ ' + Number(n).toLocaleString() + ' pts';
+}
+function versionSummary(meta) {
+  const v = meta.versions || {};
+  const names = Object.keys(v);
+  const on = names.filter(n => v[n].enabled).length;
+  return names.length ? (on + "/" + names.length + " on") : "–";
+}
+function isTrained(meta) {
+  return (meta.last_trained_at || 0) > 0;
+}
+
+async function load() {
+  try {
+    const d = await api("GET", "/models/dynamic");
+    MODELS = d.models || {};
+    $("statMin").textContent = d.min_data_points ?? "–";
+    $("statMax").textContent = (d.max_data_points ?? "–").toLocaleString?.() ?? d.max_data_points;
+    render();
+    if (SELECTED && MODELS[SELECTED]) renderDrawer(SELECTED);
+  } catch (e) {
+    toast(e.message, "err", "Load failed");
+  }
+}
+
+function render() {
+  const names = Object.keys(MODELS).sort();
+  $("statCount").textContent = names.length;
+  const rows = $("rows");
+  rows.innerHTML = "";
+  $("empty").style.display = names.length ? "none" : "block";
+  $("tbl").style.display = names.length ? "" : "none";
+  for (const name of names) {
+    const m = MODELS[name];
+    const tr = document.createElement("tr");
+    if (name === SELECTED) tr.className = "selected";
+    const trained = isTrained(m);
+    tr.innerHTML =
+      '<td><span class="name" data-m="' + esc(name) + '">' + esc(name) + "</span></td>" +
+      '<td><span class="pill ' + (trained ? "trained" : "warming") + '">' +
+        (trained ? "trained" : "warming") + "</span></td>" +
+      '<td style="text-align:right">' + (m.n_points_seen ?? 0).toLocaleString() + "</td>" +
+      "<td>" + esc(m.created || "–") + "</td>" +
+      "<td>" + fmtTrained(m.last_trained_at) + "</td>" +
+      "<td>" + versionSummary(m) + "</td>" +
+      '<td><div class="actions">' +
+        '<button class="small" data-act="train" data-m="' + esc(name) + '">Train</button>' +
+        '<button class="small" data-act="finetune" data-m="' + esc(name) + '">Finetune</button>' +
+        '<button class="small" data-act="reset" data-m="' + esc(name) + '">Reset</button>' +
+        '<button class="small danger" data-act="delete" data-m="' + esc(name) + '">Delete</button>' +
+      "</div></td>";
+    rows.appendChild(tr);
+  }
+  rows.querySelectorAll(".name").forEach(el =>
+    el.onclick = () => openDrawer(el.dataset.m));
+  rows.querySelectorAll("button[data-act]").forEach(el =>
+    el.onclick = () => doAction(el.dataset.act, el.dataset.m, el));
+}
+
+async function doAction(act, name, btn) {
+  if (act === "delete" && !confirm('Delete model "' + name + '"? This removes all data and forests.')) return;
+  if (act === "reset" && !confirm('Reset model "' + name + '"? Drops data and forests, keeps the name.')) return;
+  const orig = btn ? btn.textContent : "";
+  if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spin"></span>'; }
+  try {
+    let d;
+    if (act === "train")        d = await api("POST", "/force_train/" + enc(name));
+    else if (act === "reset")   d = await api("POST", "/models/dynamic/" + enc(name) + "/reset");
+    else if (act === "delete")  d = await api("DELETE", "/delete_model/" + enc(name));
+    else if (act === "finetune")d = await api("POST", "/api/dynamic/" + enc(name) + "/finetune");
+    toast((d && d.message) || "OK", "ok", act);
+    if (act === "delete" && SELECTED === name) closeDrawer();
+    await load();
+  } catch (e) {
+    toast(e.message, "err", act + " failed");
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = orig; }
+  }
+}
+const enc = encodeURIComponent;
+
+// ── Detail drawer ──────────────────────────────────────────────
+async function openDrawer(name) {
+  SELECTED = name;
+  $("drawer").classList.add("open");
+  $("backdrop").classList.add("open");
+  render();
+  try {
+    const meta = await api("GET", "/models/dynamic/" + enc(name) + "/metadata");
+    MODELS[name] = meta;
+    renderDrawer(name);
+  } catch (e) {
+    $("dBody").innerHTML = '<p class="muted">' + esc(e.message) + "</p>";
+  }
+}
+function closeDrawer() {
+  SELECTED = null;
+  $("drawer").classList.remove("open");
+  $("backdrop").classList.remove("open");
+  render();
+}
+function renderDrawer(name) {
+  const m = MODELS[name];
+  $("dTitle").textContent = name;
+  const cols = m.column_types || {};
+  const feats = m.feature_names || [];
+  const sched = m.schedule || { below_max: 0, at_max: 0 };
+  const vers = m.versions || {};
+
+  let colChips = Object.keys(cols).map(c =>
+    '<span class="chip">' + esc(c) + ' <span class="t">' + esc(cols[c]) + "</span></span>").join("");
+  if (!colChips) colChips = '<span class="muted">none</span>';
+
+  let vrows = Object.keys(vers).map(vn => {
+    const v = vers[vn];
+    return "<tr><td>" + esc(vn) + "</td><td>" + (v.enabled ? "✓" : "–") + "</td>" +
+      "<td>" + (v.window_minutes || 0) + "m/" + (v.window_points || 0) + "p</td>" +
+      "<td>" + (v.n_estimators || 0) + "×" + (v.max_samples || 0) + "</td>" +
+      "<td>" + fmtNum(v.decision_margin) + "</td></tr>";
+  }).join("");
+  if (!vrows) vrows = '<tr><td colspan="5" class="muted">no versions</td></tr>';
+
+  $("dBody").innerHTML =
+    '<div class="section"><h3>Overview</h3><dl class="kv">' +
+      "<dt>Status</dt><dd>" + (isTrained(m) ? "trained" : "warming up") + "</dd>" +
+      "<dt>Points seen</dt><dd>" + (m.n_points_seen ?? 0).toLocaleString() + "</dd>" +
+      "<dt>Created</dt><dd>" + esc(m.created || "–") + "</dd>" +
+      "<dt>Last trained</dt><dd>" + fmtTrained(m.last_trained_at) + "</dd>" +
+      "<dt>Features</dt><dd>" + (feats.length ? esc(feats.join(", ")) : '<span class="muted">–</span>') + "</dd>" +
+    "</dl></div>" +
+
+    '<div class="section"><h3>Columns</h3><div class="chips">' + colChips + "</div></div>" +
+
+    '<div class="section"><h3>Versions</h3><table class="vtable">' +
+      "<thead><tr><th>name</th><th>on</th><th>window</th><th>trees</th><th>margin</th></tr></thead>" +
+      "<tbody>" + vrows + "</tbody></table></div>" +
+
+    '<div class="section"><h3>Retrain schedule</h3>' +
+      '<div class="sched-form">' +
+        '<div class="field"><label>below max (every N pts)</label>' +
+          '<input type="number" id="schedBelow" min="0" value="' + (sched.below_max || 0) + '"></div>' +
+        '<div class="field"><label>at max (every N pts)</label>' +
+          '<input type="number" id="schedAt" min="0" value="' + (sched.at_max || 0) + '"></div>' +
+        '<button class="primary" onclick="saveSchedule(\'' + esc(name) + '\')">Save</button>' +
+      "</div></div>" +
+
+    '<div class="section"><h3>Actions</h3><div class="actions" style="justify-content:flex-start">' +
+      '<button onclick="doAction(\'train\',\'' + esc(name) + '\',this)">Force train</button>' +
+      '<button onclick="doAction(\'finetune\',\'' + esc(name) + '\',this)">Finetune margins</button>' +
+      '<a class="btn" href="/visualize.html?model=' + enc(name) + '">Visualize →</a>' +
+      '<a class="btn" href="/anomalies.html?model=' + enc(name) + '">Anomalies →</a>' +
+    "</div></div>";
+}
+function fmtNum(x) {
+  if (x === null || x === undefined) return "–";
+  if (typeof x !== "number") return esc(x);
+  return Math.abs(x) < 1e-4 && x !== 0 ? x.toExponential(2) : x.toFixed(4).replace(/\.?0+$/, "");
+}
+
+async function saveSchedule(name) {
+  const below = parseInt($("schedBelow").value, 10) || 0;
+  const at = parseInt($("schedAt").value, 10) || 0;
+  try {
+    const d = await api("PUT", "/api/dynamic/" + enc(name) + "/schedule", {
+      below_max_retrain_frequency: below,
+      at_max_retrain_frequency: at,
+    });
+    toast((d && d.message) || "Schedule saved", "ok", "schedule");
+    await load();
+  } catch (e) {
+    toast(e.message, "err", "Schedule failed");
+  }
+}
+
+$("auto").onchange = (e) => {
+  if (e.target.checked) autoTimer = setInterval(load, 5000);
+  else { clearInterval(autoTimer); autoTimer = null; }
+};
+document.addEventListener("keydown", e => { if (e.key === "Escape") closeDrawer(); });
+
+// deep link ?model=NAME opens the drawer
+const qp = new URLSearchParams(location.search);
+load().then(() => { const m = qp.get("model"); if (m && MODELS[m]) openDrawer(m); });
+</script>
+</body>
+</html>

--- a/packages/anomaly/static/modeltrainer.html
+++ b/packages/anomaly/static/modeltrainer.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Trainer · anomaly</title>
+<style>
+  :root {
+    --bg: #0e1116; --panel: #161b22; --panel2: #1c2230; --border: #2a3242;
+    --fg: #e6edf3; --muted: #8b98a9; --accent: #4c9aff; --accent2: #6ee7b7;
+    --danger: #ff6b6b; --warn: #f6c344; --ok: #56d364; --radius: 10px;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--fg); font-family: var(--sans); font-size: 14px; line-height: 1.5; }
+  a { color: var(--accent); text-decoration: none; }
+  header { display: flex; align-items: center; gap: 20px; padding: 14px 24px; background: var(--panel);
+           border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 10; }
+  header h1 { font-size: 16px; margin: 0; font-weight: 600; }
+  header .brand { color: var(--accent2); font-family: var(--mono); }
+  nav { display: flex; gap: 4px; margin-left: auto; }
+  nav a { padding: 6px 12px; border-radius: 8px; color: var(--muted); font-weight: 500; }
+  nav a:hover { background: var(--panel2); color: var(--fg); }
+  nav a.active { background: var(--accent); color: #06122b; }
+  main { max-width: 1100px; margin: 0 auto; padding: 24px; display: grid;
+         grid-template-columns: 1fr 1fr; gap: 20px; }
+  @media (max-width: 860px) { main { grid-template-columns: 1fr; } }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 18px 20px; }
+  .card h2 { font-size: 14px; margin: 0 0 14px; font-weight: 600; }
+  .card h2 .sub { color: var(--muted); font-weight: 400; font-size: 12px; margin-left: 8px; }
+  label.fl { display: block; font-size: 11px; color: var(--muted); text-transform: uppercase;
+             letter-spacing: .4px; margin: 12px 0 5px; }
+  input[type=text], input[type=number], select, textarea {
+    font-family: var(--mono); font-size: 13px; background: var(--bg); color: var(--fg);
+    border: 1px solid var(--border); border-radius: 8px; padding: 7px 10px; width: 100%; }
+  input:focus, select:focus, textarea:focus { outline: none; border-color: var(--accent); }
+  textarea { resize: vertical; min-height: 120px; line-height: 1.45; }
+  button { font-family: var(--sans); font-size: 13px; border: 1px solid var(--border);
+           background: var(--panel2); color: var(--fg); padding: 8px 14px; border-radius: 8px;
+           cursor: pointer; transition: .12s; font-weight: 500; }
+  button:hover { border-color: var(--accent); }
+  button:disabled { opacity: .5; cursor: default; }
+  button.primary { background: var(--accent); border-color: var(--accent); color: #06122b; }
+  button.small { padding: 4px 9px; font-size: 12px; }
+  .row { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
+  .row input.k { flex: 0 0 40%; }
+  .row input.v { flex: 1; }
+  .btns { display: flex; gap: 8px; margin-top: 16px; flex-wrap: wrap; }
+  .muted { color: var(--muted); }
+  .verdict { margin-top: 16px; border-radius: 8px; padding: 14px; border: 1px solid var(--border);
+             background: var(--panel2); font-size: 13px; }
+  .verdict.anom { border-color: var(--danger); background: rgba(255,107,107,.08); }
+  .verdict.ok { border-color: var(--ok); background: rgba(86,211,100,.06); }
+  .verdict.warm { border-color: var(--warn); background: rgba(246,195,68,.06); }
+  .verdict .big { font-size: 15px; font-weight: 700; margin-bottom: 6px; }
+  .verdict .score { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+  .vgrid { display: grid; grid-template-columns: 1fr auto auto; gap: 3px 14px; margin-top: 10px;
+           font-family: var(--mono); font-size: 12px; }
+  .vgrid .h { color: var(--muted); font-size: 10px; text-transform: uppercase; }
+  .flag { color: var(--danger); font-weight: 700; }
+  .flag.n { color: var(--ok); }
+  pre.log { background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 12px;
+            font-family: var(--mono); font-size: 12px; max-height: 240px; overflow: auto; margin: 12px 0 0;
+            white-space: pre-wrap; word-break: break-word; }
+  .bar { height: 6px; background: var(--panel2); border-radius: 3px; overflow: hidden; margin-top: 10px; }
+  .bar > i { display: block; height: 100%; background: var(--accent); width: 0; transition: width .2s; }
+  #toasts { position: fixed; bottom: 20px; right: 20px; z-index: 100; display: flex; flex-direction: column; gap: 10px; }
+  .toast { background: var(--panel2); border: 1px solid var(--border); border-left: 3px solid var(--accent);
+           padding: 12px 16px; border-radius: 8px; min-width: 220px; box-shadow: 0 8px 24px rgba(0,0,0,.4); font-size: 13px; }
+  .toast.ok { border-left-color: var(--ok); } .toast.err { border-left-color: var(--danger); }
+  .toast .th { font-weight: 600; margin-bottom: 2px; }
+  .spin { display: inline-block; width: 13px; height: 13px; border: 2px solid var(--border);
+          border-top-color: var(--accent); border-radius: 50%; animation: rot .7s linear infinite; vertical-align: -2px; }
+  @keyframes rot { to { transform: rotate(360deg); } }
+  .hint { font-size: 12px; color: var(--muted); margin-top: 6px; }
+</style>
+</head>
+<body>
+<header>
+  <h1><span class="brand">anomaly</span> · Trainer</h1>
+  <nav>
+    <a href="/modelmanager.html">Models</a>
+    <a href="/modeltrainer.html" class="active">Trainer</a>
+    <a href="/visualize.html">Visualize</a>
+    <a href="/anomalies.html">Anomalies</a>
+  </nav>
+</header>
+
+<main>
+  <!-- Single point -->
+  <div class="card">
+    <h2>Ingest a point <span class="sub">POST /detect · /detect_only</span></h2>
+    <label class="fl">Model name</label>
+    <input type="text" id="model" list="models" placeholder="e.g. sensor_hall" autocomplete="off">
+    <datalist id="models"></datalist>
+    <div class="hint">A model is created on first ingest. Names: letters, digits, underscore.</div>
+
+    <label class="fl">Features (key = value)</label>
+    <div id="fields"></div>
+    <button class="small" onclick="addField()">+ add feature</button>
+
+    <div class="btns">
+      <button class="primary" id="btnIngest" onclick="send(true)">Ingest → detect</button>
+      <button id="btnScore" onclick="send(false)">Score only</button>
+      <button onclick="forceTrain()">Force train</button>
+    </div>
+    <div id="verdict"></div>
+  </div>
+
+  <!-- Bulk feed -->
+  <div class="card">
+    <h2>Bulk feed <span class="sub">one JSON object per line → POST /detect</span></h2>
+    <label class="fl">Target model</label>
+    <input type="text" id="bulkModel" list="models" placeholder="model name" autocomplete="off">
+    <label class="fl">JSON lines</label>
+    <textarea id="bulkData" placeholder='{"temp": 21.5, "load": 3}
+{"temp": 22.0, "load": 4}
+{"temp": 80.0, "load": 9}'></textarea>
+    <div class="btns">
+      <button class="primary" id="btnBulk" onclick="bulkFeed()">Feed all</button>
+      <button onclick="genSynthetic()">Generate 80 synthetic</button>
+      <span class="muted" id="bulkCount" style="align-self:center"></span>
+    </div>
+    <div class="bar"><i id="bulkBar"></i></div>
+    <pre class="log" id="bulkLog" style="display:none"></pre>
+  </div>
+</main>
+
+<div id="toasts"></div>
+
+<script>
+"use strict";
+const $ = (id) => document.getElementById(id);
+const enc = encodeURIComponent;
+
+function toast(msg, kind, title) {
+  const t = document.createElement("div");
+  t.className = "toast " + (kind || "");
+  t.innerHTML = (title ? '<div class="th">' + esc(title) + "</div>" : "") + esc(msg);
+  $("toasts").appendChild(t);
+  setTimeout(() => { t.style.opacity = "0"; t.style.transition = "opacity .3s";
+                     setTimeout(() => t.remove(), 300); }, kind === "err" ? 5000 : 2600);
+}
+function esc(s) { return String(s).replace(/[&<>"]/g, c => ({ "&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;" }[c])); }
+
+async function api(method, url, body) {
+  const opt = { method, headers: {} };
+  if (body !== undefined) { opt.headers["Content-Type"] = "application/json"; opt.body = JSON.stringify(body); }
+  const r = await fetch(url, opt);
+  let data = null; try { data = await r.json(); } catch (e) {}
+  return { ok: r.ok, status: r.status, data };
+}
+
+function addField(k, v) {
+  const div = document.createElement("div");
+  div.className = "row";
+  div.innerHTML =
+    '<input class="k" type="text" placeholder="key" value="' + esc(k || "") + '">' +
+    '<input class="v" type="text" placeholder="value" value="' + esc(v || "") + '">' +
+    '<button class="small" onclick="this.parentNode.remove()">✕</button>';
+  $("fields").appendChild(div);
+}
+function collectRecord() {
+  const rec = {};
+  $("fields").querySelectorAll(".row").forEach(r => {
+    const k = r.querySelector(".k").value.trim();
+    let v = r.querySelector(".v").value.trim();
+    if (!k) return;
+    const n = Number(v);
+    rec[k] = (v !== "" && !isNaN(n)) ? n : v;
+  });
+  return rec;
+}
+
+function renderVerdict(el, d, status) {
+  if (!d) { el.innerHTML = '<div class="verdict err">No response</div>'; return; }
+  if (status === 202 || d.status === "collecting") {
+    el.innerHTML = '<div class="verdict warm"><div class="big">⏳ Warming up</div>' +
+      '<div>' + esc(d.message || "") + "</div>" +
+      '<div class="muted">' + (d.data_points ?? "?") + " / " + (d.min_data_points ?? "?") + " points</div></div>";
+    return;
+  }
+  if (d.status === "error") { el.innerHTML = '<div class="verdict err"><div class="big">Error</div>' + esc(d.message) + "</div>"; return; }
+  const anom = !!d.anomaly;
+  let vrows = "";
+  const versions = d.versions || {};
+  for (const vn of Object.keys(versions)) {
+    const v = versions[vn];
+    const th = v.threshold_info || {};
+    vrows += "<div>" + esc(vn) + '</div><div class="flag ' + (v.anomaly ? "" : "n") + '">' +
+      (v.anomaly ? "ANOM" : "ok") + "</div><div>" + fmtNum(v.score) + "</div>";
+  }
+  el.innerHTML = '<div class="verdict ' + (anom ? "anom" : "ok") + '">' +
+    '<div class="big">' + (anom ? "🚨 Anomaly" : "✓ Normal") + "</div>" +
+    '<div class="score">score = ' + fmtNum(d.score) + " · " + (d.data_points ?? "?") + " pts</div>" +
+    (vrows ? '<div class="vgrid"><div class="h">version</div><div class="h">flag</div><div class="h">score</div>' + vrows + "</div>" : "") +
+    "</div>";
+}
+function fmtNum(x) {
+  if (x === null || x === undefined || typeof x !== "number") return "–";
+  return Math.abs(x) < 1e-4 && x !== 0 ? x.toExponential(3) : x.toFixed(5).replace(/\.?0+$/, "");
+}
+
+async function send(ingest) {
+  const name = $("model").value.trim();
+  if (!name) { toast("Model name required", "err"); return; }
+  const rec = collectRecord();
+  if (Object.keys(rec).length === 0) { toast("Add at least one feature", "err"); return; }
+  const btn = ingest ? $("btnIngest") : $("btnScore");
+  const orig = btn.textContent; btn.disabled = true; btn.innerHTML = '<span class="spin"></span>';
+  try {
+    const url = (ingest ? "/detect/" : "/detect_only/") + enc(name);
+    const { ok, status, data } = await api("POST", url, rec);
+    renderVerdict($("verdict"), data, status);
+    if (ok || status === 202) refreshModels();
+  } catch (e) { toast(e.message, "err"); }
+  finally { btn.disabled = false; btn.textContent = orig; }
+}
+
+async function forceTrain() {
+  const name = $("model").value.trim();
+  if (!name) { toast("Model name required", "err"); return; }
+  const { ok, data } = await api("POST", "/force_train/" + enc(name));
+  toast((data && data.message) || (ok ? "trained" : "failed"), ok ? "ok" : "err", "force train");
+}
+
+async function bulkFeed() {
+  const name = $("bulkModel").value.trim();
+  if (!name) { toast("Target model required", "err"); return; }
+  const lines = $("bulkData").value.split("\n").map(l => l.trim()).filter(Boolean);
+  if (!lines.length) { toast("No JSON lines to feed", "err"); return; }
+  const btn = $("btnBulk"); btn.disabled = true;
+  const log = $("bulkLog"); log.style.display = "block"; log.textContent = "";
+  let ok = 0, warm = 0, err = 0, lastVerdict = null;
+  for (let i = 0; i < lines.length; i++) {
+    let rec;
+    try { rec = JSON.parse(lines[i]); }
+    catch (e) { err++; log.textContent += "line " + (i+1) + ": bad JSON\n"; continue; }
+    const res = await api("POST", "/detect/" + enc(name), rec);
+    if (res.status === 202) warm++;
+    else if (res.ok) { ok++; lastVerdict = res.data; }
+    else { err++; log.textContent += "line " + (i+1) + ": " + ((res.data && res.data.message) || res.status) + "\n"; }
+    $("bulkBar").style.width = Math.round((i+1)/lines.length*100) + "%";
+    $("bulkCount").textContent = (i+1) + "/" + lines.length;
+    log.scrollTop = log.scrollHeight;
+  }
+  log.textContent += "\ndone — " + ok + " scored, " + warm + " warming, " + err + " errors\n";
+  if (lastVerdict) renderVerdict($("verdict"), lastVerdict, 200);
+  btn.disabled = false;
+  refreshModels();
+  toast(ok + " scored, " + warm + " warming, " + err + " err", err ? "err" : "ok", "bulk feed");
+}
+
+function genSynthetic() {
+  const N = 80;
+  let out = [];
+  for (let i = 0; i < N; i++) {
+    // mostly-normal stream with a few injected spikes
+    const spike = (i % 27 === 0 && i > 0);
+    const temp = spike ? 70 + Math.random()*15 : 20 + Math.random()*6;
+    const load = spike ? 9 : Math.floor(Math.random()*5);
+    const vib = spike ? 8 + Math.random()*4 : 1 + Math.random()*2;
+    out.push(JSON.stringify({ temp: +temp.toFixed(2), load, vib: +vib.toFixed(2) }));
+  }
+  $("bulkData").value = out.join("\n");
+  if (!$("bulkModel").value.trim()) $("bulkModel").value = "demo";
+  toast("Generated " + N + " points (with spikes)", "ok");
+}
+
+async function refreshModels() {
+  try {
+    const r = await api("GET", "/models/dynamic");
+    if (!r.ok) return;
+    const names = Object.keys(r.data.models || {});
+    $("models").innerHTML = names.map(n => '<option value="' + esc(n) + '">').join("");
+  } catch (e) {}
+}
+
+// init
+addField("temp", "");
+addField("load", "");
+refreshModels();
+const qp = new URLSearchParams(location.search);
+if (qp.get("model")) { $("model").value = qp.get("model"); $("bulkModel").value = qp.get("model"); }
+</script>
+</body>
+</html>

--- a/packages/anomaly/static/visualize.html
+++ b/packages/anomaly/static/visualize.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Visualize · anomaly</title>
+<style>
+  :root {
+    --bg: #0e1116; --panel: #161b22; --panel2: #1c2230; --border: #2a3242;
+    --fg: #e6edf3; --muted: #8b98a9; --accent: #4c9aff; --accent2: #6ee7b7;
+    --danger: #ff6b6b; --warn: #f6c344; --ok: #56d364; --radius: 10px; --grid: #212836;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--fg); font-family: var(--sans); font-size: 14px; }
+  a { color: var(--accent); text-decoration: none; }
+  header { display: flex; align-items: center; gap: 20px; padding: 14px 24px; background: var(--panel);
+           border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 10; }
+  header h1 { font-size: 16px; margin: 0; font-weight: 600; }
+  header .brand { color: var(--accent2); font-family: var(--mono); }
+  nav { display: flex; gap: 4px; margin-left: auto; }
+  nav a { padding: 6px 12px; border-radius: 8px; color: var(--muted); font-weight: 500; }
+  nav a:hover { background: var(--panel2); color: var(--fg); }
+  nav a.active { background: var(--accent); color: #06122b; }
+  main { max-width: 1200px; margin: 0 auto; padding: 24px; }
+  .controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-bottom: 18px; }
+  select, input[type=text] { font-family: var(--mono); font-size: 13px; background: var(--bg); color: var(--fg);
+    border: 1px solid var(--border); border-radius: 8px; padding: 7px 10px; }
+  select:focus { outline: none; border-color: var(--accent); }
+  button { font-family: var(--sans); font-size: 13px; border: 1px solid var(--border); background: var(--panel2);
+           color: var(--fg); padding: 7px 12px; border-radius: 8px; cursor: pointer; font-weight: 500; }
+  button:hover { border-color: var(--accent); }
+  label.lbl { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .4px; margin-right: 4px; }
+  .layout { display: grid; grid-template-columns: 1fr 300px; gap: 20px; }
+  @media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 18px; }
+  .card h2 { font-size: 12px; text-transform: uppercase; letter-spacing: .6px; color: var(--muted);
+             margin: 0 0 14px; font-weight: 600; }
+  canvas { width: 100%; display: block; }
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip { font-family: var(--mono); font-size: 12px; background: var(--panel2); border: 1px solid var(--border);
+          border-radius: 6px; padding: 3px 9px; cursor: pointer; }
+  .chip.on { border-color: var(--accent); color: var(--accent); }
+  .chip .t { color: var(--accent2); }
+  .kv { display: grid; grid-template-columns: 110px 1fr; gap: 4px 10px; font-size: 13px; }
+  .kv dt { color: var(--muted); } .kv dd { margin: 0; font-family: var(--mono); word-break: break-word; }
+  .muted { color: var(--muted); }
+  .stat-row { display: flex; gap: 20px; margin-bottom: 14px; flex-wrap: wrap; }
+  .stat { background: var(--panel2); border: 1px solid var(--border); border-radius: 8px; padding: 10px 14px; }
+  .stat .n { font-size: 20px; font-weight: 700; font-family: var(--mono); font-variant-numeric: tabular-nums; }
+  .stat .l { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .4px; }
+  .empty { text-align: center; padding: 60px; color: var(--muted); }
+  .section { margin-bottom: 20px; }
+  #tip { position: fixed; pointer-events: none; background: var(--panel2); border: 1px solid var(--border);
+         border-radius: 6px; padding: 6px 9px; font-family: var(--mono); font-size: 12px; display: none;
+         box-shadow: 0 6px 18px rgba(0,0,0,.5); z-index: 50; white-space: nowrap; }
+</style>
+</head>
+<body>
+<header>
+  <h1><span class="brand">anomaly</span> · Visualize</h1>
+  <nav>
+    <a href="/modelmanager.html">Models</a>
+    <a href="/modeltrainer.html">Trainer</a>
+    <a href="/visualize.html" class="active">Visualize</a>
+    <a href="/anomalies.html">Anomalies</a>
+  </nav>
+</header>
+
+<main>
+  <div class="controls">
+    <span><label class="lbl">Model</label><select id="model" onchange="onModel()"></select></span>
+    <button onclick="refresh()">↻ Reload</button>
+    <span class="muted" id="count"></span>
+  </div>
+
+  <div class="layout">
+    <div>
+      <div class="stat-row" id="stats"></div>
+      <div class="card section">
+        <h2>Feature</h2>
+        <div class="chips" id="featChips"></div>
+      </div>
+      <div class="card">
+        <h2 id="chartTitle">Series</h2>
+        <canvas id="chart" height="380"></canvas>
+        <div id="chartEmpty" class="empty" style="display:none">Select a model with numeric data.</div>
+      </div>
+    </div>
+    <div>
+      <div class="card">
+        <h2>Metadata</h2>
+        <div id="meta"><div class="muted">–</div></div>
+      </div>
+    </div>
+  </div>
+</main>
+<div id="tip"></div>
+
+<script>
+"use strict";
+const $ = (id) => document.getElementById(id);
+const enc = encodeURIComponent;
+let DATA = [];         // array of raw records
+let NUMKEYS = [];      // numeric feature keys
+let FEATURE = null;
+let SERIES = [];       // [{i, x}]
+
+async function api(url) {
+  const r = await fetch(url);
+  let d = null; try { d = await r.json(); } catch (e) {}
+  if (!r.ok) throw new Error((d && d.message) || (r.status + ""));
+  return d;
+}
+function esc(s) { return String(s).replace(/[&<>"]/g, c => ({ "&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;" }[c])); }
+function fmtNum(x) {
+  if (typeof x !== "number") return esc(x);
+  if (!isFinite(x)) return "–";
+  return Math.abs(x) >= 1000 ? x.toLocaleString(undefined, {maximumFractionDigits: 2})
+       : Math.abs(x) < 1e-4 && x !== 0 ? x.toExponential(2) : +x.toFixed(4) + "";
+}
+
+async function loadModels(preselect) {
+  const d = await api("/models/dynamic");
+  const names = Object.keys(d.models || {}).sort();
+  $("model").innerHTML = names.map(n => '<option value="' + esc(n) + '">' + esc(n) + "</option>").join("");
+  if (!names.length) { $("model").innerHTML = '<option>(no models)</option>'; return; }
+  if (preselect && names.includes(preselect)) $("model").value = preselect;
+  await onModel();
+}
+
+async function onModel() {
+  const name = $("model").value;
+  if (!name || name === "(no models)") return;
+  await Promise.all([loadData(name), loadMeta(name)]);
+}
+
+async function loadData(name) {
+  try {
+    const d = await api("/models/dynamic/" + enc(name) + "/data?limit=all");
+    DATA = d.data || [];
+    $("count").textContent = DATA.length + " points";
+    // discover numeric keys
+    const keys = {};
+    for (const rec of DATA) {
+      if (rec && typeof rec === "object")
+        for (const k of Object.keys(rec)) if (typeof rec[k] === "number") keys[k] = true;
+    }
+    NUMKEYS = Object.keys(keys);
+    if (!NUMKEYS.includes(FEATURE)) FEATURE = NUMKEYS[0] || null;
+    renderChips();
+    renderStats();
+    draw();
+  } catch (e) { $("count").textContent = e.message; }
+}
+
+async function loadMeta(name) {
+  try {
+    const m = await api("/models/dynamic/" + enc(name) + "/metadata");
+    const cols = m.column_types || {};
+    const sched = m.schedule || {};
+    const vers = m.versions || {};
+    const onv = Object.keys(vers).filter(v => vers[v].enabled);
+    $("meta").innerHTML = '<dl class="kv">' +
+      "<dt>Created</dt><dd>" + esc(m.created || "–") + "</dd>" +
+      "<dt>Points seen</dt><dd>" + (m.n_points_seen ?? 0).toLocaleString() + "</dd>" +
+      "<dt>Last trained</dt><dd>" + (m.last_trained_at > 0 ? "@ " + m.last_trained_at.toLocaleString() + " pts" : "never") + "</dd>" +
+      "<dt>Schedule</dt><dd>below " + (sched.below_max||0) + " · at " + (sched.at_max||0) + "</dd>" +
+      "<dt>Versions</dt><dd>" + (onv.length ? esc(onv.join(", ")) : "–") + "</dd>" +
+      "<dt>Features</dt><dd>" + (m.feature_names||[]).map(esc).join(", ") + "</dd>" +
+      "</dl>";
+  } catch (e) { $("meta").innerHTML = '<div class="muted">' + esc(e.message) + "</div>"; }
+}
+
+function renderChips() {
+  $("featChips").innerHTML = NUMKEYS.length
+    ? NUMKEYS.map(k => '<span class="chip ' + (k===FEATURE?"on":"") + '" data-k="' + esc(k) + '">' + esc(k) + "</span>").join("")
+    : '<span class="muted">no numeric features in stored data</span>';
+  $("featChips").querySelectorAll(".chip").forEach(el =>
+    el.onclick = () => { FEATURE = el.dataset.k; renderChips(); renderStats(); draw(); });
+}
+
+function series() {
+  const s = [];
+  for (let i = 0; i < DATA.length; i++) {
+    const v = DATA[i] && DATA[i][FEATURE];
+    if (typeof v === "number" && isFinite(v)) s.push({ i, x: v });
+  }
+  return s;
+}
+function renderStats() {
+  SERIES = FEATURE ? series() : [];
+  const xs = SERIES.map(p => p.x);
+  const n = xs.length;
+  const mean = n ? xs.reduce((a,b)=>a+b,0)/n : 0;
+  const sd = n ? Math.sqrt(xs.reduce((a,b)=>a+(b-mean)*(b-mean),0)/n) : 0;
+  const mn = n ? Math.min(...xs) : 0, mx = n ? Math.max(...xs) : 0;
+  $("stats").innerHTML = [
+    ["points", n], ["mean", fmtNum(mean)], ["std", fmtNum(sd)],
+    ["min", fmtNum(mn)], ["max", fmtNum(mx)],
+  ].map(([l,v]) => '<div class="stat"><div class="n">' + v + '</div><div class="l">' + l + "</div></div>").join("");
+}
+
+function draw() {
+  const cv = $("chart");
+  const empty = !FEATURE || SERIES.length === 0;
+  $("chartEmpty").style.display = empty ? "block" : "none";
+  cv.style.display = empty ? "none" : "block";
+  $("chartTitle").textContent = FEATURE ? FEATURE + " over time" : "Series";
+  if (empty) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const W = cv.clientWidth, H = 380;
+  cv.width = W * dpr; cv.height = H * dpr;
+  const g = cv.getContext("2d"); g.scale(dpr, dpr);
+  g.clearRect(0, 0, W, H);
+  const pad = { l: 54, r: 14, t: 14, b: 26 };
+  const iw = W - pad.l - pad.r, ih = H - pad.t - pad.b;
+
+  const xs = SERIES.map(p => p.x);
+  let mn = Math.min(...xs), mx = Math.max(...xs);
+  if (mn === mx) { mn -= 1; mx += 1; }
+  const padY = (mx - mn) * 0.08; mn -= padY; mx += padY;
+  const N = SERIES.length;
+  const X = (i) => pad.l + (N <= 1 ? iw/2 : (i/(N-1))*iw);
+  const Y = (v) => pad.t + ih - ((v - mn)/(mx - mn))*ih;
+
+  // grid + y labels
+  g.strokeStyle = getVar("--grid"); g.fillStyle = getVar("--muted");
+  g.font = "11px " + getVar("--mono"); g.lineWidth = 1;
+  for (let t = 0; t <= 4; t++) {
+    const yv = mn + (mx-mn)*t/4, y = Y(yv);
+    g.beginPath(); g.moveTo(pad.l, y); g.lineTo(W-pad.r, y); g.stroke();
+    g.fillText(fmtNum(yv), 6, y+3);
+  }
+  // x ticks
+  for (let t = 0; t <= 4; t++) {
+    const idx = Math.round((N-1)*t/4), x = X(idx);
+    g.fillText(String(idx), x-6, H-8);
+  }
+
+  // area + line
+  const grad = g.createLinearGradient(0, pad.t, 0, H-pad.b);
+  grad.addColorStop(0, "rgba(76,154,255,.28)"); grad.addColorStop(1, "rgba(76,154,255,0)");
+  g.beginPath();
+  SERIES.forEach((p,i) => { const y=Y(p.x); i?g.lineTo(X(i),y):g.moveTo(X(i),y); });
+  g.lineTo(X(N-1), H-pad.b); g.lineTo(X(0), H-pad.b); g.closePath();
+  g.fillStyle = grad; g.fill();
+
+  g.beginPath();
+  SERIES.forEach((p,i) => { const y=Y(p.x); i?g.lineTo(X(i),y):g.moveTo(X(i),y); });
+  g.strokeStyle = getVar("--accent"); g.lineWidth = 1.8; g.stroke();
+
+  // points (sparse)
+  if (N <= 400) {
+    g.fillStyle = getVar("--accent");
+    SERIES.forEach((p,i) => { g.beginPath(); g.arc(X(i), Y(p.x), 2, 0, 7); g.fill(); });
+  }
+
+  // hover
+  cv._series = SERIES; cv._X = X; cv._Y = Y; cv._N = N; cv._pad = pad;
+}
+function getVar(n) { return getComputedStyle(document.documentElement).getPropertyValue(n).trim(); }
+
+$("chart").addEventListener("mousemove", (e) => {
+  const cv = $("chart"); if (!cv._series) return;
+  const rect = cv.getBoundingClientRect();
+  const mx = e.clientX - rect.left;
+  const N = cv._N, pad = cv._pad, iw = cv.clientWidth - pad.l - pad.r;
+  let idx = Math.round(((mx - pad.l)/iw)*(N-1));
+  idx = Math.max(0, Math.min(N-1, idx));
+  const p = cv._series[idx]; if (!p) return;
+  const tip = $("tip");
+  tip.style.display = "block";
+  tip.style.left = (e.clientX + 12) + "px"; tip.style.top = (e.clientY + 12) + "px";
+  tip.innerHTML = "#" + idx + " · " + FEATURE + " = " + fmtNum(p.x);
+});
+$("chart").addEventListener("mouseleave", () => { $("tip").style.display = "none"; });
+window.addEventListener("resize", draw);
+
+async function refresh() { await onModel(); }
+
+const qp = new URLSearchParams(location.search);
+loadModels(qp.get("model")).catch(e => $("count").textContent = e.message);
+</script>
+</body>
+</html>

--- a/packages/anomaly/tests/anomaly_test.sh
+++ b/packages/anomaly/tests/anomaly_test.sh
@@ -75,7 +75,7 @@ WORST=$(echo "$B" | sort -k2 -g | head -1 | cut -f1)
 
 echo "[3/3] live HTTP service"
 PORT=$((20000 + RANDOM % 20000))
-"$A" serve --addr "127.0.0.1:$PORT" --store "$WORK/svcmodels" 2>"$WORK/serve.err" &
+"$A" serve --addr "127.0.0.1:$PORT" --store "$WORK/svcmodels" --webroot static 2>"$WORK/serve.err" &
 SERVE_PID=$!
 for _ in $(seq 1 50); do
     curl -s -o /dev/null "http://127.0.0.1:$PORT/models/dynamic" 2>/dev/null && break
@@ -95,6 +95,19 @@ CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/de
 [ "$CODE" = "400" ] && ok "HTTP invalid name rejected" || bad "HTTP invalid name ($CODE)"
 CODE=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "http://127.0.0.1:$PORT/delete_model/live")
 [ "$CODE" = "200" ] && ok "HTTP delete" || bad "HTTP delete ($CODE)"
+
+# Dashboard static serving (--webroot static).
+CT=$(curl -s -o "$WORK/idx" -w '%{content_type}' "http://127.0.0.1:$PORT/")
+{ echo "$CT" | grep -q 'text/html' && grep -q '<title>Model Manager' "$WORK/idx"; } \
+    && ok "HTTP dashboard index (/)" || bad "HTTP dashboard index ($CT)"
+PAGES_OK=1
+for pg in modelmanager anomalies modeltrainer visualize; do
+    CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/$pg.html")
+    [ "$CODE" = "200" ] || PAGES_OK=0
+done
+[ "$PAGES_OK" = 1 ] && ok "HTTP dashboard pages served" || bad "HTTP dashboard pages"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/nope.html")
+[ "$CODE" = "404" ] && ok "HTTP dashboard 404 for unknown page" || bad "HTTP dashboard 404 ($CODE)"
 
 kill "$SERVE_PID" 2>/dev/null; wait "$SERVE_PID" 2>/dev/null; SERVE_PID=""
 


### PR DESCRIPTION
## What

`anomaly serve` now serves a small, self-contained **web dashboard** in addition to the JSON API. Four dependency-free pages live under `packages/anomaly/static/` and are served from disk:

| Route | Page |
| --- | --- |
| `/` · `/modelmanager.html` | list models · train / finetune / reset / delete · edit retrain schedule · metadata drawer |
| `/modeltrainer.html` | feed points (`/detect`, `/detect_only`) singly or in bulk (paste JSON lines / generate synthetic) · force-train |
| `/visualize.html` | plot any numeric feature of a model's stored points over time |
| `/anomalies.html` | re-score stored points via `/detect_only` and highlight the anomalies (canvas chart + table with the flagging versions) |

The pages are plain HTML/CSS/JS — no CDN, no build step — and talk **only** to this server's own endpoints. They replace four cruft-heavy originals (from an unrelated Flask app) that referenced endpoints this service never had (`/save_file`, `/config`, `/api/visualization/models`).

## How

- **`src/service.nu`** — `g_an_webroot` + `anomaly_service_set_webroot` + `__an_serve_file` (reads the page from disk, correct `Content-Type`, 404 when unset/missing) and the five static routes. With no web root configured the routes 404 and serving is **API-only** — unchanged behaviour.
- **`src/main.nu`** — `--webroot DIR`, auto-located in order: `--webroot` → `\$ANOMALY_WEBROOT` → `<exe>/static` → `<exe>/../share/anomaly/static` → `./static`. The chosen root is logged on startup.
- **`static/`** four new pages; **README** documents the dashboard + web-root resolution.

## Testing

- 3 new live-HTTP assertions (dashboard index, all four pages served, 404 for unknown page).
- **Full suite: 26/26 PASS** (unit + CLI + live HTTP).
- All four pages verified rendering against a live server (headless Chrome): anomalies scan correctly flags injected spikes; chart/table/metadata render; `last_trained_at` shown correctly as a point count.

Run it:

\`\`\`
anomaly serve --webroot packages/anomaly/static
# → http://127.0.0.1:8811/
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)