### PR TITLE
cloudflare: normalize scheme to http before the container proxy

### DIFF
--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -49,10 +49,19 @@ export class NurlContainer extends Container<Env> {
 
   // Self-healing proxy — see the file header for the failure it recovers from.
   override async fetch(request: Request): Promise<Response> {
+    // The container tunnel speaks plain HTTP (it is already secured by the
+    // platform), and the runtime REJECTS container connections described as
+    // https: "Connecting to a container using HTTPS is not currently
+    // supported". containerFetch only rewrites its URL *string* — the
+    // original Request it passes as fetch init still carries the https URL,
+    // which newer runtime validation trips over. Normalize the scheme here,
+    // before anything reaches the proxy.
+    const httpUrl = request.url.replace(/^https:/, "http:");
+
     // WebSocket upgrades (the /pptws voice relay) can't be buffered or
     // replayed — proxy them straight through with no retry.
     if ((request.headers.get("Upgrade") ?? "").toLowerCase() === "websocket") {
-      return super.fetch(request);
+      return super.fetch(new Request(httpUrl, request));
     }
 
     // Buffer the body once so the request can be replayed after a recycle.
@@ -61,7 +70,7 @@ export class NurlContainer extends Container<Env> {
     const hasBody = request.method !== "GET" && request.method !== "HEAD";
     const bodyBuf = hasBody ? await request.arrayBuffer() : undefined;
     const replay = (): Request =>
-      new Request(request.url, {
+      new Request(httpUrl, {
         method: request.method,
         headers: request.headers,
         body: bodyBuf,


### PR DESCRIPTION
play.nurl-lang.org intermittently returned:

```
Error proxying request to container: Connecting to a container using HTTPS is not currently supported; use HTTP instead.
```

**Root cause:** the runtime's container-port fetch now validates the *init Request's* scheme. `@cloudflare/containers` `containerFetch` rewrites only its URL string (`request.url.replace('https:', 'http:')`) and passes the original **https** `Request` as fetch init — the stricter validation (rolled onto the hosts our instances landed on during today's image rollout) reads that and rejects. The pattern is identical in the latest 0.3.7, so a library upgrade doesn't help.

**Fix at our layer:** `NurlContainer.fetch` normalizes the scheme once, up front; both the buffered replay path and the WebSocket passthrough now hand the proxy an `http://` request. No code path can present https to the container tunnel (which is platform-secured anyway, per the error's own text).

Timeline note: wrangler (4.90.0) and the lib (0.0.20) are lockfile-pinned and unchanged since initial commit — this is a runtime-side behavior change surfaced by instance placement, not a dependency drift.

tsc clean; recovery-policy unit tests 8/8. After merge: `api-deploy` (manual dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH