### PR TITLE
package graph: propagate gpu 0.9.0 and clear all dependency drift

### DIFF
--- a/packages/anomaly/CHANGELOG.md
+++ b/packages/anomaly/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.1
+
+- Widen the gpu requirement to ^0.9 (device-specific CUBIN kernel cache =
+  faster process start; pinned-staged uploads). No API change.
+
 ## 0.4.0
 
 **The timevector is a real sliding window, and the autoencoder version

--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,12 +1,12 @@
 [package]
 name = "anomaly"
-version = "0.4.0"
+version = "0.4.1"
 description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working. `anomaly serve` also ships a self-contained web dashboard (model manager, trainer, feature visualiser and anomaly scanner — plain HTML/JS, no CDN or build step) served straight from the binary's web root."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 iforest = { path = "../iforest", version = "^0.1" }
-gpu = { path = "../gpu", version = "^0.7.0" }
+gpu = { path = "../gpu", version = "^0.9.0" }
 http = { path = "../http", version = "^0.3.1" }
 cli = { path = "../cli", version = "^0.2.0" }
 gpukit = { path = "../gpukit", version = "^0.4" }

--- a/packages/embed/CHANGELOG.md
+++ b/packages/embed/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.1
+
+- Widen the gpu requirement to ^0.9: the CUBIN kernel cache removes the
+  driver JIT at start-up, and large model uploads ride the pinned-staged
+  parallel-stripe path. No API change.
+
 ## 0.1.0
 
 Initial release — the pure-NURL embedding server.

--- a/packages/embed/nurl.toml
+++ b/packages/embed/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embed"
-version = "0.1.0"
+version = "0.1.1"
 description = "The embedding server, in pure NURL — load an XLM-RoBERTa-family text encoder (BGE-M3, multilingual-e5, …) from a Hugging Face model directory and serve embeddings over HTTP, with no Python, no PyTorch and no ONNX export. The tokenizer is the tokenizer package's Unigram engine (sentencepiece Precompiled charsmap normalization, true Viterbi segmentation — token-for-token identical to Hugging Face tokenizers); weights load straight from model.safetensors via the safetensor package (mmap, f32); the 24-block bidirectional transformer (embeddings + LayerNorm, self-attention, exact-erf GELU FFN, CLS or mean pooling, L2 normalize) runs on gpukit's dtype-generic dev-layer kernels — the same library the tensor and onnx packages use — on CUDA or the CPU/OpenMP backend. Verified against sentence-transformers: cosine 1.0000000 per row on a multilingual corpus, and byte-level API compatibility with the reference FastAPI embedding service (POST/GET /create_embedding with text | texts, normalize flag, Bearer-token auth with a constant-time compare, /health). One `embed serve <model-dir>` starts it; `embed text` embeds from the CLI. Hardened serving: single honest worker, bounded body/head, slowloris idle cut, per-request deadline, panic-to-500."
 license = "MIT OR Apache-2.0"
 
@@ -8,5 +8,5 @@ license = "MIT OR Apache-2.0"
 tokenizer = { path = "../tokenizer", version = "^0.3" }
 safetensor = { path = "../safetensor", version = "^0.2" }
 gpukit = { path = "../gpukit", version = "^0.4" }
-gpu = { path = "../gpu", version = "^0.7" }
+gpu = { path = "../gpu", version = "^0.9" }
 http = { path = "../http", version = "^0.3" }

--- a/packages/gpukit/CHANGELOG.md
+++ b/packages/gpukit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.1
+
+- Widen the gpu requirement to ^0.9 (shipped with the gpu 0.9.0 publish):
+  device-specific CUBIN kernel cache (no driver JIT at process start) and
+  pinned-staged parallel uploads for large device buffers. No API change.
+
 ## 0.4.0
 
 Dev-layer op family — the kernel library a full CNN / transformer forward

--- a/packages/gpukit/nurl.toml
+++ b/packages/gpukit/nurl.toml
@@ -1,8 +1,8 @@
 [package]
 name = "gpukit"
-version = "0.4.0"
+version = "0.4.1"
 description = "The ergonomic GPU-compute toolkit for NURL — a diamond facade over the `gpu` package that kills the marshalling boilerplate every GPU-using package re-invents. Where `gpu` is the low-level interface (open a device, JIT-compile a CUDA-C kernel via NVRTC or the host-C++ CPU backend, allocate/upload/download device buffers, build the argument vector, compute a grid, launch, sync, free), `gpukit` collapses the ~35 lines of that dance per kernel into a list of typed bindings and one `gk_run`: a GpuKit with a per-name kernel cache, `gk_in_f`/`gk_in_i`/`gk_out_f`/`gk_out_i` (and raw-buffer + i32/i64/f32 scalar) bindings, and a workhorse that compiles-once, allocates a device buffer per binding, uploads inputs, marshals args in declaration order, launches, syncs, downloads outputs, and frees everything. The device-resident layer (GkBuf: GK_F32 | GK_F64 | GK_I64) keeps data on the GPU between ops and ships a dtype-generic kernel library that covers a full CNN / transformer forward pass: elementwise (including full N-D stride-broadcast — numpy broadcasting as a stride table), unary maps, matmul and batched matmul with batch broadcast, gather/scatter with ONNX index semantics, gemm (alpha/beta/transB/bias), conv2d / convtranspose2d / maxpool2d (NCHW), batchnorm, layernorm, leakyrelu, clip, erf, axis softmax, axis concat/slice, N-D transpose, nearest-neighbour resize, expand, L2 reduction, argmax and CLIP EOS read-out. Every wrapper validates buffers, dtypes and sizes and fails closed, so a wrong shape never reaches the device. True float32 semantics on GK_F32 (accumulation included, matching numpy float32 / onnxruntime); adds no numerics of its own — a kernel runs bit-for-bit the same through gk_run as through hand-written gpu_* calls, preserving the gpu package's CUDA / CPU-backend equivalence. Runs on the CPU backend when no CUDA device is present."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-gpu = { path = "../gpu", version = "^0.7.0" }
+gpu = { path = "../gpu", version = "^0.9.0" }

--- a/packages/objdet/nurl.toml
+++ b/packages/objdet/nurl.toml
@@ -1,9 +1,9 @@
 [package]
 name = "objdet"
-version = "0.3.1"
+version = "0.3.2"
 description = "Object detection from pure NURL, GPU-accelerated, using any tiny-YOLOv2-style ONNX model. Reads an image natively in any format the image package decodes (PNG, baseline+progressive JPEG, PPM) or a sequence of video frames (binary PPM), runs the detector on the GPU through the onnx package (every Conv/BatchNorm/MaxPool/LeakyRelu kernel compiled to PTX at runtime via NVRTC, no external inference engine), decodes the YOLO grid into labelled boxes (anchors, sigmoid/softmax, non-max suppression), prints the detections, and writes an annotated image. Verified against onnxruntime on the ONNX model-zoo tinyyolov2-8.onnx: identical class scores and boxes (dog 0.76, car 0.76 on the classic dog photo). Pure NURL end to end — protobuf parsing, the CNN, image I/O, decoding, and drawing; the only native dependency (the CUDA driver + NVRTC) lives in the gpu package, so a GPU-less host is unaffected. Image codecs and raster ops come from the image package; ffmpeg only for video-frame extraction."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-onnx = { path = "../onnx", version = "^0.6" }
+onnx = { path = "../onnx", version = "^0.7" }
 image = { path = "../image", version = "^0.4" }

--- a/packages/onnx/nurl.toml
+++ b/packages/onnx/nurl.toml
@@ -1,10 +1,10 @@
 [package]
 name = "onnx"
-version = "0.7.0"
+version = "0.7.1"
 description = "Run ONNX neural-network models from pure NURL, GPU-accelerated. The model's protobuf is decoded by a pure-NURL wire-format reader (no protoc, no external protobuf library) into an in-memory graph; inference keeps every weight and activation resident on the device and dispatches each node to gpukit's dev-layer kernel library — the SAME dtype-generic kernels the tensor package's DTensor uses, so the whole ML stack shares one proven kernel set (onnx carries no kernel sources of its own). Kernels JIT-compile lazily and are cached in-process and on disk; launches chain on the stream with a single device sync per graph walk. The op set covers CNNs and transformers: Conv/ConvTranspose/MaxPool/BatchNormalization, Gemm/MatMul (dense + batched)/Einsum, broadcast Mul/Add/Sub/Div, LayerNormalization/Softmax/Erf/Sigmoid/Relu/LeakyRelu/Clip, Concat/Split/Slice/Reshape/Transpose/Resize/Expand/Unsqueeze, Gather/GatherND/ArgMax/ReduceL2 — enough for YOLO-class detectors, segmentation heads and CLIP text encoders, verified byte-for-byte against the previous executor and numerically against onnxruntime. The zero-copy tensor bridge runs a graph on a device-resident DTensor input and wraps outputs back as DTensors with no host roundtrip. Runs on CUDA (libcuda + NVRTC) or the gpu package's CPU/OpenMP backend on a GPU-less host."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 tensor = { path = "../tensor", version = "^0.4" }
 gpukit = { path = "../gpukit", version = "^0.4" }
-gpu = { path = "../gpu", version = "^0.7.0" }
+gpu = { path = "../gpu", version = "^0.9.0" }

--- a/packages/whisper/nurl.toml
+++ b/packages/whisper/nurl.toml
@@ -10,6 +10,6 @@ assets = ["views"]
 [dependencies]
 gpu = { path = "../gpu", version = "^0.9" }
 safetensor = { path = "../safetensor", version = "^0.2" }
-tokenizer = { path = "../tokenizer", version = "^0.2" }
+tokenizer = { path = "../tokenizer", version = "^0.3" }
 http = { path = "../http", version = "^0.3" }
 audio = { path = "../audio", version = "^0.6" }

--- a/packages/whisper/nurl.toml
+++ b/packages/whisper/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisper"
-version = "1.0.0"
+version = "1.0.1"
 description = "Speech recognition in pure NURL — whisper, running from the safetensors checkpoint Hugging Face ships, on the GPU or the CPU. Built package by package: packages/audio turns a WAV into the log-mel spectrogram (verified against HF's own WhisperFeatureExtractor), packages/safetensor reads the weights, packages/tokenizer holds the BPE vocabulary, and packages/gpu runs the kernels — the same CUDA-C on the CUDA backend and the CPU/OpenMP one. Whisper is not the llama shape, and every kernel is a place it differs: LayerNorm with a bias rather than RMSNorm, GELU with the error function rather than the tanh approximation, two conv1d layers that turn 3000 spectrogram frames into 1500 encoder positions, and NON-CAUSAL attention — a speech encoder hears the whole 30 seconds at once, where every attention in this ecosystem until now masked the future. --vad skips the silence before the model sees it: a recording is mostly not speech, a speech model costs exactly the same over a silent 30 seconds as over a spoken one, and handed silence whisper does not stay quiet — it invents [BLANK_AUDIO], or a sentence. A 292-second recording that is 8 % speech goes from 13.3 s to 2.2 s on distil-large-v3, and stops hallucinating. --timestamps emits '[a --> b] text' segments using whisper's OWN timestamp tokens under openai's constrained-decoding rules (greedy alone never emits one: no single 20 ms bin outscores 'the' - the bins win collectively or not at all), and under --vad the times are mapped back through the condensation to the recording's real timeline: the model saw second 0.2, the subtitle says 00:20, because that is when it was said. The encoder is where the time is, and profiling rather than guessing found it in two places that were not the arithmetic: attention launched nh*nq*nkey threads that each re-read a whole query and key row from memory (45 million threads and 740 GB of traffic per window for distil, plus a 180 MB score matrix that existed only to be read back), and LayerNorm recomputed a row's mean and variance once per ELEMENT of the row rather than once per row. Attention is now the flash shape — 64 queries of one head held in registers while keys and values stream past through shared memory, softmax computed online, no score matrix at all — the projections are a 64x64-tiled GEMM at ~18 TFLOPS, and LayerNorm is a block-per-row shared reduction that went from 973 us to 12. A 292-second recording: 13.3 s to 7.3 s, with the encoder's numbers bit-for-bit what an independent numpy reference (which matches HF) says."
 license = "MIT OR Apache-2.0"
 
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 assets = ["views"]
 
 [dependencies]
-gpu = { path = "../gpu", version = "^0.7" }
+gpu = { path = "../gpu", version = "^0.9" }
 safetensor = { path = "../safetensor", version = "^0.2" }
 tokenizer = { path = "../tokenizer", version = "^0.2" }
 http = { path = "../http", version = "^0.3" }

--- a/packages/yoloe-demo/nurl.toml
+++ b/packages/yoloe-demo/nurl.toml
@@ -1,13 +1,13 @@
 [package]
 name = "yoloe-demo"
-version = "0.2.3"
+version = "0.2.4"
 description = "Live YOLOE in the browser, served by pure NURL — open your webcam on a web page and watch open-vocabulary detection + instance segmentation stream back at you. The browser posts JPEG frames to a NURL HTTP(S) server; every frame runs through the onnx package on the GPU (each layer a CUDA-C kernel compiled at runtime via NVRTC), the segmentation masks are composited onto the frame, and the masked JPEG + a JSON detection list come back — the page draws boxes/labels on top and loops. Interactive: toggle prompted classes, drag the confidence slider, flip masks on/off, or drop a still image. --tls generates a self-signed P-256 certificate at startup (std/x509_gen) so the camera also works from other machines on the LAN (getUserMedia needs a secure origin). Everything in the path is NURL: the HTTP/TLS server (http package), the page template (template package), the JPEG/PNG codecs (image package), the ONNX runtime (onnx package) and the YOLOE decode/mask stages (yoloe package). No Python, no OpenCV, no inference engine, no web framework."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl-lang"
 
 [dependencies]
 yoloe = { path = "../yoloe", version = "^0.6" }
-onnx = { path = "../onnx", version = "^0.6" }
+onnx = { path = "../onnx", version = "^0.7" }
 image = { path = "../image", version = "^0.4" }
-http = { path = "../http", version = "^0.2" }
+http = { path = "../http", version = "^0.3" }
 template = { path = "../template", version = "^0.1" }

--- a/packages/yoloe/nurl.toml
+++ b/packages/yoloe/nurl.toml
@@ -1,10 +1,10 @@
 [package]
 name = "yoloe"
-version = "0.6.4"
+version = "0.6.5"
 description = "Promptable, open-vocabulary object detection AND instance segmentation from pure NURL on the GPU — a NURL port of YOLOE (THU-MIG, 'Real-Time Seeing Anything', ICCV 2025), including live masking straight off a webcam. You name the classes you want ('dog', 'bicycle', 'a person on a bike') and the model finds them — drawing both boxes and per-object segmentation masks — without a fixed label set. The whole network runs on the GPU through the onnx package (every layer a CUDA-C kernel compiled at runtime via NVRTC — no external inference engine), including the YOLOE-seg mask-prototype branch (ConvTranspose 2× upsample) and the mask decode (coefficients · prototypes → threshold → overlay), all verified numerically against onnxruntime (proto max abs err ~6e-5). Promptability comes from YOLOE's region-text contrastive head, which scores each region's visual embedding against the text embeddings of the prompt words, with the MobileCLIP text path also in pure NURL. The webcam feed is captured in pure NURL via Video4Linux2 (open/ioctl/mmap, YUYV→RGB) — no ffmpeg, no OpenCV. Requires the NVIDIA driver + NVRTC (via the gpu package); a GPU-less host is unaffected."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-onnx = { path = "../onnx", version = "^0.6" }
+onnx = { path = "../onnx", version = "^0.7" }
 image = { path = "../image", version = "^0.4" }
 cli = { path = "../cli", version = "^0.2" }


### PR DESCRIPTION
Brings every path-dependency constraint in the workspace onto the current version of its dependency, so the whole stack resolves onto **gpu 0.9.0** (device-specific CUBIN kernel cache — no driver JIT at process start — and pinned-staged parallel uploads) and current **onnx 0.7**. Metadata-only patch bumps: no source changed, every package still typechecks against its updated dependencies.

## Bumps

| package | version | constraint change |
|---|---|---|
| gpukit | 0.4.0 → 0.4.1 | gpu ^0.7.0 → ^0.9.0 |
| onnx | 0.7.0 → 0.7.1 | gpu ^0.7.0 → ^0.9.0 |
| anomaly | 0.4.0 → 0.4.1 | gpu ^0.7.0 → ^0.9.0 |
| embed | 0.1.0 → 0.1.1 | gpu ^0.7 → ^0.9 |
| whisper | 1.0.0 → 1.0.1 | gpu ^0.7 → ^0.9, tokenizer ^0.2 → ^0.3 |
| yoloe | 0.6.4 → 0.6.5 | onnx ^0.6 → ^0.7 |
| objdet | 0.3.1 → 0.3.2 | onnx ^0.6 → ^0.7 |
| yoloe-demo | 0.2.3 → 0.2.4 | onnx ^0.6 → ^0.7, http ^0.2 → ^0.3 |

`tensor` needs no bump: it depends on `gpukit ^0.4` only, so it inherits gpukit 0.4.1 (and gpu 0.9.0) transitively.

## Why the lockstep

`^0.7` locks the minor on 0.x, so it excludes 0.9.0 — a consumer must widen to `^0.9`. gpukit is the shared kernel library the others reach gpu through; onnx / anomaly / embed carry a **direct** gpu constraint alongside `gpukit ^0.4`, so once gpukit 0.4.1 (gpu ^0.9) exists, an install still pinning gpu ^0.7 would find no gpu version satisfying both — they had to move together. The onnx-dependent leaves (yoloe / objdet / yoloe-demo) were pinned to `onnx ^0.6`, excluding the published onnx 0.7.x; onnx 0.7 removed `ops.nu` and rebuilt the executor on gpukit's gkd library, but the public surface these leaves use is unchanged, so they advance with no code change. Two pre-existing drifts surfaced and are fixed here too: whisper's `tokenizer ^0.2` (it builds against 0.3.0) and yoloe-demo's `http ^0.2` (against 0.3.1).

A full-graph audit after these edits reports zero remaining drift. All eleven affected packages are published to the registry in dependency order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS1mVN7MEpHV2zXZVe4fwH
