### PR TITLE
release: v0.14.1 — the FFT patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] — 2026-07-13
+
+A patch for the speech release's own hot path: the FFT that computes every
+whisper spectrogram frame.
+
+### Changed
+
+- **`stdlib/std/fft.nu` — "not a power of two" is not one case.** 0.14.0
+  sent every such length through Bluestein; but `400 = 2^4·5^2` is
+  perfectly factorable, and Bluestein pays for TWO radix-2 transforms of
+  length 1024 to produce one transform of length 400 — the fallback for
+  hard lengths, applied to an easy one, 3000 times per 30 seconds of
+  audio. Three paths now, picked by what N actually is: powers of two
+  keep the radix-2 core, **smooth lengths (factors 2/3/5/7) get a direct
+  mixed-radix Cooley-Tukey** with per-level twiddle tables built once in
+  the plan, and Bluestein does only the job it is for — lengths with a
+  large prime factor, where a "radix" would degenerate toward the O(n²)
+  DFT it exists to avoid (997 stays on it, and stays exact).
+- **`fft_rfft` folds a real signal of even length in half**: 400 real
+  samples become a 200-point complex transform (`z[t] = x[2t] +
+  i·x[2t+1]`) plus an O(n) untangle — the even samples' spectrum is
+  conjugate-symmetric where the odd ones' is anti-symmetric, so they
+  separate. Half the transform is half the work, whichever path the
+  half-length takes.
+- Together: whisper's 30-second mel spectrogram **0.52 s → 0.14 s**
+  (the STFT itself 288 → 99 ms). With the packages already on the
+  registry riding this stdlib, distil-large-v3 transcribes a 292-second
+  recording in 3.9 s — 1.3 s with `--vad`.
+
+### Fixed
+
+- The FFT identity suite now pins **every radix the factoriser can hand
+  out** (3, 5, 7, alone and mixed: 105 = 3·5·7, 343 = 7³) with δ[1]
+  cases — the check that catches a conjugated combine step, which
+  round-trips perfectly while transforming wrongly. Forward transforms of
+  pseudo-random signals at N = 400, 360, 105, 343 were verified against
+  `numpy.fft` directly.
+
 ## [0.14.0] — 2026-07-13
 
 The **speech** release: NURL now transcribes real audio with real models,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-07-13 · Current release: **0.14.0** · Language: **Grammar
+_Last reviewed: 2026-07-13 · Current release: **0.14.1** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
Patch release so testers get the faster spectrogram path from the released toolchain (stdlib ships with the toolchain — the registry packages are already published and ride whatever stdlib the installed toolchain has).

* **mixed-radix FFT** for smooth lengths (2/3/5/7) — 400 = 2⁴·5² no longer pays Bluestein's two 1024-point transforms per frame
* **rfft real-input folding** — 400 real samples → one 200-point complex transform + O(n) untangle
* Bluestein stays for what it is for: lengths with a large prime factor (997 stays exact)
* whisper mel spectrogram **0.52 s → 0.14 s**; distil-large-v3, 292 s recording: **3.9 s**, **1.3 s** with `--vad`
* identity suite pins every radix with δ[1] (the sign-catcher); random signals verified against `numpy.fft` at N = 400/360/105/343

After merge: annotated tag `v0.14.1` → release.yml builds and signs the artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH