### PR TITLE
whisper: distil-large-v3 — and the four things it found

### DIFF
--- a/packages/audio/src/main.nu
+++ b/packages/audio/src/main.nu
@@ -51,6 +51,7 @@ $ `src/resample.nu`
     ( args_opt p `output` 111 `FILE` `for mel: write the f32-LE spectrogram here` )
     ( args_opt p `rate` 0 `HZ` `for resample/tone: the target sample rate (default 16000)` )
     ( args_opt p `seconds` 0 `S` `for tone: length in seconds (default 1)` )
+    ( args_opt p `mels` 0 `N` `for mel: how many mel bands (default 80; whisper large-v3 wants 128)` )
     ( args_flag p `help` 104 `show this help` )
     ? ( args_parse_argv p ) {} {
         ( nurl_eprintln ( args_error p ) )
@@ -133,16 +134,22 @@ $ `src/resample.nu`
                 ( __say m )
             } {}
             ? ( nurl_str_eq cmd `mel` ) {
+                : ~ i nmel 80
+                : String smel ( args_value_or p `mels` `80` )
+                ?? ( string_to_int smel ) { T v → { = nmel v } F _ → {} }
+                ( string_free smel )
                 : ( Vec f ) mono ( wav_mono w )
                 : ( Vec f ) at16 ( resample mono . w rate 16000 )
                 // whisper always feeds its encoder exactly 30 s
                 : ( Vec f ) fixed ( pad_or_trim at16 480000 )
-                : ( Vec f ) mel ( log_mel_whisper fixed 400 160 80 16000 )
+                : ( Vec f ) mel ( log_mel_whisper fixed 400 160 nmel 16000 )
                 : String o ( args_value_or p `output` `mel.f32` )
                 = rc ( __write_f32 ( string_data o ) mel )
                 : String m ( string_from `mel — ` )
-                ( string_push_int m / ( vec_len [f] mel ) 80 )
-                ( string_push_str m ` frames x 80 mels → ` )
+                ( string_push_int m / ( vec_len [f] mel ) nmel )
+                ( string_push_str m ` frames x ` )
+                ( string_push_int m nmel )
+                ( string_push_str m ` mels → ` )
                 ( string_push_str m ( string_data o ) )
                 ( __say m )
                 ( string_free o )

--- a/packages/whisper/README.md
+++ b/packages/whisper/README.md
@@ -15,6 +15,16 @@ $ whisper transcribe ./whisper-tiny jfk.wav
 Word for word what HF transformers produces from the same model — and the
 CPU backend produces the same text as CUDA.
 
+Bigger models just work, because nothing is hardcoded to a shape:
+
+```
+$ whisper transcribe ./distil-large-v3 jfk.wav
+ And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country.
+```
+
+(128 mel bands instead of 80, 1280-wide, 32 encoder layers and 2 decoder
+layers — every one of those read out of the model's own `config.json`.)
+
 A model directory is what Hugging Face ships: `config.json`,
 `model.safetensors`, `tokenizer.json`, side by side.
 
@@ -30,7 +40,7 @@ independent implementation rather than against my own understanding of it:
 | n_fft = 400 (not a power of two) | `stdlib/std/fft.nu` | numpy's `np.fft` — Bluestein, 1.9e-14 |
 | weights | `safetensor` | 167 tensors bit-exact; a whole forward pass at r = 1.00000000 |
 | vocabulary | `tokenizer` | HF's own tokenizer, 20/20 strings |
-| encoder + decoder | this package | HF's `WhisperModel.encoder` (r = 1.00000000) and its transcription, word for word |
+| encoder + decoder | this package | HF's `WhisperModel.encoder` (r = 1.00000000) and its transcription, word for word — on whisper-tiny **and** distil-large-v3 |
 
 ## Whisper is not the llama shape
 

--- a/packages/whisper/src/main.nu
+++ b/packages/whisper/src/main.nu
@@ -152,10 +152,21 @@ $ `src/model.nu`
                     : ( Vec f ) at16 ( resample mono . aw rate 16000 )
                     ( wav_free aw )
                     ( vec_free [f] mono )
+                    // The model is opened BEFORE the spectrogram is computed:
+                    // how many mel bands it wants is a property of the model
+                    // (80 for whisper-tiny … large-v2, 128 for large-v3 and
+                    // distil-large-v3), and a hardcoded 80 would feed the
+                    // large-v3 encoder a spectrogram of the wrong shape.
                     ?? ( wh_open ( string_data cfg ) ( string_data wts ) ) {
                         T w → {
+                            : i nmel . w n_mels
                             : i total ( vec_len [f] at16 )
-                            : i window 480000
+                            // the window is the encoder's own length: 1500
+                            // positions × 2 (the stride-2 conv) × 160 samples of
+                            // hop = 30 s at 16 kHz. Derived, not assumed — a
+                            // model with a different context would want a
+                            // different window.
+                            : i window * . w n_ctx_enc 320
                             : i nwin ? > total 0 / + total - window 1 window 1
                             : ( Vec u ) text ( vec_new [u] )
                             : ~ b ok T
@@ -172,7 +183,7 @@ $ `src/model.nu`
                                     = k + k 1
                                 }
                                 : ( Vec f ) fixed ( pad_or_trim chunk window )
-                                : ( Vec f ) mel ( log_mel_whisper fixed 400 160 80 16000 )
+                                : ( Vec f ) mel ( log_mel_whisper fixed 400 160 nmel 16000 )
                                 ( vec_free [f] chunk )
                                 ( vec_free [f] fixed )
                                 ( wh_encode w mel )
@@ -271,14 +282,21 @@ $ `src/model.nu`
         T aw → {
             : ( Vec f ) mono ( wav_mono aw )
             : ( Vec f ) at16 ( resample mono . aw rate 16000 )
-            : ( Vec f ) fixed ( pad_or_trim at16 480000 )
-            : ( Vec f ) mel ( log_mel_whisper fixed 400 160 80 16000 )
             ( wav_free aw )
             ( vec_free [f] mono )
-            ( vec_free [f] at16 )
-            ( vec_free [f] fixed )
+            // at16 is NOT freed here: the model has to be opened first (how many
+            // mel bands it wants and how long a window it sees are ITS
+            // properties), and pad_or_trim reads at16 after that. Freeing it
+            // early was a use-after-free that whisper-tiny survived by luck —
+            // the freed pages were still intact — and distil-large-v3 turned
+            // into a segfault. A Vec is a shared boxed handle; free it once, at
+            // the end, on every path.
             ?? ( wh_open cfg wts ) {
                 T w → {
+                    : ( Vec f ) fixed ( pad_or_trim at16 * . w n_ctx_enc 320 )
+                    : ( Vec f ) mel ( log_mel_whisper fixed 400 160 . w n_mels 16000 )
+                    ( vec_free [f] fixed )
+                    ( vec_free [f] at16 )
                     ( wh_encode w mel )
                     : ( Vec f ) enc ( wh_enc_out w )
                     : String o ( args_value_or p `output` `enc.f32` )
@@ -301,7 +319,7 @@ $ `src/model.nu`
                 F e → {
                     ( nurl_eprintln ( string_data e ) )
                     ( string_free e )
-                    ( vec_free [f] mel )
+                    ( vec_free [f] at16 )
                     ( args_free p )
                     ^ 1
                 }

--- a/packages/whisper/src/model.nu
+++ b/packages/whisper/src/model.nu
@@ -35,6 +35,8 @@ $ `src/kernels.nu`
     i d_model
     i n_head
     i head_dim
+    i d_head  // the DECODER's head count — the same in every
+    i d_head_dim  // whisper so far, but the config states both
     i n_enc_layer
     i n_dec_layer
     i n_ctx_enc  // 1500 encoder positions
@@ -210,10 +212,12 @@ $ `src/kernels.nu`
     : ~ i n_mels 80
     : ~ i d_model 384
     : ~ i n_head 6
+    : ~ i n_dhead 6
     : ~ i n_enc 4
     : ~ i n_dec 4
     : ~ i n_ctx 1500
     : ~ i n_vocab 51865
+    : ~ i n_dctx 448
     ?? ( read_file config_path ) {
         T txt → {
             ?? ( json_parse ( string_data txt ) ) {
@@ -221,10 +225,12 @@ $ `src/kernels.nu`
                     = n_mels ( __wh_cfg_int root `num_mel_bins` 80 )
                     = d_model ( __wh_cfg_int root `d_model` 384 )
                     = n_head ( __wh_cfg_int root `encoder_attention_heads` 6 )
+                    = n_dhead ( __wh_cfg_int root `decoder_attention_heads` n_head )
                     = n_enc ( __wh_cfg_int root `encoder_layers` 4 )
                     = n_dec ( __wh_cfg_int root `decoder_layers` 4 )
                     = n_ctx ( __wh_cfg_int root `max_source_positions` 1500 )
                     = n_vocab ( __wh_cfg_int root `vocab_size` 51865 )
+                    = n_dctx ( __wh_cfg_int root `max_target_positions` 448 )
                     ( json_free root )
                     ( string_free txt )
                 }
@@ -248,6 +254,8 @@ $ `src/kernels.nu`
     = . w d_model d_model
     = . w n_head n_head
     = . w head_dim / d_model n_head
+    = . w d_head n_dhead
+    = . w d_head_dim / d_model n_dhead
     = . w n_enc_layer n_enc
     = . w n_dec_layer n_dec
     = . w n_ctx_enc n_ctx
@@ -409,7 +417,9 @@ $ `src/kernels.nu`
     = . w sc_d ( __wh_scratch w * * n_head n_ctx n_ctx )
     = . w enc_out ( __wh_scratch w * n_ctx dm )
 
-    = . w n_ctx_dec 448
+    // how many tokens the decoder can hold — its positional embedding's own
+    // length, which the config states
+    = . w n_ctx_dec n_dctx
     = L 0
     ~ < L n_dec {
         ( vec_push [i] . w kcache ( __wh_scratch w * . w n_ctx_dec dm ) )
@@ -586,8 +596,8 @@ $ `src/kernels.nu`
 // you process several positions at once.
 @ wh_decode_step * Whisper w i tok i pos → v {
     : i dm . w d_model
-    : i nh . w n_head
-    : i hd . w head_dim
+    : i nh . w d_head
+    : i hd . w d_head_dim
     : i nc . w n_ctx_enc
     : f qscale / 1.0 ( sqrt # f hd )
     : f eps 0.00001

--- a/packages/whisper/tests/whisper_test.sh
+++ b/packages/whisper/tests/whisper_test.sh
@@ -145,5 +145,31 @@ else
     echo "  SKIP transcription (tokenizer.json or the speech sample did not download)"
 fi
 
+# ── distil-large-v3: 128 mel bands, 1280-wide, 32 encoder layers ────
+# Opt-in: the checkpoint is 1.5 GB. It is the test that catches anything
+# hardcoded to whisper-tiny's shape — and it caught three things (the 80-band
+# spectrogram, the decoder's head count, the decoder's context length) plus a
+# use-after-free that tiny survived by luck.
+if [ "${WHISPER_BIG_TESTS:-0}" = "1" ]; then
+    mkdir -p "$WORK/distil"
+    if curl -sL --max-time 3600 -f -o "$WORK/distil/model.safetensors" \
+        https://huggingface.co/distil-whisper/distil-large-v3/resolve/main/model.safetensors \
+       && curl -sL --max-time 120 -f -o "$WORK/distil/config.json" \
+        https://huggingface.co/distil-whisper/distil-large-v3/resolve/main/config.json \
+       && curl -sL --max-time 120 -f -o "$WORK/distil/tokenizer.json" \
+        https://huggingface.co/distil-whisper/distil-large-v3/resolve/main/tokenizer.json; then
+
+        WANT_D=" And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country."
+        GOT_D=$("$WH" transcribe "$WORK/distil" "$WORK/jfk.wav" 2>/dev/null)
+        [ "$GOT_D" = "$WANT_D" ] \
+            && ok "distil-large-v3 (128 mels, 1280-wide, 32+2 layers) transcribes as HF does" \
+            || { bad "distil-large-v3"; echo "    got:  [$GOT_D]"; echo "    want: [$WANT_D]"; }
+    else
+        echo "  SKIP distil-large-v3 (download failed)"
+    fi
+else
+    echo "  SKIP distil-large-v3 (1.5 GB — set WHISPER_BIG_TESTS=1 to run it)"
+fi
+
 echo "== whisper tests: PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
```
$ whisper transcribe ./distil-large-v3 jfk.wav
 And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country.
```

**Word for word what HF transformers produces from the same model.** 128 mel bands instead of 80, 1280-wide, 32 encoder layers and 2 decoder layers — and *none of that is in the code*: it is read out of the model's own `config.json`.

## Running the big model is not a victory lap

It is the test that catches everything quietly hardcoded to whisper-tiny's shape. **It caught four things.**

**1. The spectrogram was always 80 bands.** The model read `num_mel_bins` from its config — and then the CLI computed the mel with a literal `80`. large-v3 and distil want **128**, so the encoder would have been handed a spectrogram of the wrong shape. The model is now opened *before* the spectrogram is computed, because how many bands it wants is **its** property.

(`packages/audio`'s mel CLI gained `--mels` for the same reason. Its filter bank was already parametric — its 128-band output matches HF's distil feature extractor at **r = 1.00000000 without a single change**, because it was written from the spec rather than for one model.)

**2. The decoder used the encoder's head count.** Every whisper so far has the same number in both, and the config states them separately. Now both are read.

**3. The decoder's context and the 30-second window were constants.** The first is `max_target_positions`. The second is *derivable* from the encoder's own length: 1500 positions × 2 (the stride-2 conv) × 160 samples of hop = 30 s at 16 kHz. Both now are.

**4. A use-after-free.** `at16` was freed before `wh_open`, and `pad_or_trim` read it afterwards. whisper-tiny **survived it by luck** — the freed pages were still intact — and distil-large-v3 turned it into a segfault. A `Vec` is a shared boxed handle: free it once, at the end, on every path.

## Verification

**7/7**, ASan clean on both models, whisper-tiny unchanged.

distil is opt-in behind `WHISPER_BIG_TESTS=1` (the checkpoint is 1.5 GB), and the suite compares its transcription against HF's word for word.

---

This closes the whisper goal: **`packages/whisper` works like whisper.cpp, in pure NURL, from a safetensors model** — and every stage of it is verified against an independent implementation rather than against my own understanding of it.

| stage | verified against |
|---|---|
| WAV → 16 kHz | scipy's `resample_poly` (r = 0.99992); out-of-band tone killed by 82 dB |
| → log-mel | HF's `WhisperFeatureExtractor` — r = 1.00000000, on 80 **and** 128 bands |
| n_fft = 400 (not a power of two) | numpy's `np.fft` — Bluestein, 1.9e-14 |
| weights | 167 tensors bit-exact; a whole forward pass at r = 1.00000000 |
| vocabulary | HF's own tokenizer, 20/20 strings |
| encoder | HF's `WhisperModel.encoder` — r = 1.00000000 |
| transcription | HF transformers — word for word, on whisper-tiny **and** distil-large-v3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH