### PR TITLE
mlp 0.1.0 + anomaly 0.4.0: trainable MLP, real sliding-window timevector, autoencoder version

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -12804,7 +12804,12 @@
     // The void/unit value (a bare type keyword `v`) is never storable —
     // `: i y v` / `= x v` used to emit `store i64 void`. Reject at the source.
     ( die_if_void lex val `initialiser / assignment` )
-    ? & ( seq from_ty `i1` ) ! ( seq to_ty `i1` )
+    // i1 (comparison / short-circuit result) widens ONLY into an integer
+    // target. An aggregate target (`?T`, a slice, a result) used to take
+    // this branch too and emit `zext i1 … to { i1, %T }` — invalid IR that
+    // nurlc accepted and only clang rejected; it now falls through to the
+    // never-valid-mix diagnostic below.
+    ? & & ( seq from_ty `i1` ) ! ( seq to_ty `i1` ) > ( int_width to_ty ) 0
     { : s r ( nurl_cg_reg cg )
         ( nurl_print `  ` ) ( nurl_print r )
         ( nurl_print ` = zext i1 ` ) ( nurl_print val )
@@ -12922,7 +12927,14 @@
     ? & ! ( seq ( nurl_llty from_ty ) ( nurl_llty to_ty ) ) != 0 ( nurl_str_len to_ty )
     { : b csv_sf | ( seq from_ty `double` ) ( seq from_ty `float` )
         : b csv_tf | ( seq to_ty `double` ) ( seq to_ty `float` )
-        ? | != csv_sf csv_tf & ( is_ptr_ty from_ty ) ! ( is_ptr_ty to_ty )
+        // An anonymous-aggregate target (`{ …` — an option, slice or
+        // result shape) can never absorb a bare scalar: every legal wrap
+        // (enum, single-handle) already returned above. Without this arm a
+        // `: ?T x <bool-expr>` stored i1 into { i1, %T } — IR only clang
+        // rejected.
+        : b csv_agg & > ( int_width from_ty ) 0
+        == ( nurl_str_get ( nurl_llty to_ty ) 0 ) 123
+        ? | | != csv_sf csv_tf & ( is_ptr_ty from_ty ) ! ( is_ptr_ty to_ty ) csv_agg
         { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
             `value of type '` from_ty `' cannot initialise / assign a binding of type '` to_ty )
             `' — NURL has no implicit conversions; use a matching value or convert with '# T expr'` ) ) }

--- a/compiler/tests/outputs/should_fail_scalar_into_aggregate.txt
+++ b/compiler/tests/outputs/should_fail_scalar_into_aggregate.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_scalar_into_aggregate.nu
+++ b/compiler/tests/should_fail_scalar_into_aggregate.nu
@@ -1,0 +1,14 @@
+// A bare scalar can never initialise an anonymous-aggregate binding (an
+// option / slice / result shape) — there is no implicit wrap. This used to
+// slip through coerce_store_val's i1-widen branch as `zext i1 … to
+// { i1, %Thing }`, invalid IR that nurlc accepted (rc 0) and only clang
+// rejected. Must be a NURL diagnostic at the binding.
+
+: Thing { i a i b2 }
+
+@ gimme → b { ^ T }
+
+@ main → i {
+    : ?Thing x ( gimme )
+    ^ 0
+}

--- a/packages/anomaly/CHANGELOG.md
+++ b/packages/anomaly/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.4.0
+
+**The timevector is a real sliding window, and the autoencoder version
+arrives.**
+
+- **timevector = sliding window.** Previously the version trained a plain
+  point-based forest on the last 100 ring points. Now `window_size`
+  consecutive points flatten to ONE window vector (stepped by `step_size`
+  during training, both configurable and persisted), the forest trains on
+  the window vectors, and detection scores the window ENDING at the
+  incoming point — the version that sees ORDER. A reversed pattern or a
+  stuck sensor whose every reading is individually in range scores
+  anomalous while the point-based versions stay blind. A ring shorter
+  than the window yields NO timevector verdict (absent, never silently
+  wrong); detection derives the live window from the trained forest's
+  width, so a config change can never desync scoring before the retrain.
+  Legacy metadata upgrades in place (timevector 100/1).
+- **autoencoder version** (over the new [`mlp`](../mlp) package): an
+  explicitly-trained reconstruction detector. Training follows the
+  reference recipe — a temporary Isolation Forest (contamination 10 %)
+  drops the ring's anomalies first, the surviving rows are MinMax-scaled,
+  an MLP autoencoder (64-32-64 default, Adam, early stopping,
+  deterministic restarts) learns to reconstruct them, and the threshold
+  is the 95th percentile of the training errors. Detection reports
+  `threshold − mse` in the standard decision_function orientation, so
+  the any-version aggregation and margin tuning need no special case.
+  It catches CORRELATION breaks the marginals hide (a pressure/flow pair
+  that is individually normal but jointly impossible). Train with
+  `anomaly train-ae <model>` or `POST /train/autoencoder/<model>`;
+  never part of the automatic retrain schedule. Persisted per model
+  (`autoencoder.json`, bit-exact weights) and loaded on model open.
+- `model_set_version_window` — library-level window configuration.
+- Tests: `timevector_test.nu` (19 checks — order-blindness made visible:
+  the reversed run scores WORSE on timevector and BETTER on short_term),
+  `autoencoder_test.nu` (15 checks — detect/persist/errors), live HTTP
+  train + version-in-detect checks. Full suite 30/0; ASan + LSan clean.
+
 ## 0.3.6
 
 - The `serve` dashboard now works out of the box after a registry install.

--- a/packages/anomaly/README.md
+++ b/packages/anomaly/README.md
@@ -21,6 +21,26 @@ It is a NURL re-implementation of the anomaly-detection interface of a
 Flask + scikit-learn reference service (`model_training.py`), with the same
 HTTP routes and response shapes, so existing dashboards keep working.
 
+## Two versions beyond the forests
+
+- **timevector — the sliding window.** `window_size` consecutive points
+  flatten to one window vector; the forest trains on window vectors and
+  detection scores the window ending at the incoming point. This is the
+  version that sees ORDER: a reversed pattern or a stuck sensor whose
+  every reading is individually in range flags here while the point-based
+  versions stay blind. Configure with `window_size` / `step_size` in the
+  version config (`model_set_version_window` in the library).
+- **autoencoder — the correlation detector** (trained on demand:
+  `anomaly train-ae <model>` / `POST /train/autoencoder/<model>`). A
+  temporary Isolation Forest first drops the ring's anomalies
+  (contamination 10 %), then an MLP autoencoder
+  ([`mlp`](../mlp) package: Adam, early stopping, deterministic restarts)
+  learns to reconstruct the normal rows; the detection threshold is the
+  95th percentile of the training reconstruction errors. It catches what
+  marginals hide — a pressure/flow pair each in range but jointly
+  impossible. Reported as the `autoencoder` version with the standard
+  decision_function orientation (`threshold − mse`; negative ⇒ anomaly).
+
 ## What a model does
 
 - **Heterogeneous features, encoded automatically.** Numbers pass through;

--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anomaly"
-version = "0.3.8"
+version = "0.4.0"
 description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working. `anomaly serve` also ships a self-contained web dashboard (model manager, trainer, feature visualiser and anomaly scanner — plain HTML/JS, no CDN or build step) served straight from the binary's web root."
 license = "MIT OR Apache-2.0"
 
@@ -10,6 +10,7 @@ gpu = { path = "../gpu", version = "^0.7.0" }
 http = { path = "../http", version = "^0.3.1" }
 cli = { path = "../cli", version = "^0.2.0" }
 gpukit = { path = "../gpukit", version = "^0.3" }
+mlp = { path = "../mlp", version = "^0.1" }
 
 # Runtime data staged into $NURL_HOME/share/anomaly/ on `nurlpkg install`.
 # The `serve` dashboard resolves its web root as <exe-dir>/../share/anomaly/static,

--- a/packages/anomaly/src/autoenc.nu
+++ b/packages/anomaly/src/autoenc.nu
@@ -1,0 +1,309 @@
+// autoenc.nu — the autoencoder model version.
+//
+// The reference recipe (model_training.py train_autoencoder_model), in
+// pure NURL over the mlp package:
+//
+//   1. a TEMPORARY Isolation Forest (contamination 10 %) is trained on the
+//      standardised ring and every point it flags is dropped — the
+//      autoencoder must learn only NORMAL behaviour, and unlabeled rings
+//      contain the very anomalies we want it to spot later;
+//   2. the surviving rows are MinMax-scaled and an MLP autoencoder
+//      (default 64-32-64, ReLU, Adam, early stopping — sklearn
+//      MLPRegressor semantics via mlp_fit with deterministic restarts)
+//      learns to reconstruct them;
+//   3. the detection threshold is the 95th percentile (nearest-rank) of
+//      the training reconstruction errors.
+//
+// Detection scores a point as threshold − mse: negative ⇒ anomaly — the
+// same decision_function orientation as the forest versions, so the
+// service's "any version flags it" aggregation needs no special case.
+//
+// The autoencoder is NEVER part of the automatic retrain schedule: it is
+// trained explicitly (CLI `anomaly train-ae`, HTTP POST
+// /train/autoencoder/<model>) and stays enabled until the model is reset —
+// mirroring the reference, where a heavier, deliberately-trained version
+// coexists with the self-training forests.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/floatbits.nu`
+$ `stdlib/std/sort.nu`
+$ `stdlib/ext/json.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/score.nu`
+$ `deps/mlp/src/mlp.nu`
+
+// ── The trained artifact ──────────────────────────────────────────────
+
+: AeModel {
+    Mlp net
+    MinMax mm
+    ( Vec String ) feats  // feature order frozen at AE train time
+    f threshold  // p95 of the training reconstruction errors
+    i trained_on  // normal rows the net was fitted on
+    i filtered  // rows the pre-filter dropped as anomalous
+    b trained
+}
+
+// A structurally-valid untrained placeholder (freeable, never scored).
+@ ae_empty → AeModel {
+    : ( Vec i ) sz ( vec_new [i] )
+    ( vec_push [i] sz 1 ) ( vec_push [i] sz 1 )
+    : Mlp net ( mlp_new sz 0 )
+    ( vec_free [i] sz )
+    : ( Vec f ) e ( vec_new [f] )
+    : MinMax mm ( minmax_fit e 0 0 )
+    ( vec_free [f] e )
+    ^ @ AeModel { net mm ( vec_new [String] ) 0.0 0 0 F }
+}
+
+@ ae_free AeModel ae → v {
+    ( mlp_free . ae net )
+    ( minmax_free . ae mm )
+    ( vec_free_with [String] . ae feats \ String s2 → v { ( string_free s2 ) } )
+}
+
+// ── Training ──────────────────────────────────────────────────────────
+
+// Reconstruction MSE of one already-MinMax-scaled row (length d) held in
+// `X` at row r.
+@ __ae_row_mse Mlp net ( Vec f ) X i d i r → f {
+    : ( Vec f ) x ( vec_new [f] )
+    : ~ i k 0
+    ~ < k d { ( vec_push [f] x ( _mlp_fget X + * r d k ) ) = k + k 1 }
+    : ( Vec f ) y ( mlp_predict net x )
+    : ~ f se 0.0
+    = k 0
+    ~ < k d {
+        : f e - ( _mlp_fget y k ) ( _mlp_fget x k )
+        = se + se * e e
+        = k + k 1
+    }
+    ( vec_free [f] x ) ( vec_free [f] y )
+    ^ / se # f d
+}
+
+// Train from the RAW (unscaled) projected matrix `raw` (n×d, row-major)
+// with its feature order `feats` (borrowed; copied into the result).
+// `hidden` lists the hidden layer widths (empty → 64-32-64);
+// `contamination` is the pre-filter rate (<=0 → 0.10); `min_rows` gates
+// both the input and the post-filter survivor count. On failure the
+// returned AeModel has trained=F and `err` (owned) says why.
+: AeTrainOut {
+    AeModel ae
+    String err
+}
+
+@ ae_train_matrix ( Vec f ) raw i n i d ( Vec String ) feats ( Vec i ) hidden f contamination i min_rows → AeTrainOut {
+    ? < n min_rows {
+        ^ @ AeTrainOut { ( ae_empty ) ( string_from `not enough data points to train the autoencoder` ) }
+    } {}
+
+    // 1. the anomaly pre-filter: a temporary forest at a FIXED
+    // contamination (the reference found 'auto' unreliable here).
+    : ~ f cont contamination
+    ? <= cont 0.0 { = cont 0.10 } {}
+    : ( Vec f ) scaled ( vec_clone [f] raw )
+    : Scaler fsc ( scaler_fit scaled n d )
+    ( scaler_apply_matrix fsc scaled n d )
+    ( scaler_free fsc )
+    : VerCfg fcfg @ VerCfg { ( string_from `aefilter` ) 0 0 0 0 200 256 cont 0.0 T }
+    : VerModel fvm ( anom_train_version scaled n d fcfg )
+    ( _an_vercfg_free fcfg )
+    : ( Vec i ) keep ( vec_new [i] )
+    : ~ i r 0
+    ~ < r n {
+        ? >= ( anom_decision_row fvm scaled r ) 0.0 { ( vec_push [i] keep r ) } {}
+        = r + r 1
+    }
+    ( anom_vermodel_free fvm )
+    ( vec_free [f] scaled )
+    : i nk ( vec_len [i] keep )
+    ? < nk min_rows {
+        ( vec_free [i] keep )
+        ^ @ AeTrainOut { ( ae_empty ) ( string_from `too few normal points remain after anomaly filtering` ) }
+    } {}
+
+    // 2. MinMax over the surviving raw rows, then the autoencoder.
+    : ( Vec f ) Xn ( vec_with_cap [f] * nk d )
+    : *f rawp ( vec_data [f] raw )
+    : ~ i k 0
+    ~ < k nk {
+        : i row ( _mlp_iget keep k )
+        : ~ i c 0
+        ~ < c d {
+            ( vec_push [f] Xn . rawp + * row d c )
+            = c + c 1
+        }
+        = k + k 1
+    }
+    ( vec_free [i] keep )
+    : MinMax mm ( minmax_fit Xn nk d )
+    ( minmax_apply mm Xn nk )
+
+    : ( Vec i ) sz ( vec_new [i] )
+    ( vec_push [i] sz d )
+    : i nh ( vec_len [i] hidden )
+    ? > nh 0 {
+        : ~ i h 0
+        ~ < h nh { ( vec_push [i] sz ( _mlp_iget hidden h ) ) = h + h 1 }
+    } {
+        ( vec_push [i] sz 64 ) ( vec_push [i] sz 32 ) ( vec_push [i] sz 64 )
+    }
+    ( vec_push [i] sz d )
+    : ~ MlpCfg cfg ( mlp_cfg_default )
+    : MlpFit fit ( mlp_fit sz Xn nk d Xn d cfg 3 )
+    ( vec_free [i] sz )
+
+    // 3. threshold = p95 (nearest-rank) of the training errors.
+    : ( Vec f ) errs ( vec_with_cap [f] nk )
+    = k 0
+    ~ < k nk {
+        ( vec_push [f] errs ( __ae_row_mse . fit model Xn d k ) )
+        = k + k 1
+    }
+    ( sort_by [f] errs \ f a f b → i { ^ ? < a b -1 ? > a b 1 0 } )
+    : i p95i # i * 0.95 # f nk
+    : f thr ( _mlp_fget errs p95i )
+    ( vec_free [f] errs )
+    ( vec_free [f] Xn )
+
+    : ( Vec String ) fcopy ( vec_new [String] )
+    : i nf ( vec_len [String] feats )
+    = k 0
+    ~ < k nf {
+        ?? ( vec_get [String] feats k ) {
+            T fs → { ( vec_push [String] fcopy ( string_from ( string_data fs ) ) ) }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ @ AeTrainOut {
+        @ AeModel { . fit model mm fcopy thr nk - n nk T }
+        ( string_new )
+    }
+}
+
+// ── Scoring ───────────────────────────────────────────────────────────
+
+// Reconstruction MSE of one RAW projected point (the AE's own feature
+// order and MinMax are applied here — independent of the forests'
+// standardising scaler).
+@ ae_mse AeModel ae ( Vec f ) raw_point → f {
+    : MinMax amm . ae mm
+    : i d . amm n_cols
+    : ( Vec f ) x ( vec_clone [f] raw_point )
+    ( minmax_apply amm x 1 )
+    : Mlp anet . ae net
+    : ( Vec f ) y ( mlp_predict anet x )
+    : ~ f se 0.0
+    : ~ i k 0
+    ~ < k d {
+        : f e - ( _mlp_fget y k ) ( _mlp_fget x k )
+        = se + se * e e
+        = k + k 1
+    }
+    ( vec_free [f] x ) ( vec_free [f] y )
+    ^ / se # f d
+}
+
+// decision_function orientation: threshold − mse (negative ⇒ anomaly).
+@ ae_decision AeModel ae ( Vec f ) raw_point → f {
+    ^ - . ae threshold ( ae_mse ae raw_point )
+}
+
+// ── Persistence (one JSON file per model) ─────────────────────────────
+
+@ ae_to_json_str AeModel ae → String {
+    : Json o ( json_obj_new )
+    : String nj ( mlp_save . ae net )
+    : String mj ( minmax_save . ae mm )
+    ( json_obj_set o `net` ( json_str_lit ( string_data nj ) ) )
+    ( json_obj_set o `minmax` ( json_str_lit ( string_data mj ) ) )
+    ( string_free nj ) ( string_free mj )
+    ( json_obj_set o `threshold_bits` ( json_int ( f64_to_bits . ae threshold ) ) )
+    ( json_obj_set o `trained_on` ( json_int . ae trained_on ) )
+    ( json_obj_set o `filtered` ( json_int . ae filtered ) )
+    : Json fa ( json_arr_new )
+    : i nf ( vec_len [String] . ae feats )
+    : ~ i k 0
+    ~ < k nf {
+        ?? ( vec_get [String] . ae feats k ) {
+            T fs → { ( json_arr_push fa ( json_str_lit ( string_data fs ) ) ) }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( json_obj_set o `features` fa )
+    : String out ( json_stringify o )
+    ( json_free o )
+    ^ out
+}
+
+@ ae_from_json_str s src → ?AeModel {
+    : !Json JsonError r ( json_parse src )
+    ?? r {
+        F _ → { ^ @ ?AeModel { F } }
+        T j → {
+            : ~ b ok T
+            : ~ s njs ``
+            : ~ s mjs ``
+            ?? ( json_obj_get j `net` ) { T e → { = njs ( json_str_data e ) } F _ → { = ok F } }
+            ?? ( json_obj_get j `minmax` ) { T e → { = mjs ( json_str_data e ) } F _ → { = ok F } }
+            ? ! ok { ( json_free j ) ^ @ ?AeModel { F } } {}
+            : ?Mlp neto ( mlp_load njs )
+            : ?MinMax mmo ( minmax_load mjs )
+            : ~ b have_net F
+            ?? neto { T _ → { = have_net T } F → {} }
+            : ~ b have_mm F
+            ?? mmo { T _ → { = have_mm T } F → {} }
+            ? & have_net have_mm {} {
+                ?? neto { T n2 → { ( mlp_free n2 ) } F → {} }
+                ?? mmo { T m2 → { ( minmax_free m2 ) } F → {} }
+                ( json_free j )
+                ^ @ ?AeModel { F }
+            }
+            : Mlp net ?? neto { T n2 → n2 F → ( ae_dummy_net ) }
+            : MinMax mm ?? mmo { T m2 → m2 F → ( ae_dummy_mm ) }
+            : f thr ( bits_to_f64 ?? ( json_obj_get j `threshold_bits` ) { T e → ?? ( json_num_as_i e ) { T x → x F → 0 } F _ → 0 } )
+            : i ton ?? ( json_obj_get j `trained_on` ) { T e → ( json_as_int e ) F _ → 0 }
+            : i fil ?? ( json_obj_get j `filtered` ) { T e → ( json_as_int e ) F _ → 0 }
+            : ( Vec String ) feats ( vec_new [String] )
+            ?? ( json_obj_get j `features` ) {
+                T fa → {
+                    : i nf ( json_arr_len fa )
+                    : ~ i k 0
+                    ~ < k nf {
+                        ?? ( json_arr_get fa k ) {
+                            T e → { ( vec_push [String] feats ( string_from ( json_str_data e ) ) ) }
+                            F → {}
+                        }
+                        = k + k 1
+                    }
+                }
+                F _ → {}
+            }
+            ( json_free j )
+            ^ @ ?AeModel { T @ AeModel { net mm feats thr ton fil T } }
+        }
+    }
+}
+
+// Fallback constructors for the load path's option unwrap (never used on
+// the success path; both arms above guarantee have_net/have_mm).
+@ ae_dummy_net → Mlp {
+    : ( Vec i ) sz ( vec_new [i] )
+    ( vec_push [i] sz 1 ) ( vec_push [i] sz 1 )
+    : Mlp m ( mlp_new sz 0 )
+    ( vec_free [i] sz )
+    ^ m
+}
+
+@ ae_dummy_mm → MinMax {
+    : ( Vec f ) e ( vec_new [f] )
+    : MinMax m ( minmax_fit e 0 0 )
+    ( vec_free [f] e )
+    ^ m
+}

--- a/packages/anomaly/src/dynamic.nu
+++ b/packages/anomaly/src/dynamic.nu
@@ -77,6 +77,8 @@ $ `src/store.nu`
         ( string_from ( string_data . vc vname ) )
         . vc window_min
         . vc window_pts
+        . vc window_size
+        . vc step_size
         . vc n_estimators
         . vc max_samples
         . vc contamination
@@ -196,6 +198,32 @@ $ `src/store.nu`
     ^ ( model_open_at st name ( now_seconds ) )
 }
 
+// Set a version's sliding-window geometry (timevector). Takes effect at
+// the NEXT retrain — detect derives the live window from the trained
+// forest's width, so a config change can never desync scoring.
+@ model_set_version_window * Model mo s vname i wsize i sstep → b {
+    : *Meta mm . mo meta
+    : i nv ( vec_len [VerCfg] . mm versions )
+    : ~ i k 0
+    ~ < k nv {
+        ?? ( vec_get [VerCfg] . mm versions k ) {
+            T vc → {
+                ? == ( nurl_str_eq ( string_data . vc vname ) vname ) 1 {
+                    : ~ VerCfg nc vc
+                    = . nc window_size wsize
+                    = . nc step_size sstep
+                    : b _o ( vec_set [VerCfg] . mm versions k nc )
+                    ( store_save_meta . mo store ( string_data . mo mname ) mm )
+                    ^ T
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ F
+}
+
 @ model_free * Model mo → v {
     ( __an_free_forests mo )
     ( vec_free [VerModel] . mo forests )
@@ -255,7 +283,50 @@ $ `src/store.nu`
 
 // Score an encoded point against every trained version. `ready` is false
 // until the model has trained at least once AND the ring holds min_points.
-@ __an_score_enc * Model mo EncPoint p → Verdict {
+// The last window_size−1 ring points before the current one, projected and
+// standardised, concatenated in time order — the sliding window's tail.
+// `skip_last` skips the ring's newest entry (at ingest the current point is
+// already IN the ring; at detect_only it is not). None when the ring is too
+// short or a stored line no longer parses.
+@ __an_window_tail * Model mo i need i skip_last → ?( Vec f ) {
+    : *Meta mm . mo meta
+    : i n - ( vec_len [String] . mo lines ) skip_last
+    ? < n need { ^ @ ?( Vec f ) { F } } {}
+    : ( Vec f ) out ( vec_new [f] )
+    : ~ b ok T
+    : ~ i k - n need
+    ~ & ok < k n {
+        ?? ( vec_get [String] . mo lines k ) {
+            T l → {
+                : !Json JsonError jr ( json_parse ( string_data l ) )
+                ?? jr {
+                    T j → {
+                        : !EncPoint String er ( anomaly_preprocess mm j )
+                        ?? er {
+                            T pt → {
+                                : ( Vec f ) row ( anomaly_project pt . mm feats )
+                                ( scaler_apply . mo sc row )
+                                ( vec_extend [f] out row )
+                                ( vec_free [f] row )
+                                ( enc_free pt )
+                            }
+                            F e → { ( string_free e ) = ok F }
+                        }
+                        ( json_free j )
+                    }
+                    F _ → { = ok F }
+                }
+            }
+            F _ → { = ok F }
+        }
+        = k + k 1
+    }
+    ? ok { ^ @ ?( Vec f ) { T out } } {}
+    ( vec_free [f] out )
+    ^ @ ?( Vec f ) { F }
+}
+
+@ __an_score_enc * Model mo EncPoint p i ring_has_current → Verdict {
     : ( Vec VerVerdict ) vvs ( vec_new [VerVerdict] )
     : b warm >= ( vec_len [String] . mo lines ) . mo min_points
     ? & ( model_is_trained mo ) warm {} {
@@ -263,6 +334,7 @@ $ `src/store.nu`
     }
 
     : *Meta mm . mo meta
+    : i nfeat ( vec_len [String] . mm feats )
     : ( Vec f ) x ( anomaly_project p . mm feats )
     ( scaler_apply . mo sc x )
 
@@ -274,18 +346,49 @@ $ `src/store.nu`
     ~ < k nf {
         ?? ( vec_get [VerModel] . mo forests k ) {
             T vm → {
-                : f df ( anom_decision vm x )
-                : f margin ( __an_margin_of mm ( string_data . vm vname ) . vm margin )
-                : b hit <= df - 0.0 margin
-                ? hit { = any T } {}
-                ? || first < df worst { = worst df } {}
-                = first F
-                ( vec_push [VerVerdict] vvs @ VerVerdict {
-                    ( string_from ( string_data . vm vname ) )
-                    hit
-                    df
-                    margin
-                } )
+                // A forest wider than one point is a timevector forest:
+                // its input is the WINDOW ending at the current point
+                // (W·nfeat features, W derived from the trained forest so
+                // a config change cannot desync until the next retrain).
+                ? & > nfeat 0 != . vm n_cols nfeat {
+                    : i W / . vm n_cols nfeat
+                    ?? ( __an_window_tail mo - W 1 ring_has_current ) {
+                        T tail → {
+                            ( vec_extend [f] tail x )
+                            ? == ( vec_len [f] tail ) . vm n_cols {
+                                : f dfw ( anom_decision vm tail )
+                                : f marginw ( __an_margin_of mm ( string_data . vm vname ) . vm margin )
+                                : b hitw <= dfw - 0.0 marginw
+                                ? hitw { = any T } {}
+                                ? || first < dfw worst { = worst dfw } {}
+                                = first F
+                                ( vec_push [VerVerdict] vvs @ VerVerdict {
+                                    ( string_from ( string_data . vm vname ) )
+                                    hitw
+                                    dfw
+                                    marginw
+                                } )
+                            } {}
+                            ( vec_free [f] tail )
+                        }
+                        F → {}
+                        // ring shorter than the window → the version has
+                        // no verdict this time (absent, never wrong)
+                    }
+                } {
+                    : f df ( anom_decision vm x )
+                    : f margin ( __an_margin_of mm ( string_data . vm vname ) . vm margin )
+                    : b hit <= df - 0.0 margin
+                    ? hit { = any T } {}
+                    ? || first < df worst { = worst df } {}
+                    = first F
+                    ( vec_push [VerVerdict] vvs @ VerVerdict {
+                        ( string_from ( string_data . vm vname ) )
+                        hit
+                        df
+                        margin
+                    } )
+                }
             }
             F _ → {}
         }
@@ -402,23 +505,62 @@ $ `src/store.nu`
                     }
                     : i cnt - ne from
 
-                    : ( Vec f ) sub ( vec_with_cap [f] * cnt nfeat )
-                    : *f subp ( vec_data [f] sub )
-                    : ~ i r 0
-                    ~ < r cnt {
-                        : ~ i c 0
-                        ~ < c nfeat {
-                            = . subp + * r nfeat c . bigp + * + from r nfeat c
-                            = c + c 1
+                    ? > . vc window_size 0 {
+                        // timevector: flatten each run of W consecutive
+                        // rows (stepped by S) into ONE window vector of
+                        // W·nfeat features and train the forest on those.
+                        // The ring is ingest-ordered (timestamps ascend),
+                        // so consecutive rows ARE the time sequence.
+                        : i W . vc window_size
+                        : ~ i S . vc step_size
+                        ? < S 1 { = S 1 } {}
+                        ? >= cnt W {
+                            : i nwin + / - cnt W S 1
+                            : i wdim * W nfeat
+                            : ( Vec f ) wins ( vec_with_cap [f] * nwin wdim )
+                            : *f winp ( vec_data [f] wins )
+                            : ~ i wi 0
+                            ~ < wi nwin {
+                                : i base + from * wi S
+                                : ~ i r2 0
+                                ~ < r2 W {
+                                    : ~ i c2 0
+                                    ~ < c2 nfeat {
+                                        = . winp + * wi wdim + * r2 nfeat c2 . bigp + * + base r2 nfeat c2
+                                        = c2 + c2 1
+                                    }
+                                    = r2 + r2 1
+                                }
+                                = wi + wi 1
+                            }
+                            ( vec_set_len [f] wins * nwin wdim )
+                            : VerModel vm ( anom_train_version wins nwin wdim vc )
+                            ( store_save_forest . mo store ( string_data . mo mname ) vm )
+                            ( vec_push [VerModel] . mo forests vm )
+                            ( vec_free [f] wins )
+                        } {}
+                        // cnt < W: too little data for one window — the
+                        // version simply has no forest this round (its
+                        // verdict is absent, never silently wrong).
+                    } {
+                        : ( Vec f ) sub ( vec_with_cap [f] * cnt nfeat )
+                        : *f subp ( vec_data [f] sub )
+                        : ~ i r 0
+                        ~ < r cnt {
+                            : ~ i c 0
+                            ~ < c nfeat {
+                                = . subp + * r nfeat c . bigp + * + from r nfeat c
+                                = c + c 1
+                            }
+                            = r + r 1
                         }
-                        = r + r 1
-                    }
-                    ( vec_set_len [f] sub * cnt nfeat )
+                        ( vec_set_len [f] sub * cnt nfeat )
 
-                    : VerModel vm ( anom_train_version sub cnt nfeat vc )
-                    ( store_save_forest . mo store ( string_data . mo mname ) vm )
-                    ( vec_push [VerModel] . mo forests vm )
-                    ( vec_free [f] sub )
+                        : VerModel vm ( anom_train_version sub cnt nfeat vc )
+                        ( store_save_forest . mo store ( string_data . mo mname ) vm )
+                        ( vec_push [VerModel] . mo forests vm )
+                        ( vec_free [f] sub )
+                    }
                 } {}
             }
             F _ → {}
@@ -475,7 +617,7 @@ $ `src/store.nu`
                 ( model_force_train_at mo now )
             } {}
 
-            : Verdict vd ( __an_score_enc mo p )
+            : Verdict vd ( __an_score_enc mo p 1 )
             ( enc_free p )
             ^ @ !Verdict String { T vd }
         }
@@ -493,7 +635,7 @@ $ `src/store.nu`
     : !EncPoint String er ( anomaly_preprocess_ro . mo meta raw )
     ?? er {
         T p → {
-            : Verdict vd ( __an_score_enc mo p )
+            : Verdict vd ( __an_score_enc mo p 0 )
             ( enc_free p )
             ^ @ !Verdict String { T vd }
         }

--- a/packages/anomaly/src/dynamic.nu
+++ b/packages/anomaly/src/dynamic.nu
@@ -34,6 +34,7 @@ $ `stdlib/ext/json.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
 $ `src/score.nu`
+$ `src/autoenc.nu`
 $ `src/store.nu`
 
 // ── Types ─────────────────────────────────────────────────────────────
@@ -63,6 +64,7 @@ $ `src/store.nu`
     ( Vec i ) times
     ( Vec VerModel ) forests
     Scaler sc
+    AeModel ae
     i next_train_at
     i min_points
     i max_points
@@ -185,6 +187,12 @@ $ `src/store.nu`
     // Scaler from persisted metadata (empty scaler if never trained).
     = . mo sc ( meta_scaler mm )
 
+    // The autoencoder version, if one has been trained for this model.
+    ?? ( store_load_ae . mo store name ) {
+        T ae → { = . mo ae ae }
+        F → { = . mo ae ( ae_empty ) }
+    }
+
     // Next scheduled training mark, from the lifetime counter.
     ? == ( vec_len [VerModel] . mo forests ) 0 {
         = . mo next_train_at . mo min_points
@@ -230,6 +238,7 @@ $ `src/store.nu`
     ( __an_free_lines . mo lines )
     ( vec_free [i] . mo times )
     ( scaler_free . mo sc )
+    ( ae_free . mo ae )
     ( meta_free . mo meta )
     ( string_free . mo mname )
     ( store_free . mo store )
@@ -394,6 +403,26 @@ $ `src/store.nu`
         }
         = k + k 1
     }
+    // The autoencoder verdict: reconstruction error against the trained
+    // threshold, on the point projected onto the AE's OWN frozen feature
+    // order (independent of the forests' scaler and current feats).
+    : AeModel cae . mo ae
+    ? . cae trained {
+        : ( Vec f ) araw ( anomaly_project p . cae feats )
+        : f adf ( ae_decision cae araw )
+        : f amargin ( __an_margin_of mm `autoencoder` 0.05 )
+        : b ahit <= adf - 0.0 amargin
+        ? ahit { = any T } {}
+        ? || first < adf worst { = worst adf } {}
+        = first F
+        ( vec_push [VerVerdict] vvs @ VerVerdict {
+            ( string_from `autoencoder` )
+            ahit
+            adf
+            amargin
+        } )
+        ( vec_free [f] araw )
+    } {}
     ( vec_free [f] x )
     ^ @ Verdict { T any worst vvs }
 }
@@ -578,6 +607,104 @@ $ `src/store.nu`
 
 @ model_force_train * Model mo → i {
     ^ ( model_force_train_at mo ( now_seconds ) )
+}
+
+// ── The autoencoder version ───────────────────────────────────────────
+
+// Ensure an `autoencoder` VerCfg exists in the metadata (margin tunable
+// through the same machinery as the forest versions; window fields 0).
+@ __an_ensure_ae_cfg * Model mo → v {
+    : *Meta mm . mo meta
+    : i nv ( vec_len [VerCfg] . mm versions )
+    : ~ i k 0
+    ~ < k nv {
+        ?? ( vec_get [VerCfg] . mm versions k ) {
+            T vc → {
+                ? == ( nurl_str_eq ( string_data . vc vname ) `autoencoder` ) 1 { ^ } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_push [VerCfg] . mm versions
+    @ VerCfg { ( string_from `autoencoder` ) 0 0 0 0 0 0 -1.0 0.05 T } )
+}
+
+// Train the autoencoder from the ring: encode + project the raw points
+// (the same pass model_force_train_at runs, minus the standardising
+// scaler — the AE recipe MinMax-scales after anomaly filtering), then
+// hand the matrix to ae_train_matrix. `hidden` empty → 64-32-64.
+// Explicit-only: never part of the retrain schedule. Returns the error
+// text ("" = success).
+@ model_train_autoencoder * Model mo ( Vec i ) hidden f contamination → String {
+    : *Meta mm . mo meta
+    : i n ( vec_len [String] . mo lines )
+    ? < n . mo min_points { ^ ( string_from `not enough data points` ) } {}
+
+    : ( Vec EncPoint ) encs ( vec_new [EncPoint] )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] . mo lines k ) {
+            T l → {
+                : !Json JsonError jr ( json_parse ( string_data l ) )
+                ?? jr {
+                    T j → {
+                        : !EncPoint String er ( anomaly_preprocess mm j )
+                        ?? er {
+                            T p → { ( vec_push [EncPoint] encs p ) }
+                            F e → { ( string_free e ) }
+                        }
+                        ( json_free j )
+                    }
+                    F _ → {}
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    : i ne ( vec_len [EncPoint] encs )
+    ? < ne . mo min_points {
+        ( vec_free_with [EncPoint] encs \ EncPoint p → v { ( enc_free p ) } )
+        ^ ( string_from `not enough decodable data points` )
+    } {}
+
+    ( meta_refresh_feats mm )
+    : i nfeat ( vec_len [String] . mm feats )
+    ? <= nfeat 0 {
+        ( vec_free_with [EncPoint] encs \ EncPoint p → v { ( enc_free p ) } )
+        ^ ( string_from `no numeric features` )
+    } {}
+    : ( Vec f ) raw ( vec_with_cap [f] * ne nfeat )
+    = k 0
+    ~ < k ne {
+        ?? ( vec_get [EncPoint] encs k ) {
+            T p → {
+                : ( Vec f ) row ( anomaly_project p . mm feats )
+                ( vec_extend [f] raw row )
+                ( vec_free [f] row )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [EncPoint] encs \ EncPoint p → v { ( enc_free p ) } )
+
+    : AeTrainOut out ( ae_train_matrix raw ne nfeat . mm feats hidden contamination . mo min_points )
+    ( vec_free [f] raw )
+    : AeModel nae . out ae
+    ? . nae trained {
+        ( ae_free . mo ae )
+        = . mo ae nae
+        ( __an_ensure_ae_cfg mo )
+        ( store_save_ae . mo store ( string_data . mo mname ) . mo ae )
+        ( store_save_meta . mo store ( string_data . mo mname ) mm )
+        ( string_free . out err )
+        ^ ( string_new )
+    } {
+        ( ae_free nae )
+        ^ . out err
+    }
 }
 
 // ── Ingest / detect ───────────────────────────────────────────────────

--- a/packages/anomaly/src/main.nu
+++ b/packages/anomaly/src/main.nu
@@ -265,7 +265,7 @@ $ `src/service.nu`
         ^ 1
     } {}
     : f margin ( ctx_float x `margin` )
-    : VerCfg cfg @ VerCfg { ( string_from `batch` ) 0 0 100 256 -1.0 margin T }
+    : VerCfg cfg @ VerCfg { ( string_from `batch` ) 0 0 0 0 100 256 -1.0 margin T }
     : BatchReport rep ( anomaly_batch . ds data . ds rows . ds cols cfg )
     ( _an_vercfg_free cfg )
 

--- a/packages/anomaly/src/main.nu
+++ b/packages/anomaly/src/main.nu
@@ -384,6 +384,43 @@ $ `src/service.nu`
     ^ rc
 }
 
+@ __an_cmd_train_ae CliCtx x → i {
+    : String mname ( ctx_arg x 0 )
+    : String root ( __an_store_root x )
+    : Store st ( store_open ( string_data root ) )
+    ( string_free root )
+    : ~ i rc 0
+    ? ( store_exists st ( string_data mname ) ) {
+        : *Model mo ( model_open st ( string_data mname ) )
+        : ( Vec i ) hidden ( vec_new [i] )
+        : String err ( model_train_autoencoder mo hidden -1.0 )
+        ( vec_free [i] hidden )
+        ? == ( string_len err ) 0 {
+            : AeModel tae . mo ae
+            : String msg ( string_from `autoencoder trained on ` )
+            ( string_push_int msg . tae trained_on )
+            ( string_push_str msg ` normal points (` )
+            ( string_push_int msg . tae filtered )
+            ( string_push_str msg ` anomalies filtered)` )
+            ( pline ( string_data msg ) )
+            ( string_free msg )
+        } {
+            ( nurl_eprint `anomaly: ` )
+            ( nurl_eprintln ( string_data err ) )
+            = rc 1
+        }
+        ( string_free err )
+        ( model_free mo )
+    } {
+        ( nurl_eprint `anomaly: model not found: ` )
+        ( nurl_eprintln ( string_data mname ) )
+        = rc 1
+    }
+    ( store_free st )
+    ( string_free mname )
+    ^ rc
+}
+
 @ __an_cmd_train CliCtx x → i {
     : String mname ( ctx_arg x 0 )
     : String root ( __an_store_root x )
@@ -470,6 +507,7 @@ $ `src/service.nu`
     ( cli_cmd c `score` `score only (never ingests or retrains)` \ CliCtx x → i { ^ ( __an_cmd_detect x F ) } )
     ( cli_cmd c `batch` `score a CSV, one index<TAB>score per row` \ CliCtx x → i { ^ ( __an_cmd_batch x ) } )
     ( cli_cmd c `train` `force a retrain now` \ CliCtx x → i { ^ ( __an_cmd_train x ) } )
+    ( cli_cmd c `train-ae` `train the autoencoder version (iforest-filtered)` \ CliCtx x → i { ^ ( __an_cmd_train_ae x ) } )
     ( cli_cmd c `reset` `drop data + forests, keep the name` \ CliCtx x → i { ^ ( __an_cmd_reset x ) } )
     ( cli_cmd c `rm` `delete the model entirely` \ CliCtx x → i { ^ ( __an_cmd_rm x ) } )
     ( cli_cmd c `ls` `list models` \ CliCtx x → i { ^ ( __an_cmd_ls x ) } )

--- a/packages/anomaly/src/prep.nu
+++ b/packages/anomaly/src/prep.nu
@@ -51,6 +51,8 @@ $ `stdlib/ext/json.nu`
     String vname
     i window_min
     i window_pts
+    i window_size  // sliding-window LENGTH in points (timevector; 0 = plain)
+    i step_size  // sliding-window step during training (timevector)
     i n_estimators
     i max_samples
     f contamination
@@ -97,11 +99,19 @@ $ `stdlib/ext/json.nu`
 // ── Version defaults ──────────────────────────────────────────────────
 //
 // The five default versions of the reference service. `seasonal`'s 90 days
-// are expressed in minutes; `timevector` has no time window — it works on
-// the most recent `window_pts` points.
+// are expressed in minutes; `timevector` is the sliding-window version: it
+// trains on flattened windows of `window_size` consecutive points (stepped
+// by `step_size`) and scores the window ENDING at the incoming point.
 
 @ __an_vc s vname i wmin i wpts i est i samp f margin → VerCfg {
-    ^ @ VerCfg { ( string_from vname ) wmin wpts est samp -1.0 margin T }
+    ^ @ VerCfg { ( string_from vname ) wmin wpts 0 0 est samp -1.0 margin T }
+}
+
+// timevector: a REAL sliding window — window_size consecutive points
+// flatten to one window_size×n_features vector; the forest is trained on
+// the window vectors (stepped by step_size) and scores the LAST window.
+@ __an_vc_tv s vname i wsize i sstep i est i samp f margin → VerCfg {
+    ^ @ VerCfg { ( string_from vname ) 0 0 wsize sstep est samp -1.0 margin T }
 }
 
 @ meta_default_versions → ( Vec VerCfg ) {
@@ -110,7 +120,7 @@ $ `stdlib/ext/json.nu`
     ( vec_push [VerCfg] vs ( __an_vc `daily` 1440 0 300 256 0.12 ) )
     ( vec_push [VerCfg] vs ( __an_vc `weekly` 10080 0 350 256 0.06 ) )
     ( vec_push [VerCfg] vs ( __an_vc `seasonal` 129600 0 400 256 0.08 ) )
-    ( vec_push [VerCfg] vs ( __an_vc `timevector` 0 100 200 256 0.10 ) )
+    ( vec_push [VerCfg] vs ( __an_vc_tv `timevector` 100 1 200 256 0.10 ) )
     ^ vs
 }
 
@@ -749,6 +759,8 @@ $ `stdlib/ext/json.nu`
                 : Json vo ( json_obj_new )
                 ( json_obj_set vo `window_minutes` ( json_int . vc window_min ) )
                 ( json_obj_set vo `window_points` ( json_int . vc window_pts ) )
+                ( json_obj_set vo `window_size` ( json_int . vc window_size ) )
+                ( json_obj_set vo `step_size` ( json_int . vc step_size ) )
                 ( json_obj_set vo `n_estimators` ( json_int . vc n_estimators ) )
                 ( json_obj_set vo `max_samples` ( json_int . vc max_samples ) )
                 ? < . vc contamination 0.0 {
@@ -804,10 +816,13 @@ $ `stdlib/ext/json.nu`
     }
     : ~ b on T
     ?? ( json_obj_get vo `enabled` ) { T ej → { = on ( json_as_bool ej ) } F _ → {} }
+    : b is_tv == ( nurl_str_eq vname `timevector` ) 1
     ^ @ VerCfg {
         ( string_from vname )
         ( _an_jint vo `window_minutes` 0 )
-        ( _an_jint vo `window_points` 0 )
+        ? is_tv 0 ( _an_jint vo `window_points` 0 )
+        ( _an_jint vo `window_size` ? is_tv 100 0 )
+        ( _an_jint vo `step_size` ? is_tv 1 0 )
         ( _an_jint vo `n_estimators` 100 )
         ( _an_jint vo `max_samples` 256 )
         cont

--- a/packages/anomaly/src/service.nu
+++ b/packages/anomaly/src/service.nu
@@ -712,7 +712,7 @@ $ `src/csvdata.nu`
                         ( string_free fpath )
                         ^ ( __an_json_err 400 `No numeric rows found in file` )
                     } {}
-                    : VerCfg cfg @ VerCfg { ( string_from `batch` ) 0 0 100 256 -1.0 0.0 T }
+                    : VerCfg cfg @ VerCfg { ( string_from `batch` ) 0 0 0 0 100 256 -1.0 0.0 T }
                     : BatchReport rep ( anomaly_batch . ds data . ds rows . ds cols cfg )
                     ( _an_vercfg_free cfg )
 

--- a/packages/anomaly/src/service.nu
+++ b/packages/anomaly/src/service.nu
@@ -617,6 +617,48 @@ $ `src/csvdata.nu`
     }
 }
 
+@ __an_h_train_ae HttpRequest req Params p → HttpResponse {
+    : String mname ( __an_param_model p )
+    ? ( __an_name_ok ( string_data mname ) ) {} {
+        ( string_free mname )
+        ^ ( __an_bad_name )
+    }
+    : Store st ( store_open g_an_root )
+    ? ( store_exists st ( string_data mname ) ) {} {
+        : HttpResponse r404 ( __an_404_model ( string_data mname ) )
+        ( store_free st )
+        ( string_free mname )
+        ^ r404
+    }
+    : *Model mo ( model_open st ( string_data mname ) )
+    : ( Vec i ) hidden ( vec_new [i] )
+    : String err ( model_train_autoencoder mo hidden -1.0 )
+    ( vec_free [i] hidden )
+    ? == ( string_len err ) 0 {
+        : AeModel tae . mo ae
+        : String msg ( string_from `Autoencoder trained successfully for model ` )
+        ( string_push_str msg ( string_data mname ) )
+        : Json o ( __an_ok_msg ( string_data msg ) )
+        ( string_free msg )
+        ( json_obj_set o `training_data_points` ( json_int . tae trained_on ) )
+        ( json_obj_set o `filtered_anomalies` ( json_int . tae filtered ) )
+        ( json_obj_set o `reconstruction_threshold` ( json_float . tae threshold ) )
+        : HttpResponse rr ( response_json 200 o )
+        ( string_free err )
+        ( model_free mo )
+        ( store_free st )
+        ( string_free mname )
+        ^ rr
+    } {
+        : HttpResponse rr ( __an_json_err 400 ( string_data err ) )
+        ( string_free err )
+        ( model_free mo )
+        ( store_free st )
+        ( string_free mname )
+        ^ rr
+    }
+}
+
 @ __an_h_finetune HttpRequest req Params p → HttpResponse {
     : String mname ( __an_param_model p )
     ? ( __an_name_ok ( string_data mname ) ) {} {
@@ -815,6 +857,7 @@ $ `src/csvdata.nu`
     ( router_get r `/delete_model/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_delete req p ) } )
     ( router_put r `/api/dynamic/:model/schedule` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_schedule req p ) } )
     ( router_post r `/api/dynamic/:model/finetune` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_finetune req p ) } )
+    ( router_post r `/train/autoencoder/:model` \ HttpRequest req Params p → HttpResponse { ^ ( __an_h_train_ae req p ) } )
     ^ r
 }
 

--- a/packages/anomaly/src/store.nu
+++ b/packages/anomaly/src/store.nu
@@ -25,6 +25,7 @@ $ `stdlib/std/floatbits.nu`
 $ `stdlib/std/sort.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
+$ `src/autoenc.nu`
 $ `deps/iforest/src/iforest.nu`
 
 // Refuse to load blobs claiming more than this many arena nodes / trees /
@@ -49,7 +50,7 @@ $ `deps/iforest/src/iforest.nu`
     ^ rd
 }
 
-@ __an_rd_u64 *BlobRd rd → i {
+@ __an_rd_u64 * BlobRd rd → i {
     ?? ( bytes_read_u64_le . rd buf . rd pos ) {
         T x → {
             = . rd pos + . rd pos 8
@@ -62,7 +63,7 @@ $ `deps/iforest/src/iforest.nu`
     }
 }
 
-@ __an_rd_f64 *BlobRd rd → f {
+@ __an_rd_f64 * BlobRd rd → f {
     ?? ( bytes_read_f64_le . rd buf . rd pos ) {
         T x → {
             = . rd pos + . rd pos 8
@@ -100,7 +101,7 @@ $ `deps/iforest/src/iforest.nu`
 }
 
 // Read `want` i64s (a count-prefixed vector whose count must equal `want`).
-@ __an_blob_read_ivec *BlobRd rd i want → ( Vec i ) {
+@ __an_blob_read_ivec * BlobRd rd i want → ( Vec i ) {
     : ( Vec i ) out ( vec_new [i] )
     : i n ( __an_rd_u64 rd )
     ? == n want {} { = . rd ok F ^ out }
@@ -113,7 +114,7 @@ $ `deps/iforest/src/iforest.nu`
     ^ out
 }
 
-@ __an_blob_read_fvec *BlobRd rd i want → ( Vec f ) {
+@ __an_blob_read_fvec * BlobRd rd i want → ( Vec f ) {
     : ( Vec f ) out ( vec_new [f] )
     : i n ( __an_rd_u64 rd )
     ? == n want {} { = . rd ok F ^ out }
@@ -324,7 +325,7 @@ $ `deps/iforest/src/iforest.nu`
 }
 
 // Persist metadata (creates the model directory as needed).
-@ store_save_meta Store st s name *Meta m → b {
+@ store_save_meta Store st s name * Meta m → b {
     : String d ( __an_model_dir st name )
     : !v IoErr mk ( dir_create_all ( string_data d ) )
     : ~ b ok T
@@ -371,6 +372,39 @@ $ `deps/iforest/src/iforest.nu`
     } {}
     ( string_free d )
     ^ ok
+}
+
+// Persist / load the autoencoder version (one JSON per model).
+@ store_save_ae Store st s name AeModel ae → b {
+    : String d ( __an_model_dir st name )
+    : !v IoErr mk ( dir_create_all ( string_data d ) )
+    : ~ b ok T
+    ?? mk { T _ → {} F _ → { = ok F } }
+    ? ok {
+        : String txt ( ae_to_json_str ae )
+        : ( Vec u ) data ( bytes_from_str ( string_data txt ) )
+        : String p ( __an_model_file st name `autoencoder.json` )
+        = ok ( __an_write_atomic ( string_data p ) data )
+        ( string_free p )
+        ( vec_free [u] data )
+        ( string_free txt )
+    } {}
+    ( string_free d )
+    ^ ok
+}
+
+@ store_load_ae Store st s name → ?AeModel {
+    : String p ( __an_model_file st name `autoencoder.json` )
+    : !String IoErr r ( read_file ( string_data p ) )
+    ( string_free p )
+    ?? r {
+        T txt → {
+            : ?AeModel m ( ae_from_json_str ( string_data txt ) )
+            ( string_free txt )
+            ^ m
+        }
+        F _ → { ^ @ ?AeModel { F } }
+    }
 }
 
 // Load one version's forest; None if absent or corrupt. The blob's

--- a/packages/anomaly/tests/anomaly_test.sh
+++ b/packages/anomaly/tests/anomaly_test.sh
@@ -29,7 +29,7 @@ ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
 bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
 
 echo "[1/3] unit suites"
-for t in prep model store dynamic versions service gpu; do
+for t in prep model store dynamic versions timevector service gpu; do
     if ! $NURL "tests/${t}_test.nu" "$WORK/${t}_test" >/dev/null 2>"$WORK/build.err"; then
         echo "FAIL: could not build ${t}_test:"; tail -5 "$WORK/build.err"; exit 1
     fi

--- a/packages/anomaly/tests/anomaly_test.sh
+++ b/packages/anomaly/tests/anomaly_test.sh
@@ -29,7 +29,7 @@ ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
 bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
 
 echo "[1/3] unit suites"
-for t in prep model store dynamic versions timevector service gpu; do
+for t in prep model store dynamic versions timevector autoencoder service gpu; do
     if ! $NURL "tests/${t}_test.nu" "$WORK/${t}_test" >/dev/null 2>"$WORK/build.err"; then
         echo "FAIL: could not build ${t}_test:"; tail -5 "$WORK/build.err"; exit 1
     fi
@@ -93,6 +93,15 @@ curl -s "http://127.0.0.1:$PORT/models/dynamic" | grep -q '"live"' && ok "HTTP m
 curl -s "http://127.0.0.1:$PORT/models/dynamic/live/metadata" | grep -q '"model_name":"live"' && ok "HTTP metadata" || bad "HTTP metadata"
 CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/detect/bad!name" -d '{"a":1}')
 [ "$CODE" = "400" ] && ok "HTTP invalid name rejected" || bad "HTTP invalid name ($CODE)"
+# top the ring up: the AE pre-filter drops ~10 %, and the survivor count
+# must still clear min_points (50)
+for i in $(seq 51 90); do
+    curl -s -o /dev/null -X POST "http://127.0.0.1:$PORT/detect/live" -d "{\"temp\": 2$((i%10)).5}"
+done
+CODE=$(curl -s -o "$WORK/rae" -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/train/autoencoder/live")
+[ "$CODE" = "200" ] && grep -q '"reconstruction_threshold"' "$WORK/rae" && ok "HTTP autoencoder train" || bad "HTTP AE train ($CODE: $(cat "$WORK/rae" | head -c 120))"
+curl -s -X POST "http://127.0.0.1:$PORT/detect_only/live" -d '{"temp": 24.5}' | grep -q '"autoencoder"' \
+    && ok "HTTP detect carries the autoencoder version" || bad "HTTP AE version in detect"
 CODE=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "http://127.0.0.1:$PORT/delete_model/live")
 [ "$CODE" = "200" ] && ok "HTTP delete" || bad "HTTP delete ($CODE)"
 

--- a/packages/anomaly/tests/autoencoder_test.nu
+++ b/packages/anomaly/tests/autoencoder_test.nu
@@ -1,0 +1,201 @@
+// autoencoder_test.nu — the autoencoder version.
+//
+//   detect   — trained on a ring of correlated 2-feature points (with a
+//              few injected anomalies the iforest pre-filter must drop),
+//              the AE flags an off-manifold probe whose every value is
+//              in range, and passes an on-manifold probe — the AE sees
+//              CORRELATION the marginals hide. (Whether a forest also
+//              catches it depends on partitioning luck; not asserted.)
+//   persist  — reopening the model loads the trained AE and scores the
+//              same probe bit-identically; the metadata carries the
+//              autoencoder version config.
+//   errors   — too few points → an error text, model untouched.
+// Store root: $ANOMALY_TEST_DIR (default ./anomaly_ae_test).
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/floatbits.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/score.nu`
+$ `src/autoenc.nu`
+$ `src/store.nu`
+$ `src/dynamic.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+: i T0 1700000000
+: ~ i g_lcg 1
+
+@ check b cond s label → v {
+    ? cond {
+        ( nurl_print `ok ` ) ( nurl_print label ) ( nurl_print `\n` )
+        = g_pass + g_pass 1
+    } {
+        ( nurl_print `FAIL ` ) ( nurl_print label ) ( nurl_print `\n` )
+        = g_fail + g_fail 1
+    }
+}
+
+@ lcg_u01 → f {
+    = g_lcg % + * g_lcg 1103515245 12345 2147483648
+    ^ / # f g_lcg 2147483648.0
+}
+
+@ ingest2 * Model mo f a f b2 i at → v {
+    : Json j ( json_obj_new )
+    ( json_obj_set j `pres` ( json_float a ) )
+    ( json_obj_set j `flow` ( json_float b2 ) )
+    : !Verdict String r ( model_ingest_at mo j at )
+    ( json_free j )
+    ?? r {
+        T vd → { ( verdict_free vd ) }
+        F e → { ( string_free e ) }
+    }
+}
+
+// detect_only → (ae verdict present, ae hit, ae df)
+: AeProbe {
+    b has_ae
+    b ae_hit
+    f ae_df
+    i hits_other
+}
+
+@ probe2 * Model mo f a f b2 → AeProbe {
+    : Json j ( json_obj_new )
+    ( json_obj_set j `pres` ( json_float a ) )
+    ( json_obj_set j `flow` ( json_float b2 ) )
+    : !Verdict String r ( model_detect_only mo j )
+    ( json_free j )
+    ?? r {
+        T vd → {
+            : ~ b has_ae F
+            : ~ b ae_hit F
+            : ~ f ae_df 0.0
+            : ~ i others 0
+            : i nv ( vec_len [VerVerdict] . vd versions )
+            : ~ i k 0
+            ~ < k nv {
+                ?? ( vec_get [VerVerdict] . vd versions k ) {
+                    T vv → {
+                        ? == ( nurl_str_eq ( string_data . vv vvname ) `autoencoder` ) 1 {
+                            = has_ae T
+                            = ae_hit . vv anomaly
+                            = ae_df . vv score
+                        } {
+                            ? . vv anomaly { = others + others 1 } {}
+                        }
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            : AeProbe out @ AeProbe { has_ae ae_hit ae_df others }
+            ( verdict_free vd )
+            ^ out
+        }
+        F e → {
+            ( string_free e )
+            ^ @ AeProbe { F F 0.0 0 }
+        }
+    }
+}
+
+@ main → i {
+    : String root ( env_var_or `ANOMALY_TEST_DIR` `./anomaly_ae_test` )
+    : Store st ( store_open ( string_data root ) )
+
+    // ── training data: flow ≈ 2·pres (a 1-D manifold in 2-D), pres in
+    // [1, 2]; 12 injected anomalies break the correlation — the
+    // pre-filter must drop them so the AE learns only the line.
+    : *Model mo ( model_open_at st `aemodel` T0 )
+    ( model_set_limits mo 30 150000 )
+    ( model_set_schedule mo 1000000 1000000 )
+    = g_lcg 7
+    : ~ i k 0
+    ~ < k 240 {
+        : f pres + 1.0 ( lcg_u01 )
+        : ~ f flow * 2.0 pres
+        ? == % k 20 19 { = flow + 1.0 * 3.0 ( lcg_u01 ) }  // broken correlation
+        ( ingest2 mo pres flow + T0 * k 60 )
+        = k + k 1
+    }
+    ( check > ( model_force_train_at mo + T0 * 241 60 ) 0 `forests trained` )
+
+    // Before AE training: no autoencoder verdict.
+    : AeProbe pre ( probe2 mo 1.5 3.0 )
+    ( check ! . pre has_ae `no AE verdict before training` )
+
+    // ── train the autoencoder ──
+    : ( Vec i ) hidden ( vec_new [i] )
+    : String err ( model_train_autoencoder mo hidden -1.0 )
+    ( check == ( string_len err ) 0 `AE trains ("" error)` )
+    ( string_free err )
+    : AeModel tae . mo ae
+    ( check . tae trained `AE marked trained` )
+    ( check > . tae filtered 0 `pre-filter dropped injected anomalies` )
+    ( check > . tae threshold 0.0 `threshold positive` )
+
+    // ── detection ──
+    // On-manifold probe: pres 1.5, flow 3.0 — clean.
+    : AeProbe onp ( probe2 mo 1.5 3.0 )
+    ( check . onp has_ae `AE verdict present after training` )
+    ( check ! . onp ae_hit `on-manifold probe passes` )
+    // Off-manifold probe: pres 1.2 (common), flow 3.8 (common for pres
+    // 1.9 — but NOT for 1.2). Marginals fine, correlation broken.
+    : AeProbe offp ( probe2 mo 1.2 3.8 )
+    ( check . offp ae_hit `off-manifold probe flagged by the AE` )
+    ( check < . offp ae_df . onp ae_df `off-manifold scores worse than on-manifold` )
+
+    // ── persistence ──
+    : f df_before . offp ae_df
+    ( model_free mo )
+    : *Model mo2 ( model_open_at st `aemodel` + T0 * 300 60 )
+    : AeModel lae . mo2 ae
+    ( check . lae trained `reopened model has the AE` )
+    : AeProbe offp2 ( probe2 mo2 1.2 3.8 )
+    ( check == ( f64_to_bits . offp2 ae_df ) ( f64_to_bits df_before ) `reload scores bit-identically` )
+    // metadata carries the version config (margin tunable)
+    : *Meta mm2 ( model_metadata mo2 )
+    : ~ b have_cfg F
+    : i nv ( vec_len [VerCfg] . mm2 versions )
+    = k 0
+    ~ < k nv {
+        ?? ( vec_get [VerCfg] . mm2 versions k ) {
+            T vc → {
+                ? == ( nurl_str_eq ( string_data . vc vname ) `autoencoder` ) 1 { = have_cfg T } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( check have_cfg `metadata carries the autoencoder version config` )
+    ( model_free mo2 )
+
+    // ── errors ──
+    : *Model tiny ( model_open_at st `aetiny` T0 )
+    ( model_set_limits tiny 30 150000 )
+    ( model_set_schedule tiny 1000000 1000000 )
+    ( ingest2 tiny 1.0 2.0 T0 )
+    : ( Vec i ) h2 ( vec_new [i] )
+    : String err2 ( model_train_autoencoder tiny h2 -1.0 )
+    ( check > ( string_len err2 ) 0 `too few points → error text` )
+    : AeModel tae2 . tiny ae
+    ( check ! . tae2 trained `failed train leaves the model untouched` )
+    ( string_free err2 )
+    ( vec_free [i] h2 )
+    ( vec_free [i] hidden )
+    ( model_free tiny )
+
+    ( store_free st )
+    ( string_free root )
+    ( nurl_print `autoencoder_test: ` ) ( nurl_print_int g_pass )
+    ( nurl_print ` passed, ` ) ( nurl_print_int g_fail ) ( nurl_print ` failed\n` )
+    ^ ? > g_fail 0 1 0
+}

--- a/packages/anomaly/tests/dynamic_test.nu
+++ b/packages/anomaly/tests/dynamic_test.nu
@@ -67,7 +67,7 @@ $ `src/dynamic.nu`
     i n_versions
 }
 
-@ ingest_pt *Model mo f temp f load i idx → IngestOut {
+@ ingest_pt * Model mo f temp f load i idx → IngestOut {
     : Json j ( json_obj_new )
     ( json_obj_set j `temp` ( json_float temp ) )
     ( json_obj_set j `load` ( json_float load ) )
@@ -86,7 +86,7 @@ $ `src/dynamic.nu`
     }
 }
 
-@ set_all_margins *Model mo f margin → v {
+@ set_all_margins * Model mo f margin → v {
     : b a ( model_set_margin mo `short_term` margin )
     : b b2 ( model_set_margin mo `daily` margin )
     : b c ( model_set_margin mo `weekly` margin )

--- a/packages/anomaly/tests/gpu_test.nu
+++ b/packages/anomaly/tests/gpu_test.nu
@@ -73,7 +73,7 @@ $ `src/score.nu`
     : ( Vec f ) data ( make_matrix ROWS COLS )
     : Scaler sc ( scaler_fit data ROWS COLS )
     ( scaler_apply_matrix sc data ROWS COLS )
-    : VerCfg cfg @ VerCfg { ( string_from `gpu` ) 0 0 300 256 -1.0 0.1 T }
+    : VerCfg cfg @ VerCfg { ( string_from `gpu` ) 0 0 0 0 300 256 -1.0 0.1 T }
     : VerModel vm ( anom_train_version data ROWS COLS cfg )
 
     // 1. Raw scores: forced accelerator vs the pure loop, every element ==.
@@ -122,7 +122,7 @@ $ `src/score.nu`
 
     // 3. Contamination percentile (trains through the accelerated scorer at
     //    this size) must equal a training run with the accelerator off.
-    : VerCfg cfg2 @ VerCfg { ( string_from `gpu2` ) 0 0 100 256 0.05 0.0 T }
+    : VerCfg cfg2 @ VerCfg { ( string_from `gpu2` ) 0 0 0 0 100 256 0.05 0.0 T }
     : VerModel vm_a ( anom_train_version data ROWS COLS cfg2 )
     : ( Vec f ) ref2 ( anom_scores_cpu vm_a data ROWS COLS )
     // offset from the pure path, recomputed by hand:

--- a/packages/anomaly/tests/model_test.nu
+++ b/packages/anomaly/tests/model_test.nu
@@ -52,7 +52,7 @@ $ `src/score.nu`
 }
 
 @ test_cfg f contamination f margin → VerCfg {
-    ^ @ VerCfg { ( string_from `test` ) 0 0 100 256 contamination margin T }
+    ^ @ VerCfg { ( string_from `test` ) 0 0 0 0 100 256 contamination margin T }
 }
 
 // ── Outlier separation, margin rule, report parity ────────────────────

--- a/packages/anomaly/tests/store_test.nu
+++ b/packages/anomaly/tests/store_test.nu
@@ -54,7 +54,7 @@ $ `src/store.nu`
 }
 
 @ train_one ( Vec f ) scaled → VerModel {
-    : VerCfg cfg @ VerCfg { ( string_from `short_term` ) 180 0 100 256 -1.0 0.1 T }
+    : VerCfg cfg @ VerCfg { ( string_from `short_term` ) 180 0 0 0 100 256 -1.0 0.1 T }
     : VerModel vm ( anom_train_version scaled 208 2 cfg )
     ( _an_vercfg_free cfg )
     ^ vm

--- a/packages/anomaly/tests/timevector_test.nu
+++ b/packages/anomaly/tests/timevector_test.nu
@@ -1,0 +1,260 @@
+// timevector_test.nu — the sliding-window version.
+//
+//   sequence  — timevector catches a SEQUENCE anomaly (a flat run whose
+//               every point is individually in range) that the point-based
+//               short_term version cannot see; a clean-tail probe stays
+//               normal on both.
+//   absent    — a window larger than the ring trains no timevector forest
+//               and yields NO timevector verdict (absent, never wrong).
+//   config    — window_size/step_size round-trip metadata JSON; legacy
+//               metadata without the fields gets the timevector defaults
+//               (100/1) and plain versions 0/0.
+// Store root: $ANOMALY_TEST_DIR (default ./anomaly_tv_test).
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `src/prep.nu`
+$ `src/model.nu`
+$ `src/score.nu`
+$ `src/store.nu`
+$ `src/dynamic.nu`
+
+: ~ i g_pass 0
+: ~ i g_fail 0
+: i T0 1700000000
+
+@ check b cond s label → v {
+    ? cond {
+        ( nurl_print `ok ` ) ( nurl_print label ) ( nurl_print `\n` )
+        = g_pass + g_pass 1
+    } {
+        ( nurl_print `FAIL ` ) ( nurl_print label ) ( nurl_print `\n` )
+        = g_fail + g_fail 1
+    }
+}
+
+@ ingest_temp * Model mo f temp i at → v {
+    : Json j ( json_obj_new )
+    ( json_obj_set j `temp` ( json_float temp ) )
+    : !Verdict String r ( model_ingest_at mo j at )
+    ( json_free j )
+    ?? r {
+        T vd → { ( verdict_free vd ) }
+        F e → { ( string_free e ) }
+    }
+}
+
+// detect_only probe → (has timevector verdict, tv anomaly, tv score,
+// short_term anomaly, short_term score)
+: TvProbe {
+    b has_tv
+    b tv_hit
+    f tv_df
+    b st_hit
+    f st_df
+    i n_versions
+}
+
+@ probe * Model mo f temp → TvProbe {
+    : Json j ( json_obj_new )
+    ( json_obj_set j `temp` ( json_float temp ) )
+    : !Verdict String r ( model_detect_only mo j )
+    ( json_free j )
+    ?? r {
+        T vd → {
+            : ~ b has_tv F
+            : ~ b tv_hit F
+            : ~ f tv_df 0.0
+            : ~ b st_hit F
+            : ~ f st_df 0.0
+            : i nv ( vec_len [VerVerdict] . vd versions )
+            : ~ i k 0
+            ~ < k nv {
+                ?? ( vec_get [VerVerdict] . vd versions k ) {
+                    T vv → {
+                        : s vn ( string_data . vv vvname )
+                        ? == ( nurl_str_eq vn `timevector` ) 1 {
+                            = has_tv T
+                            = tv_hit . vv anomaly
+                            = tv_df . vv score
+                        } {}
+                        ? == ( nurl_str_eq vn `short_term` ) 1 {
+                            = st_hit . vv anomaly
+                            = st_df . vv score
+                        } {}
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            : TvProbe out @ TvProbe { has_tv tv_hit tv_df st_hit st_df nv }
+            ( verdict_free vd )
+            ^ out
+        }
+        F e → {
+            ( string_free e )
+            ^ @ TvProbe { F F 0.0 F 0.0 0 }
+        }
+    }
+}
+
+// The clean signal: a sawtooth 20, 21, …, 27, 20, … — every level is
+// common on its own; what the window learns is the ORDER.
+@ saw f k → f {
+    ^ + 20.0 # f % # i k 8
+}
+
+@ test_sequence Store st → v {
+    : *Model mo ( model_open_at st `tvseq` T0 )
+    ( model_set_limits mo 20 150000 )
+    ( model_set_schedule mo 1000000 1000000 )  // never auto-train
+    : b wset ( model_set_version_window mo `timevector` 8 1 )
+    ( check wset `sequence: window set to 8` )
+
+    // 120 clean sawtooth points, one per minute.
+    : ~ i k 0
+    ~ < k 120 {
+        ( ingest_temp mo ( saw # f k ) + T0 * k 60 )
+        = k + k 1
+    }
+    : i used ( model_force_train_at mo + T0 * 121 60 )
+    ( check > used 0 `sequence: trained` )
+
+    // The trained timevector forest is 8 points wide (n_cols = 8·nfeat).
+    : *Meta mm ( model_metadata mo )
+    : i nfeat ( vec_len [String] . mm feats )
+    : ~ b wide F
+    : i nf ( vec_len [VerModel] . mo forests )
+    : ~ i q 0
+    ~ < q nf {
+        ?? ( vec_get [VerModel] . mo forests q ) {
+            T vm → {
+                ? == ( nurl_str_eq ( string_data . vm vname ) `timevector` ) 1 {
+                    = wide == . vm n_cols * 8 nfeat
+                } {}
+            }
+            F _ → {}
+        }
+        = q + q 1
+    }
+    ( check wide `sequence: forest is window-wide (8·nfeat)` )
+
+    // Probe continuing the sawtooth: the window is the clean tail → normal
+    // on both versions. The tail ends at k=119 (level 27), next is 20.
+    : TvProbe clean ( probe mo 20.0 )
+    ( check . clean has_tv `sequence: clean probe has a timevector verdict` )
+    ( check ! . clean tv_hit `sequence: clean probe not flagged by timevector` )
+    ( check ! . clean st_hit `sequence: clean probe not flagged by short_term` )
+
+    // A REVERSED run: the sawtooth playing backwards — 27, 26, …, 20 —
+    // every level individually common, so short_term sees nothing; the
+    // descending ORDER is a window pattern the forest never saw (the
+    // training windows are the 8 ascending rotations).
+    = k 0
+    ~ < k 10 {
+        ( ingest_temp mo - 27.0 # f % # i k 8 + + T0 * 120 60 * k 60 )
+        = k + k 1
+    }
+    : TvProbe flat ( probe mo - 27.0 # f % 10 8 )
+    ( check . flat has_tv `sequence: flat probe has a timevector verdict` )
+    ( check < . flat tv_df - . clean tv_df 0.005 `sequence: timevector scores the reversed run WORSE than the clean tail` )
+    ( check ! . flat st_hit `sequence: short_term still sees nothing (every point in range)` )
+    // The blindness pair: the point-based version thinks the reversed run
+    // is MORE normal than the clean probe (its levels sit mid-range) —
+    // only the window sees the broken ORDER. This is the property the
+    // sliding window exists for.
+    ( check > . flat st_df . clean st_df `sequence: short_term is order-blind (reversed scores BETTER pointwise)` )
+
+    ( model_free mo )
+}
+
+@ test_absent Store st → v {
+    : *Model mo ( model_open_at st `tvabsent` T0 )
+    ( model_set_limits mo 20 150000 )
+    ( model_set_schedule mo 1000000 1000000 )
+    // Window far larger than the ring will ever be here.
+    : b _w ( model_set_version_window mo `timevector` 500 1 )
+    : ~ i k 0
+    ~ < k 60 {
+        ( ingest_temp mo ( saw # f k ) + T0 * k 60 )
+        = k + k 1
+    }
+    : i used ( model_force_train_at mo + T0 * 61 60 )
+    ( check > used 0 `absent: other versions trained` )
+    : TvProbe p ( probe mo 21.0 )
+    ( check ! . p has_tv `absent: no timevector verdict when the ring < window` )
+    ( check >= . p n_versions 4 `absent: the other versions still answer` )
+    ( model_free mo )
+}
+
+@ test_config Store st → v {
+    // Round-trip: set 8/2, serialise, parse back.
+    : *Model mo ( model_open_at st `tvcfg` T0 )
+    : b _w ( model_set_version_window mo `timevector` 8 2 )
+    : *Meta mm ( model_metadata mo )
+    : Json mj ( meta_to_json mm )
+    : String ms ( json_stringify mj )
+    ( json_free mj )
+    ?? ( meta_from_json_str ( string_data ms ) ) {
+        T m2 → {
+            : ~ i ws 0
+            : ~ i ss 0
+            : i nv ( vec_len [VerCfg] . m2 versions )
+            : ~ i k 0
+            ~ < k nv {
+                ?? ( vec_get [VerCfg] . m2 versions k ) {
+                    T vc → {
+                        ? == ( nurl_str_eq ( string_data . vc vname ) `timevector` ) 1 {
+                            = ws . vc window_size
+                            = ss . vc step_size
+                        } {}
+                    }
+                    F _ → {}
+                }
+                = k + k 1
+            }
+            ( check == ws 8 `config: window_size round-trips` )
+            ( check == ss 2 `config: step_size round-trips` )
+            ( meta_free m2 )
+        }
+        F → { ( check F `config: metadata parses back` ) }
+    }
+    ( string_free ms )
+    ( model_free mo )
+
+    // Legacy metadata (no window fields): timevector gets 100/1, a plain
+    // version 0/0 — old on-disk models keep working, upgraded in place.
+    : !Json JsonError lr ( json_parse `{"window_minutes":0,"window_points":100,"n_estimators":200,"max_samples":256,"decision_margin":0.1,"enabled":true}` )
+    ?? lr {
+        T vo → {
+            : VerCfg tv ( __an_vercfg_of_json `timevector` vo )
+            ( check == . tv window_size 100 `config: legacy timevector defaults to window 100` )
+            ( check == . tv step_size 1 `config: legacy timevector defaults to step 1` )
+            ( check == . tv window_pts 0 `config: legacy point-cap dropped for the true window` )
+            ( _an_vercfg_free tv )
+            : VerCfg stv ( __an_vercfg_of_json `short_term` vo )
+            ( check == . stv window_size 0 `config: plain versions stay windowless` )
+            ( _an_vercfg_free stv )
+            ( json_free vo )
+        }
+        F _ → { ( check F `config: legacy JSON parses` ) }
+    }
+}
+
+@ main → i {
+    : String root ( env_var_or `ANOMALY_TEST_DIR` `./anomaly_tv_test` )
+    : Store st ( store_open ( string_data root ) )
+    ( test_sequence st )
+    ( test_absent st )
+    ( test_config st )
+    ( store_free st )
+    ( string_free root )
+    ( nurl_print `pass ` ) ( nurl_print_int g_pass )
+    ( nurl_print ` fail ` ) ( nurl_print_int g_fail ) ( nurl_print `\n` )
+    ^ ? > g_fail 0 1 0
+}

--- a/packages/anomaly/tests/versions_test.nu
+++ b/packages/anomaly/tests/versions_test.nu
@@ -54,7 +54,7 @@ $ `src/dynamic.nu`
 }
 
 // Ingest a single-feature {"temp": t} point at absolute time `at`.
-@ ingest_temp *Model mo f temp i at → v {
+@ ingest_temp * Model mo f temp i at → v {
     : Json j ( json_obj_new )
     ( json_obj_set j `temp` ( json_float temp ) )
     : !Verdict String r ( model_ingest_at mo j at )
@@ -77,7 +77,7 @@ $ `src/dynamic.nu`
     f df_seasonal
 }
 
-@ probe_temp *Model mo f temp → ProbeOut {
+@ probe_temp * Model mo f temp → ProbeOut {
     : Json j ( json_obj_new )
     ( json_obj_set j `temp` ( json_float temp ) )
     : !Verdict String r ( model_detect_only mo j )
@@ -162,6 +162,9 @@ $ `src/dynamic.nu`
     : *Model mo ( model_open_at st `agg` T0 )
     ( model_set_limits mo 10 150000 )
     ( model_set_schedule mo 10 1000 )
+    // The sliding-window timevector needs the window to fit in this tiny
+    // ring — 6 points keeps all five versions in play.
+    : b mw ( model_set_version_window mo `timevector` 6 1 )
     : b m1 ( model_set_margin mo `short_term` 0.5 )
     : b m2 ( model_set_margin mo `daily` 0.5 )
     : b m3 ( model_set_margin mo `weekly` 0.5 )

--- a/packages/mlp/CHANGELOG.md
+++ b/packages/mlp/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 0.1.0
+
+Initial release — a trainable MLP in pure NURL, faithful to sklearn's
+`MLPRegressor` recipe and proven against it as an oracle.
+
+- Dense layers + ReLU (linear output), Glorot-uniform init from a seeded
+  PRNG (bit-identical networks across platforms for a fixed seed).
+- Minibatch Adam (bias-corrected), squared loss with L2, sklearn's
+  batch-size "auto" (min(200, n)), per-epoch seeded shuffles.
+- Early stopping on a held-out validation split with best-weight restore;
+  the same patience applies to the training loss when disabled.
+- `mlp_fit` deterministic restarts — a narrow ReLU bottleneck can die at
+  init and collapse the net to predicting the mean (sklearn shares the
+  failure mode and leaves the retry to the user; here it is a feature).
+- JSON persistence with every f64 as its bit pattern: reload is exact.
+- MinMax scaler (fit/apply/save/load, zero-range columns → 0).
+- Tests: 23 offline checks (ASan + LSan clean) and a sklearn oracle run —
+  same data and architecture, reconstruction at the same noise floor,
+  100 % agreement on p95-rule outlier flags.

--- a/packages/mlp/README.md
+++ b/packages/mlp/README.md
@@ -1,0 +1,79 @@
+# mlp — a trainable multi-layer perceptron, pure NURL
+
+Dense layers, ReLU, minibatch **Adam**, **early stopping** — the ecosystem's
+first *trainable* neural-network package (everything else runs inference).
+The recipe is deliberately faithful to sklearn's `MLPRegressor`, and the
+test suite proves it against that oracle: on the same data, the same
+architecture reconstructs equally well and flags the same outliers.
+
+```nurl
+$ `src/mlp.nu`
+
+: ( Vec i ) sizes ( vec_new [i] )      // 6 → 64 → 32 → 64 → 6
+( vec_push [i] sizes 6 ) ( vec_push [i] sizes 64 ) ( vec_push [i] sizes 32 )
+( vec_push [i] sizes 64 ) ( vec_push [i] sizes 6 )
+
+: ~ MlpCfg cfg ( mlp_cfg_default )     // adam lr 0.001, early stopping, seed 42
+: MlpFit fit ( mlp_fit sizes X n 6 X 6 cfg 3 )   // ← an AUTOENCODER: target = input
+: Mlp ae . fit model
+
+: ( Vec f ) recon ( mlp_predict ae x ) // reconstruction of one row
+: String js ( mlp_save ae )            // JSON, every f64 bit-exact
+```
+
+## What it does
+
+- **`mlp_new sizes seed`** — Glorot-uniform init from a seeded PRNG: a fixed
+  seed gives the identical network on every platform.
+- **`mlp_train m X n d Y dout cfg`** — minibatch Adam (β₁ 0.9, β₂ 0.999,
+  bias-corrected), squared loss with L2 (`alpha`), `batch` 0 = min(200, n)
+  (sklearn's "auto"), per-epoch seeded shuffles. With `early_stop` a
+  `val_frac` split is held out once; training stops after `n_no_change`
+  epochs without the validation MSE improving by more than `tol`, and the
+  **best** weights seen are restored — not the last.
+- **`mlp_fit sizes X n d Y dout cfg restarts`** — train `restarts` networks
+  (seeds `seed`, `seed+1`, …) and keep the best by the plateau criterion.
+  This exists because a narrow ReLU bottleneck can die at init (every
+  pre-activation negative → the net collapses to predicting the mean);
+  sklearn has the same failure mode and leaves the retry to the user.
+  Here it is a deterministic feature.
+- **`mlp_predict` / `mlp_mse`** — inference and evaluation.
+- **`mlp_save` / `mlp_load`** — JSON persistence with every weight stored
+  as its f64 **bit pattern**: reload is bit-exact (decimal text would
+  silently perturb a trained model).
+- **`minmax_fit` / `minmax_apply` / `minmax_save` / `minmax_load`** — the
+  MinMax scaler the autoencoder recipe wants (zero-range columns → 0).
+
+## An autoencoder for anomaly detection
+
+Train with the input as the target, threshold the reconstruction error at
+the 95th percentile of the training errors, and a point whose
+per-row MSE exceeds the threshold is anomalous:
+
+```nurl
+: MlpFit fit ( mlp_fit sizes X n d X d cfg 3 )
+// per-row MSE over the TRAINING data → sort → p95 threshold
+// score a new point: mse(mlp_predict(x), x) > threshold ⇒ anomaly
+```
+
+The [`anomaly`](../anomaly) service wraps exactly this (with an
+Isolation-Forest pre-filter that removes anomalies from the training data
+first), but the building block is here, reusable.
+
+## Verified
+
+- `tests/mlp_test.nu` — 23 checks: shapes, seeded determinism, the Glorot
+  bound, XOR fit, bit-exact save/load, AE manifold reconstruction,
+  off-manifold discrimination, dead-bottleneck collapse + restart rescue,
+  MinMax edge cases. ASan + LeakSanitizer clean.
+- `tests/oracle.sh` — the sklearn oracle: same data, same (64, 32, 64)
+  architecture; reconstruction MSE within a small constant of
+  `MLPRegressor`'s (both at the injected-noise floor) and **100 %**
+  agreement on which injected outliers the p95 rule flags.
+
+## Scope
+
+f64, CPU, tabular-scale data (the anomaly service's rings are thousands of
+points × tens of features — fractions of a second per epoch). No
+convolutions, no attention, no autograd graph: three dense layers and the
+truth. For GPU-scale tensors see `gpukit` / `tensor`.

--- a/packages/mlp/nurl.toml
+++ b/packages/mlp/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mlp"
+version = "0.1.0"
+description = "Trainable multi-layer perceptron in pure NURL — dense layers, ReLU, Adam, minibatches, early stopping. The training-side counterpart to the ecosystem's inference packages: a seedable, deterministic MLP regressor faithful to sklearn's MLPRegressor semantics (Glorot init, squared loss with L2, Adam bias correction, validation-split early stopping with best-weight restore), plus a MinMax scaler. An autoencoder is just mlp_train with X as both input and target — reconstruction-error anomaly detection, embeddings, denoising. Models and scalers persist to JSON with bit-exact f64 round-trip. No BLAS, no GPU required: flat buffers and tight loops, fast enough for the tabular/streaming workloads it is built for."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/mlp/src/mlp.nu
+++ b/packages/mlp/src/mlp.nu
@@ -1,0 +1,719 @@
+// mlp — a trainable multi-layer perceptron in pure NURL.
+//
+// Dense layers with ReLU hidden activations and a linear output, trained
+// with minibatch Adam on squared loss — the same recipe as sklearn's
+// MLPRegressor, and deliberately faithful to it:
+//
+//   * Glorot uniform init: W, b ~ U(−√(6/(fan_in+fan_out)), +√(…)),
+//     drawn from a seedable PRNG (std/rng) — a fixed seed gives the same
+//     network on every platform.
+//   * squared loss with L2: grad = (AᵀΔ + α·W) / B per batch of B.
+//   * Adam with bias correction: lr_t = lr·√(1−β2ᵗ)/(1−β1ᵗ).
+//   * batch_size = min(200, n) — sklearn's "auto".
+//   * early stopping: a validation split (val_frac) is held out once,
+//     the epoch loop stops after n_no_change epochs without the
+//     validation MSE improving by > tol, and the BEST weights seen are
+//     restored (not the last). With early_stop off the same patience
+//     applies to the training loss, mirroring sklearn. (sklearn scores
+//     R² on the validation set; for a fixed split maximising R² is
+//     minimising MSE, so the criterion is the same up to tol's scale.)
+//
+// An autoencoder is just ( mlp_train m X n d X d cfg ) — input as target.
+//
+// Layout: one flat weight buffer + one flat bias buffer for the whole
+// network (struct-of-arrays, like iforest's node arena). Layer l maps
+// sizes[l] → sizes[l+1]; its weights are row-major n_out×n_in at
+// w_off[l], its biases at b_off[l]. Hot loops read through raw pointers
+// (vec_data) and write with vec_set — the fft.nu idiom.
+//
+// Persistence: mlp_save/mlp_load round-trip through JSON with every f64
+// stored as its bit pattern (i64) — exact, platform-independent restore
+// (nurl_str_float renders ~6 significant digits, so decimal text would
+// silently perturb a trained model).
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/floatbits.nu`
+$ `stdlib/std/rng.nu`
+$ `stdlib/ext/json.nu`
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+: Mlp {
+    i n_layers  // weight layers = len(sizes) − 1
+    ( Vec i ) sizes  // neuron counts, input first, output last
+    ( Vec i ) w_off  // offset of layer l's weights in `w`
+    ( Vec i ) b_off  // offset of layer l's biases in `b`
+    ( Vec i ) a_off  // offset of layer l's activations in a scratch
+    i n_w  // total weight count
+    i n_b  // total bias count
+    i n_a  // total activation count (all layers, one sample)
+    ( Vec f ) w
+    ( Vec f ) b
+    // Adam state, same shapes as w / b
+    ( Vec f ) mw
+    ( Vec f ) vw
+    ( Vec f ) mb
+    ( Vec f ) vb
+    i t  // Adam step counter
+}
+
+: MlpCfg {
+    f lr  // Adam initial learning rate (sklearn: 0.001)
+    f alpha  // L2 penalty (sklearn: 0.0001)
+    i max_iter  // epochs (sklearn: 200; sklearn AE recipes use 500)
+    i batch  // minibatch size; 0 = min(200, n) ("auto")
+    b early_stop  // hold out a validation split and stop on plateau
+    f val_frac  // validation fraction (sklearn: 0.1)
+    i n_no_change  // patience in epochs (sklearn: 10)
+    f tol  // minimum improvement (sklearn: 1e-4)
+    i seed  // PRNG seed (init + shuffles + the val split)
+    b verbose  // print per-epoch losses
+}
+
+// What mlp_train reports back.
+: MlpTrain {
+    i n_iter  // epochs actually run
+    f loss  // final training MSE (plain mean squared error)
+    f best_val  // best validation MSE (early_stop) or best train MSE
+    b stopped_early  // the patience tripped before max_iter
+}
+
+// Min–max scaler: x' = (x − lo) / (hi − lo), zero-range columns → 0.
+: MinMax {
+    i n_cols
+    ( Vec f ) lo
+    ( Vec f ) hi
+}
+
+// ── Small helpers ─────────────────────────────────────────────────────
+
+@ __zeros i n → ( Vec f ) {
+    : ( Vec f ) v ( vec_with_cap [f] n )
+    : ~ i k 0
+    ~ < k n { ( vec_push [f] v 0.0 ) = k + k 1 }
+    ^ v
+}
+
+@ _mlp_fget ( Vec f ) v i idx → f {
+    ^ ?? ( vec_get [f] v idx ) { T x → x F → 0.0 }
+}
+
+@ _mlp_iget ( Vec i ) v i idx → i {
+    ^ ?? ( vec_get [i] v idx ) { T x → x F → 0 }
+}
+
+// Fisher–Yates shuffle of an index vector (seeded, deterministic).
+@ __shuffle ( Vec i ) idx Rng g → v {
+    : i n ( vec_len [i] idx )
+    : ~ i k 0
+    ~ < k - n 1 {
+        : i j + k ( rng_below g - n k )
+        ( vec_swap [i] idx k j )
+        = k + k 1
+    }
+}
+
+// ── Construction ──────────────────────────────────────────────────────
+
+// A fresh network with Glorot-uniform weights. `sizes` lists every layer
+// width, input first (e.g. [8 64 32 64 8] for the classic autoencoder);
+// the caller keeps ownership of `sizes` (it is copied).
+@ mlp_new ( Vec i ) sizes i seed → Mlp {
+    : i nl - ( vec_len [i] sizes ) 1
+    : ( Vec i ) sz ( vec_new [i] )
+    : ~ i c 0
+    ~ < c + nl 1 { ( vec_push [i] sz ( _mlp_iget sizes c ) ) = c + c 1 }
+    : ( Vec i ) woff ( vec_new [i] )
+    : ( Vec i ) boff ( vec_new [i] )
+    : ( Vec i ) aoff ( vec_new [i] )
+    : ~ i nw 0
+    : ~ i nb 0
+    : ~ i na 0
+    : ~ i l 0
+    ~ < l nl {
+        ( vec_push [i] woff nw )
+        ( vec_push [i] boff nb )
+        ( vec_push [i] aoff na )
+        = nw + nw * ( _mlp_iget sz l ) ( _mlp_iget sz + l 1 )
+        = nb + nb ( _mlp_iget sz + l 1 )
+        = na + na ( _mlp_iget sz l )
+        = l + l 1
+    }
+    ( vec_push [i] aoff na )  // a_off[nl] = output activations
+    = na + na ( _mlp_iget sz nl )
+    : Rng g ( rng_seed seed )
+    : ( Vec f ) w ( vec_with_cap [f] nw )
+    : ( Vec f ) b ( vec_with_cap [f] nb )
+    = l 0
+    ~ < l nl {
+        : i fin ( _mlp_iget sz l )
+        : i fout ( _mlp_iget sz + l 1 )
+        : f bound ( sqrt / 6.0 # f + fin fout )
+        : ~ i k 0
+        ~ < k * fin fout {
+            ( vec_push [f] w - * 2.0 * bound ( rng_u01 g ) bound )
+            = k + k 1
+        }
+        = k 0
+        ~ < k fout {
+            ( vec_push [f] b - * 2.0 * bound ( rng_u01 g ) bound )
+            = k + k 1
+        }
+        = l + l 1
+    }
+    ( rng_free g )
+    ^ @ Mlp { nl sz woff boff aoff nw nb na w b
+        ( __zeros nw ) ( __zeros nw ) ( __zeros nb ) ( __zeros nb ) 0 }
+}
+
+@ mlp_cfg_default → MlpCfg {
+    ^ @ MlpCfg { 0.001 0.0001 500 0 T 0.1 10 0.0001 42 F }
+}
+
+@ mlp_free Mlp m → v {
+    ( vec_free [i] . m sizes )
+    ( vec_free [i] . m w_off )
+    ( vec_free [i] . m b_off )
+    ( vec_free [i] . m a_off )
+    ( vec_free [f] . m w )
+    ( vec_free [f] . m b )
+    ( vec_free [f] . m mw )
+    ( vec_free [f] . m vw )
+    ( vec_free [f] . m mb )
+    ( vec_free [f] . m vb )
+}
+
+// ── Forward pass ──────────────────────────────────────────────────────
+
+// One sample: read d input values at xp[x_at..], fill the activation
+// scratch `acts` (length n_a). Hidden layers ReLU, output linear.
+@ __mlp_forward Mlp m * f xp i x_at ( Vec f ) acts → v {
+    : *i szp ( vec_data [i] . m sizes )
+    : *i wop ( vec_data [i] . m w_off )
+    : *i bop ( vec_data [i] . m b_off )
+    : *i aop ( vec_data [i] . m a_off )
+    : *f wp ( vec_data [f] . m w )
+    : *f bp ( vec_data [f] . m b )
+    : i din . szp 0
+    : ~ i c 0
+    ~ < c din { ( vec_set [f] acts c . xp + x_at c ) = c + c 1 }
+    : ~ i l 0
+    ~ < l . m n_layers {
+        : i fin . szp l
+        : i fout . szp + l 1
+        : i wo . wop l
+        : i bo . bop l
+        : i ai . aop l
+        : i ao . aop + l 1
+        : b last == l - . m n_layers 1
+        : *f ap ( vec_data [f] acts )
+        : ~ i j 0
+        ~ < j fout {
+            : ~ f z . bp + bo j
+            : i wrow + wo * j fin
+            : ~ i i2 0
+            ~ < i2 fin {
+                = z + z * . wp + wrow i2 . ap + ai i2
+                = i2 + i2 1
+            }
+            ? & ! last < z 0.0 { = z 0.0 } {}
+            ( vec_set [f] acts + ao j z )
+            = j + j 1
+        }
+        = l + l 1
+    }
+}
+
+// Predict one row (a ( Vec f ) of the input width) → an OWNED output vec.
+@ mlp_predict Mlp m ( Vec f ) x → ( Vec f ) {
+    : ( Vec f ) acts ( __zeros . m n_a )
+    ( __mlp_forward m ( vec_data [f] x ) 0 acts )
+    : i dout ( _mlp_iget . m sizes . m n_layers )
+    : i oa ( _mlp_iget . m a_off . m n_layers )
+    : ( Vec f ) out ( vec_with_cap [f] dout )
+    : ~ i k 0
+    ~ < k dout { ( vec_push [f] out ( _mlp_fget acts + oa k ) ) = k + k 1 }
+    ( vec_free [f] acts )
+    ^ out
+}
+
+// Mean squared error of the network over rows X (n×d row-major) against
+// targets Y (n×dout row-major): mean over every output element.
+@ mlp_mse Mlp m ( Vec f ) X i n i d ( Vec f ) Y → f {
+    ? == n 0 { ^ 0.0 } {}
+    : ( Vec f ) acts ( __zeros . m n_a )
+    : *f xp ( vec_data [f] X )
+    : *f yp ( vec_data [f] Y )
+    : i dout ( _mlp_iget . m sizes . m n_layers )
+    : i oa ( _mlp_iget . m a_off . m n_layers )
+    : ~ f se 0.0
+    : ~ i r 0
+    ~ < r n {
+        ( __mlp_forward m xp * r d acts )
+        : *f ap ( vec_data [f] acts )
+        : ~ i j 0
+        ~ < j dout {
+            : f e - . ap + oa j . yp + * r dout j
+            = se + se * e e
+            = j + j 1
+        }
+        = r + r 1
+    }
+    ( vec_free [f] acts )
+    ^ / se # f * n dout
+}
+
+// ── Training ──────────────────────────────────────────────────────────
+
+// Accumulate one sample's gradient into gw / gb. `acts` must hold the
+// sample's forward pass; `deltas` is a scratch of n_a (layer-aligned like
+// acts). Returns nothing; the batch divide + L2 happen in the Adam step.
+@ __mlp_backprop Mlp m ( Vec f ) acts * f yp i y_at ( Vec f ) deltas ( Vec f ) gw ( Vec f ) gb → v {
+    : *i szp ( vec_data [i] . m sizes )
+    : *i wop ( vec_data [i] . m w_off )
+    : *i bop ( vec_data [i] . m b_off )
+    : *i aop ( vec_data [i] . m a_off )
+    : *f wp ( vec_data [f] . m w )
+    : *f ap ( vec_data [f] acts )
+    : i nl . m n_layers
+    : i dout . szp nl
+    : i oa . aop nl
+    // δ_out = ŷ − y  (squared loss, linear output)
+    : ~ i j 0
+    ~ < j dout {
+        ( vec_set [f] deltas + oa j - . ap + oa j . yp + y_at j )
+        = j + j 1
+    }
+    : ~ i l - nl 1
+    ~ >= l 0 {
+        : i fin . szp l
+        : i fout . szp + l 1
+        : i wo . wop l
+        : i bo . bop l
+        : i ai . aop l
+        : i ao . aop + l 1
+        : *f dp ( vec_data [f] deltas )
+        // gw += δ_{l+1} ⊗ a_l ; gb += δ_{l+1}
+        = j 0
+        ~ < j fout {
+            : f dj . dp + ao j
+            : i wrow + wo * j fin
+            : ~ i i2 0
+            ~ < i2 fin {
+                : i o + wrow i2
+                ( vec_set [f] gw o + ( _mlp_fget gw o ) * dj . ap + ai i2 )
+                = i2 + i2 1
+            }
+            : i ob + bo j
+            ( vec_set [f] gb ob + ( _mlp_fget gb ob ) dj )
+            = j + j 1
+        }
+        // δ_l = (Wᵀ δ_{l+1}) ⊙ relu'(a_l) — the input layer needs none.
+        ? > l 0 {
+            : ~ i i3 0
+            ~ < i3 fin {
+                : ~ f s 0.0
+                : ~ i j2 0
+                ~ < j2 fout {
+                    = s + s * . wp + + wo * j2 fin i3 . dp + ao j2
+                    = j2 + j2 1
+                }
+                ? <= . ap + ai i3 0.0 { = s 0.0 } {}
+                ( vec_set [f] deltas + ai i3 s )
+                = i3 + i3 1
+            }
+        } {}
+        = l - l 1
+    }
+}
+
+// One Adam update from gradient sums over a batch of `bsz` samples:
+// g = (Σg + α·param) / bsz for weights (sklearn adds the L2 term before
+// the batch divide), g = Σg / bsz for biases. Zeroes gw / gb after.
+@ __mlp_adam Mlp m ( Vec f ) gw ( Vec f ) gb i bsz f lr f alpha → v {
+    = . m t + . m t 1
+    : f t # f . m t
+    : f b1 0.9
+    : f b2 0.999
+    : f eps 0.00000001
+    : f lrt * lr / ( sqrt - 1.0 ( pow b2 t ) ) - 1.0 ( pow b1 t )
+    : f fb # f bsz
+    : *f wp ( vec_data [f] . m w )
+    : *f gwp ( vec_data [f] gw )
+    : ~ i k 0
+    ~ < k . m n_w {
+        : f g / + . gwp k * alpha . wp k fb
+        : f nm + * b1 ( _mlp_fget . m mw k ) * - 1.0 b1 g
+        : f nv + * b2 ( _mlp_fget . m vw k ) * - 1.0 b2 * g g
+        ( vec_set [f] . m mw k nm )
+        ( vec_set [f] . m vw k nv )
+        ( vec_set [f] . m w k - . wp k / * lrt nm + ( sqrt nv ) eps )
+        ( vec_set [f] gw k 0.0 )
+        = k + k 1
+    }
+    : *f bp ( vec_data [f] . m b )
+    : *f gbp ( vec_data [f] gb )
+    = k 0
+    ~ < k . m n_b {
+        : f g / . gbp k fb
+        : f nm + * b1 ( _mlp_fget . m mb k ) * - 1.0 b1 g
+        : f nv + * b2 ( _mlp_fget . m vb k ) * - 1.0 b2 * g g
+        ( vec_set [f] . m mb k nm )
+        ( vec_set [f] . m vb k nv )
+        ( vec_set [f] . m b k - . bp k / * lrt nm + ( sqrt nv ) eps )
+        ( vec_set [f] gb k 0.0 )
+        = k + k 1
+    }
+}
+
+// MSE over a subset of rows given by idx[from..to) — the validation view.
+@ __mlp_mse_idx Mlp m * f xp i d * f yp i dout ( Vec i ) idx i from i to ( Vec f ) acts → f {
+    ? <= to from { ^ 0.0 } {}
+    : i oa ( _mlp_iget . m a_off . m n_layers )
+    : ~ f se 0.0
+    : ~ i k from
+    ~ < k to {
+        : i r ( _mlp_iget idx k )
+        ( __mlp_forward m xp * r d acts )
+        : *f ap ( vec_data [f] acts )
+        : ~ i j 0
+        ~ < j dout {
+            : f e - . ap + oa j . yp + * r dout j
+            = se + se * e e
+            = j + j 1
+        }
+        = k + k 1
+    }
+    ^ / se # f * - to from dout
+}
+
+// Train on X (n×d, row-major) against Y (n×dout). For an autoencoder pass
+// X for Y and d for dout. Returns the training report; the model is
+// updated in place (best-validation weights when early_stop is on).
+@ mlp_train Mlp m ( Vec f ) X i n i d ( Vec f ) Y i dout MlpCfg cfg → MlpTrain {
+    : Rng g ( rng_seed . cfg seed )
+    : *f xp ( vec_data [f] X )
+    : *f yp ( vec_data [f] Y )
+    : ( Vec f ) acts ( __zeros . m n_a )
+    : ( Vec f ) deltas ( __zeros . m n_a )
+    : ( Vec f ) gw ( __zeros . m n_w )
+    : ( Vec f ) gb ( __zeros . m n_b )
+    // One shuffled split: [0, n_train) train, [n_train, n) validation.
+    : ( Vec i ) idx ( vec_iota 0 n )
+    ( __shuffle idx g )
+    : ~ i n_val 0
+    ? . cfg early_stop {
+        = n_val # i ( round * . cfg val_frac # f n )
+        ? < n_val 1 { = n_val 1 } {}
+        ? >= n_val n { = n_val / n 5 } {}
+    } {}
+    : i n_train - n n_val
+    : ~ i bsz . cfg batch
+    ? <= bsz 0 { = bsz 200 } {}
+    ? > bsz n_train { = bsz n_train } {}
+    // Best-weights snapshot for the early-stopping restore.
+    : ( Vec f ) best_w ( __zeros . m n_w )
+    : ( Vec f ) best_b ( __zeros . m n_b )
+    : ~ f best 0.0
+    : ~ b have_best F
+    : ~ i bad 0
+    : ~ i epoch 0
+    : ~ f train_loss 0.0
+    : ~ b stopped F
+    ~ & < epoch . cfg max_iter ! stopped {
+        // Shuffle the TRAIN region only; the val tail stays fixed.
+        : ~ i k 0
+        ~ < k - n_train 1 {
+            : i j + k ( rng_below g - n_train k )
+            ( vec_swap [i] idx k j )
+            = k + k 1
+        }
+        // Minibatch pass.
+        : ~ f se 0.0
+        : i oa ( _mlp_iget . m a_off . m n_layers )
+        : ~ i at 0
+        ~ < at n_train {
+            : ~ i bend + at bsz
+            ? > bend n_train { = bend n_train } {}
+            : ~ i s at
+            ~ < s bend {
+                : i r ( _mlp_iget idx s )
+                ( __mlp_forward m xp * r d acts )
+                : *f ap ( vec_data [f] acts )
+                : ~ i j 0
+                ~ < j dout {
+                    : f e - . ap + oa j . yp + * r dout j
+                    = se + se * e e
+                    = j + j 1
+                }
+                ( __mlp_backprop m acts yp * r dout deltas gw gb )
+                = s + s 1
+            }
+            ( __mlp_adam m gw gb - bend at . cfg lr . cfg alpha )
+            = at bend
+        }
+        = train_loss / se # f * n_train dout
+        // The plateau criterion: validation MSE with early_stop, else the
+        // training loss (sklearn's non-early-stopping path).
+        : ~ f crit train_loss
+        ? . cfg early_stop {
+            = crit ( __mlp_mse_idx m xp d yp dout idx n_train n acts )
+        } {}
+        ? . cfg verbose {
+            ( nurl_print `epoch ` ) ( nurl_print_int + epoch 1 )
+            ( nurl_print ` train_mse ` ) ( nurl_print ( nurl_str_float train_loss ) )
+            ( nurl_print ` crit ` ) ( nurl_print ( nurl_str_float crit ) )
+            ( nurl_print `\n` )
+        } {}
+        ? | ! have_best < crit - best . cfg tol {
+            = bad 0
+            ? | ! have_best < crit best { = best crit } {}
+            = have_best T
+            ? . cfg early_stop {
+                : ~ i c2 0
+                ~ < c2 . m n_w { ( vec_set [f] best_w c2 ( _mlp_fget . m w c2 ) ) = c2 + c2 1 }
+                = c2 0
+                ~ < c2 . m n_b { ( vec_set [f] best_b c2 ( _mlp_fget . m b c2 ) ) = c2 + c2 1 }
+            } {}
+        } {
+            = bad + bad 1
+            ? >= bad . cfg n_no_change { = stopped T } {}
+        }
+        = epoch + epoch 1
+    }
+    // Restore the best weights (early stopping keeps the best epoch, not
+    // the last — sklearn does the same).
+    ? & . cfg early_stop have_best {
+        : ~ i c3 0
+        ~ < c3 . m n_w { ( vec_set [f] . m w c3 ( _mlp_fget best_w c3 ) ) = c3 + c3 1 }
+        = c3 0
+        ~ < c3 . m n_b { ( vec_set [f] . m b c3 ( _mlp_fget best_b c3 ) ) = c3 + c3 1 }
+    } {}
+    ( vec_free [f] best_w )
+    ( vec_free [f] best_b )
+    ( vec_free [f] acts )
+    ( vec_free [f] deltas )
+    ( vec_free [f] gw )
+    ( vec_free [f] gb )
+    ( vec_free [i] idx )
+    ( rng_free g )
+    ^ @ MlpTrain { epoch train_loss best stopped }
+}
+
+// ── Restarts: train several inits, keep the best ──────────────────────
+//
+// A narrow ReLU bottleneck can die at init (every pre-activation negative
+// → the layer collapses and the net predicts the mean; the training MSE
+// plateaus at the data variance). sklearn has the same failure mode and
+// leaves the retry to the user. mlp_fit makes it a deterministic feature:
+// train `restarts` networks with seeds cfg.seed, cfg.seed+1, …, and keep
+// the one with the best plateau criterion (validation MSE under
+// early_stop, training MSE otherwise). restarts ≤ 1 trains exactly once.
+
+: MlpFit {
+    Mlp model
+    MlpTrain report
+}
+
+@ mlp_fit ( Vec i ) sizes ( Vec f ) X i n i d ( Vec f ) Y i dout MlpCfg cfg i restarts → MlpFit {
+    : ~ i r2 restarts
+    ? < r2 1 { = r2 1 } {}
+    // First candidate trains the returned network directly.
+    : ~ Mlp best_m ( mlp_new sizes . cfg seed )
+    : ~ MlpTrain best_tr ( mlp_train best_m X n d Y dout cfg )
+    : ~ i r 1
+    ~ < r r2 {
+        : ~ MlpCfg c cfg
+        = . c seed + . cfg seed r
+        : Mlp m ( mlp_new sizes . c seed )
+        : MlpTrain tr ( mlp_train m X n d Y dout c )
+        ? < . tr best_val . best_tr best_val {
+            ( mlp_free best_m )
+            = best_m m
+            = best_tr tr
+        } {
+            ( mlp_free m )
+        }
+        = r + r 1
+    }
+    ^ @ MlpFit { best_m best_tr }
+}
+
+// ── Persistence (bit-exact JSON) ──────────────────────────────────────
+
+@ __floats_to_bits_json ( Vec f ) v → Json {
+    : Json a ( json_arr_new )
+    : i n ( vec_len [f] v )
+    : ~ i k 0
+    ~ < k n {
+        ( json_arr_push a ( json_int ( f64_to_bits ( _mlp_fget v k ) ) ) )
+        = k + k 1
+    }
+    ^ a
+}
+
+@ __bits_json_to_floats Json a → ( Vec f ) {
+    : i n ( json_arr_len a )
+    : ( Vec f ) v ( vec_with_cap [f] n )
+    : ~ i k 0
+    ~ < k n {
+        : f x ?? ( json_arr_get a k ) {
+            T e → ( bits_to_f64 ?? ( json_num_as_i e ) { T b → b F → 0 } )
+            F → 0.0
+        }
+        ( vec_push [f] v x )
+        = k + k 1
+    }
+    ^ v
+}
+
+@ __ints_json ( Vec i ) v → Json {
+    : Json a ( json_arr_new )
+    : i n ( vec_len [i] v )
+    : ~ i k 0
+    ~ < k n { ( json_arr_push a ( json_int ( _mlp_iget v k ) ) ) = k + k 1 }
+    ^ a
+}
+
+@ __json_ints Json a → ( Vec i ) {
+    : i n ( json_arr_len a )
+    : ( Vec i ) v ( vec_with_cap [i] n )
+    : ~ i k 0
+    ~ < k n {
+        ( vec_push [i] v ?? ( json_arr_get a k ) {
+            T e → ?? ( json_num_as_i e ) { T x → x F → 0 }
+            F → 0 } )
+        = k + k 1
+    }
+    ^ v
+}
+
+// Serialise the trained network (weights + biases; Adam state is NOT
+// persisted — a loaded model predicts, or fine-tunes from a fresh
+// optimiser). Returns an OWNED String of JSON.
+@ mlp_save Mlp m → String {
+    : Json o ( json_obj_new )
+    ( json_obj_set o `sizes` ( __ints_json . m sizes ) )
+    ( json_obj_set o `w` ( __floats_to_bits_json . m w ) )
+    ( json_obj_set o `b` ( __floats_to_bits_json . m b ) )
+    : String s ( json_stringify o )
+    ( json_free o )
+    ^ s
+}
+
+// Rebuild a network from mlp_save output. F on malformed input.
+@ mlp_load s src → ?Mlp {
+    ?? ( json_parse src ) {
+        F _ → { ^ @ ?Mlp { F } }
+        T root → {
+            : ?Json szj ( json_obj_get root `sizes` )
+            : ?Json wj ( json_obj_get root `w` )
+            : ?Json bj ( json_obj_get root `b` )
+            : ~ b ok T
+            ? ?? szj { T _ → F F → T } { = ok F } {}
+            ? ?? wj { T _ → F F → T } { = ok F } {}
+            ? ?? bj { T _ → F F → T } { = ok F } {}
+            ? ! ok { ( json_free root ) ^ @ ?Mlp { F } } {}
+            : ( Vec i ) sizes ?? szj { T j → ( __json_ints j ) F → ( vec_new [i] ) }
+            ? < ( vec_len [i] sizes ) 2 {
+                ( vec_free [i] sizes ) ( json_free root ) ^ @ ?Mlp { F }
+            } {}
+            : Mlp m ( mlp_new sizes 0 )
+            ( vec_free [i] sizes )
+            : ( Vec f ) w ?? wj { T j → ( __bits_json_to_floats j ) F → ( vec_new [f] ) }
+            : ( Vec f ) b ?? bj { T j → ( __bits_json_to_floats j ) F → ( vec_new [f] ) }
+            ? & == ( vec_len [f] w ) . m n_w == ( vec_len [f] b ) . m n_b {
+                : ~ i k 0
+                ~ < k . m n_w { ( vec_set [f] . m w k ( _mlp_fget w k ) ) = k + k 1 }
+                = k 0
+                ~ < k . m n_b { ( vec_set [f] . m b k ( _mlp_fget b k ) ) = k + k 1 }
+                ( vec_free [f] w ) ( vec_free [f] b ) ( json_free root )
+                ^ @ ?Mlp { T m }
+            } {
+                ( vec_free [f] w ) ( vec_free [f] b ) ( json_free root )
+                ( mlp_free m )
+                ^ @ ?Mlp { F }
+            }
+        }
+    }
+}
+
+// ── MinMax scaler ─────────────────────────────────────────────────────
+
+@ minmax_fit ( Vec f ) X i n i d → MinMax {
+    : ( Vec f ) lo ( __zeros d )
+    : ( Vec f ) hi ( __zeros d )
+    : *f xp ( vec_data [f] X )
+    : ~ i c 0
+    ~ < c d {
+        : ~ f mn 0.0
+        : ~ f mx 0.0
+        ? > n 0 { = mn . xp c = mx . xp c } {}
+        : ~ i r 1
+        ~ < r n {
+            : f v . xp + * r d c
+            ? < v mn { = mn v } {}
+            ? > v mx { = mx v } {}
+            = r + r 1
+        }
+        ( vec_set [f] lo c mn )
+        ( vec_set [f] hi c mx )
+        = c + c 1
+    }
+    ^ @ MinMax { d lo hi }
+}
+
+// Scale rows in place: x' = (x − lo) / (hi − lo); zero-range columns → 0.
+@ minmax_apply MinMax mm ( Vec f ) X i n → v {
+    : i d . mm n_cols
+    : *f lop ( vec_data [f] . mm lo )
+    : *f hip ( vec_data [f] . mm hi )
+    : *f xp ( vec_data [f] X )
+    : ~ i r 0
+    ~ < r n {
+        : ~ i c 0
+        ~ < c d {
+            : i o + * r d c
+            : f range - . hip c . lop c
+            : f v ? == range 0.0 0.0 / - . xp o . lop c range
+            ( vec_set [f] X o v )
+            = c + c 1
+        }
+        = r + r 1
+    }
+}
+
+@ minmax_save MinMax mm → String {
+    : Json o ( json_obj_new )
+    ( json_obj_set o `n_cols` ( json_int . mm n_cols ) )
+    ( json_obj_set o `lo` ( __floats_to_bits_json . mm lo ) )
+    ( json_obj_set o `hi` ( __floats_to_bits_json . mm hi ) )
+    : String s ( json_stringify o )
+    ( json_free o )
+    ^ s
+}
+
+@ minmax_load s src → ?MinMax {
+    ?? ( json_parse src ) {
+        F _ → { ^ @ ?MinMax { F } }
+        T root → {
+            : i d ?? ( json_obj_get root `n_cols` ) { T j → ( json_as_int j ) F → 0 }
+            : ( Vec f ) lo ?? ( json_obj_get root `lo` ) { T j → ( __bits_json_to_floats j ) F → ( vec_new [f] ) }
+            : ( Vec f ) hi ?? ( json_obj_get root `hi` ) { T j → ( __bits_json_to_floats j ) F → ( vec_new [f] ) }
+            ( json_free root )
+            ? & & > d 0 == ( vec_len [f] lo ) d == ( vec_len [f] hi ) d {
+                ^ @ ?MinMax { T @ MinMax { d lo hi } }
+            } {
+                ( vec_free [f] lo ) ( vec_free [f] hi )
+                ^ @ ?MinMax { F }
+            }
+        }
+    }
+}
+
+@ minmax_free MinMax mm → v {
+    ( vec_free [f] . mm lo )
+    ( vec_free [f] . mm hi )
+}

--- a/packages/mlp/tests/mlp_test.nu
+++ b/packages/mlp/tests/mlp_test.nu
@@ -1,0 +1,202 @@
+// packages/mlp/tests/mlp_test.nu — offline unit tests, no oracle needed.
+// Run from the package root:
+//   NURL_STDLIB=<repo> ../../nurl.sh tests/mlp_test.nu /tmp/mt && /tmp/mt
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/floatbits.nu`
+$ `stdlib/std/rng.nu`
+$ `src/mlp.nu`
+
+: ~ i g_fail 0
+
+@ check b cond s name → v {
+    ? cond { ( nurl_print `  ok  ` ) } { ( nurl_print `  FAIL ` ) = g_fail + g_fail 1 }
+    ( nurl_print name ) ( nurl_print `\n` )
+}
+
+@ sizes3 i a i b2 i c → ( Vec i ) {
+    : ( Vec i ) s ( vec_new [i] )
+    ( vec_push [i] s a ) ( vec_push [i] s b2 ) ( vec_push [i] s c )
+    ^ s
+}
+
+@ main → i {
+    // ── shapes and determinism ────────────────────────────────────────
+    : ( Vec i ) sz ( sizes3 3 8 2 )
+    : Mlp m1 ( mlp_new sz 7 )
+    : Mlp m2 ( mlp_new sz 7 )
+    : Mlp m3 ( mlp_new sz 8 )
+    ( check == . m1 n_w + * 3 8 * 8 2 `n_w = 3·8 + 8·2` )
+    ( check == . m1 n_b + 8 2 `n_b = 8 + 2` )
+    ( check == . m1 n_a + + 3 8 2 `n_a = 3 + 8 + 2` )
+    : b same == ( f64_to_bits ( _mlp_fget . m1 w 0 ) ) ( f64_to_bits ( _mlp_fget . m2 w 0 ) )
+    : b diff != ( f64_to_bits ( _mlp_fget . m1 w 0 ) ) ( f64_to_bits ( _mlp_fget . m3 w 0 ) )
+    ( check same `same seed → identical init` )
+    ( check diff `different seed → different init` )
+    // Glorot bound: |w| ≤ √(6/(3+8))
+    : f bound ( sqrt / 6.0 11.0 )
+    : ~ b inb T
+    : ~ i k 0
+    ~ < k * 3 8 { ? > ( fabs ( _mlp_fget . m1 w k ) ) bound { = inb F } {} = k + k 1 }
+    ( check inb `init within the Glorot bound` )
+    ( mlp_free m2 ) ( mlp_free m3 )
+
+    // ── XOR regression (the classic non-linear sanity check) ──────────
+    // 4 points, target 1 output; a 2-8-1 net must drive MSE ~0.
+    : ( Vec f ) X ( vec_new [f] )
+    ( vec_push [f] X 0.0 ) ( vec_push [f] X 0.0 )
+    ( vec_push [f] X 0.0 ) ( vec_push [f] X 1.0 )
+    ( vec_push [f] X 1.0 ) ( vec_push [f] X 0.0 )
+    ( vec_push [f] X 1.0 ) ( vec_push [f] X 1.0 )
+    : ( Vec f ) Y ( vec_new [f] )
+    ( vec_push [f] Y 0.0 ) ( vec_push [f] Y 1.0 )
+    ( vec_push [f] Y 1.0 ) ( vec_push [f] Y 0.0 )
+    : ( Vec i ) xsz ( sizes3 2 8 1 )
+    : Mlp xm ( mlp_new xsz 3 )
+    : ~ MlpCfg cfg ( mlp_cfg_default )
+    = . cfg early_stop F  // 4 points can't spare a validation split
+    = . cfg max_iter 4000
+    = . cfg n_no_change 200
+    = . cfg lr 0.01
+    = . cfg batch 4
+    : MlpTrain tr ( mlp_train xm X 4 2 Y 1 cfg )
+    : f xor_mse ( mlp_mse xm X 4 2 Y )
+    ( check < xor_mse 0.01 `XOR fits (mse < 0.01)` )
+    ( check > . tr n_iter 0 `training ran epochs` )
+    ( vec_free [i] xsz )
+
+    // ── prediction agrees with mlp_mse's forward ──────────────────────
+    : ( Vec f ) p1 ( vec_new [f] )
+    ( vec_push [f] p1 1.0 ) ( vec_push [f] p1 0.0 )
+    : ( Vec f ) o1 ( mlp_predict xm p1 )
+    : f v10 ( _mlp_fget o1 0 )
+    ( check & > v10 0.8 < v10 1.2 `predict(1,0) ≈ 1` )
+    ( vec_free [f] p1 ) ( vec_free [f] o1 )
+
+    // ── save / load: bit-exact round-trip ─────────────────────────────
+    : String js ( mlp_save xm )
+    ?? ( mlp_load ( string_data js ) ) {
+        T lm → {
+            : ~ b bits_eq T
+            : ~ i q 0
+            ~ < q . xm n_w {
+                ? != ( f64_to_bits ( _mlp_fget . xm w q ) ) ( f64_to_bits ( _mlp_fget . lm w q ) ) { = bits_eq F } {}
+                = q + q 1
+            }
+            = q 0
+            ~ < q . xm n_b {
+                ? != ( f64_to_bits ( _mlp_fget . xm b q ) ) ( f64_to_bits ( _mlp_fget . lm b q ) ) { = bits_eq F } {}
+                = q + q 1
+            }
+            ( check bits_eq `save/load: every weight bit-exact` )
+            : f lm_mse ( mlp_mse lm X 4 2 Y )
+            ( check == ( f64_to_bits lm_mse ) ( f64_to_bits xor_mse ) `save/load: identical predictions` )
+            ( mlp_free lm )
+        }
+        F → { ( check F `save/load: parses back` ) }
+    }
+    ( string_free js )
+    ?? ( mlp_load `{"broken":1}` ) {
+        T bm → { ( check F `malformed JSON rejected` ) ( mlp_free bm ) }
+        F → { ( check T `malformed JSON rejected` ) }
+    }
+    ( vec_free [f] X ) ( vec_free [f] Y )
+    ( mlp_free xm )
+
+    // ── autoencoder: reconstruct a 1-D manifold in 3-D ────────────────
+    // Points (t, 2t, 3t) — a 3-16-2-16-3 AE must compress through the
+    // bottleneck and reconstruct well; a random point far OFF the
+    // manifold must reconstruct badly (higher error).
+    : ( Vec f ) A ( vec_new [f] )
+    : Rng g ( rng_seed 11 )
+    : ~ i r 0
+    ~ < r 300 {
+        : f t ( rng_u01 g )
+        ( vec_push [f] A t ) ( vec_push [f] A * 2.0 t ) ( vec_push [f] A * 3.0 t )
+        = r + r 1
+    }
+    ( rng_free g )
+    : ( Vec i ) asz ( vec_new [i] )
+    ( vec_push [i] asz 3 ) ( vec_push [i] asz 16 ) ( vec_push [i] asz 2 )
+    ( vec_push [i] asz 16 ) ( vec_push [i] asz 3 )
+    : ~ MlpCfg acfg ( mlp_cfg_default )
+    = . acfg max_iter 800
+    = . acfg lr 0.005
+    = . acfg seed 5
+    : MlpFit fit ( mlp_fit asz A 300 3 A 3 acfg 3 )
+    : Mlp ae . fit model
+    : MlpTrain atr . fit report
+    : f ae_mse ( mlp_mse ae A 300 3 A )
+    ( check < ae_mse 0.005 `AE reconstructs the manifold (mse < 5e-3)` )
+    // On-manifold vs off-manifold reconstruction error
+    : ( Vec f ) onp ( vec_new [f] )
+    ( vec_push [f] onp 0.5 ) ( vec_push [f] onp 1.0 ) ( vec_push [f] onp 1.5 )
+    : ( Vec f ) offp ( vec_new [f] )
+    ( vec_push [f] offp 0.9 ) ( vec_push [f] offp 0.1 ) ( vec_push [f] offp 2.9 )
+    : ( Vec f ) ron ( mlp_predict ae onp )
+    : ( Vec f ) roff ( mlp_predict ae offp )
+    : ~ f eon 0.0
+    : ~ f eoff 0.0
+    : ~ i c 0
+    ~ < c 3 {
+        : f d1 - ( _mlp_fget ron c ) ( _mlp_fget onp c )
+        : f d2 - ( _mlp_fget roff c ) ( _mlp_fget offp c )
+        = eon + eon * d1 d1
+        = eoff + eoff * d2 d2
+        = c + c 1
+    }
+    ( check < eon / eoff 10.0 `off-manifold error ≫ on-manifold (10×)` )
+    ( check . atr stopped_early `AE early-stops before max_iter` )
+    ( vec_free [f] onp ) ( vec_free [f] offp )
+    ( vec_free [f] ron ) ( vec_free [f] roff )
+    ( mlp_free ae )
+
+    // ── restarts rescue a dead-bottleneck init ────────────────────────
+    // Seed 4 alone collapses this bottleneck (every unit's pre-activation
+    // negative → the net predicts the mean; MSE ≈ the data variance
+    // 0.389). mlp_fit with 3 restarts (seeds 4, 5, 6) must recover.
+    : ~ MlpCfg rcfg ( mlp_cfg_default )
+    = . rcfg max_iter 800
+    = . rcfg lr 0.005
+    = . rcfg seed 4
+    : MlpFit solo ( mlp_fit asz A 300 3 A 3 rcfg 1 )
+    : f solo_mse ( mlp_mse . solo model A 300 3 A )
+    ( check > solo_mse 0.1 `seed 4 alone collapses (dead bottleneck)` )
+    ( mlp_free . solo model )
+    : MlpFit resc ( mlp_fit asz A 300 3 A 3 rcfg 3 )
+    : f resc_mse ( mlp_mse . resc model A 300 3 A )
+    ( check < resc_mse 0.01 `3 restarts rescue it (mse < 1e-2)` )
+    ( mlp_free . resc model )
+    ( vec_free [f] A ) ( vec_free [i] asz )
+
+    // ── MinMax scaler ─────────────────────────────────────────────────
+    : ( Vec f ) S ( vec_new [f] )
+    ( vec_push [f] S 0.0 ) ( vec_push [f] S 5.0 ) ( vec_push [f] S 7.0 )
+    ( vec_push [f] S 10.0 ) ( vec_push [f] S 5.0 ) ( vec_push [f] S 3.0 )
+    : MinMax mm ( minmax_fit S 2 3 )
+    ( check == ( f64_to_bits ( _mlp_fget . mm lo 0 ) ) ( f64_to_bits 0.0 ) `minmax lo` )
+    ( check == ( f64_to_bits ( _mlp_fget . mm hi 0 ) ) ( f64_to_bits 10.0 ) `minmax hi` )
+    ( minmax_apply mm S 2 )
+    ( check == ( f64_to_bits ( _mlp_fget S 0 ) ) ( f64_to_bits 0.0 ) `scaled row0 col0 = 0` )
+    ( check == ( f64_to_bits ( _mlp_fget S 3 ) ) ( f64_to_bits 1.0 ) `scaled row1 col0 = 1` )
+    // col1 has zero range (5, 5) → both map to 0, no div-by-zero
+    ( check == ( f64_to_bits ( _mlp_fget S 1 ) ) ( f64_to_bits 0.0 ) `zero-range col → 0` )
+    : String ms ( minmax_save mm )
+    ?? ( minmax_load ( string_data ms ) ) {
+        T lmm → {
+            ( check == ( f64_to_bits ( _mlp_fget . lmm hi 0 ) ) ( f64_to_bits 10.0 ) `minmax save/load` )
+            ( minmax_free lmm )
+        }
+        F → { ( check F `minmax save/load` ) }
+    }
+    ( string_free ms )
+    ( minmax_free mm )
+    ( vec_free [f] S )
+    ( vec_free [i] sz )
+    ( mlp_free m1 )
+
+    ? == g_fail 0 { ( nurl_print `ALL PASS\n` ) ^ 0 } { ( nurl_print `FAILURES\n` ) ^ 1 }
+}

--- a/packages/mlp/tests/oracle.sh
+++ b/packages/mlp/tests/oracle.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# packages/mlp/tests/oracle.sh — the sklearn MLPRegressor oracle.
+#
+# Generates one synthetic tabular dataset (a noisy 2-D manifold in 6-D +
+# injected outliers), trains an autoencoder on the normal points with BOTH
+# stacks — mlp (pure NURL) and sklearn MLPRegressor — using the same
+# architecture and recipe, then checks that:
+#   1. both reconstruct normal data well (MSE within 5× — both sit at
+#      the injected noise floor, so small recipe differences show as a
+#      constant factor),
+#   2. both discriminate the same injected outliers with the p95-threshold
+#      rule (≥ 90 % label agreement on the outlier set).
+# Skips (exit 0) when the reference venv with sklearn is missing.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+PY="$HOME/dev/python-scripts-runner/venv/bin/python"
+export NURL_STDLIB="$REPO"
+
+if [ ! -x "$PY" ] || ! "$PY" -c 'import sklearn' 2>/dev/null; then
+    echo "[mlp-oracle] SKIP — no sklearn venv"; exit 0
+fi
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+fail=0
+
+# ── 1. one dataset for both stacks ───────────────────────────────────
+"$PY" - "$TMP" <<'PYEOF'
+import sys, numpy as np
+tmp = sys.argv[1]
+rng = np.random.default_rng(42)
+n = 1200
+# 2-D latent → 6-D observed, mild noise
+t = rng.uniform(-1, 1, (n, 2))
+X = np.column_stack([
+    t[:,0], t[:,1], t[:,0]*t[:,1], np.sin(2*t[:,0]),
+    t[:,0]+t[:,1], t[:,0]-0.5*t[:,1],
+]) + rng.normal(0, 0.02, (n, 6))
+# 60 outliers: uniform noise across the box, clearly off-manifold
+n_out = 60
+O = rng.uniform(-2, 2, (n_out, 6))
+X.astype("<f8").tofile(f"{tmp}/train.f64")
+O.astype("<f8").tofile(f"{tmp}/outliers.f64")
+PYEOF
+
+# ── 2. sklearn side ──────────────────────────────────────────────────
+"$PY" - "$TMP" > "$TMP/sk.out" <<'PYEOF'
+import sys, numpy as np
+from sklearn.neural_network import MLPRegressor
+from sklearn.preprocessing import MinMaxScaler
+tmp = sys.argv[1]
+X = np.fromfile(f"{tmp}/train.f64", dtype="<f8").reshape(-1, 6)
+O = np.fromfile(f"{tmp}/outliers.f64", dtype="<f8").reshape(-1, 6)
+sc = MinMaxScaler().fit(X)
+Xs, Os = sc.transform(X), sc.transform(O)
+ae = MLPRegressor(hidden_layer_sizes=(64,32,64), activation='relu',
+                  solver='adam', max_iter=500, random_state=42,
+                  early_stopping=True, validation_fraction=0.1,
+                  n_iter_no_change=10)
+ae.fit(Xs, Xs)
+mse = np.mean((ae.predict(Xs)-Xs)**2, axis=1)
+thr = np.percentile(mse, 95)
+omse = np.mean((ae.predict(Os)-Os)**2, axis=1)
+flags = (omse > thr).astype(int)
+print(f"train_mse {mse.mean():.8f}")
+print(f"threshold {thr:.8f}")
+print(f"outliers_flagged {flags.sum()} / {len(flags)}")
+print("flags " + "".join(map(str, flags)))
+PYEOF
+cat "$TMP/sk.out"
+
+# ── 3. NURL side (same arch, recipe, and threshold rule) ─────────────
+cat > "$TMP/nurl_ae.nu" <<'NUEOF'
+$ `stdlib/core/io.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/floatbits.nu`
+$ `stdlib/std/sort.nu`
+$ `src/mlp.nu`
+
+// Raw little-endian f64 file → flat ( Vec f ); rows = len / d.
+@ load_f64 s path i d *u nrow → ( Vec f ) {
+    : ( Vec f ) out ( vec_new [f] )
+    ?? ( read_file_bytes path ) {
+        T bts → {
+            : i nv / ( vec_len [u] bts ) 8
+            : ~ i k 0
+            ~ < k nv {
+                : i bits ?? ( bytes_read_u64_le bts * k 8 ) { T x → # i x F → 0 }
+                ( vec_push [f] out ( bits_to_f64 bits ) )
+                = k + k 1
+            }
+            ( vec_free [u] bts )
+        }
+        F _ → {}
+    }
+    ( nurl_poke nrow 0 / ( vec_len [f] out ) d )
+    ^ out
+}
+
+@ row_mse Mlp m ( Vec f ) X i d i r → f {
+    : ( Vec f ) x ( vec_new [f] )
+    : ~ i k 0
+    ~ < k d { ( vec_push [f] x ( _mlp_fget X + * r d k ) ) = k + k 1 }
+    : ( Vec f ) y ( mlp_predict m x )
+    : ~ f se 0.0
+    = k 0
+    ~ < k d {
+        : f e - ( _mlp_fget y k ) ( _mlp_fget x k )
+        = se + se * e e
+        = k + k 1
+    }
+    ( vec_free [f] x ) ( vec_free [f] y )
+    ^ / se # f d
+}
+
+@ main → i {
+    : i argc ( nurl_argv_count )
+    ? < argc 3 { ( nurl_print `usage: nurl_ae train.f64 outliers.f64\n` ) ^ 1 } {}
+    : *u nc1 ( nurl_alloc 8 )
+    : *u nc2 ( nurl_alloc 8 )
+    : ( Vec f ) X ( load_f64 ( nurl_argv_get 1 ) 6 nc1 )
+    : ( Vec f ) O ( load_f64 ( nurl_argv_get 2 ) 6 nc2 )
+    : i n ( nurl_peek nc1 0 )
+    : i no ( nurl_peek nc2 0 )
+    : i d 6
+    // MinMax fit on train, apply to both (the sklearn recipe)
+    : MinMax mm ( minmax_fit X n d )
+    ( minmax_apply mm X n )
+    ( minmax_apply mm O no )
+    : ( Vec i ) sz ( vec_new [i] )
+    ( vec_push [i] sz d ) ( vec_push [i] sz 64 ) ( vec_push [i] sz 32 )
+    ( vec_push [i] sz 64 ) ( vec_push [i] sz d )
+    : ~ MlpCfg cfg ( mlp_cfg_default )
+    : MlpFit fit ( mlp_fit sz X n d X d cfg 3 )
+    : Mlp ae . fit model
+    // per-row train MSE → p95 threshold (nearest-rank)
+    : ( Vec f ) mses ( vec_new [f] )
+    : ~ i r 0
+    : ~ f tot 0.0
+    ~ < r n {
+        : f e ( row_mse ae X d r )
+        ( vec_push [f] mses e )
+        = tot + tot e
+        = r + r 1
+    }
+    ( sort_by [f] mses \ f a f b → i { ^ ? < a b -1 ? > a b 1 0 } )
+    : i p95i # i * 0.95 # f n
+    : f thr ( _mlp_fget mses p95i )
+    ( nurl_print `train_mse ` ) ( nurl_print ( nurl_str_float / tot # f n ) ) ( nurl_print `\n` )
+    ( nurl_print `threshold ` ) ( nurl_print ( nurl_str_float thr ) ) ( nurl_print `\n` )
+    : ~ i flagged 0
+    : String fl ( string_new )
+    = r 0
+    ~ < r no {
+        : f e ( row_mse ae O d r )
+        ? > e thr { = flagged + flagged 1 ( string_push_str fl `1` ) } { ( string_push_str fl `0` ) }
+        = r + r 1
+    }
+    ( nurl_print `outliers_flagged ` ) ( nurl_print_int flagged )
+    ( nurl_print ` / ` ) ( nurl_print_int no ) ( nurl_print `\n` )
+    ( nurl_print `flags ` ) ( nurl_print ( string_data fl ) ) ( nurl_print `\n` )
+    ( string_free fl )
+    ( vec_free [f] mses ) ( vec_free [i] sz )
+    ( mlp_free ae ) ( minmax_free mm )
+    ( vec_free [f] X ) ( vec_free [f] O )
+    ( nurl_free nc1 ) ( nurl_free nc2 )
+    ^ 0
+}
+NUEOF
+( cd "$HERE" && "$REPO/nurl.sh" "$TMP/nurl_ae.nu" "$TMP/nurl_ae" >/dev/null 2>&1 ) \
+    || { echo "[mlp-oracle] FAIL build"; ( cd "$HERE" && "$REPO/nurl.sh" "$TMP/nurl_ae.nu" "$TMP/nurl_ae" 2>&1 | tail -5 ); exit 1; }
+"$TMP/nurl_ae" "$TMP/train.f64" "$TMP/outliers.f64" > "$TMP/nu.out" || { echo "[mlp-oracle] FAIL run"; exit 1; }
+cat "$TMP/nu.out"
+
+# ── 4. compare ───────────────────────────────────────────────────────
+python3 - "$TMP" <<'PYEOF' || fail=1
+import sys
+tmp = sys.argv[1]
+def parse(p):
+    d = {}
+    for line in open(p):
+        k, _, v = line.partition(' ')
+        d[k.strip()] = v.strip()
+    return d
+sk, nu = parse(f"{tmp}/sk.out"), parse(f"{tmp}/nu.out")
+sk_mse, nu_mse = float(sk['train_mse']), float(nu['train_mse'])
+ratio = max(sk_mse, nu_mse) / max(min(sk_mse, nu_mse), 1e-12)
+sk_fl, nu_fl = sk['flags'], nu['flags']
+agree = sum(a == b for a, b in zip(sk_fl, nu_fl)) / len(sk_fl)
+sk_n = sk_fl.count('1'); nu_n = nu_fl.count('1')
+print(f"[mlp-oracle] mse ratio {ratio:.2f}x  flag agreement {agree:.0%}  (sk {sk_n}, nurl {nu_n} of {len(sk_fl)})")
+ok = ratio < 5.0 and agree >= 0.9
+print("[mlp-oracle]", "PASS" if ok else "FAIL")
+sys.exit(0 if ok else 1)
+PYEOF
+
+exit $fail


### PR DESCRIPTION
The anomaly package's upgrade to a real sliding-window timevector and a trainable autoencoder — plus the new package and the compiler fix the work surfaced.

## 1. `mlp` 0.1.0 — a trainable MLP in pure NURL (new package)

The ecosystem's first **trainable** neural-network package (everything else runs inference). Dense+ReLU, minibatch Adam (bias-corrected), squared loss + L2, early stopping with best-weight restore — deliberately faithful to sklearn `MLPRegressor` semantics, plus `mlp_fit` **deterministic restarts** (a narrow ReLU bottleneck can die at init and collapse to predicting the mean; sklearn leaves the retry to the user, here it's a feature). JSON persistence stores every f64 as its **bit pattern** — reload is exact. MinMax scaler included.

**Oracle:** `tests/oracle.sh` runs sklearn MLPRegressor on the same data and architecture — reconstruction at the same noise floor, **100 % agreement** (60/60) on p95-rule outlier flags. 23 offline checks, ASan + LSan clean.

## 2. compiler: diagnose scalar-into-aggregate bindings (was invalid IR)

Found mid-build: `: ?VerCfg x ( vec_set … )` (vec_set returns `b`) emitted `zext i1 … to { i1, %VerCfg }` — invalid IR nurlc accepted and only clang rejected, without a source location. `coerce_store_val`'s i1-widen now requires an integer target, and the never-valid-mix diagnostic gains the aggregate arm. Regression: `should_fail_scalar_into_aggregate.nu`.

## 3. anomaly: timevector is a REAL sliding window

Previously `timevector` trained a plain point forest on the last 100 points — a data cap, not a window. Now `window_size` consecutive points flatten to ONE window vector (step `step_size`, both configurable + persisted, legacy metadata upgrades in place), the forest trains on window vectors, and detection scores the window **ending at the incoming point**, with the live window derived from the trained forest's width so config changes can't desync scoring. Ring shorter than the window ⇒ the verdict is **absent, never silently wrong**.

The test that shows why it exists: a **reversed sawtooth** run — every reading individually in range — scores *worse* on timevector and *better* on short_term (order-blindness made visible).

## 4. anomaly: the autoencoder version

The reference recipe (`train_autoencoder_model`) in pure NURL: a temporary Isolation Forest (contamination 10 %) drops the ring's anomalies, an MLP autoencoder learns to reconstruct the survivors (MinMax → 64-32-64 → Adam/early-stop/restarts), threshold = p95 of training errors. Detection reports `threshold − mse` in the standard decision_function orientation — aggregation, margins and response shapes need no special case. Catches **correlation breaks the marginals hide** (pressure/flow each in range, jointly impossible). Explicit-only training: `anomaly train-ae` / `POST /train/autoencoder/<model>`; persisted bit-exact per model and loaded on open.

## Verified

- mlp: 23 checks + sklearn oracle (100 % flag agreement); ASan/LSan clean.
- anomaly: full suite **30/0** (timevector 19 checks, autoencoder 15 checks, live-HTTP AE train + version-in-detect); ASan/LSan clean.
- Compiler: corpus **550/0** (+1 compile-fail regression) + bootstrap fixed point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH