### PR TITLE
cloudflare: pass upstream redirects through — don't follow in the proxy

### DIFF
--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -69,11 +69,18 @@ export class NurlContainer extends Container<Env> {
     // survive a retry; their bodies are small.
     const hasBody = request.method !== "GET" && request.method !== "HEAD";
     const bodyBuf = hasBody ? await request.arrayBuffer() : undefined;
+    // redirect: "manual" — a reverse proxy must pass upstream redirects
+    // THROUGH to the client, never follow them itself. The default
+    // ("follow") made the container-port fetcher chase /authorize's 302
+    // Location (https://claude.ai/…) through the container binding, and
+    // the runtime rejects https on that path — which broke the whole
+    // OAuth connect flow while every non-redirecting route worked.
     const replay = (): Request =>
       new Request(httpUrl, {
         method: request.method,
         headers: request.headers,
         body: bodyBuf,
+        redirect: "manual",
       });
 
     for (let attempt = 0; ; attempt++) {


### PR DESCRIPTION
Claude web client couldn't (re)connect to the playground MCP: `GET /authorize` returned the container-https proxy error while every other route worked. #512 fixed the *request's own* scheme, but the replay Request kept the default `redirect: "follow"` — so the container-port fetcher chased `/authorize`'s 302 `Location: https://claude.ai/api/mcp/auth_callback?…` **through the container binding**, and the runtime rejects https on that path. Only redirect-returning routes were affected, which is exactly the observed pattern (`/health`, `/mcp`, `/build` fine; OAuth broken).

Fix: `redirect: "manual"` — a reverse proxy passes upstream redirects through to the client instead of following them. The browser then follows the 302 to claude.ai and the OAuth connect completes.

tsc clean, recovery unit tests 8/8. After merge: api-deploy dispatch; verify `curl -si '.../authorize?...'` returns `302` + `Location:` instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH