### PR TITLE
aes-gcm: bitsliced AES + carry-less GHASH — 0.3 MB/s → 113 MB/s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **AES-GCM is bitsliced: 0.3 MB/s → 113 MB/s, a 334× record layer.**
+  `std/aes_gcm.nu` computed the AES S-box algebraically, per byte, as
+  `Affine(x²⁵⁴)` — constant-time, which is the whole point (a table
+  indexed by key bytes leaks the key through the cache), but about a
+  thousand operations for one substitution. Ten rounds of sixteen of
+  those put AES-128-GCM at **0.3 MB/s** against ChaCha20-Poly1305's 370,
+  and AES-GCM is the one cipher suite RFC 8446 requires every TLS 1.3
+  implementation to have. A peer that insisted on it made an 8 MB
+  download take half a minute.
+
+  Constant time was never the thing to give up, so the block cipher is
+  **bitsliced** instead (a port of BearSSL's `aes_ct64`, Thomas Pornin,
+  MIT). The state is transposed so each of eight 64-bit words holds one
+  bit position of 64 bytes, and `SubBytes` becomes Boyar and Peralta's
+  113-gate boolean circuit evaluated on those words: one pass
+  substitutes 64 bytes, so the S-box costs under two operations per byte
+  instead of a thousand — with no table and no data-dependent branch,
+  the same guarantee as before. Four blocks travel together, which is
+  what CTR mode wants anyway.
+
+  GHASH was the other half: multiplying in GF(2¹²⁸) bit by bit is 128
+  iterations of a 16-byte shift-and-mask per block. It is now carry-less
+  multiplication built out of ordinary 64-bit integer multiplies
+  (`ghash_ctmul64`) — each operand split into four interleaved bit
+  groups so no carry crosses a kept bit, recombined by Karatsuba. After
+  the rewrite the two halves cost about the same (perf: 45% cipher, 47%
+  GHASH), which is where a balanced implementation should land.
+
+  | 16 KB record | before | after |
+  |---|---:|---:|
+  | `aes128_gcm_seal` | 48 312 827 ns | **144 591 ns** |
+  | | 0.3 MB/s | **113.3 MB/s** |
+  | `aes128_gcm_open` | 48 296 068 ns | **144 861 ns** |
+  | | 0.3 MB/s | **113.1 MB/s** |
+  | allocations / record | 30 835 | **15** |
+
+  The public surface is unchanged (`aes128_gcm_encrypt` / `_decrypt`,
+  `aes256_gcm_encrypt` / `_decrypt`), and so is the ciphertext: a
+  differential sweep over every plaintext length 0–200 × every AAD
+  length 0–40 × both key sizes, plus a 16 KB record, matches the
+  previous implementation byte for byte in all 33 166 cases, clean under
+  ASan/UBSan/LSan. `compiler/tests/aes_gcm_vectors.nu` additionally
+  gained the empty, single-block, AAD-only and 300-byte cases — lengths
+  chosen to walk every path through the four-block loop — checked
+  against OpenSSL rather than against the code they test.
+
+  Two caveats, both documented in `docs/CRYPTO.md`: the key schedule
+  still uses the old per-byte S-box (it runs once per key, ~2.5% of a
+  record, and is not worth bitslicing), and GHASH's constant-timeness
+  now rests on the CPU's integer multiplier being data-independent —
+  true of every mainstream 64-bit core, not true of some small in-order
+  ARM cores. TLS keeps preferring ChaCha20-Poly1305, which is still 3×
+  faster; the comments in `tls.nu` / `tls_server.nu` explaining that
+  preference by a 700× gap have been corrected to the 3× one.
+
 - **A P-256 scalar multiply allocates 44 000 times instead of 164 000 —
   22% off the handshake's instruction count.** With the accessor calls
   gone (below), what was left in front of the arithmetic was the

--- a/bench/crypto_hotpath.nu
+++ b/bench/crypto_hotpath.nu
@@ -37,10 +37,12 @@ $ `stdlib/std/ecdsa_p256.nu`
     ^ v
 }
 
-// ns/op over a 16 KB record → MB/s to one decimal. Whole MB/s would
-// print the AES suite as `0`, and the point of this table is that the
-// two suites are three orders of magnitude apart. (`nurl_print_int` ends
-// its own line, so the digits go through `nurl_str_int` instead.)
+// ns/op over a 16 KB record → MB/s to one decimal. The decimal is a
+// leftover from when the AES suite ran at 0.3 MB/s and whole numbers
+// printed it as `0`; it stays because a tenth of a MB/s is still the
+// resolution at which a regression here shows up first.
+// (`nurl_print_int` ends its own line, so the digits go through
+// `nurl_str_int` instead.)
 @ report_mbps s label i ns_per_op → v {
     : i tenths ? > ns_per_op 0 / * ( record_size ) 10000 ns_per_op 0
     ( nurl_print label )

--- a/compiler/tests/aes_gcm_vectors.nu
+++ b/compiler/tests/aes_gcm_vectors.nu
@@ -1,6 +1,16 @@
 // aes_gcm_vectors.nu — AES-128-GCM against the McGrew/NIST GCM test
 // vectors (Test Case 3: no AAD; Test Case 4: with AAD), plus roundtrip
 // and tamper-rejection.
+//
+// The cipher core encrypts FOUR blocks at a time (it is bitsliced), so
+// the lengths below are chosen to walk every path through that loop:
+// nothing at all, a single block, AAD with no plaintext, a plaintext
+// that is exactly one four-block group (64 B), one that ends mid-group
+// (60 B), and one long enough to run the group loop several times and
+// still finish on a partial block (300 B). The long vectors and the
+// empty/one-block ones were generated with OpenSSL via python
+// `cryptography`, i.e. by an implementation that shares no code with
+// this one.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -20,6 +30,19 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) key ( hx `feffe9928665731c6d6a8f9467308308` )
     : ( Vec u ) iv ( hx `cafebabefacedbaddecaf888` )
     : ( Vec u ) empty ( vec_new [u] )
+
+    // Degenerate lengths: nothing to encrypt, and AAD with no plaintext.
+    // Both leave the four-block loop unentered; only the tag is produced.
+    : ( Vec u ) zk ( hx `00000000000000000000000000000000` )
+    : ( Vec u ) ziv ( hx `000000000000000000000000` )
+    : ( Vec u ) z1 ( hx `00000000000000000000000000000000` )
+    : ( Vec u ) e1 ( aes128_gcm_encrypt zk ziv empty empty )
+    = fails + fails ( check `tc1_empty` e1 `58e2fccefa7e3061367f1d57a4e7455a` )
+    : ( Vec u ) e2 ( aes128_gcm_encrypt zk ziv empty z1 )
+    = fails + fails ( check `tc2_oneblock` e2 `0388dace60b6a392f328c2b971b2fe78ab6e47d42cec13bdf53a67b21257bddf` )
+    : ( Vec u ) dab ( hx `deadbeef` )
+    : ( Vec u ) e3 ( aes128_gcm_encrypt zk ziv dab empty )
+    = fails + fails ( check `aad_only` e3 `a583169867a1db810bbec2011a38ecb8` )
 
     // Test Case 3 — no AAD, full 64-byte plaintext.
     : ( Vec u ) p3 ( hx `d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255` )
@@ -67,6 +90,26 @@ $ `stdlib/std/aes_gcm.nu`
         F _ → ( nurl_print `tamper256: PASS\n` )
     }
 
+    // ── 300 bytes: four full four-block groups and a 44-byte tail, with
+    // a 13-byte AAD that is itself a partial GHASH block. Both key sizes.
+    : ( Vec u ) lk ( hx `000102030405060708090a0b0c0d0e0f` )
+    : ( Vec u ) lk32 ( hx `000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f` )
+    : ( Vec u ) liv ( hx `000102030405060708090a0b` )
+    : ( Vec u ) laad ( hx `a0a1a2a3a4a5a6a7a8a9aaabac` )
+    : ( Vec u ) lpt ( hx `0b2a496887a6c5e4032241607f9ebddcfb1a39587796b5d4f31231506f8eadcceb0a29486786a5c4e30221405f7e9dbcdbfa1938577695b4d3f211304f6e8daccbea0928476685a4c3e201203f5e7d9cbbdaf91837567594b3d2f1102f4e6d8cabcae90827466584a3c2e1001f3e5d7c9bbad9f81736557493b2d1f00f2e4d6c8baac9e80726456483a2c1e0ff1e3d5c7b9ab9d8f71635547392b1d0ef0e2d4c6b8aa9c8e70625446382a1c0dffe1d3c5b7a99b8d7f61534537291b0cfee0d2c4b6a89a8c7e60524436281a0bfdefd1c3b5a7998b7d6f51433527190afceed0c2b4a6988a7c6e504234261809fbeddfc1b3a597897b6d5f4133251708faecdec0b2a496887a6c5e4032241607f9ebddcfb1a39587796b5d4f31231506f8eadcceb0a29486786a5c4e3022140` )
+    : ( Vec u ) l128 ( aes128_gcm_encrypt lk liv laad lpt )
+    = fails + fails ( check `long128` l128 `9846eea6e1bd32b048f020ea493dcdd4483c23be247b48221533c07d7bca0fa06eaef2bf93061227a3f628a79ff74a2e17650dc853f1a3cffdbc63e2e5229b4851e4fc66182a4fbae0d2707f436475c7d3767c733ecae856452f36c79307e784cbefa21c314dbaf0039d9fdfecd78b6740696218b47b5f8db60e4f82c3c4b115e51e492bb87167fc770a45b5a0771a32e837caea6d82dc925f2c2368ba9b117efc6cd1138d632a8efe7c93e95057eb3d8e1bdeb5c8ff7687197d615273ebf8bf433b25a616474755cfb42218aeadabee07ccd86f2c5281cca78ce131ce782d45898c2e216f8635c848adc751d7591d1a14709f71558f0537dca964fd28270f38fcfdc87bb029f0a598ccbd5806b1257a964aa462ae1be03a9b5424d32060d1f9efccad090fc5f901cfe4725101df147a91385ab7f32c4e64c460149d` )
+    : ( Vec u ) l256 ( aes256_gcm_encrypt lk32 liv laad lpt )
+    = fails + fails ( check `long256` l256 `4c289f73424307ff8e63d6ebce77c5b178ccbe6c87edeaa8cb75d4d572e7ad7eea1a87b4c847b75c97a65eadd7f9b58435a379b50da0366eec653b29578d78423bd6cf5294b7a3c5dfb6ab4ed0d173748350307a413526fc4e2f6fdc57bed4016032b0ee8307ad9e3ddedfb2574b7c0321ddbb53f4f370eede4d863d8dc8236230f8c92eb3f18e378b438941c2c4719e4d6e5aedc207a61effcd59a715dcc4a2f81d37dd0ef9e93ac4e17c3a007e9b87c6b4539a5c5d668836ad5177be2bbadf58260352ca3bd3ed74345246059f2498da2481ee8ad64fe542c3eb57ee8662f66869bd2741e6e6217105d9882aafa1adb3a9e00d0a865c510459360304328f6d1ffbbbf81a7c8dda74fd3367c8b387d621aef395f71d347b823d5c01657a1787ea09f700dd436bd3713e1b1ab031a2413c630062b61039b8f127973f` )
+    ?? ( aes256_gcm_decrypt lk32 liv laad l256 ) {
+        T lp → { = fails + fails ( check `long256_open` lp `0b2a496887a6c5e4032241607f9ebddcfb1a39587796b5d4f31231506f8eadcceb0a29486786a5c4e30221405f7e9dbcdbfa1938577695b4d3f211304f6e8daccbea0928476685a4c3e201203f5e7d9cbbdaf91837567594b3d2f1102f4e6d8cabcae90827466584a3c2e1001f3e5d7c9bbad9f81736557493b2d1f00f2e4d6c8baac9e80726456483a2c1e0ff1e3d5c7b9ab9d8f71635547392b1d0ef0e2d4c6b8aa9c8e70625446382a1c0dffe1d3c5b7a99b8d7f61534537291b0cfee0d2c4b6a89a8c7e60524436281a0bfdefd1c3b5a7998b7d6f51433527190afceed0c2b4a6988a7c6e504234261809fbeddfc1b3a597897b6d5f4133251708faecdec0b2a496887a6c5e4032241607f9ebddcfb1a39587796b5d4f31231506f8eadcceb0a29486786a5c4e3022140` ) ( vec_free [u] lp ) }
+        F _ → { ( nurl_print `long256_open: FAIL rejected\n` ) = fails + fails 1 }
+    }
+
+    ( vec_free [u] zk ) ( vec_free [u] ziv ) ( vec_free [u] z1 )
+    ( vec_free [u] e1 ) ( vec_free [u] e2 ) ( vec_free [u] e3 ) ( vec_free [u] dab )
+    ( vec_free [u] lk ) ( vec_free [u] lk32 ) ( vec_free [u] liv )
+    ( vec_free [u] laad ) ( vec_free [u] lpt ) ( vec_free [u] l128 ) ( vec_free [u] l256 )
     ( vec_free [u] key ) ( vec_free [u] iv ) ( vec_free [u] empty )
     ( vec_free [u] p3 ) ( vec_free [u] s3 ) ( vec_free [u] p4 ) ( vec_free [u] aad ) ( vec_free [u] s4 )
     ( vec_free [u] k256z ) ( vec_free [u] ivz ) ( vec_free [u] p14 ) ( vec_free [u] s14 )

--- a/compiler/tests/outputs-windows/aes_gcm_vectors.txt
+++ b/compiler/tests/outputs-windows/aes_gcm_vectors.txt
@@ -2,6 +2,9 @@ COMPILE OK
 LINK OK
 EXIT 0
 OUTPUT
+tc1_empty: PASS
+tc2_oneblock: PASS
+aad_only: PASS
 tc3: PASS
 tc4: PASS
 tc4_open: PASS
@@ -10,4 +13,7 @@ tc14: PASS
 tc16: PASS
 tc16_open: PASS
 tamper256: PASS
+long128: PASS
+long256: PASS
+long256_open: PASS
 aes-gcm: all vectors PASS

--- a/compiler/tests/outputs/aes_gcm_vectors.txt
+++ b/compiler/tests/outputs/aes_gcm_vectors.txt
@@ -2,6 +2,9 @@ COMPILE OK
 LINK OK
 EXIT 0
 OUTPUT
+tc1_empty: PASS
+tc2_oneblock: PASS
+aad_only: PASS
 tc3: PASS
 tc4: PASS
 tc4_open: PASS
@@ -10,4 +13,7 @@ tc14: PASS
 tc16: PASS
 tc16_open: PASS
 tamper256: PASS
+long128: PASS
+long256: PASS
+long256_open: PASS
 aes-gcm: all vectors PASS

--- a/docs/CRYPTO.md
+++ b/docs/CRYPTO.md
@@ -93,10 +93,10 @@ signal.
 
 **Threat model — OUT of scope for the entire software stack:** physical
 **power / electromagnetic (DPA, SPA-power, template) side-channels.** Software
-constant-time code is *not* a defense against these: a constant-time table-free
-AES S-box still leaks the Hamming weight of the byte it processes through power
-consumption, branchless or not, and the same is true of the P-256 field
-arithmetic. Defending power/EM requires masking / hiding and ultimately
+constant-time code is *not* a defense against these: the power a gate draws
+still depends on the bits flowing through it, so a table-free or bitsliced AES
+S-box and the P-256 field arithmetic both remain readable to an attacker with
+a probe, branchless or not. Defending power/EM requires masking / hiding and ultimately
 hardware countermeasures, which are not in this (or any pure-software) library.
 Everything below concerns the **timing/cache** axis only.
 
@@ -111,8 +111,8 @@ follow-up. Hardening (timing/cache axis):
 
 | Primitive | Countermeasure |
 |---|---|
-| AES S-box | **Constant-time**: `SubBytes(x) = Affine(x⁻¹ in GF(2⁸))` computed with a branchless GF multiply and a fixed-exponent (x²⁵⁴) inversion — no table lookup or branch indexed by secret data. Verified equal to the reference S-box on all 256 inputs. `xtime` (MixColumns) is likewise branchless. |
-| GHASH | Branchless: the GF(2¹²⁸) multiply uses mask arithmetic, so its timing does not leak the authentication key H. |
+| AES S-box | **Constant-time, bitsliced**: the state is transposed so each 64-bit word holds one bit position of 64 bytes, and `SubBytes` is Boyar–Peralta's 113-gate boolean circuit evaluated on those words (the `aes_ct64` construction). Every operation is a word-wide AND/XOR — no table lookup, no branch, and nothing indexed by secret data. ShiftRows and MixColumns are shifts and XORs on the same words. The key schedule (once per key, not per block) instead uses the older per-byte form: `SubBytes(x) = Affine(x⁻¹ in GF(2⁸))` via a branchless GF multiply and a fixed-exponent (x²⁵⁴) inversion, verified equal to the reference S-box on all 256 inputs. |
+| GHASH | **Constant-time on any CPU with a constant-time multiplier.** The GF(2¹²⁸) multiply is carry-less multiplication built from ordinary 64-bit integer multiplies (`ghash_ctmul64`): each operand is split into four interleaved bit groups so no carry crosses a kept bit, and the halves recombine by Karatsuba. No branch and no table, so nothing leaks the authentication key H through cache or control flow — but the timing rests on `imul` being data-independent, which holds on every mainstream 64-bit core and does *not* hold on some small in-order ARM cores (Cortex-M3/M0, early Cortex-A), where an early-terminating multiplier would reintroduce an operand-timing signal. |
 | GCM / Poly1305 / TLS Finished tag compares | Constant-time (OR-accumulated XOR, no early exit). |
 | RSA modexp (`bigint_modpow`) | **Constant control flow**: a Montgomery powering ladder — exactly two modular multiplies per iteration for a fixed iteration count = bit-length of the **modulus `n`** (a public value), register choice by a constant-time conditional swap. The count depends only on the public modulus, **never on the secret exponent `d`** (no naive "multiply only on 1-bits" leak, and the loop length does not reveal `d`'s bit length). No CRT is used (single direct modexp with the full `d`), so there is no CRT-reduction timing surface (Brumley–Boneh class). |
 | RSA private key (PSS sign) | **Base blinding** on top: `s = ((EM·rᵉ)ᵈ · r⁻¹) mod n` for a fresh random `r` per signature. `rᵉᵈ ≡ r (mod n)`, so the result is identical, but the value fed to the (still operand-time-dependent) `bigint` mul/rem is randomized — covering the residual timing the ladder's uniform control flow does not. The setup inverse `r⁻¹ mod n` is computed with the variable-time `bigint_modinv`, but its timing is **not security-relevant**: `r` is a fresh per-signature ephemeral that is discarded, so its magnitude leaks nothing about the key. |
@@ -149,9 +149,10 @@ follow-up. Hardening (timing/cache axis):
 ### Practical guidance
 
 - **Prefer ChaCha20-Poly1305.** It is naturally constant-time and fast; it is
-  the default record cipher. The constant-time AES is correct but slower than
-  a table implementation (it computes the S-box per byte), and exists for peers
-  that only offer AES-GCM.
+  the default record cipher. AES-GCM is bitsliced, so it is constant-time
+  without needing AES instructions and no longer pays for that with orders of
+  magnitude: measured on 16 KB records, ~113 MB/s against ChaCha's ~370. It
+  remains the second choice, and exists for peers that only offer AES-GCM.
 
 ---
 
@@ -242,8 +243,8 @@ be **sound, not a hardware-grade side-channel-free implementation**:
    yet measured statistically (dudect/ctgrind — a tracked follow-up).
 4. **Power / EM (DPA, SPA-power, template) side-channels are OUT of scope for
    the entire software stack.** Software constant-time code does not defend
-   them — a table-free AES S-box still leaks the processed byte's Hamming weight
-   through power draw, and so does the P-256 field. Defending power/EM needs
+   them — a table-free or bitsliced AES S-box still leaks through power draw,
+   and so does the P-256 field. Defending power/EM needs
    masking/hiding and ultimately hardware; use a hardware-backed / audited
    library (HSM, secure element, AES-NI + a vetted bignum) where that threat
    model applies.

--- a/stdlib/std/aes_gcm.nu
+++ b/stdlib/std/aes_gcm.nu
@@ -1,12 +1,50 @@
-// stdlib/std/aes_gcm.nu — pure-NURL AES-128-GCM AEAD (NIST SP 800-38D),
+// stdlib/std/aes_gcm.nu — pure-NURL AES-128/256-GCM AEAD (NIST SP 800-38D),
 // no OpenSSL. This is the TLS_AES_128_GCM_SHA256 record protection — the
 // mandatory-to-implement TLS 1.3 cipher — so the client can talk to
 // servers that only offer AES.
 //
 //   ( aes128_gcm_encrypt key nonce aad pt )     → ( Vec u )  ct||tag
 //   ( aes128_gcm_decrypt key nonce aad ct_tag ) → ?( Vec u )  None if forged
+//   ( aes256_gcm_encrypt key nonce aad pt )     → ( Vec u )  ct||tag
+//   ( aes256_gcm_decrypt key nonce aad ct_tag ) → ?( Vec u )  None if forged
 //
-//   key = 16 bytes, nonce = 12 bytes.
+//   key = 16 or 32 bytes, nonce = 12 bytes.
+//
+// ── Why this file looks the way it does ───────────────────────────
+//
+// Constant time is not negotiable here: a table-driven AES indexes memory
+// with key-dependent bytes and leaks the key through the cache, which is
+// the whole reason CPUs grew AES instructions. NURL has no AES-NI path,
+// so the constant-time requirement has to be met in software.
+//
+// The obvious way — compute the S-box algebraically per byte, as
+// SubBytes(x) = Affine(x^254) — is constant-time and was what this file
+// did. It also costs about a thousand operations per byte, which put
+// AES-GCM at 0.3 MB/s against ChaCha20-Poly1305's 370: a TLS peer that
+// insisted on AES made an 8 MB download take half a minute.
+//
+// So the block cipher is BITSLICED instead (the technique BearSSL's
+// `aes_ct64` uses, and this is a port of it — Thomas Pornin, MIT):
+// the state is transposed so each of eight 64-bit words holds one bit
+// position of 64 bytes, and the S-box becomes Boyar and Peralta's
+// 113-gate straight-line boolean circuit evaluated on those words. One
+// circuit evaluation substitutes 64 bytes at once, so the S-box costs
+// under two operations per byte instead of a thousand, with no table and
+// no data-dependent branch anywhere. Four blocks travel together, which
+// is exactly what CTR mode wants.
+//
+// GHASH gets the same treatment. Multiplying in GF(2^128) bit by bit is
+// 128 iterations of a 16-byte shift-and-mask; instead this uses BearSSL's
+// `ghash_ctmul64` — carry-less multiplication built out of ordinary
+// 64-bit integer multiplies, by splitting each operand into four
+// bit-groups so no carry can cross a group boundary, then Karatsuba over
+// the two halves. Constant-time on any CPU whose integer multiplier is
+// (every mainstream 64-bit core; some small in-order ARM cores have
+// data-dependent multiply latency and would need the bitwise version).
+//
+// The key schedule is left as the per-byte algebraic S-box below: it runs
+// once per key, costs about 44 S-box evaluations, and is not worth
+// bitslicing.
 
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
@@ -15,13 +53,12 @@ $ `stdlib/std/bytes.nu`
     ?? ( vec_get [u] v k ) { T x → ^ # i x F _ → ^ 0 }
 }
 
-// C2: the AES S-box is computed CONSTANT-TIME, not read from a table indexed
-// by secret bytes (which leaks the key via cache-timing — the reason hardware
-// ships AES-NI / bitsliced AES). SubBytes(x) = Affine(x^{-1} in GF(2^8)).
-// Both the GF multiply and the fixed-exponent inversion are branchless in the
-// data, so duration is independent of key/plaintext. Verified to match the
-// reference S-box on all 256 inputs. (Slower than a table — ChaCha20-Poly1305
-// is the faster constant-time default; AES is the fallback for AES-only peers.)
+// ── Key schedule (cold path): algebraic constant-time S-box ───────
+// SubBytes(x) = Affine(x^{-1} in GF(2^8)). Both the GF multiply and the
+// fixed-exponent inversion are branchless in the data, so duration is
+// independent of the key. Verified to match the reference S-box on all
+// 256 inputs. Used only by the key expansion — the block cipher itself
+// uses the bitsliced circuit further down.
 
 // Constant-time GF(2^8) multiply (AES field, reduction polynomial 0x11b).
 @ __gf_mul i a i b → i {
@@ -63,15 +100,8 @@ $ `stdlib/std/bytes.nu`
     ^ & 255 ^^ ^^ ^^ ^^ ^^ b0 ( __rotl8 b0 1 ) ( __rotl8 b0 2 ) ( __rotl8 b0 3 ) ( __rotl8 b0 4 ) 99
 }
 
-// xtime (·2 in GF(2^8)), branchless: reduce by 0x1b iff the high bit was set.
-@ __xtime i x → i {
-    : i s << x 1
-    : i hi & 1 >> & x 255 7
-    ^ & 255 ^^ s & 27 - 0 hi
-}
-
 // AES-128 key expansion → 176 bytes (11 round keys).
-@ __aes128_expand ( Vec u ) key ( Vec u ) sbox → ( Vec u ) {
+@ __aes128_expand ( Vec u ) key → ( Vec u ) {
     : ( Vec u ) w ( vec_with_cap [u] 176 )
     : ~ i i 0
     ~ < i 16 { ( vec_push [u] w # u ( __aes_bget key i ) ) = i + i 1 }
@@ -105,28 +135,9 @@ $ `stdlib/std/bytes.nu`
     ^ w
 }
 
-// Encrypt one 16-byte block `in` at offset `off` → 16-byte ( Vec u ).
-// Encrypt one 16-byte block. `nr` is the round count (10 for AES-128,
-// 14 for AES-256); the final round key sits at offset nr*16.
-@ __aes_encrypt_block ( Vec u ) inb i off ( Vec u ) rk ( Vec u ) sbox i nr → ( Vec u ) {
-    : ( Vec u ) s ( vec_with_cap [u] 16 )
-    : ~ i i 0
-    ~ < i 16 { ( vec_push [u] s # u ^^ ( __aes_bget inb + off i ) ( __aes_bget rk i ) ) = i + i 1 }
-    : ~ i round 1
-    ~ < round nr {
-        ( __aes_sub_shift s sbox )
-        ( __aes_mixcolumns s )
-        ( __aes_addroundkey s rk * round 16 )
-        = round + round 1
-    }
-    ( __aes_sub_shift s sbox )
-    ( __aes_addroundkey s rk * nr 16 )
-    ^ s
-}
-
 // AES-256 key expansion → 240 bytes (15 round keys). Nk = 8: an extra
 // SubWord every 8th word (the i%8 == 4 case) on top of the 128 schedule.
-@ __aes256_expand ( Vec u ) key ( Vec u ) sbox → ( Vec u ) {
+@ __aes256_expand ( Vec u ) key → ( Vec u ) {
     : ( Vec u ) w ( vec_with_cap [u] 240 )
     : ~ i i 0
     ~ < i 32 { ( vec_push [u] w # u ( __aes_bget key i ) ) = i + i 1 }
@@ -169,209 +180,629 @@ $ `stdlib/std/bytes.nu`
 }
 
 // Pick the expanded round keys for a 16- or 32-byte key.
-@ __aes_expand ( Vec u ) key ( Vec u ) sbox → ( Vec u ) {
-    ? == ( vec_len [u] key ) 32 { ^ ( __aes256_expand key sbox ) } { ^ ( __aes128_expand key sbox ) }
+@ __aes_expand ( Vec u ) key → ( Vec u ) {
+    ? == ( vec_len [u] key ) 32 { ^ ( __aes256_expand key ) } { ^ ( __aes128_expand key ) }
 }
 
 // Round count for a 16- or 32-byte key.
 @ __aes_nr ( Vec u ) key → i { ? == ( vec_len [u] key ) 32 { ^ 14 } { ^ 10 } }
 
-@ __aes_addroundkey ( Vec u ) s ( Vec u ) rk i off → v {
-    : ~ i i 0
-    ~ < i 16 { ( vec_set [u] s i # u ^^ ( __aes_bget s i ) ( __aes_bget rk + off i ) ) = i + i 1 }
+// ── Raw-memory word helpers ──────────────────────────────────────
+// The bitsliced core works on 64-bit words held in locals; buffers are
+// plain malloc'd memory addressed through `nurl_peek` / `nurl_poke`
+// (8-byte words) or `.` (bytes), never through bounds-checked Vec
+// accessors — a 16 KB record is a thousand blocks and every checked call
+// would be paid a thousand times.
+
+// Little-endian 32-bit load. The AES state and the key schedule both use
+// the little-endian word convention throughout, so this is the only byte
+// order the cipher core ever sees.
+@ __ld32le * u p i off → u64 {
+    ^ # u64 | | | # i . p off << # i . p + off 1 8 << # i . p + off 2 16 << # i . p + off 3 24
 }
 
-// SubBytes + ShiftRows combined (state is column-major: s[r + 4c]).
-@ __aes_sub_shift ( Vec u ) s ( Vec u ) sbox → v {
-    : ( Vec u ) t ( vec_with_cap [u] 16 )
-    : ~ i i 0
-    ~ < i 16 { ( vec_push [u] t # u ( __aes_bget s i ) ) = i + i 1 }
-    : ~ i c 0
-    ~ < c 4 {
-        : ~ i r 0
-        ~ < r 4 {
-            // ShiftRows: row r takes element from column (c+r)
-            : i src + r * 4 % + c r 4
-            ( vec_set [u] s + r * 4 c # u ( __aes_sbox_ct ( __aes_bget t src ) ) )
-            = r + r 1
-        }
-        = c + c 1
-    }
-    ( vec_free [u] t )
+// Little-endian 32-bit store (writes the low 4 bytes of `w`).
+@ __st32le * u p i off u64 w → v {
+    = . p off # u # i & w 255
+    = . p + off 1 # u # i & >> w 8 255
+    = . p + off 2 # u # i & >> w 16 255
+    = . p + off 3 # u # i & >> w 24 255
 }
 
-@ __aes_mixcolumns ( Vec u ) s → v {
-    : ~ i c 0
-    ~ < c 4 {
-        : i b0 ( __aes_bget s + 0 * 4 c )
-        : i b1 ( __aes_bget s + 1 * 4 c )
-        : i b2 ( __aes_bget s + 2 * 4 c )
-        : i b3 ( __aes_bget s + 3 * 4 c )
-        ( vec_set [u] s + 0 * 4 c # u ^^ ^^ ^^ ( __xtime b0 ) ^^ ( __xtime b1 ) b1 b2 b3 )
-        ( vec_set [u] s + 1 * 4 c # u ^^ ^^ ^^ b0 ( __xtime b1 ) ^^ ( __xtime b2 ) b2 b3 )
-        ( vec_set [u] s + 2 * 4 c # u ^^ ^^ ^^ b0 b1 ( __xtime b2 ) ^^ ( __xtime b3 ) b3 )
-        ( vec_set [u] s + 3 * 4 c # u ^^ ^^ ^^ ^^ ( __xtime b0 ) b0 b1 b2 ( __xtime b3 ) )
-        = c + c 1
-    }
+// ── Bitslicing ───────────────────────────────────────────────────
+// `ortho` is the bit-matrix transpose that turns four blocks laid out as
+// bytes into eight bit-plane words and back. It is its own inverse.
+
+// One transpose step: exchange the bit groups selected by `cl` / `ch`
+// between the words at `ia` and `ib`.
+@ __swapn s q i base i ia i ib u64 cl u64 ch i sh → v {
+    : u64 a # u64 ( nurl_peek q + base ia )
+    : u64 b # u64 ( nurl_peek q + base ib )
+    ( nurl_poke q + base ia # i | & a cl << & b cl sh )
+    ( nurl_poke q + base ib # i | >> & a ch sh & b ch )
 }
 
-// ── GHASH over GF(2^128) ──────────────────────────────────────────
-// Z ^= X then Z = Z·H, accumulating one 16-byte block.
-@ __ghash_mul ( Vec u ) x ( Vec u ) h → ( Vec u ) {
-    : ( Vec u ) z ( vec_with_cap [u] 16 )
-    : ~ i zi 0
-    ~ < zi 16 { ( vec_push [u] z # u 0 ) = zi + zi 1 }
-    : ( Vec u ) v ( vec_with_cap [u] 16 )
-    : ~ i vi 0
-    ~ < vi 16 { ( vec_push [u] v # u ( __aes_bget h vi ) ) = vi + vi 1 }
-    : ~ i bit 0
-    ~ < bit 128 {
-        : i byte >> bit 3
-        // M4: branchless. xbit ∈ {0,1}; mx = 0 or 0xFF. z ^= mx & v with no
-        // data-dependent branch (the old `if x_bit` / `if lsb` leaked the
-        // input bits and — via V — the auth key H through timing).
-        : i xbit & 1 >> ( __aes_bget x byte ) - 7 & bit 7
-        : i mx - 0 xbit
+@ __ortho8 s q i base → v {
+    ( __swapn q base 0 1 0x5555555555555555 0xAAAAAAAAAAAAAAAA 1 )
+    ( __swapn q base 2 3 0x5555555555555555 0xAAAAAAAAAAAAAAAA 1 )
+    ( __swapn q base 4 5 0x5555555555555555 0xAAAAAAAAAAAAAAAA 1 )
+    ( __swapn q base 6 7 0x5555555555555555 0xAAAAAAAAAAAAAAAA 1 )
+    ( __swapn q base 0 2 0x3333333333333333 0xCCCCCCCCCCCCCCCC 2 )
+    ( __swapn q base 1 3 0x3333333333333333 0xCCCCCCCCCCCCCCCC 2 )
+    ( __swapn q base 4 6 0x3333333333333333 0xCCCCCCCCCCCCCCCC 2 )
+    ( __swapn q base 5 7 0x3333333333333333 0xCCCCCCCCCCCCCCCC 2 )
+    ( __swapn q base 0 4 0x0F0F0F0F0F0F0F0F 0xF0F0F0F0F0F0F0F0 4 )
+    ( __swapn q base 1 5 0x0F0F0F0F0F0F0F0F 0xF0F0F0F0F0F0F0F0 4 )
+    ( __swapn q base 2 6 0x0F0F0F0F0F0F0F0F 0xF0F0F0F0F0F0F0F0 4 )
+    ( __swapn q base 3 7 0x0F0F0F0F0F0F0F0F 0xF0F0F0F0F0F0F0F0 4 )
+}
+
+// Spread one block's four state words across the low and high halves of
+// the bitslice layout: block `idx` lives in words `idx` and `idx + 4`.
+@ __ilv_in s q i idx u64 w0 u64 w1 u64 w2 u64 w3 → v {
+    : ~ u64 x0 w0
+    : ~ u64 x1 w1
+    : ~ u64 x2 w2
+    : ~ u64 x3 w3
+    = x0 & | x0 << x0 16 0x0000FFFF0000FFFF
+    = x1 & | x1 << x1 16 0x0000FFFF0000FFFF
+    = x2 & | x2 << x2 16 0x0000FFFF0000FFFF
+    = x3 & | x3 << x3 16 0x0000FFFF0000FFFF
+    = x0 & | x0 << x0 8 0x00FF00FF00FF00FF
+    = x1 & | x1 << x1 8 0x00FF00FF00FF00FF
+    = x2 & | x2 << x2 8 0x00FF00FF00FF00FF
+    = x3 & | x3 << x3 8 0x00FF00FF00FF00FF
+    ( nurl_poke q idx # i | x0 << x2 8 )
+    ( nurl_poke q + idx 4 # i | x1 << x3 8 )
+}
+
+// The inverse: one block's two words back out to 16 bytes at `p + off`.
+@ __ilv_out * u p i off u64 q0 u64 q1 → v {
+    : ~ u64 x0 & q0 0x00FF00FF00FF00FF
+    : ~ u64 x1 & q1 0x00FF00FF00FF00FF
+    : ~ u64 x2 & >> q0 8 0x00FF00FF00FF00FF
+    : ~ u64 x3 & >> q1 8 0x00FF00FF00FF00FF
+    = x0 & | x0 >> x0 8 0x0000FFFF0000FFFF
+    = x1 & | x1 >> x1 8 0x0000FFFF0000FFFF
+    = x2 & | x2 >> x2 8 0x0000FFFF0000FFFF
+    = x3 & | x3 >> x3 8 0x0000FFFF0000FFFF
+    ( __st32le p off | x0 >> x0 16 )
+    ( __st32le p + off 4 | x1 >> x1 16 )
+    ( __st32le p + off 8 | x2 >> x2 16 )
+    ( __st32le p + off 12 | x3 >> x3 16 )
+}
+
+// Round keys in bitsliced form: 8 words per round, the same key material
+// replicated into all four block slots. Runs once per key. The caller
+// owns the returned buffer and frees it with `nurl_free`.
+@ __skey_bitslice ( Vec u ) rk i nr → s {
+    : s sk ( nurl_zalloc * 8 * 8 + nr 1 )
+    : s q ( nurl_zalloc 64 )
+    : *u rkp ( vec_data [u] rk )
+    : ~ i r 0
+    ~ <= r nr {
+        : i o * r 16
+        ( __ilv_in q 0 ( __ld32le rkp o ) ( __ld32le rkp + o 4 ) ( __ld32le rkp + o 8 ) ( __ld32le rkp + o 12 ) )
+        // All four slots hold the same round key.
+        ( nurl_poke q 1 ( nurl_peek q 0 ) )
+        ( nurl_poke q 2 ( nurl_peek q 0 ) )
+        ( nurl_poke q 3 ( nurl_peek q 0 ) )
+        ( nurl_poke q 5 ( nurl_peek q 4 ) )
+        ( nurl_poke q 6 ( nurl_peek q 4 ) )
+        ( nurl_poke q 7 ( nurl_peek q 4 ) )
+        ( __ortho8 q 0 )
+        : i base * r 8
         : ~ i k 0
-        ~ < k 16 { ( vec_set [u] z k # u & 255 ^^ ( __aes_bget z k ) & mx ( __aes_bget v k ) ) = k + k 1 }
-        // V >>= 1 (across 16 bytes); if LSB was set, XOR R = 0xe1||0^120.
-        : i lsb & ( __aes_bget v 15 ) 1
-        : ~ i j 15
-        ~ > j 0 {
-            ( vec_set [u] v j # u | >> ( __aes_bget v j ) 1 << & ( __aes_bget v - j 1 ) 1 7 )
-            = j - j 1
-        }
-        ( vec_set [u] v 0 # u >> ( __aes_bget v 0 ) 1 )
-        : i ml - 0 lsb
-        ( vec_set [u] v 0 # u & 255 ^^ ( __aes_bget v 0 ) & ml 225 )
-        = bit + bit 1
+        ~ < k 8 { ( nurl_poke sk + base k ( nurl_peek q k ) ) = k + k 1 }
+        = r + r 1
     }
-    ( vec_free [u] v )
-    ^ z
+    ( nurl_free q )
+    ^ sk
 }
 
-// GHASH `data` (zero-padded to blocks) starting from accumulator `y`.
-// Returns a fresh accumulator; does NOT consume `y` (the caller owns it).
-@ __ghash ( Vec u ) y ( Vec u ) h ( Vec u ) data → ( Vec u ) {
-    : ~ ( Vec u ) acc ( vec_with_cap [u] 16 )
-    : ~ i ci 0
-    ~ < ci 16 { ( vec_push [u] acc # u ( __aes_bget y ci ) ) = ci + ci 1 }
-    : i n ( vec_len [u] data )
+// ── The block cipher ─────────────────────────────────────────────
+// Encrypt four 16-byte blocks at `inp` into `outp`. `q` is a caller-owned
+// 8-word scratch buffer, allocated once per AEAD call rather than once
+// per block.
+//
+// Everything between the two transposes is held in locals so the register
+// allocator can see it: the S-box circuit alone is 113 gates, and routing
+// each of them through memory would cost more than the gates. This is why
+// the whole cipher is one function instead of the six the C reference
+// splits it into — NURL returns one value, and the round state is eight.
+@ __aes_ct64_enc4 * u inp * u outp s skey i nr s q → v {
+    ( __ilv_in q 0 ( __ld32le inp 0 ) ( __ld32le inp 4 ) ( __ld32le inp 8 ) ( __ld32le inp 12 ) )
+    ( __ilv_in q 1 ( __ld32le inp 16 ) ( __ld32le inp 20 ) ( __ld32le inp 24 ) ( __ld32le inp 28 ) )
+    ( __ilv_in q 2 ( __ld32le inp 32 ) ( __ld32le inp 36 ) ( __ld32le inp 40 ) ( __ld32le inp 44 ) )
+    ( __ilv_in q 3 ( __ld32le inp 48 ) ( __ld32le inp 52 ) ( __ld32le inp 56 ) ( __ld32le inp 60 ) )
+    ( __ortho8 q 0 )
+
+    : ~ u64 q0 # u64 ( nurl_peek q 0 )
+    : ~ u64 q1 # u64 ( nurl_peek q 1 )
+    : ~ u64 q2 # u64 ( nurl_peek q 2 )
+    : ~ u64 q3 # u64 ( nurl_peek q 3 )
+    : ~ u64 q4 # u64 ( nurl_peek q 4 )
+    : ~ u64 q5 # u64 ( nurl_peek q 5 )
+    : ~ u64 q6 # u64 ( nurl_peek q 6 )
+    : ~ u64 q7 # u64 ( nurl_peek q 7 )
+
+    // AddRoundKey, round 0.
+    = q0 ^^ q0 # u64 ( nurl_peek skey 0 )
+    = q1 ^^ q1 # u64 ( nurl_peek skey 1 )
+    = q2 ^^ q2 # u64 ( nurl_peek skey 2 )
+    = q3 ^^ q3 # u64 ( nurl_peek skey 3 )
+    = q4 ^^ q4 # u64 ( nurl_peek skey 4 )
+    = q5 ^^ q5 # u64 ( nurl_peek skey 5 )
+    = q6 ^^ q6 # u64 ( nurl_peek skey 6 )
+    = q7 ^^ q7 # u64 ( nurl_peek skey 7 )
+
+    // Rounds 1..nr. The last round skips MixColumns; the round number is
+    // public, so branching on it leaks nothing.
+    : ~ i round 1
+    ~ <= round nr {
+        // ── SubBytes: Boyar–Peralta's 113-gate circuit, evaluated on the
+        // eight bit planes at once (64 S-box substitutions per pass).
+        : u64 x0 q7
+        : u64 x1 q6
+        : u64 x2 q5
+        : u64 x3 q4
+        : u64 x4 q3
+        : u64 x5 q2
+        : u64 x6 q1
+        : u64 x7 q0
+
+        : u64 y14 ^^ x3 x5
+        : u64 y13 ^^ x0 x6
+        : u64 y9 ^^ x0 x3
+        : u64 y8 ^^ x0 x5
+        : u64 t0 ^^ x1 x2
+        : u64 y1 ^^ t0 x7
+        : u64 y4 ^^ y1 x3
+        : u64 y12 ^^ y13 y14
+        : u64 y2 ^^ y1 x0
+        : u64 y5 ^^ y1 x6
+        : u64 y3 ^^ y5 y8
+        : u64 t1 ^^ x4 y12
+        : u64 y15 ^^ t1 x5
+        : u64 y20 ^^ t1 x1
+        : u64 y6 ^^ y15 x7
+        : u64 y10 ^^ y15 t0
+        : u64 y11 ^^ y20 y9
+        : u64 y7 ^^ x7 y11
+        : u64 y17 ^^ y10 y11
+        : u64 y19 ^^ y10 y8
+        : u64 y16 ^^ t0 y11
+        : u64 y21 ^^ y13 y16
+        : u64 y18 ^^ x0 y16
+
+        : u64 t2 & y12 y15
+        : u64 t3 & y3 y6
+        : u64 t4 ^^ t3 t2
+        : u64 t5 & y4 x7
+        : u64 t6 ^^ t5 t2
+        : u64 t7 & y13 y16
+        : u64 t8 & y5 y1
+        : u64 t9 ^^ t8 t7
+        : u64 t10 & y2 y7
+        : u64 t11 ^^ t10 t7
+        : u64 t12 & y9 y11
+        : u64 t13 & y14 y17
+        : u64 t14 ^^ t13 t12
+        : u64 t15 & y8 y10
+        : u64 t16 ^^ t15 t12
+        : u64 t17 ^^ t4 t14
+        : u64 t18 ^^ t6 t16
+        : u64 t19 ^^ t9 t14
+        : u64 t20 ^^ t11 t16
+        : u64 t21 ^^ t17 y20
+        : u64 t22 ^^ t18 y19
+        : u64 t23 ^^ t19 y21
+        : u64 t24 ^^ t20 y18
+
+        : u64 t25 ^^ t21 t22
+        : u64 t26 & t21 t23
+        : u64 t27 ^^ t24 t26
+        : u64 t28 & t25 t27
+        : u64 t29 ^^ t28 t22
+        : u64 t30 ^^ t23 t24
+        : u64 t31 ^^ t22 t26
+        : u64 t32 & t31 t30
+        : u64 t33 ^^ t32 t24
+        : u64 t34 ^^ t23 t33
+        : u64 t35 ^^ t27 t33
+        : u64 t36 & t24 t35
+        : u64 t37 ^^ t36 t34
+        : u64 t38 ^^ t27 t36
+        : u64 t39 & t29 t38
+        : u64 t40 ^^ t25 t39
+
+        : u64 t41 ^^ t40 t37
+        : u64 t42 ^^ t29 t33
+        : u64 t43 ^^ t29 t40
+        : u64 t44 ^^ t33 t37
+        : u64 t45 ^^ t42 t41
+        : u64 z0 & t44 y15
+        : u64 z1 & t37 y6
+        : u64 z2 & t33 x7
+        : u64 z3 & t43 y16
+        : u64 z4 & t40 y1
+        : u64 z5 & t29 y7
+        : u64 z6 & t42 y11
+        : u64 z7 & t45 y17
+        : u64 z8 & t41 y10
+        : u64 z9 & t44 y12
+        : u64 z10 & t37 y3
+        : u64 z11 & t33 y4
+        : u64 z12 & t43 y13
+        : u64 z13 & t40 y5
+        : u64 z14 & t29 y2
+        : u64 z15 & t42 y9
+        : u64 z16 & t45 y14
+        : u64 z17 & t41 y8
+
+        : u64 t46 ^^ z15 z16
+        : u64 t47 ^^ z10 z11
+        : u64 t48 ^^ z5 z13
+        : u64 t49 ^^ z9 z10
+        : u64 t50 ^^ z2 z12
+        : u64 t51 ^^ z2 z5
+        : u64 t52 ^^ z7 z8
+        : u64 t53 ^^ z0 z3
+        : u64 t54 ^^ z6 z7
+        : u64 t55 ^^ z16 z17
+        : u64 t56 ^^ z12 t48
+        : u64 t57 ^^ t50 t53
+        : u64 t58 ^^ z4 t46
+        : u64 t59 ^^ z3 t54
+        : u64 t60 ^^ t46 t57
+        : u64 t61 ^^ z14 t57
+        : u64 t62 ^^ t52 t58
+        : u64 t63 ^^ t49 t58
+        : u64 t64 ^^ z4 t59
+        : u64 t65 ^^ t61 t62
+        : u64 t66 ^^ z1 t63
+        : u64 c0 ^^ t59 t63
+        : u64 c6 ^^ ^^ t56 t62 0xFFFFFFFFFFFFFFFF
+        : u64 c7 ^^ ^^ t48 t60 0xFFFFFFFFFFFFFFFF
+        : u64 t67 ^^ t64 t65
+        : u64 c3 ^^ t53 t66
+        : u64 c4 ^^ t51 t66
+        : u64 c5 ^^ t47 t65
+        : u64 c1 ^^ ^^ t64 c3 0xFFFFFFFFFFFFFFFF
+        : u64 c2 ^^ ^^ t55 t67 0xFFFFFFFFFFFFFFFF
+
+        // ── ShiftRows, on the transposed layout.
+        : u64 s0 | | | | | | & c7 0x000000000000FFFF >> & c7 0x00000000FFF00000 4 << & c7 0x00000000000F0000 12 >> & c7 0x0000FF0000000000 8 << & c7 0x000000FF00000000 8 >> & c7 0xF000000000000000 12 << & c7 0x0FFF000000000000 4
+        : u64 s1 | | | | | | & c6 0x000000000000FFFF >> & c6 0x00000000FFF00000 4 << & c6 0x00000000000F0000 12 >> & c6 0x0000FF0000000000 8 << & c6 0x000000FF00000000 8 >> & c6 0xF000000000000000 12 << & c6 0x0FFF000000000000 4
+        : u64 s2 | | | | | | & c5 0x000000000000FFFF >> & c5 0x00000000FFF00000 4 << & c5 0x00000000000F0000 12 >> & c5 0x0000FF0000000000 8 << & c5 0x000000FF00000000 8 >> & c5 0xF000000000000000 12 << & c5 0x0FFF000000000000 4
+        : u64 s3 | | | | | | & c4 0x000000000000FFFF >> & c4 0x00000000FFF00000 4 << & c4 0x00000000000F0000 12 >> & c4 0x0000FF0000000000 8 << & c4 0x000000FF00000000 8 >> & c4 0xF000000000000000 12 << & c4 0x0FFF000000000000 4
+        : u64 s4 | | | | | | & c3 0x000000000000FFFF >> & c3 0x00000000FFF00000 4 << & c3 0x00000000000F0000 12 >> & c3 0x0000FF0000000000 8 << & c3 0x000000FF00000000 8 >> & c3 0xF000000000000000 12 << & c3 0x0FFF000000000000 4
+        : u64 s5 | | | | | | & c2 0x000000000000FFFF >> & c2 0x00000000FFF00000 4 << & c2 0x00000000000F0000 12 >> & c2 0x0000FF0000000000 8 << & c2 0x000000FF00000000 8 >> & c2 0xF000000000000000 12 << & c2 0x0FFF000000000000 4
+        : u64 s6 | | | | | | & c1 0x000000000000FFFF >> & c1 0x00000000FFF00000 4 << & c1 0x00000000000F0000 12 >> & c1 0x0000FF0000000000 8 << & c1 0x000000FF00000000 8 >> & c1 0xF000000000000000 12 << & c1 0x0FFF000000000000 4
+        : u64 s7 | | | | | | & c0 0x000000000000FFFF >> & c0 0x00000000FFF00000 4 << & c0 0x00000000000F0000 12 >> & c0 0x0000FF0000000000 8 << & c0 0x000000FF00000000 8 >> & c0 0xF000000000000000 12 << & c0 0x0FFF000000000000 4
+
+        = q0 s0
+        = q1 s1
+        = q2 s2
+        = q3 s3
+        = q4 s4
+        = q5 s5
+        = q6 s6
+        = q7 s7
+
+        // ── MixColumns, every round but the last.
+        ? < round nr {
+            : u64 r0 | >> q0 16 << q0 48
+            : u64 r1 | >> q1 16 << q1 48
+            : u64 r2 | >> q2 16 << q2 48
+            : u64 r3 | >> q3 16 << q3 48
+            : u64 r4 | >> q4 16 << q4 48
+            : u64 r5 | >> q5 16 << q5 48
+            : u64 r6 | >> q6 16 << q6 48
+            : u64 r7 | >> q7 16 << q7 48
+            : u64 a0 ^^ q0 r0
+            : u64 a1 ^^ q1 r1
+            : u64 a2 ^^ q2 r2
+            : u64 a3 ^^ q3 r3
+            : u64 a4 ^^ q4 r4
+            : u64 a5 ^^ q5 r5
+            : u64 a6 ^^ q6 r6
+            : u64 a7 ^^ q7 r7
+            : u64 m0 ^^ ^^ ^^ q7 r7 r0 | << a0 32 >> a0 32
+            : u64 m1 ^^ ^^ ^^ ^^ ^^ q0 r0 q7 r7 r1 | << a1 32 >> a1 32
+            : u64 m2 ^^ ^^ ^^ q1 r1 r2 | << a2 32 >> a2 32
+            : u64 m3 ^^ ^^ ^^ ^^ ^^ q2 r2 q7 r7 r3 | << a3 32 >> a3 32
+            : u64 m4 ^^ ^^ ^^ ^^ ^^ q3 r3 q7 r7 r4 | << a4 32 >> a4 32
+            : u64 m5 ^^ ^^ ^^ q4 r4 r5 | << a5 32 >> a5 32
+            : u64 m6 ^^ ^^ ^^ q5 r5 r6 | << a6 32 >> a6 32
+            : u64 m7 ^^ ^^ ^^ q6 r6 r7 | << a7 32 >> a7 32
+            = q0 m0
+            = q1 m1
+            = q2 m2
+            = q3 m3
+            = q4 m4
+            = q5 m5
+            = q6 m6
+            = q7 m7
+        } {}
+
+        // ── AddRoundKey.
+        : i sb * round 8
+        = q0 ^^ q0 # u64 ( nurl_peek skey + sb 0 )
+        = q1 ^^ q1 # u64 ( nurl_peek skey + sb 1 )
+        = q2 ^^ q2 # u64 ( nurl_peek skey + sb 2 )
+        = q3 ^^ q3 # u64 ( nurl_peek skey + sb 3 )
+        = q4 ^^ q4 # u64 ( nurl_peek skey + sb 4 )
+        = q5 ^^ q5 # u64 ( nurl_peek skey + sb 5 )
+        = q6 ^^ q6 # u64 ( nurl_peek skey + sb 6 )
+        = q7 ^^ q7 # u64 ( nurl_peek skey + sb 7 )
+        = round + round 1
+    }
+
+    ( nurl_poke q 0 # i q0 )
+    ( nurl_poke q 1 # i q1 )
+    ( nurl_poke q 2 # i q2 )
+    ( nurl_poke q 3 # i q3 )
+    ( nurl_poke q 4 # i q4 )
+    ( nurl_poke q 5 # i q5 )
+    ( nurl_poke q 6 # i q6 )
+    ( nurl_poke q 7 # i q7 )
+    ( __ortho8 q 0 )
+    ( __ilv_out outp 0 # u64 ( nurl_peek q 0 ) # u64 ( nurl_peek q 4 ) )
+    ( __ilv_out outp 16 # u64 ( nurl_peek q 1 ) # u64 ( nurl_peek q 5 ) )
+    ( __ilv_out outp 32 # u64 ( nurl_peek q 2 ) # u64 ( nurl_peek q 6 ) )
+    ( __ilv_out outp 48 # u64 ( nurl_peek q 3 ) # u64 ( nurl_peek q 7 ) )
+}
+
+// ── GHASH over GF(2^128) ─────────────────────────────────────────
+// GCM's field puts bit 0 of byte 0 at the HIGH end of the polynomial, so
+// the carry-less product is computed both ways round — once on the words
+// and once on their bit-reversal — and the halves recombined. `rev64`
+// does that reversal.
+@ __rev64 u64 x → u64 {
+    : ~ u64 v x
+    = v | << & v 0x5555555555555555 1 & >> v 1 0x5555555555555555
+    = v | << & v 0x3333333333333333 2 & >> v 2 0x3333333333333333
+    = v | << & v 0x0F0F0F0F0F0F0F0F 4 & >> v 4 0x0F0F0F0F0F0F0F0F
+    = v | << & v 0x00FF00FF00FF00FF 8 & >> v 8 0x00FF00FF00FF00FF
+    = v | << & v 0x0000FFFF0000FFFF 16 & >> v 16 0x0000FFFF0000FFFF
+    ^ | << v 32 >> v 32
+}
+
+// Carry-less 64x64 → 64 multiply (low half), built from ordinary integer
+// multiplies. Each operand is split into four interleaved bit groups, so
+// within a product no carry can reach the next kept bit; masking the
+// result back to its group drops the garbage. Constant-time wherever the
+// hardware multiplier is.
+@ __bmul64 u64 x u64 y → u64 {
+    : u64 x0 & x 0x1111111111111111
+    : u64 x1 & x 0x2222222222222222
+    : u64 x2 & x 0x4444444444444444
+    : u64 x3 & x 0x8888888888888888
+    : u64 y0 & y 0x1111111111111111
+    : u64 y1 & y 0x2222222222222222
+    : u64 y2 & y 0x4444444444444444
+    : u64 y3 & y 0x8888888888888888
+    : u64 z0 ^^ ^^ ^^ * x0 y0 * x1 y3 * x2 y2 * x3 y1
+    : u64 z1 ^^ ^^ ^^ * x0 y1 * x1 y0 * x2 y3 * x3 y2
+    : u64 z2 ^^ ^^ ^^ * x0 y2 * x1 y1 * x2 y0 * x3 y3
+    : u64 z3 ^^ ^^ ^^ * x0 y3 * x1 y2 * x2 y1 * x3 y0
+    ^ | | | & z0 0x1111111111111111 & z1 0x2222222222222222 & z2 0x4444444444444444 & z3 0x8888888888888888
+}
+
+// Big-endian 64-bit load of the 8 bytes at `p + off`, zero-filled past
+// `avail` bytes. A GHASH block that runs off the end of the message is
+// zero-padded, and a negative `avail` means the whole word is padding.
+@ __be64_pad * u p i off i avail → u64 {
+    ? >= avail 8 {
+        ^ | | | | | | | << # u64 # i . p off 56 << # u64 # i . p + off 1 48 << # u64 # i . p + off 2 40 << # u64 # i . p + off 3 32 << # u64 # i . p + off 4 24 << # u64 # i . p + off 5 16 << # u64 # i . p + off 6 8 # u64 # i . p + off 7
+    } {}
+    : ~ u64 r 0
+    : ~ i k 0
+    ~ < k 8 {
+        : ~ u64 byte 0
+        ? < k avail { = byte # u64 # i . p + off k } {}
+        = r | << r 8 byte
+        = k + k 1
+    }
+    ^ r
+}
+
+// Absorb `len` bytes at `src` into the GHASH accumulator held in the two
+// words of `ystate`. The multiplier `h` is passed pre-decomposed because
+// the caller absorbs three separate runs (AAD, ciphertext, lengths) and
+// the decomposition is per-key, not per-run.
+@ __ghash_blocks s ystate u64 h0 u64 h1 u64 h0r u64 h1r u64 h2 u64 h2r * u src i len → v {
+    : ~ u64 y0 # u64 ( nurl_peek ystate 0 )
+    : ~ u64 y1 # u64 ( nurl_peek ystate 1 )
     : ~ i off 0
-    ~ < off n {
-        : ( Vec u ) blk ( vec_with_cap [u] 16 )
-        : ~ i i 0
-        ~ < i 16 {
-            ? < + off i n { ( vec_push [u] blk # u ( __aes_bget data + off i ) ) } { ( vec_push [u] blk # u 0 ) }
-            = i + i 1
-        }
-        : ~ i k 0
-        ~ < k 16 { ( vec_set [u] blk k # u ^^ ( __aes_bget blk k ) ( __aes_bget acc k ) ) = k + k 1 }
-        : ( Vec u ) nz ( __ghash_mul blk h )
-        ( vec_free [u] acc )
-        ( vec_free [u] blk )
-        = acc nz
+    ~ < off len {
+        : i rem - len off
+        = y1 ^^ y1 ( __be64_pad src off rem )
+        = y0 ^^ y0 ( __be64_pad src + off 8 - rem 8 )
+
+        : u64 y0r ( __rev64 y0 )
+        : u64 y1r ( __rev64 y1 )
+        : u64 y2 ^^ y0 y1
+        : u64 y2r ^^ y0r y1r
+
+        : u64 z0 ( __bmul64 y0 h0 )
+        : u64 z1 ( __bmul64 y1 h1 )
+        : u64 z2a ( __bmul64 y2 h2 )
+        : u64 z0h ( __bmul64 y0r h0r )
+        : u64 z1h ( __bmul64 y1r h1r )
+        : u64 z2ha ( __bmul64 y2r h2r )
+        : u64 z2 ^^ z2a ^^ z0 z1
+        : u64 z2h ^^ z2ha ^^ z0h z1h
+        : u64 z0hs >> ( __rev64 z0h ) 1
+        : u64 z1hs >> ( __rev64 z1h ) 1
+        : u64 z2hs >> ( __rev64 z2h ) 1
+
+        : u64 w0 z0
+        : u64 w1 ^^ z0hs z2
+        : u64 w2 ^^ z1 z2hs
+        : u64 w3 z1hs
+
+        : u64 v3 | << w3 1 >> w2 63
+        : u64 v2 | << w2 1 >> w1 63
+        : u64 v1 | << w1 1 >> w0 63
+        : u64 v0 << w0 1
+
+        // Reduce modulo x^128 + x^7 + x^2 + x + 1.
+        : u64 v2b ^^ v2 ^^ ^^ ^^ v0 >> v0 1 >> v0 2 >> v0 7
+        : u64 v1b ^^ v1 ^^ ^^ << v0 63 << v0 62 << v0 57
+        : u64 v3b ^^ v3 ^^ ^^ ^^ v1b >> v1b 1 >> v1b 2 >> v1b 7
+        : u64 v2c ^^ v2b ^^ ^^ << v1b 63 << v1b 62 << v1b 57
+
+        = y0 v2c
+        = y1 v3b
         = off + off 16
     }
-    ^ acc
+    ( nurl_poke ystate 0 # i y0 )
+    ( nurl_poke ystate 1 # i y1 )
 }
 
-@ __ctr_block ( Vec u ) j0 i counter ( Vec u ) rk ( Vec u ) sbox i nr → ( Vec u ) {
-    : ( Vec u ) cb ( vec_with_cap [u] 16 )
-    : ~ i i 0
-    ~ < i 12 { ( vec_push [u] cb # u ( __aes_bget j0 i ) ) = i + i 1 }
-    ( vec_push [u] cb # u & >> counter 24 255 )
-    ( vec_push [u] cb # u & >> counter 16 255 )
-    ( vec_push [u] cb # u & >> counter 8 255 )
-    ( vec_push [u] cb # u & counter 255 )
-    : ( Vec u ) ks ( __aes_encrypt_block cb 0 rk sbox nr )
-    ( vec_free [u] cb )
-    ^ ks
-}
-
-@ __u64be ( Vec u ) v i n → v {
+// Big-endian 64-bit store.
+@ __st64be * u p i off u64 w → v {
     : ~ i k 0
-    ~ < k 8 { ( vec_push [u] v # u & >> n * 8 - 7 k 255 ) = k + k 1 }
+    ~ < k 8 { = . p + off k # u # i & >> w * 8 - 7 k 255 = k + k 1 }
 }
 
-// Core GCM: returns ciphertext (or recovered plaintext) and writes the
-// 16-byte tag into `tag_out`. CTR mode is symmetric, so the same routine
-// serves encrypt and decrypt; the caller compares/produces the tag.
-@ __gcm_core ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) input ( Vec u ) tag_out → ( Vec u ) {
-    : ( Vec u ) sbox ( vec_new [u] )
+// ── GCM ──────────────────────────────────────────────────────────
+
+// Write the four CTR blocks for counters `ctr .. ctr+3` into the 64-byte
+// buffer `cb`, whose nonce bytes the caller has already filled in. The
+// counter is the low 32 bits, big-endian, per GCM's inc32.
+@ __ctr_fill * u cb i ctr → v {
+    : ~ i b 0
+    ~ < b 4 {
+        : i o + * b 16 12
+        : i c & + ctr b 0xFFFFFFFF
+        = . cb o # u & >> c 24 255
+        = . cb + o 1 # u & >> c 16 255
+        = . cb + o 2 # u & >> c 8 255
+        = . cb + o 3 # u & c 255
+        = b + b 1
+    }
+}
+
+// The GCM tag over AAD ‖ ciphertext ‖ lengths, masked with E_K(J0).
+// `hp` is the 16-byte hash subkey H, `ekp` the 16-byte E_K(J0); the tag
+// is written to the 16 bytes at `out`.
+@ __gcm_tag_raw * u hp * u ekp * u aadp i aadlen * u ctp i ctlen * u out → v {
+    : u64 h1 ( __be64_pad hp 0 8 )
+    : u64 h0 ( __be64_pad hp 8 8 )
+    : u64 h0r ( __rev64 h0 )
+    : u64 h1r ( __rev64 h1 )
+    : u64 h2 ^^ h0 h1
+    : u64 h2r ^^ h0r h1r
+    : s ystate ( nurl_zalloc 16 )
+    ? > aadlen 0 { ( __ghash_blocks ystate h0 h1 h0r h1r h2 h2r aadp aadlen ) } {}
+    ? > ctlen 0 { ( __ghash_blocks ystate h0 h1 h0r h1r h2 h2r ctp ctlen ) } {}
+    // Length block: [len(AAD)*8]_64 ‖ [len(C)*8]_64.
+    : *u lenb # *u ( nurl_zalloc 16 )
+    ( __st64be lenb 0 # u64 * aadlen 8 )
+    ( __st64be lenb 8 # u64 * ctlen 8 )
+    ( __ghash_blocks ystate h0 h1 h0r h1r h2 h2r lenb 16 )
+    ( __st64be out 0 # u64 ( nurl_peek ystate 1 ) )
+    ( __st64be out 8 # u64 ( nurl_peek ystate 0 ) )
+    : ~ i k 0
+    ~ < k 16 { = . out k # u ^^ # i . out k # i . ekp k = k + k 1 }
+    ( nurl_free # s lenb )
+    ( nurl_free ystate )
+}
+
+// One CTR pass plus the tag. `input` is the data to transform (plaintext
+// when sealing, ciphertext when opening) and the returned Vec is the
+// other one; the tag over the CIPHERTEXT — `out` when sealing, `input`
+// when opening — is written to the 16 bytes at `tagp`.
+//
+// The round keys, the hash subkey and the scratch buffers are set up once
+// here and reused across every block of the record.
+@ __gcm_run ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad * u inp i n i sealing * u tagp → ( Vec u ) {
     : i nr ( __aes_nr key )
-    : ( Vec u ) rk ( __aes_expand key sbox )
-    : ( Vec u ) zero ( vec_with_cap [u] 16 )
-    : ~ i zz 0
-    ~ < zz 16 { ( vec_push [u] zero # u 0 ) = zz + zz 1 }
-    : ( Vec u ) h ( __aes_encrypt_block zero 0 rk sbox nr )
+    : ( Vec u ) rk ( __aes_expand key )
+    : s skey ( __skey_bitslice rk nr )
+    ( vec_free [u] rk )
+    : s q ( nurl_zalloc 64 )
+    : *u cb # *u ( nurl_zalloc 64 )
+    : *u kb # *u ( nurl_zalloc 64 )
 
-    // J0 = nonce || 0x00000001
-    : ( Vec u ) j0 ( vec_with_cap [u] 12 )
+    // One cipher call covers both fixed blocks: slot 0 is the all-zero
+    // block whose ciphertext is the hash subkey H, slot 1 is J0 =
+    // nonce ‖ 0x00000001, whose ciphertext masks the tag.
     : ~ i ni 0
-    ~ < ni 12 { ( vec_push [u] j0 # u ( __aes_bget nonce ni ) ) = ni + ni 1 }
+    ~ < ni 12 { = . cb + 16 ni # u ( __aes_bget nonce ni ) = ni + ni 1 }
+    = . cb 31 # u 1
+    ( __aes_ct64_enc4 cb kb skey nr q )
+    : *u hj # *u ( nurl_zalloc 32 )
+    : ~ i hi 0
+    ~ < hi 32 { = . hj hi . kb hi = hi + hi 1 }
 
-    // CTR over the input, counter from 2 (J0 uses counter 1).
-    : i n ( vec_len [u] input )
+    // The counter blocks all carry the same nonce; only the last four
+    // bytes change, so the nonce is written once and left alone.
+    : ~ i bi 0
+    ~ < bi 4 {
+        : ~ i nj 0
+        ~ < nj 12 { = . cb + * bi 16 nj # u ( __aes_bget nonce nj ) = nj + nj 1 }
+        = bi + bi 1
+    }
+
     : ( Vec u ) out ( vec_with_cap [u] ? > n 0 n 1 )
+    : b _ol ( vec_set_len [u] out n )
+    : *u op ( vec_data [u] out )
     : ~ i off 0
     : ~ i ctr 2
     ~ < off n {
-        : ( Vec u ) ks ( __ctr_block j0 ctr rk sbox nr )
+        ( __ctr_fill cb ctr )
+        ( __aes_ct64_enc4 cb kb skey nr q )
+        : i lim ? < - n off 64 - n off 64
         : ~ i j 0
-        ~ & < j 16 < + off j n {
-            ( vec_push [u] out # u ^^ ( __aes_bget input + off j ) ( __aes_bget ks j ) )
+        ~ < j lim {
+            = . op + off j # u ^^ # i . inp + off j # i . kb j
             = j + j 1
         }
-        ( vec_free [u] ks )
-        = off + off 16
-        = ctr + ctr 1
+        = off + off 64
+        = ctr + ctr 4
     }
 
-    // For auth, GHASH covers the CIPHERTEXT. On encrypt that's `out`; on
-    // decrypt the ciphertext is the `input`. The caller passes plaintext
-    // on encrypt / ciphertext on decrypt — so GHASH the ciphertext: it is
-    // `out` when encrypting and `input` when decrypting. We always GHASH
-    // the data that travels on the wire — handled by __gcm_tag below.
-    ( vec_free [u] sbox )
-    ( vec_free [u] rk )
-    ( vec_free [u] zero )
-    ( vec_free [u] h )
-    ( vec_free [u] j0 )
+    : *u ctp ? == sealing 1 op inp
+    ( __gcm_tag_raw hj # *u + # i hj 16 ( vec_data [u] aad ) ( vec_len [u] aad ) ctp n tagp )
+
+    ( nurl_free # s hj )
+    ( nurl_free # s kb )
+    ( nurl_free # s cb )
+    ( nurl_free q )
+    ( nurl_free skey )
     ^ out
 }
 
-// Compute the GCM tag over aad + ciphertext.
-@ __gcm_tag ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) ct → ( Vec u ) {
-    : ( Vec u ) sbox ( vec_new [u] )
-    : i nr ( __aes_nr key )
-    : ( Vec u ) rk ( __aes_expand key sbox )
-    : ( Vec u ) zero ( vec_with_cap [u] 16 )
-    : ~ i zz 0
-    ~ < zz 16 { ( vec_push [u] zero # u 0 ) = zz + zz 1 }
-    : ( Vec u ) h ( __aes_encrypt_block zero 0 rk sbox nr )
-    : ( Vec u ) y ( vec_with_cap [u] 16 )
-    : ~ i yi 0
-    ~ < yi 16 { ( vec_push [u] y # u 0 ) = yi + yi 1 }
-    : ( Vec u ) y1 ( __ghash y h aad )
-    : ( Vec u ) y2 ( __ghash y1 h ct )
-    // length block: [len(aad)*8]_64 || [len(ct)*8]_64
-    : ( Vec u ) lenblk ( vec_with_cap [u] 16 )
-    ( __u64be lenblk * ( vec_len [u] aad ) 8 )
-    ( __u64be lenblk * ( vec_len [u] ct ) 8 )
-    : ( Vec u ) y3 ( __ghash y2 h lenblk )
-    // tag = E_K(J0) XOR GHASH
-    : ( Vec u ) j0 ( vec_with_cap [u] 12 )
-    : ~ i ni 0
-    ~ < ni 12 { ( vec_push [u] j0 # u ( __aes_bget nonce ni ) ) = ni + ni 1 }
-    : ( Vec u ) ekj0 ( __ctr_block j0 1 rk sbox nr )
-    : ( Vec u ) tag ( vec_with_cap [u] 16 )
+// AES-GCM seal: ciphertext with the 16-byte tag appended.
+@ __gcm_seal ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) pt → ( Vec u ) {
+    : i n ( vec_len [u] pt )
+    : *u tagp # *u ( nurl_zalloc 16 )
+    : ( Vec u ) ct ( __gcm_run key nonce aad ( vec_data [u] pt ) n 1 tagp )
     : ~ i ti 0
-    ~ < ti 16 { ( vec_push [u] tag # u ^^ ( __aes_bget y3 ti ) ( __aes_bget ekj0 ti ) ) = ti + ti 1 }
-    ( vec_free [u] sbox ) ( vec_free [u] rk ) ( vec_free [u] zero ) ( vec_free [u] h )
-    ( vec_free [u] y1 ) ( vec_free [u] y2 ) ( vec_free [u] lenblk ) ( vec_free [u] y3 )
-    ( vec_free [u] j0 ) ( vec_free [u] ekj0 ) ( vec_free [u] y )
-    ^ tag
+    ~ < ti 16 { ( vec_push [u] ct . tagp ti ) = ti + ti 1 }
+    ( nurl_free # s tagp )
+    ^ ct
+}
+
+// AES-GCM open: `ct_tag` is ciphertext followed by its 16-byte tag.
+// The tag is verified BEFORE the plaintext is handed back, and the
+// comparison is a constant-time OR-accumulate.
+@ __gcm_open ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) ct_tag → ?( Vec u ) {
+    : i total ( vec_len [u] ct_tag )
+    : i ctlen - total 16
+    : *u ctp ( vec_data [u] ct_tag )
+    : *u tagp # *u ( nurl_zalloc 16 )
+    : ( Vec u ) pt ( __gcm_run key nonce aad ctp ctlen 0 tagp )
+    : ~ i diff 0
+    : ~ i k 0
+    ~ < k 16 { = diff | diff ^^ # i . tagp k # i . ctp + ctlen k = k + k 1 }
+    ( nurl_free # s tagp )
+    ? != diff 0 { ( vec_free [u] pt ) ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    ^ @ ?( Vec u ) { T pt }
 }
 
 // AES-128-GCM seal: returns ciphertext with the 16-byte tag appended.
@@ -381,73 +812,28 @@ $ `stdlib/std/bytes.nu`
     // silently produce a malformed-but-accepted nonce → catastrophic reuse.
     ? | != ( vec_len [u] key ) 16 != ( vec_len [u] nonce ) 12 { ^ ( vec_new [u] ) } {}
     ? > ( vec_len [u] pt ) 68719476704 { ^ ( vec_new [u] ) } {}
-    : ( Vec u ) dummy ( vec_new [u] )
-    : ( Vec u ) ct ( __gcm_core key nonce aad pt dummy )
-    ( vec_free [u] dummy )
-    : ( Vec u ) tag ( __gcm_tag key nonce aad ct )
-    : ~ i ti 0
-    ~ < ti 16 { ( vec_push [u] ct # u ( __aes_bget tag ti ) ) = ti + ti 1 }
-    ( vec_free [u] tag )
-    ^ ct
+    ^ ( __gcm_seal key nonce aad pt )
 }
 
-@ __ct_eq ( Vec u ) a i aoff ( Vec u ) b → b {
-    : ~ i diff 0
-    : ~ i k 0
-    ~ < k 16 { = diff | diff ^^ ( __aes_bget a + aoff k ) ( __aes_bget b k ) = k + k 1 }
-    ^ == diff 0
-}
-
-// AES-128-GCM open: ct_tag is ciphertext followed by its 16-byte tag.
-// None on tag mismatch.
+// AES-128-GCM open. None on tag mismatch.
 @ aes128_gcm_decrypt ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) ct_tag → ?( Vec u ) {
     ? | != ( vec_len [u] key ) 16 != ( vec_len [u] nonce ) 12 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
-    : i total ( vec_len [u] ct_tag )
-    ? < total 16 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
-    : i ctlen - total 16
-    : ( Vec u ) ct ( bytes_slice ct_tag 0 ctlen )
-    : ( Vec u ) tag ( __gcm_tag key nonce aad ct )
-    : b ok ( __ct_eq ct_tag ctlen tag )
-    ( vec_free [u] tag )
-    ? ! ok { ( vec_free [u] ct ) ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
-    : ( Vec u ) dummy ( vec_new [u] )
-    : ( Vec u ) pt ( __gcm_core key nonce aad ct dummy )
-    ( vec_free [u] dummy )
-    ( vec_free [u] ct )
-    ^ @ ?( Vec u ) { T pt }
+    ? < ( vec_len [u] ct_tag ) 16 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    ^ ( __gcm_open key nonce aad ct_tag )
 }
 
 // AES-256-GCM (NIST SP 800-38D) — same GCM construction with a 32-byte key;
 // the block cipher core dispatches on key length (14 rounds). This is the
 // TLS_AES_256_GCM_SHA384 record protection and the AEAD used by ext/crypto.
-// seal: returns ciphertext with the 16-byte tag appended.
 @ aes256_gcm_encrypt ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) pt → ( Vec u ) {
     ? | != ( vec_len [u] key ) 32 != ( vec_len [u] nonce ) 12 { ^ ( vec_new [u] ) } {}
     ? > ( vec_len [u] pt ) 68719476704 { ^ ( vec_new [u] ) } {}
-    : ( Vec u ) dummy ( vec_new [u] )
-    : ( Vec u ) ct ( __gcm_core key nonce aad pt dummy )
-    ( vec_free [u] dummy )
-    : ( Vec u ) tag ( __gcm_tag key nonce aad ct )
-    : ~ i ti 0
-    ~ < ti 16 { ( vec_push [u] ct # u ( __aes_bget tag ti ) ) = ti + ti 1 }
-    ( vec_free [u] tag )
-    ^ ct
+    ^ ( __gcm_seal key nonce aad pt )
 }
 
-// open: ct_tag is ciphertext followed by its 16-byte tag. None on mismatch.
+// AES-256-GCM open. None on tag mismatch.
 @ aes256_gcm_decrypt ( Vec u ) key ( Vec u ) nonce ( Vec u ) aad ( Vec u ) ct_tag → ?( Vec u ) {
     ? | != ( vec_len [u] key ) 32 != ( vec_len [u] nonce ) 12 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
-    : i total ( vec_len [u] ct_tag )
-    ? < total 16 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
-    : i ctlen - total 16
-    : ( Vec u ) ct ( bytes_slice ct_tag 0 ctlen )
-    : ( Vec u ) tag ( __gcm_tag key nonce aad ct )
-    : b ok ( __ct_eq ct_tag ctlen tag )
-    ( vec_free [u] tag )
-    ? ! ok { ( vec_free [u] ct ) ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
-    : ( Vec u ) dummy ( vec_new [u] )
-    : ( Vec u ) pt ( __gcm_core key nonce aad ct dummy )
-    ( vec_free [u] dummy )
-    ( vec_free [u] ct )
-    ^ @ ?( Vec u ) { T pt }
+    ? < ( vec_len [u] ct_tag ) 16 { ^ @ ?( Vec u ) { F # ( Vec u ) 0 } } {}
+    ^ ( __gcm_open key nonce aad ct_tag )
 }

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -404,10 +404,13 @@ $ `stdlib/std/tls_verify.nu`
     // cipher_suites: TLS_CHACHA20_POLY1305_SHA256 (0x1303) +
     // TLS_AES_128_GCM_SHA256 (0x1301) — both use the SHA-256 key
     // schedule, so either keeps the rest of the handshake unchanged.
-    // ChaCha is listed FIRST on purpose: our AES is the constant-time
-    // (table-free) software S-box, ~0.5 MB/s, while ChaCha20-Poly1305
-    // runs ~25 MB/s — a 50× record-layer difference that is the sole
-    // throughput limit on large downloads. Servers honouring client
+    // ChaCha is listed FIRST on purpose: measured on one core over
+    // 16 KB records, ChaCha20-Poly1305 seals at ~370 MB/s and
+    // AES-128-GCM — bitsliced, so constant-time without AES
+    // instructions — at ~113. Both are now fast enough that a download
+    // is not bounded by the record layer, but ChaCha is still the
+    // better of the two on a host with no AES hardware, which is every
+    // host NURL has a code path for. Servers honouring client
     // preference (Cloudflare et al.) pick ChaCha; AES-only peers still
     // get 0x1301 from the same list.
     // 1.3 suites first, then the TLS 1.2 ECDHE suites for fallback.

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -300,16 +300,16 @@ $ `stdlib/std/aes_gcm.nu`
     // The preference used to be the other way round, and since
     // TLS_AES_128_GCM_SHA256 is the one suite RFC 8446 requires every
     // implementation to have, EVERY client offered it and EVERY
-    // connection this server accepted got it. NURL has no AES-NI path:
-    // `std/aes_gcm.nu` derives each S-box byte through a constant-time
-    // GF(2^8) inversion rather than a cache-timing-visible table, which
-    // is the right call for security and costs about four thousand
-    // cycles a byte. Measured on 16 KB records (`bench/crypto_hotpath.nu`):
-    // AES-128-GCM 0.5 MB/s against ChaCha20-Poly1305's 390 MB/s — the
-    // preference alone was a ~700x difference on everything this server
-    // sent. The two suites are equally strong; a software-only TLS stack
-    // preferring ChaCha is what OpenSSL itself does when the CPU has no
-    // AES instructions.
+    // connection this server accepted got it — back when AES-GCM ran at
+    // 0.5 MB/s against ChaCha's 390, that single line cost a ~700x
+    // slowdown on everything this server sent.
+    //
+    // `std/aes_gcm.nu` is bitsliced now and the gap is 3x, not 700x
+    // (16 KB records via `bench/crypto_hotpath.nu`: AES-128-GCM
+    // ~113 MB/s, ChaCha20-Poly1305 ~370). ChaCha still wins, and still
+    // should: NURL has no AES-NI path on any target, and a software-only
+    // TLS stack preferring ChaCha is what OpenSSL itself does when the
+    // CPU has no AES instructions. The two suites are equally strong.
     : ~ i suite 0
     : ~ i ci 0
     ~ < ci cslen {


### PR DESCRIPTION
## The problem

`TLS_AES_128_GCM_SHA256` is the one cipher suite RFC 8446 requires every TLS 1.3 implementation to have. Ours ran at **0.3 MB/s** — against ChaCha20-Poly1305's 370. A peer that insisted on AES made an 8 MB download take half a minute.

The cost was constant time bought the naive way. `SubBytes` was computed algebraically per byte as `Affine(x^254)` — correct, table-free, and about a thousand operations for one substitution; sixteen of those per round, ten rounds. GHASH was the other half: multiplying in GF(2^128) one bit at a time, 128 iterations of a 16-byte shift-and-mask through bounds-checked `Vec` accessors.

## The fix

Constant time was never the thing to give up, so the block cipher is **bitsliced** instead — a port of BearSSL's `aes_ct64` (Thomas Pornin, MIT). The state is transposed so each of eight 64-bit words holds one bit position of 64 bytes, and `SubBytes` becomes Boyar and Peralta's 113-gate boolean circuit evaluated on those words: one pass substitutes 64 bytes, so the S-box costs under two operations per byte instead of a thousand — with no table and no data-dependent branch, the same guarantee as before. Four blocks travel together, which is what CTR mode wants anyway.

GHASH is now carry-less multiplication built from ordinary 64-bit integer multiplies (`ghash_ctmul64`): each operand split into four interleaved bit groups so no carry crosses a kept bit, recombined by Karatsuba.

After the rewrite `perf` puts the two halves at 45% cipher / 47% GHASH, which is where a balanced implementation should land.

| 16 KB record | before | after |
|---|---:|---:|
| `aes128_gcm_seal` | 48 312 827 ns | **144 591 ns** |
| | 0.3 MB/s | **113.3 MB/s** |
| `aes128_gcm_open` | 48 296 068 ns | **144 861 ns** |
| | 0.3 MB/s | **113.1 MB/s** |
| allocations / record | 30 835 | **15** |

## Why this is safe

The public surface (`aes128_gcm_encrypt` / `_decrypt`, `aes256_gcm_encrypt` / `_decrypt`) and the ciphertext are unchanged:

- **Differential vs. the old code**: every plaintext length 0–200 × every AAD length 0–40 × both key sizes, plus a 16 KB record — **33 166 cases, byte-identical**, and clean under ASan/UBSan/LSan.
- **`compiler/tests/aes_gcm_vectors.nu`** gains empty, single-block, AAD-only and 300-byte cases — lengths chosen to walk every path through the four-block loop — with expected values generated by **OpenSSL**, not by the code they test.
- **End to end**: an `openssl s_client` pinned to `TLS_AES_128_GCM_SHA256` pulls 100 000 bytes through the pure-NURL TLS server byte-correct.
- Full suite: `PASS 568 · FAIL 0`.

## Two honest caveats (both in `docs/CRYPTO.md`)

- The **key schedule** still uses the per-byte algebraic S-box. It runs once per key — ~2.5% of a record — and is not worth bitslicing.
- GHASH's constant-timeness now rests on the CPU's **integer multiplier being data-independent**. True of every mainstream 64-bit core; not true of some small in-order ARM cores, where an early-terminating multiplier would reintroduce an operand-timing signal.

TLS keeps preferring ChaCha20-Poly1305, which is still 3× faster. The comments in `tls.nu` / `tls_server.nu` that justified that preference by a 700× gap now say 3×, and `docs/CRYPTO.md`'s AES and GHASH hardening rows describe what the code actually does now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ