### PR TITLE
feat(cli): default command + help-short yield; migrate yoloe/redis/psql onto the cli package

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 0.2.0
+
+Driven by migrating yoloe, redis and psql onto the facade:
+
+- **`cli_default c handler`** — register a default command for programs that
+  *are* the command (psql/redis-cli shape): a bare invocation runs it instead
+  of printing usage, and a first positional that matches no subcommand (e.g.
+  a `redis://…` connection URL) routes to it and stays readable as
+  `ctx_arg 0`. Registered subcommands still win; the default is hidden from
+  the help's command list and the usage line shows `[COMMAND]`.
+- **Automatic help-short yield** — when a user flag claims short `-h`
+  (psql-style `-h HOST`), the built-in help drops its short and remains
+  reachable as `--help`.
+- `ctx_arg` / `ctx_nargs` are default-command-aware (no command token to
+  skip when the ctx carries an empty command name).
+
+## 0.1.0
+
+Initial release: `Cli` builder over std/args + std/term + ext/env —
+subcommand dispatch, typed global flags with env fallbacks and defaults,
+coloured `--help`/`--version`, exit-code conventions, and interactive
+prompts (`cli_prompt` / `cli_confirm` / `cli_password`).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,6 +68,7 @@ Commands — the handler is `( @ i CliCtx )`, returning an exit code:
 | Call | |
 | --- | --- |
 | `( cli_cmd c name help handler )` | register a subcommand |
+| `( cli_default c handler )` | the default command — runs on a bare invocation or when no subcommand matches (psql/redis-cli-style tools where the program *is* the command; positionals such as a connection URL stay readable via `ctx_arg`) |
 
 Inside a handler, read from the `CliCtx`:
 
@@ -93,11 +94,15 @@ Interactive prompts (write to stderr; TTY-aware):
 
 - **`--help` / `-h`** — auto-generated global help (usage, aligned command
   list, options with defaults and env vars). `prog <cmd> --help` gives the
-  command's help. **`--version`** prints `prog version`.
+  command's help. **`--version`** prints `prog version`. If one of *your*
+  flags claims short `-h` (psql-style `-h HOST`), the built-in help
+  automatically yields the short and stays reachable as `--help`.
 - **Colour** is decided once: on only when stdout is a TTY and `$NO_COLOR`
   is unset. Piped output is plain.
 - **Exit codes** — a command returns its own; unknown command or a parse
-  error is `2`; a bare invocation with no command prints help and exits `1`.
+  error is `2`; a bare invocation with no command prints help and exits `1` —
+  unless a `cli_default` is registered, in which case both a bare invocation
+  and an unmatched first token route to it (the token becomes `ctx_arg 0`).
 - **Flag resolution** — an explicit `--flag` wins, else the bound env var,
   else the declared default.
 

--- a/packages/cli/nurl.toml
+++ b/packages/cli/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "The ergonomic command-line framework for NURL. A single dependency-importable facade over the stdlib command-line surface (std/args parser, std/term isatty + ANSI + line editor, core/io stdin/stdout, ext/env environment). Where the stdlib ships a flat argument parser, `cli` ships the glue every tool re-invents: a `Cli` object with git-style subcommand routing, typed flag accessors (string/int/bool/float) with environment-variable fallbacks and defaults, auto-generated and colour-aware --help / --version / usage, error → exit-code handling, and interactive prompts (confirm / prompt / no-echo password). `( cli_new … )`, a few `( cli_flag_* … )` and `( cli_cmd … )` registrations, and `( cli_run c )` stand up a complete, polished CLI — collapsing the ~100–500 line hand-written main() that every package carries today. Colours are TTY-gated and respect $NO_COLOR. Facades the command-line surface only; terminal widgets, config files and logging compose as separate packages."
 license = "MIT OR Apache-2.0"
 

--- a/packages/cli/src/cli.nu
+++ b/packages/cli/src/cli.nu
@@ -42,12 +42,12 @@ $ `prompt.nu`
 //   0 = string   1 = int   2 = bool (presence)   3 = float
 : CliFlag {
     String long
-    i short          // short-option char code, 0 = none
-    String metavar   // value placeholder in help (empty for bool)
+    i short  // short-option char code, 0 = none
+    String metavar  // value placeholder in help (empty for bool)
     String help
     i kind
-    String dflt      // default rendered as text (empty = none)
-    String env       // environment-variable fallback (empty = none)
+    String dflt  // default rendered as text (empty = none)
+    String env  // environment-variable fallback (empty = none)
 }
 
 : CliCmd {
@@ -68,7 +68,7 @@ $ `prompt.nu`
 // the Cli so accessors can resolve env fallbacks and defaults.
 : CliCtx {
     ArgParser parser
-    *Cli cli
+    * Cli cli
     String cmdname
 }
 
@@ -104,6 +104,7 @@ $ `prompt.nu`
     ( string_free o )
     ^ r
 }
+
 @ __fg i color s text → String {
     : String o ( ansi_fg color )
     : String r ( __wrap ( string_data o ) text )
@@ -155,7 +156,7 @@ $ `prompt.nu`
     ( vec_free [CliCmd] v )
 }
 
-@ cli_free *Cli c → v {
+@ cli_free * Cli c → v {
     ( string_free . c prog )
     ( string_free . c about )
     ( string_free . c version )
@@ -166,7 +167,7 @@ $ `prompt.nu`
 
 // ── Flag builders (global flags; applied across all commands) ──────────
 
-@ __cli_add_flag *Cli c s long i short s metavar s help i kind s dflt s env → v {
+@ __cli_add_flag * Cli c s long i short s metavar s help i kind s dflt s env → v {
     : CliFlag f @ CliFlag {
         ( string_from long ) short ( string_from metavar ) ( string_from help )
         kind ( string_from dflt ) ( string_from env )
@@ -174,19 +175,22 @@ $ `prompt.nu`
     ( vec_push [CliFlag] . c globals f )
 }
 
-@ cli_flag_bool *Cli c s long i short s help → v {
+@ cli_flag_bool * Cli c s long i short s help → v {
     ( __cli_add_flag c long short `` help 2 `` `` )
 }
-@ cli_flag_str *Cli c s long i short s metavar s help s dflt s env → v {
+
+@ cli_flag_str * Cli c s long i short s metavar s help s dflt s env → v {
     ( __cli_add_flag c long short metavar help 0 dflt env )
 }
-@ cli_flag_int *Cli c s long i short s metavar s help i dflt s env → v {
+
+@ cli_flag_int * Cli c s long i short s metavar s help i dflt s env → v {
     : String d ( string_new )
     ( string_push_int d dflt )
     ( __cli_add_flag c long short metavar help 1 ( string_data d ) env )
     ( string_free d )
 }
-@ cli_flag_float *Cli c s long i short s metavar s help f dflt s env → v {
+
+@ cli_flag_float * Cli c s long i short s metavar s help f dflt s env → v {
     : String d ( string_new )
     ( string_push_float d dflt )
     ( __cli_add_flag c long short metavar help 3 ( string_data d ) env )
@@ -195,13 +199,24 @@ $ `prompt.nu`
 
 // ── Command registration ──────────────────────────────────────────────
 
-@ cli_cmd *Cli c s name s help ( @ i CliCtx ) handler → v {
+@ cli_cmd * Cli c s name s help ( @ i CliCtx ) handler → v {
     : CliCmd cmd @ CliCmd { ( string_from name ) ( string_from help ) handler }
     ( vec_push [CliCmd] . c cmds cmd )
 }
 
+// Default handler — the whole program IS the command (psql/redis-cli style:
+// bare invocation acts, positionals like a connection URL are arguments, not
+// subcommand names). Stored as the reserved empty-name command. When set:
+// a first non-option token that matches no registered command routes here
+// (and stays readable as ctx_arg 0), and a bare invocation runs it instead
+// of printing usage. Registered subcommands still win when they match.
+@ cli_default * Cli c ( @ i CliCtx ) handler → v {
+    : CliCmd cmd @ CliCmd { ( string_new ) ( string_new ) handler }
+    ( vec_push [CliCmd] . c cmds cmd )
+}
+
 // Index of the command named `name`, or None.
-@ __cli_find_cmd *Cli c s name → ?i {
+@ __cli_find_cmd * Cli c s name → ?i {
     : i n ( vec_len [CliCmd] . c cmds )
     : ~ i k 0
     ~ < k n {
@@ -219,7 +234,7 @@ $ `prompt.nu`
 // ── Context accessors (used inside handlers) ──────────────────────────
 
 // Resolve a string flag: explicit value → env fallback → default → "".
-@ __cli_fallback *Cli c s name → String {
+@ __cli_fallback * Cli c s name → String {
     : i n ( vec_len [CliFlag] . c globals )
     : ~ i k 0
     ~ < k n {
@@ -270,10 +285,13 @@ $ `prompt.nu`
     ^ ( args_present . x parser name )
 }
 
-// Number of positional arguments after the command token.
+// Number of positional arguments after the command token. Under the default
+// handler (empty cmdname) there is no command token to skip — every
+// positional (e.g. a connection URL) is an argument.
 @ ctx_nargs CliCtx x → i {
     : i n ( args_positional_count . x parser )
-    ? > n 0 { ^ - n 1 } {}
+    : i skip ? > ( string_len . x cmdname ) 0 { 1 } { 0 }
+    ? > n skip { ^ - n skip } {}
     ^ 0
 }
 
@@ -283,7 +301,7 @@ $ `prompt.nu`
 @ ctx_arg CliCtx x i idx → String {
     : ( Vec String ) pos ( args_positionals . x parser )
     : i n ( vec_len [String] pos )
-    : i want + idx 1
+    : i want + idx ? > ( string_len . x cmdname ) 0 { 1 } { 0 }
     ? < want n {
         ?? ( vec_get [String] pos want ) {
             T t → { ^ ( string_from ( string_data t ) ) }
@@ -343,7 +361,7 @@ $ `prompt.nu`
     ~ < pw 24 { ( string_push_char out 32 ) = pw + pw 1 }
 }
 
-@ __cli_render_options *Cli c String out → v {
+@ __cli_render_options * Cli c String out → v {
     : String hdr ( __sgr 1 `OPTIONS` )
     ( string_push_str out ( string_data hdr ) )
     ( string_push_char out 10 )
@@ -381,7 +399,7 @@ $ `prompt.nu`
 }
 
 // Longest command name, for column alignment.
-@ __cli_cmd_width *Cli c → i {
+@ __cli_cmd_width * Cli c → i {
     : i n ( vec_len [CliCmd] . c cmds )
     : ~ i w 0
     : ~ i k 0
@@ -395,7 +413,7 @@ $ `prompt.nu`
     ^ w
 }
 
-@ __cli_print_help *Cli c → v {
+@ __cli_print_help * Cli c → v {
     : String out ( string_new )
     // header
     : String prog ( __sgr 1 ( string_data . c prog ) )
@@ -417,10 +435,12 @@ $ `prompt.nu`
     ( string_free uh )
     ( string_push_str out `\n  ` )
     ( string_push_str out ( string_data . c prog ) )
-    ( string_push_str out ` [OPTIONS] <COMMAND> [ARGS]\n\n` )
-    // commands
+    : b has_dflt ?? ( __cli_find_cmd c `` ) { T _ → T F _ → F }
+    ( string_push_str out ? has_dflt { ` [OPTIONS] [COMMAND] [ARGS]\n\n` } { ` [OPTIONS] <COMMAND> [ARGS]\n\n` } )
+    // commands (the reserved empty-name default is not listed)
     : i nc ( vec_len [CliCmd] . c cmds )
-    ? > nc 0 {
+    : i nvis ? has_dflt { - nc 1 } { nc }
+    ? > nvis 0 {
         : String ch ( __sgr 1 `COMMANDS` )
         ( string_push_str out ( string_data ch ) )
         ( string_push_char out 10 )
@@ -430,15 +450,17 @@ $ `prompt.nu`
         ~ < k nc {
             ?? ( vec_get [CliCmd] . c cmds k ) {
                 T cm → {
-                    : String nm ( __fg 6 ( string_data . cm name ) )
-                    ( string_push_str out `  ` )
-                    ( string_push_str out ( string_data nm ) )
-                    : i raw ( string_len . cm name )
-                    : ~ i pw raw
-                    ~ < pw w { ( string_push_char out 32 ) = pw + pw 1 }
-                    ( string_push_str out ( string_data . cm help ) )
-                    ( string_push_char out 10 )
-                    ( string_free nm )
+                    ? == ( string_len . cm name ) 0 {} {
+                        : String nm ( __fg 6 ( string_data . cm name ) )
+                        ( string_push_str out `  ` )
+                        ( string_push_str out ( string_data nm ) )
+                        : i raw ( string_len . cm name )
+                        : ~ i pw raw
+                        ~ < pw w { ( string_push_char out 32 ) = pw + pw 1 }
+                        ( string_push_str out ( string_data . cm help ) )
+                        ( string_push_char out 10 )
+                        ( string_free nm )
+                    }
                 }
                 F _ → {}
             }
@@ -457,7 +479,7 @@ $ `prompt.nu`
     ( string_free out )
 }
 
-@ __cli_print_cmd_help *Cli c i idx → v {
+@ __cli_print_cmd_help * Cli c i idx → v {
     : String out ( string_new )
     ?? ( vec_get [CliCmd] . c cmds idx ) {
         T cm → {
@@ -488,7 +510,7 @@ $ `prompt.nu`
 }
 
 // A styled "error: <msg>" line + usage hint on stderr.
-@ __cli_err *Cli c s msg → v {
+@ __cli_err * Cli c s msg → v {
     : String pre ( __fg 1 `error:` )
     ( nurl_eprint ( string_data pre ) )
     ( string_free pre )
@@ -501,7 +523,7 @@ $ `prompt.nu`
 
 // ── Run ───────────────────────────────────────────────────────────────
 
-@ __cli_register_flags *Cli c ArgParser p → v {
+@ __cli_register_flags * Cli c ArgParser p → v {
     : i n ( vec_len [CliFlag] . c globals )
     : ~ i k 0
     ~ < k n {
@@ -519,7 +541,27 @@ $ `prompt.nu`
     }
 }
 
-@ __cli_dispatch *Cli c i idx CliCtx ctx → i {
+// Run the reserved empty-name default command, if one is registered.
+// Some(rc) when it ran (or when --help short-circuited it); None when no
+// default exists. The ctx carries an EMPTY cmdname so ctx_arg/ctx_nargs
+// treat every positional as an argument.
+@ __cli_try_default * Cli c ArgParser p → ?i {
+    ?? ( __cli_find_cmd c `` ) {
+        T didx → {
+            ? ( args_present p `help` ) {
+                ( __cli_print_help c )
+                ^ @ ?i { T 0 }
+            } {}
+            : CliCtx ctx @ CliCtx { p c ( string_new ) }
+            : i rc ( __cli_dispatch c didx ctx )
+            ( string_free . ctx cmdname )
+            ^ @ ?i { T rc }
+        }
+        F _ → { ^ @ ?i { F } }
+    }
+}
+
+@ __cli_dispatch * Cli c i idx CliCtx ctx → i {
     ?? ( vec_get [CliCmd] . c cmds idx ) {
         T cm → {
             : ( @ i CliCtx ) f . cm handler
@@ -529,7 +571,7 @@ $ `prompt.nu`
     }
 }
 
-@ __cli_print_version *Cli c → v {
+@ __cli_print_version * Cli c → v {
     ( nurl_print ( string_data . c prog ) )
     ( nurl_print ` ` )
     ( nurl_print ( string_data . c version ) )
@@ -538,7 +580,7 @@ $ `prompt.nu`
 
 // Parse the real argv, route to a subcommand, and return its exit code.
 // Handles `--help` / `--version`, unknown commands, and parse errors.
-@ cli_run *Cli c → i {
+@ cli_run * Cli c → i {
     ( __cli_detect_color )
 
     : ( Vec String ) argv ( env_args_list )
@@ -572,8 +614,21 @@ $ `prompt.nu`
         = j + j 1
     }
 
+    // --help gets short -h only when no user flag claims it (psql-style
+    // CLIs use -h for the host; their --help stays reachable long-form).
+    : ~ i help_short 104
+    : i ngf ( vec_len [CliFlag] . c globals )
+    : ~ i gk 0
+    ~ < gk ngf {
+        ?? ( vec_get [CliFlag] . c globals gk ) {
+            T f → { ? == . f short 104 { = help_short 0 } {} }
+            F _ → {}
+        }
+        = gk + gk 1
+    }
+
     : ArgParser p ( args_new ( string_data . c prog ) ( string_data . c about ) )
-    ( args_flag p `help` 104 `show this help` )
+    ( args_flag p `help` help_short `show this help` )
     ( args_flag p `version` 0 `print the version` )
     ( __cli_register_flags c p )
     : b okp ( args_parse p toks )
@@ -583,34 +638,47 @@ $ `prompt.nu`
         ( __cli_err c ( args_error p ) )
         = rc 2
     } {
-    ? & ! found ( args_present p `version` ) {
-        ( __cli_print_version c )
-    } {
-    ? found {
-        ?? ( __cli_find_cmd c cmdname ) {
-            T idx → {
-                ? ( args_present p `help` ) {
-                    ( __cli_print_cmd_help c idx )
-                } {
-                    : CliCtx ctx @ CliCtx { p c ( string_from cmdname ) }
-                    = rc ( __cli_dispatch c idx ctx )
-                    ( string_free . ctx cmdname )
+        ? & ! found ( args_present p `version` ) {
+            ( __cli_print_version c )
+        } {
+            ? found {
+                ?? ( __cli_find_cmd c cmdname ) {
+                    T idx → {
+                        ? ( args_present p `help` ) {
+                            ( __cli_print_cmd_help c idx )
+                        } {
+                            : CliCtx ctx @ CliCtx { p c ( string_from cmdname ) }
+                            = rc ( __cli_dispatch c idx ctx )
+                            ( string_free . ctx cmdname )
+                        }
+                    }
+                    F _ → {
+                        // Unmatched token: with a default handler it is a positional
+                        // argument (e.g. a connection URL) — route to the default.
+                        ?? ( __cli_try_default c p ) {
+                            T drc → { = rc drc }
+                            F _ → {
+                                : String m ( string_from `unknown command: ` )
+                                ( string_push_str m cmdname )
+                                ( __cli_err c ( string_data m ) )
+                                ( string_free m )
+                                = rc 2
+                            }
+                        }
+                    }
                 }
-            }
-            F _ → {
-                : String m ( string_from `unknown command: ` )
-                ( string_push_str m cmdname )
-                ( __cli_err c ( string_data m ) )
-                ( string_free m )
-                = rc 2
-            }
-        }
-    } {
-        // No command. `--help` (or bare invocation) prints help; the bare
-        // case is a usage error (exit 1), an explicit --help is success.
-        ( __cli_print_help c )
-        ? ( args_present p `help` ) {} { = rc 1 }
-    } } }
+            } {
+                // No command token. A registered default runs (bare `psql` connects);
+                // otherwise `--help` (or bare invocation) prints help — the bare
+                // case is a usage error (exit 1), an explicit --help is success.
+                ?? ( __cli_try_default c p ) {
+                    T drc → { = rc drc }
+                    F _ → {
+                        ( __cli_print_help c )
+                        ? ( args_present p `help` ) {} { = rc 1 }
+                    }
+                }
+            } } }
 
     ( args_free p )
     ( vec_free_with [String] toks \ String s → v { ( string_free s ) } )

--- a/packages/cli/tests/cli_test.sh
+++ b/packages/cli/tests/cli_test.sh
@@ -54,6 +54,24 @@ $D --help >/dev/null 2>&1; [ $? = 0 ] && ok "--help → 0"             || bad "-
 $D --help | grep -q "COMMANDS" && ok "help lists commands"          || bad "help commands"
 $D hello --help | grep -q "print a greeting" && ok "command help"   || bad "command help"
 
+# default command (psql/redis-cli shape): bare invocation acts, -h is a
+# user flag (help-short yields), positionals are arguments, subcommands win.
+echo "[2b/3] default command + help-short yield (tests/demo_default.nu)"
+if ! $NURL tests/demo_default.nu "$WORK/demodef" >/dev/null 2>"$WORK/build2.err"; then
+    echo "FAIL: could not build demo_default:"; tail -8 "$WORK/build2.err"; FAIL=$((FAIL+1))
+else
+    DD="$WORK/demodef"
+    eq "bare runs default"     "$($DD)"                       "connect localhost:5432"
+    eq "-h is HOST not help"   "$($DD -h db.example)"          "connect db.example:5432"
+    eq "short value flag"      "$($DD -h db -p 6432)"          "connect db:6432"
+    eq "url positional"        "$($DD postgres://u@h/db)"      "connect localhost:5432 url=postgres://u@h/db"
+    eq "subcommand still wins" "$($DD ping)"                  "pong"
+    eq "default env fallback"  "$(DEMO_HOST=envhost $DD)"      "connect envhost:5432"
+    $DD --help >/dev/null 2>&1; [ $? = 0 ] && ok "default: --help → 0" || bad "default --help exit"
+    $DD --help | grep -q "\[COMMAND\]" && ok "help shows optional COMMAND" || bad "optional COMMAND in usage"
+    $DD --help | grep -qE "^  ping" && ok "help lists ping, hides default" || bad "help cmd listing"
+fi
+
 echo "[3/3] AddressSanitizer"
 if NURL_SAN=1 $NURL tests/demo.nu "$WORK/demo_san" >/dev/null 2>"$WORK/san_build.err"; then
     SAN_ERR=0
@@ -61,6 +79,11 @@ if NURL_SAN=1 $NURL tests/demo.nu "$WORK/demo_san" >/dev/null 2>"$WORK/san_build
         printf 'y\n' | $WORK/demo_san $run >/dev/null 2>>"$WORK/san.out" || true
     done
     printf 'data' | $WORK/demo_san wc >/dev/null 2>>"$WORK/san.out" || true
+    if NURL_SAN=1 $NURL tests/demo_default.nu "$WORK/demodef_san" >/dev/null 2>>"$WORK/san_build.err"; then
+        for run in "" "-h db -p 1" "postgres://u@h/db" "ping" "--help"; do
+            $WORK/demodef_san $run >/dev/null 2>>"$WORK/san.out" || true
+        done
+    fi
     if grep -qE "ERROR: AddressSanitizer|detected memory leaks" "$WORK/san.out" 2>/dev/null; then
         bad "ASan clean"; grep -m3 "ERROR\|leak" "$WORK/san.out"
     else

--- a/packages/cli/tests/demo_default.nu
+++ b/packages/cli/tests/demo_default.nu
@@ -1,0 +1,36 @@
+// tests/demo_default.nu — a psql-style CLI: no subcommands, -h is HOST
+// (not help), bare invocation acts, a positional URL is an argument.
+// Exercises cli_default + the automatic help-short yield.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `src/cli.nu`
+
+@ main → i {
+    : *Cli c ( cli_new `demodef` `default-command demo` `1.0.0` )
+    ( cli_flag_str c `host` 104 `HOST` `server host` `localhost` `DEMO_HOST` )
+    ( cli_flag_int c `port` 112 `N` `server port` 5432 `` )
+    ( cli_flag_bool c `verbose` 0 `chatty` )
+    ( cli_cmd c `ping` `just say pong` \ CliCtx x → i { ( nurl_print `pong\n` ) ^ 0 } )
+    ( cli_default c \ CliCtx x → i {
+        : String h ( ctx_str x `host` )
+        : i po ( ctx_int x `port` )
+        ( nurl_print `connect ` )
+        ( nurl_print ( string_data h ) )
+        ( nurl_print `:` )
+        ( nurl_print ( nurl_str_int po ) )
+        ? > ( ctx_nargs x ) 0 {
+            : String u ( ctx_arg x 0 )
+            ( nurl_print ` url=` )
+            ( nurl_print ( string_data u ) )
+            ( string_free u )
+        } {}
+        ( nurl_print `\n` )
+        ( string_free h )
+        ^ 0
+    } )
+    : i rc ( cli_run c )
+    ( cli_free c )
+    ^ rc
+}

--- a/packages/psql/README.md
+++ b/packages/psql/README.md
@@ -52,7 +52,7 @@ psql --sslmode require -U me -d mydb -c "select * from t"
 psql "postgres://me:secret@db.example.com:5432/mydb?sslmode=verify-full" -c "select now()"
 ```
 
-Run `psql --help` (or `-?`) for a usage summary. The password is taken from
+Run `psql --help` for a usage summary (flags are parsed by the cli package). The password is taken from
 `$PGPASSWORD` or the URL; if the server asks for one and neither is set, you
 are prompted for it on the terminal (with echo off, like the real `psql`).
 `-h/-p/-U/-d` fall back to `$PGHOST/$PGPORT/$PGUSER/$PGDATABASE`. With no

--- a/packages/psql/nurl.toml
+++ b/packages/psql/nurl.toml
@@ -1,7 +1,8 @@
 [package]
 name = "psql"
-version = "0.2.3"
+version = "0.3.0"
 description = "Pure-NURL PostgreSQL client — v3 wire protocol, SCRAM-SHA-256 / MD5 auth, and TLS (pure-NURL, X25519 + P-256) with no libpq and no OpenSSL. Connects securely from a host with nothing installed."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+cli = { path = "../cli", version = "^0.2" }

--- a/packages/psql/src/main.nu
+++ b/packages/psql/src/main.nu
@@ -24,9 +24,11 @@ $ `stdlib/core/io.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/ext/env.nu`
+$ `deps/cli/src/cli.nu`
 $ `pg.nu`
 
 & `c` @ isatty i32 fd → i32
+
 & `c` @ nurl_read_password s prompt → s
 
 @ __sslmode_code s m → i {
@@ -375,14 +377,17 @@ $ `pg.nu`
     }
     : ~ i hoststart p
     ? & != at -1 | == slash -1 < at slash {
-        : String ui ( string_substr ( string_from url ) p - at p )
+        : String usrc ( string_from url )
+        : String ui ( string_substr usrc p - at p )
+        ( string_free usrc )
         : ?i colon ( string_index_of ui `:` )
         ?? colon {
             T ci2 → {
-                = . c user ( string_substr ui 0 ci2 )
-                = . c password ( string_substr ui + ci2 1 - ( string_len ui ) + ci2 1 )
+                ( string_free . c user ) = . c user ( string_substr ui 0 ci2 )
+                ( string_free . c password ) = . c password ( string_substr ui + ci2 1 - ( string_len ui ) + ci2 1 )
+                ( string_free ui )
             }
-            F _ → { = . c user ui }
+            F _ → { ( string_free . c user ) = . c user ui }
         }
         = hoststart + at 1
     } {}
@@ -391,27 +396,37 @@ $ `pg.nu`
     = k hoststart
     ~ < k n { ? & == ( nurl_str_get url k ) 63 == q -1 { = q k } {} = k + k 1 }
     ? & != q -1 | == slash -1 < q hostend { = hostend q } {}
-    : String hostport ( string_substr ( string_from url ) hoststart - hostend hoststart )
+    : String uall ( string_from url )
+    : String hostport ( string_substr uall hoststart - hostend hoststart )
     : ?i pc ( string_index_of hostport `:` )
     ?? pc {
         T pci → {
-            = . c host ( string_substr hostport 0 pci )
-            = . c port ( __atoi ( string_data ( string_substr hostport + pci 1 - ( string_len hostport ) + pci 1 ) ) )
+            ( string_free . c host ) = . c host ( string_substr hostport 0 pci )
+            : String pstr ( string_substr hostport + pci 1 - ( string_len hostport ) + pci 1 )
+            = . c port ( __atoi ( string_data pstr ) )
+            ( string_free pstr )
+            ( string_free hostport )
         }
-        F _ → { = . c host hostport }
+        F _ → { ( string_free . c host ) = . c host hostport }
     }
     ? != slash -1 {
         : i dbend ? != q -1 q n
-        = . c database ( string_substr ( string_from url ) + slash 1 - dbend + slash 1 )
+        ( string_free . c database ) = . c database ( string_substr uall + slash 1 - dbend + slash 1 )
     } {}
     ? != q -1 {
-        : String qs ( string_substr ( string_from url ) + q 1 - n + q 1 )
+        : String qs ( string_substr uall + q 1 - n + q 1 )
         : ?i si ( string_index_of qs `sslmode=` )
         ?? si {
-            T sidx → { = . c sslmode ( __sslmode_code ( string_data ( string_substr qs + sidx 8 - ( string_len qs ) + sidx 8 ) ) ) }
+            T sidx → {
+                : String ms ( string_substr qs + sidx 8 - ( string_len qs ) + sidx 8 )
+                = . c sslmode ( __sslmode_code ( string_data ms ) )
+                ( string_free ms )
+            }
             F _ → {}
         }
+        ( string_free qs )
     } {}
+    ( string_free uall )
     ^ c
 }
 
@@ -436,75 +451,50 @@ $ `pg.nu`
     }
 }
 
-@ __usage → v {
-    ( nurl_print `psql (NURL) — a pure-NURL PostgreSQL client (no libpq, no OpenSSL)\n\n` )
-    ( nurl_print `Usage:\n` )
-    ( nurl_print `  psql [flags] ["postgres://user:pass@host:port/db?sslmode=..."]\n\n` )
-    ( nurl_print `Flags:\n` )
-    ( nurl_print `  -h HOST        server host   (default $PGHOST or localhost)\n` )
-    ( nurl_print `  -p PORT        server port   (default $PGPORT or 5432)\n` )
-    ( nurl_print `  -U USER        user name     (default $PGUSER or postgres)\n` )
-    ( nurl_print `  -d DB          database      (default $PGDATABASE or the user name)\n` )
-    ( nurl_print `  -c SQL         run one command and exit (otherwise start a REPL)\n` )
-    ( nurl_print `  --sslmode M    disable | prefer | require | verify-full (default prefer)\n` )
-    ( nurl_print `  --help, -?     show this help and exit\n\n` )
-    ( nurl_print `Environment:\n` )
-    ( nurl_print `  PGPASSWORD     password for authentication\n` )
-    ( nurl_print `  PGHOST PGPORT PGUSER PGDATABASE   connection defaults\n\n` )
-    ( nurl_print `In the REPL, statements end with ';'. Meta-commands:\n` )
-    ( nurl_print `  \dt   \d TABLE   \dn   \l   \du   \conninfo   \?   \q\n\n` )
-    ( nurl_print `Examples:\n` )
-    ( nurl_print `  psql -h localhost -U me -d mydb -c "select 1"\n` )
-    ( nurl_print `  psql --sslmode require -U me -d mydb\n` )
-    ( nurl_print `  psql "postgres://me:secret@db.example.com:5432/mydb?sslmode=verify-full"\n` )
-}
-
-@ main → i {
-    : ( Vec String ) args ( env_args_list )
-    : i argc ( vec_len [String] args )
-
+// The whole program is one default command (psql style): flags, an optional
+// postgres://… URL positional, then one-shot -c or the REPL.
+@ __psql_go CliCtx x → i {
+    : String hostv ( ctx_str x `host` )
+    : String userv ( ctx_str x `user` )
+    : String passv ( ctx_str x `password` )
+    : String dbv ( ctx_str x `dbname` )
+    : String sslv ( ctx_str x `sslmode` )
     : ~ ConnInfo ci @ ConnInfo {
-        ( env_var_or `PGHOST` `localhost` )
-        ( __atoi ( string_data ( env_var_or `PGPORT` `5432` ) ) )
-        ( env_var_or `PGUSER` `postgres` )
-        ( env_var_or `PGPASSWORD` `` )
-        ( env_var_or `PGDATABASE` `` )
-        1
+        hostv
+        ( ctx_int x `port` )
+        userv
+        passv
+        dbv
+        ( __sslmode_code ( string_data sslv ) )
         F
     }
-    : ~ String sql ( string_new )
-    : ~ b have_c F
-    : ~ b want_help F
+    ( string_free sslv )
+    : String sql ( ctx_str x `command` )
+    : b have_c > ( string_len sql ) 0
+    // an optional postgres:// / postgresql:// URL positional overrides flags
+    ? > ( ctx_nargs x ) 0 {
+        : String u ( ctx_arg x 0 )
+        : s us ( string_data u )
+        ? | ( nurl_str_starts us `postgres://` ) ( nurl_str_starts us `postgresql://` ) {
+            = ci ( __parse_url us ci )
+        } {
+            ( nurl_eprint `psql: unknown argument: ` ) ( nurl_eprint us ) ( nurl_eprint `\n` )
+        }
+    } {}
 
-    : ~ i ai 1
-    ~ < ai argc {
-        : String a ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_new ) }
-        : s as ( string_data a )
-        ? ( nurl_str_eq as `-h` ) { = ai + ai 1 = . ci host ?? ( vec_get [String] args ai ) { T x → x F _ → . ci host } } {
-            ? ( nurl_str_eq as `-p` ) { = ai + ai 1 = . ci port ( __atoi ( string_data ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_from `5432` ) } ) ) } {
-                ? ( nurl_str_eq as `-U` ) { = ai + ai 1 = . ci user ?? ( vec_get [String] args ai ) { T x → x F _ → . ci user } } {
-                    ? ( nurl_str_eq as `-d` ) { = ai + ai 1 = . ci database ?? ( vec_get [String] args ai ) { T x → x F _ → . ci database } } {
-                        ? ( nurl_str_eq as `-c` ) { = ai + ai 1 = sql ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_new ) } = have_c T } {
-                            ? ( nurl_str_eq as `--sslmode` ) { = ai + ai 1 = . ci sslmode ( __sslmode_code ( string_data ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_from `prefer` ) } ) ) } {
-                                ? | ( nurl_str_starts as `postgres://` ) ( nurl_str_starts as `postgresql://` ) { = ci ( __parse_url as ci ) } {
-                                    ? | ( nurl_str_eq as `--help` ) ( nurl_str_eq as `-?` ) { = want_help T } {
-                                        ( nurl_eprint `psql: unknown argument: ` ) ( nurl_eprint as ) ( nurl_eprint `\n` )
-                                    } } } } } } } }
-        = ai + ai 1
-    }
-
-    // Explicit --help: print usage and exit. (Bare `psql` still connects to
-    // the default host, like other psql clients.)
-    ? want_help { ( __usage ) ^ 0 } {}
-
-    // database defaults to the user name if unset
-    ? == ( string_len . ci database ) 0 { = . ci database . ci user } {}
+    // database defaults to the user name if unset (copied — both are freed)
+    ? == ( string_len . ci database ) 0 {
+        ( string_free . ci database )
+        = . ci database ( string_from ( string_data . ci user ) )
+    } {}
 
     : i tty # i ( isatty # i32 0 )
     : !*PgConn PgErr cr ( __connect ci tty )
     ?? cr {
         F e → {
             ( nurl_eprint `psql: connection failed: ` ) ( nurl_eprint ( pg_err_name e ) ) ( nurl_eprint `\n` )
+            ( string_free . ci host ) ( string_free . ci user ) ( string_free . ci password ) ( string_free . ci database )
+            ( string_free sql )
             ^ 1
         }
         T c → {
@@ -521,7 +511,24 @@ $ `pg.nu`
                 ( __repl c tty )
             }
             ( pg_close c )
+            ( string_free . ci host ) ( string_free . ci user ) ( string_free . ci password ) ( string_free . ci database )
+            ( string_free sql )
             ^ 0
         }
     }
+}
+
+@ main → i {
+    : *Cli c ( cli_new `psql` `a pure-NURL PostgreSQL client (no libpq, no OpenSSL); postgres://user:pass@host:port/db?sslmode=… as the argument` `0.3.0` )
+    ( cli_flag_str c `host` 104 `HOST` `server host` `localhost` `PGHOST` )
+    ( cli_flag_int c `port` 112 `PORT` `server port` 5432 `PGPORT` )
+    ( cli_flag_str c `user` 85 `USER` `user name` `postgres` `PGUSER` )
+    ( cli_flag_str c `password` 0 `PASS` `password (usually via $PGPASSWORD)` `` `PGPASSWORD` )
+    ( cli_flag_str c `dbname` 100 `DB` `database (default: the user name)` `` `PGDATABASE` )
+    ( cli_flag_str c `command` 99 `SQL` `run one command and exit (otherwise start a REPL)` `` `` )
+    ( cli_flag_str c `sslmode` 0 `MODE` `disable | prefer | require | verify-full` `prefer` `` )
+    ( cli_default c \ CliCtx x → i { ^ ( __psql_go x ) } )
+    : i rc ( cli_run c )
+    ( cli_free c )
+    ^ rc
 }

--- a/packages/psql/src/pg.nu
+++ b/packages/psql/src/pg.nu
@@ -403,7 +403,10 @@ $ `stdlib/std/tls.nu`
 
 @ pg_connect s host i port s user s password s database i sslmode → !*PgConn PgErr {
     : i rawfd ( nurl_tcp_connect host port )
-    ? != ( nurl_tcp_err_kind rawfd ) 0 { ^ @ !*PgConn PgErr { F # PgErr PgConnFail } } {}
+    ? != ( nurl_tcp_err_kind rawfd ) 0 {
+        ( nurl_tcp_close rawfd )  // failed handles still own their allocation
+        ^ @ !*PgConn PgErr { F # PgErr PgConnFail }
+    } {}
 
     : *PgConn c # *PgConn ( nurl_alloc Z PgConn )
     = . c tls 0

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -30,15 +30,17 @@ cd packages/redis
 
 ```
 redis [flags] ["redis://[user:pass@]host:port/db"]
-  -h HOST        host          (default $REDIS_HOST or 127.0.0.1)
-  -p PORT        port          (default $REDIS_PORT or 6379)
-  -a PASSWORD    AUTH password (default $REDIS_PASSWORD)
-  --user USER    ACL username for AUTH (Redis 6+)
-  -n DB          SELECT database index (default 0)
-  --tls          connect over TLS (verify-full)
-  --insecure     with --tls / rediss://, skip certificate verification
-  -c "CMD ARGS"  run one command and exit; otherwise start a REPL
+  -h, --host HOST      host          (default $REDIS_HOST or 127.0.0.1)
+  -p, --port PORT      port          (default $REDIS_PORT or 6379)
+  -a, --password PASS  AUTH password (default $REDIS_PASSWORD)
+      --user USER      ACL username for AUTH (Redis 6+)
+  -n, --db DB          SELECT database index (default 0)
+      --tls            connect over TLS (verify-full)
+      --insecure       with --tls / rediss://, skip certificate verification
+  -c, --command "CMD"  run one command and exit; otherwise start a REPL
 ```
+
+Flags are parsed by the [cli package](../cli) (`--help` for the full list).
 
 ```sh
 redis -c "PING"                                   # "PONG"

--- a/packages/redis/nurl.toml
+++ b/packages/redis/nurl.toml
@@ -1,7 +1,8 @@
 [package]
 name = "redis"
-version = "0.1.1"
+version = "0.2.0"
 description = "Pure-NURL Redis client — RESP2 protocol over a libc TCP socket, with an optional pure-NURL TLS upgrade (rediss://, no OpenSSL on the target). A reusable library plus a redis-cli-style command."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+cli = { path = "../cli", version = "^0.2" }

--- a/packages/redis/src/main.nu
+++ b/packages/redis/src/main.nu
@@ -18,6 +18,7 @@ $ `stdlib/core/io.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/ext/env.nu`
+$ `deps/cli/src/cli.nu`
 $ `redis.nu`
 
 & `c` @ isatty i32 fd → i32
@@ -67,7 +68,7 @@ $ `redis.nu`
 }
 
 // Send one already-built command, print its reply, and free args.
-@ __run_cmd *RedisConn c ( Vec String ) args → v {
+@ __run_cmd * RedisConn c ( Vec String ) args → v {
     ?? ( redis_command c args ) {
         T rep → { ( __print_node rep ( resp_reply_root rep ) 0 ) ( resp_reply_free rep ) }
         F e → {
@@ -105,22 +106,22 @@ $ `redis.nu`
         ( nurl_print `message ` ) ( nurl_print ( redis_message_channel m ) )
         ( nurl_print ` "` ) ( nurl_print ( redis_message_payload m ) ) ( nurl_print `"\n` )
     } {
-    ? == k 3 {
-        ( nurl_print `pmessage ` ) ( nurl_print ( redis_message_pattern m ) )
-        ( nurl_print ` ` ) ( nurl_print ( redis_message_channel m ) )
-        ( nurl_print ` "` ) ( nurl_print ( redis_message_payload m ) ) ( nurl_print `"\n` )
-    } {
-        : i sub | == k 1 == k 4
-        ( nurl_print ? sub `(subscribed ` `(unsubscribed ` )
-        ( nurl_print ? | == k 4 == k 5 ( redis_message_pattern m ) ( redis_message_channel m ) )
-        ( nurl_print `, ` ) ( __print_int ( redis_message_count m ) ) ( nurl_print ` active)\n` )
-    } }
+        ? == k 3 {
+            ( nurl_print `pmessage ` ) ( nurl_print ( redis_message_pattern m ) )
+            ( nurl_print ` ` ) ( nurl_print ( redis_message_channel m ) )
+            ( nurl_print ` "` ) ( nurl_print ( redis_message_payload m ) ) ( nurl_print `"\n` )
+        } {
+            : i sub | == k 1 == k 4
+            ( nurl_print ? sub `(subscribed ` `(unsubscribed ` )
+            ( nurl_print ? | == k 4 == k 5 ( redis_message_pattern m ) ( redis_message_channel m ) )
+            ( nurl_print `, ` ) ( __print_int ( redis_message_count m ) ) ( nurl_print ` active)\n` )
+        } }
 }
 
 // SUBSCRIBE / PSUBSCRIBE one or more channels, then print delivered messages
 // until the connection closes (Ctrl-C / EOF). `toks` is the whole command
 // (toks[0] = the verb, toks[1..] = channels / patterns).
-@ __subscribe_loop *RedisConn c ( Vec String ) toks i is_pattern → v {
+@ __subscribe_loop * RedisConn c ( Vec String ) toks i is_pattern → v {
     : i n ( vec_len [String] toks )
     : ~ i k 1
     ~ < k n {
@@ -143,7 +144,7 @@ $ `redis.nu`
 
 // Route a parsed command: SUBSCRIBE / PSUBSCRIBE enter the message loop,
 // everything else is a one-shot request/reply. Frees `toks` either way.
-@ __dispatch *RedisConn c ( Vec String ) toks → v {
+@ __dispatch * RedisConn c ( Vec String ) toks → v {
     : s cmd0 ( string_data ?? ( vec_get [String] toks 0 ) { T x → x F _ → ( string_new ) } )
     ? ( __rci_eq cmd0 `subscribe` ) { ( __subscribe_loop c toks 0 ) ( redis_args_free toks ) ^ v } {}
     ? ( __rci_eq cmd0 `psubscribe` ) { ( __subscribe_loop c toks 1 ) ( redis_args_free toks ) ^ v } {}
@@ -186,7 +187,7 @@ $ `redis.nu`
     String user
     String password
     i db
-    i tlsmode    // 0 plain, 1 tls insecure, 2 tls verify-full
+    i tlsmode  // 0 plain, 1 tls insecure, 2 tls verify-full
 }
 
 // redis://[user:pass@]host[:port][/db]  (rediss:// → TLS)
@@ -207,30 +208,40 @@ $ `redis.nu`
     }
     : ~ i hoststart p
     ? & != at -1 | == slash -1 < at slash {
-        : String ui ( string_substr ( string_from url ) p - at p )
+        : String usrc ( string_from url )
+        : String ui ( string_substr usrc p - at p )
+        ( string_free usrc )
         : ?i colon ( string_index_of ui `:` )
         ?? colon {
             T ci2 → {
-                = . c user ( string_substr ui 0 ci2 )
-                = . c password ( string_substr ui + ci2 1 - ( string_len ui ) + ci2 1 )
+                ( string_free . c user ) = . c user ( string_substr ui 0 ci2 )
+                ( string_free . c password ) = . c password ( string_substr ui + ci2 1 - ( string_len ui ) + ci2 1 )
+                ( string_free ui )
             }
-            F _ → { = . c password ui }
+            F _ → { ( string_free . c password ) = . c password ui }
         }
         = hoststart + at 1
     } {}
     : i hostend ? != slash -1 slash n
-    : String hostport ( string_substr ( string_from url ) hoststart - hostend hoststart )
+    : String uall ( string_from url )
+    : String hostport ( string_substr uall hoststart - hostend hoststart )
     : ?i pc ( string_index_of hostport `:` )
     ?? pc {
         T pci → {
-            = . c host ( string_substr hostport 0 pci )
-            = . c port ( __atoi ( string_data ( string_substr hostport + pci 1 - ( string_len hostport ) + pci 1 ) ) )
+            ( string_free . c host ) = . c host ( string_substr hostport 0 pci )
+            : String pstr ( string_substr hostport + pci 1 - ( string_len hostport ) + pci 1 )
+            = . c port ( __atoi ( string_data pstr ) )
+            ( string_free pstr )
+            ( string_free hostport )
         }
-        F _ → { = . c host hostport }
+        F _ → { ( string_free . c host ) = . c host hostport }
     }
     ? != slash -1 {
-        = . c db ( __atoi ( string_data ( string_substr ( string_from url ) + slash 1 - n + slash 1 ) ) )
+        : String dstr ( string_substr uall + slash 1 - n + slash 1 )
+        = . c db ( __atoi ( string_data dstr ) )
+        ( string_free dstr )
     } {}
+    ( string_free uall )
     ^ c
 }
 
@@ -241,63 +252,33 @@ $ `redis.nu`
     ^ ( redis_connect ( string_data . ci host ) . ci port )
 }
 
-@ __usage → v {
-    ( nurl_print `redis (NURL) — a pure-NURL Redis client (RESP2, optional pure TLS)\n\n` )
-    ( nurl_print `Usage:\n` )
-    ( nurl_print `  redis [flags] ["redis://[user:pass@]host:port/db"]\n\n` )
-    ( nurl_print `Flags:\n` )
-    ( nurl_print `  -h HOST        host        (default $REDIS_HOST or 127.0.0.1)\n` )
-    ( nurl_print `  -p PORT        port        (default $REDIS_PORT or 6379)\n` )
-    ( nurl_print `  -a PASSWORD    AUTH password (default $REDIS_PASSWORD)\n` )
-    ( nurl_print `  --user USER    ACL username for AUTH (Redis 6+)\n` )
-    ( nurl_print `  -n DB          SELECT database index (default 0)\n` )
-    ( nurl_print `  --tls          connect over TLS (verify-full)\n` )
-    ( nurl_print `  --insecure     skip certificate verification\n` )
-    ( nurl_print `  -c "CMD ARGS"  run one command and exit (otherwise start a REPL)\n` )
-    ( nurl_print `  --help, -?     show this help and exit\n\n` )
-    ( nurl_print `Examples:\n` )
-    ( nurl_print `  redis -c "PING"\n` )
-    ( nurl_print `  redis -h cache.example.com -p 6380 --tls -c "GET session:42"\n` )
-    ( nurl_print `  redis "rediss://default:secret@cache.example.com:6380/0"\n` )
-}
-
-@ main → i {
-    : ( Vec String ) args ( env_args_list )
-    : i argc ( vec_len [String] args )
-
+// The whole program is one default command (redis-cli style): flags,
+// an optional redis://…/rediss://… URL positional, then one-shot or REPL.
+@ __redis_go CliCtx x → i {
+    : String hostv ( ctx_str x `host` )
+    : String passv ( ctx_str x `password` )
+    : String userv ( ctx_str x `user` )
     : ~ ConnInfo ci @ ConnInfo {
-        ( env_var_or `REDIS_HOST` `127.0.0.1` )
-        ( __atoi ( string_data ( env_var_or `REDIS_PORT` `6379` ) ) )
-        ( string_new )
-        ( env_var_or `REDIS_PASSWORD` `` )
-        0
-        0
+        hostv
+        ( ctx_int x `port` )
+        userv
+        passv
+        ( ctx_int x `db` )
+        ? ( ctx_bool x `tls` ) { 2 } { 0 }
     }
-    : ~ String oneshot ( string_new )
-    : ~ b have_c F
-    : ~ b want_help F
-    : ~ i insecure 0
-
-    : ~ i ai 1
-    ~ < ai argc {
-        : String a ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_new ) }
-        : s as ( string_data a )
-        ? ( nurl_str_eq as `-h` ) { = ai + ai 1 = . ci host ?? ( vec_get [String] args ai ) { T x → x F _ → . ci host } } {
-        ? ( nurl_str_eq as `-p` ) { = ai + ai 1 = . ci port ( __atoi ( string_data ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_from `6379` ) } ) ) } {
-        ? ( nurl_str_eq as `-a` ) { = ai + ai 1 = . ci password ?? ( vec_get [String] args ai ) { T x → x F _ → . ci password } } {
-        ? ( nurl_str_eq as `--user` ) { = ai + ai 1 = . ci user ?? ( vec_get [String] args ai ) { T x → x F _ → . ci user } } {
-        ? ( nurl_str_eq as `-n` ) { = ai + ai 1 = . ci db ( __atoi ( string_data ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_from `0` ) } ) ) } {
-        ? ( nurl_str_eq as `--tls` ) { ? == . ci tlsmode 0 { = . ci tlsmode 2 } {} } {
-        ? ( nurl_str_eq as `--insecure` ) { = insecure 1 } {
-        ? ( nurl_str_eq as `-c` ) { = ai + ai 1 = oneshot ?? ( vec_get [String] args ai ) { T x → x F _ → ( string_new ) } = have_c T } {
-        ? | ( nurl_str_starts as `redis://` ) ( nurl_str_starts as `rediss://` ) { = ci ( __parse_url as ci ) } {
-        ? | ( nurl_str_eq as `--help` ) ( nurl_str_eq as `-?` ) { = want_help T } {
-            ( nurl_eprint `redis: unknown argument: ` ) ( nurl_eprint as ) ( nurl_eprint `\n` )
-        } } } } } } } } } }
-        = ai + ai 1
-    }
-
-    ? want_help { ( __usage ) ^ 0 } {}
+    : String oneshot ( ctx_str x `command` )
+    : b have_c > ( string_len oneshot ) 0
+    : i insecure ? ( ctx_bool x `insecure` ) { 1 } { 0 }
+    // an optional redis:// / rediss:// URL positional overrides the flags
+    ? > ( ctx_nargs x ) 0 {
+        : String u ( ctx_arg x 0 )
+        : s us ( string_data u )
+        ? | ( nurl_str_starts us `redis://` ) ( nurl_str_starts us `rediss://` ) {
+            = ci ( __parse_url us ci )
+        } {
+            ( nurl_eprint `redis: unknown argument: ` ) ( nurl_eprint us ) ( nurl_eprint `\n` )
+        }
+    } {}
 
     // --insecure downgrades verify-full to encrypt-only.
     ? & == insecure 1 > . ci tlsmode 0 { = . ci tlsmode 1 } {}
@@ -308,6 +289,8 @@ $ `redis.nu`
     ?? cr {
         F e → {
             ( nurl_eprint `redis: connection failed: ` ) ( nurl_eprint ( redis_err_name e ) ) ( nurl_eprint `\n` )
+            ( string_free . ci host ) ( string_free . ci user ) ( string_free . ci password )
+            ( string_free oneshot )
             ^ 1
         }
         T c → {
@@ -358,7 +341,25 @@ $ `redis.nu`
                 }
             }
             ( redis_close c )
+            ( string_free . ci host ) ( string_free . ci user ) ( string_free . ci password )
+            ( string_free oneshot )
             ^ 0
         }
     }
+}
+
+@ main → i {
+    : *Cli c ( cli_new `redis` `a pure-NURL Redis client (RESP2, optional pure TLS); redis://[user:pass@]host:port/db as the argument` `0.2.0` )
+    ( cli_flag_str c `host` 104 `HOST` `server host` `127.0.0.1` `REDIS_HOST` )
+    ( cli_flag_int c `port` 112 `PORT` `server port` 6379 `REDIS_PORT` )
+    ( cli_flag_str c `password` 97 `PASSWORD` `AUTH password` `` `REDIS_PASSWORD` )
+    ( cli_flag_str c `user` 0 `USER` `ACL username for AUTH (Redis 6+)` `` `` )
+    ( cli_flag_int c `db` 110 `DB` `SELECT database index` 0 `` )
+    ( cli_flag_bool c `tls` 0 `connect over TLS (verify-full)` )
+    ( cli_flag_bool c `insecure` 0 `skip certificate verification (encrypt-only)` )
+    ( cli_flag_str c `command` 99 `CMD` `run one command and exit (otherwise start a REPL)` `` `` )
+    ( cli_default c \ CliCtx x → i { ^ ( __redis_go x ) } )
+    : i rc ( cli_run c )
+    ( cli_free c )
+    ^ rc
 }

--- a/packages/redis/src/redis.nu
+++ b/packages/redis/src/redis.nu
@@ -316,7 +316,10 @@ $ `resp.nu`
 // tlsmode: 0 plaintext · 1 TLS no-verify · 2 TLS verify-full
 @ __redis_open s host i port i tlsmode s server_name → !*RedisConn RedisErr {
     : i rawfd ( nurl_tcp_connect host port )
-    ? != ( nurl_tcp_err_kind rawfd ) 0 { ^ @ !*RedisConn RedisErr { F # RedisErr RedisConnFail } } {}
+    ? != ( nurl_tcp_err_kind rawfd ) 0 {
+        ( nurl_tcp_close rawfd )  // failed handles still own their allocation
+        ^ @ !*RedisConn RedisErr { F # RedisErr RedisConnFail }
+    } {}
 
     : *RedisConn c # *RedisConn ( nurl_alloc Z RedisConn )
     = . c tls 0

--- a/packages/yoloe/nurl.toml
+++ b/packages/yoloe/nurl.toml
@@ -1,9 +1,10 @@
 [package]
 name = "yoloe"
-version = "0.5.0"
+version = "0.6.0"
 description = "Promptable, open-vocabulary object detection AND instance segmentation from pure NURL on the GPU — a NURL port of YOLOE (THU-MIG, 'Real-Time Seeing Anything', ICCV 2025), including live masking straight off a webcam. You name the classes you want ('dog', 'bicycle', 'a person on a bike') and the model finds them — drawing both boxes and per-object segmentation masks — without a fixed label set. The whole network runs on the GPU through the onnx package (every layer a CUDA-C kernel compiled at runtime via NVRTC — no external inference engine), including the YOLOE-seg mask-prototype branch (ConvTranspose 2× upsample) and the mask decode (coefficients · prototypes → threshold → overlay), all verified numerically against onnxruntime (proto max abs err ~6e-5). Promptability comes from YOLOE's region-text contrastive head, which scores each region's visual embedding against the text embeddings of the prompt words, with the MobileCLIP text path also in pure NURL. The webcam feed is captured in pure NURL via Video4Linux2 (open/ioctl/mmap, YUYV→RGB) — no ffmpeg, no OpenCV. Requires the NVIDIA driver + NVRTC (via the gpu package); a GPU-less host is unaffected."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 onnx = { path = "../onnx", version = "^0.4.2" }
 image = { path = "../image", version = "^0.4" }
+cli = { path = "../cli", version = "^0.2" }

--- a/packages/yoloe/src/main.nu
+++ b/packages/yoloe/src/main.nu
@@ -1,7 +1,7 @@
 // packages/yoloe/src/main.nu — the `yoloe` command: promptable open-vocabulary
 // object detection AND instance segmentation, pure NURL on the GPU, with a
 // live webcam mode that draws straight to the terminal. Single binary, three
-// flag-driven sub-commands (see `yoloe help`):
+// sub-commands, parsed by the cli package (see `yoloe --help`):
 //
 //   yoloe detect --model M --classes C --image IMG [--out OUT]
 //   yoloe seg    --model M --classes C --image IMG [--out OUT]
@@ -20,6 +20,7 @@ $ `stdlib/ext/env.nu`
 $ `deps/onnx/src/pb.nu`
 $ `deps/onnx/src/model.nu`
 $ `deps/onnx/src/runtime.nu`
+$ `deps/cli/src/cli.nu`
 $ `image.nu`
 $ `decode.nu`
 $ `mask.nu`
@@ -33,29 +34,15 @@ $ `window.nu`
 
 @ pn i n → v { ( nurl_print ( nurl_str_int n ) ) }
 
-// ── flag parsing ──────────────────────────────────────────────────
-@ __arg_index ( Vec String ) av s name → i {
-    : i n ( vec_len [String] av )
-    : ~ i k 0
-    ~ < k n {
-        ?? ( vec_get [String] av k ) { T x → ? != 0 ( nurl_str_eq ( string_data x ) name ) { ^ k } {} F _ → {} }
-        = k + k 1
-    }
-    ^ - 0 1
-}
-
-@ flag_set ( Vec String ) av s name → b { ^ >= ( __arg_index av name ) 0 }
-
-@ flag_str ( Vec String ) av s name → String {
-    : i i ( __arg_index av name )
-    ? < i 0 { ^ ( string_new ) } {}
-    ?? ( vec_get [String] av + i 1 ) { T x → ^ x F _ → ^ ( string_new ) }
-}
-
-@ flag_int ( Vec String ) av s name i dflt → i {
-    : i i ( __arg_index av name )
-    ? < i 0 { ^ dflt } {}
-    ?? ( vec_get [String] av + i 1 ) { T x → ^ ( nurl_str_to_int ( string_data x ) ) F _ → ^ dflt }
+// ── flags (parsed by the cli package; see main) ───────────────────
+// What to draw: --boxes and/or --mask (alias --segment). Neither → both.
+// Bit mask: bit0 = draw boxes, bit1 = draw masks, bit2 = --mask was explicit.
+@ __ye_wants CliCtx x → i {
+    : b fb ( ctx_bool x `boxes` )
+    : b fm | ( ctx_bool x `mask` ) ( ctx_bool x `segment` )
+    : b wb | fb ! fm
+    : b wm | fm ! fb
+    ^ + + ? wb { 1 } { 0 } ? wm { 2 } { 0 } ? fm { 4 } { 0 }
 }
 
 // Read the prompt vocabulary from a text file (one class per line); the line
@@ -282,75 +269,69 @@ $ `window.nu`
     ^ 0
 }
 
-@ usage → v {
-    ( p `yoloe — promptable open-vocabulary detection & instance segmentation (pure NURL, GPU)\n\n` )
-    ( p `usage:\n` )
-    ( p `  yoloe detect --model M --classes C --image IMG [--out OUT]\n` )
-    ( p `        draw boxes for the prompted classes\n` )
-    ( p `  yoloe seg    --model M --classes C --image IMG [--out OUT]\n` )
-    ( p `        boxes + a per-object segmentation mask\n` )
-    ( p `  yoloe cam    --model M --classes C [options]\n` )
-    ( p `        LIVE segmentation from a webcam, drawn in the terminal\n\n` )
-    ( p `flags:\n` )
-    ( p `  --model   <model.onnx>   a YOLOE-seg export from tools/export.py\n` )
-    ( p `                           (-> yoloe-v8s-seg.onnx); not bundled (~45 MB).\n` )
-    ( p `  --classes <classes.txt>  vocabulary, one prompt word per line.\n` )
-    ( p `  --image   <img>          input for detect/seg (PNG, JPEG or PPM).\n` )
-    ( p `  --out     <path>         detect/seg: output image; cam: dir to save frames.\n` )
-    ( p `  --device  <dev>          cam webcam device (default /dev/video0).\n` )
-    ( p `  --frames  <N>            cam: stop after N frames (default: run until Ctrl-C).\n` )
-    ( p `  --boxes                  draw bounding boxes.\n` )
-    ( p `  --mask                   draw the segmentation masks (alias --segment).\n` )
-    ( p `                           (neither flag = draw both; pick one for just that.)\n` )
-    ( p `  --window                 cam: show in a real GUI window (X11).\n` )
-    ( p `  --terminal               cam: show in the terminal (truecolor half-blocks).\n` )
-    ( p `  --no-show                cam: don't display (e.g. only --out). Default: window\n` )
-    ( p `                           if $DISPLAY is set, else terminal.\n` )
-    ( p `  --gpu     <N>            CUDA device ordinal to run on (default 0).\n\n` )
-    ( p `examples:\n` )
-    ( p `  yoloe seg --model yoloe-v8s-seg.onnx --classes classes.txt --image photo.ppm --out out.ppm\n` )
-    ( p `  yoloe cam --model yoloe-v8s-seg.onnx --classes classes.txt              # live GUI window\n` )
-    ( p `  yoloe cam --model yoloe-v8s-seg.onnx --classes classes.txt --mask --terminal\n` )
-    ( p `  yoloe cam --model yoloe-v8s-seg.onnx --classes classes.txt --frames 60 --out frames/ --no-show\n` )
+@ __ye_cmd_still CliCtx x b is_detect → i {
+    : String mp ( ctx_str x `model` )
+    : String np ( ctx_str x `classes` )
+    : i gpu ( ctx_int x `gpu` )
+    : i w ( __ye_wants x )
+    : i wb1 & w 1
+    : i wm2 & w 2
+    : i fm4 & w 4
+    : b want_boxes == wb1 1
+    : b want_masks == wm2 2
+    : b fm == fm4 4
+    // `detect` is boxes-only unless the user explicitly asked for a mask.
+    : b dmask & want_masks ! & is_detect ! fm
+    : String ip ( ctx_str x `image` )
+    : String op ( ctx_str x `out` )
+    : i rc ( run_still want_boxes dmask mp np ip op gpu )
+    // ctx_str returns owned Strings (the old flag_str borrowed from argv)
+    ( string_free mp ) ( string_free np ) ( string_free ip ) ( string_free op )
+    ^ rc
+}
+
+@ __ye_cmd_cam CliCtx x → i {
+    : String mp ( ctx_str x `model` )
+    : String np ( ctx_str x `classes` )
+    : i gpu ( ctx_int x `gpu` )
+    : i w ( __ye_wants x )
+    : i wb1 & w 1
+    : i wm2 & w 2
+    : b want_boxes == wb1 1
+    : b want_masks == wm2 2
+    : String dev ( ctx_str x `device` )
+    : i nframes ( ctx_int x `frames` )
+    : String od ( ctx_str x `out` )
+    // display mode: --no-show → 0; --terminal → 1; --window → 2;
+    // default → window if $DISPLAY is set, else terminal.
+    : ~ i mode ? > ( string_len ( env_var_or `DISPLAY` `` ) ) 0 2 1
+    ? ( ctx_bool x `terminal` ) { = mode 1 } {}
+    ? ( ctx_bool x `window` ) { = mode 2 } {}
+    ? ( ctx_bool x `no-show` ) { = mode 0 } {}
+    : i rc ( run_cam mp np dev nframes od mode want_boxes want_masks gpu )
+    ( string_free mp ) ( string_free np ) ( string_free dev ) ( string_free od )
+    ^ rc
 }
 
 @ main → i {
-    : ( Vec String ) av ( env_args_list )
-    ? < ( vec_len [String] av ) 2 { ( usage ) ^ 2 } {}
-    : String cmd ?? ( vec_get [String] av 1 ) { T x → x F _ → ( string_new ) }
-    : s c ( string_data cmd )
-
-    : String mp ( flag_str av `--model` )
-    : String np ( flag_str av `--classes` )
-    : i gpu ( flag_int av `--gpu` 0 )
-    // What to draw: --boxes and/or --mask (alias --segment). Neither → both.
-    : b fb ( flag_set av `--boxes` )
-    : b fm | ( flag_set av `--mask` ) ( flag_set av `--segment` )
-    : b want_boxes | fb ! fm
-    : b want_masks | fm ! fb
-
-    ? | != 0 ( nurl_str_eq c `detect` ) != 0 ( nurl_str_eq c `seg` ) {
-        // `detect` is boxes-only unless the user explicitly asked for a mask.
-        : b dmask & want_masks ! & != 0 ( nurl_str_eq c `detect` ) ! fm
-        : String ip ( flag_str av `--image` )
-        : String op ( flag_str av `--out` )
-        ^ ( run_still want_boxes dmask mp np ip op gpu )
-    } {}
-
-    ? != 0 ( nurl_str_eq c `cam` ) {
-        : String dev0 ( flag_str av `--device` )
-        : String dev ? > ( string_len dev0 ) 0 dev0 ( string_from `/dev/video0` )
-        : i nframes ? ( flag_set av `--frames` ) ( flag_int av `--frames` 30 ) - 0 1
-        : String od ( flag_str av `--out` )
-        // display mode: --no-show → 0; --terminal → 1; --window → 2;
-        // default → window if $DISPLAY is set, else terminal.
-        : ~ i mode ? > ( string_len ( env_var_or `DISPLAY` `` ) ) 0 2 1
-        ? ( flag_set av `--terminal` ) { = mode 1 } {}
-        ? ( flag_set av `--window` ) { = mode 2 } {}
-        ? ( flag_set av `--no-show` ) { = mode 0 } {}
-        ^ ( run_cam mp np dev nframes od mode want_boxes want_masks gpu )
-    } {}
-
-    ? | != 0 ( nurl_str_eq c `help` ) | != 0 ( nurl_str_eq c `-h` ) != 0 ( nurl_str_eq c `--help` ) { ( usage ) ^ 0 } {}
-    ( p `yoloe: unknown command '` ) ( p c ) ( p `'\n\n` ) ( usage ) ^ 2
+    : *Cli c ( cli_new `yoloe` `promptable open-vocabulary detection & instance segmentation (pure NURL, GPU)` `0.6.0` )
+    ( cli_flag_str c `model` 109 `MODEL.onnx` `YOLOE-seg export from tools/export.py (~45 MB, not bundled)` `` `` )
+    ( cli_flag_str c `classes` 99 `FILE` `vocabulary, one prompt word per line` `` `` )
+    ( cli_flag_str c `image` 105 `IMG` `detect/seg input (PNG, JPEG or PPM)` `` `` )
+    ( cli_flag_str c `out` 111 `PATH` `detect/seg: output image; cam: dir to save frames` `` `` )
+    ( cli_flag_str c `device` 100 `DEV` `cam: webcam device` `/dev/video0` `` )
+    ( cli_flag_int c `frames` 0 `N` `cam: stop after N frames (-1 = until Ctrl-C)` -1 `` )
+    ( cli_flag_int c `gpu` 0 `N` `CUDA device ordinal to run on` 0 `` )
+    ( cli_flag_bool c `boxes` 98 `draw bounding boxes` )
+    ( cli_flag_bool c `mask` 0 `draw the segmentation masks (neither flag = draw both)` )
+    ( cli_flag_bool c `segment` 0 `alias for --mask` )
+    ( cli_flag_bool c `window` 119 `cam: show in a real GUI window (X11)` )
+    ( cli_flag_bool c `terminal` 116 `cam: show in the terminal (truecolor half-blocks)` )
+    ( cli_flag_bool c `no-show` 0 `cam: no display (default: window if $DISPLAY, else terminal)` )
+    ( cli_cmd c `detect` `draw boxes for the prompted classes` \ CliCtx x → i { ^ ( __ye_cmd_still x T ) } )
+    ( cli_cmd c `seg` `boxes + a per-object segmentation mask` \ CliCtx x → i { ^ ( __ye_cmd_still x F ) } )
+    ( cli_cmd c `cam` `LIVE segmentation from a webcam` \ CliCtx x → i { ^ ( __ye_cmd_cam x ) } )
+    : i rc ( cli_run c )
+    ( cli_free c )
+    ^ rc
 }


### PR DESCRIPTION
## cli 0.2.0 + yoloe 0.6.0 + redis 0.2.0 + psql 0.3.0

Deletes the last three hand-rolled argv parsers in packages/ by dogfooding the cli facade — and extends the facade with the two capabilities real CLIs turned out to need.

### cli — new capabilities (driven by the migrations)
- **`cli_default c handler`** — for programs that *are* the command (psql/redis-cli shape): bare invocation runs it instead of printing usage; a first positional that matches no subcommand (e.g. a `redis://…` URL) routes to it and stays readable as `ctx_arg 0`. Subcommands still win; help hides the default and shows `[COMMAND]`.
- **Automatic help-short yield** — a user flag claiming `-h` (psql's `-h HOST`) makes the built-in help drop its short and stay reachable as `--help`.
- `tests/demo_default.nu` covers both: **suite 30/30, ASan-clean**.

### Migrations
| pkg | before | after |
|---|---|---|
| yoloe | private `__arg_index`/`flag_str` mini-framework + hand-written usage() | `cli_cmd` detect/seg/cam + typed flags; **live GPU seg on bus.jpg → byte-identical PNG** |
| redis | 10-deep `nurl_str_eq` cascade | `cli_default`; `-h/-p/-a/-n/-c` kept, long forms + per-flag env fallbacks for free; **live-verified vs redis:7** (flags, URL, env, one-shot, REPL) |
| psql | same cascade | `cli_default`; `-h/-p/-U/-d/-c/--sslmode` kept; **live-verified vs postgres:16** (flags, URL+sslmode, env, meta-commands) |

### Real pre-existing leaks fixed en route (ASan-gating the new paths found them)
- redis/psql: `nurl_tcp_connect` failure **leaked the TCP handle**; `__parse_url` overwrote ConnInfo Strings without freeing and leaked all its intermediates; handlers now free owned Strings on both exit arms; psql's database-defaults-to-user **aliased two String handles** (double-free waiting to happen — now copied).
- yoloe handlers free `ctx_str` results (old `flag_str` returned borrows).

### Known quirk (pre-existing, environment-level)
LSan's stop-the-world tracer deadlocks at exit on a few paths (redis URL, yoloe seg) — blocked on a pipe read to its own tracer. The **old** binaries hang on strictly more paths; under `detect_leaks=0`/strace they exit clean, and every path LSan does scan reports **zero leaks**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7