### PR TITLE
release: v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] — 2026-07-26
+
+A Windows repair release. 0.25.0 taught the driver to prefer the zig the
+archive has always bundled — the whole point of bundling it being that a
+machine with no Visual Studio can still build a program — and nothing had
+ever driven that path end to end. It could not link anything, in three
+different ways, each hidden behind the one before it. The release
+workflow would not have caught it either: that runner has LLVM, so the
+driver fell back to clang and passed.
+
+Nothing here changes the compiler or the language; every fix is in the
+Windows build and link path, plus the CI that was supposed to be watching
+it.
+
 ### Fixed
 
 - **Windows: the bundled zig could not link a program at all.** The
@@ -8785,7 +8799,9 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.24.1...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.25.1...HEAD
+[0.25.1]: https://github.com/nurl-lang/nurl/compare/v0.25.0...v0.25.1
+[0.25.0]: https://github.com/nurl-lang/nurl/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/nurl-lang/nurl/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/nurl-lang/nurl/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/nurl-lang/nurl/compare/v0.22.0...v0.23.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -102,6 +102,28 @@ works".)
   LLVM 15 emits opaque-pointer IR by default); on no compiler at all, exit
   with install guidance instead of a raw `clang: command not found`.
 
+`nurl.bat`'s selection follows the same shape, with one Windows-only
+complication: **the two compilers do not share an ABI.** A system clang
+targets MSVC; the bundled `zig cc` targets `x86_64-windows-gnu`. An object
+built for one cannot be linked by the other — a clang-built `runtime.o`
+references `_setjmp`, `__chkstk` and `_fltused`, and MinGW's CRT provides
+none of them. So `build.bat` produces **two** runtime objects, `runtime.o`
+(clang/MSVC) and `runtime.mingw.o` (zig/MinGW), and the driver links
+whichever matches the compiler it selected. Both ship in the archive;
+`install-toolchain.bat` copies the whole `stdlib` tree, so no packaging
+step needs to know about it.
+
+Consequences worth knowing:
+
+- The zig fetch must come **before** `build.bat` in any workflow that
+  builds a shippable prefix, or the MinGW object is silently absent and
+  everything still passes on a runner that has LLVM installed.
+- Two things stay MSVC-only, because their libraries are MSVC import
+  libs: the **canvas** FFI (`canvas.o` + `SDL2.lib`) and the **zstd** FFI
+  in `stdlib/ext/compress.nu`. A program using either needs clang; the
+  driver refuses with that message rather than leaving it to the linker.
+  gzip/deflate are unaffected — those are pure NURL.
+
 `nurl.sh` also links a feature library (`-lcurl` / `-lssl` / `-lsqlite3` /
 `-lpq` / `-lz` / `-lzstd`) **only when the emitted IR actually references
 that back-end's symbols** — so a feature-free program (the common tool)

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -26,6 +26,13 @@ verifies — not by intent:
 | macOS (x86_64 / ARM64) | **3** | expected to build from source with Homebrew LLVM; unverified — no CI job, no release artifact, and the installer rejects Darwin | build from source |
 | Alpine / musl | **3** | build from source only. The shipped Linux archives are glibc-linked and do **not** load under musl | build from source |
 
+On **Windows**, building a program works with no Visual Studio and no
+LLVM: the archive bundles a `zig cc`, and carries a MinGW-ABI runtime
+object (`stdlib\runtime.mingw.o`) for it alongside the MSVC one that a
+system clang uses — the two ABIs cannot share an object. Programs built
+through the bundled zig cannot use the canvas or zstd FFI (both need MSVC
+import libs); everything else, gzip included, is unaffected.
+
 The shipped `nurlc` / `nurlpkg` binaries link **libc only** (optional FFI
 libraries are pulled in `--as-needed`, so a program that uses none stays
 libc-only), and the `nurl.sh` wrapper is POSIX `sh` — no bash, no make, no


### PR DESCRIPTION
Cuts **v0.25.1** — a Windows repair release. Nothing in the compiler or the language changed since 0.25.0.

## Why it exists

0.25.0 taught `nurl.bat` to prefer the zig the archive has always bundled — the whole point of bundling it being that a machine with no Visual Studio can still build a program. #647 found that path could not link anything, in three ways stacked on top of each other:

1. `bcrypt` / `ws2_32` were requested only by `#pragma comment(lib, ...)` directives inside `runtime.o` — satisfiable under MSVC, impossible under MinGW.
2. Under that: `runtime.o` is clang-built and MSVC-ABI, so `_setjmp`, `__chkstk` and `_fltused` were undefined against MinGW's CRT. The toolchain now ships **two** runtime objects and links whichever matches the compiler.
3. Under *that*: both workflows fetched zig **after** `build.bat`, so the MinGW object would never have been built — and CI would have passed anyway, because those runners have LLVM and the driver falls back to clang. The release would have shipped a bundled zig that cannot link.

Verified on a real `windows-latest` runner before merge: `zig OK`, `clang OK`, full golden corpus green.

## In this PR

- `CHANGELOG.md`: `[Unreleased]` → `[0.25.1] — 2026-07-26`.
- `RELEASING.md`: the two-ABI rule next to `nurl.sh`'s compiler-selection section — why there are two runtime objects, why the zig fetch must precede `build.bat`, and the two FFIs that stay MSVC-only (canvas, zstd; gzip is pure NURL and unaffected).
- `docs/PLATFORMS.md`: what a Windows user actually needs, next to the "links libc only" note.
- Adds the `[0.25.0]` compare link, which the 0.25.0 release missed — `[Unreleased]` still pointed at `v0.24.1`.

## After merge

`git tag v0.25.1 && git push origin v0.25.1` builds and publishes the four archives. That tag is the first release where the Windows archive's bundled zig can actually build a program — and where `release.yml` proves it, since its smoke test now asserts `runtime.mingw.o` is in the archive and builds both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG