### PR TITLE
registry: desc-backfill is public + rate-limited, not key-gated

### DIFF
--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -451,12 +451,20 @@ async function handleSignBackfill(req: Request, env: Env): Promise<Response> {
 
 // POST /api/v1/admin/desc-backfill — re-extract [package].description from
 // each package's newest tarball into D1, for packages published before the
-// description column existed (or whose row is still empty). Idempotent;
-// same key-holder gate as sign-backfill.
+// description column existed (or whose row is still empty).
+//
+// Rate-limited but PUBLIC, deliberately: unlike sign-backfill (which
+// wields the signing key and must stay key-holder-gated), this endpoint
+// only derives data from published, immutable, world-readable tarballs
+// and only fills rows that are still empty — a caller can't make it
+// write anything that publishing doesn't already allow, and a re-run is
+// a no-op. The rate limit bounds the R2 reads a hostile caller could
+// trigger. (Key-holder gating was tried first and locked the operator
+// out: the seed lives only as a Cloudflare secret, which is write-only.)
 async function handleDescBackfill(req: Request, env: Env): Promise<Response> {
-  if (!env.REG_SIGN_KEY) return json({ error: "signing_not_configured" }, 503);
-  const presented = req.headers.get("x-reg-sign-key") ?? "";
-  if (!ctEq(presented, env.REG_SIGN_KEY)) return json({ error: "unauthorized" }, 401);
+  if (!(await rateLimit(env, `descbf:${clientIp(req)}`, 2, 3_600_000))) {
+    return json({ error: "rate_limited" }, 429, { "retry-after": "3600" });
+  }
 
   const rows = await env.REG_DB.prepare(
     `SELECT p.name AS name, ${LATEST_SUBQUERY} AS latest, p.description AS description

--- a/registry/test-local.sh
+++ b/registry/test-local.sh
@@ -96,6 +96,12 @@ printf '[package]\nname = "app"\nversion = "0.1.0"\n\n[dependencies]\nfoo = "^1.
 [[ -f "$WORK/app/deps/foo/nurl.toml" && -f "$WORK/app/deps/foo/src/lib.nu" ]] && echo "deps/foo: OK" || { echo "deps/foo: MISSING"; fail=1; }
 grep -q 'checksum =' "$WORK/app/nurl.lock" && echo "lock checksum: OK" || { echo "lock checksum: MISSING"; fail=1; }
 
+say "desc-backfill is public, rate-limited, idempotent"
+BF=$(curl -s -X POST "${REG%/}/api/v1/admin/desc-backfill")
+echo "$BF" | grep -q '"ok":true' && echo "  backfill ok: OK" || { echo "  backfill FAILED: $BF"; fail=1; }
+BF2=$(curl -s -X POST "${REG%/}/api/v1/admin/desc-backfill")
+echo "$BF2" | grep -qE '"ok":true|rate_limited' && echo "  re-run no-op/limited: OK" || { echo "  re-run unexpected: $BF2"; fail=1; }
+
 say "search matches and returns descriptions"
 SEARCH=$(curl -sf "${REG%/}/api/v1/search?q=frobnicator" || true)
 echo "$SEARCH" | grep -q '"name":"foo"' && echo "  description match: OK" || { echo "  description match: MISSING"; fail=1; }


### PR DESCRIPTION
The seed-presentation gate locked the operator out of their own maintenance endpoint: `REG_SIGN_KEY` exists only as a Cloudflare Worker secret (write-only — confirmed the local `.dev.vars` copy is a test key and GitHub secrets don't carry it).

Auth should match what the operation can do. `sign-backfill` wields the signing key → stays key-gated. `desc-backfill` only derives data from published, immutable, world-readable tarballs and only fills still-empty rows — a caller can't write anything publishing doesn't already allow, and re-runs are no-ops. So: **public, per-IP rate-limited (2/h)**, bounding the R2 reads a hostile caller could trigger.

`test-local.sh` now drives it: first call `ok:true`, immediate re-run no-op or 429. Full e2e PASS, `tsc` clean.

After merge + deploy: `curl -X POST https://reg.nurl-lang.org/api/v1/admin/desc-backfill` — no key needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH