### PR TITLE
nurlc: --debug survives -O2 (fix DWARF finalizeModuleInfo crash) + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,15 @@ jobs:
         # (whose process-lifetime arenas would otherwise dominate the report).
         run: ./tools/leakcheck/run.sh
 
+      - name: DWARF debug-info gate
+        # The plain corpus never builds with --debug, so it can't catch a
+        # broken !DI emission. This builds the --debug regression
+        # (dwarf_closure_drop, the -O2 inliner crash) plus the gdb
+        # behavioural checks; gdb makes the source-level asserts run too.
+        run: |
+          sudo apt-get install -y --no-install-recommends gdb
+          ./tools/dwarf_test.sh
+
   freebsd:
     name: FreeBSD (build + bootstrap fixed point + tests, in a VM)
     runs-on: ubuntu-latest

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -1371,6 +1371,30 @@
     ^ loc_id
 }
 
+// A DISubprogram for a synthetic, compiler-generated function — the
+// C-ABI `main` wrapper and the `__jdrop_*` journal thunks. These are
+// real DEFINED functions, so under --g they need their own subprogram
+// AND `!dbg` on any inlinable call they make. Without it the inliner
+// reparents a callee's scoped instructions into a subprogram-less
+// caller — LLVM reports "!dbg attachment points at wrong subprogram
+// for function" and DWARF emission then null-derefs in
+// finalizeModuleInfo at -O2 (DIE::getUnitDie). Returns the sp id, or 0
+// when --g is off; sets g_dbg_current_subprogram / g_dbg_current_loc so
+// emit_call / emit_dbg_eol attach the right location. Pair with
+// dbg_synth_end. Line 0 = artificial (no user source line).
+@ dbg_synth_begin s name → i {
+    ? == g_dbg_enabled 0 { ^ 0 } {}
+    : i sp ( dbg_emit_subprogram name 0 g_dbg_file_id )
+    = g_dbg_current_subprogram sp
+    = g_dbg_current_loc ( dbg_emit_location 0 0 sp )
+    ^ sp
+}
+
+@ dbg_synth_end → v {
+    = g_dbg_current_subprogram 0
+    = g_dbg_current_loc 0
+}
+
 // End-of-module flush. Emits the named-metadata directives
 // (`!llvm.dbg.cu`, `!llvm.module.flags`) followed by every buffered
 // `!N = !DI…` definition in id order. No-op when --g is off.
@@ -3016,7 +3040,11 @@
     { ( nurl_print `, ` ) ( nurl_print argstr ) }
     {}
 
-    ( nurl_print `)\n` )
+    // `!dbg` is required here: the callee is a module-defined closure the
+    // optimizer will inline, and an inlined call with no location leaves
+    // the closure's scoped instructions attached to the wrong subprogram
+    // (DWARF crash at -O2). emit_dbg_eol is a plain `\n` when --g is off.
+    ( nurl_print `)` ) ( emit_dbg_eol )
     ( nurl_set_last_type ret_type )
     res
 }
@@ -8452,12 +8480,22 @@
     : s donekey ( nurl_str_cat `jdrop##` mangle )
     ? != 0 ( nurl_str_len ( nurl_sym_get g_impl_name_syms donekey ) ) { ^ v } {}
     ( nurl_sym_def g_impl_name_syms donekey `1` )
-    ( nurl_print `define void @__jdrop_` ) ( nurl_print mangle )
-    ( nurl_print `(i8* %p) {\nentry:\n` )
+    // The thunk CALLS `@drop__<mangle>` (module-defined, inlinable) — so
+    // under --g it needs its own subprogram + `!dbg` on that call, or the
+    // inliner reparents drop__'s scoped instructions into this otherwise
+    // subprogram-less thunk (see dbg_synth_begin). Text is byte-identical
+    // to the pre-DWARF form when --g is off.
+    : i jsp ( dbg_synth_begin ( nurl_str_cat `__jdrop_` mangle ) )
+    ( nurl_print `define void @__jdrop_` ) ( nurl_print mangle ) ( nurl_print `(i8* %p)` )
+    ? != g_dbg_enabled 0 { ( nurl_print ` !dbg !` ) ( nurl_print ( nurl_str_int jsp ) ) } {}
+    ( nurl_print ` {\nentry:\n` )
     ( nurl_print `  %t = bitcast i8* %p to ` ) ( nurl_print llvm ) ( nurl_print `*\n` )
     ( nurl_print `  %v = load ` ) ( nurl_print llvm ) ( nurl_print `, ` ) ( nurl_print llvm ) ( nurl_print `* %t\n` )
     ( nurl_print `  call void @drop__` ) ( nurl_print mangle )
-    ( nurl_print `(` ) ( nurl_print llvm ) ( nurl_print ` %v)\n  ret void\n}\n` )
+    ( nurl_print `(` ) ( nurl_print llvm ) ( nurl_print ` %v)` ) ( emit_dbg_eol )
+    ( emit_call_term `ret void` )
+    ( nurl_print `}\n` )
+    ( dbg_synth_end )
 }
 
 // ── Closure-env reclamation for `:`-bound capturing closures (§7.4) ──
@@ -15012,15 +15050,23 @@
 }
 
 @ emit_main_wrapper s ret_ty → v {
-    ( emit `define i32 @main(i32 %argc, i8** %argv) {` )
+    // Synthetic C-ABI wrapper. It CALLS the module-defined `@_nurl_main`,
+    // which the optimizer may inline — so under --g it needs a subprogram
+    // and `!dbg` on that call (see dbg_synth_begin). Emit-order and text
+    // are byte-identical to the pre-DWARF form when --g is off.
+    : i msp ( dbg_synth_begin `main` )
+    ( nurl_print `define i32 @main(i32 %argc, i8** %argv)` )
+    ? != g_dbg_enabled 0 { ( nurl_print ` !dbg !` ) ( nurl_print ( nurl_str_int msp ) ) } {}
+    ( nurl_print ` {\n` )
     ( emit `entry:` )
-    ( emiti `call void @nurl_init(i32 %argc, i8** %argv)` )
+    ( emit_call `call void @nurl_init(i32 %argc, i8** %argv)` )
     ? ( seq ret_ty `void` )
-    { ( emiti `call void @_nurl_main()` ) ( emiti `ret i32 0` ) }
-    { ( emiti `%_ret = call i64 @_nurl_main()` )
-        ( emiti `%_exit = trunc i64 %_ret to i32` )
-        ( emiti `ret i32 %_exit` ) }
+    { ( emit_call `call void @_nurl_main()` ) ( emit_call_term `ret i32 0` ) }
+    { ( emit_call `%_ret = call i64 @_nurl_main()` )
+        ( emit_inst `%_exit = trunc i64 %_ret to i32` )
+        ( emit_call_term `ret i32 %_exit` ) }
     ( emit `}` ) ( emit `` )
+    ( dbg_synth_end )
 }
 
 // ── Top-level constant / struct declaration ── : ... ──────────────

--- a/compiler/tests/dwarf_closure_drop.nu
+++ b/compiler/tests/dwarf_closure_drop.nu
@@ -1,0 +1,42 @@
+// dwarf_closure_drop.nu — DWARF regression for the -O2 inliner crash.
+//
+// Compiling a program with `--debug` at -O2 used to crash clang in
+// DwarfDebug::finalizeModuleInfo (DIE::getUnitDie) whenever the
+// optimizer inlined a callee carrying debug info through a call site
+// that had NO `!dbg` location. nurlc emitted three such inlinable
+// calls without a location:
+//   * the indirect closure call `call %fnptr(...)` (here: the drop
+//     closure that `vec_free_with` invokes per element),
+//   * the `__jdrop_*` journal thunk's call to `drop__*`, and
+//   * the synthetic C-ABI `main` wrapper's call to `_nurl_main`.
+// The inliner reparented the callee's scoped instructions into a
+// subprogram-less / wrong-subprogram caller — "!dbg attachment points
+// at wrong subprogram for function" — and DWARF emission null-deref'd.
+//
+// `vec_free_with` + a closure is the *deterministic* trigger (the small
+// helper is always inlined, so the indirect call is always reparented).
+//
+// This is a BUILD-ONLY regression: the crash was at link time, so a
+// binary that links at -O2 with --debug is the assertion (driven by
+// tools/dwarf_test.sh). The plain corpus run also compiles + runs it.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/io.nu`
+
+@ main → i {
+    : ( Vec String ) xs ( vec_new [String] )
+    ( vec_push [String] xs ( string_from `a` ) )
+    ( vec_push [String] xs ( string_from `bb` ) )
+    ( vec_push [String] xs ( string_from `ccc` ) )
+    : ~ i total 0
+    // The closure runs per element (indirect call inside vec_free_with).
+    ( vec_free_with [String] xs \ String s → v {
+        = total + total ( string_len s )
+        ( string_free s )
+    } )
+    ( nurl_print `total_len=` )
+    ( nurl_print_int total )
+    ( nurl_print `\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs-windows/dwarf_closure_drop.txt
+++ b/compiler/tests/outputs-windows/dwarf_closure_drop.txt
@@ -1,0 +1,6 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+total_len=0
+

--- a/compiler/tests/outputs/dwarf_closure_drop.txt
+++ b/compiler/tests/outputs/dwarf_closure_drop.txt
@@ -1,0 +1,6 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+total_len=0
+

--- a/tools/dwarf_test.sh
+++ b/tools/dwarf_test.sh
@@ -31,8 +31,32 @@ BIN="$ROOT_DIR/build/dwarf_basic_dbg"
 STRUCT_SRC="$ROOT_DIR/compiler/tests/dwarf_struct.nu"
 STRUCT_BIN="$ROOT_DIR/build/dwarf_struct_dbg"
 
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "  ok: $1"; }
+
+# ── -O2 inliner regression (closure + Drop + main wrapper) ──────────
+# BUILD-ONLY, so it runs even where gdb is absent (CI, minimal hosts).
+# At the DEFAULT -O2 (not -O0), a program mixing an indirect closure
+# call, a `% Drop` thunk, and the C-ABI main wrapper used to crash clang
+# in DwarfDebug::finalizeModuleInfo. Linking at all is the assertion.
+CLD_SRC="$ROOT_DIR/compiler/tests/dwarf_closure_drop.nu"
+CLD_BIN="$ROOT_DIR/build/dwarf_closure_drop_dbg"
+if [ -f "$CLD_SRC" ]; then
+    echo "[regression] building $CLD_SRC with --debug at -O2 (inliner/DWARF)"
+    if ! "$ROOT_DIR/nurl.sh" --debug "$CLD_SRC" "$CLD_BIN" >/tmp/dwarf_cld.build 2>&1; then
+        cat /tmp/dwarf_cld.build
+        fail "nurl.sh --debug (-O2) crashed on closure+Drop — DWARF regression"
+    fi
+    readelf -S "$CLD_BIN" 2>/dev/null | grep -q '\.debug_info' \
+        || fail "closure+Drop binary has no .debug_info section"
+    OUT=$("$CLD_BIN" 2>&1)
+    echo "$OUT" | grep -q 'total_len=' \
+        || fail "closure+Drop binary produced wrong output: $OUT"
+    pass "closure+Drop links at -O2 with --debug and runs correctly"
+fi
+
 if ! command -v gdb >/dev/null 2>&1; then
-    echo "SKIP: gdb not found on PATH — DWARF behavioural test skipped"
+    echo "SKIP: gdb not found on PATH — remaining DWARF behavioural checks skipped"
     exit 0
 fi
 
@@ -40,9 +64,6 @@ if [[ ! -f "$NU_SRC" ]]; then
     echo "ERROR: $NU_SRC not present" >&2
     exit 1
 fi
-
-fail() { echo "FAIL: $1" >&2; exit 1; }
-pass() { echo "  ok: $1"; }
 
 echo "[1/5] building $NU_SRC with --debug"
 if ! "$ROOT_DIR/nurl.sh" --debug -O0 "$NU_SRC" "$BIN" >/tmp/dwarf_test.build 2>&1; then
@@ -170,27 +191,6 @@ else
     echo "$PTR_OUT" | grep -Eq '\} ?\*' \
         || fail "ptype p type is not a pointer (missing trailing *)"
     pass "ptype p shows 'struct Cell … *'"
-fi
-
-# ── -O2 inliner regression (closure + Drop + main wrapper) ──────────
-# A build-only check: at the DEFAULT -O2 (not -O0), a program mixing an
-# indirect closure call, a `% Drop` thunk, and the C-ABI main wrapper
-# used to crash clang in DwarfDebug::finalizeModuleInfo. Linking at all
-# is the assertion. (Kept last so the gdb phases run first.)
-CLD_SRC="$ROOT_DIR/compiler/tests/dwarf_closure_drop.nu"
-CLD_BIN="$ROOT_DIR/build/dwarf_closure_drop_dbg"
-if [ -f "$CLD_SRC" ]; then
-    echo "[+] building $CLD_SRC with --debug at -O2 (inliner regression)"
-    if ! "$ROOT_DIR/nurl.sh" --debug "$CLD_SRC" "$CLD_BIN" >/tmp/dwarf_cld.build 2>&1; then
-        cat /tmp/dwarf_cld.build
-        fail "nurl.sh --debug (-O2) crashed on closure+Drop — DWARF regression"
-    fi
-    readelf -S "$CLD_BIN" 2>/dev/null | grep -q '\.debug_info' \
-        || fail "closure+Drop binary has no .debug_info section"
-    OUT=$("$CLD_BIN" 2>&1)
-    echo "$OUT" | grep -q 'total_len=' \
-        || fail "closure+Drop binary produced wrong output: $OUT"
-    pass "closure+Drop links at -O2 with --debug and runs correctly"
 fi
 
 echo

--- a/tools/dwarf_test.sh
+++ b/tools/dwarf_test.sh
@@ -172,5 +172,26 @@ else
     pass "ptype p shows 'struct Cell … *'"
 fi
 
+# ── -O2 inliner regression (closure + Drop + main wrapper) ──────────
+# A build-only check: at the DEFAULT -O2 (not -O0), a program mixing an
+# indirect closure call, a `% Drop` thunk, and the C-ABI main wrapper
+# used to crash clang in DwarfDebug::finalizeModuleInfo. Linking at all
+# is the assertion. (Kept last so the gdb phases run first.)
+CLD_SRC="$ROOT_DIR/compiler/tests/dwarf_closure_drop.nu"
+CLD_BIN="$ROOT_DIR/build/dwarf_closure_drop_dbg"
+if [ -f "$CLD_SRC" ]; then
+    echo "[+] building $CLD_SRC with --debug at -O2 (inliner regression)"
+    if ! "$ROOT_DIR/nurl.sh" --debug "$CLD_SRC" "$CLD_BIN" >/tmp/dwarf_cld.build 2>&1; then
+        cat /tmp/dwarf_cld.build
+        fail "nurl.sh --debug (-O2) crashed on closure+Drop — DWARF regression"
+    fi
+    readelf -S "$CLD_BIN" 2>/dev/null | grep -q '\.debug_info' \
+        || fail "closure+Drop binary has no .debug_info section"
+    OUT=$("$CLD_BIN" 2>&1)
+    echo "$OUT" | grep -q 'total_len=' \
+        || fail "closure+Drop binary produced wrong output: $OUT"
+    pass "closure+Drop links at -O2 with --debug and runs correctly"
+fi
+
 echo
 echo "DWARF TEST PASSED"


### PR DESCRIPTION
`nurl.sh --debug` on a larger multi-file program (`packages/registry`) crashed clang in **`DwarfDebug::finalizeModuleInfo` → `DIE::getUnitDie()`** (the last real bug recorded in `TODO.md §6`).

## Root cause (llvm-reduce + the -O2 verifier)
The `-O2` verifier reports **"!dbg attachment points at wrong subprogram for function"**. Three kinds of call were emitted **without a `!dbg` location** even though their callees are module-defined functions the optimizer inlines:
1. the indirect closure call `call %fnptr(...)` (`call_closure_function`) — e.g. the drop closure `vec_free_with` invokes per element;
2. the `__jdrop_*` journal thunk's `call @drop__*` (the thunk itself had no subprogram either);
3. the synthetic C-ABI `main` wrapper's `call @_nurl_main` (no subprogram either).

When the inliner copies a debug-info callee through a location-less call site it can't compute an `inlinedAt`, so the callee's instructions land in the caller still scoped to the callee's subprogram — which the caller isn't. The verifier only flags it post-inline; at `-O2` clang inlines, then null-derefs emitting DWARF.

## Fix
- New `dbg_synth_begin`/`dbg_synth_end`: the `main` wrapper and `__jdrop_*` thunks get their own `DISubprogram`.
- All three inlinable calls now route through `emit_call` / `emit_dbg_eol`, so they carry `!dbg`.
- Everything is `--g`-guarded and `emit_dbg_eol` is a plain `\n` when debug is off → **non-debug IR is byte-identical** (fixed point holds, `./build.sh` green); only `--debug` output changes.

## Regression + CI
- `dwarf_closure_drop.nu`: `vec_free_with` + a closure — the **deterministic** trigger (the small helper is always inlined). Verified the OLD compiler crashes on it and the fixed one links; the original `packages/registry --debug` repro now builds.
- The plain corpus links `-O2 -flto` but **without `--debug`**, so it never emitted DWARF and couldn't catch this. New **DWARF debug-info gate** in `ci.yml` (installs gdb) runs the `-O2` build-only regression + the gdb source-level checks on every push/PR. The build-only phase runs even without gdb.
- Corpus **529 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)