### PR TITLE
release: v0.19.0 — reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] — 2026-07-17
+
+The **reachability** release: search that survives contact with a real
+language-model caller (ranked boundaries, zero-hit widening, exact-name
+footers, honest package descriptions), build artifacts addressed by
+absolute URLs, one shared search engine for the playground and the local
+nurl-mcp — and playground deploys that reach the live container
+deterministically instead of waiting for an idle window.
+
 ### Added
 
 - **`stdlib/ext/mcp_search.nu`** — the MCP search surface (module API

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-07-17 · Current release: **0.17.0** · Language: **Grammar
+_Last reviewed: 2026-07-17 · Current release: **0.19.0** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
Cuts **v0.19.0**: dates the `[Unreleased]` entries from #515–#522 and bumps the ROADMAP current-release line.

The **reachability** release: ranked `nurl_grep` boundaries · `nurl_api` zero-hit widening + exact-name footers · registry description quality + README fallback · absolute `download_url`s · `stdlib/ext/mcp_search` shared by nurlapi and `nurl-mcp` 0.5.0 · deterministic container-image adoption.

After merge: tag `v0.19.0` → release.yml + api-deploy from the tag; then package publishes (nurl-mcp 0.5.0 unblocks — it needs the released `ext/mcp_search.nu`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH