### PR TITLE
publish prep: md2html 0.1.2, registry http ^0.3

### DIFF
--- a/packages/md2html/nurl.toml
+++ b/packages/md2html/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md2html"
-version = "0.1.1"
+version = "0.1.2"
 description = "Render Markdown to HTML — a small CLI and reusable renderer library."
 license = "MIT OR Apache-2.0"
 

--- a/packages/registry/nurl.toml
+++ b/packages/registry/nurl.toml
@@ -6,6 +6,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl-lang"
 
 [dependencies]
-http = { path = "../http", version = "^0.2" }
+http = { path = "../http", version = "^0.3" }
 template = { path = "../template", version = "^0.1" }
 md2html = { path = "../md2html", version = "^0.1" }


### PR DESCRIPTION
Two manifest changes that unblock publishing `registry` 0.2.0:

* **md2html 0.1.1 → 0.1.2** — local source drifted from the published 0.1.1 tarball (`__`→`_` private-helper rename + nurlfmt normalisation; functionally identical). The publish drift gate demands a fresh version for fresh bytes.
* **registry: `http = ^0.2` → `^0.3`** — covers the local and published http 0.3.0 (the exact case `nurlpkg update` now automates).

Publish order after merge: `md2html` 0.1.2 → `registry` 0.2.0 (http 0.3.0 and template 0.1.0 are already published; template has no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH