### PR TITLE
bench: honest rows — unfoldable lcg/affine_mix, equal-work C json peer, runtime small-alloc cache

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -52,8 +52,8 @@ and `perfstat.sh` read.
 
 | Benchmark | Shape |
 |---|---|
-| `lcg` | Loop-carried integer dependency, 64-bit wrap-around |
-| `affine_mix` | Shift/add/mask chain over a 58-bit state, no multiply |
+| `lcg` | Loop-carried mul/add/shift/xor dependency the unroller cannot compose |
+| `affine_mix` | Shift/add/mask/xor chain over a 58-bit state, no multiply |
 | `packet_classifier` | A data-dependent 50/50 branch the predictor cannot learn |
 | `ring_write` | Dependent store per iteration plus address computation |
 | `histogram_bins` | Read-modify-write at a data-dependent index |

--- a/bench/affine_mix.c
+++ b/bench/affine_mix.c
@@ -1,4 +1,4 @@
-// benchmark-contract: affine-mix;seed=123456789;iterations=20000000;mask=0x03ffffffffffffff
+// benchmark-contract: affine-mix-xs9;seed=123456789;iterations=20000000;mask=0x03ffffffffffffff;xorshift=9
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -18,6 +18,7 @@ int main(void) {
 
   while (i < iterations) {
     state = ((state << 3) + i) & 0x03ffffffffffffffULL;
+    state ^= state >> 9;
     state = ((state << 2) - 3ULL) & 0x03ffffffffffffffULL;
     ++i;
   }

--- a/bench/affine_mix.js
+++ b/bench/affine_mix.js
@@ -1,4 +1,4 @@
-// benchmark-contract: affine-mix;seed=123456789;iterations=20000000;mask=0x03ffffffffffffff
+// benchmark-contract: affine-mix-xs9;seed=123456789;iterations=20000000;mask=0x03ffffffffffffff;xorshift=9
 //
 // affine_mix — 20M rounds of two chained affine steps over a 58-bit
 // state.
@@ -16,6 +16,7 @@ const ITERATIONS = 20000000n;
 let state = 123456789n;
 for (let i = 0n; i < ITERATIONS; i++) {
     state = ((state << 3n) + i) & MASK;
+    state ^= state >> 9n;
     state = ((state << 2n) - 3n) & MASK;
 }
 

--- a/bench/affine_mix.nu
+++ b/bench/affine_mix.nu
@@ -1,8 +1,12 @@
-// benchmark-contract: affine-mix;seed=123456789;iterations=20000000;mask=0x03ffffffffffffff
+// benchmark-contract: affine-mix-xs9;seed=123456789;iterations=20000000;mask=0x03ffffffffffffff;xorshift=9
 //
-// affine_mix — 20M rounds of two chained affine steps over a 58-bit
-// state. Every step depends on the previous one, so the loop cannot be
-// folded into a closed form; the shifts keep the mix in the integer ALU.
+// affine_mix — 20M rounds of two affine steps over a 58-bit state with
+// a xorshift mix between them. The mask makes each shift-add step
+// affine mod 2^58, and LLVM's unroller composes chained affine steps
+// into one, so without the xor this row measured the compiler's
+// composition factor rather than the chain. The xor of a shifted copy
+// breaks affinity: every step's shifts, adds, masks and xor stay on the
+// critical path, all of it in the integer ALU.
 //
 // Contract: the process prints exactly one line — the checksum in
 // decimal, masked to 63 bits — and nothing else. `bench/bench.sh` gates
@@ -17,6 +21,7 @@
 
     ~ < k iterations {
         = state & + << state 3 k mask
+        = state ^^ state >> state 9
         = state & - << state 2 3 mask
         = k + k 1
     }

--- a/bench/affine_mix.py
+++ b/bench/affine_mix.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# benchmark-contract: affine-mix;seed=123456789;iterations=20000000;mask=0x03ffffffffffffff
+# benchmark-contract: affine-mix-xs9;seed=123456789;iterations=20000000;mask=0x03ffffffffffffff;xorshift=9
 #
 # affine_mix — 20M rounds of two chained affine steps over a 58-bit
 # state. Python integers are arbitrary precision, so every step masks
@@ -12,6 +12,7 @@ MASK = 0x03FFFFFFFFFFFFFF
 state = 123456789
 for i in range(20_000_000):
     state = ((state << 3) + i) & MASK
+    state ^= state >> 9
     state = ((state << 2) - 3) & MASK
 
 print(state & 0x7FFFFFFFFFFFFFFF)

--- a/bench/affine_mix.rs
+++ b/bench/affine_mix.rs
@@ -1,4 +1,4 @@
-// benchmark-contract: affine-mix;seed=123456789;iterations=20000000;mask=0x03ffffffffffffff
+// benchmark-contract: affine-mix-xs9;seed=123456789;iterations=20000000;mask=0x03ffffffffffffff;xorshift=9
 const ITERATIONS: u64 = 20_000_000;
 const SEED: u64 = 123_456_789;
 const MASK: u64 = 0x03ff_ffff_ffff_ffff;
@@ -14,6 +14,7 @@ fn main() {
     let mut i = 0u64;
     while i < ITERATIONS {
         state = (state << 3).wrapping_add(i) & MASK;
+        state ^= state >> 9;
         state = (state << 2).wrapping_sub(3) & MASK;
         i += 1;
     }

--- a/bench/json_parse.c
+++ b/bench/json_parse.c
@@ -1,7 +1,8 @@
 // benchmark-contract: json-parse;input=bench/data.json;parses=20
 //
 // json_parse — parse bench/data.json 20 times with a small
-// recursive-descent parser and print how many parses succeeded.
+// recursive-descent parser, building an owned DOM tree each pass and
+// freeing it, and print how many parses succeeded.
 //
 // C has no JSON in its standard library, so — exactly like the Rust
 // peer — the parser is embedded here rather than pulled in as a
@@ -9,6 +10,16 @@
 // box is empty, a hand-written parser in the benchmark file itself.
 // Python (`json`), Node (`JSON.parse`) and NURL (`stdlib/ext/json.nu`)
 // all use their own.
+//
+// The row's blurb is "allocator pressure, string handling, recursive
+// descent", and every peer builds a document tree: Python and Node
+// cannot avoid it, NURL and Rust build one deliberately. An earlier
+// version of this file only *validated* — no tree, no strings, no
+// allocation — which made the C cell a measurement of different work.
+// This parser mirrors the Rust peer structure for structure: strings
+// are copied into owned buffers, numbers keep a borrowed slice of the
+// source, arrays and objects are growable vectors, and the whole tree
+// is freed after each parse.
 //
 // Contract: the process prints exactly one line — the number of parses
 // that succeeded. This is the one row in the suite whose cross-language
@@ -18,13 +29,55 @@
 #include <stdlib.h>
 #include <string.h>
 
+typedef enum { J_NULL, J_BOOL, J_NUM, J_STR, J_ARR, J_OBJ } JTag;
+
+typedef struct JVal JVal;
+typedef struct JKv JKv;
+
+struct JVal {
+  JTag tag;
+  union {
+    int boolean;
+    struct { const char* p; size_t len; } num;  // borrowed from src
+    char* str;                                  // owned copy
+    struct { JVal* items; size_t len, cap; } arr;
+    struct { JKv* items; size_t len, cap; } obj;
+  } u;
+};
+
+struct JKv {
+  char* key;  // owned copy
+  JVal val;
+};
+
+static void jval_free(JVal* v) {
+  switch (v->tag) {
+    case J_STR:
+      free(v->u.str);
+      break;
+    case J_ARR:
+      for (size_t i = 0; i < v->u.arr.len; ++i) jval_free(&v->u.arr.items[i]);
+      free(v->u.arr.items);
+      break;
+    case J_OBJ:
+      for (size_t i = 0; i < v->u.obj.len; ++i) {
+        free(v->u.obj.items[i].key);
+        jval_free(&v->u.obj.items[i].val);
+      }
+      free(v->u.obj.items);
+      break;
+    default:
+      break;
+  }
+}
+
 typedef struct {
   const unsigned char* s;
   size_t len;
   size_t i;
 } P;
 
-static int parse_value(P* p);
+static int parse_value(P* p, JVal* out);
 
 static void skip_ws(P* p) {
   while (p->i < p->len) {
@@ -49,69 +102,93 @@ static int match_kw(P* p, const char* kw, size_t n) {
 }
 
 // The benchmark input carries no escapes, matching the Rust peer, which
-// bails out on a backslash rather than decoding it.
-static int parse_string(P* p) {
+// bails out on a backslash rather than decoding it. The body bytes are
+// copied into an owned NUL-terminated buffer, like Rust's String.
+static char* parse_string_owned(P* p) {
   ++p->i;
+  size_t start = p->i;
   while (p->i < p->len) {
     unsigned char c = p->s[p->i];
     if (c == '"') {
+      size_t n = p->i - start;
+      char* out = (char*)malloc(n + 1);
+      if (!out) return NULL;
+      memcpy(out, p->s + start, n);
+      out[n] = '\0';
       ++p->i;
-      return 1;
+      return out;
     }
     if (c == '\\') {
-      return 0;
+      return NULL;  // skip escape handling — bench input has none
     }
     ++p->i;
   }
-  return 0;
+  return NULL;
 }
 
-static int parse_number(P* p) {
+static int parse_number(P* p, JVal* out) {
   size_t start = p->i;
-  if (p->s[p->i] == '-') {
-    ++p->i;
-  }
+  if (p->i < p->len && p->s[p->i] == '-') ++p->i;
   while (p->i < p->len) {
     unsigned char c = p->s[p->i];
-    int numeric = (c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E' ||
-                  c == '+' || c == '-';
-    if (!numeric) {
+    if ((c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E' ||
+        c == '+' || c == '-') {
+      ++p->i;
+    } else {
       break;
     }
-    ++p->i;
   }
-  return p->i > start;
+  if (p->i == start) return 0;
+  out->tag = J_NUM;
+  out->u.num.p = (const char*)p->s + start;
+  out->u.num.len = p->i - start;
+  return 1;
 }
 
-static int parse_array(P* p) {
+static int parse_array(P* p, JVal* out) {
   ++p->i;
+  out->tag = J_ARR;
+  out->u.arr.items = NULL;
+  out->u.arr.len = 0;
+  out->u.arr.cap = 0;
   skip_ws(p);
   if (p->i < p->len && p->s[p->i] == ']') {
     ++p->i;
     return 1;
   }
   for (;;) {
-    if (!parse_value(p)) {
+    if (out->u.arr.len == out->u.arr.cap) {
+      size_t nc = out->u.arr.cap ? out->u.arr.cap * 2 : 4;
+      JVal* ni = (JVal*)realloc(out->u.arr.items, nc * sizeof(JVal));
+      if (!ni) { jval_free(out); return 0; }
+      out->u.arr.items = ni;
+      out->u.arr.cap = nc;
+    }
+    if (!parse_value(p, &out->u.arr.items[out->u.arr.len])) {
+      jval_free(out);
       return 0;
     }
+    out->u.arr.len++;
     skip_ws(p);
-    if (p->i >= p->len) {
-      return 0;
-    }
+    if (p->i >= p->len) { jval_free(out); return 0; }
     if (p->s[p->i] == ',') {
       ++p->i;
-      continue;
-    }
-    if (p->s[p->i] == ']') {
+    } else if (p->s[p->i] == ']') {
       ++p->i;
       return 1;
+    } else {
+      jval_free(out);
+      return 0;
     }
-    return 0;
   }
 }
 
-static int parse_object(P* p) {
+static int parse_object(P* p, JVal* out) {
   ++p->i;
+  out->tag = J_OBJ;
+  out->u.obj.items = NULL;
+  out->u.obj.len = 0;
+  out->u.obj.cap = 0;
   skip_ws(p);
   if (p->i < p->len && p->s[p->i] == '}') {
     ++p->i;
@@ -119,79 +196,109 @@ static int parse_object(P* p) {
   }
   for (;;) {
     skip_ws(p);
-    if (p->i >= p->len || p->s[p->i] != '"') {
-      return 0;
-    }
-    if (!parse_string(p)) {
-      return 0;
-    }
+    if (p->i >= p->len || p->s[p->i] != '"') { jval_free(out); return 0; }
+    char* key = parse_string_owned(p);
+    if (!key) { jval_free(out); return 0; }
     skip_ws(p);
-    if (p->i >= p->len || p->s[p->i] != ':') {
-      return 0;
-    }
+    if (p->i >= p->len || p->s[p->i] != ':') { free(key); jval_free(out); return 0; }
     ++p->i;
-    if (!parse_value(p)) {
+    if (out->u.obj.len == out->u.obj.cap) {
+      size_t nc = out->u.obj.cap ? out->u.obj.cap * 2 : 4;
+      JKv* ni = (JKv*)realloc(out->u.obj.items, nc * sizeof(JKv));
+      if (!ni) { free(key); jval_free(out); return 0; }
+      out->u.obj.items = ni;
+      out->u.obj.cap = nc;
+    }
+    JKv* kv = &out->u.obj.items[out->u.obj.len];
+    kv->key = key;
+    if (!parse_value(p, &kv->val)) {
+      free(key);
+      jval_free(out);
       return 0;
     }
+    out->u.obj.len++;
     skip_ws(p);
-    if (p->i >= p->len) {
-      return 0;
-    }
+    if (p->i >= p->len) { jval_free(out); return 0; }
     if (p->s[p->i] == ',') {
       ++p->i;
-      continue;
-    }
-    if (p->s[p->i] == '}') {
+    } else if (p->s[p->i] == '}') {
       ++p->i;
       return 1;
+    } else {
+      jval_free(out);
+      return 0;
     }
-    return 0;
   }
 }
 
-static int parse_value(P* p) {
+static int parse_value(P* p, JVal* out) {
   skip_ws(p);
-  if (p->i >= p->len) {
-    return 0;
-  }
-  switch (p->s[p->i]) {
-    case 'n': return match_kw(p, "null", 4);
-    case 't': return match_kw(p, "true", 4);
-    case 'f': return match_kw(p, "false", 5);
-    case '"': return parse_string(p);
-    case '[': return parse_array(p);
-    case '{': return parse_object(p);
-    default:  return parse_number(p);
+  if (p->i >= p->len) return 0;
+  unsigned char c = p->s[p->i];
+  switch (c) {
+    case 'n':
+      if (!match_kw(p, "null", 4)) return 0;
+      out->tag = J_NULL;
+      return 1;
+    case 't':
+      if (!match_kw(p, "true", 4)) return 0;
+      out->tag = J_BOOL;
+      out->u.boolean = 1;
+      return 1;
+    case 'f':
+      if (!match_kw(p, "false", 5)) return 0;
+      out->tag = J_BOOL;
+      out->u.boolean = 0;
+      return 1;
+    case '"': {
+      char* s = parse_string_owned(p);
+      if (!s) return 0;
+      out->tag = J_STR;
+      out->u.str = s;
+      return 1;
+    }
+    case '[':
+      return parse_array(p, out);
+    case '{':
+      return parse_object(p, out);
+    default:
+      return parse_number(p, out);
   }
 }
 
 int main(void) {
-  // Resolved against the working directory, like the NURL and Rust
-  // peers: the runner always invokes the benchmarks from the repo root.
   FILE* f = fopen("bench/data.json", "rb");
-  if (f == NULL) {
+  if (!f) {
     fprintf(stderr, "json_parse: cannot open bench/data.json\n");
     return 1;
   }
   fseek(f, 0, SEEK_END);
   long size = ftell(f);
   fseek(f, 0, SEEK_SET);
+  if (size <= 0) {
+    fclose(f);
+    return 1;
+  }
   unsigned char* src = (unsigned char*)malloc((size_t)size);
-  if (src == NULL || fread(src, 1, (size_t)size, f) != (size_t)size) {
+  if (!src || fread(src, 1, (size_t)size, f) != (size_t)size) {
     fclose(f);
     return 1;
   }
   fclose(f);
 
   int ok = 0;
-  for (int r = 0; r < 20; ++r) {
+  for (int pass = 0; pass < 20; ++pass) {
     P p = {src, (size_t)size, 0};
-    if (parse_value(&p)) {
-      ++ok;
+    JVal root;
+    if (parse_value(&p, &root)) {
+      skip_ws(&p);
+      if (p.i == p.len) {
+        ++ok;
+      }
+      jval_free(&root);
     }
   }
-
-  printf("%d\n", ok);
   free(src);
+  printf("%d\n", ok);
   return 0;
 }

--- a/bench/lcg.c
+++ b/bench/lcg.c
@@ -1,8 +1,12 @@
-// benchmark-contract: lcg64-mmix;seed=1;iterations=100000000;mul=6364136223846793005;add=1442695040888963407
+// benchmark-contract: lcg64-mmix-xs33;seed=1;iterations=20000000;mul=6364136223846793005;add=1442695040888963407;xorshift=33
 //
-// lcg — 100M iterations of the MMIX linear congruential generator. One
-// 64-bit multiply and one add per step, each depending on the previous
-// result, so the loop cannot be folded into a closed form.
+// lcg — 20M iterations of the MMIX linear congruential generator with a
+// PCG-style xorshift mix folded into the state each step. A bare LCG is
+// an affine recurrence, and LLVM's unroller composes k affine steps
+// into one (x·aᵏ + cₖ), so a bare-LCG row measures the compiler's
+// composition factor rather than the chain. The xor of a shifted copy
+// breaks affinity: no number of steps composes, every step's multiply,
+// add, shift and xor stay on the critical path.
 //
 // Contract: the process prints exactly one line — the final state as a
 // signed 64-bit integer, matching the peers that have no unsigned type.
@@ -14,8 +18,9 @@ int main(void) {
   // is the same bit pattern read as int64, which is what NURL, Rust,
   // Python and Node print.
   uint64_t x = 1;
-  for (uint64_t i = 0; i < 100000000ULL; ++i) {
+  for (uint64_t i = 0; i < 20000000ULL; ++i) {
     x = x * 6364136223846793005ULL + 1442695040888963407ULL;
+    x ^= x >> 33;
   }
   printf("%lld\n", (long long)(int64_t)x);
   return 0;

--- a/bench/lcg.js
+++ b/bench/lcg.js
@@ -1,11 +1,16 @@
-// lcg — 100M iterations of the MMIX LCG via BigInt (Number's 53-bit
-// mantissa cannot hold the i64 intermediate without precision loss).
+// benchmark-contract: lcg64-mmix-xs33;seed=1;iterations=20000000;mul=6364136223846793005;add=1442695040888963407;xorshift=33
+//
+// lcg — 20M iterations of the MMIX LCG with a PCG-style xorshift mix
+// each step (see the C peer for why the mix is there), via BigInt
+// (Number's 53-bit mantissa cannot hold the i64 intermediate without
+// precision loss).
 let x = 1n;
 const A = 6364136223846793005n;
 const C = 1442695040888963407n;
 const MASK = (1n << 64n) - 1n;
 const SIGN = 1n << 63n;
-for (let i = 0; i < 100_000_000; i++) {
+for (let i = 0; i < 20_000_000; i++) {
     x = (x * A + C) & MASK;
+    x ^= x >> 33n;
 }
 console.log((x & SIGN) ? (x - (1n << 64n)).toString() : x.toString());

--- a/bench/lcg.nu
+++ b/bench/lcg.nu
@@ -1,14 +1,25 @@
-// lcg — 100 million iterations of a 64-bit linear congruential
-// generator (MMIX constants). Each step depends on the previous so
-// LLVM cannot fold it; output is the final state.
+// benchmark-contract: lcg64-mmix-xs33;seed=1;iterations=20000000;mul=6364136223846793005;add=1442695040888963407;xorshift=33
+//
+// lcg — 20M iterations of the MMIX linear congruential generator with a
+// PCG-style xorshift mix folded into the state each step. A bare LCG is
+// an affine recurrence, and LLVM's unroller composes k affine steps
+// into one (x·aᵏ + cₖ), so a bare-LCG row measures the compiler's
+// composition factor rather than the chain. The xor of a shifted copy
+// breaks affinity: no number of steps composes, every step's multiply,
+// add, shift and xor stay on the critical path.
+//
+// Contract: the process prints exactly one line — the final state as a
+// signed 64-bit integer, matching the peers that have no unsigned type.
 
 @ main → i {
-    : ~ i x 1
-    : ~ i k 0
-    ~ < k 100000000 {
+    : u64 iterations 20000000
+    : ~ u64 x 1
+    : ~ u64 k 0
+    ~ < k iterations {
         = x + * x 6364136223846793005 1442695040888963407
+        = x ^^ x >> x 33
         = k + k 1
     }
-    ( nurl_print_int x )
+    ( nurl_print_int # i x )
     ^ 0
 }

--- a/bench/lcg.py
+++ b/bench/lcg.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-# lcg — 100M iterations of the MMIX LCG. Python integers are bignum,
-# so we explicitly mask to i64 each step to match the i64-wrap
-# semantics every other language gets for free.
+# benchmark-contract: lcg64-mmix-xs33;seed=1;iterations=20000000;mul=6364136223846793005;add=1442695040888963407;xorshift=33
+#
+# lcg — 20M iterations of the MMIX LCG with a PCG-style xorshift mix
+# each step (see the C peer for why the mix is there). Python integers
+# are bignum, so we explicitly mask to 64 bits each step to match the
+# wrap semantics every other language gets for free.
 x = 1
 MASK = (1 << 64) - 1
 SIGN = 1 << 63
-for _ in range(100_000_000):
+for _ in range(20_000_000):
     x = (x * 6364136223846793005 + 1442695040888963407) & MASK
+    x ^= x >> 33
 # print signed i64 (matches NURL/Rust/Node output)
 print(x - (1 << 64) if x & SIGN else x)

--- a/bench/lcg.rs
+++ b/bench/lcg.rs
@@ -1,8 +1,15 @@
-// lcg — 100M iterations of the MMIX LCG, i64 wrap-around semantics.
+// benchmark-contract: lcg64-mmix-xs33;seed=1;iterations=20000000;mul=6364136223846793005;add=1442695040888963407;xorshift=33
+//
+// lcg — 20M iterations of the MMIX LCG with a PCG-style xorshift mix
+// each step (see the C peer for why the mix is there). Unsigned
+// arithmetic, printed as i64 to match the peers.
 fn main() {
-    let mut x: i64 = 1;
-    for _ in 0..100_000_000 {
-        x = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+    let mut x: u64 = 1;
+    for _ in 0..20_000_000u64 {
+        x = x
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        x ^= x >> 33;
     }
-    println!("{}", x);
+    println!("{}", x as i64);
 }

--- a/bench/manifest.tsv
+++ b/bench/manifest.tsv
@@ -12,8 +12,8 @@
 # and words are the held-out corpus for the generation-accuracy study in
 # genacc/ (their workloads are single short strings — they measure process
 # start-up, not a language), and http_server belongs to run_http.sh.
-lcg	100M-step 64-bit LCG	Loop-carried integer dependency; 64-bit wrap-around
-affine_mix	20M chained affine steps	Shift/add/mask chain over a 58-bit state, no multiply
+lcg	20M-step 64-bit LCG + xorshift	Loop-carried mul/add/shift/xor dependency the unroller cannot compose
+affine_mix	20M affine steps + xorshift	Shift/add/mask/xor chain over a 58-bit state, no multiply
 packet_classifier	25M unpredictable branches	A data-dependent 50/50 branch the predictor cannot learn
 ring_write	20M ring-buffer stores	Dependent store per iteration plus address computation
 histogram_bins	20M binned increments	Read-modify-write at a data-dependent index

--- a/stdlib/core/vec.nu
+++ b/stdlib/core/vec.nu
@@ -139,9 +139,19 @@
             ( nurl_poke ctl 0 # i fresh )
             ( nurl_poke ctl 2 new_cap )
         } {
-            : s fresh ( nurl_realloc cur bytes )
-            ( nurl_poke ctl 0 # i fresh )
-            ( nurl_poke ctl 2 new_cap )
+            ? == 0 # i cur {
+                // First growth: nurl_alloc, not realloc(NULL, n) — the
+                // runtime's small-allocation cache sits behind
+                // nurl_alloc/nurl_free, and a Vec's first buffer is the
+                // most recycled block shape there is.
+                : s fresh ( nurl_alloc bytes )
+                ( nurl_poke ctl 0 # i fresh )
+                ( nurl_poke ctl 2 new_cap )
+            } {
+                : s fresh ( nurl_realloc cur bytes )
+                ( nurl_poke ctl 0 # i fresh )
+                ( nurl_poke ctl 2 new_cap )
+            }
         }
     } {}
 }
@@ -203,7 +213,11 @@
 @ vec_push [A] ( Vec A ) v A x → v {
     : s ctl . v ctl
     : i len ( __vec_len_raw ctl )
-    ( __vec_grow [A] ctl + len 1 )
+    // Only call into __vec_grow when the buffer is actually full: the
+    // grow path is too big to inline, and paying a call per push showed
+    // up at ~6 % of a parse-heavy profile. The common push is then a
+    // load, a compare, a store and a length bump.
+    ? >= len ( __vec_cap_raw ctl ) { ( __vec_grow [A] ctl + len 1 ) } {}
     : *A data # *A ( nurl_peek ctl 0 )
     = . data len x
     ( nurl_poke ctl 1 + len 1 )

--- a/stdlib/ext/json.nu
+++ b/stdlib/ext/json.nu
@@ -234,9 +234,24 @@ $ `stdlib/core/vec.nu`
 // ── Recursive free ───────────────────────────────────────────────────
 //
 // Walks the tree and releases owned strings, then releases the Vec
-// buffers. Containers iterate via vec_free_with so each element gets
-// its own json_free. Caller passes the Json by value (handles inside
-// are pointers); after the call, the handle should not be reused.
+// buffers. Containers iterate over the raw element buffer and recurse
+// directly — a `vec_free_with` closure here would cost a closure
+// allocation per container and an indirect call per element, on what is
+// the second-hottest path of a parse-heavy program (right after the
+// parse that built the tree). Caller passes the Json by value (handles
+// inside are pointers); after the call, the handle should not be
+// reused.
+
+@ __json_free_vec ( Vec Json ) v → v {
+    : i len ( vec_len [Json] v )
+    : *Json buf ( vec_data [Json] v )
+    : ~ i k 0
+    ~ < k len {
+        ( json_free . buf k )
+        = k + k 1
+    }
+    ( vec_free [Json] v )
+}
 
 @ json_free Json j → v {
     ?? j {
@@ -244,14 +259,8 @@ $ `stdlib/core/vec.nu`
         JBool _ → {}
         JNum s → ( string_free s )
         JStr s → ( string_free s )
-        JArr v → {
-            : ( @ v Json ) drop \ Json e → v { ( json_free e ) }
-            ( vec_free_with [Json] v drop )
-        }
-        JObj v → {
-            : ( @ v Json ) drop \ Json e → v { ( json_free e ) }
-            ( vec_free_with [Json] v drop )
-        }
+        JArr v → ( __json_free_vec v )
+        JObj v → ( __json_free_vec v )
     }
 }
 
@@ -717,7 +726,10 @@ $ `stdlib/core/vec.nu`
 
 @ __jp_parse_array_body * JsonParser p → !Json JsonError {
     = . p pos + . p pos 1  // consume '['
-    : ( Vec Json ) elems ( vec_new [Json] )
+    // Start at capacity 8: a non-empty array almost always outgrows the
+    // default 0->4->8 doubling walk, and each step of that walk is a
+    // realloc on the parser's hottest path.
+    : ( Vec Json ) elems ( vec_with_cap [Json] 8 )
     ( __jp_skip_ws p )
     ? ( __jp_eof p ) {
         : ( @ v Json ) drop1 \ Json e → v { ( json_free e ) }
@@ -776,7 +788,9 @@ $ `stdlib/core/vec.nu`
 
 @ __jp_parse_object_body * JsonParser p → !Json JsonError {
     = . p pos + . p pos 1  // consume '{'
-    : ( Vec Json ) kvs ( vec_new [Json] )
+    // Capacity 8 = four key/value pairs before the first realloc; see
+    // the array body above.
+    : ( Vec Json ) kvs ( vec_with_cap [Json] 8 )
     ( __jp_skip_ws p )
     ? ( __jp_eof p ) {
         : ( @ v Json ) drop1 \ Json e → v { ( json_free e ) }

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -798,11 +798,183 @@ static unsigned long long nurl__actr_total(int freed) {
     return t;
 }
 
+/* ── §9a  Small-allocation cache ────────────────────────────────
+ *
+ * Allocation-heavy NURL code (every String and Vec buffer routes
+ * through nurl_alloc / nurl_free) spends most of its allocator time in
+ * libc's malloc/free slow paths: parsing bench/data.json is ~9 000
+ * nurl_alloc calls per pass and _int_malloc + _int_free alone were
+ * ~45 % of the whole parse. Nearly all of those blocks are small and
+ * short-lived, so freed blocks are recycled here instead of returned to
+ * libc: per-thread singly-linked freelists in six power-of-two size
+ * classes, 16..512 bytes. A freed block still carries its libc chunk
+ * (we never touch the malloc header), so the class is recovered from
+ * malloc_usable_size at free time and a cached block can always be
+ * handed back to libc later — realloc on a recycled block also keeps
+ * working unchanged.
+ *
+ *   - alloc: try the floor class of the request first (its head block
+ *     might be big enough — glibc's minimum 24-byte-usable chunk serves
+ *     most string buffers this way), else the next class up, whose
+ *     blocks are all guaranteed to fit. Miss → plain malloc.
+ *   - free: push into the floor class of the block's usable size,
+ *     unless that class already holds 1 MB — then give it to libc.
+ *   - the panic-unwind journal drains with raw free() and is unaffected;
+ *     nurl_free removes journal entries before recycling, same as
+ *     before.
+ *
+ * Per-thread heads mean no locking; a block may migrate threads through
+ * the cache, which is fine — it stays an ordinary libc chunk. The cache
+ * is compiled out under AddressSanitizer (recycling would blind ASan's
+ * use-after-free and leak checks) and on libcs with no usable-size
+ * query; NURL_ALLOC_CACHE=0 disables it at run time. */
+#if defined(__SANITIZE_ADDRESS__)
+#  define NURL__SC_ASAN 1
+#elif defined(__has_feature)
+#  if __has_feature(address_sanitizer)
+#    define NURL__SC_ASAN 1
+#  endif
+#endif
+#if !defined(NURL__SC_ASAN) && !defined(__wasi__) && \
+    (defined(__GLIBC__) || defined(__APPLE__) || defined(_WIN32) || defined(__linux__))
+#  define NURL__SC_ENABLED 1
+#  if defined(__APPLE__)
+#    include <malloc/malloc.h>
+#    define nurl__sc_usable(p) malloc_size(p)
+#  elif defined(_WIN32)
+#    include <malloc.h>
+#    define nurl__sc_usable(p) _msize(p)
+#  else
+#    include <malloc.h>
+#    define nurl__sc_usable(p) malloc_usable_size(p)
+#  endif
+/* A thread's cached blocks must go back to libc when the thread exits,
+ * or a thread-churning server strands up to the class budgets per
+ * exited thread. pthread_key destructors run in the exiting thread with
+ * its TLS intact, which is exactly the hook needed. MSVC-target clang
+ * has no <pthread.h> (see the §13 mutex shims) and no equivalent
+ * destructor hook here — the cache stays off there rather than leak. */
+#  ifdef _WIN32
+#    if defined(__has_include) && __has_include(<pthread.h>)
+#      include <pthread.h>   /* winpthreads (mingw-w64) */
+#    else
+#      undef NURL__SC_ENABLED
+#    endif
+#  else
+#    include <pthread.h>
+#  endif
+#endif
+
+#ifdef NURL__SC_ENABLED
+enum {
+    NURL__SC_MIN_SHIFT = 4,                    /* smallest class: 16 B  */
+    NURL__SC_MAX_SHIFT = 9,                    /* largest class:  512 B */
+    NURL__SC_CLASSES   = NURL__SC_MAX_SHIFT - NURL__SC_MIN_SHIFT + 1,
+    NURL__SC_CLASS_BUDGET_SHIFT = 20,          /* 1 MB cached per class */
+};
+static __thread void     *nurl__sc_head [NURL__SC_CLASSES];
+static __thread unsigned  nurl__sc_count[NURL__SC_CLASSES];
+static __thread int       nurl__sc_registered;
+static int nurl__sc_on = -1;   /* -1 unknown, 0 off, 1 on; benign race */
+
+static pthread_key_t  nurl__sc_key;
+static pthread_once_t nurl__sc_once = PTHREAD_ONCE_INIT;
+static void nurl__sc_thread_flush(void *unused) {
+    (void)unused;
+    for (int c = 0; c < NURL__SC_CLASSES; c++) {
+        void *p = nurl__sc_head[c];
+        while (p) { void *n = *(void**)p; free(p); p = n; }
+        nurl__sc_head[c]  = NULL;
+        nurl__sc_count[c] = 0;
+    }
+}
+static void nurl__sc_make_key(void) {
+    pthread_key_create(&nurl__sc_key, nurl__sc_thread_flush);
+}
+__attribute__((noinline, cold))
+static void nurl__sc_register(void) {
+    nurl__sc_registered = 1;
+    pthread_once(&nurl__sc_once, nurl__sc_make_key);
+    /* Any non-NULL value: the destructor only needs to fire. If the
+     * key failed to create this is a no-op and thread exit strands the
+     * cache — best effort, bounded by the class budgets. */
+    pthread_setspecific(nurl__sc_key, (void*)1);
+}
+
+__attribute__((noinline, cold))
+static int nurl__sc_init(void) {
+    const char *e = getenv("NURL_ALLOC_CACHE");
+    nurl__sc_on = !(e && e[0] == '0' && e[1] == '\0');
+    return nurl__sc_on;
+}
+static inline int nurl__sc_live(void) {
+    int on = nurl__sc_on;
+    return __builtin_expect(on >= 0, 1) ? on : nurl__sc_init();
+}
+/* Floor size class of n (clamped to class 0 below 16), or -1 above the
+ * largest class. */
+static inline int nurl__sc_floor_class(size_t n) {
+    if (n < (1u << (NURL__SC_MIN_SHIFT + 1))) return 0;
+    if (n > (1u << NURL__SC_MAX_SHIFT))       return -1;
+    return (63 - __builtin_clzll((unsigned long long)n)) - NURL__SC_MIN_SHIFT;
+}
+/* A cached block holds its freelist link in bytes [0,8) and its libc
+ * usable size in bytes [8,16) — every class block is ≥ 16 bytes, and
+ * caching the size means the alloc path never calls into libc's
+ * usable-size query (a PLT call that showed up at ~7 % of an
+ * allocation-heavy parse). */
+static inline void *nurl__sc_pop(size_t n) {
+    int c = nurl__sc_floor_class(n);
+    if (c < 0 || !nurl__sc_live()) return NULL;
+    void *p = nurl__sc_head[c];
+    /* The floor class holds blocks of usable size [2^k, 2^(k+1)) with
+     * n in the same range, so the head merely MIGHT fit — check its
+     * stored size. One class up every block fits by construction. */
+    if (p && ((size_t*)p)[1] >= n) {
+        nurl__sc_head[c] = *(void**)p;
+        nurl__sc_count[c]--;
+        return p;
+    }
+    if (++c < NURL__SC_CLASSES && (p = nurl__sc_head[c]) != NULL) {
+        nurl__sc_head[c] = *(void**)p;
+        nurl__sc_count[c]--;
+        return p;
+    }
+    return NULL;
+}
+static inline int nurl__sc_push(void *p) {
+    if (!nurl__sc_live()) return 0;
+    size_t u = nurl__sc_usable(p);
+    int c = nurl__sc_floor_class(u);
+    if (c < 0 || u < (1u << NURL__SC_MIN_SHIFT)) return 0;
+    if (nurl__sc_count[c] >=
+        (1u << (NURL__SC_CLASS_BUDGET_SHIFT - (c + NURL__SC_MIN_SHIFT)))) return 0;
+    if (__builtin_expect(!nurl__sc_registered, 0)) nurl__sc_register();
+    *(void**)p = nurl__sc_head[c];
+    ((size_t*)p)[1] = u;
+    nurl__sc_head[c] = p;
+    nurl__sc_count[c]++;
+    return 1;
+}
+#else
+static inline void *nurl__sc_pop(size_t n)  { (void)n; return NULL; }
+static inline int   nurl__sc_push(void *p)  { (void)p; return 0; }
+#endif
+
 /* OOM aborts inside the checked wrappers at the top of this file (see
  * "OOM is fatal, loudly") — malloc/calloc here are already the checked
  * forms via the file-wide macros. */
-void* nurl_alloc(long long bytes)              { nurl__actr_bump(&nurl__actr_slot()->alloc); return malloc((size_t)bytes); }
-void* nurl_zalloc(long long bytes)             { nurl__actr_bump(&nurl__actr_slot()->alloc); return calloc(1, (size_t)bytes); }
+void* nurl_alloc(long long bytes) {
+    nurl__actr_bump(&nurl__actr_slot()->alloc);
+    void *p = nurl__sc_pop((size_t)bytes);
+    return p ? p : malloc((size_t)bytes);
+}
+void* nurl_zalloc(long long bytes) {
+    nurl__actr_bump(&nurl__actr_slot()->alloc);
+    void *p = nurl__sc_pop((size_t)bytes);
+    if (p) { memset(p, 0, (size_t)bytes); return p; }
+    return calloc(1, (size_t)bytes);
+}
 long long nurl_alloc_count(void)               { return (long long)nurl__actr_total(0); }
 long long nurl_free_count(void)                { return (long long)nurl__actr_total(1); }
 void* nurl_realloc(void *ptr, long long bytes) { return realloc(ptr, (size_t)bytes); }
@@ -927,7 +1099,7 @@ static void nurl__jrnl_drain(long long mark) {
     nurl__jrnl_len = mark;
 }
 
-void  nurl_free(void *ptr)                     { if (!ptr) return; nurl__actr_bump(&nurl__actr_slot()->freed); if (nurl__jrnl_len) nurl__jrnl_remove(ptr); free(ptr); }
+void  nurl_free(void *ptr)                     { if (!ptr) return; nurl__actr_bump(&nurl__actr_slot()->freed); if (nurl__jrnl_len) nurl__jrnl_remove(ptr); if (!nurl__sc_push(ptr)) free(ptr); }
 void  nurl_memcpy(void *dst, const void *src, long long bytes) {
     memcpy(dst, src, (size_t)bytes);
 }


### PR DESCRIPTION
## What

An audit of whether `bench/bench.sh` results are genuine, prompted by the implausible `lcg` row (3.7 ms for 100M serially-dependent 64-bit multiplies ≈ 0.18 cycles/step — physically impossible for an honest chain).

### Findings

- **lcg**: LLVM composes k affine LCG steps into one (`x·aᵏ + cₖ`). The NURL binary's LTO pipeline composed **k=64**, C's plain `-O2` only **k=8** — the 5× "win" was a pass-pipeline artifact that evaporates the moment C gets `-flto`. The source comment "LLVM cannot fold it" was false.
- **affine_mix**: same composition (the mask makes shift-add affine mod 2^58).
- **json_parse**: the blurb says "allocator pressure, string handling" and Python/Node/Rust/NURL all build an owned DOM — but the C peer only *validated*, allocating nothing. Its 2.9 ms was a measurement of different work.
- All other rows check out: same algorithm, honest codegen differences (verified against disassembly and interleaved re-timings).

### Fixes

1. **lcg / affine_mix** get a PCG-style xorshift mix step in all five languages — the recurrence is no longer affine, so no compiler can compose it and the row measures the dependency chain it claims to. lcg drops 100M → 20M iterations to keep cell times in line. All five implementations agree on the new outputs (gated by bench.sh, verified by hand).
2. **json_parse.c** now mirrors the Rust peer: owned strings, growable arrays, full tree free per parse.
3. Genuine NURL-side speedups, none benchmark-specific:
   - **runtime**: per-thread size-class freelist cache (16–512 B) behind `nurl_alloc`/`nurl_zalloc`/`nurl_free`. Blocks stay ordinary malloc chunks; 1 MB/class bound; flushed on thread exit via pthread_key destructor; compiled out under ASan and MSVC-target Windows; `NURL_ALLOC_CACHE=0` kill switch.
   - **core/vec**: `vec_push` only calls `__vec_grow` when full; first Vec buffer through `nurl_alloc` (cacheable) instead of `realloc(NULL, n)`.
   - **ext/json**: containers start at capacity 8; `json_free` walks the raw buffer instead of a closure per container + indirect call per element.

### Results (local, interleaved best-of-N; CI runner is canonical)

| row | before | after |
|---|---|---|
| `lcg` | NURL 3.7 / C 17.4 (artifact) | NURL 39.8 / C 41.3 / Rust 40.7 — honest tie |
| `affine_mix` | NURL 14.3 / C 18.9 | NURL 34.5 / C 40.3 / Rust 41.9 — honest win (shorter dependent chain, same flags) |
| `json_parse` | NURL 10.7 / C 2.9 (unequal work) | NURL 8.2 / C 8.5 / Rust 13.2 — honest win, equal work |

Full compiler suite passes (558/558) with the cache on, twice (mid-stack and final runtime). The committed `bench/RESULTS.md` / `results/latest.json` are refreshed by the bench workflow as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG