### PR TITLE
refactor(gpukit,anomaly): dogfood gpukit on anomaly's GPU path

### DIFF
--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -9,3 +9,4 @@ iforest = { path = "../iforest", version = "0.1" }
 gpu = { path = "../gpu", version = "0.2.1" }
 http = { path = "../http", version = "0.1" }
 cli = { path = "../cli", version = "0.1" }
+gpukit = { path = "../gpukit", version = "0.1" }

--- a/packages/anomaly/src/score.nu
+++ b/packages/anomaly/src/score.nu
@@ -30,6 +30,7 @@ $ `src/prep.nu`
 $ `src/model.nu`
 $ `deps/iforest/src/iforest.nu`
 $ `deps/gpu/src/gpu.nu`
+$ `deps/gpukit/src/gpukit.nu`
 
 // Below this many rows the pure loop wins on latency. Bit-equality of the
 // paths makes the threshold unobservable in results.
@@ -48,15 +49,14 @@ $ `deps/gpu/src/gpu.nu`
 
 // ── GPU singleton ─────────────────────────────────────────────────────
 //
-// One device + one compiled kernel per process, probed lazily on first
-// bulk call. state: 0 = unprobed, 1 = ready, -1 = unavailable/disabled.
+// One GpuKit (device + kernel cache) per process, probed lazily on the first
+// bulk call. The gpukit facade owns the device, the compiled `anomaly_paths`
+// kernel (cached), and all the buffer marshalling. state: 0 = unprobed,
+// 1 = ready, -1 = unavailable/disabled. The kit pointer is held as an int
+// (0 = none), the same way the raw device handle used to be.
 
 : ~ i g_ag_state 0
-: ~ i g_ag_ord 0
-: ~ i g_ag_dev 0
-: ~ i g_ag_ctx 0
-: ~ i g_ag_kmod 0
-: ~ i g_ag_kfun 0
+: ~ i g_ag_kit 0
 
 // The path-walk kernel. One thread per row; per tree, descend by the same
 // comparison the pure walker uses and accumulate depth + c(leaf) — nothing
@@ -88,49 +88,40 @@ $ `deps/gpu/src/gpu.nu`
     ^ == ( nurl_str_eq v `0` ) 1
 }
 
-// Probe once: open a device (CUDA, else the gpu package's CPU backend) and
-// compile the kernel. Any failure parks the accelerator for the process.
+// Probe once: open a GpuKit (CUDA, else the gpu package's CPU backend) and
+// warm the kernel cache with `anomaly_paths`. Any failure parks the
+// accelerator for the process.
 @ __ag_ensure → b {
     ? != g_ag_state 0 { ^ == g_ag_state 1 } {}
     ? ( __ag_env_off ) {
         = g_ag_state -1
         ^ F
     } {}
-    : Gpu g ( gpu_open 0 )
-    ? ( gpu_ok g ) {} {
+    : *GpuKit kit ( gk_open 0 )
+    ? ( gk_ok kit ) {} {
+        ( gk_close kit )
         = g_ag_state -1
         ^ F
     }
-    : GpuKernel k ( gpu_compile g ( __ag_kernel_src ) `anomaly_paths` )
-    ? ( gpu_kernel_ok k ) {} {
-        ( gpu_close g )
+    ? ( gk_compile kit ( __ag_kernel_src ) `anomaly_paths` ) {} {
+        ( gk_close kit )
         = g_ag_state -1
         ^ F
     }
-    = g_ag_ord . g ordinal
-    = g_ag_dev . g dev
-    = g_ag_ctx . g ctx
-    = g_ag_kmod . k module
-    = g_ag_kfun . k func
+    = g_ag_kit # i kit
     = g_ag_state 1
     ^ T
 }
 
-@ __ag_handle → Gpu {
-    ^ @ Gpu { g_ag_ord g_ag_dev g_ag_ctx }
-}
+// The live kit (only valid when g_ag_state == 1).
+@ __ag_kit → *GpuKit { ^ # *GpuKit g_ag_kit }
 
-// Release the device + kernel (tests call this so leak checkers see a
+// Release the device + kernel cache (tests call this so leak checkers see a
 // closed shop; a long-running service just keeps the singleton).
 @ anom_gpu_close → v {
-    ? == g_ag_state 1 {
-        ( gpu_kernel_free @ GpuKernel { g_ag_kmod g_ag_kfun } )
-        ( gpu_close ( __ag_handle ) )
-    } {}
+    ? == g_ag_state 1 { ( gk_close ( __ag_kit ) ) } {}
     = g_ag_state 0
-    = g_ag_kmod 0
-    = g_ag_kfun 0
-    = g_ag_ctx 0
+    = g_ag_kit 0
 }
 
 // Which engine bulk scoring would use right now: `cuda`, `cpu` (the gpu
@@ -184,67 +175,28 @@ $ `deps/gpu/src/gpu.nu`
         = k + k 1
     }
 
-    : Gpu g ( __ag_handle )
-    : GpuKernel kn @ GpuKernel { g_ag_kmod g_ag_kfun }
-    : GpuBuffer b_xs ( gpu_alloc g * * n_rows n_cols 8 )
-    : GpuBuffer b_feat ( gpu_alloc g * n_nodes 8 )
-    : GpuBuffer b_split ( gpu_alloc g * n_nodes 8 )
-    : GpuBuffer b_left ( gpu_alloc g * n_nodes 8 )
-    : GpuBuffer b_right ( gpu_alloc g * n_nodes 8 )
-    : GpuBuffer b_cleaf ( gpu_alloc g * n_nodes 8 )
-    : GpuBuffer b_roots ( gpu_alloc g * n_trees 8 )
-    : GpuBuffer b_out ( gpu_alloc g * n_rows 8 )
-
-    : ~ b ok T
-    ? || == . b_xs dptr 0 || == . b_feat dptr 0 || == . b_split dptr 0 || == . b_left dptr 0 || == . b_right dptr 0 || == . b_cleaf dptr 0 || == . b_roots dptr 0 == . b_out dptr 0 { = ok F } {}
-    ? ok {
-        ? == ( gpu_upload b_xs # *u ( vec_data [f] scaled ) ) 0 {} { = ok F }
-        ? == ( gpu_upload b_feat # *u ( vec_data [i] . fo feature ) ) 0 {} { = ok F }
-        ? == ( gpu_upload b_split # *u ( vec_data [f] . fo split ) ) 0 {} { = ok F }
-        ? == ( gpu_upload b_left # *u ( vec_data [i] . fo left ) ) 0 {} { = ok F }
-        ? == ( gpu_upload b_right # *u ( vec_data [i] . fo right ) ) 0 {} { = ok F }
-        ? == ( gpu_upload b_cleaf # *u ( vec_data [f] cleaf ) ) 0 {} { = ok F }
-        ? == ( gpu_upload b_roots # *u ( vec_data [i] . fo roots ) ) 0 {} { = ok F }
-    } {}
-
+    // One gk_run marshals the 7 inputs, 3 scalars and 1 output; the kernel
+    // itself (anomaly_paths) is compiled once and served from the kit cache.
+    : *GpuKit kit ( __ag_kit )
     : ( Vec f ) totals ( vec_with_cap [f] n_rows )
-    ? ok {
-        : ( Vec i ) args ( vec_new [i] )
-        ( vec_push [i] args ( gpu_arg_buffer b_xs ) )
-        ( vec_push [i] args ( gpu_arg_buffer b_feat ) )
-        ( vec_push [i] args ( gpu_arg_buffer b_split ) )
-        ( vec_push [i] args ( gpu_arg_buffer b_left ) )
-        ( vec_push [i] args ( gpu_arg_buffer b_right ) )
-        ( vec_push [i] args ( gpu_arg_buffer b_cleaf ) )
-        ( vec_push [i] args ( gpu_arg_buffer b_roots ) )
-        ( vec_push [i] args ( gpu_arg_i64 n_rows ) )
-        ( vec_push [i] args ( gpu_arg_i64 n_cols ) )
-        ( vec_push [i] args ( gpu_arg_i64 n_trees ) )
-        ( vec_push [i] args ( gpu_arg_buffer b_out ) )
-        : i block 256
-        ? == ( gpu_launch kn ( gpu_grid n_rows block ) block args ) 0 {} { = ok F }
-        ( vec_free [i] args )
-    } {}
-    ? ok {
-        ? == ( gpu_sync g ) 0 {} { = ok F }
-    } {}
-    ? ok {
-        ? == ( gpu_download # *u ( vec_data [f] totals ) b_out ) 0 {
-            ( vec_set_len [f] totals n_rows )
-        } { = ok F }
-    } {}
-
-    ( gpu_free b_xs )
-    ( gpu_free b_feat )
-    ( gpu_free b_split )
-    ( gpu_free b_left )
-    ( gpu_free b_right )
-    ( gpu_free b_cleaf )
-    ( gpu_free b_roots )
-    ( gpu_free b_out )
+    : *u outp # *u ( vec_data [f] totals )
+    : ( Vec GkArg ) call ( vec_new [GkArg] )
+    ( vec_push [GkArg] call ( gk_in_f scaled ) )
+    ( vec_push [GkArg] call ( gk_in_i . fo feature ) )
+    ( vec_push [GkArg] call ( gk_in_f . fo split ) )
+    ( vec_push [GkArg] call ( gk_in_i . fo left ) )
+    ( vec_push [GkArg] call ( gk_in_i . fo right ) )
+    ( vec_push [GkArg] call ( gk_in_f cleaf ) )
+    ( vec_push [GkArg] call ( gk_in_i . fo roots ) )
+    ( vec_push [GkArg] call ( gk_i64 n_rows ) )
+    ( vec_push [GkArg] call ( gk_i64 n_cols ) )
+    ( vec_push [GkArg] call ( gk_i64 n_trees ) )
+    ( vec_push [GkArg] call ( gk_buf_out outp * n_rows 8 ) )
+    : b ok ( gk_run kit ( __ag_kernel_src ) `anomaly_paths` ( gk_grid n_rows 256 ) 256 call )
+    ( vec_free [GkArg] call )
     ( vec_free [f] cleaf )
 
-    ? ok {} {
+    ? ok { ( vec_set_len [f] totals n_rows ) } {
         ( vec_free [f] totals )
         ( nurl_eprintln `anomaly: gpu scoring failed, falling back to the pure path` )
         ^ @ ?( Vec f ) { F }

--- a/packages/gpukit/src/gpukit.nu
+++ b/packages/gpukit/src/gpukit.nu
@@ -65,21 +65,27 @@ $ `deps/gpu/src/gpu.nu`
 // ── Lifecycle ─────────────────────────────────────────────────────────
 
 // Open device `ordinal` (CUDA when present, else the gpu package's CPU
-// backend). Check `gk_ok`; even a failed open is safe to `gk_close`.
-@ gk_open i ordinal → GpuKit {
+// backend). Returns a heap `*GpuKit` so it can be held as a long-lived
+// singleton (its kernel cache persists across calls). Check `gk_ok`; even a
+// failed open is safe to `gk_close`.
+@ gk_open i ordinal → *GpuKit {
     : Gpu g ( gpu_open ordinal )
-    ^ @ GpuKit { g ( gpu_ok g ) ( vec_new [GkKernelEntry] ) }
+    : *GpuKit kit # *GpuKit ( nurl_malloc Z GpuKit )
+    = . kit gpu g
+    = . kit ok ( gpu_ok g )
+    = . kit cache ( vec_new [GkKernelEntry] )
+    ^ kit
 }
 
-@ gk_ok GpuKit kit → b { ^ . kit ok }
+@ gk_ok *GpuKit kit → b { ^ . kit ok }
 
 // "cuda" or "cpu".
-@ gk_backend GpuKit kit → s { ? ( gpu_is_cpu ) { ^ `cpu` } { ^ `cuda` } }
+@ gk_backend *GpuKit kit → s { ? ( gpu_is_cpu ) { ^ `cpu` } { ^ `cuda` } }
 
-@ gk_device_name GpuKit kit → s { ^ ( gpu_name . kit gpu ) }
+@ gk_device_name *GpuKit kit → s { ^ ( gpu_name . kit gpu ) }
 
-// Release every cached kernel and close the device.
-@ gk_close GpuKit kit → v {
+// Release every cached kernel, close the device, and free the kit.
+@ gk_close *GpuKit kit → v {
     : i n ( vec_len [GkKernelEntry] . kit cache )
     : ~ i k 0
     ~ < k n {
@@ -94,6 +100,7 @@ $ `deps/gpu/src/gpu.nu`
     }
     ( vec_free [GkKernelEntry] . kit cache )
     ? . kit ok { ( gpu_close . kit gpu ) } {}
+    ( nurl_free kit )
 }
 
 // Grid size for `n` threads at the given block size (re-export of gpu_grid).
@@ -147,7 +154,7 @@ $ `deps/gpu/src/gpu.nu`
 // Compile `src` (entry `name`) once per kit; subsequent calls with the same
 // `name` reuse the cached kernel. A failed compile returns a not-ok kernel
 // and is not cached (so a fixed source can be retried).
-@ __gk_get_kernel GpuKit kit s src s name → GpuKernel {
+@ __gk_get_kernel *GpuKit kit s src s name → GpuKernel {
     : i n ( vec_len [GkKernelEntry] . kit cache )
     : ~ i k 0
     ~ < k n {
@@ -166,12 +173,20 @@ $ `deps/gpu/src/gpu.nu`
     ^ kn
 }
 
+// Warm the cache: compile `src` (entry `name`) into the kit now and report
+// whether it succeeded, so a long-lived caller can detect a bad kernel at
+// setup instead of on the first launch.
+@ gk_compile *GpuKit kit s src s name → b {
+    ? ( gk_ok kit ) {} { ^ F }
+    ^ ( gpu_kernel_ok ( __gk_get_kernel kit src name ) )
+}
+
 // ── The workhorse ─────────────────────────────────────────────────────
 
 // Compile-cached, marshal, launch, sync, download, free. `call` lists the
 // kernel's arguments in declaration order (buffers and scalars interleaved
 // exactly as the kernel signature expects). Returns F on any device error.
-@ gk_run GpuKit kit s src s name i grid i block ( Vec GkArg ) call → b {
+@ gk_run *GpuKit kit s src s name i grid i block ( Vec GkArg ) call → b {
     ? ( gk_ok kit ) {} { ^ F }
     : GpuKernel kn ( __gk_get_kernel kit src name )
     ? ( gpu_kernel_ok kn ) {} { ^ F }

--- a/packages/gpukit/src/kernels.nu
+++ b/packages/gpukit/src/kernels.nu
@@ -29,7 +29,7 @@ $ `gpukit.nu`
     ^ s
 }
 
-@ __gk_ew GpuKit kit s name s op ( Vec f ) out ( Vec f ) a ( Vec f ) b → b {
+@ __gk_ew *GpuKit kit s name s op ( Vec f ) out ( Vec f ) a ( Vec f ) b → b {
     : i n ( vec_len [f] out )
     : String src ( __gk_ew_src name op )
     : ( Vec GkArg ) call ( vec_new [GkArg] )
@@ -43,16 +43,16 @@ $ `gpukit.nu`
     ^ r
 }
 
-@ gk_add_f GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_add` `+` out a b ) }
-@ gk_sub_f GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_sub` `-` out a b ) }
-@ gk_mul_f GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_mul` `*` out a b ) }
-@ gk_div_f GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_div` `/` out a b ) }
+@ gk_add_f *GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_add` `+` out a b ) }
+@ gk_sub_f *GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_sub` `-` out a b ) }
+@ gk_mul_f *GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_mul` `*` out a b ) }
+@ gk_div_f *GpuKit kit ( Vec f ) out ( Vec f ) a ( Vec f ) b → b { ^ ( __gk_ew kit `gk_div` `/` out a b ) }
 
 // ── Unary map: out[i] = <expr>, with `x` bound to in[i] ────────────────
 // `kname` is the CUDA entry name (a valid C identifier, stable per `expr` so
 // caching works). `expr` is C over the local `double x`, e.g. `x*x`,
 // `1.0/(1.0+exp(-x))`, `x>0.0?x:0.0`.
-@ gk_map_f GpuKit kit s kname ( Vec f ) out ( Vec f ) in s expr → b {
+@ gk_map_f *GpuKit kit s kname ( Vec f ) out ( Vec f ) in s expr → b {
     : i n ( vec_len [f] out )
     : String src ( string_from `extern "C" __global__ void ` )
     ( string_push_str src kname )
@@ -74,7 +74,7 @@ $ `gpukit.nu`
 // ── Matrix multiply: C[M×N] = A[M×K] · B[K×N] (row-major) ──────────────
 // Each output element sums t=0..K in order, exactly as a host loop — so this
 // is bit-identical to a naive sequential matmul.
-@ gk_matmul_f GpuKit kit ( Vec f ) c ( Vec f ) a ( Vec f ) b i m i k i n → b {
+@ gk_matmul_f *GpuKit kit ( Vec f ) c ( Vec f ) a ( Vec f ) b i m i k i n → b {
     : String src ( string_from `extern "C" __global__ void gk_matmul(const double* A, const double* B, double* C, long long M, long long K, long long N){` )
     ( string_push_str src `long long idx=blockIdx.x*blockDim.x+threadIdx.x;` )
     ( string_push_str src `if(idx<M*N){long long row=idx/N,col=idx%N;double s=0.0;` )
@@ -109,7 +109,7 @@ $ `gpukit.nu`
 }
 
 // Sum of `x`. None on a device error.
-@ gk_reduce_sum_f GpuKit kit ( Vec f ) x → ?f {
+@ gk_reduce_sum_f *GpuKit kit ( Vec f ) x → ?f {
     : i n ( vec_len [f] x )
     ? <= n 0 { ^ @ ?f { T 0.0 } } {}
     : i threads ( __gk_partial_threads n )
@@ -138,7 +138,7 @@ $ `gpukit.nu`
 }
 
 // Dot product a·b (equal lengths assumed). None on a device error.
-@ gk_dot_f GpuKit kit ( Vec f ) a ( Vec f ) b → ?f {
+@ gk_dot_f *GpuKit kit ( Vec f ) a ( Vec f ) b → ?f {
     : i n ( vec_len [f] a )
     ? <= n 0 { ^ @ ?f { T 0.0 } } {}
     : i threads ( __gk_partial_threads n )

--- a/packages/gpukit/tests/demo.nu
+++ b/packages/gpukit/tests/demo.nu
@@ -50,7 +50,7 @@ $ `src/kernels.nu`
 }
 
 @ main → i {
-    : GpuKit kit ( gk_open 0 )
+    : *GpuKit kit ( gk_open 0 )
     ? ( gk_ok kit ) {} {
         ( nurl_eprintln `gpukit: no device (open failed)` )
         ( gk_close kit )
@@ -106,7 +106,9 @@ $ `src/kernels.nu`
 
     // kernel cache: a second identical call must reuse (still correct)
     ( __ck `map cached rerun` ( gk_map_f kit `gk_sq` out a `x*x` ) )
-    ( __ck `map cached == host` ( __eq_vec out ( __seq_map_sq a ) ) )
+    : ( Vec f ) wsq2 ( __seq_map_sq a )
+    ( __ck `map cached == host` ( __eq_vec out wsq2 ) )
+    ( vec_free [f] wsq2 )
 
     // matmul: 3x4 · 4x2 = 3x2, checked exactly against a host loop
     : i M 3
@@ -116,7 +118,9 @@ $ `src/kernels.nu`
     : ( Vec f ) mb ( __seq_f * K Nn 2.0 )
     : ( Vec f ) mc ( __gk_zeros * M Nn )
     ( __ck `matmul ran` ( gk_matmul_f kit mc ma mb M K Nn ) )
-    ( __ck `matmul == host` ( __eq_vec mc ( __host_matmul ma mb M K Nn ) ) )
+    : ( Vec f ) hm ( __host_matmul ma mb M K Nn )
+    ( __ck `matmul == host` ( __eq_vec mc hm ) )
+    ( vec_free [f] hm )
     ( vec_free [f] ma )
     ( vec_free [f] mb )
     ( vec_free [f] mc )


### PR DESCRIPTION
Migrating anomaly's bulk scorer onto gpukit — the request was to find gpukit's narrow spots by using it for real. It found three, now fixed.

## Narrow spots surfaced (and fixed in gpukit)

1. **`GpuKit` → `*GpuKit` (heap).** A by-value kit can't be held as a lazily-probed process singleton — anomaly's pattern. `gk_open` now returns a heap pointer whose kernel cache persists across calls; `gk_close` frees it. Mirrors `Model` / `HttpApp` / `Cli`.
2. **`gk_compile`** — warm the cache and report whether a kernel builds, so a long-lived caller detects a bad kernel at *setup* instead of on first launch (anomaly parks the accelerator on a compile failure during its probe).
3. **`gk_buf_out` earns its place** — anomaly's output is a `vec_with_cap` (capacity `n`, len `0`); `gk_out_f` keys off `vec_len`, which is 0 there, so the raw buffer binding is the right tool. Good that it was already in the API.

## The payoff

`anom_scores_gpu` drops from **~65 lines** of `gpu_alloc` / `gpu_upload` / arg-vector / `gpu_launch` / `gpu_sync` / `gpu_download` / `gpu_free` to **~24** — build the `GkArg` list and one `gk_run`. The singleton holds a `*GpuKit` instead of five int globals.

## Verification — bit-identical preserved

The whole point of anomaly's GPU path is that CUDA / CPU-backend / pure are **bit-identical**. After the migration:
- `gpu_test`'s *auto-path decisions bit-identical* and *contamination offset bit-identical* checks **pass on the RTX 4090 and on the CPU backend**.
- **All 26 anomaly tests pass.**
- gpukit's own demo stays **14/14 on both backends** and **ASan-clean** (also fixed two temp-vector leaks in the demo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)