### PR TITLE
tests: Windows golden for stdout_flush_order — its harness cannot interleave

### DIFF
--- a/compiler/tests/outputs-windows/stdout_flush_order.txt
+++ b/compiler/tests/outputs-windows/stdout_flush_order.txt
@@ -1,0 +1,11 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+1 stdout via nurl_print
+3 stdout again
+5 stdout before a raw write
+6 raw write(2) on fd 1
+7 stdout last
+2 stderr via nurl_eprintln
+4 stderr via nurl_eprint

--- a/compiler/tests/run_tests.ps1
+++ b/compiler/tests/run_tests.ps1
@@ -394,6 +394,16 @@ $results = $names | ForEach-Object -ThrottleLimit $Jobs -Parallel {
         $sign = if ($_.SideIndicator -eq '<=') { '-' } else { '+' }
         "$sign $($_.InputObject)"
     }) -join "`n"
+    # Compare-Object matches line SETS, not sequences, so a pure
+    # REORDERING fails the byte compare above and produces no rows here —
+    # a FAIL printed under an empty diff, which reads like a harness bug.
+    # Name the actual difference instead. (stdout_flush_order hit this:
+    # the runner concatenates the child's two pipes rather than
+    # interleaving them, so its lines arrive in a different order than
+    # the posix golden records.)
+    if ([string]::IsNullOrWhiteSpace($diff)) {
+        $diff = '  (same lines, different order — golden and actual differ only in sequence)'
+    }
     return [pscustomobject]@{ Name = $name; Verdict = 'FAIL'; Diff = $diff }
 }
 

--- a/compiler/tests/stdout_flush_order.nu
+++ b/compiler/tests/stdout_flush_order.nu
@@ -14,8 +14,17 @@
 //      program must flush stdout itself before one — same discipline
 //      as mixing printf and write(1, …) in C.
 //
-// The runner captures `> out 2>&1`, so the golden file below IS the
-// interleaving.
+// The POSIX runner captures `> out 2>&1`, so `outputs/` IS the
+// interleaving, and rule 2 is what that golden asserts.
+//
+// `outputs-windows/` records the same run with the lines in a different
+// order, and that is expected rather than a Windows bug: run_tests.ps1
+// reads the child's two pipes separately and concatenates them
+// (`Out = $o.Result + $e.Result`), so no interleaving survives to be
+// compared — every stderr line lands after every stdout line whatever
+// the program did. Rules 1 and 3 still hold there and the Windows
+// golden still pins them; rule 2 is simply unobservable through that
+// harness. Do not "fix" the Windows golden into the POSIX order.
 
 & `libc` @ write i fd s buf i count → i
 


### PR DESCRIPTION
Fixes the Windows leg on `main`:

```
PASS 548 · FAIL 1 · MISSING 0 · ORPHAN 0 · SKIP 49
--- stdout_flush_order ---

```

## The empty diff is the diagnosis

`run_tests.ps1` compares goldens **byte-for-byte** (`-ceq`) but renders the difference with `Compare-Object`, which matches line **sets**, not sequences. A pure reordering therefore fails the compare and produces *no rows* — a FAIL under a blank diff.

Same lines, different order.

## Why the order differs — and why that is not a Windows bug

`stdout_flush_order` pins three rules; rule 2 is that a stderr write drains stdout first, so an observer merging the streams sees them in program order. The posix runner *is* such an observer (`> out 2>&1`).

`run_tests.ps1` cannot be one. It reads the child's two pipes separately and concatenates the results:

```powershell
return @{ Code = $code; Out = ($o.Result + $e.Result) }
```

Every stderr line lands after every stdout line regardless of what the program did — interleaving does not survive to be compared. `compiler/tests/outputs-windows/mcp_hardening.txt` already records exactly this shape (its `[mcp]` stderr line sits last, while the posix golden has it second).

## The fix

The test had no Windows golden and fell back to the posix one. `run_tests.ps1`'s own comment calls that fallback's failure "the deliberate moment to add an `outputs-windows/` golden" — so, added:

```
1 stdout via nurl_print
3 stdout again
5 stdout before a raw write
6 raw write(2) on fd 1
7 stdout last
2 stderr via nurl_eprintln
4 stderr via nurl_eprint
```

Rules 1 and 3 — stdout stays in program order with itself, and a raw `write(2)` on fd 1 needs an explicit flush first — still hold on Windows, and the new golden still pins them. Rule 2 is simply unobservable through that harness. The reason is written into the test header so nobody later "fixes" the Windows golden back into posix order.

## Also

An empty diff under a FAIL heading reads like a harness bug and cost a round-trip here. `run_tests.ps1` now prints *"same lines, different order"* when `Compare-Object` finds nothing.

## Checks

- `tools/check_windows_goldens.sh` — OK, 526 pairs. The new golden **reorders** lines rather than dropping them, so it is not the stale-golden shape that check hunts for (no `PURE_DELETION_OK` entry needed).
- Posix suite unaffected: `stdout_flush_order`, `dce_reachability`, `mcp_hardening`, `test_11_fat_strings` all pass.
- No compiler or runtime change — goldens, one test comment, one harness message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FREmK7Qhd5sMWtNi9QVWHw