### PR TITLE
packages/template 0.1.0: HTML template engine over Json contexts

### DIFF
--- a/packages/template/README.md
+++ b/packages/template/README.md
@@ -1,0 +1,108 @@
+# template — an HTML template engine for NURL
+
+Jinja-flavoured templates rendered against a stdlib `Json` context.
+HTML-escaped by default, lenient on missing data, strict on malformed
+tags. The engine is pure text → text with no fs or http dependency;
+a directory loader and a small CLI ship alongside it.
+
+```html
+<ul>
+{% for item in items %}
+  <li class="{% if loop.first %}first{% end %}">
+    {{ loop.index }}: {{ item.title | upper }}
+    {% if item.url %}<a href="{{ item.url }}">link</a>{% end %}
+  </li>
+{% end %}
+</ul>
+{% include 'footer' %}
+```
+
+## Rendering
+
+```nurl
+$ `deps/template/src/template.nu`
+
+: Json ctx ...                            // e.g. ( json_parse src ) or built up
+?? ( tpl_render `Hi {{ name }}!` ctx ) {
+    T html → { ... ( string_free html ) }
+    F err  → { ... ( string_free err ) }   // "template error at line L, col C: …"
+}
+```
+
+| Call | |
+| --- | --- |
+| `( tpl_render src ctx )` → `!String String` | one-shot render |
+| `( tset_new )` → `*TplSet` | named-template set (include targets) |
+| `( tset_add t name src )` | register / replace (copies both) |
+| `( tset_has t name )` → `b` | |
+| `( tset_render t name ctx )` → `!String String` | render a set member |
+| `( tpl_render_with t src ctx )` → `!String String` | one-shot, includes resolve in `t` |
+| `( tset_free t )` | |
+| `( tset_load_dir t dir ext )` → `i` | `src/loader.nu`: load `dir/*<ext>`, named by basename; -1 when the glob fails |
+
+The context is any `Json` value; top-level lookups expect a `JObj`. The
+result and error payloads are owned Strings — free both.
+
+## Template syntax
+
+| Form | |
+| --- | --- |
+| `{{ expr }}` | output, HTML-escaped (`& < > " '`) |
+| `{{ expr \| raw }}` | unescaped output |
+| `{{ expr \| upper }}` / `\| lower` | case-fold strings |
+| `{{ expr \| length }}` | string byte length / array length |
+| `{{ expr \| json }}` | stringify an array/object (escaped; add `\| raw` for raw JSON) |
+| `{% if expr %} … {% elif expr %} … {% else %} … {% end %}` | `endif` also accepted |
+| `{% for name in path %} … {% end %}` | iterate a JSON array; `endfor` also accepted |
+| `{% include 'name' %}` | render a set member in the current context + scope |
+| `{# … #}` | comment |
+
+Expressions are a dotted path (`user.name`, `rows.0.id` — numeric
+segments index arrays), a `'string'` / `"string"` literal, a number, or
+`true`/`false`, optionally combined as `a == b` / `a != b` or prefixed
+with `not`. Inside a `{% for %}` body the innermost loop exposes
+`loop.index` (0-based), `loop.first`, `loop.last`, `loop.length`; the
+loop variable shadows context keys, inner loops shadow outer ones.
+
+**Truthiness:** missing keys and `null` are falsy, as are `false`, `0`,
+`""`, and `[]`; objects are truthy. Missing keys *render* as empty, so
+`{{ maybe }}` is safe without a guard — but a typo'd tag, filter, or
+operator is a hard error, not silence.
+
+**Equality** compares like kinds only: numbers numerically, strings
+bytewise, booleans as booleans; a string never equals a number.
+
+## Errors
+
+Failures return an owned String like
+`template error at line 3, col 12: '{% if %}' without matching '{% end %}'`.
+Include cycles are cut at depth 16. Known v0.1 limits: `}}` / `%}`
+inside a string literal ends the tag early; error positions inside an
+included template are reported against the including source.
+
+## CLI
+
+```
+template -f page.html -c ctx.json -p views/
+echo '{{ msg | upper }}' | template -c ctx.json
+```
+
+`-f` template file (default stdin), `-c` JSON context file (default
+`{}`), `-p` a partials directory (`*.html`, named by basename) for
+`{% include %}`.
+
+## Memory model
+
+`tpl_render`'s Ok/Err payloads are owned Strings — free them. The
+context `Json` stays caller-owned (the engine only borrows into it).
+`tset_add` copies its arguments; `tset_free` releases the set. The
+engine allocates one renderer per call and frees it before returning —
+the test suite runs clean under ASan/LSan.
+
+## Tests
+
+`nurlpkg test` (or `./nurl.sh tests/<t>.nu` from the package dir) runs
+three self-asserting suites: `basic.nu` (variables, escaping, filters,
+literals, error paths), `control.nu` (if/elif/else, for, `loop.*`,
+nesting, conditions), `includes.nu` (sets, include, cycles, the
+directory loader).

--- a/packages/template/nurl.toml
+++ b/packages/template/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "template"
+version = "0.1.0"
+description = "HTML template engine — Jinja-flavoured {{ vars }}, {% if/elif/else %}, {% for %} with loop.index/first/last, {% include %} partials and filters (raw/upper/lower/length/json), rendered against a stdlib Json context with HTML-escaping by default. Ships the engine (src/template.nu, no fs dependency), a directory loader for named template sets (src/loader.nu), and a small CLI. Missing keys render empty and are falsy (mustache-style lenient); malformed tags are hard errors with line/col positions. Pairs with the `http` package for server-rendered pages and with md2html for static generation."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/nurl-lang/nurl-lang"
+
+[dependencies]

--- a/packages/template/src/loader.nu
+++ b/packages/template/src/loader.nu
@@ -1,0 +1,61 @@
+// loader — fill a TplSet from a directory of template files.
+//
+// ( tset_load_dir t dir ext ) loads every `dir/*<ext>` file (e.g. ext
+// `.html`) into the set, named by its basename without the extension:
+// `views/index.html` → `index`. Returns the number of templates loaded,
+// or -1 when the directory glob fails. Individual unreadable files are
+// skipped (counted out), not fatal.
+//
+// Kept out of template.nu so the engine itself has no fs dependency.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `src/template.nu`
+
+@ tset_load_dir * TplSet t s dir s ext → i {
+    : String pat ( string_from dir )
+    ( string_push_str pat `/*` )
+    ( string_push_str pat ext )
+    : ~ i count 0
+    ?? ( fs_glob ( string_data pat ) ) {
+        T files → {
+            : i nf ( vec_len [String] files )
+            : ~ i k 0
+            ~ < k nf {
+                ?? ( vec_get [String] files k ) {
+                    T path → {
+                        // name = basename minus extension
+                        : ~ i b0 0
+                        : i plen ( string_len path )
+                        : ~ i j 0
+                        ~ < j plen {
+                            ? == ( string_get path j ) 47 { = b0 + j 1 } {}
+                            = j + j 1
+                        }
+                        : i nlen - - plen b0 ( nurl_str_len ext )
+                        ? > nlen 0 {
+                            : String name ( string_substr path b0 nlen )
+                            ?? ( read_file ( string_data path ) ) {
+                                T body → {
+                                    ( tset_add t ( string_data name ) ( string_data body ) )
+                                    ( string_free body )
+                                    = count + count 1
+                                }
+                                F _ → {}
+                            }
+                            ( string_free name )
+                        } {}
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            : ( @ v String ) sdrop \ String x → v { ( string_free x ) }
+            ( vec_free_with [String] files sdrop )
+        }
+        F _ → { = count - 0 1 }
+    }
+    ( string_free pat )
+    ^ count
+}

--- a/packages/template/src/main.nu
+++ b/packages/template/src/main.nu
@@ -1,0 +1,143 @@
+// template — render a template from the command line.
+//
+//   template -f page.html -c ctx.json          # render with a JSON context
+//   template -f page.html                      # empty context
+//   echo '{{ msg }}' | template -c ctx.json    # template from stdin
+//   template -f page.html -c ctx.json -p views # partials dir for {% include %}
+//
+// The context file must contain a JSON object; {% include 'name' %}
+// resolves against --partials (every *.html in the dir, named by
+// basename without the extension).
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/std/args.nu`
+$ `stdlib/ext/json.nu`
+$ `src/template.nu`
+$ `src/loader.nu`
+
+@ main → i {
+    : ArgParser p ( args_new `template` `render a template against a JSON context` )
+    ( args_flag p `help` 104 `show this help` )  // -h
+    ( args_opt p `file` 102 `FILE` `template file (default: stdin)` )  // -f
+    ( args_opt p `ctx` 99 `FILE` `JSON context file (default: empty object)` )  // -c
+    ( args_opt p `partials` 112 `DIR` `directory of *.html partials for {% include %}` )  // -p
+
+    : ( Vec String ) argv ( vec_new [String] )
+    : i ac ( env_args_count )
+    : ~ i ai 1
+    ~ < ai ac {
+        ( vec_push [String] argv ( env_arg ai ) )
+        = ai + ai 1
+    }
+
+    : ~ i rc 0
+    ? ( args_parse p argv ) {
+        ? ( args_present p `help` ) {
+            : String h ( args_usage p )
+            ( nurl_print `template — render a template against a JSON context\n\n` )
+            ( nurl_print ( string_data h ) )
+            ( string_free h )
+        } {
+            // template source: --file or stdin
+            : ~ String tsrc ( string_new )
+            : ~ b have T
+            ?? ( args_value p `file` ) {
+                T fv → {
+                    ?? ( read_file ( string_data fv ) ) {
+                        T txt → { ( string_free tsrc ) = tsrc txt }
+                        F _ → {
+                            ( nurl_eprint `template: cannot read file: ` )
+                            ( nurl_eprintln ( string_data fv ) )
+                            = rc 1
+                            = have F
+                        }
+                    }
+                    ( string_free fv )
+                }
+                F _ → { ( string_free tsrc ) = tsrc ( read_all_stdin ) }
+            }
+
+            // context: --ctx JSON file or empty object
+            : ~ Json ctx ( json_obj_new )
+            ? have {
+                ?? ( args_value p `ctx` ) {
+                    T cv → {
+                        ?? ( read_file ( string_data cv ) ) {
+                            T ctxt → {
+                                ?? ( json_parse ( string_data ctxt ) ) {
+                                    T j → { ( json_free ctx ) = ctx j }
+                                    F e → {
+                                        : String em ( json_format_error e )
+                                        ( nurl_eprint `template: bad JSON context: ` )
+                                        ( nurl_eprintln ( string_data em ) )
+                                        ( string_free em )
+                                        = rc 1
+                                        = have F
+                                    }
+                                }
+                                ( string_free ctxt )
+                            }
+                            F _ → {
+                                ( nurl_eprint `template: cannot read context: ` )
+                                ( nurl_eprintln ( string_data cv ) )
+                                = rc 1
+                                = have F
+                            }
+                        }
+                        ( string_free cv )
+                    }
+                    F _ → {}
+                }
+            } {}
+
+            // partials set
+            : ~ * TplSet t ( tset_new )
+            ? have {
+                ?? ( args_value p `partials` ) {
+                    T pv → {
+                        : i n ( tset_load_dir t ( string_data pv ) `.html` )
+                        ? < n 0 {
+                            ( nurl_eprint `template: cannot read partials dir: ` )
+                            ( nurl_eprintln ( string_data pv ) )
+                            = rc 1
+                            = have F
+                        } {}
+                        ( string_free pv )
+                    }
+                    F _ → {}
+                }
+            } {}
+
+            ? have {
+                ?? ( tpl_render_with t ( string_data tsrc ) ctx ) {
+                    T outp → {
+                        ( nurl_print ( string_data outp ) )
+                        ( string_free outp )
+                    }
+                    F m → {
+                        ( nurl_eprint `template: ` )
+                        ( nurl_eprintln ( string_data m ) )
+                        ( string_free m )
+                        = rc 1
+                    }
+                }
+            } {}
+
+            ( tset_free t )
+            ( json_free ctx )
+            ( string_free tsrc )
+        }
+    } {
+        ( nurl_eprint `template: ` ) ( nurl_eprintln ( args_error p ) )
+        ( nurl_eprintln `try 'template --help'` )
+        = rc 2
+    }
+
+    ( args_free p )
+    ( vec_free_with [String] argv \ String x → v { ( string_free x ) } )
+    ^ rc
+}

--- a/packages/template/src/template.nu
+++ b/packages/template/src/template.nu
@@ -1,0 +1,963 @@
+// template — an HTML template engine for NURL.
+//
+// Jinja-flavoured syntax rendered against a stdlib `Json` context:
+//
+//   {{ user.name }}                     output, HTML-escaped by default
+//   {{ body | raw }}                    filters: raw / upper / lower / length / json
+//   {% if admin %} … {% elif x == 'y' %} … {% else %} … {% end %}
+//   {% for item in items %} {{ loop.index }}: {{ item.title }} {% end %}
+//   {% include 'partial' %}             from a TplSet (tset_* below)
+//   {# comment #}
+//
+// Expressions are a dotted path (`user.name`, `rows.0.id`, loop vars),
+// a quoted string literal ('x' or "x"), a number, or true/false —
+// optionally combined with `==` / `!=` or prefixed with `not`. Inside a
+// `{% for %}` body, `loop.index` (0-based), `loop.first`, `loop.last`
+// and `loop.length` resolve from the innermost loop.
+//
+// Missing keys render as empty and are falsy (mustache-style lenient);
+// malformed tags are hard errors. Rendering is an interpreter over the
+// source — a `{% for %}` body is re-scanned per item, so templates
+// stay data, no AST to manage.
+//
+// Surface:
+//   ( tpl_render src ctx )              → !String String   one-shot render
+//   ( tset_new ) / ( tset_add t n s )   named-template set (enables include)
+//   ( tset_render t name ctx )          → !String String
+//   ( tpl_render_with t src ctx )       → !String String   one-shot + includes
+//   ( tset_free t )
+//
+// The error payload is an owned String: "template error at line L, col C: …".
+// Known limits (v0.1): `}}`/`%}` inside a string literal ends the tag;
+// error positions inside an included template are reported against the
+// including template's source.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/json.nu`
+
+// ── Template set (named templates, include targets) ─────────────────
+
+: TplSet {
+    ( Vec String ) names
+    ( Vec String ) srcs
+}
+
+@ tset_new → *TplSet {
+    : *TplSet t # *TplSet ( nurl_alloc Z TplSet )
+    = . t names ( vec_new [String] )
+    = . t srcs ( vec_new [String] )
+    ^ t
+}
+
+@ __tset_find * TplSet t s name → i {
+    : i n ( vec_len [String] . t names )
+    : ~ i k 0
+    : ~ i found - 0 1
+    ~ & < k n < found 0 {
+        ?? ( vec_get [String] . t names k ) {
+            T nm → { ? == ( nurl_str_eq ( string_data nm ) name ) 1 { = found k } {} }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ found
+}
+
+// Register (or replace) a named template. Copies both arguments.
+@ tset_add * TplSet t s name s tsrc → v {
+    : i idx ( __tset_find t name )
+    ? >= idx 0 {
+        ?? ( vec_get [String] . t srcs idx ) { T old → { ( string_free old ) } F _ → {} }
+        : b _r ( vec_set [String] . t srcs idx ( string_from tsrc ) )
+    } {
+        ( vec_push [String] . t names ( string_from name ) )
+        ( vec_push [String] . t srcs ( string_from tsrc ) )
+    }
+}
+
+@ tset_has * TplSet t s name → b {
+    ^ >= ( __tset_find t name ) 0
+}
+
+@ tset_free * TplSet t → v {
+    : ( @ v String ) sdrop \ String x → v { ( string_free x ) }
+    ( vec_free_with [String] . t names sdrop )
+    ( vec_free_with [String] . t srcs sdrop )
+    ( nurl_free # s t )
+}
+
+// ── Renderer state ───────────────────────────────────────────────────
+//
+// Heap-allocated so the mutually recursive block renderer can mutate
+// `pos` and the scope stack without threading state through returns
+// (same shape as ext/json.nu's JsonParser). One TplR lives per render.
+//
+// Value slots A and B hold the result of expression evaluation
+// (kind: 0 null/missing, 1 bool, 2 number, 3 string, 4 array, 5 object).
+// The Json node for kinds 4/5 rides in a 0/1-element Vec so the struct
+// needs no bare Json field; all nodes are borrows into `ctxv[0]`.
+
+: TplR {
+    s src
+    i len
+    i pos
+    i setp  // *TplSet as an integer; 0 = no set (include fails)
+    i depth  // include nesting guard
+    i tag_a  // {% elif %} expression span, handed to the if-handler
+    i tag_b
+    i e_end  // one-past-end of the last parsed primary expression
+    b failed
+    i err_pos
+    String err
+    String out
+    String key  // scratch: NUL-terminated path segment / include name
+    ( Vec Json ) ctxv  // [0] = root context (borrow)
+    ( Vec String ) sc_names  // loop-variable scope stack (owned names)
+    ( Vec Json ) sc_vals  // parallel values (borrows)
+    ( Vec i ) lp_idx  // loop frames, innermost last
+    ( Vec i ) lp_len
+    i va_kind
+    b va_bool
+    f va_num
+    b va_raw
+    String va_str
+    ( Vec Json ) va_node
+    i vb_kind
+    b vb_bool
+    f vb_num
+    String vb_str
+    ( Vec Json ) vb_node
+}
+
+@ __tpl_new s tsrc i sp Json jctx → *TplR {
+    : *TplR r # *TplR ( nurl_alloc Z TplR )
+    = . r src tsrc
+    = . r len ( nurl_str_len tsrc )
+    = . r pos 0
+    = . r setp sp
+    = . r depth 0
+    = . r tag_a 0
+    = . r tag_b 0
+    = . r e_end 0
+    = . r failed F
+    = . r err_pos 0
+    = . r err ( string_new )
+    = . r out ( string_with_cap 256 )
+    = . r key ( string_with_cap 32 )
+    = . r ctxv ( vec_new [Json] )
+    ( vec_push [Json] . r ctxv jctx )
+    = . r sc_names ( vec_new [String] )
+    = . r sc_vals ( vec_new [Json] )
+    = . r lp_idx ( vec_new [i] )
+    = . r lp_len ( vec_new [i] )
+    = . r va_kind 0
+    = . r va_bool F
+    = . r va_num 0.0
+    = . r va_raw F
+    = . r va_str ( string_with_cap 32 )
+    = . r va_node ( vec_new [Json] )
+    = . r vb_kind 0
+    = . r vb_bool F
+    = . r vb_num 0.0
+    = . r vb_str ( string_with_cap 32 )
+    = . r vb_node ( vec_new [Json] )
+    ^ r
+}
+
+@ __tpl_free * TplR r b free_out → v {
+    ( string_free . r err )
+    ( string_free . r key )
+    ( string_free . r va_str )
+    ( string_free . r vb_str )
+    ? free_out { ( string_free . r out ) } {}
+    : ( @ v String ) sdrop \ String x → v { ( string_free x ) }
+    ( vec_free_with [String] . r sc_names sdrop )
+    ( vec_free [Json] . r sc_vals )
+    ( vec_free [Json] . r ctxv )
+    ( vec_free [Json] . r va_node )
+    ( vec_free [Json] . r vb_node )
+    ( vec_free [i] . r lp_idx )
+    ( vec_free [i] . r lp_len )
+    ( nurl_free # s r )
+}
+
+// Record the first failure; later ones are ignored (the first is the cause).
+@ __tpl_fail * TplR r i fpos s msg → v {
+    ? . r failed {} {
+        = . r failed T
+        = . r err_pos fpos
+        ( string_push_str . r err msg )
+    }
+}
+
+@ __tpl_errmsg * TplR r → String {
+    : ~ i p . r err_pos
+    ? > p . r len { = p . r len } {}
+    : ~ i line 1
+    : ~ i col 1
+    : *u bp # *u . r src
+    : ~ i k 0
+    ~ < k p {
+        ? == & 255 # i . bp k 10 { = line + line 1 = col 1 } { = col + col 1 }
+        = k + k 1
+    }
+    : String m ( string_with_cap 64 )
+    ( string_push_str m `template error at line ` )
+    ( string_push_int m line )
+    ( string_push_str m `, col ` )
+    ( string_push_int m col )
+    ( string_push_str m `: ` )
+    ( string_push_str m ( string_data . r err ) )
+    ^ m
+}
+
+// ── Byte helpers ─────────────────────────────────────────────────────
+
+@ __tpl_at * TplR r i k → i {
+    ? | < k 0 >= k . r len { ^ - 0 1 } {}
+    : *u bp # *u . r src
+    ^ & 255 # i . bp k
+}
+
+@ __tpl_is_ws i c → b {
+    ^ | | | == c 32 == c 9 == c 10 == c 13
+}
+
+@ __tpl_is_identb i c → b {
+    ? & >= c 97 <= c 122 { ^ T } {}
+    ? & >= c 65 <= c 90 { ^ T } {}
+    ? & >= c 48 <= c 57 { ^ T } {}
+    ^ == c 95
+}
+
+// Path token bytes: identifier chars plus '.'
+@ __tpl_is_pathb i c → b {
+    ? ( __tpl_is_identb c ) { ^ T } {}
+    ^ == c 46
+}
+
+// Number token bytes: digits, '-', '.', exponent chars.
+@ __tpl_is_numb i c → b {
+    ? & >= c 48 <= c 57 { ^ T } {}
+    ? | | | | == c 45 == c 46 == c 43 == c 101 == c 69 { ^ T } {}
+    ^ F
+}
+
+@ __tpl_ws * TplR r i k i bnd → i {
+    : ~ i j k
+    ~ & < j bnd ( __tpl_is_ws ( __tpl_at r j ) ) { = j + j 1 }
+    ^ j
+}
+
+// First index >= from where src[j] == c1 and src[j+1] == c2; -1 if none.
+@ __tpl_find2 * TplR r i from i c1 i c2 → i {
+    : ~ i j from
+    : ~ i found - 0 1
+    ~ & < j - . r len 1 < found 0 {
+        ? & == ( __tpl_at r j ) c1 == ( __tpl_at r + j 1 ) c2 { = found j } { = j + j 1 }
+    }
+    ^ found
+}
+
+// Does span [a,b) equal the literal `lit`?
+@ __tpl_kw_is * TplR r i a i bnd s lit → b {
+    : i n ( nurl_str_len lit )
+    ? != - bnd a n { ^ F } {}
+    : *u lp # *u lit
+    : ~ i k 0
+    : ~ b same T
+    ~ & same < k n {
+        ? != ( __tpl_at r + a k ) & 255 # i . lp k { = same F } { = k + k 1 }
+    }
+    ^ same
+}
+
+// Does span [a,b) begin with the literal `lit`?
+@ __tpl_span_starts * TplR r i a i bnd s lit → b {
+    : i n ( nurl_str_len lit )
+    ? < - bnd a n { ^ F } {}
+    ^ ( __tpl_kw_is r a + a n lit )
+}
+
+// Does span [a,a+n) equal the String `nm`?
+@ __tpl_seg_eq * TplR r i a i n String nm → b {
+    ? != ( string_len nm ) n { ^ F } {}
+    : s nd ( string_data nm )
+    : *u np # *u nd
+    : ~ i k 0
+    : ~ b same T
+    ~ & same < k n {
+        ? != ( __tpl_at r + a k ) & 255 # i . np k { = same F } { = k + k 1 }
+    }
+    ^ same
+}
+
+// scratch key := src[a, a+n)
+@ __tpl_key_set * TplR r i a i n → v {
+    ( string_clear . r key )
+    : ~ i k 0
+    ~ < k n {
+        ( string_push_char . r key ( __tpl_at r + a k ) )
+        = k + k 1
+    }
+}
+
+// Parse span [a,b) as a non-negative decimal integer; -1 when not one.
+@ __tpl_span_int * TplR r i a i bnd → i {
+    ? >= a bnd { ^ - 0 1 } {}
+    : ~ i k a
+    : ~ i acc 0
+    : ~ b ok T
+    ~ & ok < k bnd {
+        : i c ( __tpl_at r k )
+        ? & >= c 48 <= c 57 { = acc + * acc 10 - c 48 = k + k 1 } { = ok F }
+    }
+    ? ok { ^ acc } { ^ - 0 1 }
+}
+
+// HTML-escape a NUL-terminated string into `out`.
+@ __tpl_push_escaped String outbuf s raw → v {
+    : i n ( nurl_str_len raw )
+    : *u bp # *u raw
+    : ~ i k 0
+    ~ < k n {
+        : i c & 255 # i . bp k
+        ? == c 38 { ( string_push_str outbuf `&amp;` ) } {
+            ? == c 60 { ( string_push_str outbuf `&lt;` ) } {
+                ? == c 62 { ( string_push_str outbuf `&gt;` ) } {
+                    ? == c 34 { ( string_push_str outbuf `&quot;` ) } {
+                        ? == c 39 { ( string_push_str outbuf `&#39;` ) } {
+                            ( string_push_char outbuf c )
+                        } } } } }
+        = k + k 1
+    }
+}
+
+// ── Path resolution ──────────────────────────────────────────────────
+//
+// Dotted path over the scope stack (innermost loop var first) and the
+// root context object. Numeric segments index into arrays. Returns a
+// BORROW into the context; F = missing anywhere along the path.
+
+@ __tpl_resolve * TplR r i pa i pb → ?Json {
+    : ~ i sp pa
+    : ~ Json cur ( json_null )
+    : ~ b have F
+    : ~ b dead F
+    : ~ b first T
+    ~ & == dead F < sp pb {
+        : ~ i se sp
+        ~ & < se pb != ( __tpl_at r se ) 46 { = se + se 1 }
+        : i slen - se sp
+        ? == slen 0 { = dead T } {
+            ? first {
+                = first F
+                : i ns ( vec_len [String] . r sc_names )
+                : ~ i si - ns 1
+                ~ & == have F >= si 0 {
+                    ?? ( vec_get [String] . r sc_names si ) {
+                        T nm → {
+                            ? ( __tpl_seg_eq r sp slen nm ) {
+                                ?? ( vec_get [Json] . r sc_vals si ) {
+                                    T jv → { = cur jv = have T }
+                                    F _ → {}
+                                }
+                            } {}
+                        }
+                        F _ → {}
+                    }
+                    = si - si 1
+                }
+                ? == have F {
+                    ?? ( vec_get [Json] . r ctxv 0 ) {
+                        T root → {
+                            ? ( json_is_obj root ) {
+                                ( __tpl_key_set r sp slen )
+                                ?? ( json_obj_get root ( string_data . r key ) ) {
+                                    T child → { = cur child = have T }
+                                    F _ → { = dead T }
+                                }
+                            } { = dead T }
+                        }
+                        F _ → { = dead T }
+                    }
+                } {}
+            } {
+                ? ( json_is_obj cur ) {
+                    ( __tpl_key_set r sp slen )
+                    ?? ( json_obj_get cur ( string_data . r key ) ) {
+                        T child → { = cur child }
+                        F _ → { = dead T }
+                    }
+                } {
+                    ? ( json_is_arr cur ) {
+                        : i idx ( __tpl_span_int r sp se )
+                        ? >= idx 0 {
+                            ?? ( json_arr_get cur idx ) {
+                                T child → { = cur child }
+                                F _ → { = dead T }
+                            }
+                        } { = dead T }
+                    } { = dead T }
+                }
+            }
+        }
+        = sp + se 1
+    }
+    ? | dead == have F { ^ @ ?Json { F } } {}
+    ^ @ ?Json { T cur }
+}
+
+// ── Expression evaluation (value slots) ──────────────────────────────
+
+@ __tpl_slot_reset * TplR r → v {
+    = . r va_kind 0
+    = . r va_bool F
+    = . r va_num 0.0
+    = . r va_raw F
+    ( string_clear . r va_str )
+    ( vec_clear [Json] . r va_node )
+}
+
+@ __tpl_slot_a_to_b * TplR r → v {
+    = . r vb_kind . r va_kind
+    = . r vb_bool . r va_bool
+    = . r vb_num . r va_num
+    ( string_clear . r vb_str )
+    ( string_push_str . r vb_str ( string_data . r va_str ) )
+    ( vec_clear [Json] . r vb_node )
+    ?? ( vec_get [Json] . r va_node 0 ) {
+        T nd → { ( vec_push [Json] . r vb_node nd ) }
+        F _ → {}
+    }
+}
+
+@ __tpl_slot_from_node * TplR r Json node → v {
+    ? ( json_is_null node ) { = . r va_kind 0 } {
+        ? ( json_is_bool node ) {
+            = . r va_kind 1
+            = . r va_bool ( json_bool_val node )
+        } {
+            ? ( json_is_num node ) {
+                = . r va_kind 2
+                ?? node { JNum nr → { ( string_push_str . r va_str ( string_data nr ) ) } _ → {} }
+                ?? ( json_num_as_f node ) { T x → { = . r va_num x } F _ → {} }
+            } {
+                ? ( json_is_str node ) {
+                    = . r va_kind 3
+                    ( string_push_str . r va_str ( json_str_data node ) )
+                } {
+                    ? ( json_is_arr node ) {
+                        = . r va_kind 4
+                        ( vec_push [Json] . r va_node node )
+                    } {
+                        = . r va_kind 5
+                        ( vec_push [Json] . r va_node node )
+                    } } } } }
+}
+
+// Evaluate one primary (path / literal / loop.*) from span [a,bnd) into
+// slot A. Sets e_end to one past the consumed token.
+@ __tpl_eval_primary * TplR r i a i bnd → v {
+    ( __tpl_slot_reset r )
+    : i k ( __tpl_ws r a bnd )
+    ? >= k bnd { ( __tpl_fail r a `empty expression` ) } {
+        : i c ( __tpl_at r k )
+        ? | == c 39 == c 34 {
+            // string literal
+            : ~ i e - 0 1
+            : ~ i j + k 1
+            ~ & < j bnd < e 0 {
+                ? == ( __tpl_at r j ) c { = e j } { = j + j 1 }
+            }
+            ? < e 0 { ( __tpl_fail r k `unterminated string literal` ) } {
+                = . r va_kind 3
+                : ~ i q + k 1
+                ~ < q e {
+                    ( string_push_char . r va_str ( __tpl_at r q ) )
+                    = q + q 1
+                }
+                = . r e_end + e 1
+            }
+        } {
+            ? | == c 45 & >= c 48 <= c 57 {
+                // number literal
+                : ~ i te k
+                ~ & < te bnd ( __tpl_is_numb ( __tpl_at r te ) ) { = te + te 1 }
+                = . r va_kind 2
+                : ~ i q2 k
+                ~ < q2 te {
+                    ( string_push_char . r va_str ( __tpl_at r q2 ) )
+                    = q2 + q2 1
+                }
+                ?? ( string_to_float . r va_str ) {
+                    T x → { = . r va_num x }
+                    F _ → { ( __tpl_fail r k `malformed number` ) }
+                }
+                = . r e_end te
+            } {
+                ? ( __tpl_is_identb c ) {
+                    : ~ i te2 k
+                    ~ & < te2 bnd ( __tpl_is_pathb ( __tpl_at r te2 ) ) { = te2 + te2 1 }
+                    = . r e_end te2
+                    ? ( __tpl_kw_is r k te2 `true` ) { = . r va_kind 1 = . r va_bool T } {
+                        ? ( __tpl_kw_is r k te2 `false` ) { = . r va_kind 1 = . r va_bool F } {
+                            ? & > ( vec_len [i] . r lp_idx ) 0 ( __tpl_span_starts r k te2 `loop.` ) {
+                                : i nf ( vec_len [i] . r lp_idx )
+                                : ~ i li 0
+                                : ~ i ln 0
+                                ?? ( vec_get [i] . r lp_idx - nf 1 ) { T x2 → { = li x2 } F _ → {} }
+                                ?? ( vec_get [i] . r lp_len - nf 1 ) { T x3 → { = ln x3 } F _ → {} }
+                                ? ( __tpl_kw_is r k te2 `loop.index` ) {
+                                    = . r va_kind 2
+                                    = . r va_num # f li
+                                    ( string_push_int . r va_str li )
+                                } {
+                                    ? ( __tpl_kw_is r k te2 `loop.first` ) {
+                                        = . r va_kind 1
+                                        = . r va_bool == li 0
+                                    } {
+                                        ? ( __tpl_kw_is r k te2 `loop.last` ) {
+                                            = . r va_kind 1
+                                            = . r va_bool == li - ln 1
+                                        } {
+                                            ? ( __tpl_kw_is r k te2 `loop.length` ) {
+                                                = . r va_kind 2
+                                                = . r va_num # f ln
+                                                ( string_push_int . r va_str ln )
+                                            } {
+                                                ( __tpl_fail r k `unknown loop attribute (index/first/last/length)` )
+                                            } } } }
+                            } {
+                                ?? ( __tpl_resolve r k te2 ) {
+                                    T node → { ( __tpl_slot_from_node r node ) }
+                                    F _ → {}
+                                }
+                            } } }
+                } {
+                    ( __tpl_fail r k `bad expression` )
+                } } }
+    }
+}
+
+@ __tpl_truthy_a * TplR r → b {
+    : i kd . r va_kind
+    ? == kd 1 { ^ . r va_bool } {}
+    ? == kd 2 { ^ != . r va_num 0.0 } {}
+    ? == kd 3 { ^ > ( string_len . r va_str ) 0 } {}
+    ? == kd 4 {
+        : ~ i n 0
+        ?? ( vec_get [Json] . r va_node 0 ) { T nd → { = n ( json_arr_len nd ) } F _ → {} }
+        ^ > n 0
+    } {}
+    ^ == kd 5
+}
+
+@ __tpl_eq_ab * TplR r → b {
+    ? != . r va_kind . r vb_kind { ^ F } {}
+    : i kd . r va_kind
+    ? == kd 0 { ^ T } {}
+    ? == kd 1 { ^ == . r va_bool . r vb_bool } {}
+    ? == kd 2 { ^ == . r va_num . r vb_num } {}
+    ? == kd 3 { ^ ( string_eq . r va_str . r vb_str ) } {}
+    ^ F
+}
+
+// Full condition: [not] primary [(==|!=) primary]
+@ __tpl_truth * TplR r i a i bnd → b {
+    : i k ( __tpl_ws r a bnd )
+    : ~ i tn k
+    ~ & < tn bnd ( __tpl_is_pathb ( __tpl_at r tn ) ) { = tn + tn 1 }
+    ? ( __tpl_kw_is r k tn `not` ) {
+        : b inner ( __tpl_truth r tn bnd )
+        ^ == inner F
+    } {}
+    ( __tpl_eval_primary r k bnd )
+    ? . r failed { ^ F } {}
+    : i k2 ( __tpl_ws r . r e_end bnd )
+    ? >= k2 bnd { ^ ( __tpl_truthy_a r ) } {}
+    : i o1 ( __tpl_at r k2 )
+    : i o2 ( __tpl_at r + k2 1 )
+    : ~ b want T
+    ? & == o1 61 == o2 61 {} {
+        ? & == o1 33 == o2 61 { = want F } {
+            ( __tpl_fail r k2 `unsupported operator (only == and !=)` )
+        }
+    }
+    ? . r failed { ^ F } {}
+    ( __tpl_slot_a_to_b r )
+    ( __tpl_eval_primary r + k2 2 bnd )
+    ? . r failed { ^ F } {}
+    : b eq ( __tpl_eq_ab r )
+    ? want { ^ eq } { ^ == eq F }
+}
+
+// ── Output tag: {{ expr | filters }} ─────────────────────────────────
+
+@ __tpl_apply_filter * TplR r i fa i fe → v {
+    ? ( __tpl_kw_is r fa fe `raw` ) { = . r va_raw T } {
+        ? ( __tpl_kw_is r fa fe `upper` ) {
+            ? | == . r va_kind 3 == . r va_kind 2 {
+                : String u ( string_to_upper . r va_str )
+                ( string_free . r va_str )
+                = . r va_str u
+            } {}
+        } {
+            ? ( __tpl_kw_is r fa fe `lower` ) {
+                ? | == . r va_kind 3 == . r va_kind 2 {
+                    : String l ( string_to_lower . r va_str )
+                    ( string_free . r va_str )
+                    = . r va_str l
+                } {}
+            } {
+                ? ( __tpl_kw_is r fa fe `length` ) {
+                    : ~ i n 0
+                    ? == . r va_kind 3 { = n ( string_len . r va_str ) } {
+                        ? == . r va_kind 4 {
+                            ?? ( vec_get [Json] . r va_node 0 ) { T nd → { = n ( json_arr_len nd ) } F _ → {} }
+                        } {}
+                    }
+                    = . r va_kind 2
+                    = . r va_num # f n
+                    ( string_clear . r va_str )
+                    ( string_push_int . r va_str n )
+                    ( vec_clear [Json] . r va_node )
+                } {
+                    ? ( __tpl_kw_is r fa fe `json` ) {
+                        ? | == . r va_kind 4 == . r va_kind 5 {
+                            ?? ( vec_get [Json] . r va_node 0 ) {
+                                T nd → {
+                                    : String js ( json_stringify nd )
+                                    ( string_clear . r va_str )
+                                    ( string_push_str . r va_str ( string_data js ) )
+                                    ( string_free js )
+                                    = . r va_kind 3
+                                    ( vec_clear [Json] . r va_node )
+                                }
+                                F _ → {}
+                            }
+                        } {}
+                    } {
+                        ( __tpl_fail r fa `unknown filter (raw/upper/lower/length/json)` )
+                    } } } } }
+}
+
+@ __tpl_emit_a * TplR r → v {
+    : i kd . r va_kind
+    ? == kd 1 {
+        ? . r va_bool { ( string_push_str . r out `true` ) } { ( string_push_str . r out `false` ) }
+    } {
+        ? == kd 2 { ( string_push_str . r out ( string_data . r va_str ) ) } {
+            ? == kd 3 {
+                ? . r va_raw { ( string_push_str . r out ( string_data . r va_str ) ) }
+                { ( __tpl_push_escaped . r out ( string_data . r va_str ) ) }
+            } {
+                ? | == kd 4 == kd 5 {
+                    ?? ( vec_get [Json] . r va_node 0 ) {
+                        T nd → {
+                            : String js ( json_stringify nd )
+                            ? . r va_raw { ( string_push_str . r out ( string_data js ) ) }
+                            { ( __tpl_push_escaped . r out ( string_data js ) ) }
+                            ( string_free js )
+                        }
+                        F _ → {}
+                    }
+                } {} } } }
+}
+
+@ __tpl_out_tag * TplR r i a i bnd → v {
+    ( __tpl_eval_primary r a bnd )
+    ? . r failed {} {
+        : ~ i k . r e_end
+        : ~ b more T
+        ~ & more == . r failed F {
+            = k ( __tpl_ws r k bnd )
+            ? & < k bnd == ( __tpl_at r k ) 124 {
+                : i fa ( __tpl_ws r + k 1 bnd )
+                : ~ i fe fa
+                ~ & < fe bnd ( __tpl_is_identb ( __tpl_at r fe ) ) { = fe + fe 1 }
+                ? == fe fa { ( __tpl_fail r k `empty filter` ) } {
+                    ( __tpl_apply_filter r fa fe )
+                    = k fe
+                }
+            } {
+                ? < k bnd { ( __tpl_fail r k `trailing characters in expression` ) } {}
+                = more F
+            }
+        }
+        ? . r failed {} { ( __tpl_emit_a r ) }
+    }
+}
+
+// ── Control tags ─────────────────────────────────────────────────────
+
+// {% if e %} … {% elif e %} … {% else %} … {% end %}
+// Skipping is rendering with emit=F, so nesting stays balanced.
+@ __tpl_do_if * TplR r i ea i eb b emit → v {
+    : ~ b cond F
+    ? emit { = cond ( __tpl_truth r ea eb ) } {}
+    : ~ b handled cond
+    : ~ i term ( __tpl_run r & emit cond )
+    ~ & == term 3 == . r failed F {
+        : i xa . r tag_a
+        : i xb . r tag_b
+        : ~ b c2 F
+        ? & emit == handled F { = c2 ( __tpl_truth r xa xb ) } {}
+        ? c2 { = handled T } {}
+        = term ( __tpl_run r & emit c2 )
+    }
+    ? & == term 2 == . r failed F {
+        = term ( __tpl_run r & emit == handled F )
+    } {}
+    ? & != term 1 == . r failed F {
+        ( __tpl_fail r . r pos `'{% if %}' without matching '{% end %}'` )
+    } {}
+}
+
+// {% for NAME in PATH %} … {% end %}
+// The body span is re-scanned once per item; the loop variable and a
+// loop frame (index/len) are pushed for the duration.
+@ __tpl_do_for * TplR r i ea i eb b emit → v {
+    ? == emit F {
+        : i t ( __tpl_run r F )
+        ? & != t 1 == . r failed F {
+            ( __tpl_fail r . r pos `'{% for %}' without matching '{% end %}'` )
+        } {}
+    } {
+        : i va ( __tpl_ws r ea eb )
+        : ~ i ve va
+        ~ & < ve eb ( __tpl_is_identb ( __tpl_at r ve ) ) { = ve + ve 1 }
+        : i k1 ( __tpl_ws r ve eb )
+        : ~ i ke k1
+        ~ & < ke eb ( __tpl_is_pathb ( __tpl_at r ke ) ) { = ke + ke 1 }
+        : ~ b ok T
+        ? == ve va { = ok F } {}
+        ? ( __tpl_kw_is r k1 ke `in` ) {} { = ok F }
+        ? == ok F {
+            ( __tpl_fail r ea `malformed '{% for %}': expected 'for NAME in PATH'` )
+        } {
+            : i pa ( __tpl_ws r ke eb )
+            : ~ i pb eb
+            ~ & > pb pa ( __tpl_is_ws ( __tpl_at r - pb 1 ) ) { = pb - pb 1 }
+            : ~ Json seq ( json_null )
+            ?? ( __tpl_resolve r pa pb ) { T node → { = seq node } F _ → {} }
+            : ~ i n 0
+            ? ( json_is_arr seq ) { = n ( json_arr_len seq ) } {
+                ? ( json_is_null seq ) {} {
+                    ( __tpl_fail r pa `'{% for %}' over a non-array value` )
+                }
+            }
+            ? . r failed {} {
+                ? == n 0 {
+                    : i t2 ( __tpl_run r F )
+                    ? & != t2 1 == . r failed F {
+                        ( __tpl_fail r . r pos `'{% for %}' without matching '{% end %}'` )
+                    } {}
+                } {
+                    : i body . r pos
+                    ( __tpl_key_set r va - ve va )
+                    ( vec_push [String] . r sc_names ( string_clone . r key ) )
+                    : Json seed ( json_null )
+                    ( vec_push [Json] . r sc_vals seed )
+                    ( vec_push [i] . r lp_idx 0 )
+                    ( vec_push [i] . r lp_len n )
+                    : i vslot - ( vec_len [Json] . r sc_vals ) 1
+                    : i lslot - ( vec_len [i] . r lp_idx ) 1
+                    : ~ i it 0
+                    ~ & < it n == . r failed F {
+                        = . r pos body
+                        ?? ( json_arr_get seq it ) {
+                            T item → { : b _s1 ( vec_set [Json] . r sc_vals vslot item ) }
+                            F _ → {}
+                        }
+                        : b _s2 ( vec_set [i] . r lp_idx lslot it )
+                        : i t3 ( __tpl_run r T )
+                        ? & != t3 1 == . r failed F {
+                            ( __tpl_fail r . r pos `'{% for %}' without matching '{% end %}'` )
+                        } {}
+                        = it + it 1
+                    }
+                    ?? ( vec_pop [String] . r sc_names ) { T nm → { ( string_free nm ) } F _ → {} }
+                    ?? ( vec_pop [Json] . r sc_vals ) { T _ → {} F _ → {} }
+                    ?? ( vec_pop [i] . r lp_idx ) { T _ → {} F _ → {} }
+                    ?? ( vec_pop [i] . r lp_len ) { T _ → {} F _ → {} }
+                }
+            }
+        }
+    }
+}
+
+// {% include 'name' %} — renders a set member in the current context and
+// scope. Only reached with emit=T (skip mode skips the tag wholesale).
+@ __tpl_do_include * TplR r i a i bnd → v {
+    : i k ( __tpl_ws r a bnd )
+    : i qc ( __tpl_at r k )
+    ? | == qc 39 == qc 34 {
+        : ~ i e - 0 1
+        : ~ i j + k 1
+        ~ & < j bnd < e 0 {
+            ? == ( __tpl_at r j ) qc { = e j } { = j + j 1 }
+        }
+        ? < e 0 { ( __tpl_fail r k `unterminated template name` ) } {
+            ? == . r setp 0 {
+                ( __tpl_fail r k `'{% include %}' needs a template set (use tset_render / tpl_render_with)` )
+            } {
+                ? >= . r depth 16 {
+                    ( __tpl_fail r k `include depth limit exceeded (cycle?)` )
+                } {
+                    ( __tpl_key_set r + k 1 - e + k 1 )
+                    : *TplSet t # *TplSet . r setp
+                    : i idx ( __tset_find t ( string_data . r key ) )
+                    ? < idx 0 { ( __tpl_fail r k `include: template not found` ) } {
+                        : ~ s isrc # s 0
+                        ?? ( vec_get [String] . t srcs idx ) {
+                            T sv → { = isrc ( string_data sv ) }
+                            F _ → {}
+                        }
+                        : s osrc . r src
+                        : i olen . r len
+                        : i opos . r pos
+                        = . r src isrc
+                        = . r len ( nurl_str_len isrc )
+                        = . r pos 0
+                        = . r depth + . r depth 1
+                        : i t2 ( __tpl_run r T )
+                        ? & != t2 0 == . r failed F {
+                            ( __tpl_fail r . r pos `unbalanced block tag in included template` )
+                        } {}
+                        = . r src osrc
+                        = . r len olen
+                        = . r pos opos
+                        = . r depth - . r depth 1
+                    }
+                }
+            }
+        }
+    } {
+        ( __tpl_fail r k `'{% include %}' expects a quoted template name` )
+    }
+}
+
+// ── Block renderer ───────────────────────────────────────────────────
+//
+// Renders (emit=T) or skips (emit=F) from `pos` until EOF or a block
+// terminator. Returns 0 = EOF, 1 = {% end %}, 2 = {% else %},
+// 3 = {% elif %} (expression span left in tag_a/tag_b).
+
+@ __tpl_run * TplR r b emit → i {
+    : ~ i term - 0 1
+    ~ & == term - 0 1 == . r failed F {
+        : i p0 . r pos
+        ? >= p0 . r len { = term 0 } {
+            : i c ( __tpl_at r p0 )
+            : i c1 ( __tpl_at r + p0 1 )
+            ? & == c 123 == c1 123 {
+                // {{ expr }}
+                : i close ( __tpl_find2 r + p0 2 125 125 )
+                ? < close 0 { ( __tpl_fail r p0 `unclosed '{{'` ) } {
+                    ? emit { ( __tpl_out_tag r + p0 2 close ) } {}
+                    = . r pos + close 2
+                }
+            } {
+                ? & == c 123 == c1 35 {
+                    // {# comment #}
+                    : i close ( __tpl_find2 r + p0 2 35 125 )
+                    ? < close 0 { ( __tpl_fail r p0 `unclosed '{#'` ) } {
+                        = . r pos + close 2
+                    }
+                } {
+                    ? & == c 123 == c1 37 {
+                        // {% tag %}
+                        : i close ( __tpl_find2 r + p0 2 37 125 )
+                        ? < close 0 { ( __tpl_fail r p0 `unclosed '{%'` ) } {
+                            : i ta ( __tpl_ws r + p0 2 close )
+                            : ~ i te ta
+                            ~ & < te close ( __tpl_is_identb ( __tpl_at r te ) ) { = te + te 1 }
+                            = . r pos + close 2
+                            ? ( __tpl_kw_is r ta te `if` ) { ( __tpl_do_if r te close emit ) } {
+                                ? ( __tpl_kw_is r ta te `for` ) { ( __tpl_do_for r te close emit ) } {
+                                    ? ( __tpl_kw_is r ta te `include` ) {
+                                        ? emit { ( __tpl_do_include r te close ) } {}
+                                    } {
+                                        ? | | ( __tpl_kw_is r ta te `end` ) ( __tpl_kw_is r ta te `endif` ) ( __tpl_kw_is r ta te `endfor` ) {
+                                            = term 1
+                                        } {
+                                            ? ( __tpl_kw_is r ta te `else` ) { = term 2 } {
+                                                ? ( __tpl_kw_is r ta te `elif` ) {
+                                                    = . r tag_a te
+                                                    = . r tag_b close
+                                                    = term 3
+                                                } {
+                                                    ( __tpl_fail r ta `unknown tag (if/elif/else/for/include/end)` )
+                                                } } } } } }
+                        }
+                    } {
+                        // plain text: emit until the next tag opener or EOF
+                        : ~ i k p0
+                        : ~ b scan T
+                        ~ & scan < k . r len {
+                            : i tc ( __tpl_at r k )
+                            ? == tc 123 {
+                                : i tn ( __tpl_at r + k 1 )
+                                ? | | == tn 123 == tn 37 == tn 35 { = scan F } { = k + k 1 }
+                            } { = k + k 1 }
+                        }
+                        ? emit {
+                            : ~ i q p0
+                            ~ < q k {
+                                ( string_push_char . r out ( __tpl_at r q ) )
+                                = q + q 1
+                            }
+                        } {}
+                        = . r pos k
+                    } } }
+        }
+    }
+    ^ term
+}
+
+// ── Entry points ─────────────────────────────────────────────────────
+
+@ __tpl_render_ptr i sp s tsrc Json jctx → !String String {
+    : *TplR r ( __tpl_new tsrc sp jctx )
+    : i term ( __tpl_run r T )
+    ? & != term 0 == . r failed F {
+        ( __tpl_fail r . r pos `'{% end %}' or '{% else %}' without an open block` )
+    } {}
+    ? . r failed {
+        : String m ( __tpl_errmsg r )
+        ( __tpl_free r T )
+        ^ @ !String String { F m }
+    } {}
+    : String rendered . r out
+    ( __tpl_free r F )
+    ^ @ !String String { T rendered }
+}
+
+// Render template source against a Json context. The error payload is
+// an owned String ("template error at line L, col C: …").
+@ tpl_render s tsrc Json jctx → !String String {
+    ^ ( __tpl_render_ptr 0 tsrc jctx )
+}
+
+// Same, with a TplSet so `{% include 'name' %}` resolves.
+@ tpl_render_with * TplSet t s tsrc Json jctx → !String String {
+    ^ ( __tpl_render_ptr # i t tsrc jctx )
+}
+
+// Render a named member of the set.
+@ tset_render * TplSet t s name Json jctx → !String String {
+    : i idx ( __tset_find t name )
+    ? < idx 0 {
+        : String m ( string_from `template not found: ` )
+        ( string_push_str m name )
+        ^ @ !String String { F m }
+    } {}
+    : ~ s tsrc # s 0
+    ?? ( vec_get [String] . t srcs idx ) {
+        T sv → { = tsrc ( string_data sv ) }
+        F _ → {}
+    }
+    ^ ( __tpl_render_ptr # i t tsrc jctx )
+}

--- a/packages/template/tests/basic.nu
+++ b/packages/template/tests/basic.nu
@@ -1,0 +1,132 @@
+// tests/basic.nu — variables, escaping, filters, literals.
+// Self-asserting: prints PASS/FAIL per case, exits non-zero on any FAIL.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/json.nu`
+$ `src/template.nu`
+
+@ check s name s tpl s cj s want → i {
+    : ~ i rc 0
+    : ~ Json ctx ( json_null )
+    : ~ b ctxok T
+    ? > ( nurl_str_len cj ) 0 {
+        ?? ( json_parse cj ) {
+            T j → { = ctx j }
+            F e → {
+                = ctxok F
+                ( nurl_print `FAIL ` ) ( nurl_print name ) ( nurl_print ` (ctx parse error)\n` )
+            }
+        }
+    } {}
+    ? ctxok {
+        ?? ( tpl_render tpl ctx ) {
+            T got → {
+                ? == ( nurl_str_eq ( string_data got ) want ) 1 {
+                    ( nurl_print `PASS ` ) ( nurl_print name ) ( nurl_print `\n` )
+                } {
+                    = rc 1
+                    ( nurl_print `FAIL ` ) ( nurl_print name )
+                    ( nurl_print `\n  want: ` ) ( nurl_print want )
+                    ( nurl_print `\n  got:  ` ) ( nurl_print ( string_data got ) )
+                    ( nurl_print `\n` )
+                }
+                ( string_free got )
+            }
+            F m → {
+                = rc 1
+                ( nurl_print `FAIL ` ) ( nurl_print name )
+                ( nurl_print ` (error: ` ) ( nurl_print ( string_data m ) ) ( nurl_print `)\n` )
+                ( string_free m )
+            }
+        }
+    } { = rc 1 }
+    ( json_free ctx )
+    ^ rc
+}
+
+// Expect a render ERROR whose message contains `frag`.
+@ check_err s name s tpl s cj s frag → i {
+    : ~ i rc 0
+    : ~ Json ctx ( json_null )
+    ? > ( nurl_str_len cj ) 0 {
+        ?? ( json_parse cj ) { T j → { = ctx j } F e → {} }
+    } {}
+    ?? ( tpl_render tpl ctx ) {
+        T got → {
+            = rc 1
+            ( nurl_print `FAIL ` ) ( nurl_print name ) ( nurl_print ` (expected error, got output: ` )
+            ( nurl_print ( string_data got ) ) ( nurl_print `)\n` )
+            ( string_free got )
+        }
+        F m → {
+            ? ( string_contains m frag ) {
+                ( nurl_print `PASS ` ) ( nurl_print name ) ( nurl_print `\n` )
+            } {
+                = rc 1
+                ( nurl_print `FAIL ` ) ( nurl_print name ) ( nurl_print ` (wrong error: ` )
+                ( nurl_print ( string_data m ) ) ( nurl_print `)\n` )
+            }
+            ( string_free m )
+        }
+    }
+    ( json_free ctx )
+    ^ rc
+}
+
+@ main → i {
+    : ~ i rc 0
+
+    // plain text passes through
+    = rc + rc ( check `plain-text` `hello world` `` `hello world` )
+
+    // simple variable + escaping
+    = rc + rc ( check `var-str` `Hi {{ name }}!` `{"name":"Ada"}` `Hi Ada!` )
+    = rc + rc ( check `var-escaped` `{{ x }}` `{"x":"<b>&'q'</b>"}` `&lt;b&gt;&amp;&#39;q&#39;&lt;/b&gt;` )
+    = rc + rc ( check `var-raw` `{{ x | raw }}` `{"x":"<b>ok</b>"}` `<b>ok</b>` )
+
+    // missing key → empty
+    = rc + rc ( check `var-missing` `[{{ nope }}]` `{"name":"Ada"}` `[]` )
+
+    // dotted path + array index
+    = rc + rc ( check `path-nested` `{{ user.name }} ({{ user.age }})` `{"user":{"name":"Bo","age":7}}` `Bo (7)` )
+    = rc + rc ( check `path-arr-idx` `{{ xs.1 }}` `{"xs":[10,20,30]}` `20` )
+
+    // numbers and booleans render plainly
+    = rc + rc ( check `num-out` `{{ n }}` `{"n":3.5}` `3.5` )
+    = rc + rc ( check `bool-out` `{{ t }}/{{ f }}` `{"t":true,"f":false}` `true/false` )
+
+    // null renders as empty
+    = rc + rc ( check `null-out` `[{{ z }}]` `{"z":null}` `[]` )
+
+    // filters
+    = rc + rc ( check `filter-upper` `{{ s | upper }}` `{"s":"abc"}` `ABC` )
+    = rc + rc ( check `filter-lower` `{{ s | lower }}` `{"s":"AbC"}` `abc` )
+    = rc + rc ( check `filter-length-str` `{{ s | length }}` `{"s":"abcd"}` `4` )
+    = rc + rc ( check `filter-length-arr` `{{ xs | length }}` `{"xs":[1,2,3]}` `3` )
+    = rc + rc ( check `filter-json` `{{ xs | json | raw }}` `{"xs":[1,2]}` `[1,2]` )
+
+    // string/number literals in output position
+    = rc + rc ( check `lit-str` `{{ 'lit<' }}` `` `lit&lt;` )
+    = rc + rc ( check `lit-num` `{{ 42 }}` `` `42` )
+
+    // comments vanish
+    = rc + rc ( check `comment` `a{# gone #}b` `` `ab` )
+
+    // literal braces that are not tag openers pass through
+    = rc + rc ( check `lone-brace` `a { b } c` `` `a { b } c` )
+
+    // objects stringify
+    = rc + rc ( check `obj-out` `{{ o | json | raw }}` `{"o":{"k":1}}` `{"k":1}` )
+
+    // errors
+    = rc + rc ( check_err `err-unclosed-out` `x {{ name` `{"name":"A"}` `unclosed '{{'` )
+    = rc + rc ( check_err `err-unknown-filter` `{{ name | nope }}` `{"name":"A"}` `unknown filter` )
+    = rc + rc ( check_err `err-bad-tag` `{% frob %}` `` `unknown tag` )
+    = rc + rc ( check_err `err-stray-end` `x {% end %}` `` `without an open block` )
+
+    ? == rc 0 { ( nurl_print `basic: all PASS\n` ) } {
+        ( nurl_print `basic: FAILURES\n` )
+    }
+    ^ rc
+}

--- a/packages/template/tests/control.nu
+++ b/packages/template/tests/control.nu
@@ -1,0 +1,138 @@
+// tests/control.nu — if/elif/else, for + loop.*, nesting, conditions.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/json.nu`
+$ `src/template.nu`
+
+@ check s name s tpl s cj s want → i {
+    : ~ i rc 0
+    : ~ Json ctx ( json_null )
+    : ~ b ctxok T
+    ? > ( nurl_str_len cj ) 0 {
+        ?? ( json_parse cj ) {
+            T j → { = ctx j }
+            F e → {
+                = ctxok F
+                ( nurl_print `FAIL ` ) ( nurl_print name ) ( nurl_print ` (ctx parse error)\n` )
+            }
+        }
+    } {}
+    ? ctxok {
+        ?? ( tpl_render tpl ctx ) {
+            T got → {
+                ? == ( nurl_str_eq ( string_data got ) want ) 1 {
+                    ( nurl_print `PASS ` ) ( nurl_print name ) ( nurl_print `\n` )
+                } {
+                    = rc 1
+                    ( nurl_print `FAIL ` ) ( nurl_print name )
+                    ( nurl_print `\n  want: ` ) ( nurl_print want )
+                    ( nurl_print `\n  got:  ` ) ( nurl_print ( string_data got ) )
+                    ( nurl_print `\n` )
+                }
+                ( string_free got )
+            }
+            F m → {
+                = rc 1
+                ( nurl_print `FAIL ` ) ( nurl_print name )
+                ( nurl_print ` (error: ` ) ( nurl_print ( string_data m ) ) ( nurl_print `)\n` )
+                ( string_free m )
+            }
+        }
+    } { = rc 1 }
+    ( json_free ctx )
+    ^ rc
+}
+
+@ check_err s name s tpl s cj s frag → i {
+    : ~ i rc 0
+    : ~ Json ctx ( json_null )
+    ? > ( nurl_str_len cj ) 0 {
+        ?? ( json_parse cj ) { T j → { = ctx j } F e → {} }
+    } {}
+    ?? ( tpl_render tpl ctx ) {
+        T got → {
+            = rc 1
+            ( nurl_print `FAIL ` ) ( nurl_print name ) ( nurl_print ` (expected error)\n` )
+            ( string_free got )
+        }
+        F m → {
+            ? ( string_contains m frag ) {
+                ( nurl_print `PASS ` ) ( nurl_print name ) ( nurl_print `\n` )
+            } {
+                = rc 1
+                ( nurl_print `FAIL ` ) ( nurl_print name ) ( nurl_print ` (wrong error: ` )
+                ( nurl_print ( string_data m ) ) ( nurl_print `)\n` )
+            }
+            ( string_free m )
+        }
+    }
+    ( json_free ctx )
+    ^ rc
+}
+
+@ main → i {
+    : ~ i rc 0
+
+    // if / else on truthiness
+    = rc + rc ( check `if-true` `{% if on %}Y{% end %}` `{"on":true}` `Y` )
+    = rc + rc ( check `if-false` `{% if on %}Y{% end %}` `{"on":false}` `` )
+    = rc + rc ( check `if-else` `{% if on %}Y{% else %}N{% end %}` `{"on":false}` `N` )
+    = rc + rc ( check `if-missing-falsy` `{% if nope %}Y{% else %}N{% end %}` `{"a":1}` `N` )
+    = rc + rc ( check `if-empty-str` `{% if s %}Y{% else %}N{% end %}` `{"s":""}` `N` )
+    = rc + rc ( check `if-empty-arr` `{% if xs %}Y{% else %}N{% end %}` `{"xs":[]}` `N` )
+    = rc + rc ( check `if-nonzero` `{% if n %}Y{% else %}N{% end %}` `{"n":2}` `Y` )
+    = rc + rc ( check `if-zero` `{% if n %}Y{% else %}N{% end %}` `{"n":0}` `N` )
+
+    // not / == / !=
+    = rc + rc ( check `if-not` `{% if not on %}N{% end %}` `{"on":false}` `N` )
+    = rc + rc ( check `if-eq-str` `{% if role == 'admin' %}A{% else %}U{% end %}` `{"role":"admin"}` `A` )
+    = rc + rc ( check `if-neq-str` `{% if role != 'admin' %}U{% else %}A{% end %}` `{"role":"guest"}` `U` )
+    = rc + rc ( check `if-eq-num` `{% if n == 3 %}three{% end %}` `{"n":3}` `three` )
+    = rc + rc ( check `if-eq-paths` `{% if a == b %}same{% else %}diff{% end %}` `{"a":"x","b":"x"}` `same` )
+    = rc + rc ( check `if-eq-bool-lit` `{% if on == true %}Y{% end %}` `{"on":true}` `Y` )
+    = rc + rc ( check `if-eq-kind-mismatch` `{% if a == b %}same{% else %}diff{% end %}` `{"a":"1","b":1}` `diff` )
+
+    // elif chain
+    = rc + rc ( check `elif-first` `{% if n == 1 %}a{% elif n == 2 %}b{% else %}c{% end %}` `{"n":1}` `a` )
+    = rc + rc ( check `elif-mid` `{% if n == 1 %}a{% elif n == 2 %}b{% else %}c{% end %}` `{"n":2}` `b` )
+    = rc + rc ( check `elif-else` `{% if n == 1 %}a{% elif n == 2 %}b{% else %}c{% end %}` `{"n":9}` `c` )
+
+    // endif/endfor aliases
+    = rc + rc ( check `endif-alias` `{% if on %}Y{% endif %}` `{"on":true}` `Y` )
+
+    // for over arrays
+    = rc + rc ( check `for-basic` `{% for x in xs %}{{ x }},{% end %}` `{"xs":[1,2,3]}` `1,2,3,` )
+    = rc + rc ( check `for-objs` `{% for u in users %}{{ u.name }};{% end %}` `{"users":[{"name":"A"},{"name":"B"}]}` `A;B;` )
+    = rc + rc ( check `for-empty` `[{% for x in xs %}{{ x }}{% end %}]` `{"xs":[]}` `[]` )
+    = rc + rc ( check `for-missing` `[{% for x in nope %}{{ x }}{% end %}]` `{"a":1}` `[]` )
+    = rc + rc ( check `endfor-alias` `{% for x in xs %}{{ x }}{% endfor %}` `{"xs":[7]}` `7` )
+
+    // loop.* attributes
+    = rc + rc ( check `loop-index` `{% for x in xs %}{{ loop.index }}:{{ x }} {% end %}` `{"xs":["a","b"]}` `0:a 1:b ` )
+    = rc + rc ( check `loop-first-last` `{% for x in xs %}{% if loop.first %}[{% end %}{{ x }}{% if loop.last %}]{% else %},{% end %}{% end %}` `{"xs":[1,2,3]}` `[1,2,3]` )
+    = rc + rc ( check `loop-length` `{% for x in xs %}{{ loop.length }}{% end %}` `{"xs":[5,6]}` `22` )
+
+    // nested for + inner loop shadows loop.*
+    = rc + rc ( check `for-nested` `{% for row in grid %}{% for c in row %}{{ c }}{% end %};{% end %}` `{"grid":[[1,2],[3,4]]}` `12;34;` )
+    = rc + rc ( check `for-nested-loopvar` `{% for row in grid %}{% for c in row %}{{ loop.index }}{% end %}|{% end %}` `{"grid":[[9,9],[9]]}` `01|0|` )
+
+    // loop var shadows a context key
+    = rc + rc ( check `loopvar-shadows-ctx` `{% for x in xs %}{{ x }}{% end %}{{ x }}` `{"xs":[1],"x":"ctx"}` `1ctx` )
+
+    // if nested in for, for nested in if
+    = rc + rc ( check `if-in-for` `{% for x in xs %}{% if x == 2 %}<{{ x }}>{% else %}{{ x }}{% end %}{% end %}` `{"xs":[1,2,3]}` `1<2>3` )
+    = rc + rc ( check `for-in-if-skipped` `{% if off %}{% for x in xs %}{{ x }}{% end %}{% else %}skipped{% end %}` `{"off":false,"xs":[1,2]}` `skipped` )
+
+    // errors
+    = rc + rc ( check_err `err-unclosed-if` `{% if on %}Y` `{"on":true}` `without matching` )
+    = rc + rc ( check_err `err-unclosed-for` `{% for x in xs %}{{ x }}` `{"xs":[1]}` `without matching` )
+    = rc + rc ( check_err `err-for-nonarray` `{% for x in s %}{{ x }}{% end %}` `{"s":"str"}` `non-array` )
+    = rc + rc ( check_err `err-for-malformed` `{% for %}x{% end %}` `` `malformed` )
+    = rc + rc ( check_err `err-bad-op` `{% if a < b %}x{% end %}` `{"a":1,"b":2}` `unsupported operator` )
+
+    ? == rc 0 { ( nurl_print `control: all PASS\n` ) } {
+        ( nurl_print `control: FAILURES\n` )
+    }
+    ^ rc
+}

--- a/packages/template/tests/includes.nu
+++ b/packages/template/tests/includes.nu
@@ -1,0 +1,137 @@
+// tests/includes.nu — TplSet, {% include %}, tset_render, tset_load_dir.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/json.nu`
+$ `src/template.nu`
+$ `src/loader.nu`
+
+@ report s name b good → i {
+    ? good {
+        ( nurl_print `PASS ` ) ( nurl_print name ) ( nurl_print `\n` )
+        ^ 0
+    } {
+        ( nurl_print `FAIL ` ) ( nurl_print name ) ( nurl_print `\n` )
+        ^ 1
+    }
+}
+
+@ render_eq * TplSet t s name s cj s want → b {
+    : ~ Json ctx ( json_null )
+    ? > ( nurl_str_len cj ) 0 {
+        ?? ( json_parse cj ) { T j → { = ctx j } F e → {} }
+    } {}
+    : ~ b good F
+    ?? ( tset_render t name ctx ) {
+        T got → {
+            ? == ( nurl_str_eq ( string_data got ) want ) 1 { = good T } {
+                ( nurl_print `  got:  ` ) ( nurl_print ( string_data got ) ) ( nurl_print `\n` )
+                ( nurl_print `  want: ` ) ( nurl_print want ) ( nurl_print `\n` )
+            }
+            ( string_free got )
+        }
+        F m → {
+            ( nurl_print `  error: ` ) ( nurl_print ( string_data m ) ) ( nurl_print `\n` )
+            ( string_free m )
+        }
+    }
+    ( json_free ctx )
+    ^ good
+}
+
+@ main → i {
+    : ~ i rc 0
+    : *TplSet t ( tset_new )
+
+    ( tset_add t `head` `<h1>{{ title }}</h1>` )
+    ( tset_add t `page` `{% include 'head' %}<p>{{ body }}</p>` )
+    ( tset_add t `item` `[{{ x }}]` )
+    ( tset_add t `list` `{% for x in xs %}{% include 'item' %}{% end %}` )
+    ( tset_add t `cyc_a` `{% include 'cyc_b' %}` )
+    ( tset_add t `cyc_b` `{% include 'cyc_a' %}` )
+
+    // tset_has / replace
+    = rc + rc ( report `tset-has` ( tset_has t `head` ) )
+    = rc + rc ( report `tset-has-not` == ( tset_has t `nope` ) F )
+    ( tset_add t `head` `<h2>{{ title }}</h2>` )
+    = rc + rc ( report `tset-replace`
+    ( render_eq t `head` `{"title":"T"}` `<h2>T</h2>` ) )
+
+    // include inherits context
+    = rc + rc ( report `include-ctx`
+    ( render_eq t `page` `{"title":"Hi","body":"b"}` `<h2>Hi</h2><p>b</p>` ) )
+
+    // include inside a for sees the loop variable
+    = rc + rc ( report `include-loopvar`
+    ( render_eq t `list` `{"xs":[1,2]}` `[1][2]` ) )
+
+    // include cycle is caught, not a stack overflow
+    : ~ b cyc_caught F
+    : Json e0 ( json_null )
+    ?? ( tset_render t `cyc_a` e0 ) {
+        T got → { ( string_free got ) }
+        F m → {
+            ? ( string_contains m `depth` ) { = cyc_caught T } {}
+            ( string_free m )
+        }
+    }
+    = rc + rc ( report `include-cycle` cyc_caught )
+
+    // missing template name
+    : ~ b miss_caught F
+    : Json e1 ( json_null )
+    ?? ( tset_render t `ghost` e1 ) {
+        T got → { ( string_free got ) }
+        F m → {
+            ? ( string_contains m `not found` ) { = miss_caught T } {}
+            ( string_free m )
+        }
+    }
+    = rc + rc ( report `tset-missing` miss_caught )
+
+    // include without a set fails cleanly
+    : ~ b noset_caught F
+    : Json e2 ( json_null )
+    ?? ( tpl_render `{% include 'head' %}` e2 ) {
+        T got → { ( string_free got ) }
+        F m → {
+            ? ( string_contains m `template set` ) { = noset_caught T } {}
+            ( string_free m )
+        }
+    }
+    = rc + rc ( report `include-no-set` noset_caught )
+
+    // tpl_render_with: one-shot source resolving includes from the set
+    : ~ b withok F
+    : ~ Json c3 ( json_null )
+    ?? ( json_parse `{"title":"W"}` ) { T j → { = c3 j } F e → {} }
+    ?? ( tpl_render_with t `pre {% include 'head' %} post` c3 ) {
+        T got → {
+            ? == ( nurl_str_eq ( string_data got ) `pre <h2>W</h2> post` ) 1 { = withok T } {}
+            ( string_free got )
+        }
+        F m → { ( string_free m ) }
+    }
+    ( json_free c3 )
+    = rc + rc ( report `render-with` withok )
+
+    ( tset_free t )
+
+    // tset_load_dir over a scratch directory
+    : s tdir `/tmp/nurl_tpl_loader_test`
+    ?? ( dir_create_all tdir ) { T _ → {} F _ → {} }
+    ?? ( write_file `/tmp/nurl_tpl_loader_test/hello.html` `Hello {{ who }}` ) { T _ → {} F _ → {} }
+    ?? ( write_file `/tmp/nurl_tpl_loader_test/bye.html` `Bye {{ who }}` ) { T _ → {} F _ → {} }
+    : *TplSet t2 ( tset_new )
+    : i nl ( tset_load_dir t2 tdir `.html` )
+    = rc + rc ( report `load-dir-count` == nl 2 )
+    = rc + rc ( report `load-dir-render`
+    ( render_eq t2 `hello` `{"who":"you"}` `Hello you` ) )
+    ( tset_free t2 )
+
+    ? == rc 0 { ( nurl_print `includes: all PASS\n` ) } {
+        ( nurl_print `includes: FAILURES\n` )
+    }
+    ^ rc
+}


### PR DESCRIPTION
## What

A new registry package: `template` — a Jinja-flavoured HTML template engine rendered against a stdlib `Json` context. Fills the main gap between the `http` package (server facade) and real server-rendered apps, and pairs with `md2html` for static generation.

## Syntax

- `{{ expr }}` output, HTML-escaped by default; filters `raw` / `upper` / `lower` / `length` / `json`
- `{% if e %} … {% elif e %} … {% else %} … {% end %}` (`endif`/`endfor` accepted)
- `{% for x in path %}` over JSON arrays with `loop.index` / `first` / `last` / `length`; loop vars shadow context keys, inner loops shadow outer
- `{% include 'name' %}` from a named `TplSet` (+ `tset_load_dir` for `views/*.html`)
- Expressions: dotted paths (numeric segments index arrays), string/number/bool literals, `==` / `!=` / `not`

Semantics: missing keys render empty and are falsy (mustache-lenient); malformed tags are hard errors with line/col. Equality compares like kinds only.

## Design

- Interpreter over the source — a `{% for %}` body is re-scanned per item, skip = render with emit=F, so there is no AST to own and block nesting stays balanced by construction (same heap-parser shape as `ext/json.nu`'s JsonParser).
- All context access is borrows into the caller-owned `Json`; result/error payloads are owned Strings.
- Engine (`src/template.nu`) has no fs dependency; the directory loader and CLI live in separate files.
- Include cycles cut at depth 16.

## Tests

Three self-asserting `nurlpkg test` suites — 72 cases: variables/escaping/filters/literals + error paths, if/elif/else + for + `loop.*` + nesting + conditions, sets/include/cycles/loader. `nurlpkg test`: PASS 3 · FAIL 0, and all three suites are clean under `NURL_SAN=1` (ASan/LSan, exit 0). CLI smoke-tested end to end (file/stdin, ctx file, partials dir, error paths).

Known v0.1 limits (documented): `}}`/`%}` inside a string literal ends the tag early; include-error positions are reported against the including source.

## Follow-ups (not this PR)

- Publish to reg.nurl-lang.org after merge
- `http` 0.2.0: `response_render` sugar + signed-cookie sessions
- Longer term: re-host the registry on the NURL http stack using this (critic C8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7