### PR TITLE
fix(tests): the Windows cbor golden missed the nurl_str_float round-trip fix

### DIFF
--- a/compiler/tests/outputs-windows/cbor.txt
+++ b/compiler/tests/outputs-windows/cbor.txt
@@ -29,7 +29,7 @@ half_neg4: -4
 half_0: 0
 single_100000: 100000
 double_1.1: 1.1
-double_pi: 3.14159
+double_pi: 3.141592653589793
 bytestring: unsupported
 tag: unsupported
 indefinite_arr: unsupported


### PR DESCRIPTION
PR #563 taught nurl_str_float to round-trip and updated the Linux golden
(double_pi: 3.141592653589793) but the Windows golden set kept the old
6-digit truncation — the exact miss class the v0.20.0 release hit with
the __-rename. windows-tests was the only red on the v0.22.0 changelog
SHA; this makes the corpus consistent across golden sets.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WX2frzGUucJVZjARF389im
