### PR TITLE
yoloe-demo: free-text prompting — type anything, detect it live

### DIFF
--- a/packages/onnx/src/model.nu
+++ b/packages/onnx/src/model.nu
@@ -157,6 +157,7 @@ $ `pb.nu`
     : ~ i dtype 0
     : ~ i raw_start - 0 1
     : ~ i raw_len 0
+    : ( Vec i ) i64vals ( vec_new [i] )
     ~ ( pb_more r ) {
         : i tag ( pb_tag r )
         : i fld ( pb_field tag )
@@ -178,6 +179,13 @@ $ `pb.nu`
                 ( pb_set_pos r + ( pb_pos r ) len )
             } { ( pb_skip r wt ) }
         }
+        ? == fld 7 {  // int64_data (packed varints — onnxsim writes these)
+            ? == wt 2 {
+                : *PbR ds ( pb_submsg r )
+                ~ ( pb_more ds ) { ( vec_push [i] i64vals ( pb_varint ds ) ) }
+                ( pb_free ds )
+            } { ( vec_push [i] i64vals ( pb_varint r ) ) }
+        }
         ? == fld 9 {  // raw_data (LE f32 bytes)
             : i len ( pb_varint r )
             = raw_start ( pb_pos r )
@@ -188,6 +196,19 @@ $ `pb.nu`
     }
     : i nelem ( __nelem dims )
     : ~ i host 0
+    // int64_data field (no raw block): materialise the varints as the
+    // same 8-byte LE host block the raw path produces.
+    ? & & < raw_start 0 > ( vec_len [i] i64vals ) 0 == dtype 7 {
+        : i nv ( vec_len [i] i64vals )
+        : *u h64 ( nurl_alloc * nv 8 )
+        : ~ i q 0
+        ~ < q nv {
+            ( nurl_poke h64 q ?? ( vec_get [i] i64vals q ) { T x → x F _ → 0 } )
+            = q + q 1
+        }
+        = host # i h64
+    } {}
+    ( vec_free [i] i64vals )
     ? & >= raw_start 0 > raw_len 0 {
         ? == dtype 7 {  // INT64: 8-byte LE values
             : *u h ( nurl_alloc * nelem 8 )

--- a/packages/onnx/src/ops.nu
+++ b/packages/onnx/src/ops.nu
@@ -14,14 +14,14 @@ $ `deps/gpu/src/gpu.nu`
 
 // Compiled kernels, built once and reused across nodes.
 : Kernels {
-    GpuKernel gemm   GpuKernel relu
-    GpuKernel conv   GpuKernel pool
-    GpuKernel bn     GpuKernel lrelu  GpuKernel elt
-    GpuKernel sig    GpuKernel resize GpuKernel perm
-    GpuKernel softm  GpuKernel cpyax
-    GpuKernel rl2    GpuKernel clip   GpuKernel expand  GpuKernel slice
-    GpuKernel lnorm  GpuKernel erf    GpuKernel gather  GpuKernel bmm  GpuKernel amax
-    GpuKernel eos    GpuKernel convt
+    GpuKernel gemm GpuKernel relu
+    GpuKernel conv GpuKernel pool
+    GpuKernel bn GpuKernel lrelu GpuKernel elt
+    GpuKernel sig GpuKernel resize GpuKernel perm
+    GpuKernel softm GpuKernel cpyax
+    GpuKernel rl2 GpuKernel clip GpuKernel expand GpuKernel slice
+    GpuKernel lnorm GpuKernel erf GpuKernel gather GpuKernel bmm GpuKernel amax GpuKernel amax64
+    GpuKernel eos GpuKernel convt
     b ok
 }
 
@@ -279,6 +279,7 @@ $ `deps/gpu/src/gpu.nu`
         for (int j=0;j<ax;j++) q[j] = (p[j]-m)*inv*sc[j] + bi[j];
     }`
 }
+
 @ __k_erf → s {
     ^ `extern "C" __global__ void erfk(const float* X, float* Y, int n) {
         int i = blockIdx.x*blockDim.x + threadIdx.x;
@@ -326,6 +327,19 @@ $ `deps/gpu/src/gpu.nu`
 // CLIP EOS read-out: given per-row sequences `tok` [B,L] (int64) and the
 // transformer output `data` [B,L,D], select each row's EOS token (the
 // argmax token id) features → Y [B,D]. One thread per output element.
+// Same, over int64 input (CLIP token ids: the EOT position is the row's
+// max id). Output int64 indices, one per outer row.
+@ __k_amax_i64 → s {
+    ^ `extern "C" __global__ void argmaxk_i64(const long long* X, long long* Y, int outer, int ax) {
+        int o = blockIdx.x*blockDim.x + threadIdx.x;
+        if (o >= outer) return;
+        const long long* p = X + o*ax;
+        int bi = 0; long long bv = p[0];
+        for (int j=1;j<ax;j++){ if (p[j]>bv){ bv=p[j]; bi=j; } }
+        Y[o] = bi;
+    }`
+}
+
 @ __k_eosgather → s {
     ^ `extern "C" __global__ void eos_gather(const float* data, const long long* tok,
         float* Y, int B, int L, int D) {
@@ -387,15 +401,16 @@ $ `deps/gpu/src/gpu.nu`
     : GpuKernel kga ( gpu_compile g ( __k_gather ) `gather` )
     : GpuKernel kbm ( gpu_compile g ( __k_bmm ) `bmm` )
     : GpuKernel kam ( gpu_compile g ( __k_amax ) `argmaxk` )
+    : GpuKernel ka6 ( gpu_compile g ( __k_amax_i64 ) `argmaxk_i64` )
     : GpuKernel keo ( gpu_compile g ( __k_eosgather ) `eos_gather` )
     : GpuKernel kct ( gpu_compile g ( __k_convt ) `convtranspose2d` )
     : b ok1 & & & ( gpu_kernel_ok kg ) ( gpu_kernel_ok kr ) & ( gpu_kernel_ok kc ) ( gpu_kernel_ok kp )
-            & & ( gpu_kernel_ok kb ) ( gpu_kernel_ok kl ) ( gpu_kernel_ok ke )
+    & & ( gpu_kernel_ok kb ) ( gpu_kernel_ok kl ) ( gpu_kernel_ok ke )
     : b ok2 & & ( gpu_kernel_ok ksg ) ( gpu_kernel_ok krz )
-            & & ( gpu_kernel_ok kpm ) ( gpu_kernel_ok ksm ) ( gpu_kernel_ok kcp )
+    & & ( gpu_kernel_ok kpm ) ( gpu_kernel_ok ksm ) ( gpu_kernel_ok kcp )
     : b ok3 & & & ( gpu_kernel_ok krl ) ( gpu_kernel_ok kcl ) ( gpu_kernel_ok kex ) ( gpu_kernel_ok ksl )
-    : b ok4 & & & & & & ( gpu_kernel_ok kln ) ( gpu_kernel_ok ker ) ( gpu_kernel_ok kga ) ( gpu_kernel_ok kbm ) ( gpu_kernel_ok kam ) ( gpu_kernel_ok keo ) ( gpu_kernel_ok kct )
-    ^ @ Kernels { kg kr kc kp kb kl ke ksg krz kpm ksm kcp krl kcl kex ksl kln ker kga kbm kam keo kct & & & ok1 ok2 ok3 ok4 }
+    : b ok4 & & & & & & & ( gpu_kernel_ok kln ) ( gpu_kernel_ok ker ) ( gpu_kernel_ok kga ) ( gpu_kernel_ok kbm ) ( gpu_kernel_ok kam ) ( gpu_kernel_ok ka6 ) ( gpu_kernel_ok keo ) ( gpu_kernel_ok kct )
+    ^ @ Kernels { kg kr kc kp kb kl ke ksg krz kpm ksm kcp krl kcl kex ksl kln ker kga kbm kam ka6 keo kct & & & ok1 ok2 ok3 ok4 }
 }
 
 @ ops_free Kernels ks → v {
@@ -427,12 +442,14 @@ $ `deps/gpu/src/gpu.nu`
     ( gpu_launch . ks lnorm ( gpu_grid outer 256 ) 256 a )
     ( vec_free [i] a ) ^ yd
 }
+
 @ op_erf Gpu g Kernels ks i xd i yd i n → i {
     : ( Vec i ) a ( vec_new [i] )
     ( vec_push [i] a ( gpu_arg_i64 xd ) ) ( vec_push [i] a ( gpu_arg_i64 yd ) ) ( vec_push [i] a ( gpu_arg_i32 n ) )
     ( gpu_launch . ks erf ( gpu_grid n 256 ) 256 a )
     ( vec_free [i] a ) ^ yd
 }
+
 @ op_gather Gpu g Kernels ks i dd i idd i yd i outer i axis_in i inner i nidx → i {
     : ( Vec i ) a ( vec_new [i] )
     ( vec_push [i] a ( gpu_arg_i64 dd ) ) ( vec_push [i] a ( gpu_arg_i64 idd ) ) ( vec_push [i] a ( gpu_arg_i64 yd ) )
@@ -441,6 +458,7 @@ $ `deps/gpu/src/gpu.nu`
     ( gpu_launch . ks gather ( gpu_grid total 256 ) 256 a )
     ( vec_free [i] a ) ^ yd
 }
+
 @ op_bmm Gpu g Kernels ks i ad i bd i yd i batch i M i N i K → i {
     : ( Vec i ) a ( vec_new [i] )
     ( vec_push [i] a ( gpu_arg_i64 ad ) ) ( vec_push [i] a ( gpu_arg_i64 bd ) ) ( vec_push [i] a ( gpu_arg_i64 yd ) )
@@ -449,11 +467,20 @@ $ `deps/gpu/src/gpu.nu`
     ( gpu_launch . ks bmm ( gpu_grid total 256 ) 256 a )
     ( vec_free [i] a ) ^ yd
 }
+
 @ op_argmax Gpu g Kernels ks i xd i yd i outer i ax → i {
     : ( Vec i ) a ( vec_new [i] )
     ( vec_push [i] a ( gpu_arg_i64 xd ) ) ( vec_push [i] a ( gpu_arg_i64 yd ) )
     ( vec_push [i] a ( gpu_arg_i32 outer ) ) ( vec_push [i] a ( gpu_arg_i32 ax ) )
     ( gpu_launch . ks amax ( gpu_grid outer 256 ) 256 a )
+    ( vec_free [i] a ) ^ yd
+}
+
+@ op_argmax_i64 Gpu g Kernels ks i xd i yd i outer i ax → i {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 xd ) ) ( vec_push [i] a ( gpu_arg_i64 yd ) )
+    ( vec_push [i] a ( gpu_arg_i32 outer ) ) ( vec_push [i] a ( gpu_arg_i32 ax ) )
+    ( gpu_launch . ks amax64 ( gpu_grid outer 256 ) 256 a )
     ( vec_free [i] a ) ^ yd
 }
 
@@ -474,6 +501,7 @@ $ `deps/gpu/src/gpu.nu`
     ( gpu_launch . ks rl2 ( gpu_grid outer 256 ) 256 a )
     ( vec_free [i] a ) ^ yd
 }
+
 @ op_clip Gpu g Kernels ks i xd i yd i n f lo f hi → i {
     : ( Vec i ) a ( vec_new [i] )
     ( vec_push [i] a ( gpu_arg_i64 xd ) ) ( vec_push [i] a ( gpu_arg_i64 yd ) ) ( vec_push [i] a ( gpu_arg_i32 n ) )
@@ -481,6 +509,7 @@ $ `deps/gpu/src/gpu.nu`
     ( gpu_launch . ks clip ( gpu_grid n 256 ) 256 a )
     ( vec_free [i] a ) ^ yd
 }
+
 @ op_expand Gpu g Kernels ks i xd i yd i outer i rep → i {
     : ( Vec i ) a ( vec_new [i] )
     ( vec_push [i] a ( gpu_arg_i64 xd ) ) ( vec_push [i] a ( gpu_arg_i64 yd ) )

--- a/packages/onnx/src/runtime.nu
+++ b/packages/onnx/src/runtime.nu
@@ -395,6 +395,50 @@ $ `ops.nu`
 
 // Resize (nearest, integer upscale). Scales come from the FLOAT init
 // input[2] = [1,1,sh,sw].
+// Slice along ONE axis, unit step, bounds from int64 initializers
+// (inputs: data, starts, ends, axes[, steps]) — the shape torch 2.12 /
+// onnxsim emit for channel splits (older exports used Split, which has
+// its own handler). Negative axes normalise; ends clamp to the dim.
+@ rt_slice * Engine e ONode n → v {
+    : RTensor X ( __in e n 0 )
+    : i nd0 ( rt_ndim X )
+    : s st_name ( string_data ?? ( vec_get [String] . n inputs 1 ) { T x → x F _ → ( string_new ) } )
+    : s en_name ( string_data ?? ( vec_get [String] . n inputs 2 ) { T x → x F _ → ( string_new ) } )
+    : ~ i axis 1
+    ? > ( vec_len [String] . n inputs ) 3 {
+        : s ax_name ( string_data ?? ( vec_get [String] . n inputs 3 ) { T x → x F _ → ( string_new ) } )
+        = axis ( __init_i64 e ax_name 0 )
+    } {}
+    ? < axis 0 { = axis + axis nd0 } {}
+    : ~ i step 1
+    ? > ( vec_len [String] . n inputs ) 4 {
+        : s sp_name ( string_data ?? ( vec_get [String] . n inputs 4 ) { T x → x F _ → ( string_new ) } )
+        = step ( __init_i64 e sp_name 0 )
+    } {}
+    ? | != step 1 > ( __init_i64_len e st_name ) 1 {
+        ( nurl_eprint `[onnx] Slice: only single-axis unit-step supported\n` )
+    } {
+        : i dim_ax ( rt_dim X axis )
+        : ~ i sbeg ( __init_i64 e st_name 0 )
+        : ~ i send ( __init_i64 e en_name 0 )
+        ? < sbeg 0 { = sbeg + sbeg dim_ax } {}
+        ? < send 0 { = send + send dim_ax } {}
+        ? > send dim_ax { = send dim_ax } {}
+        : i sz - send sbeg
+        : ~ i outer 1
+        : ~ i j 0
+        ~ < j axis { = outer * outer ( rt_dim X j ) = j + j 1 }
+        : ~ i inner 1
+        : ~ i m + axis 1
+        ~ < m nd0 { = inner * inner ( rt_dim X m ) = m + m 1 }
+        : ( Vec i ) os ( vec_new [i] )
+        : ~ i d 0
+        ~ < d nd0 { ( vec_push [i] os ? == d axis sz ( rt_dim X d ) ) = d + d 1 }
+        : i yd ( rt_alloc_out e ( __out_name n ) os )
+        : i _r ( op_slice_ax . e g . e ks . X dptr yd outer sz inner dim_ax sbeg )
+    }
+}
+
 @ rt_resize * Engine e ONode n → v {
     : RTensor X ( __in e n 0 )
     : s sc_name ( string_data ?? ( vec_get [String] . n inputs 2 ) { T x → x F _ → ( string_new ) } )
@@ -456,8 +500,11 @@ $ `ops.nu`
 
 // Concat along `axis`, viewing each input as (outer, axis_i, inner).
 @ rt_concat * Engine e ONode n → v {
-    : i axis ( node_attr_i n `axis` 1 )
     : RTensor first ( __in e n 0 )
+    // negative axis counts from the end (same normalisation softmax
+    // needed — torch 2.12 emits Concat axis=-1 for the level merge)
+    : ~ i axis ( node_attr_i n `axis` 1 )
+    ? < axis 0 { = axis + axis ( rt_ndim first ) } {}
     : ~ i outer 1
     : ~ i j 0
     ~ < j axis { = outer * outer ( rt_dim first j ) = j + j 1 }
@@ -591,9 +638,45 @@ $ `ops.nu`
 // Gather along `axis`. Two index sources: a device tensor (e.g. the token
 // matrix → embedding lookup) gathers nidx rows; a host scalar initializer
 // (e.g. the QKV split index) selects one slice and drops the axis.
+// ArgMax along the last axis. The output is int64 (allocated at 8
+// bytes/elem — rt_alloc_out's 4-byte default would let the kernel write
+// past the buffer). Dispatches to the int64 kernel when the input is the
+// graph's raw token input (the only 8-byte tensor in play; everything
+// else on the value map is f32). Used by the CLIP text encoder's EOT
+// read-out (ArgMax over token ids → Gather), which onnxsim leaves as a
+// plain ArgMax+Gather pair — the eos_gather fast path only matches the
+// old GatherND formulation.
+@ rt_argmax * Engine e ONode n → v {
+    : RTensor x ( __in e n 0 )
+    : i nd0 ( rt_ndim x )
+    : ~ i axis ( node_attr_i n `axis` 0 )
+    ? < axis 0 { = axis + axis nd0 } {}
+    ? != axis - nd0 1 { ( nurl_eprint `[onnx] ArgMax: only last-axis supported\n` ) } {
+        : i ax ( rt_dim x axis )
+        : ~ i outer 1
+        : ~ i j 0
+        ~ < j axis { = outer * outer ( rt_dim x j ) = j + j 1 }
+        : i keep ( node_attr_i n `keepdims` 1 )
+        : ( Vec i ) os ( vec_new [i] )
+        : ~ i d 0
+        ~ < d axis { ( vec_push [i] os ( rt_dim x d ) ) = d + d 1 }
+        ? != keep 0 { ( vec_push [i] os 1 ) } {}
+        : GpuBuffer buf ( gpu_alloc . e g * ( __prod os ) 8 )
+        ( rt_own e . buf dptr )
+        ( rt_put e ( __out_name n ) . buf dptr os )
+        : s in0 ( string_data ?? ( vec_get [String] . n inputs 0 ) { T x2 → x2 F _ → ( string_new ) } )
+        ? ( streq2 in0 ( string_data . . e graph input_name ) ) {
+            : i _r1 ( op_argmax_i64 . e g . e ks . x dptr . buf dptr outer ax )
+        } {
+            : i _r2 ( op_argmax . e g . e ks . x dptr . buf dptr outer ax )
+        }
+    }
+}
+
 @ rt_gather * Engine e ONode n → v {
     : RTensor data ( __in e n 0 )
-    : i axis ( node_attr_i n `axis` 0 )
+    : ~ i axis ( node_attr_i n `axis` 0 )
+    ? < axis 0 { = axis + axis ( rt_ndim data ) } {}
     : i axis_in ( rt_dim data axis )
     : ~ i outer 1
     : ~ i j 0
@@ -658,11 +741,16 @@ $ `ops.nu`
     : RTensor X ( __in e n 0 )
     : ~ f lo - 0.0 1000000000.0
     : ~ f hi 1000000000.0
+    // min/max are OPTIONAL inputs — an omitted one arrives as an empty
+    // name ("" placeholder input), which must keep the default, not
+    // read a nonexistent initializer as 0.0 (that clamped everything).
     ? > ( vec_len [String] . n inputs ) 1 {
-        = lo ( __init_f32 e ( string_data ?? ( vec_get [String] . n inputs 1 ) { T x → x F _ → ( string_new ) } ) 0 )
+        : s lon ( string_data ?? ( vec_get [String] . n inputs 1 ) { T x → x F _ → ( string_new ) } )
+        ? > ( nurl_str_len lon ) 0 { = lo ( __init_f32 e lon 0 ) } {}
     } {}
     ? > ( vec_len [String] . n inputs ) 2 {
-        = hi ( __init_f32 e ( string_data ?? ( vec_get [String] . n inputs 2 ) { T x → x F _ → ( string_new ) } ) 0 )
+        : s hin ( string_data ?? ( vec_get [String] . n inputs 2 ) { T x → x F _ → ( string_new ) } )
+        ? > ( nurl_str_len hin ) 0 { = hi ( __init_f32 e hin 0 ) } {}
     } {}
     : i yd ( rt_alloc_out e ( __out_name n ) ( __shape_copy_rt . X shape ) )
     ( op_clip . e g . e ks . X dptr yd . X nelem lo hi )
@@ -769,6 +857,7 @@ $ `ops.nu`
                     ? ( streq2 op `Sigmoid` ) { ( rt_sigmoid e nd ) }
                     ? ( streq2 op `Concat` ) { ( rt_concat e nd ) }
                     ? ( streq2 op `Split` ) { ( rt_split e nd ) }
+                    ? ( streq2 op `Slice` ) { ( rt_slice e nd ) }
                     ? ( streq2 op `Reshape` ) { ( rt_reshape e nd ) }
                     ? ( streq2 op `Resize` ) { ( rt_resize e nd ) }
                     ? ( streq2 op `Transpose` ) { ( rt_transpose e nd ) }
@@ -783,7 +872,7 @@ $ `ops.nu`
                     ? ( streq2 op `Erf` ) { ( rt_erf e nd ) }
                     ? ( streq2 op `Gather` ) { ( rt_gather e nd ) }
                     ? ( streq2 op `GatherND` ) { ( rt_gathernd e nd ) }
-                    ? ( streq2 op `ArgMax` ) {}
+                    ? ( streq2 op `ArgMax` ) { ( rt_argmax e nd ) }
                     ? ( streq2 op `Shape` ) {}
                     ? ( streq2 op `Range` ) {}
                     ? ( streq2 op `Squeeze` ) {}

--- a/packages/yoloe-demo/README.md
+++ b/packages/yoloe-demo/README.md
@@ -62,12 +62,42 @@ self-signed-certificate warning:
 | `--tls` | off | HTTPS with a fresh self-signed cert |
 | `--page FILE` | `views/index.html` | the demo page template |
 
+## Free-text prompting
+
+With the **promptable export**, the vocabulary is no longer baked in: type
+anything — `coffee mug`, `red car`, `a person waving` — press Enter (or
+comma, or *Add*), and the server tokenizes the text with the CLIP BPE
+(pure NURL), runs the **MobileCLIP text encoder on the GPU through the
+same onnx runtime** (~65 ms), writes the embedding into a free prompt
+slot, and the very next frame detects it. New chips toggle like the seed
+ones. The K=32-slot graph keeps unused slots inert (zero embeddings).
+
+```sh
+# one-time exports (torch + ultralytics + onnxsim in a venv; see tools/)
+python tools/export_promptable.py ~/yoloe-export
+python tools/export_text_encoder.py ~/yoloe-export
+
+./demo --model ~/yoloe-export/yoloe-promptable-k32.onnx \
+       --classes ~/yoloe-classes.txt \
+       --text-encoder ~/yoloe-export/text_encoder_n1.onnx
+```
+
+`POST /prompt` (body = the prompt text) → `{ id, name, n }`; 400 on an
+empty prompt, 409 when all 32 slots are used. The decode argmaxes only
+over *enabled* classes, so a custom prompt isn't shadowed by a disabled
+seed class of the same object (`a dog` 0.63 vs `dog` 0.88).
+
+Both graphs are verified against onnxruntime: the text encoder to ~4e-7
+per embedding, the K=32 detector to `PROMPTABLE FORWARD MATCH` on
+`packages/yoloe/tests/fwd2.nu`.
+
 ## The page
 
 * **Start camera** — streams the webcam through the model; **drop any
   image** on the page to run a single frame without a camera.
 * **Prompted classes** — chips toggle which of the model's prompt words
-  are shown (server-side filter).
+  are shown (server-side filter), and with `--text-encoder` a free-text
+  input adds new ones live.
 * **Confidence slider** and a **masks on/off** switch, applied per frame.
 * **Live stats** — fps, server inference ms, round-trip ms, object
   count, and a per-detection list.
@@ -116,7 +146,6 @@ available, so CI stays green.
   by NVRTC, so an in-browser build needs a WGSL backend for
   `packages/gpu` plus a wasm↔WebGPU host bridge. This demo is the
   host-GPU streaming architecture instead.
-* The model's vocabulary is baked at export time in this version.
-  `packages/yoloe/src/prompt.nu` already supports runtime text-prompt
-  embeddings (`tools/export_promptable.py`) — wiring a free-text prompt
-  box into this page is the natural next step.
+* With the plain `--model` export the vocabulary is baked at export
+  time; the promptable K=32 export + `--text-encoder` (see above) lifts
+  that at runtime.

--- a/packages/yoloe-demo/src/main.nu
+++ b/packages/yoloe-demo/src/main.nu
@@ -41,6 +41,7 @@ $ `stdlib/std/args.nu`
 $ `deps/onnx/src/pb.nu`
 $ `deps/onnx/src/model.nu`
 $ `deps/onnx/src/runtime.nu`
+$ `deps/yoloe/src/bpe.nu`
 $ `deps/yoloe/src/image.nu`
 $ `deps/yoloe/src/decode.nu`
 $ `deps/yoloe/src/mask.nu`
@@ -57,6 +58,11 @@ $ `deps/template/src/template.nu`
     String device
     String model_path
     String index_html  // pre-rendered demo page
+    // runtime prompting (kmax > 0 → the promptable K-slot export is loaded):
+    i kmax  // prompt slots baked into the detector graph (0 = baked vocab)
+    OGraph tgraph  // MobileCLIP text encoder (pure NURL on the GPU)
+    Tokenizer tk  // CLIP BPE tokenizer
+    ( Vec u ) tpe  // kmax×512 f32 text embeddings, zero-padded past nc
 }
 
 : ~ i g_st 0
@@ -162,12 +168,14 @@ $ `deps/template/src/template.nu`
     ^ != x 0.0
 }
 
-// per-class enable flags from `on=0,2,5`; no `on` param → all enabled
-@ yd_enabled ( Vec UrlParam ) ps i nc → ( Vec i ) {
+// per-class enable flags from `on=0,2,5`; no `on` param → all ACTIVE
+// classes enabled. `ncap` is the decode width (kmax in prompt mode) —
+// ids in [nc, ncap) are inert pad slots and stay off either way.
+@ yd_enabled ( Vec UrlParam ) ps i nc i ncap → ( Vec i ) {
     : ( Vec i ) flags ( vec_new [i] )
     : ~ b listed F
     : ~ i z 0
-    ~ < z nc { ( vec_push [i] flags 0 ) = z + z 1 }
+    ~ < z ncap { ( vec_push [i] flags 0 ) = z + z 1 }
     : i n ( vec_len [UrlParam] ps )
     : ~ i k 0
     ~ < k n {
@@ -206,6 +214,70 @@ $ `deps/template/src/template.nu`
     ^ flags
 }
 
+// Tokenize one prompt, run the text encoder on the GPU, and write the
+// 512-float embedding into tpe slot `slot`. The tokens ride as int64
+// [1,77]; the n1 text-encoder export ends in an L2 normalize, so the
+// slot lands in exactly the space the contrastive head was traced with.
+@ yd_encode_prompt * DemoState st s text i slot → b {
+    : *Engine e # *Engine . st eng
+    : ( Vec i ) row ( bpe_tokenize . st tk text 77 )
+    ? != ( vec_len [i] row ) 77 { ( vec_free [i] row ) ^ F } {}
+    : *u toks ( nurl_alloc * 77 8 )
+    : ~ i j 0
+    ~ < j 77 {
+        ( nurl_poke toks j ?? ( vec_get [i] row j ) { T x → x F _ → 0 } )
+        = j + j 1
+    }
+    ( vec_free [i] row )
+    : RTensor out ( rt_run_tokens e . st tgraph toks 1 77 )
+    : ~ b ok F
+    ? == . out nelem 512 {
+        : *u h ( rt_download e out )
+        : *u tp ( vec_data [u] . st tpe )
+        : ~ i q 0
+        ~ < q 512 {
+            ( nurl_poke_f32 tp + * slot 512 q ( nurl_peek_f32 h q ) )
+            = q + q 1
+        }
+        ( nurl_free # s h )
+        = ok T
+    } {}
+    ( nurl_free # s toks )
+    ^ ok
+}
+
+// Per-anchor best ENABLED class. yolo_decode argmaxes over every class
+// and filters afterwards — so a disabled seed class ('dog' 0.88) would
+// shadow an enabled custom prompt of the same object ('a dog' 0.63) and
+// the anchor vanished. Restricting the argmax to enabled classes makes
+// toggles behave the way the chips read.
+@ yd_decode * u o i na i nc f thresh ( Vec i ) flags → ( Vec Detection ) {
+    : ( Vec Detection ) dets ( vec_new [Detection] )
+    : ~ i a 0
+    ~ < a na {
+        : ~ f best 0.0
+        : ~ i bi - 0 1
+        : ~ i c 0
+        ~ < c nc {
+            : i on ?? ( vec_get [i] flags c ) { T x → x F _ → 0 }
+            ? == on 1 {
+                : f sc ( nurl_peek_f32 o + * + 4 c na a )
+                ? > sc best { = best sc = bi c } {}
+            } {}
+            = c + c 1
+        }
+        ? & >= bi 0 > best thresh {
+            : f cx ( nurl_peek_f32 o + * 0 na a )
+            : f cy ( nurl_peek_f32 o + * 1 na a )
+            : f w ( nurl_peek_f32 o + * 2 na a )
+            : f h ( nurl_peek_f32 o + * 3 na a )
+            ( vec_push [Detection] dets @ Detection { bi best cx cy w h a } )
+        } {}
+        = a + a 1
+    }
+    ^ dets
+}
+
 // ── inference: one frame in, masks drawn on, detection JSON out ─────
 
 @ yd_detect * DemoState st Image im f conf b want_masks ( Vec i ) flags → Json {
@@ -214,7 +286,14 @@ $ `deps/template/src/template.nu`
 
     : Letterbox lb ( letterbox im 640 )
     : *u host ( img_to_nchw_norm . lb img )
-    : RTensor out ( rt_run_shaped e . st graph host ( yd_shape4 1 3 640 640 ) )
+    : ~ RTensor out @ RTensor { ( string_new ) 0 ( vec_new [i] ) 0 }
+    ? > . st kmax 0 {
+        : ( Vec i ) s3 ( vec_new [i] )
+        ( vec_push [i] s3 1 ) ( vec_push [i] s3 . st kmax ) ( vec_push [i] s3 512 )
+        = out ( rt_run_two e . st graph `images` host ( yd_shape4 1 3 640 640 ) `tpe` ( vec_data [u] . st tpe ) s3 )
+    } {
+        = out ( rt_run_shaped e . st graph host ( yd_shape4 1 3 640 640 ) )
+    }
     : *u o ( rt_download e out )
 
     : ~ b masks want_masks
@@ -227,7 +306,8 @@ $ `deps/template/src/template.nu`
     : i na 8400
     : i MH ( mask_dim )
     : i MW ( mask_dim )
-    : ( Vec Detection ) raw ( yolo_decode o na . st nc conf )
+    : i ncap ? > . st kmax 0 . st kmax . st nc
+    : ( Vec Detection ) raw ( yd_decode o na ncap conf flags )
     : ( Vec Detection ) dets ( yolo_nms raw 0.5 )
     : f scale . lb scale
 
@@ -238,8 +318,7 @@ $ `deps/template/src/template.nu`
     ~ < k nd {
         ?? ( vec_get [Detection] dets k ) {
             T d → {
-                : i on ?? ( vec_get [i] flags . d cls ) { T x → x F _ → 1 }
-                ? == on 1 {
+                ? T {
                     : i ocx # i / - . d cx # f . lb padx scale
                     : i ocy # i / - . d cy # f . lb pady scale
                     : i ow # i / . d w scale
@@ -247,7 +326,7 @@ $ `deps/template/src/template.nu`
                     : i x0 - ocx / ow 2
                     : i y0 - ocy / oh 2
                     ? masks {
-                        : *u coeff ( mask_coeffs o na . st nc . d ai )
+                        : *u coeff ( mask_coeffs o na ncap . d ai )
                         : *u L ( mask_logits # *u proto_i coeff MH MW )
                         ( mask_overlay im L lb 640 x0 y0 ow oh ( yd_pal_r shown ) ( yd_pal_g shown ) ( yd_pal_b shown ) 118 )
                         ( nurl_free coeff )
@@ -316,7 +395,8 @@ $ `deps/template/src/template.nu`
     : ( Vec UrlParam ) ps ( url_query_decode ( string_data . req query ) )
     : f conf ( yd_query_f ps `conf` 0.25 )
     : b want_masks ( yd_query_b ps `masks` T )
-    : ( Vec i ) flags ( yd_enabled ps . st nc )
+    : i ncap ? > . st kmax 0 . st kmax . st nc
+    : ( Vec i ) flags ( yd_enabled ps . st nc ncap )
     ( yd_params_free ps )
 
     : ~ b ok F
@@ -346,6 +426,50 @@ $ `deps/template/src/template.nu`
     }
 }
 
+// POST /prompt — body is the prompt text. Encodes it through the
+// MobileCLIP text encoder ON the GPU and appends it to the vocabulary;
+// the next /detect already sees it. JSON out: { id, name, n }.
+@ h_prompt HttpRequest req Params p → HttpResponse {
+    : *DemoState st # *DemoState g_st
+    ? == . st kmax 0 {
+        ^ ( response_error 400 `runtime prompting is off — start the server with --text-encoder` )
+    } {}
+    ? >= . st nc . st kmax {
+        ^ ( response_error 409 `all prompt slots are in use` )
+    } {}
+    // sanitize: printable bytes only, collapse to a trimmed prompt
+    : ( Vec u ) body . req body
+    : i bn ( vec_len [u] body )
+    : ~ String txt ( string_with_cap 64 )
+    : ~ i k 0
+    ~ & < k bn < ( string_len txt ) 60 {
+        : i c ?? ( vec_get [u] body k ) { T x → # i x F _ → 0 }
+        ? | & >= c 32 <= c 126 >= c 128 { ( string_push_char txt c ) } {}
+        = k + k 1
+    }
+    : String trimmed ( string_trim txt )
+    ( string_free txt )
+    ? == ( string_len trimmed ) 0 {
+        ( string_free trimmed )
+        ^ ( response_error 400 `empty prompt` )
+    } {}
+    : i slot . st nc
+    ? ( yd_encode_prompt st ( string_data trimmed ) slot ) {
+        ( vec_push [String] . st names trimmed )
+        = . st nc + slot 1
+        : Json j ( json_obj_new )
+        ( json_obj_set j `id` ( json_int slot ) )
+        ( json_obj_set j `name` ( json_str_lit ( yd_name_at . st names slot ) ) )
+        ( json_obj_set j `n` ( json_int . st nc ) )
+        : HttpResponse r ( response_json 200 j )
+        ( json_free j )
+        ^ r
+    } {
+        ( string_free trimmed )
+        ^ ( response_error 500 `text encoder failed on this prompt` )
+    }
+}
+
 // ── startup ──────────────────────────────────────────────────────────
 
 @ yd_load_graph s path * b okcell → OGraph {
@@ -365,6 +489,8 @@ $ `deps/template/src/template.nu`
             : Json ctx ( json_obj_new )
             ( json_obj_set ctx `device` ( json_str_lit ( string_data . st device ) ) )
             ( json_obj_set ctx `model` ( json_str_lit ( string_data . st model_path ) ) )
+            ( json_obj_set ctx `promptable` ( json_bool > . st kmax 0 ) )
+            ( json_obj_set ctx `slots` ( json_int . st kmax ) )
             : Json arr ( json_arr_new )
             : ~ i k 0
             ~ < k . st nc {
@@ -408,6 +534,8 @@ $ `deps/template/src/template.nu`
     ( args_opt ap `host` 72 `HOST` `bind address (default 0.0.0.0)` )  // -H
     ( args_opt ap `gpu` 103 `N` `CUDA device ordinal (default 0)` )  // -g
     ( args_opt ap `page` 80 `FILE` `demo page template (default views/index.html)` )  // -P
+    ( args_opt ap `text-encoder` 116 `FILE` `MobileCLIP text-encoder .onnx → free-text prompting (needs the K-slot promptable --model)` )  // -t
+    ( args_opt ap `merges` 77 `FILE` `CLIP BPE merges (default deps/yoloe/assets/clip_merges.txt)` )  // -M
 
     : ( Vec String ) argv ( vec_new [String] )
     : i ac ( env_args_count )
@@ -425,12 +553,16 @@ $ `deps/template/src/template.nu`
             : ~ String mp ( string_new )
             : ~ String np ( string_new )
             : ~ String page ( string_from `views/index.html` )
+            : ~ String tep ( string_new )
+            : ~ String mgp ( string_from `deps/yoloe/assets/clip_merges.txt` )
             : ~ String host ( string_from `0.0.0.0` )
             : ~ i port 8090
             : ~ i gpu 0
             ?? ( args_value ap `model` ) { T v → { ( string_free mp ) = mp v } F _ → {} }
             ?? ( args_value ap `classes` ) { T v → { ( string_free np ) = np v } F _ → {} }
             ?? ( args_value ap `page` ) { T v → { ( string_free page ) = page v } F _ → {} }
+            ?? ( args_value ap `text-encoder` ) { T v → { ( string_free tep ) = tep v } F _ → {} }
+            ?? ( args_value ap `merges` ) { T v → { ( string_free mgp ) = mgp v } F _ → {} }
             ?? ( args_value ap `host` ) { T v → { ( string_free host ) = host v } F _ → {} }
             ?? ( args_value ap `port` ) { T v → { ?? ( string_to_int v ) { T x → { = port x } F _ → {} } ( string_free v ) } F _ → {} }
             ?? ( args_value ap `gpu` ) { T v → { ?? ( string_to_int v ) { T x → { = gpu x } F _ → {} } ( string_free v ) } F _ → {} }
@@ -467,9 +599,56 @@ $ `deps/template/src/template.nu`
                         = . st device ( string_from ( rt_name e ) )
                         = . st model_path mp
                         = . st index_html ( string_new )
+                        = . st kmax 0
+                        = . st tpe ( vec_new [u] )
                         = g_st # i st
 
-                        ? ( yd_render_index ( string_data page ) st ) {
+                        // free-text prompting: load the text encoder +
+                        // tokenizer and GPU-encode the seed vocabulary
+                        // into the K=32 tpe slots.
+                        : ~ b prompt_ok T
+                        ? > ( string_len tep ) 0 {
+                            = prompt_ok F
+                            : *b okc2 # *b ( nurl_alloc 8 )
+                            : OGraph tg ( yd_load_graph ( string_data tep ) okc2 )
+                            ? == ( nurl_peek # *u okc2 0 ) 0 {
+                                ( nurl_eprintln `yoloe-demo: cannot read the text encoder` )
+                            } {
+                                : Tokenizer tkz ( tokenizer_load ( string_data mgp ) )
+                                ? < . tkz sot 0 {
+                                    ( nurl_eprintln `yoloe-demo: cannot read the BPE merges (--merges)` )
+                                } {
+                                    ? > nc 32 {
+                                        ( nurl_eprintln `yoloe-demo: at most 32 seed classes with the K=32 promptable model` )
+                                    } {
+                                        = . st tgraph tg
+                                        = . st tk tkz
+                                        = . st kmax 32
+                                        : ~ i zb 0
+                                        ~ < zb * * 32 512 4 { ( vec_push [u] . st tpe 0 ) = zb + zb 1 }
+                                        ( nurl_print `prompts  encoding ` ) ( nurl_print ( nurl_str_int nc ) )
+                                        ( nurl_print ` seed classes on the GPU ... ` )
+                                        : i p0 ( monotonic_ns )
+                                        : ~ i pk 0
+                                        : ~ b enc_ok T
+                                        ~ & < pk nc enc_ok {
+                                            ? ( yd_encode_prompt st ( yd_name_at names pk ) pk ) {} { = enc_ok F }
+                                            = pk + pk 1
+                                        }
+                                        ? enc_ok {
+                                            ( nurl_print ( nurl_str_int / - ( monotonic_ns ) p0 1000000 ) )
+                                            ( nurl_print ` ms  (` ) ( nurl_print ( nurl_str_int - 32 nc ) )
+                                            ( nurl_print ` free slots)\n` )
+                                            = prompt_ok T
+                                        } { ( nurl_eprintln `yoloe-demo: seed-class text encoding failed` ) }
+                                    }
+                                }
+                            }
+                        } {}
+
+                        ? == prompt_ok F { = rc 1 = g_st 0 } {}
+
+                        ? & prompt_ok ( yd_render_index ( string_data page ) st ) {
                             // warm-up: compile every kernel before the first real frame
                             ( nurl_print `warmup   compiling kernels ... ` )
                             : i w0 ( monotonic_ns )
@@ -492,6 +671,7 @@ $ `deps/template/src/template.nu`
                             ( http_app_get a `/` \ HttpRequest rq Params pp → HttpResponse { ^ ( h_index rq pp ) } )
                             ( http_app_get a `/health` \ HttpRequest rq Params pp → HttpResponse { ^ ( h_health rq pp ) } )
                             ( http_app_post a `/detect` \ HttpRequest rq Params pp → HttpResponse { ^ ( h_detect rq pp ) } )
+                            ( http_app_post a `/prompt` \ HttpRequest rq Params pp → HttpResponse { ^ ( h_prompt rq pp ) } )
                             ( http_app_cors a )
 
                             ? ( args_present ap `tls` ) {
@@ -520,6 +700,8 @@ $ `deps/template/src/template.nu`
             ( string_free np )
             ( string_free page )
             ( string_free host )
+            ( string_free tep )
+            ( string_free mgp )
         }
     } {
         ( nurl_eprint `yoloe-demo: ` ) ( nurl_eprintln ( args_error ap ) )

--- a/packages/yoloe-demo/tests/demo_test.sh
+++ b/packages/yoloe-demo/tests/demo_test.sh
@@ -99,6 +99,50 @@ RSS1="$(ps -o rss= -p "$SERVE_PID" | tr -d ' ')"
 GROW=$(( (RSS1 - RSS0) / 1024 ))
 if [ "$GROW" -lt 40 ]; then ok "60-frame sustained run (RSS +${GROW} MB)"; else bad "RSS grew ${GROW} MB over 60 frames"; fi
 
+# ── free-text prompting (needs the promptable export + text encoder) ──
+PMODEL="${YOLOE_PROMPT_MODEL:-$HOME/yoloe-export/yoloe-promptable-k32.onnx}"
+TENC="${YOLOE_TEXT_ENCODER:-$HOME/yoloe-export/text_encoder_n1.onnx}"
+if [ -f "$PMODEL" ] && [ -f "$TENC" ]; then
+    echo "[4/4] free-text prompting ($PMODEL)"
+    kill "$SERVE_PID" 2>/dev/null; wait "$SERVE_PID" 2>/dev/null; SERVE_PID=""
+    PPORT=$((PORT+1))
+    "$WORK/demo" --model "$PMODEL" --classes "$CLASSES" --text-encoder "$TENC" \
+        --host 127.0.0.1 --port "$PPORT" >"$WORK/pserver.log" 2>&1 &
+    SERVE_PID=$!
+    for i in $(seq 1 120); do
+        curl -s --max-time 1 "http://127.0.0.1:$PPORT/health" >/dev/null 2>&1 && break
+        sleep 0.5
+        kill -0 "$SERVE_PID" 2>/dev/null || { echo "FAIL: prompt server died:"; tail -5 "$WORK/pserver.log"; exit 1; }
+    done
+    PBASE="http://127.0.0.1:$PPORT"
+
+    # page advertises the prompt input
+    curl -s "$PBASE/" | grep -q 'id="promptIn"' && ok "page shows the prompt input" || bad "page shows the prompt input"
+
+    # baseline through the promptable graph still finds the dog
+    R="$(curl -s -X POST --data-binary @"$TESTIMG" "$PBASE/detect?conf=0.25&masks=1")"
+    echo "$R" | grep -q '"dog"' && ok "promptable baseline finds the dog" || bad "promptable baseline finds the dog"
+
+    # add a free-text prompt; it must land in slot 10
+    R="$(printf 'a dog' | curl -s -X POST --data-binary @- "$PBASE/prompt")"
+    echo "$R" | grep -q '"id": *10' || echo "$R" | grep -q '"id":10' \
+        && ok "prompt 'a dog' → slot 10" || bad "prompt 'a dog' → slot 10 (got $R)"
+
+    # with only the custom prompt enabled, the dog is found UNDER ITS NAME
+    R="$(curl -s -X POST --data-binary @"$TESTIMG" "$PBASE/detect?conf=0.25&on=10")"
+    if echo "$R" | grep -q '"a dog"' && ! echo "$R" | grep -q '"n": *"dog"'; then
+        ok "custom prompt detects (seeds disabled)"
+    else
+        bad "custom prompt detects (seeds disabled): $R"
+    fi
+
+    # empty prompt → 400
+    CODE="$(printf '  ' | curl -s -o /dev/null -w '%{http_code}' -X POST --data-binary @- "$PBASE/prompt")"
+    [ "$CODE" = "400" ] && ok "empty prompt → 400" || bad "empty prompt → 400 (got $CODE)"
+else
+    echo "[4/4] SKIP free-text prompting (promptable export not found — see tools/)"
+fi
+
 echo
 echo "PASS $PASS · FAIL $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/packages/yoloe-demo/tools/export_promptable.py
+++ b/packages/yoloe-demo/tools/export_promptable.py
@@ -1,0 +1,60 @@
+# export_promptable.py — YOLOE-v8s-seg with a runtime text-prompt input,
+# keeping BOTH outputs (detections + mask prototypes), folded to a fixed
+# K=32 prompt-slot graph the NURL onnx runtime executes 1:1.
+#
+#   python export_promptable.py <workdir> [K]
+#
+# Needs: torch (cpu ok) + ultralytics + onnx + onnxsim. Downloads
+# yoloe-v8s-seg.pt on first run. Writes yoloe-promptable-k<K>.onnx.
+# The fixed K matters: onnxsim folds every Shape/Cast/dynamic-dim chain
+# to constants, leaving only ops the NURL runtime supports; unused slots
+# are fed zero embeddings at runtime (the graph's epsilon-clipped
+# normalize keeps them inert, max score ~0.002).
+import os, sys, collections
+import torch, torch.nn as nn
+
+workdir = sys.argv[1]
+K = int(sys.argv[2]) if len(sys.argv) > 2 else 32
+os.chdir(workdir)
+from ultralytics import YOLOE
+
+m = YOLOE("yoloe-v8s-seg.pt"); m.eval()
+ym = m.model
+names = ["person", "dog"]                    # seed only shapes the trace
+tpe = m.get_text_pe(names).clone().detach()  # clone: escape inference mode
+ym.set_classes(names, tpe)
+
+class PromptableSeg(nn.Module):
+    def __init__(self, ym): super().__init__(); self.ym = ym
+    def forward(self, image, tpe):
+        out = self.ym.predict(image, tpe=tpe)
+        det, rest = out[0], out[1]
+        proto = None
+        if isinstance(rest, (list, tuple)):
+            for t in rest:
+                if torch.is_tensor(t) and t.dim() == 4 and t.shape[1] == 32:
+                    proto = t
+        elif torch.is_tensor(rest) and rest.dim() == 4:
+            proto = rest
+        return (det, proto) if proto is not None else det
+
+wrap = PromptableSeg(ym).eval()
+img = torch.zeros(1, 3, 640, 640)
+with torch.no_grad(): out = wrap(img, tpe)
+outnames = ["output0", "output1"] if isinstance(out, tuple) else ["output0"]
+print("forward:", [tuple(t.shape) for t in out] if isinstance(out, tuple) else tuple(out.shape))
+
+torch.onnx.export(wrap, (img, tpe), "yoloe-promptable-dyn.onnx",
+    input_names=["images", "tpe"], output_names=outnames,
+    opset_version=17, do_constant_folding=False, dynamo=False,
+    dynamic_axes={"tpe": {1: "k"}, "output0": {1: "c"}})
+
+import onnx
+from onnxsim import simplify
+mm = onnx.load("yoloe-promptable-dyn.onnx")
+ms, ok = simplify(mm, overwrite_input_shapes={"images": [1,3,640,640], "tpe": [1,K,512]})
+assert ok
+onnx.save(ms, f"yoloe-promptable-k{K}.onnx")
+ops = collections.Counter(n.op_type for n in ms.graph.node)
+print("ops:", dict(sorted(ops.items(), key=lambda x: -x[1])))
+print(f"wrote yoloe-promptable-k{K}.onnx")

--- a/packages/yoloe-demo/tools/export_text_encoder.py
+++ b/packages/yoloe-demo/tools/export_text_encoder.py
@@ -1,0 +1,67 @@
+# export_text_encoder.py — MobileCLIP-blt text encoder as a single-prompt
+# (n=1) ONNX graph the NURL runtime executes 1:1, output L2-normalized to
+# match ultralytics get_text_pe.
+#
+#   python export_text_encoder.py <workdir>
+#
+# Needs: torch + ultralytics + onnx + onnxsim + onnxruntime + the
+# traceable python mobileclip package
+# (pip install git+https://github.com/ultralytics/mobileclip.git).
+# Verifies parity against ultralytics' TS text model AND onnxruntime
+# before writing. Fixing n=1 lets onnxsim fold the whole attention-mask
+# construction (Trilu/Where/ConstantOfShape/Cast) to constants; the one
+# remaining Flatten is rewritten as the equivalent Reshape.
+import os, sys, collections
+import torch, torch.nn as nn, numpy as np
+
+os.chdir(sys.argv[1])
+from ultralytics.nn.text_model import MobileCLIP, build_text_model
+
+tm = MobileCLIP("blt", torch.device("cpu"))
+ts = build_text_model("mobileclip:blt", device=torch.device("cpu"))
+names = ["dog", "bicycle", "coffee mug"]
+tok = tm.tokenizer(names).to(torch.int64)
+
+class TextEnc(nn.Module):
+    def __init__(self, m): super().__init__(); self.m = m
+    def forward(self, tokens):
+        f = self.m.encode_text(tokens)
+        return f / f.norm(dim=-1, keepdim=True)
+
+wrap = TextEnc(tm.model).eval()
+with torch.no_grad():
+    out = wrap(tok)
+    ref_ts = ts.encode_text(ts.tokenize(names))
+assert (out - ref_ts).abs().max().item() < 1e-3, "python MobileCLIP != ultralytics TS"
+
+torch.onnx.export(wrap, (tok,), "text_encoder_dyn.onnx",
+    input_names=["tokens"], output_names=["feats"],
+    opset_version=17, do_constant_folding=True, dynamo=False,
+    dynamic_axes={"tokens": {0: "n"}, "feats": {0: "n"}})
+
+import onnx
+from onnxsim import simplify
+mm = onnx.load("text_encoder_dyn.onnx")
+ms, ok = simplify(mm, overwrite_input_shapes={"tokens": [1, 77]})
+assert ok
+g = ms.graph
+for i, n in enumerate(g.node):          # Flatten [1,77,512]→[77,512] ⇒ Reshape
+    if n.op_type == "Flatten":
+        shp = onnx.helper.make_tensor("flatten_shape_const", onnx.TensorProto.INT64,
+                                      [2], np.array([77, 512], dtype=np.int64).tobytes(), raw=True)
+        g.initializer.append(shp)
+        rn = onnx.helper.make_node("Reshape", inputs=[n.input[0], "flatten_shape_const"],
+                                   outputs=list(n.output), name="Flatten_as_Reshape")
+        g.node.remove(n); g.node.insert(i, rn)
+        break
+onnx.save(ms, "text_encoder_n1.onnx")
+
+import onnxruntime as ort
+sess = ort.InferenceSession("text_encoder_n1.onnx")
+for r in range(len(names)):
+    o = sess.run(None, {"tokens": tok[r:r+1].numpy()})[0]
+    d = float(np.abs(o - out[r].numpy()).max())
+    assert d < 1e-4, f"row {r} diff {d}"
+ops = collections.Counter(n.op_type for n in g.node)
+print("ops:", dict(sorted(ops.items(), key=lambda x: -x[1])))
+print("wrote text_encoder_n1.onnx (verified vs torch + onnxruntime)")

--- a/packages/yoloe-demo/views/index.html
+++ b/packages/yoloe-demo/views/index.html
@@ -69,6 +69,18 @@
     border-radius: 999px; padding: .3rem .75rem; font-size: .82rem; cursor: pointer; user-select: none;
   }
   .cls.on { color: #08110c; background: var(--acc); border-color: var(--acc); font-weight: 600; }
+  .cls.custom { border-style: dashed; }
+  .promptrow { display: flex; gap: .4rem; margin-top: .7rem; }
+  .promptrow input {
+    flex: 1; min-width: 0; background: var(--panel2); border: 1px solid var(--line);
+    border-radius: 8px; color: var(--txt); padding: .45rem .6rem; font-size: .85rem;
+  }
+  .promptrow input:focus { outline: 1px solid var(--acc2); }
+  .promptrow button {
+    border: 1px solid var(--line); background: linear-gradient(180deg, #1a2333, #141b29);
+    color: var(--acc); border-radius: 8px; padding: .45rem .8rem; font-weight: 600; cursor: pointer;
+  }
+  #promptMsg { font-size: .75rem; color: var(--warn); margin-top: .35rem; min-height: 1em; }
   .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: .5rem; }
   .stat { background: var(--panel2); border: 1px solid var(--line); border-radius: 10px; padding: .55rem; text-align: center; }
   .stat b { display: block; font-size: 1.15rem; font-variant-numeric: tabular-nums; color: var(--acc2); }
@@ -125,6 +137,13 @@
       <div class="classes" id="classes">
         {% for c in classes %}<span class="cls on" data-id="{{ c.id }}">{{ c.name }}</span>{% end %}
       </div>
+      {% if promptable %}
+      <div class="promptrow">
+        <input type="text" id="promptIn" placeholder="type anything — 'coffee mug', 'red car' …" maxlength="60">
+        <button id="promptBtn">Add</button>
+      </div>
+      <div id="promptMsg"></div>
+      {% end %}
     </div>
 
     <div class="panel">
@@ -292,6 +311,39 @@ function drawOverlay(dets) {
       octx.fillText(label, d.x + 4, ty + 2);
     }
   }
+}
+
+// free-text prompting: Enter, comma or the Add button encodes the text
+// on the server (MobileCLIP → tpe slot) and appends a toggle chip.
+const pIn = $("promptIn");
+if (pIn) {
+  const pMsg = $("promptMsg");
+  const addPrompt = async () => {
+    const t = pIn.value.replace(/,\s*$/, "").trim();
+    if (!t) return;
+    pIn.disabled = true;
+    try {
+      const res = await fetch("/prompt", { method: "POST", body: t });
+      if (!res.ok) throw new Error((await res.text()).slice(0, 120));
+      const j = await res.json();
+      const el = document.createElement("span");
+      el.className = "cls on custom";
+      el.dataset.id = j.id;
+      el.textContent = j.name;
+      el.onclick = () => el.classList.toggle("on");
+      $("classes").appendChild(el);
+      pIn.value = "";
+      pMsg.textContent = "";
+    } catch (e) {
+      pMsg.textContent = "" + (e.message || e);
+    }
+    pIn.disabled = false;
+    pIn.focus();
+  };
+  $("promptBtn").onclick = addPrompt;
+  pIn.addEventListener("keydown", e => {
+    if (e.key === "Enter" || e.key === ",") { e.preventDefault(); addPrompt(); }
+  });
 }
 
 // kiosk / test mode: ?auto=1 starts the camera on load


### PR DESCRIPTION
The page grows a prompt input: Enter/comma/Add tokenizes the text with the CLIP BPE (pure NURL), runs the MobileCLIP text encoder ON the GPU through the same onnx runtime (~65 ms), writes the L2-normalized embedding into one of the K=32 tpe slots of the promptable YOLOE-seg export, and the next frame detects the new class — chip toggles like the seed vocabulary. POST /prompt → {id,name,n}; 400 empty, 409 full. Decode argmaxes only over ENABLED classes so a custom prompt ('a dog' 0.63) isn't shadowed by a disabled seed class ('dog' 0.88).

Exports are reproducible via tools/export_promptable.py (K=32-folded promptable seg graph — onnxsim constant-folds every dynamic-shape chain) and tools/export_text_encoder.py (n=1 MobileCLIP-blt, mask construction folded, Flatten→Reshape, verified vs ultralytics-TS + onnxruntime).

Getting the two graphs to run 1:1 in the NURL onnx runtime fixed five real runtime/parser bugs (all torch-2.12/onnxsim-shaped graphs):
- ArgMax executed as a no-op (only the old GatherND EOS pattern was wired) → real rt_argmax + an int64 kernel for token inputs
- Slice was entirely missing (older exports emitted Split) → rt_slice over the single-axis unit-step form via the existing slice kernel
- pb parser ignored TensorProto.int64_data (packed varints — onnxsim writes shape tensors there); an Expand target read as garbage
- Clip treated its OPTIONAL empty-name max input as initializer 0.0 — everything clamped to zero → division blew up to inf
- Concat/Gather did not normalize negative axes (Concat axis=-1 is how torch 2.12 merges detection levels) — same class as the old softmax neg-axis fix

Verified: text encoder TEXT FORWARD MATCH vs torch (~4e-7, 3 prompts incl. multi-word); K=32 detector PROMPTABLE FORWARD MATCH vs onnxruntime (fwd2); live E2E — custom prompt 'a dog' masks the dog at 0.63 with seeds disabled, ort parity on tree/wheel scores to 1e-3; demo_test.sh grew a promptable section: 13/13 PASS; onnx package tests 2/2; baked-model path unchanged (8/8).


Claude-Session: https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7