### PR TITLE
MCP search that works: nurl_api + nurl_grep, ranked changelog, registry descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP: `nurl_api` — a stdlib module's API surface, or a search across
+  all of them.** `module='ext/csv.nu'` returns signatures, doc comments
+  and full type definitions with no function bodies (11 KB where the
+  source is 63 KB); `query='csv quote'` returns just the declarations
+  whose signature/doc/module-path contain every term. Backed by nurldoc,
+  which now omits `__`-private (file-scoped, uncallable) functions and
+  renders a multi-line type declaration's full field list in a fenced
+  code block — the /stdlib-docs pages get both fixes too.
+- **MCP: `nurl_grep`** — case-insensitive substring search across stdlib
+  sources, examples and compiler tests (`path:line: text`, per-file and
+  total caps), plus the package registry by name AND description — "does
+  a package for X exist" is one cheap call.
+- **Registry: package descriptions are stored, served and searchable.**
+  `[package].description` is extracted server-side from the published
+  tarball on every publish (latest wins; never a client header), shown
+  in the catalog, returned by `/api/v1/search`, and matched by it — in
+  both the Cloudflare Worker (D1 migration 0003 +
+  `/api/v1/admin/desc-backfill` for pre-existing packages) and
+  `packages/registry` 0.3.0. `nurlpkg search` prints them.
+
+### Changed
+
+- **MCP: `nurl_changelog` results are ranked, and every match stays
+  visible.** Entries whose TITLE carries the search terms outrank
+  passing mentions; the top `limit` matches return in full and every
+  further match appears as a one-line provenance+title (previously the
+  newest N matches consumed the byte cap and the rest were an opaque
+  "77 omitted" count). `compact=true` gives a titles-only overview.
+
 ## [0.16.0] — 2026-07-16
 
 The **provenance** release: the registry shows what a package contains and

--- a/compiler/tests/nurldoc.nu
+++ b/compiler/tests/nurldoc.nu
@@ -1,8 +1,10 @@
 // nurldoc.nu — ext/nurldoc.nu acceptance: render a fixture module's doc
 // surface to Markdown. Exercises: module-header block → prose, doc
 // comment above a decl → description, signature trimmed at `{`, FFI / `:`
-// const / struct / enum decls, and that `:` locals inside a function body
-// (brace depth > 0) are NOT picked up.
+// const / struct / enum decls, that `:` locals inside a function body
+// (brace depth > 0) are NOT picked up, that `__`-private (file-scoped)
+// functions are omitted, and that a multi-line type declaration renders
+// its full field list in a fenced code block.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/ext/nurldoc.nu`
@@ -25,6 +27,17 @@ $ `stdlib/ext/nurldoc.nu`
     ( string_push_str src `\n` )
     ( string_push_str src `// A point.\n` )
     ( string_push_str src `: Point { i x i y }\n` )
+    ( string_push_str src `\n` )
+    ( string_push_str src `// Internal helper — file-scoped, must NOT appear in the docs.\n` )
+    ( string_push_str src `@ __hidden i a → i {\n` )
+    ( string_push_str src `    ^ a\n` )
+    ( string_push_str src `}\n` )
+    ( string_push_str src `\n` )
+    ( string_push_str src `// A rectangle (multi-line: fields must render in a code block).\n` )
+    ( string_push_str src `: Rect {\n` )
+    ( string_push_str src `    i w  // width\n` )
+    ( string_push_str src `    i h\n` )
+    ( string_push_str src `}\n` )
     ( string_push_str src `\n` )
     ( string_push_str src `: | Color { Red Green Blue }\n` )  // no doc comment
     ( string_push_str src `\n` )

--- a/compiler/tests/outputs/nurldoc.txt
+++ b/compiler/tests/outputs/nurldoc.txt
@@ -17,6 +17,18 @@ Add two ints.
 
 A point.
 
+### `: Rect`
+
+```nurl
+: Rect {
+    i w  // width
+    i h
+}
+```
+
+A rectangle (multi-line: fields must render in a code block).
+
+
 ### `: | Color { Red Green Blue }`
 
 ### `& `c` @ getpid → i`

--- a/nurlapi/e2e_test.py
+++ b/nurlapi/e2e_test.py
@@ -186,13 +186,15 @@ def t_mcp_info(c: Client) -> None:
     assert_eq("transport", j.get("transport"), "streamable-http")
     assert_eq("url_path", j.get("url_path"), "/mcp")
     tools = j.get("tools", [])
-    assert_eq("16 tools advertised", len(tools), 16)
+    assert_eq("18 tools advertised", len(tools), 18)
     for t in (
         "nurl_build_native",
         "nurl_build_wasm",
         "nurl_list_examples",
         "nurl_read_grammar",
         "nurl_changelog",
+        "nurl_api",
+        "nurl_grep",
     ):
         assert_true(f"tool {t} listed", t in tools)
     assert_true(
@@ -244,7 +246,7 @@ def t_tools_list(c: Client) -> None:
     print("\n[MCP] tools/list")
     _, _, env = c.rpc({"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
     tools = env.get("result", {}).get("tools", [])
-    assert_eq("16 tools", len(tools), 16)
+    assert_eq("18 tools", len(tools), 18)
     names = {t.get("name") for t in tools}
     for required in (
         "nurl_build_native",
@@ -263,6 +265,8 @@ def t_tools_list(c: Client) -> None:
         "nurl_read_roadmap",
         "nurl_read_gotchas",
         "nurl_changelog",
+        "nurl_api",
+        "nurl_grep",
     ):
         assert_true(f"tools/list has {required}", required in names)
     # Each tool has description + inputSchema.
@@ -361,6 +365,48 @@ def t_tools_call_changelog(c: Client) -> None:
     env = _tool_call(c, "nurl_changelog", {"query": "zzz-no-such-term-zzz"})
     text = _tool_text(env)
     assert_true("no-match has guidance", "No matches" in text)
+
+
+def t_tools_call_api(c: Client) -> None:
+    print("\n[MCP] tools/call nurl_api (module / query / errors)")
+
+    # Module mode: csv.nu's API surface — signatures + type definitions,
+    # no function bodies, __-private helpers omitted.
+    env = _tool_call(c, "nurl_api", {"module": "ext/csv.nu"})
+    text = _tool_text(env)
+    assert_true("module renders header prose", "CSV reader/writer" in text)
+    assert_true("module renders signatures", "csv_reader_next" in text)
+    assert_true("module renders type fields", "quote_char" in text)
+    assert_true("module omits function bodies", "string_push_char" not in text)
+    assert_true("module omits __-private helpers", "__csv_drop_string" not in text)
+
+    # Query mode: AND-matched terms over declaration blocks.
+    env = _tool_call(c, "nurl_api", {"query": "csv quote"})
+    text = _tool_text(env)
+    assert_true("query reports match count", "declaration(s) match" in text)
+    assert_true("query finds the dialect struct", "CSVDialect" in text)
+
+    # Errors: unknown module, and neither argument.
+    env = _tool_call(c, "nurl_api", {"module": "ext/zzz-nope.nu"})
+    assert_true("unknown module errors", bool(env.get("result", {}).get("isError")))
+    env = _tool_call(c, "nurl_api", {})
+    assert_true("missing args errors", bool(env.get("result", {}).get("isError")))
+
+
+def t_tools_call_grep(c: Client) -> None:
+    print("\n[MCP] tools/call nurl_grep (stdlib scope / caps / missing pattern)")
+
+    env = _tool_call(c, "nurl_grep", {"pattern": "time_format", "where": "stdlib"})
+    text = _tool_text(env)
+    assert_true("grep reports line count", "line(s) match" in text)
+    assert_true("grep returns path:line hits", "stdlib/std/time.nu:" in text)
+
+    env = _tool_call(c, "nurl_grep", {"pattern": "zzz-no-such-thing-zzz", "where": "stdlib"})
+    text = _tool_text(env)
+    assert_true("grep no-match reports zero", text.startswith("0 line(s)"))
+
+    env = _tool_call(c, "nurl_grep", {})
+    assert_true("missing pattern errors", bool(env.get("result", {}).get("isError")))
 
 
 def t_tools_call_traversal(c: Client) -> None:
@@ -599,6 +645,8 @@ def main() -> int:
     t_tools_call_listing(c)
     t_tools_call_reads(c)
     t_tools_call_changelog(c)
+    t_tools_call_api(c)
+    t_tools_call_grep(c)
     t_tools_call_traversal(c)
     t_tools_call_unknown(c)
     if not args.quick:

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -3,6 +3,7 @@ $ `stdlib/ext/env.nu`
 $ `stdlib/std/fs.nu`
 $ `stdlib/std/process.nu`
 $ `stdlib/std/path.nu`
+$ `stdlib/std/url.nu`
 $ `stdlib/std/time.nu`
 $ `stdlib/std/encode.nu`
 $ `stdlib/std/int.nu`
@@ -1731,6 +1732,8 @@ s combined_stdout s combined_stderr → v {
     ( __mcp_info_push_str tools `nurl_read_roadmap` )
     ( __mcp_info_push_str tools `nurl_read_gotchas` )
     ( __mcp_info_push_str tools `nurl_changelog` )
+    ( __mcp_info_push_str tools `nurl_api` )
+    ( __mcp_info_push_str tools `nurl_grep` )
     ( json_obj_set j `tools` tools )
 
     : Json resources ( json_arr_new )
@@ -4144,12 +4147,19 @@ s combined_stdout s combined_stderr → v {
 @ __cl_out_cap → i { ^ 32768 }
 
 // Flush one accumulated ent: count it, run the release filter and the
-// term match, and append it to `out` when within `limit` and the byte
-// cap. `ctr` is the shared [total, matched, emitted] counter Vec (Vec is
-// a shared boxed handle — mutations are visible to the caller). Clears
-// `ent` so the caller can keep accumulating into the same String.
+// term match, and COLLECT matches (provenance, body, relevance score)
+// into the m_* vectors — ranking and emission happen after the walk, so
+// the byte cap keeps the most relevant entries, not merely the newest.
+// `ctr` is the shared [total, matched] counter Vec (Vec is a shared
+// boxed handle — mutations are visible to the caller). Clears `ent` so
+// the caller can keep accumulating into the same String.
+//
+// Score: a term hitting the entry's TITLE (the bullet's first line)
+// counts 3, anywhere else 1 — "when did csv quoting change" should
+// surface the entry ABOUT csv quoting above every entry that merely
+// mentions csv in passing.
 @ __cl_flush String ent String cur_rel String cur_rel_lc String cur_cat
-( Vec String ) terms String rel_lc String out i limit ( Vec i ) ctr → v {
+( Vec String ) terms String rel_lc ( Vec String ) m_prov ( Vec String ) m_body ( Vec i ) m_score ( Vec i ) ctr → v {
     ? > ( string_len ent ) 0 {
         // Trim trailing blank lines / whitespace off the body.
         : ~ i e ( string_len ent )
@@ -4179,14 +4189,33 @@ s combined_stdout s combined_stderr → v {
             ? ( __cl_terms_match hay_lc terms ) {
                 : i matched ?? ( vec_get [i] ctr 1 ) { T v → v F _ → 0 }
                 ( vec_set [i] ctr 1 + matched 1 )
-                : i emitted ?? ( vec_get [i] ctr 2 ) { T v → v F _ → 0 }
-                ? & < emitted limit < ( string_len out ) ( __cl_out_cap ) {
-                    ( string_push_str out ( string_data prov ) )
-                    ( string_push_char out 10 )
-                    ( string_push_str out ( string_data body ) )
-                    ( string_push_str out `\n\n` )
-                    ( vec_set [i] ctr 2 + emitted 1 )
-                } {}
+                // Title = the body's first line.
+                : ~ i te 0
+                : i bn ( string_len body )
+                ~ & < te bn != ( string_get body te ) 10 { = te + te 1 }
+                : String title ( string_substr body 0 te )
+                : String title_lc ( string_to_lower title )
+                ( string_free title )
+                : ~ i score 0
+                : i tn ( vec_len [String] terms )
+                : ~ i tk 0
+                ~ < tk tn {
+                    ?? ( vec_get [String] terms tk ) {
+                        T t → {
+                            ? > ( string_len t ) 0 {
+                                ? >= ( nurl_str_find ( string_data title_lc ) ( string_data t ) ) 0 {
+                                    = score + score 3
+                                } { = score + score 1 }
+                            } {}
+                        }
+                        F _ → {}
+                    }
+                    = tk + tk 1
+                }
+                ( string_free title_lc )
+                ( vec_push [String] m_prov ( string_from ( string_data prov ) ) )
+                ( vec_push [String] m_body ( string_from ( string_data body ) ) )
+                ( vec_push [i] m_score score )
             } {}
             ( string_free hay_lc ) ( string_free hay ) ( string_free prov )
         } {}
@@ -4199,7 +4228,7 @@ s combined_stdout s combined_stderr → v {
 // Continuation lines are indented or blank; a non-indented line that is
 // not a bullet or heading (intro prose, the link-reference definitions
 // at the bottom) terminates the open ent without joining it.
-@ __changelog_entries String src ( Vec String ) terms String rel_lc String out i limit ( Vec i ) ctr → v {
+@ __changelog_entries String src ( Vec String ) terms String rel_lc ( Vec String ) m_prov ( Vec String ) m_body ( Vec i ) m_score ( Vec i ) ctr → v {
     : ( Vec String ) lines ( string_split src `\n` )
     : i nl ( vec_len [String] lines )
     : ~ String cur_rel ( string_from `` )
@@ -4212,19 +4241,19 @@ s combined_stdout s combined_stderr → v {
             T line → {
                 : i ln ( string_len line )
                 ? ( string_starts_with line `## ` ) {
-                    ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc out limit ctr )
+                    ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc m_prov m_body m_score ctr )
                     ( string_free cur_rel ) = cur_rel ( string_substr line 3 - ln 3 )
                     ( string_free cur_rel_lc ) = cur_rel_lc ( string_to_lower cur_rel )
                     ( string_free cur_cat ) = cur_cat ( string_from `` )
                 } {
                     ? ( string_starts_with line `### ` ) {
-                        ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc out limit ctr )
+                        ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc m_prov m_body m_score ctr )
                         ( string_free cur_cat ) = cur_cat ( string_substr line 4 - ln 4 )
                     } {
                         // Both bullet styles appear in the file: `- ` in the
                         // 0.9.1+ sections, `* ` in the older ones.
                         ? | ( string_starts_with line `- ` ) ( string_starts_with line `* ` ) {
-                            ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc out limit ctr )
+                            ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc m_prov m_body m_score ctr )
                             ( string_push_str ent ( string_data line ) )
                             ( string_push_char ent 10 )
                         } {
@@ -4239,7 +4268,7 @@ s combined_stdout s combined_stderr → v {
                                     ( string_push_char ent 10 )
                                 } {}
                             } {
-                                ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc out limit ctr )
+                                ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc m_prov m_body m_score ctr )
                             }
                         }
                     }
@@ -4249,7 +4278,7 @@ s combined_stdout s combined_stderr → v {
         }
         = li + li 1
     }
-    ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc out limit ctr )
+    ( __cl_flush ent cur_rel cur_rel_lc cur_cat terms rel_lc m_prov m_body m_score ctr )
     ( string_free cur_rel ) ( string_free cur_rel_lc ) ( string_free cur_cat ) ( string_free ent )
     ( vec_free_with [String] lines \ String l → v { ( string_free l ) } )
 }
@@ -4310,6 +4339,7 @@ s combined_stdout s combined_stderr → v {
 @ __mcp_tool_changelog Json args → Json {
     : s query ( __mcp_args_get `query` args `` )
     : s release ( __mcp_args_get `release` args `` )
+    : b compact ( __mcp_args_get_bool `compact` args F )
     : ~ i limit ( __mcp_args_get_int `limit` args 10 )
     ? < limit 1 { = limit 1 } {}
     ? > limit 50 { = limit 50 } {}
@@ -4330,13 +4360,85 @@ s combined_stdout s combined_stderr → v {
             : String q_lc ( __lc_owned query )
             : ( Vec String ) terms ( string_split q_lc ` ` )
             : String rel_lc ( __lc_owned release )
-            : String out ( string_with_cap 4096 )
+            : ( Vec String ) m_prov ( vec_new [String] )
+            : ( Vec String ) m_body ( vec_new [String] )
+            : ( Vec i ) m_score ( vec_new [i] )
             : ( Vec i ) ctr ( vec_new [i] )
-            ( vec_push [i] ctr 0 ) ( vec_push [i] ctr 0 ) ( vec_push [i] ctr 0 )
-            ( __changelog_entries src terms rel_lc out limit ctr )
+            ( vec_push [i] ctr 0 ) ( vec_push [i] ctr 0 )
+            ( __changelog_entries src terms rel_lc m_prov m_body m_score ctr )
             : i total ?? ( vec_get [i] ctr 0 ) { T v → v F _ → 0 }
             : i matched ?? ( vec_get [i] ctr 1 ) { T v → v F _ → 0 }
-            : i emitted ?? ( vec_get [i] ctr 2 ) { T v → v F _ → 0 }
+
+            // Rank: score descending, walk order (newest-first) among
+            // equals. Insertion sort over an index array — 650 entries max.
+            : ( Vec i ) order ( vec_new [i] )
+            : ~ i oi 0
+            ~ < oi matched {
+                ( vec_push [i] order oi )
+                = oi + oi 1
+            }
+            : ~ i si 1
+            ~ < si matched {
+                : i cur ?? ( vec_get [i] order si ) { T v → v F _ → 0 }
+                : i cur_sc ?? ( vec_get [i] m_score cur ) { T v → v F _ → 0 }
+                : ~ i sj si
+                : ~ b moving T
+                ~ & moving > sj 0 {
+                    : i prev ?? ( vec_get [i] order - sj 1 ) { T v → v F _ → 0 }
+                    : i prev_sc ?? ( vec_get [i] m_score prev ) { T v → v F _ → 0 }
+                    ? < prev_sc cur_sc {
+                        ( vec_set [i] order sj prev )
+                        = sj - sj 1
+                    } { = moving F }
+                }
+                ( vec_set [i] order sj cur )
+                = si + si 1
+            }
+
+            // Emit: full text for the top `limit` (byte-capped); the rest
+            // as one-line provenance+title so nothing relevant is invisible.
+            : String out ( string_with_cap 4096 )
+            : ~ i emitted 0
+            : ~ b other_hdr F
+            : ~ i ek 0
+            ~ < ek matched {
+                : i idx ?? ( vec_get [i] order ek ) { T v → v F _ → 0 }
+                : ~ String prov ( string_new )
+                ?? ( vec_get [String] m_prov idx ) { T v → { ( string_free prov ) = prov v } F _ → {} }
+                : ~ String bod ( string_new )
+                ?? ( vec_get [String] m_body idx ) { T v → { ( string_free bod ) = bod v } F _ → {} }
+                ? & & ! compact < emitted limit < ( string_len out ) ( __cl_out_cap ) {
+                    ( string_push_str out ( string_data prov ) )
+                    ( string_push_char out 10 )
+                    ( string_push_str out ( string_data bod ) )
+                    ( string_push_str out `\n\n` )
+                    = emitted + emitted 1
+                } {
+                    // Compact line: provenance — title (first line, ≤120 b).
+                    ? < ( string_len out ) ( __cl_out_cap ) {
+                        ? & ! compact ! other_hdr {
+                            ( string_push_str out `Other matches (title only — fetch one with a narrower query):\n` )
+                            = other_hdr T
+                        } {}
+                        ( string_push_str out `  · ` )
+                        ( string_push_str out ( string_data prov ) )
+                        ( string_push_str out ` — ` )
+                        : i bn ( string_len bod )
+                        : ~ i te 0
+                        ~ & & < te bn < te 120 != ( string_get bod te ) 10 { = te + te 1 }
+                        : ~ i j 0
+                        : s braw ( string_data bod )
+                        ~ < j te {
+                            ( string_push_char out ( nurl_str_get braw j ) )
+                            = j + j 1
+                        }
+                        ? & < te bn != ( string_get bod te ) 10 { ( string_push_str out `…` ) } {}
+                        ( string_push_char out 10 )
+                        = emitted + emitted 1
+                    } {}
+                }
+                = ek + ek 1
+            }
 
             : String hdr ( string_with_cap + ( string_len out ) 256 )
             ( string_push_int hdr matched )
@@ -4353,7 +4455,7 @@ s combined_stdout s combined_stderr → v {
                 ( string_push_str hdr release )
                 ( string_push_str hdr `'` )
             } {}
-            ( string_push_str hdr `.\n\n` )
+            ( string_push_str hdr ` (ranked: title hits first).\n\n` )
             ( string_push_str hdr ( string_data out ) )
             ? == matched 0 {
                 ( string_push_str hdr `No matches — terms are AND-ed substrings; try fewer or shorter terms, or call without arguments for the release index.\n` )
@@ -4361,11 +4463,14 @@ s combined_stdout s combined_stderr → v {
             ? > matched emitted {
                 ( string_push_str hdr `… ` )
                 ( string_push_int hdr - matched emitted )
-                ( string_push_str hdr ` more matching entries omitted (limit/byte cap) — narrow the query, filter by release, or raise 'limit'.\n` )
+                ( string_push_str hdr ` more matching entries omitted (byte cap) — narrow the query or filter by release.\n` )
             } {}
             : Json result ( __mcp_result_text ( string_data hdr ) )
             ( string_free hdr ) ( string_free out ) ( string_free rel_lc )
             ( vec_free_with [String] terms \ String t → v { ( string_free t ) } )
+            ( vec_free_with [String] m_prov \ String v → v { ( string_free v ) } )
+            ( vec_free_with [String] m_body \ String v → v { ( string_free v ) } )
+            ( vec_free [i] m_score ) ( vec_free [i] order )
             ( string_free q_lc ) ( vec_free [i] ctr ) ( string_free src )
             ^ result
         }
@@ -4384,6 +4489,467 @@ s combined_stdout s combined_stderr → v {
     ( json_obj_set props `limit`
     ( __mcp_prop `integer` `Maximum entries to return (default 10, max 50). Output is also byte-capped at 32 KB.` ) )
     ( json_obj_set schema `properties` props )
+    ^ schema
+}
+
+// Boolean tool argument: JSON true/false → b; absent / other → default.
+@ __mcp_args_get_bool s key Json args b default → b {
+    : ?Json v ( json_obj_get args key )
+    ?? v {
+        T j → { ^ ? ( json_is_bool j ) ( json_as_bool j ) default }
+        F _ → { ^ default }
+    }
+}
+
+// ── nurl_api — a module's API surface, or a search across all of them ─
+//
+// nurl_read_stdlib returns whole modules; ext/csv.nu is 63 KB of which
+// an agent usually needs the ~11 KB doc surface — signatures, doc
+// comments, full type definitions — or just the three declarations that
+// match a question. `module` renders one module through nurldoc (no
+// function bodies; `__`-private helpers omitted). `query` AND-matches
+// terms against every stdlib module's declaration blocks (signature +
+// doc comment + type definition) and returns the matching blocks.
+
+@ __api_out_cap → i { ^ 28672 }
+
+// Render one stdlib module's doc surface; "" when unreadable.
+@ __api_render_module s rel → String {
+    : String dir ( get_stdlib_dir )
+    : String fp ( path_join ( string_data dir ) rel )
+    ( string_free dir )
+    : !( Vec u ) IoErr rd ( read_file_bytes ( string_data fp ) )
+    ( string_free fp )
+    ?? rd {
+        T bytes → {
+            : String src ( bytes_to_str bytes )
+            ( vec_free [u] bytes )
+            : String md ( nurldoc_render ( string_data src ) rel )
+            ( string_free src )
+            ^ md
+        }
+        F _ → ^ ( string_new )
+    }
+}
+
+// AND-match every non-empty lowercase term against hay_lc.
+@ __api_terms_match String hay_lc ( Vec String ) terms → b {
+    : i n ( vec_len [String] terms )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] terms k ) {
+            T t → {
+                ? & > ( string_len t ) 0 < ( nurl_str_find ( string_data hay_lc ) ( string_data t ) ) 0 { ^ F } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ T
+}
+
+// Match one rendered module's "### "-delimited declaration blocks and
+// append hits to `out`. ctr = [matched, emitted].
+@ __api_match_blocks String md s rel ( Vec String ) terms String out ( Vec i ) ctr → v {
+    : ( Vec String ) parts ( string_split md `\n### ` )
+    : i np ( vec_len [String] parts )
+    : ~ i k 1  // part 0 = title + module header, not a declaration block
+    ~ < k np {
+        ?? ( vec_get [String] parts k ) {
+            T blk → {
+                : String hay ( string_with_cap + ( string_len blk ) 64 )
+                ( string_push_str hay rel )
+                ( string_push_char hay 32 )
+                ( string_push_str hay ( string_data blk ) )
+                : String hay_lc ( string_to_lower hay )
+                ( string_free hay )
+                ? ( __api_terms_match hay_lc terms ) {
+                    : i matched ?? ( vec_get [i] ctr 0 ) { T v → v F _ → 0 }
+                    ( vec_set [i] ctr 0 + matched 1 )
+                    ? < ( string_len out ) ( __api_out_cap ) {
+                        // Block body, trimmed to keep many hits in view.
+                        ( string_push_str out rel )
+                        ( string_push_str out ` › ` )
+                        : i bn ( string_len blk )
+                        : i keep ? > bn 700 700 bn
+                        : ~ i j 0
+                        : s raw ( string_data blk )
+                        ~ < j keep {
+                            ( string_push_char out ( nurl_str_get raw j ) )
+                            = j + j 1
+                        }
+                        ? > bn keep { ( string_push_str out `…` ) } {}
+                        ( string_push_str out `\n\n` )
+                        : i emitted ?? ( vec_get [i] ctr 1 ) { T v → v F _ → 0 }
+                        ( vec_set [i] ctr 1 + emitted 1 )
+                    } {}
+                } {}
+                ( string_free hay_lc )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [String] parts \ String p → v { ( string_free p ) } )
+}
+
+@ __mcp_tool_api Json args → Json {
+    : s module ( __mcp_args_get `module` args `` )
+    : s query ( __mcp_args_get `query` args `` )
+    ? > ( nurl_str_len module ) 0 {
+        ? ( _has_dotdot_segment module ) { ^ ( __mcp_result_error `bad 'module'` ) } {}
+        : String md ( __api_render_module module )
+        ? == ( string_len md ) 0 {
+            ( string_free md )
+            ^ ( __mcp_result_error `module not found — 'module' is a path from nurl_list_stdlib, e.g. ext/csv.nu` )
+        } {}
+        ? > ( string_len md ) ( __api_out_cap ) {
+            : String cut ( string_substr md 0 ( __api_out_cap ) )
+            ( string_push_str cut `\n… truncated — use nurl_read_stdlib for the full source.\n` )
+            : Json r ( __mcp_result_text ( string_data cut ) )
+            ( string_free cut ) ( string_free md )
+            ^ r
+        } {}
+        : Json r ( __mcp_result_text ( string_data md ) )
+        ( string_free md )
+        ^ r
+    } {}
+    ? == ( nurl_str_len query ) 0 {
+        ^ ( __mcp_result_error `pass 'module' (a nurl_list_stdlib path, e.g. ext/csv.nu) or 'query' (search terms)` )
+    } {}
+
+    : String q_lc ( __lc_owned query )
+    : ( Vec String ) terms ( string_split q_lc ` ` )
+    : String out ( string_with_cap 4096 )
+    : ( Vec i ) ctr ( vec_new [i] )
+    ( vec_push [i] ctr 0 ) ( vec_push [i] ctr 0 )
+
+    : String dir ( get_stdlib_dir )
+    : Json files ( json_arr_new )
+    ( __walk_nu_files files ( string_data dir ) `` )
+    : i nf ( json_arr_len files )
+    : ~ i k 0
+    ~ < k nf {
+        ?? ( json_arr_get files k ) {
+            T fo → {
+                : ~ s rel ``
+                ?? ( json_obj_get fo `path` ) {
+                    T pj → { ? ( json_is_str pj ) { = rel ( json_as_str pj ) } {} }
+                    F _ → {}
+                }
+                ? > ( nurl_str_len rel ) 0 {
+                    // Cheap raw-source pre-filter: skip modules where the
+                    // terms can't all occur (path counts as haystack too).
+                    : String fp ( path_join ( string_data dir ) rel )
+                    : !( Vec u ) IoErr rd ( read_file_bytes ( string_data fp ) )
+                    ( string_free fp )
+                    ?? rd {
+                        T bytes → {
+                            : String src ( bytes_to_str bytes )
+                            ( vec_free [u] bytes )
+                            : String pre ( string_with_cap + ( string_len src ) 64 )
+                            ( string_push_str pre rel )
+                            ( string_push_char pre 32 )
+                            ( string_push_str pre ( string_data src ) )
+                            : String pre_lc ( string_to_lower pre )
+                            ( string_free pre )
+                            ? ( __api_terms_match pre_lc terms ) {
+                                : String md ( nurldoc_render ( string_data src ) rel )
+                                ( __api_match_blocks md rel terms out ctr )
+                                ( string_free md )
+                            } {}
+                            ( string_free pre_lc )
+                            ( string_free src )
+                        }
+                        F _ → {}
+                    }
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( json_free files )
+    ( string_free dir )
+
+    : i matched ?? ( vec_get [i] ctr 0 ) { T v → v F _ → 0 }
+    : i emitted ?? ( vec_get [i] ctr 1 ) { T v → v F _ → 0 }
+    : String hdr ( string_with_cap + ( string_len out ) 256 )
+    ( string_push_int hdr matched )
+    ( string_push_str hdr ` stdlib declaration(s) match '` )
+    ( string_push_str hdr query )
+    ( string_push_str hdr `'.\n\n` )
+    ( string_push_str hdr ( string_data out ) )
+    ? == matched 0 {
+        ( string_push_str hdr `No matches — terms are AND-ed substrings over signature + doc comment + module path; try fewer or shorter terms.\n` )
+    } {}
+    ? > matched emitted {
+        ( string_push_str hdr `… ` )
+        ( string_push_int hdr - matched emitted )
+        ( string_push_str hdr ` more matching declarations omitted (byte cap) — narrow the query or read one module with 'module'.\n` )
+    } {}
+    : Json result ( __mcp_result_text ( string_data hdr ) )
+    ( string_free hdr ) ( string_free out ) ( vec_free [i] ctr )
+    ( vec_free_with [String] terms \ String t → v { ( string_free t ) } )
+    ( string_free q_lc )
+    ^ result
+}
+
+@ __mcp_schema_api → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    : Json props ( json_obj_new )
+    ( json_obj_set props `module`
+    ( __mcp_prop `string` `Render ONE module's API surface (signatures, doc comments, full type definitions — no function bodies). A nurl_list_stdlib path, e.g. 'ext/csv.nu'.` ) )
+    ( json_obj_set props `query`
+    ( __mcp_prop `string` `Search every stdlib module's declarations instead: space-separated terms, ALL must occur (case-insensitive) in a declaration's signature + doc comment + module path. Ignored when 'module' is set.` ) )
+    ( json_obj_set schema `properties` props )
+    ^ schema
+}
+
+// ── nurl_grep — substring search across the corpora an agent has ──────
+//
+// grep for the toolchain's source surfaces: stdlib modules, examples,
+// compiler tests — `path:line: text` per hit, per-file and total caps —
+// plus the package registry (name + description via /api/v1/search), so
+// "is there already a package for X" is one cheap call instead of a
+// catalogue crawl.
+
+@ __grep_out_cap → i { ^ 24576 }
+
+@ __grep_file_hits_cap → i { ^ 8 }
+
+// Grep one file; append `<label>/<rel>:<ln>: <text>` lines. ctr =
+// [matched, emitted].
+@ __grep_one_file s root s rel s label String pat_lc String out ( Vec i ) ctr → v {
+    : String fp ( path_join root rel )
+    : !( Vec u ) IoErr rd ( read_file_bytes ( string_data fp ) )
+    ( string_free fp )
+    ?? rd {
+        T bytes → {
+            : String src ( bytes_to_str bytes )
+            ( vec_free [u] bytes )
+            : ( Vec String ) lines ( string_split src `\n` )
+            ( string_free src )
+            : i nl ( vec_len [String] lines )
+            : ~ i file_hits 0
+            : ~ i li 0
+            ~ < li nl {
+                ?? ( vec_get [String] lines li ) {
+                    T line → {
+                        : String line_lc ( string_to_lower line )
+                        ? >= ( nurl_str_find ( string_data line_lc ) ( string_data pat_lc ) ) 0 {
+                            : i matched ?? ( vec_get [i] ctr 0 ) { T v → v F _ → 0 }
+                            ( vec_set [i] ctr 0 + matched 1 )
+                            ? & < file_hits ( __grep_file_hits_cap ) < ( string_len out ) ( __grep_out_cap ) {
+                                ( string_push_str out label )
+                                ( string_push_char out 47 )
+                                ( string_push_str out rel )
+                                ( string_push_char out 58 )
+                                ( string_push_int out + li 1 )
+                                ( string_push_str out `: ` )
+                                // Trim the line to 200 bytes.
+                                : ~ i keep ( string_len line )
+                                ? > keep 200 { = keep 200 } {}
+                                : s lraw ( string_data line )
+                                : ~ i j 0
+                                ~ < j keep {
+                                    : i c ( nurl_str_get lraw j )
+                                    ( string_push_char out ? == c 9 32 c )
+                                    = j + j 1
+                                }
+                                ? > ( string_len line ) 200 { ( string_push_str out `…` ) } {}
+                                ( string_push_char out 10 )
+                                = file_hits + file_hits 1
+                                : i emitted ?? ( vec_get [i] ctr 1 ) { T v → v F _ → 0 }
+                                ( vec_set [i] ctr 1 + emitted 1 )
+                            } {}
+                        } {}
+                        ( string_free line_lc )
+                    }
+                    F _ → {}
+                }
+                = li + li 1
+            }
+            ? >= file_hits ( __grep_file_hits_cap ) {
+                ( string_push_str out `  (…more hits in ` )
+                ( string_push_str out rel )
+                ( string_push_str out ` capped)\n` )
+            } {}
+            ( vec_free_with [String] lines \ String l → v { ( string_free l ) } )
+        }
+        F _ → {}
+    }
+}
+
+// Grep one corpus directory (recursively, .nu files).
+@ __grep_corpus s root s label String pat_lc String out ( Vec i ) ctr → v {
+    : Json files ( json_arr_new )
+    ( __walk_nu_files files root `` )
+    : i nf ( json_arr_len files )
+    : ~ i k 0
+    ~ < k nf {
+        ? < ( string_len out ) ( __grep_out_cap ) {
+            ?? ( json_arr_get files k ) {
+                T fo → {
+                    ?? ( json_obj_get fo `path` ) {
+                        T pj → {
+                            ? ( json_is_str pj ) {
+                                ( __grep_one_file root ( json_as_str pj ) label pat_lc out ctr )
+                            } {}
+                        }
+                        F _ → {}
+                    }
+                }
+                F _ → {}
+            }
+        } {}
+        = k + k 1
+    }
+    ( json_free files )
+}
+
+// Registry package search: /api/v1/search matches name + description.
+@ __grep_packages s pattern String out → v {
+    : String url ( string_with_cap 128 )
+    : String regbase ( env_var_or `NURL_REGISTRY` `https://reg.nurl-lang.org/` )
+    ( string_push_str url ( string_data regbase ) )
+    ( string_free regbase )
+    ? != ( string_get url - ( string_len url ) 1 ) 47 { ( string_push_char url 47 ) } {}
+    ( string_push_str url `api/v1/search?q=` )
+    : String enc ( url_percent_encode pattern )
+    ( string_push_str url ( string_data enc ) )
+    ( string_free enc )
+    : !Response HttpErr r ( http_get ( string_data url ) )
+    ( string_free url )
+    ?? r {
+        T resp → {
+            : s body ( http_body_str resp )
+            ?? ( json_parse body ) {
+                T root → {
+                    ?? ( json_obj_get root `results` ) {
+                        T arr → {
+                            : i n ( json_arr_len arr )
+                            ? > n 0 { ( string_push_str out `\nRegistry packages matching (name/description):\n` ) } {}
+                            : ~ i k 0
+                            ~ < k n {
+                                ?? ( json_arr_get arr k ) {
+                                    T o → {
+                                        ( string_push_str out `  package ` )
+                                        ?? ( json_obj_get o `name` ) {
+                                            T nj → { ( string_push_str out ( json_as_str nj ) ) }
+                                            F _ → {}
+                                        }
+                                        ?? ( json_obj_get o `version` ) {
+                                            T vj → {
+                                                ? ( json_is_str vj ) {
+                                                    ( string_push_char out 32 )
+                                                    ( string_push_str out ( json_as_str vj ) )
+                                                } {}
+                                            }
+                                            F _ → {}
+                                        }
+                                        ?? ( json_obj_get o `description` ) {
+                                            T dj → {
+                                                ? ( json_is_str dj ) {
+                                                    ( string_push_str out ` — ` )
+                                                    // First 200 bytes of the description.
+                                                    : s d ( json_as_str dj )
+                                                    : i dn ( nurl_str_len d )
+                                                    : ~ i keep ? > dn 200 200 dn
+                                                    : ~ i j 0
+                                                    ~ < j keep {
+                                                        : i c ( nurl_str_get d j )
+                                                        ( string_push_char out ? == c 10 32 c )
+                                                        = j + j 1
+                                                    }
+                                                    ? > dn 200 { ( string_push_str out `…` ) } {}
+                                                } {}
+                                            }
+                                            F _ → {}
+                                        }
+                                        ( string_push_char out 10 )
+                                    }
+                                    F _ → {}
+                                }
+                                = k + k 1
+                            }
+                        }
+                        F _ → {}
+                    }
+                    ( json_free root )
+                }
+                F _ → {}
+            }
+            ( response_free resp )
+        }
+        F _ → { ( string_push_str out `\n(registry search unavailable)\n` ) }
+    }
+}
+
+@ __mcp_tool_grep Json args → Json {
+    : s pattern ( __mcp_args_get `pattern` args `` )
+    : s where_s ( __mcp_args_get `where` args `all` )
+    ? == ( nurl_str_len pattern ) 0 {
+        ^ ( __mcp_result_error `missing 'pattern'` )
+    } {}
+    : String pat_lc ( __lc_owned pattern )
+    : b all != 0 ( nurl_str_eq where_s `all` )
+    : b w_stdlib | all >= ( nurl_str_find where_s `stdlib` ) 0
+    : b w_examples | all >= ( nurl_str_find where_s `example` ) 0
+    : b w_tests | all >= ( nurl_str_find where_s `test` ) 0
+    : b w_packages | all >= ( nurl_str_find where_s `package` ) 0
+
+    : String out ( string_with_cap 4096 )
+    : ( Vec i ) ctr ( vec_new [i] )
+    ( vec_push [i] ctr 0 ) ( vec_push [i] ctr 0 )
+    ? w_stdlib {
+        : String dir ( get_stdlib_dir )
+        ( __grep_corpus ( string_data dir ) `stdlib` pat_lc out ctr )
+        ( string_free dir )
+    } {}
+    ? w_examples {
+        : String dir ( get_examples_dir )
+        ( __grep_corpus ( string_data dir ) `examples` pat_lc out ctr )
+        ( string_free dir )
+    } {}
+    ? w_tests {
+        : String dir ( get_tests_dir )
+        ( __grep_corpus ( string_data dir ) `tests` pat_lc out ctr )
+        ( string_free dir )
+    } {}
+    ? w_packages { ( __grep_packages pattern out ) } {}
+
+    : i matched ?? ( vec_get [i] ctr 0 ) { T v → v F _ → 0 }
+    : i emitted ?? ( vec_get [i] ctr 1 ) { T v → v F _ → 0 }
+    : String hdr ( string_with_cap + ( string_len out ) 256 )
+    ( string_push_int hdr matched )
+    ( string_push_str hdr ` line(s) match '` )
+    ( string_push_str hdr pattern )
+    ( string_push_str hdr `' (case-insensitive substring).\n\n` )
+    ( string_push_str hdr ( string_data out ) )
+    ? > matched emitted {
+        ( string_push_str hdr `… ` )
+        ( string_push_int hdr - matched emitted )
+        ( string_push_str hdr ` more matching lines omitted (per-file/total caps) — narrow the pattern or scope with 'where'.\n` )
+    } {}
+    : Json result ( __mcp_result_text ( string_data hdr ) )
+    ( string_free hdr ) ( string_free out ) ( vec_free [i] ctr ) ( string_free pat_lc )
+    ^ result
+}
+
+@ __mcp_schema_grep → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    : Json props ( json_obj_new )
+    ( json_obj_set props `pattern`
+    ( __mcp_prop `string` `Case-insensitive substring to find. Results are path:line: text.` ) )
+    ( json_obj_set props `where`
+    ( __mcp_prop `string` `Scope: 'stdlib', 'examples', 'tests', 'packages' (registry name+description search), or 'all' (default). Combine with commas, e.g. 'stdlib,examples'.` ) )
+    : Json req ( json_arr_new )
+    ( json_arr_push req ( json_str_lit `pattern` ) )
+    ( json_obj_set schema `properties` props )
+    ( json_obj_set schema `required` req )
     ^ schema
 }
 
@@ -4489,6 +5055,13 @@ s combined_stdout s combined_stderr → v {
     ? != 0 ( nurl_str_eq name `nurl_changelog` ) {
         ^ ( __mcp_tool_changelog args )
     } {}
+    // API surface / search.
+    ? != 0 ( nurl_str_eq name `nurl_api` ) {
+        ^ ( __mcp_tool_api args )
+    } {}
+    ? != 0 ( nurl_str_eq name `nurl_grep` ) {
+        ^ ( __mcp_tool_grep args )
+    } {}
 
     ^ ( __mcp_result_error `unknown tool` )
 }
@@ -4557,8 +5130,16 @@ s combined_stdout s combined_stderr → v {
 
     // Changelog.
     ( json_arr_push arr ( __mcp_tool_desc `nurl_changelog`
-    `Targeted CHANGELOG.md retrieval — the changelog is large (240+ KB) and growing, so never fetch it whole. Call with NO arguments first to get a compact index (releases + entry counts). Then pass query (space-separated terms, ALL must occur, case-insensitive) and/or release (e.g. 0.9.6 or Unreleased) to get complete changelog entries, each prefixed with its '[release] — date › category' provenance, newest first. Use this to find out when/whether a feature, fix, or rename happened. Results respect limit (default 10) and a 32 KB byte cap; a trailing note reports omitted match counts.`
+    `Targeted CHANGELOG.md retrieval — the changelog is large (240+ KB) and growing, so never fetch it whole. Call with NO arguments first to get a compact index (releases + entry counts). Then pass query (space-separated terms, ALL must occur, case-insensitive) and/or release (e.g. 0.9.6 or Unreleased) to get complete changelog entries, each prefixed with its '[release] — date › category' provenance, ranked by relevance (title hits first). The top 'limit' matches come in full; every further match is listed as a one-line title so nothing relevant is invisible. Pass compact=true for a titles-only overview. Use this to find out when/whether a feature, fix, or rename happened.`
     ( __mcp_schema_changelog ) ) )
+
+    ( json_arr_push arr ( __mcp_tool_desc `nurl_api`
+    `A stdlib module's API surface, or a search across all of them — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders one module's signatures + doc comments + full type definitions, no function bodies. query='csv quote' finds every stdlib declaration whose signature/doc/module-path contains ALL terms.`
+    ( __mcp_schema_api ) ) )
+
+    ( json_arr_push arr ( __mcp_tool_desc `nurl_grep`
+    `Case-insensitive substring search across the NURL corpora: stdlib sources, examples, compiler tests (path:line: text, per-file and total caps) and the package registry (name + description) — one cheap call to check how something is used in real code, or whether a package for X already exists. Scope with where='stdlib'|'examples'|'tests'|'packages'|'all'.`
+    ( __mcp_schema_grep ) ) )
 
     : Json out ( json_obj_new )
     ( json_obj_set out `tools` arr )

--- a/packages/registry/nurl.toml
+++ b/packages/registry/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "registry"
-version = "0.2.0"
+version = "0.3.0"
 description = "The NURL package registry, served by NURL itself — a self-hostable registry speaking exactly the wire protocol nurlpkg already drives: GET /index/<name>.json + GET /pkgs/<name>/<name>-<v>.tar.gz on the read side, bearer-authenticated POST /api/v1/publish (+ yank/unyank/revoke) on the write side, /api/v1/search + /api/v1/stats, and a server-rendered catalog UI with per-package pages that render the published README straight out of the tarball. SQLite is the single source of truth (users, tokens, packages, versions, deps — the index JSON is rendered from it, never dual-written); tarballs live on disk, checksummed with SHA-256 recomputed server-side. Tokens are peppered-SHA-256 hashed at rest; mint them locally with `registry token new <login>` or via the config-gated GitHub OAuth flow. Built on the http package (HttpApp), the template package (embedded server-rendered pages) and md2html (README rendering) — the registry that hosts NURL packages is itself three NURL packages deep."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl-lang"

--- a/packages/registry/src/db.nu
+++ b/packages/registry/src/db.nu
@@ -39,10 +39,14 @@ $ `stdlib/ext/sqlite.nu`
         name         TEXT    NOT NULL,
         created_at   INTEGER NOT NULL,
         last_used_at INTEGER)` ) )
+    // description = [package].description, extracted SERVER-SIDE from the
+    // published tarball at publish time (latest version wins) so search
+    // and the catalog can match on what a package IS, not just its name.
     ( vec_push [String] out ( string_from `CREATE TABLE IF NOT EXISTS packages (
         name          TEXT    PRIMARY KEY,
         owner_user_id INTEGER NOT NULL REFERENCES users(id),
-        created_at    INTEGER NOT NULL)` ) )
+        created_at    INTEGER NOT NULL,
+        description   TEXT    NOT NULL DEFAULT '')` ) )
     // published_at / created_at are epoch SECONDS (__reg_now). The
     // Cloudflare Worker's D1 stores epoch MILLISECONDS — any data
     // migration from D1 into this schema must divide by 1000.
@@ -91,6 +95,10 @@ $ `stdlib/ext/sqlite.nu`
                 = k + k 1
             }
             ( vec_free [String] stmts )
+            // Migration for pre-description databases: SQLite has no
+            // ADD COLUMN IF NOT EXISTS, so the duplicate-column failure
+            // on a fresh DB (whose CREATE already carries it) is ignored.
+            ?? ( sqlite_exec db `ALTER TABLE packages ADD COLUMN description TEXT NOT NULL DEFAULT ''` ) { T _ → {} F _ → {} }
             ? failed {
                 ^ @ !Database SqliteErr { F # SqliteErr SqliteMisuse }
             } {}
@@ -282,14 +290,33 @@ $ `stdlib/ext/sqlite.nu`
     ^ uid
 }
 
-@ reg_db_pkg_insert Database db s name i owner_uid i now → b {
-    ?? ( sqlite_prepare db `INSERT INTO packages (name, owner_user_id, created_at) VALUES (?1, ?2, ?3)` ) {
+@ reg_db_pkg_insert Database db s name i owner_uid i now s description → b {
+    ?? ( sqlite_prepare db `INSERT INTO packages (name, owner_user_id, created_at, description) VALUES (?1, ?2, ?3, ?4)` ) {
         T st → {
             : String nv ( string_from name )
             ?? ( sqlite_bind_text st 1 nv ) { T _ → {} F _ → {} }
             ( string_free nv )
             ?? ( sqlite_bind_int st 2 owner_uid ) { T _ → {} F _ → {} }
             ?? ( sqlite_bind_int st 3 now ) { T _ → {} F _ → {} }
+            : String dv ( string_from description )
+            ?? ( sqlite_bind_text st 4 dv ) { T _ → {} F _ → {} }
+            ( string_free dv )
+            ^ ( __reg_run st )
+        }
+        F _ → ^ F
+    }
+}
+
+// Refresh a package's description (the latest publish's text wins).
+@ reg_db_pkg_set_description Database db s name s description → b {
+    ?? ( sqlite_prepare db `UPDATE packages SET description = ?1 WHERE name = ?2` ) {
+        T st → {
+            : String dv ( string_from description )
+            ?? ( sqlite_bind_text st 1 dv ) { T _ → {} F _ → {} }
+            ( string_free dv )
+            : String nv ( string_from name )
+            ?? ( sqlite_bind_text st 2 nv ) { T _ → {} F _ → {} }
+            ( string_free nv )
             ^ ( __reg_run st )
         }
         F _ → ^ F
@@ -477,8 +504,10 @@ $ `stdlib/ext/sqlite.nu`
     : Json arr ( json_arr_new )
     ?? ( sqlite_prepare db `SELECT p.name,
             (SELECT v.version FROM versions v WHERE v.name = p.name AND v.yanked = 0
-              ORDER BY v.published_at DESC, v.rowid DESC LIMIT 1) AS latest
-        FROM packages p WHERE p.name LIKE ?1 ORDER BY p.name LIMIT ?2` ) {
+              ORDER BY v.published_at DESC, v.rowid DESC LIMIT 1) AS latest,
+            p.description
+        FROM packages p WHERE p.name LIKE ?1 OR p.description LIKE ?1
+        ORDER BY p.name LIMIT ?2` ) {
         T st → {
             : String pat ( __reg_like_pattern q )
             ?? ( sqlite_bind_text st 1 pat ) { T _ → {} F _ → {} }
@@ -497,6 +526,9 @@ $ `stdlib/ext/sqlite.nu`
                         : b _c ( json_obj_set row `version` ( json_str_lit ( string_data lv ) ) )
                         ( string_free lv )
                     }
+                    : String dsc ( sqlite_column_text st 2 )
+                    : b _e ( json_obj_set row `description` ( json_str_lit ( string_data dsc ) ) )
+                    ( string_free dsc )
                     : b _d ( json_arr_push arr row )
                     ( string_free nm )
                 } { = more F }

--- a/packages/registry/src/extract.nu
+++ b/packages/registry/src/extract.nu
@@ -207,8 +207,9 @@ $ `stdlib/ext/toml.nu`
     ^ arr
 }
 
-// [package].repository from the tarball's root nurl.toml; "" when absent.
-@ reg_targz_repository ( Vec u ) gz → String {
+// One [package] string scalar from the tarball's root nurl.toml, by its
+// toml_get_path path (e.g. `package.repository`); "" when absent.
+@ __rx_targz_pkg_str ( Vec u ) gz s path → String {
     : ( Vec u ) manifest ( reg_targz_member gz `nurl.toml` )
     ? == ( vec_len [u] manifest ) 0 {
         ( vec_free [u] manifest )
@@ -219,10 +220,10 @@ $ `stdlib/ext/toml.nu`
     : ~ String out ( string_new )
     ?? ( toml_parse ( string_data text ) ) {
         T root → {
-            : ?TomlValue rv ( toml_get_path root `package.repository` )
+            : ?TomlValue rv ( toml_get_path root path )
             ?? rv {
-                T repo → {
-                    : ?String rs ( toml_as_str repo )
+                T tv → {
+                    : ?String rs ( toml_as_str tv )
                     ?? rs {
                         T sv → {
                             ( string_free out )
@@ -239,4 +240,19 @@ $ `stdlib/ext/toml.nu`
     }
     ( string_free text )
     ^ out
+}
+
+// [package].repository from the tarball's root nurl.toml; "" when absent.
+@ reg_targz_repository ( Vec u ) gz → String {
+    ^ ( __rx_targz_pkg_str gz `package.repository` )
+}
+
+// [package].description, capped at 500 bytes (search metadata, not a
+// README) — mirrors the Worker's extractManifestDescription.
+@ reg_targz_description ( Vec u ) gz → String {
+    : String raw ( __rx_targz_pkg_str gz `package.description` )
+    ? <= ( string_len raw ) 500 { ^ raw } {}
+    : String cut ( string_substr raw 0 500 )
+    ( string_free raw )
+    ^ cut
 }

--- a/packages/registry/src/pages.nu
+++ b/packages/registry/src/pages.nu
@@ -26,7 +26,7 @@ $ `src/extract.nu`
     ^ `{% include 'head' %}<h1>Packages</h1>
 <form method=get><input name=q value="{{ q }}" placeholder="search packages" style="padding:.4rem;width:60%"> <button>Search</button></form>
 <p class=muted>{{ items | length }} package(s) · <a href="/login">get a publish token →</a></p>
-{% if items %}<ul>{% for p in items %}<li><a href="/packages/{{ p.name }}">{{ p.name }}</a> {% if p.version %}<code>{{ p.version }}</code>{% else %}<em>(all versions yanked)</em>{% end %}</li>{% end %}</ul>{% else %}<p>No packages{% if q %} matching “{{ q }}”{% else %} published{% end %} yet.</p>{% end %}`
+{% if items %}<ul>{% for p in items %}<li><a href="/packages/{{ p.name }}">{{ p.name }}</a> {% if p.version %}<code>{{ p.version }}</code>{% else %}<em>(all versions yanked)</em>{% end %}{% if p.description %} <span class=muted>— {{ p.description }}</span>{% end %}</li>{% end %}</ul>{% else %}<p>No packages{% if q %} matching “{{ q }}”{% else %} published{% end %} yet.</p>{% end %}`
 }
 
 @ __reg_tpl_detail → s {

--- a/packages/registry/src/service.nu
+++ b/packages/registry/src/service.nu
@@ -364,10 +364,16 @@ $ `src/pages.nu`
             } {}
 
             : i now ( __reg_now )
+            // Description from the tarball's own manifest — server-side
+            // extraction, never a client header; latest publish wins.
+            : String desc ( reg_targz_description . req body )
             : ~ b ok T
             ?? ( sqlite_begin db ) { T _ → {} F _ → { = ok F } }
             ? & ok < owner 0 {
-                ? ! ( reg_db_pkg_insert db ( string_data name ) uid now ) { = ok F } {}
+                ? ! ( reg_db_pkg_insert db ( string_data name ) uid now ( string_data desc ) ) { = ok F } {}
+            } {}
+            ? & & ok >= owner 0 > ( string_len desc ) 0 {
+                ? ! ( reg_db_pkg_set_description db ( string_data name ) ( string_data desc ) ) { = ok F } {}
             } {}
             ? ok {
                 ? ! ( reg_db_version_insert db ( string_data name ) ( string_data version ) ( string_data checksum ) uid now ) { = ok F } {}
@@ -383,6 +389,7 @@ $ `src/pages.nu`
             ? ! ok {
                 ?? ( sqlite_rollback db ) { T _ → {} F _ → {} }
             } {}
+            ( string_free desc )
             ? ! ok {
                 ( string_free name )
                 ( string_free version )

--- a/packages/registry/tests/wire.nu
+++ b/packages/registry/tests/wire.nu
@@ -79,6 +79,7 @@ $ `src/service.nu`
     ( vec_push [TarEntry] ents ( tar_entry_file `nurl.toml` ( bytes_from_str `[package]
 name = "demo"
 version = "0.1.0"
+description = "a tiny streaming widget frobnicator"
 repository = "https://example.com/repo"
 ` ) ) )
     ( vec_push [TarEntry] ents ( tar_entry_file `README.md` ( bytes_from_str `# demo
@@ -234,6 +235,18 @@ Hello *there*.
         : HttpResponse resp ( router_handle r req )
         : String b ( resp_body_str resp )
         ( check ( string_contains b `"name":"demo"` ) `search finds demo` )
+        ( check ( string_contains b `widget frobnicator` ) `search returns description` )
+        ( string_free b )
+        ( http_response_free resp )
+        ( request_free req )
+    }
+    {
+        // Description text matches even when the NAME doesn't — a
+        // "does a package for X exist" search works by topic.
+        : HttpRequest req ( mk_req `GET` `/api/v1/search` `q=frobnicator` ( no_headers ) ( vec_new [u] ) )
+        : HttpResponse resp ( router_handle r req )
+        : String b ( resp_body_str resp )
+        ( check ( string_contains b `"name":"demo"` ) `search matches by description` )
         ( string_free b )
         ( http_response_free resp )
         ( request_free req )
@@ -257,6 +270,7 @@ Hello *there*.
         : HttpResponse resp ( router_handle r req )
         : String b ( resp_body_str resp )
         ( check ( string_contains b `/packages/demo` ) `catalog links demo` )
+        ( check ( string_contains b `widget frobnicator` ) `catalog shows description` )
         ( string_free b )
         ( http_response_free resp )
         ( request_free req )

--- a/registry/migrations/0003_descriptions.sql
+++ b/registry/migrations/0003_descriptions.sql
@@ -1,0 +1,11 @@
+-- registry/migrations/0003_descriptions.sql — searchable descriptions.
+--
+-- `[package].description` is extracted SERVER-SIDE from the published
+-- tarball's nurl.toml on every publish (the latest version's text wins)
+-- and recorded here, so /api/v1/search and the catalog can match and
+-- show what a package IS — name-only search stops scaling long before
+-- a registry reaches thousands of packages. Never trusted from client
+-- headers; POST /api/v1/admin/desc-backfill re-extracts for packages
+-- published before this column existed.
+
+ALTER TABLE packages ADD COLUMN description TEXT NOT NULL DEFAULT '';

--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -22,7 +22,7 @@
 // (miniflare simulates R2 + D1) — no Cloudflare account needed to test.
 
 import { renderMarkdown } from "./markdown.ts";
-import { extractReadme, extractFile, extractManifestRepository, normalizeRelPath, listTarFiles } from "./readme.ts";
+import { extractReadme, extractFile, extractManifestRepository, extractManifestDescription, normalizeRelPath, listTarFiles } from "./readme.ts";
 
 export interface Env {
   REG_BUCKET: R2Bucket;
@@ -378,9 +378,19 @@ async function handlePublish(req: Request, env: Env): Promise<Response> {
   await env.REG_BUCKET.put(`index/${name}.json`, JSON.stringify(idx));
 
   const now = Date.now();
+  // Description comes from the tarball's own manifest, extracted
+  // server-side (never a client header) — the latest publish wins, so a
+  // wording fix ships with the next version. Extraction failure must not
+  // fail the publish: the description is search metadata, not integrity.
+  const description = await extractManifestDescription(env.REG_BUCKET, name, version)
+    .catch(() => "");
   if (!owner) {
-    await env.REG_DB.prepare(`INSERT INTO packages (name, owner_user_id, created_at) VALUES (?, ?, ?)`)
-      .bind(name, user.id, now).run();
+    await env.REG_DB.prepare(
+      `INSERT INTO packages (name, owner_user_id, created_at, description) VALUES (?, ?, ?, ?)`,
+    ).bind(name, user.id, now, description).run();
+  } else if (description) {
+    await env.REG_DB.prepare(`UPDATE packages SET description = ? WHERE name = ?`)
+      .bind(description, name).run();
   }
   await env.REG_DB.prepare(
     `INSERT INTO versions (name, version, checksum, yanked, published_by, published_at)
@@ -437,6 +447,37 @@ async function handleSignBackfill(req: Request, env: Env): Promise<Response> {
     }
   }
   return json({ ok: failed === 0, signed, skipped, failed, errors });
+}
+
+// POST /api/v1/admin/desc-backfill — re-extract [package].description from
+// each package's newest tarball into D1, for packages published before the
+// description column existed (or whose row is still empty). Idempotent;
+// same key-holder gate as sign-backfill.
+async function handleDescBackfill(req: Request, env: Env): Promise<Response> {
+  if (!env.REG_SIGN_KEY) return json({ error: "signing_not_configured" }, 503);
+  const presented = req.headers.get("x-reg-sign-key") ?? "";
+  if (!ctEq(presented, env.REG_SIGN_KEY)) return json({ error: "unauthorized" }, 401);
+
+  const rows = await env.REG_DB.prepare(
+    `SELECT p.name AS name, ${LATEST_SUBQUERY} AS latest, p.description AS description
+       FROM packages p`,
+  ).all<CatalogRow>();
+  let updated = 0, skipped = 0, failed = 0;
+  const errors: string[] = [];
+  for (const r of rows.results ?? []) {
+    if (r.description || !r.latest) { skipped++; continue; }
+    try {
+      const d = await extractManifestDescription(env.REG_BUCKET, r.name, r.latest);
+      if (!d) { skipped++; continue; }
+      await env.REG_DB.prepare(`UPDATE packages SET description = ? WHERE name = ?`)
+        .bind(d, r.name).run();
+      updated++;
+    } catch (e) {
+      failed++;
+      errors.push(`${r.name}: ${String(e)}`);
+    }
+  }
+  return json({ ok: failed === 0, updated, skipped, failed, errors });
 }
 
 // ── GitHub OAuth (token bootstrap) ────────────────────────────────────
@@ -501,7 +542,7 @@ function esc(s: string): string {
 
 // ── Catalog UI + search ───────────────────────────────────────────────
 
-interface CatalogRow { name: string; latest: string | null; }
+interface CatalogRow { name: string; latest: string | null; description: string; }
 
 // Most-recently-published non-yanked version per package (display only).
 const LATEST_SUBQUERY =
@@ -512,14 +553,16 @@ async function handleCatalog(url: URL, env: Env): Promise<Response> {
   const q = (url.searchParams.get("q") ?? "").toLowerCase().slice(0, 64);
   const like = q ? `%${q.replace(/[%_\\]/g, "")}%` : "%";
   const rows = await env.REG_DB.prepare(
-    `SELECT p.name AS name, ${LATEST_SUBQUERY} AS latest
-       FROM packages p WHERE p.name LIKE ? ORDER BY p.name LIMIT 200`,
+    `SELECT p.name AS name, ${LATEST_SUBQUERY} AS latest, p.description AS description
+       FROM packages p WHERE p.name LIKE ?1 OR p.description LIKE ?1 ORDER BY p.name LIMIT 200`,
   ).bind(like).all<CatalogRow>();
   const items = rows.results ?? [];
   const list = items.length
     ? `<ul>${items.map((p) =>
         `<li><a href="/packages/${esc(p.name)}">${esc(p.name)}</a> ` +
-        (p.latest ? `<code>${esc(p.latest)}</code>` : `<em>(all versions yanked)</em>`) + `</li>`).join("")}</ul>`
+        (p.latest ? `<code>${esc(p.latest)}</code>` : `<em>(all versions yanked)</em>`) +
+        (p.description ? ` <span style="color:#666">— ${esc(p.description.slice(0, 160))}</span>` : "") +
+        `</li>`).join("")}</ul>`
     : `<p>No packages${q ? ` matching “${esc(q)}”` : " published"} yet.</p>`;
   return htmlPage("NURL registry",
     `<h1>Packages</h1>` +
@@ -671,10 +714,13 @@ async function handleSearch(req: Request, url: URL, env: Env): Promise<Response>
   const q = (url.searchParams.get("q") ?? "").toLowerCase().slice(0, 64);
   const like = q ? `%${q.replace(/[%_\\]/g, "")}%` : "%";
   const rows = await env.REG_DB.prepare(
-    `SELECT p.name AS name, ${LATEST_SUBQUERY} AS latest
-       FROM packages p WHERE p.name LIKE ? ORDER BY p.name LIMIT 50`,
+    `SELECT p.name AS name, ${LATEST_SUBQUERY} AS latest, p.description AS description
+       FROM packages p WHERE p.name LIKE ?1 OR p.description LIKE ?1 ORDER BY p.name LIMIT 50`,
   ).bind(like).all<CatalogRow>();
-  return json({ results: (rows.results ?? []).map((r) => ({ name: r.name, version: r.latest })) });
+  return json({
+    results: (rows.results ?? []).map((r) =>
+      ({ name: r.name, version: r.latest, description: r.description ?? "" })),
+  });
 }
 
 // Public counts — powers the "registry packages" figure on nurl-lang.org
@@ -893,6 +939,7 @@ export default {
       if (path === "/api/v1/revoke") return handleRevoke(req, env);
       if (path === "/api/v1/token/new") return handleTokenNew(req, env);
       if (path === "/api/v1/admin/sign-backfill") return handleSignBackfill(req, env);
+      if (path === "/api/v1/admin/desc-backfill") return handleDescBackfill(req, env);
     }
     return json({ error: "not_found" }, 404);
   },

--- a/registry/src/readme.ts
+++ b/registry/src/readme.ts
@@ -121,14 +121,17 @@ export async function extractReadme(
   return findReadmeInTar(new Uint8Array(ab));
 }
 
-// Pull `[package].repository` out of the published tarball's nurl.toml.
-// Returns the URL string, or null when absent/unreadable. Deliberately a
-// tiny line-scan rather than a full TOML parser: we only need one scalar,
-// and the registry must never break a package page over a manifest quirk.
-export async function extractManifestRepository(
+// Pull one `[package]` scalar out of the published tarball's nurl.toml.
+// Returns the string, or null when absent/unreadable. Deliberately a
+// tiny line-scan rather than a full TOML parser: we only need scalars,
+// and the registry must never break over a manifest quirk. `key` values
+// stop at the next table header so a stray key in another section can't
+// be mistaken for it.
+export async function extractManifestKey(
   bucket: R2Bucket,
   name: string,
   version: string,
+  key: string,
 ): Promise<string | null> {
   const obj = await bucket.get(`pkgs/${name}/${name}-${version}.tar.gz`);
   if (!obj || !obj.body) return null;
@@ -136,17 +139,35 @@ export async function extractManifestRepository(
   const hit = findInTar(new Uint8Array(ab), (p) => p.replace(/^\.\//, "") === "nurl.toml");
   if (!hit) return null;
   const toml = new TextDecoder().decode(hit.data);
-  // `repository = "..."` under [package]; stop at the next table header so a
-  // stray `repository` key in another section can't be mistaken for it.
   let inPackage = false;
+  const re = new RegExp(`^${key}\\s*=\\s*"([^"]*)"`);
   for (const raw of toml.split(/\r?\n/)) {
     const line = raw.trim();
     if (line.startsWith("[")) { inPackage = line === "[package]"; continue; }
     if (!inPackage) continue;
-    const m = line.match(/^repository\s*=\s*"([^"]*)"/);
+    const m = line.match(re);
     if (m) return m[1] || null;
   }
   return null;
+}
+
+export function extractManifestRepository(
+  bucket: R2Bucket,
+  name: string,
+  version: string,
+): Promise<string | null> {
+  return extractManifestKey(bucket, name, version, "repository");
+}
+
+// Description as recorded at publish: capped so a runaway manifest can't
+// bloat search rows (yoloe-demo-style long descriptions stay useful).
+export async function extractManifestDescription(
+  bucket: R2Bucket,
+  name: string,
+  version: string,
+): Promise<string> {
+  const d = await extractManifestKey(bucket, name, version, "description");
+  return (d ?? "").slice(0, 500);
 }
 
 // Fetch + gunzip a published tarball and return the bytes of the member at

--- a/registry/test-local.sh
+++ b/registry/test-local.sh
@@ -68,7 +68,7 @@ trap 'kill $WPID 2>/dev/null; pkill -f "wrangler dev --port $PORT" 2>/dev/null; 
 for i in $(seq 1 60); do curl -sf "$REG" >/dev/null 2>&1 && break; sleep 0.5; done
 
 mkdir -p "$WORK/foo/src"
-printf '[package]\nname = "foo"\nversion = "1.0.0"\n' > "$WORK/foo/nurl.toml"
+printf '[package]\nname = "foo"\nversion = "1.0.0"\ndescription = "a demonstration frobnicator for e2e"\n' > "$WORK/foo/nurl.toml"
 printf '@ answer -> i { ^ 42 }\n' > "$WORK/foo/src/lib.nu"
 # A README that exercises the renderer: heading, code, table, link, and a
 # script-injection attempt that must be neutralised.
@@ -95,6 +95,12 @@ printf '[package]\nname = "app"\nversion = "0.1.0"\n\n[dependencies]\nfoo = "^1.
 ( cd "$WORK/app" && NURL_REGISTRY="$REG" NURL_REGISTRY_PUBKEY="$REG_SIGN_PUB" "$NURLPKG" install ) || fail=1
 [[ -f "$WORK/app/deps/foo/nurl.toml" && -f "$WORK/app/deps/foo/src/lib.nu" ]] && echo "deps/foo: OK" || { echo "deps/foo: MISSING"; fail=1; }
 grep -q 'checksum =' "$WORK/app/nurl.lock" && echo "lock checksum: OK" || { echo "lock checksum: MISSING"; fail=1; }
+
+say "search matches and returns descriptions"
+SEARCH=$(curl -sf "${REG%/}/api/v1/search?q=frobnicator" || true)
+echo "$SEARCH" | grep -q '"name":"foo"' && echo "  description match: OK" || { echo "  description match: MISSING"; fail=1; }
+echo "$SEARCH" | grep -q 'demonstration frobnicator' && echo "  description returned: OK" || { echo "  description returned: MISSING"; fail=1; }
+curl -sf "$REG" | grep -q 'demonstration frobnicator' && echo "  catalog shows description: OK" || { echo "  catalog description: MISSING"; fail=1; }
 
 say "update moves a stale requirement to the newest version"
 mkdir -p "$WORK/upd"

--- a/stdlib/ext/nurldoc.nu
+++ b/stdlib/ext/nurldoc.nu
@@ -126,6 +126,43 @@ $ `stdlib/core/vec.nu`
     ^ | == c 64 == c 38
 }
 
+// Is this function declaration file-private — a `__`-prefixed name? The
+// compiler mangles such functions with a per-file scope id, so nothing
+// outside the module can call them; documenting them as API is noise.
+// (A single `_` is convention-internal but callable — those stay.)
+@ __nd_fn_is_private s p i sp i en → b {
+    : ~ i k sp
+    ? ( __nd_starts_with p k en `pub ` ) { = k ( __nd_skip_ws p + k 4 en ) } {}
+    ? >= k en { ^ F } {}
+    // FFI form: `& `lib` @ name …` — advance past the backtick-quoted lib.
+    ? == ( nurl_str_get p k ) 38 {
+        = k ( __nd_skip_ws p + k 1 en )
+        ? & < k en == ( nurl_str_get p k ) 96 {
+            = k + k 1
+            ~ & < k en != ( nurl_str_get p k ) 96 { = k + k 1 }
+            ? < k en { = k ( __nd_skip_ws p + k 1 en ) } {}
+        } {}
+    } {}
+    ? | >= k en != ( nurl_str_get p k ) 64 { ^ F } {}  // expect `@`
+    = k ( __nd_skip_ws p + k 1 en )
+    ^ & < + k 1 en & == ( nurl_str_get p k ) 95 == ( nurl_str_get p + k 1 ) 95
+}
+
+// Append a Markdown code-fence line: ```nurl\n (open) or ```\n\n (close).
+// Backtick string literals can't carry backticks, hence char pushes.
+@ __nd_push_fence String out b open → v {
+    ( string_push_char out 96 )
+    ( string_push_char out 96 )
+    ( string_push_char out 96 )
+    ? open {
+        ( string_push_str out `nurl` )
+        ( string_push_char out 10 )
+    } {
+        ( string_push_char out 10 )
+        ( string_push_char out 10 )
+    }
+}
+
 // ── renderer ────────────────────────────────────────────────────────
 
 @ nurldoc_render s content s title → String {
@@ -144,6 +181,12 @@ $ `stdlib/core/vec.nu`
     : ~ b header_done F  // true once we leave the leading comment block
     : ~ b any_decl F
     : ~ i pending_n 0
+    // A multi-line type/enum declaration (`: Name {` … `}`) renders its
+    // FULL definition in a fenced code block — the field list IS the API
+    // (construction order, payload shapes). While one is open we copy raw
+    // lines; its doc prose is stashed and emitted after the fence closes.
+    : ~ b in_type F
+    : ~ String type_prose ( string_with_cap 64 )
 
     ~ < pos n {
         // line bounds [ls, le); advance pos past the newline
@@ -172,16 +215,39 @@ $ `stdlib/core/vec.nu`
                 } {
                     = header_done T
                     ? ( __nd_is_decl content sp le ) {
-                        = any_decl T
-                        ( string_push_str body `### ` )
-                        ( string_push_char body 96 )  // markdown `
-                        ( __nd_push_signature body content sp le ( __nd_is_fn content sp le ) )
-                        ( string_push_char body 96 )
-                        ( string_push_str body `\n\n` )
-                        ? > pending_n 0 {
-                            ( string_push_str body ( string_data pending ) )
-                            ( string_push_char body 10 )
-                        } {}
+                        : b is_fn ( __nd_is_fn content sp le )
+                        // `__`-private functions are file-scoped — not API.
+                        ? & is_fn ( __nd_fn_is_private content sp le ) {} {
+                            = any_decl T
+                            : i bd ( __nd_brace_delta content ls le )
+                            : b type_block & ! is_fn > bd 0
+                            ( string_push_str body `### ` )
+                            ( string_push_char body 96 )  // markdown `
+                            // Functions and multi-line type decls trim the
+                            // heading at `{`; single-line type/const decls
+                            // keep the whole line (their `{ … }` IS the API).
+                            ( __nd_push_signature body content sp le | is_fn type_block )
+                            ( string_push_char body 96 )
+                            ( string_push_str body `\n\n` )
+                            ? type_block {
+                                // Open the fenced full definition; prose waits.
+                                = in_type T
+                                ( string_clear type_prose )
+                                ? > pending_n 0 {
+                                    ( string_push_str type_prose ( string_data pending ) )
+                                    ( string_push_char type_prose 10 )
+                                } {}
+                                ( __nd_push_fence body T )
+                                : ~ i j ls
+                                ~ < j le { ( string_push_char body ( nurl_str_get content j ) ) = j + j 1 }
+                                ( string_push_char body 10 )
+                            } {
+                                ? > pending_n 0 {
+                                    ( string_push_str body ( string_data pending ) )
+                                    ( string_push_char body 10 )
+                                } {}
+                            }
+                        }
                     } {}
                     // any non-decl code line clears the pending doc
                     ( string_free pending )
@@ -189,12 +255,27 @@ $ `stdlib/core/vec.nu`
                     = pending_n 0
                 }
             }
-        } {}
+        } {
+            ? in_type {
+                : ~ i j ls
+                ~ < j le { ( string_push_char body ( nurl_str_get content j ) ) = j + j 1 }
+                ( string_push_char body 10 )
+            } {}
+        }
 
         = depth + depth ( __nd_brace_delta content ls le )
         ? < depth 0 { = depth 0 } {}
+        ? & in_type == depth 0 {
+            ( __nd_push_fence body F )
+            ? > ( string_len type_prose ) 0 {
+                ( string_push_str body ( string_data type_prose ) )
+                ( string_push_char body 10 )
+            } {}
+            = in_type F
+        } {}
         = pos ? < le n + le 1 le
     }
+    ( string_free type_prose )
 
     ? > ( string_len header ) 0 {
         ( string_push_str out ( string_data header ) )

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -1796,6 +1796,16 @@ $ `stdlib/std/bytes.nu`
                                     ?? no { T nm → ( nurl_print ( json_as_str nm ) ) F → {} }
                                     : ?Json vo ( json_obj_get e `version` )
                                     ?? vo { T vv → { ( nurl_print `  ` ) ( nurl_print ( json_as_str vv ) ) } F → {} }
+                                    : ?Json dso ( json_obj_get e `description` )
+                                    ?? dso {
+                                        T dv → {
+                                            ? & ( json_is_str dv ) > ( nurl_str_len ( json_as_str dv ) ) 0 {
+                                                ( nurl_print `  — ` )
+                                                ( nurl_print ( json_as_str dv ) )
+                                            } {}
+                                        }
+                                        F → {}
+                                    }
                                     ( nurl_print `\n` )
                                 }
                                 F → {}


### PR DESCRIPTION
## Problem

The playground MCP server's retrieval tools weren't genuinely usable for a model:

* `nurl_read_stdlib` returns whole modules — asking "what csv functions exist" costs **63 KB / 1802 lines** of context for `ext/csv.nu`
* `nurl_changelog` word search returned the newest N matches until the byte cap; the relevant entry was often inside the opaque "… 77 more omitted"
* nothing could search across stdlib/examples/tests, and registry search matched package **names only** — at thousands of packages, "is there already a package for X" would be unanswerable

## New tools

**`nurl_api`** — `module='ext/csv.nu'` renders the API surface via nurldoc: signatures + doc comments + full type definitions, no bodies (**11 KB instead of 63 KB**). `query='csv quote'` returns just the matching declarations (~0.3 KB each):

```
5 stdlib declaration(s) match 'csv quote'.
ext/csv.nu › `: CSVDialect`
    i delimiter  // byte value, e.g. 44 (',') or 9 ('\t')
    …
ext/csv.nu › `@ csv_dialect_unquoted → CSVDialect`
```

Two root fixes in **nurldoc** itself (also improves /stdlib-docs pages): `__`-private functions are file-scoped/uncallable since the privates change → no longer documented as API; multi-line type declarations render their full field list in a fenced block (a bare ``: CSVDialect {`` heading was useless for construction).

**`nurl_grep`** — case-insensitive substring search across stdlib/examples/tests (`path:line: text`, capped) and the registry (name + description).

**`nurl_changelog`** — matches are now scored (term in the entry TITLE = 3× a passing mention) and ranked before the byte cap applies; the top `limit` come in full, and **every further match appears as a one-line provenance+title**. `compact=true` for a titles-only overview.

## Registry descriptions (ecosystem fix)

`[package].description` is extracted **server-side** from the published tarball on every publish (latest wins; never a client header), stored, shown in the catalog, and returned+matched by `/api/v1/search` — in both registries:

* Worker: D1 migration `0003_descriptions.sql` (deploy workflow applies it), `POST /api/v1/admin/desc-backfill` re-extracts for pre-existing packages
* `packages/registry` **0.3.0**: schema + tolerated `ALTER` migration for existing self-hosted DBs
* `nurlpkg search` prints descriptions

## Verification

* nurlapi e2e **107/107** against a locally-run server (new `nurl_api`/`nurl_grep` cases; tool count 16→18)
* registry `wire.nu` **ALL PASS** + `NURL_SAN=1` zero leaks (description match/return/catalog cases added)
* `registry/test-local.sh` e2e **PASS** with live description checks
* compiler suite **546 PASS** — nurldoc fixture extended to lock the private-skip + type-block rendering

## Deploy notes

* Worker: `registry-deploy.yml` (manual) — applies 0003 automatically; then `POST /api/v1/admin/desc-backfill` with `X-Reg-Sign-Key` once to backfill the 36 existing packages
* Playground: the nurlapi deploy path ships the new MCP tools
* `packages/registry` 0.3.0 publish: user-only, as usual

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH