### PR TITLE
nurlapi: playground MCP nurl_api parity (package/version)

### DIFF
--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -4506,6 +4506,41 @@ s combined_stdout s combined_stderr → v {
 @ __mcp_tool_api Json args → Json {
     : s module ( __mcp_args_get `module` args `` )
     : s query ( __mcp_args_get `query` args `` )
+    : s package ( __mcp_args_get `package` args `` )
+    : s version ( __mcp_args_get `version` args `` )
+    // A PUBLISHED registry package's API surface — nurldoc over its src/*.nu,
+    // streamed from the tarball, same engine as the stdlib `module` path.
+    // Package function/type names are not otherwise searchable, so this is the
+    // step after a registry hit (nurl_grep where='packages' / a 0-hit query).
+    ? > ( nurl_str_len package ) 0 {
+        : String rb0 ( msearch_default_registry )
+        : String md0 ( msearch_api_package ( string_data rb0 ) package version )
+        ( string_free rb0 )
+        ? == ( string_len md0 ) 0 {
+            ( string_free md0 )
+            ^ ( __mcp_result_error `package not found or has no src/*.nu — check the name (see nurl_grep where='packages'); 'version' defaults to the latest` )
+        } {}
+        // Prepend the import recipe: the module headings below are '# <mod>.nu';
+        // a program adds the package to its nurl.toml [dependencies] and imports
+        // one as $ `deps/<name>/src/<module>`. The bridge from reading the API
+        // to a working build.
+        : String hint ( string_from `To USE this package: add it to your project's nurl.toml [dependencies] ({"` )
+        ( string_push_str hint package )
+        ( string_push_str hint `" = "^<version>"}), then import a module below as  $ ` )
+        ( string_push_char hint 96 )
+        ( string_push_str hint `deps/` )
+        ( string_push_str hint package )
+        ( string_push_str hint `/src/<MODULE>` )
+        ( string_push_char hint 96 )
+        ( string_push_str hint `  (e.g. the '# nn.nu' module → deps/` )
+        ( string_push_str hint package )
+        ( string_push_str hint `/src/nn.nu).\n\n` )
+        ( string_push_str hint ( string_data md0 ) )
+        : Json r0 ( __mcp_result_text ( string_data hint ) )
+        ( string_free hint )
+        ( string_free md0 )
+        ^ r0
+    } {}
     ? > ( nurl_str_len module ) 0 {
         ? ( _has_dotdot_segment module ) { ^ ( __mcp_result_error `bad 'module'` ) } {}
         : String sd ( get_stdlib_dir )
@@ -4520,7 +4555,7 @@ s combined_stdout s combined_stderr → v {
         ^ r
     } {}
     ? == ( nurl_str_len query ) 0 {
-        ^ ( __mcp_result_error `pass 'module' (a nurl_list_stdlib path, e.g. ext/csv.nu) or 'query' (search terms)` )
+        ^ ( __mcp_result_error `pass one of: 'module' (a stdlib path, e.g. ext/csv.nu), 'package' (a registry package name, e.g. nn), or 'query' (search terms). To read what a registry package exposes, use package=<name> (from a nurl_grep hit).` )
     } {}
     : String sd ( get_stdlib_dir )
     : String ed ( get_examples_dir )
@@ -4537,9 +4572,13 @@ s combined_stdout s combined_stderr → v {
     ( json_obj_set schema `type` ( json_str_lit `object` ) )
     : Json props ( json_obj_new )
     ( json_obj_set props `module`
-    ( __mcp_prop `string` `Render ONE module's API surface (signatures, doc comments, full type definitions — no function bodies). A nurl_list_stdlib path, e.g. 'ext/csv.nu'.` ) )
+    ( __mcp_prop `string` `Render ONE installed-stdlib module's API surface (signatures, doc comments, full type definitions — no function bodies). A nurl_list_stdlib path, e.g. 'ext/csv.nu'.` ) )
+    ( json_obj_set props `package`
+    ( __mcp_prop `string` `Render a PUBLISHED registry package's API surface — nurldoc over its src/*.nu, streamed from the tarball. The name from a registry search, e.g. 'nn'. Use this after a registry hit (nurl_grep where='packages', or a 0-hit query) to learn the functions/types a package exposes — their names are not otherwise searchable.` ) )
+    ( json_obj_set props `version`
+    ( __mcp_prop `string` `Optional package version (e.g. '0.1.1'); defaults to the latest. Only meaningful with 'package'.` ) )
     ( json_obj_set props `query`
-    ( __mcp_prop `string` `Search every stdlib module's declarations instead: space-separated terms, ALL must occur (case-insensitive) in a declaration's signature + doc comment + module path. On zero hits the search widens automatically to example programs and registry packages (name + description) in the same reply. Ignored when 'module' is set.` ) )
+    ( __mcp_prop `string` `Search every stdlib module's declarations instead: space-separated terms, ALL must occur (case-insensitive) in a declaration's signature + doc comment + module path. On zero hits the search widens automatically to example programs and registry packages (name + description) in the same reply. Ignored when 'module' or 'package' is set.` ) )
     ( json_obj_set schema `properties` props )
     ^ schema
 }
@@ -4777,7 +4816,7 @@ s combined_stdout s combined_stderr → v {
     ( __mcp_schema_changelog ) ) )
 
     ( json_arr_push arr ( __mcp_tool_desc `nurl_api`
-    `A stdlib module's API surface, or a search across all of them — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders one module's signatures + doc comments + full type definitions, no function bodies. query='csv quote' finds every stdlib declaration whose signature/doc/module-path contains ALL terms.`
+    `A stdlib module's API surface, a published package's API surface, or a search across all stdlib modules — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders one stdlib module's signatures + doc comments + full type definitions, no function bodies. package='nn' renders a registry package's API the same way (streamed from its tarball) — the step after a registry hit to see the functions/types it exposes. query='csv quote' finds every stdlib declaration whose signature/doc/module-path contains ALL terms (0 hits widen to examples + registry).`
     ( __mcp_schema_api ) ) )
 
     ( json_arr_push arr ( __mcp_tool_desc `nurl_grep`


### PR DESCRIPTION
## What

The **playground** MCP server (`nurlapi/main.nu`) is a *separate* server from the package-registry's `nurl-mcp`, and its `nurl_api` tool lagged behind: it took only `module` (a stdlib path) and `query` (a stdlib search). There was no way to read a **published package's** API surface — so `nurl_api package=nn` silently failed (the client dropped the unknown arg, the server answered *"pass module or query"*), and package function/type names — not searchable anywhere else — stayed invisible.

This brings the playground's `nurl_api` to parity with `nurl-mcp`:

- **`package`** — render a published registry package's API surface (nurldoc over its `src/*.nu`, streamed from the tarball), the same engine as the stdlib `module` path.
- **`version`** — optional pin; defaults to latest.
- **package= prepends the import→build recipe** (add to `nurl.toml` `[dependencies]`, import as `` $ `deps/<name>/src/<module>` ``) — the bridge from reading an API to building against it.
- **the no-input error names all three inputs** (module/package/query) and points at `package=<name>`, instead of omitting `package`.

The real logic already lives in the **shared engine** both servers import (`stdlib/ext/mcp_search.nu` → `msearch_api_package`); only the thin arg-parse/result-wrap shell is per-server. Parallel to the existing tools — **nothing removed**.

## Why it looked "broken" in production

The live playground was running a build whose `nurl_api` predated `package`. The client validates args against the cached `inputSchema`, drops the unknown `package` field, and the server sees an empty call. This change ships the schema + handler; a redeploy of the playground makes `nurl_api package=…` work.

## Verification (against the production registry, reg.nurl-lang.org)

- `tools/list` → `nurl_api` advertises `{module, package, version, query}`
- `nurl_api {package:"nn"}` → import hint + nn's live API surface (`nn_*` symbols)
- `nurl_api {package:"nn", version:"0.1.0"}` → version-pinned surface
- `nurl_api {package:"doesnotexist999"}` → not-found error
- empty args → error names all inputs incl. `package`
- `module=ext/csv.nu`, `query='csv quote'`, `nurl_grep` → unchanged

## Not included

`nurl_grep` is already present and current here. **`nurl_build_project` is deliberately deferred**: it needs `nurlpkg install` + the `nurl` driver + registry egress, and the playground container ships only `nurlc` — a separate infra/security decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2frzGUucJVZjARF389im