### PR TITLE
net: force accepted sockets blocking — BSD accept() inherits O_NONBLOCK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Every TLS server on FreeBSD failed its handshake, because `accept()`
+  inherits `O_NONBLOCK` there and does not on Linux.** `nurl_tcp_listen`
+  puts the listening socket in non-blocking mode — the accept-wakeup pipe
+  needs it — and POSIX leaves it *unspecified* whether `accept()` hands
+  that flag to the new socket. Linux does not; the BSDs do. So on FreeBSD
+  every accepted connection came back non-blocking.
+
+  `net.nu`'s `tcp_read_chunk` survived that (it loops on `EAGAIN`), which
+  is why plain TCP servers worked and the bug stayed hidden. But
+  `tls.nu`'s `__fill` deliberately issues **one raw blocking
+  `nurl_tcp_read`** — its comment explains why — so it got `EAGAIN`
+  instead of the ClientHello, and every pure-NURL TLS handshake died with
+  `TlsRead` before a single byte was parsed. Nothing to do with the
+  crypto: the same box passes every RFC and FIPS vector.
+
+  `nurl_tcp_accept` now clears `O_NONBLOCK` on the accepted socket, so
+  every platform behaves the way the net stack was written against. A
+  caller that wants non-blocking still asks for it through
+  `nurl_tcp_set_nonblock`.
+
+  Found by installing the toolchain on an OPNsense box and watching
+  `swarm-mcp`'s HTTPS control surface refuse every connection; reduced to
+  a 30-line reproducer (`x509_selfsigned_p256` → `tcp_listen_tls` →
+  `tcp_accept`). Not a regression — v0.30.0 fails identically.
+
+  **This had no test.** `compiler/tests/http_server_tls*.nu` are gated
+  behind `NURL_NET_TESTS=1` *and* use an openssl-generated RSA
+  certificate, so the pure server's EC P-256 path — the one `x509_gen`
+  produces and every NURL-native TLS server uses — was never exercised in
+  CI on any platform.
+
 ## [0.31.0] — 2026-08-02
 
 A cryptography release, plus the compiler change that made the rest of

--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -1083,6 +1083,28 @@ long long nurl_tcp_accept(long long listener) {
         setsockopt(c->fd, IPPROTO_TCP, TCP_NODELAY,
                    (const char*)&one, (socklen_t)sizeof(one));
     }
+#ifndef _WIN32
+    /* Force the accepted socket BLOCKING, whatever the listener was.
+     *
+     * The listener is put in O_NONBLOCK above (the accept-wakeup pipe needs
+     * it), and POSIX leaves it *unspecified* whether accept() hands that
+     * flag to the new socket. Linux does not; the BSDs do. So on FreeBSD
+     * every accepted connection came back non-blocking, and any caller
+     * doing a plain blocking read got EAGAIN instead of data.
+     *
+     * net.nu's tcp_read_chunk survived that (it loops on EAGAIN), but
+     * tls.nu's __fill deliberately issues one raw nurl_tcp_read — see its
+     * comment — so the pure TLS server failed to read the ClientHello and
+     * every handshake died with TlsRead. Normalising here means every
+     * caller sees the Linux behaviour, which is what the whole net stack
+     * was written against. A caller that wants non-blocking still asks for
+     * it explicitly through nurl_tcp_set_nonblock. */
+    {
+        int fl = fcntl(c->fd, F_GETFL, 0);
+        if (fl >= 0 && (fl & O_NONBLOCK)) fcntl(c->fd, F_SETFL, fl & ~O_NONBLOCK);
+    }
+    c->nonblock = 0;
+#endif
     return (long long)(uintptr_t)c;
 }
 


### PR DESCRIPTION
**Every pure-NURL TLS server failed its handshake on FreeBSD.** One line of C.

## Root cause

`nurl_tcp_listen` puts the listening socket in `O_NONBLOCK` — the accept-wakeup self-pipe needs it. POSIX leaves it **unspecified** whether `accept()` passes that flag to the new socket: **Linux does not, the BSDs do.** So on FreeBSD every accepted connection came back non-blocking.

`net.nu`'s `tcp_read_chunk` survived that — it loops on `EAGAIN` — which is exactly why plain TCP servers worked and this stayed hidden. But `tls.nu`'s `__fill` deliberately issues **one raw blocking `nurl_tcp_read`** (its own comment explains why it bypasses `tcp_read_chunk`), so it got `EAGAIN` instead of the ClientHello and every handshake died with `TlsRead` before a byte was parsed.

`nurl_tcp_accept` now clears `O_NONBLOCK` on the accepted socket, so every platform behaves the way the net stack was written against. A caller that wants non-blocking still asks for it through `nurl_tcp_set_nonblock`.

## How it was found, and what it was not

Installing the v0.31.0 toolchain on an OPNsense box (FreeBSD 14.3) and watching `swarm-mcp`'s HTTPS control surface refuse every connection — port listening, TLS dying right after ClientHello.

Reduced to a 30-line reproducer: `x509_selfsigned_p256` → `tcp_listen_tls` → `tcp_accept`. On that box:

| | before | after |
|---|---|---|
| reproducer | `ACCEPT/HANDSHAKE FAILED` (`TlsRead`) | `handshake OK`, **http=200** |
| `swarm-mcp` MCP surface | connection refused at TLS | `tools/list` returns, **compute job returns 499999500000** |

**Not a v0.31.0 regression** — v0.30.0's toolchain fails identically on the same box. **Not the crypto** — every RFC/FIPS vector passes on that box. **Not the package** — the FreeBSD and Linux archives are content-identical apart from the bundled zig and an ALSA marker, and bundling zig 0.13.0's `x86_64-freebsd` build (it exists) changed nothing about the handshake.

## The test gap this exposes

`compiler/tests/http_server_tls*.nu` are gated behind `NURL_NET_TESTS=1` **and** use an openssl-generated **RSA** certificate. The pure server's **EC P-256** path — what `x509_gen` produces and what every NURL-native TLS server uses — has no in-tree test on any platform. That is why a total TLS-server failure on a supported target shipped in a release. Happy to add that test in a follow-up; say the word.

## Verification

- Linux: **568 PASS · 0 FAIL**
- Linux, `NURL_NET_TESTS=1`: `http_server_tls`, `tls_large_record`, `http_server_tls_extras` all still pass
- FreeBSD 14.3: reproducer and `swarm-mcp` both go from broken to working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ