### PR TITLE
stdlib: cap recursion depth in XML and YAML-flow parsers (M4)

### DIFF
--- a/compiler/tests/deep_nesting_reject.nu
+++ b/compiler/tests/deep_nesting_reject.nu
@@ -1,0 +1,54 @@
+// deep_nesting_reject.nu — the XML and YAML-flow parsers must REJECT
+// pathologically deep nesting (a crafted-input stack-overflow DoS) instead of
+// recursing into a C-stack overflow. Regression for the XML_MAX_DEPTH /
+// YAML_MAX_DEPTH guards. Shallow documents must still parse.
+
+$ `stdlib/ext/xml.nu`
+$ `stdlib/ext/yaml.nu`
+$ `stdlib/core/string.nu`
+
+@ deep_rep s unit i times → String {
+    : String s ( string_new )
+    : ~ i i 0
+    ~ < i times { ( string_push_str s unit ) = i + i 1 }
+    ^ s
+}
+
+@ main → i {
+    // XML: 5000 nested <a> … </a> exceeds XML_MAX_DEPTH (256).
+    : String xopen ( deep_rep `<a>` 5000 )
+    : String xclose ( deep_rep `</a>` 5000 )
+    ( string_push_str xopen ( string_data xclose ) )
+    : !Xml XmlErr xr ( xml_parse ( string_data xopen ) )
+    ?? xr {
+        T nd → { ( nurl_print `xml: parsed deep (unexpected!)\n` ) ( xml_free nd ) }
+        F _ → ( nurl_print `xml: deep rejected\n` )
+    }
+    ( string_free xopen )
+    ( string_free xclose )
+
+    // YAML flow: 5000 nested [ exceeds YAML_MAX_DEPTH (256).
+    : String yopen ( deep_rep `[` 5000 )
+    : String yclose ( deep_rep `]` 5000 )
+    ( string_push_str yopen ( string_data yclose ) )
+    : !Json YamlErr yr ( yaml_parse ( string_data yopen ) )
+    ?? yr {
+        T j → { ( nurl_print `yaml: parsed deep (unexpected!)\n` ) ( json_free j ) }
+        F _ → ( nurl_print `yaml: deep rejected\n` )
+    }
+    ( string_free yopen )
+    ( string_free yclose )
+
+    // Shallow documents still parse.
+    : !Xml XmlErr sx ( xml_parse `<a><b>hi</b></a>` )
+    ?? sx {
+        T nd → { ( nurl_print `xml: shallow ok\n` ) ( xml_free nd ) }
+        F _ → ( nurl_print `xml: shallow rejected (unexpected!)\n` )
+    }
+    : !Json YamlErr sy ( yaml_parse `[1, [2, 3], 4]` )
+    ?? sy {
+        T j → { ( nurl_print `yaml: shallow ok\n` ) ( json_free j ) }
+        F _ → ( nurl_print `yaml: shallow rejected (unexpected!)\n` )
+    }
+    ^ 0
+}

--- a/compiler/tests/outputs-windows/deep_nesting_reject.txt
+++ b/compiler/tests/outputs-windows/deep_nesting_reject.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+xml: deep rejected
+yaml: deep rejected
+xml: shallow ok
+yaml: shallow ok

--- a/compiler/tests/outputs/deep_nesting_reject.txt
+++ b/compiler/tests/outputs/deep_nesting_reject.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+xml: deep rejected
+yaml: deep rejected
+xml: shallow ok
+yaml: shallow ok

--- a/stdlib/ext/xml.nu
+++ b/stdlib/ext/xml.nu
@@ -68,6 +68,13 @@ $ `stdlib/core/vec.nu`
 // node produced, 0 = none (hit `</` or EOF), -1 = error.
 : __XmlNode { Xml node i endpos i ok }
 
+// Hard cap on element-nesting depth. `<a><a>…` drives native recursion
+// (__xml_parse_element ↔ __xml_parse_node), so an unbounded document would
+// overflow the C stack — a crafted-input DoS. Exceeding the cap fails the
+// parse (reported as XmlSyntax) instead. XML frames are heavier than JSON's,
+// so this cap is lower than json's 1024.
+: i XML_MAX_DEPTH 256
+
 @ xml_err_name XmlErr e → s {
     ^ ?? e {
         XmlSyntax → `XmlSyntax`
@@ -500,8 +507,13 @@ $ `stdlib/core/vec.nu`
     ^ res
 }
 
-// Parse one element starting at the '<' at pos.
-@ __xml_parse_element s src i pos i n → __XmlNode {
+// Parse one element starting at the '<' at pos. `depth` is the current
+// element-nesting depth; exceeding XML_MAX_DEPTH fails the parse (ok = -1)
+// rather than recursing into a C-stack overflow.
+@ __xml_parse_element s src i pos i n i depth → __XmlNode {
+    ? >= depth XML_MAX_DEPTH {
+        ^ @ __XmlNode { ( __xml_empty ) pos -1 }
+    } {}
     : i nstart + pos 1
     ? ! ( __xml_is_name_start ( nurl_str_get src nstart ) ) {
         ^ @ __XmlNode { ( __xml_empty ) pos -1 }
@@ -528,7 +540,7 @@ $ `stdlib/core/vec.nu`
             ? ( __xml_match src cp n `</` ) {
                 = cdone T
             } {
-                : __XmlNode nd ( __xml_parse_node src cp n )
+                : __XmlNode nd ( __xml_parse_node src cp n + depth 1 )
                 ? < . nd ok 0 {
                     = cerr T
                     = cdone T
@@ -556,7 +568,7 @@ $ `stdlib/core/vec.nu`
 
 // Parse the next node (element, text, or CDATA) at pos. ok: 1 produced,
 // 0 = at `</` or EOF (no node), -1 = error.
-@ __xml_parse_node s src i pos i n → __XmlNode {
+@ __xml_parse_node s src i pos i n i depth → __XmlNode {
     : i p ( __xml_skip_misc src pos n )
     ? >= p n { ^ @ __XmlNode { ( __xml_empty ) p 0 } } {}
     ? ( __xml_match src p n `</` ) { ^ @ __XmlNode { ( __xml_empty ) p 0 } } {}
@@ -568,7 +580,7 @@ $ `stdlib/core/vec.nu`
         ^ @ __XmlNode { ( __xml_mk_text txt ) + cend 3 1 }
     } {}
     ? == ( nurl_str_get src p ) 60 {  // '<' → element
-        ^ ( __xml_parse_element src p n )
+        ^ ( __xml_parse_element src p n depth )
     } {}
     // text run up to the next '<'
     : i lt ( __xml_find_lit src p n `<` )
@@ -582,7 +594,7 @@ $ `stdlib/core/vec.nu`
     : i p ( __xml_skip_misc src 0 n )
     ? >= p n { ^ @ !Xml XmlErr { F @ XmlErr { XmlOther } } } {}
     ? != ( nurl_str_get src p ) 60 { ^ @ !Xml XmlErr { F @ XmlErr { XmlSyntax } } } {}
-    : __XmlNode nd ( __xml_parse_element src p n )
+    : __XmlNode nd ( __xml_parse_element src p n 0 )
     ? < . nd ok 0 {
         ( xml_free . nd node )
         ^ @ !Xml XmlErr { F @ XmlErr { XmlSyntax } }

--- a/stdlib/ext/yaml.nu
+++ b/stdlib/ext/yaml.nu
@@ -416,16 +416,24 @@ $ `stdlib/core/vec.nu`
     }
 }
 
-@ __yaml_flow_value s text i n i pos → __YFlow {
+// Hard cap on flow-collection nesting depth. `[[[…` / `{a:{a:…` drive native
+// recursion (__yaml_flow_value ↔ __yaml_flow_seq/__yaml_flow_map), so an
+// unbounded document would overflow the C stack — a crafted-input DoS (YAML
+// is commonly fed untrusted config). Exceeding the cap fails the parse
+// (reported as YamlSyntax) instead.
+: i YAML_MAX_DEPTH 256
+
+@ __yaml_flow_value s text i n i pos i depth → __YFlow {
+    ? >= depth YAML_MAX_DEPTH { ^ @ __YFlow { @ Json { JNull } pos F } } {}
     : i p ( __yaml_skip_sp text pos n )
     ? >= p n { ^ @ __YFlow { @ Json { JNull } p F } } {}
     : i c ( nurl_str_get text p )
-    ? == c 91 { ^ ( __yaml_flow_seq text n p ) } {}
-    ? == c 123 { ^ ( __yaml_flow_map text n p ) } {}
+    ? == c 91 { ^ ( __yaml_flow_seq text n p depth ) } {}
+    ? == c 123 { ^ ( __yaml_flow_map text n p depth ) } {}
     ^ ( __yaml_flow_scalar text n p F )
 }
 
-@ __yaml_flow_seq s text i n i pos → __YFlow {
+@ __yaml_flow_seq s text i n i pos i depth → __YFlow {
     : Json arr ( json_arr_new )
     : ~ i p + pos 1
     : ~ b done F
@@ -433,7 +441,7 @@ $ `stdlib/core/vec.nu`
     = p ( __yaml_skip_sp text p n )
     ? & < p n == ( nurl_str_get text p ) 93 { ^ @ __YFlow { arr + p 1 T } } {}
     ~ & ! done ok {
-        : __YFlow ev ( __yaml_flow_value text n p )
+        : __YFlow ev ( __yaml_flow_value text n p + depth 1 )
         ? ! . ev ok { = ok F = done T ( json_free . ev val ) } {
             ( json_arr_push arr . ev val )
             = p ( __yaml_skip_sp text . ev pos n )
@@ -450,7 +458,7 @@ $ `stdlib/core/vec.nu`
     ^ @ __YFlow { arr p ok }
 }
 
-@ __yaml_flow_map s text i n i pos → __YFlow {
+@ __yaml_flow_map s text i n i pos i depth → __YFlow {
     : Json obj ( json_obj_new )
     : ~ i p + pos 1
     : ~ b done F
@@ -467,7 +475,7 @@ $ `stdlib/core/vec.nu`
             : b nocolon | >= p n != ( nurl_str_get text p ) 58
             ? nocolon { = ok F = done T ( string_free keystr ) } {
                 = p ( __yaml_skip_sp text + p 1 n )
-                : __YFlow vv ( __yaml_flow_value text n p )
+                : __YFlow vv ( __yaml_flow_value text n p + depth 1 )
                 ? ! . vv ok { = ok F = done T ( string_free keystr ) ( json_free . vv val ) } {
                     ( json_obj_set obj ( string_data keystr ) . vv val )
                     ( string_free keystr )
@@ -491,7 +499,7 @@ $ `stdlib/core/vec.nu`
 // '[' or '{'). Trailing content after the close is ignored (lenient).
 @ __yaml_parse_flow s text → !Json YamlErr {
     : i n ( nurl_str_len text )
-    : __YFlow r ( __yaml_flow_value text n 0 )
+    : __YFlow r ( __yaml_flow_value text n 0 0 )
     ? . r ok { ^ @ !Json YamlErr { T . r val } } {}
     ( json_free . r val )
     ^ @ !Json YamlErr { F @ YamlErr { YamlSyntax } }


### PR DESCRIPTION
## The hole (critic.md M4)

`ext/xml.nu` (`__xml_parse_element` ↔ `__xml_parse_node`) and `ext/yaml.nu`
(`__yaml_flow_value` ↔ `__yaml_flow_seq`/`__yaml_flow_map`) recursed on nesting
with **no depth cap**. A crafted `<a><a><a>…` document or a `[[[…` flow
collection drives native recursion straight into a **C-stack overflow** — a
crafted-input DoS. YAML is commonly fed untrusted config, so it's the sharper
of the two. JSON / CBOR / msgpack already cap depth; these two were the gap.

## The fix

Thread a `depth` parameter through the mutually-recursive parse functions and
reject past a hard cap:

- `XML_MAX_DEPTH = 256`, `YAML_MAX_DEPTH = 256` — below JSON's 1024 because
  these frames are heavier (Vec allocations, attr lists).
- Exceeding the cap fails the parse via the **existing** error path
  (`XmlSyntax` / `YamlSyntax`) instead of recursing. A dedicated
  "depth-exceeded" variant is a possible follow-up — the DoS stop is the fix,
  and an over-deep document is rejectable either way.

XML already refuses DTDs, so the billion-laughs / entity-expansion class was
never present; this closes the remaining stack-overflow vector.

## Testing

New `deep_nesting_reject` test builds **5000-deep** XML and YAML-flow inputs and
asserts both are rejected without crashing, while shallow documents still parse:

```
xml: deep rejected
yaml: deep rejected
xml: shallow ok
yaml: shallow ok
```

Existing `xml_basic` / `yaml_basic` still pass; full corpus **520 PASS · 0
FAIL**. Stdlib-only change — no compiler or bootstrap-snapshot impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)