### PR TITLE
bench: cycle-exact chain floors + chaincheck gate — fix the last two composable generators

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -112,6 +112,17 @@ jobs:
         # non-zero: the timings would be comparing different computations.
         run: ./bench/bench.sh --timeout 300
 
+      - name: Physical-floor check (chaincheck)
+        # Every serial-chain row must run no faster than its dependency
+        # chain's hardware minimum — a cell below that line means a
+        # compiler shortcut the recurrence and the row is no longer
+        # measuring what its blurb claims. GitHub's Azure VMs expose no
+        # PMU, so this runs in wall-clock mode: measured time must be
+        # >= iterations x floor-cycles at 6 GHz, a clock no shipping
+        # CPU sustains. Publishing a table with an impossible number in
+        # it is worse than failing the run.
+        run: ./bench/chaincheck.sh
+
       - name: Publish the report to the run summary
         # So the numbers are readable in the Actions UI without
         # downloading an artifact or waiting for the site to publish.

--- a/bench/README.md
+++ b/bench/README.md
@@ -59,11 +59,11 @@ and `perfstat.sh` read.
 | `histogram_bins` | Read-modify-write at a data-dependent index |
 | `prefix_scan` | Store-bound fill, then a serial load/add dependency chain |
 | `binary_search` | Pointer-chasing: each load address depends on the last compare |
-| `sort_window` | Compare/branch/store mill over a 64-byte window |
+| `sort_window` | Branchless compare/exchange mill over a 64-byte window |
 | `bloom_filter` | Four unpredictable loads per query over a 2 KB working set |
 | `hash_join` | Cheap Bloom early-out plus a rare, branchy join path |
 | `sieve` | Irregular-stride byte writes, then one linear scan |
-| `fib` | The function-call path: ~29.8M calls, no memoisation |
+| `fib` | The call/return path: ~15M calls after LLVM turns one recursion into a loop |
 | `collatz` | Control-flow-heavy inner loop with no array at all |
 | `matmul` | Triple-nested loop, flat indexing, column-strided reads |
 | `json_parse` | Allocator pressure, string handling, recursive descent |

--- a/bench/README.md
+++ b/bench/README.md
@@ -126,6 +126,28 @@ these single-threaded kernels and cycles do not move with the frequency
 governor, which makes a 1 % regression visible. Use `bench.sh` to compare
 languages, `perfstat.sh` to compare two versions of NURL.
 
+## Physical floors — `chaincheck.sh`
+
+A serial-chain row must not run faster than its dependency chain's
+hardware minimum: `lcg`'s step is `imul(3)+add(1)+shr(1)+xor(1)` = 6
+cycles, so 20M iterations cannot legitimately finish under 120M cycles.
+`./bench/chaincheck.sh` builds the NURL, C and Rust binaries the way
+`bench.sh` does and verifies every chain row against its documented
+floor — with exact PMU cycle counts where `perf` works (a healthy row
+sits within ~10 % of its floor; the current table measures 6.02–6.03
+cyc/iter on `lcg` for all three languages), and as a wall-clock lower
+bound at 6 GHz on PMU-less CI runners. The bench workflow runs it after
+every suite run: a table with an impossible number in it fails the run
+instead of getting published.
+
+This gate exists because the pre-xorshift `lcg` was exactly such a
+number — LLVM composed k affine steps into one (`x·aᵏ + cₖ`), the NURL
+binary ran 100M "iterations" in 3.7 ms (a 162 GHz clock, had the chain
+been real), and the row was silently measuring the compiler's
+composition factor. The xorshift mix in `lcg`, `affine_mix`,
+`ring_write` and `histogram_bins` breaks the affinity that transform
+needs; `chaincheck.sh` keeps it broken.
+
 ## Reading the numbers
 
 * Compare a cell against the **floor row** in `RESULTS.md` (an empty

--- a/bench/chaincheck.sh
+++ b/bench/chaincheck.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  bench/chaincheck.sh — physical-floor verification.
+#
+#  A benchmark row whose blurb claims a loop-carried dependency chain
+#  must not run faster than the chain's hardware minimum — a cell below
+#  that line means the compiler shortcut the recurrence (as LLVM used to
+#  do to the pre-xorshift lcg/affine_mix by composing k affine steps
+#  into one) and the row no longer measures what it says.
+#
+#  For every row with a well-defined serial chain this script builds the
+#  NURL, C and Rust binaries the way bench.sh does and asserts each one
+#  runs no faster than its documented floor, in one of two modes:
+#
+#  * PMU mode (workstations): retired user-mode cycles via
+#    `perf stat -e cycles:u` — cycles, not wall time, so CPU frequency
+#    drops out — must satisfy  cycles/iterations >= floor(cyc/iter).
+#    A PASS margin under ~10 % means the row runs *at* its dependency
+#    chain, the strongest honesty statement a serial benchmark can make.
+#
+#  * wall-clock mode (CI: GitHub Actions / Azure VMs do not expose the
+#    PMU, `perf stat` reports <not supported>): the measured wall time
+#    must be >= iterations x floor cycles at MAX_GHZ, a frequency no
+#    current CPU exceeds. Coarser, but still catches every real
+#    violation ever seen here — the old composed lcg (100M iters in
+#    3.7 ms) would need a 162 GHz clock to be honest.
+#
+#  The floors are per-iteration critical-path latencies on current
+#  x86-64 cores (imul 3, simple ALU op 1, LEA-fused shift+add 1; a
+#  32-bit op's & 0xffffffff mask is free via implicit zero-extension).
+#
+#  Usage:  ./bench/chaincheck.sh          # auto-detects the mode
+#  Needs:  nurlc, clang, rustc; perf only for PMU mode.
+# ============================================================
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BENCH="$ROOT/bench"
+BUILD="$BENCH/_build"
+mkdir -p "$BUILD"
+
+MAX_GHZ=6.0   # no shipping CPU sustains more; a cell needing >6 GHz is dishonest
+
+NURLC="$ROOT/build/nurlc"
+RUNTIME="$ROOT/stdlib/runtime.o"
+[[ -x "$NURLC" && -f "$RUNTIME" ]] || { echo "chaincheck: need build/nurlc (run ./build.sh)" >&2; exit 1; }
+
+MODE="${CHAINCHECK_MODE:-}"   # pmu | wall | empty = auto-detect
+if [[ -z "$MODE" ]]; then
+    MODE=wall
+    if perf stat -e cycles:u true >/dev/null 2>&1 \
+       && ! perf stat -e cycles:u true 2>&1 | grep -q "not supported"; then
+        MODE=pmu
+    fi
+fi
+echo "chaincheck: mode=$MODE (pmu = exact cycles; wall = lower bound at ${MAX_GHZ} GHz)"
+
+# row  iterations  floor(cyc/iter)  chain
+# Rows without a strict serial chain (independent iterations, memory-
+# bound scans, allocator work) have no hard floor and are not listed.
+FLOORS="\
+lcg               20000000   6   imul(3)+add(1)+shr(1)+xor(1)
+affine_mix        20000000   6   lea(1)+and(1)+shr(1)+xor(1)+lea(1)+and(1)
+packet_classifier 25000000   4   imul32(3)+add(1), branch resolution on top
+ring_write        20000000   6   imul32(3)+add(1)+shr(1)+xor(1), store off-chain
+histogram_bins    20000000   6   imul32(3)+add(1)+shr(1)+xor(1), RMW on top
+prefix_scan        1000000  16   16 dependent adds per scan
+sort_window        2000000  26   13-stage compare/exchange network, 2 cyc/stage"
+
+cycles_of() {  # <bin> -> min cycles:u of 3 runs, empty on failure
+    local best=999999999999 c r
+    for r in 1 2 3; do
+        c="$(perf stat -e cycles:u -x, "$1" 2>&1 >/dev/null | head -1 | cut -d, -f1)"
+        [[ "$c" =~ ^[0-9]+$ ]] || { echo ""; return; }
+        (( c < best )) && best=$c
+    done
+    echo "$best"
+}
+
+wall_ms_of() {  # <bin> -> min wall ms of 3 runs (EPOCHREALTIME, no forks)
+    local best=999999 t0 t1 ms r
+    for r in 1 2 3; do
+        t0=$EPOCHREALTIME; "$1" >/dev/null 2>&1 || { echo ""; return; }; t1=$EPOCHREALTIME
+        ms="$(awk -v a="$t0" -v b="$t1" 'BEGIN { printf "%.3f", (b - a) * 1000 }')"
+        best="$(awk -v x="$ms" -v y="$best" 'BEGIN { print (x < y) ? x : y }')"
+    done
+    echo "$best"
+}
+
+fail=0
+if [[ $MODE == pmu ]]; then
+    printf '%-18s %-5s %14s %10s %8s  %s\n' row lang cycles cyc/iter floor verdict
+else
+    printf '%-18s %-5s %12s %14s  %s\n' row lang wall_ms floor_ms@6GHz verdict
+fi
+
+while read -r name iters floor chain; do
+    [[ -z "$name" ]] && continue
+    ( cd "$ROOT" && "$NURLC" "bench/$name.nu" > "$BUILD/$name.chk.ll" \
+        && clang -O2 -flto -Wl,--as-needed "$BUILD/$name.chk.ll" "$RUNTIME" \
+                 -lm -lpthread -o "$BUILD/$name.chk.nurl" ) 2>/dev/null \
+        || { echo "chaincheck: NURL build failed for $name" >&2; fail=1; continue; }
+    clang -O2 "$BENCH/$name.c" -lm -o "$BUILD/$name.chk.c" 2>/dev/null \
+        || { echo "chaincheck: C build failed for $name" >&2; fail=1; continue; }
+    rustc -C opt-level=2 "$BENCH/$name.rs" -o "$BUILD/$name.chk.rs" 2>/dev/null \
+        || { echo "chaincheck: Rust build failed for $name" >&2; fail=1; continue; }
+
+    for pair in "nurl:$BUILD/$name.chk.nurl" "c:$BUILD/$name.chk.c" "rust:$BUILD/$name.chk.rs"; do
+        lang="${pair%%:*}"; bin="${pair#*:}"
+        if [[ $MODE == pmu ]]; then
+            cyc="$(cd "$ROOT" && cycles_of "$bin")"
+            [[ -z "$cyc" ]] && { echo "chaincheck: perf failed on $name/$lang" >&2; fail=1; continue; }
+            verdict="$(awk -v c="$cyc" -v n="$iters" -v f="$floor" \
+                'BEGIN { print (c / n >= f * 0.97) ? "PASS" : "BELOW-FLOOR" }')"
+            [[ "$verdict" != PASS ]] && fail=1
+            awk -v r="$name" -v l="$lang" -v c="$cyc" -v n="$iters" -v f="$floor" -v v="$verdict" \
+                'BEGIN { printf "%-18s %-5s %14d %10.2f %8d  %s\n", r, l, c, c/n, f, v }'
+        else
+            ms="$(cd "$ROOT" && wall_ms_of "$bin")"
+            [[ -z "$ms" ]] && { echo "chaincheck: run failed on $name/$lang" >&2; fail=1; continue; }
+            verdict="$(awk -v t="$ms" -v n="$iters" -v f="$floor" -v g="$MAX_GHZ" \
+                'BEGIN { print (t >= n * f / (g * 1e6)) ? "PASS" : "BELOW-FLOOR" }')"
+            [[ "$verdict" != PASS ]] && fail=1
+            awk -v r="$name" -v l="$lang" -v t="$ms" -v n="$iters" -v f="$floor" -v g="$MAX_GHZ" -v v="$verdict" \
+                'BEGIN { printf "%-18s %-5s %12.2f %14.2f  %s\n", r, l, t, n * f / (g * 1e6), v }'
+        fi
+    done
+done <<< "$FLOORS"
+
+if (( fail )); then
+    echo
+    echo "chaincheck: FAIL — a cell is running below its dependency-chain floor;"
+    echo "the compiler has shortcut the recurrence and the row is not measuring"
+    echo "what its blurb claims. Fix the kernel (see how lcg's xorshift mix"
+    echo "breaks affine composition) before publishing numbers."
+    exit 1
+fi
+echo
+echo "chaincheck: all rows at or above their dependency-chain floors."

--- a/bench/fib.c
+++ b/bench/fib.c
@@ -1,7 +1,9 @@
 // benchmark-contract: fib-naive;n=35
 //
-// fib — naive double-recursive Fibonacci(35): ~29.8M calls, no
-// memoisation. The function-call path is the whole benchmark.
+// fib — naive double-recursive Fibonacci(35), no memoisation: ~29.8M
+// source-level evaluations, ~15M executed calls after LLVM turns the
+// second recursive branch into a loop (same transform in every
+// compiled peer). The call/return path is the whole benchmark.
 //
 // Contract: the process prints exactly one line — fib(35) = 9227465.
 #include <stdio.h>

--- a/bench/fib.nu
+++ b/bench/fib.nu
@@ -1,6 +1,9 @@
 // fib — recursive Fibonacci(35). Output: 9227465.
-// Naive double recursion: ~29M calls, no memoisation. Stresses the
-// function-call path and the tokeniser's handling of call syntax.
+// Naive double recursion, no memoisation: ~29.8M source-level
+// evaluations, of which the binary executes ~15M real calls — LLVM
+// rewrites the second recursive branch into a loop for every compiled
+// peer alike (each fib function keeps exactly one call site). Stresses
+// the call/return path and the tokeniser's handling of call syntax.
 @ fib i n → i {
     ? < n 2 { ^ n } {}
     ^ + ( fib - n 1 ) ( fib - n 2 )

--- a/bench/histogram_bins.c
+++ b/bench/histogram_bins.c
@@ -1,4 +1,4 @@
-// benchmark-contract: histogram;seed=123456789;iterations=20000000;bins=64;index=state&63
+// benchmark-contract: histogram-xs13;seed=123456789;iterations=20000000;bins=64;index=state&63;xorshift=13
 #include <stdint.h>
 #include <stdio.h>
 
@@ -18,6 +18,7 @@ int main(void) {
   uint64_t i = 0;
   while (i < iterations) {
     state = (state * 1664525ULL + 1013904223ULL) & 0xffffffffULL;
+    state ^= state >> 13;
     uint64_t index = state & 63ULL;
     bins[index] += 1ULL;
     ++i;

--- a/bench/histogram_bins.js
+++ b/bench/histogram_bins.js
@@ -1,4 +1,4 @@
-// benchmark-contract: histogram;seed=123456789;iterations=20000000;bins=64;index=state&63
+// benchmark-contract: histogram-xs13;seed=123456789;iterations=20000000;bins=64;index=state&63;xorshift=13
 //
 // histogram_bins — 20M LCG steps, each incrementing one of 64 bins at a
 // data-dependent index, then a weighted XOR fold over the bins.
@@ -15,6 +15,7 @@ const bins = new Uint32Array(64);
 let state = 123456789;
 for (let i = 0; i < ITERATIONS; i++) {
     state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    state = (state ^ (state >>> 13)) >>> 0;
     bins[state & 63] += 1;
 }
 

--- a/bench/histogram_bins.nu
+++ b/bench/histogram_bins.nu
@@ -1,4 +1,4 @@
-// benchmark-contract: histogram;seed=123456789;iterations=20000000;bins=64;index=state&63
+// benchmark-contract: histogram-xs13;seed=123456789;iterations=20000000;bins=64;index=state&63;xorshift=13
 //
 // histogram_bins — 20M LCG steps, each incrementing one of 64 bins at a
 // data-dependent index, then a weighted XOR fold of the bins. The
@@ -29,6 +29,7 @@
     : ~ u64 k 0
     ~ < k iterations {
         = state & + * state 1664525 1013904223 0xffffffff
+        = state ^^ state >> state 13
         : u64 index & state 63
         = . bins index + . bins index # u64 1
         = k + k 1

--- a/bench/histogram_bins.py
+++ b/bench/histogram_bins.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# benchmark-contract: histogram;seed=123456789;iterations=20000000;bins=64;index=state&63
+# benchmark-contract: histogram-xs13;seed=123456789;iterations=20000000;bins=64;index=state&63;xorshift=13
 #
 # histogram_bins — 20M LCG steps, each incrementing one of 64 bins at a
 # data-dependent index, then a weighted XOR fold over the bins.
@@ -10,6 +10,7 @@ state = 123456789
 
 for _ in range(20_000_000):
     state = (state * 1664525 + 1013904223) & 0xFFFFFFFF
+    state ^= state >> 13
     index = state & 63
     bins[index] += 1
 

--- a/bench/histogram_bins.rs
+++ b/bench/histogram_bins.rs
@@ -1,4 +1,4 @@
-// benchmark-contract: histogram;seed=123456789;iterations=20000000;bins=64;index=state&63
+// benchmark-contract: histogram-xs13;seed=123456789;iterations=20000000;bins=64;index=state&63;xorshift=13
 const ITERATIONS: u64 = 20_000_000;
 const BINS: usize = 64;
 const SEED: u64 = 123_456_789;
@@ -20,6 +20,7 @@ fn main() {
             .wrapping_mul(1_664_525)
             .wrapping_add(1_013_904_223)
             & MASK;
+        state ^= state >> 13;
         let index = (state & 63) as usize;
         bins[index] = bins[index].wrapping_add(1);
         i += 1;

--- a/bench/manifest.tsv
+++ b/bench/manifest.tsv
@@ -19,11 +19,11 @@ ring_write	20M ring-buffer stores	Dependent store per iteration plus address com
 histogram_bins	20M binned increments	Read-modify-write at a data-dependent index
 prefix_scan	1M 16-wide prefix scans	Store-bound fill then a serial load/add dependency chain
 binary_search	5M lower-bound searches	Pointer-chasing: each load address depends on the last compare
-sort_window	2M 8-element bubble sorts	Compare/branch/store mill over a 64-byte window
+sort_window	2M 8-element bubble sorts	Branchless compare/exchange mill over a 64-byte window (~50 cmovs/iter)
 bloom_filter	4M Bloom-filter queries	Four unpredictable loads per query over a 2 KB working set
 hash_join	500k hash-table probes	Cheap Bloom early-out plus a rare, branchy join path
 sieve	Sieve of Eratosthenes to 10M	Irregular-stride byte writes, then one linear scan
-fib	Recursive fib(35)	The function-call path: ~29.8M calls, no memoisation
+fib	Recursive fib(35)	The call/return path: ~15M calls after LLVM turns one recursion into a loop
 collatz	Longest Collatz chain below 100k	Control-flow-heavy inner loop with no array at all
 matmul	256x256 integer matrix product	Triple-nested loop, flat indexing, column-strided reads
 json_parse	20 parses of a 64 KB document	Allocator pressure, string handling, recursive descent

--- a/bench/ring_write.c
+++ b/bench/ring_write.c
@@ -1,4 +1,4 @@
-// benchmark-contract: ring-write;seed=123456789;iterations=20000000;words=64;value=state32x2
+// benchmark-contract: ring-write-xs13;seed=123456789;iterations=20000000;words=64;value=state32x2;xorshift=13
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -20,6 +20,7 @@ int main(void) {
 
   while (i < iterations) {
     state = (state * 1664525ULL + 1013904223ULL) & 0xffffffffULL;
+    state ^= state >> 13;
     buf[i & mask] = (state << 32) | state;
     ++i;
   }

--- a/bench/ring_write.js
+++ b/bench/ring_write.js
@@ -1,4 +1,4 @@
-// benchmark-contract: ring-write;seed=123456789;iterations=20000000;words=64;value=state32x2
+// benchmark-contract: ring-write-xs13;seed=123456789;iterations=20000000;words=64;value=state32x2;xorshift=13
 //
 // ring_write — 20M LCG steps, each storing one 64-bit word into a
 // 64-slot ring buffer.
@@ -19,6 +19,7 @@ const buf = new Uint32Array(128); // 64 slots × (low, high)
 let state = 123456789;
 for (let i = 0; i < ITERATIONS; i++) {
     state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    state = (state ^ (state >>> 13)) >>> 0;
     const slot = (i & 63) << 1;
     buf[slot] = state;
     buf[slot + 1] = state;

--- a/bench/ring_write.nu
+++ b/bench/ring_write.nu
@@ -1,4 +1,4 @@
-// benchmark-contract: ring-write;seed=123456789;iterations=20000000;words=64;value=state32x2
+// benchmark-contract: ring-write-xs13;seed=123456789;iterations=20000000;words=64;value=state32x2;xorshift=13
 //
 // ring_write — 20M LCG steps, each storing a 64-bit word into a 64-slot
 // ring buffer. Same arithmetic as stream_lcg plus one dependent store
@@ -28,6 +28,7 @@
     : ~ u64 k 0
     ~ < k iterations {
         = state & + * state 1664525 1013904223 0xffffffff
+        = state ^^ state >> state 13
         = . buf & k 63 | << state 32 state
         = k + k 1
     }

--- a/bench/ring_write.py
+++ b/bench/ring_write.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# benchmark-contract: ring-write;seed=123456789;iterations=20000000;words=64;value=state32x2
+# benchmark-contract: ring-write-xs13;seed=123456789;iterations=20000000;words=64;value=state32x2;xorshift=13
 #
 # ring_write — 20M LCG steps, each storing one 64-bit word into a
 # 64-slot ring buffer. The list write and the index arithmetic are what
@@ -11,6 +11,7 @@ state = 123456789
 
 for i in range(20_000_000):
     state = (state * 1664525 + 1013904223) & 0xFFFFFFFF
+    state ^= state >> 13
     buf[i & 63] = (state << 32) | state
 
 result = ((state << 32) | state) ^ buf[0]

--- a/bench/ring_write.rs
+++ b/bench/ring_write.rs
@@ -1,4 +1,4 @@
-// benchmark-contract: ring-write;seed=123456789;iterations=20000000;words=64;value=state32x2
+// benchmark-contract: ring-write-xs13;seed=123456789;iterations=20000000;words=64;value=state32x2;xorshift=13
 const ITERATIONS: u64 = 20_000_000;
 const WORDS: usize = 64;
 const SEED: u64 = 123_456_789;
@@ -21,6 +21,7 @@ fn main() {
             .wrapping_mul(1_664_525)
             .wrapping_add(1_013_904_223)
             & MASK;
+        state ^= state >> 13;
         buf[(i & mask) as usize] = (state << 32) | state;
         i += 1;
     }

--- a/bench/sort_window.c
+++ b/bench/sort_window.c
@@ -11,9 +11,17 @@ static inline void emit_checksum(uint64_t value) {
   printf("%llu\n", (unsigned long long)(value & 0x7fffffffffffffffULL));
 }
 
+// Signed loop indices, deliberately: with `unsigned` here clang's trip
+// count analysis gave up on the inner loop, leaving rolled loops with
+// data-dependent branches while the NURL and Rust peers were fully
+// unrolled and if-converted into a branchless compare/exchange mill —
+// the C cell then executed 2.8x the instructions of its peers and paid
+// a mispredict per random swap. With `int` all three compile to the
+// same ~50-cmov network (verified against disassembly and dynamic
+// instruction counts).
 static inline void bubble_sort8(uint64_t arr[8]) {
-  for (unsigned pass = 0; pass < 8; ++pass) {
-    for (unsigned j = 0; j + 1 < 8 - pass; ++j) {
+  for (int pass = 0; pass < 8; ++pass) {
+    for (int j = 0; j + 1 < 8 - pass; ++j) {
       if (arr[j] > arr[j + 1]) {
         uint64_t tmp = arr[j];
         arr[j] = arr[j + 1];

--- a/bench/sort_window.nu
+++ b/bench/sort_window.nu
@@ -3,7 +3,8 @@
 // sort_window — 2M iterations of "derive 8 values from the LCG state,
 // bubble-sort them, fold the extremes back into the state". 8 passes ×
 // up to 7 compare-and-maybe-swap steps per iteration, all on the same
-// 64-byte window: a compare/branch/store mill with a loop-carried
+// 64-byte window: a branchless compare/exchange mill (the compilers
+// unroll the sort and if-convert every swap to cmov) with a loop-carried
 // dependency through the state.
 //
 // NURL has no fixed-size stack array: the window lives in a `malloc`ed


### PR DESCRIPTION
Follow-up to #658. A three-way tie proves symmetry, not serialization — all three compilers could share the same shortcut. This PR proves serialization directly and installs a gate that keeps it proven.

## Cycle-exact evidence (perf `cycles:u`, frequency-independent)

| row | NURL | C | Rust | hard floor | chain |
|---|---|---|---|---|---|
| `lcg` | 6.02 | 6.03 | 6.03 | **6** | imul(3)+add(1)+shr(1)+xor(1) |
| `affine_mix` | 6.02 | 6.02 | 6.02 | **6** | lea(1)+and(1)+shr(1)+xor(1)+lea(1)+and(1) |
| `ring_write` (fixed) | 6.60 | 6.65 | 6.61 | **6** | imul32(3)+add(1)+shr(1)+xor(1) |
| `histogram_bins` (fixed) | 6.28 | 6.26 | 6.27 | **6** | same + RMW on top |

cyc/iter. Linear-scaling check: lcg at 20M/40M/100M iterations = 6.02/6.02/6.02 cyc/iter — no closed form exists. (The "lcg should be ~200 ms" intuition is correct **for the old 100M workload**: 100M × 6 cyc = 602M cycles ≈ 172 ms at 3.5 GHz. The current contract is 20M → ~40 ms on the CI runner.)

## What the audit caught

`histogram_bins` ran at **4.14 cyc/iter, below its naive 5-cycle generator floor**: its bare 32-bit LCG is still affine, so LLVM composes two steps (`a² mod 2³²`) and computes the intermediate state off the critical path — legal, symmetric across all three languages, and exactly the kind of number a critic tears apart. `ring_write` sat at 4.97, one clang release from the same fate. Both generators now get the same xorshift mix as lcg; all five implementations agree on the new outputs.

## The gate: `bench/chaincheck.sh`

Builds NURL/C/Rust the way bench.sh does and asserts every serial-chain row ≥ its documented floor:
- **PMU mode** (workstations): exact `cycles:u` per iteration.
- **wall-clock mode** (CI — GitHub's Azure VMs expose no PMU, `perf stat` reports `<not supported>`): measured time must be ≥ iterations × floor-cycles at 6 GHz, a clock no shipping CPU sustains. Coarse, but catches every real violation ever seen here: the old composed lcg (100M in 3.7 ms) implied a 162 GHz clock.

Wired into the bench workflow after every suite run — a results table with an impossible number in it now fails the run instead of getting published. Both modes verified locally (all 21 cells PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG