### PR TITLE
tests: refresh the stale Windows float_extra golden, and catch the class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,16 @@ jobs:
         # __free_str_vec class). Assert every stdlib @-function name is
         # globally unique.
         run: ./tools/check_stdlib_symbols.sh
+      - name: Windows goldens not stale (they are checked on main, not per-PR)
+        # outputs-windows/ is a parallel corpus and windows-tests.yml runs
+        # on pushes to main, so a PR that adds assertions updates outputs/
+        # and the Windows copy silently keeps the old expectation — the
+        # break lands on main, on whoever pushes next. float_extra went
+        # seven lines stale in July and reported FAIL weeks later. The
+        # shape (Windows missing lines, adding none) is detectable here,
+        # without a Windows machine.
+        run: ./tools/check_windows_goldens.sh
+
       - name: no packages/… self-imports (breaks registry installs)
         # In this repo every build runs from the root, so a
         # `$ \`packages/<name>/src/x.nu\`` import resolves and every test

--- a/compiler/tests/outputs-windows/float_extra.txt
+++ b/compiler/tests/outputs-windows/float_extra.txt
@@ -6,6 +6,13 @@ trunc(2.7)     ok
 trunc(-2.7)    ok
 cbrt(8)        ok
 cbrt(-27)      ok
+erf(0)         ok
+erf(1)         ok
+erf(-1)        ok
+erfc(1)        ok
+1-erf(10)==0   ok
+erfc(10)>0     ok
+erfc(10) mag   ok
 hypot(3,4)     ok
 hypot(0,0)     ok
 log2(8)        ok

--- a/tools/check_windows_goldens.sh
+++ b/tools/check_windows_goldens.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/check_windows_goldens.sh — catch a Windows golden that went
+#  stale, from Linux.
+#
+#  compiler/tests/outputs-windows/ is a parallel golden corpus, and
+#  windows-tests.yml runs on pushes to MAIN rather than per-PR (the
+#  Windows runner is the slowest leg). So a PR that adds assertions to a
+#  test updates outputs/ and the Windows copy silently keeps the old
+#  expectation — the break surfaces one push later, on main, to whoever
+#  pushed next.
+#
+#  That is exactly what happened to float_extra: erf/erfc added seven
+#  lines in July, the Windows golden was written in June, and Windows CI
+#  reported `PASS 537 · FAIL 1` weeks afterwards.
+#
+#  The shape is recognisable without a Windows machine: the Windows
+#  golden is missing lines the Linux one has, and adds none of its own.
+#  A genuine platform difference shows up as Windows-ONLY lines, or as a
+#  mix — those are left alone (24 of them today, all legitimate).
+#
+#  If a test ever legitimately produces FEWER lines on Windows, add its
+#  basename to PURE_DELETION_OK below with a note saying why.
+#
+#  Run from the repo root:  ./tools/check_windows_goldens.sh
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+
+LINUX_DIR=compiler/tests/outputs
+WIN_DIR=compiler/tests/outputs-windows
+
+# Basenames whose Windows golden is legitimately a subset of the Linux one.
+PURE_DELETION_OK=""
+
+fail=0
+checked=0
+for f in "$LINUX_DIR"/*.txt; do
+    b="$(basename "$f")"
+    w="$WIN_DIR/$b"
+    # No Windows golden at all = the test is skipped there; not our business.
+    [ -f "$w" ] || continue
+    checked=$((checked + 1))
+    cmp -s "$f" "$w" && continue
+    d="$(diff "$f" "$w")"
+    # Windows-only lines present → a real platform difference, leave it.
+    printf '%s\n' "$d" | grep -q '^>' && continue
+    case " $PURE_DELETION_OK " in *" $b "*) continue ;; esac
+    if [ "$fail" -eq 0 ]; then
+        echo "Windows goldens missing lines the Linux goldens have:" >&2
+        echo "(the Windows copy was not updated when the test grew)" >&2
+        echo >&2
+    fi
+    echo "  $WIN_DIR/$b" >&2
+    printf '%s\n' "$d" | sed 's/^/      /' >&2
+    fail=1
+done
+
+if [ "$fail" -ne 0 ]; then
+    cat >&2 <<'EOF'
+
+Fix: if the test's output is platform-independent (pass/fail labels, no
+raw floats or paths), copy the Linux golden over the Windows one and say
+so in the commit. If it is not, regenerate on a real runner —
+windows-tests.yml has a workflow_dispatch input `update_goldens` that
+rewrites the corpus and uploads it as an artifact to review and commit.
+EOF
+    exit 1
+fi
+
+echo "windows goldens OK ($checked pairs; none missing lines)"


### PR DESCRIPTION
## The failure

Windows CI on main reported `PASS 537 · FAIL 1`, the one failure being `float_extra`.

`diff outputs/float_extra.txt outputs-windows/float_extra.txt` is exactly `9,15d8` — the Windows golden is missing seven lines and differs in nothing else:

```
erf(0)         ok
erf(1)         ok
erf(-1)        ok
erfc(1)        ok
1-erf(10)==0   ok
erfc(10)>0     ok
erfc(10) mag   ok
```

The Windows golden was written in `7cf788f` (June, "Fix: Windows build"). erf/erfc arrived in `c0e796f` (July) and updated only the Linux golden.

## Why copying the Linux golden is correct here

Those seven lines are platform-independent by construction:

- `float_erf` / `float_erfc` are libm FFI (`stdlib/std/float.nu:102-104`), and both are in the UCRT.
- `float_extra.nu` prints `ok` / `FAIL` labels through `ck`, comparing with `feq` = `< ( float_abs - a b ) 0.000000001`. A tolerance, not raw bits — so no libm-implementation difference can change the printed text.

The authoritative confirmation is the `windows-tests.yml` run after merge.

## Why it surfaced weeks late, and the guard

`outputs-windows/` is a parallel corpus, and `windows-tests.yml` runs on pushes to **main**, not per-PR (the Windows runner is the slowest leg). So the author who grows a test never sees the stale copy — the next person to push does.

`tools/check_windows_goldens.sh` detects that shape from Linux, without a Windows machine: the Windows golden is missing lines the Linux one has and adds none of its own. A genuine platform difference shows up as Windows-only or mixed lines and is skipped. There is a `PURE_DELETION_OK` allowlist for a test that ever legitimately prints less on Windows.

Swept all 523 pairs:

| | count |
|---|---|
| identical | 498 |
| legitimate platform differences | 24 |
| **stale (Windows missing lines)** | **1 — float_extra** |
| no Windows golden (skipped there) | 36 |

Verified the guard both ways: it passes on the fixed tree, and on the pre-fix tree it prints the file plus the seven missing lines and exits 1. Wired into `ci.yml` beside the existing import guard, so the next one fails on the PR that causes it instead of on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG