### PR TITLE
release: give the FreeBSD VM 14 GB so the bootstrap doesn't OOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,9 +143,17 @@ jobs:
         with:
           release: "14.2"
           usesh: true
-          # The bootstrap self-compile peaks near ~9.5 GB RSS; give the VM
-          # most of the 16 GB runner. KVM keeps the guest near-native speed.
-          mem: 13312
+          # The bootstrap self-compile (nurlc compiling nurlc.nu) is the
+          # memory peak: it holds the whole 18k-line unit's IR + symbol
+          # tables resident, and the peak grows with the compiler. Measured
+          # ~13.2 GB RSS at this size (up from ~9.5 GB when this job was
+          # added), so give the guest 14 GB and leave ~2 GB of the 16 GB
+          # runner for the host + KVM. Raise this in step with the peak
+          # rather than living 35 MB from the edge — this is exactly what
+          # dropped the FreeBSD tarball from the v0.11.1 release (the leg
+          # OOM'd at 13312 while ci.yml had already been bumped). KVM keeps
+          # the guest near-native speed.
+          mem: 14336
           cpu: 3
           # Forward the tag so the archive is named to match the others.
           envs: 'NURL_TAG'


### PR DESCRIPTION
## What

The FreeBSD leg of the **v0.11.1 release** OOM-killed during `./build.sh`, so the release shipped without `nurl-v0.11.1-freebsd-x86_64.tar.gz`. The Linux x86_64, Linux ARM64 and Windows tarballs published fine; FreeBSD is `continue-on-error`, so the drop was silent.

## Root cause

The nurlc bootstrap self-compile peaks ~13.2 GB RSS and grows with the compiler. This VM was pinned at `mem: 13312` — 35 MB under the peak. `ci.yml`'s FreeBSD job hit the same wall earlier and was already bumped to `14336`; `release.yml` never got the parity change. Every prior release (v0.11.0, v0.10.12, v0.10.11) shipped a FreeBSD tarball, so this is a regression.

## Fix

Bump the release FreeBSD VM to `mem: 14336` (14 GB guest, ~2 GB left for host + KVM on the 16 GB runner), matching ci.yml, with the same "raise in step with the peak" note.

The missing v0.11.1 FreeBSD tarball is being **backfilled out of band** (a `workflow_dispatch` build off this branch, then `gh release upload` onto the existing v0.11.1 release — no re-tag, existing assets untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)