### PR TITLE
benchmark 0.1.1 — fix an O(N²) in the utf8 benchmark (0 MB/s in the w…

### DIFF
--- a/packages/benchmark/nurl.toml
+++ b/packages/benchmark/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.1.0"
+version = "0.1.1"
 description = "Reproduce NURL's performance claims on your own machine — a runnable benchmark suite, not a number in a README. `benchmark` measures pure-NURL throughput for the primitives the rest of the ecosystem is built on — SHA-256 hashing, JSON parsing, sorting, CBOR decoding, a dense f64 matmul, UTF-8 decoding — and prints a table of MB/s, million-ops/s and MFLOP/s as measured RIGHT NOW on the box it runs on. Built on the standard library's std/bench harness (auto-scaled iteration counts, a monotonic clock immune to NTP slew, and NURL-level allocations/op counted alongside wall time), so every row reports both throughput and how many heap allocations the operation costs. There is nothing to trust and nothing to set up: no GPU, no model download, no network, no configuration — `benchmark` installs with zero dependencies beyond the standard library and runs anywhere NURL runs. `benchmark` runs the whole suite, `benchmark <name…>` runs only the named benchmarks, `benchmark --list` shows them, and `benchmark --json` emits the same measurements as machine-readable JSON for a CI baseline or a regression gate. The answer to 'is it actually fast?' is a command a skeptic can run, not a story."
 license = "MIT OR Apache-2.0"
 

--- a/packages/benchmark/src/suite.nu
+++ b/packages/benchmark/src/suite.nu
@@ -331,7 +331,7 @@ $ `src/report.nu`
         : ~ i pos 0
         : ~ i cps 0
         ~ < pos bytes {
-            : Utf8Dec d ( utf8_decode sd pos )
+            : Utf8Dec d ( utf8_decode_n sd bytes pos )
             : i w ? > . d width 0 . d width 1
             = pos + pos w
             = cps + cps 1


### PR DESCRIPTION
…ild)

The utf8 row reported ~0 MB/s / 894 ms/op on a freshly installed benchmark, while a repo -O2 build showed ~1 GB/s. Cause: the loop called `utf8_decode`, whose one-arg form runs `nurl_str_len` (strlen) on every call — and a CSV/text view into a long buffer has no interior NUL, so each strlen scans the whole string. Per codepoint that is O(N²). A -O2 LTO build happened to hoist the loop-invariant strlen and hide it; a plainer build ran it every call.

The benchmark already has the length in hand (`bytes`), so switch to `utf8_decode_n sd bytes pos` — the exact "hoist the length outside the loop" shape its own doc-comment recommends. Now O(N) at any optimisation level (verified at -O0 and via the installed toolchain: ~185 MB/s, was 0).

The uniform ~5× lower numbers a user saw are just their machine — the install build is -O2 (the `nurl` shim runs `nurl.sh`, which defaults to -O2); a benchmark reporting a slower machine's real numbers is working as intended.


Claude-Session: https://claude.ai/code/session_01WX2frzGUucJVZjARF389im