### PR TITLE
nurllama: the model store + resumable streaming pull (phase 4)

### DIFF
--- a/packages/nurllama/README.md
+++ b/packages/nurllama/README.md
@@ -2,20 +2,37 @@
 
 The ollama-shaped engine, built package by package on top of
 [`packages/gguf`](../gguf) and [`packages/gpu`](../gpu).
-**Phase 3 (current): the inference core.**
+**Phase 4 (current): the model store.**
 
 ```
-$ nurllama run model.gguf "Once upon a time" -n 40 --temp 0
+$ nurllama pull hf.co/ggml-org/models/tinyllamas/stories260K.gguf
+pulled stories260K (sha256:270cba1bd510…, 1.1 MB)
+$ nurllama run stories260K "Once upon a time" -n 40 --temp 0
 , there was a little girl named Lily. She loved to play outside in the
 park. One day, she saw a big, red ball.
 
-nurllama run model.gguf "prompt" [-n N] [--temp F] [--topk N] [--topp F] [--seed N]
+nurllama pull <hf.co/ORG/REPO/FILE.gguf | url> [--name N]
+nurllama list · rm <name> · verify <name>
+nurllama run <name|path> "prompt" [-n N] [--temp F] [--topk N] [--topp F] [--seed N]
 nurllama logits model.gguf "prompt"               # verification tap
 nurllama tokenize model.gguf "Once upon a time"   # → 1 403 407 261 378
 nurllama detok model.gguf 1 403 407 261 378       # → " Once upon a time"
 nurllama vocab model.gguf 10                      # first 10 pieces
 nurllama selftest                                 # 17 bit-exact checks
 ```
+
+## Model store
+
+`~/.nurllama` (or `$NURLLAMA_HOME`): content-addressed blobs
+(`blobs/sha256-<hex>`) plus one small manifest per name. The pull is
+streaming end to end — HTTP chunks flow straight to disk while the
+incremental sha256 consumes the same bytes and a tty-gated progress
+bar narrates; nothing is ever fully resident. An interrupted pull
+resumes with `Range: bytes=N-` (the existing part is re-hashed in a
+stream and only the tail transfers; a server without Range support
+triggers a clean restart). `verify` re-hashes the blob and refuses
+drift; `rm` drops the blob only when the last name referencing it is
+gone. `run`/`show`/`tokenize` accept a store name or a plain path.
 
 ## Inference core
 
@@ -104,7 +121,6 @@ $ `src/tokenizer.nu`
 
 ## Roadmap
 
-Phase 4: model store + pull (`~/.nurllama`). Phase 5: CLI chat + an
-ollama-compatible HTTP API. Phase 6: device-side dequant-in-matmul,
-K-quants, batched prefill. See the plan in the repo's development
-notes.
+Phase 5: CLI chat + an ollama-compatible HTTP API. Phase 6:
+device-side dequant-in-matmul, K-quants, batched prefill. See the
+plan in the repo's development notes.

--- a/packages/nurllama/src/main.nu
+++ b/packages/nurllama/src/main.nu
@@ -1,6 +1,10 @@
 // nurllama — run language models locally.
 //
-//   nurllama run <model.gguf> <prompt>        generate (stream to stdout)
+//   nurllama pull <src> [--name N]            download into ~/.nurllama
+//                                             (hf.co/ORG/REPO/FILE.gguf or a
+//                                             URL; resumes a broken pull)
+//   nurllama list · rm <name> · verify <name> the local model store
+//   nurllama run <model|name> <prompt>        generate (stream to stdout)
 //     -n N (default 64) · --temp F (0 = greedy, default 0.8)
 //     --topk N · --topp F · --seed N · --ctx N
 //   nurllama logits <model.gguf> <prompt>     final-position logits, one
@@ -33,6 +37,8 @@ $ `src/tokenizer.nu`
 $ `src/kernels.nu`
 $ `src/model.nu`
 $ `src/sample.nu`
+$ `src/store.nu`
+$ `src/pull.nu`
 
 @ __nl_err String e → i {
     ( nurl_eprintln ( string_data e ) )
@@ -378,6 +384,7 @@ $ `src/sample.nu`
     ( args_opt p `topp` 0 `F` `run: top-p nucleus (default 0.95; 1 = off)` )
     ( args_opt p `seed` 0 `N` `run: RNG seed (default 42)` )
     ( args_opt p `ctx` 0 `N` `run: context length cap (default: model's)` )
+    ( args_opt p `name` 0 `NAME` `pull: store under this name` )
     ? ( args_parse_argv p ) {} {
         ( nurl_eprintln ( args_error p ) )
         ( args_free p )
@@ -386,7 +393,7 @@ $ `src/sample.nu`
     ? ( args_present p `help` ) {
         : String u ( args_usage p )
         ( nurl_print ( string_data u ) )
-        ( nurl_print `\ncommands:\n  run <model.gguf> <prompt> [-n N] [--temp F] [--topk N] [--topp F] [--seed N]\n  logits <model.gguf> <prompt> · tokenize <model.gguf> <text>\n  detok <model.gguf> <id> [id …] · vocab <model.gguf> [n] · selftest\n` )
+        ( nurl_print `\ncommands:\n  pull <hf.co/ORG/REPO/FILE.gguf | url> [--name N] · list · rm <name> · verify <name>\n  run <model|name> <prompt> [-n N] [--temp F] [--topk N] [--topp F] [--seed N]\n  logits <model> <prompt> · tokenize <model> <text>\n  detok <model> <id> [id …] · vocab <model> [n] · selftest\n` )
         ( string_free u )
         ( args_free p )
         ^ 0
@@ -414,17 +421,82 @@ $ `src/sample.nu`
         ^ rc
     } {}
 
+    ? ( nurl_str_eq cmd `list` ) {
+        : String root ( nl_store_root )
+        ( nl_store_list root )
+        ( string_free root )
+        ( args_free p )
+        ^ 0
+    } {}
+
+    ? | | ( nurl_str_eq cmd `pull` ) ( nurl_str_eq cmd `rm` ) ( nurl_str_eq cmd `verify` ) {
+        ? < ( args_positional_count p ) 2 {
+            ( args_free p )
+            ^ ( __nl_err ( string_from `nurllama: this command needs an argument (nurllama --help)` ) )
+        } {}
+        : ~ s a1 ``
+        ?? ( vec_get [String] pos 1 ) {
+            T c → { = a1 ( string_data c ) }
+            F → {}
+        }
+        : String root ( nl_store_root )
+        : ~ i rc 0
+        ? ( nurl_str_eq cmd `pull` ) {
+            : String nn ( args_value_or p `name` `` )
+            : !v String r ( nl_pull root a1 ( string_data nn ) )
+            ( string_free nn )
+            ?? r {
+                T _ → {}
+                F e → { = rc ( __nl_err e ) }
+            }
+        } {
+            ? ( nurl_str_eq cmd `rm` ) {
+                : !v String r ( nl_store_rm root a1 )
+                ?? r {
+                    T _ → { ( nurl_print `removed\n` ) }
+                    F e → { = rc ( __nl_err e ) }
+                }
+            } {
+                : !v String r ( nl_store_verify root a1 )
+                ?? r {
+                    T _ → { ( nurl_print `OK — blob hashes to its manifest digest\n` ) }
+                    F e → { = rc ( __nl_err e ) }
+                }
+            }
+        }
+        ( string_free root )
+        ( args_free p )
+        ^ rc
+    } {}
+
     ? < ( args_positional_count p ) 2 {
         ( args_free p )
         ^ ( __nl_err ( string_from `nurllama: this command needs a model file (nurllama --help)` ) )
     } {}
 
     ? | ( nurl_str_eq cmd `run` ) ( nurl_str_eq cmd `logits` ) {
-        : ~ s mp ``
+        : ~ s mparg ``
         ?? ( vec_get [String] pos 1 ) {
-            T c → { = mp ( string_data c ) }
+            T c → { = mparg ( string_data c ) }
             F → {}
         }
+        // an existing path wins; otherwise the store resolves the name
+        : String mroot ( nl_store_root )
+        : ~ String mres ( string_new )
+        ?? ( nl_resolve mroot mparg ) {
+            T pth → {
+                ( string_free mres )
+                = mres pth
+            }
+            F → {}
+        }
+        ( string_free mroot )
+        ? > ( string_len mres ) 0 {} {
+            ( string_free mres )
+            ( args_free p )
+            ^ ( __nl_err ( string_from `nurllama: not a file and not a stored model name (nurllama list)` ) )
+        }
+        : s mp ( string_data mres )
         : ~ s prompt ``
         ?? ( vec_get [String] pos 2 ) {
             T c → { = prompt ( string_data c ) }
@@ -506,14 +578,31 @@ $ `src/sample.nu`
             }
             F e → { = rc2 ( __nl_err e ) }
         }
+        ( string_free mres )
         ( args_free p )
         ^ rc2
     } {}
-    : ~ s mpath ``
+    : ~ s mparg2 ``
     ?? ( vec_get [String] pos 1 ) {
-        T c → { = mpath ( string_data c ) }
+        T c → { = mparg2 ( string_data c ) }
         F → {}
     }
+    : String mroot2 ( nl_store_root )
+    : ~ String mres2 ( string_new )
+    ?? ( nl_resolve mroot2 mparg2 ) {
+        T pth → {
+            ( string_free mres2 )
+            = mres2 pth
+        }
+        F → {}
+    }
+    ( string_free mroot2 )
+    ? > ( string_len mres2 ) 0 {} {
+        ( string_free mres2 )
+        ( args_free p )
+        ^ ( __nl_err ( string_from `nurllama: not a file and not a stored model name (nurllama list)` ) )
+    }
+    : s mpath ( string_data mres2 )
     : ~ i rc 0
     ?? ( gguf_open mpath ) {
         T g → {
@@ -589,6 +678,7 @@ $ `src/sample.nu`
         }
         F e → { = rc ( __nl_err e ) }
     }
+    ( string_free mres2 )
     ( args_free p )
     ^ rc
 }

--- a/packages/nurllama/src/pull.nu
+++ b/packages/nurllama/src/pull.nu
@@ -1,0 +1,338 @@
+// packages/nurllama/src/pull.nu — streaming model download with resume.
+//
+// The whole transfer is constant-memory: HTTP chunks flow straight to
+// disk through file_write_chunk while the incremental sha256 consumes
+// the same bytes and a tty-gated progress bar narrates. An interrupted
+// pull leaves blobs/<name>.part; the next attempt sends
+// `Range: bytes=<size>-` — a 206 re-hashes the existing part
+// (streamed) and appends, a 200 (server without Range) restarts
+// cleanly. The finished file is renamed to its content address
+// (blobs/sha256-<hex>) and a manifest records name → digest.
+//
+//   ( nl_resolve_url src )        → String   hf.co/ORG/REPO/FILE shorthand
+//                                             → the HF resolve URL;
+//                                             http(s):// passes through
+//   ( nl_default_name src )      → String   basename minus .gguf
+//   ( nl_pull root src name )    → !v String
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/progress.nu`
+$ `stdlib/ext/http.nu`
+$ `src/store.nu`
+
+// hf.co/ORG/REPO/path/to/file.gguf → https://huggingface.co/ORG/REPO/resolve/main/path/to/file.gguf
+@ nl_resolve_url s src → String {
+    ? | != ( nurl_str_starts src `http://` ) 0 != ( nurl_str_starts src `https://` ) 0 {
+        ^ ( string_from src )
+    } {}
+    ? != ( nurl_str_starts src `hf.co/` ) 0 {
+        // split ORG/REPO from the file path: the first two segments
+        : i n ( nurl_str_len src )
+        : ~ i slashes 0
+        : ~ i cut -1
+        : ~ i k 6
+        ~ & < k n < cut 0 {
+            ? == ( nurl_str_get src k ) 47 {
+                = slashes + slashes 1
+                ? == slashes 2 { = cut k } {}
+            } {}
+            = k + k 1
+        }
+        ? > cut 0 {
+            : String out ( string_from `https://huggingface.co/` )
+            : ~ i j 6
+            ~ < j cut {
+                ( string_push_char out ( nurl_str_get src j ) )
+                = j + j 1
+            }
+            ( string_push_str out `/resolve/main/` )
+            = j + cut 1
+            ~ < j n {
+                ( string_push_char out ( nurl_str_get src j ) )
+                = j + j 1
+            }
+            ^ out
+        } {}
+    } {}
+    ^ ( string_from src )
+}
+
+// last path segment, ".gguf" stripped — the default store name
+@ nl_default_name s src → String {
+    : i n ( nurl_str_len src )
+    : ~ i start 0
+    : ~ i k 0
+    ~ < k n {
+        ? == ( nurl_str_get src k ) 47 { = start + k 1 } {}
+        = k + k 1
+    }
+    : String out ( string_new )
+    = k start
+    ~ < k n {
+        ( string_push_char out ( nurl_str_get src k ) )
+        = k + k 1
+    }
+    ? ( string_ends_with out `.gguf` ) {
+        : String cutd ( string_substr out 0 - ( string_len out ) 5 )
+        ( string_free out )
+        ^ cutd
+    } {}
+    ^ out
+}
+
+// case-insensitive response-header lookup → owned value ("" if absent)
+@ __nl_find_header HttpStream st s want → String {
+    : ~ String out ( string_new )
+    : i hc ( http_stream_header_count st )
+    : ~ i k 0
+    ~ < k hc {
+        : s nm ( http_stream_header_name st k )
+        : String low ( string_from nm )
+        : String lowc ( string_to_lower low )
+        ( string_free low )
+        ? ( nurl_str_eq ( string_data lowc ) want ) {
+            ( string_free out )
+            = out ( string_from ( http_stream_header_value st k ) )
+            = k hc
+        } { = k + k 1 }
+        ( string_free lowc )
+    }
+    ^ out
+}
+
+// Feed the existing .part through the hasher (resume path).
+@ __nl_rehash_part * Sha256 h s path → !i String {
+    : !File IoErr fr ( file_open path )
+    ?? fr {
+        T f → {
+            : ~ i total 0
+            : ~ b more T
+            ~ more {
+                : !( Vec u ) IoErr cr ( file_read_chunk f 1048576 )
+                ?? cr {
+                    T piece → {
+                        : i pn ( vec_len [u] piece )
+                        ? == pn 0 { = more F } {
+                            ( sha256_update h piece )
+                            = total + total pn
+                        }
+                        ( vec_free [u] piece )
+                    }
+                    F _ → { = more F }
+                }
+            }
+            ( file_close f )
+            ^ @ !i String { T total }
+        }
+        F _ → { ^ @ !i String { F ( string_from `nurllama: cannot reopen the partial download` ) } }
+    }
+}
+
+@ nl_pull String root s src s name_override → !v String {
+    : !v String ir ( nl_store_init root )
+    ?? ir {
+        T _ → {}
+        F e → { ^ @ !v String { F e } }
+    }
+    : String url ( nl_resolve_url src )
+    : ~ String name ( string_new )
+    ? > ( nurl_str_len name_override ) 0 {
+        ( string_free name )
+        = name ( string_from name_override )
+    } {
+        ( string_free name )
+        = name ( nl_default_name src )
+    }
+    ? > ( string_len name ) 0 {} {
+        ( string_free name )
+        ( string_free url )
+        ^ @ !v String { F ( string_from `nurllama: cannot derive a model name — pass --name` ) }
+    }
+
+    // staging path: blobs/<safe-name>.part
+    : String bdir ( path_join ( string_data root ) `blobs` )
+    : String part0 ( path_join ( string_data bdir ) ( string_data name ) )
+    ( string_free bdir )
+    : String part ( string_from ( string_data part0 ) )
+    ( string_push_str part `.part` )
+    ( string_free part0 )
+
+    // resume offset = existing partial size
+    : ~ i off 0
+    ?? ( file_size ( string_data part ) ) {
+        T sz → { = off sz }
+        F _ → {}
+    }
+    : String hdrs ( string_new )
+    ? > off 0 {
+        ( string_push_str hdrs `Range: bytes=` )
+        ( string_push_int hdrs off )
+        ( string_push_str hdrs `-\r\n` )
+    } {}
+
+    : !HttpStream HttpErr sr ( http_stream_open `GET` ( string_data url ) `` ( string_data hdrs ) )
+    ( string_free hdrs )
+    ?? sr {
+        T st → {
+            : i status ( http_stream_pump_headers st )
+            : ~ b resume F
+            ? == status 206 { = resume T } {}
+            ? | == status 200 == status 206 {} {
+                ( http_stream_close st )
+                ( string_free part ) ( string_free name ) ( string_free url )
+                : String msg ( string_from `nurllama: download failed (HTTP ` )
+                ( string_push_int msg status )
+                ( string_push_str msg `)` )
+                ^ @ !v String { F msg }
+            }
+
+            // total size for the bar: Content-Length (+ resume offset)
+            : String cl ( __nl_find_header st `content-length` )
+            : ~ i total 0
+            ?? ( string_to_int cl ) {
+                T v → { = total v }
+                F _ → {}
+            }
+            ( string_free cl )
+            ? & resume > total 0 { = total + total off } {}
+
+            : *Sha256 h ( sha256_init )
+            : ~ i done_bytes 0
+            : ~ b failed F
+            : ~ String ferr ( string_new )
+
+            // open the staging file: append on a true 206, else truncate
+            : ~ i fh_ok 0
+            : ~ File f @ File { # s 0 }
+            ? resume {
+                : !i String rr ( __nl_rehash_part h ( string_data part ) )
+                ?? rr {
+                    T n → { = done_bytes n }
+                    F e → {
+                        = failed T
+                        ( string_free ferr )
+                        = ferr e
+                    }
+                }
+                ? failed {} {
+                    ?? ( file_append ( string_data part ) ) {
+                        T fa → { = f fa = fh_ok 1 }
+                        F _ → { = failed T ( string_free ferr ) = ferr ( string_from `nurllama: cannot open the staging file` ) }
+                    }
+                }
+            } {
+                ?? ( file_create ( string_data part ) ) {
+                    T fa → { = f fa = fh_ok 1 }
+                    F _ → { = failed T ( string_free ferr ) = ferr ( string_from `nurllama: cannot create the staging file` ) }
+                }
+            }
+
+            : *Progress pg ( progress_new ( string_data name ) total )
+            ? > done_bytes 0 { ( progress_set pg done_bytes ) } {}
+            : ~ b more ! failed
+            ~ more {
+                : ?( Vec u ) ch ( http_stream_next_bytes st )
+                ?? ch {
+                    T piece → {
+                        : i pn ( vec_len [u] piece )
+                        ? > pn 0 {
+                            ?? ( file_write_chunk f piece ) {
+                                T _ → {
+                                    ( sha256_update h piece )
+                                    = done_bytes + done_bytes pn
+                                    ( progress_add pg pn )
+                                }
+                                F _ → {
+                                    = failed T
+                                    = more F
+                                    ( string_free ferr )
+                                    = ferr ( string_from `nurllama: disk write failed mid-download` )
+                                }
+                            }
+                        } {}
+                        ( vec_free [u] piece )
+                    }
+                    F → { = more F }
+                }
+            }
+            ? == fh_ok 1 { ( file_close f ) } {}
+            ( progress_done pg )
+
+            // did the transfer itself fail?
+            ? failed {} {
+                : ?HttpErr he ( http_stream_err st )
+                ?? he {
+                    T _ → {
+                        = failed T
+                        ( string_free ferr )
+                        = ferr ( string_from `nurllama: transfer aborted — rerun to resume from the partial file` )
+                    }
+                    F → {}
+                }
+            }
+            ( http_stream_close st )
+            : ( Vec u ) dg ( sha256_final h )
+            ? failed {
+                ( vec_free [u] dg )
+                ( string_free part ) ( string_free name ) ( string_free url )
+                ^ @ !v String { F ferr }
+            } {}
+            ( string_free ferr )
+
+            // content-length sanity: a short body is a broken download
+            ? & > total 0 != done_bytes total {
+                ( vec_free [u] dg )
+                ( string_free part ) ( string_free name ) ( string_free url )
+                ^ @ !v String { F ( string_from `nurllama: transfer ended short — rerun to resume from the partial file` ) }
+            } {}
+
+            : String hex ( bytes_to_hex dg )
+            ( vec_free [u] dg )
+            : String bp ( nl_blob_path root ( string_data hex ) )
+            : !v IoErr mv ( fs_rename ( string_data part ) ( string_data bp ) )
+            ?? mv {
+                T _ → {}
+                F _ → {
+                    ( string_free hex ) ( string_free bp )
+                    ( string_free part ) ( string_free name ) ( string_free url )
+                    ^ @ !v String { F ( string_from `nurllama: cannot move the finished blob into place` ) }
+                }
+            }
+            : !v String ar ( nl_store_add root ( string_data name ) ( string_data url ) ( string_data hex ) done_bytes )
+            ( string_free bp )
+            ?? ar {
+                T _ → {}
+                F e → {
+                    ( string_free hex ) ( string_free part ) ( string_free name ) ( string_free url )
+                    ^ @ !v String { F e }
+                }
+            }
+            : String msg ( string_from `pulled ` )
+            ( string_push_str msg ( string_data name ) )
+            ( string_push_str msg ` (sha256:` )
+            : String short ( string_substr hex 0 12 )
+            ( string_push_str msg ( string_data short ) )
+            ( string_free short )
+            ( string_push_str msg `…, ` )
+            : String hs ( progress_human done_bytes )
+            ( string_push_str msg ( string_data hs ) )
+            ( string_free hs )
+            ( string_push_str msg `)` )
+            ( nurl_print ( string_data msg ) )
+            ( nurl_print `\n` )
+            ( string_free msg )
+            ( string_free hex )
+            ( string_free part ) ( string_free name ) ( string_free url )
+            ^ @ !v String { T 0 }
+        }
+        F _ → {
+            ( string_free part ) ( string_free name ) ( string_free url )
+            ^ @ !v String { F ( string_from `nurllama: cannot reach the download URL` ) }
+        }
+    }
+}

--- a/packages/nurllama/src/store.nu
+++ b/packages/nurllama/src/store.nu
@@ -1,0 +1,344 @@
+// packages/nurllama/src/store.nu — the local model store (~/.nurllama).
+//
+// Content-addressed, cas-shaped, but streaming end to end — a blob is
+// never fully resident:
+//
+//   <root>/blobs/sha256-<64hex>     the model files, named by content
+//   <root>/manifests/<name>         one small JSON per model name
+//
+// A manifest records { name, url, digest, size } — the name is the
+// user-facing handle (`nurllama run <name>`), the digest is the proof.
+// Two names may point at the same blob (dedup by content); `rm` only
+// deletes a blob once no manifest references it. `verify` re-hashes
+// the blob through the incremental sha256 and refuses drift.
+//
+//   ( nl_store_root )                 → String   $NURLLAMA_HOME | ~/.nurllama
+//   ( nl_resolve root nameOrPath )    → ?String  path to a model file
+//   ( nl_store_add root name url hex size ) → !v String
+//   ( nl_store_list root )            → v        prints the table
+//   ( nl_store_rm root name )         → !v String
+//   ( nl_store_verify root name )     → !v String
+//   ( nl_blob_path root hex ) ( nl_manifest_path root name )
+//   ( nl_hash_file path )             → !String String  streaming sha256 hex
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/progress.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+
+@ nl_store_root → String {
+    : ?String ov ( env_get `NURLLAMA_HOME` )
+    ?? ov {
+        T v → { ^ v }
+        F → {}
+    }
+    : String home ( env_var_or `HOME` `.` )
+    : String r ( path_join ( string_data home ) `.nurllama` )
+    ( string_free home )
+    ^ r
+}
+
+// Manifest names live on the filesystem: keep [A-Za-z0-9._-], map the
+// rest (slashes of repo-style names included) to '_'.
+@ __nl_safe_name s name → String {
+    : String out ( string_new )
+    : i n ( nurl_str_len name )
+    : ~ i k 0
+    ~ < k n {
+        : i c ( nurl_str_get name k )
+        : b okc | | | & >= c 48 <= c 57 & >= c 65 <= c 90 & >= c 97 <= c 122 | | == c 46 == c 95 == c 45
+        ( string_push_char out ? okc c 95 )
+        = k + k 1
+    }
+    ^ out
+}
+
+@ nl_blob_path String root s hex → String {
+    : String bdir ( path_join ( string_data root ) `blobs` )
+    : String nm ( string_from `sha256-` )
+    ( string_push_str nm hex )
+    : String p ( path_join ( string_data bdir ) ( string_data nm ) )
+    ( string_free bdir )
+    ( string_free nm )
+    ^ p
+}
+
+@ nl_manifest_path String root s name → String {
+    : String mdir ( path_join ( string_data root ) `manifests` )
+    : String sn ( __nl_safe_name name )
+    : String p ( path_join ( string_data mdir ) ( string_data sn ) )
+    ( string_free mdir )
+    ( string_free sn )
+    ^ p
+}
+
+@ nl_store_init String root → !v String {
+    : String b ( path_join ( string_data root ) `blobs` )
+    : String m ( path_join ( string_data root ) `manifests` )
+    : !v IoErr r1 ( dir_create_all ( string_data b ) )
+    : !v IoErr r2 ( dir_create_all ( string_data m ) )
+    ( string_free b )
+    ( string_free m )
+    : ~ b ok T
+    ?? r1 { T _ → {} F _ → { = ok F } }
+    ?? r2 { T _ → {} F _ → { = ok F } }
+    ? ok { ^ @ !v String { T 0 } } {}
+    : String msg ( string_from `nurllama: cannot create the store at ` )
+    ( string_push_str msg ( string_data root ) )
+    ^ @ !v String { F msg }
+}
+
+// Streaming sha256 of a file — constant memory whatever the size.
+@ nl_hash_file s path → !String String {
+    : !File IoErr fr ( file_open path )
+    ?? fr {
+        T f → {
+            : *Sha256 h ( sha256_init )
+            : ~ b more T
+            ~ more {
+                : !( Vec u ) IoErr cr ( file_read_chunk f 1048576 )
+                ?? cr {
+                    T piece → {
+                        ? == ( vec_len [u] piece ) 0 { = more F } {
+                            ( sha256_update h piece )
+                        }
+                        ( vec_free [u] piece )
+                    }
+                    F _ → { = more F }
+                }
+            }
+            ( file_close f )
+            : ( Vec u ) dg ( sha256_final h )
+            : String hex ( bytes_to_hex dg )
+            ( vec_free [u] dg )
+            ^ @ !String String { T hex }
+        }
+        F _ → {
+            : String msg ( string_from `nurllama: cannot open ` )
+            ( string_push_str msg path )
+            ^ @ !String String { F msg }
+        }
+    }
+}
+
+@ nl_store_add String root s name s url s hex i size → !v String {
+    : Json j ( json_obj_new )
+    : b _s1 ( json_obj_set j `name` ( json_str_lit name ) )
+    : b _s2 ( json_obj_set j `url` ( json_str_lit url ) )
+    : String dg ( string_from `sha256:` )
+    ( string_push_str dg hex )
+    : b _s3 ( json_obj_set j `digest` ( json_str_lit ( string_data dg ) ) )
+    ( string_free dg )
+    : b _s4 ( json_obj_set j `size` ( json_int size ) )
+    : b _s5 ( json_obj_set j `format` ( json_str_lit `gguf` ) )
+    : String txt ( json_stringify j )
+    ( json_free j )
+    : String mp ( nl_manifest_path root name )
+    : !v IoErr wr ( write_file ( string_data mp ) ( string_data txt ) )
+    ( string_free mp )
+    ( string_free txt )
+    ?? wr {
+        T _ → { ^ @ !v String { T 0 } }
+        F _ → { ^ @ !v String { F ( string_from `nurllama: cannot write the manifest` ) } }
+    }
+}
+
+// Manifest digest field → bare hex ("" when missing/malformed).
+@ __nl_manifest_hex s mpath → String {
+    : !String IoErr rr ( read_file mpath )
+    ?? rr {
+        T txt → {
+            : ~ String hex ( string_new )
+            : !Json JsonError pj ( json_parse ( string_data txt ) )
+            ?? pj {
+                T j → {
+                    // json_obj_get returns a BORROW — never freed here
+                    ?? ( json_obj_get j `digest` ) {
+                        T dj → {
+                            : s d ( json_str_data dj )
+                            ? & != ( nurl_str_starts d `sha256:` ) 0 == ( nurl_str_len d ) 71 {
+                                : ~ i k 7
+                                ~ < k 71 {
+                                    ( string_push_char hex ( nurl_str_get d k ) )
+                                    = k + k 1
+                                }
+                            } {}
+                        }
+                        F → {}
+                    }
+                    ( json_free j )
+                }
+                F _ → {}
+            }
+            ( string_free txt )
+            ^ hex
+        }
+        F _ → { ^ ( string_new ) }
+    }
+}
+
+// Resolve a model argument: an existing file path wins; otherwise the
+// store's manifest name → blob path. None = unknown.
+@ nl_resolve String root s arg → ?String {
+    ? ( file_exists arg ) { ^ @ ?String { T ( string_from arg ) } } {}
+    : String mp ( nl_manifest_path root arg )
+    : String hex ( __nl_manifest_hex ( string_data mp ) )
+    ( string_free mp )
+    ? == ( string_len hex ) 64 {} {
+        ( string_free hex )
+        ^ @ ?String { F }
+    }
+    : String bp ( nl_blob_path root ( string_data hex ) )
+    ( string_free hex )
+    ? ( file_exists ( string_data bp ) ) { ^ @ ?String { T bp } } {}
+    ( string_free bp )
+    ^ @ ?String { F }
+}
+
+@ nl_store_list String root → v {
+    : String mdir ( path_join ( string_data root ) `manifests` )
+    : !( Vec String ) IoErr lr ( dir_list ( string_data mdir ) )
+    ?? lr {
+        T names → {
+            : ~ i k 0
+            ~ < k ( vec_len [String] names ) {
+                ?? ( vec_get [String] names k ) {
+                    T nm → {
+                        : String mp ( path_join ( string_data mdir ) ( string_data nm ) )
+                        : String hex ( __nl_manifest_hex ( string_data mp ) )
+                        : ~ i bsz -1
+                        ? == ( string_len hex ) 64 {
+                            : String bp ( nl_blob_path root ( string_data hex ) )
+                            ?? ( file_size ( string_data bp ) ) {
+                                T sz → { = bsz sz }
+                                F _ → {}
+                            }
+                            ( string_free bp )
+                        } {}
+                        : String ln ( string_from ( string_data nm ) )
+                        : ~ i pad - 32 ( string_len ln )
+                        ~ > pad 0 {
+                            ( string_push_char ln 32 )
+                            = pad - pad 1
+                        }
+                        ? >= bsz 0 {
+                            : String hs ( progress_human bsz )
+                            ( string_push_str ln ( string_data hs ) )
+                            ( string_free hs )
+                            ( string_push_str ln `  sha256:` )
+                            : String short ( string_substr hex 0 12 )
+                            ( string_push_str ln ( string_data short ) )
+                            ( string_free short )
+                        } {
+                            ( string_push_str ln `MISSING BLOB` )
+                        }
+                        ( nurl_print ( string_data ln ) )
+                        ( nurl_print `\n` )
+                        ( string_free ln )
+                        ( string_free hex )
+                        ( string_free mp )
+                    }
+                    F → {}
+                }
+                = k + k 1
+            }
+            ( vec_free_with [String] names \ String s → v { ( string_free s ) } )
+        }
+        F _ → {}
+    }
+    ( string_free mdir )
+}
+
+// True when any OTHER manifest still references blob `hex`.
+@ __nl_blob_shared String root s hex s except_name → b {
+    : String mdir ( path_join ( string_data root ) `manifests` )
+    : String keep ( __nl_safe_name except_name )
+    : ~ b shared F
+    : !( Vec String ) IoErr lr ( dir_list ( string_data mdir ) )
+    ?? lr {
+        T names → {
+            : ~ i k 0
+            ~ < k ( vec_len [String] names ) {
+                ?? ( vec_get [String] names k ) {
+                    T nm → {
+                        ? ( string_eq nm keep ) {} {
+                            : String mp ( path_join ( string_data mdir ) ( string_data nm ) )
+                            : String ohex ( __nl_manifest_hex ( string_data mp ) )
+                            ? ( nurl_str_eq ( string_data ohex ) hex ) { = shared T } {}
+                            ( string_free ohex )
+                            ( string_free mp )
+                        }
+                    }
+                    F → {}
+                }
+                = k + k 1
+            }
+            ( vec_free_with [String] names \ String s → v { ( string_free s ) } )
+        }
+        F _ → {}
+    }
+    ( string_free keep )
+    ( string_free mdir )
+    ^ shared
+}
+
+@ nl_store_rm String root s name → !v String {
+    : String mp ( nl_manifest_path root name )
+    ? ( file_exists ( string_data mp ) ) {} {
+        ( string_free mp )
+        ^ @ !v String { F ( string_from `nurllama: no such model in the store` ) }
+    }
+    : String hex ( __nl_manifest_hex ( string_data mp ) )
+    : !v IoErr dr ( file_delete ( string_data mp ) )
+    ( string_free mp )
+    ?? dr {
+        T _ → {}
+        F _ → {
+            ( string_free hex )
+            ^ @ !v String { F ( string_from `nurllama: cannot remove the manifest` ) }
+        }
+    }
+    // drop the blob only when no other name still points at it
+    ? == ( string_len hex ) 64 {
+        ? ( __nl_blob_shared root ( string_data hex ) name ) {} {
+            : String bp ( nl_blob_path root ( string_data hex ) )
+            ( file_delete ( string_data bp ) )
+            ( string_free bp )
+        }
+    } {}
+    ( string_free hex )
+    ^ @ !v String { T 0 }
+}
+
+// Re-hash the blob and compare with the manifest digest — the store's
+// integrity loop (mirrors cas_get's refuse-on-mismatch, streaming).
+@ nl_store_verify String root s name → !v String {
+    : String mp ( nl_manifest_path root name )
+    : String hex ( __nl_manifest_hex ( string_data mp ) )
+    ( string_free mp )
+    ? == ( string_len hex ) 64 {} {
+        ( string_free hex )
+        ^ @ !v String { F ( string_from `nurllama: no such model (or a malformed manifest)` ) }
+    }
+    : String bp ( nl_blob_path root ( string_data hex ) )
+    : !String String hr ( nl_hash_file ( string_data bp ) )
+    ( string_free bp )
+    ?? hr {
+        T got → {
+            : b okh ( string_eq got hex )
+            ( string_free got )
+            ( string_free hex )
+            ? okh { ^ @ !v String { T 0 } } {}
+            ^ @ !v String { F ( string_from `nurllama: INTEGRITY FAILURE — blob does not hash to its manifest digest` ) }
+        }
+        F e → {
+            ( string_free hex )
+            ^ @ !v String { F e }
+        }
+    }
+}

--- a/packages/nurllama/tests/store_test.sh
+++ b/packages/nurllama/tests/store_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tests/store_test.sh — the model store + streaming pull:
+#    1. pull from a local HTTP server → digest == system sha256sum,
+#       list/verify agree
+#    2. THE POINT — resume: a pre-seeded .part makes the client send
+#       `Range: bytes=N-`; the server log proves 206 + only the tail
+#       was transferred; the final digest is still exact
+#    3. a server WITHOUT Range support answers 200 → clean restart,
+#       digest still exact
+#    4. tamper: flip one blob byte → verify refuses
+#    5. two names, one blob: rm keeps the blob until the last
+#       reference is gone
+#    6. NURL_NET_TESTS=1: real HF pull + `run` by store name
+#
+#  Run from the package dir:  ./tests/store_test.sh
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 required"; exit 0; }
+
+WORK="$(mktemp -d -t nurllama-store.XXXXXX)"
+SRV_PID=""
+trap '[ -n "$SRV_PID" ] && kill $SRV_PID 2>/dev/null; rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+
+[ -e deps/gguf ] || { mkdir -p deps && ln -s ../../gguf deps/gguf; }
+[ -e deps/gpu ]  || { mkdir -p deps && ln -s ../../gpu deps/gpu; }
+
+echo "[1/3] build nurllama"
+if ! $NURL src/main.nu "$WORK/nurllama" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build nurllama:"; tail -5 "$WORK/build.err"; exit 1
+fi
+NL="$WORK/nurllama"
+export NURLLAMA_HOME="$WORK/store"
+
+# ── local server with Range support + request log ──────────────────
+mkdir -p "$WORK/www"
+python3 -c "import sys,os; os.write(1, bytes(((k*131+7) & 255) for k in range(2*1024*1024)))" > "$WORK/www/model.gguf"
+REF_SHA=$(sha256sum "$WORK/www/model.gguf" | cut -d' ' -f1)
+
+cat > "$WORK/rangesrv.py" <<'PYEOF'
+import http.server, os, re, sys
+LOG = open(sys.argv[2], 'a', buffering=1)
+class H(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_GET(self):
+        path = os.path.join(sys.argv[3], self.path.lstrip('/'))
+        if not os.path.isfile(path):
+            self.send_response(404); self.end_headers(); return
+        data = open(path, 'rb').read()
+        rng = self.headers.get('Range')
+        LOG.write('GET %s Range=%s\n' % (self.path, rng))
+        if rng and sys.argv[4] == 'range':
+            m = re.match(r'bytes=(\d+)-$', rng)
+            start = int(m.group(1))
+            body = data[start:]
+            self.send_response(206)
+            self.send_header('Content-Range', 'bytes %d-%d/%d' % (start, len(data)-1, len(data)))
+        else:
+            body = data
+            self.send_response(200)
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        LOG.write('SERVED %d\n' % len(body))
+http.server.ThreadingHTTPServer(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
+PYEOF
+PORT=$(( (RANDOM % 20000) + 20000 ))
+python3 "$WORK/rangesrv.py" "$PORT" "$WORK/req.log" "$WORK/www" range &
+SRV_PID=$!
+sleep 0.5
+
+echo "[2/3] pull / resume / verify / rm against the local server"
+"$NL" pull "http://127.0.0.1:$PORT/model.gguf" --name m1 >/dev/null || bad "pull rc"
+BLOB="$NURLLAMA_HOME/blobs/sha256-$REF_SHA"
+[ -f "$BLOB" ] && ok "blob named by its true sha256 (== sha256sum)" || bad "blob digest ($REF_SHA)"
+"$NL" list | grep -q "m1" && ok "list shows the model" || bad "list"
+"$NL" verify m1 >/dev/null && ok "verify proves the blob" || bad "verify"
+
+# resume: seed a half .part, re-pull under a new name — server must see
+# the Range header, answer 206, and serve ONLY the tail
+head -c 1048576 "$WORK/www/model.gguf" > "$NURLLAMA_HOME/blobs/m2.part"
+: > "$WORK/req.log"
+"$NL" pull "http://127.0.0.1:$PORT/model.gguf" --name m2 >/dev/null || bad "resume pull rc"
+grep -q "Range=bytes=1048576-" "$WORK/req.log" && ok "resume sends Range: bytes=1048576-" || bad "resume Range header"
+grep -q "SERVED 1048576$" "$WORK/req.log" && ok "server sent only the missing tail (206)" || bad "tail-only transfer"
+"$NL" verify m2 >/dev/null && ok "resumed digest still exact" || bad "resumed digest"
+
+# two names, one blob: removing one keeps the blob
+"$NL" rm m2 >/dev/null || bad "rm m2 rc"
+[ -f "$BLOB" ] && ok "blob survives while m1 still references it" || bad "shared-blob rm"
+"$NL" rm m1 >/dev/null || bad "rm m1 rc"
+[ ! -f "$BLOB" ] && ok "last rm removes the blob" || bad "blob lingered"
+
+# 200-restart: server that IGNORES Range; stale .part must not corrupt
+kill $SRV_PID 2>/dev/null; wait $SRV_PID 2>/dev/null
+python3 "$WORK/rangesrv.py" "$PORT" "$WORK/req.log" "$WORK/www" norange &
+SRV_PID=$!
+sleep 0.5
+head -c 700000 "$WORK/www/model.gguf" > "$NURLLAMA_HOME/blobs/m3.part"
+"$NL" pull "http://127.0.0.1:$PORT/model.gguf" --name m3 >/dev/null || bad "200-restart pull rc"
+"$NL" verify m3 >/dev/null && ok "Range-less server → clean restart, digest exact" || bad "200-restart digest"
+
+# tamper: flip one byte in the blob → verify must refuse
+BLOB="$NURLLAMA_HOME/blobs/sha256-$REF_SHA"
+printf 'X' | dd of="$BLOB" bs=1 seek=100000 conv=notrunc 2>/dev/null
+if "$NL" verify m3 >/dev/null 2>&1; then bad "tamper accepted"; else ok "tamper: verify refuses a flipped byte"; fi
+
+echo "[3/3] real model (net-gated)"
+if [ "${NURL_NET_TESTS:-0}" = 1 ] && command -v curl >/dev/null 2>&1; then
+    rm -rf "$NURLLAMA_HOME"
+    if "$NL" pull hf.co/ggml-org/models/tinyllamas/stories260K.gguf >/dev/null; then
+        OUT=$("$NL" run stories260K "Once upon a time" -n 16 --temp 0)
+        [ "$(printf '%s' "$OUT" | wc -w)" -ge 5 ] && ok "HF pull + run by store name" || bad "run by name"
+    else
+        echo "  SKIP HF pull failed"
+    fi
+else
+    echo "  SKIP (set NURL_NET_TESTS=1 for the HF round-trip)"
+fi
+
+echo "== nurllama store tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" = 0 ]


### PR DESCRIPTION
Phase 4 of the local-LLM engine — `nurllama pull hf.co/ggml-org/models/tinyllamas/stories260K.gguf` → `nurllama run stories260K "Once upon a time"`. First real consumer of the phase-0 stdlib primitives (#454): the whole pull is constant-memory.

## What

- **Store** (`~/.nurllama` / `$NURLLAMA_HOME`): content-addressed `blobs/sha256-<hex>` + one JSON manifest per name. Multiple names may share a blob; `rm` deletes the blob only when the last reference is gone. `verify` re-hashes in a stream and refuses drift — cas_get's contract.
- **Pull**: `http_stream_next_bytes` chunks → `file_write_chunk`, with the incremental sha256 consuming the same bytes and the tty-gated progress bar narrating (CI logs stay clean). **Resume**: an interrupted pull leaves `<name>.part`; the retry sends `Range: bytes=<size>-` — 206 re-hashes the existing part (streamed) and appends only the tail; 200 from a Range-less server restarts cleanly. Short bodies are errors; the finished file is `fs_rename`d to its content address. `hf.co/ORG/REPO/FILE.gguf` shorthand resolves to the HF URL.
- **CLI**: `pull [--name] / list / rm / verify`; `run`/`logits`/`tokenize`/`detok`/`vocab` accept a store name or a plain path.

## Proof (`tests/store_test.sh`, 11 checks)

- Pulled blob name **equals the system `sha256sum`** of the fixture.
- **Resume proof**: a seeded 1 MiB partial against a local Range-serving server — the request log shows `Range: bytes=1048576-` and `SERVED 1048576` (exactly the missing tail), digest still exact.
- Range-less server + stale partial → clean restart, digest exact.
- Flipped blob byte → `verify` refuses (INTEGRITY FAILURE).
- Shared blob survives `rm` until its last name is removed.
- Net-gated: real HF pull + `run` by store name end to end.
- `pull`/`verify`/`list`/`rm` ASan/LSan-clean.

Package tests are not wired into compiler CI, per the M6 won't-do decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH