### PR TITLE
net: don't abort a large response because the client reads it slowly

### DIFF
--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -1276,6 +1276,17 @@ long long nurl_tcp_write(long long handle, const char *buf, long long n) {
         return -1;
     }
     long long total = 0;
+    /* SO_SNDTIMEO (set by nurl_tcp_set_timeout for the keep-alive idle
+     * deadline) also caps every blocking send(): when a SLOW-BUT-ALIVE
+     * client (a phone on WiFi pulling a 50 MB model) drains the socket
+     * more slowly than we fill it, send() can spend the whole window
+     * waiting for buffer space and fail with EAGAIN — which used to be
+     * treated as fatal, cutting the response mid-body. A send timeout
+     * is only a DEAD peer if there is no progress across consecutive
+     * windows: retry zero-progress timeouts up to twice (≈2-3× the
+     * idle deadline of total stall), and let any progress reset the
+     * allowance. */
+    int stalls = 0;
     while (total < n) {
         long long want = n - total;
 #ifdef _WIN32
@@ -1294,13 +1305,29 @@ long long nurl_tcp_write(long long handle, const char *buf, long long n) {
 #endif
         if (wn <= 0) {
 #ifdef _WIN32
+            /* WSAETIMEDOUT only fires on BLOCKING sockets (SO_SNDTIMEO);
+             * the async path's would-block is WSAEWOULDBLOCK and must
+             * still return immediately for the reactor. */
             int we = WSAGetLastError();
+            if (wn < 0 && we == WSAETIMEDOUT && ++stalls <= 2) continue;
             h->err_kind = nurl__net_map_wsa(we, NURL_NET_ERR_WRITE);
 #else
+            /* On POSIX a SO_SNDTIMEO expiry and a nonblocking would-block
+             * are both EAGAIN — only retry on BLOCKING sockets, so the
+             * fiber reactor's park-on-EAGAIN contract stays intact. */
+            if (wn < 0 && (errno == EAGAIN ||
+#  if defined(EWOULDBLOCK) && EWOULDBLOCK != EAGAIN
+                           errno == EWOULDBLOCK ||
+#  endif
+                           0)) {
+                int fl = fcntl(h->fd, F_GETFL, 0);
+                if (fl >= 0 && !(fl & O_NONBLOCK) && ++stalls <= 2) continue;
+            }
             h->err_kind = nurl__net_map_errno(errno, NURL_NET_ERR_WRITE);
 #endif
             return -1;
         }
+        stalls = 0;
         total += (long long)wn;
     }
     h->err_kind = NURL_NET_ERR_OK;


### PR DESCRIPTION
## Bug (from phone testing the yoloe-demo)

A phone fetching the demo's **54 MB model over LAN TLS** got `Failed to fetch` every time, while the server logged the request as a 200. Reproduced locally: any client draining slower than ~1 MB/s lost the connection mid-body (`curl --limit-rate 400k` died at 8–17 MB, point varies run to run).

## Root cause

`nurl_tcp_set_timeout` (the server's keep-alive idle deadline, default 30 s; the TLS handshake also sets 20 s) programs **both** `SO_RCVTIMEO` and `SO_SNDTIMEO`. Writing a big body to a slow-but-alive client keeps the socket buffer full; when one blocking `send()` window elapses without space freeing, `send()` fails with `EAGAIN` — and `nurl_tcp_write` treated that as **fatal** (`NET_ERR_TIMEOUT`, return -1), cutting the response mid-body.

## Fix

A send timeout is only a dead peer when there's **no progress across consecutive windows**. `nurl_tcp_write` retries zero-progress send timeouts up to twice (≈2–3× the idle deadline of tolerated stall — a truly dead peer is still dropped); any successful write resets the allowance.

Carefully gated to **blocking** sockets:
- POSIX: a nonblocking would-block is the same `EAGAIN`, and the fiber reactor's park-on-EAGAIN contract must keep returning immediately → `O_NONBLOCK` checked via `fcntl` before retrying.
- Windows: the codes already differ (`WSAETIMEDOUT` vs `WSAEWOULDBLOCK`); only the former retries.

## Verified

| client | before | after |
|---|---|---|
| `--limit-rate 400k` (phone-class) | died at 8–17 MB | **full 54 MB, 131 s, exit 0** |
| unthrottled | 2.8 s | 2.8 s (unchanged) |

Compiler corpus: **513 PASS / 0 FAIL** (includes the async http server tests — reactor path unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7