### PR TITLE
installers: stop wiping registry credentials on reinstall

### DIFF
--- a/tools/get-nurl.ps1
+++ b/tools/get-nurl.ps1
@@ -57,8 +57,18 @@ try {
     }
 
     # ── Unpack (archive has a top-level nurl\ dir) ─────────────────────
+    # Remove only the entries the toolchain owns (the list
+    # tools\install-toolchain.bat manages) — $Prefix also holds user data
+    # that must survive a reinstall, e.g. the nurlpkg publish token in
+    # $Prefix\credentials. Wiping the whole prefix silently logged users
+    # out of the registry on every upgrade.
     Write-Host "installing to $Prefix..."
-    if (Test-Path $Prefix) { Remove-Item -Recurse -Force $Prefix }
+    if (Test-Path $Prefix) {
+        foreach ($entry in @("bin", "build", "stdlib", "zig", "nurl.sh", "env")) {
+            $owned = Join-Path $Prefix $entry
+            if (Test-Path $owned) { Remove-Item -Recurse -Force $owned }
+        }
+    }
     New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
     $unzipTmp = Join-Path $tmp "x"
     Expand-Archive -Path $zip -DestinationPath $unzipTmp -Force

--- a/tools/get-nurl.sh
+++ b/tools/get-nurl.sh
@@ -113,8 +113,15 @@ else
 fi
 
 # ── Unpack (the archive has a top-level nurl/ dir) ─────────────────────
+# Remove only the entries the toolchain owns (the same list
+# tools/install-toolchain.sh manages) — $PREFIX also holds user data
+# that must survive a reinstall, e.g. the nurlpkg publish token in
+# $PREFIX/credentials. `rm -rf $PREFIX` here used to silently log
+# users out of the registry on every upgrade.
 info "installing to $PREFIX…"
-rm -rf "$PREFIX"
+for entry in bin build stdlib zig nurl.sh env; do
+    rm -rf "${PREFIX:?}/$entry"
+done
 mkdir -p "$PREFIX"
 tar xzf "$tmp/$archive" -C "$PREFIX" --strip-components=1
 


### PR DESCRIPTION
## Bug

`tools/get-nurl.sh` ran `rm -rf "$PREFIX"` (and `get-nurl.ps1` the equivalent whole-prefix `Remove-Item`) before unpacking. `$NURL_HOME` also holds **user data** — the nurlpkg publish token in `$PREFIX/credentials` — so every toolchain upgrade silently logged the user out of the registry. Bitten for real: today's v0.11.1 install ate the publish token minutes before a publish run.

## Fix

Both front-door installers now remove only the entries the toolchain owns — `bin build stdlib zig nurl.sh env` — the same list `install-toolchain.sh` / `.bat` already manage selectively. Anything else in the prefix (credentials, future user state) survives.

## Verified (real v0.11.1 archive)

- Reinstall over a prefix containing `credentials` + an old `bin/nurl` → token byte-identical after, toolchain replaced, `nurlc --version` → `v0.11.1`
- Fresh install into a nonexistent prefix → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7