### PR TITLE
fix(nn): 0.1.1 — widen grad to ^0.8 (tape_drop_consts cascade)

### DIFF
--- a/packages/nn/nurl.toml
+++ b/packages/nn/nurl.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nn"
-version = "0.1.0"
+version = "0.1.1"
 description = "Neural-network layers on the grad autograd tape — the reusable middle the training stack was missing. Every layer is a pure tape builder (GVar -> GVar over a GTape): nn_linear / nn_linear_bias / nn_lora_linear, nn_rmsnorm / nn_layernorm, nn_silu / nn_swiglu, NEOX/half-split nn_rope (+ rope tables and a causal mask helper), grouped-query nn_gqa_attention (head-slice + scores + softmax + weighted sum), and nn_cross_entropy — so a transformer block is a dozen calls, not a hundred lines of hand-wired slices. The layers are lifted verbatim from grad's PyTorch-float64-oracle-verified LoRA block (loss and every adapter gradient agree to 1e-11) and the nurllama finetune path; a Qwen2-style block rebuilt from these primitives is gated against the same torch oracle, and the two new layers (LayerNorm, SwiGLU) carry their own finite-difference checks. Backward passes are derived by grad, never hand-written; device replay and megakernel fusion come free because the graph is ordinary grad ops."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-grad = { path = "../grad", version = "^0.7" }
+grad = { path = "../grad", version = "^0.8" }
 tensor = { path = "../tensor", version = "^0.4" }


### PR DESCRIPTION
grad 0.8.0 (tape_drop_consts) is a minor bump under the 0.x caret lock;
nn still pinned grad ^0.7, so a joint install of nn + nurllama 0.12.7
(grad ^0.8) ResolveConflicts. nn doesn't use the new API — range widening
only. mlp and nurllama were widened in the grad 0.8.0 PR; nn was the
missed consumer (the joint-install verification caught it).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WX2frzGUucJVZjARF389im
