### PR TITLE
nurl_api discovers runtime builtins: stdlib/core/builtins.nu + harmless FFI redeclares

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,14 @@ jobs:
         # globally unique.
         run: ./tools/check_stdlib_symbols.sh
 
+      - name: runtime-builtins doc module in sync with the compiler preamble
+        # stdlib/core/builtins.nu is the hand-written, nurl_api-indexed
+        # documentation of the pre-registered C-runtime surface
+        # (nurl_str_float, nurl_println, …). Its authoritative list is
+        # the __emit_rt_decl preamble in compiler/nurlc.nu; assert the
+        # two agree in both directions so discovery never lies.
+        run: ./tools/check_builtins_doc.sh
+
       - name: served installers match the canonical ones
         # nurlweb/public/install.{sh,ps1} are copies of tools/get-nurl.*
         # made by a MANUAL npm script, and they are what nurl-lang.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The runtime-builtin surface is discoverable** (`stdlib/core/builtins.nu`).
+  Field report: `nurl_api query='float string convert'` returned zero stdlib
+  hits even though `nurl_str_float` exists — it is a C-runtime builtin the
+  compiler pre-registers, not a stdlib declaration, so no indexed surface
+  mentioned it. The whole pre-registered surface (114 functions: printing,
+  stdin, conversions, byte scanning, files, process/args/env, output capture,
+  allocators, raw HTTP/subprocess/TCP-TLS handles, panic/recover, the libc
+  pass-throughs) now lives in a documented module that nurldoc renders,
+  `nurl_api` indexes, and `nurl_grep` / `nurl_read_stdlib` see. Hand-written
+  prose, machine-checked list: `tools/check_builtins_doc.sh` gates it against
+  the compiler preamble in CI, both directions.
+
+- **FFI-redeclaring a runtime builtin is now harmless.** `& `c` @
+  nurl_str_float f x → s` used to make LLVM reject the whole module with
+  "invalid redefinition of function", because the compiler re-emitted a
+  `declare` its own preamble already carried. The preamble now marks each
+  symbol it declares with the same dedup key user FFI declarations use, so
+  the duplicate is skipped — which is also what lets `core/builtins.nu` be
+  imported at all.
+
 - **Extensionless import paths.** The grammar's own import examples write
   `$ `stdlib/core/string`` — extensionless — while the compiler required
   `.nu` and rejected the documented spelling with a bare

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -17479,7 +17479,28 @@
 
 // ── Module header ──────────────────────────────────────────────────
 
-@ emit_header → v {
+// Emit one preamble runtime `declare` line AND mark its symbol as
+// already declared (`<name>__ffi_emitted` — the same dedup key
+// gen_ffi_decl uses between duplicate user FFI declares). A later user
+// FFI declaration of the same builtin (`& `c` @ nurl_str_float …`,
+// e.g. via stdlib/core/builtins.nu, which redeclares this whole
+// surface for documentation) then skips its own `declare`, instead of
+// producing a duplicate LLVM rejects with "invalid redefinition of
+// function". The symbol name is parsed out of the line (between '@'
+// and '(') so the list below stays single-source.
+@ __emit_rt_decl i syms s line → v {
+    ( emit line )
+    : i at ( nurl_str_find line `@` )
+    ? >= at 0 {
+        : i lp ( nurl_str_find line `(` )
+        ? > lp at {
+            : s nm ( nurl_str_slice line + at 1 - lp + at 1 )
+            ( nurl_sym_def syms ( nurl_str_cat nm `__ffi_emitted` ) `1` )
+        } {}
+    } {}
+}
+
+@ emit_header i syms → v {
     ( emit `; NURL compiler output (nurlc.nu)` )
     ( emit `; link: clang <this.ll> stdlib/runtime.o -o out` )
     ( emit `` )
@@ -17487,114 +17508,114 @@
     // variable's storage to its !DILocalVariable metadata. Emitted
     // unconditionally; with --g off the compiler never calls it, so
     // the unused declaration is dead and the optimizer drops it.
-    ( emit `declare void @llvm.dbg.declare(metadata, metadata, metadata)` )
-    ( emit `declare i32  @puts(i8*)` )
-    ( emit `declare i32  @printf(i8*, ...)` )
-    ( emit `declare i8*  @malloc(i64)` )
-    ( emit `declare void @free(i8*)` )
+    ( __emit_rt_decl syms `declare void @llvm.dbg.declare(metadata, metadata, metadata)` )
+    ( __emit_rt_decl syms `declare i32  @puts(i8*)` )
+    ( __emit_rt_decl syms `declare i32  @printf(i8*, ...)` )
+    ( __emit_rt_decl syms `declare i8*  @malloc(i64)` )
+    ( __emit_rt_decl syms `declare void @free(i8*)` )
     // libc string / parse primitives — declared here so the pure-NURL
     // `nurl_str_*` helpers can call them globally without per-file
     // `&`-FFI declarations. Returns mapped at their native C widths
     // (i32 for int-returners, i8* for ptr-returners); NURL callers do
     // their own widening via `# i` if they need i64.
-    ( emit `declare i64  @strlen(i8*)` )
-    ( emit `declare i32  @strcmp(i8*, i8*)` )
-    ( emit `declare i32  @strncmp(i8*, i8*, i64)` )
-    ( emit `declare i32  @memcmp(i8*, i8*, i64)` )
-    ( emit `declare i8*  @strstr(i8*, i8*)` )
-    ( emit `declare i8*  @memmem(i8*, i64, i8*, i64)` )
-    ( emit `declare i64  @atoll(i8*)` )
-    ( emit `declare double @atof(i8*)` )
-    ( emit `declare double @strtod(i8*, i8**)` )
-    ( emit `declare i8*  @memcpy(i8*, i8*, i64)` )
-    ( emit `declare i8*  @strdup(i8*)` )
+    ( __emit_rt_decl syms `declare i64  @strlen(i8*)` )
+    ( __emit_rt_decl syms `declare i32  @strcmp(i8*, i8*)` )
+    ( __emit_rt_decl syms `declare i32  @strncmp(i8*, i8*, i64)` )
+    ( __emit_rt_decl syms `declare i32  @memcmp(i8*, i8*, i64)` )
+    ( __emit_rt_decl syms `declare i8*  @strstr(i8*, i8*)` )
+    ( __emit_rt_decl syms `declare i8*  @memmem(i8*, i64, i8*, i64)` )
+    ( __emit_rt_decl syms `declare i64  @atoll(i8*)` )
+    ( __emit_rt_decl syms `declare double @atof(i8*)` )
+    ( __emit_rt_decl syms `declare double @strtod(i8*, i8**)` )
+    ( __emit_rt_decl syms `declare i8*  @memcpy(i8*, i8*, i64)` )
+    ( __emit_rt_decl syms `declare i8*  @strdup(i8*)` )
     // libc stdio primitives — declared here so the pure-NURL
     // `nurl_file_*` helpers in stdlib/std/fs.nu can call them
     // globally.
-    ( emit `declare i8*  @fopen(i8*, i8*)` )
-    ( emit `declare i32  @fclose(i8*)` )
-    ( emit `declare i32  @fputs(i8*, i8*)` )
-    ( emit `declare i64  @fwrite(i8*, i64, i64, i8*)` )
-    ( emit `declare i32  @fputc(i32, i8*)` )
-    ( emit `declare i64  @fread(i8*, i64, i64, i8*)` )
-    ( emit `declare i32  @feof(i8*)` )
+    ( __emit_rt_decl syms `declare i8*  @fopen(i8*, i8*)` )
+    ( __emit_rt_decl syms `declare i32  @fclose(i8*)` )
+    ( __emit_rt_decl syms `declare i32  @fputs(i8*, i8*)` )
+    ( __emit_rt_decl syms `declare i64  @fwrite(i8*, i64, i64, i8*)` )
+    ( __emit_rt_decl syms `declare i32  @fputc(i32, i8*)` )
+    ( __emit_rt_decl syms `declare i64  @fread(i8*, i64, i64, i8*)` )
+    ( __emit_rt_decl syms `declare i32  @feof(i8*)` )
     // fseek/ftell — POSIX stdio file-position primitives. Pure-NURL
     // file_size + future random-access I/O use these to learn the
     // file's length without going through `stat(2)` (whose `struct
     // stat` layout varies per platform). SEEK_END = 2 universally.
-    ( emit `declare i32  @fseek(i8*, i64, i32)` )
-    ( emit `declare i64  @ftell(i8*)` )
+    ( __emit_rt_decl syms `declare i32  @fseek(i8*, i64, i32)` )
+    ( __emit_rt_decl syms `declare i64  @ftell(i8*)` )
     // POSIX access(2) for the pure-NURL nurl_file_exists @-fn.
-    ( emit `declare i32  @access(i8*, i32)` )
+    ( __emit_rt_decl syms `declare i32  @access(i8*, i32)` )
     // getenv(3) — import-path resolution consults $NURL_STDLIB so an
     // installed toolchain finds stdlib regardless of cwd (see
     // __norm_import_path).
-    ( emit `declare i8*  @getenv(i8*)` )
+    ( __emit_rt_decl syms `declare i8*  @getenv(i8*)` )
     // realpath(3) — the import DEDUP key is the canonical path so the same
     // file reached through two symlink chains (diamond package deps:
     // deps/a/deps/gpu vs deps/gpu) compiles exactly once (see
     // __canon_import_key). Diagnostics keep the as-written path.
-    ( emit `declare i8*  @realpath(i8*, i8*)` )
-    ( emit `declare void @nurl_init(i32, i8**)` )
-    ( emit `declare void @nurl_print(i8*)` )
-    ( emit `declare void @nurl_println(i8*)` )
-    ( emit `declare void @nurl_eprint(i8*)` )
-    ( emit `declare void @nurl_eprintln(i8*)` )
-    ( emit `declare void @nurl_print_int(i64)` )
-    ( emit `declare void @nurl_print_str(i8*)` )
-    ( emit `declare void @nurl_print_bool(i1)` )
-    ( emit `declare i64  @nurl_read_int()` )
-    ( emit `declare i8*  @nurl_read_line()` )
+    ( __emit_rt_decl syms `declare i8*  @realpath(i8*, i8*)` )
+    ( __emit_rt_decl syms `declare void @nurl_init(i32, i8**)` )
+    ( __emit_rt_decl syms `declare void @nurl_print(i8*)` )
+    ( __emit_rt_decl syms `declare void @nurl_println(i8*)` )
+    ( __emit_rt_decl syms `declare void @nurl_eprint(i8*)` )
+    ( __emit_rt_decl syms `declare void @nurl_eprintln(i8*)` )
+    ( __emit_rt_decl syms `declare void @nurl_print_int(i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_print_str(i8*)` )
+    ( __emit_rt_decl syms `declare void @nurl_print_bool(i1)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_read_int()` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_read_line()` )
     // nurl_read_n_bytes lives as pure NURL `read_n_bytes` in
     // `stdlib/core/io.nu`; it reads stdin via `nurl_stdin_read`
     // (declared by FFI in stdlib/core/posix.nu, no built-in declare).
-    ( emit `declare i64  @nurl_stdin_eof()` )
-    ( emit `declare void @nurl_flush_stdout()` )
-    ( emit `declare void @nurl_flush_stderr()` )
+    ( __emit_rt_decl syms `declare i64  @nurl_stdin_eof()` )
+    ( __emit_rt_decl syms `declare void @nurl_flush_stdout()` )
+    ( __emit_rt_decl syms `declare void @nurl_flush_stderr()` )
     // nurl_str_get / _cat / _cat3 / _cat4 / _slice / _parse_int_range
     // / _parse_float_range are pure-NURL @-fns — no preamble declare
     // here to avoid clashing with their `define`s in user code and
     // the local copies inside nurlc.nu itself.  _str_int and
     // _str_float stay in C (printf-family %g, Grisu/Ryu TODO).
-    ( emit `declare i8*  @nurl_str_int(i64)` )
-    ( emit `declare i8*  @nurl_str_float(double)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_str_int(i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_str_float(double)` )
     // nurl_str_len / _eq / _cmp / _to_int / _to_float / _starts /
     // _find / _ends / _memmem_range / _memcmp_lex are pure-NURL
     // @-fns (libc-thin wrappers calling strlen / strcmp / strncmp /
     // strstr / memcmp / memmem / atoll / atof directly via the global
     // preamble declarations emitted above).
-    ( emit `declare i64    @nurl_scan_byte3(i8*, i64, i64, i64, i64)` )
-    ( emit `declare i64    @nurl_byte_substr(i8*, i64, i8*, i64)` )
-    ( emit `declare i64    @nurl_count_byte(i8*, i64, i64)` )
-    ( emit `declare double @nurl_fast_atof(i8*, i64)` )
+    ( __emit_rt_decl syms `declare i64    @nurl_scan_byte3(i8*, i64, i64, i64, i64)` )
+    ( __emit_rt_decl syms `declare i64    @nurl_byte_substr(i8*, i64, i8*, i64)` )
+    ( __emit_rt_decl syms `declare i64    @nurl_count_byte(i8*, i64, i64)` )
+    ( __emit_rt_decl syms `declare double @nurl_fast_atof(i8*, i64)` )
     // nurl_str_slice is a pure-NURL @-fn.
     // nurl_map_* (string→i64) is not part of the runtime — use the
     // generic `stdlib/std/hashmap.nu` HashMap[K V] at [s i] instead.
-    ( emit `declare i8*  @nurl_read_file(i8*)` )
-    ( emit `declare void @nurl_exit(i64)` )
-    ( emit `declare i64  @nurl_argc()` )
-    ( emit `declare i8*  @nurl_argv(i64)` )
-    ( emit `declare i64  @nurl_argv_count()` )
-    ( emit `declare i8*  @nurl_argv_get(i64)` )
-    ( emit `declare i8*  @nurl_version()` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_read_file(i8*)` )
+    ( __emit_rt_decl syms `declare void @nurl_exit(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_argc()` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_argv(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_argv_count()` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_argv_get(i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_version()` )
     // nurl_lex_* are pure-NURL @-fns in compiler/nurlc.nu (see the
     // §6a Lexer block).
-    ( emit `declare void @nurl_print_buf_start()` )
-    ( emit `declare i8*  @nurl_print_buf_stop()` )
-    ( emit `declare void @nurl_print_buf_reset()` )
+    ( __emit_rt_decl syms `declare void @nurl_print_buf_start()` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_print_buf_stop()` )
+    ( __emit_rt_decl syms `declare void @nurl_print_buf_reset()` )
     // nurl_lex_filename, nurl_sym_*, nurl_cg_*, nurl_get_last_type
     // and _set_last_type are pure-NURL @-fns (see top of this file).
-    ( emit `declare i8*  @nurl_malloc(i64)` )
-    ( emit `declare i8*  @nurl_alloc(i64)` )
-    ( emit `declare i8*  @nurl_zalloc(i64)` )
-    ( emit `declare i8*  @nurl_realloc(i8*, i64)` )
-    ( emit `declare void @nurl_free(i8*)` )
-    ( emit `declare void @nurl_journal_push(i8*)` )
-    ( emit `declare void @nurl_journal_push_drop(i8*, ptr)` )
-    ( emit `declare void @nurl_journal_forget(i8*)` )
-    ( emit `declare void @nurl_memcpy(i8*, i8*, i64)` )
-    ( emit `declare void @nurl_memmove(i8*, i8*, i64)` )
-    ( emit `declare void @nurl_memset(i8*, i64, i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_malloc(i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_alloc(i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_zalloc(i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_realloc(i8*, i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_free(i8*)` )
+    ( __emit_rt_decl syms `declare void @nurl_journal_push(i8*)` )
+    ( __emit_rt_decl syms `declare void @nurl_journal_push_drop(i8*, ptr)` )
+    ( __emit_rt_decl syms `declare void @nurl_journal_forget(i8*)` )
+    ( __emit_rt_decl syms `declare void @nurl_memcpy(i8*, i8*, i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_memmove(i8*, i8*, i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_memset(i8*, i64, i64)` )
     // ── The memory accessors are DEFINED here, not declared ───────
     //
     // `nurl_peek` is a null check and a load, and it is what every Vec
@@ -17638,7 +17659,7 @@
     ( emit `pw.done:` )
     ( emit `  ret void` )
     ( emit `}` )
-    ( emit `declare void @nurl_vec_drop(i8*, ptr, i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_vec_drop(i8*, ptr, i64)` )
     // nurl_file_* (open/write/write_range/write_byte/close/read_chunk
     // /eof/exists/del/dir_create/dir_remove) are pure-NURL @-fns in
     // stdlib/std/fs.nu, calling libc fopen/fputs/fwrite/fputc/fclose/
@@ -17648,43 +17669,43 @@
     // libm wrappers and nurl_iabs / _ipow are pure-NURL (libm direct
     // FFI in stdlib/std/float.nu; iabs/ipow as plain @-fns in
     // stdlib/std/int.nu).
-    ( emit `declare i64    @nurl_is_nan(double)` )
-    ( emit `declare i64    @nurl_is_inf(double)` )
-    ( emit `declare i64  @nurl_dir_list_open(i8*)` )
-    ( emit `declare i8*  @nurl_dir_list_next(i64)` )
-    ( emit `declare void @nurl_dir_list_close(i64)` )
-    ( emit `declare i64  @nurl_http_perform_full(i8*, i8*, i8*, i8*)` )
-    ( emit `declare i64  @nurl_http_perform_full_to(i8*, i8*, i8*, i8*, i64, i64)` )
+    ( __emit_rt_decl syms `declare i64    @nurl_is_nan(double)` )
+    ( __emit_rt_decl syms `declare i64    @nurl_is_inf(double)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_dir_list_open(i8*)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_dir_list_next(i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_dir_list_close(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_http_perform_full(i8*, i8*, i8*, i8*)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_http_perform_full_to(i8*, i8*, i8*, i8*, i64, i64)` )
     // The 7 accessors (status / err_kind / body / body_len /
     // header_count / header_name / header_value) are pure-NURL @-fns
     // in stdlib/ext/http.nu that read the NurlHttpResponse struct via
     // nurl_peek. Only the C-side freer stays — it walks the headers
     // array deallocating every name/value pair.
-    ( emit `declare void @nurl_http_response_free(i64)` )
-    ( emit `declare i64  @nurl_http_stream_open_to(i8*, i8*, i8*, i8*, i64, i64)` )
-    ( emit `declare i8*  @nurl_http_stream_next(i64)` )
-    ( emit `declare void @nurl_http_stream_close(i64)` )
-    ( emit `declare i64  @nurl_http_stream_pump_headers(i64)` )
-    ( emit `declare i64  @nurl_proc_run(i8*, i8*, i64, i8*)` )
-    ( emit `declare i64  @nurl_proc_exit_code(i64)` )
-    ( emit `declare i64  @nurl_proc_err_kind(i64)` )
-    ( emit `declare i8*  @nurl_proc_stdout(i64)` )
-    ( emit `declare i8*  @nurl_proc_stderr(i64)` )
-    ( emit `declare i64  @nurl_proc_stdout_len(i64)` )
-    ( emit `declare i64  @nurl_proc_stderr_len(i64)` )
-    ( emit `declare void @nurl_proc_free(i64)` )
-    ( emit `declare i64  @nurl_proc_spawn(i8*, i8*, i64)` )
-    ( emit `declare i64  @nurl_proc_spawn_err_kind(i64)` )
-    ( emit `declare i64  @nurl_proc_spawn_pid(i64)` )
-    ( emit `declare i64  @nurl_proc_spawn_write(i64, i8*, i64)` )
-    ( emit `declare void @nurl_proc_spawn_close_stdin(i64)` )
-    ( emit `declare i8*  @nurl_proc_spawn_read_line(i64, i64)` )
-    ( emit `declare i64  @nurl_proc_spawn_read_line_len(i64)` )
-    ( emit `declare i64  @nurl_proc_spawn_eof(i64)` )
-    ( emit `declare i64  @nurl_proc_spawn_last_io_err(i64)` )
-    ( emit `declare i64  @nurl_proc_spawn_wait(i64)` )
-    ( emit `declare i64  @nurl_proc_spawn_kill(i64, i64)` )
-    ( emit `declare void @nurl_proc_spawn_free(i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_http_response_free(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_http_stream_open_to(i8*, i8*, i8*, i8*, i64, i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_http_stream_next(i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_http_stream_close(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_http_stream_pump_headers(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_run(i8*, i8*, i64, i8*)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_exit_code(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_err_kind(i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_proc_stdout(i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_proc_stderr(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_stdout_len(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_stderr_len(i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_proc_free(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_spawn(i8*, i8*, i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_spawn_err_kind(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_spawn_pid(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_spawn_write(i64, i8*, i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_proc_spawn_close_stdin(i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_proc_spawn_read_line(i64, i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_spawn_read_line_len(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_spawn_eof(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_spawn_last_io_err(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_spawn_wait(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_proc_spawn_kill(i64, i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_proc_spawn_free(i64)` )
     // Crypto hash transforms (SHA-1/256/512, MD5, HMAC-SHA-256/512)
     // live in pure NURL under `stdlib/std/hash_*.nu`. Random surface
     // (`rand_u64` / `rand_hex_str`) is in `stdlib/std/random.nu`;
@@ -17693,32 +17714,32 @@
     // nurl_read_file_bytes / nurl_write_file_bytes / nurl_last_bytes_len
     // are pure NURL in `stdlib/std/fs.nu`; fread / fwrite write into
     // Vec[u]'s data buffer, vec_set_len records the count.
-    ( emit `declare i64  @nurl_tcp_listen(i8*, i64, i64)` )
-    ( emit `declare i64  @nurl_tcp_listen_tls(i8*, i64, i64, i8*, i8*)` )
-    ( emit `declare i64  @nurl_tcp_listen_tls_alpn(i8*, i64, i64, i8*, i8*, i8*)` )
-    ( emit `declare i8*  @nurl_tcp_alpn_selected(i64)` )
-    ( emit `declare i64  @nurl_tcp_tls_add_sni(i64, i8*, i8*, i8*)` )
-    ( emit `declare i64  @nurl_tcp_tls_reload(i64, i8*, i8*, i8*)` )
-    ( emit `declare i64  @nurl_tcp_tls_require_client_cert(i64, i8*, i64)` )
-    ( emit `declare i8*  @nurl_tcp_peer_cert_subject(i64)` )
-    ( emit `declare i64  @nurl_tcp_accept(i64)` )
-    ( emit `declare i64  @nurl_tcp_read(i64, i8*, i64)` )
-    ( emit `declare i64  @nurl_tcp_write(i64, i8*, i64)` )
-    ( emit `declare void @nurl_tcp_close(i64)` )
-    ( emit `declare void @nurl_tcp_shutdown(i64)` )
-    ( emit `declare i64  @nurl_tcp_err_kind(i64)` )
-    ( emit `declare i8*  @nurl_tcp_peer_addr(i64)` )
-    ( emit `declare void @nurl_tcp_set_timeout(i64, i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_tcp_listen(i8*, i64, i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_tcp_listen_tls(i8*, i64, i64, i8*, i8*)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_tcp_listen_tls_alpn(i8*, i64, i64, i8*, i8*, i8*)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_tcp_alpn_selected(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_tcp_tls_add_sni(i64, i8*, i8*, i8*)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_tcp_tls_reload(i64, i8*, i8*, i8*)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_tcp_tls_require_client_cert(i64, i8*, i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_tcp_peer_cert_subject(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_tcp_accept(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_tcp_read(i64, i8*, i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_tcp_write(i64, i8*, i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_tcp_close(i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_tcp_shutdown(i64)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_tcp_err_kind(i64)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_tcp_peer_addr(i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_tcp_set_timeout(i64, i64)` )
     // Thread / mutex / cond live in pure-NURL FFI in
     // stdlib/std/thread.nu — libpthread symbols (pthread_create /
     // mutex_* / cond_*) plus the tiny nurl_pthread_join_ptr /
     // _detach_ptr trampolines are declared on-demand in that module
     // via `& `c` @ ...`.
-    ( emit `declare void @nurl_signal_install_shutdown(i64)` )
-    ( emit `declare void @nurl_signal_trigger_shutdown()` )
-    ( emit `declare void @nurl_panic(i8*)` )
-    ( emit `declare i64  @nurl_recover(i8*, i8*)` )
-    ( emit `declare i8*  @nurl_panic_last_msg()` )
+    ( __emit_rt_decl syms `declare void @nurl_signal_install_shutdown(i64)` )
+    ( __emit_rt_decl syms `declare void @nurl_signal_trigger_shutdown()` )
+    ( __emit_rt_decl syms `declare void @nurl_panic(i8*)` )
+    ( __emit_rt_decl syms `declare i64  @nurl_recover(i8*, i8*)` )
+    ( __emit_rt_decl syms `declare i8*  @nurl_panic_last_msg()` )
     ( emit `` )
 }
 
@@ -20099,7 +20120,7 @@
     // where the hazard is most common.
     = g_ptrtab ( nurl_sym_new )
     ( vis_set_current_src_file path )
-    ( emit_header )
+    ( emit_header syms )
     ? != g_dbg_enabled 0 { ( dbg_init path ) } {}
     ( init_syms syms )
     : i lex0 ( nurl_lex_new src path )

--- a/compiler/tests/builtins_import.nu
+++ b/compiler/tests/builtins_import.nu
@@ -1,0 +1,22 @@
+// builtins_import.nu — stdlib/core/builtins.nu (the documentation
+// module for the compiler's pre-registered C-runtime surface) must be
+// importable: every `& `c` @` line in it redeclares a symbol whose
+// `declare` the emitted preamble already carries, and the compiler
+// must skip the duplicate declare (LLVM rejects redefinitions) while
+// keeping the call path working. Exercises one symbol per declare
+// shape: s→v, f→s, (s,i,i)→i, ()→s, b→v, i32-typed libc.
+//
+// Determinism: pure computation + stdout, no clock/socket/env.
+
+$ `stdlib/core/builtins.nu`
+
+@ main → i {
+    ( nurl_println ( nurl_str_float 2.5 ) )
+    ( nurl_println ( nurl_str_int -42 ) )
+    ( nurl_print_int ( nurl_count_byte `abcabc` 6 97 ) )
+    ( nurl_print_int ( nurl_byte_substr `hello world` 11 `world` 5 ) )
+    ( nurl_print_bool F )
+    ( nurl_print_int # i ( strcmp `same` `same` ) )
+    ( nurl_print_int ( nurl_is_nan 1.5 ) )
+    ^ 0
+}

--- a/compiler/tests/outputs/builtins_import.txt
+++ b/compiler/tests/outputs/builtins_import.txt
@@ -1,0 +1,11 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+2.5
+-42
+2
+6
+false
+0
+0

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -5047,7 +5047,7 @@ s combined_stdout s combined_stderr → v {
     ( __mcp_schema_changelog ) ) )
 
     ( json_arr_push arr ( __mcp_tool_desc `nurl_api`
-    `A stdlib module's API surface, a published package's API surface, or a search across all stdlib modules — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders one stdlib module's signatures + doc comments + full type definitions, no function bodies. package='nn' renders a registry package's API the same way (streamed from its tarball) — the step after a registry hit to see the functions/types it exposes. query='csv quote' finds every stdlib declaration whose signature/doc/module-path contains ALL terms (0 hits widen to examples + registry).`
+    `A stdlib module's API surface, a published package's API surface, or a search across all stdlib modules — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders one stdlib module's signatures + doc comments + full type definitions, no function bodies. package='nn' renders a registry package's API the same way (streamed from its tarball) — the step after a registry hit to see the functions/types it exposes. query='csv quote' finds every stdlib declaration whose signature/doc/module-path contains ALL terms (0 hits widen to examples + registry). The import-free C-runtime builtins (nurl_println, nurl_str_float, …) are indexed too, as core/builtins.nu.`
     ( __mcp_schema_api ) ) )
 
     ( json_arr_push arr ( __mcp_tool_desc `nurl_grep`

--- a/packages/nurl-mcp/nurl.toml
+++ b/packages/nurl-mcp/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nurl-mcp"
-version = "0.7.2"
+version = "0.7.3"
 description = "Local MCP server for the NURL toolchain — exposes the installed compiler over Model Context Protocol so an LLM agent on the host can build, run, type-check, format, and compile NURL to wasm32-wasi (fully local wasm builds via the wasmbuilder package), read the installed stdlib, browse its API surface — the stdlib's or a published registry package's (nurl_api, package=) — without function bodies, search stdlib + the package registry (by name, description, or exported symbol) with ranked word boundaries (nurl_grep), and compile a program that USES a registry package end to end, resolving its dependencies (nurl_build_project). Stdio by default; an optional token-authenticated HTTP transport (--http) gates code execution behind --allow-run. The editor-facing counterpart of nurl-lsp, for LLMs."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl/tree/main/packages/nurl-mcp"

--- a/packages/nurl-mcp/src/main.nu
+++ b/packages/nurl-mcp/src/main.nu
@@ -59,7 +59,7 @@ $ `deps/wasmbuilder/src/build.nu`
 // to bump (previously the banners drifted to a stale 0.2.0 while the
 // handshake reported 0.4.0).
 
-@ nm_version → s { ^ `0.7.1` }
+@ nm_version → s { ^ `0.7.3` }
 
 // Log a startup banner "nurl-mcp <version> <suffix>" through mcp_log,
 // building the line from the single-source version so the banners can
@@ -997,7 +997,7 @@ version = "0.0.0"
     `Read one module from the installed standard library by relative path.`
     ( nm_schema_name ) ) )
     ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_api`
-    `A stdlib module's API surface, or a search across all of them — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders signatures + doc comments + type definitions; query='csv quote' finds matching declarations. Zero hits widen to the package registry; an exact package-name term is footnoted regardless.`
+    `A stdlib module's API surface, or a search across all of them — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders signatures + doc comments + type definitions; query='csv quote' finds matching declarations. The import-free C-runtime builtins (nurl_println, nurl_str_float, …) are indexed too, as core/builtins.nu. Zero hits widen to the package registry; an exact package-name term is footnoted regardless.`
     ( nm_schema_api ) ) )
     ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_grep`
     `Case-insensitive search across the installed stdlib (path:line: text; word-boundary matches ranked first, in-word substring hits in a labeled tail) and the package registry (name + description) — "is there a package for X" works from any MCP-only editor. word=true for short acronyms.`

--- a/stdlib/core/builtins.nu
+++ b/stdlib/core/builtins.nu
@@ -1,0 +1,366 @@
+// stdlib/core/builtins.nu — the compiler's pre-registered runtime
+// surface, as a documented module.
+//
+// Every function below is callable from ANY NURL program with no
+// import at all: the compiler pre-registers these C-runtime symbols
+// (they live in stdlib/runtime_core.c / runtime_ffi.c) and emits
+// their `declare` lines into every module it compiles. This file
+// exists so that surface is *discoverable* — nurldoc renders it,
+// nurl_api indexes it, nurl_grep and nurl_read_stdlib see it — and a
+// newcomer doesn't have to know which surface a symbol lives on.
+//
+// Importing this file is allowed and harmless (the compiler skips a
+// duplicate `declare` for a symbol its preamble already carries), but
+// it is never necessary.
+//
+// HAND-SYNCED with the preamble list in compiler/nurlc.nu;
+// tools/check_builtins_doc.sh gates the two against each other in CI.
+//
+// Most of these have a friendlier, Result-typed stdlib wrapper — each
+// section names it. Prefer the wrapper unless you need the raw call.
+
+// ── Printing ────────────────────────────────────────────────────────
+// Formatted templates live in stdlib/std/fmt.nu (println_fmt1…4);
+// leveled logging in stdlib/std/log.nu.
+
+// Print a string to stdout with NO trailing newline. Flushes.
+& `c` @ nurl_print s text → v
+
+// Print a string to stdout followed by a newline.
+& `c` @ nurl_println s text → v
+
+// Print a string to stderr with NO trailing newline. Flushes.
+& `c` @ nurl_eprint s text → v
+
+// Print a string to stderr followed by a newline.
+& `c` @ nurl_eprintln s text → v
+
+// Print an integer to stdout followed by a newline.
+& `c` @ nurl_print_int i n → v
+
+// Print a string to stdout followed by a newline (libc puts).
+& `c` @ nurl_print_str s text → v
+
+// Print `true` or `false` to stdout followed by a newline.
+& `c` @ nurl_print_bool b x → v
+
+// Flush buffered stdout / stderr explicitly.
+& `c` @ nurl_flush_stdout → v
+
+& `c` @ nurl_flush_stderr → v
+
+// ── Reading stdin ───────────────────────────────────────────────────
+// Buffered line/byte readers with error handling live in
+// stdlib/std/bufio.nu.
+
+// Read one integer from stdin (skips leading whitespace); 0 at EOF —
+// check nurl_stdin_eof to tell the two apart.
+& `c` @ nurl_read_int → i
+
+// Read one line from stdin WITHOUT the trailing newline. Returns an
+// owned string; "" at EOF (check nurl_stdin_eof).
+& `c` @ nurl_read_line → s
+
+// 1 once a previous read hit end-of-file on stdin, else 0.
+& `c` @ nurl_stdin_eof → i
+
+// ── Number ↔ string conversion ─────────────────────────────────────
+// String-typed helpers (string_from, string_push_int, parse_int with
+// a Result) live in stdlib/core/string.nu and stdlib/std/float.nu.
+
+// Convert an integer to its decimal string form. Owned result.
+& `c` @ nurl_str_int i n → s
+
+// Convert a float (double) to its string form — shortest text that
+// round-trips back to the same double. Owned result.
+& `c` @ nurl_str_float f x → s
+
+// Parse a float from the first `len` bytes at `p` (fast path, no
+// locale). Prefer stdlib/std/float.nu's checked parsers for input
+// validation.
+& `c` @ nurl_fast_atof s p i len → f
+
+// libc: parse an integer / float from a NUL-terminated string.
+// No error reporting — 0 on garbage. Prefer string.nu / float.nu.
+& `c` @ atoll s text → i
+
+& `c` @ atof s text → f
+
+// ── Byte scanning (SIMD hot paths) ─────────────────────────────────
+// stdlib/std/bytes.nu and core/string.nu build on these.
+
+// Offset of the first byte in p[0..len) equal to b0, b1, or b2, else
+// `len`. SSE2-vectorised; duplicate a byte to scan for fewer targets.
+& `c` @ nurl_scan_byte3 s p i len i b0 i b1 i b2 → i
+
+// First-occurrence offset of needle[0..nlen) in hay[0..hlen), or -1.
+// Empty needle returns 0.
+& `c` @ nurl_byte_substr s hay i hlen s needle i nlen → i
+
+// Count occurrences of byte `target` in p[0..len). memchr loop.
+& `c` @ nurl_count_byte s p i len i target → i
+
+// libc string primitives (NUL-terminated).
+& `c` @ strlen s text → i
+
+& `c` @ strcmp s a s b → i32
+
+& `c` @ strncmp s a s b i n → i32
+
+& `c` @ memcmp s a s b i n → i32
+
+& `c` @ strstr s hay s needle → s
+
+& `c` @ memmem s hay i hlen s needle i nlen → s
+
+& `c` @ strdup s text → s
+
+& `c` @ memcpy s dst s src i n → s
+
+// ── Files & directories ────────────────────────────────────────────
+// The real file API — Result-typed read/write/append, path checks,
+// mkdir, glob — is stdlib/std/fs.nu. These are the raw calls.
+
+// Read an entire file into an owned NUL-terminated string.
+// EXITS THE PROCESS on open failure — use std/fs.nu's read_file for a
+// Result instead.
+& `c` @ nurl_read_file s path → s
+
+// Directory listing, one entry per call: open returns a handle (0 on
+// failure), next returns the entry name or "" when done, close frees.
+// Prefer std/fs.nu's dir_list (Vec of names, Result-typed).
+& `c` @ nurl_dir_list_open s path → i
+
+& `c` @ nurl_dir_list_next i handle → s
+
+& `c` @ nurl_dir_list_close i handle → v
+
+// libc stdio pass-throughs (FILE* carried as `s`).
+& `c` @ fopen s path s mode → s
+
+& `c` @ fclose s handle → i32
+
+& `c` @ fputs s text s handle → i32
+
+& `c` @ fwrite s buf i size i count s handle → i
+
+& `c` @ fputc i32 ch s handle → i32
+
+& `c` @ fread s buf i size i count s handle → i
+
+& `c` @ feof s handle → i32
+
+& `c` @ fseek s handle i offset i32 whence → i32
+
+& `c` @ ftell s handle → i
+
+& `c` @ access s path i32 mode → i32
+
+// ── Process, arguments, environment ────────────────────────────────
+// stdlib/std/args.nu parses flags on top of these.
+
+// Terminate the process with an exit code.
+& `c` @ nurl_exit i code → v
+
+// Command-line argument count / accessor (argv[0] = program path).
+// Out-of-range index returns "". Results are owned copies.
+& `c` @ nurl_argc → i
+
+& `c` @ nurl_argv i idx → s
+
+& `c` @ nurl_argv_count → i
+
+& `c` @ nurl_argv_get i idx → s
+
+// Toolchain version string, e.g. `0.28.0`.
+& `c` @ nurl_version → s
+
+// libc: environment variable value, or null. stdlib/ext/env.nu wraps
+// this with defaults (env_var_or).
+& `c` @ getenv s name → s
+
+// libc: canonical absolute path (symlinks/.. resolved); null on
+// failure. Pass null (`# *u 0`) as `resolved` to get a malloc'd result.
+& `c` @ realpath s path s resolved → s
+
+// ── Output capture ──────────────────────────────────────────────────
+
+// Redirect nurl_print/nurl_println into an in-memory buffer (stackable);
+// stop returns the captured text (owned) and pops, reset clears all.
+& `c` @ nurl_print_buf_start → v
+
+& `c` @ nurl_print_buf_stop → s
+
+& `c` @ nurl_print_buf_reset → v
+
+// ── Memory allocation ───────────────────────────────────────────────
+// Typed containers (Vec, String, Box, arena) in core/vec.nu,
+// core/string.nu, core/box.nu, core/mem.nu are the normal API; these
+// are the raw allocators beneath them.
+
+// Allocate `bytes` (small sizes hit a freelist cache) / zero-filled /
+// resize / free. nurl_malloc is the uncached variant.
+& `c` @ nurl_alloc i bytes → s
+
+& `c` @ nurl_zalloc i bytes → s
+
+& `c` @ nurl_realloc s ptr i bytes → s
+
+& `c` @ nurl_free s ptr → v
+
+& `c` @ nurl_malloc i bytes → s
+
+// Raw byte moves/fill over possibly-overlapping regions.
+& `c` @ nurl_memcpy s dst s src i n → v
+
+& `c` @ nurl_memmove s dst s src i n → v
+
+& `c` @ nurl_memset s dst i byte i n → v
+
+// libc allocator (prefer nurl_alloc/nurl_free, which the leak tooling
+// tracks).
+& `c` @ malloc i bytes → s
+
+& `c` @ free s ptr → v
+
+// ── Floats ──────────────────────────────────────────────────────────
+// Full float toolkit (bits, formatting, checked parse) in
+// stdlib/std/float.nu and std/floatbits.nu.
+
+// 1 when x is NaN / infinite, else 0.
+& `c` @ nurl_is_nan f x → i
+
+& `c` @ nurl_is_inf f x → i
+
+// ── HTTP (raw) ─────────────────────────────────────────────────────
+// USE stdlib/ext/http.nu — http_get/http_post and friends wrap these
+// handles with headers, TLS, redirects, and streaming.
+
+// One full request: returns a response handle (0 on failure). The _to
+// variant takes connect/total timeouts (ms).
+& `c` @ nurl_http_perform_full s method s url s headers s body → i
+
+& `c` @ nurl_http_perform_full_to s method s url s headers s body i connect_ms i total_ms → i
+
+& `c` @ nurl_http_response_free i handle → v
+
+// Streaming body: open a handle, pump headers, then read chunks until
+// "" (check EOF via the stream API in ext/http.nu).
+& `c` @ nurl_http_stream_open_to s method s url s headers s body i connect_ms i total_ms → i
+
+& `c` @ nurl_http_stream_next i handle → s
+
+& `c` @ nurl_http_stream_close i handle → v
+
+& `c` @ nurl_http_stream_pump_headers i handle → i
+
+// ── Subprocesses (raw) ─────────────────────────────────────────────
+// USE stdlib/std/process.nu — proc_run/proc_spawn wrap these with
+// Result types and owned output.
+
+// Run to completion: argv is NUL-joined, returns a handle; exit code,
+// captured stdout/stderr (+ byte lengths) via accessors; free releases.
+& `c` @ nurl_proc_run s argv s stdin_data i stdin_len s cwd → i
+
+& `c` @ nurl_proc_exit_code i handle → i
+
+& `c` @ nurl_proc_err_kind i handle → i
+
+& `c` @ nurl_proc_stdout i handle → s
+
+& `c` @ nurl_proc_stderr i handle → s
+
+& `c` @ nurl_proc_stdout_len i handle → i
+
+& `c` @ nurl_proc_stderr_len i handle → i
+
+& `c` @ nurl_proc_free i handle → v
+
+// Long-lived child with piped stdin/stdout: spawn, write, read lines,
+// wait/kill, free. err_kind/last_io_err report failures; eof is 1 when
+// the child's stdout closed.
+& `c` @ nurl_proc_spawn s argv s cwd i merge_stderr → i
+
+& `c` @ nurl_proc_spawn_err_kind i handle → i
+
+& `c` @ nurl_proc_spawn_pid i handle → i
+
+& `c` @ nurl_proc_spawn_write i handle s data i len → i
+
+& `c` @ nurl_proc_spawn_close_stdin i handle → v
+
+& `c` @ nurl_proc_spawn_read_line i handle i timeout_ms → s
+
+& `c` @ nurl_proc_spawn_read_line_len i handle → i
+
+& `c` @ nurl_proc_spawn_eof i handle → i
+
+& `c` @ nurl_proc_spawn_last_io_err i handle → i
+
+& `c` @ nurl_proc_spawn_wait i handle → i
+
+& `c` @ nurl_proc_spawn_kill i handle i sig → i
+
+& `c` @ nurl_proc_spawn_free i handle → v
+
+// ── TCP / TLS sockets (raw) ────────────────────────────────────────
+// USE stdlib/std/net.nu (+ ext/http_server.nu, std/tls.nu) — typed
+// listeners, accept loops, and the pure-NURL TLS 1.3 stack sit on top
+// of these.
+
+// Listen on host:port (backlog third); returns a socket handle or <0.
+// The _tls variants add PEM cert/key (and an ALPN protocol list).
+& `c` @ nurl_tcp_listen s host i port i backlog → i
+
+& `c` @ nurl_tcp_listen_tls s host i port i backlog s cert_pem s key_pem → i
+
+& `c` @ nurl_tcp_listen_tls_alpn s host i port i backlog s cert_pem s key_pem s alpn → i
+
+& `c` @ nurl_tcp_alpn_selected i conn → s
+
+& `c` @ nurl_tcp_tls_add_sni i listener s host s cert_pem s key_pem → i
+
+& `c` @ nurl_tcp_tls_reload i listener s host s cert_pem s key_pem → i
+
+& `c` @ nurl_tcp_tls_require_client_cert i listener s ca_pem i require → i
+
+& `c` @ nurl_tcp_peer_cert_subject i conn → s
+
+// Accept a connection; read/write raw bytes (return byte count, <0 on
+// error); close/shutdown; error kind, peer address, IO timeout (ms).
+& `c` @ nurl_tcp_accept i listener → i
+
+& `c` @ nurl_tcp_read i conn s buf i cap → i
+
+& `c` @ nurl_tcp_write i conn s buf i len → i
+
+& `c` @ nurl_tcp_close i conn → v
+
+& `c` @ nurl_tcp_shutdown i conn → v
+
+& `c` @ nurl_tcp_err_kind i conn → i
+
+& `c` @ nurl_tcp_peer_addr i conn → s
+
+& `c` @ nurl_tcp_set_timeout i conn i ms → v
+
+// ── Signals, panic, recover ────────────────────────────────────────
+
+// Install a SIGINT/SIGTERM handler that flips a shutdown flag servers
+// poll (std/net.nu accept loops honor it); trigger fires it manually.
+& `c` @ nurl_signal_install_shutdown i mode → v
+
+& `c` @ nurl_signal_trigger_shutdown → v
+
+// Abort with a message and unwind (destructors run, allocation journal
+// reclaims). Catch with the `recover` language form — these are its
+// runtime entry points; nurl_panic_last_msg returns the message inside
+// a recover arm.
+& `c` @ nurl_panic s msg → v
+
+& `c` @ nurl_recover s fn_ptr s env_ptr → i
+
+& `c` @ nurl_panic_last_msg → s
+
+// libc: print a string + newline to stdout.
+& `c` @ puts s text → i32

--- a/tools/check_builtins_doc.sh
+++ b/tools/check_builtins_doc.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/check_builtins_doc.sh — assert that the documentation
+#  module stdlib/core/builtins.nu stays in sync with the runtime
+#  preamble the compiler emits into every program.
+#
+#  stdlib/core/builtins.nu exists so the pre-registered C-runtime
+#  surface (nurl_str_float, nurl_println, …) is DISCOVERABLE —
+#  nurldoc renders it, nurl_api indexes it, nurl_grep sees it. It is
+#  hand-written (the doc prose is the point), so it can drift from
+#  the authoritative list: the `__emit_rt_decl syms `declare …``
+#  lines inside emit_header in compiler/nurlc.nu. This gate fails
+#  when the two disagree.
+#
+#  Direction 1: every preamble symbol must be documented in
+#  builtins.nu, unless listed in SKIP below (compiler/IR machinery a
+#  user never calls, or shapes NURL FFI cannot spell).
+#  Direction 2: every FFI name in builtins.nu must exist in the
+#  preamble — no stale entries after a runtime removal.
+# ============================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Deliberately undocumented preamble symbols:
+#   llvm.dbg.declare       — LLVM debug-info intrinsic, not callable
+#   nurl_init              — argv stash called by the generated main()
+#   nurl_journal_*         — panic-unwind allocation journal (compiler-emitted)
+#   nurl_vec_drop          — compiler-emitted container destructor hook
+#   printf                 — variadic libc; documented C everywhere
+#   strtod                 — i8** out-param; use float.nu's checked parsers
+SKIP='^(llvm\.dbg\.declare|nurl_init|nurl_journal_push|nurl_journal_push_drop|nurl_journal_forget|nurl_vec_drop|printf|strtod)$'
+
+preamble="$(grep -oE '__emit_rt_decl syms `declare [^`]+' compiler/nurlc.nu \
+  | grep -oE '@[A-Za-z0-9_.]+' | sed 's/^@//' | sort -u)"
+
+documented="$(grep -oE '^& `c` @ [A-Za-z0-9_]+' stdlib/core/builtins.nu \
+  | awk '{ print $4 }' | sort -u)"
+
+missing="$(comm -23 <(echo "$preamble" | grep -Ev "$SKIP") <(echo "$documented"))"
+stale="$(comm -13 <(echo "$preamble") <(echo "$documented"))"
+
+status=0
+if [ -n "$missing" ]; then
+    echo "ERROR: preamble builtins missing from stdlib/core/builtins.nu:" >&2
+    echo "$missing" | sed 's/^/  /' >&2
+    echo "Document them there (or add to SKIP in $0 with a reason)." >&2
+    status=1
+fi
+if [ -n "$stale" ]; then
+    echo "ERROR: stdlib/core/builtins.nu documents symbols the compiler preamble no longer declares:" >&2
+    echo "$stale" | sed 's/^/  /' >&2
+    echo "Remove them from builtins.nu." >&2
+    status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+    n="$(echo "$documented" | wc -l)"
+    echo "OK: stdlib/core/builtins.nu documents all $n non-skipped preamble builtins."
+fi
+exit "$status"


### PR DESCRIPTION
## What

Field feedback: `nurl_api query='float string convert'` returned **zero stdlib hits** even though `nurl_str_float` exists — it's a C-runtime builtin the compiler pre-registers, not a stdlib declaration, so the nurldoc-based index never saw that surface. (`nurl_grep` only found it via call sites.) A newcomer doesn't know which surface a symbol lives on.

Two root-cause pieces:

### `stdlib/core/builtins.nu` — the pre-registered runtime surface, as a documented module
All **114** import-free runtime functions (printing, stdin, number↔string conversion, SIMD byte scanning, files/dirs, process/args/env, output capture, allocators, raw HTTP/subprocess/TCP-TLS handles, panic/recover, libc pass-throughs) as FFI declarations with doc prose, each section pointing at its friendlier stdlib wrapper. nurldoc renders it → `nurl_api` indexes it → `nurl_grep` / `nurl_read_stdlib` see it, in **both** nurlapi and nurl-mcp via the shared `mcp_search` engine — no engine change needed.

Hand-written prose, machine-checked list: `tools/check_builtins_doc.sh` (wired into CI) gates the module against the compiler preamble in both directions (missing symbol ⇒ fail; stale symbol ⇒ fail). Skip-list (with reasons): `llvm.dbg.declare`, `nurl_init`, `nurl_journal_*`, `nurl_vec_drop`, `printf`, `strtod`.

### Compiler: FFI-redeclaring a preamble builtin no longer breaks the module
`& `c` @ nurl_str_float f x → s` used to re-emit a `declare` the preamble already carries → LLVM rejects the module with "invalid redefinition of function". `emit_header` now marks every preamble symbol with the same `<name>__ffi_emitted` dedup key user FFI declares use, so the duplicate is skipped. This makes importing `builtins.nu` safe, and unbreaks hand-written redeclares of builtins.

**Not** taken: skipping the declare whenever the symbol was already registered — the scan pre-pass registers *every* FFI name, so that silently dropped all FFI declares (caught by declare-parity diffing before it ever built).

## Verification

- `msearch_api_query 'float string convert'` now returns `core/builtins.nu › nurl_str_float` with its doc text (was: 0 hits, widened to registry).
- Declare-parity: IR declares byte-identical to the previous compiler on a program importing most of stdlib.
- New test `builtins_import.nu`: imports the module, calls one symbol per declare shape.
- Full suite **PASS 563 · FAIL 0**, bootstrap fixed point holds **without** a lastgood refresh (emitted IR unchanged).
- nurl-mcp compiles against the repo stdlib; nurlapi compiles.
- nurl-mcp bumped to **0.7.3** (also fixes `nm_version` lying: said 0.7.1 while nurl.toml said 0.7.2); tool descriptions in both servers now mention the builtins surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVrMqaqvW8shK9Fhz8P27s