### PR TITLE
release: v0.24.1 — progress-rate patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] — 2026-07-25
+
+A patch for a display bug that read as a transfer bug: model downloads
+were reported as steadily slowing down when they were not.
+
 ### Fixed
 
 - **The transfer progress bar reported a falling rate on a transfer that
@@ -8622,7 +8627,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.24.1...HEAD
+[0.24.1]: https://github.com/nurl-lang/nurl/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/nurl-lang/nurl/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/nurl-lang/nurl/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/nurl-lang/nurl/compare/v0.21.0...v0.22.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-07-25 · Current release: **0.24.0** · Language: **Grammar
+_Last reviewed: 2026-07-25 · Current release: **0.24.1** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
Docs only. Prepares the `v0.24.1` patch release; the tag is **not** pushed by this PR.

## Scope

Exactly one commit since `v0.24.0`: #631, which fixed the transfer progress bar reporting a falling rate on a download that was not slowing down. No API change, no behaviour change outside the display — so a patch bump rather than a minor.

## Changes

- **CHANGELOG** — cut `## [0.24.1] — 2026-07-25` from `[Unreleased]`, with the one-line intro the other patch sections use (`0.14.1` is the shape I followed), the compare link, and `[Unreleased]` repointed at `v0.24.1...HEAD`. `tools/version.sh` and `tools/gen-site-facts.sh` both read the newest *released* section, so nurl-lang.org tracks this release in the same change instead of lagging.

- **ROADMAP.md** — current release 0.24.1.

## Checked, nothing to do

The fix is confined to `stdlib/std/progress.nu`: no new API to document, README carries no version or performance claims, and ROADMAP's reviewed date is already today from the 0.24.0 PR.

## Cutting the release

Per `RELEASING.md`, after this merges:

```bash
git tag v0.24.1
git push origin v0.24.1
```

which fires `release.yml` (linux-x86_64, linux-arm64, freebsd best-effort, windows) and `web-deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bky5SfwQZ5cn2yrqud3NMW