### PR TITLE
windows: the last two — POSIX names MSVC spells differently, and a golden that was right to change

### DIFF
--- a/compiler/tests/outputs-windows/fswatch_basic.txt
+++ b/compiler/tests/outputs-windows/fswatch_basic.txt
@@ -1,5 +1,0 @@
-COMPILE OK
-LINK FAIL
-warning: overriding the module target triple with x86_64-pc-windows-msvc19.51.36248 [-Woverride-module]
-1 warning generated.
-clang: error: linker command failed with exit code 1120 (use -v to see invocation)

--- a/compiler/tests/outputs-windows/http_static_traversal.txt
+++ b/compiler/tests/outputs-windows/http_static_traversal.txt
@@ -5,6 +5,6 @@ OUTPUT
   ok   GET /ok.txt = 200
   ok   GET / (index) = 200
   ok   GET /../secret.txt = 403
-  ok   GET //<abs>/secret.txt blocked (404)
+  ok   GET //<abs>/secret.txt blocked (403)
   ok   GET //etc/hostname blocked (404)
 http_static_traversal: all checks passed

--- a/compiler/tests/run_tests.ps1
+++ b/compiler/tests/run_tests.ps1
@@ -250,6 +250,11 @@ $results = $names | ForEach-Object -ThrottleLimit $Jobs -Parallel {
     # AF_UNIX socketpair. Their link errors are environment text (lld/MSVC
     # version-dependent), so golden-ing the failure is brittle — skip.
     elseif (@('term_basic','unixsock') -contains $name) { $skip = $true }
+    # std/fswatch.nu is Linux-only (inotify is a Linux kernel API) — the
+    # posix runner skips it everywhere but Linux, and so do we. Its old
+    # Windows golden RECORDED the link failure, which is a blessed
+    # breakage, not coverage.
+    elseif ($name -like 'fswatch_*') { $skip = $true }
     elseif ($name -like 'http_*') {
         $httpDefault = @('http_request_parser','http_response_builder','http_options','http_router',
                          'http_static_traversal','http_extras','http_middleware','http_form',
@@ -326,7 +331,11 @@ $results = $names | ForEach-Object -ThrottleLimit $Jobs -Parallel {
             $linkArgs = @('-O2', $ll, $Runtime, '-lwinhttp') + $WinLibs + @('-o', $bin)
             $lr = Run-Proc $Clang $linkArgs $RootDir
             if ($lr.Code -ne 0) {
-                $le = Normalize $lr.Err
+                # link.exe reports the unresolved SYMBOLS (LNK2019) on
+                # STDOUT and clang only relays the exit code on stderr —
+                # capture both, or every link failure reads "exit code
+                # 1120" with the one fact that matters missing.
+                $le = Normalize ($lr.Out + $lr.Err)
                 $act = "COMPILE OK`nLINK FAIL`n" + (Cap-Lines (Strip-Root $le))
             } else {
                 # Each test runs in its OWN scratch dir so relative-path

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -1078,6 +1078,7 @@ int pthread_cond_destroy(pthread_cond_t *c)   { (void)c; return 0; }
  *       as the mmap/setenv stubs at the top of this file). */
 #  ifndef __MINGW32__
 #    include <io.h>
+#    include <direct.h>   /* _chdir */
 #    include <fcntl.h>
 #    include <share.h>
 #    include <bcrypt.h>
@@ -1177,6 +1178,27 @@ int mkstemp(char *tmpl) {
  * xpixel, ypixel) from the console's real geometry, so term_width /
  * term_height WORK in a Windows console rather than merely linking and
  * falling back to $COLUMNS. Every other request is ENOSYS. */
+/* POSIX names the IR declares that UCRT spells with an underscore (or
+ * lacks). The real ones forward; the termios trio are runtime-gated
+ * link stubs — term.nu's raw mode reports failure cleanly on a console
+ * that has no termios, and the symbols exist so ANY program importing
+ * term.nu links (term_progress only wanted a progress bar and died with
+ * LNK1120 for raw-mode functions it never calls). */
+/* Signatures mirror UCRT's own NONSTDC declarations exactly — when those
+ * are in scope, a mismatched definition is a compile error. The IR calls
+ * `i64 @write`; a 32-bit C return lands zero-extended in RAX on x64, the
+ * same contract every other narrow extern already rides. */
+int isatty(int fd)                         { return _isatty(fd); }
+int write(int fd, const void *buf, unsigned int n) {
+    return _write(fd, buf, n);
+}
+int chdir(const char *path)                { return _chdir(path); }
+int  tcgetattr(int fd, char *buf)          { (void)fd; (void)buf; errno = ENOSYS; return -1; }
+int  tcsetattr(int fd, int act, const char *buf) {
+    (void)fd; (void)act; (void)buf; errno = ENOSYS; return -1;
+}
+void cfmakeraw(char *buf)                  { (void)buf; }
+
 #define NURL_WIN_TIOCGWINSZ 0x5413
 int ioctl(int fd, long long req, void *argp) {
     if (req == NURL_WIN_TIOCGWINSZ && argp) {


### PR DESCRIPTION
522 → 523 last round; these close the remaining two.

## 1. `term_progress` LNK1120 — it was never (just) ioctl

The IR of any program importing term.nu declares **and calls** `tcgetattr`/`tcsetattr`/`cfmakeraw` (raw mode compiles in whether or not the test uses it), plus the POSIX spellings `isatty`/`write`/`chdir` that UCRT only ships underscored. The MSVC runtime section now provides all of them: the first three forward to their `_`-twins (signatures mirror UCRT's own NONSTDC declarations, so a mismatch is a compile error, not a silent ABI drift), and the termios trio are ENOSYS link-stubs — raw mode on a console with no termios fails cleanly, and a program that only wanted a progress bar no longer dies at link over functions it never calls.

And the reason the **symbol names were missing from the log**, fixed: link.exe reports LNK2019 details on STDOUT and clang only relays the exit code on stderr — run_tests.ps1 captured stderr alone, so every link failure read "exit code 1120" with the one fact that matters absent. Both streams are captured now.

## 2. `blocked (403)` vs golden `(404)` — the golden was wrong, not the code

With the temp root now under TEMP, the absolute-path probe is drive-letter form (`C:...`), which serve_static's hardened `path_is_absolute` guard rejects up front (403) instead of letting it relativize into a miss (404). Both are "blocked"; 403 is the guard doing exactly what its comment promises. Golden updated by hand to the correct value.

## Also

`fswatch_*` now skips on Windows with the same rule the posix runner uses everywhere but Linux ("inotify is a Linux kernel API") — its old Windows golden **recorded the link failure**, which is a blessed breakage, not coverage; removed.

Linux: full build + corpus green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH
