### PR TITLE
nurlpkg hints + hidden login, nurl-mcp 0.4.1, registry repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,31 @@ rounds before the build is accepted. Details: [`docs/BUILDING.md`](docs/BUILDING
 
 ## Quick start
 
+### Install the toolchain
+
+Prebuilt `nurlc` / `nurlpkg` / `nurlfmt` binaries, one command — no clang, no
+build:
+
+```bash
+# Linux / macOS
+curl -fsSL https://nurl-lang.org/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://nurl-lang.org/install.ps1 | iex
+```
+
+Then:
+
+```bash
+nurlpkg install <name>     # fetch & build a program from reg.nurl-lang.org
+```
+
+### Build from source
+
+For contributors, or to run the bootstrap yourself:
+
 ```bash
 git clone https://github.com/nurl-lang/nurl.git
 cd nurl

--- a/packages/nurl-mcp/README.md
+++ b/packages/nurl-mcp/README.md
@@ -33,11 +33,16 @@ pipe; nothing listens on the network.
 
 ```sh
 # Claude Code
-claude mcp add nurl -- nurl-mcp
+claude mcp add nurl -- ~/.nurl/bin/nurl-mcp
 ```
 
-For any other client, configure an MCP server whose `command` is `nurl-mcp`
-(no arguments).
+`nurlpkg install` prints this exact line once the binary is in place. The `~`
+is expanded by your shell, so the absolute path works even from a client that
+doesn't inherit your `$PATH`; `claude mcp add nurl -- nurl-mcp` also works when
+`~/.nurl/bin` is on `$PATH`.
+
+For any other client, configure an MCP server whose `command` is
+`~/.nurl/bin/nurl-mcp` (no arguments).
 
 ## Tools
 
@@ -116,7 +121,7 @@ stdio-only by design.
 
 ## Status
 
-v0.2.0 — stdio + token-authenticated HTTP transport. Not yet bundled with the
+v0.4.1 — stdio + token-authenticated HTTP transport. Not yet bundled with the
 toolchain; install it explicitly. Possible follow-ups: serving the grammar /
 spec / examples once the installer ships them (a `nurl_doc` tool); a continuous
 SSE notification stream; per-session state.

--- a/packages/nurl-mcp/nurl.toml
+++ b/packages/nurl-mcp/nurl.toml
@@ -1,8 +1,14 @@
 [package]
 name = "nurl-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "Local MCP server for the NURL toolchain — exposes the installed compiler over Model Context Protocol so an LLM agent on the host can build, run, type-check, format, and compile NURL to wasm32-wasi (fully local wasm builds via the wasmbuilder package), and read the installed stdlib. Stdio by default; an optional token-authenticated HTTP transport (--http) gates code execution behind --allow-run. The editor-facing counterpart of nurl-lsp, for LLMs."
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/nurl-lang/nurl/tree/main/packages/nurl-mcp"
+
+# Optional post-install hint. nurlpkg prints `message` after a successful
+# `nurlpkg install`, and the registry renders it on the package page.
+[hints]
+postinstall = "Register with Claude Code:  claude mcp add nurl -- ~/.nurl/bin/nurl-mcp"
 
 [dependencies]
 wasmbuilder = { path = "../wasmbuilder", version = "^0.1.0" }

--- a/packages/nurl-mcp/src/main.nu
+++ b/packages/nurl-mcp/src/main.nu
@@ -50,6 +50,28 @@ $ `deps/wasmbuilder/src/build.nu`
 : ~ i g_run_allowed 1
 : ~ s g_token ``
 
+// ── Version ─────────────────────────────────────────────────────────
+//
+// Single source of truth for the server version. Keep this in sync with
+// `version` in nurl.toml on every release — the banners and the MCP
+// `initialize` result both read it here, so there is exactly one string
+// to bump (previously the banners drifted to a stale 0.2.0 while the
+// handshake reported 0.4.0).
+
+@ nm_version → s { ^ `0.4.1` }
+
+// Log a startup banner "nurl-mcp <version> <suffix>" through mcp_log,
+// building the line from the single-source version so the banners can
+// never drift from the handshake version again.
+@ nm_log_banner s suffix → v {
+    : String b ( string_from `nurl-mcp ` )
+    ( string_push_str b ( nm_version ) )
+    ( string_push_char b 32 )
+    ( string_push_str b suffix )
+    ( mcp_log ( string_data b ) )
+    ( string_free b )
+}
+
 // ── Temp-file plumbing ──────────────────────────────────────────────
 //
 // Inline `source` is written to a unique temp .nu so the file-oriented
@@ -609,7 +631,7 @@ $ `deps/wasmbuilder/src/build.nu`
 // examples/mcp_echo_server_http.nu, used by both transports) ─────────
 
 @ handle_initialize Json id → Json {
-    : Json result ( mcp_initialize_result `nurl-mcp` `0.4.0` )
+    : Json result ( mcp_initialize_result `nurl-mcp` ( nm_version ) )
     ^ ( mcp_response_result id result )
 }
 
@@ -844,14 +866,14 @@ $ `deps/wasmbuilder/src/build.nu`
                 ( mcp_log `WARNING: serving HTTP with no --token — any local client can drive the toolchain` )
             } {}
             ? ( nm_run_ok ) {
-                ( mcp_log `nurl-mcp 0.2.0 ready (http) — nurl_run ENABLED` )
+                ( nm_log_banner `ready (http) — nurl_run ENABLED` )
             } {
-                ( mcp_log `nurl-mcp 0.2.0 ready (http) — nurl_run disabled (pass --allow-run to enable)` )
+                ( nm_log_banner `ready (http) — nurl_run disabled (pass --allow-run to enable)` )
             }
             = rc ( run_http ( string_data host ) port )
         }
     } {
-        ( mcp_log `nurl-mcp 0.2.0 ready (stdio)` )
+        ( nm_log_banner `ready (stdio)` )
         ( stdio_loop )
         ( mcp_log `bye` )
         = rc 0

--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -22,7 +22,7 @@
 // (miniflare simulates R2 + D1) — no Cloudflare account needed to test.
 
 import { renderMarkdown } from "./markdown.ts";
-import { extractReadme, extractFile, normalizeRelPath } from "./readme.ts";
+import { extractReadme, extractFile, extractManifestRepository, normalizeRelPath } from "./readme.ts";
 
 export interface Env {
   REG_BUCKET: R2Bucket;
@@ -323,6 +323,18 @@ async function handlePackageDetail(env: Env, name: string): Promise<Response> {
     : `<p>None.</p>`;
   const reqStr = latest ? `^${latest.version}` : "*";
 
+  // Repository link, read straight from the latest tarball's nurl.toml
+  // ([package].repository). Only http(s) URLs are rendered as links.
+  let repoHtml = "";
+  if (latest) {
+    try {
+      const repo = await extractManifestRepository(env.REG_BUCKET, name, latest.version);
+      if (repo && /^https?:\/\//i.test(repo)) {
+        repoHtml = `<p style="color:#666">repository <a href="${esc(repo)}">${esc(repo)}</a></p>`;
+      }
+    } catch { /* no repository line */ }
+  }
+
   // README of the latest published version, rendered from its tarball.
   // Never let a missing/odd archive break the page.
   let readmeHtml = "";
@@ -351,6 +363,7 @@ async function handlePackageDetail(env: Env, name: string): Promise<Response> {
   return htmlPage(name,
     `<p><a href="/">← all packages</a></p><h1>${esc(name)}</h1>` +
     ownerHtml +
+    repoHtml +
     `<h3>Install</h3><pre>[dependencies]\n${esc(name)} = "${esc(reqStr)}"</pre>` +
     `<h3>Versions</h3><ul>${versionsHtml}</ul>` +
     `<h3>Dependencies (latest)</h3>${depsHtml}` +

--- a/registry/src/readme.ts
+++ b/registry/src/readme.ts
@@ -80,6 +80,34 @@ export async function extractReadme(
   return findReadmeInTar(new Uint8Array(ab));
 }
 
+// Pull `[package].repository` out of the published tarball's nurl.toml.
+// Returns the URL string, or null when absent/unreadable. Deliberately a
+// tiny line-scan rather than a full TOML parser: we only need one scalar,
+// and the registry must never break a package page over a manifest quirk.
+export async function extractManifestRepository(
+  bucket: R2Bucket,
+  name: string,
+  version: string,
+): Promise<string | null> {
+  const obj = await bucket.get(`pkgs/${name}/${name}-${version}.tar.gz`);
+  if (!obj || !obj.body) return null;
+  const ab = await new Response(obj.body.pipeThrough(new DecompressionStream("gzip"))).arrayBuffer();
+  const hit = findInTar(new Uint8Array(ab), (p) => p.replace(/^\.\//, "") === "nurl.toml");
+  if (!hit) return null;
+  const toml = new TextDecoder().decode(hit.data);
+  // `repository = "..."` under [package]; stop at the next table header so a
+  // stray `repository` key in another section can't be mistaken for it.
+  let inPackage = false;
+  for (const raw of toml.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.startsWith("[")) { inPackage = line === "[package]"; continue; }
+    if (!inPackage) continue;
+    const m = line.match(/^repository\s*=\s*"([^"]*)"/);
+    if (m) return m[1] || null;
+  }
+  return null;
+}
+
 // Fetch + gunzip a published tarball and return the bytes of the member at
 // the exact relative path `rel` (e.g. `docs/demo.png`), or null if missing.
 // Used to serve README-referenced assets (images) straight from the tarball.

--- a/stdlib/ext/manifest.nu
+++ b/stdlib/ext/manifest.nu
@@ -56,6 +56,8 @@ $ `stdlib/ext/toml.nu`
     String description
     String license
     String registry  // default registry URL for bare deps; empty → tool default
+    String repository  // [package].repository — source URL; empty → unset
+    String postinstall  // [hints].postinstall — message shown after install; empty → none
     ( Vec Dep ) dependencies
 }
 
@@ -111,6 +113,8 @@ $ `stdlib/ext/toml.nu`
     ( string_free . m version )
     ( string_free . m description )
     ( string_free . m license )
+    ( string_free . m repository )
+    ( string_free . m postinstall )
     ( string_free . m registry )
     : i n ( vec_len [Dep] . m dependencies )
     : ~ i k 0
@@ -246,6 +250,8 @@ $ `stdlib/ext/toml.nu`
             : String description ( __field_str root `package.description` )
             : String license ( __field_str root `package.license` )
             : String registry ( __field_str root `package.registry` )
+            : String repository ( __field_str root `package.repository` )
+            : String postinstall ( __field_str root `hints.postinstall` )
 
             // Dependencies.
             : ( Vec Dep ) deps ( vec_new [Dep] )
@@ -277,7 +283,7 @@ $ `stdlib/ext/toml.nu`
                 F _ → {}
             }
             ( toml_value_free root )
-            ^ @ !Manifest ManifestErr { T @ Manifest { name version description license registry deps } }
+            ^ @ !Manifest ManifestErr { T @ Manifest { name version description license registry repository postinstall deps } }
         }
     }
 }

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -1307,11 +1307,18 @@ $ `stdlib/std/bytes.nu`
 
 // ── login / logout ───────────────────────────────────────────────
 
+// Read a secret from the terminal with echo off (termios on POSIX, console
+// mode on Windows; falls back to echoed input on WASI / when stdin isn't a
+// tty). The runtime prints the prompt to stderr and returns the entered
+// line with the trailing newline stripped. Same builtin packages/psql uses
+// for its password prompt.
+& `c` @ nurl_read_password s prompt → s
+
 @ __cmd_login → i {
     : String reg ( __reg_default )
     ( nurl_print `Registry: ` ) ( nurl_print ( string_data reg ) ) ( nurl_print `\n` )
-    ( nurl_print `Paste a publish token (get one at <registry>/login): ` )
-    : String token ( read_line )
+    // Hidden entry: the pasted token must not echo to the screen.
+    : String token ( string_from ( nurl_read_password `Paste a publish token (get one at <registry>/login): ` ) )
     : ~ i rc 0
     ? == ( string_len token ) 0 {
         ( nurl_eprintln `nurlpkg: empty token; aborted` )
@@ -1644,6 +1651,27 @@ $ `stdlib/std/bytes.nu`
     ^ ok
 }
 
+// Print the freshly-installed package's [hints].postinstall message, if it
+// declares one. Best-effort: any manifest read/parse trouble is silent —
+// a missing hint must never make a successful install look like a failure.
+@ __print_postinstall s pkgdir → v {
+    : String mfp ( string_from pkgdir )
+    ( string_push_str mfp `/nurl.toml` )
+    : !Manifest ManifestErr mr ( manifest_load ( string_data mfp ) )
+    ( string_free mfp )
+    ?? mr {
+        T m → {
+            ? > ( string_len . m postinstall ) 0 {
+                ( nurl_print `\n` )
+                ( nurl_print ( string_data . m postinstall ) )
+                ( nurl_print `\n` )
+            } {}
+            ( manifest_free m )
+        }
+        F _ → {}
+    }
+}
+
 // pkgdir (absolute) holds the unpacked package (nurl.toml + src/main.nu).
 // Resolve its deps in-process, build the entry point, and install the
 // binary into bindir/name. Cross-platform: uses fs primitives + a
@@ -1714,6 +1742,8 @@ $ `stdlib/std/bytes.nu`
                 } {}
                 ( nurl_print `Installed ` ) ( nurl_print name )
                 ( nurl_print ` → ` ) ( nurl_print ( string_data dest ) ) ( nurl_print `\n` )
+                // Show the package's [hints].postinstall message, if any.
+                ( __print_postinstall pkgdir )
             }
         }
         ( string_free outbin )


### PR DESCRIPTION
Bundles five related improvements to the toolchain, the `nurl-mcp` package, and the registry.

## `nurlpkg`
- **Hidden login token.** `nurlpkg login` reads the publish token via the runtime's `nurl_read_password` builtin (the one `packages/psql` already uses), so a pasted token no longer echoes to the screen — echo-off via termios (POSIX) / console mode (Windows), graceful echoed fallback on WASI and non-tty stdin. Prompt goes to stderr; trailing newline stripped.
- **`[hints].postinstall`.** The manifest schema gains `[package].repository` and `[hints].postinstall`; `nurlpkg install` prints the postinstall message after a successful install. Best-effort — a missing/odd manifest never turns a good install into a failure.

## `nurl-mcp` → 0.4.1
- **Single-source version.** The version lives in one place (`nm_version`); the startup banners and the MCP `initialize` result both read it. Fixes the drift where the banners reported a stale `0.2.0` while the handshake said `0.4.0`.
- `nurl.toml` declares `repository` and a `[hints].postinstall` line that registers the server with Claude Code.
- README documents `claude mcp add nurl -- ~/.nurl/bin/nurl-mcp` (the exact line `nurlpkg` now prints).
- Patch-bumped to **0.4.1** so the new manifest can be published (0.4.0 is immutable).

## Registry
- The package page renders `[package].repository` as a link, read straight from the latest published tarball's `nurl.toml` (a small package-scoped line-scan — no DB migration, no publish-protocol change). Only `http(s)` URLs are shown.

## README
- Quick start now leads with the prebuilt toolchain one-liners (Linux/macOS `curl | sh`, Windows PowerShell `irm | iex`), with build-from-source kept below for contributors.

## Verification
- `nurlpkg` + `nurl-mcp` rebuild clean; `nurl-mcp` handshake and banner both report `0.4.1`.
- `manifest`/`toml`/`registry_index` tests pass; new `repository`/`postinstall` fields parse from the real `nurl.toml`.
- Login echo-off verified under a real PTY (typed secret does not echo; program still receives it).
- Registry `tsc --noEmit` clean.

## Post-merge (tracked separately)
- Publish `nurl-mcp` 0.4.1 to the registry (requires a publish token).
- Deploy the registry worker so the repository link renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)