### PR TITLE
gpu/webgpu: 2-4× faster WGSL inference — batching, kernel tiling, bind caching

### DIFF
--- a/nurlapi/static/kernels_wgsl.js
+++ b/nurlapi/static/kernels_wgsl.js
@@ -40,13 +40,46 @@ eltwise:   { params:[["X","b"],["B","b"],["Y","w"],["n","i"],["per","i"],["op","
   var r = 0.0;
   if (p.op == 0) { r = x*b; } else if (p.op == 1) { r = x+b; } else if (p.op == 2) { r = x-b; } else { r = x/b; }
   Y[idx] = r;` },
+// gemm with few outputs but a deep K (projection heads: M·N in the
+// hundreds, K in the thousands) leaves the GPU nearly idle at one
+// thread per output — so small results get a 64-lane workgroup per
+// output element, lanes strided over K, tree-reduced in workgroup
+// memory. The `invocations` hook and the body branch on the same
+// uniform predicate so dispatch and kernel agree.
 gemm:      { params:[["A","b"],["B","b"],["C","b"],["Y","w"],["M","i"],["N","i"],["K","i"],["alpha","f"],["beta","f"],["transB","i"],["hasC","i"]],
-  body:`if (idx < p.M*p.N) {
+  extra: "var<workgroup> gemm_part: array<f32, 64>;\n",
+  invocations: (p) => (p.M*p.N < 16384) ? p.M*p.N*64 : p.M*p.N,
+  body:`if (p.M*p.N < 16384) {
+    // padding workgroups (2D-dispatch rounding) redo the last output —
+    // identical value, benign write race
+    let out = min(idx / 64, p.M*p.N - 1);
+    let lane = idx % 64;
+    let r = out / p.N; let c = out % p.N;
+    var s = 0.0;
+    // transB branched OUTSIDE the loop: select() evaluates both operands,
+    // and the dead transposed load is a stride-K cache miss per iteration
+    if (p.transB != 0) {
+      for (var k = lane; k < p.K; k = k + 64) { s = s + A[r*p.K + k] * B[c*p.K + k]; }
+    } else {
+      for (var k = lane; k < p.K; k = k + 64) { s = s + A[r*p.K + k] * B[k*p.N + c]; }
+    }
+    gemm_part[lane] = s;
+    workgroupBarrier();
+    for (var w = 32; w > 0; w = w >> 1) {
+      if (lane < w) { gemm_part[lane] = gemm_part[lane] + gemm_part[lane + w]; }
+      workgroupBarrier();
+    }
+    if (lane == 0) {
+      let bias = select(0.0, C[c], p.hasC != 0);
+      Y[out] = p.alpha*gemm_part[0] + p.beta*bias;
+    }
+  } else if (idx < p.M*p.N) {
     let r = idx / p.N; let c = idx % p.N;
     var acc = 0.0;
-    for (var k = 0; k < p.K; k = k + 1) {
-      let bb = select(B[k*p.N + c], B[c*p.K + k], p.transB != 0);
-      acc = acc + A[r*p.K + k] * bb;
+    if (p.transB != 0) {
+      for (var k = 0; k < p.K; k = k + 1) { acc = acc + A[r*p.K + k] * B[c*p.K + k]; }
+    } else {
+      for (var k = 0; k < p.K; k = k + 1) { acc = acc + A[r*p.K + k] * B[k*p.N + c]; }
     }
     let bias = select(0.0, C[c], p.hasC != 0);
     Y[idx] = p.alpha*acc + p.beta*bias;
@@ -58,29 +91,127 @@ bmm:       { params:[["A","b"],["B","b"],["Y","w"],["batch","i"],["M","i"],["N",
   var acc = 0.0;
   for (var k = 0; k < p.K; k = k + 1) { acc = acc + A[aoff + r*p.K + k] * B[boff + k*p.N + c]; }
   Y[idx] = acc;` },
+// conv2d computes FOUR consecutive ow outputs per invocation (the
+// `invocations` hook sizes the dispatch): the 3×3 fast paths share the
+// overlapping input row across a vec4 accumulator (18 X-loads instead of
+// 36 for stride 1), and constant loop bounds let the compiler unroll —
+// the naive one-output-per-thread body ran at ~0.1% of a 4090's peak.
 conv2d:    { params:[["X","b"],["Wt","b"],["Bb","b"],["Y","w"],["Cin","i"],["H","i"],["W","i"],["Cout","i"],["kh","i"],["kw","i"],["OH","i"],["OW","i"],["ph","i"],["pw","i"],["sh","i"],["sw","i"],["hasB","i"]],
-  body:`let total = p.Cout*p.OH*p.OW;
-  if (idx >= total) { return; }
-  let ow = idx % p.OW; let oh = (idx / p.OW) % p.OH; let oc = idx / (p.OW*p.OH);
-  var acc = select(0.0, Bb[oc], p.hasB != 0);
-  for (var ic = 0; ic < p.Cin; ic = ic + 1) {
-    let xoff = ic*p.H*p.W; let woff = ((oc*p.Cin) + ic)*p.kh*p.kw;
-    for (var r = 0; r < p.kh; r = r + 1) {
-      let ih = oh*p.sh - p.ph + r;
-      if (ih < 0 || ih >= p.H) { continue; }
-      for (var s = 0; s < p.kw; s = s + 1) {
-        let iw = ow*p.sw - p.pw + s;
-        if (iw < 0 || iw >= p.W) { continue; }
-        acc = acc + X[xoff + ih*p.W + iw] * Wt[woff + r*p.kw + s];
+  invocations: (p) => Math.ceil(p.Cout / 2) * p.OH * Math.ceil(p.OW / 4),
+  body:`let nb = (p.OW + 3) / 4;
+  let nc = (p.Cout + 1) / 2;
+  if (idx >= nc*p.OH*nb) { return; }
+  let ob = idx % nb; let oh = (idx / nb) % p.OH; let oc = (idx / (nb*p.OH)) * 2;
+  let has2 = oc + 1 < p.Cout;
+  let ow0 = ob * 4;
+  // the oc+1 lane runs unconditionally when Cout is odd (its loads clamp
+  // in-bounds under WebGPU robustness) — only the final store is guarded
+  let oc1 = min(oc + 1, p.Cout - 1);
+  let bias0 = select(0.0, Bb[oc], p.hasB != 0);
+  let bias1 = select(0.0, Bb[oc1], p.hasB != 0);
+  var acc = vec4<f32>(bias0);
+  var acd = vec4<f32>(bias1);
+  if (p.kh == 3 && p.kw == 3 && p.sh == 1 && p.sw == 1 && ow0 + 3 < p.OW) {
+    let ih0 = oh - p.ph; let iw0 = ow0 - p.pw;
+    for (var ic = 0; ic < p.Cin; ic = ic + 1) {
+      let xoff = ic*p.H*p.W; let woff = ((oc*p.Cin) + ic)*9; let wof2 = woff + p.Cin*9;
+      for (var r = 0; r < 3; r = r + 1) {
+        let ih = ih0 + r;
+        if (ih < 0 || ih >= p.H) { continue; }
+        let ro = xoff + ih*p.W;
+        let w0 = Wt[woff + r*3]; let w1 = Wt[woff + r*3 + 1]; let w2 = Wt[woff + r*3 + 2];
+        let v0 = Wt[wof2 + r*3]; let v1 = Wt[wof2 + r*3 + 1]; let v2 = Wt[wof2 + r*3 + 2];
+        let x0 = select(0.0, X[ro + iw0    ], iw0     >= 0 && iw0     < p.W);
+        let x1 = select(0.0, X[ro + iw0 + 1], iw0 + 1 >= 0 && iw0 + 1 < p.W);
+        let x2 = select(0.0, X[ro + iw0 + 2], iw0 + 2 >= 0 && iw0 + 2 < p.W);
+        let x3 = select(0.0, X[ro + iw0 + 3], iw0 + 3 >= 0 && iw0 + 3 < p.W);
+        let x4 = select(0.0, X[ro + iw0 + 4], iw0 + 4 >= 0 && iw0 + 4 < p.W);
+        let x5 = select(0.0, X[ro + iw0 + 5], iw0 + 5 >= 0 && iw0 + 5 < p.W);
+        let a = vec4<f32>(x0,x1,x2,x3); let b = vec4<f32>(x1,x2,x3,x4); let c = vec4<f32>(x2,x3,x4,x5);
+        acc = acc + a*w0 + b*w1 + c*w2;
+        acd = acd + a*v0 + b*v1 + c*v2;
       }
     }
+  } else if (p.kh == 3 && p.kw == 3 && p.sh == 2 && p.sw == 2 && ow0 + 3 < p.OW) {
+    let ih0 = oh*2 - p.ph; let iw0 = ow0*2 - p.pw;
+    for (var ic = 0; ic < p.Cin; ic = ic + 1) {
+      let xoff = ic*p.H*p.W; let woff = ((oc*p.Cin) + ic)*9; let wof2 = woff + p.Cin*9;
+      for (var r = 0; r < 3; r = r + 1) {
+        let ih = ih0 + r;
+        if (ih < 0 || ih >= p.H) { continue; }
+        let ro = xoff + ih*p.W;
+        let w0 = Wt[woff + r*3]; let w1 = Wt[woff + r*3 + 1]; let w2 = Wt[woff + r*3 + 2];
+        let v0 = Wt[wof2 + r*3]; let v1 = Wt[wof2 + r*3 + 1]; let v2 = Wt[wof2 + r*3 + 2];
+        let x0 = select(0.0, X[ro + iw0    ], iw0     >= 0 && iw0     < p.W);
+        let x1 = select(0.0, X[ro + iw0 + 1], iw0 + 1 >= 0 && iw0 + 1 < p.W);
+        let x2 = select(0.0, X[ro + iw0 + 2], iw0 + 2 >= 0 && iw0 + 2 < p.W);
+        let x3 = select(0.0, X[ro + iw0 + 3], iw0 + 3 >= 0 && iw0 + 3 < p.W);
+        let x4 = select(0.0, X[ro + iw0 + 4], iw0 + 4 >= 0 && iw0 + 4 < p.W);
+        let x5 = select(0.0, X[ro + iw0 + 5], iw0 + 5 >= 0 && iw0 + 5 < p.W);
+        let x6 = select(0.0, X[ro + iw0 + 6], iw0 + 6 >= 0 && iw0 + 6 < p.W);
+        let x7 = select(0.0, X[ro + iw0 + 7], iw0 + 7 >= 0 && iw0 + 7 < p.W);
+        let x8 = select(0.0, X[ro + iw0 + 8], iw0 + 8 >= 0 && iw0 + 8 < p.W);
+        let a = vec4<f32>(x0,x2,x4,x6); let b = vec4<f32>(x1,x3,x5,x7); let c = vec4<f32>(x2,x4,x6,x8);
+        acc = acc + a*w0 + b*w1 + c*w2;
+        acd = acd + a*v0 + b*v1 + c*v2;
+      }
+    }
+  } else if (p.kh == 1 && p.kw == 1 && p.sh == 1 && p.sw == 1 && p.ph == 0 && p.pw == 0 && ow0 + 3 < p.OW) {
+    let ro0 = oh*p.W + ow0;
+    for (var ic = 0; ic < p.Cin; ic = ic + 1) {
+      let ro = ic*p.H*p.W + ro0;
+      let w = Wt[oc*p.Cin + ic]; let v = Wt[oc1*p.Cin + ic];
+      let a = vec4<f32>(X[ro], X[ro+1], X[ro+2], X[ro+3]);
+      acc = acc + a*w;
+      acd = acd + a*v;
+    }
+  } else {
+    for (var j = 0; j < 4; j = j + 1) {
+      let ow = ow0 + j;
+      if (ow >= p.OW) { break; }
+      var a0 = bias0; var a1 = bias1;
+      for (var ic = 0; ic < p.Cin; ic = ic + 1) {
+        let xoff = ic*p.H*p.W; let woff = ((oc*p.Cin) + ic)*p.kh*p.kw; let wof2 = woff + p.Cin*p.kh*p.kw;
+        for (var r = 0; r < p.kh; r = r + 1) {
+          let ih = oh*p.sh - p.ph + r;
+          if (ih < 0 || ih >= p.H) { continue; }
+          for (var s = 0; s < p.kw; s = s + 1) {
+            let iw = ow*p.sw - p.pw + s;
+            if (iw < 0 || iw >= p.W) { continue; }
+            let xv = X[xoff + ih*p.W + iw];
+            a0 = a0 + xv * Wt[woff + r*p.kw + s];
+            a1 = a1 + xv * Wt[wof2 + r*p.kw + s];
+          }
+        }
+      }
+      acc[j] = a0; acd[j] = a1;
+    }
   }
-  Y[(oc*p.OH + oh)*p.OW + ow] = acc;` },
+  let yb = (oc*p.OH + oh)*p.OW;
+  let yc = (oc1*p.OH + oh)*p.OW;
+  for (var j = 0; j < 4; j = j + 1) {
+    if (ow0 + j < p.OW) {
+      Y[yb + ow0 + j] = acc[j];
+      if (has2) { Y[yc + ow0 + j] = acd[j]; }
+    }
+  }` },
 convtranspose2d: { params:[["X","b"],["Wt","b"],["Bb","b"],["Y","w"],["Cin","i"],["H","i"],["W","i"],["Cout","i"],["kh","i"],["kw","i"],["OH","i"],["OW","i"],["ph","i"],["pw","i"],["sh","i"],["sw","i"],["hasB","i"]],
   body:`let total = p.Cout*p.OH*p.OW;
   if (idx >= total) { return; }
   let ox = idx % p.OW; let oy = (idx / p.OW) % p.OH; let oc = idx / (p.OW*p.OH);
   var acc = select(0.0, Bb[oc], p.hasB != 0);
+  if (p.kh == 2 && p.kw == 2 && p.sh == 2 && p.sw == 2 && p.ph == 0 && p.pw == 0) {
+    // k2s2p0 (the yolov8 mask-proto upsample): each output has exactly
+    // ONE contributing tap — (ky,kx) is the output parity, the generic
+    // scan's %-rejects all melt away (was the single slowest launch)
+    let iy = oy / 2; let ky = oy & 1; let ix = ox / 2; let kx = ox & 1;
+    let wo = ky*2 + kx;
+    for (var ic = 0; ic < p.Cin; ic = ic + 1) {
+      acc = acc + X[(ic*p.H + iy)*p.W + ix] * Wt[((ic*p.Cout)+oc)*4 + wo];
+    }
+    Y[(oc*p.OH + oy)*p.OW + ox] = acc;
+    return;
+  }
   for (var ic = 0; ic < p.Cin; ic = ic + 1) {
     let xoff = ic*p.H*p.W;
     for (var ky = 0; ky < p.kh; ky = ky + 1) {
@@ -209,3 +340,14 @@ export function buildWGSL(name) {
 }
 export function sig(name) { return K[name].params.map(([n,t]) => t).join(""); }
 export function scalarLayout(name) { return K[name].params.filter(([n,t]) => t === "i" || t === "f"); }
+// Invocation count for a launch. `total` is what the NURL side passes
+// (one thread per output element); a kernel that computes several
+// outputs per invocation overrides it with an `invocations` hook fed
+// the scalar args by name (scalarVals in param order, as numbers).
+export function dispatchInvocations(name, scalarVals, total) {
+  const k = K[name];
+  if (!k.invocations) return total;
+  const o = {}; let si = 0;
+  for (const [pn, t] of k.params) if (t === "i" || t === "f") o[pn] = scalarVals[si++];
+  return k.invocations(o);
+}

--- a/nurlapi/static/objdetdemo.html
+++ b/nurlapi/static/objdetdemo.html
@@ -187,7 +187,16 @@ async function boot() {
       $("stMs").textContent = ms;
       const now = performance.now(); if (lastT) { const inst = 1000 / (now - lastT); fpsEma = fpsEma ? fpsEma*0.8 + inst*0.2 : inst; $("stFps").textContent = fpsEma.toFixed(1); } lastT = now;
     },
-    host_status: (code) => { if (Number(code) === 2) msg.textContent = "running on your GPU"; },
+    host_status: (code) => {
+      if (Number(code) !== 2) return;
+      if (host.isFallback) {
+        msg.textContent = "⚠ software WebGPU adapter (" + host.describe() + ") — no GPU acceleration; enable Vulkan/GPU in the browser";
+        msg.style.color = "#f66";
+      } else {
+        const d = host.describe();
+        msg.textContent = "running on your GPU" + (d && d !== "GPU adapter" ? " — " + d : "");
+      }
+    },
   };
   const module = await WebAssembly.compile(wasm);
   const wasi = wasiShim(() => memory);

--- a/nurlapi/static/webgpu.js
+++ b/nurlapi/static/webgpu.js
@@ -18,10 +18,13 @@
 //
 // kernels_wgsl.js supplies the WGSL + arg signatures.
 
-import { K, buildWGSL, scalarLayout } from "./kernels_wgsl.js";
+import { K, buildWGSL, scalarLayout, dispatchInvocations } from "./kernels_wgsl.js";
 
 export async function makeWebGPUHost() {
-  const adapter = navigator.gpu && await navigator.gpu.requestAdapter();
+  // high-performance matters on multi-GPU machines: the default adapter
+  // can be the weakest device (observed: Deno/wgpu handing out a GTX 970
+  // while an RTX 4090 sat idle in the same box)
+  const adapter = navigator.gpu && await navigator.gpu.requestAdapter({ powerPreference: "high-performance" });
   const device = adapter && await adapter.requestDevice();
   const ok = !!device;
 
@@ -44,6 +47,42 @@ export async function makeWebGPUHost() {
   // so bind this 4-byte buffer — the kernel's guard never reads it.
   let dummyBuf = null;
   const nullBuf = () => (dummyBuf ||= device.createBuffer({ size: 4, usage: ST }));
+
+  // ── batched submission ──
+  // One queue.submit per kernel launch is the dominant cost in a browser
+  // (each submit is an IPC round-trip to the GPU process — a ~270-node
+  // net paid it ~270× per frame). Instead launches accumulate dispatches
+  // in ONE command encoder / compute pass, and flush() submits only when
+  // something must observe the results (download, or an upload that
+  // would otherwise be reordered before the encoded work — queue
+  // operations execute in queue order, so a writeBuffer issued while an
+  // encoder is still pending would land BEFORE those dispatches).
+  let enc = null, pass = null;
+  const deadBufs = [];            // wgpu_free'd while referenced by the pending encoder
+  function getPass() {
+    if (!enc) enc = device.createCommandEncoder();
+    if (!pass) pass = enc.beginComputePass();
+    return pass;
+  }
+  function endPass() { if (pass) { pass.end(); pass = null; } }
+  function flush() {
+    if (!enc) return;
+    endPass();
+    device.queue.submit([enc.finish()]);
+    enc = null;
+    for (const b of deadBufs) b.destroy();
+    deadBufs.length = 0;
+  }
+  // A model forward launches the same nodes with the same buffers and
+  // scalars every frame — cache the (bind group + uniform buffer) per
+  // (pipeline, buffer ids, scalar bytes), so steady-state frames create
+  // no GPU objects and write no uniforms at all.
+  const bgCache = new Map();      // key → { bg, uni, ids }
+  function dropCachedFor(bufId) {
+    for (const [k, e] of bgCache) {
+      if (e.ids.includes(bufId)) { e.uni.destroy(); bgCache.delete(k); }
+    }
+  }
 
   // ── asyncify state ──
   let stackBase = 0, stackSize = 0, stackInited = false;
@@ -80,18 +119,30 @@ export async function makeWebGPUHost() {
       buffers.set(id, b);
       return BigInt(id);
     },
-    wgpu_free: (id) => { const b = buffers.get(Number(id)); if (b) { b.destroy(); buffers.delete(Number(id)); } },
+    wgpu_free: (id) => {
+      const b = buffers.get(Number(id)); if (!b) return;
+      buffers.delete(Number(id));
+      dropCachedFor(Number(id));
+      // The pending encoder may still reference it in a bind group;
+      // destroying now would fail validation at submit. Defer to flush().
+      if (enc) deadBufs.push(b); else b.destroy();
+    },
     wgpu_upload: (id, hostPtr, bytes) => {
       const b = buffers.get(Number(id)); if (!b) return -1n;
+      // writeBuffer executes in queue order — flush pending dispatches so
+      // they read the buffer's OLD contents, not this write.
+      flush();
       const n = Number(bytes);
       device.queue.writeBuffer(b, 0, mem().slice(Number(hostPtr), Number(hostPtr) + n));
       return 0n;
     },
     wgpu_dtod: (dst, src, bytes) => {
       const d = buffers.get(Number(dst)), sb = buffers.get(Number(src)); if (!d || !sb) return -1n;
-      const enc = device.createCommandEncoder();
+      // Encode into the pending batch (copies can't live inside a compute
+      // pass, so end it; the next launch reopens one in the same encoder).
+      endPass();
+      if (!enc) enc = device.createCommandEncoder();
       enc.copyBufferToBuffer(sb, 0, d, 0, Number(bytes));
-      device.queue.submit([enc.finish()]);
       return 0n;
     },
     wgpu_launch: (pipeId, total, argsPtr, nargs) => {
@@ -106,30 +157,38 @@ export async function makeWebGPUHost() {
       const ub = new ArrayBuffer(Math.max(16, Math.ceil(scalars.length * 4 / 16) * 16));
       const ubI = new Int32Array(ub), ubF = new Float32Array(ub);
       let bufBinding = 0, scalarIdx = 0;
+      const ids = [], scalarVals = [];
       for (let i = 0; i < params.length; i++) {
         const [pn, t] = params[i];
         const lo = cellsLo[i * 2]; // low 32 bits of the i64 cell
         if (t === "b" || t === "w" || t === "q" || t === "Q") {
           const b = lo === 0 ? nullBuf() : buffers.get(lo);
           if (!b) return -2n;
+          ids.push(lo);
           storageEntries.push({ binding: bufBinding++, resource: { buffer: b } });
         } else if (t === "f") {
-          ubF[scalarIdx++] = new Float32Array(new Int32Array([lo]).buffer)[0];
+          const fv = new Float32Array(new Int32Array([lo]).buffer)[0];
+          ubF[scalarIdx++] = fv;
+          scalarVals.push(fv);
         } else {
           ubI[scalarIdx++] = lo;
+          scalarVals.push(lo);
         }
       }
-      const uni = device.createBuffer({ size: ub.byteLength, usage: UN });
-      device.queue.writeBuffer(uni, 0, ub);
-      storageEntries.push({ binding: bufBinding, resource: { buffer: uni } });
-      const bg = device.createBindGroup({ layout: entry.pipe.getBindGroupLayout(0), entries: storageEntries });
-      const enc = device.createCommandEncoder();
-      const pass = enc.beginComputePass();
-      pass.setPipeline(entry.pipe); pass.setBindGroup(0, bg);
-      const groups = Math.ceil(Number(total) / 64);
+      const key = pipeId + "|" + ids.join(",") + "|" + new Uint32Array(ub).join(",");
+      let ce = bgCache.get(key);
+      if (!ce) {
+        const uni = device.createBuffer({ size: ub.byteLength, usage: UN });
+        device.queue.writeBuffer(uni, 0, ub);
+        storageEntries.push({ binding: bufBinding, resource: { buffer: uni } });
+        ce = { bg: device.createBindGroup({ layout: entry.pipe.getBindGroupLayout(0), entries: storageEntries }), uni, ids };
+        bgCache.set(key, ce);
+      }
+      const p = getPass();
+      p.setPipeline(entry.pipe); p.setBindGroup(0, ce.bg);
+      const groups = Math.ceil(dispatchInvocations(name, scalarVals, Number(total)) / 64);
       const gx = Math.min(groups, 65535), gy = Math.ceil(groups / 65535);
-      pass.dispatchWorkgroups(gx, gy); pass.end();
-      device.queue.submit([enc.finish()]);
+      p.dispatchWorkgroups(gx, gy);
       return 0n;
     },
     // async readback → asyncify unwind/rewind
@@ -139,9 +198,12 @@ export async function makeWebGPUHost() {
       const b = buffers.get(Number(id)); if (!b) return -1n;
       const n = Number(bytes), hp = Number(hostPtr);
       const rb = device.createBuffer({ size: n, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
-      const enc = device.createCommandEncoder();
+      // Ride the pending batch: the readback copy is ordered after every
+      // encoded dispatch, and the whole frame goes up in ONE submit.
+      endPass();
+      if (!enc) enc = device.createCommandEncoder();
       enc.copyBufferToBuffer(b, 0, rb, 0, n);
-      device.queue.submit([enc.finish()]);
+      flush();
       asy.result = 0n;
       asy.pending = rb.mapAsync(GPUMapMode.READ).then(() => {
         mem().set(new Uint8Array(rb.getMappedRange().slice(0)), hp);
@@ -158,9 +220,21 @@ export async function makeWebGPUHost() {
     return new TextDecoder().decode(m.subarray(Number(ptr), e));
   }
 
+  const info = adapter ? (adapter.info || {}) : {};
   return {
     ok,
-    adapterInfo: adapter ? (adapter.info || {}) : {},
+    adapterInfo: info,
+    // A software adapter (Chrome's SwiftShader, Mesa's lavapipe) runs the
+    // shaders on the CPU — 20-50× slower than a real GPU. Surface it so a
+    // demo can warn instead of silently reading "running on your GPU".
+    isFallback: !!(adapter && (adapter.isFallbackAdapter ||
+      /swiftshader|llvmpipe|lavapipe|software|cpu/i.test(
+        (info.vendor || "") + " " + (info.architecture || "") + " " + (info.device || "") + " " + (info.description || "")))),
+    describe() {
+      if (!ok) return "no WebGPU";
+      const s = [info.vendor, info.architecture, info.description].filter(Boolean).join(" · ");
+      return s || "GPU adapter";
+    },
     imports,
     bind(instance) { memory = instance.exports.memory; exp = instance.exports; },
     // Wrap a host import so a synchronous NURL call suspends the module

--- a/nurlapi/tools/objdet_demo_test.mjs
+++ b/nurlapi/tools/objdet_demo_test.mjs
@@ -1,0 +1,87 @@
+// objdet_demo_test.mjs — drive nurlapi/static/objdet_detect.wasm the way
+// objdetdemo.html does (main thread, host.asyncImport for host_frame),
+// against Deno's headless WebGPU. 3 frames of the yoloe dog image.
+// Needs the tiny-yolov2 model:  OBJDET_MODEL=~/tinyyolov2-8.onnx
+//   deno run --unstable-webgpu --allow-read --allow-env --allow-run objdet_demo_test.mjs
+import { makeWebGPUHost } from "../static/webgpu.js";
+
+const N = 416, NCHW = 3 * N * N;
+const DIR = new URL(".", import.meta.url).pathname;
+const MODEL = Deno.env.get("OBJDET_MODEL") || Deno.env.get("HOME") + "/tinyyolov2-8.onnx";
+let model;
+try { model = await Deno.readFile(MODEL); }
+catch { console.log("SKIP: model not found (" + MODEL + ") — set OBJDET_MODEL"); Deno.exit(0); }
+const wasm = (await Deno.readFile(DIR + "../static/objdet_detect.wasm")).buffer;
+
+// dog image → 416×416 CHW 0-255 via PIL
+const rgb = new Uint8Array((new Deno.Command("python3", { args: ["-c", `
+from PIL import Image
+im=Image.open('${DIR}../../packages/yoloe/docs/demo.png').convert('RGB')
+s=min(416/im.width,416/im.height); im=im.resize((round(im.width*s),round(im.height*s)))
+bg=Image.new('RGB',(416,416)); bg.paste(im,((416-im.width)//2,(416-im.height)//2)); im=bg
+import sys; sys.stdout.buffer.write(im.tobytes())`], stdout: "piped", stderr: "piped" }).outputSync()).stdout);
+if (rgb.length !== N * N * 3) { console.log("image load failed", rgb.length); Deno.exit(1); }
+
+const host = await makeWebGPUHost();
+if (!host.ok) { console.log("SKIP: no WebGPU adapter"); Deno.exit(0); }
+console.log("adapter:", host.describe(), "fallback:", host.isFallback);
+
+let memory = null, running = true, frames = 0, t0 = 0;
+const times = [], results = [];
+const env = {
+  ...host.imports,
+  host_blob_size: (k) => BigInt(Number(k) === 0 ? model.length : 0),
+  host_blob_read: (k, dst) => { if (Number(k) === 0) new Uint8Array(memory.buffer).set(model, Number(dst)); return 0n; },
+  host_frame: host.asyncImport(async (nchwP, ctlP) => {
+    if (frames >= 3) return 9n;
+    await new Promise(r => setTimeout(r, 0));
+    new Int32Array(memory.buffer, Number(ctlP), 4)[0] = 250; // conf 25%
+    const dst = new Float32Array(memory.buffer, Number(nchwP), NCHW);
+    const plane = N * N;
+    for (let px = 0; px < plane; px++) {
+      dst[px] = rgb[px * 3]; dst[plane + px] = rgb[px * 3 + 1]; dst[2 * plane + px] = rgb[px * 3 + 2];
+    }
+    t0 = performance.now();
+    return 0n;
+  }),
+  host_result: (ptr, nd) => {
+    const ms = Math.round(performance.now() - t0);
+    const n = Number(nd), d = new Float32Array(memory.buffer, Number(ptr), n * 6);
+    const dets = [];
+    for (let k = 0; k < n; k++) dets.push({ cls: Math.round(d[k*6]), score: +d[k*6+1].toFixed(3) });
+    times.push(ms); results.push(dets); frames++;
+  },
+  host_status: () => {},
+};
+const module = await WebAssembly.compile(wasm);
+const td = new TextDecoder();
+const wasi = new Proxy({
+  fd_write: (fd, iovs, iovsLen, nwritten) => {
+    const v = new DataView(memory.buffer); let tot = 0, out = "";
+    for (let i = 0; i < iovsLen; i++) { const p = v.getUint32(iovs+i*8,true), l = v.getUint32(iovs+i*8+4,true); out += td.decode(new Uint8Array(memory.buffer, p, l)); tot += l; }
+    if (out.trim()) console.log("[wasm]", out.trim());
+    v.setUint32(nwritten, tot, true); return 0;
+  },
+  proc_exit: (c) => { const e = new Error("exit"); e.code = Number(c); throw e; },
+  random_get: (p, l) => { crypto.getRandomValues(new Uint8Array(memory.buffer, p, l)); return 0; },
+  clock_time_get: (id, prec, out) => { new DataView(memory.buffer).setBigUint64(out, BigInt(Math.round(performance.now()*1e6)), true); return 0; },
+  fd_prestat_get: () => 8, fd_prestat_dir_name: () => 8,
+  fd_fdstat_get: (fd, buf) => { new Uint8Array(memory.buffer).fill(0, buf, buf + 24); return 0; },
+  fd_fdstat_set_flags: () => 0, fd_close: () => 0, fd_read: () => 52, fd_seek: () => 52,
+  environ_sizes_get: (a, b) => { const v = new DataView(memory.buffer); v.setUint32(a,0,true); v.setUint32(b,0,true); return 0; },
+  environ_get: () => 0,
+  args_sizes_get: (a, b) => { const v = new DataView(memory.buffer); v.setUint32(a,0,true); v.setUint32(b,0,true); return 0; },
+  args_get: () => 0,
+}, { get: (t, k) => t[k] ?? (() => 52) });
+for (const imp of WebAssembly.Module.imports(module)) {
+  if (imp.module === "env" && !(imp.name in env)) env[imp.name] = () => { throw new Error("stub " + imp.name); };
+}
+const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi, env });
+memory = instance.exports.memory; host.bind(instance);
+try { await host.runWithAsyncify(() => instance.exports._start()); }
+catch (e) { if (!(typeof e.code === "number")) throw e; console.log("proc_exit code:", e.code); }
+const VOC = ["aeroplane","bicycle","bird","boat","bottle","bus","car","cat","chair","cow","diningtable","dog","horse","motorbike","person","pottedplant","sheep","sofa","train","tvmonitor"];
+const dogs = results.map(r => r.some(d => VOC[d.cls] === "dog" && d.score > 0.25));
+console.log("frames ms:", times.join(","), "dets:", JSON.stringify(results[results.length-1]));
+console.log(dogs.every(Boolean) && frames === 3 ? "PASS (dog on all frames)" : "FAIL");
+Deno.exit(dogs.every(Boolean) && frames === 3 ? 0 : 1);

--- a/packages/gpu/tests/wgsl_kernels_test.mjs
+++ b/packages/gpu/tests/wgsl_kernels_test.mjs
@@ -1,4 +1,4 @@
-import { K, buildWGSL, scalarLayout } from "../web/kernels_wgsl.js";
+import { K, buildWGSL, scalarLayout, dispatchInvocations } from "../web/kernels_wgsl.js";
 const adapter = navigator.gpu && await navigator.gpu.requestAdapter();
 if (!adapter) { console.log('no WebGPU adapter'); Deno.exit(2); }
 const device = await adapter.requestDevice();
@@ -28,7 +28,7 @@ async function run(name, storageArrays, scalarVals, outIdx, total) {
   const bg = device.createBindGroup({layout:pipe.getBindGroupLayout(0),entries});
   const enc = device.createCommandEncoder();
   const pass = enc.beginComputePass(); pass.setPipeline(pipe); pass.setBindGroup(0,bg);
-  const groups = Math.ceil(total/64); const gx = Math.min(groups,65535), gy = Math.ceil(groups/65535);
+  const groups = Math.ceil(dispatchInvocations(name, scalarVals, total)/64); const gx = Math.min(groups,65535), gy = Math.ceil(groups/65535);
   pass.dispatchWorkgroups(gx, gy); pass.end();
   const outLen = storageArrays[outIdx].length;
   const rb = device.createBuffer({size:outLen*4,usage:GPUBufferUsage.COPY_DST|GPUBufferUsage.MAP_READ});
@@ -83,6 +83,28 @@ async function check(name, storage, scalars, outIdx, total, ref) {
       for(let s=0;s<kw;s++){let iw=ow*sw-pw+s;if(iw<0||iw>=W)continue;acc+=X[(ic*H+ih)*W+iw]*Wt[((oc*Cin+ic)*kh+r)*kw+s];}}
     ref.push(acc);}
   await check("conv2d",[X,Wt,Bb,new Float32Array(Cout*OH*OW)],[Cin,H,W,Cout,kh,kw,OH,OW,ph,pw,sh,sw,1],3,Cout*OH*OW,ref); }
+// conv2d again for every specialized path in the 4-outputs-per-thread
+// kernel: k3s1 fast lane with OW not a multiple of 4 (tail lane), k3s2
+// fast lane, k1s1 lane, and a k5 shape that must take the generic lane.
+{ const convRef=(X,Wt,Bb,Cin,H,W,Cout,kh,kw,OH,OW,ph,pw,sh,sw)=>{const ref=[];
+    for(let oc=0;oc<Cout;oc++)for(let oh=0;oh<OH;oh++)for(let ow=0;ow<OW;ow++){let acc=Bb[oc];
+      for(let ic=0;ic<Cin;ic++)for(let r=0;r<kh;r++){let ih=oh*sh-ph+r;if(ih<0||ih>=H)continue;
+        for(let s=0;s<kw;s++){let iw=ow*sw-pw+s;if(iw<0||iw>=W)continue;acc+=X[(ic*H+ih)*W+iw]*Wt[((oc*Cin+ic)*kh+r)*kw+s];}}
+      ref.push(acc);}
+    return ref;};
+  const cases=[
+    ["conv k3s1 OW=7 tail", 3,6,7, 2, 3,3, 1,1, 1,1],
+    ["conv k3s2",           3,8,8, 2, 3,3, 1,1, 2,2],
+    ["conv k1s1",           4,6,8, 3, 1,1, 0,0, 1,1],
+    ["conv k5s1 generic",   2,9,9, 2, 5,5, 2,2, 1,1],
+  ];
+  for (const [label,Cin,H,W,Cout,kh,kw,ph,pw,sh,sw] of cases) {
+    const OH=Math.floor((H+2*ph-kh)/sh)+1, OW=Math.floor((W+2*pw-kw)/sw)+1;
+    const X=rnd(Cin*H*W),Wt=rnd(Cout*Cin*kh*kw),Bb=rnd(Cout);
+    const ref=convRef(X,Wt,Bb,Cin,H,W,Cout,kh,kw,OH,OW,ph,pw,sh,sw);
+    console.log(`  · ${label}`);
+    await check("conv2d",[X,Wt,Bb,new Float32Array(Cout*OH*OW)],[Cin,H,W,Cout,kh,kw,OH,OW,ph,pw,sh,sw,1],3,Cout*OH*OW,ref);
+  } }
 { // convtranspose2d 2ch 3x3, 2 out, 2x2 kernel stride2 pad0 → 6x6
   const Cin=2,H=3,W=3,Cout=2,kh=2,kw=2,sh=2,sw=2,ph=0,pw=0,OH=6,OW=6;
   const X=rnd(Cin*H*W),Wt=rnd(Cin*Cout*kh*kw),Bb=rnd(Cout); const ref=[];

--- a/packages/gpu/web/kernels_wgsl.js
+++ b/packages/gpu/web/kernels_wgsl.js
@@ -40,13 +40,46 @@ eltwise:   { params:[["X","b"],["B","b"],["Y","w"],["n","i"],["per","i"],["op","
   var r = 0.0;
   if (p.op == 0) { r = x*b; } else if (p.op == 1) { r = x+b; } else if (p.op == 2) { r = x-b; } else { r = x/b; }
   Y[idx] = r;` },
+// gemm with few outputs but a deep K (projection heads: M·N in the
+// hundreds, K in the thousands) leaves the GPU nearly idle at one
+// thread per output — so small results get a 64-lane workgroup per
+// output element, lanes strided over K, tree-reduced in workgroup
+// memory. The `invocations` hook and the body branch on the same
+// uniform predicate so dispatch and kernel agree.
 gemm:      { params:[["A","b"],["B","b"],["C","b"],["Y","w"],["M","i"],["N","i"],["K","i"],["alpha","f"],["beta","f"],["transB","i"],["hasC","i"]],
-  body:`if (idx < p.M*p.N) {
+  extra: "var<workgroup> gemm_part: array<f32, 64>;\n",
+  invocations: (p) => (p.M*p.N < 16384) ? p.M*p.N*64 : p.M*p.N,
+  body:`if (p.M*p.N < 16384) {
+    // padding workgroups (2D-dispatch rounding) redo the last output —
+    // identical value, benign write race
+    let out = min(idx / 64, p.M*p.N - 1);
+    let lane = idx % 64;
+    let r = out / p.N; let c = out % p.N;
+    var s = 0.0;
+    // transB branched OUTSIDE the loop: select() evaluates both operands,
+    // and the dead transposed load is a stride-K cache miss per iteration
+    if (p.transB != 0) {
+      for (var k = lane; k < p.K; k = k + 64) { s = s + A[r*p.K + k] * B[c*p.K + k]; }
+    } else {
+      for (var k = lane; k < p.K; k = k + 64) { s = s + A[r*p.K + k] * B[k*p.N + c]; }
+    }
+    gemm_part[lane] = s;
+    workgroupBarrier();
+    for (var w = 32; w > 0; w = w >> 1) {
+      if (lane < w) { gemm_part[lane] = gemm_part[lane] + gemm_part[lane + w]; }
+      workgroupBarrier();
+    }
+    if (lane == 0) {
+      let bias = select(0.0, C[c], p.hasC != 0);
+      Y[out] = p.alpha*gemm_part[0] + p.beta*bias;
+    }
+  } else if (idx < p.M*p.N) {
     let r = idx / p.N; let c = idx % p.N;
     var acc = 0.0;
-    for (var k = 0; k < p.K; k = k + 1) {
-      let bb = select(B[k*p.N + c], B[c*p.K + k], p.transB != 0);
-      acc = acc + A[r*p.K + k] * bb;
+    if (p.transB != 0) {
+      for (var k = 0; k < p.K; k = k + 1) { acc = acc + A[r*p.K + k] * B[c*p.K + k]; }
+    } else {
+      for (var k = 0; k < p.K; k = k + 1) { acc = acc + A[r*p.K + k] * B[k*p.N + c]; }
     }
     let bias = select(0.0, C[c], p.hasC != 0);
     Y[idx] = p.alpha*acc + p.beta*bias;
@@ -58,29 +91,127 @@ bmm:       { params:[["A","b"],["B","b"],["Y","w"],["batch","i"],["M","i"],["N",
   var acc = 0.0;
   for (var k = 0; k < p.K; k = k + 1) { acc = acc + A[aoff + r*p.K + k] * B[boff + k*p.N + c]; }
   Y[idx] = acc;` },
+// conv2d computes FOUR consecutive ow outputs per invocation (the
+// `invocations` hook sizes the dispatch): the 3×3 fast paths share the
+// overlapping input row across a vec4 accumulator (18 X-loads instead of
+// 36 for stride 1), and constant loop bounds let the compiler unroll —
+// the naive one-output-per-thread body ran at ~0.1% of a 4090's peak.
 conv2d:    { params:[["X","b"],["Wt","b"],["Bb","b"],["Y","w"],["Cin","i"],["H","i"],["W","i"],["Cout","i"],["kh","i"],["kw","i"],["OH","i"],["OW","i"],["ph","i"],["pw","i"],["sh","i"],["sw","i"],["hasB","i"]],
-  body:`let total = p.Cout*p.OH*p.OW;
-  if (idx >= total) { return; }
-  let ow = idx % p.OW; let oh = (idx / p.OW) % p.OH; let oc = idx / (p.OW*p.OH);
-  var acc = select(0.0, Bb[oc], p.hasB != 0);
-  for (var ic = 0; ic < p.Cin; ic = ic + 1) {
-    let xoff = ic*p.H*p.W; let woff = ((oc*p.Cin) + ic)*p.kh*p.kw;
-    for (var r = 0; r < p.kh; r = r + 1) {
-      let ih = oh*p.sh - p.ph + r;
-      if (ih < 0 || ih >= p.H) { continue; }
-      for (var s = 0; s < p.kw; s = s + 1) {
-        let iw = ow*p.sw - p.pw + s;
-        if (iw < 0 || iw >= p.W) { continue; }
-        acc = acc + X[xoff + ih*p.W + iw] * Wt[woff + r*p.kw + s];
+  invocations: (p) => Math.ceil(p.Cout / 2) * p.OH * Math.ceil(p.OW / 4),
+  body:`let nb = (p.OW + 3) / 4;
+  let nc = (p.Cout + 1) / 2;
+  if (idx >= nc*p.OH*nb) { return; }
+  let ob = idx % nb; let oh = (idx / nb) % p.OH; let oc = (idx / (nb*p.OH)) * 2;
+  let has2 = oc + 1 < p.Cout;
+  let ow0 = ob * 4;
+  // the oc+1 lane runs unconditionally when Cout is odd (its loads clamp
+  // in-bounds under WebGPU robustness) — only the final store is guarded
+  let oc1 = min(oc + 1, p.Cout - 1);
+  let bias0 = select(0.0, Bb[oc], p.hasB != 0);
+  let bias1 = select(0.0, Bb[oc1], p.hasB != 0);
+  var acc = vec4<f32>(bias0);
+  var acd = vec4<f32>(bias1);
+  if (p.kh == 3 && p.kw == 3 && p.sh == 1 && p.sw == 1 && ow0 + 3 < p.OW) {
+    let ih0 = oh - p.ph; let iw0 = ow0 - p.pw;
+    for (var ic = 0; ic < p.Cin; ic = ic + 1) {
+      let xoff = ic*p.H*p.W; let woff = ((oc*p.Cin) + ic)*9; let wof2 = woff + p.Cin*9;
+      for (var r = 0; r < 3; r = r + 1) {
+        let ih = ih0 + r;
+        if (ih < 0 || ih >= p.H) { continue; }
+        let ro = xoff + ih*p.W;
+        let w0 = Wt[woff + r*3]; let w1 = Wt[woff + r*3 + 1]; let w2 = Wt[woff + r*3 + 2];
+        let v0 = Wt[wof2 + r*3]; let v1 = Wt[wof2 + r*3 + 1]; let v2 = Wt[wof2 + r*3 + 2];
+        let x0 = select(0.0, X[ro + iw0    ], iw0     >= 0 && iw0     < p.W);
+        let x1 = select(0.0, X[ro + iw0 + 1], iw0 + 1 >= 0 && iw0 + 1 < p.W);
+        let x2 = select(0.0, X[ro + iw0 + 2], iw0 + 2 >= 0 && iw0 + 2 < p.W);
+        let x3 = select(0.0, X[ro + iw0 + 3], iw0 + 3 >= 0 && iw0 + 3 < p.W);
+        let x4 = select(0.0, X[ro + iw0 + 4], iw0 + 4 >= 0 && iw0 + 4 < p.W);
+        let x5 = select(0.0, X[ro + iw0 + 5], iw0 + 5 >= 0 && iw0 + 5 < p.W);
+        let a = vec4<f32>(x0,x1,x2,x3); let b = vec4<f32>(x1,x2,x3,x4); let c = vec4<f32>(x2,x3,x4,x5);
+        acc = acc + a*w0 + b*w1 + c*w2;
+        acd = acd + a*v0 + b*v1 + c*v2;
       }
     }
+  } else if (p.kh == 3 && p.kw == 3 && p.sh == 2 && p.sw == 2 && ow0 + 3 < p.OW) {
+    let ih0 = oh*2 - p.ph; let iw0 = ow0*2 - p.pw;
+    for (var ic = 0; ic < p.Cin; ic = ic + 1) {
+      let xoff = ic*p.H*p.W; let woff = ((oc*p.Cin) + ic)*9; let wof2 = woff + p.Cin*9;
+      for (var r = 0; r < 3; r = r + 1) {
+        let ih = ih0 + r;
+        if (ih < 0 || ih >= p.H) { continue; }
+        let ro = xoff + ih*p.W;
+        let w0 = Wt[woff + r*3]; let w1 = Wt[woff + r*3 + 1]; let w2 = Wt[woff + r*3 + 2];
+        let v0 = Wt[wof2 + r*3]; let v1 = Wt[wof2 + r*3 + 1]; let v2 = Wt[wof2 + r*3 + 2];
+        let x0 = select(0.0, X[ro + iw0    ], iw0     >= 0 && iw0     < p.W);
+        let x1 = select(0.0, X[ro + iw0 + 1], iw0 + 1 >= 0 && iw0 + 1 < p.W);
+        let x2 = select(0.0, X[ro + iw0 + 2], iw0 + 2 >= 0 && iw0 + 2 < p.W);
+        let x3 = select(0.0, X[ro + iw0 + 3], iw0 + 3 >= 0 && iw0 + 3 < p.W);
+        let x4 = select(0.0, X[ro + iw0 + 4], iw0 + 4 >= 0 && iw0 + 4 < p.W);
+        let x5 = select(0.0, X[ro + iw0 + 5], iw0 + 5 >= 0 && iw0 + 5 < p.W);
+        let x6 = select(0.0, X[ro + iw0 + 6], iw0 + 6 >= 0 && iw0 + 6 < p.W);
+        let x7 = select(0.0, X[ro + iw0 + 7], iw0 + 7 >= 0 && iw0 + 7 < p.W);
+        let x8 = select(0.0, X[ro + iw0 + 8], iw0 + 8 >= 0 && iw0 + 8 < p.W);
+        let a = vec4<f32>(x0,x2,x4,x6); let b = vec4<f32>(x1,x3,x5,x7); let c = vec4<f32>(x2,x4,x6,x8);
+        acc = acc + a*w0 + b*w1 + c*w2;
+        acd = acd + a*v0 + b*v1 + c*v2;
+      }
+    }
+  } else if (p.kh == 1 && p.kw == 1 && p.sh == 1 && p.sw == 1 && p.ph == 0 && p.pw == 0 && ow0 + 3 < p.OW) {
+    let ro0 = oh*p.W + ow0;
+    for (var ic = 0; ic < p.Cin; ic = ic + 1) {
+      let ro = ic*p.H*p.W + ro0;
+      let w = Wt[oc*p.Cin + ic]; let v = Wt[oc1*p.Cin + ic];
+      let a = vec4<f32>(X[ro], X[ro+1], X[ro+2], X[ro+3]);
+      acc = acc + a*w;
+      acd = acd + a*v;
+    }
+  } else {
+    for (var j = 0; j < 4; j = j + 1) {
+      let ow = ow0 + j;
+      if (ow >= p.OW) { break; }
+      var a0 = bias0; var a1 = bias1;
+      for (var ic = 0; ic < p.Cin; ic = ic + 1) {
+        let xoff = ic*p.H*p.W; let woff = ((oc*p.Cin) + ic)*p.kh*p.kw; let wof2 = woff + p.Cin*p.kh*p.kw;
+        for (var r = 0; r < p.kh; r = r + 1) {
+          let ih = oh*p.sh - p.ph + r;
+          if (ih < 0 || ih >= p.H) { continue; }
+          for (var s = 0; s < p.kw; s = s + 1) {
+            let iw = ow*p.sw - p.pw + s;
+            if (iw < 0 || iw >= p.W) { continue; }
+            let xv = X[xoff + ih*p.W + iw];
+            a0 = a0 + xv * Wt[woff + r*p.kw + s];
+            a1 = a1 + xv * Wt[wof2 + r*p.kw + s];
+          }
+        }
+      }
+      acc[j] = a0; acd[j] = a1;
+    }
   }
-  Y[(oc*p.OH + oh)*p.OW + ow] = acc;` },
+  let yb = (oc*p.OH + oh)*p.OW;
+  let yc = (oc1*p.OH + oh)*p.OW;
+  for (var j = 0; j < 4; j = j + 1) {
+    if (ow0 + j < p.OW) {
+      Y[yb + ow0 + j] = acc[j];
+      if (has2) { Y[yc + ow0 + j] = acd[j]; }
+    }
+  }` },
 convtranspose2d: { params:[["X","b"],["Wt","b"],["Bb","b"],["Y","w"],["Cin","i"],["H","i"],["W","i"],["Cout","i"],["kh","i"],["kw","i"],["OH","i"],["OW","i"],["ph","i"],["pw","i"],["sh","i"],["sw","i"],["hasB","i"]],
   body:`let total = p.Cout*p.OH*p.OW;
   if (idx >= total) { return; }
   let ox = idx % p.OW; let oy = (idx / p.OW) % p.OH; let oc = idx / (p.OW*p.OH);
   var acc = select(0.0, Bb[oc], p.hasB != 0);
+  if (p.kh == 2 && p.kw == 2 && p.sh == 2 && p.sw == 2 && p.ph == 0 && p.pw == 0) {
+    // k2s2p0 (the yolov8 mask-proto upsample): each output has exactly
+    // ONE contributing tap — (ky,kx) is the output parity, the generic
+    // scan's %-rejects all melt away (was the single slowest launch)
+    let iy = oy / 2; let ky = oy & 1; let ix = ox / 2; let kx = ox & 1;
+    let wo = ky*2 + kx;
+    for (var ic = 0; ic < p.Cin; ic = ic + 1) {
+      acc = acc + X[(ic*p.H + iy)*p.W + ix] * Wt[((ic*p.Cout)+oc)*4 + wo];
+    }
+    Y[(oc*p.OH + oy)*p.OW + ox] = acc;
+    return;
+  }
   for (var ic = 0; ic < p.Cin; ic = ic + 1) {
     let xoff = ic*p.H*p.W;
     for (var ky = 0; ky < p.kh; ky = ky + 1) {
@@ -209,3 +340,14 @@ export function buildWGSL(name) {
 }
 export function sig(name) { return K[name].params.map(([n,t]) => t).join(""); }
 export function scalarLayout(name) { return K[name].params.filter(([n,t]) => t === "i" || t === "f"); }
+// Invocation count for a launch. `total` is what the NURL side passes
+// (one thread per output element); a kernel that computes several
+// outputs per invocation overrides it with an `invocations` hook fed
+// the scalar args by name (scalarVals in param order, as numbers).
+export function dispatchInvocations(name, scalarVals, total) {
+  const k = K[name];
+  if (!k.invocations) return total;
+  const o = {}; let si = 0;
+  for (const [pn, t] of k.params) if (t === "i" || t === "f") o[pn] = scalarVals[si++];
+  return k.invocations(o);
+}

--- a/packages/gpu/web/webgpu.js
+++ b/packages/gpu/web/webgpu.js
@@ -18,10 +18,13 @@
 //
 // kernels_wgsl.js supplies the WGSL + arg signatures.
 
-import { K, buildWGSL, scalarLayout } from "./kernels_wgsl.js";
+import { K, buildWGSL, scalarLayout, dispatchInvocations } from "./kernels_wgsl.js";
 
 export async function makeWebGPUHost() {
-  const adapter = navigator.gpu && await navigator.gpu.requestAdapter();
+  // high-performance matters on multi-GPU machines: the default adapter
+  // can be the weakest device (observed: Deno/wgpu handing out a GTX 970
+  // while an RTX 4090 sat idle in the same box)
+  const adapter = navigator.gpu && await navigator.gpu.requestAdapter({ powerPreference: "high-performance" });
   const device = adapter && await adapter.requestDevice();
   const ok = !!device;
 
@@ -44,6 +47,42 @@ export async function makeWebGPUHost() {
   // so bind this 4-byte buffer — the kernel's guard never reads it.
   let dummyBuf = null;
   const nullBuf = () => (dummyBuf ||= device.createBuffer({ size: 4, usage: ST }));
+
+  // ── batched submission ──
+  // One queue.submit per kernel launch is the dominant cost in a browser
+  // (each submit is an IPC round-trip to the GPU process — a ~270-node
+  // net paid it ~270× per frame). Instead launches accumulate dispatches
+  // in ONE command encoder / compute pass, and flush() submits only when
+  // something must observe the results (download, or an upload that
+  // would otherwise be reordered before the encoded work — queue
+  // operations execute in queue order, so a writeBuffer issued while an
+  // encoder is still pending would land BEFORE those dispatches).
+  let enc = null, pass = null;
+  const deadBufs = [];            // wgpu_free'd while referenced by the pending encoder
+  function getPass() {
+    if (!enc) enc = device.createCommandEncoder();
+    if (!pass) pass = enc.beginComputePass();
+    return pass;
+  }
+  function endPass() { if (pass) { pass.end(); pass = null; } }
+  function flush() {
+    if (!enc) return;
+    endPass();
+    device.queue.submit([enc.finish()]);
+    enc = null;
+    for (const b of deadBufs) b.destroy();
+    deadBufs.length = 0;
+  }
+  // A model forward launches the same nodes with the same buffers and
+  // scalars every frame — cache the (bind group + uniform buffer) per
+  // (pipeline, buffer ids, scalar bytes), so steady-state frames create
+  // no GPU objects and write no uniforms at all.
+  const bgCache = new Map();      // key → { bg, uni, ids }
+  function dropCachedFor(bufId) {
+    for (const [k, e] of bgCache) {
+      if (e.ids.includes(bufId)) { e.uni.destroy(); bgCache.delete(k); }
+    }
+  }
 
   // ── asyncify state ──
   let stackBase = 0, stackSize = 0, stackInited = false;
@@ -80,18 +119,30 @@ export async function makeWebGPUHost() {
       buffers.set(id, b);
       return BigInt(id);
     },
-    wgpu_free: (id) => { const b = buffers.get(Number(id)); if (b) { b.destroy(); buffers.delete(Number(id)); } },
+    wgpu_free: (id) => {
+      const b = buffers.get(Number(id)); if (!b) return;
+      buffers.delete(Number(id));
+      dropCachedFor(Number(id));
+      // The pending encoder may still reference it in a bind group;
+      // destroying now would fail validation at submit. Defer to flush().
+      if (enc) deadBufs.push(b); else b.destroy();
+    },
     wgpu_upload: (id, hostPtr, bytes) => {
       const b = buffers.get(Number(id)); if (!b) return -1n;
+      // writeBuffer executes in queue order — flush pending dispatches so
+      // they read the buffer's OLD contents, not this write.
+      flush();
       const n = Number(bytes);
       device.queue.writeBuffer(b, 0, mem().slice(Number(hostPtr), Number(hostPtr) + n));
       return 0n;
     },
     wgpu_dtod: (dst, src, bytes) => {
       const d = buffers.get(Number(dst)), sb = buffers.get(Number(src)); if (!d || !sb) return -1n;
-      const enc = device.createCommandEncoder();
+      // Encode into the pending batch (copies can't live inside a compute
+      // pass, so end it; the next launch reopens one in the same encoder).
+      endPass();
+      if (!enc) enc = device.createCommandEncoder();
       enc.copyBufferToBuffer(sb, 0, d, 0, Number(bytes));
-      device.queue.submit([enc.finish()]);
       return 0n;
     },
     wgpu_launch: (pipeId, total, argsPtr, nargs) => {
@@ -106,30 +157,38 @@ export async function makeWebGPUHost() {
       const ub = new ArrayBuffer(Math.max(16, Math.ceil(scalars.length * 4 / 16) * 16));
       const ubI = new Int32Array(ub), ubF = new Float32Array(ub);
       let bufBinding = 0, scalarIdx = 0;
+      const ids = [], scalarVals = [];
       for (let i = 0; i < params.length; i++) {
         const [pn, t] = params[i];
         const lo = cellsLo[i * 2]; // low 32 bits of the i64 cell
         if (t === "b" || t === "w" || t === "q" || t === "Q") {
           const b = lo === 0 ? nullBuf() : buffers.get(lo);
           if (!b) return -2n;
+          ids.push(lo);
           storageEntries.push({ binding: bufBinding++, resource: { buffer: b } });
         } else if (t === "f") {
-          ubF[scalarIdx++] = new Float32Array(new Int32Array([lo]).buffer)[0];
+          const fv = new Float32Array(new Int32Array([lo]).buffer)[0];
+          ubF[scalarIdx++] = fv;
+          scalarVals.push(fv);
         } else {
           ubI[scalarIdx++] = lo;
+          scalarVals.push(lo);
         }
       }
-      const uni = device.createBuffer({ size: ub.byteLength, usage: UN });
-      device.queue.writeBuffer(uni, 0, ub);
-      storageEntries.push({ binding: bufBinding, resource: { buffer: uni } });
-      const bg = device.createBindGroup({ layout: entry.pipe.getBindGroupLayout(0), entries: storageEntries });
-      const enc = device.createCommandEncoder();
-      const pass = enc.beginComputePass();
-      pass.setPipeline(entry.pipe); pass.setBindGroup(0, bg);
-      const groups = Math.ceil(Number(total) / 64);
+      const key = pipeId + "|" + ids.join(",") + "|" + new Uint32Array(ub).join(",");
+      let ce = bgCache.get(key);
+      if (!ce) {
+        const uni = device.createBuffer({ size: ub.byteLength, usage: UN });
+        device.queue.writeBuffer(uni, 0, ub);
+        storageEntries.push({ binding: bufBinding, resource: { buffer: uni } });
+        ce = { bg: device.createBindGroup({ layout: entry.pipe.getBindGroupLayout(0), entries: storageEntries }), uni, ids };
+        bgCache.set(key, ce);
+      }
+      const p = getPass();
+      p.setPipeline(entry.pipe); p.setBindGroup(0, ce.bg);
+      const groups = Math.ceil(dispatchInvocations(name, scalarVals, Number(total)) / 64);
       const gx = Math.min(groups, 65535), gy = Math.ceil(groups / 65535);
-      pass.dispatchWorkgroups(gx, gy); pass.end();
-      device.queue.submit([enc.finish()]);
+      p.dispatchWorkgroups(gx, gy);
       return 0n;
     },
     // async readback → asyncify unwind/rewind
@@ -139,9 +198,12 @@ export async function makeWebGPUHost() {
       const b = buffers.get(Number(id)); if (!b) return -1n;
       const n = Number(bytes), hp = Number(hostPtr);
       const rb = device.createBuffer({ size: n, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
-      const enc = device.createCommandEncoder();
+      // Ride the pending batch: the readback copy is ordered after every
+      // encoded dispatch, and the whole frame goes up in ONE submit.
+      endPass();
+      if (!enc) enc = device.createCommandEncoder();
       enc.copyBufferToBuffer(b, 0, rb, 0, n);
-      device.queue.submit([enc.finish()]);
+      flush();
       asy.result = 0n;
       asy.pending = rb.mapAsync(GPUMapMode.READ).then(() => {
         mem().set(new Uint8Array(rb.getMappedRange().slice(0)), hp);
@@ -158,9 +220,21 @@ export async function makeWebGPUHost() {
     return new TextDecoder().decode(m.subarray(Number(ptr), e));
   }
 
+  const info = adapter ? (adapter.info || {}) : {};
   return {
     ok,
-    adapterInfo: adapter ? (adapter.info || {}) : {},
+    adapterInfo: info,
+    // A software adapter (Chrome's SwiftShader, Mesa's lavapipe) runs the
+    // shaders on the CPU — 20-50× slower than a real GPU. Surface it so a
+    // demo can warn instead of silently reading "running on your GPU".
+    isFallback: !!(adapter && (adapter.isFallbackAdapter ||
+      /swiftshader|llvmpipe|lavapipe|software|cpu/i.test(
+        (info.vendor || "") + " " + (info.architecture || "") + " " + (info.device || "") + " " + (info.description || "")))),
+    describe() {
+      if (!ok) return "no WebGPU";
+      const s = [info.vendor, info.architecture, info.description].filter(Boolean).join(" · ");
+      return s || "GPU adapter";
+    },
     imports,
     bind(instance) { memory = instance.exports.memory; exp = instance.exports; },
     // Wrap a host import so a synchronous NURL call suspends the module

--- a/packages/yoloe-demo/views/index.html
+++ b/packages/yoloe-demo/views/index.html
@@ -369,7 +369,8 @@ const wasmEng = {
     await new Promise((resolve, reject) => {
       this.worker.onmessage = (e) => {
         const m = e.data;
-        if (m.type === "status" && m.code === 2) { resolve(); }
+        if (m.type === "ready") { this.gpuDesc = m.gpu; this.gpuFallback = m.fallback; }
+        else if (m.type === "status" && m.code === 2) { resolve(); }
         else if (m.type === "status" && m.code < 0) { reject(new Error("engine init failed (" + m.extra + ")")); }
         else if (m.type === "error") { reject(new Error(m.message)); }
         else if (m.type === "log") { console.log("[wasm]", m.line); }
@@ -378,7 +379,14 @@ const wasmEng = {
     });
     this.worker.onmessage = (e) => this._onmsg(e.data);
     this.state = "ready";
-    wmsg((this.engine === "webgpu" ? "WebGPU" : "wasm") + " engine ready — " + this.names.length + " classes");
+    if (this.engine === "webgpu") {
+      const gpu = this.gpuDesc && this.gpuDesc !== "GPU adapter" ? " on " + this.gpuDesc : "";
+      wmsg(this.gpuFallback
+        ? "⚠ WebGPU is using a SOFTWARE adapter (" + (this.gpuDesc || "cpu") + ") — expect it to be slow; enable GPU/Vulkan in the browser"
+        : "WebGPU engine ready" + gpu + " — " + this.names.length + " classes");
+    } else {
+      wmsg("wasm engine ready — " + this.names.length + " classes");
+    }
   },
   stop() {
     if (this.worker) { this.worker.terminate(); this.worker = null; }
@@ -491,7 +499,9 @@ async function wasmStep() {
   }
   drawOverlay(dets);
   updateStats(res.ms, rtt, res.n, dets);
-  wmsg("wasm: " + (res.ms / 1000).toFixed(1) + " s/frame — pure NURL in this tab");
+  wmsg(wasmEng.engine === "webgpu"
+    ? "WebGPU: " + res.ms + " ms/frame" + (wasmEng.gpuFallback ? " — ⚠ software adapter" : "") + " — pure NURL in this tab"
+    : "wasm: " + (res.ms / 1000).toFixed(1) + " s/frame — pure NURL in this tab");
 }
 
 function chipName(cls) {

--- a/packages/yoloe-demo/web/worker.js
+++ b/packages/yoloe-demo/web/worker.js
@@ -179,7 +179,7 @@ onmessage = async (e) => {
     });
     memory = instance.exports.memory;
     gpuHost.bind(instance);
-    postMessage({ type: 'ready' });
+    postMessage({ type: 'ready', gpu: gpuHost.describe(), fallback: gpuHost.isFallback });
     try {
       // runWithAsyncify drives the WebGPU async readback (unwind/await/
       // rewind); for the static-CPU path nothing unwinds and it is just


### PR DESCRIPTION
## Why

The playground objdet demo reported **23 s/frame** (screenshot report). Two separate causes surfaced:

1. **The user's browser was almost certainly on a software WebGPU adapter** (Chrome-on-Linux SwiftShader): 23 s matches the wasm-CPU engine's 24 s almost exactly — and the page happily said *"running on your GPU"*. Nothing surfaced the adapter identity.
2. **The WebGPU backend itself was far off what the hardware can do** — ~66 GFLOPS on a card with an 82 TFLOP peak, plus one `queue.submit` (an IPC round-trip in browsers) per kernel launch, ~380 per yoloe frame.

## What

**Host (`packages/gpu/web/webgpu.js`)**
- Batched submission: launches accumulate in one command encoder/compute pass; flush only at download (or an upload whose queue-ordered write would otherwise reorder before the encoded work). ~380 submits/frame → ~1.
- Bind-group + uniform cache keyed by (pipeline, buffer ids, scalar bytes) — a forward launches identical nodes every frame; steady-state frames now create zero GPU objects. Also fixes a per-launch uniform-buffer leak.
- `requestAdapter({powerPreference:"high-performance"})` + the host exposes `describe()`/`isFallback` (SwiftShader/lavapipe detection).

**Kernels (`packages/gpu/web/kernels_wgsl.js`)**
- `conv2d`: 4 ow × 2 oc outputs per invocation, constant-unrolled k3s1/k3s2/k1s1 lanes sharing X loads across vec4 accumulators — 66 → 269 GFLOPS avg on the yolov8s shape mix (**4×**). New per-kernel `invocations` hook lets a kernel size its own dispatch (NURL/onnx side untouched).
- `convtranspose2d` k2s2p0 (yolov8 mask-proto upsample, the single slowest launch): each output has exactly one contributing tap, decoded from output parity — **84 → 7.8 ms**.
- `gemm`: `select(B[k*N+c], B[c*K+k], transB)` evaluated **both** operands — every iteration issued the dead transposed stride-K load (53 ms for one 32×6400×512 gemm). Branch hoisted; small-M·N gemms also get a 64-lane workgroup-reduction per output.

**Demos**
- `objdetdemo.html` + yoloe-demo page/worker now display the adapter and a loud ⚠ warning on a software adapter instead of claiming GPU execution.
- New `nurlapi/tools/objdet_demo_test.mjs`: drives the shipped `objdet_detect.wasm` main-thread against Deno's headless WebGPU (3 frames, detections asserted).

## Measured (Deno headless WebGPU, same adapter)

| net | before | after |
|---|---|---|
| yoloe-seg 640 frame | 1129 ms | **~490 ms** |
| objdet tiny-yolov2 416 frame | 194 ms | **~117 ms** |
| conv2d yolov8s shape mix | 175 ms | **43 ms** |

Detections are bit-identical to the old kernels (A/B on the same image). Real-GPU browsers additionally shed the submit-IPC tax that Deno never paid, so the browser-side win should exceed these numbers.

## Local testing

`packages/yoloe-demo` already has the engine selector (server / wasm CPU / **WebGPU in this tab**) — run the demo server locally and pick WebGPU; the page now shows which adapter the browser actually handed over.

## Tests

- 25/25 WGSL kernel tests — incl. new conv2d edge lanes (k3s1 OW-tail, k3s2, k1s1, k5 generic, odd Cout)
- 4/4 WGSL int64
- yoloe-demo worker test: webgpu **and** static engines PASS (dog detected)
- objdet demo test: 3 frames PASS, detections identical to pre-change kernels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7