### PR TITLE
grad 0.4.0: tape → CUDA-C emitter — distributed backward passes are now derived (M7-1)

### DIFF
--- a/packages/grad/CHANGELOG.md
+++ b/packages/grad/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.4.0
+
+**`src/emitc.nu` — emit a recorded scalar tape as CUDA-C.**
+`gemit_cuda_grad` walks a tape whose nodes are all single-element tensors
+and prints the `__device__ void grad(long long x, double v, double* g,
+const double* p)` function swarm-mcp's `compute_iterate` runs on every
+worker: forward locals mirroring each op's exact arithmetic, a reverse
+sweep under requires-grad propagation, and a `swarm_g_add` scatter per
+parameter. Parameters bind to `p[j]` in list order; data leaves bind to
+caller-supplied C expressions; frozen consts inline as round-trip float
+literals. Distributed backward passes are now DERIVED from the tape, not
+hand-written CUDA-C — the keystone plan's last missing verb.
+
+- The C forms mirror grad.nu expression by expression, so a host build
+  with `-ffp-contract=off` reproduces the tape bit for bit:
+  `tests/emitc_oracle.sh` compiles the emitted function with gcc and
+  asserts every parameter gradient is BIT-EQUAL to the tape's, on a loss
+  touching every supported scalar op.
+- Non-scalar nodes and linear-algebra ops are refused (emit returns F) —
+  the per-example scalar loss is compute_iterate's shape.
+
 ## 0.3.0
 
 **Requires-grad propagation (PyTorch's rule), on both engines.** A node

--- a/packages/grad/nurl.toml
+++ b/packages/grad/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grad"
-version = "0.3.0"
+version = "0.4.0"
 description = "Reverse-mode automatic differentiation over the tensor package — the training keystone. Build a computation eagerly with tape-recording ops (g_add, g_matmul, g_relu, ...) that mirror tensor's surface, call backward(loss) once, and read exact gradients for every registered parameter: backward passes are derived, not hand-written. The tape is a flat single-owner arena (indices as edges, deterministic reverse order, no per-node closures): it owns every intermediate and gradient, one tape_free releases everything, and tape_reset_to keeps the parameters while dropping the episode so a minibatch loop never re-mallocs. Ships SGD/Adam optimizers over the parameter list. Every backward rule is verified three independent ways: a central finite-difference harness, hand-derived analytic identities, and a PyTorch float64 oracle fed bit patterns. A GPU replay engine (gput_capture) mirrors a recorded episode onto the device — one kernel launch per node, device-resident Adam/SGD — under the ecosystem's bit-exactness discipline: the relu/linear-algebra tier is bit-identical to the CPU tape on CUDA and the CPU backend alike (a whole autoencoder trains to bit-equal weights, ~5x wall clock), transcendentals within an ulp on CUDA."
 license = "MIT OR Apache-2.0"
 

--- a/packages/grad/src/emitc.nu
+++ b/packages/grad/src/emitc.nu
@@ -1,0 +1,249 @@
+// grad/emitc.nu — emit a recorded SCALAR tape as CUDA-C source: the
+// `__device__ void grad(...)` function swarm-mcp's compute_iterate runs on
+// every worker. This closes the loop the keystone plan named: distributed
+// backward passes are now DERIVED from the tape, not hand-written CUDA-C.
+//
+// Scope: every node must be a single-element tensor (shape [1] — scalars;
+// g_sum/g_mean of a scalar pass through). The per-example loss is built
+// once with placeholder leaves; the emitter walks the tape and prints
+//   forward:   double tN = <op mirror>;
+//   backward:  double gN = 0.0;  …  gA += …;   (reverse order, seed 1.0)
+//   epilogue:  swarm_g_add(g, j, g<param_j>);
+// Leaf binding: parameters map to p[j] in registration order; data leaves
+// map to caller-supplied C expressions (`v`, `(double)x`, …). Requires-grad
+// propagation mirrors grad.nu — const-only branches emit no backward code.
+//
+// The C forms mirror grad.nu's scalar arithmetic EXPRESSION BY EXPRESSION
+// (sigmoid = 1/(1+exp(0-x)), tanh via e2=exp(2x), div's gB via gN*tN/tB…),
+// so a host build with -ffp-contract=off reproduces the tape BIT FOR BIT —
+// tests/emitc_oracle.sh proves exactly that with gcc.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `grad.nu`
+$ `deps/tensor/src/tensor.nu`
+
+@ __ec_t String o i k → v {
+    ( string_push_str o `t` )
+    ( string_push_str o ( nurl_str_int k ) )
+}
+
+@ __ec_g String o i k → v {
+    ( string_push_str o `g` )
+    ( string_push_str o ( nurl_str_int k ) )
+}
+
+@ __ec_f String o f v → v { ( string_push_str o ( nurl_str_float v ) ) }
+
+// The C expression bound to leaf node `k`: `p[j]` for the j-th parameter,
+// the caller's expression for a data leaf, else the leaf's recorded VALUE
+// as a literal (a frozen scalar const).
+@ __ec_leaf * GTape tp i k ( Vec i ) pids ( Vec i ) lids ( Vec s ) lexprs String o → v {
+    : ~ i j 0
+    ~ < j ( vec_len [i] pids ) {
+        ? == ( _ti pids j ) k {
+            ( string_push_str o `p[` )
+            ( string_push_str o ( nurl_str_int j ) )
+            ( string_push_str o `]` )
+            ^ v
+        } {}
+        = j + j 1
+    }
+    = j 0
+    ~ < j ( vec_len [i] lids ) {
+        ? == ( _ti lids j ) k {
+            ( string_push_str o ?? ( vec_get [s] lexprs j ) { T x → x F → `` } )
+            ^ v
+        } {}
+        = j + j 1
+    }
+    : *Tensor tv # *Tensor ( _g_val tp k )
+    ( __ec_f o ( _tf . tv data 0 ) )
+}
+
+// Emit the whole device function. `has_v` picks the dataset-bearing
+// signature compute_iterate uses. F on any non-scalar node / unknown op.
+@ gemit_cuda_grad * GTape tp GVar loss ( Vec i ) pids ( Vec i ) lids ( Vec s ) lexprs b has_v String out → b {
+    ? & ( tape_ok tp ) >= . loss id 0 {} { ^ F }
+    : i top . loss id
+    // scalar check + need/reach sets (grad.nu's rules)
+    : ( Vec i ) need ( vec_new [i] )
+    : ~ i k 0
+    ~ <= k top {
+        : *Tensor tv # *Tensor ( _g_val tp k )
+        ? == ( vec_len [f] . tv data ) 1 {} { ( vec_free [i] need ) ^ F }
+        : GNode nd ?? ( vec_get [GNode] . tp nodes k ) { T x → x F → @ GNode { -1 -1 -1 0.0 } }
+        : ~ i nv 0
+        ? == . nd op ( gop_param ) { = nv 1 } {
+            ? & >= . nd a 0 == ( _ti need . nd a ) 1 { = nv 1 } {}
+            ? & >= . nd b 0 == ( _ti need . nd b ) 1 { = nv 1 } {}
+        }
+        // params list decides "param": a grad_param NOT in pids is frozen
+        ? == . nd op ( gop_param ) {
+            = nv 0
+            : ~ i q 0
+            ~ < q ( vec_len [i] pids ) {
+                ? == ( _ti pids q ) k { = nv 1 } {}
+                = q + q 1
+            }
+        } {}
+        ( vec_push [i] need nv )
+        = k + k 1
+    }
+    : ( Vec i ) reach ( vec_new [i] )
+    = k 0
+    ~ <= k top { ( vec_push [i] reach 0 ) = k + k 1 }
+    ( vec_set [i] reach top 1 )
+    = k top
+    ~ >= k 0 {
+        ? == ( _ti reach k ) 1 {
+            : GNode nd ?? ( vec_get [GNode] . tp nodes k ) { T x → x F → @ GNode { -1 -1 -1 0.0 } }
+            ? >= . nd a 0 { ( vec_set [i] reach . nd a 1 ) } {}
+            ? >= . nd b 0 { ( vec_set [i] reach . nd b 1 ) } {}
+        } {}
+        = k - k 1
+    }
+    ( string_push_str out ? has_v
+    `__device__ void grad(long long x, double v, double* g, const double* p) {\n`
+    `__device__ void grad(long long x, double* g, const double* p) {\n` )
+    // ── forward ──
+    = k 0
+    : ~ b ok T
+    ~ & <= k top ok {
+        : GNode nd ?? ( vec_get [GNode] . tp nodes k ) { T x → x F → @ GNode { -1 -1 -1 0.0 } }
+        : i op . nd op
+        ( string_push_str out `  double ` )
+        ( __ec_t out k )
+        ( string_push_str out ` = ` )
+        ? <= op ( gop_const ) { ( __ec_leaf tp k pids lids lexprs out ) } {
+            : i a . nd a
+            : i b2 . nd b
+            ? == op ( gop_add ) { ( __ec_t out a ) ( string_push_str out ` + ` ) ( __ec_t out b2 ) } {}
+            ? == op ( gop_sub ) { ( __ec_t out a ) ( string_push_str out ` - ` ) ( __ec_t out b2 ) } {}
+            ? == op ( gop_mul ) { ( __ec_t out a ) ( string_push_str out ` * ` ) ( __ec_t out b2 ) } {}
+            ? == op ( gop_div ) { ( __ec_t out a ) ( string_push_str out ` / ` ) ( __ec_t out b2 ) } {}
+            ? == op ( gop_neg ) { ( string_push_str out `0.0 - ` ) ( __ec_t out a ) } {}
+            ? == op ( gop_adds ) { ( __ec_t out a ) ( string_push_str out ` + ` ) ( __ec_f out . nd s ) } {}
+            ? == op ( gop_muls ) { ( __ec_t out a ) ( string_push_str out ` * ` ) ( __ec_f out . nd s ) } {}
+            ? == op ( gop_relu ) {
+                ( __ec_t out a ) ( string_push_str out ` > 0.0 ? ` )
+                ( __ec_t out a ) ( string_push_str out ` : 0.0` )
+            } {}
+            ? == op ( gop_sigmoid ) {
+                ( string_push_str out `1.0 / (1.0 + exp(0.0 - ` )
+                ( __ec_t out a ) ( string_push_str out `))` )
+            } {}
+            ? == op ( gop_tanh ) {
+                // two-statement form mirroring grad.nu: e2 first
+                ( string_push_str out `0.0; { double e2 = exp(2.0 * ` )
+                ( __ec_t out a )
+                ( string_push_str out `); ` )
+                ( __ec_t out k )
+                ( string_push_str out ` = (e2 - 1.0) / (e2 + 1.0); }` )
+            } {}
+            ? == op ( gop_exp ) { ( string_push_str out `exp(` ) ( __ec_t out a ) ( string_push_str out `)` ) } {}
+            ? == op ( gop_log ) { ( string_push_str out `log(` ) ( __ec_t out a ) ( string_push_str out `)` ) } {}
+            ? == op ( gop_sqrt ) { ( string_push_str out `sqrt(` ) ( __ec_t out a ) ( string_push_str out `)` ) } {}
+            ? | == op ( gop_sum ) == op ( gop_mean ) { ( __ec_t out a ) } {}
+            // matmul/bmm/shape ops have no scalar mirror — refuse
+            ? > op ( gop_mean ) { = ok F } {}
+        }
+        ( string_push_str out `;\n` )
+        = k + k 1
+    }
+    ? ok {} { ( vec_free [i] need ) ( vec_free [i] reach ) ^ F }
+    // ── backward ──
+    = k 0
+    ~ <= k top {
+        ? & == ( _ti need k ) 1 == ( _ti reach k ) 1 {
+            ( string_push_str out `  double ` )
+            ( __ec_g out k )
+            ( string_push_str out ? == k top ` = 1.0;\n` ` = 0.0;\n` )
+        } {}
+        = k + k 1
+    }
+    = k top
+    ~ >= k 0 {
+        : GNode nd ?? ( vec_get [GNode] . tp nodes k ) { T x → x F → @ GNode { -1 -1 -1 0.0 } }
+        : i op . nd op
+        ? & & == ( _ti need k ) 1 == ( _ti reach k ) 1 > op ( gop_const ) {
+            : i a . nd a
+            : i b2 . nd b
+            : b na & >= a 0 == ( _ti need a ) 1
+            : b nb & >= b2 0 == ( _ti need b2 ) 1
+            ? & == op ( gop_add ) na { ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k ) ( string_push_str out `;\n` ) } {}
+            ? & == op ( gop_add ) nb { ( string_push_str out `  ` ) ( __ec_g out b2 ) ( string_push_str out ` += ` ) ( __ec_g out k ) ( string_push_str out `;\n` ) } {}
+            ? & == op ( gop_sub ) na { ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k ) ( string_push_str out `;\n` ) } {}
+            ? & == op ( gop_sub ) nb { ( string_push_str out `  ` ) ( __ec_g out b2 ) ( string_push_str out ` -= ` ) ( __ec_g out k ) ( string_push_str out `;\n` ) } {}
+            ? & == op ( gop_mul ) na {
+                ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k )
+                ( string_push_str out ` * ` ) ( __ec_t out b2 ) ( string_push_str out `;\n` )
+            } {}
+            ? & == op ( gop_mul ) nb {
+                ( string_push_str out `  ` ) ( __ec_g out b2 ) ( string_push_str out ` += ` ) ( __ec_g out k )
+                ( string_push_str out ` * ` ) ( __ec_t out a ) ( string_push_str out `;\n` )
+            } {}
+            ? & == op ( gop_div ) na {
+                ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k )
+                ( string_push_str out ` / ` ) ( __ec_t out b2 ) ( string_push_str out `;\n` )
+            } {}
+            ? & == op ( gop_div ) nb {
+                ( string_push_str out `  ` ) ( __ec_g out b2 ) ( string_push_str out ` -= ` ) ( __ec_g out k )
+                ( string_push_str out ` * ` ) ( __ec_t out k ) ( string_push_str out ` / ` )
+                ( __ec_t out b2 ) ( string_push_str out `;\n` )
+            } {}
+            ? & == op ( gop_neg ) na { ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` -= ` ) ( __ec_g out k ) ( string_push_str out `;\n` ) } {}
+            ? & == op ( gop_adds ) na { ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k ) ( string_push_str out `;\n` ) } {}
+            ? & == op ( gop_muls ) na {
+                ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k )
+                ( string_push_str out ` * ` ) ( __ec_f out . nd s ) ( string_push_str out `;\n` )
+            } {}
+            ? & == op ( gop_relu ) na {
+                ( string_push_str out `  if (` ) ( __ec_t out k ) ( string_push_str out ` > 0.0) ` )
+                ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k ) ( string_push_str out `;\n` )
+            } {}
+            ? & == op ( gop_sigmoid ) na {
+                ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k )
+                ( string_push_str out ` * (` ) ( __ec_t out k ) ( string_push_str out ` * (1.0 - ` )
+                ( __ec_t out k ) ( string_push_str out `));\n` )
+            } {}
+            ? & == op ( gop_tanh ) na {
+                ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k )
+                ( string_push_str out ` * (1.0 - ` ) ( __ec_t out k ) ( string_push_str out ` * ` )
+                ( __ec_t out k ) ( string_push_str out `);\n` )
+            } {}
+            ? & == op ( gop_exp ) na {
+                ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k )
+                ( string_push_str out ` * ` ) ( __ec_t out k ) ( string_push_str out `;\n` )
+            } {}
+            ? & == op ( gop_log ) na {
+                ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k )
+                ( string_push_str out ` / ` ) ( __ec_t out a ) ( string_push_str out `;\n` )
+            } {}
+            ? & == op ( gop_sqrt ) na {
+                ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k )
+                ( string_push_str out ` / (2.0 * ` ) ( __ec_t out k ) ( string_push_str out `);\n` )
+            } {}
+            ? & | == op ( gop_sum ) == op ( gop_mean ) na {
+                ( string_push_str out `  ` ) ( __ec_g out a ) ( string_push_str out ` += ` ) ( __ec_g out k ) ( string_push_str out `;\n` )
+            } {}
+        } {}
+        = k - k 1
+    }
+    // ── scatter into the K-vector ──
+    : ~ i j 0
+    ~ < j ( vec_len [i] pids ) {
+        : i pk ( _ti pids j )
+        ( string_push_str out `  swarm_g_add(g, ` )
+        ( string_push_str out ( nurl_str_int j ) )
+        ( string_push_str out `, ` )
+        ? & == ( _ti need pk ) 1 == ( _ti reach pk ) 1 { ( __ec_g out pk ) } { ( string_push_str out `0.0` ) }
+        ( string_push_str out `);\n` )
+        = j + j 1
+    }
+    ( string_push_str out `}\n` )
+    ( vec_free [i] need )
+    ( vec_free [i] reach )
+    ^ T
+}

--- a/packages/grad/tests/emitc_dump.nu
+++ b/packages/grad/tests/emitc_dump.nu
@@ -1,0 +1,83 @@
+// emitc_dump.nu — build a scalar per-example loss on the tape, print the
+// emitted CUDA-C grad() (host-compilable form) AND the tape's own
+// gradients for a probe (x, v, p) as f64 bits. tests/emitc_oracle.sh
+// compiles the emitted C with gcc -ffp-contract=off and asserts the C
+// gradients equal the tape's BIT FOR BIT.
+//
+// Model (touches every scalar op): with xf = (double)x, target v,
+//   z  = p0·xf + p1
+//   h  = tanh(z) + sigmoid(p2·xf) + relu(p1 - v)
+//   q  = log(exp(h) + sqrt(p0·p0 + 1.5)) / (p2·p2 + 1.0)
+//   L  = mean((q - v)²)   (sum/mean pass through at [1])
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/floatbits.nu`
+$ `src/grad.nu`
+$ `src/emitc.nu`
+$ `deps/tensor/src/tensor.nu`
+
+@ sc * GTape tp f v b param → GVar {
+    : ( Vec f ) d ( vec_new [f] )
+    ( vec_push [f] d v )
+    : ( Vec i ) s ( vec_new [i] )
+    ( vec_push [i] s 1 )
+    : Tensor t ( tensor_from_data TE_F64 s d )
+    : GVar o ? param ( grad_param tp t ) ( grad_const tp t )
+    ( tensor_free t ) ( vec_free [f] d )
+    ^ o
+}
+
+@ main → i {
+    : f XPROBE 3.0
+    : f VPROBE 0.7
+    : f P0 0.31
+    : f P1 -0.42
+    : f P2 0.9
+    : *GTape tp ( tape_new )
+    : GVar p0 ( sc tp P0 T )
+    : GVar p1 ( sc tp P1 T )
+    : GVar p2 ( sc tp P2 T )
+    : GVar xf ( sc tp XPROBE F )
+    : GVar vv ( sc tp VPROBE F )
+    : GVar z ( g_add tp ( g_mul tp p0 xf ) p1 )
+    : GVar h ( g_add tp ( g_add tp ( g_tanh tp z ) ( g_sigmoid tp ( g_mul tp p2 xf ) ) )
+    ( g_relu tp ( g_sub tp p1 vv ) ) )
+    : GVar num ( g_log tp ( g_add tp ( g_exp tp h ) ( g_sqrt tp ( g_adds tp ( g_mul tp p0 p0 ) 1.5 ) ) ) )
+    : GVar q ( g_div tp num ( g_adds tp ( g_mul tp p2 p2 ) 1.0 ) )
+    : GVar e ( g_sub tp q vv )
+    : GVar loss ( g_mean tp ( g_mul tp e e ) )
+    : b bok ( backward tp loss )
+    ? bok {} { ( nurl_print `BACKWARD FAILED\n` ) ^ 1 }
+    : ( Vec i ) pids ( vec_new [i] )
+    ( vec_push [i] pids . p0 id ) ( vec_push [i] pids . p1 id ) ( vec_push [i] pids . p2 id )
+    : ( Vec i ) lids ( vec_new [i] )
+    ( vec_push [i] lids . xf id ) ( vec_push [i] lids . vv id )
+    : ( Vec s ) lexprs ( vec_new [s] )
+    ( vec_push [s] lexprs `((double)x)` )
+    ( vec_push [s] lexprs `v` )
+    : String src ( string_new )
+    ? ( gemit_cuda_grad tp loss pids lids lexprs T src ) {} { ( nurl_print `EMIT FAILED\n` ) ^ 1 }
+    ( nurl_print `===SRC===\n` )
+    ( nurl_print ( string_data src ) )
+    ( nurl_print `===GRADS===\n` )
+    : ~ i j 0
+    ~ < j 3 {
+        : GVar pv @ GVar { ( _ti pids j ) }
+        : Tensor g ( grad_of tp pv )
+        ( nurl_print ( nurl_str_int ( f64_to_bits ( _tf . g data 0 ) ) ) )
+        ( nurl_print `\n` )
+        = j + j 1
+    }
+    ( nurl_print `===PROBE===\n` )
+    ( nurl_print ( nurl_str_int ( f64_to_bits XPROBE ) ) ) ( nurl_print `\n` )
+    ( nurl_print ( nurl_str_int ( f64_to_bits VPROBE ) ) ) ( nurl_print `\n` )
+    ( nurl_print ( nurl_str_int ( f64_to_bits P0 ) ) ) ( nurl_print `\n` )
+    ( nurl_print ( nurl_str_int ( f64_to_bits P1 ) ) ) ( nurl_print `\n` )
+    ( nurl_print ( nurl_str_int ( f64_to_bits P2 ) ) ) ( nurl_print `\n` )
+    ( string_free src )
+    ( vec_free [i] pids ) ( vec_free [i] lids ) ( vec_free [s] lexprs )
+    ( tape_free tp )
+    ^ 0
+}

--- a/packages/grad/tests/emitc_oracle.sh
+++ b/packages/grad/tests/emitc_oracle.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# packages/grad/tests/emitc_oracle.sh — the C oracle for the CUDA-C grad()
+# emitter. emitc_dump builds a scalar loss touching every supported op,
+# prints the emitted device function, the tape's parameter gradients (f64
+# bits) and the probe inputs. This script compiles the emitted C on the
+# HOST (gcc, -O2 -ffp-contract=off — one IEEE rounding per written op,
+# same as the tape) with a stub swarm_g_add and asserts the C gradients
+# equal the tape's BIT FOR BIT. Skips without a C compiler.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+export NURL_STDLIB="$REPO"
+command -v cc >/dev/null || { echo "[emitc-oracle] SKIP — no C compiler"; exit 0; }
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+( cd "$HERE" && "$REPO/nurl.sh" tests/emitc_dump.nu "$TMP/dump" >/dev/null 2>&1 ) \
+    || { echo "[emitc-oracle] FAIL build"; ( cd "$HERE" && "$REPO/nurl.sh" tests/emitc_dump.nu "$TMP/dump" 2>&1 | tail -5 ); exit 1; }
+"$TMP/dump" > "$TMP/out.txt" || { echo "[emitc-oracle] FAIL dump"; exit 1; }
+
+awk '/===SRC===/{f=1;next}/===GRADS===/{f=0}f' "$TMP/out.txt" > "$TMP/grad.c.in"
+awk '/===GRADS===/{f=1;next}/===PROBE===/{f=0}f' "$TMP/out.txt" > "$TMP/grads.txt"
+awk '/===PROBE===/{f=1;next}f' "$TMP/out.txt" > "$TMP/probe.txt"
+
+# host build: __device__ → nothing, stub swarm_g_add collects into g[]
+{
+  echo '#include <math.h>'
+  echo '#include <stdio.h>'
+  echo '#include <stdint.h>'
+  echo '#include <string.h>'
+  echo 'static void swarm_g_add(double* g, int j, double val) { g[j] += val; }'
+  sed 's/__device__ //' "$TMP/grad.c.in"
+  cat <<'CMAIN'
+int main(int argc, char** argv) {
+  double pr[5]; // x v p0 p1 p2 (x arrives as a double bit pattern too)
+  for (int i = 0; i < 5; i++) { long long b; sscanf(argv[1+i], "%lld", &b); memcpy(&pr[i], &b, 8); }
+  long long x = (long long)pr[0];
+  double v = pr[1];
+  double p[3] = { pr[2], pr[3], pr[4] };
+  double g[3] = { 0.0, 0.0, 0.0 };
+  grad(x, v, g, p);
+  for (int j = 0; j < 3; j++) { long long b; memcpy(&b, &g[j], 8); printf("%lld\n", b); }
+  return 0;
+}
+CMAIN
+} > "$TMP/harness.c"
+
+cc -O2 -ffp-contract=off -o "$TMP/harness" "$TMP/harness.c" -lm \
+    || { echo "[emitc-oracle] FAIL cc (emitted C does not compile)"; sed -n '1,40p' "$TMP/harness.c"; exit 1; }
+
+mapfile -t PROBE < "$TMP/probe.txt"
+"$TMP/harness" "${PROBE[@]}" > "$TMP/cgrads.txt"
+
+if diff -q "$TMP/grads.txt" "$TMP/cgrads.txt" >/dev/null; then
+  echo "[emitc-oracle] PASS — emitted C gradients BIT-EQUAL to the tape (3 params, every scalar op)"
+  exit 0
+else
+  echo "[emitc-oracle] FAIL — gradients differ:"
+  paste "$TMP/grads.txt" "$TMP/cgrads.txt"
+  exit 1
+fi


### PR DESCRIPTION
## What

**M7-1**: the bridge between the autograd tape and the swarm. `gemit_cuda_grad` (new `src/emitc.nu`) emits a recorded scalar tape as the exact `__device__ void grad(long long x, double v, double* g, const double* p)` function that swarm-mcp's `compute_iterate` ships to every worker — forward locals mirroring each op's arithmetic, a reverse sweep under requires-grad propagation, `swarm_g_add` scatter per parameter.

This closes the sentence the keystone plan opened with: *"every training story today hand-writes its backward pass (mlp in NURL, swarm-mcp in CUDA-C)"* — the swarm's `grad()` is now **derived from the tape**, like mlp's became in M4.

## Bit-exactness as the oracle

The emitted C mirrors grad.nu **expression by expression** (sigmoid via `exp(0-x)`, tanh via `e2 = exp(2x)`, div's gB via `gN·tN/tB` …). `tests/emitc_oracle.sh` compiles the emitted function on the host with `gcc -O2 -ffp-contract=off` + a stub `swarm_g_add`, feeds it the probe as f64 bit patterns, and asserts every parameter gradient is **BIT-EQUAL to the tape's** — on a loss touching every supported scalar op, with fan-out and a frozen-const branch excluded by the need set.

- Parameters bind to `p[j]` in list order; data leaves to caller C expressions (`(double)x`, `v`); frozen consts inline as round-trip float literals (the PR #563 formatter guarantees exactness).
- Non-scalar nodes / linear-algebra ops are refused (`F`) — the per-example scalar loss is `compute_iterate`'s shape.

Gates: grad_test 23/23 · train_test 7/7 · emitc oracle PASS · dev + released toolchains.

Next (M7-2): the live demo — a tape-built linear-regression loss emitted through this and trained on the swarm via `compute_iterate`, oracle = the same tape trained locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im