### PR TITLE
tls: stop serving the cipher suite we are 500x slower at, and stop copying every record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure was a pre-existing one (`-lsqlite3`, `canvas.o`, a module with
   no `main`) reproduced identically by the unsplit build.
 
+- **`bench/crypto_hotpath.nu` — AEAD record throughput, without a socket
+  in the way.** One "op" is one 16384-byte record, the largest TLS 1.3
+  allows and so the size the record layer actually works in; it reports
+  ns/op, allocations/op and the MB/s those imply for both suites TLS 1.3
+  defines. It is what found the cipher-preference bug below: the two
+  suites are three orders of magnitude apart on a CPU NURL cannot reach
+  the AES instructions of, and nothing was measuring that.
+
 ### Changed
+
+- **A pure-NURL TLS server no longer picks the cipher suite it is 500×
+  slower at — 24.9 s → 0.15 s for an 8 MB response.** `tls_server.nu`
+  walked the ClientHello and took the *client's* first acceptable suite.
+  Chrome, Firefox and Go's `crypto/tls` all list `TLS_AES_128_GCM_SHA256`
+  ahead of ChaCha20 when the CPU has AES instructions, so those clients
+  got AES-GCM — and NURL has no AES-NI path. `std/aes_gcm.nu` derives
+  every S-box byte through a constant-time GF(2^8) inversion instead of
+  a cache-timing-visible table, which is the right call for security and
+  costs about four thousand cycles a byte. Measured on 16 KB records
+  (`bench/crypto_hotpath.nu`): **AES-128-GCM 0.5 MB/s, ChaCha20-Poly1305
+  306 MB/s.** The server now prefers ChaCha20-Poly1305 whenever the
+  client offers it at all. Downloading 8 MB from a NURL HTTPS server
+  with `openssl s_client -ciphersuites
+  'TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256'` went from
+  **24.87 s to 0.151 s**. Clients that offer *only* AES-128-GCM still
+  negotiate it and still work — RFC 8446 makes that suite mandatory, so
+  it cannot simply be dropped; a software-only stack preferring ChaCha
+  is what OpenSSL itself does on a CPU without AES instructions.
+
+- **The ChaCha20-Poly1305 record path stopped copying every record
+  through a bounds-checked byte loop — TLS reads 150 → 214 MB/s.**
+  `aead_decrypt` extracted the ciphertext from the `ciphertext‖tag`
+  buffer with one `vec_get` and one `vec_push` *per byte* before either
+  the MAC or the keystream would look at it: a quarter of the whole
+  receive path, and the same shape a comment three functions up records
+  having already fixed once. Both consumers now take a range —
+  `chacha20_xor_range` is the new entry point, `__mac_data` takes an
+  offset and length — so nothing is copied out of the record at all.
+
+  Two more in the same file. `chacha20_block` was a second, accessor-based
+  copy of the round function, ~960 bounds-checked `Vec` calls a block,
+  and the AEAD ran one per record for the Poly1305 one-time key; it is
+  now the register-resident kernel applied to a zero plaintext, and the
+  duplicate quarter-round helpers are gone. And the kernel XORs a whole
+  64-byte block through eight 8-byte loads and stores when both buffers
+  are 8-byte aligned — a `Vec`'s storage is malloc'd, so they are —
+  instead of sixty-four of each with their shifts and masks. The byte
+  path stays as the fallback for unaligned offsets and big-endian
+  machines, which the file now probes for rather than assumes, and a new
+  vector pins the two paths to the same output.
+
+  | 16 KB records | before | after |
+  |---|---:|---:|
+  | `aead_encrypt` | 282 MB/s, 15 allocs/op | **313 MB/s, 12 allocs/op** |
+  | `aead_decrypt` | 198 MB/s, 17 allocs/op | **306 MB/s, 12 allocs/op** |
+  | `tls_read` over loopback | 150 MB/s | **214 MB/s** |
+  | `tls_write` over loopback | 218 MB/s | **259 MB/s** |
 
 - **Every string a NURL program allocates comes off the runtime's
   recycling allocator — 27% off `nurlc`'s own run time.** 0.30.0 put a

--- a/bench/crypto_hotpath.nu
+++ b/bench/crypto_hotpath.nu
@@ -1,0 +1,108 @@
+// bench/crypto_hotpath.nu — throughput of the AEAD record protection a
+// pure-NURL TLS connection runs every byte through, measured without a
+// socket in the way. Run directly:
+//
+//     ./nurl.sh -O2 bench/crypto_hotpath.nu bench/_build/crypto && bench/_build/crypto
+//
+// One "op" is one 16384-byte record — the largest TLS 1.3 allows, and so
+// the size the record layer actually works in. Reported as ns/op,
+// allocations/op and the MB/s those imply, because MB/s is the number a
+// download is felt in.
+//
+// Both suites TLS 1.3 defines are here: ChaCha20-Poly1305, which is what
+// NURL negotiates by default and what a host with no AES instructions
+// wants, and AES-128-GCM for the servers that pick it.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/bench.nu`
+$ `stdlib/std/chacha20poly1305.nu`
+$ `stdlib/std/aes_gcm.nu`
+
+// A TLS record's plaintext limit (RFC 8446 §5.1).
+@ record_size → i { ^ 16384 }
+
+@ filled i n i seed → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] n )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] v # u & + seed * k 31 255 ) = k + k 1 }
+    ^ v
+}
+
+// ns/op over a 16 KB record → MB/s to one decimal. Whole MB/s would
+// print the AES suite as `0`, and the point of this table is that the
+// two suites are three orders of magnitude apart. (`nurl_print_int` ends
+// its own line, so the digits go through `nurl_str_int` instead.)
+@ report_mbps s label i ns_per_op → v {
+    : i tenths ? > ns_per_op 0 / * ( record_size ) 10000 ns_per_op 0
+    ( nurl_print label )
+    ( nurl_print `: ` )
+    ( nurl_print ( nurl_str_int / tenths 10 ) )
+    ( nurl_print `.` )
+    ( nurl_print ( nurl_str_int % tenths 10 ) )
+    ( nurl_print ` MB/s\n\n` )
+}
+
+@ main → i {
+    : i n ( record_size )
+    : ( Vec u ) key32 ( filled 32 7 )
+    : ( Vec u ) key16 ( filled 16 7 )
+    : ( Vec u ) nonce ( filled 12 3 )
+    : ( Vec u ) aad ( filled 5 1 )
+    : ( Vec u ) pt ( filled n 11 )
+    : ( Vec u ) sealed_cc ( aead_encrypt key32 nonce aad pt )
+    : ( Vec u ) sealed_gcm ( aes128_gcm_encrypt key16 nonce aad pt )
+
+    ( nurl_print `AEAD record throughput, ` )
+    ( nurl_print ( nurl_str_int n ) )
+    ( nurl_print `-byte records (ns/op, allocs/op):\n\n` )
+
+    : ( @ v ) b_cc_seal \ → v {
+        : ( Vec u ) c ( aead_encrypt key32 nonce aad pt )
+        ( vec_free [u] c )
+    }
+    : BenchResult r1 ( bench_auto `chacha20poly1305_seal` b_cc_seal )
+    ( bench_report r1 )
+    ( report_mbps `chacha20poly1305_seal` . r1 ns_per_op )
+    ( bench_result_free r1 )
+
+    : ( @ v ) b_cc_open \ → v {
+        ?? ( aead_decrypt key32 nonce aad sealed_cc ) {
+            T p → { ( vec_free [u] p ) }
+            F _ → {}
+        }
+    }
+    : BenchResult r2 ( bench_auto `chacha20poly1305_open` b_cc_open )
+    ( bench_report r2 )
+    ( report_mbps `chacha20poly1305_open` . r2 ns_per_op )
+    ( bench_result_free r2 )
+
+    : ( @ v ) b_gcm_seal \ → v {
+        : ( Vec u ) c ( aes128_gcm_encrypt key16 nonce aad pt )
+        ( vec_free [u] c )
+    }
+    : BenchResult r3 ( bench_auto `aes128_gcm_seal` b_gcm_seal )
+    ( bench_report r3 )
+    ( report_mbps `aes128_gcm_seal` . r3 ns_per_op )
+    ( bench_result_free r3 )
+
+    : ( @ v ) b_gcm_open \ → v {
+        ?? ( aes128_gcm_decrypt key16 nonce aad sealed_gcm ) {
+            T p → { ( vec_free [u] p ) }
+            F _ → {}
+        }
+    }
+    : BenchResult r4 ( bench_auto `aes128_gcm_open` b_gcm_open )
+    ( bench_report r4 )
+    ( report_mbps `aes128_gcm_open` . r4 ns_per_op )
+    ( bench_result_free r4 )
+
+    ( vec_free [u] key32 )
+    ( vec_free [u] key16 )
+    ( vec_free [u] nonce )
+    ( vec_free [u] aad )
+    ( vec_free [u] pt )
+    ( vec_free [u] sealed_cc )
+    ( vec_free [u] sealed_gcm )
+    ^ 0
+}

--- a/compiler/tests/chacha20poly1305_vectors.nu
+++ b/compiler/tests/chacha20poly1305_vectors.nu
@@ -61,6 +61,26 @@ $ `stdlib/std/chacha20poly1305.nu`
         F _ → { ( nurl_print `aead_open: FAIL (rejected valid tag)\n` ) = fails + fails 1 }
     }
 
+    // chacha20_xor_range over an UNALIGNED source. The kernel XORs a
+    // whole 64-byte block through 8-byte machine words when both buffers
+    // are 8-byte aligned and falls back to a byte-at-a-time loop when
+    // they are not; a Vec's storage is always aligned, so only an odd
+    // `doff` reaches the fallback. Both paths must produce the same
+    // ciphertext, which is what this pins: the same plaintext is
+    // encrypted once at offset 0 (word path) and once as the tail of a
+    // one-byte-longer buffer (byte path).
+    : ( Vec u ) shifted ( vec_with_cap [u] + ( vec_len [u] pt ) 1 )
+    ( vec_push [u] shifted # u 170 )
+    ( bytes_extend_bytes shifted pt )
+    : ( Vec u ) ct_aligned ( chacha20_xor_range key1 1 n24 pt 0 ( vec_len [u] pt ) )
+    : ( Vec u ) ct_unaligned ( chacha20_xor_range key1 1 n24 shifted 1 ( vec_len [u] pt ) )
+    : String want_hex ( bytes_to_hex ct_aligned )
+    = fails + fails ( check `chacha20_range_unaligned` ct_unaligned ( string_data want_hex ) )
+    ( string_free want_hex )
+    ( vec_free [u] ct_aligned )
+    ( vec_free [u] ct_unaligned )
+    ( vec_free [u] shifted )
+
     // AEAD tamper detection: flip one ciphertext byte → must reject.
     ( vec_set [u] sealed 0 # u ^^ 255 ?? ( vec_get [u] sealed 0 ) { T x → # i x F _ → 0 } )
     ?? ( aead_decrypt akey anonce aad sealed ) {

--- a/compiler/tests/outputs-windows/chacha20poly1305_vectors.txt
+++ b/compiler/tests/outputs-windows/chacha20poly1305_vectors.txt
@@ -7,5 +7,6 @@ chacha20_decrypt: PASS
 poly1305: PASS
 aead_seal: PASS
 aead_open: PASS
+chacha20_range_unaligned: PASS
 aead_tamper: PASS
 chacha20poly1305: all vectors PASS

--- a/compiler/tests/outputs/chacha20poly1305_vectors.txt
+++ b/compiler/tests/outputs/chacha20poly1305_vectors.txt
@@ -7,5 +7,6 @@ chacha20_decrypt: PASS
 poly1305: PASS
 aead_seal: PASS
 aead_open: PASS
+chacha20_range_unaligned: PASS
 aead_tamper: PASS
 chacha20poly1305: all vectors PASS

--- a/stdlib/std/chacha20poly1305.nu
+++ b/stdlib/std/chacha20poly1305.nu
@@ -5,7 +5,7 @@
 // TLS_CHACHA20_POLY1305_SHA256 cipher suite), and is equally usable for
 // Noise / age / any AEAD need on a host with nothing installed.
 //
-// ChaCha20 words are kept in i64 limbs masked to 32 bits (`__m32`);
+// ChaCha20 words are kept in i64 limbs masked to 32 bits;
 // Poly1305 is a port of the well-trodden poly1305-donna radix-2^26
 // reference, whose partial products stay well under 2^63 so plain i64
 // arithmetic suffices.
@@ -13,6 +13,7 @@
 // Public surface:
 //   ( chacha20_block key counter nonce )      → ( Vec u )  64-byte block
 //   ( chacha20_xor key counter nonce data )   → ( Vec u )  stream cipher
+//   ( chacha20_xor_range k c n data off len ) → ( Vec u )  … over a range
 //   ( poly1305_mac otk msg )                  → ( Vec u )  16-byte tag
 //   ( aead_encrypt key nonce aad plaintext )  → ( Vec u )  ciphertext||tag
 //   ( aead_decrypt key nonce aad ct_and_tag ) → ?( Vec u ) None if forged
@@ -38,74 +39,49 @@ $ `stdlib/core/vec.nu`
     ^ | | | ( __cc_bget v off ) << ( __cc_bget v + off 1 ) 8 << ( __cc_bget v + off 2 ) 16 << ( __cc_bget v + off 3 ) 24
 }
 
-@ __m32 i x → i { ^ & x 4294967295 }
-
-// 32-bit rotate left.
-@ __rotl32 i x i n → i {
-    ^ & | << & x 4294967295 n >> & x 4294967295 - 32 n 4294967295
-}
-
-@ __wget ( Vec i ) v i k → i {
-    ?? ( vec_get [i] v k ) { T x → ^ x F _ → ^ 0 }
-}
-
-@ __wset ( Vec i ) v i k i val → v { ( vec_set [i] v k val ) }
-
 // ── ChaCha20 ──────────────────────────────────────────────────────
-// One quarter-round, mutating state words a,b,c,d in place.
-@ __qr ( Vec i ) s i a i b i c i d → v {
-    ( __wset s a ( __m32 + ( __wget s a ) ( __wget s b ) ) )
-    ( __wset s d ( __rotl32 ^^ ( __wget s d ) ( __wget s a ) 16 ) )
-    ( __wset s c ( __m32 + ( __wget s c ) ( __wget s d ) ) )
-    ( __wset s b ( __rotl32 ^^ ( __wget s b ) ( __wget s c ) 12 ) )
-    ( __wset s a ( __m32 + ( __wget s a ) ( __wget s b ) ) )
-    ( __wset s d ( __rotl32 ^^ ( __wget s d ) ( __wget s a ) 8 ) )
-    ( __wset s c ( __m32 + ( __wget s c ) ( __wget s d ) ) )
-    ( __wset s b ( __rotl32 ^^ ( __wget s b ) ( __wget s c ) 7 ) )
+// The round function lives once, inside `chacha20_xor_range` below, with
+// the sixteen state words held in locals. The separate quarter-round /
+// state-vector helpers this file used to carry for `chacha20_block` were
+// the accessor-based second copy of it, and are gone.
+
+// Does a 64-bit store land in memory low byte first? The block loop
+// below combines two 32-bit keystream words into one machine word and
+// stores it whole, which is only the same bytes on a little-endian
+// machine. Every target NURL builds for is one, but this file is where
+// getting it wrong would mean silently wrong ciphertext rather than a
+// build error, so it asks instead of assuming — once, into a global, not
+// once per record. (Two threads racing here both write the same answer.)
+: ~ i g_cc_le -1
+
+@ __le_words → i {
+    ? >= g_cc_le 0 { ^ g_cc_le } {}
+    : *u p # *u ( nurl_zalloc 8 )
+    ( nurl_poke # s p 0 1 )
+    = g_cc_le ? == # i . p 0 1 1 0
+    ( nurl_free # s p )
+    ^ g_cc_le
 }
 
-// Build the 16-word initial state for (key, counter, nonce).
-@ __chacha_state ( Vec u ) key i counter ( Vec u ) nonce → ( Vec i ) {
-    : ( Vec i ) s ( vec_with_cap [i] 16 )
-    ( vec_push [i] s 1634760805 )  // "expa"
-    ( vec_push [i] s 857760878 )  // "nd 3"
-    ( vec_push [i] s 2036477234 )  // "2-by"
-    ( vec_push [i] s 1797285236 )  // "te k"
+// `n` zero bytes — the plaintext that turns the XOR kernel into a plain
+// keystream generator.
+@ __zeros i n → ( Vec u ) {
+    : ( Vec u ) z ( vec_with_cap [u] ? > n 0 n 1 )
     : ~ i k 0
-    ~ < k 8 { ( vec_push [i] s ( __ld32 key * 4 k ) ) = k + k 1 }
-    ( vec_push [i] s ( __m32 counter ) )
-    ( vec_push [i] s ( __ld32 nonce 0 ) )
-    ( vec_push [i] s ( __ld32 nonce 4 ) )
-    ( vec_push [i] s ( __ld32 nonce 8 ) )
-    ^ s
+    ~ < k n { ( vec_push [u] z # u 0 ) = k + k 1 }
+    ^ z
 }
 
-// The 64-byte keystream block for (key, counter, nonce).
+// The 64-byte keystream block for (key, counter, nonce). Keystream is
+// what the XOR kernel produces against a zero plaintext, so this goes
+// through `chacha20_xor_range` rather than keeping a second, slower copy
+// of the round function: the accessor-based version this replaced ran
+// ~960 bounds-checked Vec calls a block, and the AEAD below needs one
+// block PER RECORD for the Poly1305 one-time key.
 @ chacha20_block ( Vec u ) key i counter ( Vec u ) nonce → ( Vec u ) {
-    : ( Vec i ) s ( __chacha_state key counter nonce )
-    : ( Vec i ) w ( vec_with_cap [i] 16 )
-    : ~ i k 0
-    ~ < k 16 { ( vec_push [i] w ( __wget s k ) ) = k + k 1 }
-    : ~ i r 0
-    ~ < r 10 {
-        ( __qr w 0 4 8 12 )
-        ( __qr w 1 5 9 13 )
-        ( __qr w 2 6 10 14 )
-        ( __qr w 3 7 11 15 )
-        ( __qr w 0 5 10 15 )
-        ( __qr w 1 6 11 12 )
-        ( __qr w 2 7 8 13 )
-        ( __qr w 3 4 9 14 )
-        = r + r 1
-    }
-    : ( Vec u ) out ( vec_with_cap [u] 64 )
-    : ~ i i 0
-    ~ < i 16 {
-        ( __push_le32 out ( __m32 + ( __wget w i ) ( __wget s i ) ) )
-        = i + i 1
-    }
-    ( vec_free [i] s )
-    ( vec_free [i] w )
+    : ( Vec u ) z ( __zeros 64 )
+    : ( Vec u ) out ( chacha20_xor_range key counter nonce z 0 64 )
+    ( vec_free [u] z )
     ^ out
 }
 
@@ -121,11 +97,25 @@ $ `stdlib/core/vec.nu`
 // it is what takes a pure-NURL TLS download from ~27 MB/s to well over
 // 100.
 @ chacha20_xor ( Vec u ) key i counter ( Vec u ) nonce ( Vec u ) data → ( Vec u ) {
-    : i n ( vec_len [u] data )
+    ^ ( chacha20_xor_range key counter nonce data 0 ( vec_len [u] data ) )
+}
+
+// The same, over the `n` bytes of `data` starting at `doff`, so a caller
+// that holds its plaintext or ciphertext INSIDE a larger buffer does not
+// have to slice a copy out first just to name it. An AEAD record arrives
+// as ciphertext‖tag in one Vec, and every 16 KB of a TLS transfer used
+// to be copied out of that buffer byte by bounds-checked byte before
+// this kernel would look at it.
+//
+// The caller is responsible for `doff + n` being within `data`; this is
+// a private-by-convention entry point (the AEAD pair below and the
+// record layer are its only users) and it does no bounds check of its
+// own, exactly like the raw-pointer loop it feeds.
+@ chacha20_xor_range ( Vec u ) key i counter ( Vec u ) nonce ( Vec u ) data i doff i n → ( Vec u ) {
     : ( Vec u ) out ( vec_with_cap [u] ? > n 0 n 1 )
     : b _ol ( vec_set_len [u] out n )
     ? == n 0 { ^ out } {}
-    : *u dp ( vec_data [u] data )
+    : *u dp # *u + # i ( vec_data [u] data ) doff
     : *u op ( vec_data [u] out )
     : i k0 ( __ld32 key 0 )
     : i k1 ( __ld32 key 4 )
@@ -138,6 +128,13 @@ $ `stdlib/core/vec.nu`
     : i n0 ( __ld32 nonce 0 )
     : i n1 ( __ld32 nonce 4 )
     : i n2 ( __ld32 nonce 8 )
+    // Whole-block XOR through 8-byte loads and stores when both buffers
+    // are 8-byte aligned — a Vec's storage comes from malloc, so they
+    // are unless a caller hands in an unaligned `doff`. Eight loads,
+    // eight XORs and eight stores a block, against sixty-four of each
+    // plus their shifts and masks on the byte path below, which stays as
+    // the fallback for the unaligned and big-endian cases.
+    : i wordio & ( __le_words ) ? == 0 | & # i dp 7 & # i op 7 1 0
     : *u ks # *u ( nurl_zalloc 64 )
     : ~ i ctr counter
     : ~ i off 0
@@ -274,7 +271,21 @@ $ `stdlib/core/vec.nu`
         = x13 & + x13 n0 4294967295
         = x14 & + x14 n1 4294967295
         = x15 & + x15 n2 4294967295
-        ? >= - n off 64 {
+        ? & == 1 wordio >= - n off 64 {
+            // Eight machine words: the state pairs up low-word-first,
+            // which is the same byte order the byte path spells out.
+            : i w8 >> off 3
+            ( nurl_poke # s op w8 ^^ ( nurl_peek # s dp w8 ) | x0 << x1 32 )
+            ( nurl_poke # s op + w8 1 ^^ ( nurl_peek # s dp + w8 1 ) | x2 << x3 32 )
+            ( nurl_poke # s op + w8 2 ^^ ( nurl_peek # s dp + w8 2 ) | x4 << x5 32 )
+            ( nurl_poke # s op + w8 3 ^^ ( nurl_peek # s dp + w8 3 ) | x6 << x7 32 )
+            ( nurl_poke # s op + w8 4 ^^ ( nurl_peek # s dp + w8 4 ) | x8 << x9 32 )
+            ( nurl_poke # s op + w8 5 ^^ ( nurl_peek # s dp + w8 5 ) | x10 << x11 32 )
+            ( nurl_poke # s op + w8 6 ^^ ( nurl_peek # s dp + w8 6 ) | x12 << x13 32 )
+            ( nurl_poke # s op + w8 7 ^^ ( nurl_peek # s dp + w8 7 ) | x14 << x15 32 )
+        } {}
+        // Both write the same bytes; only the width differs.
+        ? & == 0 wordio >= - n off 64 {
             : i v0 x0
             = . op off # u ^^ # i . dp off & v0 255
             = . op + off 1 # u ^^ # i . dp + off 1 & >> v0 8 255
@@ -355,7 +366,8 @@ $ `stdlib/core/vec.nu`
             = . op + off 61 # u ^^ # i . dp + off 61 & >> v15 8 255
             = . op + off 62 # u ^^ # i . dp + off 62 & >> v15 16 255
             = . op + off 63 # u ^^ # i . dp + off 63 & >> v15 24 255
-        } {
+        } {}
+        ? < - n off 64 {
             : i v0 x0
             = . ks 0 # u & v0 255
             = . ks 1 # u & >> v0 8 255
@@ -441,7 +453,7 @@ $ `stdlib/core/vec.nu`
                 = . op + off j # u ^^ # i . dp + off j # i . ks j
                 = j + j 1
             }
-        }
+        } {}
         = off + off 64
         = ctr + ctr 1
     }
@@ -611,11 +623,12 @@ $ `stdlib/core/vec.nu`
 // ── ChaCha20-Poly1305 AEAD (RFC 8439 §2.8) ────────────────────────
 // The one-time Poly1305 key: first 32 bytes of the counter-0 block.
 @ __poly_key ( Vec u ) key ( Vec u ) nonce → ( Vec u ) {
-    : ( Vec u ) blk ( chacha20_block key 0 nonce )
-    : ( Vec u ) otk ( vec_with_cap [u] 32 )
-    : ~ i k 0
-    ~ < k 32 { ( vec_push [u] otk # u ( __cc_bget blk k ) ) = k + k 1 }
-    ( vec_free [u] blk )
+    // Only the first half of the counter-0 block is the key, so ask the
+    // kernel for 32 bytes and skip both the second half and the copy out
+    // of it. One of these per AEAD record.
+    : ( Vec u ) z ( __zeros 32 )
+    : ( Vec u ) otk ( chacha20_xor_range key 0 nonce z 0 32 )
+    ( vec_free [u] z )
     ^ otk
 }
 
@@ -632,10 +645,11 @@ $ `stdlib/core/vec.nu`
     ~ < k 8 { ( vec_push [u] v # u & >> n * 8 k 255 ) = k + k 1 }
 }
 
-// Build the Poly1305 input: aad ‖ pad16 ‖ ct ‖ pad16 ‖ le64(|aad|) ‖ le64(|ct|).
-@ __mac_data ( Vec u ) aad ( Vec u ) ct → ( Vec u ) {
+// Build the Poly1305 input: aad ‖ pad16 ‖ ct ‖ pad16 ‖ le64(|aad|) ‖ le64(|ct|),
+// where the ciphertext is the `cl` bytes of `ct` at `coff` — decrypt hands
+// in the record buffer with the tag still on the end rather than a copy.
+@ __mac_data ( Vec u ) aad ( Vec u ) ct i coff i cl → ( Vec u ) {
     : i al ( vec_len [u] aad )
-    : i cl ( vec_len [u] ct )
     : ( Vec u ) m ( vec_with_cap [u] + + al cl 32 )
     // Bulk pointer copies, not per-byte checked pushes: the ciphertext
     // side is the whole record and this concat sat at ~4% of a TLS
@@ -649,7 +663,7 @@ $ `stdlib/core/vec.nu`
     : i cbase ( vec_len [u] m )
     : b _cl ( vec_set_len [u] m + cbase cl )
     : *u mp2 ( vec_data [u] m )
-    : *u cp ( vec_data [u] ct )
+    : *u cp # *u + # i ( vec_data [u] ct ) coff
     = i 0
     ~ < i cl { = . mp2 + cbase i . cp i = i + i 1 }
     ( __pad16 m cl )
@@ -667,7 +681,7 @@ $ `stdlib/core/vec.nu`
     ? > ( vec_len [u] plaintext ) 274877906880 { ^ ( vec_new [u] ) } {}
     : ( Vec u ) otk ( __poly_key key nonce )
     : ( Vec u ) ct ( chacha20_xor key 1 nonce plaintext )
-    : ( Vec u ) md ( __mac_data aad ct )
+    : ( Vec u ) md ( __mac_data aad ct 0 ( vec_len [u] ct ) )
     : ( Vec u ) tag ( poly1305_mac otk md )
     : ~ i k 0
     ~ < k 16 { ( vec_push [u] ct # u ( __cc_bget tag k ) ) = k + k 1 }
@@ -695,22 +709,19 @@ $ `stdlib/core/vec.nu`
     : i total ( vec_len [u] ct_and_tag )
     ? < total 16 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
     : i ctlen - total 16
-    : ( Vec u ) ct ( vec_with_cap [u] ? > ctlen 0 ctlen 1 )
-    : ~ i k 0
-    ~ < k ctlen { ( vec_push [u] ct # u ( __cc_bget ct_and_tag k ) ) = k + k 1 }
-
+    // The ciphertext is `ct_and_tag` minus its trailing tag — both the MAC
+    // and the keystream take it as a range, so nothing is copied out of
+    // the record to name it. Extracting it used to cost a bounds-checked
+    // `vec_get` + `vec_push` PER BYTE of every 16 KB record, a quarter of
+    // the whole receive path.
     : ( Vec u ) otk ( __poly_key key nonce )
-    : ( Vec u ) md ( __mac_data aad ct )
+    : ( Vec u ) md ( __mac_data aad ct_and_tag 0 ctlen )
     : ( Vec u ) tag ( poly1305_mac otk md )
     : b ok ( __tag_ok ct_and_tag ctlen tag )
     ( vec_free [u] otk )
     ( vec_free [u] md )
     ( vec_free [u] tag )
-    ? ! ok {
-        ( vec_free [u] ct )
-        ^ @ ?( Vec u ) { F # ( Vec u ) 0 }
-    } {}
-    : ( Vec u ) pt ( chacha20_xor key 1 nonce ct )
-    ( vec_free [u] ct )
+    ? ! ok { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    : ( Vec u ) pt ( chacha20_xor_range key 1 nonce ct_and_tag 0 ctlen )
     ^ @ ?( Vec u ) { T pt }
 }

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -294,13 +294,28 @@ $ `stdlib/std/aes_gcm.nu`
     : i sidlen ( _t_bget ch 38 )
     : i p1 + 39 sidlen
     : i cslen ( _rdint ch p1 2 )
-    // choose cipher: prefer AES-128-GCM (0x1301), else ChaCha20 (0x1303)
+    // Choose the cipher: ChaCha20-Poly1305 (0x1303) when the client
+    // offers it, AES-128-GCM (0x1301) otherwise.
+    //
+    // The preference used to be the other way round, and since
+    // TLS_AES_128_GCM_SHA256 is the one suite RFC 8446 requires every
+    // implementation to have, EVERY client offered it and EVERY
+    // connection this server accepted got it. NURL has no AES-NI path:
+    // `std/aes_gcm.nu` derives each S-box byte through a constant-time
+    // GF(2^8) inversion rather than a cache-timing-visible table, which
+    // is the right call for security and costs about four thousand
+    // cycles a byte. Measured on 16 KB records (`bench/crypto_hotpath.nu`):
+    // AES-128-GCM 0.55 MB/s against ChaCha20-Poly1305's 305 MB/s — the
+    // preference alone was a ~500x difference on everything this server
+    // sent. The two suites are equally strong; a software-only TLS stack
+    // preferring ChaCha is what OpenSSL itself does when the CPU has no
+    // AES instructions.
     : ~ i suite 0
     : ~ i ci 0
     ~ < ci cslen {
         : i s2 ( _rdint ch + + p1 2 ci 2 )
-        ? == s2 4865 { ? == suite 0 { = suite 4865 } {} } {}
-        ? == s2 4867 { ? == suite 0 { = suite 4867 } {} } {}
+        ? == s2 4867 { = suite 4867 } {}
+        ? & == s2 4865 == suite 0 { = suite 4865 } {}
         = ci + ci 2
     }
     ? == suite 0 { = suite 4867 } {}


### PR DESCRIPTION
Two findings, both surfaced by `bench/crypto_hotpath.nu` — a new AEAD
micro-benchmark added here, measuring the record layer at the 16384-byte
records TLS 1.3 actually uses, with no socket in the way.

## 1. The server was choosing the suite it is 500× slower at

`tls_server.nu` walked the ClientHello and took the **client's** first
acceptable suite. Chrome, Firefox and Go's `crypto/tls` all list
`TLS_AES_128_GCM_SHA256` ahead of ChaCha20 when the CPU has AES
instructions — and NURL has no AES-NI path. `std/aes_gcm.nu` derives every
S-box byte through a constant-time GF(2^8) inversion instead of a
cache-timing-visible table. That is the right security call, and it costs
about four thousand cycles a byte:

```
chacha20poly1305_seal: 312.6 MB/s   (12 allocs/op)
chacha20poly1305_open: 306.4 MB/s   (12 allocs/op)
aes128_gcm_seal:         0.5 MB/s   (30835 allocs/op)
aes128_gcm_open:         0.5 MB/s   (30837 allocs/op)
```

The server now prefers ChaCha20-Poly1305 whenever the client offers it at
all. An 8 MB response to a client that lists AES first:

```
openssl s_client -connect 127.0.0.1:18993 \
  -ciphersuites 'TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256'

before  24.87 s      after  0.151 s
```

Clients offering **only** AES-128-GCM still negotiate it and still work
— RFC 8446 makes that suite mandatory to implement, so it cannot be
dropped. Verified: `-ciphersuites TLS_AES_128_GCM_SHA256` still completes
and transfers every byte. A software-only stack preferring ChaCha is what
OpenSSL itself does on a CPU without AES instructions.

## 2. The ChaCha record path copied every record through a checked byte loop

`aead_decrypt` extracted the ciphertext from the `ciphertext‖tag` buffer
with one `vec_get` and one `vec_push` **per byte** before either the MAC
or the keystream would look at it — a quarter of the whole receive path,
and the same shape a comment three functions up records having already
fixed once. Both consumers now take a range (`chacha20_xor_range`, and
`__mac_data` with an offset and length), so nothing is copied out of the
record at all.

Two more in the same file:

* `chacha20_block` was a second, accessor-based copy of the round
  function — ~960 bounds-checked `Vec` calls a block — and the AEAD ran
  one per record for the Poly1305 one-time key. It is now the
  register-resident kernel applied to a zero plaintext; the duplicate
  quarter-round / state-vector helpers are deleted.
* The kernel XORs a whole 64-byte block through eight 8-byte loads and
  stores when both buffers are 8-byte aligned (a `Vec`'s storage is
  malloc'd, so they are), instead of sixty-four of each with their shifts
  and masks. The byte loop stays as the fallback for unaligned offsets and
  big-endian machines — which the file now *probes* for once rather than
  assuming, because getting it wrong here would be silently wrong
  ciphertext rather than a build error.

| 16 KB records | before | after |
|---|---:|---:|
| `aead_encrypt` | 282 MB/s, 15 allocs/op | **313 MB/s, 12 allocs/op** |
| `aead_decrypt` | 198 MB/s, 17 allocs/op | **306 MB/s, 12 allocs/op** |
| `tls_read` over loopback | 150 MB/s | **214 MB/s** |
| `tls_write` over loopback | 218 MB/s | **259 MB/s** |

## Gates

* RFC 8439 known-answer vectors pass, plus a new one that pins the word
  and byte paths of `chacha20_xor_range` to byte-identical output.
* 568/568 goldens.
* With `NURL_NET_TESTS=1`, the live pure-NURL TLS server tests pass:
  `tls_large_record` serves its 100 000-byte body byte-exact to an
  OpenSSL client, `http_server_tls` and `net_loopback` behave.
* A 4 MB TLS transfer runs clean under ASan/UBSan/LSan — no leaks, no
  memory errors.

## What this does not fix

AES-128-GCM is still 0.5 MB/s, and a client that offers only that suite
still gets it. The cost is `__gf_inv` (62% of the profile) and `__ghash`
(31%); the former needs a bitsliced AES to fix without giving up
constant time, which is its own piece of work. `bench/crypto_hotpath.nu`
now makes the number visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ
