### PR TITLE
registry: token expiry + scoped tokens, name hygiene, rate limits (M9)

### DIFF
--- a/registry/DEPLOY.md
+++ b/registry/DEPLOY.md
@@ -110,6 +110,39 @@ nurlpkg install
 server-side, enforces first-publisher name ownership, and treats published
 versions as immutable.
 
+## Tokens, name hygiene, rate limits (M9)
+
+- **Expiry.** Every token expires **90 days** after minting (pre-hardening
+  tokens were backfilled by migration `0002` to expire 90 days after it ran).
+  A 401 on a previously working setup usually means an expired token — sign
+  in again (`nurlpkg login`) to rotate. Revoke early with `nurlpkg logout
+  --revoke`.
+- **Scoped tokens (CI).** `POST /api/v1/token/new` with an existing
+  (unscoped) token mints a token restricted to specific packages — the right
+  shape for CI, which should be able to publish exactly one package:
+
+  ```bash
+  curl -X POST https://reg.nurl-lang.org/api/v1/token/new \
+       -H "Authorization: Bearer $NURL_TOKEN" \
+       -H 'content-type: application/json' \
+       -d '{"name":"ci-mypkg","pkgs":["mypkg"],"ttl_days":90}'
+  # → {"ok":true,"token":"...(shown once)...","expires_at":...,"pkgs":["mypkg"]}
+  ```
+
+  Scoped tokens can publish/yank only their listed packages and cannot mint
+  further tokens.
+- **Name hygiene.** New package names are rejected when they are reserved
+  (toolchain/stdlib/route names: `nurl`, `nurlc`, `std`, `api`, …) or
+  **lookalikes** of an existing package owned by someone else — normalised
+  match (separators dropped, digit homoglyphs folded: `imag3` ≈ `image`) or
+  edit distance ≤ 1 (`htttp` vs `http`). The owner of a package may publish
+  near its own name (`http` → `http2`).
+- **Rate limits** (D1 fixed-window): publish 30/h per user, token mint 10/h
+  (per IP for OAuth, per user for `/token/new`), search 120/min per IP.
+  Exceeding returns 429 + `retry-after`. Defaults are overridable via
+  `RL_PUBLISH_PER_HOUR` / `RL_MINT_PER_HOUR` / `RL_SEARCH_PER_MIN` /
+  `RL_TOKEN_NEW_PER_HOUR` (used by the local test harness).
+
 ## Local testing (no account)
 
 `registry/test-local.sh` runs the Worker under `wrangler dev` (miniflare

--- a/registry/migrations/0002_token_hardening.sql
+++ b/registry/migrations/0002_token_hardening.sql
@@ -1,0 +1,25 @@
+-- registry/migrations/0002_token_hardening.sql — M9 hardening.
+--
+-- Tokens gain an expiry and an optional per-package scope:
+--   expires_at  epoch ms; NULL = never (legacy rows are backfilled below so
+--               every pre-existing token expires 90 days from this migration
+--               rather than living forever)
+--   pkgs        NULL = token may act on ALL packages the user owns;
+--               else a comma-separated allow-list of package names — a CI
+--               token scoped to one package can't touch the others.
+--
+-- rate_limits backs the fixed-window per-user / per-IP limiter for
+-- publish / token-mint / search.
+
+ALTER TABLE tokens ADD COLUMN expires_at INTEGER;
+ALTER TABLE tokens ADD COLUMN pkgs TEXT;
+
+UPDATE tokens
+   SET expires_at = (strftime('%s','now') + 90*24*3600) * 1000
+ WHERE expires_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS rate_limits (
+  key          TEXT    PRIMARY KEY,  -- e.g. 'pub:<user_id>', 'search:<ip>'
+  window_start INTEGER NOT NULL,     -- epoch ms of the current window
+  count        INTEGER NOT NULL
+);

--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -38,6 +38,10 @@ export interface Env {
                                 // signatures. MUST equal the keyid inside the
                                 // public key the clients pin (bytes 2..10 of its
                                 // base64 payload). Unset ⇒ the production keyid.
+  RL_PUBLISH_PER_HOUR?: string; // rate-limit overrides (numbers as strings;
+  RL_MINT_PER_HOUR?: string;    //  defaults 30 / 10 / 120 / 10). Mostly for
+  RL_SEARCH_PER_MIN?: string;   //  the local test harness — production runs
+  RL_TOKEN_NEW_PER_HOUR?: string; // on the defaults.
 }
 
 const NAME_RE = /^[a-z0-9](?:[a-z0-9_-]{0,63})$/;
@@ -135,23 +139,60 @@ function randomToken(): string {
   return [...b].map((x) => x.toString(16).padStart(2, "0")).join("");
 }
 
-interface UserRow { id: number; github_id: number; login: string; }
+interface UserRow {
+  id: number;
+  github_id: number;
+  login: string;
+  // Per-token package scope: null ⇒ the token may act on every package the
+  // user owns; else only on the listed names. Set at token mint, immutable.
+  tokenPkgs: string[] | null;
+}
 
-// Resolve the Bearer token to a user, or null. Bumps last_used_at.
+// Resolve the Bearer token to a user, or null. Enforces token expiry;
+// bumps last_used_at.
 async function userFromAuth(req: Request, env: Env): Promise<UserRow | null> {
   const auth = req.headers.get("authorization") ?? "";
   const m = auth.match(/^Bearer\s+(.+)$/i);
   if (!m) return null;
   const hash = await hashToken(m[1].trim(), env.TOKEN_PEPPER);
   const row = await env.REG_DB.prepare(
-    `SELECT u.id AS id, u.github_id AS github_id, u.login AS login, t.id AS tid
+    `SELECT u.id AS id, u.github_id AS github_id, u.login AS login,
+            t.id AS tid, t.expires_at AS expires_at, t.pkgs AS pkgs
        FROM tokens t JOIN users u ON u.id = t.user_id
       WHERE t.token_hash = ?`,
-  ).bind(hash).first<UserRow & { tid: number }>();
+  ).bind(hash).first<UserRow & { tid: number; expires_at: number | null; pkgs: string | null }>();
   if (!row) return null;
+  if (row.expires_at !== null && row.expires_at < Date.now()) return null; // expired
   await env.REG_DB.prepare(`UPDATE tokens SET last_used_at = ? WHERE id = ?`)
     .bind(Date.now(), row.tid).run();
-  return { id: row.id, github_id: row.github_id, login: row.login };
+  const tokenPkgs = row.pkgs ? row.pkgs.split(",").filter((s) => s.length > 0) : null;
+  return { id: row.id, github_id: row.github_id, login: row.login, tokenPkgs };
+}
+
+// ── Rate limiting (D1 fixed window) ───────────────────────────────────
+// One upsert per checked request: reset the window if it has lapsed, else
+// increment, and read the count back. Returns true when the request is
+// within the limit. Keys are per-user for authenticated writes and per-IP
+// for anonymous endpoints.
+async function rateLimit(env: Env, key: string, limit: number, windowMs: number): Promise<boolean> {
+  const now = Date.now();
+  const row = await env.REG_DB.prepare(
+    `INSERT INTO rate_limits (key, window_start, count) VALUES (?1, ?2, 1)
+     ON CONFLICT(key) DO UPDATE SET
+       count        = CASE WHEN window_start <= ?2 - ?3 THEN 1 ELSE count + 1 END,
+       window_start = CASE WHEN window_start <= ?2 - ?3 THEN ?2 ELSE window_start END
+     RETURNING count`,
+  ).bind(key, now, windowMs).first<{ count: number }>();
+  return (row?.count ?? 1) <= limit;
+}
+
+function rlNum(v: string | undefined, dflt: number): number {
+  const n = v ? parseInt(v, 10) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : dflt;
+}
+
+function clientIp(req: Request): string {
+  return req.headers.get("cf-connecting-ip") ?? "unknown";
 }
 
 interface IndexDep { name: string; req: string; }
@@ -221,14 +262,77 @@ async function handleFile(env: Env, name: string, version: string, rel: string):
   return new Response(data, { headers });
 }
 
+// ── Name hygiene (typosquat + reserved) ───────────────────────────────
+// Toolchain binaries, stdlib roots, and this Worker's own route segments —
+// claiming any of these as a package name is confusing at best and an
+// attack surface at worst.
+const RESERVED_NAMES = new Set([
+  "nurl", "nurlc", "nurlpkg", "nurlfmt", "nurldoc", "nurlapi", "nurl-lsp",
+  "std", "stdlib", "core", "ext", "deps", "test", "tests", "bench",
+  "api", "admin", "index", "files", "pkgs", "packages", "login", "auth",
+  "search", "stats", "www",
+]);
+
+// Normalised form for lookalike detection: separators dropped, common
+// digit↔letter homoglyphs folded. "imag3" and "im-age" both normalise
+// to "image".
+function squatNormalize(name: string): string {
+  const homo: Record<string, string> = { "0": "o", "1": "l", "3": "e", "4": "a", "5": "s", "7": "t" };
+  let out = "";
+  for (const c of name) {
+    if (c === "-" || c === "_") continue;
+    out += homo[c] ?? c;
+  }
+  return out;
+}
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  const m = a.length, n = b.length;
+  let prev = Array.from({ length: n + 1 }, (_, j) => j);
+  for (let i = 1; i <= m; i++) {
+    const cur = [i];
+    for (let j = 1; j <= n; j++) {
+      cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1));
+    }
+    prev = cur;
+  }
+  return prev[n];
+}
+
+// A NEW package name is rejected when it is reserved, or when it is a
+// lookalike of an existing package owned by SOMEONE ELSE (normalised-equal,
+// or raw edit distance ≤ 1). The owner of `http` may publish `http2`;
+// a stranger may not publish `htttp`.
+async function newNameRejection(env: Env, name: string, userId: number): Promise<string | null> {
+  if (RESERVED_NAMES.has(name)) return "reserved_name";
+  const rows = await env.REG_DB.prepare(`SELECT name, owner_user_id FROM packages`)
+    .all<{ name: string; owner_user_id: number }>();
+  const norm = squatNormalize(name);
+  for (const r of rows.results ?? []) {
+    if (r.owner_user_id === userId) continue;
+    if (squatNormalize(r.name) === norm || levenshtein(name, r.name) <= 1) {
+      return `name_too_similar:${r.name}`;
+    }
+  }
+  return null;
+}
+
 async function handlePublish(req: Request, env: Env): Promise<Response> {
   const user = await userFromAuth(req, env);
   if (!user) return json({ error: "unauthorized" }, 401);
+  if (!(await rateLimit(env, `pub:${user.id}`, rlNum(env.RL_PUBLISH_PER_HOUR, 30), 3_600_000))) {
+    return json({ error: "rate_limited" }, 429, { "retry-after": "3600" });
+  }
 
   const name = (req.headers.get("x-nurl-package") ?? "").toLowerCase();
   const version = req.headers.get("x-nurl-version") ?? "";
   if (!NAME_RE.test(name)) return json({ error: "invalid_name" }, 400);
   if (!VERSION_RE.test(version)) return json({ error: "invalid_version" }, 400);
+  // Per-token package scope (M9): a scoped token acts only on its list.
+  if (user.tokenPkgs && !user.tokenPkgs.includes(name)) {
+    return json({ error: "token_scope" }, 403);
+  }
 
   const body = await req.arrayBuffer();
   if (body.byteLength === 0) return json({ error: "empty_body" }, 400);
@@ -239,6 +343,14 @@ async function handlePublish(req: Request, env: Env): Promise<Response> {
   const owner = await env.REG_DB.prepare(`SELECT owner_user_id FROM packages WHERE name = ?`)
     .bind(name).first<{ owner_user_id: number }>();
   if (owner && owner.owner_user_id !== user.id) return json({ error: "not_owner" }, 403);
+  // New names pass reserved-word + lookalike (typosquat) checks.
+  if (!owner) {
+    const rejection = await newNameRejection(env, name, user.id);
+    if (rejection) {
+      const [error, conflict] = rejection.split(":");
+      return json(conflict ? { error, conflict } : { error }, 403);
+    }
+  }
 
   // Immutability.
   const existing = await env.REG_DB.prepare(`SELECT version FROM versions WHERE name = ? AND version = ?`)
@@ -504,7 +616,10 @@ async function handlePackageDetail(env: Env, name: string): Promise<Response> {
     readmeHtml);
 }
 
-async function handleSearch(url: URL, env: Env): Promise<Response> {
+async function handleSearch(req: Request, url: URL, env: Env): Promise<Response> {
+  if (!(await rateLimit(env, `search:${clientIp(req)}`, rlNum(env.RL_SEARCH_PER_MIN, 120), 60_000))) {
+    return json({ error: "rate_limited" }, 429, { "retry-after": "60" });
+  }
   const q = (url.searchParams.get("q") ?? "").toLowerCase().slice(0, 64);
   const like = q ? `%${q.replace(/[%_\\]/g, "")}%` : "%";
   const rows = await env.REG_DB.prepare(
@@ -538,6 +653,9 @@ async function handleYank(req: Request, env: Env, yank: boolean): Promise<Respon
   const version = req.headers.get("x-nurl-version") ?? "";
   if (!NAME_RE.test(name)) return json({ error: "invalid_name" }, 400);
   if (!VERSION_RE.test(version)) return json({ error: "invalid_version" }, 400);
+  if (user.tokenPkgs && !user.tokenPkgs.includes(name)) {
+    return json({ error: "token_scope" }, 403);
+  }
   const owner = await env.REG_DB.prepare(`SELECT owner_user_id FROM packages WHERE name = ?`)
     .bind(name).first<{ owner_user_id: number }>();
   if (!owner) return json({ error: "not_found" }, 404);
@@ -576,7 +694,15 @@ function handleLogin(env: Env): Response {
   });
 }
 
+// Tokens minted via OAuth (and by default via /api/v1/token/new) live 90
+// days — long enough that rotation isn't a nuisance, short enough that a
+// leaked token doesn't work forever.
+const TOKEN_TTL_MS = 90 * 24 * 3_600_000;
+
 async function handleCallback(req: Request, env: Env): Promise<Response> {
+  if (!(await rateLimit(env, `mint:${clientIp(req)}`, rlNum(env.RL_MINT_PER_HOUR, 10), 3_600_000))) {
+    return json({ error: "rate_limited" }, 429, { "retry-after": "3600" });
+  }
   const url = new URL(req.url);
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
@@ -612,9 +738,10 @@ async function handleCallback(req: Request, env: Env): Promise<Response> {
     .bind(ghUser.id).first<{ id: number }>();
 
   const token = randomToken();
+  const expires = now + TOKEN_TTL_MS;
   await env.REG_DB.prepare(
-    `INSERT INTO tokens (user_id, token_hash, name, created_at) VALUES (?, ?, ?, ?)`,
-  ).bind(user!.id, await hashToken(token, env.TOKEN_PEPPER), "cli", now).run();
+    `INSERT INTO tokens (user_id, token_hash, name, created_at, expires_at) VALUES (?, ?, ?, ?, ?)`,
+  ).bind(user!.id, await hashToken(token, env.TOKEN_PEPPER), "cli", now, expires).run();
 
   return htmlPage(
     "NURL registry — token",
@@ -622,8 +749,49 @@ async function handleCallback(req: Request, env: Env): Promise<Response> {
       `<p>Your publish token (shown once — store it now):</p>` +
       `<pre style="background:#f4f4f4;padding:1rem;border-radius:6px;user-select:all">${token}</pre>` +
       `<p>Use it with nurlpkg:</p>` +
-      `<pre style="background:#f4f4f4;padding:1rem;border-radius:6px">export NURL_TOKEN=${token}\nnurlpkg publish</pre>`,
+      `<pre style="background:#f4f4f4;padding:1rem;border-radius:6px">export NURL_TOKEN=${token}\nnurlpkg publish</pre>` +
+      `<p>This token expires on <b>${new Date(expires).toISOString().slice(0, 10)}</b> ` +
+      `(90 days) — sign in again to rotate it. For CI, mint a token restricted to ` +
+      `specific packages with <code>POST /api/v1/token/new</code>.</p>`,
   );
+}
+
+// POST /api/v1/token/new — mint a scoped token from an existing full token.
+// Body: { name?, pkgs?: string[], ttl_days?: number }. `pkgs` restricts the
+// new token to those package names (the CI use case: a token that can
+// publish exactly one package). Only an UNSCOPED token may mint (a scoped
+// token minting a broader one would be privilege escalation). The plaintext
+// is returned once and never stored.
+async function handleTokenNew(req: Request, env: Env): Promise<Response> {
+  const user = await userFromAuth(req, env);
+  if (!user) return json({ error: "unauthorized" }, 401);
+  if (user.tokenPkgs) return json({ error: "scoped_token_cannot_mint" }, 403);
+  if (!(await rateLimit(env, `tok:${user.id}`, rlNum(env.RL_TOKEN_NEW_PER_HOUR, 10), 3_600_000))) {
+    return json({ error: "rate_limited" }, 429, { "retry-after": "3600" });
+  }
+  let body: { name?: unknown; pkgs?: unknown; ttl_days?: unknown };
+  try { body = await req.json(); } catch { return json({ error: "bad_json" }, 400); }
+  const label = typeof body.name === "string" && body.name.length <= 64 ? body.name : "scoped";
+  let pkgs: string[] | null = null;
+  if (body.pkgs !== undefined) {
+    if (!Array.isArray(body.pkgs) || body.pkgs.length === 0 || body.pkgs.length > 32 ||
+        !body.pkgs.every((p) => typeof p === "string" && NAME_RE.test(p))) {
+      return json({ error: "bad_pkgs" }, 400);
+    }
+    pkgs = body.pkgs as string[];
+  }
+  const ttlDays = typeof body.ttl_days === "number" && body.ttl_days >= 1 && body.ttl_days <= 365
+    ? Math.floor(body.ttl_days) : 90;
+
+  const now = Date.now();
+  const expires = now + ttlDays * 24 * 3_600_000;
+  const token = randomToken();
+  await env.REG_DB.prepare(
+    `INSERT INTO tokens (user_id, token_hash, name, created_at, expires_at, pkgs)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).bind(user.id, await hashToken(token, env.TOKEN_PEPPER), label, now, expires,
+         pkgs ? pkgs.join(",") : null).run();
+  return json({ ok: true, token, expires_at: expires, pkgs });
 }
 
 export default {
@@ -635,7 +803,7 @@ export default {
       if (path === "/") return handleCatalog(url, env);
       if (path === "/login") return handleLogin(env);
       if (path === "/auth/callback") return handleCallback(req, env);
-      if (path === "/api/v1/search") return handleSearch(url, env);
+      if (path === "/api/v1/search") return handleSearch(req, url, env);
       if (path === "/api/v1/stats") return handleStats(env);
       if (path.startsWith("/packages/")) {
         return handlePackageDetail(env, decodeURIComponent(path.slice("/packages/".length)).toLowerCase());
@@ -671,6 +839,7 @@ export default {
       if (path === "/api/v1/yank") return handleYank(req, env, true);
       if (path === "/api/v1/unyank") return handleYank(req, env, false);
       if (path === "/api/v1/revoke") return handleRevoke(req, env);
+      if (path === "/api/v1/token/new") return handleTokenNew(req, env);
       if (path === "/api/v1/admin/sign-backfill") return handleSignBackfill(req, env);
     }
     return json({ error: "not_found" }, 404);

--- a/registry/test-local.sh
+++ b/registry/test-local.sh
@@ -34,7 +34,8 @@ REG_SIGN_PUB='RWQKCwwNDg8QEXVcTLklbKfNxKz9xs/u2oSQF+W5+VFOmRkb1n4LDUJ2'
 # must embed the SAME keyid in signatures or the client's keyid check fails.
 REG_SIGN_KEYID='0a0b0c0d0e0f1011'
 
-printf 'GITHUB_CLIENT_ID=local\nGITHUB_CLIENT_SECRET=local\nTOKEN_PEPPER=%s\nREGISTRY_URL=%s\nREG_SIGN_KEY=%s\nREG_SIGN_KEYID=%s\n' "$PEPPER" "$REG" "$REG_SIGN_KEY" "$REG_SIGN_KEYID" > .dev.vars
+# Tiny search rate limit so the limiter is testable in seconds (prod: 120).
+printf 'GITHUB_CLIENT_ID=local\nGITHUB_CLIENT_SECRET=local\nTOKEN_PEPPER=%s\nREGISTRY_URL=%s\nREG_SIGN_KEY=%s\nREG_SIGN_KEYID=%s\nRL_SEARCH_PER_MIN=5\n' "$PEPPER" "$REG" "$REG_SIGN_KEY" "$REG_SIGN_KEYID" > .dev.vars
 
 # Start from a clean local state (fresh D1 + empty R2 each run).
 rm -rf .wrangler/state
@@ -46,6 +47,13 @@ npx wrangler d1 execute REG_DB --local --command \
   "INSERT OR IGNORE INTO users (id,github_id,login,created_at) VALUES (1,1,'tester',0);" >/dev/null 2>&1
 npx wrangler d1 execute REG_DB --local --command \
   "INSERT OR IGNORE INTO tokens (user_id,token_hash,name,created_at) VALUES (1,'$HASH','cli',0);" >/dev/null 2>&1
+# A second user for the cross-owner typosquat tests.
+TOKEN2=localtoken456
+HASH2=$(node -e "console.log(require('crypto').createHash('sha256').update('$PEPPER'+'$TOKEN2').digest('hex'))")
+npx wrangler d1 execute REG_DB --local --command \
+  "INSERT OR IGNORE INTO users (id,github_id,login,created_at) VALUES (2,2,'other',0);" >/dev/null 2>&1
+npx wrangler d1 execute REG_DB --local --command \
+  "INSERT OR IGNORE INTO tokens (user_id,token_hash,name,created_at) VALUES (2,'$HASH2','ci',0);" >/dev/null 2>&1
 
 # A leftover server from an interrupted run would answer the health check
 # with stale state and poison every step below — clear the port first, and
@@ -104,6 +112,57 @@ say "republish -> 409"
 
 say "bad token -> 401"
 ( cd "$WORK/foo" && NURL_REGISTRY="$REG" NURL_TOKEN="nope" "$NURLPKG" publish ) && { echo "expected failure"; fail=1; } || echo "rejected (correct)"
+
+# ── M9 hardening: name hygiene, scoped tokens, expiry, rate limits ─────
+# Raw curl for precise status assertions; the body is opaque at publish time.
+pub_code() { # pub_code <token> <name> <version> → HTTP status
+  curl -s -o /dev/null -w '%{http_code}' -X POST "${REG%/}/api/v1/publish" \
+    -H "Authorization: Bearer $1" -H "X-Nurl-Package: $2" -H "X-Nurl-Version: $3" \
+    --data-binary @"$WORK/foo.tar.gz.raw"
+}
+# Reuse the packed tarball bytes for the raw publishes.
+( cd "$WORK/foo" && tar czf "$WORK/foo.tar.gz.raw" nurl.toml src README.md )
+
+say "reserved name -> 403"
+c=$(pub_code "$TOKEN" std 1.0.0)
+[[ "$c" == 403 ]] && echo "rejected (correct)" || { echo "expected 403, got $c"; fail=1; }
+
+say "typosquat by another user -> 403"
+c=$(pub_code "$TOKEN2" fooo 1.0.0)          # edit distance 1 from foo
+[[ "$c" == 403 ]] && echo "fooo rejected (correct)" || { echo "expected 403, got $c"; fail=1; }
+c=$(pub_code "$TOKEN2" f-oo 1.0.0)          # normalised-equal to foo
+[[ "$c" == 403 ]] && echo "f-oo rejected (correct)" || { echo "expected 403, got $c"; fail=1; }
+
+say "lookalike by the owner is allowed"
+c=$(pub_code "$TOKEN" foo2 1.0.0)
+[[ "$c" == 200 ]] && echo "foo2 published (correct)" || { echo "expected 200, got $c"; fail=1; }
+
+say "scoped token: allowed package only"
+SCOPED=$(curl -s -X POST "${REG%/}/api/v1/token/new" -H "Authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' -d '{"name":"ci","pkgs":["foo"],"ttl_days":7}' \
+  | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>console.log(JSON.parse(d).token||''))")
+[[ -n "$SCOPED" ]] || { echo "token/new failed"; fail=1; }
+c=$(pub_code "$SCOPED" foo 2.0.0)
+[[ "$c" == 200 ]] && echo "in-scope publish ok" || { echo "expected 200, got $c"; fail=1; }
+c=$(pub_code "$SCOPED" bar 1.0.0)
+[[ "$c" == 403 ]] && echo "out-of-scope rejected (correct)" || { echo "expected 403, got $c"; fail=1; }
+c=$(curl -s -o /dev/null -w '%{http_code}' -X POST "${REG%/}/api/v1/token/new" \
+  -H "Authorization: Bearer $SCOPED" -H 'content-type: application/json' -d '{}')
+[[ "$c" == 403 ]] && echo "scoped token cannot mint (correct)" || { echo "expected 403, got $c"; fail=1; }
+
+say "expired token -> 401"
+npx wrangler d1 execute REG_DB --local --command \
+  "UPDATE tokens SET expires_at = 1 WHERE name = 'ci' AND user_id = 1;" >/dev/null 2>&1
+c=$(pub_code "$SCOPED" foo 3.0.0)
+[[ "$c" == 401 ]] && echo "rejected (correct)" || { echo "expected 401, got $c"; fail=1; }
+
+say "search rate limit (RL_SEARCH_PER_MIN=5)"
+limited=0
+for i in $(seq 1 8); do
+  c=$(curl -s -o /dev/null -w '%{http_code}' "${REG%/}/api/v1/search?q=foo")
+  [[ "$c" == 429 ]] && limited=1
+done
+[[ $limited -eq 1 ]] && echo "429 seen (correct)" || { echo "no 429 in 8 requests"; fail=1; }
 
 say "RESULT"
 [[ $fail -eq 0 ]] && echo "PASS" || echo "FAIL"

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -1529,6 +1529,12 @@ $ `stdlib/std/bytes.nu`
                                 ( nurl_eprint `nurlpkg: publish failed (` )
                                 ( nurl_eprint ( publish_err_name ue ) )
                                 ( nurl_eprintln `)` )
+                                // Tokens expire after 90 days — the most common
+                                // cause of a 401 on a previously working setup.
+                                ?? ue {
+                                    PubAuth → ( nurl_eprintln `hint: registry tokens expire after 90 days - run 'nurlpkg login' to mint a fresh one` )
+                                    _ → {}
+                                }
                                 = rc 1
                             }
                         }


### PR DESCRIPTION
Closes the npm-shaped account-takeover surface (critic **M9**) on the registry Worker.

## Tokens (migration `0002_token_hardening.sql`)
- **Expiry**: every token expires **90 days** after mint (`expires_at`, enforced in `userFromAuth`); legacy tokens are backfilled to expire 90 days after the migration runs. `nurlpkg` prints a rotate hint on `PubAuth`.
- **Scoped tokens**: `tokens.pkgs` allow-list + `POST /api/v1/token/new` mints per-package CI tokens (label, `pkgs`, `ttl_days` ≤ 365). Only an **unscoped** token may mint — a leaked CI token can't escalate. `publish`/`yank` enforce the scope (`403 token_scope`).

## Name hygiene (new packages only)
- **Reserved names**: toolchain/stdlib/route segments (`nurl`, `nurlc`, `std`, `api`, …).
- **Typosquat guard**: a new name is rejected when normalised-equal (separators dropped, digit homoglyphs folded — `imag3` ≈ `image`) or raw edit-distance ≤ 1 to a package owned by **someone else**. The owner of `http` may still publish `http2`.

## Rate limits (D1 fixed-window)
publish 30/h/user · OAuth mint 10/h/IP · `/token/new` 10/h/user · search 120/min/IP → `429` + `retry-after`. Env-tunable (`RL_*`) for the test harness.

## Declined (with rationale)
- `@user/pkg` namespacing — breaking wire-protocol change; flat namespace + squat guard suffices at this scale.
- 2FA — identity is delegated to GitHub OAuth; enable 2FA on the GitHub account.

## Verified (`registry/test-local.sh`, real Worker under wrangler dev, verifying nurlpkg)
reserved 403 · cross-owner `fooo`/`f-oo` 403 · owner lookalike `foo2` 200 · scoped in-scope 200 / out-of-scope 403 / mint-from-scoped 403 · expired 401 · search 429 → **PASS**

## Deploy
After merge, run the **Deploy registry Worker** workflow (Actions tab) — it applies migration `0002` to the remote D1 and deploys. Note: existing tokens (including yours) start their 90-day expiry clock at migration time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)