### PR TITLE
release: v0.14.0 — the speech release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-07-13
+
+The **speech** release: NURL now transcribes real audio with real models,
+and the ecosystem grew the four packages that took it there.
+
+### Added
+
+- **`stdlib/std/fft.nu`** — the discrete Fourier transform, for **any**
+  length. A radix-2 FFT covers powers of two; whisper's spectrogram wants
+  `n_fft = 400`, which is not one, and padding to 512 computes a
+  *different* transform rather than a rounder one. So arbitrary N is
+  handled properly, by **Bluestein's algorithm**: relative error 1.9e-14
+  at N=400 and 7.3e-15 at the prime 997, against numpy — the
+  arbitrary-length path is as accurate as the easy one. A plan
+  precomputes the twiddles and the transformed chirp, so an STFT does not
+  pay the setup per frame: whisper's whole 30-second mel spectrogram
+  (3000 frames) takes 0.30 s.
+  - The test suite pins the transform with **identities**, because its
+    round trip passed while the forward transform was wrong: the inverse
+    was wrong in the compensating way. `δ[1] → e^(−2πik/N)` pins the sign;
+    `ifft(fft(x)) == x` pins nothing on its own.
+
+- **`nurlpkg publish` refuses a package the installed toolchain cannot
+  build.** A package's `$ \`stdlib/…\`` imports are resolved by whatever
+  toolchain the USER has — so a package importing a stdlib file added
+  since the last release publishes cleanly and then fails to install for
+  everyone. It happened (packages/audio against this release's
+  `stdlib/std/fft.nu`), and the gate now names the missing files and the
+  toolchain that lacks them.
+
+### Ecosystem (published to the registry)
+
+- **`safetensor` 0.1.0** — the container Hugging Face ships every model
+  in, parsed as hostile input: the header length is checked against the
+  real file size before the JSON is looked at, every tensor's extent must
+  land inside the data region and be exactly what its dtype and shape
+  need, and element counts accumulate with an overflow check. Proven by a
+  whole forward pass: gemma-3-270m from its checkpoint reproduces HF's
+  own logits at **r = 1.00000000**.
+- **`tokenizer` 0.1.0** — nurllama's SentencePiece and byte-level BPE
+  engines, lifted out and made loader-agnostic: a vocabulary can arrive
+  from a GGUF's metadata or from HF's `tokenizer.json`. The HF oracle
+  found a **years-old bug**: GPT-2's `\s+(?!\S)` gives the last space of
+  a run *back* to the next token, and the default pre-tokenizer was
+  swallowing it.
+- **`audio` 0.1.0** — WAV (untrusted input), windowed-sinc resampling
+  (linear interpolation aliases the speech band), and whisper's log-mel
+  to the constant — matching HF's `WhisperFeatureExtractor` at
+  **r = 1.00000000** on both 80 and 128 bands.
+- **`whisper` 0.1.0** — speech recognition in pure NURL, from a
+  safetensors checkpoint, on the GPU or the CPU. **Word for word what HF
+  transformers produces**, on whisper-tiny *and* distil-large-v3.
+  LayerNorm rather than RMSNorm, error-function GELU rather than tanh,
+  two conv1d layers, cross-attention, and the ecosystem's first
+  **non-causal** attention — a speech encoder hears the whole clip at
+  once.
+- **`nurllama` 0.8.0** — the tokenizer engine now comes from the package;
+  its loader is the 128 lines that read `tokenizer.ggml.*`. Weights can
+  also come from a safetensors file (`--weights`), which is how the
+  safetensor reader is proven.
+
+### Fixed
+
+- **A quadratic vocabulary load.** `whisper transcribe` cost 14.2 s on an
+  11-second clip — and the same 13.7 s whether it generated 1 token or
+  20. A flat cost is never the model: `tokenizer.json` was being read with
+  `json_obj_get` per key, which scans linearly, so a 50 258-entry
+  vocabulary was 2.5 billion string comparisons. 12.88 s → **0.05 s**.
+
+
 ## [0.13.0] — 2026-07-12
 
 The **local-LLM release**. NURL now runs language models end to end — a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-07-12 · Current release: **0.13.0** · Language: **Grammar
+_Last reviewed: 2026-07-13 · Current release: **0.14.0** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---
@@ -177,12 +177,27 @@ platform-specific shims.
   Verified against independent references at every layer: token IDs vs a
   SentencePiece implementation, logits and greedy text vs a numpy forward
   pass, dequantisation bit-identical to an independent decoder.
+- **Speech recognition, in pure NURL** (`whisper` + `audio` + `safetensor` +
+  `tokenizer`): a WAV goes in and text comes out — *word for word what
+  Hugging Face transformers produces from the same model*, on whisper-tiny
+  and on distil-large-v3, on the GPU or the CPU. Every stage is verified
+  against an independent implementation rather than against our own
+  understanding of it: the resampler against scipy, the log-mel against HF's
+  own feature extractor (r = 1.00000000, on both 80 and 128 bands), the
+  400-point FFT against numpy (Bluestein, because 400 is not a power of two
+  and padding it computes a *different* transform), the weights bit-exact,
+  the vocabulary against HF's tokenizer, the encoder against HF's encoder,
+  and the transcription against HF's. Whisper is not the llama shape —
+  LayerNorm rather than RMSNorm, error-function GELU rather than tanh, two
+  conv1d layers, cross-attention, and the ecosystem's first **non-causal**
+  attention.
 - **Package ecosystem** on the live registry (`reg.nurl-lang.org`,
   `nurlpkg install`): GPU compute (`gpu` — CUDA driver + NVRTC, a CPU
   fallback backend, a static-kernel backend, and a **WebGPU / WGSL backend**;
   `gpukit`, `tensor`), pure-NURL vision and ML (`image` PNG/JPEG codecs,
   `onnx` runtime, `objdet`, `yoloe`, `iforest`, `anomaly`), local LLMs
-  (`nurllama`, `gguf`), distributed compute (`swarm`, `swarm-mcp`), web
+  (`nurllama`, `gguf`, `tokenizer`, `safetensor`), speech (`whisper`,
+  `audio`), distributed compute (`swarm`, `swarm-mcp`), web
   (`template` HTML templating, `http`), database clients (`psql`, `redis`
   — pure NURL), and application scaffolding (`cli`, `cas`, `wasmbuilder`,
   `nurl-mcp`).

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -1605,6 +1605,162 @@ $ `stdlib/std/bytes.nu`
 
 // 0 = every deps/ import is declared; 1 = something is missing (message
 // already printed).
+
+// ── gate: does this package build against the RELEASED toolchain? ────
+//
+// A package's `$ `stdlib/…`` imports are resolved by whatever toolchain the
+// USER has installed — not by the repo it was developed in. So a package that
+// imports a stdlib file added since the last release publishes cleanly and then
+// fails to install for everyone, with a `cannot open 'stdlib/std/fft.nu'` that
+// points at the toolchain rather than at the package.
+//
+// That happened: packages/audio was published against a stdlib/std/fft.nu that
+// only existed on main. The fix is not to remember — it is this gate. Every
+// stdlib path a package imports must exist in the INSTALLED toolchain's stdlib
+// ($NURL_STDLIB, or ~/.nurl/stdlib), and publishing is refused when one does
+// not, with the release that is missing named.
+@ __scan_stdlib_imports_file s path ( Vec String ) acc → v {
+    ?? ( read_file path ) {
+        T txt → {
+            : s src ( string_data txt )
+            : i n ( nurl_str_len src )
+            : ~ i i 0
+            ~ < i n {
+                // `$` at the start of a line, then a backtick, then "stdlib/"
+                : ~ b at_line T
+                ? == ( nurl_str_get src i ) 36 {
+                    : ~ i bk - i 1
+                    ~ & >= bk 0 at_line {
+                        : i cb ( nurl_str_get src bk )
+                        ? == cb 10 { = bk -1 } {
+                            ? | == cb 32 == cb 9 { = bk - bk 1 } { = at_line F }
+                        }
+                    }
+                } { = at_line F }
+                ? & at_line == ( nurl_str_get src i ) 36 {
+                    : ~ i q + i 1
+                    ~ & < q n == ( nurl_str_get src q ) 32 { = q + q 1 }
+                    ? & < q n == ( nurl_str_get src q ) 96 {
+                        : i d0 + q 1
+                        : String nm ( string_new )
+                        : ~ i j d0
+                        ~ & < j n != ( nurl_str_get src j ) 96 {
+                            ( string_push_char nm ( nurl_str_get src j ) )
+                            = j + j 1
+                        }
+                        ? != 0 ( nurl_str_starts ( string_data nm ) `stdlib/` ) {
+                            ? ( __vec_has_str acc ( string_data nm ) ) { ( string_free nm ) }
+                            { ( vec_push [String] acc nm ) }
+                        } { ( string_free nm ) }
+                        = i j
+                    } {}
+                } {}
+                = i + i 1
+            }
+            ( string_free txt )
+        }
+        F _ → {}
+    }
+}
+
+@ __scan_stdlib_imports → ( Vec String ) {
+    : ( Vec String ) found ( vec_new [String] )
+    : ( Vec String ) pats ( vec_new [String] )
+    ( vec_push [String] pats ( string_from `src/*.nu` ) )
+    ( vec_push [String] pats ( string_from `src/**/*.nu` ) )
+    : ~ i pi 0
+    ~ < pi ( vec_len [String] pats ) {
+        ?? ( vec_get [String] pats pi ) {
+            T pat → {
+                ?? ( fs_glob ( string_data pat ) ) {
+                    T files → {
+                        : ~ i fi 0
+                        ~ < fi ( vec_len [String] files ) {
+                            ?? ( vec_get [String] files fi ) {
+                                T f → { ( __scan_stdlib_imports_file ( string_data f ) found ) }
+                                F → {}
+                            }
+                            = fi + fi 1
+                        }
+                        ( vec_free_with [String] files \ String x → v { ( string_free x ) } )
+                    }
+                    F _ → {}
+                }
+            }
+            F → {}
+        }
+        = pi + pi 1
+    }
+    ( vec_free_with [String] pats \ String x → v { ( string_free x ) } )
+    ^ found
+}
+
+// The stdlib the USER's toolchain will use: $NURL_STDLIB when set, else
+// ~/.nurl (the installer's prefix).
+@ __toolchain_stdlib_root → String {
+    ?? ( env_get `NURL_STDLIB` ) {
+        T v → {
+            // an EMPTY NURL_STDLIB is not a stdlib — treat it as unset
+            ? > ( string_len v ) 0 { ^ v } {}
+            ( string_free v )
+        }
+        F → {}
+    }
+    ?? ( env_get `HOME` ) {
+        T h → {
+            : String p2 ( string_from ( string_data h ) )
+            ( string_push_str p2 `/.nurl` )
+            ( string_free h )
+            ^ p2
+        }
+        F → {}
+    }
+    ^ ( string_new )
+}
+
+@ __check_stdlib_available → i {
+    : String root ( __toolchain_stdlib_root )
+    ? == 0 ( string_len root ) {
+        ( string_free root )
+        ^ 0
+    } {}
+    : ( Vec String ) used ( __scan_stdlib_imports )
+    : ~ i missing 0
+    : ~ i k 0
+    ~ < k ( vec_len [String] used ) {
+        ?? ( vec_get [String] used k ) {
+            T rel → {
+                : String full ( string_from ( string_data root ) )
+                ( string_push_char full 47 )
+                ( string_push_str full ( string_data rel ) )
+                ? ( file_exists ( string_data full ) ) {} {
+                    ? == missing 0 {
+                        ( nurl_eprintln `nurlpkg: this package imports stdlib files that the INSTALLED toolchain does not have:` )
+                    } {}
+                    : String m ( string_from `  ` )
+                    ( string_push_str m ( string_data rel ) )
+                    ( nurl_eprintln ( string_data m ) )
+                    ( string_free m )
+                    = missing + missing 1
+                }
+                ( string_free full )
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [String] used \ String x → v { ( string_free x ) } )
+    ? > missing 0 {
+        : String m ( string_from `nurlpkg: they exist in the repo but not in ` )
+        ( string_push_str m ( string_data root ) )
+        ( string_push_str m ` — so this package would publish cleanly and then fail to install for everyone. Cut a toolchain release that ships them first (or set NURL_STDLIB to the toolchain you are targeting).` )
+        ( nurl_eprintln ( string_data m ) )
+        ( string_free m )
+    } {}
+    ( string_free root )
+    ^ ? > missing 0 1 0
+}
+
 @ __check_declared_deps Manifest m → i {
     : ( Vec String ) used ( __scan_dep_imports )
     : ~ i missing 0
@@ -1909,6 +2065,10 @@ $ `stdlib/std/bytes.nu`
                 = rc 1
             } {
                 ? != 0 ( __check_declared_deps m ) {
+                    ( manifest_free m )
+                    ^ 1
+                } {}
+                ? != 0 ( __check_stdlib_available ) {
                     ( manifest_free m )
                     ^ 1
                 } {}


### PR DESCRIPTION
NURL transcribes real audio with real models. A WAV goes in and text comes out — **word for word what HF transformers produces from the same model**, on whisper-tiny *and* distil-large-v3, on the GPU or the CPU.

```
$ whisper transcribe ./distil-large-v3 jfk.wav
 And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country.
```

## What's in it

**stdlib**: `std/fft.nu` — the DFT for **any** length. Whisper's spectrogram wants `n_fft = 400`, which is not a power of two, and padding to 512 computes a *different* transform rather than a rounder one. Bluestein's algorithm, at machine precision against numpy (1.9e-14 at N=400, 7.3e-15 at the prime 997).

**Ecosystem** (published): `safetensor` 0.1.0, `tokenizer` 0.1.0, `audio` 0.1.0, `whisper` 0.1.0, `nurllama` 0.8.0.

## The gate this release exists for

`nurlpkg publish` now **refuses a package the installed toolchain cannot build**.

A package's `$ \`stdlib/…\`` imports are resolved by whatever toolchain the **user** has — not by the repo it was developed in. So a package importing a stdlib file added *since the last release* publishes cleanly and then fails to install **for everyone**, with an error that points at the toolchain rather than at the package.

That happened, an hour ago:

```
$ nurlpkg install whisper
  safetensor 0.1.0 (registry)
  tokenizer 0.1.0 (registry)
  audio 0.1.0 (registry)
nurlpkg: compile failed:
nurlc: cannot open 'stdlib/std/fft.nu'
```

The gate now says so *before* publishing:

```
nurlpkg: this package imports stdlib files that the INSTALLED toolchain does not have:
  stdlib/std/fft.nu
nurlpkg: they exist in the repo but not in /home/wau/.nurl — so this package would
publish cleanly and then fail to install for everyone. Cut a toolchain release that
ships them first (or set NURL_STDLIB to the toolchain you are targeting).
```

Compiler suite 538/538, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH