### PR TITLE
installers: offer permanent PATH + auto-set current session

### DIFF
--- a/nurlweb/public/install.ps1
+++ b/nurlweb/public/install.ps1
@@ -14,6 +14,9 @@
 #  Params:
 #    -Version <tag>   release tag to install (default: latest)
 #    -Prefix  <dir>   install prefix (default: %USERPROFILE%\.nurl)
+#
+#  Env:
+#    $env:NURL_NO_MODIFY_PATH = "1"   never prompt / change the User PATH
 # ============================================================
 param(
     [string]$Version = $env:NURL_VERSION,
@@ -65,14 +68,45 @@ try {
         throw "install looks incomplete: $Prefix\bin\nurl.bat missing."
     }
 
+    $binDir = Join-Path $Prefix "bin"
+
+    # This session: `iex` evaluates in the caller's session, so we can put
+    # NURL on PATH right now — no separate command to copy-paste.
+    if (($env:Path -split ';') -notcontains $binDir) {
+        $env:Path = "$binDir;$env:Path"
+    }
+    $env:NURL_STDLIB = $Prefix
+
     Write-Host ""
     Write-Host "NURL $Version installed -> $Prefix"
+    Write-Host "This session is ready — 'nurlc' and 'nurlpkg' are on PATH now."
     Write-Host ""
-    Write-Host "Add it to this session:"
-    Write-Host "    `$env:Path = `"$Prefix\bin;`$env:Path`""
-    Write-Host "Make it permanent:"
-    Write-Host "    setx PATH `"$Prefix\bin;%PATH%`""
-    Write-Host "    setx NURL_STDLIB `"$Prefix`""
+
+    # Offer to persist to the User environment so new terminals inherit it.
+    $persist = $false
+    if ($env:NURL_NO_MODIFY_PATH -eq "1") {
+        $persist = $false
+    } elseif ([Environment]::UserInteractive) {
+        $ans = Read-Host "Add NURL to your PATH permanently (User environment)? [Y/n]"
+        if ($ans -eq "" -or $ans -match '^[Yy]') { $persist = $true }
+    }
+
+    if ($persist) {
+        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        if (-not $userPath) { $userPath = "" }
+        if (($userPath -split ';') -contains $binDir) {
+            Write-Host "PATH already contains $binDir (User environment)."
+        } else {
+            $newPath = if ($userPath) { "$binDir;$userPath" } else { $binDir }
+            [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+            Write-Host "Added $binDir to your User PATH — new terminals will have it."
+        }
+        [Environment]::SetEnvironmentVariable("NURL_STDLIB", $Prefix, "User")
+    } else {
+        Write-Host "Left your permanent PATH untouched. For future terminals, run:"
+        Write-Host "    [Environment]::SetEnvironmentVariable('Path', `"$binDir;`" + [Environment]::GetEnvironmentVariable('Path','User'), 'User')"
+    }
+
     Write-Host ""
     Write-Host "Then:  nurlc --version   ·   nurlpkg install nq"
 }

--- a/nurlweb/public/install.sh
+++ b/nurlweb/public/install.sh
@@ -14,8 +14,9 @@
 #    curl -fsSL https://nurl-lang.org/install.sh | sh -s -- --version v0.1.0
 #
 #  Env:
-#    NURL_HOME     install prefix (default ~/.nurl)
-#    NURL_VERSION  release tag to install (default: latest)
+#    NURL_HOME            install prefix (default ~/.nurl)
+#    NURL_VERSION         release tag to install (default: latest)
+#    NURL_NO_MODIFY_PATH  set to 1 to never touch shell rc files / prompt
 #
 #  POSIX sh — no bashisms; works under dash/ash/busybox.
 # ============================================================
@@ -156,16 +157,75 @@ smoke() {
 smoke "$PREFIX/build/nurlc"
 smoke "$PREFIX/build/nurlpkg"
 
-# ── Done ───────────────────────────────────────────────────────────────
+# ── PATH setup ─────────────────────────────────────────────────────────
 info ""
 info "NURL $VERSION installed → $PREFIX"
 info ""
-info "Put it on your PATH (works in any shell — add the line to your shell rc to persist):"
-info "    export PATH=\"$PREFIX/bin:\$PATH\""
+
+BIN_DIR="$PREFIX/bin"
+EXPORT_LINE="export PATH=\"$BIN_DIR:\$PATH\""
+
+# The shell rc to persist into, chosen from the user's login shell.
+rc_file() {
+    case "$(basename "${SHELL:-sh}")" in
+        zsh)  printf '%s' "${ZDOTDIR:-$HOME}/.zshrc" ;;
+        bash) printf '%s' "$HOME/.bashrc" ;;
+        *)    printf '%s' "$HOME/.profile" ;;
+    esac
+}
+
+case ":${PATH}:" in
+    *":$BIN_DIR:"*)
+        # Already visible in this shell (e.g. a re-install) — nothing to do.
+        info "$BIN_DIR is already on your PATH — you're all set."
+        ;;
+    *)
+        RC="$(rc_file)"
+        DO_PERSIST=0
+        # Piped installs have the script on stdin, so ask on the terminal
+        # directly. No tty (CI, no controlling terminal) ⇒ don't prompt and
+        # never modify rc files silently.
+        if [ "${NURL_NO_MODIFY_PATH:-0}" = "1" ]; then
+            :
+        elif ( : > /dev/tty ) 2>/dev/null && ( : < /dev/tty ) 2>/dev/null; then
+            # /dev/tty actually opens (a controlling terminal is attached) —
+            # an access() check alone passes even with no tty and then aborts.
+            # Probe in subshells: a redirection error on the special builtin
+            # ':' would otherwise exit the whole (non-interactive) shell.
+            printf 'Add %s to your PATH permanently in %s? [Y/n] ' "$BIN_DIR" "$RC" > /dev/tty
+            read ANS < /dev/tty || ANS=""
+            case "$ANS" in ""|[Yy]*) DO_PERSIST=1 ;; esac
+        fi
+
+        if [ "$DO_PERSIST" -eq 1 ]; then
+            if [ -e "$RC" ] && grep -qF "$BIN_DIR" "$RC" 2>/dev/null; then
+                info "PATH already configured in $RC — left it unchanged."
+            elif printf '\n# Added by the NURL installer (https://nurl-lang.org)\n%s\n' "$EXPORT_LINE" >> "$RC" 2>/dev/null; then
+                info "Added $BIN_DIR to PATH in $RC — new shells will pick it up."
+            else
+                info "Could not write to $RC; add this line to your shell rc yourself:"
+                info "    $EXPORT_LINE"
+            fi
+            # A piped `curl | sh` runs in a child shell and cannot change the
+            # PATH of the shell you launched it from, so this one still needs
+            # the export (or a fresh terminal).
+            info ""
+            info "This shell won't see it until you run (or open a new terminal):"
+            info "    $EXPORT_LINE"
+        else
+            info "To use NURL in this shell now, run:"
+            info "    $EXPORT_LINE"
+            info ""
+            info "To make it permanent, add that line to your shell rc (e.g. $RC),"
+            info "or re-run with a terminal attached to be offered the change."
+        fi
+        ;;
+esac
+
 info ""
-info "The shims self-locate the stdlib, so that one line is all you need —"
-info "no 'source env' required. (bash/zsh users may instead 'source $PREFIX/env',"
-info "which also exports NURL_HOME.)"
+info "The shims self-locate the stdlib, so PATH is all you need — no 'source"
+info "env' required. (bash/zsh users may instead 'source $PREFIX/env', which"
+info "also exports NURL_HOME.)"
 info ""
 info "Then:  nurlc --version   ·   nurlpkg install nq"
 

--- a/tools/get-nurl.ps1
+++ b/tools/get-nurl.ps1
@@ -14,6 +14,9 @@
 #  Params:
 #    -Version <tag>   release tag to install (default: latest)
 #    -Prefix  <dir>   install prefix (default: %USERPROFILE%\.nurl)
+#
+#  Env:
+#    $env:NURL_NO_MODIFY_PATH = "1"   never prompt / change the User PATH
 # ============================================================
 param(
     [string]$Version = $env:NURL_VERSION,
@@ -65,14 +68,45 @@ try {
         throw "install looks incomplete: $Prefix\bin\nurl.bat missing."
     }
 
+    $binDir = Join-Path $Prefix "bin"
+
+    # This session: `iex` evaluates in the caller's session, so we can put
+    # NURL on PATH right now — no separate command to copy-paste.
+    if (($env:Path -split ';') -notcontains $binDir) {
+        $env:Path = "$binDir;$env:Path"
+    }
+    $env:NURL_STDLIB = $Prefix
+
     Write-Host ""
     Write-Host "NURL $Version installed -> $Prefix"
+    Write-Host "This session is ready — 'nurlc' and 'nurlpkg' are on PATH now."
     Write-Host ""
-    Write-Host "Add it to this session:"
-    Write-Host "    `$env:Path = `"$Prefix\bin;`$env:Path`""
-    Write-Host "Make it permanent:"
-    Write-Host "    setx PATH `"$Prefix\bin;%PATH%`""
-    Write-Host "    setx NURL_STDLIB `"$Prefix`""
+
+    # Offer to persist to the User environment so new terminals inherit it.
+    $persist = $false
+    if ($env:NURL_NO_MODIFY_PATH -eq "1") {
+        $persist = $false
+    } elseif ([Environment]::UserInteractive) {
+        $ans = Read-Host "Add NURL to your PATH permanently (User environment)? [Y/n]"
+        if ($ans -eq "" -or $ans -match '^[Yy]') { $persist = $true }
+    }
+
+    if ($persist) {
+        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        if (-not $userPath) { $userPath = "" }
+        if (($userPath -split ';') -contains $binDir) {
+            Write-Host "PATH already contains $binDir (User environment)."
+        } else {
+            $newPath = if ($userPath) { "$binDir;$userPath" } else { $binDir }
+            [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+            Write-Host "Added $binDir to your User PATH — new terminals will have it."
+        }
+        [Environment]::SetEnvironmentVariable("NURL_STDLIB", $Prefix, "User")
+    } else {
+        Write-Host "Left your permanent PATH untouched. For future terminals, run:"
+        Write-Host "    [Environment]::SetEnvironmentVariable('Path', `"$binDir;`" + [Environment]::GetEnvironmentVariable('Path','User'), 'User')"
+    }
+
     Write-Host ""
     Write-Host "Then:  nurlc --version   ·   nurlpkg install nq"
 }

--- a/tools/get-nurl.sh
+++ b/tools/get-nurl.sh
@@ -14,8 +14,9 @@
 #    curl -fsSL https://nurl-lang.org/install.sh | sh -s -- --version v0.1.0
 #
 #  Env:
-#    NURL_HOME     install prefix (default ~/.nurl)
-#    NURL_VERSION  release tag to install (default: latest)
+#    NURL_HOME            install prefix (default ~/.nurl)
+#    NURL_VERSION         release tag to install (default: latest)
+#    NURL_NO_MODIFY_PATH  set to 1 to never touch shell rc files / prompt
 #
 #  POSIX sh — no bashisms; works under dash/ash/busybox.
 # ============================================================
@@ -156,16 +157,75 @@ smoke() {
 smoke "$PREFIX/build/nurlc"
 smoke "$PREFIX/build/nurlpkg"
 
-# ── Done ───────────────────────────────────────────────────────────────
+# ── PATH setup ─────────────────────────────────────────────────────────
 info ""
 info "NURL $VERSION installed → $PREFIX"
 info ""
-info "Put it on your PATH (works in any shell — add the line to your shell rc to persist):"
-info "    export PATH=\"$PREFIX/bin:\$PATH\""
+
+BIN_DIR="$PREFIX/bin"
+EXPORT_LINE="export PATH=\"$BIN_DIR:\$PATH\""
+
+# The shell rc to persist into, chosen from the user's login shell.
+rc_file() {
+    case "$(basename "${SHELL:-sh}")" in
+        zsh)  printf '%s' "${ZDOTDIR:-$HOME}/.zshrc" ;;
+        bash) printf '%s' "$HOME/.bashrc" ;;
+        *)    printf '%s' "$HOME/.profile" ;;
+    esac
+}
+
+case ":${PATH}:" in
+    *":$BIN_DIR:"*)
+        # Already visible in this shell (e.g. a re-install) — nothing to do.
+        info "$BIN_DIR is already on your PATH — you're all set."
+        ;;
+    *)
+        RC="$(rc_file)"
+        DO_PERSIST=0
+        # Piped installs have the script on stdin, so ask on the terminal
+        # directly. No tty (CI, no controlling terminal) ⇒ don't prompt and
+        # never modify rc files silently.
+        if [ "${NURL_NO_MODIFY_PATH:-0}" = "1" ]; then
+            :
+        elif ( : > /dev/tty ) 2>/dev/null && ( : < /dev/tty ) 2>/dev/null; then
+            # /dev/tty actually opens (a controlling terminal is attached) —
+            # an access() check alone passes even with no tty and then aborts.
+            # Probe in subshells: a redirection error on the special builtin
+            # ':' would otherwise exit the whole (non-interactive) shell.
+            printf 'Add %s to your PATH permanently in %s? [Y/n] ' "$BIN_DIR" "$RC" > /dev/tty
+            read ANS < /dev/tty || ANS=""
+            case "$ANS" in ""|[Yy]*) DO_PERSIST=1 ;; esac
+        fi
+
+        if [ "$DO_PERSIST" -eq 1 ]; then
+            if [ -e "$RC" ] && grep -qF "$BIN_DIR" "$RC" 2>/dev/null; then
+                info "PATH already configured in $RC — left it unchanged."
+            elif printf '\n# Added by the NURL installer (https://nurl-lang.org)\n%s\n' "$EXPORT_LINE" >> "$RC" 2>/dev/null; then
+                info "Added $BIN_DIR to PATH in $RC — new shells will pick it up."
+            else
+                info "Could not write to $RC; add this line to your shell rc yourself:"
+                info "    $EXPORT_LINE"
+            fi
+            # A piped `curl | sh` runs in a child shell and cannot change the
+            # PATH of the shell you launched it from, so this one still needs
+            # the export (or a fresh terminal).
+            info ""
+            info "This shell won't see it until you run (or open a new terminal):"
+            info "    $EXPORT_LINE"
+        else
+            info "To use NURL in this shell now, run:"
+            info "    $EXPORT_LINE"
+            info ""
+            info "To make it permanent, add that line to your shell rc (e.g. $RC),"
+            info "or re-run with a terminal attached to be offered the change."
+        fi
+        ;;
+esac
+
 info ""
-info "The shims self-locate the stdlib, so that one line is all you need —"
-info "no 'source env' required. (bash/zsh users may instead 'source $PREFIX/env',"
-info "which also exports NURL_HOME.)"
+info "The shims self-locate the stdlib, so PATH is all you need — no 'source"
+info "env' required. (bash/zsh users may instead 'source $PREFIX/env', which"
+info "also exports NURL_HOME.)"
 info ""
 info "Then:  nurlc --version   ·   nurlpkg install nq"
 


### PR DESCRIPTION
Both one-line installers now *set up PATH* instead of only printing a line to copy.

## `install.sh` (`curl | sh`)
- Prompts on **`/dev/tty`** — *"Add ~/.nurl/bin to your PATH permanently in `<rc>`? [Y/n]"* — and on yes appends a managed `export` line to the login shell's rc (`.zshrc` / `.bashrc` / `.profile`). **Idempotent**: skips if the dir is already on PATH or already written.
- A piped `curl | sh` runs in a **child shell** and physically cannot mutate the parent shell's PATH, so it still prints the one `export` line for *this* session — and says so explicitly.
- **No controlling terminal** (CI) ⇒ no prompt, rc files untouched. `NURL_NO_MODIFY_PATH=1` opts out.
- The tty probe runs in a **subshell** so a redirection error on the special builtin `:` can't exit the installer (found and fixed during testing).

## `install.ps1` (`irm | iex`)
- `iex` evaluates in the **caller's session**, so NURL is put on PATH for *this* session **automatically** — no copy-paste.
- Then offers to persist to the **User environment** via `[Environment]::SetEnvironmentVariable(..., "User")` (append-if-absent), replacing the old truncation-prone `setx PATH "...;%PATH%"`. `UserInteractive` gates the prompt; `$env:NURL_NO_MODIFY_PATH=1` opts out.

## Why the asymmetry
`curl | sh` forks a child that can't touch the parent's environment — the current session still needs one `export` (or a new terminal). `irm | iex` runs in-process, so it *can* set the session live. Both persist for future shells on opt-in.

## Verification (`install.sh`, via extracted PATH block)
- No-tty → instructions only, rc untouched, exit 0 ✅
- Interactive **y** (real PTY) → appends managed block, preserves existing rc content ✅
- Second run → detects existing, no duplicate ✅
- Interactive **n** → declines, rc not created ✅
- Already-on-PATH → "you're all set" ✅
- `sh -n` / `dash -n` clean.

`install.ps1` static-reviewed (no `pwsh` in the sandbox): session PATH set in-process, `try/finally` balanced, escaping valid.

Served copies under `nurlweb/public/` re-synced via `npm run sync-installers`.

## Post-merge
Deploy `nurl-lang.org` (`nurlweb`, `npm run deploy`) so the updated `install.sh` / `install.ps1` are served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)