### PR TITLE
windows: make the bundled zig able to link at all (two ABIs, two runtimes)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,17 +286,18 @@ jobs:
         # the produced exes carry no zlib1.dll / zstd.dll dependency.
         run: vcpkg install zlib:x64-windows-static zstd:x64-windows-static
 
-      - name: Build toolchain (nurlc + nurlpkg)
-        shell: cmd
-        run: |
-          call build.bat --no-tests || exit /b 1
-          call tools\nurlpkg\build.bat || exit /b 1
-
       # Bundle a self-contained zig, mirroring the Linux jobs. Windows
       # installs otherwise depend on a system LLVM for native builds, and
       # the wasmbuilder package needs zig's wasi-libc + wasm-ld for local
       # wasm32-wasi builds — bundling makes `nurlpkg install wasmbuilder`
       # work on a blank machine with no extra downloads.
+      #
+      # Fetched BEFORE the build: build.bat emits the MinGW-ABI
+      # stdlib\runtime.mingw.o only when it can see a zig, and that
+      # object is what the bundled zig links user programs against.
+      # Without it the archive ships a zig that cannot link anything,
+      # and the smoke test below would not catch it — this runner has
+      # LLVM installed, so nurl.bat would quietly fall back to clang.
       - name: Fetch bundled zig backend
         shell: pwsh
         run: |
@@ -306,6 +307,12 @@ jobs:
           Expand-Archive zig.zip -DestinationPath vendor
           Move-Item "vendor/zig-windows-x86_64-$zigVer" vendor/zig
           & vendor/zig/zig.exe version
+
+      - name: Build toolchain (nurlc + nurlpkg)
+        shell: cmd
+        run: |
+          call build.bat --no-tests || exit /b 1
+          call tools\nurlpkg\build.bat || exit /b 1
 
       - name: Assemble relocatable prefix
         shell: cmd
@@ -338,11 +345,28 @@ jobs:
           '@
           ($src -split "`n" | ForEach-Object { $_.TrimStart() }) -join "`n" |
             Set-Content -Path "$dir\s.nu" -Encoding utf8NoBOM
-          & cmd /c "call dist\nurl\bin\nurl.bat `"$dir\s.nu`" `"$dir\s`""
-          if ($LASTEXITCODE -ne 0) { throw "nurl.bat failed" }
-          $out = & "$dir\s.exe"
-          if ($LASTEXITCODE -ne 0) { throw "the built program failed" }
-          if ($out -ne "ok") { throw "unexpected output: $out" }
+          # The archive must carry the MinGW-ABI runtime, or the zig it
+          # bundles cannot link a thing. Assert it directly: this runner
+          # has LLVM, so nurl.bat would otherwise fall back to clang and
+          # the smoke test would pass while shipping a broken zig path.
+          if (-not (Test-Path "dist\nurl\stdlib\runtime.mingw.o")) {
+            throw "archive has no stdlib\runtime.mingw.o — the bundled zig cannot link"
+          }
+          # Build BOTH ways from the assembled prefix: bundled zig (what a
+          # machine without LLVM gets) and clang (what one with it gets).
+          # They link different runtime objects, so a break in one says
+          # nothing about the other.
+          foreach ($mode in @("zig", "clang")) {
+            if ($mode -eq "zig") { $env:NURL_ZIG = "$PWD\dist\nurl\zig\zig.exe" }
+            else                 { $env:NURL_ZIG = "$PWD\does-not-exist.exe" }
+            Remove-Item "$dir\s.exe" -ErrorAction SilentlyContinue
+            & cmd /c "call dist\nurl\bin\nurl.bat `"$dir\s.nu`" `"$dir\s`""
+            if ($LASTEXITCODE -ne 0) { throw "$mode : nurl.bat failed" }
+            $out = & "$dir\s.exe"
+            if ($LASTEXITCODE -ne 0) { throw "$mode : the built program failed" }
+            if ($out -ne "ok") { throw "$mode : unexpected output: $out" }
+            Write-Host "$mode OK"
+          }
 
       - name: Package
         shell: pwsh

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -37,14 +37,12 @@ jobs:
         run: choco install llvm --no-progress -y
         shell: cmd
 
-      - name: build.bat (bootstrap fixed point + Windows golden corpus)
-        # pwsh 7 is preinstalled on windows-latest, so build.bat runs
-        # run_tests.ps1; a missing pwsh now exits non-zero by design.
-        if: ${{ !inputs.update_goldens }}
-        run: call build.bat
-        shell: cmd
-
       # ── The DRIVER, which nothing else on Windows exercises ────────
+      # Fetched BEFORE build.bat on purpose: build.bat only emits the
+      # MinGW-ABI stdlib\runtime.mingw.o when it can see a zig, and
+      # without that object nurl.bat falls back to clang and the whole
+      # bundled-zig path silently goes untested — which is how it
+      # reached a release with three undefined CRT symbols in it.
       # build.bat compiles the toolchain with clang; nurl.bat is what a
       # USER runs to build a program, and it was never under test here.
       # That is how it came to ship looking only for a system clang while
@@ -61,6 +59,13 @@ jobs:
           Invoke-WebRequest $url -OutFile zig.zip
           Expand-Archive zig.zip -DestinationPath vendor
           Move-Item "vendor/zig-windows-x86_64-$zigVer" vendor/zig
+
+      - name: build.bat (bootstrap fixed point + Windows golden corpus)
+        # pwsh 7 is preinstalled on windows-latest, so build.bat runs
+        # run_tests.ps1; a missing pwsh now exits non-zero by design.
+        if: ${{ !inputs.update_goldens }}
+        run: call build.bat
+        shell: cmd
 
       - name: nurl.bat builds and runs a program (zig, then clang)
         if: ${{ !inputs.update_goldens }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Windows: the bundled zig could not link a program at all.** The
+  archive ships a zig so a machine with no Visual Studio can still build,
+  and 0.25.0 taught `nurl.bat` to prefer it — but nothing had ever driven
+  that path end to end. It failed three ways, each hidden behind the one
+  before it. `zig cc` targets `x86_64-windows-gnu`, so:
+  - `bcrypt` and `ws2_32` were requested only by `#pragma comment(lib,
+    ...)` directives inside `runtime.o`, which is how the MSVC toolchain
+    finds an import lib without anyone naming it. Under MinGW those
+    directives are mangled to `libbcrypt.a`, a name nothing in this
+    toolchain produces (zig synthesises `bcrypt.lib`), so the link died
+    on a file it could never open. The pragmas are now MSVC-only, as
+    `runtime_core.c` has always had them, and `nurl.bat` names the import
+    libs the way `nurlapi`'s mingw-w64 cross link always has.
+  - Underneath that, `runtime.o` is clang-built and therefore MSVC-ABI:
+    it references `_setjmp`, `__chkstk` and `_fltused`, none of which
+    MinGW's CRT provides. The two ABIs cannot share one object, so
+    `build.bat` now also emits `stdlib\runtime.mingw.o` with zig when a
+    zig is present, and `nurl.bat` links whichever object matches the
+    compiler it chose. Programs built through the bundled zig cannot use
+    the canvas FFI or the zstd FFI (both MSVC-only artifacts); the driver
+    now says so instead of leaving it to the linker.
+  - The release workflow fetched its zig *after* running `build.bat`, so
+    the archive would have shipped without the MinGW runtime — and its
+    smoke test would not have caught it, because the release runner has
+    LLVM and the driver falls back to clang. Both workflows now fetch zig
+    first, and the release smoke test asserts the object is in the
+    archive and builds a program both ways.
+- **A stale Windows golden.** `float_extra`'s expected output was written
+  in June and never grew the seven `erf`/`erfc` lines 0.25.0 added, so
+  Windows CI went red one push later. `tools/check_windows_goldens.sh`
+  now catches that shape from Linux — a Windows golden missing lines its
+  Linux counterpart has — since the Windows leg only runs on `main`.
+
 ## [0.25.0] — 2026-07-26
 
 The release that makes `packages/torchpt` and everything above it

--- a/build.bat
+++ b/build.bat
@@ -146,6 +146,36 @@ set "LABEL=runtime"
 "%CLANG%" -c stdlib/runtime.c !ZLIB_CFLAGS! -o stdlib/runtime.o >>"%LOG%" 2>&1
 if errorlevel 1 goto :failed
 
+REM ── A second runtime, for the MinGW ABI ──────────────────────
+REM The object above is clang-built and therefore MSVC-ABI: it references
+REM _setjmp, __chkstk and _fltused, none of which MinGW's CRT provides.
+REM `zig cc` targets x86_64-windows-gnu, so a program linked by the
+REM bundled zig against it dies on exactly those three symbols. The two
+REM ABIs cannot share one object, so build a second one with zig when a
+REM zig is around; nurl.bat picks whichever matches the compiler it uses,
+REM and install-toolchain ships the whole stdlib tree, so it travels.
+REM
+REM No !ZLIB_CFLAGS! here: it is an MSVC vcpkg include path, and there is
+REM nothing left in the runtime for it to feed — gzip/deflate became pure
+REM NURL in §8 P6, so -DNURL_HAVE_ZLIB no longer selects anything. The
+REM object references neither zlib nor zstd, which is what lets nurl.bat
+REM drop stdlib\winlib from a MinGW link without leaving a dangling
+REM symbol behind.
+set "ZIG_MINGW="
+if defined NURL_BUNDLE_ZIG if exist "%NURL_BUNDLE_ZIG%\zig.exe" set "ZIG_MINGW=%NURL_BUNDLE_ZIG%\zig.exe"
+if not defined ZIG_MINGW if defined NURL_ZIG if exist "%NURL_ZIG%" set "ZIG_MINGW=%NURL_ZIG%"
+if not defined ZIG_MINGW if exist "%SCRIPT_DIR%\vendor\zig\zig.exe" set "ZIG_MINGW=%SCRIPT_DIR%\vendor\zig\zig.exe"
+if defined ZIG_MINGW (
+    >>"%LOG%" echo [%LABEL%] "!ZIG_MINGW!" cc -target x86_64-windows-gnu -O2 -c stdlib/runtime.c -o stdlib\runtime.mingw.o
+    "!ZIG_MINGW!" cc -target x86_64-windows-gnu -O2 -c stdlib/runtime.c -o stdlib\runtime.mingw.o >>"%LOG%" 2>&1
+    if errorlevel 1 goto :failed
+    echo [info] MinGW runtime: stdlib\runtime.mingw.o ^(via "!ZIG_MINGW!"^)
+) else (
+    if exist stdlib\runtime.mingw.o del /q stdlib\runtime.mingw.o
+    >>"%LOG%" echo [info] no zig found - stdlib\runtime.mingw.o not built
+    echo [info] no zig found - programs will need clang to link
+)
+
 REM Persist the accumulated link fragment for the FFI consumers.
 if defined WINLIBS (
     > stdlib\runtime.winlibs echo !WINLIBS!

--- a/nurl.bat
+++ b/nurl.bat
@@ -119,11 +119,38 @@ if exist "%ZIG_BIN%" (
     set "CC="%CLANG%""
 )
 
-REM ── Locate runtime.o ─────────────────────────────────────────
+REM ── Locate the runtime object matching that compiler's ABI ───
+REM Windows has two, and they are not interchangeable. runtime.o is
+REM clang-built, so MSVC-ABI: it references _setjmp, __chkstk and
+REM _fltused, none of which MinGW's CRT provides. The zig above targets
+REM x86_64-windows-gnu, so linking it against runtime.o fails on exactly
+REM those three. build.bat builds stdlib\runtime.mingw.o with zig for
+REM this path; pick whichever object matches the compiler chosen above.
 set "RUNTIME=%SCRIPTDIR%stdlib\runtime.o"
+set "MINGW_ABI=0"
+if "%USING_ZIG%"=="1" (
+    if exist "%SCRIPTDIR%stdlib\runtime.mingw.o" (
+        set "RUNTIME=%SCRIPTDIR%stdlib\runtime.mingw.o"
+        set "MINGW_ABI=1"
+    ) else (
+        REM Built on a box with no zig, so no MinGW runtime was produced.
+        REM clang's ABI matches the object we do have — use it rather than
+        REM emitting a link that cannot possibly resolve.
+        "%CLANG%" --version >nul 2>&1
+        if errorlevel 1 (
+            echo ERROR: the bundled zig needs stdlib\runtime.mingw.o, which this
+            echo        toolchain does not carry, and no clang was found either.
+            echo        Rebuild with build.bat on a box that has zig, or install
+            echo        LLVM ^(https://releases.llvm.org^) to link with clang.
+            exit /b 1
+        )
+        set "USING_ZIG=0"
+        set "CC="%CLANG%""
+    )
+)
 if not exist "%RUNTIME%" (
-    echo ERROR: stdlib\runtime.o not found at %RUNTIME%
-    echo        Run: clang -c stdlib\runtime.c -o stdlib\runtime.o
+    echo ERROR: !RUNTIME! not found
+    echo        Run build.bat to build the NURL stdlib first.
     exit /b 1
 )
 
@@ -189,6 +216,17 @@ set "SDL2_LIBDIR="
 set "SDL2_BINDIR="
 findstr /R /C:"@canvas_open\>" /C:"@canvas_present\>" /C:"@canvas_sleep\>" /C:"@canvas_should_close\>" /C:"@canvas_close\>" /C:"@canvas_mouse_x\>" /C:"@canvas_mouse_y\>" /C:"@canvas_mouse_btn\>" "%LLFILE%" >nul 2>&1
 if not errorlevel 1 (
+    REM canvas.o is clang-built and SDL2.lib is an MSVC import lib, so
+    REM neither can go into a MinGW image. Say so here rather than let the
+    REM linker report it as a pile of undefined symbols.
+    if "!MINGW_ABI!"=="1" (
+        echo ERROR: this program uses the canvas FFI, which needs canvas.o and
+        echo        SDL2 — both MSVC-ABI, while the bundled zig links MinGW.
+        echo        Build it with clang instead: install LLVM and re-run with
+        echo        NURL_ZIG set to a path that does not exist, e.g.
+        echo            set NURL_ZIG=none
+        exit /b 1
+    )
     set "CANVAS_O=%SCRIPTDIR%stdlib\canvas.o"
     if not exist "!CANVAS_O!" (
         echo ERROR: program uses canvas FFI but !CANVAS_O! is missing.
@@ -229,9 +267,10 @@ if not errorlevel 1 (
     )
 )
 
-REM Auto-link the FFI libs build.bat detected (issue #229). runtime.o is built
-REM with -DNURL_HAVE_ZLIB, so it references zlib's deflate/inflate and EVERY
-REM program needs zlib (zstd too for compress.nu users) at link time.
+REM Auto-link the FFI libs build.bat detected (issue #229). These are for
+REM programs whose own IR declares the zstd FFI (stdlib\ext\compress.nu);
+REM the runtime itself no longer needs them, since gzip/deflate became
+REM pure NURL in §8 P6 and -DNURL_HAVE_ZLIB stopped meaning anything.
 REM   - A shipped toolchain carries the static libs in stdlib\winlib\ plus a
 REM     relocatable fragment (winlibs.reloc) whose $NURL_LIB$ placeholder is
 REM     resolved against THIS prefix — self-contained, no vcpkg on the box.
@@ -244,6 +283,14 @@ if exist "%SCRIPTDIR%stdlib\winlib\winlibs.reloc" (
 ) else if exist "%SCRIPTDIR%stdlib\runtime.winlibs" (
     set /p WINLIBS=<"%SCRIPTDIR%stdlib\runtime.winlibs"
 )
+REM Those are vcpkg's MSVC static libs, which cannot go into a MinGW
+REM image. Nothing in the runtime references them (gzip/deflate have been
+REM pure NURL since §8 P6 — stdlib\std\deflate.nu), so dropping them
+REM leaves no dangling symbol here. What it does cost is a program that
+REM declares the zstd FFI itself (stdlib\ext\compress.nu's `& `zstd``):
+REM that one needs the import lib and so needs clang. It fails at link
+REM naming ZSTD_compress, which is at least a symbol worth searching for.
+if "!MINGW_ABI!"=="1" set "WINLIBS="
 if defined WINLIBS set "EXTRA_LIBS=!EXTRA_LIBS! !WINLIBS!"
 
 REM System import libs. The whole of runtime.o is linked in, so every

--- a/nurl.bat
+++ b/nurl.bat
@@ -246,12 +246,22 @@ if exist "%SCRIPTDIR%stdlib\winlib\winlibs.reloc" (
 )
 if defined WINLIBS set "EXTRA_LIBS=!EXTRA_LIBS! !WINLIBS!"
 
-REM The runtime's HTTP client uses WinHTTP on Windows (stdlib/runtime.c §14),
-REM so every program linked against runtime.o needs winhttp.lib even if it
-REM doesn't import stdlib/ext/http.nu — unreferenced functions still end up
-REM in runtime.o and their WinHttp* calls must resolve at link time.
+REM System import libs. The whole of runtime.o is linked in, so every
+REM program needs the libraries behind every OS bridge it contains, even
+REM one that imports none of them:
+REM   winhttp  — the HTTP client (stdlib/runtime.c §14)
+REM   ws2_32   — the TCP/socket layer
+REM   bcrypt, advapi32 — the OS-entropy bridge (BCryptGenRandom)
+REM Under clang's MSVC target the last three arrive on their own, via the
+REM `#pragma comment(lib, ...)` directives in runtime_ffi.c. Under MinGW —
+REM which is what `zig cc` targets — those directives cannot be satisfied
+REM (they name bcrypt.lib, and lld-link goes looking for libbcrypt.a), so
+REM they are compiled out there and the libs must be named here instead.
+REM Naming them is harmless for clang: they are all in the Windows SDK.
+REM This is the same set, for the same reason, as the mingw-w64 cross link
+REM in nurlapi/main.nu.
 echo [2/2] %LLFILE% → %EXEFILE%  (%NURL_OPT% %DEBUG_FLAG% %EXTRA_LIBS%)
-%CC% %NURL_OPT% %CC_OPT_FIX% %DEBUG_FLAG% "%LLFILE%" "%RUNTIME%" %EXTRA_OBJS% -o "%EXEFILE%" %EXTRA_LIBS% -lwinhttp
+%CC% %NURL_OPT% %CC_OPT_FIX% %DEBUG_FLAG% "%LLFILE%" "%RUNTIME%" %EXTRA_OBJS% -o "%EXEFILE%" %EXTRA_LIBS% -lwinhttp -lws2_32 -lbcrypt -ladvapi32
 if !errorlevel! neq 0 (
     echo ERROR: clang linking failed
     exit /b 1

--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -590,7 +590,18 @@ void nurl_proc_spawn_free(long long h) {
 
 #ifdef _WIN32
 #  include <bcrypt.h>
-#  pragma comment(lib, "bcrypt.lib")
+/* MSVC-only. The pragma emits a /DEFAULTLIB:bcrypt.lib directive into this
+ * object's .drectve section, which is how the MSVC toolchain finds the
+ * import lib without anyone naming it on the link line. Under MinGW
+ * (`zig cc`, x86_64-w64-mingw32) that directive still reaches lld-link,
+ * which mangles the name the MinGW way and tries to open libbcrypt.a — a
+ * file no MinGW toolchain here produces (zig synthesises bcrypt.lib), so
+ * the link dies on a file it can never find. MinGW builds name the import
+ * libs on the link line instead: nurl.bat and nurlapi/main.nu both do.
+ * runtime_core.c guards its copy of this pragma the same way. */
+#  ifndef __MINGW32__
+#    pragma comment(lib, "bcrypt.lib")
+#  endif
 #endif
 
 #if defined(__linux__)
@@ -697,7 +708,9 @@ long long nurl_rand_fill(unsigned char *buf, long long n) {
 
 #if !defined(__wasi__)
 #  ifdef _WIN32
-#    pragma comment(lib, "ws2_32.lib")
+#    ifndef __MINGW32__          /* MSVC-only; see the bcrypt pragma above */
+#      pragma comment(lib, "ws2_32.lib")
+#    endif
 #    include <ws2tcpip.h>          /* getaddrinfo — client-side connect */
 typedef SOCKET nurl_sockfd_t;
 #    define NURL_INVALID_SOCK INVALID_SOCKET


### PR DESCRIPTION
## What was broken

The Windows archive ships a zig so a machine with no Visual Studio can still build, and #645 taught `nurl.bat` to prefer it. Nothing had ever driven that path end to end. It failed three ways, each hidden behind the one before it.

**Verified green on a real windows-latest runner** ([run 30201649998](https://github.com/nurl-lang/nurl/actions/runs/30201649998)) — `zig OK` / `clang OK`, both modes building *and running* a program.

## Layer 1 — libs nobody was naming

```
lld-link: error: could not open 'libbcrypt.a'
lld-link: error: could not open 'libws2_32.a'
```

Neither is on the command line; the echoed `EXTRA_LIBS` is empty. They were requested by `#pragma comment(lib, ...)` in `runtime_ffi.c`, which emits `/DEFAULTLIB` directives into `runtime.o`'s `.drectve` — how MSVC finds an import lib without anyone naming it, and why the gap stayed invisible: clang targets MSVC, so they always arrived on their own.

`zig cc` targets `x86_64-windows-gnu`. lld-link mangles `bcrypt.lib` to `libbcrypt.a`, a name nothing here produces — zig synthesises `bcrypt.lib` (confirmed in `~/.cache/zig`). So the pragmas are now MSVC-only, exactly as `runtime_core.c` has always guarded its copy, and `nurl.bat` names the import libs the way `nurlapi/main.nu`'s mingw-w64 cross link always has: `-lwinhttp -lws2_32 -lbcrypt -ladvapi32`. zig only synthesises an import lib for a `-l` on its own driver line — directives inside an object bypass the driver entirely.

## Layer 2 — an object of the wrong ABI

With the files found, symbol resolution finally ran and reported what layer 1 had been hiding:

```
lld-link: error: undefined symbol: _setjmp   (runtime.o, nurl_recover)
lld-link: error: undefined symbol: __chkstk  (runtime.o)
lld-link: error: undefined symbol: _fltused  (runtime.o)
```

`runtime.o` is clang-built, so MSVC-ABI; MinGW's CRT provides none of those three. One object cannot serve both ABIs. So `build.bat` now also emits `stdlib\runtime.mingw.o` with zig when a zig is present, and `nurl.bat` links whichever matches the compiler it chose. `install-toolchain.bat` already `xcopy`s the whole stdlib tree, so it ships with no packaging change.

Two artifacts stay MSVC-only and are now refused with a reason instead of being left to the linker: `canvas.o` + `SDL2.lib`, and the vcpkg zstd import lib behind `compress.nu`'s zstd FFI. Dropping `stdlib\winlib` from a MinGW link leaves nothing dangling — gzip/deflate have been pure NURL since §8 P6, so the runtime references neither zlib nor zstd (checked: zero undefined zlib/zstd symbols). Two comments claiming `runtime.o` pulls in deflate/inflate via `-DNURL_HAVE_ZLIB` were stale by that same change and are corrected.

## Layer 3 — the workflows would have hidden the fix

Both workflows fetched zig **after** running `build.bat`, so no MinGW runtime would have been produced at all:

- `windows-tests.yml` would have fallen back to clang and passed.
- `release.yml` would have shipped an archive whose bundled zig cannot link — and its smoke test would have passed for the same reason, since that runner has LLVM.

Both now fetch zig first. The release smoke test additionally asserts `runtime.mingw.o` is in the assembled archive and builds a program **both** ways, so the no-LLVM path can no longer be silently absent from a release.

## Verification

| check | result |
|---|---|
| windows-tests on windows-latest | `zig OK`, `clang OK`, `BUILD SUCCESS & TESTS PASSED` |
| `[info] MinGW runtime:` in the build log | `stdlib\runtime.mingw.o (via vendor\zig\zig.exe)` |
| local cross-build (build.bat's compile + nurl.bat's link line) | `PE32+ executable (console) x86-64` |
| `_setjmp` / `__chkstk` / `_fltused` undefined refs in the MinGW object | 0 / 0 / 0 |
| undefined zlib/zstd symbols in that object | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG
