### PR TITLE
nurllama: chat + an ollama-compatible HTTP API (phase 5) + an http streaming hook

### DIFF
--- a/packages/http/src/app.nu
+++ b/packages/http/src/app.nu
@@ -150,6 +150,18 @@ $ `stdlib/ext/http_static.nu`
     ( router_any . a router method pattern handler )
 }
 
+// Streaming routes (SSE / NDJSON / chunked). The handler sees every
+// request BEFORE the router — return F to fall through to the normal
+// routes, or write the whole response itself (response_begin_chunked /
+// response_write_chunk / response_end_chunked on the TcpConn) and
+// return T; the server then closes the connection when the handler
+// returns (a streamed response is that connection's last — do not
+// close the conn inside the handler). One hook per process: dispatch
+// on `. req path` / `. req method` inside it.
+@ http_app_stream * HttpApp a ( @ b TcpConn HttpRequest ) f → v {
+    ( server_set_stream f )
+}
+
 // The embedded router, for advanced use (mounting sub-routers, tests).
 @ http_app_router * HttpApp a → Router { ^ . a router }
 

--- a/packages/nurllama/README.md
+++ b/packages/nurllama/README.md
@@ -2,17 +2,24 @@
 
 The ollama-shaped engine, built package by package on top of
 [`packages/gguf`](../gguf) and [`packages/gpu`](../gpu).
-**Phase 4 (current): the model store.**
+**Phase 5 (current): chat + an ollama-compatible API.**
 
 ```
 $ nurllama pull hf.co/ggml-org/models/tinyllamas/stories260K.gguf
 pulled stories260K (sha256:270cba1bd510…, 1.1 MB)
+$ nurllama serve                      # ollama-compatible, port 11434
+$ curl localhost:11434/api/generate -d '{"model":"stories260K","prompt":"Once upon a time"}'
+{"model":"stories260K","response":",","done":false}
+{"model":"stories260K","response":" there","done":false}
+…
+$ nurllama chat mymodel               # interactive, model's own template
 $ nurllama run stories260K "Once upon a time" -n 40 --temp 0
 , there was a little girl named Lily. She loved to play outside in the
 park. One day, she saw a big, red ball.
 
 nurllama pull <hf.co/ORG/REPO/FILE.gguf | url> [--name N]
 nurllama list · rm <name> · verify <name>
+nurllama serve [--host H] [--port N] · chat <name|path>
 nurllama run <name|path> "prompt" [-n N] [--temp F] [--topk N] [--topp F] [--seed N]
 nurllama logits model.gguf "prompt"               # verification tap
 nurllama tokenize model.gguf "Once upon a time"   # → 1 403 407 261 378
@@ -20,6 +27,27 @@ nurllama detok model.gguf 1 403 407 261 378       # → " Once upon a time"
 nurllama vocab model.gguf 10                      # first 10 pieces
 nurllama selftest                                 # 17 bit-exact checks
 ```
+
+## The API and chat
+
+`nurllama serve` speaks enough of ollama's wire protocol that existing
+clients work unchanged: `POST /api/generate` and `POST /api/chat` emit
+**NDJSON — one object per token, the moment it decodes** (`stream:false`
+returns a single aggregated object instead), plus `GET /api/tags`,
+`POST /api/show` and a health root. Streaming rides a new
+`http_app_stream` hook in the http package: the handler owns the
+TcpConn and writes chunked frames itself.
+
+Chat templates come from **the model's own GGUF metadata**
+(`tokenizer.chat_template` → ChatML / llama3 / llama2). A model with no
+template is a *base* model, and nurllama refuses to invent turns for it
+— it completes text, which is what such a model was trained to do.
+`nurllama chat` runs the same renderer over a live message list with a
+line editor and streaming output.
+
+One model is resident at a time; a request for another swaps it in.
+The server is single-worker, so decode serialisation is structural
+rather than a lock — honest for a single-GPU host.
 
 ## Model store
 
@@ -121,6 +149,6 @@ $ `src/tokenizer.nu`
 
 ## Roadmap
 
-Phase 5: CLI chat + an ollama-compatible HTTP API. Phase 6:
-device-side dequant-in-matmul, K-quants, batched prefill. See the
-plan in the repo's development notes.
+Phase 6: device-side dequant-in-matmul, K-quants, batched prefill,
+per-model BPE pre-tokenizer variants. See the plan in the repo's
+development notes.

--- a/packages/nurllama/src/api.nu
+++ b/packages/nurllama/src/api.nu
@@ -1,0 +1,505 @@
+// packages/nurllama/src/api.nu — an ollama-compatible HTTP API.
+//
+// Speaks enough of ollama's wire protocol that existing clients work
+// unchanged:
+//
+//   POST /api/generate   { model, prompt, stream?, options? }
+//   POST /api/chat       { model, messages[{role,content}], stream?, options? }
+//        → NDJSON: one JSON object per token while generating, then a
+//          final object with done:true (+ token counts). stream:false
+//          returns a single aggregated object.
+//   GET  /api/tags       the local store, as ollama's model list
+//   POST /api/show       { model } → the model's metadata
+//   GET  /                "nurllama is running"
+//
+// Streaming rides the http package's stream hook (http_app_stream):
+// the handler owns the TcpConn and writes chunked NDJSON itself, so a
+// token reaches the client the moment it is decoded.
+//
+// One model is resident at a time (LRU of one): a request naming a
+// different model swaps it in. Generation is serialised — the decode
+// loop owns the device — which is honest for a single-GPU host; the
+// server is single-worker so that serialisation is structural rather
+// than a lock.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/rng.nu`
+$ `stdlib/ext/json.nu`
+$ `deps/http/src/http.nu`
+$ `deps/gguf/src/gguf.nu`
+$ `src/tokenizer.nu`
+$ `src/model.nu`
+$ `src/sample.nu`
+$ `src/chat.nu`
+$ `src/store.nu`
+
+// The resident model + the store root, reachable from the handlers.
+// Globals may only carry scalar/`s` literals, so the two strings are
+// plain owned C-strings (strdup'd in, nurl_free'd out) rather than
+// String structs.
+: ~ i g_api_llm 0
+: ~ i g_api_style 0
+: ~ s g_api_name ``
+: ~ s g_api_root ``
+
+@ __api_set_name s name → v {
+    ? != 0 ( nurl_str_len g_api_name ) { ( nurl_free g_api_name ) } {}
+    = g_api_name ( strdup name )
+}
+
+@ api_set_root String root → v {
+    ? != 0 ( nurl_str_len g_api_root ) { ( nurl_free g_api_root ) } {}
+    = g_api_root ( strdup ( string_data root ) )
+}
+
+@ __api_unload → v {
+    ? != g_api_llm 0 {
+        ( llm_close # *Llm g_api_llm )
+        = g_api_llm 0
+    } {}
+    ? != 0 ( nurl_str_len g_api_name ) {
+        ( nurl_free g_api_name )
+        = g_api_name ``
+    } {}
+}
+
+// Load `name` unless it is already resident. Empty error = success.
+@ __api_ensure s name → String {
+    ? & != g_api_llm 0 != 0 ( nurl_str_eq g_api_name name ) { ^ ( string_new ) } {}
+    ( __api_unload )
+    : String rootS ( string_from g_api_root )
+    : ?String rp ( nl_resolve rootS name )
+    ( string_free rootS )
+    ?? rp {
+        T path → {
+            // the chat style comes from the model's own metadata
+            : ~ i style CHAT_PLAIN
+            ?? ( gguf_open ( string_data path ) ) {
+                T gg → {
+                    = style ( chat_style_of gg )
+                    ( gguf_close gg )
+                }
+                F e → { ( string_free e ) }
+            }
+            : !*Llm String lr ( llm_open ( string_data path ) 0 )
+            ( string_free path )
+            ?? lr {
+                T m → {
+                    = g_api_llm # i m
+                    = g_api_style style
+                    ( __api_set_name name )
+                    ^ ( string_new )
+                }
+                F e → { ^ e }
+            }
+        }
+        F → {
+            : String msg ( string_from `model '` )
+            ( string_push_str msg name )
+            ( string_push_str msg `' not found — pull it first` )
+            ^ msg
+        }
+    }
+}
+
+// ── request-body helpers ────────────────────────────────────────────
+
+@ __api_body_json HttpRequest req → !Json JsonError {
+    : String txt ( bytes_to_str . req body )
+    : !Json JsonError r ( json_parse ( string_data txt ) )
+    ( string_free txt )
+    ^ r
+}
+
+@ __api_str Json j s key s def → String {
+    ?? ( json_obj_get j key ) {
+        T v → { ^ ( string_from ( json_str_data v ) ) }
+        F → { ^ ( string_from def ) }
+    }
+}
+
+@ __api_bool Json j s key b def → b {
+    ?? ( json_obj_get j key ) {
+        T v → { ^ ? ( json_is_bool v ) ( json_bool_val v ) def }
+        F → { ^ def }
+    }
+}
+
+// options.<key>, ollama's nesting
+@ __api_opt_i Json j s key i def → i {
+    ?? ( json_obj_get j `options` ) {
+        T o → {
+            ?? ( json_obj_get o key ) {
+                T v → {
+                    ?? ( json_num_as_i v ) {
+                        T n → { ^ n }
+                        F → { ^ def }
+                    }
+                }
+                F → { ^ def }
+            }
+        }
+        F → { ^ def }
+    }
+}
+
+@ __api_opt_f Json j s key f def → f {
+    ?? ( json_obj_get j `options` ) {
+        T o → {
+            ?? ( json_obj_get o key ) {
+                T v → {
+                    ?? ( json_num_as_f v ) {
+                        T x → { ^ x }
+                        F → { ^ def }
+                    }
+                }
+                F → { ^ def }
+            }
+        }
+        F → { ^ def }
+    }
+}
+
+// ── NDJSON frames ───────────────────────────────────────────────────
+
+@ __api_frame_token s model s field s piece → String {
+    : Json j ( json_obj_new )
+    : b _1 ( json_obj_set j `model` ( json_str_lit model ) )
+    ? ( nurl_str_eq field `response` ) {
+        : b _2 ( json_obj_set j `response` ( json_str_lit piece ) )
+    } {
+        : Json msg ( json_obj_new )
+        : b _3 ( json_obj_set msg `role` ( json_str_lit `assistant` ) )
+        : b _4 ( json_obj_set msg `content` ( json_str_lit piece ) )
+        : b _5 ( json_obj_set j `message` msg )
+    }
+    : b _6 ( json_obj_set j `done` ( json_bool F ) )
+    : String out ( json_stringify j )
+    ( json_free j )
+    ( string_push_char out 10 )
+    ^ out
+}
+
+@ __api_frame_done s model s field i nprompt i neval b with_text s full → String {
+    : Json j ( json_obj_new )
+    : b _1 ( json_obj_set j `model` ( json_str_lit model ) )
+    ? ( nurl_str_eq field `response` ) {
+        : b _2 ( json_obj_set j `response` ( json_str_lit ? with_text full `` ) )
+    } {
+        : Json msg ( json_obj_new )
+        : b _3 ( json_obj_set msg `role` ( json_str_lit `assistant` ) )
+        : b _4 ( json_obj_set msg `content` ( json_str_lit ? with_text full `` ) )
+        : b _5 ( json_obj_set j `message` msg )
+    }
+    : b _6 ( json_obj_set j `done` ( json_bool T ) )
+    : b _7 ( json_obj_set j `done_reason` ( json_str_lit `stop` ) )
+    : b _8 ( json_obj_set j `prompt_eval_count` ( json_int nprompt ) )
+    : b _9 ( json_obj_set j `eval_count` ( json_int neval ) )
+    : String out ( json_stringify j )
+    ( json_free j )
+    ( string_push_char out 10 )
+    ^ out
+}
+
+@ __api_write_str TcpConn c String s → b {
+    : ( Vec u ) b2 ( bytes_from_str ( string_data s ) )
+    : !v NetErr r ( response_write_chunk c b2 )
+    ( vec_free [u] b2 )
+    : ~ b ok T
+    ?? r { T _ → {} F _ → { = ok F } }
+    ^ ok
+}
+
+@ __api_begin_ndjson TcpConn c → b {
+    : ( Vec Header ) hs ( vec_new [Header] )
+    ( vec_push [Header] hs ( header_new `Content-Type` `application/x-ndjson` ) )
+    : !v NetErr r ( response_begin_chunked c 200 hs )
+    ( vec_free_with [Header] hs \ Header h → v { ( header_free h ) } )
+    : ~ b ok T
+    ?? r { T _ → {} F _ → { = ok F } }
+    ^ ok
+}
+
+@ __api_error_chunked TcpConn c i status s msg → b {
+    : ( Vec Header ) hs ( vec_new [Header] )
+    ( vec_push [Header] hs ( header_new `Content-Type` `application/json` ) )
+    : !v NetErr r ( response_begin_chunked c status hs )
+    ( vec_free_with [Header] hs \ Header h → v { ( header_free h ) } )
+    ?? r { T _ → {} F _ → { ^ T } }
+    : Json j ( json_obj_new )
+    : b _1 ( json_obj_set j `error` ( json_str_lit msg ) )
+    : String txt ( json_stringify j )
+    ( json_free j )
+    ( string_push_char txt 10 )
+    : b _w ( __api_write_str c txt )
+    ( string_free txt )
+    : !v NetErr _e ( response_end_chunked c )
+    ^ T
+}
+
+// ── the generation core, shared by /api/generate and /api/chat ──────
+//
+// Streams NDJSON frames as tokens decode (stream=true), or accumulates
+// and answers with a single object (stream=false).
+@ __api_generate TcpConn c s model String prompt s field b stream
+i npredict f temp i topk f topp i seed → b {
+    : *Llm m # *Llm g_api_llm
+    : *Tok t ( llm_tok m )
+    : ( Vec i ) ids ( tok_encode t ( string_data prompt ) T )
+    : i nprompt ( vec_len [i] ids )
+    ? > nprompt ( llm_n_ctx m ) {
+        ( vec_free [i] ids )
+        ^ ( __api_error_chunked c 400 `prompt is longer than the model's context` )
+    } {}
+    ? stream { ? ( __api_begin_ndjson c ) {} { ( vec_free [i] ids ) ^ T } } {}
+
+    : ~ i k 0
+    ~ < k nprompt {
+        ( llm_eval m ( __tk_geti ids k 0 ) k )
+        = k + k 1
+    }
+    ( vec_free [i] ids )
+
+    : Rng rng ( rng_seed seed )
+    : String full ( string_new )
+    : ~ i pos nprompt
+    : ~ i produced 0
+    : ~ b stop F
+    : ~ b broken F
+    ~ & & & < produced npredict < pos ( llm_n_ctx m ) ! stop ! broken {
+        : i nt ( sample_next m rng temp topk topp )
+        ? == nt ( tok_eos t ) { = stop T } {
+            : ( Vec u ) pb ( tok_piece t nt )
+            : String piece ( bytes_to_str pb )
+            ( vec_free [u] pb )
+            // a chat dialect's terminator may arrive as plain text
+            ? ( chat_stop_matches g_api_style ( string_data piece ) ) { = stop T } {
+                ( string_push_str full ( string_data piece ) )
+                ? stream {
+                    : String fr ( __api_frame_token model field ( string_data piece ) )
+                    ? ( __api_write_str c fr ) {} { = broken T }
+                    ( string_free fr )
+                } {}
+                ( llm_eval m nt pos )
+                = pos + pos 1
+                = produced + produced 1
+            }
+            ( string_free piece )
+        }
+    }
+
+    ? broken {
+        ( string_free full )
+        ^ T
+    } {}
+    ? stream {} { ? ( __api_begin_ndjson c ) {} { ( string_free full ) ^ T } }
+    : String fin ( __api_frame_done model field nprompt produced ! stream ( string_data full ) )
+    : b _w ( __api_write_str c fin )
+    ( string_free fin )
+    ( string_free full )
+    : !v NetErr _e ( response_end_chunked c )
+    ^ T
+}
+
+// ── the stream hook: /api/generate + /api/chat ──────────────────────
+
+@ __api_stream_hook TcpConn c HttpRequest req → b {
+    : s path ( string_data . req path )
+    : b is_gen ? ( nurl_str_eq path `/api/generate` ) T F
+    : b is_chat ? ( nurl_str_eq path `/api/chat` ) T F
+    ? | is_gen is_chat {} { ^ F }
+    ? ( nurl_str_eq ( string_data . req method ) `POST` ) {} { ^ F }
+
+    : !Json JsonError pj ( __api_body_json req )
+    ?? pj {
+        F _ → { ^ ( __api_error_chunked c 400 `invalid JSON body` ) }
+        T j → {
+            : String model ( __api_str j `model` `` )
+            ? > ( string_len model ) 0 {} {
+                ( string_free model )
+                ( json_free j )
+                ^ ( __api_error_chunked c 400 `missing "model"` )
+            }
+            : String lerr ( __api_ensure ( string_data model ) )
+            ? > ( string_len lerr ) 0 {
+                : b r ( __api_error_chunked c 404 ( string_data lerr ) )
+                ( string_free lerr )
+                ( string_free model )
+                ( json_free j )
+                ^ r
+            } {}
+            ( string_free lerr )
+
+            // prompt: /api/generate takes it verbatim; /api/chat renders
+            // the message list through the model's own chat template
+            : ~ String prompt ( string_new )
+            ? is_gen {
+                ( string_free prompt )
+                = prompt ( __api_str j `prompt` `` )
+            } {
+                : ( Vec ChatMsg ) msgs ( vec_new [ChatMsg] )
+                ?? ( json_obj_get j `messages` ) {
+                    T arr → {
+                        : ~ i k 0
+                        ~ < k ( json_arr_len arr ) {
+                            ?? ( json_arr_get arr k ) {
+                                T mo → {
+                                    : String role ( __api_str mo `role` `user` )
+                                    : String content ( __api_str mo `content` `` )
+                                    ( vec_push [ChatMsg] msgs ( chat_msg ( string_data role ) ( string_data content ) ) )
+                                    ( string_free role )
+                                    ( string_free content )
+                                }
+                                F → {}
+                            }
+                            = k + k 1
+                        }
+                    }
+                    F → {}
+                }
+                ( string_free prompt )
+                = prompt ( chat_render g_api_style msgs )
+                ( chat_msgs_free msgs )
+            }
+
+            : b stream ( __api_bool j `stream` T )
+            : i npredict ( __api_opt_i j `num_predict` 128 )
+            : f temp ( __api_opt_f j `temperature` 0.8 )
+            : i topk ( __api_opt_i j `top_k` 40 )
+            : f topp ( __api_opt_f j `top_p` 0.95 )
+            : i seed ( __api_opt_i j `seed` 42 )
+            : s field ? is_gen `response` `message`
+            : b r ( __api_generate c ( string_data model ) prompt field stream npredict temp topk topp seed )
+            ( string_free prompt )
+            ( string_free model )
+            ( json_free j )
+            ^ r
+        }
+    }
+}
+
+// ── plain JSON routes ───────────────────────────────────────────────
+
+@ __api_tags HttpRequest req Params ps → HttpResponse {
+    : Json arr ( json_arr_new )
+    : String rootS ( string_from g_api_root )
+    : String mdir ( path_join g_api_root `manifests` )
+    ?? ( dir_list ( string_data mdir ) ) {
+        T names → {
+            : ~ i k 0
+            ~ < k ( vec_len [String] names ) {
+                ?? ( vec_get [String] names k ) {
+                    T nm → {
+                        : Json o ( json_obj_new )
+                        : b _1 ( json_obj_set o `name` ( json_str_lit ( string_data nm ) ) )
+                        : b _2 ( json_obj_set o `model` ( json_str_lit ( string_data nm ) ) )
+                        : ~ i sz 0
+                        ?? ( nl_resolve rootS ( string_data nm ) ) {
+                            T bp → {
+                                ?? ( file_size ( string_data bp ) ) {
+                                    T n → { = sz n }
+                                    F _ → {}
+                                }
+                                ( string_free bp )
+                            }
+                            F → {}
+                        }
+                        : b _3 ( json_obj_set o `size` ( json_int sz ) )
+                        : b _4 ( json_arr_push arr o )
+                    }
+                    F → {}
+                }
+                = k + k 1
+            }
+            ( vec_free_with [String] names \ String s → v { ( string_free s ) } )
+        }
+        F _ → {}
+    }
+    ( string_free mdir )
+    ( string_free rootS )
+    : Json root ( json_obj_new )
+    : b _r ( json_obj_set root `models` arr )
+    : String txt ( json_stringify root )
+    ( json_free root )
+    : HttpResponse resp ( response_new 200 )
+    ( response_set_header resp `Content-Type` `application/json` )
+    ( response_set_body_str resp ( string_data txt ) )
+    ( string_free txt )
+    ^ resp
+}
+
+@ __api_show HttpRequest req Params ps → HttpResponse {
+    : !Json JsonError pj ( __api_body_json req )
+    ?? pj {
+        F _ → { ^ ( response_text 400 `{"error":"invalid JSON body"}\n` ) }
+        T j → {
+            : String model ( __api_str j `model` `` )
+            ( json_free j )
+            : String rootS ( string_from g_api_root )
+            : ?String rp ( nl_resolve rootS ( string_data model ) )
+            ( string_free rootS )
+            ?? rp {
+                F → {
+                    ( string_free model )
+                    ^ ( response_text 404 `{"error":"model not found"}\n` )
+                }
+                T path → {
+                    : Json o ( json_obj_new )
+                    : b _1 ( json_obj_set o `model` ( json_str_lit ( string_data model ) ) )
+                    ?? ( gguf_open ( string_data path ) ) {
+                        T gg → {
+                            : Json d ( json_obj_new )
+                            : b _2 ( json_obj_set d `general.architecture` ( json_str_lit ( gguf_kv_str_or gg `general.architecture` `?` ) ) )
+                            : b _3 ( json_obj_set d `llama.block_count` ( json_int ( gguf_kv_int_or gg `llama.block_count` 0 ) ) )
+                            : b _4 ( json_obj_set d `llama.embedding_length` ( json_int ( gguf_kv_int_or gg `llama.embedding_length` 0 ) ) )
+                            : b _5 ( json_obj_set d `llama.context_length` ( json_int ( gguf_kv_int_or gg `llama.context_length` 0 ) ) )
+                            : b _6 ( json_obj_set d `tensors` ( json_int ( gguf_n_tensors gg ) ) )
+                            : b _7 ( json_obj_set o `model_info` d )
+                            ( gguf_close gg )
+                        }
+                        F e → { ( string_free e ) }
+                    }
+                    ( string_free path )
+                    ( string_free model )
+                    : String txt ( json_stringify o )
+                    ( json_free o )
+                    : HttpResponse resp ( response_new 200 )
+                    ( response_set_header resp `Content-Type` `application/json` )
+                    ( response_set_body_str resp ( string_data txt ) )
+                    ( string_free txt )
+                    ^ resp
+                }
+            }
+        }
+    }
+}
+
+@ __api_root HttpRequest req Params ps → HttpResponse {
+    ^ ( response_text 200 `nurllama is running\n` )
+}
+
+// Serve on `host:port`. Single worker: the decode loop owns the device,
+// so serialisation is structural rather than a lock.
+@ api_serve String root s host i port → i {
+    ( api_set_root root )
+    : *HttpApp a ( http_app_new )
+    ( http_app_workers a 1 )
+    ( http_app_body_max a 4194304 )
+    ( http_app_get a `/` \ HttpRequest rq Params ps → HttpResponse { ^ ( __api_root rq ps ) } )
+    ( http_app_get a `/api/tags` \ HttpRequest rq Params ps → HttpResponse { ^ ( __api_tags rq ps ) } )
+    ( http_app_post a `/api/show` \ HttpRequest rq Params ps → HttpResponse { ^ ( __api_show rq ps ) } )
+    ( http_app_stream a \ TcpConn c HttpRequest rq → b { ^ ( __api_stream_hook c rq ) } )
+    : String msg ( string_from `nurllama serving on http://` )
+    ( string_push_str msg host )
+    ( string_push_char msg 58 )
+    ( string_push_int msg port )
+    ( nurl_print ( string_data msg ) )
+    ( nurl_print `\n` )
+    ( string_free msg )
+    : i rc ( http_app_listen a host port )
+    ( __api_unload )
+    ^ rc
+}

--- a/packages/nurllama/src/chat.nu
+++ b/packages/nurllama/src/chat.nu
@@ -1,0 +1,191 @@
+// packages/nurllama/src/chat.nu — chat templates.
+//
+// Turns a message list into the exact prompt string a chat-tuned model
+// was trained on. The template is chosen from the model's own GGUF
+// metadata: `tokenizer.chat_template` is matched against the shapes we
+// know, and the architecture/BOS conventions fill the rest — so a model
+// carries its own dialect and the caller never guesses.
+//
+//   ( chat_style_of g )              → i           CHAT_* below
+//   ( chat_render style msgs )       → String      prompt for generation
+//   ( chat_stop_matches style piece ) → b          stop-token text guard
+//
+// Styles:
+//   CHAT_LLAMA2   [INST] <<SYS>>…<</SYS>> user [/INST] assistant </s>
+//   CHAT_LLAMA3   <|start_header_id|>role<|end_header_id|>…<|eot_id|>
+//   CHAT_CHATML   <|im_start|>role\n…<|im_end|>   (qwen, many finetunes)
+//   CHAT_PLAIN    no template — the messages are concatenated; a base
+//                 (non-chat) model gets its raw prompt, which is the
+//                 honest thing to do rather than inventing turns.
+//
+// A ChatMsg's role is one of `system` / `user` / `assistant`.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `deps/gguf/src/gguf.nu`
+
+: i CHAT_PLAIN 0
+: i CHAT_LLAMA2 1
+: i CHAT_LLAMA3 2
+: i CHAT_CHATML 3
+
+: ChatMsg {
+    String role
+    String content
+}
+
+@ chat_msg s role s content → ChatMsg {
+    ^ @ ChatMsg { ( string_from role ) ( string_from content ) }
+}
+
+@ chat_msg_free ChatMsg m → v {
+    ( string_free . m role )
+    ( string_free . m content )
+}
+
+@ chat_msgs_free ( Vec ChatMsg ) v → v {
+    ( vec_free_with [ChatMsg] v \ ChatMsg m → v { ( chat_msg_free m ) } )
+}
+
+// Pick the style from the model's own chat template (substring match on
+// the marker tokens each dialect must contain), falling back to PLAIN
+// when the model ships no template — a base model, honestly served.
+@ chat_style_of * Gguf g → i {
+    : s tpl ( gguf_kv_str_or g `tokenizer.chat_template` `` )
+    ? > ( nurl_str_len tpl ) 0 {
+        ? >= ( nurl_str_find tpl `<|im_start|>` ) 0 { ^ CHAT_CHATML } {}
+        ? >= ( nurl_str_find tpl `<|start_header_id|>` ) 0 { ^ CHAT_LLAMA3 } {}
+        ? >= ( nurl_str_find tpl `[INST]` ) 0 { ^ CHAT_LLAMA2 } {}
+    } {}
+    ^ CHAT_PLAIN
+}
+
+@ __chat_role ChatMsg m → s { ^ ( string_data . m role ) }
+
+@ __chat_text ChatMsg m → s { ^ ( string_data . m content ) }
+
+@ __chat_is ChatMsg m s want → b { ^ ? ( nurl_str_eq ( __chat_role m ) want ) T F }
+
+// llama-2: one [INST] block per user turn, the system prompt folded
+// into the FIRST block, assistant replies closed with </s>.
+@ __chat_llama2 ( Vec ChatMsg ) msgs → String {
+    : String out ( string_new )
+    : ~ String sys ( string_new )
+    : ~ i k 0
+    ~ < k ( vec_len [ChatMsg] msgs ) {
+        ?? ( vec_get [ChatMsg] msgs k ) {
+            T m → {
+                ? ( __chat_is m `system` ) {
+                    ( string_free sys )
+                    = sys ( string_from ( __chat_text m ) )
+                } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    : ~ b first T
+    = k 0
+    ~ < k ( vec_len [ChatMsg] msgs ) {
+        ?? ( vec_get [ChatMsg] msgs k ) {
+            T m → {
+                ? ( __chat_is m `user` ) {
+                    ( string_push_str out `[INST] ` )
+                    ? & first > ( string_len sys ) 0 {
+                        ( string_push_str out `<<SYS>>\n` )
+                        ( string_push_str out ( string_data sys ) )
+                        ( string_push_str out `\n<</SYS>>\n\n` )
+                    } {}
+                    ( string_push_str out ( __chat_text m ) )
+                    ( string_push_str out ` [/INST] ` )
+                    = first F
+                } {}
+                ? ( __chat_is m `assistant` ) {
+                    ( string_push_str out ( __chat_text m ) )
+                    ( string_push_str out ` </s>` )
+                } {}
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( string_free sys )
+    ^ out
+}
+
+@ __chat_llama3 ( Vec ChatMsg ) msgs → String {
+    : String out ( string_new )
+    : ~ i k 0
+    ~ < k ( vec_len [ChatMsg] msgs ) {
+        ?? ( vec_get [ChatMsg] msgs k ) {
+            T m → {
+                ( string_push_str out `<|start_header_id|>` )
+                ( string_push_str out ( __chat_role m ) )
+                ( string_push_str out `<|end_header_id|>\n\n` )
+                ( string_push_str out ( __chat_text m ) )
+                ( string_push_str out `<|eot_id|>` )
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( string_push_str out `<|start_header_id|>assistant<|end_header_id|>\n\n` )
+    ^ out
+}
+
+@ __chat_chatml ( Vec ChatMsg ) msgs → String {
+    : String out ( string_new )
+    : ~ i k 0
+    ~ < k ( vec_len [ChatMsg] msgs ) {
+        ?? ( vec_get [ChatMsg] msgs k ) {
+            T m → {
+                ( string_push_str out `<|im_start|>` )
+                ( string_push_str out ( __chat_role m ) )
+                ( string_push_char out 10 )
+                ( string_push_str out ( __chat_text m ) )
+                ( string_push_str out `<|im_end|>\n` )
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( string_push_str out `<|im_start|>assistant\n` )
+    ^ out
+}
+
+// Base model: no invented turns — system + user text, blank-line
+// separated, which is what a completion model actually expects.
+@ __chat_plain ( Vec ChatMsg ) msgs → String {
+    : String out ( string_new )
+    : ~ i k 0
+    ~ < k ( vec_len [ChatMsg] msgs ) {
+        ?? ( vec_get [ChatMsg] msgs k ) {
+            T m → {
+                ? ( __chat_is m `assistant` ) {} {
+                    ? > ( string_len out ) 0 { ( string_push_str out `\n\n` ) } {}
+                    ( string_push_str out ( __chat_text m ) )
+                }
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ out
+}
+
+@ chat_render i style ( Vec ChatMsg ) msgs → String {
+    ? == style CHAT_LLAMA3 { ^ ( __chat_llama3 msgs ) } {}
+    ? == style CHAT_CHATML { ^ ( __chat_chatml msgs ) } {}
+    ? == style CHAT_LLAMA2 { ^ ( __chat_llama2 msgs ) } {}
+    ^ ( __chat_plain msgs )
+}
+
+// Some chat models emit their turn terminator as ordinary text rather
+// than the EOS id (a finetune whose eos_token_id was left at the base
+// value). Treat the dialect's terminator as a stop sequence too.
+@ chat_stop_matches i style s piece → b {
+    ? == style CHAT_CHATML { ^ ? >= ( nurl_str_find piece `<|im_end|>` ) 0 T F } {}
+    ? == style CHAT_LLAMA3 { ^ ? >= ( nurl_str_find piece `<|eot_id|>` ) 0 T F } {}
+    ? == style CHAT_LLAMA2 { ^ ? >= ( nurl_str_find piece `</s>` ) 0 T F } {}
+    ^ F
+}

--- a/packages/nurllama/src/main.nu
+++ b/packages/nurllama/src/main.nu
@@ -4,6 +4,9 @@
 //                                             (hf.co/ORG/REPO/FILE.gguf or a
 //                                             URL; resumes a broken pull)
 //   nurllama list · rm <name> · verify <name> the local model store
+//   nurllama serve [--host H] [--port N]      ollama-compatible HTTP API
+//   nurllama chat <model|name>                interactive chat (model's
+//                                             own template from GGUF)
 //   nurllama run <model|name> <prompt>        generate (stream to stdout)
 //     -n N (default 64) · --temp F (0 = greedy, default 0.8)
 //     --topk N · --topp F · --seed N · --ctx N
@@ -39,6 +42,9 @@ $ `src/model.nu`
 $ `src/sample.nu`
 $ `src/store.nu`
 $ `src/pull.nu`
+$ `src/chat.nu`
+$ `src/api.nu`
+$ `stdlib/std/term.nu`
 
 @ __nl_err String e → i {
     ( nurl_eprintln ( string_data e ) )
@@ -358,6 +364,48 @@ $ `src/pull.nu`
         }
     }
 
+    // ── chat-template style detection from real GGUF metadata ──
+    // Writes a model file carrying tokenizer.chat_template and reads the
+    // style back through the same path a downloaded model takes.
+    : ~ i si 0
+    ~ < si 4 {
+        : ~ s tpl ``
+        : ~ i want CHAT_PLAIN
+        ? == si 0 {
+            = tpl `{% for m in messages %}<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>{% endfor %}`
+            = want CHAT_CHATML
+        } {}
+        ? == si 1 {
+            = tpl `{% for m in messages %}<|start_header_id|>{{ m.role }}<|end_header_id|>{{ m.content }}<|eot_id|>{% endfor %}`
+            = want CHAT_LLAMA3
+        } {}
+        ? == si 2 {
+            = tpl `{% for m in messages %}[INST] {{ m.content }} [/INST]{% endfor %}`
+            = want CHAT_LLAMA2
+        } {}
+        // si == 3: no template at all → PLAIN
+        ?? ( gw_new 32 ) {
+            T w → {
+                ( gw_kv_str w `general.architecture` `llama` )
+                ? > ( nurl_str_len tpl ) 0 { ( gw_kv_str w `tokenizer.chat_template` tpl ) } {}
+                : !v String wr ( gw_write w ( string_data path ) )
+                ( gw_free w )
+                ?? wr { T _ → {} F e → { ( string_free e ) } }
+            }
+            F e → { ( string_free e ) }
+        }
+        : ~ i got -1
+        ?? ( gguf_open ( string_data path ) ) {
+            T gg → {
+                = got ( chat_style_of gg )
+                ( gguf_close gg )
+            }
+            F e → { ( string_free e ) }
+        }
+        ( __nl_ck cn == got want `chat style detected from the model's own metadata` )
+        = si + si 1
+    }
+
     ( file_delete ( string_data path ) )
     ( string_free path )
     : String m ( string_from `selftest: ` )
@@ -373,6 +421,117 @@ $ `src/pull.nu`
 
 // ── CLI ─────────────────────────────────────────────────────────────
 
+// Interactive chat: the model's own template (from its GGUF metadata)
+// renders the running message list each turn; generated pieces stream
+// to stdout as they decode. Ctrl-C / Ctrl-D (or /exit) ends it.
+@ __nl_chat s path ArgParser p → i {
+    : ~ i style CHAT_PLAIN
+    ?? ( gguf_open path ) {
+        T gg → {
+            = style ( chat_style_of gg )
+            ( gguf_close gg )
+        }
+        F e → { ( string_free e ) }
+    }
+    ?? ( llm_open path 0 ) {
+        F e → { ^ ( __nl_err e ) }
+        T m → {
+            : *Tok t ( llm_tok m )
+            : String stmp ( args_value_or p `temp` `0.8` )
+            : ~ f temp 0.8
+            ?? ( string_to_float stmp ) { T v2 → { = temp v2 } F → {} }
+            ( string_free stmp )
+            : String snp ( args_value_or p `n-predict` `256` )
+            : ~ i npredict 256
+            ?? ( string_to_int snp ) { T v2 → { = npredict v2 } F _ → {} }
+            ( string_free snp )
+            : String stk ( args_value_or p `topk` `40` )
+            : ~ i topk 40
+            ?? ( string_to_int stk ) { T v2 → { = topk v2 } F _ → {} }
+            ( string_free stk )
+            : String stp ( args_value_or p `topp` `0.95` )
+            : ~ f topp 0.95
+            ?? ( string_to_float stp ) { T v2 → { = topp v2 } F → {} }
+            ( string_free stp )
+            : String ssd ( args_value_or p `seed` `42` )
+            : ~ i seed 42
+            ?? ( string_to_int ssd ) { T v2 → { = seed v2 } F _ → {} }
+            ( string_free ssd )
+            : Rng rng ( rng_seed seed )
+
+            ? == style CHAT_PLAIN {
+                ( nurl_eprintln `note: this model ships no chat template — completing text, not chatting` )
+            } {}
+            ( nurl_print `chat ready — /exit to quit\n` )
+            : ( Vec ChatMsg ) msgs ( vec_new [ChatMsg] )
+            : ( Vec String ) hist ( vec_new [String] )
+            : ~ b running T
+            ~ running {
+                ?? ( term_read_line `> ` hist ) {
+                    F → { = running F }
+                    T line → {
+                        : s lraw ( string_data line )
+                        ? | ( nurl_str_eq lraw `/exit` ) ( nurl_str_eq lraw `/quit` ) {
+                            = running F
+                            ( string_free line )
+                        } {
+                            ? == 0 ( nurl_str_len lraw ) { ( string_free line ) } {
+                                ( vec_push [ChatMsg] msgs ( chat_msg `user` lraw ) )
+                                ( vec_push [String] hist ( string_from lraw ) )
+                                ( string_free line )
+                                : String prompt ( chat_render style msgs )
+                                : ( Vec i ) ids ( tok_encode t ( string_data prompt ) T )
+                                ( string_free prompt )
+                                : i nprompt ( vec_len [i] ids )
+                                ? > nprompt ( llm_n_ctx m ) {
+                                    ( nurl_eprintln `nurllama: conversation is longer than the context — /exit and restart` )
+                                    ( vec_free [i] ids )
+                                    = running F
+                                } {
+                                    : ~ i k 0
+                                    ~ < k nprompt {
+                                        ( llm_eval m ( __tk_geti ids k 0 ) k )
+                                        = k + k 1
+                                    }
+                                    ( vec_free [i] ids )
+                                    : String reply ( string_new )
+                                    : ~ i posn nprompt
+                                    : ~ i produced 0
+                                    : ~ b stop F
+                                    ~ & & < produced npredict < posn ( llm_n_ctx m ) ! stop {
+                                        : i nt ( sample_next m rng temp topk topp )
+                                        ? == nt ( tok_eos t ) { = stop T } {
+                                            : ( Vec u ) pb ( tok_piece t nt )
+                                            : String piece ( bytes_to_str pb )
+                                            ( vec_free [u] pb )
+                                            ? ( chat_stop_matches style ( string_data piece ) ) { = stop T } {
+                                                ( nurl_print ( string_data piece ) )
+                                                ( flush )
+                                                ( string_push_str reply ( string_data piece ) )
+                                                ( llm_eval m nt posn )
+                                                = posn + posn 1
+                                                = produced + produced 1
+                                            }
+                                            ( string_free piece )
+                                        }
+                                    }
+                                    ( nurl_print `\n` )
+                                    ( vec_push [ChatMsg] msgs ( chat_msg `assistant` ( string_data reply ) ) )
+                                    ( string_free reply )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            ( chat_msgs_free msgs )
+            ( vec_free_with [String] hist \ String s → v { ( string_free s ) } )
+            ( llm_close m )
+            ^ 0
+        }
+    }
+}
+
 @ main → i {
     : ArgParser p ( args_new `nurllama` `Run language models locally — phase 2: the GGUF-vocabulary tokenizer.` )
     ( args_flag p `help` 104 `show this help` )
@@ -385,6 +544,8 @@ $ `src/pull.nu`
     ( args_opt p `seed` 0 `N` `run: RNG seed (default 42)` )
     ( args_opt p `ctx` 0 `N` `run: context length cap (default: model's)` )
     ( args_opt p `name` 0 `NAME` `pull: store under this name` )
+    ( args_opt p `host` 0 `ADDR` `serve: bind address (default 127.0.0.1)` )
+    ( args_opt p `port` 0 `N` `serve: port (default 11434, ollama's)` )
     ? ( args_parse_argv p ) {} {
         ( nurl_eprintln ( args_error p ) )
         ( args_free p )
@@ -393,7 +554,7 @@ $ `src/pull.nu`
     ? ( args_present p `help` ) {
         : String u ( args_usage p )
         ( nurl_print ( string_data u ) )
-        ( nurl_print `\ncommands:\n  pull <hf.co/ORG/REPO/FILE.gguf | url> [--name N] · list · rm <name> · verify <name>\n  run <model|name> <prompt> [-n N] [--temp F] [--topk N] [--topp F] [--seed N]\n  logits <model> <prompt> · tokenize <model> <text>\n  detok <model> <id> [id …] · vocab <model> [n] · selftest\n` )
+        ( nurl_print `\ncommands:\n  pull <hf.co/ORG/REPO/FILE.gguf | url> [--name N] · list · rm <name> · verify <name>\n  serve [--host H] [--port N] · chat <model|name>\n  run <model|name> <prompt> [-n N] [--temp F] [--topk N] [--topp F] [--seed N]\n  logits <model> <prompt> · tokenize <model> <text>\n  detok <model> <id> [id …] · vocab <model> [n] · selftest\n` )
         ( string_free u )
         ( args_free p )
         ^ 0
@@ -427,6 +588,44 @@ $ `src/pull.nu`
         ( string_free root )
         ( args_free p )
         ^ 0
+    } {}
+
+    // Debug tap: render the three-message fixture through one dialect —
+    // gives the template renderers a unit test with no model needed.
+    ? ( nurl_str_eq cmd `chat-template` ) {
+        : ~ s which `plain`
+        ?? ( vec_get [String] pos 1 ) {
+            T c → { = which ( string_data c ) }
+            F → {}
+        }
+        : ~ i style CHAT_PLAIN
+        ? ( nurl_str_eq which `chatml` ) { = style CHAT_CHATML } {}
+        ? ( nurl_str_eq which `llama3` ) { = style CHAT_LLAMA3 } {}
+        ? ( nurl_str_eq which `llama2` ) { = style CHAT_LLAMA2 } {}
+        : ( Vec ChatMsg ) msgs ( vec_new [ChatMsg] )
+        ( vec_push [ChatMsg] msgs ( chat_msg `system` `be brief` ) )
+        ( vec_push [ChatMsg] msgs ( chat_msg `user` `hi` ) )
+        : String out ( chat_render style msgs )
+        ( chat_msgs_free msgs )
+        ( nurl_print ( string_data out ) )
+        ( nurl_print `\n` )
+        ( string_free out )
+        ( args_free p )
+        ^ 0
+    } {}
+
+    ? ( nurl_str_eq cmd `serve` ) {
+        : String root ( nl_store_root )
+        : String host ( args_value_or p `host` `127.0.0.1` )
+        : String sport ( args_value_or p `port` `11434` )
+        : ~ i port 11434
+        ?? ( string_to_int sport ) { T v2 → { = port v2 } F _ → {} }
+        ( string_free sport )
+        : i rc ( api_serve root ( string_data host ) port )
+        ( string_free host )
+        ( string_free root )
+        ( args_free p )
+        ^ rc
     } {}
 
     ? | | ( nurl_str_eq cmd `pull` ) ( nurl_str_eq cmd `rm` ) ( nurl_str_eq cmd `verify` ) {
@@ -472,6 +671,37 @@ $ `src/pull.nu`
     ? < ( args_positional_count p ) 2 {
         ( args_free p )
         ^ ( __nl_err ( string_from `nurllama: this command needs a model file (nurllama --help)` ) )
+    } {}
+
+    ? ( nurl_str_eq cmd `chat` ) {
+        ? < ( args_positional_count p ) 2 {
+            ( args_free p )
+            ^ ( __nl_err ( string_from `nurllama: chat needs a model (nurllama --help)` ) )
+        } {}
+        : ~ s carg ``
+        ?? ( vec_get [String] pos 1 ) {
+            T c → { = carg ( string_data c ) }
+            F → {}
+        }
+        : String croot ( nl_store_root )
+        : ~ String cres ( string_new )
+        ?? ( nl_resolve croot carg ) {
+            T pth → {
+                ( string_free cres )
+                = cres pth
+            }
+            F → {}
+        }
+        ( string_free croot )
+        ? > ( string_len cres ) 0 {} {
+            ( string_free cres )
+            ( args_free p )
+            ^ ( __nl_err ( string_from `nurllama: not a file and not a stored model name (nurllama list)` ) )
+        }
+        : i rc ( __nl_chat ( string_data cres ) p )
+        ( string_free cres )
+        ( args_free p )
+        ^ rc
     } {}
 
     ? | ( nurl_str_eq cmd `run` ) ( nurl_str_eq cmd `logits` ) {

--- a/packages/nurllama/tests/api_test.sh
+++ b/packages/nurllama/tests/api_test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tests/api_test.sh — the ollama-compatible HTTP API + chat templates.
+#
+#    1. GET  /            → "nurllama is running"
+#    2. GET  /api/tags    → the local store as ollama's model list
+#    3. POST /api/show    → the model's metadata
+#    4. POST /api/generate, stream=true  → NDJSON, ONE OBJECT PER TOKEN,
+#       arriving as they decode, terminated by done:true with counts
+#    5. POST /api/generate, stream=false → one aggregated object whose
+#       text EQUALS the concatenation of the streamed pieces (the two
+#       paths cannot drift)
+#    6. POST /api/chat    → assistant message shape
+#    7. errors: unknown model → 404-shaped JSON error; bad JSON → error
+#    8. chat templates: each dialect renders exactly (unit-checked via
+#       `nurllama chat-template`, a hidden debug command)
+#
+#  Run from the package dir:  ./tests/api_test.sh
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+command -v curl >/dev/null 2>&1 || { echo "SKIP: curl required"; exit 0; }
+
+WORK="$(mktemp -d -t nurllama-api.XXXXXX)"
+SRV_PID=""
+trap '[ -n "$SRV_PID" ] && kill $SRV_PID 2>/dev/null; rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+
+[ -e deps/gguf ] || { mkdir -p deps && ln -s ../../gguf deps/gguf; }
+[ -e deps/gpu ]  || { mkdir -p deps && ln -s ../../gpu deps/gpu; }
+[ -e deps/http ] || { mkdir -p deps && ln -s ../../http deps/http; }
+
+echo "[1/3] build nurllama"
+if ! $NURL src/main.nu "$WORK/nurllama" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build nurllama:"; tail -5 "$WORK/build.err"; exit 1
+fi
+NL="$WORK/nurllama"
+export NURLLAMA_HOME="$WORK/store"
+
+echo "[2/3] chat templates + style detection (offline)"
+"$NL" selftest | grep -q " 0 failed" && ok "selftest (21 checks, incl. style detection from GGUF metadata)" || bad "selftest"
+T1=$("$NL" chat-template chatml)
+[ "$T1" = '<|im_start|>system
+be brief<|im_end|>
+<|im_start|>user
+hi<|im_end|>
+<|im_start|>assistant' ] && ok "ChatML renders exactly" || { bad "ChatML"; printf '%s\n' "$T1"; }
+T2=$("$NL" chat-template llama3)
+[ "$T2" = '<|start_header_id|>system<|end_header_id|>
+
+be brief<|eot_id|><|start_header_id|>user<|end_header_id|>
+
+hi<|eot_id|><|start_header_id|>assistant<|end_header_id|>' ] && ok "llama3 renders exactly" || { bad "llama3"; printf '%s\n' "$T2"; }
+T3=$("$NL" chat-template llama2)
+[ "$T3" = '[INST] <<SYS>>
+be brief
+<</SYS>>
+
+hi [/INST] ' ] && ok "llama2 renders exactly" || { bad "llama2"; printf '%s\n' "$T3"; }
+T4=$("$NL" chat-template plain)
+[ "$T4" = 'be brief
+
+hi' ] && ok "base model: no invented turns" || { bad "plain"; printf '%s\n' "$T4"; }
+
+echo "[3/3] HTTP API (net-gated: needs a real model)"
+if [ "${NURL_NET_TESTS:-0}" != 1 ]; then
+    echo "  SKIP (set NURL_NET_TESTS=1 to pull a model and exercise the API)"
+    echo "== nurllama api tests: PASS=$PASS FAIL=$FAIL"
+    [ "$FAIL" = 0 ]; exit $?
+fi
+
+"$NL" pull hf.co/ggml-org/models/tinyllamas/stories260K.gguf >/dev/null || { echo "  SKIP pull failed"; exit 0; }
+
+PORT=$(( (RANDOM % 20000) + 25000 ))
+"$NL" serve --port "$PORT" > "$WORK/serve.log" 2>&1 &
+SRV_PID=$!
+for _ in $(seq 40); do curl -sf "http://127.0.0.1:$PORT/" >/dev/null 2>&1 && break; sleep 0.25; done
+
+curl -s "http://127.0.0.1:$PORT/" | grep -q "nurllama is running" && ok "GET /" || bad "GET /"
+curl -s "http://127.0.0.1:$PORT/api/tags" | grep -q '"name":"stories260K"' && ok "GET /api/tags lists the store" || bad "GET /api/tags"
+curl -s -X POST "http://127.0.0.1:$PORT/api/show" -d '{"model":"stories260K"}' \
+    | grep -q '"general.architecture":"llama"' && ok "POST /api/show returns metadata" || bad "POST /api/show"
+
+GEN='{"model":"stories260K","prompt":"Once upon a time","options":{"num_predict":12,"temperature":0}}'
+curl -s -X POST "http://127.0.0.1:$PORT/api/generate" -d "$GEN" > "$WORK/stream.ndjson"
+LINES=$(wc -l < "$WORK/stream.ndjson")
+[ "$LINES" = 13 ] && ok "stream: 12 token frames + 1 done frame" || bad "stream frame count ($LINES)"
+head -1 "$WORK/stream.ndjson" | grep -q '"done":false' && ok "stream: token frames carry done:false" || bad "token frame shape"
+tail -1 "$WORK/stream.ndjson" | grep -q '"done":true' && ok "stream: final frame carries done:true" || bad "done frame"
+tail -1 "$WORK/stream.ndjson" | grep -q '"eval_count":12' && ok "stream: token counts reported" || bad "counts"
+
+# non-stream text must equal the concatenation of the streamed pieces
+STREAM_TEXT=$(python3 - "$WORK/stream.ndjson" <<'PYEOF'
+import json, sys
+out = []
+for line in open(sys.argv[1]):
+    o = json.loads(line)
+    if not o.get('done'): out.append(o['response'])
+print(''.join(out))
+PYEOF
+)
+ONESHOT=$(curl -s -X POST "http://127.0.0.1:$PORT/api/generate" \
+    -d '{"model":"stories260K","prompt":"Once upon a time","stream":false,"options":{"num_predict":12,"temperature":0}}' \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["response"])')
+[ "$STREAM_TEXT" = "$ONESHOT" ] && ok "stream text == non-stream text (paths cannot drift)" || {
+    bad "stream/non-stream drift"; echo "    stream : $STREAM_TEXT"; echo "    oneshot: $ONESHOT"; }
+
+curl -s -X POST "http://127.0.0.1:$PORT/api/chat" \
+    -d '{"model":"stories260K","messages":[{"role":"user","content":"Once upon a time"}],"stream":false,"options":{"num_predict":8,"temperature":0}}' \
+    | grep -q '"message":{"role":"assistant"' && ok "POST /api/chat returns an assistant message" || bad "POST /api/chat"
+
+curl -s -X POST "http://127.0.0.1:$PORT/api/generate" -d '{"model":"nope","prompt":"x"}' \
+    | grep -q '"error"' && ok "unknown model → JSON error" || bad "unknown-model error"
+curl -s -X POST "http://127.0.0.1:$PORT/api/generate" -d 'not json' \
+    | grep -q '"error"' && ok "malformed body → JSON error" || bad "bad-JSON error"
+
+echo "== nurllama api tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" = 0 ]

--- a/stdlib/ext/http_server.nu
+++ b/stdlib/ext/http_server.nu
@@ -157,6 +157,25 @@ $ `stdlib/ext/http_response.nu`
     = g_ws_upgrade # i u
 }
 
+// ── Streaming-response hook (SSE / NDJSON / chunked bodies) ──────
+// The write-side sibling of the upgrade hook: it runs on every fully
+// parsed request (body included) AFTER the WebSocket hook and BEFORE
+// the normal HttpResponse handler. Return T after writing the whole
+// response yourself — response_begin_chunked / response_write_chunk /
+// response_end_chunked on the TcpConn — and the loop ends so the
+// server closes the finished connection (a streamed response is the
+// connection's last; do NOT close the conn in the hook). Return F for
+// "not mine" and the request falls through to the router untouched.
+// Process-global like the upgrade hook; default unset = neutral.
+: __StreamHook { ( @ b TcpConn HttpRequest ) fn }
+: ~ i g_stream_hook 0
+
+@ server_set_stream ( @ b TcpConn HttpRequest ) f → v {
+    : *__StreamHook u # *__StreamHook ( nurl_alloc Z __StreamHook )
+    = . u fn f
+    = g_stream_hook # i u
+}
+
 // DoS connection caps (server-wide + per-source-IP). All caps are
 // "soft" — a request that exceeds them is rejected with an immediate
 // close (no canned 503), which is the cheapest possible response and
@@ -763,6 +782,13 @@ $ `stdlib/ext/http_response.nu`
                         : *__WsUpgrade __wu # *__WsUpgrade g_ws_upgrade
                         : ( @ b TcpConn HttpRequest ) __upf . __wu fn
                         ? ( __upf conn req ) { = __ws_handled T } {}
+                    } {}
+                    // Streaming hook: same takeover contract as the
+                    // upgrade hook, for chunked/SSE/NDJSON responses.
+                    ? & ! __ws_handled != g_stream_hook 0 {
+                        : *__StreamHook __sh # *__StreamHook g_stream_hook
+                        : ( @ b TcpConn HttpRequest ) __shf . __sh fn
+                        ? ( __shf conn req ) { = __ws_handled T } {}
                     } {}
                     ? __ws_handled { ( request_free req ) = done T } {
                         : b req_close ( __request_says_close req )


### PR DESCRIPTION
Phase 5 of the local-LLM engine. Two commits — the stdlib/package seam first, then its consumer.

## 1. `http`: a streaming-response hook

The write-side sibling of the WebSocket upgrade hook. The keep-alive loop offers each fully-parsed request to the hook (after the upgrade hook, before the router): return **T** after writing the whole response yourself (`response_begin_chunked` / `_write_chunk` / `_end_chunked` on the TcpConn), or **F** for "not mine" and the request falls through untouched. Facade: `http_app_stream`.

The chunked writers have existed at the low level since the MCP transport, but `HttpApp`'s handler type is request→`HttpResponse` — a token-by-token body had no seam. This is the root-cause fix rather than a nurllama-local workaround.

## 2. `nurllama`: chat + the API

- **Chat templates from the model's own GGUF metadata** (`tokenizer.chat_template` → ChatML / llama3 / llama2). A model with **no** template is a *base* model, and nurllama refuses to invent turns for it — it completes text, which is what that model was trained to do. The dialect's terminator also acts as a stop sequence when a finetune emits it as text instead of the EOS id.
- **`serve`**: `POST /api/generate` + `POST /api/chat` emit **NDJSON — one object per token, the moment it decodes**; `stream:false` returns one aggregated object from the same loop. Plus `GET /api/tags`, `POST /api/show`, health root. One model resident at a time; single-worker, so decode serialisation is structural rather than a lock.
- **`chat`**: interactive REPL — line editor, streaming output, running message list rendered through the model's own template each turn.

## Proof

- `tests/api_test.sh`, **16 checks**: every endpoint; NDJSON frame shapes and token counts; **the streamed text equals the non-streamed text** (the two paths cannot drift); error paths; each dialect renders byte-exactly.
- `selftest`, **21 checks**: now writes GGUFs carrying a `tokenizer.chat_template` and proves the style is detected from the model's own metadata — the same path a downloaded model takes.
- Server ASan/LSan-clean under request load; compiler suite green (stdlib touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH