### PR TITLE
feat(tensor): M2 — batched matmul, softmax, slicing, concat, argmax/argmin

### DIFF
--- a/packages/tensor/CHANGELOG.md
+++ b/packages/tensor/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## 0.2.0
+
+M2 — batched matmul, softmax, slicing, concat, argmax/argmin.
+
+- `tensor_bmm a b` → `?Tensor` — N-D batched matmul. The last two dims are the
+  matrix `(…,M,K)·(…,K,N)`; leading batch dims broadcast by the numpy rule.
+- `tensor_softmax t axis` → `Tensor` — numerically stable softmax over one axis
+  (subtracts the axis max before exp).
+- `tensor_slice t starts stops` → `?Tensor` — per-dimension half-open slice
+  `[start, stop)`; one `start`/`stop` entry per dim.
+- `tensor_concat2 a b axis` → `?Tensor` — concatenate two tensors along an axis
+  (all other dims must match).
+- `tensor_argmax t axis keepdim` / `tensor_argmin t axis keepdim` → `Tensor` —
+  index of the max/min along an axis (indices as f64; `keepdim` is a `b`).
+
+Verified against numpy (incl. batch broadcasting): **25 / 25, ASan-clean.**
+
+## 0.1.0
+
+Initial release. The reusable ndarray layer: `Tensor` (row-major, f64 compute,
+F32-grid dtype), creation (`arange`/`zeros`/`ones`/`full`/`from_data`), reshape /
+transpose / permute, numpy-broadcasting elementwise + scalar ops, unary maps
+(exp/log/sqrt/relu/sigmoid/tanh…), 2-D matmul (GPU via gpukit for large
+problems), and axis/global reductions. Verified against numpy — 17 / 17,
+ASan-clean.

--- a/packages/tensor/README.md
+++ b/packages/tensor/README.md
@@ -67,9 +67,20 @@ Unary → `Tensor`: `tensor_neg` / `abs` / `exp` / `log` / `sqrt` / `relu` /
 `sigmoid` / `tanh`.
 
 Matmul: `( tensor_matmul a b )` → `?Tensor` — 2-D `(M,K)·(K,N)`.
+`( tensor_bmm a b )` → `?Tensor` — N-D batched matmul: the last two dims are the
+matrix, leading batch dims broadcast (numpy rule).
 
 Reductions → `Tensor` (axis `< 0` reduces everything; `keepdim` is a `b`):
 `( tensor_sum t axis keepdim )` and `_mean` / `_max` / `_min` / `_prod`.
+
+Slicing / joining / indexing:
+
+| Call | |
+| --- | --- |
+| `( tensor_slice t starts stops )` → `?Tensor` | per-dim half-open `[start,stop)` |
+| `( tensor_concat2 a b axis )` → `?Tensor` | concatenate along an axis |
+| `( tensor_softmax t axis )` → `Tensor` | stable softmax over one axis |
+| `( tensor_argmax t axis keepdim )` · `_argmin` → `Tensor` | arg index (as f64) along an axis |
 
 ## GPU
 
@@ -86,16 +97,19 @@ Elementwise ops and matmul are exact to f64 (and bit-identical across the GPU
 and CPU paths); reductions accumulate sequentially, so they match a
 pairwise-summing reference (numpy) to rounding. Verified against numpy:
 creation, reshape, broadcasting, matmul (incl. a 128×128 GPU case), transpose,
-a 3-D permute, all reductions, and the unary maps — **17 / 17**.
+a 3-D permute, all reductions, the unary maps, and the M2 ops — batched matmul
+(with batch broadcasting), softmax, slicing, concat, and argmax/argmin —
+**25 / 25**.
 
 ## Tests
 
 `./tests/tensor_test.sh` builds `tests/tcheck.nu`, checks every op against
-numpy, and re-runs under AddressSanitizer. **17/17, ASan-clean.** Skips cleanly
+numpy, and re-runs under AddressSanitizer. **25/25, ASan-clean.** Skips cleanly
 without numpy.
 
 ## Roadmap
 
-Batched/N-D matmul, slicing and gather/scatter, more ops (softmax, conv),
-native-f32 GPU kernels, and — the payoff — porting `onnx`'s `RTensor` + ops
-onto this layer so tensors stop being ONNX-only.
+Gather/scatter and fancy indexing, conv, native-f32 GPU kernels, and — the
+payoff — porting `onnx`'s `RTensor` + ops onto this layer so tensors stop being
+ONNX-only. (Done in 0.2.0: batched/N-D matmul, softmax, slicing, concat,
+argmax/argmin.)

--- a/packages/tensor/nurl.toml
+++ b/packages/tensor/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensor"
-version = "0.1.0"
+version = "0.2.0"
 description = "The reusable n-dimensional array for NURL — the shared ML layer over gpukit. Tensor logic today is welded inside the onnx runtime (RTensor is bound to the graph Engine) and gpukit is a marshalling floor; `tensor` is the ndarray that onnx, anomaly and a future training package can all sit on. Row-major contiguous storage computed in f64, with an F32 dtype that keeps values on the float32 grid for interop. Ships creation (zeros/ones/full/from_data/arange), shape ops (reshape/transpose/permute), numpy-rule broadcasting elementwise (add/sub/mul/div/pow/maximum/minimum + scalar forms), unary maps (neg/abs/exp/log/sqrt/relu/sigmoid/tanh), 2-D matmul that runs on the GPU via gpukit for large f64 problems and a plain loop otherwise (identical results), and axis/global reductions (sum/mean/max/min/prod with keepdim). Verified against numpy."
 license = "MIT OR Apache-2.0"
 

--- a/packages/tensor/src/ops.nu
+++ b/packages/tensor/src/ops.nu
@@ -393,3 +393,232 @@ $ `tensor.nu`
     ( tensor_free s )
     ^ r
 }
+
+// ══ M2: batched matmul, softmax, slicing, concat, argmax/argmin ════════
+
+@ __unwrap ? Tensor o → Tensor {
+    ?? o { T t → { ^ t } F _ → { ^ @ Tensor { TE_F64 ( vec_new [i] ) ( vec_new [f] ) } } }
+}
+
+// Batch strides of `shape` (its first ndim-2 dims), aligned into `ndb`
+// output batch dims with broadcasting (0 where the batch dim is 1 or padded).
+@ __t_batch_eff ( Vec i ) shape i ndb → ( Vec i ) {
+    : i n ( vec_len [i] shape )
+    : i nbatch - n 2
+    : ( Vec i ) full ( __t_strides shape )
+    : ( Vec i ) eff ( __ivec_t ndb 0 )
+    : ~ i d 0
+    ~ < d ndb {
+        : i j - d - ndb nbatch
+        ? & >= j 0 > ( __ti shape j ) 1 { ( vec_set [i] eff d ( __ti full j ) ) } {}
+        = d + d 1
+    }
+    ( vec_free [i] full )
+    ^ eff
+}
+
+@ __t_take_head ( Vec i ) shape i cnt → ( Vec i ) {
+    : ( Vec i ) o ( vec_with_cap [i] ? > cnt 0 { cnt } { 1 } )
+    : ~ i k 0
+    ~ < k cnt { ( vec_push [i] o ( __ti shape k ) ) = k + k 1 }
+    ^ o
+}
+
+// Batched matmul: [..,M,K] · [..,K,N] → [..,M,N], batch dims broadcast.
+@ tensor_bmm Tensor a Tensor b → ?Tensor {
+    : i na ( tensor_ndim a )
+    : i nb ( tensor_ndim b )
+    ? & >= na 2 >= nb 2 {} { ^ @ ?Tensor { F } }
+    : i M ( __ti . a shape - na 2 )
+    : i K ( __ti . a shape - na 1 )
+    : i N ( __ti . b shape - nb 1 )
+    ? == K ( __ti . b shape - nb 2 ) {} { ^ @ ?Tensor { F } }
+    : ( Vec i ) ba ( __t_take_head . a shape - na 2 )
+    : ( Vec i ) bb ( __t_take_head . b shape - nb 2 )
+    : ?( Vec i ) bso ( __t_bshape ba bb )
+    ( vec_free [i] ba ) ( vec_free [i] bb )
+    ?? bso {
+        T bshape → {
+            : i ndb ( vec_len [i] bshape )
+            : i nbatch ( __t_prod bshape )
+            : ( Vec i ) bst ( __t_strides bshape )
+            : ( Vec i ) aeff ( __t_batch_eff . a shape ndb )
+            : ( Vec i ) beff ( __t_batch_eff . b shape ndb )
+            : i mk * M K
+            : i kn * K N
+            : i mn * M N
+            : i rdt ( __t_result_dtype a b )
+            : ( Vec f ) out ( __fvec_t * nbatch mn 0.0 )
+            : ~ i bi 0
+            ~ < bi nbatch {
+                // batch offsets into a and b
+                : ~ i rem bi
+                : ~ i aoff 0
+                : ~ i boff 0
+                : ~ i d 0
+                ~ < d ndb {
+                    : i sd ( __ti bst d )
+                    : i c ? > sd 0 { / rem sd } { 0 }
+                    = rem ? > sd 0 { % rem sd } { rem }
+                    = aoff + aoff * c ( __ti aeff d )
+                    = boff + boff * c ( __ti beff d )
+                    = d + d 1
+                }
+                : i ooff * bi mn
+                : ~ i r 0
+                ~ < r M {
+                    : ~ i cc 0
+                    ~ < cc N {
+                        : ~ f s 0.0
+                        : ~ i p 0
+                        ~ < p K { = s + s * ( __tf . a data + aoff + * r K p ) ( __tf . b data + boff + * p N cc ) = p + p 1 }
+                        ( vec_set [f] out + ooff + * r N cc ? == rdt TE_F32 { ( __t_round32 s ) } { s } )
+                        = cc + cc 1
+                    }
+                    = r + r 1
+                }
+                = bi + bi 1
+            }
+            // out shape = bshape ++ [M, N]
+            : ( Vec i ) oshape ( vec_with_cap [i] + ndb 2 )
+            : ~ i k 0
+            ~ < k ndb { ( vec_push [i] oshape ( __ti bshape k ) ) = k + k 1 }
+            ( vec_push [i] oshape M ) ( vec_push [i] oshape N )
+            ( vec_free [i] bshape ) ( vec_free [i] bst ) ( vec_free [i] aeff ) ( vec_free [i] beff )
+            ^ @ ?Tensor { T @ Tensor { rdt oshape out } }
+        }
+        F _ → { ^ @ ?Tensor { F } }
+    }
+}
+
+// Numerically-stable softmax along one axis.
+@ tensor_softmax Tensor t i axis → Tensor {
+    : Tensor mx ( tensor_max t axis T )
+    : Tensor sh ( __unwrap ( tensor_sub t mx ) )
+    : Tensor e ( tensor_exp sh )
+    : Tensor sm ( tensor_sum e axis T )
+    : Tensor r ( __unwrap ( tensor_div e sm ) )
+    ( tensor_free mx ) ( tensor_free sh ) ( tensor_free e ) ( tensor_free sm )
+    ^ r
+}
+
+// Slice: out[d] spans [starts[d], stops[d]) of each dim.
+@ tensor_slice Tensor t ( Vec i ) starts ( Vec i ) stops → ?Tensor {
+    : i nd ( tensor_ndim t )
+    ? & == ( vec_len [i] starts ) nd == ( vec_len [i] stops ) nd {} { ^ @ ?Tensor { F } }
+    : ( Vec i ) oshape ( __ivec_t nd 0 )
+    : ~ i d 0
+    ~ < d nd {
+        : i s0 ( __ti starts d )
+        : i s1 ( __ti stops d )
+        ? & >= s0 0 & <= s1 ( __ti . t shape d ) <= s0 s1 {} { ( vec_free [i] oshape ) ^ @ ?Tensor { F } }
+        ( vec_set [i] oshape d - s1 s0 )
+        = d + d 1
+    }
+    : ( Vec i ) ist ( __t_strides . t shape )
+    : ( Vec i ) ost ( __t_strides oshape )
+    : i total ( __t_prod oshape )
+    : ( Vec f ) out ( vec_with_cap [f] ? > total 0 { total } { 1 } )
+    : ~ i i 0
+    ~ < i total {
+        : ~ i rem i
+        : ~ i ino 0
+        : ~ i d2 0
+        ~ < d2 nd {
+            : i sd ( __ti ost d2 )
+            : i c ? > sd 0 { / rem sd } { 0 }
+            = rem ? > sd 0 { % rem sd } { rem }
+            = ino + ino * + c ( __ti starts d2 ) ( __ti ist d2 )
+            = d2 + d2 1
+        }
+        ( vec_push [f] out ( __tf . t data ino ) )
+        = i + i 1
+    }
+    ( vec_free [i] ist ) ( vec_free [i] ost )
+    ^ @ ?Tensor { T @ Tensor { . t dtype oshape out } }
+}
+
+// Concatenate two tensors along `axis` (shapes equal except along axis).
+@ tensor_concat2 Tensor a Tensor b i axis → ?Tensor {
+    : i nd ( tensor_ndim a )
+    ? & == nd ( tensor_ndim b ) & >= axis 0 < axis nd {} { ^ @ ?Tensor { F } }
+    : ~ i d 0
+    ~ < d nd { ? | == d axis == ( __ti . a shape d ) ( __ti . b shape d ) {} { ^ @ ?Tensor { F } } = d + d 1 }
+    : ( Vec i ) oshape ( __shape_copy . a shape )
+    ( vec_set [i] oshape axis + ( __ti . a shape axis ) ( __ti . b shape axis ) )
+    : i rdt ( __t_result_dtype a b )
+    : ( Vec i ) ost ( __t_strides oshape )
+    : ( Vec i ) ast ( __t_strides . a shape )
+    : ( Vec i ) bst ( __t_strides . b shape )
+    : i asz ( __ti . a shape axis )
+    : i total ( __t_prod oshape )
+    : ( Vec f ) out ( vec_with_cap [f] ? > total 0 { total } { 1 } )
+    : ~ i i 0
+    ~ < i total {
+        : ~ i rem i
+        : ~ i coord_ax 0
+        : ~ i aoff 0
+        : ~ i boff 0
+        : ~ i d3 0
+        ~ < d3 nd {
+            : i sd ( __ti ost d3 )
+            : i c ? > sd 0 { / rem sd } { 0 }
+            = rem ? > sd 0 { % rem sd } { rem }
+            ? == d3 axis { = coord_ax c } {
+                = aoff + aoff * c ( __ti ast d3 )
+                = boff + boff * c ( __ti bst d3 )
+            }
+            = d3 + d3 1
+        }
+        : ~ f v 0.0
+        ? < coord_ax asz {
+            = v ( __tf . a data + aoff * coord_ax ( __ti ast axis ) )
+        } {
+            = v ( __tf . b data + boff * - coord_ax asz ( __ti bst axis ) )
+        }
+        ( vec_push [f] out v )
+        = i + i 1
+    }
+    ( vec_free [i] ost ) ( vec_free [i] ast ) ( vec_free [i] bst )
+    ^ @ ?Tensor { T @ Tensor { rdt oshape out } }
+}
+
+// argmax / argmin along an axis (indices as f64 in an F64 tensor).
+@ __arg_axis Tensor t i axis b want_max b keepdim → Tensor {
+    : i nd ( tensor_ndim t )
+    : ( Vec i ) ist ( __t_strides . t shape )
+    : ( Vec i ) oshape ( vec_new [i] )
+    : ~ i d 0
+    ~ < d nd { ? == d axis { ? keepdim { ( vec_push [i] oshape 1 ) } {} } { ( vec_push [i] oshape ( __ti . t shape d ) ) } = d + d 1 }
+    : i outn ( __t_prod oshape )
+    : ( Vec f ) best ( __fvec_t outn ? want_max { -1.0e308 } { 1.0e308 } )
+    : ( Vec f ) idx ( __fvec_t outn 0.0 )
+    : ( Vec i ) ost ( __t_strides oshape )
+    : i total ( tensor_size t )
+    : ~ i i 0
+    ~ < i total {
+        : ~ i rem i
+        : ~ i oo 0
+        : ~ i od 0
+        : ~ i axc 0
+        : ~ i d2 0
+        ~ < d2 nd {
+            : i sd ( __ti ist d2 )
+            : i c ? > sd 0 { / rem sd } { 0 }
+            = rem ? > sd 0 { % rem sd } { rem }
+            ? == d2 axis { = axc c ? keepdim { = od + od 1 } {} } { = oo + oo * c ( __ti ost od ) = od + od 1 }
+            = d2 + d2 1
+        }
+        : f v ( __tf . t data i )
+        : f cur ( __tf best oo )
+        : b better ? want_max { > v cur } { < v cur }
+        ? better { ( vec_set [f] best oo v ) ( vec_set [f] idx oo # f axc ) } {}
+        = i + i 1
+    }
+    ( vec_free [i] ist ) ( vec_free [i] ost ) ( vec_free [f] best )
+    ^ @ Tensor { TE_F64 oshape idx }
+}
+
+@ tensor_argmax Tensor t i axis b keepdim → Tensor { ^ ( __arg_axis t axis T keepdim ) }
+
+@ tensor_argmin Tensor t i axis b keepdim → Tensor { ^ ( __arg_axis t axis F keepdim ) }

--- a/packages/tensor/tests/tcheck.nu
+++ b/packages/tensor/tests/tcheck.nu
@@ -12,6 +12,17 @@ $ `src/ops.nu`
     : ( Vec i ) v ( vec_new [i] ) ( vec_push [i] v a ) ( vec_push [i] v b ) ^ v
 }
 
+@ sh3 i a i b i c → ( Vec i ) {
+    : ( Vec i ) v ( vec_new [i] ) ( vec_push [i] v a ) ( vec_push [i] v b ) ( vec_push [i] v c ) ^ v
+}
+// consumes t (it is always passed a fresh arange temporary here)
+@ reshape3 Tensor t i a i b i c → Tensor {
+    ?? ( tensor_reshape t ( sh3 a b c ) ) {
+        T r → { ( tensor_free t ) ^ r }
+        F _ → { ^ t }
+    }
+}
+
 @ pt s name Tensor t → v {
     : String s ( string_from name )
     ( string_push_char s 124 )
@@ -85,6 +96,29 @@ $ `src/ops.nu`
     ( pto `perm` ( tensor_permute t3 perm ) )
     ( vec_free [i] perm )
     ( tensor_free t3 )
+
+    // ── M2 ──────────────────────────────────────────────────────────
+    // batched matmul: A(2,2,3) · B(2,3,2) → (2,2,2)
+    : Tensor bmA ( reshape3 ( tensor_arange TE_F64 12 ) 2 2 3 )
+    : Tensor bmB ( reshape3 ( tensor_arange TE_F64 12 ) 2 3 2 )
+    ( pto `bmm` ( tensor_bmm bmA bmB ) )
+    // broadcast batch: A(1,2,3) · B(2,3,2) → (2,2,2)
+    : Tensor bmA1 ( reshape3 ( tensor_arange TE_F64 6 ) 1 2 3 )
+    ( pto `bmm_bc` ( tensor_bmm bmA1 bmB ) )
+    ( tensor_free bmA ) ( tensor_free bmB ) ( tensor_free bmA1 )
+
+    ( ptf `softmax1` ( tensor_softmax a 1 ) )
+
+    : ( Vec i ) sl0 ( sh2 0 1 )
+    : ( Vec i ) sl1 ( sh2 2 3 )
+    ( pto `slice` ( tensor_slice a sl0 sl1 ) )
+    ( vec_free [i] sl0 ) ( vec_free [i] sl1 )
+
+    ( pto `cat0` ( tensor_concat2 a a 0 ) )
+    ( pto `cat1` ( tensor_concat2 a a 1 ) )
+
+    ( ptf `argmax1` ( tensor_argmax a 1 F ) )
+    ( ptf `argmin0` ( tensor_argmin a 0 F ) )
 
     // large matmul to exercise the GPU path (128x128 · 128x128); print its sum
     : Tensor big16k ( tensor_arange TE_F64 16384 )

--- a/packages/tensor/tests/tensor_test.sh
+++ b/packages/tensor/tests/tensor_test.sh
@@ -43,10 +43,16 @@ for ln in open(sys.argv[1]):
              np.array([float(x) for x in d.split(',')]) if d else np.array([]))
 a=np.arange(6.).reshape(2,3); b=np.arange(3.).reshape(1,3); a24=np.arange(24.).reshape(2,3,4)
 big=np.arange(16384.).reshape(128,128)
+bmA=np.arange(12.).reshape(2,2,3); bmB=np.arange(12.).reshape(2,3,2); bmA1=np.arange(6.).reshape(1,2,3)
+def _sm(x,ax):
+    e=np.exp(x-x.max(ax,keepdims=True)); return e/e.sum(ax,keepdims=True)
 exp={"a":a,"add":a+b,"mul":a*a,"aT":a.T,"matmul":a@a.T,"sum0":a.sum(0),"sum1":a.sum(1),
  "sum1k":a.sum(1,keepdims=True),"sumall":np.array(a.sum()),"mean0":a.mean(0),"max1":a.max(1),
  "min0":a.min(0),"relu":np.maximum(a-2.5,0),"exp":np.exp(a*0.1),"sig":1/(1+np.exp(-(a-2.0))),
- "perm":np.transpose(a24,(2,0,1)),"bigmm_sum":np.array((big@big).sum())}
+ "perm":np.transpose(a24,(2,0,1)),"bigmm_sum":np.array((big@big).sum()),
+ "bmm":bmA@bmB,"bmm_bc":bmA1@bmB,"softmax1":_sm(a,1),"slice":a[0:2,1:3],
+ "cat0":np.concatenate([a,a],0),"cat1":np.concatenate([a,a],1),
+ "argmax1":a.argmax(1).astype(float),"argmin0":a.argmin(0).astype(float)}
 fails=0
 for n,(shp,dat) in rows.items():
     if n not in exp: print(f"  FAIL {n}: no reference"); fails+=1; continue


### PR DESCRIPTION
## tensor 0.2.0 — M2

Second milestone on the ndarray core. All ops compute in f64 (F32 tensors round to grid) and reuse the existing broadcasting / reduction machinery.

| Op | Signature | Notes |
| --- | --- | --- |
| `tensor_bmm` | `a b → ?Tensor` | N-D batched matmul; last two dims are the matrix, leading batch dims broadcast (numpy rule) |
| `tensor_softmax` | `t axis → Tensor` | numerically stable (subtracts axis max) |
| `tensor_slice` | `t starts stops → ?Tensor` | per-dim half-open `[start, stop)` |
| `tensor_concat2` | `a b axis → ?Tensor` | concat along an axis, other dims must match |
| `tensor_argmax` / `tensor_argmin` | `t axis keepdim → Tensor` | index (as f64) along an axis |

### Verification
`./tests/tensor_test.sh` — every op checked against numpy (incl. batch broadcasting) and re-run under AddressSanitizer: **25 / 25, ASan-clean.**

Bumps `tensor` to 0.2.0, adds `CHANGELOG.md`, updates README API/roadmap and the numpy test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)