### PR TITLE
Structural: self-compile 13.6 GB → 366 MB, strict conditional-double-free check, compiler internals map (M1/M2/M3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
         # the relevant diff so we don't need extra grep here.
         run: ./build.sh
 
+      - name: self-compile peak-RSS gate
+        # Peak memory to compile the compiler is its existential
+        # scaling liability (critic M1) — the FreeBSD job already runs
+        # a hand-sized VM because of it. This turns the number into a
+        # budget so the PR that regresses it is the one that fails.
+        run: ./tools/memgate.sh
+
       - name: examples corpus frontend gate
         # Frontend-compiles every examples/ + bench/ + duo/ program.
         # Examples have rotted silently twice (immutability-migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Self-compiling the compiler takes 366 MB instead of 13.6 GB** (and
+  3.0 s instead of 10.1 s). Instrumented per-site allocation counters
+  attributed 11.9 GB of the peak to one function — the borrow checker's
+  per-binding state lookup, which re-sliced the remainder of its state
+  string per token (O(n²) bytes, 14.8 M calls per self-compile). The
+  state-map operations now walk by index and build their output in one
+  exact-size buffer; the state format and every diagnostic are
+  unchanged (old and new compiler emit byte-identical IR). CI gates the
+  number with `tools/memgate.sh` (600 MB budget) so it cannot silently
+  regress.
+
 ### Added
 
+- **`--strict-borrowck` closes the conditional double-free hole.** A
+  value freed on one arm of a `?` and freed again unconditionally — a
+  real double-free on the path where the first free ran — is now an
+  error under the strict checker (its third opt-in check). The default
+  checker still deliberately allows it to keep the no-false-positive
+  property; `docs/MEMORY.md` §2.9/§6.5 state the trade both ways.
+- **`docs/dev/COMPILER_INTERNALS.md`** — the map of the fused walk:
+  pipeline order, every process-global table with its writers
+  (appendix generated from source by `tools/gen_globals_map.py`), the
+  invariants that bite, and the safe-change checklist.
+- `docs/MEMORY.md` §6.5 now states every way safe-looking code can
+  still fail, together, with the accurate one-line safety claim to
+  quote instead of "memory-safe like Rust".
 - **`nurlpkg install <library>` works in a plain folder — no `nurl.toml`
   required.** A library package (no `src/main.nu`) now lands under
   `./deps/<name>` with its transitive registry deps, instead of erroring;

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -316,7 +316,14 @@
     : i wl ( nurl_str_len w )
     : i tl ( nurl_str_len t )
     ? > + pos wl tl { ^ F } {}
-    ? ! ( seq ( nurl_str_slice t pos wl ) w ) { ^ F } {}
+    // Direct char compare — this runs per character of every lowered
+    // type; the old slice+seq allocated a 2-4 byte string per probe
+    // (16.5M mallocs per self-compile).
+    : ~ i ck 0
+    ~ < ck wl {
+        ? != ( nurl_str_get t + pos ck ) ( nurl_str_get w ck ) { ^ F } {}
+        = ck + ck 1
+    }
     ? > pos 0
     { : i pc ( nurl_str_get t - pos 1 )
         ? | ( __is_ident_char pc ) == pc 37 { ^ F } {} }
@@ -9019,36 +9026,84 @@
     - ( nurl_str_get tok - len 1 ) 48
 }
 
-// State lookup — BCK_UNINIT when the binding is absent.
-@ bck_st_get s state s name → i {
-    : ~ s rest state
-    ~ != 0 ( nurl_str_len rest ) {
-        : s tok ( str_first_word rest )
-        = rest ( str_skip_word rest )
-        ? ( seq ( bck_tok_name tok ) name ) { ^ ( bck_tok_val tok ) } {}
+// State lookup — BCK_UNINIT when the binding is absent. Walks by INDEX,
+// allocating nothing: bck_st_get is the hottest allocation site in the
+// whole compiler (14.8M calls per self-compile), and the old remainder-
+// re-slice walk (`= rest ( str_skip_word rest )`) copied the entire tail
+// of the state string per step — measured at 11.9 GB of the 13.6 GB
+// self-compile peak RSS. A token is `name=digit`; its name part is
+// everything but the last two chars (same rule as bck_tok_name). The
+// name to look up lives at src[at .. at+wl) so bck_join_state can probe
+// with a name that is still embedded in the other state string — no
+// copy of the name either.
+@ __bck_st_get_at s state s src i at i wl → i {
+    : i n ( nurl_str_len state )
+    : ~ i i 0
+    ~ < i n {
+        // token spans [i, e)
+        : ~ i e i
+        ~ & < e n != ( nurl_str_get state e ) 32 { = e + e 1 }
+        ? == - - e i 2 wl {
+            : ~ i k 0
+            : ~ b eq T
+            ~ & eq < k wl {
+                ? != ( nurl_str_get state + i k ) ( nurl_str_get src + at k ) { = eq F } {}
+                = k + k 1
+            }
+            ? eq { ^ - ( nurl_str_get state - e 1 ) 48 } {}
+        } {}
+        = i + e 1
     }
     BCK_UNINIT
 }
 
+@ bck_st_get s state s name → i {
+    ^ ( __bck_st_get_at state name 0 ( nurl_str_len name ) )
+}
+
 // State update — a new state with `name` set to `val` (any prior
-// entry dropped; the binding lands at the end). Every `= out ...`
-// builds a fresh string rather than aliasing the loop-local `tok`,
-// which would be a double-free once both are auto-dropped.
+// entry dropped; the binding lands at the end). Built in ONE buffer
+// with an index walk: the old version re-sliced the remainder per
+// token AND re-copied the accumulated output per append — O(B²) bytes
+// per update on a B-byte state.
 @ bck_st_set s state s name i val → s {
-    : ~ s out ( nurl_str_cat `` `` )
-    : ~ s rest state
-    ~ != 0 ( nurl_str_len rest ) {
-        : s tok ( str_first_word rest )
-        = rest ( str_skip_word rest )
-        ? ( seq ( bck_tok_name tok ) name ) {} {
-            = out ? == 0 ( nurl_str_len out )
-            ( nurl_str_cat tok `` )
-            ( nurl_str_cat3 out ` ` tok )
-        }
+    : i n ( nurl_str_len state )
+    : i wl ( nurl_str_len name )
+    : s vs ( nurl_str_int val )
+    : i vl ( nurl_str_len vs )
+    // worst case: whole state kept + separator + `name=val`
+    : s out # s ( malloc + + + n wl vl 3 )
+    : *u ob # *u out
+    : ~ i op 0
+    : ~ i i 0
+    ~ < i n {
+        : ~ i e i
+        ~ & < e n != ( nurl_str_get state e ) 32 { = e + e 1 }
+        : ~ b keep T
+        ? == - - e i 2 wl {
+            : ~ i k 0
+            : ~ b eq T
+            ~ & eq < k wl {
+                ? != ( nurl_str_get state + i k ) ( nurl_str_get name k ) { = eq F } {}
+                = k + k 1
+            }
+            ? eq { = keep F } {}
+        } {}
+        ? keep {
+            ? > op 0 { : u sp # u 32 = . ob op sp = op + op 1 } {}
+            ( memcpy # s + # i out op # s + # i state i - e i )
+            = op + op - e i
+        } {}
+        = i + e 1
     }
-    : s nt ( nurl_str_cat3 name `=` ( nurl_str_int val ) )
-    ? == 0 ( nurl_str_len out ) { ^ nt } {}
-    ( nurl_str_cat3 out ` ` nt )
+    ? > op 0 { : u sp2 # u 32 = . ob op sp2 = op + op 1 } {}
+    ( memcpy # s + # i out op name wl )
+    = op + op wl
+    : u eqc # u 61
+    = . ob op eqc
+    = op + op 1
+    ( memcpy # s + # i out op vs + vl 1 )
+    ^ out
 }
 
 // State join — least upper bound of two states, binding by binding.
@@ -9063,32 +9118,52 @@
 // builds a fresh string — aliasing a loop-local would double-free at
 // auto-drop.
 @ bck_join_state s a s b → s {
-    : ~ s out ( nurl_str_cat `` `` )
-    : ~ s rest a
-    ~ != 0 ( nurl_str_len rest ) {
-        : s tok ( str_first_word rest )
-        = rest ( str_skip_word rest )
-        : s nm ( bck_tok_name tok )
-        : i vj ( bck_join ( bck_tok_val tok ) ( bck_st_get b nm ) )
-        : s nt ( nurl_str_cat3 nm `=` ( nurl_str_int vj ) )
-        = out ? == 0 ( nurl_str_len out )
-        ( nurl_str_cat nt `` )
-        ( nurl_str_cat3 out ` ` nt )
+    // Index walk + single output buffer (see bck_st_set). The lattice
+    // digit is one char, so the join of a and b never exceeds
+    // len(a) + len(b) + 2. Names probed while still embedded in their
+    // state string via __bck_st_get_at — the whole join allocates
+    // exactly one buffer.
+    : i na ( nurl_str_len a )
+    : i nb ( nurl_str_len b )
+    : s out # s ( malloc + + na nb 2 )
+    : *u ob # *u out
+    : ~ i op 0
+    // pass 1: every binding of a, joined against its state in b
+    : ~ i i 0
+    ~ < i na {
+        : ~ i e i
+        ~ & < e na != ( nurl_str_get a e ) 32 { = e + e 1 }
+        : i wl - - e i 2
+        : i vj ( bck_join - ( nurl_str_get a - e 1 ) 48 ( __bck_st_get_at b a i wl ) )
+        ? > op 0 { : u sp # u 32 = . ob op sp = op + op 1 } {}
+        // `name=` copied verbatim from a; then the joined digit
+        ( memcpy # s + # i out op # s + # i a i + wl 1 )
+        = op + op + wl 1
+        : u dg # u + 48 vj
+        = . ob op dg
+        = op + op 1
+        = i + e 1
     }
-    : ~ s rest2 b
-    ~ != 0 ( nurl_str_len rest2 ) {
-        : s tok ( str_first_word rest2 )
-        = rest2 ( str_skip_word rest2 )
-        : s nm ( bck_tok_name tok )
-        ? == BCK_UNINIT ( bck_st_get a nm ) {
-            : i vj ( bck_join BCK_UNINIT ( bck_tok_val tok ) )
-            : s nt ( nurl_str_cat3 nm `=` ( nurl_str_int vj ) )
-            = out ? == 0 ( nurl_str_len out )
-            ( nurl_str_cat nt `` )
-            ( nurl_str_cat3 out ` ` nt )
+    // pass 2: bindings present only in b (join against BCK_UNINIT)
+    : ~ i j 0
+    ~ < j nb {
+        : ~ i e2 j
+        ~ & < e2 nb != ( nurl_str_get b e2 ) 32 { = e2 + e2 1 }
+        : i wl2 - - e2 j 2
+        ? == BCK_UNINIT ( __bck_st_get_at a b j wl2 ) {
+            : i vj2 ( bck_join BCK_UNINIT - ( nurl_str_get b - e2 1 ) 48 )
+            ? > op 0 { : u sp2 # u 32 = . ob op sp2 = op + op 1 } {}
+            ( memcpy # s + # i out op # s + # i b j + wl2 1 )
+            = op + op + wl2 1
+            : u dg2 # u + 48 vj2
+            = . ob op dg2
+            = op + op 1
         } {}
+        = j + e2 1
     }
-    out
+    : u z # u 0
+    = . ob op z
+    ^ out
 }
 
 // ── Record access ─────────────────────────────────────────────────

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -9278,6 +9278,25 @@
     }
 }
 
+// --strict-borrowck companion of bck_diag: consuming a binding whose
+// state is MAYBE-moved (freed on one arm of a `?`, still owned on the
+// other). Deduplicated through the same warnset; the `mm:` prefix keeps
+// a strict diagnostic from suppressing a later definite one (or vice
+// versa) on the same line+name.
+@ bck_diag_maybe s name i useline → v {
+    : s tag ( nurl_str_cat3 ( nurl_str_cat `mm:` ( nurl_str_int useline ) ) `:` name )
+    : s ws ( nurl_sym_get g_bck `warnset` )
+    ? ( str_contains_word ws tag ) {} {
+        ( nurl_sym_def g_bck `warnset`
+        ? == 0 ( nurl_str_len ws ) tag ( nurl_str_cat3 ws ` ` tag ) )
+        : s ml ( nurl_sym_get g_bck ( nurl_str_cat `ml_` name ) )
+        ( bck_emit_error ( nurl_sym_get g_bck `file` ) useline
+        ( nurl_str_cat4 `'` name
+        `' may already be freed here — it was conditionally consumed (one branch only) at line ` ( nurl_str_cat3 ml
+        `; this second free double-frees on that path (strict-borrowck; restructure so exactly one path frees it)` `` ) ) )
+    }
+}
+
 // Flag any read of a definitely-Moved binding as a use-after-move.
 // MaybeMoved (a conditional move at a CFG join) is deliberately NOT
 // flagged — erroring only on a definite move keeps this check
@@ -9324,6 +9343,16 @@
         ? & ! done ( seq kind `move` ) {
             // A consumed binding: Owned -> Moved; remember where.
             : s mvn ( bck_field rec 1 )
+            // --strict-borrowck: consuming a MAYBE-moved binding is the
+            // conditional double-free the default checker deliberately
+            // lets through (docs/MEMORY.md §6.2/§6.5): freed on one arm
+            // of a `?`, then freed again — a real double-free on the
+            // path where the first free ran. Opt-in because it also
+            // flags the mutually-exclusive-frees pattern the default
+            // no-false-positive contract protects.
+            ? & != 0 g_strict_borrowck == BCK_MAYBE_MOVED ( bck_st_get st mvn ) {
+                ( bck_diag_maybe mvn ( nurl_str_to_int ( bck_field rec 3 ) ) )
+            } {}
             = st ( bck_st_set st mvn BCK_MOVED )
             ( nurl_sym_def g_bck ( nurl_str_cat `ml_` mvn )
             ( bck_field rec 3 ) )

--- a/compiler/tests/borrow_strict_maybe_double_free.nu
+++ b/compiler/tests/borrow_strict_maybe_double_free.nu
@@ -1,0 +1,48 @@
+// borrow_strict_maybe_double_free.nu — strict-mode check for the
+// CONDITIONAL double-free (the "maybe-moved hole", docs/MEMORY.md
+// §6.2/§6.5).
+//
+// A value freed on only one arm of a `?` and then freed again is a real
+// double-free on the path where the first free ran. The DEFAULT checker
+// deliberately does not flag it — that keeps the no-false-positive
+// property exact, at the price of this hole. `--strict-borrowck` closes
+// it: consuming a MAYBE-moved binding is an error.
+//
+// This file compiles cleanly under the default checker and only errors
+// under --strict-borrowck (which the test runner adds for borrow_strict_*).
+//
+// One positive case + one rebind control + one join-revive control.
+
+$ `stdlib/core/vec.nu`
+
+@ use_len i n → v {
+    ? > n 100 { ( nurl_print `big
+` ) } {}
+}
+
+@ main → i {
+    // POSITIVE — freed when the condition held, then freed again
+    // unconditionally: double-free whenever n > 2.
+    : ( Vec i ) xs ( vec_new [i] )
+    ( vec_push [i] xs 1 )
+    : i n ( vec_len [i] xs )
+    ? > n 2 { ( vec_free [i] xs ) } {}
+    ( vec_free [i] xs )
+
+    // CONTROL 1 — conditionally freed but REBOUND before the second
+    // free: the rebind revives the binding to Owned, so the second
+    // free is fine and must NOT be flagged.
+    : ~ ( Vec i ) ys ( vec_new [i] )
+    ( vec_push [i] ys 2 )
+    ? > n 2 { ( vec_free [i] ys ) = ys ( vec_new [i] ) } {}
+    ( vec_free [i] ys )
+
+    // CONTROL 2 — freed on BOTH arms then never touched again: the
+    // joined state is moved, but with no further consume there is
+    // nothing to flag under this rule.
+    : ( Vec i ) zs ( vec_new [i] )
+    ? > n 2 { ( vec_free [i] zs ) } { ( vec_free [i] zs ) }
+
+    ( use_len n )
+    ^ 0
+}

--- a/compiler/tests/outputs-windows/borrow_strict_maybe_double_free.txt
+++ b/compiler/tests/outputs-windows/borrow_strict_maybe_double_free.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/borrow_strict_maybe_double_free.nu:30: error: 'xs' may already be freed here — it was conditionally consumed (one branch only) at line 29; this second free double-frees on that path (strict-borrowck; restructure so exactly one path frees it)
+    ( vec_free [i] xs )
+error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_strict_maybe_double_free.txt
+++ b/compiler/tests/outputs/borrow_strict_maybe_double_free.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/borrow_strict_maybe_double_free.nu:30: error: 'xs' may already be freed here — it was conditionally consumed (one branch only) at line 29; this second free double-frees on that path (strict-borrowck; restructure so exactly one path frees it)
+    ( vec_free [i] xs )
+error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -34,6 +34,11 @@ closure-capture and `: ~` closure-borrow-escape rules live in
 
 ## Concurrency / thread safety
 
+The complete list of ways *safe-looking* code can still fail — this
+table plus the conditional double-free — is stated together in
+[`MEMORY.md` §6.5 "This is not Rust"](MEMORY.md); read that section
+before relying on any thread-safety expectation.
+
 | Limitation | Workaround |
 |---|---|
 | Sending a non-thread-safe value across a thread boundary is **partially** checked at compile time: a `thread_spawn` closure that captures an **`Rc`** (non-atomic refcount) is rejected, since two threads racing on its control-block count is UB. This is the concrete, documented footgun. There is **no general `Send`/`Sync` auto-derive** yet — a *user* type that is internally non-thread-safe is not automatically flagged when captured | Use **`Arc`** (atomic refcount) for any handle that crosses a thread boundary, exactly as `stdlib/std/arc.nu` documents; keep shared mutable state behind `Arc[Mutex]` |

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -591,6 +591,32 @@ deliberately simpler and the equivalence does **not** hold:
   safe. Its boundary (§3) is real and intentional, not a TODO list of
   Rust features pending.
 
+Concretely — and this is the comparison that matters — code that
+compiles clean, uses no `*T`, and calls no FFI can still do things
+safe Rust cannot:
+
+1. **Conditionally double-free.** A value freed on one arm of a `?`
+   and then freed again unconditionally is a real double-free on one
+   path, and it is *not* flagged — the price of the no-false-positive
+   property (§6.2, §6.3).
+2. **Data-race on shared heap state.** There is **no `Send`/`Sync`
+   system**. The one concrete footgun the compiler does reject is an
+   `Rc` captured into `thread_spawn`; but two threads sharing an
+   `Arc[Vec]` and both mutating the *contents* are entirely
+   unchecked, and a user type that is internally non-thread-safe is
+   not flagged when it crosses a thread boundary
+   ([`LIMITATIONS.md`](LIMITATIONS.md), *Concurrency / thread
+   safety*). `Arc` makes the *refcount* atomic, not your data.
+
+(Integer division by zero used to be a third entry here — it now
+panics with a clear message instead of executing UB.)
+
+So the accurate one-line claim is: **memory-safer than C by
+construction, with the common bug classes machine-checked — not
+memory-safe by proof, and not data-race-free.** Anyone needing the
+latter two guarantees today should reach for Rust; anyone reading a
+"NURL is memory-safe like Rust" claim should be pointed here.
+
 ### 6.6 The gates — how the guarantees are checked
 
 Everything above is enforced by two CI jobs

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -377,10 +377,10 @@ has depth 0. Boundaries that remain: a parameter returned through a
 closure *capture* (`^ \ → … cb …`) rather than a struct field, and
 forward / generic calls, are not yet summarised.
 
-### 2.9 `--strict-borrowck` — two opt-in checks
+### 2.9 `--strict-borrowck` — three opt-in checks
 
 The eight rules above run by default. `--strict-borrowck` (off by
-default) adds two further checks, both diagnostic-only and both emitting
+default) adds three further checks, all diagnostic-only and all emitting
 `error:` like the rest:
 
 1. **Aliased mutation through a field argument.** §2.4 flags an `inout`
@@ -392,8 +392,15 @@ default) adds two further checks, both diagnostic-only and both emitting
    owned binding whose pointer may outlive that binding's drop is
    reported — a narrow check on the otherwise-untracked `*T` surface
    (§3).
+3. **Conditional double-free (the maybe-moved hole, §6.2/§6.5).**
+   Consuming a binding that is *maybe*-moved — freed on one arm of a
+   `?`, still owned on the other — is reported: it is a real
+   double-free on the path where the first free ran. Off by default
+   because it also flags the legitimate mutually-exclusive-frees
+   pattern (free under `cond` here, free under `! cond` later), which
+   the default no-false-positive contract protects.
 
-It is **off by default** because the extension has a meaningful
+It is **off by default** because the extensions have a meaningful
 false-positive rate against existing stdlib code; it is a tightening
 knob for auditing a specific module, not part of the standard contract.
 The default-on eight rules remain the guarantee everything else in this
@@ -597,8 +604,10 @@ safe Rust cannot:
 
 1. **Conditionally double-free.** A value freed on one arm of a `?`
    and then freed again unconditionally is a real double-free on one
-   path, and it is *not* flagged — the price of the no-false-positive
-   property (§6.2, §6.3).
+   path, and it is *not* flagged by default — the price of the
+   no-false-positive property (§6.2, §6.3). `--strict-borrowck` closes
+   exactly this hole (§2.9, check 3) at the cost of also flagging the
+   legitimate mutually-exclusive-frees pattern.
 2. **Data-race on shared heap state.** There is **no `Send`/`Sync`
    system**. The one concrete footgun the compiler does reject is an
    `Rc` captured into `thread_spawn`; but two threads sharing an

--- a/docs/dev/COMPILER_INTERNALS.md
+++ b/docs/dev/COMPILER_INTERNALS.md
@@ -1,0 +1,206 @@
+# nurlc internals — the map of the fused walk and its global state
+
+This is the document to read **before changing the compiler**. It states
+how `compiler/nurlc.nu` is organised, which process-global tables exist,
+who writes them, and which invariants keep the single fused pass honest.
+The critique this answers (critic M2) was fair: the type rules live
+inside the code generators, so without this map every change begins as
+archaeology. The map is the pragmatic first step; a real AST/IR boundary
+remains the long-term direction and is deliberately **not** attempted in
+one leap — the bootstrap fixed point makes big-bang refactors expensive
+and every incremental step here is gated (see §5).
+
+## 1. Shape
+
+`compiler/nurlc.nu` is **one self-contained file** (~18.5k lines, no `$`
+imports — it defines its own string/symtab/lexer helpers so stage0 can
+build it from `nurlc_lastgood.ll` with nothing but clang). There is **no
+AST and no IR data structure**: parsing, type checking, borrow checking
+and code generation are one recursive descent (`parse_program` →
+`gen_stmt` / `gen_expr` / `gen_*`) that **emits LLVM IR text to stdout
+as it walks** (`emit` = `nurl_print`). What crosses statement/function
+boundaries is not a tree — it is the global state in §3.
+
+Consequences to internalise before editing:
+
+- A "type rule" usually lives at the `gen_*` site that lowers the
+  construct, next to the IR it emits. Changing a rule = finding every
+  gen-site that encodes it.
+- Nothing can be re-walked. Anything needed *later* must be recorded in
+  a table *now* (that is what most globals are).
+- Output order is emission order. Deferred definitions (closures,
+  generic instantiations, drop thunks, DWARF metadata) are queued in
+  tables and flushed at safe points.
+
+## 2. Pipeline
+
+```
+main()
+ ├─ CLI flags → g_borrowck / g_strict_borrowck / g_dbg_enabled / g_lint …
+ ├─ allocate ~20 sym tables (fresh per process; nothing survives runs)
+ ├─ emit_header                     — module preamble, runtime declares
+ ├─ scan_generic_structs (prepass)  — generic struct templates → tables
+ ├─ scan_fn_sigs         (prepass)  — every fn signature, follows `$`
+ │                                    imports; makes forward calls typed
+ ├─ scan_type_names      (prepass)  — struct/enum names → kind table
+ ├─ scan_dyn_types       (prepass)  — %Trait dyn-object vtables needed
+ ├─ parse_program                   — THE fused walk (parse + typecheck
+ │                                    + borrowck + memdrop + IR emit,
+ │                                    one function at a time; deferred
+ │                                    closures/generics flushed between
+ │                                    top-level items)
+ ├─ resolve_pending_escapes         — replay escape checks parked on
+ │                                    forward/generic calls
+ ├─ dbg_flush                       — queued !DI* metadata (--g)
+ ├─ lint_report_unused_*            — --lint reports
+ └─ exit non-zero if g_err_count / g_bck_errors
+```
+
+The four `scan_*` prepasses exist so the fused walk never needs a second
+look at the source: by the time `parse_program` runs, every signature,
+type name, template and dyn-trait requirement is already in a table.
+
+## 3. Global state — families and owners
+
+~70 globals fall into a dozen families. The generated appendix (§6)
+lists every one with its writers; this section is the mental model.
+"Sym table" below = the compiler's own scoped string→string map
+(`nurl_sym_new/def/get`, push/pop for scopes; `strdup` on both def and
+get — returned values are owned copies).
+
+| family | key globals | role & lifetime |
+|---|---|---|
+| diagnostics | `g_err_count`, `g_diag_recover_active` | error count + multi-error recovery mode; whole run |
+| codegen cursor | `g_str_idx`, `g_did_ret`, `g_ret_forbidden`, `g_in_match_arm`, `g_defer_count`, `g_stmt_line/col/bare_*` | per-statement/-function flags; must be reset on the boundaries that own them (grep their writers before trusting a reset) |
+| **last-type channel** | `g_last_type_ptr` (+ unsigned flag) | the expression walk's implicit return value: every `gen_expr` sets it; the *caller* reads it. The signedness flag **rides with it** — set/reset them together or resurrect the killed bug class (see `docs/GOTCHAS.md`, signedness-coupling) |
+| string literals | `g_str_syms`, `g_str_idx` | interned literal metadata, flushed as module constants |
+| generics | `g_generic_syms`, `g_generic_struct_syms`, `g_struct_inst_syms` | stored templates (token streams) + emitted-instantiation dedupe; whole run |
+| traits/impls | `g_trait_syms`, `g_impl_{ret,name,trait,pos}_syms` | method dispatch keys `method##llvm_type` → return type / mangle / owning trait / declaration site (coherence) |
+| dyn traits | `g_dyn_needed`, `g_dyn_flat_*`, `g_super_obligations` | accumulator strings (not tables): vtables to emit + supertrait proof obligations |
+| closures | `g_closure_defs/types`, `g_func_count`, `g_type_count`, `g_*_emit_base` | deferred closure bodies/types; the `emit_base` watermarks make the between-items flush idempotent |
+| result types | `g_res_type_syms` | `! T E` lowering metadata for try-propagation checking |
+| borrow checker | `g_bck` (per-fn record list + `warnset` + `ml_*` lines), `g_bck_depth`, `g_bck_closure_depth`, `g_bck_errors` | statements are RECORDED during the walk, analysed at function end (`bck_analyze` → `bck_walk_seq` over a `name=digit` state string; see §4) |
+| escape analysis | `g_fn_inout/sink/escapes/invoke_only/ret_param`, `g_pending_escape` | interprocedural summaries; `g_pending_escape` holds checks parked on forward/generic calls, replayed by `resolve_pending_escapes` |
+| auto-drop | `mem_*` journal (function-local handles) + `g_auto_drop_strings` | owned-resource journal driving scope-exit frees |
+| DWARF | `g_dbg_*` | metadata id allocator + queued `!DI*` blobs; only live under `--g` |
+| lint | `g_lint*` | usage recording; only under `--lint` |
+| visibility/modules | `g_vis_syms`, `g_pending_pub` | import graph + pub tracking for cross-file access checks |
+
+Reset discipline: everything is initialised in `main()` and the process
+compiles exactly one program — **there is no reuse between files**
+except via `$` imports walked in the same run. If you add a global,
+initialise it in `main()` next to its family and document the writer
+set in the appendix (regenerate it — §6).
+
+## 4. Memory discipline (post-M1)
+
+The compiler allocates arena-style: temporaries are **not** freed
+(bare `s` bindings are unmanaged), and correctness relies on that in
+one place you must not break:
+
+- `nurl_str_slice` / `nurl_str_cat*` / `nurl_sym_get` **always return a
+  fresh owned allocation**. Emitted auto-drop frees a string temp that
+  is passed *directly as a call argument*, so returning a borrowed
+  pointer (e.g. a suffix of the input) is a use-after-free / invalid
+  free waiting to happen. This was measured, attempted and reverted —
+  see the M1 commit; `nurl_llty`'s comment documents the same hazard.
+- Consequently the way to save memory is **algorithmic, at call
+  sites**: walk strings by index instead of re-slicing remainders
+  (`__bck_st_get_at` is the pattern), and build outputs in one
+  exact-size buffer instead of concat-accumulating.
+- History (self-compile peak RSS): 13.6 GB before the borrow-checker
+  state-map rewrite, 366 MB after. `tools/memgate.sh` (CI) keeps it
+  from regressing; if the gate fires on your PR, instrument first —
+  per-site counters over `nurl_str_slice`/`str_skip_word` call sites
+  found the last one in two runs.
+
+## 5. Changing the compiler safely
+
+1. `./check.sh compiler/nurlc.nu` — fast frontend syntax/type gate.
+2. Build and self-compare: the OLD binary and your NEW binary must emit
+   **byte-identical IR for the same source** unless your change is
+   *supposed* to alter codegen (then goldens move and you explain why).
+3. `./build.sh` — bootstrap fixed point (stage1 ≡ stage2) + the full
+   golden corpus. Borrow-checker changes: the `borrow_*` goldens are
+   the behavioural spec.
+4. `./tools/memgate.sh` — the peak-RSS budget.
+5. Sanitizers run in CI (`build.sh --san` + `run_san_tests.sh`) — run
+   locally when touching drop/ownership codegen.
+
+## 6. Appendix — every global and its writers (generated)
+
+Regenerate after adding/renaming globals:
+`python3 tools/gen_globals_map.py` (rewrites this section in place).
+
+| global | declared | written by | holds |
+|---|---|---|---|
+| `g_auto_drop_strings` | :1415 | `main` | Phase 2B auto-drop-strings feature flag. Default ON. Compiler's own source uses patterns (strings stored via n |
+| `g_bck` | :825 | `main` |  |
+| `g_bck_closure_depth` | :829 | `gen_closure_expr` |  |
+| `g_bck_depth` | :828 | `bck_block_enter`, `bck_block_exit`, `bck_fn_begin` | data (statement list etc.); allocated in main() only when --borrowck is set |
+| `g_bck_errors` | :833 | `bck_emit_error` | capture hooks no-op so closure statements do not inline into the enclosing function's list (so closure scopes  |
+| `g_borrowck` | :808 | `main` | ── Borrow-checker state ───────────────────────────────────────── g_borrowck is 1 (ON) by default; `--no-borro |
+| `g_closure_defs` | :794 | `main` |  |
+| `g_closure_emit_base` | :798 | `emit_closure_globals`, `main` |  |
+| `g_closure_types` | :795 | `main` |  |
+| `g_dbg_blob_syms` | :917 | `dbg_init` | module-flag id we might add later |
+| `g_dbg_cu_id` | :920 | `dbg_init` |  |
+| `g_dbg_current_file_id` | :949 | `gen_fn_decl_concrete` | defining path for the mono being emitted (the mono's lexer filename is the synthetic `<generic …>`). Set/resto |
+| `g_dbg_current_loc` | :923 | `gen_closure_expr`, `gen_fn_decl_concrete`, `gen_stmt` | (0 outside any function) |
+| `g_dbg_current_subprogram` | :921 | `gen_closure_expr`, `gen_fn_decl_concrete` |  |
+| `g_dbg_enabled` | :914 | `main` | ── DWARF debug-info state ─────────────────────────────────────── All zero/empty when --g is OFF; emit helpers |
+| `g_dbg_file_id` | :919 | `dbg_init` | flushed at end-of-module by dbg_flush |
+| `g_dbg_file_syms` | :938 | `dbg_init` | uses this instead of `nurl_lex_line` for the !DISubprogram source line. Set by emit_one_instantiation so per-m |
+| `g_dbg_next_id` | :915 | `dbg_alloc_id` |  |
+| `g_dbg_override_file` | :943 | `emit_one_instantiation` | every source file gets its own !DIFile and a subprogram debug-attributes to the file that DEFINES it (imports, |
+| `g_dbg_override_line` | :932 | `emit_one_instantiation` | the type for every local until Phase 6 lays down per-LLVM-type DIBasicType entries indexed by `vt`. |
+| `g_dbg_placeholder_ty` | :928 | `dbg_init` | dbg_init and reused for every fn. Phase 6 will replace with per-fn signature types. |
+| `g_dbg_subroutine_ty` | :925 | `dbg_init` | emit_dbg_eol then omits `, !dbg !N`) |
+| `g_dbg_type_syms` | :967 | `dbg_init` |  |
+| `g_defer_count` | :744 | `gen_defer`, `gen_fn_decl_concrete` |  |
+| `g_diag_recover_active` | :92 | `parse_program` |  |
+| `g_did_ret` | :726 | `gen_closure_expr`, `gen_cond`, `gen_defer`, `gen_fn_decl_concrete` +5 |  |
+| `g_dyn_flat_out` | :781 | `__dyn_flat_add`, `__dyn_flat_reset` | Scratch accumulators for dyn_flat_methods (a NURL fn returns one value, so the recursive supertrait walk threa |
+| `g_dyn_flat_seen` | :782 | `__dyn_flat_add`, `__dyn_flat_reset` |  |
+| `g_dyn_needed` | :778 | `dyn_note_needed` | <Trait>__tparam           → trait's generic type-var name (e.g. "T") <Trait>__defaults         → space-separat |
+| `g_err_count` | :91 | `__diag_abort` | Multi-error mode (rustc-style): while parse_program's per-declaration recovery frame is active (g_diag_recover |
+| `g_ffi_host_imports` | :815 | `main` | g_ffi_host_imports is 1 when `--ffi-host-imports` is passed: external `&`-FFI libraries are then satisfied by  |
+| `g_fn_escapes` | :871 | `main` | Per-function escaping-parameter map. `g_fn_escapes[fname]` is the space-separated list of 0-based indices of p |
+| `g_fn_inout` | :850 | `main` | Per-function inout-parameter map. `g_fn_inout[fname]` is the space-separated list of 0-based indices of `inout |
+| `g_fn_invoke_only` | :885 | `main` | Per-function *invoke-only* parameter map (closure-env reclamation, docs/MEMORY.md §7.4). `g_fn_invoke_only[fna |
+| `g_fn_ret_param` | :909 | `main` | Per-function returned-parameter map. `g_fn_ret_param[fname]` is the space-separated list of 0-based indices of |
+| `g_fn_sink` | :860 | `main` | Per-function sink-parameter map. `g_fn_sink[fname]` is the space-separated list of 0-based indices of `sink` p |
+| `g_func_count` | :797 | `gen_call_kwargs`, `gen_closure_expr`, `main`, `store_closure_func` |  |
+| `g_generic_struct_syms` | :746 | `main` |  |
+| `g_generic_syms` | :745 | `main` |  |
+| `g_impl_name_syms` | :751 | `main` |  |
+| `g_impl_pos_syms` | :753 | `main` |  |
+| `g_impl_ret_syms` | :750 | `main` |  |
+| `g_impl_trait_syms` | :752 | `main` |  |
+| `g_in_match_arm` | :743 | `gen_match` | Non-zero while parsing a `??` match-arm body. The XOR-confusion warning in gen_ret keys off "a non-terminator  |
+| `g_last_closure_nonsend` | :793 | `gen_closure_expr` | record per impl block, verified after scan_fn_sigs once every impl across the program (incl. imports) is regis |
+| `g_last_type_ptr` | :3506 | `nurl_set_last_type` |  |
+| `g_lint` | :1455 | `main` | Unused-symbol lint (opt-in via `--lint`). Default OFF so ordinary builds — and the compiler's own bootstrap, w |
+| `g_lint_gen` | :1459 | `lint_fn_begin` |  |
+| `g_lint_reads` | :1458 | `lint_init` |  |
+| `g_lint_recording` | :1466 | `main` | 1 only during the main parse_program pass. Cleared before flush_deferred_instantiations so synthetic generic m |
+| `g_lint_syms` | :1456 | `lint_init` |  |
+| `g_lint_used` | :1457 | `lint_init` |  |
+| `g_mono_tparam_tys` | :966 | `emit_one_instantiation` | Space-separated list of the concrete type-arguments substituted for a generic function's type parameters in th |
+| `g_pending_escape` | :897 | `main` | Deferred interprocedural-escape checks (docs/MEMORY.md §3 forward / generic boundary). A stack reference passe |
+| `g_pending_pub` | :1430 | `parse_toplevel_decl`, `scan_fn_sigs`, `vis_take_pending_pub` | Visibility (grammar v2.0). Tracks the source-file of every @-defined function and per-file strict-mode opt-in. |
+| `g_res_type_syms` | :239 | `main` | ── Res-type NURL tracking (must be declared before parse_type_res) ── g_res_type_syms is initialized to a new  |
+| `g_ret_forbidden` | :737 | `gen_cond`, `gen_logical_or_bitwise_and`, `gen_logical_or_bitwise_or`, `gen_operand` +1 | Cascade guard: 1 while parsing a VALUE OPERAND (a binary/unary/cast/ member operand, a call argument, a `?`/`? |
+| `g_stmt_bare_lit` | :2423 | `gen_stmt` | g_stmt_bare_lit — set by gen_stmt to 1 when the statement it just parsed was a bare numeric/string LITERAL in  |
+| `g_stmt_bare_value` | :2436 | `gen_stmt` | g_stmt_bare_value — the literal flag's general sibling (critic A2, the last silent prefix-arity cascade): set  |
+| `g_stmt_col` | :2381 | `gen_stmt` | g_stmt_col — column of the current statement's first token, captured alongside g_stmt_line. `die_stmt` anchors |
+| `g_stmt_line` | :2374 | `gen_stmt` | g_stmt_line — source line of the statement gen_stmt is currently parsing. Read by gen_ident's "unexpected toke |
+| `g_str_idx` | :724 | `emit_deferred_cstr`, `emit_str_global`, `gen_str_lit` |  |
+| `g_str_syms` | :725 | `main` |  |
+| `g_strict_borrowck` | :824 | `main` | `--strict-borrowck` (off by default) enables two additional checks: (1) aliased mutation through `. obj field` |
+| `g_struct_inst_syms` | :749 | `main` | <sname>__stparams → space-separated type-var names (e.g. "T" or "K V") <sname>__sbody    → raw body source inc |
+| `g_super_obligations` | :783 | `scan_impl_decl` |  |
+| `g_trait_syms` | :760 | `main` | first registration. A `$`-imported impl is scanned once per importer, so the SAME (method, type) is registered |
+| `g_type_count` | :796 | `main`, `store_closure_type` |  |
+| `g_type_emit_base` | :799 | `main` |  |
+| `g_vis_syms` | :1431 | `main` |  |

--- a/tools/gen_globals_map.py
+++ b/tools/gen_globals_map.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/gen_globals_map.py — regenerate the globals appendix of
+#  docs/dev/COMPILER_INTERNALS.md from compiler/nurlc.nu.
+#
+#  For every module-level mutable global (`: ~ i g_*` / `: ~ s g_*`) it
+#  records the declaration line, the declaration comment (trailing, or
+#  the comment block immediately above), and the set of functions that
+#  WRITE it (`= g_x …`, excluding ==/!=/<=/>= comparisons). Rewrites
+#  everything after the "## 6." heading in place.
+# ============================================================
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "compiler/nurlc.nu"
+DOC = ROOT / "docs/dev/COMPILER_INTERNALS.md"
+MARK = "## 6."
+
+def build_table() -> str:
+    src = SRC.read_text().splitlines()
+    decl = {}
+    for i, line in enumerate(src):
+        g = re.match(r": ~ (?:i|s) (g_\w+)\s*(?://\s*(.*))?", line)
+        if g:
+            comment = g.group(2) or ""
+            if not comment:
+                j, cs = i - 1, []
+                while j >= 0 and src[j].strip().startswith("//"):
+                    cs.insert(0, src[j].strip()[2:].strip())
+                    j -= 1
+                comment = " ".join(cs)
+            decl[g.group(1)] = (i + 1, comment[:110])
+
+    writes = {g: set() for g in decl}
+    fn = None
+    for line in src:
+        m = re.match(r"@ (\S+)", line)
+        if m:
+            fn = m.group(1)
+        if fn is None:
+            continue
+        for g in set(re.findall(r"\bg_\w+\b", line)):
+            # a write is `= g_x `, NOT the tail of ==/!=/<=/>=
+            if g in decl and re.search(rf"(?<![=!<>])= {g} ", line):
+                writes[g].add(fn)
+
+    out = ["| global | declared | written by | holds |", "|---|---|---|---|"]
+    for g, (ln, c) in sorted(decl.items()):
+        w = sorted(writes[g])
+        ws = ", ".join(f"`{x}`" for x in w[:4]) + (f" +{len(w)-4}" if len(w) > 4 else "")
+        out.append(f"| `{g}` | :{ln} | {ws or '(init only)'} | {c.replace('|', chr(92)+'|')} |")
+    return "\n".join(out) + "\n"
+
+def main() -> int:
+    doc = DOC.read_text()
+    idx = doc.find(MARK)
+    if idx < 0:
+        print(f"gen_globals_map: '{MARK}' heading not found in {DOC}", file=sys.stderr)
+        return 1
+    # keep the heading + its intro paragraph (everything up to the table)
+    tbl = doc.find("| global |", idx)
+    if tbl < 0:
+        print("gen_globals_map: existing table not found after the heading", file=sys.stderr)
+        return 1
+    DOC.write_text(doc[:tbl] + build_table())
+    print(f"gen_globals_map: rewrote the appendix in {DOC}")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/memgate.sh
+++ b/tools/memgate.sh
@@ -23,8 +23,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Keep the budget a hair above the current measured peak. History:
-#   2026-07-11  13.6 GB measured pre-arena  → budget 14300
-DEFAULT_BUDGET_MB=14300
+#   2026-07-11  13.6 GB measured pre-fix   → budget 14300
+#   2026-07-11  366 MB after the bck state-map index rewrite → budget 600
+DEFAULT_BUDGET_MB=600
 
 BUDGET_MB="${1:-${NURL_RSS_BUDGET_MB:-$DEFAULT_BUDGET_MB}}"
 

--- a/tools/memgate.sh
+++ b/tools/memgate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/memgate.sh — self-compile peak-RSS regression gate (critic M1).
+#
+#  The compiler's existential scaling liability is the memory it takes to
+#  compile ITSELF: one fused walk, ~30 process-global tables, and (before
+#  the arena work) every intermediate string retained to exit. This gate
+#  turns peak RSS into a tracked budget so a regression shows up in the
+#  PR that causes it, not months later as an OOM-killed CI VM.
+#
+#  Usage:  tools/memgate.sh [budget_mb]
+#    budget_mb   fail if self-compile peak RSS exceeds this
+#                (default: $NURL_RSS_BUDGET_MB, else the value below)
+#
+#  Measures `build/nurlc compiler/nurlc.nu` under GNU time -v (IR to
+#  /dev/null — emission streams to stdout and is not what we're bounding).
+#  Skips (exit 0, loud note) where GNU time is unavailable (macOS/BSD),
+#  so the gate is Linux-CI-enforced without breaking local dev elsewhere.
+# ============================================================
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Keep the budget a hair above the current measured peak. History:
+#   2026-07-11  13.6 GB measured pre-arena  → budget 14300
+DEFAULT_BUDGET_MB=14300
+
+BUDGET_MB="${1:-${NURL_RSS_BUDGET_MB:-$DEFAULT_BUDGET_MB}}"
+
+TIME_BIN=""
+for cand in /usr/bin/time /usr/local/bin/time; do
+    if [ -x "$cand" ] && "$cand" -v true >/dev/null 2>&1; then
+        TIME_BIN="$cand"
+        break
+    fi
+done
+if [ -z "$TIME_BIN" ]; then
+    echo "memgate: GNU time (-v) not available — skipping (gate enforced on Linux CI)"
+    exit 0
+fi
+
+NURLC="$ROOT/build/nurlc"
+[ -x "$NURLC" ] || { echo "memgate: $NURLC missing — run ./build.sh first"; exit 2; }
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+"$TIME_BIN" -v "$NURLC" "$ROOT/compiler/nurlc.nu" > /dev/null 2> "$log" || {
+    echo "memgate: self-compile FAILED:"
+    tail -20 "$log"
+    exit 1
+}
+
+peak_kb="$(grep -oE 'Maximum resident set size \(kbytes\): [0-9]+' "$log" | grep -oE '[0-9]+$')"
+[ -n "$peak_kb" ] || { echo "memgate: could not parse peak RSS:"; cat "$log"; exit 2; }
+peak_mb=$(( peak_kb / 1024 ))
+
+echo "memgate: self-compile peak RSS = ${peak_mb} MB (budget ${BUDGET_MB} MB)"
+if [ "$peak_mb" -gt "$BUDGET_MB" ]; then
+    echo "memgate: FAIL — peak RSS exceeds the budget."
+    echo "  If this is expected growth, raise DEFAULT_BUDGET_MB in tools/memgate.sh"
+    echo "  in the same PR and say why in the commit message. If not, find the"
+    echo "  allocation you added: NURL_ALLOC_STATS=1 (see stdlib/runtime.c)."
+    exit 1
+fi
+echo "memgate: OK"


### PR DESCRIPTION
The three structural critique items (critic **M1/M2/M3**), shipped as six focused commits — each independently reviewable, PR opened only after the full validation ran green.

## M1 — self-compile peak RSS 13.6 GB → **366 MB** (37×), wall 10.1 s → **3.0 s** (3×)
**Measured, not guessed.** Instrumented builds (per-site allocation counters over all 152 `nurl_str_slice` sites, then all 138 `str_skip_word` sites) attributed **11.9 GB of the 13.6 GB to one function**: `bck_st_get` — the borrow checker's per-binding state lookup, 14.8 M calls per self-compile, re-slicing the remainder of its `name=digit` state string per token (O(B²) bytes).

Fix is algorithmic, at the measured hot spots, with state format and semantics unchanged:
- `__bck_st_get_at`: index walk — a lookup now **allocates nothing**; `bck_join_state` probes with names still embedded in the other state string.
- `bck_st_set` / `bck_join_state`: one exact-size output buffer (kills the concat-accumulate O(B²) too).
- `__llty_word_at`: direct char compare (16.5 M tiny allocations gone).

Rejected as unsound (and documented): borrowed-suffix returns from `nurl_str_slice` — emitted auto-drop frees slice results passed directly as call arguments (verified by the glibc abort it causes).

**Gate:** `tools/memgate.sh` in CI — budget 600 MB, so the win is locked in, not just enjoyed. The 16 GB-laptop contributor now has ~40× headroom.

## M3 — the safety-claim holes
- **(a) Stated together, prominently**: `MEMORY.md` §6.5 now enumerates everything clean-compiling, `*T`-free, FFI-free code can still do that safe Rust cannot, and ends with the accurate one-line claim to quote. `LIMITATIONS.md` cross-links.
- **(b) Conditional double-free closed under `--strict-borrowck`** (third opt-in check): consuming a MAYBE-moved binding errors with the conditional-consume line in the message. Default checker unchanged — the no-false-positive property is kept, and the trade is documented both ways. New `borrow_strict_maybe_double_free` golden: positive case fires; rebind control and both-arms control stay silent; the file compiles clean under the default checker.
- **(c) Data-race / Send-Sync**: claim explicitly scoped (a real Send/Sync system remains a 1.0 design item, stated as such).
- Div-by-zero (the former third hole) already fixed in #419 — noted.

## M2 — the map the fused walk was missing
`docs/dev/COMPILER_INTERNALS.md`: the shape (one file, no AST, IR streamed — and what that implies for editing), the pipeline (4 scan prepasses → fused walk → deferred flushes), **every process-global table grouped by family** with lifetime/reset discipline and the invariants that bite (last-type/signedness coupling, always-owned string returns), the M1 memory discipline with the measured history, and the safe-change checklist. The per-global appendix (declaration, writers, role) is **generated from source** by `tools/gen_globals_map.py` so it cannot rot. A real AST/IR boundary stays the long-term direction, explicitly deferred — the map is the step that makes the next contributor's change archaeology-free.

## Validation
- Old and new compiler emit **byte-identical IR on the same source** (fixed point holds; refreshed via `./build.sh`).
- `./build.sh` full bootstrap + corpus: **528 pass** (incl. every `borrow_*` golden and the new strict test), run again after the last compiler-touching commit.
- `tools/memgate.sh`: 359 MB / 600 MB budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)