### PR TITLE
registry: escape LIKE metachars — fixes symbol search (underscores)

### DIFF
--- a/registry/src/index.ts
+++ b/registry/src/index.ts
@@ -601,10 +601,10 @@ const LATEST_SUBQUERY =
 
 async function handleCatalog(url: URL, env: Env): Promise<Response> {
   const q = (url.searchParams.get("q") ?? "").toLowerCase().slice(0, 64);
-  const like = q ? `%${q.replace(/[%_\\]/g, "")}%` : "%";
+  const like = q ? `%${q.replace(/[\\%_]/g, (c) => "\\" + c)}%` : "%";
   const rows = await env.REG_DB.prepare(
     `SELECT p.name AS name, ${LATEST_SUBQUERY} AS latest, p.description AS description
-       FROM packages p WHERE p.name LIKE ?1 OR p.description LIKE ?1 OR p.symbols LIKE ?1 ORDER BY p.name LIMIT 200`,
+       FROM packages p WHERE p.name LIKE ?1 ESCAPE '\\' OR p.description LIKE ?1 ESCAPE '\\' OR p.symbols LIKE ?1 ESCAPE '\\' ORDER BY p.name LIMIT 200`,
   ).bind(like).all<CatalogRow>();
   const items = rows.results ?? [];
   const list = items.length
@@ -797,10 +797,10 @@ async function handleSearch(req: Request, url: URL, env: Env): Promise<Response>
     return json({ error: "rate_limited" }, 429, { "retry-after": "60" });
   }
   const q = (url.searchParams.get("q") ?? "").toLowerCase().slice(0, 64);
-  const like = q ? `%${q.replace(/[%_\\]/g, "")}%` : "%";
+  const like = q ? `%${q.replace(/[\\%_]/g, (c) => "\\" + c)}%` : "%";
   const rows = await env.REG_DB.prepare(
     `SELECT p.name AS name, ${LATEST_SUBQUERY} AS latest, p.description AS description, p.symbols AS symbols
-       FROM packages p WHERE p.name LIKE ?1 OR p.description LIKE ?1 OR p.symbols LIKE ?1 ORDER BY p.name LIMIT 50`,
+       FROM packages p WHERE p.name LIKE ?1 ESCAPE '\\' OR p.description LIKE ?1 ESCAPE '\\' OR p.symbols LIKE ?1 ESCAPE '\\' ORDER BY p.name LIMIT 50`,
   ).bind(like).all<CatalogRow>();
   return json({
     results: (rows.results ?? []).map((r) => {


### PR DESCRIPTION
## The symbol index was live but unsearchable

After #608 deployed, the `symbols` column was populated (backfill indexed **38 packages**), but searching a symbol name returned **0 results**:

```
/api/v1/search?q=gqa_attention  →  []
/api/v1/search?q=grad           →  matched: grad_param, grad_of, gput_grad  ✓
```

`grad` worked; `gqa_attention` didn't. The cause: the search sanitised the query with `q.replace(/[%_\\]/g, "")` — **stripping underscores** to neutralise the LIKE `_` single-char wildcard. But **every ecosystem symbol name has underscores** (`nn_gqa_attention`, `vx_search`, `stw_add_f32`), so `gqa_attention` became `gqaattention` and matched nothing. The one search that item 3 exists for was the one it couldn't do.

## Fix
**Escape** the LIKE metacharacters (`\ % _`) with a backslash and add `ESCAPE '\'` to each LIKE clause, so `_` matches a literal underscore instead of being dropped. Both search paths (catalog UI + `/api/v1/search`). `tsc --noEmit` clean.

## Deploy
Just redeploy the worker — no migration, no backfill (the data is already indexed; only the query changes). Then `/api/v1/search?q=nn_gqa_attention` returns `nn` with `matched_symbols: [nn_gqa_attention]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im