### PR TITLE
chore(gpukit): 0.3.1 — republish manifest with gpu ^0.3

### DIFF
--- a/packages/gpukit/CHANGELOG.md
+++ b/packages/gpukit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.1
+
+- Manifest only: the gpu dependency range is `^0.3` (0.3.0 was published
+  with `^0.2`, which is disjoint from onnx 0.5.0's `^0.3` — a resolver
+  could try to install two gpu versions side by side).
+
 ## 0.3.0
 
 Device-resident layer (`src/dev.nu`) — data stays on the GPU between ops:

--- a/packages/gpukit/nurl.toml
+++ b/packages/gpukit/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpukit"
-version = "0.3.0"
+version = "0.3.1"
 description = "The ergonomic GPU-compute toolkit for NURL — a diamond facade over the `gpu` package that kills the marshalling boilerplate every GPU-using package re-invents. Where `gpu` is the low-level interface (open a device, JIT-compile a CUDA-C kernel via NVRTC or the host-C++ CPU backend, allocate/upload/download device buffers, build the argument vector, compute a grid, launch, sync, free), `gpukit` collapses the ~35 lines of that dance per kernel into a list of typed bindings and one `gk_run`: a GpuKit with a per-name kernel cache, `gk_in_f`/`gk_in_i`/`gk_out_f`/`gk_out_i` (and raw-buffer + i32/i64/f32 scalar) bindings, and a workhorse that compiles-once, allocates a device buffer per binding, uploads inputs, marshals args in declaration order, launches, syncs, downloads outputs, and frees everything. Ships a library of ready-made f64 kernels — elementwise add/sub/mul/div, a source-baked unary map, a bit-identical matmul, and reduce-sum / dot — so ML code never writes a kernel or a device buffer for the common cases. Adds no numerics of its own: a kernel runs bit-for-bit the same through gk_run as through hand-written gpu_* calls, preserving the gpu package's CUDA / CPU-backend / pure equivalence. Runs on the CPU backend when no CUDA device is present."
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
gpukit 0.3.0 was published before PR #383's dep-range alignment, so its **registry** manifest still declares `gpu ^0.2` — disjoint from onnx 0.5.0's `^0.3`, which lets the resolver install two gpu versions into one program. Manifest-only bump to 0.3.1; publish after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7