### PR TITLE
nurlc: reject pointer↔scalar call-argument type mismatches (C1)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -4633,6 +4633,21 @@
     ^ & & ( __is_named_agg at ) ( __is_named_agg pt ) ! ( seq at pt )
 }
 
+// Exactly one operand lowers to a pointer, the other to a non-pointer
+// scalar (i64/i32/double/i1/i8…). Catches the different-base pointer↔scalar
+// class that __arg_ptr_depth_mismatch misses — e.g. an `i8*` string passed
+// where an `i64` is declared (`( add 1 \`two\` )`), or an integer passed
+// where a pointer is declared. Named aggregates and String have their own
+// checks, so a side that is a `%Name` value is excluded here to avoid
+// overlapping errors and the enum↔i64 lowering.
+@ __arg_ptr_scalar_mismatch s at s pt → b {
+    ? | == 0 ( nurl_str_len at ) == 0 ( nurl_str_len pt ) { ^ F } {}
+    : s at_ll ( nurl_llty at )
+    : s pt_ll ( nurl_llty pt )
+    ? | ( __is_named_agg at_ll ) ( __is_named_agg pt_ll ) { ^ F } {}
+    ^ != ( is_ptr_ty at_ll ) ( is_ptr_ty pt_ll )
+}
+
 @ gen_call i lex i syms i cg → s {
     ( nurl_lex_advance lex )
     : s fname ( nurl_lex_val lex )
@@ -5074,29 +5089,41 @@
         == 0 ( nurl_str_len ( nurl_sym_get g_generic_syms ( nurl_str_cat fname `__tparams` ) ) )
         != 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat fname `__ptypes_src` ) ) )
         { : s __psrc ( __ptypes_nth ( nurl_sym_get syms ( nurl_str_cat fname `__ptypes_src` ) ) arg_idx )
-            : b __at_ptr & > ( nurl_str_len at ) 0
-            == ( nurl_str_get at - ( nurl_str_len at ) 1 ) 42
-            : b __ps_ptr & > ( nurl_str_len __psrc ) 0 == ( nurl_str_get __psrc 0 ) 42
-            ? & != 0 ( nurl_str_len __psrc ) | | | __at_ptr __ps_ptr ( seq at `%String` ) ( __is_named_agg at )
+            ? != 0 ( nurl_str_len __psrc )
             { : i __plx ( nurl_lex_new __psrc `<param>` )
                 : s __pllvm ( parse_type __plx )
-                ? ( __arg_ptr_depth_mismatch at __pllvm )
-                { ( die lex ( nurl_str_cat3
-                    ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
-                    ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
-                    `' — pointer-vs-value mismatch (a '*T' was passed where a 'T' value is expected, or vice versa)` ) ) }
-                {}
-                ? ( __arg_str_cstr_mismatch at __pllvm )
-                { ( die lex ( nurl_str_cat3
-                    ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
-                    ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
-                    `' — String vs raw C-string mismatch: 'String' is a managed string, 's' (i8*) a bare char pointer; convert with 'string_data' (String→s) or 'string_from' (s→String)` ) ) }
-                {}
-                ? ( __arg_named_struct_mismatch at __pllvm )
-                { ( die lex ( nurl_str_cat3
-                    ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
-                    ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
-                    `' — wrong struct type passed by value (a value of one named type where a different one is declared); the call would silently reinterpret its fields` ) ) }
+                // Detect pointer-ness from the LOWERED types so pointer
+                // aliases with no literal `*` (e.g. `s` → i8*) are covered.
+                // That is what lets the reverse case — a bare scalar passed
+                // to an `s`/pointer parameter — reach the checks below, not
+                // just an explicit `*T` argument.
+                : b __at_ptr ( is_ptr_ty at )
+                : b __ps_ptr ( is_ptr_ty __pllvm )
+                ? | | | __at_ptr __ps_ptr ( seq at `%String` ) ( __is_named_agg at )
+                { ? ( __arg_ptr_depth_mismatch at __pllvm )
+                    { ( die lex ( nurl_str_cat3
+                        ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
+                        ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
+                        `' — pointer-vs-value mismatch (a '*T' was passed where a 'T' value is expected, or vice versa)` ) ) }
+                    {}
+                    ? ( __arg_str_cstr_mismatch at __pllvm )
+                    { ( die lex ( nurl_str_cat3
+                        ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
+                        ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
+                        `' — String vs raw C-string mismatch: 'String' is a managed string, 's' (i8*) a bare char pointer; convert with 'string_data' (String→s) or 'string_from' (s→String)` ) ) }
+                    {}
+                    ? ( __arg_named_struct_mismatch at __pllvm )
+                    { ( die lex ( nurl_str_cat3
+                        ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
+                        ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
+                        `' — wrong struct type passed by value (a value of one named type where a different one is declared); the call would silently reinterpret its fields` ) ) }
+                    {}
+                    ? ( __arg_ptr_scalar_mismatch at __pllvm )
+                    { ( die lex ( nurl_str_cat3
+                        ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
+                        ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` __pllvm )
+                        `' — pointer-vs-scalar type mismatch; NURL has no implicit conversion between a pointer and an integer/float (convert explicitly with '# T expr' if this is intended)` ) ) }
+                    {} }
                 {} }
             {} }
         {}

--- a/compiler/tests/outputs-windows/should_fail_call_arg_ptr_for_scalar.txt
+++ b/compiler/tests/outputs-windows/should_fail_call_arg_ptr_for_scalar.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs-windows/should_fail_call_arg_scalar_for_ptr.txt
+++ b/compiler/tests/outputs-windows/should_fail_call_arg_scalar_for_ptr.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_call_arg_ptr_for_scalar.txt
+++ b/compiler/tests/outputs/should_fail_call_arg_ptr_for_scalar.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_call_arg_scalar_for_ptr.txt
+++ b/compiler/tests/outputs/should_fail_call_arg_scalar_for_ptr.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_call_arg_ptr_for_scalar.nu
+++ b/compiler/tests/should_fail_call_arg_ptr_for_scalar.nu
@@ -1,0 +1,11 @@
+// should_fail_call_arg_ptr_for_scalar.nu — the argument type checker must
+// reject a pointer value (here a string literal, i8*) passed where a scalar
+// `i` parameter is expected. Without the check `( add 1 `two` )` compiled to
+// garbage (pointer arithmetic on the string's address) — the C1 hole.
+
+@ add i a i b → i { ^ + a b }
+
+@ main → i {
+    : i x ( add 1 `two` )
+    ^ 0
+}

--- a/compiler/tests/should_fail_call_arg_scalar_for_ptr.nu
+++ b/compiler/tests/should_fail_call_arg_scalar_for_ptr.nu
@@ -1,0 +1,12 @@
+// should_fail_call_arg_scalar_for_ptr.nu — the reverse of
+// should_fail_call_arg_ptr_for_scalar: a bare scalar (`42`, i64) passed
+// where a pointer parameter (`s`, i8*) is expected. The parameter's
+// pointer-ness has no literal `*`, so this only fires because the guard
+// detects pointer-ness from the lowered type.
+
+@ shout s m → v { ( nurl_print m ) }
+
+@ main → i {
+    ( shout 42 )
+    ^ 0
+}


### PR DESCRIPTION
## The hole (critic.md C1 — the top-ranked finding)

`( add 1 `two` )` — a string (`i8*`) passed where an `i` (`i64`) parameter is
declared — compiled with **exit 0** and produced garbage at runtime (pointer
arithmetic on the string's address). It's a **silent miscompile** reachable
from the first program a newcomer writes, and it directly contradicts the
README's "strong, static … no implicit conversions" guarantee.

```
$ nurlc add.nu   # @ add i a i b → i ;  ( add 1 `two` )
(exit 0)         # ← ran, printed a garbage pointer value
```

## Why it slipped through

The call-argument checker already compared each by-value argument's LLVM type
against the declared parameter type — but only via `__arg_ptr_depth_mismatch`,
which catches a **same-base** one-level pointer-depth difference (`T` vs `T*`).
It never caught the **different-base** pointer-vs-scalar case (`i8*` vs `i64`).
The guard that decides whether to run the checks also detected a pointer
parameter only by a literal leading `*`, so pointer aliases like `s` (→ `i8*`)
were skipped entirely — which is why the reverse (`( shout 42 )`, an `i64` to
an `s` parameter) also slipped.

## The fix

- New `__arg_ptr_scalar_mismatch`: fires when exactly one operand lowers to a
  pointer and the other to a non-pointer scalar. Named aggregates and `String`
  are excluded (they have their own checks, and the enum↔`i64` lowering must
  not trip).
- Detect the parameter's pointer-ness from its **lowered** type, not a literal
  `*`, so `s`/`String`/other pointer aliases are covered — this is what lets
  the reverse direction reach the check.

Now both directions error with a precise, caret-pointed diagnostic:

```
add.nu:2:36: argument 2 to 'add': value of type 'i8*' passed where parameter
expects 'i64' — pointer-vs-scalar type mismatch; NURL has no implicit
conversion between a pointer and an integer/float (convert explicitly with
'# T expr' if this is intended)
```

## Safety / testing

**Diagnostic-only** — valid programs lower byte-identically, so the bootstrap
fixed point is unaffected and no snapshot refresh is needed. Verified:
- `./build.sh` green — `nurlc.nu` self-compiles clean, fixed point holds.
- Full corpus **518 PASS · 0 FAIL** (incl. bijection) + ASan/UBSan clean.
- Valid calls (`( shout `hi` )`, `( add 1 2 )`) still compile.
- Two new `should_fail` regressions cover both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)