### PR TITLE
release: v0.16.0 — provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] — 2026-07-16
+
+The **provenance** release: the registry shows what a package contains and
+when every version shipped, nurlpkg learns to move requirements forward
+instead of making you hand-edit manifests, and one bad token inside a
+match arm no longer buries the real diagnostic under phantom errors.
+
 ### Added
 
 - **`nurlpkg update` — move dependency requirements to the newest
@@ -22,17 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   requirement the newest version already satisfies is left untouched,
   and edits are surgical: only the version value on the dep's line
   changes, so `path =` keys, formatting and comments survive.
-
-### Fixed
-
-- nurlpkg `add`/`remove` leaked one trimmed String per manifest line
-  walked (the shared dep-line matchers returned through early exits),
-  plus the initial empty buffer when reading `nurl.toml`. All
-  line-machinery commands (`add`, `remove`, `update`) are now
-  LeakSanitizer-clean.
-
-### Added
-
 - **Registry package pages show publish dates and a per-version file
   listing.** Each version row on `/packages/<name>` carries its publish
   date — read from the authoritative server-side `published_at` recorded
@@ -58,6 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`: i pub …` explains itself.** Naming a let binding `pub` now says the
   word is a reserved keyword (the visibility prefix on top-level
   declarations) instead of the bare "expected variable name in let".
+- nurlpkg `add`/`remove` leaked one trimmed String per manifest line
+  walked (the shared dep-line matchers returned through early exits),
+  plus the initial empty buffer when reading `nurl.toml`. All
+  line-machinery commands (`add`, `remove`, `update`) are now
+  LeakSanitizer-clean.
 
 ## [0.15.0] — 2026-07-14
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-07-13 · Current release: **0.15.0** · Language: **Grammar
+_Last reviewed: 2026-07-16 · Current release: **0.16.0** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
Cuts **v0.16.0**: consolidates the `[Unreleased]` entries from #505 and #506 under a dated heading and bumps the ROADMAP current-release line.

The **provenance** release:
- registry package pages show publish dates + a per-version file listing (both Worker and `packages/registry` 0.2.0)
- `nurlpkg update` moves dependency requirements to the newest versions (y/N per dep, `--all` for everything)
- nurlc: a diagnostic inside a `?`/`??` arm no longer cascades into phantom cross-file type errors; `pub`-as-binding gets a reserved-keyword hint
- nurlpkg add/remove/update line machinery is LeakSanitizer-clean

After merge: tag `v0.16.0` on the merge commit → release.yml builds + minisign-signs the archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH