### PR TITLE
net: log the error name when a response write fails

### DIFF
--- a/stdlib/ext/http_server.nu
+++ b/stdlib/ext/http_server.nu
@@ -828,7 +828,16 @@ $ `stdlib/ext/http_response.nu`
                             T _ → {
                                 ? should_close { = done T } {}
                             }
-                            F _ → { = done T }
+                            F we → {
+                                // A failed response write is invisible to the
+                                // handler (it already returned its status) —
+                                // surface it, or a client-side "failed to
+                                // fetch" has nothing to correlate against.
+                                ( nurl_eprint `http: response write failed (` )
+                                ( nurl_eprint ( net_err_name we ) )
+                                ( nurl_eprintln `) — closing connection` )
+                                = done T
+                            }
                         }
                     }
                 } {


### PR DESCRIPTION
A failed response write was invisible to the handler — it had already returned its status, so a client-side "failed to fetch" had nothing server-side to correlate against. Log the NetErr name and note that the connection is being closed.

Follow-up to #408 (the slow-client write fix); found while debugging that issue — the silent failure is what made it hard to diagnose in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7