### PR TITLE
docs(DISTRIBUTED): capability-domain routing rings + large-frame limitation

### DIFF
--- a/docs/DISTRIBUTED.md
+++ b/docs/DISTRIBUTED.md
@@ -385,6 +385,15 @@ Milk-V Duo becomes a real compute node in the ring, not merely a relay.
 [`examples/distributed_map.nu`](../examples/distributed_map.nu) shards a
 word-count across workers by key and aggregates the result.
 
+**Capability domains.** `job_set_ring(kind, ring)` scopes a task kind to its own
+routing ring — so submit, ownership, and re-homing for that kind all resolve
+against a *subset* of nodes rather than the main ring. A node that advertises a
+capability (e.g. a GPU) is folded into a second, capability-only ring; a task
+kind bound to it can never be owned by — or forwarded to — a node that lacks the
+capability. Every node must scope a kind identically, or re-homing would cross
+domains. This is how a mixed cluster runs heterogeneous work: general keys spread
+over everyone, GPU keys only over GPU nodes, on one transport.
+
 ### `dist/lease.nu` — fencing for side-effecting tasks
 
 During membership convergence two nodes can briefly both believe they own a
@@ -555,5 +564,13 @@ Known deep follow-ups (no workarounds — these are tracked for a genuine fix):
   without a timer-wheel deadline, so a recv timeout is ignored under the fiber
   reactor; single-process multi-node demos use process-per-node until fiber
   reads are registered on the timer wheel.
+- **Large relay frames.** `_relay_max` caps a forwarded frame at 16 MiB (a DoS
+  guard), and `__read_exact` now rides out a mid-frame recv timeout so a large
+  body is no longer abandoned. But a *single* multi-MiB frame is still fragile
+  through the blocking relay client in a same-process multi-thread node
+  (a not-fully-root-caused send/recv-scheduling interaction), so the reliable
+  transfer unit is ~1 MiB — higher layers that move bulk data chunk it to that
+  size rather than sending one giant frame. A genuine fix (reliable large-frame
+  transfer, or the reactor deadline above) would lift that.
 
 The mesh PSK is node-wide today (per-peer PSK is a follow-up).


### PR DESCRIPTION
## What

Two accuracy gaps in `docs/DISTRIBUTED.md` (the internal distributed-stack doc), found while reviewing whether the docs are current after the swarm-mcp work.

- **`dist/job.nu` — per-kind capability domains.** The section documented `job_register` / `job_submit` / re-homing but omitted **`job_set_ring(kind, ring)`**, which scopes a task kind to its own routing ring. That's a shipped keystone feature: a mixed cluster runs heterogeneous work on one transport (GPU keys route only over GPU-capable nodes, never to a CPU-only worker). Added.
- **Large relay frames (Known follow-ups).** `_relay_max` caps a forwarded frame at 16 MiB and `__read_exact` now rides out a mid-frame recv timeout — but a *single* multi-MiB frame is still fragile through the blocking relay client in a same-process multi-thread node (a not-fully-root-caused scheduling interaction), so the reliable transfer unit is ~1 MiB and bulk-data layers chunk rather than send one giant frame. Added as a tracked follow-up.

## Scope

Stack-level only. `swarm-mcp` is an **external package** (`packages/swarm-mcp`, with its own README/CHANGELOG), not an internal library, so it is intentionally **not** referenced in this doc — the additions describe `dist/job` and `net/relay` themselves. All API names in the section were re-verified against `stdlib/dist/job.nu`.

## Documentation freshness check (the rest)

- The **swarm-mcp package docs** (`packages/swarm-mcp/README.md`, `CHANGELOG.md`, the in-tool `swarm_help` topics and schemas) are current through 0.20.0 — typed datasets, streaming/64 GiB, shuffle cardinality + out_file, worker-death re-dispatch, iterate retry, and coordinator crash-restart persistence are all documented, and the "13 tools" count matches the code.
- No other `stdlib/dist` or `stdlib/net` changes since the doc's date besides the relay large-frame fix (now noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)