### PR TITLE
registry: publish dates + per-version file listing; nurlc: diagnostic-recovery scope fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Registry package pages show publish dates and a per-version file
+  listing.** Each version row on `/packages/<name>` carries its publish
+  date — read from the authoritative server-side `published_at` recorded
+  at publish since the registry's first day, never from client-controlled
+  tar/gzip timestamps — and links to a new
+  `/packages/<name>/<version>/files` page listing every file in the
+  published tarball with its size (USTAR-prefix and GNU-longname paths
+  reconstructed; immutable-cacheable, since versions are immutable). In
+  both registries: the live Cloudflare Worker and `packages/registry`
+  0.2.0.
+
+### Fixed
+
+- **A diagnostic inside a `?`/`??` arm no longer poisons the rest of a
+  multi-error compile.** `die`'s recovery panic unwinds out of the open
+  function/arm symbol-table scopes; the per-declaration recovery frame now
+  pops those leaked scopes before continuing. Previously gen_match's
+  synthetic `__matchtmp<n>__res_nurl_T` payload keys survived, and — the
+  label counter that numbers them resetting per function — a later
+  same-numbered option match typed its payload with the dead declaration's
+  struct, drowning the one real error under phantom cross-file type errors
+  in modules compiled much later (`diag_match_arm_recover` pins the fix).
+- **`: i pub …` explains itself.** Naming a let binding `pub` now says the
+  word is a reserved keyword (the visibility prefix on top-level
+  declarations) instead of the bare "expected variable name in let".
+
 ## [0.15.0] — 2026-07-14
 
 The **joins and guards** release: one new language behaviour, three classes

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -10605,7 +10605,9 @@
                 ^ val
             }
         }
-        { ( die lex `expected variable name in let` ) }
+        { ? == ( nurl_lex_type lex ) TT_PUB
+            { ( die lex `expected variable name in let — 'pub' is a reserved keyword (the visibility prefix on top-level declarations) and cannot name a binding` ) }
+            { ( die lex `expected variable name in let` ) } }
     }
 }
 
@@ -19328,6 +19330,22 @@
                 // buffered closure-IR emission — reset the output stack to
                 // stdout (post-error IR is garbage; the non-zero exit makes
                 // callers discard it) and resync to the next declaration.
+                //
+                // The panic also unwound out of whatever symbol-table scopes
+                // the half-compiled declaration had open (function body,
+                // `?`/`??` arm frames), skipping their nurl_sym_pop calls.
+                // Top-level declarations always compile at scope depth 0 —
+                // pop the leaked frames now, or their entries poison every
+                // later declaration. The concrete hazard: gen_match's
+                // synthetic `__matchtmp<n>__res_nurl_T/…` payload keys leak,
+                // and because the label counter numbering them resets per
+                // function (nurl_cg_reset), a later same-numbered option
+                // match — which defines only `__opt_nurl_T` — reads the dead
+                // declaration's `__res_nurl_T` and types its payload with a
+                // foreign struct. One bad let inside a `?? { T st → … }` arm
+                // then drowned the real diagnostic under phantom cross-file
+                // type errors in modules compiled much later.
+                ~ > ( nurl_peek # s syms 1 ) 0 { ( nurl_sym_pop syms ) }
                 ( nurl_print_buf_unwind )
                 ( __diag_resync lex )
             }

--- a/compiler/tests/diag_match_arm_recover.nu
+++ b/compiler/tests/diag_match_arm_recover.nu
@@ -1,0 +1,31 @@
+// A diagnostic that fires INSIDE a `??` match arm panics out of the open
+// function/arm symbol-table scopes. The recovery frame must pop those
+// leaked scopes before compiling the next declaration: gen_match's
+// synthetic `__matchtmp<n>__res_nurl_T` payload keys otherwise survive,
+// and — because the label counter numbering them resets per function —
+// the SAME-numbered option match below would read the dead arm's
+// `Widget` and type its payload `t0 : %Widget`, reporting a phantom
+// "type 'Widget' has no field 'a'" here instead of just the real error
+// in the module. Golden pins exactly ONE error, located in the module.
+
+$ `stdlib/core/vec.nu`
+$ `compiler/tests/diag_match_arm_recover_mod.nu`
+
+: Thing {
+    i a
+}
+
+@ user → i {
+    : ( Vec Thing ) ts ( vec_new [Thing] )
+    : ~ i out 0
+    ?? ( vec_get [Thing] ts 0 ) {
+        T t0 → { = out . t0 a }
+        F → {}
+    }
+    ( vec_free [Thing] ts )
+    ^ out
+}
+
+@ main → i {
+    ^ ( user )
+}

--- a/compiler/tests/diag_match_arm_recover_mod.nu
+++ b/compiler/tests/diag_match_arm_recover_mod.nu
@@ -1,0 +1,27 @@
+// Module for diag_match_arm_recover.nu — its only declaration dies on a
+// diagnostic INSIDE a `??` result-match arm, so the multi-error recovery
+// frame unwinds out of the open function + arm scopes. Not a test itself.
+
+: Widget {
+    i w
+}
+
+: | WidgetErr {
+    WidgetBoom
+}
+
+@ mk_widget → !Widget WidgetErr {
+    : Widget wg @ Widget { 1 }
+    ^ @ !Widget WidgetErr { T wg }
+}
+
+@ broken → v {
+    ?? ( mk_widget ) {
+        T wg → {
+            // `pub` is a reserved keyword — this let dies mid-arm, leaving
+            // `__matchtmp…__res_nurl_T = Widget` in the open scopes.
+            : i pub 5
+        }
+        F _ → {}
+    }
+}

--- a/compiler/tests/outputs/diag_match_arm_recover.txt
+++ b/compiler/tests/outputs/diag_match_arm_recover.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_match_arm_recover_mod.nu:23:17: expected variable name in let — 'pub' is a reserved keyword (the visibility prefix on top-level declarations) and cannot name a binding
+            : i pub 5
+                ^
+error: aborting due to 1 previous error

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -41,10 +41,13 @@ Write path (Bearer token):
 
 Plus `GET /api/v1/search?q=` and `GET /api/v1/stats` (JSON), and a
 server-rendered UI: `/` (catalog + search), `/packages/<name>` (owner,
-repository from the tarball's manifest, install snippet, versions,
-dependencies, and the README rendered straight out of the published
-tarball — relative image links rewritten onto the version-pinned
-`/files/<name>/<v>/<path>` asset route, images only, CSP-sandboxed).
+repository from the tarball's manifest, install snippet, versions with
+their publish dates, dependencies, and the README rendered straight out
+of the published tarball — relative image links rewritten onto the
+version-pinned `/files/<name>/<v>/<path>` asset route, images only,
+CSP-sandboxed), and `/packages/<name>/<version>/files` (every file in
+the published tarball with its size — immutable-cacheable, since
+versions are immutable).
 
 ## Design
 

--- a/packages/registry/nurl.toml
+++ b/packages/registry/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "registry"
-version = "0.1.0"
+version = "0.2.0"
 description = "The NURL package registry, served by NURL itself — a self-hostable registry speaking exactly the wire protocol nurlpkg already drives: GET /index/<name>.json + GET /pkgs/<name>/<name>-<v>.tar.gz on the read side, bearer-authenticated POST /api/v1/publish (+ yank/unyank/revoke) on the write side, /api/v1/search + /api/v1/stats, and a server-rendered catalog UI with per-package pages that render the published README straight out of the tarball. SQLite is the single source of truth (users, tokens, packages, versions, deps — the index JSON is rendered from it, never dual-written); tarballs live on disk, checksummed with SHA-256 recomputed server-side. Tokens are peppered-SHA-256 hashed at rest; mint them locally with `registry token new <login>` or via the config-gated GitHub OAuth flow. Built on the http package (HttpApp), the template package (embedded server-rendered pages) and md2html (README rendering) — the registry that hosts NURL packages is itself three NURL packages deep."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl-lang"

--- a/packages/registry/src/db.nu
+++ b/packages/registry/src/db.nu
@@ -19,6 +19,7 @@
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
+$ `stdlib/std/time.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/sqlite.nu`
 
@@ -42,6 +43,9 @@ $ `stdlib/ext/sqlite.nu`
         name          TEXT    PRIMARY KEY,
         owner_user_id INTEGER NOT NULL REFERENCES users(id),
         created_at    INTEGER NOT NULL)` ) )
+    // published_at / created_at are epoch SECONDS (__reg_now). The
+    // Cloudflare Worker's D1 stores epoch MILLISECONDS — any data
+    // migration from D1 into this schema must divide by 1000.
     ( vec_push [String] out ( string_from `CREATE TABLE IF NOT EXISTS versions (
         name         TEXT    NOT NULL REFERENCES packages(name),
         version      TEXT    NOT NULL,
@@ -528,9 +532,10 @@ $ `stdlib/ext/sqlite.nu`
 }
 
 // Package detail for the HTML page:
-//   { "name", "owner", "versions": [ { "version", "yanked", "login" } ],
+//   { "name", "owner", "versions": [ { "version", "yanked", "login", "date" } ],
 //     "latest": version-or-null }
 // Versions newest-first (publication order, matching the Worker page).
+// "date" is "YYYY-MM-DD" (UTC) from published_at — epoch seconds here.
 @ reg_db_pkg_detail_json Database db s name → Json {
     : Json root ( json_obj_new )
     : b _a ( json_obj_set root `name` ( json_str_lit name ) )
@@ -544,7 +549,7 @@ $ `stdlib/ext/sqlite.nu`
     }
     : Json varr ( json_arr_new )
     : ~ b have_latest F
-    ?? ( sqlite_prepare db `SELECT v.version, v.yanked, u.login
+    ?? ( sqlite_prepare db `SELECT v.version, v.yanked, u.login, v.published_at
             FROM versions v JOIN users u ON u.id = v.published_by
             WHERE v.name = ?1 ORDER BY v.published_at DESC, v.rowid DESC` ) {
         T st → {
@@ -557,10 +562,15 @@ $ `stdlib/ext/sqlite.nu`
                     : String ver ( sqlite_column_text st 0 )
                     : i yk ( sqlite_column_int st 1 )
                     : String lg ( sqlite_column_text st 2 )
+                    : i pubts ( sqlite_column_int st 3 )
                     : Json row ( json_obj_new )
                     : b _d ( json_obj_set row `version` ( json_str_lit ( string_data ver ) ) )
                     : b _e ( json_obj_set row `yanked` ( json_bool != yk 0 ) )
                     : b _f ( json_obj_set row `login` ( json_str_lit ( string_data lg ) ) )
+                    : Time pt ( time_from_unix pubts )
+                    : String dt ( time_format pt `%Y-%m-%d` )
+                    : b _f2 ( json_obj_set row `date` ( json_str_lit ( string_data dt ) ) )
+                    ( string_free dt )
                     : b _g ( json_arr_push varr row )
                     ? & ! have_latest == yk 0 {
                         : b _h ( json_obj_set root `latest` ( json_str_lit ( string_data ver ) ) )

--- a/packages/registry/src/extract.nu
+++ b/packages/registry/src/extract.nu
@@ -8,6 +8,7 @@
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/ext/compress.nu`
+$ `stdlib/ext/json.nu`
 $ `stdlib/ext/tar.nu`
 $ `stdlib/ext/toml.nu`
 
@@ -163,6 +164,47 @@ $ `stdlib/ext/toml.nu`
         }
     }
     ^ out
+}
+
+// Every regular file in the tarball, in archive order, as a Json array
+// [ { "path", "size" } ] for the files page. Empty array when the archive
+// is malformed. tar_parse reconstructs USTAR prefix long paths already.
+@ reg_targz_list ( Vec u ) gz → Json {
+    : Json arr ( json_arr_new )
+    : !( Vec u ) CompressErr dr ( gzip_decompress gz )
+    ?? dr {
+        F _ → ^ arr
+        T raw → {
+            : !( Vec TarEntry ) TarErr tr ( tar_parse raw )
+            ( vec_free [u] raw )
+            ?? tr {
+                F _ → ^ arr
+                T ents → {
+                    : i n ( vec_len [TarEntry] ents )
+                    : ~ i k 0
+                    ~ < k n {
+                        : ?TarEntry eo ( vec_get [TarEntry] ents k )
+                        ?? eo {
+                            T e → {
+                                ? == . e typeflag 48 {
+                                    : String norm ( __rx_member_norm ( string_data . e path ) )
+                                    : Json row ( json_obj_new )
+                                    : b _p ( json_obj_set row `path` ( json_str_lit ( string_data norm ) ) )
+                                    : b _s ( json_obj_set row `size` ( json_int ( vec_len [u] . e data ) ) )
+                                    : b _r ( json_arr_push arr row )
+                                    ( string_free norm )
+                                } {}
+                            }
+                            F → {}
+                        }
+                        = k + k 1
+                    }
+                    ( tar_entries_free ents )
+                }
+            }
+        }
+    }
+    ^ arr
 }
 
 // [package].repository from the tarball's root nurl.toml; "" when absent.

--- a/packages/registry/src/pages.nu
+++ b/packages/registry/src/pages.nu
@@ -17,7 +17,7 @@ $ `src/extract.nu`
 // ── Chrome (shared head/foot partials) ────────────────────────────────
 
 @ __reg_tpl_head → s {
-    ^ `<!doctype html><meta charset=utf-8><title>{{ title }}</title><meta name=viewport content="width=device-width,initial-scale=1"><style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;max-width:48rem;margin:3rem auto;padding:0 1rem;line-height:1.6;color:#1a1a1a}a{color:#0b62d6}h1{margin-bottom:.2em}code{background:#f4f4f4;padding:.1em .35em;border-radius:4px;font-size:.92em}pre{background:#f4f4f4;padding:1rem;border-radius:6px;overflow:auto}pre code{background:transparent;padding:0}.readme{border-top:1px solid #e5e5e5;margin-top:2.5rem;padding-top:.5rem}.readme img{max-width:100%}.readme table{border-collapse:collapse;margin:1rem 0}.readme th,.readme td{border:1px solid #ddd;padding:.4rem .7rem;text-align:left}.readme th{background:#f4f4f4}.readme blockquote{border-left:3px solid #ddd;margin:1em 0;padding:.2rem 1rem;color:#555}.readme h1,.readme h2{border-bottom:1px solid #eee;padding-bottom:.2em}.readme hr{border:0;border-top:1px solid #e5e5e5;margin:2rem 0}.site-head{display:flex;align-items:center;gap:.6rem;margin:-1rem 0 1.8rem;padding-bottom:1rem;border-bottom:1px solid #e5e5e5}.site-head .brand{display:flex;align-items:center;gap:.6rem;text-decoration:none;color:#1a1a1a}.site-head .wm{font-size:1.1rem;font-weight:600;letter-spacing:.01em}.site-head .wm b{color:#0b62d6}.site-head .spacer{flex:1}.site-head .home{font-size:.85rem;color:#666;font-weight:400;text-decoration:none}.site-head .home:hover{color:#0b62d6}.muted{color:#666}.yanked{color:#b00}.pub{color:#999}</style><body><div class="site-head"><a class="brand" href="/"><span class="wm">NURL <b>registry</b></span></a><span class="spacer"></span><a class="home" href="https://nurl-lang.org/" target="_blank" rel="noopener">nurl-lang.org →</a></div>`
+    ^ `<!doctype html><meta charset=utf-8><title>{{ title }}</title><meta name=viewport content="width=device-width,initial-scale=1"><style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;max-width:48rem;margin:3rem auto;padding:0 1rem;line-height:1.6;color:#1a1a1a}a{color:#0b62d6}h1{margin-bottom:.2em}code{background:#f4f4f4;padding:.1em .35em;border-radius:4px;font-size:.92em}pre{background:#f4f4f4;padding:1rem;border-radius:6px;overflow:auto}pre code{background:transparent;padding:0}.readme{border-top:1px solid #e5e5e5;margin-top:2.5rem;padding-top:.5rem}.readme img{max-width:100%}.readme table{border-collapse:collapse;margin:1rem 0}.readme th,.readme td{border:1px solid #ddd;padding:.4rem .7rem;text-align:left}.readme th{background:#f4f4f4}.readme blockquote{border-left:3px solid #ddd;margin:1em 0;padding:.2rem 1rem;color:#555}.readme h1,.readme h2{border-bottom:1px solid #eee;padding-bottom:.2em}.readme hr{border:0;border-top:1px solid #e5e5e5;margin:2rem 0}.site-head{display:flex;align-items:center;gap:.6rem;margin:-1rem 0 1.8rem;padding-bottom:1rem;border-bottom:1px solid #e5e5e5}.site-head .brand{display:flex;align-items:center;gap:.6rem;text-decoration:none;color:#1a1a1a}.site-head .wm{font-size:1.1rem;font-weight:600;letter-spacing:.01em}.site-head .wm b{color:#0b62d6}.site-head .spacer{flex:1}.site-head .home{font-size:.85rem;color:#666;font-weight:400;text-decoration:none}.site-head .home:hover{color:#0b62d6}.muted{color:#666}.yanked{color:#b00}.pub{color:#999}.files{border-collapse:collapse;width:100%}.files td{border-bottom:1px solid #eee;padding:.25rem .5rem}.fsize{text-align:right;color:#666}</style><body><div class="site-head"><a class="brand" href="/"><span class="wm">NURL <b>registry</b></span></a><span class="spacer"></span><a class="home" href="https://nurl-lang.org/" target="_blank" rel="noopener">nurl-lang.org →</a></div>`
 }
 
 // ── Page templates ────────────────────────────────────────────────────
@@ -35,9 +35,15 @@ $ `src/extract.nu`
 {% if repository %}<p class=muted>repository <a href="{{ repository }}">{{ repository }}</a></p>{% end %}
 <h3>Install</h3><pre>[dependencies]
 {{ name }} = "{{ req }}"</pre>
-<h3>Versions</h3><ul>{% for v in versions %}<li><code>{{ v.version }}</code>{% if v.yanked %} <span class=yanked>(yanked)</span>{% end %} <span class=pub>· <a href="https://github.com/{{ v.login }}">@{{ v.login }}</a></span></li>{% end %}</ul>
+<h3>Versions</h3><ul>{% for v in versions %}<li><code>{{ v.version }}</code>{% if v.yanked %} <span class=yanked>(yanked)</span>{% end %}{% if v.date %} <span class=pub>· {{ v.date }}</span>{% end %} <span class=pub>· <a href="https://github.com/{{ v.login }}">@{{ v.login }}</a></span> <span class=pub>· <a href="/packages/{{ name }}/{{ v.version }}/files">files</a></span></li>{% end %}</ul>
 <h3>Dependencies (latest)</h3>{% if deps %}<ul>{% for d in deps %}<li><a href="/packages/{{ d.name }}">{{ d.name }}</a> <code>{{ d.req }}</code></li>{% end %}</ul>{% else %}<p>None.</p>{% end %}
 {% if readme %}<div class="readme">{{ readme | raw }}</div>{% end %}`
+}
+
+@ __reg_tpl_files → s {
+    ^ `{% include 'head' %}<p><a href="/packages/{{ name }}">← {{ name }}</a></p><h1>{{ name }} <code>{{ version }}</code></h1>
+<p class=muted>{{ files | length }} file(s) · {{ total }} unpacked</p>
+<table class=files>{% for f in files %}<tr><td><code>{{ f.path }}</code></td><td class=fsize>{{ f.size }}</td></tr>{% end %}</table>`
 }
 
 @ __reg_tpl_notfound → s {
@@ -94,6 +100,11 @@ nurlpkg publish</pre>`
 //        deps:[{name,req}], readme (pre-rendered HTML, ""=none), title }
 @ reg_page_detail Json ctx → String {
     ^ ( __reg_render ( __reg_tpl_detail ) ctx )
+}
+
+// ctx: { name, version, files:[{path,size}] (size pre-formatted), total, title }
+@ reg_page_files Json ctx → String {
+    ^ ( __reg_render ( __reg_tpl_files ) ctx )
 }
 
 @ reg_page_notfound Json ctx → String {

--- a/packages/registry/src/service.nu
+++ b/packages/registry/src/service.nu
@@ -636,6 +636,122 @@ $ `src/pages.nu`
     }
 }
 
+// "512 B" / "1.2 KB" / "3.4 MB" — display size, integer math only.
+@ __reg_fmt_size i n → String {
+    ? < n 1024 {
+        : String out ( string_from ( nurl_str_int n ) )
+        ( string_push_str out ` B` )
+        ^ out
+    } {}
+    : ~ i tenths / * n 10 1024
+    : ~ s unit ` KB`
+    ? >= n * 1024 1024 {
+        = tenths / * n 10 * 1024 1024
+        = unit ` MB`
+    } {}
+    : String out ( string_from ( nurl_str_int / tenths 10 ) )
+    ( string_push_char out 46 )  // '.'
+    ( string_push_str out ( nurl_str_int % tenths 10 ) )
+    ( string_push_str out unit )
+    ^ out
+}
+
+// GET /packages/:name/:version/files — every file in the published
+// tarball (path + size). Version-pinned and versions are immutable, so
+// the page is immutable-cacheable.
+@ __reg_h_pkg_files HttpRequest req Params p → HttpResponse {
+    : ~ String rawname ( string_new )
+    ?? ( params_get p `name` ) {
+        T v → { ( string_free rawname ) = rawname v }
+        F → {}
+    }
+    : String name ( string_to_lower rawname )
+    ( string_free rawname )
+    : ~ String version ( string_new )
+    ?? ( params_get p `version` ) {
+        T v → { ( string_free version ) = version v }
+        F → {}
+    }
+    ? | ! ( reg_name_valid ( string_data name ) ) ! ( reg_version_valid ( string_data version ) ) {
+        : HttpResponse r ( __reg_notfound_page ( string_data name ) )
+        ( string_free name )
+        ( string_free version )
+        ^ r
+    } {}
+    ?? ( reg_db_open g_reg_dbpath ) {
+        F _ → {
+            ( string_free name )
+            ( string_free version )
+            ^ ( __reg_err 500 `db_unavailable` )
+        }
+        T db → {
+            ? ! ( reg_db_version_exists db ( string_data name ) ( string_data version ) ) {
+                : HttpResponse r ( __reg_notfound_page ( string_data name ) )
+                ( string_free name )
+                ( string_free version )
+                ^ r
+            } {}
+            ^ ( __reg_pkg_files_page name version )
+        }
+    }
+}
+
+// The files page body, once the version is known to exist. Owns (and
+// frees) the validated name/version Strings.
+@ __reg_pkg_files_page String name String version → HttpResponse {
+    : ( Vec u ) gz ( reg_tarball_read g_reg_data ( string_data name ) ( string_data version ) )
+    ? == ( vec_len [u] gz ) 0 {
+        ( vec_free [u] gz )
+        : HttpResponse r ( __reg_notfound_page ( string_data name ) )
+        ( string_free name )
+        ( string_free version )
+        ^ r
+    } {}
+    : Json files ( reg_targz_list gz )
+    ( vec_free [u] gz )
+    // Pre-format sizes for display; count + total while walking.
+    : ~ i total 0
+    : i nf ( json_arr_len files )
+    : ~ i k 0
+    ~ < k nf {
+        ?? ( json_arr_get files k ) {
+            T row → {
+                : ~ i sz 0
+                ?? ( json_obj_get row `size` ) {
+                    T sj → { = sz ( json_as_int sj ) }
+                    F → {}
+                }
+                = total + total sz
+                : String hs ( __reg_fmt_size sz )
+                : b _h ( json_obj_set row `size` ( json_str_lit ( string_data hs ) ) )
+                ( string_free hs )
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    : Json ctx ( json_obj_new )
+    : b _n ( json_obj_set ctx `name` ( json_str_lit ( string_data name ) ) )
+    : b _v ( json_obj_set ctx `version` ( json_str_lit ( string_data version ) ) )
+    : b _f ( json_obj_set ctx `files` files )
+    : String tot ( __reg_fmt_size total )
+    : b _t ( json_obj_set ctx `total` ( json_str_lit ( string_data tot ) ) )
+    ( string_free tot )
+    : String title ( string_from ( string_data name ) )
+    ( string_push_char title 32 )
+    ( string_push_str title ( string_data version ) )
+    ( string_push_str title ` — files` )
+    : b _ti ( json_obj_set ctx `title` ( json_str_lit ( string_data title ) ) )
+    ( string_free title )
+    ( string_free name )
+    ( string_free version )
+    : String html ( reg_page_files ctx )
+    ( json_free ctx )
+    : HttpResponse r ( __reg_html_resp 200 html )
+    ( response_set_header r `Cache-Control` `public, max-age=86400, immutable` )
+    ^ r
+}
+
 // Image MIME by lowercased extension; "" = not an allowed asset type.
 // (Images only: keeps the asset route from doubling as a file host.)
 @ __reg_asset_mime s path → s {
@@ -955,6 +1071,7 @@ $ `src/pages.nu`
     ( router_get r `/index/:file` \ HttpRequest req Params p → HttpResponse { ^ ( __reg_h_index req p ) } )
     ( router_get r `/pkgs/:name/:file` \ HttpRequest req Params p → HttpResponse { ^ ( __reg_h_tarball req p ) } )
     ( router_get r `/packages/:name` \ HttpRequest req Params p → HttpResponse { ^ ( __reg_h_pkg_detail req p ) } )
+    ( router_get r `/packages/:name/:version/files` \ HttpRequest req Params p → HttpResponse { ^ ( __reg_h_pkg_files req p ) } )
     ( router_get r `/files/:name/:version/*rest` \ HttpRequest req Params p → HttpResponse { ^ ( __reg_h_file req p ) } )
     ( router_get r `/api/v1/search` \ HttpRequest req Params p → HttpResponse { ^ ( __reg_h_search req p ) } )
     ( router_get r `/api/v1/stats` \ HttpRequest req Params p → HttpResponse { ^ ( __reg_h_stats req p ) } )

--- a/packages/registry/tests/wire.nu
+++ b/packages/registry/tests/wire.nu
@@ -269,7 +269,37 @@ Hello *there*.
         ( check ( string_contains b `/files/demo/0.1.0/docs/pic.png` ) `README image rewritten` )
         ( check ( string_contains b `https://example.com/repo` ) `repository from manifest` )
         ( check ( string_contains b `@tester` ) `owner login shown` )
+        // published_at is stamped at publish (this run) — the version row
+        // carries today's date. Assert the year prefix rather than a full
+        // date so the test doesn't flake across a midnight boundary.
+        : Time now_t ( time_now )
+        : String yr ( time_format now_t `%Y-` )
+        ( check ( string_contains b ( string_data yr ) ) `detail shows publish date` )
+        ( string_free yr )
+        ( check ( string_contains b `/packages/demo/0.1.0/files` ) `detail links files page` )
         ( string_free b )
+        ( http_response_free resp )
+        ( request_free req )
+    }
+
+    // ── files page (tarball listing) ──
+    {
+        : HttpRequest req ( mk_req `GET` `/packages/demo/0.1.0/files` `` ( no_headers ) ( vec_new [u] ) )
+        : HttpResponse resp ( router_handle r req )
+        ( check == . resp status 200 `files page 200` )
+        : String b ( resp_body_str resp )
+        ( check ( string_contains b `README.md` ) `files page lists README.md` )
+        ( check ( string_contains b `docs/pic.png` ) `files page lists docs/pic.png` )
+        ( check ( string_contains b `nurl.toml` ) `files page lists nurl.toml` )
+        ( check ( string_contains b ` B</td>` ) `files page shows sizes` )
+        ( string_free b )
+        ( http_response_free resp )
+        ( request_free req )
+    }
+    {
+        : HttpRequest req ( mk_req `GET` `/packages/demo/9.9.9/files` `` ( no_headers ) ( vec_new [u] ) )
+        : HttpResponse resp ( router_handle r req )
+        ( check == . resp status 404 `files page unknown version 404` )
         ( http_response_free resp )
         ( request_free req )
     }

--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -22,7 +22,7 @@
 // (miniflare simulates R2 + D1) — no Cloudflare account needed to test.
 
 import { renderMarkdown } from "./markdown.ts";
-import { extractReadme, extractFile, extractManifestRepository, normalizeRelPath } from "./readme.ts";
+import { extractReadme, extractFile, extractManifestRepository, normalizeRelPath, listTarFiles } from "./readme.ts";
 
 export interface Env {
   REG_BUCKET: R2Bucket;
@@ -467,7 +467,9 @@ const PAGE_STYLE =
   `.site-head .wm b{color:#0b62d6}` +
   `.site-head .spacer{flex:1}` +
   `.site-head .home{font-size:.85rem;color:#666;font-weight:400;text-decoration:none;transition:color .15s}` +
-  `.site-head .home:hover{color:#0b62d6}`;
+  `.site-head .home:hover{color:#0b62d6}` +
+  `.files{border-collapse:collapse;width:100%}` +
+  `.files td{border-bottom:1px solid #eee;padding:.25rem .5rem}`;
 
 // Branded header injected on every registry page. The mark is served from
 // the main site (nurl-lang.org) and sits on a dark chip so the neon reads
@@ -545,11 +547,11 @@ async function handlePackageDetail(env: Env, name: string): Promise<Response> {
       WHERE p.name = ?`,
   ).bind(name).first<{ login: string }>();
   const pubRows = await env.REG_DB.prepare(
-    `SELECT v.version AS version, u.login AS login
+    `SELECT v.version AS version, u.login AS login, v.published_at AS published_at
        FROM versions v JOIN users u ON u.id = v.published_by
       WHERE v.name = ?`,
-  ).bind(name).all<{ version: string; login: string }>();
-  const pubBy = new Map((pubRows.results ?? []).map((r) => [r.version, r.login]));
+  ).bind(name).all<{ version: string; login: string; published_at: number }>();
+  const pubBy = new Map((pubRows.results ?? []).map((r) => [r.version, r]));
   const ghLink = (login: string) =>
     `<a href="https://github.com/${esc(login)}">@${esc(login)}</a>`;
   const ownerHtml = ownerRow
@@ -558,9 +560,14 @@ async function handlePackageDetail(env: Env, name: string): Promise<Response> {
 
   const versionsHtml = newestFirst.map((v) => {
     const pub = pubBy.get(v.version);
+    // published_at is epoch MILLISECONDS (server clock at publish; in the
+    // schema since day one, so every version has an authoritative date).
+    const date = pub ? new Date(pub.published_at).toISOString().slice(0, 10) : "";
     return `<li><code>${esc(v.version)}</code>` +
       (v.yanked ? ` <span style="color:#b00">(yanked)</span>` : "") +
-      (pub ? ` <span style="color:#999">· ${ghLink(pub)}</span>` : "") +
+      (date ? ` <span style="color:#999">· ${date}</span>` : "") +
+      (pub ? ` <span style="color:#999">· ${ghLink(pub.login)}</span>` : "") +
+      ` <span style="color:#999">· <a href="/packages/${esc(name)}/${esc(v.version)}/files">files</a></span>` +
       `</li>`;
   }).join("");
   const depsHtml = latest && latest.deps.length
@@ -614,6 +621,47 @@ async function handlePackageDetail(env: Env, name: string): Promise<Response> {
     `<h3>Versions</h3><ul>${versionsHtml}</ul>` +
     `<h3>Dependencies (latest)</h3>${depsHtml}` +
     readmeHtml);
+}
+
+// "1.2 KB" / "3.4 MB" — display sizes for the files page.
+function fmtSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// GET /packages/<name>/<version>/files — every file in the published
+// tarball (path + size). Version-pinned and versions are immutable, so
+// the page is immutable-cacheable.
+async function handlePackageFiles(env: Env, name: string, version: string): Promise<Response> {
+  if (!NAME_RE.test(name) || !VERSION_RE.test(version)) {
+    return htmlPage("not found", `<p>Invalid package or version.</p>`, 404);
+  }
+  const idx = await readIndex(env, name);
+  const ver = idx.versions.find((v) => v.version === version);
+  if (!ver) {
+    return htmlPage("not found",
+      `<p><a href="/packages/${esc(name)}">← ${esc(name)}</a></p><p>Version not found.</p>`, 404);
+  }
+  const obj = await env.REG_BUCKET.get(`pkgs/${name}/${name}-${version}.tar.gz`);
+  if (!obj || !obj.body) {
+    return htmlPage("not found",
+      `<p><a href="/packages/${esc(name)}">← ${esc(name)}</a></p><p>Tarball missing.</p>`, 404);
+  }
+  const ab = await new Response(obj.body.pipeThrough(new DecompressionStream("gzip"))).arrayBuffer();
+  const files = listTarFiles(new Uint8Array(ab));
+  const total = files.reduce((s, f) => s + f.size, 0);
+  const rows = files.map((f) =>
+    `<tr><td><code>${esc(f.path)}</code></td>` +
+    `<td style="text-align:right;color:#666">${fmtSize(f.size)}</td></tr>`).join("");
+  const res = htmlPage(`${name} ${version} — files`,
+    `<p><a href="/packages/${esc(name)}">← ${esc(name)}</a></p>` +
+    `<h1>${esc(name)} <code>${esc(version)}</code></h1>` +
+    `<p style="color:#666">${files.length} file(s) · ${fmtSize(total)} unpacked` +
+    (ver.yanked ? ` · <span style="color:#b00">(yanked)</span>` : "") + `</p>` +
+    `<table class=files>${rows}</table>`);
+  res.headers.set("cache-control", "public, max-age=86400, immutable");
+  return res;
 }
 
 async function handleSearch(req: Request, url: URL, env: Env): Promise<Response> {
@@ -806,7 +854,11 @@ export default {
       if (path === "/api/v1/search") return handleSearch(req, url, env);
       if (path === "/api/v1/stats") return handleStats(env);
       if (path.startsWith("/packages/")) {
-        return handlePackageDetail(env, decodeURIComponent(path.slice("/packages/".length)).toLowerCase());
+        const rest = decodeURIComponent(path.slice("/packages/".length));
+        // /packages/<name>/<version>/files — the tarball's file listing.
+        const m = rest.match(/^([^/]+)\/([^/]+)\/files$/);
+        if (m) return handlePackageFiles(env, m[1].toLowerCase(), m[2]);
+        return handlePackageDetail(env, rest.toLowerCase());
       }
       if (path.startsWith("/index/") && path.endsWith(".json")) {
         const name = path.slice("/index/".length, -".json".length).toLowerCase();

--- a/registry/src/readme.ts
+++ b/registry/src/readme.ts
@@ -56,6 +56,47 @@ export function findReadmeInTar(buf: Uint8Array): string | null {
   return hit ? new TextDecoder().decode(hit.data) : null;
 }
 
+export interface TarFileEntry { path: string; size: number; }
+
+// List every regular file in an uncompressed tar image (path + size),
+// in archive order. Unlike findInTar (which only ever matches root-level
+// members, where the 100-byte name field always suffices), a full listing
+// must reconstruct long paths: honour the USTAR `prefix` field and the
+// GNU longname ('L') extension, and skip PAX/GNU metadata pseudo-entries.
+export function listTarFiles(buf: Uint8Array): TarFileEntry[] {
+  const out: TarFileEntry[] = [];
+  let pos = 0;
+  let gnuLongName: string | null = null;
+  while (pos + BLOCK <= buf.length) {
+    if (isZeroBlock(buf, pos)) break; // end-of-archive marker
+    const sizeRaw = readCStr(buf, pos + 124, 12).trim();
+    const size = parseInt(sizeRaw.replace(/[^0-7]/g, "") || "0", 8);
+    const typeflag = buf[pos + 156];
+    const dataStart = pos + BLOCK;
+    if (typeflag === 0x4c) {
+      // GNU 'L': the data block carries the NEXT entry's full path.
+      gnuLongName = readCStr(buf, dataStart, size);
+    } else if (typeflag === 0x30 || typeflag === 0) {
+      const fromLongName = gnuLongName !== null;
+      let path = gnuLongName ?? readCStr(buf, pos, 100);
+      gnuLongName = null;
+      // The USTAR prefix field only applies to names read from the 100-byte
+      // header field, never to a GNU longname (which is already complete).
+      if (!fromLongName && path && readCStr(buf, pos + 257, 6).startsWith("ustar")) {
+        const prefix = readCStr(buf, pos + 345, 155);
+        if (prefix) path = `${prefix}/${path}`;
+      }
+      path = path.replace(/^\.\//, "");
+      if (path) out.push({ path, size });
+    } else {
+      // 'x'/'g' (PAX), 'K' (GNU longlink), directories, links: not files.
+      gnuLongName = null;
+    }
+    pos = dataStart + Math.ceil(size / BLOCK) * BLOCK;
+  }
+  return out;
+}
+
 // Normalise a README-relative path to a tar member path: drop a leading
 // `./`, collapse repeated slashes, and reject traversal / absolute paths.
 // Returns null if the path is unsafe.

--- a/registry/test-local.sh
+++ b/registry/test-local.sh
@@ -106,6 +106,18 @@ check_page "<table>"                       "table"
 check_page '<a href="https://nurl-lang.org"' "link"
 check_page "&lt;script&gt;"                "script escaped as text"
 if echo "$PAGE" | grep -qF "<script>alert"; then echo "  xss: LEAKED"; fail=1; else echo "  xss: neutralised"; fi
+# The version row carries its publish date (from D1 published_at) and a
+# link to the per-version file listing.
+echo "$PAGE" | grep -qE '· [0-9]{4}-[0-9]{2}-[0-9]{2}' && echo "  publish date: OK" || { echo "  publish date: MISSING"; fail=1; }
+check_page '/packages/foo/1.0.0/files'      "files link"
+
+say "files page lists the tarball"
+FPAGE=$(curl -sf "${REG}packages/foo/1.0.0/files" || true)
+check_fpage() { echo "$FPAGE" | grep -qF "$1" && echo "  $2: OK" || { echo "  $2: MISSING"; fail=1; }; }
+check_fpage "src/lib.nu" "lists src/lib.nu"
+check_fpage "nurl.toml"  "lists nurl.toml"
+c=$(curl -s -o /dev/null -w '%{http_code}' "${REG}packages/foo/9.9.9/files")
+[[ "$c" == 404 ]] && echo "  unknown version -> 404: OK" || { echo "  unknown version -> $c (want 404)"; fail=1; }
 
 say "republish -> 409"
 ( cd "$WORK/foo" && NURL_REGISTRY="$REG" NURL_TOKEN="$TOKEN" "$NURLPKG" publish ) && { echo "expected failure"; fail=1; } || echo "rejected (correct)"

--- a/registry/test-readme.ts
+++ b/registry/test-readme.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { gzipSync } from "node:zlib";
 import { renderMarkdown } from "./src/markdown.ts";
-import { findReadmeInTar, normalizeRelPath } from "./src/readme.ts";
+import { findReadmeInTar, normalizeRelPath, listTarFiles } from "./src/readme.ts";
 
 let pass = 0, fail = 0;
 function ok(cond: boolean, msg: string) {
@@ -93,6 +93,61 @@ ok(findReadmeInTar(tarWith("README.md", "# Hi\n")) === "# Hi\n", "extract README
 ok(findReadmeInTar(tarWith("src/main.nu", "x")) === null, "no README -> null");
 // nested-path README is found by basename
 ok(findReadmeInTar(tarWith("nq/README.md", "# nq\n")) === "# nq\n", "README under a dir");
+
+// ── tar file listing (the /packages/<n>/<v>/files page) ───────────────
+// Multi-member archive builder; `typeflag`/`prefix` let one member carry
+// USTAR long-path or GNU-longname metadata.
+function tarMulti(members: { name: string; body: string; typeflag?: number; prefix?: string }[]): Uint8Array {
+  const enc = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  for (const m of members) {
+    const data = enc.encode(m.body);
+    const buf = new Uint8Array(512 + Math.ceil(data.length / 512) * 512);
+    buf.set(enc.encode(m.name), 0);
+    buf.set(enc.encode("0000644\0"), 100);
+    buf.set(enc.encode(data.length.toString(8).padStart(11, "0") + "\0"), 124);
+    buf[156] = m.typeflag ?? 0x30;
+    buf.set(enc.encode("ustar\0"), 257);
+    buf.set(enc.encode("00"), 263);
+    if (m.prefix) buf.set(enc.encode(m.prefix), 345);
+    buf.set(data, 512);
+    parts.push(buf);
+  }
+  parts.push(new Uint8Array(1024)); // end-of-archive
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let off = 0;
+  for (const p of parts) { out.set(p, off); off += p.length; }
+  return out;
+}
+{
+  const files = listTarFiles(tarMulti([
+    { name: "nurl.toml", body: "[package]\n" },
+    { name: "./src/main.nu", body: "code" },
+    { name: "docs/", body: "", typeflag: 0x35 },               // directory: skipped
+    { name: "docs/pic.png", body: "png-bytes" },
+  ]));
+  ok(files.length === 3, `listing has 3 files (got ${files.length})`);
+  ok(files[0].path === "nurl.toml" && files[0].size === 10, "member path + size");
+  ok(files[1].path === "src/main.nu", "leading ./ stripped");
+  ok(files.every((f) => f.path !== "docs/"), "directory member skipped");
+}
+{
+  // USTAR prefix reassembly for >100-char paths.
+  const files = listTarFiles(tarMulti([{ name: "leaf.nu", body: "x", prefix: "very/deep/dir" }]));
+  ok(files[0].path === "very/deep/dir/leaf.nu", "ustar prefix joined");
+}
+{
+  // GNU longname: an 'L' pseudo-entry carries the NEXT member's path and
+  // must itself not appear in the listing (nor pick up the ustar prefix).
+  const files = listTarFiles(tarMulti([
+    { name: "././@LongLink", body: "some/very/long/path/file.nu\0", typeflag: 0x4c },
+    { name: "some/very/long/path/", body: "y", prefix: "ignored-for-longname" },
+    { name: "plain.nu", body: "z" },
+  ]));
+  ok(files.length === 2, `longname listing has 2 files (got ${files.length})`);
+  ok(files[0].path === "some/very/long/path/file.nu", "GNU longname applied");
+  ok(files[1].path === "plain.nu", "longname does not leak to later members");
+}
 
 // ── round-trip: real nq README renders without throwing ───────────────
 try {


### PR DESCRIPTION
## Registry — what files a package contains + when versions were published

Goal: the registry shows each package's file contents, and version publish dates **if** dates can be read back reliably. They can: `published_at` has been in the D1 schema since the registry's first commit (2026-06-03), written server-side at publish — every version has an authoritative date, and nothing is guessed from client-controlled tar/gzip timestamps.

Implemented in **both** registries (live Cloudflare Worker + `packages/registry`, bumped to 0.2.0):

* **Publish dates** on `/packages/<name>` version rows (`· YYYY-MM-DD`), joined from `versions.published_at`.
* **`GET /packages/<name>/<version>/files`** — every file in the published tarball with its size; USTAR-prefix and GNU-longname long paths reconstructed, PAX/GNU metadata pseudo-entries skipped. Version-pinned → `immutable` cache. Linked from each version row.
* Schema comment pins the unit mismatch found on the way: `packages/registry` stores epoch **seconds**, the Worker's D1 stores **milliseconds** — a future D1→SQLite migration must divide by 1000.

## nurlc — diagnostic-recovery scope leak (found by this work)

Adding `: i pub …` to db.nu (`pub` is reserved) produced **five phantom `%Statement` type errors in semver.nu and template.nu** — modules nowhere near the change. Root cause: a `die` inside a `?`/`??` arm panics out of the open function/arm symbol-table scopes; the per-declaration recovery frame resynced the lexer but left the scopes pushed. gen_match's synthetic `__matchtmp<n>__res_nurl_T` payload keys leaked, and since the label counter numbering them resets per function, a later same-numbered option match in an unrelated file read the dead declaration's key and typed its payload with a foreign struct.

Fix: the recovery frame pops the leaked scopes back to depth 0 (freeing their entries) before resyncing. Plus a targeted hint: `: i pub …` now says `pub` is a reserved keyword.

Regression test `diag_match_arm_recover` pins it — pre-fix it reports a phantom `type 'Widget' has no field 'a'`, post-fix exactly the one real error.

## Verification

* Compiler: full bootstrap + suite **546 PASS / 0 FAIL** (new test + golden included).
* `packages/registry` wire tests **43/43**, also `NURL_SAN=1` — zero leaks (the files handler returns from inside the `??`-arm so the `Database` auto-drop fires, matching every other handler).
* Worker: `tsc --noEmit` clean, `test-readme.ts` **54/54** (new `listTarFiles` units incl. ustar-prefix + GNU-longname), `test-local.sh` e2e **PASS** with new date / files-page / unknown-version-404 checks.

## Deploy note

`registry-deploy.yml` is manual (`workflow_dispatch`) — trigger it after merge to ship the Worker. `packages/registry` 0.2.0 publish to reg.nurl-lang.org is user-only, as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH