### PR TITLE
feat(cli): diamond command-line framework + migrate anomaly onto it

### DIFF
--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -8,3 +8,4 @@ license = "MIT OR Apache-2.0"
 iforest = { path = "../iforest", version = "0.1" }
 gpu = { path = "../gpu", version = "0.2.1" }
 http = { path = "../http", version = "0.1" }
+cli = { path = "../cli", version = "0.1" }

--- a/packages/anomaly/src/main.nu
+++ b/packages/anomaly/src/main.nu
@@ -15,6 +15,11 @@
 // strings are timestamps, anything else is categorical (one-hot). Verdicts
 // print as one JSON object per invocation. The store lives under --store
 // DIR (default $ANOMALY_HOME, else ~/.anomaly).
+//
+// The command line is assembled with the `cli` package: one Cli, a flag set,
+// and a handler per subcommand — routing, typed flags with the $ANOMALY_HOME
+// / $ANOMALY_WEBROOT fallbacks, --help / --version and exit codes are the
+// framework's job.
 
 $ `stdlib/core/io.nu`
 $ `stdlib/core/string.nu`
@@ -22,9 +27,9 @@ $ `stdlib/core/vec.nu`
 $ `stdlib/std/float.nu`
 $ `stdlib/std/fs.nu`
 $ `stdlib/std/path.nu`
-$ `stdlib/std/args.nu`
 $ `stdlib/ext/env.nu`
 $ `stdlib/ext/json.nu`
+$ `deps/cli/src/cli.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
 $ `src/score.nu`
@@ -33,38 +38,34 @@ $ `src/dynamic.nu`
 $ `src/csvdata.nu`
 $ `src/service.nu`
 
-@ __cli_store_root ArgParser p → String {
-    : ?String ov ( args_value p `store` )
-    ?? ov { T v → { ^ v } F junk → { ( string_free junk ) } }
-    : ?String ev ( env_get `ANOMALY_HOME` )
-    ?? ev { T v → { ^ v } F junk → { ( string_free junk ) } }
+@ pline s x → v {
+    ( nurl_print x )
+    ( nurl_print `\n` )
+}
+
+// Store directory: --store → $ANOMALY_HOME (via the flag's env fallback) →
+// ~/.anomaly. The flag binds $ANOMALY_HOME, so an empty resolved value means
+// neither was set and we fall back to the home directory.
+@ __an_store_root CliCtx x → String {
+    : String s ( ctx_str x `store` )
+    ? > ( string_len s ) 0 { ^ s } {}
+    ( string_free s )
     : String home ( env_var_or `HOME` `.` )
     : String r ( path_join ( string_data home ) `.anomaly` )
     ( string_free home )
     ^ r
 }
 
-@ pline s x → v {
-    ( nurl_print x )
-    ( nurl_print `\n` )
-}
-
-// Resolve the directory that holds the dashboard HTML for `serve`. Order:
-//   --webroot DIR  →  $ANOMALY_WEBROOT  →  <exe-dir>/static  →
-//   <exe-dir>/../share/anomaly/static  →  ./static.
-// Returns the first candidate that exists; empty String disables the
-// dashboard (API-only serving still works).
-@ __cli_webroot ArgParser p → String {
-    : ?String ov ( args_value p `webroot` )
-    ?? ov { T v → { ^ v } F junk → { ( string_free junk ) } }
-    : ?String ev ( env_get `ANOMALY_WEBROOT` )
-    ?? ev {
-        T v → {
-            ? ( file_exists ( string_data v ) ) { ^ v } { ( string_free v ) }
-        }
-        F junk → { ( string_free junk ) }
+// Dashboard web root for `serve`. --webroot / $ANOMALY_WEBROOT (via the
+// flag) first, then <exe-dir>/static, <exe-dir>/../share/anomaly/static,
+// then ./static. Empty String disables the dashboard (API-only).
+@ __an_webroot CliCtx x → String {
+    : String v ( ctx_str x `webroot` )
+    ? > ( string_len v ) 0 {
+        ? ( file_exists ( string_data v ) ) { ^ v } { ( string_free v ) }
+    } {
+        ( string_free v )
     }
-    // Candidates derived from the executable location.
     : !String IoErr exe ( fs_readlink `/proc/self/exe` )
     ?? exe {
         T ep → {
@@ -81,64 +82,62 @@ $ `src/service.nu`
         }
         F _ → {}
     }
-    // Last resort: ./static relative to the current directory.
     ? ( file_exists `static` ) { ^ ( string_from `static` ) } {}
     ^ ( string_new )
 }
 
-// key=val positionals (from index `from`) → a JSON record. Numeric-looking
+// The key=val positionals after the model → a JSON record. Numeric-looking
 // values become JSON numbers, everything else a JSON string (the library's
 // auto-typing takes it from there). None on a malformed argument.
-@ __cli_record ( Vec String ) pos i from → ?Json {
+@ __an_record CliCtx x → ?Json {
     : Json o ( json_obj_new )
-    : i n ( vec_len [String] pos )
-    : ~ i k from
+    : i n ( ctx_nargs x )
+    : ~ i k 1
     ~ < k n {
-        ?? ( vec_get [String] pos k ) {
-            T kv → {
-                : ?i eq ( string_index_of kv `=` )
-                ?? eq {
-                    T at → {
-                        ? <= at 0 {
-                            ( json_free o )
-                            ^ @ ?Json { F }
-                        } {}
-                        : String key ( string_new )
-                        : String val ( string_new )
-                        : i len ( string_len kv )
-                        : ~ i c 0
-                        ~ < c at {
-                            ( string_push_char key ( string_get kv c ) )
-                            = c + c 1
-                        }
-                        = c + at 1
-                        ~ < c len {
-                            ( string_push_char val ( string_get kv c ) )
-                            = c + c 1
-                        }
-                        : ?f fx ( string_to_float val )
-                        ?? fx {
-                            T x → { ( json_obj_set o ( string_data key ) ( json_float x ) ) }
-                            F _ → { ( json_obj_set o ( string_data key ) ( json_str_lit ( string_data val ) ) ) }
-                        }
-                        ( string_free key )
-                        ( string_free val )
-                    }
-                    F _ → {
-                        ( json_free o )
-                        ^ @ ?Json { F }
-                    }
+        : String kv ( ctx_arg x k )
+        : ?i eq ( string_index_of kv `=` )
+        ?? eq {
+            T at → {
+                ? <= at 0 {
+                    ( string_free kv )
+                    ( json_free o )
+                    ^ @ ?Json { F }
+                } {}
+                : String key ( string_new )
+                : String val ( string_new )
+                : i len ( string_len kv )
+                : ~ i c 0
+                ~ < c at {
+                    ( string_push_char key ( string_get kv c ) )
+                    = c + c 1
                 }
+                = c + at 1
+                ~ < c len {
+                    ( string_push_char val ( string_get kv c ) )
+                    = c + c 1
+                }
+                : ?f fx ( string_to_float val )
+                ?? fx {
+                    T fv → { ( json_obj_set o ( string_data key ) ( json_float fv ) ) }
+                    F _ → { ( json_obj_set o ( string_data key ) ( json_str_lit ( string_data val ) ) ) }
+                }
+                ( string_free key )
+                ( string_free val )
             }
-            F _ → {}
+            F _ → {
+                ( string_free kv )
+                ( json_free o )
+                ^ @ ?Json { F }
+            }
         }
+        ( string_free kv )
         = k + k 1
     }
     ^ @ ?Json { T o }
 }
 
 // Print a verdict as one compact JSON object.
-@ __cli_print_verdict *Model mo Verdict vd → v {
+@ __an_print_verdict *Model mo Verdict vd → v {
     : Json o ( json_obj_new )
     ? . vd ready {
         ( json_obj_set o `status` ( json_str_lit `success` ) )
@@ -173,10 +172,10 @@ $ `src/service.nu`
 }
 
 // Print (or report the error of) one detect/score result. Exit code.
-@ __cli_report *Model mo !Verdict String vr → i {
+@ __an_report *Model mo !Verdict String vr → i {
     ?? vr {
         T vd → {
-            ( __cli_print_verdict mo vd )
+            ( __an_print_verdict mo vd )
             ( verdict_free vd )
             ^ 0
         }
@@ -189,77 +188,75 @@ $ `src/service.nu`
     }
 }
 
-// detect / score shared path. Returns the exit code.
-@ __cli_detect ArgParser p ( Vec String ) pos b ingest → i {
-    ? < ( vec_len [String] pos ) 2 {
+// ── Command handlers ──────────────────────────────────────────────────
+
+// detect / score share a path: ingest = true stores + retrains, false only
+// scores. Model = first positional; features = the remaining key=val args.
+@ __an_cmd_detect CliCtx x b ingest → i {
+    ? < ( ctx_nargs x ) 1 {
         ( nurl_eprintln `anomaly: model name required` )
         ^ 2
     } {}
-    : ~ s mname ``
-    ?? ( vec_get [String] pos 1 ) { T m → { = mname ( string_data m ) } F _ → {} }
-    : ?Json ro ( __cli_record pos 2 )
+    : String mname ( ctx_arg x 0 )
+    : ?Json ro ( __an_record x )
+    : ~ i rc 0
     ?? ro {
         T rec → {
-            ? > ( json_arr_len rec ) 0 { } {}
-            : String root ( __cli_store_root p )
+            : String root ( __an_store_root x )
             : Store st ( store_open ( string_data root ) )
             ( string_free root )
-            : ~ i rc 0
-            ? & == ingest F == ( store_exists st mname ) F {
+            ? & == ingest F == ( store_exists st ( string_data mname ) ) F {
                 ( nurl_eprint `anomaly: model not found: ` )
-                ( nurl_eprintln mname )
+                ( nurl_eprintln ( string_data mname ) )
                 = rc 1
             } {
-                : *Model mo ( model_open st mname )
+                : *Model mo ( model_open st ( string_data mname ) )
                 ? ingest {
                     : !Verdict String vr ( model_ingest mo rec )
-                    = rc ( __cli_report mo vr )
+                    = rc ( __an_report mo vr )
                 } {
                     : !Verdict String vr ( model_detect_only mo rec )
-                    = rc ( __cli_report mo vr )
+                    = rc ( __an_report mo vr )
                 }
                 ( model_free mo )
             }
             ( store_free st )
             ( json_free rec )
-            ^ rc
         }
         F _ → {
             ( nurl_eprintln `anomaly: arguments must be key=value pairs` )
-            ^ 2
+            = rc 2
         }
     }
+    ( string_free mname )
+    ^ rc
 }
 
 // batch: stateless CSV scoring, one `index<TAB>score` line per row.
-@ __cli_batch ArgParser p → i {
+@ __an_cmd_batch CliCtx x → i {
     : ~ String input ( string_new )
     : ~ b have_input T
-    : ?String fo ( args_value p `file` )
-    ?? fo {
-        T fv → {
-            : !String IoErr r ( read_file ( string_data fv ) )
-            ?? r {
-                T txt → { ( string_free input ) = input txt }
-                F _ → {
-                    ( nurl_eprint `anomaly: cannot read file: ` )
-                    ( nurl_eprintln ( string_data fv ) )
-                    = have_input F
-                }
+    : String fv ( ctx_str x `file` )
+    ? > ( string_len fv ) 0 {
+        : !String IoErr r ( read_file ( string_data fv ) )
+        ?? r {
+            T txt → { ( string_free input ) = input txt }
+            F _ → {
+                ( nurl_eprint `anomaly: cannot read file: ` )
+                ( nurl_eprintln ( string_data fv ) )
+                = have_input F
             }
-            ( string_free fv )
         }
-        F junk → {
-            ( string_free junk )
-            ( string_free input )
-            = input ( read_all_stdin )
-        }
+    } {
+        ( string_free input )
+        = input ( read_all_stdin )
     }
+    ( string_free fv )
     ? have_input {} {
         ( string_free input )
         ^ 1
     }
-    : b header ( args_present p `header` )
+    : b header ( ctx_bool x `header` )
     : AnomCsv ds ( anom_parse_csv ( string_data input ) `,` header )
     ( string_free input )
     ? || <= . ds rows 0 <= . ds cols 0 {
@@ -267,15 +264,7 @@ $ `src/service.nu`
         ( anom_csv_free ds )
         ^ 1
     } {}
-    : ~ f margin 0.0
-    : ?String mg ( args_value p `margin` )
-    ?? mg {
-        T mv → {
-            ?? ( string_to_float mv ) { T x → { = margin x } F _ → {} }
-            ( string_free mv )
-        }
-        F junk → { ( string_free junk ) }
-    }
+    : f margin ( ctx_float x `margin` )
     : VerCfg cfg @ VerCfg { ( string_from `batch` ) 0 0 100 256 -1.0 margin T }
     : BatchReport rep ( anomaly_batch . ds data . ds rows . ds cols cfg )
     ( __an_vercfg_free cfg )
@@ -305,197 +294,189 @@ $ `src/service.nu`
     ^ 0
 }
 
-@ main → i {
-    : ArgParser p ( args_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` )
-    ( args_opt p `store` 115 `DIR` `model store (default: $ANOMALY_HOME, else ~/.anomaly)` )
-    ( args_opt p `file` 102 `FILE` `for batch: read CSV from FILE instead of stdin` )
-    ( args_opt p `margin` 109 `M` `for batch: decision margin (default 0 = predict==-1)` )
-    ( args_opt p `addr` 97 `HOST:PORT` `for serve: bind address (default 127.0.0.1:8811)` )
-    ( args_opt p `webroot` 119 `DIR` `for serve: dashboard HTML dir (default: <exe>/static, $ANOMALY_WEBROOT)` )
-    ( args_flag p `header` 72 `for batch: skip the first CSV line (header)` )
-    ( args_flag p `help` 104 `show this help` )
-    ( args_flag p `version` 0 `print the version` )
-
-    ? ( args_parse_argv p ) {} {
-        ( nurl_eprintln ( args_error p ) )
-        ( args_free p )
-        ^ 2
+@ __an_cmd_serve CliCtx x → i {
+    : String addr ( ctx_str x `addr` )
+    : ~ String host ( string_new )
+    : ~ i port 8811
+    : ?i colon ( string_index_of addr `:` )
+    ?? colon {
+        T at → {
+            : i n ( string_len addr )
+            : ~ i c 0
+            ~ < c at {
+                ( string_push_char host ( string_get addr c ) )
+                = c + c 1
+            }
+            : String ps ( string_new )
+            = c + at 1
+            ~ < c n {
+                ( string_push_char ps ( string_get addr c ) )
+                = c + c 1
+            }
+            ?? ( string_to_int ps ) { T v → { = port v } F _ → {} }
+            ( string_free ps )
+        }
+        F _ → {
+            ( string_free host )
+            = host ( string_from ( string_data addr ) )
+        }
     }
-    ? ( args_present p `help` ) {
-        : String u ( args_usage p )
-        ( nurl_print ( string_data u ) )
-        ( nurl_print `\ncommands:\n  detect <model> key=val ...   ingest one point, print the verdict\n  score  <model> key=val ...   score only (never ingests or retrains)\n  batch  [-f FILE] [-H]        score a CSV, one "index<TAB>score" per row\n  train  <model>               force a retrain now\n  reset  <model>               drop data + forests, keep the name\n  rm     <model>               delete the model entirely\n  ls                           list models\n  info   <model>               print model metadata\n  serve  [--addr H:P] [--webroot DIR]  HTTP/JSON service + web dashboard\n` )
-        ( string_free u )
-        ( args_free p )
-        ^ 0
-    } {}
-    ? ( args_present p `version` ) {
-        ( pline `anomaly 0.3.1` )
-        ( args_free p )
-        ^ 0
-    } {}
-    ? < ( args_positional_count p ) 1 {
-        ( nurl_eprintln `usage: anomaly <detect|score|batch|train|reset|rm|ls|info|serve> ... (anomaly --help)` )
-        ( args_free p )
-        ^ 2
-    } {}
+    : String root ( __an_store_root x )
+    ( anomaly_service_set_root ( string_data root ) )
+    : String webroot ( __an_webroot x )
+    ( anomaly_service_set_webroot ( string_data webroot ) )
+    ? > ( string_len webroot ) 0 {
+        ( nurl_eprint `anomaly: dashboard web root: ` )
+        ( nurl_eprintln ( string_data webroot ) )
+    } {
+        ( nurl_eprintln `anomaly: no dashboard web root found (API-only)` )
+    }
+    : i rc ( anomaly_serve ( string_data host ) port )
+    ( string_free webroot )
+    ( string_free root )
+    ( string_free host )
+    ( string_free addr )
+    ^ rc
+}
 
-    : ( Vec String ) pos ( args_positionals p )
-    : ~ s cmd ``
-    ?? ( vec_get [String] pos 0 ) { T c → { = cmd ( string_data c ) } F _ → {} }
-    : ~ s arg1 ``
-    ? >= ( args_positional_count p ) 2 {
-        ?? ( vec_get [String] pos 1 ) { T a → { = arg1 ( string_data a ) } F _ → {} }
-    } {}
+@ __an_cmd_ls CliCtx x → i {
+    : String root ( __an_store_root x )
+    : Store st ( store_open ( string_data root ) )
+    ( string_free root )
+    : ( Vec String ) names ( store_list st )
+    : i n ( vec_len [String] names )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] names k ) {
+            T nm → { ( pline ( string_data nm ) ) }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [String] names \ String s → v { ( string_free s ) } )
+    ( store_free st )
+    ^ 0
+}
 
+@ __an_cmd_info CliCtx x → i {
+    : String mname ( ctx_arg x 0 )
+    : String root ( __an_store_root x )
+    : Store st ( store_open ( string_data root ) )
+    ( string_free root )
     : ~ i rc 0
-    : ~ b handled T
-    ? ( nurl_str_eq cmd `detect` ) {
-        = rc ( __cli_detect p pos T )
-    } {
-    ? ( nurl_str_eq cmd `score` ) {
-        = rc ( __cli_detect p pos F )
-    } {
-    ? ( nurl_str_eq cmd `batch` ) {
-        = rc ( __cli_batch p )
-    } {
-    ? ( nurl_str_eq cmd `serve` ) {
-        : ~ String addr ( string_from `127.0.0.1:8811` )
-        : ?String av ( args_value p `addr` )
-        ?? av {
-            T v → { ( string_free addr ) = addr v }
-            F junk → { ( string_free junk ) }
+    ?? ( store_load_meta st ( string_data mname ) ) {
+        T mm → {
+            : Json o ( meta_to_json mm )
+            : String out ( json_pretty o )
+            ( pline ( string_data out ) )
+            ( string_free out )
+            ( json_free o )
+            ( meta_free mm )
         }
-        : ~ String host ( string_new )
-        : ~ i port 8811
-        : ?i colon ( string_index_of addr `:` )
-        ?? colon {
-            T at → {
-                : i n ( string_len addr )
-                : ~ i c 0
-                ~ < c at {
-                    ( string_push_char host ( string_get addr c ) )
-                    = c + c 1
-                }
-                : String ps ( string_new )
-                = c + at 1
-                ~ < c n {
-                    ( string_push_char ps ( string_get addr c ) )
-                    = c + c 1
-                }
-                ?? ( string_to_int ps ) { T x → { = port x } F _ → {} }
-                ( string_free ps )
-            }
-            F _ → {
-                ( string_free host )
-                = host ( string_from ( string_data addr ) )
-            }
+        F _ → {
+            ( nurl_eprint `anomaly: model not found: ` )
+            ( nurl_eprintln ( string_data mname ) )
+            = rc 1
         }
-        : String root ( __cli_store_root p )
-        ( anomaly_service_set_root ( string_data root ) )
-        : String webroot ( __cli_webroot p )
-        ( anomaly_service_set_webroot ( string_data webroot ) )
-        ? > ( string_len webroot ) 0 {
-            ( nurl_eprint `anomaly: dashboard web root: ` )
-            ( nurl_eprintln ( string_data webroot ) )
-        } {
-            ( nurl_eprintln `anomaly: no dashboard web root found (API-only)` )
-        }
-        = rc ( anomaly_serve ( string_data host ) port )
-        ( string_free webroot )
-        ( string_free root )
-        ( string_free host )
-        ( string_free addr )
-    } {
-        // Store-backed single-model commands.
-        : String root ( __cli_store_root p )
-        : Store st ( store_open ( string_data root ) )
-        ( string_free root )
-        ? ( nurl_str_eq cmd `ls` ) {
-            : ( Vec String ) names ( store_list st )
-            : i n ( vec_len [String] names )
-            : ~ i k 0
-            ~ < k n {
-                ?? ( vec_get [String] names k ) {
-                    T nm → { ( pline ( string_data nm ) ) }
-                    F _ → {}
-                }
-                = k + k 1
-            }
-            ( vec_free_with [String] names \ String x → v { ( string_free x ) } )
-        } {
-        ? ( nurl_str_eq cmd `info` ) {
-            : ?*Meta mload ( store_load_meta st arg1 )
-            ?? mload {
-                T mm → {
-                    : Json o ( meta_to_json mm )
-                    : String out ( json_pretty o )
-                    ( pline ( string_data out ) )
-                    ( string_free out )
-                    ( json_free o )
-                    ( meta_free mm )
-                }
-                F _ → {
-                    ( nurl_eprint `anomaly: model not found: ` )
-                    ( nurl_eprintln arg1 )
-                    = rc 1
-                }
-            }
-        } {
-        ? ( nurl_str_eq cmd `train` ) {
-            ? ( store_exists st arg1 ) {
-                : *Model mo ( model_open st arg1 )
-                : i used ( model_force_train mo )
-                ? > used 0 {
-                    : String msg ( string_from `trained on ` )
-                    ( string_push_int msg used )
-                    ( string_push_str msg ` points` )
-                    ( pline ( string_data msg ) )
-                    ( string_free msg )
-                } {
-                    ( nurl_eprintln `anomaly: not enough data to train` )
-                    = rc 1
-                }
-                ( model_free mo )
-            } {
-                ( nurl_eprint `anomaly: model not found: ` )
-                ( nurl_eprintln arg1 )
-                = rc 1
-            }
-        } {
-        ? ( nurl_str_eq cmd `reset` ) {
-            ? ( store_exists st arg1 ) {
-                : *Model mo ( model_open st arg1 )
-                ( model_reset mo )
-                ( model_free mo )
-                ( pline `reset` )
-            } {
-                ( nurl_eprint `anomaly: model not found: ` )
-                ( nurl_eprintln arg1 )
-                = rc 1
-            }
-        } {
-        ? ( nurl_str_eq cmd `rm` ) {
-            ? ( store_exists st arg1 ) {
-                : b okd ( model_delete st arg1 )
-                ? okd { ( pline `deleted` ) } {
-                    ( nurl_eprintln `anomaly: delete failed` )
-                    = rc 1
-                }
-            } {
-                ( nurl_eprint `anomaly: model not found: ` )
-                ( nurl_eprintln arg1 )
-                = rc 1
-            }
-        } {
-            ( nurl_eprint `anomaly: unknown command: ` )
-            ( nurl_eprintln cmd )
-            ( nurl_eprintln `try 'anomaly --help'` )
-            = rc 2
-        } } } } }
-        ( store_free st )
-    } } } }
+    }
+    ( store_free st )
+    ( string_free mname )
+    ^ rc
+}
 
-    ( args_free p )
+@ __an_cmd_train CliCtx x → i {
+    : String mname ( ctx_arg x 0 )
+    : String root ( __an_store_root x )
+    : Store st ( store_open ( string_data root ) )
+    ( string_free root )
+    : ~ i rc 0
+    ? ( store_exists st ( string_data mname ) ) {
+        : *Model mo ( model_open st ( string_data mname ) )
+        : i used ( model_force_train mo )
+        ? > used 0 {
+            : String msg ( string_from `trained on ` )
+            ( string_push_int msg used )
+            ( string_push_str msg ` points` )
+            ( pline ( string_data msg ) )
+            ( string_free msg )
+        } {
+            ( nurl_eprintln `anomaly: not enough data to train` )
+            = rc 1
+        }
+        ( model_free mo )
+    } {
+        ( nurl_eprint `anomaly: model not found: ` )
+        ( nurl_eprintln ( string_data mname ) )
+        = rc 1
+    }
+    ( store_free st )
+    ( string_free mname )
+    ^ rc
+}
+
+@ __an_cmd_reset CliCtx x → i {
+    : String mname ( ctx_arg x 0 )
+    : String root ( __an_store_root x )
+    : Store st ( store_open ( string_data root ) )
+    ( string_free root )
+    : ~ i rc 0
+    ? ( store_exists st ( string_data mname ) ) {
+        : *Model mo ( model_open st ( string_data mname ) )
+        ( model_reset mo )
+        ( model_free mo )
+        ( pline `reset` )
+    } {
+        ( nurl_eprint `anomaly: model not found: ` )
+        ( nurl_eprintln ( string_data mname ) )
+        = rc 1
+    }
+    ( store_free st )
+    ( string_free mname )
+    ^ rc
+}
+
+@ __an_cmd_rm CliCtx x → i {
+    : String mname ( ctx_arg x 0 )
+    : String root ( __an_store_root x )
+    : Store st ( store_open ( string_data root ) )
+    ( string_free root )
+    : ~ i rc 0
+    ? ( store_exists st ( string_data mname ) ) {
+        : b okd ( model_delete st ( string_data mname ) )
+        ? okd { ( pline `deleted` ) } {
+            ( nurl_eprintln `anomaly: delete failed` )
+            = rc 1
+        }
+    } {
+        ( nurl_eprint `anomaly: model not found: ` )
+        ( nurl_eprintln ( string_data mname ) )
+        = rc 1
+    }
+    ( store_free st )
+    ( string_free mname )
+    ^ rc
+}
+
+@ main → i {
+    : *Cli c ( cli_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` `0.3.1` )
+    ( cli_flag_str  c `store`   115 `DIR`  `model store (default: $ANOMALY_HOME, else ~/.anomaly)` `` `ANOMALY_HOME` )
+    ( cli_flag_str  c `file`    102 `FILE` `for batch: read CSV from FILE instead of stdin` `` `` )
+    ( cli_flag_str  c `margin`  109 `M`    `for batch: decision margin (default 0 = predict==-1)` `0` `` )
+    ( cli_flag_str  c `addr`    97  `HOST:PORT` `for serve: bind address` `127.0.0.1:8811` `` )
+    ( cli_flag_str  c `webroot` 119 `DIR`  `for serve: dashboard HTML dir (default: <exe>/static, $ANOMALY_WEBROOT)` `` `ANOMALY_WEBROOT` )
+    ( cli_flag_bool c `header`  72  `for batch: skip the first CSV line (header)` )
+
+    ( cli_cmd c `detect` `ingest one point, print the verdict` \ CliCtx x → i { ^ ( __an_cmd_detect x T ) } )
+    ( cli_cmd c `score`  `score only (never ingests or retrains)` \ CliCtx x → i { ^ ( __an_cmd_detect x F ) } )
+    ( cli_cmd c `batch`  `score a CSV, one index<TAB>score per row` \ CliCtx x → i { ^ ( __an_cmd_batch x ) } )
+    ( cli_cmd c `train`  `force a retrain now` \ CliCtx x → i { ^ ( __an_cmd_train x ) } )
+    ( cli_cmd c `reset`  `drop data + forests, keep the name` \ CliCtx x → i { ^ ( __an_cmd_reset x ) } )
+    ( cli_cmd c `rm`     `delete the model entirely` \ CliCtx x → i { ^ ( __an_cmd_rm x ) } )
+    ( cli_cmd c `ls`     `list models` \ CliCtx x → i { ^ ( __an_cmd_ls x ) } )
+    ( cli_cmd c `info`   `print model metadata` \ CliCtx x → i { ^ ( __an_cmd_info x ) } )
+    ( cli_cmd c `serve`  `run the HTTP/JSON service + web dashboard` \ CliCtx x → i { ^ ( __an_cmd_serve x ) } )
+
+    : i rc ( cli_run c )
+    ( cli_free c )
     ^ rc
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,116 @@
+# cli — the command-line framework for NURL
+
+One dependency for building a real command-line tool. NURL's stdlib ships a
+flat argument parser (`std/args`), terminal control (`std/term` — isatty,
+ANSI, a line editor), stdin/stdout (`core/io`), and the environment
+(`ext/env`). What it doesn't ship is the glue every tool re-invents: a
+subcommand dispatch cascade, typed flag accessors with env fallbacks and
+defaults, colour-aware `--help` / `--version` / usage, error → exit-code
+handling, and interactive prompts.
+
+`cli` is that glue — a `Cli` object that collapses the 100–500 line
+hand-written `main()` every package carries into a declarative handful of
+calls.
+
+## Hello, CLI
+
+```nurl
+$ `deps/cli/src/cli.nu`
+
+@ main → i {
+    : *Cli c ( cli_new `greet` `a tiny greeter` `1.0.0` )
+    ( cli_flag_str  c `name` 110 `NAME` `who to greet` `world` `GREET_NAME` )
+    ( cli_flag_bool c `loud` 108 `shout it` )
+    ( cli_cmd c `hello` `print a greeting` \ CliCtx x → i {
+        : String who ( ctx_str x `name` )
+        ( nurl_print `hello, ` ) ( nurl_print ( string_data who ) )
+        ? ( ctx_bool x `loud` ) { ( nurl_print `!` ) } {}
+        ( nurl_print `\n` )
+        ( string_free who )
+        ^ 0
+    } )
+    : i rc ( cli_run c )
+    ( cli_free c )
+    ^ rc
+}
+```
+
+```
+$ greet hello --name Tero --loud
+hello, Tero!
+$ GREET_NAME=Env greet hello          # env fallback
+hello, Env
+$ greet --help                        # auto, coloured on a TTY
+```
+
+## The API
+
+Construction & run:
+
+| Call | |
+| --- | --- |
+| `( cli_new prog about version )` → `*Cli` | create (free with `cli_free`) |
+| `( cli_run c )` → `i` | parse argv, route to a command, return its exit code |
+
+Flags (global; resolved per command). Each takes `long`, a `short` char code
+(0 = none), and — for value flags — a `metavar`, `help`, a default, and an
+env-var name (empty `` = none):
+
+| Call | |
+| --- | --- |
+| `( cli_flag_bool c long short help )` | presence flag |
+| `( cli_flag_str  c long short metavar help dflt env )` | string |
+| `( cli_flag_int  c long short metavar help dflt env )` | integer (`dflt` is `i`) |
+| `( cli_flag_float c long short metavar help dflt env )` | float (`dflt` is `f`) |
+
+Commands — the handler is `( @ i CliCtx )`, returning an exit code:
+
+| Call | |
+| --- | --- |
+| `( cli_cmd c name help handler )` | register a subcommand |
+
+Inside a handler, read from the `CliCtx`:
+
+| Call | |
+| --- | --- |
+| `( ctx_str x name )` → `String` | value → env → default (owned; free it) |
+| `( ctx_int x name )` → `i`, `( ctx_float x name )` → `f` | typed |
+| `( ctx_bool x name )` → `b` | flag presence |
+| `( ctx_arg x idx )` → `String` | idx-th positional after the command |
+| `( ctx_nargs x )` → `i` | positional count |
+| `( ctx_stdin x )` → `String` | slurp stdin (pipe-friendly) |
+| `( ctx_cmd x )` → `s` | the invoked command name |
+
+Interactive prompts (write to stderr; TTY-aware):
+
+| Call | |
+| --- | --- |
+| `( cli_prompt question )` → `String` | free-text line |
+| `( cli_confirm question def )` → `b` | y/N (or Y/n), `def` on Enter/EOF |
+| `( cli_password question )` → `String` | no echo on a TTY |
+
+## Behaviour
+
+- **`--help` / `-h`** — auto-generated global help (usage, aligned command
+  list, options with defaults and env vars). `prog <cmd> --help` gives the
+  command's help. **`--version`** prints `prog version`.
+- **Colour** is decided once: on only when stdout is a TTY and `$NO_COLOR`
+  is unset. Piped output is plain.
+- **Exit codes** — a command returns its own; unknown command or a parse
+  error is `2`; a bare invocation with no command prints help and exits `1`.
+- **Flag resolution** — an explicit `--flag` wins, else the bound env var,
+  else the declared default.
+
+## Scope
+
+`cli` facades the command-line surface — args, env, stdin, TTY/colour/prompt,
+exit codes. It deliberately does **not** absorb terminal widgets
+(tables / spinners / progress), config-file loading, or logging; those
+compose as their own packages.
+
+## Tests
+
+`./tests/cli_test.sh` builds `tests/demo.nu` (a five-command CLI) and drives
+routing, typed flags with env + precedence, positionals, stdin, prompts,
+help/version and exit codes — then re-runs the allocating paths under
+AddressSanitizer (0 errors, 0 leaks).

--- a/packages/cli/nurl.toml
+++ b/packages/cli/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cli"
+version = "0.1.0"
+description = "The ergonomic command-line framework for NURL. A single dependency-importable facade over the stdlib command-line surface (std/args parser, std/term isatty + ANSI + line editor, core/io stdin/stdout, ext/env environment). Where the stdlib ships a flat argument parser, `cli` ships the glue every tool re-invents: a `Cli` object with git-style subcommand routing, typed flag accessors (string/int/bool/float) with environment-variable fallbacks and defaults, auto-generated and colour-aware --help / --version / usage, error → exit-code handling, and interactive prompts (confirm / prompt / no-echo password). `( cli_new … )`, a few `( cli_flag_* … )` and `( cli_cmd … )` registrations, and `( cli_run c )` stand up a complete, polished CLI — collapsing the ~100–500 line hand-written main() that every package carries today. Colours are TTY-gated and respect $NO_COLOR. Facades the command-line surface only; terminal widgets, config files and logging compose as separate packages."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/cli/src/cli.nu
+++ b/packages/cli/src/cli.nu
@@ -1,0 +1,619 @@
+// cli/cli.nu — the ergonomic command-line facade over the stdlib.
+//
+// The stdlib ships a flat argument parser (std/args), terminal control
+// (std/term: isatty + ANSI + a line editor), stdin/stdout (core/io) and the
+// process environment (ext/env). What every CLI re-invents on top is the
+// same glue: a subcommand dispatch cascade, typed flag accessors with env
+// fallbacks and defaults, coloured `--help` / `--version` / usage, error →
+// exit-code handling, and interactive prompts.
+//
+// `Cli` collapses that into one object:
+//
+//     : *Cli c ( cli_new `greet` `a tiny greeter` `1.0.0` )
+//     ( cli_flag_str  c `name` 110 `NAME` `who to greet` `world` `` )
+//     ( cli_flag_bool c `loud` 108 `shout it` )
+//     ( cli_cmd c `hello` `print a greeting` \ CliCtx x → i {
+//         : String who ( ctx_str x `name` )
+//         ( nurl_print `hello, ` ) ( nurl_print ( string_data who ) ) ( nurl_print `\n` )
+//         ( string_free who )
+//         ^ 0
+//     } )
+//     ^ ( cli_run c )     // parse argv, route, auto --help/--version → exit code
+//
+// Scope: this facades the command-line surface (args + env + stdin + tty /
+// colour / prompts + exit codes). It deliberately does NOT absorb terminal
+// widgets (tables/spinners), config-file loading, or logging — those compose
+// as their own packages.
+//
+// Memory model: `cli_new` returns a heap `*Cli`, mutable across the builder
+// calls; free it with `cli_free`. Flags and commands accumulate into its
+// Vecs. `cli_run` owns the parse and frees everything it allocates.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/args.nu`
+$ `stdlib/std/term.nu`
+$ `stdlib/ext/env.nu`
+$ `prompt.nu`
+
+// Flag kinds.
+//   0 = string   1 = int   2 = bool (presence)   3 = float
+: CliFlag {
+    String long
+    i short          // short-option char code, 0 = none
+    String metavar   // value placeholder in help (empty for bool)
+    String help
+    i kind
+    String dflt      // default rendered as text (empty = none)
+    String env       // environment-variable fallback (empty = none)
+}
+
+: CliCmd {
+    String name
+    String help
+    ( @ i CliCtx ) handler
+}
+
+: Cli {
+    String prog
+    String about
+    String version
+    ( Vec CliFlag ) globals
+    ( Vec CliCmd ) cmds
+}
+
+// Passed to every command handler; wraps the parsed args plus a back-ref to
+// the Cli so accessors can resolve env fallbacks and defaults.
+: CliCtx {
+    ArgParser parser
+    *Cli cli
+    String cmdname
+}
+
+// ── Colour (decided once per run: stdout is a TTY and $NO_COLOR unset) ──
+
+: ~ b g_cli_color F
+
+@ __cli_detect_color → v {
+    : ~ b on ( term_is_tty 1 )
+    ?? ( env_get `NO_COLOR` ) {
+        T v → { = on F ( string_free v ) }
+        F junk → { ( string_free junk ) }
+    }
+    = g_cli_color on
+}
+
+@ __wrap s open s text → String {
+    ? g_cli_color {
+        : String r ( string_from open )
+        ( string_push_str r text )
+        : String rst ( ansi_reset )
+        ( string_push_str r ( string_data rst ) )
+        ( string_free rst )
+        ^ r
+    } {
+        ^ ( string_from text )
+    }
+}
+
+@ __sgr i code s text → String {
+    : String o ( ansi_sgr code )
+    : String r ( __wrap ( string_data o ) text )
+    ( string_free o )
+    ^ r
+}
+@ __fg i color s text → String {
+    : String o ( ansi_fg color )
+    : String r ( __wrap ( string_data o ) text )
+    ( string_free o )
+    ^ r
+}
+
+// ── Construction / teardown ───────────────────────────────────────────
+
+@ cli_new s prog s about s version → *Cli {
+    : *Cli c # *Cli ( nurl_malloc Z Cli )
+    = . c prog ( string_from prog )
+    = . c about ( string_from about )
+    = . c version ( string_from version )
+    = . c globals ( vec_new [CliFlag] )
+    = . c cmds ( vec_new [CliCmd] )
+    ^ c
+}
+
+@ __cli_free_flags ( Vec CliFlag ) v → v {
+    : i n ( vec_len [CliFlag] v )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [CliFlag] v k ) {
+            T f → {
+                ( string_free . f long )
+                ( string_free . f metavar )
+                ( string_free . f help )
+                ( string_free . f dflt )
+                ( string_free . f env )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [CliFlag] v )
+}
+
+@ __cli_free_cmds ( Vec CliCmd ) v → v {
+    : i n ( vec_len [CliCmd] v )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [CliCmd] v k ) {
+            T cm → { ( string_free . cm name ) ( string_free . cm help ) }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [CliCmd] v )
+}
+
+@ cli_free *Cli c → v {
+    ( string_free . c prog )
+    ( string_free . c about )
+    ( string_free . c version )
+    ( __cli_free_flags . c globals )
+    ( __cli_free_cmds . c cmds )
+    ( nurl_free c )
+}
+
+// ── Flag builders (global flags; applied across all commands) ──────────
+
+@ __cli_add_flag *Cli c s long i short s metavar s help i kind s dflt s env → v {
+    : CliFlag f @ CliFlag {
+        ( string_from long ) short ( string_from metavar ) ( string_from help )
+        kind ( string_from dflt ) ( string_from env )
+    }
+    ( vec_push [CliFlag] . c globals f )
+}
+
+@ cli_flag_bool *Cli c s long i short s help → v {
+    ( __cli_add_flag c long short `` help 2 `` `` )
+}
+@ cli_flag_str *Cli c s long i short s metavar s help s dflt s env → v {
+    ( __cli_add_flag c long short metavar help 0 dflt env )
+}
+@ cli_flag_int *Cli c s long i short s metavar s help i dflt s env → v {
+    : String d ( string_new )
+    ( string_push_int d dflt )
+    ( __cli_add_flag c long short metavar help 1 ( string_data d ) env )
+    ( string_free d )
+}
+@ cli_flag_float *Cli c s long i short s metavar s help f dflt s env → v {
+    : String d ( string_new )
+    ( string_push_float d dflt )
+    ( __cli_add_flag c long short metavar help 3 ( string_data d ) env )
+    ( string_free d )
+}
+
+// ── Command registration ──────────────────────────────────────────────
+
+@ cli_cmd *Cli c s name s help ( @ i CliCtx ) handler → v {
+    : CliCmd cmd @ CliCmd { ( string_from name ) ( string_from help ) handler }
+    ( vec_push [CliCmd] . c cmds cmd )
+}
+
+// Index of the command named `name`, or None.
+@ __cli_find_cmd *Cli c s name → ?i {
+    : i n ( vec_len [CliCmd] . c cmds )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [CliCmd] . c cmds k ) {
+            T cm → {
+                ? == 1 ( nurl_str_eq ( string_data . cm name ) name ) { ^ @ ?i { T k } } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ @ ?i { F }
+}
+
+// ── Context accessors (used inside handlers) ──────────────────────────
+
+// Resolve a string flag: explicit value → env fallback → default → "".
+@ __cli_fallback *Cli c s name → String {
+    : i n ( vec_len [CliFlag] . c globals )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [CliFlag] . c globals k ) {
+            T f → {
+                ? == 1 ( nurl_str_eq ( string_data . f long ) name ) {
+                    ? > ( string_len . f env ) 0 {
+                        ?? ( env_get ( string_data . f env ) ) {
+                            T v → { ^ v }
+                            F junk → { ( string_free junk ) }
+                        }
+                    } {}
+                    ^ ( string_from ( string_data . f dflt ) )
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ ( string_new )
+}
+
+@ ctx_str CliCtx x s name → String {
+    ?? ( args_value . x parser name ) {
+        T v → { ^ v }
+        F junk → { ( string_free junk ) }
+    }
+    ^ ( __cli_fallback . x cli name )
+}
+
+@ ctx_int CliCtx x s name → i {
+    : String s ( ctx_str x name )
+    : ~ i r 0
+    ?? ( string_to_int s ) { T v → { = r v } F _ → {} }
+    ( string_free s )
+    ^ r
+}
+
+@ ctx_float CliCtx x s name → f {
+    : String s ( ctx_str x name )
+    : ~ f r 0.0
+    ?? ( string_to_float s ) { T v → { = r v } F _ → {} }
+    ( string_free s )
+    ^ r
+}
+
+@ ctx_bool CliCtx x s name → b {
+    ^ ( args_present . x parser name )
+}
+
+// Number of positional arguments after the command token.
+@ ctx_nargs CliCtx x → i {
+    : i n ( args_positional_count . x parser )
+    ? > n 0 { ^ - n 1 } {}
+    ^ 0
+}
+
+// The idx-th positional after the command (0-based); empty String if absent.
+// `args_positionals` hands back a BORROW of the parser's own vector — read
+// from it and copy out the one element; never free it here.
+@ ctx_arg CliCtx x i idx → String {
+    : ( Vec String ) pos ( args_positionals . x parser )
+    : i n ( vec_len [String] pos )
+    : i want + idx 1
+    ? < want n {
+        ?? ( vec_get [String] pos want ) {
+            T t → { ^ ( string_from ( string_data t ) ) }
+            F _ → {}
+        }
+    } {}
+    ^ ( string_new )
+}
+
+// Slurp stdin to EOF (for pipe-friendly commands).
+@ ctx_stdin CliCtx x → String {
+    ^ ( read_all_stdin )
+}
+
+// The command name that was invoked.
+@ ctx_cmd CliCtx x → s {
+    ^ ( string_data . x cmdname )
+}
+
+// ── Help / usage rendering ────────────────────────────────────────────
+
+@ __cli_pad String out s text i width → v {
+    ( string_push_str out text )
+    : i n ( nurl_str_len text )
+    : ~ i k n
+    ~ < k width { ( string_push_char out 32 ) = k + k 1 }
+}
+
+// "-h, --long" (or "    --long" when there's no short).
+@ __cli_flag_names CliFlag f → String {
+    : String r ( string_new )
+    ? > . f short 0 {
+        ( string_push_char r 45 )
+        ( string_push_char r . f short )
+        ( string_push_str r `, ` )
+    } {
+        ( string_push_str r `    ` )
+    }
+    ( string_push_str r `--` )
+    ( string_push_str r ( string_data . f long ) )
+    ? > ( string_len . f metavar ) 0 {
+        ( string_push_str r ` <` )
+        ( string_push_str r ( string_data . f metavar ) )
+        ( string_push_char r 62 )
+    } {}
+    ^ r
+}
+
+// "      " + cyan(names) + spaces padding the raw name width to column 24.
+@ __cli_opt_col String out s names → v {
+    : String cyan ( __fg 6 names )
+    ( string_push_str out `      ` )
+    ( string_push_str out ( string_data cyan ) )
+    ( string_free cyan )
+    : i raw ( nurl_str_len names )
+    : ~ i pw raw
+    ~ < pw 24 { ( string_push_char out 32 ) = pw + pw 1 }
+}
+
+@ __cli_render_options *Cli c String out → v {
+    : String hdr ( __sgr 1 `OPTIONS` )
+    ( string_push_str out ( string_data hdr ) )
+    ( string_push_char out 10 )
+    ( string_free hdr )
+    // help + version are always present
+    ( __cli_opt_col out `-h, --help` )
+    ( string_push_str out `show this help\n` )
+    ( __cli_opt_col out `    --version` )
+    ( string_push_str out `print the version\n` )
+    : i n ( vec_len [CliFlag] . c globals )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [CliFlag] . c globals k ) {
+            T f → {
+                : String names ( __cli_flag_names f )
+                ( __cli_opt_col out ( string_data names ) )
+                ( string_push_str out ( string_data . f help ) )
+                ? > ( string_len . f dflt ) 0 {
+                    ( string_push_str out ` [default: ` )
+                    ( string_push_str out ( string_data . f dflt ) )
+                    ( string_push_char out 93 )
+                } {}
+                ? > ( string_len . f env ) 0 {
+                    ( string_push_str out ` [env: ` )
+                    ( string_push_str out ( string_data . f env ) )
+                    ( string_push_char out 93 )
+                } {}
+                ( string_push_char out 10 )
+                ( string_free names )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+}
+
+// Longest command name, for column alignment.
+@ __cli_cmd_width *Cli c → i {
+    : i n ( vec_len [CliCmd] . c cmds )
+    : ~ i w 0
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [CliCmd] . c cmds k ) {
+            T cm → { : i l ( string_len . cm name ) ? > l w { = w l } {} }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ w
+}
+
+@ __cli_print_help *Cli c → v {
+    : String out ( string_new )
+    // header
+    : String prog ( __sgr 1 ( string_data . c prog ) )
+    ( string_push_str out ( string_data prog ) )
+    ( string_free prog )
+    ( string_push_char out 32 )
+    : String ver ( __fg 6 ( string_data . c version ) )
+    ( string_push_str out ( string_data ver ) )
+    ( string_free ver )
+    ( string_push_char out 10 )
+    ? > ( string_len . c about ) 0 {
+        ( string_push_str out ( string_data . c about ) )
+        ( string_push_char out 10 )
+    } {}
+    ( string_push_char out 10 )
+    // usage
+    : String uh ( __sgr 1 `USAGE` )
+    ( string_push_str out ( string_data uh ) )
+    ( string_free uh )
+    ( string_push_str out `\n  ` )
+    ( string_push_str out ( string_data . c prog ) )
+    ( string_push_str out ` [OPTIONS] <COMMAND> [ARGS]\n\n` )
+    // commands
+    : i nc ( vec_len [CliCmd] . c cmds )
+    ? > nc 0 {
+        : String ch ( __sgr 1 `COMMANDS` )
+        ( string_push_str out ( string_data ch ) )
+        ( string_push_char out 10 )
+        ( string_free ch )
+        : i w + ( __cli_cmd_width c ) 2
+        : ~ i k 0
+        ~ < k nc {
+            ?? ( vec_get [CliCmd] . c cmds k ) {
+                T cm → {
+                    : String nm ( __fg 6 ( string_data . cm name ) )
+                    ( string_push_str out `  ` )
+                    ( string_push_str out ( string_data nm ) )
+                    : i raw ( string_len . cm name )
+                    : ~ i pw raw
+                    ~ < pw w { ( string_push_char out 32 ) = pw + pw 1 }
+                    ( string_push_str out ( string_data . cm help ) )
+                    ( string_push_char out 10 )
+                    ( string_free nm )
+                }
+                F _ → {}
+            }
+            = k + k 1
+        }
+        ( string_push_char out 10 )
+    } {}
+    // options
+    ( __cli_render_options c out )
+    ( string_push_char out 10 )
+    : String tip ( __fg 8 `Run a command with --help for its details.` )
+    ( string_push_str out ( string_data tip ) )
+    ( string_push_char out 10 )
+    ( string_free tip )
+    ( nurl_print ( string_data out ) )
+    ( string_free out )
+}
+
+@ __cli_print_cmd_help *Cli c i idx → v {
+    : String out ( string_new )
+    ?? ( vec_get [CliCmd] . c cmds idx ) {
+        T cm → {
+            : String nm ( __sgr 1 ( string_data . cm name ) )
+            ( string_push_str out ( string_data . c prog ) )
+            ( string_push_char out 32 )
+            ( string_push_str out ( string_data nm ) )
+            ( string_free nm )
+            ? > ( string_len . cm help ) 0 {
+                ( string_push_str out ` — ` )
+                ( string_push_str out ( string_data . cm help ) )
+            } {}
+            ( string_push_str out `\n\n` )
+            : String uh ( __sgr 1 `USAGE` )
+            ( string_push_str out ( string_data uh ) )
+            ( string_free uh )
+            ( string_push_str out `\n  ` )
+            ( string_push_str out ( string_data . c prog ) )
+            ( string_push_char out 32 )
+            ( string_push_str out ( string_data . cm name ) )
+            ( string_push_str out ` [OPTIONS] [ARGS]\n\n` )
+        }
+        F _ → {}
+    }
+    ( __cli_render_options c out )
+    ( nurl_print ( string_data out ) )
+    ( string_free out )
+}
+
+// A styled "error: <msg>" line + usage hint on stderr.
+@ __cli_err *Cli c s msg → v {
+    : String pre ( __fg 1 `error:` )
+    ( nurl_eprint ( string_data pre ) )
+    ( string_free pre )
+    ( nurl_eprint ` ` )
+    ( nurl_eprintln msg )
+    ( nurl_eprint `Run '` )
+    ( nurl_eprint ( string_data . c prog ) )
+    ( nurl_eprintln ` --help' for usage.` )
+}
+
+// ── Run ───────────────────────────────────────────────────────────────
+
+@ __cli_register_flags *Cli c ArgParser p → v {
+    : i n ( vec_len [CliFlag] . c globals )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [CliFlag] . c globals k ) {
+            T f → {
+                ? == . f kind 2 {
+                    ( args_flag p ( string_data . f long ) . f short ( string_data . f help ) )
+                } {
+                    ( args_opt p ( string_data . f long ) . f short ( string_data . f metavar ) ( string_data . f help ) )
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+}
+
+@ __cli_dispatch *Cli c i idx CliCtx ctx → i {
+    ?? ( vec_get [CliCmd] . c cmds idx ) {
+        T cm → {
+            : ( @ i CliCtx ) f . cm handler
+            ^ ( f ctx )
+        }
+        F _ → { ^ 70 }
+    }
+}
+
+@ __cli_print_version *Cli c → v {
+    ( nurl_print ( string_data . c prog ) )
+    ( nurl_print ` ` )
+    ( nurl_print ( string_data . c version ) )
+    ( nurl_print `\n` )
+}
+
+// Parse the real argv, route to a subcommand, and return its exit code.
+// Handles `--help` / `--version`, unknown commands, and parse errors.
+@ cli_run *Cli c → i {
+    ( __cli_detect_color )
+
+    : ( Vec String ) argv ( env_args_list )
+    : i argc ( vec_len [String] argv )
+    : ( Vec String ) toks ( vec_new [String] )
+    : ~ i k 1
+    ~ < k argc {
+        ?? ( vec_get [String] argv k ) {
+            T t → { ( vec_push [String] toks ( string_from ( string_data t ) ) ) }
+            F _ → {}
+        }
+        = k + k 1
+    }
+
+    // Command = first token that is not an option.
+    : ~ s cmdname ``
+    : ~ b found F
+    : i tn ( vec_len [String] toks )
+    : ~ i j 0
+    ~ & ! found < j tn {
+        ?? ( vec_get [String] toks j ) {
+            T t → {
+                : s ts ( string_data t )
+                ? & > ( nurl_str_len ts ) 0 != ( nurl_str_get ts 0 ) 45 {
+                    = cmdname ts
+                    = found T
+                } {}
+            }
+            F _ → {}
+        }
+        = j + j 1
+    }
+
+    : ArgParser p ( args_new ( string_data . c prog ) ( string_data . c about ) )
+    ( args_flag p `help` 104 `show this help` )
+    ( args_flag p `version` 0 `print the version` )
+    ( __cli_register_flags c p )
+    : b okp ( args_parse p toks )
+
+    : ~ i rc 0
+    ? ! okp {
+        ( __cli_err c ( args_error p ) )
+        = rc 2
+    } {
+    ? & ! found ( args_present p `version` ) {
+        ( __cli_print_version c )
+    } {
+    ? found {
+        ?? ( __cli_find_cmd c cmdname ) {
+            T idx → {
+                ? ( args_present p `help` ) {
+                    ( __cli_print_cmd_help c idx )
+                } {
+                    : CliCtx ctx @ CliCtx { p c ( string_from cmdname ) }
+                    = rc ( __cli_dispatch c idx ctx )
+                    ( string_free . ctx cmdname )
+                }
+            }
+            F _ → {
+                : String m ( string_from `unknown command: ` )
+                ( string_push_str m cmdname )
+                ( __cli_err c ( string_data m ) )
+                ( string_free m )
+                = rc 2
+            }
+        }
+    } {
+        // No command. `--help` (or bare invocation) prints help; the bare
+        // case is a usage error (exit 1), an explicit --help is success.
+        ( __cli_print_help c )
+        ? ( args_present p `help` ) {} { = rc 1 }
+    } } }
+
+    ( args_free p )
+    ( vec_free_with [String] toks \ String s → v { ( string_free s ) } )
+    ( vec_free_with [String] argv \ String s → v { ( string_free s ) } )
+    ^ rc
+}

--- a/packages/cli/src/prompt.nu
+++ b/packages/cli/src/prompt.nu
@@ -1,0 +1,75 @@
+// cli/prompt.nu — interactive prompts over std/term + core/io.
+//
+// All prompts write to stderr (so a command's stdout stays clean for pipes)
+// and read a line from stdin. `cli_password` suppresses the echo when stdin
+// is a real terminal, and degrades to a plain read otherwise.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/term.nu`
+
+// Ask a free-text question; returns the entered line (trailing newline
+// stripped by read_line). Empty String on EOF.
+@ cli_prompt s question → String {
+    ( nurl_eprint question )
+    ( eflush )
+    ^ ( read_line )
+}
+
+// Yes/no confirmation. `def` is returned on a bare Enter or EOF. Only the
+// first character is inspected (y/Y → true, n/N → false, else the default).
+@ cli_confirm s question b def → b {
+    ( nurl_eprint question )
+    ? def { ( nurl_eprint ` [Y/n] ` ) } { ( nurl_eprint ` [y/N] ` ) }
+    ( eflush )
+    : String line ( read_line )
+    : i n ( string_len line )
+    ? == n 0 { ( string_free line ) ^ def } {}
+    : i c ( string_get line 0 )
+    ( string_free line )
+    ? || == c 121 == c 89 { ^ T } {}
+    ? || == c 110 == c 78 { ^ F } {}
+    ^ def
+}
+
+// Read a secret. When stdin is a TTY the terminal echo is disabled for the
+// duration; otherwise this is a normal (echoed) line read. No in-line
+// editing (backspace) in the no-echo path — kept intentionally minimal.
+@ cli_password s question → String {
+    ( nurl_eprint question )
+    ( eflush )
+    ?? ( term_raw_enable 0 ) {
+        T st → {
+            : String secret ( __cli_read_secret )
+            ( term_raw_disable st )
+            ( nurl_eprint `\n` )
+            ( eflush )
+            ^ secret
+        }
+        F → { ^ ( read_line ) }
+    }
+}
+
+@ __cli_read_secret → String {
+    : String buf ( string_new )
+    : ~ b going T
+    ~ going {
+        : ( Vec u ) b1 ( read_n_bytes 1 )
+        ? == ( vec_len [u] b1 ) 0 {
+            = going F
+            ( vec_free [u] b1 )
+        } {
+            : ~ i c 0
+            ?? ( vec_get [u] b1 0 ) { T x → { = c # i x } F _ → {} }
+            ( vec_free [u] b1 )
+            ? || == c 10 == c 13 {
+                = going F
+            } {
+                // ignore control bytes (< 32) except printable
+                ? >= c 32 { ( string_push_char buf c ) } {}
+            }
+        }
+    }
+    ^ buf
+}

--- a/packages/cli/tests/cli_test.sh
+++ b/packages/cli/tests/cli_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ============================================================
+#  tests/cli_test.sh — build tests/demo.nu (a multi-command CLI built
+#  with the facade) and drive every surface: subcommand routing, typed
+#  flags with env + defaults + precedence, positionals, stdin, prompts,
+#  help/version, unknown-command and no-command exit codes. Re-runs the
+#  allocating paths under AddressSanitizer.
+#
+#  Run from the package dir:  ./tests/cli_test.sh
+#  Env: NURL (build driver; defaults to ../../nurl.sh in a checkout)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t cli-test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+eq()  { [ "$2" = "$3" ] && ok "$1" || bad "$1 (got '$2', want '$3')"; }
+
+echo "[1/3] build tests/demo.nu"
+if ! $NURL tests/demo.nu "$WORK/demo" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build demo:"; tail -8 "$WORK/build.err"; exit 1
+fi
+D="$WORK/demo"
+
+echo "[2/3] drive the facade"
+eq "default flag value"  "$($D hello)"                 "hello, world"
+eq "flag override"       "$($D hello --name Tero)"     "hello, Tero"
+eq "bool flag"           "$($D hello -n T --loud)"     "hello, T!"
+eq "env fallback"        "$(DEMO_NAME=E $D hello)"      "hello, E"
+eq "flag beats env"      "$(DEMO_NAME=E $D hello -n F)" "hello, F"
+eq "positional sum"      "$($D add 3 4 5)"              "12"
+eq "empty positionals"   "$($D add)"                   "0"
+eq "int flag default"    "$($D port)"                  "port=8080"
+eq "int flag override"   "$($D port --port 9000)"      "port=9000"
+eq "int flag env"        "$(DEMO_PORT=7000 $D port)"   "port=7000"
+eq "stdin slurp"         "$(printf hello | $D wc)"      "bytes=5"
+eq "version"             "$($D --version)"             "demo 1.0.0"
+eq "prompt confirm yes"  "$(printf 'y\n' | $D rm foo)"  "deleted foo"
+eq "prompt confirm no"   "$(printf 'n\n' | $D rm foo)"  "aborted"
+
+# exit codes
+$D bogus  >/dev/null 2>&1; [ $? = 2 ] && ok "unknown command → 2"    || bad "unknown command exit"
+$D        >/dev/null 2>&1; [ $? = 1 ] && ok "no command → 1"         || bad "no command exit"
+$D hello  >/dev/null 2>&1; [ $? = 0 ] && ok "valid command → 0"      || bad "valid command exit"
+$D --help >/dev/null 2>&1; [ $? = 0 ] && ok "--help → 0"             || bad "--help exit"
+$D --help | grep -q "COMMANDS" && ok "help lists commands"          || bad "help commands"
+$D hello --help | grep -q "print a greeting" && ok "command help"   || bad "command help"
+
+echo "[3/3] AddressSanitizer"
+if NURL_SAN=1 $NURL tests/demo.nu "$WORK/demo_san" >/dev/null 2>"$WORK/san_build.err"; then
+    SAN_ERR=0
+    for run in "add 3 4 5" "hello -n x --loud" "port --port 9" "--help" "hello --help" "bogus"; do
+        printf 'y\n' | $WORK/demo_san $run >/dev/null 2>>"$WORK/san.out" || true
+    done
+    printf 'data' | $WORK/demo_san wc >/dev/null 2>>"$WORK/san.out" || true
+    if grep -qE "ERROR: AddressSanitizer|detected memory leaks" "$WORK/san.out" 2>/dev/null; then
+        bad "ASan clean"; grep -m3 "ERROR\|leak" "$WORK/san.out"
+    else
+        ok "ASan clean (no errors, no leaks)"
+    fi
+else
+    echo "  (skipped ASan build)"
+fi
+
+echo "== cli tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" = 0 ]

--- a/packages/cli/tests/demo.nu
+++ b/packages/cli/tests/demo.nu
@@ -1,0 +1,87 @@
+// tests/demo.nu — a multi-command CLI built with the facade. Exercises
+// subcommand routing, typed flags with env + defaults, positionals, stdin,
+// and an interactive confirm. The harness (cli_test.sh) drives it.
+
+$ `src/cli.nu`
+
+@ cmd_hello CliCtx x → i {
+    : String who ( ctx_str x `name` )
+    : b loud ( ctx_bool x `loud` )
+    : String msg ( string_from `hello, ` )
+    ( string_push_str msg ( string_data who ) )
+    ? loud { ( string_push_char msg 33 ) } {}
+    ( nurl_print ( string_data msg ) )
+    ( nurl_print `\n` )
+    ( string_free msg )
+    ( string_free who )
+    ^ 0
+}
+
+@ cmd_add CliCtx x → i {
+    : i n ( ctx_nargs x )
+    : ~ i sum 0
+    : ~ i k 0
+    ~ < k n {
+        : String a ( ctx_arg x k )
+        ?? ( string_to_int a ) { T v → { = sum + sum v } F _ → {} }
+        ( string_free a )
+        = k + k 1
+    }
+    : String out ( string_new )
+    ( string_push_int out sum )
+    ( nurl_print ( string_data out ) )
+    ( nurl_print `\n` )
+    ( string_free out )
+    ^ 0
+}
+
+@ cmd_port CliCtx x → i {
+    : i port ( ctx_int x `port` )
+    : String o ( string_new )
+    ( string_push_int o port )
+    ( nurl_print `port=` )
+    ( nurl_print ( string_data o ) )
+    ( nurl_print `\n` )
+    ( string_free o )
+    ^ 0
+}
+
+@ cmd_wc CliCtx x → i {
+    : String s ( ctx_stdin x )
+    : String o ( string_new )
+    ( string_push_int o ( string_len s ) )
+    ( nurl_print `bytes=` )
+    ( nurl_print ( string_data o ) )
+    ( nurl_print `\n` )
+    ( string_free o )
+    ( string_free s )
+    ^ 0
+}
+
+@ cmd_rm CliCtx x → i {
+    : String what ( ctx_arg x 0 )
+    ? ( cli_confirm `really delete?` F ) {
+        ( nurl_print `deleted ` )
+        ( nurl_print ( string_data what ) )
+        ( nurl_print `\n` )
+    } {
+        ( nurl_print `aborted\n` )
+    }
+    ( string_free what )
+    ^ 0
+}
+
+@ main → i {
+    : *Cli c ( cli_new `demo` `cli facade demo` `1.0.0` )
+    ( cli_flag_str  c `name` 110 `NAME` `who to greet` `world` `DEMO_NAME` )
+    ( cli_flag_bool c `loud` 108 `shout the greeting` )
+    ( cli_flag_int  c `port` 112 `PORT` `a port number` 8080 `DEMO_PORT` )
+    ( cli_cmd c `hello` `print a greeting` \ CliCtx x → i { ^ ( cmd_hello x ) } )
+    ( cli_cmd c `add`   `sum integer arguments` \ CliCtx x → i { ^ ( cmd_add x ) } )
+    ( cli_cmd c `port`  `show the resolved port` \ CliCtx x → i { ^ ( cmd_port x ) } )
+    ( cli_cmd c `wc`    `count bytes on stdin` \ CliCtx x → i { ^ ( cmd_wc x ) } )
+    ( cli_cmd c `rm`    `delete with confirmation` \ CliCtx x → i { ^ ( cmd_rm x ) } )
+    : i rc ( cli_run c )
+    ( cli_free c )
+    ^ rc
+}


### PR DESCRIPTION
A production-grade **`packages/cli`** — the one dependency for building a real command-line tool — plus a proof migration of `anomaly`'s CLI onto it.

## The package

NURL's stdlib ships a flat argument parser (`std/args`), terminal control (`std/term` — isatty, ANSI, line editor), stdin/stdout (`core/io`) and the environment (`ext/env`). `cli` is the glue every tool re-invents, as an ergonomic `Cli`:

```nurl
$ `deps/cli/src/cli.nu`
@ main → i {
    : *Cli c ( cli_new `greet` `a greeter` `1.0.0` )
    ( cli_flag_str c `name` 110 `NAME` `who to greet` `world` `GREET_NAME` )
    ( cli_cmd c `hello` `print a greeting` \ CliCtx x → i {
        : String w ( ctx_str x `name` )
        ( nurl_print `hello, ` ) ( nurl_print ( string_data w ) ) ( nurl_print `\n` )
        ( string_free w ) ^ 0
    } )
    : i rc ( cli_run c ) ( cli_free c ) ^ rc
}
```

- **git-style subcommand routing** + typed flag accessors (`ctx_str/int/bool/float`, `ctx_arg/nargs`, `ctx_stdin`, `ctx_cmd`) with **env-var fallback and defaults**.
- **auto, colour-aware `--help` / `<cmd> --help` / `--version` / usage** — colour is TTY-gated and respects `$NO_COLOR`.
- **error → exit-code convention** (unknown command / parse error = 2; bare invocation = 1).
- **interactive prompts**: `cli_confirm` / `cli_prompt` / `cli_password` (no-echo on a TTY).

**Scope** is the command-line surface only — terminal widgets, config files and logging compose as separate packages.

## Proof: anomaly

`anomaly`'s `main()` drops from **~150 lines** (hand-rolled arg spec + a 9-branch dispatch cascade + a hand-written help string) to **~25 declarative lines**. Command behaviour is unchanged and the help is now auto-generated and coloured. **All 26 anomaly tests pass** (unit + CLI + live HTTP + dashboard).

## Testing

- **cli:** `tests/cli_test.sh` — 21 checks (routing, typed flags + env precedence, positionals, stdin, prompts, help/version, exit codes) + **AddressSanitizer (0 errors, 0 leaks)**. ASan caught a real UAF during development — `ctx_arg` must not free the borrowed `args_positionals` vector; fixed.
- **anomaly:** full suite **26/26** after migration; CLI paths ASan-clean.

Note: registry `anomaly` stays at 0.3.1 (pre-migration); republishing the cli-backed version needs a version bump — left for a separate release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)