### PR TITLE
web docs: fix content path and correct grammar

### DIFF
--- a/webdocs/content/docs/compiling-and-running.mdx
+++ b/webdocs/content/docs/compiling-and-running.mdx
@@ -14,8 +14,8 @@ hello.ll → (clang)  → hello      (native binary for your machine)
 ```
 
 `nurlc` (the NURL compiler) never touches your CPU's instruction set
-directly, it emits LLVM IR and hands it to
-`clang` to turn into a real binary. This is the
+directly. It emits LLVM IR and hands that to
+`clang`, which turns it into a real binary. This is the
 same backend Rust and Swift use.
 
 ## Script compiling
@@ -34,17 +34,17 @@ Useful flags (put them *before* the source file):
 |---|---|
 | `-O0` … `-O3` | Optimization level passed to `clang` (default `-O2`) |
 | `-g`, `--debug` | Include debug info |
-| `--emit-ir` | Stop after stage 1 — just produce the `.ll` file, don't link |
+| `--emit-ir` | Stop after stage 1 — just produce the `.ll` file, do not link |
 | `--emit-asm` | Emit native assembly (`.s`), skip linking |
 
 <Accordions>
   <Accordion title="Why does -O0 matter for debugging?">
-    At the default `-O2`, `clang` inlines and reorders code aggressively
-    enough that a debugger's "break at this source line" can become
-    unreliable — the line may not correspond to a single instruction
-    anymore. `-O0` keeps the generated code close to the source structure,
-    which is what you want while stepping through a bug, at the cost of a
-    slower binary. Reach for `-O2`/`-O3` again once you're past debugging.
+    At the default `-O2`, `clang` inlines and reorders code aggressively.
+    A debugger's "break at this source line" can become unreliable, because
+    the line may not correspond to a single instruction anymore. `-O0` keeps
+    the generated code close to the source structure, which is what you want
+    while stepping through a bug, at the cost of a slower binary. Reach for
+    `-O2`/`-O3` again once you are past debugging.
   </Accordion>
 </Accordions>
 
@@ -70,4 +70,4 @@ The prebuilt `curl | sh` installer gives you `nurlc`, `nurlpkg`, and
 See the [online playground](https://play.nurl-lang.org/)
 to try NURL in the browser without installing anything, and
 [`docs/PLATFORMS.md`](https://github.com/nurl-lang/nurl/blob/main/docs/PLATFORMS.md)
-for the full target list once you're ready to cross-compile.
+for the full target list once you are ready to cross-compile.

--- a/webdocs/content/docs/contribute.mdx
+++ b/webdocs/content/docs/contribute.mdx
@@ -7,26 +7,26 @@ icon: Users
 # Contribute to documentation
 
 - The web documentation is powered by [Fumadocs](https://fumadocs.dev).
-- All of the NURL documentation is located under `fumadocs/content/docs`.
+- All of the NURL documentation is located under `webdocs/content/docs`.
 
-You can freely contribute to the web documentation with following rules:
+You can freely contribute to the web documentation with the following rules:
 
 - Follow the main [CONTRIBUTING.md](https://github.com/nurl-lang/nurl/blob/main/CONTRIBUTING.md) ruleset
-- Web documentation differs from the repository one with being primarily managed **by hand**. The repository documentation changes rapidly due to the project early-state nature, with future automation implementations in mind.
-- The goal of the web documentation is to be a simple to understand and broad by content, while repository one is minimal and technical.
-- AI usage for **web documentation** contributions is **allowed with limitations.** The developer takes the full responsibility of the commit if AI is used. You must transparently disclose any use of automation in the pull request, including but not limited to LLM‐based AI tools.
-- If low-quality or misleading information is contributed the developers have full allowance to discard all your future contributions.
+- Web documentation differs from the repository documentation in that it is primarily managed **by hand**. The repository documentation changes rapidly due to the project's early-state nature, with future automation implementations in mind.
+- The goal of the web documentation is to be simple to understand and broad in content, while the repository documentation is minimal and technical.
+- AI usage for **web documentation** contributions is **allowed with limitations.** The developer takes full responsibility for the commit if AI is used. You must transparently disclose any use of automation in the pull request, including but not limited to LLM-based AI tools.
+- If low-quality or misleading information is contributed, the developers have full allowance to discard all your future contributions.
 
 ## How To
 
-Below I'll explain a simple way to make edits and additions.
+Below I will explain a simple way to make edits and additions.
 
-1. Fork & Clone the nurl repository
+1. Fork and clone the NURL repository
 2. Set the upstream repository:
    ```bash
    git remote add upstream git@github.com:nurl-lang/nurl.git
    ```
-3. Create a new branch from the main:
+3. Create a new branch from the main branch:
    ```bash
    # Have the latest upstream changes
    git fetch upstream

--- a/webdocs/content/docs/index.mdx
+++ b/webdocs/content/docs/index.mdx
@@ -7,16 +7,16 @@ icon: Rocket
 <Callout type="warn" title="Work In Progress">
   NURL web documentation is maintained separately. For up-to-date information
   refer to the repository documentation in
-  [docs.](https://github.com/nurl-lang/nurl/tree/main/docs)
+  [docs](https://github.com/nurl-lang/nurl/tree/main/docs).
 </Callout>
 
-**NURL** is a compiled language without a virtual machine, garbage collector and interpreter. `.nu` files are compiled straight to a native excecutable or a WebAssembly module.
+**NURL** is a compiled language without a virtual machine, garbage collector and interpreter. `.nu` files are compiled straight to a native executable or a WebAssembly module.
 
 ## Features of NURL
 
 NURL is **designed** to be a target for **LLM code generation** specifically. The regular grammar means errors stay local and a whole program fits predictably in a context window.
 
-- **Prefix-arity grammar** -- every construct has a fixed arity and there's no infix/precedence table to learn. This is easier to parse for the AI and results in lower token usage. The grammar fits on one page and parses with at most 4 tokens of lookahead (LL(k≤4)).
+- **Prefix-arity grammar** -- every construct has a fixed arity and there is no infix/precedence table to learn. This is easier to parse for the AI and results in lower token usage. The grammar fits on one page and parses with at most 4 tokens of lookahead (LL(k≤4)).
 - **Reproducible builds** (deterministic compilation) -- same source produces byte-identical output on every supported platform.
 - **Single-owner memory** -- values auto-drop at scope exit.
 - **Static borrow checker** -- rejects use-after-move, alias-double-free, escaping closure-captures, and iterator invalidation at compile time.
@@ -26,18 +26,18 @@ NURL is **designed** to be a target for **LLM code generation** specifically. Th
 
 NURL is actively developed and is now in a **pre-release** state. See [`ROADMAP.md`](https://github.com/nurl-lang/nurl/blob/main/ROADMAP.md) for the latest version.
 
-Major changes are currently less frequent and the stable release is aimed for late 2026.
+Major changes are currently less frequent, and the stable release is planned for late 2026.
 
 ## Requirements
 
-- Only clang / LLVM 15 or newer if you're building from source
+- Only clang / LLVM 15 or newer if you are building from source
 
 ## Get NURL
 
 1. **[Installation](./install.mdx)** — The `nurlc` compiler (and the
    `nurlpkg` / `nurlfmt` tools)
 2. **First program** — write and understand
-   a minimal "hello world"
+   a minimal "hello world" program
 3. **[Compiling and running](./compiling-and-running.mdx)** — the compile
    pipeline, the `nurl` wrapper, and useful flags.
 4. **[Next steps](./next-steps.mdx)** — The

--- a/webdocs/content/docs/install.mdx
+++ b/webdocs/content/docs/install.mdx
@@ -6,14 +6,14 @@ icon: Download
 
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
-NURL can be obtained in two ways: installing a prebuilt toolchain or by building them from the source code.
+NURL can be obtained in two ways: by installing a prebuilt toolchain, or by building it from the source code.
 
 ## Prebuilt toolchain (Linux / FreeBSD / Windows)
 
 This gives you `nurlc` (compiler), `nurlpkg` (package manager), and
 `nurlfmt` (source formatter) on your `PATH`.
 
-### One command install
+### One-command install
 
 Linux / FreeBSD
 
@@ -30,8 +30,8 @@ irm https://nurl-lang.org/install.ps1 | iex
 <Accordions>
   <Accordion title="Why is there no prebuilt path for macOS?">
     NURL's CI currently builds and tests on **Linux and FreeBSD** only. macOS
-    support exists, but there's no CI coverage or prebuilt toolchain for
-    *running on* macOS yet — hence "build from source" being the macOS path
+    support exists, but there is no CI coverage or prebuilt toolchain for
+    *running on* macOS yet, so building from source is the macOS path
     for now.
   </Accordion>
 </Accordions>
@@ -44,7 +44,7 @@ own `.nu` files right away.
 ### Prerequisites
 
 NURL's compiler emits LLVM IR text; `clang` turns that into a native binary.
-It's the **only** required build-time dependency.
+It is the **only** required build-time dependency.
 
 | OS | Command |
 |---|---|
@@ -53,7 +53,7 @@ It's the **only** required build-time dependency.
 | Windows | Install from [llvm.org/releases](https://llvm.org/releases/) |
 | FreeBSD | already ships `clang`; also install `bash` for `build.sh` |
 
-macOS's brew-installed LLVM isn't symlinked onto `PATH` by default. Add this line to `~/.zshrc` to persist it
+macOS's brew-installed LLVM is not symlinked onto `PATH` by default. Add this line to `~/.zshrc` to persist it.
 
 ```bash
 export PATH="$(brew --prefix llvm)/bin:$PATH"
@@ -69,16 +69,16 @@ build.bat           # Windows
 ```
 
 `./build.sh` performs a full **bootstrap**: it compiles the C runtime,
-links a committed known-good compiler snapshot, uses that to compile the
-current compiler source, compiles it *again* with the result, and checks
-that both self-compiles produce byte-for-byte identical output before
-accepting the build. On success it prints `BUILD SUCCESS & TESTS PASSED`
+links a committed known-good compiler snapshot, and uses that snapshot to
+compile the current compiler source. It then compiles the result *again*
+and checks that both self-compiles produce byte-for-byte identical output
+before accepting the build. On success it prints `BUILD SUCCESS & TESTS PASSED`
 and leaves the compiler at `build/nurlc` (symlinked at the repo root).
 
 <Accordions>
   <Accordion title="Why compile the compiler with itself, twice?">
     The compiler (`compiler/nurlc.nu`) is written in NURL. To prove a change
-    to the compiler didn't silently break itself, `build.sh` compiles the
+    to the compiler did not silently break itself, `build.sh` compiles the
     compiler source with itself, then does it *again* using the result of
     the first pass, and requires the two outputs to be byte-identical. This
     "fixed point" check is the same idea GCC and Zig use to validate a

--- a/webdocs/content/docs/next-steps.mdx
+++ b/webdocs/content/docs/next-steps.mdx
@@ -6,8 +6,8 @@ icon: Compass
 
 ## Learn the language
 
-- **Language Guide** - prefix syntax, types, control flow, structs & enums, pattern matching,
-  memory & ownership, error handling, closures, concurrency.
+- **Language Guide** - prefix syntax, types, control flow, structs and enums, pattern matching,
+  memory and ownership, error handling, closures, concurrency.
 - **Standard Library tour** - collections, strings, JSON, HTTP, crypto,
   channels, and more.
 - **[examples](https://github.com/nurl-lang/nurl/tree/main/examples)** in
@@ -18,14 +18,14 @@ icon: Compass
 ## Try without installing anything
 
 The [online playground](https://play.nurl-lang.org/) compiles and runs NURL
-in your browser via WebAssembly. Good for testing a snippet or using on a machine you haven't set NURL up on yet.
+in your browser via WebAssembly. It is good for testing a snippet, or for using a machine where you have not set up NURL yet.
 
 ## When something goes wrong
 
-NURL treats compiler errors as the primary way to learn what's allowed. Every diagnostic names the problem and the fix. If you hit an error you don't understand, read it fully before
-searching elsewhere, it's designed to be the answer.
+NURL treats compiler errors as the primary way to learn what is allowed. Every diagnostic names the problem and the fix. If you hit an error you do not understand, read it fully before
+searching elsewhere. It is designed to be the answer.
 
-For anything the compiler itself can't catch, or model-level questions like
+For anything the compiler itself cannot catch, or model-level questions like
 "what exactly does the borrow checker check," the two normative references
 are:
 
@@ -37,7 +37,7 @@ are:
 NURL is pre-1.0 and developed in the open at
 [github.com/nurl-lang/nurl](https://github.com/nurl-lang/nurl). The
 [roadmap](https://github.com/nurl-lang/nurl/blob/main/ROADMAP.md) tracks
-what's shipped and what's next; [`CONTRIBUTING.md`](https://github.com/nurl-lang/nurl/blob/main/CONTRIBUTING.md)
+what is shipped and what is next. [`CONTRIBUTING.md`](https://github.com/nurl-lang/nurl/blob/main/CONTRIBUTING.md)
 covers how to contribute to the compiler and standard library, and this
 site's own [contribution guide](./contribute.mdx) covers the
 web documentation specifically.


### PR DESCRIPTION
Fix a stale `fumadocs/content/docs` path left over from the VitePress→ Fumadocs migration (actual location is `webdocs/content/docs`), and clean up grammar across the docs pages: remove contractions, fix comma splices and run-on sentences, correct articles/prepositions, and standardize terminology, per ASD-STE100 (Simplified Technical English) conventions.