### PR TITLE
fix(mlp): 0.3.3 — widen grad to ^0.6 (the finetune-arc cascade)

### DIFF
--- a/packages/mlp/nurl.toml
+++ b/packages/mlp/nurl.toml
@@ -1,9 +1,9 @@
 [package]
 name = "mlp"
-version = "0.3.2"
+version = "0.3.3"
 description = "Trainable multi-layer perceptron in pure NURL — dense layers, ReLU, Adam, minibatches, early stopping. The training-side counterpart to the ecosystem's inference packages: a seedable, deterministic MLP regressor faithful to sklearn's MLPRegressor semantics (Glorot init, squared loss with L2, Adam bias correction, validation-split early stopping with best-weight restore), plus a MinMax scaler. An autoencoder is just mlp_train with X as both input and target — reconstruction-error anomaly detection, embeddings, denoising. Models and scalers persist to JSON with bit-exact f64 round-trip. Two training engines: the hand-written backprop (default, no dependencies beyond flat buffers) and mlp_fit_grad, the same sklearn recipe driven by the grad autograd package — same API, same oracle bar, one loss expression instead of hand-derived layer deltas."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-grad = "^0.5"
+grad = "^0.6"
 tensor = "^0.4"


### PR DESCRIPTION
grad 0.6.1 (f32 replay + perf) shipped with nurllama 0.12.3 requiring
grad ^0.6; mlp still pinned grad ^0.5, and 0.x carets are minor-locked,
so any joint install of mlp + nurllama hit ResolveConflict. mlp doesn't
use the new grad API — this is purely the range widening (verified: mlp
oracle + gradfit unchanged behaviourally). A clean-dir install of
nurllama + anomaly + mlp + swarm-mcp + whisper + onnx now resolves
(grad 0.6.1, mlp 0.3.3).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WX2frzGUucJVZjARF389im
