### PR TITLE
safetensor 0.2.1 — publish-gate drift from the file-private migration

### DIFF
--- a/packages/safetensor/nurl.toml
+++ b/packages/safetensor/nurl.toml
@@ -1,5 +1,5 @@
 [package]
 name = "safetensor"
-version = "0.2.0"
+version = "0.2.1"
 description = "Read the safetensors tensor container in pure NURL — the format Hugging Face ships every modern model in. The parser treats every file as hostile input: the format's entire attack surface is that each tensor's bytes are addressed by offsets the file itself supplies, so the 8-byte header length is checked against the real file size before the JSON is even looked at, every tensor's [start,end) must lie inside the data region computed from that size, the extent must be exactly what its dtype and shape need, and element counts are accumulated with an overflow check rather than multiplied and hoped for — a malformed, truncated or adversarial file is a clean error, never a crash or an allocation sized by a number a stranger chose (proven by a crafted-file battery under `safetensor selftest`). mmap-backed and lazy: the header is parsed up front and tensor bytes are addressed straight out of the mapping, so inspecting a multi-GB model costs no RAM. Every dtype widens to f32 on demand (F64/F32/F16/BF16, the signed and unsigned integers, BOOL), and an element RANGE is exact — safetensors has no block quantisation, so a single row of an embedding table can be read without touching the rest. CLI: safetensor info/tensors/verify/stats/export/selftest."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The #496 migration renamed safetensor's shared internals (__st_u32 → _st_u32) after 0.2.0 was published; the publish gate refused whisper 0.9.0 until the dep matched. Published: tokenizer 0.2.0, safetensor 0.2.1, whisper 0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH