### PR TITLE
whisper: long audio, and the O(n²) that ate 12.9 of every 14 seconds

### DIFF
--- a/packages/tokenizer/src/hf.nu
+++ b/packages/tokenizer/src/hf.nu
@@ -357,24 +357,36 @@ $ `stdlib/ext/json.nu`
     }
 }
 
-// { piece: id } → pieces indexed BY ID (JSON promises no order)
+// { piece: id } → pieces indexed BY ID (JSON promises nothing about order).
+//
+// Two things are load-bearing here.
+//
+// ONE: this walks the object's PAIRS with json_obj_each. The obvious version —
+// take json_obj_keys, then json_obj_get each key — is QUADRATIC, because
+// json_obj_get scans the object linearly: a 50 258-entry vocabulary costs 2.5
+// billion string comparisons, and loaded whisper's vocabulary in 12.9 seconds.
+// It was found by MEASURING: `whisper transcribe` cost the same 13.7 s whether
+// it generated 1 token or 20, and a flat cost is never the model.
+//
+// TWO: the callback accumulates into VECTORS, not into a counter. A NURL closure
+// captures a struct (a Vec is a boxed handle) by reference, but a SCALAR by
+// value — so `= maxid id` inside the callback would update a copy and the
+// vocabulary would come out empty. It did, until this was written the other way:
+// collect keys and ids in one pass, then size and fill the table from them.
 @ __hf_vocab_into Json voc ( Vec String ) pieces ( Vec i ) types → v {
-    : ( Vec String ) keys ( json_obj_keys voc )
+    : ( Vec String ) keys ( vec_new [String] )
+    : ( Vec i ) ids ( vec_new [i] )
+    ( json_obj_each voc \ s key Json v → v {
+        ? ( json_is_num v ) {
+            ( vec_push [String] keys ( string_from key ) )
+            ( vec_push [i] ids ( json_as_int v ) )
+        } {}
+    } )
     : ~ i maxid -1
     : ~ i k 0
-    ~ < k ( vec_len [String] keys ) {
-        ?? ( vec_get [String] keys k ) {
-            T kn → {
-                ?? ( json_obj_get voc ( string_data kn ) ) {
-                    T v → {
-                        ? ( json_is_num v ) {
-                            : i id ( json_as_int v )
-                            ? > id maxid { = maxid id } {}
-                        } {}
-                    }
-                    F → {}
-                }
-            }
+    ~ < k ( vec_len [i] ids ) {
+        ?? ( vec_get [i] ids k ) {
+            T id → { ? > id maxid { = maxid id } {} }
             F → {}
         }
         = k + k 1
@@ -386,30 +398,28 @@ $ `stdlib/ext/json.nu`
         = k + k 1
     }
     = k 0
-    ~ < k ( vec_len [String] keys ) {
-        ?? ( vec_get [String] keys k ) {
-            T kn → {
-                ?? ( json_obj_get voc ( string_data kn ) ) {
-                    T v → {
-                        ? ( json_is_num v ) {
-                            : i id ( json_as_int v )
-                            ? & >= id 0 <= id maxid {
-                                ?? ( vec_get [String] pieces id ) {
-                                    T old → { ( string_free old ) }
-                                    F → {}
-                                }
-                                ( vec_set [String] pieces id ( string_from ( string_data kn ) ) )
-                            } {}
-                        } {}
+    ~ < k ( vec_len [i] ids ) {
+        ?? ( vec_get [i] ids k ) {
+            T id → {
+                ? & >= id 0 <= id maxid {
+                    ?? ( vec_get [String] keys k ) {
+                        T kn → {
+                            ?? ( vec_get [String] pieces id ) {
+                                T old → { ( string_free old ) }
+                                F → {}
+                            }
+                            ( vec_set [String] pieces id ( string_from ( string_data kn ) ) )
+                        }
+                        F → {}
                     }
-                    F → {}
-                }
+                } {}
             }
             F → {}
         }
         = k + k 1
     }
     ( vec_free_with [String] keys \ String x → v { ( string_free x ) } )
+    ( vec_free [i] ids )
 }
 
 // merges: either ["A B", …] or [["A","B"], …] — tokenizers changed the shape

--- a/packages/whisper/src/main.nu
+++ b/packages/whisper/src/main.nu
@@ -75,6 +75,68 @@ $ `src/model.nu`
     ^ id
 }
 
+// Decode ONE 30-second window: the encoder has already run over it, and the
+// cross-attention K/V are prepared. Appends the text to `out`.
+@ __wh_decode_window * Whisper w * Tok t s lang i maxtok ( Vec u ) out → b {
+    : String ltok ( string_from `<|` )
+    ( string_push_str ltok lang )
+    ( string_push_str ltok `|>` )
+    : i sot ( __wh_special t `<|startoftranscript|>` )
+    : i lid ( __wh_special t ( string_data ltok ) )
+    : i task ( __wh_special t `<|transcribe|>` )
+    : i nots ( __wh_special t `<|notimestamps|>` )
+    : i eot ( __wh_special t `<|endoftext|>` )
+    ( string_free ltok )
+    ? | | | | < sot 0 < lid 0 < task 0 < nots 0 < eot 0 { ^ F } {}
+
+    : ( Vec i ) prompt ( vec_new [i] )
+    ( vec_push [i] prompt sot )
+    ( vec_push [i] prompt lid )
+    ( vec_push [i] prompt task )
+    ( vec_push [i] prompt nots )
+    : ( Vec i ) outids ( vec_new [i] )
+    : ~ i pos 0
+    : ~ i k 0
+    ~ < k ( vec_len [i] prompt ) {
+        ?? ( vec_get [i] prompt k ) {
+            T tk → { ( wh_decode_step w tk pos ) }
+            F → {}
+        }
+        = pos + pos 1
+        = k + k 1
+    }
+    : ~ b done F
+    : ~ i made 0
+    ~ & ! done < made maxtok {
+        : ( Vec f ) lg ( wh_logits w )
+        : i nt ( wh_argmax lg )
+        ( vec_free [f] lg )
+        ? == nt eot { = done T } {
+            ( vec_push [i] outids nt )
+            ( wh_decode_step w nt pos )
+            = pos + pos 1
+            = made + made 1
+        }
+    }
+    : ( Vec u ) txt ( tok_decode t outids )
+    : ~ i j 0
+    ~ < j ( vec_len [u] txt ) {
+        ?? ( vec_get [u] txt j ) {
+            T b → { ( vec_push [u] out b ) }
+            F → {}
+        }
+        = j + j 1
+    }
+    ( vec_free [u] txt )
+    ( vec_free [i] outids )
+    ( vec_free [i] prompt )
+    ^ T
+}
+
+// Audio longer than 30 seconds is transcribed in 30-second WINDOWS: the encoder
+// sees exactly 30 s (that is the length it was trained on and the length its
+// positional embedding has), so a longer clip is split, and each window is
+// decoded from a fresh prompt with its own KV cache.
 @ __wh_transcribe s dir s wavpath s lang i maxtok → i {
     : String cfg ( __wh_path dir `config.json` )
     : String wts ( __wh_path dir `model.safetensors` )
@@ -88,76 +150,55 @@ $ `src/model.nu`
                 T aw → {
                     : ( Vec f ) mono ( wav_mono aw )
                     : ( Vec f ) at16 ( resample mono . aw rate 16000 )
-                    : ( Vec f ) fixed ( pad_or_trim at16 480000 )
-                    : ( Vec f ) mel ( log_mel_whisper fixed 400 160 80 16000 )
                     ( wav_free aw )
-                    ( vec_free [f] mono ) ( vec_free [f] at16 ) ( vec_free [f] fixed )
+                    ( vec_free [f] mono )
                     ?? ( wh_open ( string_data cfg ) ( string_data wts ) ) {
                         T w → {
-                            ( wh_encode w mel )
-                            ( wh_prepare_cross w )
-                            ( vec_free [f] mel )
-
-                            : String ltok ( string_from `<|` )
-                            ( string_push_str ltok lang )
-                            ( string_push_str ltok `|>` )
-                            : i sot ( __wh_special t `<|startoftranscript|>` )
-                            : i lid ( __wh_special t ( string_data ltok ) )
-                            : i task ( __wh_special t `<|transcribe|>` )
-                            : i nots ( __wh_special t `<|notimestamps|>` )
-                            : i eot ( __wh_special t `<|endoftext|>` )
-                            ( string_free ltok )
-                            ? | | | | < sot 0 < lid 0 < task 0 < nots 0 < eot 0 {
-                                ( nurl_eprintln `whisper: the vocabulary has no control tokens (is this a whisper tokenizer.json?)` )
-                                = rc 1
-                            } {
-                                : ( Vec i ) prompt ( vec_new [i] )
-                                ( vec_push [i] prompt sot )
-                                ( vec_push [i] prompt lid )
-                                ( vec_push [i] prompt task )
-                                ( vec_push [i] prompt nots )
-                                : ( Vec i ) outids ( vec_new [i] )
-                                : ~ i pos 0
-                                // feed the prompt, then generate
+                            : i total ( vec_len [f] at16 )
+                            : i window 480000
+                            : i nwin ? > total 0 / + total - window 1 window 1
+                            : ( Vec u ) text ( vec_new [u] )
+                            : ~ b ok T
+                            : ~ i wi 0
+                            ~ & ok < wi nwin {
+                                : i from * wi window
+                                : ( Vec f ) chunk ( vec_new [f] )
                                 : ~ i k 0
-                                ~ < k ( vec_len [i] prompt ) {
-                                    ?? ( vec_get [i] prompt k ) {
-                                        T tk → { ( wh_decode_step w tk pos ) }
+                                ~ & < k window < + from k total {
+                                    ?? ( vec_get [f] at16 + from k ) {
+                                        T x → { ( vec_push [f] chunk x ) }
                                         F → {}
                                     }
-                                    = pos + pos 1
                                     = k + k 1
                                 }
-                                : ~ b done F
-                                : ~ i made 0
-                                ~ & ! done < made maxtok {
-                                    : ( Vec f ) lg ( wh_logits w )
-                                    : i nt ( wh_argmax lg )
-                                    ( vec_free [f] lg )
-                                    ? == nt eot { = done T } {
-                                        ( vec_push [i] outids nt )
-                                        ( wh_decode_step w nt pos )
-                                        = pos + pos 1
-                                        = made + made 1
-                                    }
-                                }
-                                : ( Vec u ) txt ( tok_decode t outids )
-                                : i n ( vec_len [u] txt )
-                                ? > n 0 { : i _w ( write 1 # *u ( vec_data [u] txt ) n ) } {}
-                                ( nurl_print `\n` )
-                                ( vec_free [u] txt )
-                                ( vec_free [i] outids )
-                                ( vec_free [i] prompt )
+                                : ( Vec f ) fixed ( pad_or_trim chunk window )
+                                : ( Vec f ) mel ( log_mel_whisper fixed 400 160 80 16000 )
+                                ( vec_free [f] chunk )
+                                ( vec_free [f] fixed )
+                                ( wh_encode w mel )
+                                ( wh_prepare_cross w )
+                                ( vec_free [f] mel )
+                                ? ( __wh_decode_window w t lang maxtok text ) {} { = ok F }
+                                = wi + wi 1
                             }
+                            ? ok {
+                                : i n ( vec_len [u] text )
+                                ? > n 0 { : i _w ( write 1 # *u ( vec_data [u] text ) n ) } {}
+                                ( nurl_print `\n` )
+                            } {
+                                ( nurl_eprintln `whisper: the vocabulary has no control tokens (is this a whisper tokenizer.json?)` )
+                                = rc 1
+                            }
+                            ( vec_free [u] text )
                             ( wh_close w )
                         }
                         F e → {
                             ( nurl_eprintln ( string_data e ) )
                             ( string_free e )
-                            ( vec_free [f] mel )
                             = rc 1
                         }
                     }
+                    ( vec_free [f] at16 )
                 }
                 F e → {
                     ( nurl_eprintln ( string_data e ) )

--- a/packages/whisper/tests/whisper_test.sh
+++ b/packages/whisper/tests/whisper_test.sh
@@ -115,6 +115,32 @@ if curl -sL --max-time 120 -f -o "$WORK/tokenizer.json" \
     [ "$GOT_CPU" = "$GOT" ] \
         && ok "CPU backend transcribes identically to CUDA" \
         || { bad "transcription backend parity"; echo "    cpu: [$GOT_CPU]"; }
+
+    # audio longer than 30 s: the encoder sees exactly 30 s (that is the length
+    # its positional embedding has), so a longer clip is split into windows
+    python3 - "$WORK" <<'PYEOF2'
+import sys, wave, numpy as np
+W = sys.argv[1]
+w = wave.open(W + '/jfk.wav', 'rb')
+x = np.frombuffer(w.readframes(w.getnframes()), dtype='<i2')
+o = wave.open(W + '/long.wav', 'wb'); o.setnchannels(1); o.setsampwidth(2); o.setframerate(16000)
+o.writeframes(np.tile(x, 3).tobytes()); o.close()
+PYEOF2
+    LONG=$("$WH" transcribe "$WORK/model" "$WORK/long.wav" 2>/dev/null)
+    # three copies of the clip → the sentence three times, across two windows
+    HITS=$(printf '%s' "$LONG" | grep -oi "ask not what your country" | wc -l)
+    [ "$HITS" -eq 3 ] \
+        && ok "33 s of audio transcribes across two 30-second windows (3/3 sentences)" \
+        || { bad "long-audio windowing"; echo "    got ($HITS/3): [$LONG]"; }
+
+    # a flat cost is never the model: loading the vocabulary used to be O(n^2)
+    # and took 12.9 s. It must not creep back.
+    START=$(date +%s%N)
+    "$WH" transcribe "$WORK/model" "$WORK/jfk.wav" >/dev/null 2>&1
+    MS=$(( ($(date +%s%N) - START) / 1000000 ))
+    [ "$MS" -lt 8000 ] \
+        && ok "11 s of speech transcribes in ${MS} ms (the O(n^2) vocabulary load stays dead)" \
+        || bad "transcription took ${MS} ms — something is quadratic again"
 else
     echo "  SKIP transcription (tokenizer.json or the speech sample did not download)"
 fi


### PR DESCRIPTION
## The measurement, not the guess

`whisper transcribe` took **14.2 s** on an 11-second clip. The obvious suspects were the decoder's per-token work — the 51 865 × 384 logits matvec, the cross-attention. So I measured instead:

```
--max 1 token    13.68 s
--max 5 tokens   13.86 s
--max 20 tokens  13.95 s
```

**A flat cost is never the model.** It was loading `tokenizer.json`: **12.88 s**.

The loader took `json_obj_keys` and then `json_obj_get` for each key — and `json_obj_get` scans the object **linearly**. A 50 258-entry vocabulary is **2.5 billion string comparisons**. Walking the object's pairs once with `json_obj_each` instead:

| | before | after |
|---|---|---|
| `tokenizer.json` load | 12.88 s | **0.05 s** (250×) |
| 11 s of speech, end to end | 14.2 s | **1.15 s** (~10× realtime) |

## A language corner it surfaced

The first rewrite came back with an **empty vocabulary**. NURL closures capture a struct (a `Vec` is a boxed handle) **by reference**, but a **scalar by value** — so `= maxid id` inside the callback updated a copy, no pieces were sized, and the tokenizer produced nothing.

The callback now accumulates into **vectors**, which are handles. The comment says why, so the next person doesn't rediscover it the same way.

## Long audio

The encoder sees exactly 30 seconds — that is the length it was trained on, and the length its positional embedding *has*. So longer audio is split into 30-second **windows**, each decoded from a fresh prompt with its own KV cache. 33 s of speech (the clip three times) comes back as the sentence three times, across two windows, in 1.65 s.

## Verification

**7/7**, ASan clean:

* encoder vs independent numpy reference — r = 1.00000000
* real speech vs HF transformers — word for word
* CPU/OpenMP backend — identical transcription
* long-audio windowing — 3/3 sentences across two windows
* **a regression test that fails if a transcription ever takes more than 8 s again** — the quadratic load stays dead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH