### PR TITLE
MCP wasm builds return download links/paths, never inline base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed
+
+- **MCP build tools answer with links/paths, never an inline base64
+  module.** A compiled module returned as base64 in a tool result lands
+  verbatim in the calling model's context — hundreds of KB spent on bytes
+  the model can't read. The playground MCP tool `nurl_build_wasm` now
+  returns `wasm_artifact` + `ll_artifact` download URLs (backed by a new
+  `links_only:true` field on `POST /build_wasm`; the default REST response
+  keeps the inline `wasm_base64` the playground consumes, and now carries
+  the artifact objects too — `ll_artifact` even when the link step failed,
+  which is exactly when the IR is wanted). The local `nurl-mcp` server
+  (0.7.4) does the file-system equivalent: inline-source `nurl_build_wasm`
+  keeps the module and its `.ll` on disk and returns `wasm_path` /
+  `ll_path`, and `nurl_build_project` returns `binary_path` / `ll_path`
+  instead of `binary_base64`.
 
 ## [0.29.0] — 2026-07-30
 

--- a/nurlapi/e2e_test.py
+++ b/nurlapi/e2e_test.py
@@ -708,6 +708,57 @@ def t_build_wasm_libc_shims(c: Client) -> None:
     assert_true("no shim/call-site signature mismatch", not mismatched, "; ".join(mismatched))
 
 
+def t_tools_call_build_wasm(c: Client) -> None:
+    # The MCP tool must answer with download links, never the inline
+    # base64 module (which would land verbatim in the caller's context).
+    print("\n[MCP] tools/call nurl_build_wasm (links, no base64)")
+    src = '@ main → i {\n  ( puts `hello-wasm-mcp` )\n  ^ 0\n}\n'
+    env = _tool_call(c, "nurl_build_wasm", {"source": src, "filename": "hellow.nu"})
+    text = _tool_text(env)
+    try:
+        j = json.loads(text)
+    except json.JSONDecodeError:
+        bad("wasm build result is JSON text", f"got: {text[:200]!r}")
+        return
+    assert_eq("wasm build ok", j.get("status"), "ok")
+    assert_true("no inline wasm_base64", not j.get("wasm_base64"), "base64 present")
+    assert_true("no inline llvm_ir", not j.get("llvm_ir"), "llvm_ir present")
+    for key, suffix in (("wasm_artifact", ".wasm"), ("ll_artifact", ".ll")):
+        art = j.get(key)
+        if not isinstance(art, dict):
+            bad(f"{key} present", f"{key}={art!r}")
+            continue
+        assert_true(f"{key}.name ends {suffix}", str(art.get("name", "")).endswith(suffix))
+        assert_true(f"{key}.bytes > 0", int(art.get("bytes") or 0) > 0)
+        token = art.get("token")
+        assert_true(f"{key}.token present", bool(token))
+        status, _, body = c.get(f"/download/{token}")
+        assert_eq(f"{key} download → 200", status, 200)
+        if suffix == ".wasm":
+            assert_true("download body is wasm", body[:4] == b"\x00asm", f"prefix={body[:4]!r}")
+        else:
+            assert_true("download body looks like IR", b"target triple" in body[:400])
+
+
+def t_build_wasm_links_only_rest(c: Client) -> None:
+    # REST default keeps the inline base64 (the playground consumes it);
+    # links_only:true is the opt-out the MCP layer uses.
+    print("\n[REST] /build_wasm links_only:true")
+    src = '@ main → i {\n  ( puts `hello-wasm-rest` )\n  ^ 0\n}\n'
+    status, _, raw = c.post(
+        "/build_wasm",
+        {"source": src, "filename": "hellol.nu", "links_only": True},
+        timeout=180.0,
+    )
+    assert_eq("status 200", status, 200)
+    j = json.loads(raw)
+    assert_eq("build ok", j.get("status"), "ok")
+    assert_true("no wasm_base64", not j.get("wasm_base64"), f"keys={list(j)}")
+    assert_true("wasm_artifact present", isinstance(j.get("wasm_artifact"), dict))
+    assert_true("ll_artifact present", isinstance(j.get("ll_artifact"), dict))
+    assert_true("download_url still set", bool(j.get("download_url")))
+
+
 def t_get_sse_and_delete(c: Client) -> None:
     print("\n[MCP] GET /mcp (SSE stub) + DELETE /mcp")
     status, hdrs, raw = c.get("/mcp")
@@ -782,10 +833,14 @@ def main() -> int:
     t_tools_call_unknown(c)
     if not args.quick:
         t_tools_call_build(c)
+        t_tools_call_build_wasm(c)
         t_build_wasm_libc_shims(c)
+        t_build_wasm_links_only_rest(c)
     else:
         print("\n[MCP] tools/call nurl_build_native — skipped (--quick)")
+        print("[MCP] tools/call nurl_build_wasm — skipped (--quick)")
         print("[REST] /build_wasm libc shims — skipped (--quick)")
+        print("[REST] /build_wasm links_only — skipped (--quick)")
 
     t_resources(c)
     t_prompts(c)

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -1366,6 +1366,13 @@ s combined_stdout s combined_stderr → v {
             { ( json_free root ) ( string_free body_str )
                 ^ ( unsupported_target_response filename __wasm_nodep `WebAssembly` ) } {}
             : b emit_ll ( get_common_bool root `emit_ll` F )
+            // links_only:true (the MCP tool sets it) omits the inline
+            // wasm_base64 payload and the inline llvm_ir blob — the caller
+            // fetches them via wasm_artifact / ll_artifact download URLs
+            // instead of paying for a base64 copy in the response (and in
+            // the model's context, when the caller is an LLM). The
+            // playground keeps the default inline path.
+            : b links_only ( get_common_bool root `links_only` F )
             // /build_wasm opt level — defaults to -O1 (was -O2). On serde_demo /
             // claude_chat / json_basic the -O2 link step accounted for 14-24 s of
             // the perceived "playground feels slow"; -O1 produces ~5-15% larger
@@ -1560,25 +1567,41 @@ s combined_stdout s combined_stderr → v {
                             // code did) silently swallowed wasi-clang errors like
                             // "undefined symbol: canvas_open".
                             ( json_obj_set res `stderr` ( json_str_lit ( string_data combined_stderr ) ) )
-                            ( json_obj_set res `llvm_ir` ? | emit_ll != c_rc 0 { ( json_str_lit ( string_data ir_fixed ) ) } { ( json_null ) } )
+                            ( json_obj_set res `llvm_ir` ? & ! links_only | emit_ll != c_rc 0 { ( json_str_lit ( string_data ir_fixed ) ) } { ( json_null ) } )
                             ( json_obj_set res `uses_canvas` ( json_bool uses_canvas ) )
                             ( json_obj_set res `uses_audio` ( json_bool uses_audio ) )
+
+                            // The .ll is on disk whenever nurlc succeeded (we are
+                            // past the nok gate), so its artifact is exposed even
+                            // when the LINK failed — that is exactly when a caller
+                            // wants to inspect the IR.
+                            : !i IoErr ll_size_res ( file_size ( string_data ll_path ) )
+                            : i ll_bytes ?? ll_size_res { T s → s F _ → 0 }
+                            ( json_obj_set res `ll_artifact` ( make_artifact_json ( string_data ll_name ) ll_bytes ( string_data build_id ) ) )
 
                             : ~ String b64 ( string_new ) : ~ String wasm_url ( string_new )
                             ? == c_rc 0 {
                                 : !i IoErr wasm_size_res ( file_size ( string_data wasm_path ) )
                                 : i w_bytes ?? wasm_size_res { T s → s F _ → 0 }
                                 ( json_obj_set res `wasm_bytes` ( json_int w_bytes ) )
-                                : !( Vec u ) IoErr wasm_data_res ( read_file_bytes ( string_data wasm_path ) )
-                                ?? wasm_data_res { T w_data → {
-                                        : String b ( b64_encode_vec w_data ) ( json_obj_set res `wasm_base64` ( json_str_lit ( string_data b ) ) )
-                                        ( string_free b64 ) = b64 b ( vec_free [u] w_data ) } F _ → {} }
+                                // Artifact name = the file actually produced —
+                                // <bin>.async.wasm after the asyncify pass, not
+                                // the pre-instrumentation <bin>.wasm.
+                                : String final_name ( path_basename ( string_data wasm_path ) )
+                                ( json_obj_set res `wasm_artifact` ( make_artifact_json ( string_data final_name ) w_bytes ( string_data build_id ) ) )
+                                ? links_only {} {
+                                    : !( Vec u ) IoErr wasm_data_res ( read_file_bytes ( string_data wasm_path ) )
+                                    ?? wasm_data_res { T w_data → {
+                                            : String b ( b64_encode_vec w_data ) ( json_obj_set res `wasm_base64` ( json_str_lit ( string_data b ) ) )
+                                            ( string_free b64 ) = b64 b ( vec_free [u] w_data ) } F _ → {} }
+                                }
                                 = wasm_url ( string_with_cap 96 )
                                 : String w_base ( __public_base_url )
                                 ( string_push_str wasm_url ( string_data w_base ) )
                                 ( string_free w_base )
-                                ( string_push_str wasm_url `/download/` ) ( string_push_str wasm_url ( string_data build_id ) ) ( string_push_str wasm_url `/` ) ( string_push_str wasm_url ( string_data wasm_name ) )
+                                ( string_push_str wasm_url `/download/` ) ( string_push_str wasm_url ( string_data build_id ) ) ( string_push_str wasm_url `/` ) ( string_push_str wasm_url ( string_data final_name ) )
                                 ( json_obj_set res `download_url` ( json_str_lit ( string_data wasm_url ) ) )
+                                ( string_free final_name )
                             } {}
 
                             : String body ( json_stringify res )
@@ -2100,7 +2123,7 @@ s combined_stdout s combined_stderr → v {
 
     ( __oa_path paths `/health` `get` `Liveness probe` `Returns 200 OK with a small JSON payload.` )
     ( __oa_path paths `/build` `post` `Compile NURL source to a native x86_64 Linux binary (mirrors nurl.sh)` `nurlc → LLVM IR → clang link → ELF. Returns BuildResponse with ll_artifact + binary_artifact download URLs on success.` )
-    ( __oa_path paths `/build_wasm` `post` `Compile NURL source to a wasm32-wasi WebAssembly module` `nurlc → wasi-clang link → .wasm. Returns base64 wasm + canvas/audio FFI flags.` )
+    ( __oa_path paths `/build_wasm` `post` `Compile NURL source to a wasm32-wasi WebAssembly module` `nurlc → wasi-clang link → .wasm. Returns base64 wasm + canvas/audio FFI flags + wasm_artifact/ll_artifact download URLs; links_only:true omits the inline base64.` )
     ( __oa_path paths `/build_windows` `post` `Cross-compile to a Windows .exe via mingw-w64` `nurlc → clang+mingw link → PE/COFF. Static libcurl + Schannel TLS.` )
     ( __oa_path paths `/build_macos` `post` `Cross-compile to a macOS x86_64 Mach-O binary via zig cc` `Unsigned — clear quarantine attribute before running on macOS.` )
     ( __oa_path paths `/build_target` `post` `Cross-compile to a registered zig target (linux-arm64-musl, riscv64, …)` `See GET /targets for available target ids.` )
@@ -4288,7 +4311,10 @@ s combined_stdout s combined_stderr → v {
     }
 }
 
-@ __mcp_tool_build_source_filename s endpoint Json args → Json {
+// `links_only` — set by the wasm tool: the handler then answers with
+// wasm_artifact/ll_artifact download URLs and no inline base64 module,
+// which would otherwise land verbatim in the calling model's context.
+@ __mcp_tool_build_source_filename s endpoint b links_only Json args → Json {
     : s source ( __mcp_args_get `source` args `` )
     : s filename ( __mcp_args_get `filename` args `main.nu` )
     ? == ( nurl_str_len source ) 0 {
@@ -4297,6 +4323,7 @@ s combined_stdout s combined_stderr → v {
     : Json body ( json_obj_new )
     ( json_obj_set body `source` ( json_str_lit source ) )
     ( json_obj_set body `filename` ( json_str_lit filename ) )
+    ? links_only { ( json_obj_set body `links_only` ( json_bool T ) ) } {}
     : Json result ( __mcp_build_endpoint endpoint body )
     ( json_free body )
     ^ result
@@ -4871,16 +4898,16 @@ s combined_stdout s combined_stderr → v {
 @ __mcp_dispatch_tool s name Json args → Json {
     // Build tools — five compilation targets.
     ? != 0 ( nurl_str_eq name `nurl_build_native` ) {
-        ^ ( __mcp_tool_build_source_filename `/build` args )
+        ^ ( __mcp_tool_build_source_filename `/build` F args )
     } {}
     ? != 0 ( nurl_str_eq name `nurl_build_wasm` ) {
-        ^ ( __mcp_tool_build_source_filename `/build_wasm` args )
+        ^ ( __mcp_tool_build_source_filename `/build_wasm` T args )
     } {}
     ? != 0 ( nurl_str_eq name `nurl_build_windows` ) {
-        ^ ( __mcp_tool_build_source_filename `/build_windows` args )
+        ^ ( __mcp_tool_build_source_filename `/build_windows` F args )
     } {}
     ? != 0 ( nurl_str_eq name `nurl_build_macos` ) {
-        ^ ( __mcp_tool_build_source_filename `/build_macos` args )
+        ^ ( __mcp_tool_build_source_filename `/build_macos` F args )
     } {}
     ? != 0 ( nurl_str_eq name `nurl_build_target` ) {
         ^ ( __mcp_tool_build_target_impl args )
@@ -4993,7 +5020,7 @@ s combined_stdout s combined_stderr → v {
     `Compile NURL source to a native x86_64 Linux ELF binary. Returns build status, nurlc+clang return codes, combined stderr, download URLs for the generated .ll and the binary. Equivalent to POST /build.`
     ( __mcp_schema_source_filename ) ) )
     ( json_arr_push arr ( __mcp_tool_desc `nurl_build_wasm`
-    `Compile NURL source to a wasm32-wasi WebAssembly module. Returns base64-encoded wasm bytes, compile logs, download URL. Runs in-browser via a WASI shim or with wasmtime. Equivalent to POST /build_wasm.`
+    `Compile NURL source to a wasm32-wasi WebAssembly module. Returns build status, compile logs, and download URLs for the generated .wasm module (wasm_artifact) and the LLVM IR (ll_artifact) — no inline base64. Runs in-browser via a WASI shim or with wasmtime. Equivalent to POST /build_wasm with links_only:true.`
     ( __mcp_schema_source_filename ) ) )
     ( json_arr_push arr ( __mcp_tool_desc `nurl_build_windows`
     `Cross-compile NURL source to a Windows x86_64 .exe via mingw-w64 (clang -c → x86_64-w64-mingw32-gcc link). Static libcurl + Schannel TLS when the runtime is libcurl-enabled. Returns build status, return codes, combined stderr, download URL. Equivalent to POST /build_windows.`

--- a/packages/nurl-mcp/README.md
+++ b/packages/nurl-mcp/README.md
@@ -49,7 +49,7 @@ For any other client, configure an MCP server whose `command` is
 | Tool | Arguments | Does |
 |---|---|---|
 | `nurl_build` | `source` *or* `path` | Compile with the local toolchain; report success or compiler diagnostics. Does not run the program. |
-| `nurl_build_wasm` | `source` *or* `path`, optional `out` | Compile to a **wasm32-wasi module**, fully locally (wasmbuilder package — no build service). `out` = output path; a `path` input defaults to `<input>.wasm`; inline `source` without `out` returns JSON with `wasm_base64`. |
+| `nurl_build_wasm` | `source` *or* `path`, optional `out` | Compile to a **wasm32-wasi module**, fully locally (wasmbuilder package — no build service). `out` = output path; a `path` input defaults to `<input>.wasm`; inline `source` without `out` keeps the module + its `.ll` at a temp path and returns JSON with `wasm_path` / `ll_path` (no inline base64). |
 | `nurl_run` | `source` *or* `path` | Compile **and** run; return the program's exit code, stdout, and stderr. |
 | `nurl_check` | `source` *or* `path` | Front-end only — type-check + borrow-check, no binary. Fast. |
 | `nurl_fmt` | `source` *or* `path` | Format to canonical form (`nurlfmt`); return the formatted source. |

--- a/packages/nurl-mcp/nurl.toml
+++ b/packages/nurl-mcp/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nurl-mcp"
-version = "0.7.3"
+version = "0.7.4"
 description = "Local MCP server for the NURL toolchain — exposes the installed compiler over Model Context Protocol so an LLM agent on the host can build, run, type-check, format, and compile NURL to wasm32-wasi (fully local wasm builds via the wasmbuilder package), read the installed stdlib, browse its API surface — the stdlib's or a published registry package's (nurl_api, package=) — without function bodies, search stdlib + the package registry (by name, description, or exported symbol) with ranked word boundaries (nurl_grep), and compile a program that USES a registry package end to end, resolving its dependencies (nurl_build_project). Stdio by default; an optional token-authenticated HTTP transport (--http) gates code execution behind --allow-run. The editor-facing counterpart of nurl-lsp, for LLMs."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl/tree/main/packages/nurl-mcp"

--- a/packages/nurl-mcp/src/main.nu
+++ b/packages/nurl-mcp/src/main.nu
@@ -34,7 +34,6 @@ $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/ext/http_server.nu`
 $ `stdlib/ext/mcp_http.nu`
-$ `stdlib/std/encode.nu`
 $ `deps/wasmbuilder/src/build.nu`
 
 // ── Policy (set once in main, read by the dispatcher) ───────────────
@@ -59,7 +58,7 @@ $ `deps/wasmbuilder/src/build.nu`
 // to bump (previously the banners drifted to a stale 0.2.0 while the
 // handshake reported 0.4.0).
 
-@ nm_version → s { ^ `0.7.3` }
+@ nm_version → s { ^ `0.7.4` }
 
 // Log a startup banner "nurl-mcp <version> <suffix>" through mcp_log,
 // building the line from the single-source version so the banners can
@@ -257,9 +256,10 @@ $ `deps/wasmbuilder/src/build.nu`
 // synthesized nurl.toml with [dependencies]), runs `nurlpkg install` to
 // resolve the full transitive graph from the registry (signature- and
 // checksum-verified — reusing nurlpkg's supply-chain checks verbatim),
-// then `nurl <entry>` to compile. Nothing is executed; the binary is
-// returned base64. So an agent that found `nn` (nurl_grep), learned its
-// API (nurl_api package=nn), can now compile a program that calls it.
+// then `nurl <entry>` to compile. Nothing is executed; the binary and
+// its .ll stay at a temp path returned as binary_path / ll_path. So an
+// agent that found `nn` (nurl_grep), learned its API (nurl_api
+// package=nn), can now compile a program that calls it.
 //
 //   args: { source | files:{path:content}, deps:{name:req}, entry?, run? }
 
@@ -423,27 +423,35 @@ version = "0.0.0"
         T co → {
             ? ( output_success co ) {
                 ( output_free co )
-                : !( Vec u ) IoErr br ( read_file_bytes ( string_data out ) )
-                ( nm_unlink_artifacts ( string_data out ) )
-                ( nm_unlink ( string_data out ) )
-                ( string_free out )
-                ?? br {
-                    T bytes → {
-                        : i sz ( vec_len [u] bytes )
-                        : String b64 ( b64_encode_vec bytes )
-                        ( vec_free [u] bytes )
+                // The binary and its .ll stay on disk; the result carries
+                // their paths, never the bytes — a base64 binary in the
+                // tool result lands verbatim in the calling model's context.
+                : !i IoErr szr ( file_size ( string_data out ) )
+                ?? szr {
+                    T sz → {
+                        : String ll_p ( string_from ( string_data out ) )
+                        ( string_push_str ll_p `.ll` )
                         : Json res ( json_obj_new )
                         ( json_obj_set res `status` ( json_str_lit `ok` ) )
                         ( json_obj_set res `binary_bytes` ( json_int sz ) )
-                        ( json_obj_set res `binary_base64` ( json_str_lit ( string_data b64 ) ) )
-                        ( string_free b64 )
+                        ( json_obj_set res `binary_path` ( json_str_lit ( string_data out ) ) )
+                        ( json_obj_set res `ll_path` ( json_str_lit ( string_data ll_p ) ) )
+                        : String hint ( string_from `run: ` )
+                        ( string_push_str hint ( string_data out ) )
+                        ( json_obj_set res `note` ( json_str_lit ( string_data hint ) ) )
+                        ( string_free hint )
+                        ( string_free ll_p )
+                        ( string_free out )
                         : String body ( json_stringify res )
                         ( json_free res )
                         : Json j ( mcp_tool_result_text ( string_data body ) )
                         ( string_free body )
                         ^ j
                     }
-                    F _ → { ^ ( mcp_tool_result_error `compiled, but the binary could not be read back` ) }
+                    F _ → {
+                        ( string_free out )
+                        ^ ( mcp_tool_result_error `compiled, but the binary could not be read back` )
+                    }
                 }
             } {
                 : Json j ( nm_fail_from_output `build failed` co T )
@@ -472,8 +480,12 @@ version = "0.0.0"
 //   * `out` argument given          → module written there, text summary
 //   * `path` input, no `out`        → written next to the input as
 //                                     <input minus .nu>.wasm
-//   * inline `source`, no `out`     → JSON text with `wasm_base64`
-//                                     (mirrors the playground MCP tool)
+//   * inline `source`, no `out`     → module + its .ll kept at a temp
+//                                     path, JSON text with `wasm_path` /
+//                                     `ll_path` (mirrors the playground
+//                                     MCP tool — never inline base64,
+//                                     which would land verbatim in the
+//                                     calling model's context)
 @ nm_tool_build_wasm Json args → Json {
     : ?String po ( nm_input_path args )
     ?? po {
@@ -483,10 +495,10 @@ version = "0.0.0"
             : ~ String outp ( string_new )
             : ?Json oj ( json_obj_get args `out` )
             ?? oj { T ov → { ( string_free outp ) = outp ( string_from ( json_str_data ov ) ) } F → {} }
-            : ~ b b64_mode F
+            : ~ b tmp_out F
             ? == ( string_len outp ) 0 {
                 ? was_inline {
-                    = b64_mode T
+                    = tmp_out T
                     ( string_free outp ) = outp ( nm_tmp_path `.wasm` )
                 } {
                     ( string_free outp ) = outp ( string_from ( string_data p ) )
@@ -501,6 +513,9 @@ version = "0.0.0"
             : ~ WbOpts wopts ( wb_opts_default )
             = . wopts opt `-O1`
             = . wopts quiet T
+            // Inline-source builds keep the rewritten .ll next to the
+            // module so the result can point at both files.
+            ? tmp_out { = . wopts keep_ll T } {}
             : !v String r ( wb_build_file ( string_data p ) ( string_data outp ) wopts )
             ? was_inline { ( nm_unlink ( string_data p ) ) } {}
             ( string_free p )
@@ -508,27 +523,27 @@ version = "0.0.0"
                 T _ → {
                     : !i IoErr szr ( file_size ( string_data outp ) )
                     : i sz ?? szr { T sv → sv F _ → 0 }
-                    ? b64_mode {
-                        : !( Vec u ) IoErr br ( read_file_bytes ( string_data outp ) )
-                        ( nm_unlink ( string_data outp ) )
+                    ? tmp_out {
+                        // The module and its .ll stay on disk; the result
+                        // carries their paths, never the bytes.
+                        : String ll_p ( string_from ( string_data outp ) )
+                        ( string_push_str ll_p `.ll` )
+                        : Json res ( json_obj_new )
+                        ( json_obj_set res `status` ( json_str_lit `ok` ) )
+                        ( json_obj_set res `wasm_bytes` ( json_int sz ) )
+                        ( json_obj_set res `wasm_path` ( json_str_lit ( string_data outp ) ) )
+                        ( json_obj_set res `ll_path` ( json_str_lit ( string_data ll_p ) ) )
+                        : String hint ( string_from `run: wt run ` )
+                        ( string_push_str hint ( string_data outp ) )
+                        ( json_obj_set res `note` ( json_str_lit ( string_data hint ) ) )
+                        ( string_free hint )
+                        ( string_free ll_p )
                         ( string_free outp )
-                        ?? br {
-                            T bytes → {
-                                : String b64 ( b64_encode_vec bytes )
-                                ( vec_free [u] bytes )
-                                : Json res ( json_obj_new )
-                                ( json_obj_set res `status` ( json_str_lit `ok` ) )
-                                ( json_obj_set res `wasm_bytes` ( json_int sz ) )
-                                ( json_obj_set res `wasm_base64` ( json_str_lit ( string_data b64 ) ) )
-                                ( string_free b64 )
-                                : String body ( json_stringify res )
-                                ( json_free res )
-                                : Json j ( mcp_tool_result_text ( string_data body ) )
-                                ( string_free body )
-                                ^ j
-                            }
-                            F _ → { ^ ( mcp_tool_result_error `built module could not be read back` ) }
-                        }
+                        : String body ( json_stringify res )
+                        ( json_free res )
+                        : Json j ( mcp_tool_result_text ( string_data body ) )
+                        ( string_free body )
+                        ^ j
                     } {
                         : String msg ( string_from `OK — wrote ` )
                         ( string_push_str msg ( string_data outp ) )
@@ -971,12 +986,12 @@ version = "0.0.0"
         `Compile NURL (inline "source" or a "path") with the local toolchain; reports success or compiler diagnostics. Does not run the program.`
         ( nm_schema_src_path ) ) )
         ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_build_project`
-        `Compile a program that USES registry packages: give "source" (or "files") plus "deps" ({name: req}); the tool resolves them (nurlpkg install — transitive, checksum + signature verified) and compiles with the local toolchain, returning the binary as base64. The bridge from nurl_api/nurl_grep discovery to a working build. Does not run the program.`
+        `Compile a program that USES registry packages: give "source" (or "files") plus "deps" ({name: req}); the tool resolves them (nurlpkg install — transitive, checksum + signature verified) and compiles with the local toolchain, returning JSON with binary_path and ll_path (no inline base64). The bridge from nurl_api/nurl_grep discovery to a working build. Does not run the program.`
         ( nm_schema_project ) ) )
     } {}
     ? ( nm_build_ok ) {
         ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_build_wasm`
-        `Compile NURL (inline "source" or a "path") to a wasm32-wasi module, fully locally (no build service). Optional "out" = output path; a "path" input defaults to <input>.wasm next to it; inline "source" without "out" returns JSON with wasm_base64.`
+        `Compile NURL (inline "source" or a "path") to a wasm32-wasi module, fully locally (no build service). Optional "out" = output path; a "path" input defaults to <input>.wasm next to it; inline "source" without "out" writes the module + its .ll to a temp path and returns JSON with wasm_path and ll_path (no inline base64).`
         ( nm_schema_src_path ) ) )
     } {}
     ? ( nm_run_ok ) {


### PR DESCRIPTION
## Summary

A compiled module returned as base64 in an MCP tool result lands verbatim in the calling model's context — hundreds of KB spent on bytes the model can't read. Both MCP surfaces now answer with links/paths instead.

### nurlapi (playground MCP)
- `POST /build_wasm` grows `links_only:true`; the MCP tool `nurl_build_wasm` sets it, so it now returns `wasm_artifact` + `ll_artifact` download URLs (same shape as the native build's artifacts) and no inline `wasm_base64` / `llvm_ir`.
- The default REST response keeps the inline base64 the playground consumes, and now also carries the artifact objects — `ll_artifact` even when the link step failed, which is exactly when the IR is wanted.
- Canvas builds' download link now points at the asyncified module actually produced (`<bin>.async.wasm`), not the pre-instrumentation one.

### nurl-mcp 0.7.4 (local server — filesystem equivalent)
- Inline-source `nurl_build_wasm` keeps the module + its `.ll` on disk (wasmbuilder `keep_ll`) and returns `wasm_path` / `ll_path`.
- `nurl_build_project` returns `binary_path` / `ll_path` instead of `binary_base64`.
- Unused `std/encode.nu` import dropped; version bumped in both `nurl.toml` and `nm_version`.

## Testing

- nurlapi: playground container built locally, full e2e suite **152/152**, including two new tests — MCP `nurl_build_wasm` (no base64, both artifacts download with correct magic/IR content) and REST `links_only:true`; the existing shim test confirms the default REST path still returns `wasm_base64`.
- nurl-mcp: driven over stdio — wasm result carries paths, module runs under wasmtime, `nurl_build_project` binary runs natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVrMqaqvW8shK9Fhz8P27s