### PR TITLE
packages/whisper — the decoder: it transcribes real speech, word for word

### DIFF
--- a/packages/tokenizer/src/hf.nu
+++ b/packages/tokenizer/src/hf.nu
@@ -23,7 +23,12 @@ $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/std/fs.nu`
 $ `stdlib/ext/json.nu`
-$ `src/tokenizer.nu`
+
+// NOTE: this file does NOT import src/tokenizer.nu. A package's sibling files do
+// not import each other — the CONSUMER imports them in dependency order, because
+// a relative `src/…` path only resolves from the package's own root and would
+// break the moment the package is used as a dependency (deps/tokenizer/src/…).
+// gguf follows the same rule. So: import tokenizer.nu, then hf.nu.
 
 @ __hf_err s msg → !*Tok String {
     ^ @ !*Tok String { F ( string_from msg ) }

--- a/packages/whisper/README.md
+++ b/packages/whisper/README.md
@@ -1,0 +1,60 @@
+# whisper
+
+Speech recognition in pure NURL. Real audio in, real text out — running
+from the safetensors checkpoint Hugging Face ships, on the GPU or the CPU.
+
+```
+nurlpkg install whisper
+```
+
+```
+$ whisper transcribe ./whisper-tiny jfk.wav
+ And so my fellow Americans ask not what your country can do for you ask what you can do for your country.
+```
+
+Word for word what HF transformers produces from the same model — and the
+CPU backend produces the same text as CUDA.
+
+A model directory is what Hugging Face ships: `config.json`,
+`model.safetensors`, `tokenizer.json`, side by side.
+
+## Built package by package
+
+Nothing here is a black box, and every stage is verified against an
+independent implementation rather than against my own understanding of it:
+
+| stage | package | verified against |
+|---|---|---|
+| WAV → 16 kHz mono | `audio` | scipy's `resample_poly` (r = 0.99992); a tone above the new Nyquist is killed by 82 dB |
+| → log-mel | `audio` | HF's `WhisperFeatureExtractor` — max \|Δ\| = 1.8e-5, r = 1.00000000 |
+| n_fft = 400 (not a power of two) | `stdlib/std/fft.nu` | numpy's `np.fft` — Bluestein, 1.9e-14 |
+| weights | `safetensor` | 167 tensors bit-exact; a whole forward pass at r = 1.00000000 |
+| vocabulary | `tokenizer` | HF's own tokenizer, 20/20 strings |
+| encoder + decoder | this package | HF's `WhisperModel.encoder` (r = 1.00000000) and its transcription, word for word |
+
+## Whisper is not the llama shape
+
+Every kernel is a place it differs:
+
+* **LayerNorm**, not RMSNorm — it subtracts the mean, and it has a bias.
+* **GELU with the error function**, not the tanh approximation. Gemma
+  wants the other one; they are different functions.
+* **conv1d**, twice (stride 1 then 2) — that is what turns 3000
+  spectrogram frames into 1500 encoder positions.
+* **Non-causal attention.** Every attention in this ecosystem before this
+  masked the future. A speech encoder hears the whole 30 seconds at once.
+* **Cross-attention**: the decoder's queries, the *encoder's* keys and
+  values — computed **once per clip**, not once per generated token.
+* **`k_proj` has no bias**, alone among the projections.
+
+## The control tokens are looked up, not hardcoded
+
+A whisper prompt is four tokens — `<|startoftranscript|>`, the language,
+`<|transcribe|>`, `<|notimestamps|>` — and they are the model being *told
+what task it is doing*. Their ids move between whisper versions (v3 added
+a language, and every id after it shifted), so they are looked up in the
+vocabulary the checkpoint ships with.
+
+## License
+
+MIT OR Apache-2.0

--- a/packages/whisper/src/kernels.nu
+++ b/packages/whisper/src/kernels.nu
@@ -36,6 +36,8 @@ $ `deps/gpu/src/gpu.nu`
     GpuKernel addv
     GpuKernel addrow
     GpuKernel scale
+    GpuKernel getrow  // one row of the embedding table → the activation
+    GpuKernel setrow  // write a row INTO the KV cache
     b ok
 }
 
@@ -192,6 +194,24 @@ $ `deps/gpu/src/gpu.nu`
     }`
 }
 
+// The embedding table is on the device (it is also the output projection —
+// whisper ties them), so a token's row is a copy, not a host round-trip.
+@ __wk_getrow → s {
+    ^ `extern "C" __global__ void getrow(const float* table, float* y, int row, int n) {
+        int i = blockIdx.x*blockDim.x + threadIdx.x;
+        if (i < n) y[i] = table[(long long)row*n + i];
+    }`
+}
+
+// Append a vector to a cache at `row` — the decoder's KV cache grows one
+// position per token, and the k/v it just computed belong at the end.
+@ __wk_setrow → s {
+    ^ `extern "C" __global__ void setrow(float* cache, const float* v, int row, int n) {
+        int i = blockIdx.x*blockDim.x + threadIdx.x;
+        if (i < n) cache[(long long)row*n + i] = v[i];
+    }`
+}
+
 @ __wk_addv → s {
     ^ `extern "C" __global__ void addv(float* a, const float* b, int n) {
         int i = blockIdx.x*blockDim.x + threadIdx.x;
@@ -228,10 +248,13 @@ $ `deps/gpu/src/gpu.nu`
     : GpuKernel k7 ( gpu_compile g ( __wk_addv ) `addv` )
     : GpuKernel k8 ( gpu_compile g ( __wk_addrow ) `addrow` )
     : GpuKernel k9 ( gpu_compile g ( __wk_scale ) `scale` )
+    : GpuKernel k10 ( gpu_compile g ( __wk_getrow ) `getrow` )
+    : GpuKernel k11 ( gpu_compile g ( __wk_setrow ) `setrow` )
     : b ok1 & & ( gpu_kernel_ok k1 ) ( gpu_kernel_ok k2 ) & ( gpu_kernel_ok k3 ) ( gpu_kernel_ok k4 )
     : b ok2 & & ( gpu_kernel_ok k5 ) ( gpu_kernel_ok k6 ) & ( gpu_kernel_ok k7 ) ( gpu_kernel_ok k8 )
-    : b ok & & ok1 ok2 ( gpu_kernel_ok k9 )
-    ^ @ WhKernels { k1 k1w warp k2 k3 k4 k5 k6 k7 k8 k9 ok }
+    : b ok3 & ( gpu_kernel_ok k9 ) & ( gpu_kernel_ok k10 ) ( gpu_kernel_ok k11 )
+    : b ok & & ok1 ok2 ok3
+    ^ @ WhKernels { k1 k1w warp k2 k3 k4 k5 k6 k7 k8 k9 k10 k11 ok }
 }
 
 @ wk_free WhKernels ks → v {
@@ -245,6 +268,8 @@ $ `deps/gpu/src/gpu.nu`
     ( gpu_kernel_free . ks addv )
     ( gpu_kernel_free . ks addrow )
     ( gpu_kernel_free . ks scale )
+    ( gpu_kernel_free . ks getrow )
+    ( gpu_kernel_free . ks setrow )
 }
 
 // ── launchers ───────────────────────────────────────────────────────
@@ -358,5 +383,25 @@ $ `deps/gpu/src/gpu.nu`
     ( vec_push [i] a ( gpu_arg_f32 s ) )
     ( vec_push [i] a ( gpu_arg_i32 n ) )
     : i _r ( gpu_launch . ks scale ( gpu_grid n 256 ) 256 a )
+    ( vec_free [i] a )
+}
+
+@ wk_getrow WhKernels ks i table i yd i row i n → v {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 table ) )
+    ( vec_push [i] a ( gpu_arg_i64 yd ) )
+    ( vec_push [i] a ( gpu_arg_i32 row ) )
+    ( vec_push [i] a ( gpu_arg_i32 n ) )
+    : i _r ( gpu_launch . ks getrow ( gpu_grid n 256 ) 256 a )
+    ( vec_free [i] a )
+}
+
+@ wk_setrow WhKernels ks i cache i vd i row i n → v {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 cache ) )
+    ( vec_push [i] a ( gpu_arg_i64 vd ) )
+    ( vec_push [i] a ( gpu_arg_i32 row ) )
+    ( vec_push [i] a ( gpu_arg_i32 n ) )
+    : i _r ( gpu_launch . ks setrow ( gpu_grid n 256 ) 256 a )
     ( vec_free [i] a )
 }

--- a/packages/whisper/src/main.nu
+++ b/packages/whisper/src/main.nu
@@ -1,10 +1,14 @@
 // packages/whisper/src/main.nu — the CLI (encoder stage).
 //
-//   whisper encode <config.json> <model.safetensors> <audio.wav> -o enc.f32
+//   whisper transcribe <model-dir> <audio.wav> [--lang en] [--max N]
+//   whisper encode     <config.json> <model.safetensors> <audio.wav> -o enc.f32
 //
-// Runs the encoder over a 30-second window and writes the 1500 × d_model states
-// — which is exactly what the decoder will attend to, and what the test suite
-// compares against HF's WhisperModel.encoder.
+// `transcribe` is the whole thing: WAV → log-mel → encoder → decoder → text.
+// `encode` stops after the encoder and writes its 1500 × d_model states, which
+// is what the test suite compares against HF's WhisperModel.encoder.
+//
+// A model directory is what Hugging Face ships: config.json, model.safetensors
+// and tokenizer.json, side by side.
 
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
@@ -15,6 +19,8 @@ $ `stdlib/std/floatbits.nu`
 $ `deps/audio/src/wav.nu`
 $ `deps/audio/src/mel.nu`
 $ `deps/audio/src/resample.nu`
+$ `deps/tokenizer/src/tokenizer.nu`
+$ `deps/tokenizer/src/hf.nu`
 $ `src/model.nu`
 
 @ __wcli_write_f32 s path ( Vec f ) v → i {
@@ -39,9 +45,143 @@ $ `src/model.nu`
     ^ rc
 }
 
+// <dir>/<name>
+@ __wh_path s dir s name → String {
+    : String p2 ( string_from dir )
+    ? > ( string_len p2 ) 0 {
+        ? != ( nurl_str_get ( string_data p2 ) - ( string_len p2 ) 1 ) 47 {
+            ( string_push_char p2 47 )
+        } {}
+    } {}
+    ( string_push_str p2 name )
+    ^ p2
+}
+
+// A whisper prompt is four control tokens, and getting them wrong is not a
+// subtle failure: the model is being told what task it is doing.
+//
+//   <|startoftranscript|> <|LANG|> <|transcribe|> <|notimestamps|>
+//
+// Their ids are NOT hardcoded here — they are looked up in the vocabulary the
+// checkpoint ships, because they move between whisper versions (v3 added a
+// language and every id after it shifted).
+@ __wh_special * Tok t s name → i {
+    : ( Vec i ) ids ( tok_encode t name T )
+    : ~ i id -1
+    ? == 1 ( vec_len [i] ids ) {
+        ?? ( vec_get [i] ids 0 ) { T x → { = id x } F → {} }
+    } {}
+    ( vec_free [i] ids )
+    ^ id
+}
+
+@ __wh_transcribe s dir s wavpath s lang i maxtok → i {
+    : String cfg ( __wh_path dir `config.json` )
+    : String wts ( __wh_path dir `model.safetensors` )
+    : String tjs ( __wh_path dir `tokenizer.json` )
+
+    : TokSpec spec @ TokSpec { TOK_BPE PRE_DEFAULT -1 -1 -1 F F F }
+    : ~ i rc 0
+    ?? ( tok_from_tokenizer_json ( string_data tjs ) spec ) {
+        T t → {
+            ?? ( wav_read wavpath ) {
+                T aw → {
+                    : ( Vec f ) mono ( wav_mono aw )
+                    : ( Vec f ) at16 ( resample mono . aw rate 16000 )
+                    : ( Vec f ) fixed ( pad_or_trim at16 480000 )
+                    : ( Vec f ) mel ( log_mel_whisper fixed 400 160 80 16000 )
+                    ( wav_free aw )
+                    ( vec_free [f] mono ) ( vec_free [f] at16 ) ( vec_free [f] fixed )
+                    ?? ( wh_open ( string_data cfg ) ( string_data wts ) ) {
+                        T w → {
+                            ( wh_encode w mel )
+                            ( wh_prepare_cross w )
+                            ( vec_free [f] mel )
+
+                            : String ltok ( string_from `<|` )
+                            ( string_push_str ltok lang )
+                            ( string_push_str ltok `|>` )
+                            : i sot ( __wh_special t `<|startoftranscript|>` )
+                            : i lid ( __wh_special t ( string_data ltok ) )
+                            : i task ( __wh_special t `<|transcribe|>` )
+                            : i nots ( __wh_special t `<|notimestamps|>` )
+                            : i eot ( __wh_special t `<|endoftext|>` )
+                            ( string_free ltok )
+                            ? | | | | < sot 0 < lid 0 < task 0 < nots 0 < eot 0 {
+                                ( nurl_eprintln `whisper: the vocabulary has no control tokens (is this a whisper tokenizer.json?)` )
+                                = rc 1
+                            } {
+                                : ( Vec i ) prompt ( vec_new [i] )
+                                ( vec_push [i] prompt sot )
+                                ( vec_push [i] prompt lid )
+                                ( vec_push [i] prompt task )
+                                ( vec_push [i] prompt nots )
+                                : ( Vec i ) outids ( vec_new [i] )
+                                : ~ i pos 0
+                                // feed the prompt, then generate
+                                : ~ i k 0
+                                ~ < k ( vec_len [i] prompt ) {
+                                    ?? ( vec_get [i] prompt k ) {
+                                        T tk → { ( wh_decode_step w tk pos ) }
+                                        F → {}
+                                    }
+                                    = pos + pos 1
+                                    = k + k 1
+                                }
+                                : ~ b done F
+                                : ~ i made 0
+                                ~ & ! done < made maxtok {
+                                    : ( Vec f ) lg ( wh_logits w )
+                                    : i nt ( wh_argmax lg )
+                                    ( vec_free [f] lg )
+                                    ? == nt eot { = done T } {
+                                        ( vec_push [i] outids nt )
+                                        ( wh_decode_step w nt pos )
+                                        = pos + pos 1
+                                        = made + made 1
+                                    }
+                                }
+                                : ( Vec u ) txt ( tok_decode t outids )
+                                : i n ( vec_len [u] txt )
+                                ? > n 0 { : i _w ( write 1 # *u ( vec_data [u] txt ) n ) } {}
+                                ( nurl_print `\n` )
+                                ( vec_free [u] txt )
+                                ( vec_free [i] outids )
+                                ( vec_free [i] prompt )
+                            }
+                            ( wh_close w )
+                        }
+                        F e → {
+                            ( nurl_eprintln ( string_data e ) )
+                            ( string_free e )
+                            ( vec_free [f] mel )
+                            = rc 1
+                        }
+                    }
+                }
+                F e → {
+                    ( nurl_eprintln ( string_data e ) )
+                    ( string_free e )
+                    = rc 1
+                }
+            }
+            ( tok_free t )
+        }
+        F e → {
+            ( nurl_eprintln ( string_data e ) )
+            ( string_free e )
+            = rc 1
+        }
+    }
+    ( string_free cfg ) ( string_free wts ) ( string_free tjs )
+    ^ rc
+}
+
 @ main → i {
     : ArgParser p ( args_new `whisper` `Speech recognition in pure NURL (encoder stage).` )
     ( args_opt p `output` 111 `FILE` `write the encoder states here (f32 LE)` )
+    ( args_opt p `lang` 0 `LANG` `transcribe: the language token (default en)` )
+    ( args_opt p `max` 0 `N` `transcribe: stop after N tokens (default 200)` )
     ( args_flag p `help` 104 `show this help` )
     ? ( args_parse_argv p ) {} {
         ( nurl_eprintln ( args_error p ) )
@@ -56,12 +196,29 @@ $ `src/model.nu`
         ( args_free p )
         ^ 0
     } {}
-    ? < ( args_positional_count p ) 4 {
-        ( nurl_eprintln `usage: whisper encode <config.json> <model.safetensors> <audio.wav> -o enc.f32` )
+    ? < ( args_positional_count p ) 3 {
+        ( nurl_eprintln `usage: whisper transcribe <model-dir> <audio.wav> · whisper encode <config.json> <model.safetensors> <audio.wav> -o enc.f32` )
         ( args_free p )
         ^ 2
     } {}
     : ( Vec String ) pos ( args_positionals p )
+    : ~ s cmd0 ``
+    ?? ( vec_get [String] pos 0 ) { T c → { = cmd0 ( string_data c ) } F → {} }
+    ? ( nurl_str_eq cmd0 `transcribe` ) {
+        : ~ s dir ``
+        : ~ s awav ``
+        ?? ( vec_get [String] pos 1 ) { T c → { = dir ( string_data c ) } F → {} }
+        ?? ( vec_get [String] pos 2 ) { T c → { = awav ( string_data c ) } F → {} }
+        : String lang ( args_value_or p `lang` `en` )
+        : ~ i maxtok 200
+        : String smax ( args_value_or p `max` `200` )
+        ?? ( string_to_int smax ) { T v → { = maxtok v } F _ → {} }
+        ( string_free smax )
+        : i rc ( __wh_transcribe dir awav ( string_data lang ) maxtok )
+        ( string_free lang )
+        ( args_free p )
+        ^ rc
+    } {}
     : ~ s cfg ``
     : ~ s wts ``
     : ~ s wav ``

--- a/packages/whisper/src/model.nu
+++ b/packages/whisper/src/model.nu
@@ -62,6 +62,52 @@ $ `src/kernels.nu`
     ( Vec i ) e_fc2_b
     i e_lnf_w
     i e_lnf_b
+    // decoder weights
+    i tok_embd  // also the output projection — whisper ties them
+    i dec_pos
+    ( Vec i ) d_ln1_w
+    ( Vec i ) d_ln1_b
+    ( Vec i ) d_wq
+    ( Vec i ) d_bq
+    ( Vec i ) d_wk  // no bias, like the encoder's
+    ( Vec i ) d_wv
+    ( Vec i ) d_bv
+    ( Vec i ) d_wo
+    ( Vec i ) d_bo
+    ( Vec i ) d_lnx_w  // cross-attention's norm
+    ( Vec i ) d_lnx_b
+    ( Vec i ) x_wq
+    ( Vec i ) x_bq
+    ( Vec i ) x_wk  // no bias
+    ( Vec i ) x_wv
+    ( Vec i ) x_bv
+    ( Vec i ) x_wo
+    ( Vec i ) x_bo
+    ( Vec i ) d_ln2_w
+    ( Vec i ) d_ln2_b
+    ( Vec i ) d_fc1_w
+    ( Vec i ) d_fc1_b
+    ( Vec i ) d_fc2_w
+    ( Vec i ) d_fc2_b
+    i d_lnf_w
+    i d_lnf_b
+    // decoder state
+    ( Vec i ) kcache  // per layer: n_ctx_dec × d_model
+    ( Vec i ) vcache
+    ( Vec i ) xk  // per layer: the encoder's K, computed ONCE
+    ( Vec i ) xv
+    i n_ctx_dec
+    i dx_d  // one token's activation
+    i dxn_d
+    i dq_d
+    i dk_d
+    i dv_d
+    i dao_d
+    i dtmp_d
+    i dff_d
+    i dsc_d  // scores: n_head × max(n_ctx_dec, n_ctx_enc)
+    i logits_d
+    * u logits_host
     // scratch
     i mel_d  // 3000 × n_mels
     i c1_d  // 3000 × d_model
@@ -117,6 +163,23 @@ $ `src/kernels.nu`
     ( string_push_char s2 46 )
     ( string_push_str s2 suffix )
     ^ s2
+}
+
+// model.decoder.layers.<L>.<suffix>
+@ __wh_dname i layer s suffix → String {
+    : String s2 ( string_from `model.decoder.layers.` )
+    ( string_push_int s2 layer )
+    ( string_push_char s2 46 )
+    ( string_push_str s2 suffix )
+    ^ s2
+}
+
+@ __wh_up_dlayer * Whisper w i layer s suffix ( Vec i ) dst → b {
+    : String nm ( __wh_dname layer suffix )
+    : i d ( __wh_up w ( string_data nm ) )
+    ( string_free nm )
+    ( vec_push [i] dst d )
+    ^ >= d 0
 }
 
 @ __wh_up_layer * Whisper w i layer s suffix ( Vec i ) dst → b {
@@ -261,6 +324,76 @@ $ `src/kernels.nu`
         ^ ( __wh_err `whisper: the checkpoint is missing encoder tensors` )
     }
 
+    // ── the decoder ──────────────────────────────────────────────────
+    = . w d_ln1_w ( vec_new [i] )
+    = . w d_ln1_b ( vec_new [i] )
+    = . w d_wq ( vec_new [i] )
+    = . w d_bq ( vec_new [i] )
+    = . w d_wk ( vec_new [i] )
+    = . w d_wv ( vec_new [i] )
+    = . w d_bv ( vec_new [i] )
+    = . w d_wo ( vec_new [i] )
+    = . w d_bo ( vec_new [i] )
+    = . w d_lnx_w ( vec_new [i] )
+    = . w d_lnx_b ( vec_new [i] )
+    = . w x_wq ( vec_new [i] )
+    = . w x_bq ( vec_new [i] )
+    = . w x_wk ( vec_new [i] )
+    = . w x_wv ( vec_new [i] )
+    = . w x_bv ( vec_new [i] )
+    = . w x_wo ( vec_new [i] )
+    = . w x_bo ( vec_new [i] )
+    = . w d_ln2_w ( vec_new [i] )
+    = . w d_ln2_b ( vec_new [i] )
+    = . w d_fc1_w ( vec_new [i] )
+    = . w d_fc1_b ( vec_new [i] )
+    = . w d_fc2_w ( vec_new [i] )
+    = . w d_fc2_b ( vec_new [i] )
+    = . w kcache ( vec_new [i] )
+    = . w vcache ( vec_new [i] )
+    = . w xk ( vec_new [i] )
+    = . w xv ( vec_new [i] )
+
+    = . w tok_embd ( __wh_up w `model.decoder.embed_tokens.weight` )
+    = . w dec_pos ( __wh_up w `model.decoder.embed_positions.weight` )
+    = . w d_lnf_w ( __wh_up w `model.decoder.layer_norm.weight` )
+    = . w d_lnf_b ( __wh_up w `model.decoder.layer_norm.bias` )
+    ? | | | < . w tok_embd 0 < . w dec_pos 0 < . w d_lnf_w 0 < . w d_lnf_b 0 { = ok F } {}
+
+    = L 0
+    ~ & ok < L n_dec {
+        ? ( __wh_up_dlayer w L `self_attn_layer_norm.weight` . w d_ln1_w ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `self_attn_layer_norm.bias` . w d_ln1_b ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `self_attn.q_proj.weight` . w d_wq ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `self_attn.q_proj.bias` . w d_bq ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `self_attn.k_proj.weight` . w d_wk ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `self_attn.v_proj.weight` . w d_wv ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `self_attn.v_proj.bias` . w d_bv ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `self_attn.out_proj.weight` . w d_wo ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `self_attn.out_proj.bias` . w d_bo ) {} { = ok F }
+        // cross-attention: q comes from the decoder, k and v from the ENCODER
+        ? ( __wh_up_dlayer w L `encoder_attn_layer_norm.weight` . w d_lnx_w ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `encoder_attn_layer_norm.bias` . w d_lnx_b ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `encoder_attn.q_proj.weight` . w x_wq ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `encoder_attn.q_proj.bias` . w x_bq ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `encoder_attn.k_proj.weight` . w x_wk ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `encoder_attn.v_proj.weight` . w x_wv ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `encoder_attn.v_proj.bias` . w x_bv ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `encoder_attn.out_proj.weight` . w x_wo ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `encoder_attn.out_proj.bias` . w x_bo ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `final_layer_norm.weight` . w d_ln2_w ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `final_layer_norm.bias` . w d_ln2_b ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `fc1.weight` . w d_fc1_w ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `fc1.bias` . w d_fc1_b ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `fc2.weight` . w d_fc2_w ) {} { = ok F }
+        ? ( __wh_up_dlayer w L `fc2.bias` . w d_fc2_b ) {} { = ok F }
+        = L + L 1
+    }
+    ? ok {} {
+        ( wh_close w )
+        ^ ( __wh_err `whisper: the checkpoint is missing decoder tensors` )
+    }
+
     : i nfr * 2 n_ctx
     : i dm d_model
     = . w mel_d ( __wh_scratch w * nfr n_mels )
@@ -275,6 +408,29 @@ $ `src/kernels.nu`
     = . w ff_d ( __wh_scratch w * n_ctx * 4 dm )
     = . w sc_d ( __wh_scratch w * * n_head n_ctx n_ctx )
     = . w enc_out ( __wh_scratch w * n_ctx dm )
+
+    = . w n_ctx_dec 448
+    = L 0
+    ~ < L n_dec {
+        ( vec_push [i] . w kcache ( __wh_scratch w * . w n_ctx_dec dm ) )
+        ( vec_push [i] . w vcache ( __wh_scratch w * . w n_ctx_dec dm ) )
+        // the encoder's K and V for cross-attention: 1500 × d_model per layer,
+        // computed ONCE per clip rather than once per generated token
+        ( vec_push [i] . w xk ( __wh_scratch w * n_ctx dm ) )
+        ( vec_push [i] . w xv ( __wh_scratch w * n_ctx dm ) )
+        = L + L 1
+    }
+    = . w dx_d ( __wh_scratch w dm )
+    = . w dxn_d ( __wh_scratch w dm )
+    = . w dq_d ( __wh_scratch w dm )
+    = . w dk_d ( __wh_scratch w dm )
+    = . w dv_d ( __wh_scratch w dm )
+    = . w dao_d ( __wh_scratch w dm )
+    = . w dtmp_d ( __wh_scratch w dm )
+    = . w dff_d ( __wh_scratch w * 4 dm )
+    = . w dsc_d ( __wh_scratch w * n_head ? > n_ctx . w n_ctx_dec n_ctx . w n_ctx_dec )
+    = . w logits_d ( __wh_scratch w n_vocab )
+    = . w logits_host ( gpu_host_alloc * n_vocab 4 )
     ^ @ !*Whisper String { T w }
 }
 
@@ -294,6 +450,22 @@ $ `src/kernels.nu`
     ( vec_free [i] . w e_ln2_w ) ( vec_free [i] . w e_ln2_b )
     ( vec_free [i] . w e_fc1_w ) ( vec_free [i] . w e_fc1_b )
     ( vec_free [i] . w e_fc2_w ) ( vec_free [i] . w e_fc2_b )
+    ( vec_free [i] . w d_ln1_w ) ( vec_free [i] . w d_ln1_b )
+    ( vec_free [i] . w d_wq ) ( vec_free [i] . w d_bq )
+    ( vec_free [i] . w d_wk )
+    ( vec_free [i] . w d_wv ) ( vec_free [i] . w d_bv )
+    ( vec_free [i] . w d_wo ) ( vec_free [i] . w d_bo )
+    ( vec_free [i] . w d_lnx_w ) ( vec_free [i] . w d_lnx_b )
+    ( vec_free [i] . w x_wq ) ( vec_free [i] . w x_bq )
+    ( vec_free [i] . w x_wk )
+    ( vec_free [i] . w x_wv ) ( vec_free [i] . w x_bv )
+    ( vec_free [i] . w x_wo ) ( vec_free [i] . w x_bo )
+    ( vec_free [i] . w d_ln2_w ) ( vec_free [i] . w d_ln2_b )
+    ( vec_free [i] . w d_fc1_w ) ( vec_free [i] . w d_fc1_b )
+    ( vec_free [i] . w d_fc2_w ) ( vec_free [i] . w d_fc2_b )
+    ( vec_free [i] . w kcache ) ( vec_free [i] . w vcache )
+    ( vec_free [i] . w xk ) ( vec_free [i] . w xv )
+    ? != . w logits_host 0 { ( gpu_host_free . w logits_host ) } {}
     ? != . w st 0 { ( st_close # *St . w st ) } {}
     ? ( gpu_ok . w g ) { ( wk_free . w ks ) ( gpu_close . w g ) } {}
     ( nurl_free # s w )
@@ -385,4 +557,120 @@ $ `src/kernels.nu`
 
 @ __wh_u32 * u p i o → i {
     ^ | # i . p o | << # i . p + o 1 8 | << # i . p + o 2 16 << # i . p + o 3 24
+}
+
+// ── the decoder ─────────────────────────────────────────────────────
+
+// Cross-attention's K and V come from the ENCODER, and the encoder does not
+// change while a clip is being transcribed. So they are computed ONCE here,
+// after wh_encode — not once per generated token, which would redo 1500×d_model
+// of work for every word.
+@ wh_prepare_cross * Whisper w → v {
+    : i dm . w d_model
+    : i nc . w n_ctx_enc
+    : ~ i L 0
+    ~ < L . w n_dec_layer {
+        ( wk_matvec . w ks ( __wh_geti . w x_wk L ) . w enc_out 0
+        ( __wh_geti . w xk L ) dm dm nc )
+        ( wk_matvec . w ks ( __wh_geti . w x_wv L ) . w enc_out ( __wh_geti . w x_bv L )
+        ( __wh_geti . w xv L ) dm dm nc )
+        = L + L 1
+    }
+}
+
+// One decoder step: token `tok` at position `pos`, with everything before it
+// already in the KV cache. Leaves the logits on the device.
+//
+// The self-attention needs no causal mask: there is exactly ONE query, at the
+// end, and the cache holds only what came before it. Masking is what you do when
+// you process several positions at once.
+@ wh_decode_step * Whisper w i tok i pos → v {
+    : i dm . w d_model
+    : i nh . w n_head
+    : i hd . w head_dim
+    : i nc . w n_ctx_enc
+    : f qscale / 1.0 ( sqrt # f hd )
+    : f eps 0.00001
+
+    // token embedding + the position's own vector (a matrix, one row each)
+    ( wk_getrow . w ks . w tok_embd . w dx_d tok dm )
+    : ( Vec i ) _unused ( vec_new [i] )
+    ( vec_free [i] _unused )
+    ( wk_addv_row w pos )
+
+    : ~ i L 0
+    ~ < L . w n_dec_layer {
+        // ── causal self-attention, over the cache ──
+        ( wk_layernorm . w ks . w dx_d ( __wh_geti . w d_ln1_w L ) ( __wh_geti . w d_ln1_b L )
+        . w dxn_d dm eps 1 )
+        ( wk_matvec . w ks ( __wh_geti . w d_wq L ) . w dxn_d ( __wh_geti . w d_bq L ) . w dq_d dm dm 1 )
+        ( wk_matvec . w ks ( __wh_geti . w d_wk L ) . w dxn_d 0 . w dk_d dm dm 1 )
+        ( wk_matvec . w ks ( __wh_geti . w d_wv L ) . w dxn_d ( __wh_geti . w d_bv L ) . w dv_d dm dm 1 )
+        ( wk_setrow . w ks ( __wh_geti . w kcache L ) . w dk_d pos dm )
+        ( wk_setrow . w ks ( __wh_geti . w vcache L ) . w dv_d pos dm )
+        ( wk_attn . w ks . w dq_d ( __wh_geti . w kcache L ) ( __wh_geti . w vcache L )
+        . w dsc_d . w dao_d nh hd 1 + pos 1 qscale 0 )
+        ( wk_matvec . w ks ( __wh_geti . w d_wo L ) . w dao_d ( __wh_geti . w d_bo L ) . w dtmp_d dm dm 1 )
+        ( wk_addv . w ks . w dx_d . w dtmp_d dm )
+
+        // ── cross-attention into the encoder's 1500 states ──
+        ( wk_layernorm . w ks . w dx_d ( __wh_geti . w d_lnx_w L ) ( __wh_geti . w d_lnx_b L )
+        . w dxn_d dm eps 1 )
+        ( wk_matvec . w ks ( __wh_geti . w x_wq L ) . w dxn_d ( __wh_geti . w x_bq L ) . w dq_d dm dm 1 )
+        ( wk_attn . w ks . w dq_d ( __wh_geti . w xk L ) ( __wh_geti . w xv L )
+        . w dsc_d . w dao_d nh hd 1 nc qscale 0 )
+        ( wk_matvec . w ks ( __wh_geti . w x_wo L ) . w dao_d ( __wh_geti . w x_bo L ) . w dtmp_d dm dm 1 )
+        ( wk_addv . w ks . w dx_d . w dtmp_d dm )
+
+        // ── feed-forward ──
+        ( wk_layernorm . w ks . w dx_d ( __wh_geti . w d_ln2_w L ) ( __wh_geti . w d_ln2_b L )
+        . w dxn_d dm eps 1 )
+        ( wk_matvec . w ks ( __wh_geti . w d_fc1_w L ) . w dxn_d ( __wh_geti . w d_fc1_b L )
+        . w dff_d * 4 dm dm 1 )
+        ( wk_gelu . w ks . w dff_d * 4 dm )
+        ( wk_matvec . w ks ( __wh_geti . w d_fc2_w L ) . w dff_d ( __wh_geti . w d_fc2_b L )
+        . w dtmp_d dm * 4 dm 1 )
+        ( wk_addv . w ks . w dx_d . w dtmp_d dm )
+        = L + L 1
+    }
+    ( wk_layernorm . w ks . w dx_d . w d_lnf_w . w d_lnf_b . w dxn_d dm eps 1 )
+    // logits: the embedding table again — whisper ties input and output
+    ( wk_matvec . w ks . w tok_embd . w dxn_d 0 . w logits_d . w n_vocab dm 1 )
+}
+
+// x += embed_positions[pos]. The row lives inside a matrix, so it is added by
+// pointing at the row rather than by a broadcast.
+@ wk_addv_row * Whisper w i pos → v {
+    : i dm . w d_model
+    : i rowptr + . w dec_pos * * pos dm 4
+    ( wk_addv . w ks . w dx_d rowptr dm )
+}
+
+// The logits of the last step, on the host.
+@ wh_logits * Whisper w → ( Vec f ) {
+    : GpuBuffer b @ GpuBuffer { . w logits_d * . w n_vocab 4 }
+    : i _d ( gpu_download . w logits_host b )
+    : ( Vec f ) out ( vec_with_cap [f] . w n_vocab )
+    : ~ i k 0
+    ~ < k . w n_vocab {
+        ( vec_push [f] out # f ( bits_to_f32 ( __wh_u32 . w logits_host * k 4 ) ) )
+        = k + k 1
+    }
+    ^ out
+}
+
+// argmax — greedy decoding is what whisper does by default, and what the
+// reference implementations are compared at.
+@ wh_argmax ( Vec f ) v → i {
+    : ~ i best 0
+    : ~ f bv -1.0e30
+    : ~ i k 0
+    ~ < k ( vec_len [f] v ) {
+        ?? ( vec_get [f] v k ) {
+            T x → { ? > x bv { = bv x = best k } {} }
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ best
 }

--- a/packages/whisper/tests/whisper_test.sh
+++ b/packages/whisper/tests/whisper_test.sh
@@ -95,5 +95,29 @@ else
     bad "CPU backend run"
 fi
 
+# ── the whole thing: real speech, in and out ────────────────────────
+if curl -sL --max-time 120 -f -o "$WORK/tokenizer.json" \
+    https://huggingface.co/openai/whisper-tiny/resolve/main/tokenizer.json \
+   && curl -sL --max-time 180 -f -o "$WORK/jfk.wav" \
+    https://github.com/ggerganov/whisper.cpp/raw/master/samples/jfk.wav; then
+
+    mkdir -p "$WORK/model"
+    cp "$WORK/config.json" "$WORK/tokenizer.json" "$WORK/model/"
+    cp "$WORK/model.safetensors" "$WORK/model/"
+
+    WANT=" And so my fellow Americans ask not what your country can do for you ask what you can do for your country."
+    GOT=$("$WH" transcribe "$WORK/model" "$WORK/jfk.wav" 2>/dev/null)
+    [ "$GOT" = "$WANT" ] \
+        && ok "real speech transcribes word-for-word as HF transformers does" \
+        || { bad "transcription"; echo "    got:  [$GOT]"; echo "    want: [$WANT]"; }
+
+    GOT_CPU=$(NURL_GPU=cpu "$WH" transcribe "$WORK/model" "$WORK/jfk.wav" 2>/dev/null)
+    [ "$GOT_CPU" = "$GOT" ] \
+        && ok "CPU backend transcribes identically to CUDA" \
+        || { bad "transcription backend parity"; echo "    cpu: [$GOT_CPU]"; }
+else
+    echo "  SKIP transcription (tokenizer.json or the speech sample did not download)"
+fi
+
 echo "== whisper tests: PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
```
$ whisper transcribe ./whisper-tiny jfk.wav
 And so my fellow Americans ask not what your country can do for you ask what you can do for your country.
```

**Word for word what HF transformers produces from the same model** — and the CPU backend produces the same text as CUDA.

The whole chain is pure NURL: WAV → resample → log-mel (`packages/audio`) → safetensors weights (`packages/safetensor`) → encoder + decoder kernels (`packages/gpu`, the same CUDA-C on both backends) → BPE vocabulary (`packages/tokenizer`) → text.

## What the decoder adds

**A KV cache — and no mask.** The causal self-attention needs no causal mask at all: there is exactly **one** query, at the end, and the cache holds only what came before it. Masking is what you do when you process several positions at once.

**Cross-attention** into the encoder's 1500 states — the decoder's queries, the *encoder's* keys and values. Those K and V are computed **once per clip**, not once per generated token, which would redo 1500 × d_model of work for every word.

**The control tokens.** A whisper prompt is `<|startoftranscript|>`, the language, `<|transcribe|>`, `<|notimestamps|>` — the model being *told what task it is doing*. Their ids are **looked up in the checkpoint's own vocabulary, never hardcoded**: whisper-v3 added a language, and every id after it shifted.

## A packaging rule this surfaced

`packages/tokenizer`'s `hf.nu` imported its sibling as `src/tokenizer.nu` — which resolves only from that package's own root, and **breaks the moment the package is a dependency** (`deps/tokenizer/src/…`). The ecosystem's rule, which `gguf` already followed: a package's sibling files do not import each other; the **consumer** imports them in dependency order. Fixed, with the reason written down where the next person will look.

## Verification

| | |
|---|---|
| encoder vs independent numpy reference | max \|Δ\| = 1.4e-3, **r = 1.00000000** |
| that reference vs HF `WhisperModel.encoder` | r = 1.00000000 |
| **real speech (JFK sample) vs HF transformers** | **word for word identical** |
| CPU/OpenMP backend | identical transcription to CUDA |
| ASan/LSan | clean |

**5/5.**

Step 6 of the whisper package (`temp.md`). Next: the CLI proper — long-audio windowing, timestamps, and distil-large-v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH