### PR TITLE
nurl-mcp 0.7.1: AX polish — errors name every input, import→build bridge

### DIFF
--- a/packages/nurl-mcp/nurl.toml
+++ b/packages/nurl-mcp/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nurl-mcp"
-version = "0.7.0"
+version = "0.7.1"
 description = "Local MCP server for the NURL toolchain — exposes the installed compiler over Model Context Protocol so an LLM agent on the host can build, run, type-check, format, and compile NURL to wasm32-wasi (fully local wasm builds via the wasmbuilder package), read the installed stdlib, browse its API surface without function bodies (nurl_api), and search stdlib + the package registry with ranked word boundaries (nurl_grep). Stdio by default; an optional token-authenticated HTTP transport (--http) gates code execution behind --allow-run. The editor-facing counterpart of nurl-lsp, for LLMs."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl/tree/main/packages/nurl-mcp"

--- a/packages/nurl-mcp/src/main.nu
+++ b/packages/nurl-mcp/src/main.nu
@@ -59,7 +59,7 @@ $ `deps/wasmbuilder/src/build.nu`
 // to bump (previously the banners drifted to a stale 0.2.0 while the
 // handshake reported 0.4.0).
 
-@ nm_version → s { ^ `0.7.0` }
+@ nm_version → s { ^ `0.7.1` }
 
 // Log a startup banner "nurl-mcp <version> <suffix>" through mcp_log,
 // building the line from the single-source version so the banners can
@@ -797,7 +797,24 @@ version = "0.0.0"
             ( string_free md0 )
             ^ ( mcp_tool_result_error `package not found or has no src/*.nu — check the name (see nurl_grep where='packages'); 'version' defaults to the latest` )
         } {}
-        : Json r0 ( mcp_tool_result_text ( string_data md0 ) )
+        // Prepend the import + build recipe: the module headings below are
+        // '# <module>.nu'; a program imports one and compiles via
+        // nurl_build_project. This is the bridge from reading the API to a
+        // working build.
+        : String hint ( string_from `To USE this package: add it under nurl_build_project deps ({"` )
+        ( string_push_str hint package )
+        ( string_push_str hint `": "^<version>"}), then import a module below as  $ ` )
+        ( string_push_char hint 96 )
+        ( string_push_str hint `deps/` )
+        ( string_push_str hint package )
+        ( string_push_str hint `/src/<MODULE>` )
+        ( string_push_char hint 96 )
+        ( string_push_str hint `  (e.g. the '# nn.nu' module → deps/` )
+        ( string_push_str hint package )
+        ( string_push_str hint `/src/nn.nu).\n\n` )
+        ( string_push_str hint ( string_data md0 ) )
+        : Json r0 ( mcp_tool_result_text ( string_data hint ) )
+        ( string_free hint )
         ( string_free md0 )
         ^ r0
     } {}
@@ -818,7 +835,7 @@ version = "0.0.0"
     } {}
     ? == ( nurl_str_len query ) 0 {
         ( string_free root )
-        ^ ( mcp_tool_result_error `pass 'module' (a nurl_list_stdlib path, e.g. ext/csv.nu) or 'query' (search terms)` )
+        ^ ( mcp_tool_result_error `pass one of: 'module' (a stdlib path, e.g. ext/csv.nu), 'package' (a registry package name, e.g. nn), or 'query' (search terms). To read what a registry package exposes, use package=<name> (from a nurl_grep hit).` )
     } {}
     // No local examples corpus in an installed toolchain → "" skips it;
     // the registry fallback + exact-name footer still apply.


### PR DESCRIPTION
## Root cause of the broken `package=` pointer, and two AX fixes

A live test showed the registry-hit footer says *"call `nurl_api package=nn`"*, but `nurl_api package=nn` → *"pass 'module' … or 'query'"*, and the tool def still advertised only `module` + `query`.

**Root cause (not a missing schema line — the line is there):** the deployed server runs **nurl-mcp 0.5.0** (whose `main.nu` predates the whole `package` param) built against the **new v0.23.0 stdlib**. That's why item 2's footer works (it lives in stdlib `ext/mcp_search`) but the `package` param doesn't (it lives in nurl-mcp's `main.nu`, added in 0.6.0). Verified: the current source **does** advertise `package` (`tools/list` → `['module','package','version','query']`) and **does** handle it (`tools/call nurl_api {package:nn}` → renders `nn_gqa_attention`). **Fix = redeploy with nurl-mcp 0.7.x** (now published).

### AX fixes shipped here (0.7.1)
1. **Errors name every input.** `nurl_api`'s empty-call error now lists all three — `'module'` (stdlib path), `'package'` (registry name), `'query'` (search terms) — and points to `package=<name>`. The old error omitted `package`, so a fumbling agent couldn't discover it.
2. **The import→build bridge.** `nurl_api package=<name>` now *prepends* the recipe: add the package under `nurl_build_project` deps, then import a module as `$ ` + backtick + `deps/<name>/src/<MODULE>`. This is the exact step the loop was missing between reading an API and compiling against it.

No new stdlib symbols; builds against the released v0.23.0 stdlib. Verified via the MCP protocol (import hint present, error names `package`). version 0.7.0 → 0.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im