### PR TITLE
chore: pre-commit hook that runs nurlfmt on staged .nu files

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,22 @@
+# Git hooks
+
+Version-controlled hooks for this repo. Activate them once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+(`build.sh` runs this for you, so a normal build already wires them up.)
+
+## `pre-commit`
+
+Runs `nurlfmt` on staged `.nu` files so a commit is always canonical and
+never trips the CI `nurlfmt --check` gate:
+
+- **fully staged** files are `nurlfmt --write`-formatted and re-staged;
+- **partially staged** files are only `--check`ed (auto-writing would stage
+  the unstaged edits too) and block the commit if not canonical.
+
+`bench/` is excluded (recorded model outputs must keep their exact bytes).
+It skips cleanly if `build/nurlfmt` isn't built yet, and can be bypassed with
+`git commit --no-verify`.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# ============================================================
+#  .githooks/pre-commit — keep staged NURL sources nurlfmt-canonical,
+#  the same gate CI enforces (compiler/tests/nurlfmt_check.sh).
+#
+#  For each staged *.nu file (bench/ excluded — those are recorded model
+#  outputs that must keep their exact bytes):
+#    * fully staged (no unstaged edits) → `nurlfmt --write` then re-stage,
+#      so the commit is always canonical with nothing to re-run;
+#    * partially staged → `nurlfmt --check` only, and block the commit if it
+#      isn't canonical (auto-writing would stage the unstaged edits too).
+#
+#  Skips cleanly (does not block) when build/nurlfmt hasn't been built yet.
+#  Bypass once with `git commit --no-verify`.
+#
+#  Activate:  git config core.hooksPath .githooks   (see .githooks/README.md)
+# ============================================================
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+FMT="$ROOT/build/nurlfmt"
+
+if [[ ! -x "$FMT" ]]; then
+    echo "pre-commit: build/nurlfmt not found — skipping fmt check (run ./build.sh)." >&2
+    exit 0
+fi
+
+# Staged, added/copied/modified *.nu files, minus bench/.
+mapfile -t FILES < <(git diff --cached --name-only --diff-filter=ACM -- '*.nu' | grep -v '^bench/' || true)
+(( ${#FILES[@]} == 0 )) && exit 0
+
+blocked=()
+fixed=()
+for f in "${FILES[@]}"; do
+    [[ -f "$f" ]] || continue
+    if git diff --quiet -- "$f"; then
+        # No unstaged edits — safe to rewrite and re-stage.
+        before="$(git hash-object "$f")"
+        "$FMT" --write "$f" >/dev/null 2>&1 || true
+        after="$(git hash-object "$f")"
+        if [[ "$before" != "$after" ]]; then
+            git add -- "$f"
+            fixed+=("$f")
+        fi
+    else
+        # Partially staged — don't touch the working tree; just verify.
+        "$FMT" --check "$f" >/dev/null 2>&1 || blocked+=("$f")
+    fi
+done
+
+if (( ${#fixed[@]} > 0 )); then
+    echo "pre-commit: nurlfmt formatted and re-staged:" >&2
+    for f in "${fixed[@]}"; do echo "  $f" >&2; done
+fi
+
+if (( ${#blocked[@]} > 0 )); then
+    echo "pre-commit: not nurlfmt-canonical (has unstaged edits, not auto-fixed):" >&2
+    for f in "${blocked[@]}"; do echo "  $f" >&2; done
+    echo "Fix: build/nurlfmt --write <file>  then re-stage." >&2
+    exit 1
+fi
+
+exit 0

--- a/build.sh
+++ b/build.sh
@@ -40,6 +40,14 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Wire up the version-controlled git hooks (idempotent; only in a work-tree
+# checkout). The pre-commit hook keeps staged .nu files nurlfmt-canonical.
+if [[ -d .githooks ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ "$(git config --local core.hooksPath 2>/dev/null || true)" != ".githooks" ]]; then
+        git config --local core.hooksPath .githooks 2>/dev/null || true
+    fi
+fi
+
 # Wall-clock timers (bash $SECONDS, integer). BUILD_T0 marks the start of
 # the whole build; TEST_T0 is set just before the test runner. fmt_dur
 # renders seconds as "1m 20s" / "12s" for the summary line.


### PR DESCRIPTION
Adds a version-controlled `pre-commit` hook that runs `nurlfmt` on staged `.nu` files, so a commit is always canonical and never trips the CI `nurlfmt --check` gate (which just failed on `stdlib/ext/semver.nu`).

## Behaviour

For each staged `*.nu` (`bench/` excluded — recorded model outputs keep their exact bytes):
- **fully staged** (no unstaged edits) → `nurlfmt --write` then re-stage, so there's nothing to re-run;
- **partially staged** → `nurlfmt --check` only, and block the commit if not canonical (auto-writing would stage the unstaged edits too).

Skips cleanly if `build/nurlfmt` isn't built yet; bypass once with `git commit --no-verify`.

## Activation

- `.githooks/pre-commit` + `.githooks/README.md`.
- **`build.sh`** sets `core.hooksPath = .githooks` (idempotent, work-tree only), so a normal build wires it up — no manual step for anyone who builds.

## Verified

Staged a deliberately non-canonical file (`@ foo i x  →  i {  ^  +  x   1  }`); the hook formatted and re-staged it, and the committed file was canonical (`@ foo i x → i { ^ + x 1 }`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)