### PR TITLE
release: sign toolchain archives with minisign; installers verify (M8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,6 +317,31 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Sign archives with minisign
+        # Detached minisign signatures over every archive, so `minisign -V` (or
+        # nurl's pure-NURL verifier) can confirm a download came from the real
+        # release key — not just that it matches a checksum served alongside it.
+        # The passwordless secret key lives only in the MINISIGN_SECRET_KEY
+        # secret. If the secret is unset (e.g. a fork), skip signing rather than
+        # fail the release.
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+        run: |
+          if [ -z "${MINISIGN_SECRET_KEY:-}" ]; then
+            echo "MINISIGN_SECRET_KEY not set — skipping signing." >&2
+            exit 0
+          fi
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends minisign
+          printf '%s\n' "$MINISIGN_SECRET_KEY" > "$RUNNER_TEMP/minisign.key"
+          trap 'shred -u "$RUNNER_TEMP/minisign.key" 2>/dev/null || rm -f "$RUNNER_TEMP/minisign.key"' EXIT
+          for f in artifacts/*.tar.gz artifacts/*.zip; do
+            [ -e "$f" ] || continue
+            minisign -S -s "$RUNNER_TEMP/minisign.key" -m "$f" \
+              -c "nurl release $GITHUB_REF_NAME" -t "nurl $GITHUB_REF_NAME"
+            echo "signed $f -> $f.minisig"
+          done
+
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
@@ -327,3 +352,4 @@ jobs:
             artifacts/*.tar.gz
             artifacts/*.zip
             artifacts/*.sha256
+            artifacts/*.minisig

--- a/nurlweb/public/install.ps1
+++ b/nurlweb/public/install.ps1
@@ -74,6 +74,29 @@ try {
         throw "no checksum file published for $Version ($archive.sha256). Refusing to install unverified bytes; use -Insecure to override."
     }
 
+    # ── Signature (defense-in-depth beyond the same-release checksum) ──
+    # If minisign is on PATH, verify the detached signature against the pinned
+    # release key, fail-closed. If it isn't, we don't force an install of it —
+    # checksum + HTTPS stay the root of trust (nurl's pure-NURL verifier covers
+    # the package layer, where nurl is present).
+    $minisignPub = "RWQT5WWtjTnEyaYAG5X4HKCRtb7rFT5psjJVGB5Q9kVQBI71F5jfPWUf"
+    if (Get-Command minisign -ErrorAction SilentlyContinue) {
+        $sig = "$zip.minisig"
+        $haveSig = $false
+        try { Invoke-WebRequest "$base/$archive.minisig" -OutFile $sig; $haveSig = $true } catch { }
+        if ($haveSig) {
+            & minisign -Vm $zip -P $minisignPub | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "signature verification FAILED — refusing to install." }
+            Write-Host "signature OK"
+        } elseif ($Insecure) {
+            Write-Host "warning: no signature for $Version — continuing (-Insecure)."
+        } else {
+            throw "no signature (.minisig) published for $Version, and minisign is available to check it. Use -Insecure to override."
+        }
+    } else {
+        Write-Host "note: minisign not installed — skipping signature check (checksum + HTTPS enforced)."
+    }
+
     # ── Unpack (archive has a top-level nurl\ dir) ─────────────────────
     # Guard the wipe: never delete the user profile root or a directory that
     # isn't ours. Only clear an empty dir or a prior NURL install.

--- a/nurlweb/public/install.sh
+++ b/nurlweb/public/install.sh
@@ -135,6 +135,27 @@ else
     insecure_or_die "no checksum file published for $VERSION ($archive.sha256)"
 fi
 
+# ── Signature (defense-in-depth beyond the same-release checksum) ──────
+# The pinned release public key. A minisign signature proves the archive was
+# produced by the holder of the release key, which a same-release checksum
+# can't. If minisign is available we verify fail-closed; if it isn't, we do
+# NOT force an install of it — the checksum + HTTPS remain the root of trust,
+# exactly as with rustup/deno. (nurl's own pure-NURL verifier — stdlib
+# minisign.nu — covers the package layer, where nurl is already present.)
+MINISIGN_PUB="RWQT5WWtjTnEyaYAG5X4HKCRtb7rFT5psjJVGB5Q9kVQBI71F5jfPWUf"
+if have minisign; then
+    if dl "$base/$archive.minisig" "$tmp/$archive.minisig" 2>/dev/null; then
+        info "verifying signature…"
+        minisign -Vm "$tmp/$archive" -P "$MINISIGN_PUB" >/dev/null 2>&1 \
+            || err "signature verification FAILED — refusing to install."
+        info "signature OK"
+    else
+        insecure_or_die "no signature (.minisig) published for $VERSION, and minisign is available to check it"
+    fi
+else
+    info "note: minisign not installed — skipping signature check (checksum + HTTPS enforced)."
+fi
+
 # ── Unpack (the archive has a top-level nurl/ dir) ─────────────────────
 # Guard the destructive wipe: never delete $HOME, /, or a directory that
 # isn't ours. Only clear an empty dir or a prior NURL install (has bin/nurl).


### PR DESCRIPTION
Signs the toolchain releases with the `nurl-release` minisign key and verifies
in the installers — authenticity on top of the fail-closed checksum from #431.

## Signing (release.yml)

The `release` job signs every archive with `minisign -S` using the passwordless
key in the `MINISIGN_SECRET_KEY` secret and publishes the detached `.minisig`
alongside. Signing is **skipped, not failed**, when the secret is unset, so
forks can still cut releases.

## Verifying (installers)

`install.sh` and `install.ps1` pin the release **public** key
(`RWQT5WWt…`) and verify the `.minisig` against it, **fail-closed**. A
same-release checksum only proves the bytes weren't corrupted; the signature
proves they came from the release key — closing the "compromised release" gap.

Verification is opportunistic on the toolchain layer **by necessity**: at
install time `nurl` isn't present (can't use the pure-NURL verifier), and we do
**not** force users to install `minisign` to run the one-liner (rustup/deno make
the same call). When `minisign` is on PATH we verify fail-closed; when it isn't,
checksum + HTTPS stay the root of trust, with a printed note.

## Verified end-to-end

Local mock release signed with a throwaway key (installer copy pinned to it):

| scenario | result |
|---|---|
| valid signature | verifies, installs |
| tampered archive + **re-matched checksum** | signature **FAILS → refused**, dest never created |

That last row is the point — the signature catches what a re-matched checksum
can't.

## Where this fits

The sound, mandatory, zero-dependency, cross-platform signature check is the
**package** layer: the pure-NURL verifier (`stdlib/std/minisign.nu`, #432) runs
inside `nurlpkg`, where `nurl` is already present. Registry-side package signing
(registry signs with the project key; `nurlpkg` verifies) is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)