### PR TITLE
bench: instruction-parity double-check — fix the C sort_window peer

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -59,11 +59,11 @@ and `perfstat.sh` read.
 | `histogram_bins` | Read-modify-write at a data-dependent index |
 | `prefix_scan` | Store-bound fill, then a serial load/add dependency chain |
 | `binary_search` | Pointer-chasing: each load address depends on the last compare |
-| `sort_window` | Compare/branch/store mill over a 64-byte window |
+| `sort_window` | Branchless compare/exchange mill over a 64-byte window |
 | `bloom_filter` | Four unpredictable loads per query over a 2 KB working set |
 | `hash_join` | Cheap Bloom early-out plus a rare, branchy join path |
 | `sieve` | Irregular-stride byte writes, then one linear scan |
-| `fib` | The function-call path: ~29.8M calls, no memoisation |
+| `fib` | The call/return path: ~15M calls after LLVM turns one recursion into a loop |
 | `collatz` | Control-flow-heavy inner loop with no array at all |
 | `matmul` | Triple-nested loop, flat indexing, column-strided reads |
 | `json_parse` | Allocator pressure, string handling, recursive descent |

--- a/bench/fib.c
+++ b/bench/fib.c
@@ -1,7 +1,9 @@
 // benchmark-contract: fib-naive;n=35
 //
-// fib — naive double-recursive Fibonacci(35): ~29.8M calls, no
-// memoisation. The function-call path is the whole benchmark.
+// fib — naive double-recursive Fibonacci(35), no memoisation: ~29.8M
+// source-level evaluations, ~15M executed calls after LLVM turns the
+// second recursive branch into a loop (same transform in every
+// compiled peer). The call/return path is the whole benchmark.
 //
 // Contract: the process prints exactly one line — fib(35) = 9227465.
 #include <stdio.h>

--- a/bench/fib.nu
+++ b/bench/fib.nu
@@ -1,6 +1,9 @@
 // fib — recursive Fibonacci(35). Output: 9227465.
-// Naive double recursion: ~29M calls, no memoisation. Stresses the
-// function-call path and the tokeniser's handling of call syntax.
+// Naive double recursion, no memoisation: ~29.8M source-level
+// evaluations, of which the binary executes ~15M real calls — LLVM
+// rewrites the second recursive branch into a loop for every compiled
+// peer alike (each fib function keeps exactly one call site). Stresses
+// the call/return path and the tokeniser's handling of call syntax.
 @ fib i n → i {
     ? < n 2 { ^ n } {}
     ^ + ( fib - n 1 ) ( fib - n 2 )

--- a/bench/manifest.tsv
+++ b/bench/manifest.tsv
@@ -19,11 +19,11 @@ ring_write	20M ring-buffer stores	Dependent store per iteration plus address com
 histogram_bins	20M binned increments	Read-modify-write at a data-dependent index
 prefix_scan	1M 16-wide prefix scans	Store-bound fill then a serial load/add dependency chain
 binary_search	5M lower-bound searches	Pointer-chasing: each load address depends on the last compare
-sort_window	2M 8-element bubble sorts	Compare/branch/store mill over a 64-byte window
+sort_window	2M 8-element bubble sorts	Branchless compare/exchange mill over a 64-byte window (~50 cmovs/iter)
 bloom_filter	4M Bloom-filter queries	Four unpredictable loads per query over a 2 KB working set
 hash_join	500k hash-table probes	Cheap Bloom early-out plus a rare, branchy join path
 sieve	Sieve of Eratosthenes to 10M	Irregular-stride byte writes, then one linear scan
-fib	Recursive fib(35)	The function-call path: ~29.8M calls, no memoisation
+fib	Recursive fib(35)	The call/return path: ~15M calls after LLVM turns one recursion into a loop
 collatz	Longest Collatz chain below 100k	Control-flow-heavy inner loop with no array at all
 matmul	256x256 integer matrix product	Triple-nested loop, flat indexing, column-strided reads
 json_parse	20 parses of a 64 KB document	Allocator pressure, string handling, recursive descent

--- a/bench/sort_window.c
+++ b/bench/sort_window.c
@@ -11,9 +11,17 @@ static inline void emit_checksum(uint64_t value) {
   printf("%llu\n", (unsigned long long)(value & 0x7fffffffffffffffULL));
 }
 
+// Signed loop indices, deliberately: with `unsigned` here clang's trip
+// count analysis gave up on the inner loop, leaving rolled loops with
+// data-dependent branches while the NURL and Rust peers were fully
+// unrolled and if-converted into a branchless compare/exchange mill —
+// the C cell then executed 2.8x the instructions of its peers and paid
+// a mispredict per random swap. With `int` all three compile to the
+// same ~50-cmov network (verified against disassembly and dynamic
+// instruction counts).
 static inline void bubble_sort8(uint64_t arr[8]) {
-  for (unsigned pass = 0; pass < 8; ++pass) {
-    for (unsigned j = 0; j + 1 < 8 - pass; ++j) {
+  for (int pass = 0; pass < 8; ++pass) {
+    for (int j = 0; j + 1 < 8 - pass; ++j) {
       if (arr[j] > arr[j + 1]) {
         uint64_t tmp = arr[j];
         arr[j] = arr[j + 1];

--- a/bench/sort_window.nu
+++ b/bench/sort_window.nu
@@ -3,7 +3,8 @@
 // sort_window — 2M iterations of "derive 8 values from the LCG state,
 // bubble-sort them, fold the extremes back into the state". 8 passes ×
 // up to 7 compare-and-maybe-swap steps per iteration, all on the same
-// 64-byte window: a compare/branch/store mill with a loop-carried
+// 64-byte window: a branchless compare/exchange mill (the compilers
+// unroll the sort and if-convert every swap to cmov) with a loop-carried
 // dependency through the state.
 //
 // NURL has no fixed-size stack array: the window lives in a `malloc`ed


### PR DESCRIPTION
Follow-up to #656: a physical-limits audit of **every** row before critics do it for us.

## Method

For each benchmark, `perf stat -e instructions:u` on the NURL, C and Rust binaries, plus a cycles-per-iteration check against the dependency chain's hardware minimum, plus disassembly of every hot loop.

## Findings

| check | result |
|---|---|
| Instruction parity NURL vs C | **12/15 rows identical to within 0.1%** (ratio 1.00) |
| Sub-physical cells | **none** — every row sits above its chain minimum (e.g. new lcg: 5.4 instr/iter, 8.6 cyc/iter vs 6-cycle chain; binary_search's 31 cyc/search explained by ILP across independent searches) |
| `sort_window` | **C peer was broken**: `unsigned` loop indices blocked clang's trip-count analysis → rolled loops, a mispredict per random swap, **649M instructions vs peers' 234M**. NURL's 1.7× "win" was a handicapped peer. |
| `fib` | blurb claimed "~29.8M calls"; every compiled peer actually executes ~15M (LLVM turns the second recursive branch into a loop in all three alike — 302M/302M/284M instructions). Honest, but the claim wasn't. |

## Fixes

- `sort_window.c`: `int` loop indices (with a comment explaining why) — all three languages now compile to the same ~50-cmov branchless network, 234.1M/234.2M/234.3M instructions, and the row becomes an honest three-way tie (42–44 ms interleaved locally; old C was 60 ms).
- `fib` and `sort_window` blurbs/comments now describe what the binaries actually execute.

Outputs verified identical across all five languages for both touched rows; bench.sh gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG