### PR TITLE
nurlpkg: install <library> lands under ./deps/ — no nurl.toml required

### DIFF
--- a/registry/DEPLOY.md
+++ b/registry/DEPLOY.md
@@ -54,9 +54,13 @@ verifies with its pure-NURL minisign implementation, so a compromised R2/CDN
 can't substitute tarball bytes. Verification is **mandatory + fail-closed**.
 
 - `REG_SIGN_KEY` is the base64 32-byte Ed25519 **seed**. The pinned public key
-  lives in `stdlib/ext/pkg_fetch.nu` (`__pkg_reg_pubkey`) and its keyid is
-  hard-coded in `src/index.ts` (`REG_SIGN_KEYID`) — all three must correspond
-  to the same key.
+  lives in `stdlib/ext/pkg_fetch.nu` (`__pkg_reg_pubkey`) and the keyid
+  embedded in signatures defaults to the production key's
+  (`DEFAULT_SIGN_KEYID` in `src/index.ts`) — all three must correspond to the
+  same key. Signing with a **different** key (self-hosted registry, local
+  tests) additionally requires `REG_SIGN_KEYID` (16 hex chars): the keyid
+  inside the public key your clients pin (bytes 2..10 of its base64 payload).
+  A wrong keyid makes every client reject the signature.
 - **One-time backfill** — packages published *before* signing was enabled have
   no `.minisig`, so after the first deploy that sets `REG_SIGN_KEY`, sign them
   all (idempotent; auth = presenting the seed itself):

--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -34,6 +34,10 @@ export interface Env {
   REG_SIGN_KEY?: string;        // wrangler secret: base64 Ed25519 seed (32B) —
                                 // signs every published tarball (minisign legacy
                                 // 'Ed' mode). Unset ⇒ publishes stay unsigned.
+  REG_SIGN_KEYID?: string;      // 16 hex chars: the minisign keyid embedded in
+                                // signatures. MUST equal the keyid inside the
+                                // public key the clients pin (bytes 2..10 of its
+                                // base64 payload). Unset ⇒ the production keyid.
 }
 
 const NAME_RE = /^[a-z0-9](?:[a-z0-9_-]{0,63})$/;
@@ -64,9 +68,22 @@ async function sha256Hex(data: ArrayBuffer | string): Promise<string> {
 // signature over the tarball bytes — no BLAKE2b prehash — because Web Crypto
 // exposes Ed25519 but not BLAKE2b. The pure-NURL verifier supports both.
 
-// keyid = first 8 bytes of the .minisig, must match the pinned public key's.
-// Public key: RWTGgah04Ft7n6+UNxc/MKT4eMViHBo4DLgKryJVbv9ZwedeQWpmmPq5
-const REG_SIGN_KEYID = new Uint8Array([0xc6, 0x81, 0xa8, 0x74, 0xe0, 0x5b, 0x7b, 0x9f]);
+// keyid = 8 bytes embedded in the .minisig; clients check it equals the keyid
+// inside the public key they pin, so it must match bytes 2..10 of that key's
+// base64 payload. Default = the production key's keyid
+// (pub RWTGgah04Ft7n6+UNxc/MKT4eMViHBo4DLgKryJVbv9ZwedeQWpmmPq5); override
+// with env.REG_SIGN_KEYID (16 hex chars) when signing with a different key
+// (self-hosted registries, the local test harness).
+const DEFAULT_SIGN_KEYID = new Uint8Array([0xc6, 0x81, 0xa8, 0x74, 0xe0, 0x5b, 0x7b, 0x9f]);
+
+function signKeyid(env: Env): Uint8Array {
+  const hex = env.REG_SIGN_KEYID;
+  if (!hex) return DEFAULT_SIGN_KEYID;
+  if (!/^[0-9a-fA-F]{16}$/.test(hex)) throw new Error("REG_SIGN_KEYID must be 16 hex chars (8 bytes)");
+  const out = new Uint8Array(8);
+  for (let i = 0; i < 8; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
 
 // PKCS#8 wrapper for a bare Ed25519 seed: SEQUENCE header + OID + the 32-byte
 // seed as an OCTET STRING. Lets crypto.subtle.importKey ingest a raw seed.
@@ -89,7 +106,7 @@ function bytesToB64(bytes: Uint8Array): string {
 }
 
 // Produce the .minisig text signing `body` with the given base64 Ed25519 seed.
-async function signTarball(seedB64: string, body: ArrayBuffer): Promise<string> {
+async function signTarball(seedB64: string, keyid: Uint8Array, body: ArrayBuffer): Promise<string> {
   const seed = b64ToBytes(seedB64);
   if (seed.length !== 32) throw new Error("REG_SIGN_KEY must be a 32-byte Ed25519 seed");
   const pkcs8 = new Uint8Array(PKCS8_ED25519_PREFIX.length + 32);
@@ -101,7 +118,7 @@ async function signTarball(seedB64: string, body: ArrayBuffer): Promise<string> 
   const line = new Uint8Array(2 + 8 + 64);
   line[0] = 0x45; // 'E'
   line[1] = 0x64; // 'd'  → legacy raw-Ed25519 mode
-  line.set(REG_SIGN_KEYID, 2);
+  line.set(keyid, 2);
   line.set(sig, 10);
   return `untrusted comment: nurl registry signature\n${bytesToB64(line)}\n`;
 }
@@ -235,7 +252,7 @@ async function handlePublish(req: Request, env: Env): Promise<Response> {
   await env.REG_BUCKET.put(tarKey, body);
   if (env.REG_SIGN_KEY) {
     try {
-      const sig = await signTarball(env.REG_SIGN_KEY, body);
+      const sig = await signTarball(env.REG_SIGN_KEY, signKeyid(env), body);
       await env.REG_BUCKET.put(`${tarKey}.minisig`, sig, {
         httpMetadata: { contentType: "text/plain" },
       });
@@ -299,7 +316,7 @@ async function handleSignBackfill(req: Request, env: Env): Promise<Response> {
       const obj = await env.REG_BUCKET.get(key);
       if (!obj) { failed++; errors.push(`${key}: vanished`); continue; }
       const body = await obj.arrayBuffer();
-      const sig = await signTarball(env.REG_SIGN_KEY, body);
+      const sig = await signTarball(env.REG_SIGN_KEY, signKeyid(env), body);
       await env.REG_BUCKET.put(`${key}.minisig`, sig, { httpMetadata: { contentType: "text/plain" } });
       signed++;
     } catch (e) {

--- a/registry/test-local.sh
+++ b/registry/test-local.sh
@@ -30,8 +30,11 @@ cd "$HERE"
 # (Matches the deterministic key in compiler/tests/pkg_install_e2e.nu.)
 REG_SIGN_KEY='AwoRGB8mLTQ7QklQV15lbHN6gYiPlp2kq7K5wMfO1dw='
 REG_SIGN_PUB='RWQKCwwNDg8QEXVcTLklbKfNxKz9xs/u2oSQF+W5+VFOmRkb1n4LDUJ2'
+# keyid inside REG_SIGN_PUB (bytes 2..10 of its base64 payload) — the Worker
+# must embed the SAME keyid in signatures or the client's keyid check fails.
+REG_SIGN_KEYID='0a0b0c0d0e0f1011'
 
-printf 'GITHUB_CLIENT_ID=local\nGITHUB_CLIENT_SECRET=local\nTOKEN_PEPPER=%s\nREGISTRY_URL=%s\nREG_SIGN_KEY=%s\n' "$PEPPER" "$REG" "$REG_SIGN_KEY" > .dev.vars
+printf 'GITHUB_CLIENT_ID=local\nGITHUB_CLIENT_SECRET=local\nTOKEN_PEPPER=%s\nREGISTRY_URL=%s\nREG_SIGN_KEY=%s\nREG_SIGN_KEYID=%s\n' "$PEPPER" "$REG" "$REG_SIGN_KEY" "$REG_SIGN_KEYID" > .dev.vars
 
 # Start from a clean local state (fresh D1 + empty R2 each run).
 rm -rf .wrangler/state
@@ -44,9 +47,16 @@ npx wrangler d1 execute REG_DB --local --command \
 npx wrangler d1 execute REG_DB --local --command \
   "INSERT OR IGNORE INTO tokens (user_id,token_hash,name,created_at) VALUES (1,'$HASH','cli',0);" >/dev/null 2>&1
 
+# A leftover server from an interrupted run would answer the health check
+# with stale state and poison every step below — clear the port first, and
+# kill the whole tree (wrangler's workerd child survives a plain `kill`).
+pkill -f "wrangler dev --port $PORT" 2>/dev/null || true
+pkill -f "workerd.*entry=localhost:$PORT" 2>/dev/null || true
+sleep 0.5
+
 npx wrangler dev --port "$PORT" --local > "$WORK/wrangler.log" 2>&1 &
 WPID=$!
-trap 'kill $WPID 2>/dev/null; rm -rf "$WORK"' EXIT
+trap 'kill $WPID 2>/dev/null; pkill -f "wrangler dev --port $PORT" 2>/dev/null; pkill -f "workerd.*entry=localhost:$PORT" 2>/dev/null; rm -rf "$WORK"' EXIT
 for i in $(seq 1 60); do curl -sf "$REG" >/dev/null 2>&1 && break; sleep 0.5; done
 
 mkdir -p "$WORK/foo/src"

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -205,7 +205,7 @@ $ `stdlib/std/bytes.nu`
     ( nurl_print `  nurlpkg info           Print the parsed manifest in the current directory.\n` )
     ( nurl_print `  nurlpkg deps           List dependencies, one per line.\n` )
     ( nurl_print `  nurlpkg install        Resolve this project's deps and symlink them under ./deps/.\n` )
-    ( nurl_print `  nurlpkg install <name> Fetch, build, and install a program from the registry onto $PATH.\n` )
+    ( nurl_print `  nurlpkg install <name> Program: fetch, build + install onto $PATH. Library: install under ./deps/ (no nurl.toml needed).\n` )
     ( nurl_print `  nurlpkg lock           Regenerate nurl.lock from the current deps/ tree.\n` )
     ( nurl_print `  nurlpkg publish        Pack + upload this package to the registry.\n` )
     ( nurl_print `  nurlpkg login          Store a publish token in ~/.nurl/credentials.\n` )
@@ -1553,6 +1553,9 @@ $ `stdlib/std/bytes.nu`
 // published package from the registry, resolve ITS dependencies, compile
 // its `src/main.nu` entry point with the installed compiler, and drop the
 // resulting binary on $PATH (under $NURL_HOME/bin, default ~/.nurl/bin).
+// If the package has no `src/main.nu` it is a LIBRARY: it lands under
+// ./deps/<name> instead (with its transitive registry deps), so a plain
+// folder of .nu files can pull a library without writing a nurl.toml.
 //
 // This is the payoff of the installable toolchain: an outside user runs
 // `nurlpkg install nq` and gets a working program built from
@@ -1879,6 +1882,106 @@ $ `stdlib/std/bytes.nu`
     ^ rc
 }
 
+// True if ./nurl.toml exists and already declares `name` under
+// [dependencies] (so a library install doesn't duplicate the entry).
+@ __toml_declares_dep s name → b {
+    : ~ b found F
+    ?? ( manifest_load `nurl.toml` ) {
+        T m → {
+            : i n ( vec_len [Dep] . m dependencies )
+            : ~ i k 0
+            ~ < k n {
+                : ?Dep d ( vec_get [Dep] . m dependencies k )
+                ?? d {
+                    T dv → { ? != 0 ( nurl_str_eq ( string_data . dv name ) name ) { = found T } {} }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( manifest_free m )
+        }
+        F _ → {}
+    }
+    ^ found
+}
+
+// `install <name>` on a LIBRARY package: land the latest version (and its
+// transitive registry deps) under ./deps/<name> — the same layout a
+// manifest-driven `nurlpkg install` produces — so a plain folder of .nu
+// files can pull a registry library without writing a nurl.toml first.
+// When a nurl.toml IS present, the dependency is recorded there too (same
+// effect as `nurlpkg add <name> --version ^<ver>`), so a later
+// manifest-driven install reproduces this state.
+@ __install_lib_deps s name s reg → i {
+    ( nurl_print `'` ) ( nurl_print name )
+    ( nurl_print `' is a library — installing into ./deps/\n` )
+    : ( Vec Dep ) roots ( vec_new [Dep] )
+    ( vec_push [Dep] roots @ Dep {
+        ( string_from name ) ( string_new ) ( string_from `*` ) ( string_new )
+    } )
+    : ( @ String s ) fetch \ s nm → String { ^ ( pkg_fetch_index reg nm ) }
+    : ~ i rc 0
+    : ~ String rootver ( string_new )
+    : !( Vec LockPkg ) ResolveErr rr ( resolve_registry roots reg fetch )
+    ?? rr {
+        F e → {
+            ( nurl_eprint `nurlpkg: registry resolution failed (` )
+            ( nurl_eprint ( resolve_err_name e ) ) ( nurl_eprintln `)` )
+            = rc 1
+        }
+        T locked → {
+            : i ln ( vec_len [LockPkg] locked )
+            : ~ i k 0
+            ~ < k ln {
+                : ?LockPkg po ( vec_get [LockPkg] locked k )
+                ?? po {
+                    T p → {
+                        : !i PkgFetchErr ir ( pkg_install_one reg ( string_data . p name ) ( string_data . p version ) ( string_data . p checksum ) `deps` )
+                        ?? ir {
+                            T _ → {
+                                ( nurl_print `  ` ) ( nurl_print ( string_data . p name ) )
+                                ( nurl_print ` ` ) ( nurl_print ( string_data . p version ) )
+                                ( nurl_print ` → deps/` ) ( nurl_print ( string_data . p name ) )
+                                ( nurl_print `\n` )
+                                ? != 0 ( nurl_str_eq ( string_data . p name ) name ) {
+                                    ( string_free rootver )
+                                    = rootver ( string_from ( string_data . p version ) )
+                                } {}
+                            }
+                            F fe → {
+                                ( nurl_eprint `  ` ) ( nurl_eprint ( string_data . p name ) )
+                                ( nurl_eprint `: ` ) ( nurl_eprintln ( pkg_err_name fe ) )
+                                = rc 1
+                            }
+                        }
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( lockpkgs_free locked )
+        }
+    }
+    ( __deps_free_vec roots )
+    ? & == rc 0 & ( file_exists `nurl.toml` ) > ( string_len rootver ) 0 {
+        ? ( __toml_declares_dep name ) {} {
+            : String req ( string_with_cap 24 )
+            ( string_push_char req 94 )
+            ( string_push_str req ( string_data rootver ) )
+            : i arc ( __cmd_add name `` ( string_data req ) )
+            ? != arc 0 { = rc arc } {}
+            ( string_free req )
+        }
+    } {}
+    ? == rc 0 {
+        ( nurl_print `done. Import it with:  $ deps/` )
+        ( nurl_print name )
+        ( nurl_print `/src/<module>.nu  (backtick-quoted)\n` )
+    } {}
+    ( string_free rootver )
+    ^ rc
+}
+
 @ __cmd_install_tool s name → i {
     : String regS ( __reg_default )
     : s reg ( string_data regS )
@@ -1927,8 +2030,9 @@ $ `stdlib/std/bytes.nu`
                                 ( string_push_char pkgdir 47 ) ( string_push_str pkgdir name )
                                 : String binsrc ( string_concat ( string_from ( string_data pkgdir ) ) ( string_from `/src/main.nu` ) )
                                 ? ! ( file_exists ( string_data binsrc ) ) {
-                                    ( nurl_eprint `nurlpkg: '` ) ( nurl_eprint name )
-                                    ( nurl_eprintln `' is a library, not an installable program (no src/main.nu)` )
+                                    // No src/main.nu → a library. Install it
+                                    // under ./deps/ instead of erroring.
+                                    = rc ( __install_lib_deps name reg )
                                 } {
                                     = rc ( __tool_build_and_install name ( string_data pkgdir ) ( string_data binsrc ) )
                                 }


### PR DESCRIPTION
`nurlpkg install <name>` used to hard-error on library packages ("is a library, not an installable program"), so pulling a registry library into a plain folder of `.nu` files required writing a manifest first. Now the command does the right thing for both package shapes:

- **program** (has `src/main.nu`): fetch + build + install onto `$PATH` — unchanged
- **library**: install the latest version **and its transitive registry deps** under `./deps/<name>` (the exact layout a manifest-driven install produces), then print the import hint. If a `nurl.toml` is present, the dependency is also recorded there (same effect as `nurlpkg add`, skipped when already declared). No `nurl.toml` → no problem: `deps/` alone is enough to build.

```
$ mkdir hack && cd hack
$ nurlpkg install http
'http' is a library — installing into ./deps/
  http 0.2.0 → deps/http
done. Import it with:  $ deps/http/src/<module>.nu  (backtick-quoted)
```

## Registry keyid fix (real bug, previously masked)

`signTarball` embedded the **hard-coded production keyid** in every signature regardless of which seed signed. Any non-default key (self-hosted registry, the local test harness) produced signatures that every client rejects — the pure-NURL verifier checks `sig.keyid == pinned-pub.keyid`. The keyid is now configurable (`REG_SIGN_KEYID`, 16 hex chars; **default = production keyid, so the live deployment is a no-op**). The earlier `test-local.sh` "PASS" that should have caught this came from a stale `build/nurlpkg` with no verification at all.

## test-local.sh hardening

- Writes `REG_SIGN_KEYID` for the test key.
- Clears leftover wrangler/workerd processes from an interrupted run before starting — a stale server on the port answered the health check with wiped state and poisoned every subsequent step. The EXIT trap now kills the whole process tree, not just the npx wrapper.

## Verified

- `registry/test-local.sh` full publish→sign→fetch→**verify** round-trip: **PASS** (now with a *verifying* nurlpkg).
- Live registry: `install http` into a bare folder → compiles + serves via `deps/http`; `install gpukit` pulls `gpu` transitively; repeat install idempotent; toml entry recorded once; `install nq` (program path) unchanged.
- Full suite **527 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)