### PR TITLE
feat(gpukit): diamond GPU-compute toolkit over the gpu package

### DIFF
--- a/packages/gpukit/README.md
+++ b/packages/gpukit/README.md
@@ -1,0 +1,110 @@
+# gpukit — the GPU-compute toolkit for NURL
+
+One dependency for running compute on the GPU without the marshalling
+boilerplate. The [`gpu`](../gpu) package is the low-level interface — open a
+device, JIT-compile a CUDA-C kernel (NVRTC, or the host-C++ CPU backend),
+allocate device buffers, upload/download, build the argument vector, compute a
+grid, launch, sync, free. Every GPU-using package re-writes the same ~35 lines
+of that dance for each kernel. `gpukit` is that glue, as a facade.
+
+## Before / after
+
+Hand-marshalled (the pattern in onnx / anomaly today):
+
+```nurl
+: GpuBuffer b_x   ( gpu_alloc g (* n 8) )
+: GpuBuffer b_out ( gpu_alloc g (* n 8) )
+( gpu_upload b_x (# *u (vec_data [f] xs)) )
+: (Vec i) args ( vec_new [i] )
+( vec_push [i] args (gpu_arg_buffer b_x) )
+( vec_push [i] args (gpu_arg_i64 n) )
+( vec_push [i] args (gpu_arg_buffer b_out) )
+( gpu_launch k (gpu_grid n 256) 256 args )
+( gpu_sync g )
+( gpu_download (# *u (vec_data [f] out)) b_out )
+( gpu_free b_x ) ( gpu_free b_out ) ( vec_free [i] args )
+```
+
+With gpukit:
+
+```nurl
+: (Vec GkArg) call ( vec_new [GkArg] )
+( vec_push [GkArg] call ( gk_in_f  xs ) )
+( vec_push [GkArg] call ( gk_i64   n  ) )
+( vec_push [GkArg] call ( gk_out_f out ) )
+( gk_run kit src `my_kernel` ( gk_grid n 256 ) 256 call )
+( vec_free [GkArg] call )
+```
+
+`gk_run` compiles-and-caches the kernel by name, allocates a device buffer per
+buffer binding, uploads inputs, marshals the args in binding order, launches,
+syncs, downloads outputs, and frees every device buffer.
+
+## Ready-made kernels
+
+For the common cases you don't write a kernel at all:
+
+```nurl
+: GpuKit kit ( gk_open 0 )
+( gk_add_f kit out a b )                 // out = a + b   (also sub/mul/div)
+( gk_map_f kit `relu` out x `x>0.0?x:0.0` )   // out[i] = f(x)
+( gk_matmul_f kit c a b m k n )          // C[m×n] = A[m×k]·B[k×n]
+: ?f s ( gk_reduce_sum_f kit x )         // Σ x
+: ?f d ( gk_dot_f kit a b )              // a·b
+( gk_close kit )
+```
+
+## API
+
+Lifecycle:
+
+| Call | |
+| --- | --- |
+| `( gk_open ordinal )` → `GpuKit` | open a device (CUDA, else CPU backend) |
+| `( gk_ok kit )` → `b`, `( gk_backend kit )` → `s`, `( gk_device_name kit )` → `s` | |
+| `( gk_close kit )` | free cached kernels + close the device |
+| `( gk_grid n block )` → `i` | grid size for `n` threads |
+
+Bindings (`f` is a C `double`, `i` a C `long long`):
+
+| Call | |
+| --- | --- |
+| `( gk_in_f v )` / `( gk_in_i v )` | input `double[]` / `long long[]` |
+| `( gk_out_f v )` / `( gk_out_i v )` | output (caller pre-sizes) |
+| `( gk_buf_in host bytes )` / `( gk_buf_out host bytes )` | raw buffer (e.g. packed f32) |
+| `( gk_i64 v )` / `( gk_i32 v )` / `( gk_f32 v )` | scalar |
+
+Workhorse:
+
+| Call | |
+| --- | --- |
+| `( gk_run kit src name grid block call )` → `b` | compile-cached, marshal, launch, sync, download, free |
+
+The `call` is a `Vec GkArg` listing the kernel's arguments in declaration
+order (buffers and scalars interleaved exactly as the signature expects).
+
+Ready-made f64 kernels: `gk_add_f` / `gk_sub_f` / `gk_mul_f` / `gk_div_f`,
+`gk_map_f`, `gk_matmul_f`, `gk_reduce_sum_f`, `gk_dot_f`.
+
+## Numerics
+
+gpukit adds no numerics of its own — it only marshals — so a kernel runs
+bit-for-bit the same through `gk_run` as through hand-written `gpu_*` calls,
+and the gpu package's **CUDA / CPU-backend / pure equivalence is preserved**.
+The elementwise ops and `gk_matmul_f` accumulate in the same order a
+sequential host loop would, so they are **bit-identical** to a naive host
+implementation. `gk_reduce_sum_f` / `gk_dot_f` combine per-thread partial sums
+(a parallel order), matching a host sum to rounding but not guaranteed
+bit-identical to a strictly sequential accumulation.
+
+## Memory
+
+`GpuKit` carries a stable kernel-cache Vec, so it is passed by value and
+mutated across calls (like an `ArgParser`). Free it with `gk_close`.
+
+## Tests
+
+`./tests/gpukit_test.sh` builds `tests/demo.nu` and runs it on the default
+backend and, when a host C++ compiler is present, on the CPU backend —
+checking every bit-identical op with `==` against a host computation. On an
+RTX 4090 and on the CPU backend: **14 / 14**.

--- a/packages/gpukit/nurl.toml
+++ b/packages/gpukit/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "gpukit"
+version = "0.1.0"
+description = "The ergonomic GPU-compute toolkit for NURL — a diamond facade over the `gpu` package that kills the marshalling boilerplate every GPU-using package re-invents. Where `gpu` is the low-level interface (open a device, JIT-compile a CUDA-C kernel via NVRTC or the host-C++ CPU backend, allocate/upload/download device buffers, build the argument vector, compute a grid, launch, sync, free), `gpukit` collapses the ~35 lines of that dance per kernel into a list of typed bindings and one `gk_run`: a GpuKit with a per-name kernel cache, `gk_in_f`/`gk_in_i`/`gk_out_f`/`gk_out_i` (and raw-buffer + i32/i64/f32 scalar) bindings, and a workhorse that compiles-once, allocates a device buffer per binding, uploads inputs, marshals args in declaration order, launches, syncs, downloads outputs, and frees everything. Ships a library of ready-made f64 kernels — elementwise add/sub/mul/div, a source-baked unary map, a bit-identical matmul, and reduce-sum / dot — so ML code never writes a kernel or a device buffer for the common cases. Adds no numerics of its own: a kernel runs bit-for-bit the same through gk_run as through hand-written gpu_* calls, preserving the gpu package's CUDA / CPU-backend / pure equivalence. Runs on the CPU backend when no CUDA device is present."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+gpu = { path = "../gpu", version = "0.2" }

--- a/packages/gpukit/src/gpukit.nu
+++ b/packages/gpukit/src/gpukit.nu
@@ -1,0 +1,244 @@
+// gpukit/gpukit.nu — the ergonomic GPU-compute facade over the `gpu` package.
+//
+// The `gpu` package is the low-level interface: open a device, compile a
+// CUDA-C kernel (JIT via NVRTC, or the host-C++ CPU backend), allocate device
+// buffers, upload/download, build the argument vector, compute a grid, launch,
+// sync, free. Every GPU-using package (onnx, objdet, anomaly, yoloe) hand-
+// writes the same ~35 lines of that marshalling for each kernel it runs:
+//
+//     : GpuBuffer b_x ( gpu_alloc g (* n 8) )        // one per array …
+//     ( gpu_upload b_x (# *u (vec_data [f] xs)) )    // upload each input …
+//     : (Vec i) args (vec_new [i])                   // build the arg vector …
+//     ( vec_push [i] args (gpu_arg_buffer b_x) ) …
+//     ( gpu_launch k (gpu_grid n 256) 256 args )
+//     ( gpu_sync g )
+//     ( gpu_download (# *u (vec_data [f] out)) b_out )
+//     ( gpu_free b_x ) …                             // free each buffer
+//
+// `gpukit` collapses that to a list of typed bindings and one `gk_run`:
+//
+//     : GpuKit kit ( gk_open 0 )
+//     : (Vec GkArg) call ( vec_new [GkArg] )
+//     ( vec_push [GkArg] call ( gk_in_f  xs ) )      // input  double[]
+//     ( vec_push [GkArg] call ( gk_i64   n  ) )      // long long scalar
+//     ( vec_push [GkArg] call ( gk_out_f out) )      // output double[]
+//     ( gk_run kit src `my_kernel` ( gk_grid n 256 ) 256 call )
+//     ( vec_free [GkArg] call )
+//
+// gk_run compiles-and-caches the kernel by name, allocates a device buffer per
+// buffer binding, uploads inputs, builds the arg vector in binding order,
+// launches, syncs, downloads outputs, and frees every device buffer. Kernel
+// sources are cached on the kit, so a hot path compiles each kernel once.
+//
+// gpukit adds no numerics of its own — it only marshals — so a kernel runs
+// bit-for-bit the same through gk_run as through hand-written gpu_* calls, and
+// the gpu package's CUDA / CPU-backend / pure equivalence is preserved.
+//
+// Memory: `GpuKit` carries a stable kernel-cache Vec, so it is passed by value
+// and mutated across calls (like an ArgParser). Free it with `gk_close`, which
+// releases the cached kernels and the device.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `deps/gpu/src/gpu.nu`
+
+// A single argument to a kernel launch.
+//   kind 0 = input buffer   1 = output buffer   2 = scalar
+: GkArg {
+    i kind
+    *u host      // host data pointer for a buffer binding
+    i bytes      // buffer byte size
+    i argval     // pre-encoded scalar arg (gpu_arg_*) for a scalar binding
+}
+
+: GkKernelEntry {
+    String name
+    GpuKernel kernel
+}
+
+: GpuKit {
+    Gpu gpu
+    b ok
+    ( Vec GkKernelEntry ) cache
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────
+
+// Open device `ordinal` (CUDA when present, else the gpu package's CPU
+// backend). Check `gk_ok`; even a failed open is safe to `gk_close`.
+@ gk_open i ordinal → GpuKit {
+    : Gpu g ( gpu_open ordinal )
+    ^ @ GpuKit { g ( gpu_ok g ) ( vec_new [GkKernelEntry] ) }
+}
+
+@ gk_ok GpuKit kit → b { ^ . kit ok }
+
+// "cuda" or "cpu".
+@ gk_backend GpuKit kit → s { ? ( gpu_is_cpu ) { ^ `cpu` } { ^ `cuda` } }
+
+@ gk_device_name GpuKit kit → s { ^ ( gpu_name . kit gpu ) }
+
+// Release every cached kernel and close the device.
+@ gk_close GpuKit kit → v {
+    : i n ( vec_len [GkKernelEntry] . kit cache )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [GkKernelEntry] . kit cache k ) {
+            T e → {
+                ( gpu_kernel_free . e kernel )
+                ( string_free . e name )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free [GkKernelEntry] . kit cache )
+    ? . kit ok { ( gpu_close . kit gpu ) } {}
+}
+
+// Grid size for `n` threads at the given block size (re-export of gpu_grid).
+@ gk_grid i n i block → i { ^ ( gpu_grid n block ) }
+
+// ── Bindings ──────────────────────────────────────────────────────────
+// NURL `f` is a C double and `i` is a C long long (both 8 bytes), so an
+// `f` vector uploads as `double*` and an `i` vector as `long long*`.
+
+@ gk_in_f ( Vec f ) v → GkArg {
+    : *u h # *u ( vec_data [f] v )
+    : i by * ( vec_len [f] v ) 8
+    ^ @ GkArg { 0 h by 0 }
+}
+@ gk_in_i ( Vec i ) v → GkArg {
+    : *u h # *u ( vec_data [i] v )
+    : i by * ( vec_len [i] v ) 8
+    ^ @ GkArg { 0 h by 0 }
+}
+// Output buffers must be pre-sized by the caller; results are copied back in.
+@ gk_out_f ( Vec f ) v → GkArg {
+    : *u h # *u ( vec_data [f] v )
+    : i by * ( vec_len [f] v ) 8
+    ^ @ GkArg { 1 h by 0 }
+}
+@ gk_out_i ( Vec i ) v → GkArg {
+    : *u h # *u ( vec_data [i] v )
+    : i by * ( vec_len [i] v ) 8
+    ^ @ GkArg { 1 h by 0 }
+}
+// Raw buffers, for element layouts other than f64/i64 (e.g. a packed float32
+// host buffer): pass the host pointer and byte size directly.
+@ gk_buf_in *u host i bytes → GkArg { ^ @ GkArg { 0 host bytes 0 } }
+@ gk_buf_out *u host i bytes → GkArg { ^ @ GkArg { 1 host bytes 0 } }
+
+@ gk_i64 i v → GkArg {
+    : *u nullp # *u 0
+    ^ @ GkArg { 2 nullp 0 ( gpu_arg_i64 v ) }
+}
+@ gk_i32 i v → GkArg {
+    : *u nullp # *u 0
+    ^ @ GkArg { 2 nullp 0 ( gpu_arg_i32 v ) }
+}
+@ gk_f32 f v → GkArg {
+    : *u nullp # *u 0
+    ^ @ GkArg { 2 nullp 0 ( gpu_arg_f32 v ) }
+}
+
+// ── Kernel cache ──────────────────────────────────────────────────────
+
+// Compile `src` (entry `name`) once per kit; subsequent calls with the same
+// `name` reuse the cached kernel. A failed compile returns a not-ok kernel
+// and is not cached (so a fixed source can be retried).
+@ __gk_get_kernel GpuKit kit s src s name → GpuKernel {
+    : i n ( vec_len [GkKernelEntry] . kit cache )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [GkKernelEntry] . kit cache k ) {
+            T e → {
+                ? == 1 ( nurl_str_eq ( string_data . e name ) name ) { ^ . e kernel } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    : GpuKernel kn ( gpu_compile . kit gpu src name )
+    ? ( gpu_kernel_ok kn ) {
+        ( vec_push [GkKernelEntry] . kit cache @ GkKernelEntry { ( string_from name ) kn } )
+    } {}
+    ^ kn
+}
+
+// ── The workhorse ─────────────────────────────────────────────────────
+
+// Compile-cached, marshal, launch, sync, download, free. `call` lists the
+// kernel's arguments in declaration order (buffers and scalars interleaved
+// exactly as the kernel signature expects). Returns F on any device error.
+@ gk_run GpuKit kit s src s name i grid i block ( Vec GkArg ) call → b {
+    ? ( gk_ok kit ) {} { ^ F }
+    : GpuKernel kn ( __gk_get_kernel kit src name )
+    ? ( gpu_kernel_ok kn ) {} { ^ F }
+
+    : i nc ( vec_len [GkArg] call )
+    : ( Vec i ) args ( vec_new [i] )
+    : ( Vec GpuBuffer ) bufs ( vec_new [GpuBuffer] )
+    : ( Vec i ) buf_arg ( vec_new [i] )     // call-index that each buffer came from
+    : ~ b ok T
+
+    : ~ i k 0
+    ~ & ok < k nc {
+        ?? ( vec_get [GkArg] call k ) {
+            T a → {
+                ? == . a kind 2 {
+                    ( vec_push [i] args . a argval )
+                } {
+                    : GpuBuffer db ( gpu_alloc . kit gpu . a bytes )
+                    ? == . a kind 0 {
+                        ? == ( gpu_upload db . a host ) 0 {} { = ok F }
+                    } {}
+                    ( vec_push [GpuBuffer] bufs db )
+                    ( vec_push [i] buf_arg k )
+                    ( vec_push [i] args ( gpu_arg_buffer db ) )
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+
+    ? ok { ? == ( gpu_launch kn grid block args ) 0 {} { = ok F } } {}
+    ? ok { ? == ( gpu_sync . kit gpu ) 0 {} { = ok F } } {}
+
+    // download outputs
+    : i nb ( vec_len [GpuBuffer] bufs )
+    ? ok {
+        : ~ i j 0
+        ~ & ok < j nb {
+            ?? ( vec_get [i] buf_arg j ) {
+                T ci → {
+                    ?? ( vec_get [GkArg] call ci ) {
+                        T a → {
+                            ? == . a kind 1 {
+                                ?? ( vec_get [GpuBuffer] bufs j ) {
+                                    T db → { ? == ( gpu_download . a host db ) 0 {} { = ok F } }
+                                    F _ → {}
+                                }
+                            } {}
+                        }
+                        F _ → {}
+                    }
+                }
+                F _ → {}
+            }
+            = j + j 1
+        }
+    } {}
+
+    // free every device buffer
+    : ~ i j 0
+    ~ < j nb {
+        ?? ( vec_get [GpuBuffer] bufs j ) { T db → { ( gpu_free db ) } F _ → {} }
+        = j + j 1
+    }
+    ( vec_free [i] args )
+    ( vec_free [GpuBuffer] bufs )
+    ( vec_free [i] buf_arg )
+    ^ ok
+}

--- a/packages/gpukit/src/kernels.nu
+++ b/packages/gpukit/src/kernels.nu
@@ -1,0 +1,168 @@
+// gpukit/kernels.nu — a small library of ready-made f64 kernels over gk_run.
+//
+// These cover the operations ML code writes over and over. They generate the
+// CUDA-C source, cache it on the kit (by a fixed entry name), and marshal
+// through gk_run — so a caller never writes a kernel or a device buffer for
+// the common cases.
+//
+// Numerics: `f` is a C double, so every buffer is float64. Elementwise ops and
+// `gk_matmul_f` accumulate in the same order a sequential host loop would, so
+// they are bit-identical across the CUDA / CPU / pure backends and to a naive
+// host implementation. `gk_reduce_sum_f` / `gk_dot_f` combine per-thread
+// partial sums (a parallel order), so they match a host sum to rounding but
+// are not guaranteed bit-identical to a strictly sequential accumulation.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `gpukit.nu`
+
+// ── Elementwise binary: out[i] = a[i] <op> b[i] ───────────────────────
+
+@ __gk_ew_src s name s op → String {
+    : String s ( string_from `extern "C" __global__ void ` )
+    ( string_push_str s name )
+    ( string_push_str s `(const double* a, const double* b, double* out, long long n){` )
+    ( string_push_str s `long long i=blockIdx.x*blockDim.x+threadIdx.x;` )
+    ( string_push_str s `if(i<n){out[i]=a[i]` )
+    ( string_push_str s op )
+    ( string_push_str s `b[i];}}` )
+    ^ s
+}
+
+@ __gk_ew GpuKit kit s name s op ( Vec f ) out ( Vec f ) a ( Vec f ) b → b {
+    : i n ( vec_len [f] out )
+    : String src ( __gk_ew_src name op )
+    : ( Vec GkArg ) call ( vec_new [GkArg] )
+    ( vec_push [GkArg] call ( gk_in_f a ) )
+    ( vec_push [GkArg] call ( gk_in_f b ) )
+    ( vec_push [GkArg] call ( gk_out_f out ) )
+    ( vec_push [GkArg] call ( gk_i64 n ) )
+    : b r ( gk_run kit ( string_data src ) name ( gk_grid n 256 ) 256 call )
+    ( vec_free [GkArg] call )
+    ( string_free src )
+    ^ r
+}
+
+@ gk_add_f GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_add` `+` out a b ) }
+@ gk_sub_f GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_sub` `-` out a b ) }
+@ gk_mul_f GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_mul` `*` out a b ) }
+@ gk_div_f GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_div` `/` out a b ) }
+
+// ── Unary map: out[i] = <expr>, with `x` bound to in[i] ────────────────
+// `kname` is the CUDA entry name (a valid C identifier, stable per `expr` so
+// caching works). `expr` is C over the local `double x`, e.g. `x*x`,
+// `1.0/(1.0+exp(-x))`, `x>0.0?x:0.0`.
+@ gk_map_f GpuKit kit s kname ( Vec f ) out ( Vec f ) in s expr → b {
+    : i n ( vec_len [f] out )
+    : String src ( string_from `extern "C" __global__ void ` )
+    ( string_push_str src kname )
+    ( string_push_str src `(const double* in, double* out, long long n){` )
+    ( string_push_str src `long long i=blockIdx.x*blockDim.x+threadIdx.x;` )
+    ( string_push_str src `if(i<n){double x=in[i];out[i]=(` )
+    ( string_push_str src expr )
+    ( string_push_str src `);}}` )
+    : ( Vec GkArg ) call ( vec_new [GkArg] )
+    ( vec_push [GkArg] call ( gk_in_f in ) )
+    ( vec_push [GkArg] call ( gk_out_f out ) )
+    ( vec_push [GkArg] call ( gk_i64 n ) )
+    : b r ( gk_run kit ( string_data src ) kname ( gk_grid n 256 ) 256 call )
+    ( vec_free [GkArg] call )
+    ( string_free src )
+    ^ r
+}
+
+// ── Matrix multiply: C[M×N] = A[M×K] · B[K×N] (row-major) ──────────────
+// Each output element sums t=0..K in order, exactly as a host loop — so this
+// is bit-identical to a naive sequential matmul.
+@ gk_matmul_f GpuKit kit ( Vec f ) c ( Vec f ) a ( Vec f ) b i m i k i n → b {
+    : String src ( string_from `extern "C" __global__ void gk_matmul(const double* A, const double* B, double* C, long long M, long long K, long long N){` )
+    ( string_push_str src `long long idx=blockIdx.x*blockDim.x+threadIdx.x;` )
+    ( string_push_str src `if(idx<M*N){long long row=idx/N,col=idx%N;double s=0.0;` )
+    ( string_push_str src `for(long long t=0;t<K;t++)s+=A[row*K+t]*B[t*N+col];C[idx]=s;}}` )
+    : i total * m n
+    : ( Vec GkArg ) call ( vec_new [GkArg] )
+    ( vec_push [GkArg] call ( gk_in_f a ) )
+    ( vec_push [GkArg] call ( gk_in_f b ) )
+    ( vec_push [GkArg] call ( gk_out_f c ) )
+    ( vec_push [GkArg] call ( gk_i64 m ) )
+    ( vec_push [GkArg] call ( gk_i64 k ) )
+    ( vec_push [GkArg] call ( gk_i64 n ) )
+    : b r ( gk_run kit ( string_data src ) `gk_matmul` ( gk_grid total 256 ) 256 call )
+    ( vec_free [GkArg] call )
+    ( string_free src )
+    ^ r
+}
+
+// ── Reductions (parallel partials + host combine) ─────────────────────
+
+@ __gk_zeros i n → ( Vec f ) {
+    : ( Vec f ) v ( vec_new [f] )
+    : ~ i k 0
+    ~ < k n { ( vec_push [f] v 0.0 ) = k + k 1 }
+    ^ v
+}
+
+@ __gk_partial_threads i n → i {
+    : i g ( gk_grid n 256 )
+    ? > g 64 { ^ * 64 256 } {}
+    ^ * g 256
+}
+
+// Sum of `x`. None on a device error.
+@ gk_reduce_sum_f GpuKit kit ( Vec f ) x → ?f {
+    : i n ( vec_len [f] x )
+    ? <= n 0 { ^ @ ?f { T 0.0 } } {}
+    : i threads ( __gk_partial_threads n )
+    : ( Vec f ) partial ( __gk_zeros threads )
+    : String src ( string_from `extern "C" __global__ void gk_reduce_sum(const double* in, double* partial, long long n){` )
+    ( string_push_str src `long long tid=blockIdx.x*blockDim.x+threadIdx.x;long long stride=gridDim.x*blockDim.x;` )
+    ( string_push_str src `double s=0.0;for(long long i=tid;i<n;i+=stride)s+=in[i];partial[tid]=s;}` )
+    : ( Vec GkArg ) call ( vec_new [GkArg] )
+    ( vec_push [GkArg] call ( gk_in_f x ) )
+    ( vec_push [GkArg] call ( gk_out_f partial ) )
+    ( vec_push [GkArg] call ( gk_i64 n ) )
+    : i blocks / threads 256
+    : b ok ( gk_run kit ( string_data src ) `gk_reduce_sum` blocks 256 call )
+    ( vec_free [GkArg] call )
+    ( string_free src )
+    : ~ f acc 0.0
+    ? ok {
+        : ~ i k 0
+        ~ < k threads {
+            ?? ( vec_get [f] partial k ) { T v → { = acc + acc v } F _ → {} }
+            = k + k 1
+        }
+    } {}
+    ( vec_free [f] partial )
+    ? ok { ^ @ ?f { T acc } } { ^ @ ?f { F } }
+}
+
+// Dot product a·b (equal lengths assumed). None on a device error.
+@ gk_dot_f GpuKit kit ( Vec f ) a ( Vec f ) b → ?f {
+    : i n ( vec_len [f] a )
+    ? <= n 0 { ^ @ ?f { T 0.0 } } {}
+    : i threads ( __gk_partial_threads n )
+    : ( Vec f ) partial ( __gk_zeros threads )
+    : String src ( string_from `extern "C" __global__ void gk_dot(const double* a, const double* b, double* partial, long long n){` )
+    ( string_push_str src `long long tid=blockIdx.x*blockDim.x+threadIdx.x;long long stride=gridDim.x*blockDim.x;` )
+    ( string_push_str src `double s=0.0;for(long long i=tid;i<n;i+=stride)s+=a[i]*b[i];partial[tid]=s;}` )
+    : ( Vec GkArg ) call ( vec_new [GkArg] )
+    ( vec_push [GkArg] call ( gk_in_f a ) )
+    ( vec_push [GkArg] call ( gk_in_f b ) )
+    ( vec_push [GkArg] call ( gk_out_f partial ) )
+    ( vec_push [GkArg] call ( gk_i64 n ) )
+    : i blocks / threads 256
+    : b ok ( gk_run kit ( string_data src ) `gk_dot` blocks 256 call )
+    ( vec_free [GkArg] call )
+    ( string_free src )
+    : ~ f acc 0.0
+    ? ok {
+        : ~ i k 0
+        ~ < k threads {
+            ?? ( vec_get [f] partial k ) { T v → { = acc + acc v } F _ → {} }
+            = k + k 1
+        }
+    } {}
+    ( vec_free [f] partial )
+    ? ok { ^ @ ?f { T acc } } { ^ @ ?f { F } }
+}

--- a/packages/gpukit/tests/demo.nu
+++ b/packages/gpukit/tests/demo.nu
@@ -1,0 +1,209 @@
+// tests/demo.nu — exercise the gpukit facade end to end and check every
+// result against a host computation. Bit-identical ops (elementwise, matmul,
+// and the generic gk_run path) are compared with ==; the parallel reductions
+// are compared within a relative tolerance. Prints "PASS n / FAIL m" and
+// exits non-zero on any failure. The harness runs it on the GPU and, via
+// NURL_GPU=cpu, on the CPU backend.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `src/kernels.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+
+@ __ck s name b cond → v {
+    ? cond {
+        = g_pass + g_pass 1
+    } {
+        = g_fail + g_fail 1
+        ( nurl_eprint `  FAIL ` )
+        ( nurl_eprintln name )
+    }
+}
+
+@ __absf f x → f { ? < x 0.0 { ^ - 0.0 x } {} ^ x }
+
+// out and expected match exactly at every index.
+@ __eq_vec ( Vec f ) got ( Vec f ) want → b {
+    : i n ( vec_len [f] want )
+    : ~ b ok T
+    : ~ i k 0
+    ~ & ok < k n {
+        : ~ f a 0.0
+        : ~ f b 0.0
+        ?? ( vec_get [f] got k ) { T v → { = a v } F _ → {} }
+        ?? ( vec_get [f] want k ) { T v → { = b v } F _ → {} }
+        ? == a b {} { = ok F }
+        = k + k 1
+    }
+    ^ ok
+}
+
+@ __seq_f i n f base → ( Vec f ) {
+    : ( Vec f ) v ( vec_new [f] )
+    : ~ i k 0
+    ~ < k n { ( vec_push [f] v + base # f k ) = k + k 1 }
+    ^ v
+}
+
+@ main → i {
+    : GpuKit kit ( gk_open 0 )
+    ? ( gk_ok kit ) {} {
+        ( nurl_eprintln `gpukit: no device (open failed)` )
+        ( gk_close kit )
+        ^ 1
+    }
+    ( nurl_eprint `gpukit demo on ` )
+    ( nurl_eprint ( gk_backend kit ) )
+    ( nurl_eprint ` — ` )
+    ( nurl_eprintln ( gk_device_name kit ) )
+
+    : i N 1000
+    : ( Vec f ) a ( __seq_f N 1.0 )      // 1..1000
+    : ( Vec f ) b ( __seq_f N 3.0 )      // 3..1002
+
+    // elementwise add
+    : ( Vec f ) out ( __gk_zeros N )
+    : ( Vec f ) want ( vec_new [f] )
+    : ~ i k 0
+    ~ < k N {
+        : ~ f av 0.0
+        : ~ f bv 0.0
+        ?? ( vec_get [f] a k ) { T v → { = av v } F _ → {} }
+        ?? ( vec_get [f] b k ) { T v → { = bv v } F _ → {} }
+        ( vec_push [f] want + av bv )
+        = k + k 1
+    }
+    ( __ck `add ran` ( gk_add_f kit out a b ) )
+    ( __ck `add == host` ( __eq_vec out want ) )
+    ( vec_free [f] want )
+
+    // elementwise mul
+    : ( Vec f ) wm ( vec_new [f] )
+    = k 0
+    ~ < k N {
+        : ~ f av 0.0
+        : ~ f bv 0.0
+        ?? ( vec_get [f] a k ) { T v → { = av v } F _ → {} }
+        ?? ( vec_get [f] b k ) { T v → { = bv v } F _ → {} }
+        ( vec_push [f] wm * av bv )
+        = k + k 1
+    }
+    ( __ck `mul ran` ( gk_mul_f kit out a b ) )
+    ( __ck `mul == host` ( __eq_vec out wm ) )
+    ( vec_free [f] wm )
+
+    // unary map: x*x
+    : ( Vec f ) wsq ( vec_new [f] )
+    = k 0
+    ~ < k N { : ~ f av 0.0 ?? ( vec_get [f] a k ) { T v → { = av v } F _ → {} } ( vec_push [f] wsq * av av ) = k + k 1 }
+    ( __ck `map ran` ( gk_map_f kit `gk_sq` out a `x*x` ) )
+    ( __ck `map x*x == host` ( __eq_vec out wsq ) )
+    ( vec_free [f] wsq )
+
+    // kernel cache: a second identical call must reuse (still correct)
+    ( __ck `map cached rerun` ( gk_map_f kit `gk_sq` out a `x*x` ) )
+    ( __ck `map cached == host` ( __eq_vec out ( __seq_map_sq a ) ) )
+
+    // matmul: 3x4 · 4x2 = 3x2, checked exactly against a host loop
+    : i M 3
+    : i K 4
+    : i Nn 2
+    : ( Vec f ) ma ( __seq_f * M K 1.0 )
+    : ( Vec f ) mb ( __seq_f * K Nn 2.0 )
+    : ( Vec f ) mc ( __gk_zeros * M Nn )
+    ( __ck `matmul ran` ( gk_matmul_f kit mc ma mb M K Nn ) )
+    ( __ck `matmul == host` ( __eq_vec mc ( __host_matmul ma mb M K Nn ) ) )
+    ( vec_free [f] ma )
+    ( vec_free [f] mb )
+    ( vec_free [f] mc )
+
+    // reduce sum + dot (tolerance)
+    : ~ f host_sum 0.0
+    = k 0
+    ~ < k N { ?? ( vec_get [f] a k ) { T v → { = host_sum + host_sum v } F _ → {} } = k + k 1 }
+    ?? ( gk_reduce_sum_f kit a ) {
+        T s → { ( __ck `reduce_sum ~ host` < ( __absf - s host_sum ) 0.001 ) }
+        F → { ( __ck `reduce_sum ran` F ) }
+    }
+    : ~ f host_dot 0.0
+    = k 0
+    ~ < k N {
+        : ~ f av 0.0
+        : ~ f bv 0.0
+        ?? ( vec_get [f] a k ) { T v → { = av v } F _ → {} }
+        ?? ( vec_get [f] b k ) { T v → { = bv v } F _ → {} }
+        = host_dot + host_dot * av bv
+        = k + k 1
+    }
+    ?? ( gk_dot_f kit a b ) {
+        T d → { ( __ck `dot ~ host` < ( __absf - d host_dot ) 1.0 ) }
+        F → { ( __ck `dot ran` F ) }
+    }
+
+    // generic gk_run: a hand-written kernel out[i]=in[i]*s + off, s/off i64
+    : String src ( string_from `extern "C" __global__ void wsum(const double* in, double* out, long long s, long long off, long long n){long long i=blockIdx.x*blockDim.x+threadIdx.x;if(i<n){out[i]=in[i]*(double)s+(double)off;}}` )
+    : ( Vec GkArg ) call ( vec_new [GkArg] )
+    ( vec_push [GkArg] call ( gk_in_f a ) )
+    ( vec_push [GkArg] call ( gk_out_f out ) )
+    ( vec_push [GkArg] call ( gk_i64 5 ) )
+    ( vec_push [GkArg] call ( gk_i64 7 ) )
+    ( vec_push [GkArg] call ( gk_i64 N ) )
+    ( __ck `gk_run custom kernel` ( gk_run kit ( string_data src ) `wsum` ( gk_grid N 256 ) 256 call ) )
+    ( vec_free [GkArg] call )
+    ( string_free src )
+    : ( Vec f ) wcustom ( vec_new [f] )
+    = k 0
+    ~ < k N { : ~ f av 0.0 ?? ( vec_get [f] a k ) { T v → { = av v } F _ → {} } ( vec_push [f] wcustom + * av 5.0 7.0 ) = k + k 1 }
+    ( __ck `gk_run == host` ( __eq_vec out wcustom ) )
+    ( vec_free [f] wcustom )
+
+    ( vec_free [f] a )
+    ( vec_free [f] b )
+    ( vec_free [f] out )
+    ( gk_close kit )
+
+    : String sm ( string_from `PASS ` )
+    ( string_push_int sm g_pass )
+    ( string_push_str sm ` / FAIL ` )
+    ( string_push_int sm g_fail )
+    ( nurl_eprintln ( string_data sm ) )
+    ( string_free sm )
+    ? > g_fail 0 { ^ 1 } {}
+    ^ 0
+}
+
+@ __seq_map_sq ( Vec f ) a → ( Vec f ) {
+    : i n ( vec_len [f] a )
+    : ( Vec f ) v ( vec_new [f] )
+    : ~ i k 0
+    ~ < k n { : ~ f av 0.0 ?? ( vec_get [f] a k ) { T x → { = av x } F _ → {} } ( vec_push [f] v * av av ) = k + k 1 }
+    ^ v
+}
+
+@ __host_matmul ( Vec f ) a ( Vec f ) b i m i k i n → ( Vec f ) {
+    : ( Vec f ) c ( vec_new [f] )
+    : ~ i r 0
+    ~ < r m {
+        : ~ i col 0
+        ~ < col n {
+            : ~ f s 0.0
+            : ~ i t 0
+            ~ < t k {
+                : ~ f av 0.0
+                : ~ f bv 0.0
+                ?? ( vec_get [f] a + * r k t ) { T v → { = av v } F _ → {} }
+                ?? ( vec_get [f] b + * t n col ) { T v → { = bv v } F _ → {} }
+                = s + s * av bv
+                = t + t 1
+            }
+            ( vec_push [f] c s )
+            = col + col 1
+        }
+        = r + r 1
+    }
+    ^ c
+}

--- a/packages/gpukit/tests/gpukit_test.sh
+++ b/packages/gpukit/tests/gpukit_test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# ============================================================
+#  tests/gpukit_test.sh — build tests/demo.nu (which exercises the whole
+#  facade: elementwise add/mul, source-baked map + kernel-cache reuse,
+#  bit-identical matmul, reduce-sum / dot, and a hand-written kernel through
+#  the generic gk_run) and run it on the default backend and, when a C++
+#  compiler is present, on the gpu package's CPU backend. Every bit-identical
+#  op is checked with == against a host computation.
+#
+#  Run from the package dir:  ./tests/gpukit_test.sh
+#  Env: NURL (build driver; defaults to ../../nurl.sh in a checkout)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t gpukit-test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+
+echo "[1/2] build tests/demo.nu"
+if ! $NURL tests/demo.nu "$WORK/demo" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build demo:"; tail -8 "$WORK/build.err"; exit 1
+fi
+
+echo "[2/2] run on the available backends"
+# Default backend (CUDA when a device is present, else CPU).
+if "$WORK/demo" >"$WORK/def.out" 2>&1; then
+    ok "default backend ($(grep -oE 'on (cuda|cpu)' "$WORK/def.out" | head -1)): $(grep -oE 'PASS [0-9]+ / FAIL [0-9]+' "$WORK/def.out")"
+else
+    bad "default backend"; sed 's/^/    /' "$WORK/def.out"
+fi
+
+# CPU backend — skip cleanly if there's no host C++ compiler.
+if NURL_GPU=cpu "$WORK/demo" >"$WORK/cpu.out" 2>&1; then
+    ok "CPU backend: $(grep -oE 'PASS [0-9]+ / FAIL [0-9]+' "$WORK/cpu.out")"
+elif grep -q "need a C++ compiler" "$WORK/cpu.out"; then
+    echo "  (CPU backend skipped — no host C++ compiler on PATH)"
+else
+    bad "CPU backend"; sed 's/^/    /' "$WORK/cpu.out"
+fi
+
+echo "== gpukit tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" = 0 ]


### PR DESCRIPTION
A **`packages/gpukit`** — the ergonomic GPU-compute facade that kills the marshalling boilerplate every GPU-using package (onnx, objdet, anomaly, yoloe) re-invents. Verified on an **RTX 4090** and on the **CPU backend**.

## The boilerplate it kills

The [`gpu`](../gpu) package is the low-level interface. Running one kernel means ~35 lines: `gpu_alloc` per array, `gpu_upload` per input, build a `Vec i` of `gpu_arg_*`, `gpu_launch`, `gpu_sync`, `gpu_download` per output, `gpu_free` per buffer. gpukit collapses that to typed bindings + one `gk_run`:

```nurl
: (Vec GkArg) call ( vec_new [GkArg] )
( vec_push [GkArg] call ( gk_in_f  xs ) )
( vec_push [GkArg] call ( gk_i64   n  ) )
( vec_push [GkArg] call ( gk_out_f out ) )
( gk_run kit src `my_kernel` ( gk_grid n 256 ) 256 call )
( vec_free [GkArg] call )
```

`gk_run` compiles-and-caches the kernel by name, allocates a device buffer per binding, uploads inputs, marshals args in order, launches, syncs, downloads outputs, and frees everything.

## Ready-made kernels

For common cases you write no kernel: `gk_add_f` / `gk_sub_f` / `gk_mul_f` / `gk_div_f`, `gk_map_f` (source-baked unary expr), `gk_matmul_f`, `gk_reduce_sum_f`, `gk_dot_f`.

## Numerics

gpukit adds no numerics — it only marshals — so a kernel runs **bit-for-bit the same** through `gk_run` as through hand-written `gpu_*`, preserving the gpu package's CUDA / CPU / pure equivalence. Elementwise ops and `gk_matmul_f` are bit-identical to a sequential host loop; the reductions combine per-thread partials (parallel order), matching a host sum to rounding.

## Testing

`tests/demo.nu` exercises the whole facade — elementwise, source-baked map + kernel-cache reuse, bit-identical matmul, reduce/dot, and a hand-written kernel through the generic `gk_run` — checking every bit-identical op with `==` against a host computation. `tests/gpukit_test.sh` runs it on both backends: **14/14 on the RTX 4090 (CUDA) and 14/14 on the CPU backend.**

Development note: ASan-style discipline caught a real out-of-bounds bug during bring-up — the reductions were launched with the total thread count as the *grid* argument, over-writing the partials buffer; fixed to `blocks = threads/256`.

Follow-up (offered, not in this PR): migrate anomaly's / onnx's hand-marshalled GPU paths onto `gk_run` as a dogfood — deferred because it touches their bit-identical guarantees and warrants its own verified change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)