### PR TITLE
nurlc: multi-error reporting + internal-compiler-error path (M12)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -79,6 +79,34 @@
 
 // ── Abort helpers ─────────────────────────────────────────────────
 
+// Multi-error mode (rustc-style): while parse_program's per-declaration
+// recovery frame is active (g_diag_recover_active), `die` prints its
+// diagnostic and then PANICS with the __nurlc_diag__ sentinel instead of
+// exiting — parse_program catches it, resyncs the lexer to the next
+// top-level declaration, and keeps going, so one run reports many errors.
+// Outside a recovery frame (the scan pre-passes, deferred flush stages)
+// `die` stays fail-fast exit(1). Capped at NURLC_MAX_ERRORS so a cascade
+// can't scroll forever; the emitted IR after the first error is garbage,
+// but the non-zero exit makes every caller discard it.
+: ~ i g_err_count 0
+: ~ i g_diag_recover_active 0
+: i NURLC_MAX_ERRORS 20
+
+// die → __diag_abort: print-position variants share this exit/panic tail.
+@ __diag_abort → v {
+    ? != g_diag_recover_active 0
+    { = g_err_count + g_err_count 1
+        ? >= g_err_count NURLC_MAX_ERRORS
+        { ( nurl_eprintln ( nurl_str_cat3 `error: too many errors (`
+            ( nurl_str_int g_err_count ) `) — stopping here` ) )
+            ( nurl_exit 1 ) }
+        {}
+        ( nurl_panic `__nurlc_diag__` )
+    }
+    {}
+    ( nurl_exit 1 )
+}
+
 @ die i lex s msg → v {
     // Format:
     //   file:line:col: msg
@@ -94,7 +122,7 @@
     ( nurl_eprintln ( nurl_str_cat3 loc `: ` msg ) )
     ( nurl_eprintln ( nurl_lex_line_text lex ) )
     ( nurl_eprintln ( nurl_diag_caret col ) )
-    ( nurl_exit 1 )
+    ( __diag_abort )
 }
 
 // die_at: a fatal diagnostic for a deferred (post-scan) check that has only a
@@ -104,7 +132,7 @@
 // been registered and so cannot point at a single lexer position.
 @ die_at s loc s msg → v {
     ( nurl_eprintln ( nurl_str_cat3 loc `: ` msg ) )
-    ( nurl_exit 1 )
+    ( __diag_abort )
 }
 
 // Soft diagnostic — same format as `die` but does not exit. Used for
@@ -2358,7 +2386,7 @@
     ( nurl_str_cat `:` ( nurl_str_cat ( nurl_str_int g_stmt_line )
     ( nurl_str_cat `:` ( nurl_str_int g_stmt_col ) ) ) ) )
     ( nurl_eprintln ( nurl_str_cat3 loc `: ` msg ) )
-    ( nurl_exit 1 )
+    ( __diag_abort )
 }
 
 // g_stmt_bare_lit — set by gen_stmt to 1 when the statement it just
@@ -18127,41 +18155,139 @@
 
 // ── Top-level loop ─────────────────────────────────────────────────
 
+// One top-level declaration — the body of parse_program's loop, split out
+// so the multi-error recovery frame can wrap exactly one declaration.
+@ parse_toplevel_decl i lex i syms i cg → v {
+    // Grammar v2.0: consume an optional `pub` visibility prefix
+    // before dispatching to the matching decl handler. The pending
+    // flag is read-and-cleared by vis_take_pending_pub at the @-
+    // decl site (gen_fn_decl). Other decl kinds parse the prefix
+    // for forward-compat but enforcement is fn-only in v2.0.
+    ? == ( nurl_lex_type lex ) TT_PUB
+    { ( nurl_lex_advance lex )
+        = g_pending_pub 1
+    }
+    {}
+    : i tt ( nurl_lex_type lex )
+    ? == tt TT_AT { ( gen_fn_decl lex syms cg ) }
+    ? == tt TT_COLON { ( gen_const_or_struct lex syms ) }
+    ? == tt TT_AMP { ( gen_ffi_decl lex syms ) }
+    ? == tt TT_DOLLAR { ( gen_import_decl lex syms cg ) }
+    ? == tt TT_PERCENT { ( gen_trait_or_impl lex syms cg ) }
+    // A bare `|` is the most common near-miss: enums are declared
+    // `: | Name { … }`, not `| Name { … }`. (The `:`-less spelling
+    // used to be silently skipped — and only "worked" when the enum
+    // was also imported under the same name; now it's a diagnostic.)
+    ? == tt TT_PIPE { ( die lex `enum declarations start with ': |', not a bare '|' — write ': | Name { Variant... }'` ) }
+    // Anything else at the top level is a hard error. The decl loop
+    // used to silently advance past stray tokens — which is exactly
+    // how an unbalanced-brace function body slipped through: an extra
+    // `}` closed the body early, and the leftover statements (`^ x`,
+    // a stray `}`, …) leaked here and were swallowed, leaving the
+    // truncated function to silently miscompile (undef return) or to
+    // desync the scan_fn_sigs pre-pass. Refusing them turns that whole
+    // class into a diagnostic at the first leaked token.
+    { ( die lex ( nurl_str_cat3
+        `unexpected `
+        ( __tok_label tt ( nurl_lex_val lex ) )
+        ` at the top level — expected a declaration (@ fn, : const/struct/enum, & ffi, $ import, or % trait/impl). A stray '}' or leftover expression here usually means an earlier function body has unbalanced braces.` ) ) }
+}
+
+// Runtime entry points for the multi-error machinery, declared via the
+// language's own `&` FFI (NOT compiler builtins): the committed bootstrap
+// compiler must be able to compile this file, and it predates these
+// symbols — an `&` decl needs no compiler support beyond the FFI feature
+// itself. Both live in runtime_core.c and resolve from runtime.o.
+& `c` @ nurl_recover_nojournal *u fnp *u env → i
+
+& `c` @ nurl_print_buf_unwind → v
+
+// Minimal recover for the compiler's own multi-error frames (nurlc.nu
+// imports no stdlib): decompose the closure into (fn, env), run it under
+// the JOURNAL-FREE recover variant, free the env. The journal-free
+// variant matters: the journalled one makes every nurl_free scan the
+// live journal, which would make error-free compilation quadratic in
+// per-declaration allocations. The trade is that a panic leaks whatever
+// the declaration allocated — fine, the process exits non-zero shortly.
+// Returns 0 = completed, 1 = panicked (message via nurl_panic_last_msg).
+@ __diag_recover ( @ v ) closure → i {
+    : *u fnp # *u closure 0
+    : *u env # *u closure 1
+    : i rv ( nurl_recover_nojournal fnp env )
+    ( nurl_free # s env )
+    ^ rv
+}
+
+// Does the lexer sit on a token that can start a top-level declaration,
+// at column 1? (Canonical nurlfmt source puts every top-level decl at
+// column 1, so this is a reliable resync anchor; non-canonical code just
+// gets coarser recovery.)
+@ __at_toplevel_start i lex → b {
+    ? != ( nurl_lex_col lex ) 1 { ^ F } {}
+    : i tt ( nurl_lex_type lex )
+    ? == tt TT_AT { ^ T } {}
+    ? == tt TT_COLON { ^ T } {}
+    ? == tt TT_AMP { ^ T } {}
+    ? == tt TT_DOLLAR { ^ T } {}
+    ? == tt TT_PERCENT { ^ T } {}
+    ? == tt TT_PUB { ^ T } {}
+    ^ F
+}
+
+// Skip the rest of a failed declaration: advance at least one token
+// (the error may have fired ON a decl starter), then to the next
+// column-1 declaration token or EOF.
+@ __diag_resync i lex → v {
+    ? != ( nurl_lex_type lex ) TT_EOF { ( nurl_lex_advance lex ) } {}
+    ~ & != ( nurl_lex_type lex ) TT_EOF ! ( __at_toplevel_start lex ) {
+        ( nurl_lex_advance lex )
+    }
+}
+
+// The compiler itself panicked (div-by-zero, OOB, …) with no diagnostic
+// reported: an internal compiler error, not a user error. Say so loudly
+// and ask for a report — the alternative is an opaque abort.
+@ __ice_report s file s pm → v {
+    ( nurl_eprintln `` )
+    ( nurl_eprintln `internal compiler error: nurlc itself panicked` )
+    ( nurl_eprintln ( nurl_str_cat `  panic message: ` pm ) )
+    ( nurl_eprintln ( nurl_str_cat ( nurl_str_cat3 `  while processing ` file `, near line ` )
+    ( nurl_str_int g_stmt_line ) ) )
+    ( nurl_eprintln `  this is a bug in nurlc, not in your program — please report it at` )
+    ( nurl_eprintln `  https://github.com/nurl-lang/nurl/issues with the source that triggered it.` )
+    ( nurl_eprintln ( nurl_str_cat `  nurlc version: ` ( nurl_version ) ) )
+    ( nurl_exit 3 )
+}
+
 @ parse_program i lex i syms i cg → v {
     ~ != ( nurl_lex_type lex ) TT_EOF {
-        // Grammar v2.0: consume an optional `pub` visibility prefix
-        // before dispatching to the matching decl handler. The pending
-        // flag is read-and-cleared by vis_take_pending_pub at the @-
-        // decl site (gen_fn_decl). Other decl kinds parse the prefix
-        // for forward-compat but enforcement is fn-only in v2.0.
-        ? == ( nurl_lex_type lex ) TT_PUB
-        { ( nurl_lex_advance lex )
-            = g_pending_pub 1
-        }
-        {}
-        : i tt ( nurl_lex_type lex )
-        ? == tt TT_AT { ( gen_fn_decl lex syms cg ) }
-        ? == tt TT_COLON { ( gen_const_or_struct lex syms ) }
-        ? == tt TT_AMP { ( gen_ffi_decl lex syms ) }
-        ? == tt TT_DOLLAR { ( gen_import_decl lex syms cg ) }
-        ? == tt TT_PERCENT { ( gen_trait_or_impl lex syms cg ) }
-        // A bare `|` is the most common near-miss: enums are declared
-        // `: | Name { … }`, not `| Name { … }`. (The `:`-less spelling
-        // used to be silently skipped — and only "worked" when the enum
-        // was also imported under the same name; now it's a diagnostic.)
-        ? == tt TT_PIPE { ( die lex `enum declarations start with ': |', not a bare '|' — write ': | Name { Variant... }'` ) }
-        // Anything else at the top level is a hard error. The decl loop
-        // used to silently advance past stray tokens — which is exactly
-        // how an unbalanced-brace function body slipped through: an extra
-        // `}` closed the body early, and the leftover statements (`^ x`,
-        // a stray `}`, …) leaked here and were swallowed, leaving the
-        // truncated function to silently miscompile (undef return) or to
-        // desync the scan_fn_sigs pre-pass. Refusing them turns that whole
-        // class into a diagnostic at the first leaked token.
-        { ( die lex ( nurl_str_cat3
-            `unexpected `
-            ( __tok_label tt ( nurl_lex_val lex ) )
-            ` at the top level — expected a declaration (@ fn, : const/struct/enum, & ffi, $ import, or % trait/impl). A stray '}' or leftover expression here usually means an earlier function body has unbalanced braces.` ) ) }
+        // Each top-level declaration compiles under a recovery frame so a
+        // diagnostic (die → __nurlc_diag__ panic) skips just that decl and
+        // the walk continues — one run reports many errors. Nested calls
+        // (imports re-enter parse_program) nest frames; the depth counter
+        // keeps die's panic-vs-exit decision right on the way back out.
+        = g_diag_recover_active + g_diag_recover_active 1
+        : i rv ( __diag_recover \ → v { ( parse_toplevel_decl lex syms cg ) } )
+        = g_diag_recover_active - g_diag_recover_active 1
+        ? != rv 0 {
+            : s pm ( nurl_panic_last_msg )
+            ? ( seq pm `__nurlc_diag__` )
+            {  // A reported diagnostic. The panic may have unwound out of
+                // buffered closure-IR emission — reset the output stack to
+                // stdout (post-error IR is garbage; the non-zero exit makes
+                // callers discard it) and resync to the next declaration.
+                ( nurl_print_buf_unwind )
+                ( __diag_resync lex )
+            }
+            { ? > g_err_count 0
+                {  // The compiler lost its footing in state a half-parsed
+                    // declaration left behind. The diagnostics above are
+                    // real; don't bury them under an ICE report.
+                    ( nurl_eprintln `note: stopping early — the compiler could not continue past the errors above` )
+                    ( nurl_exit 1 ) }
+                { ( __ice_report ( nurl_lex_filename lex ) pm ) }
+            }
+        } {}
     }
 }
 
@@ -18273,6 +18399,17 @@
     : i lex ( nurl_lex_new src path )
     ? != g_lint 0 { = g_lint_recording 1 } {}
     ( parse_program lex syms cg )
+    // Multi-error mode: diagnostics were reported per-declaration and the
+    // walk continued. If any fired, fail NOW — the deferred stages below
+    // (generic flush, escape resolution, lint) walk state that half-parsed
+    // declarations may have left inconsistent, and the emitted IR is
+    // already garbage past the first error.
+    ? > g_err_count 0
+    { ( nurl_eprintln ( nurl_str_cat ( nurl_str_cat3 `error: aborting due to `
+        ( nurl_str_int g_err_count ) ` previous error` )
+        ? > g_err_count 1 `s` `` ) )
+        ( nurl_exit 1 ) }
+    {}
     // Stop recording new lint targets before flushing generic
     // monomorphisations — those are synthetic, not the user's source.
     = g_lint_recording 0

--- a/compiler/tests/diag_multi_error.nu
+++ b/compiler/tests/diag_multi_error.nu
@@ -1,0 +1,24 @@
+// diag_multi_error.nu — multi-error reporting: one nurlc run must report
+// EVERY failing declaration (not stop at the first), then the summary
+// line. Three independent errors in three functions; the golden pins all
+// three diagnostics, their locations, and the "aborting due to 3
+// previous errors" tail. Regression for the per-declaration recovery
+// frame (die → resync → continue).
+
+@ f1 → i {
+    : i x `oops`
+    ^ x
+}
+
+@ f2 → i {
+    ^ ( no_such_fn 1 )
+}
+
+@ f3 → i {
+    : i y 1.5
+    ^ y
+}
+
+@ main → i {
+    ^ + ( f1 ) + ( f2 ) ( f3 )
+}

--- a/compiler/tests/outputs-windows/diag_multi_error.txt
+++ b/compiler/tests/outputs-windows/diag_multi_error.txt
@@ -1,0 +1,8 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_multi_error.nu:9:5: value of type 'i8*' cannot initialise / assign a binding of type 'i64' — NURL has no implicit conversions; use a matching value or convert with '# T expr'
+compiler/tests/diag_multi_error.nu:14:22: call to unknown function 'no_such_fn' — it is not defined in this file, not in any '$'-imported file processed so far, and not a known FFI/builtin. Add the missing '$' import (or move it above this file's import in the program), or check the spelling.
+    ^ ( no_such_fn 1 )
+                     ^
+compiler/tests/diag_multi_error.nu:18:5: value of type 'double' cannot initialise / assign a binding of type 'i64' — NURL has no implicit conversions; use a matching value or convert with '# T expr'
+error: aborting due to 3 previous errors

--- a/compiler/tests/outputs/diag_multi_error.txt
+++ b/compiler/tests/outputs/diag_multi_error.txt
@@ -1,0 +1,8 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_multi_error.nu:9:5: value of type 'i8*' cannot initialise / assign a binding of type 'i64' — NURL has no implicit conversions; use a matching value or convert with '# T expr'
+compiler/tests/diag_multi_error.nu:14:22: call to unknown function 'no_such_fn' — it is not defined in this file, not in any '$'-imported file processed so far, and not a known FFI/builtin. Add the missing '$' import (or move it above this file's import in the program), or check the spelling.
+    ^ ( no_such_fn 1 )
+                     ^
+compiler/tests/diag_multi_error.nu:18:5: value of type 'double' cannot initialise / assign a binding of type 'i64' — NURL has no implicit conversions; use a matching value or convert with '# T expr'
+error: aborting due to 3 previous errors

--- a/compiler/tests/run_san_tests.sh
+++ b/compiler/tests/run_san_tests.sh
@@ -109,7 +109,7 @@ export UBSAN_OPTIONS="${UBSAN_OPTIONS:-print_stacktrace=1:halt_on_error=0}"
 
 # should_fail_* are compile-time negative tests; nurlfmt_idempotent is a
 # shell round-trip, not a binary; *_mod are helper modules without main().
-SKIP_RE='(should_fail_|nurlfmt_idempotent|alias_rewrite_types_mod)'
+SKIP_RE='(should_fail_|diag_|nurlfmt_idempotent|alias_rewrite_types_mod)'
 
 # ── per-test worker (exported, fanned out with xargs -P) ─────────
 # Echoes a single "<name> <VERDICT>" line; writes its own logs under

--- a/compiler/tests/run_tests.bat
+++ b/compiler/tests/run_tests.bat
@@ -159,12 +159,13 @@ REM net_* (except net_basic) opt-in via NURL_NET_TESTS=1.
 if "%name:~0,4%"=="net_" if not "%name%"=="net_basic" if not "%NURL_NET_TESTS%"=="1" set "SKIP=1"
 if "%SKIP%"=="1" exit /b 0
 
-REM borrow_* and should_fail_* expect COMPILE FAIL; borrow_strict_*
+REM borrow_*, diag_* and should_fail_* expect COMPILE FAIL; borrow_strict_*
 REM only fires under the stricter checker flag (mirrors run_tests.sh).
 set "EXPECT_FAIL=0"
 set "CFLAGS="
 if "%name:~0,12%"=="should_fail_" set "EXPECT_FAIL=1"
 if "%name:~0,7%"=="borrow_"       set "EXPECT_FAIL=1"
+if "%name:~0,5%"=="diag_"         set "EXPECT_FAIL=1"
 if "%name:~0,14%"=="borrow_strict_" set "CFLAGS=--strict-borrowck"
 
 "%NURLC%" %CFLAGS% "%src%" > "%ll%" 2>"%err%"

--- a/compiler/tests/run_tests.ps1
+++ b/compiler/tests/run_tests.ps1
@@ -291,6 +291,18 @@ $results = $names | ForEach-Object -ThrottleLimit $Jobs -Parallel {
             $act = "COMPILE FAIL`n"
         }
     }
+    elseif ($name -like 'diag_*') {
+        # diag_* — like should_fail_ but the diagnostic TEXT is baselined
+        # (default flags; front-end stderr captured verbatim).
+        $r = Run-Proc $Nurlc @($src) $RootDir
+        if ($r.Code -eq 0) {
+            $act = "COMPILE OK`n(expected COMPILE FAIL but compiler accepted it)`n"
+        } else {
+            $act = "COMPILE FAIL`n"
+            $e = Normalize $r.Err
+            if ($e.Length -gt 0) { $act += "ERRORS`n" + (Cap-Lines (Strip-Root $e)) }
+        }
+    }
     else {
         $isWarn = $name -like 'should_warn_*'
         $r = Run-Proc $Nurlc @($src) $RootDir

--- a/compiler/tests/run_tests.sh
+++ b/compiler/tests/run_tests.sh
@@ -8,8 +8,8 @@
 #
 #  Record shapes (the golden file holds exactly these lines):
 #
-#    normal test          should_fail_* / should_*       borrow_*
-#    ───────────          ─────────────────────────      ────────
+#    normal test          should_fail_* / should_*       borrow_* / diag_*
+#    ───────────          ─────────────────────────      ─────────────────
 #    COMPILE OK           COMPILE FAIL                   COMPILE FAIL
 #    LINK OK                                             ERRORS
 #    EXIT <n>                                            <diagnostics>
@@ -235,6 +235,18 @@ run_one() {
             { echo "COMPILE OK"; echo "(expected COMPILE FAIL but compiler accepted it)"; } > "$act"
         else
             echo "COMPILE FAIL" > "$act"
+        fi
+    # ── diag_* — like should_fail_ but the diagnostic TEXT is baselined
+    #            (default flags, front-end stderr captured verbatim).
+    #            For multi-error / diagnostic-quality regressions where
+    #            WHAT was reported matters, not just that compilation
+    #            failed.
+    elif [[ "$name" == diag_* ]]; then
+        if "$NURLC" "$src" > "$ll" 2>"$err"; then
+            { echo "COMPILE OK"; echo "(expected COMPILE FAIL but compiler accepted it)"; } > "$act"
+        else
+            { echo "COMPILE FAIL"; } > "$act"
+            if [[ -s "$err" ]]; then strip_root "$err"; echo "ERRORS" >> "$act"; append_capped "$act" "$err"; fi
         fi
     else
         # ── should_warn_* keep the compile diagnostic as WARNINGS ──

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1379,6 +1379,26 @@ foo.nu:6:3: error: bare identifier 'nurl_print' as a statement has no
   ^
 ```
 
+**Multi-error reporting.** One `nurlc` run reports the errors of *every*
+failing top-level declaration, not just the first: a diagnostic aborts
+only the declaration it fired in, the compiler resynchronises to the
+next top-level declaration, and the run ends with an
+`error: aborting due to N previous error(s)` summary and a non-zero
+exit. Reporting is capped at 20 errors per run (`too many errors`).
+Two scopes stay fail-fast (first error exits immediately): the
+structural pre-scan passes that run before the main walk, and the
+deferred stages after it (generic-instantiation flush). On wasm32-wasi
+the resynchronisation mechanism is unavailable (no unwinding), so the
+compiler degrades to fail-fast there. Any IR emitted after the first
+error is garbage; the non-zero exit makes every caller discard it.
+
+**Internal compiler errors.** If the compiler *itself* panics while
+processing a declaration — as opposed to reporting a diagnostic about
+the program — it prints an `internal compiler error:` report naming the
+panic message, the file and approximate line being processed, and the
+compiler version, asks for a bug report, and exits with status 3
+(distinct from status 1, a rejected program).
+
 ### 10.3 The grammar v2.1 Tier-A diagnostics
 
 Four new diagnostics shipped 2026-05-25 closing the remaining

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -449,6 +449,22 @@ void nurl_print_buf_reset(void) {
     }
 }
 
+/* Hard-unwind the whole buffering stack back to stdout mode, freeing any
+ * saved frames. For panic-recovery paths (nurlc's multi-error resync):
+ * a panic can fire while frames pushed by nurl_print_buf_start are still
+ * open, and the matching _stop calls will never run — without this, later
+ * output would land in an abandoned buffer via stale frames. */
+void nurl_print_buf_unwind(void) {
+    outbuf_init();
+    while (g_outbuf_sp > 0) {
+        struct OutbufFrame *f = &g_outbuf_stack[--g_outbuf_sp];
+        if (f->bytes) { free(f->bytes); f->bytes = NULL; }
+    }
+    g_outbuf_len  = 0;
+    g_outbuf[0]   = '\0';
+    g_outbuf_mode = 0;
+}
+
 /* Print without a trailing newline. */
 void nurl_print(const char *s) {
     if (g_outbuf_mode) {
@@ -1621,6 +1637,32 @@ long long nurl_recover(void *fn_ptr, void *env_ptr) {
     return 1;
 }
 
+/* Like nurl_recover but WITHOUT activating the allocation journal.
+ * For recovery extents on a program's error/exit path (nurlc's
+ * multi-error resync): the journal exists to prevent unwind leaks, but
+ * it makes every nurl_free scan the live journal — quadratic when the
+ * extent allocates heavily. Here the caller accepts that a panic leaks
+ * whatever the extent allocated (the process is about to exit non-zero
+ * anyway) in exchange for ZERO happy-path overhead: with jrnl_active
+ * unchanged, journal pushes stay no-ops and nurl_free never scans. */
+long long nurl_recover_nojournal(void *fn_ptr, void *env_ptr) {
+    if (!fn_ptr) return 0;
+    NurlPanicFrame frame;
+    frame.msg   = NULL;
+    frame.jmark = nurl__jrnl_mark();
+    frame.prev  = nurl__panic_top;
+    nurl__panic_top = &frame;
+    if (setjmp(frame.jb) == 0) {
+        ((void (*)(void *))fn_ptr)(env_ptr);
+        nurl__panic_top = frame.prev;
+        return 0;
+    }
+    nurl__panic_top = frame.prev;
+    free(nurl__panic_last_msg);
+    nurl__panic_last_msg = frame.msg ? frame.msg : strdup("(no panic message)");
+    return 1;
+}
+
 /* Captured panic message from the most recent recover-with-panic on
  * this thread. BORROWED — overwritten by the next panic. */
 const char *nurl_panic_last_msg(void) {
@@ -1673,6 +1715,14 @@ void nurl_panic(const char *msg) {
         *   - nurl_panic_last_msg always returns "". */
 
 long long nurl_recover(void *fn_ptr, void *env_ptr) {
+    if (!fn_ptr) return 0;
+    ((void (*)(void *))fn_ptr)(env_ptr);
+    return 0;
+}
+
+/* Same stub shape: run inline, no unwind (a panic aborts). nurlc's
+ * multi-error resync therefore degrades to fail-fast on wasm. */
+long long nurl_recover_nojournal(void *fn_ptr, void *env_ptr) {
     if (!fn_ptr) return 0;
     ((void (*)(void *))fn_ptr)(env_ptr);
     return 0;


### PR DESCRIPTION
The two biggest diagnostics gaps from critic.md M12, one mechanism.

## Before

- **One error per run.** `die` printed and exited — a refactor with 10 type
  errors took 10 compiles to enumerate.
- **No ICE story.** When the compiler itself failed, the user got an opaque
  abort or a downstream clang error, with nothing saying "this is a nurlc bug".

## After

```
$ nurlc multi.nu
multi.nu:2:5:  value of type 'i8*' cannot initialise ... 'i64' — ...
multi.nu:7:22: call to unknown function 'unknown_fn' — ...
multi.nu:11:5: value of type 'double' cannot initialise ... 'i64' — ...
error: aborting due to 3 previous errors
```

and when the compiler itself panics (verified with an injected panic):

```
internal compiler error: nurlc itself panicked
  panic message: ...
  while processing ice.nu, near line 1
  this is a bug in nurlc, not in your program — please report it at
  https://github.com/nurl-lang/nurl/issues with the source that triggered it.
  nurlc version: v0.11.2-...
(exit 3 — distinct from a rejected program's exit 1)
```

## How

`parse_program` compiles each top-level declaration under a **recovery frame**.
`die` prints its diagnostic, then panics with a sentinel; the frame catches it,
resets the buffered-output stack, resyncs the lexer to the next column-1
declaration token, and continues. Capped at 20. Pre-scan passes and the
deferred post-parse stages stay fail-fast; imports nest frames (per-file
resync). A **non-sentinel** panic with no prior diagnostics → the ICE report;
with prior diagnostics it stops quietly so a recovery cascade can't bury real
errors under a scary ICE.

**Zero happy-path cost, by construction:** new runtime entry
`nurl_recover_nojournal` installs the setjmp frame *without* activating the
allocation journal — the journalled variant makes every `nurl_free` scan the
live journal, which would have made clean compilation quadratic in
per-declaration allocations. The trade: a panicking declaration leaks what it
allocated, on a path that exits non-zero anyway. `nurl_print_buf_unwind`
hard-resets the output stack a panic may have unwound through mid-closure-IR
emission.

**Bootstrap-clean:** both runtime entries are declared in nurlc.nu via the
language's own `&` FFI, *not* as compiler builtins — the committed bootstrap
compiler predates them, and an `&` decl needs no compiler support beyond the
FFI feature itself. So the old snapshot compiles the new source: **no
bootstrap refresh**, and valid-program IR is verified **byte-identical** to the
pre-change compiler.

## Verified

- 3 errors in 3 fns → all reported + summary; singular/plural correct.
- Error **inside buffered closure emission** + a later error → both reported
  (output-stack unwind works).
- 25-error file → capped at 20 with `too many errors`.
- Error in an **import** + in the main file → both, correct per-file locations.
- ICE: injected panic → exit 3 report (injection removed).
- Recovery paths **ASan/UBSan-clean**; wasm32-wasi degrades to fail-fast
  (no unwinding) — documented in spec §10.2.
- Fixed point holds; full corpus **523 PASS · 0 FAIL**.

## Test infrastructure

New `diag_*` category (COMPILE FAIL + stderr baselined, default flags) in
`run_tests.sh` / `.ps1` / `.bat`, skipped by the san runner like
`should_fail_`. `diag_multi_error` pins all three diagnostics + the summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)