### PR TITLE
stdlib: BLAKE2b-512 in pure NURL (RFC 7693) — minisign prehash primitive

### DIFF
--- a/compiler/tests/blake2b_vectors.nu
+++ b/compiler/tests/blake2b_vectors.nu
@@ -1,0 +1,49 @@
+// blake2b_vectors.nu — BLAKE2b-512 known-answer tests (RFC 7693 + openssl).
+// Pins the pure-NURL hash used by minisign verification.
+
+$ `stdlib/std/hash_blake2b.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+
+@ check s label ( Vec u ) input s want → b {
+    : ( Vec u ) digest ( blake2b512_pure input )
+    : String got ( bytes_to_hex digest )
+    : b ok != 0 ( nurl_str_eq ( string_data got ) want )
+    ( nurl_print label ) ( nurl_print ? ok ` ok\n` ` FAIL\n` )
+    ? ! ok {
+        ( nurl_print `  got:  ` ) ( nurl_print ( string_data got ) ) ( nurl_print `\n` )
+        ( nurl_print `  want: ` ) ( nurl_print want ) ( nurl_print `\n` )
+    } {}
+    ( string_free got )
+    ( vec_free [u] digest )
+    ^ ok
+}
+
+@ repeat_byte i b i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] n )
+    : ~ i i 0
+    ~ < i n { ( vec_push [u] v # u b ) = i + i 1 }
+    ^ v
+}
+
+@ main → i {
+    : ~ b all T
+    // empty
+    : ( Vec u ) e ( vec_new [u] )
+    = all & all ( check `empty ` e `786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce` )
+    ( vec_free [u] e )
+    // "abc"
+    : ( Vec u ) abc ( bytes_from_str `abc` )
+    = all & all ( check `abc   ` abc `ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d17d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923` )
+    ( vec_free [u] abc )
+    // 200 × 'x' (spans two 128-byte blocks)
+    : ( Vec u ) x200 ( repeat_byte 120 200 )
+    = all & all ( check `200x  ` x200 `949668855c1886ab93efa9b12a4a9907dc8ecf4196b764e1e12f89d54070976ca7fdb16a8286e05f37b76e5d1e6ae417b892034093a13e79afd45db041c4c609` )
+    ( vec_free [u] x200 )
+    // exactly 128 bytes (one full block, last-flag on it)
+    : ( Vec u ) x128 ( repeat_byte 120 128 )
+    = all & all ( check `128x  ` x128 `082b91ea2e15d1556d2ceefdd5af5d64d31b4e01aff1959724578876293825b236ee8079173a0a38160d7d6685d6bca0bfb62c177b3599b8727d9173e2115b91` )
+    ( vec_free [u] x128 )
+    ^ ? all 0 1
+}

--- a/compiler/tests/minisign_verify.nu
+++ b/compiler/tests/minisign_verify.nu
@@ -1,0 +1,44 @@
+// minisign_verify.nu — pure-NURL minisign verification against a REAL
+// signature produced by minisign 0.11 (`minisign -S`, default prehashed `ED`
+// mode). Pins: a valid signature verifies; a tampered message is rejected;
+// the wrong public key is rejected.
+
+$ `stdlib/std/minisign.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+
+// The signed message was exactly "hello nurl signing\n".
+@ msg → ( Vec u ) { ^ ( bytes_from_str `hello nurl signing\n` ) }
+
+@ report s label b got b want → b {
+    : b ok == got want
+    ( nurl_print label ) ( nurl_print ? ok ` ok\n` ` FAIL\n` )
+    ^ ok
+}
+
+@ main → i {
+    : s good_pub `RWReZ7BZS0qAJzqoeFaEsqbNLrUuFLgq1vLoavX51L1di/EBO4kX921b`
+    : s good_sig `RUReZ7BZS0qAJ66Y3rmtIP3Umsna5fGt43lbQyNv1QWtQxkKrkqYg7NjthCT6FgcStvfus2KM8iBozAzRdN8asG7zcY3LcVQHQ8=`
+    // a different, unrelated minisign public key
+    : s wrong_pub `RWQT5WWtjTnEyaYAG5X4HKCRtb7rFT5psjJVGB5Q9kVQBI71F5jfPWUf`
+
+    : ~ b all T
+
+    // 1. valid signature → true
+    : ( Vec u ) m1 ( msg )
+    = all & all ( report `valid    ` ( minisign_verify_b64 m1 good_pub good_sig ) T )
+    ( vec_free [u] m1 )
+
+    // 2. tampered message → false
+    : ( Vec u ) m2 ( bytes_from_str `hello nurl signingX` )
+    = all & all ( report `tampered ` ( minisign_verify_b64 m2 good_pub good_sig ) F )
+    ( vec_free [u] m2 )
+
+    // 3. wrong public key → false
+    : ( Vec u ) m3 ( msg )
+    = all & all ( report `wrongkey ` ( minisign_verify_b64 m3 wrong_pub good_sig ) F )
+    ( vec_free [u] m3 )
+
+    ^ ? all 0 1
+}

--- a/compiler/tests/outputs-windows/blake2b_vectors.txt
+++ b/compiler/tests/outputs-windows/blake2b_vectors.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+empty  ok
+abc    ok
+200x   ok
+128x   ok

--- a/compiler/tests/outputs-windows/minisign_verify.txt
+++ b/compiler/tests/outputs-windows/minisign_verify.txt
@@ -1,0 +1,7 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+valid     ok
+tampered  ok
+wrongkey  ok

--- a/compiler/tests/outputs/blake2b_vectors.txt
+++ b/compiler/tests/outputs/blake2b_vectors.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+empty  ok
+abc    ok
+200x   ok
+128x   ok

--- a/compiler/tests/outputs/minisign_verify.txt
+++ b/compiler/tests/outputs/minisign_verify.txt
@@ -1,0 +1,7 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+valid     ok
+tampered  ok
+wrongkey  ok

--- a/stdlib/std/hash_blake2b.nu
+++ b/stdlib/std/hash_blake2b.nu
@@ -1,0 +1,182 @@
+// stdlib/std/hash_blake2b.nu — BLAKE2b-512 in pure NURL (RFC 7693).
+//
+// Unkeyed BLAKE2b with a 64-byte digest — the hash minisign uses to prehash a
+// message before the Ed25519 signature (algorithm `ED`). See stdlib/std/minisign.nu.
+//
+// API:
+//   ( blake2b512_pure ( Vec u ) data ) → ( Vec u )   64-byte digest
+//
+// 64-bit words, 128-byte blocks, 12 rounds. u64 constants above 2^63-1 are
+// written as their negative-two's-complement i64 (no hex literals); `# u64 -N`
+// reinterprets the bit pattern.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+
+@ __b2b_vu64 ( Vec u64 ) v i idx → u64 {
+    : ?u64 o ( vec_get [u64] v idx )
+    ?? o { T x → { ^ x } F → { ^ # u64 0 } }
+}
+
+@ __b2b_vu ( Vec u ) v i idx → i {
+    : ?u o ( vec_get [u] v idx )
+    ?? o { T x → { ^ # i x } F → { ^ 0 } }
+}
+
+// Right-rotate a u64 by c bits (0 < c < 64).
+@ __b2b_rotr u64 x i c → u64 {
+    : u64 cu # u64 c
+    : u64 inv # u64 - 64 c
+    ^ | >> x cu << x inv
+}
+
+// The eight BLAKE2b IV words (identical to the SHA-512 IV).
+@ __b2b_iv → ( Vec u64 ) {
+    : ( Vec u64 ) v ( vec_with_cap [u64] 8 )
+    ( vec_push [u64] v # u64 7640891576956012808 )
+    ( vec_push [u64] v # u64 -4942790177534073029 )
+    ( vec_push [u64] v # u64 4354685564936845355 )
+    ( vec_push [u64] v # u64 -6534734903238641935 )
+    ( vec_push [u64] v # u64 5840696475078001361 )
+    ( vec_push [u64] v # u64 -7276294671716946913 )
+    ( vec_push [u64] v # u64 2270897969802886507 )
+    ( vec_push [u64] v # u64 6620516959819538809 )
+    ^ v
+}
+
+// The message-word permutation schedule σ, flattened to 12·16 entries
+// (round-major). Parsed once from a decimal string.
+@ __b2b_sigma → ( Vec u ) {
+    : s s ( nurl_str_cat
+    `0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 14 10 4 8 9 15 13 6 1 12 0 2 11 7 5 3 11 8 12 0 5 2 15 13 10 14 3 6 7 1 9 4 7 9 3 1 13 12 11 14 2 6 5 10 4 0 15 8 9 0 5 7 2 4 10 15 14 1 11 12 6 8 3 13 2 12 6 10 0 11 8 3 4 13 7 5 15 14 1 9 `
+    `12 5 1 15 14 13 4 10 0 7 6 3 9 2 8 11 13 11 7 14 12 1 3 9 5 0 15 4 8 6 2 10 6 15 14 9 11 3 0 8 12 2 13 7 1 4 10 5 10 2 8 4 7 6 1 5 15 11 9 14 3 12 13 0 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 14 10 4 8 9 15 13 6 1 12 0 2 11 7 5 3` )
+    : ( Vec u ) out ( vec_new [u] )
+    : i n ( nurl_str_len s )
+    : ~ i k 0
+    : ~ i cur 0
+    : ~ b indig F
+    ~ < k n {
+        : i c ( nurl_str_get s k )
+        ? & >= c 48 <= c 57
+        { = cur + * cur 10 - c 48 = indig T }
+        { ? indig { ( vec_push [u] out # u cur ) = cur 0 = indig F } {} }
+        = k + k 1
+    }
+    ? indig { ( vec_push [u] out # u cur ) } {}
+    ^ out
+}
+
+// The G mixing function, in place on the working vector v (16 u64).
+@ __b2b_g ( Vec u64 ) v i a i b i c i d u64 x u64 y → v {
+    : ~ u64 va ( __b2b_vu64 v a )
+    : ~ u64 vb ( __b2b_vu64 v b )
+    : ~ u64 vc ( __b2b_vu64 v c )
+    : ~ u64 vd ( __b2b_vu64 v d )
+    = va + + va vb x
+    = vd ( __b2b_rotr ^^ vd va 32 )
+    = vc + vc vd
+    = vb ( __b2b_rotr ^^ vb vc 24 )
+    = va + + va vb y
+    = vd ( __b2b_rotr ^^ vd va 16 )
+    = vc + vc vd
+    = vb ( __b2b_rotr ^^ vb vc 63 )
+    ( vec_set [u64] v a va )
+    ( vec_set [u64] v b vb )
+    ( vec_set [u64] v c vc )
+    ( vec_set [u64] v d vd )
+}
+
+// One message word m[j], the j-th little-endian u64 in `block` at `off`.
+@ __b2b_m ( Vec u ) block i off i j → u64 {
+    : ?u64 o ( bytes_read_u64_le block + off * j 8 )
+    ?? o { T x → { ^ x } F → { ^ # u64 0 } }
+}
+
+// Compress one 128-byte block into state h. `t` = bytes hashed through this
+// block; `last` != 0 marks the final block.
+@ __b2b_compress ( Vec u64 ) h ( Vec u ) block i off u64 t i last ( Vec u ) sigma → v {
+    : ( Vec u64 ) iv ( __b2b_iv )
+    : ( Vec u64 ) v ( vec_with_cap [u64] 16 )
+    : ~ i i 0
+    ~ < i 8 { ( vec_push [u64] v ( __b2b_vu64 h i ) ) = i + i 1 }
+    = i 0
+    ~ < i 8 { ( vec_push [u64] v ( __b2b_vu64 iv i ) ) = i + i 1 }
+    // v[12] ^= t_lo ; v[13] ^= t_hi (0 for our sizes) ; v[14] ^= ~0 if last
+    ( vec_set [u64] v 12 ^^ ( __b2b_vu64 v 12 ) t )
+    ? != last 0 { ( vec_set [u64] v 14 ^^ ( __b2b_vu64 v 14 ) # u64 -1 ) } {}
+    // read the 16 message words
+    : ( Vec u64 ) m ( vec_with_cap [u64] 16 )
+    = i 0
+    ~ < i 16 { ( vec_push [u64] m ( __b2b_m block off i ) ) = i + i 1 }
+    : ~ i r 0
+    ~ < r 12 {
+        : i base * r 16
+        ( __b2b_g v 0 4 8 12 ( __b2b_vu64 m ( __b2b_vu sigma + base 0 ) ) ( __b2b_vu64 m ( __b2b_vu sigma + base 1 ) ) )
+        ( __b2b_g v 1 5 9 13 ( __b2b_vu64 m ( __b2b_vu sigma + base 2 ) ) ( __b2b_vu64 m ( __b2b_vu sigma + base 3 ) ) )
+        ( __b2b_g v 2 6 10 14 ( __b2b_vu64 m ( __b2b_vu sigma + base 4 ) ) ( __b2b_vu64 m ( __b2b_vu sigma + base 5 ) ) )
+        ( __b2b_g v 3 7 11 15 ( __b2b_vu64 m ( __b2b_vu sigma + base 6 ) ) ( __b2b_vu64 m ( __b2b_vu sigma + base 7 ) ) )
+        ( __b2b_g v 0 5 10 15 ( __b2b_vu64 m ( __b2b_vu sigma + base 8 ) ) ( __b2b_vu64 m ( __b2b_vu sigma + base 9 ) ) )
+        ( __b2b_g v 1 6 11 12 ( __b2b_vu64 m ( __b2b_vu sigma + base 10 ) ) ( __b2b_vu64 m ( __b2b_vu sigma + base 11 ) ) )
+        ( __b2b_g v 2 7 8 13 ( __b2b_vu64 m ( __b2b_vu sigma + base 12 ) ) ( __b2b_vu64 m ( __b2b_vu sigma + base 13 ) ) )
+        ( __b2b_g v 3 4 9 14 ( __b2b_vu64 m ( __b2b_vu sigma + base 14 ) ) ( __b2b_vu64 m ( __b2b_vu sigma + base 15 ) ) )
+        = r + r 1
+    }
+    = i 0
+    ~ < i 8 {
+        ( vec_set [u64] h i ^^ ( __b2b_vu64 h i ) ^^ ( __b2b_vu64 v i ) ( __b2b_vu64 v + i 8 ) )
+        = i + i 1
+    }
+    ( vec_free [u64] iv )
+    ( vec_free [u64] v )
+    ( vec_free [u64] m )
+}
+
+@ __b2b_zeros i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] n )
+    : ~ i i 0
+    ~ < i n { ( vec_push [u] v # u 0 ) = i + i 1 }
+    ^ v
+}
+
+@ blake2b512_pure ( Vec u ) data → ( Vec u ) {
+    : ( Vec u ) sigma ( __b2b_sigma )
+    : ( Vec u64 ) h ( __b2b_iv )
+    // h[0] ^= 0x01010040 (params: digest length 64, no key, fanout/depth 1)
+    ( vec_set [u64] h 0 ^^ ( __b2b_vu64 h 0 ) # u64 16842816 )
+    : i n ( vec_len [u] data )
+    ? == n 0 {
+        : ( Vec u ) blk ( __b2b_zeros 128 )
+        ( __b2b_compress h blk 0 # u64 0 1 sigma )
+        ( vec_free [u] blk )
+    } {
+        : ~ i off 0
+        : ~ u64 t # u64 0
+        : ~ b done F
+        ~ ! done {
+            : i remain - n off
+            ? > remain 128 {
+                = t + t # u64 128
+                ( __b2b_compress h data off t 0 sigma )
+                = off + off 128
+            } {
+                = t + t # u64 remain
+                : ( Vec u ) blk ( __b2b_zeros 128 )
+                : ~ i j 0
+                ~ < j remain {
+                    ( vec_set [u] blk j # u ( __b2b_vu data + off j ) )
+                    = j + j 1
+                }
+                ( __b2b_compress h blk 0 t 1 sigma )
+                ( vec_free [u] blk )
+                = done T
+            }
+        }
+    }
+    // serialize h → 64 little-endian bytes
+    : ( Vec u ) out ( vec_with_cap [u] 64 )
+    : ~ i i 0
+    ~ < i 8 { ( bytes_push_u64_le out ( __b2b_vu64 h i ) ) = i + i 1 }
+    ( vec_free [u64] h )
+    ( vec_free [u] sigma )
+    ^ out
+}

--- a/stdlib/std/minisign.nu
+++ b/stdlib/std/minisign.nu
@@ -1,0 +1,124 @@
+// stdlib/std/minisign.nu — pure-NURL minisign signature verification.
+//
+// Verifies a minisign detached signature against a public key, with zero
+// external dependencies (so nurlpkg can check package signatures on any
+// machine nurl runs on, Windows included). Supports both signature modes:
+//   ED  (prehashed, minisign's default)  — Ed25519 over BLAKE2b-512(message)
+//   Ed  (legacy)                         — Ed25519 over the raw message
+//
+// Formats (base64 on the second, non-comment line):
+//   public key : algo(2) ‖ key_id(8) ‖ ed25519_pubkey(32)   = 42 bytes
+//   signature  : algo(2) ‖ key_id(8) ‖ ed25519_sig(64)      = 74 bytes
+// This checks the primary signature; the "global signature" over the trusted
+// comment (line 4 of a .minisig) is not checked — callers that need a trusted
+// comment should verify it separately.
+//
+// API:
+//   ( minisign_verify msg pubfile_text sigfile_text ) → b   parse .pub + .minisig text
+//   ( minisign_verify_b64 msg pub_b64 sig_b64 )       → b   raw base64 lines
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/ed25519.nu`
+$ `stdlib/std/hash_blake2b.nu`
+
+// The second line of a minisign .pub / .minisig text (line index 1: the
+// base64 payload under the "untrusted comment:" header), right-trimmed of
+// CR / spaces. Returns "" if there is no second line.
+@ __ms_line2 s text → String {
+    : i n ( nurl_str_len text )
+    : ~ i i 0
+    // skip line 0
+    ~ & < i n != ( nurl_str_get text i ) 10 { = i + i 1 }
+    ? >= i n { ^ ( string_new ) } {}
+    = i + i 1
+    : i start i
+    ~ & < i n != ( nurl_str_get text i ) 10 { = i + i 1 }
+    : ~ i end i
+    : ~ b trimming T
+    ~ & trimming > end start {
+        : i c ( nurl_str_get text - end 1 )
+        ? | | == c 13 == c 32 == c 9 { = end - end 1 } { = trimming F }
+    }
+    ^ ( __ms_substr text start - end start )
+}
+
+@ __ms_substr s src i start i len → String {
+    : String out ( string_with_cap ? > len 0 len 1 )
+    : ~ i k 0
+    ~ < k len {
+        ( string_push_char out ( nurl_str_get src + start k ) )
+        = k + k 1
+    }
+    ^ out
+}
+
+// Decode a base64 line to bytes, or an empty Vec on error.
+@ __ms_b64 s line → ( Vec u ) {
+    : !( Vec u ) ParseErr r ( b64_decode_vec line )
+    ^ ?? r { T v → v F _ → ( vec_new [u] ) }
+}
+
+// Verify against raw base64 pubkey + signature lines.
+@ minisign_verify_b64 ( Vec u ) message s pub_b64 s sig_b64 → b {
+    : ( Vec u ) pubv ( __ms_b64 pub_b64 )
+    : ( Vec u ) sig ( __ms_b64 sig_b64 )
+    : ~ b ok F
+    // shapes: pubkey 42 bytes (Ed), signature 74 bytes (Ed/ED)
+    ? & == ( vec_len [u] pubv ) 42 == ( vec_len [u] sig ) 74 {
+        : i pa0 ( __ms_byte pubv 0 )
+        : i pa1 ( __ms_byte pubv 1 )
+        : i sa0 ( __ms_byte sig 0 )
+        : i sa1 ( __ms_byte sig 1 )
+        // pubkey algo must be 'Ed' (0x45 0x64); sig algo 'E' + 'D'|'d'
+        ? & & == pa0 69 == pa1 100 == sa0 69 {
+            // key ids (bytes 2..10) must match
+            ? ( __ms_keyid_eq pubv sig ) {
+                : ( Vec u ) pk ( bytes_slice pubv 10 42 )
+                : ( Vec u ) sg ( bytes_slice sig 10 74 )
+                ? == sa1 68 {
+                    // 'D' → prehashed: Ed25519 over BLAKE2b-512(message)
+                    : ( Vec u ) h ( blake2b512_pure message )
+                    = ok ( ed25519_verify_pure pk h sg )
+                    ( vec_free [u] h )
+                } {
+                    ? == sa1 100 {
+                        // 'd' → legacy: Ed25519 over the raw message
+                        = ok ( ed25519_verify_pure pk message sg )
+                    } {}
+                }
+                ( vec_free [u] pk )
+                ( vec_free [u] sg )
+            } {}
+        } {}
+    } {}
+    ( vec_free [u] pubv )
+    ( vec_free [u] sig )
+    ^ ok
+}
+
+@ __ms_byte ( Vec u ) v i idx → i {
+    ?? ( vec_get [u] v idx ) { T x → { ^ # i x } F → { ^ -1 } }
+}
+
+@ __ms_keyid_eq ( Vec u ) pubv ( Vec u ) sig → b {
+    : ~ i k 2
+    : ~ b eq T
+    ~ & eq < k 10 {
+        ? != ( __ms_byte pubv k ) ( __ms_byte sig k ) { = eq F } {}
+        = k + k 1
+    }
+    ^ eq
+}
+
+// Verify against full .pub and .minisig file contents.
+@ minisign_verify ( Vec u ) message s pubfile s sigfile → b {
+    : String pl ( __ms_line2 pubfile )
+    : String sl ( __ms_line2 sigfile )
+    : b r ( minisign_verify_b64 message ( string_data pl ) ( string_data sl ) )
+    ( string_free pl )
+    ( string_free sl )
+    ^ r
+}


### PR DESCRIPTION
First step toward pure-NURL supply-chain verification. minisign's default
signatures (algorithm `ED`) sign the **BLAKE2b-512** hash of the file — so
verifying them in pure NURL (so `nurlpkg` can check package signatures on any
machine, Windows included, with zero external deps) needs BLAKE2b-512, which the
stdlib lacked (it had SHA-512, BLAKE3, Ed25519).

## What

Unkeyed **BLAKE2b-512** (RFC 7693) in pure NURL: 64-bit words, 128-byte blocks,
12 rounds, the G mixing function (rotations 32/24/16/63), the round-major σ
schedule. `blake2b512_pure ( Vec u ) → ( Vec u )` returns the 64-byte digest.
Integer add wraps (defined two's-complement) — exactly BLAKE2b's mod-2^64
arithmetic.

## Verified

Byte-exact against known answers:
- RFC 7693 `"abc"` and the empty input
- 128-byte input (one full block with the final flag set) and 200-byte input
  (two blocks) vs `openssl dgst -blake2b512`

`blake2b_vectors` pins all four and is **LSan-clean** (a first draft leaked the
digest `Vec`s — caught under ASan+LSan and fixed).

## Scope

Stdlib + test only. `nurlc.nu` doesn't use BLAKE2b, so the bootstrap fixed point
is unaffected (no snapshot refresh). Full corpus green. Next: `minisign.nu`
(verify) on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)