### PR TITLE
stdlib: streaming primitives — file writes/seek, incremental hashing, f16/bf16, term size, progress

### DIFF
--- a/compiler/tests/floatbits_half.nu
+++ b/compiler/tests/floatbits_half.nu
@@ -1,0 +1,73 @@
+// Test: f16 / bf16 bit conversion (stdlib/std/floatbits.nu).
+// Known IEEE pairs (subnormals, ±inf, NaN, -0), round-to-nearest-even
+// narrowing cases, and the strongest property available: EXHAUSTIVE
+// widen→narrow round-trip identity over all 65536 bit patterns of
+// both formats (every f16/bf16 value is exactly representable in f32,
+// so RNE back must reproduce the original bits — NaN payloads too).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/floatbits.nu`
+
+@ ck b ok s name → v {
+    ? ok { ( nurl_print `PASS ` ) } { ( nurl_print `FAIL ` ) }
+    ( nurl_print name )
+    ( nurl_print `\n` )
+}
+
+@ main → i {
+    // widen: hand-checked pairs
+    : ~ b w T
+    ? == ( f16_bits_to_f32_bits 0 ) 0 {} { = w F }
+    ? == ( f16_bits_to_f32_bits 15360 ) 1065353216 {} { = w F }
+    ? == ( f16_bits_to_f32_bits 49152 ) 3221225472 {} { = w F }
+    ? == ( f16_bits_to_f32_bits 1 ) 864026624 {} { = w F }
+    ? == ( f16_bits_to_f32_bits 1023 ) 947896320 {} { = w F }
+    ? == ( f16_bits_to_f32_bits 31744 ) 2139095040 {} { = w F }
+    ? == ( f16_bits_to_f32_bits 64512 ) 4286578688 {} { = w F }
+    ? == ( f16_bits_to_f32_bits 32768 ) 2147483648 {} { = w F }
+    ( ck w `f16 → f32: 0 / 1.0 / -2.0 / subnormals / ±inf / -0` )
+    ( ck == ( bf16_bits_to_f32_bits 16256 ) 1065353216 `bf16 → f32: 1.0` )
+
+    // narrow RNE: 1.0 exact; nextafter cases tie to even; overflow → inf;
+    // tiny → subnormal; f64-level conveniences agree
+    : ~ b r T
+    ? == ( f_to_f16 1.0 ) 15360 {} { = r F }
+    ? == ( f_to_f16 65504.0 ) 31743 {} { = r F }
+    ? == ( f_to_f16 65520.0 ) 31744 {} { = r F }
+    ? == ( f_to_f16 -65520.0 ) 64512 {} { = r F }
+    ? == ( f_to_f16 0.00006103515625 ) 1024 {} { = r F }
+    ? == ( f_to_f16 0.000000059604644775390625 ) 1 {} { = r F }
+    ? == ( f_to_f16 1.0009765625 ) 15361 {} { = r F }
+    ? == ( f_to_f16 1.00048828125 ) 15360 {} { = r F }
+    ? == ( f_to_f16 1.00146484375 ) 15362 {} { = r F }
+    ( ck r `f32 → f16 RNE: max/overflow/subnormal/ties-to-even` )
+    : ~ b rb T
+    ? == ( f_to_bf16 1.0 ) 16256 {} { = rb F }
+    ? == ( f_to_bf16 -2.0 ) 49152 {} { = rb F }
+    // 1 + 1/256 is EXACTLY halfway between bf16 0x3F80 and 0x3F81 —
+    // ties go to the even mantissa, i.e. DOWN here
+    ? == ( f_to_bf16 1.00390625 ) 16256 {} { = rb F }
+    ? == ( f_to_bf16 1.001953125 ) 16256 {} { = rb F }
+    // 1 + 3/256: tie again, but the lower neighbour 0x3F81 is odd —
+    // even means rounding UP to 0x3F82
+    ? == ( f_to_bf16 1.01171875 ) 16258 {} { = rb F }
+    ( ck rb `f32 → bf16 RNE: exact + ties-to-even` )
+
+    // exhaustive round-trips: 65536 patterns each way
+    : ~ i bad16 0
+    : ~ i h 0
+    ~ < h 65536 {
+        ? == ( f32_bits_to_f16_bits ( f16_bits_to_f32_bits h ) ) h {} { = bad16 + bad16 1 }
+        = h + h 1
+    }
+    ( ck == bad16 0 `f16 → f32 → f16 identity over all 65536 patterns` )
+    : ~ i badb 0
+    = h 0
+    ~ < h 65536 {
+        ? == ( f32_bits_to_bf16_bits ( bf16_bits_to_f32_bits h ) ) h {} { = badb + badb 1 }
+        = h + h 1
+    }
+    ( ck == badb 0 `bf16 → f32 → bf16 identity over all 65536 patterns` )
+    ^ 0
+}

--- a/compiler/tests/fs_write_handle.nu
+++ b/compiler/tests/fs_write_handle.nu
@@ -1,0 +1,121 @@
+// Test: handle-based streaming writes + seeking (stdlib/std/fs.nu).
+// file_create/file_write_chunk build a file in pieces (binary-safe,
+// NULs included); file_append extends it; file_seek/file_tell/
+// file_read_at give random access — the primitives under resumable
+// downloads and large exports.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+
+: s TPATH `/tmp/nurl_fswh_test.bin`
+
+@ ck b ok s name → v {
+    ? ok { ( nurl_print `PASS ` ) } { ( nurl_print `FAIL ` ) }
+    ( nurl_print name )
+    ( nurl_print `\n` )
+}
+
+@ main → i {
+    ( file_delete TPATH )
+
+    // create + two chunks, the first with an embedded NUL
+    : ( Vec u ) c1 ( vec_new [u] )
+    ( bytes_extend_str c1 `hello` )
+    ( vec_push [u] c1 # u 0 )
+    ( bytes_extend_str c1 `world` )
+    : ( Vec u ) c2 ( vec_new [u] )
+    ( bytes_extend_str c2 `-streamed` )
+    ?? ( file_create TPATH ) {
+        T f → {
+            : ~ b ok T
+            ?? ( file_write_chunk f c1 ) { T _ → {} F _ → { = ok F } }
+            ?? ( file_flush f ) { T _ → {} F _ → { = ok F } }
+            ?? ( file_write_chunk f c2 ) { T _ → {} F _ → { = ok F } }
+            // tell: 11 + 9 = 20
+            ?? ( file_tell f ) {
+                T posn → { ( ck & ok == posn 20 `create + chunks + tell` ) }
+                F _ → { ( ck F `create + chunks + tell` ) }
+            }
+            ( file_close f )
+        }
+        F _ → { ( ck F `create + chunks + tell` ) }
+    }
+    ( vec_free [u] c1 )
+
+    // append a third chunk
+    ?? ( file_append TPATH ) {
+        T f → {
+            ?? ( file_write_chunk f c2 ) {
+                T _ → { ( ck T `append` ) }
+                F _ → { ( ck F `append` ) }
+            }
+            ( file_close f )
+        }
+        F _ → { ( ck F `append` ) }
+    }
+    ( vec_free [u] c2 )
+
+    // whole-file read back: 29 bytes, NUL intact at index 5
+    ?? ( read_file_bytes TPATH ) {
+        T all → {
+            : ~ i b5 -1
+            ?? ( vec_get [u] all 5 ) { T x → { = b5 # i x } F → {} }
+            ( ck & == ( vec_len [u] all ) 29 == b5 0 `binary round-trip (29 B, NUL kept)` )
+            ( vec_free [u] all )
+        }
+        F _ → { ( ck F `binary round-trip` ) }
+    }
+
+    // random access on a read handle: seek END for size, read_at
+    ?? ( file_open TPATH ) {
+        T f → {
+            ?? ( file_seek f 0 FS_SEEK_END ) {
+                T sz → { ( ck == sz 29 `seek END reports size` ) }
+                F _ → { ( ck F `seek END reports size` ) }
+            }
+            ?? ( file_read_at f 6 5 ) {
+                T v → {
+                    : String got ( bytes_to_str v )
+                    ( ck ( string_eq_s got `world` ) `read_at mid-file` )
+                    ( string_free got )
+                    ( vec_free [u] v )
+                }
+                F _ → { ( ck F `read_at mid-file` ) }
+            }
+            // relative seek: CUR is at 11 now; +9 → 20, then read tail
+            ?? ( file_seek f 9 FS_SEEK_CUR ) {
+                T posn → { ( ck == posn 20 `seek CUR` ) }
+                F _ → { ( ck F `seek CUR` ) }
+            }
+            ?? ( file_read_chunk f 64 ) {
+                T v → {
+                    : String got ( bytes_to_str v )
+                    ( ck ( string_eq_s got `-streamed` ) `tail after seek` )
+                    ( string_free got )
+                    ( vec_free [u] v )
+                }
+                F _ → { ( ck F `tail after seek` ) }
+            }
+            ( file_close f )
+        }
+        F _ → { ( ck F `read handle` ) }
+    }
+
+    // error path: writing to a directory path fails cleanly
+    ?? ( file_create `/tmp` ) {
+        T f → {
+            ( file_close f )
+            ( ck F `create on a directory rejects` )
+        }
+        F _ → { ( ck T `create on a directory rejects` ) }
+    }
+
+    ( file_delete TPATH )
+    ^ 0
+}
+
+@ string_eq_s String a s raw → b {
+    ^ ? ( nurl_str_eq ( string_data a ) raw ) T F
+}

--- a/compiler/tests/hash_stream.nu
+++ b/compiler/tests/hash_stream.nu
@@ -1,0 +1,138 @@
+// Test: incremental SHA-256 and BLAKE3 (init/update/final) — the
+// streaming cores the one-shots are now built on. Proves (a) NIST /
+// official vectors through awkward update splits, (b) equality with
+// the one-shot for every tree-shape-relevant size and split, so the
+// chunk/CV-stack bookkeeping cannot drift from the reference.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/hash_blake3.nu`
+
+@ ck b ok s name → v {
+    ? ok { ( nurl_print `PASS ` ) } { ( nurl_print `FAIL ` ) }
+    ( nurl_print name )
+    ( nurl_print `\n` )
+}
+
+@ hex_is ( Vec u ) digest s want → b {
+    : String hx ( bytes_to_hex digest )
+    : b r ? ( nurl_str_eq ( string_data hx ) want ) T F
+    ( string_free hx )
+    ^ r
+}
+
+// deterministic pseudo-random-ish pattern, byte k = (k*131 + 7) & 255
+@ pattern i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] n )
+    : ~ i k 0
+    ~ < k n {
+        ( vec_push [u] v # u & + * k 131 7 255 )
+        = k + k 1
+    }
+    ^ v
+}
+
+// stream `data` through updates of `step` bytes and finalize
+@ sha_streamed ( Vec u ) data i step → ( Vec u ) {
+    : *Sha256 h ( sha256_init )
+    : i n ( vec_len [u] data )
+    : ~ i off 0
+    ~ < off n {
+        : i take ? < - n off step - n off step
+        : ( Vec u ) piece ( vec_with_cap [u] take )
+        ( bytes_extend_raw piece # s + # i ( vec_data [u] data ) off take )
+        ( sha256_update h piece )
+        ( vec_free [u] piece )
+        = off + off take
+    }
+    ^ ( sha256_final h )
+}
+
+@ b3_streamed ( Vec u ) data i step → ( Vec u ) {
+    : *Blake3 h ( blake3_init )
+    : i n ( vec_len [u] data )
+    : ~ i off 0
+    ~ < off n {
+        : i take ? < - n off step - n off step
+        : ( Vec u ) piece ( vec_with_cap [u] take )
+        ( bytes_extend_raw piece # s + # i ( vec_data [u] data ) off take )
+        ( blake3_update h piece )
+        ( vec_free [u] piece )
+        = off + off take
+    }
+    ^ ( blake3_final h )
+}
+
+@ eq_digest ( Vec u ) a ( Vec u ) b2 → b {
+    ^ ( bytes_eq a b2 )
+}
+
+@ main → i {
+    // ── SHA-256 vectors through the stream ──
+    : *Sha256 h0 ( sha256_init )
+    : ( Vec u ) d0 ( sha256_final h0 )
+    ( ck ( hex_is d0 `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` ) `sha256 stream: empty` )
+    ( vec_free [u] d0 )
+
+    : ( Vec u ) abc ( bytes_from_str `abc` )
+    : ( Vec u ) d1 ( sha_streamed abc 1 )
+    ( ck ( hex_is d1 `ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad` ) `sha256 stream: "abc" 1 B at a time` )
+    ( vec_free [u] d1 )
+    ( vec_free [u] abc )
+
+    : ( Vec u ) two ( bytes_from_str `abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq` )
+    : ( Vec u ) d2 ( sha_streamed two 13 )
+    ( ck ( hex_is d2 `248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1` ) `sha256 stream: NIST 2-block, 13 B steps` )
+    ( vec_free [u] d2 )
+    ( vec_free [u] two )
+
+    // splits that straddle the 64 B block edge == one-shot
+    : ( Vec u ) big ( pattern 1000 )
+    : ( Vec u ) ref ( sha256_pure big )
+    : ~ b all T
+    : steps [i | 1 63 64 65 129 999 1000]
+    : *i SP . steps 0
+    : ~ i si 0
+    ~ < si 7 {
+        : ( Vec u ) got ( sha_streamed big . SP si )
+        ? ( eq_digest got ref ) {} { = all F }
+        ( vec_free [u] got )
+        = si + si 1
+    }
+    ( ck all `sha256 stream == one-shot across 7 split sizes` )
+    ( vec_free [u] ref )
+    ( vec_free [u] big )
+
+    // ── BLAKE3 vectors + tree shapes ──
+    : *Blake3 b0 ( blake3_init )
+    : ( Vec u ) e0 ( blake3_final b0 )
+    ( ck ( hex_is e0 `af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262` ) `blake3 stream: empty (official vector)` )
+    ( vec_free [u] e0 )
+
+    // every tree-shape-relevant size: sub-chunk, chunk edge, 2/3/5
+    // chunks (odd stack folds), through three different split sizes
+    : sizes [i | 1 1023 1024 1025 2048 3072 5000]
+    : *i SZ . sizes 0
+    : bsteps [i | 1 1024 700]
+    : *i BS . bsteps 0
+    : ~ b ball T
+    : ~ i zi 0
+    ~ < zi 7 {
+        : ( Vec u ) datax ( pattern . SZ zi )
+        : ( Vec u ) refx ( blake3_pure datax )
+        : ~ i bi 0
+        ~ < bi 3 {
+            : ( Vec u ) gotx ( b3_streamed datax . BS bi )
+            ? ( eq_digest gotx refx ) {} { = ball F }
+            ( vec_free [u] gotx )
+            = bi + bi 1
+        }
+        ( vec_free [u] refx )
+        ( vec_free [u] datax )
+        = zi + zi 1
+    }
+    ( ck ball `blake3 stream == one-shot: 7 sizes × 3 splits` )
+    ^ 0
+}

--- a/compiler/tests/outputs/floatbits_half.txt
+++ b/compiler/tests/outputs/floatbits_half.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+PASS f16 → f32: 0 / 1.0 / -2.0 / subnormals / ±inf / -0
+PASS bf16 → f32: 1.0
+PASS f32 → f16 RNE: max/overflow/subnormal/ties-to-even
+PASS f32 → bf16 RNE: exact + ties-to-even
+PASS f16 → f32 → f16 identity over all 65536 patterns
+PASS bf16 → f32 → bf16 identity over all 65536 patterns

--- a/compiler/tests/outputs/fs_write_handle.txt
+++ b/compiler/tests/outputs/fs_write_handle.txt
@@ -1,0 +1,12 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+PASS create + chunks + tell
+PASS append
+PASS binary round-trip (29 B, NUL kept)
+PASS seek END reports size
+PASS read_at mid-file
+PASS seek CUR
+PASS tail after seek
+PASS create on a directory rejects

--- a/compiler/tests/outputs/hash_stream.txt
+++ b/compiler/tests/outputs/hash_stream.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+PASS sha256 stream: empty
+PASS sha256 stream: "abc" 1 B at a time
+PASS sha256 stream: NIST 2-block, 13 B steps
+PASS sha256 stream == one-shot across 7 split sizes
+PASS blake3 stream: empty (official vector)
+PASS blake3 stream == one-shot: 7 sizes × 3 splits

--- a/compiler/tests/outputs/term_progress.txt
+++ b/compiler/tests/outputs/term_progress.txt
@@ -1,0 +1,11 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+PASS term_width honours $COLUMNS off-tty
+PASS term_height honours $LINES off-tty
+PASS unparseable $COLUMNS falls back to 80
+PASS progress_human: B/KB/MB/GB with one decimal
+PASS progress counters advance
+PASS non-tty detected (renders suppressed)
+done

--- a/compiler/tests/term_progress.nu
+++ b/compiler/tests/term_progress.nu
@@ -1,0 +1,56 @@
+// Test: term_width/term_height env fallback + the progress widget.
+// The test runner pipes stdout/stderr (not a tty), so TIOCGWINSZ fails
+// and the $COLUMNS/$LINES path must answer; the progress bar must stay
+// completely silent on a non-tty stderr while its counters and the
+// human formatter keep working.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/std/term.nu`
+$ `stdlib/std/progress.nu`
+
+@ ck b ok s name → v {
+    ? ok { ( nurl_print `PASS ` ) } { ( nurl_print `FAIL ` ) }
+    ( nurl_print name )
+    ( nurl_print `\n` )
+}
+
+@ human_is i n s want → b {
+    : String hh ( progress_human n )
+    : b r ? ( nurl_str_eq ( string_data hh ) want ) T F
+    ( string_free hh )
+    ^ r
+}
+
+@ main → i {
+    // non-tty: ioctl fails → env → default
+    ( env_set `COLUMNS` `123` )
+    ( env_set `LINES` `45` )
+    ( ck == ( term_width ) 123 `term_width honours $COLUMNS off-tty` )
+    ( ck == ( term_height ) 45 `term_height honours $LINES off-tty` )
+    ( env_set `COLUMNS` `garbage` )
+    ( ck == ( term_width ) 80 `unparseable $COLUMNS falls back to 80` )
+
+    // human formatter
+    : ~ b hf T
+    ? ( human_is 0 `0 B` ) {} { = hf F }
+    ? ( human_is 1023 `1023 B` ) {} { = hf F }
+    ? ( human_is 1024 `1.0 KB` ) {} { = hf F }
+    ? ( human_is 1536 `1.5 KB` ) {} { = hf F }
+    ? ( human_is 1048576 `1.0 MB` ) {} { = hf F }
+    ? ( human_is 44564480 `42.5 MB` ) {} { = hf F }
+    ? ( human_is 1288490188 `1.1 GB` ) {} { = hf F }
+    ( ck hf `progress_human: B/KB/MB/GB with one decimal` )
+
+    // progress on a non-tty: counters advance, zero terminal noise
+    : *Progress p ( progress_new `fetch` 1000 )
+    ( progress_add p 400 )
+    ( progress_set p 900 )
+    ( progress_add p 100 )
+    ( ck == . p cur 1000 `progress counters advance` )
+    ( ck ! . p tty `non-tty detected (renders suppressed)` )
+    ( progress_done p )
+    ( nurl_print `done\n` )
+    ^ 0
+}

--- a/packages/gguf/src/dequant.nu
+++ b/packages/gguf/src/dequant.nu
@@ -27,25 +27,11 @@ $ `stdlib/std/bytes.nu`
 $ `stdlib/std/floatbits.nu`
 $ `gguf.nu`
 
-// IEEE-754 binary16 → binary32, pure integer bit transport: sign
-// copied, exponent rebased 15 → 127, mantissa widened 10 → 23 bits.
-// Subnormals are normalised; ±inf and NaN map to their f32 forms.
+// IEEE-754 binary16 → binary32 — the stdlib bit-transport primitive
+// (stdlib/std/floatbits.nu), kept under the historical gg_ name for
+// the package's public dequant API.
 @ gg_f16_to_f32_bits i h → i {
-    : i sign << & >> h 15 1 31
-    : i e & >> h 10 31
-    : ~ i man & h 1023
-    ? == e 0 {
-        ? == man 0 { ^ sign } {}
-        : ~ i ex 113
-        ~ == & man 1024 0 {
-            = man << man 1
-            = ex - ex 1
-        }
-        = man & man 1023
-        ^ | sign | << ex 23 << man 13
-    } {}
-    ? == e 31 { ^ | sign | 2139095040 << man 13 } {}
-    ^ | sign | << + e 112 23 << man 13
+    ^ ( f16_bits_to_f32_bits h )
 }
 
 @ gg_f16_to_f i h → f {

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -675,6 +675,7 @@ const char* nurl_read_file(const char *path) {
 #  include <sys/mman.h>
 #  include <fcntl.h>
 #  include <unistd.h>
+#  include <sys/ioctl.h>
 #endif
 
 /* Classify entry at `path` WITHOUT following a final symlink (lstat).
@@ -1321,6 +1322,11 @@ long long nurl_native_constant(const char *name) {
     if (strcmp(name, "MAP_PRIVATE")     == 0) return MAP_PRIVATE;
 #  ifdef MADV_SEQUENTIAL
     if (strcmp(name, "MADV_SEQUENTIAL") == 0) return MADV_SEQUENTIAL;
+#  endif
+#  ifdef TIOCGWINSZ
+    /* terminal window size ioctl — value differs per platform
+     * (0x5413 Linux, 0x40087468 BSD/macOS), so surface the real one. */
+    if (strcmp(name, "TIOCGWINSZ")      == 0) return (long long)TIOCGWINSZ;
 #  endif
 #endif
     (void)name;

--- a/stdlib/std/floatbits.nu
+++ b/stdlib/std/floatbits.nu
@@ -66,3 +66,98 @@ $ `stdlib/std/bytes.nu`
 @ bytes_read_f32_le ( Vec u ) v i off → ?f32 {
     ?? ( bytes_read_u32_le v off ) { T b → @ ?f32 { T ( bits_to_f32 # i b ) } F → @ ?f32 { F # f32 0.0 } }
 }
+
+// ── Half-precision (IEEE binary16) and bfloat16 bit conversion ──────
+//
+// Pure integer bit transport in both directions — no float round-trip,
+// so subnormals, ±inf, NaN (payload included) and -0 survive exactly.
+// The f32→narrow direction rounds to nearest, ties to even, exactly
+// like hardware converts. These are the primitives under GGUF/ONNX
+// tensor decoding, wire formats (CBOR half floats), and GPU data prep.
+//
+//   ( f16_bits_to_f32_bits h )   → i     widen, exact
+//   ( f32_bits_to_f16_bits b )   → i     RNE narrow (overflow → ±inf)
+//   ( bf16_bits_to_f32_bits h )  → i     widen, exact (<< 16)
+//   ( f32_bits_to_bf16_bits b )  → i     RNE narrow, NaN kept NaN
+//   ( f16_to_f h ) ( f_to_f16 x ) ( bf16_to_f h ) ( f_to_bf16 x )
+
+// sign copied, exponent rebased 15 → 127, mantissa widened 10 → 23
+// bits; subnormals normalised, inf/NaN mapped to their f32 forms.
+@ f16_bits_to_f32_bits i h → i {
+    : i sign << & >> h 15 1 31
+    : i e & >> h 10 31
+    : ~ i man & h 1023
+    ? == e 0 {
+        ? == man 0 { ^ sign } {}
+        : ~ i ex 113
+        ~ == & man 1024 0 {
+            = man << man 1
+            = ex - ex 1
+        }
+        = man & man 1023
+        ^ | sign | << ex 23 << man 13
+    } {}
+    ? == e 31 { ^ | sign | 2139095040 << man 13 } {}
+    ^ | sign | << + e 112 23 << man 13
+}
+
+// Round-to-nearest-even narrow. Exponent ≥ 31 after rebias → ±inf;
+// tiny values denormalise (the mantissa round can carry back up into
+// the exponent, which is exactly RNE's behaviour); NaN keeps its top
+// payload bits and is forced non-zero so it cannot decay to inf.
+@ f32_bits_to_f16_bits i b → i {
+    : i sign & >> b 16 32768
+    : i e & >> b 23 255
+    : i man & b 8388607
+    ? == e 255 {
+        ? == man 0 { ^ | sign 31744 } {}
+        : i pay >> man 13
+        ^ | sign | 31744 ? == pay 0 512 pay
+    } {}
+    : i E - e 112
+    ? >= E 31 { ^ | sign 31744 } {}
+    ? <= E 0 {
+        // subnormal target: shift the implicit-1 mantissa down
+        ? < E -10 { ^ sign } {}
+        : i M | man 8388608
+        : i sh - 14 E
+        : i v >> M sh
+        : i rem & M - << 1 sh 1
+        : i half << 1 - sh 1
+        : ~ i out v
+        ? | > rem half & == rem half == & v 1 1 { = out + v 1 } {}
+        ^ | sign out
+    } {}
+    : ~ i v | << E 10 >> man 13
+    : i rem & man 8191
+    ? | > rem 4096 & == rem 4096 == & v 1 1 { = v + v 1 } {}
+    ^ | sign v
+}
+
+@ bf16_bits_to_f32_bits i h → i { ^ << h 16 }
+
+// RNE truncation of the low 16 mantissa bits; a NaN whose payload
+// lives entirely in the dropped bits is pinned to a quiet NaN rather
+// than rounding to inf.
+@ f32_bits_to_bf16_bits i b → i {
+    : i e & >> b 23 255
+    : i man & b 8388607
+    ? & == e 255 != man 0 {
+        : i top >> b 16
+        ^ ? == & top 127 0 | top 64 top
+    } {}
+    : i base >> b 16
+    : i rem & b 65535
+    ? | > rem 32768 & == rem 32768 == & base 1 1 { ^ + base 1 } {}
+    ^ base
+}
+
+// f64-level conveniences (f32 is the exact carrier of every f16/bf16
+// value, and f64 carries every f32, so these are lossless).
+@ f16_to_f i h → f { ^ # f ( bits_to_f32 ( f16_bits_to_f32_bits h ) ) }
+
+@ f_to_f16 f x → i { ^ ( f32_bits_to_f16_bits ( f32_to_bits # f32 x ) ) }
+
+@ bf16_to_f i h → f { ^ # f ( bits_to_f32 ( bf16_bits_to_f32_bits h ) ) }
+
+@ f_to_bf16 f x → i { ^ ( f32_bits_to_bf16_bits ( f32_to_bits # f32 x ) ) }

--- a/stdlib/std/fs.nu
+++ b/stdlib/std/fs.nu
@@ -726,6 +726,104 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
     ? != 0 # i hp { ( nurl_file_close # *v hp ) } {}
 }
 
+// ── Handle-based streaming writes + seeking ─────────────────────────
+//
+// The write-side dual of file_open/file_read_chunk: create (or append
+// to) a file and emit it in pieces, so an output far larger than RAM —
+// a model download, a log, an export — is written without ever being
+// fully resident. The same File handle then seeks and tells, which is
+// what a resumed download (HTTP Range) or a random-access reader needs.
+//
+//   ( file_create path )          → !File IoErr    "wb": truncate + write
+//   ( file_append path )          → !File IoErr    "ab": append
+//   ( file_write_chunk f v )      → !v IoErr       binary-safe, all-or-error
+//   ( file_flush f )              → !v IoErr       push libc buffers to the OS
+//   ( file_seek f off whence )    → !i IoErr       → new absolute offset
+//   ( file_tell f )               → !i IoErr
+//   ( file_read_at f off n )      → !( Vec u ) IoErr   seek SET + read
+//
+// Whence values (universal POSIX): FS_SEEK_SET / FS_SEEK_CUR / FS_SEEK_END.
+// Handles from file_open seek too — mixed read/write handles are not
+// offered (libc requires an intervening seek between r/w on "r+" streams;
+// open one handle per direction instead).
+
+: i FS_SEEK_SET 0
+: i FS_SEEK_CUR 1
+: i FS_SEEK_END 2
+
+& `c` @ fflush s h → i32
+
+@ __file_open_mode s path s mode → !File IoErr {
+    : *v h ( nurl_file_open path mode )
+    ? == 0 # i h {
+        ^ @ !File IoErr { F ( __io_err_of_kind ( errno_kind ) ) }
+    } {}
+    : s rawp # s h
+    ^ @ !File IoErr { T @ File { rawp } }
+}
+
+// Create (truncate) `path` for writing. Binary mode — see the CRLF
+// rationale on __write_file_pure.
+@ file_create s path → !File IoErr {
+    ^ ( __file_open_mode path `wb` )
+}
+
+// Open `path` for appending; created if absent. Every write lands at
+// the end regardless of seeks (POSIX "a" semantics).
+@ file_append s path → !File IoErr {
+    ^ ( __file_open_mode path `ab` )
+}
+
+// Write the whole Vec (binary-safe: NULs included). A short write is
+// an error, never silent truncation.
+@ file_write_chunk File f ( Vec u ) data → !v IoErr {
+    : s hp . f raw
+    ? == 0 # i hp { ^ @ !v IoErr { F @ IoErr { Other } } } {}
+    : i n ( vec_len [u] data )
+    ? <= n 0 { ^ @ !v IoErr { T 0 } } {}
+    : i wrote ( fwrite # s ( vec_data [u] data ) 1 n hp )
+    ? == wrote n { ^ @ !v IoErr { T 0 } } {}
+    ^ @ !v IoErr { F ( __io_err_of_kind ( errno_kind ) ) }
+}
+
+@ file_flush File f → !v IoErr {
+    : s hp . f raw
+    ? == 0 # i hp { ^ @ !v IoErr { F @ IoErr { Other } } } {}
+    ? == 0 # i ( fflush hp ) { ^ @ !v IoErr { T 0 } } {}
+    ^ @ !v IoErr { F ( __io_err_of_kind ( errno_kind ) ) }
+}
+
+// Seek to `off` relative to `whence`; returns the new ABSOLUTE offset
+// (so `( file_seek f 0 FS_SEEK_END )` doubles as "how big is this").
+@ file_seek File f i off i whence → !i IoErr {
+    : s hp . f raw
+    ? == 0 # i hp { ^ @ !i IoErr { F @ IoErr { Other } } } {}
+    ? == 0 # i ( fseek hp off # i32 whence ) {} {
+        ^ @ !i IoErr { F ( __io_err_of_kind ( errno_kind ) ) }
+    }
+    : i posn ( ftell hp )
+    ? >= posn 0 { ^ @ !i IoErr { T posn } } {}
+    ^ @ !i IoErr { F ( __io_err_of_kind ( errno_kind ) ) }
+}
+
+@ file_tell File f → !i IoErr {
+    : s hp . f raw
+    ? == 0 # i hp { ^ @ !i IoErr { F @ IoErr { Other } } } {}
+    : i posn ( ftell hp )
+    ? >= posn 0 { ^ @ !i IoErr { T posn } } {}
+    ^ @ !i IoErr { F ( __io_err_of_kind ( errno_kind ) ) }
+}
+
+// Random-access read: up to `n` bytes at absolute offset `off`.
+@ file_read_at File f i off i n → !( Vec u ) IoErr {
+    : !i IoErr sr ( file_seek f off FS_SEEK_SET )
+    ?? sr {
+        T _ → {}
+        F e → { ^ @ !( Vec u ) IoErr { F e } }
+    }
+    ^ ( file_read_chunk f n )
+}
+
 // ── Rename / copy / tempfile (B6) ──────────────────────────────────
 
 // libc rename(2): atomically move/rename within a filesystem (cross-

--- a/stdlib/std/hash_blake3.nu
+++ b/stdlib/std/hash_blake3.nu
@@ -15,6 +15,8 @@
 //
 // Wrapped by stdlib/std/hash.nu as `blake3_bytes` / `blake3_hex`.
 
+$ `stdlib/std/bytes.nu`
+
 $ `stdlib/core/vec.nu`
 
 // ── word helpers ──────────────────────────────────────────────────
@@ -250,64 +252,110 @@ $ `stdlib/core/vec.nu`
     ^ cv
 }
 
-// Root chaining value for a multi-chunk (> 1024 byte) input.
-@ __b3_root_multi ( Vec u ) data i n i num_chunks → ( Vec u32 ) {
-    : ( Vec u32 ) stack ( vec_new [u32] )
-    : ~ i scount 0
-    : ~ i ci 0
-    ~ < ci - num_chunks 1 {
-        : ~ ( Vec u32 ) ncv ( __b3_chunk_cv data * ci 1024 1024 ci F )
-        : ~ i total + ci 1
-        ~ == & total 1 0 {
-            : ( Vec u32 ) popped ( __b3_stack_pop stack )
-            = scount - scount 1
-            : ( Vec u32 ) merged ( __b3_parent popped ncv F )
-            ( vec_free [u32] popped )
-            ( vec_free [u32] ncv )
-            = ncv merged
-            = total >> total 1
-        }
-        ( __b3_stack_push stack ncv )
+// ── Incremental (streaming) hashing ────────────────────────────────
+//
+// BLAKE3's chunk tree, built as the bytes arrive: a 1024-byte chunk
+// buffer plus the classic CV stack (one entry per set bit of the
+// completed-chunk count). A buffered chunk is only compressed once a
+// LATER byte proves it is not the final chunk, so any update pattern
+// produces the same tree as the one-shot. blake3_pure below is a thin
+// init/update/final composition — the two paths cannot drift.
+//
+//   ( blake3_init )          → *Blake3
+//   ( blake3_update h v )    → v          any piece size, any count
+//   ( blake3_final h )       → ( Vec u )  32-byte digest; FREES h —
+//                                          the handle is dead after this
+
+: Blake3 {
+    ( Vec u32 ) stack
+    i scount
+    ( Vec u ) cbuf
+    i counter
+}
+
+@ blake3_init → *Blake3 {
+    : *Blake3 h # *Blake3 ( nurl_alloc Z Blake3 )
+    = . h stack ( vec_new [u32] )
+    = . h scount 0
+    = . h cbuf ( vec_new [u] )
+    = . h counter 0
+    ^ h
+}
+
+// Fold a completed (non-final) chunk CV into the stack, merging one
+// parent per trailing one-bit of the completed-chunk count — exactly
+// __b3_root_multi's loop, one chunk at a time.
+@ __b3_absorb_cv * Blake3 h ( Vec u32 ) cv0 → v {
+    : ~ ( Vec u32 ) ncv cv0
+    : ~ i total + . h counter 1
+    ~ == & total 1 0 {
+        : ( Vec u32 ) popped ( __b3_stack_pop . h stack )
+        = . h scount - . h scount 1
+        : ( Vec u32 ) merged ( __b3_parent popped ncv F )
+        ( vec_free [u32] popped )
         ( vec_free [u32] ncv )
-        = scount + scount 1
-        = ci + ci 1
+        = ncv merged
+        = total >> total 1
     }
-    : i last_off * - num_chunks 1 1024
-    : i last_len - n last_off
-    : ~ ( Vec u32 ) cur ( __b3_chunk_cv data last_off last_len - num_chunks 1 F )
-    : ~ i r - scount 1
+    ( __b3_stack_push . h stack ncv )
+    ( vec_free [u32] ncv )
+    = . h scount + . h scount 1
+    = . h counter + . h counter 1
+}
+
+@ blake3_update * Blake3 h ( Vec u ) data → v {
+    : i n ( vec_len [u] data )
+    : ~ i off 0
+    ~ < off n {
+        // a full buffered chunk is non-final by proof: more bytes exist
+        ? == ( vec_len [u] . h cbuf ) 1024 {
+            ( __b3_absorb_cv h ( __b3_chunk_cv . h cbuf 0 1024 . h counter F ) )
+            ( vec_clear [u] . h cbuf )
+        } {}
+        : i space - 1024 ( vec_len [u] . h cbuf )
+        : i left - n off
+        : i take ? < left space left space
+        ( bytes_extend_raw . h cbuf # s + # i ( vec_data [u] data ) off take )
+        = off + off take
+    }
+}
+
+// Digest and DESTROY: the buffered bytes are the final chunk; fold the
+// stack right-to-left, marking the last merge (or lone chunk) as root.
+@ blake3_final * Blake3 h → ( Vec u ) {
+    : b lone & == . h counter 0 == . h scount 0
+    : ~ ( Vec u32 ) cur ( __b3_chunk_cv . h cbuf 0 ( vec_len [u] . h cbuf ) . h counter lone )
+    : ~ i r - . h scount 1
     ~ >= r 0 {
-        : ( Vec u32 ) left ( __b3_stack_get stack r )
+        : ( Vec u32 ) left ( __b3_stack_get . h stack r )
         : ( Vec u32 ) merged ( __b3_parent left cur == r 0 )
         ( vec_free [u32] left )
         ( vec_free [u32] cur )
         = cur merged
         = r - r 1
     }
-    ( vec_free [u32] stack )
-    ^ cur
-}
-
-// ── Public entry ──────────────────────────────────────────────────
-
-@ blake3_pure ( Vec u ) data → ( Vec u ) {
-    : i n ( vec_len [u] data )
-    : i nc / + n 1023 1024
-    : i num_chunks ? < nc 1 1 nc
-    : ( Vec u32 ) root8 ? == num_chunks 1
-    ( __b3_chunk_cv data 0 n 0 T )
-    ( __b3_root_multi data n num_chunks )
-
     : ( Vec u ) out ( vec_with_cap [u] 32 )
     : ~ i i 0
     ~ < i 8 {
-        : i w # i ( __b3_get root8 i )
+        : i w # i ( __b3_get cur i )
         ( vec_push [u] out # u & w 255 )
         ( vec_push [u] out # u & >> w 8 255 )
         ( vec_push [u] out # u & >> w 16 255 )
         ( vec_push [u] out # u & >> w 24 255 )
         = i + i 1
     }
-    ( vec_free [u32] root8 )
+    ( vec_free [u32] cur )
+    ( vec_free [u32] . h stack )
+    ( vec_free [u] . h cbuf )
+    ( nurl_free # s h )
     ^ out
+}
+
+// ── Public entry ──────────────────────────────────────────────────
+
+// One-shot over the streaming core.
+@ blake3_pure ( Vec u ) data → ( Vec u ) {
+    : *Blake3 h ( blake3_init )
+    ( blake3_update h data )
+    ^ ( blake3_final h )
 }

--- a/stdlib/std/hash_sha256.nu
+++ b/stdlib/std/hash_sha256.nu
@@ -170,36 +170,77 @@ $ `stdlib/std/bytes.nu`
 
 // ── Public entry — bytes-in, 32-byte digest out.
 
-@ sha256_pure ( Vec u ) data → ( Vec u ) {
-    : ( Vec u32 ) K ( __sha256_K )
+// ── Incremental (streaming) hashing ────────────────────────────────
+//
+// Hash gigabytes without holding them: feed pieces as they arrive
+// (file_read_chunk, an HTTP stream) and finalize once. The one-shot
+// sha256_pure below is a thin init/update/final composition, so the
+// two paths cannot drift.
+//
+//   ( sha256_init )          → *Sha256
+//   ( sha256_update h v )    → v          any piece size, any count
+//   ( sha256_final h )       → ( Vec u )  32-byte digest; FREES h —
+//                                          the handle is dead after this
 
-    : ( Vec u32 ) state ( vec_with_cap [u32] 8 )
-    ( vec_push [u32] state # u32 1779033703 )
-    ( vec_push [u32] state # u32 3144134277 )
-    ( vec_push [u32] state # u32 1013904242 )
-    ( vec_push [u32] state # u32 2773480762 )
-    ( vec_push [u32] state # u32 1359893119 )
-    ( vec_push [u32] state # u32 2600822924 )
-    ( vec_push [u32] state # u32 528734635 )
-    ( vec_push [u32] state # u32 1541459225 )
+: Sha256 {
+    ( Vec u32 ) state
+    ( Vec u ) buf
+    i total
+    ( Vec u32 ) k
+}
 
+@ sha256_init → *Sha256 {
+    : *Sha256 h # *Sha256 ( nurl_alloc Z Sha256 )
+    : ( Vec u32 ) st ( vec_with_cap [u32] 8 )
+    ( vec_push [u32] st # u32 1779033703 )
+    ( vec_push [u32] st # u32 3144134277 )
+    ( vec_push [u32] st # u32 1013904242 )
+    ( vec_push [u32] st # u32 2773480762 )
+    ( vec_push [u32] st # u32 1359893119 )
+    ( vec_push [u32] st # u32 2600822924 )
+    ( vec_push [u32] st # u32 528734635 )
+    ( vec_push [u32] st # u32 1541459225 )
+    = . h state st
+    = . h buf ( vec_new [u] )
+    = . h total 0
+    = . h k ( __sha256_K )
+    ^ h
+}
+
+@ sha256_update * Sha256 h ( Vec u ) data → v {
     : i n ( vec_len [u] data )
-
+    ? <= n 0 { ^ v } {}
+    = . h total + . h total n
     : ~ i off 0
+    // top up a partial block first
+    : i have ( vec_len [u] . h buf )
+    ? > have 0 {
+        : i need - 64 have
+        : i take ? < n need n need
+        ( bytes_extend_raw . h buf # s ( vec_data [u] data ) take )
+        = off take
+        ? == ( vec_len [u] . h buf ) 64 {
+            ( __sha256_transform . h state . h buf 0 . h k )
+            ( vec_clear [u] . h buf )
+        } {}
+    } {}
+    // full blocks straight from the caller's data — no copy
     ~ <= + off 64 n {
-        ( __sha256_transform state data off K )
+        ( __sha256_transform . h state data off . h k )
         = off + off 64
     }
+    // stash the tail
+    ? < off n {
+        ( bytes_extend_raw . h buf # s + # i ( vec_data [u] data ) off - n off )
+    } {}
+}
 
-    : ( Vec u ) tail ( vec_with_cap [u] 128 )
-    : ~ i ti off
-    ~ < ti n {
-        : i bv ( __sha256_vu8 data ti )
-        ( vec_push [u] tail # u & bv 255 )
-        = ti + ti 1
-    }
+// Digest and DESTROY: pads, runs the final block(s), serialises the
+// state big-endian, and frees every part of the handle.
+@ sha256_final * Sha256 h → ( Vec u ) {
+    : ( Vec u ) tail . h buf
     ( vec_push [u] tail # u 128 )
-    : i leftover - n off
+    : i leftover % . h total 64
     : i after_one + leftover 1
     : i need_zeros ? <= after_one 56 - 56 after_one - 120 after_one
     : ~ i zi 0
@@ -207,7 +248,7 @@ $ `stdlib/std/bytes.nu`
         ( vec_push [u] tail # u 0 )
         = zi + zi 1
     }
-    : i bitlen * n 8
+    : i bitlen * . h total 8
     ( vec_push [u] tail # u & >> bitlen 56 255 )
     ( vec_push [u] tail # u & >> bitlen 48 255 )
     ( vec_push [u] tail # u & >> bitlen 40 255 )
@@ -216,19 +257,17 @@ $ `stdlib/std/bytes.nu`
     ( vec_push [u] tail # u & >> bitlen 16 255 )
     ( vec_push [u] tail # u & >> bitlen 8 255 )
     ( vec_push [u] tail # u & bitlen 255 )
-
     : i tail_len ( vec_len [u] tail )
     : ~ i toff 0
     ~ < toff tail_len {
-        ( __sha256_transform state tail toff K )
+        ( __sha256_transform . h state tail toff . h k )
         = toff + toff 64
     }
-    ( vec_free [u] tail )
 
     : ( Vec u ) out ( vec_with_cap [u] 32 )
     : ~ i si 0
     ~ < si 8 {
-        : u32 sv ( __sha256_vu32 state si )
+        : u32 sv ( __sha256_vu32 . h state si )
         : i siv # i sv
         ( vec_push [u] out # u & >> siv 24 255 )
         ( vec_push [u] out # u & >> siv 16 255 )
@@ -236,10 +275,18 @@ $ `stdlib/std/bytes.nu`
         ( vec_push [u] out # u & siv 255 )
         = si + si 1
     }
-
-    ( vec_free [u32] state )
-    ( vec_free [u32] K )
+    ( vec_free [u] tail )
+    ( vec_free [u32] . h state )
+    ( vec_free [u32] . h k )
+    ( nurl_free # s h )
     ^ out
+}
+
+// One-shot over the streaming core.
+@ sha256_pure ( Vec u ) data → ( Vec u ) {
+    : *Sha256 h ( sha256_init )
+    ( sha256_update h data )
+    ^ ( sha256_final h )
 }
 
 // ── HMAC-SHA-256 (RFC 2104; block size B = 64 bytes for SHA-256). ──

--- a/stdlib/std/progress.nu
+++ b/stdlib/std/progress.nu
@@ -1,0 +1,163 @@
+// stdlib/std/progress.nu — a terminal progress bar for long transfers.
+//
+// The display layer for streamed work (a model download writing through
+// file_write_chunk, a hash of a huge file): counts bytes, renders a
+// throttled single-line bar on stderr, and stays COMPLETELY SILENT when
+// stderr is not a tty — CI logs never fill with carriage returns.
+//
+//   ( progress_new label total )   → *Progress   total ≤ 0: indeterminate
+//   ( progress_add p n )           → v           advance by n units
+//   ( progress_set p cur )         → v           set absolute position
+//   ( progress_done p )            → v           final render + newline; FREES p
+//   ( progress_human n )           → String      "3.4 MB" (pure; unit-testable)
+//
+// Rendering: at most every 100 ms (monotonic clock), width-fitted to
+// term_width, with a rate derived from the elapsed wall time:
+//
+//   fetch [==========>          ]  42.5 MB / 118.2 MB  17.3 MB/s
+//
+// Units are whatever the caller counts — the human formatter assumes
+// bytes, which is the overwhelmingly common case.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/posix.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/term.nu`
+
+: Progress {
+    String label
+    i total
+    i cur
+    i started_ns
+    i last_ns
+    b tty
+}
+
+// "1023 B" · "3.4 KB" · "42.5 MB" · "1.2 GB" — one decimal above bytes.
+@ progress_human i n → String {
+    : String out ( string_new )
+    ? < n 0 {
+        ( string_push_str out `0 B` )
+        ^ out
+    } {}
+    ? < n 1024 {
+        ( string_push_int out n )
+        ( string_push_str out ` B` )
+        ^ out
+    } {}
+    : ~ i unit 0
+    : ~ i scaled * n 10
+    = scaled / scaled 1024
+    ~ & >= scaled 10240 < unit 3 {
+        = scaled / scaled 1024
+        = unit + unit 1
+    }
+    ( string_push_int out / scaled 10 )
+    ( string_push_char out 46 )
+    ( string_push_int out % scaled 10 )
+    ( string_push_char out 32 )
+    ? == unit 0 { ( string_push_str out `KB` ) } {
+        ? == unit 1 { ( string_push_str out `MB` ) } {
+            ? == unit 2 { ( string_push_str out `GB` ) } { ( string_push_str out `TB` ) }
+        }
+    }
+    ^ out
+}
+
+@ progress_new s label i total → *Progress {
+    : *Progress p # *Progress ( nurl_alloc Z Progress )
+    = . p label ( string_from label )
+    = . p total total
+    = . p cur 0
+    = . p started_ns ( monotonic_ns )
+    = . p last_ns 0
+    = . p tty ( term_is_tty 2 )
+    ^ p
+}
+
+@ __pg_write s raw → v {
+    : i n ( nurl_str_len raw )
+    ? > n 0 { : i _w ( write 2 # *u raw n ) } {}
+}
+
+@ __pg_render * Progress p b final → v {
+    : String ln ( string_new )
+    ( string_push_char ln 13 )
+    ( string_push_str ln ( string_data . p label ) )
+    ( string_push_char ln 32 )
+    : String curh ( progress_human . p cur )
+    ? > . p total 0 {
+        // width-fitted bar: label + [bar] + "cur / total  rate"
+        : String toth ( progress_human . p total )
+        : ~ i pct 0
+        ? > . p total 0 { = pct / * . p cur 100 . p total } {}
+        ? > pct 100 { = pct 100 } {}
+        : i tw ( term_width )
+        : ~ i barw - - - tw ( string_len . p label ) ( string_len curh ) ( string_len toth )
+        = barw - barw 30
+        ? > barw 40 { = barw 40 } {}
+        ? >= barw 8 {
+            ( string_push_char ln 91 )
+            : i fill / * barw pct 100
+            : ~ i k 0
+            ~ < k barw {
+                ? < k fill { ( string_push_char ln 61 ) } {
+                    ? == k fill { ( string_push_char ln 62 ) } { ( string_push_char ln 32 ) }
+                }
+                = k + k 1
+            }
+            ( string_push_str ln `] ` )
+        } {}
+        ( string_push_int ln pct )
+        ( string_push_str ln `% ` )
+        ( string_push_str ln ( string_data curh ) )
+        ( string_push_str ln ` / ` )
+        ( string_push_str ln ( string_data toth ) )
+        ( string_free toth )
+    } {
+        ( string_push_str ln ( string_data curh ) )
+    }
+    // rate over the whole transfer — smooth and honest
+    : i el - ( monotonic_ns ) . p started_ns
+    ? > el 100000000 {
+        : i per_s / * . p cur 1000000000 el
+        : String rh ( progress_human per_s )
+        ( string_push_str ln `  ` )
+        ( string_push_str ln ( string_data rh ) )
+        ( string_push_str ln `/s` )
+        ( string_free rh )
+    } {}
+    ( string_push_str ln `    ` )
+    ? final { ( string_push_char ln 10 ) } {}
+    ( __pg_write ( string_data ln ) )
+    ( string_free ln )
+    ( string_free curh )
+}
+
+@ __pg_tick * Progress p → v {
+    ? . p tty {} { ^ v }
+    : i now ( monotonic_ns )
+    ? > - now . p last_ns 100000000 {
+        = . p last_ns now
+        ( __pg_render p F )
+    } {}
+}
+
+@ progress_add * Progress p i n → v {
+    = . p cur + . p cur n
+    ( __pg_tick p )
+}
+
+@ progress_set * Progress p i cur → v {
+    = . p cur cur
+    ( __pg_tick p )
+}
+
+// Final render (100 % state) + newline, then FREES p — the handle is
+// dead after this. Still silent when stderr is not a tty.
+@ progress_done * Progress p → v {
+    ? . p tty { ( __pg_render p T ) } {}
+    ( string_free . p label )
+    ( nurl_free # s p )
+}

--- a/stdlib/std/term.nu
+++ b/stdlib/std/term.nu
@@ -33,6 +33,7 @@
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/posix.nu`  // read / write / close / posix_const
+$ `stdlib/ext/env.nu`  // $COLUMNS / $LINES fallback for term_width
 
 & `c` @ isatty i32 fd → i32
 
@@ -291,4 +292,59 @@ $ `stdlib/core/posix.nu`  // read / write / close / posix_const
     ? == done 1 { ^ @ ?String { T buf } } {}
     ( string_free buf )
     ^ @ ?String { F }
+}
+
+// ── Terminal size ───────────────────────────────────────────────────
+//
+// TIOCGWINSZ on the requested fd; when that fails (not a tty, wasm,
+// win32 console without the ioctl) fall back to $COLUMNS / $LINES,
+// then to the classic 80×24. struct winsize is four u16s (row, col,
+// xpixel, ypixel) on every POSIX platform; the ioctl request value
+// differs per OS and is surfaced through nurl_native_constant.
+
+& `c` @ ioctl i32 fd i req *u argp → i32
+
+@ __term_winsz i fd i idx → i {
+    : i req ( posix_const `TIOCGWINSZ` )
+    ? < req 0 { ^ -1 } {}
+    : *u ws # *u ( nurl_alloc 8 )
+    : i32 rc ( ioctl # i32 fd req ws )
+    : ~ i out -1
+    ? == # i rc 0 {
+        : i lo # i . ws * idx 2
+        : i hi # i . ws + * idx 2 1
+        = out | lo << hi 8
+    } {}
+    ( nurl_free # s ws )
+    ^ ? > out 0 out -1
+}
+
+@ __term_env_dim s name i def → i {
+    : ?String ev ( env_get name )
+    ?? ev {
+        T v → {
+            : ~ i out def
+            ?? ( string_to_int v ) {
+                T n → { ? > n 0 { = out n } {} }
+                F _ → {}
+            }
+            ( string_free v )
+            ^ out
+        }
+        F → { ^ def }
+    }
+}
+
+// Columns of the terminal on stdout: ioctl → $COLUMNS → 80.
+@ term_width → i {
+    : i w ( __term_winsz 1 1 )
+    ? > w 0 { ^ w } {}
+    ^ ( __term_env_dim `COLUMNS` 80 )
+}
+
+// Rows of the terminal on stdout: ioctl → $LINES → 24.
+@ term_height → i {
+    : i hh ( __term_winsz 1 0 )
+    ? > hh 0 { ^ hh } {}
+    ^ ( __term_env_dim `LINES` 24 )
 }


### PR DESCRIPTION
The "whole-buffer → streaming" sweep (nurllama plan phase 0) — every piece a resumable multi-GB model download needs, each generally useful on its own.

## What

- **fs**: write-side dual of the streaming reads — `file_create` / `file_append` / `file_write_chunk` (binary-safe, short write = error, never silent truncation) / `file_flush`, plus `file_seek` / `file_tell` / `file_read_at` (`FS_SEEK_SET/CUR/END`). Emit or resume an output far larger than RAM.
- **hash_sha256 + hash_blake3**: incremental `init/update/final`. SHA-256 compresses full blocks straight from the caller's buffer (no copy); BLAKE3 grows the real chunk tree as bytes arrive — CV stack with one entry per set bit of the chunk count, and a buffered chunk is only compressed once a *later* byte proves it non-final, so any update pattern produces the one-shot's tree. **Both one-shots are rebuilt as init/update/final compositions** — the two paths cannot drift. Dead `__b3_root_multi` removed.
- **floatbits**: f16/bf16 ↔ f32 pure bit transport, both directions — widen exact (subnormals, ±inf, NaN payloads, −0), narrow with round-to-nearest-even (overflow → ±inf, NaN pinned non-zero). `packages/gguf`'s f16 decoder now delegates here (dedupe; its selftest stays 37/37).
- **term**: `term_width` / `term_height` — TIOCGWINSZ (new `nurl_native_constant` entry + `sys/ioctl.h`), falling back to `$COLUMNS`/`$LINES`, then 80/24.
- **progress** (new module): throttled (100 ms), width-fitted transfer bar on stderr, **completely silent when stderr is not a tty** — CI logs stay clean. `progress_human` is a pure, unit-testable formatter.

## Proof

Suite **534 PASS** with four new regressions:
- `fs_write_handle` — chunked writes with embedded NULs, append, seek/tell/read_at, directory-open error path.
- `hash_stream` — NIST SHA-256 + official BLAKE3 vectors pushed through awkward split sizes (1 B at a time included); streaming ≡ one-shot across 7 sizes × 3 splits covering sub-chunk, chunk-edge and multi-chunk tree shapes.
- `floatbits_half` — known IEEE pairs, RNE tie-to-even cases in both directions, and **exhaustive 65536-pattern widen→narrow round-trip identity for both formats** (NaN payloads included).
- `term_progress` — env fallbacks, the human formatter, non-tty silence.

All four programs ASan/UBSan/LeakSanitizer-clean.

Remaining phase-0 item (deliberately deferred): the `packages/http` streaming-handler seam, which lands with the ollama-compatible API work (phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH