### PR TITLE
release 0.25.0 — the toolchain packages/torchpt has always needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] — 2026-07-26
+
+The release that makes `packages/torchpt` and everything above it
+installable: the zip64 reading a 4.6 GB PyTorch checkpoint needs landed
+an hour after 0.24.1 was tagged, so every package built on it has been
+unbuildable by the released toolchain until now.
+
+Also the largest compiler speed-up so far, and a codegen fix that made
+`vec_extend` uncompilable for struct elements.
+
+### Added
+
+- **zip64 reading, and archives over a pointer.** `stdlib/ext/zip.nu`
+  gained `zip_open_ptr` (open an archive over a memory-mapped range
+  without copying it into a `Vec u` first), `zip_find`, `zip_csize_at`,
+  `zip_method_at`, `zip_data_off`, and zip64 central-directory support —
+  the 64-bit size/offset extra field, so an archive over 4 GB is
+  readable at all. A PyTorch `.pt` checkpoint is a zip, and a 4.6 GB one
+  needs every part of that: `packages/torchpt` reads the 1342 tensors of
+  a real checkpoint in 0.01 s and 31 MB of RSS by mapping the file and
+  never copying an entry it is not asked for.
+- **`erf` / `erfc`** in `stdlib/std/float.nu` — the exact GELU a
+  transformer wants (`x·Φ(x)`), not the tanh approximation.
+
 ### Changed
 
 - **The compiler is 34% faster and uses a third of the memory.** A
@@ -63,6 +87,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   produced them.
 
 ### Fixed
+
+- **`= . p + k 0 v` did not compile when the element type was a
+  struct.** A store through a computed pointer index died with
+  `unknown field or variable: +`, naming the operator as if it were a
+  field. The READ path had always accepted the same expression; only the
+  store peeked at the token after the pointer and, finding something
+  that was not an identifier, fell through to the error.
+  `stdlib/core/vec.nu`'s `vec_extend` hits it the moment its element
+  type is an aggregate — the generic monomorphises and fails with a
+  diagnostic pointing at nothing the caller wrote.
+- **wasm builds trapped at runtime for programs calling libc `rand`.**
+  The wasm32 ABI shims hardcoded each shim's signature from a letter
+  table, but the signature the CALL SITES use comes from the NURL
+  source. They are derived from the IR now.
 
 - **Canvas examples that call libc `rand` died on the playground with
   "runtime error: unreachable".** `doomfire.nu`, `sand.nu` and


### PR DESCRIPTION
Cuts **v0.25.0**. The tag is the release — `tools/version.sh` derives the
version from `git describe` and `release.yml` builds the archives on a
`v*` tag — so this PR is the changelog, and the tag follows the merge.

## Why this release has to exist

`packages/torchpt` reads a PyTorch `.pt` checkpoint, and a 4.6 GB one
needs zip64. That zip64 support landed **an hour after v0.24.1 was
tagged**:

```
v0.24.1                          2026-07-25 12:27
zip_open_ptr / zip64 read        2026-07-25 13:36
```

So torchpt has been unbuildable by the released toolchain since the day
it was published, and it takes `lingbot-map` down with it. Installing it
today gives:

```
call to unknown function 'zip_find'
call to unknown function 'zip_open_ptr'
```

which is a confusing way to learn "your toolchain is too old" — see the
note at the bottom.

## What is in it

**Added** — `zip_open_ptr` (open an archive over a memory-mapped range
without copying it first), `zip_find`, `zip_csize_at`, `zip_method_at`,
`zip_data_off`, and zip64 central-directory support. Plus `erf` / `erfc`,
the exact GELU rather than the tanh approximation.

**Changed** — the compiler is **34% faster and uses a third of the
memory** (0.83 s → 0.55 s, 405 MB → 122 MB on a self-compile, IR
byte-identical across all 1121 `.nu` files), and `nurl_str_float` now
binary-searches for the shortest round-tripping decimal instead of
scanning 1..17 digits.

**Fixed** — a store through a computed pointer index (`= . p + k 0 v`)
did not compile when the element type was a struct, which made
`vec_extend` uncompilable for aggregate elements; wasm builds trapped at
runtime for programs calling libc `rand`; canvas examples on the
playground.

The zip64, `erf`/`erfc` and the two fixes landed with the packages that
needed them and never got changelog entries — they are written up here.

## Gates

```
BUILD SUCCESS & TESTS PASSED          (557 compiler tests)
package imports OK                    (41 packages)
stdlib symbol check                   (no duplicate @-names)
examples gate: PASS 90 · FAIL 0
```

## Follow-up worth doing separately

Nothing in a manifest can say "this package needs nurl ≥ 0.25". A
package can be published that no released toolchain can build, and the
consumer finds out as an unknown-function error deep inside a
dependency. A `[package] nurl = ">=0.25.0"` field with an install-time
check would turn that into one clear line. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG
