### PR TITLE
compiler: refresh the bootstrap snapshot

### DIFF
--- a/compiler/nurlc_lastgood.ll
+++ b/compiler/nurlc_lastgood.ll
@@ -35300,15 +35300,17 @@ entry:
   %r10 = alloca i64
   %r19 = alloca i8*
   %r22 = alloca i8*
-  %r23 = alloca i64
-  %r24 = alloca i64
-  %r29 = alloca i64
-  %r39 = alloca i1
-  %r46 = alloca i64
-  %r47 = alloca i1
-  %r69 = alloca i8
-  %r99 = alloca i8
-  %r117 = alloca i8
+  %r24 = alloca i8*
+  %r26 = alloca i8*
+  %r27 = alloca i64
+  %r28 = alloca i64
+  %r33 = alloca i64
+  %r46 = alloca i1
+  %r53 = alloca i64
+  %r54 = alloca i1
+  %r82 = alloca i8
+  %r112 = alloca i8
+  %r130 = alloca i8
   %r1 = call i64 @nurl_str_len(i8* %state)
   store i64 %r1, i64* %r2
   %r3 = call i64 @nurl_str_len(i8* %name)
@@ -35332,86 +35334,99 @@ entry:
   %r20 = load i8*, i8** %r19
   %r21 = bitcast i8* %r20 to i8*
   store i8* %r21, i8** %r22
-  store i64 0, i64* %r23
-  store i64 0, i64* %r24
+  %r23 = bitcast i8* %state to i8*
+  store i8* %r23, i8** %r24
+  %r25 = bitcast i8* %name to i8*
+  store i8* %r25, i8** %r26
+  store i64 0, i64* %r27
+  store i64 0, i64* %r28
   br label %loop_check_1
 loop_check_1:
-  %r25 = load i64, i64* %r24
-  %r26 = load i64, i64* %r2
-  %r27 = icmp slt i64 %r25, %r26
-  br i1 %r27, label %loop_body_2, label %loop_exit_3
+  %r29 = load i64, i64* %r28
+  %r30 = load i64, i64* %r2
+  %r31 = icmp slt i64 %r29, %r30
+  br i1 %r31, label %loop_body_2, label %loop_exit_3
 loop_body_2:
-  %r28 = load i64, i64* %r24
-  store i64 %r28, i64* %r29
+  %r32 = load i64, i64* %r28
+  store i64 %r32, i64* %r33
   br label %loop_check_4
 loop_check_4:
-  %r30 = load i64, i64* %r29
-  %r31 = load i64, i64* %r2
-  %r32 = icmp slt i64 %r30, %r31
-  br i1 %r32, label %and_right_7, label %and_end_8
+  %r34 = load i64, i64* %r33
+  %r35 = load i64, i64* %r2
+  %r36 = icmp slt i64 %r34, %r35
+  br i1 %r36, label %and_right_7, label %and_end_8
 and_right_7:
-  %r33 = load i64, i64* %r29
-  %r34 = call i64 @nurl_str_get(i8* %state, i64 %r33)
-  %r35 = icmp ne i64 %r34, 32
+  %r37 = load i8*, i8** %r24
+  %r38 = load i64, i64* %r33
+  %r39 = getelementptr i8, i8* %r37, i64 %r38
+  %r40 = load i8, i8* %r39
+  %r41 = zext i8 %r40 to i64
+  %r42 = icmp ne i64 %r41, 32
   br label %and_end_8
 and_end_8:
-  %r36 = phi i1 [ 0, %loop_check_4 ], [ %r35, %and_right_7 ]
-  br i1 %r36, label %loop_body_5, label %loop_exit_6
+  %r43 = phi i1 [ 0, %loop_check_4 ], [ %r42, %and_right_7 ]
+  br i1 %r43, label %loop_body_5, label %loop_exit_6
 loop_body_5:
-  %r37 = load i64, i64* %r29
-  %r38 = add i64 %r37, 1
-  store i64 %r38, i64* %r29
+  %r44 = load i64, i64* %r33
+  %r45 = add i64 %r44, 1
+  store i64 %r45, i64* %r33
   br label %loop_check_4
 loop_exit_6:
-  store i1 1, i1* %r39
-  %r40 = load i64, i64* %r29
-  %r41 = load i64, i64* %r24
-  %r42 = sub i64 %r40, %r41
-  %r43 = sub i64 %r42, 2
-  %r44 = load i64, i64* %r4
-  %r45 = icmp eq i64 %r43, %r44
-  br i1 %r45, label %then_9, label %else_10
+  store i1 1, i1* %r46
+  %r47 = load i64, i64* %r33
+  %r48 = load i64, i64* %r28
+  %r49 = sub i64 %r47, %r48
+  %r50 = sub i64 %r49, 2
+  %r51 = load i64, i64* %r4
+  %r52 = icmp eq i64 %r50, %r51
+  br i1 %r52, label %then_9, label %else_10
 then_9:
-  store i64 0, i64* %r46
-  store i1 1, i1* %r47
+  store i64 0, i64* %r53
+  store i1 1, i1* %r54
   br label %loop_check_12
 loop_check_12:
-  %r48 = load i1, i1* %r47
-  br i1 %r48, label %and_right_15, label %and_end_16
+  %r55 = load i1, i1* %r54
+  br i1 %r55, label %and_right_15, label %and_end_16
 and_right_15:
-  %r49 = load i64, i64* %r46
-  %r50 = load i64, i64* %r4
-  %r51 = icmp slt i64 %r49, %r50
+  %r56 = load i64, i64* %r53
+  %r57 = load i64, i64* %r4
+  %r58 = icmp slt i64 %r56, %r57
   br label %and_end_16
 and_end_16:
-  %r52 = phi i1 [ 0, %loop_check_12 ], [ %r51, %and_right_15 ]
-  br i1 %r52, label %loop_body_13, label %loop_exit_14
+  %r59 = phi i1 [ 0, %loop_check_12 ], [ %r58, %and_right_15 ]
+  br i1 %r59, label %loop_body_13, label %loop_exit_14
 loop_body_13:
-  %r53 = load i64, i64* %r24
-  %r54 = load i64, i64* %r46
-  %r55 = add i64 %r53, %r54
-  %r56 = call i64 @nurl_str_get(i8* %state, i64 %r55)
-  %r57 = load i64, i64* %r46
-  %r58 = call i64 @nurl_str_get(i8* %name, i64 %r57)
-  %r59 = icmp ne i64 %r56, %r58
-  br i1 %r59, label %then_17, label %else_18
+  %r60 = load i8*, i8** %r24
+  %r61 = load i64, i64* %r28
+  %r62 = load i64, i64* %r53
+  %r63 = add i64 %r61, %r62
+  %r64 = getelementptr i8, i8* %r60, i64 %r63
+  %r65 = load i8, i8* %r64
+  %r66 = zext i8 %r65 to i64
+  %r67 = load i8*, i8** %r26
+  %r68 = load i64, i64* %r53
+  %r69 = getelementptr i8, i8* %r67, i64 %r68
+  %r70 = load i8, i8* %r69
+  %r71 = zext i8 %r70 to i64
+  %r72 = icmp ne i64 %r66, %r71
+  br i1 %r72, label %then_17, label %else_18
 then_17:
-  store i1 0, i1* %r47
-  %r60 = zext i1 0 to i64
+  store i1 0, i1* %r54
+  %r73 = zext i1 0 to i64
   br label %end_19
 else_18:
   br label %end_19
 end_19:
-  %r61 = load i64, i64* %r46
-  %r62 = add i64 %r61, 1
-  store i64 %r62, i64* %r46
+  %r74 = load i64, i64* %r53
+  %r75 = add i64 %r74, 1
+  store i64 %r75, i64* %r53
   br label %loop_check_12
 loop_exit_14:
-  %r63 = load i1, i1* %r47
-  br i1 %r63, label %then_20, label %else_21
+  %r76 = load i1, i1* %r54
+  br i1 %r76, label %then_20, label %else_21
 then_20:
-  store i1 0, i1* %r39
-  %r64 = zext i1 0 to i64
+  store i1 0, i1* %r46
+  %r77 = zext i1 0 to i64
   br label %end_22
 else_21:
   br label %end_22
@@ -35420,107 +35435,107 @@ end_22:
 else_10:
   br label %end_11
 end_11:
-  %r65 = load i1, i1* %r39
-  br i1 %r65, label %then_23, label %else_24
+  %r78 = load i1, i1* %r46
+  br i1 %r78, label %then_23, label %else_24
 then_23:
-  %r66 = load i64, i64* %r23
-  %r67 = icmp sgt i64 %r66, 0
-  br i1 %r67, label %then_26, label %else_27
+  %r79 = load i64, i64* %r27
+  %r80 = icmp sgt i64 %r79, 0
+  br i1 %r80, label %then_26, label %else_27
 then_26:
-  %r68 = trunc i64 32 to i8
-  store i8 %r68, i8* %r69
-  %r70 = load i8*, i8** %r22
-  %r71 = load i64, i64* %r23
-  %r72 = load i8, i8* %r69
-  %r73 = getelementptr i8, i8* %r70, i64 %r71
-  store i8 %r72, i8* %r73
-  %r74 = load i64, i64* %r23
-  %r75 = add i64 %r74, 1
-  store i64 %r75, i64* %r23
+  %r81 = trunc i64 32 to i8
+  store i8 %r81, i8* %r82
+  %r83 = load i8*, i8** %r22
+  %r84 = load i64, i64* %r27
+  %r85 = load i8, i8* %r82
+  %r86 = getelementptr i8, i8* %r83, i64 %r84
+  store i8 %r85, i8* %r86
+  %r87 = load i64, i64* %r27
+  %r88 = add i64 %r87, 1
+  store i64 %r88, i64* %r27
   br label %end_28
 else_27:
   br label %end_28
 end_28:
-  %r76 = load i8*, i8** %r19
-  %r77 = ptrtoint i8* %r76 to i64
-  %r78 = load i64, i64* %r23
-  %r79 = add i64 %r77, %r78
-  %r80 = inttoptr i64 %r79 to i8*
-  %r81 = ptrtoint i8* %state to i64
-  %r82 = load i64, i64* %r24
-  %r83 = add i64 %r81, %r82
-  %r84 = inttoptr i64 %r83 to i8*
-  %r85 = load i64, i64* %r29
-  %r86 = load i64, i64* %r24
-  %r87 = sub i64 %r85, %r86
-  %r88 = call i8* @memcpy(i8* %r80, i8* %r84, i64 %r87)
-  %r89 = load i64, i64* %r23
-  %r90 = load i64, i64* %r29
-  %r91 = load i64, i64* %r24
-  %r92 = sub i64 %r90, %r91
-  %r93 = add i64 %r89, %r92
-  store i64 %r93, i64* %r23
+  %r89 = load i8*, i8** %r19
+  %r90 = ptrtoint i8* %r89 to i64
+  %r91 = load i64, i64* %r27
+  %r92 = add i64 %r90, %r91
+  %r93 = inttoptr i64 %r92 to i8*
+  %r94 = ptrtoint i8* %state to i64
+  %r95 = load i64, i64* %r28
+  %r96 = add i64 %r94, %r95
+  %r97 = inttoptr i64 %r96 to i8*
+  %r98 = load i64, i64* %r33
+  %r99 = load i64, i64* %r28
+  %r100 = sub i64 %r98, %r99
+  %r101 = call i8* @memcpy(i8* %r93, i8* %r97, i64 %r100)
+  %r102 = load i64, i64* %r27
+  %r103 = load i64, i64* %r33
+  %r104 = load i64, i64* %r28
+  %r105 = sub i64 %r103, %r104
+  %r106 = add i64 %r102, %r105
+  store i64 %r106, i64* %r27
   br label %end_25
 else_24:
   br label %end_25
 end_25:
-  %r94 = load i64, i64* %r29
-  %r95 = add i64 %r94, 1
-  store i64 %r95, i64* %r24
+  %r107 = load i64, i64* %r33
+  %r108 = add i64 %r107, 1
+  store i64 %r108, i64* %r28
   br label %loop_check_1
 loop_exit_3:
-  %r96 = load i64, i64* %r23
-  %r97 = icmp sgt i64 %r96, 0
-  br i1 %r97, label %then_29, label %else_30
+  %r109 = load i64, i64* %r27
+  %r110 = icmp sgt i64 %r109, 0
+  br i1 %r110, label %then_29, label %else_30
 then_29:
-  %r98 = trunc i64 32 to i8
-  store i8 %r98, i8* %r99
-  %r100 = load i8*, i8** %r22
-  %r101 = load i64, i64* %r23
-  %r102 = load i8, i8* %r99
-  %r103 = getelementptr i8, i8* %r100, i64 %r101
-  store i8 %r102, i8* %r103
-  %r104 = load i64, i64* %r23
-  %r105 = add i64 %r104, 1
-  store i64 %r105, i64* %r23
+  %r111 = trunc i64 32 to i8
+  store i8 %r111, i8* %r112
+  %r113 = load i8*, i8** %r22
+  %r114 = load i64, i64* %r27
+  %r115 = load i8, i8* %r112
+  %r116 = getelementptr i8, i8* %r113, i64 %r114
+  store i8 %r115, i8* %r116
+  %r117 = load i64, i64* %r27
+  %r118 = add i64 %r117, 1
+  store i64 %r118, i64* %r27
   br label %end_31
 else_30:
   br label %end_31
 end_31:
-  %r106 = load i8*, i8** %r19
-  %r107 = ptrtoint i8* %r106 to i64
-  %r108 = load i64, i64* %r23
-  %r109 = add i64 %r107, %r108
-  %r110 = inttoptr i64 %r109 to i8*
-  %r111 = load i64, i64* %r4
-  %r112 = call i8* @memcpy(i8* %r110, i8* %name, i64 %r111)
-  %r113 = load i64, i64* %r23
-  %r114 = load i64, i64* %r4
-  %r115 = add i64 %r113, %r114
-  store i64 %r115, i64* %r23
-  %r116 = trunc i64 61 to i8
-  store i8 %r116, i8* %r117
-  %r118 = load i8*, i8** %r22
-  %r119 = load i64, i64* %r23
-  %r120 = load i8, i8* %r117
-  %r121 = getelementptr i8, i8* %r118, i64 %r119
-  store i8 %r120, i8* %r121
-  %r122 = load i64, i64* %r23
-  %r123 = add i64 %r122, 1
-  store i64 %r123, i64* %r23
-  %r124 = load i8*, i8** %r19
-  %r125 = ptrtoint i8* %r124 to i64
-  %r126 = load i64, i64* %r23
-  %r127 = add i64 %r125, %r126
-  %r128 = inttoptr i64 %r127 to i8*
-  %r129 = load i8*, i8** %r6
-  %r130 = load i64, i64* %r10
-  %r131 = add i64 %r130, 1
-  %r132 = call i8* @memcpy(i8* %r128, i8* %r129, i64 %r131)
-  %r133 = load i8*, i8** %r19
-  %r134 = load i8*, i8** %r6
-  call void @nurl_free(i8* %r134)
-  ret i8* %r133
+  %r119 = load i8*, i8** %r19
+  %r120 = ptrtoint i8* %r119 to i64
+  %r121 = load i64, i64* %r27
+  %r122 = add i64 %r120, %r121
+  %r123 = inttoptr i64 %r122 to i8*
+  %r124 = load i64, i64* %r4
+  %r125 = call i8* @memcpy(i8* %r123, i8* %name, i64 %r124)
+  %r126 = load i64, i64* %r27
+  %r127 = load i64, i64* %r4
+  %r128 = add i64 %r126, %r127
+  store i64 %r128, i64* %r27
+  %r129 = trunc i64 61 to i8
+  store i8 %r129, i8* %r130
+  %r131 = load i8*, i8** %r22
+  %r132 = load i64, i64* %r27
+  %r133 = load i8, i8* %r130
+  %r134 = getelementptr i8, i8* %r131, i64 %r132
+  store i8 %r133, i8* %r134
+  %r135 = load i64, i64* %r27
+  %r136 = add i64 %r135, 1
+  store i64 %r136, i64* %r27
+  %r137 = load i8*, i8** %r19
+  %r138 = ptrtoint i8* %r137 to i64
+  %r139 = load i64, i64* %r27
+  %r140 = add i64 %r138, %r139
+  %r141 = inttoptr i64 %r140 to i8*
+  %r142 = load i8*, i8** %r6
+  %r143 = load i64, i64* %r10
+  %r144 = add i64 %r143, 1
+  %r145 = call i8* @memcpy(i8* %r141, i8* %r142, i64 %r144)
+  %r146 = load i8*, i8** %r19
+  %r147 = load i8*, i8** %r6
+  call void @nurl_free(i8* %r147)
+  ret i8* %r146
 }
 
 define i8* @bck_join_state(i8* %a, i8* %b) {
@@ -35530,20 +35545,22 @@ entry:
   %r4 = alloca i64
   %r11 = alloca i8*
   %r14 = alloca i8*
-  %r15 = alloca i64
-  %r16 = alloca i64
-  %r21 = alloca i64
-  %r35 = alloca i64
-  %r44 = alloca i64
-  %r48 = alloca i8
-  %r74 = alloca i8
-  %r83 = alloca i64
-  %r88 = alloca i64
-  %r102 = alloca i64
-  %r114 = alloca i64
-  %r118 = alloca i8
-  %r144 = alloca i8
-  %r154 = alloca i8
+  %r16 = alloca i8*
+  %r18 = alloca i8*
+  %r19 = alloca i64
+  %r20 = alloca i64
+  %r25 = alloca i64
+  %r42 = alloca i64
+  %r54 = alloca i64
+  %r58 = alloca i8
+  %r84 = alloca i8
+  %r93 = alloca i64
+  %r98 = alloca i64
+  %r115 = alloca i64
+  %r130 = alloca i64
+  %r134 = alloca i8
+  %r160 = alloca i8
+  %r170 = alloca i8
   %r1 = call i64 @nurl_str_len(i8* %a)
   store i64 %r1, i64* %r2
   %r3 = call i64 @nurl_str_len(i8* %b)
@@ -35558,217 +35575,233 @@ entry:
   %r12 = load i8*, i8** %r11
   %r13 = bitcast i8* %r12 to i8*
   store i8* %r13, i8** %r14
-  store i64 0, i64* %r15
-  store i64 0, i64* %r16
+  %r15 = bitcast i8* %a to i8*
+  store i8* %r15, i8** %r16
+  %r17 = bitcast i8* %b to i8*
+  store i8* %r17, i8** %r18
+  store i64 0, i64* %r19
+  store i64 0, i64* %r20
   br label %loop_check_1
 loop_check_1:
-  %r17 = load i64, i64* %r16
-  %r18 = load i64, i64* %r2
-  %r19 = icmp slt i64 %r17, %r18
-  br i1 %r19, label %loop_body_2, label %loop_exit_3
+  %r21 = load i64, i64* %r20
+  %r22 = load i64, i64* %r2
+  %r23 = icmp slt i64 %r21, %r22
+  br i1 %r23, label %loop_body_2, label %loop_exit_3
 loop_body_2:
-  %r20 = load i64, i64* %r16
-  store i64 %r20, i64* %r21
+  %r24 = load i64, i64* %r20
+  store i64 %r24, i64* %r25
   br label %loop_check_4
 loop_check_4:
-  %r22 = load i64, i64* %r21
-  %r23 = load i64, i64* %r2
-  %r24 = icmp slt i64 %r22, %r23
-  br i1 %r24, label %and_right_7, label %and_end_8
+  %r26 = load i64, i64* %r25
+  %r27 = load i64, i64* %r2
+  %r28 = icmp slt i64 %r26, %r27
+  br i1 %r28, label %and_right_7, label %and_end_8
 and_right_7:
-  %r25 = load i64, i64* %r21
-  %r26 = call i64 @nurl_str_get(i8* %a, i64 %r25)
-  %r27 = icmp ne i64 %r26, 32
+  %r29 = load i8*, i8** %r16
+  %r30 = load i64, i64* %r25
+  %r31 = getelementptr i8, i8* %r29, i64 %r30
+  %r32 = load i8, i8* %r31
+  %r33 = zext i8 %r32 to i64
+  %r34 = icmp ne i64 %r33, 32
   br label %and_end_8
 and_end_8:
-  %r28 = phi i1 [ 0, %loop_check_4 ], [ %r27, %and_right_7 ]
-  br i1 %r28, label %loop_body_5, label %loop_exit_6
+  %r35 = phi i1 [ 0, %loop_check_4 ], [ %r34, %and_right_7 ]
+  br i1 %r35, label %loop_body_5, label %loop_exit_6
 loop_body_5:
-  %r29 = load i64, i64* %r21
-  %r30 = add i64 %r29, 1
-  store i64 %r30, i64* %r21
+  %r36 = load i64, i64* %r25
+  %r37 = add i64 %r36, 1
+  store i64 %r37, i64* %r25
   br label %loop_check_4
 loop_exit_6:
-  %r31 = load i64, i64* %r21
-  %r32 = load i64, i64* %r16
-  %r33 = sub i64 %r31, %r32
-  %r34 = sub i64 %r33, 2
-  store i64 %r34, i64* %r35
-  %r36 = load i64, i64* %r21
-  %r37 = sub i64 %r36, 1
-  %r38 = call i64 @nurl_str_get(i8* %a, i64 %r37)
-  %r39 = sub i64 %r38, 48
-  %r40 = load i64, i64* %r16
-  %r41 = load i64, i64* %r35
-  %r42 = call i64 @__bck_st_get_at__fp1(i8* %b, i8* %a, i64 %r40, i64 %r41)
-  %r43 = call i64 @bck_join(i64 %r39, i64 %r42)
-  store i64 %r43, i64* %r44
-  %r45 = load i64, i64* %r15
-  %r46 = icmp sgt i64 %r45, 0
-  br i1 %r46, label %then_9, label %else_10
+  %r38 = load i64, i64* %r25
+  %r39 = load i64, i64* %r20
+  %r40 = sub i64 %r38, %r39
+  %r41 = sub i64 %r40, 2
+  store i64 %r41, i64* %r42
+  %r43 = load i8*, i8** %r16
+  %r44 = load i64, i64* %r25
+  %r45 = sub i64 %r44, 1
+  %r46 = getelementptr i8, i8* %r43, i64 %r45
+  %r47 = load i8, i8* %r46
+  %r48 = zext i8 %r47 to i64
+  %r49 = sub i64 %r48, 48
+  %r50 = load i64, i64* %r20
+  %r51 = load i64, i64* %r42
+  %r52 = call i64 @__bck_st_get_at__fp1(i8* %b, i8* %a, i64 %r50, i64 %r51)
+  %r53 = call i64 @bck_join(i64 %r49, i64 %r52)
+  store i64 %r53, i64* %r54
+  %r55 = load i64, i64* %r19
+  %r56 = icmp sgt i64 %r55, 0
+  br i1 %r56, label %then_9, label %else_10
 then_9:
-  %r47 = trunc i64 32 to i8
-  store i8 %r47, i8* %r48
-  %r49 = load i8*, i8** %r14
-  %r50 = load i64, i64* %r15
-  %r51 = load i8, i8* %r48
-  %r52 = getelementptr i8, i8* %r49, i64 %r50
-  store i8 %r51, i8* %r52
-  %r53 = load i64, i64* %r15
-  %r54 = add i64 %r53, 1
-  store i64 %r54, i64* %r15
+  %r57 = trunc i64 32 to i8
+  store i8 %r57, i8* %r58
+  %r59 = load i8*, i8** %r14
+  %r60 = load i64, i64* %r19
+  %r61 = load i8, i8* %r58
+  %r62 = getelementptr i8, i8* %r59, i64 %r60
+  store i8 %r61, i8* %r62
+  %r63 = load i64, i64* %r19
+  %r64 = add i64 %r63, 1
+  store i64 %r64, i64* %r19
   br label %end_11
 else_10:
   br label %end_11
 end_11:
-  %r55 = load i8*, i8** %r11
-  %r56 = ptrtoint i8* %r55 to i64
-  %r57 = load i64, i64* %r15
-  %r58 = add i64 %r56, %r57
-  %r59 = inttoptr i64 %r58 to i8*
-  %r60 = ptrtoint i8* %a to i64
-  %r61 = load i64, i64* %r16
-  %r62 = add i64 %r60, %r61
-  %r63 = inttoptr i64 %r62 to i8*
-  %r64 = load i64, i64* %r35
-  %r65 = add i64 %r64, 1
-  %r66 = call i8* @memcpy(i8* %r59, i8* %r63, i64 %r65)
-  %r67 = load i64, i64* %r15
-  %r68 = load i64, i64* %r35
-  %r69 = add i64 %r68, 1
-  %r70 = add i64 %r67, %r69
-  store i64 %r70, i64* %r15
-  %r71 = load i64, i64* %r44
-  %r72 = add i64 48, %r71
-  %r73 = trunc i64 %r72 to i8
-  store i8 %r73, i8* %r74
-  %r75 = load i8*, i8** %r14
-  %r76 = load i64, i64* %r15
-  %r77 = load i8, i8* %r74
-  %r78 = getelementptr i8, i8* %r75, i64 %r76
-  store i8 %r77, i8* %r78
-  %r79 = load i64, i64* %r15
-  %r80 = add i64 %r79, 1
-  store i64 %r80, i64* %r15
-  %r81 = load i64, i64* %r21
-  %r82 = add i64 %r81, 1
-  store i64 %r82, i64* %r16
+  %r65 = load i8*, i8** %r11
+  %r66 = ptrtoint i8* %r65 to i64
+  %r67 = load i64, i64* %r19
+  %r68 = add i64 %r66, %r67
+  %r69 = inttoptr i64 %r68 to i8*
+  %r70 = ptrtoint i8* %a to i64
+  %r71 = load i64, i64* %r20
+  %r72 = add i64 %r70, %r71
+  %r73 = inttoptr i64 %r72 to i8*
+  %r74 = load i64, i64* %r42
+  %r75 = add i64 %r74, 1
+  %r76 = call i8* @memcpy(i8* %r69, i8* %r73, i64 %r75)
+  %r77 = load i64, i64* %r19
+  %r78 = load i64, i64* %r42
+  %r79 = add i64 %r78, 1
+  %r80 = add i64 %r77, %r79
+  store i64 %r80, i64* %r19
+  %r81 = load i64, i64* %r54
+  %r82 = add i64 48, %r81
+  %r83 = trunc i64 %r82 to i8
+  store i8 %r83, i8* %r84
+  %r85 = load i8*, i8** %r14
+  %r86 = load i64, i64* %r19
+  %r87 = load i8, i8* %r84
+  %r88 = getelementptr i8, i8* %r85, i64 %r86
+  store i8 %r87, i8* %r88
+  %r89 = load i64, i64* %r19
+  %r90 = add i64 %r89, 1
+  store i64 %r90, i64* %r19
+  %r91 = load i64, i64* %r25
+  %r92 = add i64 %r91, 1
+  store i64 %r92, i64* %r20
   br label %loop_check_1
 loop_exit_3:
-  store i64 0, i64* %r83
+  store i64 0, i64* %r93
   br label %loop_check_12
 loop_check_12:
-  %r84 = load i64, i64* %r83
-  %r85 = load i64, i64* %r4
-  %r86 = icmp slt i64 %r84, %r85
-  br i1 %r86, label %loop_body_13, label %loop_exit_14
+  %r94 = load i64, i64* %r93
+  %r95 = load i64, i64* %r4
+  %r96 = icmp slt i64 %r94, %r95
+  br i1 %r96, label %loop_body_13, label %loop_exit_14
 loop_body_13:
-  %r87 = load i64, i64* %r83
-  store i64 %r87, i64* %r88
+  %r97 = load i64, i64* %r93
+  store i64 %r97, i64* %r98
   br label %loop_check_15
 loop_check_15:
-  %r89 = load i64, i64* %r88
-  %r90 = load i64, i64* %r4
-  %r91 = icmp slt i64 %r89, %r90
-  br i1 %r91, label %and_right_18, label %and_end_19
+  %r99 = load i64, i64* %r98
+  %r100 = load i64, i64* %r4
+  %r101 = icmp slt i64 %r99, %r100
+  br i1 %r101, label %and_right_18, label %and_end_19
 and_right_18:
-  %r92 = load i64, i64* %r88
-  %r93 = call i64 @nurl_str_get(i8* %b, i64 %r92)
-  %r94 = icmp ne i64 %r93, 32
+  %r102 = load i8*, i8** %r18
+  %r103 = load i64, i64* %r98
+  %r104 = getelementptr i8, i8* %r102, i64 %r103
+  %r105 = load i8, i8* %r104
+  %r106 = zext i8 %r105 to i64
+  %r107 = icmp ne i64 %r106, 32
   br label %and_end_19
 and_end_19:
-  %r95 = phi i1 [ 0, %loop_check_15 ], [ %r94, %and_right_18 ]
-  br i1 %r95, label %loop_body_16, label %loop_exit_17
+  %r108 = phi i1 [ 0, %loop_check_15 ], [ %r107, %and_right_18 ]
+  br i1 %r108, label %loop_body_16, label %loop_exit_17
 loop_body_16:
-  %r96 = load i64, i64* %r88
-  %r97 = add i64 %r96, 1
-  store i64 %r97, i64* %r88
+  %r109 = load i64, i64* %r98
+  %r110 = add i64 %r109, 1
+  store i64 %r110, i64* %r98
   br label %loop_check_15
 loop_exit_17:
-  %r98 = load i64, i64* %r88
-  %r99 = load i64, i64* %r83
-  %r100 = sub i64 %r98, %r99
-  %r101 = sub i64 %r100, 2
-  store i64 %r101, i64* %r102
-  %r103 = load i64, i64* @BCK_UNINIT
-  %r104 = load i64, i64* %r83
-  %r105 = load i64, i64* %r102
-  %r106 = call i64 @__bck_st_get_at__fp1(i8* %a, i8* %b, i64 %r104, i64 %r105)
-  %r107 = icmp eq i64 %r103, %r106
-  br i1 %r107, label %then_20, label %else_21
+  %r111 = load i64, i64* %r98
+  %r112 = load i64, i64* %r93
+  %r113 = sub i64 %r111, %r112
+  %r114 = sub i64 %r113, 2
+  store i64 %r114, i64* %r115
+  %r116 = load i64, i64* @BCK_UNINIT
+  %r117 = load i64, i64* %r93
+  %r118 = load i64, i64* %r115
+  %r119 = call i64 @__bck_st_get_at__fp1(i8* %a, i8* %b, i64 %r117, i64 %r118)
+  %r120 = icmp eq i64 %r116, %r119
+  br i1 %r120, label %then_20, label %else_21
 then_20:
-  %r108 = load i64, i64* @BCK_UNINIT
-  %r109 = load i64, i64* %r88
-  %r110 = sub i64 %r109, 1
-  %r111 = call i64 @nurl_str_get(i8* %b, i64 %r110)
-  %r112 = sub i64 %r111, 48
-  %r113 = call i64 @bck_join(i64 %r108, i64 %r112)
-  store i64 %r113, i64* %r114
-  %r115 = load i64, i64* %r15
-  %r116 = icmp sgt i64 %r115, 0
-  br i1 %r116, label %then_23, label %else_24
+  %r121 = load i64, i64* @BCK_UNINIT
+  %r122 = load i8*, i8** %r18
+  %r123 = load i64, i64* %r98
+  %r124 = sub i64 %r123, 1
+  %r125 = getelementptr i8, i8* %r122, i64 %r124
+  %r126 = load i8, i8* %r125
+  %r127 = zext i8 %r126 to i64
+  %r128 = sub i64 %r127, 48
+  %r129 = call i64 @bck_join(i64 %r121, i64 %r128)
+  store i64 %r129, i64* %r130
+  %r131 = load i64, i64* %r19
+  %r132 = icmp sgt i64 %r131, 0
+  br i1 %r132, label %then_23, label %else_24
 then_23:
-  %r117 = trunc i64 32 to i8
-  store i8 %r117, i8* %r118
-  %r119 = load i8*, i8** %r14
-  %r120 = load i64, i64* %r15
-  %r121 = load i8, i8* %r118
-  %r122 = getelementptr i8, i8* %r119, i64 %r120
-  store i8 %r121, i8* %r122
-  %r123 = load i64, i64* %r15
-  %r124 = add i64 %r123, 1
-  store i64 %r124, i64* %r15
+  %r133 = trunc i64 32 to i8
+  store i8 %r133, i8* %r134
+  %r135 = load i8*, i8** %r14
+  %r136 = load i64, i64* %r19
+  %r137 = load i8, i8* %r134
+  %r138 = getelementptr i8, i8* %r135, i64 %r136
+  store i8 %r137, i8* %r138
+  %r139 = load i64, i64* %r19
+  %r140 = add i64 %r139, 1
+  store i64 %r140, i64* %r19
   br label %end_25
 else_24:
   br label %end_25
 end_25:
-  %r125 = load i8*, i8** %r11
-  %r126 = ptrtoint i8* %r125 to i64
-  %r127 = load i64, i64* %r15
-  %r128 = add i64 %r126, %r127
-  %r129 = inttoptr i64 %r128 to i8*
-  %r130 = ptrtoint i8* %b to i64
-  %r131 = load i64, i64* %r83
-  %r132 = add i64 %r130, %r131
-  %r133 = inttoptr i64 %r132 to i8*
-  %r134 = load i64, i64* %r102
-  %r135 = add i64 %r134, 1
-  %r136 = call i8* @memcpy(i8* %r129, i8* %r133, i64 %r135)
-  %r137 = load i64, i64* %r15
-  %r138 = load i64, i64* %r102
-  %r139 = add i64 %r138, 1
-  %r140 = add i64 %r137, %r139
-  store i64 %r140, i64* %r15
-  %r141 = load i64, i64* %r114
-  %r142 = add i64 48, %r141
-  %r143 = trunc i64 %r142 to i8
-  store i8 %r143, i8* %r144
-  %r145 = load i8*, i8** %r14
-  %r146 = load i64, i64* %r15
-  %r147 = load i8, i8* %r144
-  %r148 = getelementptr i8, i8* %r145, i64 %r146
-  store i8 %r147, i8* %r148
-  %r149 = load i64, i64* %r15
-  %r150 = add i64 %r149, 1
-  store i64 %r150, i64* %r15
+  %r141 = load i8*, i8** %r11
+  %r142 = ptrtoint i8* %r141 to i64
+  %r143 = load i64, i64* %r19
+  %r144 = add i64 %r142, %r143
+  %r145 = inttoptr i64 %r144 to i8*
+  %r146 = ptrtoint i8* %b to i64
+  %r147 = load i64, i64* %r93
+  %r148 = add i64 %r146, %r147
+  %r149 = inttoptr i64 %r148 to i8*
+  %r150 = load i64, i64* %r115
+  %r151 = add i64 %r150, 1
+  %r152 = call i8* @memcpy(i8* %r145, i8* %r149, i64 %r151)
+  %r153 = load i64, i64* %r19
+  %r154 = load i64, i64* %r115
+  %r155 = add i64 %r154, 1
+  %r156 = add i64 %r153, %r155
+  store i64 %r156, i64* %r19
+  %r157 = load i64, i64* %r130
+  %r158 = add i64 48, %r157
+  %r159 = trunc i64 %r158 to i8
+  store i8 %r159, i8* %r160
+  %r161 = load i8*, i8** %r14
+  %r162 = load i64, i64* %r19
+  %r163 = load i8, i8* %r160
+  %r164 = getelementptr i8, i8* %r161, i64 %r162
+  store i8 %r163, i8* %r164
+  %r165 = load i64, i64* %r19
+  %r166 = add i64 %r165, 1
+  store i64 %r166, i64* %r19
   br label %end_22
 else_21:
   br label %end_22
 end_22:
-  %r151 = load i64, i64* %r88
-  %r152 = add i64 %r151, 1
-  store i64 %r152, i64* %r83
+  %r167 = load i64, i64* %r98
+  %r168 = add i64 %r167, 1
+  store i64 %r168, i64* %r93
   br label %loop_check_12
 loop_exit_14:
-  %r153 = trunc i64 0 to i8
-  store i8 %r153, i8* %r154
-  %r155 = load i8*, i8** %r14
-  %r156 = load i64, i64* %r15
-  %r157 = load i8, i8* %r154
-  %r158 = getelementptr i8, i8* %r155, i64 %r156
-  store i8 %r157, i8* %r158
-  %r159 = load i8*, i8** %r11
-  ret i8* %r159
+  %r169 = trunc i64 0 to i8
+  store i8 %r169, i8* %r170
+  %r171 = load i8*, i8** %r14
+  %r172 = load i64, i64* %r19
+  %r173 = load i8, i8* %r170
+  %r174 = getelementptr i8, i8* %r171, i64 %r172
+  store i8 %r173, i8* %r174
+  %r175 = load i8*, i8** %r11
+  ret i8* %r175
 }
 
 define i8* @bck_rec(i64 %idx) {
@@ -35787,71 +35820,77 @@ define i8* @bck_field(i8* %rec, i64 %idx) {
 entry:
   %r0 = alloca i8*
   %r2 = alloca i64
-  %r3 = alloca i64
-  %r4 = alloca i64
+  %r4 = alloca i8*
   %r5 = alloca i64
+  %r6 = alloca i64
+  %r7 = alloca i64
   %r1 = call i64 @nurl_str_len(i8* %rec)
   store i64 %r1, i64* %r2
-  store i64 0, i64* %r3
-  store i64 0, i64* %r4
+  %r3 = bitcast i8* %rec to i8*
+  store i8* %r3, i8** %r4
   store i64 0, i64* %r5
+  store i64 0, i64* %r6
+  store i64 0, i64* %r7
   br label %loop_check_1
 loop_check_1:
-  %r6 = load i64, i64* %r5
-  %r7 = load i64, i64* %r2
-  %r8 = icmp slt i64 %r6, %r7
-  br i1 %r8, label %loop_body_2, label %loop_exit_3
+  %r8 = load i64, i64* %r7
+  %r9 = load i64, i64* %r2
+  %r10 = icmp slt i64 %r8, %r9
+  br i1 %r10, label %loop_body_2, label %loop_exit_3
 loop_body_2:
-  %r9 = load i64, i64* %r5
-  %r10 = call i64 @nurl_str_get(i8* %rec, i64 %r9)
-  %r11 = icmp eq i64 %r10, 9
-  br i1 %r11, label %then_4, label %else_5
+  %r11 = load i8*, i8** %r4
+  %r12 = load i64, i64* %r7
+  %r13 = getelementptr i8, i8* %r11, i64 %r12
+  %r14 = load i8, i8* %r13
+  %r15 = zext i8 %r14 to i64
+  %r16 = icmp eq i64 %r15, 9
+  br i1 %r16, label %then_4, label %else_5
 then_4:
-  %r12 = load i64, i64* %r4
-  %r13 = icmp eq i64 %r12, %idx
-  br i1 %r13, label %then_7, label %else_8
+  %r17 = load i64, i64* %r6
+  %r18 = icmp eq i64 %r17, %idx
+  br i1 %r18, label %then_7, label %else_8
 then_7:
-  %r14 = load i64, i64* %r3
-  %r15 = load i64, i64* %r5
-  %r16 = load i64, i64* %r3
-  %r17 = sub i64 %r15, %r16
-  %r18 = tail call i8* @nurl_str_slice(i8* %rec, i64 %r14, i64 %r17)
-  ret i8* %r18
+  %r19 = load i64, i64* %r5
+  %r20 = load i64, i64* %r7
+  %r21 = load i64, i64* %r5
+  %r22 = sub i64 %r20, %r21
+  %r23 = tail call i8* @nurl_str_slice(i8* %rec, i64 %r19, i64 %r22)
+  ret i8* %r23
 else_8:
   br label %end_9
 end_9:
-  %r19 = load i64, i64* %r4
-  %r20 = add i64 %r19, 1
-  store i64 %r20, i64* %r4
-  %r21 = load i64, i64* %r5
-  %r22 = add i64 %r21, 1
-  store i64 %r22, i64* %r3
+  %r24 = load i64, i64* %r6
+  %r25 = add i64 %r24, 1
+  store i64 %r25, i64* %r6
+  %r26 = load i64, i64* %r7
+  %r27 = add i64 %r26, 1
+  store i64 %r27, i64* %r5
   br label %end_6
 else_5:
   br label %end_6
 end_6:
-  %r23 = load i64, i64* %r5
-  %r24 = add i64 %r23, 1
-  store i64 %r24, i64* %r5
+  %r28 = load i64, i64* %r7
+  %r29 = add i64 %r28, 1
+  store i64 %r29, i64* %r7
   br label %loop_check_1
 loop_exit_3:
-  %r25 = load i64, i64* %r4
-  %r26 = icmp eq i64 %r25, %idx
-  br i1 %r26, label %then_10, label %else_11
+  %r30 = load i64, i64* %r6
+  %r31 = icmp eq i64 %r30, %idx
+  br i1 %r31, label %then_10, label %else_11
 then_10:
-  %r27 = load i64, i64* %r3
-  %r28 = load i64, i64* %r2
-  %r29 = load i64, i64* %r3
-  %r30 = sub i64 %r28, %r29
-  %r31 = tail call i8* @nurl_str_slice(i8* %rec, i64 %r27, i64 %r30)
-  ret i8* %r31
+  %r32 = load i64, i64* %r5
+  %r33 = load i64, i64* %r2
+  %r34 = load i64, i64* %r5
+  %r35 = sub i64 %r33, %r34
+  %r36 = tail call i8* @nurl_str_slice(i8* %rec, i64 %r32, i64 %r35)
+  ret i8* %r36
 else_11:
   br label %end_12
 end_12:
-  %r32 = getelementptr [1 x i8], [1 x i8]* @.str.2462, i64 0, i64 0
-  %r33 = getelementptr [1 x i8], [1 x i8]* @.str.2463, i64 0, i64 0
-  %r34 = call i8* @nurl_str_cat(i8* %r32, i8* %r33)
-  ret i8* %r34
+  %r37 = getelementptr [1 x i8], [1 x i8]* @.str.2462, i64 0, i64 0
+  %r38 = getelementptr [1 x i8], [1 x i8]* @.str.2463, i64 0, i64 0
+  %r39 = call i8* @nurl_str_cat(i8* %r37, i8* %r38)
+  ret i8* %r39
 }
 
 @.str.2462 = private unnamed_addr constant [1 x i8] c"\00"
@@ -35861,9 +35900,10 @@ entry:
   %r0 = alloca i64
   %r4 = alloca i8*
   %r7 = alloca i64
-  %r8 = alloca i64
-  %r9 = alloca i64
-  %r10 = alloca i64
+  %r10 = alloca i8*
+  %r11 = alloca i64
+  %r12 = alloca i64
+  %r13 = alloca i64
   %r1 = load i64, i64* @g_bck
   %r2 = getelementptr [6 x i8], [6 x i8]* @.str.2464, i64 0, i64 0
   %r3 = call i8* @nurl_sym_get(i64 %r1, i8* %r2)
@@ -35871,87 +35911,92 @@ entry:
   %r5 = load i8*, i8** %r4
   %r6 = call i64 @nurl_str_len(i8* %r5)
   store i64 %r6, i64* %r7
-  store i64 0, i64* %r8
-  store i64 0, i64* %r9
-  store i64 0, i64* %r10
+  %r8 = load i8*, i8** %r4
+  %r9 = bitcast i8* %r8 to i8*
+  store i8* %r9, i8** %r10
+  store i64 0, i64* %r11
+  store i64 0, i64* %r12
+  store i64 0, i64* %r13
   br label %loop_check_1
 loop_check_1:
-  %r11 = load i64, i64* %r10
-  %r12 = load i64, i64* %r7
-  %r13 = icmp slt i64 %r11, %r12
-  br i1 %r13, label %loop_body_2, label %loop_exit_3
+  %r14 = load i64, i64* %r13
+  %r15 = load i64, i64* %r7
+  %r16 = icmp slt i64 %r14, %r15
+  br i1 %r16, label %loop_body_2, label %loop_exit_3
 loop_body_2:
-  %r14 = load i8*, i8** %r4
-  %r15 = load i64, i64* %r10
-  %r16 = call i64 @nurl_str_get(i8* %r14, i64 %r15)
-  %r17 = icmp eq i64 %r16, 10
-  br i1 %r17, label %then_4, label %else_5
+  %r17 = load i8*, i8** %r10
+  %r18 = load i64, i64* %r13
+  %r19 = getelementptr i8, i8* %r17, i64 %r18
+  %r20 = load i8, i8* %r19
+  %r21 = zext i8 %r20 to i64
+  %r22 = icmp eq i64 %r21, 10
+  br i1 %r22, label %then_4, label %else_5
 then_4:
-  %r18 = load i64, i64* @g_bck
-  %r19 = getelementptr [2 x i8], [2 x i8]* @.str.2465, i64 0, i64 0
-  %r20 = load i64, i64* %r9
-  %r21 = call i8* @nurl_str_int(i64 %r20)
-  %r22 = call i8* @nurl_str_cat(i8* %r19, i8* %r21)
-  call void @nurl_free(i8* %r21)
-  %r23 = load i8*, i8** %r4
-  %r24 = load i64, i64* %r8
-  %r25 = load i64, i64* %r10
-  %r26 = load i64, i64* %r8
-  %r27 = sub i64 %r25, %r26
-  %r28 = call i8* @nurl_str_slice(i8* %r23, i64 %r24, i64 %r27)
-  call void @nurl_sym_set(i64 %r18, i8* %r22, i8* %r28)
-  call void @nurl_free(i8* %r22)
-  call void @nurl_free(i8* %r28)
-  %r29 = load i64, i64* %r9
-  %r30 = add i64 %r29, 1
-  store i64 %r30, i64* %r9
-  %r31 = load i64, i64* %r10
-  %r32 = add i64 %r31, 1
-  store i64 %r32, i64* %r8
+  %r23 = load i64, i64* @g_bck
+  %r24 = getelementptr [2 x i8], [2 x i8]* @.str.2465, i64 0, i64 0
+  %r25 = load i64, i64* %r12
+  %r26 = call i8* @nurl_str_int(i64 %r25)
+  %r27 = call i8* @nurl_str_cat(i8* %r24, i8* %r26)
+  call void @nurl_free(i8* %r26)
+  %r28 = load i8*, i8** %r4
+  %r29 = load i64, i64* %r11
+  %r30 = load i64, i64* %r13
+  %r31 = load i64, i64* %r11
+  %r32 = sub i64 %r30, %r31
+  %r33 = call i8* @nurl_str_slice(i8* %r28, i64 %r29, i64 %r32)
+  call void @nurl_sym_set(i64 %r23, i8* %r27, i8* %r33)
+  call void @nurl_free(i8* %r27)
+  call void @nurl_free(i8* %r33)
+  %r34 = load i64, i64* %r12
+  %r35 = add i64 %r34, 1
+  store i64 %r35, i64* %r12
+  %r36 = load i64, i64* %r13
+  %r37 = add i64 %r36, 1
+  store i64 %r37, i64* %r11
   br label %end_6
 else_5:
   br label %end_6
 end_6:
-  %r33 = load i64, i64* %r10
-  %r34 = add i64 %r33, 1
-  store i64 %r34, i64* %r10
+  %r38 = load i64, i64* %r13
+  %r39 = add i64 %r38, 1
+  store i64 %r39, i64* %r13
   br label %loop_check_1
 loop_exit_3:
-  %r35 = load i64, i64* %r7
-  %r36 = load i64, i64* %r8
-  %r37 = icmp sgt i64 %r35, %r36
-  br i1 %r37, label %then_7, label %else_8
+  %r40 = load i64, i64* %r7
+  %r41 = load i64, i64* %r11
+  %r42 = icmp sgt i64 %r40, %r41
+  br i1 %r42, label %then_7, label %else_8
 then_7:
-  %r38 = load i64, i64* @g_bck
-  %r39 = getelementptr [2 x i8], [2 x i8]* @.str.2466, i64 0, i64 0
-  %r40 = load i64, i64* %r9
-  %r41 = call i8* @nurl_str_int(i64 %r40)
-  %r42 = call i8* @nurl_str_cat(i8* %r39, i8* %r41)
-  call void @nurl_free(i8* %r41)
-  %r43 = load i8*, i8** %r4
-  %r44 = load i64, i64* %r8
-  %r45 = load i64, i64* %r7
-  %r46 = load i64, i64* %r8
-  %r47 = sub i64 %r45, %r46
-  %r48 = call i8* @nurl_str_slice(i8* %r43, i64 %r44, i64 %r47)
-  call void @nurl_sym_set(i64 %r38, i8* %r42, i8* %r48)
-  call void @nurl_free(i8* %r42)
-  call void @nurl_free(i8* %r48)
-  %r49 = load i64, i64* %r9
-  %r50 = add i64 %r49, 1
-  store i64 %r50, i64* %r9
+  %r43 = load i64, i64* @g_bck
+  %r44 = getelementptr [2 x i8], [2 x i8]* @.str.2466, i64 0, i64 0
+  %r45 = load i64, i64* %r12
+  %r46 = call i8* @nurl_str_int(i64 %r45)
+  %r47 = call i8* @nurl_str_cat(i8* %r44, i8* %r46)
+  call void @nurl_free(i8* %r46)
+  %r48 = load i8*, i8** %r4
+  %r49 = load i64, i64* %r11
+  %r50 = load i64, i64* %r7
+  %r51 = load i64, i64* %r11
+  %r52 = sub i64 %r50, %r51
+  %r53 = call i8* @nurl_str_slice(i8* %r48, i64 %r49, i64 %r52)
+  call void @nurl_sym_set(i64 %r43, i8* %r47, i8* %r53)
+  call void @nurl_free(i8* %r47)
+  call void @nurl_free(i8* %r53)
+  %r54 = load i64, i64* %r12
+  %r55 = add i64 %r54, 1
+  store i64 %r55, i64* %r12
   br label %end_9
 else_8:
   br label %end_9
 end_9:
-  %r51 = load i64, i64* @g_bck
-  %r52 = getelementptr [3 x i8], [3 x i8]* @.str.2467, i64 0, i64 0
-  %r53 = load i64, i64* %r9
-  %r54 = call i8* @nurl_str_int(i64 %r53)
-  call void @nurl_sym_set(i64 %r51, i8* %r52, i8* %r54)
-  call void @nurl_free(i8* %r54)
-  %r55 = load i64, i64* %r9
-  ret i64 %r55
+  %r56 = load i64, i64* @g_bck
+  %r57 = getelementptr [3 x i8], [3 x i8]* @.str.2467, i64 0, i64 0
+  %r58 = load i64, i64* %r12
+  %r59 = call i8* @nurl_str_int(i64 %r58)
+  call void @nurl_sym_set(i64 %r56, i8* %r57, i8* %r59)
+  call void @nurl_free(i8* %r59)
+  %r60 = load i64, i64* %r12
+  ret i64 %r60
 }
 
 @.str.2464 = private unnamed_addr constant [6 x i8] c"stmts\00"
@@ -39995,47 +40040,47 @@ entry:
   %r92 = alloca i8*
   %r94 = alloca i8*
   %r96 = alloca i8*
-  %r133 = alloca i64
-  %r135 = alloca i8*
-  %r138 = alloca i64
-  %r143 = alloca i8*
-  %r146 = alloca i8*
-  %r178 = alloca i64
-  %r184 = alloca i1
-  %r190 = alloca i8*
-  %r197 = alloca i64
-  %r202 = alloca i8*
-  %r205 = alloca i8*
-  %r218 = alloca i8*
-  %r221 = alloca i1
-  %r227 = alloca i1
-  %r229 = alloca i1
-  %r232 = alloca i8*
-  %r240 = alloca i8*
-  %r242 = alloca i8*
-  %r244 = alloca i8*
-  %r246 = alloca i8*
-  %r288 = alloca i8*
-  %r291 = alloca i64
-  %r293 = alloca i8*
-  %r308 = alloca i8*
-  %r346 = alloca i8*
+  %r134 = alloca i64
+  %r136 = alloca i8*
+  %r139 = alloca i64
+  %r144 = alloca i8*
+  %r147 = alloca i8*
+  %r179 = alloca i64
+  %r185 = alloca i1
+  %r191 = alloca i8*
+  %r198 = alloca i64
+  %r203 = alloca i8*
+  %r206 = alloca i8*
+  %r219 = alloca i8*
+  %r222 = alloca i1
+  %r228 = alloca i1
+  %r230 = alloca i1
+  %r233 = alloca i8*
+  %r241 = alloca i8*
+  %r243 = alloca i8*
+  %r245 = alloca i8*
+  %r247 = alloca i8*
+  %r290 = alloca i8*
+  %r293 = alloca i64
+  %r295 = alloca i8*
+  %r310 = alloca i8*
   %r348 = alloca i8*
   %r350 = alloca i8*
   %r352 = alloca i8*
-  %r389 = alloca i8*
-  %r391 = alloca i8*
-  %r393 = alloca i8*
-  %r395 = alloca i8*
-  %r430 = alloca i8*
+  %r354 = alloca i8*
+  %r392 = alloca i8*
+  %r394 = alloca i8*
+  %r396 = alloca i8*
+  %r398 = alloca i8*
   %r434 = alloca i8*
-  %r440 = alloca i8*
-  %r443 = alloca i8*
-  %r451 = alloca i8*
-  %r459 = alloca i8*
-  %r462 = alloca i64
-  %r464 = alloca i8*
-  %r479 = alloca i8*
+  %r438 = alloca i8*
+  %r444 = alloca i8*
+  %r447 = alloca i8*
+  %r455 = alloca i8*
+  %r463 = alloca i8*
+  %r466 = alloca i64
+  %r468 = alloca i8*
+  %r483 = alloca i8*
   call void @nurl_lex_advance(i64 %lex)
   %r1 = call i64 @nurl_lex_type(i64 %lex)
   %r2 = call i1 @is_ident_tok(i64 %r1)
@@ -40209,668 +40254,672 @@ else_10:
   %r108 = getelementptr [3 x i8], [3 x i8]* @.str.2790, i64 0, i64 0
   call void @nurl_print(i8* %r108)
   %r109 = load i8*, i8** %r92
-  call void @nurl_print(i8* %r109)
-  %r110 = getelementptr [2 x i8], [2 x i8]* @.str.2791, i64 0, i64 0
+  %r110 = call i8* @nurl_llty(i8* %r109)
   call void @nurl_print(i8* %r110)
-  %r111 = load i8*, i8** %r90
+  %r111 = getelementptr [2 x i8], [2 x i8]* @.str.2791, i64 0, i64 0
   call void @nurl_print(i8* %r111)
-  %r112 = getelementptr [2 x i8], [2 x i8]* @.str.2792, i64 0, i64 0
+  %r112 = load i8*, i8** %r90
   call void @nurl_print(i8* %r112)
-  %r113 = getelementptr [9 x i8], [9 x i8]* @.str.2793, i64 0, i64 0
+  %r113 = getelementptr [2 x i8], [2 x i8]* @.str.2792, i64 0, i64 0
   call void @nurl_print(i8* %r113)
-  %r114 = load i8*, i8** %r36
-  %r115 = call i8* @nurl_llty(i8* %r114)
-  call void @nurl_print(i8* %r115)
-  %r116 = getelementptr [2 x i8], [2 x i8]* @.str.2794, i64 0, i64 0
+  %r114 = getelementptr [9 x i8], [9 x i8]* @.str.2793, i64 0, i64 0
+  call void @nurl_print(i8* %r114)
+  %r115 = load i8*, i8** %r36
+  %r116 = call i8* @nurl_llty(i8* %r115)
   call void @nurl_print(i8* %r116)
-  %r117 = load i8*, i8** %r94
+  %r117 = getelementptr [2 x i8], [2 x i8]* @.str.2794, i64 0, i64 0
   call void @nurl_print(i8* %r117)
-  %r118 = getelementptr [3 x i8], [3 x i8]* @.str.2795, i64 0, i64 0
+  %r118 = load i8*, i8** %r94
   call void @nurl_print(i8* %r118)
-  %r119 = load i8*, i8** %r36
-  %r120 = call i8* @nurl_llty(i8* %r119)
-  call void @nurl_print(i8* %r120)
-  %r121 = getelementptr [3 x i8], [3 x i8]* @.str.2796, i64 0, i64 0
+  %r119 = getelementptr [3 x i8], [3 x i8]* @.str.2795, i64 0, i64 0
+  call void @nurl_print(i8* %r119)
+  %r120 = load i8*, i8** %r36
+  %r121 = call i8* @nurl_llty(i8* %r120)
   call void @nurl_print(i8* %r121)
-  %r122 = load i8*, i8** %r96
+  %r122 = getelementptr [3 x i8], [3 x i8]* @.str.2796, i64 0, i64 0
   call void @nurl_print(i8* %r122)
-  %r123 = getelementptr [2 x i8], [2 x i8]* @.str.2797, i64 0, i64 0
+  %r123 = load i8*, i8** %r96
   call void @nurl_print(i8* %r123)
-  %r124 = load i8*, i8** %r94
-  %r125 = load i8*, i8** %r29
-  call void @nurl_free(i8* %r125)
-  %r126 = load i8*, i8** %r36
+  %r124 = getelementptr [2 x i8], [2 x i8]* @.str.2797, i64 0, i64 0
+  call void @nurl_print(i8* %r124)
+  %r125 = load i8*, i8** %r94
+  %r126 = load i8*, i8** %r29
   call void @nurl_free(i8* %r126)
-  %r127 = load i8*, i8** %r39
+  %r127 = load i8*, i8** %r36
   call void @nurl_free(i8* %r127)
-  %r128 = load i8*, i8** %r96
+  %r128 = load i8*, i8** %r39
   call void @nurl_free(i8* %r128)
-  ret i8* %r124
+  %r129 = load i8*, i8** %r96
+  call void @nurl_free(i8* %r129)
+  ret i8* %r125
 end_11:
   unreachable
 else_7:
-  %r129 = call i64 @nurl_lex_type(i64 %lex)
-  %r130 = load i64, i64* @TT_INT
-  %r131 = icmp eq i64 %r129, %r130
-  br i1 %r131, label %then_12, label %else_13
+  %r130 = call i64 @nurl_lex_type(i64 %lex)
+  %r131 = load i64, i64* @TT_INT
+  %r132 = icmp eq i64 %r130, %r131
+  br i1 %r132, label %then_12, label %else_13
 then_12:
-  %r132 = call i64 @nurl_lex_inum(i64 %lex)
-  store i64 %r132, i64* %r133
+  %r133 = call i64 @nurl_lex_inum(i64 %lex)
+  store i64 %r133, i64* %r134
   call void @nurl_lex_advance(i64 %lex)
-  %r134 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
-  store i8* %r134, i8** %r135
-  %r136 = load i8*, i8** %r10
-  %r137 = call i64 @nurl_str_len(i8* %r136)
-  store i64 %r137, i64* %r138
-  %r139 = load i8*, i8** %r10
-  %r140 = load i64, i64* %r138
-  %r141 = sub i64 %r140, 1
-  %r142 = call i8* @nurl_str_slice(i8* %r139, i64 0, i64 %r141)
-  store i8* %r142, i8** %r143
-  %r144 = load i8*, i8** %r143
-  call void @nurl_journal_push(i8* %r144)
-  %r145 = call i8* @nurl_cg_reg(i64 %cg)
-  store i8* %r145, i8** %r146
-  %r147 = load i8*, i8** %r146
-  call void @nurl_journal_push(i8* %r147)
-  %r148 = getelementptr [3 x i8], [3 x i8]* @.str.2798, i64 0, i64 0
-  call void @nurl_print(i8* %r148)
-  %r149 = load i8*, i8** %r146
+  %r135 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
+  store i8* %r135, i8** %r136
+  %r137 = load i8*, i8** %r10
+  %r138 = call i64 @nurl_str_len(i8* %r137)
+  store i64 %r138, i64* %r139
+  %r140 = load i8*, i8** %r10
+  %r141 = load i64, i64* %r139
+  %r142 = sub i64 %r141, 1
+  %r143 = call i8* @nurl_str_slice(i8* %r140, i64 0, i64 %r142)
+  store i8* %r143, i8** %r144
+  %r145 = load i8*, i8** %r144
+  call void @nurl_journal_push(i8* %r145)
+  %r146 = call i8* @nurl_cg_reg(i64 %cg)
+  store i8* %r146, i8** %r147
+  %r148 = load i8*, i8** %r147
+  call void @nurl_journal_push(i8* %r148)
+  %r149 = getelementptr [3 x i8], [3 x i8]* @.str.2798, i64 0, i64 0
   call void @nurl_print(i8* %r149)
-  %r150 = getelementptr [18 x i8], [18 x i8]* @.str.2799, i64 0, i64 0
+  %r150 = load i8*, i8** %r147
   call void @nurl_print(i8* %r150)
-  %r151 = load i8*, i8** %r143
-  %r152 = call i8* @nurl_llty(i8* %r151)
-  call void @nurl_print(i8* %r152)
-  %r153 = getelementptr [3 x i8], [3 x i8]* @.str.2800, i64 0, i64 0
+  %r151 = getelementptr [18 x i8], [18 x i8]* @.str.2799, i64 0, i64 0
+  call void @nurl_print(i8* %r151)
+  %r152 = load i8*, i8** %r144
+  %r153 = call i8* @nurl_llty(i8* %r152)
   call void @nurl_print(i8* %r153)
-  %r154 = load i8*, i8** %r10
-  %r155 = call i8* @nurl_llty(i8* %r154)
-  call void @nurl_print(i8* %r155)
-  %r156 = getelementptr [2 x i8], [2 x i8]* @.str.2801, i64 0, i64 0
+  %r154 = getelementptr [3 x i8], [3 x i8]* @.str.2800, i64 0, i64 0
+  call void @nurl_print(i8* %r154)
+  %r155 = load i8*, i8** %r10
+  %r156 = call i8* @nurl_llty(i8* %r155)
   call void @nurl_print(i8* %r156)
-  %r157 = load i8*, i8** %r8
+  %r157 = getelementptr [2 x i8], [2 x i8]* @.str.2801, i64 0, i64 0
   call void @nurl_print(i8* %r157)
-  %r158 = getelementptr [7 x i8], [7 x i8]* @.str.2802, i64 0, i64 0
+  %r158 = load i8*, i8** %r8
   call void @nurl_print(i8* %r158)
-  %r159 = load i64, i64* %r133
-  %r160 = call i8* @nurl_str_int(i64 %r159)
-  call void @nurl_print(i8* %r160)
-  call void @nurl_free(i8* %r160)
-  %r161 = getelementptr [2 x i8], [2 x i8]* @.str.2803, i64 0, i64 0
+  %r159 = getelementptr [7 x i8], [7 x i8]* @.str.2802, i64 0, i64 0
+  call void @nurl_print(i8* %r159)
+  %r160 = load i64, i64* %r134
+  %r161 = call i8* @nurl_str_int(i64 %r160)
   call void @nurl_print(i8* %r161)
-  %r162 = getelementptr [9 x i8], [9 x i8]* @.str.2804, i64 0, i64 0
+  call void @nurl_free(i8* %r161)
+  %r162 = getelementptr [2 x i8], [2 x i8]* @.str.2803, i64 0, i64 0
   call void @nurl_print(i8* %r162)
-  %r163 = load i8*, i8** %r143
-  %r164 = call i8* @nurl_llty(i8* %r163)
-  call void @nurl_print(i8* %r164)
-  %r165 = getelementptr [2 x i8], [2 x i8]* @.str.2805, i64 0, i64 0
+  %r163 = getelementptr [9 x i8], [9 x i8]* @.str.2804, i64 0, i64 0
+  call void @nurl_print(i8* %r163)
+  %r164 = load i8*, i8** %r144
+  %r165 = call i8* @nurl_llty(i8* %r164)
   call void @nurl_print(i8* %r165)
-  %r166 = load i8*, i8** %r135
+  %r166 = getelementptr [2 x i8], [2 x i8]* @.str.2805, i64 0, i64 0
   call void @nurl_print(i8* %r166)
-  %r167 = getelementptr [3 x i8], [3 x i8]* @.str.2806, i64 0, i64 0
+  %r167 = load i8*, i8** %r136
   call void @nurl_print(i8* %r167)
-  %r168 = load i8*, i8** %r143
-  %r169 = call i8* @nurl_llty(i8* %r168)
-  call void @nurl_print(i8* %r169)
-  %r170 = getelementptr [3 x i8], [3 x i8]* @.str.2807, i64 0, i64 0
+  %r168 = getelementptr [3 x i8], [3 x i8]* @.str.2806, i64 0, i64 0
+  call void @nurl_print(i8* %r168)
+  %r169 = load i8*, i8** %r144
+  %r170 = call i8* @nurl_llty(i8* %r169)
   call void @nurl_print(i8* %r170)
-  %r171 = load i8*, i8** %r146
+  %r171 = getelementptr [3 x i8], [3 x i8]* @.str.2807, i64 0, i64 0
   call void @nurl_print(i8* %r171)
-  %r172 = getelementptr [2 x i8], [2 x i8]* @.str.2808, i64 0, i64 0
+  %r172 = load i8*, i8** %r147
   call void @nurl_print(i8* %r172)
-  %r173 = load i8*, i8** %r135
-  %r174 = load i8*, i8** %r143
-  call void @nurl_free(i8* %r174)
-  %r175 = load i8*, i8** %r146
+  %r173 = getelementptr [2 x i8], [2 x i8]* @.str.2808, i64 0, i64 0
+  call void @nurl_print(i8* %r173)
+  %r174 = load i8*, i8** %r136
+  %r175 = load i8*, i8** %r144
   call void @nurl_free(i8* %r175)
-  ret i8* %r173
+  %r176 = load i8*, i8** %r147
+  call void @nurl_free(i8* %r176)
+  ret i8* %r174
 else_13:
-  %r176 = load i8*, i8** %r10
-  %r177 = call i64 @nurl_str_len(i8* %r176)
-  store i64 %r177, i64* %r178
-  %r179 = load i8*, i8** %r10
-  %r180 = load i64, i64* %r178
-  %r181 = sub i64 %r180, 1
-  %r182 = call i64 @nurl_str_get(i8* %r179, i64 %r181)
-  %r183 = icmp eq i64 %r182, 42
-  store i1 %r183, i1* %r184
-  %r185 = load i1, i1* %r184
-  br i1 %r185, label %then_15, label %else_16
+  %r177 = load i8*, i8** %r10
+  %r178 = call i64 @nurl_str_len(i8* %r177)
+  store i64 %r178, i64* %r179
+  %r180 = load i8*, i8** %r10
+  %r181 = load i64, i64* %r179
+  %r182 = sub i64 %r181, 1
+  %r183 = call i64 @nurl_str_get(i8* %r180, i64 %r182)
+  %r184 = icmp eq i64 %r183, 42
+  store i1 %r184, i1* %r185
+  %r186 = load i1, i1* %r185
+  br i1 %r186, label %then_15, label %else_16
 then_15:
-  %r186 = load i8*, i8** %r10
-  %r187 = load i64, i64* %r178
-  %r188 = sub i64 %r187, 1
-  %r189 = call i8* @nurl_str_slice(i8* %r186, i64 0, i64 %r188)
-  store i8* %r189, i8** %r190
-  %r191 = load i8*, i8** %r190
-  call void @nurl_journal_push(i8* %r191)
-  %r192 = load i8*, i8** %r190
-  %r193 = call i64 @nurl_str_get(i8* %r192, i64 0)
-  %r194 = icmp eq i64 %r193, 37
-  br i1 %r194, label %then_18, label %else_19
+  %r187 = load i8*, i8** %r10
+  %r188 = load i64, i64* %r179
+  %r189 = sub i64 %r188, 1
+  %r190 = call i8* @nurl_str_slice(i8* %r187, i64 0, i64 %r189)
+  store i8* %r190, i8** %r191
+  %r192 = load i8*, i8** %r191
+  call void @nurl_journal_push(i8* %r192)
+  %r193 = load i8*, i8** %r191
+  %r194 = call i64 @nurl_str_get(i8* %r193, i64 0)
+  %r195 = icmp eq i64 %r194, 37
+  br i1 %r195, label %then_18, label %else_19
 then_18:
-  %r195 = load i8*, i8** %r190
-  %r196 = call i64 @nurl_str_len(i8* %r195)
-  store i64 %r196, i64* %r197
-  %r198 = load i8*, i8** %r190
-  %r199 = load i64, i64* %r197
-  %r200 = sub i64 %r199, 1
-  %r201 = call i8* @nurl_str_slice(i8* %r198, i64 1, i64 %r200)
-  store i8* %r201, i8** %r202
-  %r203 = load i8*, i8** %r202
-  call void @nurl_journal_push(i8* %r203)
-  %r204 = call i8* @nurl_lex_val(i64 %lex)
-  store i8* %r204, i8** %r205
-  %r206 = load i8*, i8** @g_mono_tparam_tys
-  %r207 = load i8*, i8** %r202
-  %r208 = call i1 @str_contains_word(i8* %r206, i8* %r207)
-  br i1 %r208, label %then_21, label %else_22
+  %r196 = load i8*, i8** %r191
+  %r197 = call i64 @nurl_str_len(i8* %r196)
+  store i64 %r197, i64* %r198
+  %r199 = load i8*, i8** %r191
+  %r200 = load i64, i64* %r198
+  %r201 = sub i64 %r200, 1
+  %r202 = call i8* @nurl_str_slice(i8* %r199, i64 1, i64 %r201)
+  store i8* %r202, i8** %r203
+  %r204 = load i8*, i8** %r203
+  call void @nurl_journal_push(i8* %r204)
+  %r205 = call i8* @nurl_lex_val(i64 %lex)
+  store i8* %r205, i8** %r206
+  %r207 = load i8*, i8** @g_mono_tparam_tys
+  %r208 = load i8*, i8** %r203
+  %r209 = call i1 @str_contains_word(i8* %r207, i8* %r208)
+  br i1 %r209, label %then_21, label %else_22
 then_21:
-  %r209 = getelementptr [1 x i8], [1 x i8]* @.str.2809, i64 0, i64 0
+  %r210 = getelementptr [1 x i8], [1 x i8]* @.str.2809, i64 0, i64 0
   br label %end_23
 else_22:
-  %r210 = load i8*, i8** %r202
-  %r211 = getelementptr [3 x i8], [3 x i8]* @.str.2810, i64 0, i64 0
-  %r212 = load i8*, i8** %r205
-  %r213 = getelementptr [6 x i8], [6 x i8]* @.str.2811, i64 0, i64 0
-  %r214 = call i8* @nurl_str_cat(i8* %r212, i8* %r213)
-  %r215 = call i8* @nurl_str_cat(i8* %r211, i8* %r214)
-  call void @nurl_free(i8* %r214)
-  %r216 = call i8* @nurl_sym_get2(i64 %syms, i8* %r210, i8* %r215)
+  %r211 = load i8*, i8** %r203
+  %r212 = getelementptr [3 x i8], [3 x i8]* @.str.2810, i64 0, i64 0
+  %r213 = load i8*, i8** %r206
+  %r214 = getelementptr [6 x i8], [6 x i8]* @.str.2811, i64 0, i64 0
+  %r215 = call i8* @nurl_str_cat(i8* %r213, i8* %r214)
+  %r216 = call i8* @nurl_str_cat(i8* %r212, i8* %r215)
   call void @nurl_free(i8* %r215)
+  %r217 = call i8* @nurl_sym_get2(i64 %syms, i8* %r211, i8* %r216)
+  call void @nurl_free(i8* %r216)
   br label %end_23
 end_23:
-  %r217 = phi i8* [ %r209, %then_21 ], [ %r216, %else_22 ]
-  store i8* %r217, i8** %r218
-  %r219 = call i64 @nurl_lex_type(i64 %lex)
-  %r220 = call i1 @is_ident_tok(i64 %r219)
-  store i1 %r220, i1* %r221
-  %r222 = load i1, i1* %r221
-  br i1 %r222, label %and_right_24, label %and_end_25
+  %r218 = phi i8* [ %r210, %then_21 ], [ %r217, %else_22 ]
+  store i8* %r218, i8** %r219
+  %r220 = call i64 @nurl_lex_type(i64 %lex)
+  %r221 = call i1 @is_ident_tok(i64 %r220)
+  store i1 %r221, i1* %r222
+  %r223 = load i1, i1* %r222
+  br i1 %r223, label %and_right_24, label %and_end_25
 and_right_24:
-  %r223 = load i8*, i8** %r218
-  %r224 = call i64 @nurl_str_len(i8* %r223)
-  %r225 = icmp ne i64 0, %r224
+  %r224 = load i8*, i8** %r219
+  %r225 = call i64 @nurl_str_len(i8* %r224)
+  %r226 = icmp ne i64 0, %r225
   br label %and_end_25
 and_end_25:
-  %r226 = phi i1 [ 0, %end_23 ], [ %r225, %and_right_24 ]
-  store i1 %r226, i1* %r227
-  %r228 = load i1, i1* %r227
-  store i1 %r228, i1* %r229
-  %r230 = load i8*, i8** %r205
-  %r231 = call i8* @nurl_sym_get(i64 %syms, i8* %r230)
-  store i8* %r231, i8** %r232
-  %r233 = load i1, i1* %r229
-  %r234 = xor i1 %r233, 1
-  br i1 %r234, label %and_right_26, label %and_end_27
+  %r227 = phi i1 [ 0, %end_23 ], [ %r226, %and_right_24 ]
+  store i1 %r227, i1* %r228
+  %r229 = load i1, i1* %r228
+  store i1 %r229, i1* %r230
+  %r231 = load i8*, i8** %r206
+  %r232 = call i8* @nurl_sym_get(i64 %syms, i8* %r231)
+  store i8* %r232, i8** %r233
+  %r234 = load i1, i1* %r230
+  %r235 = xor i1 %r234, 1
+  br i1 %r235, label %and_right_26, label %and_end_27
 and_right_26:
-  %r235 = load i8*, i8** %r232
-  %r236 = call i64 @int_width(i8* %r235)
-  %r237 = icmp sgt i64 %r236, 0
+  %r236 = load i8*, i8** %r233
+  %r237 = call i64 @int_width(i8* %r236)
+  %r238 = icmp sgt i64 %r237, 0
   br label %and_end_27
 and_end_27:
-  %r238 = phi i1 [ 0, %and_end_25 ], [ %r237, %and_right_26 ]
-  br i1 %r238, label %then_28, label %else_29
+  %r239 = phi i1 [ 0, %and_end_25 ], [ %r238, %and_right_26 ]
+  br i1 %r239, label %then_28, label %else_29
 then_28:
-  %r239 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
-  store i8* %r239, i8** %r240
-  %r241 = call i8* @nurl_get_last_type()
-  store i8* %r241, i8** %r242
-  %r243 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
-  store i8* %r243, i8** %r244
-  %r245 = call i8* @nurl_cg_reg(i64 %cg)
-  store i8* %r245, i8** %r246
-  %r247 = load i8*, i8** %r246
-  call void @nurl_journal_push(i8* %r247)
-  %r248 = getelementptr [3 x i8], [3 x i8]* @.str.2812, i64 0, i64 0
-  call void @nurl_print(i8* %r248)
-  %r249 = load i8*, i8** %r246
+  %r240 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
+  store i8* %r240, i8** %r241
+  %r242 = call i8* @nurl_get_last_type()
+  store i8* %r242, i8** %r243
+  %r244 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
+  store i8* %r244, i8** %r245
+  %r246 = call i8* @nurl_cg_reg(i64 %cg)
+  store i8* %r246, i8** %r247
+  %r248 = load i8*, i8** %r247
+  call void @nurl_journal_push(i8* %r248)
+  %r249 = getelementptr [3 x i8], [3 x i8]* @.str.2812, i64 0, i64 0
   call void @nurl_print(i8* %r249)
-  %r250 = getelementptr [18 x i8], [18 x i8]* @.str.2813, i64 0, i64 0
+  %r250 = load i8*, i8** %r247
   call void @nurl_print(i8* %r250)
-  %r251 = load i8*, i8** %r190
-  %r252 = call i8* @nurl_llty(i8* %r251)
-  call void @nurl_print(i8* %r252)
-  %r253 = getelementptr [3 x i8], [3 x i8]* @.str.2814, i64 0, i64 0
+  %r251 = getelementptr [18 x i8], [18 x i8]* @.str.2813, i64 0, i64 0
+  call void @nurl_print(i8* %r251)
+  %r252 = load i8*, i8** %r191
+  %r253 = call i8* @nurl_llty(i8* %r252)
   call void @nurl_print(i8* %r253)
-  %r254 = load i8*, i8** %r10
-  %r255 = call i8* @nurl_llty(i8* %r254)
-  call void @nurl_print(i8* %r255)
-  %r256 = getelementptr [2 x i8], [2 x i8]* @.str.2815, i64 0, i64 0
+  %r254 = getelementptr [3 x i8], [3 x i8]* @.str.2814, i64 0, i64 0
+  call void @nurl_print(i8* %r254)
+  %r255 = load i8*, i8** %r10
+  %r256 = call i8* @nurl_llty(i8* %r255)
   call void @nurl_print(i8* %r256)
-  %r257 = load i8*, i8** %r8
+  %r257 = getelementptr [2 x i8], [2 x i8]* @.str.2815, i64 0, i64 0
   call void @nurl_print(i8* %r257)
-  %r258 = getelementptr [3 x i8], [3 x i8]* @.str.2816, i64 0, i64 0
+  %r258 = load i8*, i8** %r8
   call void @nurl_print(i8* %r258)
-  %r259 = load i8*, i8** %r242
+  %r259 = getelementptr [3 x i8], [3 x i8]* @.str.2816, i64 0, i64 0
   call void @nurl_print(i8* %r259)
-  %r260 = getelementptr [2 x i8], [2 x i8]* @.str.2817, i64 0, i64 0
-  call void @nurl_print(i8* %r260)
-  %r261 = load i8*, i8** %r240
+  %r260 = load i8*, i8** %r243
+  %r261 = call i8* @nurl_llty(i8* %r260)
   call void @nurl_print(i8* %r261)
-  %r262 = getelementptr [2 x i8], [2 x i8]* @.str.2818, i64 0, i64 0
+  %r262 = getelementptr [2 x i8], [2 x i8]* @.str.2817, i64 0, i64 0
   call void @nurl_print(i8* %r262)
-  %r263 = getelementptr [9 x i8], [9 x i8]* @.str.2819, i64 0, i64 0
+  %r263 = load i8*, i8** %r241
   call void @nurl_print(i8* %r263)
-  %r264 = load i8*, i8** %r190
-  %r265 = call i8* @nurl_llty(i8* %r264)
+  %r264 = getelementptr [2 x i8], [2 x i8]* @.str.2818, i64 0, i64 0
+  call void @nurl_print(i8* %r264)
+  %r265 = getelementptr [9 x i8], [9 x i8]* @.str.2819, i64 0, i64 0
   call void @nurl_print(i8* %r265)
-  %r266 = getelementptr [2 x i8], [2 x i8]* @.str.2820, i64 0, i64 0
-  call void @nurl_print(i8* %r266)
-  %r267 = load i8*, i8** %r244
+  %r266 = load i8*, i8** %r191
+  %r267 = call i8* @nurl_llty(i8* %r266)
   call void @nurl_print(i8* %r267)
-  %r268 = getelementptr [3 x i8], [3 x i8]* @.str.2821, i64 0, i64 0
+  %r268 = getelementptr [2 x i8], [2 x i8]* @.str.2820, i64 0, i64 0
   call void @nurl_print(i8* %r268)
-  %r269 = load i8*, i8** %r190
-  %r270 = call i8* @nurl_llty(i8* %r269)
+  %r269 = load i8*, i8** %r245
+  call void @nurl_print(i8* %r269)
+  %r270 = getelementptr [3 x i8], [3 x i8]* @.str.2821, i64 0, i64 0
   call void @nurl_print(i8* %r270)
-  %r271 = getelementptr [3 x i8], [3 x i8]* @.str.2822, i64 0, i64 0
-  call void @nurl_print(i8* %r271)
-  %r272 = load i8*, i8** %r246
+  %r271 = load i8*, i8** %r191
+  %r272 = call i8* @nurl_llty(i8* %r271)
   call void @nurl_print(i8* %r272)
-  %r273 = getelementptr [2 x i8], [2 x i8]* @.str.2823, i64 0, i64 0
+  %r273 = getelementptr [3 x i8], [3 x i8]* @.str.2822, i64 0, i64 0
   call void @nurl_print(i8* %r273)
-  %r274 = load i8*, i8** %r244
-  %r275 = load i8*, i8** %r190
-  call void @nurl_free(i8* %r275)
-  %r276 = load i8*, i8** %r202
-  call void @nurl_free(i8* %r276)
-  %r277 = load i8*, i8** %r246
+  %r274 = load i8*, i8** %r247
+  call void @nurl_print(i8* %r274)
+  %r275 = getelementptr [2 x i8], [2 x i8]* @.str.2823, i64 0, i64 0
+  call void @nurl_print(i8* %r275)
+  %r276 = load i8*, i8** %r245
+  %r277 = load i8*, i8** %r191
   call void @nurl_free(i8* %r277)
-  ret i8* %r274
+  %r278 = load i8*, i8** %r203
+  call void @nurl_free(i8* %r278)
+  %r279 = load i8*, i8** %r247
+  call void @nurl_free(i8* %r279)
+  ret i8* %r276
 else_29:
-  %r278 = load i8*, i8** %r218
-  %r279 = call i64 @nurl_str_len(i8* %r278)
-  %r280 = icmp ne i64 0, %r279
-  br i1 %r280, label %then_31, label %else_32
+  %r280 = load i8*, i8** %r219
+  %r281 = call i64 @nurl_str_len(i8* %r280)
+  %r282 = icmp ne i64 0, %r281
+  br i1 %r282, label %then_31, label %else_32
 then_31:
   call void @nurl_lex_advance(i64 %lex)
-  %r281 = load i8*, i8** %r202
-  %r282 = getelementptr [3 x i8], [3 x i8]* @.str.2824, i64 0, i64 0
-  %r283 = load i8*, i8** %r205
-  %r284 = getelementptr [7 x i8], [7 x i8]* @.str.2825, i64 0, i64 0
-  %r285 = call i8* @nurl_str_cat(i8* %r283, i8* %r284)
-  %r286 = call i8* @nurl_str_cat(i8* %r282, i8* %r285)
-  call void @nurl_free(i8* %r285)
-  %r287 = call i8* @nurl_sym_get2(i64 %syms, i8* %r281, i8* %r286)
-  call void @nurl_free(i8* %r286)
-  store i8* %r287, i8** %r288
-  %r289 = load i8*, i8** %r218
-  %r290 = call i64 @nurl_str_to_int(i8* %r289)
-  store i64 %r290, i64* %r291
-  %r292 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
-  store i8* %r292, i8** %r293
-  %r294 = call i8* @nurl_get_last_type()
-  %r295 = load i8*, i8** %r288
-  %r296 = call i1 @__store_type_clash__fp1(i8* %r294, i8* %r295)
-  br i1 %r296, label %then_34, label %else_35
+  %r283 = load i8*, i8** %r203
+  %r284 = getelementptr [3 x i8], [3 x i8]* @.str.2824, i64 0, i64 0
+  %r285 = load i8*, i8** %r206
+  %r286 = getelementptr [7 x i8], [7 x i8]* @.str.2825, i64 0, i64 0
+  %r287 = call i8* @nurl_str_cat(i8* %r285, i8* %r286)
+  %r288 = call i8* @nurl_str_cat(i8* %r284, i8* %r287)
+  call void @nurl_free(i8* %r287)
+  %r289 = call i8* @nurl_sym_get2(i64 %syms, i8* %r283, i8* %r288)
+  call void @nurl_free(i8* %r288)
+  store i8* %r289, i8** %r290
+  %r291 = load i8*, i8** %r219
+  %r292 = call i64 @nurl_str_to_int(i8* %r291)
+  store i64 %r292, i64* %r293
+  %r294 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
+  store i8* %r294, i8** %r295
+  %r296 = call i8* @nurl_get_last_type()
+  %r297 = load i8*, i8** %r290
+  %r298 = call i1 @__store_type_clash__fp1(i8* %r296, i8* %r297)
+  br i1 %r298, label %then_34, label %else_35
 then_34:
-  %r297 = getelementptr [31 x i8], [31 x i8]* @.str.2826, i64 0, i64 0
-  %r298 = call i8* @nurl_get_last_type()
-  %r299 = getelementptr [15 x i8], [15 x i8]* @.str.2827, i64 0, i64 0
-  %r300 = load i8*, i8** %r205
-  %r301 = call i8* @nurl_str_cat4(i8* %r297, i8* %r298, i8* %r299, i8* %r300)
-  %r302 = getelementptr [12 x i8], [12 x i8]* @.str.2828, i64 0, i64 0
-  %r303 = load i8*, i8** %r288
-  %r304 = getelementptr [39 x i8], [39 x i8]* @.str.2829, i64 0, i64 0
-  %r305 = call i8* @nurl_str_cat3(i8* %r302, i8* %r303, i8* %r304)
-  %r306 = call i8* @nurl_str_cat(i8* %r301, i8* %r305)
-  call void @nurl_free(i8* %r301)
-  call void @nurl_free(i8* %r305)
-  call void @die(i64 %lex, i8* %r306)
-  call void @nurl_free(i8* %r306)
+  %r299 = getelementptr [31 x i8], [31 x i8]* @.str.2826, i64 0, i64 0
+  %r300 = call i8* @nurl_get_last_type()
+  %r301 = getelementptr [15 x i8], [15 x i8]* @.str.2827, i64 0, i64 0
+  %r302 = load i8*, i8** %r206
+  %r303 = call i8* @nurl_str_cat4(i8* %r299, i8* %r300, i8* %r301, i8* %r302)
+  %r304 = getelementptr [12 x i8], [12 x i8]* @.str.2828, i64 0, i64 0
+  %r305 = load i8*, i8** %r290
+  %r306 = getelementptr [39 x i8], [39 x i8]* @.str.2829, i64 0, i64 0
+  %r307 = call i8* @nurl_str_cat3(i8* %r304, i8* %r305, i8* %r306)
+  %r308 = call i8* @nurl_str_cat(i8* %r303, i8* %r307)
+  call void @nurl_free(i8* %r303)
+  call void @nurl_free(i8* %r307)
+  call void @die(i64 %lex, i8* %r308)
+  call void @nurl_free(i8* %r308)
   br label %end_36
 else_35:
   br label %end_36
 end_36:
-  %r307 = call i8* @nurl_cg_reg(i64 %cg)
-  store i8* %r307, i8** %r308
-  %r309 = load i8*, i8** %r308
-  call void @nurl_journal_push(i8* %r309)
-  %r310 = getelementptr [3 x i8], [3 x i8]* @.str.2830, i64 0, i64 0
-  call void @nurl_print(i8* %r310)
-  %r311 = load i8*, i8** %r308
-  call void @nurl_print(i8* %r311)
-  %r312 = getelementptr [18 x i8], [18 x i8]* @.str.2831, i64 0, i64 0
+  %r309 = call i8* @nurl_cg_reg(i64 %cg)
+  store i8* %r309, i8** %r310
+  %r311 = load i8*, i8** %r310
+  call void @nurl_journal_push(i8* %r311)
+  %r312 = getelementptr [3 x i8], [3 x i8]* @.str.2830, i64 0, i64 0
   call void @nurl_print(i8* %r312)
-  %r313 = load i8*, i8** %r190
-  %r314 = call i8* @nurl_llty(i8* %r313)
+  %r313 = load i8*, i8** %r310
+  call void @nurl_print(i8* %r313)
+  %r314 = getelementptr [18 x i8], [18 x i8]* @.str.2831, i64 0, i64 0
   call void @nurl_print(i8* %r314)
-  %r315 = getelementptr [3 x i8], [3 x i8]* @.str.2832, i64 0, i64 0
-  call void @nurl_print(i8* %r315)
-  %r316 = load i8*, i8** %r10
-  %r317 = call i8* @nurl_llty(i8* %r316)
+  %r315 = load i8*, i8** %r191
+  %r316 = call i8* @nurl_llty(i8* %r315)
+  call void @nurl_print(i8* %r316)
+  %r317 = getelementptr [3 x i8], [3 x i8]* @.str.2832, i64 0, i64 0
   call void @nurl_print(i8* %r317)
-  %r318 = getelementptr [2 x i8], [2 x i8]* @.str.2833, i64 0, i64 0
-  call void @nurl_print(i8* %r318)
-  %r319 = load i8*, i8** %r8
+  %r318 = load i8*, i8** %r10
+  %r319 = call i8* @nurl_llty(i8* %r318)
   call void @nurl_print(i8* %r319)
-  %r320 = getelementptr [14 x i8], [14 x i8]* @.str.2834, i64 0, i64 0
+  %r320 = getelementptr [2 x i8], [2 x i8]* @.str.2833, i64 0, i64 0
   call void @nurl_print(i8* %r320)
-  %r321 = load i64, i64* %r291
-  %r322 = call i8* @nurl_str_int(i64 %r321)
+  %r321 = load i8*, i8** %r8
+  call void @nurl_print(i8* %r321)
+  %r322 = getelementptr [14 x i8], [14 x i8]* @.str.2834, i64 0, i64 0
   call void @nurl_print(i8* %r322)
-  call void @nurl_free(i8* %r322)
-  %r323 = getelementptr [2 x i8], [2 x i8]* @.str.2835, i64 0, i64 0
-  call void @nurl_print(i8* %r323)
-  %r324 = getelementptr [9 x i8], [9 x i8]* @.str.2836, i64 0, i64 0
+  %r323 = load i64, i64* %r293
+  %r324 = call i8* @nurl_str_int(i64 %r323)
   call void @nurl_print(i8* %r324)
-  %r325 = load i8*, i8** %r288
-  %r326 = call i8* @nurl_llty(i8* %r325)
+  call void @nurl_free(i8* %r324)
+  %r325 = getelementptr [2 x i8], [2 x i8]* @.str.2835, i64 0, i64 0
+  call void @nurl_print(i8* %r325)
+  %r326 = getelementptr [9 x i8], [9 x i8]* @.str.2836, i64 0, i64 0
   call void @nurl_print(i8* %r326)
-  %r327 = getelementptr [2 x i8], [2 x i8]* @.str.2837, i64 0, i64 0
-  call void @nurl_print(i8* %r327)
-  %r328 = load i8*, i8** %r293
+  %r327 = load i8*, i8** %r290
+  %r328 = call i8* @nurl_llty(i8* %r327)
   call void @nurl_print(i8* %r328)
-  %r329 = getelementptr [3 x i8], [3 x i8]* @.str.2838, i64 0, i64 0
+  %r329 = getelementptr [2 x i8], [2 x i8]* @.str.2837, i64 0, i64 0
   call void @nurl_print(i8* %r329)
-  %r330 = load i8*, i8** %r288
-  %r331 = call i8* @nurl_llty(i8* %r330)
+  %r330 = load i8*, i8** %r295
+  call void @nurl_print(i8* %r330)
+  %r331 = getelementptr [3 x i8], [3 x i8]* @.str.2838, i64 0, i64 0
   call void @nurl_print(i8* %r331)
-  %r332 = getelementptr [3 x i8], [3 x i8]* @.str.2839, i64 0, i64 0
-  call void @nurl_print(i8* %r332)
-  %r333 = load i8*, i8** %r308
+  %r332 = load i8*, i8** %r290
+  %r333 = call i8* @nurl_llty(i8* %r332)
   call void @nurl_print(i8* %r333)
-  %r334 = getelementptr [2 x i8], [2 x i8]* @.str.2840, i64 0, i64 0
+  %r334 = getelementptr [3 x i8], [3 x i8]* @.str.2839, i64 0, i64 0
   call void @nurl_print(i8* %r334)
-  %r335 = load i8*, i8** %r293
-  %r336 = load i8*, i8** %r190
-  call void @nurl_free(i8* %r336)
-  %r337 = load i8*, i8** %r202
-  call void @nurl_free(i8* %r337)
-  %r338 = load i8*, i8** %r308
+  %r335 = load i8*, i8** %r310
+  call void @nurl_print(i8* %r335)
+  %r336 = getelementptr [2 x i8], [2 x i8]* @.str.2840, i64 0, i64 0
+  call void @nurl_print(i8* %r336)
+  %r337 = load i8*, i8** %r295
+  %r338 = load i8*, i8** %r191
   call void @nurl_free(i8* %r338)
-  ret i8* %r335
+  %r339 = load i8*, i8** %r203
+  call void @nurl_free(i8* %r339)
+  %r340 = load i8*, i8** %r310
+  call void @nurl_free(i8* %r340)
+  ret i8* %r337
 else_32:
-  %r339 = load i8*, i8** %r232
-  %r340 = call i64 @nurl_str_len(i8* %r339)
-  %r341 = icmp ne i64 0, %r340
-  br i1 %r341, label %or_end_38, label %or_right_37
+  %r341 = load i8*, i8** %r233
+  %r342 = call i64 @nurl_str_len(i8* %r341)
+  %r343 = icmp ne i64 0, %r342
+  br i1 %r343, label %or_end_38, label %or_right_37
 or_right_37:
-  %r342 = load i1, i1* %r221
-  %r343 = xor i1 %r342, 1
+  %r344 = load i1, i1* %r222
+  %r345 = xor i1 %r344, 1
   br label %or_end_38
 or_end_38:
-  %r344 = phi i1 [ 1, %else_32 ], [ %r343, %or_right_37 ]
-  br i1 %r344, label %then_39, label %else_40
+  %r346 = phi i1 [ 1, %else_32 ], [ %r345, %or_right_37 ]
+  br i1 %r346, label %then_39, label %else_40
 then_39:
-  %r345 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
-  store i8* %r345, i8** %r346
-  %r347 = call i8* @nurl_get_last_type()
+  %r347 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
   store i8* %r347, i8** %r348
-  %r349 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
+  %r349 = call i8* @nurl_get_last_type()
   store i8* %r349, i8** %r350
-  %r351 = call i8* @nurl_cg_reg(i64 %cg)
+  %r351 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
   store i8* %r351, i8** %r352
-  %r353 = load i8*, i8** %r352
-  call void @nurl_journal_push(i8* %r353)
-  %r354 = getelementptr [3 x i8], [3 x i8]* @.str.2841, i64 0, i64 0
-  call void @nurl_print(i8* %r354)
-  %r355 = load i8*, i8** %r352
-  call void @nurl_print(i8* %r355)
-  %r356 = getelementptr [18 x i8], [18 x i8]* @.str.2842, i64 0, i64 0
+  %r353 = call i8* @nurl_cg_reg(i64 %cg)
+  store i8* %r353, i8** %r354
+  %r355 = load i8*, i8** %r354
+  call void @nurl_journal_push(i8* %r355)
+  %r356 = getelementptr [3 x i8], [3 x i8]* @.str.2841, i64 0, i64 0
   call void @nurl_print(i8* %r356)
-  %r357 = load i8*, i8** %r190
-  %r358 = call i8* @nurl_llty(i8* %r357)
+  %r357 = load i8*, i8** %r354
+  call void @nurl_print(i8* %r357)
+  %r358 = getelementptr [18 x i8], [18 x i8]* @.str.2842, i64 0, i64 0
   call void @nurl_print(i8* %r358)
-  %r359 = getelementptr [3 x i8], [3 x i8]* @.str.2843, i64 0, i64 0
-  call void @nurl_print(i8* %r359)
-  %r360 = load i8*, i8** %r10
-  %r361 = call i8* @nurl_llty(i8* %r360)
+  %r359 = load i8*, i8** %r191
+  %r360 = call i8* @nurl_llty(i8* %r359)
+  call void @nurl_print(i8* %r360)
+  %r361 = getelementptr [3 x i8], [3 x i8]* @.str.2843, i64 0, i64 0
   call void @nurl_print(i8* %r361)
-  %r362 = getelementptr [2 x i8], [2 x i8]* @.str.2844, i64 0, i64 0
-  call void @nurl_print(i8* %r362)
-  %r363 = load i8*, i8** %r8
+  %r362 = load i8*, i8** %r10
+  %r363 = call i8* @nurl_llty(i8* %r362)
   call void @nurl_print(i8* %r363)
-  %r364 = getelementptr [3 x i8], [3 x i8]* @.str.2845, i64 0, i64 0
+  %r364 = getelementptr [2 x i8], [2 x i8]* @.str.2844, i64 0, i64 0
   call void @nurl_print(i8* %r364)
-  %r365 = load i8*, i8** %r348
+  %r365 = load i8*, i8** %r8
   call void @nurl_print(i8* %r365)
-  %r366 = getelementptr [2 x i8], [2 x i8]* @.str.2846, i64 0, i64 0
+  %r366 = getelementptr [3 x i8], [3 x i8]* @.str.2845, i64 0, i64 0
   call void @nurl_print(i8* %r366)
-  %r367 = load i8*, i8** %r346
-  call void @nurl_print(i8* %r367)
-  %r368 = getelementptr [2 x i8], [2 x i8]* @.str.2847, i64 0, i64 0
+  %r367 = load i8*, i8** %r350
+  %r368 = call i8* @nurl_llty(i8* %r367)
   call void @nurl_print(i8* %r368)
-  %r369 = getelementptr [9 x i8], [9 x i8]* @.str.2848, i64 0, i64 0
+  %r369 = getelementptr [2 x i8], [2 x i8]* @.str.2846, i64 0, i64 0
   call void @nurl_print(i8* %r369)
-  %r370 = load i8*, i8** %r190
-  %r371 = call i8* @nurl_llty(i8* %r370)
+  %r370 = load i8*, i8** %r348
+  call void @nurl_print(i8* %r370)
+  %r371 = getelementptr [2 x i8], [2 x i8]* @.str.2847, i64 0, i64 0
   call void @nurl_print(i8* %r371)
-  %r372 = getelementptr [2 x i8], [2 x i8]* @.str.2849, i64 0, i64 0
+  %r372 = getelementptr [9 x i8], [9 x i8]* @.str.2848, i64 0, i64 0
   call void @nurl_print(i8* %r372)
-  %r373 = load i8*, i8** %r350
-  call void @nurl_print(i8* %r373)
-  %r374 = getelementptr [3 x i8], [3 x i8]* @.str.2850, i64 0, i64 0
+  %r373 = load i8*, i8** %r191
+  %r374 = call i8* @nurl_llty(i8* %r373)
   call void @nurl_print(i8* %r374)
-  %r375 = load i8*, i8** %r190
-  %r376 = call i8* @nurl_llty(i8* %r375)
+  %r375 = getelementptr [2 x i8], [2 x i8]* @.str.2849, i64 0, i64 0
+  call void @nurl_print(i8* %r375)
+  %r376 = load i8*, i8** %r352
   call void @nurl_print(i8* %r376)
-  %r377 = getelementptr [3 x i8], [3 x i8]* @.str.2851, i64 0, i64 0
+  %r377 = getelementptr [3 x i8], [3 x i8]* @.str.2850, i64 0, i64 0
   call void @nurl_print(i8* %r377)
-  %r378 = load i8*, i8** %r352
-  call void @nurl_print(i8* %r378)
-  %r379 = getelementptr [2 x i8], [2 x i8]* @.str.2852, i64 0, i64 0
+  %r378 = load i8*, i8** %r191
+  %r379 = call i8* @nurl_llty(i8* %r378)
   call void @nurl_print(i8* %r379)
-  %r380 = load i8*, i8** %r350
-  %r381 = load i8*, i8** %r190
-  call void @nurl_free(i8* %r381)
-  %r382 = load i8*, i8** %r202
-  call void @nurl_free(i8* %r382)
+  %r380 = getelementptr [3 x i8], [3 x i8]* @.str.2851, i64 0, i64 0
+  call void @nurl_print(i8* %r380)
+  %r381 = load i8*, i8** %r354
+  call void @nurl_print(i8* %r381)
+  %r382 = getelementptr [2 x i8], [2 x i8]* @.str.2852, i64 0, i64 0
+  call void @nurl_print(i8* %r382)
   %r383 = load i8*, i8** %r352
-  call void @nurl_free(i8* %r383)
-  ret i8* %r380
-else_40:
-  %r384 = getelementptr [28 x i8], [28 x i8]* @.str.2853, i64 0, i64 0
-  %r385 = load i8*, i8** %r205
-  %r386 = call i8* @nurl_str_cat(i8* %r384, i8* %r385)
-  call void @die(i64 %lex, i8* %r386)
+  %r384 = load i8*, i8** %r191
+  call void @nurl_free(i8* %r384)
+  %r385 = load i8*, i8** %r203
+  call void @nurl_free(i8* %r385)
+  %r386 = load i8*, i8** %r354
   call void @nurl_free(i8* %r386)
+  ret i8* %r383
+else_40:
+  %r387 = getelementptr [28 x i8], [28 x i8]* @.str.2853, i64 0, i64 0
+  %r388 = load i8*, i8** %r206
+  %r389 = call i8* @nurl_str_cat(i8* %r387, i8* %r388)
+  call void @die(i64 %lex, i8* %r389)
+  call void @nurl_free(i8* %r389)
   br label %end_41
 end_41:
   br label %end_33
 end_33:
   br label %end_30
 end_30:
-  %r387 = load i8*, i8** %r202
-  call void @nurl_free(i8* %r387)
+  %r390 = load i8*, i8** %r203
+  call void @nurl_free(i8* %r390)
   br label %end_20
 else_19:
-  %r388 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
-  store i8* %r388, i8** %r389
-  %r390 = call i8* @nurl_get_last_type()
-  store i8* %r390, i8** %r391
-  %r392 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
-  store i8* %r392, i8** %r393
-  %r394 = call i8* @nurl_cg_reg(i64 %cg)
-  store i8* %r394, i8** %r395
-  %r396 = load i8*, i8** %r395
-  call void @nurl_journal_push(i8* %r396)
-  %r397 = getelementptr [3 x i8], [3 x i8]* @.str.2854, i64 0, i64 0
-  call void @nurl_print(i8* %r397)
-  %r398 = load i8*, i8** %r395
-  call void @nurl_print(i8* %r398)
-  %r399 = getelementptr [18 x i8], [18 x i8]* @.str.2855, i64 0, i64 0
-  call void @nurl_print(i8* %r399)
-  %r400 = load i8*, i8** %r190
-  %r401 = call i8* @nurl_llty(i8* %r400)
+  %r391 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
+  store i8* %r391, i8** %r392
+  %r393 = call i8* @nurl_get_last_type()
+  store i8* %r393, i8** %r394
+  %r395 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
+  store i8* %r395, i8** %r396
+  %r397 = call i8* @nurl_cg_reg(i64 %cg)
+  store i8* %r397, i8** %r398
+  %r399 = load i8*, i8** %r398
+  call void @nurl_journal_push(i8* %r399)
+  %r400 = getelementptr [3 x i8], [3 x i8]* @.str.2854, i64 0, i64 0
+  call void @nurl_print(i8* %r400)
+  %r401 = load i8*, i8** %r398
   call void @nurl_print(i8* %r401)
-  %r402 = getelementptr [3 x i8], [3 x i8]* @.str.2856, i64 0, i64 0
+  %r402 = getelementptr [18 x i8], [18 x i8]* @.str.2855, i64 0, i64 0
   call void @nurl_print(i8* %r402)
-  %r403 = load i8*, i8** %r10
+  %r403 = load i8*, i8** %r191
   %r404 = call i8* @nurl_llty(i8* %r403)
   call void @nurl_print(i8* %r404)
-  %r405 = getelementptr [2 x i8], [2 x i8]* @.str.2857, i64 0, i64 0
+  %r405 = getelementptr [3 x i8], [3 x i8]* @.str.2856, i64 0, i64 0
   call void @nurl_print(i8* %r405)
-  %r406 = load i8*, i8** %r8
-  call void @nurl_print(i8* %r406)
-  %r407 = getelementptr [3 x i8], [3 x i8]* @.str.2858, i64 0, i64 0
+  %r406 = load i8*, i8** %r10
+  %r407 = call i8* @nurl_llty(i8* %r406)
   call void @nurl_print(i8* %r407)
-  %r408 = load i8*, i8** %r391
+  %r408 = getelementptr [2 x i8], [2 x i8]* @.str.2857, i64 0, i64 0
   call void @nurl_print(i8* %r408)
-  %r409 = getelementptr [2 x i8], [2 x i8]* @.str.2859, i64 0, i64 0
+  %r409 = load i8*, i8** %r8
   call void @nurl_print(i8* %r409)
-  %r410 = load i8*, i8** %r389
+  %r410 = getelementptr [3 x i8], [3 x i8]* @.str.2858, i64 0, i64 0
   call void @nurl_print(i8* %r410)
-  %r411 = getelementptr [2 x i8], [2 x i8]* @.str.2860, i64 0, i64 0
-  call void @nurl_print(i8* %r411)
-  %r412 = getelementptr [9 x i8], [9 x i8]* @.str.2861, i64 0, i64 0
+  %r411 = load i8*, i8** %r394
+  %r412 = call i8* @nurl_llty(i8* %r411)
   call void @nurl_print(i8* %r412)
-  %r413 = load i8*, i8** %r190
-  %r414 = call i8* @nurl_llty(i8* %r413)
+  %r413 = getelementptr [2 x i8], [2 x i8]* @.str.2859, i64 0, i64 0
+  call void @nurl_print(i8* %r413)
+  %r414 = load i8*, i8** %r392
   call void @nurl_print(i8* %r414)
-  %r415 = getelementptr [2 x i8], [2 x i8]* @.str.2862, i64 0, i64 0
+  %r415 = getelementptr [2 x i8], [2 x i8]* @.str.2860, i64 0, i64 0
   call void @nurl_print(i8* %r415)
-  %r416 = load i8*, i8** %r393
+  %r416 = getelementptr [9 x i8], [9 x i8]* @.str.2861, i64 0, i64 0
   call void @nurl_print(i8* %r416)
-  %r417 = getelementptr [3 x i8], [3 x i8]* @.str.2863, i64 0, i64 0
-  call void @nurl_print(i8* %r417)
-  %r418 = load i8*, i8** %r190
-  %r419 = call i8* @nurl_llty(i8* %r418)
+  %r417 = load i8*, i8** %r191
+  %r418 = call i8* @nurl_llty(i8* %r417)
+  call void @nurl_print(i8* %r418)
+  %r419 = getelementptr [2 x i8], [2 x i8]* @.str.2862, i64 0, i64 0
   call void @nurl_print(i8* %r419)
-  %r420 = getelementptr [3 x i8], [3 x i8]* @.str.2864, i64 0, i64 0
+  %r420 = load i8*, i8** %r396
   call void @nurl_print(i8* %r420)
-  %r421 = load i8*, i8** %r395
+  %r421 = getelementptr [3 x i8], [3 x i8]* @.str.2863, i64 0, i64 0
   call void @nurl_print(i8* %r421)
-  %r422 = getelementptr [2 x i8], [2 x i8]* @.str.2865, i64 0, i64 0
-  call void @nurl_print(i8* %r422)
-  %r423 = load i8*, i8** %r393
-  %r424 = load i8*, i8** %r190
-  call void @nurl_free(i8* %r424)
-  %r425 = load i8*, i8** %r395
-  call void @nurl_free(i8* %r425)
-  ret i8* %r423
+  %r422 = load i8*, i8** %r191
+  %r423 = call i8* @nurl_llty(i8* %r422)
+  call void @nurl_print(i8* %r423)
+  %r424 = getelementptr [3 x i8], [3 x i8]* @.str.2864, i64 0, i64 0
+  call void @nurl_print(i8* %r424)
+  %r425 = load i8*, i8** %r398
+  call void @nurl_print(i8* %r425)
+  %r426 = getelementptr [2 x i8], [2 x i8]* @.str.2865, i64 0, i64 0
+  call void @nurl_print(i8* %r426)
+  %r427 = load i8*, i8** %r396
+  %r428 = load i8*, i8** %r191
+  call void @nurl_free(i8* %r428)
+  %r429 = load i8*, i8** %r398
+  call void @nurl_free(i8* %r429)
+  ret i8* %r427
 end_20:
-  %r426 = load i8*, i8** %r190
-  call void @nurl_free(i8* %r426)
+  %r430 = load i8*, i8** %r191
+  call void @nurl_free(i8* %r430)
   br label %end_17
 else_16:
-  %r427 = load i8*, i8** %r6
-  %r428 = getelementptr [6 x i8], [6 x i8]* @.str.2866, i64 0, i64 0
-  %r429 = call i8* @nurl_sym_get2(i64 %syms, i8* %r427, i8* %r428)
-  store i8* %r429, i8** %r430
-  %r431 = load i8*, i8** %r10
-  %r432 = getelementptr [2 x i8], [2 x i8]* @.str.2867, i64 0, i64 0
-  %r433 = call i8* @nurl_str_cat(i8* %r431, i8* %r432)
+  %r431 = load i8*, i8** %r6
+  %r432 = getelementptr [6 x i8], [6 x i8]* @.str.2866, i64 0, i64 0
+  %r433 = call i8* @nurl_sym_get2(i64 %syms, i8* %r431, i8* %r432)
   store i8* %r433, i8** %r434
-  %r435 = load i8*, i8** %r434
-  call void @nurl_journal_push(i8* %r435)
-  %r436 = load i8*, i8** %r10
-  %r437 = load i64, i64* %r178
-  %r438 = sub i64 %r437, 1
-  %r439 = call i8* @nurl_str_slice(i8* %r436, i64 1, i64 %r438)
-  store i8* %r439, i8** %r440
-  %r441 = load i8*, i8** %r440
-  call void @nurl_journal_push(i8* %r441)
-  %r442 = call i8* @nurl_lex_val(i64 %lex)
-  store i8* %r442, i8** %r443
+  %r435 = load i8*, i8** %r10
+  %r436 = getelementptr [2 x i8], [2 x i8]* @.str.2867, i64 0, i64 0
+  %r437 = call i8* @nurl_str_cat(i8* %r435, i8* %r436)
+  store i8* %r437, i8** %r438
+  %r439 = load i8*, i8** %r438
+  call void @nurl_journal_push(i8* %r439)
+  %r440 = load i8*, i8** %r10
+  %r441 = load i64, i64* %r179
+  %r442 = sub i64 %r441, 1
+  %r443 = call i8* @nurl_str_slice(i8* %r440, i64 1, i64 %r442)
+  store i8* %r443, i8** %r444
+  %r445 = load i8*, i8** %r444
+  call void @nurl_journal_push(i8* %r445)
+  %r446 = call i8* @nurl_lex_val(i64 %lex)
+  store i8* %r446, i8** %r447
   call void @nurl_lex_advance(i64 %lex)
-  %r444 = load i8*, i8** %r440
-  %r445 = getelementptr [3 x i8], [3 x i8]* @.str.2868, i64 0, i64 0
-  %r446 = load i8*, i8** %r443
-  %r447 = getelementptr [6 x i8], [6 x i8]* @.str.2869, i64 0, i64 0
-  %r448 = call i8* @nurl_str_cat(i8* %r446, i8* %r447)
-  %r449 = call i8* @nurl_str_cat(i8* %r445, i8* %r448)
-  call void @nurl_free(i8* %r448)
-  %r450 = call i8* @nurl_sym_get2(i64 %syms, i8* %r444, i8* %r449)
-  call void @nurl_free(i8* %r449)
-  store i8* %r450, i8** %r451
-  %r452 = load i8*, i8** %r440
-  %r453 = getelementptr [3 x i8], [3 x i8]* @.str.2870, i64 0, i64 0
-  %r454 = load i8*, i8** %r443
-  %r455 = getelementptr [7 x i8], [7 x i8]* @.str.2871, i64 0, i64 0
-  %r456 = call i8* @nurl_str_cat(i8* %r454, i8* %r455)
-  %r457 = call i8* @nurl_str_cat(i8* %r453, i8* %r456)
-  call void @nurl_free(i8* %r456)
-  %r458 = call i8* @nurl_sym_get2(i64 %syms, i8* %r452, i8* %r457)
-  call void @nurl_free(i8* %r457)
-  store i8* %r458, i8** %r459
-  %r460 = load i8*, i8** %r451
-  %r461 = call i64 @nurl_str_to_int(i8* %r460)
-  store i64 %r461, i64* %r462
-  %r463 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
-  store i8* %r463, i8** %r464
-  %r465 = call i8* @nurl_get_last_type()
-  %r466 = load i8*, i8** %r459
-  %r467 = call i1 @__store_type_clash__fp1(i8* %r465, i8* %r466)
-  br i1 %r467, label %then_42, label %else_43
-then_42:
-  %r468 = getelementptr [31 x i8], [31 x i8]* @.str.2872, i64 0, i64 0
+  %r448 = load i8*, i8** %r444
+  %r449 = getelementptr [3 x i8], [3 x i8]* @.str.2868, i64 0, i64 0
+  %r450 = load i8*, i8** %r447
+  %r451 = getelementptr [6 x i8], [6 x i8]* @.str.2869, i64 0, i64 0
+  %r452 = call i8* @nurl_str_cat(i8* %r450, i8* %r451)
+  %r453 = call i8* @nurl_str_cat(i8* %r449, i8* %r452)
+  call void @nurl_free(i8* %r452)
+  %r454 = call i8* @nurl_sym_get2(i64 %syms, i8* %r448, i8* %r453)
+  call void @nurl_free(i8* %r453)
+  store i8* %r454, i8** %r455
+  %r456 = load i8*, i8** %r444
+  %r457 = getelementptr [3 x i8], [3 x i8]* @.str.2870, i64 0, i64 0
+  %r458 = load i8*, i8** %r447
+  %r459 = getelementptr [7 x i8], [7 x i8]* @.str.2871, i64 0, i64 0
+  %r460 = call i8* @nurl_str_cat(i8* %r458, i8* %r459)
+  %r461 = call i8* @nurl_str_cat(i8* %r457, i8* %r460)
+  call void @nurl_free(i8* %r460)
+  %r462 = call i8* @nurl_sym_get2(i64 %syms, i8* %r456, i8* %r461)
+  call void @nurl_free(i8* %r461)
+  store i8* %r462, i8** %r463
+  %r464 = load i8*, i8** %r455
+  %r465 = call i64 @nurl_str_to_int(i8* %r464)
+  store i64 %r465, i64* %r466
+  %r467 = call i8* @gen_expr(i64 %lex, i64 %syms, i64 %cg)
+  store i8* %r467, i8** %r468
   %r469 = call i8* @nurl_get_last_type()
-  %r470 = getelementptr [15 x i8], [15 x i8]* @.str.2873, i64 0, i64 0
-  %r471 = load i8*, i8** %r443
-  %r472 = call i8* @nurl_str_cat4(i8* %r468, i8* %r469, i8* %r470, i8* %r471)
-  %r473 = getelementptr [12 x i8], [12 x i8]* @.str.2874, i64 0, i64 0
-  %r474 = load i8*, i8** %r459
-  %r475 = getelementptr [39 x i8], [39 x i8]* @.str.2875, i64 0, i64 0
-  %r476 = call i8* @nurl_str_cat3(i8* %r473, i8* %r474, i8* %r475)
-  %r477 = call i8* @nurl_str_cat(i8* %r472, i8* %r476)
-  call void @nurl_free(i8* %r472)
+  %r470 = load i8*, i8** %r463
+  %r471 = call i1 @__store_type_clash__fp1(i8* %r469, i8* %r470)
+  br i1 %r471, label %then_42, label %else_43
+then_42:
+  %r472 = getelementptr [31 x i8], [31 x i8]* @.str.2872, i64 0, i64 0
+  %r473 = call i8* @nurl_get_last_type()
+  %r474 = getelementptr [15 x i8], [15 x i8]* @.str.2873, i64 0, i64 0
+  %r475 = load i8*, i8** %r447
+  %r476 = call i8* @nurl_str_cat4(i8* %r472, i8* %r473, i8* %r474, i8* %r475)
+  %r477 = getelementptr [12 x i8], [12 x i8]* @.str.2874, i64 0, i64 0
+  %r478 = load i8*, i8** %r463
+  %r479 = getelementptr [39 x i8], [39 x i8]* @.str.2875, i64 0, i64 0
+  %r480 = call i8* @nurl_str_cat3(i8* %r477, i8* %r478, i8* %r479)
+  %r481 = call i8* @nurl_str_cat(i8* %r476, i8* %r480)
   call void @nurl_free(i8* %r476)
-  call void @die(i64 %lex, i8* %r477)
-  call void @nurl_free(i8* %r477)
+  call void @nurl_free(i8* %r480)
+  call void @die(i64 %lex, i8* %r481)
+  call void @nurl_free(i8* %r481)
   br label %end_44
 else_43:
   br label %end_44
 end_44:
-  %r478 = call i8* @nurl_cg_reg(i64 %cg)
-  store i8* %r478, i8** %r479
-  %r480 = load i8*, i8** %r479
-  call void @nurl_journal_push(i8* %r480)
-  %r481 = getelementptr [3 x i8], [3 x i8]* @.str.2876, i64 0, i64 0
-  call void @nurl_print(i8* %r481)
-  %r482 = load i8*, i8** %r479
-  call void @nurl_print(i8* %r482)
-  %r483 = getelementptr [18 x i8], [18 x i8]* @.str.2877, i64 0, i64 0
-  call void @nurl_print(i8* %r483)
-  %r484 = load i8*, i8** %r10
-  %r485 = call i8* @nurl_llty(i8* %r484)
+  %r482 = call i8* @nurl_cg_reg(i64 %cg)
+  store i8* %r482, i8** %r483
+  %r484 = load i8*, i8** %r483
+  call void @nurl_journal_push(i8* %r484)
+  %r485 = getelementptr [3 x i8], [3 x i8]* @.str.2876, i64 0, i64 0
   call void @nurl_print(i8* %r485)
-  %r486 = getelementptr [3 x i8], [3 x i8]* @.str.2878, i64 0, i64 0
+  %r486 = load i8*, i8** %r483
   call void @nurl_print(i8* %r486)
-  %r487 = load i8*, i8** %r434
+  %r487 = getelementptr [18 x i8], [18 x i8]* @.str.2877, i64 0, i64 0
   call void @nurl_print(i8* %r487)
-  %r488 = getelementptr [2 x i8], [2 x i8]* @.str.2879, i64 0, i64 0
-  call void @nurl_print(i8* %r488)
-  %r489 = load i8*, i8** %r430
+  %r488 = load i8*, i8** %r10
+  %r489 = call i8* @nurl_llty(i8* %r488)
   call void @nurl_print(i8* %r489)
-  %r490 = getelementptr [14 x i8], [14 x i8]* @.str.2880, i64 0, i64 0
+  %r490 = getelementptr [3 x i8], [3 x i8]* @.str.2878, i64 0, i64 0
   call void @nurl_print(i8* %r490)
-  %r491 = load i64, i64* %r462
-  %r492 = call i8* @nurl_str_int(i64 %r491)
+  %r491 = load i8*, i8** %r438
+  call void @nurl_print(i8* %r491)
+  %r492 = getelementptr [2 x i8], [2 x i8]* @.str.2879, i64 0, i64 0
   call void @nurl_print(i8* %r492)
-  call void @nurl_free(i8* %r492)
-  %r493 = getelementptr [2 x i8], [2 x i8]* @.str.2881, i64 0, i64 0
+  %r493 = load i8*, i8** %r434
   call void @nurl_print(i8* %r493)
-  %r494 = getelementptr [9 x i8], [9 x i8]* @.str.2882, i64 0, i64 0
+  %r494 = getelementptr [14 x i8], [14 x i8]* @.str.2880, i64 0, i64 0
   call void @nurl_print(i8* %r494)
-  %r495 = load i8*, i8** %r459
-  %r496 = call i8* @nurl_llty(i8* %r495)
+  %r495 = load i64, i64* %r466
+  %r496 = call i8* @nurl_str_int(i64 %r495)
   call void @nurl_print(i8* %r496)
-  %r497 = getelementptr [2 x i8], [2 x i8]* @.str.2883, i64 0, i64 0
+  call void @nurl_free(i8* %r496)
+  %r497 = getelementptr [2 x i8], [2 x i8]* @.str.2881, i64 0, i64 0
   call void @nurl_print(i8* %r497)
-  %r498 = load i8*, i8** %r464
+  %r498 = getelementptr [9 x i8], [9 x i8]* @.str.2882, i64 0, i64 0
   call void @nurl_print(i8* %r498)
-  %r499 = getelementptr [3 x i8], [3 x i8]* @.str.2884, i64 0, i64 0
-  call void @nurl_print(i8* %r499)
-  %r500 = load i8*, i8** %r459
-  %r501 = call i8* @nurl_llty(i8* %r500)
+  %r499 = load i8*, i8** %r463
+  %r500 = call i8* @nurl_llty(i8* %r499)
+  call void @nurl_print(i8* %r500)
+  %r501 = getelementptr [2 x i8], [2 x i8]* @.str.2883, i64 0, i64 0
   call void @nurl_print(i8* %r501)
-  %r502 = getelementptr [3 x i8], [3 x i8]* @.str.2885, i64 0, i64 0
+  %r502 = load i8*, i8** %r468
   call void @nurl_print(i8* %r502)
-  %r503 = load i8*, i8** %r479
+  %r503 = getelementptr [3 x i8], [3 x i8]* @.str.2884, i64 0, i64 0
   call void @nurl_print(i8* %r503)
-  %r504 = getelementptr [2 x i8], [2 x i8]* @.str.2886, i64 0, i64 0
-  call void @nurl_print(i8* %r504)
-  %r505 = load i8*, i8** %r464
-  %r506 = load i8*, i8** %r434
-  call void @nurl_free(i8* %r506)
-  %r507 = load i8*, i8** %r440
-  call void @nurl_free(i8* %r507)
-  %r508 = load i8*, i8** %r479
-  call void @nurl_free(i8* %r508)
-  ret i8* %r505
+  %r504 = load i8*, i8** %r463
+  %r505 = call i8* @nurl_llty(i8* %r504)
+  call void @nurl_print(i8* %r505)
+  %r506 = getelementptr [3 x i8], [3 x i8]* @.str.2885, i64 0, i64 0
+  call void @nurl_print(i8* %r506)
+  %r507 = load i8*, i8** %r483
+  call void @nurl_print(i8* %r507)
+  %r508 = getelementptr [2 x i8], [2 x i8]* @.str.2886, i64 0, i64 0
+  call void @nurl_print(i8* %r508)
+  %r509 = load i8*, i8** %r468
+  %r510 = load i8*, i8** %r438
+  call void @nurl_free(i8* %r510)
+  %r511 = load i8*, i8** %r444
+  call void @nurl_free(i8* %r511)
+  %r512 = load i8*, i8** %r483
+  call void @nurl_free(i8* %r512)
+  ret i8* %r509
 end_17:
   br label %end_14
 end_14:

--- a/compiler/nurlc_lastgood.nu
+++ b/compiler/nurlc_lastgood.nu
@@ -9716,6 +9716,14 @@
 // with an index walk: the old version re-sliced the remainder per
 // token AND re-copied the accumulated output per append — O(B²) bytes
 // per update on a B-byte state.
+//
+// The scan reads through hoisted `*u` pointers, like __bck_st_get_at
+// above: `nurl_str_get` re-runs strlen on EVERY call, so walking the
+// state with it cost a strlen over the whole state per byte examined —
+// O(B²) again, in the one function whose comment claims to have removed
+// exactly that. Both indices are bounded by the loop guard (`e < n`)
+// and by `wl` against a token already measured to be `wl + 2` long, so
+// the bounds check nurl_str_get performed was dead weight.
 @ bck_st_set s state s name i val → s {
     : i n ( nurl_str_len state )
     : i wl ( nurl_str_len name )
@@ -9724,17 +9732,19 @@
     // worst case: whole state kept + separator + `name=val`
     : s out # s ( malloc + + + n wl vl 3 )
     : *u ob # *u out
+    : *u stp # *u state
+    : *u nmp # *u name
     : ~ i op 0
     : ~ i i 0
     ~ < i n {
         : ~ i e i
-        ~ & < e n != ( nurl_str_get state e ) 32 { = e + e 1 }
+        ~ & < e n != # i . stp e 32 { = e + e 1 }
         : ~ b keep T
         ? == - - e i 2 wl {
             : ~ i k 0
             : ~ b eq T
             ~ & eq < k wl {
-                ? != ( nurl_str_get state + i k ) ( nurl_str_get name k ) { = eq F } {}
+                ? != # i . stp + i k # i . nmp k { = eq F } {}
                 = k + k 1
             }
             ? eq { = keep F } {}
@@ -9772,19 +9782,23 @@
     // digit is one char, so the join of a and b never exceeds
     // len(a) + len(b) + 2. Names probed while still embedded in their
     // state string via __bck_st_get_at — the whole join allocates
-    // exactly one buffer.
+    // exactly one buffer. Both states are scanned through hoisted `*u`
+    // pointers rather than `nurl_str_get`, which re-runs strlen per
+    // call and made each pass quadratic in the state length.
     : i na ( nurl_str_len a )
     : i nb ( nurl_str_len b )
     : s out # s ( malloc + + na nb 2 )
     : *u ob # *u out
+    : *u ap # *u a
+    : *u bp # *u b
     : ~ i op 0
     // pass 1: every binding of a, joined against its state in b
     : ~ i i 0
     ~ < i na {
         : ~ i e i
-        ~ & < e na != ( nurl_str_get a e ) 32 { = e + e 1 }
+        ~ & < e na != # i . ap e 32 { = e + e 1 }
         : i wl - - e i 2
-        : i vj ( bck_join - ( nurl_str_get a - e 1 ) 48 ( __bck_st_get_at b a i wl ) )
+        : i vj ( bck_join - # i . ap - e 1 48 ( __bck_st_get_at b a i wl ) )
         ? > op 0 { : u sp # u 32 = . ob op sp = op + op 1 } {}
         // `name=` copied verbatim from a; then the joined digit
         ( memcpy # s + # i out op # s + # i a i + wl 1 )
@@ -9798,10 +9812,10 @@
     : ~ i j 0
     ~ < j nb {
         : ~ i e2 j
-        ~ & < e2 nb != ( nurl_str_get b e2 ) 32 { = e2 + e2 1 }
+        ~ & < e2 nb != # i . bp e2 32 { = e2 + e2 1 }
         : i wl2 - - e2 j 2
         ? == BCK_UNINIT ( __bck_st_get_at a b j wl2 ) {
-            : i vj2 ( bck_join BCK_UNINIT - ( nurl_str_get b - e2 1 ) 48 )
+            : i vj2 ( bck_join BCK_UNINIT - # i . bp - e2 1 48 )
             ? > op 0 { : u sp2 # u 32 = . ob op sp2 = op + op 1 } {}
             ( memcpy # s + # i out op # s + # i b j + wl2 1 )
             = op + op + wl2 1
@@ -9825,13 +9839,18 @@
 }
 
 // idx-th tab-delimited field of a record (0=kind .. 4=depth).
+// The tab scan reads through a hoisted `*u`: `nurl_str_get` re-runs
+// strlen per call, which made finding field 4 of an R-byte record cost
+// O(R²) — and bck_field is called for every field of every statement
+// row the walk visits.
 @ bck_field s rec i idx → s {
     : i len ( nurl_str_len rec )
+    : *u rp # *u rec
     : ~ i start 0
     : ~ i fno 0
     : ~ i pos 0
     ~ < pos len {
-        ? == ( nurl_str_get rec pos ) 9 {
+        ? == # i . rp pos 9 {
             ? == fno idx { ^ ( nurl_str_slice rec start - pos start ) } {}
             = fno + fno 1
             = start + pos 1
@@ -9844,14 +9863,19 @@
     ( nurl_str_cat `` `` )
 }
 
+// Split the captured statement list on newlines. The scan reads through
+// a hoisted `*u` for the same reason as bck_field: with `nurl_str_get`
+// this single loop was O(total²) over the whole function's statement
+// text.
 @ bck_explode → i {
     : s txt ( nurl_sym_get g_bck `stmts` )
     : i len ( nurl_str_len txt )
+    : *u tp # *u txt
     : ~ i start 0
     : ~ i n 0
     : ~ i pos 0
     ~ < pos len {
-        ? == ( nurl_str_get txt pos ) 10 {
+        ? == # i . tp pos 10 {
             ( nurl_sym_set g_bck ( nurl_str_cat `r` ( nurl_str_int n ) )
             ( nurl_str_slice txt start - pos start ) )
             = n + n 1
@@ -11195,6 +11219,14 @@
             ^ rhs
         }
         { : s idx_val ( gen_expr lex syms cg )
+            // `nurl_get_last_type` yields a NURL type name, so the GEP's
+            // index operand has to be lowered like every other type on
+            // the line. Printing it raw emitted `getelementptr i64, i64*
+            // %p, u64 %idx` for an unsigned index — IR that nurlc
+            // accepted (rc 0) and only clang rejected ("expected type").
+            // All four index-store paths share this shape; the matching
+            // load paths were already correct, so a program could read at
+            // an unsigned index but not write at one.
             : s idx_type ( nurl_get_last_type )
             : s rhs ( gen_expr lex syms cg )
             : s gep ( nurl_cg_reg cg )
@@ -11202,7 +11234,7 @@
             ( nurl_print ` = getelementptr ` ) ( nurl_print ( nurl_llty elem_ty ) )
             ( nurl_print `, ` ) ( nurl_print ( nurl_llty ptr_ty ) )
             ( nurl_print ` ` ) ( nurl_print data_ptr )
-            ( nurl_print `, ` ) ( nurl_print idx_type ) ( nurl_print ` ` ) ( nurl_print idx_val ) ( nurl_print `\n` )
+            ( nurl_print `, ` ) ( nurl_print ( nurl_llty idx_type ) ) ( nurl_print ` ` ) ( nurl_print idx_val ) ( nurl_print `\n` )
             ( nurl_print `  store ` ) ( nurl_print ( nurl_llty elem_ty ) )
             ( nurl_print ` ` ) ( nurl_print rhs )
             ( nurl_print `, ` ) ( nurl_print ( nurl_llty elem_ty ) )
@@ -11284,7 +11316,7 @@
                         ( nurl_print ` = getelementptr ` ) ( nurl_print ( nurl_llty st ) )
                         ( nurl_print `, ` ) ( nurl_print ( nurl_llty pt ) )
                         ( nurl_print ` ` ) ( nurl_print pv )
-                        ( nurl_print `, ` ) ( nurl_print idx_type ) ( nurl_print ` ` ) ( nurl_print idx_val ) ( nurl_print `\n` )
+                        ( nurl_print `, ` ) ( nurl_print ( nurl_llty idx_type ) ) ( nurl_print ` ` ) ( nurl_print idx_val ) ( nurl_print `\n` )
                         ( nurl_print `  store ` ) ( nurl_print ( nurl_llty st ) )
                         ( nurl_print ` ` ) ( nurl_print rhs )
                         ( nurl_print `, ` ) ( nurl_print ( nurl_llty st ) )
@@ -11334,7 +11366,7 @@
                                 ( nurl_print ` = getelementptr ` ) ( nurl_print ( nurl_llty st ) )
                                 ( nurl_print `, ` ) ( nurl_print ( nurl_llty pt ) )
                                 ( nurl_print ` ` ) ( nurl_print pv )
-                                ( nurl_print `, ` ) ( nurl_print idx_type ) ( nurl_print ` ` ) ( nurl_print idx_val ) ( nurl_print `\n` )
+                                ( nurl_print `, ` ) ( nurl_print ( nurl_llty idx_type ) ) ( nurl_print ` ` ) ( nurl_print idx_val ) ( nurl_print `\n` )
                                 ( nurl_print `  store ` ) ( nurl_print ( nurl_llty st ) )
                                 ( nurl_print ` ` ) ( nurl_print rhs )
                                 ( nurl_print `, ` ) ( nurl_print ( nurl_llty st ) )
@@ -11354,7 +11386,7 @@
                     ( nurl_print ` = getelementptr ` ) ( nurl_print ( nurl_llty st ) )
                     ( nurl_print `, ` ) ( nurl_print ( nurl_llty pt ) )
                     ( nurl_print ` ` ) ( nurl_print pv )
-                    ( nurl_print `, ` ) ( nurl_print idx_type ) ( nurl_print ` ` ) ( nurl_print idx_val ) ( nurl_print `\n` )
+                    ( nurl_print `, ` ) ( nurl_print ( nurl_llty idx_type ) ) ( nurl_print ` ` ) ( nurl_print idx_val ) ( nurl_print `\n` )
                     ( nurl_print `  store ` ) ( nurl_print ( nurl_llty st ) )
                     ( nurl_print ` ` ) ( nurl_print rhs )
                     ( nurl_print `, ` ) ( nurl_print ( nurl_llty st ) )


### PR DESCRIPTION
`./build.sh --refresh-bootstrap` on top of #656: flips `compiler/nurlc_lastgood.{nu,ll}` forward so the committed bootstrap snapshot embeds the current stdlib (the vec_push fast path and first-buffer-through-`nurl_alloc` from #656) and compiles current `nurlc.nu`. Full build and test suite (558/558) pass with the new snapshot.

Stacked on #656 — the regenerated `.ll` bakes in that branch's stdlib, so this merges after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG