### PR TITLE
nurlweb: give the package registry a section, a nav link and a footer link

### DIFF
--- a/nurlweb/public/index.html
+++ b/nurlweb/public/index.html
@@ -36,6 +36,7 @@
       <a href="#targets">Targets</a>
       <a href="#proof">Built with it</a>
       <a href="#start">Get started</a>
+      <a href="#packages">Packages</a>
       <a href="#mcp">MCP</a>
       <a class="btn-link" href="https://play.nurl-lang.org" target="_blank" rel="noopener">Playground →</a>
       <a class="btn-link btn-link-lg" href="https://docs.nurl-lang.org" target="_blank" rel="noopener">Docs</a>
@@ -64,7 +65,7 @@
     </a>
   </div>
   <div class="stats">
-    <div class="stat"><strong data-fact="version">v0.25.1</strong><span>current release</span></div>
+    <div class="stat"><strong data-fact="version">v0.26.0</strong><span>current release</span></div>
     <div class="stat"><strong data-fact="compiler_lines">20,101</strong><span>lines of NURL in the compiler</span></div>
     <div class="stat"><strong data-fact="tests">588</strong><span>compiler test programs</span></div>
     <div class="stat"><strong data-fact="stdlib_modules">174</strong><span>stdlib modules</span></div>
@@ -561,6 +562,57 @@ cd nurl
   </div>
 </section>
 
+<!-- ───── Package registry ─────────────────────────────── -->
+<section id="packages">
+  <div class="container">
+    <div class="section-head">
+      <h2><span data-fact="registry_packages">45</span> packages, one command away</h2>
+      <p><a href="https://reg.nurl-lang.org" target="_blank" rel="noopener">reg.nurl-lang.org</a> is the package registry — <span data-fact="registry_versions">251</span> published versions of real libraries and tools, not placeholders. Semver ranges in <code>nurl.toml</code>, a lockfile for reproducible installs, and a signature on every tarball that <code>nurlpkg</code> checks before it unpacks anything.</p>
+    </div>
+
+    <div class="pkg-layout">
+      <div class="pkg-cmds">
+        <div class="cmd-label">Find, install, publish</div>
+        <div class="cmd-block">
+          <button class="copy-btn" data-copy-target="#pkg-cmd">Copy</button>
+<pre id="pkg-cmd">nurlpkg search whisper   # search
+nurlpkg install nq       # program → your PATH
+nurlpkg add tensor       # library → deps/
+nurlpkg publish          # your turn</pre>
+        </div>
+        <a class="btn btn-primary" href="https://reg.nurl-lang.org" target="_blank" rel="noopener">Browse the registry</a>
+      </div>
+
+      <ul class="pkg-facts">
+        <li><strong>Signed, and verified in pure NURL.</strong> The registry signs every tarball with Ed25519; <code>nurlpkg</code> verifies that signature against a pinned public key, and the SHA-256, before a single file is written.</li>
+        <li><strong>Readable before you install it.</strong> Every published version gets generated API docs and a file browser on the registry — you can read a package's source without downloading it.</li>
+        <li><strong>Reproducible.</strong> <code>nurl.lock</code> pins what you resolved, <code>nurlpkg verify</code> fails on drift, and a bad version can be yanked without breaking the ones that pinned it.</li>
+        <li><strong>Your own packages.</strong> Sign in with GitHub, mint a token with <code>nurlpkg login</code>, and <code>nurlpkg publish</code> — with <code>--dry-run</code> to walk every gate first.</li>
+      </ul>
+    </div>
+
+    <div class="grid pkg-grid">
+      <div class="card"><h3><code>nurllama</code></h3><p>Run language models locally: pull a GGUF model, chat with it, or serve an ollama-compatible API your existing clients already speak.</p></div>
+      <div class="card"><h3><code>whisper</code></h3><p>Speech recognition in pure NURL — real audio in, real text out, running OpenAI's Whisper checkpoints as shipped.</p></div>
+      <div class="card"><h3><code>onnx</code></h3><p>Load a trained ONNX model and run inference on the GPU, written entirely in NURL.</p></div>
+      <div class="card"><h3><code>tensor</code></h3><p>The n-dimensional array the ML packages share — the reusable ndarray, GPU-backed.</p></div>
+      <div class="card"><h3><code>grad</code></h3><p>Reverse-mode autograd over <code>tensor</code>: record a tape with ops that mirror its surface, call backward, train.</p></div>
+      <div class="card"><h3><code>yoloe</code></h3><p>Promptable open-vocabulary object detection and segmentation — a NURL port of YOLOE, on the GPU.</p></div>
+      <div class="card"><h3><code>wasmtime</code></h3><p>A WebAssembly runtime written from scratch in NURL — no libwasm, no embedded engine.</p></div>
+      <div class="card"><h3><code>image</code></h3><p>PNG and JPEG decode, encode and raster ops with no native library and no shell-out.</p></div>
+      <div class="card"><h3><code>nq</code></h3><p>jq-lite: filter JSON on stdin with a small query language. The one-liner in the install block above.</p></div>
+    </div>
+
+    <p class="bench-note">
+      Also published: <code>gpu</code> and <code>gpukit</code> (CUDA driver API + NVRTC, with an OpenMP CPU backend),
+      <code>tls</code>, <code>psql</code>, <code>redis</code>, <code>http</code>, <code>swarm</code>,
+      <code>embed</code>, <code>safetensor</code>, <code>vindex</code>, <code>cli</code>, <code>chart</code>,
+      <code>template</code>, <code>cas</code> and more — the full list, with docs and sources for every version, is at
+      <a href="https://reg.nurl-lang.org" target="_blank" rel="noopener">reg.nurl-lang.org</a>.
+    </p>
+  </div>
+</section>
+
 <!-- ───── MCP server ───────────────────────────────────── -->
 <section id="mcp">
   <div class="container">
@@ -644,7 +696,7 @@ cd nurl
       </div>
       <div class="card">
         <h3>Changelog</h3>
-        <p>Every release documented in Keep-a-Changelog format with the reasoning behind each fix — currently at <span data-fact="version">v0.25.1</span>.</p>
+        <p>Every release documented in Keep-a-Changelog format with the reasoning behind each fix — currently at <span data-fact="version">v0.26.0</span>.</p>
         <p style="margin-top: 0.8rem;"><a href="https://github.com/nurl-lang/nurl/blob/main/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG.md</a></p>
       </div>
       <div class="card">
@@ -667,6 +719,7 @@ cd nurl
     <a href="https://github.com/nurl-lang/nurl" target="_blank" rel="noopener">GitHub</a>
     <a href="https://docs.nurl-lang.org" target="_blank" rel="noopener">Docs</a>
     <a href="https://play.nurl-lang.org" target="_blank" rel="noopener">Playground</a>
+    <a href="https://reg.nurl-lang.org" target="_blank" rel="noopener">Package registry</a>
     <a href="https://play.nurl-lang.org/gameboydemo" target="_blank" rel="noopener">Game Boy demo</a>
     <a href="https://github.com/nurl-lang/nurl#readme" target="_blank" rel="noopener">README</a>
     <a href="https://github.com/nurl-lang/nurl/blob/main/spec/grammar.ebnf" target="_blank" rel="noopener">Grammar</a>

--- a/nurlweb/public/styles.css
+++ b/nurlweb/public/styles.css
@@ -328,6 +328,55 @@ section:last-of-type { border-bottom: none; }
   line-height: 1.6;
   margin-top: 1.4rem;
 }
+
+/* ── Package registry ─────────────────────────────────────── */
+.pkg-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) 1fr;
+  gap: 1.6rem;
+  align-items: start;
+  margin-bottom: 1.6rem;
+}
+@media (max-width: 820px) {
+  .pkg-layout { grid-template-columns: 1fr; }
+}
+/* min-width:0 lets the grid column shrink below the <pre>'s intrinsic
+   width, so a long command scrolls inside its own block instead of
+   spilling over the bullet list next to it. */
+.pkg-cmds { min-width: 0; }
+.pkg-cmds pre { overflow-x: auto; }
+.pkg-cmds .btn { margin-top: 0.3rem; }
+.pkg-facts {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+.pkg-facts li {
+  color: var(--fg-dim);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  padding-left: 1.1rem;
+  position: relative;
+}
+.pkg-facts li::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0.62em;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+.pkg-facts strong { color: var(--fg); font-weight: 600; }
+.pkg-grid .card h3 { margin-bottom: 0.4rem; }
+.pkg-grid .card h3 code {
+  background: none;
+  padding: 0;
+  color: var(--accent);
+  font-size: 0.98rem;
+}
 @media (max-width: 720px) {
   .bench-table th, .bench-table td { padding: 0.7rem 0.8rem; font-size: 0.86rem; }
 }
@@ -374,7 +423,7 @@ section:last-of-type { border-bottom: none; }
 .start-card p { color: var(--fg-dim); margin: 0 0 1.2rem; font-size: 0.93rem; flex: 1; }
 .start-card .step { color: var(--accent); font-size: 0.75rem; font-weight: 700;
   letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 0.5rem; }
-.start-card pre {
+.start-card pre, .pkg-cmds pre {
   background: var(--code-bg);
   border: 1px solid var(--border);
   border-radius: 6px;

--- a/tools/gen-site-facts.sh
+++ b/tools/gen-site-facts.sh
@@ -46,8 +46,10 @@ examples="$(find "$ROOT/examples" -maxdepth 1 -name '*.nu' | wc -l | tr -d ' ')"
 # place instead of aborting the deploy (or zeroing the figure).
 registry_url="${NURL_REGISTRY_URL:-https://reg.nurl-lang.org}"
 registry_packages=""
+registry_versions=""
 if stats="$(curl -fsS --max-time 8 "$registry_url/api/v1/stats" 2>/dev/null)"; then
     registry_packages="$(printf '%s' "$stats" | grep -oE '"packages"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)"
+    registry_versions="$(printf '%s' "$stats" | grep -oE '"versions"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)"
 fi
 
 # ── Inject into every data-fact="<key>" element ────────────────────────
@@ -63,9 +65,12 @@ inject compiler_lines "$compiler_lines"
 inject tests          "$tests"
 inject stdlib_modules "$stdlib_modules"
 inject examples       "$examples"
-# Only overwrite the registry figure when the fetch actually produced one.
+# Only overwrite the registry figures when the fetch actually produced them.
 if [[ -n "$registry_packages" ]]; then
     inject registry_packages "$(comma "$registry_packages")"
+fi
+if [[ -n "$registry_versions" ]]; then
+    inject registry_versions "$(comma "$registry_versions")"
 fi
 
 echo "site facts → $HTML"


### PR DESCRIPTION
The registry had **one card at the bottom** of the "Go deeper" resources grid and a number in the hero. A visitor could read the whole landing page without learning that NURL has a package manager, and the single link to `reg.nurl-lang.org` was the last item before the footer. No nav entry, no footer entry.

## What's added

A `#packages` section after the install steps, before MCP:

* **What it is** — 45 packages, 251 published versions, semver ranges in `nurl.toml`, a lockfile.
* **The four commands that matter** — `search`, `install` (program → PATH), `add` (library → `deps/`), `publish`.
* **What it guarantees**, all verified against the implementation rather than written from memory:
  * every tarball is signed with Ed25519 and `nurlpkg` verifies that signature against a **pinned** public key — plus the SHA-256 — before a file is written (`stdlib/ext/pkg_fetch.nu`, `stdlib/std/minisign.nu`, `registry/src/index.ts`);
  * every published version gets generated API docs and a file browser (`/packages/<name>/<version>/{api,files}`);
  * `nurl.lock` + `nurlpkg verify` for reproducibility, `yank` for withdrawing a version;
  * publish flow: GitHub sign-in → `nurlpkg login` → `nurlpkg publish` (`--dry-run` walks every gate).
* **Nine real packages** with one-line descriptions pulled from their own published READMEs on the registry — `nurllama`, `whisper`, `onnx`, `tensor`, `grad`, `yoloe`, `wasmtime`, `image`, `nq` — and a tail naming a dozen more.

Nav gains **Packages**; the footer gains **Package registry**.

## Honesty wiring

`registry_versions` is a new `data-fact`, fetched from the registry's stats API next to the existing package count, so neither figure can go stale by hand. Both stay best-effort: a failed fetch leaves the previous value rather than zeroing it.

## Checked

* Rendered at 1240 px and 420 px — the command block gets the same panel as the install blocks and scrolls inside its own column instead of spilling into the bullet list (`min-width: 0` on the grid child, which is what the first render got wrong).
* HTML nesting validated; `tools/gen-site-facts.sh` runs clean and injects both registry figures.

Deploys on the next `v*` tag, or manually from Actions ▸ Deploy nurlweb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG
