### PR TITLE
lingbot-map 0.2.0 — the registry is serving code that no longer exists

### DIFF
--- a/packages/lingbot-map/CHANGELOG.md
+++ b/packages/lingbot-map/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+## 0.2.0
+
+The port was correct and slow; this is the release where it is fast.
+Measured on an RTX 4090 in f32, model load excluded on both sides, it is
+**at parity with the reference**: 138 ms a frame against its 141, ahead
+on the camera head (16 ms vs 54) and behind on the aggregator and depth
+head. End to end, eight frames went **38.2 s -> 3.2 s** and the 4.6 GB
+checkpoint load 25 s -> 1.6 s.
+
+Almost all of the work landed in [gpukit](../gpukit) 0.6.0 and
+[gpu](../gpu) 0.11.0, because every gap this hit is one any GPU package
+hits — a tiled GEMM, fused attention, a caching device allocator,
+per-kernel profiling. What is here:
+
+- **The checkpoint is read straight into device memory.** The load path
+  widened every f32 weight to f64, transposed the four hot Linear
+  weights on the host with a column-strided write per element, and
+  narrowed them again on upload. Now the mapped bytes go to the device
+  as they are and the transpose is a permute kernel.
+- **Two per-frame constants are built once.** The DPT
+  positional-embedding grid is a pure function of (channels, height,
+  width, aspect) — rebuilding it was ~10 million host `sin`/`cos` a
+  frame. The DINOv2 position grid is a bicubic resample over 1024
+  channels and a pure function of (gh, gw) — another 53 ms a frame.
+  Together a third of the frame, both bit-identical.
+- **Binary PLY by default**, `--ascii` for the text form. Formatting
+  three coordinates per point cost 15 us a point — 470 ms a frame at the
+  default stride, more than the depth head. The end-to-end test checks
+  both formats agree.
+- **`--profile`** prints per-stage frame timings and the kernel profile.
+- **`--frames` and the device choice**: the run opens the strongest GPU
+  on the box rather than ordinal 0, which on a machine with an old card
+  beside a new one is whichever the driver enumerated first.
+
+Numerics are unchanged or better: 18/18 against the real model, with the
+aggregator at 5.291e-6 and the end-to-end depth at 1.505e-5. Everything
+except the fused attention is bit-identical to the 0.1.0 kernels — the
+`depthcheck` dump is byte-for-byte what a pristine 0.1.0 build produces.
+
+## 0.1.0
+
+First release: the Geometric Context Transformer end to end in pure
+NURL — checkpoint reader, preprocessing, DINOv2 trunk, streaming
+aggregator with a sliding-window KV cache, camera head, DPT depth head,
+geometry, and a CLI that writes a point cloud. Every stage checked
+against the reference PyTorch implementation.

--- a/packages/lingbot-map/nurl.toml
+++ b/packages/lingbot-map/nurl.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lingbot-map"
-version = "0.1.0"
-description = "LingBot-Map in pure NURL — the Geometric Context Transformer for streaming 3D reconstruction, ported from the reference PyTorch implementation. Feed it a folder of frames and it returns per-frame camera poses, depth and a world-space point cloud."
+version = "0.2.0"
+description = "LingBot-Map in pure NURL — the Geometric Context Transformer for streaming 3D reconstruction, ported from the reference PyTorch implementation. Feed it a folder of frames and it returns per-frame camera poses, depth and a world-space point cloud. Runs at parity with the reference on the same GPU — 138 ms a frame against its 141, f32 both sides, with eight frames end to end in 3.2 s including the 4.6 GB checkpoint load. Writes binary_little_endian PLY (--ascii for text), and --profile reports per-stage frame timings and a per-kernel GPU profile."
 license = "Apache-2.0"
 
 [dependencies]


### PR DESCRIPTION
`lingbot-map 0.1.0` is published, and PR #637's speed work landed on top
of it without a version change. So `nurlpkg install lingbot-map`
currently fetches the slow port: **38.2 s** for the eight-frame
reconstruction that the source in this tree does in **3.2 s**, and a
25 s checkpoint load rather than 1.6 s.

That is the same standard the release sweep (1a1dcea) applied to the
five packages it found drifted — the registry serves what the source is.

Minor rather than patch, because the CLI grew `--profile` and `--ascii`
and the default output format changed to `binary_little_endian` PLY.

Adds a CHANGELOG; the 0.1.0 entry is written from the README's stage
table rather than invented.

`nurlpkg publish --dry-run` passes every gate (127 422 bytes).

## Publishing order

This depends on gpukit `^0.6` and gpu `^0.11`, neither of which is on
the registry yet (latest are 0.5.0 and 0.10.1, both from the sweep).
They come from PR #638's branch and must go up first:

```
cd packages/gpu         && nurlpkg publish   # 0.11.0
cd ../gpukit            && nurlpkg publish   # 0.6.0
cd ../lingbot-map       && nurlpkg publish   # 0.2.0
```

## Still drifted, not addressed here

Seven packages had their gpukit/gpu requirement widened by #637
(anomaly, embed, grad, nurllama, onnx, tensor, whisper). Their published
tarballs still say `^0.5` / `^0.10`, which resolves to versions that
exist and work, so nothing is broken — but by the sweep's own standard
they have drifted and want a patch bump the next time they go up. Left
out of this PR deliberately: it is a release decision, not a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG
