### PR TITLE
packages/gguf 0.1.0 — bulletproof GGUF container toolkit

### DIFF
--- a/packages/gguf/README.md
+++ b/packages/gguf/README.md
@@ -1,0 +1,93 @@
+# gguf — bulletproof GGUF container toolkit in pure NURL
+
+GGUF is the ggml-ecosystem tensor container: the file format of
+llama.cpp, whisper.cpp and stable-diffusion.cpp models. This package
+reads it, proves it, writes it and dequantises it — with no
+dependency beyond the NURL stdlib.
+
+```
+gguf info  model.gguf                 # GGUF v3 — 20 kv, 57 tensors, align 32, arch llama
+gguf dump  model.gguf                 # every metadata key/value + the tensor table
+gguf kv    model.gguf llama.context_length
+gguf tensors model.gguf
+gguf verify model.gguf                # deep structural proof (bounds, alignment, overlap)
+gguf export model.gguf blk.0.attn_q.weight -o q.f32   # dequantised f32-LE
+gguf gen   sample.gguf                # write the reference sample file
+gguf selftest                         # write → parse → compare, bit-exact
+```
+
+## The point: hostile-input parsing
+
+A model file is a download — treat it as an attack. The parser
+validates **every count, length and offset against the actual file
+size before any allocation or read depends on it**, and allocations
+are proportional to bytes actually consumed from the file, never to
+what a header merely claims. A 24-byte file claiming 2⁶³ tensors
+fails in microseconds; a truncated vocab array, a NUL-smuggling key,
+a nested array, a duplicate key or tensor name, an unaligned or
+out-of-bounds tensor, a dimension product that would overflow —
+each is a clean `gguf:` error, never a crash, a hang or a wrong
+answer. `tests/gguf_test.sh` proves this with a corruption battery
+(truncations at every structural boundary, hostile counts, absurd
+lengths) plus attack files crafted independently in python.
+
+## Lazy by design
+
+`gguf_open` mmaps the file and parses only metadata and the tensor
+table; tensor bytes are addressed straight out of the mapping
+(`gguf_tensor_ptr`) and uploaded/decoded tensor by tensor. Inspecting
+a multi-gigabyte model costs no RAM. Platforms without mmap (wasm,
+win32) fall back to a whole-file buffer transparently.
+
+## Library API
+
+```nurl
+$ `gguf.nu`      // parser + accessors
+$ `dequant.nu`   // host-side scalar dequantisation
+$ `write.nu`     // GGUF v3 writer/builder
+
+: !*Gguf String r ( gguf_open `model.gguf` )
+?? r {
+    T g → {
+        : i n_layers ( gguf_kv_int_or g `llama.block_count` 0 )
+        : s arch ( gguf_kv_str_or g `general.architecture` `?` )   // borrowed
+        : i ti ( gguf_find_tensor g `token_embd.weight` )
+        : !( Vec u ) String w ( gguf_dequant g ti )   // f32-LE, upload-ready
+        ( gguf_close g )
+    }
+    F e → {
+        ( nurl_eprintln ( string_data e ) )
+        ( string_free e )
+    }
+}
+```
+
+- **Versions**: GGUF v2 and v3 (v1's legacy 32-bit layout is rejected
+  with a clear message).
+- **Metadata**: all 13 value types, including arrays of
+  ints/floats/strings (tokeniser vocabularies).
+- **Tensor types**: every current ggml id is named and sized
+  (F32/F16/BF16/F64, Q4_0/Q4_1/Q5_0/Q5_1/Q8_0/Q8_1, all K-quants,
+  IQ4_NL, I8–I64); unknown ids are still listed — the parser degrades
+  loudly, not wrongly.
+- **Dequantisation** (`gguf_dequant` → little-endian f32, one element
+  per value in storage order): F32, F64, F16, BF16, Q4_0, Q4_1, Q8_0.
+  F16 conversion is a pure bit transport (subnormals, ±inf, NaN and
+  −0 preserved exactly). This is the CPU decode path *and* the golden
+  oracle for GPU dequant kernels — verified bit-identical against
+  independent python decodes of real llama.cpp models.
+- **Writer** (`gw_new` / `gw_kv_*` / `gw_tensor` / `gw_finish`): emits
+  spec-exact v3 images, validates shapes against payload sizes with
+  the same rules the parser enforces, and round-trips bit-for-bit
+  (`gguf selftest`, 37 checks).
+
+## Testing
+
+```
+./tests/gguf_test.sh                  # 48 checks, no network needed
+NURL_NET_TESTS=1 ./tests/gguf_test.sh # + parses a real llama.cpp model from HF
+```
+
+The suite was developed under ASan/UBSan + LeakSanitizer
+(`NURL_SAN=1 nurl.sh …`): zero leaks, zero UB on every path including
+the corruption battery.

--- a/packages/gguf/nurl.toml
+++ b/packages/gguf/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gguf"
+version = "0.1.0"
+description = "Bulletproof GGUF container toolkit — parse, verify, write and dequantise the ggml-ecosystem tensor format (llama.cpp, whisper.cpp, stable-diffusion.cpp) in pure NURL. The parser treats every file as hostile input: each count, length and offset is validated against the real file size before anything is allocated or read, allocations are proportional to bytes actually consumed (never to what a header claims), and malformed, truncated or adversarial files are a clean error — never a crash, hang or unbounded allocation, proven by a corruption battery plus python-crafted attack files in tests/. mmap-backed and lazy: metadata and the tensor table are parsed up front, tensor bytes are addressed straight out of the mapping so a multi-GB model costs no RAM to inspect. Ships a spec-exact v3 writer (the reader's round-trip partner, bit-for-bit under `gguf selftest`), host-side scalar dequantisation for F32/F64/F16/BF16/Q4_0/Q4_1/Q8_0 (the golden oracle for any GPU dequant kernel — verified bit-identical against independent decodes of real llama.cpp models), and a CLI: `gguf info/dump/kv/tensors/verify/export/gen/selftest`. The foundation of nurllama and any tool that needs to read model weights."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/gguf/src/dequant.nu
+++ b/packages/gguf/src/dequant.nu
@@ -1,0 +1,236 @@
+// packages/gguf/src/dequant.nu — host-side scalar dequantisation.
+//
+// Reference implementation of the ggml block-quant decodings, pure
+// NURL, no GPU dependency: this is the CPU decode path AND the golden
+// oracle a GPU dequant kernel is verified against. Output is the
+// upload-ready canonical form — a ( Vec u ) of little-endian IEEE-754
+// f32 values, one per tensor element, in storage order.
+//
+//   ( gg_f16_to_f32_bits h )     → i    IEEE half → f32 bit pattern
+//   ( gg_f16_to_f )              → f    IEEE half → double
+//   ( gguf_dequant g idx )       → !( Vec u ) String   f32-LE buffer
+//   ( gguf_dequant_f64 g idx )   → !( Vec f ) String   convenience
+//
+// Supported source types: F32, F64, F16, BF16, Q4_0, Q4_1, Q8_0.
+// Anything else is a clean error naming the type — never a wrong
+// answer. Layouts follow ggml exactly:
+//   Q4_0: 18-byte block = f16 scale d + 16 nibble bytes; elements
+//         0..15 are the LOW nibbles, 16..31 the HIGH nibbles; value
+//         = d * (q - 8).
+//   Q4_1: 20-byte block = f16 d + f16 min m + 16 nibble bytes;
+//         value = d * q + m (same nibble order).
+//   Q8_0: 34-byte block = f16 d + 32 signed bytes; value = d * q.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/floatbits.nu`
+$ `gguf.nu`
+
+// IEEE-754 binary16 → binary32, pure integer bit transport: sign
+// copied, exponent rebased 15 → 127, mantissa widened 10 → 23 bits.
+// Subnormals are normalised; ±inf and NaN map to their f32 forms.
+@ gg_f16_to_f32_bits i h → i {
+    : i sign << & >> h 15 1 31
+    : i e & >> h 10 31
+    : ~ i man & h 1023
+    ? == e 0 {
+        ? == man 0 { ^ sign } {}
+        : ~ i ex 113
+        ~ == & man 1024 0 {
+            = man << man 1
+            = ex - ex 1
+        }
+        = man & man 1023
+        ^ | sign | << ex 23 << man 13
+    } {}
+    ? == e 31 { ^ | sign | 2139095040 << man 13 } {}
+    ^ | sign | << + e 112 23 << man 13
+}
+
+@ gg_f16_to_f i h → f {
+    ^ # f ( bits_to_f32 ( gg_f16_to_f32_bits h ) )
+}
+
+// f16 at byte offset o of pointer P (little-endian).
+@ __gg_ld_f16 * u P i o → f {
+    ^ ( gg_f16_to_f | # i . P o << # i . P + o 1 8 )
+}
+
+@ __gg_push_f ( Vec u ) out f v → v {
+    ( bytes_push_u32_le out # u32 ( f32_to_bits # f32 v ) )
+}
+
+// Dequantise tensor #idx of g to little-endian f32 (4 bytes per
+// element, storage order). Allocation is nelems * 4 — bounded because
+// nelems was range-proven against the file at parse time.
+@ gguf_dequant * Gguf g i idx → !( Vec u ) String {
+    ? | < idx 0 >= idx ( gguf_n_tensors g ) {
+        ^ @ !( Vec u ) String { F ( string_from `gguf: tensor index out of range` ) }
+    } {}
+    : ~ i gt -1
+    : ~ i ne 0
+    : ~ i nb -1
+    : ~ i addr 0
+    ?? ( vec_get [GgufTensor] . g tensors idx ) {
+        T t → {
+            = gt . t gtype
+            = ne . t nelems
+            = nb . t nbytes
+            = addr # i ( gguf_tensor_ptr g t )
+        }
+        F → {}
+    }
+    ? < nb 0 {
+        : String m ( string_from `gguf: cannot dequantise tensor of unsized type ` )
+        ( string_push_int m gt )
+        ^ @ !( Vec u ) String { F m }
+    } {}
+    : *u P # *u addr
+    : ( Vec u ) out ( vec_with_cap [u] * ne 4 )
+
+    // F32: verbatim copy.
+    ? == gt 0 {
+        ( bytes_extend_raw out # s P nb )
+        ^ @ !( Vec u ) String { T out }
+    } {}
+
+    // F64: narrow each element.
+    ? == gt 28 {
+        : ~ i k 0
+        ~ < k ne {
+            : i o * k 8
+            : ~ i b8 0
+            : ~ i j 8
+            ~ > j 0 {
+                = j - j 1
+                = b8 | << b8 8 # i . P + o j
+            }
+            ( __gg_push_f out ( bits_to_f64 b8 ) )
+            = k + k 1
+        }
+        ^ @ !( Vec u ) String { T out }
+    } {}
+
+    // F16: pure bit transport, no rounding anywhere.
+    ? == gt 1 {
+        : ~ i k 0
+        ~ < k ne {
+            : i o * k 2
+            : i h | # i . P o << # i . P + o 1 8
+            ( bytes_push_u32_le out # u32 ( gg_f16_to_f32_bits h ) )
+            = k + k 1
+        }
+        ^ @ !( Vec u ) String { T out }
+    } {}
+
+    // BF16: f32 with the low 16 mantissa bits dropped — shift back up.
+    ? == gt 30 {
+        : ~ i k 0
+        ~ < k ne {
+            : i o * k 2
+            : i h | # i . P o << # i . P + o 1 8
+            ( bytes_push_u32_le out # u32 << h 16 )
+            = k + k 1
+        }
+        ^ @ !( Vec u ) String { T out }
+    } {}
+
+    // Q4_0
+    ? == gt 2 {
+        : i nblk / ne 32
+        : ~ i b 0
+        ~ < b nblk {
+            : i base * b 18
+            : f d ( __gg_ld_f16 P base )
+            : ~ i j 0
+            ~ < j 16 {
+                : i q & # i . P + base + 2 j 15
+                ( __gg_push_f out * d # f - q 8 )
+                = j + j 1
+            }
+            = j 0
+            ~ < j 16 {
+                : i q & >> # i . P + base + 2 j 4 15
+                ( __gg_push_f out * d # f - q 8 )
+                = j + j 1
+            }
+            = b + b 1
+        }
+        ^ @ !( Vec u ) String { T out }
+    } {}
+
+    // Q4_1
+    ? == gt 3 {
+        : i nblk / ne 32
+        : ~ i b 0
+        ~ < b nblk {
+            : i base * b 20
+            : f d ( __gg_ld_f16 P base )
+            : f m ( __gg_ld_f16 P + base 2 )
+            : ~ i j 0
+            ~ < j 16 {
+                : i q & # i . P + base + 4 j 15
+                ( __gg_push_f out + * d # f q m )
+                = j + j 1
+            }
+            = j 0
+            ~ < j 16 {
+                : i q & >> # i . P + base + 4 j 4 15
+                ( __gg_push_f out + * d # f q m )
+                = j + j 1
+            }
+            = b + b 1
+        }
+        ^ @ !( Vec u ) String { T out }
+    } {}
+
+    // Q8_0
+    ? == gt 8 {
+        : i nblk / ne 32
+        : ~ i b 0
+        ~ < b nblk {
+            : i base * b 34
+            : f d ( __gg_ld_f16 P base )
+            : ~ i j 0
+            ~ < j 32 {
+                : ~ i q # i . P + base + 2 j
+                ? > q 127 { = q - q 256 } {}
+                ( __gg_push_f out * d # f q )
+                = j + j 1
+            }
+            = b + b 1
+        }
+        ^ @ !( Vec u ) String { T out }
+    } {}
+
+    ( vec_free [u] out )
+    : String m ( string_from `gguf: dequantisation not implemented for type ` )
+    ( string_push_str m ( gguf_type_name gt ) )
+    ( string_push_str m ` (` )
+    ( string_push_int m gt )
+    ( string_push_str m `)` )
+    ^ @ !( Vec u ) String { F m }
+}
+
+// Convenience: dequantise to host doubles (tests, small tensors).
+@ gguf_dequant_f64 * Gguf g i idx → !( Vec f ) String {
+    : !( Vec u ) String r ( gguf_dequant g idx )
+    ?? r {
+        T raw → {
+            : i n / ( vec_len [u] raw ) 4
+            : ( Vec f ) out ( vec_with_cap [f] n )
+            : ~ i k 0
+            ~ < k n {
+                ?? ( bytes_read_f32_le raw * k 4 ) {
+                    T x → { ( vec_push [f] out # f x ) }
+                    F → {}
+                }
+                = k + k 1
+            }
+            ( vec_free [u] raw )
+            ^ @ !( Vec f ) String { T out }
+        }
+        F e → { ^ @ !( Vec f ) String { F e } }
+    }
+}

--- a/packages/gguf/src/gguf.nu
+++ b/packages/gguf/src/gguf.nu
@@ -1,0 +1,798 @@
+// packages/gguf/src/gguf.nu — a bulletproof GGUF container parser.
+//
+// GGUF is the ggml-ecosystem tensor container (llama.cpp, whisper.cpp,
+// stable-diffusion.cpp): a little-endian header, typed metadata
+// key/values, a tensor table, then an aligned data section. This module
+// parses versions 2 and 3, mmap-backed, without ever loading tensor
+// data into memory — tensor bytes are addressed lazily straight out of
+// the mapping.
+//
+// Trust model: the file is UNTRUSTED input. Every count, length and
+// offset is validated against the actual file size BEFORE any
+// allocation or read depends on it; allocations are proportional to
+// bytes actually consumed from the file, never to what a header merely
+// claims. A malformed or truncated file is an error, never a crash, a
+// hang, or an unbounded allocation.
+//
+//   ( gguf_open path )                → !*Gguf String    mmap + parse
+//   ( gguf_parse_bytes data )         → !*Gguf String    parse a buffer
+//                                       (BORROWS data — keep it alive
+//                                        until gguf_close)
+//   ( gguf_close g )                  → v                unmap + free
+//   ( gguf_n_kv g ) ( gguf_n_tensors g )            → i
+//   ( gguf_find_kv g key )            → i   index, -1 when absent
+//   ( gguf_kv_int_or g key def )      → i   any int/bool-typed KV
+//   ( gguf_kv_f_or g key def )        → f   f32/f64-typed KV
+//   ( gguf_kv_str_or g key def )      → s   BORROWED from g
+//   ( gguf_find_tensor g name )       → i   index, -1 when absent
+//   ( gguf_tensor_ptr g t )           → *u  BORROWED tensor bytes
+//   ( gguf_type_name t ) ( gguf_type_blck t ) ( gguf_type_size t )
+//
+// Layout invariants enforced at parse time: magic, version ∈ {2,3},
+// sane KV/tensor counts, in-bounds strings, no nested arrays, unique
+// KV keys and tensor names, power-of-two alignment, dims ≥ 1 with
+// overflow-checked element counts, aligned tensor offsets, and every
+// sizable tensor fully inside the data section.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/posix.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/floatbits.nu`
+
+// ── GGUF metadata value types (spec) ────────────────────────────────
+: i GGUF_VT_U8 0
+: i GGUF_VT_I8 1
+: i GGUF_VT_U16 2
+: i GGUF_VT_I16 3
+: i GGUF_VT_U32 4
+: i GGUF_VT_I32 5
+: i GGUF_VT_F32 6
+: i GGUF_VT_BOOL 7
+: i GGUF_VT_STR 8
+: i GGUF_VT_ARR 9
+: i GGUF_VT_U64 10
+: i GGUF_VT_I64 11
+: i GGUF_VT_F64 12
+
+// ── ggml tensor types ───────────────────────────────────────────────
+// Name for a ggml type id; `?` for ids this parser has no name for.
+@ gguf_type_name i t → s {
+    ? == t 0 { ^ `F32` } {}
+    ? == t 1 { ^ `F16` } {}
+    ? == t 2 { ^ `Q4_0` } {}
+    ? == t 3 { ^ `Q4_1` } {}
+    ? == t 6 { ^ `Q5_0` } {}
+    ? == t 7 { ^ `Q5_1` } {}
+    ? == t 8 { ^ `Q8_0` } {}
+    ? == t 9 { ^ `Q8_1` } {}
+    ? == t 10 { ^ `Q2_K` } {}
+    ? == t 11 { ^ `Q3_K` } {}
+    ? == t 12 { ^ `Q4_K` } {}
+    ? == t 13 { ^ `Q5_K` } {}
+    ? == t 14 { ^ `Q6_K` } {}
+    ? == t 15 { ^ `Q8_K` } {}
+    ? == t 16 { ^ `IQ2_XXS` } {}
+    ? == t 17 { ^ `IQ2_XS` } {}
+    ? == t 18 { ^ `IQ3_XXS` } {}
+    ? == t 19 { ^ `IQ1_S` } {}
+    ? == t 20 { ^ `IQ4_NL` } {}
+    ? == t 21 { ^ `IQ3_S` } {}
+    ? == t 22 { ^ `IQ2_S` } {}
+    ? == t 23 { ^ `IQ4_XS` } {}
+    ? == t 24 { ^ `I8` } {}
+    ? == t 25 { ^ `I16` } {}
+    ? == t 26 { ^ `I32` } {}
+    ? == t 27 { ^ `I64` } {}
+    ? == t 28 { ^ `F64` } {}
+    ? == t 29 { ^ `IQ1_M` } {}
+    ? == t 30 { ^ `BF16` } {}
+    ^ `?`
+}
+
+// Elements per quantisation block; 0 when this parser cannot size the
+// type (unknown or not-yet-tabled id — such tensors are still listed,
+// but their byte extent cannot be verified or dequantised).
+@ gguf_type_blck i t → i {
+    ? | | == t 0 == t 1 | == t 24 | == t 25 | == t 26 | == t 27 | == t 28 == t 30 { ^ 1 } {}
+    ? | | == t 2 == t 3 | == t 6 | == t 7 | == t 8 | == t 9 == t 20 { ^ 32 } {}
+    ? | | == t 10 == t 11 | == t 12 | == t 13 | == t 14 == t 15 { ^ 256 } {}
+    ^ 0
+}
+
+// Bytes per quantisation block; 0 when unknown (pairs with gguf_type_blck).
+@ gguf_type_size i t → i {
+    ? == t 0 { ^ 4 } {}
+    ? == t 1 { ^ 2 } {}
+    ? == t 2 { ^ 18 } {}
+    ? == t 3 { ^ 20 } {}
+    ? == t 6 { ^ 22 } {}
+    ? == t 7 { ^ 24 } {}
+    ? == t 8 { ^ 34 } {}
+    ? == t 9 { ^ 36 } {}
+    ? == t 10 { ^ 84 } {}
+    ? == t 11 { ^ 110 } {}
+    ? == t 12 { ^ 144 } {}
+    ? == t 13 { ^ 176 } {}
+    ? == t 14 { ^ 210 } {}
+    ? == t 15 { ^ 292 } {}
+    ? == t 20 { ^ 18 } {}
+    ? == t 24 { ^ 1 } {}
+    ? == t 25 { ^ 2 } {}
+    ? == t 26 { ^ 4 } {}
+    ? == t 27 { ^ 8 } {}
+    ? == t 28 { ^ 8 } {}
+    ? == t 30 { ^ 2 } {}
+    ^ 0
+}
+
+// ── parsed structures ───────────────────────────────────────────────
+
+// One metadata key/value. `vt` discriminates which payload field holds
+// the value: int family (u8..u64/i64/bool) → ival, f32/f64 → fval,
+// string → sval, array → atype + one of ai/af/astr.
+: GgufKv {
+    String key
+    i vt
+    i ival
+    f fval
+    String sval
+    i atype
+    ( Vec i ) ai
+    ( Vec f ) af
+    ( Vec String ) astr
+}
+
+// One tensor-table entry. `offset` is RELATIVE to the data section
+// (exactly as stored in the file); absolute bytes are reached through
+// gguf_tensor_ptr. nbytes is -1 when the type cannot be sized.
+: GgufTensor {
+    String name
+    i gtype
+    i nd
+    i d0
+    i d1
+    i d2
+    i d3
+    i nelems
+    i offset
+    i nbytes
+}
+
+: Gguf {
+    i version
+    i align
+    ( Vec GgufKv ) kvs
+    ( Vec GgufTensor ) tensors
+    i data_off
+    i data_size
+    * u map
+    i map_size
+    b from_mmap
+    ( Vec u ) buf
+}
+
+// ── bounded little-endian cursor over the raw mapping ───────────────
+// Every read checks the remaining byte budget first; the first
+// out-of-bounds read latches `fail` and all subsequent reads return
+// zero values, so a parse can run to a checkpoint and test `fail` once.
+: GCur {
+    * u p
+    i n
+    i off
+    b fail
+}
+
+@ __gc_rem inout GCur c → i { ^ - . c n . c off }
+
+// Overflow-safe budget check: compares k against (n - off), never
+// forms off + k (a huge attacker-chosen k must not wrap negative).
+@ __gc_need inout GCur c i k → b {
+    ? . c fail { ^ F } {}
+    ? | < k 0 > k - . c n . c off { = . c fail T ^ F } {}
+    ^ T
+}
+
+@ __gc_u8 inout GCur c → i {
+    ? ( __gc_need c 1 ) {} { ^ 0 }
+    : *u P . c p
+    : i v # i . P . c off
+    = . c off + . c off 1
+    ^ v
+}
+
+@ __gc_u16 inout GCur c → i {
+    ? ( __gc_need c 2 ) {} { ^ 0 }
+    : *u P . c p
+    : i o . c off
+    = . c off + o 2
+    ^ | # i . P o << # i . P + o 1 8
+}
+
+@ __gc_u32 inout GCur c → i {
+    ? ( __gc_need c 4 ) {} { ^ 0 }
+    : *u P . c p
+    : i o . c off
+    = . c off + o 4
+    ^ | # i . P o | << # i . P + o 1 8 | << # i . P + o 2 16 << # i . P + o 3 24
+}
+
+// Reads 8 bytes as i64 (two's-complement bit pattern). GGUF stores
+// u64 here; a value ≥ 2^63 surfaces as negative and is rejected by
+// the `< 0` validations at every use site.
+@ __gc_u64 inout GCur c → i {
+    : i lo ( __gc_u32 c )
+    : i hi ( __gc_u32 c )
+    ^ | lo << hi 32
+}
+
+// Length-prefixed GGUF string. `maxlen` caps the accepted length
+// (keys/names are identifier-sized; general values are bounded by the
+// remaining file bytes anyway). `forbid_nul` rejects embedded NULs —
+// required for keys and tensor names which flow into C-string
+// comparisons; value strings keep arbitrary bytes.
+@ __gc_str inout GCur c i maxlen b forbid_nul → String {
+    : i len ( __gc_u64 c )
+    ? . c fail { ^ ( string_new ) } {}
+    ? | < len 0 > len maxlen { = . c fail T ^ ( string_new ) } {}
+    ? ( __gc_need c len ) {} { ^ ( string_new ) }
+    : *u P . c p
+    ? forbid_nul {
+        : ~ i j 0
+        ~ < j len {
+            ? == # i . P + . c off j 0 { = . c fail T = j len } { = j + j 1 }
+        }
+    } {}
+    ? . c fail { ^ ( string_new ) } {}
+    : *u src # *u + # i . c p . c off
+    : String out ( string_from_bytes src len )
+    = . c off + . c off len
+    ^ out
+}
+
+// ── typed value readers ─────────────────────────────────────────────
+
+// Fixed byte size of a SCALAR value type; 0 for string/array/unknown.
+@ __g_vt_size i vt → i {
+    ? | == vt 0 == vt 1 { ^ 1 } {}
+    ? | == vt 2 == vt 3 { ^ 2 } {}
+    ? | == vt 4 | == vt 5 == vt 6 { ^ 4 } {}
+    ? == vt 7 { ^ 1 } {}
+    ? | == vt 10 | == vt 11 == vt 12 { ^ 8 } {}
+    ^ 0
+}
+
+@ __g_read_int inout GCur c i vt → i {
+    ? == vt 0 { ^ ( __gc_u8 c ) } {}
+    ? == vt 1 {
+        : i x ( __gc_u8 c )
+        ^ ? > x 127 - x 256 x
+    } {}
+    ? == vt 2 { ^ ( __gc_u16 c ) } {}
+    ? == vt 3 {
+        : i x ( __gc_u16 c )
+        ^ ? > x 32767 - x 65536 x
+    } {}
+    ? == vt 4 { ^ ( __gc_u32 c ) } {}
+    ? == vt 5 {
+        : i x ( __gc_u32 c )
+        ^ ? > x 2147483647 - x 4294967296 x
+    } {}
+    ? == vt 7 {
+        : i x ( __gc_u8 c )
+        ^ ? != x 0 1 0
+    } {}
+    ? | == vt 10 == vt 11 { ^ ( __gc_u64 c ) } {}
+    = . c fail T
+    ^ 0
+}
+
+@ __g_read_f inout GCur c i vt → f {
+    ? == vt 6 {
+        : i bits ( __gc_u32 c )
+        ^ # f ( bits_to_f32 bits )
+    } {}
+    ? == vt 12 { ^ ( bits_to_f64 ( __gc_u64 c ) ) } {}
+    = . c fail T
+    ^ 0.0
+}
+
+@ __g_int_vt i vt → b {
+    ^ | | == vt 0 == vt 1 | == vt 2 | == vt 3 | == vt 4 | == vt 5 | == vt 7 | == vt 10 == vt 11
+}
+
+// ── KV / tensor entry parsers ───────────────────────────────────────
+// Both always return a fully-initialised value (owned fields present
+// even on failure) so error paths free exactly one shape.
+
+@ __g_parse_kv inout GCur c → GgufKv {
+    : String key ( __gc_str c 65536 T )
+    : i vt ( __gc_u32 c )
+    : ~ i ival 0
+    : ~ f fval 0.0
+    // string payload read in-place at declaration: a `= sval …`
+    // reassignment would leak the initial empty String
+    : String sval ? & ! . c fail == vt 8 ( __gc_str c ( __gc_rem c ) F ) ( string_new )
+    : ~ i atype -1
+    : ( Vec i ) ai ( vec_new [i] )
+    : ( Vec f ) af ( vec_new [f] )
+    : ( Vec String ) astr ( vec_new [String] )
+    ? | . c fail == vt 8 {} {
+        {
+            ? == vt 9 {
+                = atype ( __gc_u32 c )
+                : i cnt ( __gc_u64 c )
+                ? | . c fail < cnt 0 { = . c fail T } {
+                    ? == atype 8 {
+                        // string array: each element consumes ≥ 8 bytes
+                        ? > cnt / ( __gc_rem c ) 8 { = . c fail T } {
+                            : ~ i j 0
+                            ~ & < j cnt ! . c fail {
+                                ( vec_push [String] astr ( __gc_str c ( __gc_rem c ) F ) )
+                                = j + j 1
+                            }
+                        }
+                    } {
+                        : i esz ( __g_vt_size atype )
+                        ? == esz 0 { = . c fail T } {
+                            ? > cnt / ( __gc_rem c ) esz { = . c fail T } {
+                                : ~ i j 0
+                                ~ & < j cnt ! . c fail {
+                                    ? | == atype 6 == atype 12 {
+                                        ( vec_push [f] af ( __g_read_f c atype ) )
+                                    } {
+                                        ( vec_push [i] ai ( __g_read_int c atype ) )
+                                    }
+                                    = j + j 1
+                                }
+                            }
+                        }
+                    }
+                }
+            } {
+                ? | == vt 6 == vt 12 {
+                    = fval ( __g_read_f c vt )
+                } {
+                    ? ( __g_int_vt vt ) { = ival ( __g_read_int c vt ) } { = . c fail T }
+                }
+            }
+        }
+    }
+    ^ @ GgufKv { key vt ival fval sval atype ai af astr }
+}
+
+// Per-dimension cap 2^48 and running-product cap 2^48 keep
+// nelems * max-block-bytes (292) far away from i64 overflow.
+@ __g_parse_tensor inout GCur c → GgufTensor {
+    : String name ( __gc_str c 4096 T )
+    : i nd ( __gc_u32 c )
+    : ~ i d0 1
+    : ~ i d1 1
+    : ~ i d2 1
+    : ~ i d3 1
+    ? | . c fail | < nd 1 > nd 4 { = . c fail T } {
+        : ~ i j 0
+        ~ & < j nd ! . c fail {
+            : i d ( __gc_u64 c )
+            ? | < d 1 > d 281474976710656 { = . c fail T } {
+                ? == j 0 { = d0 d } {
+                    ? == j 1 { = d1 d } {
+                        ? == j 2 { = d2 d } { = d3 d }
+                    }
+                }
+            }
+            = j + j 1
+        }
+    }
+    : i gt ( __gc_u32 c )
+    : i rel ( __gc_u64 c )
+    : ~ i ne 0
+    ? . c fail {} {
+        = ne d0
+        ? > ne / 281474976710656 d1 { = . c fail T } { = ne * ne d1 }
+    }
+    ? . c fail {} {
+        ? > ne / 281474976710656 d2 { = . c fail T } { = ne * ne d2 }
+    }
+    ? . c fail {} {
+        ? > ne / 281474976710656 d3 { = . c fail T } { = ne * ne d3 }
+    }
+    ? < rel 0 { = . c fail T } {}
+    : ~ i nb -1
+    : i blk ( gguf_type_blck gt )
+    ? & ! . c fail > blk 0 {
+        ? != % d0 blk 0 { = . c fail T } {
+            = nb * / ne blk ( gguf_type_size gt )
+        }
+    } {}
+    ^ @ GgufTensor { name gt nd d0 d1 d2 d3 ne rel nb }
+}
+
+// ── owned-structure teardown ────────────────────────────────────────
+
+@ __g_kv_drop GgufKv k → v {
+    ( string_free . k key )
+    ( string_free . k sval )
+    ( vec_free [i] . k ai )
+    ( vec_free [f] . k af )
+    ( vec_free_with [String] . k astr \ String s → v { ( string_free s ) } )
+}
+
+@ __g_free_kvs ( Vec GgufKv ) v → v {
+    ( vec_free_with [GgufKv] v \ GgufKv k → v { ( __g_kv_drop k ) } )
+}
+
+@ __g_free_tensors ( Vec GgufTensor ) v → v {
+    ( vec_free_with [GgufTensor] v \ GgufTensor t → v { ( string_free . t name ) } )
+}
+
+@ __g_errs s msg → !*Gguf String {
+    ^ @ !*Gguf String { F ( string_from msg ) }
+}
+
+// ── the parser ──────────────────────────────────────────────────────
+// Parses the metadata + tensor table of the mapping [p, p+n) and
+// returns a heap Gguf borrowing that mapping. Ownership flags are
+// filled in by the callers (gguf_open / gguf_parse_bytes).
+@ __gguf_parse * u p i n → !*Gguf String {
+    ? < n 24 { ^ ( __g_errs `gguf: file too small to be GGUF (< 24 bytes)` ) } {}
+    : ~ GCur c @ GCur { p n 0 F }
+    : i m0 ( __gc_u8 c )
+    : i m1 ( __gc_u8 c )
+    : i m2 ( __gc_u8 c )
+    : i m3 ( __gc_u8 c )
+    ? | != m0 71 | != m1 71 | != m2 85 != m3 70 {
+        ^ ( __g_errs `gguf: bad magic (not a GGUF file)` )
+    } {}
+    : i ver ( __gc_u32 c )
+    ? == ver 1 {
+        ^ ( __g_errs `gguf: version 1 is unsupported (legacy 32-bit layout); re-export as v2/v3` )
+    } {}
+    ? | < ver 2 > ver 3 {
+        : String m ( string_from `gguf: unsupported version ` )
+        ( string_push_int m ver )
+        ^ @ !*Gguf String { F m }
+    } {}
+    : i ntens ( __gc_u64 c )
+    : i nkv ( __gc_u64 c )
+    // Minimum encoded sizes (KV ≥ 12 bytes, tensor entry ≥ 32 bytes)
+    // bound the counts by what the file could physically contain.
+    ? | < nkv 0 > nkv / - n 24 12 {
+        ^ ( __g_errs `gguf: absurd metadata count (corrupt or truncated file)` )
+    } {}
+    ? | < ntens 0 > ntens / - n 24 32 {
+        ^ ( __g_errs `gguf: absurd tensor count (corrupt or truncated file)` )
+    } {}
+
+    // metadata key/values
+    : ( Vec GgufKv ) kvs ( vec_new [GgufKv] )
+    : ~ i k 0
+    ~ & < k nkv ! . c fail {
+        ( vec_push [GgufKv] kvs ( __g_parse_kv c ) )
+        = k + k 1
+    }
+    ? . c fail {
+        ( __g_free_kvs kvs )
+        : String m ( string_from `gguf: corrupt or truncated metadata (kv #` )
+        ( string_push_int m k )
+        ( string_push_str m ` of ` )
+        ( string_push_int m nkv )
+        ( string_push_str m `)` )
+        ^ @ !*Gguf String { F m }
+    } {}
+
+    // unique keys (spec requirement; duplicates would make lookups lie)
+    : ~ i dupk -1
+    = k 0
+    ~ < k ( vec_len [GgufKv] kvs ) {
+        : ~ i j + k 1
+        ~ < j ( vec_len [GgufKv] kvs ) {
+            ?? ( vec_get [GgufKv] kvs k ) {
+                T a → {
+                    ?? ( vec_get [GgufKv] kvs j ) {
+                        T b2 → {
+                            ? ( string_eq . a key . b2 key ) { = dupk k } {}
+                        }
+                        F → {}
+                    }
+                }
+                F → {}
+            }
+            = j + j 1
+        }
+        = k + k 1
+    }
+    ? >= dupk 0 {
+        : ~ String m ( string_from `gguf: duplicate metadata key ` )
+        ?? ( vec_get [GgufKv] kvs dupk ) {
+            T a → { ( string_push_str m ( string_data . a key ) ) }
+            F → {}
+        }
+        ( __g_free_kvs kvs )
+        ^ @ !*Gguf String { F m }
+    } {}
+
+    // alignment (general.alignment, any integer type; default 32)
+    : ~ i align 32
+    = k 0
+    ~ < k ( vec_len [GgufKv] kvs ) {
+        ?? ( vec_get [GgufKv] kvs k ) {
+            T a → {
+                ? & != ( nurl_str_eq ( string_data . a key ) `general.alignment` ) 0 ( __g_int_vt . a vt ) {
+                    = align . a ival
+                } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ? | | < align 1 > align 1048576 != & align - align 1 0 {
+        ( __g_free_kvs kvs )
+        ^ ( __g_errs `gguf: invalid general.alignment (must be a power of two, 1..1048576)` )
+    } {}
+
+    // tensor table
+    : ( Vec GgufTensor ) ts ( vec_new [GgufTensor] )
+    = k 0
+    ~ & < k ntens ! . c fail {
+        ( vec_push [GgufTensor] ts ( __g_parse_tensor c ) )
+        = k + k 1
+    }
+    ? . c fail {
+        ( __g_free_kvs kvs )
+        ( __g_free_tensors ts )
+        : String m ( string_from `gguf: corrupt or truncated tensor table (entry #` )
+        ( string_push_int m k )
+        ( string_push_str m ` of ` )
+        ( string_push_int m ntens )
+        ( string_push_str m `)` )
+        ^ @ !*Gguf String { F m }
+    } {}
+
+    // unique tensor names
+    : ~ i dupt -1
+    = k 0
+    ~ < k ( vec_len [GgufTensor] ts ) {
+        : ~ i j + k 1
+        ~ < j ( vec_len [GgufTensor] ts ) {
+            ?? ( vec_get [GgufTensor] ts k ) {
+                T a → {
+                    ?? ( vec_get [GgufTensor] ts j ) {
+                        T b2 → {
+                            ? ( string_eq . a name . b2 name ) { = dupt k } {}
+                        }
+                        F → {}
+                    }
+                }
+                F → {}
+            }
+            = j + j 1
+        }
+        = k + k 1
+    }
+    ? >= dupt 0 {
+        : ~ String m ( string_from `gguf: duplicate tensor name ` )
+        ?? ( vec_get [GgufTensor] ts dupt ) {
+            T a → { ( string_push_str m ( string_data . a name ) ) }
+            F → {}
+        }
+        ( __g_free_kvs kvs )
+        ( __g_free_tensors ts )
+        ^ @ !*Gguf String { F m }
+    } {}
+
+    // data section start: metadata end rounded up to the alignment
+    : i meta_end . c off
+    : ~ i doff meta_end
+    : i rem % meta_end align
+    ? != rem 0 { = doff + meta_end - align rem } {}
+    ? > doff n {
+        ? == ntens 0 { = doff n } {
+            ( __g_free_kvs kvs )
+            ( __g_free_tensors ts )
+            ^ ( __g_errs `gguf: truncated before the tensor data section` )
+        }
+    } {}
+    : i dsize - n doff
+
+    // every sizable tensor must sit aligned and fully inside the data
+    // section (offset compared against dsize first — no overflow path)
+    : ~ i badt -1
+    = k 0
+    ~ < k ( vec_len [GgufTensor] ts ) {
+        ?? ( vec_get [GgufTensor] ts k ) {
+            T t → {
+                ? != % . t offset align 0 { = badt k } {}
+                ? > . t offset dsize { = badt k } {}
+                ? & >= . t nbytes 0 > . t nbytes - dsize . t offset { = badt k } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ? >= badt 0 {
+        : ~ String m ( string_from `gguf: tensor ` )
+        ?? ( vec_get [GgufTensor] ts badt ) {
+            T t → {
+                ( string_push_str m ( string_data . t name ) )
+                ( string_push_str m ` lies outside the data section (offset ` )
+                ( string_push_int m . t offset )
+                ( string_push_str m `, bytes ` )
+                ( string_push_int m . t nbytes )
+                ( string_push_str m `, data size ` )
+                ( string_push_int m dsize )
+                ( string_push_str m `)` )
+            }
+            F → {}
+        }
+        ( __g_free_kvs kvs )
+        ( __g_free_tensors ts )
+        ^ @ !*Gguf String { F m }
+    } {}
+
+    : *Gguf g # *Gguf ( nurl_alloc Z Gguf )
+    = . g version ver
+    = . g align align
+    = . g kvs kvs
+    = . g tensors ts
+    = . g data_off doff
+    = . g data_size dsize
+    = . g map p
+    = . g map_size n
+    = . g from_mmap F
+    = . g buf ( vec_new [u] )
+    ^ @ !*Gguf String { T g }
+}
+
+// ── open / close ────────────────────────────────────────────────────
+
+// mmap-backed open (POSIX). Platforms without MAP_PRIVATE (wasm,
+// win32) fall back to reading the whole file into an owned buffer —
+// correct everywhere, mmap-lazy where it matters.
+@ gguf_open s path → !*Gguf String {
+    ? != ( posix_const `MAP_PRIVATE` ) -1 {
+        : i32 fd ( open path # i32 ( posix_const `O_RDONLY` ) # i32 0 )
+        ? < # i fd 0 {
+            : String m ( string_from `gguf: cannot open ` )
+            ( string_push_str m path )
+            ^ @ !*Gguf String { F m }
+        } {}
+        : i sz ( lseek fd 0 # i32 2 )
+        ? < sz 24 {
+            : i _c ( close # i fd )
+            ^ ( __g_errs `gguf: file too small to be GGUF (< 24 bytes)` )
+        } {}
+        : *u m ( mmap # *u 0 sz # i32 ( posix_const `PROT_READ` ) # i32 ( posix_const `MAP_PRIVATE` ) fd 0 )
+        : i _c ( close # i fd )
+        ? == # i m -1 { ^ ( __g_errs `gguf: mmap failed` ) } {}
+        : !*Gguf String r ( __gguf_parse m sz )
+        ?? r {
+            T g → {
+                = . g from_mmap T
+                ^ @ !*Gguf String { T g }
+            }
+            F e → {
+                : i32 _u ( munmap m sz )
+                ^ @ !*Gguf String { F e }
+            }
+        }
+    } {
+        : !( Vec u ) IoErr r ( read_file_bytes path )
+        ?? r {
+            T data → {
+                : !*Gguf String pr ( __gguf_parse ( vec_data [u] data ) ( vec_len [u] data ) )
+                ?? pr {
+                    T g → {
+                        // adopt the file buffer: drop the placeholder
+                        // empty vec first (g is manually managed — no
+                        // auto-drop reaches its fields)
+                        ( vec_free [u] . g buf )
+                        = . g buf data
+                        ^ @ !*Gguf String { T g }
+                    }
+                    F e → {
+                        ( vec_free [u] data )
+                        ^ @ !*Gguf String { F e }
+                    }
+                }
+            }
+            F _ → {
+                : String m ( string_from `gguf: cannot read ` )
+                ( string_push_str m path )
+                ^ @ !*Gguf String { F m }
+            }
+        }
+    }
+}
+
+// Parse an in-memory GGUF image. BORROWS `data` — the caller keeps the
+// vec alive until gguf_close and frees it afterwards.
+@ gguf_parse_bytes ( Vec u ) data → !*Gguf String {
+    ^ ( __gguf_parse ( vec_data [u] data ) ( vec_len [u] data ) )
+}
+
+@ gguf_close * Gguf g → v {
+    ( __g_free_kvs . g kvs )
+    ( __g_free_tensors . g tensors )
+    ? . g from_mmap {
+        : i32 _u ( munmap . g map . g map_size )
+    } {}
+    ( vec_free [u] . g buf )
+    ( nurl_free # s g )
+}
+
+// ── accessors ───────────────────────────────────────────────────────
+
+@ gguf_version * Gguf g → i { ^ . g version }
+
+@ gguf_align * Gguf g → i { ^ . g align }
+
+@ gguf_n_kv * Gguf g → i { ^ ( vec_len [GgufKv] . g kvs ) }
+
+@ gguf_n_tensors * Gguf g → i { ^ ( vec_len [GgufTensor] . g tensors ) }
+
+@ gguf_data_size * Gguf g → i { ^ . g data_size }
+
+@ gguf_find_kv * Gguf g s key → i {
+    : ~ i k 0
+    : ~ i found -1
+    ~ < k ( vec_len [GgufKv] . g kvs ) {
+        ?? ( vec_get [GgufKv] . g kvs k ) {
+            T a → {
+                ? ( nurl_str_eq ( string_data . a key ) key ) { = found k = k ( vec_len [GgufKv] . g kvs ) } { = k + k 1 }
+            }
+            F → { = k + k 1 }
+        }
+    }
+    ^ found
+}
+
+@ gguf_kv_int_or * Gguf g s key i def → i {
+    : i idx ( gguf_find_kv g key )
+    ? < idx 0 { ^ def } {}
+    ?? ( vec_get [GgufKv] . g kvs idx ) {
+        T a → { ^ ? ( __g_int_vt . a vt ) . a ival def }
+        F → { ^ def }
+    }
+}
+
+@ gguf_kv_f_or * Gguf g s key f def → f {
+    : i idx ( gguf_find_kv g key )
+    ? < idx 0 { ^ def } {}
+    ?? ( vec_get [GgufKv] . g kvs idx ) {
+        T a → { ^ ? | == . a vt 6 == . a vt 12 . a fval def }
+        F → { ^ def }
+    }
+}
+
+// BORROWED: the returned s points into g (or is `def`); valid until
+// gguf_close. Do not free.
+@ gguf_kv_str_or * Gguf g s key s def → s {
+    : i idx ( gguf_find_kv g key )
+    ? < idx 0 { ^ def } {}
+    ?? ( vec_get [GgufKv] . g kvs idx ) {
+        T a → { ^ ? == . a vt 8 ( string_data . a sval ) def }
+        F → { ^ def }
+    }
+}
+
+@ gguf_find_tensor * Gguf g s name → i {
+    : ~ i k 0
+    : ~ i found -1
+    ~ < k ( vec_len [GgufTensor] . g tensors ) {
+        ?? ( vec_get [GgufTensor] . g tensors k ) {
+            T t → {
+                ? ( nurl_str_eq ( string_data . t name ) name ) { = found k = k ( vec_len [GgufTensor] . g tensors ) } { = k + k 1 }
+            }
+            F → { = k + k 1 }
+        }
+    }
+    ^ found
+}
+
+// BORROWED pointer to a tensor's first byte inside the mapping; valid
+// until gguf_close. Length is t.nbytes (when ≥ 0).
+@ gguf_tensor_ptr * Gguf g GgufTensor t → *u {
+    ^ # *u + + # i . g map . g data_off . t offset
+}

--- a/packages/gguf/src/main.nu
+++ b/packages/gguf/src/main.nu
@@ -1,0 +1,922 @@
+// gguf — inspect, verify and export GGUF model containers.
+//
+//   gguf info <file>                  one-line summary
+//   gguf dump <file>                  header + all metadata + tensors
+//   gguf kv <file> <key>              print one metadata value
+//   gguf tensors <file>               tensor table
+//   gguf verify <file>                deep structural check (+ overlap)
+//   gguf export <file> <tensor> -o out.f32    dequantise to f32-LE
+//   gguf gen <out.gguf>               write the reference sample file
+//   gguf selftest                     write → parse → compare, bit-exact
+//
+// The parser treats every input as hostile: malformed, truncated or
+// adversarial files produce an error message, never a crash, hang or
+// unbounded allocation (see tests/gguf_test.sh, which proves this
+// with a corruption battery).
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/posix.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/args.nu`
+$ `stdlib/std/floatbits.nu`
+$ `gguf.nu`
+$ `dequant.nu`
+$ `write.nu`
+
+: i GGUF_CLI_VERSION_MAJOR 0
+
+@ __gg_vt_name i vt → s {
+    ? == vt 0 { ^ `u8` } {}
+    ? == vt 1 { ^ `i8` } {}
+    ? == vt 2 { ^ `u16` } {}
+    ? == vt 3 { ^ `i16` } {}
+    ? == vt 4 { ^ `u32` } {}
+    ? == vt 5 { ^ `i32` } {}
+    ? == vt 6 { ^ `f32` } {}
+    ? == vt 7 { ^ `bool` } {}
+    ? == vt 8 { ^ `str` } {}
+    ? == vt 9 { ^ `arr` } {}
+    ? == vt 10 { ^ `u64` } {}
+    ? == vt 11 { ^ `i64` } {}
+    ? == vt 12 { ^ `f64` } {}
+    ^ `?`
+}
+
+// Render one KV as `key = <type> value` (arrays truncated to 8 elems).
+@ __gg_fmt_kv GgufKv a → String {
+    : String m ( string_from ( string_data . a key ) )
+    ( string_push_str m ` = ` )
+    : i vt . a vt
+    ? == vt 8 {
+        ( string_push_str m `str ` )
+        ( string_push_str m ( string_data . a sval ) )
+        ^ m
+    } {}
+    ? == vt 9 {
+        ( string_push_str m `[` )
+        ( string_push_str m ( __gg_vt_name . a atype ) )
+        : ~ i n 0
+        ? == . a atype 8 { = n ( vec_len [String] . a astr ) } {
+            ? | == . a atype 6 == . a atype 12 { = n ( vec_len [f] . a af ) } {
+                = n ( vec_len [i] . a ai )
+            }
+        }
+        ( string_push_str m ` x ` )
+        ( string_push_int m n )
+        ( string_push_str m `]` )
+        : ~ i k 0
+        ~ & < k n < k 8 {
+            ( string_push_str m ` ` )
+            ? == . a atype 8 {
+                ?? ( vec_get [String] . a astr k ) {
+                    T sv → { ( string_push_str m ( string_data sv ) ) }
+                    F → {}
+                }
+            } {
+                ? | == . a atype 6 == . a atype 12 {
+                    ?? ( vec_get [f] . a af k ) {
+                        T x → { ( string_push_float m x ) }
+                        F → {}
+                    }
+                } {
+                    ?? ( vec_get [i] . a ai k ) {
+                        T x → { ( string_push_int m x ) }
+                        F → {}
+                    }
+                }
+            }
+            = k + k 1
+        }
+        ? > n 8 { ( string_push_str m ` …` ) } {}
+        ^ m
+    } {}
+    ( string_push_str m ( __gg_vt_name vt ) )
+    ( string_push_str m ` ` )
+    ? | == vt 6 == vt 12 { ( string_push_float m . a fval ) } {
+        ? == vt 7 { ( string_push_str m ? != . a ival 0 `true` `false` ) } {
+            ( string_push_int m . a ival )
+        }
+    }
+    ^ m
+}
+
+@ __gg_fmt_tensor GgufTensor t → String {
+    : String m ( string_from ( string_data . t name ) )
+    : ~ i pad - 40 ( string_len m )
+    ~ > pad 0 {
+        ( string_push_char m 32 )
+        = pad - pad 1
+    }
+    ( string_push_str m ` ` )
+    : s tn ( gguf_type_name . t gtype )
+    ? ( nurl_str_eq tn `?` ) {
+        ( string_push_str m `unknown(` )
+        ( string_push_int m . t gtype )
+        ( string_push_str m `)` )
+    } {
+        ( string_push_str m tn )
+    }
+    ( string_push_str m ` [` )
+    ( string_push_int m . t d0 )
+    ? >= . t nd 2 {
+        ( string_push_str m ` ` )
+        ( string_push_int m . t d1 )
+    } {}
+    ? >= . t nd 3 {
+        ( string_push_str m ` ` )
+        ( string_push_int m . t d2 )
+    } {}
+    ? >= . t nd 4 {
+        ( string_push_str m ` ` )
+        ( string_push_int m . t d3 )
+    } {}
+    ( string_push_str m `] ` )
+    ? >= . t nbytes 0 { ( string_push_int m . t nbytes ) } { ( string_push_str m `?` ) }
+    ( string_push_str m ` B @ ` )
+    ( string_push_int m . t offset )
+    ^ m
+}
+
+@ __gg_print_owned String m → v {
+    ( nurl_print ( string_data m ) )
+    ( nurl_print `\n` )
+    ( string_free m )
+}
+
+@ __gg_err String e → i {
+    ( nurl_eprintln ( string_data e ) )
+    ( string_free e )
+    ^ 1
+}
+
+@ __gg_info * Gguf g → v {
+    : String m ( string_from `GGUF v` )
+    ( string_push_int m ( gguf_version g ) )
+    ( string_push_str m ` — ` )
+    ( string_push_int m ( gguf_n_kv g ) )
+    ( string_push_str m ` kv, ` )
+    ( string_push_int m ( gguf_n_tensors g ) )
+    ( string_push_str m ` tensors, align ` )
+    ( string_push_int m ( gguf_align g ) )
+    ( string_push_str m `, data ` )
+    ( string_push_int m ( gguf_data_size g ) )
+    ( string_push_str m ` B` )
+    : s arch ( gguf_kv_str_or g `general.architecture` `` )
+    ? > ( nurl_str_len arch ) 0 {
+        ( string_push_str m `, arch ` )
+        ( string_push_str m arch )
+    } {}
+    : s nm ( gguf_kv_str_or g `general.name` `` )
+    ? > ( nurl_str_len nm ) 0 {
+        ( string_push_str m `, name ` )
+        ( string_push_str m nm )
+    } {}
+    ( __gg_print_owned m )
+}
+
+@ __gg_cmd_dump * Gguf g → v {
+    ( __gg_info g )
+    : ~ i k 0
+    ~ < k ( gguf_n_kv g ) {
+        ?? ( vec_get [GgufKv] . g kvs k ) {
+            T a → { ( __gg_print_owned ( __gg_fmt_kv a ) ) }
+            F → {}
+        }
+        = k + k 1
+    }
+    = k 0
+    ~ < k ( gguf_n_tensors g ) {
+        ?? ( vec_get [GgufTensor] . g tensors k ) {
+            T t → { ( __gg_print_owned ( __gg_fmt_tensor t ) ) }
+            F → {}
+        }
+        = k + k 1
+    }
+}
+
+// Deep structural verify: parse invariants already held at open; add
+// the pairwise overlap proof for every sizable tensor and count what
+// could not be sized.
+@ __gg_cmd_verify * Gguf g → i {
+    : i nt ( gguf_n_tensors g )
+    : ~ i unsized 0
+    : ~ i k 0
+    ~ < k nt {
+        ?? ( vec_get [GgufTensor] . g tensors k ) {
+            T t → { ? < . t nbytes 0 { = unsized + unsized 1 } {} }
+            F → {}
+        }
+        = k + k 1
+    }
+    = k 0
+    : ~ i ova -1
+    : ~ i ovb -1
+    ~ < k nt {
+        ?? ( vec_get [GgufTensor] . g tensors k ) {
+            T a → {
+                ? < . a nbytes 0 {} {
+                    : ~ i j + k 1
+                    ~ < j nt {
+                        ?? ( vec_get [GgufTensor] . g tensors j ) {
+                            T b2 → {
+                                ? < . b2 nbytes 0 {} {
+                                    ? & < . a offset + . b2 offset . b2 nbytes < . b2 offset + . a offset . a nbytes {
+                                        = ova k
+                                        = ovb j
+                                    } {}
+                                }
+                            }
+                            F → {}
+                        }
+                        = j + j 1
+                    }
+                }
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ? >= ova 0 {
+        : ~ String m ( string_from `gguf: OVERLAP — tensors ` )
+        ?? ( vec_get [GgufTensor] . g tensors ova ) {
+            T a → { ( string_push_str m ( string_data . a name ) ) }
+            F → {}
+        }
+        ( string_push_str m ` and ` )
+        ?? ( vec_get [GgufTensor] . g tensors ovb ) {
+            T a → { ( string_push_str m ( string_data . a name ) ) }
+            F → {}
+        }
+        ( string_push_str m ` share bytes in the data section` )
+        ^ ( __gg_err m )
+    } {}
+    : String m ( string_from `OK — GGUF v` )
+    ( string_push_int m ( gguf_version g ) )
+    ( string_push_str m `, ` )
+    ( string_push_int m ( gguf_n_kv g ) )
+    ( string_push_str m ` kv, ` )
+    ( string_push_int m nt )
+    ( string_push_str m ` tensors` )
+    ? > unsized 0 {
+        ( string_push_str m ` (` )
+        ( string_push_int m unsized )
+        ( string_push_str m ` of unknown type not size-checked)` )
+    } {}
+    ( string_push_str m `, all offsets aligned, in-bounds and disjoint` )
+    ( __gg_print_owned m )
+    ^ 0
+}
+
+// ── the reference sample (gen + selftest) ───────────────────────────
+
+@ __st_push_f32 ( Vec u ) v f x → v {
+    ( bytes_push_u32_le v # u32 ( f32_to_bits # f32 x ) )
+}
+
+// Builds the reference sample: every KV type, and one tensor per
+// dequantisable ggml type with hand-picked edge values (f16 subnormal,
+// ±inf, NaN, negative quants).
+@ __st_build → *GgufW {
+    : ~ i waddr 0
+    ?? ( gw_new 32 ) {
+        T w2 → { = waddr # i w2 }
+        F e → { ( string_free e ) }
+    }
+    : *GgufW w # *GgufW waddr
+    ( gw_kv_str w `general.architecture` `selftest` )
+    ( gw_kv_str w `general.name` `gguf reference sample` )
+    ( gw_kv_u32 w `selftest.u32` 4000000000 )
+    ( gw_kv_i32 w `selftest.i32` -12345 )
+    ( gw_kv_u64 w `selftest.u64` 8589934592 )
+    ( gw_kv_i64 w `selftest.i64` -8589934592 )
+    ( gw_kv_f32 w `selftest.f32` 1.5 )
+    ( gw_kv_f64 w `selftest.f64` -2.25 )
+    ( gw_kv_bool w `selftest.bool_t` T )
+    ( gw_kv_bool w `selftest.bool_f` F )
+    : ( Vec i ) ai ( vec_new [i] )
+    ( vec_push [i] ai 3 )
+    ( vec_push [i] ai -7 )
+    ( vec_push [i] ai 42 )
+    ( gw_kv_arr_i32 w `selftest.arr_i32` ai )
+    ( vec_free [i] ai )
+    : ( Vec f ) af ( vec_new [f] )
+    ( vec_push [f] af 0.5 )
+    ( vec_push [f] af -2.25 )
+    ( gw_kv_arr_f32 w `selftest.arr_f32` af )
+    ( vec_free [f] af )
+    : ( Vec String ) astr ( vec_new [String] )
+    ( vec_push [String] astr ( string_from `alpha` ) )
+    ( vec_push [String] astr ( string_from `beta` ) )
+    ( vec_push [String] astr ( string_from `gamma` ) )
+    ( gw_kv_arr_str w `selftest.arr_str` astr )
+    ( vec_free_with [String] astr \ String s → v { ( string_free s ) } )
+
+    // t_f32: 8 exactly-representable values
+    : ( Vec u ) bf32 ( vec_new [u] )
+    ( __st_push_f32 bf32 0.0 )
+    ( __st_push_f32 bf32 1.5 )
+    ( __st_push_f32 bf32 -2.25 )
+    ( __st_push_f32 bf32 3.75 )
+    ( __st_push_f32 bf32 100.0 )
+    ( __st_push_f32 bf32 -0.0078125 )
+    ( __st_push_f32 bf32 6.5 )
+    ( __st_push_f32 bf32 -7.0 )
+    : !v String r1 ( gw_tensor w `t_f32` 0 2 4 2 1 1 bf32 )
+    ( vec_free [u] bf32 )
+    ?? r1 { T _ → {} F e → { ( string_free e ) } }
+
+    // t_f16: 9 bit-exact edge cases incl. subnormals, ±inf, NaN, -0
+    : ( Vec u ) bf16 ( vec_new [u] )
+    ( bytes_push_u16_le bf16 # u16 0 )
+    ( bytes_push_u16_le bf16 # u16 15360 )
+    ( bytes_push_u16_le bf16 # u16 49152 )
+    ( bytes_push_u16_le bf16 # u16 1 )
+    ( bytes_push_u16_le bf16 # u16 1023 )
+    ( bytes_push_u16_le bf16 # u16 31744 )
+    ( bytes_push_u16_le bf16 # u16 64512 )
+    ( bytes_push_u16_le bf16 # u16 32256 )
+    ( bytes_push_u16_le bf16 # u16 32768 )
+    : !v String r2 ( gw_tensor w `t_f16` 1 1 9 1 1 1 bf16 )
+    ( vec_free [u] bf16 )
+    ?? r2 { T _ → {} F e → { ( string_free e ) } }
+
+    // t_bf16: shift-up transport
+    : ( Vec u ) bbf ( vec_new [u] )
+    ( bytes_push_u16_le bbf # u16 16256 )
+    ( bytes_push_u16_le bbf # u16 49152 )
+    ( bytes_push_u16_le bbf # u16 0 )
+    ( bytes_push_u16_le bbf # u16 32640 )
+    : !v String r3 ( gw_tensor w `t_bf16` 30 1 4 1 1 1 bbf )
+    ( vec_free [u] bbf )
+    ?? r3 { T _ → {} F e → { ( string_free e ) } }
+
+    // t_q4_0: one block, d = 1.0, qs[j] = j | (15-j)<<4
+    : ( Vec u ) bq4 ( vec_new [u] )
+    ( bytes_push_u16_le bq4 # u16 15360 )
+    : ~ i j 0
+    ~ < j 16 {
+        ( vec_push [u] bq4 # u | j << - 15 j 4 )
+        = j + j 1
+    }
+    : !v String r4 ( gw_tensor w `t_q4_0` 2 1 32 1 1 1 bq4 )
+    ( vec_free [u] bq4 )
+    ?? r4 { T _ → {} F e → { ( string_free e ) } }
+
+    // t_q4_1: d = 1.0, m = -8.0 — must decode identically to t_q4_0
+    : ( Vec u ) bq41 ( vec_new [u] )
+    ( bytes_push_u16_le bq41 # u16 15360 )
+    ( bytes_push_u16_le bq41 # u16 51200 )
+    = j 0
+    ~ < j 16 {
+        ( vec_push [u] bq41 # u | j << - 15 j 4 )
+        = j + j 1
+    }
+    : !v String r5 ( gw_tensor w `t_q4_1` 3 1 32 1 1 1 bq41 )
+    ( vec_free [u] bq41 )
+    ?? r5 { T _ → {} F e → { ( string_free e ) } }
+
+    // t_q8_0: d = 0.5, q = 0..30 then -56
+    : ( Vec u ) bq8 ( vec_new [u] )
+    ( bytes_push_u16_le bq8 # u16 14336 )
+    = j 0
+    ~ < j 31 {
+        ( vec_push [u] bq8 # u j )
+        = j + j 1
+    }
+    ( vec_push [u] bq8 # u 200 )
+    : !v String r6 ( gw_tensor w `t_q8_0` 8 1 32 1 1 1 bq8 )
+    ( vec_free [u] bq8 )
+    ?? r6 { T _ → {} F e → { ( string_free e ) } }
+    ^ w
+}
+
+: STCnt {
+    i pass
+    i fail
+}
+
+@ __st_ck inout STCnt cn b ok s name → v {
+    ? ok { = . cn pass + . cn pass 1 } {
+        = . cn fail + . cn fail 1
+        ( nurl_print `  FAIL ` )
+        ( nurl_print name )
+        ( nurl_print `\n` )
+    }
+}
+
+// f64 vector equality against a raw expected pointer + count
+@ __st_vec_eq ( Vec f ) got * f exp i n → b {
+    ? != ( vec_len [f] got ) n { ^ F } {}
+    : ~ i k 0
+    : ~ b ok T
+    ~ < k n {
+        ?? ( vec_get [f] got k ) {
+            T x → { ? == x . exp k {} { = ok F } }
+            F → { = ok F }
+        }
+        = k + k 1
+    }
+    ^ ok
+}
+
+@ __st_run → i {
+    : ~ STCnt cn @ STCnt { 0 0 }
+    // expected-value tables live at function scope: owned slice
+    // literals inside ?/??-arms are not yet dropped by the compiler
+    // (TODO.md §8) — at function scope the scope-exit drop is sound
+    : f32exp [f | 0.0 1.5 -2.25 3.75 100.0 -0.0078125 6.5 -7.0]
+    : f16exp [i | 0 1065353216 3221225472 864026624 947896320 2139095040 4286578688 2143289344 2147483648]
+    : bfexp [i | 1065353216 3221225472 0 2139095040]
+    : *GgufW w ( __st_build )
+    : !String IoErr tf ( fs_tempfile `/tmp` `gguf-selftest.` )
+    : ~ String path ( string_new )
+    ?? tf {
+        T p → {
+            ( string_free path )
+            = path p
+        }
+        F _ → {
+            ( nurl_eprintln `selftest: cannot create a temp file under /tmp` )
+            ( gw_free w )
+            ^ 1
+        }
+    }
+    : !v String wr ( gw_write w ( string_data path ) )
+    ( gw_free w )
+    ?? wr {
+        T _ → {}
+        F e → {
+            ( nurl_eprintln ( string_data e ) )
+            ( string_free e )
+            ( file_delete ( string_data path ) )
+            ( string_free path )
+            ^ 1
+        }
+    }
+
+    : !*Gguf String orr ( gguf_open ( string_data path ) )
+    : ~ i rc 0
+    ?? orr {
+        T g → {
+            ( __st_ck cn == ( gguf_version g ) 3 `version is 3` )
+            ( __st_ck cn == ( gguf_align g ) 32 `alignment is 32` )
+            ( __st_ck cn == ( gguf_n_kv g ) 14 `kv count` )
+            ( __st_ck cn == ( gguf_n_tensors g ) 6 `tensor count` )
+            ( __st_ck cn ( nurl_str_eq ( gguf_kv_str_or g `general.architecture` `` ) `selftest` ) `str kv` )
+            ( __st_ck cn == ( gguf_kv_int_or g `selftest.u32` 0 ) 4000000000 `u32 kv` )
+            ( __st_ck cn == ( gguf_kv_int_or g `selftest.i32` 0 ) -12345 `i32 kv (negative)` )
+            ( __st_ck cn == ( gguf_kv_int_or g `selftest.u64` 0 ) 8589934592 `u64 kv (> 32 bit)` )
+            ( __st_ck cn == ( gguf_kv_int_or g `selftest.i64` 0 ) -8589934592 `i64 kv (negative)` )
+            ( __st_ck cn == ( gguf_kv_f_or g `selftest.f32` 0.0 ) 1.5 `f32 kv` )
+            ( __st_ck cn == ( gguf_kv_f_or g `selftest.f64` 0.0 ) -2.25 `f64 kv` )
+            ( __st_ck cn == ( gguf_kv_int_or g `selftest.bool_t` 0 ) 1 `bool kv true` )
+            ( __st_ck cn == ( gguf_kv_int_or g `selftest.bool_f` 1 ) 0 `bool kv false` )
+            ( __st_ck cn == ( gguf_kv_int_or g `general.alignment` 0 ) 32 `alignment kv emitted` )
+            ( __st_ck cn == ( gguf_kv_int_or g `no.such.key` -1 ) -1 `absent kv falls to default` )
+
+            : i ai_idx ( gguf_find_kv g `selftest.arr_i32` )
+            ( __st_ck cn >= ai_idx 0 `arr_i32 present` )
+            ? >= ai_idx 0 {
+                ?? ( vec_get [GgufKv] . g kvs ai_idx ) {
+                    T a → {
+                        ( __st_ck cn == ( vec_len [i] . a ai ) 3 `arr_i32 length` )
+                        : ~ i v1 0
+                        ?? ( vec_get [i] . a ai 1 ) { T x → { = v1 x } F → {} }
+                        ( __st_ck cn == v1 -7 `arr_i32 negative element` )
+                    }
+                    F → {}
+                }
+            } {}
+            : i as_idx ( gguf_find_kv g `selftest.arr_str` )
+            ( __st_ck cn >= as_idx 0 `arr_str present` )
+            ? >= as_idx 0 {
+                ?? ( vec_get [GgufKv] . g kvs as_idx ) {
+                    T a → {
+                        ( __st_ck cn == ( vec_len [String] . a astr ) 3 `arr_str length` )
+                        : ~ b ok F
+                        ?? ( vec_get [String] . a astr 2 ) {
+                            T sv → { = ok ( string_eq_raw sv `gamma` ) }
+                            F → {}
+                        }
+                        ( __st_ck cn ok `arr_str element` )
+                    }
+                    F → {}
+                }
+            } {}
+
+            // t_f32 round-trips bit-exactly
+            : i tf32 ( gguf_find_tensor g `t_f32` )
+            ( __st_ck cn >= tf32 0 `t_f32 present` )
+            ? >= tf32 0 {
+                ?? ( vec_get [GgufTensor] . g tensors tf32 ) {
+                    T t → {
+                        ( __st_ck cn & == . t nd 2 & == . t d0 4 == . t d1 2 `t_f32 dims` )
+                        ( __st_ck cn == . t nelems 8 `t_f32 nelems` )
+                        ( __st_ck cn == . t nbytes 32 `t_f32 nbytes` )
+                    }
+                    F → {}
+                }
+                : !( Vec f ) String dr ( gguf_dequant_f64 g tf32 )
+                ?? dr {
+                    T got → {
+                        ( __st_ck cn ( __st_vec_eq got . f32exp 0 8 ) `t_f32 dequant values` )
+                        ( vec_free [f] got )
+                    }
+                    F e → {
+                        ( string_free e )
+                        ( __st_ck cn F `t_f32 dequant` )
+                    }
+                }
+            } {}
+
+            // t_f16: IEEE edge table, bit-for-bit
+            : i tf16 ( gguf_find_tensor g `t_f16` )
+            ( __st_ck cn >= tf16 0 `t_f16 present` )
+            ? >= tf16 0 {
+                : !( Vec u ) String dr ( gguf_dequant g tf16 )
+                ?? dr {
+                    T got → {
+                        : *i EP . f16exp 0
+                        : ~ b ok == ( vec_len [u] got ) 36
+                        : ~ i k 0
+                        ~ < k 9 {
+                            : ~ i gb -1
+                            ?? ( bytes_read_u32_le got * k 4 ) {
+                                T x → { = gb # i x }
+                                F → {}
+                            }
+                            ? == gb . EP k {} { = ok F }
+                            = k + k 1
+                        }
+                        ( __st_ck cn ok `t_f16 bit-exact (incl. subnormal/inf/NaN/-0)` )
+                        ( vec_free [u] got )
+                    }
+                    F e → {
+                        ( string_free e )
+                        ( __st_ck cn F `t_f16 dequant` )
+                    }
+                }
+            } {}
+
+            // t_bf16
+            : i tbf ( gguf_find_tensor g `t_bf16` )
+            ? >= tbf 0 {
+                : !( Vec u ) String dr ( gguf_dequant g tbf )
+                ?? dr {
+                    T got → {
+                        : *i EP . bfexp 0
+                        : ~ b ok == ( vec_len [u] got ) 16
+                        : ~ i k 0
+                        ~ < k 4 {
+                            : ~ i gb -1
+                            ?? ( bytes_read_u32_le got * k 4 ) {
+                                T x → { = gb # i x }
+                                F → {}
+                            }
+                            ? == gb . EP k {} { = ok F }
+                            = k + k 1
+                        }
+                        ( __st_ck cn ok `t_bf16 bit-exact` )
+                        ( vec_free [u] got )
+                    }
+                    F e → {
+                        ( string_free e )
+                        ( __st_ck cn F `t_bf16 dequant` )
+                    }
+                }
+            } { ( __st_ck cn F `t_bf16 present` ) }
+
+            // t_q4_0: element k = k-8 (k<16), 7-(k-16) (k≥16)
+            : i tq4 ( gguf_find_tensor g `t_q4_0` )
+            : ( Vec f ) q4exp ( vec_new [f] )
+            : ~ i k 0
+            ~ < k 16 {
+                ( vec_push [f] q4exp # f - k 8 )
+                = k + k 1
+            }
+            = k 0
+            ~ < k 16 {
+                ( vec_push [f] q4exp # f - 7 k )
+                = k + k 1
+            }
+            ? >= tq4 0 {
+                : !( Vec f ) String dr ( gguf_dequant_f64 g tq4 )
+                ?? dr {
+                    T got → {
+                        ( __st_ck cn ( __st_vec_eq got ( vec_data [f] q4exp ) 32 ) `t_q4_0 dequant values` )
+                        ( vec_free [f] got )
+                    }
+                    F e → {
+                        ( string_free e )
+                        ( __st_ck cn F `t_q4_0 dequant` )
+                    }
+                }
+            } { ( __st_ck cn F `t_q4_0 present` ) }
+
+            // t_q4_1 with d=1, m=-8 must equal t_q4_0
+            : i tq41 ( gguf_find_tensor g `t_q4_1` )
+            ? >= tq41 0 {
+                : !( Vec f ) String dr ( gguf_dequant_f64 g tq41 )
+                ?? dr {
+                    T got → {
+                        ( __st_ck cn ( __st_vec_eq got ( vec_data [f] q4exp ) 32 ) `t_q4_1 equals t_q4_0 (d=1, m=-8)` )
+                        ( vec_free [f] got )
+                    }
+                    F e → {
+                        ( string_free e )
+                        ( __st_ck cn F `t_q4_1 dequant` )
+                    }
+                }
+            } { ( __st_ck cn F `t_q4_1 present` ) }
+            ( vec_free [f] q4exp )
+
+            // t_q8_0: 0.5*k, last = -28
+            : i tq8 ( gguf_find_tensor g `t_q8_0` )
+            ? >= tq8 0 {
+                : !( Vec f ) String dr ( gguf_dequant_f64 g tq8 )
+                ?? dr {
+                    T got → {
+                        : ( Vec f ) q8exp ( vec_new [f] )
+                        = k 0
+                        ~ < k 31 {
+                            ( vec_push [f] q8exp * 0.5 # f k )
+                            = k + k 1
+                        }
+                        ( vec_push [f] q8exp -28.0 )
+                        ( __st_ck cn ( __st_vec_eq got ( vec_data [f] q8exp ) 32 ) `t_q8_0 dequant (incl. negative q)` )
+                        ( vec_free [f] q8exp )
+                        ( vec_free [f] got )
+                    }
+                    F e → {
+                        ( string_free e )
+                        ( __st_ck cn F `t_q8_0 dequant` )
+                    }
+                }
+            } { ( __st_ck cn F `t_q8_0 present` ) }
+
+            // unknown tensor / bad index are clean errors
+            ( __st_ck cn < ( gguf_find_tensor g `no_such_tensor` ) 0 `absent tensor → -1` )
+            : !( Vec u ) String bad ( gguf_dequant g 99 )
+            ?? bad {
+                T got2 → {
+                    ( vec_free [u] got2 )
+                    ( __st_ck cn F `out-of-range dequant must fail` )
+                }
+                F e → {
+                    ( string_free e )
+                    ( __st_ck cn T `out-of-range dequant fails cleanly` )
+                }
+            }
+            ( gguf_close g )
+        }
+        F e → {
+            ( nurl_eprintln ( string_data e ) )
+            ( string_free e )
+            = rc 1
+        }
+    }
+
+    // second path: parse the same image from an in-memory buffer
+    ? == rc 0 {
+        : !( Vec u ) IoErr br ( read_file_bytes ( string_data path ) )
+        ?? br {
+            T img → {
+                : !*Gguf String pr ( gguf_parse_bytes img )
+                ?? pr {
+                    T g → {
+                        ( __st_ck cn == ( gguf_n_tensors g ) 6 `parse_bytes sees the same tensors` )
+                        ( gguf_close g )
+                    }
+                    F e → {
+                        ( string_free e )
+                        ( __st_ck cn F `parse_bytes` )
+                    }
+                }
+                // corrupt the magic in memory → must fail
+                ( vec_set [u] img 0 # u 88 )
+                : !*Gguf String cr ( gguf_parse_bytes img )
+                ?? cr {
+                    T g → {
+                        ( gguf_close g )
+                        ( __st_ck cn F `bad magic must be rejected` )
+                    }
+                    F e → {
+                        ( string_free e )
+                        ( __st_ck cn T `bad magic rejected` )
+                    }
+                }
+                ( vec_free [u] img )
+            }
+            F _ → { ( __st_ck cn F `re-read sample file` ) }
+        }
+        // tiny buffer → clean error
+        : ( Vec u ) tiny ( vec_new [u] )
+        ( vec_push [u] tiny # u 71 )
+        ( vec_push [u] tiny # u 71 )
+        : !*Gguf String tr ( gguf_parse_bytes tiny )
+        ?? tr {
+            T g → {
+                ( gguf_close g )
+                ( __st_ck cn F `truncated buffer must be rejected` )
+            }
+            F e → {
+                ( string_free e )
+                ( __st_ck cn T `truncated buffer rejected` )
+            }
+        }
+        ( vec_free [u] tiny )
+    } {}
+
+    ( file_delete ( string_data path ) )
+    ( string_free path )
+    ? != rc 0 { ^ rc } {}
+    : String m ( string_from `selftest: ` )
+    ( string_push_int m . cn pass )
+    ( string_push_str m ` passed, ` )
+    ( string_push_int m . cn fail )
+    ( string_push_str m ` failed` )
+    ( __gg_print_owned m )
+    ^ ? > . cn fail 0 1 0
+}
+
+// String vs raw-literal equality (helper for selftest)
+@ string_eq_raw String a s raw → b {
+    ^ ? ( nurl_str_eq ( string_data a ) raw ) T F
+}
+
+@ main → i {
+    : ArgParser p ( args_new `gguf` `Inspect, verify and export GGUF model containers (parser treats every file as untrusted input).` )
+    ( args_opt p `output` 111 `FILE` `for export: write the f32-LE tensor here` )
+    ( args_flag p `help` 104 `show this help` )
+    ( args_flag p `version` 0 `print the version` )
+    ? ( args_parse_argv p ) {} {
+        ( nurl_eprintln ( args_error p ) )
+        ( args_free p )
+        ^ 2
+    }
+    ? ( args_present p `help` ) {
+        : String u ( args_usage p )
+        ( nurl_print ( string_data u ) )
+        ( nurl_print `\ncommands:\n  info <file> · dump <file> · kv <file> <key> · tensors <file>\n  verify <file> · export <file> <tensor> -o out.f32\n  gen <out.gguf> · selftest\n` )
+        ( string_free u )
+        ( args_free p )
+        ^ 0
+    } {}
+    ? ( args_present p `version` ) {
+        ( nurl_print `gguf 0.1.0\n` )
+        ( args_free p )
+        ^ 0
+    } {}
+    ? < ( args_positional_count p ) 1 {
+        ( nurl_eprintln `usage: gguf <info|dump|kv|tensors|verify|export|gen|selftest> … (gguf --help)` )
+        ( args_free p )
+        ^ 2
+    } {}
+    : ( Vec String ) pos ( args_positionals p )
+    : ~ s cmd ``
+    ?? ( vec_get [String] pos 0 ) {
+        T c → { = cmd ( string_data c ) }
+        F → {}
+    }
+    : ~ String a1 ( string_new )
+    ? >= ( args_positional_count p ) 2 {
+        ?? ( vec_get [String] pos 1 ) {
+            T v2 → {
+                ( string_free a1 )
+                = a1 ( string_from ( string_data v2 ) )
+            }
+            F → {}
+        }
+    } {}
+    : ~ String a2 ( string_new )
+    ? >= ( args_positional_count p ) 3 {
+        ?? ( vec_get [String] pos 2 ) {
+            T v2 → {
+                ( string_free a2 )
+                = a2 ( string_from ( string_data v2 ) )
+            }
+            F → {}
+        }
+    } {}
+
+    ? ( nurl_str_eq cmd `selftest` ) {
+        : i rc ( __st_run )
+        ( string_free a1 )
+        ( string_free a2 )
+        ( args_free p )
+        ^ rc
+    } {}
+
+    ? ( nurl_str_eq cmd `gen` ) {
+        ? == ( string_len a1 ) 0 {
+            ( string_free a1 )
+            ( string_free a2 )
+            ( args_free p )
+            ^ ( __gg_err ( string_from `gguf: gen needs an output path` ) )
+        } {}
+        : *GgufW w ( __st_build )
+        : !v String wr ( gw_write w ( string_data a1 ) )
+        ( gw_free w )
+        : ~ i rc 0
+        ?? wr {
+            T _ → {}
+            F e → { = rc ( __gg_err e ) }
+        }
+        ( string_free a1 )
+        ( string_free a2 )
+        ( args_free p )
+        ^ rc
+    } {}
+
+    // every remaining command opens a file first
+    ? == ( string_len a1 ) 0 {
+        ( string_free a1 )
+        ( string_free a2 )
+        ( args_free p )
+        ^ ( __gg_err ( string_from `gguf: this command needs a file argument (gguf --help)` ) )
+    } {}
+    : !*Gguf String orr ( gguf_open ( string_data a1 ) )
+    : ~ i rc 0
+    ?? orr {
+        T g → {
+            ? ( nurl_str_eq cmd `info` ) {
+                ( __gg_info g )
+            } {
+                ? ( nurl_str_eq cmd `dump` ) {
+                    ( __gg_cmd_dump g )
+                } {
+                    ? ( nurl_str_eq cmd `tensors` ) {
+                        : ~ i k 0
+                        ~ < k ( gguf_n_tensors g ) {
+                            ?? ( vec_get [GgufTensor] . g tensors k ) {
+                                T t → { ( __gg_print_owned ( __gg_fmt_tensor t ) ) }
+                                F → {}
+                            }
+                            = k + k 1
+                        }
+                    } {
+                        ? ( nurl_str_eq cmd `verify` ) {
+                            = rc ( __gg_cmd_verify g )
+                        } {
+                            ? ( nurl_str_eq cmd `kv` ) {
+                                : i idx ( gguf_find_kv g ( string_data a2 ) )
+                                ? < idx 0 {
+                                    = rc ( __gg_err ( string_from `gguf: no such metadata key` ) )
+                                } {
+                                    ?? ( vec_get [GgufKv] . g kvs idx ) {
+                                        T a → { ( __gg_print_owned ( __gg_fmt_kv a ) ) }
+                                        F → {}
+                                    }
+                                }
+                            } {
+                                ? ( nurl_str_eq cmd `export` ) {
+                                    : i idx ( gguf_find_tensor g ( string_data a2 ) )
+                                    ? < idx 0 {
+                                        = rc ( __gg_err ( string_from `gguf: no such tensor` ) )
+                                    } {
+                                        : !( Vec u ) String dr ( gguf_dequant g idx )
+                                        ?? dr {
+                                            T raw → {
+                                                : ?String oo ( args_value p `output` )
+                                                ?? oo {
+                                                    T out → {
+                                                        : !v IoErr wr2 ( write_file_bytes ( string_data out ) raw )
+                                                        ?? wr2 {
+                                                            T _ → {
+                                                                : String m ( string_from `wrote ` )
+                                                                ( string_push_int m ( vec_len [u] raw ) )
+                                                                ( string_push_str m ` bytes of f32-LE` )
+                                                                ( __gg_print_owned m )
+                                                            }
+                                                            F _ → { = rc ( __gg_err ( string_from `gguf: cannot write the output file` ) ) }
+                                                        }
+                                                        ( string_free out )
+                                                    }
+                                                    F → { = rc ( __gg_err ( string_from `gguf: export needs -o FILE` ) ) }
+                                                }
+                                                ( vec_free [u] raw )
+                                            }
+                                            F e → { = rc ( __gg_err e ) }
+                                        }
+                                    }
+                                } {
+                                    ( nurl_eprintln `gguf: unknown command (gguf --help)` )
+                                    = rc 2
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            ( gguf_close g )
+        }
+        F e → { = rc ( __gg_err e ) }
+    }
+    ( string_free a1 )
+    ( string_free a2 )
+    ( args_free p )
+    ^ rc
+}

--- a/packages/gguf/src/write.nu
+++ b/packages/gguf/src/write.nu
@@ -1,0 +1,292 @@
+// packages/gguf/src/write.nu — a GGUF v3 writer/builder.
+//
+// The reader's round-trip partner: build typed metadata and tensors in
+// memory, then serialise a spec-exact GGUF v3 image. Powers the test
+// suite (write → parse → compare, bit for bit) and gives the ecosystem
+// an export path (tensor snapshots, converted models, fixtures).
+//
+//   ( gw_new align )                       → !*GgufW String
+//   ( gw_kv_u32 w key v )  ( gw_kv_i32 … ) ( gw_kv_u64 … )
+//   ( gw_kv_f32 w key x )  ( gw_kv_f64 … ) ( gw_kv_bool … )
+//   ( gw_kv_str w key val )
+//   ( gw_kv_arr_i32 w key vals )           — ( Vec i ),   borrowed
+//   ( gw_kv_arr_f32 w key vals )           — ( Vec f ),   borrowed
+//   ( gw_kv_arr_str w key vals )           — ( Vec String ), borrowed
+//   ( gw_tensor w name gt nd d0 d1 d2 d3 bytes ) → !v String
+//   ( gw_finish w )                        → ( Vec u )   the file image
+//   ( gw_write w path )                    → !v String
+//   ( gw_free w )
+//
+// gw_new emits `general.alignment` itself (so the image is
+// self-describing) — callers must not add that key again.
+// gw_tensor validates the payload length against the declared
+// type/dims and pads the data section to the alignment, exactly as
+// the parser will demand on the way back in.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/floatbits.nu`
+$ `gguf.nu`
+
+: GgufW {
+    i align
+    i n_kv
+    ( Vec u ) kvb
+    ( Vec String ) tnames
+    ( Vec i ) ttype
+    ( Vec i ) tnd
+    ( Vec i ) td0
+    ( Vec i ) td1
+    ( Vec i ) td2
+    ( Vec i ) td3
+    ( Vec i ) toff
+    ( Vec u ) data
+}
+
+// length-prefixed GGUF string: u64 LE length + raw bytes (no NUL)
+@ __gw_pstr ( Vec u ) b s raw → v {
+    ( bytes_push_u64_le b # u64 ( nurl_str_len raw ) )
+    ( bytes_extend_str b raw )
+}
+
+@ __gw_key ( Vec u ) b s key i vt → v {
+    ( __gw_pstr b key )
+    ( bytes_push_u32_le b # u32 vt )
+}
+
+@ gw_new i align → !*GgufW String {
+    ? | | < align 1 > align 1048576 != & align - align 1 0 {
+        ^ @ !*GgufW String { F ( string_from `gguf: writer alignment must be a power of two, 1..1048576` ) }
+    } {}
+    : *GgufW w # *GgufW ( nurl_alloc Z GgufW )
+    = . w align align
+    = . w n_kv 0
+    = . w kvb ( vec_new [u] )
+    = . w tnames ( vec_new [String] )
+    = . w ttype ( vec_new [i] )
+    = . w tnd ( vec_new [i] )
+    = . w td0 ( vec_new [i] )
+    = . w td1 ( vec_new [i] )
+    = . w td2 ( vec_new [i] )
+    = . w td3 ( vec_new [i] )
+    = . w toff ( vec_new [i] )
+    = . w data ( vec_new [u] )
+    ( gw_kv_u32 w `general.alignment` align )
+    ^ @ !*GgufW String { T w }
+}
+
+@ gw_kv_u32 * GgufW w s key i v → v {
+    ( __gw_key . w kvb key 4 )
+    ( bytes_push_u32_le . w kvb # u32 v )
+    = . w n_kv + . w n_kv 1
+}
+
+@ gw_kv_i32 * GgufW w s key i v → v {
+    ( __gw_key . w kvb key 5 )
+    ( bytes_push_u32_le . w kvb # u32 & v 4294967295 )
+    = . w n_kv + . w n_kv 1
+}
+
+@ gw_kv_u64 * GgufW w s key i v → v {
+    ( __gw_key . w kvb key 10 )
+    ( bytes_push_u64_le . w kvb # u64 v )
+    = . w n_kv + . w n_kv 1
+}
+
+@ gw_kv_i64 * GgufW w s key i v → v {
+    ( __gw_key . w kvb key 11 )
+    ( bytes_push_u64_le . w kvb # u64 v )
+    = . w n_kv + . w n_kv 1
+}
+
+@ gw_kv_f32 * GgufW w s key f x → v {
+    ( __gw_key . w kvb key 6 )
+    ( bytes_push_u32_le . w kvb # u32 ( f32_to_bits # f32 x ) )
+    = . w n_kv + . w n_kv 1
+}
+
+@ gw_kv_f64 * GgufW w s key f x → v {
+    ( __gw_key . w kvb key 12 )
+    ( bytes_push_u64_le . w kvb # u64 ( f64_to_bits x ) )
+    = . w n_kv + . w n_kv 1
+}
+
+@ gw_kv_bool * GgufW w s key b v → v {
+    ( __gw_key . w kvb key 7 )
+    ( vec_push [u] . w kvb # u ? v 1 0 )
+    = . w n_kv + . w n_kv 1
+}
+
+@ gw_kv_str * GgufW w s key s val → v {
+    ( __gw_key . w kvb key 8 )
+    ( __gw_pstr . w kvb val )
+    = . w n_kv + . w n_kv 1
+}
+
+@ gw_kv_arr_i32 * GgufW w s key ( Vec i ) vals → v {
+    ( __gw_key . w kvb key 9 )
+    ( bytes_push_u32_le . w kvb # u32 5 )
+    ( bytes_push_u64_le . w kvb # u64 ( vec_len [i] vals ) )
+    : ~ i k 0
+    ~ < k ( vec_len [i] vals ) {
+        ?? ( vec_get [i] vals k ) {
+            T v → { ( bytes_push_u32_le . w kvb # u32 & v 4294967295 ) }
+            F → {}
+        }
+        = k + k 1
+    }
+    = . w n_kv + . w n_kv 1
+}
+
+@ gw_kv_arr_f32 * GgufW w s key ( Vec f ) vals → v {
+    ( __gw_key . w kvb key 9 )
+    ( bytes_push_u32_le . w kvb # u32 6 )
+    ( bytes_push_u64_le . w kvb # u64 ( vec_len [f] vals ) )
+    : ~ i k 0
+    ~ < k ( vec_len [f] vals ) {
+        ?? ( vec_get [f] vals k ) {
+            T v → { ( bytes_push_u32_le . w kvb # u32 ( f32_to_bits # f32 v ) ) }
+            F → {}
+        }
+        = k + k 1
+    }
+    = . w n_kv + . w n_kv 1
+}
+
+@ gw_kv_arr_str * GgufW w s key ( Vec String ) vals → v {
+    ( __gw_key . w kvb key 9 )
+    ( bytes_push_u32_le . w kvb # u32 8 )
+    ( bytes_push_u64_le . w kvb # u64 ( vec_len [String] vals ) )
+    : ~ i k 0
+    ~ < k ( vec_len [String] vals ) {
+        ?? ( vec_get [String] vals k ) {
+            T v → { ( __gw_pstr . w kvb ( string_data v ) ) }
+            F → {}
+        }
+        = k + k 1
+    }
+    = . w n_kv + . w n_kv 1
+}
+
+// Add a tensor: validates the declared shape against the payload size
+// with the same rules the parser enforces, aligns the data section,
+// and records the entry. Unused trailing dims pass 1.
+@ gw_tensor * GgufW w s name i gt i nd i d0 i d1 i d2 i d3 ( Vec u ) bytes → !v String {
+    ? | < nd 1 > nd 4 {
+        ^ @ !v String { F ( string_from `gguf: tensor n_dims must be 1..4` ) }
+    } {}
+    ? | | | < d0 1 < d1 1 < d2 1 < d3 1 {
+        ^ @ !v String { F ( string_from `gguf: tensor dims must be ≥ 1` ) }
+    } {}
+    : i blk ( gguf_type_blck gt )
+    ? == blk 0 {
+        ^ @ !v String { F ( string_from `gguf: writer cannot size this tensor type` ) }
+    } {}
+    ? != % d0 blk 0 {
+        ^ @ !v String { F ( string_from `gguf: dim0 must be a multiple of the type's block size` ) }
+    } {}
+    : i ne * * * d0 d1 d2 d3
+    : i nb * / ne blk ( gguf_type_size gt )
+    ? != nb ( vec_len [u] bytes ) {
+        : String m ( string_from `gguf: tensor payload is ` )
+        ( string_push_int m ( vec_len [u] bytes ) )
+        ( string_push_str m ` bytes but the declared shape needs ` )
+        ( string_push_int m nb )
+        ^ @ !v String { F m }
+    } {}
+    : ~ i k 0
+    : ~ b dup F
+    ~ < k ( vec_len [String] . w tnames ) {
+        ?? ( vec_get [String] . w tnames k ) {
+            T t → { ? ( nurl_str_eq ( string_data t ) name ) { = dup T } {} }
+            F → {}
+        }
+        = k + k 1
+    }
+    ? dup {
+        ^ @ !v String { F ( string_from `gguf: duplicate tensor name in writer` ) }
+    } {}
+    // pad data to alignment, then append
+    ~ != % ( vec_len [u] . w data ) . w align 0 {
+        ( vec_push [u] . w data # u 0 )
+    }
+    ( vec_push [i] . w toff ( vec_len [u] . w data ) )
+    ( vec_extend [u] . w data bytes )
+    ( vec_push [String] . w tnames ( string_from name ) )
+    ( vec_push [i] . w ttype gt )
+    ( vec_push [i] . w tnd nd )
+    ( vec_push [i] . w td0 d0 )
+    ( vec_push [i] . w td1 d1 )
+    ( vec_push [i] . w td2 d2 )
+    ( vec_push [i] . w td3 d3 )
+    ^ @ !v String { T 0 }
+}
+
+@ __gw_geti ( Vec i ) v i k → i {
+    ?? ( vec_get [i] v k ) { T x → { ^ x } F → { ^ 0 } }
+}
+
+// Serialise the complete GGUF v3 image.
+@ gw_finish * GgufW w → ( Vec u ) {
+    : i nt ( vec_len [String] . w tnames )
+    : ( Vec u ) out ( vec_new [u] )
+    ( vec_push [u] out # u 71 )
+    ( vec_push [u] out # u 71 )
+    ( vec_push [u] out # u 85 )
+    ( vec_push [u] out # u 70 )
+    ( bytes_push_u32_le out # u32 3 )
+    ( bytes_push_u64_le out # u64 nt )
+    ( bytes_push_u64_le out # u64 . w n_kv )
+    ( vec_extend [u] out . w kvb )
+    : ~ i k 0
+    ~ < k nt {
+        ?? ( vec_get [String] . w tnames k ) {
+            T t → { ( __gw_pstr out ( string_data t ) ) }
+            F → {}
+        }
+        : i nd ( __gw_geti . w tnd k )
+        ( bytes_push_u32_le out # u32 nd )
+        ( bytes_push_u64_le out # u64 ( __gw_geti . w td0 k ) )
+        ? >= nd 2 { ( bytes_push_u64_le out # u64 ( __gw_geti . w td1 k ) ) } {}
+        ? >= nd 3 { ( bytes_push_u64_le out # u64 ( __gw_geti . w td2 k ) ) } {}
+        ? >= nd 4 { ( bytes_push_u64_le out # u64 ( __gw_geti . w td3 k ) ) } {}
+        ( bytes_push_u32_le out # u32 ( __gw_geti . w ttype k ) )
+        ( bytes_push_u64_le out # u64 ( __gw_geti . w toff k ) )
+        = k + k 1
+    }
+    ~ != % ( vec_len [u] out ) . w align 0 {
+        ( vec_push [u] out # u 0 )
+    }
+    ( vec_extend [u] out . w data )
+    ^ out
+}
+
+@ gw_write * GgufW w s path → !v String {
+    : ( Vec u ) img ( gw_finish w )
+    : !v IoErr r ( write_file_bytes path img )
+    ( vec_free [u] img )
+    ?? r {
+        T _ → { ^ @ !v String { T 0 } }
+        F _ → {
+            : String m ( string_from `gguf: cannot write ` )
+            ( string_push_str m path )
+            ^ @ !v String { F m }
+        }
+    }
+}
+
+@ gw_free * GgufW w → v {
+    ( vec_free [u] . w kvb )
+    ( vec_free_with [String] . w tnames \ String s → v { ( string_free s ) } )
+    ( vec_free [i] . w ttype )
+    ( vec_free [i] . w tnd )
+    ( vec_free [i] . w td0 )
+    ( vec_free [i] . w td1 )
+    ( vec_free [i] . w td2 )
+    ( vec_free [i] . w td3 )
+    ( vec_free [i] . w toff )
+    ( vec_free [u] . w data )
+    ( nurl_free # s w )
+}

--- a/packages/gguf/tests/gguf_test.sh
+++ b/packages/gguf/tests/gguf_test.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tests/gguf_test.sh — end-to-end proof of the gguf package:
+#    1. selftest: write → parse → compare, bit-exact (f16 subnormal/
+#       inf/NaN/-0, Q4_0/Q4_1/Q8_0 quant blocks, every KV type)
+#    2. CLI surface: gen / info / dump / kv / tensors / verify / export
+#    3. THE POINT — a corruption battery: truncations, bad magic,
+#       hostile counts, absurd lengths. Every one must produce a clean
+#       `gguf:` error, never a crash (exit 139), a hang (timeout 5) or
+#       a wrong answer.
+#    4. Independence: a golden file crafted by python struct-packing
+#       (no shared code with the NURL writer) parses to the expected
+#       values, and python-crafted attack files (v1, nested arrays,
+#       duplicate names, out-of-bounds offsets, alignment 3, zero dims)
+#       are all rejected.
+#
+#  Run from the package dir:  ./tests/gguf_test.sh
+#  Env: NURL (build driver; defaults to ../../nurl.sh in a checkout)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t gguf-test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+
+echo "[1/4] build gguf"
+if ! $NURL src/main.nu "$WORK/gguf" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build gguf:"; tail -5 "$WORK/build.err"; exit 1
+fi
+GGUF="$WORK/gguf"
+
+# A parse attempt must fail CLEANLY: exit 1/2, a `gguf:` message on
+# stderr, no crash (139 = SIGSEGV, 134 = SIGABRT), no hang (124).
+expect_reject() { # <label> <file> [cmd]
+    local label="$1" file="$2" cmd="${3:-info}"
+    local out rc
+    out=$(timeout 5 "$GGUF" "$cmd" "$file" 2>&1); rc=$?
+    if [ "$rc" -ge 1 ] && [ "$rc" -le 2 ] && printf '%s' "$out" | grep -q "gguf:"; then
+        ok "$label"
+    else
+        bad "$label (rc=$rc, out=$(printf '%s' "$out" | head -1))"
+    fi
+}
+
+echo "[2/4] selftest + CLI surface"
+if timeout 60 "$GGUF" selftest | grep -q " 0 failed"; then ok "selftest bit-exact"; else bad "selftest"; fi
+
+S="$WORK/sample.gguf"
+"$GGUF" gen "$S" || bad "gen"
+"$GGUF" info "$S" | grep -q "GGUF v3 — 14 kv, 6 tensors, align 32" && ok "info summary" || bad "info"
+"$GGUF" dump "$S" > "$WORK/dump.txt" || bad "dump rc"
+grep -q "selftest.i32 = i32 -12345" "$WORK/dump.txt" && ok "dump i32" || bad "dump i32"
+grep -q "selftest.u64 = u64 8589934592" "$WORK/dump.txt" && ok "dump u64 > 32 bit" || bad "dump u64"
+grep -q "selftest.arr_str = \[str x 3\] alpha beta gamma" "$WORK/dump.txt" && ok "dump str array" || bad "dump arr_str"
+grep -q "t_q8_0 .*Q8_0 \[32\] 34 B @ 160" "$WORK/dump.txt" && ok "dump tensor row" || bad "dump tensor row"
+"$GGUF" kv "$S" selftest.f32 | grep -q "f32 1.5" && ok "kv lookup" || bad "kv lookup"
+"$GGUF" kv "$S" no.such.key >/dev/null 2>&1 && bad "kv missing key rc" || ok "kv missing key rejects"
+[ "$("$GGUF" tensors "$S" | wc -l)" = 6 ] && ok "tensors lists 6" || bad "tensors count"
+"$GGUF" verify "$S" | grep -q "^OK — GGUF v3, 14 kv, 6 tensors, all offsets aligned" && ok "verify clean file" || bad "verify"
+
+"$GGUF" export "$S" t_f32 -o "$WORK/t.f32" | grep -q "wrote 32 bytes" && ok "export t_f32" || bad "export"
+[ "$(stat -c %s "$WORK/t.f32")" = 32 ] && ok "export size" || bad "export size"
+"$GGUF" export "$S" nope -o "$WORK/x" >/dev/null 2>&1 && bad "export missing tensor rc" || ok "export missing tensor rejects"
+
+echo "[3/4] corruption battery"
+# not a gguf at all
+printf 'hello world, definitely not a model' > "$WORK/junk.bin"
+expect_reject "random bytes rejected" "$WORK/junk.bin"
+: > "$WORK/empty.bin"
+expect_reject "empty file rejected" "$WORK/empty.bin"
+
+# truncations at every structural boundary
+for n in 3 10 23 24 30 60 100; do
+    head -c "$n" "$S" > "$WORK/trunc$n.gguf"
+    expect_reject "truncated to $n bytes rejected" "$WORK/trunc$n.gguf"
+done
+SZ=$(stat -c %s "$S")
+head -c $((SZ - 20)) "$S" > "$WORK/trunc-data.gguf"
+expect_reject "data section truncated rejected" "$WORK/trunc-data.gguf"
+
+corrupt() { # <src> <dst> <offset> <hexbytes…>
+    local src="$1" dst="$2" off="$3"; shift 3
+    cp "$src" "$dst"
+    printf "$(printf '\\x%s' "$@")" | dd of="$dst" bs=1 seek="$off" conv=notrunc 2>/dev/null
+}
+
+corrupt "$S" "$WORK/magic.gguf" 0 58
+expect_reject "flipped magic rejected" "$WORK/magic.gguf"
+corrupt "$S" "$WORK/v1.gguf" 4 01 00 00 00
+expect_reject "version 1 rejected" "$WORK/v1.gguf"
+corrupt "$S" "$WORK/v99.gguf" 4 63 00 00 00
+expect_reject "version 99 rejected" "$WORK/v99.gguf"
+# hostile counts: n_tensors / n_kv = 2^63-ish and u64-max — the parser
+# must fail fast on the count sanity bound, not allocate or spin
+corrupt "$S" "$WORK/tens-huge.gguf" 8 ff ff ff ff ff ff ff 7f
+expect_reject "absurd tensor count rejected" "$WORK/tens-huge.gguf"
+corrupt "$S" "$WORK/tens-neg.gguf" 8 ff ff ff ff ff ff ff ff
+expect_reject "tensor count ≥ 2^63 rejected" "$WORK/tens-neg.gguf"
+corrupt "$S" "$WORK/kv-huge.gguf" 16 ff ff ff ff ff ff ff 7f
+expect_reject "absurd kv count rejected" "$WORK/kv-huge.gguf"
+# first key length (offset 24) → absurd / ≥ 2^63
+corrupt "$S" "$WORK/key-huge.gguf" 24 ff ff ff ff ff ff ff 7f
+expect_reject "absurd string length rejected" "$WORK/key-huge.gguf"
+corrupt "$S" "$WORK/key-neg.gguf" 24 ff ff ff ff ff ff ff ff
+expect_reject "string length ≥ 2^63 rejected" "$WORK/key-neg.gguf"
+# embedded NUL in a key
+corrupt "$S" "$WORK/key-nul.gguf" 32 00
+expect_reject "NUL in key rejected" "$WORK/key-nul.gguf"
+
+echo "[4/4] python-crafted independence + attack files"
+if command -v python3 >/dev/null 2>&1; then
+    python3 - "$WORK" <<'PYEOF'
+import struct, sys, os
+W = sys.argv[1]
+def s(x):
+    b = x.encode(); return struct.pack('<Q', len(b)) + b
+def kv_str(k, v):  return s(k) + struct.pack('<I', 8) + s(v)
+def kv_u32(k, v):  return s(k) + struct.pack('<I', 4) + struct.pack('<I', v)
+def tinfo(name, dims, typ, off):
+    b = s(name) + struct.pack('<I', len(dims))
+    for d in dims: b += struct.pack('<Q', d)
+    return b + struct.pack('<I', typ) + struct.pack('<Q', off)
+def build(path, version=3, kvs=b'', nkv=0, tis=b'', nt=0, data=b'', align=32):
+    hdr = b'GGUF' + struct.pack('<I', version) + struct.pack('<Q', nt) + struct.pack('<Q', nkv)
+    meta = hdr + kvs + tis
+    pad = (-len(meta)) % align
+    open(os.path.join(W, path), 'wb').write(meta + b'\0'*pad + data)
+
+f32 = struct.pack('<ff', 1.0, -2.0)
+# golden: one str kv + one F32 [2] tensor, written by python not NURL
+build('py-good.gguf', kvs=kv_str('general.architecture', 'pygold'), nkv=1,
+      tis=tinfo('w', [2], 0, 0), nt=1, data=f32)
+# attack files
+build('py-v1.gguf', version=1, kvs=kv_str('a', 'b'), nkv=1)
+nested = s('bad') + struct.pack('<I', 9) + struct.pack('<I', 9) + struct.pack('<Q', 1)
+build('py-nested.gguf', kvs=nested, nkv=1)
+build('py-dupkey.gguf', kvs=kv_str('k', 'a') + kv_str('k', 'b'), nkv=2)
+build('py-dupt.gguf', tis=tinfo('w', [2], 0, 0) + tinfo('w', [2], 0, 32), nt=2,
+      data=f32 + b'\0'*24 + f32)
+build('py-oob.gguf', tis=tinfo('w', [2], 0, 1024), nt=1, data=f32)
+build('py-unaligned.gguf', tis=tinfo('w', [2], 0, 4), nt=1, data=b'\0'*4 + f32)
+build('py-align3.gguf', kvs=kv_u32('general.alignment', 3), nkv=1)
+build('py-dim0.gguf', tis=tinfo('w', [0], 0, 0), nt=1, data=b'')
+build('py-5dim.gguf', tis=tinfo('w', [2,1,1,1,1], 0, 0), nt=1, data=f32)
+build('py-blk.gguf', tis=tinfo('w', [30], 2, 0), nt=1, data=b'\0'*18)  # 30 % 32 != 0
+build('py-unknown.gguf', tis=tinfo('w', [2], 200, 0), nt=1, data=f32)
+# dims that overflow i64 when multiplied
+big = 2**47
+build('py-ovf.gguf', tis=tinfo('w', [big, big, big, 2], 0, 0), nt=1, data=f32)
+PYEOF
+    "$GGUF" dump "$WORK/py-good.gguf" > "$WORK/pydump.txt" 2>&1 \
+        && grep -q "general.architecture = str pygold" "$WORK/pydump.txt" \
+        && grep -q "w .*F32 \[2\] 8 B @ 0" "$WORK/pydump.txt" \
+        && ok "python golden parses to expected values" || bad "python golden"
+    "$GGUF" export "$WORK/py-good.gguf" w -o "$WORK/py-w.f32" >/dev/null \
+        && cmp -s <(tail -c 8 "$WORK/py-good.gguf") "$WORK/py-w.f32" \
+        && ok "python golden export byte-identical" || bad "python golden export"
+    expect_reject "py: version 1 rejected"            "$WORK/py-v1.gguf"
+    expect_reject "py: nested array rejected"         "$WORK/py-nested.gguf"
+    expect_reject "py: duplicate kv key rejected"     "$WORK/py-dupkey.gguf"
+    expect_reject "py: duplicate tensor name rejected" "$WORK/py-dupt.gguf"
+    expect_reject "py: out-of-bounds tensor rejected" "$WORK/py-oob.gguf"
+    expect_reject "py: unaligned tensor rejected"     "$WORK/py-unaligned.gguf"
+    expect_reject "py: alignment 3 rejected"          "$WORK/py-align3.gguf"
+    expect_reject "py: zero dimension rejected"       "$WORK/py-dim0.gguf"
+    expect_reject "py: 5 dimensions rejected"         "$WORK/py-5dim.gguf"
+    expect_reject "py: dim0 not block-multiple rejected" "$WORK/py-blk.gguf"
+    expect_reject "py: dim overflow rejected"         "$WORK/py-ovf.gguf"
+    # unknown tensor type: listed, verifiable, but not exportable
+    "$GGUF" dump "$WORK/py-unknown.gguf" | grep -q "unknown(200)" \
+        && ok "py: unknown type listed as unknown(200)" || bad "py: unknown type dump"
+    "$GGUF" verify "$WORK/py-unknown.gguf" | grep -q "1 of unknown type not size-checked" \
+        && ok "py: verify notes the unsized tensor" || bad "py: verify unknown"
+    out=$(timeout 5 "$GGUF" export "$WORK/py-unknown.gguf" w -o "$WORK/x.f32" 2>&1)
+    [ $? -ne 0 ] && printf '%s' "$out" | grep -q "gguf:" \
+        && ok "py: unknown type export fails cleanly" || bad "py: unknown export"
+else
+    echo "  SKIP python3 not found — independence battery skipped"
+fi
+
+if [ "${NURL_NET_TESTS:-0}" = 1 ] && command -v curl >/dev/null 2>&1; then
+    echo "[net] real llama.cpp model from HuggingFace"
+    M="$WORK/stories260K.gguf"
+    if curl -sL --max-time 120 -f -o "$M" \
+        https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf; then
+        "$GGUF" info "$M" | grep -q "arch llama" && ok "net: real model parses" || bad "net: real model info"
+        "$GGUF" verify "$M" | grep -q "^OK — " && ok "net: real model verifies" || bad "net: real model verify"
+        "$GGUF" kv "$M" tokenizer.ggml.tokens | grep -q "\[str x 512\]" && ok "net: vocab array" || bad "net: vocab array"
+    else
+        echo "  SKIP download failed"
+    fi
+fi
+
+echo "== gguf tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" = 0 ]


### PR DESCRIPTION
## What

New package `packages/gguf`: pure-NURL GGUF v2/v3 **parser, writer and dequantiser** for the ggml-ecosystem tensor format (llama.cpp, whisper.cpp, stable-diffusion.cpp). No dependencies beyond the stdlib (fs/mmap/floatbits) — deliberately no gpu dependency, so it stays reusable by tensor/swarm/future model tooling. Foundation package for nurllama.

- `src/gguf.nu` — mmap-backed hostile-input parser. Every count/length/offset validated against the **real file size before any allocation or read depends on it**; allocations proportional to bytes actually consumed, never to header claims. All 13 metadata value types (incl. vocab arrays), full tensor table; tensor bytes addressed lazily out of the mapping — inspecting a multi-GB model costs no RAM. wasm/win32 fall back to a whole-file buffer.
- `src/dequant.nu` — host scalar dequant F32/F64/F16/BF16/Q4_0/Q4_1/Q8_0 → upload-ready f32-LE. F16 is a pure bit transport (subnormals, ±inf, NaN, −0 exact). CPU decode path **and** golden oracle for future GPU dequant kernels.
- `src/write.nu` — spec-exact GGUF v3 writer/builder (round-trip partner + export path).
- `src/main.nu` — CLI: `info / dump / kv / tensors / verify / export / gen / selftest`.

## Proof

- `gguf selftest`: 37 bit-exact checks (write → parse → compare; f16 edge table, Q4_0/Q4_1/Q8_0 blocks incl. negative quants, every KV type).
- `tests/gguf_test.sh`: **51/51** — corruption battery (truncations at every structural boundary, hostile counts up to 2⁶³, absurd string lengths, NUL-smuggling keys) and independently **python-crafted attack files** (v1, nested arrays, duplicate keys/names, OOB/unaligned offsets, dim overflow) all rejected cleanly under a `timeout` hang-watchdog; a python-crafted golden file parses and exports byte-identically. `NURL_NET_TESTS=1` adds a real llama.cpp model pulled from HF.
- **ASan/UBSan/LSan zero findings** on every path, including the corruption battery and real quantised models.
- Real models: `stories260K` (F32) and `stories15M-q4_0` (Q4_0+Q8_0 mix) — info/verify/dump/export OK; Q4_0 dequant proven **bit-identical** against an independent python decode of the raw model bytes.

## Side find

Owned slice literals inside `?`/`??` arms are never dropped (memory-model rule 5 violation; minimal repro filed in the local backlog §8). Worked around here by hoisting the literals to function scope — compiler fix + leak regression to follow separately.

Package tests are not wired into compiler CI, per the M6 won't-do decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)