### PR TITLE
perf: drop a locked atomic from every allocation, and four quadratic scans from the borrow checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- **The runtime's allocation counters cost more than the allocations
+  they counted.** `nurl_alloc` / `nurl_zalloc` / `nurl_free` each bumped
+  a process-wide `unsigned long long` with a RELAXED atomic, on the
+  recorded grounds that it "costs nothing measurable next to the malloc
+  itself". On x86 a relaxed read-modify-write is still a `lock xadd` —
+  ~20 cycles plus a store-buffer stall — and every NURL program paid it
+  twice per allocate/free pair whether or not anything ever read the
+  counter. Each thread now counts into a heap block of its own with
+  plain arithmetic and readers sum the blocks, so the totals and their
+  monotonicity are unchanged (verified across threads) and the lock
+  prefix is gone. Measured on a pinned core: `bench/stdlib_hotpath.nu`'s
+  `sort_32_desc` −10.0 % cycles, `string_build_16` −9.7 %,
+  `vec_push_64` −3.9 %; parsing `bench/data.json` −8.1 % cycles / −9.4 %
+  wall clock.
+
+- **Four borrow-checker scans were quadratic in their own input.**
+  `bck_st_set`, `bck_join_state`, `bck_field` and `bck_explode` walked
+  their strings with `nurl_str_get`, which re-runs `strlen` on every
+  call — so each byte examined cost a pass over the whole string, in the
+  functions whose own comments described removing exactly that cost
+  elsewhere. They now read through hoisted `*u` pointers, like the
+  neighbouring `__bck_st_get_at`. A nurlc self-compile drops 3.69 G →
+  3.26 G instructions (−11.6 %) and 552 ms → 514 ms (−7.0 %); the borrow
+  checker was 42 % of the compiler's run time before the change. Gate:
+  all 1122 `.nu` files under `compiler/tests`, `stdlib`, `examples` and
+  `packages` compile to byte-identical IR *and* byte-identical
+  diagnostics.
+
+### Fixed
+
+- **`bench_auto` could report a regression for a build that got
+  faster.** Its iteration ramp multiplies by 4 and stops at the first
+  pass clearing 50 ms, so a body whose cost sits near that threshold
+  lands on opposite sides for two builds and the two results then come
+  from runs 4× apart in length. On `sort_32_desc` that reported +5 %
+  ns/op for a build that was 8 % faster on both cycle count and wall
+  clock. `bench_auto` now scales back onto the target window and
+  measures once more, so every reported number comes from a run of about
+  the same length.
 
 - **An array store at an unsigned index emitted invalid IR.** `= . p idx v`
   where `idx` had a sized unsigned type printed the NURL type name into
@@ -29,6 +70,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   all three languages, extends the checksum gate across optimisation
   levels as well as languages, and reports what the optimiser is worth
   per language.
+
+- `bench/perfstat.sh` — the same u64 set measured in retired
+  instructions and core cycles instead of wall clock, with a
+  save/compare mode for A/B-ing a compiler or runtime change. Wall clock
+  on this set drifts by several per cent between runs, which is enough
+  to invent a language difference that is not there: the first report
+  showed `histogram_bins` at 1.15× against C when the two binaries
+  retire the same instructions in the same cycles. Counters make a 1 %
+  change legible and a regression impossible to miss.
 
 ## [0.25.1] — 2026-07-26
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -179,6 +179,42 @@ project), and a multi-threaded allocator stress test cannot have the
 deterministic byte-exact checksum gate the rest of the set relies on, so
 there was nothing honest to compare.
 
+## Telling a speed-up from noise
+
+Wall clock on this hardware drifts by several per cent between runs of the
+same binary, and `run_micro.sh` reports a median of a handful of runs — so
+any ratio it prints inside roughly ±10 % is not evidence of anything. The
+first report of the u64 set showed `histogram_bins` at 1.15× against C;
+the two binaries retire the same instructions in the same cycles, and the
+generated inner loops are instruction-for-instruction the same.
+
+`bench/perfstat.sh` measures the same set with the CPU's own counters:
+
+```sh
+./bench/perfstat.sh --cpu 4 --save ref.tsv        # baseline
+#   … change the compiler or the runtime, rebuild …
+./bench/perfstat.sh --cpu 4 --against ref.tsv     # A/B
+```
+
+Retired instructions are essentially deterministic for these
+single-threaded kernels (±0.1 % run to run) and core cycles do not move
+with the frequency governor (±1 %, and ±2–3 % for the sub-10 ms rows,
+whose code layout shifts between links). A change that does not clear
+those bands has not been demonstrated. The comparison mode re-checks each
+binary's checksum as well, so a "speed-up" that stopped computing the
+right answer is reported rather than celebrated.
+
+Two further rules that this set has already had to learn:
+
+- **Pin the core and idle the machine.** A background build was enough to
+  inflate `binary_search` by 58 % and `bloom_filter` by 73 %.
+- **Compare like with like when a harness auto-calibrates.**
+  `std/bench.nu`'s `bench_auto` ramps its iteration count ×4 and stops at
+  the first pass over 50 ms; two builds of the same body can therefore be
+  timed over runs 4× apart in length. That reported a 5 % regression for a
+  build that was 8 % faster. `bench_auto` now re-runs on the target window
+  before reporting.
+
 ## Verifying correctness
 
 A token or speed comparison only means something if every language computes

--- a/bench/perfstat.sh
+++ b/bench/perfstat.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# bench/perfstat.sh — build the u64 micro set with the current `build/nurlc`
+# and report retired instructions and core cycles for each binary.
+#
+# Why not wall clock: `bench/run_micro.sh` measures the whole process with
+# a millisecond-ish resolution and several per cent of run-to-run drift, so
+# anything under ~10 % there is indistinguishable from noise (the first
+# report of this set showed `histogram_bins` at 1.15× against C when the
+# two binaries retire the same instructions in the same cycles). Retired
+# instructions and cycles are counted by the CPU itself: instructions are
+# essentially deterministic for these single-threaded kernels, and cycles
+# do not move with the frequency governor. That makes a 1 % change
+# meaningful and a regression impossible to miss.
+#
+# Usage:
+#   ./bench/perfstat.sh                     # build + measure, print a table
+#   ./bench/perfstat.sh --save ref.tsv      # also write the raw numbers
+#   ./bench/perfstat.sh --against ref.tsv   # compare against a saved run
+#   ./bench/perfstat.sh --reps 15           # perf repetitions (default 10)
+#   ./bench/perfstat.sh --cpu 4             # pin to a core (default: none)
+#   ./bench/perfstat.sh --no-build          # measure what is already built
+#
+# The build directory is bench/_build/perf, kept apart from run_micro.sh's.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BENCH="$ROOT/bench"
+BUILD="$BENCH/_build/perf"
+NURLC="$ROOT/build/nurlc"
+RUNTIME="$ROOT/stdlib/runtime.o"
+CLANG="${CLANG:-clang}"
+
+REPS=10
+SAVE=""
+AGAINST=""
+CPU=""
+DO_BUILD=1
+
+BENCHES=(affine_mix stream_lcg ring_write packet_classifier histogram_bins
+         prefix_scan binary_search sort_window bloom_filter hash_join)
+
+while (( $# > 0 )); do
+    case "$1" in
+        --reps)     REPS="$2"; shift 2 ;;
+        --save)     SAVE="$2"; shift 2 ;;
+        --against)  AGAINST="$2"; shift 2 ;;
+        --cpu)      CPU="$2"; shift 2 ;;
+        --bench)    BENCHES=("$2"); shift 2 ;;
+        --no-build) DO_BUILD=0; shift ;;
+        -h|--help)  sed -n '2,26p' "${BASH_SOURCE[0]}"; exit 0 ;;
+        *)          echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+mkdir -p "$BUILD"
+PIN=(); [[ -n "$CPU" ]] && PIN=(taskset -c "$CPU")
+
+if (( DO_BUILD )); then
+    for n in "${BENCHES[@]}"; do
+        printf '  …building %s\r' "$n" >&2
+        ( cd "$ROOT" && "$NURLC" "$BENCH/$n.nu" > "$BUILD/$n.ll" ) || { echo "$n: nurlc FAILED" >&2; exit 1; }
+        "$CLANG" -O2 -flto -Wl,--as-needed "$BUILD/$n.ll" "$RUNTIME" -lm -lpthread \
+                 -o "$BUILD/${n}_nu" 2>/dev/null || { echo "$n: link FAILED" >&2; exit 1; }
+    done
+    printf '                              \r' >&2
+fi
+
+# The checksum gate, cheaply: every binary must still report the same
+# `checksum & 0x7f` exit status it did before. A speed number for a
+# program that stopped computing the right thing is worthless.
+declare -A INSTR CYCLES SUMS
+for n in "${BENCHES[@]}"; do
+    printf '  …measuring %s\r' "$n" >&2
+    SUMS[$n]=$("$BUILD/${n}_nu" --verify | xxd -p)
+    out=$("${PIN[@]}" perf stat -r "$REPS" -x, -e instructions,cycles "$BUILD/${n}_nu" 2>&1)
+    INSTR[$n]=$(awk -F, '/instructions/{print $1}' <<< "$out")
+    CYCLES[$n]=$(awk -F, '/cycles/{print $1}' <<< "$out")
+done
+printf '                              \r' >&2
+
+if [[ -n "$AGAINST" ]]; then
+    declare -A REF_I REF_C REF_S
+    while IFS=$'\t' read -r n i c s; do
+        REF_I[$n]=$i; REF_C[$n]=$c; REF_S[$n]=$s
+    done < "$AGAINST"
+    printf '%-20s %14s %14s %8s %14s %14s %8s %s\n' \
+        benchmark instr ref_instr Δ cycles ref_cycles Δ checksum
+    for n in "${BENCHES[@]}"; do
+        di="—"; dc="—"; ck="—"
+        [[ -n "${REF_I[$n]:-}" ]] && di=$(awk -v a="${INSTR[$n]}" -v b="${REF_I[$n]}" 'BEGIN{printf "%+.2f%%",(a/b-1)*100}')
+        [[ -n "${REF_C[$n]:-}" ]] && dc=$(awk -v a="${CYCLES[$n]}" -v b="${REF_C[$n]}" 'BEGIN{printf "%+.2f%%",(a/b-1)*100}')
+        [[ -n "${REF_S[$n]:-}" ]] && { [[ "${SUMS[$n]}" == "${REF_S[$n]}" ]] && ck="ok" || ck="CHANGED"; }
+        printf '%-20s %14s %14s %8s %14s %14s %8s %s\n' \
+            "$n" "${INSTR[$n]}" "${REF_I[$n]:-—}" "$di" \
+            "${CYCLES[$n]}" "${REF_C[$n]:-—}" "$dc" "$ck"
+    done
+else
+    printf '%-20s %14s %14s  %s\n' benchmark instructions cycles checksum
+    for n in "${BENCHES[@]}"; do
+        printf '%-20s %14s %14s  %s\n' "$n" "${INSTR[$n]}" "${CYCLES[$n]}" "${SUMS[$n]}"
+    done
+fi
+
+if [[ -n "$SAVE" ]]; then
+    : > "$SAVE"
+    for n in "${BENCHES[@]}"; do
+        printf '%s\t%s\t%s\t%s\n' "$n" "${INSTR[$n]}" "${CYCLES[$n]}" "${SUMS[$n]}" >> "$SAVE"
+    done
+    echo "saved → $SAVE" >&2
+fi

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -9716,6 +9716,14 @@
 // with an index walk: the old version re-sliced the remainder per
 // token AND re-copied the accumulated output per append — O(B²) bytes
 // per update on a B-byte state.
+//
+// The scan reads through hoisted `*u` pointers, like __bck_st_get_at
+// above: `nurl_str_get` re-runs strlen on EVERY call, so walking the
+// state with it cost a strlen over the whole state per byte examined —
+// O(B²) again, in the one function whose comment claims to have removed
+// exactly that. Both indices are bounded by the loop guard (`e < n`)
+// and by `wl` against a token already measured to be `wl + 2` long, so
+// the bounds check nurl_str_get performed was dead weight.
 @ bck_st_set s state s name i val → s {
     : i n ( nurl_str_len state )
     : i wl ( nurl_str_len name )
@@ -9724,17 +9732,19 @@
     // worst case: whole state kept + separator + `name=val`
     : s out # s ( malloc + + + n wl vl 3 )
     : *u ob # *u out
+    : *u stp # *u state
+    : *u nmp # *u name
     : ~ i op 0
     : ~ i i 0
     ~ < i n {
         : ~ i e i
-        ~ & < e n != ( nurl_str_get state e ) 32 { = e + e 1 }
+        ~ & < e n != # i . stp e 32 { = e + e 1 }
         : ~ b keep T
         ? == - - e i 2 wl {
             : ~ i k 0
             : ~ b eq T
             ~ & eq < k wl {
-                ? != ( nurl_str_get state + i k ) ( nurl_str_get name k ) { = eq F } {}
+                ? != # i . stp + i k # i . nmp k { = eq F } {}
                 = k + k 1
             }
             ? eq { = keep F } {}
@@ -9772,19 +9782,23 @@
     // digit is one char, so the join of a and b never exceeds
     // len(a) + len(b) + 2. Names probed while still embedded in their
     // state string via __bck_st_get_at — the whole join allocates
-    // exactly one buffer.
+    // exactly one buffer. Both states are scanned through hoisted `*u`
+    // pointers rather than `nurl_str_get`, which re-runs strlen per
+    // call and made each pass quadratic in the state length.
     : i na ( nurl_str_len a )
     : i nb ( nurl_str_len b )
     : s out # s ( malloc + + na nb 2 )
     : *u ob # *u out
+    : *u ap # *u a
+    : *u bp # *u b
     : ~ i op 0
     // pass 1: every binding of a, joined against its state in b
     : ~ i i 0
     ~ < i na {
         : ~ i e i
-        ~ & < e na != ( nurl_str_get a e ) 32 { = e + e 1 }
+        ~ & < e na != # i . ap e 32 { = e + e 1 }
         : i wl - - e i 2
-        : i vj ( bck_join - ( nurl_str_get a - e 1 ) 48 ( __bck_st_get_at b a i wl ) )
+        : i vj ( bck_join - # i . ap - e 1 48 ( __bck_st_get_at b a i wl ) )
         ? > op 0 { : u sp # u 32 = . ob op sp = op + op 1 } {}
         // `name=` copied verbatim from a; then the joined digit
         ( memcpy # s + # i out op # s + # i a i + wl 1 )
@@ -9798,10 +9812,10 @@
     : ~ i j 0
     ~ < j nb {
         : ~ i e2 j
-        ~ & < e2 nb != ( nurl_str_get b e2 ) 32 { = e2 + e2 1 }
+        ~ & < e2 nb != # i . bp e2 32 { = e2 + e2 1 }
         : i wl2 - - e2 j 2
         ? == BCK_UNINIT ( __bck_st_get_at a b j wl2 ) {
-            : i vj2 ( bck_join BCK_UNINIT - ( nurl_str_get b - e2 1 ) 48 )
+            : i vj2 ( bck_join BCK_UNINIT - # i . bp - e2 1 48 )
             ? > op 0 { : u sp2 # u 32 = . ob op sp2 = op + op 1 } {}
             ( memcpy # s + # i out op # s + # i b j + wl2 1 )
             = op + op + wl2 1
@@ -9825,13 +9839,18 @@
 }
 
 // idx-th tab-delimited field of a record (0=kind .. 4=depth).
+// The tab scan reads through a hoisted `*u`: `nurl_str_get` re-runs
+// strlen per call, which made finding field 4 of an R-byte record cost
+// O(R²) — and bck_field is called for every field of every statement
+// row the walk visits.
 @ bck_field s rec i idx → s {
     : i len ( nurl_str_len rec )
+    : *u rp # *u rec
     : ~ i start 0
     : ~ i fno 0
     : ~ i pos 0
     ~ < pos len {
-        ? == ( nurl_str_get rec pos ) 9 {
+        ? == # i . rp pos 9 {
             ? == fno idx { ^ ( nurl_str_slice rec start - pos start ) } {}
             = fno + fno 1
             = start + pos 1
@@ -9844,14 +9863,19 @@
     ( nurl_str_cat `` `` )
 }
 
+// Split the captured statement list on newlines. The scan reads through
+// a hoisted `*u` for the same reason as bck_field: with `nurl_str_get`
+// this single loop was O(total²) over the whole function's statement
+// text.
 @ bck_explode → i {
     : s txt ( nurl_sym_get g_bck `stmts` )
     : i len ( nurl_str_len txt )
+    : *u tp # *u txt
     : ~ i start 0
     : ~ i n 0
     : ~ i pos 0
     ~ < pos len {
-        ? == ( nurl_str_get txt pos ) 10 {
+        ? == # i . tp pos 10 {
             ( nurl_sym_set g_bck ( nurl_str_cat `r` ( nurl_str_int n ) )
             ( nurl_str_slice txt start - pos start ) )
             = n + n 1

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -733,25 +733,78 @@ long long nurl_path_type(const char *path) {
 
 /* ── §9  Memory allocation ─────────────────────────────────────── */
 
-/* Process-wide count of NURL-level allocations (every nurl_alloc /
- * nurl_zalloc — which is what stdlib vec/string/struct ctl blocks route
- * through). Exposed via nurl_alloc_count() for std/bench.nu's per-op
- * allocation metric. A relaxed atomic so the increment is correct under
- * threads while costing nothing measurable next to the malloc itself. */
-static unsigned long long g_nurl_alloc_count = 0;
+/* Count of NURL-level allocations (every nurl_alloc / nurl_zalloc —
+ * which is what stdlib vec/string/struct ctl blocks route through) and
+ * the symmetric count of nurl_free calls on a non-NULL pointer.
+ * nurl_alloc_count() feeds std/bench.nu's per-op allocation metric;
+ * together the two let a test bracket a scope and assert leak-freedom
+ * deterministically without a sanitizer — see
+ * compiler/tests/trait_owned_ret_no_leak.nu.
+ *
+ * These were one global each, bumped with a RELAXED atomic on the
+ * grounds that it "costs nothing measurable next to the malloc itself".
+ * It is not free: on x86 a relaxed read-modify-write is still a `lock
+ * xadd`, ~20 cycles plus a store-buffer stall, and every NURL program
+ * pays it twice per allocate/free pair whether or not anything ever
+ * reads the counter. Parsing bench/data.json makes 9 004 nurl_alloc
+ * calls per pass, and those two increments were 6.5 % of the parse.
+ *
+ * Instead every thread counts into a block of its own with plain
+ * arithmetic, and a reader sums the blocks. The blocks are heap
+ * allocated rather than __thread objects because a thread's counts must
+ * outlive it: the list is only ever pushed to, so a node freed at thread
+ * exit would leave the reader walking into freed memory. One 24-byte
+ * block per thread that ever allocates is the whole cost.
+ *
+ * Only the owning thread writes a block, so its updates are a relaxed
+ * load/store pair (no lock prefix); readers load relaxed as well. A
+ * reader racing a live thread may therefore observe a count one behind,
+ * which is exactly the latitude the RELAXED atomic already gave it. */
+struct nurl__actr {
+    unsigned long long alloc;
+    unsigned long long freed;
+    struct nurl__actr *next;
+};
+static struct nurl__actr        *nurl__actr_list = NULL;  /* push-only */
+static __thread struct nurl__actr *nurl__actr_self = NULL;
+
+/* First allocation on this thread: publish a block for it. Kept out of
+ * line and marked cold so nurl_alloc / nurl_free stay small enough for
+ * the inliner — folding this once-per-thread path into them costs more
+ * at every call site than the atomic it replaces. */
+__attribute__((noinline, cold))
+static struct nurl__actr *nurl__actr_join(void) {
+    struct nurl__actr *self = (struct nurl__actr *)calloc(1, sizeof *self);
+    struct nurl__actr *head = __atomic_load_n(&nurl__actr_list, __ATOMIC_RELAXED);
+    do { self->next = head; }
+    while (!__atomic_compare_exchange_n(&nurl__actr_list, &head, self, 1,
+                                        __ATOMIC_RELEASE, __ATOMIC_RELAXED));
+    nurl__actr_self = self;
+    return self;
+}
+static inline struct nurl__actr *nurl__actr_slot(void) {
+    struct nurl__actr *c = nurl__actr_self;
+    return __builtin_expect(c != NULL, 1) ? c : nurl__actr_join();
+}
+static inline void nurl__actr_bump(unsigned long long *slot) {
+    __atomic_store_n(slot, __atomic_load_n(slot, __ATOMIC_RELAXED) + 1, __ATOMIC_RELAXED);
+}
+/* Sum over every thread that has ever allocated, live or exited. */
+static unsigned long long nurl__actr_total(int freed) {
+    unsigned long long t = 0;
+    for (struct nurl__actr *c = __atomic_load_n(&nurl__actr_list, __ATOMIC_ACQUIRE);
+         c; c = c->next)
+        t += __atomic_load_n(freed ? &c->freed : &c->alloc, __ATOMIC_RELAXED);
+    return t;
+}
 
 /* OOM aborts inside the checked wrappers at the top of this file (see
  * "OOM is fatal, loudly") — malloc/calloc here are already the checked
  * forms via the file-wide macros. */
-void* nurl_alloc(long long bytes)              { __atomic_fetch_add(&g_nurl_alloc_count, 1, __ATOMIC_RELAXED); return malloc((size_t)bytes); }
-void* nurl_zalloc(long long bytes)             { __atomic_fetch_add(&g_nurl_alloc_count, 1, __ATOMIC_RELAXED); return calloc(1, (size_t)bytes); }
-long long nurl_alloc_count(void)               { return (long long)__atomic_load_n(&g_nurl_alloc_count, __ATOMIC_RELAXED); }
-/* Symmetric free counter: every nurl_free of a non-NULL pointer. Together with
- * nurl_alloc_count() the difference (alloc - free) is the live-allocation count,
- * which a test can bracket around a scope to assert leak-freedom deterministically
- * (no sanitizer needed) — see compiler/tests/trait_owned_ret_no_leak.nu. */
-static unsigned long long g_nurl_free_count = 0;
-long long nurl_free_count(void)                { return (long long)__atomic_load_n(&g_nurl_free_count, __ATOMIC_RELAXED); }
+void* nurl_alloc(long long bytes)              { nurl__actr_bump(&nurl__actr_slot()->alloc); return malloc((size_t)bytes); }
+void* nurl_zalloc(long long bytes)             { nurl__actr_bump(&nurl__actr_slot()->alloc); return calloc(1, (size_t)bytes); }
+long long nurl_alloc_count(void)               { return (long long)nurl__actr_total(0); }
+long long nurl_free_count(void)                { return (long long)nurl__actr_total(1); }
 void* nurl_realloc(void *ptr, long long bytes) { return realloc(ptr, (size_t)bytes); }
 
 /* ── §9b  Panic-unwind allocation journal ──────────────────────────
@@ -874,7 +927,7 @@ static void nurl__jrnl_drain(long long mark) {
     nurl__jrnl_len = mark;
 }
 
-void  nurl_free(void *ptr)                     { if (!ptr) return; __atomic_fetch_add(&g_nurl_free_count, 1, __ATOMIC_RELAXED); if (nurl__jrnl_len) nurl__jrnl_remove(ptr); free(ptr); }
+void  nurl_free(void *ptr)                     { if (!ptr) return; nurl__actr_bump(&nurl__actr_slot()->freed); if (nurl__jrnl_len) nurl__jrnl_remove(ptr); free(ptr); }
 void  nurl_memcpy(void *dst, const void *src, long long bytes) {
     memcpy(dst, src, (size_t)bytes);
 }

--- a/stdlib/std/bench.nu
+++ b/stdlib/std/bench.nu
@@ -63,22 +63,49 @@ $ `stdlib/std/time.nu`
     ^ @ BenchResult { nm n total / total n / - a1 a0 n }
 }
 
-// Auto-scale iters until a timed pass clears ~50 ms, so ns/op is stable
-// even for sub-microsecond operations. Caps the ramp so a slow body
-// cannot run away.
+// Auto-scale iters until a timed pass clears ~50 ms, then re-run once at
+// the count that lands ON that window, so ns/op is stable even for
+// sub-microsecond operations. Caps the ramp so a slow body cannot run
+// away.
+//
+// The ramp alone is not enough to compare two builds. It multiplies by
+// 4, so a body whose cost sits near the threshold clears it for one
+// build and misses it for the next, and the two results then come from
+// runs 4× apart in length — different amounts of warm-up, frequency
+// ramp and timer overhead amortised over the ops. Measured on
+// `bench/stdlib_hotpath.nu`'s `sort_32_desc`, that reported a 5 %
+// REGRESSION for a build that was 8 % faster on both cycle count and
+// wall clock. The final calibrated pass removes the dependence on where
+// the ramp happened to stop: every reported number comes from a run of
+// about `target` nanoseconds.
 @ bench_auto s name ( @ v ) body → BenchResult {
+    : i target 50000000
+    : i cap 100000000
     : ~ i iters 1
     : ~ b done F
     : ~ BenchResult best ( bench_run name 1 body )
     ~ ! done {
         ( bench_result_free best )
         = best ( bench_run name iters body )
-        ? | >= ( bench_result_total_ns best ) 50000000 >= iters 100000000 {
+        ? | >= ( bench_result_total_ns best ) target >= iters cap {
             = done T
         } {
             = iters * iters 4
         }
     }
+    // The clearing pass may have overshot by up to the ramp factor.
+    // Scale back onto the target window and measure once more; skip it
+    // when the ramp hit its cap (the body is slow enough that the window
+    // is already the best available) or when one iteration alone is
+    // longer than the target.
+    : i total ( bench_result_total_ns best )
+    ? & > total target & > iters 1 < iters cap {
+        : i want / * iters target total
+        ? & > want 0 < want iters {
+            ( bench_result_free best )
+            = best ( bench_run name want body )
+        } {}
+    } {}
     ^ best
 }
 


### PR DESCRIPTION
Stacked on #650 — `bench/perfstat.sh` needs the u64 kernel sources that
PR adds. Merge #650 first; this then retargets to `main` cleanly.

Four NURL execution results are permanently faster. Every number below
is retired instructions / core cycles from `perf stat -r 10` on a pinned,
idle core, against a baseline built from a verified-clean bootstrap
(`BUILD SUCCESS & TESTS PASSED`), with the measurement noise floor
established first: **±0.1 % on instructions, ±1 % on cycles**.

| result | before | after | Δ cycles | Δ wall |
|---|---:|---:|---:|---:|
| `sort_32_desc` | 125.1 M | 112.6 M | **−10.0 %** | −9.9 % |
| `string_build_16` | 338.6 M | 305.9 M | **−9.7 %** | −9.6 % |
| `json_parse` | 12.68 M | 11.66 M | **−8.1 %** | −9.4 % |
| `vec_push_64` | 195.6 M | 188.0 M | **−3.9 %** | −3.9 % |
| nurlc self-compile | 3.69 G instr | 3.26 G instr | **−11.6 %** | 552 → 514 ms |

## 1. The allocation counters cost more than the allocations they counted

`nurl_alloc` / `nurl_zalloc` / `nurl_free` bumped a process-wide counter
with a RELAXED atomic. The comment claimed that "costs nothing
measurable next to the malloc itself" — never measured, and wrong. On
x86 a relaxed read-modify-write is still a `lock xadd`: ~20 cycles plus a
store-buffer stall, paid twice per allocate/free pair by every NURL
program, for a diagnostic almost nothing reads. Parsing
`bench/data.json` makes 9 004 `nurl_alloc` calls per pass.

Each thread now counts into a heap block of its own with plain
arithmetic; a reader sums the blocks. Blocks are heap allocated, not
`__thread` objects, because a thread's counts must outlive it — the list
is push-only, so a node freed at thread exit would leave the reader
walking freed memory. Only the owner writes a block, so updates are a
relaxed load/store pair rather than an RMW.

The registration path is `noinline, cold` on purpose: left inlinable it
pushes `nurl_alloc` past the inliner's threshold and gives back half the
win (12.37 M cycles vs 11.60 M on `json_parse`).

**Semantics unchanged** — a three-thread churn test reports identical
alloc and free totals before and after.

## 2. Four borrow-checker scans were quadratic in their own input

`nurl_str_get` re-runs `strlen` on every call, so walking a string one
byte at a time with it costs a pass over the whole string per byte.
`bck_st_set`, `bck_join_state`, `bck_field` and `bck_explode` all did
that — in the same file where `__bck_st_get_at`'s comment describes
removing exactly this cost. They now read through hoisted `*u` pointers.
Every index is already bounded by a loop guard or by a token length
measured on the line above, so the bounds check bought nothing.

The borrow checker was **42 % of a self-compile** before this.

**Gate:** all 1122 `.nu` files under `compiler/tests`, `stdlib`,
`examples` and `packages`, compiled with a pristine build and with this
one — IR *and* diagnostics byte-identical on every file, including the
316 that emit diagnostics. The u64 micro set shows no regression and all
ten checksums still match.

## 3. The instrument was the first bug

`std/bench.nu`'s `bench_auto` ramps iterations ×4 and stops at the first
pass over 50 ms, so two builds of the same body get timed over runs 4×
apart in length. On `sort_32_desc` it reported **+5 % for a build that
was 8 % faster** on both cycle count and wall clock — this nearly buried
a real win. It now scales back onto the target window before reporting.

`bench/perfstat.sh` measures the u64 set in instructions and cycles with
`--save` / `--against`, re-checking each checksum. `bench/README.md`
gains the rest of what this cost: pin the core and idle the machine (a
background build inflated `binary_search` 58 % and `bloom_filter` 73 %),
and never A/B through an auto-calibrating harness without checking it
landed on the same iteration count.

## Measured non-results, recorded so they are not retried

Adding `inbounds` to every `getelementptr`, and `nounwind` to every
`define`, changes nothing on the u64 set — after LTO and inlining there
is no barrier left for them to remove. That set is already at C parity
instruction-for-instruction, which is why the wins here are all in the
runtime and the compiler instead.

## Verification

`./build.sh` (bootstrap fixed point + full test suite) run after every
change; green each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG