### PR TITLE
release: publish template 0.1.0 + gpu 0.4.0 / onnx 0.6.0 / wasmbuilder 0.1.2 / image 0.4.1

### DIFF
--- a/packages/gpu/nurl.toml
+++ b/packages/gpu/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpu"
-version = "0.3.0"
+version = "0.4.0"
 description = "GPU compute for NURL — a backend-neutral interface (Gpu / GpuKernel / GpuBuffer: open, compile, alloc, upload/download, launch, sync) with two backends: CUDA and CPU. The CUDA backend writes kernels in CUDA-C, compiles them to PTX at runtime via NVRTC, and runs them through the CUDA Driver API — bound directly from pure NURL with no runtime.c bridge. The CPU backend (v0.2.0) runs the very same CUDA-C kernels on the host: each is wrapped in a small CUDA-compatibility shim (blockIdx/threadIdx as thread-locals, __global__ etc. as no-op macros) plus a generated grid-loop, compiled by the system C++ compiler, dlopen'd, and run with OpenMP parallelising the grid across cores — so an onnx/YOLOE model runs with no GPU at all. gpu_open selects CUDA when a device is available, else falls back to CPU; NURL_GPU=cpu forces it. The neutral surface is unchanged, so callers (packages/onnx, objdet, yoloe) get CPU fallback for free. The toolchain auto-links -lcuda / -lnvrtc only when a program references those symbols; the CPU backend needs only a C++ compiler on PATH (the analogue of NVRTC). Verified: the tiny MLP and the full 267-node YOLOE-seg forward produce identical results on CPU and GPU."
 license = "MIT OR Apache-2.0"
 

--- a/packages/image/nurl.toml
+++ b/packages/image/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.4.0"
+version = "0.4.1"
 description = "Pure-NURL image codecs + raster ops — decode, encode and transform images with no native library and no ImageMagick/ffmpeg shell-out. PNG decode covers the complete still-image matrix: bit depths 1/2/4/8/16, grey/RGB/palette/grey+alpha/RGBA, Adam7 interlacing, tRNS transparency (palette alpha and colour keys), all five scanline filters; png_encode writes lossless 8-bit PNGs. JPEG decode handles both baseline (SOF0/SOF1) and PROGRESSIVE (SOF2) Huffman JPEGs — any 4:4:4/4:2:2/4:2:0/4:1:1 subsampling, restart intervals, spectral selection + successive approximation — matching libjpeg to within IDCT rounding; jpeg_encode writes baseline JFIF at quality 1-100 (4:4:4/4:2:2/4:2:0, Annex K tables, loss profile matches Pillow's encoder). PPM (P5/P6) both ways. ops.nu has the raster toolkit every vision pipeline hand-rolls: bilinear/box/nearest resize, crop, flips, rotations, channel conversion (BT.601), fill/rect/line drawing, alpha blit, packed 0xRRGGBBAA pixel access — all clipped and bounds-checked. image_load/image_decode sniff the format; image_error says why a decode failed. Ships an img CLI (info/convert/resize with keep-aspect specs). Fuzz-hardened under ASan: truncation/mutation sweeps across all decoders, dimension caps, no OOB/hang/leak — malformed input is a clean None, never a crash. The front door for objdet, yoloe and chart."
 license = "MIT OR Apache-2.0"
 

--- a/packages/onnx/nurl.toml
+++ b/packages/onnx/nurl.toml
@@ -1,9 +1,9 @@
 [package]
 name = "onnx"
-version = "0.5.0"
+version = "0.6.0"
 description = "Run ONNX neural-network models from pure NURL, GPU-accelerated. The model's protobuf is decoded by a pure-NURL wire-format reader (no protoc, no external protobuf library) into an in-memory graph; inference runs on the GPU through the `gpu` package — each operator is a CUDA-C kernel compiled to PTX at runtime via NVRTC and launched over the CUDA Driver API, with every weight and activation resident on the device. v0.1.0 is a proof-of-concept covering feed-forward MLPs (Gemm + Relu); the demo loads a model and input, runs it on the GPU, and matches onnxruntime's output (max abs error ~1e-6). Requires the NVIDIA driver (libcuda) and NVRTC (libnvrtc); a GPU-less host is unaffected since the CUDA dependency lives entirely in the `gpu` package."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 tensor = { path = "../tensor", version = "^0.3" }
-gpu = { path = "../gpu", version = "^0.3" }
+gpu = { path = "../gpu", version = "^0.4" }

--- a/packages/wasmbuilder/nurl.toml
+++ b/packages/wasmbuilder/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbuilder"
-version = "0.1.1"
+version = "0.1.2"
 description = "Compile NURL to wasm32-wasi locally — no wasi-sdk, no build service. Drives the installed toolchain end to end: nurlc emits LLVM IR, the production IR rewriter retargets it for wasm32-wasi (libc width shims, POSIX stubs, main rename), and the toolchain's bundled `zig cc` (wasi-libc + wasm-ld built in) links the .wasm. The NURL runtime is compiled from the installed stdlib's runtime.c on first use and cached by content hash, so it always matches your toolchain version. If no bundled zig is present (e.g. a Windows install), wasmbuilder downloads a pinned, sha256-verified zig into $NURL_HOME/zig once. Ships as both a CLI (`wasmbuilder file.nu -o file.wasm`, plus `--doctor` for setup diagnosis) and a library other packages embed to compile wasm in-process (swarm-mcp kernel builds, nurl-mcp). Optional: `--asyncify` for browser canvas programs (needs binaryen's wasm-opt). Run the result with the pure-NURL `wasmtime` package or any wasm runtime."
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Version bumps for the packages changed this session, **already published to reg.nurl-lang.org**:

| package | version | what changed |
| --- | --- | --- |
| **template** | 0.1.0 (new) | Jinja-style HTML template engine over stdlib Json |
| **gpu** | 0.3.0 → 0.4.0 | WebGPU backend (backend 3) — onnx kernels as WGSL compute shaders on the browser GPU |
| **onnx** | 0.5.0 → 0.6.0 | static-kernel generator, int64_data pb parsing, rt_slice / rt_argmax, optional-Clip-input + negative-axis fixes; gpu dep ^0.3 → ^0.4 |
| **wasmbuilder** | 0.1.1 → 0.1.2 | --obj (multi) / --cflags / --asyncify-imports / --strip-dwarf; working env import-name attrs |
| **image** | 0.4.0 → 0.4.1 | internal `__jp_` → `__jpg_` rename (cross-package collision with ext/json.nu) |

All five are live and complete (the gpu tarball includes `web/webgpu.js` + `kernels_wgsl.js` + `wgpu_asyncify.c`). This PR records the nurl.toml bumps + onnx's gpu-dep constraint on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7