### PR TITLE
ci: run the Windows golden corpus on a real runner (M15 residual)

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,0 +1,36 @@
+name: windows-tests
+
+# Runs the FULL Windows path — build.bat bootstrap fixed point + the
+# per-test golden corpus (compiler/tests/run_tests.ps1 against
+# outputs-windows/) — on a real windows-latest runner.
+#
+# This is what backs docs/PLATFORMS.md's Windows tier: without this
+# workflow the 447 Windows goldens were exercised only on a developer's
+# machine. Runs on pushes to main (not per-PR: the Windows leg is the
+# slowest runner and PRs are already gated by the Linux+FreeBSD corpus;
+# a main breakage surfaces here within one push) and on demand.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install LLVM/clang
+        # windows-latest ships a clang via Visual Studio, but pin the
+        # LLVM one on PATH explicitly so build.bat's probe is stable.
+        run: choco install llvm --no-progress -y
+        shell: cmd
+
+      - name: build.bat (bootstrap fixed point + Windows golden corpus)
+        # pwsh 7 is preinstalled on windows-latest, so build.bat runs
+        # run_tests.ps1; a missing pwsh now exits non-zero by design.
+        run: call build.bat
+        shell: cmd

--- a/build.bat
+++ b/build.bat
@@ -290,12 +290,23 @@ REM Windows-PowerShell 5.1 fallback.
 set "PWSH=pwsh"
 where pwsh >nul 2>&1
 if errorlevel 1 (
-    echo BUILD SUCCESS, but PowerShell 7+ ^(pwsh^) not found - skipping tests.
-    echo Install pwsh and run: pwsh compiler\tests\run_tests.ps1
+    REM Skipping tests is a DEGRADED result, not success: exit non-zero so
+    REM CI (and scripts) can't mistake an untested build for a tested one.
+    REM Set NURL_ALLOW_NOTESTS=1 to accept the skip locally.
+    if "%NURL_ALLOW_NOTESTS%"=="1" (
+        echo BUILD SUCCESS, TESTS SKIPPED - PowerShell 7+ ^(pwsh^) not found ^(NURL_ALLOW_NOTESTS=1^).
+        del "%TESTOUT%" 2>nul
+        call :cleanup
+        popd >nul
+        exit /b 0
+    )
+    echo BUILD SUCCESS, but TESTS DID NOT RUN: PowerShell 7+ ^(pwsh^) not found.
+    echo Install pwsh ^(winget install Microsoft.PowerShell^) and re-run,
+    echo or set NURL_ALLOW_NOTESTS=1 to accept an untested build.
     del "%TESTOUT%" 2>nul
     call :cleanup
     popd >nul
-    exit /b 0
+    exit /b 2
 )
 set "TESTOUT=%TEMP%\nurl_testout_%RANDOM%%RANDOM%.log"
 "%PWSH%" -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%\compiler\tests\run_tests.ps1" > "%TESTOUT%" 2>&1

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -22,7 +22,7 @@ verifies — not by intent:
 | Linux x86_64 (glibc ≥ 2.28) | **1** | `build.sh` bootstrap fixed point + full corpus + examples gate + ASan/UBSan/LSan + peak-RSS / symbol-collision / leak gates, every push and PR; release artifact smoke-tested | `install.sh` |
 | FreeBSD x86_64 | **1** | build + bootstrap + full corpus on a FreeBSD 14.2 VM in CI (hard gate); the *release* artifact leg is best-effort (`continue-on-error`) | `install.sh` |
 | Linux ARM64 (glibc) | **2** | release workflow builds natively on an ARM64 runner (`--no-tests`) and smoke-tests a hello-world; not in `ci.yml` | `install.sh` |
-| Windows x86_64 | **2** | release workflow runs `build.bat --no-tests` — bootstrap fixed point only; the test corpus (`run_tests.ps1` against `outputs-windows/` goldens, needs PowerShell 7) runs locally, not in CI | `install.ps1` |
+| Windows x86_64 | **2** | the `windows-tests` workflow runs `build.bat` — bootstrap fixed point + the full Windows golden corpus (`run_tests.ps1`) — on every push to `main` (not a per-PR merge gate); the release job builds with `--no-tests` | `install.ps1` |
 | macOS (x86_64 / ARM64) | **3** | expected to build from source with Homebrew LLVM; unverified — no CI job, no release artifact, and the installer rejects Darwin | build from source |
 | Alpine / musl | **3** | build from source only. The shipped Linux archives are glibc-linked and do **not** load under musl | build from source |
 
@@ -44,7 +44,7 @@ container's cross-compile endpoints (see [`PLAYGROUND.md`](PLAYGROUND.md)).
 | Target | Backend | Tier | Notes |
 |---|---|---|---|
 | Linux x86_64 | LLVM | 1 | primary target — `build.sh` + full corpus |
-| Windows x86_64 | LLVM (mingw-w64) | 2 | separate Windows goldens (`compiler/tests/outputs-windows/`); corpus runs locally via `build.bat`, not in CI |
+| Windows x86_64 | LLVM (mingw-w64) | 2 | separate Windows goldens (`compiler/tests/outputs-windows/`); corpus runs on `main` pushes via the `windows-tests` workflow |
 | macOS x86_64 | LLVM + zig cc | 3 | `POST /build_macos`; Mach-O links only libSystem (no Apple SDK). Runs on Apple Silicon via Rosetta 2. canvas/audio/libcurl-HTTP not supported |
 | macOS ARM64 | LLVM + zig cc | 3 | `POST /build_target` (`target=macos-arm64`) — native Apple Silicon Mach-O, links only libSystem. Unsigned: clear quarantine before running |
 | WebAssembly | wasm32-wasi | 3 | via the `nurlapi/` container (WASI SDK 24.0); browser execution via `browser_wasi_shim`. The self-hosting compiler itself also builds to wasm — see [`PLAYGROUND.md`](PLAYGROUND.md) |


### PR DESCRIPTION
Closes the last M15 residual: **the 447 Windows goldens now run in CI.**

- New **`windows-tests`** workflow: full `build.bat` (bootstrap fixed point + `run_tests.ps1` corpus) on `windows-latest`, on every push to `main` + `workflow_dispatch`. Not a per-PR gate — the Windows runner is the slowest, PRs are already gated by the Linux+FreeBSD corpus, and a `main` breakage surfaces within one push.
- **`build.bat` no longer reports success when it skipped the tests**: a missing pwsh used to print `BUILD SUCCESS … skipping tests` and exit 0 — an untested build indistinguishable from a tested one. It now exits 2 with instructions; `NURL_ALLOW_NOTESTS=1` accepts the skip explicitly for local use.
- `PLATFORMS.md` Windows tier rows updated to state exactly what runs where; TODO.md §7 entries cleared.

After merge: trigger the workflow once via Actions → windows-tests → Run workflow to see the first green Windows corpus run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)