### PR TITLE
nurlc: reject integer-width mismatches at return position (b↔i invalid IR)

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -2331,6 +2331,23 @@
             `return value type '` lt `' does not match the declared return type '` fn_rt )
             `' — wrong struct type returned by value (the fields would be silently reinterpreted)` ) ) }
         {}
+        // Integer WIDTH mismatch — above all the bool boundary. `^ ( ffi )` in
+        // a `→ b` function lowered `ret i64 …` out of an i1 function (and the
+        // mirror image, `^ == a b` from `→ i`, lowered `ret i1` out of an i64
+        // one): invalid IR that nurlc accepted (rc 0) and only the LLVM
+        // verifier rejected, three build stages later, with a line number
+        // into the .ll. Same policy as the float/pointer clashes: no
+        // implicit conversions, say so HERE with the cure spelled out.
+        ? & & ( is_int_ty lt ) ( is_int_ty fn_rt ) ! ( seq lt fn_rt )
+        { : s cure ? ( seq fn_rt `i1` )
+            `' — NURL has no implicit conversions; compare the value to get a b, e.g. '^ != 0 ( … )'`
+            ? ( seq lt `i1` )
+            `' — NURL has no implicit conversions; select to widen the b, e.g. '^ ? cond 1 0'`
+            `' — NURL has no implicit conversions; convert with '# T expr'`
+            ( die lex ( nurl_str_cat ( nurl_str_cat4
+            `return value type '` ( llvm_to_nurl lt ) `' does not match the declared return type '` ( llvm_to_nurl fn_rt ) )
+            cure ) ) }
+        {}
     }
     {}
     // Determine which owned-slice binding (if any) is escaping as the return value.
@@ -11446,6 +11463,16 @@
 
 // True iff an LLVM type string is a float type (`double` or f32 `float`).
 @ is_float_ty s ty → b { ^ | ( seq ty `double` ) ( seq ty `float` ) }
+
+// A first-class LLVM integer scalar. i1 counts — that is the point: the
+// return-type width check exists mostly to catch b/i mixups.
+@ is_int_ty s ty → b {
+    ? ( seq ty `i1` ) { ^ T } {}
+    ? ( seq ty `i8` ) { ^ T } {}
+    ? ( seq ty `i16` ) { ^ T } {}
+    ? ( seq ty `i32` ) { ^ T } {}
+    ^ ( seq ty `i64` )
+}
 
 // A never-legal store/assign type clash between a value's LLVM type `vt`
 // and the declared destination type `dt`: float-vs-non-float, a different

--- a/compiler/tests/outputs/should_fail_ret_bool_as_int.txt
+++ b/compiler/tests/outputs/should_fail_ret_bool_as_int.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/outputs/should_fail_ret_int_width.txt
+++ b/compiler/tests/outputs/should_fail_ret_int_width.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_ret_bool_as_int.nu
+++ b/compiler/tests/should_fail_ret_bool_as_int.nu
@@ -1,0 +1,6 @@
+// The mirror image of should_fail_ret_int_width: a `b`-typed comparison
+// returned from a `→ i` function emitted `ret i1` out of an i64
+// function. Must be a compile error suggesting '^ ? cond 1 0'.
+@ cmp i a i b → i { ^ == a b }
+
+@ main → i { ^ ( cmp 1 1 ) }

--- a/compiler/tests/should_fail_ret_int_width.nu
+++ b/compiler/tests/should_fail_ret_int_width.nu
@@ -1,0 +1,14 @@
+// Returning an `i` from a `→ b` function (or a `b` from `→ i`) used to
+// emit `ret i64 …` out of an i1 LLVM function — invalid IR nurlc
+// accepted (rc 0) and only the LLVM verifier rejected, three build
+// stages later. The classic trigger: tail-returning an int-returning
+// FFI call from a bool-typed wrapper. Must be a compile error with the
+// cure ('^ != 0 ( … )') in the message.
+$ `stdlib/core/string.nu`
+
+@ streq s a s b → b { ^ ( nurl_str_eq a b ) }
+
+@ main → i {
+    ? ( streq `x` `x` ) { ^ 0 } {}
+    ^ 1
+}


### PR DESCRIPTION
`@ f … → b { ^ ( nurl_str_eq a b ) }` compiled to `ret i64 %r1` inside a `define i1` — invalid IR that nurlc accepted and only the LLVM verifier caught, three stages later, pointing into the .ll. The mirror direction (`^ == a b` from a `→ i` function) emitted `ret i1` out of an i64 function identically. Found while porting map-anything (its streq wrapper), worked around there; this is the root fix.

gen_ret's return-type agreement check (float↔int, pointer↔scalar) now also rejects integer width clashes, with the cure per direction in the message: `^ != 0 ( … )` to get a `b`, `^ ? cond 1 0` to widen one. No codegen changes — accepted programs lower identically, and nothing hitting the new diagnostic could ever have linked. Bootstrap fixed point + full corpus green, including two new `should_fail_*` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVrMqaqvW8shK9Fhz8P27s