### PR TITLE
stdlib: emission cursor + regex scratch reuse (to_lower 39×, hex 25×, regex_replace 7.2×)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`string_reserve_at` / `string_commit` (`stdlib/core/string.nu`) — a
+  bulk emission cursor.** `string_push_char` costs a call, three
+  `nurl_peek`s and a `nurl_poke` per byte — ~1.7 ns even on its fast
+  path, because the compiler must re-read the control block every time
+  (the store could alias it). An encoder that knows how many bytes it is
+  about to produce can now reserve the room once, write straight through
+  a `*u`, and commit at the end: measured **565 ns vs 7 061 ns** for
+  4096 bytes (12.5×). The reserved pointer is valid only until the next
+  operation that can grow the buffer — the contract is spelled out at
+  the definition. Committing fewer bytes than reserved is allowed, so
+  encoders whose output size is only an upper bound (percent-encoding)
+  can use it too.
+
 - **`nurl_str_at str len idx` (`stdlib/core/string.nu`) — the O(1) byte
   accessor scan loops want.** Same contract as `nurl_str_get` (0 when
   `idx` is outside `[0, len)`, which is what parsers rely on when they
@@ -18,6 +31,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one-off reads where no length is at hand.
 
 ### Changed
+
+- **Per-item overhead removed from the hot emitters and from the regex
+  engine.** Two distinct costs, same shape — work repeated per byte or
+  per loop iteration that only needed doing once:
+
+  *Cursor emission.* `bytes_to_hex`, `hex_encode`, `__b64_emit`,
+  `url_percent_encode`, `string_to_lower` / `_to_upper` / `_reverse` and
+  `__fmt_emit` produced their output one `string_push_char` at a time.
+  They now reserve the exact (or upper-bound) output length once and
+  write through the new cursor; `__fmt_emit` additionally copies each
+  literal run between placeholders in one `string_push_bytes` instead of
+  a push per byte.
+
+  *Scratch reuse.* `__rx_run_at` allocated **four `Vec[i]` on every start
+  position** of a search — 8 005 allocations for a 2 KB `regex_replace` —
+  and re-zeroed them with a per-state loop each time. The four buffers
+  carry no state between runs, so every public regex entry point now
+  builds one `RxScratch` up front and reuses it for the whole scan.
+  Passing the scratch explicitly (rather than caching it inside the
+  `Regex`) keeps a compiled `Regex` reentrant.
+
+  Measured (`std/bench.nu`, `-O2`, ns/op):
+
+  | | before | after | |
+  |---|---|---|---|
+  | `string_to_lower` 4 KB | 14 325 | 366 | **39×** |
+  | `hex_encode` 4 KB | 25 573 | 1 004 | **25×** |
+  | `bytes_to_hex` 4 KB | 25 342 | 1 058 | **24×** |
+  | `regex_replace` 2 KB | 557 647 | 77 382 | **7.2×** |
+  | `b64_encode` 4 KB | 16 349 | 4 270 | **3.8×** |
+  | `url_percent_encode` 1 KB | 6 902 | 2 157 | **3.2×** |
+  | `regex_test` 2 KB | 1 924 | 595 | **3.2×** |
+  | `fmt1`, 512 B template | 1 758 | 548 | **3.2×** |
+
+  `regex_replace` drops from 8 005 to 5 allocations per call and
+  `regex_test` from 28 to 4. Byte-for-byte output is unchanged: the
+  encoders are covered by the RFC known-answer vectors in the corpus
+  (blake2b, chacha20poly1305, x25519, ed25519, aes-gcm, hkdf, pbkdf2,
+  ecdsa-p256), and the whole suite is ASan/UBSan-clean — the check that
+  matters for an API that hands out a raw write cursor.
 
 - **The `nurl_str_get` scan loops are gone from the parsers — 278 of the
   426 call sites migrated to `nurl_str_at`.** Follow-up to the hot-path

--- a/stdlib/core/string.nu
+++ b/stdlib/core/string.nu
@@ -473,6 +473,53 @@ $ `stdlib/core/char.nu`
     ^ == 0 # i ( memcmp # s pa # s pb la )
 }
 
+// ── Bulk emission cursor ────────────────────────────────────────────
+//
+// `string_push_char` is a call, three `nurl_peek`s and a `nurl_poke`
+// per byte — ~1.7 ns even on its fast path, because the compiler has to
+// re-read the control block every time (the store could alias it). An
+// encoder that knows how many bytes it is about to produce can instead
+// reserve the room once, write straight through a `*u`, and commit the
+// length at the end: measured 4096 bytes in 565 ns versus 7061 ns
+// through `string_push_char` — 12.5×.
+//
+//   : *u w ( string_reserve_at out n )     // room for n bytes + NUL
+//   … = . w k # u byte …                   // k in [0, n)
+//   ( string_commit out n )                // len += n, NUL re-sealed
+//
+// CONTRACT — the returned pointer is valid only until the next
+// operation that can grow the buffer. Between `string_reserve_at` and
+// `string_commit`, do NOT call any other mutator on `str` (push_char,
+// push_str, push_bytes, clear, …) and do NOT write past index n-1: a
+// realloc would move the buffer and leave the cursor dangling. Write
+// the bytes, commit, then go back to the normal API.
+//
+// Committing fewer bytes than reserved is fine (encoders whose output
+// size is only an upper bound reserve the bound and commit the truth).
+
+@ string_reserve_at String str i n → *u {
+    : ( Vec u ) b ( __sbuf str )
+    ( vec_reserve [u] b + n 1 )
+    // Re-read the control block rather than deriving the result from
+    // `b`: `b` is a VIEW of str's ctl (see __sbuf), but strict borrowck
+    // cannot know that and would flag a raw pointer escaping an owned
+    // local. Going through nurl_peek keeps the provenance on `str`.
+    : s ctl . str ctl
+    : i len ( nurl_peek ctl 1 )
+    : *u p # *u ( nurl_peek ctl 0 )
+    ^ # *u + # i p len
+}
+
+@ string_commit String str i n → v {
+    ? <= n 0 { ^ } {}
+    : s ctl . str ctl
+    : i len ( nurl_peek ctl 1 )
+    ( nurl_poke ctl 1 + len n )
+    : *u p # *u ( nurl_peek ctl 0 )
+    : u zero # u 0
+    = . p + len n zero
+}
+
 // ── Mutators ────────────────────────────────────────────────────────
 
 @ string_push_char String str i c → v {
@@ -700,31 +747,44 @@ $ `stdlib/core/char.nu`
     ^ @ String { . tmp ctl }
 }
 
-// Copy all bytes with ASCII 'A'..'Z' mapped to 'a'..'z'.
+// Copy all bytes with ASCII 'A'..'Z' mapped to 'a'..'z'. The output is
+// exactly as long as the input, so it is emitted straight through a
+// reserved cursor instead of n separate `string_push_char` calls.
 @ string_to_lower String str → String {
     : i n ( string_len str )
     : String out ( string_with_cap n )
-    : ~ i i 0
-    ~ < i n {
-        : ~ i c ( string_get str i )
-        ? & >= c 65 <= c 90 { = c + c 32 } {}
-        ( string_push_char out c )
-        = i + i 1
-    }
+    ? > n 0 {
+        : *u src ( vec_data [u] ( __sbuf str ) )
+        : *u w ( string_reserve_at out n )
+        : ~ i i 0
+        ~ < i n {
+            : ~ i c & # i . src i 255
+            ? & >= c 65 <= c 90 { = c + c 32 } {}
+            = . w i # u c
+            = i + i 1
+        }
+        ( string_commit out n )
+    } {}
     ^ out
 }
 
-// Copy all bytes with ASCII 'a'..'z' mapped to 'A'..'Z'.
+// Copy all bytes with ASCII 'a'..'z' mapped to 'A'..'Z'. Cursor-emitted
+// like `string_to_lower`.
 @ string_to_upper String str → String {
     : i n ( string_len str )
     : String out ( string_with_cap n )
-    : ~ i i 0
-    ~ < i n {
-        : ~ i c ( string_get str i )
-        ? & >= c 97 <= c 122 { = c - c 32 } {}
-        ( string_push_char out c )
-        = i + i 1
-    }
+    ? > n 0 {
+        : *u src ( vec_data [u] ( __sbuf str ) )
+        : *u w ( string_reserve_at out n )
+        : ~ i i 0
+        ~ < i n {
+            : ~ i c & # i . src i 255
+            ? & >= c 97 <= c 122 { = c - c 32 } {}
+            = . w i # u c
+            = i + i 1
+        }
+        ( string_commit out n )
+    } {}
     ^ out
 }
 
@@ -732,11 +792,16 @@ $ `stdlib/core/char.nu`
 @ string_reverse String str → String {
     : i n ( string_len str )
     : String out ( string_with_cap n )
-    : ~ i i - n 1
-    ~ >= i 0 {
-        ( string_push_char out ( string_get str i ) )
-        = i - i 1
-    }
+    ? > n 0 {
+        : *u src ( vec_data [u] ( __sbuf str ) )
+        : *u w ( string_reserve_at out n )
+        : ~ i i 0
+        ~ < i n {
+            = . w i . src - - n 1 i
+            = i + i 1
+        }
+        ( string_commit out n )
+    } {}
     ^ out
 }
 

--- a/stdlib/ext/regex.nu
+++ b/stdlib/ext/regex.nu
@@ -653,26 +653,72 @@ $ `stdlib/core/vec.nu`
     }
 }
 
+// Per-search scratch: the four Vec[i] the NFA simulation needs. These
+// used to be allocated (and freed) inside __rx_run_at, i.e. once per
+// START POSITION — 8005 allocations for a 2 KB subject in
+// `regex_replace`. They carry no state between runs, so every public
+// entry point now builds one scratch up front and reuses it across the
+// whole scan. Passing it explicitly (rather than caching it in the
+// Regex) keeps a compiled Regex reentrant: two searches can run over
+// the same Regex at once, each with its own scratch.
+: RxScratch {
+    ( Vec i ) cur
+    ( Vec i ) nxt
+    ( Vec i ) marked_cur
+    ( Vec i ) marked_nxt
+    i nstates
+}
+
+@ __rx_nstates Regex r → i {
+    : *RegexImpl impl # *RegexImpl . r ctl
+    ^ / ( vec_len [i] . impl states ) 4
+}
+
+// A Vec[i] of `n` zeros — the marked-set shape __vi_set writes into.
+@ __rx_zeros i n → ( Vec i ) {
+    : ( Vec i ) v ( vec_with_cap [i] n )
+    : ~ i k 0
+    ~ < k n { ( vec_push [i] v 0 ) = k + k 1 }
+    ^ v
+}
+
+@ __rx_scratch_new Regex r → RxScratch {
+    : i ns ( __rx_nstates r )
+    ^ @ RxScratch {
+        ( vec_with_cap [i] ns )
+        ( vec_with_cap [i] ns )
+        ( __rx_zeros ns )
+        ( __rx_zeros ns )
+        ns
+    }
+}
+
+@ __rx_scratch_free RxScratch sc → v {
+    ( vec_free [i] . sc cur )
+    ( vec_free [i] . sc nxt )
+    ( vec_free [i] . sc marked_cur )
+    ( vec_free [i] . sc marked_nxt )
+}
+
 // Try to match starting at text_pos. Returns the longest match length
-// found at this start (≥0), or -1 if no match.
-@ __rx_run_at Regex r s text i text_len i text_pos → i {
+// found at this start (≥0), or -1 if no match. `sc` is scratch owned by
+// the caller; its contents are reset here, so the same scratch can be
+// handed to every start position of a scan.
+@ __rx_run_at Regex r s text i text_len i text_pos RxScratch sc → i {
     : *RegexImpl impl # *RegexImpl . r ctl
     : ( Vec i ) states . impl states
     : ( Vec i ) classes . impl classes
     : ( Vec i ) class_starts . impl class_starts
     : i start . impl start
-    : i nstates / ( vec_len [i] states ) 4
-    : ~ ( Vec i ) cur ( vec_with_cap [i] nstates )
-    : ~ ( Vec i ) nxt ( vec_with_cap [i] nstates )
-    : ~ ( Vec i ) marked_cur ( vec_with_cap [i] nstates )
-    : ~ ( Vec i ) marked_nxt ( vec_with_cap [i] nstates )
-    // Initialize marked vectors to length nstates with 0.
-    : ~ i k 0
-    ~ < k nstates {
-        ( vec_push [i] marked_cur 0 )
-        ( vec_push [i] marked_nxt 0 )
-        = k + k 1
-    }
+    : i nstates . sc nstates
+    : ~ ( Vec i ) cur . sc cur
+    : ~ ( Vec i ) nxt . sc nxt
+    : ~ ( Vec i ) marked_cur . sc marked_cur
+    : ~ ( Vec i ) marked_nxt . sc marked_nxt
+    ( vec_clear [i] cur )
+    ( vec_clear [i] nxt )
+    ( __rx_clear_marked marked_cur nstates )
+    ( __rx_clear_marked marked_nxt nstates )
     ( __rx_add_active_v states cur marked_cur start text_pos text_len )
 
     : ~ i best -1
@@ -734,10 +780,6 @@ $ `stdlib/core/vec.nu`
         }
     }
 
-    ( vec_free [i] cur )
-    ( vec_free [i] nxt )
-    ( vec_free [i] marked_cur )
-    ( vec_free [i] marked_nxt )
     ^ best
 }
 
@@ -745,40 +787,47 @@ $ `stdlib/core/vec.nu`
 
 @ regex_test Regex r s text → b {
     : i n ( nurl_str_len text )
+    : RxScratch sc ( __rx_scratch_new r )
     : ~ i pos 0
-    ~ <= pos n {
-        : i m ( __rx_run_at r text n pos )
-        ? >= m 0 { ^ T } {}
-        = pos + pos 1
+    : ~ b hit F
+    ~ & ! hit <= pos n {
+        : i m ( __rx_run_at r text n pos sc )
+        ? >= m 0 { = hit T } { = pos + pos 1 }
     }
-    ^ F
+    ( __rx_scratch_free sc )
+    ^ hit
 }
 
 @ regex_match Regex r s text → b {
     : i n ( nurl_str_len text )
-    : i m ( __rx_run_at r text n 0 )
+    : RxScratch sc ( __rx_scratch_new r )
+    : i m ( __rx_run_at r text n 0 sc )
+    ( __rx_scratch_free sc )
     ^ == m n
 }
 
 @ regex_find Regex r s text → ?Match {
     : i n ( nurl_str_len text )
+    : RxScratch sc ( __rx_scratch_new r )
     : ~ i pos 0
-    ~ <= pos n {
-        : i m ( __rx_run_at r text n pos )
-        ? >= m 0 {
-            ^ @ ?Match { T @ Match { pos m } }
-        } {}
-        = pos + pos 1
+    : ~ i hit_at -1
+    : ~ i hit_len 0
+    ~ & < hit_at 0 <= pos n {
+        : i m ( __rx_run_at r text n pos sc )
+        ? >= m 0 { = hit_at pos = hit_len m } { = pos + pos 1 }
     }
+    ( __rx_scratch_free sc )
+    ? >= hit_at 0 { ^ @ ?Match { T @ Match { hit_at hit_len } } } {}
     ^ @ ?Match { F @ Match { 0 0 } }
 }
 
 @ regex_find_all Regex r s text → ( Vec Match ) {
     : ( Vec Match ) out ( vec_new [Match] )
     : i n ( nurl_str_len text )
+    : RxScratch sc ( __rx_scratch_new r )
     : ~ i pos 0
     ~ <= pos n {
-        : i m ( __rx_run_at r text n pos )
+        : i m ( __rx_run_at r text n pos sc )
         ? >= m 0 {
             ( vec_push [Match] out @ Match { pos m } )
             ? == m 0 { = pos + pos 1 } { = pos + pos m }
@@ -786,15 +835,17 @@ $ `stdlib/core/vec.nu`
             = pos + pos 1
         }
     }
+    ( __rx_scratch_free sc )
     ^ out
 }
 
 @ regex_replace Regex r s text s repl → String {
     : String out ( string_with_cap ( nurl_str_len text ) )
     : i n ( nurl_str_len text )
+    : RxScratch sc ( __rx_scratch_new r )
     : ~ i pos 0
     ~ <= pos n {
-        : i m ( __rx_run_at r text n pos )
+        : i m ( __rx_run_at r text n pos sc )
         ? >= m 0 {
             ( string_push_str out repl )
             ? == m 0 {
@@ -810,16 +861,18 @@ $ `stdlib/core/vec.nu`
             = pos + pos 1
         }
     }
+    ( __rx_scratch_free sc )
     ^ out
 }
 
 @ regex_split Regex r s text → ( Vec String ) {
     : ( Vec String ) out ( vec_new [String] )
     : i n ( nurl_str_len text )
+    : RxScratch sc ( __rx_scratch_new r )
     : ~ i seg_start 0
     : ~ i pos 0
     ~ <= pos n {
-        : i m ( __rx_run_at r text n pos )
+        : i m ( __rx_run_at r text n pos sc )
         ? & >= m 0 > m 0 {
             // Emit segment [seg_start..pos)
             : i seg_len - pos seg_start
@@ -834,6 +887,7 @@ $ `stdlib/core/vec.nu`
             = seg_start pos
         } { = pos + pos 1 }
     }
+    ( __rx_scratch_free sc )
     // Emit final segment [seg_start..n)
     : i tail_len - n seg_start
     : String tail ( string_with_cap tail_len )

--- a/stdlib/std/bytes.nu
+++ b/stdlib/std/bytes.nu
@@ -180,13 +180,17 @@ $ `stdlib/core/errors.nu`
     : String out ( string_with_cap * n 2 )
     ? > n 0 {
         : *u p ( vec_data [u] v )
+        // Output length is exactly 2n, so reserve once and write through
+        // the cursor rather than paying string_push_char per nibble.
+        : *u w ( string_reserve_at out * n 2 )
         : ~ i k 0
         ~ < k n {
             : i ib & # i . p k 255
-            ( string_push_char out ( __byte_hex_hi ib ) )
-            ( string_push_char out ( __byte_hex_lo ib ) )
+            = . w * k 2 # u ( __byte_hex_hi ib )
+            = . w + * k 2 1 # u ( __byte_hex_lo ib )
             = k + k 1
         }
+        ( string_commit out * n 2 )
     } {}
     ^ out
 }

--- a/stdlib/std/encode.nu
+++ b/stdlib/std/encode.nu
@@ -35,15 +35,20 @@ $ `stdlib/core/errors.nu`
 @ hex_encode s str → String {
     : i len ( nurl_str_len str )
     : String out ( string_with_cap * len 2 )
-    : ~ i i 0
-    ~ < i len {
-        : i b ( nurl_str_at str len i )
-        : i hi ( __hex_digit & 15 / b 16 )
-        : i lo ( __hex_digit & b 15 )
-        ( string_push_char out hi )
-        ( string_push_char out lo )
-        = i + i 1
-    }
+    ? > len 0 {
+        : *u src # *u str
+        // Exactly 2 output bytes per input byte — reserve once and write
+        // through the cursor (string_push_char is ~12x the cost here).
+        : *u w ( string_reserve_at out * len 2 )
+        : ~ i i 0
+        ~ < i len {
+            : i b & # i . src i 255
+            = . w * i 2 # u ( __hex_digit & 15 / b 16 )
+            = . w + * i 2 1 # u ( __hex_digit & b 15 )
+            = i + i 1
+        }
+        ( string_commit out * len 2 )
+    } {}
     ^ out
 }
 
@@ -93,43 +98,62 @@ $ `stdlib/core/errors.nu`
 }
 
 // Binary-safe emitter. Processes exactly n_in bytes from str.
+//
+// The output length is a pure function of n_in, so the whole result is
+// reserved once and written through a raw cursor. The previous version
+// paid a `string_push_char` per output character — a call plus three
+// control-block reads each — which dominated base64 entirely (measured
+// 3.8 ns per input byte).
 @ __b64_emit String out s str i n_in b url b pad → v {
-    : ~ i i 0
+    ? <= n_in 0 { ^ } {}
+    : i groups / n_in 3
+    : i rem_in - n_in * groups 3
+    : i tail ? == rem_in 0 0 ? pad 4 ? == rem_in 1 2 3
+    : i out_n + * groups 4 tail
     : *u data # *u str
+    : *u w ( string_reserve_at out out_n )
+    : ~ i i 0
+    : ~ i o 0
     ~ <= + i 3 n_in {
         : i b0 & 255 # i . data i
         : i b1 & 255 # i . data + i 1
         : i b2 & 255 # i . data + i 2
         : i n + + * b0 65536 * b1 256 b2
-        ( string_push_char out ( __b64_digit & 63 / n 262144 url ) )
-        ( string_push_char out ( __b64_digit & 63 / n 4096 url ) )
-        ( string_push_char out ( __b64_digit & 63 / n 64 url ) )
-        ( string_push_char out ( __b64_digit & 63 n url ) )
+        = . w o # u ( __b64_digit & 63 / n 262144 url )
+        = . w + o 1 # u ( __b64_digit & 63 / n 4096 url )
+        = . w + o 2 # u ( __b64_digit & 63 / n 64 url )
+        = . w + o 3 # u ( __b64_digit & 63 n url )
         = i + i 3
+        = o + o 4
     }
     : i rem - n_in i
     ? == rem 1 {
         : i b0 & 255 # i . data i
         : i n * b0 65536
-        ( string_push_char out ( __b64_digit & 63 / n 262144 url ) )
-        ( string_push_char out ( __b64_digit & 63 / n 4096 url ) )
+        = . w o # u ( __b64_digit & 63 / n 262144 url )
+        = . w + o 1 # u ( __b64_digit & 63 / n 4096 url )
+        = o + o 2
         ? pad {
-            ( string_push_char out 61 )  // '='
-            ( string_push_char out 61 )
+            : u eq # u 61  // '='
+            = . w o eq
+            = . w + o 1 eq
+            = o + o 2
         } {}
     } {}
     ? == rem 2 {
         : i b0 & 255 # i . data i
         : i b1 & 255 # i . data + i 1
         : i n + * b0 65536 * b1 256
-        ( string_push_char out ( __b64_digit & 63 / n 262144 url ) )
-        ( string_push_char out ( __b64_digit & 63 / n 4096 url ) )
-        ( string_push_char out ( __b64_digit & 63 / n 64 url ) )
+        = . w o # u ( __b64_digit & 63 / n 262144 url )
+        = . w + o 1 # u ( __b64_digit & 63 / n 4096 url )
+        = . w + o 2 # u ( __b64_digit & 63 / n 64 url )
+        = o + o 3
         ? pad {
-            ( string_push_char out 61 )  // '='
+            = . w o # u 61  // '='
+            = o + o 1
         } {}
     } {}
-    ( _string_seal out )
+    ( string_commit out o )
 }
 
 @ b64_encode s str → String {

--- a/stdlib/std/fmt.nu
+++ b/stdlib/std/fmt.nu
@@ -98,8 +98,15 @@ $ `stdlib/core/vec.nu`
                     = i + i 1
                 }
             } {
-                ( string_push_char out c )
-                = i + i 1
+                // Literal run: copy everything up to the next brace in
+                // one memcpy instead of a string_push_char per byte.
+                : ~ i run + i 1
+                ~ & < run tlen & != & # i . tp run 255 123 != & # i . tp run 255 125 {
+                    = run + run 1
+                }
+                : *u at # *u + # i tp i
+                ( string_push_bytes out at - run i )
+                = i run
             }
         }
     }

--- a/stdlib/std/url.nu
+++ b/stdlib/std/url.nu
@@ -128,23 +128,34 @@ $ `stdlib/core/vec.nu`
     ^ out
 }
 
-// Same hoisted-length / raw-pointer walk as url_percent_decode.
+// Same hoisted-length / raw-pointer walk as url_percent_decode, and the
+// output goes through a reserved cursor: each input byte yields either
+// 1 byte or a 3-byte `%XX`, so 3n is a hard upper bound. We reserve that
+// once and commit the actual length — `string_push_char` per emitted
+// byte was ~12x the cost of a cursor store.
 @ url_percent_encode s in → String {
     : i n ( nurl_str_len in )
     : *u p # *u in
     : String out ( string_with_cap + n 1 )
-    : ~ i k 0
-    ~ < k n {
-        : i c & # i . p k 255
-        ? ( __url_is_unreserved c ) {
-            ( string_push_char out c )
-        } {
-            ( string_push_char out 37 )  // '%'
-            ( string_push_char out ( __url_hex_digit / c 16 ) )
-            ( string_push_char out ( __url_hex_digit % c 16 ) )
+    ? > n 0 {
+        : *u w ( string_reserve_at out * n 3 )
+        : ~ i k 0
+        : ~ i o 0
+        ~ < k n {
+            : i c & # i . p k 255
+            ? ( __url_is_unreserved c ) {
+                = . w o # u c
+                = o + o 1
+            } {
+                = . w o # u 37  // '%'
+                = . w + o 1 # u ( __url_hex_digit / c 16 )
+                = . w + o 2 # u ( __url_hex_digit % c 16 )
+                = o + o 3
+            }
+            = k + k 1
         }
-        = k + k 1
-    }
+        ( string_commit out o )
+    } {}
     ^ out
 }
 


### PR DESCRIPTION
A different class of target from #625 / #626. Not a quadratic scan this time, but **work repeated per byte or per loop iteration that only needed doing once**. Found by surveying allocations/op and ns/byte across the stdlib rather than by grepping for a pattern.

## 1. Emission cursor

`string_push_char` is a call, three `nurl_peek`s and a `nurl_poke` per byte — ~1.7 ns even on the fast path from #625, because the compiler has to re-read the control block every time (the store could alias it). Every encoder in the stdlib emitted its output that way.

New in `core/string.nu`:

```
: *u w ( string_reserve_at out n )   // room for n bytes + NUL
… = . w k # u byte …                 // k in [0, n)
( string_commit out n )              // len += n, NUL re-sealed
```

Measured on the bare pattern: **4096 bytes in 565 ns versus 7 061 ns** through `string_push_char` — 12.5×.

The reserved pointer is valid only until the next operation that can grow the buffer, and the contract is spelled out at the definition (no other mutator between reserve and commit, no writing past `n-1`). Committing fewer bytes than reserved is allowed, so encoders whose output size is only an upper bound — percent-encoding — can use it too.

Converted: `bytes_to_hex`, `hex_encode`, `__b64_emit`, `url_percent_encode`, `string_to_lower` / `_to_upper` / `_reverse`. `__fmt_emit` additionally copies each literal run between placeholders in one `string_push_bytes` instead of a push per byte.

## 2. Scratch reuse in the regex engine

`__rx_run_at` allocated **four `Vec[i]` on every start position** of a search — 8 005 allocations for a 2 KB `regex_replace` — and re-zeroed them with a per-state loop each time. The four buffers carry no state between runs, so every public entry point (`regex_test`, `regex_match`, `regex_find`, `regex_find_all`, `regex_replace`, `regex_split`) now builds one `RxScratch` up front and reuses it for the whole scan.

The scratch is passed explicitly rather than cached inside the `Regex`, so a compiled `Regex` stays reentrant — two searches can run over the same `Regex` at once, each with its own scratch.

## Measured

`std/bench.nu`, `-O2`, ns/op, same machine:

| | before | after | |
|---|---|---|---|
| `string_to_lower` 4 KB | 14 325 | 366 | **39×** |
| `hex_encode` 4 KB | 25 573 | 1 004 | **25×** |
| `bytes_to_hex` 4 KB | 25 342 | 1 058 | **24×** |
| `regex_replace` 2 KB | 557 647 | 77 382 | **7.2×** |
| `b64_encode` 4 KB | 16 349 | 4 270 | **3.8×** |
| `url_percent_encode` 1 KB | 6 902 | 2 157 | **3.2×** |
| `regex_test` 2 KB | 1 924 | 595 | **3.2×** |
| `fmt1`, 512 B template | 1 758 | 548 | **3.2×** |

`regex_replace` drops from **8 005 to 5** allocations per call, `regex_test` from 28 to 4.

## Correctness

Output is byte-for-byte unchanged. The converted encoders are exactly the ones already covered by RFC known-answer vectors in the corpus — `blake2b_vectors`, `chacha20poly1305_vectors`, `x25519_vectors`, `ed25519_vectors`, `aes_gcm_vectors`, `hkdf_vectors`, `pbkdf2_vectors`, `ecdsa_p256_sign`, `minisign_verify`, `jwt_basic` — all of which compare hex/base64 output against fixed expected strings.

One implementation note worth reviewing: `string_reserve_at` re-reads the control block through `nurl_peek` rather than deriving its result from the `__sbuf` view. Strict borrowck (`compiler/tests/borrow_strict_raw_ptr_escape`) correctly refuses a raw pointer derived from an owned local; going through the ctl keeps the provenance on `str`. That diagnostic firing was a useful check, not an obstacle.

## Verification

- `./build.sh` — **BUILD SUCCESS & TESTS PASSED** (554 PASS / 0 FAIL)
- `./build.sh --san` + `compiler/tests/run_san_tests.sh` — **SAN_FAIL: 0** (459 PASS, 103 SKIP). This is the check that matters for an API that hands out a raw write cursor: an off-by-one in any of the reserve-size computations would land as a heap-buffer-overflow here. The 18 COMPILE / 4 LINK counts are the pre-existing `borrow_*` negative tests and `*_mod` helper modules with no `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bky5SfwQZ5cn2yrqud3NMW