### PR TITLE
stdlib: tcp_connect in std/net.nu; random.nu draws fail closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`std/random.nu` draws fail closed.** `rand_u64` / `rand_hex_str` now
+  check `nurl_rand_fill`'s return and panic when every OS entropy source
+  failed (the runtime would otherwise degrade to a non-cryptographic
+  LCG) — the same contract the tls/rsa/x509 draws already enforced.
+
 - **Self-compiling the compiler takes 366 MB instead of 13.6 GB** (and
   3.0 s instead of 10.1 s). Instrumented per-site allocation counters
   attributed 11.9 GB of the peak to one function — the borrow checker's
@@ -23,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`std/net.nu` gains `tcp_connect`** — the plain-TCP client connect,
+  returning `!TcpConn NetErr` like its TLS siblings. The MQTT module's
+  private duplicate (which returned `MqttErr`) is gone; `async_tcp`'s
+  local FFI shim now uses the public API.
 - **`--strict-borrowck` closes the conditional double-free hole.** A
   value freed on one arm of a `?` and freed again unconditionally — a
   real double-free on the path where the first free ran — is now an

--- a/compiler/tests/async_tcp.nu
+++ b/compiler/tests/async_tcp.nu
@@ -22,11 +22,6 @@ $ `stdlib/std/time.nu`
 $ `stdlib/ext/env.nu`
 $ `stdlib/core/string.nu`
 
-// Client-side FFI: blocking TCP connect (runtime §18b — landed via
-// the MQTT work but not exposed in std/net.nu yet). Declared
-// locally; same C symbol as mqtt.nu's binding.
-& `libc` @ nurl_tcp_connect s host i port → i
-
 : ~ i echoed 0
 : ~ i client_match 0
 
@@ -60,40 +55,39 @@ $ `stdlib/core/string.nu`
                 }
             }
 
+            // Client uses std/net.nu's tcp_connect — the public
+            // plain-TCP client connect this test also serves to pin.
             : ( @ v ) client \ → v {
                 ( sleep_ms 50 )
-                : i craw ( nurl_tcp_connect `127.0.0.1` 18910 )
-                ? == craw 0 {
-                    ( chan_send [i] done 0 )
-                } {
-                    : i ek ( nurl_tcp_err_kind craw )
-                    ? != ek 0 {
-                        ( nurl_tcp_close craw )
-                        ( chan_send [i] done 0 )
-                    } {
-                        : s msg `hi`
-                        : i wn ( nurl_tcp_write craw msg 2 )
-                        ? != wn 2 {
-                            ( nurl_tcp_close craw )
-                            ( chan_send [i] done 0 )
-                        } {
-                            : s buf ( nurl_alloc 16 )
-                            ( nurl_poke buf 0 0 )
-                            ( nurl_poke buf 1 0 )
-                            : i rdn ( nurl_tcp_read craw buf 16 )
-                            ? == rdn 2 {
-                                : i b0 ( nurl_peek buf 0 )
-                                : i lo & b0 255
-                                ? == lo 104 {
-                                    : i hi & / b0 256 255
-                                    ? == hi 105 {
-                                        = client_match 1
-                                    } {}
-                                } {}
-                            } {}
-                            ( nurl_free buf )
-                            ( nurl_tcp_close craw )
-                            ( chan_send [i] done 1 )
+                ?? ( tcp_connect `127.0.0.1` 18910 ) {
+                    F e → ( chan_send [i] done 0 )
+                    T c → {
+                        : ( Vec u ) msg ( vec_new [u] )
+                        ( vec_push [u] msg # u 104 )
+                        ( vec_push [u] msg # u 105 )
+                        : !v NetErr wr ( tcp_write_all c msg )
+                        ( vec_free [u] msg )
+                        ?? wr {
+                            F e2 → {
+                                ( tcp_close_conn c )
+                                ( chan_send [i] done 0 )
+                            }
+                            T _ → {
+                                : !( Vec u ) NetErr rd ( tcp_read_chunk c 16 )
+                                ?? rd {
+                                    T v → {
+                                        ? == ( vec_len [u] v ) 2 {
+                                            : i b0 ?? ( vec_get [u] v 0 ) { T x → # i x F → 0 }
+                                            : i b1 ?? ( vec_get [u] v 1 ) { T x → # i x F → 0 }
+                                            ? & == b0 104 == b1 105 { = client_match 1 } {}
+                                        } {}
+                                        ( vec_free [u] v )
+                                    }
+                                    F e3 → {}
+                                }
+                                ( tcp_close_conn c )
+                                ( chan_send [i] done 1 )
+                            }
                         }
                     }
                 }

--- a/docs/CRYPTO.md
+++ b/docs/CRYPTO.md
@@ -48,11 +48,11 @@ separate, explicitly-named `tls_connect_insecure`.
 All key, nonce, salt and blinding-factor entropy comes from one runtime
 bridge, `nurl_rand_fill`, which selects the OS CSPRNG per platform —
 `getrandom(2)` on Linux, `arc4random_buf` on macOS, `BCryptGenRandom` on
-Windows, `/dev/urandom` otherwise. The crypto modules (`std/tls.nu`,
-`std/rsa.nu`, `std/x509_gen.nu`) each check its return value and **fail
-closed** (panic) rather than proceed with predictable bytes. Note:
-`std/random.nu`'s convenience draws (`rand_u64`, `rand_hex_str`) do **not**
-check the return value — do not use them for key material. `std/rng.nu`
+Windows, `/dev/urandom` otherwise. Every draw — the crypto modules
+(`std/tls.nu`, `std/rsa.nu`, `std/x509_gen.nu`) and `std/random.nu`'s
+convenience draws (`rand_u64`, `rand_hex_str`) alike — checks its return
+value and **fails closed** (panics) rather than proceed with predictable
+bytes. `std/rng.nu`
 (xoshiro256\*\*) is a separate, clearly-marked **non-cryptographic** PRNG
 for simulations and is never used by this stack.
 

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -10,11 +10,10 @@ dual-stack IPv4/IPv6 and integrated with the fiber reactor for async I/O.
   HTTP/1.1 server stack on top (`stdlib/ext/http_*` — routing, static files,
   middleware, multipart, WebSockets, TLS with SNI + ALPN + mTLS + live cert
   reload; see [HTTPS / TLS](#https--tls) below).
-- **TCP client** — `tcp_connect_tls` (TLS client handshake with SNI; the
-  `verify` flag turns on peer-certificate chain + host-name verification
-  against the system trust store — the primitive behind any outbound TLS
-  application). A plain-TCP connect is currently provided by the MQTT
-  module (`ext/mqtt.nu`, `tcp_connect`), not by `std/net.nu`.
+- **TCP client** — `tcp_connect` (plain) / `tcp_connect_tls` (TLS client
+  handshake with SNI; the `verify` flag turns on peer-certificate chain +
+  host-name verification against the system trust store — the primitive
+  behind any outbound TLS application).
 - **UDP** (`stdlib/std/udp.nu`) — `udp_bind` (dual-stack wildcard),
   `udp_connect`, `udp_send_to` / `udp_recv_from`, connected-mode `udp_send` /
   `udp_recv`, broadcast and multicast (`udp_join_group` / `_leave_group` /

--- a/stdlib/ext/mqtt.nu
+++ b/stdlib/ext/mqtt.nu
@@ -60,7 +60,7 @@
 // connection. `mqtt_listen` spawns a background reader thread that owns
 // the connection and feeds inbound messages through a channel — the
 // application does other work and just `mqtt_listener_recv`s. Plain TCP
-// (`tcp_connect`) is also exported. `mqtt_topic_matches` runs the MQTT
+// (`std/net.nu`'s `tcp_connect`) is available for plaintext use. `mqtt_topic_matches` runs the MQTT
 // §4.7 `+` / `#` wildcard rules for client-side dispatch when one
 // connection carries several subscriptions.
 //
@@ -141,9 +141,8 @@ $ `stdlib/ext/websocket.nu`
 
 // ── client-side connect ──────────────────────────────────────────────
 //
-// Plaintext connect uses runtime.o's `nurl_tcp_connect` (declared via the
-// websocket.nu import above). TLS goes through net.nu's pure
-// `tcp_connect_tls` — no runtime SSL.
+// Plaintext connect is std/net.nu's `tcp_connect`. TLS goes through
+// net.nu's pure `tcp_connect_tls` — no runtime SSL.
 
 // Open a TLS client connection. `verify` T = check the broker cert
 // chain + hostname against the system trust store; F = encrypt but
@@ -154,20 +153,6 @@ $ `stdlib/ext/websocket.nu`
         F e → ^ @ !TcpConn MqttErr { F ( __mqtt_of_net e ) }
         T c → ^ @ !TcpConn MqttErr { T c }
     }
-}
-
-// Open a plain (unencrypted) TCP client connection — port 1883.
-@ tcp_connect s host i port → !TcpConn MqttErr {
-    : i craw ( nurl_tcp_connect host port )
-    ? == craw 0 { ^ @ !TcpConn MqttErr { F # MqttErr MqttTransport } } {}
-    : i ek ( nurl_tcp_err_kind craw )
-    ? != ek 0 {
-        ( nurl_tcp_close craw )
-        ^ @ !TcpConn MqttErr { F ( __mqtt_of_net ( __net_err_of ek ) ) }
-    } {}
-    : s crp # s craw
-    : TcpConn c @ TcpConn { crp 0 0 }
-    ^ @ !TcpConn MqttErr { T c }
 }
 
 // ── client handle + message ──────────────────────────────────────────

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -321,6 +321,22 @@ $ `stdlib/std/pkey.nu`
     ^ ( tls_alpn_selected # *TlsConn tp )
 }
 
+// Open a plain (unencrypted) TCP client connection. Returns a
+// polymorphic TcpConn (kind 0) usable with the same tcp_read/tcp_write
+// family as accepted connections. For an encrypted connection use
+// tcp_connect_tls below.
+@ tcp_connect s host i port → !TcpConn NetErr {
+    : i craw ( nurl_tcp_connect host port )
+    ? == craw 0 { ^ @ !TcpConn NetErr { F # NetErr NetOther } } {}
+    : i ek ( nurl_tcp_err_kind craw )
+    ? != ek 0 {
+        ( nurl_tcp_close craw )
+        ^ @ !TcpConn NetErr { F ( __net_err_of ek ) }
+    } {}
+    : s crp # s craw
+    ^ @ !TcpConn NetErr { T @ TcpConn { crp 0 0 } }
+}
+
 // Open a verified (or, with verify = 0, encrypted-only) pure-TLS client
 // connection. Returns a polymorphic TcpConn (kind 1) whose reads/writes
 // dispatch to the pure client stack.

--- a/stdlib/std/random.nu
+++ b/stdlib/std/random.nu
@@ -25,7 +25,7 @@ $ `stdlib/core/string.nu`
 // Single syscall-shaped runtime bridge. Returns 1 on success, 0 on a
 // total entropy failure (which the degraded /dev/urandom-or-PRNG fallback
 // makes impossible on every supported target). Platform-branched in C:
-// getrandom(2) on Linux, arc4random_buf on macOS/BSD, BCryptGenRandom on
+// getrandom(2) on Linux, arc4random_buf on macOS, BCryptGenRandom on
 // Windows, /dev/urandom otherwise.
 & `c` @ nurl_rand_fill *u buf i n → i
 
@@ -37,7 +37,12 @@ $ `stdlib/core/string.nu`
 
 @ rand_u64 → i {
     : s buf ( nurl_zalloc 8 )
-    ( nurl_rand_fill # *u buf 8 )
+    : i r ( nurl_rand_fill # *u buf 8 )
+    // Fail closed: nurl_rand_fill returns 0 only when every OS entropy
+    // source failed and the runtime degraded to a non-cryptographic LCG.
+    // Proceeding would hand predictable bytes to whoever asked for random
+    // ones — panic instead (same contract as the tls/rsa/x509 draws).
+    ? == r 0 { ( nurl_panic `random: CSPRNG (nurl_rand_fill) failed` ) } {}
     : *u p # *u buf
     : ~ i v 0
     : ~ i k 0
@@ -75,7 +80,8 @@ $ `stdlib/core/string.nu`
     ? <= n 0 { ^ ( string_with_cap 0 ) } {}
     : i cap ? > n 4096 4096 n
     : s buf ( nurl_zalloc cap )
-    ( nurl_rand_fill # *u buf cap )
+    : i r ( nurl_rand_fill # *u buf cap )
+    ? == r 0 { ( nurl_panic `random: CSPRNG (nurl_rand_fill) failed` ) } {}
     : *u p # *u buf
     : String out ( string_with_cap * cap 2 )
     : ~ i k 0


### PR DESCRIPTION
Two code-level findings from the documentation accuracy audit (#440, TODO.md §7), fixed at the root.

## `std/net.nu` gains `tcp_connect`
The plain-TCP client connect lived only in `ext/mqtt.nu` — typed `!TcpConn MqttErr`, so every non-MQTT consumer redeclared the raw FFI (`async_tcp.nu` carried a local shim with a *"not exposed in std/net.nu yet"* apology). Now: `tcp_connect s host i port → !TcpConn NetErr` next to its TLS siblings; MQTT's duplicate removed (**the M14 symbol-collision gate caught the overlap immediately** — working as designed); `async_tcp`'s client migrated to the public API and re-verified live (`NURL_NET_TESTS=1`: echo round-trip passes).

## `std/random.nu` fails closed
`rand_u64` / `rand_hex_str` ignored `nurl_rand_fill`'s return — on total OS-entropy failure the runtime degrades to a non-cryptographic LCG and the draws would have proceeded with predictable bytes. They now panic, the same contract the tls/rsa/x509 draws already enforce.

Docs synced (NETWORKING.md, CRYPTO.md), TODO §7 entries cleared, CHANGELOG [Unreleased] updated. Full suite **528 pass**; symbol gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)