### PR TITLE
data 0.1.0: a training DataLoader (Phase 4)

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1,0 +1,55 @@
+# data — a training DataLoader
+
+Minibatch iteration for training: seeded reproducible shuffle, epoch
+reshuffling, drop-last, worker sharding, and disk streaming. The batching
+layer the training stack was missing — grad/nn build the graph, this feeds
+it.
+
+```
+: *DataSet ds   ( data_new x y n d l )        // x: n·d, y: n·l (l may be 0)
+: *DataLoader dl ( dl_new ds 32 F 42 )         // batch 32, no drop-last, seed 42
+: ( Vec f ) bx ( vec_new [f] )
+: ( Vec f ) by ( vec_new [f] )
+: ~ i rows ( dl_next dl bx by )                // fills bx/by, returns row count
+~ > rows 0 {
+    // train on bx (rows·d), by (rows·l)
+    = rows ( dl_next dl bx by )
+}
+( dl_reset dl 43 )                             // next epoch, new permutation
+```
+
+## What it does
+
+- **Batching** — `dl_next` gathers the next `batch` rows into caller vectors
+  and returns the count (0 at end-of-epoch; the last batch is partial unless
+  `drop_last`).
+- **Seeded shuffle** — an unbiased Fisher-Yates permutation from `std/rng`.
+  The order is a pure function of the seed: `dl_reset dl seed` reproduces it
+  regardless of prior state. `seed <= 0` disables shuffling (identity order).
+- **Epochs** — `dl_reset` rewinds and reshuffles; pass a fresh seed per epoch.
+- **Sharding** — `dl_new_shard ds batch drop_last seed nshards shard`
+  partitions `[0,n)` into contiguous, exactly-once slices, one per worker.
+- **Disk streaming** — `data_save_ndf` writes the `.ndf` format (magic +
+  n/d/l header + little-endian f64 rows); `ndf_open` + `dl_stream` iterate it
+  with random-access preads, so a corpus larger than RAM never loads whole —
+  `dl_next` reads only the rows a batch needs.
+
+## Verification (`tests/data_test.nu`, 16/16)
+
+Determinism is a gate, not a hope:
+
+- the seeded order is a real permutation, and the same seed reproduces it
+  byte-for-byte after `dl_reset`;
+- an epoch covers every example **exactly once** (features stay row-aligned
+  with labels), and `drop_last` yields exactly `floor(n/batch)·batch` rows;
+- `N` shards partition the dataset exactly once (disjoint, complete union);
+- a `.ndf` round-trips its header, and **streamed batches equal in-memory
+  batches** for the same seed.
+
+## Dependencies
+
+None beyond the standard library (`rng`, `fs`, `bytes`, `floatbits`).
+
+## License
+
+MIT OR Apache-2.0

--- a/packages/data/nurl.toml
+++ b/packages/data/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "data"
+version = "0.1.0"
+description = "A training DataLoader in pure NURL — the batching layer the training stack was missing. Wrap an in-memory dataset (flat f64 features + optional labels) or stream one straight off disk, and iterate minibatches with a seeded, reproducible Fisher-Yates shuffle, epoch reshuffling, drop-last, and worker sharding (each of N shards sees a disjoint, exactly-once slice). The on-disk .ndf format (magic + n/d/l header + little-endian f64 rows) is read with random-access preads, so a corpus larger than RAM never loads whole — dl_next pulls only the rows a batch needs. Determinism is a gate, not a hope: the same seed yields the same batch order byte-for-byte, streamed batches equal in-memory batches, and the shard union covers every example once. No dependencies beyond the standard library (rng, fs, bytes)."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/data/src/data.nu
+++ b/packages/data/src/data.nu
@@ -1,0 +1,322 @@
+// data.nu — a training DataLoader: batching + seeded shuffle + epochs +
+// drop-last + worker sharding, over an in-memory dataset OR one streamed
+// off disk.
+//
+// A dataset is n examples, each d f64 features and l f64 labels (l may be
+// 0). In memory it is two flat vectors (x: n·d, y: n·l). On disk it is the
+// .ndf format — a magic + n/d/l header, then n rows of (d+l) little-endian
+// f64 (x then y) — read with random-access preads so a corpus larger than
+// RAM never loads whole.
+//
+// A DataLoader holds a permutation of its shard's example indices; dl_next
+// gathers the next `batch` rows (in memory: a copy; streaming: one pread per
+// row) into caller-provided vectors and returns the row count (0 =
+// exhausted). dl_reset reshuffles for the next epoch. Sharding partitions
+// [0,n) into contiguous, exactly-once slices — shard s of N gets
+// [s·n/N, (s+1)·n/N).
+//
+//   ( data_new x y n d l )                → *DataSet   (takes ownership of x,y)
+//   ( dl_new ds batch drop_last seed )    → *DataLoader
+//   ( dl_new_shard ds batch drop_last seed nshards shard ) → *DataLoader
+//   ( dl_next dl bx by )                  → i          (rows; 0 = end)
+//   ( dl_reset dl seed )                  → v          (next epoch)
+//   ( dl_num_batches dl )                 → i
+//   ( data_save_ndf path ds )             → !v String
+//   ( ndf_open path )                     → !*NdfStream String
+//   ( dl_stream st batch drop_last seed )                → *DataLoader
+//   ( dl_stream_shard st batch drop_last seed nshards shard ) → *DataLoader
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/rng.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/floatbits.nu`
+
+@ __data_gf ( Vec f ) v i k → f { ?? ( vec_get [f] v k ) { T x → x F → 0.0 } }
+
+@ __data_gi ( Vec i ) v i k → i { ?? ( vec_get [i] v k ) { T x → x F → 0 } }
+
+// ── dataset ────────────────────────────────────────────────────────────
+
+: DataSet {
+    ( Vec f ) x  // n·d features, row-major
+    ( Vec f ) y  // n·l labels (empty when l == 0)
+    i n
+    i d
+    i l
+}
+
+// Take ownership of x (n·d) and y (n·l); data_free releases both.
+@ data_new ( Vec f ) x ( Vec f ) y i n i d i l → *DataSet {
+    : *DataSet ds # *DataSet ( nurl_alloc Z DataSet )
+    = . ds x x
+    = . ds y y
+    = . ds n n
+    = . ds d d
+    = . ds l l
+    ^ ds
+}
+
+@ data_free * DataSet ds → v {
+    ( vec_free [f] . ds x )
+    ( vec_free [f] . ds y )
+    ( nurl_free # s ds )
+}
+
+@ data_n * DataSet ds → i { ^ . ds n }
+
+@ data_d * DataSet ds → i { ^ . ds d }
+
+@ data_l * DataSet ds → i { ^ . ds l }
+
+// ── .ndf on-disk format ────────────────────────────────────────────────
+// bytes:  'N' 'D' 'F' '1' | u64 n | u64 d | u64 l | rows((d+l) f64 LE)…
+: i __NDF_HDR 28
+
+: NdfStream {
+    File f
+    i n
+    i d
+    i l
+    i data_off
+}
+
+@ data_save_ndf s path * DataSet ds → !v String {
+    : ( Vec u ) out ( vec_new [u] )
+    ( vec_push [u] out # u 78 ) ( vec_push [u] out # u 68 )
+    ( vec_push [u] out # u 70 ) ( vec_push [u] out # u 49 )
+    ( bytes_push_u64_le out # u64 . ds n )
+    ( bytes_push_u64_le out # u64 . ds d )
+    ( bytes_push_u64_le out # u64 . ds l )
+    : i nd . ds d
+    : i nl . ds l
+    : ~ i e 0
+    ~ < e . ds n {
+        : ~ i c 0
+        ~ < c nd { ( bytes_push_f64_le out ( __data_gf . ds x + * e nd c ) ) = c + c 1 }
+        = c 0
+        ~ < c nl { ( bytes_push_f64_le out ( __data_gf . ds y + * e nl c ) ) = c + c 1 }
+        = e + e 1
+    }
+    : ~ b wok T
+    ?? ( write_file_bytes path out ) { T _ → {} F _ → { = wok F } }
+    ( vec_free [u] out )
+    ? wok { ^ @ !v String { T } }
+    ^ @ !v String { F ( string_from `data: cannot write .ndf` ) }
+}
+
+@ ndf_open s path → !*NdfStream String {
+    : !File IoErr fr ( file_open path )
+    : ~ File fh @ File { # s 0 }
+    ?? fr { T h → { = fh h } F _ → { ^ @ !*NdfStream String { F ( string_from `data: cannot open .ndf` ) } } }
+    : !( Vec u ) IoErr hr ( file_read_at fh 0 __NDF_HDR )
+    ?? hr {
+        T hb → {
+            ? >= ( vec_len [u] hb ) __NDF_HDR {} {
+                ( vec_free [u] hb ) ( file_close fh )
+                ^ @ !*NdfStream String { F ( string_from `data: truncated .ndf header` ) }
+            }
+            : ~ b magic T
+            ? == ?? ( vec_get [u] hb 0 ) { T x → x F → # u 0 } # u 78 {} { = magic F }
+            ? == ?? ( vec_get [u] hb 1 ) { T x → x F → # u 0 } # u 68 {} { = magic F }
+            ? == ?? ( vec_get [u] hb 2 ) { T x → x F → # u 0 } # u 70 {} { = magic F }
+            ? == ?? ( vec_get [u] hb 3 ) { T x → x F → # u 0 } # u 49 {} { = magic F }
+            ? magic {} {
+                ( vec_free [u] hb ) ( file_close fh )
+                ^ @ !*NdfStream String { F ( string_from `data: bad .ndf magic` ) }
+            }
+            : i n # i ?? ( bytes_read_u64_le hb 4 ) { T v → v F → # u64 0 }
+            : i d # i ?? ( bytes_read_u64_le hb 12 ) { T v → v F → # u64 0 }
+            : i l # i ?? ( bytes_read_u64_le hb 20 ) { T v → v F → # u64 0 }
+            ( vec_free [u] hb )
+            : *NdfStream st # *NdfStream ( nurl_alloc Z NdfStream )
+            = . st f fh
+            = . st n n
+            = . st d d
+            = . st l l
+            = . st data_off __NDF_HDR
+            ^ @ !*NdfStream String { T st }
+        }
+        F _ → {
+            ( file_close fh )
+            ^ @ !*NdfStream String { F ( string_from `data: cannot read .ndf header` ) }
+        }
+    }
+    ^ @ !*NdfStream String { F ( string_from `data: cannot read .ndf header` ) }
+}
+
+@ ndf_close * NdfStream st → v {
+    ( file_close . st f )
+    ( nurl_free # s st )
+}
+
+@ ndf_n * NdfStream st → i { ^ . st n }
+
+@ ndf_d * NdfStream st → i { ^ . st d }
+
+@ ndf_l * NdfStream st → i { ^ . st l }
+
+// Read example `idx`: append its d features to x_out and l labels to y_out.
+@ ndf_read_row * NdfStream st i idx ( Vec f ) x_out ( Vec f ) y_out → b {
+    : i rowf + . st d . st l
+    : i off + . st data_off * idx * rowf 8
+    : !( Vec u ) IoErr rr ( file_read_at . st f off * rowf 8 )
+    ?? rr {
+        T b → {
+            ? >= ( vec_len [u] b ) * rowf 8 {} { ( vec_free [u] b ) ^ F }
+            : ~ i c 0
+            ~ < c . st d {
+                ( vec_push [f] x_out ?? ( bytes_read_f64_le b * c 8 ) { T v → v F → 0.0 } )
+                = c + c 1
+            }
+            = c 0
+            ~ < c . st l {
+                ( vec_push [f] y_out ?? ( bytes_read_f64_le b * + . st d c 8 ) { T v → v F → 0.0 } )
+                = c + c 1
+            }
+            ( vec_free [u] b )
+            ^ T
+        }
+        F _ → { ^ F }
+    }
+    ^ F
+}
+
+// ── index machinery ────────────────────────────────────────────────────
+
+// Fisher-Yates shuffle of `idx` in place with a fresh seeded rng.
+@ __data_shuffle ( Vec i ) idx i seed → v {
+    : Rng g ( rng_seed seed )
+    : i n ( vec_len [i] idx )
+    : ~ i k - n 1
+    ~ > k 0 {
+        : i j ( rng_below g + k 1 )
+        : i a ( __data_gi idx k )
+        : i b ( __data_gi idx j )
+        ( vec_set [i] idx k b )
+        ( vec_set [i] idx j a )
+        = k - k 1
+    }
+    ( rng_free g )
+}
+
+// The shard's absolute example range [base, base+count) of [0,n).
+@ __data_shard_base i n i nshards i shard → i { ^ / * shard n nshards }
+
+// ── loader ─────────────────────────────────────────────────────────────
+
+: DataLoader {
+    * DataSet ds  // in-memory source (0 when streaming)
+    * NdfStream st  // streaming source (0 when in-memory)
+    i n  // examples in this shard
+    i d
+    i l
+    i base  // absolute index of this shard's first example
+    i batch
+    b drop_last
+    b shuffle
+    ( Vec i ) idx  // permutation of [base, base+n)
+    i pos
+    i last_rows
+}
+
+@ __dl_make * DataSet ds * NdfStream st i n i d i l i batch b drop_last i seed i nshards i shard → *DataLoader {
+    : i base ( __data_shard_base n nshards shard )
+    : i end ( __data_shard_base n nshards + shard 1 )
+    : i cnt - end base
+    : *DataLoader dl # *DataLoader ( nurl_alloc Z DataLoader )
+    = . dl ds ds
+    = . dl st st
+    = . dl n cnt
+    = . dl d d
+    = . dl l l
+    = . dl base base
+    = . dl batch batch
+    = . dl drop_last drop_last
+    = . dl shuffle > seed 0
+    = . dl pos 0
+    = . dl last_rows 0
+    : ( Vec i ) idx ( vec_with_cap [i] cnt )
+    : ~ i k 0
+    ~ < k cnt { ( vec_push [i] idx + base k ) = k + k 1 }
+    = . dl idx idx
+    ? . dl shuffle { ( __data_shuffle . dl idx seed ) } {}
+    ^ dl
+}
+
+// Full in-memory dataset (one shard). seed <= 0 disables shuffling.
+@ dl_new * DataSet ds i batch b drop_last i seed → *DataLoader {
+    ^ ( __dl_make ds # *NdfStream 0 . ds n . ds d . ds l batch drop_last seed 1 0 )
+}
+
+@ dl_new_shard * DataSet ds i batch b drop_last i seed i nshards i shard → *DataLoader {
+    ^ ( __dl_make ds # *NdfStream 0 . ds n . ds d . ds l batch drop_last seed nshards shard )
+}
+
+// Streaming dataset (one shard).
+@ dl_stream * NdfStream st i batch b drop_last i seed → *DataLoader {
+    ^ ( __dl_make # *DataSet 0 st . st n . st d . st l batch drop_last seed 1 0 )
+}
+
+@ dl_stream_shard * NdfStream st i batch b drop_last i seed i nshards i shard → *DataLoader {
+    ^ ( __dl_make # *DataSet 0 st . st n . st d . st l batch drop_last seed nshards shard )
+}
+
+// Reshuffle for the next epoch and rewind. The permutation is a pure
+// function of `seed` — idx is reset to the ordered shard range [base,
+// base+n) BEFORE the shuffle, so the same seed always yields the same
+// order regardless of the loader's prior state.
+@ dl_reset * DataLoader dl i seed → v {
+    : ~ i k 0
+    ~ < k . dl n { ( vec_set [i] . dl idx k + . dl base k ) = k + k 1 }
+    ? > seed 0 { ( __data_shuffle . dl idx seed ) } {}
+    = . dl pos 0
+}
+
+@ dl_num_batches * DataLoader dl → i {
+    : i b . dl batch
+    ? <= b 0 { ^ 0 } {}
+    ? . dl drop_last { ^ / . dl n b } {}
+    ^ / + . dl n - b 1 b
+}
+
+// Emit the next batch into bx (rows·d) and by (rows·l), overwriting them.
+// Returns the row count (0 at end-of-epoch; the last batch may be partial
+// unless drop_last).
+@ dl_next * DataLoader dl ( Vec f ) bx ( Vec f ) by → i {
+    : i rem - . dl n . dl pos
+    ? <= rem 0 { = . dl last_rows 0 ^ 0 } {}
+    : ~ i rows . dl batch
+    ? > rows rem { = rows rem } {}
+    ? & . dl drop_last < rows . dl batch { = . dl last_rows 0 ^ 0 } {}
+    : b _cx ( vec_set_len [f] bx 0 )
+    : b _cy ( vec_set_len [f] by 0 )
+    : i d . dl d
+    : i l . dl l
+    : ~ i k 0
+    ~ < k rows {
+        : i ex ( __data_gi . dl idx + . dl pos k )
+        ? != # i . dl ds 0 {
+            : *DataSet ds . dl ds
+            : ~ i c 0
+            ~ < c d { ( vec_push [f] bx ( __data_gf . ds x + * ex d c ) ) = c + c 1 }
+            = c 0
+            ~ < c l { ( vec_push [f] by ( __data_gf . ds y + * ex l c ) ) = c + c 1 }
+        } {
+            : b _r ( ndf_read_row . dl st ex bx by )
+        }
+        = k + k 1
+    }
+    = . dl pos + . dl pos rows
+    = . dl last_rows rows
+    ^ rows
+}
+
+@ dl_last_rows * DataLoader dl → i { ^ . dl last_rows }
+
+@ dl_free * DataLoader dl → v {
+    ( vec_free [i] . dl idx )
+    ( nurl_free # s dl )
+}

--- a/packages/data/tests/data_test.nu
+++ b/packages/data/tests/data_test.nu
@@ -1,0 +1,181 @@
+// data_test.nu — DataLoader gates: deterministic seeded shuffle, exactly-
+// once epoch coverage, drop-last, shard partitioning, and streamed batches
+// equal to in-memory batches. Each example carries its own id in y[0], so
+// coverage and order are checked directly regardless of feature values.
+//
+//   NURL_STDLIB=<repo> ../../nurl.sh tests/data_test.nu /tmp/dt && /tmp/dt
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/float.nu`
+$ `src/data.nu`
+
+: ~ i g_pass 0
+
+: ~ i g_fail 0
+
+@ check b ok s label → v {
+    ? ok { ( nurl_print `  ok ` ) = g_pass + g_pass 1 } { ( nurl_print `  FAIL ` ) = g_fail + g_fail 1 }
+    ( nurl_print label ) ( nurl_print `\n` )
+}
+
+@ gf ( Vec f ) v i k → f { ?? ( vec_get [f] v k ) { T x → x F → 0.0 } }
+
+@ gi ( Vec i ) v i k → i { ?? ( vec_get [i] v k ) { T x → x F → 0 } }
+
+// dataset of n examples, d=2 features [i, i*10], l=1 label [i] (the id).
+@ mkds i n → *DataSet {
+    : ( Vec f ) x ( vec_new [f] )
+    : ( Vec f ) y ( vec_new [f] )
+    : ~ i i2 0
+    ~ < i2 n {
+        ( vec_push [f] x # f i2 ) ( vec_push [f] x * 10.0 # f i2 )
+        ( vec_push [f] y # f i2 )
+        = i2 + i2 1
+    }
+    ^ ( data_new x y n 2 1 )
+}
+
+// Run a whole epoch, appending each emitted example's id (y[0]) to `ids`.
+// Also asserts x[0] == id (feature/label stay aligned per row).
+@ epoch_ids * DataLoader dl ( Vec i ) ids * u okal → v {
+    : ( Vec f ) bx ( vec_new [f] )
+    : ( Vec f ) by ( vec_new [f] )
+    : ~ i rows ( dl_next dl bx by )
+    ~ > rows 0 {
+        : ~ i k 0
+        ~ < k rows {
+            : i id # i ( gf by k )
+            ( vec_push [i] ids id )
+            ? == # i ( gf bx * k 2 ) id {} { ( nurl_poke okal 0 0 ) }
+            = k + k 1
+        }
+        = rows ( dl_next dl bx by )
+    }
+    ( vec_free [f] bx ) ( vec_free [f] by )
+}
+
+@ sorted_covers ( Vec i ) ids i n → b {
+    ? == ( vec_len [i] ids ) n {} { ^ F }
+    // mark-and-count: every id in [0,n) appears exactly once
+    : ( Vec i ) seen ( vec_with_cap [i] n )
+    : ~ i k 0
+    ~ < k n { ( vec_push [i] seen 0 ) = k + k 1 }
+    = k 0
+    ~ < k ( vec_len [i] ids ) {
+        : i id ( gi ids k )
+        ? & >= id 0 < id n { ( vec_set [i] seen id + 1 ( gi seen id ) ) } { ^ F }
+        = k + k 1
+    }
+    = k 0
+    ~ < k n { ? == ( gi seen k ) 1 {} { ( vec_free [i] seen ) ^ F } = k + k 1 }
+    ( vec_free [i] seen )
+    ^ T
+}
+
+@ ids_eq ( Vec i ) a ( Vec i ) b → b {
+    ? == ( vec_len [i] a ) ( vec_len [i] b ) {} { ^ F }
+    : ~ i k 0
+    ~ < k ( vec_len [i] a ) { ? == ( gi a k ) ( gi b k ) {} { ^ F } = k + k 1 }
+    ^ T
+}
+
+@ main → i {
+    : i N 10
+    : *DataSet ds ( mkds N )
+    : *u okal ( nurl_alloc 8 )
+    ( nurl_poke okal 0 1 )
+
+    // ── determinism + coverage (batch 3, no drop_last) ──
+    : *DataLoader dl ( dl_new ds 3 F 42 )
+    ( check == ( dl_num_batches dl ) 4 `num_batches = ceil(10/3) = 4` )
+    : ( Vec i ) e1 ( vec_new [i] )
+    ( epoch_ids dl e1 okal )
+    ( check ( sorted_covers e1 N ) `epoch covers every example exactly once` )
+    ( check == ( nurl_peek okal 0 ) 1 `features stay row-aligned with labels` )
+    // reset with the SAME seed → identical order
+    ( dl_reset dl 42 )
+    : ( Vec i ) e2 ( vec_new [i] )
+    ( epoch_ids dl e2 okal )
+    ( check ( ids_eq e1 e2 ) `same seed → identical batch order` )
+    // a shuffle actually happened (not the identity 0..9)
+    : ~ b shuffled F
+    : ~ i k 0
+    ~ < k N { ? != ( gi e1 k ) k { = shuffled T } {} = k + k 1 }
+    ( check shuffled `seeded order is a real permutation, not identity` )
+    // different seed → different order (very likely)
+    ( dl_reset dl 43 )
+    : ( Vec i ) e3 ( vec_new [i] )
+    ( epoch_ids dl e3 okal )
+    ( check == ( ids_eq e1 e3 ) F `different seed → different order` )
+    ( check ( sorted_covers e3 N ) `reshuffled epoch still covers once` )
+    ( dl_free dl )
+
+    // ── drop_last ──
+    : *DataLoader dl2 ( dl_new ds 3 T 42 )
+    ( check == ( dl_num_batches dl2 ) 3 `drop_last num_batches = floor(10/3) = 3` )
+    : ( Vec i ) ed ( vec_new [i] )
+    ( epoch_ids dl2 ed okal )
+    ( check == ( vec_len [i] ed ) 9 `drop_last yields 9 rows (last partial dropped)` )
+    ( dl_free dl2 )
+
+    // ── no shuffle (seed <= 0) → identity order ──
+    : *DataLoader dl3 ( dl_new ds 4 F 0 )
+    : ( Vec i ) en ( vec_new [i] )
+    ( epoch_ids dl3 en okal )
+    : ~ b ident T
+    = k 0
+    ~ < k N { ? == ( gi en k ) k {} { = ident F } = k + k 1 }
+    ( check ident `seed<=0 → identity (no shuffle)` )
+    ( dl_free dl3 )
+
+    // ── sharding: 3 shards partition [0,10) once ──
+    : ( Vec i ) allsh ( vec_new [i] )
+    : ~ i sh 0
+    ~ < sh 3 {
+        : *DataLoader dls ( dl_new_shard ds 2 F 0 3 sh )
+        : ( Vec i ) es ( vec_new [i] )
+        ( epoch_ids dls es okal )
+        : ~ i j 0
+        ~ < j ( vec_len [i] es ) { ( vec_push [i] allsh ( gi es j ) ) = j + j 1 }
+        ( vec_free [i] es )
+        ( dl_free dls )
+        = sh + sh 1
+    }
+    ( check ( sorted_covers allsh N ) `3 shards partition the dataset exactly once` )
+    ( vec_free [i] allsh )
+
+    // ── streaming round-trip: streamed batches == in-memory batches ──
+    : s ndfp `/tmp/nurl_data_test.ndf`
+    : ~ b saveok F
+    ?? ( data_save_ndf ndfp ds ) { T _ → { = saveok T } F e → { ( string_free e ) } }
+    ( check saveok `dataset saves to .ndf` )
+    // in-memory order for seed 7
+    : *DataLoader dlm ( dl_new ds 3 F 7 )
+    : ( Vec i ) mem ( vec_new [i] )
+    ( epoch_ids dlm mem okal )
+    ( dl_free dlm )
+    ?? ( ndf_open ndfp ) {
+        T st → {
+            ( check & & == ( ndf_n st ) N == ( ndf_d st ) 2 == ( ndf_l st ) 1 `.ndf header round-trips (n/d/l)` )
+            : *DataLoader dlst ( dl_stream st 3 F 7 )
+            : ( Vec i ) strm ( vec_new [i] )
+            ( epoch_ids dlst strm okal )
+            ( check == ( nurl_peek okal 0 ) 1 `streamed rows stay feature/label-aligned` )
+            ( check ( ids_eq mem strm ) `streamed batches == in-memory batches (same seed)` )
+            ( check ( sorted_covers strm N ) `streamed epoch covers once` )
+            ( vec_free [i] strm )
+            ( dl_free dlst )
+            ( ndf_close st )
+        }
+        F e → { ( nurl_print ( string_data e ) ) ( nurl_print `\n` ) ( string_free e ) = g_fail + g_fail 1 }
+    }
+    ( vec_free [i] mem )
+
+    ( vec_free [i] e1 ) ( vec_free [i] e2 ) ( vec_free [i] e3 ) ( vec_free [i] ed ) ( vec_free [i] en )
+    ( nurl_free okal )
+    ( data_free ds )
+    ( nurl_print `data_test: ` ) ( nurl_print_int g_pass )
+    ( nurl_print ` passed, ` ) ( nurl_print_int g_fail ) ( nurl_print ` failed\n` )
+    ^ ? > g_fail 0 1 0
+}


### PR DESCRIPTION
## Phase 4 — the training DataLoader

The batching layer the training stack was missing. grad/nn build the graph; this feeds it. Greenfield, no dependencies beyond the standard library.

A `DataSet` is `n` examples of `d` f64 features + `l` f64 labels, in memory or streamed off disk.

### What it does
- **Batching** — `dl_next` gathers the next `batch` rows into caller vectors, returns the row count (partial last batch unless `drop_last`).
- **Seeded shuffle** — unbiased Fisher-Yates over `std/rng`; the order is a **pure function of the seed** — `dl_reset dl seed` reproduces it regardless of prior state (the reset rebuilds the ordered range before shuffling, which is exactly the bug the tests caught). `seed <= 0` = identity.
- **Epochs** — `dl_reset` rewinds + reshuffles.
- **Sharding** — `dl_new_shard` partitions `[0,n)` into contiguous, exactly-once slices, one per worker.
- **Disk streaming** — the `.ndf` format (magic + n/d/l header + LE f64 rows), read with random-access preads so a corpus larger than RAM never loads whole; `dl_next` pulls only the rows a batch needs.

### Verification (`data_test.nu`, 16/16)
Determinism is a gate, not a hope:
- the seeded order is a real permutation, reproduced byte-for-byte across `dl_reset`;
- an epoch covers every example **exactly once**, features row-aligned to labels;
- `drop_last` yields exactly `floor(n/batch)·batch` rows;
- `N` shards partition the dataset exactly once (disjoint, complete union);
- a `.ndf` round-trips its header, and **streamed batches equal in-memory batches** for the same seed.

Consumer wiring (mlp / nurllama finetune dropping their inline windowing) is a natural follow-up — the package stands on its own gates here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im