### PR TITLE
grad 0.3.0: requires-grad propagation on both engines (M6b prep)

### DIFF
--- a/packages/grad/CHANGELOG.md
+++ b/packages/grad/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.3.0
+
+**Requires-grad propagation (PyTorch's rule), on both engines.** A node
+gets a gradient only if a PARAMETER lies in its ancestor cone. `backward`
+computes a need set before the sweep and neither processes nodes outside
+it nor accumulates into no-need inputs; the device engine additionally
+allocates gradient BUFFERS only for backward-active nodes. Consequences:
+
+- A frozen-const branch now costs nothing: no backward compute, no
+  gradient memory. For LoRA over a large frozen model this is the
+  difference between duplicating every base weight's size in gradient
+  buffers (plus a full dW matmul per step for weights nobody updates)
+  and paying only for the adapters. Parameter gradients and optimizer
+  trajectories are bit-identical to 0.2.0 — const-side gradients never
+  influenced them (leaves propagate nothing).
+- Observable change: `grad_of` on an intermediate node with no parameter
+  upstream now reports zeros (previously the true local gradient). The
+  device engine's `gput_grad` mirrors that exactly.
+- The const-zeroing backward epilogue is gone — nothing writes into
+  no-need slots in the first place.
+
+**The M6a LoRA transformer-block proof** (tests only): a Qwen2-style block
+— RMSNorm, GQA attention with q/k/v bias + NEOX rotary embeddings + causal
+mask, SwiGLU, lm_head, softmax cross-entropy — with LoRA pairs on
+q/k/v/o/gate/up/down as the only parameters, expressed ENTIRELY in
+existing ops (row reductions via ones-matmul, rotate-half via slice+concat,
+GQA via per-head slices, CE pick via one-hot). Proven by finite differences
+through the whole block (2e-7), the PEFT B=0 identity to the bit, a PyTorch
+float64 oracle fed bit patterns (loss 3e-16, grads 1e-13), device replay
+(bitwise on the CPU backend, 4e-14 on CUDA), and a 60-step on-device Adam
+run (CE 2.65 → 0.92).
+
 ## 0.2.0
 
 **The GPU replay engine (`src/gput.nu`) — device training, bit-exact.**

--- a/packages/grad/README.md
+++ b/packages/grad/README.md
@@ -111,6 +111,11 @@ Device restrictions (capture fails closed, with a message): TE_F64 tapes;
 A shape mismatch **poisons the tape** (`tape_ok` → `F`, `backward` refuses)
 rather than half-computing.
 
+Gradients follow **requires-grad propagation** (PyTorch's rule): they are
+computed and stored only where a parameter lies upstream. Frozen-const
+branches — a LoRA base model, input batches — cost no backward compute and
+no gradient memory on either engine; `grad_of` on such nodes reports zeros.
+
 ## Verification
 
 Every backward rule is checked several independent ways:

--- a/packages/grad/nurl.toml
+++ b/packages/grad/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grad"
-version = "0.2.0"
+version = "0.3.0"
 description = "Reverse-mode automatic differentiation over the tensor package — the training keystone. Build a computation eagerly with tape-recording ops (g_add, g_matmul, g_relu, ...) that mirror tensor's surface, call backward(loss) once, and read exact gradients for every registered parameter: backward passes are derived, not hand-written. The tape is a flat single-owner arena (indices as edges, deterministic reverse order, no per-node closures): it owns every intermediate and gradient, one tape_free releases everything, and tape_reset_to keeps the parameters while dropping the episode so a minibatch loop never re-mallocs. Ships SGD/Adam optimizers over the parameter list. Every backward rule is verified three independent ways: a central finite-difference harness, hand-derived analytic identities, and a PyTorch float64 oracle fed bit patterns. A GPU replay engine (gput_capture) mirrors a recorded episode onto the device — one kernel launch per node, device-resident Adam/SGD — under the ecosystem's bit-exactness discipline: the relu/linear-algebra tier is bit-identical to the CPU tape on CUDA and the CPU backend alike (a whole autoencoder trains to bit-equal weights, ~5x wall clock), transcendentals within an ulp on CUDA."
 license = "MIT OR Apache-2.0"
 

--- a/packages/grad/src/gput.nu
+++ b/packages/grad/src/gput.nu
@@ -516,7 +516,10 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
     ? & ( tape_ok tp ) >= . loss id 0 {} { ( _gp_fail pg `tape is poisoned or loss invalid` ) ^ pg }
     ? ( gk_ok kit ) {} { ( _gp_fail pg `no device` ) ^ pg }
     : i nn ( tape_len tp )
-    // reach = loss-ancestor set (mirrors "grad exists" on the CPU sweep)
+    // reach = loss-ancestor set; need = requires-grad propagation (a param
+    // in the ancestor cone). The backward sweep and the gradient BUFFERS
+    // exist only where both hold — grad.nu's rule mirrored, and a frozen
+    // 4 GB const costs no device gradient memory and no backward launch.
     : ( Vec i ) reach ( vec_new [i] )
     : ~ i k 0
     ~ < k nn { ( vec_push [i] reach 0 ) = k + k 1 }
@@ -530,6 +533,37 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         } {}
         = k - k 1
     }
+    : ( Vec i ) needv ( vec_new [i] )
+    = k 0
+    ~ < k nn {
+        : GNode nd ?? ( vec_get [GNode] . tp nodes k ) { T x → x F → @ GNode { -1 -1 -1 0.0 } }
+        : ~ i nv 0
+        ? == . nd op ( gop_param ) { = nv 1 } {
+            ? & >= . nd a 0 == ( _ti needv . nd a ) 1 { = nv 1 } {}
+            ? & >= . nd b 0 == ( _ti needv . nd b ) 1 { = nv 1 } {}
+        }
+        ( vec_push [i] needv nv )
+        // the stored per-node flag = BW-active (reach AND need)
+        ? & == ( _ti reach k ) 1 == nv 1 {} { ( vec_set [i] reach k 0 ) }
+        = k + k 1
+    }
+    ( vec_free [i] needv )
+    // gbuf = which nodes get a gradient BUFFER: every BW-active node, plus
+    // both inputs of a BW-active concat (its fused backward kernel writes
+    // both sides; an inactive side's buffer is pure workspace — gput_grad
+    // still reports zeros for it, like the CPU tape)
+    : ( Vec i ) gbuf ( vec_new [i] )
+    = k 0
+    ~ < k nn { ( vec_push [i] gbuf ( _ti reach k ) ) = k + k 1 }
+    = k 0
+    ~ < k nn {
+        : GNode nd ?? ( vec_get [GNode] . tp nodes k ) { T x → x F → @ GNode { -1 -1 -1 0.0 } }
+        ? & == . nd op ( gop_concat ) == ( _ti reach k ) 1 {
+            ( vec_set [i] gbuf . nd a 1 )
+            ( vec_set [i] gbuf . nd b 1 )
+        } {}
+        = k + k 1
+    }
     = k 0
     ~ & < k nn . pg ok {
         : GNode nd ?? ( vec_get [GNode] . tp nodes k ) { T x → x F → @ GNode { -1 -1 -1 0.0 } }
@@ -537,11 +571,15 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         ? == . tv dtype TE_F64 {} { ( _gp_fail pg `only TE_F64 tapes` ) }
         : i n ( vec_len [f] . tv data )
         : GkBuf val ( _gp_upload_tensor kit tv )
-        : GkBuf grad ( gk_dbuf_new kit n GK_F64 )
+        : ~ GkBuf grad ( _gp_nobuf )
+        ? == ( _ti gbuf k ) 1 { = grad ( gk_dbuf_new kit n GK_F64 ) } {}
         : ~ GkBuf scr ( _gp_nobuf )
         : ~ GkBuf meta ( _gp_nobuf )
         : ( Vec i ) dims ( vec_new [i] )
-        ? & ( gk_buf_ok val ) ( gk_buf_ok grad ) {} { ( _gp_fail pg `device alloc failed` ) }
+        ? ( gk_buf_ok val ) {} { ( _gp_fail pg `device alloc failed` ) }
+        ? == ( _ti gbuf k ) 1 {
+            ? ( gk_buf_ok grad ) {} { ( _gp_fail pg `device alloc failed` ) }
+        } {}
         : i op . nd op
         ? & >= op ( gop_add ) <= op ( gop_div ) {
             // binop: ew blocks B0(fwd) B1(g,b) B2(g,a) B3(g,g) + accred A/B
@@ -649,6 +687,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         = k + k 1
     }
     ( vec_free [i] reach )
+    ( vec_free [i] gbuf )
     ^ pg
 }
 
@@ -918,26 +957,36 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         : i offBB ( _ti . nd dims 4 )
         : i tfa ( _ti . nd dims 5 )
         : i tfb ( _ti . nd dims 6 )
+        : b needa == . na reach 1
+        : b needb == . nb reach 1
         ? == op ( gop_add ) {
-            = r & r ( _gp_accred pg na nd . nd grad offBA tfa 1.0 )
-            = r & r ( _gp_accred pg nb nd . nd grad offBB tfb 1.0 )
+            ? needa { = r & r ( _gp_accred pg na nd . nd grad offBA tfa 1.0 ) } {}
+            ? needb { = r & r ( _gp_accred pg nb nd . nd grad offBB tfb 1.0 ) } {}
         } {}
         ? == op ( gop_sub ) {
-            = r & r ( _gp_accred pg na nd . nd grad offBA tfa 1.0 )
-            = r & r ( _gp_accred pg nb nd . nd grad offBB tfb -1.0 )
+            ? needa { = r & r ( _gp_accred pg na nd . nd grad offBA tfa 1.0 ) } {}
+            ? needb { = r & r ( _gp_accred pg nb nd . nd grad offBB tfb -1.0 ) } {}
         } {}
         ? == op ( gop_mul ) {
-            = r & r ( _gp_scr_ew pg nd . nd grad . nb val offB1 ( gop_mul ) )
-            = r & r ( _gp_accred pg na nd . nd scr offBA tfa 1.0 )
-            = r & r ( _gp_scr_ew pg nd . nd grad . na val offB2 ( gop_mul ) )
-            = r & r ( _gp_accred pg nb nd . nd scr offBB tfb 1.0 )
+            ? needa {
+                = r & r ( _gp_scr_ew pg nd . nd grad . nb val offB1 ( gop_mul ) )
+                = r & r ( _gp_accred pg na nd . nd scr offBA tfa 1.0 )
+            } {}
+            ? needb {
+                = r & r ( _gp_scr_ew pg nd . nd grad . na val offB2 ( gop_mul ) )
+                = r & r ( _gp_accred pg nb nd . nd scr offBB tfb 1.0 )
+            } {}
         } {}
         ? == op ( gop_div ) {
-            = r & r ( _gp_scr_ew pg nd . nd grad . nb val offB1 ( gop_div ) )
-            = r & r ( _gp_accred pg na nd . nd scr offBA tfa 1.0 )
-            = r & r ( _gp_scr_ew pg nd . nd grad . nd val offB3 ( gop_mul ) )
-            = r & r ( _gp_scr_ew pg nd . nd scr . nb val offB1 ( gop_div ) )
-            = r & r ( _gp_accred pg nb nd . nd scr offBB tfb -1.0 )
+            ? needa {
+                = r & r ( _gp_scr_ew pg nd . nd grad . nb val offB1 ( gop_div ) )
+                = r & r ( _gp_accred pg na nd . nd scr offBA tfa 1.0 )
+            } {}
+            ? needb {
+                = r & r ( _gp_scr_ew pg nd . nd grad . nd val offB3 ( gop_mul ) )
+                = r & r ( _gp_scr_ew pg nd . nd scr . nb val offB1 ( gop_div ) )
+                = r & r ( _gp_accred pg nb nd . nd scr offBB tfb -1.0 )
+            } {}
         } {}
         ^ r
     } {}
@@ -979,7 +1028,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         ( vec_push [i] a ( gpu_arg_i64 M ) )
         ( vec_push [i] a ( gpu_arg_i64 K ) )
         ( vec_push [i] a ( gpu_arg_i64 N2 ) )
-        = r ( _gp_run pg `gp_bw_mm_a` ( gk_grid * M K 256 ) 256 a )
+        ? == . na reach 1 { = r ( _gp_run pg `gp_bw_mm_a` ( gk_grid * M K 256 ) 256 a ) } {}
         ( vec_free [i] a )
         : ( Vec i ) a2 ( vec_new [i] )
         ( vec_push [i] a2 ( gk_arg_dev . nb grad ) )
@@ -988,7 +1037,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         ( vec_push [i] a2 ( gpu_arg_i64 M ) )
         ( vec_push [i] a2 ( gpu_arg_i64 K ) )
         ( vec_push [i] a2 ( gpu_arg_i64 N2 ) )
-        = r & r ( _gp_run pg `gp_bw_mm_b` ( gk_grid * K N2 256 ) 256 a2 )
+        ? == . nb reach 1 { = r & r ( _gp_run pg `gp_bw_mm_b` ( gk_grid * K N2 256 ) 256 a2 ) } {}
         ( vec_free [i] a2 )
         ^ r
     } {}
@@ -1007,7 +1056,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         ( vec_push [i] a ( gpu_arg_i64 M ) )
         ( vec_push [i] a ( gpu_arg_i64 K ) )
         ( vec_push [i] a ( gpu_arg_i64 N2 ) )
-        = r ( _gp_run pg `gp_bw_bmm_a` ( gk_grid * B2 * M K 256 ) 256 a )
+        ? == . na reach 1 { = r ( _gp_run pg `gp_bw_bmm_a` ( gk_grid * B2 * M K 256 ) 256 a ) } {}
         ( vec_free [i] a )
         : ( Vec i ) a2 ( vec_new [i] )
         ( vec_push [i] a2 ( gk_arg_dev . nb grad ) )
@@ -1017,7 +1066,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         ( vec_push [i] a2 ( gpu_arg_i64 M ) )
         ( vec_push [i] a2 ( gpu_arg_i64 K ) )
         ( vec_push [i] a2 ( gpu_arg_i64 N2 ) )
-        = r & r ( _gp_run pg `gp_bw_bmm_b` ( gk_grid * B2 * K N2 256 ) 256 a2 )
+        ? == . nb reach 1 { = r & r ( _gp_run pg `gp_bw_bmm_b` ( gk_grid * B2 * K N2 256 ) 256 a2 ) } {}
         ( vec_free [i] a2 )
         ^ r
     } {}
@@ -1097,24 +1146,19 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
     : ~ i k 0
     ~ & < k n r {
         : GpNode nd ( _gp_node pg k )
-        = r ( _gp_fill_buf pg . nd grad 0.0 )
+        : GkBuf gb2 . nd grad
+        ? ( gk_buf_ok gb2 ) { = r ( _gp_fill_buf pg gb2 0.0 ) } {}
         = k + k 1
     }
     ? r {
         : GpNode lo ( _gp_node pg . pg loss )
-        = r ( _gp_fill_buf pg . lo grad 1.0 )
+        : GkBuf lg . lo grad
+        ? ( gk_buf_ok lg ) { = r ( _gp_fill_buf pg lg 1.0 ) } {}
     } {}
     = k . pg loss
     ~ & >= k 0 r {
         = r ( _gp_bwd_node pg k )
         = k - k 1
-    }
-    // epilogue: constants report zero gradients
-    = k 0
-    ~ & <= k . pg loss r {
-        : GpNode nd ( _gp_node pg k )
-        ? == . nd op ( gop_const ) { = r ( _gp_fill_buf pg . nd grad 0.0 ) } {}
-        = k + k 1
     }
     ( gk_autosync T )
     ? r { ^ ( gk_sync . pg kit ) } {}
@@ -1137,6 +1181,13 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
     ? & >= . v id 0 < . v id ( vec_len [GpNode] . pg nodes ) {} { ^ F }
     : GpNode nd ( _gp_node pg . v id )
     ? == ( vec_len [f] out ) . nd n {} { ^ F }
+    // no gradient flows here (const branch / not a loss ancestor): report
+    // zeros, exactly like the CPU tape's grad_of
+    ? == . nd reach 1 {} {
+        : ~ i k 0
+        ~ < k . nd n { ( vec_set [f] out k 0.0 ) = k + k 1 }
+        ^ T
+    }
     ^ ( gk_dbuf_download . pg kit . nd grad out )
 }
 

--- a/packages/grad/src/grad.nu
+++ b/packages/grad/src/grad.nu
@@ -558,6 +558,23 @@ $ `deps/tensor/src/ops.nu`
     ? == . tp ok 1 {} { ^ F }
     ? >= . loss id 0 {} { ^ F }
     : i top . loss id
+    // requires-grad propagation (PyTorch's rule): a node NEEDS a gradient
+    // only if a parameter lies in its ancestor cone. Gradients are neither
+    // computed nor stored anywhere else — a frozen-const branch (a LoRA
+    // base weight, an input batch) costs nothing in the sweep, and its
+    // grad_of stays a zero tensor exactly as before.
+    : ( Vec i ) need ( vec_new [i] )
+    : ~ i q2 0
+    ~ <= q2 top {
+        : GNode nq ?? ( vec_get [GNode] . tp nodes q2 ) { T x → x F → @ GNode { -1 -1 -1 0.0 } }
+        : ~ i nv 0
+        ? == . nq op ( gop_param ) { = nv 1 } {
+            ? & >= . nq a 0 == ( _ti need . nq a ) 1 { = nv 1 } {}
+            ? & >= . nq b 0 == ( _ti need . nq b ) 1 { = nv 1 } {}
+        }
+        ( vec_push [i] need nv )
+        = q2 + q2 1
+    }
     ( _g_ensure_grad tp top )
     : *Tensor gl # *Tensor ( _g_grad_ptr tp top )
     : i ln ( vec_len [f] . gl data )
@@ -567,71 +584,81 @@ $ `deps/tensor/src/ops.nu`
     ~ >= k 0 {
         : GNode nd ?? ( vec_get [GNode] . tp nodes k ) { T x → x F → @ GNode { -1 -1 -1 0.0 } }
         : s gp ( _g_grad_ptr tp k )
-        ? & != # i gp 0 > . nd op ( gop_const ) {
+        ? & & != # i gp 0 > . nd op ( gop_const ) == ( _ti need k ) 1 {
             : *Tensor g # *Tensor gp
             : *Tensor yv # *Tensor ( _g_val tp k )
             : i n ( vec_len [f] . g data )
             : i op . nd op
             : i ia . nd a
             : i ib . nd b
-            ? >= ia 0 { ( _g_ensure_grad tp ia ) } {}
-            ? >= ib 0 { ( _g_ensure_grad tp ib ) } {}
+            : b needa & >= ia 0 == ( _ti need ia ) 1
+            : b needb & >= ib 0 == ( _ti need ib ) 1
+            ? needa { ( _g_ensure_grad tp ia ) } {}
+            ? needb { ( _g_ensure_grad tp ib ) } {}
             // binops: broadcast-aware. Contributions are built through the
             // tensor package (broadcasting), then summed over broadcast axes
             // into each input's own shape by _g_acc_reduce.
             ? == op ( gop_add ) {
                 : Tensor gv @ Tensor { . g dtype . g shape . g data }
-                ( _g_acc_reduce tp ia gv 1.0 )
-                ( _g_acc_reduce tp ib gv 1.0 )
+                ? needa { ( _g_acc_reduce tp ia gv 1.0 ) } {}
+                ? needb { ( _g_acc_reduce tp ib gv 1.0 ) } {}
             } {}
             ? == op ( gop_sub ) {
                 : Tensor gv @ Tensor { . g dtype . g shape . g data }
-                ( _g_acc_reduce tp ia gv 1.0 )
-                ( _g_acc_reduce tp ib gv -1.0 )
+                ? needa { ( _g_acc_reduce tp ia gv 1.0 ) } {}
+                ? needb { ( _g_acc_reduce tp ib gv -1.0 ) } {}
             } {}
             ? == op ( gop_mul ) {
                 : Tensor gv @ Tensor { . g dtype . g shape . g data }
                 : Tensor av2 ( _g_view ( _g_val tp ia ) )
                 : Tensor bv2 ( _g_view ( _g_val tp ib ) )
-                ?? ( tensor_mul gv bv2 ) {
-                    T ca → {
-                        ( _g_acc_reduce tp ia ca 1.0 )
-                        ( tensor_free ca )
+                ? needa {
+                    ?? ( tensor_mul gv bv2 ) {
+                        T ca → {
+                            ( _g_acc_reduce tp ia ca 1.0 )
+                            ( tensor_free ca )
+                        }
+                        F → {}
                     }
-                    F → {}
-                }
-                ?? ( tensor_mul gv av2 ) {
-                    T cb → {
-                        ( _g_acc_reduce tp ib cb 1.0 )
-                        ( tensor_free cb )
+                } {}
+                ? needb {
+                    ?? ( tensor_mul gv av2 ) {
+                        T cb → {
+                            ( _g_acc_reduce tp ib cb 1.0 )
+                            ( tensor_free cb )
+                        }
+                        F → {}
                     }
-                    F → {}
-                }
+                } {}
             } {}
             ? == op ( gop_div ) {
                 : Tensor gv @ Tensor { . g dtype . g shape . g data }
                 : Tensor bv2 ( _g_view ( _g_val tp ib ) )
                 : Tensor yv2 @ Tensor { . yv dtype . yv shape . yv data }
-                ?? ( tensor_div gv bv2 ) {
-                    T ca → {
-                        ( _g_acc_reduce tp ia ca 1.0 )
-                        ( tensor_free ca )
-                    }
-                    F → {}
-                }
-                ?? ( tensor_mul gv yv2 ) {
-                    T t1 → {
-                        ?? ( tensor_div t1 bv2 ) {
-                            T cb → {
-                                ( _g_acc_reduce tp ib cb -1.0 )
-                                ( tensor_free cb )
-                            }
-                            F → {}
+                ? needa {
+                    ?? ( tensor_div gv bv2 ) {
+                        T ca → {
+                            ( _g_acc_reduce tp ia ca 1.0 )
+                            ( tensor_free ca )
                         }
-                        ( tensor_free t1 )
+                        F → {}
                     }
-                    F → {}
-                }
+                } {}
+                ? needb {
+                    ?? ( tensor_mul gv yv2 ) {
+                        T t1 → {
+                            ?? ( tensor_div t1 bv2 ) {
+                                T cb → {
+                                    ( _g_acc_reduce tp ib cb -1.0 )
+                                    ( tensor_free cb )
+                                }
+                                F → {}
+                            }
+                            ( tensor_free t1 )
+                        }
+                        F → {}
+                    }
+                } {}
             } {}
             ? == op ( gop_neg ) {
                 : *Tensor ga # *Tensor ( _g_grad_ptr tp ia )
@@ -735,44 +762,50 @@ $ `deps/tensor/src/ops.nu`
             ? == op ( gop_matmul ) {
                 // C[m,n] = A[m,k]·B[k,n]: dA[i,p] += Σ_j g[i,j]·B[p,j];
                 // dB[p,j] += Σ_i A[i,p]·g[i,j]. Serial inner sums, row-major.
-                : *Tensor ga # *Tensor ( _g_grad_ptr tp ia )
-                : *Tensor gb # *Tensor ( _g_grad_ptr tp ib )
+                // (an unneeded side's grad slot is NULL — deref only under
+                // its need flag; the loops below are inside those guards)
+                : *Tensor ga # *Tensor ? needa ( _g_grad_ptr tp ia ) # s 0
+                : *Tensor gb # *Tensor ? needb ( _g_grad_ptr tp ib ) # s 0
                 : *Tensor av # *Tensor ( _g_val tp ia )
                 : *Tensor bv # *Tensor ( _g_val tp ib )
                 : i M ( _ti . av shape 0 )
                 : i K ( _ti . av shape 1 )
                 : i N2 ( _ti . bv shape 1 )
-                : ~ i i2 0
-                ~ < i2 M {
-                    : ~ i p 0
-                    ~ < p K {
-                        : ~ f acc 0.0
-                        : ~ i j 0
-                        ~ < j N2 { = acc + acc * ( _tf . g data + * i2 N2 j ) ( _tf . bv data + * p N2 j ) = j + j 1 }
-                        : i o + * i2 K p
-                        ( vec_set [f] . ga data o + ( _tf . ga data o ) acc )
-                        = p + p 1
+                ? needa {
+                    : ~ i i2 0
+                    ~ < i2 M {
+                        : ~ i p 0
+                        ~ < p K {
+                            : ~ f acc 0.0
+                            : ~ i j 0
+                            ~ < j N2 { = acc + acc * ( _tf . g data + * i2 N2 j ) ( _tf . bv data + * p N2 j ) = j + j 1 }
+                            : i o + * i2 K p
+                            ( vec_set [f] . ga data o + ( _tf . ga data o ) acc )
+                            = p + p 1
+                        }
+                        = i2 + i2 1
                     }
-                    = i2 + i2 1
-                }
-                : ~ i p2 0
-                ~ < p2 K {
-                    : ~ i j2 0
-                    ~ < j2 N2 {
-                        : ~ f acc2 0.0
-                        : ~ i i3 0
-                        ~ < i3 M { = acc2 + acc2 * ( _tf . av data + * i3 K p2 ) ( _tf . g data + * i3 N2 j2 ) = i3 + i3 1 }
-                        : i o2 + * p2 N2 j2
-                        ( vec_set [f] . gb data o2 + ( _tf . gb data o2 ) acc2 )
-                        = j2 + j2 1
+                } {}
+                ? needb {
+                    : ~ i p2 0
+                    ~ < p2 K {
+                        : ~ i j2 0
+                        ~ < j2 N2 {
+                            : ~ f acc2 0.0
+                            : ~ i i3 0
+                            ~ < i3 M { = acc2 + acc2 * ( _tf . av data + * i3 K p2 ) ( _tf . g data + * i3 N2 j2 ) = i3 + i3 1 }
+                            : i o2 + * p2 N2 j2
+                            ( vec_set [f] . gb data o2 + ( _tf . gb data o2 ) acc2 )
+                            = j2 + j2 1
+                        }
+                        = p2 + p2 1
                     }
-                    = p2 + p2 1
-                }
+                } {}
             } {}
             ? == op ( gop_bmm ) {
                 // per-batch matmul backward, identical index math + batch offset
-                : *Tensor ga # *Tensor ( _g_grad_ptr tp ia )
-                : *Tensor gb # *Tensor ( _g_grad_ptr tp ib )
+                : *Tensor ga # *Tensor ? needa ( _g_grad_ptr tp ia ) # s 0
+                : *Tensor gb # *Tensor ? needb ( _g_grad_ptr tp ib ) # s 0
                 : *Tensor av # *Tensor ( _g_val tp ia )
                 : *Tensor bv # *Tensor ( _g_val tp ib )
                 : i B2 ( _ti . av shape 0 )
@@ -784,32 +817,36 @@ $ `deps/tensor/src/ops.nu`
                     : i ao * bb * M K
                     : i bo * bb * K N2
                     : i go * bb * M N2
-                    : ~ i i2 0
-                    ~ < i2 M {
-                        : ~ i p 0
-                        ~ < p K {
-                            : ~ f acc 0.0
-                            : ~ i j 0
-                            ~ < j N2 { = acc + acc * ( _tf . g data + go + * i2 N2 j ) ( _tf . bv data + bo + * p N2 j ) = j + j 1 }
-                            : i o + ao + * i2 K p
-                            ( vec_set [f] . ga data o + ( _tf . ga data o ) acc )
-                            = p + p 1
+                    ? needa {
+                        : ~ i i2 0
+                        ~ < i2 M {
+                            : ~ i p 0
+                            ~ < p K {
+                                : ~ f acc 0.0
+                                : ~ i j 0
+                                ~ < j N2 { = acc + acc * ( _tf . g data + go + * i2 N2 j ) ( _tf . bv data + bo + * p N2 j ) = j + j 1 }
+                                : i o + ao + * i2 K p
+                                ( vec_set [f] . ga data o + ( _tf . ga data o ) acc )
+                                = p + p 1
+                            }
+                            = i2 + i2 1
                         }
-                        = i2 + i2 1
-                    }
-                    : ~ i p2 0
-                    ~ < p2 K {
-                        : ~ i j2 0
-                        ~ < j2 N2 {
-                            : ~ f acc2 0.0
-                            : ~ i i3 0
-                            ~ < i3 M { = acc2 + acc2 * ( _tf . av data + ao + * i3 K p2 ) ( _tf . g data + go + * i3 N2 j2 ) = i3 + i3 1 }
-                            : i o2 + bo + * p2 N2 j2
-                            ( vec_set [f] . gb data o2 + ( _tf . gb data o2 ) acc2 )
-                            = j2 + j2 1
+                    } {}
+                    ? needb {
+                        : ~ i p2 0
+                        ~ < p2 K {
+                            : ~ i j2 0
+                            ~ < j2 N2 {
+                                : ~ f acc2 0.0
+                                : ~ i i3 0
+                                ~ < i3 M { = acc2 + acc2 * ( _tf . av data + ao + * i3 K p2 ) ( _tf . g data + go + * i3 N2 j2 ) = i3 + i3 1 }
+                                : i o2 + bo + * p2 N2 j2
+                                ( vec_set [f] . gb data o2 + ( _tf . gb data o2 ) acc2 )
+                                = j2 + j2 1
+                            }
+                            = p2 + p2 1
                         }
-                        = p2 + p2 1
-                    }
+                    } {}
                     = bb + bb 1
                 }
             } {}
@@ -901,8 +938,8 @@ $ `deps/tensor/src/ops.nu`
             } {}
             ? == op ( gop_concat ) {
                 // split g along the axis at a's extent
-                : *Tensor ga # *Tensor ( _g_grad_ptr tp ia )
-                : *Tensor gb # *Tensor ( _g_grad_ptr tp ib )
+                : *Tensor ga # *Tensor ? needa ( _g_grad_ptr tp ia ) # s 0
+                : *Tensor gb # *Tensor ? needb ( _g_grad_ptr tp ib ) # s 0
                 : i axis # i . nd s
                 : i ndim ( vec_len [i] . yv shape )
                 : i da ( _ti . ga shape axis )
@@ -921,11 +958,15 @@ $ `deps/tensor/src/ops.nu`
                         ~ < in2 inner {
                             : i six + + * * o axlen inner * t2 inner in2
                             ? < t2 da {
-                                : i dix + + * * o da inner * t2 inner in2
-                                ( vec_set [f] . ga data dix + ( _tf . ga data dix ) ( _tf . g data six ) )
+                                ? needa {
+                                    : i dix + + * * o da inner * t2 inner in2
+                                    ( vec_set [f] . ga data dix + ( _tf . ga data dix ) ( _tf . g data six ) )
+                                } {}
                             } {
-                                : i dix2 + + * * o - axlen da inner * - t2 da inner in2
-                                ( vec_set [f] . gb data dix2 + ( _tf . gb data dix2 ) ( _tf . g data six ) )
+                                ? needb {
+                                    : i dix2 + + * * o - axlen da inner * - t2 da inner in2
+                                    ( vec_set [f] . gb data dix2 + ( _tf . gb data dix2 ) ( _tf . g data six ) )
+                                } {}
                             }
                             = in2 + in2 1
                         }
@@ -937,24 +978,9 @@ $ `deps/tensor/src/ops.nu`
         } {}
         = k - k 1
     }
-    // Constants report a ZERO gradient. The sweep accumulates into every
-    // input slot uniformly (leaves propagate nothing further, so a const's
-    // accumulated value is never read by the sweep itself); zeroing here
-    // keeps grad_of() honest without a per-write requires-grad branch in
-    // every op loop.
-    = k 0
-    ~ <= k top {
-        : GNode nd2 ?? ( vec_get [GNode] . tp nodes k ) { T x → x F → @ GNode { -1 -1 -1 0.0 } }
-        ? == . nd2 op ( gop_const ) {
-            : s gp2 ( _g_grad_ptr tp k )
-            ? != # i gp2 0 {
-                : *Tensor gz # *Tensor gp2
-                : i zn ( vec_len [f] . gz data )
-                : ~ i j2 0
-                ~ < j2 zn { ( vec_set [f] . gz data j2 0.0 ) = j2 + j2 1 }
-            } {}
-        } {}
-        = k + k 1
-    }
+    // With requires-grad propagation nothing ever writes into a no-need
+    // slot (consts included), so their grad_of stays the zero tensor it
+    // allocates on first touch — no epilogue sweep required.
+    ( vec_free [i] need )
     ^ T
 }


### PR DESCRIPTION
## What

**M6b prerequisite** (the commit was pushed to the #573 branch moments after that PR merged — this PR carries it alone).

A node gets a gradient only if a **parameter lies in its ancestor cone** (PyTorch's requires-grad rule), on both engines: `backward` computes a need set and skips everything outside it — per-input guards on binop sides, matmul/bmm dA/dB, concat splits — and `gput_capture` allocates gradient buffers only for backward-active nodes (a BW-active concat also buffers its inactive side as kernel workspace; `gput_grad` still reports zeros for it).

## Why now

LoRA over a frozen model. Without this, every frozen base weight carries a same-sized gradient buffer and a full dW computation per step — for Qwen2.5-0.5B in f64 that is **~4 GB of dead device buffers** and a [896×151936] lm_head gradient matmul nobody reads, every minibatch. With it, frozen branches cost nothing; only the adapters pay.

## Semantics

Parameter gradients and optimizer trajectories are **bit-identical** to 0.2.0 — const-side gradients never fed back (leaves propagate nothing). The observable change: `grad_of`/`gput_grad` on a node with no parameter upstream now report zeros (previously the true local gradient); documented in the CHANGELOG. The const-zeroing backward epilogue is gone — nothing writes into no-need slots in the first place.

## Gates

grad_test 23/23 · train_test 7/7 · gput_parity 15/15 (CUDA + CPU backend × dev + released toolchains, LSan clean) · lora_block_test 11/11 · PyTorch oracles PASS (block grads 1.04e-13).

Publish after merge: grad 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im