### PR TITLE
feat(http): unified HTTP server interface package + migrate anomaly onto it

### DIFF
--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -7,3 +7,4 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 iforest = { path = "../iforest", version = "0.1" }
 gpu = { path = "../gpu", version = "0.2.1" }
+http = { path = "../http", version = "0.1" }

--- a/packages/anomaly/src/service.nu
+++ b/packages/anomaly/src/service.nu
@@ -44,6 +44,7 @@ $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_router.nu`
 $ `stdlib/ext/http_server.nu`
+$ `deps/http/src/app.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
 $ `src/score.nu`
@@ -818,37 +819,15 @@ $ `src/csvdata.nu`
 }
 
 // Serve until the listener errors. Returns a process exit code.
+// Serve the routes over the `http` package's App facade: it owns the
+// bind + keep-alive loop, a graceful SIGINT/SIGTERM shutdown, and turns a
+// handler panic into a 500 (rather than dropping the connection). The
+// router itself is still built by anomaly_service_router, so every route
+// stays drivable without a socket in the test suite.
 @ anomaly_serve s host i port → i {
-    : Router r ( anomaly_service_router )
-    : !TcpListener NetErr lr ( tcp_listen host port )
-    ?? lr {
-        T listener → {
-            : ( @ HttpResponse HttpRequest ) h \ HttpRequest req → HttpResponse { ^ ( router_handle r req ) }
-            : HttpServer srv ( server_new listener h )
-            ( nurl_eprint `anomaly: serving on ` )
-            ( nurl_eprint host )
-            ( nurl_eprint `:` )
-            : String ps ( string_new )
-            ( string_push_int ps port )
-            ( nurl_eprintln ( string_data ps ) )
-            ( string_free ps )
-            : !v NetErr rr ( server_run srv )
-            ( server_stop srv )
-            ( router_free r )
-            ?? rr {
-                T _ → { ^ 0 }
-                F e → {
-                    ( nurl_eprint `anomaly: server error: ` )
-                    ( nurl_eprintln ( net_err_name e ) )
-                    ^ 1
-                }
-            }
-        }
-        F e → {
-            ( router_free r )
-            ( nurl_eprint `anomaly: cannot bind ` )
-            ( nurl_eprintln host )
-            ^ 1
-        }
-    }
+    : *HttpApp app ( http_app_new )
+    ( http_app_use_router app ( anomaly_service_router ) )
+    : i rc ( http_app_listen app host port )
+    ( http_app_free app )
+    ^ rc
 }

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -1,0 +1,106 @@
+# http — the unified HTTP server interface for NURL
+
+One dependency for anything that needs to **serve** HTTP. NURL's stdlib
+already ships a complete HTTP stack — sockets + TLS, a request parser, a
+response builder, a keep-alive server with worker pools and DoS limits, a
+router, static-file serving, and auth / jwt / multipart / middleware /
+websocket helpers. What it *doesn't* ship is the ~40 lines of glue every
+server re-invents: bind → build a router → install a shutdown signal → wrap
+the handler in logging / CORS / panic-recovery → run the keep-alive loop.
+
+`http` is that glue, as an ergonomic, dependency-importable facade — plus
+the whole stdlib surface pulled in transitively, so you `$`-include one file
+and have everything a handler needs in scope.
+
+## Hello, server
+
+```nurl
+$ `deps/http/src/http.nu`
+
+@ main → i {
+    : *HttpApp a ( http_app_new )
+    ( http_app_get a `/` \ HttpRequest req Params p → HttpResponse {
+        ^ ( response_text 200 `hello` )
+    } )
+    ( http_app_get a `/hi/:name` \ HttpRequest req Params p → HttpResponse {
+        : String o ( string_from `hi ` )
+        ?? ( params_get p `name` ) { T n → { ( string_push_str o ( string_data n ) ) ( string_free n ) } F j → { ( string_free j ) } }
+        : HttpResponse r ( response_text 200 ( string_data o ) )
+        ( string_free o )
+        ^ r
+    } )
+    ^ ( http_app_listen a `127.0.0.1` 8080 )   // blocks; returns an exit code
+}
+```
+
+## The App API
+
+Construction & serving:
+
+| Call | Effect |
+| --- | --- |
+| `( http_app_new )` → `*HttpApp` | create an app (free with `http_app_free`) |
+| `( http_app_listen a host port )` → `i` | bind + serve until closed (SIGINT/SIGTERM/error) |
+| `( http_app_listen_tls a host port cert key )` → `i` | same, over TLS (PEM paths; EC or RSA leaf) |
+
+Routing (handlers are `( @ HttpResponse HttpRequest Params )`):
+
+| Call | |
+| --- | --- |
+| `( http_app_get a pattern h )` | also `http_app_post` / `put` / `patch` / `delete` |
+| `( http_app_route a method pattern h )` | any method |
+| `( http_app_use_router a router )` | adopt a pre-built `Router` (keeps it socket-testable) |
+| `( http_app_router a )` → `Router` | the embedded router |
+
+Patterns use the stdlib router: `:name` captures a segment (read with
+`params_get`), `*rest` is a tail wildcard.
+
+Configuration (call before serving):
+
+| Call | Default | |
+| --- | --- | --- |
+| `( http_app_static_dir a dir )` | off | serve files for unmatched GET/HEAD (traversal-safe) |
+| `( http_app_cors a )` | off | permissive CORS + 204 OPTIONS preflight |
+| `( http_app_logging a )` | off | access log (method path → status) to stderr |
+| `( http_app_recover a on )` | **on** | handler panic → 500 instead of a dropped connection |
+| `( http_app_workers a n )` | 0 | 0 = single-threaded keep-alive; n > 0 = worker pool |
+| `( http_app_idle_ms a ms )` | 5000 | keep-alive idle timeout |
+| `( http_app_quiet a )` | off | suppress the startup banner |
+
+Everything under the facade is the untouched stdlib implementation, in scope
+from the one include: `HttpRequest` / `HttpResponse`, `response_text` /
+`response_json` / `response_new` / `response_set_header` / …, `Router` /
+`params_get`, plus the auth, jwt, multipart and websocket helpers.
+
+## Wrapping an existing router
+
+A server that already builds a `Router` (e.g. to keep every route testable
+without a socket) drops onto the facade with one seam:
+
+```nurl
+@ my_service_router → Router { ... router_post r `/x` h ... ^ r }
+
+@ my_serve s host i port → i {
+    : *HttpApp a ( http_app_new )
+    ( http_app_use_router a ( my_service_router ) )   // adopt the routes
+    : i rc ( http_app_listen a host port )            // facade owns the glue
+    ( http_app_free a )
+    ^ rc
+}
+```
+
+The `anomaly` package's HTTP service is served exactly this way.
+
+## Memory model
+
+`http_app_new` returns a heap `*HttpApp`, mutable across the registration
+calls; free it with `http_app_free`. The embedded `Router` holds a stable
+`Vec` handle, so registrations accumulate correctly. `http_app_listen`
+**moves** the bound listener into the server and stops it on return.
+
+## Tests
+
+`./tests/http_test.sh` builds `tests/smoke.nu` (a server exercising routing,
+path params, POST bodies, static fallback, CORS, and panic recovery) and
+drives it over curl — including that the keep-alive loop survives a handler
+panic.

--- a/packages/http/nurl.toml
+++ b/packages/http/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "http"
+version = "0.1.0"
+description = "The unified HTTP server interface library for NURL. A single dependency-importable facade over the stdlib HTTP stack (sockets + TLS, request parser, response builder, keep-alive server with worker pools and DoS limits, router, static-file serving, auth / jwt / multipart / middleware / websocket). Where the stdlib ships the building blocks, `http` ships the glue: an ergonomic `HttpApp` that collapses bind → router → shutdown-signal → logging / CORS / panic-recovery → keep-alive loop into a few calls, so `( http_app_new )`, a handful of `( http_get a ... )` registrations, and `( http_listen a host port )` stand up a complete server — over plain TCP or TLS. Includes the full stdlib surface transitively, so handler bodies get `HttpRequest`, `HttpResponse`, `response_json`, `Router`, `Params`, and the auth/jwt/multipart helpers in scope from one include. Complete enough to stand in for hand-wired servers."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/http/src/app.nu
+++ b/packages/http/src/app.nu
@@ -1,0 +1,255 @@
+// http/app.nu — the ergonomic App facade over the stdlib HTTP stack.
+//
+// The stdlib already ships a complete HTTP toolkit (net sockets + TLS,
+// request parser, response builder, keep-alive server with worker pools
+// and DoS limits, router, static-file serving, middleware). What every
+// server re-invents is the ~40 lines of glue that wire them together:
+// bind → build a router → install a shutdown signal → wrap the handler in
+// logging / CORS / panic-recovery → run the keep-alive loop.
+//
+// `HttpApp` collapses that into one object:
+//
+//     : *HttpApp a ( http_app_new )
+//     ( http_app_get a `/health` \ HttpRequest req Params p → HttpResponse {
+//         ^ ( response_text 200 `ok` )
+//     } )
+//     ( http_app_static_dir a `./static` )     // fallback file serving
+//     ( http_app_cors a )
+//     ( http_app_logging a )
+//     : i rc ( http_app_listen a `127.0.0.1` 8080 )    // blocks; returns exit code
+//
+// Everything below the App is the untouched stdlib implementation, reached
+// through the umbrella include in http.nu — so `HttpRequest`, `HttpResponse`,
+// `response_json`, `Router`, `Params`, the auth/jwt/multipart helpers, etc.
+// are all in scope for the handler bodies.
+//
+// Memory model: `http_app_new` returns a heap `*HttpApp` (mutable across the
+// registration calls); free it with `http_app_free`. The embedded `Router`
+// holds a stable Vec handle, so route registrations through `. a router`
+// accumulate correctly. `http_app_listen` MOVES the bound listener into the
+// server and stops it on return.
+
+$ `stdlib/std/net.nu`
+$ `stdlib/std/signal.nu`
+$ `stdlib/std/panic.nu`
+$ `stdlib/ext/http_request.nu`
+$ `stdlib/ext/http_response.nu`
+$ `stdlib/ext/http_router.nu`
+$ `stdlib/ext/http_server.nu`
+$ `stdlib/ext/http_static.nu`
+
+: HttpApp {
+    Router router
+    i idle_ms          // keep-alive idle timeout (ms) for server_new_with_timeout
+    i workers          // 0 → single-threaded server_run; >0 → server_run_pool(n)
+    b recover_panics   // wrap dispatch in `recover`, turning a panic into 500
+    b log_requests     // access log (method/path/status) to stderr
+    b cors             // permissive CORS + OPTIONS preflight
+    b quiet            // suppress the "serving on host:port" banner
+    b has_static       // static fallback enabled
+    String webroot     // directory served for unmatched GET/HEAD when has_static
+}
+
+// ── Construction / teardown ───────────────────────────────────────────
+
+@ http_app_new → *HttpApp {
+    : *HttpApp a # *HttpApp ( nurl_malloc Z HttpApp )
+    = . a router ( router_new )
+    = . a idle_ms 5000
+    = . a workers 0
+    = . a recover_panics T
+    = . a log_requests F
+    = . a cors F
+    = . a quiet F
+    = . a has_static F
+    = . a webroot ( string_new )
+    ^ a
+}
+
+@ http_app_free *HttpApp a → v {
+    ( router_free . a router )
+    ( string_free . a webroot )
+    ( nurl_free a )
+}
+
+// ── Configuration (each returns v; call before http_app_listen) ───────────
+
+// Serve on a worker pool of `n` threads (0 = single-threaded keep-alive).
+@ http_app_workers *HttpApp a i n → v { = . a workers n }
+
+// Keep-alive idle timeout in milliseconds (0 = server default).
+@ http_app_idle_ms *HttpApp a i ms → v { = . a idle_ms ms }
+
+// Toggle panic→500 recovery (on by default). A handler that panics then
+// yields a 500 instead of tearing down the connection loop.
+@ http_app_recover *HttpApp a b on → v { = . a recover_panics on }
+
+// Log every request (method path → status) to stderr.
+@ http_app_logging *HttpApp a → v { = . a log_requests T }
+
+// Permissive CORS: reflect `*`, answer OPTIONS preflight with 204.
+@ http_app_cors *HttpApp a → v { = . a cors T }
+
+// Suppress the startup banner on stderr.
+@ http_app_quiet *HttpApp a → v { = . a quiet T }
+
+// Serve files from `dir` for any GET/HEAD the router leaves unmatched
+// (404). Path traversal is rejected by the underlying serve_static.
+@ http_app_static_dir *HttpApp a s dir → v {
+    ( string_free . a webroot )
+    = . a webroot ( string_from dir )
+    = . a has_static T
+}
+
+// ── Route registration (thin over the router) ─────────────────────────
+
+@ http_app_get *HttpApp a s pattern ( @ HttpResponse HttpRequest Params ) handler → v {
+    ( router_get . a router pattern handler )
+}
+@ http_app_post *HttpApp a s pattern ( @ HttpResponse HttpRequest Params ) handler → v {
+    ( router_post . a router pattern handler )
+}
+@ http_app_put *HttpApp a s pattern ( @ HttpResponse HttpRequest Params ) handler → v {
+    ( router_put . a router pattern handler )
+}
+@ http_app_patch *HttpApp a s pattern ( @ HttpResponse HttpRequest Params ) handler → v {
+    ( router_patch . a router pattern handler )
+}
+@ http_app_delete *HttpApp a s pattern ( @ HttpResponse HttpRequest Params ) handler → v {
+    ( router_delete . a router pattern handler )
+}
+@ http_app_route *HttpApp a s method s pattern ( @ HttpResponse HttpRequest Params ) handler → v {
+    ( router_any . a router method pattern handler )
+}
+
+// The embedded router, for advanced use (mounting sub-routers, tests).
+@ http_app_router *HttpApp a → Router { ^ . a router }
+
+// Adopt a pre-built router as the app's router, freeing the default empty
+// one. For servers that assemble their routes elsewhere (e.g. a
+// `*_service_router → Router` that stays testable without a socket): build
+// the router, hand it to the app, and let the facade own the serving glue.
+@ http_app_use_router *HttpApp a Router r → v {
+    ( router_free . a router )
+    = . a router r
+}
+
+// ── Dispatch (top-level fns: keeps `recover` out of a nested closure) ──
+
+@ __httpapp_is_get_or_head HttpRequest req → b {
+    : s m ( string_data . req method )
+    ? != 0 ( nurl_str_eq m `GET` ) { ^ T } {}
+    ? != 0 ( nurl_str_eq m `HEAD` ) { ^ T } {}
+    ^ F
+}
+
+// Router first; on a 404 for GET/HEAD with static enabled, fall through to
+// file serving (which itself returns a clean 404 when the file is absent).
+@ __httpapp_route_and_static *HttpApp a HttpRequest req → HttpResponse {
+    : HttpResponse resp ( router_handle . a router req )
+    ? & . a has_static & == 404 . resp status ( __httpapp_is_get_or_head req ) {
+        ( http_response_free resp )
+        ^ ( serve_static ( string_data . a webroot ) req )
+    } {}
+    ^ resp
+}
+
+// Optional panic→500 wrapper. `recover` sits directly in this top-level
+// function body (not inside another closure), the shape the runtime wants.
+@ __httpapp_dispatch *HttpApp a HttpRequest req → HttpResponse {
+    ? . a recover_panics {
+        : ~ HttpResponse resp ( response_text 500 `internal error: handler panicked\n` )
+        : !v PanicInfo pr ( recover \ → v { = resp ( __httpapp_route_and_static a req ) } )
+        ?? pr { T _ → {} F p → { ( panic_info_free p ) } }
+        ^ resp
+    } {
+        ^ ( __httpapp_route_and_static a req )
+    }
+}
+
+// ── Serving ───────────────────────────────────────────────────────────
+
+@ __httpapp_banner *HttpApp a s scheme s host i port → v {
+    ? . a quiet { ^ v } {}
+    ( nurl_eprint `http: serving ` )
+    ( nurl_eprint scheme )
+    ( nurl_eprint `://` )
+    ( nurl_eprint host )
+    ( nurl_eprint `:` )
+    : String ps ( string_new )
+    ( string_push_int ps port )
+    ( nurl_eprintln ( string_data ps ) )
+    ( string_free ps )
+}
+
+@ __httpapp_run_result !v NetErr rr → i {
+    ?? rr {
+        T _ → { ^ 0 }
+        F e → {
+            ( nurl_eprint `http: server error: ` )
+            ( nurl_eprintln ( net_err_name e ) )
+            ^ 1
+        }
+    }
+}
+
+// Drive a bound listener: shutdown signal + composed handler + keep-alive
+// loop (pool when workers>0). MOVES `listener`; stops the server on return.
+@ __httpapp_serve *HttpApp a TcpListener listener s scheme s host i port → i {
+    ( signal_install_shutdown listener )
+    : ~ ( @ HttpResponse HttpRequest ) base \ HttpRequest req → HttpResponse { ^ ( __httpapp_dispatch a req ) }
+    ? . a cors { = base ( with_cors_default base ) } {}
+    ? . a log_requests { = base ( with_log_requests base ) } {}
+    : HttpServer srv ( server_new_with_timeout listener base . a idle_ms )
+    ( __httpapp_banner a scheme host port )
+    : ~ i rc 0
+    ? > . a workers 0 {
+        = rc ( __httpapp_run_result ( server_run_pool srv . a workers ) )
+    } {
+        = rc ( __httpapp_run_result ( server_run srv ) )
+    }
+    ( server_stop srv )
+    ^ rc
+}
+
+// Bind host:port and serve until the listener is closed (SIGINT/SIGTERM or
+// error). Returns a process exit code (0 clean, 1 on bind/serve error).
+@ http_app_listen *HttpApp a s host i port → i {
+    : !TcpListener NetErr lr ( tcp_listen host port )
+    ?? lr {
+        T listener → { ^ ( __httpapp_serve a listener `http` host port ) }
+        F e → {
+            ( nurl_eprint `http: cannot bind ` )
+            ( nurl_eprint host )
+            ( nurl_eprint `:` )
+            : String ps ( string_new )
+            ( string_push_int ps port )
+            ( nurl_eprint ( string_data ps ) )
+            ( nurl_eprint ` — ` )
+            ( nurl_eprintln ( net_err_name e ) )
+            ( string_free ps )
+            ^ 1
+        }
+    }
+}
+
+// Same, over TLS. `cert`/`key` are PEM paths (EC or RSA leaf; a fullchain
+// PEM is accepted for `cert`).
+@ http_app_listen_tls *HttpApp a s host i port s cert s key → i {
+    : !TcpListener NetErr lr ( tcp_listen_tls host port cert key )
+    ?? lr {
+        T listener → { ^ ( __httpapp_serve a listener `https` host port ) }
+        F e → {
+            ( nurl_eprint `http: cannot bind TLS ` )
+            ( nurl_eprint host )
+            ( nurl_eprint `:` )
+            : String ps ( string_new )
+            ( string_push_int ps port )
+            ( nurl_eprint ( string_data ps ) )
+            ( nurl_eprint ` — ` )
+            ( nurl_eprintln ( net_err_name e ) )
+            ( string_free ps )
+            ^ 1
+        }
+    }
+}

--- a/packages/http/src/http.nu
+++ b/packages/http/src/http.nu
@@ -1,0 +1,29 @@
+// http — the unified HTTP server interface library for NURL.
+//
+// One include gives a consumer both:
+//
+//   * the complete stdlib HTTP surface (sockets + TLS, request parser,
+//     response builder, keep-alive server with pools & DoS limits, router,
+//     static files, auth / jwt / multipart / middleware / websocket), via
+//     the `http_full` aggregator; and
+//   * the ergonomic `HttpApp` facade (app.nu) that wires those pieces into
+//     a running server in a few calls.
+//
+// Usage from a dependent package:
+//
+//     $ `deps/http/src/http.nu`
+//
+//     @ main → i {
+//         : *HttpApp a ( http_app_new )
+//         ( http_get a `/` \ HttpRequest req Params p → HttpResponse {
+//             ^ ( response_text 200 `hello` )
+//         } )
+//         ^ ( http_listen a `127.0.0.1` 8080 )
+//     }
+//
+// The intent is that this package is THE dependency anything needing an
+// HTTP server reaches for — complete enough to stand in for hand-wired
+// servers such as the anomaly service or the nurlapi playground server.
+
+$ `stdlib/ext/http_full.nu`
+$ `app.nu`

--- a/packages/http/tests/http_test.sh
+++ b/packages/http/tests/http_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# ============================================================
+#  tests/http_test.sh — build the HttpApp smoke server and drive
+#  the full facade over curl: routing, path params, POST body,
+#  static fallback, 404, panic→500 recovery, CORS preflight, and
+#  keep-alive survival after a handler panic.
+#
+#  Run from the package dir:  ./tests/http_test.sh
+#  Env: NURL (build driver; defaults to ../../nurl.sh in a checkout)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t http-test.XXXXXX)"
+SERVE_PID=""
+cleanup() { [ -n "$SERVE_PID" ] && kill "$SERVE_PID" 2>/dev/null; rm -rf "$WORK"; }
+trap cleanup EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+
+echo "[1/2] build tests/smoke.nu"
+if ! $NURL tests/smoke.nu "$WORK/smoke" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build smoke server:"; tail -8 "$WORK/build.err"; exit 1
+fi
+
+echo "[2/2] drive the facade over HTTP"
+mkdir -p "$WORK/webroot"
+printf 'STATIC-OK' > "$WORK/webroot/file.txt"
+PORT=$((20000 + RANDOM % 20000))
+"$WORK/smoke" --port "$PORT" --webroot "$WORK/webroot" 2>"$WORK/serve.err" &
+SERVE_PID=$!
+for _ in $(seq 1 50); do
+    curl -s -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null && break
+    sleep 0.1
+done
+
+B="http://127.0.0.1:$PORT"
+[ "$(curl -s "$B/")" = "hello from http" ] && ok "GET / route" || bad "GET /"
+[ "$(curl -s "$B/hi/tero")" = "hi tero" ] && ok "path param :name" || bad "path param"
+[ "$(curl -s -X POST "$B/echo" -d '{"a":1}')" = '{"a":1}' ] && ok "POST body echo" || bad "POST echo"
+[ "$(curl -s "$B/file.txt")" = "STATIC-OK" ] && ok "static fallback" || bad "static fallback"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' "$B/nope")
+[ "$CODE" = "404" ] && ok "unmatched → 404" || bad "404 ($CODE)"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' "$B/boom")
+[ "$CODE" = "500" ] && ok "handler panic → 500" || bad "panic→500 ($CODE)"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X OPTIONS "$B/")
+[ "$CODE" = "204" ] && ok "CORS preflight → 204" || bad "CORS preflight ($CODE)"
+curl -s -D- -o /dev/null "$B/" | grep -qi 'access-control-allow-origin: \*' \
+    && ok "CORS header on response" || bad "CORS header"
+# keep-alive must survive the earlier panic
+CODE=$(curl -s -o /dev/null -w '%{http_code}' "$B/")
+[ "$CODE" = "200" ] && ok "server alive after panic" || bad "server died after panic ($CODE)"
+
+kill "$SERVE_PID" 2>/dev/null; wait "$SERVE_PID" 2>/dev/null; SERVE_PID=""
+
+echo "== http tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" = 0 ]

--- a/packages/http/tests/smoke.nu
+++ b/packages/http/tests/smoke.nu
@@ -1,0 +1,66 @@
+// tests/smoke.nu — a minimal server built with the HttpApp facade. Drives
+// routing, path params, a POST body echo, static fallback, CORS and the
+// panic→500 recovery. The test harness (http_test.sh) curls it.
+//
+//   smoke --port N [--webroot DIR]
+
+$ `stdlib/std/args.nu`
+$ `src/http.nu`
+
+@ h_hi HttpRequest req Params p → HttpResponse {
+    : String out ( string_from `hi ` )
+    ?? ( params_get p `name` ) {
+        T nm → { ( string_push_str out ( string_data nm ) ) ( string_free nm ) }
+        F junk → { ( string_free junk ) }
+    }
+    : HttpResponse r ( response_text 200 ( string_data out ) )
+    ( string_free out )
+    ^ r
+}
+
+@ h_echo HttpRequest req Params p → HttpResponse {
+    : String body ( bytes_to_str . req body )
+    : HttpResponse r ( response_new 200 )
+    ( response_set_header r `Content-Type` `application/json; charset=utf-8` )
+    ( response_set_body_str r ( string_data body ) )
+    ( string_free body )
+    ^ r
+}
+
+@ h_boom HttpRequest req Params p → HttpResponse {
+    ( nurl_panic `boom` )
+    ^ ( response_text 200 `unreachable` )
+}
+
+@ main → i {
+    : ArgParser ap ( args_new `smoke` `http facade smoke server` )
+    ( args_opt ap `port` 112 `N` `bind port on 127.0.0.1` )
+    ( args_opt ap `webroot` 119 `DIR` `static dir` )
+    ? ( args_parse_argv ap ) {} { ( args_free ap ) ^ 2 }
+
+    : ~ i port 8099
+    : ?String pv ( args_value ap `port` )
+    ?? pv {
+        T v → { ?? ( string_to_int v ) { T x → { = port x } F _ → {} } ( string_free v ) }
+        F junk → { ( string_free junk ) }
+    }
+
+    : *HttpApp a ( http_app_new )
+    ( http_app_cors a )
+    ( http_app_logging a )
+    ( http_app_get a `/` \ HttpRequest req Params p → HttpResponse { ^ ( response_text 200 `hello from http` ) } )
+    ( http_app_get a `/hi/:name` \ HttpRequest req Params p → HttpResponse { ^ ( h_hi req p ) } )
+    ( http_app_post a `/echo` \ HttpRequest req Params p → HttpResponse { ^ ( h_echo req p ) } )
+    ( http_app_get a `/boom` \ HttpRequest req Params p → HttpResponse { ^ ( h_boom req p ) } )
+
+    : ?String wv ( args_value ap `webroot` )
+    ?? wv {
+        T w → { ( http_app_static_dir a ( string_data w ) ) ( string_free w ) }
+        F junk → { ( string_free junk ) }
+    }
+
+    : i rc ( http_app_listen a `127.0.0.1` port )
+    ( http_app_free a )
+    ( args_free ap )
+    ^ rc
+}


### PR DESCRIPTION
## What

A new **`packages/http`** — the single dependency anything needing to *serve* HTTP reaches for. NURL's stdlib already ships a complete HTTP stack (sockets + TLS, request parser, response builder, keep-alive server with worker pools + DoS limits, router, static files, auth/jwt/multipart/middleware/websocket). What it doesn't ship is the ~40 lines of glue every server re-invents. `http` is that glue, as an ergonomic facade — no reimplementation, it composes the battle-tested stdlib pieces.

```nurl
$ `deps/http/src/http.nu`
@ main → i {
    : *HttpApp a ( http_app_new )
    ( http_app_get a `/health` \ HttpRequest req Params p → HttpResponse { ^ ( response_text 200 `ok` ) } )
    ( http_app_static_dir a `./static` )
    ^ ( http_app_listen a `127.0.0.1` 8080 )     // or http_app_listen_tls a host port cert key
}
```

`HttpApp` collapses bind → router → shutdown signal → logging / CORS / panic→500 → keep-alive loop into a few calls. Config: `http_app_cors`, `http_app_logging`, `http_app_recover`, `http_app_workers`, `http_app_idle_ms`, `http_app_static_dir`, `http_app_quiet`. Routes: `http_app_get/post/put/patch/delete/route`, or adopt a pre-built `Router` with `http_app_use_router` (keeps routes socket-testable). One include also pulls the full stdlib surface transitively, so handler bodies get `HttpRequest`/`HttpResponse`/`response_json`/`Router`/`params_get`/… in scope.

## Proof it can replace a hand-wired server

`anomaly_serve` is migrated onto the facade: **~35 lines → 6**. It keeps `anomaly_service_router` (so every route stays drivable without a socket in the test suite), hands it to the app, and lets the facade own the glue — gaining graceful SIGINT/SIGTERM shutdown and handler-panic→500 for free.

## Design notes

- **Facade, not reimplementation** — reuses `stdlib/ext/http_*`; zero duplication, zero risk.
- Names are `http_app_*` (server side); the stdlib `http_get`/`http_post`/… are the *client* request verbs.
- `recover` sits in a top-level dispatch fn (not a nested closure), the shape the runtime wants.
- Intra-package imports are importer-relative bare filenames; the embedded `Router` holds a stable `Vec` handle so registrations accumulate through the heap `*HttpApp`.

## Testing

- **http:** `tests/http_test.sh` — 9/9 (routing, path params, POST body, static fallback, 404, panic→500, CORS preflight + header, **keep-alive survives a handler panic**).
- **anomaly:** full suite **26/26** after migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)