### PR TITLE
playground: deploys reach the live container deterministically

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -82,7 +82,9 @@ jobs:
           file: nurlapi/Dockerfile
           push: true
           tags: nurllang/nurl:${{ steps.ver.outputs.version }}
-          build-args: NURL_VERSION=${{ steps.ver.outputs.version }}
+          build-args: |
+            NURL_VERSION=${{ steps.ver.outputs.version }}
+            NURL_BUILD_ID=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -109,7 +111,7 @@ jobs:
       - name: Deploy to Cloudflare
         if: env.DEPLOY_ENABLED == 'true'
         working-directory: cloudflare
-        run: npx wrangler deploy
+        run: npx wrangler deploy --var NURL_DEPLOY_ID:${{ github.sha }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -1,5 +1,5 @@
 import { Container, getContainer } from "@cloudflare/containers";
-import { decideAction } from "./recovery";
+import { decideAction, stampMismatch } from "./recovery";
 
 // ── Why this file has a custom fetch override ─────────────────────────────
 //
@@ -32,6 +32,14 @@ import { decideAction } from "./recovery";
 // How many times to recycle+retry before giving up and surfacing the error.
 // (The classification policy lives in ./recovery, kept pure for unit testing.)
 const MAX_RECYCLES = 2;
+
+// How often (at most) to compare the running image's build stamp against
+// the deployed one. A live instance under steady public traffic never
+// idles long enough to recycle onto a new image on its own — this check
+// makes deploys reach it deterministically, converging even when the
+// image rollout finishes minutes after `wrangler deploy` (a premature
+// recycle lands back on the old image, and the next check fires again).
+const STAMP_CHECK_MS = 5 * 60_000;
 
 export class NurlContainer extends Container<Env> {
   defaultPort = 8000;
@@ -90,6 +98,28 @@ export class NurlContainer extends Container<Env> {
         body: bodyBuf,
         redirect: "manual",
       });
+
+    // Deploy-stamp adoption: /health reports the image's baked build_id;
+    // when it differs from the Worker's NURL_DEPLOY_ID, this instance is
+    // running a pre-deploy image — recycle it (throttled) so the request
+    // is served by the new one.
+    if (this.env.NURL_DEPLOY_ID) {
+      const last = (await this.ctx.storage.get<number>("stampCheckAt")) ?? 0;
+      if (Date.now() - last > STAMP_CHECK_MS) {
+        await this.ctx.storage.put("stampCheckAt", Date.now());
+        try {
+          const h = await super.fetch(new Request("http://container/health"));
+          const j = (await h.json()) as { build_id?: string };
+          if (stampMismatch(this.env.NURL_DEPLOY_ID, j.build_id)) {
+            await this.recycle(
+              `image build ${j.build_id ?? "?"} != deploy ${this.env.NURL_DEPLOY_ID}`,
+            );
+          }
+        } catch {
+          // Probe failure = the normal request path will deal with it.
+        }
+      }
+    }
 
     for (let attempt = 0; ; attempt++) {
       let res: Response;

--- a/cloudflare/src/recovery.ts
+++ b/cloudflare/src/recovery.ts
@@ -55,3 +55,13 @@ export function decideAction(
   if (verdict === "wedged") return "recycle";
   return "retry";
 }
+
+// Deploy-stamp policy: recycle only when BOTH identities are known and
+// disagree. An image without a stamp (self-hosted, local dev) or a
+// worker without NURL_DEPLOY_ID must never trigger recycling.
+export function stampMismatch(
+  deployId: string | undefined | null,
+  buildId: string | undefined | null,
+): boolean {
+  return Boolean(deployId) && Boolean(buildId) && deployId !== buildId;
+}

--- a/cloudflare/test-recovery.ts
+++ b/cloudflare/test-recovery.ts
@@ -7,7 +7,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { classifyError, decideAction } from "./src/recovery.ts";
+import { classifyError, decideAction, stampMismatch } from "./src/recovery.ts";
 
 // The literal string the user observed at https://play.nurl-lang.org/.
 const PROD_WEDGE =
@@ -56,4 +56,13 @@ test("decideAction: transient 500 retries without a teardown", () => {
 
 test("decideAction: a genuine app 500 is never recycled", () => {
   assert.equal(decideAction(500, "internal error: handler panicked\n", 0, MAX), "return");
+});
+
+test("stampMismatch: recycles only on a known, differing pair", () => {
+  assert.equal(stampMismatch("abc", "def"), true);
+  assert.equal(stampMismatch("abc", "abc"), false);
+  assert.equal(stampMismatch(undefined, "def"), false);
+  assert.equal(stampMismatch("abc", undefined), false);
+  assert.equal(stampMismatch("abc", ""), false);
+  assert.equal(stampMismatch("", "def"), false);
 });

--- a/nurlapi/Dockerfile
+++ b/nurlapi/Dockerfile
@@ -205,6 +205,14 @@ COPY --from=builder /src/nurlapi/static /app/static
 ARG NURL_VERSION=dev
 RUN sed -i "s/__NURL_VERSION__/${NURL_VERSION}/g" /app/static/index.html
 
+# Exact build identity (the git SHA), reported by /health as build_id.
+# The Worker compares it against its NURL_DEPLOY_ID var and recycles a
+# container instance still running an older image — deploys reach the
+# LIVE instance deterministically instead of waiting for an idle window
+# that steady public traffic may never allow.
+ARG NURL_BUILD_ID=dev
+ENV NURL_BUILD_ID=${NURL_BUILD_ID}
+
 # Bring in all cross-compilation artifacts
 RUN mkdir -p /opt/nurl/build /opt/nurl/stdlib /app/output /opt/nurl/examples /opt/nurl/compiler /opt/nurl/spec /opt/nurl/docs
 COPY --from=builder /src/build/nurlc             /opt/nurl/build/nurlc

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -1692,6 +1692,12 @@ s combined_stdout s combined_stderr → v {
     : String nurlc_path ( get_nurlc_path ) : String stdlib_dir ( get_stdlib_dir ) : String wasi_clang ( get_wasi_clang ) : String runtime_wasm ( get_runtime_wasm_o )
     : Json j ( json_obj_new )
     ( json_obj_set j `status` ( json_str_lit `ok` ) )
+    // Exact image identity (git SHA baked at image build) — the Worker
+    // compares this against its NURL_DEPLOY_ID and recycles an instance
+    // still running an older image.
+    : String build_id ( env_var_or `NURL_BUILD_ID` `` )
+    ( json_obj_set j `build_id` ( json_str_lit ( string_data build_id ) ) )
+    ( string_free build_id )
     ( json_obj_set j `nurlc_available` ( json_bool ( file_exists ( string_data nurlc_path ) ) ) )
     ( json_obj_set j `nurlc_path` ( json_str_lit ( string_data nurlc_path ) ) )
     ( json_obj_set j `wasi_toolchain_available` ( json_bool | ( file_exists ( string_data wasi_clang ) ) ( file_exists ( string_data runtime_wasm ) ) ) )


### PR DESCRIPTION
Operational root fix surfaced by verifying the last three deploys: a container instance under steady public traffic **never idles** the 10 minutes `sleepAfter` needs, so a freshly-rolled image can wait indefinitely for adoption — and monitoring probes reset the very idle timer being waited on.

**Mechanism:**
* Image bakes its identity: `ARG/ENV NURL_BUILD_ID` = git SHA (api-deploy passes it as a build-arg); `/health` reports it as `build_id`
* Deploy passes the same SHA to the Worker: `wrangler deploy --var NURL_DEPLOY_ID:$GITHUB_SHA`
* `NurlContainer.fetch` compares the two at most every 5 min (DO-storage throttle); mismatch → `destroy()` → the request continues on a fresh instance running the new image

**Convergent by construction:** a recycle that fires before the CF image rollout completes lands back on the old image — the next check fires again until the stamps agree. Both stamps unset (self-hosted / local dev) → zero behavior change. Policy is pure (`stampMismatch`) and unit-tested.

tsc clean, recovery tests 9/9. After merge: api-deploy dispatch — **this deploy is the last one that needs idle-window babysitting**; the next one adopts within one request + ≤5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH