### PR TITLE
packages/nurllama 0.1.0 — tokenizer from GGUF metadata (phase 2)

### DIFF
--- a/packages/gguf/src/main.nu
+++ b/packages/gguf/src/main.nu
@@ -424,12 +424,6 @@ $ `write.nu`
 
 @ __st_run → i {
     : ~ STCnt cn @ STCnt { 0 0 }
-    // expected-value tables live at function scope: owned slice
-    // literals inside ?/??-arms are not yet dropped by the compiler
-    // (TODO.md §8) — at function scope the scope-exit drop is sound
-    : f32exp [f | 0.0 1.5 -2.25 3.75 100.0 -0.0078125 6.5 -7.0]
-    : f16exp [i | 0 1065353216 3221225472 864026624 947896320 2139095040 4286578688 2143289344 2147483648]
-    : bfexp [i | 1065353216 3221225472 0 2139095040]
     : *GgufW w ( __st_build )
     : !String IoErr tf ( fs_tempfile `/tmp` `gguf-selftest.` )
     : ~ String path ( string_new )
@@ -522,6 +516,7 @@ $ `write.nu`
                 : !( Vec f ) String dr ( gguf_dequant_f64 g tf32 )
                 ?? dr {
                     T got → {
+                        : f32exp [f | 0.0 1.5 -2.25 3.75 100.0 -0.0078125 6.5 -7.0]
                         ( __st_ck cn ( __st_vec_eq got . f32exp 0 8 ) `t_f32 dequant values` )
                         ( vec_free [f] got )
                     }
@@ -539,6 +534,7 @@ $ `write.nu`
                 : !( Vec u ) String dr ( gguf_dequant g tf16 )
                 ?? dr {
                     T got → {
+                        : f16exp [i | 0 1065353216 3221225472 864026624 947896320 2139095040 4286578688 2143289344 2147483648]
                         : *i EP . f16exp 0
                         : ~ b ok == ( vec_len [u] got ) 36
                         : ~ i k 0
@@ -567,6 +563,7 @@ $ `write.nu`
                 : !( Vec u ) String dr ( gguf_dequant g tbf )
                 ?? dr {
                     T got → {
+                        : bfexp [i | 1065353216 3221225472 0 2139095040]
                         : *i EP . bfexp 0
                         : ~ b ok == ( vec_len [u] got ) 16
                         : ~ i k 0

--- a/packages/nurllama/README.md
+++ b/packages/nurllama/README.md
@@ -1,0 +1,79 @@
+# nurllama — run language models locally, in pure NURL
+
+The ollama-shaped engine, built package by package on top of
+[`packages/gguf`](../gguf). **Phase 2 (current): the tokenizer.**
+
+```
+nurllama tokenize model.gguf "Once upon a time"   # → 1 424 3520 264 632
+nurllama detok model.gguf 1 424 3520 264 632      # → " Once upon a time"
+nurllama vocab model.gguf 10                      # first 10 pieces
+nurllama selftest                                 # 17 bit-exact checks
+```
+
+## Tokenizer from the model file alone
+
+Everything is loaded from the model's own `tokenizer.ggml.*` GGUF
+metadata — vocabulary, scores, token types, merges, special ids and
+the add-BOS/EOS flags. No external vocab files, no exporter step.
+
+Two families, selected by `tokenizer.ggml.model`:
+
+- **SPM (`llama`)** — SentencePiece-style bigram merging: space-escape
+  (` ` → `▁`, optional leading space), split to UTF-8 characters, then
+  repeatedly merge the adjacent pair whose concatenation is the
+  highest-scoring vocab piece — llama.cpp's `llm_tokenizer_spm`
+  selection order exactly (ties break leftmost). Unmatched characters
+  fall back to the `<0xNN>` byte tokens, then to UNK.
+- **BPE (`gpt2`)** — byte-level BPE: GPT-2's byte→unicode remap,
+  contraction/letter/digit/punct/whitespace pre-split, then
+  lowest-merge-rank pairing from `tokenizer.ggml.merges`.
+  *v1 note:* the pre-split approximates `\p{L}` as "ASCII letters +
+  any codepoint ≥ 0x80"; per-model `tokenizer.ggml.pre` variants
+  (qwen2 digit splitting etc.) are a follow-up.
+
+Decoding inverts both: `▁` → space and `<0xNN>` → raw byte for SPM,
+the byte remap for BPE; control tokens produce nothing.
+
+## Library API
+
+```nurl
+$ `deps/gguf/src/gguf.nu`
+$ `src/tokenizer.nu`
+
+: !*Gguf String gr ( gguf_open `model.gguf` )
+?? gr {
+    T g → {
+        : !*Tok String tr ( tok_new g )       // copies the vocab —
+        ( gguf_close g )                      // the Gguf can close now
+        ?? tr {
+            T t → {
+                : ( Vec i ) ids ( tok_encode t `hello world` T )
+                : ( Vec u ) bytes ( tok_decode t ids )
+                ( tok_free t )
+            }
+            F e → { /* … */ }
+        }
+    }
+    F e → { /* … */ }
+}
+```
+
+## Verified
+
+- `selftest`: synthetic SPM + BPE vocabularies built with the gguf
+  **writer** and parsed back through the real parser, checked against
+  hand-derived ids — merge chains, prefix pieces, byte fallback
+  (emoji), UNK, empty input, decode round-trips. 17 checks.
+- `tests/tokenizer_test.sh` with `NURL_NET_TESTS=1`: token-for-token
+  parity with an **independent python SentencePiece implementation**
+  on a real llama.cpp model (stories260K) across unicode, emoji,
+  whitespace runs and the empty string, plus encode→decode
+  round-trips.
+- ASan/UBSan/LeakSanitizer clean.
+
+## Roadmap
+
+Phase 3: the inference core on gpukit (dequant-on-device, RMSNorm,
+RoPE, causal attention, KV-cache, sampling). Phase 4: model store +
+pull (`~/.nurllama`). Phase 5: CLI chat + an ollama-compatible HTTP
+API. See the plan in the repo's development notes.

--- a/packages/nurllama/nurl.toml
+++ b/packages/nurllama/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nurllama"
+version = "0.1.0"
+description = "Run language models locally, in pure NURL — the ollama-shaped engine being built package by package on top of the gguf container toolkit. Phase 2 (this release): the tokenizer, loaded entirely from the model's own tokenizer.ggml.* GGUF metadata — no external vocab files, no exporter step. Two families: SentencePiece-style bigram merging for llama-family models (space-escape to ▁, highest-score adjacent merge with llama.cpp's exact selection order, <0xNN> byte fallback, UNK) and byte-level BPE for gpt2-family models (GPT-2 byte→unicode remap, contraction/letter/digit/punct/whitespace pre-split, lowest-merge-rank pairing from tokenizer.ggml.merges). Encode and decode are verified bit-for-bit: a 17-check selftest over synthetic vocabularies with hand-derived expected ids (built with the gguf writer, parsed back through the real parser), plus token-for-token parity with an independent python SentencePiece implementation on a real llama.cpp model — unicode, emoji byte-fallback, tabs, runs of spaces and the empty string included. CLI: nurllama tokenize/detok/vocab/selftest. Next phases: the gpukit inference core (RMSNorm/RoPE/attention/KV-cache), the model store + pull, and an ollama-compatible HTTP API."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+gguf = { path = "../gguf", version = "^0.1" }

--- a/packages/nurllama/src/main.nu
+++ b/packages/nurllama/src/main.nu
@@ -1,0 +1,486 @@
+// nurllama — run language models locally (phase 2: the tokenizer).
+//
+//   nurllama tokenize <model.gguf> <text>     encode → token ids
+//   nurllama detok <model.gguf> <id> [id …]   decode ids → bytes
+//   nurllama vocab <model.gguf> [n]           dump the first n pieces
+//   nurllama selftest                         synthetic SPM + BPE vocab
+//                                             round-trips, bit-exact
+//
+// The tokenizer is loaded straight from the model's own
+// tokenizer.ggml.* metadata via packages/gguf — no side files.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/posix.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/args.nu`
+$ `stdlib/std/hashmap.nu`
+$ `stdlib/std/utf8.nu`
+$ `stdlib/std/floatbits.nu`
+$ `deps/gguf/src/gguf.nu`
+$ `deps/gguf/src/write.nu`
+$ `src/tokenizer.nu`
+
+@ __nl_err String e → i {
+    ( nurl_eprintln ( string_data e ) )
+    ( string_free e )
+    ^ 1
+}
+
+@ __nl_print_ids ( Vec i ) ids → v {
+    : String m ( string_new )
+    : ~ i k 0
+    ~ < k ( vec_len [i] ids ) {
+        ? > k 0 { ( string_push_char m 32 ) } {}
+        ( string_push_int m ( __tk_geti ids k -1 ) )
+        = k + k 1
+    }
+    ( nurl_print ( string_data m ) )
+    ( nurl_print `\n` )
+    ( string_free m )
+}
+
+// ── selftest ────────────────────────────────────────────────────────
+
+: NlCnt {
+    i pass
+    i fail
+}
+
+@ __nl_ck inout NlCnt cn b ok s name → v {
+    ? ok { = . cn pass + . cn pass 1 } {
+        = . cn fail + . cn fail 1
+        ( nurl_print `  FAIL ` )
+        ( nurl_print name )
+        ( nurl_print `\n` )
+    }
+}
+
+@ __nl_ids_eq ( Vec i ) got * i exp i n → b {
+    ? != ( vec_len [i] got ) n { ^ F } {}
+    : ~ i k 0
+    : ~ b ok T
+    ~ < k n {
+        ? == ( __tk_geti got k -1 ) . exp k {} { = ok F }
+        = k + k 1
+    }
+    ^ ok
+}
+
+@ __nl_bytes_is ( Vec u ) got s want → b {
+    ? != ( vec_len [u] got ) ( nurl_str_len want ) { ^ F } {}
+    : ~ i k 0
+    : ~ b ok T
+    ~ < k ( vec_len [u] got ) {
+        : ~ i gb -1
+        ?? ( vec_get [u] got k ) { T x → { = gb # i x } F → {} }
+        ? == gb ( nurl_str_get want k ) {} { = ok F }
+        = k + k 1
+    }
+    ^ ok
+}
+
+// Synthetic SPM vocabulary: full merge chains for ▁hello / ▁world,
+// specials, and the four byte tokens of 😀 (F0 9F 98 80).
+//  0 <unk>  1 <s>  2 </s>
+//  3 ▁ 4 ▁h 5 ▁he 6 ▁hel 7 ▁hell 8 ▁hello
+//  9 ▁w 10 ▁wo 11 ▁wor 12 ▁worl 13 ▁world
+//  14 h 15 e 16 l 17 o 18 ll
+//  19 <0xF0> 20 <0x9F> 21 <0x98> 22 <0x80>
+@ __nl_build_spm s path → b {
+    : ~ i ok 1
+    ?? ( gw_new 32 ) {
+        T w → {
+            ( gw_kv_str w `tokenizer.ggml.model` `llama` )
+            : ( Vec String ) toks ( vec_new [String] )
+            ( vec_push [String] toks ( string_from `<unk>` ) )
+            ( vec_push [String] toks ( string_from `<s>` ) )
+            ( vec_push [String] toks ( string_from `</s>` ) )
+            ( vec_push [String] toks ( string_from `▁` ) )
+            ( vec_push [String] toks ( string_from `▁h` ) )
+            ( vec_push [String] toks ( string_from `▁he` ) )
+            ( vec_push [String] toks ( string_from `▁hel` ) )
+            ( vec_push [String] toks ( string_from `▁hell` ) )
+            ( vec_push [String] toks ( string_from `▁hello` ) )
+            ( vec_push [String] toks ( string_from `▁w` ) )
+            ( vec_push [String] toks ( string_from `▁wo` ) )
+            ( vec_push [String] toks ( string_from `▁wor` ) )
+            ( vec_push [String] toks ( string_from `▁worl` ) )
+            ( vec_push [String] toks ( string_from `▁world` ) )
+            ( vec_push [String] toks ( string_from `h` ) )
+            ( vec_push [String] toks ( string_from `e` ) )
+            ( vec_push [String] toks ( string_from `l` ) )
+            ( vec_push [String] toks ( string_from `o` ) )
+            ( vec_push [String] toks ( string_from `ll` ) )
+            ( vec_push [String] toks ( string_from `<0xF0>` ) )
+            ( vec_push [String] toks ( string_from `<0x9F>` ) )
+            ( vec_push [String] toks ( string_from `<0x98>` ) )
+            ( vec_push [String] toks ( string_from `<0x80>` ) )
+            ( gw_kv_arr_str w `tokenizer.ggml.tokens` toks )
+            ( vec_free_with [String] toks \ String s → v { ( string_free s ) } )
+            : ( Vec f ) sc ( vec_new [f] )
+            ( vec_push [f] sc 0.0 ) ( vec_push [f] sc 0.0 ) ( vec_push [f] sc 0.0 )
+            ( vec_push [f] sc -10.0 ) ( vec_push [f] sc -6.0 ) ( vec_push [f] sc -5.0 )
+            ( vec_push [f] sc -4.0 ) ( vec_push [f] sc -3.0 ) ( vec_push [f] sc -1.0 )
+            ( vec_push [f] sc -6.5 ) ( vec_push [f] sc -5.5 ) ( vec_push [f] sc -4.5 )
+            ( vec_push [f] sc -3.5 ) ( vec_push [f] sc -2.0 ) ( vec_push [f] sc -20.0 )
+            ( vec_push [f] sc -20.0 ) ( vec_push [f] sc -20.0 ) ( vec_push [f] sc -20.0 )
+            ( vec_push [f] sc -8.0 ) ( vec_push [f] sc 0.0 ) ( vec_push [f] sc 0.0 )
+            ( vec_push [f] sc 0.0 ) ( vec_push [f] sc 0.0 )
+            ( gw_kv_arr_f32 w `tokenizer.ggml.scores` sc )
+            ( vec_free [f] sc )
+            : ( Vec i ) ty ( vec_new [i] )
+            ( vec_push [i] ty 2 ) ( vec_push [i] ty 3 ) ( vec_push [i] ty 3 )
+            : ~ i k 3
+            ~ < k 19 {
+                ( vec_push [i] ty 1 )
+                = k + k 1
+            }
+            ( vec_push [i] ty 6 ) ( vec_push [i] ty 6 ) ( vec_push [i] ty 6 ) ( vec_push [i] ty 6 )
+            ( gw_kv_arr_i32 w `tokenizer.ggml.token_type` ty )
+            ( vec_free [i] ty )
+            ( gw_kv_u32 w `tokenizer.ggml.bos_token_id` 1 )
+            ( gw_kv_u32 w `tokenizer.ggml.eos_token_id` 2 )
+            ( gw_kv_u32 w `tokenizer.ggml.unknown_token_id` 0 )
+            ( gw_kv_bool w `tokenizer.ggml.add_bos_token` T )
+            : !v String wr ( gw_write w path )
+            ( gw_free w )
+            ?? wr { T _ → {} F e → { ( string_free e ) = ok 0 } }
+        }
+        F e → {
+            ( string_free e )
+            = ok 0
+        }
+    }
+    ^ != ok 0
+}
+
+// Synthetic byte-level BPE vocabulary. Singles are GPT-2-remapped
+// bytes (space → Ġ U+0120): 0..4 h e l o Ġ, then the merge products.
+//  0 h 1 e 2 l 3 o 4 Ġ 5 he 6 hel 7 hell 8 hello 9 Ġhello 10 <|end|>
+@ __nl_build_bpe s path → b {
+    : ~ i ok 1
+    ?? ( gw_new 32 ) {
+        T w → {
+            ( gw_kv_str w `tokenizer.ggml.model` `gpt2` )
+            : ( Vec String ) toks ( vec_new [String] )
+            ( vec_push [String] toks ( string_from `h` ) )
+            ( vec_push [String] toks ( string_from `e` ) )
+            ( vec_push [String] toks ( string_from `l` ) )
+            ( vec_push [String] toks ( string_from `o` ) )
+            ( vec_push [String] toks ( utf8_encode_cp 288 ) )
+            ( vec_push [String] toks ( string_from `he` ) )
+            ( vec_push [String] toks ( string_from `hel` ) )
+            ( vec_push [String] toks ( string_from `hell` ) )
+            ( vec_push [String] toks ( string_from `hello` ) )
+            : String gh ( utf8_encode_cp 288 )
+            ( string_push_str gh `hello` )
+            ( vec_push [String] toks gh )
+            ( vec_push [String] toks ( string_from `<|end|>` ) )
+            ( gw_kv_arr_str w `tokenizer.ggml.tokens` toks )
+            ( vec_free_with [String] toks \ String s → v { ( string_free s ) } )
+            : ( Vec i ) ty ( vec_new [i] )
+            : ~ i k 0
+            ~ < k 10 {
+                ( vec_push [i] ty 1 )
+                = k + k 1
+            }
+            ( vec_push [i] ty 3 )
+            ( gw_kv_arr_i32 w `tokenizer.ggml.token_type` ty )
+            ( vec_free [i] ty )
+            : ( Vec String ) mg ( vec_new [String] )
+            ( vec_push [String] mg ( string_from `h e` ) )
+            ( vec_push [String] mg ( string_from `he l` ) )
+            ( vec_push [String] mg ( string_from `hel l` ) )
+            ( vec_push [String] mg ( string_from `hell o` ) )
+            : String m5 ( utf8_encode_cp 288 )
+            ( string_push_str m5 ` hello` )
+            ( vec_push [String] mg m5 )
+            ( gw_kv_arr_str w `tokenizer.ggml.merges` mg )
+            ( vec_free_with [String] mg \ String s → v { ( string_free s ) } )
+            ( gw_kv_u32 w `tokenizer.ggml.eos_token_id` 10 )
+            : !v String wr ( gw_write w path )
+            ( gw_free w )
+            ?? wr { T _ → {} F e → { ( string_free e ) = ok 0 } }
+        }
+        F e → {
+            ( string_free e )
+            = ok 0
+        }
+    }
+    ^ != ok 0
+}
+
+@ __nl_selftest → i {
+    : ~ NlCnt cn @ NlCnt { 0 0 }
+    : !String IoErr tf ( fs_tempfile `/tmp` `nurllama-selftest.` )
+    : ~ String path ( string_new )
+    ?? tf {
+        T p → {
+            ( string_free path )
+            = path p
+        }
+        F _ → {
+            ( nurl_eprintln `selftest: cannot create a temp file under /tmp` )
+            ^ 1
+        }
+    }
+
+    // ── SPM ──
+    ( __nl_ck cn ( __nl_build_spm ( string_data path ) ) `SPM: synthetic vocab written` )
+    ?? ( gguf_open ( string_data path ) ) {
+        T g → {
+            ?? ( tok_new g ) {
+                T t → {
+                    ( __nl_ck cn == ( tok_n_vocab t ) 23 `SPM: vocab size` )
+                    ( __nl_ck cn & == ( tok_bos t ) 1 == ( tok_eos t ) 2 `SPM: special ids` )
+
+                    : ( Vec i ) e1 ( tok_encode t `hello` T )
+                    : x1 [i | 1 8]
+                    ( __nl_ck cn ( __nl_ids_eq e1 . x1 0 2 ) `SPM: 'hello' → merge chain to ▁hello` )
+                    ( vec_free [i] e1 )
+
+                    : ( Vec i ) e2 ( tok_encode t `hello world` T )
+                    : x2 [i | 1 8 13]
+                    ( __nl_ck cn ( __nl_ids_eq e2 . x2 0 3 ) `SPM: two words` )
+                    ( vec_free [i] e2 )
+
+                    : ( Vec i ) e3 ( tok_encode t `hell` T )
+                    : x3 [i | 1 7]
+                    ( __nl_ck cn ( __nl_ids_eq e3 . x3 0 2 ) `SPM: prefix piece wins` )
+                    ( vec_free [i] e3 )
+
+                    // 😀 = F0 9F 98 80 → the four BYTE tokens
+                    : ( Vec i ) e4 ( tok_encode t `😀` T )
+                    : x4 [i | 1 3 19 20 21 22]
+                    ( __nl_ck cn ( __nl_ids_eq e4 . x4 0 6 ) `SPM: byte fallback (emoji)` )
+                    ( vec_free [i] e4 )
+
+                    // 'z' has no piece and no byte token → UNK
+                    : ( Vec i ) e5 ( tok_encode t `z` T )
+                    : x5 [i | 1 3 0]
+                    ( __nl_ck cn ( __nl_ids_eq e5 . x5 0 3 ) `SPM: unknown char → UNK` )
+                    ( vec_free [i] e5 )
+
+                    : ( Vec i ) e6 ( tok_encode t `` T )
+                    : x6 [i | 1]
+                    ( __nl_ck cn ( __nl_ids_eq e6 . x6 0 1 ) `SPM: empty text → just BOS` )
+                    ( vec_free [i] e6 )
+
+                    // decode: control tokens vanish, ▁ → space, bytes rejoin
+                    : ( Vec i ) e7 ( tok_encode t `hello world` T )
+                    : ( Vec u ) d7 ( tok_decode t e7 )
+                    ( __nl_ck cn ( __nl_bytes_is d7 ` hello world` ) `SPM: decode round-trip` )
+                    ( vec_free [u] d7 )
+                    ( vec_free [i] e7 )
+                    : ( Vec i ) e8 ( tok_encode t `😀` T )
+                    : ( Vec u ) d8 ( tok_decode t e8 )
+                    ( __nl_ck cn ( __nl_bytes_is d8 ` 😀` ) `SPM: byte tokens decode to the emoji` )
+                    ( vec_free [u] d8 )
+                    ( vec_free [i] e8 )
+                    ( tok_free t )
+                }
+                F e → {
+                    ( string_free e )
+                    ( __nl_ck cn F `SPM: tok_new` )
+                }
+            }
+            ( gguf_close g )
+        }
+        F e → {
+            ( string_free e )
+            ( __nl_ck cn F `SPM: gguf_open` )
+        }
+    }
+
+    // ── BPE ──
+    ( __nl_ck cn ( __nl_build_bpe ( string_data path ) ) `BPE: synthetic vocab written` )
+    ?? ( gguf_open ( string_data path ) ) {
+        T g → {
+            ?? ( tok_new g ) {
+                T t → {
+                    ( __nl_ck cn == ( tok_n_vocab t ) 11 `BPE: vocab size` )
+
+                    // "hello hello" → [hello, Ġhello]; gpt2 adds no BOS
+                    : ( Vec i ) e1 ( tok_encode t `hello hello` T )
+                    : x1 [i | 8 9]
+                    ( __nl_ck cn ( __nl_ids_eq e1 . x1 0 2 ) `BPE: merge ranks + space glue` )
+                    ( vec_free [i] e1 )
+
+                    // partial merges only: "hell" stops at rank-3 product
+                    : ( Vec i ) e2 ( tok_encode t `hell` T )
+                    : x2 [i | 7]
+                    ( __nl_ck cn ( __nl_ids_eq e2 . x2 0 1 ) `BPE: partial merge chain` )
+                    ( vec_free [i] e2 )
+
+                    // 'ol' has no merge → two singles
+                    : ( Vec i ) e3 ( tok_encode t `ol` T )
+                    : x3 [i | 3 2]
+                    ( __nl_ck cn ( __nl_ids_eq e3 . x3 0 2 ) `BPE: unmergeable pair stays split` )
+                    ( vec_free [i] e3 )
+
+                    : ( Vec i ) e4 ( tok_encode t `hello hello` T )
+                    : ( Vec u ) d4 ( tok_decode t e4 )
+                    ( __nl_ck cn ( __nl_bytes_is d4 `hello hello` ) `BPE: decode inverts the byte remap` )
+                    ( vec_free [u] d4 )
+                    ( vec_free [i] e4 )
+                    ( tok_free t )
+                }
+                F e → {
+                    ( string_free e )
+                    ( __nl_ck cn F `BPE: tok_new` )
+                }
+            }
+            ( gguf_close g )
+        }
+        F e → {
+            ( string_free e )
+            ( __nl_ck cn F `BPE: gguf_open` )
+        }
+    }
+
+    ( file_delete ( string_data path ) )
+    ( string_free path )
+    : String m ( string_from `selftest: ` )
+    ( string_push_int m . cn pass )
+    ( string_push_str m ` passed, ` )
+    ( string_push_int m . cn fail )
+    ( string_push_str m ` failed` )
+    ( nurl_print ( string_data m ) )
+    ( nurl_print `\n` )
+    ( string_free m )
+    ^ ? > . cn fail 0 1 0
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────
+
+@ main → i {
+    : ArgParser p ( args_new `nurllama` `Run language models locally — phase 2: the GGUF-vocabulary tokenizer.` )
+    ( args_flag p `help` 104 `show this help` )
+    ( args_flag p `version` 0 `print the version` )
+    ( args_flag p `no-special` 0 `tokenize: do not add BOS/EOS` )
+    ? ( args_parse_argv p ) {} {
+        ( nurl_eprintln ( args_error p ) )
+        ( args_free p )
+        ^ 2
+    }
+    ? ( args_present p `help` ) {
+        : String u ( args_usage p )
+        ( nurl_print ( string_data u ) )
+        ( nurl_print `\ncommands:\n  tokenize <model.gguf> <text> · detok <model.gguf> <id> [id …]\n  vocab <model.gguf> [n] · selftest\n` )
+        ( string_free u )
+        ( args_free p )
+        ^ 0
+    } {}
+    ? ( args_present p `version` ) {
+        ( nurl_print `nurllama 0.1.0\n` )
+        ( args_free p )
+        ^ 0
+    } {}
+    ? < ( args_positional_count p ) 1 {
+        ( nurl_eprintln `usage: nurllama <tokenize|detok|vocab|selftest> … (nurllama --help)` )
+        ( args_free p )
+        ^ 2
+    } {}
+    : ( Vec String ) pos ( args_positionals p )
+    : ~ s cmd ``
+    ?? ( vec_get [String] pos 0 ) {
+        T c → { = cmd ( string_data c ) }
+        F → {}
+    }
+
+    ? ( nurl_str_eq cmd `selftest` ) {
+        : i rc ( __nl_selftest )
+        ( args_free p )
+        ^ rc
+    } {}
+
+    ? < ( args_positional_count p ) 2 {
+        ( args_free p )
+        ^ ( __nl_err ( string_from `nurllama: this command needs a model file (nurllama --help)` ) )
+    } {}
+    : ~ s mpath ``
+    ?? ( vec_get [String] pos 1 ) {
+        T c → { = mpath ( string_data c ) }
+        F → {}
+    }
+    : ~ i rc 0
+    ?? ( gguf_open mpath ) {
+        T g → {
+            ?? ( tok_new g ) {
+                T t → {
+                    ? ( nurl_str_eq cmd `tokenize` ) {
+                        : ~ s text ``
+                        ?? ( vec_get [String] pos 2 ) {
+                            T c → { = text ( string_data c ) }
+                            F → {}
+                        }
+                        : ( Vec i ) ids ( tok_encode t text ! ( args_present p `no-special` ) )
+                        ( __nl_print_ids ids )
+                        ( vec_free [i] ids )
+                    } {
+                        ? ( nurl_str_eq cmd `detok` ) {
+                            : ( Vec i ) ids ( vec_new [i] )
+                            : ~ i k 2
+                            ~ < k ( args_positional_count p ) {
+                                ?? ( vec_get [String] pos k ) {
+                                    T c → {
+                                        ?? ( string_to_int c ) {
+                                            T v2 → { ( vec_push [i] ids v2 ) }
+                                            F _ → {}
+                                        }
+                                    }
+                                    F → {}
+                                }
+                                = k + k 1
+                            }
+                            : ( Vec u ) out ( tok_decode t ids )
+                            : i n ( vec_len [u] out )
+                            ? > n 0 { : i _w ( write 1 # *u ( vec_data [u] out ) n ) } {}
+                            ( nurl_print `\n` )
+                            ( vec_free [u] out )
+                            ( vec_free [i] ids )
+                        } {
+                            ? ( nurl_str_eq cmd `vocab` ) {
+                                : ~ i n ( tok_n_vocab t )
+                                ? >= ( args_positional_count p ) 3 {
+                                    ?? ( vec_get [String] pos 2 ) {
+                                        T c → {
+                                            ?? ( string_to_int c ) {
+                                                T v2 → { ? < v2 n { = n v2 } {} }
+                                                F _ → {}
+                                            }
+                                        }
+                                        F → {}
+                                    }
+                                } {}
+                                : ~ i k 0
+                                ~ < k n {
+                                    : String m ( string_new )
+                                    ( string_push_int m k )
+                                    ( string_push_str m `: ` )
+                                    ( string_push_str m ( __tk_piece_data t k ) )
+                                    ( nurl_print ( string_data m ) )
+                                    ( nurl_print `\n` )
+                                    ( string_free m )
+                                    = k + k 1
+                                }
+                            } {
+                                ( nurl_eprintln `nurllama: unknown command (nurllama --help)` )
+                                = rc 2
+                            }
+                        }
+                    }
+                    ( tok_free t )
+                }
+                F e → { = rc ( __nl_err e ) }
+            }
+            ( gguf_close g )
+        }
+        F e → { = rc ( __nl_err e ) }
+    }
+    ( args_free p )
+    ^ rc
+}

--- a/packages/nurllama/src/tokenizer.nu
+++ b/packages/nurllama/src/tokenizer.nu
@@ -1,0 +1,669 @@
+// packages/nurllama/src/tokenizer.nu — LLM tokenizer from a GGUF vocabulary.
+//
+// Everything comes out of the model file itself (tokenizer.ggml.* metadata
+// read through packages/gguf) — no external vocab files, no exporter step:
+//
+//   ( tok_new g )                     → !*Tok String    from an open *Gguf
+//   ( tok_free t )
+//   ( tok_encode t text add_special ) → ( Vec i )       token ids
+//   ( tok_piece t id )                → ( Vec u )       one token's raw bytes
+//   ( tok_decode t ids )              → ( Vec u )       ids → bytes (skips
+//                                                        control tokens)
+//   ( tok_n_vocab t ) ( tok_bos t ) ( tok_eos t ) ( tok_unk t )
+//
+// Two tokenizer families, selected by `tokenizer.ggml.model`:
+//
+//   SPM ("llama") — SentencePiece-style bigram merging: split the
+//   space-escaped text (` ` → ▁ U+2581, optional leading space) into
+//   UTF-8 characters, then repeatedly merge the adjacent pair whose
+//   concatenation is a vocab piece with the HIGHEST score (ties →
+//   leftmost), exactly llama.cpp's llm_tokenizer_spm selection order.
+//   Characters that never reach a vocab piece fall back to the <0xXX>
+//   BYTE tokens, then to UNK.
+//
+//   BPE ("gpt2") — byte-level BPE: GPT-2's byte→unicode remap, greedy
+//   regex-style pre-split (contractions / letters / digits / punct /
+//   whitespace), then lowest-merge-rank pairing driven by
+//   tokenizer.ggml.merges. NOTE v1: the pre-split implements the GPT-2
+//   pattern with \p{L} approximated as "ASCII letters + any cp ≥ 0x80"
+//   — per-model `tokenizer.ggml.pre` variants (qwen2 digit splitting
+//   etc.) are a follow-up.
+//
+// The Tok owns copies of every piece (the source Gguf can be closed
+// after tok_new). The piece→id map borrows the buffers of `pieces` —
+// stable because Vec growth moves the String structs, never the heap
+// buffers they point to.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/hashmap.nu`
+$ `stdlib/std/utf8.nu`
+$ `deps/gguf/src/gguf.nu`
+
+// token_type values (tokenizer.ggml.token_type, llama.cpp llama_token_type)
+: i TT_NORMAL 1
+: i TT_UNKNOWN 2
+: i TT_CONTROL 3
+: i TT_USER 4
+: i TT_UNUSED 5
+: i TT_BYTE 6
+
+: i TOK_SPM 0
+: i TOK_BPE 1
+
+: Tok {
+    i mode
+    ( Vec String ) pieces
+    ( Vec f ) scores
+    ( Vec i ) ttype
+    ( HashMap s i ) lookup
+    ( HashMap s i ) ranks
+    ( Vec String ) rankkeys
+    ( Vec String ) byte_enc
+    ( Vec i ) byte_id
+    i bos
+    i eos
+    i unk
+    b add_bos
+    b add_eos
+    b add_space_prefix
+}
+
+// ── string-keyed map helpers (yoloe/bpe.nu idiom) ───────────────────
+@ __tk_set ( HashMap s i ) m s key i val → v {
+    : ?i _old ( map_set [s i] m key val \ s x → i { ^ ( hash_string x ) } \ s a s b → b { ^ ( eq_string a b ) } )
+}
+
+@ __tk_get ( HashMap s i ) m s key → ?i {
+    ^ ( map_get [s i] m key \ s x → i { ^ ( hash_string x ) } \ s a s b → b { ^ ( eq_string a b ) } )
+}
+
+@ __tk_geti ( Vec i ) v i k i def → i {
+    ?? ( vec_get [i] v k ) { T x → { ^ x } F → { ^ def } }
+}
+
+@ __tk_getf ( Vec f ) v i k → f {
+    ?? ( vec_get [f] v k ) { T x → { ^ x } F → { ^ 0.0 } }
+}
+
+// Borrowed data pointer of piece #k ("" when out of range).
+@ __tk_piece_data * Tok t i k → s {
+    ?? ( vec_get [String] . t pieces k ) { T p → { ^ ( string_data p ) } F → { ^ `` } }
+}
+
+// ── GPT-2 byte→unicode remap ────────────────────────────────────────
+// Bytes that are "printable" keep their codepoint ('!'..'~', 0xA1..0xAC,
+// 0xAE..0xFF); every other byte b gets 256+n with n counting the
+// non-printable bytes in ascending byte order. Exactly gpt2's
+// bytes_to_unicode().
+@ __tk_byte_keeps_cp i b2 → b {
+    ? & >= b2 33 <= b2 126 { ^ T } {}
+    ? & >= b2 161 <= b2 172 { ^ T } {}
+    ^ & >= b2 174 <= b2 255
+}
+
+@ __tk_build_byte_enc → ( Vec String ) {
+    : ( Vec String ) enc ( vec_new [String] )
+    : ~ i n 0
+    : ~ i b2 0
+    ~ < b2 256 {
+        ? ( __tk_byte_keeps_cp b2 ) {
+            ( vec_push [String] enc ( utf8_encode_cp b2 ) )
+        } {
+            ( vec_push [String] enc ( utf8_encode_cp + 256 n ) )
+            = n + n 1
+        }
+        = b2 + b2 1
+    }
+    ^ enc
+}
+
+// ── construction ────────────────────────────────────────────────────
+
+@ __tk_err s msg → !*Tok String {
+    ^ @ !*Tok String { F ( string_from msg ) }
+}
+
+// Parse "<0xNN>" → byte value, -1 when the piece is not that shape.
+@ __tk_parse_byte_piece s p → i {
+    ? != ( nurl_str_len p ) 6 { ^ -1 } {}
+    ? | == ( nurl_str_starts p `<0x` ) 0 != ( nurl_str_get p 5 ) 62 { ^ -1 } {}
+    : i h1 ( hex_val ( nurl_str_get p 3 ) )
+    : i h2 ( hex_val ( nurl_str_get p 4 ) )
+    ? | < h1 0 < h2 0 { ^ -1 } {}
+    ^ | << h1 4 h2
+}
+
+// Build a tokenizer from an open GGUF model. Copies the vocabulary —
+// the Gguf may be closed afterwards.
+@ tok_new * Gguf g → !*Tok String {
+    : s model ( gguf_kv_str_or g `tokenizer.ggml.model` `` )
+    : ~ i mode -1
+    ? ( nurl_str_eq model `llama` ) { = mode TOK_SPM } {}
+    ? ( nurl_str_eq model `gpt2` ) { = mode TOK_BPE } {}
+    ? < mode 0 {
+        : String m ( string_from `tokenizer: unsupported tokenizer.ggml.model '` )
+        ( string_push_str m model )
+        ( string_push_str m `' (supported: llama, gpt2)` )
+        ^ @ !*Tok String { F m }
+    } {}
+
+    : i tki ( gguf_find_kv g `tokenizer.ggml.tokens` )
+    ? < tki 0 { ^ ( __tk_err `tokenizer: model has no tokenizer.ggml.tokens vocabulary` ) } {}
+
+    : *Tok t # *Tok ( nurl_alloc Z Tok )
+    = . t mode mode
+    = . t pieces ( vec_new [String] )
+    = . t scores ( vec_new [f] )
+    = . t ttype ( vec_new [i] )
+    = . t lookup ( map_new [s i] )
+    = . t ranks ( map_new [s i] )
+    = . t rankkeys ( vec_new [String] )
+    = . t byte_enc ? == mode TOK_BPE ( __tk_build_byte_enc ) ( vec_new [String] )
+    = . t byte_id ( vec_new [i] )
+    = . t bos ( gguf_kv_int_or g `tokenizer.ggml.bos_token_id` -1 )
+    = . t eos ( gguf_kv_int_or g `tokenizer.ggml.eos_token_id` -1 )
+    = . t unk ( gguf_kv_int_or g `tokenizer.ggml.unknown_token_id` -1 )
+    = . t add_bos ? != 0 ( gguf_kv_int_or g `tokenizer.ggml.add_bos_token` ? == mode TOK_SPM 1 0 ) T F
+    = . t add_eos ? != 0 ( gguf_kv_int_or g `tokenizer.ggml.add_eos_token` 0 ) T F
+    = . t add_space_prefix ? != 0 ( gguf_kv_int_or g `tokenizer.ggml.add_space_prefix` ? == mode TOK_SPM 1 0 ) T F
+
+    // vocabulary: copy pieces + scores + types out of the kv arrays
+    ?? ( vec_get [GgufKv] . g kvs tki ) {
+        T a → {
+            : i n ( vec_len [String] . a astr )
+            : ~ i k 0
+            ~ < k n {
+                ?? ( vec_get [String] . a astr k ) {
+                    T p → { ( vec_push [String] . t pieces ( string_clone p ) ) }
+                    F → { ( vec_push [String] . t pieces ( string_new ) ) }
+                }
+                = k + k 1
+            }
+        }
+        F → {}
+    }
+    : i nvocab ( vec_len [String] . t pieces )
+    ? == nvocab 0 {
+        ( tok_free t )
+        ^ ( __tk_err `tokenizer: empty vocabulary` )
+    } {}
+
+    : i sci ( gguf_find_kv g `tokenizer.ggml.scores` )
+    ? >= sci 0 {
+        ?? ( vec_get [GgufKv] . g kvs sci ) {
+            T a → {
+                : ~ i k 0
+                ~ < k nvocab {
+                    ( vec_push [f] . t scores ( __tk_getf . a af k ) )
+                    = k + k 1
+                }
+            }
+            F → {}
+        }
+    } {}
+    : i tyi ( gguf_find_kv g `tokenizer.ggml.token_type` )
+    ? >= tyi 0 {
+        ?? ( vec_get [GgufKv] . g kvs tyi ) {
+            T a → {
+                : ~ i k 0
+                ~ < k nvocab {
+                    ( vec_push [i] . t ttype ( __tk_geti . a ai k TT_NORMAL ) )
+                    = k + k 1
+                }
+            }
+            F → {}
+        }
+    } {}
+
+    // piece → id (last one wins on a duplicate piece, like llama.cpp's
+    // token_to_id map). Keys borrow the pieces' heap buffers.
+    : ~ i k 0
+    ~ < k nvocab {
+        ( __tk_set . t lookup ( __tk_piece_data t k ) k )
+        = k + k 1
+    }
+
+    // byte → id table: SPM <0xNN> BYTE pieces; BPE remapped singles
+    = k 0
+    ~ < k 256 {
+        ( vec_push [i] . t byte_id -1 )
+        = k + k 1
+    }
+    ? == mode TOK_SPM {
+        = k 0
+        ~ < k nvocab {
+            : i bv ( __tk_parse_byte_piece ( __tk_piece_data t k ) )
+            ? >= bv 0 { ( vec_set [i] . t byte_id bv k ) } {}
+            = k + k 1
+        }
+    } {
+        = k 0
+        ~ < k 256 {
+            ?? ( vec_get [String] . t byte_enc k ) {
+                T e → {
+                    ?? ( __tk_get . t lookup ( string_data e ) ) {
+                        T id → { ( vec_set [i] . t byte_id k id ) }
+                        F → {}
+                    }
+                }
+                F → {}
+            }
+            = k + k 1
+        }
+    }
+
+    // BPE merge ranks: "A B" (as stored in the merges array) → rank
+    ? == mode TOK_BPE {
+        : i mgi ( gguf_find_kv g `tokenizer.ggml.merges` )
+        ? < mgi 0 {
+            ( tok_free t )
+            ^ ( __tk_err `tokenizer: gpt2 model has no tokenizer.ggml.merges` )
+        } {}
+        ?? ( vec_get [GgufKv] . g kvs mgi ) {
+            T a → {
+                : i nm ( vec_len [String] . a astr )
+                : ~ i r 0
+                ~ < r nm {
+                    ?? ( vec_get [String] . a astr r ) {
+                        T mstr → {
+                            ( vec_push [String] . t rankkeys ( string_clone mstr ) )
+                            ?? ( vec_get [String] . t rankkeys r ) {
+                                T own → { ( __tk_set . t ranks ( string_data own ) r ) }
+                                F → {}
+                            }
+                        }
+                        F → {}
+                    }
+                    = r + r 1
+                }
+            }
+            F → {}
+        }
+    } {}
+    ^ @ !*Tok String { T t }
+}
+
+@ tok_free * Tok t → v {
+    ( vec_free_with [String] . t pieces \ String s → v { ( string_free s ) } )
+    ( vec_free [f] . t scores )
+    ( vec_free [i] . t ttype )
+    ( map_free [s i] . t lookup )
+    ( map_free [s i] . t ranks )
+    ( vec_free_with [String] . t rankkeys \ String s → v { ( string_free s ) } )
+    ( vec_free_with [String] . t byte_enc \ String s → v { ( string_free s ) } )
+    ( vec_free [i] . t byte_id )
+    ( nurl_free # s t )
+}
+
+@ tok_n_vocab * Tok t → i { ^ ( vec_len [String] . t pieces ) }
+
+@ tok_bos * Tok t → i { ^ . t bos }
+
+@ tok_eos * Tok t → i { ^ . t eos }
+
+@ tok_unk * Tok t → i { ^ . t unk }
+
+// ── SPM encode ──────────────────────────────────────────────────────
+
+// Push token(s) for one unmerged symbol: vocab piece, else per-byte
+// <0xNN>, else UNK once.
+@ __tk_spm_emit * Tok t s esc i off i len ( Vec i ) out → v {
+    : String sym ( string_new )
+    ( string_push_bytes sym # *u + # i esc off len )
+    ?? ( __tk_get . t lookup ( string_data sym ) ) {
+        T id → { ( vec_push [i] out id ) }
+        F → {
+            : ~ i j 0
+            ~ < j len {
+                : i bv ( nurl_str_get esc + off j )
+                : i bid ( __tk_geti . t byte_id bv -1 )
+                ? >= bid 0 { ( vec_push [i] out bid ) } {
+                    ? >= . t unk 0 { ( vec_push [i] out . t unk ) } {}
+                }
+                = j + j 1
+            }
+        }
+    }
+    ( string_free sym )
+}
+
+@ __tk_spm_encode * Tok t s text ( Vec i ) out → v {
+    // escape: optional leading space, then every ' ' → ▁ (E2 96 81)
+    : String esc ( string_new )
+    ? & . t add_space_prefix > ( nurl_str_len text ) 0 {
+        ( string_push_str esc `▁` )
+    } {}
+    : ~ i p 0
+    : i tn ( nurl_str_len text )
+    ~ < p tn {
+        : i b2 ( nurl_str_get text p )
+        ? == b2 32 { ( string_push_str esc `▁` ) } { ( string_push_char esc b2 ) }
+        = p + p 1
+    }
+    : s e ( string_data esc )
+    : i en ( string_len esc )
+
+    // split into UTF-8 characters: parallel start/len + doubly-linked
+    // alive list (nxt/prv by symbol index, -1 = end)
+    : ( Vec i ) starts ( vec_new [i] )
+    : ( Vec i ) lens ( vec_new [i] )
+    : ( Vec i ) nxt ( vec_new [i] )
+    : ( Vec i ) prv ( vec_new [i] )
+    = p 0
+    : ~ i nsym 0
+    ~ < p en {
+        : Utf8Dec d ( utf8_decode e p )
+        ? < . d width 1 { = p en } {
+            ( vec_push [i] starts p )
+            ( vec_push [i] lens . d width )
+            ( vec_push [i] nxt + nsym 1 )
+            ( vec_push [i] prv - nsym 1 )
+            = nsym + nsym 1
+            = p + p . d width
+        }
+    }
+    ? == nsym 0 {
+        ( string_free esc )
+        ( vec_free [i] starts ) ( vec_free [i] lens )
+        ( vec_free [i] nxt ) ( vec_free [i] prv )
+        ^ v
+    } {}
+    ( vec_set [i] nxt - nsym 1 -1 )
+
+    // bigram merge: highest-score vocab pair wins, leftmost on ties —
+    // llama.cpp llm_tokenizer_spm order. Rescan per round: prompt-sized
+    // inputs make O(n²) irrelevant next to the model forward pass.
+    : String pair ( string_new )
+    : ~ b again T
+    ~ again {
+        = again F
+        : ~ i best -1
+        : ~ f best_score -1.0e30
+        : ~ i j 0
+        ~ >= j 0 {
+            : i nj ( __tk_geti nxt j -1 )
+            ? >= nj 0 {
+                : i o1 ( __tk_geti starts j 0 )
+                : i l1 ( __tk_geti lens j 0 )
+                : i l2 ( __tk_geti lens nj 0 )
+                ( string_clear pair )
+                ( string_push_bytes pair # *u + # i e o1 + l1 l2 )
+                ?? ( __tk_get . t lookup ( string_data pair ) ) {
+                    T id → {
+                        : f sc ( __tk_getf . t scores id )
+                        ? > sc best_score {
+                            = best j
+                            = best_score sc
+                        } {}
+                    }
+                    F → {}
+                }
+            } {}
+            = j nj
+        }
+        ? >= best 0 {
+            : i nb ( __tk_geti nxt best -1 )
+            ( vec_set [i] lens best + ( __tk_geti lens best 0 ) ( __tk_geti lens nb 0 ) )
+            : i nn ( __tk_geti nxt nb -1 )
+            ( vec_set [i] nxt best nn )
+            ? >= nn 0 { ( vec_set [i] prv nn best ) } {}
+            = again T
+        } {}
+    }
+    ( string_free pair )
+
+    : ~ i j 0
+    ~ >= j 0 {
+        ( __tk_spm_emit t e ( __tk_geti starts j 0 ) ( __tk_geti lens j 0 ) out )
+        = j ( __tk_geti nxt j -1 )
+    }
+    ( vec_free [i] starts ) ( vec_free [i] lens )
+    ( vec_free [i] nxt ) ( vec_free [i] prv )
+    ( string_free esc )
+}
+
+// ── BPE encode ──────────────────────────────────────────────────────
+
+@ __tk_is_ascii_letter i b2 → b {
+    ^ | & >= b2 65 <= b2 90 & >= b2 97 <= b2 122
+}
+
+@ __tk_is_ascii_digit i b2 → b { ^ & >= b2 48 <= b2 57 }
+
+@ __tk_is_ws i b2 → b {
+    ^ | | | == b2 32 == b2 9 == b2 10 == b2 13
+}
+
+// "letter" under the v1 \p{L} approximation: ASCII letter or any
+// non-ASCII lead byte (multibyte scripts tokenize as letter runs).
+@ __tk_is_letterish i b2 → b {
+    ^ | ( __tk_is_ascii_letter b2 ) >= b2 128
+}
+
+// GPT-2 contraction after an apostrophe at text[p]: returns the length
+// INCLUDING the apostrophe, or 0.
+@ __tk_contraction s text i p i n → i {
+    ? >= + p 1 n { ^ 0 } {}
+    : i c1 ( nurl_str_get text + p 1 )
+    ? | | == c1 115 == c1 116 | == c1 109 == c1 100 { ^ 2 } {}
+    ? >= + p 2 n { ^ 0 } {}
+    : i c2 ( nurl_str_get text + p 2 )
+    ? & == c1 114 == c2 101 { ^ 3 } {}
+    ? & == c1 118 == c2 101 { ^ 3 } {}
+    ? & == c1 108 == c2 108 { ^ 3 } {}
+    ^ 0
+}
+
+// One GPT-2 pre-token starting at p; returns its byte length (≥ 1).
+@ __tk_pretoken_len s text i p i n → i {
+    : i b0 ( nurl_str_get text p )
+    ? == b0 39 {
+        : i cl ( __tk_contraction text p n )
+        ? > cl 0 { ^ cl } {}
+    } {}
+    // ' ?<run>': a single leading space glues to a following letter /
+    // digit / punct run
+    : ~ i q p
+    : ~ i lead 0
+    ? & == b0 32 < + p 1 n {
+        : i b1 ( nurl_str_get text + p 1 )
+        ? ! ( __tk_is_ws b1 ) {
+            = q + p 1
+            = lead 1
+        } {}
+    } {}
+    : i c ( nurl_str_get text q )
+    ? ( __tk_is_letterish c ) {
+        : ~ i r q
+        ~ & < r n ( __tk_is_letterish ( nurl_str_get text r ) ) { = r + r 1 }
+        ^ + lead - r q
+    } {}
+    ? ( __tk_is_ascii_digit c ) {
+        : ~ i r q
+        ~ & < r n ( __tk_is_ascii_digit ( nurl_str_get text r ) ) { = r + r 1 }
+        ^ + lead - r q
+    } {}
+    ? ( __tk_is_ws c ) {
+        // whitespace run (only reachable with lead == 0)
+        : ~ i r q
+        ~ & < r n ( __tk_is_ws ( nurl_str_get text r ) ) { = r + r 1 }
+        ^ - r q
+    } {}
+    // punct run: neither ws nor letterish nor digit
+    : ~ i r q
+    : ~ b more T
+    ~ & more < r n {
+        : i cc ( nurl_str_get text r )
+        ? | | ( __tk_is_ws cc ) ( __tk_is_letterish cc ) ( __tk_is_ascii_digit cc ) { = more F } { = r + r 1 }
+    }
+    ^ + lead - r q
+}
+
+// BPE-merge one pre-token (raw bytes text[off..off+len)) and append ids.
+@ __tk_bpe_word * Tok t s text i off i len ( Vec i ) out → v {
+    // word = remapped single-byte symbols
+    : ( Vec String ) word ( vec_new [String] )
+    : ~ i j 0
+    ~ < j len {
+        : i bv ( nurl_str_get text + off j )
+        ?? ( vec_get [String] . t byte_enc bv ) {
+            T e → { ( vec_push [String] word ( string_clone e ) ) }
+            F → {}
+        }
+        = j + j 1
+    }
+    // lowest-rank adjacent pair merges first (yoloe __bpe idiom, ranks
+    // keyed as "A B" exactly as the merges array stores them)
+    : String key ( string_new )
+    : ~ b again T
+    ~ again {
+        = again F
+        : ~ i best -1
+        : ~ i best_rank 2147483647
+        : ~ i k 0
+        ~ < k - ( vec_len [String] word ) 1 {
+            ( string_clear key )
+            ?? ( vec_get [String] word k ) {
+                T a → { ( string_push_str key ( string_data a ) ) }
+                F → {}
+            }
+            ( string_push_char key 32 )
+            ?? ( vec_get [String] word + k 1 ) {
+                T b3 → { ( string_push_str key ( string_data b3 ) ) }
+                F → {}
+            }
+            ?? ( __tk_get . t ranks ( string_data key ) ) {
+                T r → {
+                    ? < r best_rank {
+                        = best k
+                        = best_rank r
+                    } {}
+                }
+                F → {}
+            }
+            = k + k 1
+        }
+        ? >= best 0 {
+            // concat word[best] ++ word[best+1], drop word[best+1]
+            ?? ( vec_get [String] word + best 1 ) {
+                T b3 → {
+                    ?? ( vec_get [String] word best ) {
+                        T a → { ( string_push_str a ( string_data b3 ) ) }
+                        F → {}
+                    }
+                    ( string_free b3 )
+                }
+                F → {}
+            }
+            : ?String _rm ( vec_remove [String] word + best 1 )
+            = again T
+        } {}
+    }
+    ( string_free key )
+    : ~ i k 0
+    ~ < k ( vec_len [String] word ) {
+        ?? ( vec_get [String] word k ) {
+            T a → {
+                ?? ( __tk_get . t lookup ( string_data a ) ) {
+                    T id → { ( vec_push [i] out id ) }
+                    F → { ? >= . t unk 0 { ( vec_push [i] out . t unk ) } {} }
+                }
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [String] word \ String s → v { ( string_free s ) } )
+}
+
+@ __tk_bpe_encode * Tok t s text ( Vec i ) out → v {
+    : i n ( nurl_str_len text )
+    : ~ i p 0
+    ~ < p n {
+        : i len ( __tk_pretoken_len text p n )
+        ( __tk_bpe_word t text p ? < len 1 1 len out )
+        = p + p ? < len 1 1 len
+    }
+}
+
+// ── public encode / decode ──────────────────────────────────────────
+
+@ tok_encode * Tok t s text b add_special → ( Vec i ) {
+    : ( Vec i ) out ( vec_new [i] )
+    ? & & add_special . t add_bos >= . t bos 0 { ( vec_push [i] out . t bos ) } {}
+    ? == . t mode TOK_SPM { ( __tk_spm_encode t text out ) } { ( __tk_bpe_encode t text out ) }
+    ? & & add_special . t add_eos >= . t eos 0 { ( vec_push [i] out . t eos ) } {}
+    ^ out
+}
+
+// Raw bytes of one token: SPM BYTE pieces become their byte, ▁ becomes
+// a space, control tokens become nothing; BPE pieces run the inverse
+// byte remap.
+@ tok_piece * Tok t i id → ( Vec u ) {
+    : ( Vec u ) out ( vec_new [u] )
+    ? | < id 0 >= id ( tok_n_vocab t ) { ^ out } {}
+    : i ty ( __tk_geti . t ttype id TT_NORMAL )
+    ? == ty TT_CONTROL { ^ out } {}
+    : s p ( __tk_piece_data t id )
+    ? == . t mode TOK_SPM {
+        ? == ty TT_BYTE {
+            : i bv ( __tk_parse_byte_piece p )
+            ? >= bv 0 {
+                ( vec_push [u] out # u bv )
+                ^ out
+            } {}
+        } {}
+        // copy piece bytes, ▁ (E2 96 81) → ' '
+        : i n ( nurl_str_len p )
+        : ~ i j 0
+        ~ < j n {
+            : i b2 ( nurl_str_get p j )
+            ? & & == b2 226 < + j 2 n & == ( nurl_str_get p + j 1 ) 150 == ( nurl_str_get p + j 2 ) 129 {
+                ( vec_push [u] out # u 32 )
+                = j + j 3
+            } {
+                ( vec_push [u] out # u b2 )
+                = j + j 1
+            }
+        }
+        ^ out
+    } {}
+    // BPE: decode remapped codepoints back to bytes
+    : ~ i j 0
+    : i n ( nurl_str_len p )
+    ~ < j n {
+        : Utf8Dec d ( utf8_decode p j )
+        ? < . d width 1 { = j n } {
+            // find the byte whose enc codepoint is d.cp — 256-entry scan
+            // is fine at decode granularity
+            : ~ i bv 0
+            : ~ i hit -1
+            ~ < bv 256 {
+                ?? ( vec_get [String] . t byte_enc bv ) {
+                    T e → {
+                        : Utf8Dec de ( utf8_decode ( string_data e ) 0 )
+                        ? == . de cp . d cp { = hit bv = bv 256 } { = bv + bv 1 }
+                    }
+                    F → { = bv + bv 1 }
+                }
+            }
+            ? >= hit 0 { ( vec_push [u] out # u hit ) } {}
+            = j + j . d width
+        }
+    }
+    ^ out
+}
+
+@ tok_decode * Tok t ( Vec i ) ids → ( Vec u ) {
+    : ( Vec u ) out ( vec_new [u] )
+    : ~ i k 0
+    ~ < k ( vec_len [i] ids ) {
+        : ( Vec u ) pb ( tok_piece t ( __tk_geti ids k -1 ) )
+        ( vec_extend [u] out pb )
+        ( vec_free [u] pb )
+        = k + k 1
+    }
+    ^ out
+}

--- a/packages/nurllama/tests/tokenizer_test.sh
+++ b/packages/nurllama/tests/tokenizer_test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tests/tokenizer_test.sh — proof of the nurllama tokenizer:
+#    1. selftest: synthetic SPM + BPE vocabularies (built with the gguf
+#       writer, parsed back through the real parser) against
+#       hand-derived expected ids — merge chains, byte fallback, UNK,
+#       specials, decode round-trips. 17 checks, no network.
+#    2. CLI surface: tokenize / detok / vocab against the same files.
+#    3. NURL_NET_TESTS=1: token-for-token parity with an INDEPENDENT
+#       python SentencePiece implementation on a real llama.cpp model
+#       (stories260K), plus encode→decode round-trips — unicode,
+#       emoji byte-fallback, whitespace runs, empty string.
+#
+#  Run from the package dir:  ./tests/tokenizer_test.sh
+#  Env: NURL (build driver; defaults to ../../nurl.sh in a checkout)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t nurllama-test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+
+echo "[1/3] build nurllama"
+if ! $NURL src/main.nu "$WORK/nurllama" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build nurllama:"; tail -5 "$WORK/build.err"; exit 1
+fi
+NL="$WORK/nurllama"
+
+echo "[2/3] selftest + CLI surface"
+if timeout 60 "$NL" selftest | grep -q " 0 failed"; then ok "selftest (17 checks)"; else bad "selftest"; fi
+"$NL" tokenize /nonexistent.gguf x >/dev/null 2>&1 && bad "missing model rc" || ok "missing model rejects"
+"$NL" nosuchcmd >/dev/null 2>&1 && bad "unknown command rc" || ok "unknown command rejects"
+
+echo "[3/3] real llama.cpp model parity (independent python reference)"
+if [ "${NURL_NET_TESTS:-0}" = 1 ] && command -v curl >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+    M="$WORK/stories260K.gguf"
+    if curl -sL --max-time 120 -f -o "$M" \
+        https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf; then
+        cat > "$WORK/spm_ref.py" <<'PYEOF'
+import struct, sys
+def read_gguf(path):
+    d=open(path,'rb').read(); off=8
+    nt,nkv=struct.unpack_from('<QQ',d,off); off+=16
+    kvs={}
+    def rs(off):
+        n=struct.unpack_from('<Q',d,off)[0]; off+=8
+        return d[off:off+n], off+n
+    for _ in range(nkv):
+        k,off=rs(off); vt=struct.unpack_from('<I',d,off)[0]; off+=4
+        if vt==8: v,off=rs(off)
+        elif vt==9:
+            at=struct.unpack_from('<I',d,off)[0]; off+=4
+            cnt=struct.unpack_from('<Q',d,off)[0]; off+=8
+            v=[]
+            for _ in range(cnt):
+                if at==8: e,off=rs(off); v.append(e)
+                elif at==6: v.append(struct.unpack_from('<f',d,off)[0]); off+=4
+                elif at==5: v.append(struct.unpack_from('<i',d,off)[0]); off+=4
+                elif at==4: v.append(struct.unpack_from('<I',d,off)[0]); off+=4
+                else: raise Exception('at %d'%at)
+        elif vt==4: v=struct.unpack_from('<I',d,off)[0]; off+=4
+        elif vt==5: v=struct.unpack_from('<i',d,off)[0]; off+=4
+        elif vt==6: v=struct.unpack_from('<f',d,off)[0]; off+=4
+        elif vt==7: v=d[off]; off+=1
+        elif vt in (10,11): v=struct.unpack_from('<q',d,off)[0]; off+=8
+        else: raise Exception('vt %d'%vt)
+        kvs[k.decode()]=v
+    return kvs
+
+kvs=read_gguf(sys.argv[1])
+toks=[t.decode('utf-8',errors='replace') for t in kvs['tokenizer.ggml.tokens']]
+scores=kvs.get('tokenizer.ggml.scores',[0.0]*len(toks))
+bos=kvs.get('tokenizer.ggml.bos_token_id',-1)
+unk=kvs.get('tokenizer.ggml.unknown_token_id',-1)
+lut={}
+for i,t in enumerate(toks): lut[t]=i   # last wins, like llama.cpp
+
+def spm_encode(text):
+    ids=[bos] if bos>=0 else []
+    if not text: return ids
+    esc='▁'+text.replace(' ','▁')
+    syms=list(esc)
+    while True:
+        best=-1; best_score=-1e30
+        for j in range(len(syms)-1):
+            cand=syms[j]+syms[j+1]
+            if cand in lut and scores[lut[cand]]>best_score:
+                best=j; best_score=scores[lut[cand]]
+        if best<0: break
+        syms=syms[:best]+[syms[best]+syms[best+1]]+syms[best+2:]
+    for s in syms:
+        if s in lut: ids.append(lut[s])
+        else:
+            for b in s.encode('utf-8'):
+                ids.append(lut.get('<0x%02X>'%b, unk))
+    return ids
+
+print(' '.join(str(i) for i in spm_encode(sys.stdin.read())))
+PYEOF
+        declare -a TESTS=("Once upon a time" "hello world" \
+            "The quick brown fox jumps over the lazy dog." \
+            "  double  spaces  " "123 + 456 = 579" "emoji: 😀🎉" \
+            "ÄÖ äö ülichen straße" "a" "")
+        P2=0; F2=0
+        for t in "${TESTS[@]}"; do
+            ours=$("$NL" tokenize "$M" "$t")
+            ref=$(printf '%s' "$t" | python3 "$WORK/spm_ref.py" "$M")
+            if [ "$ours" = "$ref" ]; then P2=$((P2+1)); else F2=$((F2+1)); echo "    MISMATCH [$t]: ours=$ours ref=$ref"; fi
+        done
+        [ "$F2" = 0 ] && ok "python parity on ${#TESTS[@]} strings" || bad "python parity ($F2 mismatches)"
+        RT=0
+        for t in "Once upon a time" "ÄÖ straße 😀" "  spaces  "; do
+            ids=$("$NL" tokenize "$M" "$t")
+            back=$("$NL" detok "$M" $ids)
+            [ "$back" = " $t" ] || { RT=1; echo "    RT-MISMATCH [$t] → [$back]"; }
+        done
+        [ "$RT" = 0 ] && ok "encode→decode round-trips" || bad "round-trip"
+        [ "$("$NL" vocab "$M" 3 | wc -l)" = 3 ] && ok "vocab listing" || bad "vocab"
+    else
+        echo "  SKIP download failed"
+    fi
+else
+    echo "  SKIP (set NURL_NET_TESTS=1 with curl + python3 for real-model parity)"
+fi
+
+echo "== nurllama tokenizer tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" = 0 ]

--- a/packages/nurllama/tests/tokenizer_test.sh
+++ b/packages/nurllama/tests/tokenizer_test.sh
@@ -26,6 +26,10 @@ else NURL="nurl"; fi
 
 WORK="$(mktemp -d -t nurllama-test.XXXXXX)"
 trap 'rm -rf "$WORK"' EXIT
+
+# deps/ symlinks are local build artifacts (nurlpkg materialises them from
+# nurl.toml path-deps; .gitignore keeps them out) — create for a fresh clone.
+[ -e deps/gguf ] || { mkdir -p deps && ln -s ../../gguf deps/gguf; }
 PASS=0; FAIL=0
 ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
 bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }


### PR DESCRIPTION
Phase 2 of the local-LLM engine (phase 1 = `packages/gguf`, #449). Two commits:

1. **gguf: drop the arm-slice hoist workaround** — the compiler's arm-drop fix (#450) made the selftest's function-scope hoist unnecessary; the expected-value literals move back to their natural point of use. 37/37 + ASan-clean.

2. **packages/nurllama 0.1.0 — the tokenizer**, loaded entirely from the model's own `tokenizer.ggml.*` metadata (no external vocab files). First consumer of the gguf package as a dependency — including its *writer*, which the selftest uses to fabricate vocabularies and feed them back through the real parser.

   - **SPM (`llama`)**: space-escape to `▁`, UTF-8 char split, repeated highest-score adjacent merge — llama.cpp's `llm_tokenizer_spm` selection order exactly (ties leftmost); `<0xNN>` byte fallback, then UNK. Honors `add_bos/add_eos/add_space_prefix`.
   - **BPE (`gpt2`)**: GPT-2 byte→unicode remap, contraction/letter/digit/punct/whitespace pre-split, lowest-merge-rank pairing from `tokenizer.ggml.merges`. *v1 note:* `\p{L}` approximated as ASCII letters + any cp ≥ 0x80; per-model `tokenizer.ggml.pre` variants (qwen2) are a follow-up.
   - Decode inverts both; control tokens produce nothing. CLI: `tokenize / detok / vocab / selftest`.

## Verification

- `selftest`: **17 checks** against hand-derived ids over synthetic SPM + BPE vocabularies (merge chains, prefix pieces, emoji byte fallback, UNK, empty input, decode round-trips).
- `tests/tokenizer_test.sh` with `NURL_NET_TESTS=1`: **token-for-token parity with an independent python SentencePiece implementation** on a real llama.cpp model (stories260K) — 9 strings incl. unicode, emoji, whitespace runs, empty string — plus encode→decode round-trips.
- ASan/UBSan/LeakSanitizer clean.

Package tests are not wired into compiler CI, per the M6 won't-do decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH