### PR TITLE
nurl upgrade: the toolchain updates itself, and the served installer stops wiping the prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,16 @@ jobs:
         # __free_str_vec class). Assert every stdlib @-function name is
         # globally unique.
         run: ./tools/check_stdlib_symbols.sh
+
+      - name: served installers match the canonical ones
+        # nurlweb/public/install.{sh,ps1} are copies of tools/get-nurl.*
+        # made by a MANUAL npm script, and they are what nurl-lang.org
+        # actually serves. They drifted once already: the fix that stopped
+        # an upgrade from wiping the prefix (registry token, models/,
+        # every installed tool) sat in tools/ for weeks while the website
+        # kept handing out the destructive version.
+        run: ./tools/check_installer_sync.sh
+
       - name: Windows goldens not stale (they are checked on main, not per-PR)
         # outputs-windows/ is a parallel corpus and windows-tests.yml runs
         # on pushes to main, so a PR that adds assertions updates outputs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,62 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`nurl upgrade` — the toolchain updates itself.** Until now the only way
+  to move to a new release was to re-run the website's one-liner, which the
+  "a newer NURL toolchain is available" notice duly printed at you. There is
+  now a command, and it is the one the notice prints:
+
+  ```
+  nurl upgrade                    # install the newest release, in place
+  nurl upgrade --check            # report only; install nothing
+  nurl upgrade --version v0.25.0  # pin a release (or go back to one)
+  nurl upgrade --force            # reinstall this version / replace a dev build
+  ```
+
+  `nurl update`, `nurlpkg self-update` and `nurlpkg upgrade` are the same
+  command — the spellings people guess all land in one place. `nurlpkg
+  update` deliberately keeps its existing meaning (a *project's* dependency
+  requirements); quietly repurposing it would have been worse than any
+  naming win.
+
+  It does not reimplement the installer: the release archive's checksum
+  gate, signature gate and "replace the toolchain's files, keep the rest of
+  the prefix" rule live in one script, and that script now ships *inside*
+  the toolchain at `<prefix>/libexec/get-nurl.sh`. So an upgrade runs the
+  installer that came with the version you already trust, rather than
+  downloading a script and piping it to a shell — and there is no second
+  implementation to keep in step. On Windows the same command drives the
+  bundled `get-nurl.ps1`.
+
+- **`--version` / `-v` on every binary in the toolchain.** `nurlfmt` had no
+  version flag at all; `nurlc` only had the long form; `nurl` and `nurlpkg`
+  accepted `--version` but never mentioned it. All four now answer to
+  `--version`, `-v` and (where it isn't ambiguous) the bare word `version`,
+  and say so in their usage text.
+
+### Fixed
+
+- **The installer served from nurl-lang.org still wiped the whole install
+  prefix.** `tools/get-nurl.{sh,ps1}` stopped doing that in July —
+  an upgrade had been deleting the registry token, `models/`, `share/` and
+  every program installed with `nurlpkg install`. But `nurlweb/public/
+  install.{sh,ps1}`, the copies actually downloaded by
+  `curl … | sh`, are made by a *manual* npm script that nobody re-ran, so
+  the one-liner on the website kept handing out the destructive version.
+  The copies are re-synced, and `tools/check_installer_sync.sh` now runs in
+  CI so this class of drift cannot outlive a pull request.
+
+- The prefix's `models/` cache and `libexec/` are now named explicitly in
+  the installers' keep/remove rules, and the Windows installer renames a
+  file it cannot delete instead of failing: `nurl upgrade` is a process
+  upgrading the tree it is executing from, and Windows refuses to unlink a
+  running `.exe` (POSIX allows it, which is why the same code path is
+  uneventful there).
+
 ## [0.26.0] — 2026-07-26
 
 A measurement release. Nothing here changes the language; what changes is

--- a/README.md
+++ b/README.md
@@ -91,7 +91,14 @@ Then:
 
 ```bash
 nurlpkg install <name>     # fetch & build a program from reg.nurl-lang.org
+nurl --version             # what you have
+nurl upgrade               # move to the newest release, in place
 ```
+
+`nurl upgrade` keeps everything else in `~/.nurl` — your registry token, the
+model cache, and every program installed with `nurlpkg install`. (Aliases:
+`nurl update`, `nurlpkg self-update`. Not `nurlpkg update` — that one is
+about a project's dependencies.)
 
 ### Build from source
 

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -19948,7 +19948,7 @@
     ( nurl_print `usage: nurlc [flags] <file.nu>  >out.ll\n\n` )
     ( nurl_print `flags:\n` )
     ( nurl_print `  --help, -h          print this help and exit\n` )
-    ( nurl_print `  --version           print the compiler version and exit\n` )
+    ( nurl_print `  --version, -v       print the toolchain version and exit\n` )
     ( nurl_print `  --g, -g             emit DWARF debug info (nurl.sh --debug forwards this)\n` )
     ( nurl_print `  --lint              run lint-only diagnostics (e.g. unused imports)\n` )
     ( nurl_print `  --no-borrowck       disable the borrow-checker pass (on by default)\n` )
@@ -19971,7 +19971,7 @@
     : ~ i ai 1
     ~ < ai ( nurl_argc ) {
         : s a ( nurl_argv ai )
-        ? ( seq a `--version` )
+        ? | ( seq a `--version` ) ( seq a `-v` )
         { ( nurl_print ( nurl_version ) ) ( nurl_print `\n` ) ( nurl_exit 0 ) }
         { ? | ( seq a `--help` ) ( seq a `-h` )
             { ( nurlc_print_help ) ( nurl_exit 0 ) }

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -90,7 +90,15 @@ versions — confirms each on stdin, `--all` takes everything; registry
 deps follow the newest published version, path deps the local copy's
 `nurl.toml`), `install` (project deps, or a registry program/library),
 `lock`, `verify`, `publish`, `login`, `logout [--revoke]`, `search`,
-`yank` / `unyank`, `test`, `bench`, `version`, `help`.
+`yank` / `unyank`, `test`, `bench`, `self-update`, `version`, `help`.
+
+`self-update` is the odd one out: it upgrades the **toolchain**, not a
+package, and `nurl upgrade` is its canonical spelling (that is what the
+"a newer NURL toolchain is available" notice prints). It runs the installer
+bundled at `$NURL_HOME/libexec/get-nurl.sh`, so the checksum/signature
+gates and the "replace the toolchain's files, keep the rest of the prefix"
+rule have exactly one implementation. Take care not to read it as a synonym
+for `nurlpkg update`, which moves a project's dependency requirements.
 
 ## MCP server (`nurl-mcp`)
 

--- a/nurl.bat
+++ b/nurl.bat
@@ -35,6 +35,20 @@ set "EMIT_ASM=0"
 set "DEBUG_INFO=0"
 set "CLI_OPT="
 
+REM -- version / upgrade: whole-toolchain commands, no source file --
+REM `nurl upgrade` is the canonical name for a toolchain upgrade (it is
+REM what the "a newer NURL toolchain is available" notice prints). The
+REM implementation lives in nurlpkg; every spelling a user might guess
+REM lands there. `nurlpkg update` is NOT one of them - that moves a
+REM project's dependency requirements.
+if /i "%~1"=="--version"    goto show_version
+if /i "%~1"=="-v"           goto show_version
+if /i "%~1"=="version"      goto show_version
+if /i "%~1"=="upgrade"      goto do_upgrade
+if /i "%~1"=="update"       goto do_upgrade
+if /i "%~1"=="self-update"  goto do_upgrade
+if /i "%~1"=="self-upgrade" goto do_upgrade
+
 :parse_flags
 if /i "%~1"=="--emit-ir"  set "EMIT_IR=1"     & shift & goto parse_flags
 if /i "%~1"=="--emit=ir"  set "EMIT_IR=1"     & shift & goto parse_flags
@@ -53,6 +67,9 @@ if "%~1"=="" (
     echo  Flags: --emit-ir ^| --emit-asm ^| -O0..-O3 ^| -g ^| --debug
     echo.
     echo  Compiles a NURL source file to a native Windows executable.
+    echo.
+    echo  nurl --version ^| -v         Print the toolchain version.
+    echo  nurl upgrade [--check]      Upgrade the toolchain in place.
     echo  The intermediate .ll file is kept alongside the output.
     exit /b 1
 )
@@ -323,3 +340,33 @@ if defined SDL2_BINDIR if exist "%SDL2_BINDIR%\SDL2.dll" (
 echo.
 echo Done: %EXEFILE%
 endlocal
+
+goto :eof
+
+:show_version
+set "SDIR=%~dp0"
+if exist "%SDIR%build\nurlc.exe" (
+    "%SDIR%build\nurlc.exe" --version
+) else (
+    nurlc.exe --version
+)
+exit /b %ERRORLEVEL%
+
+:do_upgrade
+set "SDIR=%~dp0"
+shift
+set "PKGARGS="
+:collect_upgrade_args
+if not "%~1"=="" (
+    set "PKGARGS=!PKGARGS! %~1"
+    shift
+    goto collect_upgrade_args
+)
+if exist "%SDIR%bin\nurlpkg.bat" (
+    call "%SDIR%bin\nurlpkg.bat" self-update !PKGARGS!
+) else if exist "%SDIR%build\nurlpkg.exe" (
+    "%SDIR%build\nurlpkg.exe" self-update !PKGARGS!
+) else (
+    nurlpkg self-update !PKGARGS!
+)
+exit /b %ERRORLEVEL%

--- a/nurl.sh
+++ b/nurl.sh
@@ -6,6 +6,10 @@
 #  nurl.sh — compile a .nu file to a native executable
 #
 #  Usage:  ./nurl.sh [flags] <file.nu> [output_name]
+#          ./nurl.sh --version | -v          print the toolchain version
+#          ./nurl.sh upgrade [--check]       upgrade the toolchain in place
+#                                            (--version vX.Y.Z, --force;
+#                                             runs `nurlpkg self-update`)
 #
 #  Flags (all must come before the source file):
 #    --emit-ir | --emit=ir     Stop after stage 1, leave only the .ll
@@ -73,9 +77,32 @@ fi
 
 # ── --version ────────────────────────────────────────────────
 # The version is baked into nurlc (runtime.o), so this needs no stdlib/env.
-if [ "${1:-}" = "--version" ] || [ "${1:-}" = "-v" ]; then
+if [ "${1:-}" = "--version" ] || [ "${1:-}" = "-v" ] || [ "${1:-}" = "version" ]; then
     exec "$NURLC" --version
 fi
+
+# ── upgrade ──────────────────────────────────────────────────
+# `nurl upgrade` is the canonical name for a toolchain upgrade — it is what
+# the "a newer NURL toolchain is available" notice tells you to run. The
+# implementation lives in nurlpkg (stdlib/ext/toolchain.nu); this is one
+# dispatch so that all the spellings a user might guess land in one place:
+#   nurl upgrade  ·  nurl update  ·  nurlpkg self-update
+# (`nurlpkg update` is NOT one of them — that moves a project's dependency
+# requirements, and has since 0.4.)
+case "${1:-}" in
+    upgrade|update|self-update|self-upgrade)
+        shift
+        for __pkg in "$SCRIPT_DIR/bin/nurlpkg" "$SCRIPT_DIR/build/nurlpkg"; do
+            [ -x "$__pkg" ] && exec "$__pkg" self-update "$@"
+        done
+        if command -v nurlpkg >/dev/null 2>&1; then
+            exec nurlpkg self-update "$@"
+        fi
+        echo "ERROR: nurlpkg not found next to this script or on PATH — cannot upgrade." >&2
+        echo "       Reinstall the toolchain: curl -fsSL https://nurl-lang.org/install.sh | sh" >&2
+        exit 1
+        ;;
+esac
 
 # ── Locate runtime.o ─────────────────────────────────────────
 RUNTIME="$SCRIPT_DIR/stdlib/runtime.o"
@@ -113,6 +140,10 @@ if [ $# -eq 0 ]; then
     echo "" >&2
     echo "  Compiles a NURL source file to a native binary." >&2
     echo "  The intermediate .ll file is kept alongside the output." >&2
+    echo "" >&2
+    echo "  nurl --version | -v          Print the toolchain version." >&2
+    echo "  nurl upgrade [--check]       Upgrade the toolchain in place" >&2
+    echo "                               (--version vX.Y.Z pins a release, --force reinstalls)." >&2
     exit 1
 fi
 

--- a/nurlweb/public/install.ps1
+++ b/nurlweb/public/install.ps1
@@ -29,6 +29,26 @@ param(
 )
 if ($env:NURL_INSTALL_INSECURE -eq "1") { $Insecure = $true }
 $ErrorActionPreference = "Stop"
+
+# Delete a toolchain-owned path. Anything Windows refuses to delete because
+# it is IN USE (the running nurlpkg.exe during `nurl upgrade`) is renamed
+# out of the way instead — a rename is permitted where a delete is not —
+# and swept the next time the installer runs.
+function New-StalePath($p) {
+    return ($p + ".old-" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))
+}
+function Remove-ToolchainPath($p) {
+    if (-not (Test-Path $p)) { return }
+    try { Remove-Item -Recurse -Force -ErrorAction Stop $p; return } catch { }
+    # Something under $p is in use. Clear what we can, rename what we can't.
+    Get-ChildItem -Recurse -File -Force $p -ErrorAction SilentlyContinue | ForEach-Object {
+        try { Remove-Item -Force -ErrorAction Stop $_.FullName }
+        catch { Move-Item -Force $_.FullName (New-StalePath $_.FullName) }
+    }
+    try { Remove-Item -Recurse -Force -ErrorAction Stop $p }
+    catch { Move-Item -Force $p (New-StalePath $p) }
+}
+
 $repo = "nurl-lang/nurl"
 $target = "windows-x86_64"
 
@@ -109,7 +129,36 @@ try {
     if (Test-Path $Prefix) {
         $isNurl  = (Test-Path (Join-Path $Prefix "bin\nurl.bat")) -or (Test-Path (Join-Path $Prefix "bin\nurlc.exe"))
         $isEmpty = -not (Get-ChildItem -Force $Prefix -ErrorAction SilentlyContinue)
-        if ($isNurl -or $isEmpty) { Remove-Item -Recurse -Force $Prefix }
+        # Preserve USER state in the prefix across an upgrade: the
+        # registry token (credentials), the model cache (models\), tool
+        # assets (share\), and any program installed with `nurlpkg install`
+        # (bin\<other>). Only the toolchain's own paths are removed; the
+        # archive overwrites the rest. build\, stdlib\, zig\ and libexec\
+        # go wholesale so a file deleted upstream cannot linger.
+        #
+        # Windows cannot DELETE a running executable — and `nurl upgrade`
+        # is exactly that case: nurlpkg.exe upgrading the tree it runs
+        # from. It CAN be renamed, so anything undeletable is moved aside
+        # as <name>.old-<id> and swept on the next run. (POSIX needs none
+        # of this: unlinking a running binary is legal there.)
+        if ($isNurl -or $isEmpty) {
+            foreach ($d in @($Prefix, (Join-Path $Prefix "bin"), (Join-Path $Prefix "build"))) {
+                if (Test-Path $d) {
+                    Get-ChildItem -Force $d -Filter "*.old-*" -ErrorAction SilentlyContinue |
+                        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+                }
+            }
+            foreach ($d in @("build", "stdlib", "zig", "libexec")) {
+                Remove-ToolchainPath (Join-Path $Prefix $d)
+            }
+            foreach ($f in @("nurl.bat", "nurl.sh", "env",
+                             "bin\nurl.bat", "bin\nurlc.bat",
+                             "bin\nurlfmt.bat", "bin\nurlpkg.bat",
+                             "bin\nurl.exe", "bin\nurlc.exe",
+                             "bin\nurlfmt.exe", "bin\nurlpkg.exe")) {
+                Remove-ToolchainPath (Join-Path $Prefix $f)
+            }
+        }
         else { throw "'$Prefix' exists, is not empty, and is not a NURL install — refusing to overwrite it. Remove it yourself or set -Prefix to a fresh path." }
     }
     New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
@@ -161,7 +210,7 @@ try {
     }
 
     Write-Host ""
-    Write-Host "Then:  nurlc --version   ·   nurlpkg install nq"
+    Write-Host "Then:  nurl --version   ·   nurlpkg install nq   ·   nurl upgrade  (later)"
 }
 finally {
     Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue

--- a/nurlweb/public/install.sh
+++ b/nurlweb/public/install.sh
@@ -162,9 +162,27 @@ fi
 case "$PREFIX" in
     ""|/|"$HOME"|"$HOME"/) err "refusing to install into '$PREFIX' — set NURL_HOME to a dedicated directory (e.g. ~/.nurl)." ;;
 esac
+# An upgrade must not destroy USER state living in the same prefix:
+#   credentials          the registry publish token (nurlpkg login)
+#   models/              the model cache (hub / nurllama — tens of GB)
+#   share/               assets of tools installed via nurlpkg
+#   bin/<other tools>    programs installed via nurlpkg install
+# Wiping the whole prefix (as this did) silently logged the user out and
+# removed every installed tool. Remove only the toolchain's OWN paths —
+# the four shipped binaries, build/, stdlib/, zig/, libexec/, the shims —
+# and let tar overwrite the rest. Those directories are removed wholesale
+# so a file deleted upstream cannot linger.
+#
+# Unlinking a RUNNING binary is fine on POSIX (the kernel keeps the inode
+# alive for the running process), which is what makes `nurl upgrade` —
+# nurlpkg upgrading the very tree it is executing from — safe here. The
+# Windows installer has to work around the same case differently.
 if [ -e "$PREFIX" ]; then
     if [ -x "$PREFIX/bin/nurl" ] || [ -x "$PREFIX/bin/nurlc" ] || [ -z "$(ls -A "$PREFIX" 2>/dev/null)" ]; then
-        rm -rf "$PREFIX"
+        rm -rf "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/zig" "$PREFIX/libexec"
+        rm -f  "$PREFIX/nurl.sh" "$PREFIX/nurl.bat" "$PREFIX/env" \
+               "$PREFIX/bin/nurl" "$PREFIX/bin/nurlc" \
+               "$PREFIX/bin/nurlfmt" "$PREFIX/bin/nurlpkg"
     else
         err "'$PREFIX' exists, is not empty, and is not a NURL install (no bin/nurl) — refusing to overwrite it. Remove it yourself or set NURL_HOME to a fresh path."
     fi
@@ -282,7 +300,7 @@ info "The shims self-locate the stdlib, so PATH is all you need — no 'source"
 info "env' required. (bash/zsh users may instead 'source $PREFIX/env', which"
 info "also exports NURL_HOME.)"
 info ""
-info "Then:  nurlc --version   ·   nurlpkg install nq"
+info "Then:  nurl --version   ·   nurlpkg install nq   ·   nurl upgrade  (later)"
 
 # Building a program (and therefore `nurlpkg install <tool>`, which compiles
 # the package from source) needs an LLVM compiler. The archive bundles a

--- a/stdlib/ext/toolchain.nu
+++ b/stdlib/ext/toolchain.nu
@@ -1,0 +1,294 @@
+// stdlib/ext/toolchain.nu — upgrade the installed NURL toolchain in place.
+//
+//   ( toolchain_upgrade want current check_only force )  → i   exit code
+//
+// This is the active half of the update story whose passive half is
+// stdlib/ext/update_check.nu's once-a-day "a newer toolchain is out"
+// notice. Both are reached from the same two front-ends:
+//
+//   nurl upgrade [--check] [--version vX.Y.Z] [--force]
+//   nurlpkg self-update  (same flags; `nurl upgrade` is the canonical name)
+//
+// Design — it RUNS THE OFFICIAL INSTALLER, it does not reimplement it.
+// Unpacking a release involves a checksum gate, a minisign signature gate,
+// and a very specific "replace the toolchain's own paths, keep everything
+// else" rule (the prefix also holds the registry token, the model cache and
+// every program installed with `nurlpkg install`). A second implementation
+// of that would be a second thing to keep correct — and the one place this
+// project already got bitten was exactly a drifted copy of the installer.
+// So the installer is shipped INSIDE the toolchain, at
+// <prefix>/libexec/get-nurl.sh (get-nurl.ps1 on Windows), and this module
+// resolves a version, decides whether anything needs doing, and spawns it.
+//
+// Nothing here is downloaded-and-executed: the script that runs is the one
+// that came with the toolchain you already trust. It then fetches the new
+// archive over HTTPS and verifies it fail-closed, as it always has.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/process.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/ext/update_check.nu`
+
+// `!b` has no prefix form in the grammar; this keeps the guards readable.
+@ __tc_not b x → b {
+    ? x { ^ F } {}
+    ^ T
+}
+
+// Windows host? Windows always exports OS=Windows_NT; nothing else does.
+@ __tc_is_windows → b {
+    : ~ b w F
+    ?? ( env_get `OS` ) {
+        T e → { = w ( nurl_str_eq ( string_data e ) `Windows_NT` ) ( string_free e ) }
+        F → {}
+    }
+    ^ w
+}
+
+// The install prefix this toolchain lives in. $NURL_HOME wins (the env
+// file exports it); the PATH shims always export $NURL_STDLIB, which is
+// the same directory; otherwise fall back to the installer's default.
+// Empty String when even the home directory is unknown.
+@ toolchain_prefix → String {
+    ?? ( env_get `NURL_HOME` ) {
+        T v → { ? > ( string_len v ) 0 { ^ v } { ( string_free v ) } }
+        F → {}
+    }
+    ?? ( env_get `NURL_STDLIB` ) {
+        T v → { ? > ( string_len v ) 0 { ^ v } { ( string_free v ) } }
+        F → {}
+    }
+    : s home_var ? ( __tc_is_windows ) `USERPROFILE` `HOME`
+    : String home ( env_var_or home_var `` )
+    ? == ( string_len home ) 0 { ( string_free home ) ^ ( string_new ) } {}
+    : String p ( path_join ( string_data home ) `.nurl` )
+    ( string_free home )
+    ^ p
+}
+
+// The bundled installer inside `prefix`, or an empty String when this
+// toolchain shipped without one (an old release, or a source checkout).
+@ toolchain_installer s prefix → String {
+    : s name ? ( __tc_is_windows ) `get-nurl.ps1` `get-nurl.sh`
+    : String dir ( path_join prefix `libexec` )
+    : String f ( path_join ( string_data dir ) name )
+    ( string_free dir )
+    ? ( file_exists ( string_data f ) ) { ^ f } {}
+    ( string_free f )
+    ^ ( string_new )
+}
+
+// "0.26.0" → "v0.26.0"; "v0.26.0" → unchanged. Release archives are named
+// after the tag, so the leading v is not optional downstream.
+@ __tc_norm_tag s ver → String {
+    ? & > ( nurl_str_len ver ) 0 != ( nurl_str_get ver 0 ) 118 {
+        : String out ( string_from `v` )
+        ( string_push_str out ver )
+        ^ out
+    } {}
+    ^ ( string_from ver )
+}
+
+// Spawn `prog args…`, echoing its stdout line by line as it arrives.
+// The child inherits stderr, so the installer's own progress output
+// (which it writes there) streams straight to the terminal. Returns the
+// child's exit code, or -1 when it could not be launched at all.
+@ __tc_stream s prog ( Vec s ) args → i {
+    ?? ( process_spawn prog args ) {
+        T ch → {
+            : ~ i done 0
+            ~ == done 0 {
+                ?? ( proc_read_line ch 0 ) {
+                    T ln → {
+                        ( nurl_print ( string_data ln ) )
+                        ( nurl_print `\n` )
+                        ( string_free ln )
+                    }
+                    F → { = done 1 }
+                }
+            }
+            : i rc ( proc_wait ch )
+            ( proc_free ch )
+            ^ rc
+        }
+        F e → {
+            ( nurl_eprint `nurl upgrade: could not run the installer: ` )
+            ( nurl_eprintln ( process_err_name e ) )
+            ^ -1
+        }
+    }
+}
+
+@ __tc_report_dev s current → v {
+    ( nurl_eprint `nurl upgrade: this is a development build (` )
+    ( nurl_eprint current )
+    ( nurl_eprintln `), not a release.` )
+    ( nurl_eprintln `  In a source checkout, update it with:  git pull && ./build.sh` )
+    ( nurl_eprintln `  To install a published release over it: nurl upgrade --force` )
+}
+
+@ __tc_report_no_installer s prefix → v {
+    ( nurl_eprint `nurl upgrade: no bundled installer under ` )
+    ( nurl_eprint prefix )
+    ( nurl_eprintln `/libexec.` )
+    ( nurl_eprintln `  This toolchain predates in-place upgrades — install the current one with:` )
+    ( nurl_eprintln `    curl -fsSL https://nurl-lang.org/install.sh | sh` )
+}
+
+// Resolve the version to install: the pinned `want`, or the newest
+// release. Empty String when the release index could not be reached
+// (the caller has already been told why).
+@ __tc_resolve_target s want → String {
+    ? > ( nurl_str_len want ) 0 { ^ ( __tc_norm_tag want ) } {}
+    ( nurl_eprintln `resolving the latest release…` )
+    ?? ( update_check_latest ) {
+        T v → { ^ v }
+        F → {
+            ( nurl_eprintln `nurl upgrade: could not reach the release index (offline?).` )
+            ( nurl_eprintln `  Retry later, or pin a version:  nurl upgrade --version vX.Y.Z` )
+        }
+    }
+    ^ ( string_new )
+}
+
+// --check: report and change NOTHING. Deliberately does not care where
+// the toolchain lives or whether it is a release build — a read-only
+// probe has no reason to fail in a source checkout.
+@ __tc_check s want s current → i {
+    : String target ( __tc_resolve_target want )
+    ? == ( string_len target ) 0 { ( string_free target ) ^ 1 } {}
+    ? ( update_check_is_release current ) {
+        ? ( update_check_newer ( string_data target ) current ) {
+            ( nurl_print `update available: ` )
+            ( nurl_print current )
+            ( nurl_print ` → ` )
+            ( nurl_print ( string_data target ) )
+            ( nurl_print `\n  run:  nurl upgrade\n` )
+        } {
+            ( nurl_print `up to date (` )
+            ( nurl_print current )
+            ( nurl_print `)\n` )
+        }
+    } {
+        ( nurl_print `development build ` )
+        ( nurl_print current )
+        ( nurl_print ` — the newest release is ` )
+        ( nurl_print ( string_data target ) )
+        ( nurl_print `\n` )
+    }
+    ( string_free target )
+    ^ 0
+}
+
+// `want` is a pinned tag ("" = resolve the latest release), `current` the
+// running toolchain's version (nurl_version). Returns a process exit code.
+@ toolchain_upgrade s want s current b check_only b force → i {
+    ? check_only { ^ ( __tc_check want current ) } {}
+
+    : String prefix ( toolchain_prefix )
+    ? == ( string_len prefix ) 0 {
+        ( nurl_eprintln `nurl upgrade: cannot locate the toolchain — set $NURL_HOME to its install prefix.` )
+        ( string_free prefix )
+        ^ 1
+    } {}
+
+    // A dev build has no release lineage: replacing it with a tarball is
+    // almost never what the user meant, so it takes an explicit --force.
+    ? | ( update_check_is_release current ) force {} {
+        ( __tc_report_dev current )
+        ( string_free prefix )
+        ^ 1
+    }
+
+    : String installer ( toolchain_installer ( string_data prefix ) )
+    ? == ( string_len installer ) 0 {
+        ( __tc_report_no_installer ( string_data prefix ) )
+        ( string_free installer )
+        ( string_free prefix )
+        ^ 1
+    } {}
+
+    : String target ( __tc_resolve_target want )
+    ? == ( string_len target ) 0 {
+        ( string_free target )
+        ( string_free installer )
+        ( string_free prefix )
+        ^ 1
+    } {}
+
+    : b same != 0 ( nurl_str_eq ( string_data target ) current )
+    : b newer ( update_check_newer ( string_data target ) current )
+
+    ? & same ( __tc_not force ) {
+        ( nurl_print `already on ` )
+        ( nurl_print current )
+        ( nurl_print ` — nothing to do (use --force to reinstall it).\n` )
+        ( string_free target )
+        ( string_free installer )
+        ( string_free prefix )
+        ^ 0
+    } {}
+
+    ? newer {
+        ( nurl_print `upgrading ` ) ( nurl_print current )
+        ( nurl_print ` → ` ) ( nurl_print ( string_data target ) ) ( nurl_print `\n` )
+    } {
+        ? same {
+            ( nurl_print `reinstalling ` ) ( nurl_print ( string_data target ) ) ( nurl_print `\n` )
+        } {
+            ( nurl_print `installing ` ) ( nurl_print ( string_data target ) )
+            ( nurl_print ` over ` ) ( nurl_print current )
+            ( nurl_print ` (a downgrade)\n` )
+        }
+    }
+
+    // ── run the bundled installer, pinned to this prefix + version ────
+    // NURL_NO_MODIFY_PATH: the prefix is already on PATH (that is how we
+    // got here), so an upgrade must never prompt about shell rc files.
+    ?? ( env_set `NURL_NO_MODIFY_PATH` `1` ) { T _ → {} F _ → {} }
+
+    : ( Vec s ) args ( vec_new [s] )
+    : ~ s prog `sh`
+    ? ( __tc_is_windows ) {
+        = prog `powershell`
+        ( vec_push [s] args `-NoProfile` )
+        ( vec_push [s] args `-ExecutionPolicy` )
+        ( vec_push [s] args `Bypass` )
+        ( vec_push [s] args `-File` )
+        ( vec_push [s] args ( string_data installer ) )
+        ( vec_push [s] args `-Version` )
+        ( vec_push [s] args ( string_data target ) )
+        ( vec_push [s] args `-Prefix` )
+        ( vec_push [s] args ( string_data prefix ) )
+    } {
+        ( vec_push [s] args ( string_data installer ) )
+        ( vec_push [s] args `--version` )
+        ( vec_push [s] args ( string_data target ) )
+        ( vec_push [s] args `--prefix` )
+        ( vec_push [s] args ( string_data prefix ) )
+    }
+    : i rc ( __tc_stream prog args )
+    ( vec_free [s] args )
+
+    ? == rc 0 {
+        // The cached probe still names the version we just left behind;
+        // drop it so the next command does not repeat the notice.
+        ( update_check_forget )
+        ( nurl_print `\nNURL ` )
+        ( nurl_print ( string_data target ) )
+        ( nurl_print ` is installed in ` )
+        ( nurl_print ( string_data prefix ) )
+        ( nurl_print `.\n` )
+    } {
+        ( nurl_eprintln `nurl upgrade: the installer did not complete — the toolchain is unchanged.` )
+    }
+
+    ( string_free target )
+    ( string_free installer )
+    ( string_free prefix )
+    ^ ? == rc 0 0 1
+}

--- a/stdlib/ext/update_check.nu
+++ b/stdlib/ext/update_check.nu
@@ -184,9 +184,45 @@ $ `stdlib/ext/http_cli.nu`
     ( string_push_str m latest )
     ( string_push_str m ` (you have ` )
     ( string_push_str m current )
-    ( string_push_str m `).\n  update:  curl -fsSL https://nurl-lang.org/install.sh | sh\n` )
+    ( string_push_str m `).\n  update:  nurl upgrade\n` )
     ( nurl_eprint ( string_data m ) )
     ( string_free m )
+}
+
+// ── public helpers ───────────────────────────────────────────────────
+//
+// The notice above is the passive half of the story; `nurl upgrade`
+// (stdlib/ext/toolchain.nu) is the active one and needs the same three
+// primitives — probe, release-tag test, compare. They are exported here
+// rather than duplicated so both halves always agree on what "newer"
+// means.
+
+// Probe GitHub for the newest release tag, IGNORING the once-a-day cache.
+// None when the network / API is unavailable. Owned String on Some.
+@ update_check_latest → ?String {
+    ^ ( __uc_fetch_latest )
+}
+
+// Is `ver` a clean release tag (vX.Y.Z), as opposed to a dev build
+// (vX.Y.Z-<n>-g<sha>[-dirty])? Upgrading only makes sense for the former.
+@ update_check_is_release s ver → b {
+    ^ ( __uc_is_release ver )
+}
+
+// Strictly-greater release comparison, tolerant of a leading 'v'.
+@ update_check_newer s latest s current → b {
+    ^ ( __uc_newer latest current )
+}
+
+// Drop the cached probe. Called right after a successful upgrade so the
+// next command re-probes instead of repeating a notice for the version
+// the user just installed.
+@ update_check_forget → v {
+    : String cp ( __uc_cache_path )
+    ? ( file_exists ( string_data cp ) ) {
+        ?? ( file_delete ( string_data cp ) ) { T _ → {} F _ → {} }
+    } {}
+    ( string_free cp )
 }
 
 @ update_check_notice s current → v {

--- a/tools/check_installer_sync.sh
+++ b/tools/check_installer_sync.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  check_installer_sync.sh — the served installers must equal the
+#  canonical ones.
+#
+#  tools/get-nurl.{sh,ps1} are the sources of truth. nurlweb/public/
+#  install.{sh,ps1} are the copies actually served from nurl-lang.org,
+#  produced by `npm run sync-installers` — a MANUAL step, which is
+#  precisely how they drifted before: a fix that stopped the installer
+#  from wiping the whole prefix (credentials, models/, every tool
+#  installed with `nurlpkg install`) landed in tools/ and never reached
+#  the copy users actually download. For two weeks the one-liner on the
+#  website was the destructive version.
+#
+#  A byte-compare in CI is the whole fix: drift cannot outlive a PR.
+#  On failure, run:  cd nurlweb && npm run sync-installers
+# ============================================================
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+rc=0
+check_pair() {
+    local canonical="$1" served="$2"
+    if [[ ! -f "$ROOT/$canonical" ]]; then
+        echo "ERROR: missing $canonical" >&2; rc=1; return
+    fi
+    if [[ ! -f "$ROOT/$served" ]]; then
+        echo "ERROR: missing $served (run: cd nurlweb && npm run sync-installers)" >&2; rc=1; return
+    fi
+    if ! cmp -s "$ROOT/$canonical" "$ROOT/$served"; then
+        echo "ERROR: $served has drifted from $canonical" >&2
+        diff -u "$ROOT/$canonical" "$ROOT/$served" | head -40 >&2 || true
+        echo "       fix with:  cd nurlweb && npm run sync-installers" >&2
+        rc=1
+        return
+    fi
+    echo "ok: $served == $canonical"
+}
+
+check_pair tools/get-nurl.sh  nurlweb/public/install.sh
+check_pair tools/get-nurl.ps1 nurlweb/public/install.ps1
+
+exit $rc

--- a/tools/get-nurl.ps1
+++ b/tools/get-nurl.ps1
@@ -29,6 +29,26 @@ param(
 )
 if ($env:NURL_INSTALL_INSECURE -eq "1") { $Insecure = $true }
 $ErrorActionPreference = "Stop"
+
+# Delete a toolchain-owned path. Anything Windows refuses to delete because
+# it is IN USE (the running nurlpkg.exe during `nurl upgrade`) is renamed
+# out of the way instead — a rename is permitted where a delete is not —
+# and swept the next time the installer runs.
+function New-StalePath($p) {
+    return ($p + ".old-" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))
+}
+function Remove-ToolchainPath($p) {
+    if (-not (Test-Path $p)) { return }
+    try { Remove-Item -Recurse -Force -ErrorAction Stop $p; return } catch { }
+    # Something under $p is in use. Clear what we can, rename what we can't.
+    Get-ChildItem -Recurse -File -Force $p -ErrorAction SilentlyContinue | ForEach-Object {
+        try { Remove-Item -Force -ErrorAction Stop $_.FullName }
+        catch { Move-Item -Force $_.FullName (New-StalePath $_.FullName) }
+    }
+    try { Remove-Item -Recurse -Force -ErrorAction Stop $p }
+    catch { Move-Item -Force $p (New-StalePath $p) }
+}
+
 $repo = "nurl-lang/nurl"
 $target = "windows-x86_64"
 
@@ -110,21 +130,33 @@ try {
         $isNurl  = (Test-Path (Join-Path $Prefix "bin\nurl.bat")) -or (Test-Path (Join-Path $Prefix "bin\nurlc.exe"))
         $isEmpty = -not (Get-ChildItem -Force $Prefix -ErrorAction SilentlyContinue)
         # Preserve USER state in the prefix across an upgrade: the
-        # registry token (credentials), tool assets (share\), and any
-        # program installed with `nurlpkg install` (bin\<other>). Only
-        # the toolchain's own paths are removed; the archive overwrites
-        # the rest. build\ and stdlib\ go wholesale so a module deleted
-        # upstream cannot linger.
+        # registry token (credentials), the model cache (models\), tool
+        # assets (share\), and any program installed with `nurlpkg install`
+        # (bin\<other>). Only the toolchain's own paths are removed; the
+        # archive overwrites the rest. build\, stdlib\, zig\ and libexec\
+        # go wholesale so a file deleted upstream cannot linger.
+        #
+        # Windows cannot DELETE a running executable — and `nurl upgrade`
+        # is exactly that case: nurlpkg.exe upgrading the tree it runs
+        # from. It CAN be renamed, so anything undeletable is moved aside
+        # as <name>.old-<id> and swept on the next run. (POSIX needs none
+        # of this: unlinking a running binary is legal there.)
         if ($isNurl -or $isEmpty) {
-            foreach ($d in @("build", "stdlib", "zig")) {
-                $p2 = Join-Path $Prefix $d
-                if (Test-Path $p2) { Remove-Item -Recurse -Force $p2 }
+            foreach ($d in @($Prefix, (Join-Path $Prefix "bin"), (Join-Path $Prefix "build"))) {
+                if (Test-Path $d) {
+                    Get-ChildItem -Force $d -Filter "*.old-*" -ErrorAction SilentlyContinue |
+                        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+                }
+            }
+            foreach ($d in @("build", "stdlib", "zig", "libexec")) {
+                Remove-ToolchainPath (Join-Path $Prefix $d)
             }
             foreach ($f in @("nurl.bat", "nurl.sh", "env",
-                             "bin\nurl.bat", "bin\nurlc.exe",
+                             "bin\nurl.bat", "bin\nurlc.bat",
+                             "bin\nurlfmt.bat", "bin\nurlpkg.bat",
+                             "bin\nurl.exe", "bin\nurlc.exe",
                              "bin\nurlfmt.exe", "bin\nurlpkg.exe")) {
-                $p2 = Join-Path $Prefix $f
-                if (Test-Path $p2) { Remove-Item -Force $p2 }
+                Remove-ToolchainPath (Join-Path $Prefix $f)
             }
         }
         else { throw "'$Prefix' exists, is not empty, and is not a NURL install — refusing to overwrite it. Remove it yourself or set -Prefix to a fresh path." }
@@ -178,7 +210,7 @@ try {
     }
 
     Write-Host ""
-    Write-Host "Then:  nurlc --version   ·   nurlpkg install nq"
+    Write-Host "Then:  nurl --version   ·   nurlpkg install nq   ·   nurl upgrade  (later)"
 }
 finally {
     Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue

--- a/tools/get-nurl.sh
+++ b/tools/get-nurl.sh
@@ -164,16 +164,22 @@ case "$PREFIX" in
 esac
 # An upgrade must not destroy USER state living in the same prefix:
 #   credentials          the registry publish token (nurlpkg login)
+#   models/              the model cache (hub / nurllama — tens of GB)
 #   share/               assets of tools installed via nurlpkg
 #   bin/<other tools>    programs installed via nurlpkg install
 # Wiping the whole prefix (as this did) silently logged the user out and
 # removed every installed tool. Remove only the toolchain's OWN paths —
-# the four shipped binaries, build/, stdlib/, zig/, the shims — and let
-# tar overwrite the rest. stdlib/ and build/ are removed wholesale so a
-# module deleted upstream cannot linger.
+# the four shipped binaries, build/, stdlib/, zig/, libexec/, the shims —
+# and let tar overwrite the rest. Those directories are removed wholesale
+# so a file deleted upstream cannot linger.
+#
+# Unlinking a RUNNING binary is fine on POSIX (the kernel keeps the inode
+# alive for the running process), which is what makes `nurl upgrade` —
+# nurlpkg upgrading the very tree it is executing from — safe here. The
+# Windows installer has to work around the same case differently.
 if [ -e "$PREFIX" ]; then
     if [ -x "$PREFIX/bin/nurl" ] || [ -x "$PREFIX/bin/nurlc" ] || [ -z "$(ls -A "$PREFIX" 2>/dev/null)" ]; then
-        rm -rf "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/zig"
+        rm -rf "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/zig" "$PREFIX/libexec"
         rm -f  "$PREFIX/nurl.sh" "$PREFIX/nurl.bat" "$PREFIX/env" \
                "$PREFIX/bin/nurl" "$PREFIX/bin/nurlc" \
                "$PREFIX/bin/nurlfmt" "$PREFIX/bin/nurlpkg"
@@ -294,7 +300,7 @@ info "The shims self-locate the stdlib, so PATH is all you need — no 'source"
 info "env' required. (bash/zsh users may instead 'source $PREFIX/env', which"
 info "also exports NURL_HOME.)"
 info ""
-info "Then:  nurlc --version   ·   nurlpkg install nq"
+info "Then:  nurl --version   ·   nurlpkg install nq   ·   nurl upgrade  (later)"
 
 # Building a program (and therefore `nurlpkg install <tool>`, which compiles
 # the package from source) needs an LLVM compiler. The archive bundles a

--- a/tools/install-toolchain.bat
+++ b/tools/install-toolchain.bat
@@ -73,6 +73,17 @@ xcopy /e /i /y /q "%ROOT%\stdlib" "%PREFIX%\stdlib" >nul
 REM Build driver (resolves build\nurlc.exe + stdlib\runtime.o relative to itself).
 copy /y "%ROOT%\nurl.bat" "%PREFIX%\nurl.bat" >nul
 
+REM -- Bundled installer - this is what `nurl upgrade` runs ------
+REM Shipping it means an in-place upgrade executes the script that came
+REM WITH the toolchain you already trust, instead of downloading one and
+REM piping it to a shell. Mirrors install-toolchain.sh.
+if not exist "%PREFIX%\libexec" mkdir "%PREFIX%\libexec"
+if exist "%ROOT%\tools\get-nurl.ps1" (
+  copy /y "%ROOT%\tools\get-nurl.ps1" "%PREFIX%\libexec\get-nurl.ps1" >nul
+) else (
+  echo Note: tools\get-nurl.ps1 absent - "nurl upgrade" will not be available.
+)
+
 REM ── Bundled zig backend (optional but recommended) ─────────────
 REM Mirrors install-toolchain.sh: point NURL_BUNDLE_ZIG at an extracted
 REM zig dist (the dir with zig.exe + lib\) and it is staged at

--- a/tools/install-toolchain.sh
+++ b/tools/install-toolchain.sh
@@ -71,6 +71,19 @@ cp -a "$ROOT/stdlib/." "$PREFIX/stdlib/"
 # Build driver (resolves build/nurlc + stdlib/runtime.o relative to itself).
 install -m755 "$ROOT/nurl.sh" "$PREFIX/nurl.sh"
 
+# ── Bundled installer — this is what `nurl upgrade` runs ───────────────
+# Shipping it means an in-place upgrade executes the script that came WITH
+# the toolchain you already trust, instead of downloading a script and
+# piping it to a shell. It is also the single implementation of "verify the
+# archive, then replace the toolchain's own paths and keep everything else
+# in the prefix" — nothing reimplements that in NURL.
+mkdir -p "$PREFIX/libexec"
+if [[ -f "$ROOT/tools/get-nurl.sh" ]]; then
+    install -m755 "$ROOT/tools/get-nurl.sh" "$PREFIX/libexec/get-nurl.sh"
+else
+    echo "Note: tools/get-nurl.sh absent — 'nurl upgrade' will not be available."
+fi
+
 # ── Bundle a self-contained zig backend (optional but recommended) ─────
 # `nurl.sh` prefers a bundled `zig cc` over a system clang: zig carries its
 # own modern LLVM (parses nurlc's opaque-pointer IR), its own lld linker
@@ -183,3 +196,5 @@ echo "    # and add that line to your ~/.bashrc / ~/.zshrc"
 echo
 echo "Then, from anywhere:"
 echo "    nurlpkg install nq             # fetch + build + install a registry program"
+echo "    nurl --version                 # what you have"
+echo "    nurl upgrade                   # move to the newest release, in place"

--- a/tools/nurlfmt/nurlfmt.nu
+++ b/tools/nurlfmt/nurlfmt.nu
@@ -68,6 +68,7 @@ $ `tools/nurlfmt/pretty.nu`
     ( nurl_eprint `    --write    Reformat each FILE in place.\n` )
     ( nurl_eprint `    --stdin    Read from stdin, write to stdout.\n` )
     ( nurl_eprint `    --help     Print this message.\n` )
+    ( nurl_eprint `    --version  Print the toolchain version (-v too).\n` )
     ( nurl_eprint `\n` )
     ( nurl_eprint `Without FILE and without --stdin, reads stdin → writes stdout.\n` )
 }
@@ -136,6 +137,19 @@ $ `tools/nurlfmt/pretty.nu`
     : ~ b stdin_mode F
     : ~ b help_mode F
     : ( Vec String ) paths ( vec_with_cap [String] 4 )
+
+    // --version / -v, like every other binary in the toolchain. Checked
+    // before the parse loop so it can never be mistaken for a file path.
+    : ~ i vi 1
+    ~ < vi argc {
+        : s va ( nurl_argv_get vi )
+        ? | | != 0 ( nurl_str_eq va `--version` ) != 0 ( nurl_str_eq va `-v` ) != 0 ( nurl_str_eq va `version` ) {
+            ( nurl_print ( nurl_version ) )
+            ( nurl_print `\n` )
+            ^ 0
+        } {}
+        = vi + vi 1
+    }
 
     : ~ i idx 1
     ~ < idx argc {

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -46,6 +46,7 @@ $ `stdlib/ext/semver.nu`
 $ `stdlib/ext/credentials.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/update_check.nu`
+$ `stdlib/ext/toolchain.nu`
 $ `stdlib/core/io.nu`
 $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/bytes.nu`
@@ -228,7 +229,10 @@ $ `stdlib/std/bytes.nu`
     ( nurl_print `  nurlpkg verify         Check deps/ matches nurl.lock (names + versions); exit 1 if drift.\n` )
     ( nurl_print `  nurlpkg test           Build + run every tests/*.nu (exit 0 = pass; optional tests/outputs/ goldens).\n` )
     ( nurl_print `  nurlpkg bench          Build + run every benches/*.nu and stream their std/bench.nu reports.\n` )
-    ( nurl_print `  nurlpkg version        Print the nurlpkg version.\n` )
+    ( nurl_print `  nurlpkg self-update [--check] [--version vX.Y.Z] [--force]\n` )
+    ( nurl_print `                         Upgrade the NURL TOOLCHAIN itself (same as 'nurl upgrade').\n` )
+    ( nurl_print `                         Note: 'nurlpkg update' is about this project's dependencies.\n` )
+    ( nurl_print `  nurlpkg version        Print the toolchain version (--version / -v too).\n` )
     ( nurl_print `  nurlpkg help [<cmd>]   This message, or one command's own help.\n` )
     ( nurl_print `\nEvery command also takes --help / -h (help never runs the command).\n` )
 }
@@ -239,6 +243,43 @@ $ `stdlib/std/bytes.nu`
 // command runs — an agent probing `nurlpkg publish --help` must never
 // trigger a publish. Returns F for an unknown command.
 @ __cmd_help s cmd → b {
+    ? | | != 0 ( nurl_str_eq cmd `self-update` ) != 0 ( nurl_str_eq cmd `upgrade` ) != 0 ( nurl_str_eq cmd `self-upgrade` ) {
+        ( nurl_print `nurlpkg self-update — upgrade the NURL toolchain itself
+
+` )
+        ( nurl_print `Usage: nurlpkg self-update [--check] [--version vX.Y.Z] [--force]
+` )
+        ( nurl_print `       nurl upgrade [...]          the canonical spelling; same command
+
+` )
+        ( nurl_print `Downloads the release that matches this machine and unpacks it over the
+` )
+        ( nurl_print `current install prefix ($NURL_HOME), verifying the checksum and (when
+` )
+        ( nurl_print `minisign is present) the signature. USER STATE in the prefix is kept:
+` )
+        ( nurl_print `the registry token, ~/.nurl/models, and every program you installed
+` )
+        ( nurl_print `with 'nurlpkg install' stay exactly where they are.
+
+` )
+        ( nurl_print `Flags:
+` )
+        ( nurl_print `  --check            Report whether an update exists; install nothing.
+` )
+        ( nurl_print `  --version <tag>    Install a specific release (pin, or go back).
+` )
+        ( nurl_print `  --force            Reinstall the same version, or replace a dev build.
+` )
+        ( nurl_print `  --help             This message (nothing is installed).
+
+` )
+        ( nurl_print `Not to be confused with 'nurlpkg update', which moves THIS PROJECT's
+` )
+        ( nurl_print `dependency requirements to newer versions.
+` )
+        ^ T
+    } {}
     ? != 0 ( nurl_str_eq cmd `publish` ) {
         ( nurl_print `nurlpkg publish — pack this package and upload it to the registry
 
@@ -3883,13 +3924,76 @@ Usage: nurlpkg login   (paste the token from the registry; kept in ~/.nurl/crede
     }
 }
 
+// ── self-update: upgrade the toolchain itself ───────────────────
+//
+// Deliberately NOT spelled `nurlpkg update`: that has moved this project's
+// dependency requirements since 0.4, and silently changing what it means
+// would be worse than any naming win. The canonical spelling is
+// `nurl upgrade` (what the update notice prints); this is the same command
+// under the name other package managers use for it, so either guess lands.
+
+// The value that follows `--name` in argv[from..], or an empty String.
+@ __flag_value s name i from → String {
+    : i argc ( env_args_count )
+    : ~ i k from
+    : ~ String out ( string_new )
+    ~ < k argc {
+        : String a ( env_arg k )
+        : i nx + k 1
+        ? & != 0 ( nurl_str_eq ( string_data a ) name ) < nx argc {
+            ( string_free out )
+            = out ( env_arg nx )
+        } {}
+        ( string_free a )
+        = k + k 1
+    }
+    ^ out
+}
+
+// T when `--name` appears anywhere in argv[from..].
+@ __has_flag s name i from → b {
+    : i argc ( env_args_count )
+    : ~ i k from
+    ~ < k argc {
+        : String a ( env_arg k )
+        : b hit != 0 ( nurl_str_eq ( string_data a ) name )
+        ( string_free a )
+        ? hit { ^ T } {}
+        = k + k 1
+    }
+    ^ F
+}
+
+@ __cmd_self_update → i {
+    ? != 0 ( __reject_unknown_flags `self-update` `--check --force --version` 2 ) { ^ 1 } {}
+    : b check_only ( __has_flag `--check` 2 )
+    : b force ( __has_flag `--force` 2 )
+    : String want ( __flag_value `--version` 2 )
+    : i rc ( toolchain_upgrade ( string_data want ) ( nurl_version ) check_only force )
+    ( string_free want )
+    ^ rc
+}
+
 // ── dispatch ─────────────────────────────────────────────────────
+
+// Was this invocation the self-update itself? If so, skip the trailing
+// "a newer toolchain is out" notice: the version baked into THIS process
+// is the one we just replaced on disk, so the notice would fire against
+// the toolchain the user has already upgraded away from.
+@ __is_self_update → b {
+    ? < ( env_args_count ) 2 { ^ F } {}
+    : String a ( env_arg 1 )
+    : s v ( string_data a )
+    : b hit | | != 0 ( nurl_str_eq v `self-update` ) != 0 ( nurl_str_eq v `upgrade` ) != 0 ( nurl_str_eq v `self-upgrade` )
+    ( string_free a )
+    ^ hit
+}
 
 // Run the command, then print a best-effort "a newer toolchain is out" notice
 // AFTER its output (stderr; cached, opt-out — see stdlib/ext/update_check.nu).
 @ main → i {
     : i rc ( __nurlpkg_run )
-    ( update_check_notice ( nurl_version ) )
+    ? ( __is_self_update ) {} { ( update_check_notice ( nurl_version ) ) }
     ^ rc
 }
 
@@ -3922,10 +4026,15 @@ Usage: nurlpkg login   (paste the token from the registry; kept in ~/.nurl/crede
         ( string_free sub )
         ^ 0
     } {}
-    ? | != 0 ( nurl_str_eq s_sub `--version` ) != 0 ( nurl_str_eq s_sub `version` ) {
+    ? | | != 0 ( nurl_str_eq s_sub `--version` ) != 0 ( nurl_str_eq s_sub `-v` ) != 0 ( nurl_str_eq s_sub `version` ) {
         ( nurl_print ( nurl_version ) ) ( nurl_print `\n` )
         ( string_free sub )
         ^ 0
+    } {}
+    // Upgrade the toolchain. `nurl upgrade` routes here too.
+    ? | | != 0 ( nurl_str_eq s_sub `self-update` ) != 0 ( nurl_str_eq s_sub `upgrade` ) != 0 ( nurl_str_eq s_sub `self-upgrade` ) {
+        ( string_free sub )
+        ^ ( __cmd_self_update )
     } {}
     ? != 0 ( nurl_str_eq s_sub `init` ) {
         : String name ? >= argc 3 ( env_arg 2 ) ( string_new )

--- a/webdocs/content/docs/editor-and-tooling.mdx
+++ b/webdocs/content/docs/editor-and-tooling.mdx
@@ -57,7 +57,13 @@ nurlpkg publish                        # pack + upload
 ```
 
 Other subcommands: `info`, `deps`, `remove`, `update`, `lock`, `login`,
-`logout`, `search`, `yank` / `unyank`, `test`, `bench`, `version`.
+`logout`, `search`, `yank` / `unyank`, `test`, `bench`, `version`,
+`self-update`.
+
+`self-update` upgrades the **toolchain** rather than a package — normally
+you spell it `nurl upgrade` (see [Install](/docs/install#keeping-it-up-to-date)).
+`nurlpkg update` is a different thing entirely: it moves your project's
+dependency requirements.
 
 ## MCP server (`nurl-mcp`)
 

--- a/webdocs/content/docs/install.mdx
+++ b/webdocs/content/docs/install.mdx
@@ -27,6 +27,34 @@ Windows (PowerShell)
 irm https://nurl-lang.org/install.ps1 | iex
 ```
 
+### Keeping it up to date
+
+Once the toolchain is installed it upgrades itself — you never need the
+one-liner again:
+
+```bash
+nurl upgrade              # fetch + install the newest release
+nurl upgrade --check      # is there a newer one? (installs nothing)
+```
+
+`nurl update` and `nurlpkg self-update` are the same command under the
+names people tend to guess. It is *not* `nurlpkg update`, which moves your
+**project's** dependency requirements.
+
+The upgrade replaces only the toolchain's own files. Everything else in
+`$NURL_HOME` (default `~/.nurl`) is left alone: your registry token, the
+model cache under `models/`, and every program you installed with
+`nurlpkg install`. Two other flags matter occasionally:
+
+| Flag | Effect |
+|---|---|
+| `--version vX.Y.Z` | Install one specific release — pin it, or go back |
+| `--force` | Reinstall the version you already have, or replace a source build |
+
+Each release archive is checked against its published SHA-256, and against
+its minisign signature when `minisign` is on your `PATH`; a mismatch aborts
+before anything is unpacked.
+
 <Accordions>
   <Accordion title="Why is there no prebuilt path for macOS?">
      NURL's CI now builds and tests on **Linux and FreeBSD** only. NURL


### PR DESCRIPTION
## Why

`nurlpkg` has been telling users a newer toolchain exists and then handing them a `curl … | sh` line, because there was no command to offer. Now there is one, and it is what the notice prints.

```
nurl upgrade                    # newest release, in place
nurl upgrade --check            # report only; installs nothing
nurl upgrade --version v0.25.0  # pin a release, or go back to one
nurl upgrade --force            # reinstall this version / replace a dev build
```

`nurl update`, `nurlpkg self-update` and `nurlpkg upgrade` are the same command, so the spellings people guess all land in one place. **`nurlpkg update` deliberately keeps its existing meaning** — a *project's* dependency requirements — and both help texts say so; quietly repurposing it would have been worse than any naming win.

## It runs the installer, it does not reimplement it

The checksum gate, the signature gate, and the "replace the toolchain's files, keep the rest of the prefix" rule are one script. That script now ships **inside** the toolchain at `<prefix>/libexec/get-nurl.sh` (`.ps1` on Windows), installed by `install-toolchain.{sh,bat}`.

So an upgrade executes the installer that came with the version you already trust — not a script downloaded and piped to a shell — and there is no second implementation to keep in step. `stdlib/ext/toolchain.nu` resolves a version, decides whether anything needs doing, and spawns it. `process_spawn` inherits stderr, so the installer's progress streams live rather than arriving in a lump at the end.

## The bug this uncovered

`tools/get-nurl.{sh,ps1}` stopped wiping the whole install prefix in July (b8975fe) — before that, an upgrade deleted the registry token, `models/`, `share/`, and every program installed with `nurlpkg install`.

But `nurlweb/public/install.{sh,ps1}` — the copies actually served from nurl-lang.org and downloaded by the one-liner — are produced by a **manual** npm script that was never re-run. For two weeks the website kept handing out the destructive version.

- The copies are re-synced.
- `tools/check_installer_sync.sh` byte-compares both pairs and now runs in CI, so this class of drift cannot outlive a PR.

## Also here

- **`--version` / `-v` on every binary.** `nurlfmt` had no version flag at all; `nurlc` only the long form; `nurl` and `nurlpkg` accepted it but never mentioned it in usage.
- `models/` and `libexec/` named explicitly in the installers' keep/remove rules.
- **Windows cannot delete a running `.exe`** — and `nurl upgrade` is precisely that: nurlpkg upgrading the tree it is executing from. `get-nurl.ps1` renames what it cannot delete to `.old-<id>` and sweeps the leftovers on the next run. POSIX allows unlinking a running binary, which is why the same code path is uneventful there.

## Verification

End to end against a sandbox prefix, with a seeded token, a `models/` entry, a `share/` asset and a user-installed tool:

- real download from GitHub Releases, SHA-256 **and** minisign verified, `v0.26.0` installed;
- **all four pieces of user state survived**;
- the prefix resolves from `$NURL_STDLIB` when `NURL_HOME` is unset — the common case, since the PATH shims export only the former;
- `--version 0.26.0` (no leading `v`) normalises to the tag;
- dev-build guard, unknown-flag rejection, missing-`libexec` message and every alias exercised.

Gates: `build.sh` + test suite, `nurlfmt --check` (845 files), stdlib symbol-collision gate, package-import gate, and the new installer-sync gate.

Windows paths are reviewed but not executed here — no PowerShell on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvBEWHJaQCmjxq3YJ35naG