### PR TITLE
packages/whisper — the encoder (and the first non-causal attention in the ecosystem)

### DIFF
--- a/packages/whisper/nurl.toml
+++ b/packages/whisper/nurl.toml
@@ -1,0 +1,11 @@
+[package]
+name = "whisper"
+version = "0.1.0"
+description = "Speech recognition in pure NURL — whisper, running from the safetensors checkpoint Hugging Face ships, on the GPU or the CPU. Built package by package: packages/audio turns a WAV into the log-mel spectrogram (verified against HF's own WhisperFeatureExtractor), packages/safetensor reads the weights, packages/tokenizer holds the BPE vocabulary, and packages/gpu runs the kernels — the same CUDA-C on the CUDA backend and the CPU/OpenMP one. Whisper is not the llama shape, and every kernel is a place it differs: LayerNorm with a bias rather than RMSNorm, GELU with the error function rather than the tanh approximation, two conv1d layers that turn 3000 spectrogram frames into 1500 encoder positions, and NON-CAUSAL attention — a speech encoder hears the whole 30 seconds at once, where every attention in this ecosystem until now masked the future."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+gpu = { path = "../gpu", version = "^0.6" }
+safetensor = { path = "../safetensor", version = "^0.1" }
+tokenizer = { path = "../tokenizer", version = "^0.1" }
+audio = { path = "../audio", version = "^0.1" }

--- a/packages/whisper/src/kernels.nu
+++ b/packages/whisper/src/kernels.nu
@@ -1,0 +1,362 @@
+// packages/whisper/src/kernels.nu — the encoder/decoder kernels.
+//
+// CUDA-C sources compiled by packages/gpu, which runs the SAME text on the CUDA
+// backend (via NVRTC) and on the CPU/OpenMP backend (via a compat shim). No
+// __shared__, no __syncthreads: whatever runs on the GPU runs identically on the
+// host, and the test suite requires the two to agree.
+//
+// Whisper is not the llama shape, and every kernel here is a place it differs:
+//
+//   * LAYERNORM, not RMSNorm — it subtracts the mean and it has a BIAS.
+//   * GELU with the ERROR FUNCTION, not the tanh approximation. HF's
+//     ACT2FN["gelu"] is the exact one; the tanh form is a different function and
+//     using it would be a quiet, small, everywhere-wrong bias.
+//   * CONV1D: two of them in front of the encoder (stride 1 then stride 2),
+//     which is what turns 3000 spectrogram frames into 1500 encoder positions.
+//   * NON-CAUSAL attention. Everything in this ecosystem so far has masked the
+//     future; the whisper encoder looks at the whole 30 seconds at once, and the
+//     decoder's cross-attention looks at all of it too.
+//
+// Weights are f32 (safetensors), so there is no quantised matvec zoo here — one
+// warp-per-row matvec, coalesced the way nurllama's is.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `deps/gpu/src/gpu.nu`
+
+: WhKernels {
+    GpuKernel matvec  // y = W x (+ bias), one thread per row — portable
+    GpuKernel matvec_w  // the same, one WARP per row (CUDA only)
+    b warp
+    GpuKernel layernorm
+    GpuKernel gelu
+    GpuKernel conv1d
+    GpuKernel attn_sc  // scores = q·k / sqrt(hd), NO causal mask
+    GpuKernel attn_out  // softmax(scores) · v
+    GpuKernel addv
+    GpuKernel addrow
+    GpuKernel scale
+    b ok
+}
+
+// The portable matvec: one thread per output row. `bias` may be 0 — whisper's
+// k_proj has none, alone among its projections.
+@ __wk_matvec → s {
+    ^ `extern "C" __global__ void matvec(
+        const float* __restrict__ W, const float* __restrict__ x,
+        const float* __restrict__ bias, float* __restrict__ y,
+        int rows, int cols, int batch) {
+        int idx = blockIdx.x*blockDim.x + threadIdx.x;
+        if (idx >= rows*batch) return;
+        int b = idx / rows, r = idx % rows;
+        const float* w  = W + (long long)r*cols;
+        const float* xb = x + (long long)b*cols;
+        float acc = 0.f;
+        for (int c = 0; c < cols; ++c) acc += w[c]*xb[c];
+        y[(long long)b*rows + r] = acc + (bias ? bias[r] : 0.f);
+    }`
+}
+
+// One WARP per output row: the 32 lanes stride through the row together, so each
+// warp's loads are one contiguous span, and a shuffle reduction folds the lane
+// partials. __shfl_down_sync exists only on CUDA, so the CPU/OpenMP backend runs
+// the portable kernel above — and the test suite requires the two to agree.
+@ __wk_matvec_w → s {
+    ^ `
+    __device__ static inline float wh_warp_sum(float v) {
+        for (int off = 16; off > 0; off >>= 1) v += __shfl_down_sync(0xffffffffu, v, off);
+        return v;
+    }
+    extern "C" __global__ void matvec_w(
+        const float* __restrict__ W, const float* __restrict__ x,
+        const float* __restrict__ bias, float* __restrict__ y,
+        int rows, int cols, int batch) {
+        int gid  = blockIdx.x*blockDim.x + threadIdx.x;
+        int warp = gid >> 5, lane = gid & 31;
+        if (warp >= rows*batch) return;
+        int b = warp / rows, r = warp % rows;
+        const float* w  = W + (long long)r*cols;
+        const float* xb = x + (long long)b*cols;
+        float acc = 0.f;
+        for (int c = lane; c < cols; c += 32) acc += w[c]*xb[c];
+        acc = wh_warp_sum(acc);
+        if (lane == 0) y[(long long)b*rows + r] = acc + (bias ? bias[r] : 0.f);
+    }`
+}
+
+// LayerNorm: subtract the mean, divide by the standard deviation, scale and
+// SHIFT. RMSNorm does none of the mean and none of the shift, which is why a
+// model trained with one cannot be run with the other.
+@ __wk_layernorm → s {
+    ^ `extern "C" __global__ void layernorm(
+        const float* __restrict__ x, const float* __restrict__ w,
+        const float* __restrict__ b, float* __restrict__ y,
+        int n, float eps, int batch) {
+        int idx = blockIdx.x*blockDim.x + threadIdx.x;
+        if (idx >= n*batch) return;
+        int row = idx / n, i = idx % n;
+        const float* xr = x + (long long)row*n;
+        float mean = 0.f;
+        for (int j = 0; j < n; ++j) mean += xr[j];
+        mean /= (float)n;
+        float var = 0.f;
+        for (int j = 0; j < n; ++j) { float d = xr[j] - mean; var += d*d; }
+        var /= (float)n;
+        float inv = rsqrtf(var + eps);
+        y[(long long)row*n + i] = (xr[i] - mean)*inv*w[i] + b[i];
+    }`
+}
+
+// GELU, exact: 0.5·x·(1 + erf(x/√2)). NOT the tanh approximation — whisper was
+// trained with this one, and the two differ by enough to matter once it has run
+// through 32 encoder layers.
+@ __wk_gelu → s {
+    ^ `extern "C" __global__ void gelu(float* x, int n) {
+        int i = blockIdx.x*blockDim.x + threadIdx.x;
+        if (i < n) {
+            float v = x[i];
+            x[i] = 0.5f*v*(1.f + erff(v*0.70710678118654752440f));
+        }
+    }`
+}
+
+// Conv1d over time, kernel 3, `pad` on both sides, `stride` between outputs.
+// Layout: x is [T_in][C_in] (a spectrogram frame is contiguous), W is
+// [C_out][C_in][3] as safetensors stores it, y is [T_out][C_out].
+@ __wk_conv1d → s {
+    ^ `extern "C" __global__ void conv1d(
+        const float* __restrict__ x, const float* __restrict__ W,
+        const float* __restrict__ bias, float* __restrict__ y,
+        int T_in, int C_in, int C_out, int stride, int pad) {
+        int idx = blockIdx.x*blockDim.x + threadIdx.x;
+        int T_out = (T_in + 2*pad - 3)/stride + 1;
+        if (idx >= T_out*C_out) return;
+        int t = idx / C_out, o = idx % C_out;
+        float acc = bias ? bias[o] : 0.f;
+        for (int k = 0; k < 3; ++k) {
+            int ti = t*stride + k - pad;
+            if (ti < 0 || ti >= T_in) continue;     // zero padding
+            const float* xi = x + (long long)ti*C_in;
+            const float* wi = W + ((long long)o*C_in)*3 + k;
+            for (int c = 0; c < C_in; ++c) acc += xi[c] * wi[(long long)c*3];
+        }
+        y[(long long)t*C_out + o] = acc;
+    }`
+}
+
+// Attention scores, NON-CAUSAL: every query sees every key. `nkey` is the number
+// of keys (the encoder's own length for self-attention, the encoder's length for
+// the decoder's cross-attention, the tokens so far for the decoder's causal
+// self-attention — which passes its own mask through `causal`).
+@ __wk_attn_sc → s {
+    ^ `extern "C" __global__ void attn_sc(
+        const float* __restrict__ q, const float* __restrict__ K,
+        float* __restrict__ scores,
+        int nh, int hd, int nq, int nkey, float qscale, int causal) {
+        int idx = blockIdx.x*blockDim.x + threadIdx.x;
+        if (idx >= nh*nq*nkey) return;
+        int t  = idx % nkey;
+        int qh = idx / nkey;
+        int h  = qh % nh, i = qh / nh;      // head, query position
+        if (causal && t > i) {              // the decoder's self-attention
+            scores[(long long)qh*nkey + t] = -1e30f;
+            return;
+        }
+        const float* qv = q + (long long)i*nh*hd + (long long)h*hd;
+        const float* kv = K + (long long)t*nh*hd + (long long)h*hd;
+        float d = 0.f;
+        for (int j = 0; j < hd; ++j) d += qv[j]*kv[j];
+        scores[(long long)qh*nkey + t] = d * qscale;
+    }`
+}
+
+@ __wk_attn_out → s {
+    ^ `extern "C" __global__ void attn_out(
+        const float* __restrict__ V, const float* __restrict__ scores,
+        float* __restrict__ out, int nh, int hd, int nq, int nkey) {
+        int idx = blockIdx.x*blockDim.x + threadIdx.x;
+        if (idx >= nh*nq*hd) return;
+        int d  = idx % hd;
+        int qh = idx / hd;
+        int h  = qh % nh, i = qh / nh;
+        const float* sc = scores + (long long)qh*nkey;
+        float mx = -1e30f;
+        for (int t = 0; t < nkey; ++t) if (sc[t] > mx) mx = sc[t];
+        float sum = 0.f, acc = 0.f;
+        for (int t = 0; t < nkey; ++t) {
+            float p = expf(sc[t] - mx);
+            sum += p;
+            acc += p * V[(long long)t*nh*hd + (long long)h*hd + d];
+        }
+        out[(long long)i*nh*hd + (long long)h*hd + d] = acc / sum;
+    }`
+}
+
+@ __wk_addv → s {
+    ^ `extern "C" __global__ void addv(float* a, const float* b, int n) {
+        int i = blockIdx.x*blockDim.x + threadIdx.x;
+        if (i < n) a[i] += b[i];
+    }`
+}
+
+// Add a row vector to every row of a batch (a bias, or the positional
+// embedding).
+@ __wk_addrow → s {
+    ^ `extern "C" __global__ void addrow(float* a, const float* v, int n, int batch) {
+        int i = blockIdx.x*blockDim.x + threadIdx.x;
+        if (i < n*batch) a[i] += v[i % n];
+    }`
+}
+
+@ __wk_scale → s {
+    ^ `extern "C" __global__ void scale(float* x, float s, int n) {
+        int i = blockIdx.x*blockDim.x + threadIdx.x;
+        if (i < n) x[i] *= s;
+    }`
+}
+
+@ wk_build Gpu g → WhKernels {
+    : GpuKernel k1 ( gpu_compile g ( __wk_matvec ) `matvec` )
+    : b want_warp == ( gpu_backend ) 0
+    : GpuKernel k1w ? want_warp ( gpu_compile g ( __wk_matvec_w ) `matvec_w` ) @ GpuKernel { 0 0 }
+    : b warp & want_warp ( gpu_kernel_ok k1w )
+    : GpuKernel k2 ( gpu_compile g ( __wk_layernorm ) `layernorm` )
+    : GpuKernel k3 ( gpu_compile g ( __wk_gelu ) `gelu` )
+    : GpuKernel k4 ( gpu_compile g ( __wk_conv1d ) `conv1d` )
+    : GpuKernel k5 ( gpu_compile g ( __wk_attn_sc ) `attn_sc` )
+    : GpuKernel k6 ( gpu_compile g ( __wk_attn_out ) `attn_out` )
+    : GpuKernel k7 ( gpu_compile g ( __wk_addv ) `addv` )
+    : GpuKernel k8 ( gpu_compile g ( __wk_addrow ) `addrow` )
+    : GpuKernel k9 ( gpu_compile g ( __wk_scale ) `scale` )
+    : b ok1 & & ( gpu_kernel_ok k1 ) ( gpu_kernel_ok k2 ) & ( gpu_kernel_ok k3 ) ( gpu_kernel_ok k4 )
+    : b ok2 & & ( gpu_kernel_ok k5 ) ( gpu_kernel_ok k6 ) & ( gpu_kernel_ok k7 ) ( gpu_kernel_ok k8 )
+    : b ok & & ok1 ok2 ( gpu_kernel_ok k9 )
+    ^ @ WhKernels { k1 k1w warp k2 k3 k4 k5 k6 k7 k8 k9 ok }
+}
+
+@ wk_free WhKernels ks → v {
+    ( gpu_kernel_free . ks matvec )
+    ? . ks warp { ( gpu_kernel_free . ks matvec_w ) } {}
+    ( gpu_kernel_free . ks layernorm )
+    ( gpu_kernel_free . ks gelu )
+    ( gpu_kernel_free . ks conv1d )
+    ( gpu_kernel_free . ks attn_sc )
+    ( gpu_kernel_free . ks attn_out )
+    ( gpu_kernel_free . ks addv )
+    ( gpu_kernel_free . ks addrow )
+    ( gpu_kernel_free . ks scale )
+}
+
+// ── launchers ───────────────────────────────────────────────────────
+
+// y[batch][rows] = W[rows][cols] · x[batch][cols] + bias[rows]. `bd` may be 0.
+@ wk_matvec WhKernels ks i wd i xd i bd i yd i rows i cols i batch → v {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 wd ) )
+    ( vec_push [i] a ( gpu_arg_i64 xd ) )
+    ( vec_push [i] a ( gpu_arg_i64 bd ) )
+    ( vec_push [i] a ( gpu_arg_i64 yd ) )
+    ( vec_push [i] a ( gpu_arg_i32 rows ) )
+    ( vec_push [i] a ( gpu_arg_i32 cols ) )
+    ( vec_push [i] a ( gpu_arg_i32 batch ) )
+    ? . ks warp {
+        : i threads * * rows batch 32
+        : i _r ( gpu_launch . ks matvec_w ( gpu_grid threads 128 ) 128 a )
+    } {
+        : i _r ( gpu_launch . ks matvec ( gpu_grid * rows batch 128 ) 128 a )
+    }
+    ( vec_free [i] a )
+}
+
+@ wk_layernorm WhKernels ks i xd i wd i bd i yd i n f eps i batch → v {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 xd ) )
+    ( vec_push [i] a ( gpu_arg_i64 wd ) )
+    ( vec_push [i] a ( gpu_arg_i64 bd ) )
+    ( vec_push [i] a ( gpu_arg_i64 yd ) )
+    ( vec_push [i] a ( gpu_arg_i32 n ) )
+    ( vec_push [i] a ( gpu_arg_f32 eps ) )
+    ( vec_push [i] a ( gpu_arg_i32 batch ) )
+    : i _r ( gpu_launch . ks layernorm ( gpu_grid * n batch 256 ) 256 a )
+    ( vec_free [i] a )
+}
+
+@ wk_gelu WhKernels ks i xd i n → v {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 xd ) )
+    ( vec_push [i] a ( gpu_arg_i32 n ) )
+    : i _r ( gpu_launch . ks gelu ( gpu_grid n 256 ) 256 a )
+    ( vec_free [i] a )
+}
+
+@ wk_conv1d WhKernels ks i xd i wd i bd i yd i t_in i c_in i c_out i stride i pad → v {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 xd ) )
+    ( vec_push [i] a ( gpu_arg_i64 wd ) )
+    ( vec_push [i] a ( gpu_arg_i64 bd ) )
+    ( vec_push [i] a ( gpu_arg_i64 yd ) )
+    ( vec_push [i] a ( gpu_arg_i32 t_in ) )
+    ( vec_push [i] a ( gpu_arg_i32 c_in ) )
+    ( vec_push [i] a ( gpu_arg_i32 c_out ) )
+    ( vec_push [i] a ( gpu_arg_i32 stride ) )
+    ( vec_push [i] a ( gpu_arg_i32 pad ) )
+    : i t_out + / - + t_in * 2 pad 3 stride 1
+    : i _r ( gpu_launch . ks conv1d ( gpu_grid * t_out c_out 256 ) 256 a )
+    ( vec_free [i] a )
+}
+
+// Attention. `causal` 0 = every query sees every key (the encoder, and the
+// decoder's cross-attention); 1 = a query sees only keys at or before it (the
+// decoder's self-attention).
+@ wk_attn WhKernels ks i qd i kd i vd i scd i outd i nh i hd i nq i nkey f qscale i causal → v {
+    : ( Vec i ) a1 ( vec_new [i] )
+    ( vec_push [i] a1 ( gpu_arg_i64 qd ) )
+    ( vec_push [i] a1 ( gpu_arg_i64 kd ) )
+    ( vec_push [i] a1 ( gpu_arg_i64 scd ) )
+    ( vec_push [i] a1 ( gpu_arg_i32 nh ) )
+    ( vec_push [i] a1 ( gpu_arg_i32 hd ) )
+    ( vec_push [i] a1 ( gpu_arg_i32 nq ) )
+    ( vec_push [i] a1 ( gpu_arg_i32 nkey ) )
+    ( vec_push [i] a1 ( gpu_arg_f32 qscale ) )
+    ( vec_push [i] a1 ( gpu_arg_i32 causal ) )
+    : i _r1 ( gpu_launch . ks attn_sc ( gpu_grid * * nh nq nkey 256 ) 256 a1 )
+    ( vec_free [i] a1 )
+    : ( Vec i ) a2 ( vec_new [i] )
+    ( vec_push [i] a2 ( gpu_arg_i64 vd ) )
+    ( vec_push [i] a2 ( gpu_arg_i64 scd ) )
+    ( vec_push [i] a2 ( gpu_arg_i64 outd ) )
+    ( vec_push [i] a2 ( gpu_arg_i32 nh ) )
+    ( vec_push [i] a2 ( gpu_arg_i32 hd ) )
+    ( vec_push [i] a2 ( gpu_arg_i32 nq ) )
+    ( vec_push [i] a2 ( gpu_arg_i32 nkey ) )
+    : i _r2 ( gpu_launch . ks attn_out ( gpu_grid * * nh nq hd 256 ) 256 a2 )
+    ( vec_free [i] a2 )
+}
+
+@ wk_addv WhKernels ks i ad i bd i n → v {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 ad ) )
+    ( vec_push [i] a ( gpu_arg_i64 bd ) )
+    ( vec_push [i] a ( gpu_arg_i32 n ) )
+    : i _r ( gpu_launch . ks addv ( gpu_grid n 256 ) 256 a )
+    ( vec_free [i] a )
+}
+
+@ wk_addrow WhKernels ks i ad i vd i n i batch → v {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 ad ) )
+    ( vec_push [i] a ( gpu_arg_i64 vd ) )
+    ( vec_push [i] a ( gpu_arg_i32 n ) )
+    ( vec_push [i] a ( gpu_arg_i32 batch ) )
+    : i _r ( gpu_launch . ks addrow ( gpu_grid * n batch 256 ) 256 a )
+    ( vec_free [i] a )
+}
+
+@ wk_scale WhKernels ks i xd f s i n → v {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 xd ) )
+    ( vec_push [i] a ( gpu_arg_f32 s ) )
+    ( vec_push [i] a ( gpu_arg_i32 n ) )
+    : i _r ( gpu_launch . ks scale ( gpu_grid n 256 ) 256 a )
+    ( vec_free [i] a )
+}

--- a/packages/whisper/src/main.nu
+++ b/packages/whisper/src/main.nu
@@ -1,0 +1,119 @@
+// packages/whisper/src/main.nu — the CLI (encoder stage).
+//
+//   whisper encode <config.json> <model.safetensors> <audio.wav> -o enc.f32
+//
+// Runs the encoder over a 30-second window and writes the 1500 × d_model states
+// — which is exactly what the decoder will attend to, and what the test suite
+// compares against HF's WhisperModel.encoder.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/args.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/floatbits.nu`
+$ `deps/audio/src/wav.nu`
+$ `deps/audio/src/mel.nu`
+$ `deps/audio/src/resample.nu`
+$ `src/model.nu`
+
+@ __wcli_write_f32 s path ( Vec f ) v → i {
+    : ( Vec u ) d ( vec_with_cap [u] * 4 ( vec_len [f] v ) )
+    : ~ i k 0
+    ~ < k ( vec_len [f] v ) {
+        ?? ( vec_get [f] v k ) {
+            T x → { ( bytes_push_u32_le d # u32 ( f32_to_bits # f32 x ) ) }
+            F → {}
+        }
+        = k + k 1
+    }
+    : ~ i rc 0
+    ?? ( write_file_bytes path d ) {
+        T _ → {}
+        F _ → {
+            ( nurl_eprintln `whisper: cannot write output` )
+            = rc 1
+        }
+    }
+    ( vec_free [u] d )
+    ^ rc
+}
+
+@ main → i {
+    : ArgParser p ( args_new `whisper` `Speech recognition in pure NURL (encoder stage).` )
+    ( args_opt p `output` 111 `FILE` `write the encoder states here (f32 LE)` )
+    ( args_flag p `help` 104 `show this help` )
+    ? ( args_parse_argv p ) {} {
+        ( nurl_eprintln ( args_error p ) )
+        ( args_free p )
+        ^ 2
+    }
+    ? ( args_present p `help` ) {
+        : String u ( args_usage p )
+        ( nurl_print ( string_data u ) )
+        ( nurl_print `\ncommands:\n  encode <config.json> <model.safetensors> <audio.wav> -o enc.f32\n` )
+        ( string_free u )
+        ( args_free p )
+        ^ 0
+    } {}
+    ? < ( args_positional_count p ) 4 {
+        ( nurl_eprintln `usage: whisper encode <config.json> <model.safetensors> <audio.wav> -o enc.f32` )
+        ( args_free p )
+        ^ 2
+    } {}
+    : ( Vec String ) pos ( args_positionals p )
+    : ~ s cfg ``
+    : ~ s wts ``
+    : ~ s wav ``
+    ?? ( vec_get [String] pos 1 ) { T c → { = cfg ( string_data c ) } F → {} }
+    ?? ( vec_get [String] pos 2 ) { T c → { = wts ( string_data c ) } F → {} }
+    ?? ( vec_get [String] pos 3 ) { T c → { = wav ( string_data c ) } F → {} }
+
+    ?? ( wav_read wav ) {
+        T aw → {
+            : ( Vec f ) mono ( wav_mono aw )
+            : ( Vec f ) at16 ( resample mono . aw rate 16000 )
+            : ( Vec f ) fixed ( pad_or_trim at16 480000 )
+            : ( Vec f ) mel ( log_mel_whisper fixed 400 160 80 16000 )
+            ( wav_free aw )
+            ( vec_free [f] mono )
+            ( vec_free [f] at16 )
+            ( vec_free [f] fixed )
+            ?? ( wh_open cfg wts ) {
+                T w → {
+                    ( wh_encode w mel )
+                    : ( Vec f ) enc ( wh_enc_out w )
+                    : String o ( args_value_or p `output` `enc.f32` )
+                    : i rc ( __wcli_write_f32 ( string_data o ) enc )
+                    : String m ( string_from `encoder — ` )
+                    ( string_push_int m . w n_ctx_enc )
+                    ( string_push_str m ` x ` )
+                    ( string_push_int m . w d_model )
+                    ( string_push_str m ` states → ` )
+                    ( string_push_str m ( string_data o ) )
+                    ( nurl_print ( string_data m ) ) ( nurl_print `\n` )
+                    ( string_free m )
+                    ( string_free o )
+                    ( vec_free [f] enc )
+                    ( vec_free [f] mel )
+                    ( wh_close w )
+                    ( args_free p )
+                    ^ rc
+                }
+                F e → {
+                    ( nurl_eprintln ( string_data e ) )
+                    ( string_free e )
+                    ( vec_free [f] mel )
+                    ( args_free p )
+                    ^ 1
+                }
+            }
+        }
+        F e → {
+            ( nurl_eprintln ( string_data e ) )
+            ( string_free e )
+            ( args_free p )
+            ^ 1
+        }
+    }
+}

--- a/packages/whisper/src/model.nu
+++ b/packages/whisper/src/model.nu
@@ -1,0 +1,388 @@
+// packages/whisper/src/model.nu — the encoder.
+//
+// Whisper's encoder turns a 30-second log-mel spectrogram (3000 frames × 80
+// mels) into 1500 vectors the decoder attends to. The shape, read out of the
+// checkpoint's own tensor names rather than remembered:
+//
+//   conv1 (k=3, s=1, pad=1)  80 → d_model     then GELU
+//   conv2 (k=3, s=2, pad=1)  d_model → d_model then GELU     3000 → 1500 frames
+//   + embed_positions        (a stored tensor, not computed sinusoids)
+//   N × [ LN → self-attn (NON-CAUSAL) → +residual
+//         LN → fc1 → GELU → fc2       → +residual ]
+//   LN
+//
+// The corner that bites: `k_proj` HAS NO BIAS. q, v and out_proj all have one;
+// k does not. Whisper is not alone in this — it is inherited from the original
+// implementation — and a loader that adds a zero bias where none exists is fine,
+// while one that expects a bias tensor and finds none will happily read whatever
+// is next in the file.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/floatbits.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/std/fs.nu`
+$ `deps/gpu/src/gpu.nu`
+$ `deps/safetensor/src/safetensor.nu`
+$ `src/kernels.nu`
+
+: Whisper {
+    Gpu g
+    WhKernels ks
+    i st  // *St, the safetensors file
+    i n_mels
+    i d_model
+    i n_head
+    i head_dim
+    i n_enc_layer
+    i n_dec_layer
+    i n_ctx_enc  // 1500 encoder positions
+    i n_vocab
+    // encoder weights (device pointers)
+    i conv1_w
+    i conv1_b
+    i conv2_w
+    i conv2_b
+    i enc_pos
+    ( Vec i ) e_ln1_w
+    ( Vec i ) e_ln1_b
+    ( Vec i ) e_wq
+    ( Vec i ) e_bq
+    ( Vec i ) e_wk  // no bias — whisper's k_proj has none
+    ( Vec i ) e_wv
+    ( Vec i ) e_bv
+    ( Vec i ) e_wo
+    ( Vec i ) e_bo
+    ( Vec i ) e_ln2_w
+    ( Vec i ) e_ln2_b
+    ( Vec i ) e_fc1_w
+    ( Vec i ) e_fc1_b
+    ( Vec i ) e_fc2_w
+    ( Vec i ) e_fc2_b
+    i e_lnf_w
+    i e_lnf_b
+    // scratch
+    i mel_d  // 3000 × n_mels
+    i c1_d  // 3000 × d_model
+    i c2_d  // 1500 × d_model
+    i xn_d
+    i q_d
+    i k_d
+    i v_d
+    i ao_d
+    i tmp_d
+    i ff_d  // 1500 × 4·d_model
+    i sc_d  // n_head × 1500 × 1500 scores
+    i enc_out  // 1500 × d_model — what the decoder attends to
+    ( Vec i ) bufs  // every device allocation, for the free
+    ( Vec i ) bufsz
+}
+
+@ __wh_err s msg → !*Whisper String {
+    ^ @ !*Whisper String { F ( string_from msg ) }
+}
+
+@ __wh_geti ( Vec i ) v i k → i {
+    ?? ( vec_get [i] v k ) { T x → { ^ x } F → { ^ 0 } }
+}
+
+// Upload a tensor from the safetensors file as f32. -1 when it is not there —
+// which is a fact about the model (k_proj has no bias), not always an error.
+@ __wh_up * Whisper w s name → i {
+    : *St st # *St . w st
+    : i ti ( st_find_tensor st name )
+    ? < ti 0 { ^ -1 } {}
+    ?? ( st_dequant st ti ) {
+        T raw → {
+            : i n ( vec_len [u] raw )
+            : GpuBuffer b ( gpu_alloc . w g n )
+            : i _u ( gpu_upload b ( vec_data [u] raw ) )
+            ( vec_free [u] raw )
+            ( vec_push [i] . w bufs . b dptr )
+            ( vec_push [i] . w bufsz . b bytes )
+            ^ . b dptr
+        }
+        F e → {
+            ( string_free e )
+            ^ -1
+        }
+    }
+}
+
+// A per-layer tensor: model.encoder.layers.<L>.<suffix>
+@ __wh_lname i layer s suffix → String {
+    : String s2 ( string_from `model.encoder.layers.` )
+    ( string_push_int s2 layer )
+    ( string_push_char s2 46 )
+    ( string_push_str s2 suffix )
+    ^ s2
+}
+
+@ __wh_up_layer * Whisper w i layer s suffix ( Vec i ) dst → b {
+    : String nm ( __wh_lname layer suffix )
+    : i d ( __wh_up w ( string_data nm ) )
+    ( string_free nm )
+    ( vec_push [i] dst d )
+    ^ >= d 0
+}
+
+@ __wh_scratch * Whisper w i nfloats → i {
+    : GpuBuffer b ( gpu_alloc . w g * nfloats 4 )
+    ( vec_push [i] . w bufs . b dptr )
+    ( vec_push [i] . w bufsz . b bytes )
+    ^ . b dptr
+}
+
+// config.json — the hyperparameters live next to the weights, not inside them
+@ __wh_cfg_int Json root s key i def → i {
+    ?? ( json_obj_get root key ) {
+        T v → { ? ( json_is_num v ) { ^ ( json_as_int v ) } { ^ def } }
+        F → { ^ def }
+    }
+}
+
+@ wh_open s config_path s weights_path → !*Whisper String {
+    // hyperparameters
+    : ~ i n_mels 80
+    : ~ i d_model 384
+    : ~ i n_head 6
+    : ~ i n_enc 4
+    : ~ i n_dec 4
+    : ~ i n_ctx 1500
+    : ~ i n_vocab 51865
+    ?? ( read_file config_path ) {
+        T txt → {
+            ?? ( json_parse ( string_data txt ) ) {
+                T root → {
+                    = n_mels ( __wh_cfg_int root `num_mel_bins` 80 )
+                    = d_model ( __wh_cfg_int root `d_model` 384 )
+                    = n_head ( __wh_cfg_int root `encoder_attention_heads` 6 )
+                    = n_enc ( __wh_cfg_int root `encoder_layers` 4 )
+                    = n_dec ( __wh_cfg_int root `decoder_layers` 4 )
+                    = n_ctx ( __wh_cfg_int root `max_source_positions` 1500 )
+                    = n_vocab ( __wh_cfg_int root `vocab_size` 51865 )
+                    ( json_free root )
+                    ( string_free txt )
+                }
+                F _e → {
+                    ( string_free txt )
+                    ^ ( __wh_err `whisper: config.json is not valid JSON` )
+                }
+            }
+        }
+        F _ → {
+            : String m ( string_from `whisper: cannot read ` )
+            ( string_push_str m config_path )
+            ^ @ !*Whisper String { F m }
+        }
+    }
+
+    : *Whisper w # *Whisper ( nurl_alloc Z Whisper )
+    = . w bufs ( vec_new [i] )
+    = . w bufsz ( vec_new [i] )
+    = . w n_mels n_mels
+    = . w d_model d_model
+    = . w n_head n_head
+    = . w head_dim / d_model n_head
+    = . w n_enc_layer n_enc
+    = . w n_dec_layer n_dec
+    = . w n_ctx_enc n_ctx
+    = . w n_vocab n_vocab
+
+    ?? ( st_open weights_path ) {
+        T st → { = . w st # i st }
+        F e → {
+            ( nurl_free # s w )
+            ^ @ !*Whisper String { F e }
+        }
+    }
+
+    = . w g ( gpu_open ( gpu_best_device ) )
+    ? ( gpu_ok . w g ) {} {
+        ( wh_close w )
+        ^ ( __wh_err `whisper: no compute device (set NURL_GPU=cpu for the host backend)` )
+    }
+    = . w ks ( wk_build . w g )
+    ? . . w ks ok {} {
+        ( wh_close w )
+        ^ ( __wh_err `whisper: kernel compilation failed` )
+    }
+
+    = . w e_ln1_w ( vec_new [i] )
+    = . w e_ln1_b ( vec_new [i] )
+    = . w e_wq ( vec_new [i] )
+    = . w e_bq ( vec_new [i] )
+    = . w e_wk ( vec_new [i] )
+    = . w e_wv ( vec_new [i] )
+    = . w e_bv ( vec_new [i] )
+    = . w e_wo ( vec_new [i] )
+    = . w e_bo ( vec_new [i] )
+    = . w e_ln2_w ( vec_new [i] )
+    = . w e_ln2_b ( vec_new [i] )
+    = . w e_fc1_w ( vec_new [i] )
+    = . w e_fc1_b ( vec_new [i] )
+    = . w e_fc2_w ( vec_new [i] )
+    = . w e_fc2_b ( vec_new [i] )
+
+    : ~ b ok T
+    = . w conv1_w ( __wh_up w `model.encoder.conv1.weight` )
+    = . w conv1_b ( __wh_up w `model.encoder.conv1.bias` )
+    = . w conv2_w ( __wh_up w `model.encoder.conv2.weight` )
+    = . w conv2_b ( __wh_up w `model.encoder.conv2.bias` )
+    = . w enc_pos ( __wh_up w `model.encoder.embed_positions.weight` )
+    = . w e_lnf_w ( __wh_up w `model.encoder.layer_norm.weight` )
+    = . w e_lnf_b ( __wh_up w `model.encoder.layer_norm.bias` )
+    ? | | | | | < . w conv1_w 0 < . w conv1_b 0 < . w conv2_w 0 < . w conv2_b 0
+    < . w enc_pos 0 | < . w e_lnf_w 0 < . w e_lnf_b 0 { = ok F } {}
+
+    : ~ i L 0
+    ~ & ok < L n_enc {
+        ? ( __wh_up_layer w L `self_attn_layer_norm.weight` . w e_ln1_w ) {} { = ok F }
+        ? ( __wh_up_layer w L `self_attn_layer_norm.bias` . w e_ln1_b ) {} { = ok F }
+        ? ( __wh_up_layer w L `self_attn.q_proj.weight` . w e_wq ) {} { = ok F }
+        ? ( __wh_up_layer w L `self_attn.q_proj.bias` . w e_bq ) {} { = ok F }
+        // k_proj has NO bias — the vector is loaded, no bias is looked for
+        ? ( __wh_up_layer w L `self_attn.k_proj.weight` . w e_wk ) {} { = ok F }
+        ? ( __wh_up_layer w L `self_attn.v_proj.weight` . w e_wv ) {} { = ok F }
+        ? ( __wh_up_layer w L `self_attn.v_proj.bias` . w e_bv ) {} { = ok F }
+        ? ( __wh_up_layer w L `self_attn.out_proj.weight` . w e_wo ) {} { = ok F }
+        ? ( __wh_up_layer w L `self_attn.out_proj.bias` . w e_bo ) {} { = ok F }
+        ? ( __wh_up_layer w L `final_layer_norm.weight` . w e_ln2_w ) {} { = ok F }
+        ? ( __wh_up_layer w L `final_layer_norm.bias` . w e_ln2_b ) {} { = ok F }
+        ? ( __wh_up_layer w L `fc1.weight` . w e_fc1_w ) {} { = ok F }
+        ? ( __wh_up_layer w L `fc1.bias` . w e_fc1_b ) {} { = ok F }
+        ? ( __wh_up_layer w L `fc2.weight` . w e_fc2_w ) {} { = ok F }
+        ? ( __wh_up_layer w L `fc2.bias` . w e_fc2_b ) {} { = ok F }
+        = L + L 1
+    }
+    ? ok {} {
+        ( wh_close w )
+        ^ ( __wh_err `whisper: the checkpoint is missing encoder tensors` )
+    }
+
+    : i nfr * 2 n_ctx
+    : i dm d_model
+    = . w mel_d ( __wh_scratch w * nfr n_mels )
+    = . w c1_d ( __wh_scratch w * nfr dm )
+    = . w c2_d ( __wh_scratch w * n_ctx dm )
+    = . w xn_d ( __wh_scratch w * n_ctx dm )
+    = . w q_d ( __wh_scratch w * n_ctx dm )
+    = . w k_d ( __wh_scratch w * n_ctx dm )
+    = . w v_d ( __wh_scratch w * n_ctx dm )
+    = . w ao_d ( __wh_scratch w * n_ctx dm )
+    = . w tmp_d ( __wh_scratch w * n_ctx dm )
+    = . w ff_d ( __wh_scratch w * n_ctx * 4 dm )
+    = . w sc_d ( __wh_scratch w * * n_head n_ctx n_ctx )
+    = . w enc_out ( __wh_scratch w * n_ctx dm )
+    ^ @ !*Whisper String { T w }
+}
+
+@ wh_close * Whisper w → v {
+    : ~ i k 0
+    ~ < k ( vec_len [i] . w bufs ) {
+        ( gpu_free @ GpuBuffer { ( __wh_geti . w bufs k ) ( __wh_geti . w bufsz k ) } )
+        = k + k 1
+    }
+    ( vec_free [i] . w bufs )
+    ( vec_free [i] . w bufsz )
+    ( vec_free [i] . w e_ln1_w ) ( vec_free [i] . w e_ln1_b )
+    ( vec_free [i] . w e_wq ) ( vec_free [i] . w e_bq )
+    ( vec_free [i] . w e_wk )
+    ( vec_free [i] . w e_wv ) ( vec_free [i] . w e_bv )
+    ( vec_free [i] . w e_wo ) ( vec_free [i] . w e_bo )
+    ( vec_free [i] . w e_ln2_w ) ( vec_free [i] . w e_ln2_b )
+    ( vec_free [i] . w e_fc1_w ) ( vec_free [i] . w e_fc1_b )
+    ( vec_free [i] . w e_fc2_w ) ( vec_free [i] . w e_fc2_b )
+    ? != . w st 0 { ( st_close # *St . w st ) } {}
+    ? ( gpu_ok . w g ) { ( wk_free . w ks ) ( gpu_close . w g ) } {}
+    ( nurl_free # s w )
+}
+
+// Run the encoder over a 30-second log-mel spectrogram: `mel` is 3000 × n_mels,
+// row-major (a frame is contiguous) — exactly what packages/audio produces.
+// Leaves the 1500 encoder states on the device (wh_enc_out).
+@ wh_encode * Whisper w ( Vec f ) mel → v {
+    : i nframe / ( vec_len [f] mel ) . w n_mels
+    : i dm . w d_model
+    : i nh . w n_head
+    : i hd . w head_dim
+    : i nc . w n_ctx_enc
+    : f eps 0.00001
+
+    // mel → device
+    : ( Vec u ) raw ( vec_with_cap [u] * 4 ( vec_len [f] mel ) )
+    : ~ i k 0
+    ~ < k ( vec_len [f] mel ) {
+        ?? ( vec_get [f] mel k ) {
+            T x → { ( bytes_push_u32_le raw # u32 ( f32_to_bits # f32 x ) ) }
+            F → {}
+        }
+        = k + k 1
+    }
+    : GpuBuffer mb @ GpuBuffer { . w mel_d * 4 ( vec_len [f] mel ) }
+    : i _u ( gpu_upload mb ( vec_data [u] raw ) )
+    ( vec_free [u] raw )
+
+    // conv1 (stride 1) → GELU → conv2 (stride 2) → GELU
+    ( wk_conv1d . w ks . w mel_d . w conv1_w . w conv1_b . w c1_d nframe . w n_mels dm 1 1 )
+    ( wk_gelu . w ks . w c1_d * nframe dm )
+    ( wk_conv1d . w ks . w c1_d . w conv2_w . w conv2_b . w c2_d nframe dm dm 2 1 )
+    ( wk_gelu . w ks . w c2_d * nc dm )
+
+    // + the stored positional embedding. This is a MATRIX (1500 × d_model), one
+    // vector per position — not a row broadcast over the batch the way a bias is.
+    // Adding it with addrow would give every one of the 1500 positions the same
+    // positional vector, which is the same as having no positions at all.
+    ( wk_addv . w ks . w c2_d . w enc_pos * nc dm )
+
+    : f qscale / 1.0 ( sqrt # f hd )
+    : ~ i L 0
+    ~ < L . w n_enc_layer {
+        // self-attention, NON-CAUSAL: every one of the 1500 positions sees all
+        // 1500. This is the first attention in the ecosystem that does not mask
+        // the future — a speech encoder hears the whole clip at once.
+        ( wk_layernorm . w ks . w c2_d ( __wh_geti . w e_ln1_w L ) ( __wh_geti . w e_ln1_b L )
+        . w xn_d dm eps nc )
+        ( wk_matvec . w ks ( __wh_geti . w e_wq L ) . w xn_d ( __wh_geti . w e_bq L ) . w q_d dm dm nc )
+        // k_proj: no bias, so none is passed
+        ( wk_matvec . w ks ( __wh_geti . w e_wk L ) . w xn_d 0 . w k_d dm dm nc )
+        ( wk_matvec . w ks ( __wh_geti . w e_wv L ) . w xn_d ( __wh_geti . w e_bv L ) . w v_d dm dm nc )
+        ( wk_attn . w ks . w q_d . w k_d . w v_d . w sc_d . w ao_d nh hd nc nc qscale 0 )
+        ( wk_matvec . w ks ( __wh_geti . w e_wo L ) . w ao_d ( __wh_geti . w e_bo L ) . w tmp_d dm dm nc )
+        ( wk_addv . w ks . w c2_d . w tmp_d * nc dm )
+
+        // feed-forward: fc1 → GELU → fc2
+        ( wk_layernorm . w ks . w c2_d ( __wh_geti . w e_ln2_w L ) ( __wh_geti . w e_ln2_b L )
+        . w xn_d dm eps nc )
+        ( wk_matvec . w ks ( __wh_geti . w e_fc1_w L ) . w xn_d ( __wh_geti . w e_fc1_b L )
+        . w ff_d * 4 dm dm nc )
+        ( wk_gelu . w ks . w ff_d * nc * 4 dm )
+        ( wk_matvec . w ks ( __wh_geti . w e_fc2_w L ) . w ff_d ( __wh_geti . w e_fc2_b L )
+        . w tmp_d dm * 4 dm nc )
+        ( wk_addv . w ks . w c2_d . w tmp_d * nc dm )
+        = L + L 1
+    }
+    ( wk_layernorm . w ks . w c2_d . w e_lnf_w . w e_lnf_b . w enc_out dm eps nc )
+}
+
+// The encoder states, back on the host: 1500 × d_model, row-major.
+@ wh_enc_out * Whisper w → ( Vec f ) {
+    : i n * . w n_ctx_enc . w d_model
+    : *u host ( gpu_host_alloc * n 4 )
+    : GpuBuffer b @ GpuBuffer { . w enc_out * n 4 }
+    : i _d ( gpu_download host b )
+    : ( Vec f ) out ( vec_with_cap [f] n )
+    : ~ i k 0
+    ~ < k n {
+        : i bits ( __wh_u32 host * k 4 )
+        ( vec_push [f] out # f ( bits_to_f32 bits ) )
+        = k + k 1
+    }
+    ( gpu_host_free host )
+    ^ out
+}
+
+@ __wh_u32 * u p i o → i {
+    ^ | # i . p o | << # i . p + o 1 8 | << # i . p + o 2 16 << # i . p + o 3 24
+}

--- a/packages/whisper/tests/encoder_ref.py
+++ b/packages/whisper/tests/encoder_ref.py
@@ -1,0 +1,85 @@
+# Independent numpy reference for whisper's ENCODER, reading the safetensors
+# checkpoint directly.
+#
+# It is itself checked against HF's WhisperModel.encoder (r = 1.00000000,
+# max|delta| = 4.3e-4 in float64) — so when the GPU path disagrees with THIS, the
+# GPU path is what is wrong. That is exactly how the positional-embedding bug was
+# found: the reference agreed with HF, and the kernels did not agree with either.
+import sys
+import json
+import struct
+import numpy as np
+
+
+def load(path):
+    raw = open(path, 'rb').read()
+    n = struct.unpack('<Q', raw[:8])[0]
+    hdr = json.loads(raw[8:8 + n])
+
+    def T(name):
+        e = hdr[name]
+        a, b = e['data_offsets']
+        return np.frombuffer(raw[8 + n + a:8 + n + b], dtype='<f4').reshape(e['shape']).astype(np.float64)
+    return T
+
+
+def gelu(x):
+    # The ERROR-FUNCTION gelu, which is what whisper was trained with — not the
+    # tanh approximation (which gemma wants, and which is a different function).
+    from math import sqrt, erf
+    return 0.5 * x * (1 + np.vectorize(erf)(x / sqrt(2)))
+
+
+def ln(x, w, b, eps=1e-5):
+    m = x.mean(-1, keepdims=True)
+    v = x.var(-1, keepdims=True)
+    return (x - m) / np.sqrt(v + eps) * w + b
+
+
+def conv1d(x, W, b, stride):          # x (C_in, T), W (C_out, C_in, 3)
+    T = x.shape[1]
+    xp = np.pad(x, ((0, 0), (1, 1)))
+    T_out = (T + 2 - 3) // stride + 1
+    y = np.zeros((W.shape[0], T_out))
+    for t in range(T_out):
+        y[:, t] = np.einsum('oik,ik->o', W, xp[:, t * stride:t * stride + 3]) + b
+    return y
+
+
+def encode(T, mel, n_layer, n_head):  # mel (n_mels, 3000)
+    h = gelu(conv1d(mel, T('model.encoder.conv1.weight'), T('model.encoder.conv1.bias'), 1))
+    h = gelu(conv1d(h,   T('model.encoder.conv2.weight'), T('model.encoder.conv2.bias'), 2))
+    # embed_positions is a MATRIX — one vector per position, not a row broadcast
+    x = h.T + T('model.encoder.embed_positions.weight')
+    d_model = x.shape[1]
+    hd = d_model // n_head
+    for L in range(n_layer):
+        p = f'model.encoder.layers.{L}.'
+        r = x
+        y = ln(x, T(p + 'self_attn_layer_norm.weight'), T(p + 'self_attn_layer_norm.bias'))
+        q = y @ T(p + 'self_attn.q_proj.weight').T + T(p + 'self_attn.q_proj.bias')
+        k = y @ T(p + 'self_attn.k_proj.weight').T          # k_proj has NO bias
+        v = y @ T(p + 'self_attn.v_proj.weight').T + T(p + 'self_attn.v_proj.bias')
+        q = q.reshape(-1, n_head, hd).transpose(1, 0, 2)
+        k = k.reshape(-1, n_head, hd).transpose(1, 0, 2)
+        v = v.reshape(-1, n_head, hd).transpose(1, 0, 2)
+        sc = q @ k.transpose(0, 2, 1) / np.sqrt(hd)         # NON-causal: no mask
+        sc = np.exp(sc - sc.max(-1, keepdims=True))
+        sc /= sc.sum(-1, keepdims=True)
+        o = (sc @ v).transpose(1, 0, 2).reshape(-1, d_model)
+        x = r + (o @ T(p + 'self_attn.out_proj.weight').T + T(p + 'self_attn.out_proj.bias'))
+        r = x
+        y = ln(x, T(p + 'final_layer_norm.weight'), T(p + 'final_layer_norm.bias'))
+        y = gelu(y @ T(p + 'fc1.weight').T + T(p + 'fc1.bias'))
+        x = r + (y @ T(p + 'fc2.weight').T + T(p + 'fc2.bias'))
+    return ln(x, T('model.encoder.layer_norm.weight'), T('model.encoder.layer_norm.bias'))
+
+
+if __name__ == "__main__":
+    # encoder_ref.py <model.safetensors> <mel.f32 (frames x n_mels)> <out.f32> [n_layer] [n_head] [n_mels]
+    T = load(sys.argv[1])
+    n_layer = int(sys.argv[4]) if len(sys.argv) > 4 else 4
+    n_head = int(sys.argv[5]) if len(sys.argv) > 5 else 6
+    n_mels = int(sys.argv[6]) if len(sys.argv) > 6 else 80
+    mel = np.fromfile(sys.argv[2], dtype='<f4').reshape(-1, n_mels).T.astype(np.float64)
+    encode(T, mel, n_layer, n_head).astype('<f4').tofile(sys.argv[3])

--- a/packages/whisper/tests/whisper_test.sh
+++ b/packages/whisper/tests/whisper_test.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# ============================================================
+#  packages/whisper — test suite (encoder stage)
+#
+#  The encoder is checked against an independent numpy reference reading the
+#  same checkpoint — and that reference is itself checked against HF's
+#  WhisperModel.encoder, so a shared misconception cannot hide between the two.
+#  That is how the positional-embedding bug was found: the reference agreed with
+#  HF, and the kernels agreed with neither.
+#
+#  Run from the package dir:  ./tests/whisper_test.sh
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t whisper.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+
+echo "[1/3] build"
+if ! $NURL src/main.nu "$WORK/whisper" >/dev/null 2>"$WORK/build.err"; then
+    echo "  build FAILED"; cat "$WORK/build.err"; exit 1
+fi
+WH="$WORK/whisper"
+(cd ../audio && $NURL src/main.nu "$WORK/audio" >/dev/null 2>&1)
+
+echo "[2/3] whisper-tiny + a test clip"
+if ! curl -sL --max-time 900 -f -o "$WORK/model.safetensors" \
+    https://huggingface.co/openai/whisper-tiny/resolve/main/model.safetensors \
+   || ! curl -sL --max-time 120 -f -o "$WORK/config.json" \
+    https://huggingface.co/openai/whisper-tiny/resolve/main/config.json; then
+    echo "  SKIP (model download failed)"
+    echo "== whisper tests: PASS=$PASS FAIL=$FAIL"
+    exit 0
+fi
+python3 - "$WORK" <<'PYEOF'
+import sys, numpy as np, wave, struct
+W = sys.argv[1]; sr = 16000
+t = np.arange(3 * sr) / sr
+rng = np.random.RandomState(7)
+x = 0.4*np.sin(2*np.pi*220*t)*(1 + 0.5*np.sin(2*np.pi*3*t))
+x += 0.25*np.sin(2*np.pi*880*t + 2*np.sin(2*np.pi*5*t))
+x += 0.15*np.sin(2*np.pi*2400*t) + 0.05*rng.randn(t.size)
+x = x / np.abs(x).max() * 0.9
+w = wave.open(W + '/clip.wav', 'wb'); w.setnchannels(1); w.setsampwidth(2); w.setframerate(sr)
+w.writeframes(b''.join(struct.pack('<h', int(v * 32767)) for v in x)); w.close()
+PYEOF
+
+echo "[3/3] the encoder, against numpy and across both backends"
+if "$WH" encode "$WORK/config.json" "$WORK/model.safetensors" "$WORK/clip.wav" \
+        -o "$WORK/enc_gpu.f32" >/dev/null 2>&1; then
+    ok "the encoder runs end to end (WAV → mel → 1500 x 384 states)"
+else
+    bad "encoder run"
+fi
+
+# the reference gets the mel from our own audio package, so both see one input
+"$WORK/audio" mel "$WORK/clip.wav" -o "$WORK/mel.f32" >/dev/null 2>&1
+python3 tests/encoder_ref.py "$WORK/model.safetensors" "$WORK/mel.f32" "$WORK/enc_ref.f32" 4 6 80
+
+python3 - "$WORK" <<'PYEOF' && ok "encoder states == independent numpy reference (which matches HF)" || bad "encoder vs numpy"
+import sys, numpy as np
+W = sys.argv[1]
+ours = np.fromfile(W + '/enc_gpu.f32', dtype='<f4')
+ref  = np.fromfile(W + '/enc_ref.f32', dtype='<f4')
+assert ours.shape == ref.shape, f"{ours.shape} != {ref.shape}"
+d = np.abs(ours - ref).max()
+r = np.corrcoef(ours, ref)[0, 1]
+# f32 kernels against a float64 reference, through 4 layers of 1500x1500
+# attention: 1e-3 is accumulation order, and the correlation is what pins the
+# answer — a structural bug (like the positional embedding) sends r to 0.004.
+assert r > 0.999999, f"correlation {r:.8f}"
+assert d < 5e-2, f"max|delta| = {d:.3e}"
+print(f"    max|delta| = {d:.3e}, r = {r:.8f}")
+PYEOF
+
+if NURL_GPU=cpu "$WH" encode "$WORK/config.json" "$WORK/model.safetensors" "$WORK/clip.wav" \
+        -o "$WORK/enc_cpu.f32" >/dev/null 2>&1; then
+    python3 - "$WORK" <<'PYEOF' && ok "CPU/OpenMP backend == CUDA backend (the portable matvec agrees with the warp one)" || bad "backend parity"
+import sys, numpy as np
+W = sys.argv[1]
+g = np.fromfile(W + '/enc_gpu.f32', dtype='<f4')
+c = np.fromfile(W + '/enc_cpu.f32', dtype='<f4')
+d = np.abs(g - c).max()
+assert d < 5e-2, f"max|delta| = {d:.3e}"
+PYEOF
+else
+    bad "CPU backend run"
+fi
+
+echo "== whisper tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Whisper's encoder turns a 30-second log-mel spectrogram (3000 frames × 80 mels) into the 1500 vectors the decoder attends to. **It is not the llama shape**, and every kernel here is a place it differs:

| | |
|---|---|
| **LayerNorm**, not RMSNorm | it subtracts the mean, and it has a **bias** |
| **GELU with the error function** | not the tanh approximation. HF's `ACT2FN["gelu"]` is the exact one — gemma wanting the other does not make them interchangeable |
| **conv1d**, twice (stride 1, then 2) | this is what turns 3000 spectrogram frames into 1500 encoder positions |
| **non-causal attention** | every attention in this ecosystem so far masked the future. A speech encoder hears the whole clip at once |
| **`k_proj` has no bias** | alone among the projections — q, v and out_proj all have one |

The whole chain now runs end to end in NURL: **WAV → resample → log-mel** (`packages/audio`) → **safetensors weights** (`packages/safetensor`) → **these kernels** (`packages/gpu`, the same CUDA-C on the CUDA and CPU/OpenMP backends).

## The bug — and why the reference is not optional

The first run came back at **correlation 0.004** against HF. Structurally wrong, not numerically off.

Instead of guessing, I wrote a numpy reference reading the same checkpoint and asked whether **it** matched HF. It did — `r = 1.00000000`. So my *understanding* was right and my *kernels* were wrong, which halved the search space in a single step.

The bug: **`embed_positions` is a matrix** (1500 × d_model), one vector per position — and I added it with `addrow`, which broadcasts a single row over the batch the way a bias does. All 1500 positions got the same positional vector, which is the same as having no positions at all. One kernel call, and the encoder was noise.

## Verification

whisper-tiny, a 3-second clip through the whole chain:

| | |
|---|---|
| ours vs numpy reference | max \|Δ\| = **1.4e-3**, **r = 1.00000000** |
| numpy reference vs HF `WhisperModel.encoder` | max \|Δ\| = 4.3e-4, r = 1.00000000 |
| CPU/OpenMP backend vs CUDA | max \|Δ\| = 6.1e-4 |

**3/3**, ASan clean. The portable matvec (one thread per row) and the warp one (`__shfl_down_sync`, CUDA-only) agree — the CPU backend runs the portable one and the suite requires both to produce the same encoder.

Step 5 of the whisper package (`temp.md`). Next: the decoder — cross-attention into these states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH