### PR TITLE
onnx: the CLI did not compile — and the tests never noticed

### DIFF
--- a/packages/onnx/nurl.toml
+++ b/packages/onnx/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onnx"
-version = "0.6.0"
+version = "0.6.1"
 description = "Run ONNX neural-network models from pure NURL, GPU-accelerated. The model's protobuf is decoded by a pure-NURL wire-format reader (no protoc, no external protobuf library) into an in-memory graph; inference runs on the GPU through the `gpu` package — each operator is a CUDA-C kernel compiled to PTX at runtime via NVRTC and launched over the CUDA Driver API, with every weight and activation resident on the device. v0.1.0 is a proof-of-concept covering feed-forward MLPs (Gemm + Relu); the demo loads a model and input, runs it on the GPU, and matches onnxruntime's output (max abs error ~1e-6). Requires the NVIDIA driver (libcuda) and NVRTC (libnvrtc); a GPU-less host is unaffected since the CUDA dependency lives entirely in the `gpu` package."
 license = "MIT OR Apache-2.0"
 

--- a/packages/onnx/src/main.nu
+++ b/packages/onnx/src/main.nu
@@ -23,7 +23,7 @@ $ `runtime.nu`
 
 // Load a raw little-endian f32 file into a fresh host buffer; returns the
 // buffer and writes the element count through `pcount` (an i64 cell).
-@ load_f32 s path *u pcount → *u {
+@ load_f32 s path * u pcount → *u {
     ?? ( read_file_bytes path ) {
         T bytes → {
             : i n / ( vec_len [u] bytes ) 4
@@ -70,7 +70,9 @@ $ `runtime.nu`
     ( nurl_print `input elements: ` ) ( nurl_print ( nurl_str_int in_n ) ) ( nurl_print `\n` )
 
     : RTensor out ( rt_run e g input 1 in_n )
-    : i out_n * . out rows . out cols
+    // RTensor carries its full shape now (the 0.5.0 tensor bridge replaced
+    // the old rows/cols pair); the element count is a field, not a product.
+    : i out_n . out nelem
     : *u host ( rt_download e out )
 
     ( nurl_print `output [` ) ( nurl_print ( nurl_str_int out_n ) ) ( nurl_print `]: ` )

--- a/packages/onnx/tests/cli_test.sh
+++ b/packages/onnx/tests/cli_test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# ============================================================
+#  packages/onnx — CLI smoke test
+#
+#  The 0.5.0 tensor bridge changed RTensor's shape and the CLI's one use of
+#  the old fields (rows/cols) went unnoticed for months: the .nu tests cover
+#  rt_run directly, so the package "passed" while its entry point did not
+#  compile. This builds src/main.nu and runs the whole thing — parse, upload,
+#  execute, download, compare — against the checked-in onnxruntime reference.
+#
+#  Run from the package dir:  ./tests/cli_test.sh
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t onnxcli.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "[1/2] build the CLI"
+if ! $NURL src/main.nu "$WORK/onnx" >/dev/null 2>"$WORK/build.err"; then
+    echo "  build FAILED"; cat "$WORK/build.err"; exit 1
+fi
+
+echo "[2/2] run tiny.onnx end to end against the onnxruntime reference"
+OUT=$("$WORK/onnx" tests/data/tiny.onnx tests/data/tiny.in.f32 tests/data/tiny.out.f32 2>&1)
+printf '%s\n' "$OUT" | grep -q "MATCH" \
+    && echo "  PASS the CLI parses, runs and matches the reference" \
+    || { echo "  FAIL"; printf '%s\n' "$OUT"; exit 1; }


### PR DESCRIPTION
The 0.5.0 tensor bridge replaced `RTensor`'s `rows`/`cols` pair with a full shape vector plus an element count — and `src/main.nu`'s one use of the old fields went unnoticed since: the package's `.nu` tests drive `rt_run` directly, so the suite passed while the package's **entry point failed to compile**. Found by sweeping every package during the duplicate-definition compiler work — the one pre-existing failure in the tree.

* The count is a field now (`. out nelem`).
* `tests/cli_test.sh` builds and runs the **whole CLI** — parse, upload, execute, download, compare — against the checked-in onnxruntime reference, so the entry point can no longer rot while the library tests stay green:

```
output [3]: 0.0641051 0.0813513 -0.0214344
max abs error vs reference: 0
MATCH ✓
```

* yoloe, yoloe-demo and objdet (the onnx consumers) all compile clean; both existing `.nu` suites still pass (GPU output matches onnxruntime; device softmax matches host after `rt_reset`).

onnx 0.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH