### PR TITLE
playground: native builds link with -Wl,--as-needed (downloaded binaries were unloadable off-container)

### DIFF
--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -936,7 +936,16 @@ s combined_stdout s combined_stderr → v {
 // what nurl.sh produces locally so a /build link succeeds against the
 // committed stdlib/runtime.native.o (FFI-rich: libcurl + openssl +
 // sqlite3 + libpq + zlib + zstd).
+//
+// `-Wl,--as-needed` MUST precede the `-l` flags: it makes the linker
+// keep a DT_NEEDED entry only for a library the program actually
+// references a symbol from — without it every downloaded binary carried
+// hard deps on libpq/libsqlite3/libcurl/… and failed to LOAD on any box
+// missing one of them (`error while loading shared libraries:
+// libpq.so.5`), even for a hello world. Same flag, same position, as
+// nurl.sh's local link line.
 @ push_native_runtime_libs ( Vec s ) args → v {
+    ( vec_push [s] args `-Wl,--as-needed` )
     ( vec_push [s] args `-lm` )
     ( vec_push [s] args `-lpthread` )
     ( vec_push [s] args `-lcurl` )


### PR DESCRIPTION
## What

A binary compiled on the playground (web or MCP `nurl_build_native`) and downloaded to another machine failed to **load**:

```
./hello: error while loading shared libraries: libpq.so.5: cannot open shared object file
```

`push_native_runtime_libs` links every runtime backend unconditionally (`-lcurl -lssl -lcrypto -lsqlite3 -lpq -lz -lzstd`), and without `-Wl,--as-needed` the linker records a `DT_NEEDED` for each — so even a hello world demanded PostgreSQL/OpenSSL/sqlite client libraries at load time.

## Fix

The toolchain's own mechanism, applied to the playground's link line: `-Wl,--as-needed` pushed ahead of the `-l` flags (position matters — it governs what follows), exactly like `nurl.sh` does locally.

## Verified

Reproduced with the committed `stdlib/runtime.native.o`:

| program | NEEDED before | NEEDED after |
|---|---|---|
| hello world | libm, libcurl, libssl, libcrypto, libsqlite3, **libpq**, libz, libzstd, libc | **libc.so.6 only** — runs |
| sqlite-importing program | (same, all) | libsqlite3 + libc — still links and runs |

So portability comes for free and feature programs keep exactly the libraries they use.

Deploy: api-deploy workflow after merge; post-deploy check = build a hello via MCP and `readelf -d` the downloaded binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH