### PR TITLE
bench: a printed tie is not a win, so stop colouring it

### DIFF
--- a/nurlweb/public/index.html
+++ b/nurlweb/public/index.html
@@ -286,131 +286,133 @@
         <tbody>
           <tr>
             <td class="lang"><code>lcg</code><span class="bench-blurb">20M-step 64-bit LCG + xorshift</span></td>
-            <td class="num nurl-col fastest">39 ms</td>
-            <td class="num">39 ms</td>
-            <td class="num">39 ms</td>
-            <td class="num">1,875 ms</td>
-            <td class="num">5,112 ms</td>
+            <td class="num nurl-col">34 ms</td>
+            <td class="num">34 ms</td>
+            <td class="num">35 ms</td>
+            <td class="num">1,416 ms</td>
+            <td class="num">4,124 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>packet_classifier</code><span class="bench-blurb">25M unpredictable branches</span></td>
-            <td class="num nurl-col fastest">56 ms</td>
-            <td class="num">56 ms</td>
-            <td class="num">57 ms</td>
-            <td class="num">163 ms</td>
-            <td class="num">4,360 ms</td>
+            <td class="num nurl-col">50 ms</td>
+            <td class="num">50 ms</td>
+            <td class="num">50 ms</td>
+            <td class="num">123 ms</td>
+            <td class="num">3,575 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>ring_write</code><span class="bench-blurb">20M ring-buffer stores</span></td>
-            <td class="num nurl-col fastest">42 ms</td>
-            <td class="num">42 ms</td>
-            <td class="num">43 ms</td>
-            <td class="num">66 ms</td>
-            <td class="num">6,252 ms</td>
+            <td class="num nurl-col">37 ms</td>
+            <td class="num">37 ms</td>
+            <td class="num">37 ms</td>
+            <td class="num">57 ms</td>
+            <td class="num">5,004 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>histogram_bins</code><span class="bench-blurb">20M binned increments</span></td>
-            <td class="num nurl-col fastest">40 ms</td>
-            <td class="num">41 ms</td>
-            <td class="num">40 ms</td>
-            <td class="num">66 ms</td>
-            <td class="num">6,241 ms</td>
+            <td class="num nurl-col">35 ms</td>
+            <td class="num">35 ms</td>
+            <td class="num">35 ms</td>
+            <td class="num">58 ms</td>
+            <td class="num">5,179 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>prefix_scan</code><span class="bench-blurb">1M 16-wide prefix scans</span></td>
-            <td class="num nurl-col fastest">22 ms</td>
-            <td class="num">22 ms</td>
-            <td class="num">22 ms</td>
-            <td class="num">66 ms</td>
-            <td class="num">4,660 ms</td>
+            <td class="num nurl-col">19 ms</td>
+            <td class="num">19 ms</td>
+            <td class="num">19 ms</td>
+            <td class="num">58 ms</td>
+            <td class="num">3,720 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>binary_search</code><span class="bench-blurb">5M lower-bound searches</span></td>
-            <td class="num nurl-col">40 ms</td>
-            <td class="num">39 ms</td>
-            <td class="num">43 ms</td>
-            <td class="num">107 ms</td>
-            <td class="num">6,308 ms</td>
+            <td class="num nurl-col">28 ms</td>
+            <td class="num">28 ms</td>
+            <td class="num">36 ms</td>
+            <td class="num">88 ms</td>
+            <td class="num">5,020 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>sort_window</code><span class="bench-blurb">2M 8-element bubble sorts</span></td>
-            <td class="num nurl-col tied">27 ms</td>
-            <td class="num">27 ms</td>
-            <td class="num">27 ms</td>
-            <td class="num">198 ms</td>
-            <td class="num">11,246 ms</td>
+            <td class="num nurl-col">24 ms</td>
+            <td class="num">24 ms</td>
+            <td class="num">24 ms</td>
+            <td class="num">129 ms</td>
+            <td class="num">8,534 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>bloom_filter</code><span class="bench-blurb">4M Bloom-filter queries</span></td>
-            <td class="num nurl-col fastest">18 ms</td>
-            <td class="num">18 ms</td>
-            <td class="num">18 ms</td>
-            <td class="num">2,846 ms</td>
-            <td class="num">7,378 ms</td>
+            <td class="num nurl-col fastest">15 ms</td>
+            <td class="num">16 ms</td>
+            <td class="num">16 ms</td>
+            <td class="num">2,146 ms</td>
+            <td class="num">5,960 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>hash_join</code><span class="bench-blurb">5M hash-table probes</span></td>
-            <td class="num nurl-col fastest">28 ms</td>
-            <td class="num">30 ms</td>
-            <td class="num">30 ms</td>
-            <td class="num">3,453 ms</td>
-            <td class="num">8,391 ms</td>
+            <td class="num nurl-col fastest">23 ms</td>
+            <td class="num">24 ms</td>
+            <td class="num">24 ms</td>
+            <td class="num">2,604 ms</td>
+            <td class="num">6,454 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>sieve</code><span class="bench-blurb">Sieve of Eratosthenes to 10M</span></td>
-            <td class="num nurl-col">21 ms</td>
-            <td class="num">21 ms</td>
-            <td class="num">20 ms</td>
-            <td class="num">68 ms</td>
-            <td class="num">3,326 ms</td>
+            <td class="num nurl-col">16 ms</td>
+            <td class="num">16 ms</td>
+            <td class="num">16 ms</td>
+            <td class="num">56 ms</td>
+            <td class="num">2,656 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>fib</code><span class="bench-blurb">Recursive fib(35)</span></td>
-            <td class="num nurl-col fastest">25 ms</td>
-            <td class="num">30 ms</td>
-            <td class="num">29 ms</td>
-            <td class="num">135 ms</td>
-            <td class="num">1,382 ms</td>
+            <td class="num nurl-col fastest">22 ms</td>
+            <td class="num">26 ms</td>
+            <td class="num">23 ms</td>
+            <td class="num">110 ms</td>
+            <td class="num">997 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>collatz</code><span class="bench-blurb">Longest Collatz chain below 100k</span></td>
-            <td class="num nurl-col fastest">12 ms</td>
-            <td class="num">13 ms</td>
-            <td class="num">13 ms</td>
-            <td class="num">52 ms</td>
-            <td class="num">722 ms</td>
+            <td class="num nurl-col">11 ms</td>
+            <td class="num">11 ms</td>
+            <td class="num">11 ms</td>
+            <td class="num">41 ms</td>
+            <td class="num">587 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>matmul</code><span class="bench-blurb">256x256 integer matrix product</span></td>
-            <td class="num nurl-col fastest">34 ms</td>
-            <td class="num">34 ms</td>
-            <td class="num">34 ms</td>
-            <td class="num">76 ms</td>
-            <td class="num">3,642 ms</td>
+            <td class="num nurl-col">37 ms</td>
+            <td class="num">36 ms</td>
+            <td class="num">36 ms</td>
+            <td class="num">66 ms</td>
+            <td class="num">2,666 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>json_parse</code><span class="bench-blurb">20 parses of a 64 KB document</span></td>
-            <td class="num nurl-col fastest">8.6 ms</td>
-            <td class="num">8.9 ms</td>
-            <td class="num">12 ms</td>
-            <td class="num">35 ms</td>
-            <td class="num">38 ms</td>
+            <td class="num nurl-col fastest">6.7 ms</td>
+            <td class="num">7.2 ms</td>
+            <td class="num">9.6 ms</td>
+            <td class="num">30 ms</td>
+            <td class="num">31 ms</td>
           </tr>
           <tr>
             <td class="lang"><code>nbody</code><span class="bench-blurb">500k n-body integration steps</span></td>
-            <td class="num nurl-col">41 ms</td>
-            <td class="num">41 ms</td>
-            <td class="num">39 ms</td>
-            <td class="num">100 ms</td>
-            <td class="num">3,091 ms</td>
+            <td class="num nurl-col">36 ms</td>
+            <td class="num">36 ms</td>
+            <td class="num">35 ms</td>
+            <td class="num">77 ms</td>
+            <td class="num">2,513 ms</td>
           </tr>
         </tbody>
       </table>
     </div>
 
     <p class="bench-note">
-       Median wall-clock milliseconds, whole process, lower is better; NURL is highlighted
-       only when it is faster than every other language. Same algorithm in every language — each row is
+      Median wall-clock milliseconds, whole process, lower is better; NURL is
+      highlighted only where it prints a lower number than every other language —
+      two cells showing the same figure are a tie at this resolution, and neither
+      is marked. Same algorithm in every language — each row is
       timed only after all 5 implementations print the same result, so a cell can
       never be fast by computing something else.
       Measured on GitHub Actions ubuntu-latest runner (4 logical cores)
@@ -419,7 +421,7 @@
       rustc 1.97.1 ·
       Node 22.23.1 ·
       Python 3.12.3,
-      generated 2026-07-31 from commit <a href="https://github.com/nurl-lang/nurl/commit/64195f4e6054dfb8169742ec32e0a55e66c85f8c" target="_blank" rel="noopener"><code>64195f4</code></a>.
+      generated 2026-08-01 from commit <a href="https://github.com/nurl-lang/nurl/commit/701df62fbbb9645ea3c7374126475108fce7b20d" target="_blank" rel="noopener"><code>701df62</code></a>.
       Reproduce it with <code>./bench/bench.sh</code>; sources, compile times, the
       correctness gate and the process-start-up floor are in
       <a href="https://github.com/nurl-lang/nurl/tree/main/bench" target="_blank" rel="noopener">bench/</a>.

--- a/nurlweb/public/styles.css
+++ b/nurlweb/public/styles.css
@@ -332,19 +332,16 @@ section { padding: 4rem 0; }
   color: var(--fg-faint);
   line-height: 1.35;
 }
-/* The NURL column keeps an accented header; only a strict NURL win receives
-   the cell background below. */
+/* The NURL column keeps an accented header; only a win receives the cell
+   treatment below. The generator adds `fastest` when NURL prints a lower
+   number than every other language — a row where two cells print the same
+   figure is a tie at this resolution and stays plain, so the page never
+   marks one "39 ms" as beating the "39 ms" next to it. */
 .bench-table td.nurl-col { color: var(--fg); font-weight: 600; }
-/* The generator adds fasted when NURL is strictly fastest.  When NURL
-   ties with the best value the cell gets the accent color but no background. */
 .bench-table td.fastest {
   color: var(--accent);
   font-weight: 700;
   background: var(--accent-soft);
-}
-.bench-table td.tied {
-  color: var(--accent);
-  font-weight: 700;
 }
 .bench-note {
   color: var(--fg-dim);

--- a/tools/gen-bench-table.mjs
+++ b/tools/gen-bench-table.mjs
@@ -100,25 +100,27 @@ const head = COLUMNS.map(
 
 const body = rows
     .map((bench) => {
+        // NURL glows only when the number it PRINTS beats every other printed
+        // number. Comparing the underlying floats instead would light up rows
+        // where NURL leads by 0.1 ms — a third of a percent, well inside the
+        // run-to-run spread of a shared CI runner, and invisible in a table
+        // rounded to whole milliseconds. Highlighting one "39 ms" and not the
+        // "39 ms" beside it reads as a mistake, and at this resolution it is
+        // one: the two runs did not measurably differ. A tie is left plain.
         const values = COLUMNS.map((c) => bench.run_ms?.[c.key] ?? null);
+        const labels = values.map(formatMs);
         const finite = values.filter((v) => typeof v === "number" && Number.isFinite(v));
         const bestLabel = finite.length > 0 ? formatMs(Math.min(...finite)) : null;
-        const nurlLabel = formatMs(values[0]);
-        const [nurlMs, ...otherValues] = values;
-        const nurlWins = typeof nurlMs === "number" && Number.isFinite(nurlMs) &&
-            otherValues.every((value) =>
-                typeof value === "number" && Number.isFinite(value) && nurlMs < value,
-            );
-        const nurlTies = !nurlWins &&
-            bestLabel !== null && nurlLabel === bestLabel;
+        const nurlWins =
+            bestLabel !== null &&
+            labels[0] === bestLabel &&
+            !labels.slice(1).includes(bestLabel);
 
         const cells = COLUMNS.map((column, i) => {
-            const label = formatMs(values[i]);
             const classes = ["num"];
             if (column.nurl) classes.push("nurl-col");
             if (column.nurl && nurlWins) classes.push("fastest");
-            if (column.nurl && nurlTies) classes.push("tied");
-            return `            <td class="${classes.join(" ")}">${label}</td>`;
+            return `            <td class="${classes.join(" ")}">${labels[i]}</td>`;
         }).join("\n");
 
         return [
@@ -158,8 +160,10 @@ ${body}
     </div>
 
     <p class="bench-note">
-       Median wall-clock milliseconds, whole process, lower is better; NURL is highlighted
-       only when it is faster than every other language. Same algorithm in every language — each row is
+      Median wall-clock milliseconds, whole process, lower is better; NURL is
+      highlighted only where it prints a lower number than every other language —
+      two cells showing the same figure are a tie at this resolution, and neither
+      is marked. Same algorithm in every language — each row is
       timed only after all ${COLUMNS.length} implementations print the same result, so a cell can
       never be fast by computing something else.
       Measured on ${escapeHtml(host.label ?? "unknown host")}${host.cores ? ` (${host.cores} logical cores)` : ""}


### PR DESCRIPTION
Follow-up to #733.

The highlight rule compared the underlying floats, so `lcg` marked NURL's 39.255 ms as a win over C's 39.369 ms — two cells both printing **39 ms**, one glowing. At whole-millisecond resolution that reads as a rendering bug, and it more or less is one: a 0.1 ms lead on a shared Actions runner is inside the run-to-run spread.

Given the choice between *don't colour printed ties* and *print decimals everywhere*, this takes the first. Decimals would resolve the contradiction by asserting a precision the measurements do not have — `5,111.6 ms` for Python is noise dressed up as significance.

**Now:** NURL is highlighted only where the number it prints is lower than every other printed number. The `tied` class (accent colour, no background — still colouring a tie) is gone, and its CSS rule with it.

Highlights drop from ten rows to four — `bloom_filter`, `hash_join`, `fib`, `json_parse` — the rows where the lead is large enough for the table to show it.

The rendered table is regenerated here too, so its numbers move from the 2026-07-31 run to 2026-08-01: `bench.yml` commits only `bench/results/latest.json`, which leaves the table in the repo one run behind until a publish.

Verified every row of `latest.json` against the emitted classes (15/15 agree), and the generator is idempotent across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe2Yxai5o5yBArnVvWNomg