### PR TITLE
ci: hard self-compile leak gate (LSan, zero tolerance)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       webdocs: ${{ steps.filter.outputs.webdocs }}
+      compiler: ${{ steps.filter.outputs.compiler }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,6 +42,13 @@ jobs:
               - 'webdocs/**'
             code:
               - '!webdocs/**'
+            # The self-compile leak gate (in the sanitizers job) runs when
+            # the compiler source itself changes — that is what owns the
+            # allocations it is asserting about — or when the gate script
+            # changes, so a change to the gate is exercised by its own PR.
+            compiler:
+              - 'compiler/nurlc.nu'
+              - 'tools/leakgate.sh'
 
   build-test:
     name: build + bootstrap fixed point + test corpus
@@ -241,6 +249,20 @@ jobs:
         # sanitised runtime; run_san_tests.sh below is the
         # sanitiser-aware corpus driver.
         run: ./build.sh --san --no-tests
+
+      - name: self-compile leak gate (LSan) — hard, zero tolerance
+        # Runs only when compiler/nurlc.nu (or the gate itself) changed: that
+        # source owns the allocations this asserts about. Reuses the --san
+        # build above, so the whole gate costs ~3 s.
+        #
+        # The July 2026 ownership campaign took `nurlc compiler/nurlc.nu` from
+        # 2,793,226 leaked allocations / 33.4 MB to ZERO (peak RSS 115.9 ->
+        # 18.5 MB). Nothing in CI was watching while those leaks accumulated
+        # one unowned helper at a time, and leak freedom decays the same way.
+        # ANY LeakSanitizer report fails this — there is no budget to raise,
+        # unlike the RSS gate. ASan/UBSan findings in the same run fail too.
+        if: needs.changes.outputs.compiler == 'true'
+        run: ./tools/leakgate.sh
 
       - name: ASan + UBSan corpus
         # Leak detection is opt-in via LSAN_DETECT_LEAKS=1; NURL has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Self-compile leak gate — `nurlc compiler/nurlc.nu` must leak nothing,
+  and CI now enforces it.** The ownership campaign took the self-compile
+  from 2,793,226 leaked allocations / 33.4 MB to zero (peak RSS
+  115.9 → 18.5 MB), and nothing was watching while those leaks accumulated
+  one unowned helper at a time — they decay back the same way. `tools/leakgate.sh`
+  runs the self-compile under ASan+LSan with `detect_leaks=1` and fails on
+  ANY report: no budget to raise, unlike the peak-RSS gate, because the
+  number a leak gate accepts is zero. ASan/UBSan findings in the same run
+  fail it too, and it refuses to run against an uninstrumented build rather
+  than passing while checking nothing. It is a step in the existing
+  `sanitizers` job (already a required check), so it reuses that job's
+  `./build.sh --san` and costs ~3 s; it runs when `compiler/nurlc.nu` — the
+  source that owns the allocations in question — or the gate script itself
+  changed. Verified in both directions: green on the current compiler, and
+  it fails as designed on a pre-campaign build (2.8M allocations reported).
+
 ### Changed
 
 - **MCP build tools answer with links/paths, never an inline base64

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -168,6 +168,7 @@ Every pull request, and every push to `main`, runs
 |---|---|
 | build + bootstrap fixed point + test corpus | `build.sh` on Linux x86_64 — stage1 ≡ stage2 byte-identical IR, then the snapshot test suite |
 | self-compile peak-RSS gate | `tools/memgate.sh` — compiling the compiler must stay under the memory budget |
+| self-compile leak gate | `tools/leakgate.sh` — `nurlc compiler/nurlc.nu` must leak nothing under LSan; runs when `compiler/nurlc.nu` changes |
 | examples corpus frontend gate | every program under `examples/` compiles (`tools/check_examples.sh`) |
 | stdlib symbol-collision gate | no two stdlib helpers mangle to the same symbol (`tools/check_stdlib_symbols.sh`) |
 | `nurlfmt --check` | the whole tree is in canonical format (no drift) |

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -720,11 +720,21 @@ on; they are not two separate tools or two separate builds.
      fails on *any* leak; it locks the per-request leak class
      (None-placeholder allocations, the keepalive-500 response, and
      router/handler closure envs).
+   - `tools/leakgate.sh` — the self-compile. `nurlc compiler/nurlc.nu`
+     under `detect_leaks=1` must report nothing at all. This is the
+     largest NURL program there is, so it exercises the ownership rules
+     at a density no test does; the July 2026 campaign took it from
+     2,793,226 leaked allocations / 33.4 MB to zero (peak RSS
+     115.9 → 18.5 MB) and this is what holds the line. Zero tolerance
+     by design: unlike the RSS gate there is no budget to raise, because
+     the number a leak gate accepts is zero.
 
-   Both pinned checks are now wired into `ci.yml`: the leak-pinned
-   subset runs under `LSAN_DETECT_LEAKS=1` in the sanitizers job, and
-   `tools/leakcheck/run.sh` runs in the build-test job. So a leak
-   regression in the pinned surface fails CI, not just a manual audit.
+   All three pinned checks are wired into `ci.yml`: the leak-pinned
+   subset runs under `LSAN_DETECT_LEAKS=1` in the sanitizers job,
+   `tools/leakcheck/run.sh` runs in the build-test job, and
+   `tools/leakgate.sh` runs in the sanitizers job — reusing its
+   `--san` build, and only when `compiler/nurlc.nu` itself changed. So a
+   leak regression in the pinned surface fails CI, not just a manual audit.
 
 ## 7. Leaks versus memory safety
 

--- a/tools/leakgate.sh
+++ b/tools/leakgate.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/leakgate.sh — self-compile leak-freedom gate.
+#
+#  `nurlc compiler/nurlc.nu` must leak NOTHING. The July 2026 campaign
+#  took that compile from 2,793,226 leaked allocations / 33.4 MB to zero
+#  (peak RSS 115.9 -> 18.5 MB); this gate is what keeps it there. Leak
+#  freedom is a property that decays one unowned helper at a time, and
+#  every step of the campaign found leaks that had sat unnoticed for
+#  months — nothing in CI was looking.
+#
+#  Hard gate: ANY LeakSanitizer report fails, no allowance, no budget.
+#  A leak is not a threshold to stay under, it is a bug to not have.
+#  ASan and UBSan findings fail it too — the compile is instrumented, so
+#  a use-after-free or UB in the same run is free signal.
+#
+#  Usage:  tools/leakgate.sh [source.nu]
+#    source.nu   what to compile (default: compiler/nurlc.nu — the
+#                self-compile, the largest NURL program that exists)
+#
+#  Pre-req: ./build.sh --san --no-tests, so build/nurlc and
+#  stdlib/runtime.o carry the sanitizer instrumentation. Like
+#  run_san_tests.sh this script DOES NOT rebuild — keep concerns
+#  separate, and never silently gate an uninstrumented binary (which
+#  would pass every time while checking nothing).
+#
+#  Exit:  0 = zero leaks · 1 = leaks/sanitizer findings · 2 = harness
+#         precondition unmet (no sanitized build)
+# ============================================================
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+NURLC="$ROOT/build/nurlc"
+RUNTIME="$ROOT/stdlib/runtime.o"
+SRC="${1:-$ROOT/compiler/nurlc.nu}"
+
+[ -x "$NURLC" ] || { echo "leakgate: $NURLC missing — run ./build.sh --san --no-tests first" >&2; exit 2; }
+[ -f "$SRC" ]   || { echo "leakgate: source not found: $SRC" >&2; exit 2; }
+
+# An uninstrumented build would sail through this gate reporting nothing,
+# which is the one failure mode a leak gate must not have. Both the
+# runtime object and the linked compiler have to carry ASan.
+# (grep -c, not grep -q: -q closes the pipe on its first match, and under
+# `pipefail` nm's SIGPIPE would fail the test that just succeeded.)
+if [ "$(nm "$RUNTIME" 2>/dev/null | grep -c "asan_init")" -eq 0 ]; then
+    echo "leakgate: $RUNTIME was not built with -fsanitize=address." >&2
+    echo "          Run ./build.sh --san --no-tests to rebuild it." >&2
+    exit 2
+fi
+if [ "$( { nm -D "$NURLC" 2>/dev/null; nm "$NURLC" 2>/dev/null; } | grep -c "asan_init")" -eq 0 ]; then
+    echo "leakgate: $NURLC is not sanitizer-instrumented." >&2
+    echo "          Run ./build.sh --san --no-tests to rebuild it." >&2
+    exit 2
+fi
+
+ir="$(mktemp)"
+err="$(mktemp)"
+trap 'rm -f "$ir" "$err"' EXIT
+
+echo "leakgate: $NURLC ${SRC#"$ROOT"/} under ASan+LSan"
+
+# exitcode=23 is LSan's own convention for "leaks were found"; spelling it
+# out keeps the verdict readable when a future ASan default changes.
+ASAN_OPTIONS="detect_leaks=1:exitcode=23:abort_on_error=0:halt_on_error=0:print_stacktrace=1" \
+UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+    "$NURLC" "$SRC" > "$ir" 2> "$err"
+rc=$?
+
+# A sanitizer finding of any kind fails the gate. Checked before the exit
+# code so a leak report reads as a leak report rather than "exit 23".
+if grep -qE "LeakSanitizer|AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:" "$err"; then
+    echo "leakgate: FAIL — the self-compile is not clean."
+    echo
+    summary="$(grep -E "^SUMMARY: " "$err" | head -1)"
+    [ -n "$summary" ] && echo "  $summary" && echo
+    echo "  first findings (full report above the summary in the log):"
+    head -60 "$err" | sed 's/^/  /'
+    echo
+    echo "  Leak freedom here is absolute — there is no budget to raise."
+    echo "  Reproduce locally: ./build.sh --san --no-tests && tools/leakgate.sh"
+    echo "  Each frame names the NURL function that allocated; the usual"
+    echo "  cause is a helper whose result is fresh but is not declared"
+    echo "  owning, so no consumer ever releases it."
+    exit 1
+fi
+
+if [ "$rc" -ne 0 ]; then
+    echo "leakgate: FAIL — the compile itself failed (exit $rc):"
+    tail -20 "$err" | sed 's/^/  /'
+    exit 1
+fi
+
+# Zero stderr and exit 0 could also mean "compiled nothing at all", which
+# is exactly how a broken gate looks green. Assert real IR came out.
+ir_bytes="$(wc -c < "$ir")"
+if [ "$ir_bytes" -lt 100000 ]; then
+    echo "leakgate: FAIL — only $ir_bytes bytes of IR emitted; the compile did not run to completion." >&2
+    exit 1
+fi
+
+if [ -s "$err" ]; then
+    echo "leakgate: note — compiler stderr was not empty:"
+    head -20 "$err" | sed 's/^/  /'
+fi
+
+echo "leakgate: OK — zero leaks, ${ir_bytes} bytes of IR emitted"


### PR DESCRIPTION
`nurlc compiler/nurlc.nu` is leak-free as of the ownership campaign
(2,793,226 leaked allocations / 33.4 MB → **0**, peak RSS 115.9 → 18.5 MB).
Nothing in CI was watching while those leaks accumulated, one unowned helper
at a time — and that is exactly how they come back. This gate holds the line.

## What it does

`tools/leakgate.sh` runs the self-compile under ASan+LSan with
`detect_leaks=1` and fails on **any** report. No budget to raise, unlike the
peak-RSS gate: the number a leak gate accepts is zero.

- ASan/UBSan findings in the same run fail it too — the compile is
  instrumented, so that signal is free.
- Refuses to run against an uninstrumented build (exit 2) instead of passing
  while checking nothing — the one failure mode a leak gate must not have.
- Asserts real IR came out, so "compiled nothing" cannot read as green.

## Where it runs

A step in the **existing `sanitizers` job**, not a new job — that job already
does `./build.sh --san --no-tests` (the expensive part) and is already in the
branch-protection required set, so the gate is hard the moment this merges,
with no settings change. Marginal cost: **~3 s**.

It runs when `compiler/nurlc.nu` — the source that owns the allocations being
asserted about — or the gate script itself changed, via a new `compiler`
output on the paths filter. (A PR that touches only `stdlib/runtime.c` will
not trigger it; say the word and I will widen the filter, it is one line and
the gate is cheap enough to run unconditionally.)

## Verified both directions

| | Result |
|---|---|
| Current `main`, sanitized build | `leakgate: OK — zero leaks, 3286885 bytes of IR emitted` (2.5 s) |
| Pre-campaign build (`c3745b0`) | `FAIL` — `SUMMARY: AddressSanitizer: 50591717 byte(s) leaked in 2659003 allocation(s)`, exit 1 |
| Non-sanitized build | exit 2, "run ./build.sh --san --no-tests first" |

Docs: a row in the `docs/BUILDING.md` CI table and a third bullet in
`docs/MEMORY.md` §6.3 (leak verification), next to the pinned-test set and the
HTTP per-request gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FREmK7Qhd5sMWtNi9QVWHw