### PR TITLE
bench: a wasm suite, and the -O0 bug it found in every wasm module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--version`, `-v` and (where it isn't ambiguous) the bare word `version`,
   and say so in their usage text.
 
+- **A wasm benchmark suite: `bench/wasmbench.sh` → `bench/WASMRESULTS.md`.**
+  The sibling of `bench.sh`, same roster and same protocol, one axis
+  rotated. `bench.sh` asks how fast NURL is against four other languages;
+  this asks what *targeting wasm* costs, and what running that wasm on
+  **NURL's own runtime** costs. Every benchmark's NURL, C and Rust sources
+  are compiled twice — native and `wasm32-wasi` — and each module is run
+  on two runtimes: the reference `wasmtime` (Cranelift JIT) and
+  `packages/wasmtime`, the WebAssembly interpreter written in pure NURL.
+  Ten timed cells per row, all gated on printing the same line as the
+  native NURL binary, the interpreter *inside* the gate rather than beside
+  it — a runtime that gets the wrong answer quickly is not a fast runtime.
+
+  - **C and Rust are the control, not decoration.** A NURL-only
+    wasm-vs-native ratio cannot tell "wasm is slower here" from "NURL's
+    wasm pipeline is slower here". And modules emitted by two other LLVM
+    frontends are the only honest test of a runtime developed against
+    NURL's own output: `packages/wasmtime` runs all 15 benchmarks from all
+    three languages with output identical to native.
+  - **Everything under test is built from the working tree** — `nurlc`,
+    `stdlib/runtime.o`, `packages/wasmbuilder` and `packages/wasmtime` —
+    so the numbers describe this repo and not whatever is in `$NURL_HOME`.
+  - **Running both runtimes is what found the bug.** A JIT re-optimises
+    whatever it is given, so it reports roughly the same number for a good
+    module and a bad one; an interpreter executes exactly what is in the
+    module and reports the difference. The `-Xclang -O2` defect below had
+    been shipping in every wasm build and was invisible in the reference
+    column — it showed up as a 5.5× gap in the interpreter column.
+  - **The reference runtime's compiled-module cache is turned off**
+    (`-C cache=n`). Its CLI enables that cache by default, which made a
+    cell mean "Cranelift ran" or "Cranelift did not run" depending on what
+    happened to be in `~/.cache/wasmtime` — including for the floor row,
+    whose whole job is to be subtracted from the others. Measured across
+    that boundary, `lcg` came out *ten times faster* than its own empty
+    program. Off, both runtimes are measured doing the same work: read the
+    module, translate it, run it.
+
+- **`wasmbuilder --gc-sections`**, and `WbOpts.gc_sections` for embedders.
+  The builder has always passed `-Wl,--no-gc-sections`, because NURL
+  closures store function-table indices and section GC renumbers that
+  table — a `call_indirect` trap at run time with no link error to warn
+  anyone, observed on `nurlc.wasm`. The flag was not the problem; having no
+  way to opt out of it was. What it drops is most of the NURL runtime a
+  program never calls: on `bench/lcg.nu` the module goes 1064 KiB → 819 KiB
+  and a reference `wasmtime` run goes ~120 ms → ~85 ms, because the runtime
+  stops translating code nothing reaches. `wasmbench.sh` builds every
+  benchmark both ways and holds both to the same output, so the size of the
+  prize is now a measured number rather than an argument. It is an opt-in,
+  not a new default: what stands between it and being one is making closure
+  indices survive renumbering.
+
+- **`wasmtime --version` / `--help`.** The package had neither, while its
+  sibling `wasmbuilder` had both, so nothing that shelled out to it could
+  record which runtime produced a result.
+
 ### Fixed
 
 - **The installer served from nurl-lang.org still wiped the whole install
@@ -61,6 +115,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upgrading the tree it is executing from, and Windows refuses to unlink a
   running `.exe` (POSIX allows it, which is why the same code path is
   uneventful there).
+
+- **Every wasm module `wasmbuilder` ever produced shipped unoptimised code.**
+  `zig cc` drops `-O` for LLVM IR inputs — it forwards the level for C, but
+  for a `.ll` it passes nothing to cc1 and cc1 defaults to `-O0`. This
+  pipeline hands zig a `.ll`, so nothing the user wrote was optimised: no
+  mem2reg, so a loop counter stayed a linear-memory load/store pair, and
+  `bench/lcg.nu`'s inner loop reloaded the same value twice per iteration.
+
+  `nurl.sh` has carried the workaround for native builds since it was
+  discovered there (`-Xclang <level>`, which reaches cc1 and survives);
+  `wasmbuilder` never got the wasm half of it. Now it does.
+
+  A JIT hid this completely, which is why it lasted: Cranelift re-optimises
+  whatever it is handed, so the reference `wasmtime` timings moved by
+  nothing. An interpreter cannot — `packages/wasmtime` ran `lcg` at 1M
+  iterations in 1.09 s before and 0.20 s after, and the full 20M-iteration
+  benchmark went **17.86 s → 2.77 s**. The gap between those two columns is
+  what made the bug visible at all, and it is the reason the wasm suite runs
+  both runtimes rather than only the fast one.
+
+- **`packages/wasmtime`: the interpreter loop re-read its frame on every
+  instruction.** The frame stack only moves on a call, a return, or falling
+  off the end of a body, but the loop did a bounds-checked `vec_get`, an
+  Option unwrap and a dependent load per *instruction*, then copied
+  `pos`/`end` into the cursor and back out again. The cursor is now the
+  authority on where execution is and the frame is cached until the stack
+  moves; `pos` is written back exactly where something reads it (a call
+  suspending the frame, a trap printing a backtrace). Worth 3–4 %.
+
+  Two other candidates were tried and reverted, both measured: bisecting the
+  opcode dispatch chain (−5 %) and a single-byte fast path in the LEB128
+  reader (−12 %). The dispatch chain reads like a 177-comparison linear scan
+  in the source but LLVM already lowers it to jump tables — one indirect jump
+  in `__exec_op`, two in `__exec_num` — so "reordering by frequency" only
+  split a working table into five. At 3.4 IPC and a 0.05 % branch-miss rate
+  the interpreter is not stalling anywhere; it retires ~191 host
+  instructions per wasm instruction, and that cost is spread across
+  decode-at-execution and bounds-checked container access on every stack and
+  local touch. Bringing it down needs a pre-decoded instruction
+  representation, not local edits.
+
+- **`wasmbuilder --version` reported 0.1.1 when the package was 0.1.3.** A
+  version string is what a bug report quotes; a stale one misattributes the
+  bug. Both this and the new `wasmtime` version literal carry a comment
+  saying to keep them in step with `nurl.toml`.
+
+- **`wasmbuilder`'s `--cflags`, `--obj` and `--asyncify-imports` were
+  undocumented** — implemented in the CLI, absent from the README, so the
+  only way to find them was `--help` or the source.
 
 ## [0.26.0] — 2026-07-26
 

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,3 +1,4 @@
 _build/
 data.json
 _venv/
+_wasmbuild/

--- a/bench/README.md
+++ b/bench/README.md
@@ -5,6 +5,10 @@ Fifteen benchmarks. Five languages each — **NURL**, **C**, **Rust**,
 report. A row is timed only when all five implementations print the same
 line, so no cell can be fast by computing something else.
 
+Two runners read the same roster: `bench.sh` compares languages on the
+native target, and [`wasmbench.sh`](#the-wasm-suite--wasmbenchsh) compares
+native against `wasm32-wasi` on two runtimes.
+
 ```sh
 ./build.sh                 # build/nurlc + stdlib/runtime.o must exist first
 ./bench/bench.sh           # the whole suite (~10 min; Python is the long pole)
@@ -24,6 +28,25 @@ Both are refreshed by [`.github/workflows/bench.yml`](../.github/workflows/bench
 on a fixed `ubuntu-latest` runner — weekly, and on demand from the Actions
 tab. Those runs commit the refreshed files, which is how nurl-lang.org's
 numbers stay honest without anyone typing a figure into HTML.
+
+## On Windows — `bench.ps1`
+
+[`bench.ps1`](bench.ps1) is the same suite, same manifest, same protocol,
+for a Windows box. It needs `build.bat` to have run, plus clang, rustc,
+node and a Python the `py` launcher can find.
+
+```powershell
+build.bat --no-tests               # build\nurlc.exe + stdlib\runtime.o
+pwsh bench\bench.ps1               # the whole suite
+pwsh bench\bench.ps1 -Quick        # one run per cell, for a smoke test
+pwsh bench\bench.ps1 -Bench lcg,sieve
+pwsh bench\bench.ps1 -Stdout       # print the report, write nothing
+```
+
+It writes [`results/latest-windows.json`](results/latest-windows.json) and
+`RESULTS-WINDOWS.md`, deliberately **not** the two files above: those are
+the Linux CI numbers the landing page publishes, and a local Windows run
+must not be able to end up in that table by accident.
 
 ## The contract
 
@@ -109,6 +132,56 @@ checksum gate is what keeps "fastest" from drifting into "different".
   load generator; results in [`HTTP_RESULTS.md`](HTTP_RESULTS.md). It
   measures requests per second, not wall clock, so it has its own runner.
 * `stdlib_hotpath.nu` is a NURL-only profiling probe with no peers.
+
+## The wasm suite — `wasmbench.sh`
+
+[`wasmbench.sh`](wasmbench.sh) is the same corpus with one axis rotated.
+`bench.sh` asks how fast NURL is against four other languages;
+`wasmbench.sh` asks what **targeting wasm** costs, and what running that
+wasm on **NURL's own runtime** costs:
+
+```sh
+./bench/wasmbench.sh                 # the whole suite (~15 min)
+./bench/wasmbench.sh --wt-all-langs  # + C/Rust on the interpreter (~45 min)
+./bench/wasmbench.sh --quick --bench lcg
+```
+
+Everything but the interpreter column costs about what `bench.sh` does;
+the interpreter is ~500× native, so it is the whole budget. Running the C
+and Rust modules on it too — the cross-frontend control — triples that, so
+it is opt-in.
+
+Each benchmark's NURL, C and Rust sources are compiled **twice** — native
+and `wasm32-wasi` — and each module is run on **two** runtimes: the
+reference `wasmtime` (Cranelift JIT) and
+[`packages/wasmtime`](../packages/wasmtime), a WebAssembly interpreter
+written in pure NURL. Ten timed cells per row, all gated on printing the
+same line as the native NURL binary — the interpreter is *inside* the
+gate, because a runtime that gets the wrong answer quickly is not a fast
+runtime. Results: [`WASMRESULTS.md`](WASMRESULTS.md) and
+[`results/wasm-latest.json`](results/wasm-latest.json).
+
+The tenth cell is the NURL module relinked with `--gc-sections`, which
+`wasmbuilder` leaves off by default because NURL closures store function
+table indices that section GC renumbers. None of these benchmarks uses a
+closure, so the suite can put a number on what that default costs — see
+section 5 of the report, and
+[`packages/wasmbuilder`](../packages/wasmbuilder/README.md#--gc-sections)
+for when it is safe to turn on.
+
+C and Rust are there as the control. Without them a wasm-vs-native ratio
+cannot distinguish "wasm is slower here" from "NURL's wasm pipeline is
+slower here", and modules from two other LLVM frontends are the only
+honest test of a runtime written against NURL's own output.
+
+The pieces are all built from this repo rather than from an installed
+toolchain — `nurlc`, `stdlib/runtime.o`,
+[`packages/wasmbuilder`](../packages/wasmbuilder) (NURL → wasm) and
+`packages/wasmtime` (the runtime) — so the numbers describe this working
+tree. What it additionally needs on the host is `zig` (wasi-libc +
+`wasm-ld`, and the NURL toolchain bundles one), `rustup target add
+wasm32-wasip1`, and a reference `wasmtime`, which is deliberately *not*
+vendored here: its whole job is to be the outside opinion.
 
 ## Beyond wall clock
 

--- a/bench/RESULTS-WINDOWS.md
+++ b/bench/RESULTS-WINDOWS.md
@@ -1,0 +1,145 @@
+# Benchmark results (Windows) — NURL vs C vs Rust vs Node vs Python
+
+Generated `2026-07-27T09:12:12Z` by `bench/bench.ps1`, the Windows port of
+`bench/bench.sh`. **Do not edit by hand** — the next run overwrites it.
+The machine-readable form of this same run is
+[`results/latest-windows.json`](results/latest-windows.json).
+
+These are **not** the numbers the landing page publishes: that table comes
+from the Linux CI run in [`RESULTS.md`](RESULTS.md) /
+[`results/latest.json`](results/latest.json). Two things differ beyond the
+host — NURL links without `-flto` here, because `build.bat` does not compile
+`stdlib/runtime.o` to bitcode, and the link names `-lwinhttp` instead of
+`-lm -lpthread`. Both match what a real `nurl.bat` build does on this
+platform, which is the property worth measuring; both make the NURL column
+incomparable to a Linux run cell-for-cell.
+
+## Environment
+
+| Item | Value |
+|---|---|
+| Host | `Windows AMD64` |
+| OS | `Microsoft Windows 11 Pro 10.0.26200 AMD64` |
+| CPU | 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz (16 logical cores) |
+| Memory | 33250360 KiB |
+| Commit | `1b8552a56ec3440f299144297322fd7bd11b0c25` |
+| NURL | `v0.26.0-17-g1b8552a` |
+| C | clang version 22.1.3 (https://github.com/llvm/llvm-project e9846648fd6183ee6d8cbdb4502213fcf902a211) |
+| Rust | rustc 1.97.1 (8bab26f4f 2026-07-14) |
+| Node | v22.16.0 |
+| Python | Python 3.12.6 |
+
+| Setting | Value |
+|---|---|
+| Optimisation | NURL/C `clang -O2` (no LTO), Rust `-C opt-level=2` |
+| NURL link | `-lwinhttp -LC:\vcpkg\installed\x64-windows-static\lib -lzlib -LC:\vcpkg\installed\x64-windows-static\lib -lzstd` |
+| Timed runs per cell | up to 5, adaptive: as many as fit in 8000 ms |
+| Timed compiles per cell | 3 (median) |
+| Per-run timeout | 300 s |
+
+## 1. Run time (median wall clock, ms — lower is better)
+
+Whole-process wall clock, start-up included. Every implementation of a
+row prints the same line (section 3), so these are five timings of the
+same computation. **Bold** is the fastest cell in the row.
+
+| Benchmark | NURL | C | Rust | Node | Python |
+|---|---:|---:|---:|---:|---:|
+| _(floor: empty program)_ | _17.974_ | _16.930_ | _16.894_ | _45.416_ | _34.080_ |
+| `lcg` | 43.842 | **42.598** | 43.376 | 2691.907 | 4883.625 |
+| `affine_mix` | **43.338** | 43.860 | 45.427 | 1801.460 | 5707.761 |
+| `packet_classifier` | 56.976 | **54.543** | 54.823 | 149.417 | 3692.680 |
+| `ring_write` | 46.586 | **43.584** | 44.457 | 79.780 | 6047.521 |
+| `histogram_bins` | 46.700 | 46.549 | **44.944** | 80.052 | 5890.072 |
+| `prefix_scan` | 33.603 | 32.084 | **31.011** | 82.763 | 4156.530 |
+| `binary_search` | **38.135** | 39.071 | 47.589 | 114.913 | 5556.885 |
+| `sort_window` | 56.797 | 73.591 | **43.306** | 180.255 | 9803.525 |
+| `bloom_filter` | 27.923 | 27.381 | **26.781** | 3032.633 | 7399.137 |
+| `hash_join` | 21.939 | 20.800 | **18.817** | 417.576 | 797.204 |
+| `sieve` | 40.803 | **38.092** | 39.073 | 88.439 | 2887.155 |
+| `fib` | 39.900 | **34.760** | 38.585 | 126.255 | 1135.616 |
+| `collatz` | 26.092 | **24.686** | 27.535 | 74.279 | 721.317 |
+| `matmul` | 28.820 | **28.188** | 30.106 | 83.410 | 2774.881 |
+| `json_parse` | 38.834 | **26.497** | 31.166 | 55.709 | 56.647 |
+
+## 2. Compile time (median, ms)
+
+NURL's compile is two stages: `nurlc.exe` emits LLVM IR, then `clang`
+lowers and links it against `stdlib\runtime.o`. **NURL total** is the
+number comparable to the C and Rust columns. The floor row is what each
+toolchain costs for a program that does nothing — for NURL that is
+dominated by the link every NURL binary pays for, so subtract it to read
+the marginal cost of the benchmark itself. Node and Python have no column
+here: they compile at run time, inside their own cells above.
+
+| Benchmark | NURL `nurlc` | NURL `clang` | **NURL total** | C `clang` | Rust `rustc` |
+|---|---:|---:|---:|---:|---:|
+| _(floor: empty program)_ | _19.296_ | _140.689_ | _**159.985**_ | _134.885_ | _150.452_ |
+| `lcg` | 20.275 | 147.284 | **167.559** | 142.459 | 161.837 |
+| `affine_mix` | 19.871 | 137.448 | **157.319** | 148.864 | 165.992 |
+| `packet_classifier` | 19.912 | 132.855 | **152.767** | 143.176 | 163.810 |
+| `ring_write` | 19.853 | 142.181 | **162.034** | 146.878 | 163.316 |
+| `histogram_bins` | 19.582 | 139.547 | **159.129** | 159.375 | 165.832 |
+| `prefix_scan` | 20.905 | 140.252 | **161.157** | 146.447 | 167.459 |
+| `binary_search` | 20.524 | 136.254 | **156.778** | 149.383 | 169.737 |
+| `sort_window` | 20.875 | 143.335 | **164.210** | 154.604 | 173.932 |
+| `bloom_filter` | 20.333 | 143.749 | **164.082** | 147.674 | 169.643 |
+| `hash_join` | 27.745 | 175.182 | **202.927** | 179.524 | 213.555 |
+| `sieve` | 20.176 | 152.034 | **172.210** | 159.493 | 173.474 |
+| `fib` | 19.631 | 135.299 | **154.930** | 144.115 | 157.994 |
+| `collatz` | 19.652 | 145.569 | **165.221** | 146.551 | 160.852 |
+| `matmul` | 20.816 | 146.205 | **167.021** | 164.708 | 189.942 |
+| `json_parse` | 100.124 | 490.862 | **590.986** | 187.992 | 296.932 |
+
+## 3. Correctness gate
+
+Each row is timed only when all five implementations print the same
+line. A speed number for a program computing something else is worthless,
+so a mismatch drops the row out of the tables above rather than being
+reported as a fast cell. Comparison is on the text, with CRLF normalised
+to LF — C's and Python's stdio are in text mode on Windows and the NURL
+runtime writes bytes, which is a line-ending difference and nothing more.
+
+| Benchmark | Output | Verdict |
+|---|---|---|
+| `lcg` | `-7585129161289236796` | identical across 5 languages |
+| `affine_mix` | `227901546981696845` | identical across 5 languages |
+| `packet_classifier` | `4205972061` | identical across 5 languages |
+| `ring_write` | `8299504528805184357` | identical across 5 languages |
+| `histogram_bins` | `1215643728` | identical across 5 languages |
+| `prefix_scan` | `492982549` | identical across 5 languages |
+| `binary_search` | `805907445` | identical across 5 languages |
+| `sort_window` | `2815490238` | identical across 5 languages |
+| `bloom_filter` | `2351703` | identical across 5 languages |
+| `hash_join` | `2814341850483607168` | identical across 5 languages |
+| `sieve` | `664579` | identical across 5 languages |
+| `fib` | `9227465` | identical across 5 languages |
+| `collatz` | `350` | identical across 5 languages |
+| `matmul` | `393199` | identical across 5 languages |
+| `json_parse` | `20` | identical across 5 languages |
+
+## 4. Reading the numbers
+
+* A cell near the floor row is mostly process start-up, DLL loading and
+  page faults rather than the benchmark. The rows worth comparing are the
+  ones in the tens of milliseconds and up. The Windows floor is higher
+  than the Linux one across the board — loader work, not the language.
+* All three compiled back ends are LLVM-based and all three are allowed to
+  be clever: LLVM will fold an affine recurrence or unroll a loop by a
+  different factor in each language. A cell measures optimised throughput
+  of the same algorithm, not the source-level iteration count.
+* Ten of the fifteen benchmarks are defined over 64-bit unsigned integers.
+  Python has arbitrary-precision integers and masks; JS has no 64-bit
+  integer at all, so those rows use `BigInt` where the algorithm genuinely
+  needs 64 bits and Numbers with `Math.imul` where 32 bits suffice. Each
+  file says which and why. That gap *is* part of what this table reports.
+* `json_parse` is the one row whose gate is "every parser accepted the
+  document" rather than a structural checksum: each language uses the
+  parser in its own box (Python `json`, Node `JSON.parse`, NURL
+  `stdlib/ext/json.nu`), and C and Rust — whose boxes are empty — carry a
+  small hand-written recursive-descent parser in the benchmark file.
+* Wall clock on a machine that was not quiesced drifts a few per cent
+  between runs, and more on a laptop that can thermally throttle or drop
+  to a power-saving governor mid-suite. Compare deltas between runs on the
+  same box, not absolutes across machines — and never across OSes here,
+  for the link-line reason at the top of this file.

--- a/bench/WASMRESULTS.md
+++ b/bench/WASMRESULTS.md
@@ -1,0 +1,301 @@
+# WebAssembly benchmark results — NURL native vs NURL wasm
+
+Generated `2026-07-27T09:53:03Z` by `bench/wasmbench.sh`. **Do not edit by hand** —
+the next run overwrites it. The machine-readable form of this same run
+is [`results/wasm-latest.json`](results/wasm-latest.json).
+
+This is the sibling of [`RESULTS.md`](RESULTS.md): same corpus, same
+protocol, one axis rotated. `RESULTS.md` asks how fast NURL is against
+four other languages; this file asks what **targeting wasm** costs, and
+what running that wasm on **NURL's own runtime** costs. Every benchmark
+is compiled to a native binary *and* a `wasm32-wasi` module in three
+languages, and each module is run on two runtimes — ten timed cells per
+row, all gated on printing the same line (section 7).
+
+## Environment
+
+| Item | Value |
+|---|---|
+| Host | `Linux x86_64` |
+| Kernel | `Linux 7.0.0-28-generic x86_64` |
+| CPU | Intel(R) Core(TM) i7-5930K CPU @ 3.50GHz (12 logical cores) |
+| Memory | 32770952 KiB |
+| Commit | `ad7e4391c17af5bc82ffc997b8e97005329aabd2` |
+| NURL | `v0.26.0-15-gad7e439` |
+| C | Ubuntu clang version 18.1.3 (1ubuntu1) |
+| Rust | rustc 1.82.0 (f6e511eec 2024-10-15) |
+
+| Component | Value |
+|---|---|
+| NURL → wasm | `packages/wasmbuilder` (wasmbuilder 0.1.3), built from this repo |
+| C → wasm | `zig 0.13.0 cc --target=wasm32-wasi` |
+| Rust → wasm | `rustc --target wasm32-wasip1` |
+| wasm runtime (reference) | `wasmtime 44.0.0 (af382d7d9 2026-04-20)` — Cranelift JIT |
+| wasm runtime (NURL) | `packages/wasmtime` (wasmtime 0.6.2 (pure NURL)) — interpreter, built from this repo |
+
+| Setting | Value |
+|---|---|
+| Optimisation | NURL/C `-O2`, Rust `-C opt-level=2`, both targets |
+| Timed runs per cell | up to 5, adaptive: as many as fit in 8000 ms |
+| Timed compiles per cell | 3 (median) |
+| Per-run timeout | 900 s |
+| C/Rust on the NURL interpreter | no (add --wt-all-langs) |
+| Reference runtime cache | **off** (`-C cache=n`) — every cell is decode + compile + run |
+
+## 1. What wasm costs — native vs the same module on a JIT
+
+Whole-process wall clock in milliseconds, start-up included. The `x`
+columns are wasm ÷ native for that language: how much slower the *same
+source* got by being compiled to wasm and run under a JIT instead of
+straight to the machine. Because all three languages appear, the column
+answers a question a NURL-only table could not: whether a gap belongs to
+NURL's wasm pipeline or to wasm itself.
+
+| Benchmark | NURL native | NURL wasm | x | C native | C wasm | x | Rust native | Rust wasm | x |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| _(floor: empty program)_ | _1.664_ | _62.536_ | _37.6_ | _1.527_ | _7.151_ | _4.7_ | _1.705_ | _17.188_ | _10.1_ |
+| `lcg` | 39.454 | 92.613 | 2.3 | 36.734 | 70.561 | 1.9 | 40.684 | 55.154 | 1.4 |
+| `affine_mix` | 33.592 | 91.026 | 2.7 | 34.469 | 59.458 | 1.7 | 40.279 | 53.595 | 1.3 |
+| `packet_classifier` | 63.118 | 111.411 | 1.8 | 68.643 | 77.651 | 1.1 | 68.195 | 69.459 | 1.0 |
+| `ring_write` | 37.471 | 98.644 | 2.6 | 37.305 | 69.063 | 1.9 | 43.807 | 64.403 | 1.5 |
+| `histogram_bins` | 41.374 | 100.163 | 2.4 | 41.853 | 73.794 | 1.8 | 41.801 | 64.298 | 1.5 |
+| `prefix_scan` | 24.097 | 79.843 | 3.3 | 24.841 | 48.479 | 2.0 | 24.624 | 29.781 | 1.2 |
+| `binary_search` | 34.228 | 132.185 | 3.9 | 36.161 | 117.260 | 3.2 | 43.948 | 99.095 | 2.3 |
+| `sort_window` | 41.188 | 110.110 | 2.7 | 52.501 | 75.914 | 1.4 | 53.575 | 123.660 | 2.3 |
+| `bloom_filter` | 18.133 | 81.014 | 4.5 | 16.750 | 45.560 | 2.7 | 17.689 | 36.494 | 2.1 |
+| `hash_join` | 6.320 | 66.795 | 10.6 | 4.886 | 31.750 | 6.5 | 5.320 | 24.550 | 4.6 |
+| `sieve` | 43.446 | 99.869 | 2.3 | 42.302 | 68.849 | 1.6 | 37.415 | 61.224 | 1.6 |
+| `fib` | 34.440 | 102.493 | 3.0 | 33.702 | 65.008 | 1.9 | 30.222 | 64.897 | 2.1 |
+| `collatz` | 18.651 | 78.851 | 4.2 | 17.458 | 43.512 | 2.5 | 18.617 | 38.712 | 2.1 |
+| `matmul` | 35.631 | 89.686 | 2.5 | 35.353 | 60.555 | 1.7 | 35.041 | 55.030 | 1.6 |
+| `json_parse` | 11.850 | 88.650 | 7.5 | 8.871 | 39.651 | 4.5 | 14.477 | 40.095 | 2.8 |
+
+The floor row matters more here than in `RESULTS.md`. A wasm cell pays
+for the runtime compiling the whole module before `_start` runs, and a
+NURL module links the entire NURL runtime whatever the program does — so
+even the empty program is a ~1 MB module to JIT. Section 2 subtracts that
+floor from both ends to show the steady-state ratio.
+
+## 2. The same ratios, with start-up subtracted
+
+Cell minus the floor of its own column, wasm ÷ native. This is the
+number to quote for a long-running program, where module compilation is
+amortised to nothing; section 1 is the number to quote for a short one,
+where it is most of the run.
+
+A `—` means the subtraction has no signal left in it: the floor is more
+than half of that cell, so the remainder is a difference of two similar
+numbers carrying both their errors. That is not a rare edge case in the
+**NURL x** column — a 1 MB module's compilation is comparable to the
+benchmarks themselves, which is exactly why the `+gc` column beside it
+exists: the same NURL programs linked with `--gc-sections` (section 5)
+have a floor small enough to subtract cleanly, so they are where the
+steady-state throughput of NURL's wasm can actually be read.
+
+| Benchmark | NURL x | NURL +gc x | C x | Rust x |
+|---|---:|---:|---:|---:|
+| `lcg` | — | 1.3 | 1.8 | 1.0 |
+| `affine_mix` | — | 1.5 | 1.6 | 0.9 |
+| `packet_classifier` | — | 1.1 | 1.1 | 0.8 |
+| `ring_write` | — | 1.6 | 1.7 | 1.1 |
+| `histogram_bins` | — | 1.7 | 1.7 | 1.2 |
+| `prefix_scan` | — | 1.8 | 1.8 | — |
+| `binary_search` | 2.1 | 2.9 | 3.2 | 1.9 |
+| `sort_window` | — | 1.8 | 1.3 | 2.1 |
+| `bloom_filter` | — | 2.0 | 2.5 | 1.2 |
+| `hash_join` | — | 4.4 | 7.3 | — |
+| `sieve` | — | 1.3 | 1.5 | 1.2 |
+| `fib` | — | 1.9 | 1.8 | 1.7 |
+| `collatz` | — | 2.0 | 2.3 | 1.3 |
+| `matmul` | — | 1.5 | 1.6 | 1.1 |
+| `json_parse` | — | 3.6 | 4.4 | 1.8 |
+
+## 3. The pure-NURL runtime (`packages/wasmtime`)
+
+The identical modules from section 1, executed by an interpreter written
+in NURL instead of by a JIT written in Rust. `vs JIT` is the cost of the
+runtime; `vs native` is the end-to-end cost of choosing this way to ship.
+Losing orders of magnitude to a JIT is the shape an interpreter has; the
+point of the column is that the size of the gap is measured rather than
+assumed, per benchmark, so it can be aimed at.
+
+Read the floor row first, because it goes the other way: on a program
+that does nothing the interpreter *beats* the JIT. Nothing surprising is
+happening — the JIT compiles the whole module before `_start`, and the
+interpreter only decodes it and walks the handful of instructions that
+run. That crossover is the honest answer to "which runtime should I
+use": it depends entirely on how long the guest runs.
+
+| Benchmark | NURL on `wt` | vs JIT | vs native | C on `wt` | Rust on `wt` |
+|---|---:|---:|---:|---:|---:|
+| _(floor: empty program)_ | _45.100_ | _0.7_ | _27.1_ | _SKIPPED_ | _SKIPPED_ |
+| `lcg` | 2561.128 | 27.7 | 64.9 | SKIPPED | SKIPPED |
+| `affine_mix` | 5261.156 | 57.8 | 156.6 | SKIPPED | SKIPPED |
+| `packet_classifier` | 5645.706 | 50.7 | 89.4 | SKIPPED | SKIPPED |
+| `ring_write` | 7022.937 | 71.2 | 187.4 | SKIPPED | SKIPPED |
+| `histogram_bins` | 7289.204 | 72.8 | 176.2 | SKIPPED | SKIPPED |
+| `prefix_scan` | 2512.158 | 31.5 | 104.3 | SKIPPED | SKIPPED |
+| `binary_search` | 15085.611 | 114.1 | 440.7 | SKIPPED | SKIPPED |
+| `sort_window` | 40323.696 | 366.2 | 979.0 | SKIPPED | SKIPPED |
+| `bloom_filter` | 3820.273 | 47.2 | 210.7 | SKIPPED | SKIPPED |
+| `hash_join` | 3324.280 | 49.8 | 526.0 | SKIPPED | SKIPPED |
+| `sieve` | 5165.420 | 51.7 | 118.9 | SKIPPED | SKIPPED |
+| `fib` | 11474.997 | 112.0 | 333.2 | SKIPPED | SKIPPED |
+| `collatz` | 2662.316 | 33.8 | 142.7 | SKIPPED | SKIPPED |
+| `matmul` | 4240.486 | 47.3 | 119.0 | SKIPPED | SKIPPED |
+| `json_parse` | 29424.539 | 331.9 | 2483.1 | SKIPPED | SKIPPED |
+
+The C and Rust columns are `SKIPPED`: they are the cross-frontend
+control — modules this runtime never saw during development, from two
+other LLVM frontends — and running them costs about three times the
+whole rest of the suite, so they are opt-in. `--wt-all-langs` fills
+them in. Until it is run, this section says what the interpreter does
+with NURL output and nothing about whether it is tuned for it.
+
+## 4. Artefact size (KiB)
+
+A wasm module carries its own copy of everything it links — wasi-libc,
+the language runtime — where a native binary borrows the system one.
+These are the bytes that have to be shipped, and (for the two runtimes
+above) parsed before the program starts.
+
+| Benchmark | NURL native | NURL wasm | C native | C wasm | Rust native | Rust wasm |
+|---|---:|---:|---:|---:|---:|---:|
+| `lcg` | 16 | 1064 | 16 | 686 | 3743 | 1733 |
+| `affine_mix` | 16 | 1064 | 16 | 686 | 3743 | 1734 |
+| `packet_classifier` | 16 | 1064 | 16 | 686 | 3743 | 1734 |
+| `ring_write` | 16 | 1064 | 16 | 686 | 3743 | 1734 |
+| `histogram_bins` | 16 | 1064 | 16 | 686 | 3743 | 1734 |
+| `prefix_scan` | 16 | 1064 | 16 | 687 | 3743 | 1734 |
+| `binary_search` | 16 | 1064 | 16 | 687 | 3743 | 1735 |
+| `sort_window` | 16 | 1064 | 16 | 687 | 3743 | 1734 |
+| `bloom_filter` | 16 | 1064 | 16 | 687 | 3743 | 1734 |
+| `hash_join` | 20 | 1067 | 16 | 695 | 3743 | 1736 |
+| `sieve` | 16 | 1064 | 16 | 691 | 3742 | 1733 |
+| `fib` | 16 | 1063 | 16 | 686 | 3738 | 1733 |
+| `collatz` | 16 | 1064 | 16 | 686 | 3738 | 1733 |
+| `matmul` | 16 | 1064 | 16 | 691 | 3743 | 1734 |
+| `json_parse` | 34 | 1119 | 16 | 736 | 3757 | 1763 |
+
+## 5. Dead code — what `--gc-sections` costs and buys
+
+Every NURL module above was linked with `-Wl,--no-gc-sections`, the
+default `wasmbuilder` ships. NURL closures store **function-table indices**
+and section GC renumbers that table, so a closure captured before the
+collection can call the wrong function after it — a run-time
+`call_indirect` trap with no link error to warn anyone. The cost of that
+default is that most of the NURL runtime ships in, and is translated by
+the runtime, in every module that never calls it.
+
+These rows are the same benchmarks rebuilt with `--gc-sections`, run on
+the reference runtime, and held to the same output — none of them uses a
+closure, so the hazard does not apply and the saving is measurable.
+
+| Benchmark | Size | Size +gc | Δ | JIT | JIT +gc | Δ |
+|---|---:|---:|---:|---:|---:|---:|
+| _(floor: empty program)_ | _1063_ | _798_ | _−25 %_ | _62.536_ | _10.267_ | _−84 %_ |
+| `lcg` | 1064 | 819 | −23 % | 92.613 | 60.884 | −34 % |
+| `affine_mix` | 1064 | 819 | −23 % | 91.026 | 59.683 | −34 % |
+| `packet_classifier` | 1064 | 819 | −23 % | 111.411 | 79.172 | −29 % |
+| `ring_write` | 1064 | 819 | −23 % | 98.644 | 68.821 | −30 % |
+| `histogram_bins` | 1064 | 819 | −23 % | 100.163 | 77.872 | −22 % |
+| `prefix_scan` | 1064 | 820 | −23 % | 79.843 | 49.952 | −37 % |
+| `binary_search` | 1064 | 820 | −23 % | 132.185 | 104.771 | −21 % |
+| `sort_window` | 1064 | 820 | −23 % | 110.110 | 80.610 | −27 % |
+| `bloom_filter` | 1064 | 820 | −23 % | 81.014 | 42.536 | −47 % |
+| `hash_join` | 1067 | 821 | −23 % | 66.795 | 30.637 | −54 % |
+| `sieve` | 1064 | 819 | −23 % | 99.869 | 66.558 | −33 % |
+| `fib` | 1063 | 819 | −23 % | 102.493 | 71.491 | −30 % |
+| `collatz` | 1064 | 819 | −23 % | 78.851 | 44.133 | −44 % |
+| `matmul` | 1064 | 820 | −23 % | 89.686 | 60.514 | −33 % |
+| `json_parse` | 1119 | 849 | −24 % | 88.650 | 47.099 | −47 % |
+
+The saving is almost all fixed cost, so it is largest where the benchmark
+itself is smallest — compare each row against the floor. It is reported
+on the JIT and not on the interpreter because the interpreter is
+execution-bound, not decode-bound: its floor row in section 3 is a few
+tens of milliseconds against cells in the tens of *seconds*, so shrinking
+the module cannot move it. This is a real optimisation, and what stands
+between it and being the default is making closure function-table indices
+survive renumbering — not the linker flag.
+
+## 6. Compile time (median, ms)
+
+The NURL wasm build is `wasmbuilder`: `nurlc` emits host LLVM IR, the IR
+rewriter retargets it for `wasm32-wasi`, and the toolchain-bundled
+`zig cc` links it against wasi-libc and a cached `runtime.wasm.o`. The
+column is the whole pipeline, comparable to the NURL native total beside
+it and to the C and Rust wasm columns.
+
+| Benchmark | NURL `nurlc` | NURL native | NURL wasm | C native | C wasm | Rust native | Rust wasm |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| _(floor: empty program)_ | _3.968_ | _109.052_ | _1334.094_ | _81.312_ | _602.986_ | _156.370_ | _109.577_ |
+| `lcg` | 3.911 | 110.031 | 1362.946 | 95.402 | 951.330 | 183.458 | 123.338 |
+| `affine_mix` | 4.045 | 110.049 | 1305.744 | 86.817 | 938.474 | 168.551 | 121.083 |
+| `packet_classifier` | 3.792 | 109.116 | 1317.276 | 94.783 | 915.998 | 176.435 | 121.980 |
+| `ring_write` | 3.754 | 106.551 | 1286.930 | 89.003 | 940.199 | 171.690 | 113.975 |
+| `histogram_bins` | 4.750 | 117.854 | 1297.838 | 87.753 | 924.073 | 168.438 | 112.015 |
+| `prefix_scan` | 4.434 | 113.783 | 1293.032 | 87.699 | 921.444 | 166.301 | 111.517 |
+| `binary_search` | 3.848 | 111.293 | 1301.846 | 90.424 | 913.416 | 179.118 | 125.883 |
+| `sort_window` | 4.458 | 123.809 | 1379.428 | 92.877 | 944.488 | 176.587 | 131.672 |
+| `bloom_filter` | 5.249 | 118.834 | 1296.963 | 96.674 | 916.469 | 178.571 | 119.138 |
+| `hash_join` | 9.265 | 246.170 | 1307.893 | 141.155 | 967.105 | 232.732 | 177.676 |
+| `sieve` | 5.235 | 119.781 | 1358.393 | 94.151 | 938.741 | 186.617 | 131.672 |
+| `fib` | 3.771 | 111.500 | 1337.662 | 87.876 | 938.591 | 171.183 | 114.812 |
+| `collatz` | 4.219 | 107.542 | 1326.105 | 89.276 | 929.486 | 170.377 | 123.266 |
+| `matmul` | 5.588 | 123.111 | 1337.730 | 99.820 | 950.490 | 213.000 | 153.248 |
+| `json_parse` | 85.653 | 849.593 | 1560.415 | 141.863 | 1102.307 | 322.235 | 235.882 |
+
+## 7. Correctness gate
+
+Each row is timed only when all ten cells print the same line as the
+native NURL binary. The interpreter is inside the gate, not beside it:
+a runtime that gets the wrong answer quickly is not a fast runtime.
+
+| Benchmark | Output | Verdict |
+|---|---|---|
+| `lcg` | `-7585129161289236796` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `affine_mix` | `227901546981696845` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `packet_classifier` | `4205972061` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `ring_write` | `8299504528805184357` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `histogram_bins` | `1215643728` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `prefix_scan` | `492982549` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `binary_search` | `805907445` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `sort_window` | `2815490238` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `bloom_filter` | `2351703` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `hash_join` | `2814341850483607168` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `sieve` | `664579` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `fib` | `9227465` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `collatz` | `350` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `matmul` | `393199` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `json_parse` | `20` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+
+## 8. Reading the numbers
+
+* Sections 1 and 3 are whole-process wall clock, so a cell near its
+  column's floor is mostly start-up — and on wasm, start-up includes the
+  runtime ingesting the module. Section 2 is where the steady-state
+  throughput ratio lives.
+* Every cell in a row computes the same thing, but not necessarily with
+  the same machine code. LLVM optimises for wasm and for x86-64
+  differently: wasm has no flags register, no `cmov`, and a JIT compiling
+  at load time cannot spend the time an offline `-O2` does. A ratio above
+  1 is that difference, not lost work.
+* The three languages share a corpus but not a runtime. A NURL module
+  carries NURL's allocator and string machinery; a Rust module carries
+  Rust's; a C module carries almost nothing. Section 4 is that difference
+  in bytes, and part of the floor row is the same difference in time.
+* The reference runtime's compiled-module cache is off. Its CLI enables
+  that cache by default, which would make a cell mean "Cranelift ran" or
+  "Cranelift did not run" depending on what happened to be in
+  `~/.cache/wasmtime` — including across the floor row, whose whole job is
+  to be subtracted from the others. Off, both runtimes are measured doing
+  the same work: read the module, translate it, run it. A deployment that
+  keeps the cache (or precompiles with `wasmtime compile`) pays the floor
+  once instead of every run — section 2 is the number that survives that.
+* `json_parse` reads `bench/data.json`, so every wasm run gets a `--dir .`
+  preopen. The other rows pay the same preopen cost and need nothing from
+  it, which keeps the column internally comparable.
+* Wall clock on a machine that was not quiesced drifts a few per cent
+  between runs, and more on a shared CI runner. Compare deltas between
+  runs of the same workflow, not absolutes across machines.

--- a/bench/bench.ps1
+++ b/bench/bench.ps1
@@ -1,0 +1,787 @@
+#!/usr/bin/env pwsh
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Dual-licensed under MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE) at your option.
+# ============================================================
+#  bench/bench.ps1 — the Windows benchmark runner. Faithful port
+#  of bench/bench.sh: same corpus, same manifest, same protocol,
+#  same two artefacts.
+#
+#  Every benchmark in bench/manifest.tsv is implemented five times —
+#  NURL, C, Rust, Node, Python — and every implementation prints one
+#  line. This script compiles what needs compiling, gates the row on all
+#  five printing the *same* line, then times them and writes two
+#  artefacts:
+#
+#    bench/results/latest-windows.json   machine-readable, schema 1 —
+#                                        the same shape the landing
+#                                        page's table generator reads
+#    bench/RESULTS-WINDOWS.md            the same run rendered for
+#                                        humans, with the compile-time
+#                                        and correctness tables
+#
+#  Usage:
+#      pwsh bench\bench.ps1                    # full suite, write both files
+#      pwsh bench\bench.ps1 -Quick             # 1 rep/cell, for a smoke test
+#      pwsh bench\bench.ps1 -Bench lcg,sieve
+#      pwsh bench\bench.ps1 -Reps 9 -BudgetMs 20000
+#      pwsh bench\bench.ps1 -Stdout            # print the report, touch nothing
+#
+#  Requires build\nurlc.exe + stdlib\runtime.o (build.bat), clang, rustc,
+#  node and python. A missing toolchain is a hard error: a table with a
+#  hole in it is worse than no table, because the hole is invisible once
+#  the numbers are copied out.
+#
+#  ── Deliberate deviations from bench.sh, and why ────────────────
+#
+#  * SEPARATE OUTPUT FILES. bench.sh writes results/latest.json and
+#    RESULTS.md, and the landing page's table is generated from the
+#    former at publish time. Those are the *Linux CI* numbers. A local
+#    Windows run must not overwrite them, or a careless commit ships
+#    Windows timings as the project's published table — so this script
+#    defaults to `-windows` variants. Pass -Json/-Md to override.
+#
+#  * NO -flto ON THE NURL LINK. bench.sh links NURL with
+#    `clang -O2 -flto` because build.sh compiles stdlib/runtime.o to
+#    LLVM bitcode. build.bat does NOT (see compiler/tests/run_tests.ps1,
+#    which links the same way for the same reason), so runtime.o here is
+#    a real object file and cross-module inlining into it is not
+#    available. This is the link line a real `nurl.bat` build uses, byte
+#    for byte, which is the property that matters — but it does mean the
+#    NURL column is not directly comparable to a Linux run's.
+#
+#  * NO -lm / -lpthread, YES -lwinhttp. The MSVC CRT folds libm in, has
+#    no separate pthread, and every NURL binary links the whole of
+#    runtime.o — including its WinHTTP bridge. Same set as nurl.bat.
+#    Feature libs build.bat detected (vcpkg zlib/zstd) come from
+#    stdlib\runtime.winlibs, parsed exactly as run_tests.ps1 parses it.
+#
+#  * OUTPUT COMPARISON NORMALISES LINE ENDINGS. C's and Python's stdio
+#    are in text mode on Windows and emit CRLF; the NURL runtime and
+#    Node emit LF. Comparing raw bytes would fail all fifteen rows for a
+#    reason that has nothing to do with the benchmark.
+#
+#  * PYTHON IS RESOLVED TO A REAL INTERPRETER PATH. `python3` usually
+#    does not exist on Windows and `python` is often the App Execution
+#    Alias stub. This script resolves through `py -3` to sys.executable
+#    and times THAT, so the py-launcher's own dispatch cost does not
+#    land in the Python column's floor.
+#
+#  Exit code: 0 iff every row passed the correctness gate, 1 otherwise.
+# ============================================================
+[CmdletBinding()]
+param(
+    # Time only these benchmarks (manifest names), instead of the whole roster.
+    [string[]]$Bench,
+    # Timed runs per cell, at most.
+    [int]$Reps = 5,
+    # Per-cell time budget in ms; a slow cell gets fewer reps.
+    [int]$BudgetMs = 8000,
+    # Per-run wall-clock cap, seconds.
+    [int]$TimeoutS = 300,
+    # Timed compiles per compiled language (median of).
+    [int]$CompileReps = 3,
+    [string]$Json,
+    [string]$Md,
+    # Print the Markdown report to stdout and write nothing.
+    [switch]$Stdout,
+    # 1 rep/cell, 1 compile/cell — a smoke test of the harness itself.
+    [switch]$Quick
+)
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Root      = (Resolve-Path (Join-Path $ScriptDir '..')).Path
+$BenchDir  = Join-Path $Root 'bench'
+$BuildDir  = Join-Path $BenchDir '_build'
+$Manifest  = Join-Path $BenchDir 'manifest.tsv'
+
+# ── settings ─────────────────────────────────────────────────────
+$MaxReps = $Reps
+$Opt     = '-O2'
+if ($Quick) { $MaxReps = 1; $BudgetMs = 1; $CompileReps = 1 }
+if (-not $Json) { $Json = Join-Path $BenchDir 'results\latest-windows.json' }
+if (-not $Md)   { $Md   = Join-Path $BenchDir 'RESULTS-WINDOWS.md' }
+
+# nurlc resolves `$ "stdlib/..."` imports relative to its working
+# directory, so every compile and every run happens from $Root.
+Set-Location $Root
+New-Item -ItemType Directory -Force -Path $BuildDir | Out-Null
+
+$Utf8NoBom = New-Object System.Text.UTF8Encoding $false
+
+# ── toolchain detection ──────────────────────────────────────────
+$Nurlc   = Join-Path $Root 'build\nurlc.exe'
+$Runtime = Join-Path $Root 'stdlib\runtime.o'
+
+# Resolve a command to an absolute executable path: PATH first, then the
+# extra directories a Windows install might hide it in. Returns $null when
+# nothing runnable was found.
+function Resolve-Exe([string]$name, [string[]]$candidates = @()) {
+    $c = Get-Command $name -CommandType Application -ErrorAction SilentlyContinue |
+         Select-Object -First 1
+    if ($c) { return $c.Source }
+    foreach ($p in $candidates) { if ($p -and (Test-Path -LiteralPath $p)) { return (Resolve-Path -LiteralPath $p).Path } }
+    return $null
+}
+
+# `python` on PATH is very often the Microsoft Store App Execution Alias:
+# a 0-byte reparse point that prints an ad and exits non-zero. Only accept
+# an interpreter that actually reports its own executable.
+function Test-Python([string]$exe) {
+    if (-not $exe) { return $null }
+    try {
+        $out = & $exe -c 'import sys; sys.stdout.write(sys.executable)' 2>$null
+        if ($LASTEXITCODE -eq 0 -and $out -and (Test-Path -LiteralPath $out)) {
+            return (Resolve-Path -LiteralPath $out).Path
+        }
+    } catch {}
+    return $null
+}
+function Resolve-Python {
+    if ($env:NURL_BENCH_PYTHON) {
+        $r = Test-Python $env:NURL_BENCH_PYTHON
+        if ($r) { return $r }
+    }
+    foreach ($n in 'python3', 'python') {
+        $r = Test-Python (Resolve-Exe $n)
+        if ($r) { return $r }
+    }
+    # The py launcher knows about every registered install; ask it for the
+    # real interpreter path and time that directly, not the launcher.
+    $py = Resolve-Exe 'py' @('C:\Windows\py.exe')
+    if ($py) {
+        try {
+            $out = & $py -3 -c 'import sys; sys.stdout.write(sys.executable)' 2>$null
+            if ($LASTEXITCODE -eq 0 -and $out -and (Test-Path -LiteralPath $out)) {
+                return (Resolve-Path -LiteralPath $out).Path
+            }
+        } catch {}
+    }
+    return $null
+}
+
+$Clang  = Resolve-Exe ($env:CLANG ? $env:CLANG : 'clang') @(
+              $env:CLANG,
+              "$env:ProgramFiles\LLVM\bin\clang.exe",
+              "${env:ProgramFiles(x86)}\LLVM\bin\clang.exe")
+$Rustc  = Resolve-Exe 'rustc' @("$env:USERPROFILE\.cargo\bin\rustc.exe")
+$Node   = Resolve-Exe 'node'  @("$env:ProgramFiles\nodejs\node.exe")
+$Python = Resolve-Python
+
+function First-Line([string]$s) {
+    if (-not $s) { return '' }
+    return (($s -replace "`r`n", "`n") -split "`n")[0].Trim()
+}
+# First line of `<exe> --version`, or $null when the thing cannot actually
+# run. Existing on disk is not enough: `rustc.exe` in ~\.cargo\bin is a
+# rustup SHIM, and a fresh `winget install Rustlang.Rustup` leaves it with
+# no default toolchain — it resolves fine, then fails every compile. Caught
+# here it is one line of diagnosis; caught later it is fifteen MISMATCH rows.
+function Get-ToolVersion([string]$exe) {
+    if (-not $exe) { return $null }
+    try {
+        $v = First-Line (& $exe --version 2>&1 | Out-String)
+        if ($LASTEXITCODE -eq 0 -and $v) { return $v }
+    } catch {}
+    return $null
+}
+
+$ClangVersion  = Get-ToolVersion $Clang
+$RustcVersion  = Get-ToolVersion $Rustc
+$NodeVersion   = Get-ToolVersion $Node
+$PythonVersion = Get-ToolVersion $Python
+
+$missing = @()
+if (-not (Test-Path -LiteralPath $Nurlc) -or -not (Test-Path -LiteralPath $Runtime)) {
+    $missing += 'nurlc + stdlib\runtime.o (run build.bat)'
+}
+if     (-not $Clang)        { $missing += 'clang (install LLVM, or set CLANG=<path>)' }
+elseif (-not $ClangVersion) { $missing += "clang at $Clang does not run" }
+if     (-not $Rustc)        { $missing += 'rustc (install Rust: winget install Rustlang.Rustup)' }
+elseif (-not $RustcVersion) { $missing += "rustc at $Rustc does not run (a rustup shim with no toolchain? run: rustup default stable)" }
+if     (-not $Node)         { $missing += 'node' }
+elseif (-not $NodeVersion)  { $missing += "node at $Node does not run" }
+if     (-not $Python)       { $missing += 'python (set NURL_BENCH_PYTHON=<path> to override)' }
+if ($missing.Count -gt 0) {
+    Write-Host "bench.ps1: missing toolchain: $($missing -join ', ')" -ForegroundColor Red
+    exit 1
+}
+
+# Feature libs build.bat detected (vcpkg zlib/zstd → stdlib\runtime.winlibs),
+# so a NURL benchmark importing stdlib\ext\compress.nu links the way
+# nurl.bat links it. Parsed into clean argv tokens — -L<dir> with quotes
+# stripped (ArgumentList re-quotes if it has spaces) and -l<name> — exactly
+# as compiler/tests/run_tests.ps1 does. This is the Windows counterpart of
+# bench.sh's pkg-config EXTRA_LIBS block.
+$WinLibs = @()
+$winFile = Join-Path $Root 'stdlib\runtime.winlibs'
+if (Test-Path -LiteralPath $winFile) {
+    $winRaw = [System.IO.File]::ReadAllText($winFile)
+    foreach ($m in [regex]::Matches($winRaw, '-L"([^"]*)"|-L(\S+)|-l(\S+)')) {
+        if     ($m.Groups[1].Success) { $WinLibs += ('-L' + $m.Groups[1].Value) }
+        elseif ($m.Groups[2].Success) { $WinLibs += ('-L' + $m.Groups[2].Value) }
+        else                          { $WinLibs += ('-l' + $m.Groups[3].Value) }
+    }
+}
+# Every NURL binary links the whole of runtime.o, including its WinHTTP
+# bridge; the socket/bcrypt/advapi32 imports arrive on their own via the
+# `#pragma comment(lib, ...)` directives in runtime_ffi.c under clang's
+# MSVC target. Same set, same reason, as run_tests.ps1.
+$NurlLinkLibs = @('-lwinhttp') + $WinLibs
+
+$NurlVersion = Get-ToolVersion $Nurlc
+if (-not $NurlVersion) {
+    $NurlVersion = First-Line (& git -C $Root describe --tags --always --dirty 2>$null | Out-String)
+}
+
+# `uname -srm` has no Windows equivalent; assemble the same three facts.
+$Arch       = if ($env:PROCESSOR_ARCHITECTURE) { $env:PROCESSOR_ARCHITECTURE } else { 'AMD64' }
+$HostKernel = "Windows $([System.Environment]::OSVersion.Version) $Arch"
+$HostCpu    = $Arch
+$HostCores  = [Environment]::ProcessorCount
+$HostMemKb  = 0
+try {
+    $cpu = Get-CimInstance Win32_Processor -ErrorAction Stop | Select-Object -First 1
+    if ($cpu.Name) { $HostCpu = $cpu.Name.Trim() }
+    if ($cpu.NumberOfLogicalProcessors) { $HostCores = [int]$cpu.NumberOfLogicalProcessors }
+    $cs = Get-CimInstance Win32_ComputerSystem -ErrorAction Stop
+    if ($cs.TotalPhysicalMemory) { $HostMemKb = [int64]($cs.TotalPhysicalMemory / 1024) }
+    $os = Get-CimInstance Win32_OperatingSystem -ErrorAction Stop
+    if ($os.Caption) { $HostKernel = "$($os.Caption.Trim()) $($os.Version) $Arch" }
+} catch {}
+$HostLabel = if ($env:BENCH_HOST_LABEL) { $env:BENCH_HOST_LABEL } else { "Windows $Arch" }
+$Commit    = First-Line (& git -C $Root rev-parse HEAD 2>$null | Out-String)
+if (-not $Commit) { $Commit = 'unknown' }
+$RunUrl    = if ($env:BENCH_RUN_URL) { $env:BENCH_RUN_URL } else { '' }
+
+# ── timing helpers ───────────────────────────────────────────────
+# One wall-clock reading in milliseconds, three decimals, measured with
+# Stopwatch (QueryPerformanceCounter) around exactly the child process —
+# no shell fork, no `timeout` wrapper, unlike the bash version which has
+# to subtract its own overhead from $EPOCHREALTIME readings.
+#
+# stdout/stderr are redirected and read asynchronously: a benchmark that
+# writes more than the pipe buffer would otherwise deadlock. Pass
+# -StdoutFile to keep stdout instead of discarding it — nurlc writes its
+# LLVM IR there, so the compile stage has to keep it while still being
+# timed, and the write to disk is part of what bench.sh measures too.
+#
+# Returns 'TIMEOUT' when the cap is hit and 'FAIL' on a non-zero exit.
+function Measure-Proc {
+    param(
+        [string]$Exe,
+        [string[]]$Arguments = @(),
+        [string]$StdoutFile,
+        [switch]$PassThru        # also return the captured stdout
+    )
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $Exe
+    foreach ($a in $Arguments) { [void]$psi.ArgumentList.Add($a) }
+    $psi.WorkingDirectory       = $Root
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute        = $false
+    $psi.CreateNoWindow         = $true
+    # Windows auto-flags exes whose name contains "install"/"setup"/etc. as
+    # requiring UAC elevation (installer-detection heuristic), which makes
+    # Process.Start throw. RunAsInvoker suppresses it — same guard as
+    # run_tests.ps1, cheap insurance for a future benchmark name.
+    $psi.Environment['__COMPAT_LAYER'] = 'RunAsInvoker'
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try { $proc = [System.Diagnostics.Process]::Start($psi) }
+    catch { return @{ Ms = 'FAIL'; Out = '' } }
+    $o = $proc.StandardOutput.ReadToEndAsync()
+    $e = $proc.StandardError.ReadToEndAsync()
+    if (-not $proc.WaitForExit($TimeoutS * 1000)) {
+        try { $proc.Kill($true) } catch {}
+        try { $proc.WaitForExit() } catch {}
+        return @{ Ms = 'TIMEOUT'; Out = '' }
+    }
+    # STOP THE CLOCK HERE, on process exit — before draining the readers and
+    # before touching the disk. WaitForExit(ms) returning true means the child
+    # is gone; the argless overload below additionally waits for the async
+    # readers, and the StdoutFile write is this script's bookkeeping, not the
+    # child's cost. bench.sh has the child write to its own redirected fd and
+    # measures only the process, so this is where the two agree.
+    $sw.Stop()
+    $ms = $sw.Elapsed.TotalMilliseconds
+    $proc.WaitForExit()
+    $code = $proc.ExitCode
+    $out  = $o.Result
+    [void]$e.Result
+    if ($StdoutFile) { [System.IO.File]::WriteAllText($StdoutFile, $out, $Utf8NoBom) }
+    if ($code -ne 0) { return @{ Ms = 'FAIL'; Out = $out } }
+    $r = @{ Ms = ('{0:F3}' -f $ms); Out = '' }
+    if ($PassThru -or $StdoutFile) { $r.Out = $out }
+    return $r
+}
+
+function Time-Ms([string]$Exe, [string[]]$Arguments = @(), [string]$StdoutFile) {
+    return (Measure-Proc -Exe $Exe -Arguments $Arguments -StdoutFile $StdoutFile).Ms
+}
+
+function Median([string[]]$values) {
+    foreach ($v in $values) {
+        if ($v -eq 'FAIL')    { return 'FAIL' }
+        if ($v -eq 'TIMEOUT') { return 'TIMEOUT' }
+    }
+    if ($values.Count -eq 0) { return 'FAIL' }
+    $n = @($values | ForEach-Object { [double]$_ } | Sort-Object)
+    $c = $n.Count
+    $m = if ($c % 2) { $n[[int](($c - 1) / 2)] } else { ($n[$c / 2 - 1] + $n[$c / 2]) / 2 }
+    return ('{0:F3}' -f $m)
+}
+
+# Time a cell adaptively: one run first, then as many more as fit in
+# BudgetMs, capped at MaxReps. A 6 ms cell gets the full 5 runs for 30 ms;
+# a 25-second Python cell gets one, because a second run buys noise
+# reduction the reader cannot use and costs another 25 seconds.
+# Returns @{ Ms = <median or FAIL/TIMEOUT>; Reps = <n> }.
+function Time-Cell([string]$Exe, [string[]]$Arguments = @()) {
+    $first = Time-Ms $Exe $Arguments
+    if ($first -eq 'FAIL' -or $first -eq 'TIMEOUT') { return @{ Ms = $first; Reps = 1 } }
+    $runs = @($first)
+    $f = [double]$first
+    $n = if ($f -gt 0) { [int][Math]::Floor($BudgetMs / $f) } else { $MaxReps }
+    if ($n -lt 1)        { $n = 1 }
+    if ($n -gt $MaxReps) { $n = $MaxReps }
+    while ($runs.Count -lt $n) {
+        $r = Time-Ms $Exe $Arguments
+        if ($r -eq 'FAIL' -or $r -eq 'TIMEOUT') { return @{ Ms = $r; Reps = $runs.Count } }
+        $runs += $r
+    }
+    return @{ Ms = (Median $runs); Reps = $runs.Count }
+}
+
+# ── compile helpers ──────────────────────────────────────────────
+# <src.nu> <outbase> → @{ Frontend = <ms>; Total = <ms> }, or FAIL in both.
+function Compile-Nurl([string]$src, [string]$outbase) {
+    $ll  = "$outbase.ll"
+    $bin = "$outbase.nurl.exe"
+    $fe = @(); $tot = @()
+    for ($r = 0; $r -lt $CompileReps; $r++) {
+        $f = Time-Ms $Nurlc @($src) -StdoutFile $ll
+        if ($f -eq 'FAIL' -or $f -eq 'TIMEOUT') { return @{ Frontend = 'FAIL'; Total = 'FAIL' } }
+        $l = Time-Ms $Clang (@($Opt, $ll, $Runtime) + $NurlLinkLibs + @('-o', $bin))
+        if ($l -eq 'FAIL' -or $l -eq 'TIMEOUT') { return @{ Frontend = 'FAIL'; Total = 'FAIL' } }
+        $fe  += $f
+        $tot += ('{0:F3}' -f ([double]$f + [double]$l))
+    }
+    return @{ Frontend = (Median $fe); Total = (Median $tot) }
+}
+
+# `-lm` is deliberately absent: no benchmark includes <math.h> and the
+# MSVC CRT folds libm in anyway, so naming it only makes lld-link hunt
+# for a nonexistent m.lib.
+function Compile-C([string]$src, [string]$outbase) {
+    $bin = "$outbase.c.exe"
+    $out = @()
+    for ($r = 0; $r -lt $CompileReps; $r++) {
+        $t = Time-Ms $Clang @($Opt, $src, '-o', $bin)
+        if ($t -eq 'FAIL' -or $t -eq 'TIMEOUT') { return 'FAIL' }
+        $out += $t
+    }
+    return (Median $out)
+}
+
+function Compile-Rust([string]$src, [string]$outbase) {
+    $bin = "$outbase.rs.exe"
+    $out = @()
+    for ($r = 0; $r -lt $CompileReps; $r++) {
+        $t = Time-Ms $Rustc @('-C', 'opt-level=2', $src, '-o', $bin)
+        if ($t -eq 'FAIL' -or $t -eq 'TIMEOUT') { return 'FAIL' }
+        $out += $t
+    }
+    return (Median $out)
+}
+
+# ── roster ───────────────────────────────────────────────────────
+# `pwsh bench\bench.ps1 -Bench lcg,sieve` is -File invocation, and -File
+# hands every argument over as a literal string — so the comma list arrives
+# as ONE element, not three, and every name silently fails to match. Split
+# it here so the documented spelling works from pwsh, cmd and a PowerShell
+# prompt alike; `-Bench lcg,sieve` dot-sourced still binds as a real array
+# and splitting it is a no-op.
+if ($Bench) {
+    $Bench = @($Bench | ForEach-Object { $_ -split '[,;\s]+' } | Where-Object { $_ })
+}
+
+$names = @(); $blurbs = @(); $shapes = @()
+foreach ($line in [System.IO.File]::ReadAllLines($Manifest)) {
+    if (-not $line -or $line.StartsWith('#')) { continue }
+    $cols = $line -split "`t"
+    if ($cols.Count -lt 3) { continue }
+    $n = $cols[0].Trim()
+    if (-not $n) { continue }
+    if ($Bench -and ($Bench -notcontains $n)) { continue }
+    $names  += $n
+    $blurbs += $cols[1]
+    $shapes += $cols[2]
+}
+if ($names.Count -eq 0) {
+    Write-Host 'bench.ps1: no benchmarks selected' -ForegroundColor Red
+    exit 2
+}
+
+# json_parse reads a generated fixture; make sure it exists before the
+# gate runs, or four languages fail identically and the row looks fine.
+if (-not (Test-Path -LiteralPath (Join-Path $BenchDir 'data.json'))) {
+    & $Python (Join-Path $BenchDir 'gen_data.py') | Out-Null
+}
+
+# ── process-start-up floor ───────────────────────────────────────
+# What each language costs for a program that does nothing. Subtract it
+# from a cell to see the marginal cost of the benchmark itself; a row
+# under ~10 ms is mostly this.
+$floorDir = Join-Path $BuildDir 'floor'
+New-Item -ItemType Directory -Force -Path $floorDir | Out-Null
+# LF, no BOM: nurlc reads UTF-8 and the `→` in the signature must survive.
+[System.IO.File]::WriteAllText((Join-Path $floorDir 'floor.nu'), "@ main → i {`n    ^ 0`n}`n", $Utf8NoBom)
+[System.IO.File]::WriteAllText((Join-Path $floorDir 'floor.c'),  "int main(void) { return 0; }`n", $Utf8NoBom)
+[System.IO.File]::WriteAllText((Join-Path $floorDir 'floor.rs'), "fn main() {}`n", $Utf8NoBom)
+[System.IO.File]::WriteAllText((Join-Path $floorDir 'floor.py'), '', $Utf8NoBom)
+[System.IO.File]::WriteAllText((Join-Path $floorDir 'floor.js'), '', $Utf8NoBom)
+
+Write-Host "bench.ps1: $($names.Count) benchmark(s), up to $MaxReps rep(s)/cell within $BudgetMs ms, $CompileReps compile(s)/cell"
+Write-Host '  measuring the process-start-up floor…'
+
+# The same compile path the benchmarks take, so the compile-time table
+# has a floor to subtract too: for NURL that floor is the link against
+# stdlib\runtime.o, which every NURL binary pays whatever it does.
+$fbase       = Join-Path $floorDir 'floor'
+$ccFloorNurl = Compile-Nurl (Join-Path $floorDir 'floor.nu') $fbase
+$ccFloorC    = Compile-C    (Join-Path $floorDir 'floor.c')  $fbase
+$ccFloorRust = Compile-Rust (Join-Path $floorDir 'floor.rs') $fbase
+
+$floorNurl   = (Time-Cell "$fbase.nurl.exe").Ms
+$floorC      = (Time-Cell "$fbase.c.exe").Ms
+$floorRust   = (Time-Cell "$fbase.rs.exe").Ms
+$floorNode   = (Time-Cell $Node   @((Join-Path $floorDir 'floor.js'))).Ms
+$floorPython = (Time-Cell $Python @((Join-Path $floorDir 'floor.py'))).Ms
+
+# ── measure ──────────────────────────────────────────────────────
+# Per-benchmark results, collected as parallel arrays in manifest order —
+# which is the order the report needs them in anyway.
+$rows = @()
+
+function Progress-Line([string]$b, [string]$msg) {
+    Write-Host ("`r`e[K  {0,-18} {1}" -f $b, $msg) -NoNewline
+}
+# Whole-process stdout of one implementation, normalised for comparison.
+# C and Python run their stdio in text mode on Windows and emit CRLF; the
+# NURL runtime and Node emit LF. Trailing newlines go too, matching what
+# bash's $(...) does to the outputs bench.sh compares.
+function Run-Output([string]$Exe, [string[]]$Arguments = @()) {
+    $r = Measure-Proc -Exe $Exe -Arguments $Arguments -PassThru
+    if ($r.Ms -eq 'FAIL' -or $r.Ms -eq 'TIMEOUT') { return '' }
+    return (($r.Out -replace "`r`n", "`n" -replace "`r", "`n").TrimEnd("`n"))
+}
+
+foreach ($i in 0..($names.Count - 1)) {
+    $b    = $names[$i]
+    $base = Join-Path $BuildDir $b
+
+    Progress-Line $b 'compiling…'
+    $ccNurl = Compile-Nurl (Join-Path $BenchDir "$b.nu") $base
+    $ccC    = Compile-C    (Join-Path $BenchDir "$b.c")  $base
+    $ccRust = Compile-Rust (Join-Path $BenchDir "$b.rs") $base
+
+    Progress-Line $b 'verifying…'
+    $outNurl   = Run-Output "$base.nurl.exe"
+    $outC      = Run-Output "$base.c.exe"
+    $outRust   = Run-Output "$base.rs.exe"
+    $outNode   = Run-Output $Node   @((Join-Path $BenchDir "$b.js"))
+    $outPython = Run-Output $Python @((Join-Path $BenchDir "$b.py"))
+
+    $verified = $true
+    $details  = @()
+    foreach ($pair in @(@('NURL', $outNurl), @('C', $outC), @('Rust', $outRust),
+                        @('Node', $outNode), @('Python', $outPython))) {
+        $lang = $pair[0]; $got = $pair[1]
+        if ($got -cne $outNurl) { $verified = $false }
+        if (-not $got)          { $verified = $false }
+        $details += "$lang=$(if ($got) { $got } else { '<empty>' })"
+    }
+    $detail = $details -join ', '
+
+    $row = [ordered]@{
+        name = $b; blurb = $blurbs[$i]; measures = $shapes[$i]
+        checksum = $outNurl; verified = $verified; detail = $detail
+        cc_nurl_fe = $ccNurl.Frontend; cc_nurl = $ccNurl.Total; cc_c = $ccC; cc_rust = $ccRust
+    }
+
+    if (-not $verified) {
+        Write-Host ("`r`e[K  {0,-18} MISMATCH — {1}" -f $b, $detail) -ForegroundColor Yellow
+        foreach ($k in 'nurl', 'c', 'rust', 'node', 'python') {
+            $row["ms_$k"] = 'SKIPPED'; $row["reps_$k"] = 0
+        }
+        $rows += $row
+        continue
+    }
+
+    Progress-Line $b 'timing NURL…';   $t = Time-Cell "$base.nurl.exe"
+    $row.ms_nurl = $t.Ms;   $row.reps_nurl = $t.Reps
+    Progress-Line $b 'timing C…';      $t = Time-Cell "$base.c.exe"
+    $row.ms_c = $t.Ms;      $row.reps_c = $t.Reps
+    Progress-Line $b 'timing Rust…';   $t = Time-Cell "$base.rs.exe"
+    $row.ms_rust = $t.Ms;   $row.reps_rust = $t.Reps
+    Progress-Line $b 'timing Node…';   $t = Time-Cell $Node   @((Join-Path $BenchDir "$b.js"))
+    $row.ms_node = $t.Ms;   $row.reps_node = $t.Reps
+    Progress-Line $b 'timing Python…'; $t = Time-Cell $Python @((Join-Path $BenchDir "$b.py"))
+    $row.ms_python = $t.Ms; $row.reps_python = $t.Reps
+
+    Write-Host ("`r`e[K  {0,-18} nurl {1,9}  c {2,9}  rust {3,9}  node {4,9}  python {5,9}" -f `
+        $b, $row.ms_nurl, $row.ms_c, $row.ms_rust, $row.ms_node, $row.ms_python)
+    $rows += $row
+}
+Write-Host "`r`e[K" -NoNewline
+
+# ── emit ─────────────────────────────────────────────────────────
+$Now = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
+
+function JStr([string]$s) {
+    if ($null -eq $s) { return '' }
+    return ($s -replace '\\', '\\\\' -replace '"', '\"')
+}
+# A cell that is FAIL/TIMEOUT/SKIPPED becomes JSON null, not a string —
+# schema 1 says these fields are numbers.
+function JNum($v) {
+    $s = [string]$v
+    if ($s -match '^[0-9.]+$') { return $s }
+    return 'null'
+}
+
+function Emit-Json {
+    $sb = [System.Text.StringBuilder]::new()
+    $w  = { param($t) [void]$sb.Append($t); [void]$sb.Append("`n") }
+    & $w '{'
+    & $w '  "schema": 1,'
+    & $w "  ""generated_utc"": ""$(JStr $Now)"","
+    & $w "  ""commit"": ""$(JStr $Commit)"","
+    & $w "  ""run_url"": ""$(JStr $RunUrl)"","
+    & $w '  "host": {'
+    & $w "    ""label"": ""$(JStr $HostLabel)"","
+    & $w "    ""kernel"": ""$(JStr $HostKernel)"","
+    & $w "    ""cpu"": ""$(JStr $HostCpu)"","
+    & $w "    ""cores"": $(JNum $HostCores),"
+    & $w "    ""mem_kb"": $(JNum $HostMemKb)"
+    & $w '  },'
+    & $w '  "toolchains": {'
+    & $w "    ""nurl"": ""$(JStr $NurlVersion)"","
+    & $w "    ""c"": ""$(JStr $ClangVersion)"","
+    & $w "    ""rust"": ""$(JStr $RustcVersion)"","
+    & $w "    ""node"": ""$(JStr $NodeVersion)"","
+    & $w "    ""python"": ""$(JStr $PythonVersion)"""
+    & $w '  },'
+    & $w '  "settings": {'
+    & $w "    ""opt"": ""$(JStr $Opt)"","
+    & $w "    ""max_reps"": $MaxReps,"
+    & $w "    ""budget_ms"": $BudgetMs,"
+    & $w "    ""timeout_s"": $TimeoutS,"
+    & $w "    ""compile_reps"": $CompileReps"
+    & $w '  },'
+    & $w ("  ""floor_ms"": {{ ""nurl"": {0}, ""c"": {1}, ""rust"": {2}, ""node"": {3}, ""python"": {4} }}," -f `
+        (JNum $floorNurl), (JNum $floorC), (JNum $floorRust), (JNum $floorNode), (JNum $floorPython))
+    & $w ("  ""floor_compile_ms"": {{ ""nurl_frontend"": {0}, ""nurl"": {1}, ""c"": {2}, ""rust"": {3} }}," -f `
+        (JNum $ccFloorNurl.Frontend), (JNum $ccFloorNurl.Total), (JNum $ccFloorC), (JNum $ccFloorRust))
+    & $w '  "benchmarks": ['
+    for ($i = 0; $i -lt $rows.Count; $i++) {
+        $r = $rows[$i]
+        & $w '    {'
+        & $w "      ""name"": ""$(JStr $r.name)"","
+        & $w "      ""blurb"": ""$(JStr $r.blurb)"","
+        & $w "      ""measures"": ""$(JStr $r.measures)"","
+        & $w "      ""checksum"": ""$(JStr $r.checksum)"","
+        & $w "      ""verified"": $(if ($r.verified) { 'true' } else { 'false' }),"
+        & $w ("      ""run_ms"": {{ ""nurl"": {0}, ""c"": {1}, ""rust"": {2}, ""node"": {3}, ""python"": {4} }}," -f `
+            (JNum $r.ms_nurl), (JNum $r.ms_c), (JNum $r.ms_rust), (JNum $r.ms_node), (JNum $r.ms_python))
+        & $w ("      ""reps"": {{ ""nurl"": {0}, ""c"": {1}, ""rust"": {2}, ""node"": {3}, ""python"": {4} }}," -f `
+            $r.reps_nurl, $r.reps_c, $r.reps_rust, $r.reps_node, $r.reps_python)
+        & $w ("      ""compile_ms"": {{ ""nurl_frontend"": {0}, ""nurl"": {1}, ""c"": {2}, ""rust"": {3} }}" -f `
+            (JNum $r.cc_nurl_fe), (JNum $r.cc_nurl), (JNum $r.cc_c), (JNum $r.cc_rust))
+        & $w ('    }' + $(if ($i -lt $rows.Count - 1) { ',' } else { '' }))
+    }
+    & $w '  ]'
+    & $w '}'
+    return $sb.ToString()
+}
+
+# Markdown cell: bold when this language is the fastest in its row.
+function MdCell($val, $best) {
+    if ([string]$val -eq [string]$best) { return "**$val**" }
+    return [string]$val
+}
+function Fastest-Of([object[]]$vals) {
+    $best = ''
+    foreach ($v in $vals) {
+        $s = [string]$v
+        if ($s -match '^[0-9.]+$') {
+            if ($best -eq '' -or [double]$s -lt [double]$best) { $best = $s }
+        }
+    }
+    return $best
+}
+# NURL's clang stage = total − frontend, when both are numbers.
+function Link-Ms($total, $fe) {
+    if (([string]$total -match '^[0-9.]+$') -and ([string]$fe -match '^[0-9.]+$')) {
+        return ('{0:F3}' -f ([double]$total - [double]$fe))
+    }
+    return 'n/a'
+}
+
+function Emit-Md {
+    $L = [System.Collections.Generic.List[string]]::new()
+    $a = { param($t) $L.Add($t) }
+
+    & $a '# Benchmark results (Windows) — NURL vs C vs Rust vs Node vs Python'
+    & $a ''
+    & $a "Generated ``$Now`` by ``bench/bench.ps1``, the Windows port of"
+    & $a '`bench/bench.sh`. **Do not edit by hand** — the next run overwrites it.'
+    & $a 'The machine-readable form of this same run is'
+    & $a '[`results/latest-windows.json`](results/latest-windows.json).'
+    & $a ''
+    & $a 'These are **not** the numbers the landing page publishes: that table comes'
+    & $a 'from the Linux CI run in [`RESULTS.md`](RESULTS.md) /'
+    & $a '[`results/latest.json`](results/latest.json). Two things differ beyond the'
+    & $a 'host — NURL links without `-flto` here, because `build.bat` does not compile'
+    & $a '`stdlib/runtime.o` to bitcode, and the link names `-lwinhttp` instead of'
+    & $a '`-lm -lpthread`. Both match what a real `nurl.bat` build does on this'
+    & $a 'platform, which is the property worth measuring; both make the NURL column'
+    & $a 'incomparable to a Linux run cell-for-cell.'
+    & $a ''
+
+    & $a '## Environment'
+    & $a ''
+    & $a '| Item | Value |'
+    & $a '|---|---|'
+    & $a "| Host | ``$HostLabel`` |"
+    & $a "| OS | ``$HostKernel`` |"
+    & $a "| CPU | $HostCpu ($HostCores logical cores) |"
+    & $a "| Memory | $HostMemKb KiB |"
+    & $a "| Commit | ``$Commit`` |"
+    if ($RunUrl) { & $a "| CI run | $RunUrl |" }
+    & $a "| NURL | ``$NurlVersion`` |"
+    & $a "| C | $ClangVersion |"
+    & $a "| Rust | $RustcVersion |"
+    & $a "| Node | $NodeVersion |"
+    & $a "| Python | $PythonVersion |"
+    & $a ''
+    & $a '| Setting | Value |'
+    & $a '|---|---|'
+    & $a "| Optimisation | NURL/C ``clang $Opt`` (no LTO), Rust ``-C opt-level=2`` |"
+    & $a "| NURL link | ``$($NurlLinkLibs -join ' ')`` |"
+    & $a "| Timed runs per cell | up to $MaxReps, adaptive: as many as fit in $BudgetMs ms |"
+    & $a "| Timed compiles per cell | $CompileReps (median) |"
+    & $a "| Per-run timeout | $TimeoutS s |"
+    & $a ''
+
+    & $a '## 1. Run time (median wall clock, ms — lower is better)'
+    & $a ''
+    & $a 'Whole-process wall clock, start-up included. Every implementation of a'
+    & $a 'row prints the same line (section 3), so these are five timings of the'
+    & $a 'same computation. **Bold** is the fastest cell in the row.'
+    & $a ''
+    & $a '| Benchmark | NURL | C | Rust | Node | Python |'
+    & $a '|---|---:|---:|---:|---:|---:|'
+    & $a ("| _(floor: empty program)_ | _{0}_ | _{1}_ | _{2}_ | _{3}_ | _{4}_ |" -f `
+        $floorNurl, $floorC, $floorRust, $floorNode, $floorPython)
+    foreach ($r in $rows) {
+        $best = Fastest-Of @($r.ms_nurl, $r.ms_c, $r.ms_rust, $r.ms_node, $r.ms_python)
+        & $a ("| ``{0}`` | {1} | {2} | {3} | {4} | {5} |" -f $r.name,
+            (MdCell $r.ms_nurl $best), (MdCell $r.ms_c $best), (MdCell $r.ms_rust $best),
+            (MdCell $r.ms_node $best), (MdCell $r.ms_python $best))
+    }
+    & $a ''
+
+    & $a '## 2. Compile time (median, ms)'
+    & $a ''
+    & $a "NURL's compile is two stages: ``nurlc.exe`` emits LLVM IR, then ``clang``"
+    & $a 'lowers and links it against `stdlib\runtime.o`. **NURL total** is the'
+    & $a 'number comparable to the C and Rust columns. The floor row is what each'
+    & $a 'toolchain costs for a program that does nothing — for NURL that is'
+    & $a 'dominated by the link every NURL binary pays for, so subtract it to read'
+    & $a 'the marginal cost of the benchmark itself. Node and Python have no column'
+    & $a 'here: they compile at run time, inside their own cells above.'
+    & $a ''
+    & $a '| Benchmark | NURL `nurlc` | NURL `clang` | **NURL total** | C `clang` | Rust `rustc` |'
+    & $a '|---|---:|---:|---:|---:|---:|'
+    & $a ("| _(floor: empty program)_ | _{0}_ | _{1}_ | _**{2}**_ | _{3}_ | _{4}_ |" -f `
+        $ccFloorNurl.Frontend, (Link-Ms $ccFloorNurl.Total $ccFloorNurl.Frontend),
+        $ccFloorNurl.Total, $ccFloorC, $ccFloorRust)
+    foreach ($r in $rows) {
+        & $a ("| ``{0}`` | {1} | {2} | **{3}** | {4} | {5} |" -f $r.name,
+            $r.cc_nurl_fe, (Link-Ms $r.cc_nurl $r.cc_nurl_fe), $r.cc_nurl, $r.cc_c, $r.cc_rust)
+    }
+    & $a ''
+
+    & $a '## 3. Correctness gate'
+    & $a ''
+    & $a 'Each row is timed only when all five implementations print the same'
+    & $a 'line. A speed number for a program computing something else is worthless,'
+    & $a 'so a mismatch drops the row out of the tables above rather than being'
+    & $a 'reported as a fast cell. Comparison is on the text, with CRLF normalised'
+    & $a "to LF — C's and Python's stdio are in text mode on Windows and the NURL"
+    & $a 'runtime writes bytes, which is a line-ending difference and nothing more.'
+    & $a ''
+    & $a '| Benchmark | Output | Verdict |'
+    & $a '|---|---|---|'
+    foreach ($r in $rows) {
+        if ($r.verified) {
+            & $a ("| ``{0}`` | ``{1}`` | identical across 5 languages |" -f $r.name, $r.checksum)
+        } else {
+            & $a ("| ``{0}`` | — | **MISMATCH** — {1} |" -f $r.name, $r.detail)
+        }
+    }
+    & $a ''
+
+    & $a '## 4. Reading the numbers'
+    & $a ''
+    & $a '* A cell near the floor row is mostly process start-up, DLL loading and'
+    & $a '  page faults rather than the benchmark. The rows worth comparing are the'
+    & $a '  ones in the tens of milliseconds and up. The Windows floor is higher'
+    & $a '  than the Linux one across the board — loader work, not the language.'
+    & $a '* All three compiled back ends are LLVM-based and all three are allowed to'
+    & $a '  be clever: LLVM will fold an affine recurrence or unroll a loop by a'
+    & $a '  different factor in each language. A cell measures optimised throughput'
+    & $a '  of the same algorithm, not the source-level iteration count.'
+    & $a '* Ten of the fifteen benchmarks are defined over 64-bit unsigned integers.'
+    & $a '  Python has arbitrary-precision integers and masks; JS has no 64-bit'
+    & $a '  integer at all, so those rows use `BigInt` where the algorithm genuinely'
+    & $a '  needs 64 bits and Numbers with `Math.imul` where 32 bits suffice. Each'
+    & $a '  file says which and why. That gap *is* part of what this table reports.'
+    & $a '* `json_parse` is the one row whose gate is "every parser accepted the'
+    & $a '  document" rather than a structural checksum: each language uses the'
+    & $a '  parser in its own box (Python `json`, Node `JSON.parse`, NURL'
+    & $a "  ``stdlib/ext/json.nu``), and C and Rust — whose boxes are empty — carry a"
+    & $a '  small hand-written recursive-descent parser in the benchmark file.'
+    & $a '* Wall clock on a machine that was not quiesced drifts a few per cent'
+    & $a '  between runs, and more on a laptop that can thermally throttle or drop'
+    & $a '  to a power-saving governor mid-suite. Compare deltas between runs on the'
+    & $a '  same box, not absolutes across machines — and never across OSes here,'
+    & $a '  for the link-line reason at the top of this file.'
+
+    return (($L -join "`n") + "`n")
+}
+
+if ($Stdout) {
+    Write-Output (Emit-Md)
+} else {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Json), (Split-Path -Parent $Md) | Out-Null
+    # LF, UTF-8 without BOM — the same bytes bench.sh writes, so a diff
+    # against a Linux artefact shows numbers and not line endings.
+    [System.IO.File]::WriteAllText($Json, (Emit-Json), $Utf8NoBom)
+    [System.IO.File]::WriteAllText($Md,   (Emit-Md),   $Utf8NoBom)
+    Write-Host "wrote $Json"
+    Write-Host "wrote $Md"
+}
+
+# A mismatched row is a failure of the suite, not a slow benchmark.
+foreach ($r in $rows) {
+    if (-not $r.verified) {
+        Write-Host 'bench.ps1: at least one row failed the correctness gate' -ForegroundColor Red
+        exit 1
+    }
+}
+exit 0

--- a/bench/results/wasm-latest.json
+++ b/bench/results/wasm-latest.json
@@ -1,0 +1,326 @@
+{
+  "schema": 1,
+  "kind": "wasm",
+  "generated_utc": "2026-07-27T09:53:03Z",
+  "commit": "ad7e4391c17af5bc82ffc997b8e97005329aabd2",
+  "run_url": "",
+  "host": {
+    "label": "Linux x86_64",
+    "kernel": "Linux 7.0.0-28-generic x86_64",
+    "cpu": "Intel(R) Core(TM) i7-5930K CPU @ 3.50GHz",
+    "cores": 12,
+    "mem_kb": 32770952
+  },
+  "toolchains": {
+    "nurl": "v0.26.0-15-gad7e439",
+    "clang": "Ubuntu clang version 18.1.3 (1ubuntu1)",
+    "rustc": "rustc 1.82.0 (f6e511eec 2024-10-15)",
+    "zig": "zig 0.13.0",
+    "wasmbuilder": "wasmbuilder 0.1.3",
+    "wasmtime_ref": "wasmtime 44.0.0 (af382d7d9 2026-04-20)",
+    "wasmtime_nurl": "wasmtime 0.6.2 (pure NURL)"
+  },
+  "settings": {
+    "opt": "-O2",
+    "wasm_target_c": "wasm32-wasi",
+    "wasm_target_rust": "wasm32-wasip1",
+    "max_reps": 5,
+    "budget_ms": 8000,
+    "timeout_s": 900,
+    "compile_reps": 3,
+    "interpreter_all_languages": false
+  },
+  "floor_ms": {
+    "native": { "nurl": 1.664, "c": 1.527, "rust": 1.705 },
+    "wasm_ref": { "nurl": 62.536, "c": 7.151, "rust": 17.188, "nurl_gc_sections": 10.267 },
+    "wasm_wt": { "nurl": 45.100, "c": null, "rust": null }
+  },
+  "floor_compile_ms": { "nurl_frontend": 3.968, "nurl_native": 109.052, "nurl_wasm": 1334.094, "nurl_wasm_gc_sections": 1364.862, "c_native": 81.312, "c_wasm": 602.986, "rust_native": 156.370, "rust_wasm": 109.577 },
+  "benchmarks": [
+    {
+      "name": "lcg",
+      "blurb": "20M-step 64-bit LCG + xorshift",
+      "measures": "Loop-carried mul/add/shift/xor dependency the unroller cannot compose",
+      "checksum": "-7585129161289236796",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 39.454, "c": 36.734, "rust": 40.684 },
+        "wasm_ref": { "nurl": 92.613, "c": 70.561, "rust": 55.154, "nurl_gc_sections": 60.884 },
+        "wasm_wt":  { "nurl": 2561.128, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 3, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 3.911, "nurl_native": 110.031, "nurl_wasm": 1362.946, "nurl_wasm_gc_sections": 1398.934, "c_native": 95.402, "c_wasm": 951.330, "rust_native": 183.458, "rust_wasm": 123.338 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089299, "nurl_wasm_gc_sections": 839041, "c_native": 16008, "c_wasm": 702181, "rust_native": 3832512, "rust_wasm": 1774926 }
+    },
+    {
+      "name": "affine_mix",
+      "blurb": "20M affine steps + xorshift",
+      "measures": "Shift/add/mask/xor chain over a 58-bit state, no multiply",
+      "checksum": "227901546981696845",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 33.592, "c": 34.469, "rust": 40.279 },
+        "wasm_ref": { "nurl": 91.026, "c": 59.458, "rust": 53.595, "nurl_gc_sections": 59.683 },
+        "wasm_wt":  { "nurl": 5261.156, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 4.045, "nurl_native": 110.049, "nurl_wasm": 1305.744, "nurl_wasm_gc_sections": 1316.444, "c_native": 86.817, "c_wasm": 938.474, "rust_native": 168.551, "rust_wasm": 121.083 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089174, "nurl_wasm_gc_sections": 838982, "c_native": 16016, "c_wasm": 702280, "rust_native": 3832584, "rust_wasm": 1775198 }
+    },
+    {
+      "name": "packet_classifier",
+      "blurb": "25M unpredictable branches",
+      "measures": "A data-dependent 50/50 branch the predictor cannot learn",
+      "checksum": "4205972061",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 63.118, "c": 68.643, "rust": 68.195 },
+        "wasm_ref": { "nurl": 111.411, "c": 77.651, "rust": 69.459, "nurl_gc_sections": 79.172 },
+        "wasm_wt":  { "nurl": 5645.706, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 3.792, "nurl_native": 109.116, "nurl_wasm": 1317.276, "nurl_wasm_gc_sections": 1364.031, "c_native": 94.783, "c_wasm": 915.998, "rust_native": 176.435, "rust_wasm": 121.980 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089164, "nurl_wasm_gc_sections": 838981, "c_native": 16024, "c_wasm": 702214, "rust_native": 3832608, "rust_wasm": 1775209 }
+    },
+    {
+      "name": "ring_write",
+      "blurb": "20M ring-buffer stores",
+      "measures": "Dependent store per iteration plus address computation",
+      "checksum": "8299504528805184357",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 37.471, "c": 37.305, "rust": 43.807 },
+        "wasm_ref": { "nurl": 98.644, "c": 69.063, "rust": 64.403, "nurl_gc_sections": 68.821 },
+        "wasm_wt":  { "nurl": 7022.937, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 3.754, "nurl_native": 106.551, "nurl_wasm": 1286.930, "nurl_wasm_gc_sections": 1300.691, "c_native": 89.003, "c_wasm": 940.199, "rust_native": 171.690, "rust_wasm": 113.975 },
+      "bytes": { "nurl_native": 16080, "nurl_wasm": 1089324, "nurl_wasm_gc_sections": 839054, "c_native": 16064, "c_wasm": 702453, "rust_native": 3832584, "rust_wasm": 1775263 }
+    },
+    {
+      "name": "histogram_bins",
+      "blurb": "20M binned increments",
+      "measures": "Read-modify-write at a data-dependent index",
+      "checksum": "1215643728",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 41.374, "c": 41.853, "rust": 41.801 },
+        "wasm_ref": { "nurl": 100.163, "c": 73.794, "rust": 64.298, "nurl_gc_sections": 77.872 },
+        "wasm_wt":  { "nurl": 7289.204, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 4.750, "nurl_native": 117.854, "nurl_wasm": 1297.838, "nurl_wasm_gc_sections": 1285.593, "c_native": 87.753, "c_wasm": 924.073, "rust_native": 168.438, "rust_wasm": 112.015 },
+      "bytes": { "nurl_native": 16080, "nurl_wasm": 1089464, "nurl_wasm_gc_sections": 839128, "c_native": 16072, "c_wasm": 702643, "rust_native": 3832600, "rust_wasm": 1775356 }
+    },
+    {
+      "name": "prefix_scan",
+      "blurb": "1M 16-wide prefix scans",
+      "measures": "Store-bound fill then a serial load/add dependency chain",
+      "checksum": "492982549",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 24.097, "c": 24.841, "rust": 24.624 },
+        "wasm_ref": { "nurl": 79.843, "c": 48.479, "rust": 29.781, "nurl_gc_sections": 49.952 },
+        "wasm_wt":  { "nurl": 2512.158, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 3, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 4.434, "nurl_native": 113.783, "nurl_wasm": 1293.032, "nurl_wasm_gc_sections": 1293.663, "c_native": 87.699, "c_wasm": 921.444, "rust_native": 166.301, "rust_wasm": 111.517 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089468, "nurl_wasm_gc_sections": 839428, "c_native": 16016, "c_wasm": 703429, "rust_native": 3832584, "rust_wasm": 1775615 }
+    },
+    {
+      "name": "binary_search",
+      "blurb": "5M lower-bound searches",
+      "measures": "Pointer-chasing: each load address depends on the last compare",
+      "checksum": "805907445",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 34.228, "c": 36.161, "rust": 43.948 },
+        "wasm_ref": { "nurl": 132.185, "c": 117.260, "rust": 99.095, "nurl_gc_sections": 104.771 },
+        "wasm_wt":  { "nurl": 15085.611, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 3.848, "nurl_native": 111.293, "nurl_wasm": 1301.846, "nurl_wasm_gc_sections": 1299.296, "c_native": 90.424, "c_wasm": 913.416, "rust_native": 179.118, "rust_wasm": 125.883 },
+      "bytes": { "nurl_native": 16080, "nurl_wasm": 1089208, "nurl_wasm_gc_sections": 839168, "c_native": 16016, "c_wasm": 703201, "rust_native": 3832592, "rust_wasm": 1776147 }
+    },
+    {
+      "name": "sort_window",
+      "blurb": "2M 8-element bubble sorts",
+      "measures": "Branchless compare/exchange mill over a 64-byte window (~50 cmovs/iter)",
+      "checksum": "2815490238",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 41.188, "c": 52.501, "rust": 53.575 },
+        "wasm_ref": { "nurl": 110.110, "c": 75.914, "rust": 123.660, "nurl_gc_sections": 80.610 },
+        "wasm_wt":  { "nurl": 40323.696, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 4.458, "nurl_native": 123.809, "nurl_wasm": 1379.428, "nurl_wasm_gc_sections": 1356.701, "c_native": 92.877, "c_wasm": 944.488, "rust_native": 176.587, "rust_wasm": 131.672 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089919, "nurl_wasm_gc_sections": 839462, "c_native": 16016, "c_wasm": 703289, "rust_native": 3832584, "rust_wasm": 1775550 }
+    },
+    {
+      "name": "bloom_filter",
+      "blurb": "4M Bloom-filter queries",
+      "measures": "Four unpredictable loads per query over a 2 KB working set",
+      "checksum": "2351703",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 18.133, "c": 16.750, "rust": 17.689 },
+        "wasm_ref": { "nurl": 81.014, "c": 45.560, "rust": 36.494, "nurl_gc_sections": 42.536 },
+        "wasm_wt":  { "nurl": 3820.273, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 2, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 5.249, "nurl_native": 118.834, "nurl_wasm": 1296.963, "nurl_wasm_gc_sections": 1289.292, "c_native": 96.674, "c_wasm": 916.469, "rust_native": 178.571, "rust_wasm": 119.138 },
+      "bytes": { "nurl_native": 16080, "nurl_wasm": 1089670, "nurl_wasm_gc_sections": 839296, "c_native": 16072, "c_wasm": 703714, "rust_native": 3832592, "rust_wasm": 1775478 }
+    },
+    {
+      "name": "hash_join",
+      "blurb": "500k hash-table probes",
+      "measures": "Cheap Bloom early-out plus a rare, branchy join path",
+      "checksum": "2814341850483607168",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 6.320, "c": 4.886, "rust": 5.320 },
+        "wasm_ref": { "nurl": 66.795, "c": 31.750, "rust": 24.550, "nurl_gc_sections": 30.637 },
+        "wasm_wt":  { "nurl": 3324.280, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 2, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 9.265, "nurl_native": 246.170, "nurl_wasm": 1307.893, "nurl_wasm_gc_sections": 1318.450, "c_native": 141.155, "c_wasm": 967.105, "rust_native": 232.732, "rust_wasm": 177.676 },
+      "bytes": { "nurl_native": 20176, "nurl_wasm": 1092266, "nurl_wasm_gc_sections": 841200, "c_native": 16064, "c_wasm": 711257, "rust_native": 3832576, "rust_wasm": 1777836 }
+    },
+    {
+      "name": "sieve",
+      "blurb": "Sieve of Eratosthenes to 10M",
+      "measures": "Irregular-stride byte writes, then one linear scan",
+      "checksum": "664579",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 43.446, "c": 42.302, "rust": 37.415 },
+        "wasm_ref": { "nurl": 99.869, "c": 68.849, "rust": 61.224, "nurl_gc_sections": 66.558 },
+        "wasm_wt":  { "nurl": 5165.420, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 5.235, "nurl_native": 119.781, "nurl_wasm": 1358.393, "nurl_wasm_gc_sections": 1358.959, "c_native": 94.151, "c_wasm": 938.741, "rust_native": 186.617, "rust_wasm": 131.672 },
+      "bytes": { "nurl_native": 16128, "nurl_wasm": 1089383, "nurl_wasm_gc_sections": 839062, "c_native": 16112, "c_wasm": 707132, "rust_native": 3832288, "rust_wasm": 1775002 }
+    },
+    {
+      "name": "fib",
+      "blurb": "Recursive fib(35)",
+      "measures": "The call/return path: ~15M calls after LLVM turns one recursion into a loop",
+      "checksum": "9227465",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 34.440, "c": 33.702, "rust": 30.222 },
+        "wasm_ref": { "nurl": 102.493, "c": 65.008, "rust": 64.897, "nurl_gc_sections": 71.491 },
+        "wasm_wt":  { "nurl": 11474.997, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 3.771, "nurl_native": 111.500, "nurl_wasm": 1337.662, "nurl_wasm_gc_sections": 1332.718, "c_native": 87.876, "c_wasm": 938.591, "rust_native": 171.183, "rust_wasm": 114.812 },
+      "bytes": { "nurl_native": 16032, "nurl_wasm": 1089021, "nurl_wasm_gc_sections": 838949, "c_native": 16040, "c_wasm": 702022, "rust_native": 3828224, "rust_wasm": 1774826 }
+    },
+    {
+      "name": "collatz",
+      "blurb": "Longest Collatz chain below 100k",
+      "measures": "Control-flow-heavy inner loop with no array at all",
+      "checksum": "350",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 18.651, "c": 17.458, "rust": 18.617 },
+        "wasm_ref": { "nurl": 78.851, "c": 43.512, "rust": 38.712, "nurl_gc_sections": 44.133 },
+        "wasm_wt":  { "nurl": 2662.316, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 3, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 4.219, "nurl_native": 107.542, "nurl_wasm": 1326.105, "nurl_wasm_gc_sections": 1340.779, "c_native": 89.276, "c_wasm": 929.486, "rust_native": 170.377, "rust_wasm": 123.266 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089194, "nurl_wasm_gc_sections": 838955, "c_native": 16016, "c_wasm": 702163, "rust_native": 3828176, "rust_wasm": 1774828 }
+    },
+    {
+      "name": "matmul",
+      "blurb": "256x256 integer matrix product",
+      "measures": "Triple-nested loop, flat indexing, column-strided reads",
+      "checksum": "393199",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 35.631, "c": 35.353, "rust": 35.041 },
+        "wasm_ref": { "nurl": 89.686, "c": 60.555, "rust": 55.030, "nurl_gc_sections": 60.514 },
+        "wasm_wt":  { "nurl": 4240.486, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 5.588, "nurl_native": 123.111, "nurl_wasm": 1337.730, "nurl_wasm_gc_sections": 1329.532, "c_native": 99.820, "c_wasm": 950.490, "rust_native": 213.000, "rust_wasm": 153.248 },
+      "bytes": { "nurl_native": 16128, "nurl_wasm": 1089379, "nurl_wasm_gc_sections": 839339, "c_native": 16160, "c_wasm": 708006, "rust_native": 3832536, "rust_wasm": 1775486 }
+    },
+    {
+      "name": "json_parse",
+      "blurb": "20 parses of a 64 KB document",
+      "measures": "Allocator pressure, string handling, recursive descent",
+      "checksum": "20",
+      "verified": true,
+      "run_ms": {
+        "native":   { "nurl": 11.850, "c": 8.871, "rust": 14.477 },
+        "wasm_ref": { "nurl": 88.650, "c": 39.651, "rust": 40.095, "nurl_gc_sections": 47.099 },
+        "wasm_wt":  { "nurl": 29424.539, "c": null, "rust": null }
+      },
+      "reps": {
+        "native":   { "nurl": 5, "c": 5, "rust": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
+      },
+      "compile_ms": { "nurl_frontend": 85.653, "nurl_native": 849.593, "nurl_wasm": 1560.415, "nurl_wasm_gc_sections": 1543.646, "c_native": 141.863, "c_wasm": 1102.307, "rust_native": 322.235, "rust_wasm": 235.882 },
+      "bytes": { "nurl_native": 34824, "nurl_wasm": 1145493, "nurl_wasm_gc_sections": 869437, "c_native": 16632, "c_wasm": 753401, "rust_native": 3847336, "rust_wasm": 1805091 }
+    }
+  ]
+}

--- a/bench/wasmbench.sh
+++ b/bench/wasmbench.sh
@@ -1,0 +1,926 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  bench/wasmbench.sh — the wasm benchmark runner.
+#
+#  The sibling of bench/bench.sh, same corpus and same protocol, one axis
+#  rotated: instead of asking "how fast is NURL against four other
+#  languages", it asks "what does *targeting wasm* cost, and what does
+#  running that wasm on NURL's own runtime cost".
+#
+#  Every benchmark in bench/manifest.tsv is implemented in NURL, C and
+#  Rust. Each of those three is compiled twice — native and wasm32-wasi —
+#  and every wasm module is then run on two runtimes:
+#
+#    reference wasmtime   Cranelift JIT, the industry baseline. The
+#                         wasm-vs-native gap it shows is the cost of the
+#                         *target*, with the compiler quality controlled for.
+#    packages/wasmtime    `wt`, a WebAssembly interpreter written in pure
+#                         NURL. Same modules, same outputs; the gap to the
+#                         column on its left is the cost of *this runtime*.
+#
+#  Ten timed cells per row — 3 languages x {native, JIT, interpreter}, plus
+#  the NURL module relinked with --gc-sections — all gated on printing the
+#  same line as the native NURL binary. A speed number for a program
+#  computing something else is worthless.
+#
+#  Artefacts:
+#    bench/results/wasm-latest.json   machine-readable
+#    bench/WASMRESULTS.md             the same run rendered for humans
+#
+#  Usage:
+#      ./bench/wasmbench.sh                    # full suite, write both files
+#      ./bench/wasmbench.sh --quick            # 1 rep/cell, for a smoke test
+#      ./bench/wasmbench.sh --bench lcg --bench sieve
+#      ./bench/wasmbench.sh --wt-all-langs      # + C/Rust on the interpreter
+#      ./bench/wasmbench.sh --stdout           # print the report, touch nothing
+#
+#  Everything but the interpreter costs about what bench.sh does. The
+#  interpreter is ~500x slower than native, so its column alone is ~15
+#  minutes for NURL — that is the measurement, not a defect of the harness.
+#  --wt-all-langs adds the C and Rust modules to it (the cross-frontend
+#  control) and triples that, so it is opt-in rather than the default.
+#
+#  Requires nurlc (./build.sh), clang, rustc + the wasm32-wasip1 target,
+#  zig (the toolchain's bundled one is fine) and a reference wasmtime.
+#  A missing toolchain is a hard error: a table with a hole in it is worse
+#  than no table, because the hole is invisible once the numbers are copied
+#  out. `wasmbuilder` and `wt` are compiled from packages/ by this script,
+#  so they always match the repo they are measuring.
+# ============================================================
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BENCH="$ROOT/bench"
+BUILD="$BENCH/_wasmbuild"
+MANIFEST="$BENCH/manifest.tsv"
+
+# ── settings ─────────────────────────────────────────────────────
+MAX_REPS=5            # timed runs per cell, at most
+BUDGET_MS=8000        # per-cell time budget; a slow cell gets fewer reps
+TIMEOUT_S=900         # per-run wall-clock cap (the interpreter needs room)
+COMPILE_REPS=3        # timed compiles per compiled language
+OPT="-O2"
+WASM_TARGET_C="wasm32-wasi"       # zig cc's spelling
+WASM_TARGET_RS="wasm32-wasip1"    # rustc's spelling
+JSON_OUT="$BENCH/results/wasm-latest.json"
+MD_OUT="$BENCH/WASMRESULTS.md"
+WRITE=1
+WT_ALL_LANGS=0        # also run C/Rust on the interpreter (--wt-all-langs)
+SELECTED=()
+
+usage() { sed -n '4,50p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+while (( $# > 0 )); do
+    case "$1" in
+        --bench)         SELECTED+=("$2"); shift 2 ;;
+        --reps)          MAX_REPS="$2"; shift 2 ;;
+        --budget-ms)     BUDGET_MS="$2"; shift 2 ;;
+        --timeout)       TIMEOUT_S="$2"; shift 2 ;;
+        --compile-reps)  COMPILE_REPS="$2"; shift 2 ;;
+        --json)          JSON_OUT="$2"; shift 2 ;;
+        --md)            MD_OUT="$2"; shift 2 ;;
+        --stdout)        WRITE=0; shift ;;
+        --wt-all-langs)  WT_ALL_LANGS=1; shift ;;
+        --quick)         MAX_REPS=1; BUDGET_MS=1; COMPILE_REPS=1; shift ;;
+        -h|--help)       usage 0 ;;
+        *)               echo "wasmbench.sh: unknown argument '$1'" >&2; usage 2 ;;
+    esac
+done
+
+mkdir -p "$BUILD"
+
+# ── toolchain detection ──────────────────────────────────────────
+NURLC="$ROOT/build/nurlc"
+RUNTIME="$ROOT/stdlib/runtime.o"
+NURL_HOME_DIR="${NURL_HOME:-$HOME/.nurl}"
+
+missing=()
+[[ -x "$NURLC" && -f "$RUNTIME" ]] || missing+=("nurlc (run ./build.sh)")
+command -v clang >/dev/null || missing+=("clang")
+command -v rustc >/dev/null || missing+=("rustc")
+
+# zig carries its own wasi-libc and wasm-ld — that is what makes a wasi-sdk
+# unnecessary, for the C column here and inside wasmbuilder alike. Same
+# discovery order the wasmbuilder package uses, so both find the same zig.
+ZIG="${NURL_ZIG:-}"
+if [[ -z "$ZIG" ]]; then
+    if   [[ -x "$NURL_HOME_DIR/zig/zig" ]]; then ZIG="$NURL_HOME_DIR/zig/zig"
+    elif command -v zig >/dev/null;        then ZIG="$(command -v zig)"
+    fi
+fi
+[[ -n "$ZIG" ]] || missing+=("zig (install the NURL toolchain, or set \$NURL_ZIG)")
+
+# The reference runtime. Not vendored anywhere in this repo on purpose: its
+# whole job here is to be the outside opinion.
+WASMTIME="${WASMTIME:-}"
+if [[ -z "$WASMTIME" ]]; then
+    if   command -v wasmtime >/dev/null;            then WASMTIME="$(command -v wasmtime)"
+    elif [[ -x "$HOME/.wasmtime/bin/wasmtime" ]];   then WASMTIME="$HOME/.wasmtime/bin/wasmtime"
+    fi
+fi
+[[ -n "$WASMTIME" ]] || missing+=("wasmtime (curl https://wasmtime.dev/install.sh -sSf | bash)")
+
+# rustc ships wasm32-wasip1 as a rustup component, not by default.
+if command -v rustc >/dev/null; then
+    rustc --print target-libdir --target "$WASM_TARGET_RS" >/dev/null 2>&1 \
+        || missing+=("rust std for $WASM_TARGET_RS (rustup target add $WASM_TARGET_RS)")
+fi
+
+if (( ${#missing[@]} > 0 )); then
+    printf 'wasmbench.sh: missing toolchain: %s\n' "${missing[*]}" >&2
+    exit 1
+fi
+
+# Optional FFI libs the NURL runtime may have been built against — the same
+# detection bench.sh does, so the native link line here matches a normal
+# `nurl.sh` build byte for byte.
+EXTRA_LIBS=""
+for pair in "runtime.curl:libcurl" "runtime.openssl:openssl" "runtime.sqlite3:sqlite3" \
+            "runtime.pq:libpq" "runtime.z:zlib" "runtime.zstd:libzstd"; do
+    marker="${pair%%:*}"; pc="${pair##*:}"
+    [[ -f "$ROOT/stdlib/$marker" ]] && EXTRA_LIBS="$EXTRA_LIBS $(pkg-config --libs "$pc" 2>/dev/null)"
+done
+
+# ── build the two packages under test ────────────────────────────
+# wasmbuilder compiles the wasm; wt runs it. Both are NURL programs living
+# in packages/, and both are rebuilt from source here rather than taken from
+# an installed toolchain — a benchmark of this repo has to measure this
+# repo's compiler, runtime and packages, not whatever happens to be in
+# $NURL_HOME.
+WASMBUILDER="$BUILD/wasmbuilder"
+WT="$BUILD/wt"
+
+echo "  building packages/wasmbuilder and packages/wasmtime …" >&2
+for pkg in "wasmbuilder:$WASMBUILDER" "wasmtime:$WT"; do
+    name="${pkg%%:*}"; out="${pkg##*:}"
+    if ! (cd "$ROOT" && ./nurl.sh "packages/$name/src/main.nu" "$out") >"$out.buildlog" 2>&1; then
+        echo "wasmbench.sh: failed to build packages/$name — see $out.buildlog" >&2
+        exit 1
+    fi
+done
+
+# wasmbuilder resolves nurlc and the stdlib C sources from the environment;
+# point both at this repo so the wasm modules and the native binaries come
+# out of the same compiler.
+export NURLC
+export NURL_STDLIB="$ROOT"
+
+# First use compiles stdlib/runtime.c to runtime.wasm.o and caches it by
+# content hash. Do that now, outside the timed region, or the first
+# benchmark's compile cell would carry it.
+"$WASMBUILDER" --doctor >/dev/null 2>&1
+
+NURL_VERSION="$("$NURLC" --version 2>/dev/null | head -1)"
+[[ -n "$NURL_VERSION" ]] || NURL_VERSION="$(git -C "$ROOT" describe --tags --always --dirty 2>/dev/null)"
+CLANG_VERSION="$(clang --version | head -1)"
+RUSTC_VERSION="$(rustc --version)"
+ZIG_VERSION="zig $("$ZIG" version 2>/dev/null)"
+WASMTIME_VERSION="$("$WASMTIME" --version 2>/dev/null | head -1)"
+WASMBUILDER_VERSION="$("$WASMBUILDER" --version 2>/dev/null | head -1)"
+WT_VERSION="$("$WT" --version 2>/dev/null | head -1)"
+
+HOST_KERNEL="$(uname -srm)"
+HOST_CPU="$(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | sed 's/.*: //')"
+[[ -n "$HOST_CPU" ]] || HOST_CPU="$(uname -p)"
+HOST_CORES="$(nproc 2>/dev/null || echo 0)"
+HOST_MEM_KB="$(grep -m1 MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}')"
+[[ -n "$HOST_MEM_KB" ]] || HOST_MEM_KB=0
+HOST_LABEL="${BENCH_HOST_LABEL:-$(uname -s) $(uname -m)}"
+COMMIT="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+RUN_URL="${BENCH_RUN_URL:-}"
+
+# ── timing helpers ───────────────────────────────────────────────
+# Identical to bench.sh's, deliberately: the two reports have to be
+# comparable cell for cell. One wall-clock reading in milliseconds from
+# bash 5's $EPOCHREALTIME rather than forking `date` twice, which would add
+# ~3 ms to every reading — larger than several of the native cells.
+time_ms() {
+    local t0 t1 ec
+    t0=$EPOCHREALTIME
+    if [[ -n "${TIME_STDOUT:-}" ]]; then
+        timeout --foreground "${TIMEOUT_S}s" "$@" >"$TIME_STDOUT" 2>/dev/null
+    else
+        timeout --foreground "${TIMEOUT_S}s" "$@" >/dev/null 2>&1
+    fi
+    ec=$?
+    t1=$EPOCHREALTIME
+    if [[ $ec -eq 124 ]]; then echo TIMEOUT; return; fi
+    if [[ $ec -ne 0 ]];   then echo FAIL;    return; fi
+    local sa=${t0%.*} ua=${t0#*.} sb=${t1%.*} ub=${t1#*.}
+    awk -v us=$(( (sb * 1000000 + 10#$ub) - (sa * 1000000 + 10#$ua) )) \
+        'BEGIN { printf "%.3f", us / 1000 }'
+}
+
+median() {
+    local a
+    for a in "$@"; do
+        [[ "$a" == FAIL    ]] && { echo FAIL; return; }
+        [[ "$a" == TIMEOUT ]] && { echo TIMEOUT; return; }
+    done
+    printf '%s\n' "$@" | sort -g | awk '{ v[NR]=$1 } END {
+        if (NR % 2) printf "%.3f", v[(NR+1)/2]; else printf "%.3f", (v[NR/2] + v[NR/2+1]) / 2 }'
+}
+
+# Time a cell adaptively: one run first, then as many more as fit in
+# BUDGET_MS, capped at MAX_REPS. A 6 ms native cell gets the full 5 runs for
+# 30 ms; a 40-second interpreter cell gets one, because a second run buys
+# noise reduction the reader cannot use and costs another 40 seconds.
+# Echoes "<median_ms> <reps>".
+time_cell() {
+    local first rest reps runs=()
+    first="$(time_ms "$@")"
+    if [[ "$first" == FAIL || "$first" == TIMEOUT ]]; then echo "$first 1"; return; fi
+    runs=("$first")
+    reps="$(awk -v b="$BUDGET_MS" -v f="$first" -v m="$MAX_REPS" \
+        'BEGIN { n = (f > 0) ? int(b / f) : m; if (n < 1) n = 1; if (n > m) n = m; print n }')"
+    while (( ${#runs[@]} < reps )); do
+        rest="$(time_ms "$@")"
+        [[ "$rest" == FAIL || "$rest" == TIMEOUT ]] && { echo "$rest ${#runs[@]}"; return; }
+        runs+=("$rest")
+    done
+    echo "$(median "${runs[@]}") ${#runs[@]}"
+}
+
+# ── compile helpers ──────────────────────────────────────────────
+# nurlc resolves `$ "stdlib/..."` imports relative to its working directory,
+# so every compile and every run happens from $ROOT. So does every wasm run:
+# json_parse opens bench/data.json through a `--dir .` preopen.
+compile_nurl_native() {    # <src.nu> <outbase> -> "<frontend_ms> <total_ms>" or FAIL
+    local src="$1" ll="$2.ll" bin="$2.nurl.bin"
+    local fe=() tot=() r f l
+    for ((r = 0; r < COMPILE_REPS; r++)); do
+        f="$(cd "$ROOT" && TIME_STDOUT="$ll" time_ms "$NURLC" "$src")"
+        [[ "$f" == FAIL || "$f" == TIMEOUT ]] && { echo FAIL; return 1; }
+        # shellcheck disable=SC2086
+        l="$(cd "$ROOT" && time_ms clang $OPT -flto -Wl,--as-needed "$ll" "$RUNTIME" \
+                 -lm -lpthread $EXTRA_LIBS -o "$bin")"
+        [[ "$l" == FAIL || "$l" == TIMEOUT ]] && { echo FAIL; return 1; }
+        fe+=("$f"); tot+=("$(awk -v a="$f" -v b="$l" 'BEGIN { printf "%.3f", a + b }')")
+    done
+    echo "$(median "${fe[@]}") $(median "${tot[@]}")"
+}
+
+# The whole wasmbuilder pipeline in one number: nurlc to LLVM IR, the IR
+# rewriter retargeting it for wasm32-wasi, and zig cc linking the module
+# against wasi-libc and the cached runtime.wasm.o. Comparable to the NURL
+# native total in the same row.
+compile_nurl_wasm() {      # <src.nu> <outbase> -> "<ms>" or FAIL
+    local src="$1" out="$2.nu.wasm" res=() r t
+    for ((r = 0; r < COMPILE_REPS; r++)); do
+        t="$(cd "$ROOT" && time_ms "$WASMBUILDER" -q "$src" -o "$out")"
+        [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
+        res+=("$t")
+    done
+    median "${res[@]}"
+}
+
+# The same pipeline with `--gc-sections`, which wasmbuilder leaves off by
+# default: NURL closures store function-table indices and section GC
+# renumbers that table, so a closure captured before the collection can call
+# the wrong function after it — a run-time `call_indirect` trap, with no
+# link error to warn anyone. What it drops is most of the NURL runtime a
+# small program never calls, which on the reference runtime is code being
+# translated for nothing. None of these benchmarks uses a closure, so the
+# variant is built for all of them, gated on identical output like every
+# other cell, and reported beside the default in section 5.
+compile_nurl_wasm_gc() {   # <src.nu> <outbase> -> "<ms>" or FAIL
+    local src="$1" out="$2.nugc.wasm" res=() r t
+    for ((r = 0; r < COMPILE_REPS; r++)); do
+        t="$(cd "$ROOT" && time_ms "$WASMBUILDER" -q --gc-sections "$src" -o "$out")"
+        [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
+        res+=("$t")
+    done
+    median "${res[@]}"
+}
+
+compile_c_native() {       # <src.c> <outbase> -> "<ms>" or FAIL
+    local src="$1" bin="$2.c.bin" out=() r t
+    for ((r = 0; r < COMPILE_REPS; r++)); do
+        # shellcheck disable=SC2086
+        t="$(cd "$ROOT" && time_ms clang $OPT "$src" -lm -o "$bin")"
+        [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
+        out+=("$t")
+    done
+    median "${out[@]}"
+}
+
+compile_c_wasm() {         # <src.c> <outbase> -> "<ms>" or FAIL
+    local src="$1" bin="$2.c.wasm" out=() r t
+    for ((r = 0; r < COMPILE_REPS; r++)); do
+        # shellcheck disable=SC2086
+        t="$(cd "$ROOT" && time_ms "$ZIG" cc "--target=$WASM_TARGET_C" $OPT "$src" -lm -o "$bin")"
+        [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
+        out+=("$t")
+    done
+    median "${out[@]}"
+}
+
+compile_rust_native() {    # <src.rs> <outbase> -> "<ms>" or FAIL
+    local src="$1" bin="$2.rs.bin" out=() r t
+    for ((r = 0; r < COMPILE_REPS; r++)); do
+        t="$(cd "$ROOT" && time_ms rustc -C opt-level=2 "$src" -o "$bin")"
+        [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
+        out+=("$t")
+    done
+    median "${out[@]}"
+}
+
+compile_rust_wasm() {      # <src.rs> <outbase> -> "<ms>" or FAIL
+    local src="$1" bin="$2.rs.wasm" out=() r t
+    for ((r = 0; r < COMPILE_REPS; r++)); do
+        t="$(cd "$ROOT" && time_ms rustc --target "$WASM_TARGET_RS" -C opt-level=2 "$src" -o "$bin")"
+        [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
+        out+=("$t")
+    done
+    median "${out[@]}"
+}
+
+fsize() { [[ -f "$1" ]] && stat -c%s "$1" 2>/dev/null || echo 0; }
+
+# ── roster ───────────────────────────────────────────────────────
+names=(); blurbs=(); shapes=()
+while IFS=$'\t' read -r name blurb shape; do
+    [[ -z "${name:-}" || "$name" == \#* ]] && continue
+    if (( ${#SELECTED[@]} > 0 )); then
+        selected_hit=0
+        for s in "${SELECTED[@]}"; do [[ "$s" == "$name" ]] && selected_hit=1; done
+        (( selected_hit )) || continue
+    fi
+    names+=("$name"); blurbs+=("$blurb"); shapes+=("$shape")
+done < "$MANIFEST"
+
+if (( ${#names[@]} == 0 )); then
+    echo "wasmbench.sh: no benchmarks selected" >&2
+    exit 2
+fi
+
+# json_parse reads a generated fixture; make sure it exists before the gate
+# runs, or every implementation fails identically and the row looks fine.
+[[ -f "$BENCH/data.json" ]] || python3 "$BENCH/gen_data.py"
+
+# ── run helpers ──────────────────────────────────────────────────
+# Every wasm run gets `--dir .` — json_parse needs a preopen and the others
+# pay the same cost, so the column stays internally comparable.
+#
+# `-C cache=n` turns off the reference runtime's on-disk compiled-module
+# cache, which its CLI enables by default. Leaving it on makes a cell mean
+# two different things depending on whether ~/.cache/wasmtime already holds
+# that module: here the first rep would pay Cranelift and the rest would
+# not, so the median silently reported a *warm* number while the floor row
+# — measured once — could still be a cold one. Ratios computed across that
+# boundary are nonsense (a benchmark came out ten times *faster* than its
+# own empty program). With the cache off, every reference cell is
+# decode + compile + run, exactly like every `wt` cell, both runtimes are
+# measured doing the same work, and the floor row subtracts cleanly.
+#
+# These are argv prefixes rather than shell functions on purpose: time_ms
+# runs its command under `timeout`, which execs a real binary and cannot see
+# a function defined in this shell.
+REF_RUN=("$WASMTIME" run -C cache=n --dir .)
+WT_RUN=("$WT" run --dir .)
+
+# ── process-start-up floor ───────────────────────────────────────
+# What each cell costs for a program that does nothing. On the two wasm
+# columns this is not a small number and not a constant one: the reference
+# runtime JIT-compiles the whole module before `_start`, and the interpreter
+# decodes it — and a NURL "empty" module still links the entire runtime, so
+# its floor is the floor of a ~1 MB module. Subtract the floor to read the
+# marginal cost of the benchmark itself.
+floor_dir="$BUILD/floor"
+mkdir -p "$floor_dir"
+printf '@ main → i {\n    ^ 0\n}\n'      > "$floor_dir/floor.nu"
+printf 'int main(void) { return 0; }\n'  > "$floor_dir/floor.c"
+printf 'fn main() {}\n'                  > "$floor_dir/floor.rs"
+
+echo "  measuring the floor …" >&2
+read -r floor_cc_nurl_fe floor_cc_nurl <<<"$(compile_nurl_native "$floor_dir/floor.nu" "$floor_dir/floor")"
+floor_cc_nurl_wasm="$(compile_nurl_wasm "$floor_dir/floor.nu" "$floor_dir/floor")"
+floor_cc_nurl_wasm_gc="$(compile_nurl_wasm_gc "$floor_dir/floor.nu" "$floor_dir/floor")"
+floor_cc_c="$(compile_c_native "$floor_dir/floor.c" "$floor_dir/floor")"
+floor_cc_c_wasm="$(compile_c_wasm "$floor_dir/floor.c" "$floor_dir/floor")"
+floor_cc_rust="$(compile_rust_native "$floor_dir/floor.rs" "$floor_dir/floor")"
+floor_cc_rust_wasm="$(compile_rust_wasm "$floor_dir/floor.rs" "$floor_dir/floor")"
+
+read -r floor_nurl _      <<<"$(cd "$ROOT" && time_cell "$floor_dir/floor.nurl.bin")"
+read -r floor_c _         <<<"$(cd "$ROOT" && time_cell "$floor_dir/floor.c.bin")"
+read -r floor_rust _      <<<"$(cd "$ROOT" && time_cell "$floor_dir/floor.rs.bin")"
+read -r floor_nurl_ref _  <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$floor_dir/floor.nu.wasm")"
+read -r floor_nurl_ref_gc _ <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$floor_dir/floor.nugc.wasm")"
+read -r floor_c_ref _     <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$floor_dir/floor.c.wasm")"
+read -r floor_rust_ref _  <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$floor_dir/floor.rs.wasm")"
+read -r floor_nurl_wt _   <<<"$(cd "$ROOT" && time_cell "${WT_RUN[@]}" "$floor_dir/floor.nu.wasm")"
+if (( WT_ALL_LANGS )); then
+    read -r floor_c_wt _    <<<"$(cd "$ROOT" && time_cell "${WT_RUN[@]}" "$floor_dir/floor.c.wasm")"
+    read -r floor_rust_wt _ <<<"$(cd "$ROOT" && time_cell "${WT_RUN[@]}" "$floor_dir/floor.rs.wasm")"
+else
+    floor_c_wt=SKIPPED; floor_rust_wt=SKIPPED
+fi
+
+# ── measure ──────────────────────────────────────────────────────
+# Per-benchmark results as parallel arrays, in manifest order.
+r_checksum=(); r_verified=(); r_detail=()
+r_nurl=(); r_c=(); r_rust=()
+r_nurl_ref=(); r_c_ref=(); r_rust_ref=()
+r_nurl_wt=(); r_c_wt=(); r_rust_wt=()
+r_nurl_reps=(); r_c_reps=(); r_rust_reps=()
+r_nurl_ref_reps=(); r_c_ref_reps=(); r_rust_ref_reps=()
+r_nurl_wt_reps=(); r_c_wt_reps=(); r_rust_wt_reps=()
+r_cc_nurl_fe=(); r_cc_nurl=(); r_cc_nurl_wasm=()
+r_cc_c=(); r_cc_c_wasm=(); r_cc_rust=(); r_cc_rust_wasm=()
+r_sz_nurl=(); r_sz_nurl_wasm=(); r_sz_c=(); r_sz_c_wasm=(); r_sz_rust=(); r_sz_rust_wasm=()
+# the --gc-sections variant of the NURL module (section 5)
+r_cc_nurl_wasm_gc=(); r_sz_nurl_wasm_gc=(); r_nurl_ref_gc=(); r_nurl_ref_gc_reps=()
+
+progress() { printf '\r\033[K  %-18s %s' "$1" "$2" >&2; }
+
+for idx in "${!names[@]}"; do
+    b="${names[$idx]}"
+
+    progress "$b" "compiling native…"
+    read -r cc_fe cc_nurl <<<"$(compile_nurl_native "$BENCH/$b.nu" "$BUILD/$b")"
+    cc_c="$(compile_c_native "$BENCH/$b.c" "$BUILD/$b")"
+    cc_rust="$(compile_rust_native "$BENCH/$b.rs" "$BUILD/$b")"
+    progress "$b" "compiling wasm…"
+    cc_nurl_wasm="$(compile_nurl_wasm "$BENCH/$b.nu" "$BUILD/$b")"
+    cc_nurl_wasm_gc="$(compile_nurl_wasm_gc "$BENCH/$b.nu" "$BUILD/$b")"
+    cc_c_wasm="$(compile_c_wasm "$BENCH/$b.c" "$BUILD/$b")"
+    cc_rust_wasm="$(compile_rust_wasm "$BENCH/$b.rs" "$BUILD/$b")"
+    r_cc_nurl_fe+=("${cc_fe:-FAIL}"); r_cc_nurl+=("${cc_nurl:-FAIL}")
+    r_cc_nurl_wasm+=("$cc_nurl_wasm"); r_cc_nurl_wasm_gc+=("$cc_nurl_wasm_gc")
+    r_cc_c+=("$cc_c"); r_cc_c_wasm+=("$cc_c_wasm")
+    r_cc_rust+=("$cc_rust"); r_cc_rust_wasm+=("$cc_rust_wasm")
+
+    r_sz_nurl+=("$(fsize "$BUILD/$b.nurl.bin")")
+    r_sz_nurl_wasm+=("$(fsize "$BUILD/$b.nu.wasm")")
+    r_sz_nurl_wasm_gc+=("$(fsize "$BUILD/$b.nugc.wasm")")
+    r_sz_c+=("$(fsize "$BUILD/$b.c.bin")")
+    r_sz_c_wasm+=("$(fsize "$BUILD/$b.c.wasm")")
+    r_sz_rust+=("$(fsize "$BUILD/$b.rs.bin")")
+    r_sz_rust_wasm+=("$(fsize "$BUILD/$b.rs.wasm")")
+
+    # ── the gate ──
+    # Ten cells, one expected line. The native NURL output is the reference
+    # the other nine are compared against; the interpreter is included in
+    # the gate, so a wrong answer from `wt` drops the row rather than being
+    # reported as a fast cell.
+    progress "$b" "verifying native + JIT…"
+    out_nurl="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "$BUILD/$b.nurl.bin" 2>/dev/null)"
+    out_c="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "$BUILD/$b.c.bin" 2>/dev/null)"
+    out_rust="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "$BUILD/$b.rs.bin" 2>/dev/null)"
+    out_nurl_ref="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${REF_RUN[@]}" "$BUILD/$b.nu.wasm" 2>/dev/null)"
+    out_c_ref="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${REF_RUN[@]}" "$BUILD/$b.c.wasm" 2>/dev/null)"
+    out_rust_ref="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${REF_RUN[@]}" "$BUILD/$b.rs.wasm" 2>/dev/null)"
+    out_nurl_ref_gc="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${REF_RUN[@]}" "$BUILD/$b.nugc.wasm" 2>/dev/null)"
+
+    progress "$b" "verifying interpreter…"
+    out_nurl_wt="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${WT_RUN[@]}" "$BUILD/$b.nu.wasm" 2>/dev/null)"
+    if (( WT_ALL_LANGS )); then
+        out_c_wt="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${WT_RUN[@]}" "$BUILD/$b.c.wasm" 2>/dev/null)"
+        out_rust_wt="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${WT_RUN[@]}" "$BUILD/$b.rs.wasm" 2>/dev/null)"
+    else
+        out_c_wt="$out_nurl"; out_rust_wt="$out_nurl"   # not run: excluded from the gate
+    fi
+
+    verified=true; detail=""
+    for pair in "NURL:$out_nurl" "C:$out_c" "Rust:$out_rust" \
+                "NURL/wasm:$out_nurl_ref" "C/wasm:$out_c_ref" "Rust/wasm:$out_rust_ref" \
+                "NURL/wasm+gc:$out_nurl_ref_gc" \
+                "NURL/wt:$out_nurl_wt" "C/wt:$out_c_wt" "Rust/wt:$out_rust_wt"; do
+        lang="${pair%%:*}"; got="${pair#*:}"
+        # An empty line fails the gate even when every cell agrees on it:
+        # nine programs that all printed nothing agree about nothing.
+        if [[ "$got" != "$out_nurl" || -z "$got" ]]; then
+            verified=false
+            detail="$detail${detail:+, }$lang=${got:-<empty>}"
+        fi
+    done
+    [[ -n "$detail" ]] || detail="all ten cells printed ${out_nurl:-<empty>}"
+    r_checksum+=("$out_nurl"); r_verified+=("$verified"); r_detail+=("$detail")
+
+    if [[ "$verified" != true ]]; then
+        printf '\r\033[K  %-18s MISMATCH — %s\n' "$b" "$detail" >&2
+        r_nurl+=(SKIPPED); r_c+=(SKIPPED); r_rust+=(SKIPPED)
+        r_nurl_ref+=(SKIPPED); r_c_ref+=(SKIPPED); r_rust_ref+=(SKIPPED)
+        r_nurl_wt+=(SKIPPED); r_c_wt+=(SKIPPED); r_rust_wt+=(SKIPPED)
+        r_nurl_ref_gc+=(SKIPPED); r_nurl_ref_gc_reps+=(0)
+        r_nurl_reps+=(0); r_c_reps+=(0); r_rust_reps+=(0)
+        r_nurl_ref_reps+=(0); r_c_ref_reps+=(0); r_rust_ref_reps+=(0)
+        r_nurl_wt_reps+=(0); r_c_wt_reps+=(0); r_rust_wt_reps+=(0)
+        continue
+    fi
+
+    progress "$b" "timing NURL native…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "$BUILD/$b.nurl.bin")"
+    r_nurl+=("$ms"); r_nurl_reps+=("$reps")
+    progress "$b" "timing C native…";    read -r ms reps <<<"$(cd "$ROOT" && time_cell "$BUILD/$b.c.bin")"
+    r_c+=("$ms"); r_c_reps+=("$reps")
+    progress "$b" "timing Rust native…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "$BUILD/$b.rs.bin")"
+    r_rust+=("$ms"); r_rust_reps+=("$reps")
+
+    progress "$b" "timing NURL wasm (JIT)…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$BUILD/$b.nu.wasm")"
+    r_nurl_ref+=("$ms"); r_nurl_ref_reps+=("$reps")
+    progress "$b" "timing C wasm (JIT)…";    read -r ms reps <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$BUILD/$b.c.wasm")"
+    r_c_ref+=("$ms"); r_c_ref_reps+=("$reps")
+    progress "$b" "timing Rust wasm (JIT)…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$BUILD/$b.rs.wasm")"
+    r_rust_ref+=("$ms"); r_rust_ref_reps+=("$reps")
+    progress "$b" "timing NURL wasm+gc (JIT)…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$BUILD/$b.nugc.wasm")"
+    r_nurl_ref_gc+=("$ms"); r_nurl_ref_gc_reps+=("$reps")
+
+    progress "$b" "timing NURL wasm (wt)…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "${WT_RUN[@]}" "$BUILD/$b.nu.wasm")"
+    r_nurl_wt+=("$ms"); r_nurl_wt_reps+=("$reps")
+    if (( WT_ALL_LANGS )); then
+        progress "$b" "timing C wasm (wt)…";    read -r ms reps <<<"$(cd "$ROOT" && time_cell "${WT_RUN[@]}" "$BUILD/$b.c.wasm")"
+        r_c_wt+=("$ms"); r_c_wt_reps+=("$reps")
+        progress "$b" "timing Rust wasm (wt)…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "${WT_RUN[@]}" "$BUILD/$b.rs.wasm")"
+        r_rust_wt+=("$ms"); r_rust_wt_reps+=("$reps")
+    else
+        r_c_wt+=(SKIPPED); r_c_wt_reps+=(0)
+        r_rust_wt+=(SKIPPED); r_rust_wt_reps+=(0)
+    fi
+
+    printf '\r\033[K  %-18s native %8s  jit %8s  wt %10s   (nurl)\n' \
+        "$b" "${r_nurl[$idx]}" "${r_nurl_ref[$idx]}" "${r_nurl_wt[$idx]}" >&2
+done
+printf '\r\033[K' >&2
+
+# ── emit ─────────────────────────────────────────────────────────
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+jstr() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+jnum() { [[ "$1" =~ ^[0-9.]+$ ]] && printf '%s' "$1" || printf 'null'; }
+
+# "how many times slower than the cell to compare against", or an em dash
+# when either end is missing.
+ratio() { awk -v a="$1" -v b="$2" \
+    'BEGIN { if (a ~ /^[0-9.]+$/ && b ~ /^[0-9.]+$/ && b + 0 > 0) printf "%.1f", a / b; else printf "—" }'; }
+# The same, with the floor of each column subtracted first: the marginal
+# cost of the benchmark, with start-up (and, on wasm, module compilation)
+# taken out of both ends.
+#
+# Refuses to print when a floor is more than half of the cell it is being
+# taken out of. Past that point the answer is a difference of two similar
+# numbers and inherits both their errors — the first version of this table
+# reported Rust `prefix_scan` at 0.5x, i.e. wasm running the benchmark
+# twice as fast as the machine did, purely because 17 ms of floor came out
+# of a 29 ms cell. A missing number is honest; that one was not.
+ratio_net() { awk -v a="$1" -v af="$2" -v b="$3" -v bf="$4" 'BEGIN {
+    if (a !~ /^[0-9.]+$/ || b !~ /^[0-9.]+$/ || af !~ /^[0-9.]+$/ || bf !~ /^[0-9.]+$/) { printf "—"; exit }
+    an = a - af; bn = b - bf
+    if (an <= 0 || bn <= 0) { printf "—"; exit }
+    if (an < a / 2 || bn < b / 2) { printf "—"; exit }
+    printf "%.1f", an / bn }'; }
+
+emit_json() {
+    printf '{\n'
+    printf '  "schema": 1,\n'
+    printf '  "kind": "wasm",\n'
+    printf '  "generated_utc": "%s",\n' "$(jstr "$NOW")"
+    printf '  "commit": "%s",\n' "$(jstr "$COMMIT")"
+    printf '  "run_url": "%s",\n' "$(jstr "$RUN_URL")"
+    printf '  "host": {\n'
+    printf '    "label": "%s",\n'  "$(jstr "$HOST_LABEL")"
+    printf '    "kernel": "%s",\n' "$(jstr "$HOST_KERNEL")"
+    printf '    "cpu": "%s",\n'    "$(jstr "$HOST_CPU")"
+    printf '    "cores": %s,\n'    "$(jnum "$HOST_CORES")"
+    printf '    "mem_kb": %s\n'    "$(jnum "$HOST_MEM_KB")"
+    printf '  },\n'
+    printf '  "toolchains": {\n'
+    printf '    "nurl": "%s",\n'        "$(jstr "$NURL_VERSION")"
+    printf '    "clang": "%s",\n'       "$(jstr "$CLANG_VERSION")"
+    printf '    "rustc": "%s",\n'       "$(jstr "$RUSTC_VERSION")"
+    printf '    "zig": "%s",\n'         "$(jstr "$ZIG_VERSION")"
+    printf '    "wasmbuilder": "%s",\n' "$(jstr "$WASMBUILDER_VERSION")"
+    printf '    "wasmtime_ref": "%s",\n' "$(jstr "$WASMTIME_VERSION")"
+    printf '    "wasmtime_nurl": "%s"\n' "$(jstr "$WT_VERSION")"
+    printf '  },\n'
+    printf '  "settings": {\n'
+    printf '    "opt": "%s",\n' "$(jstr "$OPT")"
+    printf '    "wasm_target_c": "%s",\n' "$(jstr "$WASM_TARGET_C")"
+    printf '    "wasm_target_rust": "%s",\n' "$(jstr "$WASM_TARGET_RS")"
+    printf '    "max_reps": %s,\n' "$MAX_REPS"
+    printf '    "budget_ms": %s,\n' "$BUDGET_MS"
+    printf '    "timeout_s": %s,\n' "$TIMEOUT_S"
+    printf '    "compile_reps": %s,\n' "$COMPILE_REPS"
+    printf '    "interpreter_all_languages": %s\n' "$( (( WT_ALL_LANGS )) && echo true || echo false )"
+    printf '  },\n'
+    printf '  "floor_ms": {\n'
+    printf '    "native": { "nurl": %s, "c": %s, "rust": %s },\n' \
+        "$(jnum "$floor_nurl")" "$(jnum "$floor_c")" "$(jnum "$floor_rust")"
+    printf '    "wasm_ref": { "nurl": %s, "c": %s, "rust": %s, "nurl_gc_sections": %s },\n' \
+        "$(jnum "$floor_nurl_ref")" "$(jnum "$floor_c_ref")" "$(jnum "$floor_rust_ref")" \
+        "$(jnum "$floor_nurl_ref_gc")"
+    printf '    "wasm_wt": { "nurl": %s, "c": %s, "rust": %s }\n' \
+        "$(jnum "$floor_nurl_wt")" "$(jnum "$floor_c_wt")" "$(jnum "$floor_rust_wt")"
+    printf '  },\n'
+    printf '  "floor_compile_ms": { "nurl_frontend": %s, "nurl_native": %s, "nurl_wasm": %s, "nurl_wasm_gc_sections": %s, "c_native": %s, "c_wasm": %s, "rust_native": %s, "rust_wasm": %s },\n' \
+        "$(jnum "$floor_cc_nurl_fe")" "$(jnum "$floor_cc_nurl")" "$(jnum "$floor_cc_nurl_wasm")" \
+        "$(jnum "$floor_cc_nurl_wasm_gc")" \
+        "$(jnum "$floor_cc_c")" "$(jnum "$floor_cc_c_wasm")" \
+        "$(jnum "$floor_cc_rust")" "$(jnum "$floor_cc_rust_wasm")"
+    printf '  "benchmarks": [\n'
+    local i last=$(( ${#names[@]} - 1 ))
+    for i in "${!names[@]}"; do
+        printf '    {\n'
+        printf '      "name": "%s",\n'     "$(jstr "${names[$i]}")"
+        printf '      "blurb": "%s",\n'    "$(jstr "${blurbs[$i]}")"
+        printf '      "measures": "%s",\n' "$(jstr "${shapes[$i]}")"
+        printf '      "checksum": "%s",\n' "$(jstr "${r_checksum[$i]}")"
+        printf '      "verified": %s,\n'   "${r_verified[$i]}"
+        printf '      "run_ms": {\n'
+        printf '        "native":   { "nurl": %s, "c": %s, "rust": %s },\n' \
+            "$(jnum "${r_nurl[$i]}")" "$(jnum "${r_c[$i]}")" "$(jnum "${r_rust[$i]}")"
+        printf '        "wasm_ref": { "nurl": %s, "c": %s, "rust": %s, "nurl_gc_sections": %s },\n' \
+            "$(jnum "${r_nurl_ref[$i]}")" "$(jnum "${r_c_ref[$i]}")" "$(jnum "${r_rust_ref[$i]}")" \
+            "$(jnum "${r_nurl_ref_gc[$i]}")"
+        printf '        "wasm_wt":  { "nurl": %s, "c": %s, "rust": %s }\n' \
+            "$(jnum "${r_nurl_wt[$i]}")" "$(jnum "${r_c_wt[$i]}")" "$(jnum "${r_rust_wt[$i]}")"
+        printf '      },\n'
+        printf '      "reps": {\n'
+        printf '        "native":   { "nurl": %s, "c": %s, "rust": %s },\n' \
+            "${r_nurl_reps[$i]}" "${r_c_reps[$i]}" "${r_rust_reps[$i]}"
+        printf '        "wasm_ref": { "nurl": %s, "c": %s, "rust": %s, "nurl_gc_sections": %s },\n' \
+            "${r_nurl_ref_reps[$i]}" "${r_c_ref_reps[$i]}" "${r_rust_ref_reps[$i]}" \
+            "${r_nurl_ref_gc_reps[$i]}"
+        printf '        "wasm_wt":  { "nurl": %s, "c": %s, "rust": %s }\n' \
+            "${r_nurl_wt_reps[$i]}" "${r_c_wt_reps[$i]}" "${r_rust_wt_reps[$i]}"
+        printf '      },\n'
+        printf '      "compile_ms": { "nurl_frontend": %s, "nurl_native": %s, "nurl_wasm": %s, "nurl_wasm_gc_sections": %s, "c_native": %s, "c_wasm": %s, "rust_native": %s, "rust_wasm": %s },\n' \
+            "$(jnum "${r_cc_nurl_fe[$i]}")" "$(jnum "${r_cc_nurl[$i]}")" "$(jnum "${r_cc_nurl_wasm[$i]}")" \
+            "$(jnum "${r_cc_nurl_wasm_gc[$i]}")" \
+            "$(jnum "${r_cc_c[$i]}")" "$(jnum "${r_cc_c_wasm[$i]}")" \
+            "$(jnum "${r_cc_rust[$i]}")" "$(jnum "${r_cc_rust_wasm[$i]}")"
+        printf '      "bytes": { "nurl_native": %s, "nurl_wasm": %s, "nurl_wasm_gc_sections": %s, "c_native": %s, "c_wasm": %s, "rust_native": %s, "rust_wasm": %s }\n' \
+            "${r_sz_nurl[$i]}" "${r_sz_nurl_wasm[$i]}" "${r_sz_nurl_wasm_gc[$i]}" \
+            "${r_sz_c[$i]}" "${r_sz_c_wasm[$i]}" \
+            "${r_sz_rust[$i]}" "${r_sz_rust_wasm[$i]}"
+        printf '    }%s\n' "$( (( i < last )) && echo ',' )"
+    done
+    printf '  ]\n'
+    printf '}\n'
+}
+
+kib() { awk -v b="$1" 'BEGIN { if (b + 0 > 0) printf "%.0f", b / 1024; else printf "—" }'; }
+
+# Signed percentage change from <before> to <after>, e.g. "−23 %".
+pct() { awk -v a="$1" -v b="$2" 'BEGIN {
+    if (a !~ /^[0-9.]+$/ || b !~ /^[0-9.]+$/ || a + 0 <= 0) { printf "—"; exit }
+    d = (b - a) * 100 / a
+    printf "%s%.0f %%", (d > 0 ? "+" : (d < 0 ? "−" : "")), (d < 0 ? -d : d) }'; }
+
+emit_md() {
+    printf '# WebAssembly benchmark results — NURL native vs NURL wasm\n\n'
+    printf 'Generated `%s` by `bench/wasmbench.sh`. **Do not edit by hand** —\n' "$NOW"
+    printf 'the next run overwrites it. The machine-readable form of this same run\n'
+    printf 'is [`results/wasm-latest.json`](results/wasm-latest.json).\n\n'
+    printf 'This is the sibling of [`RESULTS.md`](RESULTS.md): same corpus, same\n'
+    printf 'protocol, one axis rotated. `RESULTS.md` asks how fast NURL is against\n'
+    printf 'four other languages; this file asks what **targeting wasm** costs, and\n'
+    printf "what running that wasm on **NURL's own runtime** costs. Every benchmark\n"
+    printf 'is compiled to a native binary *and* a `wasm32-wasi` module in three\n'
+    printf 'languages, and each module is run on two runtimes — ten timed cells per\n'
+    printf 'row, all gated on printing the same line (section 7).\n\n'
+
+    printf '## Environment\n\n| Item | Value |\n|---|---|\n'
+    printf '| Host | `%s` |\n' "$HOST_LABEL"
+    printf '| Kernel | `%s` |\n' "$HOST_KERNEL"
+    printf '| CPU | %s (%s logical cores) |\n' "$HOST_CPU" "$HOST_CORES"
+    printf '| Memory | %s KiB |\n' "$HOST_MEM_KB"
+    printf '| Commit | `%s` |\n' "$COMMIT"
+    [[ -n "$RUN_URL" ]] && printf '| CI run | %s |\n' "$RUN_URL"
+    printf '| NURL | `%s` |\n' "$NURL_VERSION"
+    printf '| C | %s |\n' "$CLANG_VERSION"
+    printf '| Rust | %s |\n' "$RUSTC_VERSION"
+    printf '\n'
+    printf '| Component | Value |\n|---|---|\n'
+    printf '| NURL → wasm | `packages/wasmbuilder` (%s), built from this repo |\n' "$WASMBUILDER_VERSION"
+    printf '| C → wasm | `%s cc --target=%s` |\n' "$ZIG_VERSION" "$WASM_TARGET_C"
+    printf '| Rust → wasm | `rustc --target %s` |\n' "$WASM_TARGET_RS"
+    printf '| wasm runtime (reference) | `%s` — Cranelift JIT |\n' "$WASMTIME_VERSION"
+    printf '| wasm runtime (NURL) | `packages/wasmtime` (%s) — interpreter, built from this repo |\n' "$WT_VERSION"
+    printf '\n'
+    printf '| Setting | Value |\n|---|---|\n'
+    printf '| Optimisation | NURL/C `%s`, Rust `-C opt-level=2`, both targets |\n' "$OPT"
+    printf '| Timed runs per cell | up to %s, adaptive: as many as fit in %s ms |\n' "$MAX_REPS" "$BUDGET_MS"
+    printf '| Timed compiles per cell | %s (median) |\n' "$COMPILE_REPS"
+    printf '| Per-run timeout | %s s |\n' "$TIMEOUT_S"
+    printf '| C/Rust on the NURL interpreter | %s |\n' "$( (( WT_ALL_LANGS )) && echo 'yes' || echo 'no (add --wt-all-langs)' )"
+    printf '| Reference runtime cache | **off** (`-C cache=n`) — every cell is decode + compile + run |\n'
+    printf '\n'
+
+    printf '## 1. What wasm costs — native vs the same module on a JIT\n\n'
+    printf 'Whole-process wall clock in milliseconds, start-up included. The `x`\n'
+    printf 'columns are wasm ÷ native for that language: how much slower the *same\n'
+    printf 'source* got by being compiled to wasm and run under a JIT instead of\n'
+    printf 'straight to the machine. Because all three languages appear, the column\n'
+    printf 'answers a question a NURL-only table could not: whether a gap belongs to\n'
+    printf "NURL's wasm pipeline or to wasm itself.\n\n"
+    printf '| Benchmark | NURL native | NURL wasm | x | C native | C wasm | x | Rust native | Rust wasm | x |\n'
+    printf '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n'
+    printf '| _(floor: empty program)_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ |\n' \
+        "$floor_nurl" "$floor_nurl_ref" "$(ratio "$floor_nurl_ref" "$floor_nurl")" \
+        "$floor_c" "$floor_c_ref" "$(ratio "$floor_c_ref" "$floor_c")" \
+        "$floor_rust" "$floor_rust_ref" "$(ratio "$floor_rust_ref" "$floor_rust")"
+    local i
+    for i in "${!names[@]}"; do
+        printf '| `%s` | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' "${names[$i]}" \
+            "${r_nurl[$i]}" "${r_nurl_ref[$i]}" "$(ratio "${r_nurl_ref[$i]}" "${r_nurl[$i]}")" \
+            "${r_c[$i]}" "${r_c_ref[$i]}" "$(ratio "${r_c_ref[$i]}" "${r_c[$i]}")" \
+            "${r_rust[$i]}" "${r_rust_ref[$i]}" "$(ratio "${r_rust_ref[$i]}" "${r_rust[$i]}")"
+    done
+    printf '\n'
+    printf 'The floor row matters more here than in `RESULTS.md`. A wasm cell pays\n'
+    printf 'for the runtime compiling the whole module before `_start` runs, and a\n'
+    printf 'NURL module links the entire NURL runtime whatever the program does — so\n'
+    printf 'even the empty program is a ~1 MB module to JIT. Section 2 subtracts that\n'
+    printf 'floor from both ends to show the steady-state ratio.\n\n'
+
+    printf '## 2. The same ratios, with start-up subtracted\n\n'
+    printf 'Cell minus the floor of its own column, wasm ÷ native. This is the\n'
+    printf 'number to quote for a long-running program, where module compilation is\n'
+    printf 'amortised to nothing; section 1 is the number to quote for a short one,\n'
+    printf 'where it is most of the run.\n\n'
+    printf 'A `—` means the subtraction has no signal left in it: the floor is more\n'
+    printf 'than half of that cell, so the remainder is a difference of two similar\n'
+    printf 'numbers carrying both their errors. That is not a rare edge case in the\n'
+    printf "**NURL x** column — a 1 MB module's compilation is comparable to the\n"
+    printf 'benchmarks themselves, which is exactly why the `+gc` column beside it\n'
+    printf 'exists: the same NURL programs linked with `--gc-sections` (section 5)\n'
+    printf 'have a floor small enough to subtract cleanly, so they are where the\n'
+    printf "steady-state throughput of NURL's wasm can actually be read.\n\n"
+    printf '| Benchmark | NURL x | NURL +gc x | C x | Rust x |\n|---|---:|---:|---:|---:|\n'
+    for i in "${!names[@]}"; do
+        printf '| `%s` | %s | %s | %s | %s |\n' "${names[$i]}" \
+            "$(ratio_net "${r_nurl_ref[$i]}" "$floor_nurl_ref" "${r_nurl[$i]}" "$floor_nurl")" \
+            "$(ratio_net "${r_nurl_ref_gc[$i]}" "$floor_nurl_ref_gc" "${r_nurl[$i]}" "$floor_nurl")" \
+            "$(ratio_net "${r_c_ref[$i]}" "$floor_c_ref" "${r_c[$i]}" "$floor_c")" \
+            "$(ratio_net "${r_rust_ref[$i]}" "$floor_rust_ref" "${r_rust[$i]}" "$floor_rust")"
+    done
+    printf '\n'
+
+    printf '## 3. The pure-NURL runtime (`packages/wasmtime`)\n\n'
+    printf 'The identical modules from section 1, executed by an interpreter written\n'
+    printf 'in NURL instead of by a JIT written in Rust. `vs JIT` is the cost of the\n'
+    printf 'runtime; `vs native` is the end-to-end cost of choosing this way to ship.\n'
+    printf 'Losing orders of magnitude to a JIT is the shape an interpreter has; the\n'
+    printf 'point of the column is that the size of the gap is measured rather than\n'
+    printf 'assumed, per benchmark, so it can be aimed at.\n\n'
+    printf 'Read the floor row first, because it goes the other way: on a program\n'
+    printf 'that does nothing the interpreter *beats* the JIT. Nothing surprising is\n'
+    printf 'happening — the JIT compiles the whole module before `_start`, and the\n'
+    printf 'interpreter only decodes it and walks the handful of instructions that\n'
+    printf 'run. That crossover is the honest answer to "which runtime should I\n'
+    printf 'use": it depends entirely on how long the guest runs.\n\n'
+    printf '| Benchmark | NURL on `wt` | vs JIT | vs native | C on `wt` | Rust on `wt` |\n'
+    printf '|---|---:|---:|---:|---:|---:|\n'
+    printf '| _(floor: empty program)_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ |\n' \
+        "$floor_nurl_wt" "$(ratio "$floor_nurl_wt" "$floor_nurl_ref")" \
+        "$(ratio "$floor_nurl_wt" "$floor_nurl")" "$floor_c_wt" "$floor_rust_wt"
+    for i in "${!names[@]}"; do
+        printf '| `%s` | %s | %s | %s | %s | %s |\n' "${names[$i]}" \
+            "${r_nurl_wt[$i]}" \
+            "$(ratio "${r_nurl_wt[$i]}" "${r_nurl_ref[$i]}")" \
+            "$(ratio "${r_nurl_wt[$i]}" "${r_nurl[$i]}")" \
+            "${r_c_wt[$i]}" "${r_rust_wt[$i]}"
+    done
+    printf '\n'
+    if (( WT_ALL_LANGS )); then
+        printf 'The C and Rust columns are the control. They are modules this runtime\n'
+        printf 'never saw during development, emitted by two other LLVM frontends; that\n'
+        printf 'they run at all is a correctness result, and that they run at a similar\n'
+        printf 'ratio says the interpreter has no NURL-shaped fast path.\n\n'
+    else
+        printf 'The C and Rust columns are `SKIPPED`: they are the cross-frontend\n'
+        printf 'control — modules this runtime never saw during development, from two\n'
+        printf 'other LLVM frontends — and running them costs about three times the\n'
+        printf 'whole rest of the suite, so they are opt-in. `--wt-all-langs` fills\n'
+        printf 'them in. Until it is run, this section says what the interpreter does\n'
+        printf 'with NURL output and nothing about whether it is tuned for it.\n\n'
+    fi
+
+    printf '## 4. Artefact size (KiB)\n\n'
+    printf 'A wasm module carries its own copy of everything it links — wasi-libc,\n'
+    printf 'the language runtime — where a native binary borrows the system one.\n'
+    printf 'These are the bytes that have to be shipped, and (for the two runtimes\n'
+    printf 'above) parsed before the program starts.\n\n'
+    printf '| Benchmark | NURL native | NURL wasm | C native | C wasm | Rust native | Rust wasm |\n'
+    printf '|---|---:|---:|---:|---:|---:|---:|\n'
+    for i in "${!names[@]}"; do
+        printf '| `%s` | %s | %s | %s | %s | %s | %s |\n' "${names[$i]}" \
+            "$(kib "${r_sz_nurl[$i]}")" "$(kib "${r_sz_nurl_wasm[$i]}")" \
+            "$(kib "${r_sz_c[$i]}")" "$(kib "${r_sz_c_wasm[$i]}")" \
+            "$(kib "${r_sz_rust[$i]}")" "$(kib "${r_sz_rust_wasm[$i]}")"
+    done
+    printf '\n'
+
+    printf '## 5. Dead code — what `--gc-sections` costs and buys\n\n'
+    printf 'Every NURL module above was linked with `-Wl,--no-gc-sections`, the\n'
+    printf 'default `wasmbuilder` ships. NURL closures store **function-table indices**\n'
+    printf 'and section GC renumbers that table, so a closure captured before the\n'
+    printf 'collection can call the wrong function after it — a run-time\n'
+    printf '`call_indirect` trap with no link error to warn anyone. The cost of that\n'
+    printf 'default is that most of the NURL runtime ships in, and is translated by\n'
+    printf 'the runtime, in every module that never calls it.\n\n'
+    printf 'These rows are the same benchmarks rebuilt with `--gc-sections`, run on\n'
+    printf 'the reference runtime, and held to the same output — none of them uses a\n'
+    printf 'closure, so the hazard does not apply and the saving is measurable.\n\n'
+    printf '| Benchmark | Size | Size +gc | Δ | JIT | JIT +gc | Δ |\n'
+    printf '|---|---:|---:|---:|---:|---:|---:|\n'
+    printf '| _(floor: empty program)_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ |\n' \
+        "$(kib "$(fsize "$floor_dir/floor.nu.wasm")")" "$(kib "$(fsize "$floor_dir/floor.nugc.wasm")")" \
+        "$(pct "$(fsize "$floor_dir/floor.nu.wasm")" "$(fsize "$floor_dir/floor.nugc.wasm")")" \
+        "$floor_nurl_ref" "$floor_nurl_ref_gc" "$(pct "$floor_nurl_ref" "$floor_nurl_ref_gc")"
+    for i in "${!names[@]}"; do
+        printf '| `%s` | %s | %s | %s | %s | %s | %s |\n' "${names[$i]}" \
+            "$(kib "${r_sz_nurl_wasm[$i]}")" "$(kib "${r_sz_nurl_wasm_gc[$i]}")" \
+            "$(pct "${r_sz_nurl_wasm[$i]}" "${r_sz_nurl_wasm_gc[$i]}")" \
+            "${r_nurl_ref[$i]}" "${r_nurl_ref_gc[$i]}" \
+            "$(pct "${r_nurl_ref[$i]}" "${r_nurl_ref_gc[$i]}")"
+    done
+    printf '\n'
+    printf 'The saving is almost all fixed cost, so it is largest where the benchmark\n'
+    printf 'itself is smallest — compare each row against the floor. It is reported\n'
+    printf 'on the JIT and not on the interpreter because the interpreter is\n'
+    printf 'execution-bound, not decode-bound: its floor row in section 3 is a few\n'
+    printf 'tens of milliseconds against cells in the tens of *seconds*, so shrinking\n'
+    printf 'the module cannot move it. This is a real optimisation, and what stands\n'
+    printf 'between it and being the default is making closure function-table indices\n'
+    printf 'survive renumbering — not the linker flag.\n\n'
+
+    printf '## 6. Compile time (median, ms)\n\n'
+    printf 'The NURL wasm build is `wasmbuilder`: `nurlc` emits host LLVM IR, the IR\n'
+    printf 'rewriter retargets it for `wasm32-wasi`, and the toolchain-bundled\n'
+    printf '`zig cc` links it against wasi-libc and a cached `runtime.wasm.o`. The\n'
+    printf 'column is the whole pipeline, comparable to the NURL native total beside\n'
+    printf 'it and to the C and Rust wasm columns.\n\n'
+    printf '| Benchmark | NURL `nurlc` | NURL native | NURL wasm | C native | C wasm | Rust native | Rust wasm |\n'
+    printf '|---|---:|---:|---:|---:|---:|---:|---:|\n'
+    printf '| _(floor: empty program)_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ |\n' \
+        "$floor_cc_nurl_fe" "$floor_cc_nurl" "$floor_cc_nurl_wasm" \
+        "$floor_cc_c" "$floor_cc_c_wasm" "$floor_cc_rust" "$floor_cc_rust_wasm"
+    for i in "${!names[@]}"; do
+        printf '| `%s` | %s | %s | %s | %s | %s | %s | %s |\n' "${names[$i]}" \
+            "${r_cc_nurl_fe[$i]}" "${r_cc_nurl[$i]}" "${r_cc_nurl_wasm[$i]}" \
+            "${r_cc_c[$i]}" "${r_cc_c_wasm[$i]}" "${r_cc_rust[$i]}" "${r_cc_rust_wasm[$i]}"
+    done
+    printf '\n'
+
+    printf '## 7. Correctness gate\n\n'
+    printf 'Each row is timed only when all ten cells print the same line as the\n'
+    printf 'native NURL binary. The interpreter is inside the gate, not beside it:\n'
+    printf 'a runtime that gets the wrong answer quickly is not a fast runtime.\n\n'
+    printf '| Benchmark | Output | Verdict |\n|---|---|---|\n'
+    for i in "${!names[@]}"; do
+        if [[ "${r_verified[$i]}" == true ]]; then
+            printf '| `%s` | `%s` | identical: 3 languages x {native, JIT%s}, + NURL wasm `--gc-sections` |\n' \
+                "${names[$i]}" "${r_checksum[$i]}" \
+                "$( (( WT_ALL_LANGS )) && echo ', interpreter' || echo ', interpreter (NURL only)' )"
+        else
+            printf '| `%s` | — | **MISMATCH** — %s |\n' "${names[$i]}" "${r_detail[$i]}"
+        fi
+    done
+    printf '\n'
+
+    printf '## 8. Reading the numbers\n\n'
+    printf '* Sections 1 and 3 are whole-process wall clock, so a cell near its\n'
+    printf "  column's floor is mostly start-up — and on wasm, start-up includes the\n"
+    printf '  runtime ingesting the module. Section 2 is where the steady-state\n'
+    printf '  throughput ratio lives.\n'
+    printf '* Every cell in a row computes the same thing, but not necessarily with\n'
+    printf '  the same machine code. LLVM optimises for wasm and for x86-64\n'
+    printf '  differently: wasm has no flags register, no `cmov`, and a JIT compiling\n'
+    printf '  at load time cannot spend the time an offline `-O2` does. A ratio above\n'
+    printf '  1 is that difference, not lost work.\n'
+    printf '* The three languages share a corpus but not a runtime. A NURL module\n'
+    printf "  carries NURL's allocator and string machinery; a Rust module carries\n"
+    printf "  Rust's; a C module carries almost nothing. Section 4 is that difference\n"
+    printf '  in bytes, and part of the floor row is the same difference in time.\n'
+    printf "* The reference runtime's compiled-module cache is off. Its CLI enables\n"
+    printf '  that cache by default, which would make a cell mean "Cranelift ran" or\n'
+    printf '  "Cranelift did not run" depending on what happened to be in\n'
+    printf '  `~/.cache/wasmtime` — including across the floor row, whose whole job is\n'
+    printf '  to be subtracted from the others. Off, both runtimes are measured doing\n'
+    printf '  the same work: read the module, translate it, run it. A deployment that\n'
+    printf '  keeps the cache (or precompiles with `wasmtime compile`) pays the floor\n'
+    printf '  once instead of every run — section 2 is the number that survives that.\n'
+    printf '* `json_parse` reads `bench/data.json`, so every wasm run gets a `--dir .`\n'
+    printf '  preopen. The other rows pay the same preopen cost and need nothing from\n'
+    printf '  it, which keeps the column internally comparable.\n'
+    printf '* Wall clock on a machine that was not quiesced drifts a few per cent\n'
+    printf '  between runs, and more on a shared CI runner. Compare deltas between\n'
+    printf '  runs of the same workflow, not absolutes across machines.\n'
+}
+
+if (( WRITE )); then
+    mkdir -p "$(dirname "$JSON_OUT")" "$(dirname "$MD_OUT")"
+    emit_json > "$JSON_OUT"
+    emit_md   > "$MD_OUT"
+    echo "wrote $JSON_OUT"
+    echo "wrote $MD_OUT"
+else
+    emit_md
+fi
+
+# A mismatched row is a failure of the suite, not a slow benchmark.
+for v in "${r_verified[@]}"; do
+    [[ "$v" == true ]] || { echo "wasmbench.sh: at least one row failed the correctness gate" >&2; exit 1; }
+done

--- a/packages/wasmbuilder/README.md
+++ b/packages/wasmbuilder/README.md
@@ -54,20 +54,49 @@ and fail instead.
 ```
 wasmbuilder <file.nu> [options]
 
-  -o, --output FILE      output path (default: <input>.wasm)
-  -O, --opt LEVEL        0..3 or z (default 2; z = size)
-      --emit-ll          keep the rewritten wasm32 .ll next to the output
-      --asyncify         wasm-opt asyncify wrap for canvas programs
-                         (needs binaryen's wasm-opt on PATH)
-      --no-host-imports  don't pass --ffi-host-imports to nurlc
-  -q, --quiet            suppress progress output
-      --doctor           show how nurlc / zig / runtime resolve here
+  -o, --output FILE        output path (default: <input>.wasm)
+  -O, --opt LEVEL          0..3 or z (default 2; z = size)
+      --emit-ll            keep the rewritten wasm32 .ll next to the output
+      --asyncify           wasm-opt asyncify wrap for canvas programs
+                           (needs binaryen's wasm-opt on PATH)
+      --asyncify-imports L comma-separated async import names
+                           (e.g. env.wgpu_download); implies --asyncify
+      --obj FILE           extra wasm object(s) linked in, space-separated
+                           (e.g. a kernels_static.wasm.o, so `& c` symbols
+                           resolve statically instead of becoming imports)
+      --cflags FLAGS       extra compile/link flags, space-separated
+                           (e.g. "-msimd128" for wasm SIMD)
+      --gc-sections        drop unreachable code at link time — see below
+      --no-host-imports    don't pass --ffi-host-imports to nurlc
+  -q, --quiet              suppress progress output
+      --doctor             show how nurlc / zig / runtime resolve here
       --version, -h
 ```
 
 `--doctor` is the first thing to run when something is off — it prints
 each resolution step (nurlc, stdlib C sources, wasm compiler, cache dir)
 and what would happen next.
+
+### `--gc-sections`
+
+Off by default, and the default is not timidity. NURL closures store
+**function-table indices**, and `--gc-sections` renumbers that table, so a
+closure captured before the collection can call the wrong function after
+it — a `call_indirect` trap at run time, with no link error to warn you.
+That was observed on `nurlc.wasm` (>150 functions).
+
+It is worth turning on for a program that uses no closures, because what
+it drops is most of the NURL runtime the module never calls. On
+`bench/lcg.nu` the module goes 1064 KiB → 819 KiB and a reference
+`wasmtime` run goes ~120 ms → ~85 ms, because the runtime no longer
+translates code nothing reaches. [`bench/wasmbench.sh`](../../bench/wasmbench.sh)
+measures both forms of every benchmark and gates them on identical
+output.
+
+The rule is: turn it on, run the program, check the output. Do not
+assume — and note that `--cflags "-Wl,--gc-sections"` is *not* the same
+thing: that appends a flag after the `--no-gc-sections` this builder
+already passes, leaving the outcome to wasm-ld's last-one-wins ordering.
 
 ## Library use (embed the builder)
 

--- a/packages/wasmbuilder/src/build.nu
+++ b/packages/wasmbuilder/src/build.nu
@@ -8,7 +8,14 @@
 // Link flags mirror nurlapi's production /build_wasm handler:
 //   -Wl,--no-gc-sections   NURL closures store function-table indices;
 //                          gc-sections renumbers the table → call_indirect
-//                          traps at scale (proven on nurlc.wasm >150 fns)
+//                          traps at scale (proven on nurlc.wasm >150 fns).
+//                          Opt back in per build with `. opts gc_sections`
+//                          / `--gc-sections` when the program has no
+//                          closures: it is worth ~25 % of the module and
+//                          about as much of a runtime's load time
+//                          (bench/wasmbench.sh measures both). Verify the
+//                          output, do not assume — the failure mode is a
+//                          call_indirect trap at run time, not a link error.
 //   (nurlapi's -Wl,--allow-undefined is replaced by per-declare
 //   "wasm-import-module"="env" IR attributes — zig cc's driver rejects
 //   the linker flag; see wasi_ir.nu. Same semantics: undefined symbols
@@ -47,6 +54,11 @@ $ `toolchain.nu`
     // — e.g. `-msimd128` for wasm SIMD
     s asyncify_imports  // comma-separated async import names (`` = none);
     // e.g. `env.wgpu_download` for the WebGPU backend's async readback
+    b gc_sections  // link with --gc-sections instead of the safe default
+    // --no-gc-sections. Opt-in, and read the note above the link
+    // stage before turning it on: it drops unreachable code (~25 %
+    // off a small module, and as much again off the runtime's
+    // load time) but renumbers the function table.
 }
 
 // Split a space-separated flag string into owned Strings (caller frees).
@@ -76,7 +88,7 @@ $ `toolchain.nu`
 }
 
 @ wb_opts_default → WbOpts {
-    ^ @ WbOpts { `-O2` T F F F `` `` `` }
+    ^ @ WbOpts { `-O2` T F F F `` `` `` F }
 }
 
 @ __wb_say b quiet s msg → v {
@@ -208,8 +220,28 @@ $ `toolchain.nu`
     ? . cc is_zig { ( vec_push [s] args `cc` ) } {}
     ( vec_push [s] args `--target=wasm32-wasi` )
     ( vec_push [s] args . opts opt )
+    // `zig cc` drops -O for LLVM IR inputs. Not for C — `zig cc -O2 -c x.c`
+    // forwards -O2 to cc1 as expected — but for a `.ll` it passes NOTHING
+    // and cc1 defaults to -O0. This pipeline hands zig a `.ll`, so every
+    // wasm module wasmbuilder produced shipped UNOPTIMISED user code: no
+    // mem2reg, so a loop counter stayed a linear-memory load/store pair.
+    // A JIT hides it (Cranelift re-optimises what it is given, so the
+    // reference wasmtime timings barely moved) and an interpreter cannot:
+    // bench/lcg.nu at 1M iterations ran 1.09 s on packages/wasmtime before
+    // this line and 0.20 s after it — 5.5x, from two argv tokens.
+    // `nurl.sh` carries the same workaround for native builds; this is the
+    // wasm side of it. `-Xclang <level>` goes straight to cc1 and survives.
+    ? . cc is_zig { ( vec_push [s] args `-Xclang` ) ( vec_push [s] args . opts opt ) } {}
     ( vec_push [s] args `-Wno-override-module` )
-    ( vec_push [s] args `-Wl,--no-gc-sections` )
+    // Section GC is off by default and opt-in per build, not per flag
+    // string: a caller who passes `-Wl,--gc-sections` through
+    // extra_cflags would be relying on wasm-ld's last-one-wins ordering
+    // to defeat the `--no-` we push here, which is not a contract worth
+    // depending on. `. opts gc_sections` picks one flag or the other, so
+    // the argv says what was meant.
+    ? . opts gc_sections
+    { ( vec_push [s] args `-Wl,--gc-sections` ) }
+    { ( vec_push [s] args `-Wl,--no-gc-sections` ) }
     ? > ( nurl_str_len . opts extra_cflags ) 0 {
         // split the space-separated flag string into separate argv slots
         : ( Vec String ) fl ( string_split_borrow . opts extra_cflags )

--- a/packages/wasmbuilder/src/main.nu
+++ b/packages/wasmbuilder/src/main.nu
@@ -23,7 +23,9 @@ $ `stdlib/std/args.nu`
 $ `stdlib/ext/env.nu`
 $ `build.nu`
 
-@ __wbc_version → s { ^ `wasmbuilder 0.1.1` }
+// Keep in step with nurl.toml's [package] version — `--version` is what a
+// bug report quotes, so a stale literal here misattributes the bug.
+@ __wbc_version → s { ^ `wasmbuilder 0.1.3` }
 
 // --doctor: print every resolution step so a broken setup explains itself.
 @ __wbc_doctor → i {
@@ -77,6 +79,7 @@ $ `build.nu`
     ( args_opt p `obj` 0 `FILE` `extra wasm object linked into the module (e.g. kernels_static.wasm.o)` )
     ( args_opt p `cflags` 0 `FLAGS` `extra compile/link flags, space-separated (e.g. "-msimd128")` )
     ( args_opt p `asyncify-imports` 0 `LIST` `comma-separated async import names (e.g. env.wgpu_download); implies --asyncify` )
+    ( args_flag p `gc-sections` 0 `link with --gc-sections: drops unreachable code (~25% smaller, loads faster), but renumbers the function table — verify closure-using programs still run` )
     ( args_flag p `no-host-imports` 0 `do not pass --ffi-host-imports to nurlc` )
     ( args_flag p `quiet` 113 `suppress progress output` )
     ( args_flag p `doctor` 0 `print how nurlc/zig/runtime resolve on this machine` )
@@ -136,6 +139,7 @@ $ `build.nu`
     ? ( args_present p `no-host-imports` ) { = . opts host_imports F } {}
     ? ( args_present p `emit-ll` ) { = . opts keep_ll T } {}
     ? ( args_present p `asyncify` ) { = . opts asyncify T } {}
+    ? ( args_present p `gc-sections` ) { = . opts gc_sections T } {}
     : ~ String objv ( string_new )
     ?? ( args_value p `obj` ) { T v → { ( string_free objv ) = objv v = . opts extra_obj ( string_data objv ) } F _ → {} }
     : ~ String cflv ( string_new )

--- a/packages/wasmtime/src/interp.nu
+++ b/packages/wasmtime/src/interp.nu
@@ -816,24 +816,44 @@ $ `module.nu`
     : s fr0 ( __frame_new it m fidx )
     ? != # i fr0 0 { ( vec_push [s] frames fr0 ) } {}
     : *Wc c ( wc_new . m code )
+    // The frame stack changes only on a call, a return, or falling off the end
+    // of a body — but this loop used to re-read the top frame out of `frames`
+    // on every *instruction*: a bounds-checked vec_get, an Option unwrap and a
+    // dependent load, then two stores copying pos/end into the cursor and one
+    // copying pos back. At instruction-level profile that was the single
+    // hottest line in the interpreter (14.5 % of all cycles on the vec_get's
+    // load alone, ~8 % more on the cursor store) — pure bookkeeping, none of it
+    // the guest's work.
+    //
+    // So the cursor is now the authority on where execution is, and the top
+    // frame is cached in `tp` and refreshed only when `reload` says the frame
+    // stack moved. `. fr pos` is written back exactly at the transitions where
+    // something else will read it: before a call suspends this frame, and
+    // before a trap prints a backtrace off it.
+    : ~ s tp # s 0
+    : ~ i reload 1
     ~ & & > ( vec_len [s] frames ) 0 ! . it exited ! . it trap {
-        : i depth ( vec_len [s] frames )
-        : s tp ?? ( vec_get [s] frames - depth 1 ) { T x → x F → # s 0 }
+        ? != reload 0 {
+            = tp ?? ( vec_get [s] frames - ( vec_len [s] frames ) 1 ) { T x → x F → # s 0 }
+            : *Frame nfr # *Frame tp
+            = . c pos . nfr pos
+            = . c len . nfr end
+            = reload 0
+        } {}
         : *Frame fr # *Frame tp
-        ? >= . fr pos . fr end {  // fell off the end of the body → return
-            ( __frame_free tp ) ( vec_pop [s] frames )
+        ? >= . c pos . c len {  // fell off the end of the body → return
+            ( __frame_free tp ) ( vec_pop [s] frames ) = reload 1
         } {
             ? == . it fuel 0 { ( __trap it `fuel exhausted` ) } {
                 ? > . it fuel 0 { = . it fuel - . it fuel 1 } {}
-                = . c pos . fr pos
-                = . c len . fr end
                 : i op ( wc_u8 c )
                 ( __exec_op it m c . fr ctrl . fr locals op )
-                = . fr pos . c pos
-                ? == op 15 { ( __frame_free tp ) ( vec_pop [s] frames ) } {  // return
+                ? == op 15 { ( __frame_free tp ) ( vec_pop [s] frames ) = reload 1 } {  // return
                     ? >= . it pending_call 0 {  // call / call_indirect
                         : i callee . it pending_call
                         = . it pending_call -1
+                        = . fr pos . c pos  // this frame resumes here
+                        = reload 1
                         ? < callee . m num_import_funcs { ( __call_import it m callee ) } {
                             ? >= ( vec_len [s] frames ) . it max_depth { ( __trap it `call stack exhausted` ) } {
                                 : s nf ( __frame_new it m callee )
@@ -845,7 +865,20 @@ $ `module.nu`
             }
         }
     }
-    ? . it trap { ( __trap_backtrace it m frames ) } {}
+    // The cursor, not the frame, holds the trapping position — sync it back so
+    // the backtrace's `+offset` is the instruction that actually trapped.
+    // Only when `reload` is still 0: that is exactly the case where the cursor
+    // belongs to the frame still on top. If the stack moved (a pop freed `tp`,
+    // or `call stack exhausted` trapped after the caller's pos was already
+    // saved) the cursor describes a frame that is gone or already up to date,
+    // and `tp` may be dangling — so re-read the top rather than trusting it.
+    ? . it trap {
+        ? & == reload 0 > ( vec_len [s] frames ) 0 {
+            : s ttp ?? ( vec_get [s] frames - ( vec_len [s] frames ) 1 ) { T x → x F → # s 0 }
+            ? != # i ttp 0 { : *Frame ftr # *Frame ttp = . ftr pos . c pos } {}
+        } {}
+        ( __trap_backtrace it m frames )
+    } {}
     : i fn ( vec_len [s] frames )
     : ~ i fi 0
     ~ < fi fn { ?? ( vec_get [s] frames fi ) { T pp → ( __frame_free pp ) F → {} } = fi + fi 1 }

--- a/packages/wasmtime/src/main.nu
+++ b/packages/wasmtime/src/main.nu
@@ -39,13 +39,33 @@ $ `interp.nu`
     ^ ?? ( vec_get [i] . ft results 0 ) { T x → x F → 127 }
 }
 
+// Keep in step with nurl.toml's [package] version — `--version` is what a
+// bug report quotes, so a stale literal here misattributes the bug.
+@ __wt_version → s { ^ `wasmtime 0.6.2 (pure NURL)` }
+
 @ usage → v {
     ( nurl_print `wasmtime — a WebAssembly runtime in pure NURL\n\n` )
-    ( nurl_print `  wasmtime run [--dir <path>]… [--env NAME=VALUE]… <module.wasm> [args…]\n` )
-    ( nurl_print `  wasmtime run --invoke <export> <module.wasm> [args…]\n\n` )
+    ( nurl_print `  wasmtime run [--dir <path>]… [--env NAME=VALUE]… [--fuel N] [--allow-gpu] <module.wasm> [args…]\n` )
+    ( nurl_print `  wasmtime run --invoke <export> <module.wasm> [args…]\n` )
+    ( nurl_print `  wasmtime --version | --help\n\n` )
     ( nurl_print `Command mode runs a wasm32-wasi module's _start with the given preopened\n` )
     ( nurl_print `directories and environment. Invoke mode calls an exported function with\n` )
     ( nurl_print `integer / floating-point arguments and prints the result.\n` )
+}
+
+// Is `flag` anywhere in argv, position 1 included? __arg_index starts at 2
+// because every flag it looks for follows the `run` subcommand; `--version`
+// and `--help` are the two that stand in the subcommand's place instead.
+@ __has_flag i argc s flag → i {
+    : ~ i found 0
+    : ~ i k 1
+    ~ & == found 0 < k argc {
+        : String a ( env_arg k )
+        ? != 0 ( nurl_str_eq ( string_data a ) flag ) { = found 1 } {}
+        ( string_free a )
+        = k + k 1
+    }
+    ^ found
 }
 
 // Find the index of `flag` in argv (after position 1); -1 if absent.
@@ -164,6 +184,9 @@ $ `interp.nu`
 
 @ main → i {
     : i argc ( env_args_count )
+    ? != 0 ( __has_flag argc `--version` ) { ( nurl_print ( __wt_version ) ) ( nurl_print `\n` ) ^ 0 } {}
+    ? != 0 ( __has_flag argc `--help` ) { ( usage ) ^ 0 } {}
+    ? != 0 ( __has_flag argc `-h` ) { ( usage ) ^ 0 } {}
     ? < argc 2 { ( usage ) ^ 1 } {}
     // Direct-call mode: `[run] --invoke <export> <module> [args]`.
     : i allow_gpu ? >= ( __arg_index argc `--allow-gpu` ) 0 1 0


### PR DESCRIPTION
`bench/wasmbench.sh` is the sibling of `bench.sh` — same roster, same protocol,
one axis rotated. Instead of NURL against four other languages on the native
target, it asks what **targeting wasm** costs and what running that wasm on
**NURL's own runtime** costs. Each benchmark's NURL, C and Rust sources are
compiled twice (native and `wasm32-wasi`) and every module runs on two runtimes:
the reference `wasmtime` and `packages/wasmtime`, the interpreter written in pure
NURL. Ten timed cells a row, all gated on printing the same line as the native
NURL binary — the interpreter *inside* the gate, not beside it.

Artefacts: [`bench/WASMRESULTS.md`](bench/WASMRESULTS.md) and
[`bench/results/wasm-latest.json`](bench/results/wasm-latest.json). Full suite:
**9m22s**, 15/15 rows verified.

## Running both runtimes is what earns its keep

A JIT re-optimises whatever it is handed, so it reports about the same number for
a good module and a bad one. An interpreter executes exactly what is in the
module. That asymmetry found the real defect here:

**`zig cc` drops `-O` for LLVM IR inputs.** It forwards the level for C, but for
a `.ll` it passes nothing to cc1 and cc1 defaults to `-O0`. This pipeline hands
zig a `.ll`, so **every wasm module `wasmbuilder` ever produced shipped
unoptimised** — no mem2reg, a loop counter left as a linear-memory load/store
pair. `nurl.sh` has carried the `-Xclang <level>` workaround for native builds
since it was found there; the wasm half was missing.

| `bench/lcg.nu` on `packages/wasmtime` | |
|---|---:|
| before | 17.86 s |
| after | **2.77 s** |

The reference-`wasmtime` column moved by nothing, which is why it lasted.

## What the suite now measures rather than guesses

**NURL's steady-state wasm throughput is 1.3–2.1× native on most rows, and at or
better than clang's own wasm output on 11 of 14 comparable rows** (§2, `NURL +gc`
column). The exceptions are `json_parse` (4.4 vs 2.8) and `sort_window`
(1.6 vs 1.2).

**The default build's ratio is unreadable, and that is the finding.** A ~1 MB
module's JIT compilation (59.5 ms, against C's 7.0 and Rust's 18.0) is comparable
to the benchmarks themselves, so §2's `NURL x` column is almost all `—`. For a
short wasm program NURL pays more for start-up than for the computation.

**The interpreter retires ~191 host instructions per wasm instruction** at 3.4 IPC
and a 0.05 % branch-miss rate — it is not stalling, it is executing too many
instructions. Getting to the 20–40 a tight interpreter manages needs a
pre-decoded instruction representation, not local edits; two candidate edits were
tried and reverted with measurements (see CHANGELOG).

**On an empty program the interpreter beats the JIT** (50.8 ms vs 59.5 ms),
because the JIT compiles the whole module before `_start`. §3 explains the
crossover rather than hiding it.

## Also here

- **`wasmbuilder --gc-sections`** (and `WbOpts.gc_sections`). The default stays
  `--no-gc-sections` — NURL closures store function-table indices that section GC
  renumbers — but there was no way to opt out, and the suite now measures the
  cost: −23 % of the module and **−83 % of the empty program's JIT floor**, i.e.
  most of NURL's start-up penalty against C. Every benchmark is built both ways
  and both are held to the same output.
- **`packages/wasmtime`**: the interpreter loop caches its frame instead of
  re-reading it out of a `Vec` per instruction (+3–4 %), and gained
  `--version` / `--help`, which it never had.
- **Fixed**: `wasmbuilder --version` said 0.1.1 at package version 0.1.3;
  `--cflags` / `--obj` / `--asyncify-imports` were implemented but undocumented.
- **`bench/bench.ps1` + `RESULTS-WINDOWS.md`**, the Windows runner and one run
  from it.

## One thing to look at before merging

`RESULTS-WINDOWS.md` links `results/latest-windows.json`, which is **not
included** — the markdown half of the pair is here without the machine-readable
half, so the link is dead and nothing can read that run programmatically.

(An earlier revision of this description also flagged its `Commit` field as
naming a commit absent from the repository. That was true when written and is
no longer: `1b8552a` landed on `main` in #662, which this branch is now rebased
onto, so the field resolves.)

## Test evidence

- `packages/wasmtime`: 7/7 (`interp`, `mem`, `table`, `float`, `wasi`,
  `semantics`, `hardening`)
- `packages/wasmbuilder`: 16/16 end-to-end, incl. `test_05_closures_and_capture`
  and `test_06_torture_chamber`
- `bench/wasmbench.sh`: 15/15 rows through the correctness gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FREmK7Qhd5sMWtNi9QVWHw

