### PR TITLE
url: reject out-of-range ports instead of wrapping (critic minor)

### DIFF
--- a/compiler/tests/outputs-windows/url_parse.txt
+++ b/compiler/tests/outputs-windows/url_parse.txt
@@ -6,6 +6,9 @@ https://example.com/path/to/page?a=1&b=2#section => scheme=https user= host=exam
 http://example.com => scheme=http user= host=example.com port=-1 eff=80 path= query= frag= target=/
 https://user:pass@host.example.org:8443/secure?token=abc => scheme=https user=user:pass host=host.example.org port=8443 eff=8443 path=/secure query=token=abc frag= target=/secure?token=abc
 ws://localhost:9001/chat => scheme=ws user= host=localhost port=9001 eff=9001 path=/chat query= frag= target=/chat
+http://host:65535/edge => scheme=http user= host=host port=65535 eff=65535 path=/edge query= frag= target=/edge
+http://host:65536/over => NONE
+http://host:99999999999999/huge => NONE
 wss://stream.example.com/feed => scheme=wss user= host=stream.example.com port=-1 eff=443 path=/feed query= frag= target=/feed
 https://[2001:db8::1]:8080/v6 => scheme=https user= host=2001:db8::1 port=8080 eff=8080 path=/v6 query= frag= target=/v6
 http://[::1]/loopback => scheme=http user= host=::1 port=-1 eff=80 path=/loopback query= frag= target=/loopback

--- a/compiler/tests/outputs/url_parse.txt
+++ b/compiler/tests/outputs/url_parse.txt
@@ -6,6 +6,9 @@ https://example.com/path/to/page?a=1&b=2#section => scheme=https user= host=exam
 http://example.com => scheme=http user= host=example.com port=-1 eff=80 path= query= frag= target=/
 https://user:pass@host.example.org:8443/secure?token=abc => scheme=https user=user:pass host=host.example.org port=8443 eff=8443 path=/secure query=token=abc frag= target=/secure?token=abc
 ws://localhost:9001/chat => scheme=ws user= host=localhost port=9001 eff=9001 path=/chat query= frag= target=/chat
+http://host:65535/edge => scheme=http user= host=host port=65535 eff=65535 path=/edge query= frag= target=/edge
+http://host:65536/over => NONE
+http://host:99999999999999/huge => NONE
 wss://stream.example.com/feed => scheme=wss user= host=stream.example.com port=-1 eff=443 path=/feed query= frag= target=/feed
 https://[2001:db8::1]:8080/v6 => scheme=https user= host=2001:db8::1 port=8080 eff=8080 path=/v6 query= frag= target=/v6
 http://[::1]/loopback => scheme=http user= host=::1 port=-1 eff=80 path=/loopback query= frag= target=/loopback

--- a/compiler/tests/url_parse.nu
+++ b/compiler/tests/url_parse.nu
@@ -34,6 +34,9 @@ $ `stdlib/std/url.nu`
     ( show `http://example.com` )
     ( show `https://user:pass@host.example.org:8443/secure?token=abc` )
     ( show `ws://localhost:9001/chat` )
+    ( show `http://host:65535/edge` )  // max valid port
+    ( show `http://host:65536/over` )  // one past → reject
+    ( show `http://host:99999999999999/huge` )  // overflow → reject
     ( show `wss://stream.example.com/feed` )
     ( show `https://[2001:db8::1]:8080/v6` )
     ( show `http://[::1]/loopback` )

--- a/stdlib/std/url.nu
+++ b/stdlib/std/url.nu
@@ -229,17 +229,29 @@ $ `stdlib/core/vec.nu`
         ( string_free scheme ) ( string_free userinfo ) ( string_free host )
         ^ @ ?Url { F # Url 0 }
     } {}
-    // optional :port
+    // optional :port. A port is 0..65535 (RFC 3986 allows *DIGIT, but a
+    // TCP/UDP port that doesn't fit 16 bits is meaningless); a bad or
+    // overflowing port rejects the whole URL rather than wrapping into a
+    // plausible-looking small number.
     : ~ i port -1
     ? & < hp auth_end == ( nurl_str_get in hp ) 58 {
         = hp + hp 1
         : ~ i pv 0
         : ~ b anyd F
+        : ~ b over F
         ~ & < hp auth_end ( __url_is_digit ( nurl_str_get in hp ) ) {
             = pv + * pv 10 - ( nurl_str_get in hp ) 48
+            ? > pv 65535 { = over T } {}
             = anyd T
             = hp + hp 1
         }
+        // An out-of-range port → invalid URL (rather than a 16-bit-wrapped
+        // small number). A bare ':' with no digits stays lenient (no port),
+        // matching the prior behaviour.
+        ? over {
+            ( string_free scheme ) ( string_free userinfo ) ( string_free host )
+            ^ @ ?Url { F # Url 0 }
+        } {}
         ? anyd { = port pv } {}
     } {}
     = pos auth_end


### PR DESCRIPTION
`url_parse` accumulated port digits with **no bound**, so a port past 65535 silently wrapped into a plausible 16-bit-ish number — `:65536` → `0`, `:99999999999999` → whatever the low bits landed on — and the URL parsed as "valid" pointing at the **wrong port**. A port that doesn't fit a 16-bit TCP/UDP port number now rejects the whole URL (`?Url` None).

The lenient bare-`:` case (colon, no digits → no port) is unchanged, so no valid URL regresses.

**Tests**: `url_parse` gains `:65535` (max, accepted), `:65536` (one past, rejected), a 14-digit overflow (rejected). Linux + Windows goldens updated (output is platform-independent).

---
Also worth noting: the **`windows-tests` workflow just went green** on `main` for the first time — the full Windows golden corpus now runs and passes on `windows-latest`, closing the last M15 residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)