### PR TITLE
tests: Windows goldens fall back to posix; the traversal test stops guessing

### DIFF
--- a/compiler/tests/fs_write_handle.nu
+++ b/compiler/tests/fs_write_handle.nu
@@ -8,8 +8,21 @@ $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
 
-: s TPATH `/tmp/nurl_fswh_test.bin`
+// Temp path from the environment (TMPDIR → TEMP → /tmp) — a hardcoded /tmp
+// works on Windows only while the C runtime's drive-relative mapping holds.
+: ~ s TPATH ``
+
+@ __fswh_path → String {
+    : ~ String tdir ( env_var_or `TMPDIR` `` )
+    ? == ( string_len tdir ) 0 {
+        ( string_free tdir )
+        = tdir ( env_var_or `TEMP` `/tmp` )
+    } {}
+    ( string_push_str tdir `/nurl_fswh_test.bin` )
+    ^ tdir
+}
 
 @ ck b ok s name → v {
     ? ok { ( nurl_print `PASS ` ) } { ( nurl_print `FAIL ` ) }
@@ -18,6 +31,9 @@ $ `stdlib/std/fs.nu`
 }
 
 @ main → i {
+    : String __tp ( __fswh_path )
+    = TPATH ( strdup ( string_data __tp ) )
+    ( string_free __tp )
     ( file_delete TPATH )
 
     // create + two chunks, the first with an embedded NUL

--- a/compiler/tests/http_static_traversal.nu
+++ b/compiler/tests/http_static_traversal.nu
@@ -24,6 +24,7 @@ $ `stdlib/core/vec.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_static.nu`
+$ `stdlib/ext/env.nu`
 
 // Build a borrowed request with the given path. Caller frees with
 // request_free.
@@ -105,9 +106,19 @@ $ `stdlib/ext/http_static.nu`
 }
 
 @ main → i {
-    // Unique-ish temp root under /tmp.
+    // Temp root from the environment — TMPDIR (posix), then TEMP (Windows),
+    // then /tmp. A hardcoded /tmp only works on Windows for as long as the
+    // C runtime's drive-relative mapping happens to hold, and when it stops
+    // holding the symptom is 404s three layers away.
+    : ~ String tdir ( env_var_or `TMPDIR` `` )
+    ? == ( string_len tdir ) 0 {
+        ( string_free tdir )
+        = tdir ( env_var_or `TEMP` `/tmp` )
+    } {}
     : String base ( string_new )
-    ( string_push_str base `/tmp/nurl_static_traversal_test` )
+    ( string_push_str base ( string_data tdir ) )
+    ( string_free tdir )
+    ( string_push_str base `/nurl_static_traversal_test` )
     : s b ( string_data base )
 
     : String pubdir ( string_new )
@@ -115,27 +126,27 @@ $ `stdlib/ext/http_static.nu`
     ( string_push_str pubdir `/pubdir` )
 
     : !v IoErr d1 ( dir_create_all ( string_data pubdir ) )
-    ?? d1 { T _ → {} F _ → {} }
+    ?? d1 { T _ → {} F _ → { ( nurl_print `SETUP FAIL: dir_create_all\n` ) } }
 
     // secret OUTSIDE pubdir
     : String secret_path ( string_new )
     ( string_push_str secret_path b )
     ( string_push_str secret_path `/secret.txt` )
     : !v IoErr w1 ( write_file ( string_data secret_path ) `TOP-SECRET\n` )
-    ?? w1 { T _ → {} F _ → {} }
+    ?? w1 { T _ → {} F _ → { ( nurl_print `SETUP FAIL: write secret.txt\n` ) } }
 
     // index.html + ok.txt INSIDE pubdir
     : String idx ( string_new )
     ( string_push_str idx ( string_data pubdir ) )
     ( string_push_str idx `/index.html` )
     : !v IoErr w2 ( write_file ( string_data idx ) `<h1>index</h1>\n` )
-    ?? w2 { T _ → {} F _ → {} }
+    ?? w2 { T _ → {} F _ → { ( nurl_print `SETUP FAIL: write index.html\n` ) } }
 
     : String okp ( string_new )
     ( string_push_str okp ( string_data pubdir ) )
     ( string_push_str okp `/ok.txt` )
     : !v IoErr w3 ( write_file ( string_data okp ) `ok\n` )
-    ?? w3 { T _ → {} F _ → {} }
+    ?? w3 { T _ → {} F _ → { ( nurl_print `SETUP FAIL: write ok.txt\n` ) } }
 
     : i fails ( run b )
 

--- a/compiler/tests/run_tests.ps1
+++ b/compiler/tests/run_tests.ps1
@@ -353,10 +353,25 @@ $results = $names | ForEach-Object -ThrottleLimit $Jobs -Parallel {
     }
 
     # ── compare / update ────────────────────────────────────────
+    # -Update always writes the WINDOWS golden — that part of the two-set
+    # design stays. But for COMPARISON, a test with no Windows golden falls
+    # back to the posix one: 500 of the 524 Windows goldens are byte-identical
+    # to their posix twins, so requiring a hand-run `-Update` on a Windows box
+    # for every new test bought nothing except a permanently lagging suite
+    # (13 MISSING at v0.15.0). With the fallback, a new test is covered on
+    # Windows from the day it lands; a test whose Windows behaviour GENUINELY
+    # differs fails loudly against the posix golden — and that failure is the
+    # deliberate moment to add an outputs-windows/ golden for it. Silent lag
+    # becomes an actionable diff, and an existing Windows golden still always
+    # wins, so a Windows drift can never masquerade as a Linux regression.
     $enc = New-Object System.Text.UTF8Encoding $false
     if ($Update) {
         [System.IO.File]::WriteAllText($gold, $act, $enc)
         return [pscustomobject]@{ Name = $name; Verdict = 'UPDATED'; Diff = '' }
+    }
+    if (-not (Test-Path -LiteralPath $gold)) {
+        $posixGold = Join-Path (Join-Path $ScriptDir 'outputs') "$name.txt"
+        if (Test-Path -LiteralPath $posixGold) { $gold = $posixGold }
     }
     if (-not (Test-Path -LiteralPath $gold)) {
         return [pscustomobject]@{ Name = $name; Verdict = 'MISSING'; Diff = '' }


### PR DESCRIPTION
The answer to "how do we keep the Windows CI tests healthy":

## 1. The root cause of the lag: mandatory manual work

`run_tests.ps1` refused to run a test without an `outputs-windows/` golden, and those only come from hand-running `-Update` on a Windows box — which is why v0.15.0 shipped with 13 tests MISSING on Windows. But **500 of the 524 Windows goldens are byte-identical to their posix twins**; the separate set only earns its keep for the 24 that genuinely differ.

Comparison now falls back to `outputs/<name>.txt` when no Windows golden exists:

* a new test is covered on Windows **from the day it lands** — no more MISSING queue
* a genuinely-different test fails **loudly** against the posix golden — and that failure is the deliberate moment to add a Windows golden
* an existing Windows golden always wins — a Windows drift can never masquerade as a Linux regression, so the original point of the two-set design is preserved
* `-Update` still writes only to the Windows set

Silent lag becomes an actionable diff.

## 2. Those 404s

`http_static_traversal` hardcodes `/tmp` and **swallows every setup error** — so when file creation stopped working on the runner (timing matches a runner-image rollout, not any change on this path in the repo), the symptom was "GET /ok.txt → 404" three layers from the cause, with nothing in the log. The temp root now comes from the environment (`TMPDIR` → `TEMP` → `/tmp`) and every setup step prints `SETUP FAIL: <what>` on error. If the next Windows run still fails, the log **says where**. `fs_write_handle` (new test, same hardcoding) got the same fix.

Both tests pass unchanged on Linux (goldens untouched — the new prints are failure-path only). Corpus 542/542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH
