### PR TITLE
packages: anomaly 0.3.7, yoloe-demo 0.2.3 — depend on http ^0.2

### DIFF
--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,13 +1,13 @@
 [package]
 name = "anomaly"
-version = "0.3.6"
+version = "0.3.7"
 description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working. `anomaly serve` also ships a self-contained web dashboard (model manager, trainer, feature visualiser and anomaly scanner — plain HTML/JS, no CDN or build step) served straight from the binary's web root."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 iforest = { path = "../iforest", version = "^0.1" }
 gpu = { path = "../gpu", version = "^0.4" }
-http = { path = "../http", version = "^0.1" }
+http = { path = "../http", version = "^0.2" }
 cli = { path = "../cli", version = "^0.1" }
 gpukit = { path = "../gpukit", version = "^0.3" }
 

--- a/packages/yoloe-demo/nurl.toml
+++ b/packages/yoloe-demo/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoloe-demo"
-version = "0.2.2"
+version = "0.2.3"
 description = "Live YOLOE in the browser, served by pure NURL — open your webcam on a web page and watch open-vocabulary detection + instance segmentation stream back at you. The browser posts JPEG frames to a NURL HTTP(S) server; every frame runs through the onnx package on the GPU (each layer a CUDA-C kernel compiled at runtime via NVRTC), the segmentation masks are composited onto the frame, and the masked JPEG + a JSON detection list come back — the page draws boxes/labels on top and loops. Interactive: toggle prompted classes, drag the confidence slider, flip masks on/off, or drop a still image. --tls generates a self-signed P-256 certificate at startup (std/x509_gen) so the camera also works from other machines on the LAN (getUserMedia needs a secure origin). Everything in the path is NURL: the HTTP/TLS server (http package), the page template (template package), the JPEG/PNG codecs (image package), the ONNX runtime (onnx package) and the YOLOE decode/mask stages (yoloe package). No Python, no OpenCV, no inference engine, no web framework."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl-lang"
@@ -9,5 +9,5 @@ repository = "https://github.com/nurl-lang/nurl-lang"
 yoloe = { path = "../yoloe", version = "^0.6" }
 onnx = { path = "../onnx", version = "^0.6" }
 image = { path = "../image", version = "^0.4" }
-http = { path = "../http", version = "^0.1" }
+http = { path = "../http", version = "^0.2" }
 template = { path = "../template", version = "^0.1" }


### PR DESCRIPTION
http 0.2.0 (merged in #413) carries the per-request leak fixes and the server limit knobs, but `^0.1` on a 0.x dependency locks the minor — registry installs of anomaly/yoloe-demo kept resolving http 0.1.0 and never got the fixes (the same local-path-dep-hides-it drift class as #401/#411).

Publish order after merge (the gpukit lesson — dependency order): **http 0.2.0 → anomaly 0.3.7 → yoloe-demo 0.2.3 → registry 0.1.0** (registry's `^0.2` can't resolve until http 0.2.0 is in the index; it also needs the v0.11.2 stdlib — `sqlite_changes` — which is now released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWYamSmAqLFKCSMqYLTfi7