### PR TITLE
docs: fix inaccurate claims and broken commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3849,7 +3849,7 @@ releases ship install packages for Linux and Windows.
 - **`docs/LIMITATIONS.md` scoped to actual language/compiler limitations.**
   Removed the standard-library capability tables (PostgreSQL, SQLite,
   panic/recover) that were never language limitations — that information
-  lives with each module (stdlib headers, `ROADMAP.md`, `TODO.md`). Moved
+  lives with each module (stdlib headers, `ROADMAP.md`). Moved
   the HTTPS/TLS table to [`docs/NETWORKING.md`](docs/NETWORKING.md) where it
   belongs. Removed two entries that were **stale** (the behaviour already
   works, verified empirically): "no tail-call optimisation" (self-recursive

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,8 +84,12 @@ enough — we'll iterate on the design in the issue thread.
   The bootstrap requires byte-identical LLVM IR on its second pass —
   if your change is non-deterministic, the build will reject it.
 - **Add or update tests** for compiler changes. New language features
-  belong in `compiler/tests/` as `.nu` snippets with their expected
-  output checked in via `correct.txt`.
+  belong in `compiler/tests/` as `.nu` snippets, each with a per-test
+  golden under `compiler/tests/outputs/` (record it with
+  `compiler/tests/run_tests.sh --update <name>`; run a single test with
+  `run_tests.sh <name>`). Programs that must be *rejected* go in as
+  `should_fail_*.nu` / `borrow_*.nu`, with their expected diagnostic as
+  the golden.
 - **Update docs** if you change observable behaviour. The README is a
   thin overview that links to topic docs under [`docs/`](docs/); update
   the relevant one (`docs/spec.md`, `docs/LIMITATIONS.md`,
@@ -130,21 +134,19 @@ The browser playground lives under `nurlapi/`; see its `README.md`
 
 ## Style conventions
 
-NURL doesn't ship an autoformatter yet, so style is "match the
-surrounding code". Some loose conventions:
+Run **`nurlfmt --write`** before pushing. It applies the canonical `.nu`
+format (indentation, spacing, import grouping) and is idempotent and
+IR-preserving; CI **hard-gates** on `nurlfmt --check`, and a pre-commit
+hook under `.githooks/` formats on commit. See [`docs/FORMAT.md`](docs/FORMAT.md).
 
-- **Indentation**: 4 spaces in `.nu` files, 2 spaces in
-  TypeScript/JSON.
+A few conventions the formatter does **not** enforce, so apply them by hand:
+
 - **Naming**: `snake_case` for functions and bindings, `PascalCase`
   for types, `SCREAMING_CASE` for top-level constants.
 - **Comments**: `//` for single-line. Avoid restating what the code
   obviously does; document *why* when the answer isn't immediately
   obvious from context.
-- **Imports** (`$ \`path/module.nu\``) go at the top of the file,
-  grouped by category (core / std / ext).
-
-If you want to propose tighter conventions or an autoformatter,
-please do — both would be welcome additions.
+- **Non-`.nu` files**: 2 spaces in TypeScript/JSON.
 
 ## Licensing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,8 +136,15 @@ The browser playground lives under `nurlapi/`; see its `README.md`
 
 Run **`nurlfmt --write`** before pushing. It applies the canonical `.nu`
 format (indentation, spacing, import grouping) and is idempotent and
-IR-preserving; CI **hard-gates** on `nurlfmt --check`, and a pre-commit
-hook under `.githooks/` formats on commit. See [`docs/FORMAT.md`](docs/FORMAT.md).
+IR-preserving; CI **hard-gates** on `nurlfmt --check`. `./build.sh` also
+activates the pre-commit hook (`.githooks/pre-commit`, via `core.hooksPath`),
+which keeps commits canonical for you: a **fully-staged** `.nu` file is
+`nurlfmt --write`'n and re-staged automatically, while a **partially-staged**
+file that isn't canonical **blocks** the commit (run `nurlfmt --write` and
+re-stage it — the hook won't rewrite it, to avoid staging your unstaged
+edits). The hook skips cleanly if `build/nurlfmt` isn't built yet, excludes
+`bench/`, and can be bypassed once with `git commit --no-verify`. See
+[`docs/FORMAT.md`](docs/FORMAT.md).
 
 A few conventions the formatter does **not** enforce, so apply them by hand:
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 NURL takes a few design positions that are uncommon together:
 
 - **Regular prefix-arity grammar** — every operator has a fixed arity, no infix, no precedence cliffs. The grammar fits on a single page and is LL(k≤4) — recursive-descent with up to 4 tokens of lookahead.
-- **Local semantics** — a construct's meaning is derivable from a short window of surrounding tokens. No long-range dependencies.
-- **Deterministic compiler** — the same source always produces identical output. No UB, no platform-dependent behaviour. The self-hosted compiler reaches a byte-identical fixed point on its own source.
+- **Locally parseable** — a construct's shape (arity and nesting) is fixed by a short window of surrounding tokens, with no long-range parse dependencies. (A few operators — `.`, `&`, `|`, `#` — resolve their *lowering* by operand type; see [`docs/spec.md`](docs/spec.md) §4.9/§6.)
+- **Deterministic compiler** — the same source always produces identical output, with no platform-dependent codegen. The self-hosted compiler reaches a byte-identical fixed point on its own source. (Raw `*T` pointers and out-of-range shifts inherit LLVM semantics — spec §4.2, §6.1.)
 - **Single-owner memory + default-on static borrow checker** — auto-drop at scope exit, plus a diagnostic pass (on by default, `--no-borrowck` to disable) that catches use-after-move, alias-double-free, escaping closure-captures, and iterator invalidation as hard errors.
 - **LLVM-based codegen, broad platform reach** — one pipeline targets Linux, macOS, Windows, wasm32-wasi, RISC-V, and ARM64.
 
@@ -35,8 +35,8 @@ they are machine-specific, so run the suite locally for figures you can trust.
 ## Design principles
 
 1. **Regular grammar** — no exceptions; the same construct always works the same way.
-2. **Local semantics** — meaning derives from a short window of tokens, no long-range dependencies.
-3. **Deterministic compiler** — same source → identical output, no UB, no platform variation.
+2. **Local structure** — a construct's shape derives from a short window of tokens, no long-range parse dependencies.
+3. **Deterministic compiler** — same source → identical output, no platform variation.
 4. **Full platform support** — one compilation pipeline → every LLVM target without porting.
 
 ---
@@ -100,9 +100,8 @@ For contributors, or to run the bootstrap yourself:
 ```bash
 git clone https://github.com/nurl-lang/nurl.git
 cd nurl
-clang -c stdlib/runtime.c -o stdlib/runtime.o   # once (already checked in)
-./build.sh                                       # bootstrap + test suite
-./nurl.sh examples/fizzbuzz.nu && ./fizzbuzz     # compile & run a program
+./build.sh                                            # builds the C runtime, bootstraps, runs tests
+./nurl.sh examples/fizzbuzz.nu fizzbuzz && ./fizzbuzz # compile & run a program
 ```
 
 The only build-time dependency is **clang / LLVM 15+**. `./install.sh` also

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -34,14 +34,21 @@ export PATH="$(brew --prefix llvm)/bin:$PATH"   # add to ~/.zshrc to persist
 The toolchain binaries themselves link only libc, so they also run on
 musl/Alpine without extra packages (see [`PLATFORMS.md`](PLATFORMS.md)).
 
-## Step 1 — Build the C runtime (once)
+## Step 1 — Build the C runtime
+
+`./build.sh` (Step 2) compiles the C runtime for you, so most contributors
+can skip straight to Step 2. Build it by hand only for the manual bootstrap
+below:
 
 ```sh
 clang -c stdlib/runtime.c -o stdlib/runtime.o      # Linux / macOS
 clang -c stdlib\runtime.c -o stdlib\runtime.o      # Windows
 ```
 
-> `stdlib/runtime.o` is already checked in; rebuild it only if you modify `runtime.c`.
+> `stdlib/runtime.o` is **not** checked in (it is gitignored). `./build.sh`
+> regenerates it; note that the build compiles it with `-flto`, so after a
+> build `runtime.o` is LLVM bitcode and the build also emits a plain-ELF
+> `stdlib/runtime.native.o` for non-LTO linking (see below).
 
 ## Step 2 — Bootstrap the self-hosting compiler
 
@@ -93,10 +100,15 @@ nurl.bat  myprogram.nu              # → myprogram.exe         (Windows)
 
 **Manual (two-step):**
 ```sh
-./nurlc myprogram.nu > myprogram.ll               # or build/nurlc
-clang myprogram.ll stdlib/runtime.o -o myprogram
+./nurlc myprogram.nu > myprogram.ll                          # or build/nurlc
+clang myprogram.ll stdlib/runtime.native.o -lm -lpthread -o myprogram
 ./myprogram
 ```
+
+> Link against `stdlib/runtime.native.o` (a real ELF object), not
+> `stdlib/runtime.o` — after `./build.sh` the latter is LLVM bitcode and a
+> plain `clang` link rejects it with *"file format not recognized"*. The
+> `-lm -lpthread` libraries are required.
 
 ## Debugging with `gdb` / `lldb` (DWARF)
 
@@ -105,10 +117,16 @@ like any C-toolchain ELF: source-level breakpoints, single-step by `.nu`
 line, `info locals`, `print x` with the NURL type name.
 
 ```sh
-./nurl.sh --debug examples/fizzbuzz.nu          # builds fizzbuzz with DWARF
-gdb -ex 'break fizzbuzz' -ex run ./fizzbuzz     # break by name
-gdb -ex 'break examples/fizzbuzz.nu:18' …       # break by source line
+./nurl.sh -O0 --debug examples/fizzbuzz.nu            # DWARF, no optimisation
+gdb -ex 'break fizzbuzz' -ex run ./examples/fizzbuzz  # break by name
+gdb -ex 'break examples/fizzbuzz.nu:18' …             # break by source line
 ```
+
+Pass `-O0` (or `-O1`): at the default `-O2`, optimisation inlines and
+reorders enough that source-line breakpoints and `info locals` become
+unreliable — the breakpoint may never fire. `nurl.sh` writes the binary
+next to the source, so a program under `examples/` lands at
+`./examples/fizzbuzz`, not `./fizzbuzz`.
 
 Two knobs cooperate:
 - `nurlc --g <file>` emits `!DICompileUnit` / `!DISubprogram` /

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -10,11 +10,11 @@ feature coverage and gaps (databases, TLS, MQTT, …) are *not* language
 limitations — they live with each module (the `stdlib/**` file headers and
 [`docs/NETWORKING.md`](NETWORKING.md)) and on the [`ROADMAP.md`](../ROADMAP.md).
 
-For active compiler quirks (binary `&` / `|` arity, bare `@-fn` closure
-coercion, same-line parameter shadowing, ternary cascading, `: ~`
-closure-borrow escape) see [`docs/GOTCHAS.md`](GOTCHAS.md). The memory model
-and the borrow checker's not-yet-checked list live in
-[`docs/MEMORY.md`](MEMORY.md).
+The fixed grammar quirks (binary `&` / `|` arity, ternary cascading, `^`
+vs `^^`) are documented in the [Grammar](#grammar) section below; the
+closure-capture and `: ~` closure-borrow-escape rules live in
+[`docs/MEMORY.md`](MEMORY.md). All of these are compiler-diagnosed — see
+[`docs/GOTCHAS.md`](GOTCHAS.md) for the "the error message is the API" policy.
 
 ## Type system
 
@@ -26,7 +26,7 @@ and the borrow checker's not-yet-checked list live in
 
 | Limitation | Workaround |
 |---|---|
-| Dispatch is **fully static** — a bare-name method call resolves to `method__<mangled-first-arg-type>` at monomorphisation. There is no runtime trait identity, no vtable, and **no `dyn Trait`** (dynamic dispatch / heterogeneous collections of differing impls). The model is a deliberately reserved extension point (see `docs/spec.md` §4.9) | Keep the concrete type at the call site; for a heterogeneous set, use an enum of the variants and match |
+| Bare-name method calls are **statically** dispatched — resolved to `method__<mangled-first-arg-type>` at monomorphisation, with no per-call vtable. Dynamic dispatch **is** supported but must be opted into via the `%Trait` object type + `( dyn Trait value )` construction: a `%dyn.<Trait> = { i8*, i8* }` box-plus-vtable fat pointer (spec §4.9). A trait must be **object-safe** to be used as `%Trait` (see `compiler/tests/should_fail_dyn_not_object_safe.nu`) | Keep the concrete type at the call site for static hot paths; for a heterogeneous collection, box values as `%Trait` with `( dyn Trait v )`, or use an enum of the variants and match |
 | Associated types have **no projection**: an associated type cannot be named as `A::Elem` at a generic call site — it is usable only inside the declaring trait's own method bodies/signatures | Make the element an explicit type parameter of the function (`[A E]`) when a caller needs to name it |
 | An associated-type binding (`type Elem Concrete`) must be a **single simple type name** (IDENT / type keyword); compound types (`* T`, `Vec T`, `?T`) are not accepted — the same restriction trait-default substitution carries | Bind to a named struct/alias type that wraps the compound type |
 | A trait must be scanned **before** its impls (defaults, supertrait names, and associated types are read from the trait when an impl is processed) | Declare the trait — or place its `$`-import — above the impl (the natural order) |

--- a/docs/dev/result-widening-kickoff.md
+++ b/docs/dev/result-widening-kickoff.md
@@ -88,7 +88,7 @@ test that returns/matches a Result is your canary — `string_to_int`
 - `nurlfmt`: `build/nurlfmt --write` any touched + new files;
   `./compiler/tests/nurlfmt_check.sh` must say OK.
 - Update `docs/spec.md` §4.5 (the `{ i1, i64 }` description) and remove the
-  `docs/LIMITATIONS.md` / TODO.md "Result boxes multi-field payloads" entry.
+  `docs/LIMITATIONS.md` "Result boxes multi-field payloads" entry.
 - Commit (one focused commit), push, PR. Keep the two planning docs or fold them
   into the PR description.
 

--- a/examples/fizzbuzz.nu
+++ b/examples/fizzbuzz.nu
@@ -8,8 +8,10 @@
 //   - String operations
 //
 // Build & run:
+//   ./nurl.sh examples/fizzbuzz.nu fizzbuzz && ./fizzbuzz
+// Or manually (link the plain-ELF runtime, not the LTO-bitcode runtime.o):
 //   ./build/nurlc examples/fizzbuzz.nu > /tmp/fizzbuzz.ll
-//   clang /tmp/fizzbuzz.ll stdlib/runtime.o -o /tmp/fizzbuzz
+//   clang /tmp/fizzbuzz.ll stdlib/runtime.native.o -lm -lpthread -o /tmp/fizzbuzz
 //   /tmp/fizzbuzz
 
 @ fizzbuzz i n → v {

--- a/stdlib/ext/yaml.nu
+++ b/stdlib/ext/yaml.nu
@@ -5,7 +5,7 @@
 // `json_*` accessor, `json_free`, and `json_stringify` work unchanged on a
 // parsed document) and serializes a `Json` tree back to block-style YAML.
 //
-// Handled (the pragmatic subset called out in TODO.md):
+// Handled (the pragmatic subset this module targets):
 //   * Block mappings        key: value  /  key:\n  (nested block)
 //   * Block sequences       - item      /  -\n      (nested block)
 //   * The "sequence under a key at the same indentation" idiom:


### PR DESCRIPTION
A clean-room documentation audit surfaced several statements the code
contradicts and quickstart commands that fail as written. Every fix below was
verified by running the command or checking the source at this commit.

## Inaccurate claims
- **README "No UB"** — the spec itself documents `*T` wild-pointer UB (§4.2)
  and out-of-range-shift poison (§6.1). Reframed to "no platform-dependent
  codegen" with an explicit note that `*T`/shifts inherit LLVM semantics.
- **README "Local semantics"** — a construct is locally *parseable*, but a few
  operators (`.`, `&`, `|`, `#`) resolve their *lowering* by operand type.
  Reworded to "locally parseable" / "local structure".
- **docs/LIMITATIONS.md "no `dyn Trait`"** — dynamic dispatch ships (`%Trait`
  fat pointer + `( dyn Trait v )`, spec §4.9; tests `dyn_dispatch.nu`,
  `dyn_diamond.nu`, `should_fail_dyn_not_object_safe.nu`). Rewrote the row to
  describe the object-safety boundary instead of denying the feature.
- **CONTRIBUTING.md "NURL doesn't ship an autoformatter yet"** — `nurlfmt`
  ships and hard-gates CI (`nurlfmt --check`). Also fixed the `correct.txt`
  golden reference (goldens are per-test under `compiler/tests/outputs/`).

## Broken commands (verified failing → fixed)
- **README quickstart** — removed the false `runtime.o … already checked in`
  line (it's gitignored; `build.sh` makes it) and fixed `./fizzbuzz`
  (`nurl.sh` writes the binary next to the source → give an explicit output
  name).
- **docs/BUILDING.md manual link** — after a build `runtime.o` is LTO bitcode
  and a plain `clang` link fails with *"file format not recognized"*.
  Documented `stdlib/runtime.native.o -lm -lpthread`.
- **docs/BUILDING.md gdb example** — `--debug` alone runs at `-O2`, where
  breakpoints don't fire; documented `-O0 --debug` and the correct
  `./examples/fizzbuzz` output path (verified: breakpoint fires, `i = 1`).
- **examples/fizzbuzz.nu header** — same `runtime.native.o` + libs fix.

## Housekeeping
- Removed references to the internal, gitignored `TODO.md` from
  `CHANGELOG.md`, `docs/dev/result-widening-kickoff.md`, and
  `stdlib/ext/yaml.nu`.

No code behavior changes; `.nu` edits are comment-only and pass `nurlfmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)