### PR TITLE
fix(nurllama+anomaly): release metadata — dep floor, stale version banners

### DIFF
--- a/packages/anomaly/nurl.toml
+++ b/packages/anomaly/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anomaly"
-version = "0.5.0"
+version = "0.5.1"
 description = "Streaming anomaly-detection service in pure NURL — dynamically created, automatically trained models over Isolation Forests. Where the `iforest` package is the kernel (matrix in, scores out), `anomaly` is the service around it: named dynamic models are created on first use, ingest one JSON data point at a time, and train themselves once enough history has accumulated — no offline training step, no labels. Heterogeneous features are encoded automatically (numeric passthrough, categorical → deterministic one-hot, ISO-8601 timestamps → calendar features), standardised with a persisted scaler, and projected onto a stable feature order so retrains never scramble one-hot columns. Each model keeps several time-window versions (short-term / daily / weekly / seasonal) judged at once; a point is anomalous if any enabled window flags it, thresholds are tunable per version, and a fine-tune pass recalibrates margins against observed data. Models persist to disk (JSON metadata + compact forest blobs) and survive restarts. Ships as a library (model_open/model_ingest/model_detect_only/…), a CLI (`anomaly detect|score|batch|train|ls|info|serve`), and an HTTP/JSON service whose routes mirror a Flask reference API (POST /detect/<model>, /detect_only/<model>, /detect_anomalies, model management) so existing dashboards keep working. `anomaly serve` also ships a self-contained web dashboard (model manager, trainer, feature visualiser and anomaly scanner — plain HTML/JS, no CDN or build step) served straight from the binary's web root."
 license = "MIT OR Apache-2.0"
 
@@ -10,7 +10,7 @@ gpu = { path = "../gpu", version = "^0.9.0" }
 http = { path = "../http", version = "^0.3.1" }
 cli = { path = "../cli", version = "^0.2.0" }
 gpukit = { path = "../gpukit", version = "^0.4" }
-mlp = { path = "../mlp", version = "^0.2" }
+mlp = { path = "../mlp", version = "^0.3" }
 
 # Runtime data staged into $NURL_HOME/share/anomaly/ on `nurlpkg install`.
 # The `serve` dashboard resolves its web root as <exe-dir>/../share/anomaly/static,

--- a/packages/anomaly/src/main.nu
+++ b/packages/anomaly/src/main.nu
@@ -495,7 +495,7 @@ $ `src/service.nu`
 }
 
 @ main → i {
-    : *Cli c ( cli_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` `0.3.6` )
+    : *Cli c ( cli_new `anomaly` `Streaming anomaly detection: dynamic self-training models over Isolation Forests.` `0.5.1` )
     ( cli_flag_str c `store` 115 `DIR` `model store (default: $ANOMALY_HOME, else ~/.anomaly)` `` `ANOMALY_HOME` )
     ( cli_flag_str c `file` 102 `FILE` `for batch: read CSV from FILE instead of stdin` `` `` )
     ( cli_flag_str c `margin` 109 `M` `for batch: decision margin (default 0 = predict==-1)` `0` `` )

--- a/packages/mlp/nurl.toml
+++ b/packages/mlp/nurl.toml
@@ -1,9 +1,9 @@
 [package]
 name = "mlp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Trainable multi-layer perceptron in pure NURL — dense layers, ReLU, Adam, minibatches, early stopping. The training-side counterpart to the ecosystem's inference packages: a seedable, deterministic MLP regressor faithful to sklearn's MLPRegressor semantics (Glorot init, squared loss with L2, Adam bias correction, validation-split early stopping with best-weight restore), plus a MinMax scaler. An autoencoder is just mlp_train with X as both input and target — reconstruction-error anomaly detection, embeddings, denoising. Models and scalers persist to JSON with bit-exact f64 round-trip. Two training engines: the hand-written backprop (default, no dependencies beyond flat buffers) and mlp_fit_grad, the same sklearn recipe driven by the grad autograd package — same API, same oracle bar, one loss expression instead of hand-derived layer deltas."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-grad = "^0.1"
+grad = "^0.4"
 tensor = "^0.4"

--- a/packages/nurllama/nurl.toml
+++ b/packages/nurllama/nurl.toml
@@ -10,6 +10,6 @@ safetensor = { path = "../safetensor", version = "^0.2.1" }
 tokenizer = { path = "../tokenizer", version = "^0.3.0" }
 gpu = { path = "../gpu", version = "^0.9.0" }
 http = { path = "../http", version = "^0.3" }
-grad = { path = "../grad", version = "^0.3" }
+grad = { path = "../grad", version = "^0.4" }
 gpukit = { path = "../gpukit", version = "^0.4.2" }
 tensor = { path = "../tensor", version = "^0.4" }

--- a/packages/nurllama/src/main.nu
+++ b/packages/nurllama/src/main.nu
@@ -606,7 +606,7 @@ $ `stdlib/std/term.nu`
         ^ 0
     } {}
     ? ( args_present p `version` ) {
-        ( nurl_print `nurllama 0.1.0\n` )
+        ( nurl_print `nurllama 0.12.1\n` )
         ( args_free p )
         ^ 0
     } {}


### PR DESCRIPTION
- nurllama: widen grad to ^0.4 (the publish gate rejected ^0.3 — the
  local build compiles against grad 0.4.0, so registry consumers must
  too), and `--version` said "nurllama 0.1.0" since the first release;
  it now tracks the manifest (0.12.1).
- anomaly: the CLI banner said 0.3.6 (three releases stale); 0.5.1 with
  the banner in lockstep.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WX2frzGUucJVZjARF389im
