### PR TITLE
proxy scheme signal: X-Forwarded-Proto from the Worker, honored by nurlapi

### DIFF
--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -58,10 +58,18 @@ export class NurlContainer extends Container<Env> {
     // before anything reaches the proxy.
     const httpUrl = request.url.replace(/^https:/, "http:");
 
+    // Standard reverse-proxy contract: tell the origin what scheme the
+    // CLIENT used, since the tunnel itself is always plain http. nurlapi
+    // reads this when it builds absolute URLs (OAuth issuer/endpoints,
+    // mcp.json snippets) so they say https://, not the tunnel's http://.
+    const fwdHeaders = new Headers(request.headers);
+    fwdHeaders.set("X-Forwarded-Proto", new URL(request.url).protocol.replace(":", ""));
+
     // WebSocket upgrades (the /pptws voice relay) can't be buffered or
-    // replayed — proxy them straight through with no retry.
+    // replayed — proxy them straight through with no retry. Upgrades are
+    // always GET, so a headers-only rebuild loses nothing.
     if ((request.headers.get("Upgrade") ?? "").toLowerCase() === "websocket") {
-      return super.fetch(new Request(httpUrl, request));
+      return super.fetch(new Request(httpUrl, { headers: fwdHeaders }));
     }
 
     // Buffer the body once so the request can be replayed after a recycle.
@@ -78,7 +86,7 @@ export class NurlContainer extends Container<Env> {
     const replay = (): Request =>
       new Request(httpUrl, {
         method: request.method,
-        headers: request.headers,
+        headers: fwdHeaders,
         body: bodyBuf,
         redirect: "manual",
       });

--- a/nurlapi/e2e_test.py
+++ b/nurlapi/e2e_test.py
@@ -197,6 +197,20 @@ def t_mcp_info(c: Client) -> None:
         "nurl_grep",
     ):
         assert_true(f"tool {t} listed", t in tools)
+    # Reverse-proxy scheme signal: with X-Forwarded-Proto: https the
+    # advertised absolute URLs must say https (the CF Worker sets this;
+    # without it the http tunnel scheme would leak into OAuth metadata).
+    status, _, raw = c.get("/mcp-info", headers={"X-Forwarded-Proto": "https"})
+    assert_eq("fwd-proto status 200", status, 200)
+    fwd = json.loads(raw)
+    fwd_url = (
+        fwd.get("client_config_example", {})
+        .get("mcpServers", {})
+        .get("nurl", {})
+        .get("url", "")
+    )
+    assert_true("X-Forwarded-Proto: https yields https URL", fwd_url.startswith("https://"))
+
     assert_true(
         "client_config_example.mcpServers.nurl.url ends in /mcp",
         j.get("client_config_example", {})

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -1682,11 +1682,12 @@ s combined_stdout s combined_stderr → v {
     ( json_arr_push arr ( json_str_lit v ) )
 }
 
-// Resolve the public base URL for the example mcp.json snippet. Prefer
-// the NURL_PUBLIC_URL env var (production deployments behind a proxy
-// terminate TLS upstream and need an absolute URL); fall back to the
-// request's Host header with http://; degrade to http://localhost:8000
-// if even that is missing. Returns an owned String.
+// Resolve the public base URL for absolute links (OAuth issuer/endpoints,
+// the example mcp.json snippet). Prefer the NURL_PUBLIC_URL env var; then
+// the standard reverse-proxy signal X-Forwarded-Proto + Host (a proxy
+// terminates TLS upstream and tunnels plain http to us — the Cloudflare
+// Worker sets the header); then http:// + Host; degrade to
+// http://localhost:8000 if even that is missing. Returns an owned String.
 @ __mcp_info_base_url HttpRequest req → String {
     : String env ( env_var_or `NURL_PUBLIC_URL` `` )
     : i envl ( string_len env )
@@ -1697,11 +1698,21 @@ s combined_stdout s combined_stderr → v {
             ^ trimmed
         } { ^ env }
     } { ( string_free env ) }
+    : ~ s scheme `http`
+    : ?String proto_opt ( header_get . req headers `X-Forwarded-Proto` )
+    ?? proto_opt {
+        T proto → {
+            ? != 0 ( nurl_str_eq ( string_data proto ) `https` ) { = scheme `https` } {}
+            ( string_free proto )
+        }
+        F _ → {}
+    }
     : ?String host_opt ( header_get . req headers `Host` )
     ?? host_opt {
         T host → {
             : String out ( string_with_cap 64 )
-            ( string_push_str out `http://` )
+            ( string_push_str out scheme )
+            ( string_push_str out `://` )
             ( string_push_str out ( string_data host ) )
             ( string_free host )
             ^ out


### PR DESCRIPTION
Follow-up to #513: with the tunnel now honestly http, nurlapi's absolute URLs (OAuth `issuer`/`authorization_endpoint`/`token_endpoint`, the mcp.json snippet) advertise `http://play.nurl-lang.org`. It has always been that way (containerFetch always rewrote the URL string) and clients tolerate it — but OAuth metadata pointing at http endpoints is one strict client update away from breaking connects again.

Standard fix: the Worker sets **`X-Forwarded-Proto`** from the client's original scheme; nurlapi's base-URL builder honors it (`NURL_PUBLIC_URL` > `X-Forwarded-Proto` + Host > `http://` + Host).

e2e 109/109 (new check: `/mcp-info` with the header advertises https), tsc clean, recovery tests 8/8. After merge: api-deploy dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH