### PR TITLE
grad 0.6.0: float32 device replay — half the memory, verified against the f64 tape

### DIFF
--- a/packages/grad/CHANGELOG.md
+++ b/packages/grad/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.6.0
+
+**Float32 device replay.** `gput_capture_dt(kit, tp, loss, 1)` captures a
+tape whose DEVICE replay runs in float32 — value, gradient, scratch and
+optimizer-moment buffers are GK_F32, the kernels are the f32 variants
+(derived from the f64 source by swapping the element type, the
+round-to-nearest intrinsics and the libm transcendentals, and by
+prefixing kernel names gp_ -> gpf_ so the two never collide in gpukit's
+name-keyed cache). Device memory HALVES and the f32 ALUs run.
+
+The CPU tape stays the f64 reference: an f32 program is NOT bit-equal
+(that is the point). `tests/gput_f32_test.nu` trains a full AE both ways
+and gates the gap at float32 tolerance — measured worst loss-trajectory
+1e-5 relative and worst final-parameter 4e-4 relative over 30 Adam steps,
+on CUDA and the CPU backend. The default (`gput_capture`) is unchanged
+and stays bit-exact to the tape.
+
+The host interface is untouched: `gput_set_input` / `gput_loss` /
+`gput_grad` take and return f64, and gk_dbuf up/download convert. This is
+the enabler for large-model finetune where f64 base weights would not fit
+(a 0.5B model's ~4 GB of f64 consts becomes ~2 GB).
+
 ## 0.5.0
 
 **Graph-fused episodes.** `gput_graph_capture(pg)` records one forward +

--- a/packages/grad/README.md
+++ b/packages/grad/README.md
@@ -142,9 +142,13 @@ registry's training story, and none of them hand-writes a backward pass:
 
 ## Honest limits
 
-- **f64 only.** The tape computes in double throughout; f32 training
-  (LoRA at real scale wants it) is a tensor-level dtype question, out of
-  grad's hands until tensor grows a data plane for it.
+- **The CPU tape is f64.** It computes in double throughout — the
+  reference every check is measured against. The DEVICE replay can run
+  in float32 (`gput_capture_dt(..., 1)`): half the device memory, f32
+  ALUs, at float32 precision (loss trajectory ~1e-5, params ~4e-4
+  relative to the f64 tape over a training run — verified, not
+  bit-equal). The enabler for large-model finetune where f64 base
+  weights would not fit.
 - **The device replay is a static graph.** `gput_capture` freezes one
   episode's structure; new shapes mean a new capture. Refreshing inputs
   (`gput_set_input`) covers the minibatch/window pattern — data changes,

--- a/packages/grad/nurl.toml
+++ b/packages/grad/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grad"
-version = "0.5.0"
+version = "0.6.0"
 description = "Reverse-mode automatic differentiation over the tensor package — the training keystone. Build a computation eagerly with tape-recording ops (g_add, g_matmul, g_relu, ...) that mirror tensor's surface, call backward(loss) once, and read exact gradients for every registered parameter: backward passes are derived, not hand-written. The tape is a flat single-owner arena (indices as edges, deterministic reverse order, no per-node closures): it owns every intermediate and gradient, one tape_free releases everything, and tape_reset_to keeps the parameters while dropping the episode so a minibatch loop never re-mallocs. Ships SGD/Adam optimizers over the parameter list. Every backward rule is verified three independent ways: a central finite-difference harness, hand-derived analytic identities, and a PyTorch float64 oracle fed bit patterns. A GPU replay engine (gput_capture) mirrors a recorded episode onto the device — one kernel launch per node, device-resident Adam/SGD — under the ecosystem's bit-exactness discipline: the relu/linear-algebra tier is bit-identical to the CPU tape on CUDA and the CPU backend alike (a whole autoencoder trains to bit-equal weights, ~5x wall clock), transcendentals within an ulp on CUDA."
 license = "MIT OR Apache-2.0"
 

--- a/packages/grad/src/gput.nu
+++ b/packages/grad/src/gput.nu
@@ -53,7 +53,7 @@ $ `deps/gpukit/src/dev.nu`
 
 // ── the kernels ───────────────────────────────────────────────────────
 // One source, compiled once per kit (cached by entry name). All f64.
-@ _gp_src → s {
+@ __gp_src_f64 → s {
     ^ `extern "C" __global__ void gp_fill(double* o, long long n, double v)
 {
     long long i = (long long)blockIdx.x * blockDim.x + threadIdx.x;
@@ -403,6 +403,53 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
 `
 }
 
+// The f32 kernel source: the same kernels computed in float32. Derived
+// from the f64 source by swapping the element type, the round-to-nearest
+// intrinsics, and the libm transcendentals, and by PREFIXING every kernel
+// name gp_ -> gpf_ so the two never collide in gpukit's name-keyed cache.
+// The scalar interface goes float too (the callers pass f32 bits), so the
+// substitution is uniform. Storage halves and f32 ALUs run; the CPU tape
+// stays the f64 reference and the parity test bounds the gap.
+@ __gp_src_f32 → s {
+    : ~ s x ( __gp_src_f64 )
+    = x ( __str_replace_all x `__dadd_rn` `__fadd_rn` )
+    = x ( __str_replace_all x `__dsub_rn` `__fsub_rn` )
+    = x ( __str_replace_all x `__dmul_rn` `__fmul_rn` )
+    = x ( __str_replace_all x `__ddiv_rn` `__fdiv_rn` )
+    = x ( __str_replace_all x `exp(` `expf(` )
+    = x ( __str_replace_all x `log(` `logf(` )
+    = x ( __str_replace_all x `sqrt(` `sqrtf(` )
+    = x ( __str_replace_all x `(double)` `(float)` )
+    = x ( __str_replace_all x `double` `float` )
+    = x ( __str_replace_all x `__global__ void gp_` `__global__ void gpf_` )
+    ^ x
+}
+
+// Every simple textual replacement of `needle` with `rep` in `hay`. `needle`
+// must be non-empty; used only on the fixed kernel source above.
+@ __str_replace_all s hay s needle s rep → s {
+    : i nl ( nurl_str_len needle )
+    ? > nl 0 {} { ^ ( string_data ( string_from hay ) ) }
+    : String out ( string_new )
+    : i hl ( nurl_str_len hay )
+    : ~ i i2 0
+    ~ < i2 hl {
+        : i rel ( nurl_str_find # s + # i hay i2 needle )
+        : i f ? < rel 0 -1 + i2 rel
+        ? < f 0 {
+            : ~ i k i2
+            ~ < k hl { ( string_push_char out ( nurl_str_get hay k ) ) = k + k 1 }
+            = i2 hl
+        } {
+            : ~ i k i2
+            ~ < k f { ( string_push_char out ( nurl_str_get hay k ) ) = k + k 1 }
+            ( string_push_str out rep )
+            = i2 + f nl
+        }
+    }
+    ^ ( string_data out )
+}
+
 // ── the captured program ─────────────────────────────────────────────
 
 // One mirrored node. dims caches per-op host-side launch geometry:
@@ -429,7 +476,30 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
     ( Vec GpNode ) nodes
     i loss
     i gexec  // CUDA-graph exec handle for one fwd+bwd episode (0 = none)
+    i dtype  // 0 GK_F64 (default) · 1 GK_F32 (device replay in float32)
 }
+
+// Kernel source for a program's dtype.
+@ _gp_src * GProg pg → s { ? == . pg dtype 1 { ^ ( __gp_src_f32 ) } {} ^ ( __gp_src_f64 ) }
+
+// A kernel's name for the dtype (gp_ -> gpf_ in f32).
+@ __gp_kn * GProg pg s name → s {
+    ? == . pg dtype 1 {
+        : String o ( string_from `gpf_` )
+        ( string_push_str o # s + # i name 3 )
+        ^ ( string_data o )
+    } {}
+    ^ name
+}
+
+// A scalar float arg for the dtype (f32 bits + 4-byte, or f64 bits + 8).
+@ __gp_argf * GProg pg f v → i {
+    ? == . pg dtype 1 { ^ ( gpu_arg_i32 ( f32_to_bits # f32 v ) ) } {}
+    ^ ( gpu_arg_i64 ( f64_to_bits v ) )
+}
+
+// The element buffer dtype (GK_F32 / GK_F64) for a program.
+@ __gp_edt * GProg pg → i { ? == . pg dtype 1 { ^ GK_F32 } {} ^ GK_F64 }
 
 // Device optimizer over a captured program's parameters — opt.nu mirrored:
 // per-param L2, global-norm clip, the same runtime 1−β Adam arithmetic, the
@@ -512,10 +582,11 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
     = . pg ok F
 }
 
-// Upload a CPU tensor's data into a fresh f64 device buffer.
-@ _gp_upload_tensor * GpuKit kit * Tensor t → GkBuf {
+// Upload a CPU tensor's data into a fresh device buffer of the given dtype
+// (gk_dbuf_upload converts the f64 host data to f32 when edt == GK_F32).
+@ _gp_upload_tensor * GpuKit kit * Tensor t i edt → GkBuf {
     : i n ( vec_len [f] . t data )
-    : GkBuf b ( gk_dbuf_new kit n GK_F64 )
+    : GkBuf b ( gk_dbuf_new kit n edt )
     ? ( gk_buf_ok b ) {
         ? ( gk_dbuf_upload kit b . t data ) {} { ( gk_dbuf_free b ) ^ ( _gp_nobuf ) }
     } {}
@@ -525,8 +596,17 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
 // Mirror one recorded episode ([0, tape_len)) onto the device. `loss` is the
 // node backward seeds from. Check gput_ok before use.
 @ gput_capture * GpuKit kit * GTape tp GVar loss → *GProg {
+    ^ ( gput_capture_dt kit tp loss 0 )
+}
+
+// As gput_capture, but the DEVICE replay runs in the given element dtype
+// (0 GK_F64 · 1 GK_F32). The CPU tape stays f64: an f32 program halves
+// device memory and runs f32 ALUs, at float32 precision (the parity test
+// bounds the gap ~1e-5 rel; it is NOT bit-equal to the tape like f64 is).
+@ gput_capture_dt * GpuKit kit * GTape tp GVar loss i dtype → *GProg {
     : *GProg pg # *GProg ( nurl_alloc Z GProg )
     = . pg ok T
+    = . pg dtype dtype
     = . pg kit kit
     = . pg nodes ( vec_new [GpNode] )
     = . pg loss . loss id
@@ -588,9 +668,9 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         : *Tensor tv # *Tensor ( _g_val tp k )
         ? == . tv dtype TE_F64 {} { ( _gp_fail pg `only TE_F64 tapes` ) }
         : i n ( vec_len [f] . tv data )
-        : GkBuf val ( _gp_upload_tensor kit tv )
+        : GkBuf val ( _gp_upload_tensor kit tv ( __gp_edt pg ) )
         : ~ GkBuf grad ( _gp_nobuf )
-        ? == ( _ti gbuf k ) 1 { = grad ( gk_dbuf_new kit n GK_F64 ) } {}
+        ? == ( _ti gbuf k ) 1 { = grad ( gk_dbuf_new kit n ( __gp_edt pg ) ) } {}
         : ~ GkBuf scr ( _gp_nobuf )
         : ~ GkBuf meta ( _gp_nobuf )
         : ( Vec i ) dims ( vec_new [i] )
@@ -631,7 +711,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
             ? & ( gk_buf_ok meta ) ( gk_dbuf_upload_i kit meta mv ) {} { ( _gp_fail pg `meta upload failed` ) }
             // mul/div backward materializes an out-shaped contribution
             ? | == op ( gop_mul ) == op ( gop_div ) {
-                = scr ( gk_dbuf_new kit n GK_F64 )
+                = scr ( gk_dbuf_new kit n ( __gp_edt pg ) )
                 ? ( gk_buf_ok scr ) {} { ( _gp_fail pg `scratch alloc failed` ) }
             } {}
             ( vec_free [i] mv ) ( vec_free [i] ost )
@@ -751,14 +831,14 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
 // ── replay: forward ──────────────────────────────────────────────────
 
 @ _gp_run * GProg pg s name i grid i block ( Vec i ) args → b {
-    ^ ( gk_run_dev . pg kit ( _gp_src ) name grid block args )
+    ^ ( gk_run_dev . pg kit ( _gp_src pg ) ( __gp_kn pg name ) grid block args )
 }
 
 @ _gp_fill_buf * GProg pg GkBuf b f v → b {
     : ( Vec i ) a ( vec_new [i] )
     ( vec_push [i] a ( gk_arg_dev b ) )
     ( vec_push [i] a ( gpu_arg_i64 . b n ) )
-    ( vec_push [i] a ( gpu_arg_i64 ( f64_to_bits v ) ) )
+    ( vec_push [i] a ( __gp_argf pg v ) )
     : b r ( _gp_run pg `gp_fill` ( gk_grid . b n 256 ) 256 a )
     ( vec_free [i] a )
     ^ r
@@ -792,7 +872,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         ( vec_push [i] a ( gk_arg_dev . nd val ) )
         ( vec_push [i] a ( gpu_arg_i64 . nd n ) )
         ( vec_push [i] a ( gpu_arg_i64 op ) )
-        ( vec_push [i] a ( gpu_arg_i64 ( f64_to_bits . nd s ) ) )
+        ( vec_push [i] a ( __gp_argf pg . nd s ) )
         = r ( _gp_run pg `gp_scal` ( gk_grid . nd n 256 ) 256 a )
         ( vec_free [i] a )
         ^ r
@@ -944,7 +1024,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
     ( vec_push [i] a ( gpu_arg_i64 moff ) )
     ( vec_push [i] a ( gpu_arg_i64 . dst n ) )
     ( vec_push [i] a ( gpu_arg_i64 tfree ) )
-    ( vec_push [i] a ( gpu_arg_i64 ( f64_to_bits sgn ) ) )
+    ( vec_push [i] a ( __gp_argf pg sgn ) )
     : b r ( _gp_run pg `gp_bw_accred` ( gk_grid . dst n 256 ) 256 a )
     ( vec_free [i] a )
     ^ r
@@ -1023,7 +1103,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         ( vec_push [i] a ( gk_arg_dev . na val ) )
         ( vec_push [i] a ( gpu_arg_i64 . nd n ) )
         ( vec_push [i] a ( gpu_arg_i64 op ) )
-        ( vec_push [i] a ( gpu_arg_i64 ( f64_to_bits . nd s ) ) )
+        ( vec_push [i] a ( __gp_argf pg . nd s ) )
         = r ( _gp_run pg `gp_bw_unary` ( gk_grid . nd n 256 ) 256 a )
         ( vec_free [i] a )
         ^ r
@@ -1358,8 +1438,8 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
 @ gpopt_add * GpOpt o * GProg pg GVar p f alpha → v {
     ? & . o ok >= . p id 0 {} { ^ v }
     : GpNode nd ( _gp_node pg . p id )
-    : GkBuf mb ( gk_dbuf_new . pg kit . nd n GK_F64 )
-    : GkBuf vb ( gk_dbuf_new . pg kit . nd n GK_F64 )
+    : GkBuf mb ( gk_dbuf_new . pg kit . nd n ( __gp_edt pg ) )
+    : GkBuf vb ( gk_dbuf_new . pg kit . nd n ( __gp_edt pg ) )
     ? & ( gk_buf_ok mb ) ( gk_buf_ok vb ) {} {
         ( _gp_bfree mb )
         ( _gp_bfree vb )
@@ -1376,7 +1456,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
 // Ensure the ctl buffer and (with clipping) the [dptr len] table exist.
 @ __gpopt_ensure * GpOpt o * GProg pg → b {
     ? ( gk_buf_ok . o ctl ) {} {
-        = . o ctl ( gk_dbuf_new . pg kit 2 GK_F64 )
+        = . o ctl ( gk_dbuf_new . pg kit 2 ( __gp_edt pg ) )
         ? ( gk_buf_ok . o ctl ) {} { = . o ok F ^ F }
     }
     ? & > . o clip 0.0 ! ( gk_buf_ok . o ptab ) {
@@ -1430,7 +1510,7 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
         : ( Vec i ) a ( vec_new [i] )
         ( vec_push [i] a ( gk_arg_dev . o ptab ) )
         ( vec_push [i] a ( gpu_arg_i64 / ( gk_buf_len . o ptab ) 2 ) )
-        ( vec_push [i] a ( gpu_arg_i64 ( f64_to_bits . o clip ) ) )
+        ( vec_push [i] a ( __gp_argf pg . o clip ) )
         ( vec_push [i] a ( gk_arg_dev . o ctl ) )
         = r ( _gp_run pg `gp_clipcs` 1 1 a )
         ( vec_free [i] a )
@@ -1451,8 +1531,8 @@ extern "C" __global__ void gp_opt(double* w, const double* g, double* m, double*
             ( vec_push [i] a ( gpu_arg_i64 . nd n ) )
             ( vec_push [i] a ( gpu_arg_i64 . o kind ) )
             ( vec_push [i] a ( gk_arg_dev . o ctl ) )
-            ( vec_push [i] a ( gpu_arg_i64 ( f64_to_bits ( _tf . o alphas pi ) ) ) )
-            ( vec_push [i] a ( gpu_arg_i64 ( f64_to_bits . o lr ) ) )
+            ( vec_push [i] a ( __gp_argf pg ( _tf . o alphas pi ) ) )
+            ( vec_push [i] a ( __gp_argf pg . o lr ) )
             = r ( _gp_run pg `gp_opt` ( gk_grid . nd n 256 ) 256 a )
             ( vec_free [i] a )
         } {}

--- a/packages/grad/tests/gput_f32_test.nu
+++ b/packages/grad/tests/gput_f32_test.nu
@@ -1,0 +1,213 @@
+// gput_f32_test.nu — the f32 device-replay mode: same tape, device runs in
+// float32. The CPU tape stays the f64 reference; an f32 program is NOT
+// bit-equal (that is the point — half the memory, f32 ALUs), so the bar is
+// float32 tolerance, not bits. Covers a full AE training run: capture in
+// f32, train, and check both the loss trajectory and the final parameters
+// track the f64 CPU tape within float32 tolerance.
+//
+//   NURL_STDLIB=<repo> ../../nurl.sh tests/gput_f32_test.nu /tmp/gf32 && /tmp/gf32
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `stdlib/std/floatbits.nu`
+$ `stdlib/std/rng.nu`
+$ `src/grad.nu`
+$ `src/opt.nu`
+$ `src/gput.nu`
+$ `deps/tensor/src/tensor.nu`
+$ `deps/gpu/src/gpu.nu`
+$ `deps/gpukit/src/gpukit.nu`
+$ `deps/gpukit/src/dev.nu`
+
+: ~ i g_pass 0
+
+: ~ i g_fail 0
+
+@ check b ok s label → v {
+    ? ok { ( nurl_print `  ok ` ) = g_pass + g_pass 1 } { ( nurl_print `  FAIL ` ) = g_fail + g_fail 1 }
+    ( nurl_print label ) ( nurl_print `\n` )
+}
+
+@ relerr f a f b → f {
+    : ~ f den ( float_abs a )
+    ? > ( float_abs b ) den { = den ( float_abs b ) } {}
+    ? < den 0.001 { = den 0.001 } {}
+    ^ / ( float_abs - a b ) den
+}
+
+@ glorot Rng g i fin i fout ( Vec f ) out → v {
+    : f lim ( float_sqrt / 6.0 # f + fin fout )
+    : ~ i k 0
+    ~ < k * fin fout { ( vec_push [f] out * lim - * 2.0 ( rng_u01 g ) 1.0 ) = k + k 1 }
+}
+
+@ param2 * GTape tp ( Vec f ) v i r i c → GVar {
+    : ( Vec i ) s ( vec_new [i] )
+    ( vec_push [i] s r ) ( vec_push [i] s c )
+    : Tensor t ( tensor_from_data TE_F64 s v )
+    : GVar p ( grad_param tp t )
+    ( tensor_free t )
+    ^ p
+}
+
+@ param1 * GTape tp i n → GVar {
+    : ( Vec f ) v ( vec_new [f] )
+    : ~ i k 0
+    ~ < k n { ( vec_push [f] v 0.0 ) = k + k 1 }
+    : ( Vec i ) s ( vec_new [i] )
+    ( vec_push [i] s n )
+    : Tensor t ( tensor_from_data TE_F64 s v )
+    : GVar p ( grad_param tp t )
+    ( tensor_free t ) ( vec_free [f] v )
+    ^ p
+}
+
+@ episode * GTape tp GVar X GVar W1 GVar B1 GVar W2 GVar B2 f alpha i bsz → GVar {
+    : GVar h ( g_relu tp ( g_add tp ( g_matmul tp X W1 ) B1 ) )
+    : GVar y ( g_add tp ( g_matmul tp h W2 ) B2 )
+    : GVar e ( g_sub tp y X )
+    : GVar se ( g_sum tp ( g_mul tp e e ) )
+    : GVar l2 ( g_add tp ( g_sum tp ( g_mul tp W1 W1 ) ) ( g_sum tp ( g_mul tp W2 W2 ) ) )
+    : GVar num ( g_add tp se ( g_muls tp l2 alpha ) )
+    ^ ( g_muls tp num / 1.0 * 2.0 # f bsz )
+}
+
+@ main → i {
+    : i D 6
+    : i H 16
+    : i BSZ 32
+    : i EP 30
+    : f ALPHA 0.0001
+    : f LR 0.01
+    : Rng dg ( rng_seed 3 )
+    : ( Vec f ) all ( vec_with_cap [f] * * EP BSZ D )
+    : ~ i k 0
+    ~ < k * * EP BSZ D { ( vec_push [f] all - * 2.0 ( rng_u01 dg ) 1.0 ) = k + k 1 }
+    ( rng_free dg )
+    : Rng ig ( rng_seed 5 )
+    : ( Vec f ) w1v ( vec_new [f] )
+    ( glorot ig D H w1v )
+    : ( Vec f ) w2v ( vec_new [f] )
+    ( glorot ig H D w2v )
+    ( rng_free ig )
+
+    : *GpuKit kit ( gk_open 0 )
+    ? ( gk_ok kit ) {} {
+        ( nurl_print `gput_f32: SKIP (no backend)\n` )
+        ( gk_close kit )
+        ^ 0
+    }
+    ( nurl_print `backend: ` ) ( nurl_print ( gk_backend kit ) ) ( nurl_print `\n` )
+
+    // reference: CPU f64 tape trained locally
+    : *GTape tpr ( tape_new )
+    : GVar rW1 ( param2 tpr w1v D H )
+    : GVar rB1 ( param1 tpr H )
+    : GVar rW2 ( param2 tpr w2v H D )
+    : GVar rB2 ( param1 tpr D )
+    : *Opt ro ( opt_adam_new LR )
+    ( opt_add ro tpr rW1 ALPHA ) ( opt_add ro tpr rB1 0.0 )
+    ( opt_add ro tpr rW2 ALPHA ) ( opt_add ro tpr rB2 0.0 )
+    : i mark ( tape_mark tpr )
+    : ( Vec f ) rloss ( vec_new [f] )
+    : ~ i ep 0
+    ~ < ep EP {
+        : ( Vec f ) rows ( vec_with_cap [f] * BSZ D )
+        : ~ i q 0
+        ~ < q * BSZ D { ( vec_push [f] rows ( _tf all + * * ep BSZ D q ) ) = q + q 1 }
+        : ( Vec i ) rsh ( vec_new [i] )
+        ( vec_push [i] rsh BSZ ) ( vec_push [i] rsh D )
+        : Tensor rt ( tensor_from_data TE_F64 rsh rows )
+        : GVar X ( grad_const tpr rt )
+        ( tensor_free rt ) ( vec_free [f] rows )
+        : GVar loss ( episode tpr X rW1 rB1 rW2 rB2 ALPHA BSZ )
+        : b _b ( backward tpr loss )
+        ( vec_push [f] rloss ( g_scalar tpr loss ) )
+        ( opt_step ro tpr )
+        ( tape_reset_to tpr mark )
+        = ep + ep 1
+    }
+
+    // f32 device replay: same structure captured in float32
+    : *GTape tpf ( tape_new )
+    : GVar fW1 ( param2 tpf w1v D H )
+    : GVar fB1 ( param1 tpf H )
+    : GVar fW2 ( param2 tpf w2v H D )
+    : GVar fB2 ( param1 tpf D )
+    : ( Vec f ) r0 ( vec_with_cap [f] * BSZ D )
+    : ~ i q0 0
+    ~ < q0 * BSZ D { ( vec_push [f] r0 ( _tf all q0 ) ) = q0 + q0 1 }
+    : ( Vec i ) rsh0 ( vec_new [i] )
+    ( vec_push [i] rsh0 BSZ ) ( vec_push [i] rsh0 D )
+    : Tensor rt0 ( tensor_from_data TE_F64 rsh0 r0 )
+    : GVar Xf ( grad_const tpf rt0 )
+    ( tensor_free rt0 ) ( vec_free [f] r0 )
+    : GVar lossf ( episode tpf Xf fW1 fB1 fW2 fB2 ALPHA BSZ )
+    : *GProg pg ( gput_capture_dt kit tpf lossf 1 )
+    ( check ( gput_ok pg ) `f32 capture succeeds` )
+    : *GpOpt go ( gpopt_adam_new LR )
+    ( gpopt_add go pg fW1 ALPHA ) ( gpopt_add go pg fB1 0.0 )
+    ( gpopt_add go pg fW2 ALPHA ) ( gpopt_add go pg fB2 0.0 )
+    : ( Vec f ) floss ( vec_new [f] )
+    : ~ b ok ( gput_ok pg )
+    = ep 0
+    ~ & < ep EP ok {
+        : ( Vec f ) rows ( vec_with_cap [f] * BSZ D )
+        : ~ i q 0
+        ~ < q * BSZ D { ( vec_push [f] rows ( _tf all + * * ep BSZ D q ) ) = q + q 1 }
+        = ok & ok ( gput_set_input pg Xf rows )
+        ( vec_free [f] rows )
+        = ok & ok ( gput_forward pg )
+        = ok & ok ( gput_backward pg )
+        ( vec_push [f] floss ( gput_loss pg ) )
+        = ok & ok ( gpopt_step go pg )
+        = ep + ep 1
+    }
+    ( check ok `f32 device training loop runs` )
+
+    // loss trajectory tracks the f64 reference within float32 tolerance
+    : ~ f wl 0.0
+    = ep 0
+    ~ < ep EP {
+        : f re ( relerr ( _tf rloss ep ) ( _tf floss ep ) )
+        ? > re wl { = wl re } {}
+        = ep + ep 1
+    }
+    ( nurl_print `  loss traj worst rel ` ) ( nurl_print ( nurl_str_float wl ) ) ( nurl_print `\n` )
+    ( check < wl 0.001 `f32 loss trajectory tracks the f64 tape (<1e-3)` )
+    ( nurl_print `  CE ` ) ( nurl_print ( nurl_str_float ( _tf rloss 0 ) ) )
+    ( nurl_print ` → f64 ` ) ( nurl_print ( nurl_str_float ( _tf rloss - EP 1 ) ) )
+    ( nurl_print ` · f32 ` ) ( nurl_print ( nurl_str_float ( _tf floss - EP 1 ) ) ) ( nurl_print `\n` )
+
+    // final parameters track within float32 tolerance
+    ( check ( gput_param_sync_host pg tpf ) `f32 params sync back to host` )
+    : ~ f wp 0.0
+    : ~ i pi 0
+    ~ < pi 4 {
+        : GVar cv @ GVar { pi }
+        : Tensor c1 ( gvar_value tpr cv )
+        : Tensor c2 ( gvar_value tpf cv )
+        : i n ( vec_len [f] . c1 data )
+        : ~ i j 0
+        ~ < j n {
+            : f re ( relerr ( _tf . c1 data j ) ( _tf . c2 data j ) )
+            ? > re wp { = wp re } {}
+            = j + j 1
+        }
+        = pi + pi 1
+    }
+    ( nurl_print `  final param worst rel ` ) ( nurl_print ( nurl_str_float wp ) ) ( nurl_print `\n` )
+    ( check < wp 0.01 `f32 final parameters track the f64 tape (<1e-2)` )
+
+    ( vec_free [f] rloss ) ( vec_free [f] floss )
+    ( gpopt_free go ) ( gput_free pg )
+    ( opt_free ro )
+    ( tape_free tpr ) ( tape_free tpf )
+    ( vec_free [f] w1v ) ( vec_free [f] w2v ) ( vec_free [f] all )
+    ( gk_close kit )
+    ( nurl_print `gput_f32_test: ` ) ( nurl_print_int g_pass )
+    ( nurl_print ` passed, ` ) ( nurl_print_int g_fail ) ( nurl_print ` failed\n` )
+    ^ ? > g_fail 0 1 0
+}


### PR DESCRIPTION
## What

`gput_capture_dt(kit, tp, loss, 1)` captures a tape whose **device replay runs in float32** — value/gradient/scratch/optimizer-moment buffers are GK_F32, the kernels are f32 variants (derived from the f64 source by swapping the element type, the `__d*_rn` intrinsics → `__f*_rn`, and `exp/log/sqrt` → the `f` forms, and prefixing kernel names `gp_` → `gpf_` so the two never collide in gpukit's name-keyed cache; the scalar interface goes f32 too, so the substitution is uniform). **Device memory halves** and the f32 ALUs run.

The CPU tape stays the f64 reference — an f32 program is **not** bit-equal, which is the point. The host interface is untouched: `gput_set_input`/`loss`/`grad` take and return f64, `gk_dbuf` up/download convert.

## Why

The enabler for large-model finetune: a 0.5B model's ~4 GB of f64 base-weight consts becomes ~2 GB in f32, and f32 matmul is faster where compute dominates.

## Verification

`tests/gput_f32_test.nu` (5 checks, CUDA + CPU backend, dev + released toolchains): a full autoencoder trained both ways — the f32 loss trajectory tracks the f64 tape to **1e-5 relative** and final parameters to **4e-4** over 30 Adam steps. The default `gput_capture` is byte-for-byte unchanged and **`gput_parity` still 15/15** (f64 path bitwise, both backends), LSan clean.

Publish grad 0.6.0 after merge (no dep change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im