### PR TITLE
packages: yoloe 0.6.2, yoloe-demo 0.2.1 — republish with the embedded merges

### DIFF
--- a/packages/yoloe-demo/nurl.toml
+++ b/packages/yoloe-demo/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoloe-demo"
-version = "0.2.0"
+version = "0.2.1"
 description = "Live YOLOE in the browser, served by pure NURL — open your webcam on a web page and watch open-vocabulary detection + instance segmentation stream back at you. The browser posts JPEG frames to a NURL HTTP(S) server; every frame runs through the onnx package on the GPU (each layer a CUDA-C kernel compiled at runtime via NVRTC), the segmentation masks are composited onto the frame, and the masked JPEG + a JSON detection list come back — the page draws boxes/labels on top and loops. Interactive: toggle prompted classes, drag the confidence slider, flip masks on/off, or drop a still image. --tls generates a self-signed P-256 certificate at startup (std/x509_gen) so the camera also works from other machines on the LAN (getUserMedia needs a secure origin). Everything in the path is NURL: the HTTP/TLS server (http package), the page template (template package), the JPEG/PNG codecs (image package), the ONNX runtime (onnx package) and the YOLOE decode/mask stages (yoloe package). No Python, no OpenCV, no inference engine, no web framework."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl-lang"

--- a/packages/yoloe/nurl.toml
+++ b/packages/yoloe/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoloe"
-version = "0.6.1"
+version = "0.6.2"
 description = "Promptable, open-vocabulary object detection AND instance segmentation from pure NURL on the GPU — a NURL port of YOLOE (THU-MIG, 'Real-Time Seeing Anything', ICCV 2025), including live masking straight off a webcam. You name the classes you want ('dog', 'bicycle', 'a person on a bike') and the model finds them — drawing both boxes and per-object segmentation masks — without a fixed label set. The whole network runs on the GPU through the onnx package (every layer a CUDA-C kernel compiled at runtime via NVRTC — no external inference engine), including the YOLOE-seg mask-prototype branch (ConvTranspose 2× upsample) and the mask decode (coefficients · prototypes → threshold → overlay), all verified numerically against onnxruntime (proto max abs err ~6e-5). Promptability comes from YOLOE's region-text contrastive head, which scores each region's visual embedding against the text embeddings of the prompt words, with the MobileCLIP text path also in pure NURL. The webcam feed is captured in pure NURL via Video4Linux2 (open/ioctl/mmap, YUYV→RGB) — no ffmpeg, no OpenCV. Requires the NVIDIA driver + NVRTC (via the gpu package); a GPU-less host is unaffected."
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
The registry publishes done right after login went out from the **PR #401 merge state** — before PR #402 landed. So the published `yoloe 0.6.1` / `yoloe-demo 0.2.0` still contain the *"cannot read the BPE merges"* bug the embedding fixed (verified by installing them back from the registry: no `clip_merges_data.nu`, no `tokenizer_load_builtin`, old `--merges` default). The other four (gpu 0.4.1, gpukit 0.3.2, anomaly 0.3.4, objdet 0.3.1) match main and are fine.

Published versions are immutable (`PubConflict`), so: **yoloe 0.6.2** + **yoloe-demo 0.2.1**, republished from current main. `yoloe-demo`'s `yoloe ^0.6` range matches 0.6.2 without changes.

After merge these two get published; the registry then matches main everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7