### PR TITLE
stdlib: rename colliding helpers + symbol-collision CI gate (M14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,14 @@ jobs:
         # linking or running anything.
         run: ./tools/check_examples.sh
 
+      - name: stdlib symbol-collision gate
+        # NURL's flat namespace makes two stdlib modules that define the
+        # same top-level @ name collide when a program imports both (link
+        # error, or a silent link-order-dependent pick — the __u32 /
+        # __free_str_vec class). Assert every stdlib @-function name is
+        # globally unique.
+        run: ./tools/check_stdlib_symbols.sh
+
       - name: nurlfmt --check (canonical-form gate)
         # Every first-party .nu file must be in canonical nurlfmt
         # form. build.sh above already produced build/nurlfmt, so

--- a/stdlib/ext/cookies.nu
+++ b/stdlib/ext/cookies.nu
@@ -58,7 +58,7 @@ $ `stdlib/std/time.nu`
     ( vec_free [Cookie] . j cookies )
 }
 
-@ __free_str_vec ( Vec String ) v → v {
+@ __cookies_free_str_vec ( Vec String ) v → v {
     : ~ i k 0
     ~ < k ( vec_len [String] v ) {
         ?? ( vec_get [String] v k ) { T s → ( string_free s ) F _ → {} }
@@ -178,7 +178,7 @@ $ `stdlib/std/time.nu`
     }
     ? == ( string_len nm ) 0 {
         ( string_free nm ) ( string_free val )
-        ( __free_str_vec parts )
+        ( __cookies_free_str_vec parts )
         ^ @ ?Cookie { F }
     } {}
 
@@ -236,7 +236,7 @@ $ `stdlib/std/time.nu`
         }
         = pi + pi 1
     }
-    ( __free_str_vec parts )
+    ( __cookies_free_str_vec parts )
 
     : Cookie c @ Cookie { nm val dom cpath expires host_only secure }
     ^ @ ?Cookie { T c }

--- a/stdlib/net/securedgram.nu
+++ b/stdlib/net/securedgram.nu
@@ -50,7 +50,7 @@ $ `stdlib/net/session.nu`
     ^ o
 }
 
-@ __u32 ( Vec u ) v i off → i { ^ ?? ( bytes_read_u32_be v off ) { T x → # i x F → 0 } }
+@ __sdg_u32 ( Vec u ) v i off → i { ^ ?? ( bytes_read_u32_be v off ) { T x → # i x F → 0 } }
 
 @ __u64 ( Vec u ) v i off → i { ^ ?? ( bytes_read_u64_be v off ) { T x → # i x F → 0 } }
 
@@ -228,7 +228,7 @@ $ `stdlib/net/session.nu`
 // Responder side: process a handshake init, reply with msg2, establish.
 @ __handle_init * SecureNode n String src ( Vec u ) buf → v {
     ? < ( vec_len [u] buf ) 101 { ^ v } {}
-    : i sender_index ( __u32 buf 1 )
+    : i sender_index ( __sdg_u32 buf 1 )
     : ( Vec u ) msg1 ( __slc buf 5 96 )
     : *Handshake hs ( noise_init F ( __node_kp n ) . n s_pub . n psk )
     : !v NoiseErr r1 ( noise_read_msg1 hs msg1 )
@@ -264,8 +264,8 @@ $ `stdlib/net/session.nu`
 // Initiator side: process the handshake response, establish.
 @ __handle_resp * SecureNode n String src ( Vec u ) buf → v {
     ? < ( vec_len [u] buf ) 57 { ^ v } {}
-    : i resp_index ( __u32 buf 1 )
-    : i our_index ( __u32 buf 5 )
+    : i resp_index ( __sdg_u32 buf 1 )
+    : i our_index ( __sdg_u32 buf 5 )
     : ( Vec u ) msg2 ( __slc buf 9 48 )
     : s pp ( __find_idx n our_index )
     ? == # i pp 0 { ( vec_free [u] msg2 ) ^ v } {}
@@ -304,7 +304,7 @@ $ `stdlib/net/session.nu`
 // datagram.
 @ __handle_data * SecureNode n String src ( Vec u ) buf → ?RecvData {
     ? < ( vec_len [u] buf ) 13 { ^ @ ?RecvData { F # RecvData 0 } } {}
-    : i recv_index ( __u32 buf 1 )
+    : i recv_index ( __sdg_u32 buf 1 )
     : i counter ( __u64 buf 5 )
     : ( Vec u ) ct ( __slc buf 13 - ( vec_len [u] buf ) 13 )
     : s pp ( __find_idx n recv_index )

--- a/stdlib/net/stun.nu
+++ b/stdlib/net/stun.nu
@@ -29,7 +29,7 @@ $ `stdlib/std/random.nu`
 
 @ __u16 ( Vec u ) v i off → i { ^ ?? ( bytes_read_u16_be v off ) { T x → # i x F → -1 } }
 
-@ __u32 ( Vec u ) v i off → i { ^ ?? ( bytes_read_u32_be v off ) { T x → # i x F → -1 } }
+@ __stun_u32 ( Vec u ) v i off → i { ^ ?? ( bytes_read_u32_be v off ) { T x → # i x F → -1 } }
 
 @ __b ( Vec u ) v i off → i { ^ ?? ( vec_get [u] v off ) { T x → # i x F → -1 } }
 
@@ -74,7 +74,7 @@ $ `stdlib/std/random.nu`
     : i len ( vec_len [u] msg )
     ? < len 20 { ^ @ ?StunAddr { F # StunAddr 0 } } {}
     ? != ( __u16 msg 0 ) 257 { ^ @ ?StunAddr { F # StunAddr 0 } } {}  // 0x0101
-    ? != ( __u32 msg 4 ) ( __stun_cookie ) { ^ @ ?StunAddr { F # StunAddr 0 } } {}
+    ? != ( __stun_u32 msg 4 ) ( __stun_cookie ) { ^ @ ?StunAddr { F # StunAddr 0 } } {}
     : ~ b txok T
     : ~ i ti 0
     ~ & txok < ti 12 {

--- a/stdlib/std/fs.nu
+++ b/stdlib/std/fs.nu
@@ -629,7 +629,7 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
 }
 
 // Free a Vec[String] and every String it owns.
-@ __free_str_vec ( Vec String ) v → v {
+@ __fs_free_str_vec ( Vec String ) v → v {
     : ( @ v String ) drop_str \ String e → v { ( string_free e ) }
     ( vec_free_with [String] v drop_str )
 }
@@ -659,7 +659,7 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
                         ?? r {
                             T → {}
                             F e → {
-                                ( __free_str_vec entries )
+                                ( __fs_free_str_vec entries )
                                 ^ @ !v IoErr { F e }
                             }
                         }
@@ -668,7 +668,7 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
                 }
                 = idx + idx 1
             }
-            ( __free_str_vec entries )
+            ( __fs_free_str_vec entries )
         }
     }
     // The directory is empty now — remove the directory itself.

--- a/tools/check_stdlib_symbols.sh
+++ b/tools/check_stdlib_symbols.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/check_stdlib_symbols.sh — assert that no two top-level
+#  @-functions in the stdlib share a name.
+#
+#  NURL's `$`-include is a flat inline-include into one LLVM module,
+#  so two stdlib modules that define the same top-level `@` name
+#  collide the moment a program imports both — a duplicate symbol at
+#  link time, or (worse) a silent link-order-dependent pick when the
+#  two definitions differ. That is exactly the `__u32` (stun vs
+#  securedgram, opposite failure sentinels) and `__free_str_vec` (fs
+#  vs cookies) bug this gate guards against.
+#
+#  Rule: every top-level `@` function name in stdlib/ is globally
+#  unique. Prefix per-module for private helpers (e.g. `__stun_u32`).
+#
+#  Scope: stdlib/ only (the shared library). Package/test programs are
+#  each their own compilation, so their names don't share this
+#  namespace. Type / enum / const names are not yet checked here.
+# ============================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+dups="$(grep -rhoE '^@ [A-Za-z_][A-Za-z0-9_]*' stdlib --include='*.nu' \
+  | awk '{ print $2 }' | sort | uniq -d)"
+
+if [ -n "$dups" ]; then
+    echo "error: duplicate top-level @-function names in stdlib" >&2
+    echo "       (NURL's flat namespace makes these collide when both modules" >&2
+    echo "        are imported into one program):" >&2
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        echo "  $name" >&2
+        grep -rnE "^@ ${name}([^A-Za-z0-9_]|\$)" stdlib --include='*.nu' \
+          | sed 's/^/    /' >&2
+    done <<< "$dups"
+    echo "Fix: rename with a per-module prefix (e.g. __stun_u32)." >&2
+    exit 1
+fi
+
+echo "stdlib symbol check: no duplicate top-level @-function names."


### PR DESCRIPTION
## The hole (critic.md M14)

NURL's `$`-include is a flat inline-include into one LLVM module, so two stdlib
modules that define the same top-level `@` name collide when a program imports
both. Two collisions existed in first-party stdlib:

- **`__u32`** — `net/stun.nu` (fails to `-1`) and `net/securedgram.nu` (fails
  to `0`): **same name, opposite failure sentinel.** A NAT-traversal program
  importing both `stun` and `securedgram` would get a link-order-dependent,
  silently-wrong `__u32` — a latent correctness bug, not just a link error.
- **`__free_str_vec`** — `std/fs.nu` and `ext/cookies.nu`.

## The fix

Both are file-local private helpers, so rename each with a per-module prefix
and update the in-file call sites:

| old | fs / stun | cookies / securedgram |
|---|---|---|
| `__u32` | `__stun_u32` | `__sdg_u32` |
| `__free_str_vec` | `__fs_free_str_vec` | `__cookies_free_str_vec` |

Behaviour is unchanged — internal renames only, no golden churn.

## Regression gate

New `tools/check_stdlib_symbols.sh`, wired into `ci.yml`'s build-test job
alongside the examples/nurlfmt gates. It fails if any two top-level
`@`-function names in `stdlib/` are identical, printing each duplicate's
locations. Verified both ways (passes clean; fails with a reintroduced dup).
Type/enum/const names are clean today and a possible follow-up.

## Testing

`cookies_basic`, `fs_*`, `stun_codec` and the full corpus (**521 PASS · 0
FAIL**) pass. Stdlib + CI only — no compiler or bootstrap-snapshot impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)