### PR TITLE
progress: show the current rate, not a cumulative average

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The transfer progress bar reported a falling rate on a transfer that
+  was not slowing down.** `stdlib/std/progress.nu` derived its rate from
+  `cur / (now - started)` — an average over the whole transfer. Two
+  consequences, both visible on a model download:
+
+  * On a **resume**, the caller sets the already-downloaded bytes with
+    `progress_set` immediately after `progress_new`, so the first render
+    divided (say) 400 MB by 0.2 s and printed **3.7 GB/s**, then decayed
+    continuously — 763 MB/s, 381 MB/s, 191 MB/s — while the actual
+    throughput sat at a constant 1 MB/s. That is the "starts at full
+    speed and steadily declines" report.
+  * Even from zero, a cumulative average cannot react: a transfer that
+    settles at its real rate after a fast first second spends minutes
+    crawling down toward the truth.
+
+  The rate is now the **current** throughput — an exponential moving
+  average over roughly the last second of samples, the number `curl` and
+  `wget` show — measured from the resume point, so bytes that came off
+  the disk never count as network throughput. `progress_done` reports the
+  average over this session's bytes.
+
+  Measured on the same synthetic resume (400 MB present, steady 1 MB/s):
+  before `3.7 GB/s → 763 → 381 → 191 → 127 MB/s`; after a flat
+  `975 KB/s`.
+
+  The transfer itself was never slow: a 4-minute, 195 MB download through
+  the same stdlib path (TLS + `file_write_chunk` + `sha256_update`) held
+  462 → 939 KB/s with no trend, at 15% CPU and flat RSS, against 725 KB/s
+  for `curl` on the same URL at the same time.
+
 ## [0.24.0] — 2026-07-25
 
 The **performance** release. No new language surface — this one is about

--- a/stdlib/std/progress.nu
+++ b/stdlib/std/progress.nu
@@ -7,17 +7,31 @@
 //
 //   ( progress_new label total )   → *Progress   total ≤ 0: indeterminate
 //   ( progress_add p n )           → v           advance by n units
-//   ( progress_set p cur )         → v           set absolute position
+//   ( progress_set p cur )         → v           set absolute position AND
+//                                                rebase the rate (resume)
 //   ( progress_done p )            → v           final render + newline; FREES p
 //   ( progress_human n )           → String      "3.4 MB" (pure; unit-testable)
 //
 // Rendering: at most every 100 ms (monotonic clock), width-fitted to
-// term_width, with a rate derived from the elapsed wall time:
+// term_width, with a CURRENT rate — the recent throughput, the number
+// curl and wget show — not a cumulative average:
 //
 //   fetch [==========>          ]  42.5 MB / 118.2 MB  17.3 MB/s
 //
 // Units are whatever the caller counts — the human formatter assumes
 // bytes, which is the overwhelmingly common case.
+//
+// Why a windowed rate: the rate used to be `cur / (now - started)`, an
+// average over the whole transfer. Two things made that misleading on a
+// long download. It cannot react — a transfer that settles at 1 MB/s
+// after a fast first second spends minutes crawling down toward the
+// truth, which reads as "the download is slowing down" when it is not.
+// And on a RESUME the caller sets the already-downloaded bytes with
+// `progress_set`, so the first render divided (say) 400 MB by 0.2 s and
+// printed gigabytes per second, then decayed continuously from there.
+// The rate is now an exponential moving average over the last ~1 s of
+// samples, measured from the resume point, and `progress_done` reports
+// the average over THIS session's bytes.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -32,6 +46,14 @@ $ `stdlib/std/term.nu`
     i started_ns
     i last_ns
     b tty
+    // Rate state. `base_*` is the point the rate is measured from —
+    // reset by progress_set so resumed bytes never count as throughput.
+    // `w_*` is the previous sample; `rate` the smoothed bytes/s.
+    i base_cur
+    i base_ns
+    i w_cur
+    i w_ns
+    i rate
 }
 
 // "1023 B" · "3.4 KB" · "42.5 MB" · "1.2 GB" — one decimal above bytes.
@@ -70,9 +92,15 @@ $ `stdlib/std/term.nu`
     = . p label ( string_from label )
     = . p total total
     = . p cur 0
-    = . p started_ns ( monotonic_ns )
+    : i now ( monotonic_ns )
+    = . p started_ns now
     = . p last_ns 0
     = . p tty ( term_is_tty 2 )
+    = . p base_cur 0
+    = . p base_ns now
+    = . p w_cur 0
+    = . p w_ns now
+    = . p rate 0
     ^ p
 }
 
@@ -118,10 +146,20 @@ $ `stdlib/std/term.nu`
     } {
         ( string_push_str ln ( string_data curh ) )
     }
-    // rate over the whole transfer — smooth and honest
-    : i el - ( monotonic_ns ) . p started_ns
-    ? > el 100000000 {
-        : i per_s / * . p cur 1000000000 el
+    // Current rate: the smoothed recent throughput. Before the first
+    // sample lands, fall back to this session's average (bytes since the
+    // resume point over the time since it) so the field is never blank.
+    // `final` reports that session average — the summary wget prints.
+    : i el - ( monotonic_ns ) . p base_ns
+    : ~ i per_s 0
+    ? final {
+        ? > el 100000000 { = per_s / * - . p cur . p base_cur 1000000000 el } {}
+    } {
+        ? > . p rate 0 { = per_s . p rate } {
+            ? > el 100000000 { = per_s / * - . p cur . p base_cur 1000000000 el } {}
+        }
+    }
+    ? > per_s 0 {
         : String rh ( progress_human per_s )
         ( string_push_str ln `  ` )
         ( string_push_str ln ( string_data rh ) )
@@ -135,11 +173,25 @@ $ `stdlib/std/term.nu`
     ( string_free curh )
 }
 
+// Fold one sample into the moving average. alpha = 1/8 over the 100 ms
+// render cadence ≈ a 0.8 s time constant: responsive enough to show a
+// stall, smooth enough not to jitter on chunk boundaries.
+@ __pg_sample * Progress p i now → v {
+    : i dt - now . p w_ns
+    ? <= dt 0 { ^ v } {}
+    : i db - . p cur . p w_cur
+    : i inst / * db 1000000000 dt
+    ? <= . p rate 0 { = . p rate inst } { = . p rate / + * . p rate 7 inst 8 }
+    = . p w_cur . p cur
+    = . p w_ns now
+}
+
 @ __pg_tick * Progress p → v {
     ? . p tty {} { ^ v }
     : i now ( monotonic_ns )
     ? > - now . p last_ns 100000000 {
         = . p last_ns now
+        ( __pg_sample p now )
         ( __pg_render p F )
     } {}
 }
@@ -149,8 +201,18 @@ $ `stdlib/std/term.nu`
     ( __pg_tick p )
 }
 
+// Absolute position — and the rate's new zero. The caller that uses
+// this is resuming a partial transfer: those bytes came off the disk,
+// not the network, so counting them as throughput is what produced the
+// "starts at gigabytes per second, then falls forever" display.
 @ progress_set * Progress p i cur → v {
+    : i now ( monotonic_ns )
     = . p cur cur
+    = . p base_cur cur
+    = . p base_ns now
+    = . p w_cur cur
+    = . p w_ns now
+    = . p rate 0
     ( __pg_tick p )
 }
 


### PR DESCRIPTION
Reported as *"nurllama pull starts at full speed but steadily slows down as the download progresses"*. It does not slow down. The transfer is fine; the meter was wrong.

## Measured before touching anything

The first question was whether this is even our code — and the answer decides the tool. Both runs against the same Hugging Face URL:

| | rate | CPU | RSS |
|---|---|---|---|
| our stdlib path (TLS + `file_write_chunk` + `sha256_update`), 4 min / 195 MB | 462 → 775 → 818 → 926 → 939 → 828 KB/s (**no trend**) | 15% | flat, 2.5 MB |
| `curl` on the same URL, same minutes | 725 KB/s | — | — |

At 15% CPU the process is not compute-bound, so `perf` would have found nothing worth having — and the windowed throughput is flat and matches curl. ~750 KB/s is simply what that CDN gave at that moment.

## The actual bug

`stdlib/std/progress.nu` derived its rate from `cur / (now - started)` — an average over the *whole* transfer.

* **On a resume** the caller sets the already-downloaded bytes with `progress_set` right after `progress_new` (`hub/src/pull.nu`, `nurllama/src/pull.nu`), so the first render divided ~400 MB by ~0.2 s. Reproduced synthetically with a steady 1 MB/s and 400 MB already present:

  | | first render | then | | | |
  |---|---|---|---|---|---|
  | before | 3.7 GB/s | 763 MB/s | 381 MB/s | 191 MB/s | 127 MB/s |
  | after | 975 KB/s | 975 KB/s | 975 KB/s | 975 KB/s | 975 KB/s |

  A smooth, permanent decline from an absurd starting number — exactly the reported symptom, at a constant true rate.

* **Even from zero** a cumulative average cannot react. Once a transfer settles below its early rate, the displayed number spends minutes crawling toward the truth, which reads as "it is slowing down".

## The fix

The rate is now the **current** throughput — the number curl and wget show. An exponential moving average over roughly the last second of samples (alpha 1/8 at the 100 ms render cadence: responsive enough to show a stall, smooth enough not to jitter on chunk boundaries), measured **from the resume point**, so bytes that came off the disk never count as network throughput. `progress_done` reports the average over this session's bytes — the summary wget prints at the end.

`progress_set` is only ever used for the resume baseline, so giving it "set position **and** rebase the rate" semantics is correct for every caller in the tree.

## Deliberately not changed

Nothing in the transfer path. If the download feels slow on a fast link, the lever is Hugging Face's per-connection throttling — an auth token, or parallel range requests the way `hf_transfer` does — which is a feature worth its own discussion, not part of a display fix. Claiming a speed-up here would have been claiming something I measured to be false.

## Verification

- `./build.sh` — 554 PASS / 0 FAIL, including `term_progress`
- `./build.sh --san` + `run_san_tests.sh` — SAN_FAIL 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bky5SfwQZ5cn2yrqud3NMW