### PR TITLE
packages: version bumps + fix stale dep ranges that break registry installs

### DIFF
--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,12 +1,12 @@
 [package]
 name = "anomaly"
-version = "0.3.3"
+version = "0.3.4"
 description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working. `anomaly serve` also ships a self-contained web dashboard (model manager, trainer, feature visualiser and anomaly scanner — plain HTML/JS, no CDN or build step) served straight from the binary's web root."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 iforest = { path = "../iforest", version = "^0.1" }
-gpu = { path = "../gpu", version = "^0.3" }
+gpu = { path = "../gpu", version = "^0.4" }
 http = { path = "../http", version = "^0.1" }
 cli = { path = "../cli", version = "^0.1" }
 gpukit = { path = "../gpukit", version = "^0.2" }

--- a/packages/gpu/nurl.toml
+++ b/packages/gpu/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpu"
-version = "0.4.0"
+version = "0.4.1"
 description = "GPU compute for NURL — a backend-neutral interface (Gpu / GpuKernel / GpuBuffer: open, compile, alloc, upload/download, launch, sync) with two backends: CUDA and CPU. The CUDA backend writes kernels in CUDA-C, compiles them to PTX at runtime via NVRTC, and runs them through the CUDA Driver API — bound directly from pure NURL with no runtime.c bridge. The CPU backend (v0.2.0) runs the very same CUDA-C kernels on the host: each is wrapped in a small CUDA-compatibility shim (blockIdx/threadIdx as thread-locals, __global__ etc. as no-op macros) plus a generated grid-loop, compiled by the system C++ compiler, dlopen'd, and run with OpenMP parallelising the grid across cores — so an onnx/YOLOE model runs with no GPU at all. gpu_open selects CUDA when a device is available, else falls back to CPU; NURL_GPU=cpu forces it. The neutral surface is unchanged, so callers (packages/onnx, objdet, yoloe) get CPU fallback for free. The toolchain auto-links -lcuda / -lnvrtc only when a program references those symbols; the CPU backend needs only a C++ compiler on PATH (the analogue of NVRTC). Verified: the tiny MLP and the full 267-node YOLOE-seg forward produce identical results on CPU and GPU."
 license = "MIT OR Apache-2.0"
 

--- a/packages/gpukit/nurl.toml
+++ b/packages/gpukit/nurl.toml
@@ -1,8 +1,8 @@
 [package]
 name = "gpukit"
-version = "0.3.1"
+version = "0.3.2"
 description = "The ergonomic GPU-compute toolkit for NURL — a diamond facade over the `gpu` package that kills the marshalling boilerplate every GPU-using package re-invents. Where `gpu` is the low-level interface (open a device, JIT-compile a CUDA-C kernel via NVRTC or the host-C++ CPU backend, allocate/upload/download device buffers, build the argument vector, compute a grid, launch, sync, free), `gpukit` collapses the ~35 lines of that dance per kernel into a list of typed bindings and one `gk_run`: a GpuKit with a per-name kernel cache, `gk_in_f`/`gk_in_i`/`gk_out_f`/`gk_out_i` (and raw-buffer + i32/i64/f32 scalar) bindings, and a workhorse that compiles-once, allocates a device buffer per binding, uploads inputs, marshals args in declaration order, launches, syncs, downloads outputs, and frees everything. Ships a library of ready-made f64 kernels — elementwise add/sub/mul/div, a source-baked unary map, a bit-identical matmul, and reduce-sum / dot — so ML code never writes a kernel or a device buffer for the common cases. Adds no numerics of its own: a kernel runs bit-for-bit the same through gk_run as through hand-written gpu_* calls, preserving the gpu package's CUDA / CPU-backend / pure equivalence. Runs on the CPU backend when no CUDA device is present."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-gpu = { path = "../gpu", version = "^0.3" }
+gpu = { path = "../gpu", version = "^0.4" }

--- a/packages/objdet/nurl.toml
+++ b/packages/objdet/nurl.toml
@@ -1,9 +1,9 @@
 [package]
 name = "objdet"
-version = "0.3.0"
+version = "0.3.1"
 description = "Object detection from pure NURL, GPU-accelerated, using any tiny-YOLOv2-style ONNX model. Reads an image natively in any format the image package decodes (PNG, baseline+progressive JPEG, PPM) or a sequence of video frames (binary PPM), runs the detector on the GPU through the onnx package (every Conv/BatchNorm/MaxPool/LeakyRelu kernel compiled to PTX at runtime via NVRTC, no external inference engine), decodes the YOLO grid into labelled boxes (anchors, sigmoid/softmax, non-max suppression), prints the detections, and writes an annotated image. Verified against onnxruntime on the ONNX model-zoo tinyyolov2-8.onnx: identical class scores and boxes (dog 0.76, car 0.76 on the classic dog photo). Pure NURL end to end — protobuf parsing, the CNN, image I/O, decoding, and drawing; the only native dependency (the CUDA driver + NVRTC) lives in the gpu package, so a GPU-less host is unaffected. Image codecs and raster ops come from the image package; ffmpeg only for video-frame extraction."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-onnx = { path = "../onnx", version = "^0.4.2" }
+onnx = { path = "../onnx", version = "^0.6" }
 image = { path = "../image", version = "^0.4" }

--- a/packages/yoloe-demo/nurl.toml
+++ b/packages/yoloe-demo/nurl.toml
@@ -1,13 +1,13 @@
 [package]
 name = "yoloe-demo"
-version = "0.1.0"
+version = "0.2.0"
 description = "Live YOLOE in the browser, served by pure NURL — open your webcam on a web page and watch open-vocabulary detection + instance segmentation stream back at you. The browser posts JPEG frames to a NURL HTTP(S) server; every frame runs through the onnx package on the GPU (each layer a CUDA-C kernel compiled at runtime via NVRTC), the segmentation masks are composited onto the frame, and the masked JPEG + a JSON detection list come back — the page draws boxes/labels on top and loops. Interactive: toggle prompted classes, drag the confidence slider, flip masks on/off, or drop a still image. --tls generates a self-signed P-256 certificate at startup (std/x509_gen) so the camera also works from other machines on the LAN (getUserMedia needs a secure origin). Everything in the path is NURL: the HTTP/TLS server (http package), the page template (template package), the JPEG/PNG codecs (image package), the ONNX runtime (onnx package) and the YOLOE decode/mask stages (yoloe package). No Python, no OpenCV, no inference engine, no web framework."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl-lang"
 
 [dependencies]
 yoloe = { path = "../yoloe", version = "^0.6" }
-onnx = { path = "../onnx", version = "^0.5" }
+onnx = { path = "../onnx", version = "^0.6" }
 image = { path = "../image", version = "^0.4" }
 http = { path = "../http", version = "^0.1" }
 template = { path = "../template", version = "^0.1" }

--- a/packages/yoloe/nurl.toml
+++ b/packages/yoloe/nurl.toml
@@ -1,10 +1,10 @@
 [package]
 name = "yoloe"
-version = "0.6.0"
+version = "0.6.1"
 description = "Promptable, open-vocabulary object detection AND instance segmentation from pure NURL on the GPU — a NURL port of YOLOE (THU-MIG, 'Real-Time Seeing Anything', ICCV 2025), including live masking straight off a webcam. You name the classes you want ('dog', 'bicycle', 'a person on a bike') and the model finds them — drawing both boxes and per-object segmentation masks — without a fixed label set. The whole network runs on the GPU through the onnx package (every layer a CUDA-C kernel compiled at runtime via NVRTC — no external inference engine), including the YOLOE-seg mask-prototype branch (ConvTranspose 2× upsample) and the mask decode (coefficients · prototypes → threshold → overlay), all verified numerically against onnxruntime (proto max abs err ~6e-5). Promptability comes from YOLOE's region-text contrastive head, which scores each region's visual embedding against the text embeddings of the prompt words, with the MobileCLIP text path also in pure NURL. The webcam feed is captured in pure NURL via Video4Linux2 (open/ioctl/mmap, YUYV→RGB) — no ffmpeg, no OpenCV. Requires the NVIDIA driver + NVRTC (via the gpu package); a GPU-less host is unaffected."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-onnx = { path = "../onnx", version = "^0.4.2" }
+onnx = { path = "../onnx", version = "^0.6" }
 image = { path = "../image", version = "^0.4" }
 cli = { path = "../cli", version = "^0.2" }


### PR DESCRIPTION
## Why

`packages/yoloe-demo` was still 0.1.0 after PR #400 — and auditing the version bump surfaced a real ecosystem bug: **several dep ranges lag the published versions**, so registry installs resolve stale (or unsatisfiable) trees that local path-deps mask:

- `yoloe` / `objdet` pin `onnx ^0.4.2` → a registry install resolves onnx **0.4.x** (caret on 0.x locks the minor), missing the ops their current code needs (rt_slice, rt_argmax, int64 initializers, static kernels).
- `yoloe-demo` pins `onnx ^0.5`.
- `gpukit` / `anomaly` pin `gpu ^0.3` while `onnx 0.6` requires `gpu ^0.4` → the tree `onnx → tensor → gpukit → gpu` can't satisfy both ranges in one install.

## What

| package | version | range fix |
|---|---|---|
| gpu | 0.4.0 → **0.4.1** | — (ships PR #400's faster WebGPU host in `web/`) |
| gpukit | 0.3.1 → **0.3.2** | gpu `^0.3` → `^0.4` |
| anomaly | 0.3.3 → **0.3.4** | gpu `^0.3` → `^0.4` |
| yoloe | 0.6.0 → **0.6.1** | onnx `^0.4.2` → `^0.6` |
| objdet | 0.3.0 → **0.3.1** | onnx `^0.4.2` → `^0.6` |
| yoloe-demo | 0.1.0 → **0.2.0** | onnx `^0.5` → `^0.6` |

yoloe-demo gets a minor (not patch): 0.2.0 carries the WebGPU adapter reporting, per-frame ms display and the software-adapter warning from PR #400.

After merge these six get published to reg.nurl-lang.org so the registry matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7