### PR TITLE
registry: make header nurl-lang.org link open in a new tab

### DIFF
--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -211,26 +211,30 @@ const PAGE_STYLE =
   `.readme blockquote{border-left:3px solid #ddd;margin:1em 0;padding:.2rem 1rem;color:#555}` +
   `.readme h1,.readme h2{border-bottom:1px solid #eee;padding-bottom:.2em}` +
   `.readme hr{border:0;border-top:1px solid #e5e5e5;margin:2rem 0}` +
-  `.site-head{display:flex;align-items:center;gap:.6rem;text-decoration:none;color:#1a1a1a;` +
+  `.site-head{display:flex;align-items:center;gap:.6rem;` +
     `margin:-1rem 0 1.8rem;padding-bottom:1rem;border-bottom:1px solid #e5e5e5}` +
+  `.site-head .brand{display:flex;align-items:center;gap:.6rem;text-decoration:none;color:#1a1a1a}` +
   `.site-head .badge{display:inline-flex;background:#0f1115;border-radius:9px;padding:5px;` +
     `box-shadow:0 2px 10px rgba(20,184,166,.25)}` +
   `.site-head .badge img{display:block}` +
   `.site-head .wm{font-size:1.1rem;font-weight:600;letter-spacing:.01em}` +
   `.site-head .wm b{color:#0b62d6}` +
   `.site-head .spacer{flex:1}` +
-  `.site-head .home{font-size:.85rem;color:#666;font-weight:400}`;
+  `.site-head .home{font-size:.85rem;color:#666;font-weight:400;text-decoration:none;transition:color .15s}` +
+  `.site-head .home:hover{color:#0b62d6}`;
 
 // Branded header injected on every registry page. The mark is served from
 // the main site (nurl-lang.org) and sits on a dark chip so the neon reads
 // against the light page.
 const SITE_HEAD =
-  `<a class="site-head" href="/">` +
-    `<span class="badge"><img src="https://nurl-lang.org/img/logo-sm.png" width="30" height="30" alt="NURL"></span>` +
-    `<span class="wm">NURL <b>registry</b></span>` +
+  `<div class="site-head">` +
+    `<a class="brand" href="/">` +
+      `<span class="badge"><img src="https://nurl-lang.org/img/logo-sm.png" width="30" height="30" alt="NURL"></span>` +
+      `<span class="wm">NURL <b>registry</b></span>` +
+    `</a>` +
     `<span class="spacer"></span>` +
-    `<span class="home">nurl-lang.org →</span>` +
-  `</a>`;
+    `<a class="home" href="https://nurl-lang.org/" target="_blank" rel="noopener">nurl-lang.org →</a>` +
+  `</div>`;
 
 function htmlPage(title: string, bodyHtml: string, status = 200): Response {
   return new Response(


### PR DESCRIPTION
## What

The top-right `nurl-lang.org →` text in the registry page header was a dead `<span>` nested inside the header's link to `/`, so it did nothing.

This splits the header into two real links:
- **Brand** (logo + wordmark) → `/` (unchanged behavior)
- **`nurl-lang.org →`** → `https://nurl-lang.org/`, opening in a new tab (`target="_blank"` + `rel="noopener"`)

Nesting an `<a>` inside another `<a>` is invalid HTML, so the header element became a `<div>` flex container holding the two anchors.

## Styling

Keeps the current look — gray (`#666`), no underline — and adds a subtle blue hover instead of the browser-default underlined-blue link.

## Deploy

Already deployed to production (`nurl-registry` worker, version `68e11f24`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)