### PR TITLE
lingbot-map 0.3.0 — the front door, and what measuring it turned up

### DIFF
--- a/packages/lingbot-map/CHANGELOG.md
+++ b/packages/lingbot-map/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## 0.3.0
+
+The model was right and the front door was not. `lingbot-map --model
+<ckpt>` printed the usage and left the reader to work out which line
+applied to them; this is the release where the command explains itself.
+
+- **`lingbot-map <frames-dir>` is the whole command.** A directory as a
+  positional argument is the frames; `--model` is now optional and
+  resolves through [hub](../hub) — `$LINGBOT_MAP_MODEL`, else
+  `~/.nurl/models/lingbot-map/lingbot-map.pt`, else
+  `robbyant/lingbot-map/lingbot-map.pt` is fetched once and cached. A
+  Hugging Face ref works as `--model` too.
+- **Errors name what is wrong.** No frames, an unknown option, a missing
+  value, a frame that does not exist, a directory with nothing in it —
+  each says so and shows the command that would have worked, instead of
+  reprinting the usage. `--help` is a real help page with examples and
+  exits 0; `--version` was missing entirely.
+- **A mistyped option is an error**, not a frame filename that fails
+  much later as a missing file. Frame paths are all checked *before* the
+  4.6 GB checkpoint is read, so a typo costs nothing.
+- **The reference's spellings are accepted** — `--model_path`,
+  `--image_folder`, `--conf_threshold`, `--first_k` — so a `demo.py`
+  command line mostly transfers.
+- **`--stride <n>`**, the reference's own frame subsampling, which had no
+  equivalent here: `--stride 20` reconstructs a 286-frame walk from 15
+  frames in 4 s. It applies *after* `--max-frames`, in the order
+  `demo.py` applies `--first_k` and `--stride`, so thirty frames at a
+  stride of three is ten.
+- **`--conf` defaults to 1.5**, which is `demo.py`'s own
+  `--conf_threshold`. It was 2.0, described in a comment as the
+  reference's default, which it is not. At the same threshold the cloud
+  is byte-for-byte what 0.2.1 produced.
+- **Frame directories are listed with `dir_list`, not `fs_glob`.** The
+  glob did not descend through a symlinked directory, so pointing at a
+  linked frame folder reported "no .png or .jpg" and stopped. `.jpeg` is
+  recognised now, and the extension match is case-insensitive. Each
+  directory is sorted on its own before being appended, so naming two of
+  them keeps them in the order given.
+- **The run says what it is doing**: the checkpoint it chose, the frame
+  count and the output path up front, and frames, points and elapsed time
+  at the end.
+- The README is now about using it. The porting war stories moved to
+  [`docs/porting-notes.md`](docs/porting-notes.md) intact.
+
+No change to the model, the kernels or the numerics.
+
+**And one thing that is not a feature.** Turning "as fast as the
+reference" into a measurement — `tests/ref_cloud.py` drives
+`~/dev/lingbot-map` through its own `inference_streaming` and writes the
+same cloud, `tests/cmp_cloud.py` compares them, and both are step 20 of
+the suite — turned up something the per-module tests cannot see:
+
+- **The port is 3.4–9.2x faster end to end**, mostly because the 4.6 GB
+  checkpoint reads in 1.6 s against `torch.load`'s ~12.6 s. On inference
+  alone the two are within about 5%.
+- **One frame agrees to 2.3e-5.** Over a sequence the reconstruction
+  drifts: by 20 frames the centroid is 1.8e-1 of the scene's own scale
+  away and the cloud is ~9% smaller. The depth is right — point counts
+  agree to one part in 30 000 — and the poses are not.
+- **That drift is not the arithmetic.** Perturbing the reference's input
+  by 3e-4, the size of the port's own activation-level disagreement,
+  moves the reference's 20-frame cloud by 3.9e-5. The port is ~600x
+  further away than the model's conditioning explains.
+- Separately, `demo.py` runs the first 8 frames as one bidirectional
+  block (`--num_scale_frames`); the port is causal from frame 0, which is
+  worth 3.3% of the cloud on 12 frames.
+
+Neither is a regression — both predate 0.2.0 — and neither is fixed here.
+They are now measured, written down in the README under "How close is it
+really", and pinned by a test, which is the prerequisite for fixing them.
+
 ## 0.2.1
 
 - **Parity.** 0.2.0 shipped without the two gpukit kernels that close the

--- a/packages/lingbot-map/README.md
+++ b/packages/lingbot-map/README.md
@@ -1,102 +1,205 @@
-# lingbot-map — Geometric Context Transformer in pure NURL
+# lingbot-map
 
-A port of [LingBot-Map](https://github.com/robbyant/lingbot-map), the
-feed-forward 3D foundation model for **streaming 3D reconstruction**:
-feed it a sequence of frames, get back per-frame camera poses, depth
-maps and a world-space point cloud, one frame at a time, with no
-per-scene optimisation.
+Streaming 3-D reconstruction, in pure NURL. Hand it a folder of video
+frames; it hands back a world-space point cloud, plus a camera pose and a
+depth map for every frame — one frame at a time, no per-scene
+optimisation, no structure-from-motion pass.
 
-**Status: in progress.** The port is staged, and each stage is verified
-against the reference PyTorch implementation before the next one starts.
-What is done and what is not is spelled out below — nothing here claims
-to work that has not been checked against the oracle.
+It is a port of [LingBot-Map](https://github.com/robbyant/lingbot-map),
+the feed-forward 3-D foundation model, and it runs the same 1.16 B
+parameter checkpoint the reference does. Every stage is checked against
+the reference PyTorch implementation, and on the same GPU it is several
+times faster end to end. On a single frame it reproduces the reference to
+2e-5; over a long sequence it drifts, which is measured and quantified
+under [How close is it really](#how-close-is-it-really) rather than
+glossed.
 
-## Why this port is the size it is
+## Install
 
-The reference is ~13 000 lines of PyTorch and the checkpoint is 4.6 GB
-of fp32 — roughly 1.16 B parameters in three stacked transformers:
+```
+nurlpkg install lingbot-map
+```
 
-| part | shape |
+## Reconstruct something
+
+```
+lingbot-map my-frames/
+```
+
+That is the whole command: a folder of `.png` or `.jpg` frames in, a
+point cloud out. The first run downloads the 4.6 GB checkpoint from
+Hugging Face and caches it under `~/.nurl/models`; every run after that
+starts straight away.
+
+```
+frames 286 -> cloud.ply
+model  /home/wau/.nurl/models/lingbot-map/lingbot-map.pt
+frame 1/286  33025 points  526 ms  .../courthouse/000000.png
+frame 2/286  66564 points  157 ms  .../courthouse/000001.png
+frame 3/286  98930 points  158 ms  .../courthouse/000002.png
+...
+frame 286/286  8602925 points  410 ms  .../courthouse/000285.png
+wrote 8602925 points to cloud.ply  (286 frames, 108624 ms)
+```
+
+`cloud.ply` opens in MeshLab, CloudCompare, Blender, or `f3d cloud.ply`.
+
+## Where frames come from
+
+Any folder of `.png`, `.jpg` or `.jpeg` files whose names sort into the
+order they were shot. From a video, that is one `ffmpeg` call:
+
+```bash
+mkdir frames && ffmpeg -i walk.mp4 -r 10 frames/%06d.png
+lingbot-map frames/
+```
+
+The example sequences the reference uses — `courthouse`, `loop`,
+`university` — come with
+[its repository](https://github.com/robbyant/lingbot-map), under
+`example/`. Everything below uses one of those, so the numbers are
+reproducible.
+
+## More things to try
+
+```bash
+# a quick look first: 30 frames instead of all 286
+lingbot-map --max-frames 30 ~/dev/lingbot-map/example/courthouse
+
+# the whole walk, but every 20th frame — 15 frames, 4 s
+lingbot-map --stride 20 --out sparse.ply ~/dev/lingbot-map/example/courthouse
+
+# every pixel rather than every second one — 4x the points
+lingbot-map --pixel-stride 1 --out dense.ply ~/dev/lingbot-map/example/courthouse
+
+# keep more of the uncertain geometry (1.0 is "the model knows nothing")
+lingbot-map --conf 1.2 --out loose.ply ~/dev/lingbot-map/example/courthouse
+
+# a checkpoint you already downloaded, and where the time goes
+lingbot-map --model ./lingbot-map.pt --profile ~/dev/lingbot-map/example/courthouse
+
+# a few individual frames, in the order you name them
+lingbot-map shot0.png shot1.png shot2.png
+
+# a text PLY, for reading with your eyes
+lingbot-map --ascii --max-frames 2 --out two.ply ~/dev/lingbot-map/example/courthouse
+```
+
+## Options
+
+| | |
 |---|---|
-| `patch_embed` | DINOv2 ViT-L/14 — 24 blocks, dim 1024, used as a frozen feature extractor |
-| `aggregator.frame_blocks` | 24 blocks, dim 1024 — attention **within** a frame |
-| `aggregator.global_blocks` | 24 blocks, dim 1024 — causal attention **across** frames, over a paged KV cache |
-| `camera_head` | iterative pose refinement, 4 passes |
-| `depth_head`, `point_head` | DPT decoders over four intermediate layers |
+| `--model <path\|ref>` | checkpoint to run: a local `.pt`, or a Hugging Face ref such as `robbyant/lingbot-map/lingbot-map.pt`. Default: `$LINGBOT_MAP_MODEL`, else `~/.nurl/models/lingbot-map/lingbot-map.pt`, else that ref is fetched |
+| `--out <file.ply>` | where to write the cloud (default `cloud.ply`) |
+| `--conf <f>` | keep pixels whose confidence exceeds this (default 1.5, the reference's own `--conf_threshold`) |
+| `--pixel-stride <n>` | take every nth pixel on both axes (default 2) |
+| `--max-frames <n>` | stop after n frames |
+| `--stride <n>` | use every nth frame, applied after `--max-frames` |
+| `--frames <dir>` | a directory of frames; the same as naming it positionally |
+| `--ascii` | write an ASCII PLY instead of `binary_little_endian` |
+| `--quiet`, `-q` | no per-frame progress |
+| `--profile` | per-stage frame timings and a per-kernel GPU profile |
+| `--version`, `--help` | |
 
-Frame and global blocks alternate, and every fourth pair (`[4, 11, 17,
-23]`) is tapped for the DPT heads. That structure — anchor context,
-pose-reference window, trajectory memory — is the paper's contribution
-and is what the port has to reproduce exactly, not approximately.
+The reference's own spellings work too — `--model_path`,
+`--image_folder`, `--conf_threshold`, `--first_k` — so a `demo.py`
+command line mostly transfers.
 
-## Stages
+**Order is the trajectory.** Frames are read in name order, and the model
+keeps a cache across frames, so each one is placed relative to the ones
+before it. A shuffled directory reconstructs a different scene.
 
-| # | stage | state |
-|---|---|---|
-| 1 | read the `.pt` checkpoint | **done** — [`torchpt`](../torchpt); the real 4.6 GB file in 0.01 s / 31 MB RSS, values identical to `torch.load` |
-| 2 | image loading and preprocessing | **done** — byte-identical to the reference pipeline on real frames |
-| 3 | ViT layers: patch embed, 2-D RoPE, qk-norm attention, block | **done** — the full block matches the reference to 4e-15 |
-| 4 | streaming aggregator + KV cache | **done** — 5.9e-6 vs the real model; sliding-window eviction 8.5e-6, checked against the model past the eviction point |
-| 5 | camera head, DPT heads | **done** — camera head 2.2e-7, DPT depth head 1.6e-6 |
-| 6 | camera geometry | **done** — matches torch to 2.4e-16 |
-| 7 | CLI, point-cloud export, end-to-end check | **done** — `src/main.nu`; world points 1.5e-6 vs the real model |
+## How it differs from `demo.py`
 
-## Performance
+The model is the same and the numbers agree; the packaging does not.
 
-Everything below is one machine — an RTX 4090, f32 on both sides — and
-the port's numbers are with `--profile`, which prints per-stage times and
-a per-kernel GPU profile.
+* **It writes a file, it does not open a viewer.** `demo.py` ends in a
+  viser web viewer; this ends in a PLY, and you bring your own viewer.
+* **No video input.** `demo.py --video_path` shells out to OpenCV; split
+  the video with `ffmpeg` and point at the folder.
+* **No scale-frame block.** `demo.py` runs the first `--num_scale_frames`
+  (8 by default) frames as **one block with bidirectional attention among
+  themselves**, and only then goes frame-by-frame. The port is causal from
+  frame 0, which is what `demo.py --num_scale_frames 1` does. Measured on
+  12 frames, that alone is worth **3.3% of the cloud** (370 052 points
+  against 357 693). Everything in [How close is it
+  really](#how-close-is-it-really) compares against the reference driven
+  the port's way, so it is a separate gap and is not folded into those
+  numbers.
+* **Streaming only.** `--mode windowed`, `--keyframe_interval`,
+  `--mask_sky` and `--rotate_clockwise_90` have no equivalent here. The
+  sliding KV window is what bounds the memory instead of keyframes,
+  which is why 286 frames run at a flat 410 ms each; past ~320 frames
+  `demo.py` would start dropping to keyframes and this will not.
+* **f32 throughout.** `demo.py` casts the aggregator to bf16. In eager
+  mode that is *slower* on this card — 155 ms a frame against f32's
+  141 — and it is not what the accuracy figures above were measured
+  against.
 
-**The same eight-frame reconstruction, before and after the speed work:**
+## What you need
 
-| | before | after |
-| --- | --- | --- |
-| 8 frames, end to end | 38.2 s | **3.6 s** |
-| loading the 4.6 GB checkpoint | ~25 s | **1.6 s** |
-| per frame, steady state | ~1.25 s | **0.20–0.24 s** |
-| 30 frames, end to end | — | **10.7 s** |
-| `tests/depthcheck.nu` (load + a frame + dumps) | 25.8 s | **2.1 s** |
+* An NVIDIA GPU and the CUDA driver. VRAM goes with the length of the
+  sequence, and stops growing once the sliding KV window fills: ~6.8 GB
+  for 8 frames, ~10 GB for 30, ~16.4 GB for 286 and for anything longer.
+  `--max-frames` caps the sequence, and so caps the memory.
+* The 4.6 GB checkpoint, which the first run fetches for you. To fetch it
+  yourself: `hub pull robbyant/lingbot-map/lingbot-map.pt`, or download
+  `lingbot-map.pt` from
+  [huggingface.co/robbyant/lingbot-map](https://huggingface.co/robbyant/lingbot-map)
+  and pass `--model <path>`. The `-long` and `-stage1` checkpoints in the
+  same repository are read the same way — layer counts come off the file
+  rather than from a constant.
 
-Identical output: the same 237 123 points, and `depthcheck`'s dump is
-byte-for-byte what the pre-optimisation build produced. (Worth knowing
-before reading anything into a tolerance number: the end-to-end
-depth/confidence/world-points check reports 1.6e-5, on the CUDA and CPU
-backends alike, and reported the same 1.646e-5 from a pristine build of
-`HEAD` — it is what that three-row comparison has always been, not
-something the speed work moved. The 1.6e-6 in the stage table is the
-depth map on its own.) Every kernel
-rewrite kept its accumulation order, so this is the same arithmetic run
-in a better shape — with one deliberate exception, noted below.
+No Python and no PyTorch. The kernels are CUDA C compiled at run time
+through NVRTC, so the driver (`libcuda`) and `libnvrtc` are what you
+need at run time, and nothing at all at build time.
 
-**Against the reference on the same card.** `tests/ref_timing.py` runs
-the reference's aggregator, camera head and depth head on one frame with
-the checkpoint load excluded, which is the same slice the port's
-`--profile` reports:
+## Speed
 
-| | reference | port |
+An RTX 4090, f32 on both sides, same frames, same checkpoint.
+`tests/ref_cloud.py` drives `~/dev/lingbot-map` through its own
+`inference_streaming` and writes the same cloud, so this is the whole
+command against the whole command, not a module against a module:
+
+| frames | reference | this port | |
+| ---: | ---: | ---: | --- |
+| 1 | 14.6 s | 1.6 s | **9.2x** |
+| 4 | 14.5 s | 2.0 s | **7.1x** |
+| 12 | 15.8 s | 3.4 s | **4.6x** |
+| 20 | 17.2 s | 5.1 s | **3.4x** |
+
+Most of that is the checkpoint: the port reads 4.6 GB straight into
+device memory in 1.6 s where `torch.load` plus `load_state_dict` takes
+~12.6 s, and that cost is paid once however long the sequence. On
+inference alone the two are close — at 20 frames the reference spends
+3.7 s and the port about 3.5 s.
+
+Per module, on one frame with the load excluded (`tests/ref_timing.py`,
+the same slice `--profile` reports):
+
+| | reference | this port |
 | --- | --- | --- |
 | aggregator | 77 ms | 100 ms |
 | camera head | 54 ms | **16 ms** |
 | depth head | 10 ms | 22 ms |
-| **total** | **141 ms** | **138 ms** |
+| **one frame** | **141 ms** | **138 ms** |
 
-**So the port is at parity** — 138 ms against 141, best of four runs on
-each side, with the port's three numbers stable to a millisecond across
-runs. It is well ahead on the camera head, behind on the other two, and
-the sum lands where the reference does. The port's own preprocessing —
-PNG decode and the bicubic resize, ~33 ms — is outside this table on
-both sides, as `load_and_preprocess_images` is for the reference.
+Ahead on the camera head, behind on the other two, and the sum lands
+where the reference's does. End to end, including the 1.6 s checkpoint
+load, eight frames take 2.8 s, thirty take 7.5 s and all 286 take 109 s.
 
-Worth saying plainly what this is and is not: torch here is eager mode,
-which is what `ref_timing.py` measures on both sides. `demo.py` also
-turns on `torch.compile` and CUDA graphs, and that is a different (and
-faster) reference this has not been measured against. The reference as `demo.py` ships it — the
-aggregator cast to bf16 — measures 155 ms here, slower than its own
-fp32 path: at one frame of 783 tokens this model is latency-bound in
-eager mode, and bf16 only pays off with the `torch.compile` and CUDA
-graphs `demo.py` also turns on.
+A frame costs more the more of the sequence it has to attend to, and then
+stops: 157 ms at frame 2, 400 ms by frame 73, and 410 ms at frame 286.
+That plateau is the sliding KV window filling up — past 72 frames the
+model attends over a bounded cache, so the per-frame cost is flat however
+long the walk is.
 
-**Where a frame goes now** (frame 4 of a sequence, `--profile`):
+The reference here is torch in eager mode, which is what `ref_timing.py`
+measures on both sides. `demo.py` can also turn on `torch.compile` and
+CUDA graphs; that is a faster reference this has not been measured
+against.
+
+`--profile` shows where a frame goes, and which kernels it spends it in:
 
 ```
 prep 33 ms  aggregator 100 ms  camera 16 ms  depth 22 ms  cloud 1 ms
@@ -106,666 +209,123 @@ prep 33 ms  aggregator 100 ms  camera 16 ms  depth 22 ms  cloud 1 ms
    7%  gk32_lnormrow       760 calls     53 us
 ```
 
-Nearly half of it is now one kernel, the tiled GEMM, at 19–27 TFLOP/s
-where cuBLAS would do ~50. That is where a further gain would come from,
-and it needs a different structure — warp-level tiling with
-register-resident fragments — rather than another parameter; four
-parameter changes were measured and none helped (see below).
+## Accuracy
 
-### What made the difference
+Every stage is checked against the reference itself. Where an oracle can
+import the upstream module and drive it, it does, rather than working
+from a second reading of the source — a hand-written oracle is just
+another chance to make the same mistake, and once did.
 
-Nearly all of it is in [`gpukit`](../gpukit) rather than here — this port
-was the thing that made the gaps visible, and the fixes belong where
-every GPU package gets them. In rough order of what it bought:
+These are what the suite prints, worst relative error in each case:
 
-* **Tiled GEMM.** One thread per output element costs a global load of B
-  per multiply-add; a 64x64 shared-memory tile with a 4x4 register tile
-  and `float4` shared reads costs a fraction of one. 3.1 → 19.1 TFLOP/s
-  (and 0.6 → 20.1 with a transposed B, which the old kernel read along
-  the wrong axis entirely). Bit-identical: blocking changes when a
-  product is computed, not the order the sum runs in.
-* **Fused attention.** The composed form materialises a
-  `[heads, n, nkv]` score matrix, writes it once and reads it five
-  times. `gkd_attention` never writes it. 3.8x at `nkv = n`, 6.2x at
-  `nkv = 4n` — and, more to the point for a *streaming* model, the
-  buffer it does not allocate is 2.8 GB at a 72-frame window. This is
-  the one change that is not bit-identical (an online softmax rescales a
-  running sum rather than summing left to right); it moved the whole
-  aggregator from 5.385e-6 to 5.853e-6 against the real model, and the
-  end-to-end depth agreement *improved*, from 1.646e-5 to 1.591e-5 —
-  which figures, since the reference uses SDPA and so does this.
-* **A caching device allocator.** `cuMemAlloc`/`cuMemFree` synchronise
-  and cost ~315 us per 12 MB pair. A frame allocates its scratch a few
-  hundred times, so a third of every frame was the allocator, with the
-  device idle for all of it.
-* **The checkpoint is read straight into device memory.** The load path
-  widened every f32 weight to f64, transposed the four hot Linear
-  weights on the host with a column-strided write per element, and
-  narrowed them again on upload. Now the mapped bytes go to the device
-  as they are and the transpose is a permute kernel: 25 s → 1.6 s.
-* **Layernorm a row per block, not per thread** (~800 rows is three
-  blocks on a 128-SM card): 6.3x. **Convolution with a 4x4 output tile
-  per thread**: 2.2x. **Transposed convolution** with a fast path for
-  stride == kernel, where the general body was doing two 64-bit modulos
-  per tap to discover that fifteen of every sixteen taps contribute
-  nothing: 14.2 ms → 0.35 ms. **GEMV shape for M = 1**, which the camera
-  head runs twenty times per frame and which was eight blocks on a
-  128-SM card.
-* **The convolution is shape-specialised too**, for the same reason as
-  the permute: every loop bound and stride was a kernel argument, so a
-  3x3 layer paid a 64-bit multiply-add chain per tap to compute an
-  address the compiler could have folded, and could not unroll a
-  nine-tap window it did not know was nine taps. The twelve dimensions
-  go in as literals; each layer geometry compiles once. The depth head
-  went 39 ms → 22 ms, and the dumps are byte-identical with the
-  specialisation forced off.
-* **The permute is shape-specialised.** The generic body decomposed
-  each output index with six 64-bit divisions and modulos and kept its
-  working arrays in local memory, which is why moving 9 MB took 87 us.
-  The kernel source is generated per call anyway, so the dims and the
-  permutation go in as literals and it takes 15 us.
-* **Two per-frame constants are now built once.** The DPT
-  positional-embedding grid is a pure function of (channels, height,
-  width, aspect); rebuilding it was ~10 million host `sin`/`cos` a
-  frame, a fifth of the frame. The DINOv2 position grid is a bicubic
-  resample over 1024 channels and a pure function of (gh, gw);
-  rebuilding it was another 53 ms a frame — a *quarter* of what the
-  frame had shrunk to by then. Both were found the same way, by
-  profiling a build without LTO so the inlined frame loop resolves into
-  named functions, and both are bit-identical: the eight-frame cloud is
-  byte-for-byte unchanged.
-* **The point cloud is binary PLY by default.** ASCII cost 15 us per
-  point — 470 ms a frame at the default stride, more than the depth
-  head. `--ascii` still writes the text form, and the two agree exactly.
-  The float formatting behind it was worth fixing on its own:
-  `nurl_str_float` searched 1..17 significant digits linearly for the
-  shortest round-trip, which is ~2.5 us for a value that came from an
-  f32 (the worst case). It binary-searches now — the property is
-  monotone in the digit count — which is five probes instead of
-  seventeen, for every float any NURL program prints.
-
-Four things this did NOT need, all measured and dropped: double
-buffering the GEMM's global loads (neutral — the kernel is not
-latency-bound), a 128x128 tile with an 8x8 register tile (worse — at
-these shapes it halves the block count on a 128-SM card, and idle SMs
-cost more than the better reuse gains; worse again when re-tried after
-the `float4` change, this time on register pressure), and 16-byte global
-loads in the staging phase (also neutral-to-worse, so it is not
-issue-bound on those either). Four negative results on one kernel is
-itself the finding: at ~25 TFLOP/s it is not short of any single
-resource, and the next step is warp-level tiling with register-resident
-fragments rather than another parameter.
-
-The convolution and the attention, by contrast, were both short of
-something specific and both moved a lot when it was fixed — which is the
-argument for measuring each kernel rather than assuming the biggest one
-is the one to work on.
-
-### Stage 2 — preprocessing (`src/preproc.nu`)
-
-`load_and_preprocess_images(mode="crop", image_size=518, patch_size=14)`,
-which is what `demo.py` runs: alpha onto white, RGB, bicubic resize to
-width 518 with the height snapped to a whole number of patches, centre
-crop, scale to [0, 1], CHW. ImageNet normalisation is *not* done here —
-the aggregator does it, and doing it twice is a quiet way to get a
-plausible but wrong reconstruction.
-
-That needed a **PIL-compatible bicubic resampler**, which the `image`
-package did not have (only nearest, bilinear and box). It has one now:
-`image_resize_bicubic`, byte-identical to Pillow — same `a = −0.5`
-kernel, same support scaling, same 22-bit fixed-point two-pass
-arithmetic. Note that this is a *different kernel* from the one stage 3
-needs for the position grid (torch's `a = −0.75`); they are not
-interchangeable.
-
-Verified on the repo's own example frames: six frames, every sampled
-value identical to the reference pipeline.
-
-EXIF orientation is deliberately **not** applied — the reference calls
-`exif_transpose`, `image` does not surface EXIF, and silently ignoring a
-rotation beats silently applying the wrong one. Video-derived frames,
-which is what streaming reconstruction is actually fed, carry none.
-
-### Stage 6 — camera geometry (`src/geom.nu`)
-
-The model's per-frame output is a 9-vector: translation, a **scalar-last**
-quaternion, and two field-of-view angles. `src/geom.nu` turns that into
-extrinsics, intrinsics, a camera-to-world transform, and unprojected
-world points.
-
-Verified against the upstream `quat_to_mat` / `mat_to_quat` /
-`pose_encoding_to_extri_intri` / `closed_form_inverse_se3` code paths:
-worst relative error **2.4e-16** across six random pose encodings — the
-last bit, and it comes from torch's vectorised `tan` disagreeing with
-glibc's, not from the port.
-
-### Stage 7 — the CLI, hardening pass
-
-Three defects the finishing pass turned up, all in `src/main.nu`:
-
-* **It always exited 0.** A frame could fail, the message went to
-  stdout, and the process reported success — a caller piping the cloud
-  into a build would never learn. Failures now set `rc` and it is
-  returned.
-* **The workspace was sized `nframes · P`.** Eviction caps the cache far
-  below that, and the attention matrix is `heads · n · nkv`: at 300
-  frames the oversized version wants ~12 GB for that term alone and
-  would not run at all. It is now sized by `ag_kv_rows`, a 4× cut at
-  300 frames.
-* **No way to name a directory.** A 324-frame scene meant 324 paths on
-  the command line. `--frames <dir>` takes every `.png`/`.jpg`, **sorted
-  by name** — order is not a nicety, the KV cache makes frame N depend
-  on every frame before it, so a raw `readdir` order reconstructs a
-  different scene.
-
-`vec_extend` looked like the way to append the glob results, and it
-exposed a compiler bug: `= . p + k 0 v` for an aggregate element type
-died with *"unknown field or variable: +"*. Fixed in `nurlc` with a
-regression test (`compiler/tests/ptr_agg_index_store.nu`). `vec_extend`
-documents itself as safe only for trivial element types, so the CLI
-pushes the handles across instead.
-
-### Stage 4 (partial) — KV-cache eviction (`src/aggregator.nu`)
-
-The reference keeps the first `kv_cache_scale_frames` = 8 frames
-forever, keeps the last `kv_cache_sliding_window` = 64 frames
-**including the current one**, and from every frame it drops it
-preserves the six special-token rows. Past 72 frames a cache that just
-grows is not merely wasteful, it is **wrong** — the model attends to
-frames it should not. The example scenes are 237–324 frames.
-
-That "including the current one" is the whole subtlety, and it is not
-visible in the eviction function. `attention.py:239-244` concatenates
-the frame into the cache and only *then* calls
-`_apply_kv_cache_eviction_causal`, so `num_cached` already counts it:
-the trigger is `f ≥ S + W` and the live set is the scale frames plus
-`f−W+1 … f`. The port first read the function alone, got a window one
-frame too wide starting one frame too late, and was wrong from the very
-first eviction — by **2.7e-2**.
-
-The port implements the policy as a ring rather than as the reference's
-repeated `torch.cat`. Each cache is laid out as
-
-```
-[0, S·P)              the scale frames, never moved
-[S·P, S·P + W·P)      a ring of the last W frames
-[S·P + W·P, …)        six preserved rows per evicted frame
-```
-
-The live region is always a **prefix**, so attention still reads a
-contiguous run and nothing in the attention path had to learn about
-eviction. Shifting the survivors down instead, which is what
-`torch.cat` amounts to, would move about 5 GB per frame across 24
-blocks.
-
-That did force one honest change: `LmKv`'s single `used` became `woff`
-and `nvalid`. Where a frame writes and how much of the cache is live are
-the same number only while frames go on the end.
-
-Two tests, and it took both:
-
-* `tests/kvcheck.nu` vs `tests/kv_oracle.py` — the bookkeeping, 120
-  frames, exact, one second. `kv_oracle.py` replays the reference's own
-  eviction; it needs no torch and no checkpoint.
-* `tests/streamcheck.nu` vs the real model with the window shrunk to
-  **1 + 2 on both sides** (`LINGBOT_KV_SCALE` / `LINGBOT_KV_WINDOW`,
-  which the reference takes as constructor arguments) — six frames,
-  three of them past eviction, **7.7e-6**.
-
-The bookkeeping test alone was not enough, and the reason is worth
-keeping: `kv_oracle.py` replayed the reference's eviction *function*
-faithfully but placed the *call* where the port placed it. It agreed
-with the port's wrong window and reported an exact match. Only running
-the activations caught it. **A replay has to reproduce the call site,
-not just the callee.**
-
-### Stage 7 — the CLI and the point cloud (`src/main.nu`)
-
-```
-lingbot-map --model <checkpoint.pt> [options] <frame> ...
-  --out <file.ply>    where to write the cloud (default cloud.ply)
-  --conf <f>          keep pixels with confidence above this (default 2.0)
-  --pixel-stride <n>  take every nth pixel on both axes (default 2)
-  --max-frames <n>    stop after n frames
-  --quiet             no per-frame progress
-  --profile           per-stage frame timings and a per-kernel GPU profile
-  --ascii             write an ASCII PLY instead of binary_little_endian
-```
-
-Each frame goes through preprocessing, the DINOv2 trunk and the
-streaming aggregator — which keeps its KV cache across frames, so the
-poses land in one shared world frame — then the camera head for a pose
-and the DPT head for depth and confidence. Depth plus intrinsics plus
-the camera-to-world transform unprojects to world points, which is the
-cloud.
-
-`world_points` matches the reference's own
-`unproject_depth_map_to_point_map` to **1.5e-6**, and is checked as part
-of the end-to-end test rather than assumed from the depth agreeing.
-
-Two things about the geometry are easy to get wrong and are worth
-stating, because both are silent:
-
-* The reference builds its pixel grid with `np.arange(W)` — **integer**
-  pixel coordinates, not sample centres. Half a pixel of offset is not
-  visible in any single number.
-* `unproject_depth_map_to_point_map` takes the **world-from-camera**
-  extrinsic that the pose encoding decodes to and inverts it itself.
-  Handing it the already-inverted one gives a plausible-looking cloud
-  that is in the wrong frame.
-
-Output is `binary_little_endian` PLY, which every viewer reads, with
-`--ascii` for the text form. Binary is the default because ASCII is not
-a rounding cost here: formatting three coordinates per point ran at
-15 us a point, 470 ms a frame at the default stride — more than the
-depth head. The two formats produce the same points exactly, which the
-end-to-end test checks by writing both.
-
-The vertex count is not known until the last frame is done, so the
-header is written with a fixed-width zero-padded placeholder and patched
-by seeking back at the end — the alternative is holding the whole cloud
-in memory, and a 300-frame sequence is tens of millions of points.
-Points are flushed a row at a time.
-
-On two consecutive courthouse frames at the defaults: 61 458 points,
-frame centroids 0.0095 apart in a scene 2.82 across — the two frames
-land on top of each other, which is what a shared world frame means.
-
-### Stage 5 — the DPT depth head (`src/dpthead.nu`)
-
-Loads and runs end to end in ~150 s and matches the reference: `depth`
-to **1.6e-6** and `depth_conf` to **7.8e-6**, with every intermediate —
-the token norm, the four projections, the position embedding, all four
-resize layers (both ConvTransposes and the strided conv), the four
-`layerN_rn` reductions, all four fusion blocks and `output_conv1` —
-inside 5e-6.
-
-Getting there took a bisect worth writing down, because the bug was
-invisible to everything except the reference itself.
-
-The divergence started at `dpt_f4`, the first fusion block, at a scaled
-error of 6.8e+2. Every stage before it was already correct to float32
-noise. Three things were ruled out in turn:
-
-* **The ops.** `tests/fusecheck.nu` runs one fusion block on synthetic
-  weights at 8×3×5 — seconds instead of 150 — and `resConfUnit2`, the
-  bilinear upsample and the 1×1 `out_conv` each matched.
-* **The plumbing.** The real head keeps its blocks in a `Vec DpFuse`,
-  36 scalars deep, and pulls them out by index through an `Option`
-  match. Four blocks with distinguishable weights came back correct.
-* **The weights.** Every DPT tensor read through `Lw` matched torch's
-  sum and absolute maximum exactly.
-
-Right input, right ops, right plumbing, right weights, wrong output.
-What broke the deadlock was strengthening the dumps: a strided sample of
-a 53 504-element tensor is six numbers, and six numbers can agree while
-the tensor does not, so `__dp_dump` and the oracle's DPT trace both
-gained a whole-tensor sum and absolute maximum. That confirmed the input
-was right over every element, and — once probes went *inside* the block
-— that the reference's `resConfUnit2` takes an input peaking at 974 and
-returns one peaking at **0.144**, while the port returned its input
-essentially unchanged.
-
-No residual unit of the form `x + g(x)` can do that. The reference's is
-not that form:
-
-```python
-self.activation = nn.ReLU(inplace=True)   # _make_fusion_block
-...
-out = self.activation(x)      # OVERWRITES x
-out = self.conv1(out); out = self.activation(out); out = self.conv2(out)
-return self.skip_add.add(out, x)          # x is relu(x) by now
-```
-
-The residual added back is `relu(x)`, not `x`. The input to refinenet4
-averages −473, so clipping it is the whole point — and adding back the
-original `x` instead leaves that entire negative bulk in the output.
-Nothing fails, no shape is wrong, no weight is missing; the depth map is
-just wrong by three orders of magnitude.
-
-The lesson is about the oracle, not the language. `tests/fuse_oracle.py`
-originally re-implemented the block from a *reading* of the reference
-source and reproduced the same misreading, so the unit test passed while
-the head was wrong. It now imports `_make_fusion_block` and drives the
-reference's own module, which cannot drift from it.
-
-The bisect harness is kept:
-
-* `LINGBOT_DPT_TRACE=1 tests/agg_oracle.py …` re-walks the reference
-  head's own submodules and dumps every stage: `dpt_proj_N`,
-  `dpt_pos_N`, `dpt_rs_N`, `dpt_rn_N`, `dpt_rcu4`, `dpt_up4`,
-  `dpt_f4..f1`, `dpt_oc1`, each with a whole-tensor sum and absmax.
-* `dp_forward`'s `trace` argument prints the same stages from the port,
-  in the same format, so a single run localises the divergence. A
-  150 s forward is not something to bisect by adding one print at a
-  time.
-
-The reference stage values are recorded below for orientation; note how
-large `dpt_rs_3` and `dpt_rn_3` legitimately get (−170 … −447), which
-is *not* the bug.
-
-The shapes below are read off the real checkpoint:
-
-| piece | shape | note |
-|---|---|---|
-| `norm` | LayerNorm(2048) | over the tapped tokens, patches only (from index 6) |
-| `projects.0..3` | 1×1 conv 2048 → **256, 512, 1024, 1024** | one per tapped layer; the four differ |
-| `resize_layers.0` | ConvTranspose2d 256→256, k4 s4 | ×4 up |
-| `resize_layers.1` | ConvTranspose2d 512→512, k2 s2 | ×2 up |
-| `resize_layers.2` | Identity | — |
-| `resize_layers.3` | Conv2d 1024→1024, k3 s2 p1 | ×2 down |
-| `scratch.layer{1..4}_rn` | 3×3 conv → 256, **no bias** | 256/512/1024/1024 in |
-| `scratch.refinenet{1..4}` | fusion blocks | refinenet4 has **no** `resConfUnit1` |
-| `scratch.output_conv1` | 3×3 conv 256 → 128 | |
-| `scratch.output_conv2` | 3×3 conv 128→32, ReLU, 1×1 conv 32→**2** | depth + confidence |
-
-Config: `intermediate_layer_idx = [0,1,2,3]`, `pos_embed=True`,
-`activation="exp"`, `conf_activation="expp1"`.
-
-`gkd_resize_bilinear` was added to gpukit for this (both corner
-conventions, verified against torch); `gkd_conv2d` and
-`gkd_convtranspose2d` already existed. `gkd_convtranspose2d` indexes its
-weight as `[cin, cout, kh, kw]`, which is PyTorch's ConvTranspose2d
-layout — checked, and not the bug.
-
-Also needed: `_apply_pos_embed`, which builds a UV grid and a sinusoidal
-embedding scaled by 0.1 and adds it **twice** — after each project and
-after the final interpolate.
-
-### Stage 5 (partial) — the camera head (`src/camhead.nu`)
-
-**This is where a pose comes out.** It reads one token per frame — the
-camera token, row 0 of the last tapped aggregator layer — and refines a
-9-vector over four passes:
-
-```
-pred ← 0
-repeat 4:
-    cond               = embed_pose(pred)                9 → 2048
-    shift, scale, gate = Linear(SiLU(cond))              2048 → 3·2048
-    x                  = gate · (adaLN(tok)·(1+scale) + shift) + tok
-    x                  = trunk(x)                        4 blocks, dim 2048
-    pred               = pred + pose_branch(trunk_norm(x))
-```
-
-A DiT-style adaptive-LayerNorm loop: each pass sees its own previous
-answer, so the trunk is asked *what is wrong with this pose* rather than
-*what is the pose*.
-
-End to end on the real checkpoint — preprocess, DINOv2, aggregator,
-camera head — **106 s, 5.7e-7** against the real model's `pose_enc`, and
-the decoded result is what frame 0 should be: identity rotation,
-zero translation, fx ≈ 290.8 / fy ≈ 290.9 for a 518×294 frame.
-
-Details that bite:
-
-* the trunk is dim 2048 with 16 heads, so head_dim is **128** and its
-  3-D rope splits **40/44/44** — not the 20/22/22 the aggregator's
-  64-dim heads use. Same kernel, different geometry, so the axis widths
-  are a parameter now.
-* `adaln_norm` has **no affine parameters** and eps **1e-6**, while
-  `token_norm`, `trunk_norm` and the trunk's own norms are plain
-  `nn.LayerNorm` at 1e-5. That is a *fourth* epsilon.
-* only the field of view is activated (ReLU — it cannot be negative).
-  Translation and quaternion pass through linear, which is why the
-  quaternion is never unit and why `src/geom.nu` divides by its own
-  squared norm.
-* `poseLN_modulation` is `Sequential(SiLU, Linear)`, so the checkpoint
-  only carries `.1.weight` / `.1.bias` — element 0 is the SiLU.
-
-### Stage 4 — the aggregator, one frame (`src/aggregator.nu`)
-
-DINOv2's patch tokens, six special tokens prepended, then 24 **frame**
-and 24 **global** blocks alternating, with four pairs tapped and
-concatenated into [P, 2048] feature maps. On the real checkpoint, for
-one 518×294 frame: **103 s, 7.3 GB, 5.4e-6** against the actual model's
-four outputs.
-
-That is 909M parameters and 72 transformer blocks agreeing to float32's
-noise floor.
-
-Streaming works: `LmKv` holds each global block's keys and values as
-`[heads, maxkv, hd]`, each frame appends its rotated k/v at row `kvused`
-and attends over everything stored. **Two frames through the cache match
-the real model to 5.4e-6** — the same figure as one frame, which is what
-a correct cache should give.
-
-`used` is read by the block and never written by it: one frame passes
-through 24 separate caches, so the count belongs to the frame and is
-passed in per call rather than stored 24 times and kept in step by hand.
-
-One subtlety in the layout: a cache is `[heads, maxkv, hd]` but only
-`nkv` rows are live, so a prefix view is **not** contiguous per head.
-The live rows are repacked into a tight `[heads, nkv, hd]` before the
-permute. Correct, and the obvious thing to make cheaper later.
-
-Cost is close to linear so far: 103 s for one frame, 201 s for two on
-the CPU backend. Frame 2 attends over 1566 keys instead of 783 and pays
-the repack, and it still comes in at about what frame 1 costs — the
-per-frame DINOv2 trunk dominates at this length.
-
-**Eviction is implemented as a ring, not as repeated `torch.cat`** —
-see the stage 4 eviction section. Past 72 frames the sliding window is
-needed for *correctness*, not just for memory: without it the model
-attends to frames the reference has already dropped.
-
-**Three different LayerNorm epsilons in one model**, and getting one
-wrong is worth ~1e-3:
-
-| | ε |
+| stage | vs the reference |
 |---|---|
-| DINOv2's blocks and final norm | 1e-6 |
-| aggregator frame/global `norm1`/`norm2` | **1e-5** |
-| `q_norm` / `k_norm` everywhere | 1e-5 |
+| frame preprocessing | identical, every value |
+| the `.pt` checkpoint, 1342 tensors | identical to `torch.load` |
+| 2-D and 3-D rotary embeddings | 0 |
+| patch embedding, one transformer block | 4.4e-15 |
+| camera geometry | 2.4e-16 |
+| DINOv2 trunk, on a real frame | 6.5e-6 |
+| the whole aggregator, four tapped layers | 5.3e-6 |
+| two frames through the KV cache | 5.3e-6 |
+| KV eviction, 120 frames | 0 |
+| eviction against the real model, past the window | 9.3e-6 |
+| camera pose, after four refinement passes | 2.3e-7 |
+| depth, confidence and world points, end to end | 1.5e-5 |
 
-Only `DinoVisionTransformer` passes `partial(LayerNorm, eps=1e-6)` to
-its blocks. `Block` and `Attention` both default to plain
-`nn.LayerNorm`, so everything the aggregator builds gets 1e-5. Using
-1e-6 throughout produced a *constant* 4e-3 absolute error that appeared
-in the very first block group and never grew — which is how it was
-found: real accumulation grows with depth, a systematic error does not.
+f32 on both sides. The 1e-6-and-up figures are float32's own noise
+accumulating over 72 transformer blocks; the ones near 1e-15 are stages
+short enough that nothing accumulates.
 
-### Stage 4 (partial) — the DINOv2 trunk (`src/dino.nu`)
+**Every one of those is a one- or two-frame measurement.** They say the
+arithmetic is right. They do not say what a 300-frame reconstruction
+looks like, and the next section does.
 
-The aggregator's "patch embedding" is a whole frozen 24-block ViT-L/14,
-and it now runs on the real checkpoint: **35 s, 2.5 GB, 3.9e-6** against
-the actual model's `x_norm_patchtokens` for an example frame.
+## How close is it really
 
-The token order matters and is easy to get subtly wrong, because the
-position embedding is added *in the middle* of building it:
+`tests/ref_cloud.py` runs `~/dev/lingbot-map` over the same frames and
+writes the same cloud; `tests/cmp_cloud.py` asks whether every point of
+one has a point of the other in the same place, relative to the size of
+the scene. Both are in the suite as step 20.
 
-```
-[cls] + patches            ← pos_embed added HERE
-[cls] + [reg×4] + patches  ← register tokens spliced in AFTER
-```
+| frames | point counts | median displacement | centroid drift |
+| ---: | --- | ---: | ---: |
+| 1 | 33 024 vs 33 025 | 2.3e-5 | 6.9e-5 |
+| 2 | identical | 2.3e-4 | 8.9e-3 |
+| 4 | 129 979 vs 129 982 | 1.7e-3 | 5.1e-2 |
+| 12 | identical | 2.4e-3 | 1.0e-1 |
+| 20 | 589 997 vs 590 002 | 3.0e-3 | 1.8e-1 |
 
-so the four register tokens get no position embedding at all, and the
-patch tokens the aggregator wants start at index 5.
+So the **depth is right** — the point counts agree to about one part in
+30 000, which is the handful of pixels whose confidence sits within f32
+noise of the threshold — and the **poses drift**. Each frame's cloud has
+the right shape and very nearly the right size; it is placed slightly
+wrong, and the error compounds down the sequence.
 
-`src/load.nu` maps the checkpoint onto device buffers with nothing
-transposed — torch stores a `Linear` weight as `[out, in]` and
-`gkd_gemm` reads it with `transb=1` — and stages one tensor at a time,
-so peak extra memory is the largest single weight (32 MB) rather than
-the model.
+Some of that is unavoidable in a streaming model: frame N's pose is
+estimated from a cache carrying every frame before it, so a small
+disagreement early is a larger one later. But not this much. Perturbing
+the *reference's* input by 3e-4 — the size of the port's own
+activation-level disagreement — moves the reference's own 20-frame cloud
+by 4.3e-5 median and 3.9e-5 centroid. The port sits **roughly 600x
+further away than the model's own conditioning explains**, so this is a
+real accumulating difference in the streaming path and not the arithmetic
+being unlucky.
 
-### Stage 4 (partial) — 3-D RoPE (`src/rope.nu`)
+It is not visible to any of the per-module tests above, which is the
+point of keeping step 20: the aggregator's activations disagree by a flat
+~3e-4 from frame 1 to frame 10 and never grow, while the trajectory built
+out of them does. Finding where that turns into pose drift is the open
+piece of work on this package.
 
-The aggregator's **global** blocks do not use the 2-D rope the frame
-blocks use. With `enable_3d_rope` — which is `demo.py`'s default — they
-use `WanRotaryPosEmbed`, and it differs on three axes at once:
+For a short sequence, or for the shape of a scene rather than its
+absolute placement, the port and the reference are the same
+reconstruction. For a long walk where the far end has to land in the
+right spot, they are not yet.
 
-| | 2-D (frame blocks) | 3-D (global blocks) |
-|---|---|---|
-| axes | row, column | frame, row, column |
-| head split | half / half | 20 / 22 / 22 |
-| theta | 100 | 10000 |
-| pairs | split each half at half/2 | **interleaved** (x₀,x₁), (x₂,x₃), … |
+## How it works
 
-Same idea, incompatible memory order, and nothing about picking the
-wrong one looks wrong. Bit-exact against the real `WanRotaryPosEmbed` —
-that test imports the upstream package rather than re-implementing it,
-because a hand-written oracle for this would just be a second chance to
-make the same mistake.
+Each frame is resized and cropped to 518 px wide, run through a frozen
+DINOv2 ViT-L/14 trunk, then through 24 pairs of transformer blocks that
+alternate between attention *within* the frame and causal attention
+*across* frames over a KV cache. Four of those pairs are tapped and fed
+to two heads: a camera head, which refines a 9-vector pose over four
+passes, and a DPT decoder, which gives a depth map and a per-pixel
+confidence. Depth plus the pose plus the intrinsics unprojects to
+world-space points, and that is the cloud.
 
-Token positions are fixed by the layout: special token *j* sits at
-`(f, j, j)` and patch `(py, px)` at `(f, 6+py, 6+px)`, so the six
-special tokens run down a diagonal that the patch grid never reaches.
+The cache is what makes it *streaming*: frame N is placed relative to
+every frame before it, so the poses all land in one world frame without
+any global optimisation. Past 72 frames a sliding window evicts the
+middle of the sequence and keeps the first 8 frames and the last 64,
+which is what bounds the memory.
 
-### Stage 4 (partial) — the block on the device (`src/devblock.nu`)
-
-The block again, this time in **f32 over gpukit's `gkd_*` ops** — gemm,
-layernorm, bmm, softmax, permute, broadcast-elementwise — so the same
-code runs on CUDA and on the CPU backend. This is the one that will
-actually run the model; `src/block.nu` stays as the reference it is
-checked against.
-
-Keeping both is the point. A device block is ~15 kernel launches, every
-one with a stride or a permutation that can be silently wrong, and
-comparing against one slow implementation that is known correct catches
-all of them at once. Measured difference: **3e-6**, which is what f32
-accumulation over these sizes should give — against ~9e-2 for the head
-stride bug that was in the host version.
-
-Torch's weight layouts are used unchanged: a `Linear` weight is
-`[out, in]` and goes straight into `gkd_gemm` with `transb=1`, so
-nothing is transposed at load time.
-
-The one kernel that had to be written is 2-D RoPE — the rest of the
-block is composition.
-
-### Stage 3 — the transformer block (`src/block.nu`)
-
-The unit this model is 72 of (24 DINOv2 + 24 frame + 24 global):
-
-```
-x = x + ls1 · attn(norm1(x))
-x = x + ls2 · mlp(norm2(x))
-```
-
-pre-norm LayerNorm, LayerScale on both branches, exact (erf) GELU, and
-attention that layer-normalises q and k **per head** before rotating
-them. Matches the reference to 4e-15.
-
-Two things the reference does that a careful reading still misses:
-
-* **`qk_norm=True` uses a different epsilon.** `Block` builds its
-  `Attention` without passing `norm_layer`, so `norm1`/`norm2` get
-  DINOv2's `partial(LayerNorm, eps=1e-6)` while `q_norm`/`k_norm` fall
-  back to `nn.LayerNorm`'s own default of `1e-5`. Two constants, and
-  the port has to carry both.
-* q/k/v are `[heads, n, head_dim]`, so a head's stride is `n·head_dim`,
-  **not** `n·dim`. Getting that wrong leaves every head past the first
-  reading zeros — and attention still produces plausible numbers, so it
-  surfaces as a few percent of error rather than as anything obviously
-  broken. (It did, here, until the intermediates were dumped.)
-
-`erf` was missing from `stdlib/std/float.nu` and is now there
-(`float_erf` / `float_erfc`) — exact GELU needs it, and so does any
-normal-distribution CDF.
-
-### Stage 3 — patch embedding (`src/patchembed.nu`)
-
-`Conv2d(3, 1024, kernel=14, stride=14)`. Kernel equals stride, so the
-patches do not overlap and the convolution is exactly a matmul: im2col
-each 14×14×3 patch into a 588-wide row, multiply by the reshaped
-weight. Matches torch's `conv2d` to 4e-15.
-
-im2col is written out rather than fused into the multiply, because the
-multiply is what moves to a device kernel later and the layout is what
-has to be right first.
-
-### Stage 3 — 2-D RoPE (`src/rope.nu`)
-
-Attention rotates q and k by the token's position in the patch **grid**,
-not its index in the sequence: the head dimension splits in half, the
-first half rotated by the row coordinate and the second by the column.
-Bit-exact against `RotaryPositionEmbedding2D`.
-
-Two things here are silent when wrong: the rotation splits each *half*
-at half/2 (not the full head dim at D/2), and `positions` is (row, col)
-with row driving the first half — swapping them transposes the model's
-idea of the image without changing a single shape.
-
-### Stage 3 — weight access (`src/weights.nu`)
-
-`lw_require` declares the shape a module expects and accumulates
-failures, so a mismatched checkpoint names the first thing actually
-wrong at load time. Layer counts are read off the file rather than
-hard-coded, so the `-long` and `-stage1` checkpoints load too.
-
-## Running the tests
+## Tests
 
 ```
 cd packages/lingbot-map && ./tests/lingbot_map_test.sh
 ```
 
-**It is slow.** Eleven steps, each with its own NURL build, and the last
-two run the model on real weights (35 s for the trunk, 105 s for the
-aggregator). Budget ~45 minutes on a CPU. The steps that need the
-checkpoint or the upstream package skip cleanly when those are absent,
-which is the fast path.
+Twenty steps, each building its own NURL binary. Steps that need the
+checkpoint, a python with torch, or the upstream package skip cleanly
+when those are absent — that is the fast path, and it is what CI runs.
+For the full set, set `PYTORCH_PY` (or drop a venv at the repo root as
+`.venv-oracle`) and check out the upstream package at `~/dev/lingbot-map`.
 
-Needs a python with torch (any CPU build) for the oracle; set
-`PYTORCH_PY`, or drop a venv at the repo root as `.venv-oracle`. Without
-one the oracle steps skip and the code is only smoke-run.
+Step 20, the end-to-end differential, additionally needs a **CUDA** torch —
+`.venv-oracle` is deliberately a CPU build, since correctness is all the
+other steps need. Set `LINGBOT_CUDA_PY`, or drop one at the repo root as
+`.venv-cuda`, and `LINGBOT_CUDA_DEV` if the first CUDA device is not the
+one you want.
 
-Two steps go further and import the **upstream package** from
-`~/dev/lingbot-map` (needs `torch torchvision pillow numpy scipy einops
-huggingface_hub`): the 3-D rope check, and `tests/agg_oracle.py`, which
-loads the real checkpoint and runs the actual model end to end. That
-last one is how `tests/agg_ref_courthouse0.txt` was produced — the
-aggregator's four outputs for one example frame, which is the ground
-truth the rest of stage 4 is built against. Regenerating it takes the
-4.6 GB checkpoint and a few minutes of CPU, so it is committed.
+## Under the hood
 
-## Notes for whoever picks this up
+[`docs/porting-notes.md`](docs/porting-notes.md) — how the port was
+built, every trap that was silent when it was wrong, and what the speed
+work actually turned out to be. [`docs/checkpoint.md`](docs/checkpoint.md)
+— all 1342 tensors read out of the real file.
 
-**Compute.** There is no usable GPU on the development machine, so the
-port runs on gpukit's CPU backend. That made two things necessary before
-any model code could be written, both now upstream:
-
-* the CPU backend's matmul was a per-output-element kernel — right on a
-  GPU, 24× off the machine on a CPU. It is register-tiled now (1.7 →
-  42 GFLOP/s on a 6-core i7-5930K), bit-identical either way.
-* `stdlib/ext/zip.nu` could not read zip64 and needed the whole archive
-  in memory, so a 4.6 GB checkpoint was simply unopenable.
-
-A frame is roughly 2 TFLOP, so expect ~1–2 minutes per frame on a CPU
-and design the CLI around that (stream, checkpoint, resume) rather than
-around interactive use.
-
-**Two resamplers, and the trap between them.** Preprocessing resizes
-frames with **PIL's** bicubic; `interpolate_pos_encoding` resamples
-DINOv2's 37×37 position grid to the frame's patch grid with **torch's
-`bicubic` + `antialias=True`**. Both are implemented and both are
-verified — `image_resize_bicubic` and `src/interp.nu`.
-
-The trap is the kernel constant. torch has *two* bicubic
-implementations that disagree on it:
-
-| | kernel `a` | arithmetic |
-|---|---|---|
-| PIL (preprocessing) | −0.5 | 8-bit fixed point, clamped |
-| torch `antialias=True` | **−0.5** | float, unclamped |
-| torch `antialias=False` | **−0.75** | float, border-replicated |
-
-Every reference to "torch bicubic" means the −0.75 one, and the
-antialias path — which is what this model uses — is −0.5, because it
-was written to reproduce PIL. Building the position-grid resample from
-the documented −0.75 gives a kernel that is a few percent wrong
-everywhere and right nowhere, with nothing to notice. (Recovered by
-probing torch with unit impulses and solving for `a`: −0.49997.)
-
-**Checkpoint layout.** [`docs/checkpoint.md`](docs/checkpoint.md) is the
-full inventory read out of the real 4.6 GB file: every tensor name, dtype
-and shape, 1342 of them, 1.16 B parameters, all f32. Worth reading before
-writing any of stages 3–5 — a few things are not what the Python source
-suggests:
-
-* the root is a **bare `OrderedDict`**, not `{"model": …}`, so names come
-  out of `torchpt` unprefixed (`aggregator.frame_blocks.0.attn.qkv.weight`);
-* there is **no `point_head`** — `enable_point` is off, which is
-  `GCTStream`'s default. World points come from unprojecting the depth
-  map, not from a second DPT head;
-* `aggregator.patch_embed.pos_embed` is `1×1370×1024` = 1 cls + 37×37
-  patches, which is what forces the position-grid resample.
+Built on [`torchpt`](../torchpt) (reads the `.pt` without executing its
+pickle), [`gpukit`](../gpukit) (the kernels) and
+[`image`](../image) (PNG/JPEG decode and a PIL-compatible bicubic
+resize).

--- a/packages/lingbot-map/docs/porting-notes.md
+++ b/packages/lingbot-map/docs/porting-notes.md
@@ -1,0 +1,746 @@
+# lingbot-map — porting notes
+
+How the port was built and what it cost, kept out of the
+[README](../README.md) because none of it is needed to use the thing.
+It is here because the next person to touch the model code will want it:
+the traps below are all silent ones — nothing crashes, no shape is wrong,
+the reconstruction is just quietly not the reference's.
+
+## Why this port is the size it is
+
+The reference is ~13 000 lines of PyTorch and the checkpoint is 4.6 GB
+of fp32 — roughly 1.16 B parameters in three stacked transformers:
+
+| part | shape |
+|---|---|
+| `patch_embed` | DINOv2 ViT-L/14 — 24 blocks, dim 1024, used as a frozen feature extractor |
+| `aggregator.frame_blocks` | 24 blocks, dim 1024 — attention **within** a frame |
+| `aggregator.global_blocks` | 24 blocks, dim 1024 — causal attention **across** frames, over a paged KV cache |
+| `camera_head` | iterative pose refinement, 4 passes |
+| `depth_head`, `point_head` | DPT decoders over four intermediate layers |
+
+Frame and global blocks alternate, and every fourth pair (`[4, 11, 17,
+23]`) is tapped for the DPT heads. That structure — anchor context,
+pose-reference window, trajectory memory — is the paper's contribution
+and is what the port has to reproduce exactly, not approximately.
+
+## Stages
+
+| # | stage | state |
+|---|---|---|
+| 1 | read the `.pt` checkpoint | **done** — [`torchpt`](../../torchpt); the real 4.6 GB file in 0.01 s / 31 MB RSS, values identical to `torch.load` |
+| 2 | image loading and preprocessing | **done** — byte-identical to the reference pipeline on real frames |
+| 3 | ViT layers: patch embed, 2-D RoPE, qk-norm attention, block | **done** — the full block matches the reference to 4e-15 |
+| 4 | streaming aggregator + KV cache | **done** — 5.9e-6 vs the real model; sliding-window eviction 8.5e-6, checked against the model past the eviction point |
+| 5 | camera head, DPT heads | **done** — camera head 2.2e-7, DPT depth head 1.6e-6 |
+| 6 | camera geometry | **done** — matches torch to 2.4e-16 |
+| 7 | CLI, point-cloud export, end-to-end check | **done** — `src/main.nu`; world points 1.5e-6 vs the real model |
+
+## The speed work — what made the difference
+
+The port was correct long before it was fast: eight frames took 38.2 s
+end to end and the 4.6 GB checkpoint load alone was ~25 s. Those are now
+2.8 s and 1.6 s, on an RTX 4090, with the per-frame steady state down
+from ~1.25 s to ~0.16 s. Every kernel rewrite kept its accumulation
+order, so this is the same arithmetic run in a better shape — with one
+deliberate exception, the fused attention, noted below.
+
+Nearly all of it is in [`gpukit`](../../gpukit) rather than here — this port
+was the thing that made the gaps visible, and the fixes belong where
+every GPU package gets them. In rough order of what it bought:
+
+* **Tiled GEMM.** One thread per output element costs a global load of B
+  per multiply-add; a 64x64 shared-memory tile with a 4x4 register tile
+  and `float4` shared reads costs a fraction of one. 3.1 → 19.1 TFLOP/s
+  (and 0.6 → 20.1 with a transposed B, which the old kernel read along
+  the wrong axis entirely). Bit-identical: blocking changes when a
+  product is computed, not the order the sum runs in.
+* **Fused attention.** The composed form materialises a
+  `[heads, n, nkv]` score matrix, writes it once and reads it five
+  times. `gkd_attention` never writes it. 3.8x at `nkv = n`, 6.2x at
+  `nkv = 4n` — and, more to the point for a *streaming* model, the
+  buffer it does not allocate is 2.8 GB at a 72-frame window. This is
+  the one change that is not bit-identical (an online softmax rescales a
+  running sum rather than summing left to right); it moved the whole
+  aggregator from 5.385e-6 to 5.853e-6 against the real model, and the
+  end-to-end depth agreement *improved*, from 1.646e-5 to 1.591e-5 —
+  which figures, since the reference uses SDPA and so does this.
+* **A caching device allocator.** `cuMemAlloc`/`cuMemFree` synchronise
+  and cost ~315 us per 12 MB pair. A frame allocates its scratch a few
+  hundred times, so a third of every frame was the allocator, with the
+  device idle for all of it.
+* **The checkpoint is read straight into device memory.** The load path
+  widened every f32 weight to f64, transposed the four hot Linear
+  weights on the host with a column-strided write per element, and
+  narrowed them again on upload. Now the mapped bytes go to the device
+  as they are and the transpose is a permute kernel: 25 s → 1.6 s.
+* **Layernorm a row per block, not per thread** (~800 rows is three
+  blocks on a 128-SM card): 6.3x. **Convolution with a 4x4 output tile
+  per thread**: 2.2x. **Transposed convolution** with a fast path for
+  stride == kernel, where the general body was doing two 64-bit modulos
+  per tap to discover that fifteen of every sixteen taps contribute
+  nothing: 14.2 ms → 0.35 ms. **GEMV shape for M = 1**, which the camera
+  head runs twenty times per frame and which was eight blocks on a
+  128-SM card.
+* **The convolution is shape-specialised too**, for the same reason as
+  the permute: every loop bound and stride was a kernel argument, so a
+  3x3 layer paid a 64-bit multiply-add chain per tap to compute an
+  address the compiler could have folded, and could not unroll a
+  nine-tap window it did not know was nine taps. The twelve dimensions
+  go in as literals; each layer geometry compiles once. The depth head
+  went 39 ms → 22 ms, and the dumps are byte-identical with the
+  specialisation forced off.
+* **The permute is shape-specialised.** The generic body decomposed
+  each output index with six 64-bit divisions and modulos and kept its
+  working arrays in local memory, which is why moving 9 MB took 87 us.
+  The kernel source is generated per call anyway, so the dims and the
+  permutation go in as literals and it takes 15 us.
+* **Two per-frame constants are now built once.** The DPT
+  positional-embedding grid is a pure function of (channels, height,
+  width, aspect); rebuilding it was ~10 million host `sin`/`cos` a
+  frame, a fifth of the frame. The DINOv2 position grid is a bicubic
+  resample over 1024 channels and a pure function of (gh, gw);
+  rebuilding it was another 53 ms a frame — a *quarter* of what the
+  frame had shrunk to by then. Both were found the same way, by
+  profiling a build without LTO so the inlined frame loop resolves into
+  named functions, and both are bit-identical: the eight-frame cloud is
+  byte-for-byte unchanged.
+* **The point cloud is binary PLY by default.** ASCII cost 15 us per
+  point — 470 ms a frame at the default stride, more than the depth
+  head. `--ascii` still writes the text form, and the two select exactly
+  the same points.
+  The float formatting behind it was worth fixing on its own:
+  `nurl_str_float` searched 1..17 significant digits linearly for the
+  shortest round-trip, which is ~2.5 us for a value that came from an
+  f32 (the worst case). It binary-searches now — the property is
+  monotone in the digit count — which is five probes instead of
+  seventeen, for every float any NURL program prints.
+
+Four things this did NOT need, all measured and dropped: double
+buffering the GEMM's global loads (neutral — the kernel is not
+latency-bound), a 128x128 tile with an 8x8 register tile (worse — at
+these shapes it halves the block count on a 128-SM card, and idle SMs
+cost more than the better reuse gains; worse again when re-tried after
+the `float4` change, this time on register pressure), and 16-byte global
+loads in the staging phase (also neutral-to-worse, so it is not
+issue-bound on those either). Four negative results on one kernel is
+itself the finding: at ~25 TFLOP/s it is not short of any single
+resource, and the next step is warp-level tiling with register-resident
+fragments rather than another parameter.
+
+The convolution and the attention, by contrast, were both short of
+something specific and both moved a lot when it was fixed — which is the
+argument for measuring each kernel rather than assuming the biggest one
+is the one to work on.
+
+## The stages, one at a time
+
+Newest first, roughly — each section is what that stage cost to get
+right, not what it does. The order below is the order they were
+finished, which is not the order the model runs them in.
+
+### Stage 2 — preprocessing (`src/preproc.nu`)
+
+`load_and_preprocess_images(mode="crop", image_size=518, patch_size=14)`,
+which is what `demo.py` runs: alpha onto white, RGB, bicubic resize to
+width 518 with the height snapped to a whole number of patches, centre
+crop, scale to [0, 1], CHW. ImageNet normalisation is *not* done here —
+the aggregator does it, and doing it twice is a quiet way to get a
+plausible but wrong reconstruction.
+
+That needed a **PIL-compatible bicubic resampler**, which the `image`
+package did not have (only nearest, bilinear and box). It has one now:
+`image_resize_bicubic`, byte-identical to Pillow — same `a = −0.5`
+kernel, same support scaling, same 22-bit fixed-point two-pass
+arithmetic. Note that this is a *different kernel* from the one stage 3
+needs for the position grid (torch's `a = −0.75`); they are not
+interchangeable.
+
+Verified on the repo's own example frames: six frames, every sampled
+value identical to the reference pipeline.
+
+EXIF orientation is deliberately **not** applied — the reference calls
+`exif_transpose`, `image` does not surface EXIF, and silently ignoring a
+rotation beats silently applying the wrong one. Video-derived frames,
+which is what streaming reconstruction is actually fed, carry none.
+
+### Stage 6 — camera geometry (`src/geom.nu`)
+
+The model's per-frame output is a 9-vector: translation, a **scalar-last**
+quaternion, and two field-of-view angles. `src/geom.nu` turns that into
+extrinsics, intrinsics, a camera-to-world transform, and unprojected
+world points.
+
+Verified against the upstream `quat_to_mat` / `mat_to_quat` /
+`pose_encoding_to_extri_intri` / `closed_form_inverse_se3` code paths:
+worst relative error **2.4e-16** across six random pose encodings — the
+last bit, and it comes from torch's vectorised `tan` disagreeing with
+glibc's, not from the port.
+
+### Stage 7 — the CLI, hardening pass
+
+Three defects the finishing pass turned up, all in `src/main.nu`:
+
+* **It always exited 0.** A frame could fail, the message went to
+  stdout, and the process reported success — a caller piping the cloud
+  into a build would never learn. Failures now set `rc` and it is
+  returned.
+* **The workspace was sized `nframes · P`.** Eviction caps the cache far
+  below that, and the attention matrix is `heads · n · nkv`: at 300
+  frames the oversized version wants ~12 GB for that term alone and
+  would not run at all. It is now sized by `ag_kv_rows`, a 4× cut at
+  300 frames.
+* **No way to name a directory.** A 324-frame scene meant 324 paths on
+  the command line. `--frames <dir>` takes every `.png`/`.jpg`, **sorted
+  by name** — order is not a nicety, the KV cache makes frame N depend
+  on every frame before it, so a raw `readdir` order reconstructs a
+  different scene.
+
+`vec_extend` looked like the way to append the glob results, and it
+exposed a compiler bug: `= . p + k 0 v` for an aggregate element type
+died with *"unknown field or variable: +"*. Fixed in `nurlc` with a
+regression test (`compiler/tests/ptr_agg_index_store.nu`). `vec_extend`
+documents itself as safe only for trivial element types, so the CLI
+pushes the handles across instead.
+
+### Stage 4 (partial) — KV-cache eviction (`src/aggregator.nu`)
+
+The reference keeps the first `kv_cache_scale_frames` = 8 frames
+forever, keeps the last `kv_cache_sliding_window` = 64 frames
+**including the current one**, and from every frame it drops it
+preserves the six special-token rows. Past 72 frames a cache that just
+grows is not merely wasteful, it is **wrong** — the model attends to
+frames it should not. The example scenes are 237–324 frames.
+
+That "including the current one" is the whole subtlety, and it is not
+visible in the eviction function. `attention.py:239-244` concatenates
+the frame into the cache and only *then* calls
+`_apply_kv_cache_eviction_causal`, so `num_cached` already counts it:
+the trigger is `f ≥ S + W` and the live set is the scale frames plus
+`f−W+1 … f`. The port first read the function alone, got a window one
+frame too wide starting one frame too late, and was wrong from the very
+first eviction — by **2.7e-2**.
+
+The port implements the policy as a ring rather than as the reference's
+repeated `torch.cat`. Each cache is laid out as
+
+```
+[0, S·P)              the scale frames, never moved
+[S·P, S·P + W·P)      a ring of the last W frames
+[S·P + W·P, …)        six preserved rows per evicted frame
+```
+
+The live region is always a **prefix**, so attention still reads a
+contiguous run and nothing in the attention path had to learn about
+eviction. Shifting the survivors down instead, which is what
+`torch.cat` amounts to, would move about 5 GB per frame across 24
+blocks.
+
+That did force one honest change: `LmKv`'s single `used` became `woff`
+and `nvalid`. Where a frame writes and how much of the cache is live are
+the same number only while frames go on the end.
+
+Two tests, and it took both:
+
+* `tests/kvcheck.nu` vs `tests/kv_oracle.py` — the bookkeeping, 120
+  frames, exact, one second. `kv_oracle.py` replays the reference's own
+  eviction; it needs no torch and no checkpoint.
+* `tests/streamcheck.nu` vs the real model with the window shrunk to
+  **1 + 2 on both sides** (`LINGBOT_KV_SCALE` / `LINGBOT_KV_WINDOW`,
+  which the reference takes as constructor arguments) — six frames,
+  three of them past eviction, **7.7e-6**.
+
+The bookkeeping test alone was not enough, and the reason is worth
+keeping: `kv_oracle.py` replayed the reference's eviction *function*
+faithfully but placed the *call* where the port placed it. It agreed
+with the port's wrong window and reported an exact match. Only running
+the activations caught it. **A replay has to reproduce the call site,
+not just the callee.**
+
+### Stage 7 — the CLI and the point cloud (`src/main.nu`)
+
+`lingbot-map --help` has the current surface; the README has the
+examples. What matters here is what happens between the frames and the
+file.
+
+Each frame goes through preprocessing, the DINOv2 trunk and the
+streaming aggregator — which keeps its KV cache across frames, so the
+poses land in one shared world frame — then the camera head for a pose
+and the DPT head for depth and confidence. Depth plus intrinsics plus
+the camera-to-world transform unprojects to world points, which is the
+cloud.
+
+`world_points` matches the reference's own
+`unproject_depth_map_to_point_map` to **1.5e-6**, and is checked as part
+of the end-to-end test rather than assumed from the depth agreeing.
+
+Two things about the geometry are easy to get wrong and are worth
+stating, because both are silent:
+
+* The reference builds its pixel grid with `np.arange(W)` — **integer**
+  pixel coordinates, not sample centres. Half a pixel of offset is not
+  visible in any single number.
+* `unproject_depth_map_to_point_map` takes the **world-from-camera**
+  extrinsic that the pose encoding decodes to and inverts it itself.
+  Handing it the already-inverted one gives a plausible-looking cloud
+  that is in the wrong frame.
+
+Output is `binary_little_endian` PLY, which every viewer reads, with
+`--ascii` for the text form. Binary is the default because ASCII is not
+a rounding cost here: formatting three coordinates per point ran at
+15 us a point, 470 ms a frame at the default stride — more than the
+depth head. The two forms select the same points; the binary one stores
+each coordinate as the f32 it came from rather than the shortest
+round-tripping decimal, so they agree to 6e-8. The end-to-end test writes
+both and checks it.
+
+The vertex count is not known until the last frame is done, so the
+header is written with a fixed-width zero-padded placeholder and patched
+by seeking back at the end — the alternative is holding the whole cloud
+in memory, and a 300-frame sequence is tens of millions of points.
+Points are flushed a row at a time.
+
+On two consecutive courthouse frames at the defaults: 61 458 points,
+frame centroids 0.0095 apart in a scene 2.82 across — the two frames
+land on top of each other, which is what a shared world frame means.
+
+### Stage 5 — the DPT depth head (`src/dpthead.nu`)
+
+Loads and runs end to end in ~150 s and matches the reference: `depth`
+to **1.6e-6** and `depth_conf` to **7.8e-6**, with every intermediate —
+the token norm, the four projections, the position embedding, all four
+resize layers (both ConvTransposes and the strided conv), the four
+`layerN_rn` reductions, all four fusion blocks and `output_conv1` —
+inside 5e-6.
+
+Getting there took a bisect worth writing down, because the bug was
+invisible to everything except the reference itself.
+
+The divergence started at `dpt_f4`, the first fusion block, at a scaled
+error of 6.8e+2. Every stage before it was already correct to float32
+noise. Three things were ruled out in turn:
+
+* **The ops.** `tests/fusecheck.nu` runs one fusion block on synthetic
+  weights at 8×3×5 — seconds instead of 150 — and `resConfUnit2`, the
+  bilinear upsample and the 1×1 `out_conv` each matched.
+* **The plumbing.** The real head keeps its blocks in a `Vec DpFuse`,
+  36 scalars deep, and pulls them out by index through an `Option`
+  match. Four blocks with distinguishable weights came back correct.
+* **The weights.** Every DPT tensor read through `Lw` matched torch's
+  sum and absolute maximum exactly.
+
+Right input, right ops, right plumbing, right weights, wrong output.
+What broke the deadlock was strengthening the dumps: a strided sample of
+a 53 504-element tensor is six numbers, and six numbers can agree while
+the tensor does not, so `__dp_dump` and the oracle's DPT trace both
+gained a whole-tensor sum and absolute maximum. That confirmed the input
+was right over every element, and — once probes went *inside* the block
+— that the reference's `resConfUnit2` takes an input peaking at 974 and
+returns one peaking at **0.144**, while the port returned its input
+essentially unchanged.
+
+No residual unit of the form `x + g(x)` can do that. The reference's is
+not that form:
+
+```python
+self.activation = nn.ReLU(inplace=True)   # _make_fusion_block
+...
+out = self.activation(x)      # OVERWRITES x
+out = self.conv1(out); out = self.activation(out); out = self.conv2(out)
+return self.skip_add.add(out, x)          # x is relu(x) by now
+```
+
+The residual added back is `relu(x)`, not `x`. The input to refinenet4
+averages −473, so clipping it is the whole point — and adding back the
+original `x` instead leaves that entire negative bulk in the output.
+Nothing fails, no shape is wrong, no weight is missing; the depth map is
+just wrong by three orders of magnitude.
+
+The lesson is about the oracle, not the language. `tests/fuse_oracle.py`
+originally re-implemented the block from a *reading* of the reference
+source and reproduced the same misreading, so the unit test passed while
+the head was wrong. It now imports `_make_fusion_block` and drives the
+reference's own module, which cannot drift from it.
+
+The bisect harness is kept:
+
+* `LINGBOT_DPT_TRACE=1 tests/agg_oracle.py …` re-walks the reference
+  head's own submodules and dumps every stage: `dpt_proj_N`,
+  `dpt_pos_N`, `dpt_rs_N`, `dpt_rn_N`, `dpt_rcu4`, `dpt_up4`,
+  `dpt_f4..f1`, `dpt_oc1`, each with a whole-tensor sum and absmax.
+* `dp_forward`'s `trace` argument prints the same stages from the port,
+  in the same format, so a single run localises the divergence. A
+  150 s forward is not something to bisect by adding one print at a
+  time.
+
+The reference stage values are recorded below for orientation; note how
+large `dpt_rs_3` and `dpt_rn_3` legitimately get (−170 … −447), which
+is *not* the bug.
+
+The shapes below are read off the real checkpoint:
+
+| piece | shape | note |
+|---|---|---|
+| `norm` | LayerNorm(2048) | over the tapped tokens, patches only (from index 6) |
+| `projects.0..3` | 1×1 conv 2048 → **256, 512, 1024, 1024** | one per tapped layer; the four differ |
+| `resize_layers.0` | ConvTranspose2d 256→256, k4 s4 | ×4 up |
+| `resize_layers.1` | ConvTranspose2d 512→512, k2 s2 | ×2 up |
+| `resize_layers.2` | Identity | — |
+| `resize_layers.3` | Conv2d 1024→1024, k3 s2 p1 | ×2 down |
+| `scratch.layer{1..4}_rn` | 3×3 conv → 256, **no bias** | 256/512/1024/1024 in |
+| `scratch.refinenet{1..4}` | fusion blocks | refinenet4 has **no** `resConfUnit1` |
+| `scratch.output_conv1` | 3×3 conv 256 → 128 | |
+| `scratch.output_conv2` | 3×3 conv 128→32, ReLU, 1×1 conv 32→**2** | depth + confidence |
+
+Config: `intermediate_layer_idx = [0,1,2,3]`, `pos_embed=True`,
+`activation="exp"`, `conf_activation="expp1"`.
+
+`gkd_resize_bilinear` was added to gpukit for this (both corner
+conventions, verified against torch); `gkd_conv2d` and
+`gkd_convtranspose2d` already existed. `gkd_convtranspose2d` indexes its
+weight as `[cin, cout, kh, kw]`, which is PyTorch's ConvTranspose2d
+layout — checked, and not the bug.
+
+Also needed: `_apply_pos_embed`, which builds a UV grid and a sinusoidal
+embedding scaled by 0.1 and adds it **twice** — after each project and
+after the final interpolate.
+
+### Stage 5 (partial) — the camera head (`src/camhead.nu`)
+
+**This is where a pose comes out.** It reads one token per frame — the
+camera token, row 0 of the last tapped aggregator layer — and refines a
+9-vector over four passes:
+
+```
+pred ← 0
+repeat 4:
+    cond               = embed_pose(pred)                9 → 2048
+    shift, scale, gate = Linear(SiLU(cond))              2048 → 3·2048
+    x                  = gate · (adaLN(tok)·(1+scale) + shift) + tok
+    x                  = trunk(x)                        4 blocks, dim 2048
+    pred               = pred + pose_branch(trunk_norm(x))
+```
+
+A DiT-style adaptive-LayerNorm loop: each pass sees its own previous
+answer, so the trunk is asked *what is wrong with this pose* rather than
+*what is the pose*.
+
+End to end on the real checkpoint — preprocess, DINOv2, aggregator,
+camera head — **106 s, 5.7e-7** against the real model's `pose_enc`, and
+the decoded result is what frame 0 should be: identity rotation,
+zero translation, fx ≈ 290.8 / fy ≈ 290.9 for a 518×294 frame.
+
+Details that bite:
+
+* the trunk is dim 2048 with 16 heads, so head_dim is **128** and its
+  3-D rope splits **40/44/44** — not the 20/22/22 the aggregator's
+  64-dim heads use. Same kernel, different geometry, so the axis widths
+  are a parameter now.
+* `adaln_norm` has **no affine parameters** and eps **1e-6**, while
+  `token_norm`, `trunk_norm` and the trunk's own norms are plain
+  `nn.LayerNorm` at 1e-5. That is a *fourth* epsilon.
+* only the field of view is activated (ReLU — it cannot be negative).
+  Translation and quaternion pass through linear, which is why the
+  quaternion is never unit and why `src/geom.nu` divides by its own
+  squared norm.
+* `poseLN_modulation` is `Sequential(SiLU, Linear)`, so the checkpoint
+  only carries `.1.weight` / `.1.bias` — element 0 is the SiLU.
+
+### Stage 4 — the aggregator, one frame (`src/aggregator.nu`)
+
+DINOv2's patch tokens, six special tokens prepended, then 24 **frame**
+and 24 **global** blocks alternating, with four pairs tapped and
+concatenated into [P, 2048] feature maps. On the real checkpoint, for
+one 518×294 frame: **103 s, 7.3 GB, 5.4e-6** against the actual model's
+four outputs.
+
+That is 909M parameters and 72 transformer blocks agreeing to float32's
+noise floor.
+
+Streaming works: `LmKv` holds each global block's keys and values as
+`[heads, maxkv, hd]`, each frame appends its rotated k/v at row `kvused`
+and attends over everything stored. **Two frames through the cache match
+the real model to 5.4e-6** — the same figure as one frame, which is what
+a correct cache should give.
+
+`used` is read by the block and never written by it: one frame passes
+through 24 separate caches, so the count belongs to the frame and is
+passed in per call rather than stored 24 times and kept in step by hand.
+
+One subtlety in the layout: a cache is `[heads, maxkv, hd]` but only
+`nkv` rows are live, so a prefix view is **not** contiguous per head.
+The live rows are repacked into a tight `[heads, nkv, hd]` before the
+permute. Correct, and the obvious thing to make cheaper later.
+
+Cost is close to linear so far: 103 s for one frame, 201 s for two on
+the CPU backend. Frame 2 attends over 1566 keys instead of 783 and pays
+the repack, and it still comes in at about what frame 1 costs — the
+per-frame DINOv2 trunk dominates at this length.
+
+**Eviction is implemented as a ring, not as repeated `torch.cat`** —
+see the stage 4 eviction section. Past 72 frames the sliding window is
+needed for *correctness*, not just for memory: without it the model
+attends to frames the reference has already dropped.
+
+**Three different LayerNorm epsilons in one model**, and getting one
+wrong is worth ~1e-3:
+
+| | ε |
+|---|---|
+| DINOv2's blocks and final norm | 1e-6 |
+| aggregator frame/global `norm1`/`norm2` | **1e-5** |
+| `q_norm` / `k_norm` everywhere | 1e-5 |
+
+Only `DinoVisionTransformer` passes `partial(LayerNorm, eps=1e-6)` to
+its blocks. `Block` and `Attention` both default to plain
+`nn.LayerNorm`, so everything the aggregator builds gets 1e-5. Using
+1e-6 throughout produced a *constant* 4e-3 absolute error that appeared
+in the very first block group and never grew — which is how it was
+found: real accumulation grows with depth, a systematic error does not.
+
+### Stage 4 (partial) — the DINOv2 trunk (`src/dino.nu`)
+
+The aggregator's "patch embedding" is a whole frozen 24-block ViT-L/14,
+and it now runs on the real checkpoint: **35 s, 2.5 GB, 3.9e-6** against
+the actual model's `x_norm_patchtokens` for an example frame.
+
+The token order matters and is easy to get subtly wrong, because the
+position embedding is added *in the middle* of building it:
+
+```
+[cls] + patches            ← pos_embed added HERE
+[cls] + [reg×4] + patches  ← register tokens spliced in AFTER
+```
+
+so the four register tokens get no position embedding at all, and the
+patch tokens the aggregator wants start at index 5.
+
+`src/load.nu` maps the checkpoint onto device buffers with nothing
+transposed — torch stores a `Linear` weight as `[out, in]` and
+`gkd_gemm` reads it with `transb=1` — and stages one tensor at a time,
+so peak extra memory is the largest single weight (32 MB) rather than
+the model.
+
+### Stage 4 (partial) — 3-D RoPE (`src/rope.nu`)
+
+The aggregator's **global** blocks do not use the 2-D rope the frame
+blocks use. With `enable_3d_rope` — which is `demo.py`'s default — they
+use `WanRotaryPosEmbed`, and it differs on three axes at once:
+
+| | 2-D (frame blocks) | 3-D (global blocks) |
+|---|---|---|
+| axes | row, column | frame, row, column |
+| head split | half / half | 20 / 22 / 22 |
+| theta | 100 | 10000 |
+| pairs | split each half at half/2 | **interleaved** (x₀,x₁), (x₂,x₃), … |
+
+Same idea, incompatible memory order, and nothing about picking the
+wrong one looks wrong. Bit-exact against the real `WanRotaryPosEmbed` —
+that test imports the upstream package rather than re-implementing it,
+because a hand-written oracle for this would just be a second chance to
+make the same mistake.
+
+Token positions are fixed by the layout: special token *j* sits at
+`(f, j, j)` and patch `(py, px)` at `(f, 6+py, 6+px)`, so the six
+special tokens run down a diagonal that the patch grid never reaches.
+
+### Stage 4 (partial) — the block on the device (`src/devblock.nu`)
+
+The block again, this time in **f32 over gpukit's `gkd_*` ops** — gemm,
+layernorm, bmm, softmax, permute, broadcast-elementwise — so the same
+code runs on CUDA and on the CPU backend. This is the one that will
+actually run the model; `src/block.nu` stays as the reference it is
+checked against.
+
+Keeping both is the point. A device block is ~15 kernel launches, every
+one with a stride or a permutation that can be silently wrong, and
+comparing against one slow implementation that is known correct catches
+all of them at once. Measured difference: **3e-6**, which is what f32
+accumulation over these sizes should give — against ~9e-2 for the head
+stride bug that was in the host version.
+
+Torch's weight layouts are used unchanged: a `Linear` weight is
+`[out, in]` and goes straight into `gkd_gemm` with `transb=1`, so
+nothing is transposed at load time.
+
+The one kernel that had to be written is 2-D RoPE — the rest of the
+block is composition.
+
+### Stage 3 — the transformer block (`src/block.nu`)
+
+The unit this model is 72 of (24 DINOv2 + 24 frame + 24 global):
+
+```
+x = x + ls1 · attn(norm1(x))
+x = x + ls2 · mlp(norm2(x))
+```
+
+pre-norm LayerNorm, LayerScale on both branches, exact (erf) GELU, and
+attention that layer-normalises q and k **per head** before rotating
+them. Matches the reference to 4e-15.
+
+Two things the reference does that a careful reading still misses:
+
+* **`qk_norm=True` uses a different epsilon.** `Block` builds its
+  `Attention` without passing `norm_layer`, so `norm1`/`norm2` get
+  DINOv2's `partial(LayerNorm, eps=1e-6)` while `q_norm`/`k_norm` fall
+  back to `nn.LayerNorm`'s own default of `1e-5`. Two constants, and
+  the port has to carry both.
+* q/k/v are `[heads, n, head_dim]`, so a head's stride is `n·head_dim`,
+  **not** `n·dim`. Getting that wrong leaves every head past the first
+  reading zeros — and attention still produces plausible numbers, so it
+  surfaces as a few percent of error rather than as anything obviously
+  broken. (It did, here, until the intermediates were dumped.)
+
+`erf` was missing from `stdlib/std/float.nu` and is now there
+(`float_erf` / `float_erfc`) — exact GELU needs it, and so does any
+normal-distribution CDF.
+
+### Stage 3 — patch embedding (`src/patchembed.nu`)
+
+`Conv2d(3, 1024, kernel=14, stride=14)`. Kernel equals stride, so the
+patches do not overlap and the convolution is exactly a matmul: im2col
+each 14×14×3 patch into a 588-wide row, multiply by the reshaped
+weight. Matches torch's `conv2d` to 4e-15.
+
+im2col is written out rather than fused into the multiply, because the
+multiply is what moves to a device kernel later and the layout is what
+has to be right first.
+
+### Stage 3 — 2-D RoPE (`src/rope.nu`)
+
+Attention rotates q and k by the token's position in the patch **grid**,
+not its index in the sequence: the head dimension splits in half, the
+first half rotated by the row coordinate and the second by the column.
+Bit-exact against `RotaryPositionEmbedding2D`.
+
+Two things here are silent when wrong: the rotation splits each *half*
+at half/2 (not the full head dim at D/2), and `positions` is (row, col)
+with row driving the first half — swapping them transposes the model's
+idea of the image without changing a single shape.
+
+### Stage 3 — weight access (`src/weights.nu`)
+
+`lw_require` declares the shape a module expects and accumulates
+failures, so a mismatched checkpoint names the first thing actually
+wrong at load time. Layer counts are read off the file rather than
+hard-coded, so the `-long` and `-stage1` checkpoints load too.
+
+## The open one: pose drift over a sequence
+
+Every stage section above is a one- or two-frame comparison, and every one
+of them passes. Step 20 of the suite asks a different question — does the
+*cloud* match over a *sequence* — and the answer is no. The README's
+["How close is it really"](../README.md#how-close-is-it-really) has the
+table; what belongs here is what has been ruled out and what has not.
+
+Ruled out:
+
+* **Arithmetic.** One frame agrees to 2.3e-5, which is the same figure the
+  per-module tests report.
+* **Inherent sensitivity.** `tests/ref_cloud.py --jitter EPS` perturbs the
+  reference's own input and re-runs it against itself. At 3e-4 — the size
+  of the port's own activation-level disagreement — the reference's
+  20-frame cloud moves by 4.3e-5 median and 3.9e-5 centroid. The port sits
+  at 3.0e-3 and 2.6e-2, about 600x further. The model is well conditioned
+  over this length; the port is not tracking it.
+* **The depth head.** Point counts agree to about one part in 30 000 over
+  20 frames, which is the handful of pixels whose confidence sits within
+  f32 noise of a strict `>`. Each frame's cloud is the right shape and
+  very nearly the right size. It is placed wrong.
+* **Growing activation error.** `streamcheck.nu` over ten streamed frames
+  against the real model on the same GPU disagrees by a **flat** 1e-4 to
+  6e-4 — frame 1 and frame 10 are the same. A non-growing activation error
+  is producing a growing trajectory error, so the divergence is in what is
+  built out of those activations, or in cache state they do not expose.
+
+Not ruled out, and where to look next: the per-frame centroid offset jumps
+from 5.5e-5 at frame 1 to 1.9e-2 at frame 2 — the first frame that reads a
+non-empty KV cache. Three things change at that boundary at once (the
+camera/register special-token slots, which are frame-0 only; the scale
+slot, which covers the first `nscale` frames; and the cache going
+non-empty), and the tests that exist cannot separate them because they all
+compare activations, which agree.
+
+The method that would separate them is the one the eviction bug needed: a
+per-frame `pose_enc` dump from both sides over twenty frames, not a
+strided sample of an activation. If the pose diverges smoothly it is
+accumulation; if it steps at a particular frame index it is a boundary.
+
+## Running the tests
+
+```
+cd packages/lingbot-map && ./tests/lingbot_map_test.sh
+```
+
+**It is slow.** Eleven steps, each with its own NURL build, and the last
+two run the model on real weights (35 s for the trunk, 105 s for the
+aggregator). Budget ~45 minutes on a CPU. The steps that need the
+checkpoint or the upstream package skip cleanly when those are absent,
+which is the fast path.
+
+Needs a python with torch (any CPU build) for the oracle; set
+`PYTORCH_PY`, or drop a venv at the repo root as `.venv-oracle`. Without
+one the oracle steps skip and the code is only smoke-run.
+
+Two steps go further and import the **upstream package** from
+`~/dev/lingbot-map` (needs `torch torchvision pillow numpy scipy einops
+huggingface_hub`): the 3-D rope check, and `tests/agg_oracle.py`, which
+loads the real checkpoint and runs the actual model end to end. That
+last one is how `tests/agg_ref_courthouse0.txt` was produced — the
+aggregator's four outputs for one example frame, which is the ground
+truth the rest of stage 4 is built against. Regenerating it takes the
+4.6 GB checkpoint and a few minutes of CPU, so it is committed.
+
+## Notes for whoever picks this up
+
+**Compute.** Most of the port was written with no usable GPU on the
+development machine, on gpukit's CPU backend. That made two things
+necessary before any model code could be written, both now upstream:
+
+* the CPU backend's matmul was a per-output-element kernel — right on a
+  GPU, 24× off the machine on a CPU. It is register-tiled now (1.7 →
+  42 GFLOP/s on a 6-core i7-5930K), bit-identical either way.
+* `stdlib/ext/zip.nu` could not read zip64 and needed the whole archive
+  in memory, so a 4.6 GB checkpoint was simply unopenable.
+
+A frame is roughly 2 TFLOP, so on a CPU expect ~1–2 minutes per frame.
+The CPU backend is still worth keeping: it is how `src/devblock.nu` is
+checked against `src/block.nu`, and a kernel that disagrees between the
+two backends is a kernel bug rather than a porting bug.
+
+**Two resamplers, and the trap between them.** Preprocessing resizes
+frames with **PIL's** bicubic; `interpolate_pos_encoding` resamples
+DINOv2's 37×37 position grid to the frame's patch grid with **torch's
+`bicubic` + `antialias=True`**. Both are implemented and both are
+verified — `image_resize_bicubic` and `src/interp.nu`.
+
+The trap is the kernel constant. torch has *two* bicubic
+implementations that disagree on it:
+
+| | kernel `a` | arithmetic |
+|---|---|---|
+| PIL (preprocessing) | −0.5 | 8-bit fixed point, clamped |
+| torch `antialias=True` | **−0.5** | float, unclamped |
+| torch `antialias=False` | **−0.75** | float, border-replicated |
+
+Every reference to "torch bicubic" means the −0.75 one, and the
+antialias path — which is what this model uses — is −0.5, because it
+was written to reproduce PIL. Building the position-grid resample from
+the documented −0.75 gives a kernel that is a few percent wrong
+everywhere and right nowhere, with nothing to notice. (Recovered by
+probing torch with unit impulses and solving for `a`: −0.49997.)
+
+**Checkpoint layout.** [`checkpoint.md`](checkpoint.md) is the
+full inventory read out of the real 4.6 GB file: every tensor name, dtype
+and shape, 1342 of them, 1.16 B parameters, all f32. Worth reading before
+writing any of stages 3–5 — a few things are not what the Python source
+suggests:
+
+* the root is a **bare `OrderedDict`**, not `{"model": …}`, so names come
+  out of `torchpt` unprefixed (`aggregator.frame_blocks.0.attn.qkv.weight`);
+* there is **no `point_head`** — `enable_point` is off, which is
+  `GCTStream`'s default. World points come from unprojecting the depth
+  map, not from a second DPT head;
+* `aggregator.patch_embed.pos_embed` is `1×1370×1024` = 1 cls + 37×37
+  patches, which is what forces the position-grid resample.

--- a/packages/lingbot-map/nurl.toml
+++ b/packages/lingbot-map/nurl.toml
@@ -1,10 +1,11 @@
 [package]
 name = "lingbot-map"
-version = "0.2.1"
-description = "LingBot-Map in pure NURL — the Geometric Context Transformer for streaming 3D reconstruction, ported from the reference PyTorch implementation. Feed it a folder of frames and it returns per-frame camera poses, depth and a world-space point cloud. Runs at parity with the reference on the same GPU — 138 ms a frame against its 141, f32 both sides, with eight frames end to end in 3.2 s including the 4.6 GB checkpoint load. Writes binary_little_endian PLY (--ascii for text), and --profile reports per-stage frame timings and a per-kernel GPU profile."
+version = "0.3.0"
+description = "Streaming 3-D reconstruction in pure NURL. Point it at a folder of video frames — `lingbot-map frames/` — and it writes a world-space point cloud as a PLY, plus a camera pose and a depth map for every frame, one frame at a time, with no per-scene optimisation and no structure-from-motion pass. It is a port of LingBot-Map's Geometric Context Transformer and runs the reference's own 1.16 B parameter checkpoint, which the first run fetches from Hugging Face and caches under ~/.nurl/models; no Python, no PyTorch, no CUDA toolkit, since the kernels are compiled at run time through NVRTC. Every stage is checked against the reference PyTorch implementation by importing and driving the upstream modules rather than re-implementing them: preprocessing byte-identical, the DINOv2 trunk 3.9e-6, the streaming aggregator with sliding-window KV eviction 5.9e-6, the camera head 2.2e-7, the DPT depth head 1.6e-6, the geometry 2.4e-16, world points end to end 1.5e-6. On one RTX 4090 in f32 it is at parity with the reference — 138 ms a frame against its 141 — and the per-frame cost is flat past 72 frames because the KV window bounds it: 286 frames of the courthouse example in 109 s. Writes binary_little_endian PLY (--ascii for text); --profile reports per-stage frame timings and a per-kernel GPU profile; the reference's own flag spellings (--model_path, --image_folder, --conf_threshold, --first_k) are accepted."
 license = "Apache-2.0"
 
 [dependencies]
 torchpt = { path = "../torchpt", version = "^0.1" }
+hub = { path = "../hub", version = "^0.1" }
 gpukit = { path = "../gpukit", version = "^0.6.1" }
 image = { path = "../image", version = "^0.5" }

--- a/packages/lingbot-map/src/main.nu
+++ b/packages/lingbot-map/src/main.nu
@@ -1,7 +1,8 @@
 // lingbot-map — streaming 3-D reconstruction from a sequence of frames,
 // in pure NURL.
 //
-//   lingbot-map --model <checkpoint.pt> [options] <frame.png> ...
+//   lingbot-map [options] <frames-dir>
+//   lingbot-map [options] <frame.png> <frame.png> ...
 //
 // Each frame is preprocessed, run through the DINOv2 trunk and the
 // streaming aggregator (which keeps a KV cache across frames), and then
@@ -10,19 +11,25 @@
 // pose plus intrinsics unprojects to world-space points, which is what
 // the point cloud is.
 //
-// Output is an ASCII PLY, which every viewer reads. The vertex count is
-// not known until the last frame is done, so the header is written with
-// a fixed-width placeholder and patched at the end rather than holding
-// the whole cloud in memory.
+// Output is a PLY, which every viewer reads. The vertex count is not
+// known until the last frame is done, so the header is written with a
+// fixed-width placeholder and patched at the end rather than holding the
+// whole cloud in memory.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/float.nu`
 $ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/sort.nu`
 $ `stdlib/std/time.nu`
 $ `stdlib/std/floatbits.nu`
+$ `stdlib/ext/env.nu`
+$ `deps/hub/src/store.nu`
+$ `deps/hub/src/hf.nu`
+$ `deps/hub/src/pull.nu`
+$ `deps/hub/src/hub.nu`
 $ `deps/gpukit/src/gpukit.nu`
 $ `deps/gpukit/src/dev.nu`
 $ `deps/gpukit/src/devops.nu`
@@ -38,9 +45,10 @@ $ `src/preproc.nu`
 
 : i LM_SIZE 518
 : i LM_PATCH 14
-// The reference's own default for what to draw: confidence is 1+exp(x),
-// so 1.0 is "no information" and anything above ~2 is a real surface.
-: f LM_CONF 2.0
+// demo.py's own --conf_threshold default. Confidence is 1+exp(x), so 1.0
+// is "no information"; the reference draws everything above 1.5 and so
+// does this.
+: f LM_CONF 1.5
 : i LM_COUNT_WIDTH 12
 
 : Opts {
@@ -57,64 +65,177 @@ $ `src/preproc.nu`
 }
 
 @ __lm_usage → v {
-    ( nurl_print `usage: lingbot-map --model <checkpoint.pt> [options] <frame> ...\n` )
-    ( nurl_print `  --out <file.ply>   where to write the cloud (default cloud.ply)\n` )
-    ( nurl_print `  --conf <f>         keep pixels with confidence above this (default 2.0)\n` )
-    ( nurl_print `  --pixel-stride <n> take every nth pixel on both axes (default 2)\n` )
-    ( nurl_print `  --frames <dir>     every .png/.jpg in a directory, in name order\n` )
-    ( nurl_print `  --max-frames <n>   stop after n frames\n` )
-    ( nurl_print `  --quiet            no per-frame progress\n` )
-    ( nurl_print `  --profile          per-frame timings and a per-kernel GPU profile\n` )
-    ( nurl_print `  --ascii            write an ASCII PLY instead of binary_little_endian\n` )
+    ( nurl_print `usage: lingbot-map [options] <frames-dir>\n` )
+    ( nurl_print `       lingbot-map [options] <frame.png> <frame.png> ...\n` )
+    ( nurl_print `try 'lingbot-map --help' for the options and some examples\n` )
 }
+
+@ __lm_help → v {
+    ( nurl_print `lingbot-map -- streaming 3-D reconstruction from a sequence of frames.\n` )
+    ( nurl_print `Give it frames in order; it writes a world-space point cloud as a PLY.\n` )
+    ( nurl_print `\n` )
+    ( nurl_print `usage: lingbot-map [options] <frames-dir>\n` )
+    ( nurl_print `       lingbot-map [options] <frame.png> <frame.png> ...\n` )
+    ( nurl_print `\n` )
+    ( nurl_print `examples:\n` )
+    ( nurl_print `  # a folder of frames -> cloud.ply. The checkpoint is downloaded once,\n` )
+    ( nurl_print `  # on the first run, and cached under ~/.nurl/models.\n` )
+    ( nurl_print `  lingbot-map ~/dev/lingbot-map/example/courthouse\n` )
+    ( nurl_print `\n` )
+    ( nurl_print `  # the first 30 frames, every pixel, written where you want it\n` )
+    ( nurl_print `  lingbot-map --max-frames 30 --pixel-stride 1 --out courthouse.ply \\\n` )
+    ( nurl_print `      ~/dev/lingbot-map/example/courthouse\n` )
+    ( nurl_print `\n` )
+    ( nurl_print `  # a checkpoint you already have, plus per-stage timings\n` )
+    ( nurl_print `  lingbot-map --model ~/.nurl/models/lingbot-map/lingbot-map.pt --profile \\\n` )
+    ( nurl_print `      ~/dev/lingbot-map/example/courthouse\n` )
+    ( nurl_print `\n` )
+    ( nurl_print `  # a handful of individual frames\n` )
+    ( nurl_print `  lingbot-map shot0.png shot1.png shot2.png\n` )
+    ( nurl_print `\n` )
+    ( nurl_print `options:\n` )
+    ( nurl_print `  --model <path|ref>  checkpoint to run: a local .pt, or a Hugging Face ref\n` )
+    ( nurl_print `                      such as robbyant/lingbot-map/lingbot-map.pt. Default:\n` )
+    ( nurl_print `                      $LINGBOT_MAP_MODEL, else ~/.nurl/models/lingbot-map/\n` )
+    ( nurl_print `                      lingbot-map.pt, else that ref is fetched (4.6 GB).\n` )
+    ( nurl_print `  --out <file.ply>    where to write the cloud (default cloud.ply)\n` )
+    ( nurl_print `  --conf <f>          keep pixels whose confidence exceeds this\n` )
+    ( nurl_print `                      (default 1.5, the reference's own --conf_threshold)\n` )
+    ( nurl_print `  --pixel-stride <n>  take every nth pixel on both axes (default 2)\n` )
+    ( nurl_print `  --max-frames <n>    stop after n frames\n` )
+    ( nurl_print `  --stride <n>        use every nth frame (applied after --max-frames)\n` )
+    ( nurl_print `  --frames <dir>      a directory of frames; same as naming it positionally\n` )
+    ( nurl_print `  --ascii             write an ASCII PLY instead of binary_little_endian\n` )
+    ( nurl_print `  --quiet, -q         no per-frame progress\n` )
+    ( nurl_print `  --profile           per-stage frame timings and a per-kernel GPU profile\n` )
+    ( nurl_print `  --version           print the version\n` )
+    ( nurl_print `  --help, -h          this\n` )
+    ( nurl_print `\n` )
+    ( nurl_print `The reference's spellings are accepted too: --model_path, --image_folder,\n` )
+    ( nurl_print `--conf_threshold, --first_k.\n` )
+    ( nurl_print `\n` )
+    ( nurl_print `Frames are read in name order, and the order is the trajectory: the model\n` )
+    ( nurl_print `keeps a cache across frames, so each one is placed relative to the ones\n` )
+    ( nurl_print `before it. A shuffled directory reconstructs a different scene.\n` )
+    ( nurl_print `\n` )
+    ( nurl_print `The cloud is a PLY. MeshLab, CloudCompare, Blender and f3d all open it.\n` )
+}
+
+@ __lm_version → v { ( nurl_print `lingbot-map 0.3.0\n` ) }
 
 @ __lm_streq s a s b → b { ^ == 0 ( nurl_str_cmp a b ) }
 
-// Every .png and .jpg in a directory, appended in NAME order. Order is
-// not a nicety here: the aggregator's KV cache makes frame N depend on
-// every frame before it, so a shuffled directory listing reconstructs a
-// different scene. fs_glob's order is the filesystem's, so it is sorted
-// explicitly.
-@ __lm_dir ( Vec String ) into s dir → b {
-    : ~ i found 0
-    : ~ i k 0
-    ~ < k 2 {
-        : String pat ( string_from dir )
-        ? > ( string_len pat ) 0 {
-            : i pl ( string_len pat )
-            ? != ( nurl_str_at ( string_data pat ) pl - pl 1 ) 47 {
-                ( string_push_char pat 47 )
-            } {}
-        } {}
-        ( string_push_str pat ? == k 0 `*.png` `*.jpg` )
-        ?? ( fs_glob ( string_data pat ) ) {
-            T hits → {
-                = found + found ( vec_len [String] hits )
-                // A MOVE of the handles: vec_extend documents itself as
-                // safe only for trivial element types, so the Strings are
-                // pushed across and only the source container is dropped.
-                : ~ i g 0
-                ~ < g ( vec_len [String] hits ) {
-                    ?? ( vec_get [String] hits g ) {
-                        T h → { ( vec_push [String] into h ) }
-                        F → {}
-                    }
-                    = g + g 1
-                }
-                ( vec_free [String] hits )
-            }
-            F _e → {}
+// Anything that looks like an option, so a typo is reported as one
+// instead of being taken for a frame and failing later as a missing file.
+@ __lm_is_flag s a → b {
+    : i n ( nurl_str_len a )
+    ^ & > n 1 == 45 ( nurl_str_at a n 0 )
+}
+
+// The options that take a value, in one place: the argument loop needs to
+// know before it can tell "--out" from a frame called "--out".
+@ __lm_wants s a → b {
+    ? | ( __lm_streq a `--model` ) ( __lm_streq a `--model_path` ) { ^ T } {}
+    ? | ( __lm_streq a `--out` ) ( __lm_streq a `--conf` ) { ^ T } {}
+    ? | ( __lm_streq a `--conf_threshold` ) ( __lm_streq a `--pixel-stride` ) { ^ T } {}
+    ? | ( __lm_streq a `--max-frames` ) ( __lm_streq a `--first_k` ) { ^ T } {}
+    ? | ( __lm_streq a `--frames` ) ( __lm_streq a `--image_folder` ) { ^ T } {}
+    ? ( __lm_streq a `--stride` ) { ^ T } {}
+    ^ F
+}
+
+// A directory, following symlinks — `nurl_path_type` lstats, so a linked
+// frame folder reports as a link rather than as the directory it is.
+@ __lm_is_dir s p → b {
+    ?? ( dir_list p ) {
+        T v → {
+            ( vec_free_with [String] v \ String s → v { ( string_free s ) } )
+            ^ T
         }
-        ( string_free pat )
+        F _e → { ^ F }
+    }
+}
+
+@ __lm_lower i c → i { ^ ? & >= c 65 <= c 90 + c 32 c }
+
+// Case-insensitive suffix test. The reference globs ".jpg,.png,.JPG"; a
+// frame folder off a phone or out of a video split is as likely to hold
+// .JPEG, and there is no reason for the case to matter.
+@ __lm_ext_is s name s ext → b {
+    : i n ( nurl_str_len name )
+    : i m ( nurl_str_len ext )
+    ? <= n m { ^ F } {}
+    : ~ i k 0
+    ~ < k m {
+        ? != ( __lm_lower ( nurl_str_at name n + - n m k ) ) ( nurl_str_at ext m k ) {
+            ^ F
+        } {}
         = k + k 1
     }
-    ? == found 0 {
-        ( nurl_print `lingbot-map: no .png or .jpg in ` )
+    ^ T
+}
+
+@ __lm_is_frame s name → b {
+    ? ( __lm_ext_is name `.png` ) { ^ T } {}
+    ? ( __lm_ext_is name `.jpg` ) { ^ T } {}
+    ? ( __lm_ext_is name `.jpeg` ) { ^ T } {}
+    ^ F
+}
+
+// Every frame in a directory, appended in NAME order. Order is not a
+// nicety here: the aggregator's KV cache makes frame N depend on every
+// frame before it, so a shuffled directory listing reconstructs a
+// different scene, and a readdir order is the filesystem's.
+//
+// dir_list rather than fs_glob, because the glob does not descend through
+// a symlinked directory and pointing at a linked frame folder is an
+// ordinary thing to do. The batch is sorted on its own and only then
+// appended, so naming two directories keeps them in the order given.
+@ __lm_dir ( Vec String ) into s dir → b {
+    : ( Vec String ) hits ( vec_new [String] )
+    ?? ( dir_list dir ) {
+        F _e → {
+            ( vec_free [String] hits )
+            ( nurl_print `lingbot-map: cannot read the directory ` )
+            ( nurl_print dir ) ( nurl_print `\n` )
+            ^ F
+        }
+        T names → {
+            : ~ i k 0
+            ~ < k ( vec_len [String] names ) {
+                ?? ( vec_get [String] names k ) {
+                    T nm → {
+                        ? ( __lm_is_frame ( string_data nm ) ) {
+                            ( vec_push [String] hits ( path_join dir ( string_data nm ) ) )
+                        } {}
+                    }
+                    F → {}
+                }
+                = k + k 1
+            }
+            ( vec_free_with [String] names \ String s → v { ( string_free s ) } )
+        }
+    }
+    ? == ( vec_len [String] hits ) 0 {
+        ( vec_free [String] hits )
+        ( nurl_print `lingbot-map: no .png, .jpg or .jpeg frames in ` )
         ( nurl_print dir ) ( nurl_print `\n` )
         ^ F
     } {}
-    ( sort_by [String] into \ String x String y → i {
+    ( sort_by [String] hits \ String x String y → i {
         ^ ( nurl_str_cmp ( string_data x ) ( string_data y ) ) } )
+    // A MOVE of the handles: vec_extend documents itself as safe only for
+    // trivial element types, so the Strings are pushed across and only the
+    // source container is dropped.
+    : ~ i g 0
+    ~ < g ( vec_len [String] hits ) {
+        ?? ( vec_get [String] hits g ) {
+            T h → { ( vec_push [String] into h ) }
+            F → {}
+        }
+        = g + g 1
+    }
+    ( vec_free [String] hits )
     ^ T
 }
 
@@ -125,61 +246,159 @@ $ `src/preproc.nu`
     : ~ f conf LM_CONF
     : ~ i pstride 2
     : ~ i maxf 0
+    : ~ i fstride 1
     : ~ i verbose 1
     : ~ i profile 0
     : ~ i ascii 0
     : ~ i bad 0
     : i argc ( nurl_argc )
     : ~ i i0 1
-    ~ < i0 argc {
+    ~ & == bad 0 < i0 argc {
         : s a ( nurl_argv i0 )
-        : b wants | | ( __lm_streq a `--model` ) ( __lm_streq a `--out` )
-        | ( __lm_streq a `--conf` ) | ( __lm_streq a `--pixel-stride` )
-        | ( __lm_streq a `--max-frames` ) ( __lm_streq a `--frames` )
-        ? & wants >= + i0 1 argc {
-            ( nurl_print a ) ( nurl_print ` needs a value\n` )
-            = bad 1
-            = i0 argc
-        } {
-            ? ( __lm_streq a `--model` ) { = model ( nurl_argv + i0 1 ) = i0 + i0 1 } {
-                ? ( __lm_streq a `--out` ) { = out ( nurl_argv + i0 1 ) = i0 + i0 1 } {
-                    ? ( __lm_streq a `--conf` ) {
-                        = conf ( nurl_str_to_float ( nurl_argv + i0 1 ) ) = i0 + i0 1
+        : ~ i take 0
+        ? ( __lm_wants a ) {
+            ? >= + i0 1 argc {
+                ( nurl_print `lingbot-map: ` ) ( nurl_print a )
+                ( nurl_print ` needs a value\n` )
+                = bad 1
+            } { = take 1 }
+        } {}
+        ? == take 1 {
+            : s v ( nurl_argv + i0 1 )
+            ? | ( __lm_streq a `--model` ) ( __lm_streq a `--model_path` ) { = model v } {}
+            ? ( __lm_streq a `--out` ) { = out v } {}
+            ? | ( __lm_streq a `--conf` ) ( __lm_streq a `--conf_threshold` ) {
+                = conf ( nurl_str_to_float v )
+            } {}
+            ? ( __lm_streq a `--pixel-stride` ) { = pstride ( nurl_str_to_int v ) } {}
+            ? | ( __lm_streq a `--max-frames` ) ( __lm_streq a `--first_k` ) {
+                = maxf ( nurl_str_to_int v )
+            } {}
+            ? ( __lm_streq a `--stride` ) { = fstride ( nurl_str_to_int v ) } {}
+            ? | ( __lm_streq a `--frames` ) ( __lm_streq a `--image_folder` ) {
+                ? ( __lm_dir fr v ) {} { = bad 1 }
+            } {}
+            = i0 + i0 1
+        } {}
+        ? & == bad 0 == take 0 {
+            : ~ i hit 0
+            ? | ( __lm_streq a `--quiet` ) ( __lm_streq a `-q` ) { = verbose 0 = hit 1 } {}
+            ? ( __lm_streq a `--profile` ) { = profile 1 = hit 1 } {}
+            ? ( __lm_streq a `--ascii` ) { = ascii 1 = hit 1 } {}
+            ? | ( __lm_streq a `--help` ) ( __lm_streq a `-h` ) { = bad 2 = hit 1 } {}
+            ? ( __lm_streq a `--version` ) { = bad 3 = hit 1 } {}
+            ? == hit 0 {
+                ? ( __lm_is_flag a ) {
+                    ( nurl_print `lingbot-map: unknown option ` ) ( nurl_print a )
+                    ( nurl_print `\n` )
+                    = bad 1
+                } {
+                    // A positional is either a directory of frames or one
+                    // frame. Naming the directory is what people try first.
+                    ? ( __lm_is_dir a ) {
+                        ? ( __lm_dir fr a ) {} { = bad 1 }
                     } {
-                        ? ( __lm_streq a `--pixel-stride` ) {
-                            = pstride ( nurl_str_to_int ( nurl_argv + i0 1 ) ) = i0 + i0 1
-                        } {
-                            ? ( __lm_streq a `--max-frames` ) {
-                                = maxf ( nurl_str_to_int ( nurl_argv + i0 1 ) ) = i0 + i0 1
-                            } {
-                                ? ( __lm_streq a `--frames` ) {
-                                    ? ( __lm_dir fr ( nurl_argv + i0 1 ) ) {} { = bad 1 }
-                                    = i0 + i0 1
-                                } {
-                                    ? ( __lm_streq a `--quiet` ) { = verbose 0 } {
-                                        ? ( __lm_streq a `--profile` ) { = profile 1 } {
-                                            ? ( __lm_streq a `--ascii` ) { = ascii 1 } {
-                                                ? ( __lm_streq a `--help` ) { = bad 2 } {
-                                                    ( vec_push [String] fr ( string_from a ) )
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        ( vec_push [String] fr ( string_from a ) )
                     }
                 }
-            }
-            = i0 + i0 1
-        }
+            } {}
+        } {}
+        = i0 + i0 1
     }
     ? < pstride 1 { = pstride 1 } {}
+
+    // --max-frames caps the sequence and --stride then subsamples what is
+    // left, which is the order the reference applies its own --first_k and
+    // --stride in: thirty frames at a stride of three is ten, not ninety.
+    ? & > maxf 0 < maxf ( vec_len [String] fr ) {
+        : ~ i d maxf
+        ~ < d ( vec_len [String] fr ) {
+            ?? ( vec_get [String] fr d ) { T s → { ( string_free s ) } F → {} }
+            = d + d 1
+        }
+        : b _c ( vec_set_len [String] fr maxf )
+    } {}
+    // Compacted in place: the kept handles move down to fill the gaps and
+    // the dropped ones are freed as they are passed. The stale duplicates
+    // left past the new length are never freed, so nothing is freed twice.
+    ? > fstride 1 {
+        : ~ i r 0
+        : ~ i w 0
+        ~ < r ( vec_len [String] fr ) {
+            ?? ( vec_get [String] fr r ) {
+                T s → {
+                    ? == 0 % r fstride {
+                        : b _s ( vec_set [String] fr w s )
+                        = w + w 1
+                    } { ( string_free s ) }
+                }
+                F → {}
+            }
+            = r + r 1
+        }
+        : b _c ( vec_set_len [String] fr w )
+    } {}
     ^ @ Opts { model out conf pstride maxf verbose profile ascii fr bad }
 }
 
 @ __lm_free_opts Opts o → v {
     ( vec_free_with [String] . o frames \ String s → v { ( string_free s ) } )
+}
+
+// ── the checkpoint ──────────────────────────────────────────────────
+
+// A `/`- or `.`- or `~`-led argument is a filename the user meant, so a
+// typo in it is a missing file and not a repository to go looking for on
+// Hugging Face. Without this, `--model ~/typo.pt` reports whatever the
+// network said about a repository named `~`.
+@ __lm_looks_local s a → b {
+    : i n ( nurl_str_len a )
+    ? == n 0 { ^ F } {}
+    : i c0 ( nurl_str_at a n 0 )
+    ^ | | == c0 47 == c0 46 == c0 126
+}
+
+// `hub_get` passes an existing local path straight through and otherwise
+// treats the argument as a Hugging Face ref. Announce the download first,
+// because 4.6 GB arriving unannounced looks like a hang.
+@ __lm_fetch s ref i verbose i isdefault → !String String {
+    ? != 0 ( nurl_path_type ref ) { ^ ( hub_get ref ) } {}
+    ? ( __lm_looks_local ref ) {
+        : String m ( string_from `no such file: ` )
+        ( string_push_str m ref )
+        ^ @ !String String { F m }
+    } {}
+    ? != verbose 0 {
+        ( nurl_print `fetching ` ) ( nurl_print ref )
+        ? != isdefault 0 { ( nurl_print ` — 4.6 GB` ) } {}
+        ( nurl_print `, once. Cached under ` )
+        : String root ( hub_store_root )
+        ( nurl_print ( string_data root ) ) ( nurl_print `\n` )
+        ( string_free root )
+    } {}
+    ^ ( hub_get ref )
+}
+
+// Where the checkpoint comes from when --model did not say: the
+// environment, then the conventional spot in the model cache, then
+// Hugging Face. The point is that a first run needs frames and nothing
+// else.
+@ __lm_model s arg i verbose → !String String {
+    ? > ( nurl_str_len arg ) 0 { ^ ( __lm_fetch arg verbose 0 ) } {}
+    ?? ( env_get `LINGBOT_MAP_MODEL` ) {
+        T v → {
+            : !String String r ( __lm_fetch ( string_data v ) verbose 0 )
+            ( string_free v )
+            ^ r
+        }
+        F → {}
+    }
+    : String root ( hub_store_root )
+    : String p ( path_join ( string_data root ) `lingbot-map/lingbot-map.pt` )
+    ( string_free root )
+    ? == 1 ( nurl_path_type ( string_data p ) ) { ^ @ !String String { T p } } {}
+    ( string_free p )
+    ^ ( __lm_fetch `robbyant/lingbot-map/lingbot-map.pt` verbose 1 )
 }
 
 // ── PLY ─────────────────────────────────────────────────────────────
@@ -365,19 +584,86 @@ i h i w f cmin i stride → Ply {
 
 @ main → i {
     : Opts o ( __lm_parse )
-    ? != . o bad 0 { ( __lm_usage ) ( __lm_free_opts o ) ^ ? == . o bad 2 0 2 } {}
+    ? == . o bad 2 { ( __lm_help ) ( __lm_free_opts o ) ^ 0 } {}
+    ? == . o bad 3 { ( __lm_version ) ( __lm_free_opts o ) ^ 0 } {}
+    ? != . o bad 0 { ( __lm_usage ) ( __lm_free_opts o ) ^ 2 } {}
     : ~ i nframes ( vec_len [String] . o frames )
-    ? | ( __lm_streq . o model `` ) == nframes 0 {
-        ( __lm_usage ) ( __lm_free_opts o ) ^ 2
+    // Say what is missing. The old behaviour here was to print the usage
+    // and leave the reader to spot which line applied to them.
+    ? == nframes 0 {
+        ( nurl_print `lingbot-map: no frames to reconstruct.\n` )
+        ( nurl_print `Point it at a folder of frames, in order:\n` )
+        ( nurl_print `    lingbot-map ~/dev/lingbot-map/example/courthouse\n` )
+        ( nurl_print `or name the frames yourself:\n` )
+        ( nurl_print `    lingbot-map shot0.png shot1.png shot2.png\n` )
+        ( nurl_print `'lingbot-map --help' has the rest.\n` )
+        ( __lm_free_opts o ) ^ 2
     } {}
-    ? & > . o maxframes 0 < . o maxframes nframes { = nframes . o maxframes } {}
+    // Every frame is checked before the 4.6 GB checkpoint is read. A
+    // mistyped path used to cost a full model load and then fail on the
+    // first decode.
+    : ~ i missing 0
+    : ~ i vi 0
+    ~ < vi nframes {
+        ?? ( vec_get [String] . o frames vi ) {
+            T s → {
+                ? == 0 ( nurl_path_type ( string_data s ) ) {
+                    ? == missing 0 {
+                        ( nurl_print `lingbot-map: no such frame: ` )
+                        ( nurl_print ( string_data s ) ) ( nurl_print `\n` )
+                    } {}
+                    = missing + missing 1
+                } {}
+            }
+            F → {}
+        }
+        = vi + vi 1
+    }
+    ? != missing 0 {
+        ? > missing 1 {
+            ( nurl_print `(and ` ) ( nurl_print ( nurl_str_int - missing 1 ) )
+            ( nurl_print ` more of the ` ) ( nurl_print ( nurl_str_int nframes ) )
+            ( nurl_print ` frames)\n` )
+        } {}
+        ( __lm_free_opts o ) ^ 2
+    } {}
+
+    // What is about to be reconstructed, said BEFORE the checkpoint is
+    // resolved: on a first run that line is the last thing printed for as
+    // long as 4.6 GB takes to arrive, so it had better be there.
+    ? != . o verbose 0 {
+        ( nurl_print `frames ` ) ( nurl_print ( nurl_str_int nframes ) )
+        ( nurl_print ` -> ` ) ( nurl_print . o out ) ( nurl_print `\n` )
+    } {}
+
+    // Resolved before the GPU is touched: a checkpoint that is missing or
+    // still downloading has nothing to do with the device, and failing in
+    // that order is what a reader expects.
+    : ~ String model ( string_new )
+    ?? ( __lm_model . o model . o verbose ) {
+        F e → {
+            ( nurl_print `lingbot-map: no checkpoint: ` )
+            ( nurl_print ( string_data e ) ) ( nurl_print `\n` )
+            ( nurl_print `Fetch it once with:\n` )
+            ( nurl_print `    hub pull robbyant/lingbot-map/lingbot-map.pt\n` )
+            ( nurl_print `or download lingbot-map.pt from\n` )
+            ( nurl_print `    https://huggingface.co/robbyant/lingbot-map\n` )
+            ( nurl_print `and name it with --model <path>.\n` )
+            ( string_free e ) ( __lm_free_opts o ) ^ 1
+        }
+        T p → { ( string_free model ) = model p }
+    }
 
     // Set by any frame that fails, and returned. A reconstruction that
     // half-ran and exited 0 is worse than one that failed loudly: the
     // caller writes the cloud into a pipeline and never learns.
     : ~ i rc 0
     : *GpuKit kit ( gk_open_best )
-    ? ( gk_ok kit ) {} { ( nurl_print `lingbot-map: no gpukit backend\n` ) ^ 1 }
+    ? ( gk_ok kit ) {} {
+        ( nurl_print `lingbot-map: no GPU backend — no CUDA device is visible, and this\n` )
+        ( nurl_print `build has no CPU fallback compiled in.\n` )
+        ( string_free model ) ( __lm_free_opts o ) ^ 1
+    }
     // Every gkd_* launch syncs the device by default, which is right for
     // one-shot compute and wrong for a model: a frame is thousands of
     // launches, and the stream already serialises them. Downloads sync
@@ -390,11 +676,19 @@ i h i w f cmin i stride → Ply {
         ( gk_prof kit T )
     } {}
 
-    : !*Lw String lo ( lw_open . o model )
+    : i t_start ( monotonic_ns )
+    ? != . o verbose 0 {
+        ( nurl_print `model  ` ) ( nurl_print ( string_data model ) ) ( nurl_print `\n` )
+    } {}
+    : !*Lw String lo ( lw_open ( string_data model ) )
     ?? lo {
         F e → {
+            ( nurl_print `lingbot-map: cannot read the checkpoint ` )
+            ( nurl_print ( string_data model ) ) ( nurl_print `\n` )
             ( nurl_print ( string_data e ) ) ( nurl_print `\n` ) ( string_free e )
-            ( gk_close kit ) ( __lm_free_opts o ) ^ 1
+            ( nurl_print `It should be lingbot-map.pt (or -long / -stage1) from\n` )
+            ( nurl_print `    https://huggingface.co/robbyant/lingbot-map\n` )
+            ( gk_close kit ) ( string_free model ) ( __lm_free_opts o ) ^ 1
         }
         T lw → {
             : Agg a ( ag_load lw kit )
@@ -579,7 +873,11 @@ i h i w f cmin i stride → Ply {
                     ? == failed 0 {
                         ( nurl_print `wrote ` ) ( nurl_print ( nurl_str_int total ) )
                         ( nurl_print ` points to ` ) ( nurl_print . o out )
-                        ( nurl_print `\n` )
+                        ( nurl_print `  (` ) ( nurl_print ( nurl_str_int nframes ) )
+                        ( nurl_print ` frames, ` )
+                        ( nurl_print ( nurl_str_int
+                        / - ( monotonic_ns ) t_start 1000000 ) )
+                        ( nurl_print ` ms)\n` )
                     } {}
                     ? != . o profile 0 { ( gk_prof_report kit ) } {}
                     ( nurl_free # s taps )
@@ -594,6 +892,7 @@ i h i w f cmin i stride → Ply {
         }
     }
     ( gk_close kit )
+    ( string_free model )
     ( __lm_free_opts o )
     ^ rc
 }

--- a/packages/lingbot-map/tests/cmp_cloud.py
+++ b/packages/lingbot-map/tests/cmp_cloud.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Compare two point clouds written by `ref_cloud.py` and `lingbot-map`.
+
+  cmp_cloud.py <a.ply> <b.ply> [relative-tolerance]
+
+Both are binary_little_endian PLY with the same property order. They are
+NOT compared positionally: the confidence gate is a strict `>` against a
+threshold, so a pixel whose confidence lands within f32 noise of it falls
+on one side in one cloud and the other side in the other. A handful of
+such pixels — a few per 30 000 — shifts every later point by one slot and
+makes an index-wise diff meaningless while the reconstruction is in fact
+identical.
+
+So the question asked is the one that matters: does every point of A have
+a point of B in the same place? That is a nearest-neighbour lookup, over
+a sample, reported relative to the scene's own extent:
+
+  * point counts, and how far apart they are in proportion
+  * the median and 99th-percentile nearest-neighbour distance, A into B
+  * centroid drift
+
+A cloud that agrees to f32 noise gives a 99th percentile around 1e-6
+relative. A cloud reconstructed slightly differently — a different scale
+phase, a different window — gives something orders of magnitude larger,
+and the point counts move too.
+"""
+import sys
+
+import numpy as np
+from scipy.spatial import cKDTree
+
+SAMPLE = 200_000
+
+
+def read_ply(path):
+    with open(path, "rb") as f:
+        hdr = b""
+        while b"end_header" not in hdr:
+            line = f.readline()
+            if not line:
+                sys.exit("%s: no end_header" % path)
+            hdr += line
+        txt = hdr.decode("ascii", "replace")
+        if "format binary_little_endian" not in txt:
+            sys.exit("%s: not binary_little_endian" % path)
+        n = 0
+        for line in txt.splitlines():
+            if line.startswith("element vertex"):
+                n = int(line.split()[2])
+        dt = np.dtype([("x", "<f4"), ("y", "<f4"), ("z", "<f4"),
+                       ("r", "u1"), ("g", "u1"), ("b", "u1")])
+        d = np.frombuffer(f.read(n * dt.itemsize), dtype=dt, count=n)
+    if len(d) != n:
+        sys.exit("%s: header says %d vertices, body has %d" % (path, n, len(d)))
+    return np.stack([d["x"], d["y"], d["z"]], 1).astype(np.float64)
+
+
+def main():
+    a_path, b_path = sys.argv[1], sys.argv[2]
+    tol = float(sys.argv[3]) if len(sys.argv) > 3 else 1e-4
+    A = read_ply(a_path)
+    B = read_ply(b_path)
+    if len(A) == 0 or len(B) == 0:
+        sys.exit("one of the clouds is empty")
+
+    count_drift = abs(len(A) - len(B)) / max(len(A), len(B))
+    extent = float(np.linalg.norm(A.max(0) - A.min(0))) or 1.0
+
+    rng = np.random.default_rng(0)
+    idx = (rng.choice(len(A), SAMPLE, replace=False)
+           if len(A) > SAMPLE else np.arange(len(A)))
+    dist, _ = cKDTree(B).query(A[idx], k=1)
+    med, p99, worst = (float(np.median(dist)), float(np.percentile(dist, 99)),
+                       float(dist.max()))
+    cdrift = float(np.linalg.norm(A.mean(0) - B.mean(0))) / extent
+
+    print("points %d vs %d (%.4f%% apart)"
+          % (len(A), len(B), 100 * count_drift))
+    print("nearest-neighbour A->B over an extent of %.3f: "
+          "median %.2e, p99 %.2e, worst %.2e (relative)"
+          % (extent, med / extent, p99 / extent, worst / extent))
+    print("centroid drift %.2e relative" % cdrift)
+
+    # The MEDIAN is the verdict, not the tail. The p99 is dominated by
+    # far-field points, where a relative depth difference of 1e-5 moves the
+    # point a long way in absolute terms and says more about how far away
+    # it is than about whether the two agree.
+    ok = (med / extent) <= tol and count_drift <= 1e-3
+    print("VERDICT", "match" if ok else "DIFFER")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/lingbot-map/tests/lingbot_map_test.sh
+++ b/packages/lingbot-map/tests/lingbot_map_test.sh
@@ -67,7 +67,7 @@ print("worst relative error %.3e" % worst)
 PY
 }
 
-echo "[1/18] camera geometry vs the reference torch code"
+echo "[1/20] camera geometry vs the reference torch code"
 if ! $NURL tests/geomcheck.nu "$WORK/geomcheck" >/dev/null 2>"$WORK/build.err"; then
     bad "geomcheck build"; cat "$WORK/build.err"
 elif [ -z "$PYTORCH_PY" ] || ! "$PYTORCH_PY" -c "import torch" 2>/dev/null; then
@@ -84,7 +84,7 @@ else
     fi
 fi
 
-echo "[2/18] frame preprocessing vs the reference load_fn pipeline"
+echo "[2/20] frame preprocessing vs the reference load_fn pipeline"
 # Real frames, not synthetic ones: the resize ratio, the patch-multiple
 # rounding and the centre crop only interact on an actual aspect ratio.
 FRAMES=""
@@ -113,7 +113,7 @@ else
     fi
 fi
 
-echo "[3/18] position-grid resample vs torch bicubic+antialias"
+echo "[3/20] position-grid resample vs torch bicubic+antialias"
 if ! $NURL tests/interpcheck.nu "$WORK/ic" >/dev/null 2>"$WORK/ic_build.err"; then
     bad "interpcheck build"; tail -6 "$WORK/ic_build.err"
 elif [ -z "$PYTORCH_PY" ] || ! "$PYTORCH_PY" -c "import torch" 2>/dev/null; then
@@ -128,7 +128,7 @@ else
     fi
 fi
 
-echo "[4/18] 2-D rotary position embedding vs the reference"
+echo "[4/20] 2-D rotary position embedding vs the reference"
 if ! $NURL tests/ropecheck.nu "$WORK/rc" >/dev/null 2>"$WORK/rc_build.err"; then
     bad "ropecheck build"; tail -6 "$WORK/rc_build.err"
 elif [ -z "$PYTORCH_PY" ] || ! "$PYTORCH_PY" -c "import torch" 2>/dev/null; then
@@ -143,7 +143,7 @@ else
     fi
 fi
 
-echo "[5/18] patch embedding vs torch Conv2d"
+echo "[5/20] patch embedding vs torch Conv2d"
 if ! $NURL tests/pecheck.nu "$WORK/pe" >/dev/null 2>"$WORK/pe_build.err"; then
     bad "pecheck build"; tail -6 "$WORK/pe_build.err"
 elif [ -z "$PYTORCH_PY" ] || ! "$PYTORCH_PY" -c "import torch" 2>/dev/null; then
@@ -158,7 +158,7 @@ else
     fi
 fi
 
-echo "[6/18] full transformer block vs the reference Block"
+echo "[6/20] full transformer block vs the reference Block"
 if ! $NURL tests/blockcheck.nu "$WORK/bc" >/dev/null 2>"$WORK/bc_build.err"; then
     bad "blockcheck build"; tail -6 "$WORK/bc_build.err"
 elif [ -z "$PYTORCH_PY" ] || ! "$PYTORCH_PY" -c "import torch" 2>/dev/null; then
@@ -174,7 +174,7 @@ else
 fi
 
 CKPT="${LINGBOT_CKPT:-$HOME/.nurl/models/lingbot-map/lingbot-map.pt}"
-echo "[7/18] the real 4.6 GB checkpoint (skipped when absent)"
+echo "[7/20] the real 4.6 GB checkpoint (skipped when absent)"
 if [ ! -f "$CKPT" ]; then
     skip "no checkpoint at $CKPT — set LINGBOT_CKPT"
 elif ! $NURL tests/wcheck.nu "$WORK/wc" >/dev/null 2>"$WORK/wc_build.err"; then
@@ -196,7 +196,7 @@ else
     fi
 fi
 
-echo "[8/18] the block on the DEVICE (f32) vs the host reference"
+echo "[8/20] the block on the DEVICE (f32) vs the host reference"
 # Tolerance is float32's, not float64's: the device path computes in f32
 # on purpose. 1e-4 is two orders above what is observed (~3e-6) and two
 # orders below what any real stride bug produces (a wrong head stride
@@ -220,7 +220,7 @@ else
     fi
 fi
 
-echo "[9/18] 3-D rope vs the real WanRotaryPosEmbed"
+echo "[9/20] 3-D rope vs the real WanRotaryPosEmbed"
 # This one imports the upstream package rather than re-implementing it:
 # the 3-D rope is fiddly enough (three axes, interleaved pairs, a 20/22/22
 # head split) that a hand-written oracle would just be a second chance to
@@ -240,7 +240,7 @@ else
     fi
 fi
 
-echo "[10/18] the DINOv2 trunk on a real frame vs the real model"
+echo "[10/20] the DINOv2 trunk on a real frame vs the real model"
 # 24 blocks and 300M real weights against tests/agg_ref_courthouse0.txt,
 # which tests/agg_oracle.py produced by running the actual model. Takes
 # ~35 s and ~2.5 GB. Tolerance is float32's.
@@ -265,7 +265,7 @@ else
     fi
 fi
 
-echo "[11/18] the WHOLE aggregator on a real frame vs the real model"
+echo "[11/20] the WHOLE aggregator on a real frame vs the real model"
 # 72 blocks and 909M real weights: DINOv2 trunk, then 24 frame/global
 # pairs with 2-D and 3-D rope and the six special tokens. ~105 s, 7.3 GB.
 if [ ! -f "$CKPT" ]; then
@@ -294,7 +294,7 @@ else
     fi
 fi
 
-echo "[12/18] two frames STREAMED through the KV cache"
+echo "[12/20] two frames STREAMED through the KV cache"
 # The cache is the whole point of the model: frame 2's global blocks
 # attend over frame 1's keys as well as their own. ~200 s.
 FRAME1="$HOME/dev/lingbot-map/example/courthouse/000001.png"
@@ -318,7 +318,7 @@ else
     fi
 fi
 
-echo "[13/18] a camera POSE, end to end, vs the real model"
+echo "[13/20] a camera POSE, end to end, vs the real model"
 # preprocess -> DINOv2 -> aggregator -> camera head -> 9-vector, then
 # decoded to extrinsics and intrinsics. ~106 s.
 if [ ! -f "$CKPT" ] || [ ! -f "$FRAME0" ]; then
@@ -344,7 +344,7 @@ else
     fi
 fi
 
-echo "[14/18] one DPT fusion block, on synthetic weights"
+echo "[14/20] one DPT fusion block, on synthetic weights"
 # Seconds, not the ~150 s the real head takes: resConfUnit2 -> bilinear
 # upsample -> 1x1 out_conv against torch, so a fix to the fusion can be
 # checked without a 909M-parameter transformer in front of it.
@@ -366,7 +366,7 @@ else
     fi
 fi
 
-echo "[15/18] a DEPTH MAP and WORLD POINTS, end to end, vs the real model"
+echo "[15/20] a DEPTH MAP and WORLD POINTS, end to end, vs the real model"
 # preprocess -> DINOv2 -> aggregator -> DPT head -> depth + confidence
 # at full frame resolution. ~150 s on top of the aggregator.
 if [ ! -f "$CKPT" ] || [ ! -f "$FRAME0" ]; then
@@ -390,7 +390,60 @@ else
     fi
 fi
 
-echo "[16/18] the CLI, end to end, to a point-cloud file"
+echo "[16/20] the CLI's front door — no checkpoint, no GPU, no network"
+# Everything the command does BEFORE it loads a model: what it says when
+# it has nothing to reconstruct, that a mistyped option is an error
+# rather than a frame filename, that a directory of frames is found and
+# sorted, and that a `/`-led --model that does not exist fails as a
+# missing file instead of being looked up on Hugging Face. Seconds, and
+# it needs none of the heavy inputs the rest of the suite does.
+if ! $NURL src/main.nu "$WORK/lbm-cli" >/dev/null 2>"$WORK/cliarg.err"; then
+    bad "CLI build"; tail -6 "$WORK/cliarg.err"
+else
+    cf=0
+    # --help succeeds and shows an example; the usage alone is not help
+    "$WORK/lbm-cli" --help > "$WORK/help.txt" 2>&1 || cf=$((cf+1))
+    grep -q "^examples:" "$WORK/help.txt" || { bad "--help has no examples"; cf=$((cf+1)); }
+    "$WORK/lbm-cli" --version 2>&1 | grep -q "^lingbot-map " \
+        || { bad "--version prints nothing recognisable"; cf=$((cf+1)); }
+
+    # each of these must fail, and must SAY what is wrong
+    expect_msg() {  # <pattern> <args...>
+        pat="$1"; shift
+        if "$WORK/lbm-cli" "$@" > "$WORK/cliarg.txt" 2>&1; then
+            bad "'$*' should have failed"; cf=$((cf+1))
+        elif ! grep -qi "$pat" "$WORK/cliarg.txt"; then
+            bad "'$*' did not mention '$pat': $(head -1 "$WORK/cliarg.txt")"
+            cf=$((cf+1))
+        fi
+    }
+    expect_msg "no frames"      # nothing at all
+    expect_msg "no frames"      --model /nope/x.pt
+    expect_msg "unknown option" --qiuet frame.png
+    expect_msg "needs a value"  --out
+    expect_msg "no such frame"  no-such-frame.png
+    expect_msg "no .png"        "$WORK"          # a directory with no frames
+
+    # A directory IS the frames — and the failure that follows must be
+    # the missing local checkpoint, never a network lookup.
+    if [ -d "$HOME/dev/lingbot-map/example/courthouse" ]; then
+        expect_msg "no such file" --model /nope/x.pt --max-frames 2 \
+            "$HOME/dev/lingbot-map/example/courthouse"
+
+        # --max-frames then --stride, the order demo.py applies --first_k
+        # and --stride in: 30 frames every 3rd is 10, not 90. The count is
+        # printed before the checkpoint is opened, so this needs neither.
+        "$WORK/lbm-cli" --model /nope/x.pt --max-frames 30 --stride 3 \
+            "$HOME/dev/lingbot-map/example/courthouse" > "$WORK/stride.txt" 2>&1
+        if ! grep -q "^frames 10 " "$WORK/stride.txt"; then
+            bad "--max-frames 30 --stride 3 selected $(sed -n 's/^frames \([0-9]*\) .*/\1/p' "$WORK/stride.txt") frames, expected 10"
+            cf=$((cf+1))
+        fi
+    fi
+    [ "$cf" -eq 0 ] && ok "help, usage, unknown options, missing frames, dirs and --stride"
+fi
+
+echo "[17/20] the CLI, end to end, to a point-cloud file"
 # One frame all the way through to a PLY a viewer can open. The numbers
 # are already checked above; what this checks is that the program runs,
 # that the header's vertex count matches the body it wrote (it is
@@ -433,7 +486,7 @@ else
     fi
 fi
 
-echo "[17/18] KV-cache eviction bookkeeping, 120 frames"
+echo "[18/20] KV-cache eviction bookkeeping, 120 frames"
 # A replay of the reference's own _apply_kv_cache_eviction_causal on
 # frame indices. Checking eviction against the model itself would need
 # 73+ frames through a 909M-parameter transformer on both sides; this
@@ -453,7 +506,7 @@ else
     fi
 fi
 
-echo "[18/18] EVICTION against the real model, at a window that fits"
+echo "[19/20] EVICTION against the real model, at a window that fits"
 # The bookkeeping test above is indices; this one is activations. The
 # window is shrunk to 1 + 2 on BOTH sides, so eviction bites at frame 3
 # instead of frame 72 and six frames are enough. This is the test that
@@ -493,6 +546,86 @@ else
             bad "eviction differs from the real model"; echo "$out"
         fi
     fi
+fi
+
+
+echo "[20/20] THE WHOLE DELIVERABLE vs the reference: same frames, same cloud"
+# Every other step compares a module's activations on one or two frames.
+# This one compares what the user actually gets — the point cloud — over a
+# SEQUENCE, against ~/dev/lingbot-map driven through its own
+# `inference_streaming`, and times both.
+#
+# It needs a CUDA torch, which `.venv-oracle` is NOT (it is a CPU build,
+# deliberately — the rest of the suite only needs correctness). Set
+# LINGBOT_CUDA_PY, or drop a CUDA venv at the repo root as `.venv-cuda`.
+#
+# `--scale-frames 1` drives the reference the way the port drives the
+# model: every frame causal. demo.py's default is 8, which gives the first
+# eight frames BIDIRECTIONAL attention as one block — a mode the port does
+# not implement, and worth about 3% of the cloud. That is a known gap, not
+# something this step can hide.
+#
+# The two thresholds are different questions. ONE frame is pure arithmetic
+# and must agree tightly. A SEQUENCE accumulates: the pose of frame N is
+# estimated from a cache carrying every frame before it. The sequence
+# bound is set at what is measured TODAY so that a regression is caught —
+# it is NOT a statement that this much drift is correct. It is not: the
+# reference perturbed by 3e-4, the port's own activation-level
+# disagreement, moves only 3.9e-5, so the drift below is roughly 600x what
+# the model's conditioning explains. See README, "How close is it really".
+if [ -n "${LINGBOT_CUDA_PY:-}" ]; then :;
+elif [ -x "$REPO_ROOT/.venv-cuda/bin/python" ]; then LINGBOT_CUDA_PY="$REPO_ROOT/.venv-cuda/bin/python";
+else LINGBOT_CUDA_PY=""; fi
+CH="$HOME/dev/lingbot-map/example/courthouse"
+
+if [ ! -f "$CKPT" ] || [ ! -d "$CH" ]; then
+    skip "needs the checkpoint and ~/dev/lingbot-map/example/courthouse"
+elif [ -z "$LINGBOT_CUDA_PY" ] || \
+     ! CUDA_VISIBLE_DEVICES="${LINGBOT_CUDA_DEV:-0}" "$LINGBOT_CUDA_PY" \
+         -c "import torch,sys; sys.exit(0 if torch.cuda.is_available() else 1)" 2>/dev/null; then
+    skip "end-to-end differential — needs a CUDA torch (set LINGBOT_CUDA_PY)"
+elif ! $NURL src/main.nu "$WORK/lbm-e2e" >/dev/null 2>"$WORK/e2e_build.err"; then
+    bad "CLI build"; tail -6 "$WORK/e2e_build.err"
+elif ! "$LINGBOT_CUDA_PY" -c "import scipy.spatial" 2>/dev/null; then
+    skip "cloud comparison needs scipy"
+else
+    e2e_fail=0
+    for N in 1 20; do
+        FR=$(ls "$CH"/*.png 2>/dev/null | head -"$N")
+        # shellcheck disable=SC2086
+        if ! CUDA_VISIBLE_DEVICES="${LINGBOT_CUDA_DEV:-0}" PYTHONPATH="$HOME/dev/lingbot-map" \
+                "$LINGBOT_CUDA_PY" tests/ref_cloud.py --scale-frames 1 \
+                "$CKPT" "$WORK/ref$N.ply" $FR >/dev/null 2>"$WORK/ref$N.err"; then
+            bad "the reference failed to run on $N frames"; tail -3 "$WORK/ref$N.err"
+            e2e_fail=1; continue
+        fi
+        if ! "$WORK/lbm-e2e" --quiet --model "$CKPT" --max-frames "$N" \
+                --out "$WORK/port$N.ply" "$CH" >"$WORK/port$N.log" 2>&1; then
+            bad "the port failed to run on $N frames"; tail -3 "$WORK/port$N.log"
+            e2e_fail=1; continue
+        fi
+        # 1 frame is arithmetic; 20 frames is arithmetic plus accumulation.
+        [ "$N" = "1" ] && TOL=1e-4 || TOL=5e-3
+        if out="$("$LINGBOT_CUDA_PY" tests/cmp_cloud.py \
+                    "$WORK/ref$N.ply" "$WORK/port$N.ply" "$TOL" 2>&1)"; then
+            ok "$N frame(s): $(echo "$out" | sed -n '2p')"
+        else
+            bad "$N frame(s) differ beyond $TOL"; echo "$out" | sed -n '1,3p'
+            e2e_fail=1
+        fi
+        # Faster is half the requirement, so it is measured, not assumed.
+        rs=$(sed -n 's/^ref_seconds \([0-9.]*\) .*/\1/p' "$WORK/ref$N.err")
+        ps=$(sed -n 's/.*(\([0-9]*\) frames, \([0-9]*\) ms).*/\2/p' "$WORK/port$N.log")
+        if [ -n "$rs" ] && [ -n "$ps" ]; then
+            rms=$(awk -v r="$rs" 'BEGIN { printf "%d", r * 1000 }')
+            echo "       $N frame(s): reference ${rs}s, port $((ps / 1000)).$((ps % 1000 / 100))s" \
+                 "= $(awk -v r="$rms" -v p="$ps" 'BEGIN { printf "%.1fx", r / p }') faster"
+            if [ "$ps" -ge "$rms" ]; then
+                bad "$N frame(s): the port is NOT faster than the reference"
+                e2e_fail=1
+            fi
+        fi
+    done
 fi
 
 echo

--- a/packages/lingbot-map/tests/ref_cloud.py
+++ b/packages/lingbot-map/tests/ref_cloud.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""The REFERENCE, writing the same point cloud `lingbot-map` writes.
+
+  ref_cloud.py <checkpoint.pt> <out.ply> <frame.png> ...
+      [--conf F] [--pixel-stride N] [--dtype float32|bf16]
+
+This exists so that "the port behaves exactly like ~/dev/lingbot-map, but
+faster" is a number rather than a claim. `tests/ref_timing.py` compares
+one frame of three modules; this compares the actual deliverable — every
+frame, every point, and the wall clock around the whole run.
+
+The model is built exactly as `demo.py` builds it (streaming mode,
+enable_3d_rope, 8 scale frames, a 64-frame sliding window, 4 camera
+iterations) and driven through the same `inference_streaming`. The cloud
+is then assembled the way `main.nu` assembles it: keep pixels whose
+`depth_conf` exceeds --conf, take every --pixel-stride-th pixel on both
+axes, unproject with the reference's own
+`unproject_depth_map_to_point_map`, and write binary_little_endian PLY
+with the same property order.
+
+Two conventions are load-bearing and are the reference's, not choices
+made here: the pixel grid is integer coordinates (np.arange, not sample
+centres), and the unprojection takes the WORLD-FROM-CAMERA extrinsic and
+inverts it itself.
+
+Timing is reported on stderr as `ref_seconds <total> <load> <inference>`
+so a caller can compare it against the port's own total.
+"""
+import os
+import struct
+import sys
+import time
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.expanduser("~/dev/lingbot-map"))
+torch.set_grad_enabled(False)
+
+from lingbot_map.models.gct_stream import GCTStream               # noqa: E402
+from lingbot_map.utils.load_fn import load_and_preprocess_images   # noqa: E402
+from lingbot_map.utils.pose_enc import pose_encoding_to_extri_intri  # noqa: E402
+from lingbot_map.utils.geometry import (                          # noqa: E402
+    unproject_depth_map_to_point_map,
+)
+
+DTYPES = {"float32": torch.float32, "fp32": torch.float32,
+          "bfloat16": torch.bfloat16, "bf16": torch.bfloat16}
+
+
+def main():
+    args = sys.argv[1:]
+    conf_thr, pixel_stride, dtype, scale_frames = 1.5, 2, torch.float32, 8
+    jitter = 0.0
+    rest = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--conf":
+            conf_thr = float(args[i + 1]); i += 2
+        elif a == "--pixel-stride":
+            pixel_stride = int(args[i + 1]); i += 2
+        elif a == "--dtype":
+            dtype = DTYPES[args[i + 1]]; i += 2
+        elif a == "--jitter":
+            # Perturb the preprocessed frames by this RELATIVE amount before
+            # inference. The point is to measure the reference's sensitivity
+            # to a disturbance the size of the port's own f32 disagreement:
+            # if the reference moves as far when nudged by 1e-6 as the port
+            # sits from it, the two are as close as this model allows, and
+            # the gap is the system's conditioning rather than a porting bug.
+            jitter = float(args[i + 1]); i += 2
+        elif a == "--scale-frames":
+            # inference_streaming's Phase 1 batch size. demo.py's default
+            # is 8, which gives those frames BIDIRECTIONAL attention among
+            # themselves; 1 makes every frame causal, which is how the port
+            # drives the model. This is the one behavioural axis on which
+            # the two can legitimately disagree.
+            scale_frames = int(args[i + 1]); i += 2
+        else:
+            rest.append(a); i += 1
+    ckpt_path, out_path, frames = rest[0], rest[1], rest[2:]
+    if not frames:
+        sys.exit("ref_cloud.py: no frames")
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    cuda = device.type == "cuda"
+
+    def sync():
+        if cuda:
+            torch.cuda.synchronize()
+
+    t_total0 = time.time()
+
+    model = GCTStream(img_size=518, patch_size=14, enable_3d_rope=True,
+                      max_frame_num=1024, kv_cache_sliding_window=64,
+                      kv_cache_scale_frames=8, kv_cache_cross_frame_special=True,
+                      kv_cache_include_scale_frames=True, use_sdpa=True,
+                      camera_num_iterations=4)
+    sd = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    model.load_state_dict(sd.get("model", sd), strict=False)
+    model = model.to(device).eval()
+    if dtype != torch.float32:
+        model.aggregator = model.aggregator.to(dtype=dtype)
+
+    images = load_and_preprocess_images(frames, mode="crop",
+                                        image_size=518, patch_size=14)
+    if jitter:
+        g = torch.Generator().manual_seed(0)
+        images = images * (1.0 + jitter * torch.randn(images.shape, generator=g))
+    sync()
+    t_load = time.time() - t_total0
+
+    t_inf0 = time.time()
+    preds = model.inference_streaming(images.to(device),
+                                      num_scale_frames=scale_frames,
+                                      keyframe_interval=1)
+    sync()
+    t_inf = time.time() - t_inf0
+
+    # demo.py's postprocess: pose encoding -> extrinsics/intrinsics. It
+    # then inverts w2c to c2w for the viewer; the unprojection helper wants
+    # the world-from-camera one and inverts it itself, so the raw w2c
+    # extrinsic is what goes in.
+    h, w = images.shape[-2:]
+    extri, intri = pose_encoding_to_extri_intri(preds["pose_enc"], (h, w))
+    extri = extri[0].float().cpu().numpy()
+    intri = intri[0].float().cpu().numpy()
+    depth = preds["depth"][0].float().cpu().numpy()          # [S, H, W, 1]
+    conf = preds["depth_conf"][0].float().cpu().numpy()      # [S, H, W]
+    rgb = images.float().cpu().numpy()                       # [S, 3, H, W]
+
+    world = unproject_depth_map_to_point_map(depth, extri, intri)  # [S,H,W,3]
+
+    xyz, col, per_frame = [], [], []
+    for s in range(world.shape[0]):
+        m = conf[s][::pixel_stride, ::pixel_stride] > conf_thr
+        p = world[s][::pixel_stride, ::pixel_stride][m]
+        c = rgb[s].transpose(1, 2, 0)[::pixel_stride, ::pixel_stride][m]
+        xyz.append(p)
+        col.append(np.clip(np.rint(c * 255.0), 0, 255).astype(np.uint8))
+        per_frame.append(len(p))
+    # Cumulative, so it lines up with what the port prints per frame.
+    print("ref_cumulative " + " ".join(str(n) for n in np.cumsum(per_frame)),
+          file=sys.stderr)
+    xyz = np.concatenate(xyz).astype(np.float32)
+    col = np.concatenate(col)
+
+    with open(out_path, "wb") as f:
+        f.write(b"ply\nformat binary_little_endian 1.0\n"
+                b"comment lingbot-map reference\n")
+        f.write(("element vertex %d\n" % len(xyz)).encode())
+        f.write(b"property float x\nproperty float y\nproperty float z\n"
+                b"property uchar red\nproperty uchar green\nproperty uchar blue\n"
+                b"end_header\n")
+        for p, c in zip(xyz, col):
+            f.write(struct.pack("<fffBBB", p[0], p[1], p[2], c[0], c[1], c[2]))
+
+    t_total = time.time() - t_total0
+    print("ref_seconds %.2f %.2f %.2f" % (t_total, t_load, t_inf), file=sys.stderr)
+    print("%d points to %s" % (len(xyz), out_path))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`lingbot-map --model ~/.nurl/models/lingbot-map/lingbot-map.pt` printed the bare usage and left the reader to work out which line applied to them:

```
usage: lingbot-map --model <checkpoint.pt> [options] <frame> ...
  --out <file.ply>   where to write the cloud (default cloud.ply)
  ...
```

Now:

```
lingbot-map: no frames to reconstruct.
Point it at a folder of frames, in order:
    lingbot-map ~/dev/lingbot-map/example/courthouse
or name the frames yourself:
    lingbot-map shot0.png shot1.png shot2.png
'lingbot-map --help' has the rest.
```

## The front door

`lingbot-map <frames-dir>` is the whole command.

- A directory positional is the frames. `--model` is optional and resolves `$LINGBOT_MAP_MODEL` → `~/.nurl/models/lingbot-map/lingbot-map.pt` → fetches `robbyant/lingbot-map/lingbot-map.pt` through [hub](../tree/main/packages/hub). A Hugging Face ref works as `--model` too.
- Every error names what is wrong and shows a command that would have worked. `--help` is a real help page with examples and exits 0; `--version` did not exist.
- A mistyped option is an error, not a frame filename that fails much later as a missing file. Frame paths are all checked **before** the 4.6 GB checkpoint is read.
- `--stride <n>`, the reference's frame subsampling, which had no equivalent: `--stride 20` reconstructs a 286-frame walk from 15 frames in 4 s. Applied *after* `--max-frames`, the order `demo.py` applies `--first_k` and `--stride`.
- The reference's spellings are accepted: `--model_path`, `--image_folder`, `--conf_threshold`, `--first_k`.

Three real defects fell out of the pass:

- **`fs_glob` does not descend through a symlinked directory** — a linked frame folder reported "no .png or .jpg" and stopped. Now `dir_list` plus a case-insensitive extension test; `.jpeg` is recognised.
- **A mistyped `--flag` became a frame path** and failed much later as a missing file.
- **`--conf` defaulted to 2.0**, with a comment claiming that was the reference's default. `demo.py`'s `--conf_threshold` is **1.5**. At the same threshold the cloud is byte-for-byte what 0.2.1 produced.

The README is now about using it. The porting war stories moved intact to `docs/porting-notes.md`.

## What measuring it turned up

The claim "as fast as the reference" rested on `ref_timing.py`, which compares three modules on one frame. `tests/ref_cloud.py` drives `~/dev/lingbot-map` through its own `inference_streaming` and writes the same cloud; `tests/cmp_cloud.py` compares them. Both are suite step 20. Same frames, same checkpoint, same GPU.

**Faster — yes:**

| frames | reference | port | |
|---:|---:|---:|---|
| 1 | 14.6 s | 1.6 s | **9.2x** |
| 12 | 15.8 s | 3.4 s | **4.6x** |
| 20 | 17.2 s | 5.1 s | **3.4x** |

Almost all of it is the checkpoint — 1.6 s against `torch.load` + `load_state_dict`'s ~12.6 s. On inference alone the two are within about 5%.

**Exactly like — no, and it is not the arithmetic:**

| frames | point counts | median displacement | centroid drift |
|---:|---|---:|---:|
| 1 | 33 024 vs 33 025 | 2.3e-5 | 6.9e-5 |
| 4 | 129 979 vs 129 982 | 1.7e-3 | 5.1e-2 |
| 20 | 589 997 vs 590 002 | 3.0e-3 | 1.8e-1 |

The **depth is right** — point counts agree to one part in 30 000, the pixels whose confidence sits within f32 noise of a strict `>` — and the **poses drift**.

"Streaming models drift" would be a comfortable explanation and it is wrong. `ref_cloud.py --jitter EPS` perturbs the *reference's* input and re-runs it against itself. At 3e-4, the size of the port's own activation-level disagreement, the reference's 20-frame cloud moves by **3.9e-5**. The port sits at **2.6e-2** — roughly **600x further away than the model's conditioning explains**.

Two more things narrow it: the aggregator's activations disagree by a **flat** 3e-4 from frame 1 to frame 10 and never grow, so the divergence is in what is built *out* of them; and the per-frame centroid jumps 5.5e-5 → 1.9e-2 at frame 2, the first frame that reads a non-empty KV cache.

Separately, `demo.py` runs the first 8 frames as **one bidirectional block** (`--num_scale_frames`, default 8); the port is causal from frame 0. That alone is 3.3% of the cloud on 12 frames.

**Neither is a regression** — both predate 0.2.0, and neither is fixed here. Steps 1–19 cannot see either, because every one of them is a 1–6 frame comparison of *activations*. They are now measured, written down in the README under "How close is it really", and pinned by a test.

The README previously claimed parity on the strength of single-frame numbers. That has been corrected rather than softened.

## Testing

`21 passed, 0 failed, 0 skipped` on an RTX 4090 with the real 4.6 GB checkpoint.

- Step 16 is new and fast: the whole argument surface with no checkpoint, no GPU and no network.
- Step 20 is the end-to-end differential. It needs a **CUDA** torch — `.venv-oracle` is deliberately a CPU build — via `LINGBOT_CUDA_PY` / `.venv-cuda`, and skips cleanly without one, so CI is unaffected.
- Gate for the CLI work: the 8-frame cloud is `cmp`-identical to one produced by a binary built from the pre-change source at the same `--conf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFg7AdSVzW5ZzQHyPcN9e5
