### PR TITLE
release: cut v0.30.0 — a compiler-efficiency release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] — 2026-07-31
+
+A compiler-efficiency release. Everything in it is about what `nurlc`
+spends — memory, syscalls, and the work it hands to clang — and nothing
+in it changes what a NURL program means. The self-compile went from
+leaking 2.8 million allocations to leaking none and from 115.9 MB peak
+RSS to 18.5; the borrow checker's state representation was rewritten and
+took 20.7% of the compiler's instructions with it; printing stopped
+paying a write syscall per fragment; and `nurlc` now emits only the
+functions a program can actually reach, which is 30–40% off the clang
+step for anything that imports a stdlib module. Four new CI gates keep
+each of those from decaying back.
+
 ### Added
 
 - **Self-compile leak gate — `nurlc compiler/nurlc.nu` must leak nothing,
@@ -138,6 +151,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keeps the module and its `.ll` on disk and returns `wasm_path` /
   `ll_path`, and `nurl_build_project` returns `binary_path` / `ll_path`
   instead of `binary_base64`.
+
+- **Web docs build on fumadocs 16.14.**
+
+### Performance
+
+- **The borrow checker's per-binding state is a direct-indexed lattice
+  array — 20.7% off the whole compiler's instruction count.** The state
+  was a space-separated `name=digit` token string: every lookup
+  `memmem`'d the whole thing (11.2% of a self-compile sat inside libc
+  `memmem`), every update rebuilt the string token by token, and a join
+  probed each token of one side against the whole of the other —
+  O(na·nb). Binding names are now interned once per function into dense
+  ids at `bck_explode` time (generation-stamped entries on `g_bck`, so
+  there is no clearing pass; `rv_<id>` keeps the reverse map for
+  diagnostics), and a state is a byte string indexed by id: get is a
+  byte load, set a memcpy plus one store, join and the loop-carry seed
+  pointwise passes.
+
+  Self-compile, pinned, `perf stat -r 5`: instructions 3.318 G → 2.631 G
+  (−20.7%), cycles −13.2%, wall 0.528 → 0.459 s, peak RSS 125 → 115 MB.
+  The borrow checker's own overhead — the delta against `--no-borrowck`
+  — drops 44%. Gated by a differential sweep over all 1,654 `.nu` files
+  in the tree: IR, diagnostics and exit codes byte-identical.
+
+### Fixed
+
+- **The compiler stopped leaking: 2,793,226 allocations / 33.4 MB per
+  self-compile → zero, peak RSS 115.9 → 18.5 MB.** A single-owner
+  language whose own compiler leaks a third of its address space is
+  making an argument it does not believe, and every step of this
+  campaign found leaks that had sat unnoticed for months because nothing
+  was looking. About thirty commits, each closing a *class* rather than
+  a site — the recurring roots were worth naming:
+
+  - **Ownership hidden behind a cast.** The strdup-returning getters
+    (`nurl_sym_get`/`get2`, `nurl_lex_val`/`filename`/`peek_val`,
+    `nurl_llty`, …) returned `^ # s ( strdup … )`, and the cast hid the
+    freshness from return-site inference, so no caller ever freed the
+    copy. `nurl_sym_get` alone leaked 1.77 M strdups per self-compile.
+  - **Ownership as a per-path guess.** Return inference is now
+    all-paths-or-nothing: any `i8*` return site that cannot prove
+    freshness sets a poison that vetoes the marker. One owned
+    `^ ( slice … )` beside a borrowed `^ param` tail used to mark the
+    whole function owned — and callers then freed the borrow.
+  - **The def-order gap.** A helper defined *below* its caller had no
+    ownership summary yet at the call site, so its result went
+    uncollected. Fixed both by hoisting and by a forward-call ownership
+    channel that lets a call ask a not-yet-compiled callee, at run time,
+    whether the pointer it returned was fresh.
+  - **Copies nobody consumes.** A `?`/`??` arm whose value merely
+    aliases a binding was copied like any other tracked value, while the
+    binding's own scope-exit drop already owned that buffer — so every
+    `? c { = x y } {}` minted a buffer with no consumer. The single
+    biggest remaining class.
+  - **Mixed joins.** A join with a borrowed parameter on one side and a
+    tracked local on the other never collected the tracked arm's copy:
+    71 k leaks on one `ws_echo` compile, through `subst_source` alone.
+
+  Two of these were live-memory bugs, not just leaks: reassigning a
+  tracked mutable string could `free` a `.rodata` literal or a borrow,
+  and an over-eager owned marker made callers free a value they did not
+  own. `arm_local_trailing_drop` and `ret_owned_propagation` pin the
+  copy contract as regressions.
+
+  The self-compile is the workload `nurlc.nu` exercises, and it has no
+  `$` imports and instantiates no generics — so the whole
+  mangling/substitution path was untested by it. Compiling an
+  import-heavy program was taken the same way: 96 k → 7.6 k → **zero**
+  leaked allocations, at `-O0` as well as `-O2` (an `-O0` ASan build
+  elides no allocations and was the honest measurement). `tools/leakgate.sh`
+  above is what keeps all of it at zero.
 
 ## [0.29.0] — 2026-07-30
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-07-25 · Current release: **0.24.1** · Language: **Grammar
+_Last reviewed: 2026-07-31 · Current release: **0.30.0** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---

--- a/docs/dev/COMPILER_INTERNALS.md
+++ b/docs/dev/COMPILER_INTERNALS.md
@@ -38,6 +38,9 @@ Consequences to internalise before editing:
 main()
  ├─ CLI flags → g_borrowck / g_strict_borrowck / g_dbg_enabled / g_lint …
  ├─ allocate ~20 sym tables (fresh per process; nothing survives runs)
+ ├─ nurl_print_buf_start            — the whole module is emitted into
+ │                                    one buffering frame, not straight
+ │                                    to stdout (see dce_emit_module)
  ├─ emit_header                     — module preamble, runtime declares
  ├─ scan_generic_structs (prepass)  — generic struct templates → tables
  ├─ scan_fn_sigs         (prepass)  — every fn signature, follows `$`
@@ -53,12 +56,26 @@ main()
  │                                    forward/generic calls
  ├─ dbg_flush                       — queued !DI* metadata (--g)
  ├─ lint_report_unused_*            — --lint reports
- └─ exit non-zero if g_err_count / g_bck_errors
+ ├─ exit non-zero if g_err_count / g_bck_errors
+ └─ dce_emit_module                 — stop the buffer; write out the
+                                      globals plus the functions `main`
+                                      can reach (--no-dce: all of them)
 ```
 
 The four `scan_*` prepasses exist so the fused walk never needs a second
 look at the source: by the time `parse_program` runs, every signature,
 type name, template and dyn-trait requirement is already in a table.
+
+`dce_emit_module` is the only stage that looks at the emitted IR as
+*text*. It indexes every `define … }` block, marks the ones reachable
+from `main` (roots: `main`, plus anything named between blocks — a
+`@__vt.…` vtable constant names its thunks at module scope), and prints
+the live sub-sequence. Working on the finished text rather than a
+source-level call graph is what keeps it indifferent to how a function
+came to exist: closures, monomorphisations, drop glue and dyn thunks are
+all just `@name` references by then. Nothing is rewritten or reordered,
+only dropped, and dropping something still referenced surfaces as an
+undefined symbol at link time.
 
 ## 3. Global state — families and owners
 
@@ -79,7 +96,7 @@ get — returned values are owned copies).
 | dyn traits | `g_dyn_needed`, `g_dyn_flat_*`, `g_super_obligations` | accumulator strings (not tables): vtables to emit + supertrait proof obligations |
 | closures | `g_closure_defs/types`, `g_func_count`, `g_type_count`, `g_*_emit_base` | deferred closure bodies/types; the `emit_base` watermarks make the between-items flush idempotent |
 | result types | `g_res_type_syms` | `! T E` lowering metadata for try-propagation checking |
-| borrow checker | `g_bck` (per-fn record list + `warnset` + `ml_*` lines), `g_bck_depth`, `g_bck_closure_depth`, `g_bck_errors` | statements are RECORDED during the walk, analysed at function end (`bck_analyze` → `bck_walk_seq` over a `name=digit` state string; see §4) |
+| borrow checker | `g_bck` (per-fn record list + `warnset` + `ml_*` lines), `g_bck_depth`, `g_bck_closure_depth`, `g_bck_errors` | statements are RECORDED during the walk, analysed at function end (`bck_analyze` → `bck_walk_seq` over a byte-per-binding lattice array; names are interned to dense ids at `bck_explode`, `rv_<id>` is the reverse map for diagnostics) |
 | escape analysis | `g_fn_inout/sink/escapes/invoke_only/ret_param`, `g_pending_escape` | interprocedural summaries; `g_pending_escape` holds checks parked on forward/generic calls, replayed by `resolve_pending_escapes` |
 | auto-drop | `mem_*` journal (function-local handles) + `g_auto_drop_strings` | owned-resource journal driving scope-exit frees |
 | DWARF | `g_dbg_*` | metadata id allocator + queued `!DI*` blobs; only live under `--g` |
@@ -92,11 +109,13 @@ except via `$` imports walked in the same run. If you add a global,
 initialise it in `main()` next to its family and document the writer
 set in the appendix (regenerate it — §6).
 
-## 4. Memory discipline (post-M1)
+## 4. Memory discipline
 
-The compiler allocates arena-style: temporaries are **not** freed
-(bare `s` bindings are unmanaged), and correctness relies on that in
-one place you must not break:
+The compiler used to allocate arena-style — temporaries were simply not
+freed. As of 0.30.0 **the self-compile leaks nothing**, and
+`tools/leakgate.sh` (CI, zero tolerance) is what holds that. The
+invariant that made the arena era safe still holds and still must not
+be broken:
 
 - `nurl_str_slice` / `nurl_str_cat*` / `nurl_sym_get` **always return a
   fresh owned allocation**. Emitted auto-drop frees a string temp that
@@ -104,13 +123,26 @@ one place you must not break:
   pointer (e.g. a suffix of the input) is a use-after-free / invalid
   free waiting to happen. This was measured, attempted and reverted —
   see the M1 commit; `nurl_llty`'s comment documents the same hazard.
-- Consequently the way to save memory is **algorithmic, at call
-  sites**: walk strings by index instead of re-slicing remainders
-  (`__bck_st_get_at` is the pattern), and build outputs in one
-  exact-size buffer instead of concat-accumulating.
-- History (self-compile peak RSS): 13.6 GB before the borrow-checker
-  state-map rewrite, 366 MB after. `tools/memgate.sh` (CI) keeps it
-  from regressing; if the gate fires on your PR, instrument first —
+- The way to save memory is still **algorithmic, at call sites**: walk
+  strings by index instead of re-slicing remainders (`__bck_st_get_at`
+  is the pattern), and build outputs in one exact-size buffer instead
+  of concat-accumulating.
+- What the campaign changed is that a helper's result is now *collected*
+  rather than abandoned, which is a property of its **ownership
+  summary**. Three ways to lose it, all of which cost real memory
+  before: returning `^ # s ( strdup … )` so the cast hides freshness
+  from return-site inference (declare the function `__ret_owned`);
+  defining a helper *below* its only caller, so no summary exists at
+  the call site (hoist it, or rely on the forward-call ownership
+  channel); and a mixed join — a borrowed parameter on one arm, a
+  tracked local on the other — which vetoes the marker for the whole
+  function. If you add a string-returning helper, check `leakgate` before
+  you check the clock.
+- History (self-compile peak RSS): 13.6 GB → 366 MB (borrow-checker
+  state-map rewrite) → 125 MB → 115.9 MB (lattice-array rewrite) →
+  **18.5 MB** (ownership campaign) → 24 MB (the module buffer the
+  dead-function pass needs). `tools/memgate.sh` (CI) keeps it from
+  regressing; if the gate fires on your PR, instrument first —
   per-site counters over `nurl_str_slice`/`str_skip_word` call sites
   found the last one in two runs.
 
@@ -124,7 +156,13 @@ one place you must not break:
    golden corpus. Borrow-checker changes: the `borrow_*` goldens are
    the behavioural spec.
 4. `./tools/memgate.sh` — the peak-RSS budget.
-5. Sanitizers run in CI (`build.sh --san` + `run_san_tests.sh`) — run
+5. `./tools/dcegate.sh` — proves the dead-function pass still drops
+   unreachable code AND still keeps the indirect routes (dyn vtable
+   thunks, `% Drop`, closures, monomorphs). The corpus catches only the
+   second half: a pass that kept everything would stay green.
+6. `./tools/leakgate.sh` — the self-compile must leak nothing. Needs a
+   `./build.sh --san --no-tests` first; zero tolerance, no budget.
+7. Sanitizers run in CI (`build.sh --san` + `run_san_tests.sh`) — run
    locally when touching drop/ownership codegen.
 
 ## 6. Appendix — every global and its writers (generated)
@@ -134,73 +172,93 @@ Regenerate after adding/renaming globals:
 
 | global | declared | written by | holds |
 |---|---|---|---|
-| `g_auto_drop_strings` | :1415 | `main` | Phase 2B auto-drop-strings feature flag. Default ON. Compiler's own source uses patterns (strings stored via n |
-| `g_bck` | :825 | `main` |  |
-| `g_bck_closure_depth` | :829 | `gen_closure_expr` |  |
-| `g_bck_depth` | :828 | `bck_block_enter`, `bck_block_exit`, `bck_fn_begin` | data (statement list etc.); allocated in main() only when --borrowck is set |
-| `g_bck_errors` | :833 | `bck_emit_error` | capture hooks no-op so closure statements do not inline into the enclosing function's list (so closure scopes  |
-| `g_borrowck` | :808 | `main` | ── Borrow-checker state ───────────────────────────────────────── g_borrowck is 1 (ON) by default; `--no-borro |
-| `g_closure_defs` | :794 | `main` |  |
-| `g_closure_emit_base` | :798 | `emit_closure_globals`, `main` |  |
-| `g_closure_types` | :795 | `main` |  |
-| `g_dbg_blob_syms` | :917 | `dbg_init` | module-flag id we might add later |
-| `g_dbg_cu_id` | :920 | `dbg_init` |  |
-| `g_dbg_current_file_id` | :949 | `gen_fn_decl_concrete` | defining path for the mono being emitted (the mono's lexer filename is the synthetic `<generic …>`). Set/resto |
-| `g_dbg_current_loc` | :923 | `gen_closure_expr`, `gen_fn_decl_concrete`, `gen_stmt` | (0 outside any function) |
-| `g_dbg_current_subprogram` | :921 | `gen_closure_expr`, `gen_fn_decl_concrete` |  |
-| `g_dbg_enabled` | :914 | `main` | ── DWARF debug-info state ─────────────────────────────────────── All zero/empty when --g is OFF; emit helpers |
-| `g_dbg_file_id` | :919 | `dbg_init` | flushed at end-of-module by dbg_flush |
-| `g_dbg_file_syms` | :938 | `dbg_init` | uses this instead of `nurl_lex_line` for the !DISubprogram source line. Set by emit_one_instantiation so per-m |
-| `g_dbg_next_id` | :915 | `dbg_alloc_id` |  |
-| `g_dbg_override_file` | :943 | `emit_one_instantiation` | every source file gets its own !DIFile and a subprogram debug-attributes to the file that DEFINES it (imports, |
-| `g_dbg_override_line` | :932 | `emit_one_instantiation` | the type for every local until Phase 6 lays down per-LLVM-type DIBasicType entries indexed by `vt`. |
-| `g_dbg_placeholder_ty` | :928 | `dbg_init` | dbg_init and reused for every fn. Phase 6 will replace with per-fn signature types. |
-| `g_dbg_subroutine_ty` | :925 | `dbg_init` | emit_dbg_eol then omits `, !dbg !N`) |
-| `g_dbg_type_syms` | :967 | `dbg_init` |  |
-| `g_defer_count` | :744 | `gen_defer`, `gen_fn_decl_concrete` |  |
+| `g_auto_drop_strings` | :1491 | `main` | Phase 2B auto-drop-strings feature flag. Default ON. Compiler's own source uses patterns (strings stored via n |
+| `g_bck` | :872 | `main` |  |
+| `g_bck_closure_depth` | :881 | `gen_closure_expr` |  |
+| `g_bck_depth` | :875 | `bck_block_enter`, `bck_block_exit`, `bck_fn_begin` | data (statement list etc.); allocated in main() only when --borrowck is set |
+| `g_bck_errors` | :885 | `bck_emit_error` | capture hooks no-op so closure statements do not inline into the enclosing function's list (so closure scopes  |
+| `g_bck_gen` | :876 | `bck_analyze` |  |
+| `g_bck_inn` | :880 | `bck_analyze`, `bck_intern` | intern table — bumped per bck_analyze so entries from earlier functions read as misses without any table clear |
+| `g_borrowck` | :853 | `main` | ── Borrow-checker state ───────────────────────────────────────── g_borrowck is 1 (ON) by default; `--no-borro |
+| `g_closure_defs` | :839 | `main` |  |
+| `g_closure_emit_base` | :843 | `emit_closure_globals`, `main` |  |
+| `g_closure_types` | :840 | `main` |  |
+| `g_dbg_blob_syms` | :969 | `dbg_init` | module-flag id we might add later |
+| `g_dbg_cu_id` | :972 | `dbg_init` |  |
+| `g_dbg_current_file_id` | :1001 | `gen_fn_decl_concrete` | defining path for the mono being emitted (the mono's lexer filename is the synthetic `<generic …>`). Set/resto |
+| `g_dbg_current_loc` | :975 | `dbg_synth_begin`, `dbg_synth_end`, `gen_closure_expr`, `gen_fn_decl_concrete` +1 | (0 outside any function) |
+| `g_dbg_current_subprogram` | :973 | `dbg_synth_begin`, `dbg_synth_end`, `gen_closure_expr`, `gen_fn_decl_concrete` |  |
+| `g_dbg_enabled` | :966 | `main` | ── DWARF debug-info state ─────────────────────────────────────── All zero/empty when --g is OFF; emit helpers |
+| `g_dbg_file_id` | :971 | `dbg_init` | flushed at end-of-module by dbg_flush |
+| `g_dbg_file_syms` | :990 | `dbg_init` | uses this instead of `nurl_lex_line` for the !DISubprogram source line. Set by emit_one_instantiation so per-m |
+| `g_dbg_next_id` | :967 | `dbg_alloc_id` |  |
+| `g_dbg_override_file` | :995 | `emit_one_instantiation` | every source file gets its own !DIFile and a subprogram debug-attributes to the file that DEFINES it (imports, |
+| `g_dbg_override_line` | :984 | `emit_one_instantiation` | the type for every local until Phase 6 lays down per-LLVM-type DIBasicType entries indexed by `vt`. |
+| `g_dbg_placeholder_ty` | :980 | `dbg_init` | dbg_init and reused for every fn. Phase 6 will replace with per-fn signature types. |
+| `g_dbg_subroutine_ty` | :977 | `dbg_init` | emit_dbg_eol then omits `, !dbg !N`) |
+| `g_dbg_type_syms` | :1019 | `dbg_init` |  |
+| `g_dce` | :21278 | `main` |  |
+| `g_dce_end` | :21284 | `dce_emit_module`, `dce_free` |  |
+| `g_dce_live` | :21285 | `dce_emit_module`, `dce_free` |  |
+| `g_dce_map` | :21288 | `dce_emit_module`, `dce_free` |  |
+| `g_dce_mod` | :21282 | `dce_emit_module` | The module text, as an integer cast of a BORROWED `s`. Deliberately not a `: ~ s` global: a mutable string glo |
+| `g_dce_qn` | :21287 | `__dce_mark_name`, `dce_emit_module` |  |
+| `g_dce_queue` | :21286 | `dce_emit_module`, `dce_free` |  |
+| `g_dce_start` | :21283 | `dce_emit_module`, `dce_free` |  |
+| `g_defer_count` | :759 | `gen_defer`, `gen_fn_decl_concrete` |  |
 | `g_diag_recover_active` | :92 | `parse_program` |  |
 | `g_did_ret` | :726 | `gen_closure_expr`, `gen_cond`, `gen_defer`, `gen_fn_decl_concrete` +5 |  |
-| `g_dyn_flat_out` | :781 | `__dyn_flat_add`, `__dyn_flat_reset` | Scratch accumulators for dyn_flat_methods (a NURL fn returns one value, so the recursive supertrait walk threa |
-| `g_dyn_flat_seen` | :782 | `__dyn_flat_add`, `__dyn_flat_reset` |  |
-| `g_dyn_needed` | :778 | `dyn_note_needed` | <Trait>__tparam           → trait's generic type-var name (e.g. "T") <Trait>__defaults         → space-separat |
+| `g_dyn_flat_out` | :826 | `__dyn_flat_add`, `__dyn_flat_reset` | Scratch accumulators for dyn_flat_methods (a NURL fn returns one value, so the recursive supertrait walk threa |
+| `g_dyn_flat_seen` | :827 | `__dyn_flat_add`, `__dyn_flat_reset` |  |
+| `g_dyn_needed` | :823 | `dyn_note_needed` | <Trait>__tparam           → trait's generic type-var name (e.g. "T") <Trait>__defaults         → space-separat |
 | `g_err_count` | :91 | `__diag_abort` | Multi-error mode (rustc-style): while parse_program's per-declaration recovery frame is active (g_diag_recover |
-| `g_ffi_host_imports` | :815 | `main` | g_ffi_host_imports is 1 when `--ffi-host-imports` is passed: external `&`-FFI libraries are then satisfied by  |
-| `g_fn_escapes` | :871 | `main` | Per-function escaping-parameter map. `g_fn_escapes[fname]` is the space-separated list of 0-based indices of p |
-| `g_fn_inout` | :850 | `main` | Per-function inout-parameter map. `g_fn_inout[fname]` is the space-separated list of 0-based indices of `inout |
-| `g_fn_invoke_only` | :885 | `main` | Per-function *invoke-only* parameter map (closure-env reclamation, docs/MEMORY.md §7.4). `g_fn_invoke_only[fna |
-| `g_fn_ret_param` | :909 | `main` | Per-function returned-parameter map. `g_fn_ret_param[fname]` is the space-separated list of 0-based indices of |
-| `g_fn_sink` | :860 | `main` | Per-function sink-parameter map. `g_fn_sink[fname]` is the space-separated list of 0-based indices of `sink` p |
-| `g_func_count` | :797 | `gen_call_kwargs`, `gen_closure_expr`, `main`, `store_closure_func` |  |
-| `g_generic_struct_syms` | :746 | `main` |  |
-| `g_generic_syms` | :745 | `main` |  |
-| `g_impl_name_syms` | :751 | `main` |  |
-| `g_impl_pos_syms` | :753 | `main` |  |
-| `g_impl_ret_syms` | :750 | `main` |  |
-| `g_impl_trait_syms` | :752 | `main` |  |
-| `g_in_match_arm` | :743 | `gen_match` | Non-zero while parsing a `??` match-arm body. The XOR-confusion warning in gen_ret keys off "a non-terminator  |
-| `g_last_closure_nonsend` | :793 | `gen_closure_expr` | record per impl block, verified after scan_fn_sigs once every impl across the program (incl. imports) is regis |
-| `g_last_type_ptr` | :3506 | `nurl_set_last_type` |  |
-| `g_lint` | :1455 | `main` | Unused-symbol lint (opt-in via `--lint`). Default OFF so ordinary builds — and the compiler's own bootstrap, w |
-| `g_lint_gen` | :1459 | `lint_fn_begin` |  |
-| `g_lint_reads` | :1458 | `lint_init` |  |
-| `g_lint_recording` | :1466 | `main` | 1 only during the main parse_program pass. Cleared before flush_deferred_instantiations so synthetic generic m |
-| `g_lint_syms` | :1456 | `lint_init` |  |
-| `g_lint_used` | :1457 | `lint_init` |  |
-| `g_mono_tparam_tys` | :966 | `emit_one_instantiation` | Space-separated list of the concrete type-arguments substituted for a generic function's type parameters in th |
-| `g_pending_escape` | :897 | `main` | Deferred interprocedural-escape checks (docs/MEMORY.md §3 forward / generic boundary). A stack reference passe |
-| `g_pending_pub` | :1430 | `parse_toplevel_decl`, `scan_fn_sigs`, `vis_take_pending_pub` | Visibility (grammar v2.0). Tracks the source-file of every @-defined function and per-file strict-mode opt-in. |
+| `g_ffi_host_imports` | :860 | `main` | g_ffi_host_imports is 1 when `--ffi-host-imports` is passed: external `&`-FFI libraries are then satisfied by  |
+| `g_fn_escapes` | :923 | `main` | Per-function escaping-parameter map. `g_fn_escapes[fname]` is the space-separated list of 0-based indices of p |
+| `g_fn_inout` | :902 | `main` | Per-function inout-parameter map. `g_fn_inout[fname]` is the space-separated list of 0-based indices of `inout |
+| `g_fn_invoke_only` | :937 | `main` | Per-function *invoke-only* parameter map (closure-env reclamation, docs/MEMORY.md §7.4). `g_fn_invoke_only[fna |
+| `g_fn_pos_syms` | :789 | `main` |  |
+| `g_fn_ret_param` | :961 | `main` | Per-function returned-parameter map. `g_fn_ret_param[fname]` is the space-separated list of 0-based indices of |
+| `g_fn_sink` | :912 | `main` | Per-function sink-parameter map. `g_fn_sink[fname]` is the space-separated list of 0-based indices of `sink` p |
+| `g_fn_slice_decls` | :757 | `gen_fn_decl_concrete`, `mem_slice_decl_add` | Cheap per-function gate for the Phase 2D slice machinery: most functions declare no owned slices at all, and t |
+| `g_func_count` | :842 | `gen_call_kwargs`, `gen_closure_expr`, `main`, `store_closure_func` |  |
+| `g_generic_struct_syms` | :761 | `main` |  |
+| `g_generic_syms` | :760 | `main` |  |
+| `g_impl_name_syms` | :766 | `main` |  |
+| `g_impl_pos_syms` | :798 | `main` | `@ fname` scan registration. Two files are free to each have a private `__get`-style helper IN THEIR OWN HEADS |
+| `g_impl_ret_syms` | :765 | `main` |  |
+| `g_impl_trait_syms` | :767 | `main` |  |
+| `g_in_match_arm` | :747 | `gen_match` | Non-zero while parsing a `??` match-arm body. The XOR-confusion warning in gen_ret keys off "a non-terminator  |
+| `g_last_closure_nonsend` | :838 | `gen_closure_expr` | record per impl block, verified after scan_fn_sigs once every impl across the program (incl. imports) is regis |
+| `g_last_type_ptr` | :3866 | `nurl_set_last_type` |  |
+| `g_lint` | :1531 | `main` | Unused-symbol lint (opt-in via `--lint`). Default OFF so ordinary builds — and the compiler's own bootstrap, w |
+| `g_lint_gen` | :1535 | `lint_fn_begin` |  |
+| `g_lint_reads` | :1534 | `lint_init` |  |
+| `g_lint_recording` | :1542 | `main` | 1 only during the main parse_program pass. Cleared before flush_deferred_instantiations so synthetic generic m |
+| `g_lint_syms` | :1532 | `lint_init` |  |
+| `g_lint_used` | :1533 | `lint_init` |  |
+| `g_mono_tparam_tys` | :1018 | `emit_one_instantiation` | Space-separated list of the concrete type-arguments substituted for a generic function's type parameters in th |
+| `g_owned_globals` | :730 | `gen_const_decl` | Names of the mutable string globals that own their buffer (each has a compiler-emitted `<name>__nurlown` flag) |
+| `g_pending_escape` | :949 | `main` | Deferred interprocedural-escape checks (docs/MEMORY.md §3 forward / generic boundary). A stack reference passe |
+| `g_pending_pub` | :1506 | `parse_toplevel_decl`, `scan_fn_sigs`, `vis_take_pending_pub` | Visibility (grammar v2.0). Tracks the source-file of every @-defined function and per-file strict-mode opt-in. |
+| `g_priv_file_count` | :785 | `priv_file_id` |  |
+| `g_priv_file_ids` | :784 | `main` | `??`/`?` arms). Consumers that NEED a value (a cast, a let/assign) die with this appended, so "produced no val |
+| `g_priv_owner_files` | :787 | `main` |  |
+| `g_priv_owner_ids` | :786 | `main` |  |
+| `g_priv_warned` | :788 | `main` |  |
+| `g_ptrtab` | :871 | `main` |  |
 | `g_res_type_syms` | :239 | `main` | ── Res-type NURL tracking (must be declared before parse_type_res) ── g_res_type_syms is initialized to a new  |
-| `g_ret_forbidden` | :737 | `gen_cond`, `gen_logical_or_bitwise_and`, `gen_logical_or_bitwise_or`, `gen_operand` +1 | Cascade guard: 1 while parsing a VALUE OPERAND (a binary/unary/cast/ member operand, a call argument, a `?`/`? |
-| `g_stmt_bare_lit` | :2423 | `gen_stmt` | g_stmt_bare_lit — set by gen_stmt to 1 when the statement it just parsed was a bare numeric/string LITERAL in  |
-| `g_stmt_bare_value` | :2436 | `gen_stmt` | g_stmt_bare_value — the literal flag's general sibling (critic A2, the last silent prefix-arity cascade): set  |
-| `g_stmt_col` | :2381 | `gen_stmt` | g_stmt_col — column of the current statement's first token, captured alongside g_stmt_line. `die_stmt` anchors |
-| `g_stmt_line` | :2374 | `gen_stmt` | g_stmt_line — source line of the statement gen_stmt is currently parsing. Read by gen_ident's "unexpected toke |
+| `g_ret_forbidden` | :741 | `gen_cond`, `gen_logical_or_bitwise_and`, `gen_logical_or_bitwise_or`, `gen_operand` +1 | Cascade guard: 1 while parsing a VALUE OPERAND (a binary/unary/cast/ member operand, a call argument, a `?`/`? |
+| `g_stmt_bare_lit` | :2625 | `gen_stmt` | g_stmt_bare_lit — set by gen_stmt to 1 when the statement it just parsed was a bare numeric/string LITERAL in  |
+| `g_stmt_bare_value` | :2638 | `gen_stmt` | g_stmt_bare_value — the literal flag's general sibling (critic A2, the last silent prefix-arity cascade): set  |
+| `g_stmt_col` | :2583 | `gen_stmt` | g_stmt_col — column of the current statement's first token, captured alongside g_stmt_line. `die_stmt` anchors |
+| `g_stmt_line` | :2576 | `gen_stmt` | g_stmt_line — source line of the statement gen_stmt is currently parsing. Read by gen_ident's "unexpected toke |
 | `g_str_idx` | :724 | `emit_deferred_cstr`, `emit_str_global`, `gen_str_lit` |  |
 | `g_str_syms` | :725 | `main` |  |
-| `g_strict_borrowck` | :824 | `main` | `--strict-borrowck` (off by default) enables two additional checks: (1) aliased mutation through `. obj field` |
-| `g_struct_inst_syms` | :749 | `main` | <sname>__stparams → space-separated type-var names (e.g. "T" or "K V") <sname>__sbody    → raw body source inc |
-| `g_super_obligations` | :783 | `scan_impl_decl` |  |
-| `g_trait_syms` | :760 | `main` | first registration. A `$`-imported impl is scanned once per importer, so the SAME (method, type) is registered |
-| `g_type_count` | :796 | `main`, `store_closure_type` |  |
-| `g_type_emit_base` | :799 | `main` |  |
-| `g_vis_syms` | :1431 | `main` |  |
+| `g_strict_borrowck` | :870 | `main` | `--strict-borrowck` (off by default) enables three additional checks: (1) aliased mutation through `. obj fiel |
+| `g_struct_inst_syms` | :764 | `main` | <sname>__stparams → space-separated type-var names (e.g. "T" or "K V") <sname>__sbody    → raw body source inc |
+| `g_super_obligations` | :828 | `scan_impl_decl` |  |
+| `g_trait_syms` | :805 | `main` | first registration. A `$`-imported impl is scanned once per importer, so the SAME (method, type) is registered |
+| `g_type_count` | :841 | `main`, `store_closure_type` |  |
+| `g_type_emit_base` | :844 | `main` |  |
+| `g_vis_syms` | :1507 | `main` |  |
+| `g_void_reason` | :768 | `__void_reason_clear`, `gen_cond`, `gen_match`, `int_width` |  |

--- a/webdocs/content/docs/compiling-and-running.mdx
+++ b/webdocs/content/docs/compiling-and-running.mdx
@@ -60,6 +60,26 @@ Link against `stdlib/runtime.native.o`, not `stdlib/runtime.o` — after a
 normal build the latter is LLVM bitcode (for link-time optimization), and a
 plain `clang` link rejects it with *"file format not recognized"*.
 
+<Accordions>
+  <Accordion title="Why is the .ll smaller than the code I imported?">
+    `nurlc` emits only the functions your `main` can actually reach. An
+    import brings in a whole module — importing `stdlib/ext/json.nu` for
+    `json_parse` also brings the pretty-printer, the comparison helpers
+    and the float formatter — and handing all of that to `clang` means
+    paying for optimizing code the linker then throws away. Dropping it
+    at the source of the IR instead is worth 30–40% of the `clang` step
+    on a stdlib-heavy program.
+
+    The binary is unchanged: link-time optimization was already removing
+    the same code, just later. Reachability is computed over the finished
+    IR, so closures, generic instantiations, destructors and dynamic
+    trait vtables are all handled without special cases, and a file with
+    no `main` — a module you intend to link into something else — is
+    left whole. `nurlc --no-dce` emits everything, which is what you want
+    when diffing IR against an older compiler.
+  </Accordion>
+</Accordions>
+
 ## If you installed the prebuilt toolchain
 
 The prebuilt `curl | sh` installer gives you `nurlc`, `nurlpkg`, and


### PR DESCRIPTION
Release prep for **v0.30.0**. No code changes — CHANGELOG, ROADMAP and the docs that had gone stale. Tag goes on `main` once this merges.

## Why 0.30.0

Everything since `v0.29.0` is about what `nurlc` **spends** — memory, syscalls, and the work it hands to clang. Nothing in it changes what a NURL program means.

| | before | after |
|---|---:|---:|
| self-compile leaked allocations | 2,793,226 | **0** |
| self-compile peak RSS | 115.9 MB | **18.5 MB** → 24 MB (module buffer) |
| compiler instruction count | 3.318 G | **2.631 G** (−20.7%) |
| write syscalls compiling static_server | 188,713 | **725** |
| `examples/static_server.nu` end-to-end | 7.19 s | **4.32 s** |
| test corpus wall clock (`./build.sh`) | 1 m 11 s | **42 s** |

## CHANGELOG

The `[Unreleased]` entries become `[0.30.0]`, and **the ~30 commits of the ownership campaign that had no entry at all** are now written up.

The campaign landed one class at a time — each commit its own root cause — which reads as a wall of near-identical subjects in the log. The changelog records it as one `### Fixed` entry naming the five recurring roots:

- ownership hidden behind a `# s ( strdup … )` cast (`nurl_sym_get` alone: 1.77 M strdups per self-compile);
- ownership guessed per path, now all-paths-or-nothing;
- the def-order gap — a helper defined below its caller has no summary at the call site;
- copies nobody consumes — every `? c { = x y } {}` minted a buffer with no consumer;
- mixed joins — a borrowed parameter on one arm, a tracked local on the other.

Plus the two that were **live-memory bugs**, not leaks: reassigning a tracked mutable string could `free` a `.rodata` literal or a borrow, and an over-eager owned marker made callers free a value they did not own.

Also newly recorded: the borrow-checker lattice-array rewrite under `### Performance`, and the fumadocs 16.14 bump.

## Docs — stale, not merely incomplete

- **`docs/dev/COMPILER_INTERNALS.md` §4** opened with *"the compiler allocates arena-style: temporaries are **not** freed"*. That stopped being true at the end of the campaign. Rewritten around what a contributor now has to get right (the three ways to lose a helper's ownership summary), peak-RSS history extended `13.6 GB → 366 MB → 115.9 → 18.5 → 24 MB`, and `dcegate` + `leakgate` added to the changing-the-compiler checklist.
- The same file's **pipeline diagram** and **borrow-checker row** predated both the lattice array and the module buffer. Both updated; the generated globals appendix regenerated for the `g_dce*` family.
- **`ROADMAP.md`** still said *"Current release: 0.24.1"* — five releases stale.
- **webdocs `compiling-and-running`** gained the "why is the `.ll` smaller than the code I imported?" answer, since `--no-dce` is the first `nurlc` flag a user meets by being surprised.

Checked and already current: `docs/MEMORY.md` §6.6 (it gained `leakgate` with the gate itself), `docs/BUILDING.md` (gained the emission section with the DCE change), `README.md` (no pinned version), `tools/gen-site-facts.sh` (derives from `git describe`). `check_builtins_doc`, `check_stdlib_symbols`, `check_installer_sync`, `check_package_imports` all pass.

## Verification on the release tree

`./build.sh` green (568 tests, bootstrap fixed point) · examples gate 98/98 · `dcegate` OK · `memgate` OK.

## One thing deliberately not in this release

`tools/mcp_spec_drift_check.sh` reports the upstream MCP spec moved `2025-11-25 → 2026-07-28`. Pre-existing, unrelated to this release, and re-pinning it is its own review against the upstream changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FREmK7Qhd5sMWtNi9QVWHw