### PR TITLE
stdlib: leaf-site error-handling combinators — expect/unwrap/or_else/bridges (M13)

### DIFF
--- a/compiler/tests/expect_unwrap.nu
+++ b/compiler/tests/expect_unwrap.nu
@@ -1,0 +1,90 @@
+// expect_unwrap.nu — the leaf-site error-handling combinators (critic M13):
+// res_expect / res_unwrap / res_unwrap_or_else / res_ok / res_err and
+// opt_expect / opt_unwrap / opt_unwrap_or_else / opt_ok_or. Happy paths
+// return the payload; the panicking paths are caught with recover and the
+// message round-trips. A struct payload checks the `. r 1` extraction on
+// aggregates, not just scalars.
+
+$ `stdlib/core/option.nu`
+$ `stdlib/core/result.nu`
+$ `stdlib/std/panic.nu`
+$ `stdlib/core/string.nu`
+
+: Point { i x i y }
+
+@ ok_i → !i s {
+    ^ @ !i s { T 42 }
+}
+
+@ err_i → !i s {
+    ^ @ !i s { F `boom` }
+}
+
+@ some_p → ?Point {
+    ^ @ ?Point { T @ Point { 3 4 } }
+}
+
+@ none_i → ?i {
+    ^ @ ?i { F }
+}
+
+@ main → i {
+    // ── happy paths ──────────────────────────────────────────────
+    ( nurl_print `expect ok: ` )
+    ( nurl_print_int ( res_expect [i s] ( ok_i ) `should not fire` ) )
+    ( nurl_print `\n` )
+    ( nurl_print `unwrap ok: ` )
+    ( nurl_print_int ( res_unwrap [i s] ( ok_i ) ) )
+    ( nurl_print `\n` )
+    : Point p ( opt_expect [Point] ( some_p ) `should not fire` )
+    ( nurl_print `opt expect struct: ` )
+    ( nurl_print_int + . p x . p y )
+    ( nurl_print `\n` )
+
+    // ── or_else fallbacks ────────────────────────────────────────
+    ( nurl_print `res or_else: ` )
+    ( nurl_print_int ( res_unwrap_or_else [i s] ( err_i ) \ s _e → i { ^ -1 } ) )
+    ( nurl_print `\n` )
+    ( nurl_print `opt or_else: ` )
+    ( nurl_print_int ( opt_unwrap_or_else [i] ( none_i ) \ → i { ^ -2 } ) )
+    ( nurl_print `\n` )
+
+    // ── bridges ──────────────────────────────────────────────────
+    ( nurl_print `res_ok some: ` )
+    ( nurl_print_int ( opt_unwrap_or [i] ( res_ok [i s] ( ok_i ) ) 0 ) )
+    ( nurl_print `\n` )
+    ( nurl_print `res_err some: ` )
+    ( nurl_print ( opt_unwrap_or [s] ( res_err [i s] ( err_i ) ) `none` ) )
+    ( nurl_print `\n` )
+    ( nurl_print `ok_or err: ` )
+    : !i s bridged ( opt_ok_or [i s] ( none_i ) `was-none` )
+    ?? bridged {
+        T v → ( nurl_print_int v )
+        F e → ( nurl_print e )
+    }
+    ( nurl_print `\n` )
+
+    // ── panic paths, caught ──────────────────────────────────────
+    : !v PanicInfo r1 ( recover \ → v { : i _x ( res_expect [i s] ( err_i ) `parse the config` ) } )
+    ?? r1 {
+        T _ → ( nurl_print `expect: no panic (bug)\n` )
+        F pi → {
+            ( nurl_print `expect panicked: ` )
+            ( nurl_print ( string_data . pi msg ) )
+            ( nurl_print `\n` )
+            ( panic_info_free pi )
+        }
+    }
+    : !v PanicInfo r2 ( recover \ → v { : i _y ( opt_unwrap [i] ( none_i ) ) } )
+    ?? r2 {
+        T _ → ( nurl_print `unwrap: no panic (bug)\n` )
+        F pi → {
+            ( nurl_print `unwrap panicked: ` )
+            ( nurl_print ( string_data . pi msg ) )
+            ( nurl_print `\n` )
+            ( panic_info_free pi )
+        }
+    }
+    ( nurl_print `alive\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs-windows/expect_unwrap.txt
+++ b/compiler/tests/outputs-windows/expect_unwrap.txt
@@ -1,0 +1,21 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+expect ok: 42
+
+unwrap ok: 42
+
+opt expect struct: 7
+
+res or_else: -1
+
+opt or_else: -2
+
+res_ok some: 42
+
+res_err some: boom
+ok_or err: was-none
+expect panicked: parse the config
+unwrap panicked: opt_unwrap on a None value
+alive

--- a/compiler/tests/outputs/expect_unwrap.txt
+++ b/compiler/tests/outputs/expect_unwrap.txt
@@ -1,0 +1,21 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+expect ok: 42
+
+unwrap ok: 42
+
+opt expect struct: 7
+
+res or_else: -1
+
+opt or_else: -2
+
+res_ok some: 42
+
+res_err some: boom
+ok_or err: was-none
+expect panicked: parse the config
+unwrap panicked: opt_unwrap on a None value
+alive

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -903,6 +903,15 @@ at the next 1–3 tokens:
 : n \ ( parse_int src )              // try-propagate Result
 ```
 
+`\` propagation requires the **enclosing function** to return a
+compatible `?` / `!` shape (same error type for results). At a site
+that cannot propagate — a `→ i` `main`, a callback with a fixed
+signature — use the leaf-site combinators from the stdlib instead of
+nesting `??`: `res_expect` / `opt_expect` (payload or panic with your
+message), `res_unwrap_or` / `res_unwrap_or_else` (payload or fallback),
+and the `res_ok` / `res_err` / `opt_ok_or` bridges
+(`stdlib/core/result.nu`, `stdlib/core/option.nu`).
+
 A closure compiles to a 16-byte `{ fn_ptr, env_ptr }` value. Captures
 are stored in a heap-allocated environment struct. A closure that
 provably does **not** escape its creating frame has that env reclaimed

--- a/examples/json_basic.nu
+++ b/examples/json_basic.nu
@@ -15,6 +15,7 @@
 //   err trailing: trailing garbage
 
 $ `stdlib/ext/json.nu`
+$ `stdlib/core/result.nu`
 
 @ show_err s label JsonError e → v {
     ( nurl_print label )
@@ -360,24 +361,22 @@ $ `stdlib/ext/json.nu`
         F → {}
     }
 
-    // 17. json_eq round-trip on a parsed object
-    : !Json JsonError e1 ( json_parse `{"x":1,"y":2}` )
-    : !Json JsonError e2 ( json_parse `{"x":1,"y":2}` )
-    : !Json JsonError e3 ( json_parse `{"x":1,"y":3}` )
-    ?? e1 { T j1 → {
-            ?? e2 { T j2 → {
-                    ?? e3 { T j3 → {
-                            ( nurl_print `eq_same=` )
-                            ( nurl_print ? ( json_eq j1 j2 ) `T` `F` )
-                            ( nurl_print ` eq_diff=` )
-                            ( nurl_print ? ( json_eq j1 j3 ) `T` `F` )
-                            ( nurl_print `\n` )
-                            ( json_free j3 )
-                        } F _ → {} }
-                    ( json_free j2 )
-                } F _ → {} }
-            ( json_free j1 )
-        } F _ → {} }
+    // 17. json_eq round-trip on a parsed object. main returns `i` so `\`
+    // cannot propagate here — `res_expect` (stdlib/core/result.nu) is the
+    // leaf-site tool: Ok payload straight out, panic with the message on
+    // Err. Compare this flat sequence with the triple-nested `??` pyramid
+    // it replaced.
+    : Json j1 ( res_expect [Json JsonError] ( json_parse `{"x":1,"y":2}` ) `parse j1` )
+    : Json j2 ( res_expect [Json JsonError] ( json_parse `{"x":1,"y":2}` ) `parse j2` )
+    : Json j3 ( res_expect [Json JsonError] ( json_parse `{"x":1,"y":3}` ) `parse j3` )
+    ( nurl_print `eq_same=` )
+    ( nurl_print ? ( json_eq j1 j2 ) `T` `F` )
+    ( nurl_print ` eq_diff=` )
+    ( nurl_print ? ( json_eq j1 j3 ) `T` `F` )
+    ( nurl_print `\n` )
+    ( json_free j3 )
+    ( json_free j2 )
+    ( json_free j1 )
 
     ( json_free dup )
     ( string_free built_s )

--- a/stdlib/core/option.nu
+++ b/stdlib/core/option.nu
@@ -8,8 +8,18 @@
 //   ( opt_is_some [T] o )          → b       true iff o = Some
 //   ( opt_is_none [T] o )          → b       true iff o = None
 //   ( opt_unwrap_or [T] o default) → T       payload if Some, default otherwise
+//   ( opt_unwrap_or_else [T] o f ) → T       payload if Some, ( f ) otherwise
+//   ( opt_unwrap [T] o )           → T       payload, PANICS on None
+//   ( opt_expect [T] o msg )       → T       payload, PANICS with msg on None
+//   ( opt_ok_or [T E] o err )      → !T E    Some(v) → Ok(v); None → Err(err)
 //   ( opt_map [T U] o f )          → ?U      None → None; Some(v) → Some(f v)
 //   ( opt_and_then [T U] o f )     → ?U      None → None; Some(v) → f v
+//
+// Leaf-site tools: at a site that cannot `\`-propagate (a `→ i` main, a
+// callback with a fixed signature), `opt_expect` / `opt_unwrap` take the
+// payload or PANIC — a real NURL panic: recover-able, and the unwind
+// journal reclaims tracked owned values (docs/MEMORY.md §7). Prefer
+// `opt_expect` with a message that names what was being attempted.
 //
 // Type-variable names use A/B (not T/U) to avoid colliding with the boolean
 // literal `T` used inside `@ ? A { T ... }` constructors.
@@ -27,6 +37,31 @@
 
 @ opt_unwrap_or [A] ? A o A default → A {
     ^ ?? o { T v → v F → default }
+}
+
+@ opt_unwrap_or_else [A] ? A o ( @ A ) f → A {
+    ^ ?? o { T v → v F → ( f ) }
+}
+
+// Payload or PANIC with `msg` (recover-able; see the header note).
+@ opt_expect [A] ? A o s msg → A {
+    ? ( opt_is_none [A] o ) { ( nurl_panic msg ) } {}
+    ^ . o 1
+}
+
+@ opt_unwrap [A] ? A o → A {
+    ? ( opt_is_none [A] o ) { ( nurl_panic `opt_unwrap on a None value` ) } {}
+    ^ . o 1
+}
+
+// Option → Result bridge: Some(v) → Ok(v), None → Err(err). `err` is
+// consumed (moved into the result) on the None path and dropped by the
+// caller's normal ownership on the Some path.
+@ opt_ok_or [A E] ? A o E err → !A E {
+    ^ ?? o {
+        T v → @ !A E { T v }
+        F → @ !A E { F err }
+    }
 }
 
 @ opt_map [A B] ? A o ( @ B A ) f → ?B {

--- a/stdlib/core/result.nu
+++ b/stdlib/core/result.nu
@@ -10,9 +10,22 @@
 //   ( res_is_ok      [T E]   r )           → b     true iff r = Ok
 //   ( res_is_err     [T E]   r )           → b     true iff r = Err
 //   ( res_unwrap_or  [T E]   r default )   → T     Ok payload or default
+//   ( res_unwrap_or_else [T E] r f )       → T     Ok payload or ( f err )
+//   ( res_unwrap     [T E]   r )           → T     Ok payload, PANICS on Err
+//   ( res_expect     [T E]   r msg )       → T     Ok payload, PANICS with msg on Err
+//   ( res_ok         [T E]   r )           → ?T    Ok(v) → Some(v); Err → None
+//   ( res_err        [T E]   r )           → ?E    Err(e) → Some(e); Ok → None
 //   ( res_map        [T U E] r f )         → !U E  f: T → U; Err forwards
 //   ( res_and_then   [T U E] r f )         → !U E  f: T → !U E; Err forwards
 //   ( res_map_err    [T E G] r fe )        → !T G  fe: E → G; Ok forwards
+//
+// Leaf-site tools: at a site that cannot `\`-propagate (a `→ i` main, a
+// callback with a fixed signature), `res_expect` / `res_unwrap` take the
+// Ok payload or PANIC — a real NURL panic: recover-able, and the unwind
+// journal reclaims tracked owned values (docs/MEMORY.md §7). Prefer
+// `res_expect` with a message that names what was being attempted; the
+// Err payload itself is not rendered (no generic display dispatch), so
+// say it in the message.
 //
 // Forwarding note: the Err branch is rebuilt via `@ ! U E { F . r 2 }`. `!T E`
 // and `!U E` share the same Err slot type E in field 2, so `. r 2` yields the
@@ -38,6 +51,39 @@
 
 @ res_unwrap_or [A E] ! A E r A default → A {
     ^ ?? r { T v → v F → default }
+}
+
+@ res_unwrap_or_else [A E] ! A E r ( @ A E ) f → A {
+    ^ ?? r {
+        T v → v
+        F e → ( f # E e )
+    }
+}
+
+// Ok payload or PANIC with `msg` (recover-able; see the header note).
+@ res_expect [A E] ! A E r s msg → A {
+    ? ( res_is_err [A E] r ) { ( nurl_panic msg ) } {}
+    ^ . r 1
+}
+
+@ res_unwrap [A E] ! A E r → A {
+    ? ( res_is_err [A E] r ) { ( nurl_panic `res_unwrap on an Err value` ) } {}
+    ^ . r 1
+}
+
+// Result → Option bridges (drop the other payload).
+@ res_ok [A E] ! A E r → ?A {
+    ^ ?? r {
+        T v → @ ?A { T v }
+        F → @ ?A { F }
+    }
+}
+
+@ res_err [A E] ! A E r → ?E {
+    ^ ?? r {
+        T → @ ?E { F }
+        F e → @ ?E { T # E e }
+    }
 }
 
 @ res_map [A B E] ! A E r ( @ B A ) f → !B E {


### PR DESCRIPTION
## The gap (critic.md M13)

`\` propagation requires the enclosing function to return a compatible `?`/`!`
shape. At a site that can't propagate — a `→ i` `main`, a fixed-signature
callback — the only tool was nested `??`, producing real match pyramids
(`examples/json_basic.nu` §17: triple-nested `??` where every intermediate
`F _ → {}` is boilerplate).

## The fix — the standard leaf-site set, no new syntax

The grammar is locked for 1.0, so this is the combinator route:

| combinator | behavior |
|---|---|
| `res_expect` / `opt_expect` | payload, or **panic with the caller's message** |
| `res_unwrap` / `opt_unwrap` | payload, or panic with a fixed message |
| `res_unwrap_or_else` / `opt_unwrap_or_else` | payload, or closure fallback |
| `res_ok` / `res_err` / `opt_ok_or` | Result ↔ Option bridges |

The panicking pair is the Rust `expect`/`unwrap` precedent, and it's honest in
NURL terms: a **real panic** — recover-able, and the unwind journal reclaims
tracked owned values. Verified **leak-clean under LSan including the panic
paths** (the loop-drop + journal work from #424 carrying its weight). The Err
payload is not rendered (no generic display dispatch — trait bounds are
guarantee-not-dispatch), so the docs tell callers to name what was being
attempted in the message.

## Before / after (the critic's cited pyramid, now in-tree)

```
?? e1 { T j1 → {                        : Json j1 ( res_expect [Json JsonError] ( json_parse … ) `parse j1` )
    ?? e2 { T j2 → {                    : Json j2 ( res_expect [Json JsonError] ( json_parse … ) `parse j2` )
        ?? e3 { T j3 → {           →    : Json j3 ( res_expect [Json JsonError] ( json_parse … ) `parse j3` )
            …                           ( nurl_print … )
        } F _ → {} } … } F _ → {} } … } F _ → {} }
```

Identical output (`eq_same=T eq_diff=F`). spec §6.4 now routes non-propagating
sites here instead of nested `??`.

## Testing

New `expect_unwrap` test: all nine combinators — happy paths, **struct payload**
extraction (validates `. r 1`/`. o 1` on aggregates), closure fallbacks,
bridges, and both panic paths caught via `recover` with message round-trip.
LSan-clean. Stdlib + docs only — no compiler change, no snapshot churn. Full
corpus **525 PASS**; examples gate **90 PASS**.

Deliberately not done: `main → !i E` (Rust's `Termination`) — needs generic-E
rendering at the C wrapper; noted in critic.md as a possible future nicety. The
leaf-site problem itself is solved without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)