### PR TITLE
nurlpkg: install a package's [install] assets into $NURL_HOME/share/<name>

### DIFF
--- a/compiler/tests/manifest_basic.nu
+++ b/compiler/tests/manifest_basic.nu
@@ -22,6 +22,20 @@ $ `stdlib/ext/manifest.nu`
         ( nurl_print ( string_data . m license ) )
     } { ( nurl_print `<empty>` ) }
     ( nurl_print `\n` )
+    : i na ( vec_len [String] . m assets )
+    ( nurl_print `assets_count=` ) ( nurl_print ( nurl_str_int na ) ) ( nurl_print `\n` )
+    : ~ i ak 0
+    ~ < ak na {
+        : ?String ao ( vec_get [String] . m assets ak )
+        ?? ao {
+            T a → {
+                ( nurl_print `asset[` ) ( nurl_print ( nurl_str_int ak ) ) ( nurl_print `] ` )
+                ( nurl_print ( string_data a ) ) ( nurl_print `\n` )
+            }
+            F _ → {}
+        }
+        = ak + ak 1
+    }
     : i n ( vec_len [Dep] . m dependencies )
     ( nurl_print `deps_count=` ) ( nurl_print ( nurl_str_int n ) ) ( nurl_print `\n` )
     : ~ i k 0
@@ -48,6 +62,9 @@ name = "demo-app"
 version = "0.1.0"
 description = "Demo of the manifest parser"
 license = "MIT OR Apache-2.0"
+
+[install]
+assets = ["static", "web/dashboard"]
 
 [dependencies]
 http-router = { path = "../router", version = "0.2.0" }

--- a/compiler/tests/outputs/manifest_basic.txt
+++ b/compiler/tests/outputs/manifest_basic.txt
@@ -7,6 +7,9 @@ name=demo-app
 version=0.1.0
 description=Demo of the manifest parser
 license=MIT OR Apache-2.0
+assets_count=2
+asset[0] static
+asset[1] web/dashboard
 deps_count=2
 dep[0] http-router path=../router version=0.2.0
 dep[1] some-lib path=../some-lib version=

--- a/packages/anomaly/CHANGELOG.md
+++ b/packages/anomaly/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.6
+
+- The `serve` dashboard now works out of the box after a registry install.
+  Declares `[install] assets = ["static"]`, so `nurlpkg install anomaly`
+  stages the dashboard HTML into `$NURL_HOME/share/anomaly/static`, which
+  `serve` already resolves relative to its own executable
+  (`<exe-dir>/../share/anomaly/static`). Before this, only the binary was
+  installed and `anomaly serve` silently fell back to API-only unless you
+  pointed `--webroot` at a source checkout. Now `anomaly serve --addr
+  0.0.0.0:8080` serves the dashboard with no extra flags.
+
 ## 0.3.5
 
 - Fix a broken registry install. 0.3.4 bumped the `gpu` requirement to

--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anomaly"
-version = "0.3.5"
+version = "0.3.6"
 description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working. `anomaly serve` also ships a self-contained web dashboard (model manager, trainer, feature visualiser and anomaly scanner — plain HTML/JS, no CDN or build step) served straight from the binary's web root."
 license = "MIT OR Apache-2.0"
 
@@ -10,3 +10,9 @@ gpu = { path = "../gpu", version = "^0.4" }
 http = { path = "../http", version = "^0.1" }
 cli = { path = "../cli", version = "^0.1" }
 gpukit = { path = "../gpukit", version = "^0.3" }
+
+# Runtime data staged into $NURL_HOME/share/anomaly/ on `nurlpkg install`.
+# The `serve` dashboard resolves its web root as <exe-dir>/../share/anomaly/static,
+# so a registry install serves the dashboard with no --webroot needed.
+[install]
+assets = ["static"]

--- a/packages/anomaly/src/main.nu
+++ b/packages/anomaly/src/main.nu
@@ -458,7 +458,7 @@ $ `src/service.nu`
 }
 
 @ main → i {
-    : *Cli c ( cli_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` `0.3.5` )
+    : *Cli c ( cli_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` `0.3.6` )
     ( cli_flag_str  c `store`   115 `DIR`  `model store (default: $ANOMALY_HOME, else ~/.anomaly)` `` `ANOMALY_HOME` )
     ( cli_flag_str  c `file`    102 `FILE` `for batch: read CSV from FILE instead of stdin` `` `` )
     ( cli_flag_str  c `margin`  109 `M`    `for batch: decision margin (default 0 = predict==-1)` `0` `` )

--- a/stdlib/ext/manifest.nu
+++ b/stdlib/ext/manifest.nu
@@ -59,6 +59,7 @@ $ `stdlib/ext/toml.nu`
     String repository  // [package].repository — source URL; empty → unset
     String postinstall  // [hints].postinstall — message shown after install; empty → none
     ( Vec Dep ) dependencies
+    ( Vec String ) assets  // [install].assets — package-relative paths staged under $NURL_HOME/share/<name>/ on tool install
 }
 
 : | ManifestErr {
@@ -127,6 +128,14 @@ $ `stdlib/ext/toml.nu`
         = k + k 1
     }
     ( vec_free [Dep] . m dependencies )
+    : i na ( vec_len [String] . m assets )
+    : ~ i ak 0
+    ~ < ak na {
+        : ?String ao ( vec_get [String] . m assets ak )
+        ?? ao { T av → ( string_free av ) F _ → {} }
+        = ak + ak 1
+    }
+    ( vec_free [String] . m assets )
 }
 
 // ── Field extraction helpers ─────────────────────────────────────
@@ -145,6 +154,43 @@ $ `stdlib/ext/toml.nu`
             ?? s {
                 T sv → { ( string_free out ) = out sv }
                 F empty → ( string_free empty )
+            }
+        }
+        F _ → {}
+    }
+    ^ out
+}
+
+// Read a dotted `path` expected to hold an array of strings, returning an
+// OWNED Vec[String] (its elements each owned). Missing path, non-array
+// value, or non-string elements yield an empty vector; non-string elements
+// are skipped. `toml_get_path` borrows into `root`, so we copy each string
+// out (toml_as_str returns an owned copy) and never free the borrowed nodes.
+@ __field_str_array TomlValue root s path → ( Vec String ) {
+    : ( Vec String ) out ( vec_new [String] )
+    : ?TomlValue v ( toml_get_path root path )
+    ?? v {
+        T tv → {
+            ?? tv {
+                TArr arr → {
+                    : i n ( vec_len [TomlValue] arr )
+                    : ~ i k 0
+                    ~ < k n {
+                        : ?TomlValue ek ( vec_get [TomlValue] arr k )
+                        ?? ek {
+                            T ev → {
+                                : ?String sv ( toml_as_str ev )
+                                ?? sv {
+                                    T s → ( vec_push [String] out s )
+                                    F empty → ( string_free empty )
+                                }
+                            }
+                            F _ → {}
+                        }
+                        = k + k 1
+                    }
+                }
+                _ → {}
             }
         }
         F _ → {}
@@ -252,6 +298,7 @@ $ `stdlib/ext/toml.nu`
             : String registry ( __field_str root `package.registry` )
             : String repository ( __field_str root `package.repository` )
             : String postinstall ( __field_str root `hints.postinstall` )
+            : ( Vec String ) assets ( __field_str_array root `install.assets` )
 
             // Dependencies.
             : ( Vec Dep ) deps ( vec_new [Dep] )
@@ -283,7 +330,7 @@ $ `stdlib/ext/toml.nu`
                 F _ → {}
             }
             ( toml_value_free root )
-            ^ @ !Manifest ManifestErr { T @ Manifest { name version description license registry repository postinstall deps } }
+            ^ @ !Manifest ManifestErr { T @ Manifest { name version description license registry repository postinstall deps assets } }
         }
     }
 }

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -1676,6 +1676,116 @@ $ `stdlib/std/bytes.nu`
 // Resolve its deps in-process, build the entry point, and install the
 // binary into bindir/name. Cross-platform: uses fs primitives + a
 // shell-free driver spawn, no POSIX coreutils.
+// Recursively copy a file or directory tree from `src` to `dst`, creating
+// parent directories as needed. Returns 0 on success, 1 on any failure (or
+// if `src` does not exist). Used to stage a tool's declared assets into
+// $NURL_HOME/share/<name>/.
+@ __copy_tree s src s dst → i {
+    : i t ( nurl_path_type src )
+    ? == t 1 {
+        : String parent ( path_dirname dst )
+        ?? ( dir_create_all ( string_data parent ) ) { T _ → {} F _ → {} }
+        ( string_free parent )
+        ?? ( fs_copy_file src dst ) { T _ → { ^ 0 } F _ → { ^ 1 } }
+    } {}
+    ? == t 2 {
+        : ~ i rc 0
+        ?? ( dir_create_all dst ) { T _ → {} F _ → { = rc 1 } }
+        ? != rc 0 { ^ rc } {}
+        : !( Vec String ) IoErr lr ( dir_list src )
+        ?? lr {
+            F _ → { = rc 1 }
+            T entries → {
+                : i n ( vec_len [String] entries )
+                : ~ i k 0
+                ~ < k n {
+                    : ?String eo ( vec_get [String] entries k )
+                    ?? eo {
+                        T nm → {
+                            : String s2 ( path_join src ( string_data nm ) )
+                            : String d2 ( path_join dst ( string_data nm ) )
+                            ? != 0 ( __copy_tree ( string_data s2 ) ( string_data d2 ) ) { = rc 1 } {}
+                            ( string_free s2 )
+                            ( string_free d2 )
+                            ( string_free nm )
+                        }
+                        F _ → {}
+                    }
+                    = k + k 1
+                }
+                ( vec_free [String] entries )
+            }
+        }
+        ^ rc
+    } {}
+    // Missing source or unsupported node type.
+    ^ 1
+}
+
+// Stage a tool's declared `[install].assets` into $NURL_HOME/share/<name>/,
+// preserving each path (so `static` lands at `<prefix>/share/<name>/static`,
+// which a relocatable tool finds via `<exe-dir>/../share/<name>/…`). The
+// share dir is a sibling of `bindir`. Cleared first so an upgrade never
+// leaves a stale file behind. Returns 0 on success (including nothing to
+// do), 1 if any asset path is missing or fails to copy.
+// An asset path is safe to stage only if it stays inside the package: no
+// absolute paths (a leading `/`) and no `..` anywhere (which `path_join`
+// would happily let escape the share dir). Registry manifests are untrusted
+// input, so reject rather than trust.
+@ __asset_path_safe s a → b {
+    : i n ( nurl_str_len a )
+    ? == n 0 { ^ F } {}
+    ? == ( nurl_str_get a 0 ) 47 { ^ F } {}
+    : ~ i k 0
+    ~ < k - n 1 {
+        ? & == ( nurl_str_get a k ) 46 == ( nurl_str_get a + k 1 ) 46 { ^ F } {}
+        = k + k 1
+    }
+    ^ T
+}
+
+@ __install_assets Manifest m s pkgdir s name s bindir → i {
+    : i na ( vec_len [String] . m assets )
+    ? == na 0 { ^ 0 } {}
+    : String prefix ( path_dirname bindir )
+    : String sharedir ( path_join ( string_data prefix ) `share` )
+    ( string_free prefix )
+    : String pkgshare ( path_join ( string_data sharedir ) name )
+    ( string_free sharedir )
+    ?? ( dir_remove_all ( string_data pkgshare ) ) { T _ → {} F _ → {} }
+    : ~ i rc 0
+    : ~ i k 0
+    ~ < k na {
+        : ?String ao ( vec_get [String] . m assets k )
+        ?? ao {
+            T a → {
+                ? ! ( __asset_path_safe ( string_data a ) ) {
+                    ( nurl_eprint `nurlpkg: unsafe asset path rejected: ` )
+                    ( nurl_eprintln ( string_data a ) )
+                    = rc 1
+                } {
+                    : String srcp ( path_join pkgdir ( string_data a ) )
+                    : String dstp ( path_join ( string_data pkgshare ) ( string_data a ) )
+                    ? != 0 ( __copy_tree ( string_data srcp ) ( string_data dstp ) ) {
+                        ( nurl_eprint `nurlpkg: asset not staged: ` )
+                        ( nurl_eprintln ( string_data a ) )
+                        = rc 1
+                    } {}
+                    ( string_free srcp )
+                    ( string_free dstp )
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ? == rc 0 {
+        ( nurl_print `Assets → ` ) ( nurl_print ( string_data pkgshare ) ) ( nurl_print `\n` )
+    } {}
+    ( string_free pkgshare )
+    ^ rc
+}
+
 @ __tool_build_and_install s name s pkgdir s binsrc → i {
     : String nurl ( __env_or `NURL` `nurl` )
     : String bindir ( __tool_bindir )
@@ -1742,6 +1852,19 @@ $ `stdlib/std/bytes.nu`
                 } {}
                 ( nurl_print `Installed ` ) ( nurl_print name )
                 ( nurl_print ` → ` ) ( nurl_print ( string_data dest ) ) ( nurl_print `\n` )
+                // Stage the package's declared runtime assets ([install].assets)
+                // into <prefix>/share/<name>/ so the tool finds them relative to
+                // its own executable (a registry install ships data, not just a
+                // binary). A missing/failed asset fails the install.
+                : String ampath ( path_join pkgdir `nurl.toml` )
+                ?? ( manifest_load ( string_data ampath ) ) {
+                    T am → {
+                        ? != 0 ( __install_assets am pkgdir name ( string_data bindir ) ) { = rc 1 } {}
+                        ( manifest_free am )
+                    }
+                    F _ → {}
+                }
+                ( string_free ampath )
                 // Show the package's [hints].postinstall message, if any.
                 ( __print_postinstall pkgdir )
             }


### PR DESCRIPTION
Stacked on #411 (the gpukit dep fix). Review/merge #411 first.

## Problem

`nurlpkg install <tool>` installed **only the compiled binary**. A package with runtime data files had no way to ship them. Concretely: anomaly's `serve` dashboard resolves its web root as `<exe-dir>/../share/anomaly/static`, but nothing ever populated that path — so a registry-installed `anomaly serve` silently ran **API-only** unless you hand-pointed `--webroot` at a source checkout. Assets were shipped in the tarball, extracted to a temp staging dir, and thrown away after the build.

## Design

A general, opt-in, FHS-shaped mechanism — `bin/` + `share/<name>/`, the layout tools already probe:

- **Manifest**: optional `[install] assets = [...]`, package-relative paths (files or dirs). Parsed in `stdlib/ext/manifest.nu` via a new `__field_str_array`.
- **nurlpkg**: after installing the binary, `install <tool>` copies each declared asset into `<prefix>/share/<name>/`, preserving layout (sibling of `bin/`). Cleared first so upgrades don't leave stale files. A missing/failed asset fails the install.
- **Path safety**: asset paths with a leading `/` or any `..` are rejected — registry manifests are untrusted input, and `path_join` would otherwise let an entry escape the share dir. (This footgun bit me mid-development: a swapped-arg `path_join(share, "/abs/staging")` returned the absolute path and a `dir_remove_all` wiped the staging tree. The guard makes that class of bug impossible.)

## anomaly

Declares `assets = ["static"]`, bumps to 0.3.6. A registry install now serves the dashboard with **no flags**:

```
$ nurlpkg install anomaly
Installed anomaly → ~/.nurl/bin/anomaly
Assets → ~/.nurl/share/anomaly
$ anomaly serve --addr 0.0.0.0:8080
anomaly: dashboard web root: .../bin/../share/anomaly/static   # resolved, not API-only
```

## Verification

- `manifest_basic` extended to cover `[install] assets` parsing (incl. a nested path); golden updated. Full manifest/toml/pkg/resolver test set green.
- End-to-end against a local registry: install stages `share/anomaly/static/*.html`, and `anomaly serve` (no `--webroot`) resolves the webroot and serves the dashboard + `/modelmanager.html`.

Note: reaches end users with the next toolchain release (the logic is in `nurlpkg`). The manifest field is forward-compatible — an older nurlpkg simply ignores `[install] assets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)