### PR TITLE
nurlpkg: unlink the destination before installing a binary over it

### DIFF
--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -3280,6 +3280,14 @@ Usage: nurlpkg login   (paste the token from the registry; kept in ~/.nurl/crede
         ? win { ( string_push_str dest `.exe` ) } {}
 
         ?? ( dir_create_all ( string_data bindir ) ) { T _ → {} F _ → {} }
+        // Unlink the destination first. Writing INTO a binary that some
+        // process is executing fails with ETXTBSY on Linux; unlinking the
+        // directory entry and creating a fresh file succeeds, and the
+        // running process keeps its old inode until it exits — which is
+        // how every package manager replaces a running executable. This
+        // surfaced as a bare "failed to install binary" while an old
+        // `lingbot-map view` was still serving.
+        : i32 _unl ( unlink ( string_data dest ) )
         ?? ( fs_copy_file ( string_data outbin ) ( string_data dest ) ) {
             F _ → { ( nurl_eprintln `nurlpkg: failed to install binary` ) = rc 1 }
             T _ → {


### PR DESCRIPTION
`nurlpkg install <tool>` over a **running** executable fails with a bare `failed to install binary`: writing into a binary some process is executing is ETXTBSY on Linux. The compile had succeeded, the copy had not, and nothing said why.

It bit for real during the lingbot-map 0.6.0 publish verification — a `lingbot-map view` server left running from an earlier session made every upgrade of that tool fail, and the message gave no hint that a live process was the cause.

The fix is what every package manager does: **unlink the directory entry, then create the fresh file**. The running process keeps its old inode until it exits; the new binary takes the name.

Verified both ways with the binary held open by a live `lingbot-map view`:

```
=== OLD nurlpkg while the binary runs ===
nurlpkg: failed to install binary
=== FIXED nurlpkg while the binary runs ===
Installed lingbot-map → /home/wau/.nurl/bin/lingbot-map
old viewer still serving: 200        ← the old inode lives on
```

One `unlink` call before the `fs_copy_file`; `unlink` on a missing destination is a harmless -1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFg7AdSVzW5ZzQHyPcN9e5
