### PR TITLE
feat(nurl-mcp): serve --http through the stdlib Streamable-HTTP facade

### DIFF
--- a/packages/nurl-mcp/README.md
+++ b/packages/nurl-mcp/README.md
@@ -60,8 +60,12 @@ too — the server leaves nothing behind).
 **stdio** (default) — described above; the client spawns the binary and talks
 over the pipe. Nothing listens on the network.
 
-**HTTP** (`--http`) — Streamable-HTTP-style `POST /mcp` (JSON-RPC in, JSON-RPC
-out), for clients that speak MCP over HTTP or when the agent runs elsewhere.
+**HTTP** (`--http`) — the MCP **Streamable HTTP** transport, served through
+the stdlib facade (`ext/mcp_http.nu`, the same plumbing swarm-mcp uses):
+`POST /mcp` single requests **and JSON-RPC batches**, `GET /mcp` SSE probe,
+`Mcp-Session-Id` echo, `DELETE /mcp`, CORS + preflight. Bearer-token auth
+wraps the whole endpoint. For clients that speak MCP over HTTP or when the
+agent runs elsewhere.
 
 ```
 nurl-mcp --http [--host ADDR] [--port N] [--token TOK] [--read-only] [--allow-run]

--- a/packages/nurl-mcp/nurl.toml
+++ b/packages/nurl-mcp/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nurl-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local MCP server for the NURL toolchain — exposes the installed compiler over Model Context Protocol so an LLM agent on the host can build, run, type-check, format, and compile NURL to wasm32-wasi (fully local wasm builds via the wasmbuilder package), and read the installed stdlib. Stdio by default; an optional token-authenticated HTTP transport (--http) gates code execution behind --allow-run. The editor-facing counterpart of nurl-lsp, for LLMs."
 license = "MIT OR Apache-2.0"
 

--- a/packages/nurl-mcp/src/main.nu
+++ b/packages/nurl-mcp/src/main.nu
@@ -14,8 +14,11 @@
 // (found on $PATH — the installed toolchain shims export $NURL_STDLIB so the
 // compiler resolves stdlib imports). Running NURL is full code execution
 // (libc FFI, no sandbox); over stdio that is safe because only the process
-// that spawned this server talks to it. A network (`--http`) transport with
-// token auth is intentionally deferred to a later version.
+// that spawned this server talks to it. The `--http` transport serves the
+// MCP Streamable-HTTP protocol via the stdlib facade (`ext/mcp_http.nu`:
+// POST single/batch, GET SSE probe, Mcp-Session-Id echo, DELETE, CORS)
+// with bearer-token auth layered on top; nurl_run stays off over HTTP
+// unless --allow-run is given.
 
 $ `stdlib/ext/mcp.nu`
 $ `stdlib/ext/json.nu`
@@ -26,10 +29,10 @@ $ `stdlib/ext/env.nu`
 $ `stdlib/core/posix.nu`
 $ `stdlib/std/args.nu`
 $ `stdlib/std/net.nu`
-$ `stdlib/std/bytes.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`
+$ `stdlib/ext/mcp_http.nu`
 $ `stdlib/std/encode.nu`
 $ `deps/wasmbuilder/src/build.nu`
 
@@ -547,6 +550,7 @@ $ `deps/wasmbuilder/src/build.nu`
 
 // Policy predicates (read the globals set in main).
 @ nm_build_ok → b { ^ ? == g_read_only 0 T F }
+
 @ nm_run_ok → b { ^ ? & == g_read_only 0 != g_run_allowed 0 T F }
 
 @ build_tools_list → ( Vec Json ) {
@@ -605,7 +609,7 @@ $ `deps/wasmbuilder/src/build.nu`
 // examples/mcp_echo_server_http.nu, used by both transports) ─────────
 
 @ handle_initialize Json id → Json {
-    : Json result ( mcp_initialize_result `nurl-mcp` `0.3.0` )
+    : Json result ( mcp_initialize_result `nurl-mcp` `0.4.0` )
     ^ ( mcp_response_result id result )
 }
 
@@ -717,12 +721,18 @@ $ `deps/wasmbuilder/src/build.nu`
     }
 }
 
-// ── HTTP transport (POST /mcp, bearer-token auth, permissive CORS) ───
+// ── HTTP transport ───────────────────────────────────────────────────
+//
+// The wire protocol (POST single/batch, GET SSE probe, DELETE,
+// Mcp-Session-Id echo, CORS + preflight) comes from the stdlib's
+// Streamable-HTTP facade (`ext/mcp_http.nu` — the same plumbing
+// swarm-mcp serves through); this file only layers bearer-token auth
+// around it. CORS headers for the auth reject, matching the facade's.
 
 @ nm_cors HttpResponse r → v {
     ( response_set_header r `Access-Control-Allow-Origin` `*` )
     ( response_set_header r `Access-Control-Allow-Headers` `Content-Type, Authorization, Mcp-Session-Id` )
-    ( response_set_header r `Access-Control-Allow-Methods` `POST, OPTIONS` )
+    ( response_set_header r `Access-Control-Allow-Methods` `POST, GET, DELETE, OPTIONS` )
 }
 
 @ nm_authed HttpRequest req → b {
@@ -742,64 +752,6 @@ $ `deps/wasmbuilder/src/build.nu`
     ^ F
 }
 
-@ http_handler HttpRequest req → HttpResponse {
-    : s rm ( string_data . req method )
-    ? != ( nurl_str_eq rm `OPTIONS` ) 0 {
-        : HttpResponse pre ( response_status_only 204 )
-        ( nm_cors pre )
-        ^ pre
-    } {}
-    ? != ( nurl_str_eq rm `POST` ) 0 {} {
-        : HttpResponse r ( response_text 405 `Method Not Allowed\n` )
-        ( response_set_header r `Allow` `POST, OPTIONS` )
-        ( nm_cors r )
-        ^ r
-    }
-    ? ! ( nm_authed req ) {
-        : HttpResponse r ( response_text 401 `Unauthorized\n` )
-        ( response_set_header r `WWW-Authenticate` `Bearer` )
-        ( nm_cors r )
-        ^ r
-    } {}
-    : i bn ( vec_len [u] . req body )
-    ? <= bn 0 {
-        : HttpResponse r ( response_text 400 `empty request body\n` )
-        ( nm_cors r )
-        ^ r
-    } {}
-    : String body_str ( bytes_to_str . req body )
-    : !Json JsonError pj ( json_parse ( string_data body_str ) )
-    ( string_free body_str )
-    ?? pj {
-        T jreq → {
-            : ?Json reply ( dispatch jreq )
-            ( json_free jreq )
-            ?? reply {
-                T resp → {
-                    : HttpResponse r ( response_json 200 resp )
-                    ( json_free resp )
-                    ( nm_cors r )
-                    ^ r
-                }
-                F empty → {
-                    ( json_free empty )
-                    : HttpResponse r ( response_status_only 202 )
-                    ( nm_cors r )
-                    ^ r
-                }
-            }
-        }
-        F e → {
-            : HttpResponse r ( response_text 400 `request body is not valid JSON\n` )
-            ( nm_cors r )
-            ^ r
-        }
-    }
-    : HttpResponse r ( response_text 500 `internal\n` )
-    ( nm_cors r )
-    ^ r
-}
-
 @ nm_is_loopback s host → b {
     ? != ( nurl_str_eq host `127.0.0.1` ) 0 { ^ T } {}
     ? != ( nurl_str_eq host `::1` ) 0 { ^ T } {}
@@ -811,7 +763,19 @@ $ `deps/wasmbuilder/src/build.nu`
     : !TcpListener NetErr lr ( tcp_listen host port )
     ?? lr {
         T listener → {
-            : ( @ HttpResponse HttpRequest ) h \ HttpRequest req → HttpResponse { ^ ( http_handler req ) }
+            // The facade handles the whole MCP wire protocol; auth wraps it.
+            // OPTIONS bypasses auth (browser preflights carry no headers).
+            : ( @ HttpResponse HttpRequest ) inner ( mcp_http_handler \ Json rq → ?Json { ^ ( dispatch rq ) } )
+            : ( @ HttpResponse HttpRequest ) h \ HttpRequest req → HttpResponse {
+                ? != ( nurl_str_eq ( string_data . req method ) `OPTIONS` ) 0 { ^ ( inner req ) } {}
+                ? ! ( nm_authed req ) {
+                    : HttpResponse r ( response_text 401 `Unauthorized\n` )
+                    ( response_set_header r `WWW-Authenticate` `Bearer` )
+                    ( nm_cors r )
+                    ^ r
+                } {}
+                ^ ( inner req )
+            }
             : HttpServer srv ( server_new listener h )
             : !v NetErr rr ( server_run srv )
             ( server_stop srv )


### PR DESCRIPTION
## nurl-mcp 0.4.0

nurl-mcp's `--http` was a hand-rolled single-POST handler that reimplemented (a subset of) what `stdlib/ext/mcp_http.nu` already ships — manual CORS on every response path, **no batch support, 405 on GET, no `Mcp-Session-Id`**.

Now it mounts the stdlib **Streamable HTTP** facade (the same plumbing swarm-mcp uses); nurl-mcp's own layer is just bearer-token auth wrapped around the handler (OPTIONS preflight bypasses auth — browser preflights carry no headers).

### Gained for free
| | before | after |
|---|---|---|
| JSON-RPC batch | ✗ | ✅ |
| `GET /mcp` (SSE probe) | 405 | ✅ `text/event-stream` |
| `Mcp-Session-Id` echo | ✗ | ✅ |
| `DELETE /mcp` | 405 | ✅ |
| CORS | hand-rolled | facade (incl. preflight + Max-Age) |

### Verified live
401 without bearer · 204 preflight without auth · initialize · 2-element batch · SSE content-type · session-id round-trip · read-only gating holds (6 tools over HTTP vs 7 on stdio). stdio transport untouched; ASan-clean.

Note: this deliberately does **not** use packages/http — a single MCP endpoint needs the MCP transport facade, not a web-app framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7