### PR TITLE
sha256/sha512: raw limbs, and a schedule that is not per-block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **SHA-256 is 2× faster (112 → 222 MB/s) and SHA-512 2.05×
+  (170 → 349 MB/s), because the hash cores stopped going through
+  bounds-checked Vec accessors.** One SHA-256 block made about 380 of
+  them — 64 pushes to build the message schedule, 192 gets to expand it,
+  128 more to read the round constants and the schedule back in the round
+  loop — plus one allocation for the schedule itself, all for a
+  compression function whose real work is 64 rounds of ALU. Every index
+  is fixed-count and provably in range, so every check was overhead. It
+  showed up as **12% of a TLS handshake** in `vec_push`/`vec_get` alone.
+
+  The schedule now lives in a scratch owned by the hash (allocated once
+  instead of once per block) and every limb — state, schedule, round
+  constants, and the block's own bytes — is reached through a raw `*u32`
+  / `*u64`. The round-constant tables are filled by index too: they are
+  rebuilt on every `sha256_init`, and TLS's key schedule runs one of
+  those per HMAC leg.
+
+  | | before | after |
+  |---|---:|---:|
+  | SHA-256 | 112 MB/s | **222 MB/s** |
+  | SHA-512 | 170 MB/s | **349 MB/s** |
+  | HMAC-SHA-256, short input | 3.47 µs | **2.30 µs** |
+
+  This is the same change `std/p256_field` and `std/x25519` got, applied
+  to the hash every part of the stack leans on: the TLS 1.3 key schedule
+  and transcript, HMAC and HKDF, package hashing, the CAS Merkle tree,
+  JWT. Ed25519 signing is *unchanged* — SHA-512 is not where its time
+  goes (18568 allocations per signature are).
+
 - **X25519 is 4.3× faster — 0.58 → 0.135 ms, and 26 allocations instead
   of 6146 — because the 25519 field stopped being sixteen 16-bit limbs.**
   `std/x25519` carried TweetNaCl's `gf`: sixteen signed limbs of about

--- a/stdlib/std/hash_sha256.nu
+++ b/stdlib/std/hash_sha256.nu
@@ -28,112 +28,82 @@ $ `stdlib/std/bytes.nu`
 // ── 64-entry round-constant table per FIPS 180-4 §4.2.2 ────────────
 
 @ __sha256_K → ( Vec u32 ) {
+    // Filled by index through a raw `*u32`: this table is rebuilt on every
+    // `sha256_init`, and TLS's key schedule runs one of those per HMAC leg,
+    // so sixty-four capacity-checked pushes are sixty-four too many.
     : ( Vec u32 ) k ( vec_with_cap [u32] 64 )
-    ( vec_push [u32] k # u32 1116352408 )
-    ( vec_push [u32] k # u32 1899447441 )
-    ( vec_push [u32] k # u32 3049323471 )
-    ( vec_push [u32] k # u32 3921009573 )
-    ( vec_push [u32] k # u32 961987163 )
-    ( vec_push [u32] k # u32 1508970993 )
-    ( vec_push [u32] k # u32 2453635748 )
-    ( vec_push [u32] k # u32 2870763221 )
-    ( vec_push [u32] k # u32 3624381080 )
-    ( vec_push [u32] k # u32 310598401 )
-    ( vec_push [u32] k # u32 607225278 )
-    ( vec_push [u32] k # u32 1426881987 )
-    ( vec_push [u32] k # u32 1925078388 )
-    ( vec_push [u32] k # u32 2162078206 )
-    ( vec_push [u32] k # u32 2614888103 )
-    ( vec_push [u32] k # u32 3248222580 )
-    ( vec_push [u32] k # u32 3835390401 )
-    ( vec_push [u32] k # u32 4022224774 )
-    ( vec_push [u32] k # u32 264347078 )
-    ( vec_push [u32] k # u32 604807628 )
-    ( vec_push [u32] k # u32 770255983 )
-    ( vec_push [u32] k # u32 1249150122 )
-    ( vec_push [u32] k # u32 1555081692 )
-    ( vec_push [u32] k # u32 1996064986 )
-    ( vec_push [u32] k # u32 2554220882 )
-    ( vec_push [u32] k # u32 2821834349 )
-    ( vec_push [u32] k # u32 2952996808 )
-    ( vec_push [u32] k # u32 3210313671 )
-    ( vec_push [u32] k # u32 3336571891 )
-    ( vec_push [u32] k # u32 3584528711 )
-    ( vec_push [u32] k # u32 113926993 )
-    ( vec_push [u32] k # u32 338241895 )
-    ( vec_push [u32] k # u32 666307205 )
-    ( vec_push [u32] k # u32 773529912 )
-    ( vec_push [u32] k # u32 1294757372 )
-    ( vec_push [u32] k # u32 1396182291 )
-    ( vec_push [u32] k # u32 1695183700 )
-    ( vec_push [u32] k # u32 1986661051 )
-    ( vec_push [u32] k # u32 2177026350 )
-    ( vec_push [u32] k # u32 2456956037 )
-    ( vec_push [u32] k # u32 2730485921 )
-    ( vec_push [u32] k # u32 2820302411 )
-    ( vec_push [u32] k # u32 3259730800 )
-    ( vec_push [u32] k # u32 3345764771 )
-    ( vec_push [u32] k # u32 3516065817 )
-    ( vec_push [u32] k # u32 3600352804 )
-    ( vec_push [u32] k # u32 4094571909 )
-    ( vec_push [u32] k # u32 275423344 )
-    ( vec_push [u32] k # u32 430227734 )
-    ( vec_push [u32] k # u32 506948616 )
-    ( vec_push [u32] k # u32 659060556 )
-    ( vec_push [u32] k # u32 883997877 )
-    ( vec_push [u32] k # u32 958139571 )
-    ( vec_push [u32] k # u32 1322822218 )
-    ( vec_push [u32] k # u32 1537002063 )
-    ( vec_push [u32] k # u32 1747873779 )
-    ( vec_push [u32] k # u32 1955562222 )
-    ( vec_push [u32] k # u32 2024104815 )
-    ( vec_push [u32] k # u32 2227730452 )
-    ( vec_push [u32] k # u32 2361852424 )
-    ( vec_push [u32] k # u32 2428436474 )
-    ( vec_push [u32] k # u32 2756734187 )
-    ( vec_push [u32] k # u32 3204031479 )
-    ( vec_push [u32] k # u32 3329325298 )
+    : b _l ( vec_set_len [u32] k 64 )
+    : *u32 kp ( vec_data [u32] k )
+    = . kp 0 # u32 1116352408 = . kp 1 # u32 1899447441 = . kp 2 # u32 3049323471 = . kp 3 # u32 3921009573
+    = . kp 4 # u32 961987163 = . kp 5 # u32 1508970993 = . kp 6 # u32 2453635748 = . kp 7 # u32 2870763221
+    = . kp 8 # u32 3624381080 = . kp 9 # u32 310598401 = . kp 10 # u32 607225278 = . kp 11 # u32 1426881987
+    = . kp 12 # u32 1925078388 = . kp 13 # u32 2162078206 = . kp 14 # u32 2614888103 = . kp 15 # u32 3248222580
+    = . kp 16 # u32 3835390401 = . kp 17 # u32 4022224774 = . kp 18 # u32 264347078 = . kp 19 # u32 604807628
+    = . kp 20 # u32 770255983 = . kp 21 # u32 1249150122 = . kp 22 # u32 1555081692 = . kp 23 # u32 1996064986
+    = . kp 24 # u32 2554220882 = . kp 25 # u32 2821834349 = . kp 26 # u32 2952996808 = . kp 27 # u32 3210313671
+    = . kp 28 # u32 3336571891 = . kp 29 # u32 3584528711 = . kp 30 # u32 113926993 = . kp 31 # u32 338241895
+    = . kp 32 # u32 666307205 = . kp 33 # u32 773529912 = . kp 34 # u32 1294757372 = . kp 35 # u32 1396182291
+    = . kp 36 # u32 1695183700 = . kp 37 # u32 1986661051 = . kp 38 # u32 2177026350 = . kp 39 # u32 2456956037
+    = . kp 40 # u32 2730485921 = . kp 41 # u32 2820302411 = . kp 42 # u32 3259730800 = . kp 43 # u32 3345764771
+    = . kp 44 # u32 3516065817 = . kp 45 # u32 3600352804 = . kp 46 # u32 4094571909 = . kp 47 # u32 275423344
+    = . kp 48 # u32 430227734 = . kp 49 # u32 506948616 = . kp 50 # u32 659060556 = . kp 51 # u32 883997877
+    = . kp 52 # u32 958139571 = . kp 53 # u32 1322822218 = . kp 54 # u32 1537002063 = . kp 55 # u32 1747873779
+    = . kp 56 # u32 1955562222 = . kp 57 # u32 2024104815 = . kp 58 # u32 2227730452 = . kp 59 # u32 2361852424
+    = . kp 60 # u32 2428436474 = . kp 61 # u32 2756734187 = . kp 62 # u32 3204031479 = . kp 63 # u32 3329325298
     ^ k
 }
 
 // ── Transform one 64-byte block. Mutates state (8 × u32) in place.
+//
+// Every limb here goes through a raw `*u32` / `*u` rather than the
+// bounds-checked Vec accessors. One block used to make about 380 of those
+// calls — 64 pushes to build the message schedule, 192 gets to expand it,
+// and 128 more to read K and the schedule back in the round loop — for a
+// compression function whose actual work is 64 rounds of ALU. The indices
+// are all fixed-count and provably in range, so the checks were pure
+// overhead; they showed up as 12% of a TLS handshake.
+//
+// The schedule `m` is the caller's 64-word scratch, allocated once per
+// hash instead of once per block.
 
-@ __sha256_transform ( Vec u32 ) state ( Vec u ) block i offset ( Vec u32 ) K → v {
-    : ( Vec u32 ) m ( vec_with_cap [u32] 64 )
+@ __sha256_be32 * u p i o → u32 {
+    ^ | | | << # u32 . p o # u32 24 << # u32 . p + o 1 # u32 16
+    << # u32 . p + o 2 # u32 8 # u32 . p + o 3
+}
+
+@ __sha256_transform ( Vec u32 ) state ( Vec u ) block i offset ( Vec u32 ) K ( Vec u32 ) m → v {
+    : *u32 mp ( vec_data [u32] m )
+    : *u32 kp ( vec_data [u32] K )
+    : *u32 sp ( vec_data [u32] state )
+    : *u bp ( vec_data [u] block )
     : ~ i wi 0
     ~ < wi 16 {
-        : ?u32 wo ( bytes_read_u32_be block + offset * wi 4 )
-        : u32 wv ?? wo { T x → x F → # u32 0 }
-        ( vec_push [u32] m wv )
+        = . mp wi ( __sha256_be32 bp + offset * wi 4 )
         = wi + wi 1
     }
     ~ < wi 64 {
-        : u32 m15 ( __sha256_vu32 m - wi 15 )
-        : u32 m2 ( __sha256_vu32 m - wi 2 )
-        : u32 m7 ( __sha256_vu32 m - wi 7 )
-        : u32 m16 ( __sha256_vu32 m - wi 16 )
+        : u32 m15 . mp - wi 15
+        : u32 m2 . mp - wi 2
         : u32 s0 ^^ ^^ ( __sha256_rotr m15 7 ) ( __sha256_rotr m15 18 ) >> m15 # u32 3
         : u32 s1 ^^ ^^ ( __sha256_rotr m2 17 ) ( __sha256_rotr m2 19 ) >> m2 # u32 10
-        ( vec_push [u32] m + + + m16 s0 m7 s1 )
+        = . mp wi + + + . mp - wi 16 s0 . mp - wi 7 s1
         = wi + wi 1
     }
 
-    : ~ u32 a ( __sha256_vu32 state 0 )
-    : ~ u32 b ( __sha256_vu32 state 1 )
-    : ~ u32 c ( __sha256_vu32 state 2 )
-    : ~ u32 d ( __sha256_vu32 state 3 )
-    : ~ u32 e ( __sha256_vu32 state 4 )
-    : ~ u32 f ( __sha256_vu32 state 5 )
-    : ~ u32 g ( __sha256_vu32 state 6 )
-    : ~ u32 h ( __sha256_vu32 state 7 )
+    : ~ u32 a . sp 0
+    : ~ u32 b . sp 1
+    : ~ u32 c . sp 2
+    : ~ u32 d . sp 3
+    : ~ u32 e . sp 4
+    : ~ u32 f . sp 5
+    : ~ u32 g . sp 6
+    : ~ u32 h . sp 7
 
     : ~ i ri 0
     ~ < ri 64 {
         : u32 S1 ^^ ^^ ( __sha256_rotr e 6 ) ( __sha256_rotr e 11 ) ( __sha256_rotr e 25 )
         : u32 ch ^^ & e f & ~ e g
-        : u32 ki ( __sha256_vu32 K ri )
-        : u32 mi ( __sha256_vu32 m ri )
-        : u32 t1 + + + + h S1 ch ki mi
+        : u32 t1 + + + + h S1 ch . kp ri . mp ri
         : u32 S0 ^^ ^^ ( __sha256_rotr a 2 ) ( __sha256_rotr a 13 ) ( __sha256_rotr a 22 )
         : u32 mj ^^ ^^ & a b & a c & b c
         : u32 t2 + S0 mj
@@ -148,24 +118,14 @@ $ `stdlib/std/bytes.nu`
         = ri + ri 1
     }
 
-    : u32 s0 ( __sha256_vu32 state 0 )
-    : u32 s1 ( __sha256_vu32 state 1 )
-    : u32 s2 ( __sha256_vu32 state 2 )
-    : u32 s3 ( __sha256_vu32 state 3 )
-    : u32 s4 ( __sha256_vu32 state 4 )
-    : u32 s5 ( __sha256_vu32 state 5 )
-    : u32 s6 ( __sha256_vu32 state 6 )
-    : u32 s7 ( __sha256_vu32 state 7 )
-    : b _0 ( vec_set [u32] state 0 + s0 a )
-    : b _1 ( vec_set [u32] state 1 + s1 b )
-    : b _2 ( vec_set [u32] state 2 + s2 c )
-    : b _3 ( vec_set [u32] state 3 + s3 d )
-    : b _4 ( vec_set [u32] state 4 + s4 e )
-    : b _5 ( vec_set [u32] state 5 + s5 f )
-    : b _6 ( vec_set [u32] state 6 + s6 g )
-    : b _7 ( vec_set [u32] state 7 + s7 h )
-
-    ( vec_free [u32] m )
+    = . sp 0 + . sp 0 a
+    = . sp 1 + . sp 1 b
+    = . sp 2 + . sp 2 c
+    = . sp 3 + . sp 3 d
+    = . sp 4 + . sp 4 e
+    = . sp 5 + . sp 5 f
+    = . sp 6 + . sp 6 g
+    = . sp 7 + . sp 7 h
 }
 
 // ── Public entry — bytes-in, 32-byte digest out.
@@ -187,6 +147,7 @@ $ `stdlib/std/bytes.nu`
     ( Vec u ) buf
     i total
     ( Vec u32 ) k
+    ( Vec u32 ) m
 }
 
 @ sha256_init → *Sha256 {
@@ -204,6 +165,9 @@ $ `stdlib/std/bytes.nu`
     = . h buf ( vec_new [u] )
     = . h total 0
     = . h k ( __sha256_K )
+    : ( Vec u32 ) sched ( vec_with_cap [u32] 64 )
+    : b _m ( vec_set_len [u32] sched 64 )
+    = . h m sched
     ^ h
 }
 
@@ -220,13 +184,13 @@ $ `stdlib/std/bytes.nu`
         ( bytes_extend_raw . h buf # s ( vec_data [u] data ) take )
         = off take
         ? == ( vec_len [u] . h buf ) 64 {
-            ( __sha256_transform . h state . h buf 0 . h k )
+            ( __sha256_transform . h state . h buf 0 . h k . h m )
             ( vec_clear [u] . h buf )
         } {}
     } {}
     // full blocks straight from the caller's data — no copy
     ~ <= + off 64 n {
-        ( __sha256_transform . h state data off . h k )
+        ( __sha256_transform . h state data off . h k . h m )
         = off + off 64
     }
     // stash the tail
@@ -260,7 +224,7 @@ $ `stdlib/std/bytes.nu`
     : i tail_len ( vec_len [u] tail )
     : ~ i toff 0
     ~ < toff tail_len {
-        ( __sha256_transform . h state tail toff . h k )
+        ( __sha256_transform . h state tail toff . h k . h m )
         = toff + toff 64
     }
 
@@ -278,6 +242,7 @@ $ `stdlib/std/bytes.nu`
     ( vec_free [u] tail )
     ( vec_free [u32] . h state )
     ( vec_free [u32] . h k )
+    ( vec_free [u32] . h m )
     ( nurl_free # s h )
     ^ out
 }

--- a/stdlib/std/hash_sha512.nu
+++ b/stdlib/std/hash_sha512.nu
@@ -35,128 +35,101 @@ $ `stdlib/std/bytes.nu`
 // ── 80-entry K table (FIPS 180-4 §4.2.3) ──────────────────────────
 
 @ __sha512_K → ( Vec u64 ) {
+    // Filled by index through a raw `*u64` — see hash_sha256.nu's K for why
+    // eighty capacity-checked pushes per hash are eighty too many.
     : ( Vec u64 ) k ( vec_with_cap [u64] 80 )
-    ( vec_push [u64] k # u64 4794697086780616226 )
-    ( vec_push [u64] k # u64 8158064640168781261 )
-    ( vec_push [u64] k # u64 -5349999486874862801 )
-    ( vec_push [u64] k # u64 -1606136188198331460 )
-    ( vec_push [u64] k # u64 4131703408338449720 )
-    ( vec_push [u64] k # u64 6480981068601479193 )
-    ( vec_push [u64] k # u64 -7908458776815382629 )
-    ( vec_push [u64] k # u64 -6116909921290321640 )
-    ( vec_push [u64] k # u64 -2880145864133508542 )
-    ( vec_push [u64] k # u64 1334009975649890238 )
-    ( vec_push [u64] k # u64 2608012711638119052 )
-    ( vec_push [u64] k # u64 6128411473006802146 )
-    ( vec_push [u64] k # u64 8268148722764581231 )
-    ( vec_push [u64] k # u64 -9160688886553864527 )
-    ( vec_push [u64] k # u64 -7215885187991268811 )
-    ( vec_push [u64] k # u64 -4495734319001033068 )
-    ( vec_push [u64] k # u64 -1973867731355612462 )
-    ( vec_push [u64] k # u64 -1171420211273849373 )
-    ( vec_push [u64] k # u64 1135362057144423861 )
-    ( vec_push [u64] k # u64 2597628984639134821 )
-    ( vec_push [u64] k # u64 3308224258029322869 )
-    ( vec_push [u64] k # u64 5365058923640841347 )
-    ( vec_push [u64] k # u64 6679025012923562964 )
-    ( vec_push [u64] k # u64 8573033837759648693 )
-    ( vec_push [u64] k # u64 -7476448914759557205 )
-    ( vec_push [u64] k # u64 -6327057829258317296 )
-    ( vec_push [u64] k # u64 -5763719355590565569 )
-    ( vec_push [u64] k # u64 -4658551843659510044 )
-    ( vec_push [u64] k # u64 -4116276920077217854 )
-    ( vec_push [u64] k # u64 -3051310485924567259 )
-    ( vec_push [u64] k # u64 489312712824947311 )
-    ( vec_push [u64] k # u64 1452737877330783856 )
-    ( vec_push [u64] k # u64 2861767655752347644 )
-    ( vec_push [u64] k # u64 3322285676063803686 )
-    ( vec_push [u64] k # u64 5560940570517711597 )
-    ( vec_push [u64] k # u64 5996557281743188959 )
-    ( vec_push [u64] k # u64 7280758554555802590 )
-    ( vec_push [u64] k # u64 8532644243296465576 )
-    ( vec_push [u64] k # u64 -9096487096722542874 )
-    ( vec_push [u64] k # u64 -7894198246740708037 )
-    ( vec_push [u64] k # u64 -6719396339535248540 )
-    ( vec_push [u64] k # u64 -6333637450476146687 )
-    ( vec_push [u64] k # u64 -4446306890439682159 )
-    ( vec_push [u64] k # u64 -4076793802049405392 )
-    ( vec_push [u64] k # u64 -3345356375505022440 )
-    ( vec_push [u64] k # u64 -2983346525034927856 )
-    ( vec_push [u64] k # u64 -860691631967231958 )
-    ( vec_push [u64] k # u64 1182934255886127544 )
-    ( vec_push [u64] k # u64 1847814050463011016 )
-    ( vec_push [u64] k # u64 2177327727835720531 )
-    ( vec_push [u64] k # u64 2830643537854262169 )
-    ( vec_push [u64] k # u64 3796741975233480872 )
-    ( vec_push [u64] k # u64 4115178125766777443 )
-    ( vec_push [u64] k # u64 5681478168544905931 )
-    ( vec_push [u64] k # u64 6601373596472566643 )
-    ( vec_push [u64] k # u64 7507060721942968483 )
-    ( vec_push [u64] k # u64 8399075790359081724 )
-    ( vec_push [u64] k # u64 8693463985226723168 )
-    ( vec_push [u64] k # u64 -8878714635349349518 )
-    ( vec_push [u64] k # u64 -8302665154208450068 )
-    ( vec_push [u64] k # u64 -8016688836872298968 )
-    ( vec_push [u64] k # u64 -6606660893046293015 )
-    ( vec_push [u64] k # u64 -4685533653050689259 )
-    ( vec_push [u64] k # u64 -4147400797238176981 )
-    ( vec_push [u64] k # u64 -3880063495543823972 )
-    ( vec_push [u64] k # u64 -3348786107499101689 )
-    ( vec_push [u64] k # u64 -1523767162380948706 )
-    ( vec_push [u64] k # u64 -757361751448694408 )
-    ( vec_push [u64] k # u64 500013540394364858 )
-    ( vec_push [u64] k # u64 748580250866718886 )
-    ( vec_push [u64] k # u64 1242879168328830382 )
-    ( vec_push [u64] k # u64 1977374033974150939 )
-    ( vec_push [u64] k # u64 2944078676154940804 )
-    ( vec_push [u64] k # u64 3659926193048069267 )
-    ( vec_push [u64] k # u64 4368137639120453308 )
-    ( vec_push [u64] k # u64 4836135668995329356 )
-    ( vec_push [u64] k # u64 5532061633213252278 )
-    ( vec_push [u64] k # u64 6448918945643986474 )
-    ( vec_push [u64] k # u64 6902733635092675308 )
-    ( vec_push [u64] k # u64 7801388544844847127 )
+    : b _l ( vec_set_len [u64] k 80 )
+    : *u64 kp ( vec_data [u64] k )
+    = . kp 0 # u64 4794697086780616226 = . kp 1 # u64 8158064640168781261
+    = . kp 2 # u64 -5349999486874862801 = . kp 3 # u64 -1606136188198331460
+    = . kp 4 # u64 4131703408338449720 = . kp 5 # u64 6480981068601479193
+    = . kp 6 # u64 -7908458776815382629 = . kp 7 # u64 -6116909921290321640
+    = . kp 8 # u64 -2880145864133508542 = . kp 9 # u64 1334009975649890238
+    = . kp 10 # u64 2608012711638119052 = . kp 11 # u64 6128411473006802146
+    = . kp 12 # u64 8268148722764581231 = . kp 13 # u64 -9160688886553864527
+    = . kp 14 # u64 -7215885187991268811 = . kp 15 # u64 -4495734319001033068
+    = . kp 16 # u64 -1973867731355612462 = . kp 17 # u64 -1171420211273849373
+    = . kp 18 # u64 1135362057144423861 = . kp 19 # u64 2597628984639134821
+    = . kp 20 # u64 3308224258029322869 = . kp 21 # u64 5365058923640841347
+    = . kp 22 # u64 6679025012923562964 = . kp 23 # u64 8573033837759648693
+    = . kp 24 # u64 -7476448914759557205 = . kp 25 # u64 -6327057829258317296
+    = . kp 26 # u64 -5763719355590565569 = . kp 27 # u64 -4658551843659510044
+    = . kp 28 # u64 -4116276920077217854 = . kp 29 # u64 -3051310485924567259
+    = . kp 30 # u64 489312712824947311 = . kp 31 # u64 1452737877330783856
+    = . kp 32 # u64 2861767655752347644 = . kp 33 # u64 3322285676063803686
+    = . kp 34 # u64 5560940570517711597 = . kp 35 # u64 5996557281743188959
+    = . kp 36 # u64 7280758554555802590 = . kp 37 # u64 8532644243296465576
+    = . kp 38 # u64 -9096487096722542874 = . kp 39 # u64 -7894198246740708037
+    = . kp 40 # u64 -6719396339535248540 = . kp 41 # u64 -6333637450476146687
+    = . kp 42 # u64 -4446306890439682159 = . kp 43 # u64 -4076793802049405392
+    = . kp 44 # u64 -3345356375505022440 = . kp 45 # u64 -2983346525034927856
+    = . kp 46 # u64 -860691631967231958 = . kp 47 # u64 1182934255886127544
+    = . kp 48 # u64 1847814050463011016 = . kp 49 # u64 2177327727835720531
+    = . kp 50 # u64 2830643537854262169 = . kp 51 # u64 3796741975233480872
+    = . kp 52 # u64 4115178125766777443 = . kp 53 # u64 5681478168544905931
+    = . kp 54 # u64 6601373596472566643 = . kp 55 # u64 7507060721942968483
+    = . kp 56 # u64 8399075790359081724 = . kp 57 # u64 8693463985226723168
+    = . kp 58 # u64 -8878714635349349518 = . kp 59 # u64 -8302665154208450068
+    = . kp 60 # u64 -8016688836872298968 = . kp 61 # u64 -6606660893046293015
+    = . kp 62 # u64 -4685533653050689259 = . kp 63 # u64 -4147400797238176981
+    = . kp 64 # u64 -3880063495543823972 = . kp 65 # u64 -3348786107499101689
+    = . kp 66 # u64 -1523767162380948706 = . kp 67 # u64 -757361751448694408
+    = . kp 68 # u64 500013540394364858 = . kp 69 # u64 748580250866718886
+    = . kp 70 # u64 1242879168328830382 = . kp 71 # u64 1977374033974150939
+    = . kp 72 # u64 2944078676154940804 = . kp 73 # u64 3659926193048069267
+    = . kp 74 # u64 4368137639120453308 = . kp 75 # u64 4836135668995329356
+    = . kp 76 # u64 5532061633213252278 = . kp 77 # u64 6448918945643986474
+    = . kp 78 # u64 6902733635092675308 = . kp 79 # u64 7801388544844847127
     ^ k
 }
 
 // ── Transform: one 128-byte block. Mutates state (8 × u64) in place.
+//
+// Limbs go through raw `*u64` / `*u` rather than the bounds-checked Vec
+// accessors, and the 80-word message schedule `w` is the caller's scratch
+// — allocated once per hash instead of once per block. Same change, same
+// reasoning as hash_sha256.nu.
 
-@ __sha512_transform ( Vec u64 ) state ( Vec u ) block i offset ( Vec u64 ) K → v {
-    : ( Vec u64 ) w ( vec_with_cap [u64] 80 )
+@ __sha512_be64 * u p i o → u64 {
+    ^ | | | | | | | << # u64 . p o # u64 56 << # u64 . p + o 1 # u64 48
+    << # u64 . p + o 2 # u64 40 << # u64 . p + o 3 # u64 32
+    << # u64 . p + o 4 # u64 24 << # u64 . p + o 5 # u64 16
+    << # u64 . p + o 6 # u64 8 # u64 . p + o 7
+}
+
+@ __sha512_transform ( Vec u64 ) state ( Vec u ) block i offset ( Vec u64 ) K ( Vec u64 ) w → v {
+    : *u64 wp ( vec_data [u64] w )
+    : *u64 kp ( vec_data [u64] K )
+    : *u64 sp ( vec_data [u64] state )
+    : *u bp ( vec_data [u] block )
     : ~ i wi 0
     ~ < wi 16 {
-        : ?u64 wo ( bytes_read_u64_be block + offset * wi 8 )
-        : u64 wv ?? wo { T x → x F → # u64 0 }
-        ( vec_push [u64] w wv )
+        = . wp wi ( __sha512_be64 bp + offset * wi 8 )
         = wi + wi 1
     }
     ~ < wi 80 {
-        : u64 w15 ( __sha512_vu64 w - wi 15 )
-        : u64 w2 ( __sha512_vu64 w - wi 2 )
-        : u64 w7 ( __sha512_vu64 w - wi 7 )
-        : u64 w16 ( __sha512_vu64 w - wi 16 )
+        : u64 w15 . wp - wi 15
+        : u64 w2 . wp - wi 2
         : u64 s0 ^^ ^^ ( __sha512_rotr w15 1 ) ( __sha512_rotr w15 8 ) >> w15 # u64 7
         : u64 s1 ^^ ^^ ( __sha512_rotr w2 19 ) ( __sha512_rotr w2 61 ) >> w2 # u64 6
-        ( vec_push [u64] w + + + w16 s0 w7 s1 )
+        = . wp wi + + + . wp - wi 16 s0 . wp - wi 7 s1
         = wi + wi 1
     }
 
-    : ~ u64 a ( __sha512_vu64 state 0 )
-    : ~ u64 b ( __sha512_vu64 state 1 )
-    : ~ u64 c ( __sha512_vu64 state 2 )
-    : ~ u64 d ( __sha512_vu64 state 3 )
-    : ~ u64 e ( __sha512_vu64 state 4 )
-    : ~ u64 f ( __sha512_vu64 state 5 )
-    : ~ u64 g ( __sha512_vu64 state 6 )
-    : ~ u64 h ( __sha512_vu64 state 7 )
+    : ~ u64 a . sp 0
+    : ~ u64 b . sp 1
+    : ~ u64 c . sp 2
+    : ~ u64 d . sp 3
+    : ~ u64 e . sp 4
+    : ~ u64 f . sp 5
+    : ~ u64 g . sp 6
+    : ~ u64 h . sp 7
 
     : ~ i ri 0
     ~ < ri 80 {
         : u64 S1 ^^ ^^ ( __sha512_rotr e 14 ) ( __sha512_rotr e 18 ) ( __sha512_rotr e 41 )
         : u64 ch ^^ & e f & ~ e g
-        : u64 ki ( __sha512_vu64 K ri )
-        : u64 wi2 ( __sha512_vu64 w ri )
-        : u64 t1 + + + + h S1 ch ki wi2
+        : u64 t1 + + + + h S1 ch . kp ri . wp ri
         : u64 S0 ^^ ^^ ( __sha512_rotr a 28 ) ( __sha512_rotr a 34 ) ( __sha512_rotr a 39 )
         : u64 mj ^^ ^^ & a b & a c & b c
         : u64 t2 + S0 mj
@@ -171,24 +144,14 @@ $ `stdlib/std/bytes.nu`
         = ri + ri 1
     }
 
-    : u64 s0 ( __sha512_vu64 state 0 )
-    : u64 s1 ( __sha512_vu64 state 1 )
-    : u64 s2 ( __sha512_vu64 state 2 )
-    : u64 s3 ( __sha512_vu64 state 3 )
-    : u64 s4 ( __sha512_vu64 state 4 )
-    : u64 s5 ( __sha512_vu64 state 5 )
-    : u64 s6 ( __sha512_vu64 state 6 )
-    : u64 s7 ( __sha512_vu64 state 7 )
-    : b _0 ( vec_set [u64] state 0 + s0 a )
-    : b _1 ( vec_set [u64] state 1 + s1 b )
-    : b _2 ( vec_set [u64] state 2 + s2 c )
-    : b _3 ( vec_set [u64] state 3 + s3 d )
-    : b _4 ( vec_set [u64] state 4 + s4 e )
-    : b _5 ( vec_set [u64] state 5 + s5 f )
-    : b _6 ( vec_set [u64] state 6 + s6 g )
-    : b _7 ( vec_set [u64] state 7 + s7 h )
-
-    ( vec_free [u64] w )
+    = . sp 0 + . sp 0 a
+    = . sp 1 + . sp 1 b
+    = . sp 2 + . sp 2 c
+    = . sp 3 + . sp 3 d
+    = . sp 4 + . sp 4 e
+    = . sp 5 + . sp 5 f
+    = . sp 6 + . sp 6 g
+    = . sp 7 + . sp 7 h
 }
 
 // ── Public entry — bytes-in, 64-byte digest out. ──────────────────
@@ -224,12 +187,14 @@ $ `stdlib/std/bytes.nu`
 // to `outlen` bytes. Consumes `state`.
 @ __sha512_finish ( Vec u ) data ( Vec u64 ) state i outlen → ( Vec u ) {
     : ( Vec u64 ) K ( __sha512_K )
+    : ( Vec u64 ) sched ( vec_with_cap [u64] 80 )
+    : b _w ( vec_set_len [u64] sched 80 )
     : i n ( vec_len [u] data )
 
     // Process complete 128-byte blocks straight from the input.
     : ~ i off 0
     ~ <= + off 128 n {
-        ( __sha512_transform state data off K )
+        ( __sha512_transform state data off K sched )
         = off + off 128
     }
 
@@ -272,7 +237,7 @@ $ `stdlib/std/bytes.nu`
     : i tail_len ( vec_len [u] tail )
     : ~ i toff 0
     ~ < toff tail_len {
-        ( __sha512_transform state tail toff K )
+        ( __sha512_transform state tail toff K sched )
         = toff + toff 128
     }
     ( vec_free [u] tail )
@@ -296,6 +261,7 @@ $ `stdlib/std/bytes.nu`
 
     ( vec_free [u64] state )
     ( vec_free [u64] K )
+    ( vec_free [u64] sched )
     : b _t ( vec_set_len [u] out outlen )
     ^ out
 }


### PR DESCRIPTION
Profiling a TLS handshake after #747 put **12% of it in `vec_push__u32` + `vec_get__u32`** — bounds-checked Vec accessors, not arithmetic. They belong to SHA-256.

One SHA-256 block made about **380** of those calls: 64 pushes to build the message schedule, 192 gets to expand it, and 128 more to read `K` and the schedule back in the round loop — for a compression function whose actual work is 64 rounds of ALU. It also allocated the 64-word schedule *per block*. Every index is fixed-count and provably in range, so every check was pure overhead.

The schedule is now a scratch owned by the hash — allocated once instead of once per block — and state, schedule, round constants and the block's own bytes are all reached through a raw `*u32` / `*u64`. The `K` tables are filled by index rather than pushed: they are rebuilt on every `sha256_init`, and TLS's key schedule runs one of those per HMAC leg.

SHA-512 had the identical shape (80 pushes per init, an 80-word per-block schedule) and gets the identical treatment.

| | before | after |
|---|---:|---:|
| SHA-256 | 112 MB/s | **222 MB/s** |
| SHA-512 | 170 MB/s | **349 MB/s** |
| HMAC-SHA-256, short input | 3.47 µs | **2.30 µs** |

A/B binaries interleaved back to back, 64 KB inputs.

This is the same change `std/p256_field` got in #743 and `std/x25519` got in #747, applied to the hash the rest of the stack leans on: the TLS 1.3 key schedule and transcript, HMAC and HKDF, package hashing, the CAS Merkle tree, JWT.

**Two things this does not do**, stated plainly:

- **Ed25519 signing is unchanged** (735 µs before and after). SHA-512 is not where its time goes — 18568 allocations per signature are. That is a separate, and now fairly obvious, next lever.
- **The end-to-end handshake gain is below my harness's noise floor.** SHA was ~20% of the profile and this removes a good part of that, so a few percent is expected, but the python-`ssl` server this measures against drifts ±15% run to run. The throughput numbers above are the ones I stand behind.

## Verification

- `hash_extended.nu` — FIPS 180-4 SHA-256/384/512 vectors and RFC 4231 HMAC vectors. PASS.
- `hash_stream.nu` — streaming vs one-shot across 7 split sizes. PASS.
- `hkdf_vectors.nu` — RFC 5869 plus the TLS 1.3 early/derived secrets. PASS.
- `ed25519_vectors.nu` — RFC 8032 (exercises SHA-512). PASS.
- Full suite: **568 PASS · 0 FAIL**.
- `hash_extended` and `hash_stream` under ASan + UBSan: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ