### PR TITLE
chore: gitignore TODO.md.recovered-* (local recovery archives)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ vendor/
 stdlib/nurl_version_gen.h
 stdlib/runtime.cuda
 stdlib/runtime.nvrtc
+TODO.md.recovered-*


### PR DESCRIPTION
One line: keep local TODO.md recovery archives untracked, like the working list itself. (Context: local TODO.md was mysteriously truncated; content recovered from session transcripts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7