### PR TITLE
nurlc: bare integer into a plain struct-literal field is now a source-located error

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -12055,7 +12055,29 @@
                 ? != 0 ( nurl_str_len __sldft )
                 { : b __slvf | ( seq fty `double` ) ( seq fty `float` )
                     : b __sldf | ( seq __sldft `double` ) ( seq __sldft `float` )
-                    ? | != __slvf __sldf ( __arg_named_struct_mismatch fty __sldft )
+                    // (c) a bare integer into a PLAIN named-struct field.
+                    // Enum fields (variant names lower to i64 tags) and
+                    // single-pointer-handle structs (Vec/String — an i64
+                    // wraps via inttoptr) coerce legally and are excluded;
+                    // anything else would emit `insertvalue %S i64` —
+                    // invalid IR that only clang used to reject, with no
+                    // source location (found by an FtG literal that kept an
+                    // old arity after the struct grew).
+                    : ~ b __slint_ps F
+                    ? & > ( int_width fty ) 0 == ( nurl_str_get __sldft 0 ) 37
+                    { : s __sltn ( nurl_str_slice __sldft 1 - ( nurl_str_len __sldft ) 1 )
+                        ? == 0 ( nurl_str_len ( nurl_sym_get syms ( nurl_str_cat __sltn `__variants` ) ) )
+                        { : s __slf0 ( nurl_sym_get syms ( nurl_str_cat3 __sltn `__idx_0` `__type` ) )
+                            : s __slf1 ( nurl_sym_get syms ( nurl_str_cat3 __sltn `__idx_1` `__type` ) )
+                            : b __slsh & & != 0 ( nurl_str_len __slf0 )
+                            == ( nurl_str_get __slf0 - ( nurl_str_len __slf0 ) 1 ) 42
+                            == 0 ( nurl_str_len __slf1 )
+                            ? __slsh {} { = __slint_ps T }
+                        }
+                        {}
+                    }
+                    {}
+                    ? | | != __slvf __sldf ( __arg_named_struct_mismatch fty __sldft ) __slint_ps
                     { ( die lex ( nurl_str_cat3
                         ( nurl_str_cat4 `field ` ( nurl_str_int idx ) ` of struct literal '` cur_sname )
                         ( nurl_str_cat4 `' expects type '` __sldft `' but the value has type '` fty )

--- a/compiler/tests/outputs/struct_lit_int_field_clash.txt
+++ b/compiler/tests/outputs/struct_lit_int_field_clash.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/struct_lit_int_field_clash.nu:15:31: field 2 of struct literal 'Outer' expects type '%Gv' but the value has type 'i64' — NURL has no implicit conversions
+    : Outer o @ Outer { g g 0 }
+                              ^
+error: aborting due to 1 previous error

--- a/compiler/tests/struct_lit_int_field_clash.nu
+++ b/compiler/tests/struct_lit_int_field_clash.nu
@@ -1,0 +1,17 @@
+// struct_lit_int_field_clash.nu — a bare integer supplied for a PLAIN
+// named-struct field in an aggregate literal must be a compile error.
+// `@ Outer { g g 0 }` (an old 3-value literal kept after Outer grew a
+// struct-typed field) used to emit `insertvalue %Outer i64 0` — invalid
+// IR that nurlc accepted (rc 0) and only clang rejected, with no source
+// location. Enum fields (variant tags) and single-pointer-handle structs
+// (Vec/String) still coerce legally.
+
+: Gv { i id }
+
+: Outer { Gv a Gv b Gv c i n }
+
+@ main → i {
+    : Gv g @ Gv { 7 }
+    : Outer o @ Outer { g g 0 }
+    ^ . o n
+}


### PR DESCRIPTION
## The bug

`@ Outer { g g 0 }` — e.g. a literal that kept its old arity after the struct grew a struct-typed field — emitted `insertvalue %Outer i64 0`: **invalid IR** that nurlc accepted (rc 0) and only clang rejected, with no source location. Found live when nurllama's `FtG` grew two fields and a poison-path literal wasn't updated.

## The fix

`gen_agg_lit`'s existing field-clash check gains a third case: a bare integer supplied for a **plain named-struct** field dies at the source with the standard "expects type '%Gv' but the value has type 'i64'" diagnostic. The two legal coercions remain excluded: enum-typed fields (variant names lower to i64 tags) and single-pointer-handle structs (Vec/String — i64 wraps via `inttoptr`).

New golden-pinned negative test `struct_lit_int_field_clash.nu`. Suite **554/554**, self-compile green, nurlfmt idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im