### PR TITLE
registry (TS Worker): API documentation pages

### DIFF
--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -22,7 +22,8 @@
 // (miniflare simulates R2 + D1) — no Cloudflare account needed to test.
 
 import { renderMarkdown } from "./markdown.ts";
-import { extractReadme, extractFile, extractManifestRepository, extractManifestDescription, normalizeRelPath, listTarFiles } from "./readme.ts";
+import { extractReadme, extractFile, extractManifestRepository, extractManifestDescription, normalizeRelPath, listTarFiles, listTarSrcModules } from "./readme.ts";
+import { renderNurldoc } from "./nurldoc.ts";
 
 export interface Env {
   REG_BUCKET: R2Bucket;
@@ -619,6 +620,7 @@ async function handlePackageDetail(env: Env, name: string): Promise<Response> {
       (date ? ` <span style="color:#999">· ${date}</span>` : "") +
       (pub ? ` <span style="color:#999">· ${ghLink(pub.login)}</span>` : "") +
       ` <span style="color:#999">· <a href="/packages/${esc(name)}/${esc(v.version)}/files">files</a></span>` +
+      ` <span style="color:#999">· <a href="/packages/${esc(name)}/${esc(v.version)}/api">api</a></span>` +
       `</li>`;
   }).join("");
   const depsHtml = latest && latest.deps.length
@@ -711,6 +713,40 @@ async function handlePackageFiles(env: Env, name: string, version: string): Prom
     `<p style="color:#666">${files.length} file(s) · ${fmtSize(total)} unpacked` +
     (ver.yanked ? ` · <span style="color:#b00">(yanked)</span>` : "") + `</p>` +
     `<table class=files>${rows}</table>`);
+  res.headers.set("cache-control", "public, max-age=86400, immutable");
+  return res;
+}
+
+// GET /packages/<name>/<version>/api — nurldoc-rendered API docs for the
+// release's src/*.nu modules. Version-pinned → immutable-cacheable.
+async function handlePackageApi(env: Env, name: string, version: string): Promise<Response> {
+  if (!NAME_RE.test(name) || !VERSION_RE.test(version)) {
+    return htmlPage("not found", `<p>Invalid package or version.</p>`, 404);
+  }
+  const idx = await readIndex(env, name);
+  const ver = idx.versions.find((v) => v.version === version);
+  if (!ver) {
+    return htmlPage("not found",
+      `<p><a href="/packages/${esc(name)}">← ${esc(name)}</a></p><p>Version not found.</p>`, 404);
+  }
+  const obj = await env.REG_BUCKET.get(`pkgs/${name}/${name}-${version}.tar.gz`);
+  if (!obj || !obj.body) {
+    return htmlPage("not found",
+      `<p><a href="/packages/${esc(name)}">← ${esc(name)}</a></p><p>Tarball missing.</p>`, 404);
+  }
+  const ab = await new Response(obj.body.pipeThrough(new DecompressionStream("gzip"))).arrayBuffer();
+  const mods = listTarSrcModules(new Uint8Array(ab));
+  let bodyHtml =
+    `<p><a href="/packages/${esc(name)}">← ${esc(name)}</a></p>` +
+    `<h1>${esc(name)} <span style="color:#666">${esc(version)}</span> API</h1>`;
+  if (mods.length === 0) {
+    bodyHtml += `<p style="color:#666">No <code>src/*.nu</code> modules in this release.</p>`;
+  } else {
+    const md = mods.map((m) => renderNurldoc(m.text, m.path.replace(/^src\//, "")))
+      .join("\n\n---\n\n");
+    bodyHtml += `<div class="readme">${renderMarkdown(md)}</div>`;
+  }
+  const res = htmlPage(`${name} ${version} — API`, bodyHtml);
   res.headers.set("cache-control", "public, max-age=86400, immutable");
   return res;
 }
@@ -912,6 +948,9 @@ export default {
         // /packages/<name>/<version>/files — the tarball's file listing.
         const m = rest.match(/^([^/]+)\/([^/]+)\/files$/);
         if (m) return handlePackageFiles(env, m[1].toLowerCase(), m[2]);
+        // /packages/<name>/<version>/api — nurldoc API docs.
+        const ma = rest.match(/^([^/]+)\/([^/]+)\/api$/);
+        if (ma) return handlePackageApi(env, ma[1].toLowerCase(), ma[2]);
         return handlePackageDetail(env, rest.toLowerCase());
       }
       if (path.startsWith("/index/") && path.endsWith(".json")) {

--- a/registry/src/nurldoc.ts
+++ b/registry/src/nurldoc.ts
@@ -1,0 +1,160 @@
+// Render a NURL module's doc surface to Markdown — a faithful TypeScript
+// port of stdlib/ext/nurldoc.nu, so the Worker's /api pages match what the
+// `nurldoc` CLI (and the pure-NURL registry) produce.
+//
+// The discipline it reads: a `//` module-header block at the top, top-level
+// declarations, and `//` doc comments immediately above them. It emits the
+// header block as prose, then each top-level declaration's signature (the
+// line up to its `{` body, for functions; the full `{ … }` definition for
+// types/enums) with any preceding doc comment. Brace depth is tracked so
+// `:` locals inside function bodies are never picked up, and `__`-prefixed
+// (file-private) functions are excluded.
+
+function skipWs(s: string): number {
+  let i = 0;
+  while (i < s.length && (s[i] === " " || s[i] === "\t")) i++;
+  return i;
+}
+
+// Net brace delta of one line, counting {/} only in code (outside a `//`
+// comment and outside backtick strings).
+function braceDelta(line: string): number {
+  let depth = 0;
+  let inStr = false;
+  for (let k = 0; k < line.length; k++) {
+    const c = line[k];
+    if (inStr) {
+      if (c === "`") inStr = false;
+    } else if (c === "`") {
+      inStr = true;
+    } else if (c === "/" && line[k + 1] === "/") {
+      break; // rest of line is a comment
+    } else if (c === "{") {
+      depth++;
+    } else if (c === "}") {
+      depth--;
+    }
+  }
+  return depth;
+}
+
+// The first declaration char after an optional leading `pub `, or "".
+function declChar(rest: string): string {
+  let r = rest;
+  if (r.startsWith("pub ")) r = r.slice(4).replace(/^[ \t]+/, "");
+  return r.length ? r[0] : "";
+}
+
+// The `//` comment body (leading `//` + one optional space stripped).
+function commentBody(line: string, sp: number): string {
+  let k = sp + 2;
+  if (line[k] === " ") k++;
+  return line.slice(k);
+}
+
+// The declaration signature from `sp`. Functions/multi-line type decls cut
+// at the `{` body open; single-line decls keep the whole line. Trailing
+// whitespace trimmed.
+function signature(line: string, sp: number, cutBrace: boolean): string {
+  let brace = line.length;
+  if (cutBrace) {
+    let inStr = false;
+    for (let k = sp; k < line.length; k++) {
+      const c = line[k];
+      if (inStr) {
+        if (c === "`") inStr = false;
+      } else if (c === "`") {
+        inStr = true;
+      } else if (c === "{") {
+        brace = k;
+        break;
+      }
+    }
+  }
+  return line.slice(sp, brace).replace(/[ \t\n]+$/, "");
+}
+
+// Is this function declaration file-private (a `__`-prefixed name)? The
+// compiler scopes such functions per-file, so documenting them is noise.
+function fnIsPrivate(line: string, sp: number): boolean {
+  let s = line.slice(sp);
+  if (s.startsWith("pub ")) s = s.slice(4).replace(/^[ \t]+/, "");
+  if (s.startsWith("&")) {
+    // FFI form: & `lib` @ name … — advance past the backtick-quoted lib.
+    s = s.slice(1).replace(/^[ \t]+/, "");
+    if (s.startsWith("`")) {
+      const e = s.indexOf("`", 1);
+      if (e >= 0) s = s.slice(e + 1).replace(/^[ \t]+/, "");
+    }
+  }
+  if (!s.startsWith("@")) return false;
+  s = s.slice(1).replace(/^[ \t]+/, "");
+  return s.startsWith("__");
+}
+
+export function renderNurldoc(content: string, title: string): string {
+  const lines = content.split("\n");
+  let header = ""; // top `//` block (module prose)
+  let pending: string[] = []; // doc comment(s) above the next decl
+  let body = ""; // accumulated "## API" entries
+  let depth = 0;
+  let headerDone = false;
+  let anyDecl = false;
+  let inType = false;
+  let typeProse: string[] = [];
+
+  for (const line of lines) {
+    const sp = skipWs(line);
+    const blank = sp === line.length;
+    const isComment = !blank && line.slice(sp).startsWith("//");
+
+    if (depth === 0) {
+      if (isComment) {
+        if (headerDone) pending.push(commentBody(line, sp));
+        else header += commentBody(line, sp) + "\n";
+      } else if (blank) {
+        // a blank line ends a pending doc block (and the header)
+        headerDone = true;
+        pending = [];
+      } else {
+        headerDone = true;
+        const dc = declChar(line.slice(sp));
+        if (dc === "@" || dc === "&" || dc === "%" || dc === ":") {
+          const isFn = dc === "@" || dc === "&";
+          if (isFn && fnIsPrivate(line, sp)) {
+            // file-private: not API
+          } else {
+            anyDecl = true;
+            const bd = braceDelta(line);
+            const typeBlock = !isFn && bd > 0;
+            body += "### `" + signature(line, sp, isFn || typeBlock) + "`\n\n";
+            if (typeBlock) {
+              // open the fenced full definition; prose waits for the close
+              inType = true;
+              typeProse = pending.slice();
+              body += "```nurl\n" + line + "\n";
+            } else if (pending.length) {
+              body += pending.join("\n") + "\n\n";
+            }
+          }
+        }
+        pending = [];
+      }
+    } else if (inType) {
+      body += line + "\n";
+    }
+
+    depth += braceDelta(line);
+    if (depth < 0) depth = 0;
+    if (inType && depth === 0) {
+      body += "```\n\n";
+      if (typeProse.length) body += typeProse.join("\n") + "\n\n";
+      inType = false;
+    }
+  }
+
+  let out = `# ${title}\n\n`;
+  if (header.length) out += header + "\n";
+  if (anyDecl) out += "## API\n\n" + body;
+  return out;
+}

--- a/registry/src/readme.ts
+++ b/registry/src/readme.ts
@@ -205,3 +205,39 @@ export async function extractFile(
   const hit = findInTar(new Uint8Array(ab), (p) => p.replace(/^\.\//, "") === rel);
   return hit ? hit.data : null;
 }
+
+// Every `src/*.nu` module in an uncompressed tar image (path + decoded
+// text), in archive order — the input to the API-docs renderer. Mirrors
+// listTarFiles' walk (USTAR prefix + GNU longname) but keeps the data of
+// the matched members.
+export function listTarSrcModules(buf: Uint8Array): { path: string; text: string }[] {
+  const out: { path: string; text: string }[] = [];
+  let pos = 0;
+  let gnuLongName: string | null = null;
+  while (pos + BLOCK <= buf.length) {
+    if (isZeroBlock(buf, pos)) break;
+    const sizeRaw = readCStr(buf, pos + 124, 12).trim();
+    const size = parseInt(sizeRaw.replace(/[^0-7]/g, "") || "0", 8);
+    const typeflag = buf[pos + 156];
+    const dataStart = pos + BLOCK;
+    if (typeflag === 0x4c) {
+      gnuLongName = readCStr(buf, dataStart, size);
+    } else if (typeflag === 0x30 || typeflag === 0) {
+      const fromLongName = gnuLongName !== null;
+      let path = gnuLongName ?? readCStr(buf, pos, 100);
+      gnuLongName = null;
+      if (!fromLongName && path && readCStr(buf, pos + 257, 6).startsWith("ustar")) {
+        const prefix = readCStr(buf, pos + 345, 155);
+        if (prefix) path = `${prefix}/${path}`;
+      }
+      path = path.replace(/^\.\//, "");
+      if (path.startsWith("src/") && path.endsWith(".nu")) {
+        out.push({ path, text: new TextDecoder().decode(buf.subarray(dataStart, dataStart + size)) });
+      }
+    } else {
+      gnuLongName = null;
+    }
+    pos = dataStart + Math.ceil(size / BLOCK) * BLOCK;
+  }
+  return out;
+}

--- a/registry/test-readme.ts
+++ b/registry/test-readme.ts
@@ -3,7 +3,8 @@
 import { readFileSync } from "node:fs";
 import { gzipSync } from "node:zlib";
 import { renderMarkdown } from "./src/markdown.ts";
-import { findReadmeInTar, normalizeRelPath, listTarFiles, readmeFirstParagraph } from "./src/readme.ts";
+import { findReadmeInTar, normalizeRelPath, listTarFiles, listTarSrcModules, readmeFirstParagraph } from "./src/readme.ts";
+import { renderNurldoc } from "./src/nurldoc.ts";
 
 let pass = 0, fail = 0;
 function ok(cond: boolean, msg: string) {
@@ -170,6 +171,44 @@ ok(readmeFirstParagraph("# t — x\n\nOne dependency for **serving** HTTP.\nSeco
   "One dependency for serving HTTP. Second line.", "first paragraph joined, bold stripped, heading skipped");
 ok(readmeFirstParagraph("# only a title") === "", "title-only README yields empty");
 ok(readmeFirstParagraph("no heading at all\n\nrest") === "no heading at all", "headingless README works");
+
+// ── nurldoc: doc surface extraction ──────────────────────
+const NUDOC = `// demo.nu — the fixture module.
+
+// A friendly greeting for @who.
+@ demo_hello s who -> i { ^ 0 }
+
+// file-private, must NOT appear in the API docs.
+@ __demo_secret i x -> i { ^ x }
+
+// A record with fields.
+: Point {
+    i x
+    i y
+}
+`;
+{
+  const md = renderNurldoc(NUDOC, "demo.nu");
+  has(md, "# demo.nu", "nurldoc emits the module title");
+  has(md, "the fixture module", "nurldoc emits the header prose");
+  has(md, "demo_hello", "nurldoc documents the public function");
+  has(md, "friendly greeting", "nurldoc keeps the doc comment");
+  absent(md, "__demo_secret", "nurldoc omits file-private functions");
+  has(md, "Point", "nurldoc documents a type");
+  has(md, "```nurl", "nurldoc fences the type definition");
+  has(md, "i x", "nurldoc includes the type fields");
+}
+{
+  const gz = tarMulti([
+    { name: "README.md", body: "# demo\n" },
+    { name: "src/demo.nu", body: NUDOC },
+    { name: "nurl.toml", body: "[package]\nname=x\n" },
+  ]);
+  const mods = listTarSrcModules(gz);
+  ok(mods.length === 1, "listTarSrcModules finds exactly the src/*.nu module");
+  ok(mods.length === 1 && mods[0].path === "src/demo.nu", "listTarSrcModules returns the src path");
+  ok(mods.length === 1 && mods[0].text.includes("demo_hello"), "listTarSrcModules returns the module text");
+}
 
 console.log(`\n==== ${pass} passed, ${fail} failed ====`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## API docs on the deployed registry (the TS Worker)

The pure-NURL registry gained `/api` docs in #601, but **prod runs the TypeScript Cloudflare Worker** (`registry/`, D1 + R2) — a native server can't run on Workers, and the user chose to keep prod on TS (cheaper on CF than a container). So the feature is ported here to actually appear live at reg.nurl-lang.org.

### What changed
- **`src/nurldoc.ts`** — `renderNurldoc(content, title)`, a faithful port of `stdlib/ext/nurldoc.nu`: module-header prose, top-level declaration signatures with their doc comments, type/enum definitions in a fenced block, and `__`-private functions excluded (brace depth tracked so `:` locals inside bodies are never picked up).
- **`readme.ts`** — `listTarSrcModules` walks the tarball for every `src/*.nu` (path + decoded text), reusing the existing USTAR-prefix / GNU-longname walk.
- **`index.ts`** — `GET /packages/<name>/<version>/api` → `handlePackageApi` (fetch + gunzip from R2, render each module, `md → renderMarkdown → htmlPage`, immutable-cache); the detail page's version list gains an **"api" link** beside "files".

### Verification (`test-readme.ts`, 68/68, +11)
`renderNurldoc` emits the title, header prose, the public function **with its doc comment**, **omits** the file-private function, and documents a type with a **fenced field list**; `listTarSrcModules` finds exactly the `src/*.nu` module with its text. `tsc --noEmit` clean.

Matches the pure-NURL registry's `/api` (#601) byte-for-byte in behaviour, so both implementations stay in sync. Deploy is the registry-deploy Worker workflow (user-triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im