### PR TITLE
whisper: 11.6 s → 2.2 s — don't copy what you can point at, and don't read the weights 1500 times

### DIFF
--- a/packages/safetensor/src/safetensor.nu
+++ b/packages/safetensor/src/safetensor.nu
@@ -537,11 +537,24 @@ $ `stdlib/ext/json.nu`
         ^ ( __st_err_vec `safetensor: element range outside the tensor` )
     } {}
     : *u p # *u + # i . s map off
+    // The output is SIZED ONCE and written through a raw pointer.
+    //
+    // The obvious loop — push four bytes per element — pays a capacity check per
+    // byte, and a 378-million-element F16 checkpoint is 1.5 BILLION of them: it
+    // cost 11.3 seconds of a whisper transcription, while reading the same 1.5 GB
+    // off disk takes 0.25 s. Same arithmetic, same result, one allocation.
     : ( Vec u ) out ( vec_with_cap [u] * count 4 )
+    : b _sz ( vec_set_len [u] out * count 4 )
+    : *u q ( vec_data [u] out )
     : ~ i k 0
     ~ < k count {
         : f v ( __st_read_f p dt + first k )
-        ( bytes_push_u32_le out # u32 ( f32_to_bits # f32 v ) )
+        : i bits # i ( f32_to_bits # f32 v )
+        : i o * k 4
+        = . q o # u & bits 255
+        = . q + o 1 # u & >> bits 8 255
+        = . q + o 2 # u & >> bits 16 255
+        = . q + o 3 # u & >> bits 24 255
         = k + k 1
     }
     ^ @ !( Vec u ) String { T out }

--- a/packages/whisper/src/kernels.nu
+++ b/packages/whisper/src/kernels.nu
@@ -36,6 +36,8 @@ $ `deps/gpu/src/gpu.nu`
     GpuKernel addv
     GpuKernel addrow
     GpuKernel scale
+    GpuKernel cvt_f16  // f16/bf16 weights → f32, ON THE DEVICE
+    GpuKernel cvt_bf16
     GpuKernel getrow  // one row of the embedding table → the activation
     GpuKernel setrow  // write a row INTO the KV cache
     b ok
@@ -194,6 +196,60 @@ $ `deps/gpu/src/gpu.nu`
     }`
 }
 
+// Widen f16 / bf16 weights to f32 ON THE DEVICE.
+//
+// A whisper checkpoint is f16, and the host loop that widened it — one function
+// call and four byte-writes per element, 378 million of them for
+// distil-large-v3 — was most of what a transcription cost. Uploading the raw
+// halves and widening them here does the same arithmetic where there are
+// thousands of threads for it, and halves the PCIe traffic on the way.
+//
+// The decode is a bit trick rather than __half: NVRTC has no cuda_fp16.h and the
+// CPU backend's shim has no half type at all. Same source, both backends.
+@ __wk_cvt_f16 → s {
+    ^ `extern "C" __global__ void cvt_f16(const unsigned char* src, float* dst, int n) {
+        int i = blockIdx.x*blockDim.x + threadIdx.x;
+        if (i >= n) return;
+        unsigned int h = (unsigned int)src[2*i] | ((unsigned int)src[2*i+1] << 8);
+        unsigned int sign = (h >> 15) << 31;
+        unsigned int e = (h >> 10) & 31u;
+        unsigned int m = h & 1023u;
+        unsigned int bits;
+        if (e == 0u) {
+            if (m == 0u) bits = sign;
+            else {
+                int ex = 113;
+                while (!(m & 1024u)) { m <<= 1; ex--; }
+                m &= 1023u;
+                bits = sign | ((unsigned int)ex << 23) | (m << 13);
+            }
+        } else if (e == 31u) {
+            bits = sign | 0x7F800000u | (m << 13);
+        } else {
+            bits = sign | ((e + 112u) << 23) | (m << 13);
+        }
+        // a UNION, not memcpy and not __half: memcpy needs a header the CPU
+        // shim does not include, and __half needs cuda_fp16.h, which NVRTC does
+        // not have. This compiles identically on both backends — the same trick
+        // nurllama's quant kernels use.
+        union { unsigned int u; float f; } cv;
+        cv.u = bits;
+        dst[i] = cv.f;
+    }`
+}
+
+// bf16 is the top 16 bits of an f32 — the widening is a shift.
+@ __wk_cvt_bf16 → s {
+    ^ `extern "C" __global__ void cvt_bf16(const unsigned char* src, float* dst, int n) {
+        int i = blockIdx.x*blockDim.x + threadIdx.x;
+        if (i >= n) return;
+        unsigned int bits = (((unsigned int)src[2*i] | ((unsigned int)src[2*i+1] << 8))) << 16;
+        union { unsigned int u; float f; } cv;
+        cv.u = bits;
+        dst[i] = cv.f;
+    }`
+}
+
 // The embedding table is on the device (it is also the output projection —
 // whisper ties them), so a token's row is a copy, not a host round-trip.
 @ __wk_getrow → s {
@@ -248,13 +304,16 @@ $ `deps/gpu/src/gpu.nu`
     : GpuKernel k7 ( gpu_compile g ( __wk_addv ) `addv` )
     : GpuKernel k8 ( gpu_compile g ( __wk_addrow ) `addrow` )
     : GpuKernel k9 ( gpu_compile g ( __wk_scale ) `scale` )
+    : GpuKernel k12 ( gpu_compile g ( __wk_cvt_f16 ) `cvt_f16` )
+    : GpuKernel k13 ( gpu_compile g ( __wk_cvt_bf16 ) `cvt_bf16` )
     : GpuKernel k10 ( gpu_compile g ( __wk_getrow ) `getrow` )
     : GpuKernel k11 ( gpu_compile g ( __wk_setrow ) `setrow` )
     : b ok1 & & ( gpu_kernel_ok k1 ) ( gpu_kernel_ok k2 ) & ( gpu_kernel_ok k3 ) ( gpu_kernel_ok k4 )
     : b ok2 & & ( gpu_kernel_ok k5 ) ( gpu_kernel_ok k6 ) & ( gpu_kernel_ok k7 ) ( gpu_kernel_ok k8 )
     : b ok3 & ( gpu_kernel_ok k9 ) & ( gpu_kernel_ok k10 ) ( gpu_kernel_ok k11 )
-    : b ok & & ok1 ok2 ok3
-    ^ @ WhKernels { k1 k1w warp k2 k3 k4 k5 k6 k7 k8 k9 k10 k11 ok }
+    : b ok4 & ( gpu_kernel_ok k12 ) ( gpu_kernel_ok k13 )
+    : b ok & & ok1 ok2 & ok3 ok4
+    ^ @ WhKernels { k1 k1w warp k2 k3 k4 k5 k6 k7 k8 k9 k12 k13 k10 k11 ok }
 }
 
 @ wk_free WhKernels ks → v {
@@ -268,6 +327,8 @@ $ `deps/gpu/src/gpu.nu`
     ( gpu_kernel_free . ks addv )
     ( gpu_kernel_free . ks addrow )
     ( gpu_kernel_free . ks scale )
+    ( gpu_kernel_free . ks cvt_f16 )
+    ( gpu_kernel_free . ks cvt_bf16 )
     ( gpu_kernel_free . ks getrow )
     ( gpu_kernel_free . ks setrow )
 }
@@ -403,5 +464,17 @@ $ `deps/gpu/src/gpu.nu`
     ( vec_push [i] a ( gpu_arg_i32 row ) )
     ( vec_push [i] a ( gpu_arg_i32 n ) )
     : i _r ( gpu_launch . ks setrow ( gpu_grid n 256 ) 256 a )
+    ( vec_free [i] a )
+}
+
+// `half` = 1 for f16, 0 for bf16.
+@ wk_cvt WhKernels ks i srcd i dstd i n b half → v {
+    : ( Vec i ) a ( vec_new [i] )
+    ( vec_push [i] a ( gpu_arg_i64 srcd ) )
+    ( vec_push [i] a ( gpu_arg_i64 dstd ) )
+    ( vec_push [i] a ( gpu_arg_i32 n ) )
+    ? half
+    { : i _r ( gpu_launch . ks cvt_f16 ( gpu_grid n 256 ) 256 a ) }
+    { : i _r ( gpu_launch . ks cvt_bf16 ( gpu_grid n 256 ) 256 a ) }
     ( vec_free [i] a )
 }

--- a/packages/whisper/src/kernels.nu
+++ b/packages/whisper/src/kernels.nu
@@ -27,6 +27,7 @@ $ `deps/gpu/src/gpu.nu`
 : WhKernels {
     GpuKernel matvec  // y = W x (+ bias), one thread per row — portable
     GpuKernel matvec_w  // the same, one WARP per row (CUDA only)
+    GpuKernel matvec_t  // one warp per row × EIGHT positions (CUDA only)
     b warp
     GpuKernel layernorm
     GpuKernel gelu
@@ -85,6 +86,51 @@ $ `deps/gpu/src/gpu.nu`
         for (int c = lane; c < cols; c += 32) acc += w[c]*xb[c];
         acc = wh_warp_sum(acc);
         if (lane == 0) y[(long long)b*rows + r] = acc + (bias ? bias[r] : 0.f);
+    }`
+}
+
+// The encoder runs 1500 positions through the same weight matrix, and the
+// warp-per-row kernel above re-reads that matrix FOR EVERY ONE OF THEM: for
+// distil-large-v3 that is 1500 x 840 MB of weight traffic per encoder pass, and
+// it is the whole reason a transcription spent 2.5 s in the encoder.
+//
+// This one gives a warp a row AND EIGHT POSITIONS: w[c] is loaded once and
+// multiplied into eight accumulators. Eight times less weight traffic, the same
+// arithmetic. (nurllama tried the same trick on its DECODE path and it lost —
+// there the batch is 1, so there is nothing to amortise. The regime is what
+// decides, not the trick.)
+@ __wk_matvec_t → s {
+    ^ `
+    __device__ static inline float wh_warp_sum_t(float v) {
+        for (int off = 16; off > 0; off >>= 1) v += __shfl_down_sync(0xffffffffu, v, off);
+        return v;
+    }
+    extern "C" __global__ void matvec_t(
+        const float* __restrict__ W, const float* __restrict__ x,
+        const float* __restrict__ bias, float* __restrict__ y,
+        int rows, int cols, int batch) {
+        int gid  = blockIdx.x*blockDim.x + threadIdx.x;
+        int warp = gid >> 5, lane = gid & 31;
+        int tiles = (batch + 7) / 8;
+        if (warp >= rows*tiles) return;
+        int t = warp / rows, r = warp % rows;
+        int b0 = t*8;
+        const float* w = W + (long long)r*cols;
+        float acc[8];
+        for (int j = 0; j < 8; ++j) acc[j] = 0.f;
+        for (int c = lane; c < cols; c += 32) {
+            float wc = w[c];                       // ONE load, eight uses
+            for (int j = 0; j < 8; ++j) {
+                int b = b0 + j;
+                if (b < batch) acc[j] += wc * x[(long long)b*cols + c];
+            }
+        }
+        float bs = bias ? bias[r] : 0.f;
+        for (int j = 0; j < 8; ++j) {
+            float v = wh_warp_sum_t(acc[j]);
+            int b = b0 + j;
+            if (lane == 0 && b < batch) y[(long long)b*rows + r] = v + bs;
+        }
     }`
 }
 
@@ -295,7 +341,8 @@ $ `deps/gpu/src/gpu.nu`
     : GpuKernel k1 ( gpu_compile g ( __wk_matvec ) `matvec` )
     : b want_warp == ( gpu_backend ) 0
     : GpuKernel k1w ? want_warp ( gpu_compile g ( __wk_matvec_w ) `matvec_w` ) @ GpuKernel { 0 0 }
-    : b warp & want_warp ( gpu_kernel_ok k1w )
+    : GpuKernel k1t ? want_warp ( gpu_compile g ( __wk_matvec_t ) `matvec_t` ) @ GpuKernel { 0 0 }
+    : b warp & want_warp & ( gpu_kernel_ok k1w ) ( gpu_kernel_ok k1t )
     : GpuKernel k2 ( gpu_compile g ( __wk_layernorm ) `layernorm` )
     : GpuKernel k3 ( gpu_compile g ( __wk_gelu ) `gelu` )
     : GpuKernel k4 ( gpu_compile g ( __wk_conv1d ) `conv1d` )
@@ -313,12 +360,15 @@ $ `deps/gpu/src/gpu.nu`
     : b ok3 & ( gpu_kernel_ok k9 ) & ( gpu_kernel_ok k10 ) ( gpu_kernel_ok k11 )
     : b ok4 & ( gpu_kernel_ok k12 ) ( gpu_kernel_ok k13 )
     : b ok & & ok1 ok2 & ok3 ok4
-    ^ @ WhKernels { k1 k1w warp k2 k3 k4 k5 k6 k7 k8 k9 k12 k13 k10 k11 ok }
+    ^ @ WhKernels { k1 k1w k1t warp k2 k3 k4 k5 k6 k7 k8 k9 k12 k13 k10 k11 ok }
 }
 
 @ wk_free WhKernels ks → v {
     ( gpu_kernel_free . ks matvec )
-    ? . ks warp { ( gpu_kernel_free . ks matvec_w ) } {}
+    ? . ks warp {
+        ( gpu_kernel_free . ks matvec_w )
+        ( gpu_kernel_free . ks matvec_t )
+    } {}
     ( gpu_kernel_free . ks layernorm )
     ( gpu_kernel_free . ks gelu )
     ( gpu_kernel_free . ks conv1d )
@@ -346,8 +396,17 @@ $ `deps/gpu/src/gpu.nu`
     ( vec_push [i] a ( gpu_arg_i32 cols ) )
     ( vec_push [i] a ( gpu_arg_i32 batch ) )
     ? . ks warp {
-        : i threads * * rows batch 32
-        : i _r ( gpu_launch . ks matvec_w ( gpu_grid threads 128 ) 128 a )
+        // Many positions at once (the encoder): amortise the weight matrix over
+        // eight of them. One position (the decoder): there is nothing to
+        // amortise, and the plain warp kernel is the right one.
+        ? >= batch 8 {
+            : i tiles / + batch 7 8
+            : i threads * * rows tiles 32
+            : i _r ( gpu_launch . ks matvec_t ( gpu_grid threads 128 ) 128 a )
+        } {
+            : i threads * * rows batch 32
+            : i _r ( gpu_launch . ks matvec_w ( gpu_grid threads 128 ) 128 a )
+        }
     } {
         : i _r ( gpu_launch . ks matvec ( gpu_grid * rows batch 128 ) 128 a )
     }

--- a/packages/whisper/src/model.nu
+++ b/packages/whisper/src/model.nu
@@ -141,6 +141,41 @@ $ `src/kernels.nu`
     : *St st # *St . w st
     : i ti ( st_find_tensor st name )
     ? < ti 0 { ^ -1 } {}
+    // A tensor that is ALREADY f32 — which is what a whisper checkpoint is —
+    // needs no conversion at all: upload it straight out of the mapping.
+    //
+    // The obvious path (st_dequant → a Vec of f32 bytes → upload) reads every
+    // element through a function call and pushes four bytes at a time. For
+    // distil-large-v3 that is 378 MILLION of each, and it cost 11.3 of the
+    // 11.6 seconds a transcription took — while reading the whole 1.5 GB file
+    // off disk takes 0.25 s. Don't copy what you can point at.
+    ?? ( vec_get [StTensor] . st tensors ti ) {
+        T t → {
+            ? == . t dtype ST_F32 {
+                : GpuBuffer b ( gpu_alloc . w g . t nbytes )
+                : i _u ( gpu_upload b ( st_tensor_ptr st t ) )
+                ( vec_push [i] . w bufs . b dptr )
+                ( vec_push [i] . w bufsz . b bytes )
+                ^ . b dptr
+            } {}
+            // f16 / bf16 — which is what a whisper checkpoint actually is — go up
+            // as RAW HALVES and are widened by a kernel. Half the bytes over PCIe,
+            // and the widening happens where there are thousands of threads for
+            // it instead of one host loop doing 378 million iterations.
+            ? | == . t dtype ST_F16 == . t dtype ST_BF16 {
+                : GpuBuffer raw ( gpu_alloc . w g . t nbytes )
+                : i _u2 ( gpu_upload raw ( st_tensor_ptr st t ) )
+                : GpuBuffer b ( gpu_alloc . w g * . t nelems 4 )
+                ( wk_cvt . w ks . raw dptr . b dptr . t nelems == . t dtype ST_F16 )
+                ( gpu_free raw )
+                ( vec_push [i] . w bufs . b dptr )
+                ( vec_push [i] . w bufsz . b bytes )
+                ^ . b dptr
+            } {}
+        }
+        F → {}
+    }
+    // anything else (an integer tensor) widens on the host
     ?? ( st_dequant st ti ) {
         T raw → {
             : i n ( vec_len [u] raw )


### PR DESCRIPTION
distil-large-v3 took **11.6 s** to transcribe an 11-second clip, and the cost was **flat** — the same whether it generated 1 token or 20. So it was the load, not the model. Reading the whole 1.5 GB file off disk takes 0.25 s.

| | |
|---|---|
| start | **11.55 s** |
| the dequantiser stopped pushing four bytes at a time | 5.16 s |
| the f16 → f32 widening moved to the GPU | 2.78 s |
| the encoder stopped re-reading its weights 1500 times | **2.23 s** |

whisper-tiny came along for the ride: 1.15 s → 0.74 s.

## 1. `st_dequant` pushed one byte at a time

It built its output by pushing bytes into a `Vec`, paying a capacity check per byte. A 378-million-element checkpoint is **1.5 billion** of them. The output is now sized once and written through a raw pointer — same arithmetic, same result, one allocation.

## 2. A whisper checkpoint is f16, and the widening belongs on the GPU

The host loop that widened it (one function call and four byte-writes per element) was the rest of it. The raw halves now go up **as they are** and a kernel widens them: half the bytes over PCIe, and the arithmetic happens where there are thousands of threads for it. An f32 tensor is uploaded straight out of the mmap — there is nothing to convert.

**The corner:** the first version of that kernel used `memcpy` for the bit transport. NVRTC compiled it; the CPU backend's shim did not — so the kernel silently failed to compile, `gpu_launch` ran a null kernel, and the CPU backend died on a `0xbebebebe` pointer. It is a **union** now, the same trick nurllama's quant kernels use, and it compiles identically on both backends.

## 3. The encoder read its weight matrix 1500 times

1500 positions go through the same matrix, and the warp-per-row kernel re-read it **for every one of them** — 1500 × 840 MB of weight traffic per encoder pass. The tiled kernel gives a warp a row **and eight positions**: `w[c]` is loaded once and multiplied into eight accumulators.

Worth saying plainly: **nurllama tried this exact trick on its decode path and it lost** (prefill +10 %, decode −15 %), and it was reverted. There the batch is 1 — there is nothing to amortise. *The regime decides, not the trick*, which is why the launcher picks the tiled kernel only when there are ≥ 8 positions, and the plain warp kernel otherwise. The decoder still gets the one that suits it.

## Verification

7/7 whisper, 5/5 safetensor, nurllama's safetensors path unchanged, ASan **and** UBSan clean on both models and both backends. The transcription is byte-identical throughout — on whisper-tiny and distil-large-v3, on CUDA and on CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH