### PR TITLE
fix(mlp): declare the direct tensor dependency

### DIFF
--- a/packages/mlp/nurl.toml
+++ b/packages/mlp/nurl.toml
@@ -6,3 +6,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 grad = "^0.1"
+tensor = "^0.4"


### PR DESCRIPTION
src/gradfit.nu imports deps/tensor/src/tensor.nu directly (tensor_of /
tensor_free for building tape inputs), so tensor must be declared in
[dependencies] — relying on it arriving transitively through grad breaks
the moment grad reorganizes its own deps. Caught by nurlpkg's
undeclared-import gate at publish time; the published mlp 0.3.0 tarball
already carries this manifest.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WX2frzGUucJVZjARF389im
