### PR TITLE
stdlib: kill the per-byte nurl_str_get / vec_get walks (up to 656× on hot paths)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **stdlib hot paths — the per-byte `nurl_str_get` / `vec_get` walks are
+  gone.** `nurl_str_get` re-runs `strlen` on every call, so a loop that
+  scans a string with it is O(n²). In a read-only loop LLVM hoists that
+  `strlen` away, which is why the cost hid for so long — but every real
+  parser *writes* while it scans, and the store blocks the hoist. Six
+  stdlib functions were paying it, plus four more that walked a byte
+  buffer through an `?u`-returning `vec_get` (a bounds check and an
+  Option per byte) where a `memcpy` / `memcmp` / `memmem` was available.
+  Measured (`std/bench.nu`, `-O2`, ns/op, same machine):
+
+  | | before | after | |
+  |---|---|---|---|
+  | `bytes_from_str` 4 KB | 117 497 | 179 | **656×** |
+  | `bytes_to_str` 4 KB | 16 820 | 171 | **98×** |
+  | `bytes_eq` 4 KB | 1 481 | 55 | **27×** |
+  | `bytes_from_hex` 2 KB | 20 047 | 3 322 | 6.0× |
+  | `parse_request_head` 4 KB | 16 776 | 5 244 | 3.2× |
+  | `url_percent_decode` 768 B | 6 216 | 1 764 | 3.5× |
+  | `url_percent_encode` 768 B | 11 248 | 4 000 | 2.8× |
+  | `fmt1`, 512 B template | 5 092 | 1 845 | 2.8× |
+  | `bytes_to_hex` 1 KB | 9 122 | 6 895 | 1.32× |
+  | `string_push_char` ×1024 | 4 035 | 2 693 | 1.50× |
+
+  `string_push_char` also gained an inline fast path: it used to run two
+  independent capacity checks per byte (one in `vec_push`, one in
+  `_string_seal`'s `vec_reserve`) even on a pre-sized buffer. It is the
+  most-called mutator in the stdlib, so every text builder — JSON, CBOR,
+  YAML, TOML, `fmt`, hex — gets the 1.5×. No API or allocation-count
+  change anywhere.
+
 - **`stdlib/std/sort.nu` — insertion-sort cutoff for small subranges.**
   `sort_by` / `binary_search`'s quicksort now hands ranges of ≤16 elements to
   a straight insertion sort instead of partitioning them all the way down.
@@ -21,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in NURL is already essentially free. As a side effect small all-equal
   ranges now keep their input order (insertion sort is stable below the
   cutoff); `sort_by` still makes no general stability guarantee.
+
+### Fixed
+
+- **`string_eq` compared with `strcmp`, ignoring everything after an
+  embedded NUL.** `String` stores inner NUL bytes verbatim, so two
+  strings of equal length differing only past a NUL compared *equal*.
+  Now `memcmp` over the full byte range — which is also 1.3× faster.
 
 The **ecosystem** release. v0.22.0 made the registry a training stack;
 v0.23.0 closes the loop around it — the missing packages that turn "train

--- a/stdlib/core/string.nu
+++ b/stdlib/core/string.nu
@@ -436,23 +436,42 @@ $ `stdlib/core/char.nu`
     }
 }
 
+// Content equality over the FULL byte range [0, len). The lengths are
+// compared first, then the bytes with `memcmp` — not `strcmp`, which
+// stops at the first embedded NUL and would report two strings equal
+// when they differ only after it. `String` stores inner NULs verbatim
+// (see the module header), so the comparison has to honour them.
 @ string_eq String a String b → b {
     : ( Vec u ) ba ( __sbuf a )
     : ( Vec u ) bb ( __sbuf b )
     : i la ( vec_len [u] ba )
     : i lb ( vec_len [u] bb )
     ? != la lb { ^ F } {}
+    ? == la 0 { ^ T } {}
     : *u pa ( vec_data [u] ba )
     : *u pb ( vec_data [u] bb )
-    ^ == ( nurl_str_eq # s pa # s pb ) 1
+    ^ == 0 # i ( memcmp # s pa # s pb la )
 }
 
 // ── Mutators ────────────────────────────────────────────────────────
 
 @ string_push_char String str i c → v {
-    : ( Vec u ) b ( __sbuf str )
-    ( vec_push [u] b # u c )
-    ( _string_seal str )
+    : s ctl . str ctl
+    : i len ( nurl_peek ctl 1 )
+    : i cap ( nurl_peek ctl 2 )
+    // Fast path: room for the byte AND the trailing NUL already exists,
+    // so no grow-check and no _string_seal re-reserve is needed.
+    ? >= cap + len 2 {
+        : *u p # *u ( nurl_peek ctl 0 )
+        : u zero # u 0
+        = . p len # u c
+        = . p + len 1 zero
+        ( nurl_poke ctl 1 + len 1 )
+    } {
+        : ( Vec u ) b ( __sbuf str )
+        ( vec_push [u] b # u c )
+        ( _string_seal str )
+    }
 }
 
 @ string_push_str String str s raw → v {

--- a/stdlib/ext/http_request.nu
+++ b/stdlib/ext/http_request.nu
@@ -164,25 +164,27 @@ $ `stdlib/ext/http.nu`
 }
 
 // First index in [start..len-3] at which buf contains \r\n\r\n.
+//
+// One `memmem` over the tail instead of a per-byte `_bbyte` walk (a
+// bounds check plus an `?u` Option per byte). This runs on every
+// inbound request, over the whole received buffer, until the header
+// terminator arrives — libc's SIMD search is the right tool.
 @ __find_head_end ( Vec u ) buf i start → i {
     : i n ( vec_len [u] buf )
-    ? < n + start 4 { ^ -1 } {}
-    : ~ i i start
-    : i stop - n 3
-    ~ <= i stop {
-        : i b0 ( _bbyte buf i )
-        ? == b0 13 {
-            : i b1 ( _bbyte buf + i 1 )
-            : i b2 ( _bbyte buf + i 2 )
-            : i b3 ( _bbyte buf + i 3 )
-            ? & & == b1 10 == b2 13 == b3 10 { ^ i } {}
-        } {}
-        = i + i 1
-    }
-    ^ -1
+    : i st ? > start 0 start 0
+    ? < n + st 4 { ^ -1 } {}
+    : *u data ( vec_data [u] buf )
+    : s hay # s + # i data st
+    : i rel ( nurl_memmem_range hay - n st `\r\n\r\n` 4 )
+    ? < rel 0 { ^ -1 } {}
+    ^ + st rel
 }
 
-// Copy bytes [from..to) of `buf` into a fresh owned String.
+// Copy bytes [from..to) of `buf` into a fresh owned String. Bulk
+// `string_push_bytes` (one memcpy) rather than a per-byte push — this
+// is called for the request line and for every header of every
+// request. The range is already clamped into [0, len), so the per-byte
+// bounds check the old `_bbyte` loop paid for was dead weight.
 @ _bsubstr ( Vec u ) buf i from i to → String {
     : i n ( vec_len [u] buf )
     : ~ i a ? < from 0 0 from
@@ -190,12 +192,11 @@ $ `stdlib/ext/http.nu`
     ? > a b { = a b } {}
     : i out_n - b a
     : String out ( string_with_cap out_n )
-    : ~ i k a
-    ~ < k b {
-        : i bb ( _bbyte buf k )
-        ? >= bb 0 { ( string_push_char out bb ) } {}
-        = k + k 1
-    }
+    ? > out_n 0 {
+        : *u data ( vec_data [u] buf )
+        : *u at # *u + # i data a
+        ( string_push_bytes out at out_n )
+    } {}
     ^ out
 }
 

--- a/stdlib/std/bytes.nu
+++ b/stdlib/std/bytes.nu
@@ -54,14 +54,21 @@ $ `stdlib/core/errors.nu`
 
 // ── Construction from raw / String ─────────────────────────────────
 
+// One `strlen` + one `nurl_memcpy`. The previous body pushed byte by
+// byte through `nurl_str_get`, which re-runs `strlen` on EVERY call —
+// and because the `vec_push` in the same loop stores, LLVM could not
+// CSE that strlen away, so the whole converter was O(n²): 117 µs for a
+// 4 KB input, versus 168 ns for the memcpy below (699×). Same shape as
+// `bytes_extend_str`.
 @ bytes_from_str s raw → ( Vec u ) {
     : i n ( nurl_str_len raw )
     : ( Vec u ) v ( vec_with_cap [u] n )
-    : ~ i k 0
-    ~ < k n {
-        ( vec_push [u] v # u ( nurl_str_get raw k ) )
-        = k + k 1
-    }
+    ? > n 0 {
+        : *u src # *u raw
+        : *u dst ( vec_data [u] v )
+        ( nurl_memcpy dst src n )
+        : b _ok ( vec_set_len [u] v n )
+    } {}
     ^ v
 }
 
@@ -137,18 +144,17 @@ $ `stdlib/core/errors.nu`
 // trailing NUL automatically. NUL bytes inside `v` are stored verbatim
 // — `string_data` returns the buffer up to the first NUL, so if you
 // want the full contents iterate the bytes manually.
+//
+// `string_push_bytes` is one memcpy; the previous per-byte
+// `vec_get` + `string_push_char` walk cost 16.8 µs on a 4 KB buffer
+// against 164 ns here (103×), because every pushed byte re-sealed the
+// NUL terminator and re-ran the capacity check.
 @ bytes_to_str ( Vec u ) v → String {
     : i n ( vec_len [u] v )
     : String out ( string_with_cap n )
-    : ~ i k 0
-    ~ < k n {
-        : ?u got ( vec_get [u] v k )
-        ?? got {
-            T b → ( string_push_char out # i b )
-            F _ → {}
-        }
-        = k + k 1
-    }
+    ? > n 0 {
+        ( string_push_bytes out ( vec_data [u] v ) n )
+    } {}
     ^ out
 }
 
@@ -166,22 +172,22 @@ $ `stdlib/core/errors.nu`
     ^ + 87 n
 }
 
+// Hoists the data pointer once instead of an `?u`-returning `vec_get`
+// (bounds check + Option construction) per byte; the loop index is
+// already bounded by the length read above.
 @ bytes_to_hex ( Vec u ) v → String {
     : i n ( vec_len [u] v )
     : String out ( string_with_cap * n 2 )
-    : ~ i k 0
-    ~ < k n {
-        : ?u got ( vec_get [u] v k )
-        ?? got {
-            T b → {
-                : i ib # i b
-                ( string_push_char out ( __byte_hex_hi ib ) )
-                ( string_push_char out ( __byte_hex_lo ib ) )
-            }
-            F _ → {}
+    ? > n 0 {
+        : *u p ( vec_data [u] v )
+        : ~ i k 0
+        ~ < k n {
+            : i ib & # i . p k 255
+            ( string_push_char out ( __byte_hex_hi ib ) )
+            ( string_push_char out ( __byte_hex_lo ib ) )
+            = k + k 1
         }
-        = k + k 1
-    }
+    } {}
     ^ out
 }
 
@@ -199,10 +205,14 @@ $ `stdlib/core/errors.nu`
         ^ @ !( Vec u ) ParseErr { F @ ParseErr { BadFormat } }
     } {}
     : ( Vec u ) v ( vec_with_cap [u] / n 2 )
+    // Read through a raw pointer with the length hoisted above: the
+    // former `nurl_str_get` per nibble re-ran strlen on every call, and
+    // the `vec_push` in the loop blocked LLVM from hoisting it — O(n²).
+    : *u p # *u raw
     : ~ i k 0
     ~ < k n {
-        : i hi ( __hex_byte_value ( nurl_str_get raw k ) )
-        : i lo ( __hex_byte_value ( nurl_str_get raw + k 1 ) )
+        : i hi ( __hex_byte_value & # i . p k 255 )
+        : i lo ( __hex_byte_value & # i . p + k 1 255 )
         ? | < hi 0 < lo 0 {
             ( vec_free [u] v )
             ^ @ !( Vec u ) ParseErr { F @ ParseErr { BadFormat } }
@@ -219,16 +229,10 @@ $ `stdlib/core/errors.nu`
     : i la ( vec_len [u] a )
     : i lb ( vec_len [u] b )
     ? != la lb { ^ F } {}
+    ? == la 0 { ^ T } {}
     : *u pa ( vec_data [u] a )
     : *u pb ( vec_data [u] b )
-    : ~ i k 0
-    ~ < k la {
-        : u xa . pa k
-        : u xb . pb k
-        ? != xa xb { ^ F } {}
-        = k + k 1
-    }
-    ^ T
+    ^ == 0 # i ( memcmp # s pa # s pb la )
 }
 
 // ── Search ──────────────────────────────────────────────────────────

--- a/stdlib/std/fmt.nu
+++ b/stdlib/std/fmt.nu
@@ -37,18 +37,24 @@ $ `stdlib/core/vec.nu`
 
 // ── Core engine ────────────────────────────────────────────────────
 
+// The template is walked through a raw pointer with its length hoisted
+// once. `nurl_str_get` re-runs strlen on every call, and the pushes
+// into `out` keep LLVM from hoisting it, so the scan used to be
+// quadratic in template length — 9.4 ns per byte on a 512-byte
+// template. Short templates hid the cost; HTML-sized ones do not.
 @ __fmt_emit String out s tmpl ( Vec s ) args → v {
     : i tlen ( nurl_str_len tmpl )
+    : *u tp # *u tmpl
     : i nargs ( vec_len [s] args )
     : ~ i i 0
     : ~ i ai 0
     ~ < i tlen {
-        : i c ( nurl_str_get tmpl i )
+        : i c & # i . tp i 255
         // '{' = 123, '}' = 125
         ? == c 123 {
             : i nxt + i 1
             ? < nxt tlen {
-                : i c2 ( nurl_str_get tmpl nxt )
+                : i c2 & # i . tp nxt 255
                 ? == c2 123 {
                     ( string_push_char out 123 )
                     = i + i 2
@@ -79,7 +85,7 @@ $ `stdlib/core/vec.nu`
             ? == c 125 {
                 : i nxt + i 1
                 ? < nxt tlen {
-                    : i c2 ( nurl_str_get tmpl nxt )
+                    : i c2 & # i . tp nxt 255
                     ? == c2 125 {
                         ( string_push_char out 125 )
                         = i + i 2

--- a/stdlib/std/url.nu
+++ b/stdlib/std/url.nu
@@ -99,15 +99,20 @@ $ `stdlib/core/vec.nu`
 // path/generic component). url_query_decode handles the
 // form-urlencoded '+'→space rule for query strings.
 
+// Reads the input through a raw pointer with the length hoisted once.
+// `nurl_str_get` re-runs strlen per call, and the `string_push_char`
+// in this loop stores, so LLVM cannot hoist that strlen out — the byte
+// walk was O(n²) in the length of every decoded URL / query value.
 @ url_percent_decode s in → String {
     : i n ( nurl_str_len in )
+    : *u p # *u in
     : String out ( string_with_cap + n 1 )
     : ~ i k 0
     ~ < k n {
-        : i c ( nurl_str_get in k )
+        : i c & # i . p k 255
         ? & == c 37 <= + k 2 - n 1 {
-            : i hi ( __url_hex_val ( nurl_str_get in + k 1 ) )
-            : i lo ( __url_hex_val ( nurl_str_get in + k 2 ) )
+            : i hi ( __url_hex_val & # i . p + k 1 255 )
+            : i lo ( __url_hex_val & # i . p + k 2 255 )
             ? & >= hi 0 >= lo 0 {
                 ( string_push_char out + * hi 16 lo )
                 = k + k 3
@@ -123,12 +128,14 @@ $ `stdlib/core/vec.nu`
     ^ out
 }
 
+// Same hoisted-length / raw-pointer walk as url_percent_decode.
 @ url_percent_encode s in → String {
     : i n ( nurl_str_len in )
+    : *u p # *u in
     : String out ( string_with_cap + n 1 )
     : ~ i k 0
     ~ < k n {
-        : i c & 255 ( nurl_str_get in k )
+        : i c & # i . p k 255
         ? ( __url_is_unreserved c ) {
             ( string_push_char out c )
         } {
@@ -308,14 +315,15 @@ $ `stdlib/core/vec.nu`
 @ __url_form_decode s in → String {
     // like url_percent_decode but '+' → space (form-urlencoded)
     : i n ( nurl_str_len in )
+    : *u p # *u in
     : String out ( string_with_cap + n 1 )
     : ~ i k 0
     ~ < k n {
-        : i c ( nurl_str_get in k )
+        : i c & # i . p k 255
         ? == c 43 { ( string_push_char out 32 ) = k + k 1 } {
             ? & == c 37 <= + k 2 - n 1 {
-                : i hi ( __url_hex_val ( nurl_str_get in + k 1 ) )
-                : i lo ( __url_hex_val ( nurl_str_get in + k 2 ) )
+                : i hi ( __url_hex_val & # i . p + k 1 255 )
+                : i lo ( __url_hex_val & # i . p + k 2 255 )
                 ? & >= hi 0 >= lo 0 { ( string_push_char out + * hi 16 lo ) = k + k 3 }
                 { ( string_push_char out c ) = k + k 1 }
             } { ( string_push_char out c ) = k + k 1 }


### PR DESCRIPTION
## The bug class

`nurl_str_get` re-runs `strlen` on every call — its own doc comment says so — yet the stdlib scans strings with it in **426 places**. A loop that walks a string byte-by-byte with it is O(n²).

It hid for a long time because in a **read-only** loop LLVM CSEs the `strlen` away (only ~2.3× penalty). But every real parser *writes* while it scans, and the store blocks the hoist, restoring the full quadratic. Measured, parser-shaped loop over 4 KB:

| | ns/op |
|---|---|
| `nurl_str_get` per byte | 119 903 |
| hoisted `strlen` + `*u` pointer walk | 10 999 |

and it scales quadratically — the same loop at n = 1k/2k/4k/8k costs 12/33/146/462 µs.

Six stdlib functions were paying that, plus four more that walked a byte buffer through an `?u`-returning `vec_get` (a bounds check *and* an Option per byte) where a `memcpy` / `memcmp` / `memmem` was already sitting in the module next door.

## Measured

`std/bench.nu`, `-O2`, ns/op, same machine, before → after:

| | before | after | |
|---|---|---|---|
| `bytes_from_str` 4 KB | 117 497 | 179 | **656×** |
| `bytes_to_str` 4 KB | 16 820 | 171 | **98×** |
| `bytes_eq` 4 KB | 1 481 | 55 | **27×** |
| `bytes_from_hex` 2 KB | 20 047 | 3 322 | 6.0× |
| `parse_request_head` 4 KB | 16 776 | 5 244 | 3.2× |
| `url_percent_decode` 768 B | 6 216 | 1 764 | 3.5× |
| `url_percent_encode` 768 B | 11 248 | 4 000 | 2.8× |
| `fmt1`, 512 B template | 5 092 | 1 845 | 2.8× |
| `bytes_to_hex` 1 KB | 9 122 | 6 895 | 1.32× |
| `string_push_char` ×1024 | 4 035 | 2 693 | 1.50× |

These are all *shared* paths: `bytes_from_str` / `bytes_to_str` are the canonical String ↔ byte-buffer converters that every hashing, crypto, TLS, HTTP-body, gguf, safetensor and registry path goes through; `parse_request_head` + `url_percent_*` run on every inbound HTTP request; `fmt` is every log line.

## What changed

- **`std/bytes.nu`** — `bytes_from_str` → one `nurl_memcpy`; `bytes_to_str` → `string_push_bytes`; `bytes_eq` → `memcmp`; `bytes_to_hex` / `bytes_from_hex` → hoisted pointer walk.
- **`core/string.nu`** — `string_push_char` gains an inline fast path. It ran *two* independent capacity checks per byte (one in `vec_push`, one in `_string_seal`'s `vec_reserve`) even on a pre-sized buffer. The slow path is kept verbatim so the packed layout from `string_from_bytes_packed` (`cap == len+1`) still unpacks through `vec_push`. This is the most-called mutator in the stdlib — every text builder (JSON, CBOR, YAML, TOML, `fmt`, hex) gets the 1.5×.
- **`std/url.nu`** — `url_percent_decode` / `url_percent_encode` / `__url_form_decode` read through a raw pointer with the length hoisted.
- **`std/fmt.nu`** — `__fmt_emit` walks the template the same way.
- **`ext/http_request.nu`** — `__find_head_end` uses `nurl_memmem_range` (libc SIMD) instead of a per-byte `_bbyte` scan for `\r\n\r\n`; `_bsubstr` uses one `string_push_bytes` instead of a per-byte push (it is called for the request line and every header of every request).

No API, signature or allocation-count change anywhere.

## Also fixes a correctness bug

`string_eq` compared equal-length strings with `strcmp`, which stops at the first embedded NUL — so two `String`s differing only *after* a NUL compared **equal**. `String` stores inner NULs verbatim (module header says so), so the comparison has to honour them. `memcmp` over the full byte range is both correct and 1.3× faster.

## Verification

- `./build.sh` — **BUILD SUCCESS & TESTS PASSED** (554 PASS / 0 FAIL)
- `./build.sh --san` + `compiler/tests/run_san_tests.sh` — **SAN_FAIL: 0** (459 PASS, 103 SKIP). The 18 COMPILE / 4 LINK counts are the pre-existing `borrow_*` negative tests and `*_mod` helper modules with no `main`.

## Left on the table

This PR fixes the confirmed instances. The `nurl_str_get` *class* still has ~400 call sites (`time.nu` 41, `yaml.nu` 41, `toml.nu` 25, `xml.nu` 20, `fs.nu` 19, `path.nu` 17, `semver.nu` 17, …). The durable fix is an O(1) length-explicit accessor or a `StrView {ptr,len}` so the quadratic shape becomes unexpressible rather than merely documented — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bky5SfwQZ5cn2yrqud3NMW