### PR TITLE
windows: MinGW runtime POSIX compat tier; nurlpkg transport failures no longer report as "package not found"

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -75,9 +75,28 @@ jobs:
           New-Item -ItemType Directory -Path $dir -Force | Out-Null
           # single-quoted here-string: NURL uses backticks for strings and
           # PowerShell would otherwise eat them as escapes
+          # The import list is the REGRESSION: v0.27.0 shipped a
+          # runtime.mingw.o that could not link std/net or ext/http
+          # (clock_gettime / nanosleep / readlink and friends lived in
+          # the MSVC-only compat tier), and a core/io-only smoke was
+          # blind to it. Import the wide surface and call now_ms so the
+          # clock path also RUNS on both ABIs.
           $src = @'
           $ `stdlib/core/io.nu`
-          @ main → i { ( nurl_print `ok` ) ^ 0 }
+          $ `stdlib/core/string.nu`
+          $ `stdlib/core/vec.nu`
+          $ `stdlib/std/time.nu`
+          $ `stdlib/std/fs.nu`
+          $ `stdlib/std/net.nu`
+          $ `stdlib/std/process.nu`
+          $ `stdlib/std/term.nu`
+          $ `stdlib/std/path.nu`
+          $ `stdlib/ext/http.nu`
+          $ `stdlib/ext/env.nu`
+          @ main → i {
+          ? > ( now_ms ) 0 { ( nurl_print `ok` ) } { ( nurl_print `bad-clock` ) }
+          ^ 0
+          }
           '@
           ($src -split "`n" | ForEach-Object { $_.TrimStart() }) -join "`n" |
             Set-Content -Path "$dir\s.nu" -Encoding utf8NoBOM

--- a/stdlib/ext/http_cli.nu
+++ b/stdlib/ext/http_cli.nu
@@ -52,15 +52,34 @@ $ `stdlib/ext/env.nu`
 
 // ── Temp directory ──────────────────────────────────────────────────
 // $TMPDIR if set and non-empty, else /tmp.
+// The temp directory, on every platform's own terms. POSIX spells it
+// TMPDIR; Windows spells it TEMP (or TMP) and has no /tmp at all — the
+// old TMPDIR-or-/tmp fallback made EVERY request on Windows die staging
+// its response file, before curl was even spawned, and nurlpkg then
+// reported the silence as "package not found in the registry".
 @ __httpc_tmpdir → String {
     ?? ( env_get `TMPDIR` ) {
         T d → {
             ? > ( string_len d ) 0 { ^ d } {}
             ( string_free d )
-            ^ ( string_from `/tmp` )
         }
-        F _ → ^ ( string_from `/tmp` )
+        F _ → {}
     }
+    ?? ( env_get `TEMP` ) {
+        T d → {
+            ? > ( string_len d ) 0 { ^ d } {}
+            ( string_free d )
+        }
+        F _ → {}
+    }
+    ?? ( env_get `TMP` ) {
+        T d → {
+            ? > ( string_len d ) 0 { ^ d } {}
+            ( string_free d )
+        }
+        F _ → {}
+    }
+    ^ ( string_from `/tmp` )
 }
 
 // Copy bytes [a, b) of `str` into a fresh owned String.

--- a/stdlib/ext/pkg_fetch.nu
+++ b/stdlib/ext/pkg_fetch.nu
@@ -73,18 +73,51 @@ $ `stdlib/ext/registry_index.nu`
 @ pkg_fetch_index s registry s name → String {
     : String url ( __pkg_index_url registry name )
     : !HttpcResp HttpcErr rr ( httpc_get ( string_data url ) )
-    ( string_free url )
     ?? rr {
         T resp → {
             : ~ String out ( string_new )
-            ? == ( httpc_status resp ) 200 {
+            : i st ( httpc_status resp )
+            ? == st 200 {
                 ( string_free out )
                 = out ( string_from ( httpc_body_str resp ) )
-            } {}
+            } {
+                // 404 is the registry's honest "no such package" and stays
+                // silent; anything else is the registry misbehaving and
+                // must not be reported downstream as a missing package.
+                ? != st 404 {
+                    ( nurl_eprint `nurlpkg: registry returned HTTP ` )
+                    : String ss ( string_new )
+                    ( string_push_int ss st )
+                    ( nurl_eprint ( string_data ss ) )
+                    ( string_free ss )
+                    ( nurl_eprint ` for ` )
+                    ( nurl_eprint ( string_data url ) )
+                    ( nurl_eprint `\n` )
+                } {}
+            }
             ( httpc_resp_free resp )
+            ( string_free url )
             ^ out
         }
-        F → ^ ( string_new )
+        F e → {
+            // A TRANSPORT failure — no bytes ever moved. Say so, with the
+            // failing URL: on Windows this was a dead temp-dir path being
+            // reported as "package not found" with zero network calls.
+            ( nurl_eprint `nurlpkg: registry request FAILED (` )
+            ( nurl_eprint ?? e {
+                HttpcConnect → `connect`
+                HttpcTimeout → `timeout`
+                HttpcTls → `tls`
+                HttpcDns → `dns`
+                HttpcInvalidUrl → `bad url`
+                HttpcOther → `transport — is curl on PATH, and is the temp dir writable?`
+            } )
+            ( nurl_eprint `) for ` )
+            ( nurl_eprint ( string_data url ) )
+            ( nurl_eprint `\n` )
+            ( string_free url )
+            ^ ( string_new )
+        }
     }
 }
 

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -1343,48 +1343,6 @@ int pthread_cond_destroy(pthread_cond_t *c)   { (void)c; return 0; }
 #      define CLOCK_MONOTONIC 1
 #    endif
 
-/* UCRT <time.h> defines struct timespec (time_t tv_sec; long tv_nsec)
- * but no clock_gettime — only timespec_get. NURL allocates 16 zeroed
- * bytes and peeks slot 1 as i64, so the 4 pad bytes after the 32-bit
- * tv_nsec must stay zero — we only ever store through the long. */
-int clock_gettime(int clk, struct timespec *ts) {
-    if (!ts) { errno = EINVAL; return -1; }
-    if (clk == CLOCK_MONOTONIC) {
-        static LARGE_INTEGER freq;  /* benign race: same value either way */
-        if (!freq.QuadPart) QueryPerformanceFrequency(&freq);
-        LARGE_INTEGER c;
-        QueryPerformanceCounter(&c);
-        ts->tv_sec  = (time_t)(c.QuadPart / freq.QuadPart);
-        ts->tv_nsec = (long)((c.QuadPart % freq.QuadPart) * 1000000000LL
-                             / freq.QuadPart);
-        return 0;
-    }
-    if (clk != CLOCK_REALTIME) { errno = EINVAL; return -1; }
-    FILETIME ft;
-    GetSystemTimePreciseAsFileTime(&ft);
-    ULARGE_INTEGER u;
-    u.LowPart  = ft.dwLowDateTime;
-    u.HighPart = ft.dwHighDateTime;
-    /* 100 ns ticks, 1601 epoch → Unix epoch. */
-    unsigned long long t = u.QuadPart - 116444736000000000ULL;
-    ts->tv_sec  = (time_t)(t / 10000000ULL);
-    ts->tv_nsec = (long)(t % 10000000ULL) * 100;
-    return 0;
-}
-
-/* Sleep() can't be interrupted by POSIX signals on Windows, so this
- * never reports EINTR / a remainder. req may alias rem (time.nu passes
- * the same buffer twice) — read req fully before touching rem. */
-int nanosleep(const struct timespec *req, struct timespec *rem) {
-    if (!req) { errno = EINVAL; return -1; }
-    long long ms = (long long)req->tv_sec * 1000
-                 + (req->tv_nsec + 999999L) / 1000000L;
-    if (rem) { rem->tv_sec = 0; rem->tv_nsec = 0; }
-    if (ms <= 0) return 0;
-    Sleep(ms > 0xFFFFFFFELL ? 0xFFFFFFFEUL : (DWORD)ms);
-    return 0;
-}
-
 int mkstemp(char *tmpl) {
     static const char alpha[] =
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -1445,6 +1403,72 @@ int write(int fd, const void *buf, unsigned int n) {
     return _write(fd, buf, n);
 }
 int chdir(const char *path)                { return _chdir(path); }
+void *opendir(const char *path)            { (void)path; errno = ENOSYS; return NULL; }
+void *readdir(void *d)                     { (void)d; errno = ENOSYS; return NULL; }
+int   closedir(void *d)                    { (void)d; errno = ENOSYS; return -1; }
+#  endif /* !__MINGW32__ */
+
+/* ── Windows POSIX-compat shared by BOTH ABIs (MSVC and MinGW) ──────
+ *
+ * These lived in the MSVC-only tier above on the theory that mingw-w64
+ * ships them. Its HEADERS do; the functions live in libwinpthread
+ * (clock_gettime / nanosleep) or nowhere at all (readlink, fork, poll,
+ * termios), and the bundled zig's MinGW link carries neither — so
+ * stdlib\runtime.mingw.o lacked them and anything importing std/net or
+ * ext/http failed to link on Windows (reported in the field on
+ * v0.27.0). One definition for both ABIs; the MSVC pragma tier keeps
+ * only what mingw genuinely provides (isatty/_write forwards, mkstemp,
+ * the dirent trio). */
+#  include <io.h>     /* _get_osfhandle — both ABIs spell it this way */
+#  ifndef CLOCK_REALTIME
+#    define CLOCK_REALTIME  0
+#  endif
+#  ifndef CLOCK_MONOTONIC
+#    define CLOCK_MONOTONIC 1
+#  endif
+
+/* UCRT <time.h> defines struct timespec (time_t tv_sec; long tv_nsec)
+ * but no clock_gettime — only timespec_get. NURL allocates 16 zeroed
+ * bytes and peeks slot 1 as i64, so the 4 pad bytes after the 32-bit
+ * tv_nsec must stay zero — we only ever store through the long. */
+int clock_gettime(int clk, struct timespec *ts) {
+    if (!ts) { errno = EINVAL; return -1; }
+    if (clk == CLOCK_MONOTONIC) {
+        static LARGE_INTEGER freq;  /* benign race: same value either way */
+        if (!freq.QuadPart) QueryPerformanceFrequency(&freq);
+        LARGE_INTEGER c;
+        QueryPerformanceCounter(&c);
+        ts->tv_sec  = (time_t)(c.QuadPart / freq.QuadPart);
+        ts->tv_nsec = (long)((c.QuadPart % freq.QuadPart) * 1000000000LL
+                             / freq.QuadPart);
+        return 0;
+    }
+    if (clk != CLOCK_REALTIME) { errno = EINVAL; return -1; }
+    FILETIME ft;
+    GetSystemTimePreciseAsFileTime(&ft);
+    ULARGE_INTEGER u;
+    u.LowPart  = ft.dwLowDateTime;
+    u.HighPart = ft.dwHighDateTime;
+    /* 100 ns ticks, 1601 epoch → Unix epoch. */
+    unsigned long long t = u.QuadPart - 116444736000000000ULL;
+    ts->tv_sec  = (time_t)(t / 10000000ULL);
+    ts->tv_nsec = (long)(t % 10000000ULL) * 100;
+    return 0;
+}
+
+/* Sleep() can't be interrupted by POSIX signals on Windows, so this
+ * never reports EINTR / a remainder. req may alias rem (time.nu passes
+ * the same buffer twice) — read req fully before touching rem. */
+int nanosleep(const struct timespec *req, struct timespec *rem) {
+    if (!req) { errno = EINVAL; return -1; }
+    long long ms = (long long)req->tv_sec * 1000
+                 + (req->tv_nsec + 999999L) / 1000000L;
+    if (rem) { rem->tv_sec = 0; rem->tv_nsec = 0; }
+    if (ms <= 0) return 0;
+    Sleep(ms > 0xFFFFFFFELL ? 0xFFFFFFFEUL : (DWORD)ms);
+    return 0;
+}
+
 int  tcgetattr(int fd, char *buf)          { (void)fd; (void)buf; errno = ENOSYS; return -1; }
 int  tcsetattr(int fd, int act, const char *buf) {
     (void)fd; (void)act; (void)buf; errno = ENOSYS; return -1;
@@ -1471,9 +1495,6 @@ int ioctl(int fd, long long req, void *argp) {
     errno = ENOSYS;
     return -1;
 }
-void *opendir(const char *path)            { (void)path; errno = ENOSYS; return NULL; }
-void *readdir(void *d)                     { (void)d; errno = ENOSYS; return NULL; }
-int   closedir(void *d)                    { (void)d; errno = ENOSYS; return -1; }
 long long readlink(const char *p, char *buf, unsigned long long n) {
     (void)p; (void)buf; (void)n; errno = ENOSYS; return -1;
 }
@@ -1485,7 +1506,8 @@ int  fcntl(int fd, int cmd, ...)           { (void)fd; (void)cmd; errno = ENOSYS
 int  poll(void *fds, unsigned long n, int timeout) {
     (void)fds; (void)n; (void)timeout; errno = ENOSYS; return -1;
 }
-#  endif /* !__MINGW32__ */
+
+
 #elif !defined(__wasi__)
 #  include <pthread.h>
 #  include <sys/socket.h>
@@ -1630,9 +1652,9 @@ long long nurl_native_constant(const char *name) {
     if (strcmp(name, "TIOCGWINSZ")      == 0) return (long long)TIOCGWINSZ;
 #  endif
 #endif
-#if defined(_WIN32) && !defined(__MINGW32__)
-    /* The MSVC path's ioctl shim (above) answers this request with
-     * GetConsoleScreenBufferInfo — surface the sentinel it matches on. */
+#if defined(_WIN32)
+    /* The Windows ioctl shim (above, both ABIs) answers this request
+     * with GetConsoleScreenBufferInfo — surface its sentinel. */
     if (strcmp(name, "TIOCGWINSZ")      == 0) return 0x5413;
 #endif
     (void)name;


### PR DESCRIPTION
Fixes the two field-reported v0.27.0 Windows issues (machine with no LLVM and no `C:\tmp` — paths CI runners never walk):

1. **runtime.mingw.o lacked the POSIX compat symbols.** `clock_gettime` / `nanosleep` / `readlink` + ten friends sat in the MSVC-only tier ("mingw ships these" — its headers do, the functions live in libwinpthread or nowhere, and the bundled zig links neither). The tier is now split: a shared `_WIN32` section for what neither ABI provides, MSVC-only for what mingw genuinely has (`_isatty`/`_write` forwards, `mkstemp`, dirent trio). Reproduced + verified on Linux via `zig cc -target x86_64-windows-gnu`: importing time+fs+net+process+term+http linked with 13 undefined symbols before, links clean now.

2. **"package not found" was a masked transport failure.** `__httpc_tmpdir` was TMPDIR-or-`/tmp`; Windows spells it TEMP/TMP and has no `/tmp`, so every registry request died staging its response tempfile before curl was even spawned — zero network calls, reported as not-found. Temp dir now resolves TMPDIR → TEMP → TMP → `/tmp`, and `pkg_fetch_index` reports transport failures as transport failures (URL + hint), staying silent only for a genuine 404. Machines where it always worked (LLVM present → MSVC path; `C:\tmp` exists) behave identically.

The Windows smoke test now imports the wide stdlib surface and calls `now_ms` under both compiler paths — the core/io-only smoke was blind to exactly this class. (The Windows leg runs on push to main; the MinGW link fix is verified in this PR by the Linux zig cross-link repro.)

Ships to users with the next toolchain release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVrMqaqvW8shK9Fhz8P27s