### PR TITLE
cloudflare: stamp bootstrap — missing build stamp recycles once per deploy

### DIFF
--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -1,5 +1,5 @@
 import { Container, getContainer } from "@cloudflare/containers";
-import { decideAction, stampMismatch } from "./recovery";
+import { decideAction, stampAction } from "./recovery";
 
 // ── Why this file has a custom fetch override ─────────────────────────────
 //
@@ -110,9 +110,11 @@ export class NurlContainer extends Container<Env> {
         try {
           const h = await super.fetch(new Request("http://container/health"));
           const j = (await h.json()) as { build_id?: string };
-          if (stampMismatch(this.env.NURL_DEPLOY_ID, j.build_id)) {
+          const recycledFor = await this.ctx.storage.get<string>("stampRecycledFor");
+          if (stampAction(this.env.NURL_DEPLOY_ID, j.build_id, recycledFor) === "recycle") {
+            await this.ctx.storage.put("stampRecycledFor", this.env.NURL_DEPLOY_ID);
             await this.recycle(
-              `image build ${j.build_id ?? "?"} != deploy ${this.env.NURL_DEPLOY_ID}`,
+              `image build ${j.build_id || "?"} != deploy ${this.env.NURL_DEPLOY_ID}`,
             );
           }
         } catch {

--- a/cloudflare/src/recovery.ts
+++ b/cloudflare/src/recovery.ts
@@ -56,12 +56,21 @@ export function decideAction(
   return "retry";
 }
 
-// Deploy-stamp policy: recycle only when BOTH identities are known and
-// disagree. An image without a stamp (self-hosted, local dev) or a
-// worker without NURL_DEPLOY_ID must never trigger recycling.
-export function stampMismatch(
+// Deploy-stamp policy. With no NURL_DEPLOY_ID (self-hosted, local dev)
+// nothing ever recycles. With one set:
+//   * a KNOWN, differing build stamp recycles every time — converges to
+//     a match once the image rollout has completed;
+//   * a MISSING stamp (image predates stamping, or was built without
+//     the arg) recycles at most ONCE per deploy id (`recycledFor` is
+//     what the DO remembers) — bootstraps the first stamped deploy onto
+//     a live unstamped instance without risking a permanent recycle
+//     loop against a misconfigured image.
+export function stampAction(
   deployId: string | undefined | null,
   buildId: string | undefined | null,
-): boolean {
-  return Boolean(deployId) && Boolean(buildId) && deployId !== buildId;
+  recycledFor: string | undefined | null,
+): "recycle" | "skip" {
+  if (!deployId) return "skip";
+  if (buildId) return buildId !== deployId ? "recycle" : "skip";
+  return recycledFor === deployId ? "skip" : "recycle";
 }

--- a/cloudflare/test-recovery.ts
+++ b/cloudflare/test-recovery.ts
@@ -7,7 +7,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { classifyError, decideAction, stampMismatch } from "./src/recovery.ts";
+import { classifyError, decideAction, stampAction } from "./src/recovery.ts";
 
 // The literal string the user observed at https://play.nurl-lang.org/.
 const PROD_WEDGE =
@@ -58,11 +58,17 @@ test("decideAction: a genuine app 500 is never recycled", () => {
   assert.equal(decideAction(500, "internal error: handler panicked\n", 0, MAX), "return");
 });
 
-test("stampMismatch: recycles only on a known, differing pair", () => {
-  assert.equal(stampMismatch("abc", "def"), true);
-  assert.equal(stampMismatch("abc", "abc"), false);
-  assert.equal(stampMismatch(undefined, "def"), false);
-  assert.equal(stampMismatch("abc", undefined), false);
-  assert.equal(stampMismatch("abc", ""), false);
-  assert.equal(stampMismatch("", "def"), false);
+test("stampAction: known differing stamp always recycles; match never", () => {
+  assert.equal(stampAction("abc", "def", undefined), "recycle");
+  assert.equal(stampAction("abc", "def", "abc"), "recycle");
+  assert.equal(stampAction("abc", "abc", undefined), "skip");
+  assert.equal(stampAction(undefined, "def", undefined), "skip");
+  assert.equal(stampAction("", "def", undefined), "skip");
+});
+
+test("stampAction: missing stamp recycles once per deploy id", () => {
+  assert.equal(stampAction("abc", undefined, undefined), "recycle");
+  assert.equal(stampAction("abc", "", undefined), "recycle");
+  assert.equal(stampAction("abc", undefined, "abc"), "skip");
+  assert.equal(stampAction("abc", undefined, "old-deploy"), "recycle");
 });


### PR DESCRIPTION
#520's both-stamps-known policy left a bootstrap gap: the live image predates stamping (`/health` has no `build_id`), so the *first* stamped deploy would still wait for an idle window — the exact failure mode the mechanism removes.

`stampAction(deployId, buildId, recycledFor)`:
* known differing stamp → **recycle every check** (converges once the rollout completes)
* missing stamp → **recycle at most once per deploy id** (DO storage remembers) — bootstraps stamping onto the live unstamped instance, and an image built without the arg can't cause a recycle loop
* no `NURL_DEPLOY_ID` → never (self-hosted/dev unchanged)

tsc clean, recovery tests 10/10. After merge + api-deploy: the live instance adopts within one request + ≤5 min, and every later deploy is fully deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH