### PR TITLE
x25519: ten limbs at radix 2^25.5, not sixteen at 16 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **X25519 is 4.3× faster — 0.58 → 0.135 ms, and 26 allocations instead
+  of 6146 — because the 25519 field stopped being sixteen 16-bit limbs.**
+  `std/x25519` carried TweetNaCl's `gf`: sixteen signed limbs of about
+  16 bits each. That shape needs **16×16 = 256 products** per field
+  multiply, and `_M` allocated a fresh 31-limb accumulator for every one
+  of the 1280 multiplies a scalar multiply performs.
+
+  A field element is now ten signed limbs at radix 2^25.5 — limb `i`
+  weighing `2^ceil(25.5·i)`, alternately 26 and 25 bits — which is the
+  classic 32-bit curve25519 layout. Ten limbs need **100 products**, and
+  a 26×26 → 52-bit product still leaves room to accumulate ten of them
+  times the folding factors inside a signed 64-bit limb. The multiply is
+  register-resident: it reads its operands into locals, computes the ten
+  output limbs and carries, allocating nothing.
+
+  The two coefficient shapes are folded into the *operands* rather than
+  the terms, so each of the hundred products is a single multiply: a
+  product of two odd-indexed limbs lands one bit low (because
+  `ceil(25.5j) + ceil(25.5k) = ceil(25.5(j+k)) + 1` when both are odd) and
+  is taken against a pre-doubled operand; a product that runs past limb 9
+  wraps by `2^255 ≡ 19` and is taken against a pre-nineteened one.
+
+  | | before | after |
+  |---|---:|---:|
+  | products per field multiply | 256 | **100** |
+  | `x25519_base` | 0.58 ms | **0.135 ms** |
+  | allocations per scalar multiply | 6146 | **26** |
+  | TLS 1.3 client handshake | ~4.2 ms | **~3.0 ms** |
+
+  **Ed25519 rides along** — `std/ed25519` builds on the same field, and
+  its constants are already decoded through `_unpack25519`, so they
+  re-encode themselves.
+
+  Constant time is unchanged: the ladder keeps its fixed iteration count
+  and its branchless conditional swap, and the new field has no branch on
+  data anywhere. Verified against RFC 7748 §5.2 and §6.1 and RFC 8032,
+  and the whole representation — multiply, carry chain, byte decode and
+  byte encode — was checked as a model first, including a full ladder
+  simulation that reproduces the RFC vectors and pins the worst-case
+  intermediate at 2^57 against a 2^63 ceiling.
+
 - **The P-256 ladder consumes the scalar a nibble at a time: 334 point
   additions instead of 512, a keygen 0.93 → 0.62 ms.** The bit-at-a-time
   always-add ladder paid two complete additions per scalar bit — one to
@@ -228,7 +269,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the stage that runs closest to CI's memory and time ceilings. `build.bat`
   gets the same treatment for the two throwaway stages (untested on
   Windows beyond the flag swap — the structure is identical).
-=======
+
 - **AES-GCM is bitsliced: 0.3 MB/s → 113 MB/s, a 334× record layer.**
   `std/aes_gcm.nu` computed the AES S-box algebraically, per byte, as
   `Affine(x²⁵⁴)` — constant-time, which is the whole point (a table

--- a/docs/CRYPTO.md
+++ b/docs/CRYPTO.md
@@ -30,7 +30,7 @@ All sources live in `stdlib/std/`.
 | Hashes | `hash_sha256`, `hash_sha512`, `hash_sha1`, `hash_md5`, `hash_blake3` | SHA-1/MD5 for legacy interop only (never trusted for signatures) |
 | HMAC / KDF | `hkdf`, `pbkdf2`, `scrypt` | HKDF-Expand-Label for TLS 1.3 |
 | AEAD | `aes_gcm` (AES-128/256-GCM), `chacha20poly1305` | the two TLS 1.3 record ciphers |
-| ECDH / signatures | `x25519`, `ed25519`, `ecdsa_p256` (P-256 + P-384), `p256_field` | TweetNaCl-derived 25519; `p256_field` is the dedicated **constant-time** fixed-limb GF(p) for the P-256 secret path |
+| ECDH / signatures | `x25519`, `ed25519`, `ecdsa_p256` (P-256 + P-384), `p256_field` | TweetNaCl-derived 25519 ladder over a ten-limb radix-2^25.5 field; `p256_field` is the dedicated **constant-time** fixed-limb GF(p) for the P-256 secret path |
 | RSA | `rsa` (PKCS#1 v1.5 verify, PSS verify + sign) | built on `bigint` |
 | Bignum | `bigint` | sign-magnitude, schoolbook mul / long division, `modpow`, `modinv` |
 | X.509 | `x509`, `tls_verify` | DER parser + chain/host/policy verification |
@@ -127,8 +127,8 @@ follow-up. Hardening (timing/cache axis):
 - **P-256 (ECDSA signing, ECDHE), X25519, Ed25519, AES-GCM, ChaCha20-Poly1305,
   GHASH, all tag compares** — constant-time *including operand timing*: no
   secret-dependent branch, no secret-indexed table, and a fixed-width field
-  representation (P-256 via `std/p256_field`; 25519 via the TweetNaCl packed
-  limbs) so even `mul`/`reduce` duration is value-independent. This resists a
+  representation (P-256 via `std/p256_field`; 25519 via ten fixed signed limbs
+  at radix 2^25.5) so even `mul`/`reduce` duration is value-independent. This resists a
   *single-trace* **timing/cache** observer (not just the multi-trace remote
   attacker) — but, like all software constant-time code, it does **not** resist
   a power/EM (DPA/template) attacker, which is out of scope stack-wide.

--- a/stdlib/std/ed25519.nu
+++ b/stdlib/std/ed25519.nu
@@ -142,7 +142,7 @@ $ `stdlib/std/hash_sha512.nu`
 @ __ed_scalarmult EdPt p EdPt q ( Vec u ) s ( Vec i ) d2 → v {
     // identity: (0, 1, 1, 0)
     : ~ i z 0
-    ~ < z 16 { ( _vset . p x z 0 ) ( _vset . p y z 0 ) ( _vset . p z z 0 ) ( _vset . p t z 0 ) = z + z 1 }
+    ~ < z 10 { ( _vset . p x z 0 ) ( _vset . p y z 0 ) ( _vset . p z z 0 ) ( _vset . p t z 0 ) = z + z 1 }
     ( _vset . p y 0 1 )
     ( _vset . p z 0 1 )
     : ~ i i 255

--- a/stdlib/std/x25519.nu
+++ b/stdlib/std/x25519.nu
@@ -4,11 +4,11 @@
 // multiplication over GF(2^255 − 19), so a NURL program can do the key
 // exchange for TLS 1.3 / Noise / age with nothing installed on the host.
 //
-// The field arithmetic is a direct port of the well-trodden TweetNaCl
-// reference (Bernstein et al.): a field element ("gf") is 16 signed
-// 64-bit limbs, each holding ~16 bits, carried with `__car25519`. Every
-// branch is data-independent (the conditional swap is a constant-time
-// mask), so the ladder runs in constant time w.r.t. the scalar.
+// The ladder is the well-trodden TweetNaCl one (Bernstein et al.); the
+// field underneath it is the classic 32-bit curve25519 representation —
+// ten signed 64-bit limbs at radix 2^25.5, carried with `__car25519`.
+// Every branch is data-independent (the conditional swap is a constant-
+// time mask), so the ladder runs in constant time w.r.t. the scalar.
 //
 // Public surface:
 //   ( x25519 scalar point ) → ( Vec u )   scalar·point  (both 32 bytes)
@@ -33,9 +33,8 @@ $ `stdlib/core/vec.nu`
 
 // The ladder's inner routines index their limbs through `*i` instead of
 // the two accessors above. Every one of those loops is fixed-count over
-// a 16- or 31-limb gf, so the bounds check is provably redundant — but
-// it is a real call, and one field multiply makes about a thousand of
-// them while one X25519 scalar multiply makes 1280 field multiplies.
+// a ten-limb gf, so the bounds check is provably redundant — but it is a
+// real call, and one X25519 scalar multiply makes 1280 field multiplies.
 // Constant time is unaffected: the trip counts are fixed and the data
 // takes no branch.
 
@@ -49,9 +48,8 @@ $ `stdlib/core/vec.nu`
 
 // n zeroed i64 limbs.
 @ _zeros_i i n → ( Vec i ) {
-    // Filled by index rather than pushed — `_M` builds a 31-limb one of
-    // these per field multiply, 1280 of them per scalar multiply, and a
-    // push carries a capacity check a known length does not need.
+    // Filled by index rather than pushed: a push carries a capacity check
+    // a known length does not need.
     : ( Vec i ) v ( vec_with_cap [i] ? > n 0 n 1 )
     : b _l ( vec_set_len [i] v ? > n 0 n 0 )
     : *i q ( vec_data [i] v )
@@ -68,53 +66,106 @@ $ `stdlib/core/vec.nu`
     ^ v
 }
 
-// A fresh 16-limb field element, all zero.
-@ _gf_zero → ( Vec i ) { ^ ( _zeros_i 16 ) }
+// ── the field: ten limbs at radix 2^25.5 ──────────────────────────
+// A field element is ten SIGNED limbs, limb i weighing 2^ceil(25.5·i) —
+// alternately 26 and 25 bits. That is the classic 32-bit curve25519
+// layout, and the reason for it is the multiply: sixteen 16-bit limbs
+// (the TweetNaCl shape this module used to carry) need 16×16 = 256
+// products, ten need 10×10 = 100, and a 26×26 → 52-bit product still
+// leaves room to accumulate ten of them, times the 2 and 19 folding
+// factors, inside a signed 64-bit limb — 2^57 at the worst point of a
+// real ladder, measured, against a 2^63 ceiling.
 
-// Copy the first 16 limbs of `a` into a new gf.
+// A fresh field element, all zero.
+@ _gf_zero → ( Vec i ) { ^ ( _zeros_i 10 ) }
+
+// Copy the ten limbs of `a` into a new gf.
 @ _gf_copy ( Vec i ) a → ( Vec i ) {
     : ( Vec i ) o ( _gf_zero )
     : *i op ( vec_data [i] o )
     : *i ap ( vec_data [i] a )
     : ~ i k 0
-    ~ < k 16 { = . op k . ap k = k + k 1 }
+    ~ < k 10 { = . op k . ap k = k + k 1 }
     ^ o
 }
 
-// dst ← src (16 limbs), in place.
+// dst ← src (ten limbs), in place.
 @ _gf_into ( Vec i ) dst ( Vec i ) src → v {
     : *i dp ( vec_data [i] dst )
     : *i sp ( vec_data [i] src )
     : ~ i k 0
-    ~ < k 16 { = . dp k . sp k = k + k 1 }
+    ~ < k 10 { = . dp k . sp k = k + k 1 }
 }
 
-// The constant 121665 as a gf (used in the ladder).
+// The constant 121665 as a gf — it fits limb 0 whole.
 @ __gf_121665 → ( Vec i ) {
     : ( Vec i ) o ( _gf_zero )
-    ( _vset o 0 56129 )  // 0xDB41
-    ( _vset o 1 1 )
+    ( _vset o 0 121665 )
     ^ o
 }
 
-// ── carry / reduce ────────────────────────────────────────────────
-// Propagate carries so each limb is back in [0, 2^16). Handles signed
-// limbs via TweetNaCl's bias trick; the wrap from limb 15 folds back
-// into limb 0 with the ×38 (= 2·19) reduction for 2^256 ≡ 38.
+// Propagate carries so every limb is back within its width. The order is
+// the reference one: the two halves are carried in parallel so each step
+// depends on the step two back, not the one before it, and limb 9 wraps
+// into limb 0 with the ×19 that 2^255 ≡ 19 gives.
 @ __car25519 ( Vec i ) o → v {
     : *i op ( vec_data [i] o )
-    : ~ i i 0
-    ~ < i 16 {
-        : i oi + . op i 65536
-        : i c >> oi 16
-        ? < i 15 {
-            = . op + i 1 + . op + i 1 - c 1
-        } {
-            = . op 0 + . op 0 * 38 - c 1
-        }
-        = . op i - oi << c 16
-        = i + i 1
-    }
+    : ~ i h0 . op 0
+    : ~ i h1 . op 1
+    : ~ i h2 . op 2
+    : ~ i h3 . op 3
+    : ~ i h4 . op 4
+    : ~ i h5 . op 5
+    : ~ i h6 . op 6
+    : ~ i h7 . op 7
+    : ~ i h8 . op 8
+    : ~ i h9 . op 9
+    : ~ i cc >> + h0 33554432 26
+    = h1 + h1 cc
+    = h0 - h0 << cc 26
+    = cc >> + h4 33554432 26
+    = h5 + h5 cc
+    = h4 - h4 << cc 26
+    = cc >> + h1 16777216 25
+    = h2 + h2 cc
+    = h1 - h1 << cc 25
+    = cc >> + h5 16777216 25
+    = h6 + h6 cc
+    = h5 - h5 << cc 25
+    = cc >> + h2 33554432 26
+    = h3 + h3 cc
+    = h2 - h2 << cc 26
+    = cc >> + h6 33554432 26
+    = h7 + h7 cc
+    = h6 - h6 << cc 26
+    = cc >> + h3 16777216 25
+    = h4 + h4 cc
+    = h3 - h3 << cc 25
+    = cc >> + h7 16777216 25
+    = h8 + h8 cc
+    = h7 - h7 << cc 25
+    = cc >> + h4 33554432 26
+    = h5 + h5 cc
+    = h4 - h4 << cc 26
+    = cc >> + h8 33554432 26
+    = h9 + h9 cc
+    = h8 - h8 << cc 26
+    = cc >> + h9 16777216 25
+    = h0 + h0 * 19 cc
+    = h9 - h9 << cc 25
+    = cc >> + h0 33554432 26
+    = h1 + h1 cc
+    = h0 - h0 << cc 26
+    = . op 0 h0
+    = . op 1 h1
+    = . op 2 h2
+    = . op 3 h3
+    = . op 4 h4
+    = . op 5 h5
+    = . op 6 h6
+    = . op 7 h7
+    = . op 8 h8
+    = . op 9 h9
 }
 
 // Constant-time conditional swap of p and q when b = 1.
@@ -123,7 +174,7 @@ $ `stdlib/core/vec.nu`
     : *i pp ( vec_data [i] p )
     : *i qp ( vec_data [i] q )
     : ~ i i 0
-    ~ < i 16 {
+    ~ < i 10 {
         : i t & c ^^ . pp i . qp i
         = . pp i ^^ . pp i t
         = . qp i ^^ . qp i t
@@ -131,51 +182,118 @@ $ `stdlib/core/vec.nu`
     }
 }
 
-// Decode 32 little-endian bytes into a gf (clears the top bit).
+// Decode 32 little-endian bytes into a gf (the top bit is dropped, per
+// RFC 7748 §5). Limb i is the 25-or-26 bits starting at 2^ceil(25.5·i);
+// five bytes always cover one limb whatever the bit offset, and a read
+// past the end yields 0.
 @ _unpack25519 ( Vec u ) n → ( Vec i ) {
     : ( Vec i ) o ( _gf_zero )
-    : ~ i i 0
-    ~ < i 16 {
-        : i lo ( _x_bget n * 2 i )
-        : i hi ( _x_bget n + * 2 i 1 )
-        ( _vset o i + lo << hi 8 )
-        = i + i 1
-    }
-    ( _vset o 15 & ( _vget o 15 ) 32767 )
+    : *i op ( vec_data [i] o )
+    = . op 0 & >> | | | | ( _x_bget n 0 ) << ( _x_bget n 1 ) 8 << ( _x_bget n 2 ) 16 << ( _x_bget n 3 ) 24 << ( _x_bget n 4 ) 32 0 67108863
+    = . op 1 & >> | | | | ( _x_bget n 3 ) << ( _x_bget n 4 ) 8 << ( _x_bget n 5 ) 16 << ( _x_bget n 6 ) 24 << ( _x_bget n 7 ) 32 2 33554431
+    = . op 2 & >> | | | | ( _x_bget n 6 ) << ( _x_bget n 7 ) 8 << ( _x_bget n 8 ) 16 << ( _x_bget n 9 ) 24 << ( _x_bget n 10 ) 32 3 67108863
+    = . op 3 & >> | | | | ( _x_bget n 9 ) << ( _x_bget n 10 ) 8 << ( _x_bget n 11 ) 16 << ( _x_bget n 12 ) 24 << ( _x_bget n 13 ) 32 5 33554431
+    = . op 4 & >> | | | | ( _x_bget n 12 ) << ( _x_bget n 13 ) 8 << ( _x_bget n 14 ) 16 << ( _x_bget n 15 ) 24 << ( _x_bget n 16 ) 32 6 67108863
+    = . op 5 & >> | | | | ( _x_bget n 16 ) << ( _x_bget n 17 ) 8 << ( _x_bget n 18 ) 16 << ( _x_bget n 19 ) 24 << ( _x_bget n 20 ) 32 0 33554431
+    = . op 6 & >> | | | | ( _x_bget n 19 ) << ( _x_bget n 20 ) 8 << ( _x_bget n 21 ) 16 << ( _x_bget n 22 ) 24 << ( _x_bget n 23 ) 32 1 67108863
+    = . op 7 & >> | | | | ( _x_bget n 22 ) << ( _x_bget n 23 ) 8 << ( _x_bget n 24 ) 16 << ( _x_bget n 25 ) 24 << ( _x_bget n 26 ) 32 3 33554431
+    = . op 8 & >> | | | | ( _x_bget n 25 ) << ( _x_bget n 26 ) 8 << ( _x_bget n 27 ) 16 << ( _x_bget n 28 ) 24 << ( _x_bget n 29 ) 32 4 67108863
+    = . op 9 & >> | | | | ( _x_bget n 28 ) << ( _x_bget n 29 ) 8 << ( _x_bget n 30 ) 16 << ( _x_bget n 31 ) 24 << ( _x_bget n 32 ) 32 6 33554431
     ^ o
 }
 
 // Fully reduce `n` mod 2^255−19 and emit 32 little-endian bytes.
+// The leading pass computes q, the number of times p divides the value
+// (0 or 1 for a carried input), by running the carry chain's shifts
+// against p's own limbs; adding 19·q then puts the value in [0, p) and
+// a plain non-negative carry chain makes every limb canonical.
 @ _pack25519 ( Vec i ) n → ( Vec u ) {
-    : ( Vec i ) t ( _gf_copy n )
-    ( __car25519 t )
-    ( __car25519 t )
-    ( __car25519 t )
-    : ~ i j 0
-    ~ < j 2 {
-        : ( Vec i ) m ( _gf_zero )
-        ( _vset m 0 - ( _vget t 0 ) 65517 )  // 0xffed
-        : ~ i i 1
-        ~ < i 15 {
-            ( _vset m i - - ( _vget t i ) 65535 & >> ( _vget m - i 1 ) 16 1 )
-            ( _vset m - i 1 & ( _vget m - i 1 ) 65535 )
-            = i + i 1
-        }
-        ( _vset m 15 - - ( _vget t 15 ) 32767 & >> ( _vget m 14 ) 16 1 )
-        : i b & >> ( _vget m 15 ) 16 1
-        ( _vset m 14 & ( _vget m 14 ) 65535 )
-        ( _sel25519 t m - 1 b )
-        ( vec_free [i] m )
-        = j + j 1
-    }
+    : *i np ( vec_data [i] n )
+    : ~ i h0 . np 0
+    : ~ i h1 . np 1
+    : ~ i h2 . np 2
+    : ~ i h3 . np 3
+    : ~ i h4 . np 4
+    : ~ i h5 . np 5
+    : ~ i h6 . np 6
+    : ~ i h7 . np 7
+    : ~ i h8 . np 8
+    : ~ i h9 . np 9
+    : ~ i q >> + * 19 h9 16777216 25
+    = q >> + h0 q 26
+    = q >> + h1 q 25
+    = q >> + h2 q 26
+    = q >> + h3 q 25
+    = q >> + h4 q 26
+    = q >> + h5 q 25
+    = q >> + h6 q 26
+    = q >> + h7 q 25
+    = q >> + h8 q 26
+    = q >> + h9 q 25
+    = h0 + h0 * 19 q
+    : ~ i cc 0
+    = cc >> h0 26
+    = h1 + h1 cc
+    = h0 - h0 << cc 26
+    = cc >> h1 25
+    = h2 + h2 cc
+    = h1 - h1 << cc 25
+    = cc >> h2 26
+    = h3 + h3 cc
+    = h2 - h2 << cc 26
+    = cc >> h3 25
+    = h4 + h4 cc
+    = h3 - h3 << cc 25
+    = cc >> h4 26
+    = h5 + h5 cc
+    = h4 - h4 << cc 26
+    = cc >> h5 25
+    = h6 + h6 cc
+    = h5 - h5 << cc 25
+    = cc >> h6 26
+    = h7 + h7 cc
+    = h6 - h6 << cc 26
+    = cc >> h7 25
+    = h8 + h8 cc
+    = h7 - h7 << cc 25
+    = cc >> h8 26
+    = h9 + h9 cc
+    = h8 - h8 << cc 26
+    = cc >> h9 25
+    = h9 - h9 << cc 25
     : ( Vec u ) o ( _zeros_u 32 )
-    : ~ i i 0
-    ~ < i 16 {
-        ( _bset o * 2 i & ( _vget t i ) 255 )
-        ( _bset o + * 2 i 1 & >> ( _vget t i ) 8 255 )
-        = i + i 1
-    }
-    ( vec_free [i] t )
+    ( _bset o 0 & >> h0 0 255 )
+    ( _bset o 1 & >> h0 8 255 )
+    ( _bset o 2 & >> h0 16 255 )
+    ( _bset o 3 & + >> h0 24 << h1 2 255 )
+    ( _bset o 4 & >> h1 6 255 )
+    ( _bset o 5 & >> h1 14 255 )
+    ( _bset o 6 & + >> h1 22 << h2 3 255 )
+    ( _bset o 7 & >> h2 5 255 )
+    ( _bset o 8 & >> h2 13 255 )
+    ( _bset o 9 & + >> h2 21 << h3 5 255 )
+    ( _bset o 10 & >> h3 3 255 )
+    ( _bset o 11 & >> h3 11 255 )
+    ( _bset o 12 & + >> h3 19 << h4 6 255 )
+    ( _bset o 13 & >> h4 2 255 )
+    ( _bset o 14 & >> h4 10 255 )
+    ( _bset o 15 & >> h4 18 255 )
+    ( _bset o 16 & >> h5 0 255 )
+    ( _bset o 17 & >> h5 8 255 )
+    ( _bset o 18 & >> h5 16 255 )
+    ( _bset o 19 & + >> h5 24 << h6 1 255 )
+    ( _bset o 20 & >> h6 7 255 )
+    ( _bset o 21 & >> h6 15 255 )
+    ( _bset o 22 & + >> h6 23 << h7 3 255 )
+    ( _bset o 23 & >> h7 5 255 )
+    ( _bset o 24 & >> h7 13 255 )
+    ( _bset o 25 & + >> h7 21 << h8 4 255 )
+    ( _bset o 26 & >> h8 4 255 )
+    ( _bset o 27 & >> h8 12 255 )
+    ( _bset o 28 & + >> h8 20 << h9 6 255 )
+    ( _bset o 29 & >> h9 2 255 )
+    ( _bset o 30 & >> h9 10 255 )
+    ( _bset o 31 & >> h9 18 255 )
     ^ o
 }
 
@@ -185,7 +303,7 @@ $ `stdlib/core/vec.nu`
     : *i ap ( vec_data [i] a )
     : *i bp ( vec_data [i] b )
     : ~ i i 0
-    ~ < i 16 { = . op i + . ap i . bp i = i + i 1 }
+    ~ < i 10 { = . op i + . ap i . bp i = i + i 1 }
 }
 
 @ _Z ( Vec i ) o ( Vec i ) a ( Vec i ) b → v {
@@ -193,38 +311,114 @@ $ `stdlib/core/vec.nu`
     : *i ap ( vec_data [i] a )
     : *i bp ( vec_data [i] b )
     : ~ i i 0
-    ~ < i 16 { = . op i - . ap i . bp i = i + i 1 }
+    ~ < i 10 { = . op i - . ap i . bp i = i + i 1 }
 }
 
-// o ← a·b mod p. Schoolbook into a 31-limb accumulator, fold the high
-// half back with ×38, then carry twice. a/b may alias o (o is written
-// only from the independent accumulator t).
+// o ← a·b mod 2^255−19. Schoolbook over the ten limbs, with the two
+// coefficient shapes folded into the OPERANDS instead of the terms:
+//   * a product of two odd-indexed limbs lands one bit low, because
+//     ceil(25.5j) + ceil(25.5k) = ceil(25.5(j+k)) + 1 when both are odd,
+//     so it is taken against a pre-doubled `f`;
+//   * a product that runs past limb 9 wraps by 2^255 ≡ 19, so it is
+//     taken against a pre-nineteened `g`.
+// Each of the hundred terms is then a single multiply, and the doublings
+// and ×19s are five and ten cheap ops done once. Operands are read into
+// locals before anything is written, so `o` may alias `a` or `b`.
 @ _M ( Vec i ) o ( Vec i ) a ( Vec i ) b → v {
-    : ( Vec i ) t ( _zeros_i 31 )
-    : *i tp ( vec_data [i] t )
-    : *i ap ( vec_data [i] a )
-    : *i bp ( vec_data [i] b )
-    : ~ i i 0
-    ~ < i 16 {
-        : i ai . ap i
-        : ~ i j 0
-        ~ < j 16 {
-            = . tp + i j + . tp + i j * ai . bp j
-            = j + j 1
-        }
-        = i + i 1
-    }
-    : ~ i i 0
-    ~ < i 15 {
-        = . tp i + . tp i * 38 . tp + i 16
-        = i + i 1
-    }
+    : *i fp ( vec_data [i] a )
+    : *i gp ( vec_data [i] b )
+    : i f0 . fp 0
+    : i f1 . fp 1
+    : i f2 . fp 2
+    : i f3 . fp 3
+    : i f4 . fp 4
+    : i f5 . fp 5
+    : i f6 . fp 6
+    : i f7 . fp 7
+    : i f8 . fp 8
+    : i f9 . fp 9
+    : i f1_2 * 2 f1
+    : i f3_2 * 2 f3
+    : i f5_2 * 2 f5
+    : i f7_2 * 2 f7
+    : i f9_2 * 2 f9
+    : i g0 . gp 0
+    : i g1 . gp 1
+    : i g2 . gp 2
+    : i g3 . gp 3
+    : i g4 . gp 4
+    : i g5 . gp 5
+    : i g6 . gp 6
+    : i g7 . gp 7
+    : i g8 . gp 8
+    : i g9 . gp 9
+    : i g0_19 * 19 g0
+    : i g1_19 * 19 g1
+    : i g2_19 * 19 g2
+    : i g3_19 * 19 g3
+    : i g4_19 * 19 g4
+    : i g5_19 * 19 g5
+    : i g6_19 * 19 g6
+    : i g7_19 * 19 g7
+    : i g8_19 * 19 g8
+    : i g9_19 * 19 g9
+    : ~ i h0 + + + + + + + + + * f0 g0 * f1_2 g9_19 * f2 g8_19 * f3_2 g7_19 * f4 g6_19 * f5_2 g5_19 * f6 g4_19 * f7_2 g3_19 * f8 g2_19 * f9_2 g1_19
+    : ~ i h1 + + + + + + + + + * f0 g1 * f1 g0 * f2 g9_19 * f3 g8_19 * f4 g7_19 * f5 g6_19 * f6 g5_19 * f7 g4_19 * f8 g3_19 * f9 g2_19
+    : ~ i h2 + + + + + + + + + * f0 g2 * f1_2 g1 * f2 g0 * f3_2 g9_19 * f4 g8_19 * f5_2 g7_19 * f6 g6_19 * f7_2 g5_19 * f8 g4_19 * f9_2 g3_19
+    : ~ i h3 + + + + + + + + + * f0 g3 * f1 g2 * f2 g1 * f3 g0 * f4 g9_19 * f5 g8_19 * f6 g7_19 * f7 g6_19 * f8 g5_19 * f9 g4_19
+    : ~ i h4 + + + + + + + + + * f0 g4 * f1_2 g3 * f2 g2 * f3_2 g1 * f4 g0 * f5_2 g9_19 * f6 g8_19 * f7_2 g7_19 * f8 g6_19 * f9_2 g5_19
+    : ~ i h5 + + + + + + + + + * f0 g5 * f1 g4 * f2 g3 * f3 g2 * f4 g1 * f5 g0 * f6 g9_19 * f7 g8_19 * f8 g7_19 * f9 g6_19
+    : ~ i h6 + + + + + + + + + * f0 g6 * f1_2 g5 * f2 g4 * f3_2 g3 * f4 g2 * f5_2 g1 * f6 g0 * f7_2 g9_19 * f8 g8_19 * f9_2 g7_19
+    : ~ i h7 + + + + + + + + + * f0 g7 * f1 g6 * f2 g5 * f3 g4 * f4 g3 * f5 g2 * f6 g1 * f7 g0 * f8 g9_19 * f9 g8_19
+    : ~ i h8 + + + + + + + + + * f0 g8 * f1_2 g7 * f2 g6 * f3_2 g5 * f4 g4 * f5_2 g3 * f6 g2 * f7_2 g1 * f8 g0 * f9_2 g9_19
+    : ~ i h9 + + + + + + + + + * f0 g9 * f1 g8 * f2 g7 * f3 g6 * f4 g5 * f5 g4 * f6 g3 * f7 g2 * f8 g1 * f9 g0
+    : ~ i cc >> + h0 33554432 26
+    = h1 + h1 cc
+    = h0 - h0 << cc 26
+    = cc >> + h4 33554432 26
+    = h5 + h5 cc
+    = h4 - h4 << cc 26
+    = cc >> + h1 16777216 25
+    = h2 + h2 cc
+    = h1 - h1 << cc 25
+    = cc >> + h5 16777216 25
+    = h6 + h6 cc
+    = h5 - h5 << cc 25
+    = cc >> + h2 33554432 26
+    = h3 + h3 cc
+    = h2 - h2 << cc 26
+    = cc >> + h6 33554432 26
+    = h7 + h7 cc
+    = h6 - h6 << cc 26
+    = cc >> + h3 16777216 25
+    = h4 + h4 cc
+    = h3 - h3 << cc 25
+    = cc >> + h7 16777216 25
+    = h8 + h8 cc
+    = h7 - h7 << cc 25
+    = cc >> + h4 33554432 26
+    = h5 + h5 cc
+    = h4 - h4 << cc 26
+    = cc >> + h8 33554432 26
+    = h9 + h9 cc
+    = h8 - h8 << cc 26
+    = cc >> + h9 16777216 25
+    = h0 + h0 * 19 cc
+    = h9 - h9 << cc 25
+    = cc >> + h0 33554432 26
+    = h1 + h1 cc
+    = h0 - h0 << cc 26
     : *i op ( vec_data [i] o )
-    : ~ i i 0
-    ~ < i 16 { = . op i . tp i = i + i 1 }
-    ( __car25519 o )
-    ( __car25519 o )
-    ( vec_free [i] t )
+    = . op 0 h0
+    = . op 1 h1
+    = . op 2 h2
+    = . op 3 h3
+    = . op 4 h4
+    = . op 5 h5
+    = . op 6 h6
+    = . op 7 h7
+    = . op 8 h8
+    = . op 9 h9
 }
 
 @ _S ( Vec i ) o ( Vec i ) a → v { ( _M o a a ) }


### PR DESCRIPTION
Independent of #746 (different files) — either can merge first.

With P-256 down to 0.62 ms, profiling an actual TLS handshake put **44% of it in `_M`**, the 25519 field multiply. `std/x25519` carried TweetNaCl's `gf`: sixteen signed limbs of about 16 bits each. That shape needs **16×16 = 256 products** per field multiply, and `_M` allocated a fresh 31-limb accumulator for each of the **1280** multiplies a scalar multiply performs.

A field element is now ten signed limbs at radix 2^25.5 — limb `i` weighing `2^ceil(25.5·i)`, alternately 26 and 25 bits. That is the classic 32-bit curve25519 layout, and the reason for it is exactly this multiply: ten limbs need **100 products**, and a 26×26 → 52-bit product still leaves room to accumulate ten of them times the folding factors inside a signed 64-bit limb. `_M` reads its operands into locals, computes the ten output limbs and carries — it allocates nothing.

Both coefficient shapes are folded into the **operands** rather than the terms, so each of the hundred products is a single multiply:

- two odd-indexed limbs land one bit low, because `ceil(25.5j) + ceil(25.5k) = ceil(25.5(j+k)) + 1` when both are odd → that term is taken against a pre-doubled operand;
- a product running past limb 9 wraps by `2^255 ≡ 19` → taken against a pre-nineteened one.

| | before | after |
|---|---:|---:|
| products per field multiply | 256 | **100** |
| `x25519_base` | 0.58 ms | **0.135 ms** |
| allocations per scalar multiply | 6146 | **26** |
| TLS 1.3 client handshake | ~4.2 ms | **~3.0 ms** |

**Ed25519 rides along.** `std/ed25519` builds on the same field, and its constants are already decoded through `_unpack25519`, so they re-encode themselves. Its one hard-coded limb count — zeroing the identity point — becomes ten.

## Constant time

Unchanged. The ladder keeps its fixed iteration count and its branchless constant-time conditional swap; the new field has no branch on data anywhere (the carry chain is a fixed sequence of shifts, and `_pack25519`'s reduction is the standard branch-free "subtract p once" form). `docs/CRYPTO.md` is updated where it described the representation.

## How it was verified

The representation was built and checked **as a model before any NURL was written** — the thing that makes a rewrite like this land rather than turn into a debugging session:

- multiply against integers mod p, 20 000 random inputs;
- the carry chain for value preservation and for bounding every limb under 2^26;
- byte decode and encode (exactly the formulation the NURL uses, including the five-byte reads and the per-byte emission plan), 20 000 round-trips;
- **a full ladder simulation** in the model, which reproduces the RFC 7748 vectors and pins the worst-case intermediate at **2^57 against a 2^63 ceiling** — that bound is the whole safety argument for radix 2^25.5 with signed 64-bit limbs, and it is measured rather than assumed;
- the 100 generated product terms were checked against the model's own term enumeration on 2000 random inputs before being emitted.

Then in the tree:

- `x25519_vectors.nu` — RFC 7748 §5.2 and §6.1. PASS.
- `ed25519_vectors.nu` — RFC 8032. PASS.
- `noise_handshake.nu`, `noise_session.nu` — PASS.
- Full suite: **568 PASS · 0 FAIL**.
- Under ASan + UBSan: `ed25519_vectors` clean; `x25519_vectors` reports 560 B in 20 allocations, against **616 B in 22 on `main`** — a pre-existing leak in the test's own `main`, two allocations smaller now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ