### PR TITLE
nurlpkg: notify when a newer NURL toolchain is available

### DIFF
--- a/stdlib/ext/update_check.nu
+++ b/stdlib/ext/update_check.nu
@@ -1,0 +1,225 @@
+// stdlib/ext/update_check.nu — a best-effort "a newer toolchain is out" notice.
+//
+//   ( update_check_notice current )   → v
+//
+// `current` is this build's version (nurl_version). The check is:
+//   * silent and non-fatal — it never blocks the command, never changes its
+//     exit code, and prints at most one line to stderr;
+//   * cached — the network is touched at most once per day ($NURL_HOME/
+//     .update-check records the last check and the version it saw);
+//   * opt-out — set $NURL_NO_UPDATE_CHECK to disable it entirely;
+//   * quiet where a notice would be noise — skipped in CI ($CI), when stderr
+//     is not a terminal (pipes, scripts), and on a dev/dirty build (a version
+//     that is not a clean release tag).
+//
+// The version oracle is GitHub's releases/latest for nurl-lang/nurl — the same
+// source the installer resolves "latest" from — read once a day with a User-
+// Agent (GitHub rejects requests without one). nurlc can adopt the same notice
+// by calling update_check_notice( nurl_version ) at startup.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/term.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/semver.nu`
+$ `stdlib/ext/http_cli.nu`
+
+// one day, in seconds
+: i __UC_TTL 86400
+
+// strip a single leading 'v' — "v0.24.0" → "0.24.0"
+@ __uc_strip_v s ver → String {
+    ? & > ( nurl_str_len ver ) 0 == ( nurl_str_get ver 0 ) 118 {
+        : String out ( string_new )
+        : ~ i k 1
+        ~ < k ( nurl_str_len ver ) {
+            ( string_push_char out ( nurl_str_get ver k ) )
+            = k + k 1
+        }
+        ^ out
+    } {}
+    ^ ( string_from ver )
+}
+
+// a clean release tag has no '-' (a dev build is "vX-<n>-g<sha>[-dirty]")
+@ __uc_is_release s ver → b {
+    : i n ( nurl_str_len ver )
+    : ~ i k 0
+    ~ < k n {
+        ? == ( nurl_str_get ver k ) 45 { ^ F } {}
+        = k + k 1
+    }
+    ^ T
+}
+
+// $NURL_HOME/.update-check, else ~/.nurl/.update-check
+@ __uc_cache_path → String {
+    : ~ String base ( string_new )
+    ?? ( env_get `NURL_HOME` ) {
+        T v → { ( string_free base ) = base v }
+        F → {
+            : String home ( env_var_or `HOME` `.` )
+            ( string_free base )
+            = base ( path_join ( string_data home ) `.nurl` )
+            ( string_free home )
+        }
+    }
+    : String p ( path_join ( string_data base ) `.update-check` )
+    ( string_free base )
+    ^ p
+}
+
+// true when `latest` is a strictly greater release than `current`
+@ __uc_newer s latest s current → b {
+    : String ls ( __uc_strip_v latest )
+    : String cs ( __uc_strip_v current )
+    : ~ b gt F
+    ?? ( semver_parse ( string_data ls ) ) {
+        T lv → {
+            ?? ( semver_parse ( string_data cs ) ) {
+                T cv → {
+                    = gt ( semver_gt lv cv )
+                    ( semver_free cv )
+                }
+                F _ → {}
+            }
+            ( semver_free lv )
+        }
+        F _ → {}
+    }
+    ( string_free ls )
+    ( string_free cs )
+    ^ gt
+}
+
+// GET the latest release tag from GitHub (None on any failure)
+@ __uc_fetch_latest → ?String {
+    : String hb ( string_new )
+    ( string_push_str hb `User-Agent: nurl-update-check\r\nAccept: application/vnd.github+json\r\n` )
+    : !HttpcResp HttpcErr rr ( httpc_request `GET` `https://api.github.com/repos/nurl-lang/nurl/releases/latest` `` ( string_data hb ) )
+    ( string_free hb )
+    ?? rr {
+        T resp → {
+            : ~ ? String out @ ?String { F }
+            ? == ( httpc_status resp ) 200 {
+                : !Json JsonError pj ( json_parse ( httpc_body_str resp ) )
+                ?? pj {
+                    T j → {
+                        ?? ( json_obj_get j `tag_name` ) {
+                            T tj → { = out @ ?String { T ( string_from ( json_str_data tj ) ) } }
+                            F → {}
+                        }
+                        ( json_free j )
+                    }
+                    F _ → {}
+                }
+            } {}
+            ( httpc_resp_free resp )
+            ^ out
+        }
+        F _ → { ^ @ ?String { F } }
+    }
+}
+
+// write { "checked": <secs>, "latest": "<ver-or-dash>" }
+@ __uc_write_cache s path i secs s latest → v {
+    : Json j ( json_obj_new )
+    : b _1 ( json_obj_set j `checked` ( json_int secs ) )
+    : b _2 ( json_obj_set j `latest` ( json_str_lit latest ) )
+    : String txt ( json_stringify j )
+    ( json_free j )
+    ?? ( write_file path ( string_data txt ) ) { T _ → {} F _ → {} }
+    ( string_free txt )
+}
+
+// the cache read result: was the probe fresh (within the TTL), and the
+// latest version it recorded ("" when absent / stale / a failed probe).
+: UcCache {
+    b fresh
+    String latest
+}
+
+@ __uc_cache_free UcCache c → v { ( string_free . c latest ) }
+
+@ __uc_read_cache s path i now → UcCache {
+    : ~ b fresh F
+    : ~ String latest ( string_new )
+    ?? ( read_file path ) {
+        T txt → {
+            : !Json JsonError pj ( json_parse ( string_data txt ) )
+            ?? pj {
+                T j → {
+                    : ~ i checked 0
+                    ?? ( json_obj_get j `checked` ) {
+                        T cj → { ?? ( json_num_as_i cj ) { T v → { = checked v } F → {} } }
+                        F → {}
+                    }
+                    ? & > checked 0 < - now checked __UC_TTL {
+                        = fresh T
+                        ?? ( json_obj_get j `latest` ) {
+                            T lj → {
+                                : s ld ( json_str_data lj )
+                                ? != ( nurl_str_eq ld `-` ) 0 {} { ( string_free latest ) = latest ( string_from ld ) }
+                            }
+                            F → {}
+                        }
+                    } {}
+                    ( json_free j )
+                }
+                F _ → {}
+            }
+            ( string_free txt )
+        }
+        F → {}
+    }
+    ^ @ UcCache { fresh latest }
+}
+
+@ __uc_notice s latest s current → v {
+    : String m ( string_from `\nA newer NURL toolchain is available: ` )
+    ( string_push_str m latest )
+    ( string_push_str m ` (you have ` )
+    ( string_push_str m current )
+    ( string_push_str m `).\n  update:  curl -fsSL https://nurl-lang.org/install.sh | sh\n` )
+    ( nurl_eprint ( string_data m ) )
+    ( string_free m )
+}
+
+@ update_check_notice s current → v {
+    // opt-out and noise guards
+    ?? ( env_get `NURL_NO_UPDATE_CHECK` ) { T v → { ( string_free v ) ^ } F → {} }
+    ?? ( env_get `CI` ) { T v → { ( string_free v ) ^ } F → {} }
+    ? ( __uc_is_release current ) {} { ^ }
+    ? ( term_is_tty 2 ) {} { ^ }
+
+    : i now ( now_seconds )
+    : String cp ( __uc_cache_path )
+    : UcCache c ( __uc_read_cache ( string_data cp ) now )
+    : ~ String latest ( string_from ( string_data . c latest ) )
+    ( __uc_cache_free c )
+
+    ? . c fresh {} {
+        // one probe per day; record the outcome either way so a persistent
+        // failure does not re-probe on every run
+        ?? ( __uc_fetch_latest ) {
+            T v → {
+                ( string_free latest )
+                = latest v
+                ( __uc_write_cache ( string_data cp ) now ( string_data latest ) )
+            }
+            F → { ( __uc_write_cache ( string_data cp ) now `-` ) }
+        }
+    }
+    ( string_free cp )
+
+    ? > ( string_len latest ) 0 {
+        ? ( __uc_newer ( string_data latest ) current ) {
+            ( __uc_notice ( string_data latest ) current )
+        } {}
+    } {}
+    ( string_free latest )
+}

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -45,6 +45,7 @@ $ `stdlib/ext/pkg_publish.nu`
 $ `stdlib/ext/semver.nu`
 $ `stdlib/ext/credentials.nu`
 $ `stdlib/ext/json.nu`
+$ `stdlib/ext/update_check.nu`
 $ `stdlib/core/io.nu`
 $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/bytes.nu`
@@ -3869,7 +3870,15 @@ Usage: nurlpkg login   (paste the token from the registry; kept in ~/.nurl/crede
 
 // ── dispatch ─────────────────────────────────────────────────────
 
+// Run the command, then print a best-effort "a newer toolchain is out" notice
+// AFTER its output (stderr; cached, opt-out — see stdlib/ext/update_check.nu).
 @ main → i {
+    : i rc ( __nurlpkg_run )
+    ( update_check_notice ( nurl_version ) )
+    ^ rc
+}
+
+@ __nurlpkg_run → i {
     : i argc ( env_args_count )
     ? < argc 2 {
         ( __print_usage )


### PR DESCRIPTION
## Why

The "publish --dry-run published for real" scare had a mundane root cause: a **stale binary**. An old `nurlpkg` (v0.19.0, predating `--dry-run`) ran against today's registry. `--dry-run` itself is fine — proven with `nurlpkg-smoketest 0.0.2`, which stayed absent from the registry after a dry-run. The real fix is to **tell the user when their toolchain is behind**, so they update instead of running something ancient.

## What

New **`stdlib/ext/update_check.nu`** → `update_check_notice(current)`:

- **best-effort, non-fatal** — never blocks the command, never changes its exit code, prints at most one stderr line **after** the command's output;
- **cached** — the network is touched at most once per day (`$NURL_HOME/.update-check` records the last probe + version);
- **quiet where a notice would be noise** — skipped on opt-out (`$NURL_NO_UPDATE_CHECK`), in CI (`$CI`), when stderr isn't a terminal, and on a dev/`-dirty` build (a version that isn't a clean release tag);
- **oracle = GitHub `releases/latest`** for `nurl-lang/nurl` — the same source `install.sh` resolves "latest" from — read with a User-Agent, compared to the baked `nurl_version` via the `semver` package.

`nurlpkg`'s `main()` now runs the command, then calls the notice, so it trails the output and covers every exit path.

```
$ nurlpkg version
v0.23.0

A newer NURL toolchain is available: v0.24.0 (you have v0.23.0).
  update:  curl -fsSL https://nurl-lang.org/install.sh | sh
```

## Design decisions (from the discussion)

- **Version stays coupled to the toolchain** — `nurlpkg` is built from the toolchain's own stdlib and shares its ABI; a separately-versioned nurlpkg would create a skew matrix for no benefit. The notice points at `install.sh`, which updates `nurlc` + `nurlpkg` + stdlib **atomically**. No separate nurlpkg version to chase.
- **No infra change** — GitHub releases is already the installer's source of truth; zero registry or CI work.
- **Reusable** — `nurlc` can adopt the same notice with one call to `update_check_notice(nurl_version)`.

## Verified

dev build → silent · old release → notice after output · opt-out / CI / non-tty → silent · equal-or-newer → silent · second run within a day → cache hit, no re-probe · live GitHub fetch + semver compare path is **LSan-clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)