### PR TITLE
anomaly: 0.3.5 — fix gpukit dep range that broke registry installs

### DIFF
--- a/packages/anomaly/CHANGELOG.md
+++ b/packages/anomaly/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.5
+
+- Fix a broken registry install. 0.3.4 bumped the `gpu` requirement to
+  `^0.4` but left `gpukit` pinned at `^0.2`; since `^0.2` selects gpukit
+  0.2.0 (which itself requires `gpu 0.2`), the two constraints could not
+  share a `gpu` version and resolution failed with `ResolveConflict`.
+  Bumps `gpukit` to `^0.3` (gpukit 0.3.2 requires `gpu ^0.4`), so the whole
+  graph agrees on `gpu 0.4.x`. No code or behaviour change.
+
 ## 0.3.3
 
 - Internal: the GPU bulk-scoring path now runs on the [`gpukit`](../gpukit)

--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anomaly"
-version = "0.3.4"
+version = "0.3.5"
 description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working. `anomaly serve` also ships a self-contained web dashboard (model manager, trainer, feature visualiser and anomaly scanner — plain HTML/JS, no CDN or build step) served straight from the binary's web root."
 license = "MIT OR Apache-2.0"
 
@@ -9,4 +9,4 @@ iforest = { path = "../iforest", version = "^0.1" }
 gpu = { path = "../gpu", version = "^0.4" }
 http = { path = "../http", version = "^0.1" }
 cli = { path = "../cli", version = "^0.1" }
-gpukit = { path = "../gpukit", version = "^0.2" }
+gpukit = { path = "../gpukit", version = "^0.3" }

--- a/packages/anomaly/src/main.nu
+++ b/packages/anomaly/src/main.nu
@@ -458,7 +458,7 @@ $ `src/service.nu`
 }
 
 @ main → i {
-    : *Cli c ( cli_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` `0.3.3` )
+    : *Cli c ( cli_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` `0.3.5` )
     ( cli_flag_str  c `store`   115 `DIR`  `model store (default: $ANOMALY_HOME, else ~/.anomaly)` `` `ANOMALY_HOME` )
     ( cli_flag_str  c `file`    102 `FILE` `for batch: read CSV from FILE instead of stdin` `` `` )
     ( cli_flag_str  c `margin`  109 `M`    `for batch: decision margin (default 0 = predict==-1)` `0` `` )


### PR DESCRIPTION
## Problem

`nurlpkg install anomaly` failed against the live registry:

```
resolving registry dependencies against https://reg.nurl-lang.org/
nurlpkg: registry resolution failed (ResolveConflict)
```

## Root cause

Commit f800b23 ("fix stale dep ranges") bumped anomaly's `gpu` requirement to `^0.4` but **left `gpukit` pinned at `^0.2`**. npm-style `^0.2` means `>=0.2.0 <0.3.0`, so the resolver selects **gpukit 0.2.0** — whose own manifest requires **`gpu 0.2`** — which cannot share a version with the **gpu 0.4.1** already locked by anomaly's own `gpu ^0.4`. The constraint graph is genuinely unsatisfiable, so no resolver could paper over it.

## Fix

Bump `gpukit` to `^0.3` (gpukit 0.3.2 requires `gpu ^0.4`), so the whole tree agrees on `gpu 0.4.x`. Version bump `0.3.4 → 0.3.5` because registry versions are immutable. Also corrects the hard-coded CLI version string (stuck at `0.3.3`).

## Verification

Proven end-to-end twice — first against a local registry mirroring live (incl. historical `cli 0.1.0`), then against the live registry after publishing 0.3.5:

```
resolving registry dependencies against https://reg.nurl-lang.org/
  iforest 0.1.1 · gpu 0.4.1 · http 0.1.0 · cli 0.1.0 · gpukit 0.3.2   ← no conflict
Installed anomaly → ~/.nurl/bin/anomaly    (exit 0)
```

`anomaly --help` and `anomaly ls` both run (exit 0).

> Note: **anomaly 0.3.5 is already published** to the live registry, so `nurlpkg install anomaly` works now. This PR lands the same fix in the monorepo source of truth. (The CLI-version-string bump won't be visible until a future publish, since 0.3.5 is immutable.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)