### PR TITLE
bench: [skip ci] on the results commit

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -208,8 +208,17 @@ jobs:
           git checkout stash@{0} -- bench/results/latest.json bench/RESULTS.md
           git stash drop
 
+          # [skip ci] because this commit is two data files and nothing
+          # else. ci.yml and windows-tests.yml have no paths filter, so
+          # every results commit would otherwise fire the three required
+          # checks — one of them a FreeBSD VM — plus the Windows suite,
+          # against code that did not change. bench.yml itself already
+          # excludes the results files from its own paths filter, so there
+          # was never a loop; there was a second full CI round per merge,
+          # which is pure waste. The numbers were produced by a run that
+          # passed the correctness gate and chaincheck before committing.
           git add bench/results/latest.json bench/RESULTS.md
-          git commit -m "bench: refresh measured numbers ($today)"
+          git commit -m "bench: refresh measured numbers ($today) [skip ci]"
 
           # Keep the measured files OUTSIDE the worktree for the replay
           # below. Stashing them cannot work there: by that point they are
@@ -240,7 +249,7 @@ jobs:
               echo "the new tip already carries these numbers — nothing to do."
               exit 0
             fi
-            git commit -am "bench: refresh measured numbers ($today)"
+            git commit -am "bench: refresh measured numbers ($today) [skip ci]"
           done
           echo "::error::could not push refreshed results after 3 attempts."
           echo "::error::If this is GH013, BENCH_PUSH_TOKEN's account is not in the"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Each bench results commit fired a second full CI round.** Now that the
+  suite re-measures on every merge to main, the commit it pushes back — two
+  data files, no code — re-triggered `ci.yml` (three required checks, one of
+  them a FreeBSD VM) and `windows-tests.yml`, neither of which has a paths
+  filter. Not a loop: `bench.yml` already excludes the results files from its
+  own filter, so it never re-triggered itself. Just a doubling of CI cost per
+  merge, against code that did not change. The results commits now carry
+  `[skip ci]`; the numbers in them come from a run that passed the correctness
+  gate and chaincheck before committing.
+
 - **The bench results push authenticated as the wrong actor, and its retry
   destroyed the run's numbers.** Two defects in the freshly-landed direct-push
   path, both caught on its first real run. `actions/checkout` writes an


### PR DESCRIPTION
Now that the suite re-measures on every merge to main, the commit it pushes
back — `bench/results/latest.json` and `bench/RESULTS.md`, no code —
re-triggered `ci.yml` (three required checks, one of them a FreeBSD VM) and
`windows-tests.yml`. Neither has a paths filter, so both ran in full against a
diff that cannot affect them.

Observed on `5716a129`, the first results commit to land:

```
5716a1296 windows-tests | push | completed success
5716a1296 ci           | push | in_progress
```

**Not a loop** — `bench.yml` already excludes the results files from its own
paths filter and did not re-trigger itself (no `bench` run on `5716a129`). It
was a second full CI round per merge, which is pure waste.

## Why `[skip ci]` and not `paths-ignore`

Those three contexts are **required status checks**. Teaching them to skip a
path would let a pull request touching only that path sit forever with its
checks in "expected" — a worse failure than the one being fixed, and a silent
one. Skipping is a property of this one commit, so it belongs in this one
commit.

The numbers being committed come from a run that passed the correctness gate
(all 15 rows' five implementations printing the same result) and `chaincheck`
before committing, so there is nothing for CI to add.

## Status of the wider fix

With this, the chain works end to end. The results commit that landed while
diagnosing this is already on main and `latest.json` is current
(`2026-07-27T18:55:06Z`, measured at `220fe3b7`) — the site will pick it up on
the next deploy, manual or tagged, because #671 made `web-deploy.yml` read the
results from main rather than from the checked-out ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FREmK7Qhd5sMWtNi9QVWHw
