### PR TITLE
wasmbuilder: --gc-sections by default, and the two bugs under the old one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`wasmbuilder` links with `--gc-sections` by default.** The previous
+  default, `--no-gc-sections`, guarded against a real trap: NURL closures
+  store function-table indices, section GC renumbers that table, and
+  `nurlc.wasm` was observed to `call_indirect`-trap under it at >150
+  functions. Before flipping, that blocker was re-tested at exactly the
+  documented scale — a `--gc-sections`-linked `nurlc.wasm` **self-compiles
+  the 65k-line compiler byte-identically to the native binary** under both
+  the reference `wasmtime` and the pure-NURL `wt`, and the closure corpus
+  (`test_05_closures_and_capture`, `test_06_torture_chamber`) passes.
+  Whatever produced the historical trap, today's `wasm-ld` relocates
+  address-taken functions correctly through GC.
+
+  What the old default cost, measured by `bench/wasmbench.sh`: ~25 % of
+  every module (`lcg`: 1064 → 820 KiB) and ~83 % of an empty program's
+  module-load floor on the reference JIT (~60 → ~10 ms) — the single
+  largest start-up gap between NURL wasm and C wasm. `--no-gc-sections`
+  (library: `WbOpts.no_gc_sections`, replacing the short-lived
+  `gc_sections` field) remains as the escape hatch; an indirect-call trap
+  that appears only under the default would be the renumbering bug
+  resurfacing and should be reported. The suite now measures the escape
+  hatch as its tenth cell instead of the GC build, so its price stays a
+  number. `nurlapi`'s `/build_wasm` still links `--no-gc-sections` — its
+  wasi-sdk container path has not been re-validated the same way; the
+  comment there now records the evidence for flipping it.
+
 ### Added
 
 - **`nurl upgrade` — the toolchain updates itself.** Until now the only way
@@ -98,6 +125,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   record which runtime produced a result.
 
 ### Fixed
+
+- **Every wasm build of a program whose imports reached `path_canonical`
+  failed — including `nurlc.wasm` itself.** Two stacked defects, one seam.
+  wasi-libc ships no `realpath(3)`, and it was missing from `wasi_ir.nu`'s
+  POSIX stub list, so the symbol became an `env` wasm import and the
+  reference `wasmtime` refused to *instantiate* the module (`unknown
+  import: env::realpath`). Adding the stub exposed the second defect: the
+  stub machinery removes the now-renamed `declare` line by *reconstructing*
+  it with single spacing, but nurlc has two declare emitters — the FFI path
+  prints `declare i64 @fork()`, the column-aligned prelude prints
+  `declare i8*  @realpath(i8*, i8*)` — so the rebuilt line missed the
+  padded kind, the stale declare collided with the appended define, and
+  clang rejected the module ("invalid redefinition"). The stripper now
+  locates the actual line by symbol (`__wb_ir_decl_line`) instead of
+  guessing its spelling. The stub returns NULL, which `path_canonical`
+  already maps to `None` — the honest wasm answer. `find_clone` (whose
+  import graph spans the whole POSIX-stub surface) joins the wasmbuilder
+  corpus so this seam stays covered.
 
 - **The installer served from nurl-lang.org still wiped the whole install
   prefix.** `tools/get-nurl.{sh,ps1}` stopped doing that in July —

--- a/bench/README.md
+++ b/bench/README.md
@@ -161,13 +161,11 @@ gate, because a runtime that gets the wrong answer quickly is not a fast
 runtime. Results: [`WASMRESULTS.md`](WASMRESULTS.md) and
 [`results/wasm-latest.json`](results/wasm-latest.json).
 
-The tenth cell is the NURL module relinked with `--gc-sections`, which
-`wasmbuilder` leaves off by default because NURL closures store function
-table indices that section GC renumbers. None of these benchmarks uses a
-closure, so the suite can put a number on what that default costs — see
-section 5 of the report, and
-[`packages/wasmbuilder`](../packages/wasmbuilder/README.md#--gc-sections)
-for when it is safe to turn on.
+The tenth cell is the NURL module relinked with `--no-gc-sections` —
+`wasmbuilder`'s pre-0.1.4 default, kept measured so the price of its
+escape hatch stays a number (section 5 of the report). See
+[`packages/wasmbuilder`](../packages/wasmbuilder/README.md#--gc-sections-is-the-default-and---no-gc-sections-the-escape-hatch)
+for why the default flipped and what would justify flipping it back.
 
 C and Rust are there as the control. Without them a wasm-vs-native ratio
 cannot distinguish "wasm is slower here" from "NURL's wasm pipeline is

--- a/bench/WASMRESULTS.md
+++ b/bench/WASMRESULTS.md
@@ -1,6 +1,6 @@
 # WebAssembly benchmark results — NURL native vs NURL wasm
 
-Generated `2026-07-27T09:53:03Z` by `bench/wasmbench.sh`. **Do not edit by hand** —
+Generated `2026-07-27T12:22:26Z` by `bench/wasmbench.sh`. **Do not edit by hand** —
 the next run overwrites it. The machine-readable form of this same run
 is [`results/wasm-latest.json`](results/wasm-latest.json).
 
@@ -20,7 +20,7 @@ row, all gated on printing the same line (section 7).
 | Kernel | `Linux 7.0.0-28-generic x86_64` |
 | CPU | Intel(R) Core(TM) i7-5930K CPU @ 3.50GHz (12 logical cores) |
 | Memory | 32770952 KiB |
-| Commit | `ad7e4391c17af5bc82ffc997b8e97005329aabd2` |
+| Commit | `9111299b88a23cbb25425c2c91c305a29f59fac5` |
 | NURL | `v0.26.0-15-gad7e439` |
 | C | Ubuntu clang version 18.1.3 (1ubuntu1) |
 | Rust | rustc 1.82.0 (f6e511eec 2024-10-15) |
@@ -53,22 +53,22 @@ NURL's wasm pipeline or to wasm itself.
 
 | Benchmark | NURL native | NURL wasm | x | C native | C wasm | x | Rust native | Rust wasm | x |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| _(floor: empty program)_ | _1.664_ | _62.536_ | _37.6_ | _1.527_ | _7.151_ | _4.7_ | _1.705_ | _17.188_ | _10.1_ |
-| `lcg` | 39.454 | 92.613 | 2.3 | 36.734 | 70.561 | 1.9 | 40.684 | 55.154 | 1.4 |
-| `affine_mix` | 33.592 | 91.026 | 2.7 | 34.469 | 59.458 | 1.7 | 40.279 | 53.595 | 1.3 |
-| `packet_classifier` | 63.118 | 111.411 | 1.8 | 68.643 | 77.651 | 1.1 | 68.195 | 69.459 | 1.0 |
-| `ring_write` | 37.471 | 98.644 | 2.6 | 37.305 | 69.063 | 1.9 | 43.807 | 64.403 | 1.5 |
-| `histogram_bins` | 41.374 | 100.163 | 2.4 | 41.853 | 73.794 | 1.8 | 41.801 | 64.298 | 1.5 |
-| `prefix_scan` | 24.097 | 79.843 | 3.3 | 24.841 | 48.479 | 2.0 | 24.624 | 29.781 | 1.2 |
-| `binary_search` | 34.228 | 132.185 | 3.9 | 36.161 | 117.260 | 3.2 | 43.948 | 99.095 | 2.3 |
-| `sort_window` | 41.188 | 110.110 | 2.7 | 52.501 | 75.914 | 1.4 | 53.575 | 123.660 | 2.3 |
-| `bloom_filter` | 18.133 | 81.014 | 4.5 | 16.750 | 45.560 | 2.7 | 17.689 | 36.494 | 2.1 |
-| `hash_join` | 6.320 | 66.795 | 10.6 | 4.886 | 31.750 | 6.5 | 5.320 | 24.550 | 4.6 |
-| `sieve` | 43.446 | 99.869 | 2.3 | 42.302 | 68.849 | 1.6 | 37.415 | 61.224 | 1.6 |
-| `fib` | 34.440 | 102.493 | 3.0 | 33.702 | 65.008 | 1.9 | 30.222 | 64.897 | 2.1 |
-| `collatz` | 18.651 | 78.851 | 4.2 | 17.458 | 43.512 | 2.5 | 18.617 | 38.712 | 2.1 |
-| `matmul` | 35.631 | 89.686 | 2.5 | 35.353 | 60.555 | 1.7 | 35.041 | 55.030 | 1.6 |
-| `json_parse` | 11.850 | 88.650 | 7.5 | 8.871 | 39.651 | 4.5 | 14.477 | 40.095 | 2.8 |
+| _(floor: empty program)_ | _1.510_ | _10.570_ | _7.0_ | _1.708_ | _8.232_ | _4.8_ | _1.515_ | _19.302_ | _12.7_ |
+| `lcg` | 41.183 | 63.348 | 1.5 | 32.909 | 61.315 | 1.9 | 36.185 | 55.044 | 1.5 |
+| `affine_mix` | 40.523 | 61.405 | 1.5 | 41.117 | 66.680 | 1.6 | 40.623 | 54.937 | 1.4 |
+| `packet_classifier` | 70.215 | 78.930 | 1.1 | 69.073 | 80.049 | 1.2 | 67.798 | 69.127 | 1.0 |
+| `ring_write` | 41.292 | 79.389 | 1.9 | 43.946 | 77.009 | 1.8 | 43.901 | 64.662 | 1.5 |
+| `histogram_bins` | 42.732 | 71.423 | 1.7 | 42.018 | 74.914 | 1.8 | 41.307 | 64.209 | 1.6 |
+| `prefix_scan` | 21.309 | 49.506 | 2.3 | 18.372 | 56.206 | 3.1 | 24.808 | 31.197 | 1.3 |
+| `binary_search` | 33.155 | 105.340 | 3.2 | 36.373 | 116.769 | 3.2 | 41.671 | 97.377 | 2.3 |
+| `sort_window` | 49.554 | 86.902 | 1.8 | 52.290 | 73.854 | 1.4 | 53.553 | 126.604 | 2.4 |
+| `bloom_filter` | 19.152 | 48.000 | 2.5 | 18.007 | 51.440 | 2.9 | 17.037 | 35.199 | 2.1 |
+| `hash_join` | 6.134 | 31.054 | 5.1 | 6.490 | 33.094 | 5.1 | 6.628 | 25.039 | 3.8 |
+| `sieve` | 42.894 | 67.377 | 1.6 | 42.528 | 64.524 | 1.5 | 42.194 | 60.775 | 1.4 |
+| `fib` | 33.745 | 70.521 | 2.1 | 34.790 | 65.328 | 1.9 | 33.466 | 63.047 | 1.9 |
+| `collatz` | 18.066 | 42.776 | 2.4 | 18.866 | 40.755 | 2.2 | 17.400 | 39.977 | 2.3 |
+| `matmul` | 35.267 | 64.453 | 1.8 | 36.260 | 58.969 | 1.6 | 34.066 | 55.368 | 1.6 |
+| `json_parse` | 12.571 | 51.354 | 4.1 | 11.904 | 37.642 | 3.2 | 15.011 | 40.701 | 2.7 |
 
 The floor row matters more here than in `RESULTS.md`. A wasm cell pays
 for the runtime compiling the whole module before `_start` runs, and a
@@ -85,30 +85,28 @@ where it is most of the run.
 
 A `—` means the subtraction has no signal left in it: the floor is more
 than half of that cell, so the remainder is a difference of two similar
-numbers carrying both their errors. That is not a rare edge case in the
-**NURL x** column — a 1 MB module's compilation is comparable to the
-benchmarks themselves, which is exactly why the `+gc` column beside it
-exists: the same NURL programs linked with `--gc-sections` (section 5)
-have a floor small enough to subtract cleanly, so they are where the
-steady-state throughput of NURL's wasm can actually be read.
+numbers carrying both their errors. The `no gc` column is the
+pre-0.1.4 default relinked with `--no-gc-sections` (section 5); its
+floor is big enough that most of its rows land there, which is one of
+the reasons it is no longer the default.
 
-| Benchmark | NURL x | NURL +gc x | C x | Rust x |
+| Benchmark | NURL x | NURL no-gc x | C x | Rust x |
 |---|---:|---:|---:|---:|
-| `lcg` | — | 1.3 | 1.8 | 1.0 |
-| `affine_mix` | — | 1.5 | 1.6 | 0.9 |
-| `packet_classifier` | — | 1.1 | 1.1 | 0.8 |
-| `ring_write` | — | 1.6 | 1.7 | 1.1 |
-| `histogram_bins` | — | 1.7 | 1.7 | 1.2 |
-| `prefix_scan` | — | 1.8 | 1.8 | — |
-| `binary_search` | 2.1 | 2.9 | 3.2 | 1.9 |
-| `sort_window` | — | 1.8 | 1.3 | 2.1 |
-| `bloom_filter` | — | 2.0 | 2.5 | 1.2 |
-| `hash_join` | — | 4.4 | 7.3 | — |
-| `sieve` | — | 1.3 | 1.5 | 1.2 |
-| `fib` | — | 1.9 | 1.8 | 1.7 |
-| `collatz` | — | 2.0 | 2.3 | 1.3 |
-| `matmul` | — | 1.5 | 1.6 | 1.1 |
-| `json_parse` | — | 3.6 | 4.4 | 1.8 |
+| `lcg` | 1.3 | — | 1.7 | 1.0 |
+| `affine_mix` | 1.3 | — | 1.5 | 0.9 |
+| `packet_classifier` | 1.0 | — | 1.1 | 0.8 |
+| `ring_write` | 1.7 | — | 1.6 | 1.1 |
+| `histogram_bins` | 1.5 | — | 1.7 | 1.1 |
+| `prefix_scan` | 2.0 | — | 2.9 | — |
+| `binary_search` | 3.0 | 2.3 | 3.1 | 1.9 |
+| `sort_window` | 1.6 | — | 1.3 | 2.1 |
+| `bloom_filter` | 2.1 | — | 2.7 | — |
+| `hash_join` | 4.4 | — | 5.2 | — |
+| `sieve` | 1.4 | — | 1.4 | 1.0 |
+| `fib` | 1.9 | — | 1.7 | 1.4 |
+| `collatz` | 1.9 | — | 1.9 | 1.3 |
+| `matmul` | 1.6 | — | 1.5 | 1.1 |
+| `json_parse` | 3.7 | — | 2.9 | 1.6 |
 
 ## 3. The pure-NURL runtime (`packages/wasmtime`)
 
@@ -128,22 +126,22 @@ use": it depends entirely on how long the guest runs.
 
 | Benchmark | NURL on `wt` | vs JIT | vs native | C on `wt` | Rust on `wt` |
 |---|---:|---:|---:|---:|---:|
-| _(floor: empty program)_ | _45.100_ | _0.7_ | _27.1_ | _SKIPPED_ | _SKIPPED_ |
-| `lcg` | 2561.128 | 27.7 | 64.9 | SKIPPED | SKIPPED |
-| `affine_mix` | 5261.156 | 57.8 | 156.6 | SKIPPED | SKIPPED |
-| `packet_classifier` | 5645.706 | 50.7 | 89.4 | SKIPPED | SKIPPED |
-| `ring_write` | 7022.937 | 71.2 | 187.4 | SKIPPED | SKIPPED |
-| `histogram_bins` | 7289.204 | 72.8 | 176.2 | SKIPPED | SKIPPED |
-| `prefix_scan` | 2512.158 | 31.5 | 104.3 | SKIPPED | SKIPPED |
-| `binary_search` | 15085.611 | 114.1 | 440.7 | SKIPPED | SKIPPED |
-| `sort_window` | 40323.696 | 366.2 | 979.0 | SKIPPED | SKIPPED |
-| `bloom_filter` | 3820.273 | 47.2 | 210.7 | SKIPPED | SKIPPED |
-| `hash_join` | 3324.280 | 49.8 | 526.0 | SKIPPED | SKIPPED |
-| `sieve` | 5165.420 | 51.7 | 118.9 | SKIPPED | SKIPPED |
-| `fib` | 11474.997 | 112.0 | 333.2 | SKIPPED | SKIPPED |
-| `collatz` | 2662.316 | 33.8 | 142.7 | SKIPPED | SKIPPED |
-| `matmul` | 4240.486 | 47.3 | 119.0 | SKIPPED | SKIPPED |
-| `json_parse` | 29424.539 | 331.9 | 2483.1 | SKIPPED | SKIPPED |
+| _(floor: empty program)_ | _49.586_ | _4.7_ | _32.8_ | _SKIPPED_ | _SKIPPED_ |
+| `lcg` | 2551.115 | 40.3 | 61.9 | SKIPPED | SKIPPED |
+| `affine_mix` | 5236.536 | 85.3 | 129.2 | SKIPPED | SKIPPED |
+| `packet_classifier` | 5609.458 | 71.1 | 79.9 | SKIPPED | SKIPPED |
+| `ring_write` | 6964.832 | 87.7 | 168.7 | SKIPPED | SKIPPED |
+| `histogram_bins` | 7687.511 | 107.6 | 179.9 | SKIPPED | SKIPPED |
+| `prefix_scan` | 2514.534 | 50.8 | 118.0 | SKIPPED | SKIPPED |
+| `binary_search` | 14824.405 | 140.7 | 447.1 | SKIPPED | SKIPPED |
+| `sort_window` | 40168.675 | 462.2 | 810.6 | SKIPPED | SKIPPED |
+| `bloom_filter` | 3837.375 | 79.9 | 200.4 | SKIPPED | SKIPPED |
+| `hash_join` | 3264.882 | 105.1 | 532.3 | SKIPPED | SKIPPED |
+| `sieve` | 5110.445 | 75.8 | 119.1 | SKIPPED | SKIPPED |
+| `fib` | 11376.658 | 161.3 | 337.1 | SKIPPED | SKIPPED |
+| `collatz` | 2645.571 | 61.8 | 146.4 | SKIPPED | SKIPPED |
+| `matmul` | 4192.871 | 65.1 | 118.9 | SKIPPED | SKIPPED |
+| `json_parse` | 29149.574 | 567.6 | 2318.8 | SKIPPED | SKIPPED |
 
 The C and Rust columns are `SKIPPED`: they are the cross-frontend
 control — modules this runtime never saw during development, from two
@@ -161,63 +159,59 @@ above) parsed before the program starts.
 
 | Benchmark | NURL native | NURL wasm | C native | C wasm | Rust native | Rust wasm |
 |---|---:|---:|---:|---:|---:|---:|
-| `lcg` | 16 | 1064 | 16 | 686 | 3743 | 1733 |
-| `affine_mix` | 16 | 1064 | 16 | 686 | 3743 | 1734 |
-| `packet_classifier` | 16 | 1064 | 16 | 686 | 3743 | 1734 |
-| `ring_write` | 16 | 1064 | 16 | 686 | 3743 | 1734 |
-| `histogram_bins` | 16 | 1064 | 16 | 686 | 3743 | 1734 |
-| `prefix_scan` | 16 | 1064 | 16 | 687 | 3743 | 1734 |
-| `binary_search` | 16 | 1064 | 16 | 687 | 3743 | 1735 |
-| `sort_window` | 16 | 1064 | 16 | 687 | 3743 | 1734 |
-| `bloom_filter` | 16 | 1064 | 16 | 687 | 3743 | 1734 |
-| `hash_join` | 20 | 1067 | 16 | 695 | 3743 | 1736 |
-| `sieve` | 16 | 1064 | 16 | 691 | 3742 | 1733 |
-| `fib` | 16 | 1063 | 16 | 686 | 3738 | 1733 |
-| `collatz` | 16 | 1064 | 16 | 686 | 3738 | 1733 |
-| `matmul` | 16 | 1064 | 16 | 691 | 3743 | 1734 |
-| `json_parse` | 34 | 1119 | 16 | 736 | 3757 | 1763 |
+| `lcg` | 16 | 819 | 16 | 686 | 3743 | 1733 |
+| `affine_mix` | 16 | 819 | 16 | 686 | 3743 | 1734 |
+| `packet_classifier` | 16 | 819 | 16 | 686 | 3743 | 1734 |
+| `ring_write` | 16 | 819 | 16 | 686 | 3743 | 1734 |
+| `histogram_bins` | 16 | 819 | 16 | 686 | 3743 | 1734 |
+| `prefix_scan` | 16 | 820 | 16 | 687 | 3743 | 1734 |
+| `binary_search` | 16 | 819 | 16 | 687 | 3743 | 1735 |
+| `sort_window` | 16 | 820 | 16 | 687 | 3743 | 1734 |
+| `bloom_filter` | 16 | 820 | 16 | 687 | 3743 | 1734 |
+| `hash_join` | 20 | 821 | 16 | 695 | 3743 | 1736 |
+| `sieve` | 16 | 819 | 16 | 691 | 3742 | 1733 |
+| `fib` | 16 | 819 | 16 | 686 | 3738 | 1733 |
+| `collatz` | 16 | 819 | 16 | 686 | 3738 | 1733 |
+| `matmul` | 16 | 820 | 16 | 691 | 3743 | 1734 |
+| `json_parse` | 34 | 849 | 16 | 736 | 3757 | 1763 |
 
-## 5. Dead code — what `--gc-sections` costs and buys
+## 5. Dead code — what `--no-gc-sections` would cost
 
-Every NURL module above was linked with `-Wl,--no-gc-sections`, the
-default `wasmbuilder` ships. NURL closures store **function-table indices**
-and section GC renumbers that table, so a closure captured before the
-collection can call the wrong function after it — a run-time
-`call_indirect` trap with no link error to warn anyone. The cost of that
-default is that most of the NURL runtime ships in, and is translated by
-the runtime, in every module that never calls it.
+Every NURL module above was linked with `-Wl,--gc-sections`, the
+`wasmbuilder` default since 0.1.4: the unreachable part of the NURL
+runtime is dropped instead of shipped and JIT-translated for nothing.
+The old default, `--no-gc-sections`, exists as an escape hatch for a
+closure/table-renumbering hazard that no longer reproduces — a
+`--gc-sections` `nurlc.wasm` self-compiles byte-identically under both
+runtimes. These rows are the same benchmarks relinked with the escape
+hatch, held to the same output, so its price stays a number: what you
+pay in bytes and module-load time if you ever have to reach for it.
 
-These rows are the same benchmarks rebuilt with `--gc-sections`, run on
-the reference runtime, and held to the same output — none of them uses a
-closure, so the hazard does not apply and the saving is measurable.
-
-| Benchmark | Size | Size +gc | Δ | JIT | JIT +gc | Δ |
+| Benchmark | Size | Size no-gc | Δ | JIT | JIT no-gc | Δ |
 |---|---:|---:|---:|---:|---:|---:|
-| _(floor: empty program)_ | _1063_ | _798_ | _−25 %_ | _62.536_ | _10.267_ | _−84 %_ |
-| `lcg` | 1064 | 819 | −23 % | 92.613 | 60.884 | −34 % |
-| `affine_mix` | 1064 | 819 | −23 % | 91.026 | 59.683 | −34 % |
-| `packet_classifier` | 1064 | 819 | −23 % | 111.411 | 79.172 | −29 % |
-| `ring_write` | 1064 | 819 | −23 % | 98.644 | 68.821 | −30 % |
-| `histogram_bins` | 1064 | 819 | −23 % | 100.163 | 77.872 | −22 % |
-| `prefix_scan` | 1064 | 820 | −23 % | 79.843 | 49.952 | −37 % |
-| `binary_search` | 1064 | 820 | −23 % | 132.185 | 104.771 | −21 % |
-| `sort_window` | 1064 | 820 | −23 % | 110.110 | 80.610 | −27 % |
-| `bloom_filter` | 1064 | 820 | −23 % | 81.014 | 42.536 | −47 % |
-| `hash_join` | 1067 | 821 | −23 % | 66.795 | 30.637 | −54 % |
-| `sieve` | 1064 | 819 | −23 % | 99.869 | 66.558 | −33 % |
-| `fib` | 1063 | 819 | −23 % | 102.493 | 71.491 | −30 % |
-| `collatz` | 1064 | 819 | −23 % | 78.851 | 44.133 | −44 % |
-| `matmul` | 1064 | 820 | −23 % | 89.686 | 60.514 | −33 % |
-| `json_parse` | 1119 | 849 | −24 % | 88.650 | 47.099 | −47 % |
+| _(floor: empty program)_ | _798_ | _1063_ | _+33 %_ | _10.570_ | _60.276_ | _+470 %_ |
+| `lcg` | 819 | 1064 | +30 % | 63.348 | 90.273 | +43 % |
+| `affine_mix` | 819 | 1064 | +30 % | 61.405 | 95.278 | +55 % |
+| `packet_classifier` | 819 | 1064 | +30 % | 78.930 | 112.320 | +42 % |
+| `ring_write` | 819 | 1064 | +30 % | 79.389 | 99.169 | +25 % |
+| `histogram_bins` | 819 | 1064 | +30 % | 71.423 | 104.321 | +46 % |
+| `prefix_scan` | 820 | 1064 | +30 % | 49.506 | 78.566 | +59 % |
+| `binary_search` | 819 | 1064 | +30 % | 105.340 | 133.505 | +27 % |
+| `sort_window` | 820 | 1064 | +30 % | 86.902 | 113.051 | +30 % |
+| `bloom_filter` | 820 | 1064 | +30 % | 48.000 | 80.531 | +68 % |
+| `hash_join` | 821 | 1067 | +30 % | 31.054 | 67.468 | +117 % |
+| `sieve` | 819 | 1064 | +30 % | 67.377 | 99.631 | +48 % |
+| `fib` | 819 | 1064 | +30 % | 70.521 | 100.020 | +42 % |
+| `collatz` | 819 | 1064 | +30 % | 42.776 | 77.469 | +81 % |
+| `matmul` | 820 | 1064 | +30 % | 64.453 | 92.486 | +43 % |
+| `json_parse` | 849 | 1119 | +32 % | 51.354 | 86.472 | +68 % |
 
-The saving is almost all fixed cost, so it is largest where the benchmark
+The cost is almost all fixed, so it is largest where the benchmark
 itself is smallest — compare each row against the floor. It is reported
 on the JIT and not on the interpreter because the interpreter is
 execution-bound, not decode-bound: its floor row in section 3 is a few
-tens of milliseconds against cells in the tens of *seconds*, so shrinking
-the module cannot move it. This is a real optimisation, and what stands
-between it and being the default is making closure function-table indices
-survive renumbering — not the linker flag.
+tens of milliseconds against cells in the tens of *seconds*, so module
+size cannot move it either way.
 
 ## 6. Compile time (median, ms)
 
@@ -229,22 +223,22 @@ it and to the C and Rust wasm columns.
 
 | Benchmark | NURL `nurlc` | NURL native | NURL wasm | C native | C wasm | Rust native | Rust wasm |
 |---|---:|---:|---:|---:|---:|---:|---:|
-| _(floor: empty program)_ | _3.968_ | _109.052_ | _1334.094_ | _81.312_ | _602.986_ | _156.370_ | _109.577_ |
-| `lcg` | 3.911 | 110.031 | 1362.946 | 95.402 | 951.330 | 183.458 | 123.338 |
-| `affine_mix` | 4.045 | 110.049 | 1305.744 | 86.817 | 938.474 | 168.551 | 121.083 |
-| `packet_classifier` | 3.792 | 109.116 | 1317.276 | 94.783 | 915.998 | 176.435 | 121.980 |
-| `ring_write` | 3.754 | 106.551 | 1286.930 | 89.003 | 940.199 | 171.690 | 113.975 |
-| `histogram_bins` | 4.750 | 117.854 | 1297.838 | 87.753 | 924.073 | 168.438 | 112.015 |
-| `prefix_scan` | 4.434 | 113.783 | 1293.032 | 87.699 | 921.444 | 166.301 | 111.517 |
-| `binary_search` | 3.848 | 111.293 | 1301.846 | 90.424 | 913.416 | 179.118 | 125.883 |
-| `sort_window` | 4.458 | 123.809 | 1379.428 | 92.877 | 944.488 | 176.587 | 131.672 |
-| `bloom_filter` | 5.249 | 118.834 | 1296.963 | 96.674 | 916.469 | 178.571 | 119.138 |
-| `hash_join` | 9.265 | 246.170 | 1307.893 | 141.155 | 967.105 | 232.732 | 177.676 |
-| `sieve` | 5.235 | 119.781 | 1358.393 | 94.151 | 938.741 | 186.617 | 131.672 |
-| `fib` | 3.771 | 111.500 | 1337.662 | 87.876 | 938.591 | 171.183 | 114.812 |
-| `collatz` | 4.219 | 107.542 | 1326.105 | 89.276 | 929.486 | 170.377 | 123.266 |
-| `matmul` | 5.588 | 123.111 | 1337.730 | 99.820 | 950.490 | 213.000 | 153.248 |
-| `json_parse` | 85.653 | 849.593 | 1560.415 | 141.863 | 1102.307 | 322.235 | 235.882 |
+| _(floor: empty program)_ | _3.080_ | _100.137_ | _1344.016_ | _75.422_ | _582.966_ | _156.718_ | _102.580_ |
+| `lcg` | 3.858 | 114.276 | 1382.076 | 87.007 | 959.991 | 178.911 | 117.602 |
+| `affine_mix` | 3.493 | 115.152 | 1356.697 | 87.965 | 949.898 | 170.456 | 122.011 |
+| `packet_classifier` | 3.473 | 112.784 | 1317.455 | 89.343 | 921.005 | 168.487 | 114.505 |
+| `ring_write` | 3.394 | 112.196 | 1288.880 | 88.396 | 923.347 | 166.190 | 112.252 |
+| `histogram_bins` | 4.284 | 112.554 | 1298.565 | 91.446 | 919.696 | 176.198 | 114.709 |
+| `prefix_scan` | 4.437 | 116.553 | 1303.081 | 92.921 | 928.181 | 176.495 | 113.213 |
+| `binary_search` | 4.875 | 118.572 | 1293.481 | 89.775 | 913.326 | 176.963 | 119.733 |
+| `sort_window` | 3.885 | 119.865 | 1286.924 | 94.916 | 933.638 | 178.569 | 131.538 |
+| `bloom_filter` | 6.264 | 123.713 | 1303.167 | 93.007 | 921.550 | 173.527 | 124.198 |
+| `hash_join` | 11.743 | 247.889 | 1292.096 | 141.570 | 964.115 | 224.254 | 165.530 |
+| `sieve` | 4.461 | 116.452 | 1289.724 | 99.464 | 916.268 | 179.714 | 122.395 |
+| `fib` | 3.826 | 104.812 | 1284.927 | 85.011 | 910.366 | 164.787 | 109.382 |
+| `collatz` | 4.465 | 114.138 | 1296.565 | 89.066 | 907.583 | 172.090 | 115.567 |
+| `matmul` | 5.611 | 124.134 | 1299.104 | 101.733 | 923.450 | 217.474 | 150.153 |
+| `json_parse` | 84.447 | 832.449 | 1490.903 | 144.127 | 1061.113 | 314.274 | 225.747 |
 
 ## 7. Correctness gate
 
@@ -254,21 +248,21 @@ a runtime that gets the wrong answer quickly is not a fast runtime.
 
 | Benchmark | Output | Verdict |
 |---|---|---|
-| `lcg` | `-7585129161289236796` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `affine_mix` | `227901546981696845` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `packet_classifier` | `4205972061` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `ring_write` | `8299504528805184357` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `histogram_bins` | `1215643728` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `prefix_scan` | `492982549` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `binary_search` | `805907445` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `sort_window` | `2815490238` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `bloom_filter` | `2351703` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `hash_join` | `2814341850483607168` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `sieve` | `664579` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `fib` | `9227465` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `collatz` | `350` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `matmul` | `393199` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
-| `json_parse` | `20` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--gc-sections` |
+| `lcg` | `-7585129161289236796` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `affine_mix` | `227901546981696845` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `packet_classifier` | `4205972061` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `ring_write` | `8299504528805184357` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `histogram_bins` | `1215643728` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `prefix_scan` | `492982549` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `binary_search` | `805907445` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `sort_window` | `2815490238` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `bloom_filter` | `2351703` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `hash_join` | `2814341850483607168` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `sieve` | `664579` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `fib` | `9227465` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `collatz` | `350` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `matmul` | `393199` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
+| `json_parse` | `20` | identical: 3 languages x {native, JIT, interpreter (NURL only)}, + NURL wasm `--no-gc-sections` |
 
 ## 8. Reading the numbers
 

--- a/bench/results/wasm-latest.json
+++ b/bench/results/wasm-latest.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
   "kind": "wasm",
-  "generated_utc": "2026-07-27T09:53:03Z",
-  "commit": "ad7e4391c17af5bc82ffc997b8e97005329aabd2",
+  "generated_utc": "2026-07-27T12:22:26Z",
+  "commit": "9111299b88a23cbb25425c2c91c305a29f59fac5",
   "run_url": "",
   "host": {
     "label": "Linux x86_64",
@@ -31,11 +31,11 @@
     "interpreter_all_languages": false
   },
   "floor_ms": {
-    "native": { "nurl": 1.664, "c": 1.527, "rust": 1.705 },
-    "wasm_ref": { "nurl": 62.536, "c": 7.151, "rust": 17.188, "nurl_gc_sections": 10.267 },
-    "wasm_wt": { "nurl": 45.100, "c": null, "rust": null }
+    "native": { "nurl": 1.510, "c": 1.708, "rust": 1.515 },
+    "wasm_ref": { "nurl": 10.570, "c": 8.232, "rust": 19.302, "nurl_no_gc_sections": 60.276 },
+    "wasm_wt": { "nurl": 49.586, "c": null, "rust": null }
   },
-  "floor_compile_ms": { "nurl_frontend": 3.968, "nurl_native": 109.052, "nurl_wasm": 1334.094, "nurl_wasm_gc_sections": 1364.862, "c_native": 81.312, "c_wasm": 602.986, "rust_native": 156.370, "rust_wasm": 109.577 },
+  "floor_compile_ms": { "nurl_frontend": 3.080, "nurl_native": 100.137, "nurl_wasm": 1344.016, "nurl_wasm_no_gc_sections": 1373.618, "c_native": 75.422, "c_wasm": 582.966, "rust_native": 156.718, "rust_wasm": 102.580 },
   "benchmarks": [
     {
       "name": "lcg",
@@ -44,17 +44,17 @@
       "checksum": "-7585129161289236796",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 39.454, "c": 36.734, "rust": 40.684 },
-        "wasm_ref": { "nurl": 92.613, "c": 70.561, "rust": 55.154, "nurl_gc_sections": 60.884 },
-        "wasm_wt":  { "nurl": 2561.128, "c": null, "rust": null }
+        "native":   { "nurl": 41.183, "c": 32.909, "rust": 36.185 },
+        "wasm_ref": { "nurl": 63.348, "c": 61.315, "rust": 55.044, "nurl_no_gc_sections": 90.273 },
+        "wasm_wt":  { "nurl": 2551.115, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 3, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 3.911, "nurl_native": 110.031, "nurl_wasm": 1362.946, "nurl_wasm_gc_sections": 1398.934, "c_native": 95.402, "c_wasm": 951.330, "rust_native": 183.458, "rust_wasm": 123.338 },
-      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089299, "nurl_wasm_gc_sections": 839041, "c_native": 16008, "c_wasm": 702181, "rust_native": 3832512, "rust_wasm": 1774926 }
+      "compile_ms": { "nurl_frontend": 3.858, "nurl_native": 114.276, "nurl_wasm": 1382.076, "nurl_wasm_no_gc_sections": 1379.245, "c_native": 87.007, "c_wasm": 959.991, "rust_native": 178.911, "rust_wasm": 117.602 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 839039, "nurl_wasm_no_gc_sections": 1089303, "c_native": 16008, "c_wasm": 702181, "rust_native": 3832512, "rust_wasm": 1774926 }
     },
     {
       "name": "affine_mix",
@@ -63,17 +63,17 @@
       "checksum": "227901546981696845",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 33.592, "c": 34.469, "rust": 40.279 },
-        "wasm_ref": { "nurl": 91.026, "c": 59.458, "rust": 53.595, "nurl_gc_sections": 59.683 },
-        "wasm_wt":  { "nurl": 5261.156, "c": null, "rust": null }
+        "native":   { "nurl": 40.523, "c": 41.117, "rust": 40.623 },
+        "wasm_ref": { "nurl": 61.405, "c": 66.680, "rust": 54.937, "nurl_no_gc_sections": 95.278 },
+        "wasm_wt":  { "nurl": 5236.536, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 4.045, "nurl_native": 110.049, "nurl_wasm": 1305.744, "nurl_wasm_gc_sections": 1316.444, "c_native": 86.817, "c_wasm": 938.474, "rust_native": 168.551, "rust_wasm": 121.083 },
-      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089174, "nurl_wasm_gc_sections": 838982, "c_native": 16016, "c_wasm": 702280, "rust_native": 3832584, "rust_wasm": 1775198 }
+      "compile_ms": { "nurl_frontend": 3.493, "nurl_native": 115.152, "nurl_wasm": 1356.697, "nurl_wasm_no_gc_sections": 1317.717, "c_native": 87.965, "c_wasm": 949.898, "rust_native": 170.456, "rust_wasm": 122.011 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 838980, "nurl_wasm_no_gc_sections": 1089178, "c_native": 16016, "c_wasm": 702280, "rust_native": 3832584, "rust_wasm": 1775198 }
     },
     {
       "name": "packet_classifier",
@@ -82,17 +82,17 @@
       "checksum": "4205972061",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 63.118, "c": 68.643, "rust": 68.195 },
-        "wasm_ref": { "nurl": 111.411, "c": 77.651, "rust": 69.459, "nurl_gc_sections": 79.172 },
-        "wasm_wt":  { "nurl": 5645.706, "c": null, "rust": null }
+        "native":   { "nurl": 70.215, "c": 69.073, "rust": 67.798 },
+        "wasm_ref": { "nurl": 78.930, "c": 80.049, "rust": 69.127, "nurl_no_gc_sections": 112.320 },
+        "wasm_wt":  { "nurl": 5609.458, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 3.792, "nurl_native": 109.116, "nurl_wasm": 1317.276, "nurl_wasm_gc_sections": 1364.031, "c_native": 94.783, "c_wasm": 915.998, "rust_native": 176.435, "rust_wasm": 121.980 },
-      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089164, "nurl_wasm_gc_sections": 838981, "c_native": 16024, "c_wasm": 702214, "rust_native": 3832608, "rust_wasm": 1775209 }
+      "compile_ms": { "nurl_frontend": 3.473, "nurl_native": 112.784, "nurl_wasm": 1317.455, "nurl_wasm_no_gc_sections": 1310.936, "c_native": 89.343, "c_wasm": 921.005, "rust_native": 168.487, "rust_wasm": 114.505 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 838979, "nurl_wasm_no_gc_sections": 1089168, "c_native": 16024, "c_wasm": 702214, "rust_native": 3832608, "rust_wasm": 1775209 }
     },
     {
       "name": "ring_write",
@@ -101,17 +101,17 @@
       "checksum": "8299504528805184357",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 37.471, "c": 37.305, "rust": 43.807 },
-        "wasm_ref": { "nurl": 98.644, "c": 69.063, "rust": 64.403, "nurl_gc_sections": 68.821 },
-        "wasm_wt":  { "nurl": 7022.937, "c": null, "rust": null }
+        "native":   { "nurl": 41.292, "c": 43.946, "rust": 43.901 },
+        "wasm_ref": { "nurl": 79.389, "c": 77.009, "rust": 64.662, "nurl_no_gc_sections": 99.169 },
+        "wasm_wt":  { "nurl": 6964.832, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 3.754, "nurl_native": 106.551, "nurl_wasm": 1286.930, "nurl_wasm_gc_sections": 1300.691, "c_native": 89.003, "c_wasm": 940.199, "rust_native": 171.690, "rust_wasm": 113.975 },
-      "bytes": { "nurl_native": 16080, "nurl_wasm": 1089324, "nurl_wasm_gc_sections": 839054, "c_native": 16064, "c_wasm": 702453, "rust_native": 3832584, "rust_wasm": 1775263 }
+      "compile_ms": { "nurl_frontend": 3.394, "nurl_native": 112.196, "nurl_wasm": 1288.880, "nurl_wasm_no_gc_sections": 1306.318, "c_native": 88.396, "c_wasm": 923.347, "rust_native": 166.190, "rust_wasm": 112.252 },
+      "bytes": { "nurl_native": 16080, "nurl_wasm": 839052, "nurl_wasm_no_gc_sections": 1089328, "c_native": 16064, "c_wasm": 702453, "rust_native": 3832584, "rust_wasm": 1775263 }
     },
     {
       "name": "histogram_bins",
@@ -120,17 +120,17 @@
       "checksum": "1215643728",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 41.374, "c": 41.853, "rust": 41.801 },
-        "wasm_ref": { "nurl": 100.163, "c": 73.794, "rust": 64.298, "nurl_gc_sections": 77.872 },
-        "wasm_wt":  { "nurl": 7289.204, "c": null, "rust": null }
+        "native":   { "nurl": 42.732, "c": 42.018, "rust": 41.307 },
+        "wasm_ref": { "nurl": 71.423, "c": 74.914, "rust": 64.209, "nurl_no_gc_sections": 104.321 },
+        "wasm_wt":  { "nurl": 7687.511, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 4.750, "nurl_native": 117.854, "nurl_wasm": 1297.838, "nurl_wasm_gc_sections": 1285.593, "c_native": 87.753, "c_wasm": 924.073, "rust_native": 168.438, "rust_wasm": 112.015 },
-      "bytes": { "nurl_native": 16080, "nurl_wasm": 1089464, "nurl_wasm_gc_sections": 839128, "c_native": 16072, "c_wasm": 702643, "rust_native": 3832600, "rust_wasm": 1775356 }
+      "compile_ms": { "nurl_frontend": 4.284, "nurl_native": 112.554, "nurl_wasm": 1298.565, "nurl_wasm_no_gc_sections": 1298.714, "c_native": 91.446, "c_wasm": 919.696, "rust_native": 176.198, "rust_wasm": 114.709 },
+      "bytes": { "nurl_native": 16080, "nurl_wasm": 839126, "nurl_wasm_no_gc_sections": 1089468, "c_native": 16072, "c_wasm": 702643, "rust_native": 3832600, "rust_wasm": 1775356 }
     },
     {
       "name": "prefix_scan",
@@ -139,17 +139,17 @@
       "checksum": "492982549",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 24.097, "c": 24.841, "rust": 24.624 },
-        "wasm_ref": { "nurl": 79.843, "c": 48.479, "rust": 29.781, "nurl_gc_sections": 49.952 },
-        "wasm_wt":  { "nurl": 2512.158, "c": null, "rust": null }
+        "native":   { "nurl": 21.309, "c": 18.372, "rust": 24.808 },
+        "wasm_ref": { "nurl": 49.506, "c": 56.206, "rust": 31.197, "nurl_no_gc_sections": 78.566 },
+        "wasm_wt":  { "nurl": 2514.534, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 3, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 4.434, "nurl_native": 113.783, "nurl_wasm": 1293.032, "nurl_wasm_gc_sections": 1293.663, "c_native": 87.699, "c_wasm": 921.444, "rust_native": 166.301, "rust_wasm": 111.517 },
-      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089468, "nurl_wasm_gc_sections": 839428, "c_native": 16016, "c_wasm": 703429, "rust_native": 3832584, "rust_wasm": 1775615 }
+      "compile_ms": { "nurl_frontend": 4.437, "nurl_native": 116.553, "nurl_wasm": 1303.081, "nurl_wasm_no_gc_sections": 1288.204, "c_native": 92.921, "c_wasm": 928.181, "rust_native": 176.495, "rust_wasm": 113.213 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 839426, "nurl_wasm_no_gc_sections": 1089472, "c_native": 16016, "c_wasm": 703429, "rust_native": 3832584, "rust_wasm": 1775615 }
     },
     {
       "name": "binary_search",
@@ -158,17 +158,17 @@
       "checksum": "805907445",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 34.228, "c": 36.161, "rust": 43.948 },
-        "wasm_ref": { "nurl": 132.185, "c": 117.260, "rust": 99.095, "nurl_gc_sections": 104.771 },
-        "wasm_wt":  { "nurl": 15085.611, "c": null, "rust": null }
+        "native":   { "nurl": 33.155, "c": 36.373, "rust": 41.671 },
+        "wasm_ref": { "nurl": 105.340, "c": 116.769, "rust": 97.377, "nurl_no_gc_sections": 133.505 },
+        "wasm_wt":  { "nurl": 14824.405, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 3.848, "nurl_native": 111.293, "nurl_wasm": 1301.846, "nurl_wasm_gc_sections": 1299.296, "c_native": 90.424, "c_wasm": 913.416, "rust_native": 179.118, "rust_wasm": 125.883 },
-      "bytes": { "nurl_native": 16080, "nurl_wasm": 1089208, "nurl_wasm_gc_sections": 839168, "c_native": 16016, "c_wasm": 703201, "rust_native": 3832592, "rust_wasm": 1776147 }
+      "compile_ms": { "nurl_frontend": 4.875, "nurl_native": 118.572, "nurl_wasm": 1293.481, "nurl_wasm_no_gc_sections": 1285.422, "c_native": 89.775, "c_wasm": 913.326, "rust_native": 176.963, "rust_wasm": 119.733 },
+      "bytes": { "nurl_native": 16080, "nurl_wasm": 839166, "nurl_wasm_no_gc_sections": 1089212, "c_native": 16016, "c_wasm": 703201, "rust_native": 3832592, "rust_wasm": 1776147 }
     },
     {
       "name": "sort_window",
@@ -177,17 +177,17 @@
       "checksum": "2815490238",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 41.188, "c": 52.501, "rust": 53.575 },
-        "wasm_ref": { "nurl": 110.110, "c": 75.914, "rust": 123.660, "nurl_gc_sections": 80.610 },
-        "wasm_wt":  { "nurl": 40323.696, "c": null, "rust": null }
+        "native":   { "nurl": 49.554, "c": 52.290, "rust": 53.553 },
+        "wasm_ref": { "nurl": 86.902, "c": 73.854, "rust": 126.604, "nurl_no_gc_sections": 113.051 },
+        "wasm_wt":  { "nurl": 40168.675, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 4.458, "nurl_native": 123.809, "nurl_wasm": 1379.428, "nurl_wasm_gc_sections": 1356.701, "c_native": 92.877, "c_wasm": 944.488, "rust_native": 176.587, "rust_wasm": 131.672 },
-      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089919, "nurl_wasm_gc_sections": 839462, "c_native": 16016, "c_wasm": 703289, "rust_native": 3832584, "rust_wasm": 1775550 }
+      "compile_ms": { "nurl_frontend": 3.885, "nurl_native": 119.865, "nurl_wasm": 1286.924, "nurl_wasm_no_gc_sections": 1298.029, "c_native": 94.916, "c_wasm": 933.638, "rust_native": 178.569, "rust_wasm": 131.538 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 839460, "nurl_wasm_no_gc_sections": 1089923, "c_native": 16016, "c_wasm": 703289, "rust_native": 3832584, "rust_wasm": 1775550 }
     },
     {
       "name": "bloom_filter",
@@ -196,17 +196,17 @@
       "checksum": "2351703",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 18.133, "c": 16.750, "rust": 17.689 },
-        "wasm_ref": { "nurl": 81.014, "c": 45.560, "rust": 36.494, "nurl_gc_sections": 42.536 },
-        "wasm_wt":  { "nurl": 3820.273, "c": null, "rust": null }
+        "native":   { "nurl": 19.152, "c": 18.007, "rust": 17.037 },
+        "wasm_ref": { "nurl": 48.000, "c": 51.440, "rust": 35.199, "nurl_no_gc_sections": 80.531 },
+        "wasm_wt":  { "nurl": 3837.375, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 2, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 5.249, "nurl_native": 118.834, "nurl_wasm": 1296.963, "nurl_wasm_gc_sections": 1289.292, "c_native": 96.674, "c_wasm": 916.469, "rust_native": 178.571, "rust_wasm": 119.138 },
-      "bytes": { "nurl_native": 16080, "nurl_wasm": 1089670, "nurl_wasm_gc_sections": 839296, "c_native": 16072, "c_wasm": 703714, "rust_native": 3832592, "rust_wasm": 1775478 }
+      "compile_ms": { "nurl_frontend": 6.264, "nurl_native": 123.713, "nurl_wasm": 1303.167, "nurl_wasm_no_gc_sections": 1293.098, "c_native": 93.007, "c_wasm": 921.550, "rust_native": 173.527, "rust_wasm": 124.198 },
+      "bytes": { "nurl_native": 16080, "nurl_wasm": 839294, "nurl_wasm_no_gc_sections": 1089674, "c_native": 16072, "c_wasm": 703714, "rust_native": 3832592, "rust_wasm": 1775478 }
     },
     {
       "name": "hash_join",
@@ -215,17 +215,17 @@
       "checksum": "2814341850483607168",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 6.320, "c": 4.886, "rust": 5.320 },
-        "wasm_ref": { "nurl": 66.795, "c": 31.750, "rust": 24.550, "nurl_gc_sections": 30.637 },
-        "wasm_wt":  { "nurl": 3324.280, "c": null, "rust": null }
+        "native":   { "nurl": 6.134, "c": 6.490, "rust": 6.628 },
+        "wasm_ref": { "nurl": 31.054, "c": 33.094, "rust": 25.039, "nurl_no_gc_sections": 67.468 },
+        "wasm_wt":  { "nurl": 3264.882, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 2, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 9.265, "nurl_native": 246.170, "nurl_wasm": 1307.893, "nurl_wasm_gc_sections": 1318.450, "c_native": 141.155, "c_wasm": 967.105, "rust_native": 232.732, "rust_wasm": 177.676 },
-      "bytes": { "nurl_native": 20176, "nurl_wasm": 1092266, "nurl_wasm_gc_sections": 841200, "c_native": 16064, "c_wasm": 711257, "rust_native": 3832576, "rust_wasm": 1777836 }
+      "compile_ms": { "nurl_frontend": 11.743, "nurl_native": 247.889, "nurl_wasm": 1292.096, "nurl_wasm_no_gc_sections": 1320.414, "c_native": 141.570, "c_wasm": 964.115, "rust_native": 224.254, "rust_wasm": 165.530 },
+      "bytes": { "nurl_native": 20176, "nurl_wasm": 841198, "nurl_wasm_no_gc_sections": 1092270, "c_native": 16064, "c_wasm": 711257, "rust_native": 3832576, "rust_wasm": 1777836 }
     },
     {
       "name": "sieve",
@@ -234,17 +234,17 @@
       "checksum": "664579",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 43.446, "c": 42.302, "rust": 37.415 },
-        "wasm_ref": { "nurl": 99.869, "c": 68.849, "rust": 61.224, "nurl_gc_sections": 66.558 },
-        "wasm_wt":  { "nurl": 5165.420, "c": null, "rust": null }
+        "native":   { "nurl": 42.894, "c": 42.528, "rust": 42.194 },
+        "wasm_ref": { "nurl": 67.377, "c": 64.524, "rust": 60.775, "nurl_no_gc_sections": 99.631 },
+        "wasm_wt":  { "nurl": 5110.445, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 5.235, "nurl_native": 119.781, "nurl_wasm": 1358.393, "nurl_wasm_gc_sections": 1358.959, "c_native": 94.151, "c_wasm": 938.741, "rust_native": 186.617, "rust_wasm": 131.672 },
-      "bytes": { "nurl_native": 16128, "nurl_wasm": 1089383, "nurl_wasm_gc_sections": 839062, "c_native": 16112, "c_wasm": 707132, "rust_native": 3832288, "rust_wasm": 1775002 }
+      "compile_ms": { "nurl_frontend": 4.461, "nurl_native": 116.452, "nurl_wasm": 1289.724, "nurl_wasm_no_gc_sections": 1286.726, "c_native": 99.464, "c_wasm": 916.268, "rust_native": 179.714, "rust_wasm": 122.395 },
+      "bytes": { "nurl_native": 16128, "nurl_wasm": 839060, "nurl_wasm_no_gc_sections": 1089387, "c_native": 16112, "c_wasm": 707132, "rust_native": 3832288, "rust_wasm": 1775002 }
     },
     {
       "name": "fib",
@@ -253,17 +253,17 @@
       "checksum": "9227465",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 34.440, "c": 33.702, "rust": 30.222 },
-        "wasm_ref": { "nurl": 102.493, "c": 65.008, "rust": 64.897, "nurl_gc_sections": 71.491 },
-        "wasm_wt":  { "nurl": 11474.997, "c": null, "rust": null }
+        "native":   { "nurl": 33.745, "c": 34.790, "rust": 33.466 },
+        "wasm_ref": { "nurl": 70.521, "c": 65.328, "rust": 63.047, "nurl_no_gc_sections": 100.020 },
+        "wasm_wt":  { "nurl": 11376.658, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 3.771, "nurl_native": 111.500, "nurl_wasm": 1337.662, "nurl_wasm_gc_sections": 1332.718, "c_native": 87.876, "c_wasm": 938.591, "rust_native": 171.183, "rust_wasm": 114.812 },
-      "bytes": { "nurl_native": 16032, "nurl_wasm": 1089021, "nurl_wasm_gc_sections": 838949, "c_native": 16040, "c_wasm": 702022, "rust_native": 3828224, "rust_wasm": 1774826 }
+      "compile_ms": { "nurl_frontend": 3.826, "nurl_native": 104.812, "nurl_wasm": 1284.927, "nurl_wasm_no_gc_sections": 1289.261, "c_native": 85.011, "c_wasm": 910.366, "rust_native": 164.787, "rust_wasm": 109.382 },
+      "bytes": { "nurl_native": 16032, "nurl_wasm": 838947, "nurl_wasm_no_gc_sections": 1089025, "c_native": 16040, "c_wasm": 702022, "rust_native": 3828224, "rust_wasm": 1774826 }
     },
     {
       "name": "collatz",
@@ -272,17 +272,17 @@
       "checksum": "350",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 18.651, "c": 17.458, "rust": 18.617 },
-        "wasm_ref": { "nurl": 78.851, "c": 43.512, "rust": 38.712, "nurl_gc_sections": 44.133 },
-        "wasm_wt":  { "nurl": 2662.316, "c": null, "rust": null }
+        "native":   { "nurl": 18.066, "c": 18.866, "rust": 17.400 },
+        "wasm_ref": { "nurl": 42.776, "c": 40.755, "rust": 39.977, "nurl_no_gc_sections": 77.469 },
+        "wasm_wt":  { "nurl": 2645.571, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 3, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 4.219, "nurl_native": 107.542, "nurl_wasm": 1326.105, "nurl_wasm_gc_sections": 1340.779, "c_native": 89.276, "c_wasm": 929.486, "rust_native": 170.377, "rust_wasm": 123.266 },
-      "bytes": { "nurl_native": 15976, "nurl_wasm": 1089194, "nurl_wasm_gc_sections": 838955, "c_native": 16016, "c_wasm": 702163, "rust_native": 3828176, "rust_wasm": 1774828 }
+      "compile_ms": { "nurl_frontend": 4.465, "nurl_native": 114.138, "nurl_wasm": 1296.565, "nurl_wasm_no_gc_sections": 1295.016, "c_native": 89.066, "c_wasm": 907.583, "rust_native": 172.090, "rust_wasm": 115.567 },
+      "bytes": { "nurl_native": 15976, "nurl_wasm": 838953, "nurl_wasm_no_gc_sections": 1089198, "c_native": 16016, "c_wasm": 702163, "rust_native": 3828176, "rust_wasm": 1774828 }
     },
     {
       "name": "matmul",
@@ -291,17 +291,17 @@
       "checksum": "393199",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 35.631, "c": 35.353, "rust": 35.041 },
-        "wasm_ref": { "nurl": 89.686, "c": 60.555, "rust": 55.030, "nurl_gc_sections": 60.514 },
-        "wasm_wt":  { "nurl": 4240.486, "c": null, "rust": null }
+        "native":   { "nurl": 35.267, "c": 36.260, "rust": 34.066 },
+        "wasm_ref": { "nurl": 64.453, "c": 58.969, "rust": 55.368, "nurl_no_gc_sections": 92.486 },
+        "wasm_wt":  { "nurl": 4192.871, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 5.588, "nurl_native": 123.111, "nurl_wasm": 1337.730, "nurl_wasm_gc_sections": 1329.532, "c_native": 99.820, "c_wasm": 950.490, "rust_native": 213.000, "rust_wasm": 153.248 },
-      "bytes": { "nurl_native": 16128, "nurl_wasm": 1089379, "nurl_wasm_gc_sections": 839339, "c_native": 16160, "c_wasm": 708006, "rust_native": 3832536, "rust_wasm": 1775486 }
+      "compile_ms": { "nurl_frontend": 5.611, "nurl_native": 124.134, "nurl_wasm": 1299.104, "nurl_wasm_no_gc_sections": 1292.232, "c_native": 101.733, "c_wasm": 923.450, "rust_native": 217.474, "rust_wasm": 150.153 },
+      "bytes": { "nurl_native": 16128, "nurl_wasm": 839337, "nurl_wasm_no_gc_sections": 1089383, "c_native": 16160, "c_wasm": 708006, "rust_native": 3832536, "rust_wasm": 1775486 }
     },
     {
       "name": "json_parse",
@@ -310,17 +310,17 @@
       "checksum": "20",
       "verified": true,
       "run_ms": {
-        "native":   { "nurl": 11.850, "c": 8.871, "rust": 14.477 },
-        "wasm_ref": { "nurl": 88.650, "c": 39.651, "rust": 40.095, "nurl_gc_sections": 47.099 },
-        "wasm_wt":  { "nurl": 29424.539, "c": null, "rust": null }
+        "native":   { "nurl": 12.571, "c": 11.904, "rust": 15.011 },
+        "wasm_ref": { "nurl": 51.354, "c": 37.642, "rust": 40.701, "nurl_no_gc_sections": 86.472 },
+        "wasm_wt":  { "nurl": 29149.574, "c": null, "rust": null }
       },
       "reps": {
         "native":   { "nurl": 5, "c": 5, "rust": 5 },
-        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_gc_sections": 5 },
+        "wasm_ref": { "nurl": 5, "c": 5, "rust": 5, "nurl_no_gc_sections": 5 },
         "wasm_wt":  { "nurl": 1, "c": 0, "rust": 0 }
       },
-      "compile_ms": { "nurl_frontend": 85.653, "nurl_native": 849.593, "nurl_wasm": 1560.415, "nurl_wasm_gc_sections": 1543.646, "c_native": 141.863, "c_wasm": 1102.307, "rust_native": 322.235, "rust_wasm": 235.882 },
-      "bytes": { "nurl_native": 34824, "nurl_wasm": 1145493, "nurl_wasm_gc_sections": 869437, "c_native": 16632, "c_wasm": 753401, "rust_native": 3847336, "rust_wasm": 1805091 }
+      "compile_ms": { "nurl_frontend": 84.447, "nurl_native": 832.449, "nurl_wasm": 1490.903, "nurl_wasm_no_gc_sections": 1535.475, "c_native": 144.127, "c_wasm": 1061.113, "rust_native": 314.274, "rust_wasm": 225.747 },
+      "bytes": { "nurl_native": 34824, "nurl_wasm": 869435, "nurl_wasm_no_gc_sections": 1145497, "c_native": 16632, "c_wasm": 753401, "rust_native": 3847336, "rust_wasm": 1805091 }
     }
   ]
 }

--- a/bench/wasmbench.sh
+++ b/bench/wasmbench.sh
@@ -21,7 +21,7 @@
 #                         column on its left is the cost of *this runtime*.
 #
 #  Ten timed cells per row — 3 languages x {native, JIT, interpreter}, plus
-#  the NURL module relinked with --gc-sections — all gated on printing the
+#  the NURL module relinked with --no-gc-sections — all gated on printing the
 #  same line as the native NURL binary. A speed number for a program
 #  computing something else is worthless.
 #
@@ -276,19 +276,16 @@ compile_nurl_wasm() {      # <src.nu> <outbase> -> "<ms>" or FAIL
     median "${res[@]}"
 }
 
-# The same pipeline with `--gc-sections`, which wasmbuilder leaves off by
-# default: NURL closures store function-table indices and section GC
-# renumbers that table, so a closure captured before the collection can call
-# the wrong function after it — a run-time `call_indirect` trap, with no
-# link error to warn anyone. What it drops is most of the NURL runtime a
-# small program never calls, which on the reference runtime is code being
-# translated for nothing. None of these benchmarks uses a closure, so the
-# variant is built for all of them, gated on identical output like every
-# other cell, and reported beside the default in section 5.
-compile_nurl_wasm_gc() {   # <src.nu> <outbase> -> "<ms>" or FAIL
-    local src="$1" out="$2.nugc.wasm" res=() r t
+# The same pipeline with `--no-gc-sections` — what wasmbuilder's default
+# USED to be, kept measured so the cost of ever needing the escape hatch
+# (a call_indirect trap under table renumbering, not seen since the flip)
+# stays a number instead of a memory. Built for every benchmark, gated on
+# identical output like every other cell, reported beside the default in
+# section 5.
+compile_nurl_wasm_nogc() { # <src.nu> <outbase> -> "<ms>" or FAIL
+    local src="$1" out="$2.nunogc.wasm" res=() r t
     for ((r = 0; r < COMPILE_REPS; r++)); do
-        t="$(cd "$ROOT" && time_ms "$WASMBUILDER" -q --gc-sections "$src" -o "$out")"
+        t="$(cd "$ROOT" && time_ms "$WASMBUILDER" -q --no-gc-sections "$src" -o "$out")"
         [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
         res+=("$t")
     done
@@ -397,7 +394,7 @@ printf 'fn main() {}\n'                  > "$floor_dir/floor.rs"
 echo "  measuring the floor …" >&2
 read -r floor_cc_nurl_fe floor_cc_nurl <<<"$(compile_nurl_native "$floor_dir/floor.nu" "$floor_dir/floor")"
 floor_cc_nurl_wasm="$(compile_nurl_wasm "$floor_dir/floor.nu" "$floor_dir/floor")"
-floor_cc_nurl_wasm_gc="$(compile_nurl_wasm_gc "$floor_dir/floor.nu" "$floor_dir/floor")"
+floor_cc_nurl_wasm_nogc="$(compile_nurl_wasm_nogc "$floor_dir/floor.nu" "$floor_dir/floor")"
 floor_cc_c="$(compile_c_native "$floor_dir/floor.c" "$floor_dir/floor")"
 floor_cc_c_wasm="$(compile_c_wasm "$floor_dir/floor.c" "$floor_dir/floor")"
 floor_cc_rust="$(compile_rust_native "$floor_dir/floor.rs" "$floor_dir/floor")"
@@ -407,7 +404,7 @@ read -r floor_nurl _      <<<"$(cd "$ROOT" && time_cell "$floor_dir/floor.nurl.b
 read -r floor_c _         <<<"$(cd "$ROOT" && time_cell "$floor_dir/floor.c.bin")"
 read -r floor_rust _      <<<"$(cd "$ROOT" && time_cell "$floor_dir/floor.rs.bin")"
 read -r floor_nurl_ref _  <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$floor_dir/floor.nu.wasm")"
-read -r floor_nurl_ref_gc _ <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$floor_dir/floor.nugc.wasm")"
+read -r floor_nurl_ref_nogc _ <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$floor_dir/floor.nunogc.wasm")"
 read -r floor_c_ref _     <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$floor_dir/floor.c.wasm")"
 read -r floor_rust_ref _  <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$floor_dir/floor.rs.wasm")"
 read -r floor_nurl_wt _   <<<"$(cd "$ROOT" && time_cell "${WT_RUN[@]}" "$floor_dir/floor.nu.wasm")"
@@ -430,8 +427,8 @@ r_nurl_wt_reps=(); r_c_wt_reps=(); r_rust_wt_reps=()
 r_cc_nurl_fe=(); r_cc_nurl=(); r_cc_nurl_wasm=()
 r_cc_c=(); r_cc_c_wasm=(); r_cc_rust=(); r_cc_rust_wasm=()
 r_sz_nurl=(); r_sz_nurl_wasm=(); r_sz_c=(); r_sz_c_wasm=(); r_sz_rust=(); r_sz_rust_wasm=()
-# the --gc-sections variant of the NURL module (section 5)
-r_cc_nurl_wasm_gc=(); r_sz_nurl_wasm_gc=(); r_nurl_ref_gc=(); r_nurl_ref_gc_reps=()
+# the --no-gc-sections variant of the NURL module (section 5)
+r_cc_nurl_wasm_nogc=(); r_sz_nurl_wasm_nogc=(); r_nurl_ref_nogc=(); r_nurl_ref_nogc_reps=()
 
 progress() { printf '\r\033[K  %-18s %s' "$1" "$2" >&2; }
 
@@ -444,17 +441,17 @@ for idx in "${!names[@]}"; do
     cc_rust="$(compile_rust_native "$BENCH/$b.rs" "$BUILD/$b")"
     progress "$b" "compiling wasm…"
     cc_nurl_wasm="$(compile_nurl_wasm "$BENCH/$b.nu" "$BUILD/$b")"
-    cc_nurl_wasm_gc="$(compile_nurl_wasm_gc "$BENCH/$b.nu" "$BUILD/$b")"
+    cc_nurl_wasm_nogc="$(compile_nurl_wasm_nogc "$BENCH/$b.nu" "$BUILD/$b")"
     cc_c_wasm="$(compile_c_wasm "$BENCH/$b.c" "$BUILD/$b")"
     cc_rust_wasm="$(compile_rust_wasm "$BENCH/$b.rs" "$BUILD/$b")"
     r_cc_nurl_fe+=("${cc_fe:-FAIL}"); r_cc_nurl+=("${cc_nurl:-FAIL}")
-    r_cc_nurl_wasm+=("$cc_nurl_wasm"); r_cc_nurl_wasm_gc+=("$cc_nurl_wasm_gc")
+    r_cc_nurl_wasm+=("$cc_nurl_wasm"); r_cc_nurl_wasm_nogc+=("$cc_nurl_wasm_nogc")
     r_cc_c+=("$cc_c"); r_cc_c_wasm+=("$cc_c_wasm")
     r_cc_rust+=("$cc_rust"); r_cc_rust_wasm+=("$cc_rust_wasm")
 
     r_sz_nurl+=("$(fsize "$BUILD/$b.nurl.bin")")
     r_sz_nurl_wasm+=("$(fsize "$BUILD/$b.nu.wasm")")
-    r_sz_nurl_wasm_gc+=("$(fsize "$BUILD/$b.nugc.wasm")")
+    r_sz_nurl_wasm_nogc+=("$(fsize "$BUILD/$b.nunogc.wasm")")
     r_sz_c+=("$(fsize "$BUILD/$b.c.bin")")
     r_sz_c_wasm+=("$(fsize "$BUILD/$b.c.wasm")")
     r_sz_rust+=("$(fsize "$BUILD/$b.rs.bin")")
@@ -472,7 +469,7 @@ for idx in "${!names[@]}"; do
     out_nurl_ref="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${REF_RUN[@]}" "$BUILD/$b.nu.wasm" 2>/dev/null)"
     out_c_ref="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${REF_RUN[@]}" "$BUILD/$b.c.wasm" 2>/dev/null)"
     out_rust_ref="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${REF_RUN[@]}" "$BUILD/$b.rs.wasm" 2>/dev/null)"
-    out_nurl_ref_gc="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${REF_RUN[@]}" "$BUILD/$b.nugc.wasm" 2>/dev/null)"
+    out_nurl_ref_nogc="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${REF_RUN[@]}" "$BUILD/$b.nunogc.wasm" 2>/dev/null)"
 
     progress "$b" "verifying interpreter…"
     out_nurl_wt="$(cd "$ROOT" && timeout "${TIMEOUT_S}s" "${WT_RUN[@]}" "$BUILD/$b.nu.wasm" 2>/dev/null)"
@@ -486,7 +483,7 @@ for idx in "${!names[@]}"; do
     verified=true; detail=""
     for pair in "NURL:$out_nurl" "C:$out_c" "Rust:$out_rust" \
                 "NURL/wasm:$out_nurl_ref" "C/wasm:$out_c_ref" "Rust/wasm:$out_rust_ref" \
-                "NURL/wasm+gc:$out_nurl_ref_gc" \
+                "NURL/wasm+nogc:$out_nurl_ref_nogc" \
                 "NURL/wt:$out_nurl_wt" "C/wt:$out_c_wt" "Rust/wt:$out_rust_wt"; do
         lang="${pair%%:*}"; got="${pair#*:}"
         # An empty line fails the gate even when every cell agrees on it:
@@ -504,7 +501,7 @@ for idx in "${!names[@]}"; do
         r_nurl+=(SKIPPED); r_c+=(SKIPPED); r_rust+=(SKIPPED)
         r_nurl_ref+=(SKIPPED); r_c_ref+=(SKIPPED); r_rust_ref+=(SKIPPED)
         r_nurl_wt+=(SKIPPED); r_c_wt+=(SKIPPED); r_rust_wt+=(SKIPPED)
-        r_nurl_ref_gc+=(SKIPPED); r_nurl_ref_gc_reps+=(0)
+        r_nurl_ref_nogc+=(SKIPPED); r_nurl_ref_nogc_reps+=(0)
         r_nurl_reps+=(0); r_c_reps+=(0); r_rust_reps+=(0)
         r_nurl_ref_reps+=(0); r_c_ref_reps+=(0); r_rust_ref_reps+=(0)
         r_nurl_wt_reps+=(0); r_c_wt_reps+=(0); r_rust_wt_reps+=(0)
@@ -524,8 +521,8 @@ for idx in "${!names[@]}"; do
     r_c_ref+=("$ms"); r_c_ref_reps+=("$reps")
     progress "$b" "timing Rust wasm (JIT)…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$BUILD/$b.rs.wasm")"
     r_rust_ref+=("$ms"); r_rust_ref_reps+=("$reps")
-    progress "$b" "timing NURL wasm+gc (JIT)…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$BUILD/$b.nugc.wasm")"
-    r_nurl_ref_gc+=("$ms"); r_nurl_ref_gc_reps+=("$reps")
+    progress "$b" "timing NURL wasm+nogc (JIT)…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "${REF_RUN[@]}" "$BUILD/$b.nunogc.wasm")"
+    r_nurl_ref_nogc+=("$ms"); r_nurl_ref_nogc_reps+=("$reps")
 
     progress "$b" "timing NURL wasm (wt)…"; read -r ms reps <<<"$(cd "$ROOT" && time_cell "${WT_RUN[@]}" "$BUILD/$b.nu.wasm")"
     r_nurl_wt+=("$ms"); r_nurl_wt_reps+=("$reps")
@@ -606,15 +603,15 @@ emit_json() {
     printf '  "floor_ms": {\n'
     printf '    "native": { "nurl": %s, "c": %s, "rust": %s },\n' \
         "$(jnum "$floor_nurl")" "$(jnum "$floor_c")" "$(jnum "$floor_rust")"
-    printf '    "wasm_ref": { "nurl": %s, "c": %s, "rust": %s, "nurl_gc_sections": %s },\n' \
+    printf '    "wasm_ref": { "nurl": %s, "c": %s, "rust": %s, "nurl_no_gc_sections": %s },\n' \
         "$(jnum "$floor_nurl_ref")" "$(jnum "$floor_c_ref")" "$(jnum "$floor_rust_ref")" \
-        "$(jnum "$floor_nurl_ref_gc")"
+        "$(jnum "$floor_nurl_ref_nogc")"
     printf '    "wasm_wt": { "nurl": %s, "c": %s, "rust": %s }\n' \
         "$(jnum "$floor_nurl_wt")" "$(jnum "$floor_c_wt")" "$(jnum "$floor_rust_wt")"
     printf '  },\n'
-    printf '  "floor_compile_ms": { "nurl_frontend": %s, "nurl_native": %s, "nurl_wasm": %s, "nurl_wasm_gc_sections": %s, "c_native": %s, "c_wasm": %s, "rust_native": %s, "rust_wasm": %s },\n' \
+    printf '  "floor_compile_ms": { "nurl_frontend": %s, "nurl_native": %s, "nurl_wasm": %s, "nurl_wasm_no_gc_sections": %s, "c_native": %s, "c_wasm": %s, "rust_native": %s, "rust_wasm": %s },\n' \
         "$(jnum "$floor_cc_nurl_fe")" "$(jnum "$floor_cc_nurl")" "$(jnum "$floor_cc_nurl_wasm")" \
-        "$(jnum "$floor_cc_nurl_wasm_gc")" \
+        "$(jnum "$floor_cc_nurl_wasm_nogc")" \
         "$(jnum "$floor_cc_c")" "$(jnum "$floor_cc_c_wasm")" \
         "$(jnum "$floor_cc_rust")" "$(jnum "$floor_cc_rust_wasm")"
     printf '  "benchmarks": [\n'
@@ -629,28 +626,28 @@ emit_json() {
         printf '      "run_ms": {\n'
         printf '        "native":   { "nurl": %s, "c": %s, "rust": %s },\n' \
             "$(jnum "${r_nurl[$i]}")" "$(jnum "${r_c[$i]}")" "$(jnum "${r_rust[$i]}")"
-        printf '        "wasm_ref": { "nurl": %s, "c": %s, "rust": %s, "nurl_gc_sections": %s },\n' \
+        printf '        "wasm_ref": { "nurl": %s, "c": %s, "rust": %s, "nurl_no_gc_sections": %s },\n' \
             "$(jnum "${r_nurl_ref[$i]}")" "$(jnum "${r_c_ref[$i]}")" "$(jnum "${r_rust_ref[$i]}")" \
-            "$(jnum "${r_nurl_ref_gc[$i]}")"
+            "$(jnum "${r_nurl_ref_nogc[$i]}")"
         printf '        "wasm_wt":  { "nurl": %s, "c": %s, "rust": %s }\n' \
             "$(jnum "${r_nurl_wt[$i]}")" "$(jnum "${r_c_wt[$i]}")" "$(jnum "${r_rust_wt[$i]}")"
         printf '      },\n'
         printf '      "reps": {\n'
         printf '        "native":   { "nurl": %s, "c": %s, "rust": %s },\n' \
             "${r_nurl_reps[$i]}" "${r_c_reps[$i]}" "${r_rust_reps[$i]}"
-        printf '        "wasm_ref": { "nurl": %s, "c": %s, "rust": %s, "nurl_gc_sections": %s },\n' \
+        printf '        "wasm_ref": { "nurl": %s, "c": %s, "rust": %s, "nurl_no_gc_sections": %s },\n' \
             "${r_nurl_ref_reps[$i]}" "${r_c_ref_reps[$i]}" "${r_rust_ref_reps[$i]}" \
-            "${r_nurl_ref_gc_reps[$i]}"
+            "${r_nurl_ref_nogc_reps[$i]}"
         printf '        "wasm_wt":  { "nurl": %s, "c": %s, "rust": %s }\n' \
             "${r_nurl_wt_reps[$i]}" "${r_c_wt_reps[$i]}" "${r_rust_wt_reps[$i]}"
         printf '      },\n'
-        printf '      "compile_ms": { "nurl_frontend": %s, "nurl_native": %s, "nurl_wasm": %s, "nurl_wasm_gc_sections": %s, "c_native": %s, "c_wasm": %s, "rust_native": %s, "rust_wasm": %s },\n' \
+        printf '      "compile_ms": { "nurl_frontend": %s, "nurl_native": %s, "nurl_wasm": %s, "nurl_wasm_no_gc_sections": %s, "c_native": %s, "c_wasm": %s, "rust_native": %s, "rust_wasm": %s },\n' \
             "$(jnum "${r_cc_nurl_fe[$i]}")" "$(jnum "${r_cc_nurl[$i]}")" "$(jnum "${r_cc_nurl_wasm[$i]}")" \
-            "$(jnum "${r_cc_nurl_wasm_gc[$i]}")" \
+            "$(jnum "${r_cc_nurl_wasm_nogc[$i]}")" \
             "$(jnum "${r_cc_c[$i]}")" "$(jnum "${r_cc_c_wasm[$i]}")" \
             "$(jnum "${r_cc_rust[$i]}")" "$(jnum "${r_cc_rust_wasm[$i]}")"
-        printf '      "bytes": { "nurl_native": %s, "nurl_wasm": %s, "nurl_wasm_gc_sections": %s, "c_native": %s, "c_wasm": %s, "rust_native": %s, "rust_wasm": %s }\n' \
-            "${r_sz_nurl[$i]}" "${r_sz_nurl_wasm[$i]}" "${r_sz_nurl_wasm_gc[$i]}" \
+        printf '      "bytes": { "nurl_native": %s, "nurl_wasm": %s, "nurl_wasm_no_gc_sections": %s, "c_native": %s, "c_wasm": %s, "rust_native": %s, "rust_wasm": %s }\n' \
+            "${r_sz_nurl[$i]}" "${r_sz_nurl_wasm[$i]}" "${r_sz_nurl_wasm_nogc[$i]}" \
             "${r_sz_c[$i]}" "${r_sz_c_wasm[$i]}" \
             "${r_sz_rust[$i]}" "${r_sz_rust_wasm[$i]}"
         printf '    }%s\n' "$( (( i < last )) && echo ',' )"
@@ -741,17 +738,15 @@ emit_md() {
     printf 'where it is most of the run.\n\n'
     printf 'A `—` means the subtraction has no signal left in it: the floor is more\n'
     printf 'than half of that cell, so the remainder is a difference of two similar\n'
-    printf 'numbers carrying both their errors. That is not a rare edge case in the\n'
-    printf "**NURL x** column — a 1 MB module's compilation is comparable to the\n"
-    printf 'benchmarks themselves, which is exactly why the `+gc` column beside it\n'
-    printf 'exists: the same NURL programs linked with `--gc-sections` (section 5)\n'
-    printf 'have a floor small enough to subtract cleanly, so they are where the\n'
-    printf "steady-state throughput of NURL's wasm can actually be read.\n\n"
-    printf '| Benchmark | NURL x | NURL +gc x | C x | Rust x |\n|---|---:|---:|---:|---:|\n'
+    printf 'numbers carrying both their errors. The `no gc` column is the\n'
+    printf 'pre-0.1.4 default relinked with `--no-gc-sections` (section 5); its\n'
+    printf 'floor is big enough that most of its rows land there, which is one of\n'
+    printf 'the reasons it is no longer the default.\n\n'
+    printf '| Benchmark | NURL x | NURL no-gc x | C x | Rust x |\n|---|---:|---:|---:|---:|\n'
     for i in "${!names[@]}"; do
         printf '| `%s` | %s | %s | %s | %s |\n' "${names[$i]}" \
             "$(ratio_net "${r_nurl_ref[$i]}" "$floor_nurl_ref" "${r_nurl[$i]}" "$floor_nurl")" \
-            "$(ratio_net "${r_nurl_ref_gc[$i]}" "$floor_nurl_ref_gc" "${r_nurl[$i]}" "$floor_nurl")" \
+            "$(ratio_net "${r_nurl_ref_nogc[$i]}" "$floor_nurl_ref_nogc" "${r_nurl[$i]}" "$floor_nurl")" \
             "$(ratio_net "${r_c_ref[$i]}" "$floor_c_ref" "${r_c[$i]}" "$floor_c")" \
             "$(ratio_net "${r_rust_ref[$i]}" "$floor_rust_ref" "${r_rust[$i]}" "$floor_rust")"
     done
@@ -812,39 +807,36 @@ emit_md() {
     done
     printf '\n'
 
-    printf '## 5. Dead code — what `--gc-sections` costs and buys\n\n'
-    printf 'Every NURL module above was linked with `-Wl,--no-gc-sections`, the\n'
-    printf 'default `wasmbuilder` ships. NURL closures store **function-table indices**\n'
-    printf 'and section GC renumbers that table, so a closure captured before the\n'
-    printf 'collection can call the wrong function after it — a run-time\n'
-    printf '`call_indirect` trap with no link error to warn anyone. The cost of that\n'
-    printf 'default is that most of the NURL runtime ships in, and is translated by\n'
-    printf 'the runtime, in every module that never calls it.\n\n'
-    printf 'These rows are the same benchmarks rebuilt with `--gc-sections`, run on\n'
-    printf 'the reference runtime, and held to the same output — none of them uses a\n'
-    printf 'closure, so the hazard does not apply and the saving is measurable.\n\n'
-    printf '| Benchmark | Size | Size +gc | Δ | JIT | JIT +gc | Δ |\n'
+    printf '## 5. Dead code — what `--no-gc-sections` would cost\n\n'
+    printf 'Every NURL module above was linked with `-Wl,--gc-sections`, the\n'
+    printf '`wasmbuilder` default since 0.1.4: the unreachable part of the NURL\n'
+    printf 'runtime is dropped instead of shipped and JIT-translated for nothing.\n'
+    printf 'The old default, `--no-gc-sections`, exists as an escape hatch for a\n'
+    printf 'closure/table-renumbering hazard that no longer reproduces — a\n'
+    printf '`--gc-sections` `nurlc.wasm` self-compiles byte-identically under both\n'
+    printf 'runtimes. These rows are the same benchmarks relinked with the escape\n'
+    printf 'hatch, held to the same output, so its price stays a number: what you\n'
+    printf 'pay in bytes and module-load time if you ever have to reach for it.\n\n'
+    printf '| Benchmark | Size | Size no-gc | Δ | JIT | JIT no-gc | Δ |\n'
     printf '|---|---:|---:|---:|---:|---:|---:|\n'
     printf '| _(floor: empty program)_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ | _%s_ |\n' \
-        "$(kib "$(fsize "$floor_dir/floor.nu.wasm")")" "$(kib "$(fsize "$floor_dir/floor.nugc.wasm")")" \
-        "$(pct "$(fsize "$floor_dir/floor.nu.wasm")" "$(fsize "$floor_dir/floor.nugc.wasm")")" \
-        "$floor_nurl_ref" "$floor_nurl_ref_gc" "$(pct "$floor_nurl_ref" "$floor_nurl_ref_gc")"
+        "$(kib "$(fsize "$floor_dir/floor.nu.wasm")")" "$(kib "$(fsize "$floor_dir/floor.nunogc.wasm")")" \
+        "$(pct "$(fsize "$floor_dir/floor.nu.wasm")" "$(fsize "$floor_dir/floor.nunogc.wasm")")" \
+        "$floor_nurl_ref" "$floor_nurl_ref_nogc" "$(pct "$floor_nurl_ref" "$floor_nurl_ref_nogc")"
     for i in "${!names[@]}"; do
         printf '| `%s` | %s | %s | %s | %s | %s | %s |\n' "${names[$i]}" \
-            "$(kib "${r_sz_nurl_wasm[$i]}")" "$(kib "${r_sz_nurl_wasm_gc[$i]}")" \
-            "$(pct "${r_sz_nurl_wasm[$i]}" "${r_sz_nurl_wasm_gc[$i]}")" \
-            "${r_nurl_ref[$i]}" "${r_nurl_ref_gc[$i]}" \
-            "$(pct "${r_nurl_ref[$i]}" "${r_nurl_ref_gc[$i]}")"
+            "$(kib "${r_sz_nurl_wasm[$i]}")" "$(kib "${r_sz_nurl_wasm_nogc[$i]}")" \
+            "$(pct "${r_sz_nurl_wasm[$i]}" "${r_sz_nurl_wasm_nogc[$i]}")" \
+            "${r_nurl_ref[$i]}" "${r_nurl_ref_nogc[$i]}" \
+            "$(pct "${r_nurl_ref[$i]}" "${r_nurl_ref_nogc[$i]}")"
     done
     printf '\n'
-    printf 'The saving is almost all fixed cost, so it is largest where the benchmark\n'
+    printf 'The cost is almost all fixed, so it is largest where the benchmark\n'
     printf 'itself is smallest — compare each row against the floor. It is reported\n'
     printf 'on the JIT and not on the interpreter because the interpreter is\n'
     printf 'execution-bound, not decode-bound: its floor row in section 3 is a few\n'
-    printf 'tens of milliseconds against cells in the tens of *seconds*, so shrinking\n'
-    printf 'the module cannot move it. This is a real optimisation, and what stands\n'
-    printf 'between it and being the default is making closure function-table indices\n'
-    printf 'survive renumbering — not the linker flag.\n\n'
+    printf 'tens of milliseconds against cells in the tens of *seconds*, so module\n'
+    printf 'size cannot move it either way.\n\n'
 
     printf '## 6. Compile time (median, ms)\n\n'
     printf 'The NURL wasm build is `wasmbuilder`: `nurlc` emits host LLVM IR, the IR\n'
@@ -871,7 +863,7 @@ emit_md() {
     printf '| Benchmark | Output | Verdict |\n|---|---|---|\n'
     for i in "${!names[@]}"; do
         if [[ "${r_verified[$i]}" == true ]]; then
-            printf '| `%s` | `%s` | identical: 3 languages x {native, JIT%s}, + NURL wasm `--gc-sections` |\n' \
+            printf '| `%s` | `%s` | identical: 3 languages x {native, JIT%s}, + NURL wasm `--no-gc-sections` |\n' \
                 "${names[$i]}" "${r_checksum[$i]}" \
                 "$( (( WT_ALL_LANGS )) && echo ', interpreter' || echo ', interpreter (NURL only)' )"
         else

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -1465,6 +1465,14 @@ s combined_stdout s combined_stderr → v {
                     // longer maps to its function, trapping at scale (e.g. nurlc.wasm
                     // compiling >150-function programs). --no-gc-sections keeps the
                     // table stable so indices stay valid.
+                    //
+                    // 2026-07-27: that trap no longer reproduces — packages/
+                    // wasmbuilder (this same pipeline, zig's wasm-ld) now defaults
+                    // to --gc-sections, validated by a byte-identical nurlc.wasm
+                    // SELF-COMPILE under two runtimes plus the closure corpus.
+                    // This service still links --no-gc-sections only because its
+                    // wasi-sdk container path has not been re-validated the same
+                    // way; flipping it is a measured ~25 % module-size win.
                     ( vec_push [s] clang_args `-Wl,--no-gc-sections` )
                     // Undefined symbols become wasm IMPORTS the host
                     // runtime resolves (WASI, and — via the GPU

--- a/packages/wasmbuilder/README.md
+++ b/packages/wasmbuilder/README.md
@@ -66,7 +66,7 @@ wasmbuilder <file.nu> [options]
                            resolve statically instead of becoming imports)
       --cflags FLAGS       extra compile/link flags, space-separated
                            (e.g. "-msimd128" for wasm SIMD)
-      --gc-sections        drop unreachable code at link time — see below
+      --no-gc-sections     keep unreachable code at link time — see below
       --no-host-imports    don't pass --ffi-host-imports to nurlc
   -q, --quiet              suppress progress output
       --doctor             show how nurlc / zig / runtime resolve here
@@ -77,26 +77,33 @@ wasmbuilder <file.nu> [options]
 each resolution step (nurlc, stdlib C sources, wasm compiler, cache dir)
 and what would happen next.
 
-### `--gc-sections`
+### `--gc-sections` is the default (and `--no-gc-sections` the escape hatch)
 
-Off by default, and the default is not timidity. NURL closures store
-**function-table indices**, and `--gc-sections` renumbers that table, so a
-closure captured before the collection can call the wrong function after
-it — a `call_indirect` trap at run time, with no link error to warn you.
-That was observed on `nurlc.wasm` (>150 functions).
+Since 0.1.4 modules are linked with `-Wl,--gc-sections`: unreachable
+code — mostly the part of the NURL runtime a program never calls — is
+dropped at link time. It is worth ~25 % of the module (`bench/lcg.nu`:
+1064 KiB → 820 KiB) and most of a JIT runtime's load-the-module floor
+(an empty program under the reference `wasmtime`: ~60 ms → ~10 ms),
+because the runtime stops translating code nothing reaches.
 
-It is worth turning on for a program that uses no closures, because what
-it drops is most of the NURL runtime the module never calls. On
-`bench/lcg.nu` the module goes 1064 KiB → 819 KiB and a reference
-`wasmtime` run goes ~120 ms → ~85 ms, because the runtime no longer
-translates code nothing reaches. [`bench/wasmbench.sh`](../../bench/wasmbench.sh)
-measures both forms of every benchmark and gates them on identical
-output.
+Earlier versions defaulted to `--no-gc-sections`, citing a real trap:
+NURL closures store function-table indices, section GC renumbers that
+table, and `nurlc.wasm` (>150 functions) was observed to `call_indirect`
+-trap under it. That blocker was re-tested at exactly the documented
+scale on 2026-07-27 and does not reproduce: a `--gc-sections`-linked
+`nurlc.wasm` **self-compiles the 65k-line compiler byte-identically to
+the native binary** under both the reference `wasmtime` and the
+pure-NURL `wt`, and the closure corpus (`test_05_closures_and_capture`,
+`test_06_torture_chamber`) passes. Today's `wasm-ld` relocates
+address-taken functions correctly through GC.
 
-The rule is: turn it on, run the program, check the output. Do not
-assume — and note that `--cflags "-Wl,--gc-sections"` is *not* the same
-thing: that appends a flag after the `--no-gc-sections` this builder
-already passes, leaving the outcome to wasm-ld's last-one-wins ordering.
+`--no-gc-sections` (library: `WbOpts.no_gc_sections`) restores the old
+behaviour. If a program ever traps on an indirect call *only* under the
+default, that is a table-renumbering bug resurfacing: switch it off and
+please report it. Use the flag rather than
+`--cflags "-Wl,--no-gc-sections"` — the latter appends after the flag
+this builder already passes and leaves the outcome to wasm-ld's
+last-one-wins ordering.
 
 ## Library use (embed the builder)
 

--- a/packages/wasmbuilder/src/build.nu
+++ b/packages/wasmbuilder/src/build.nu
@@ -5,17 +5,24 @@
 //   .nu ──nurlc──▶ LLVM IR ──wb_prepare_ir_for_wasi──▶ wasm32 IR
 //        ──[zig] cc --target=wasm32-wasi + runtime.wasm.o──▶ .wasm
 //
-// Link flags mirror nurlapi's production /build_wasm handler:
-//   -Wl,--no-gc-sections   NURL closures store function-table indices;
-//                          gc-sections renumbers the table → call_indirect
-//                          traps at scale (proven on nurlc.wasm >150 fns).
-//                          Opt back in per build with `. opts gc_sections`
-//                          / `--gc-sections` when the program has no
-//                          closures: it is worth ~25 % of the module and
-//                          about as much of a runtime's load time
-//                          (bench/wasmbench.sh measures both). Verify the
-//                          output, do not assume — the failure mode is a
-//                          call_indirect trap at run time, not a link error.
+// Link flags:
+//   -Wl,--gc-sections      The DEFAULT since 2026-07: drops the unreachable
+//                          part of the NURL runtime from every module —
+//                          ~25 % of the bytes and ~80 % of a JIT's
+//                          load-the-module floor. An old note here said NURL
+//                          closures (function-table indices) could not
+//                          survive the table renumbering, "proven on
+//                          nurlc.wasm >150 fns"; re-tested 2026-07-27 at
+//                          exactly that scale — a --gc-sections nurlc.wasm
+//                          SELF-COMPILES byte-identically to the native
+//                          compiler under both the reference wasmtime and
+//                          the pure-NURL wt, and the closure corpus
+//                          (test_05/test_06) passes. Wherever that trap came
+//                          from, today's wasm-ld relocates address-taken
+//                          functions correctly through GC. `--no-gc-sections`
+//                          / `. opts no_gc_sections` remains as the escape
+//                          hatch; a trap that appears only without it would
+//                          be a table-renumbering bug — please report it.
 //   (nurlapi's -Wl,--allow-undefined is replaced by per-declare
 //   "wasm-import-module"="env" IR attributes — zig cc's driver rejects
 //   the linker flag; see wasi_ir.nu. Same semantics: undefined symbols
@@ -54,11 +61,11 @@ $ `toolchain.nu`
     // — e.g. `-msimd128` for wasm SIMD
     s asyncify_imports  // comma-separated async import names (`` = none);
     // e.g. `env.wgpu_download` for the WebGPU backend's async readback
-    b gc_sections  // link with --gc-sections instead of the safe default
-    // --no-gc-sections. Opt-in, and read the note above the link
-    // stage before turning it on: it drops unreachable code (~25 %
-    // off a small module, and as much again off the runtime's
-    // load time) but renumbers the function table.
+    b no_gc_sections  // link with --no-gc-sections instead of the default
+    // --gc-sections — the escape hatch if a call_indirect trap
+    // ever points at table renumbering again (see the link-flags
+    // note at the top of this file). Costs ~25 % module size and
+    // most of a JIT runtime's module-load floor.
 }
 
 // Split a space-separated flag string into owned Strings (caller frees).
@@ -233,15 +240,15 @@ $ `toolchain.nu`
     // wasm side of it. `-Xclang <level>` goes straight to cc1 and survives.
     ? . cc is_zig { ( vec_push [s] args `-Xclang` ) ( vec_push [s] args . opts opt ) } {}
     ( vec_push [s] args `-Wno-override-module` )
-    // Section GC is off by default and opt-in per build, not per flag
-    // string: a caller who passes `-Wl,--gc-sections` through
-    // extra_cflags would be relying on wasm-ld's last-one-wins ordering
-    // to defeat the `--no-` we push here, which is not a contract worth
-    // depending on. `. opts gc_sections` picks one flag or the other, so
-    // the argv says what was meant.
-    ? . opts gc_sections
-    { ( vec_push [s] args `-Wl,--gc-sections` ) }
+    // Section GC is a single explicit choice, not a flag-string fight: a
+    // caller layering `-Wl,--(no-)gc-sections` through extra_cflags would
+    // be relying on wasm-ld's last-one-wins ordering to defeat the one we
+    // push here. `. opts no_gc_sections` picks one flag or the other, so
+    // the argv says what was meant. GC is the default; the field is the
+    // escape hatch.
+    ? . opts no_gc_sections
     { ( vec_push [s] args `-Wl,--no-gc-sections` ) }
+    { ( vec_push [s] args `-Wl,--gc-sections` ) }
     ? > ( nurl_str_len . opts extra_cflags ) 0 {
         // split the space-separated flag string into separate argv slots
         : ( Vec String ) fl ( string_split_borrow . opts extra_cflags )

--- a/packages/wasmbuilder/src/main.nu
+++ b/packages/wasmbuilder/src/main.nu
@@ -79,7 +79,8 @@ $ `build.nu`
     ( args_opt p `obj` 0 `FILE` `extra wasm object linked into the module (e.g. kernels_static.wasm.o)` )
     ( args_opt p `cflags` 0 `FLAGS` `extra compile/link flags, space-separated (e.g. "-msimd128")` )
     ( args_opt p `asyncify-imports` 0 `LIST` `comma-separated async import names (e.g. env.wgpu_download); implies --asyncify` )
-    ( args_flag p `gc-sections` 0 `link with --gc-sections: drops unreachable code (~25% smaller, loads faster), but renumbers the function table — verify closure-using programs still run` )
+    ( args_flag p `no-gc-sections` 0 `keep unreachable code: link with --no-gc-sections (the pre-0.1.4 default) — the escape hatch if an indirect call ever traps only under the default --gc-sections` )
+    ( args_flag p `gc-sections` 0 `link with --gc-sections (the default; flag kept for compatibility)` )
     ( args_flag p `no-host-imports` 0 `do not pass --ffi-host-imports to nurlc` )
     ( args_flag p `quiet` 113 `suppress progress output` )
     ( args_flag p `doctor` 0 `print how nurlc/zig/runtime resolve on this machine` )
@@ -139,7 +140,7 @@ $ `build.nu`
     ? ( args_present p `no-host-imports` ) { = . opts host_imports F } {}
     ? ( args_present p `emit-ll` ) { = . opts keep_ll T } {}
     ? ( args_present p `asyncify` ) { = . opts asyncify T } {}
-    ? ( args_present p `gc-sections` ) { = . opts gc_sections T } {}
+    ? ( args_present p `no-gc-sections` ) { = . opts no_gc_sections T } {}
     : ~ String objv ( string_new )
     ?? ( args_value p `obj` ) { T v → { ( string_free objv ) = objv v = . opts extra_obj ( string_data objv ) } F _ → {} }
     : ~ String cflv ( string_new )

--- a/packages/wasmbuilder/src/wasi_ir.nu
+++ b/packages/wasmbuilder/src/wasi_ir.nu
@@ -542,6 +542,13 @@ $ `stdlib/core/vec.nu`
     ( vec_push [s] posix_names `pipe` ) ( vec_push [s] posix_bodies `i64 @__nurl_pipe_stub(i8*) { ret i64 -1 }` )
     ( vec_push [s] posix_names `dup2` ) ( vec_push [s] posix_bodies `i64 @__nurl_dup2_stub(i64, i64) { ret i64 -1 }` )
     ( vec_push [s] posix_names `signal` ) ( vec_push [s] posix_bodies `i8* @__nurl_signal_stub(i64, i8*) { ret i8* null }` )
+    // realpath(3) — wasi-libc doesn't ship it (no symlink story on wasi).
+    // stdlib/std/path.nu's path_canonical treats a NULL return as "path not
+    // resolvable" and answers None, which is the honest wasm answer. Without
+    // this stub the symbol becomes an env import and the reference wasmtime
+    // refuses to *instantiate* the module — nurlc.wasm broke this way the
+    // moment path_canonical entered the compiler's import graph.
+    ( vec_push [s] posix_names `realpath` ) ( vec_push [s] posix_bodies `i8* @__nurl_realpath_stub(i8*, i8*) { ret i8* null }` )
     // pthread family — wasi-libc doesn't ship pthread at all. std/thread.nu
     // + std/arc.nu + the M:N async runtime declare these unconditionally.
     // Single-threaded wasm stubs: lock/unlock/signal/broadcast/wait become
@@ -576,7 +583,8 @@ $ `stdlib/core/vec.nu`
                 : String needle ( string_from ` @` ) ( string_push_str needle name ) ( string_push_char needle 40 )
                 ? ( string_contains res ( string_data needle ) ) {
                     // 1. Rename ` @<name>(` → ` @__nurl_<name>_stub(` everywhere.
-                    : String repl ( string_from ` @__nurl_` ) ( string_push_str repl name ) ( string_push_str repl `_stub(` )
+                    : String repl_name ( string_from `__nurl_` ) ( string_push_str repl_name name ) ( string_push_str repl_name `_stub` )
+                    : String repl ( string_from ` @` ) ( string_push_str repl ( string_data repl_name ) ) ( string_push_char repl 40 )
                     : String tmp ( string_replace res ( string_data needle ) ( string_data repl ) )
                     ( string_free res ) = res tmp ( string_free repl )
 
@@ -587,30 +595,32 @@ $ `stdlib/core/vec.nu`
                     //    even though logically the define satisfies the declare.
                     //    The declare comes from nurlc emitting the FFI prototype;
                     //    we don't want it once we provide our own definition.
+                    //
+                    //    Find the line rather than reconstructing it: nurlc's two
+                    //    declare emitters space differently (`declare i64 @fork()`
+                    //    from the FFI path, `declare i8*  @realpath(i8*, i8*)` from
+                    //    the column-aligned prelude), and a rebuilt one-space line
+                    //    silently missed the second kind — leaving the declare in
+                    //    place and failing every wasm build of a program whose
+                    //    import graph reached path_canonical. __wb_ir_decl_line
+                    //    locates the actual line by symbol, whatever its spacing.
                     ?? body_o { T body → {
-                            // body is `s` (string literal). Locate ` {` via nurl_str_find
-                            // — string_index_of needs a String, not a raw `s`. The IR
-                            // template strings we declared above always end in ` { … }`
-                            // so the find returns ≥ 0.
-                            : i sp_idx ( nurl_str_find body ` {` )
-                            ? >= sp_idx 0 {
-                                // Build `declare ` + body[0..sp_idx] + `\n` and delete it
-                                // from `res`. The renamed declare lives there from step 1.
-                                : String body_str ( string_from body )
-                                : String prefix ( string_substr body_str 0 sp_idx )
-                                : String declare_line ( string_from `declare ` )
-                                ( string_push_str declare_line ( string_data prefix ) )
-                                ( string_push_char declare_line 10 )
-                                : String tmp2 ( string_replace res ( string_data declare_line ) `` )
+                            : String decl ( __wb_ir_decl_line res ( string_data repl_name ) )
+                            ? > ( string_len decl ) 0 {
+                                : String decl_nl ( string_from ( string_data decl ) )
+                                ( string_push_char decl_nl 10 )
+                                : String tmp2 ( string_replace res ( string_data decl_nl ) `` )
                                 ( string_free res ) = res tmp2
-                                ( string_free declare_line ) ( string_free prefix ) ( string_free body_str )
+                                ( string_free decl_nl )
                             } {}
+                            ( string_free decl )
 
                             // 3. Append the stub definition.
                             ( string_push_str shims `define internal ` )
                             ( string_push_str shims body )
                             ( string_push_str shims `\n` )
                         } F _ → {} }
+                    ( string_free repl_name )
                 } {}
                 ( string_free needle )
             } F _ → {} }

--- a/packages/wasmbuilder/tests/build_test.sh
+++ b/packages/wasmbuilder/tests/build_test.sh
@@ -49,7 +49,13 @@ echo "[2/3] corpus: native vs wasm output"
 # enum_payload_64bit_slots compiler test guard the i64 enum-payload
 # slots: both carry f64 / >2^32 payloads that a pre-fix nurlc truncated
 # on wasm32 (they need a toolchain with the i64-slot enum layout).
-CORPUS="fizzbuzz collatz math_basic json_basic showcase serde_demo msgpack_demo dict_coder enigma rule30 slice_test test_05_closures_and_capture test_06_torture_chamber chaotic-showcase tests:enum_payload_64bit_slots"
+# find_clone is here for its import graph, not its no-args usage run: it
+# pulls std/path.nu (realpath) and std/process.nu (fork/waitpid/mmap), the
+# POSIX-stub surface of wasi_ir.nu. Its wasm build broke silently when
+# path_canonical entered the stdlib import graph — realpath's prelude
+# declare is column-padded ("i8*  @realpath") and the stub stripper
+# rebuilt the line with single spacing, so nothing in this corpus caught it.
+CORPUS="fizzbuzz collatz math_basic json_basic showcase serde_demo msgpack_demo dict_coder enigma rule30 slice_test test_05_closures_and_capture test_06_torture_chamber chaotic-showcase find_clone tests:enum_payload_64bit_slots"
 for name in $CORPUS; do
     case "$name" in
         tests:*) src="$REPO_ROOT/compiler/tests/${name#tests:}.nu" ;;


### PR DESCRIPTION
`wasmbuilder` now links wasm modules with `-Wl,--gc-sections`. The old default
existed for a real reason, so the first half of this PR is the evidence that the
reason is gone; the second half is the two stacked bugs found while gathering it
— which had **every wasm build of a `path_canonical`-reaching program failing on
`main`, including `nurlc.wasm` itself**, independent of GC.

## The blocker, re-tested at its documented scale

The `--no-gc-sections` default guarded against: NURL closures store
function-table indices, section GC renumbers the table, and `nurlc.wasm` (>150
functions) was observed to `call_indirect`-trap. Re-tested before flipping:

| test | result |
|---|---|
| `--gc-sections` `nurlc.wasm` self-compiles `compiler/nurlc.nu` (65k lines), reference `wasmtime` | **byte-identical to native**, 0.7 s |
| same, pure-NURL `wt` | **byte-identical to native**, 5m45s |
| closure corpus (`test_05_closures_and_capture`, `test_06_torture_chamber`) under the new default | pass, output identical to native |

Whatever produced the historical trap, today's `wasm-ld` relocates address-taken
functions correctly through GC. `--no-gc-sections` (library:
`WbOpts.no_gc_sections`, replacing the short-lived `gc_sections` field) stays as
the escape hatch; a trap that appears only under the default would be the
renumbering bug resurfacing and should be reported.

## What the flip is worth (fresh 15/15 suite run, 9m21s)

- **~25 % off every module** (`lcg`: 1064 → 820 KiB)
- **empty-program JIT floor 60 ms → 10.6 ms**, beside C's 8.2 ms — this was the
  single largest start-up gap between NURL wasm and C wasm, and it was all dead
  code being Cranelift-compiled for nothing
- §2's steady-state ratio now reads straight off the default build:
  **1.0–2.1× native on most rows, at or better than clang's own wasm on 10/15**
- the suite's tenth cell now measures the escape hatch, so its price stays a
  number instead of a memory

`nurlapi`'s `/build_wasm` keeps `--no-gc-sections` — its wasi-sdk container path
has not been re-validated the same way; its comment now records the evidence so
flipping it is a decision, not an archaeology project.

## The two bugs under the old default

Reproducing the blocker required building `nurlc.wasm`, which **failed on
`main`** (`unknown import: env::realpath` at instantiation):

1. **wasi-libc ships no `realpath(3)`** and it was missing from `wasi_ir.nu`'s
   POSIX stub list, so it became an `env` import the reference runtime refuses.
   It entered the compiler's import graph when `path_canonical` did. The stub
   returns NULL, which `path_canonical` already maps to `None`.
2. Adding the stub exposed the second bug: the stub stripper removes the renamed
   `declare` by **reconstructing** it with single spacing, but nurlc has two
   declare emitters — the FFI path prints `declare i64 @fork()`, the
   column-aligned prelude prints `declare i8*  @realpath(i8*, i8*)` — so the
   padded kind survived and clang rejected declare+define as an invalid
   redefinition. The stripper now finds the actual line by symbol
   (`__wb_ir_decl_line`) instead of guessing its spelling.

`find_clone` joins the wasmbuilder corpus: its import graph spans the whole
POSIX-stub surface (realpath, fork/waitpid, mmap) — exactly the seam nothing was
covering, which is how both bugs shipped.

## Test evidence

- wasmbuilder corpus **17/17** under the new default (closures included)
- `packages/wasmtime` **7/7**
- `bench/wasmbench.sh` **15/15** through the ten-cell correctness gate;
  [`WASMRESULTS.md`](bench/WASMRESULTS.md) +
  [`wasm-latest.json`](bench/results/wasm-latest.json) refreshed from that run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FREmK7Qhd5sMWtNi9QVWHw
