### PR TITLE
install: verify fail-closed and guard the destructive wipe (M8)

### DIFF
--- a/nurlweb/public/install.ps1
+++ b/nurlweb/public/install.ps1
@@ -17,11 +17,17 @@
 #
 #  Env:
 #    $env:NURL_NO_MODIFY_PATH = "1"   never prompt / change the User PATH
+#    $env:NURL_INSTALL_INSECURE = "1" (or -Insecure) install even without a
+#                                     verifiable checksum. OFF by default: a
+#                                     missing checksum file ABORTS rather than
+#                                     silently trusting unverified bytes.
 # ============================================================
 param(
     [string]$Version = $env:NURL_VERSION,
-    [string]$Prefix  = $(if ($env:NURL_HOME) { $env:NURL_HOME } else { Join-Path $env:USERPROFILE ".nurl" })
+    [string]$Prefix  = $(if ($env:NURL_HOME) { $env:NURL_HOME } else { Join-Path $env:USERPROFILE ".nurl" }),
+    [switch]$Insecure
 )
+if ($env:NURL_INSTALL_INSECURE -eq "1") { $Insecure = $true }
 $ErrorActionPreference = "Stop"
 $repo = "nurl-lang/nurl"
 $target = "windows-x86_64"
@@ -44,21 +50,45 @@ try {
     $zip = Join-Path $tmp $archive
     Invoke-WebRequest "$base/$archive" -OutFile $zip
 
-    # ── Verify checksum (best-effort) ──────────────────────────────────
-    try {
-        $sumFile = "$zip.sha256"
-        Invoke-WebRequest "$base/$archive.sha256" -OutFile $sumFile
+    # ── Verify checksum (fail-CLOSED unless -Insecure) ─────────────────
+    # A checksum MISMATCH always aborts. Only the *inability* to fetch the
+    # checksum file is what -Insecure downgrades to a warning. (Same-release
+    # checksum defends against corruption, not a compromised release.)
+    $sumFile = "$zip.sha256"
+    $haveSum = $false
+    try { Invoke-WebRequest "$base/$archive.sha256" -OutFile $sumFile; $haveSum = $true } catch { }
+    if ($haveSum) {
         $want = ((Get-Content $sumFile) -split '\s+')[0].ToLower()
         $got = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
-        if ($want -ne $got) { throw "checksum mismatch (expected $want, got $got)." }
-        Write-Host "checksum OK"
-    } catch {
-        Write-Host "warning: checksum verification skipped ($($_.Exception.Message))"
+        if (-not $want) {
+            if ($Insecure) { Write-Host "warning: empty checksum file — continuing (-Insecure)." }
+            else { throw "the published checksum file is empty/malformed. Refusing; use -Insecure to override." }
+        } elseif ($want -ne $got) {
+            throw "checksum mismatch (expected $want, got $got) — refusing to install."
+        } else {
+            Write-Host "checksum OK"
+        }
+    } elseif ($Insecure) {
+        Write-Host "warning: no checksum file for $Version — continuing (-Insecure)."
+    } else {
+        throw "no checksum file published for $Version ($archive.sha256). Refusing to install unverified bytes; use -Insecure to override."
     }
 
     # ── Unpack (archive has a top-level nurl\ dir) ─────────────────────
+    # Guard the wipe: never delete the user profile root or a directory that
+    # isn't ours. Only clear an empty dir or a prior NURL install.
+    $userRoot = $env:USERPROFILE.TrimEnd('\', '/')
+    $pfxNorm  = "$Prefix".TrimEnd('\', '/')
+    if ([string]::IsNullOrWhiteSpace($pfxNorm) -or $pfxNorm -eq $userRoot) {
+        throw "refusing to install into '$Prefix' — pick a dedicated directory (e.g. `$env:USERPROFILE\.nurl)."
+    }
     Write-Host "installing to $Prefix..."
-    if (Test-Path $Prefix) { Remove-Item -Recurse -Force $Prefix }
+    if (Test-Path $Prefix) {
+        $isNurl  = (Test-Path (Join-Path $Prefix "bin\nurl.bat")) -or (Test-Path (Join-Path $Prefix "bin\nurlc.exe"))
+        $isEmpty = -not (Get-ChildItem -Force $Prefix -ErrorAction SilentlyContinue)
+        if ($isNurl -or $isEmpty) { Remove-Item -Recurse -Force $Prefix }
+        else { throw "'$Prefix' exists, is not empty, and is not a NURL install — refusing to overwrite it. Remove it yourself or set -Prefix to a fresh path." }
+    }
     New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
     $unzipTmp = Join-Path $tmp "x"
     Expand-Archive -Path $zip -DestinationPath $unzipTmp -Force

--- a/nurlweb/public/install.sh
+++ b/nurlweb/public/install.sh
@@ -14,9 +14,14 @@
 #    curl -fsSL https://nurl-lang.org/install.sh | sh -s -- --version v0.1.0
 #
 #  Env:
-#    NURL_HOME            install prefix (default ~/.nurl)
-#    NURL_VERSION         release tag to install (default: latest)
-#    NURL_NO_MODIFY_PATH  set to 1 to never touch shell rc files / prompt
+#    NURL_HOME              install prefix (default ~/.nurl)
+#    NURL_VERSION           release tag to install (default: latest)
+#    NURL_NO_MODIFY_PATH    set to 1 to never touch shell rc files / prompt
+#    NURL_INSTALL_INSECURE  set to 1 (or pass --insecure) to install even when
+#                           the download can't be checksum-verified. OFF by
+#                           default: a missing checksum file or a missing
+#                           sha256 tool ABORTS the install rather than
+#                           silently trusting unverified bytes.
 #
 #  POSIX sh — no bashisms; works under dash/ash/busybox.
 # ============================================================
@@ -25,6 +30,7 @@ set -eu
 REPO="nurl-lang/nurl"
 PREFIX="${NURL_HOME:-$HOME/.nurl}"
 VERSION="${NURL_VERSION:-}"
+INSECURE="${NURL_INSTALL_INSECURE:-0}"
 
 err() { printf 'error: %s\n' "$*" >&2; exit 1; }
 info() { printf '%s\n' "$*" >&2; }
@@ -37,6 +43,7 @@ while [ $# -gt 0 ]; do
         --version=*) VERSION="${1#--version=}"; shift ;;
         --prefix) PREFIX="${2:-}"; shift 2 ;;
         --prefix=*) PREFIX="${1#--prefix=}"; shift ;;
+        --insecure) INSECURE=1; shift ;;
         -h|--help)
             sed -n '5,22p' "$0" 2>/dev/null | sed 's/^# \{0,1\}//'
             exit 0 ;;
@@ -97,24 +104,51 @@ trap 'rm -rf "$tmp"' EXIT
 info "downloading $archive ($VERSION)…"
 dl "$base/$archive" "$tmp/$archive" || err "download failed: $base/$archive"
 
+# Verification is fail-CLOSED: anything that stops us confirming the bytes
+# match the published SHA-256 aborts, unless the user set --insecure /
+# NURL_INSTALL_INSECURE=1. (Note: the checksum comes from the same release, so
+# it defends against a corrupted/truncated download — not against a compromised
+# release. Detached signatures would close that; tracked separately.)
+insecure_or_die() {
+    if [ "$INSECURE" = 1 ]; then
+        info "warning: $1 — continuing anyway (--insecure)."
+    else
+        err "$1. Refusing to install unverified bytes; re-run with --insecure to override."
+    fi
+}
 if dl "$base/$archive.sha256" "$tmp/$archive.sha256" 2>/dev/null; then
     info "verifying checksum…"
     want="$(awk '{print $1}' "$tmp/$archive.sha256")"
+    [ -n "$want" ] || insecure_or_die "the published checksum file is empty or malformed"
     if have sha256sum; then
         got="$(sha256sum "$tmp/$archive" | awk '{print $1}')"
     elif have shasum; then
         got="$(shasum -a 256 "$tmp/$archive" | awk '{print $1}')"
     else
-        got=""; info "warning: no sha256sum/shasum — skipping checksum verification."
+        got=""
+        insecure_or_die "no sha256sum/shasum on PATH to verify the download"
     fi
-    [ -z "$got" ] || [ "$got" = "$want" ] || err "checksum mismatch (expected $want, got $got)."
+    if [ -n "$got" ] && [ -n "$want" ] && [ "$got" != "$want" ]; then
+        err "checksum mismatch (expected $want, got $got) — refusing to install."
+    fi
 else
-    info "warning: no checksum file published — skipping verification."
+    insecure_or_die "no checksum file published for $VERSION ($archive.sha256)"
 fi
 
 # ── Unpack (the archive has a top-level nurl/ dir) ─────────────────────
+# Guard the destructive wipe: never delete $HOME, /, or a directory that
+# isn't ours. Only clear an empty dir or a prior NURL install (has bin/nurl).
+case "$PREFIX" in
+    ""|/|"$HOME"|"$HOME"/) err "refusing to install into '$PREFIX' — set NURL_HOME to a dedicated directory (e.g. ~/.nurl)." ;;
+esac
+if [ -e "$PREFIX" ]; then
+    if [ -x "$PREFIX/bin/nurl" ] || [ -x "$PREFIX/bin/nurlc" ] || [ -z "$(ls -A "$PREFIX" 2>/dev/null)" ]; then
+        rm -rf "$PREFIX"
+    else
+        err "'$PREFIX' exists, is not empty, and is not a NURL install (no bin/nurl) — refusing to overwrite it. Remove it yourself or set NURL_HOME to a fresh path."
+    fi
+fi
 info "installing to $PREFIX…"
-rm -rf "$PREFIX"
 mkdir -p "$PREFIX"
 tar xzf "$tmp/$archive" -C "$PREFIX" --strip-components=1
 


### PR DESCRIPTION
## The holes (critic.md M8)

- **Fail-open verification.** `nurlweb/public/install.sh` and `install.ps1`: a
  missing `.sha256` → "skipping verification, installing anyway". On Windows it
  was worse — a checksum **mismatch** `throw` sat inside the skip-on-error
  `try/catch`, so a mismatch was swallowed into a warning too.
- **`rm -rf "$PREFIX"`** on a user-controlled path — `NURL_HOME=$HOME
  curl…|sh` wipes the home directory before unpacking.

## The fixes

**Verification is fail-CLOSED.** A missing checksum file, a missing
`sha256sum`/`shasum`, an empty/malformed checksum, or (always) a mismatch
**aborts**. Opt out explicitly with `--insecure` / `NURL_INSTALL_INSECURE=1`
(`-Insecure` on Windows), documented in both headers. On Windows, only the
*inability to fetch* the checksum is downgradable — a mismatch always throws.

**The wipe is guarded.** It refuses `$HOME` / `/` / the USERPROFILE root, and
any directory that exists, is non-empty, and isn't a prior NURL install (no
`bin/nurl`). Empty dirs and real prior installs clear as before.

## Verified end-to-end (local mock release)

| scenario | result |
|---|---|
| valid checksum | installs, `nurl` runs |
| reinstall over prior NURL install | succeeds (rm-guard allows) |
| `NURL_HOME` = non-NURL dir with user data | **refused, data intact** |
| tampered archive | **checksum mismatch → aborts, nothing written** |

## Not in scope

Detached release/package **signatures** (to defend against a *compromised*
release, not just corruption) need a maintainer-provisioned keypair — the
private key in a GitHub Actions secret, the public key pinned in the installer.
The exact minisign recipe is recorded in critic.md M8 for when a key exists.

Docs/scripts only — no compiler, stdlib, or test change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)