### PR TITLE
anomaly 0.5.0: GPU autoencoder training (bit-exact, 34×) + mlp 0.2.0 frozen-Adam fix

### DIFF
--- a/packages/anomaly/CHANGELOG.md
+++ b/packages/anomaly/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.5.0
+
+**The autoencoder trains on the GPU when one is present — bit-exactly.**
+Training was the autoencoder's whole cost (~20 s for 20 k rows on the CPU;
+the scoring passes are milliseconds), and it now runs on a CUDA device by
+default, with the package's standing guarantee intact: **backend choice can
+never change a result**. The GPU-trained network is bit-for-bit identical to
+the CPU-trained one — same weights, same threshold, same verdicts — so GPU is
+pure speed: **~34× faster** end-to-end on the parity benchmark (6 k × 12,
+64-32-64, 3 restarts: 7.6 s → 0.22 s).
+
+- `src/aegpu.nu`: a bit-exact device mirror of `mlp_fit`. Control flow (the
+  seeded shuffles, validation split, early stopping, best-weights restore,
+  restarts, Adam scalars via host `pow`/`sqrt`) stays on the host; five
+  kernels (forward / backprop / gradient / Adam / eval-diff) reproduce the
+  CPU's rounding and accumulation order exactly — explicit `__dadd_rn`/
+  `__dmul_rn` (no FMA contraction), serial dot products in the CPU's k-order,
+  per-weight gradient sums in the CPU's row order. Weights and Adam state
+  stay device-resident across the whole run.
+- Selection: CUDA present → GPU; otherwise (no device, `ANOMALY_GPU=0`, or
+  any mid-setup failure) the pure `mlp_fit` — identical results either way.
+  The gpu package's host-C++ backend is deliberately not used for training:
+  native `mlp_fit` already is the optimised CPU path.
+- `tests/aegpu_parity_test.nu` (+ `tests/aegpu_smoke.sh`) pins the guarantee:
+  weights, biases, the full Adam state, epoch count and both loss figures
+  are asserted BIT-IDENTICAL between `mlp_fit` and `aegpu_fit`.
+- Requires `mlp` ≥ 0.2 — whose frozen-Adam-bias-correction fix this parity
+  work uncovered (a scalar step-counter field on a by-value struct never
+  advanced; see the mlp changelog).
+
 ## 0.4.1
 
 - Widen the gpu requirement to ^0.9 (device-specific CUBIN kernel cache =

--- a/packages/anomaly/README.md
+++ b/packages/anomaly/README.md
@@ -109,6 +109,20 @@ rows × 300 trees: pure NURL 9.6 s, host C++ backend 1.1 s (~9×), RTX 4090
 213 ms (~45×). `ANOMALY_GPU=0` disables the accelerator; `NURL_GPU=cpu`
 forces the CPU backend on a CUDA machine.
 
+**Autoencoder training** (`/train/autoencoder/<model>`) also runs on the
+GPU by default when a CUDA device is present — and training is where the
+autoencoder's time goes (the scoring passes are milliseconds). The device
+mirror (`src/aegpu.nu`) keeps the training loop on the host (same seeded
+shuffles, validation split, early stopping, restarts) and reproduces the
+CPU's floating-point rounding and accumulation order in its kernels, so the
+GPU-trained network is **bit-for-bit identical** to the CPU-trained one —
+same weights, same p95 threshold, same verdicts, just **~34× faster**
+(6 k rows × 12 features, 64-32-64, 3 restarts: 7.6 s → 0.22 s on an
+RTX 4090). Without a CUDA device (or with `ANOMALY_GPU=0`) training uses
+the pure `mlp` path — the same result at CPU pace.
+`tests/aegpu_parity_test.nu` asserts the bit-identity: weights, biases,
+the full Adam state, epoch count and losses.
+
 ## CLI
 
 ```

--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anomaly"
-version = "0.4.1"
+version = "0.5.0"
 description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working. `anomaly serve` also ships a self-contained web dashboard (model manager, trainer, feature visualiser and anomaly scanner — plain HTML/JS, no CDN or build step) served straight from the binary's web root."
 license = "MIT OR Apache-2.0"
 
@@ -10,7 +10,7 @@ gpu = { path = "../gpu", version = "^0.9.0" }
 http = { path = "../http", version = "^0.3.1" }
 cli = { path = "../cli", version = "^0.2.0" }
 gpukit = { path = "../gpukit", version = "^0.4" }
-mlp = { path = "../mlp", version = "^0.1" }
+mlp = { path = "../mlp", version = "^0.2" }
 
 # Runtime data staged into $NURL_HOME/share/anomaly/ on `nurlpkg install`.
 # The `serve` dashboard resolves its web root as <exe-dir>/../share/anomaly/static,

--- a/packages/anomaly/src/aegpu.nu
+++ b/packages/anomaly/src/aegpu.nu
@@ -1,0 +1,604 @@
+// anomaly/aegpu.nu — GPU-accelerated autoencoder training (bit-exact).
+//
+// The autoencoder trains through mlp_fit — minibatch Adam over a small dense
+// net — and that training is where /train/autoencoder spends its time
+// (~20 s for 20 k rows; the bulk-MSE pass after it is milliseconds). This
+// module runs THE SAME training on the GPU when one is present, with the
+// package's standing guarantee intact: **backend choice can never change a
+// result**. The GPU path is bit-for-bit identical to mlp_fit, so a model
+// trained on a CUDA machine equals the CPU-trained model exactly — same
+// weights, same threshold, same verdicts. GPU is pure speed.
+//
+// How bit-exactness is achieved (and pinned by tests/aegpu_parity_smoke.sh):
+//
+//   * Control flow stays on the host and MIRRORS mlp_train exactly: the same
+//     seeded PRNG call order (init, the one full shuffle, the per-epoch train
+//     -region shuffles), the same validation split, minibatch bounds, early-
+//     stopping/patience/best-weights logic, and the same Adam scalar
+//     bookkeeping (lr_t via host pow/sqrt, passed to the kernel as data).
+//   * The kernels reproduce the CPU's floating-point ROUNDING AND ORDER:
+//     every accumulation chain uses explicit __dadd_rn/__dmul_rn/__dsub_rn
+//     (round-to-nearest, never fused — NVRTC's default fmad contraction
+//     would change results), dot products run serially in the CPU's k-order
+//     inside one thread, and per-weight gradient sums walk the batch rows in
+//     the CPU's row order. Division and sqrt are IEEE-correctly-rounded on
+//     both sides. Scalars that need libm pow are computed on the HOST and
+//     shipped to the kernel, so no transcendental runs on the device.
+//   * Loss/criterion sums come back as per-element differences and are
+//     folded on the host in the same flat order as the CPU loop.
+//
+// Weights, Adam state and the data live on the device for the whole run;
+// per minibatch the device does forward → backprop → gradient → Adam in four
+// launches and only the output-layer diffs (batch×d f64s) come back.
+//
+// Selection: engine `cuda` (score.nu's probe) → GPU; anything else — no
+// device, ANOMALY_GPU=0, any mid-setup failure — falls back to the pure
+// mlp_fit, which (being bit-identical) is a pace change, never a behaviour
+// change. The gpu package's host-C++ backend is deliberately NOT used for
+// training: native mlp_fit already is the optimized CPU path.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/floatbits.nu`
+$ `stdlib/std/rng.nu`
+$ `src/score.nu`
+$ `deps/mlp/src/mlp.nu`
+$ `deps/gpu/src/gpu.nu`
+$ `deps/gpukit/src/gpukit.nu`
+
+// Rows per eval chunk (validation pass): bounds the acts buffer.
+@ _aeg_eval_chunk → i { ^ 4096 }
+
+// ── the kernels ───────────────────────────────────────────────────────
+// meta (i64): [0]=n_layers [1]=n_a [2]=d [3]=dout, then sizes(nl+1),
+// w_off(nl), b_off(nl), a_off(nl+1). One block per row for fwd/bwd/diff
+// (threads stride the neurons, __syncthreads between layers); one thread
+// per parameter for grad/adam.
+@ _aeg_kernel_src → s {
+    ^ `extern "C" __global__ void ae_fwd(const long long* meta, const double* X, const long long* idx, long long at, long long count, long long d, const double* w, const double* bb, double* acts)
+{
+    long long s = blockIdx.x; if (s >= count) return;
+    long long nl = meta[0]; long long n_a = meta[1];
+    const long long* sz = meta + 4;
+    const long long* wop = sz + nl + 1;
+    const long long* bop = wop + nl;
+    const long long* aop = bop + nl;
+    long long r = idx[at + s];
+    double* a = acts + s * n_a;
+    for (long long c = threadIdx.x; c < d; c += blockDim.x) a[c] = X[r * d + c];
+    __syncthreads();
+    for (long long l = 0; l < nl; l++) {
+        long long fin = sz[l]; long long fout = sz[l + 1];
+        long long wo = wop[l]; long long bo = bop[l];
+        long long ai = aop[l]; long long ao = aop[l + 1];
+        int last = (l == nl - 1) ? 1 : 0;
+        for (long long j = threadIdx.x; j < fout; j += blockDim.x) {
+            double z = bb[bo + j];
+            long long wrow = wo + j * fin;
+            for (long long i2 = 0; i2 < fin; i2++)
+                z = __dadd_rn(z, __dmul_rn(w[wrow + i2], a[ai + i2]));
+            if (!last && z < 0.0) z = 0.0;
+            a[ao + j] = z;
+        }
+        __syncthreads();
+    }
+}
+extern "C" __global__ void ae_bwd(const long long* meta, const double* Y, const long long* idx, long long at, long long count, long long dout, const double* w, const double* acts, double* deltas, double* outdiff)
+{
+    long long s = blockIdx.x; if (s >= count) return;
+    long long nl = meta[0]; long long n_a = meta[1];
+    const long long* sz = meta + 4;
+    const long long* wop = sz + nl + 1;
+    const long long* aop = wop + nl + nl;
+    long long r = idx[at + s];
+    const double* a = acts + s * n_a;
+    double* dl = deltas + s * n_a;
+    long long oa = aop[nl];
+    for (long long j = threadIdx.x; j < dout; j += blockDim.x) {
+        double e = __dsub_rn(a[oa + j], Y[r * dout + j]);
+        dl[oa + j] = e;
+        outdiff[s * dout + j] = e;
+    }
+    __syncthreads();
+    for (long long l = nl - 1; l >= 1; l--) {
+        long long fin = sz[l]; long long fout = sz[l + 1];
+        long long wo = wop[l]; long long ai = aop[l]; long long ao = aop[l + 1];
+        for (long long i3 = threadIdx.x; i3 < fin; i3 += blockDim.x) {
+            double sm = 0.0;
+            for (long long j2 = 0; j2 < fout; j2++)
+                sm = __dadd_rn(sm, __dmul_rn(w[wo + j2 * fin + i3], dl[ao + j2]));
+            if (a[ai + i3] <= 0.0) sm = 0.0;
+            dl[ai + i3] = sm;
+        }
+        __syncthreads();
+    }
+}
+extern "C" __global__ void ae_grad(const long long* meta, long long n_w, long long n_b, long long count, const double* acts, const double* deltas, double* gw, double* gb)
+{
+    long long k = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long nl = meta[0]; long long n_a = meta[1];
+    const long long* sz = meta + 4;
+    const long long* wop = sz + nl + 1;
+    const long long* bop = wop + nl;
+    const long long* aop = bop + nl;
+    if (k < n_w) {
+        long long l = nl - 1;
+        while (l > 0 && wop[l] > k) l--;
+        long long fin = sz[l];
+        long long off = k - wop[l];
+        long long j = off / fin; long long i2 = off % fin;
+        long long ai = aop[l]; long long ao = aop[l + 1];
+        double acc = 0.0;
+        for (long long s = 0; s < count; s++)
+            acc = __dadd_rn(acc, __dmul_rn(deltas[s * n_a + ao + j], acts[s * n_a + ai + i2]));
+        gw[k] = acc;
+    } else if (k < n_w + n_b) {
+        long long kb = k - n_w;
+        long long l = nl - 1;
+        while (l > 0 && bop[l] > kb) l--;
+        long long j = kb - bop[l];
+        long long ao = aop[l + 1];
+        double acc = 0.0;
+        for (long long s = 0; s < count; s++)
+            acc = __dadd_rn(acc, deltas[s * n_a + ao + j]);
+        gb[kb] = acc;
+    }
+}
+extern "C" __global__ void ae_adam(long long n_w, long long n_b, double lrt, double alpha, double fb, double* w, double* bb, double* mw, double* vw, double* mb, double* vb, double* gw, double* gb)
+{
+    long long k = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    double b1 = 0.9; double b2 = 0.999; double eps = 0.00000001;
+    if (k < n_w) {
+        double g = __dadd_rn(gw[k], __dmul_rn(alpha, w[k])) / fb;
+        double nm = __dadd_rn(__dmul_rn(b1, mw[k]), __dmul_rn(__dsub_rn(1.0, b1), g));
+        double nv = __dadd_rn(__dmul_rn(b2, vw[k]), __dmul_rn(__dsub_rn(1.0, b2), __dmul_rn(g, g)));
+        mw[k] = nm; vw[k] = nv;
+        w[k] = __dsub_rn(w[k], __dmul_rn(lrt, nm) / __dadd_rn(sqrt(nv), eps));
+        gw[k] = 0.0;
+    } else if (k < n_w + n_b) {
+        long long kb = k - n_w;
+        double g = gb[kb] / fb;
+        double nm = __dadd_rn(__dmul_rn(b1, mb[kb]), __dmul_rn(__dsub_rn(1.0, b1), g));
+        double nv = __dadd_rn(__dmul_rn(b2, vb[kb]), __dmul_rn(__dsub_rn(1.0, b2), __dmul_rn(g, g)));
+        mb[kb] = nm; vb[kb] = nv;
+        bb[kb] = __dsub_rn(bb[kb], __dmul_rn(lrt, nm) / __dadd_rn(sqrt(nv), eps));
+        gb[kb] = 0.0;
+    }
+}
+extern "C" __global__ void ae_diff(const long long* meta, const double* Y, const long long* idx, long long at, long long count, long long dout, const double* acts, double* outdiff)
+{
+    long long s = blockIdx.x; if (s >= count) return;
+    long long nl = meta[0]; long long n_a = meta[1];
+    const long long* aop = meta + 4 + (nl + 1) + nl + nl;
+    long long oa = aop[nl];
+    long long r = idx[at + s];
+    for (long long j = threadIdx.x; j < dout; j += blockDim.x)
+        outdiff[s * dout + j] = __dsub_rn(acts[s * n_a + oa + j], Y[r * dout + j]);
+}
+`
+}
+
+// ── device context ────────────────────────────────────────────────────
+// Everything one aegpu_fit run holds on the device. All buffers are f64
+// except idx / meta (i64). X doubles as Y (autoencoder: target == input).
+: AeGpu {
+    b ok
+    Gpu g
+    GpuKernel kfwd
+    GpuKernel kbwd
+    GpuKernel kgrad
+    GpuKernel kadam
+    GpuKernel kdiff
+    GpuBuffer bmeta
+    GpuBuffer bx
+    GpuBuffer bidx
+    GpuBuffer bw
+    GpuBuffer bb
+    GpuBuffer bmw
+    GpuBuffer bvw
+    GpuBuffer bmb
+    GpuBuffer bvb
+    GpuBuffer bgw
+    GpuBuffer bgb
+    GpuBuffer bacts
+    GpuBuffer bdeltas
+    GpuBuffer bodt  // train outdiff: bsz × dout
+    GpuBuffer bode  // eval outdiff: eval_chunk × dout
+}
+
+@ _aeg_free AeGpu cx → v {
+    ( gpu_free . cx bmeta ) ( gpu_free . cx bx ) ( gpu_free . cx bidx )
+    ( gpu_free . cx bw ) ( gpu_free . cx bb )
+    ( gpu_free . cx bmw ) ( gpu_free . cx bvw ) ( gpu_free . cx bmb ) ( gpu_free . cx bvb )
+    ( gpu_free . cx bgw ) ( gpu_free . cx bgb )
+    ( gpu_free . cx bacts ) ( gpu_free . cx bdeltas )
+    ( gpu_free . cx bodt ) ( gpu_free . cx bode )
+    ( gpu_kernel_free . cx kfwd ) ( gpu_kernel_free . cx kbwd ) ( gpu_kernel_free . cx kgrad )
+    ( gpu_kernel_free . cx kadam ) ( gpu_kernel_free . cx kdiff )
+}
+
+// The meta buffer content for a freshly built net.
+@ _aeg_meta Mlp m i d i dout → ( Vec i ) {
+    : i nl . m n_layers
+    : ( Vec i ) meta ( vec_new [i] )
+    ( vec_push [i] meta nl )
+    ( vec_push [i] meta . m n_a )
+    ( vec_push [i] meta d )
+    ( vec_push [i] meta dout )
+    : ~ i k 0
+    ~ < k + nl 1 { ( vec_push [i] meta ( _mlp_iget . m sizes k ) ) = k + k 1 }
+    = k 0
+    ~ < k nl { ( vec_push [i] meta ( _mlp_iget . m w_off k ) ) = k + k 1 }
+    = k 0
+    ~ < k nl { ( vec_push [i] meta ( _mlp_iget . m b_off k ) ) = k + k 1 }
+    = k 0
+    ~ < k + nl 1 { ( vec_push [i] meta ( _mlp_iget . m a_off k ) ) = k + k 1 }
+    ^ meta
+}
+
+// Open the context: buffers + the five kernels, on score.nu's device
+// singleton. Any failure → ok=F (caller falls back to mlp_fit).
+@ _aeg_open Mlp m i n i d i dout i bsz → AeGpu {
+    : Gpu g . ( __an_gpukit_ref ) gpu
+    : s src ( _aeg_kernel_src )
+    : GpuKernel kfwd ( gpu_compile g src `ae_fwd` )
+    : GpuKernel kbwd ( gpu_compile g src `ae_bwd` )
+    : GpuKernel kgrad ( gpu_compile g src `ae_grad` )
+    : GpuKernel kadam ( gpu_compile g src `ae_adam` )
+    : GpuKernel kdiff ( gpu_compile g src `ae_diff` )
+    : ( Vec i ) meta ( _aeg_meta m d dout )
+    : i ch ( _aeg_eval_chunk )
+    : i rows ? > bsz ch bsz ch
+    : GpuBuffer bmeta ( gpu_alloc g * ( vec_len [i] meta ) 8 )
+    : GpuBuffer bx ( gpu_alloc g * * n d 8 )
+    : GpuBuffer bidx ( gpu_alloc g * n 8 )
+    : GpuBuffer bw ( gpu_alloc g * . m n_w 8 )
+    : GpuBuffer bb2 ( gpu_alloc g * . m n_b 8 )
+    : GpuBuffer bmw ( gpu_alloc g * . m n_w 8 )
+    : GpuBuffer bvw ( gpu_alloc g * . m n_w 8 )
+    : GpuBuffer bmb ( gpu_alloc g * . m n_b 8 )
+    : GpuBuffer bvb ( gpu_alloc g * . m n_b 8 )
+    : GpuBuffer bgw ( gpu_alloc g * . m n_w 8 )
+    : GpuBuffer bgb ( gpu_alloc g * . m n_b 8 )
+    : GpuBuffer bacts ( gpu_alloc g * * rows . m n_a 8 )
+    : GpuBuffer bdeltas ( gpu_alloc g * * bsz . m n_a 8 )
+    : GpuBuffer bodt ( gpu_alloc g * * bsz dout 8 )
+    : GpuBuffer bode ( gpu_alloc g * * ch dout 8 )
+    : ~ b ok T
+    ? ( gpu_kernel_ok kfwd ) {} { = ok F }
+    ? ( gpu_kernel_ok kbwd ) {} { = ok F }
+    ? ( gpu_kernel_ok kgrad ) {} { = ok F }
+    ? ( gpu_kernel_ok kadam ) {} { = ok F }
+    ? ( gpu_kernel_ok kdiff ) {} { = ok F }
+    ? != . bmeta dptr 0 {} { = ok F }
+    ? != . bx dptr 0 {} { = ok F }
+    ? != . bidx dptr 0 {} { = ok F }
+    ? != . bw dptr 0 {} { = ok F }
+    ? != . bb2 dptr 0 {} { = ok F }
+    ? != . bacts dptr 0 {} { = ok F }
+    ? != . bdeltas dptr 0 {} { = ok F }
+    ? ok { ? != ( gpu_upload bmeta # *u ( vec_data [i] meta ) ) 0 { = ok F } {} } {}
+    ( vec_free [i] meta )
+    ^ @ AeGpu { ok g kfwd kbwd kgrad kadam kdiff bmeta bx bidx bw bb2 bmw bvw bmb bvb bgw bgb bacts bdeltas bodt bode }
+}
+
+// score.nu's kit (only valid when the engine probe succeeded).
+@ __an_gpukit_ref → *GpuKit { ^ ( anom_gpu_kit ) }
+
+// ── the mirrored trainer ──────────────────────────────────────────────
+// Exactly mlp_train, with the four per-minibatch compute steps and the
+// validation forward on the device. Returns MlpTrain; the model's w/b,
+// Adam state and t are updated in place, exactly as mlp_train leaves them.
+// On ANY device error sets *fail and returns immediately (the caller
+// discards everything and reruns on the CPU).
+@ _aeg_train AeGpu cx Mlp m ( Vec f ) X i n i d i dout MlpCfg cfg * u fail → MlpTrain {
+    : Rng g2 ( rng_seed . cfg seed )
+    : i oa2 ( _mlp_iget . m a_off . m n_layers )
+    // One shuffled split: [0, n_train) train, [n_train, n) validation.
+    : ( Vec i ) idx ( vec_iota 0 n )
+    : ~ i k0 0
+    ~ < k0 - n 1 {
+        : i j0 + k0 ( rng_below g2 - n k0 )
+        ( vec_swap [i] idx k0 j0 )
+        = k0 + k0 1
+    }
+    : ~ i n_val 0
+    ? . cfg early_stop {
+        = n_val # i ( round * . cfg val_frac # f n )
+        ? < n_val 1 { = n_val 1 } {}
+        ? >= n_val n { = n_val / n 5 } {}
+    } {}
+    : i n_train - n n_val
+    : ~ i bsz . cfg batch
+    ? <= bsz 0 { = bsz 200 } {}
+    ? > bsz n_train { = bsz n_train } {}
+    // Device state for THIS candidate: weights + zeroed Adam/grad state.
+    : ( Vec f ) zeros ( vec_with_cap [f] . m n_w )
+    : ~ i z 0
+    ~ < z . m n_w { ( vec_push [f] zeros 0.0 ) = z + z 1 }
+    : ~ i up 0
+    = up + up ( gpu_upload . cx bw # *u ( vec_data [f] . m w ) )
+    = up + up ( gpu_upload . cx bb # *u ( vec_data [f] . m b ) )
+    = up + up ( gpu_upload . cx bmw # *u ( vec_data [f] zeros ) )
+    = up + up ( gpu_upload . cx bvw # *u ( vec_data [f] zeros ) )
+    = up + up ( gpu_upload . cx bmb # *u ( vec_data [f] zeros ) )
+    = up + up ( gpu_upload . cx bvb # *u ( vec_data [f] zeros ) )
+    = up + up ( gpu_upload . cx bgw # *u ( vec_data [f] zeros ) )
+    = up + up ( gpu_upload . cx bgb # *u ( vec_data [f] zeros ) )
+    = up + up ( gpu_upload . cx bx # *u ( vec_data [f] X ) )
+    ( vec_free [f] zeros )
+    ? != up 0 {
+        ( nurl_poke fail 0 1 )
+        ( vec_free [i] idx ) ( rng_free g2 )
+        ^ @ MlpTrain { 0 0.0 0.0 F }
+    } {}
+    : ( Vec f ) best_w ( vec_with_cap [f] . m n_w )
+    : ( Vec f ) best_b ( vec_with_cap [f] . m n_b )
+    = z 0
+    ~ < z . m n_w { ( vec_push [f] best_w 0.0 ) = z + z 1 }
+    = z 0
+    ~ < z . m n_b { ( vec_push [f] best_b 0.0 ) = z + z 1 }
+    : i ch ( _aeg_eval_chunk )
+    : ( Vec f ) od ( vec_with_cap [f] * ? > bsz ch bsz ch dout )
+    = z 0
+    ~ < z * ? > bsz ch bsz ch dout { ( vec_push [f] od 0.0 ) = z + z 1 }
+    : i nparam + . m n_w . m n_b
+    : i pgrid ( gpu_grid nparam 256 )
+    : f alpha . cfg alpha
+    : ~ f fb0 0.0  // per-batch, set below
+    : ~ i tstep 0
+    : ~ f best 0.0
+    : ~ b have_best F
+    : ~ i bad 0
+    : ~ i epoch 0
+    : ~ f train_loss 0.0
+    : ~ b stopped F
+    : ~ i gerr 0
+    ~ & & < epoch . cfg max_iter ! stopped == gerr 0 {
+        // Shuffle the TRAIN region only; the val tail stays fixed.
+        : ~ i k 0
+        ~ < k - n_train 1 {
+            : i j + k ( rng_below g2 - n_train k )
+            ( vec_swap [i] idx k j )
+            = k + k 1
+        }
+        = gerr + gerr ( gpu_upload . cx bidx # *u ( vec_data [i] idx ) )
+        // Minibatch pass.
+        : ~ f se 0.0
+        : ~ i at 0
+        ~ & < at n_train == gerr 0 {
+            : ~ i bend + at bsz
+            ? > bend n_train { = bend n_train } {}
+            : i cnt - bend at
+            // forward + backprop + gradient + Adam, on the device
+            : ( Vec i ) a1 ( vec_new [i] )
+            ( vec_push [i] a1 ( gpu_arg_buffer . cx bmeta ) )
+            ( vec_push [i] a1 ( gpu_arg_buffer . cx bx ) )
+            ( vec_push [i] a1 ( gpu_arg_buffer . cx bidx ) )
+            ( vec_push [i] a1 ( gpu_arg_i64 at ) )
+            ( vec_push [i] a1 ( gpu_arg_i64 cnt ) )
+            ( vec_push [i] a1 ( gpu_arg_i64 d ) )
+            ( vec_push [i] a1 ( gpu_arg_buffer . cx bw ) )
+            ( vec_push [i] a1 ( gpu_arg_buffer . cx bb ) )
+            ( vec_push [i] a1 ( gpu_arg_buffer . cx bacts ) )
+            = gerr + gerr ( gpu_launch . cx kfwd cnt 64 a1 )
+            ( vec_free [i] a1 )
+            : ( Vec i ) a2 ( vec_new [i] )
+            ( vec_push [i] a2 ( gpu_arg_buffer . cx bmeta ) )
+            ( vec_push [i] a2 ( gpu_arg_buffer . cx bx ) )
+            ( vec_push [i] a2 ( gpu_arg_buffer . cx bidx ) )
+            ( vec_push [i] a2 ( gpu_arg_i64 at ) )
+            ( vec_push [i] a2 ( gpu_arg_i64 cnt ) )
+            ( vec_push [i] a2 ( gpu_arg_i64 dout ) )
+            ( vec_push [i] a2 ( gpu_arg_buffer . cx bw ) )
+            ( vec_push [i] a2 ( gpu_arg_buffer . cx bacts ) )
+            ( vec_push [i] a2 ( gpu_arg_buffer . cx bdeltas ) )
+            ( vec_push [i] a2 ( gpu_arg_buffer . cx bodt ) )
+            = gerr + gerr ( gpu_launch . cx kbwd cnt 64 a2 )
+            ( vec_free [i] a2 )
+            : ( Vec i ) a3 ( vec_new [i] )
+            ( vec_push [i] a3 ( gpu_arg_buffer . cx bmeta ) )
+            ( vec_push [i] a3 ( gpu_arg_i64 . m n_w ) )
+            ( vec_push [i] a3 ( gpu_arg_i64 . m n_b ) )
+            ( vec_push [i] a3 ( gpu_arg_i64 cnt ) )
+            ( vec_push [i] a3 ( gpu_arg_buffer . cx bacts ) )
+            ( vec_push [i] a3 ( gpu_arg_buffer . cx bdeltas ) )
+            ( vec_push [i] a3 ( gpu_arg_buffer . cx bgw ) )
+            ( vec_push [i] a3 ( gpu_arg_buffer . cx bgb ) )
+            = gerr + gerr ( gpu_launch . cx kgrad pgrid 256 a3 )
+            ( vec_free [i] a3 )
+            // Adam scalars on the host — exactly mlp's expressions.
+            = tstep + tstep 1
+            : f tf # f tstep
+            : f lrt * . cfg lr / ( sqrt - 1.0 ( pow 0.999 tf ) ) - 1.0 ( pow 0.9 tf )
+            = fb0 # f cnt
+            : ( Vec i ) a4 ( vec_new [i] )
+            ( vec_push [i] a4 ( gpu_arg_i64 . m n_w ) )
+            ( vec_push [i] a4 ( gpu_arg_i64 . m n_b ) )
+            ( vec_push [i] a4 ( gpu_arg_i64 ( f64_to_bits lrt ) ) )
+            ( vec_push [i] a4 ( gpu_arg_i64 ( f64_to_bits alpha ) ) )
+            ( vec_push [i] a4 ( gpu_arg_i64 ( f64_to_bits fb0 ) ) )
+            ( vec_push [i] a4 ( gpu_arg_buffer . cx bw ) )
+            ( vec_push [i] a4 ( gpu_arg_buffer . cx bb ) )
+            ( vec_push [i] a4 ( gpu_arg_buffer . cx bmw ) )
+            ( vec_push [i] a4 ( gpu_arg_buffer . cx bvw ) )
+            ( vec_push [i] a4 ( gpu_arg_buffer . cx bmb ) )
+            ( vec_push [i] a4 ( gpu_arg_buffer . cx bvb ) )
+            ( vec_push [i] a4 ( gpu_arg_buffer . cx bgw ) )
+            ( vec_push [i] a4 ( gpu_arg_buffer . cx bgb ) )
+            = gerr + gerr ( gpu_launch . cx kadam pgrid 256 a4 )
+            ( vec_free [i] a4 )
+            // the training-loss contribution, folded in the CPU's flat order
+            = gerr + gerr ( gpu_download # *u ( vec_data [f] od ) . cx bodt )
+            : ~ i s2 0
+            ~ < s2 cnt {
+                : ~ i j2 0
+                ~ < j2 dout {
+                    : f e ( _mlp_fget od + * s2 dout j2 )
+                    = se + se * e e
+                    = j2 + j2 1
+                }
+                = s2 + s2 1
+            }
+            = at bend
+        }
+        = train_loss / se # f * n_train dout
+        // The plateau criterion: validation MSE with early_stop, else the
+        // training loss.
+        : ~ f crit train_loss
+        ? & . cfg early_stop == gerr 0 {
+            : ~ f sev 0.0
+            : ~ i vat n_train
+            ~ & < vat n == gerr 0 {
+                : ~ i vend + vat ch
+                ? > vend n { = vend n } {}
+                : i vcnt - vend vat
+                : ( Vec i ) a5 ( vec_new [i] )
+                ( vec_push [i] a5 ( gpu_arg_buffer . cx bmeta ) )
+                ( vec_push [i] a5 ( gpu_arg_buffer . cx bx ) )
+                ( vec_push [i] a5 ( gpu_arg_buffer . cx bidx ) )
+                ( vec_push [i] a5 ( gpu_arg_i64 vat ) )
+                ( vec_push [i] a5 ( gpu_arg_i64 vcnt ) )
+                ( vec_push [i] a5 ( gpu_arg_i64 d ) )
+                ( vec_push [i] a5 ( gpu_arg_buffer . cx bw ) )
+                ( vec_push [i] a5 ( gpu_arg_buffer . cx bb ) )
+                ( vec_push [i] a5 ( gpu_arg_buffer . cx bacts ) )
+                = gerr + gerr ( gpu_launch . cx kfwd vcnt 64 a5 )
+                ( vec_free [i] a5 )
+                : ( Vec i ) a6 ( vec_new [i] )
+                ( vec_push [i] a6 ( gpu_arg_buffer . cx bmeta ) )
+                ( vec_push [i] a6 ( gpu_arg_buffer . cx bx ) )
+                ( vec_push [i] a6 ( gpu_arg_buffer . cx bidx ) )
+                ( vec_push [i] a6 ( gpu_arg_i64 vat ) )
+                ( vec_push [i] a6 ( gpu_arg_i64 vcnt ) )
+                ( vec_push [i] a6 ( gpu_arg_i64 dout ) )
+                ( vec_push [i] a6 ( gpu_arg_buffer . cx bacts ) )
+                ( vec_push [i] a6 ( gpu_arg_buffer . cx bode ) )
+                = gerr + gerr ( gpu_launch . cx kdiff vcnt 64 a6 )
+                ( vec_free [i] a6 )
+                = gerr + gerr ( gpu_download # *u ( vec_data [f] od ) . cx bode )
+                : ~ i s3 0
+                ~ < s3 vcnt {
+                    : ~ i j3 0
+                    ~ < j3 dout {
+                        : f e2 ( _mlp_fget od + * s3 dout j3 )
+                        = sev + sev * e2 e2
+                        = j3 + j3 1
+                    }
+                    = s3 + s3 1
+                }
+                = vat vend
+            }
+            = crit / sev # f * n_val dout
+        } {}
+        ? . cfg verbose {
+            ( nurl_print `epoch ` ) ( nurl_print_int + epoch 1 )
+            ( nurl_print ` train_mse ` ) ( nurl_print ( nurl_str_float train_loss ) )
+            ( nurl_print ` crit ` ) ( nurl_print ( nurl_str_float crit ) )
+            ( nurl_print `\n` )
+        } {}
+        ? == gerr 0 {
+            ? | ! have_best < crit - best . cfg tol {
+                = bad 0
+                ? | ! have_best < crit best { = best crit } {}
+                = have_best T
+                ? . cfg early_stop {
+                    = gerr + gerr ( gpu_download # *u ( vec_data [f] best_w ) . cx bw )
+                    = gerr + gerr ( gpu_download # *u ( vec_data [f] best_b ) . cx bb )
+                } {}
+            } {
+                = bad + bad 1
+                ? >= bad . cfg n_no_change { = stopped T } {}
+            }
+            = epoch + epoch 1
+        } {}
+    }
+    ? != gerr 0 {
+        ( nurl_poke fail 0 1 )
+        ( vec_free [f] best_w ) ( vec_free [f] best_b ) ( vec_free [f] od )
+        ( vec_free [i] idx ) ( rng_free g2 )
+        ^ @ MlpTrain { 0 0.0 0.0 F }
+    } {}
+    // Restore the best weights (early stopping keeps the best epoch, not
+    // the last); Adam state and t stay FINAL, exactly like mlp_train.
+    : ~ i derr 0
+    ? & . cfg early_stop have_best {
+        : ~ i c3 0
+        ~ < c3 . m n_w { ( vec_set [f] . m w c3 ( _mlp_fget best_w c3 ) ) = c3 + c3 1 }
+        = c3 0
+        ~ < c3 . m n_b { ( vec_set [f] . m b c3 ( _mlp_fget best_b c3 ) ) = c3 + c3 1 }
+    } {
+        = derr + derr ( gpu_download # *u ( vec_data [f] . m w ) . cx bw )
+        = derr + derr ( gpu_download # *u ( vec_data [f] . m b ) . cx bb )
+    }
+    = derr + derr ( gpu_download # *u ( vec_data [f] . m mw ) . cx bmw )
+    = derr + derr ( gpu_download # *u ( vec_data [f] . m vw ) . cx bvw )
+    = derr + derr ( gpu_download # *u ( vec_data [f] . m mb ) . cx bmb )
+    = derr + derr ( gpu_download # *u ( vec_data [f] . m vb ) . cx bvb )
+    ? != derr 0 { ( nurl_poke fail 0 1 ) } {}
+    ( vec_free [f] best_w ) ( vec_free [f] best_b ) ( vec_free [f] od )
+    ( vec_free [i] idx ) ( rng_free g2 )
+    ^ @ MlpTrain { epoch train_loss best stopped }
+}
+
+// ── the public entry: mlp_fit, GPU when a CUDA device is present ─────
+// Bit-identical to ( mlp_fit sizes X n d X d cfg restarts ) — the
+// autoencoder case (target == input). Falls back to mlp_fit whenever the
+// engine is not `cuda` or any device step fails.
+@ aegpu_fit ( Vec i ) sizes ( Vec f ) X i n i d MlpCfg cfg i restarts → MlpFit {
+    ? == ( nurl_str_eq ( anom_gpu_engine ) `cuda` ) 1 {} {
+        ^ ( mlp_fit sizes X n d X d cfg restarts )
+    }
+    // The batch size is data-dependent but restart-independent: compute it
+    // once for the buffer sizing (mirrors mlp_train's own derivation).
+    : ~ i n_val 0
+    ? . cfg early_stop {
+        = n_val # i ( round * . cfg val_frac # f n )
+        ? < n_val 1 { = n_val 1 } {}
+        ? >= n_val n { = n_val / n 5 } {}
+    } {}
+    : i n_train - n n_val
+    : ~ i bsz . cfg batch
+    ? <= bsz 0 { = bsz 200 } {}
+    ? > bsz n_train { = bsz n_train } {}
+    : ~ i r2 restarts
+    ? < r2 1 { = r2 1 } {}
+    // First candidate sizes the context (every restart shares the topology).
+    : ~ Mlp best_m ( mlp_new sizes . cfg seed )
+    : AeGpu cx ( _aeg_open best_m n d d bsz )
+    ? . cx ok {} {
+        ( _aeg_free cx )
+        ( mlp_free best_m )
+        ( nurl_eprintln `anomaly: autoencoder GPU setup failed, training on the CPU` )
+        ^ ( mlp_fit sizes X n d X d cfg restarts )
+    }
+    : *u fail ( nurl_alloc 8 )
+    ( nurl_poke fail 0 0 )
+    : ~ MlpTrain best_tr ( _aeg_train cx best_m X n d d cfg fail )
+    : ~ i r 1
+    ~ & < r r2 == ( nurl_peek fail 0 ) 0 {
+        : ~ MlpCfg c cfg
+        = . c seed + . cfg seed r
+        : Mlp m ( mlp_new sizes . c seed )
+        : MlpTrain tr ( _aeg_train cx m X n d d c fail )
+        ? & == ( nurl_peek fail 0 ) 0 < . tr best_val . best_tr best_val {
+            ( mlp_free best_m )
+            = best_m m
+            = best_tr tr
+        } {
+            ( mlp_free m )
+        }
+        = r + r 1
+    }
+    ( _aeg_free cx )
+    : i failed ( nurl_peek fail 0 )
+    ( nurl_free fail )
+    ? != failed 0 {
+        ( mlp_free best_m )
+        ( nurl_eprintln `anomaly: autoencoder GPU training failed, retraining on the CPU` )
+        ^ ( mlp_fit sizes X n d X d cfg restarts )
+    } {}
+    ^ @ MlpFit { best_m best_tr }
+}

--- a/packages/anomaly/src/autoenc.nu
+++ b/packages/anomaly/src/autoenc.nu
@@ -33,6 +33,7 @@ $ `stdlib/ext/json.nu`
 $ `src/prep.nu`
 $ `src/model.nu`
 $ `src/score.nu`
+$ `src/aegpu.nu`
 $ `deps/mlp/src/mlp.nu`
 
 // ── The trained artifact ──────────────────────────────────────────────
@@ -154,7 +155,9 @@ $ `deps/mlp/src/mlp.nu`
     }
     ( vec_push [i] sz d )
     : ~ MlpCfg cfg ( mlp_cfg_default )
-    : MlpFit fit ( mlp_fit sz Xn nk d Xn d cfg 3 )
+    // GPU when a CUDA device is present, CPU otherwise — bit-identical either
+    // way (aegpu.nu), so the backend can never change the trained model.
+    : MlpFit fit ( aegpu_fit sz Xn nk d cfg 3 )
     ( vec_free [i] sz )
 
     // 3. threshold = p95 (nearest-rank) of the training errors.

--- a/packages/anomaly/src/score.nu
+++ b/packages/anomaly/src/score.nu
@@ -116,6 +116,11 @@ $ `deps/gpukit/src/gpukit.nu`
 // The live kit (only valid when g_ag_state == 1).
 @ __ag_kit → *GpuKit { ^ # *GpuKit g_ag_kit }
 
+// Public view of the kit for sibling modules (aegpu.nu shares the device —
+// __-prefixed functions are file-scoped). Only valid after anom_gpu_engine
+// reported `cuda` or `cpu`.
+@ anom_gpu_kit → *GpuKit { ^ # *GpuKit g_ag_kit }
+
 // Release the device + kernel cache (tests call this so leak checkers see a
 // closed shop; a long-running service just keeps the singleton).
 @ anom_gpu_close → v {

--- a/packages/anomaly/tests/aegpu_parity_test.nu
+++ b/packages/anomaly/tests/aegpu_parity_test.nu
@@ -1,0 +1,73 @@
+// packages/anomaly/tests/aegpu_parity_test.nu — the autoencoder GPU-training
+// parity gate. Trains the SAME data with mlp_fit (CPU) and aegpu_fit (GPU)
+// and asserts the results are BIT-IDENTICAL: weights, biases, the full Adam
+// state, epoch count, and both loss figures. This is the proof behind the
+// package's guarantee that backend choice can never change a result — the
+// GPU path is pure speed. Prints both wall times as a bonus.
+//
+// Needs a CUDA device (aegpu_fit falls back to mlp_fit without one, which
+// would make the comparison trivially true) — the .sh wrapper skips cleanly
+// on machines without one. Run from the package root:
+//   NURL_STDLIB=<repo> ../../nurl.sh tests/aegpu_parity_test.nu /tmp/aep && /tmp/aep
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/rng.nu`
+$ `stdlib/std/floatbits.nu`
+$ `src/aegpu.nu`
+$ `deps/mlp/src/mlp.nu`
+
+@ veq s label ( Vec f ) a ( Vec f ) b → b {
+    : i n ( vec_len [f] a )
+    ? != n ( vec_len [f] b ) { ( nurl_print label ) ( nurl_print ` LEN MISMATCH\n` ) ^ F } {}
+    : ~ i bad 0
+    : ~ i k 0
+    ~ < k n {
+        ? != ( f64_to_bits ( _mlp_fget a k ) ) ( f64_to_bits ( _mlp_fget b k ) ) { = bad + bad 1 } {}
+        = k + k 1
+    }
+    ( nurl_print label )
+    ? == bad 0 { ( nurl_print ` BIT-EXACT (` ) ( nurl_print_int n ) ( nurl_print ` values)\n` ) ^ T } {
+        ( nurl_print ` MISMATCH: ` ) ( nurl_print_int bad ) ( nurl_print ` of ` ) ( nurl_print_int n ) ( nurl_print `\n` ) ^ F
+    }
+}
+
+@ main → i {
+    : i n 6000
+    : i d 12
+    : Rng g ( rng_seed 99 )
+    : ( Vec f ) X ( vec_with_cap [f] * n d )
+    : ~ i k 0
+    ~ < k * n d { ( vec_push [f] X ( rng_u01 g ) ) = k + k 1 }
+    ( rng_free g )
+    : ( Vec i ) sz ( vec_new [i] )
+    ( vec_push [i] sz d ) ( vec_push [i] sz 64 ) ( vec_push [i] sz 32 ) ( vec_push [i] sz 64 ) ( vec_push [i] sz d )
+    : MlpCfg cfg ( mlp_cfg_default )
+    ( nurl_print `engine: ` ) ( nurl_print ( anom_gpu_engine ) ) ( nurl_print `\n` )
+    : i t0 ( monotonic_ns )
+    : MlpFit cpu ( mlp_fit sz X n d X d cfg 3 )
+    : i t1 ( monotonic_ns )
+    : MlpFit gpu ( aegpu_fit sz X n d cfg 3 )
+    : i t2 ( monotonic_ns )
+    ( nurl_print `cpu mlp_fit:  ` ) ( nurl_print_int / - t1 t0 1000000 ) ( nurl_print ` ms\n` )
+    ( nurl_print `gpu aegpu_fit: ` ) ( nurl_print_int / - t2 t1 1000000 ) ( nurl_print ` ms\n` )
+    : Mlp cm . cpu model
+    : Mlp gm . gpu model
+    : MlpTrain cr . cpu report
+    : MlpTrain gr . gpu report
+    : ~ b ok T
+    ? ( veq `weights:` . cm w . gm w ) {} { = ok F }
+    ? ( veq `biases: ` . cm b . gm b ) {} { = ok F }
+    ? ( veq `adam mw:` . cm mw . gm mw ) {} { = ok F }
+    ? ( veq `adam vw:` . cm vw . gm vw ) {} { = ok F }
+    ? ( veq `adam mb:` . cm mb . gm mb ) {} { = ok F }
+    ? ( veq `adam vb:` . cm vb . gm vb ) {} { = ok F }
+    ? == . cr n_iter . gr n_iter { ( nurl_print `n_iter: EQUAL\n` ) } { ( nurl_print `n_iter: MISMATCH\n` ) = ok F }
+    ? == ( f64_to_bits . cr best_val ) ( f64_to_bits . gr best_val ) { ( nurl_print `best_val: BIT-EXACT\n` ) } { ( nurl_print `best_val: MISMATCH\n` ) = ok F }
+    ? == ( f64_to_bits . cr loss ) ( f64_to_bits . gr loss ) { ( nurl_print `loss: BIT-EXACT\n` ) } { ( nurl_print `loss: MISMATCH\n` ) = ok F }
+    ( mlp_free cm ) ( mlp_free gm )
+    ( vec_free [f] X ) ( vec_free [i] sz )
+    ( anom_gpu_close )
+    ? ok { ( nurl_print `PARITY: ALL BIT-EXACT\n` ) ^ 0 } { ( nurl_print `PARITY: FAILED\n` ) ^ 1 }
+}

--- a/packages/anomaly/tests/aegpu_smoke.sh
+++ b/packages/anomaly/tests/aegpu_smoke.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# packages/anomaly/tests/aegpu_smoke.sh — GPU autoencoder training: the
+# bit-exact parity gate (aegpu_parity_test.nu) on real hardware.
+# Skips (exit 0) without an NVIDIA GPU.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+export NURL_STDLIB="$REPO"
+if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi -L >/dev/null 2>&1; then
+    echo "[aegpu-smoke] SKIP — no NVIDIA GPU visible"; exit 0
+fi
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cd "$HERE"
+"$REPO/nurl.sh" tests/aegpu_parity_test.nu "$TMP/aep" >/dev/null 2>&1 || { echo "[aegpu-smoke] FAIL build"; exit 1; }
+if "$TMP/aep"; then echo "[aegpu-smoke] ALL PASS"; else echo "[aegpu-smoke] FAILURES"; exit 1; fi

--- a/packages/mlp/CHANGELOG.md
+++ b/packages/mlp/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.2.0
+
+**Fixed: Adam's bias correction was frozen at t = 1.** `__mlp_adam` kept its
+step counter as a scalar field on the `Mlp` struct — but NURL structs pass by
+value (only their `Vec` fields alias), so `= . m t + . m t 1` incremented a
+copy and the counter never advanced. Every minibatch after the first ran with
+the t = 1 correction, i.e. a permanently inflated effective learning rate
+(lr·√(1−β₂)/(1−β₁) ≈ 0.316·lr·√10 instead of the documented, sklearn-matching
+schedule that decays toward lr).
+
+- The step count now lives in `mlp_train` as a local and is passed to the
+  Adam step explicitly; the vestigial `t` field is removed from `Mlp` (nothing
+  outside the Adam step ever read it, and `mlp_save` never persisted it).
+- **Trained networks change** versus 0.1.x for any multi-batch training run —
+  that is the fix. The sklearn oracle still passes with 100 % outlier-flag
+  agreement (and a tighter MSE ratio); persisted models load unchanged
+  (`mlp_save`/`mlp_load` round-trip only sizes + weights).
+- Found by the `anomaly` package's GPU-training parity work: a bit-exact GPU
+  mirror of `mlp_train` disagreed with the CPU only from the second minibatch
+  on, and the diff isolated the frozen counter.
+
 ## 0.1.0
 
 Initial release — a trainable MLP in pure NURL, faithful to sklearn's

--- a/packages/mlp/nurl.toml
+++ b/packages/mlp/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlp"
-version = "0.1.0"
+version = "0.2.0"
 description = "Trainable multi-layer perceptron in pure NURL — dense layers, ReLU, Adam, minibatches, early stopping. The training-side counterpart to the ecosystem's inference packages: a seedable, deterministic MLP regressor faithful to sklearn's MLPRegressor semantics (Glorot init, squared loss with L2, Adam bias correction, validation-split early stopping with best-weight restore), plus a MinMax scaler. An autoencoder is just mlp_train with X as both input and target — reconstruction-error anomaly detection, embeddings, denoising. Models and scalers persist to JSON with bit-exact f64 round-trip. No BLAS, no GPU required: flat buffers and tight loops, fast enough for the tabular/streaming workloads it is built for."
 license = "MIT OR Apache-2.0"
 

--- a/packages/mlp/src/mlp.nu
+++ b/packages/mlp/src/mlp.nu
@@ -56,7 +56,6 @@ $ `stdlib/ext/json.nu`
     ( Vec f ) vw
     ( Vec f ) mb
     ( Vec f ) vb
-    i t  // Adam step counter
 }
 
 : MlpCfg {
@@ -165,7 +164,7 @@ $ `stdlib/ext/json.nu`
     }
     ( rng_free g )
     ^ @ Mlp { nl sz woff boff aoff nw nb na w b
-        ( __zeros nw ) ( __zeros nw ) ( __zeros nb ) ( __zeros nb ) 0 }
+        ( __zeros nw ) ( __zeros nw ) ( __zeros nb ) ( __zeros nb ) }
 }
 
 @ mlp_cfg_default → MlpCfg {
@@ -332,9 +331,12 @@ $ `stdlib/ext/json.nu`
 // One Adam update from gradient sums over a batch of `bsz` samples:
 // g = (Σg + α·param) / bsz for weights (sklearn adds the L2 term before
 // the batch divide), g = Σg / bsz for biases. Zeroes gw / gb after.
-@ __mlp_adam Mlp m ( Vec f ) gw ( Vec f ) gb i bsz f lr f alpha → v {
-    = . m t + . m t 1
-    : f t # f . m t
+// `tstep` is the 1-based Adam step count, owned by mlp_train: NURL structs
+// pass by value (only their Vec fields alias), so a counter FIELD on Mlp
+// could never advance across calls — it silently froze the bias correction
+// at t = 1 for every batch after the first.
+@ __mlp_adam Mlp m ( Vec f ) gw ( Vec f ) gb i bsz f lr f alpha i tstep → v {
+    : f t # f tstep
     : f b1 0.9
     : f b2 0.999
     : f eps 0.00000001
@@ -422,6 +424,7 @@ $ `stdlib/ext/json.nu`
     : ~ i epoch 0
     : ~ f train_loss 0.0
     : ~ b stopped F
+    : ~ i adam_t 0  // Adam step count (see __mlp_adam)
     ~ & < epoch . cfg max_iter ! stopped {
         // Shuffle the TRAIN region only; the val tail stays fixed.
         : ~ i k 0
@@ -451,7 +454,8 @@ $ `stdlib/ext/json.nu`
                 ( __mlp_backprop m acts yp * r dout deltas gw gb )
                 = s + s 1
             }
-            ( __mlp_adam m gw gb - bend at . cfg lr . cfg alpha )
+            = adam_t + adam_t 1
+            ( __mlp_adam m gw gb - bend at . cfg lr . cfg alpha adam_t )
             = at bend
         }
         = train_loss / se # f * n_train dout


### PR DESCRIPTION
## What

The anomaly package's **autoencoder now trains on the GPU by default** when a CUDA device is present, with the CPU (`mlp_fit`) as the fallback — and the package's standing guarantee holds: **backend choice can never change a result**. The GPU-trained network is **bit-for-bit identical** to the CPU-trained one (weights, biases, full Adam state, epoch count, losses), so GPU is pure speed: **~34×** on the parity benchmark (6 k × 12, 64-32-64, 3 restarts: **7.6 s → 0.22 s** on an RTX 4090). Training is where the autoencoder's time goes (~20 s for 20 k rows on CPU; the scoring passes are milliseconds), so this is the part worth accelerating — single-point detection stays on the CPU where latency wins.

## How bit-exactness is achieved (`anomaly/src/aegpu.nu`)

- **Control flow stays on the host** and mirrors `mlp_train` exactly: seeded PRNG call order (init, the one full shuffle, per-epoch train-region shuffles), validation split, minibatch bounds, early stopping/patience/best-weights restore, restarts, and Adam's scalars (`lr_t` via host `pow`/`sqrt`, shipped to the kernel as data — no transcendental runs on the device).
- **Five kernels** (forward / backprop / gradient / Adam / eval-diff) reproduce the CPU's floating-point **rounding and order**: explicit `__dadd_rn`/`__dmul_rn`/`__dsub_rn` (NVRTC's default FMA contraction would change results), dot products serial in the CPU's k-order, per-weight gradient sums walking batch rows in the CPU's row order; loss sums come back as per-element diffs and fold on the host in the CPU's flat order.
- Weights + Adam state stay **device-resident** across the whole run. Any failure at any stage falls back to `mlp_fit` — identical results at CPU pace. `ANOMALY_GPU=0` opts out.

## The bug this uncovered — mlp 0.2.0

The first parity run disagreed from the **second minibatch on**, and the bisect landed on a real bug in the published mlp package: **Adam's bias correction was frozen at t = 1**. `__mlp_adam` kept its step counter as a scalar field on the by-value `Mlp` struct — NURL structs pass by value and only their `Vec` fields alias, so `= . m t + . m t 1` incremented a copy and the counter never advanced. Every batch after the first trained with a permanently inflated effective learning rate instead of the documented, sklearn-matching schedule.

Fix: the step count lives in `mlp_train` as a local and is passed to the Adam step explicitly; the vestigial `t` field is removed (nothing else read it; `mlp_save` never persisted it). **Trained networks change vs 0.1.x for multi-batch runs — that is the fix.** The sklearn oracle still passes with **100 % outlier-flag agreement** (MSE ratio 2.02×, within its 5× bound).

## Verification

- `tests/aegpu_parity_test.nu` + `tests/aegpu_smoke.sh` (skips without a GPU): **PARITY: ALL BIT-EXACT** — weights, biases, `mw`/`vw`/`mb`/`vb`, `n_iter`, `best_val`, `loss`.
- mlp unit tests ALL PASS; sklearn oracle PASS (100 % agreement).
- anomaly full suite **30/30**; `autoencoder_test` **15/15 on both engines** (its one pre-existing flake turned out to be a stale `./anomaly_ae_test` dir from prior manual runs, not code).
- Both packages build on the released v0.21.0 toolchain. `anomaly` requires `mlp ^0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)