### PR TITLE
packages: the manifests the registry now serves

### DIFF
--- a/packages/safetensor/nurl.toml
+++ b/packages/safetensor/nurl.toml
@@ -1,5 +1,5 @@
 [package]
 name = "safetensor"
-version = "0.1.0"
+version = "0.2.0"
 description = "Read the safetensors tensor container in pure NURL — the format Hugging Face ships every modern model in. The parser treats every file as hostile input: the format's entire attack surface is that each tensor's bytes are addressed by offsets the file itself supplies, so the 8-byte header length is checked against the real file size before the JSON is even looked at, every tensor's [start,end) must lie inside the data region computed from that size, the extent must be exactly what its dtype and shape need, and element counts are accumulated with an overflow check rather than multiplied and hoped for — a malformed, truncated or adversarial file is a clean error, never a crash or an allocation sized by a number a stranger chose (proven by a crafted-file battery under `safetensor selftest`). mmap-backed and lazy: the header is parsed up front and tensor bytes are addressed straight out of the mapping, so inspecting a multi-GB model costs no RAM. Every dtype widens to f32 on demand (F64/F32/F16/BF16, the signed and unsigned integers, BOOL), and an element RANGE is exact — safetensors has no block quantisation, so a single row of an embedding table can be read without touching the rest. CLI: safetensor info/tensors/verify/stats/export/selftest."
 license = "MIT OR Apache-2.0"

--- a/packages/tokenizer/nurl.toml
+++ b/packages/tokenizer/nurl.toml
@@ -1,5 +1,5 @@
 [package]
 name = "tokenizer"
-version = "0.1.0"
+version = "0.1.1"
 description = "The tokenizer that feeds a language model, in pure NURL — and it does not care which file the vocabulary arrived in. Two engines: SentencePiece-style bigram merging for llama-family vocabularies (space-escape, highest-score adjacent merge with llama.cpp's exact selection order and leftmost ties, byte fallback, UNK) and byte-level BPE for gpt2-family ones (the GPT-2 byte-to-unicode remap, contraction/letter/digit/punct/whitespace pre-split with per-model variants, lowest-merge-rank pairing). Special tokens are parsed INLINE: a chat template writes its turn markers into the prompt as text, and each must come back as its own single id — tokenised as ordinary pieces they shred into a dozen tokens and the model answers a question nobody asked. The engine takes PARTS (pieces, scores, token types, merge rules), so a vocabulary can arrive from a GGUF's tokenizer.ggml.* metadata, from Hugging Face's vocab.json + merges.txt + added_tokens.json (src/hf.nu — what whisper and every HF checkpoint ship), or from anywhere else, with nothing about the engine changing. Verified token-for-token against independent python SentencePiece and BPE implementations on real llama.cpp models, and against Hugging Face's own tokenizer on HF checkpoints."
 license = "MIT OR Apache-2.0"

--- a/packages/whisper/nurl.toml
+++ b/packages/whisper/nurl.toml
@@ -6,6 +6,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 gpu = { path = "../gpu", version = "^0.7" }
-safetensor = { path = "../safetensor", version = "^0.1" }
+safetensor = { path = "../safetensor", version = "^0.2" }
 tokenizer = { path = "../tokenizer", version = "^0.1" }
 audio = { path = "../audio", version = "^0.4" }


### PR DESCRIPTION
Publishing the whisper stack surfaced two drifts the publish gate caught — a path dep is built locally but fetched from the registry by everyone else, so "local differs from published" is an install-time wrong answer waiting to happen:

* **safetensor 0.2.0** — the registry's 0.1.0 predates the pointer-write dequant loop (PR #480); whisper's dep moves to `^0.2`
* **tokenizer 0.1.1** — the README landed after 0.1.0 was published

Published to reg.nurl-lang.org: **gpu 0.7.0, audio 0.4.0, safetensor 0.2.0, tokenizer 0.1.1, whisper 0.4.0**.

Verified from the registry with the **released v0.14.0 toolchain**: `nurlpkg install whisper` → `--vad --timestamps` stamps padded speech at `00:19.85` and the 292 s meeting at `00:59.85` / `03:11.00` — the condensation map works in the installed binary, not only in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH