### PR TITLE
feat(registry,web): live registry package count on nurl-lang.org

### DIFF
--- a/nurlweb/public/index.html
+++ b/nurlweb/public/index.html
@@ -63,11 +63,12 @@
     </a>
   </div>
   <div class="stats">
-    <div class="stat"><strong data-fact="version">v0.9.14</strong><span>current release</span></div>
-    <div class="stat"><strong data-fact="compiler_lines">16,548</strong><span>lines of NURL in the compiler</span></div>
-    <div class="stat"><strong data-fact="tests">480</strong><span>compiler test programs</span></div>
-    <div class="stat"><strong data-fact="stdlib_modules">148</strong><span>stdlib modules</span></div>
+    <div class="stat"><strong data-fact="version">v0.10.12</strong><span>current release</span></div>
+    <div class="stat"><strong data-fact="compiler_lines">18,101</strong><span>lines of NURL in the compiler</span></div>
+    <div class="stat"><strong data-fact="tests">531</strong><span>compiler test programs</span></div>
+    <div class="stat"><strong data-fact="stdlib_modules">168</strong><span>stdlib modules</span></div>
     <div class="stat"><strong>10</strong><span>tested targets</span></div>
+    <div class="stat"><strong data-fact="registry_packages">22</strong><span>registry packages</span></div>
   </div>
   <p style="margin-top: 1.8rem; color: var(--fg-faint); font-size: 0.88rem;">
     Driving an LLM agent? The compiler is also exposed as an
@@ -128,7 +129,7 @@
       <div class="card">
         <div class="icon">⟳</div>
         <h3>Self-hosting</h3>
-        <p>The compiler is <span data-fact="compiler_lines">16,548</span> lines of NURL. The bootstrap compiles it with itself twice and requires byte-identical LLVM IR on both rounds before a build is accepted.</p>
+        <p>The compiler is <span data-fact="compiler_lines">18,101</span> lines of NURL. The bootstrap compiles it with itself twice and requires byte-identical LLVM IR on both rounds before a build is accepted.</p>
       </div>
     </div>
   </div>
@@ -321,7 +322,7 @@
 <section id="stdlib">
   <div class="container">
     <div class="section-head">
-      <h2><span data-fact="stdlib_modules">148</span> stdlib modules, batteries included</h2>
+      <h2><span data-fact="stdlib_modules">168</span> stdlib modules, batteries included</h2>
       <p>Not stubs — production-hardened modules with their own test programs, leak-checked under AddressSanitizer.</p>
     </div>
 
@@ -365,7 +366,7 @@
     <div class="grid">
       <div class="card">
         <h3>The compiler itself</h3>
-        <p><span data-fact="compiler_lines">16,548</span> lines of NURL compile NURL. Every release must reproduce its own LLVM IR byte-for-byte through two self-compilation rounds — a fixed point, not a checksum.</p>
+        <p><span data-fact="compiler_lines">18,101</span> lines of NURL compile NURL. Every release must reproduce its own LLVM IR byte-for-byte through two self-compilation rounds — a fixed point, not a checksum.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/blob/main/compiler/nurlc.nu" target="_blank" rel="noopener">compiler/nurlc.nu</a></p>
       </div>
       <div class="card">
@@ -379,7 +380,7 @@
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/tree/main/nurlapi" target="_blank" rel="noopener">nurlapi/</a></p>
       </div>
       <div class="card">
-        <h3><span data-fact="examples">65</span> examples</h3>
+        <h3><span data-fact="examples">64</span> examples</h3>
         <p>From an Enigma machine and Game of Life to a distributed Push-To-Talk voice app, an HTTP/2 client, MCP servers, a Claude-powered agent, and a C64 emulator.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/tree/main/examples" target="_blank" rel="noopener">examples/</a></p>
       </div>
@@ -523,13 +524,18 @@ cd nurl
       </div>
       <div class="card">
         <h3>Changelog</h3>
-        <p>Every release documented in Keep-a-Changelog format with the reasoning behind each fix — currently at <span data-fact="version">v0.9.14</span>.</p>
+        <p>Every release documented in Keep-a-Changelog format with the reasoning behind each fix — currently at <span data-fact="version">v0.10.12</span>.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/blob/main/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG.md</a></p>
       </div>
       <div class="card">
         <h3>Roadmap</h3>
         <p>What's done, what's next. Maintained alongside the source so it doesn't drift from reality.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/blob/main/ROADMAP.md" target="_blank" rel="noopener">ROADMAP.md</a></p>
+      </div>
+      <div class="card">
+        <h3>Package registry</h3>
+        <p><span data-fact="registry_packages">22</span> packages published and installable with <code>nurlpkg install &lt;name&gt;</code> — browse, search, and read docs on the registry.</p>
+        <p style="margin-top: 0.8rem;"><a href="https://reg.nurl-lang.org" target="_blank" rel="noopener">reg.nurl-lang.org</a></p>
       </div>
     </div>
   </div>

--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -363,6 +363,21 @@ async function handleSearch(url: URL, env: Env): Promise<Response> {
   return json({ results: (rows.results ?? []).map((r) => ({ name: r.name, version: r.latest })) });
 }
 
+// Public counts — powers the "registry packages" figure on nurl-lang.org
+// (injected at build time by tools/gen-site-facts.sh). CORS-open and briefly
+// cached so it's also safe to read from a browser.
+async function handleStats(env: Env): Promise<Response> {
+  const pkgs = await env.REG_DB.prepare(`SELECT COUNT(*) AS n FROM packages`).first<{ n: number }>();
+  const vers = await env.REG_DB.prepare(
+    `SELECT COUNT(*) AS n FROM versions WHERE yanked = 0`,
+  ).first<{ n: number }>();
+  return json(
+    { packages: pkgs?.n ?? 0, versions: vers?.n ?? 0 },
+    200,
+    { "access-control-allow-origin": "*", "cache-control": "public, max-age=300" },
+  );
+}
+
 // ── Yank / unyank (owner-only) + token revoke ─────────────────────────
 
 async function handleYank(req: Request, env: Env, yank: boolean): Promise<Response> {
@@ -470,6 +485,7 @@ export default {
       if (path === "/login") return handleLogin(env);
       if (path === "/auth/callback") return handleCallback(req, env);
       if (path === "/api/v1/search") return handleSearch(url, env);
+      if (path === "/api/v1/stats") return handleStats(env);
       if (path.startsWith("/packages/")) {
         return handlePackageDetail(env, decodeURIComponent(path.slice("/packages/".length)).toLowerCase());
       }

--- a/tools/gen-site-facts.sh
+++ b/tools/gen-site-facts.sh
@@ -8,11 +8,13 @@
 #  (version, compiler size, test/stdlib/example counts) that drift and
 #  even contradict each other when hand-edited. This script computes them
 #  from the repo — the single source of truth — and writes them into every
-#  element carrying a matching `data-fact="<key>"` attribute.
+#  element carrying a matching `data-fact="<key>"` attribute. The one
+#  exception is the registry package count, whose source of truth is the
+#  live registry: it's fetched (best-effort) from the registry's stats API.
 #
-#  The page stays 100% static at serve time (no JS, no API); it just can't
-#  fall behind, because `nurlweb`'s `predeploy` hook runs this first. Run
-#  it by hand anytime to refresh:  ./tools/gen-site-facts.sh
+#  The page stays 100% static at serve time (no JS, no API calls from the
+#  browser); it just can't fall behind, because `nurlweb`'s `predeploy` hook
+#  runs this first. Run it by hand anytime to refresh:  ./tools/gen-site-facts.sh
 # ============================================================
 set -euo pipefail
 
@@ -38,6 +40,16 @@ tests="$(comma "$(find "$ROOT/compiler/tests" -maxdepth 1 -name '*.nu' | wc -l |
 stdlib_modules="$(find "$ROOT/stdlib" -name '*.nu' | wc -l | tr -d ' ')"
 examples="$(find "$ROOT/examples" -maxdepth 1 -name '*.nu' | wc -l | tr -d ' ')"
 
+# Registry package count — the one fact whose source of truth is the live
+# registry, not the repo. Fetched best-effort from its public stats endpoint;
+# a build-time outage or missing curl leaves the page's previous value in
+# place instead of aborting the deploy (or zeroing the figure).
+registry_url="${NURL_REGISTRY_URL:-https://reg.nurl-lang.org}"
+registry_packages=""
+if stats="$(curl -fsS --max-time 8 "$registry_url/api/v1/stats" 2>/dev/null)"; then
+    registry_packages="$(printf '%s' "$stats" | grep -oE '"packages"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)"
+fi
+
 # ── Inject into every data-fact="<key>" element ────────────────────────
 # Replaces the text content between `data-fact="key"…>` and the next `<`,
 # globally, so a key used in several places stays consistent.
@@ -51,6 +63,10 @@ inject compiler_lines "$compiler_lines"
 inject tests          "$tests"
 inject stdlib_modules "$stdlib_modules"
 inject examples       "$examples"
+# Only overwrite the registry figure when the fetch actually produced one.
+if [[ -n "$registry_packages" ]]; then
+    inject registry_packages "$(comma "$registry_packages")"
+fi
 
 echo "site facts → $HTML"
-echo "  version=$version  compiler_lines=$compiler_lines  tests=$tests  stdlib_modules=$stdlib_modules  examples=$examples"
+echo "  version=$version  compiler_lines=$compiler_lines  tests=$tests  stdlib_modules=$stdlib_modules  examples=$examples  registry_packages=${registry_packages:-unchanged}"


### PR DESCRIPTION
Adds an auto-updating "registry packages" figure to nurl-lang.org, sourced from the registry. Both sites are already deployed live.

## registry
- **`GET /api/v1/stats`** → `{ packages, versions }` — public counts (CORS-open, 5-min cached). `{"packages":22,"versions":55}` today.

## web
- **`gen-site-facts.sh`** now fetches the package count from the registry stats API and injects it into `data-fact="registry_packages"`. Best-effort: a build-time registry outage (or missing curl) leaves the page's previous value in place instead of aborting the deploy or zeroing the figure. Override the URL with `NURL_REGISTRY_URL`.
- **Hero stats** gain a **registry packages** box.
- **Resources grid** gains a professional **Package registry** card: the count, `nurlpkg install <name>`, and a link to **reg.nurl-lang.org** — styled exactly like the sibling cards.
- Running the facts script also refreshed the other figures to current (v0.10.12, 18,101 compiler lines, 531 tests, 168 stdlib modules) — they'd drifted since the last facts run.

The page stays **100% static at serve time**; the count refreshes on each deploy via the existing `predeploy` hook (no client-side JS/API).

Verified live: `/api/v1/stats` returns the counts; the hero box and resources card render with **22** and link to the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)