### PR TITLE
release: gate publish on the tagged commit's CI status (C4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,40 @@ env:
   NURL_TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
 jobs:
+  # ── Gate: the tagged commit must already have a green ci.yml run ──────
+  # Branch protection keeps `main` green, so a tag on a merged main commit
+  # passes this instantly. It exists to catch a tag pushed to a NON-main /
+  # untested SHA. It does NOT re-run the suite (that would be redundant —
+  # ci.yml runs on every push/PR); it reads the existing ci.yml conclusion
+  # for the tagged commit. Skipped on workflow_dispatch dry runs (they don't
+  # publish anyway).
+  verify-ci:
+    name: verify tagged commit passed CI
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+      - name: Require a successful ci.yml run for this SHA
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.sha;
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              head_sha: sha,
+              per_page: 100,
+            });
+            const conclusions = runs.map(r => r.conclusion);
+            if (conclusions.includes('success')) {
+              core.info(`ci.yml is green for ${sha} — proceeding.`);
+            } else {
+              core.setFailed(
+                `No successful ci.yml run for ${sha}. Tag a commit whose CI is ` +
+                `green (a merged main commit). ci.yml runs seen for this SHA: ` +
+                (conclusions.join(', ') || 'none'));
+            }
+
   # ── Linux (x86_64 + arm64), native per-arch runners ──────────────────
   linux:
     strategy:
@@ -267,14 +301,16 @@ jobs:
     # so the freebsd archive was silently dropped from the release. With all
     # three in `needs` + the `if` below, release runs after they all COMPLETE,
     # then attaches whatever each produced via the artifact glob.
-    needs: [linux, freebsd, windows]
+    needs: [verify-ci, linux, freebsd, windows]
     runs-on: ubuntu-latest
-    # Linux gates publishing; freebsd stays best-effort (continue-on-error) and
-    # windows is now a required-to-build job (its failure reds the run) but is
-    # not a hard publish gate — don't require their `result`, just that they
-    # finished. `!cancelled()` lets us publish after a best-effort job fails;
-    # still only for a real pushed tag, not a workflow_dispatch dry run.
-    if: ${{ !cancelled() && needs.linux.result == 'success' && startsWith(github.ref, 'refs/tags/v') }}
+    # verify-ci gates publishing on the tagged commit's CI being green; linux
+    # gates on the primary artifact building. freebsd stays best-effort
+    # (continue-on-error) and windows is a required-to-build job (its failure
+    # reds the run) but neither is a hard publish gate — don't require their
+    # `result`, just that they finished. `!cancelled()` lets us publish after a
+    # best-effort job fails; still only for a real pushed tag, not a
+    # workflow_dispatch dry run.
+    if: ${{ !cancelled() && needs.verify-ci.result == 'success' && needs.linux.result == 'success' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Second and final piece of critic.md **C4**, after branch protection on `main`.

## The remaining gap

`release.yml` fired on any `v*` tag and published if the *build* succeeded — it
never checked that the tagged commit had a green `ci.yml` run. Branch protection
now keeps `main` green, so tagging a merged main commit is safe; this closes the
last case: **a tag pushed to a non-main / untested SHA.**

## The fix (no re-run)

A new `verify-ci` job that the `release` job depends on. It reads the **existing**
`ci.yml` conclusion for the tagged SHA (`listWorkflowRuns` by `head_sha`) and
fails the release if there's no successful run:

```js
const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
  owner, repo, workflow_id: 'ci.yml', head_sha: context.sha, per_page: 100,
});
if (!runs.map(r => r.conclusion).includes('success')) core.setFailed(...);
```

It does **not** re-run the suite — `ci.yml` already runs on every push/PR, so a
re-run would be redundant compute (the point raised on the original C4 framing).
The release build keeps `--no-tests`. `verify-ci` is skipped on
`workflow_dispatch` dry runs, which don't publish anyway.

## Wiring

- `release` job: `needs: [verify-ci, linux, freebsd, windows]` and
  `if: … && needs.verify-ci.result == 'success' && …`.
- Real tag + CI green → publish; real tag + no green CI → release skipped;
  dry run → verify-ci skipped, release skipped (unchanged).

## Scope note

Only the publish is gated; build jobs still run on a mis-tag (rare operator
error). Gating the builds too would save compute there but adds dry-run
skip-propagation complexity for little gain — left as a possible follow-up.

Validated: `release.yml` parses and the gate is wired (`verify-ci` in
`release.needs` and its `if`). The workflow itself can only be exercised by a
real tag, so it hasn't run end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)