### PR TITLE
nurlc: drop arm-local owned slices at fall-through (memory-model rule 5)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,7 +103,19 @@ if (( SAN == 1 )); then
     # exit-1-on-detect. run_san_tests.sh re-enables leak detection on
     # demand via LSAN_DETECT_LEAKS=1 for the test corpus, where the
     # release-and-cleanup discipline is meaningfully different.
-    export ASAN_OPTIONS="detect_leaks=0:abort_on_error=0:halt_on_error=0:print_stacktrace=1"
+    #
+    # Memory knobs: the instrumented self-compile (stage1/stage2 ir)
+    # holds tens of millions of live small allocations (that same
+    # process-lifetime str-pool strategy), and default ASan redzones on
+    # the larger pool blocks push the stage peak right against the
+    # 16 GB GitHub runner — the job then dies as a 143/OOM with no
+    # output. max_redzone=16 alone cuts ~1.9 GB off the self-compile
+    # peak (measured); the small quarantine + shallow malloc stacks
+    # trim the rest of the always-on cost. Error DETECTION is
+    # unaffected — only the free-reuse distance and the alloc-stack
+    # depth in reports shrink, and run_san_tests.sh (the corpus that
+    # actually hunts bugs in small programs) sets its own defaults.
+    export ASAN_OPTIONS="detect_leaks=0:abort_on_error=0:halt_on_error=0:print_stacktrace=1:quarantine_size_mb=4:malloc_context_size=2:max_redzone=16"
     export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0"
 else
     NO_LTO_IN_SAN=0

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -741,6 +741,17 @@
 // (`T x → ^ x  F _ → …`), not a stray XOR operand — so the warning is
 // suppressed inside arm bodies. Save/restore (nested matches).
 : ~ i g_in_match_arm 0
+
+// Cheap per-function gate for the Phase 2D slice machinery: most
+// functions declare no owned slices at all, and the sanitized
+// self-compile runs tight against CI memory — skip the per-arm
+// `__slice_decls__` snapshot/walk (each a strdup'ing sym_get) entirely
+// unless this function has actually declared one. Set by
+// mem_slice_decl_add, reset at function entry. A closure body lifted
+// mid-function inherits the enclosing value — a stale 1 only costs the
+// snapshot, never correctness (the drop walks the real lists).
+: ~ i g_fn_slice_decls 0
+
 : ~ i g_defer_count 0  // number of active defers in the current function
 : ~ i g_generic_syms 0  // sym handle for stored generic function templates (Group E)
 : ~ i g_generic_struct_syms 0  // generic struct templates (Group E-structs).
@@ -6063,7 +6074,7 @@
     { = old_strs_t ( nurl_sym_get syms `__owned_strings__` )
         = old_structs_t ( nurl_sym_get syms `__owned_struct_fields__` )
         = old_user_t ( nurl_sym_get syms `__user_drops__` )
-        = old_slices_t ( nurl_sym_get syms `__slice_decls__` )
+        ? != 0 g_fn_slice_decls { = old_slices_t ( nurl_sym_get syms `__slice_decls__` ) } {}
         ( nurl_sym_push syms )
     } {}
     ( nurl_sym_def syms `__cur_lbl__` lt )
@@ -6098,7 +6109,7 @@
         { ( mem_drop_new_strings syms cg old_strs_t )
             ( mem_drop_new_struct_fields syms cg old_structs_t )
             ( mem_drop_new_user_drops syms cg old_user_t )
-            ( mem_drop_new_slices syms cg old_slices_t ) } {}
+            ? != 0 g_fn_slice_decls { ( mem_drop_new_slices syms cg old_slices_t ) } {} } {}
         ( mem_drop_new_closure_envs syms cg old_closure_t )
         ( nurl_print `  br label %` ) ( nurl_print lend ) ( emit_dbg_eol )
     } {}
@@ -6113,7 +6124,7 @@
     { = old_strs_e ( nurl_sym_get syms `__owned_strings__` )
         = old_structs_e ( nurl_sym_get syms `__owned_struct_fields__` )
         = old_user_e ( nurl_sym_get syms `__user_drops__` )
-        = old_slices_e ( nurl_sym_get syms `__slice_decls__` )
+        ? != 0 g_fn_slice_decls { = old_slices_e ( nurl_sym_get syms `__slice_decls__` ) } {}
         ( nurl_sym_push syms )
     } {}
     ( nurl_sym_def syms `__cur_lbl__` le )
@@ -6135,7 +6146,7 @@
         { ( mem_drop_new_strings syms cg old_strs_e )
             ( mem_drop_new_struct_fields syms cg old_structs_e )
             ( mem_drop_new_user_drops syms cg old_user_e )
-            ( mem_drop_new_slices syms cg old_slices_e ) } {}
+            ? != 0 g_fn_slice_decls { ( mem_drop_new_slices syms cg old_slices_e ) } {} } {}
         ( mem_drop_new_closure_envs syms cg old_closure_e )
         ( nurl_print `  br label %` ) ( nurl_print lend ) ( emit_dbg_eol )
     } {}
@@ -6888,7 +6899,7 @@
             { = old_strs_m ( nurl_sym_get syms `__owned_strings__` )
                 = old_structs_m ( nurl_sym_get syms `__owned_struct_fields__` )
                 = old_user_m ( nurl_sym_get syms `__user_drops__` )
-                = old_slices_m ( nurl_sym_get syms `__slice_decls__` )
+                ? != 0 g_fn_slice_decls { = old_slices_m ( nurl_sym_get syms `__slice_decls__` ) } {}
                 ( nurl_sym_push syms )
             } {}
 
@@ -7445,7 +7456,7 @@
             { ( mem_drop_new_strings syms cg old_strs_m )
                 ( mem_drop_new_struct_fields syms cg old_structs_m )
                 ( mem_drop_new_user_drops syms cg old_user_m )
-                ( mem_drop_new_slices syms cg old_slices_m ) } {}
+                ? != 0 g_fn_slice_decls { ( mem_drop_new_slices syms cg old_slices_m ) } {} } {}
             ? == arm_did_ret 0
             { ( mem_drop_new_closure_envs syms cg old_closure_m ) } {}
             ? != 0 g_auto_drop_strings { ( nurl_sym_pop syms ) } {}
@@ -7706,7 +7717,7 @@
     { = old_strs_fe ( nurl_sym_get syms `__owned_strings__` )
         = old_structs_fe ( nurl_sym_get syms `__owned_struct_fields__` )
         = old_user_fe ( nurl_sym_get syms `__user_drops__` )
-        = old_slices_fe ( nurl_sym_get syms `__slice_decls__` )
+        ? != 0 g_fn_slice_decls { = old_slices_fe ( nurl_sym_get syms `__slice_decls__` ) } {}
         ( nurl_sym_push syms )
     } {}
     = g_did_ret 0
@@ -7723,7 +7734,7 @@
         { ( mem_drop_new_strings syms cg old_strs_fe )
             ( mem_drop_new_struct_fields syms cg old_structs_fe )
             ( mem_drop_new_user_drops syms cg old_user_fe )
-            ( mem_drop_new_slices syms cg old_slices_fe ) } {}
+            ? != 0 g_fn_slice_decls { ( mem_drop_new_slices syms cg old_slices_fe ) } {} } {}
         ( mem_drop_new_closure_envs syms cg old_closure_fe )
         : s next_idx ( nurl_cg_reg cg )
         ( nurl_print `  ` ) ( nurl_print next_idx )
@@ -7787,7 +7798,7 @@
         { = old_strs_lp ( nurl_sym_get syms `__owned_strings__` )
             = old_structs_lp ( nurl_sym_get syms `__owned_struct_fields__` )
             = old_user_lp ( nurl_sym_get syms `__user_drops__` )
-            = old_slices_lp ( nurl_sym_get syms `__slice_decls__` )
+            ? != 0 g_fn_slice_decls { = old_slices_lp ( nurl_sym_get syms `__slice_decls__` ) } {}
             ( nurl_sym_push syms )
         } {}
         ( nurl_sym_def syms `__cur_lbl__` lb )
@@ -7801,7 +7812,7 @@
             { ( mem_drop_new_strings syms cg old_strs_lp )
                 ( mem_drop_new_struct_fields syms cg old_structs_lp )
                 ( mem_drop_new_user_drops syms cg old_user_lp )
-                ( mem_drop_new_slices syms cg old_slices_lp ) } {}
+                ? != 0 g_fn_slice_decls { ( mem_drop_new_slices syms cg old_slices_lp ) } {} } {}
             ( mem_drop_new_closure_envs syms cg old_closure_lp )
             ( nurl_print `  br label %` ) ( nurl_print lc ) ( emit_dbg_eol )
         } {}
@@ -7979,6 +7990,7 @@
 // fall-through would be a use-after-free — only bindings declared
 // during the arm itself may be dropped there.
 @ mem_slice_decl_add i syms s name → v {
+    = g_fn_slice_decls 1
     : s cur ( nurl_sym_get syms `__slice_decls__` )
     ( nurl_sym_def syms `__slice_decls__`
     ? == 0 ( nurl_str_len cur ) name ( nurl_str_cat3 cur ` ` name ) )
@@ -14518,6 +14530,7 @@
     ( nurl_sym_push syms )
     ( nurl_sym_def syms `__owned_slices__` `` )
     ( nurl_sym_def syms `__slice_decls__` `` )
+    = g_fn_slice_decls 0
     ( nurl_sym_def syms `__last_ident_name__` `` )
     ( nurl_sym_def syms `__fn_ret_owned__` `` )
     // Borrow provenance: does THIS function return a borrow (a value that

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -6057,11 +6057,13 @@
     : ~ s old_strs_t ``
     : ~ s old_structs_t ``
     : ~ s old_user_t ``
+    : ~ s old_slices_t ``
     : ~ s old_closure_t ( nurl_sym_get syms `__owned_closure_envs__` )
     ? != 0 g_auto_drop_strings
     { = old_strs_t ( nurl_sym_get syms `__owned_strings__` )
         = old_structs_t ( nurl_sym_get syms `__owned_struct_fields__` )
         = old_user_t ( nurl_sym_get syms `__user_drops__` )
+        = old_slices_t ( nurl_sym_get syms `__slice_decls__` )
         ( nurl_sym_push syms )
     } {}
     ( nurl_sym_def syms `__cur_lbl__` lt )
@@ -6095,7 +6097,8 @@
         ? & != 0 g_auto_drop_strings ( seq tt2 `void` )
         { ( mem_drop_new_strings syms cg old_strs_t )
             ( mem_drop_new_struct_fields syms cg old_structs_t )
-            ( mem_drop_new_user_drops syms cg old_user_t ) } {}
+            ( mem_drop_new_user_drops syms cg old_user_t )
+            ( mem_drop_new_slices syms cg old_slices_t ) } {}
         ( mem_drop_new_closure_envs syms cg old_closure_t )
         ( nurl_print `  br label %` ) ( nurl_print lend ) ( emit_dbg_eol )
     } {}
@@ -6104,11 +6107,13 @@
     : ~ s old_strs_e ``
     : ~ s old_structs_e ``
     : ~ s old_user_e ``
+    : ~ s old_slices_e ``
     : ~ s old_closure_e ( nurl_sym_get syms `__owned_closure_envs__` )
     ? != 0 g_auto_drop_strings
     { = old_strs_e ( nurl_sym_get syms `__owned_strings__` )
         = old_structs_e ( nurl_sym_get syms `__owned_struct_fields__` )
         = old_user_e ( nurl_sym_get syms `__user_drops__` )
+        = old_slices_e ( nurl_sym_get syms `__slice_decls__` )
         ( nurl_sym_push syms )
     } {}
     ( nurl_sym_def syms `__cur_lbl__` le )
@@ -6129,7 +6134,8 @@
     { ? & != 0 g_auto_drop_strings ( seq et2 `void` )
         { ( mem_drop_new_strings syms cg old_strs_e )
             ( mem_drop_new_struct_fields syms cg old_structs_e )
-            ( mem_drop_new_user_drops syms cg old_user_e ) } {}
+            ( mem_drop_new_user_drops syms cg old_user_e )
+            ( mem_drop_new_slices syms cg old_slices_e ) } {}
         ( mem_drop_new_closure_envs syms cg old_closure_e )
         ( nurl_print `  br label %` ) ( nurl_print lend ) ( emit_dbg_eol )
     } {}
@@ -6876,11 +6882,13 @@
             : ~ s old_strs_m ``
             : ~ s old_structs_m ``
             : ~ s old_user_m ``
+            : ~ s old_slices_m ``
             : ~ s old_closure_m ( nurl_sym_get syms `__owned_closure_envs__` )
             ? != 0 g_auto_drop_strings
             { = old_strs_m ( nurl_sym_get syms `__owned_strings__` )
                 = old_structs_m ( nurl_sym_get syms `__owned_struct_fields__` )
                 = old_user_m ( nurl_sym_get syms `__user_drops__` )
+                = old_slices_m ( nurl_sym_get syms `__slice_decls__` )
                 ( nurl_sym_push syms )
             } {}
 
@@ -7436,7 +7444,8 @@
             ? & & != 0 g_auto_drop_strings ( seq arm_type `void` ) == arm_did_ret 0
             { ( mem_drop_new_strings syms cg old_strs_m )
                 ( mem_drop_new_struct_fields syms cg old_structs_m )
-                ( mem_drop_new_user_drops syms cg old_user_m ) } {}
+                ( mem_drop_new_user_drops syms cg old_user_m )
+                ( mem_drop_new_slices syms cg old_slices_m ) } {}
             ? == arm_did_ret 0
             { ( mem_drop_new_closure_envs syms cg old_closure_m ) } {}
             ? != 0 g_auto_drop_strings { ( nurl_sym_pop syms ) } {}
@@ -7691,11 +7700,13 @@
     : ~ s old_strs_fe ``
     : ~ s old_structs_fe ``
     : ~ s old_user_fe ``
+    : ~ s old_slices_fe ``
     : ~ s old_closure_fe ( nurl_sym_get syms `__owned_closure_envs__` )
     ? != 0 g_auto_drop_strings
     { = old_strs_fe ( nurl_sym_get syms `__owned_strings__` )
         = old_structs_fe ( nurl_sym_get syms `__owned_struct_fields__` )
         = old_user_fe ( nurl_sym_get syms `__user_drops__` )
+        = old_slices_fe ( nurl_sym_get syms `__slice_decls__` )
         ( nurl_sym_push syms )
     } {}
     = g_did_ret 0
@@ -7711,7 +7722,8 @@
     { ? != 0 g_auto_drop_strings
         { ( mem_drop_new_strings syms cg old_strs_fe )
             ( mem_drop_new_struct_fields syms cg old_structs_fe )
-            ( mem_drop_new_user_drops syms cg old_user_fe ) } {}
+            ( mem_drop_new_user_drops syms cg old_user_fe )
+            ( mem_drop_new_slices syms cg old_slices_fe ) } {}
         ( mem_drop_new_closure_envs syms cg old_closure_fe )
         : s next_idx ( nurl_cg_reg cg )
         ( nurl_print `  ` ) ( nurl_print next_idx )
@@ -7769,11 +7781,13 @@
         : ~ s old_strs_lp ``
         : ~ s old_structs_lp ``
         : ~ s old_user_lp ``
+        : ~ s old_slices_lp ``
         : ~ s old_closure_lp ( nurl_sym_get syms `__owned_closure_envs__` )
         ? != 0 g_auto_drop_strings
         { = old_strs_lp ( nurl_sym_get syms `__owned_strings__` )
             = old_structs_lp ( nurl_sym_get syms `__owned_struct_fields__` )
             = old_user_lp ( nurl_sym_get syms `__user_drops__` )
+            = old_slices_lp ( nurl_sym_get syms `__slice_decls__` )
             ( nurl_sym_push syms )
         } {}
         ( nurl_sym_def syms `__cur_lbl__` lb )
@@ -7786,7 +7800,8 @@
         { ? != 0 g_auto_drop_strings
             { ( mem_drop_new_strings syms cg old_strs_lp )
                 ( mem_drop_new_struct_fields syms cg old_structs_lp )
-                ( mem_drop_new_user_drops syms cg old_user_lp ) } {}
+                ( mem_drop_new_user_drops syms cg old_user_lp )
+                ( mem_drop_new_slices syms cg old_slices_lp ) } {}
             ( mem_drop_new_closure_envs syms cg old_closure_lp )
             ( nurl_print `  br label %` ) ( nurl_print lc ) ( emit_dbg_eol )
         } {}
@@ -7957,6 +7972,45 @@
     >= ( nurl_str_find t `*, i64 }` ) 0
 }
 
+// Record that `name` was DECLARED (`:`-bound) as an owned slice in the
+// current scope. Parallel sideband to `__owned_slices__`, needed by the
+// Phase 2D arm-local slice drop: `= outer [ … ]` inside an arm also
+// calls mem_own_add for an OUTER binding, and freeing that at the arm's
+// fall-through would be a use-after-free — only bindings declared
+// during the arm itself may be dropped there.
+@ mem_slice_decl_add i syms s name → v {
+    : s cur ( nurl_sym_get syms `__slice_decls__` )
+    ( nurl_sym_def syms `__slice_decls__`
+    ? == 0 ( nurl_str_len cur ) name ( nurl_str_cat3 cur ` ` name ) )
+}
+
+// Emit the free of one owned-slice binding's backing buffer: load the
+// slice struct from the binding's alloca, extract the data pointer,
+// free it. Symtab lookup is innermost-scope, so inside an arm this
+// resolves a shadowing declaration to the arm's own alloca.
+@ mem_emit_slice_free i syms i cg s name → v {
+    : s ty ( nurl_sym_get syms name )
+    : s ptr ( nurl_sym_get syms ( nurl_str_cat name `__ptr` ) )
+    // Slice type is always "{ <T>*, i64 }" (suffix ", i64 }" = 7 chars).
+    // Extract <T>* = chars [2 .. len-7).
+    : i tylen ( nurl_str_len ty )
+    : s tptr ( nurl_str_slice ty 2 - tylen 9 )
+    : s v ( nurl_cg_reg cg )
+    ( nurl_print `  ` ) ( nurl_print v )
+    ( nurl_print ` = load ` ) ( nurl_print ( nurl_llty ty ) )
+    ( nurl_print `, ` ) ( nurl_print ( nurl_llty ty ) )
+    ( nurl_print `* ` ) ( nurl_print ptr ) ( nurl_print `\n` )
+    : s dp ( nurl_cg_reg cg )
+    ( nurl_print `  ` ) ( nurl_print dp )
+    ( nurl_print ` = extractvalue ` ) ( nurl_print ( nurl_llty ty ) )
+    ( nurl_print ` ` ) ( nurl_print v ) ( nurl_print `, 0\n` )
+    : s raw ( nurl_cg_reg cg )
+    ( nurl_print `  ` ) ( nurl_print raw )
+    ( nurl_print ` = bitcast ` ) ( nurl_print ( nurl_llty tptr ) )
+    ( nurl_print ` ` ) ( nurl_print dp ) ( nurl_print ` to i8*\n` )
+    ( nurl_print `  call void @nurl_free(i8* ` ) ( nurl_print raw ) ( nurl_print `)` ) ( emit_dbg_eol )
+}
+
 // Emit `free` for every binding in the owned list, skipping `skip_name`.
 // If defers are active, skips entirely (defers may still reference slices).
 // Does NOT clear the list — each return path emits its own set; paths are
@@ -7969,27 +8023,7 @@
             : s name ( str_first_word rest )
             = rest ( str_skip_word rest )
             ? ! ( seq name skip_name )
-            { : s ty ( nurl_sym_get syms name )
-                : s ptr ( nurl_sym_get syms ( nurl_str_cat name `__ptr` ) )
-                // Slice type is always "{ <T>*, i64 }" (suffix ", i64 }" = 7 chars).
-                // Extract <T>* = chars [2 .. len-7).
-                : i tylen ( nurl_str_len ty )
-                : s tptr ( nurl_str_slice ty 2 - tylen 9 )
-                : s v ( nurl_cg_reg cg )
-                ( nurl_print `  ` ) ( nurl_print v )
-                ( nurl_print ` = load ` ) ( nurl_print ( nurl_llty ty ) )
-                ( nurl_print `, ` ) ( nurl_print ( nurl_llty ty ) )
-                ( nurl_print `* ` ) ( nurl_print ptr ) ( nurl_print `\n` )
-                : s dp ( nurl_cg_reg cg )
-                ( nurl_print `  ` ) ( nurl_print dp )
-                ( nurl_print ` = extractvalue ` ) ( nurl_print ( nurl_llty ty ) )
-                ( nurl_print ` ` ) ( nurl_print v ) ( nurl_print `, 0\n` )
-                : s raw ( nurl_cg_reg cg )
-                ( nurl_print `  ` ) ( nurl_print raw )
-                ( nurl_print ` = bitcast ` ) ( nurl_print ( nurl_llty tptr ) )
-                ( nurl_print ` ` ) ( nurl_print dp ) ( nurl_print ` to i8*\n` )
-                ( nurl_print `  call void @nurl_free(i8* ` ) ( nurl_print raw ) ( nurl_print `)` ) ( emit_dbg_eol )
-            }
+            { ( mem_emit_slice_free syms cg name ) }
             {}
         }
     }
@@ -8455,6 +8489,33 @@
             ? ( str_contains_word old_list ptr )
             {}
             { ( mem_emit_struct_field_drop syms cg ptr sname path kind leaf_sname leaf_idx ) }
+        }
+    }
+    {}
+}
+
+// Slice counterpart of mem_drop_new_strings: at an arm's fall-through,
+// free every owned slice DECLARED during the arm (memory-model rule 5 —
+// arm-local slice literals used to leak because `__owned_slices__` is
+// scope-shadowed and the arm's delta died unseen at nurl_sym_pop).
+// Driven by the `__slice_decls__` delta, NOT the ownership list: an
+// `= outer [ … ]` inside the arm registers an OUTER binding in the
+// arm's ownership shadow, and freeing that here would be a UAF — only
+// arm-DECLARED names are candidates, and each must still be word-in
+// the current ownership list. Names (unlike alloca registers) are not
+// unique, so an arm-local shadow of an outer slice-declaring name is
+// skipped (a leak, never a double free).
+@ mem_drop_new_slices i syms i cg s old_decls → v {
+    : s dtop ( nurl_sym_get syms `__defer_top__` )
+    ? == 0 ( nurl_str_len dtop )
+    { : s owned ( nurl_sym_get syms `__owned_slices__` )
+        : ~ s rest ( nurl_sym_get syms `__slice_decls__` )
+        ~ != 0 ( nurl_str_len rest ) {
+            : s name ( str_first_word rest )
+            = rest ( str_skip_word rest )
+            ? | ( str_contains_word old_decls name ) ! ( str_contains_word owned name )
+            {}
+            { ( mem_emit_slice_free syms cg name ) }
         }
     }
     {}
@@ -9900,7 +9961,9 @@
         { ( nurl_sym_def syms ( nurl_str_cat name `__mutable` ) `1` ) }
         {}
         ? | rhs_is_slice_lit & rhs_is_owned_call ( mem_is_slice_ty vt )
-        { ( mem_own_add syms name ) ( mem_journal_push_slice cg vt ptr ) }
+        { ( mem_own_add syms name )
+            ( mem_slice_decl_add syms name )
+            ( mem_journal_push_slice cg vt ptr ) }
         {}
         // Closure-env reclamation (§7.4): a `: f \ … x …` literal binding
         // owns the env → track it for the function-exit free. A `: g f`
@@ -10077,7 +10140,9 @@
                 { ( nurl_sym_def syms ( nurl_str_cat name `__mutable` ) `1` ) }
                 {}
                 ? | rhs_is_slice_lit & rhs_is_owned_call ( mem_is_slice_ty ptype )
-                { ( mem_own_add syms name ) ( mem_journal_push_slice cg ptype ptr ) }
+                { ( mem_own_add syms name )
+                    ( mem_slice_decl_add syms name )
+                    ( mem_journal_push_slice cg ptype ptr ) }
                 {}
                 // Closure-env reclamation (§7.4): track a capturing closure
                 // bound here for the function-exit free.
@@ -10184,7 +10249,11 @@
         : b lhs_is_owned_str & & != 0 g_auto_drop_strings
         ( seq ( nurl_llty vt ) `i8*` )
         ( str_contains_word ( nurl_sym_get syms `__owned_strings__` ) ptr )
-        ? lhs_is_owned_str { ( nurl_sym_def syms `__last_call_ret_owned__` `` ) } {}
+        // Slice dual: LHS is a tracked owned-slice binding (keyed by
+        // NAME — Phase 1 protocol) being overwritten.
+        : b lhs_is_owned_slc & ( mem_is_slice_ty vt )
+        ( str_contains_word ( nurl_sym_get syms `__owned_slices__` ) name )
+        ? | lhs_is_owned_str lhs_is_owned_slc { ( nurl_sym_def syms `__last_call_ret_owned__` `` ) } {}
         // Escape analysis: snapshot the RHS's
         // first token (a bare identifier may copy a stack reference)
         // and clear the side-channel a closure / aggregate literal
@@ -10219,6 +10288,19 @@
             ( nurl_print ` = load i8*, i8** ` ) ( nurl_print ptr ) ( nurl_print `\n` )
             ( nurl_print `  call void @nurl_free(i8* ` ) ( nurl_print old_reg ) ( nurl_print `)` ) ( emit_dbg_eol )
         }
+        {}
+        // Slice reassignment-drop (rule 3 dual of the string block
+        // above): `= xs [ … ]` / `= xs ( fresh-slice-call )` frees the
+        // old backing buffer before the store overwrites the alloca.
+        // Same alias discipline: gated on a FRESH RHS (a slice literal
+        // token, or a call that published slice-ownership `1`) — a
+        // bare-identifier RHS may alias the old heap and is left alone.
+        // nurl_free auto-forgets the journal entry, so a later panic
+        // cannot replay the freed buffer.
+        ? & lhs_is_owned_slc
+        | == bck_rhs_tt TT_LBRACK
+        ( seq ( nurl_sym_get syms `__last_call_ret_owned__` ) `1` )
+        { ( mem_emit_slice_free syms cg name ) }
         {}
         // Ownership transfer: `= name x` with a bare-identifier RHS
         // copies x's pointer into `name`. If x was a tracked owned
@@ -12758,6 +12840,7 @@
     : i body_syms syms
     // Shadow outer __owned_slices__ with empty list for the closure body
     ( nurl_sym_def body_syms `__owned_slices__` `` )
+    ( nurl_sym_def body_syms `__slice_decls__` `` )
     // Defers don't cross closure boundaries — clear shadow too
     ( nurl_sym_def body_syms `__defer_top__` `` )
     // Reset the shadow-check roster so a `:` inside the closure body
@@ -14434,6 +14517,7 @@
     0
     ( nurl_sym_push syms )
     ( nurl_sym_def syms `__owned_slices__` `` )
+    ( nurl_sym_def syms `__slice_decls__` `` )
     ( nurl_sym_def syms `__last_ident_name__` `` )
     ( nurl_sym_def syms `__fn_ret_owned__` `` )
     // Borrow provenance: does THIS function return a borrow (a value that

--- a/compiler/tests/arm_local_slice_drop.nu
+++ b/compiler/tests/arm_local_slice_drop.nu
@@ -1,0 +1,71 @@
+// Test: Phase 2D arm-local fall-through drop for OWNED SLICES (memory-
+// model rule 5). A slice literal `:`-bound inside a ? / ?? / while /
+// foreach arm that falls through must be freed at arm end — these used
+// to leak because `__owned_slices__` is scope-shadowed and the arm's
+// delta died unseen at nurl_sym_pop (found by ASan in packages/gguf).
+// Also covers the rule 3 dual (`= xs [ … ]` frees the old backing
+// buffer) and the alias hazard the fix must NOT introduce: an
+// `= outer [ … ]` inside an arm registers an OUTER binding, which must
+// survive the arm's fall-through — only bindings DECLARED during the
+// arm are dropped there (driven by the `__slice_decls__` delta).
+// Values are asserted through acc so a premature free (UAF) or a skip
+// shows up as a wrong sum even without ASan; run the suite's san build
+// to prove the leak side.
+
+@ main → i {
+    : ~ i acc 0
+
+    // ? arm, inferred let — freed at the arm's fall-through
+    ? 1 {
+        : xs [i | 1 2 3]
+        : *i p . xs 0
+        = acc . p 0
+        ( nurl_print `then-arm ok\n` )
+    } {}
+
+    // ?? arm, annotated let — same
+    : ?i o @ ?i { T 5 }
+    ?? o {
+        T v → {
+            : [i ys [i | 4 5]
+            : *i q . ys 0
+            = acc + acc + . q 0 v
+            ( nurl_print `match-arm ok\n` )
+        }
+        F → {}
+    }
+
+    // while body — freed once per iteration (a leak would be 10×)
+    : ~ i k 0
+    ~ < k 10 {
+        : zs [i | 7 8 9]
+        : *i r . zs 0
+        = acc + acc . r 2
+        = k + k 1
+    }
+
+    // foreach body — same per-iteration drop
+    : ws [i | 1 2]
+    ~ w ws {
+        : vs [i | 6]
+        : *i s2 . vs 0
+        = acc + acc . s2 0
+    }
+
+    // rule 3: reassignment with a fresh literal frees the OLD buffer
+    : ~ rs [i | 10 20]
+    = rs [i | 30 40 50]
+    : *i rp . rs 0
+    = acc + acc . rp 0
+
+    // arm-reassign of an OUTER binding: the new buffer must survive the
+    // arm (reading it later would UAF if the arm dropped it)
+    ? 1 { = rs [i | 7] } {}
+    : *i up . rs 0
+    = acc + acc . up 0
+
+    // 1 + 9 + 90 + 12 + 30 + 7 = 149
+    ( nurl_print ( nurl_str_int acc ) )
+    ( nurl_print `\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs/arm_local_slice_drop.txt
+++ b/compiler/tests/outputs/arm_local_slice_drop.txt
@@ -1,0 +1,7 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+then-arm ok
+match-arm ok
+149


### PR DESCRIPTION
## Bug

An owned slice literal `:`-bound inside a `?` / `??` / `~` while / foreach arm that falls through was **never freed**. Minimal repro (LSan: 24 B, ×iterations in loops):

```nurl
@ main → i {
    ? T {
        : xs [ i | 1 2 3 ]
        : *i P . xs 0
        ( nurl_print ? > . P 0 0 `x` `y` )
    } {}
    ^ 0
}
```

Root cause: `__owned_slices__` is name-keyed and scope-shadowed, so the arm's delta died unseen at `nurl_sym_pop` — Phase 2D (arm-local fall-through drop) had counterparts for strings, struct fields and user drops, but **none for slices**. Found by ASan while hardening `packages/gguf` (#449).

## Fix

- **New `__slice_decls__` sideband** records only bindings *declared* as owned slices in the current scope (both let paths: inferred and type-annotated). The arm drop is driven by its delta, **not** the ownership list — `= outer [ … ]` inside an arm registers an *outer* binding in the arm's ownership shadow, and freeing that at the arm's fall-through would be a use-after-free.
- **`mem_drop_new_slices`** (delta protocol mirroring `mem_drop_new_strings`: same defer guard, same void-arm gate) wired into all five Phase 2D sites: cond then-arm, cond else-arm, match arm, while body, foreach body. Emission shared with the function-exit path via the extracted `mem_emit_slice_free`.
- **Rule 3 dual, same root family:** `= xs [ … ]` / `= xs ( fresh-slice-call )` now frees the old backing buffer before the store — gated on a fresh RHS exactly like the Phase 2B string reassignment-drop, so an aliasing `= xs y` is left alone. `nurl_free` auto-forgets the panic-journal entry, so no unwind double-free.

## Verification

- Full suite green — **530 PASS**, incl. the new `arm_local_slice_drop` regression, which asserts every value through arithmetic so a premature free (UAF) shows up as a wrong sum even without ASan.
- ASan/LSan-clean on: `?`/`??` arms (inferred + annotated lets), per-iteration drops in `~` while (×10) and foreach bodies, fresh-RHS reassign, outer-reassign-inside-arm alias case, and the slice-through-phi case (`? c [ … ] [ … ]` — void gate keeps it safe).
- `packages/gguf` selftest (37 bit-exact checks) and `verify` of a real quantised llama.cpp model stay ASan-clean when built with the fixed compiler.

## Known remaining (documented, deliberate)

- A non-void-tailed arm (e.g. ending in `= acc …`) still skips Phase 2D for **every** ownership class — the conservative gate is correct as-is, since the arm's value may be a pointer derived from an arm-local; finer escape analysis is Phase 2A-scale work.
- Ternary-produced slices (`: r ? c [ … ] [ … ]`) are still untracked (rule 1 gap) — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)