### PR TITLE
M7-2: tape-derived gradient kernel trains on the live swarm (grad dump + swarm-mcp smoke)

### DIFF
--- a/packages/grad/tests/swarm_linreg_dump.nu
+++ b/packages/grad/tests/swarm_linreg_dump.nu
@@ -1,0 +1,111 @@
+// swarm_linreg_dump.nu — the M7-2 bridge program: build a linear-regression
+// per-example loss ON THE TAPE, emit it as compute_iterate's grad() kernel,
+// and run the SAME gradient descent locally (tape backward per example,
+// coordinator update rule state -= lr·Σg/N mirrored) as the reference.
+// swarm-mcp/tests/grad_iterate_smoke.sh feeds the emitted kernel to a live
+// cluster and asserts the distributed run lands on this reference.
+//
+// Data: v(x) = 2.5·xf − 1.2 with xf = (double)x · 0.001, x ∈ [0, N).
+// Loss per example: (a·xf + b − v)².
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/floatbits.nu`
+$ `src/grad.nu`
+$ `src/emitc.nu`
+$ `deps/tensor/src/tensor.nu`
+
+@ sc * GTape tp f v b param → GVar {
+    : ( Vec f ) d ( vec_new [f] )
+    ( vec_push [f] d v )
+    : ( Vec i ) s ( vec_new [i] )
+    ( vec_push [i] s 1 )
+    : Tensor t ( tensor_from_data TE_F64 s d )
+    : GVar o ? param ( grad_param tp t ) ( grad_const tp t )
+    ( tensor_free t ) ( vec_free [f] d )
+    ^ o
+}
+
+@ cN → i { ^ 1000 }
+
+@ cLR → f { ^ 0.5 }
+
+@ cROUNDS → i { ^ 120 }
+
+// One example's parameter gradients via the tape (fresh episode per call).
+@ tape_grads f a f b f xf f v * u ga * u gb → v {
+    : *GTape tp ( tape_new )
+    : GVar pa ( sc tp a T )
+    : GVar pb ( sc tp b T )
+    : GVar xl ( sc tp xf F )
+    : GVar vl ( sc tp v F )
+    : GVar e ( g_sub tp ( g_add tp ( g_mul tp pa xl ) pb ) vl )
+    : GVar loss ( g_mul tp e e )
+    : b _bk ( backward tp loss )
+    : Tensor g1 ( grad_of tp pa )
+    : Tensor g2 ( grad_of tp pb )
+    ( nurl_poke ga 0 ( f64_to_bits ( _tf . g1 data 0 ) ) )
+    ( nurl_poke gb 0 ( f64_to_bits ( _tf . g2 data 0 ) ) )
+    ( tape_free tp )
+}
+
+@ main → i {
+    // ── emit the kernel from ONE symbolic episode ────────────────────
+    : *GTape tp ( tape_new )
+    : GVar pa ( sc tp 0.0 T )
+    : GVar pb ( sc tp 0.0 T )
+    : GVar xl ( sc tp 0.5 F )
+    : GVar vl ( sc tp 0.5 F )
+    : GVar e ( g_sub tp ( g_add tp ( g_mul tp pa xl ) pb ) vl )
+    : GVar loss ( g_mul tp e e )
+    : ( Vec i ) pids ( vec_new [i] )
+    ( vec_push [i] pids . pa id ) ( vec_push [i] pids . pb id )
+    : ( Vec i ) lids ( vec_new [i] )
+    ( vec_push [i] lids . xl id ) ( vec_push [i] lids . vl id )
+    : ( Vec s ) lexprs ( vec_new [s] )
+    ( vec_push [s] lexprs `(((double)x) * 0.001)` )
+    ( vec_push [s] lexprs `v` )
+    : String src ( string_new )
+    ? ( gemit_cuda_grad tp loss pids lids lexprs T src ) {} { ( nurl_print `EMIT FAILED\n` ) ^ 1 }
+    ( nurl_print `===SRC===\n` )
+    ( nurl_print ( string_data src ) )
+    ( string_free src )
+    ( vec_free [i] pids ) ( vec_free [i] lids ) ( vec_free [s] lexprs )
+    ( tape_free tp )
+
+    // ── the local reference: same GD, tape backward per example ─────
+    : i N ( cN )
+    : f LR ( cLR )
+    : i ROUNDS ( cROUNDS )
+    : ~ f a 0.0
+    : ~ f b2 0.0
+    : *u ga ( nurl_alloc 8 )
+    : *u gb ( nurl_alloc 8 )
+    : ~ i r 0
+    ~ < r ROUNDS {
+        : ~ f sa 0.0
+        : ~ f sb 0.0
+        : ~ i x 0
+        ~ < x N {
+            : f xf * # f x 0.001
+            : f v - * 2.5 xf 1.2
+            ( tape_grads a b2 xf v ga gb )
+            = sa + sa ( bits_to_f64 ( nurl_peek ga 0 ) )
+            = sb + sb ( bits_to_f64 ( nurl_peek gb 0 ) )
+            = x + x 1
+        }
+        = a - a / * LR sa # f N
+        = b2 - b2 / * LR sb # f N
+        = r + r 1
+    }
+    ( nurl_free ga ) ( nurl_free gb )
+    ( nurl_print `===REF===\n` )
+    ( nurl_print ( nurl_str_float a ) ) ( nurl_print `\n` )
+    ( nurl_print ( nurl_str_float b2 ) ) ( nurl_print `\n` )
+    ( nurl_print `===CFG===\n` )
+    ( nurl_print ( nurl_str_int N ) ) ( nurl_print `\n` )
+    ( nurl_print ( nurl_str_float LR ) ) ( nurl_print `\n` )
+    ( nurl_print ( nurl_str_int ROUNDS ) ) ( nurl_print `\n` )
+    ^ 0
+}

--- a/packages/swarm-mcp/tests/grad_iterate_smoke.sh
+++ b/packages/swarm-mcp/tests/grad_iterate_smoke.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# packages/swarm-mcp/tests/grad_iterate_smoke.sh — M7-2 live: the
+# compute_iterate kernel is DERIVED, not hand-written. grad's
+# tests/swarm_linreg_dump.nu builds a linear-regression loss on the
+# autograd tape, emits it as the __device__ grad() via gemit_cuda_grad,
+# and runs the same GD locally as the reference; this script feeds the
+# EMITTED kernel to a live cluster through compute_iterate and asserts
+# the distributed parameters land on the local tape's (atomicAdd/combine
+# order differs → tolerance, not bits; the bit-level tape↔C equivalence
+# is grad/tests/emitc_oracle.sh's job).
+#
+#   ./tests/grad_iterate_smoke.sh     # from the package root
+# Skips (exit 0) without an NVIDIA GPU.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+NURL_SH="$REPO/nurl.sh"
+export NURL_STDLIB="$REPO"
+
+if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi -L >/dev/null 2>&1; then
+    echo "[grad-iterate] SKIP — no NVIDIA GPU visible"; exit 0
+fi
+
+PORT="${SWARM_PORT:-47895}"; MCPP="${SWARM_MCP_PORT:-48458}"
+TOKEN="grad-iterate-secret"
+TMP="$(mktemp -d)"; export HOME="$TMP"; export TMPDIR="$TMP"
+BIN="$TMP/swarm-mcp"; WT="$TMP/wt"; node_pid=""
+cleanup() { [ -n "$node_pid" ] && kill -TERM "$node_pid" 2>/dev/null; sleep 0.3; [ -n "$node_pid" ] && kill -9 "$node_pid" 2>/dev/null; rm -rf "$TMP"; }
+trap cleanup EXIT
+MCP() { curl -sk -m 180 "https://127.0.0.1:$MCPP/mcp" -H 'Content-Type: application/json' -d "$1"; }
+
+echo "[grad-iterate] building the tape dump (packages/grad)"
+( cd "$REPO/packages/grad" && "$NURL_SH" tests/swarm_linreg_dump.nu "$TMP/dump" >/dev/null 2>&1 ) \
+    || { echo "[grad-iterate] FAIL build dump"; exit 1; }
+"$TMP/dump" > "$TMP/dump.txt" || { echo "[grad-iterate] FAIL run dump"; exit 1; }
+awk '/===SRC===/{f=1;next}/===REF===/{f=0}f' "$TMP/dump.txt" > "$TMP/grad.cu"
+REF_A="$(awk '/===REF===/{getline; print; exit}' "$TMP/dump.txt")"
+REF_B="$(awk '/===REF===/{getline; getline; print; exit}' "$TMP/dump.txt")"
+N="$(awk '/===CFG===/{getline; print; exit}' "$TMP/dump.txt")"
+LR="$(awk '/===CFG===/{getline; getline; print; exit}' "$TMP/dump.txt")"
+ROUNDS="$(awk '/===CFG===/{getline; getline; getline; print; exit}' "$TMP/dump.txt")"
+echo "[grad-iterate] emitted kernel: $(wc -l < "$TMP/grad.cu") lines · local tape ref a=$REF_A b=$REF_B (N=$N lr=$LR rounds=$ROUNDS)"
+
+echo "[grad-iterate] building swarm-mcp + wasmtime"
+"$NURL_SH" "$HERE/src/main.nu" "$BIN" >/dev/null 2>&1 || { echo "[grad-iterate] FAIL build swarm-mcp"; exit 1; }
+"$NURL_SH" "$REPO/packages/wasmtime/src/main.nu" "$WT" >/dev/null 2>&1 || { echo "[grad-iterate] FAIL build wt"; exit 1; }
+
+# the dataset the dump's reference used: v_k = 2.5·(k·0.001) − 1.2
+python3 - "$TMP/ds.f64" "$N" <<'PY'
+import struct, sys
+path, n = sys.argv[1], int(sys.argv[2])
+with open(path, "wb") as f:
+    for k in range(n): f.write(struct.pack("<d", 2.5 * (k * 0.001) - 1.2))
+PY
+
+echo "[grad-iterate] starting node on :$PORT / :$MCPP"
+WASMTIME="$WT" "$BIN" --token "$TOKEN" --relay --worker --gpu --mcp \
+    --listen 127.0.0.1:"$PORT" --mcp-listen 127.0.0.1:"$MCPP" >"$TMP/node.log" 2>&1 &
+node_pid=$!; sleep 2.5
+
+ds="$(MCP "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"compute_upload_data\",\"arguments\":{\"file\":\"$TMP/ds.f64\"}}}" | grep -oE 'dataset_id[^0-9]*[0-9]+' | grep -oE '[0-9]+' | head -1)"
+[ -z "$ds" ] && { echo "[grad-iterate] FAIL upload"; cat "$TMP/node.log" | tail -5; exit 1; }
+
+req="$(python3 -c "
+import json, sys
+src = open(sys.argv[1]).read()
+print(json.dumps({'jsonrpc':'2.0','id':2,'method':'tools/call','params':{'name':'compute_iterate','arguments':{'cuda':src,'state':[0.0,0.0],'rounds':int(sys.argv[3]),'lr':float(sys.argv[4]),'dataset':int(sys.argv[2])}}}))
+" "$TMP/grad.cu" "$ds" "$ROUNDS" "$LR")"
+res="$(MCP "$req")"
+
+got="$(printf '%s' "$res" | python3 -c "import json,sys; d=json.load(sys.stdin); t=d['result']['content'][0]['text']; o=json.loads(t); print(repr(o['state'][0])); print(repr(o['state'][1]))" 2>/dev/null)"
+A="$(printf '%s' "$got" | sed -n 1p)"
+B="$(printf '%s' "$got" | sed -n 2p)"
+echo "[grad-iterate] swarm result a=$A b=$B"
+
+if python3 -c "
+import sys
+a, b = float('$A'), float('$B')
+ra, rb = float('$REF_A'), float('$REF_B')
+ok = abs(a - ra) < 1e-6 and abs(b - rb) < 1e-6
+ok2 = abs(a - 2.5) < 0.05 and abs(b + 1.2) < 0.05
+sys.exit(0 if (ok and ok2) else 1)
+"; then
+    echo "[grad-iterate] PASS — DERIVED kernel trained on the swarm lands on the local tape reference (|Δ| < 1e-6) and the true line (2.5, −1.2)"
+else
+    echo "[grad-iterate] FAIL — swarm ($A,$B) vs tape ref ($REF_A,$REF_B)"
+    tail -5 "$TMP/node.log"
+    exit 1
+fi


### PR DESCRIPTION
## What

The live half of M7. `grad/tests/swarm_linreg_dump.nu` builds a linear-regression per-example loss **on the autograd tape**, emits it via `gemit_cuda_grad` as `compute_iterate`'s `__device__ grad()`, and runs the same GD locally (tape backward per example, the coordinator's `state -= lr·Σg/N` rule mirrored) as the reference. `swarm-mcp/tests/grad_iterate_smoke.sh` spins a live node (relay + GPU worker + MCP), uploads the dataset, feeds the **emitted** kernel through `compute_iterate`, and compares.

## Result

On the RTX 4090 the distributed parameters came back **bit-identical to the local tape reference** — `a=2.4993042033090695`, `b=−1.1996279824266811`, every digit, after 120 rounds over 1000 examples. The assertion stays tolerance-based (1e-6 vs the tape, 0.05 vs the true line) since atomicAdd/combine ordering is not guaranteed — but the whole derivation chain *tape → emitted C → NVRTC → cluster → SGD* reproduced the pure-NURL run exactly on this workload.

With this, the keystone plan's M7 sentence is true end to end: **swarm-mcp's gradient kernels are derived from the tape, not hand-written.** (The bit-level tape↔C equivalence itself is pinned by `grad/tests/emitc_oracle.sh` from #581.)

Skips cleanly without an NVIDIA GPU; released-toolchain build of the dump verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im