### PR TITLE
gpu 0.5.1: publish the kernel-cache leak fix (nurllama 0.2.0 needs it)

### DIFF
--- a/packages/gpu/nurl.toml
+++ b/packages/gpu/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpu"
-version = "0.5.0"
+version = "0.5.1"
 description = "GPU compute for NURL — compiled kernels are cached on disk (keyed by source hash), so a process start costs a file read instead of an NVRTC/C++ compile: a dozen-kernel package starts ~3x faster, and NURL_GPU_CACHE=off disables it. A backend-neutral interface (Gpu / GpuKernel / GpuBuffer: open, compile, alloc, upload/download, launch, sync) with two backends: CUDA and CPU. The CUDA backend writes kernels in CUDA-C, compiles them to PTX at runtime via NVRTC, and runs them through the CUDA Driver API — bound directly from pure NURL with no runtime.c bridge. The CPU backend (v0.2.0) runs the very same CUDA-C kernels on the host: each is wrapped in a small CUDA-compatibility shim (blockIdx/threadIdx as thread-locals, __global__ etc. as no-op macros) plus a generated grid-loop, compiled by the system C++ compiler, dlopen'd, and run with OpenMP parallelising the grid across cores — so an onnx/YOLOE model runs with no GPU at all. gpu_open selects CUDA when a device is available, else falls back to CPU; NURL_GPU=cpu forces it. The neutral surface is unchanged, so callers (packages/onnx, objdet, yoloe) get CPU fallback for free. The toolchain auto-links -lcuda / -lnvrtc only when a program references those symbols; the CPU backend needs only a C++ compiler on PATH (the analogue of NVRTC). Verified: the tiny MLP and the full 267-node YOLOE-seg forward produce identical results on CPU and GPU."
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Version bump only — the code shipped with #463.

`cpu_compile` leaked the generated CUDA-C source on an on-disk cache **hit** (86 KB per run with a dozen kernels). The fix went in with the qwen2 work but the version was not bumped, so the registry still served the leaking 0.5.0 — and `nurllama` 0.2.0, which resolves `gpu ^0.5`, would have picked it up.

**Registry:** `gpu` 0.5.1 and `nurllama` 0.2.0 (qwen2 support) are published. A clean install with the released v0.13.0 toolchain runs Qwen2.5 end to end:

```
$ nurlpkg install nurllama
$ nurllama run qwen2.5-0.5b-instruct-q4_k_m "The capital of France is" -n 12
 Paris. It is the largest city in Europe and the third
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH