### PR TITLE
feat(image): diamond close-out — libjpeg-exact fancy upsampling + objdet/yoloe wired on

### DIFF
--- a/packages/image/CHANGELOG.md
+++ b/packages/image/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.4.0
+
+- **libjpeg-exact "fancy" chroma upsampling** — 2x1/2x2 expansion now uses
+  libjpeg's default triangular filter (bit-matching jdsample.c, including
+  the 1/2 and 8/7 rounding biases and edge clamping); other ratios keep box,
+  as libjpeg does. 4:2:0 decode drops to IDCT-rounding distance from Pillow
+  (synthetic max_diff 3, tolerance tightened 12 → 4; real photos max 3,
+  mean ≈ 0.02). Both baseline and progressive decode benefit.
+- **Consumers wired**: objdet 0.3.0 and yoloe 0.5.0 now decode/encode
+  through this package (their private PPM/resize/draw copies are deleted) —
+  both proven equivalent bit-for-bit on their preprocessing tensors, and
+  yoloe verified live on GPU reading a JPEG and writing a mask-overlay PNG.
+
 ## 0.3.0
 
 The "diamond" release: real-world coverage on every axis.

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -102,9 +102,11 @@ colour keys add an alpha channel), all five scanline filters. Encode:
 **JPEG decode** — 8-bit Huffman, greyscale or YCbCr, any 4:4:4 / 4:2:2 /
 4:2:0 / 4:1:1 subsampling, restart intervals, sequential (SOF0/SOF1) and
 **progressive** (SOF2: spectral selection + successive approximation, the
-format most web JPEGs use). Decode matches libjpeg/Pillow to within
-IDCT/upsampling rounding; progressive output is bit-identical to the
-baseline decode of the same content. **Encode** — baseline JFIF, Annex K
+format most web JPEGs use). Chroma upsampling is libjpeg's default "fancy"
+(triangular) filter, bit-matching jdsample.c for 2x1/2x2 expansion, so
+decode matches libjpeg/Pillow to within IDCT rounding even at 4:2:0;
+progressive output is bit-identical to the baseline decode of the same
+content. **Encode** — baseline JFIF, Annex K
 tables, libjpeg-style quality 1–100, 4:4:4 / 4:2:2 / 4:2:0; loss profile
 matches Pillow's encoder on the same content.
 
@@ -131,9 +133,13 @@ pixel-exact, JPEG decode within tolerance (baseline + progressive), JPEG
 encode re-decoded by Pillow, CLI smoke tests, the fuzz sweeps, and an ASan
 pass over everything. Skips the reference parts cleanly without Pillow.
 
+## Consumers
+
+[`objdet`](../objdet) and [`yoloe`](../yoloe) decode photos and encode
+annotated output through this package (their private PPM/resize/draw
+copies are gone); [`chart`](../chart) is terminal-only and needs no raster.
+
 ## Roadmap
 
-- Wire objdet / yoloe / chart to `image_load` and delete their private
-  PPM/resize/draw copies.
-- "Fancy" (triangle) chroma upsampling for closer 4:2:0 parity; optional
-  PNG adaptive filtering for smaller encodes.
+- Optional PNG adaptive filtering for smaller encodes; fancier resampling
+  (Lanczos) if a consumer needs it.

--- a/packages/image/nurl.toml
+++ b/packages/image/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.3.0"
+version = "0.4.0"
 description = "Pure-NURL image codecs + raster ops — decode, encode and transform images with no native library and no ImageMagick/ffmpeg shell-out. PNG decode covers the complete still-image matrix: bit depths 1/2/4/8/16, grey/RGB/palette/grey+alpha/RGBA, Adam7 interlacing, tRNS transparency (palette alpha and colour keys), all five scanline filters; png_encode writes lossless 8-bit PNGs. JPEG decode handles both baseline (SOF0/SOF1) and PROGRESSIVE (SOF2) Huffman JPEGs — any 4:4:4/4:2:2/4:2:0/4:1:1 subsampling, restart intervals, spectral selection + successive approximation — matching libjpeg to within IDCT rounding; jpeg_encode writes baseline JFIF at quality 1-100 (4:4:4/4:2:2/4:2:0, Annex K tables, loss profile matches Pillow's encoder). PPM (P5/P6) both ways. ops.nu has the raster toolkit every vision pipeline hand-rolls: bilinear/box/nearest resize, crop, flips, rotations, channel conversion (BT.601), fill/rect/line drawing, alpha blit, packed 0xRRGGBBAA pixel access — all clipped and bounds-checked. image_load/image_decode sniff the format; image_error says why a decode failed. Ships an img CLI (info/convert/resize with keep-aspect specs). Fuzz-hardened under ASan: truncation/mutation sweeps across all decoders, dimension caps, no OOB/hang/leak — malformed input is a clean None, never a crash. The front door for objdet, yoloe and chart."
 license = "MIT OR Apache-2.0"
 

--- a/packages/image/src/jpeg.nu
+++ b/packages/image/src/jpeg.nu
@@ -5,9 +5,11 @@
 // 4:1:1 subsampling, restart intervals (DRI/RSTn), sequential (SOF0/SOF1)
 // and **progressive** (SOF2) frames — spectral selection and successive
 // approximation, DC and AC first/refinement scans, EOB runs. Chroma planes
-// are box-upsampled and a separable float IDCT is used, so output matches a
-// reference decoder (libjpeg) to within IDCT/upsampling rounding — JPEG is
-// lossy and the spec permits IDCT variation, so this is not bit-exact.
+// use libjpeg's "fancy" (triangular) upsampling for 2x1/2x2 expansion —
+// bit-matching libjpeg's default path — and a separable float IDCT, so
+// output matches a reference decoder (libjpeg/Pillow) to within IDCT
+// rounding — JPEG is lossy and the spec permits IDCT variation, so this is
+// not bit-exact.
 //
 // Not supported (clean None, never an out-of-bounds read): arithmetic
 // coding, 12-bit, lossless/hierarchical, and 4-component (CMYK/YCCK).
@@ -17,20 +19,20 @@ $ `stdlib/std/float.nu`
 $ `core.nu`
 
 : Jpeg {
-    ( Vec u ) buf   i len
-    i width  i height  i ncomp
-    ( Vec i ) cid  ( Vec i ) chf  ( Vec i ) cvf  ( Vec i ) ctq  ( Vec i ) ctd  ( Vec i ) cta  ( Vec i ) cpred
-    i hmax  i vmax  i restart
+    ( Vec u ) buf i len
+    i width i height i ncomp
+    ( Vec i ) cid ( Vec i ) chf ( Vec i ) cvf ( Vec i ) ctq ( Vec i ) ctd ( Vec i ) cta ( Vec i ) cpred
+    i hmax i vmax i restart
     ( Vec i ) qt
-    ( Vec i ) hmin  ( Vec i ) hmaxc  ( Vec i ) hptr  ( Vec i ) hvals
-    ( Vec f ) idct_a  ( Vec i ) zz
-    i bpos  i bbuf  i bcnt  i marker
+    ( Vec i ) hmin ( Vec i ) hmaxc ( Vec i ) hptr ( Vec i ) hvals
+    ( Vec f ) idct_a ( Vec i ) zz
+    i bpos i bbuf i bcnt i marker
     b ok
     // progressive state: scan parameters, per-component coefficient grids
-    b prog  i ss  i se  i ah  i al  i eobrun
-    i nscomp  ( Vec i ) scomp
+    b prog i ss i se i ah i al i eobrun
+    i nscomp ( Vec i ) scomp
     ( Vec ( Vec i ) ) coefs
-    ( Vec i ) cbw  ( Vec i ) cbh          // padded block-grid dims per comp
+    ( Vec i ) cbw ( Vec i ) cbh  // padded block-grid dims per comp
 }
 
 @ __ivec i n i fill → ( Vec i ) {
@@ -52,6 +54,7 @@ $ `core.nu`
     ( vec_push [f] a 0.19509032201612833 ) ( vec_push [f] a -0.55557023301960218 ) ( vec_push [f] a 0.83146961230254546 ) ( vec_push [f] a -0.98078528040323065 ) ( vec_push [f] a 0.98078528040323043 ) ( vec_push [f] a -0.83146961230254501 ) ( vec_push [f] a 0.55557023301960151 ) ( vec_push [f] a -0.19509032201612858 )
     ^ a
 }
+
 @ __zigzag → ( Vec i ) {
     : ( Vec i ) z ( vec_with_cap [i] 64 )
     ( vec_push [i] z 0 ) ( vec_push [i] z 1 ) ( vec_push [i] z 8 ) ( vec_push [i] z 16 ) ( vec_push [i] z 9 ) ( vec_push [i] z 2 ) ( vec_push [i] z 3 ) ( vec_push [i] z 10 )
@@ -101,7 +104,7 @@ $ `core.nu`
     ^ j
 }
 
-@ __jp_free *Jpeg j → v {
+@ __jp_free * Jpeg j → v {
     ( vec_free [i] . j cid ) ( vec_free [i] . j chf ) ( vec_free [i] . j cvf )
     ( vec_free [i] . j ctq ) ( vec_free [i] . j ctd ) ( vec_free [i] . j cta )
     ( vec_free [i] . j cpred ) ( vec_free [i] . j qt )
@@ -122,7 +125,7 @@ $ `core.nu`
 @ __u16 ( Vec u ) buf i p → i { ^ + * ( __b buf p ) 256 ( __b buf + p 1 ) }
 
 // ── Entropy bit reader (handles 0xFF00 stuffing; stops at a marker) ────
-@ __jp_bit *Jpeg j → i {
+@ __jp_bit * Jpeg j → i {
     ? > . j bcnt 0 {} {
         : i p . j bpos
         ? >= p . j len { = . j marker 217 ^ 0 } {}
@@ -146,19 +149,20 @@ $ `core.nu`
     ^ & >> . j bbuf . j bcnt 1
 }
 
-@ __jp_receive *Jpeg j i n → i {
+@ __jp_receive * Jpeg j i n → i {
     : ~ i v 0
     : ~ i k 0
     ~ < k n { = v | << v 1 ( __jp_bit j ) = k + k 1 }
     ^ v
 }
+
 @ __jp_extend i v i n → i {
     ? == n 0 { ^ 0 } {}
     ? < v << 1 - n 1 { ^ - v - << 1 n 1 } { ^ v }
 }
 
 // Decode one Huffman symbol from table `t` (0..7 = 4 DC then 4 AC).
-@ __jp_huff *Jpeg j i t → i {
+@ __jp_huff * Jpeg j i t → i {
     : i base * t 17
     : ~ i code ( __jp_bit j )
     : ~ i len 1
@@ -177,14 +181,14 @@ $ `core.nu`
 }
 
 // ── Decode + dequantize one 8×8 block into `blk` (natural order) ──────
-@ __jp_block *Jpeg j i comp ( Vec i ) blk → v {
+@ __jp_block * Jpeg j i comp ( Vec i ) blk → v {
     : ~ i k 0
     ~ < k 64 { ( vec_set [i] blk k 0 ) = k + k 1 }
     : i tq * ( __b_i . j ctq comp ) 64
     : i td ( __b_i . j ctd comp )
     : i ta + 4 ( __b_i . j cta comp )
     : i s ( __jp_huff j td )
-    ? < s 0 { = . j ok F ^ } {}          // corrupt Huffman table/stream
+    ? < s 0 { = . j ok F ^ } {}  // corrupt Huffman table/stream
     : i diff ? > s 0 { ( __jp_extend ( __jp_receive j s ) s ) } { 0 }
     : i pred + ( __b_i . j cpred comp ) diff
     ( vec_set [i] . j cpred comp pred )
@@ -209,7 +213,7 @@ $ `core.nu`
 }
 
 // ── Separable float IDCT: blk (natural) → out (8×8 row-major, 0..255) ──
-@ __jp_idct *Jpeg j ( Vec i ) blk ( Vec f ) tmp ( Vec i ) out i ox i oy i pw → v {
+@ __jp_idct * Jpeg j ( Vec i ) blk ( Vec f ) tmp ( Vec i ) out i ox i oy i pw → v {
     : ( Vec f ) A . j idct_a
     // rows: tmp[y*8+x] = 0.5 * Σ_u A[u*8+x] blk[y*8+u]
     : ~ i y 0
@@ -242,12 +246,13 @@ $ `core.nu`
         = x2 + x2 1
     }
 }
+
 @ __b_f ( Vec f ) v i p → f {
     ?? ( vec_get [f] v p ) { T x → { ^ x } F _ → { ^ 0.0 } }
 }
 
 // Reset at a restart marker: drop partial bits, skip FFDn, clear predictors.
-@ __jp_restart *Jpeg j → v {
+@ __jp_restart * Jpeg j → v {
     = . j bcnt 0
     = . j marker 0
     : i p . j bpos
@@ -260,7 +265,7 @@ $ `core.nu`
 
 // ── Segment parsers ───────────────────────────────────────────────────
 
-@ __jp_dqt *Jpeg j i dp i dend → v {
+@ __jp_dqt * Jpeg j i dp i dend → v {
     : ~ i p dp
     ~ < p dend {
         : i pqtq ( __b . j buf p )
@@ -277,7 +282,7 @@ $ `core.nu`
     }
 }
 
-@ __jp_dht *Jpeg j i dp i dend → v {
+@ __jp_dht * Jpeg j i dp i dend → v {
     : ~ i p dp
     ~ < p dend {
         : i tcth ( __b . j buf p )
@@ -323,12 +328,12 @@ $ `core.nu`
     }
 }
 
-@ __jp_sof *Jpeg j i dp → b {
+@ __jp_sof * Jpeg j i dp → b {
     ? == ( __b . j buf dp ) 8 {} { ^ F }
     = . j height ( __u16 . j buf + dp 1 )
     = . j width ( __u16 . j buf + dp 3 )
     ? & > . j width 0 > . j height 0 {} { ^ F }
-    ? <= * . j width . j height 67108864 {} { ^ F }           // ≤ 64 Mpx
+    ? <= * . j width . j height 67108864 {} { ^ F }  // ≤ 64 Mpx
     : i nc ( __b . j buf + dp 5 )
     ? || == nc 1 == nc 3 {} { ^ F }
     = . j ncomp nc
@@ -341,7 +346,7 @@ $ `core.nu`
         : i hv ( __b . j buf + o 1 )
         : i h >> hv 4
         : i vv & hv 15
-        ? & & >= h 1 <= h 4 & >= vv 1 <= vv 4 {} { ^ F }      // T.81 sampling range
+        ? & & >= h 1 <= h 4 & >= vv 1 <= vv 4 {} { ^ F }  // T.81 sampling range
         ( vec_set [i] . j chf c h )
         ( vec_set [i] . j cvf c vv )
         : i tq ( __b . j buf + o 2 )
@@ -356,7 +361,7 @@ $ `core.nu`
     ^ T
 }
 
-@ __jp_sos *Jpeg j i dp → v {
+@ __jp_sos * Jpeg j i dp → v {
     : ~ i ns ( __b . j buf dp )
     ? || < ns 1 > ns 4 { = ns 1 } {}
     = . j nscomp ns
@@ -400,7 +405,7 @@ $ `core.nu`
 // the IDCT once, after the last scan.
 
 // Allocate the per-component coefficient grids (padded to the MCU grid).
-@ __jp_prog_alloc *Jpeg j → v {
+@ __jp_prog_alloc * Jpeg j → v {
     : i mcux / + . j width - * . j hmax 8 1 * . j hmax 8
     : i mcuy / + . j height - * . j vmax 8 1 * . j vmax 8
     : ~ i c 0
@@ -414,14 +419,14 @@ $ `core.nu`
     }
 }
 
-@ __jp_prog_restart *Jpeg j → v {
+@ __jp_prog_restart * Jpeg j → v {
     ( __jp_restart j )
     = . j eobrun 0
 }
 
 // DC scan, one block. First pass (Ah=0) decodes the diff at reduced
 // precision; refinement passes append one magnitude bit.
-@ __jp_prog_dc *Jpeg j i ci ( Vec i ) cf i bidx → v {
+@ __jp_prog_dc * Jpeg j i ci ( Vec i ) cf i bidx → v {
     : i base * bidx 64
     ? == . j ah 0 {
         : i td ( __b_i . j ctd ci )
@@ -439,7 +444,7 @@ $ `core.nu`
 }
 
 // AC scan, first pass (Ah=0): run-length + size symbols with EOB runs.
-@ __jp_prog_ac1 *Jpeg j i ci ( Vec i ) cf i bidx → v {
+@ __jp_prog_ac1 * Jpeg j i ci ( Vec i ) cf i bidx → v {
     : i base * bidx 64
     ? > . j eobrun 0 { = . j eobrun - . j eobrun 1 ^ } {}
     : i ta + 4 ( __b_i . j cta ci )
@@ -470,7 +475,7 @@ $ `core.nu`
 }
 
 // One correction bit for an already-nonzero coefficient.
-@ __jp_prog_fix *Jpeg j ( Vec i ) cf i pos i bit → v {
+@ __jp_prog_fix * Jpeg j ( Vec i ) cf i pos i bit → v {
     : i cur ( __b_i cf pos )
     ? == ( __jp_bit j ) 1 {
         ? == & cur bit 0 {
@@ -481,7 +486,7 @@ $ `core.nu`
 
 // AC scan, refinement pass (Ah>0): new coefficients arrive as ±1<<Al and
 // every already-nonzero coefficient on the way gets a correction bit.
-@ __jp_prog_ac2 *Jpeg j i ci ( Vec i ) cf i bidx → v {
+@ __jp_prog_ac2 * Jpeg j i ci ( Vec i ) cf i bidx → v {
     : i base * bidx 64
     : i bit << 1 . j al
     ? > . j eobrun 0 {
@@ -506,7 +511,7 @@ $ `core.nu`
                 : ~ i er - << 1 r 1
                 ? > r 0 { = er + er ( __jp_receive j r ) } {}
                 = . j eobrun er
-                = r 64                      // walk out the rest of the block
+                = r 64  // walk out the rest of the block
             } {}
         } {
             = s ? == ( __jp_bit j ) 1 { bit } { - 0 bit }
@@ -526,7 +531,7 @@ $ `core.nu`
 }
 
 // Route one block to the right scan kind.
-@ __jp_prog_block *Jpeg j i ci ( Vec i ) cf i bidx → v {
+@ __jp_prog_block * Jpeg j i ci ( Vec i ) cf i bidx → v {
     ? == . j ss 0 { ( __jp_prog_dc j ci cf bidx ) } {
         ? == . j ah 0 { ( __jp_prog_ac1 j ci cf bidx ) } { ( __jp_prog_ac2 j ci cf bidx ) }
     }
@@ -534,7 +539,7 @@ $ `core.nu`
 
 // Run one progressive scan: interleaved (ns>1, MCU order) or single
 // component (its own unpadded block raster).
-@ __jp_prog_scan *Jpeg j → v {
+@ __jp_prog_scan * Jpeg j → v {
     : i ns . j nscomp
     ? == ns 1 {
         : i ci ( __b_i . j scomp 0 )
@@ -601,7 +606,7 @@ $ `core.nu`
 
 // After the last scan: dequantise + IDCT every block, then share the
 // baseline upsample/colour-convert tail.
-@ __jp_prog_finish *Jpeg j → ?Image {
+@ __jp_prog_finish * Jpeg j → ?Image {
     ? & & > . j width 0 > . j height 0 & > . j hmax 0 > . j vmax 0 {} { ^ @ ?Image { F } }
     : i nc . j ncomp
     : ( Vec ( Vec i ) ) planes ( vec_new [( Vec i )] )
@@ -649,7 +654,7 @@ $ `core.nu`
 
 // Walk all segments. Sequential (SOF0/SOF1) frames decode at their single
 // SOS; progressive (SOF2) frames accumulate scans until EOI, then finish.
-@ __jp_run *Jpeg j → ?Image {
+@ __jp_run * Jpeg j → ?Image {
     : ~ i p 2
     : i n . j len
     : ~ b sof F
@@ -660,59 +665,59 @@ $ `core.nu`
         ? going {
             : i m ( __b . j buf + p 1 )
             ? == m 255 { = p + p 1 } {
-            ? || == m 1 & >= m 208 <= m 215 { = p + p 2 } {      // TEM / stray RSTn
-            ? == m 216 { = p + p 2 } {                           // stray SOI
-            ? == m 217 { = going F } {                           // EOI
-                ? < + p 4 n {} { = . j ok F = going F }
-                ? going {
-                    : i seg + p 2
-                    : i slen ( __u16 . j buf seg )
-                    : i dp + seg 2
-                    : i dend + seg slen
-                    ? || < slen 2 > dend n { = . j ok F = going F } {
-                        : ~ i np dend
-                        ? == m 219 { ( __jp_dqt j dp dend ) } {
-                        ? == m 196 { ( __jp_dht j dp dend ) } {
-                        ? == m 221 { = . j restart ( __u16 . j buf dp ) } {
-                        ? || == m 192 == m 193 {
-                            ? || sof ! ( __jp_sof j dp ) {
-                                ( __img_set_err `JPEG: unsupported frame (precision, size, components or sampling)` )
-                                = . j ok F
-                            } { = sof T = . j prog F }
-                        } {
-                        ? == m 194 {
-                            ? || sof ! ( __jp_sof j dp ) {
-                                ( __img_set_err `JPEG: unsupported frame (precision, size, components or sampling)` )
-                                = . j ok F
-                            } {
-                                = sof T
-                                = . j prog T
-                                ( __jp_prog_alloc j )
-                            }
-                        } {
-                        ? & >= m 195 <= m 207 {
-                            ? == m 204 {} {
-                                ( __img_set_err `JPEG: unsupported coding (arithmetic, 12-bit or lossless)` )
-                                = . j ok F
-                            }
-                        } {
-                        ? == m 218 {
-                            ? sof {} { = . j ok F }
-                            ? . j ok {
-                                ( __jp_sos j dp )
-                                ? . j prog {
-                                    ( __jp_prog_scan j )
-                                    = sawscan T
-                                    = np . j bpos
-                                } {
-                                    ^ ( __jp_scan j )
+                ? || == m 1 & >= m 208 <= m 215 { = p + p 2 } {  // TEM / stray RSTn
+                    ? == m 216 { = p + p 2 } {  // stray SOI
+                        ? == m 217 { = going F } {  // EOI
+                            ? < + p 4 n {} { = . j ok F = going F }
+                            ? going {
+                                : i seg + p 2
+                                : i slen ( __u16 . j buf seg )
+                                : i dp + seg 2
+                                : i dend + seg slen
+                                ? || < slen 2 > dend n { = . j ok F = going F } {
+                                    : ~ i np dend
+                                    ? == m 219 { ( __jp_dqt j dp dend ) } {
+                                        ? == m 196 { ( __jp_dht j dp dend ) } {
+                                            ? == m 221 { = . j restart ( __u16 . j buf dp ) } {
+                                                ? || == m 192 == m 193 {
+                                                    ? || sof ! ( __jp_sof j dp ) {
+                                                        ( __img_set_err `JPEG: unsupported frame (precision, size, components or sampling)` )
+                                                        = . j ok F
+                                                    } { = sof T = . j prog F }
+                                                } {
+                                                    ? == m 194 {
+                                                        ? || sof ! ( __jp_sof j dp ) {
+                                                            ( __img_set_err `JPEG: unsupported frame (precision, size, components or sampling)` )
+                                                            = . j ok F
+                                                        } {
+                                                            = sof T
+                                                            = . j prog T
+                                                            ( __jp_prog_alloc j )
+                                                        }
+                                                    } {
+                                                        ? & >= m 195 <= m 207 {
+                                                            ? == m 204 {} {
+                                                                ( __img_set_err `JPEG: unsupported coding (arithmetic, 12-bit or lossless)` )
+                                                                = . j ok F
+                                                            }
+                                                        } {
+                                                            ? == m 218 {
+                                                                ? sof {} { = . j ok F }
+                                                                ? . j ok {
+                                                                    ( __jp_sos j dp )
+                                                                    ? . j prog {
+                                                                        ( __jp_prog_scan j )
+                                                                        = sawscan T
+                                                                        = np . j bpos
+                                                                    } {
+                                                                        ^ ( __jp_scan j )
+                                                                    }
+                                                                } {}
+                                                            } {} } } } } } }
+                                    = p np
                                 }
                             } {}
-                        } {} } } } } } }
-                        = p np
-                    }
-                } {}
-            } } } }
+                        } } } }
         } {}
     }
     ? & & . j ok . j prog sawscan { ^ ( __jp_prog_finish j ) } {}
@@ -721,13 +726,55 @@ $ `core.nu`
 
 // ── Scan: decode MCUs into per-component planes, upsample, colour-convert.
 
-@ __jp_sample ( Vec i ) plane i pw i hf i vf i hmax i vmax i x i y → i {
+// Clamped component-plane read (sample coordinates; cw/ch are the REAL
+// sample dimensions of the component — the plane is padded to the MCU grid
+// and the padding must never be read).
+@ __jp_pat ( Vec i ) p i pw i cw i ch i sx i sy → i {
+    : i xx ? < sx 0 { 0 } { ? < sx cw { sx } { - cw 1 } }
+    : i yy ? < sy 0 { 0 } { ? < sy ch { sy } { - ch 1 } }
+    ^ ( __b_i p + * yy pw xx )
+}
+
+// One full-resolution sample of a (possibly subsampled) component plane.
+// Matches libjpeg's DEFAULT upsamplers exactly (do_fancy_upsampling=TRUE,
+// what Pillow uses): direct read for 1:1; the triangular "fancy" filter for
+// 2x1 and 2x2 expansion — out = (3*near + far + bias) with edge clamping,
+// biases 1/2 (h2v1, >>2) and 8/7 (h2v2, >>4 on 3:1 column sums); plain box
+// for any other ratio and for tiny components (cw <= 2), as libjpeg does.
+@ __jp_sample ( Vec i ) plane i pw i cw i ch i hf i vf i hmax i vmax i x i y → i {
+    ? & == hf hmax == vf vmax { ^ ( __b_i plane + * y pw x ) } {}
+    ? & & == * hf 2 hmax > cw 2 == vf vmax {
+        // h2v1 fancy: (3*near + far + 1|2) >> 2
+        : i sx / x 2
+        : i px & x 1
+        : i dx ? == px 0 { -1 } { 1 }
+        : i near ( __jp_pat plane pw cw ch sx y )
+        : i far ( __jp_pat plane pw cw ch + sx dx y )
+        : i bias ? == px 0 { 1 } { 2 }
+        ^ >> + + * 3 near far bias 2
+    } {}
+    ? & & == * hf 2 hmax > cw 2 == * vf 2 vmax {
+        // h2v2 fancy: colsum = 3*near_row + far_row, then (3*cs + cs_far + 8|7) >> 4
+        : i sx / x 2
+        : i px & x 1
+        : i dx ? == px 0 { -1 } { 1 }
+        : i sy / y 2
+        : i py & y 1
+        : i dy ? == py 0 { -1 } { 1 }
+        : i syf + sy dy
+        : i sxf + sx dx
+        : i cs0 + * 3 ( __jp_pat plane pw cw ch sx sy ) ( __jp_pat plane pw cw ch sx syf )
+        : i cs1 + * 3 ( __jp_pat plane pw cw ch sxf sy ) ( __jp_pat plane pw cw ch sxf syf )
+        : i bias ? == px 0 { 8 } { 7 }
+        ^ >> + + * 3 cs0 cs1 bias 4
+    } {}
+    // box upsample (non-2x or fractional ratios)
     : i sx / * x hf hmax
     : i sy / * y vf vmax
     ^ ( __b_i plane + * sy pw sx )
 }
 
-@ __jp_scan *Jpeg j → ?Image {
+@ __jp_scan * Jpeg j → ?Image {
     : i W . j width
     : i H . j height
     : i hmax . j hmax
@@ -793,7 +840,7 @@ $ `core.nu`
 
 // Shared tail: per-component planes (padded to the MCU grid) → upsampled,
 // colour-converted Image. Frees `planes`.
-@ __jp_to_image *Jpeg j ( Vec ( Vec i ) ) planes → ?Image {
+@ __jp_to_image * Jpeg j ( Vec ( Vec i ) ) planes → ?Image {
     : i W . j width
     : i H . j height
     : i hmax . j hmax
@@ -804,7 +851,21 @@ $ `core.nu`
     : ( Vec u ) out ( vec_with_cap [u] * * W H outch )
     ?? ( vec_get [( Vec i )] planes 0 ) {
         T p0 → {
-            : i pw0 * * mcux ( __b_i . j chf 0 ) 8
+            : i hf0 ( __b_i . j chf 0 )
+            : i vf0 ( __b_i . j cvf 0 )
+            : i pw0 * * mcux hf0 8
+            : i cw0 / + * W hf0 - hmax 1 hmax
+            : i ch0 / + * H vf0 - vmax 1 vmax
+            : i hf1 ( __b_i . j chf 1 )
+            : i vf1 ( __b_i . j cvf 1 )
+            : i pw1 * * mcux hf1 8
+            : i cw1 / + * W hf1 - hmax 1 hmax
+            : i ch1 / + * H vf1 - vmax 1 vmax
+            : i hf2 ( __b_i . j chf 2 )
+            : i vf2 ( __b_i . j cvf 2 )
+            : i pw2 * * mcux hf2 8
+            : i cw2 / + * W hf2 - hmax 1 hmax
+            : i ch2 / + * H vf2 - vmax 1 vmax
             : ~ i y 0
             ~ < y H {
                 : ~ i x 0
@@ -812,15 +873,15 @@ $ `core.nu`
                     ? == nc 1 {
                         ( vec_push [u] out & ( __b_i p0 + * y pw0 x ) 255 )
                     } {
-                        : i Y ( __jp_sample p0 pw0 ( __b_i . j chf 0 ) ( __b_i . j cvf 0 ) hmax vmax x y )
+                        : i Y ( __jp_sample p0 pw0 cw0 ch0 hf0 vf0 hmax vmax x y )
                         : ~ i Cb 128
                         : ~ i Cr 128
                         ?? ( vec_get [( Vec i )] planes 1 ) {
-                            T p1 → { = Cb ( __jp_sample p1 * * mcux ( __b_i . j chf 1 ) 8 ( __b_i . j chf 1 ) ( __b_i . j cvf 1 ) hmax vmax x y ) }
+                            T p1 → { = Cb ( __jp_sample p1 pw1 cw1 ch1 hf1 vf1 hmax vmax x y ) }
                             F _ → {}
                         }
                         ?? ( vec_get [( Vec i )] planes 2 ) {
-                            T p2 → { = Cr ( __jp_sample p2 * * mcux ( __b_i . j chf 2 ) 8 ( __b_i . j chf 2 ) ( __b_i . j cvf 2 ) hmax vmax x y ) }
+                            T p2 → { = Cr ( __jp_sample p2 pw2 cw2 ch2 hf2 vf2 hmax vmax x y ) }
                             F _ → {}
                         }
                         : f cbf # f - Cb 128

--- a/packages/image/tests/image_test.sh
+++ b/packages/image/tests/image_test.sh
@@ -121,8 +121,9 @@ done
 python3 - "$WORK" <<'PY'
 import sys, numpy as np; from PIL import Image
 W=sys.argv[1]; f=0
-# (name, max-abs-diff tolerance) — 4:4:4/grey = IDCT rounding, 4:2:0 = box upsample
-for n,tol in (("j444",3),("j420",12),("jgray",3),("p444",3),("p420",12),("pgray",3),("pnoise",3)):
+# (name, max-abs-diff tolerance) — IDCT rounding only: chroma upsampling is
+# libjpeg-identical "fancy" (triangular), so 4:2:0 is nearly as tight as 4:4:4
+for n,tol in (("j444",3),("j420",4),("jgray",3),("p444",3),("p420",4),("pgray",3),("pnoise",3)):
     ref=np.asarray(Image.open(f"{W}/{n}.jpg").convert("RGB"),dtype=int)
     ours=np.asarray(Image.open(f"{W}/{n}.out.ppm").convert("RGB"),dtype=int)
     if ref.shape!=ours.shape: print(f"  FAIL {n}: shape {ref.shape} vs {ours.shape}"); f+=1; continue
@@ -156,7 +157,7 @@ python3 - "$WORK" <<'PY'
 import sys, numpy as np; from PIL import Image
 W=sys.argv[1]; f=0
 src=np.asarray(Image.open(f"{W}/grad.png").convert("RGB"),dtype=int)
-for n,tol in (("e444",6),("e420",12),("e422",12)):
+for n,tol in (("e444",6),("e420",8),("e422",8)):
     im=Image.open(f"{W}/{n}.jpg"); im.load()
     d=int(np.abs(np.asarray(im.convert("RGB"),dtype=int)-src).max())
     ok=d<=tol

--- a/packages/objdet/README.md
+++ b/packages/objdet/README.md
@@ -1,22 +1,24 @@
 # objdet — object detection from pure NURL, on the GPU
 
 Detect objects in an image or video feed using a tiny-YOLOv2-style **ONNX**
-model — written entirely in NURL. The image is read (PPM), the network runs
-on the **GPU** through [`packages/onnx`](../onnx) (every layer a CUDA-C
-kernel compiled at runtime via NVRTC — no external inference engine), and
-the YOLO grid is decoded into labelled boxes with non-max suppression.
+model — written entirely in NURL. The image is decoded natively through
+[`packages/image`](../image) (PNG, baseline+progressive JPEG, PPM — no
+ImageMagick), the network runs on the **GPU** through
+[`packages/onnx`](../onnx) (every layer a CUDA-C kernel compiled at runtime
+via NVRTC — no external inference engine), and the YOLO grid is decoded into
+labelled boxes with non-max suppression.
 
 Verified against **onnxruntime** on the ONNX model-zoo `tinyyolov2-8.onnx`:
 identical class scores and boxes.
 
 ```
-$ objdet tinyyolov2-8.onnx dog.ppm out.ppm
+$ objdet tinyyolov2-8.onnx dog.jpg out.png
 device: NVIDIA GeForce RTX 4090
 image 416x416
 detections:
   dog 0.764437  box[x=55 y=161 w=129 h=220]
   car 0.763744  box[x=240 y=66 w=133 h=68]
-wrote out.ppm
+wrote out.png
 ```
 
 ![annotated output: a dog and a car, each in a red box](docs/out.png)
@@ -24,18 +26,17 @@ wrote out.ppm
 ## Usage
 
 ```
-objdet <model.onnx> <image.ppm> [out.ppm]              # single image
-objdet <model.onnx> --video <in_dir> <out_dir> <count> # frame sequence
+objdet <model.onnx> <image.{png,jpg,ppm}> [out.{png,jpg,ppm}] # single image
+objdet <model.onnx> --video <in_dir> <out_dir> <count>        # frame sequence
 ```
 
-`in_dir`/`out_dir` hold `frame00000.ppm`, `frame00001.ppm`, … The video
-mode reuses one GPU engine (kernels compiled once) across all frames.
-
-Images are **binary PPM (P6)**. Convert anything with `ffmpeg`/ImageMagick:
+Stills are decoded and encoded natively (PNG / JPEG / PPM, by extension) —
+feed it a photo straight from a camera. `in_dir`/`out_dir` hold
+`frame00000.ppm`, `frame00001.ppm`, … The video mode reuses one GPU engine
+(kernels compiled once) across all frames; use ffmpeg for the container:
 
 ```
-convert photo.jpg photo.ppm
-objdet tinyyolov2-8.onnx photo.ppm out.ppm
+objdet tinyyolov2-8.onnx photo.jpg out.png
 
 ffmpeg -i clip.mp4 -vf fps=10 in/frame%05d.ppm     # video → frames
 objdet tinyyolov2-8.onnx --video in out $(ls in | wc -l)

--- a/packages/objdet/nurl.toml
+++ b/packages/objdet/nurl.toml
@@ -1,8 +1,9 @@
 [package]
 name = "objdet"
-version = "0.2.1"
-description = "Object detection from pure NURL, GPU-accelerated, using any tiny-YOLOv2-style ONNX model. Reads an image or a sequence of video frames (binary PPM), runs the detector on the GPU through the onnx package (every Conv/BatchNorm/MaxPool/LeakyRelu kernel compiled to PTX at runtime via NVRTC, no external inference engine), decodes the YOLO grid into labelled boxes (anchors, sigmoid/softmax, non-max suppression), prints the detections, and writes an annotated image. Verified against onnxruntime on the ONNX model-zoo tinyyolov2-8.onnx: identical class scores and boxes (dog 0.76, car 0.76 on the classic dog photo). Pure NURL end to end — protobuf parsing, the CNN, image I/O, decoding, and drawing; the only native dependency (the CUDA driver + NVRTC) lives in the gpu package, so a GPU-less host is unaffected. ffmpeg/ImageMagick convert to/from PPM for arbitrary formats and video."
+version = "0.3.0"
+description = "Object detection from pure NURL, GPU-accelerated, using any tiny-YOLOv2-style ONNX model. Reads an image natively in any format the image package decodes (PNG, baseline+progressive JPEG, PPM) or a sequence of video frames (binary PPM), runs the detector on the GPU through the onnx package (every Conv/BatchNorm/MaxPool/LeakyRelu kernel compiled to PTX at runtime via NVRTC, no external inference engine), decodes the YOLO grid into labelled boxes (anchors, sigmoid/softmax, non-max suppression), prints the detections, and writes an annotated image. Verified against onnxruntime on the ONNX model-zoo tinyyolov2-8.onnx: identical class scores and boxes (dog 0.76, car 0.76 on the classic dog photo). Pure NURL end to end — protobuf parsing, the CNN, image I/O, decoding, and drawing; the only native dependency (the CUDA driver + NVRTC) lives in the gpu package, so a GPU-less host is unaffected. Image codecs and raster ops come from the image package; ffmpeg only for video-frame extraction."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 onnx = { path = "../onnx", version = "^0.4.2" }
+image = { path = "../image", version = "^0.4" }

--- a/packages/objdet/src/detect.nu
+++ b/packages/objdet/src/detect.nu
@@ -13,27 +13,35 @@ $ `stdlib/std/float.nu`
 & `c` @ nurl_peek_f32 *u base i idx → f
 
 // A detection in normalised (0..1) centre/size coordinates.
-: Detection { i cls  f score  f cx  f cy  f w  f h }
+: Detection { i cls f score f cx f cy f w f h }
 
 @ sigmoid f x → f { ^ / 1.0 + 1.0 ( exp - 0.0 x ) }
 
-// VOC 2007 20 classes (tiny-yolov2 order).
+// VOC 2007 20 classes (tiny-yolov2 order). Static literals — the old
+// version built a fresh Vec String per call and returned a borrow into it
+// (leaked the vector every lookup).
 @ voc_class i i → s {
-    ?? ( vec_get [String] ( __voc ) i ) { T s → ^ ( string_data s ) F _ → ^ `?` }
-}
-@ __voc → ( Vec String ) {
-    : ( Vec String ) v ( vec_new [String] )
-    ( vec_push [String] v ( string_from `aeroplane` ) ) ( vec_push [String] v ( string_from `bicycle` ) )
-    ( vec_push [String] v ( string_from `bird` ) ) ( vec_push [String] v ( string_from `boat` ) )
-    ( vec_push [String] v ( string_from `bottle` ) ) ( vec_push [String] v ( string_from `bus` ) )
-    ( vec_push [String] v ( string_from `car` ) ) ( vec_push [String] v ( string_from `cat` ) )
-    ( vec_push [String] v ( string_from `chair` ) ) ( vec_push [String] v ( string_from `cow` ) )
-    ( vec_push [String] v ( string_from `diningtable` ) ) ( vec_push [String] v ( string_from `dog` ) )
-    ( vec_push [String] v ( string_from `horse` ) ) ( vec_push [String] v ( string_from `motorbike` ) )
-    ( vec_push [String] v ( string_from `person` ) ) ( vec_push [String] v ( string_from `pottedplant` ) )
-    ( vec_push [String] v ( string_from `sheep` ) ) ( vec_push [String] v ( string_from `sofa` ) )
-    ( vec_push [String] v ( string_from `train` ) ) ( vec_push [String] v ( string_from `tvmonitor` ) )
-    ^ v
+    ? == i 0 { ^ `aeroplane` } {}
+    ? == i 1 { ^ `bicycle` } {}
+    ? == i 2 { ^ `bird` } {}
+    ? == i 3 { ^ `boat` } {}
+    ? == i 4 { ^ `bottle` } {}
+    ? == i 5 { ^ `bus` } {}
+    ? == i 6 { ^ `car` } {}
+    ? == i 7 { ^ `cat` } {}
+    ? == i 8 { ^ `chair` } {}
+    ? == i 9 { ^ `cow` } {}
+    ? == i 10 { ^ `diningtable` } {}
+    ? == i 11 { ^ `dog` } {}
+    ? == i 12 { ^ `horse` } {}
+    ? == i 13 { ^ `motorbike` } {}
+    ? == i 14 { ^ `person` } {}
+    ? == i 15 { ^ `pottedplant` } {}
+    ? == i 16 { ^ `sheep` } {}
+    ? == i 17 { ^ `sofa` } {}
+    ? == i 18 { ^ `train` } {}
+    ? == i 19 { ^ `tvmonitor` } {}
+    ^ `?`
 }
 
 // Anchor box dims (w,h in grid cells), tiny-yolov2 VOC.
@@ -47,10 +55,10 @@ $ `stdlib/std/float.nu`
 }
 
 // grid value at (channel, cy, cx) for a 13×13 grid.
-@ __gv *u grid i ch i cy i cx → f { ^ ( nurl_peek_f32 grid + * ch 169 + * cy 13 cx ) }
+@ __gv * u grid i ch i cy i cx → f { ^ ( nurl_peek_f32 grid + * ch 169 + * cy 13 cx ) }
 
 // Decode the grid into detections above `thresh`.
-@ yolo_decode *u grid f thresh → ( Vec Detection ) {
+@ yolo_decode * u grid f thresh → ( Vec Detection ) {
     : ( Vec Detection ) out ( vec_new [Detection] )
     : ~ i cy 0
     ~ < cy 13 {

--- a/packages/objdet/src/image.nu
+++ b/packages/objdet/src/image.nu
@@ -1,163 +1,81 @@
-// packages/objdet/src/image.nu — minimal image I/O for object detection.
+// packages/objdet/src/image.nu — detector-facing adapter over packages/image.
 //
-// Reads/writes binary PPM (P6) — the simplest lossless RGB container, which
-// `ffmpeg`/`convert` produce from any image or video frame. Plus the pixel
-// ops a detector needs: bilinear resize (to the model's input size), box
-// drawing (for annotated output), and packing to an NCHW float tensor.
-//
-// An Image keeps the raw file bytes and an offset to the pixel data, so
-// reading copies nothing; a freshly built image (resize/blank) owns a new
-// byte buffer. Pixels are interleaved RGB, row-major.
+// The codecs and raster ops live in the image package (PNG/JPEG/PPM decode,
+// bilinear resize, rectangle drawing — see deps/image); this file keeps only
+// what is detector-specific: loading ANY supported format as guaranteed-RGB,
+// saving by extension, saturating pixel stores, and packing to the NCHW
+// float tensor the model consumes. The Image type is the image package's
+// (width/height/channels/data).
 
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/std/fs.nu`
+$ `deps/image/src/image.nu`
 
 & `c` @ nurl_poke_f32 *u base i idx f val → v
 
-: Image { i w  i h  ( Vec u ) buf  i off }
+@ img_w Image im → i { ^ . im width }
 
-@ img_w Image im → i { ^ . im w }
-@ img_h Image im → i { ^ . im h }
+@ img_h Image im → i { ^ . im height }
 
-// Byte at (x,y,ch); clamped to the edge so resize/draw never read OOB.
-@ img_get Image im i x i y i ch → i {
-    : i xx ? < x 0 0 ? >= x . im w - . im w 1 x
-    : i yy ? < y 0 0 ? >= y . im h - . im h 1 y
-    : i idx + . im off + * + * yy . im w xx 3 ch
-    ?? ( vec_get [u] . im buf idx ) { T b → ^ # i b F _ → ^ 0 }
-}
+// A blank (black) RGB image.
+@ img_blank i w i h → Image { ^ ( image_new w h 3 ) }
 
+@ img_get Image im i x i y i ch → i { ^ ( image_get im x y ch ) }
+
+// Saturating store (image_set masks to the low byte; the detector's callers
+// pass computed values that must clamp, not wrap).
 @ img_set Image im i x i y i ch i val → v {
-    ? | | < x 0 >= x . im w | < y 0 >= y . im h { ^ {} } {}
-    : i idx + . im off + * + * y . im w x 3 ch
-    : i cv ? < val 0 0 ? > val 255 255 val
-    ( vec_set [u] . im buf idx # u cv )
+    : i cv ? < val 0 { 0 } { ? > val 255 { 255 } { val } }
+    ( image_set im x y ch cv )
 }
 
-// ── PPM (P6) ──────────────────────────────────────────────────────
-@ __ws i b → b { ^ | | | == b 32 == b 10 == b 13 == b 9 }
+@ img_resize Image im i nw i nh → Image { ^ ( image_resize im nw nh ) }
 
-// Parse a whitespace-delimited decimal starting at/after `pos`; returns the
-// value, and writes the position just past it through `pnext` (an i64 cell).
-@ __ppm_int ( Vec u ) buf i pos *u pnext → i {
-    : ~ i p pos
-    ~ ?? ( vec_get [u] buf p ) { T b → ( __ws # i b ) F _ → F } { = p + p 1 }
-    : ~ i v 0
-    ~ ?? ( vec_get [u] buf p ) { T b → & >= # i b 48 <= # i b 57 F _ → F } {
-        : i d ?? ( vec_get [u] buf p ) { T b → - # i b 48 F _ → 0 }
-        = v + * v 10 d
-        = p + p 1
-    }
-    ( nurl_poke pnext 0 p )
-    ^ v
-}
-
-@ ppm_read s path → ?Image {
-    ?? ( read_file_bytes path ) {
-        T buf → {
-            // header: P6 <w> <h> <maxval> then a single whitespace byte
-            : i b0 ?? ( vec_get [u] buf 0 ) { T x → # i x F _ → 0 }
-            : i b1 ?? ( vec_get [u] buf 1 ) { T x → # i x F _ → 0 }
-            ? | != b0 80 != b1 54 { ^ @ ?Image { F @ Image { 0 0 ( vec_new [u] ) 0 } } } {}
-            : *u pc ( nurl_alloc 8 )
-            : i w ( __ppm_int buf 2 pc )
-            : i h ( __ppm_int buf ( nurl_peek pc 0 ) pc )
-            : i mx ( __ppm_int buf ( nurl_peek pc 0 ) pc )
-            : i off + ( nurl_peek pc 0 ) 1   // one whitespace separator
-            ^ @ ?Image { T @ Image { w h buf off } }
+// Load any supported format (PNG / baseline+progressive JPEG / PPM) as
+// 3-channel RGB. On None, ( image_error ) says why.
+@ img_load s path → ?Image {
+    ?? ( image_load path ) {
+        T im → {
+            ? == ( image_channels im ) 3 { ^ @ ?Image { T im } } {}
+            : Image rgb ( image_convert im 3 )
+            ( image_free im )
+            ^ @ ?Image { T rgb }
         }
-        F _ → ^ @ ?Image { F @ Image { 0 0 ( vec_new [u] ) 0 } }
+        F _ → { ^ @ ?Image { F } }
     }
 }
 
-// A blank (black) image of the given size, owning a fresh buffer.
-@ img_blank i w i h → Image {
-    : i n * * w h 3
-    : ( Vec u ) buf ( vec_new [u] )
+@ __od_sfx s path s sfx → b {
+    : i n ( nurl_str_len path )
+    : i m ( nurl_str_len sfx )
+    ? < n m { ^ F } {}
     : ~ i k 0
-    ~ < k n { ( vec_push [u] buf # u 0 ) = k + k 1 }
-    ^ @ Image { w h buf 0 }
-}
-
-@ ppm_write s path Image im → b {
-    : String hdr ( string_from ( nurl_str_cat4 `P6\n` ( nurl_str_int . im w ) ` ` ( nurl_str_cat3 ( nurl_str_int . im h ) `\n` `255\n` ) ) )
-    : ( Vec u ) out ( vec_new [u] )
-    : s hs ( string_data hdr )
-    : i hn ( nurl_str_len hs )
-    : ~ i k 0
-    ~ < k hn { ( vec_push [u] out # u ( nurl_str_get hs k ) ) = k + k 1 }
-    : i n * * . im w . im h 3
-    : ~ i j 0
-    ~ < j n {
-        ?? ( vec_get [u] . im buf + . im off j ) { T b → ( vec_push [u] out b ) F _ → {} }
-        = j + j 1
+    ~ < k m {
+        ? == ( nurl_str_get path + - n m k ) ( nurl_str_get sfx k ) {} { ^ F }
+        = k + k 1
     }
-    ?? ( write_file_bytes path out ) { T _ → ^ T F _ → ^ F }
+    ^ T
 }
 
-// ── bilinear resize ───────────────────────────────────────────────
-@ img_resize Image im i nw i nh → Image {
-    : Image out ( img_blank nw nh )
-    : f sx / # f . im w # f nw
-    : f sy / # f . im h # f nh
-    : ~ i oy 0
-    ~ < oy nh {
-        : f oyf + # f oy 0.5
-        : f fy - * oyf sy 0.5
-        : i y0 # i fy
-        : f wy - fy # f y0
-        : ~ i ox 0
-        ~ < ox nw {
-            : f oxf + # f ox 0.5
-            : f fx - * oxf sx 0.5
-            : i x0 # i fx
-            : f wx - fx # f x0
-            : ~ i c 0
-            ~ < c 3 {
-                : f p00 # f ( img_get im x0 y0 c )
-                : f p10 # f ( img_get im + x0 1 y0 c )
-                : f p01 # f ( img_get im x0 + y0 1 c )
-                : f p11 # f ( img_get im + x0 1 + y0 1 c )
-                : f top + * p00 - 1.0 wx * p10 wx
-                : f bot + * p01 - 1.0 wx * p11 wx
-                : f v + * top - 1.0 wy * bot wy
-                ( img_set out ox oy c # i + v 0.5 )
-                = c + c 1
-            }
-            = ox + ox 1
-        }
-        = oy + oy 1
-    }
-    ^ out
+// Save by extension: .png / .jpg / .jpeg (quality 90) / anything else = PPM.
+@ img_save s path Image im → b {
+    ? ( __od_sfx path `.png` ) { ^ ( image_save_png path im ) } {}
+    ? | ( __od_sfx path `.jpg` ) ( __od_sfx path `.jpeg` ) { ^ ( image_save_jpeg path im 90 ) } {}
+    ^ ( image_save_ppm path im )
 }
 
-// ── drawing ───────────────────────────────────────────────────────
-@ __hline Image im i x0 i x1 i y i r i gg i bb → v {
-    : ~ i x x0
-    ~ <= x x1 { ( img_set im x y 0 r ) ( img_set im x y 1 gg ) ( img_set im x y 2 bb ) = x + x 1 }
-}
-@ __vline Image im i x i y0 i y1 i r i gg i bb → v {
-    : ~ i y y0
-    ~ <= y y1 { ( img_set im x y 0 r ) ( img_set im x y 1 gg ) ( img_set im x y 2 bb ) = y + y 1 }
-}
-
-// Draw a (thick) rectangle outline in the given colour.
+// Draw a thickness-2 rectangle outline in the given colour.
 @ img_draw_rect Image im i x0 i y0 i x1 i y1 i r i gg i bb → v {
-    : ~ i t 0
-    ~ < t 2 {
-        ( __hline im x0 x1 + y0 t r gg bb ) ( __hline im x0 x1 - y1 t r gg bb )
-        ( __vline im + x0 t y0 y1 r gg bb ) ( __vline im - x1 t y0 y1 r gg bb )
-        = t + t 1
-    }
+    : i rgba + + + * r 16777216 * gg 65536 * bb 256 255
+    ( image_draw_rect im x0 y0 x1 y1 2 rgba )
 }
 
 // ── pack to NCHW float tensor (values 0..255) ─────────────────────
 // Writes a fresh host buffer of 3*H*W floats in CHW order; the model's
 // in-graph preprocessor scales by 1/255.
 @ img_to_nchw Image im → *u {
-    : i W . im w
-    : i H . im h
+    : i W . im width
+    : i H . im height
     : *u host ( nurl_alloc * * * 3 H W 4 )
     : ~ i c 0
     ~ < c 3 {
@@ -165,7 +83,7 @@ $ `stdlib/std/fs.nu`
         ~ < y H {
             : ~ i x 0
             ~ < x W {
-                ( nurl_poke_f32 host + * c * H W + * y W x # f ( img_get im x y c ) )
+                ( nurl_poke_f32 host + * c * H W + * y W x # f ( image_get im x y c ) )
                 = x + x 1
             }
             = y + y 1

--- a/packages/objdet/src/main.nu
+++ b/packages/objdet/src/main.nu
@@ -1,16 +1,15 @@
 // packages/objdet/src/main.nu — object detection from pure NURL on the GPU.
 //
-//   objdet <model.onnx> <image.ppm> [out.ppm]
+//   objdet <model.onnx> <image.{png,jpg,ppm}> [out.{png,jpg,ppm}]
 //   objdet <model.onnx> --video <in_dir> <out_dir> <count>
 //
 // Loads any tiny-YOLOv2-style ONNX detector (e.g. the ONNX model-zoo
 // tinyyolov2-8.onnx), runs it on the GPU through packages/onnx, decodes the
 // grid into labelled boxes (packages objdet/detect), prints them, and (for
-// an image) writes an annotated PPM. The video mode runs a frame sequence
-// frame00000.ppm … reusing one GPU engine (kernels compiled once).
-//
-// Convert to/from PPM with ffmpeg/ImageMagick, e.g.
-//   convert photo.jpg photo.ppm
+// an image) writes an annotated image. Stills are read/written natively via
+// packages/image (PNG, baseline+progressive JPEG, PPM) — no ImageMagick.
+// The video mode runs a frame sequence frame00000.ppm … reusing one GPU
+// engine (kernels compiled once); use ffmpeg for the container:
 //   ffmpeg -i clip.mp4 -vf fps=10 in/frame%05d.ppm
 //   ffmpeg -framerate 10 -i out/frame%05d.ppm out.mp4
 
@@ -26,8 +25,11 @@ $ `image.nu`
 $ `detect.nu`
 
 @ p s m → v { ( nurl_print m ) }
+
 @ pf f x → v { ( nurl_print ( nurl_str_float x ) ) }
+
 @ pn i n → v { ( nurl_print ( nurl_str_int n ) ) }
+
 @ streqm s a s b → b { ^ != ( nurl_str_eq a b ) 0 }
 
 @ shape4 i a i b i c i d → ( Vec i ) {
@@ -36,7 +38,7 @@ $ `detect.nu`
 
 // Run the detector on one image, draw boxes in place, print detections.
 // Returns the number of detections.
-@ detect_image *Engine e OGraph g Image im f conf f iou → i {
+@ detect_image * Engine e OGraph g Image im f conf f iou → i {
     : Image in416 ? & == ( img_w im ) 416 == ( img_h im ) 416 im ( img_resize im 416 416 )
     : *u host ( img_to_nchw in416 )
     : RTensor out ( rt_run_shaped e g host ( shape4 1 3 416 416 ) )
@@ -67,7 +69,7 @@ $ `detect.nu`
     ^ nd
 }
 
-@ load_model s path *u pok → OGraph {
+@ load_model s path * u pok → OGraph {
     ?? ( read_file_bytes path ) {
         T mb → { ( nurl_poke pok 0 1 ) ^ ( onnx_parse mb ) }
         F _ → { ( nurl_poke pok 0 0 ) ^ @ OGraph { ( vec_new [ONode] ) ( vec_new [OTensor] ) ( string_new ) ( string_new ) } }
@@ -87,7 +89,7 @@ $ `detect.nu`
 @ main → i {
     : ( Vec String ) av ( env_args_list )
     ? < ( vec_len [String] av ) 3 {
-        ( p `usage: objdet <model.onnx> <image.ppm> [out.ppm]\n` )
+        ( p `usage: objdet <model.onnx> <image.{png,jpg,ppm}> [out.{png,jpg,ppm}]\n` )
         ( p `       objdet <model.onnx> --video <in_dir> <out_dir> <count>\n` )
         ^ 2
     } {}
@@ -112,12 +114,12 @@ $ `detect.nu`
         : ~ i fr 0
         ~ < fr count {
             : String fin ( frame_path ( string_data indir ) fr )
-            ?? ( ppm_read ( string_data fin ) ) {
+            ?? ( img_load ( string_data fin ) ) {
                 T im → {
                     ( p `frame ` ) ( pn fr ) ( p `:\n` )
                     ( detect_image e g im conf iou )
                     : String fout ( frame_path ( string_data outdir ) fr )
-                    ( ppm_write ( string_data fout ) im )
+                    ( img_save ( string_data fout ) im )
                 } F _ → { ( p `frame ` ) ( pn fr ) ( p ` unreadable\n` ) }
             }
             = fr + fr 1
@@ -126,7 +128,7 @@ $ `detect.nu`
     } {}
 
     // single-image mode
-    ?? ( ppm_read ( string_data a2 ) ) {
+    ?? ( img_load ( string_data a2 ) ) {
         T im → {
             ( p `image ` ) ( pn ( img_w im ) ) ( p `x` ) ( pn ( img_h im ) ) ( p `\n` )
             ( p `detections:\n` )
@@ -134,10 +136,10 @@ $ `detect.nu`
             ? == nd 0 { ( p `  (none above threshold)\n` ) } {}
             ? > ( vec_len [String] av ) 3 {
                 : String outp ?? ( vec_get [String] av 3 ) { T x → x F _ → ( string_new ) }
-                ? ( ppm_write ( string_data outp ) im ) { ( p `wrote ` ) ( p ( string_data outp ) ) ( p `\n` ) } { ( p `write failed\n` ) }
+                ? ( img_save ( string_data outp ) im ) { ( p `wrote ` ) ( p ( string_data outp ) ) ( p `\n` ) } { ( p `write failed\n` ) }
             } {}
         }
-        F _ → { ( p `cannot read image (PPM P6 expected)\n` ) ( rt_close e ) ^ 1 }
+        F _ → { ( p `cannot read image: ` ) ( p ( image_error ) ) ( p `\n` ) ( rt_close e ) ^ 1 }
     }
     ( rt_close e )
     ^ 0

--- a/packages/objdet/tests/detect_test.nu
+++ b/packages/objdet/tests/detect_test.nu
@@ -12,9 +12,11 @@ $ `src/image.nu`
 $ `src/detect.nu`
 
 & `c` @ nurl_poke_f32 *u base i idx f val → v
+
 & `c` @ nurl_peek_f32 *u base i idx → f
 
 : ~ i g_fail 0
+
 @ check b cond s name → v {
     ? cond { ( nurl_print `  ok  ` ) } { ( nurl_print `  FAIL ` ) = g_fail + g_fail 1 }
     ( nurl_print name ) ( nurl_print `\n` )
@@ -36,6 +38,7 @@ $ `src/detect.nu`
     : Image big ( img_resize solid 8 8 )
     ( check == ( img_get big 4 4 1 ) 120 `resize preserves solid colour` )
     ( check & == ( img_w big ) 8 == ( img_h big ) 8 `resize dims` )
+    ( image_free im ) ( image_free solid ) ( image_free big )
 }
 
 @ test_nchw → v {
@@ -50,6 +53,7 @@ $ `src/detect.nu`
     // channel 1 plane starts at index 4; (0,0) -> index 4 = 30.
     : f g00 ( nurl_peek_f32 t 4 )
     ( check & > g00 29.5 < g00 30.5 `nchw G(0,0)=30` )
+    ( nurl_free t ) ( image_free im )
 }
 
 // Build a 13x13x125 grid with one strong "dog" box planted at cell (6,6),
@@ -58,14 +62,14 @@ $ `src/detect.nu`
     ( nurl_print `[decode]\n` )
     : *u grid ( nurl_alloc * 21125 4 )
     : ~ i z 0
-    ~ < z 21125 { ( nurl_poke_f32 grid z # f - 0.0 10.0 ) = z + z 1 }   // all logits very negative
+    ~ < z 21125 { ( nurl_poke_f32 grid z # f - 0.0 10.0 ) = z + z 1 }  // all logits very negative
     : i cy 6
     : i cx 6
-    : i o 0   // anchor 0, channels 0..24
+    : i o 0  // anchor 0, channels 0..24
     // objectness logit high; class 11 (dog) logit high
-    ( nurl_poke_f32 grid + * + o 4 169 + * cy 13 cx # f 4.0 )    // to -> sigmoid ~0.98
+    ( nurl_poke_f32 grid + * + o 4 169 + * cy 13 cx # f 4.0 )  // to -> sigmoid ~0.98
     ( nurl_poke_f32 grid + * + o 5 169 + * cy 13 cx # f -10.0 )  // keep others low
-    ( nurl_poke_f32 grid + * + + o 5 11 169 + * cy 13 cx # f 8.0 ) // class 11 = dog
+    ( nurl_poke_f32 grid + * + + o 5 11 169 + * cy 13 cx # f 8.0 )  // class 11 = dog
     : ( Vec Detection ) dets ( yolo_decode grid 0.3 )
     ( check > ( vec_len [Detection] dets ) 0 `decode finds the planted box` )
     ?? ( vec_get [Detection] dets 0 ) {
@@ -74,17 +78,20 @@ $ `src/detect.nu`
             ( check & > . d cx 0.4 < . d cx 0.6 `box centre near cell (6,6)` )
         } F _ → ( check F `det fetch` )
     }
+    ( vec_free [Detection] dets )
     ( nurl_free grid )
 }
 
 @ test_nms → v {
     ( nurl_print `[nms]\n` )
     : ( Vec Detection ) ds ( vec_new [Detection] )
-    ( vec_push [Detection] ds @ Detection { 6 0.9 0.5 0.5 0.2 0.2 } )   // dog, strong
-    ( vec_push [Detection] ds @ Detection { 6 0.6 0.51 0.51 0.2 0.2 } ) // dog, overlaps -> dropped
-    ( vec_push [Detection] ds @ Detection { 7 0.7 0.5 0.5 0.2 0.2 } )   // cat, same box, kept (diff class)
+    ( vec_push [Detection] ds @ Detection { 6 0.9 0.5 0.5 0.2 0.2 } )  // dog, strong
+    ( vec_push [Detection] ds @ Detection { 6 0.6 0.51 0.51 0.2 0.2 } )  // dog, overlaps -> dropped
+    ( vec_push [Detection] ds @ Detection { 7 0.7 0.5 0.5 0.2 0.2 } )  // cat, same box, kept (diff class)
     : ( Vec Detection ) keep ( yolo_nms ds 0.45 )
     ( check == ( vec_len [Detection] keep ) 2 `nms drops the overlapping same-class box` )
+    ( vec_free [Detection] keep )
+    ( vec_free [Detection] ds )
 }
 
 @ test_names → v {

--- a/packages/yoloe/README.md
+++ b/packages/yoloe/README.md
@@ -47,7 +47,7 @@ yoloe cam    --model M --classes C [options]                 live webcam
 |---|---|
 | `--model <model.onnx>` | a YOLOE-seg export from `tools/export.py` (→ `yoloe-v8s-seg.onnx`); not bundled (~45 MB) |
 | `--classes <classes.txt>` | the vocabulary, **one prompt word per line** — swap it (and the model) to detect a different set of objects |
-| `--image <image.ppm>` | input for `detect`/`seg`, a binary PPM (P6): `convert photo.jpg photo.ppm` |
+| `--image <img>` | input for `detect`/`seg` — PNG, JPEG (baseline or progressive) or PPM, decoded natively via [`packages/image`](../image) |
 | `--out <path>` | `detect`/`seg`: the annotated output image; `cam`: a directory to save frames to (created if missing) |
 | `--device <dev>` | `cam` webcam device (default `/dev/video0`) |
 | `--frames <N>` | `cam`: stop after N frames — **omit to run until Ctrl-C** |
@@ -71,7 +71,7 @@ preview's resolution is the terminal's cell grid: a bigger window (or smaller
 font) gives a sharper picture.
 
 ```
-yoloe seg --model yoloe-v8s-seg.onnx --classes classes.txt --image dog.ppm --out out.ppm
+yoloe seg --model yoloe-v8s-seg.onnx --classes classes.txt --image dog.jpg --out out.png
 yoloe cam --model yoloe-v8s-seg.onnx --classes classes.txt              # live, in the terminal
 yoloe cam --model yoloe-v8s-seg.onnx --classes classes.txt --frames 60 --out frames/
 ffmpeg -framerate 10 -i frames/frame%05d.ppm seg.mp4                    # saved frames → video
@@ -110,7 +110,7 @@ frames. (Needs read access to the device — `ls -l /dev/video0`.)
 
 ```
 NURL_STDLIB=<repo> ../../nurl.sh src/prompt.nu
-./src/prompt <model.onnx> <tpe.f32> <classes.txt> <image.ppm> [out.ppm]
+./src/prompt <model.onnx> <tpe.f32> <classes.txt> <img> [out]
 ```
 
 `tpe.f32` is `K×512` raw MobileCLIP text features and `classes.txt` the K
@@ -122,7 +122,7 @@ them (no re-export) to detect different objects with the *same* model.
 ```
 nurlpkg install                                   # symlink deps/
 NURL_STDLIB=<repo> ../../nurl.sh src/main.nu      # build the `yoloe` command
-./src/main seg yoloe-v8s-seg.onnx example/classes.txt dog.ppm dog-out.ppm
+./src/main seg yoloe-v8s-seg.onnx example/classes.txt dog.jpg dog-out.png
 ```
 
 ## Why this is the crown jewel

--- a/packages/yoloe/nurl.toml
+++ b/packages/yoloe/nurl.toml
@@ -1,8 +1,9 @@
 [package]
 name = "yoloe"
-version = "0.4.1"
+version = "0.5.0"
 description = "Promptable, open-vocabulary object detection AND instance segmentation from pure NURL on the GPU — a NURL port of YOLOE (THU-MIG, 'Real-Time Seeing Anything', ICCV 2025), including live masking straight off a webcam. You name the classes you want ('dog', 'bicycle', 'a person on a bike') and the model finds them — drawing both boxes and per-object segmentation masks — without a fixed label set. The whole network runs on the GPU through the onnx package (every layer a CUDA-C kernel compiled at runtime via NVRTC — no external inference engine), including the YOLOE-seg mask-prototype branch (ConvTranspose 2× upsample) and the mask decode (coefficients · prototypes → threshold → overlay), all verified numerically against onnxruntime (proto max abs err ~6e-5). Promptability comes from YOLOE's region-text contrastive head, which scores each region's visual embedding against the text embeddings of the prompt words, with the MobileCLIP text path also in pure NURL. The webcam feed is captured in pure NURL via Video4Linux2 (open/ioctl/mmap, YUYV→RGB) — no ffmpeg, no OpenCV. Requires the NVIDIA driver + NVRTC (via the gpu package); a GPU-less host is unaffected."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 onnx = { path = "../onnx", version = "^0.4.2" }
+image = { path = "../image", version = "^0.4" }

--- a/packages/yoloe/src/image.nu
+++ b/packages/yoloe/src/image.nu
@@ -1,92 +1,86 @@
-// packages/yoloe/src/image.nu — image I/O + YOLO letterbox preprocessing.
+// packages/yoloe/src/image.nu — YOLO-facing adapter over packages/image.
 //
-// Reads/writes binary PPM (P6), letterboxes to the model's square input
-// (aspect-preserving resize + grey pad), packs to an NCHW float tensor
-// normalised to [0,1], and draws labelled boxes. An Image keeps the raw
-// file bytes plus a pixel-data offset, so reading copies nothing; a fresh
-// image (letterbox/blank) owns a new byte buffer.
+// The codecs and raster ops live in the image package (PNG / baseline +
+// progressive JPEG / PPM decode+encode, rectangle drawing — see deps/image);
+// this file keeps only what is YOLO-specific: letterbox preprocessing
+// (aspect-preserving nearest resize + grey-114 pad, matching ultralytics),
+// packing to the [0,1]-normalised NCHW float tensor the model consumes,
+// edge-clamped reads for the mask overlay, and load/save-by-extension.
+// The Image type is the image package's (width/height/channels/data).
 
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
-$ `stdlib/std/fs.nu`
+$ `deps/image/src/image.nu`
 
 & `c` @ nurl_poke_f32 *u base i idx f val → v
 
-: Image { i w  i h  ( Vec u ) buf  i off }
 // Letterbox result: the square image plus the transform back to original
 // pixels (orig = (lb - pad) / scale).
-: Letterbox { Image img  f scale  i padx  i pady }
+: Letterbox { Image img f scale i padx i pady }
 
-@ img_w Image im → i { ^ . im w }
-@ img_h Image im → i { ^ . im h }
+@ img_w Image im → i { ^ . im width }
 
+@ img_h Image im → i { ^ . im height }
+
+// Edge-clamped read (the mask overlay and letterbox sample with clamping).
 @ img_get Image im i x i y i ch → i {
-    : i xx ? < x 0 0 ? >= x . im w - . im w 1 x
-    : i yy ? < y 0 0 ? >= y . im h - . im h 1 y
-    : i idx + . im off + * + * yy . im w xx 3 ch
-    ?? ( vec_get [u] . im buf idx ) { T b → ^ # i b F _ → ^ 0 }
-}
-@ img_set Image im i x i y i ch i val → v {
-    ? | | < x 0 >= x . im w | < y 0 >= y . im h { ^ {} } {}
-    : i idx + . im off + * + * y . im w x 3 ch
-    : i cv ? < val 0 0 ? > val 255 255 val
-    ( vec_set [u] . im buf idx # u cv )
+    : i xx ? < x 0 { 0 } { ? >= x . im width { - . im width 1 } { x } }
+    : i yy ? < y 0 { 0 } { ? >= y . im height { - . im height 1 } { y } }
+    ^ ( image_get im xx yy ch )
 }
 
-// ── PPM (P6) ──────────────────────────────────────────────────────
-@ __ws i b → b { ^ | | | == b 32 == b 10 == b 13 == b 9 }
-@ __ppm_int ( Vec u ) buf i pos *u pnext → i {
-    : ~ i p pos
-    ~ ?? ( vec_get [u] buf p ) { T b → ( __ws # i b ) F _ → F } { = p + p 1 }
-    : ~ i v 0
-    ~ ?? ( vec_get [u] buf p ) { T b → & >= # i b 48 <= # i b 57 F _ → F } {
-        : i d ?? ( vec_get [u] buf p ) { T b → - # i b 48 F _ → 0 }
-        = v + * v 10 d
-        = p + p 1
-    }
-    ( nurl_poke pnext 0 p )
-    ^ v
+// Saturating store (image_set masks to the low byte; overlay math must clamp).
+@ img_set Image im i x i y i ch i val → v {
+    : i cv ? < val 0 { 0 } { ? > val 255 { 255 } { val } }
+    ( image_set im x y ch cv )
 }
-@ ppm_read s path → ?Image {
-    ?? ( read_file_bytes path ) {
-        T buf → {
-            : i b0 ?? ( vec_get [u] buf 0 ) { T x → # i x F _ → 0 }
-            : i b1 ?? ( vec_get [u] buf 1 ) { T x → # i x F _ → 0 }
-            ? | != b0 80 != b1 54 { ^ @ ?Image { F @ Image { 0 0 ( vec_new [u] ) 0 } } } {}
-            : *u pc ( nurl_alloc 8 )
-            : i w ( __ppm_int buf 2 pc )
-            : i h ( __ppm_int buf ( nurl_peek pc 0 ) pc )
-            : i mx ( __ppm_int buf ( nurl_peek pc 0 ) pc )
-            : i off + ( nurl_peek pc 0 ) 1
-            ^ @ ?Image { T @ Image { w h buf off } }
-        }
-        F _ → ^ @ ?Image { F @ Image { 0 0 ( vec_new [u] ) 0 } }
-    }
-}
+
+// An RGB image filled with a constant grey level.
 @ img_blank i w i h i fill → Image {
+    : Image im ( image_new w h 3 )
     : i n * * w h 3
-    : ( Vec u ) buf ( vec_new [u] )
     : ~ i k 0
-    ~ < k n { ( vec_push [u] buf # u fill ) = k + k 1 }
-    ^ @ Image { w h buf 0 }
+    ~ < k n { ( vec_set [u] . im data k # u fill ) = k + k 1 }
+    ^ im
 }
-@ ppm_write s path Image im → b {
-    : String hdr ( string_from ( nurl_str_cat4 `P6\n` ( nurl_str_int . im w ) ` ` ( nurl_str_cat3 ( nurl_str_int . im h ) `\n` `255\n` ) ) )
-    : ( Vec u ) out ( vec_new [u] )
-    : s hs ( string_data hdr )
-    : i hn ( nurl_str_len hs )
+
+// Load any supported format (PNG / baseline+progressive JPEG / PPM) as
+// 3-channel RGB. On None, ( image_error ) says why.
+@ img_load s path → ?Image {
+    ?? ( image_load path ) {
+        T im → {
+            ? == ( image_channels im ) 3 { ^ @ ?Image { T im } } {}
+            : Image rgb ( image_convert im 3 )
+            ( image_free im )
+            ^ @ ?Image { T rgb }
+        }
+        F _ → { ^ @ ?Image { F } }
+    }
+}
+
+@ __ye_sfx s path s sfx → b {
+    : i n ( nurl_str_len path )
+    : i m ( nurl_str_len sfx )
+    ? < n m { ^ F } {}
     : ~ i k 0
-    ~ < k hn { ( vec_push [u] out # u ( nurl_str_get hs k ) ) = k + k 1 }
-    : i n * * . im w . im h 3
-    : ~ i j 0
-    ~ < j n { ?? ( vec_get [u] . im buf + . im off j ) { T b → ( vec_push [u] out b ) F _ → {} } = j + j 1 }
-    ?? ( write_file_bytes path out ) { T _ → ^ T F _ → ^ F }
+    ~ < k m {
+        ? == ( nurl_str_get path + - n m k ) ( nurl_str_get sfx k ) {} { ^ F }
+        = k + k 1
+    }
+    ^ T
+}
+
+// Save by extension: .png / .jpg / .jpeg (quality 90) / anything else = PPM.
+@ img_save s path Image im → b {
+    ? ( __ye_sfx path `.png` ) { ^ ( image_save_png path im ) } {}
+    ? | ( __ye_sfx path `.jpg` ) ( __ye_sfx path `.jpeg` ) { ^ ( image_save_jpeg path im 90 ) } {}
+    ^ ( image_save_ppm path im )
 }
 
 // ── letterbox to S×S (aspect-preserving, grey 114 pad) ────────────
 @ letterbox Image im i S → Letterbox {
-    : i W . im w
-    : i H . im h
+    : i W . im width
+    : i H . im height
     : f sx / # f S # f W
     : f sy / # f S # f H
     : f scale ? < sx sy sx sy
@@ -114,8 +108,8 @@ $ `stdlib/std/fs.nu`
 
 // Pack to NCHW float tensor normalised to [0,1].
 @ img_to_nchw_norm Image im → *u {
-    : i W . im w
-    : i H . im h
+    : i W . im width
+    : i H . im height
     : *u host ( nurl_alloc * * * 3 H W 4 )
     : ~ i c 0
     ~ < c 3 {
@@ -123,7 +117,7 @@ $ `stdlib/std/fs.nu`
         ~ < y H {
             : ~ i x 0
             ~ < x W {
-                ( nurl_poke_f32 host + * c * H W + * y W x / # f ( img_get im x y c ) 255.0 )
+                ( nurl_poke_f32 host + * c * H W + * y W x / # f ( image_get im x y c ) 255.0 )
                 = x + x 1
             }
             = y + y 1
@@ -133,20 +127,8 @@ $ `stdlib/std/fs.nu`
     ^ host
 }
 
-// ── drawing ───────────────────────────────────────────────────────
-@ __hline Image im i x0 i x1 i y i r i gg i bb → v {
-    : ~ i x x0
-    ~ <= x x1 { ( img_set im x y 0 r ) ( img_set im x y 1 gg ) ( img_set im x y 2 bb ) = x + x 1 }
-}
-@ __vline Image im i x i y0 i y1 i r i gg i bb → v {
-    : ~ i y y0
-    ~ <= y y1 { ( img_set im x y 0 r ) ( img_set im x y 1 gg ) ( img_set im x y 2 bb ) = y + y 1 }
-}
+// Draw a thickness-3 rectangle outline in the given colour.
 @ img_draw_rect Image im i x0 i y0 i x1 i y1 i r i gg i bb → v {
-    : ~ i t 0
-    ~ < t 3 {
-        ( __hline im x0 x1 + y0 t r gg bb ) ( __hline im x0 x1 - y1 t r gg bb )
-        ( __vline im + x0 t y0 y1 r gg bb ) ( __vline im - x1 t y0 y1 r gg bb )
-        = t + t 1
-    }
+    : i rgba + + + * r 16777216 * gg 65536 * bb 256 255
+    ( image_draw_rect im x0 y0 x1 y1 3 rgba )
 }

--- a/packages/yoloe/src/main.nu
+++ b/packages/yoloe/src/main.nu
@@ -28,7 +28,9 @@ $ `display.nu`
 $ `window.nu`
 
 @ p s m → v { ( nurl_print m ) }
+
 @ pf f x → v { ( nurl_print ( nurl_str_float x ) ) }
+
 @ pn i n → v { ( nurl_print ( nurl_str_int n ) ) }
 
 // ── flag parsing ──────────────────────────────────────────────────
@@ -41,12 +43,15 @@ $ `window.nu`
     }
     ^ - 0 1
 }
+
 @ flag_set ( Vec String ) av s name → b { ^ >= ( __arg_index av name ) 0 }
+
 @ flag_str ( Vec String ) av s name → String {
     : i i ( __arg_index av name )
     ? < i 0 { ^ ( string_new ) } {}
     ?? ( vec_get [String] av + i 1 ) { T x → ^ x F _ → ^ ( string_new ) }
 }
+
 @ flag_int ( Vec String ) av s name i dflt → i {
     : i i ( __arg_index av name )
     ? < i 0 { ^ dflt } {}
@@ -74,7 +79,9 @@ $ `window.nu`
     }
     ^ out
 }
+
 @ name_at ( Vec String ) names i i → s { ?? ( vec_get [String] names i ) { T s → ^ ( string_data s ) F _ → ^ `?` } }
+
 @ shape4 i a i b i c i d → ( Vec i ) { : ( Vec i ) v ( vec_new [i] )
     ( vec_push [i] v a ) ( vec_push [i] v b ) ( vec_push [i] v c ) ( vec_push [i] v d ) ^ v }
 
@@ -83,11 +90,14 @@ $ `window.nu`
     : ( Vec i ) v ( vec_new [i] )
     ? == ch 0 { ( vec_push [i] v 255 ) ( vec_push [i] v 60 ) ( vec_push [i] v 60 ) ( vec_push [i] v 255 ) ( vec_push [i] v 220 ) ( vec_push [i] v 60 ) }
     { ? == ch 1 { ( vec_push [i] v 70 ) ( vec_push [i] v 200 ) ( vec_push [i] v 90 ) ( vec_push [i] v 200 ) ( vec_push [i] v 60 ) ( vec_push [i] v 220 ) }
-    { ( vec_push [i] v 70 ) ( vec_push [i] v 90 ) ( vec_push [i] v 230 ) ( vec_push [i] v 60 ) ( vec_push [i] v 220 ) ( vec_push [i] v 220 ) } }
+        { ( vec_push [i] v 70 ) ( vec_push [i] v 90 ) ( vec_push [i] v 230 ) ( vec_push [i] v 60 ) ( vec_push [i] v 220 ) ( vec_push [i] v 220 ) } }
     ^ v
 }
+
 @ pal_r i k → i { ^ ?? ( vec_get [i] ( __pal 0 ) % k 6 ) { T x → x F _ → 255 } }
+
 @ pal_g i k → i { ^ ?? ( vec_get [i] ( __pal 1 ) % k 6 ) { T x → x F _ → 60 } }
+
 @ pal_b i k → i { ^ ?? ( vec_get [i] ( __pal 2 ) % k 6 ) { T x → x F _ → 60 } }
 
 // frame path: <dir>/frameNNNNN.ppm
@@ -103,13 +113,13 @@ $ `window.nu`
 // Run the network on one image, drawing boxes (and, when `want_masks`, the
 // per-object segmentation mask) onto `im`. When `verbose`, prints one line per
 // detection. Returns the detection count.
-@ process_frame Image im OGraph g *Engine e ( Vec String ) names i nc b want_boxes b want_masks b verbose → i {
+@ process_frame Image im OGraph g * Engine e ( Vec String ) names i nc b want_boxes b want_masks b verbose → i {
     : Letterbox lb ( letterbox im 640 )
     : *u host ( img_to_nchw_norm . lb img )
     : RTensor out ( rt_run_shaped e g host ( shape4 1 3 640 640 ) )
     : *u o ( rt_download e out )
     : ~ b masks want_masks
-    : ~ i proto_i 0     // proto buffer address carried as i64 (cast per use)
+    : ~ i proto_i 0  // proto buffer address carried as i64 (cast per use)
     ? masks {
         : RTensor proto_t ( rt_output1 e )
         ? == . proto_t nelem 0 { = masks F } { = proto_i # i ( rt_download e proto_t ) }
@@ -153,7 +163,7 @@ $ `window.nu`
     ^ nd
 }
 
-@ load_model s path *b okcell → OGraph {
+@ load_model s path * b okcell → OGraph {
     : ~ OGraph g @ OGraph { ( vec_new [ONode] ) ( vec_new [OTensor] ) ( string_new ) ( string_new ) ( string_new ) }
     ?? ( read_file_bytes path ) { T mb → { = g ( onnx_parse mb ) ( nurl_poke # *u okcell 0 1 ) } F _ → { ( nurl_poke # *u okcell 0 0 ) } }
     ^ g
@@ -162,7 +172,7 @@ $ `window.nu`
 // ── still-image modes (detect / seg) ──────────────────────────────
 @ run_still b want_boxes b want_masks String mp String np String ip String op i gpu → i {
     ? == ( string_len mp ) 0 { ( p `missing --model <model.onnx>\n` ) ^ 1 } {}
-    ? == ( string_len ip ) 0 { ( p `missing --image <image.ppm>\n` ) ^ 1 } {}
+    ? == ( string_len ip ) 0 { ( p `missing --image <img>\n` ) ^ 1 } {}
     : *b okc # *b ( nurl_alloc 8 )
     : OGraph g ( load_model ( string_data mp ) okc )
     ? == ( nurl_peek # *u okc 0 ) 0 { ( p `cannot read model: ` ) ( p ( string_data mp ) ) ( p `\n` ) ^ 1 } {}
@@ -170,7 +180,7 @@ $ `window.nu`
     : i nc ( vec_len [String] names )
     ? == nc 0 { ( p `missing/empty --classes <classes.txt>\n` ) ^ 1 } {}
     ( p `prompts: ` ) ( pn nc ) ( p ` classes\n` )
-    ?? ( ppm_read ( string_data ip ) ) {
+    ?? ( img_load ( string_data ip ) ) {
         T im → {
             ( p `image ` ) ( pn ( img_w im ) ) ( p `x` ) ( pn ( img_h im ) ) ( p `\n` )
             : *Engine e ( rt_open gpu )
@@ -181,11 +191,11 @@ $ `window.nu`
             ? == nd 0 { ( p `  (none above threshold)\n` ) } {}
             ( rt_close e )
             ? > ( string_len op ) 0 {
-                ? ( ppm_write ( string_data op ) im ) { ( p `wrote ` ) ( p ( string_data op ) ) ( p `\n` ) } { ( p `write failed\n` ) }
+                ? ( img_save ( string_data op ) im ) { ( p `wrote ` ) ( p ( string_data op ) ) ( p `\n` ) } { ( p `write failed\n` ) }
             } {}
             ^ 0
         }
-        F _ → { ( p `cannot read image (PPM P6 expected): ` ) ( p ( string_data ip ) ) ( p `\n` ) ^ 1 }
+        F _ → { ( p `cannot read image ` ) ( p ( string_data ip ) ) ( p `: ` ) ( p ( image_error ) ) ( p `\n` ) ^ 1 }
     }
 }
 
@@ -240,7 +250,7 @@ $ `window.nu`
         ~ < z * * cw ch 3 { ( vec_push [u] rgb 0 ) = z + z 1 }
         ? ( cam_grab cam rgb ) {
             = fails 0
-            : Image im @ Image { cw ch rgb 0 }
+            : Image im ( image_of cw ch 3 rgb )
             : i nd ( process_frame im g e names nc want_boxes want_masks F )
             ? == disp 2 {
                 ( xwin_show win im )
@@ -252,7 +262,7 @@ $ `window.nu`
             } {}
             ? save {
                 : String fp ( frame_path ( string_data od ) f )
-                ? ( ppm_write ( string_data fp ) im ) {
+                ? ( img_save ( string_data fp ) im ) {
                     ? == disp 0 { ( p `frame ` ) ( pn f ) ( p `: ` ) ( pn nd ) ( p ` objects -> ` ) ( p ( string_data fp ) ) ( p `\n` ) } {}
                 } { ( p `frame ` ) ( pn f ) ( p ` write failed\n` ) }
             } {}
@@ -285,7 +295,7 @@ $ `window.nu`
     ( p `  --model   <model.onnx>   a YOLOE-seg export from tools/export.py\n` )
     ( p `                           (-> yoloe-v8s-seg.onnx); not bundled (~45 MB).\n` )
     ( p `  --classes <classes.txt>  vocabulary, one prompt word per line.\n` )
-    ( p `  --image   <image.ppm>    input for detect/seg (binary PPM P6).\n` )
+    ( p `  --image   <img>          input for detect/seg (PNG, JPEG or PPM).\n` )
     ( p `  --out     <path>         detect/seg: output image; cam: dir to save frames.\n` )
     ( p `  --device  <dev>          cam webcam device (default /dev/video0).\n` )
     ( p `  --frames  <N>            cam: stop after N frames (default: run until Ctrl-C).\n` )

--- a/packages/yoloe/src/prompt.nu
+++ b/packages/yoloe/src/prompt.nu
@@ -1,6 +1,6 @@
 // packages/yoloe/src/prompt.nu — RUNTIME-promptable open-vocabulary detection.
 //
-//   yoloe-prompt <model.onnx> <tpe.f32> <classes.txt> <image.ppm> [out.ppm]
+//   yoloe-prompt <model.onnx> <tpe.f32> <classes.txt> <img> [out]
 //
 // Unlike src/main.nu (whose vocabulary is baked into the model at export
 // time), this takes the prompt text embeddings as a *runtime input*: the
@@ -25,15 +25,18 @@ $ `decode.nu`
 & `c` @ nurl_peek_f32 *u base i idx → f
 
 @ p s m → v { ( nurl_print m ) }
+
 @ pf f x → v { ( nurl_print ( nurl_str_float x ) ) }
+
 @ pn i n → v { ( nurl_print ( nurl_str_int n ) ) }
 
-@ load_f32 s path *u pcell → *u {
+@ load_f32 s path * u pcell → *u {
     ?? ( read_file_bytes path ) {
         T b → { : i n / ( vec_len [u] b ) 4 : *u h ( nurl_alloc * n 4 )
             : *PbR r ( pb_new b ) ( pb_read_f32_into r h n ) ( pb_free r ) ( nurl_poke pcell 0 n ) ^ h }
         F _ → { ( nurl_poke pcell 0 0 ) ^ # *u 0 } }
 }
+
 @ read_names s path → ( Vec String ) {
     : ( Vec String ) out ( vec_new [String] )
     ?? ( read_file_bytes path ) {
@@ -52,15 +55,18 @@ $ `decode.nu`
     }
     ^ out
 }
+
 @ name_at ( Vec String ) names i i → s { ?? ( vec_get [String] names i ) { T s → ^ ( string_data s ) F _ → ^ `?` } }
+
 @ shape4 i a i b i c i d → ( Vec i ) { : ( Vec i ) v ( vec_new [i] )
     ( vec_push [i] v a ) ( vec_push [i] v b ) ( vec_push [i] v c ) ( vec_push [i] v d ) ^ v }
+
 @ shape3 i a i b i c → ( Vec i ) { : ( Vec i ) v ( vec_new [i] )
     ( vec_push [i] v a ) ( vec_push [i] v b ) ( vec_push [i] v c ) ^ v }
 
 @ main → i {
     : ( Vec String ) av ( env_args_list )
-    ? < ( vec_len [String] av ) 5 { ( p `usage: yoloe-prompt <model.onnx> <tpe.f32> <classes.txt> <image.ppm> [out.ppm]\n` ) ^ 2 } {}
+    ? < ( vec_len [String] av ) 5 { ( p `usage: yoloe-prompt <model.onnx> <tpe.f32> <classes.txt> <img> [out]\n` ) ^ 2 } {}
     : String mp ?? ( vec_get [String] av 1 ) { T x → x F _ → ( string_new ) }
     : String tp ?? ( vec_get [String] av 2 ) { T x → x F _ → ( string_new ) }
     : String np ?? ( vec_get [String] av 3 ) { T x → x F _ → ( string_new ) }
@@ -83,7 +89,7 @@ $ `decode.nu`
     ?? ( read_file_bytes ( string_data mp ) ) { T mb → { = g ( onnx_parse mb ) = have T } F _ → {} }
     ? ! have { ( p `cannot read model\n` ) ^ 1 } {}
 
-    ?? ( ppm_read ( string_data ip ) ) {
+    ?? ( img_load ( string_data ip ) ) {
         T im → {
             ( p `image ` ) ( pn ( img_w im ) ) ( p `x` ) ( pn ( img_h im ) ) ( p `\n` )
             : Letterbox lb ( letterbox im 640 )
@@ -122,10 +128,10 @@ $ `decode.nu`
             ( rt_close e )
             ? > ( vec_len [String] av ) 5 {
                 : String outp ?? ( vec_get [String] av 5 ) { T x → x F _ → ( string_new ) }
-                ? ( ppm_write ( string_data outp ) im ) { ( p `wrote ` ) ( p ( string_data outp ) ) ( p `\n` ) } { ( p `write failed\n` ) }
+                ? ( img_save ( string_data outp ) im ) { ( p `wrote ` ) ( p ( string_data outp ) ) ( p `\n` ) } { ( p `write failed\n` ) }
             } {}
             ^ 0
         }
-        F _ → { ( p `cannot read image (PPM P6 expected)\n` ) ^ 1 }
+        F _ → { ( p `cannot read image: ` ) ( p ( image_error ) ) ( p `\n` ) ^ 1 }
     }
 }

--- a/packages/yoloe/src/v4l2.nu
+++ b/packages/yoloe/src/v4l2.nu
@@ -18,33 +18,44 @@ $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
 
 & `c` @ open s path i flags → i
+
 & `c` @ close i fd → i
+
 & `c` @ ioctl i fd i req *u argp → i
+
 & `c` @ mmap *u addr i length i prot i flags i fd i offset → *u
+
 & `c` @ munmap *u addr i length → i
+
 & `c` @ nurl_peek_i32 *u base i idx → i32
+
 & `c` @ nurl_poke_i32 *u base i idx i32 val → v
 
 // A streaming webcam: fd, frame geometry, and the mmap'd buffer ring.
-: Camera { i fd  i w  i h  i nbuf  ( Vec i ) bufptr  ( Vec i ) buflen  i ok }
+: Camera { i fd i w i h i nbuf ( Vec i ) bufptr ( Vec i ) buflen i ok }
 
 @ __O_RDWR → i { ^ 2 }
-@ __VIDIOC_S_FMT → i { ^ 3234878981 }       // 0xc0d05605
-@ __VIDIOC_REQBUFS → i { ^ 3222558216 }     // 0xc0145608
-@ __VIDIOC_QUERYBUF → i { ^ 3227014665 }    // 0xc0585609
-@ __VIDIOC_QBUF → i { ^ 3227014671 }        // 0xc058560f
-@ __VIDIOC_DQBUF → i { ^ 3227014673 }       // 0xc0585611
-@ __VIDIOC_STREAMON → i { ^ 1074026002 }    // 0x40045612
-@ __VIDIOC_STREAMOFF → i { ^ 1074026003 }   // 0x40045613
-@ __PIXFMT_YUYV → i { ^ 1448695129 }        // 0x56595559 'YUYV'
+
+@ __VIDIOC_S_FMT → i { ^ 3234878981 }  // 0xc0d05605
+@ __VIDIOC_REQBUFS → i { ^ 3222558216 }  // 0xc0145608
+@ __VIDIOC_QUERYBUF → i { ^ 3227014665 }  // 0xc0585609
+@ __VIDIOC_QBUF → i { ^ 3227014671 }  // 0xc058560f
+@ __VIDIOC_DQBUF → i { ^ 3227014673 }  // 0xc0585611
+@ __VIDIOC_STREAMON → i { ^ 1074026002 }  // 0x40045612
+@ __VIDIOC_STREAMOFF → i { ^ 1074026003 }  // 0x40045613
+@ __PIXFMT_YUYV → i { ^ 1448695129 }  // 0x56595559 'YUYV'
 @ __BUF_TYPE_CAPTURE → i { ^ 1 }
+
 @ __MEMORY_MMAP → i { ^ 1 }
+
 @ __FIELD_NONE → i { ^ 1 }
+
 @ __PROT_RW → i { ^ 3 }
+
 @ __MAP_SHARED → i { ^ 1 }
 
 // Zero `nslots` 4-byte slots of a buffer.
-@ __zero *u b i nslots → v {
+@ __zero * u b i nslots → v {
     : ~ i k 0
     ~ < k nslots { ( nurl_poke_i32 b k 0 ) = k + k 1 }
 }
@@ -57,11 +68,11 @@ $ `stdlib/core/string.nu`
     // VIDIOC_S_FMT: request YUYV w×h, progressive.
     : *u fmt ( nurl_alloc 208 )
     ( __zero fmt 52 )
-    ( nurl_poke_i32 fmt 0 ( __BUF_TYPE_CAPTURE ) )   // type @0
-    ( nurl_poke_i32 fmt 2 w )                         // pix.width @8
-    ( nurl_poke_i32 fmt 3 h )                         // pix.height @12
-    ( nurl_poke_i32 fmt 4 ( __PIXFMT_YUYV ) )         // pix.pixelformat @16
-    ( nurl_poke_i32 fmt 5 ( __FIELD_NONE ) )          // pix.field @20
+    ( nurl_poke_i32 fmt 0 ( __BUF_TYPE_CAPTURE ) )  // type @0
+    ( nurl_poke_i32 fmt 2 w )  // pix.width @8
+    ( nurl_poke_i32 fmt 3 h )  // pix.height @12
+    ( nurl_poke_i32 fmt 4 ( __PIXFMT_YUYV ) )  // pix.pixelformat @16
+    ( nurl_poke_i32 fmt 5 ( __FIELD_NONE ) )  // pix.field @20
     : i rf ( ioctl fd ( __VIDIOC_S_FMT ) fmt )
     ? < rf 0 { ( close fd ) ( nurl_free fmt )
         ^ @ Camera { - 0 1 w h 0 ( vec_new [i] ) ( vec_new [i] ) 0 } } {}
@@ -73,9 +84,9 @@ $ `stdlib/core/string.nu`
     // VIDIOC_REQBUFS: nbuf mmap buffers.
     : *u rb ( nurl_alloc 20 )
     ( __zero rb 5 )
-    ( nurl_poke_i32 rb 0 nbuf )                       // count @0
-    ( nurl_poke_i32 rb 1 ( __BUF_TYPE_CAPTURE ) )     // type @4
-    ( nurl_poke_i32 rb 2 ( __MEMORY_MMAP ) )          // memory @8
+    ( nurl_poke_i32 rb 0 nbuf )  // count @0
+    ( nurl_poke_i32 rb 1 ( __BUF_TYPE_CAPTURE ) )  // type @4
+    ( nurl_poke_i32 rb 2 ( __MEMORY_MMAP ) )  // memory @8
     : i rr ( ioctl fd ( __VIDIOC_REQBUFS ) rb )
     : i got ( nurl_peek_i32 rb 0 )
     ( nurl_free rb )
@@ -90,12 +101,12 @@ $ `stdlib/core/string.nu`
     ~ < bi got {
         : *u bf ( nurl_alloc 88 )
         ( __zero bf 22 )
-        ( nurl_poke_i32 bf 0 bi )                     // index @0
-        ( nurl_poke_i32 bf 1 ( __BUF_TYPE_CAPTURE ) ) // type @4
-        ( nurl_poke_i32 bf 15 ( __MEMORY_MMAP ) )     // memory @60
+        ( nurl_poke_i32 bf 0 bi )  // index @0
+        ( nurl_poke_i32 bf 1 ( __BUF_TYPE_CAPTURE ) )  // type @4
+        ( nurl_poke_i32 bf 15 ( __MEMORY_MMAP ) )  // memory @60
         : i qr ( ioctl fd ( __VIDIOC_QUERYBUF ) bf )
-        : i moff ( nurl_peek_i32 bf 16 )              // m.offset @64
-        : i blen ( nurl_peek_i32 bf 18 )              // length @72
+        : i moff ( nurl_peek_i32 bf 16 )  // m.offset @64
+        : i blen ( nurl_peek_i32 bf 18 )  // length @72
         ? < qr 0 { = allok F } {
             : *u m ( mmap # *u 0 blen ( __PROT_RW ) ( __MAP_SHARED ) fd moff )
             ? | == # i m 0 == # i m - 0 1 { = allok F } {
@@ -120,7 +131,9 @@ $ `stdlib/core/string.nu`
 }
 
 @ cam_ok Camera c → b { ^ != . c ok 0 }
+
 @ cam_w Camera c → i { ^ . c w }
+
 @ cam_h Camera c → i { ^ . c h }
 
 @ __clip255 i v → i { ^ ? < v 0 0 ? > v 255 255 v }
@@ -130,11 +143,11 @@ $ `stdlib/core/string.nu`
 @ cam_grab Camera c ( Vec u ) rgb → b {
     : *u bf ( nurl_alloc 88 )
     ( __zero bf 22 )
-    ( nurl_poke_i32 bf 1 ( __BUF_TYPE_CAPTURE ) )    // type @4
-    ( nurl_poke_i32 bf 15 ( __MEMORY_MMAP ) )        // memory @60
+    ( nurl_poke_i32 bf 1 ( __BUF_TYPE_CAPTURE ) )  // type @4
+    ( nurl_poke_i32 bf 15 ( __MEMORY_MMAP ) )  // memory @60
     : i dr ( ioctl . c fd ( __VIDIOC_DQBUF ) bf )
     ? < dr 0 { ( nurl_free bf ) ^ F } {}
-    : i idx ( nurl_peek_i32 bf 0 )                    // index @0
+    : i idx ( nurl_peek_i32 bf 0 )  // index @0
     : *u src # *u ?? ( vec_get [i] . c bufptr idx ) { T x → x F _ → 0 }
     : i w . c w
     : i h . c h
@@ -143,7 +156,8 @@ $ `stdlib/core/string.nu`
     : i ngrp / npix 2
     : ~ i gi 0
     ~ < gi ngrp {
-        : i v & ( nurl_peek_i32 src gi ) 4294967295
+        // widen the i32 group to i before masking (& needs matching types)
+        : i v & # i ( nurl_peek_i32 src gi ) 4294967295
         : i y0 & v 255
         : i uu & >> v 8 255
         : i y1 & >> v 16 255

--- a/packages/yoloe/tests/camtest.nu
+++ b/packages/yoloe/tests/camtest.nu
@@ -12,6 +12,7 @@ $ `../src/image.nu`
 $ `../src/v4l2.nu`
 
 @ p s m → v { ( nurl_print m ) }
+
 @ pn i n → v { ( nurl_print ( nurl_str_int n ) ) }
 
 @ main → i {
@@ -41,6 +42,6 @@ $ `../src/v4l2.nu`
     ( p `grabbed ` ) ( pn ok ) ( p ` frames\n` )
     ( cam_close c )
 
-    : Image im @ Image { aw ah rgb 0 }
-    ? ( ppm_write ( string_data outp ) im ) { ( p `wrote ` ) ( p ( string_data outp ) ) ( p `\n` ) ^ 0 } { ( p `write failed\n` ) ^ 1 }
+    : Image im ( image_of aw ah 3 rgb )
+    ? ( img_save ( string_data outp ) im ) { ( p `wrote ` ) ( p ( string_data outp ) ) ( p `\n` ) ^ 0 } { ( p `write failed\n` ) ^ 1 }
 }

--- a/packages/yoloe/tests/seg_fwd.nu
+++ b/packages/yoloe/tests/seg_fwd.nu
@@ -19,13 +19,14 @@ $ `../src/image.nu`
 
 & `c` @ nurl_peek_f32 *u base i idx → f
 
-@ load_f32 s path *u pcell → *u {
+@ load_f32 s path * u pcell → *u {
     ?? ( read_file_bytes path ) {
         T bytes → { : i n / ( vec_len [u] bytes ) 4 : *u host ( nurl_alloc * n 4 )
             : *PbR r ( pb_new bytes ) ( pb_read_f32_into r host n ) ( pb_free r ) ( nurl_poke pcell 0 n ) ^ host }
         F _ → { ( nurl_poke pcell 0 0 ) ^ # *u 0 }
     }
 }
+
 @ shape4 i a i b i c i d → ( Vec i ) {
     : ( Vec i ) v ( vec_new [i] ) ( vec_push [i] v a ) ( vec_push [i] v b ) ( vec_push [i] v c ) ( vec_push [i] v d ) ^ v
 }
@@ -42,7 +43,7 @@ $ `../src/image.nu`
     ( nurl_print `out0=` ) ( nurl_print ( string_data . g output_name ) )
     ( nurl_print ` out1=` ) ( nurl_print ( string_data . g output1_name ) ) ( nurl_print `\n` )
 
-    ?? ( ppm_read ( string_data ip ) ) {
+    ?? ( img_load ( string_data ip ) ) {
         T im → {
             : Letterbox lb ( letterbox im 640 )
             : *u host ( img_to_nchw_norm . lb img )

--- a/packages/yoloe/tests/wintest.nu
+++ b/packages/yoloe/tests/wintest.nu
@@ -16,7 +16,7 @@ $ `../src/window.nu`
     ? < ( vec_len [String] av ) 2 { ( nurl_print `usage: wintest <image.ppm> [iters]\n` ) ^ 2 } {}
     : String ip ?? ( vec_get [String] av 1 ) { T x → x F _ → ( string_new ) }
     : i iters ? > ( vec_len [String] av ) 2 ( nurl_str_to_int ?? ( vec_get [String] av 2 ) { T x → ( string_data x ) F _ → `60` } ) 60
-    ?? ( ppm_read ( string_data ip ) ) {
+    ?? ( img_load ( string_data ip ) ) {
         T im → {
             : i w ( img_w im )
             : i h ( img_h im )


### PR DESCRIPTION
## packages/image 0.4.0 + objdet 0.3.0 + yoloe 0.5.0

Closes the remaining diamond gaps for packages/image: the decoder now matches libjpeg's default chroma path exactly, and the two real consumers stop hand-rolling image code.

### image — fancy chroma upsampling
- 2x1/2x2 chroma expansion now uses libjpeg's default **"fancy" (triangular) upsampler**, bit-matching jdsample.c (1/2 and 8/7 rounding biases, edge clamping); other ratios keep box, as libjpeg does. Shared by baseline + progressive decode.
- 4:2:0 decode vs Pillow is now IDCT-rounding-level: synthetic max_diff **3** (tolerance tightened 12 → 4), real 1-Mpx photos max **3**, mean ≈ 0.02.

### objdet — wired onto image (0.3.0)
- Private PPM/resize/draw deleted; `src/image.nu` is a thin adapter. Reads photos (PNG/JPEG/PPM) and writes annotated PNG/JPEG directly — no ImageMagick.
- **Equivalence proven**: old vs new path produce a bit-identical 3×416×416 NCHW tensor on a real 1200×669 photo.
- Fixed a real leak: `voc_class` built a fresh `Vec String` per call and returned a borrow into it. Unit suite now ASan-clean.

### yoloe — wired onto image (0.5.0)
- Private PPM/drawing deleted; letterbox (ultralytics-matching) + [0,1] NCHW stay local. `seg`/`detect` take photos directly, masks written as PNG.
- **Equivalence proven**: letterbox(640) + NCHW bit-identical (0 float mismatches).
- **Live GPU run**: `yoloe seg --image bus.jpg` on the RTX 4090 → 4 persons + vehicle, pixel-tight masks (matches the previously verified result).
- Fixes `yoloe cam` on main: v4l2 YUYV masking tripped the newer `& requires matching types` check (i32 vs i).

### Tests
- image: full suite PASS (PNG matrix, JPEG decode/encode vs Pillow with tightened 4:2:0 tolerances, CLI, fuzz, ASan).
- objdet: unit suite ALL PASS + ASan-clean.
- yoloe: all 5 entrypoints build; live GPU seg verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7