### PR TITLE
release: v0.17.0 — findability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-07-17
+
+The **findability** release: the MCP server answers "what's in this
+module", "when did this change" and "does a package for X exist" in
+kilobytes instead of context-flooding dumps — and the registry learns
+what its packages are about.
+
 ### Added
 
 - **MCP: `nurl_api` — a stdlib module's API surface, or a search across

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-07-16 · Current release: **0.16.0** · Language: **Grammar
+_Last reviewed: 2026-07-17 · Current release: **0.17.0** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
Cuts **v0.17.0**: dates the `[Unreleased]` entries from #509 and bumps the ROADMAP current-release line.

The **findability** release: MCP `nurl_api` + `nurl_grep`, relevance-ranked `nurl_changelog`, registry package descriptions stored/served/searchable, nurldoc private-skip + type-definition rendering.

After merge: tag `v0.17.0` on the merge commit → release.yml builds + signs archives, api-deploy redeploys the playground from the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH