### PR TITLE
nurlc: float↔double stores miscompiled to invalid IR — width adjustment now mirrors the integer rule

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -10706,7 +10706,9 @@
         }
         { ? == ( nurl_lex_type lex ) TT_PUB
             { ( die lex `expected variable name in let — 'pub' is a reserved keyword (the visibility prefix on top-level declarations) and cannot name a binding` ) }
-            { ( die lex `expected variable name in let` ) } }
+            { ? == ( nurl_lex_type lex ) TT_BOOL
+                { ( die lex `expected variable name in let — 'T' and 'F' are the boolean literals and cannot name a binding; pick another name` ) }
+                { ( die lex `expected variable name in let` ) } } }
     }
 }
 
@@ -12901,8 +12903,7 @@
     //   * Widen, source signed (default): emit `sext`.
     // Shipped 2026-05-14 with the fixed-size types Phase 1 — `: i32 x 5`,
     // `: i32 width  ( fn → i32 )`, and FFI-style narrow returns now store
-    // cleanly without manual `# T` casts. Float-width adjustment (f32 ↔
-    // double) lives in gen_cast since it needs explicit `#` syntax.
+    // cleanly without manual `# T` casts.
     : i fw ( int_width from_ty )
     : i tw ( int_width to_ty )
     ? & & > fw 0 > tw 0 != fw tw
@@ -12922,6 +12923,27 @@
             ( nurl_print ( nurl_llty from_ty ) ) ( nurl_print ` ` ) ( nurl_print val )
             ( nurl_print ` to ` ) ( nurl_print ( nurl_llty to_ty ) ) ( nurl_print `\n` )
             ^ r } }
+    {}
+    // Float width adjustment, the exact mirror of the integer case above:
+    // an `f32` value stores into an `f` slot via `fpext`, an `f` value into
+    // an `f32` slot via `fptrunc` — `: f x ( bits_to_f32 b )` and
+    // `: f32 y ( float_sqrt v )` now store cleanly, like their integer
+    // counterparts have since 2026-05-14. Before this, the float↔double
+    // pair fell through EVERY branch here (the never-valid-mix check below
+    // fires only when exactly ONE side is a float), so the caller emitted
+    // `store double %float_val` — invalid IR that nurlc accepted (rc 0)
+    // and only clang rejected, with no source location.
+    : s csv_fll ( nurl_llty from_ty )
+    : s csv_tll ( nurl_llty to_ty )
+    ? | & ( seq csv_fll `float` ) ( seq csv_tll `double` )
+    & ( seq csv_fll `double` ) ( seq csv_tll `float` )
+    { : s inst ? ( seq csv_fll `float` ) `fpext` `fptrunc`
+        : s r ( nurl_cg_reg cg )
+        ( nurl_print `  ` ) ( nurl_print r )
+        ( nurl_print ` = ` ) ( nurl_print inst ) ( nurl_print ` ` )
+        ( nurl_print csv_fll ) ( nurl_print ` ` ) ( nurl_print val )
+        ( nurl_print ` to ` ) ( nurl_print csv_tll ) ( nurl_print `\n` )
+        ^ r }
     {}
     // A void source can NEVER initialise anything — it is not a type clash,
     // it is the absence of a value. Before this check, `: i x ?? m { T v → v

--- a/compiler/tests/f32_store_widening.nu
+++ b/compiler/tests/f32_store_widening.nu
@@ -1,0 +1,39 @@
+// f32_store_widening.nu — float↔double width adjustment at STORES, the
+// exact mirror of the integer widths that have coerced since 2026-05-14.
+// Before this, `: f a ( f32-returning-call )` fell through every branch of
+// coerce_store_val (the never-valid-mix check fires only when exactly ONE
+// side is a float), so nurlc emitted `store double %float_val` — invalid
+// IR accepted by nurlc (rc 0) and rejected only by clang, with no source
+// location. Found live by nurllama's finetune diagnostics
+// (`: f x ( bits_to_f32 b )`).
+//
+// Covers: widen at let (call result, f32 var, cast chain), narrow at let
+// (double literal into f32), widen and narrow at `=` reassignment.
+
+@ f32ret → f32 { ^ # f32 1.5 }
+
+@ pr s l f v → v {
+    ( nurl_print l )
+    ( nurl_print `=` )
+    ( nurl_print ( nurl_str_float v ) )
+    ( nurl_print `\n` )
+}
+
+@ main → i {
+    : f a ( f32ret )  // f32 call result → f slot (fpext)
+    ( pr `call_widen` a )
+    : f32 s # f32 2.5
+    : f b s  // f32 var → f slot
+    ( pr `var_widen` b )
+    : f c # f # f32 3.25  // explicit chain: double → float → double
+    ( pr `cast_chain` c )
+    : f32 g 1.25  // double literal → f32 slot (fptrunc)
+    ( pr `lit_narrow` # f g )
+    : ~ f32 d # f32 0.0
+    = d a  // f value → f32 slot at reassignment
+    ( pr `assign_narrow` # f d )
+    : ~ f e 0.0
+    = e s  // f32 value → f slot at reassignment
+    ( pr `assign_widen` e )
+    ^ 0
+}

--- a/compiler/tests/outputs/f32_store_widening.txt
+++ b/compiler/tests/outputs/f32_store_widening.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+call_widen=1.5
+var_widen=2.5
+cast_chain=3.25
+lit_narrow=1.25
+assign_narrow=1.5
+assign_widen=2.5


### PR DESCRIPTION
## The bug

`: f a ( bits_to_f32 b )` — any f32 value bound/assigned to an `f` slot, or the reverse — produced **invalid LLVM IR** (`store double %float_val`): nurlc accepted it (rc 0) and only clang rejected it, with no source location. Found live during nurllama's finetune diagnostics.

Root cause in `coerce_store_val`: the integer-width block only handles ints, and the final never-valid-mix diagnostic fires only when exactly **one** side is a float — the float↔double pair fell through every branch untouched. The comment even documented the inconsistency: integer widths have adjusted implicitly at stores since 2026-05-14, floats were claimed to "live in gen_cast" — and instead miscompiled.

## The fix

Float widths now follow the exact same rule as integer widths, in the same helper: `float → double` stores via `fpext`, `double → float` via `fptrunc`. Let bindings, `=` reassignment and result-field stores all route through `coerce_store_val`, so one block covers them all.

Also upgraded: `: i T 5` now explains that `T`/`F` are the boolean literals and cannot name a binding (was a bare "expected variable name in let" — hit twice this week writing real code).

## Verification

- New regression test `f32_store_widening.nu`: widen at let (call result, f32 var, `# f # f32` cast chain), narrow at let (double literal into an f32 slot), both directions at `=` — golden-pinned values.
- Full compiler suite **553/553**, self-compile green, nurlfmt idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im