### PR TITLE
nurlc: kill two more quadratics found by perf (self-compile 1.01s → 0.86s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Two more quadratics inside `nurlc` — self-compile 1.01 s → 0.86 s.**
+  Found with `perf` (the previous compiler fix came from gprof), which
+  showed 20% of the compiler's runtime inside libc `strlen` and named
+  the two callers:
+
+  * `emit_hoisted` materialised **every IR line** with `nurl_str_slice`,
+    which re-runs `strlen` over the *whole function body* and mallocs a
+    copy — per line, and twice, since the pass runs once for allocas and
+    once for everything else. That is quadratic in function-body size
+    (8.7% of total runtime in `strlen` alone, plus a leaked allocation
+    per emitted line). Lines are now printed in place: write a NUL over
+    the terminating newline, print from the buffer, restore the byte.
+    `nurl_print` consumes its argument synchronously and
+    `nurl_print_buf_stop` returns an independent `strdup`, so the swap is
+    never observable.
+  * `__bck_st_get_at` — the borrow checker's per-binding state lookup,
+    called 14.8M times per self-compile — scanned its space-separated
+    state string with `nurl_str_get`, i.e. a `strlen` per byte examined
+    (17% of the profile, plus 5% more inside `strlen`). The token walk
+    now runs on `memmem` + `memcmp`.
+
+  Emitted IR is byte-identical and the bootstrap fixed point holds. Peak
+  RSS is unchanged. `memchr` was tried in place of `memmem` for the
+  one-byte needles and made no measurable difference, so it was dropped
+  rather than carried for the extra FFI declaration.
+
 - **`nurlc` recomputed the current line number by rescanning the source
   from byte 0 on every parser backtrack — 3.3× faster self-compile.**
   `nurl_lex_set_pos` counted newlines from the start of the file to

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -9488,21 +9488,33 @@
 // name to look up lives at src[at .. at+wl) so bck_join_state can probe
 // with a name that is still embedded in the other state string — no
 // copy of the name either.
+// Reads through hoisted `*u` pointers: `nurl_str_get` re-runs strlen on
+// EVERY call, so scanning the state string with it cost a strlen per
+// byte examined — O(state_len^2) per lookup, at 14.8M lookups per
+// self-compile. That single loop was 17% of nurlc's profile plus most
+// of the 20% spent inside libc strlen. Both indices are already bounded
+// by the loop guards (`e < n`) and by the caller's `wl` (the name it
+// probes with is embedded in a NUL-terminated string), so the bounds
+// check nurl_str_get performed was dead weight here.
+// The token walk runs on `memmem` (next separator) + `memcmp` (name
+// compare) rather than a NURL byte loop through `nurl_str_get`. This
+// lookup is called 14.8M times per self-compile and was 17% of nurlc's
+// profile, plus 5% more inside libc strlen — `nurl_str_get` re-runs
+// strlen on EVERY byte it reads. Both indices are bounded by `n` and by
+// the caller's `wl`, so the per-byte bounds check bought nothing.
 @ __bck_st_get_at s state s src i at i wl → i {
     : i n ( nurl_str_len state )
+    : *u sp # *u state
+    : *u qp # *u src
     : ~ i i 0
     ~ < i n {
         // token spans [i, e)
-        : ~ i e i
-        ~ & < e n != ( nurl_str_get state e ) 32 { = e + e 1 }
+        : i r ( nurl_memmem_range # s + # i sp i - n i ` ` 1 )
+        : i e ? < r 0 n + i r
         ? == - - e i 2 wl {
-            : ~ i k 0
-            : ~ b eq T
-            ~ & eq < k wl {
-                ? != ( nurl_str_get state + i k ) ( nurl_str_get src + at k ) { = eq F } {}
-                = k + k 1
-            }
-            ? eq { ^ - ( nurl_str_get state - e 1 ) 48 } {}
+            ? == 0 # i ( memcmp # s + # i sp i # s + # i qp at wl ) {
+                ^ - & # i . sp - e 1 255 48
+            } {}
         } {}
         = i + e 1
     }
@@ -15046,13 +15058,15 @@
 
 // Index of the '\n' ending the line starting at `p`, or `flen` if the
 // text has no further newline.
+// Offset of the newline at or after `p`, or flen. `memmem` with a
+// one-byte needle, not a NURL byte loop: the old version called
+// nurl_str_get per byte, i.e. a strlen over the whole function body per
+// byte examined.
 @ __ha_line_end s text i p i flen → i {
-    : ~ i q p
-    ~ < q flen {
-        ? == ( nurl_str_get text q ) 10 { ^ q } {}
-        = q + q 1
-    }
-    ^ flen
+    : *u tp # *u text
+    : i r ( nurl_memmem_range # s + # i tp p - flen p `\n` 1 )
+    ? < r 0 { ^ flen } {}
+    ^ + p r
 }
 
 // True when `line` is an alloca INSTRUCTION (`  %reg = alloca <ty>`).
@@ -15061,9 +15075,10 @@
 // operand, no SSA reference), which is what makes hoisting sound.
 @ __ha_is_alloca s line → b {
     ? < ( strlen line ) 3 { ^ F } {}
-    ? != ( nurl_str_get line 0 ) 32 { ^ F } {}
-    ? != ( nurl_str_get line 1 ) 32 { ^ F } {}
-    ? != ( nurl_str_get line 2 ) 37 { ^ F } {}
+    : *u p # *u line
+    ? != & # i . p 0 255 32 { ^ F } {}
+    ? != & # i . p 1 255 32 { ^ F } {}
+    ? != & # i . p 2 255 37 { ^ F } {}
     ^ ? >= ( nurl_str_find line ` = alloca ` ) 0 T F
 }
 
@@ -15072,26 +15087,47 @@
 // relative order preserved); all other instructions — including each
 // alloca's matching `store` — stay exactly where they were. A function
 // with no `entry:` label (should not happen) is emitted verbatim.
+// Each line used to be materialised with `nurl_str_slice`, which
+// re-runs strlen over the WHOLE function body and mallocs a copy — per
+// line, twice (both passes). On a large function that is quadratic in
+// body size, and it was 8.7% of nurlc's total runtime in strlen alone
+// plus a leaked allocation per emitted IR line.
+//
+// Instead we print each line in place: write a NUL over its terminating
+// newline, print from the buffer, put the byte back. `nurl_print`
+// consumes the string synchronously (fputs, or a memcpy into the output
+// buffer), so the swap is never observable, and no line is copied.
 @ emit_hoisted s funcdef → v {
     : i flen ( strlen funcdef )
     : i ei ( nurl_str_find funcdef `\nentry:\n` )
     ? < ei 0 { ( nurl_print funcdef ) ^ v } {}
     : i hdr_end + ei 8  // past "\nentry:\n"
-    ( nurl_print ( nurl_str_slice funcdef 0 hdr_end ) )
+    : *u fp # *u funcdef
+    // Header [0, hdr_end).
+    : u sv_h . fp hdr_end
+    = . fp hdr_end # u 0
+    ( nurl_print funcdef )
+    = . fp hdr_end sv_h
     // Pass 1: the alloca instructions, hoisted into the entry block.
     : ~ i p hdr_end
     ~ < p flen {
         : i le ( __ha_line_end funcdef p flen )
-        : s line ( nurl_str_slice funcdef p - le p )
+        : u sv . fp le
+        = . fp le # u 0
+        : s line # s + # i fp p
         ? ( __ha_is_alloca line ) { ( nurl_print line ) ( nurl_print `\n` ) } {}
+        = . fp le sv
         = p + le 1
     }
     // Pass 2: everything else, in original order.
     = p hdr_end
     ~ < p flen {
         : i le ( __ha_line_end funcdef p flen )
-        : s line ( nurl_str_slice funcdef p - le p )
+        : u sv2 . fp le
+        = . fp le # u 0
+        : s line # s + # i fp p
         ? ! ( __ha_is_alloca line ) { ( nurl_print line ) ( nurl_print `\n` ) } {}
+        = . fp le sv2
         = p + le 1
     }
 }


### PR DESCRIPTION
With `perf` usable now, a real profile of nurlc compiling its own source put **20% of the runtime inside libc `strlen`** and — with `--call-graph dwarf` — named both callers. Neither was visible to gprof, which had attributed everything to the one function that dominated before #628.

```
20.36%  __strlen_avx2
        |--8.66%--emit_hoisted
         --4.94%--__bck_st_get_at
17.14%  __bck_st_get_at   (self)
```

## 1. `emit_hoisted` — a slice per IR line

It materialised **every IR line** with `nurl_str_slice`, which re-runs `strlen` over the *whole function body* and mallocs a copy. Per line. And twice over, since the pass runs once for allocas and once for everything else. That is quadratic in function-body size, and it leaked an allocation per emitted IR line.

Lines are now printed in place: write a NUL over the line's terminating newline, print from the buffer, put the byte back.

That is safe for two specific reasons, both checked: `nurl_print` consumes its argument synchronously (`fputs`, or a `memcpy` into the output buffer), and `nurl_print_buf_stop` returns an independent `strdup` rather than a pointer into `g_outbuf` — so the swapped byte is never observable and the buffer we mutate is private.

`__ha_line_end` (a per-byte `nurl_str_get` scan for the newline) now uses `nurl_memmem_range`, and `__ha_is_alloca` reads its first three bytes through one hoisted pointer instead of three `nurl_str_get` calls that each re-`strlen`'d the line.

## 2. `__bck_st_get_at` — a strlen per byte examined

The borrow checker's per-binding state lookup — called **14.8M times per self-compile**, per the note already in the source — walked its space-separated state string with `nurl_str_get`, i.e. a `strlen` per byte. The token walk now runs on `memmem` (next separator) + `memcmp` (name compare). Both indices were already bounded by the loop guard and by the caller's name length, so `nurl_str_get`'s bounds check bought nothing here.

## Measured

nurlc compiling its own 1 MB source: **1.01 s → 0.86 s (1.17×)**.

Emitted IR is **byte-identical**, the bootstrap fixed point holds, and peak RSS is unchanged at 403 MB (the per-line slices were small enough not to matter — I checked rather than claiming a memory win).

## A negative result, recorded

`memchr` was tried in place of `memmem` for the one-byte needles, on the theory that glibc's Two-Way setup is wasted there. It made **no measurable difference** (0.86 s either way) and added a per-file FFI declaration that showed up as an extra `declare` line in every compiled program's IR — so it was dropped rather than carried.

## Next, from the same profile

~14% is now `malloc`/`_int_malloc`/`free`. `nurl_sym_get` `strdup`s its result on every one of its millions of lookups, and `strdup`s `""` on a miss. Changing that touches the ownership contract of every caller, so it belongs in its own change rather than being bolted on here. `nurl_sym_get` + `strcmp` is a further ~9%.

## Verification

- `./build.sh` — **BUILD SUCCESS & TESTS PASSED** (554 PASS / 0 FAIL)
- `./build.sh --san` + `compiler/tests/run_san_tests.sh` — **SAN_FAIL: 0** (459 PASS). This is the check that matters for the in-place NUL swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bky5SfwQZ5cn2yrqud3NMW