### PR TITLE
runtime: stop flushing stdout on every print — 16.7x faster output, 19–25% off every nurlc run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`nurl_print` stops paying a `write(2)` per print — 16.7× faster
+  output, 19–25% off every `nurlc` run.** The runtime flushed stdout
+  after *every* print call. NURL code prints in small pieces (nurlc
+  emits one IR line as ~8 separate prints), so the flush, not the
+  formatting, was the cost: compiling `examples/static_server.nu` issued
+  **188,713** write syscalls, and a program printing 300k lines spent
+  16× longer in the kernel than in its own loop. stdout is now
+  block-buffered when it is a pipe or a file and still flushed per print
+  on a terminal — the same split C and Python make, so an interactive
+  prompt with no trailing newline still appears before its read
+  (verified against a pty).
+
+  | | before | after |
+  |---|---:|---:|
+  | `nurlc examples/static_server.nu` — write syscalls | 188,713 | **725** |
+  | `nurlc compiler/nurlc.nu` (self-compile IR) | 601 ms | **449 ms** |
+  | `nurlc examples/static_server.nu` | 693 ms | **556 ms** |
+  | `nurlc examples/ws_echo.nu` | 637 ms | **517 ms** |
+  | 300k-line print loop | 435 ms | **26 ms** |
+
+  Buffered bytes are never lost or reordered: `exit` flushes, every
+  `abort()` path (`nurl__oom`, `nurl_panic`, the wasi panic stub)
+  flushes stdout first, `stdlib/std/process.nu` flushes before its two
+  `fork`s so the child cannot re-emit the parent's pending bytes, and
+  **`nurl_eprint`/`nurl_eprintln` drain stdout before writing** — so
+  anything merging the streams (a terminal, `2>&1`, a CI log) sees them
+  in the order the program produced them. That last rule is stricter
+  than before: `compiler/tests/outputs/mcp_hardening.txt` recorded a
+  stderr line jumping *ahead* of a `puts` printed earlier, and the
+  golden now shows true program order. The one case the runtime cannot
+  see — a raw `write(2)` on fd 1, which bypasses stdio — needs an
+  explicit `( flush )`, exactly as mixing `printf` and `write(1, …)`
+  does in C; `stdlib/core/io.nu` documents both that and the
+  follow-my-redirected-log case, and `compiler/tests/stdout_flush_order.nu`
+  pins all three ordering rules.
+
 - **MCP build tools answer with links/paths, never an inline base64
   module.** A compiled module returned as base64 in a tool result lands
   verbatim in the calling model's context — hundreds of KB spent on bytes

--- a/compiler/tests/outputs/mcp_hardening.txt
+++ b/compiler/tests/outputs/mcp_hardening.txt
@@ -2,8 +2,8 @@ COMPILE OK
 LINK OK
 EXIT 0
 OUTPUT
-[mcp] tool handler panicked: kaboom
 ok: success tool returned real result
+[mcp] tool handler panicked: kaboom
 ok: tool panic returned isError
 ok: forged reverse-RPC response rejected
 ok: pending reverse-RPC response settled

--- a/compiler/tests/outputs/stdout_flush_order.txt
+++ b/compiler/tests/outputs/stdout_flush_order.txt
@@ -1,0 +1,11 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+1 stdout via nurl_print
+2 stderr via nurl_eprintln
+3 stdout again
+4 stderr via nurl_eprint
+5 stdout before a raw write
+6 raw write(2) on fd 1
+7 stdout last

--- a/compiler/tests/stdout_flush_order.nu
+++ b/compiler/tests/stdout_flush_order.nu
@@ -1,0 +1,33 @@
+// stdout buffering — ordering contract.
+//
+// `nurl_print` block-buffers when stdout is a pipe or a file (the test
+// runner redirects, so that is the mode here) and flushes per call only
+// on a terminal. Buffering is what keeps a print-heavy program from
+// paying one write(2) per fragment — but it must not reorder anything
+// an observer merging stdout and stderr can see. This test pins the
+// three rules that make that true:
+//
+//   1. stdout stays in program order with itself (trivially).
+//   2. a stderr write drains stdout first, so `2>&1` sees the two
+//      streams in the order the program produced them.
+//   3. a raw `write(2)` on fd 1 bypasses stdio entirely, so the
+//      program must flush stdout itself before one — same discipline
+//      as mixing printf and write(1, …) in C.
+//
+// The runner captures `> out 2>&1`, so the golden file below IS the
+// interleaving.
+
+& `libc` @ write i fd s buf i count → i
+
+@ main → i {
+    ( nurl_print `1 stdout via nurl_print\n` )
+    ( nurl_eprintln `2 stderr via nurl_eprintln` )
+    ( nurl_print `3 stdout again\n` )
+    ( nurl_eprint `4 stderr via nurl_eprint\n` )
+    ( nurl_print `5 stdout before a raw write\n` )
+    // Rule 3: raw fd-1 write, so drain stdio's buffer first.
+    ( nurl_flush_stdout )
+    ( write 1 `6 raw write(2) on fd 1\n` 23 )
+    ( nurl_print `7 stdout last\n` )
+    ^ 0
+}

--- a/compiler/tests/test_11_fat_strings.nu
+++ b/compiler/tests/test_11_fat_strings.nu
@@ -24,7 +24,12 @@
 
 // 3. Turvallinen tulostus: Käyttää libc:n write-funktiota.
 // Ei välitä null-päätteistä, tulostaa tasan 'len' tavua.
+// write(2) ohittaa stdion puskurin, ja nurl_print on lohkopuskuroitu
+// kun stdout on putki tai tiedosto — joten stdout on tyhjennettävä
+// ennen raakaa kirjoitusta, tai rivit tulostuvat väärässä
+// järjestyksessä. Sama sääntö kuin C:ssä printf + write(1, ...).
 @ safe_print String str → i {
+    ( nurl_flush_stdout )
     ( write 1 . str ptr . str len )
     ( write 1 `\n` 1 )
     ^ 0

--- a/stdlib/core/io.nu
+++ b/stdlib/core/io.nu
@@ -14,6 +14,25 @@
 //   ( stdin_eof )         → b       T iff a previous read hit EOF
 //   ( flush )             → v       fflush(stdout)
 //   ( eflush )            → v       fflush(stderr)
+//
+// ── When you need ( flush ) ──────────────────────────────────────────
+//
+// stdout is block-buffered when it is a pipe or a file, and flushed per
+// print when it is a terminal — the same split C and Python make. That
+// keeps a print-heavy program from paying one write(2) per fragment
+// (measured: 300k printed lines went from 435 ms to 26 ms) without
+// costing an interactive prompt its immediacy.
+//
+// The runtime already drains stdout for you at process exit, before a
+// panic aborts, before every stderr write (so `2>&1` never reorders the
+// two streams), and before `process`'s fork. Call ( flush ) yourself in
+// the two cases it cannot see:
+//
+//   * before writing to fd 1 with raw `write(2)` instead of a print —
+//     that path bypasses stdio's buffer entirely;
+//   * when another process is *following* your redirected stdout and
+//     must see a line the moment you print it (a server announcing its
+//     port to a supervisor, a progress line piped into `tee`).
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -78,6 +78,10 @@
 static void nurl__oom(unsigned long long bytes) {
     fprintf(stderr, "nurl: out of memory (requested %llu bytes)\n", bytes);
     fflush(stderr);
+    /* abort() skips stdio cleanup — push whatever the program had
+     * already printed (stdout is block-buffered when redirected; see
+     * nurl_print) before the process dies. */
+    fflush(stdout);
     abort();
 }
 static void *nurl__xmalloc(size_t n) {
@@ -465,6 +469,29 @@ void nurl_print_buf_unwind(void) {
     g_outbuf_mode = 0;
 }
 
+/* stdout flush policy, resolved once on the first write (-1 = not yet
+ * probed, 1 = terminal, 0 = pipe/file).
+ *
+ * `nurl_print` used to fflush after EVERY call, which turns each print
+ * fragment into its own write(2). NURL code prints in small pieces —
+ * nurlc emits an IR line as ~8 separate prints — so compiling
+ * examples/static_server.nu cost 188,713 write syscalls, ~20% of the
+ * compiler's wall clock, and a program printing 300k lines spent 16.7x
+ * longer in the kernel than in its own loop.
+ *
+ * On a terminal the per-call flush still earns its keep: a prompt with
+ * no trailing newline has to appear before the matching read. So keep
+ * flushing there, and let stdio's own buffer do its job when stdout is
+ * a pipe or a file. That is the same split C and Python make.
+ *
+ * Buffered bytes must not be lost when the process dies abnormally:
+ * `exit()` (nurl_exit) flushes for us, and every `abort()` path in this
+ * file — nurl__oom, nurl_panic — flushes stdout first. A NURL program
+ * that forks (stdlib/std/process.nu) flushes before the fork so the
+ * child does not inherit, and re-emit, the parent's pending bytes.
+ * `nurl_flush_stdout` is exported for anything else that needs it. */
+static int g_stdout_tty = -1;
+
 /* Print without a trailing newline. */
 void nurl_print(const char *s) {
     if (g_outbuf_mode) {
@@ -474,15 +501,24 @@ void nurl_print(const char *s) {
             g_outbuf_len += n;
         }
     } else {
+        if (g_stdout_tty < 0) g_stdout_tty = nurl_stdout_isatty() ? 1 : 0;
         fputs(s, stdout);
-        fflush(stdout);
+        if (g_stdout_tty) fflush(stdout);
     }
 }
 /* Print with a trailing newline. Routed through nurl_print so the
  * output-capture buffer (nurl_print_buf_*) sees it too. */
 void nurl_println(const char *s)  { nurl_print(s); nurl_print("\n"); }
-void nurl_eprint(const char *s)   { fputs(s, stderr); fflush(stderr); }
-void nurl_eprintln(const char *s) { fputs(s, stderr); fputc('\n', stderr); fflush(stderr); }
+/* stderr is flushed per call, and stdout is block-buffered when it is
+ * redirected — so without draining stdout first, a program that
+ * interleaves the two would have its stderr lines jump ahead of stdout
+ * lines printed earlier. Anything that merges the two streams (a
+ * terminal, `2>&1`, a CI log) has to see them in the order the program
+ * produced them. The extra fflush is free when nothing is pending, and
+ * stderr writes are diagnostics — orders of magnitude rarer than the
+ * stdout prints this buffering is here to make cheap. */
+void nurl_eprint(const char *s)   { fflush(stdout); fputs(s, stderr); fflush(stderr); }
+void nurl_eprintln(const char *s) { fflush(stdout); fputs(s, stderr); fputc('\n', stderr); fflush(stderr); }
 
 
 /* ── §2  String operations ─────────────────────────────────────── */
@@ -2030,6 +2066,8 @@ void nurl_panic(const char *msg) {
         }
 #endif
         fflush(stderr);
+        /* abort() skips stdio cleanup — see nurl__oom. */
+        fflush(stdout);
         abort();
     }
     nurl__panic_top->msg = (msg && *msg) ? strdup(msg)
@@ -2071,6 +2109,8 @@ void nurl_panic(const char *msg) {
     fprintf(stderr, "nurl panic (wasi: no recover): %s\n",
             msg && *msg ? msg : "(no message)");
     fflush(stderr);
+    /* abort() skips stdio cleanup — see nurl__oom. */
+    fflush(stdout);
     abort();
 }
 

--- a/stdlib/std/process.nu
+++ b/stdlib/std/process.nu
@@ -382,6 +382,11 @@ $ `stdlib/core/posix.nu`
 
     : s full ( __build_argv cmd args )
 
+    // stdout is block-buffered when it is a pipe or a file, so anything
+    // the parent has printed but not yet written out would be inherited
+    // by the child's copy of the buffer and emitted TWICE. Drain it
+    // before the fork — the standard pre-fork discipline.
+    ( nurl_flush_stdout )
     : i pid ( fork )
     ? < pid 0 {
         ( close ( __pipe_fd sin_p 0 ) ) ( close ( __pipe_fd sin_p 1 ) )
@@ -853,6 +858,9 @@ $ `stdlib/core/posix.nu`
 
     : s full ( __build_argv cmd args )
 
+    // See the fork in __process_run: drain the parent's pending stdout
+    // so the child cannot re-emit it.
+    ( nurl_flush_stdout )
     : i pid ( fork )
     ? < pid 0 {
         ( nurl_free full )


### PR DESCRIPTION
## The problem

`nurl_print` called `fflush(stdout)` after **every** call, so each print fragment became its own `write(2)`. NURL code prints in small pieces — `nurlc` emits one IR line as ~8 separate prints — which made the flush, not the formatting, the cost.

`strace -c` on `nurlc examples/static_server.nu`:

```
% time     seconds  usecs/call     calls    syscall
 97.21    0.870963           4    188713    write
```

## The change

stdout is block-buffered when it is a pipe or a file, and still flushed per print on a terminal — the same split C and Python make. Verified against a pty that an interactive prompt with no trailing newline still appears before its matching read.

| | before | after |
|---|---:|---:|
| `nurlc examples/static_server.nu` — write syscalls | 188,713 | **725** |
| `nurlc compiler/nurlc.nu` (self-compile IR) | 601 ms | **449 ms** |
| `nurlc examples/static_server.nu` | 693 ms | **556 ms** |
| `nurlc examples/ws_echo.nu` | 637 ms | **517 ms** |
| `nurlc examples/h2c_server.nu` | 601 ms | **487 ms** |
| `nurlc examples/claude_agent.nu` | 535 ms | **432 ms** |
| 300k-line print loop | 435 ms | **26 ms** |

(best-of-7, same machine, IR byte-identical before/after)

## Nothing is lost or reordered

- `exit()` (`nurl_exit`, normal return) flushes for us.
- Every `abort()` path — `nurl__oom`, `nurl_panic`, the wasi panic stub — flushes stdout first.
- `stdlib/std/process.nu` flushes before both of its `fork`s, so the child cannot inherit and re-emit the parent's pending bytes.
- `nurl_eprint` / `nurl_eprintln` **drain stdout before writing**, so anything merging the two streams (a terminal, `2>&1`, a CI log) sees them in the order the program produced them.

That last rule is *stricter* than the old behaviour. `compiler/tests/outputs/mcp_hardening.txt` had recorded a stderr line jumping **ahead** of a `puts` printed earlier (libc `puts` never went through `nurl_print`, so it was never flushed); the golden now shows true program order.

## The one case the runtime cannot see

A raw `write(2)` on fd 1 bypasses stdio entirely and needs an explicit `( flush )` — exactly as mixing `printf` and `write(1, …)` does in C.

- `stdlib/core/io.nu` documents that, plus the follow-my-redirected-log case (a server announcing its port to a supervisor).
- `compiler/tests/stdout_flush_order.nu` (new) pins all three ordering rules against the runner's `2>&1` capture.
- `compiler/tests/test_11_fat_strings.nu` mixes `write(2)` with prints and now flushes between them.

## Verification

- Bootstrap fixed point holds (stage1 ≡ stage2, byte-identical).
- `./build.sh` — 616 tests pass.
- `./build.sh --san` + `run_san_tests.sh` — **0 SAN_FAIL**.
- `tools/leakgate.sh` — zero leaks, 3,286,885 bytes of IR emitted.
- Interactive prompt-before-read verified under a pty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FREmK7Qhd5sMWtNi9QVWHw