### PR TITLE
anomaly: widen the gpukit requirement to ^0.4 (shipped with the 0.4.0 publish)

### DIFF
--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -9,7 +9,7 @@ iforest = { path = "../iforest", version = "^0.1" }
 gpu = { path = "../gpu", version = "^0.7.0" }
 http = { path = "../http", version = "^0.3.1" }
 cli = { path = "../cli", version = "^0.2.0" }
-gpukit = { path = "../gpukit", version = "^0.3" }
+gpukit = { path = "../gpukit", version = "^0.4" }
 mlp = { path = "../mlp", version = "^0.1" }
 
 # Runtime data staged into $NURL_HOME/share/anomaly/ on `nurlpkg install`.


### PR DESCRIPTION
The anomaly 0.4.0 publish required widening the gpukit dependency from ^0.3 to ^0.4 — the local (and registry-published) gpukit is 0.4.0, and nurlpkg correctly refuses to publish against a requirement the registry would resolve differently. This records what shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH