### PR TITLE
fix(nurllama): declare the direct gpukit dependency

### DIFF
--- a/packages/nurllama/nurl.toml
+++ b/packages/nurllama/nurl.toml
@@ -11,4 +11,5 @@ tokenizer = { path = "../tokenizer", version = "^0.3.0" }
 gpu = { path = "../gpu", version = "^0.9.0" }
 http = { path = "../http", version = "^0.3" }
 grad = { path = "../grad", version = "^0.3" }
+gpukit = { path = "../gpukit", version = "^0.4.2" }
 tensor = { path = "../tensor", version = "^0.4" }


### PR DESCRIPTION
src/finetune.nu imports deps/gpukit directly (GkBuf plumbing for the
gput replay engine), so gpukit must be declared — relying on it arriving
transitively through grad breaks the moment grad reorganizes. Caught by
nurlpkg's undeclared-import gate at publish; the published 0.12.0
tarball carries this manifest.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WX2frzGUucJVZjARF389im
