### PR TITLE
release: cut v0.31.1 — TLS servers on FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.31.1] — 2026-08-03
+
+A one-fix patch release: TLS servers did not work on FreeBSD at all, and
+the reason was a socket flag, not the cryptography.
 
 ### Fixed
 
@@ -10372,7 +10375,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.31.0...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.31.1...HEAD
+[0.31.1]: https://github.com/nurl-lang/nurl/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/nurl-lang/nurl/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/nurl-lang/nurl/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/nurl-lang/nurl/compare/v0.28.0...v0.29.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-02 · Current release: **0.31.0** · Language: **Grammar
+_Last reviewed: 2026-08-03 · Current release: **0.31.1** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
A one-fix patch release for #751.

No pure-NURL TLS server could complete a handshake on FreeBSD. `nurl_tcp_listen` puts the listening socket in `O_NONBLOCK` for the accept-wakeup pipe; POSIX leaves it **unspecified** whether `accept()` passes that flag to the new socket, and **the BSDs do where Linux does not**. So `tls.nu`'s one raw blocking read got `EAGAIN` instead of the ClientHello, and every handshake died with `TlsRead` before a byte was parsed. `nurl_tcp_accept` now clears `O_NONBLOCK` on the accepted socket.

Not a v0.31.0 regression — v0.30.0 fails identically. Nothing to do with the cryptography: every RFC/FIPS vector passes on the affected box.

## Changes

- `CHANGELOG.md` — `[Unreleased]` → `[0.31.1]`, compare links added
- `ROADMAP.md` — current release

## Verified on the release tree

- `./build.sh` green — 31 s build, 42 s tests, **568 PASS · 0 FAIL**
- Bootstrap fixed point **byte-identical** (`nurlc_self.ll` == `nurlc_self2.ll`)

And on FreeBSD 14.3 before the merge: the 30-line reproducer goes from `ACCEPT/HANDSHAKE FAILED` to `http=200`, and `swarm-mcp` goes from refusing every TLS connection to serving `tools/list` and returning a correct distributed compute result.

## Deliberately not in this patch

The pure server's **EC P-256** path still has no in-tree test on any platform — `http_server_tls*.nu` are `NURL_NET_TESTS`-gated and RSA-only, which is how a total TLS-server failure on a supported target shipped. Worth its own PR rather than widening a patch release.

Tag `v0.31.1` after this merges and CI is clean on the merge SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ