### PR TITLE
fuzz: mutational parser fuzzer (x509/DER + formats) + weekly CI for both fuzzers (M5)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,69 @@
+name: fuzz
+
+# Continuous fuzzing — NOT a per-PR gate (it would slow every merge and its
+# value is in breadth over time, not a single run). Runs weekly and on demand:
+#   1. differential integer/float miscompile fuzzer (tools/fuzz/fuzz.sh):
+#      generate a self-checking program + a Python oracle, compile at -O0 and
+#      -O2, require stdout(-O0) == stdout(-O2) == oracle. Found 7 real
+#      miscompiles historically.
+#   2. mutational parser fuzzer (tools/fuzz/fuzz_parsers.sh): mutate seeds for
+#      the untrusted-input parsers (x509/DER, cbor, msgpack, json, yaml, xml,
+#      toml) against an ASan+UBSan harness; any crash / OOB / UB / hang is a
+#      finding.
+# Either finding fails the run and uploads the reproducer inputs as artifacts.
+# Seed corpora live in-tree (tools/fuzz/gen.py, tools/fuzz/fuzz_parsers.py).
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'          # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      diff_seeds:
+        description: 'differential fuzzer: number of seeds'
+        default: '1500'
+      parser_iters:
+        description: 'parser fuzzer: iterations per RNG seed'
+        default: '4000'
+
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps (clang + optional FFI libs)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            clang pkg-config \
+            libcurl4-openssl-dev libssl-dev libsqlite3-dev \
+            libpq-dev zlib1g-dev libzstd-dev
+          clang --version
+
+      - name: Build toolchain
+        run: ./build.sh --no-tests
+
+      - name: Differential miscompile fuzzer
+        run: ./tools/fuzz/fuzz.sh 1 "${{ github.event.inputs.diff_seeds || '1500' }}"
+
+      - name: Parser fuzzer (ASan + UBSan)
+        # Two RNG seeds for a bit of breadth; each builds the harness once and
+        # runs N mutated inputs. 8s per-input timeout catches hangs.
+        run: |
+          iters="${{ github.event.inputs.parser_iters || '4000' }}"
+          ./tools/fuzz/fuzz_parsers.sh 1 "$iters" 8
+          ./tools/fuzz/fuzz_parsers.sh 2 "$iters" 8
+
+      - name: Upload reproducers on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-failures
+          path: tools/fuzz/failures/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/tools/fuzz/README.md
+++ b/tools/fuzz/README.md
@@ -1,12 +1,22 @@
-# tools/fuzz — differential miscompile testing for nurlc
+# tools/fuzz — fuzzing for nurlc and the stdlib parsers
 
-A generative, oracle-backed fuzzer that systematically hunts silent
-integer miscompiles in `nurlc`. It complements the hand-written
-`compiler/tests/` corpus: instead of checking a fixed set of programs, it
-generates thousands of random ones and checks each against an independent
-reference.
+Two fuzzers, both run weekly (and on demand) by
+[`.github/workflows/fuzz.yml`](../../.github/workflows/fuzz.yml), never as a
+per-PR gate. Either finding fails the run and uploads its reproducer inputs
+from `failures/` as an artifact.
 
-## How it works
+1. **Differential miscompile fuzzer** (`fuzz.sh` + `gen.py`) — described below:
+   oracle-backed hunt for silent integer/float miscompiles in `nurlc`.
+2. **Mutational parser fuzzer** (`fuzz_parsers.sh` + `fuzz_parsers.py` +
+   `parse_harness.nu`) — mutates seeds for the untrusted-input parsers
+   (x509/DER, cbor, msgpack, json, yaml, xml, toml) against an ASan+UBSan
+   harness; a crash / out-of-bounds / UB / hang is a bug. Run it locally with
+   `./tools/fuzz/fuzz_parsers.sh [SEED] [ITERS] [TIMEOUT]` after `./build.sh`.
+
+Both are deterministic per seed, so a finding reproduces. Seed corpora live
+in-tree (`gen.py`'s generator; `fuzz_parsers.py`'s `TEXT_SEEDS`/`BINARY_SEEDS`).
+
+## Differential fuzzer — how it works
 
 `gen.py` builds a random **integer expression tree** over NURL's sized
 types (`i8 i16 i32 i64 u u16 u32 u64`) and operators (`+ - * / % & | << >>`

--- a/tools/fuzz/fuzz_parsers.py
+++ b/tools/fuzz/fuzz_parsers.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# tools/fuzz/fuzz_parsers.py — mutational fuzzer for the untrusted-input
+# parsers (x509/DER, cbor, msgpack, json, yaml, xml, toml).
+#
+# It mutates format-appropriate seeds and runs the ASan+UBSan-built harness
+# (tools/fuzz/parse_harness) on each. A parser must ALWAYS finish with either
+# a value or a graceful error — never a crash, out-of-bounds access, UB, or a
+# hang. So a finding is any of:
+#     * non-zero / signal exit from the harness (abort, SIGSEGV, SIGFPE, …)
+#     * an AddressSanitizer / UndefinedBehaviorSanitizer report on stderr
+#     * a timeout (a hang or unbounded recursion the OS hasn't killed yet)
+#
+# Deterministic per --seed, so a finding reproduces. Failing inputs are saved
+# under tools/fuzz/failures/ for triage.
+#
+# Usage:
+#   fuzz_parsers.py --harness <bin> [--seed N] [--iters N] [--timeout SEC]
+#                   [--formats a,b,...]
+
+import argparse
+import os
+import random
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+FAILDIR = os.path.join(ROOT, "tools", "fuzz", "failures")
+
+# ── Seed corpora (valid + deliberately adversarial) ──────────────────
+TEXT_SEEDS = {
+    "json": [
+        b'{"a":1,"b":[1,2,3],"c":{"d":true,"e":null},"f":"str\\u00e9"}',
+        b'[[[[[[[[[[1]]]]]]]]]]',
+        b'{"x":  -1.5e10 , "y": 0.0}',
+        b'"\\ud834\\udd1e"',            # surrogate pair
+        b'[' + b'1,' * 500 + b'1]',
+        b'{',                            # truncated
+        b'[' * 4000,                     # deep-nesting DoS probe
+    ],
+    "yaml": [
+        b"a: 1\nb:\n  - x\n  - y\nc: {k: v, l: [1, 2]}\n",
+        b"- - - - - - - - - x\n",
+        b"key: 'quoted '' value'\nflow: [a, {b: c}, d]\n",
+        b"[" * 4000,                      # flow-nesting DoS probe
+        b"deep:\n" + b" " * 0 + b"x: 1\n",
+    ],
+    "xml": [
+        b'<?xml version="1.0"?><r a="1"><c>t</c><c2/></r>',
+        b"<a>&lt;&amp;&#233;&#x1F600;</a>",
+        b"<a><b><c><d>x</d></c></b></a>",
+        b"<a>" * 4000,                    # element-nesting DoS probe
+        b"<!-- unterminated",
+        b"<a><![CDATA[ ]]]]></a>",
+    ],
+    "toml": [
+        b'k = 1\nf = 1.5\ns = "str"\n[t]\nx = "y"\n[[arr]]\nn = 1\n',
+        b'a = [1, [2, [3, [4]]]]\n',
+        b'd = 2020-01-01T00:00:00Z\n',
+        b'k = ' + b'[' * 2000,
+    ],
+}
+
+BINARY_SEEDS = {
+    # A DER SEQUENCE with a couple of INTEGERs — the shape x509_parse walks.
+    "x509": [
+        bytes.fromhex("3006020101020102"),
+        bytes.fromhex("30820006"),                 # long-form length, no body
+        bytes.fromhex("3080020100"),               # indefinite-length (invalid in DER)
+        bytes.fromhex("30ff"),                      # length byte lies (0xff bytes follow)
+        bytes.fromhex("30840fffffff020101"),        # 4-byte length claiming ~256MB
+        b"\x30" * 200,                              # nested-SEQUENCE probe
+    ],
+    "cbor": [
+        bytes.fromhex("a161610161620263"),          # {"a":1,"b":2}
+        bytes.fromhex("9f01029f0304ffff"),          # indefinite arrays
+        bytes.fromhex("5bffffffffffffffff"),        # byte string, 2^64-1 length
+        bytes.fromhex("bf6161016162ff"),            # indefinite map
+        b"\x9f" * 300,                              # indefinite-array nesting probe
+    ],
+    "msgpack": [
+        bytes.fromhex("82a1610181a1620263"),        # {"a":[1],"b":2}
+        bytes.fromhex("dd ffffffff".replace(" ", "")),  # array32, 2^32-1 elements
+        bytes.fromhex("c4ffffffffff"),              # bin8-ish with big length
+        b"\x91" * 300,                              # fixarray nesting probe
+    ],
+}
+
+SEEDS = {}
+for f, ss in TEXT_SEEDS.items():
+    SEEDS[f] = [("text", s) for s in ss]
+for f, ss in BINARY_SEEDS.items():
+    SEEDS[f] = [("bin", s) for s in ss]
+
+
+def mutate(data: bytes, rng: random.Random) -> bytes:
+    b = bytearray(data)
+    for _ in range(rng.randint(1, 6)):
+        if not b:
+            b = bytearray(rng.randbytes(rng.randint(1, 8)))
+            continue
+        op = rng.randint(0, 7)
+        i = rng.randrange(len(b))
+        if op == 0:                       # flip a byte
+            b[i] ^= 1 << rng.randint(0, 7)
+        elif op == 1:                     # set to an interesting byte
+            b[i] = rng.choice([0, 0xFF, 0x7F, 0x80, 0x30, 0x82, 0x0A, 0x5B])
+        elif op == 2:                     # delete a byte
+            del b[i]
+        elif op == 3:                     # insert a byte
+            b.insert(i, rng.randint(0, 255))
+        elif op == 4:                     # duplicate a slice (length inflation)
+            j = rng.randrange(len(b))
+            lo, hi = min(i, j), max(i, j)
+            b[lo:lo] = b[lo:hi + 1]
+        elif op == 5:                     # truncate
+            b = b[:i]
+        elif op == 6:                     # repeat a byte (nesting / length DoS)
+            b[i:i] = bytes([b[i]]) * rng.randint(50, 3000)
+        else:                             # splice random bytes
+            b[i:i] = rng.randbytes(rng.randint(1, 16))
+    return bytes(b)
+
+
+def is_finding(rc: int, stderr: bytes, timed_out: bool) -> str:
+    if timed_out:
+        return "timeout (hang / unbounded recursion)"
+    if rc < 0:
+        return f"killed by signal {-rc}"
+    # harness returns 0 (parsed or graceful error) or 2 (usage/unknown).
+    if rc not in (0, 2):
+        return f"non-zero exit {rc}"
+    marks = (b"AddressSanitizer", b"UndefinedBehaviorSanitizer", b"runtime error:")
+    if any(m in stderr for m in marks):
+        return "sanitizer report"
+    return ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--harness", required=True)
+    ap.add_argument("--seed", type=int, default=1)
+    ap.add_argument("--iters", type=int, default=2000)
+    ap.add_argument("--timeout", type=float, default=10.0)
+    ap.add_argument("--formats", default=",".join(SEEDS.keys()))
+    args = ap.parse_args()
+
+    formats = [f for f in args.formats.split(",") if f in SEEDS]
+    rng = random.Random(args.seed)
+    os.makedirs(FAILDIR, exist_ok=True)
+    env = dict(os.environ,
+               ASAN_OPTIONS="detect_leaks=0:abort_on_error=1:halt_on_error=1",
+               UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1")
+
+    findings = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        inp = os.path.join(tmp, "in")
+        for it in range(args.iters):
+            fmt = rng.choice(formats)
+            kind, seed = rng.choice(SEEDS[fmt])
+            data = mutate(seed, rng)
+            with open(inp, "wb") as fh:
+                fh.write(data)
+            timed_out = False
+            try:
+                p = subprocess.run([args.harness, fmt, inp], env=env,
+                                   capture_output=True, timeout=args.timeout)
+                rc, err = p.returncode, p.stderr
+            except subprocess.TimeoutExpired:
+                timed_out, rc, err = True, 0, b""
+            why = is_finding(rc, err, timed_out)
+            if why:
+                findings += 1
+                tag = f"parse_{fmt}_seed{args.seed}_it{it}"
+                with open(os.path.join(FAILDIR, tag + ".bin"), "wb") as fh:
+                    fh.write(data)
+                with open(os.path.join(FAILDIR, tag + ".log"), "wb") as fh:
+                    fh.write(b"format: " + fmt.encode() + b"\nreason: " +
+                             why.encode() + b"\n\n" + err)
+                print(f"FINDING [{fmt}] it={it}: {why}  → {tag}.bin", flush=True)
+
+    print("─" * 42)
+    print(f"seed={args.seed} iters={args.iters} formats={','.join(formats)} "
+          f"findings={findings}")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/fuzz/fuzz_parsers.sh
+++ b/tools/fuzz/fuzz_parsers.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# tools/fuzz/fuzz_parsers.sh — build the parser harness with ASan+UBSan and
+# run the mutational parser fuzzer (fuzz_parsers.py).
+#
+# The untrusted-input parsers (x509/DER, cbor, msgpack, json, yaml, xml, toml)
+# must never crash / read OOB / hit UB / hang on any input — only parse or
+# gracefully error. This builds the dispatch harness once and mutates
+# format-appropriate seeds against it; any sanitizer report, signal exit, or
+# timeout is a real bug, saved under tools/fuzz/failures/.
+#
+# Usage:  fuzz_parsers.sh [SEED] [ITERS] [TIMEOUT]
+# Defaults: SEED=1 ITERS=2000 TIMEOUT=10
+#
+# Requires only a built toolchain (./build.sh). `NURL_SAN=1 ./nurl.sh`
+# auto-builds the sanitized runtime and links the harness with ASan+UBSan.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+SEED="${1:-1}"
+ITERS="${2:-2000}"
+TIMEOUT="${3:-10}"
+
+[[ -x "$ROOT/build/nurlc" ]] || { echo "fuzz_parsers: build/nurlc missing — run ./build.sh" >&2; exit 2; }
+
+HARNESS="$(mktemp)"
+trap 'rm -f "$HARNESS"' EXIT
+
+echo "[build] harness (ASan+UBSan, via NURL_SAN=1 ./nurl.sh)"
+NURL_SAN=1 ./nurl.sh -O1 tools/fuzz/parse_harness.nu "$HARNESS" \
+    || { echo "harness build failed" >&2; exit 2; }
+
+echo "[run] $ITERS iterations, seed $SEED, ${TIMEOUT}s per-input timeout"
+exec python3 tools/fuzz/fuzz_parsers.py \
+    --harness "$HARNESS" --seed "$SEED" --iters "$ITERS" --timeout "$TIMEOUT"

--- a/tools/fuzz/parse_harness.nu
+++ b/tools/fuzz/parse_harness.nu
@@ -1,0 +1,88 @@
+// tools/fuzz/parse_harness.nu — a single dispatch harness for fuzzing the
+// untrusted-input parsers. Usage: `parse_harness <which> <file>`.
+//
+// It reads `file` (raw bytes for binary formats, a C-string for text
+// formats), feeds it to the selected parser, and frees whatever came back.
+// The ONLY acceptable outcomes are a parsed value or a graceful parse error
+// — never a crash, out-of-bounds access, UB, or a hang. Built with
+// ASan+UBSan and driven over mutated inputs by fuzz_parsers.sh, any
+// sanitizer report or non-zero exit is a real parser bug.
+//
+// which ∈ { x509 cbor msgpack json yaml xml toml }
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/yaml.nu`
+$ `stdlib/ext/xml.nu`
+$ `stdlib/ext/toml.nu`
+$ `stdlib/ext/cbor.nu`
+$ `stdlib/ext/msgpack.nu`
+$ `stdlib/std/x509.nu`
+
+@ __fuzz_bytes s path → ( Vec u ) {
+    : !( Vec u ) IoErr rb ( read_file_bytes path )
+    ^ ?? rb { T b → b F _ → ( vec_new [u] ) }
+}
+
+@ main → i {
+    ? < ( nurl_argc ) 3 {
+        ( nurl_eprintln `usage: parse_harness <x509|cbor|msgpack|json|yaml|xml|toml> <file>` )
+        ^ 2
+    } {}
+    : s which ( nurl_argv 1 )
+    : s path ( nurl_argv 2 )
+
+    // ── binary formats (raw bytes) ──────────────────────────────────
+    ? != 0 ( nurl_str_eq which `x509` ) {
+        : ( Vec u ) b ( __fuzz_bytes path )
+        : X509 c ( x509_parse b )
+        ( x509_free c )
+        ( vec_free [u] b )
+        ^ 0
+    } {}
+    ? != 0 ( nurl_str_eq which `cbor` ) {
+        : ( Vec u ) b ( __fuzz_bytes path )
+        : !Json CborErr r ( cbor_decode b )
+        ?? r { T j → ( json_free j ) F _ → {} }
+        ( vec_free [u] b )
+        ^ 0
+    } {}
+    ? != 0 ( nurl_str_eq which `msgpack` ) {
+        : ( Vec u ) b ( __fuzz_bytes path )
+        : !Json MsgpackErr r ( msgpack_decode b )
+        ?? r { T j → ( json_free j ) F _ → {} }
+        ( vec_free [u] b )
+        ^ 0
+    } {}
+
+    // ── text formats (C-string; embedded NUL truncates, by contract) ─
+    ? != 0 ( nurl_str_eq which `json` ) {
+        : s src ( nurl_read_file path )
+        : !Json JsonError r ( json_parse src )
+        ?? r { T j → ( json_free j ) F _ → {} }
+        ^ 0
+    } {}
+    ? != 0 ( nurl_str_eq which `yaml` ) {
+        : s src ( nurl_read_file path )
+        : !Json YamlErr r ( yaml_parse src )
+        ?? r { T j → ( json_free j ) F _ → {} }
+        ^ 0
+    } {}
+    ? != 0 ( nurl_str_eq which `xml` ) {
+        : s src ( nurl_read_file path )
+        : !Xml XmlErr r ( xml_parse src )
+        ?? r { T x → ( xml_free x ) F _ → {} }
+        ^ 0
+    } {}
+    ? != 0 ( nurl_str_eq which `toml` ) {
+        : s src ( nurl_read_file path )
+        : !TomlValue TomlErr r ( toml_parse src )
+        ?? r { T t → ( toml_value_free t ) F _ → {} }
+        ^ 0
+    } {}
+
+    ( nurl_eprintln ( nurl_str_cat `unknown parser: ` which ) )
+    ^ 2
+}


### PR DESCRIPTION
## The gap (critic.md M5)

The untrusted-input parsers had no fuzzing — sharpest for the **X.509/DER**
parser, which handles attacker-controlled certificate bytes. And the existing
differential miscompile fuzzer ran only when someone remembered.

## Parser fuzzer

- **`parse_harness.nu`** — one dispatch harness: reads a file (raw bytes for
  `x509`/`cbor`/`msgpack`, a C-string for `json`/`yaml`/`xml`/`toml`), feeds it
  to the selected parser, frees the result. The only acceptable outcomes are a
  value or a graceful error.
- **`fuzz_parsers.py`** — mutates format-appropriate seeds (byte
  flips/inserts/deletes, length-field abuse like `30 ff …` / `5b ffffffff…`,
  deep-nesting probes) against the harness built with **ASan+UBSan**. A crash,
  OOB read, UB report, or timeout (hang / unbounded recursion) is a finding,
  saved under `failures/`.
- **`fuzz_parsers.sh`** — builds the harness via `NURL_SAN=1 ./nurl.sh`
  (auto-builds the sanitized runtime); run `./tools/fuzz/fuzz_parsers.sh [SEED]
  [ITERS] [TIMEOUT]` after `./build.sh`.

## Result: ~5300 iterations, 4 seeds → 0 findings

The parsers hold up, including the previously-unfuzzed **x509/DER** — its DER
walk is *iterative over a fixed certificate shape*, not deeply recursive, so it
has no nesting-stack-overflow surface; `cbor`/`msgpack` cap depth at 256;
`json`/`xml`/`yaml` were depth-capped in M4. Length-field abuse (huge/lying
lengths) produced graceful errors, no OOB. A clean run is the deliverable — it
converts "unfuzzed" into "fuzzed, holds", with a harness that keeps it that way.

## CI

`.github/workflows/fuzz.yml` runs **both** fuzzers weekly + on demand — *not* a
per-PR gate (value is breadth over time, and it would slow every merge under
branch protection). It fails the run and uploads reproducers on any finding.
Seed corpora are in-tree; the differential fuzzer's 7 historical bugs stay
pinned by `cast_*.nu` tests.

## Scope note

This covers the parser attack surface. The crypto **primitives'**
constant-timeness still lacks dudect-style empirical measurement, and none of
this is an external audit — `docs/CRYPTO.md` already discloses both. No compiler
or stdlib change; tools + workflow only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)