### PR TITLE
nurl.sh + nurl.bat: every program built with the bundled zig was compiled -O0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,6 +314,36 @@ jobs:
           set "NURL_BUNDLE_ZIG=%CD%\vendor\zig"
           call tools\install-toolchain.bat
 
+      # The Linux legs smoke-test the assembled prefix; Windows never did,
+      # which is how nurl.bat came to ship without ever using the zig it
+      # bundles — every native build needed a system LLVM, and nothing
+      # noticed because CI installs one. Build and RUN a program with the
+      # assembled toolchain, from a directory whose name contains a space
+      # so a quoting regression in the driver fails here rather than on a
+      # user's machine.
+      - name: Smoke test the assembled toolchain
+        shell: pwsh
+        run: |
+          # A directory with a space in the name on purpose: the driver
+          # builds its compiler command by string concatenation, and an
+          # install path like C:\Users\First Last\.nurl\ is the normal
+          # case, not the exotic one.
+          $dir = "dist\smoke dir"
+          New-Item -ItemType Directory -Path $dir | Out-Null
+          # single-quoted here-string: NURL uses backticks for strings and
+          # PowerShell would otherwise eat them as escapes
+          $src = @'
+          $ `stdlib/core/io.nu`
+          @ main → i { ( nurl_print `ok` ) ^ 0 }
+          '@
+          ($src -split "`n" | ForEach-Object { $_.TrimStart() }) -join "`n" |
+            Set-Content -Path "$dir\s.nu" -Encoding utf8NoBOM
+          & cmd /c "call dist\nurl\bin\nurl.bat `"$dir\s.nu`" `"$dir\s`""
+          if ($LASTEXITCODE -ne 0) { throw "nurl.bat failed" }
+          $out = & "$dir\s.exe"
+          if ($LASTEXITCODE -ne 0) { throw "the built program failed" }
+          if ($out -ne "ok") { throw "unexpected output: $out" }
+
       - name: Package
         shell: pwsh
         run: |

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -44,6 +44,50 @@ jobs:
         run: call build.bat
         shell: cmd
 
+      # ── The DRIVER, which nothing else on Windows exercises ────────
+      # build.bat compiles the toolchain with clang; nurl.bat is what a
+      # USER runs to build a program, and it was never under test here.
+      # That is how it came to ship looking only for a system clang while
+      # the archive bundled a zig it never used — CI installs LLVM, so the
+      # clang path always worked. Fetch a zig and drive nurl.bat both
+      # ways, from a directory whose name contains a space (the normal
+      # install path is C:\Users\First Last\.nurl\).
+      - name: Fetch zig (to exercise the bundled-compiler path)
+        if: ${{ !inputs.update_goldens }}
+        shell: pwsh
+        run: |
+          $zigVer = "0.13.0"
+          $url = "https://ziglang.org/download/$zigVer/zig-windows-x86_64-$zigVer.zip"
+          Invoke-WebRequest $url -OutFile zig.zip
+          Expand-Archive zig.zip -DestinationPath vendor
+          Move-Item "vendor/zig-windows-x86_64-$zigVer" vendor/zig
+
+      - name: nurl.bat builds and runs a program (zig, then clang)
+        if: ${{ !inputs.update_goldens }}
+        shell: pwsh
+        run: |
+          $dir = "smoke dir"
+          New-Item -ItemType Directory -Path $dir -Force | Out-Null
+          # single-quoted here-string: NURL uses backticks for strings and
+          # PowerShell would otherwise eat them as escapes
+          $src = @'
+          $ `stdlib/core/io.nu`
+          @ main → i { ( nurl_print `ok` ) ^ 0 }
+          '@
+          ($src -split "`n" | ForEach-Object { $_.TrimStart() }) -join "`n" |
+            Set-Content -Path "$dir\s.nu" -Encoding utf8NoBOM
+          foreach ($mode in @("zig", "clang")) {
+            if ($mode -eq "zig") { $env:NURL_ZIG = "$PWD\vendor\zig\zig.exe" }
+            else                 { $env:NURL_ZIG = "$PWD\does-not-exist.exe" }
+            Remove-Item "$dir\s.exe" -ErrorAction SilentlyContinue
+            & cmd /c "call nurl.bat `"$dir\s.nu`" `"$dir\s`""
+            if ($LASTEXITCODE -ne 0) { throw "$mode : nurl.bat failed" }
+            $out = & "$dir\s.exe"
+            if ($LASTEXITCODE -ne 0) { throw "$mode : the built program failed" }
+            if ($out -ne "ok") { throw "$mode : unexpected output: $out" }
+            Write-Host "$mode OK"
+          }
+
       # ── Golden regeneration mode (workflow_dispatch only) ──────────
       # The Windows goldens can only be produced on Windows; this runner
       # IS the canonical environment. Build without tests, then rewrite

--- a/nurl.bat
+++ b/nurl.bat
@@ -91,10 +91,32 @@ if not exist "%NURLC%" (
     )
 )
 
-REM ── Locate clang ─────────────────────────────────────────────
+REM ── Pick the compiler: bundled zig (preferred) or system clang ──
+REM The Windows archive ships a zig at <prefix>\zig\zig.exe, exactly as
+REM the Linux one does, but this driver used to look only for clang — so
+REM a blank Windows box with no system LLVM could not build a program
+REM natively even though the compiler it needed was sitting in the
+REM install. Prefer the bundled zig, fall back to clang.
+REM
+REM CC_OPT_FIX: `zig cc` drops the -O level for LLVM IR inputs. It
+REM forwards it for C (`zig cc -O2 -c x.c` reaches cc1 as -O2) but for a
+REM `.ll` it passes nothing and cc1 defaults to -O0 — and NURL compiles
+REM to `.ll`. `-Xclang <level>` goes straight to cc1 and survives. See
+REM the same handling in nurl.sh.
 set "CLANG=clang"
 if exist "C:\Program Files\LLVM\bin\clang.exe" (
     set "CLANG=C:\Program Files\LLVM\bin\clang.exe"
+)
+set "ZIG_BIN=%NURL_ZIG%"
+if "%ZIG_BIN%"=="" set "ZIG_BIN=%SCRIPTDIR%zig\zig.exe"
+set "USING_ZIG=0"
+REM The quotes live INSIDE the variable: an install path with a space
+REM (C:\Users\First Last\.nurl\) otherwise splits the command.
+if exist "%ZIG_BIN%" (
+    set "USING_ZIG=1"
+    set "CC="%ZIG_BIN%" cc"
+) else (
+    set "CC="%CLANG%""
 )
 
 REM ── Locate runtime.o ─────────────────────────────────────────
@@ -136,6 +158,10 @@ if defined CLI_OPT (
     set "NURL_OPT=-O2"
 )
 
+REM zig needs the level restated for cc1 (see the CC selection above).
+set "CC_OPT_FIX="
+if "%USING_ZIG%"=="1" set "CC_OPT_FIX=-Xclang %NURL_OPT%"
+
 REM Debug flag passthrough. With no `!dbg` metadata in the IR, `-g` yields
 REM only crude line info from the inlined .ll filename; still useful in
 REM debuggers for frame isolation and symbol demangling.
@@ -145,9 +171,9 @@ if "%DEBUG_INFO%"=="1" set "DEBUG_FLAG=-g"
 REM --emit-asm: stop after clang -S, skip linking.
 if "%EMIT_ASM%"=="1" (
     echo [2/2] %LLFILE% → %SFILE%  ^(%NURL_OPT% %DEBUG_FLAG% -S^)
-    "%CLANG%" %NURL_OPT% %DEBUG_FLAG% -S "%LLFILE%" -o "%SFILE%"
+    %CC% %NURL_OPT% %CC_OPT_FIX% %DEBUG_FLAG% -S "%LLFILE%" -o "%SFILE%"
     if !errorlevel! neq 0 (
-        echo ERROR: clang -S failed
+        echo ERROR: -S step failed
         exit /b 1
     )
     echo.
@@ -225,7 +251,7 @@ REM so every program linked against runtime.o needs winhttp.lib even if it
 REM doesn't import stdlib/ext/http.nu — unreferenced functions still end up
 REM in runtime.o and their WinHttp* calls must resolve at link time.
 echo [2/2] %LLFILE% → %EXEFILE%  (%NURL_OPT% %DEBUG_FLAG% %EXTRA_LIBS%)
-"%CLANG%" %NURL_OPT% %DEBUG_FLAG% "%LLFILE%" "%RUNTIME%" %EXTRA_OBJS% -o "%EXEFILE%" %EXTRA_LIBS% -lwinhttp
+%CC% %NURL_OPT% %CC_OPT_FIX% %DEBUG_FLAG% "%LLFILE%" "%RUNTIME%" %EXTRA_OBJS% -o "%EXEFILE%" %EXTRA_LIBS% -lwinhttp
 if !errorlevel! neq 0 (
     echo ERROR: clang linking failed
     exit /b 1

--- a/nurl.sh
+++ b/nurl.sh
@@ -211,7 +211,22 @@ resolve_clang() {
 # whitespace-safe regardless of the prefix path.
 ZIG_BIN="${NURL_ZIG:-$SCRIPT_DIR/zig/zig}"
 OPAQUE_FLAGS=""
+# `zig cc` drops -O for LLVM IR inputs. Not for C — `zig cc -O2 -c x.c`
+# forwards -O2 to cc1 as expected — but for a `.ll` it passes NOTHING,
+# and cc1's default is -O0. NURL compiles to `.ll` and hands it to the
+# compiler, so every program built with the bundled zig came out
+# UNOPTIMISED: no vectorisation, no inlining of vec_get / nurl_peek.
+# Measured on a real package's host code (image decode + bicubic
+# resample): 179 ms a frame against 68 with the level restored, and 33
+# for a clang build with LTO. Since zig is bundled precisely for boxes
+# with no clang, that was the DEFAULT path for anyone installing the
+# toolchain.
+#
+# `-Xclang <level>` goes straight to cc1 and survives, so it is appended
+# after the driver's own -O. Harmless for C inputs (same level twice).
+USING_ZIG=0
 if [ -x "$ZIG_BIN" ]; then
+    USING_ZIG=1
     cc_run() { "$ZIG_BIN" cc "$@"; }
 else
     resolve_clang
@@ -490,7 +505,10 @@ echo "[2/2] $LLFILE → $OUTBASE  ($OPT${LTO_FLAG:+ $LTO_FLAG}${DEBUG_FLAGS:+ $D
 # because the build machine had them. Positional: it must precede the
 # `-l` libraries to govern them.
 # shellcheck disable=SC2086
-cc_run $OPT $LTO_FLAG -Wl,--as-needed $OPAQUE_FLAGS $DEBUG_FLAGS $COVERAGE_FLAGS $SAN_LINK_FLAGS "$LLFILE" "$RUNTIME_TO_LINK" $EXTRA_OBJS -o "$OUTBASE" -lm -lpthread $DL_LIB $EXTRA_LIBS
+ZIG_OPT_FIX=""
+[ "$USING_ZIG" = "1" ] && ZIG_OPT_FIX="-Xclang $OPT"
+# shellcheck disable=SC2086
+cc_run $OPT $ZIG_OPT_FIX $LTO_FLAG -Wl,--as-needed $OPAQUE_FLAGS $DEBUG_FLAGS $COVERAGE_FLAGS $SAN_LINK_FLAGS "$LLFILE" "$RUNTIME_TO_LINK" $EXTRA_OBJS -o "$OUTBASE" -lm -lpthread $DL_LIB $EXTRA_LIBS
 
 echo ""
 echo "Done: $OUTBASE"


### PR DESCRIPTION
`zig cc` drops the optimisation level for LLVM IR inputs. Not for C —
`zig cc -O2 -c x.c` forwards `-O2` to cc1 exactly as expected — but for
a `.ll` it passes **nothing**, and cc1's default is `-O0`:

```
zig cc -### -O2 -c x.c   → cc1 gets "-O2"
zig cc -### -O2 -c x.ll  → cc1 gets no -O at all
```

NURL compiles to `.ll` and hands that to the compiler. So **every
program built with the bundled zig came out unoptimised** — no
vectorisation, no inlining of `vec_get` / `nurl_peek` / `__px_idx`.

And zig is bundled *precisely for boxes that have no clang*, which makes
this the default path for anyone who installs the toolchain rather than
building it from source.

## Measured

A real package's host-side work (PNG decode + bicubic resample), per
frame:

| | prep |
| --- | --- |
| bundled zig, as shipped | 179 ms |
| bundled zig, **this fix** | **63 ms** |
| system clang + LTO | 33 ms |

In the same hot float loop: 18 SIMD instructions before, 53 after —
matching clang exactly.

## The fix

`-Xclang <level>` goes straight to cc1 and survives, so it is appended
after the driver's own `-O` when zig is the compiler. No change on the
clang path (`USING_ZIG` stays 0), and `nurl.bat` is unaffected — Windows
uses clang directly.

## How it was found, since the first two answers were wrong

The installed `lingbot-map` ran 2.2× slower than the same source built
in the repo. I first blamed the shipped `runtime.o`, then LTO — **both
wrong**, because the binaries I was comparing differed in more than one
variable at a time. Swapping exactly one (same IR, same runtime, same
linker, only the compiler) put it on zig's codegen, and `-###` showed
the missing `-O`.

Worth stating because it is the reusable part: a 5× difference between
"the same thing built two ways" is worth isolating one variable at a
time before theorising about the mechanism.

## Windows

The same fix, plus something it exposed: **Windows ships a zig in the
archive and `nurl.bat` never used it.** The release job downloads and
bundles zig exactly as the Linux jobs do, but the driver looked only for
a system clang — so a blank Windows box could not build a program
natively even though the compiler it needed was in the install.

`nurl.bat` now prefers the bundled zig and falls back to clang, matching
`nurl.sh`, and carries the same `-Xclang <level>` fix. The two have to
land together: the moment zig becomes the default compiler on Windows,
the `.ll` `-O0` bug applies there too.

The compiler path is quoted *inside* the variable
(`set "CC="%ZIG%" cc"`) because the normal install path is
`C:\Users\First Last\.nurl\`.

**Nothing on Windows exercised `nurl.bat`** — CI installs LLVM, so
`build.bat`'s clang path always worked and the driver was never under
test. The release job now builds and *runs* a program with the assembled
prefix, from a directory whose name contains a space, so a quoting
regression fails in CI rather than on a user's machine. The Linux legs
have had that smoke test all along.

**Not verified on Windows** — I have no Windows machine here. The batch
logic is reviewed and the NURL source the smoke step writes is checked by
compiling and running it on Linux, but the first real run of both is CI
on this PR.

## Still open

The residual 63 vs 33 ms is zig's LTO backend running at a lower level.
It rejects `-Wl,--lto-O2`, so that one needs a different lever and is
not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG
