### PR TITLE
windows: the three failures the loud logs named — dir_create_all, ioctl, /tmp

### DIFF
--- a/compiler/tests/fs_write_handle.nu
+++ b/compiler/tests/fs_write_handle.nu
@@ -13,14 +13,14 @@ $ `stdlib/ext/env.nu`
 // Temp path from the environment (TMPDIR → TEMP → /tmp) — a hardcoded /tmp
 // works on Windows only while the C runtime's drive-relative mapping holds.
 : ~ s TPATH ``
+: ~ s TDIR ``
 
-@ __fswh_path → String {
+@ __fswh_tmpdir → String {
     : ~ String tdir ( env_var_or `TMPDIR` `` )
     ? == ( string_len tdir ) 0 {
         ( string_free tdir )
         = tdir ( env_var_or `TEMP` `/tmp` )
     } {}
-    ( string_push_str tdir `/nurl_fswh_test.bin` )
     ^ tdir
 }
 
@@ -31,9 +31,11 @@ $ `stdlib/ext/env.nu`
 }
 
 @ main → i {
-    : String __tp ( __fswh_path )
-    = TPATH ( strdup ( string_data __tp ) )
-    ( string_free __tp )
+    : String __td ( __fswh_tmpdir )
+    = TDIR ( strdup ( string_data __td ) )
+    ( string_push_str __td `/nurl_fswh_test.bin` )
+    = TPATH ( strdup ( string_data __td ) )
+    ( string_free __td )
     ( file_delete TPATH )
 
     // create + two chunks, the first with an embedded NUL
@@ -119,8 +121,12 @@ $ `stdlib/ext/env.nu`
         F _ → { ( ck F `read handle` ) }
     }
 
-    // error path: writing to a directory path fails cleanly
-    ?? ( file_create `/tmp` ) {
+    // error path: writing to a directory path fails cleanly. The directory
+    // is the resolved temp root — guaranteed to EXIST as a directory on
+    // every platform, which a hardcoded /tmp is not on Windows (there
+    // file_create("/tmp") happily created a FILE named \tmp and the
+    // "rejects" check failed against a successful create).
+    ?? ( file_create TDIR ) {
         T f → {
             ( file_close f )
             ( ck F `create on a directory rejects` )

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -1170,6 +1170,33 @@ int mkstemp(char *tmpl) {
 /* (c) Unreachable on the Windows path (dir listing goes through
  * FindFirstFileA, process/signal/net through Win32) — these exist so
  * lld-link resolves the IR's declare lines. */
+/* Terminal size — the ONE ioctl the stdlib issues (term.nu, TIOCGWINSZ).
+ * 0x5413 is Linux's request value, reused here purely as the sentinel
+ * nurl_native_constant hands out below: the pair only has to agree with
+ * itself. Fills the POSIX `struct winsize` shape (four u16: row, col,
+ * xpixel, ypixel) from the console's real geometry, so term_width /
+ * term_height WORK in a Windows console rather than merely linking and
+ * falling back to $COLUMNS. Every other request is ENOSYS. */
+#define NURL_WIN_TIOCGWINSZ 0x5413
+int ioctl(int fd, long long req, void *argp) {
+    if (req == NURL_WIN_TIOCGWINSZ && argp) {
+        HANDLE h = (HANDLE)_get_osfhandle(fd);
+        CONSOLE_SCREEN_BUFFER_INFO bi;
+        if (h != INVALID_HANDLE_VALUE && GetConsoleScreenBufferInfo(h, &bi)) {
+            unsigned short *ws = (unsigned short *)argp;
+            ws[0] = (unsigned short)(bi.srWindow.Bottom - bi.srWindow.Top + 1);
+            ws[1] = (unsigned short)(bi.srWindow.Right - bi.srWindow.Left + 1);
+            ws[2] = 0;
+            ws[3] = 0;
+            return 0;
+        }
+        errno = ENOTTY;
+        return -1;
+    }
+    (void)fd; (void)argp;
+    errno = ENOSYS;
+    return -1;
+}
 void *opendir(const char *path)            { (void)path; errno = ENOSYS; return NULL; }
 void *readdir(void *d)                     { (void)d; errno = ENOSYS; return NULL; }
 int   closedir(void *d)                    { (void)d; errno = ENOSYS; return -1; }
@@ -1328,6 +1355,11 @@ long long nurl_native_constant(const char *name) {
      * (0x5413 Linux, 0x40087468 BSD/macOS), so surface the real one. */
     if (strcmp(name, "TIOCGWINSZ")      == 0) return (long long)TIOCGWINSZ;
 #  endif
+#endif
+#if defined(_WIN32) && !defined(__MINGW32__)
+    /* The MSVC path's ioctl shim (above) answers this request with
+     * GetConsoleScreenBufferInfo — surface the sentinel it matches on. */
+    if (strcmp(name, "TIOCGWINSZ")      == 0) return 0x5413;
 #endif
     (void)name;
     return -1;

--- a/stdlib/std/fs.nu
+++ b/stdlib/std/fs.nu
@@ -585,6 +585,17 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
     ? == rc 0 { ^ @ !v IoErr { T 0 } } {}
     : i k ( errno_kind )
     ? == k 2 { ^ @ !v IoErr { T 0 } } {}
+    // mkdir can refuse an EXISTING directory with something other than
+    // EEXIST: Windows answers "C:" and other roots with EACCES, and
+    // dir_create_all walks an absolute path's every prefix — so without
+    // this, creating ANY absolute path on Windows aborted at its first
+    // component. If the path opens as a directory, it exists; that is
+    // what mkdir -p semantics promise, whatever errno the refusal wore.
+    : i dh ( nurl_dir_list_open p )
+    ? != dh 0 {
+        ( nurl_dir_list_close dh )
+        ^ @ !v IoErr { T 0 }
+    } {}
     ^ @ !v IoErr { F ( __io_err_of_kind k ) }
 }
 


### PR DESCRIPTION
The previous PR turned silent Windows lag into named failures (511 → 522 PASS, 13 MISSING → 0). These are the three names, each fixed where the bug actually lives:

## 1. `SETUP FAIL: dir_create_all` — died on *every* absolute Windows path

`dir_create_all` walks the path's prefixes, and `mkdir("C:")` answers **EACCES** — not EEXIST — so the walk died at the first component and everything downstream saw "directory missing" (the traversal test's 404s, three layers from the cause). `__dir_create_step` now accepts a component whose mkdir failed **if the path opens as a directory** — that is what `mkdir -p` semantics promise, whatever errno the refusal wore. The existence probe is `nurl_dir_list_open/close` (the FindFirstFile-backed trio), so the check is portable by construction.

## 2. `term_progress: LINK FAIL 1120` — MSVC has no `ioctl`

term.nu declares POSIX `ioctl` for TIOCGWINSZ. The MSVC runtime now provides the one ioctl the stdlib ever issues: request `0x5413` (the same sentinel `nurl_native_constant` hands out on this path) fills the POSIX `winsize` shape from `GetConsoleScreenBufferInfo` — so `term_width`/`term_height` **work** in a Windows console instead of merely linking. Every other request is ENOSYS; the `$COLUMNS`/`$LINES` fallback is untouched.

## 3. `fs_write_handle: create on a directory rejects` — /tmp is not a directory on Windows

`file_create("/tmp")` happily created a *file* named `\tmp` and the "rejects" check failed against a successful create. The check now uses the resolved temp root — a directory that exists on every platform by definition.

## Verified

* Linux: full build + corpus green (every directory-creating test exercises the dir_create_step change)
* Windows validation lands on the next main push — and if anything is still broken, the logs now say what

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH
