### PR TITLE
manifests: requirement widenings shipped with the v0.19.0 publishes

### DIFF
--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -6,9 +6,9 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 iforest = { path = "../iforest", version = "^0.1" }
-gpu = { path = "../gpu", version = "^0.4" }
-http = { path = "../http", version = "^0.2" }
-cli = { path = "../cli", version = "^0.1" }
+gpu = { path = "../gpu", version = "^0.7.0" }
+http = { path = "../http", version = "^0.3.1" }
+cli = { path = "../cli", version = "^0.2.0" }
 gpukit = { path = "../gpukit", version = "^0.3" }
 
 # Runtime data staged into $NURL_HOME/share/anomaly/ on `nurlpkg install`.

--- a/packages/gpukit/nurl.toml
+++ b/packages/gpukit/nurl.toml
@@ -5,4 +5,4 @@ description = "The ergonomic GPU-compute toolkit for NURL — a diamond facade o
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-gpu = { path = "../gpu", version = "^0.4" }
+gpu = { path = "../gpu", version = "^0.7.0" }

--- a/packages/nurllama/nurl.toml
+++ b/packages/nurllama/nurl.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 gguf = { path = "../gguf", version = "^0.2" }
-safetensor = { path = "../safetensor", version = "^0.1" }
-tokenizer = { path = "../tokenizer", version = "^0.1" }
-gpu = { path = "../gpu", version = "^0.6" }
+safetensor = { path = "../safetensor", version = "^0.2.1" }
+tokenizer = { path = "../tokenizer", version = "^0.2.0" }
+gpu = { path = "../gpu", version = "^0.7.0" }
 http = { path = "../http", version = "^0.3" }

--- a/packages/onnx/nurl.toml
+++ b/packages/onnx/nurl.toml
@@ -6,4 +6,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 tensor = { path = "../tensor", version = "^0.3" }
-gpu = { path = "../gpu", version = "^0.4" }
+gpu = { path = "../gpu", version = "^0.7.0" }


### PR DESCRIPTION
`nurlpkg update --all` made these during the publish sweep (the widen-gate demanded them); the published tarballs carry exactly these manifests — this makes the repo match. Diff is 8 requirement lines across 4 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH