### PR TITLE
mcp: dual-era support for the 2026-07-28 (stateless) spec revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **MCP 2026-07-28 (the stateless revision) — the stdlib MCP stack is
+  now dual-era.** The new spec revision removes the
+  `initialize`/`notifications/initialized` handshake and protocol-level
+  sessions: a *modern* request carries its protocol version, client
+  identity and capabilities in `params._meta`
+  (`io.modelcontextprotocol/protocolVersion` & co), and servers MUST
+  implement `server/discover`. NURL's stack now serves **both eras on
+  the same endpoint**, per the spec's own dual-era compatibility
+  matrix — nothing was removed, so every existing legacy client keeps
+  working:
+
+  * `mcp_registry.nu` — `server/discover` dispatch; requests declaring
+    an unsupported `_meta` version get the spec-shaped
+    `UnsupportedProtocolVersionError` (−32022 with `data.supported`);
+    results for modern requests carry `_meta` serverInfo; `initialize`
+    now echoes the client's requested handshake-era revision when
+    supported (previously it always pinned the latest). The stdio serve
+    loop was unified onto `mcp_registry_envelope` — which also fixed a
+    latent double-free (`json_free` after the consuming
+    `mcp_send_message`).
+  * `mcp.nu` — `mcp_protocol_version` is now `2026-07-28`;
+    `mcp_protocol_version_initialize` (2025-11-25) is what handshake
+    responses advertise. New: `mcp_version_supported`,
+    `mcp_supported_versions_json`, `mcp_request_protocol_version` /
+    `mcp_request_is_modern`, `mcp_client_meta`, `mcp_discover_result`,
+    `mcp_result_set_cacheable` / `mcp_result_set_server_info`,
+    `mcp_response_error_data` / `mcp_unsupported_version_response`, and
+    error-code constants −32020…−32022. Every result built via
+    `mcp_response_result` now carries `resultType: "complete"`
+    (required in 2026-07-28, additive for older clients), and
+    `mcp_tools_list_result` fills the now-required CacheableResult
+    fields (`ttlMs`, `cacheScope`) — as do the registry's list/read
+    dispatchers.
+  * `mcp_http.nu` — validates the 2026-07-28 header-routing headers
+    (`Mcp-Method`, `Mcp-Name`) against the body when present
+    (mismatch → `HeaderMismatchError` −32020; absent headers stay
+    legal for legacy clients) and allows them through CORS.
+  * `mcp_client.nu` — modern era client calls: `mcp_call_modern` /
+    `mcp_tools_call_modern` (per-request `_meta` + routing headers),
+    `mcp_discover`, and the dual-era probe `mcp_server_is_modern`.
+    `mcp_stdio.nu` grew `mcp_stdio_discover` (the spec's stdio
+    backward-compat probe). Both `initialize` wrappers now send the
+    handshake-era revision instead of the latest one.
+  * `examples/mcp_echo_server.nu` demonstrates the `server/discover`
+    handler; new offline regression `compiler/tests/mcp_dual_era.nu`
+    locks the dual-era wire shapes byte-for-byte.
+
 ## [0.31.1] — 2026-08-03
 
 A one-fix patch release: TLS servers did not work on FreeBSD at all, and

--- a/compiler/tests/mcp_dual_era.nu
+++ b/compiler/tests/mcp_dual_era.nu
@@ -1,0 +1,92 @@
+// mcp_dual_era.nu — offline regression for the 2026-07-28 dual-era
+// registry behavior on top of mcp_registry_envelope:
+//   * server/discover returns supportedVersions + caps + _meta
+//     serverInfo + the CacheableResult fields
+//   * a modern request (per-request `_meta` protocolVersion) gets
+//     `_meta` serverInfo on its result; a legacy request does not
+//   * an unsupported declared version gets the spec-shaped
+//     UnsupportedProtocolVersionError (-32022, data.supported)
+//   * legacy `initialize` echoes a supported handshake-era revision
+//     and never advertises the modern (handshake-less) revision
+//   * list results carry ttlMs + cacheScope; every result carries
+//     resultType "complete"
+// No sockets, no stdio — pure dispatcher exercises, full response
+// JSON printed so the wire shape is locked byte-for-byte.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/ext/mcp.nu`
+$ `stdlib/ext/mcp_registry.nu`
+
+@ echo_tool Json args → Json {
+    : ?Json t ( json_obj_get args `text` )
+    : ~ s text `(none)`
+    ?? t {
+        T jt → { = text ( json_as_str jt ) }
+        F _ → {}
+    }
+    ^ ( mcp_tool_result_text text )
+}
+
+@ roundtrip McpRegistry r s tag s reqs → v {
+    : !Json JsonError pj ( json_parse reqs )
+    ?? pj {
+        T req → {
+            : ?Json resp_o ( mcp_registry_envelope r req )
+            ?? resp_o {
+                T resp → {
+                    : String out ( json_stringify resp )
+                    ( nurl_print tag )
+                    ( nurl_print ` ` )
+                    ( nurl_print ( string_data out ) )
+                    ( nurl_print `\n` )
+                    ( string_free out )
+                    ( json_free resp )
+                }
+                F e → {
+                    ( json_free e )
+                    ( nurl_print tag )
+                    ( nurl_print ` (no response)\n` )
+                }
+            }
+            ( json_free req )
+        }
+        F _ → { ( nurl_print `parse fail\n` ) }
+    }
+}
+
+@ main → i {
+    : McpRegistry r ( mcp_registry_new `dual-test` `1.2.3` )
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    ( mcp_registry_add_tool r `echo` `Echo back the input.` schema \ Json a → Json { ^ ( echo_tool a ) } )
+
+    // Modern: server/discover.
+    ( roundtrip r `discover` `{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"t","version":"0"}}}}` )
+
+    // Modern: tools/list — CacheableResult fields + _meta serverInfo.
+    ( roundtrip r `list-mod` `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}` )
+
+    // Modern: tools/call still works with per-request _meta.
+    ( roundtrip r `call-mod` `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}` )
+
+    // Unsupported declared version → -32022 with data.supported.
+    ( roundtrip r `badver` `{"jsonrpc":"2.0","id":4,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"1900-01-01"}}}` )
+
+    // Legacy initialize, old revision → echoed back.
+    ( roundtrip r `init-old` `{"jsonrpc":"2.0","id":5,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}` )
+
+    // Legacy initialize requesting the modern revision → answered with
+    // the newest handshake-era revision instead (2026-07-28 has no
+    // handshake; echoing it would strand a legacy client).
+    ( roundtrip r `init-mod` `{"jsonrpc":"2.0","id":6,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}` )
+
+    // Legacy tools/list (no _meta) → no serverInfo _meta on the result.
+    ( roundtrip r `list-leg` `{"jsonrpc":"2.0","id":7,"method":"tools/list"}` )
+
+    // Legacy ping still answered.
+    ( roundtrip r `ping` `{"jsonrpc":"2.0","id":8,"method":"ping"}` )
+
+    ( mcp_registry_free r )
+    ^ 0
+}

--- a/compiler/tests/mcp_http.nu
+++ b/compiler/tests/mcp_http.nu
@@ -278,6 +278,45 @@ s label s method s path s body → v {
     ( http_response_free sresp2 )
     ( request_free sreq2 )
 
+    // ── 2026-07-28 header-based routing (Mcp-Method / Mcp-Name) ────────
+    // A matching header passes through; a mismatch is the spec's
+    // HeaderMismatchError (-32020). Absent headers stay legal (legacy
+    // clients never send them — dual-era surface).
+    ( nurl_print `── header_method_match ──\n` )
+    : HttpRequest hreq ( make_req `POST` `/mcp` `{"jsonrpc":"2.0","id":200,"method":"ping"}` )
+    : Header hh @ Header { ( string_from `Mcp-Method` ) ( string_from `ping` ) }
+    ( vec_push [Header] . hreq headers hh )
+    : HttpResponse hresp ( handler hreq )
+    : String hbody ( body_to_string hresp )
+    ( println_str `  body=` ( string_data hbody ) )
+    ( string_free hbody )
+    ( http_response_free hresp )
+    ( request_free hreq )
+
+    ( nurl_print `── header_method_mismatch ──\n` )
+    : HttpRequest mreq ( make_req `POST` `/mcp` `{"jsonrpc":"2.0","id":201,"method":"ping"}` )
+    : Header mh @ Header { ( string_from `Mcp-Method` ) ( string_from `tools/call` ) }
+    ( vec_push [Header] . mreq headers mh )
+    : HttpResponse mresp ( handler mreq )
+    : String mbody ( body_to_string mresp )
+    ( println_str `  body=` ( string_data mbody ) )
+    ( string_free mbody )
+    ( http_response_free mresp )
+    ( request_free mreq )
+
+    ( nurl_print `── header_name_mismatch ──\n` )
+    : HttpRequest nreq ( make_req `POST` `/mcp` `{"jsonrpc":"2.0","id":202,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}` )
+    : Header nh1 @ Header { ( string_from `Mcp-Method` ) ( string_from `tools/call` ) }
+    ( vec_push [Header] . nreq headers nh1 )
+    : Header nh2 @ Header { ( string_from `Mcp-Name` ) ( string_from `other-tool` ) }
+    ( vec_push [Header] . nreq headers nh2 )
+    : HttpResponse nresp ( handler nreq )
+    : String nbody ( body_to_string nresp )
+    ( println_str `  body=` ( string_data nbody ) )
+    ( string_free nbody )
+    ( http_response_free nresp )
+    ( request_free nreq )
+
     ( nurl_print `── session_absent ──\n` )
     : HttpRequest noreq ( make_req `POST` `/mcp` `{"jsonrpc":"2.0","id":100,"method":"ping"}` )
     : HttpResponse noresp ( handler noreq )

--- a/compiler/tests/outputs/mcp_basic.txt
+++ b/compiler/tests/outputs/mcp_basic.txt
@@ -2,13 +2,13 @@ COMPILE OK
 LINK OK
 EXIT 0
 OUTPUT
-result    {"jsonrpc":"2.0","id":7,"result":{"ok":true}}
+result    {"jsonrpc":"2.0","id":7,"result":{"ok":true,"resultType":"complete"}}
 error     {"jsonrpc":"2.0","id":9,"error":{"code":-32601,"message":"unknown"}}
 notify    {"jsonrpc":"2.0","method":"progress","params":{"n":1}}
 text      {"type":"text","text":"hi"}
 tool_ok   {"content":[{"type":"text","text":"done"}],"isError":false}
 tool_err  {"content":[{"type":"text","text":"boom"}],"isError":true}
 tooldesc  {"name":"echo","description":"Repeat input","inputSchema":{"type":"object"}}
-toolslist {"tools":[{"name":"echo","description":"e","inputSchema":{"type":"object"}},{"name":"ping","description":"p","inputSchema":{"type":"object"}}]}
+toolslist {"tools":[{"name":"echo","description":"e","inputSchema":{"type":"object"}},{"name":"ping","description":"p","inputSchema":{"type":"object"}}],"ttlMs":60000,"cacheScope":"private"}
 init      {"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"nurl-srv","version":"0.1.0"}}
 codes -32700 -32600 -32601 -32602 -32603

--- a/compiler/tests/outputs/mcp_dual_era.txt
+++ b/compiler/tests/outputs/mcp_dual_era.txt
@@ -1,0 +1,12 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+discover {"jsonrpc":"2.0","id":1,"result":{"resultType":"complete","supportedVersions":["2026-07-28","2025-11-25","2025-06-18","2025-03-26","2024-11-05"],"capabilities":{"tools":{}},"_meta":{"io.modelcontextprotocol/serverInfo":{"name":"dual-test","version":"1.2.3"}},"ttlMs":3600000,"cacheScope":"public"}}
+list-mod {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"echo","description":"Echo back the input.","inputSchema":{"type":"object"}}],"ttlMs":60000,"cacheScope":"private","_meta":{"io.modelcontextprotocol/serverInfo":{"name":"dual-test","version":"1.2.3"}},"resultType":"complete"}}
+call-mod {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"hi"}],"isError":false,"_meta":{"io.modelcontextprotocol/serverInfo":{"name":"dual-test","version":"1.2.3"}},"resultType":"complete"}}
+badver {"jsonrpc":"2.0","id":4,"error":{"code":-32022,"message":"Unsupported protocol version","data":{"supported":["2026-07-28","2025-11-25","2025-06-18","2025-03-26","2024-11-05"],"requested":"1900-01-01"}}}
+init-old {"jsonrpc":"2.0","id":5,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{}},"serverInfo":{"name":"dual-test","version":"1.2.3"},"resultType":"complete"}}
+init-mod {"jsonrpc":"2.0","id":6,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"dual-test","version":"1.2.3"},"resultType":"complete"}}
+list-leg {"jsonrpc":"2.0","id":7,"result":{"tools":[{"name":"echo","description":"Echo back the input.","inputSchema":{"type":"object"}}],"ttlMs":60000,"cacheScope":"private","resultType":"complete"}}
+ping {"jsonrpc":"2.0","id":8,"result":{"resultType":"complete"}}

--- a/compiler/tests/outputs/mcp_http.txt
+++ b/compiler/tests/outputs/mcp_http.txt
@@ -6,8 +6,8 @@ OUTPUT
   status=200
   ct=application/json; charset=utf-8
   cors=*
-  body_len=150
-  body={"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"nurl-mcp-test","version":"0.1.0"}}}
+  body_len=174
+  body={"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"nurl-mcp-test","version":"0.1.0"},"resultType":"complete"}}
 ── post_notification ──
   status=202
   ct=<absent>
@@ -18,20 +18,20 @@ OUTPUT
   status=200
   ct=application/json; charset=utf-8
   cors=*
-  body_len=36
-  body={"jsonrpc":"2.0","id":2,"result":{}}
+  body_len=59
+  body={"jsonrpc":"2.0","id":2,"result":{"resultType":"complete"}}
 ── post_tools_list ──
   status=200
   ct=application/json; charset=utf-8
   cors=*
-  body_len=190
-  body={"jsonrpc":"2.0","id":3,"result":{"tools":[{"name":"echo","description":"Echo back the input.","inputSchema":{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}}]}}
+  body_len=251
+  body={"jsonrpc":"2.0","id":3,"result":{"tools":[{"name":"echo","description":"Echo back the input.","inputSchema":{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}}],"ttlMs":60000,"cacheScope":"private","resultType":"complete"}}
 ── post_tools_call_echo ──
   status=200
   ct=application/json; charset=utf-8
   cors=*
-  body_len=91
-  body={"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"hi"}],"isError":false}}
+  body_len=115
+  body={"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"hi"}],"isError":false,"resultType":"complete"}}
 ── post_unknown_method ──
   status=200
   ct=application/json; charset=utf-8
@@ -82,8 +82,8 @@ data: {"server":"nurl-mcp","streaming":"single-event"}
   status=200
   ct=application/json; charset=utf-8
   cors=*
-  body_len=116
-  body=[{"jsonrpc":"2.0","id":10,"result":{}},{"jsonrpc":"2.0","id":11,"error":{"code":-32601,"message":"unknown method"}}]
+  body_len=139
+  body=[{"jsonrpc":"2.0","id":10,"result":{"resultType":"complete"}},{"jsonrpc":"2.0","id":11,"error":{"code":-32601,"message":"unknown method"}}]
 ── batch_all_notifications ──
   status=202
   ct=<absent>
@@ -100,5 +100,11 @@ data: {"server":"nurl-mcp","streaming":"single-event"}
   echoed=sess-abc-123
 ── session_echo_get ──
   echoed=sess-xyz-789
+── header_method_match ──
+  body={"jsonrpc":"2.0","id":200,"result":{"resultType":"complete"}}
+── header_method_mismatch ──
+  body={"jsonrpc":"2.0","id":null,"error":{"code":-32020,"message":"Mcp-Method/Mcp-Name header does not match the request body"}}
+── header_name_mismatch ──
+  body={"jsonrpc":"2.0","id":null,"error":{"code":-32020,"message":"Mcp-Method/Mcp-Name header does not match the request body"}}
 ── session_absent ──
   echoed=<absent>

--- a/examples/mcp_echo_server.nu
+++ b/examples/mcp_echo_server.nu
@@ -85,6 +85,15 @@ $ `stdlib/core/string.nu`
     ( mcp_send_message ( mcp_response_result id result ) )
 }
 
+// server/discover — 2026-07-28 servers MUST implement this; it also
+// serves as the stdio backward-compat probe for dual-era clients.
+@ handle_discover Json id → v {
+    : Json caps ( json_obj_new )
+    ( json_obj_set caps `tools` ( json_obj_new ) )
+    : Json result ( mcp_discover_result `nurl-echo-mcp` `0.1.0` caps `` )
+    ( mcp_send_message ( mcp_response_result id result ) )
+}
+
 @ handle_ping Json id → v {
     : Json empty ( json_obj_new )
     ( mcp_send_message ( mcp_response_result id empty ) )
@@ -142,26 +151,29 @@ $ `stdlib/core/string.nu`
             // reply for, e.g., `notifications/initialized`.
             ?? id_opt {
                 T id → {
-                    ? != ( nurl_str_eq method `initialize` ) 0 {
-                        ( handle_initialize id )
+                    ? != ( nurl_str_eq method `server/discover` ) 0 {
+                        ( handle_discover id )
                     } {
-                        ? != ( nurl_str_eq method `ping` ) 0 {
-                            ( handle_ping id )
+                        ? != ( nurl_str_eq method `initialize` ) 0 {
+                            ( handle_initialize id )
                         } {
-                            ? != ( nurl_str_eq method `tools/list` ) 0 {
-                                ( handle_tools_list id )
+                            ? != ( nurl_str_eq method `ping` ) 0 {
+                                ( handle_ping id )
                             } {
-                                ? != ( nurl_str_eq method `tools/call` ) 0 {
-                                    : ?Json params_j ( json_obj_get req `params` )
-                                    : Json params ?? params_j {
-                                        T pv → ( json_clone pv )
-                                        F → ( json_obj_new )
-                                    }
-                                    ( handle_tools_call id params )
-                                    ( json_free params )
+                                ? != ( nurl_str_eq method `tools/list` ) 0 {
+                                    ( handle_tools_list id )
                                 } {
-                                    ( handle_unknown_method id method )
-                                } } } }
+                                    ? != ( nurl_str_eq method `tools/call` ) 0 {
+                                        : ?Json params_j ( json_obj_get req `params` )
+                                        : Json params ?? params_j {
+                                            T pv → ( json_clone pv )
+                                            F → ( json_obj_new )
+                                        }
+                                        ( handle_tools_call id params )
+                                        ( json_free params )
+                                    } {
+                                        ( handle_unknown_method id method )
+                                    } } } } }
                 }
                 F → {
                     // Notification — nothing to send. Trace at most.

--- a/stdlib/ext/mcp.nu
+++ b/stdlib/ext/mcp.nu
@@ -237,6 +237,32 @@ $ `stdlib/ext/json.nu`
     ^ > ( nurl_str_len ( mcp_request_protocol_version req ) ) 0
 }
 
+// Legacy handshake negotiation: the revision an `initialize` response
+// should advertise for the given request params — the client's
+// requested `protocolVersion` when it is a supported HANDSHAKE-era
+// revision, else `mcp_protocol_version_initialize`. (Echoing the
+// modern, handshake-less revision would strand a legacy client.)
+// Returned s is BORROWED (from params or from a static literal).
+@ mcp_initialize_version_for ? Json params → s {
+    : ~ s ver ( mcp_protocol_version_initialize )
+    ?? params {
+        T p → {
+            : ?Json rv ( json_obj_get p `protocolVersion` )
+            ?? rv {
+                T jv → {
+                    : s req_ver ( json_as_str jv )
+                    ? & ( mcp_version_supported req_ver )
+                    == 0 ( nurl_str_eq req_ver ( mcp_protocol_version ) )
+                    { = ver req_ver } {}
+                }
+                F _ → {}
+            }
+        }
+        F _ → {}
+    }
+    ^ ver
+}
+
 // Client-side `_meta` for modern requests: protocolVersion +
 // clientInfo + clientCapabilities. Caller sets it on `params._meta`.
 @ mcp_client_meta s client_name s client_version → Json {

--- a/stdlib/ext/mcp.nu
+++ b/stdlib/ext/mcp.nu
@@ -92,21 +92,39 @@
 // * Notifications (no `id` field) require NO response from the server
 //   — the user's main loop must check `( json_obj_get req `id` )` and
 //   skip the reply when the result is None.
-// * `notifications/initialized` is sent by the client right after the
-//   `initialize` handshake completes; servers should accept and
+// * `notifications/initialized` is sent by LEGACY clients right after
+//   the `initialize` handshake completes; servers should accept and
 //   ignore it.
-// * `ping` requests get an empty result `{}`.
-// * `protocolVersion` defaults to the value returned by
-//   `mcp_protocol_version` — currently the latest stable revision
-//   (`2025-11-25`). MCP revisions only bump on backwards-incompatible
-//   changes, so a server advertising the latest revision serves older
-//   clients fine — but pinning to an old revision pushes negotiation
-//   the wrong way. `tools/mcp_spec_drift_check.sh` verifies the
-//   pinned version matches the spec site's "current".
-// * `mcp_protocol_version_legacy` returns `2024-11-05` — the previous
-//   pinned revision. Useful for serving clients that explicitly
-//   negotiate that version (a server MAY agree to whatever the
-//   client requests, as long as it's a revision the server supports).
+// * `ping` requests (legacy revisions) get an empty result `{}`.
+//
+// ── Protocol eras (2026-07-28 spec) ─────────────────────────────────
+//
+// Revision 2026-07-28 removed the `initialize` handshake: a MODERN
+// request carries its protocol version + client identity in
+// `params._meta` (`io.modelcontextprotocol/protocolVersion` etc.) and
+// servers MUST implement `server/discover`. Revisions `2025-11-25`
+// and earlier are LEGACY (handshake-based). This module supports
+// building DUAL-ERA servers per the spec's compatibility matrix
+// (specification/2026-07-28/basic/versioning):
+//
+//   * `mcp_protocol_version` — the latest revision (`2026-07-28`);
+//     what `server/discover` and client `_meta` advertise first.
+//     `tools/mcp_spec_drift_check.sh` verifies it matches the spec
+//     site's "current".
+//   * `mcp_protocol_version_initialize` — the newest HANDSHAKE-era
+//     revision (`2025-11-25`); what `initialize` responses advertise
+//     (a legacy client would reject a non-handshake revision).
+//   * `mcp_protocol_version_legacy` — `2024-11-05`, kept for callers
+//     that explicitly negotiate the oldest shape.
+//   * `mcp_version_supported` / `mcp_supported_versions_json` — the
+//     full supported set, for `server/discover` and the
+//     `UnsupportedProtocolVersionError` data payload.
+//   * `mcp_request_protocol_version` / `mcp_request_is_modern` — read
+//     a request's `_meta` version (empty string = legacy request).
+//   * Every result built via `mcp_response_result` carries
+//     `resultType: "complete"` (required in 2026-07-28; ignored by
+//     legacy clients, whose spec says unknown fields are tolerated
+//     and absence means "complete").
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/io.nu`
@@ -124,6 +142,12 @@ $ `stdlib/ext/json.nu`
 : i mcp_err_invalid_params -32602
 : i mcp_err_internal_error -32603
 
+// MCP-reserved codes (2026-07-28 partitioned -32020..-32099 for the
+// spec; earlier drafts used -32001/-32003/-32004 — renumbered).
+: i mcp_err_header_mismatch -32020
+: i mcp_err_missing_client_capability -32021
+: i mcp_err_unsupported_protocol_version -32022
+
 // ── Protocol version ────────────────────────────────────────────────
 //
 // MCP revisions are dated YYYY-MM-DD per
@@ -137,15 +161,93 @@ $ `stdlib/ext/json.nu`
 // fail fast when the spec drifts.
 
 @ mcp_protocol_version → s {
-    // Latest stable revision (as of 2026-05-19; verified via spec site).
+    // Latest stable revision (as of 2026-08-03; verified via spec site).
+    // First of the MODERN (stateless, per-request `_meta`) era.
+    ^ `2026-07-28`
+}
+
+@ mcp_protocol_version_initialize → s {
+    // Newest HANDSHAKE-era revision — what `initialize` responses
+    // advertise. 2026-07-28 has no handshake, so answering an
+    // `initialize` with it would make a legacy client disconnect;
+    // dual-era servers answer initialize with a legacy revision and
+    // serve modern clients through per-request `_meta`.
     ^ `2025-11-25`
 }
 
 @ mcp_protocol_version_legacy → s {
-    // Previous pinned revision — kept exported for callers that want
+    // Oldest supported revision — kept exported for callers that want
     // to explicitly negotiate the older shape (e.g. for compatibility
     // with a fixed older client).
     ^ `2024-11-05`
+}
+
+// The full supported set. A dual-era server serves every handshake
+// revision through the same JSON-RPC methods (the wire shapes NURL
+// implements are unchanged across them), plus the modern revision.
+@ mcp_version_supported s v → b {
+    ? != 0 ( nurl_str_eq v `2026-07-28` ) { ^ T } {}
+    ? != 0 ( nurl_str_eq v `2025-11-25` ) { ^ T } {}
+    ? != 0 ( nurl_str_eq v `2025-06-18` ) { ^ T } {}
+    ? != 0 ( nurl_str_eq v `2025-03-26` ) { ^ T } {}
+    ? != 0 ( nurl_str_eq v `2024-11-05` ) { ^ T } {}
+    ^ F
+}
+
+// Owned JSON array of the supported revisions, newest first — the
+// shape `server/discover`'s `supportedVersions` and the
+// UnsupportedProtocolVersionError `data.supported` field carry.
+@ mcp_supported_versions_json → Json {
+    : Json arr ( json_arr_new )
+    ( json_arr_push arr ( json_str_lit `2026-07-28` ) )
+    ( json_arr_push arr ( json_str_lit `2025-11-25` ) )
+    ( json_arr_push arr ( json_str_lit `2025-06-18` ) )
+    ( json_arr_push arr ( json_str_lit `2025-03-26` ) )
+    ( json_arr_push arr ( json_str_lit `2024-11-05` ) )
+    ^ arr
+}
+
+// ── Per-request `_meta` (modern era) ────────────────────────────────
+
+// The protocol version a request declares in
+// `params._meta["io.modelcontextprotocol/protocolVersion"]`.
+// Returns a BORROWED s (valid while `req` lives); empty string when
+// absent — i.e. a legacy-era request.
+@ mcp_request_protocol_version Json req → s {
+    : ?Json p ( json_obj_get req `params` )
+    ?? p {
+        T pv → {
+            : ?Json m ( json_obj_get pv `_meta` )
+            ?? m {
+                T mv → {
+                    : ?Json ver ( json_obj_get mv `io.modelcontextprotocol/protocolVersion` )
+                    ?? ver {
+                        T jv → { ^ ( json_as_str jv ) }
+                        F _ → { ^ `` }
+                    }
+                }
+                F _ → { ^ `` }
+            }
+        }
+        F _ → { ^ `` }
+    }
+}
+
+@ mcp_request_is_modern Json req → b {
+    ^ > ( nurl_str_len ( mcp_request_protocol_version req ) ) 0
+}
+
+// Client-side `_meta` for modern requests: protocolVersion +
+// clientInfo + clientCapabilities. Caller sets it on `params._meta`.
+@ mcp_client_meta s client_name s client_version → Json {
+    : Json info ( json_obj_new )
+    ( json_obj_set info `name` ( json_str_lit client_name ) )
+    ( json_obj_set info `version` ( json_str_lit client_version ) )
+    : Json meta ( json_obj_new )
+    ( json_obj_set meta `io.modelcontextprotocol/protocolVersion` ( json_str_lit ( mcp_protocol_version ) ) )
+    ( json_obj_set meta `io.modelcontextprotocol/clientInfo` info )
+    ( json_obj_set meta `io.modelcontextprotocol/clientCapabilities` ( json_obj_new ) )
+    ^ meta
 }
 
 // ── Logging ─────────────────────────────────────────────────────────
@@ -207,11 +309,46 @@ $ `stdlib/ext/json.nu`
 // ── JSON-RPC envelopes ──────────────────────────────────────────────
 
 @ mcp_response_result Json id Json result → Json {
+    // 2026-07-28: every result carries `resultType` ("complete" for
+    // ordinary results). Injected centrally so every server built on
+    // these envelopes conforms. Safe for legacy clients too: JSON-RPC
+    // consumers tolerate unknown result fields, and the changelog
+    // requires clients to treat an ABSENT field as "complete" — the
+    // field is purely additive.
+    ? ( json_is_obj result ) {
+        ? ( json_obj_has result `resultType` ) {} {
+            ( json_obj_set result `resultType` ( json_str_lit `complete` ) )
+        }
+    } {}
     : Json out ( json_obj_new )
     ( json_obj_set out `jsonrpc` ( json_str_lit `2.0` ) )
     ( json_obj_set out `id` ( json_clone id ) )
     ( json_obj_set out `result` result )
     ^ out
+}
+
+// Error envelope with a `data` member (e.g. the -32022
+// UnsupportedProtocolVersionError's {supported, requested}).
+// CONSUMES `data`; `id` is borrowed (cloned) like the other builders.
+@ mcp_response_error_data Json id i code s message Json data → Json {
+    : Json err ( json_obj_new )
+    ( json_obj_set err `code` ( json_int code ) )
+    ( json_obj_set err `message` ( json_str_lit message ) )
+    ( json_obj_set err `data` data )
+    : Json out ( json_obj_new )
+    ( json_obj_set out `jsonrpc` ( json_str_lit `2.0` ) )
+    ( json_obj_set out `id` ( json_clone id ) )
+    ( json_obj_set out `error` err )
+    ^ out
+}
+
+// The spec-shaped UnsupportedProtocolVersionError response: the
+// client reads `data.supported`, picks a mutual revision and retries.
+@ mcp_unsupported_version_response Json id s requested → Json {
+    : Json data ( json_obj_new )
+    ( json_obj_set data `supported` ( mcp_supported_versions_json ) )
+    ( json_obj_set data `requested` ( json_str_lit requested ) )
+    ^ ( mcp_response_error_data id mcp_err_unsupported_protocol_version `Unsupported protocol version` data )
 }
 
 @ mcp_response_error Json id i code s message → Json {
@@ -286,6 +423,11 @@ $ `stdlib/ext/json.nu`
     ( vec_free [Json] tools )
     : Json out ( json_obj_new )
     ( json_obj_set out `tools` arr )
+    // CacheableResult fields are REQUIRED on tools/list results in
+    // 2026-07-28 (and harmless earlier). Conservative defaults; a
+    // server with a static tool set can overwrite with a longer
+    // public hint via mcp_result_set_cacheable.
+    ( mcp_result_set_cacheable out 60000 `private` )
     ^ out
 }
 
@@ -301,8 +443,55 @@ $ `stdlib/ext/json.nu`
     ( json_obj_set caps `tools` tools_cap )
 
     : Json out ( json_obj_new )
-    ( json_obj_set out `protocolVersion` ( json_str_lit ( mcp_protocol_version ) ) )
+    // Handshake-era revision on purpose — see mcp_protocol_version_initialize.
+    ( json_obj_set out `protocolVersion` ( json_str_lit ( mcp_protocol_version_initialize ) ) )
     ( json_obj_set out `capabilities` caps )
     ( json_obj_set out `serverInfo` info )
+    ^ out
+}
+
+// ── 2026-07-28 result decorations ───────────────────────────────────
+
+// CacheableResult (required on tools/list, prompts/list,
+// resources/list, resources/read, resources/templates/list results):
+// `ttlMs` = freshness hint in milliseconds; `cacheScope` = "public"
+// (shared intermediaries may cache) or "private".
+@ mcp_result_set_cacheable Json result i ttl_ms s scope → v {
+    ( json_obj_set result `ttlMs` ( json_int ttl_ms ) )
+    ( json_obj_set result `cacheScope` ( json_str_lit scope ) )
+}
+
+// Attach `_meta["io.modelcontextprotocol/serverInfo"]` to a result —
+// modern-era servers SHOULD identify themselves in every result.
+// Merges into an existing `_meta` object when present.
+@ mcp_result_set_server_info Json result s name s version → v {
+    : Json info ( json_obj_new )
+    ( json_obj_set info `name` ( json_str_lit name ) )
+    ( json_obj_set info `version` ( json_str_lit version ) )
+    : ?Json m ( json_obj_get result `_meta` )
+    ?? m {
+        T mv → { ( json_obj_set mv `io.modelcontextprotocol/serverInfo` info ) }
+        F _ → {
+            : Json meta ( json_obj_new )
+            ( json_obj_set meta `io.modelcontextprotocol/serverInfo` info )
+            ( json_obj_set result `_meta` meta )
+        }
+    }
+}
+
+// server/discover result (servers MUST implement the RPC in
+// 2026-07-28). CONSUMES `caps`. `instructions` empty = omitted. The
+// discover output is static for the server's lifetime, so it carries
+// a long public cache hint.
+@ mcp_discover_result s name s version Json caps s instructions → Json {
+    : Json out ( json_obj_new )
+    ( json_obj_set out `resultType` ( json_str_lit `complete` ) )
+    ( json_obj_set out `supportedVersions` ( mcp_supported_versions_json ) )
+    ( json_obj_set out `capabilities` caps )
+    ( mcp_result_set_server_info out name version )
+    ? > ( nurl_str_len instructions ) 0 {
+        ( json_obj_set out `instructions` ( json_str_lit instructions ) )
+    } {}
+    ( mcp_result_set_cacheable out 3600000 `public` )
     ^ out
 }

--- a/stdlib/ext/mcp_client.nu
+++ b/stdlib/ext/mcp_client.nu
@@ -25,8 +25,20 @@
 //                                  → ! Json McpErr     full response
 //
 //   ( mcp_initialize McpClient c s client_name s client_version )
-//                                  → ! Json McpErr
-//   ( mcp_ping        McpClient c ) → ! Json McpErr
+//                                  → ! Json McpErr    legacy handshake
+//   ( mcp_ping        McpClient c ) → ! Json McpErr   legacy heartbeat
+//
+//   Modern era (2026-07-28 — per-request `_meta`, no handshake):
+//   ( mcp_discover McpClient c s client_name s client_version )
+//                                  → ! Json McpErr    server/discover
+//   ( mcp_server_is_modern McpClient c s name s ver ) → b
+//                                  dual-era probe: T ⇒ speak modern,
+//                                  F ⇒ fall back to mcp_initialize
+//   ( mcp_call_modern McpClient c s method ( ? Json ) params s name s ver )
+//                                  → ! Json McpErr    injects `_meta` +
+//                                  Mcp-Method / MCP-Protocol-Version headers
+//   ( mcp_tools_call_modern McpClient c s tool Json args s name s ver )
+//                                  → ! Json McpErr    + Mcp-Name header
 //   ( mcp_tools_list  McpClient c ) → ! ( Vec Json ) McpErr
 //   ( mcp_tools_call  McpClient c s name Json args )
 //                                  → ! Json McpErr
@@ -111,6 +123,13 @@ $ `stdlib/core/vec.nu`
 // ── mcp_call: single round-trip ──────────────────────────────────────
 
 @ mcp_call McpClient c s method ? Json params → !Json McpErr {
+    ^ ( __mcp_call_with_headers c method params `` )
+}
+
+// Internal transport core shared by the legacy and modern call paths.
+// `extra_headers` rides after the base headers; `` for none. Each
+// entry must be `Name: value\r\n`-terminated.
+@ __mcp_call_with_headers McpClient c s method ? Json params s extra_headers → !Json McpErr {
     : i n ( string_len . c endpoint )
     ? == n 0 {
         ?? params { T p → ( json_free p ) F _ → {} }
@@ -125,13 +144,17 @@ $ `stdlib/core/vec.nu`
     : String body ( json_stringify req )
     ( json_free req )
 
+    : String hdrs ( string_from `Content-Type: application/json\r\nAccept: application/json\r\n` )
+    ( string_push_str hdrs extra_headers )
+
     : !Response HttpErr hr ( http_request_to
     `POST`
     ( string_data . c endpoint )
     ( string_data body )
-    `Content-Type: application/json\r\nAccept: application/json\r\n`
+    ( string_data hdrs )
     . c timeout_ms
     0 )
+    ( string_free hdrs )
     ( string_free body )
 
     ?? hr {
@@ -220,10 +243,81 @@ $ `stdlib/core/vec.nu`
     ( json_obj_set info `name` ( json_str_lit client_name ) )
     ( json_obj_set info `version` ( json_str_lit client_version ) )
     : Json params ( json_obj_new )
-    ( json_obj_set params `protocolVersion` ( json_str_lit ( mcp_protocol_version ) ) )
+    // Handshake-era revision — `initialize` IS the legacy path; the
+    // modern revision has no handshake (use mcp_discover/_call_modern).
+    ( json_obj_set params `protocolVersion` ( json_str_lit ( mcp_protocol_version_initialize ) ) )
     ( json_obj_set params `capabilities` caps )
     ( json_obj_set params `clientInfo` info )
     ^ ( mcp_call c `initialize` @ ?Json { T params } )
+}
+
+// ── Modern era (2026-07-28) ──────────────────────────────────────────
+
+// Modern call: injects per-request `_meta` (protocolVersion +
+// clientInfo + clientCapabilities — set only when the caller's params
+// don't already carry a `_meta`) plus the Mcp-Method and
+// MCP-Protocol-Version headers the Streamable HTTP transport requires.
+// `params` None → a fresh object is created to carry `_meta`.
+@ mcp_call_modern McpClient c s method ? Json params s client_name s client_version → !Json McpErr {
+    : Json p ?? params { T pv → pv F _ → ( json_obj_new ) }
+    ? ( json_obj_has p `_meta` ) {} {
+        ( json_obj_set p `_meta` ( mcp_client_meta client_name client_version ) )
+    }
+    : String eh ( string_from `Mcp-Method: ` )
+    ( string_push_str eh method )
+    ( string_push_str eh `\r\nMCP-Protocol-Version: ` )
+    ( string_push_str eh ( mcp_protocol_version ) )
+    ( string_push_str eh `\r\n` )
+    : !Json McpErr r ( __mcp_call_with_headers c method @ ?Json { T p } ( string_data eh ) )
+    ( string_free eh )
+    ^ r
+}
+
+// tools/call with the additional `Mcp-Name` routing header (the
+// header names the tool so gateways can meter per-tool). `args` is
+// CONSUMED.
+@ mcp_tools_call_modern McpClient c s name Json args s client_name s client_version → !Json McpErr {
+    : Json params ( json_obj_new )
+    ( json_obj_set params `name` ( json_str_lit name ) )
+    ( json_obj_set params `arguments` args )
+    ( json_obj_set params `_meta` ( mcp_client_meta client_name client_version ) )
+    : String eh ( string_from `Mcp-Method: tools/call\r\nMcp-Name: ` )
+    ( string_push_str eh name )
+    ( string_push_str eh `\r\nMCP-Protocol-Version: ` )
+    ( string_push_str eh ( mcp_protocol_version ) )
+    ( string_push_str eh `\r\n` )
+    : !Json McpErr r ( __mcp_call_with_headers c `tools/call` @ ?Json { T params } ( string_data eh ) )
+    ( string_free eh )
+    ^ r
+}
+
+// server/discover — supported versions + capabilities + identity.
+@ mcp_discover McpClient c s client_name s client_version → !Json McpErr {
+    ^ ( mcp_call_modern c `server/discover` @ ?Json { F } client_name client_version )
+}
+
+// Dual-era probe per the 2026-07-28 versioning page: T when the
+// server answered server/discover with a DiscoverResult (modern or
+// dual-era server — keep speaking modern), F otherwise (legacy server
+// — fall back to mcp_initialize; or transport failure). Cache the
+// answer for the lifetime of the origin, per the spec.
+@ mcp_server_is_modern McpClient c s client_name s client_version → b {
+    : !Json McpErr r ( mcp_discover c client_name client_version )
+    ?? r {
+        T resp → {
+            : ~ b modern F
+            : ?Json res ( json_obj_get resp `result` )
+            ?? res {
+                T rv → {
+                    ? ( json_obj_has rv `supportedVersions` ) { = modern T } {}
+                }
+                F _ → {}
+            }
+            ( json_free resp )
+            ^ modern
+        }
+        F _ → { ^ F }
+    }
 }
 
 @ mcp_ping McpClient c → !Json McpErr {

--- a/stdlib/ext/mcp_http.nu
+++ b/stdlib/ext/mcp_http.nu
@@ -143,8 +143,71 @@ $ `stdlib/core/vec.nu`
 
 @ __mcp_http_apply_cors HttpResponse r → v {
     ( response_set_header r `Access-Control-Allow-Origin` `*` )
-    ( response_set_header r `Access-Control-Allow-Headers` `Content-Type, Authorization, Mcp-Session-Id` )
+    ( response_set_header r `Access-Control-Allow-Headers` `Content-Type, Authorization, Mcp-Session-Id, Mcp-Method, Mcp-Name, MCP-Protocol-Version` )
     ( response_set_header r `Access-Control-Expose-Headers` `Mcp-Session-Id` )
+}
+
+// ── 2026-07-28 header-based routing validation ──────────────────────
+//
+// Modern Streamable HTTP POSTs carry `Mcp-Method` (and `Mcp-Name` for
+// named calls: the tool/prompt name or resource uri) so gateways and
+// rate limiters can route on headers without parsing the body. When a
+// header IS present it must match the body — mismatch is the spec's
+// HeaderMismatchError (-32020). An ABSENT header is accepted: legacy
+// clients never send these, and a dual-era server serves both.
+@ __mcp_http_header_mismatch HttpRequest req Json jreq → b {
+    : ~ b bad F
+    : ?String hm ( header_get . req headers `Mcp-Method` )
+    ?? hm {
+        T hv → {
+            : ?Json bm ( json_obj_get jreq `method` )
+            ?? bm {
+                T jm → {
+                    ? == 0 ( nurl_str_eq ( string_data hv ) ( json_as_str jm ) )
+                    { = bad T } {}
+                }
+                F _ → { = bad T }
+            }
+            ( string_free hv )
+        }
+        F e → { ( string_free e ) }
+    }
+    ? bad { ^ T } {}
+    : ?String hn ( header_get . req headers `Mcp-Name` )
+    ?? hn {
+        T nv → {
+            : ~ b nm_ok F
+            : ?Json pj ( json_obj_get jreq `params` )
+            ?? pj {
+                T pv → {
+                    : ?Json nj ( json_obj_get pv `name` )
+                    ?? nj {
+                        T jn → {
+                            ? != 0 ( nurl_str_eq ( string_data nv ) ( json_as_str jn ) )
+                            { = nm_ok T } {}
+                        }
+                        F _ → {}
+                    }
+                    // resources/read names its target with `uri`.
+                    ? ! nm_ok {
+                        : ?Json uj ( json_obj_get pv `uri` )
+                        ?? uj {
+                            T ju → {
+                                ? != 0 ( nurl_str_eq ( string_data nv ) ( json_as_str ju ) )
+                                { = nm_ok T } {}
+                            }
+                            F _ → {}
+                        }
+                    } {}
+                }
+                F _ → {}
+            }
+            ? nm_ok {} { = bad T }
+            ( string_free nv )
+        }
+        F e → { ( string_free e ) }
+    }
+    ^ bad
 }
 
 // MCP Streamable HTTP content-negotiation: if the client offers
@@ -335,6 +398,13 @@ $ `stdlib/core/vec.nu`
                 } {}
 
                 // Single request — original path.
+                ? ( __mcp_http_header_mismatch req jreq ) {
+                    ( json_free jreq )
+                    : HttpResponse r ( __mcp_http_jsonrpc_error mcp_err_header_mismatch `Mcp-Method/Mcp-Name header does not match the request body` )
+                    ( __mcp_http_apply_cors r )
+                    ( __mcp_http_echo_session req r )
+                    ^ r
+                } {}
                 : ?Json reply ( dispatch jreq )
                 ( json_free jreq )
 

--- a/stdlib/ext/mcp_registry.nu
+++ b/stdlib/ext/mcp_registry.nu
@@ -309,25 +309,7 @@ $ `stdlib/ext/http_response.nu`
     ( json_obj_set info `version` ( json_str_lit ( string_data . r server_version ) ) )
 
     : Json caps ( __mcp_registry_caps r )
-
-    : ~ s ver ( mcp_protocol_version_initialize )
-    ?? params {
-        T p → {
-            : ?Json rv ( json_obj_get p `protocolVersion` )
-            ?? rv {
-                T jv → {
-                    : s req_ver ( json_as_str jv )
-                    // Only handshake-era revisions can be echoed here.
-                    ? & ( mcp_version_supported req_ver )
-                    == 0 ( nurl_str_eq req_ver ( mcp_protocol_version ) )
-                    { = ver req_ver } {}
-                }
-                F _ → {}
-            }
-        }
-        F _ → {}
-    }
-
+    : s ver ( mcp_initialize_version_for params )
     : Json out ( json_obj_new )
     ( json_obj_set out `protocolVersion` ( json_str_lit ver ) )
     ( json_obj_set out `capabilities` caps )

--- a/stdlib/ext/mcp_registry.nu
+++ b/stdlib/ext/mcp_registry.nu
@@ -14,14 +14,22 @@
 // registry struct as Vec[McpTool] / Vec[McpPrompt] / Vec[McpResource]
 // and dispatched by name lookup at request time.
 //
-// Spec coverage (Model Context Protocol — latest stable revision per
-// `mcp_protocol_version`, currently 2025-11-25):
-//   * initialize / initialized
+// Spec coverage — DUAL-ERA per the 2026-07-28 versioning page: one
+// registry serves both modern (per-request `_meta`, `server/discover`)
+// and legacy (initialize handshake) clients on the same endpoint:
+//   * server/discover (2026-07-28 — servers MUST implement)
+//   * initialize / initialized (legacy handshake; echoes the client's
+//     requested revision when supported)
 //   * tools/list, tools/call
 //   * prompts/list, prompts/get
-//   * resources/list, resources/read
+//   * resources/list, resources/read   (list/read results carry the
+//     2026-07-28 CacheableResult fields ttlMs + cacheScope)
 //   * completion/complete (argument autocompletion for prompts/resources)
-//   * ping (heartbeat — empty result)
+//   * ping (legacy heartbeat — empty result)
+// Requests declaring an unsupported `_meta` protocolVersion get the
+// spec-shaped UnsupportedProtocolVersionError (-32022); results for
+// modern requests carry `_meta` serverInfo. `resultType: "complete"`
+// rides on every result via mcp.nu's envelope builder.
 //
 // Out of scope here (transport-level; served by mcp_session/mcp_http):
 //   * resources/subscribe + notifications/resources/updated — session-
@@ -275,15 +283,10 @@ $ `stdlib/ext/http_response.nu`
 
 // ── Per-method dispatchers ────────────────────────────────────────────
 
-// initialize: returns server capabilities + info per spec §3.2.
-@ __mcp_dispatch_initialize McpRegistry r → Json {
-    : Json info ( json_obj_new )
-    ( json_obj_set info `name` ( json_str_lit ( string_data . r server_name ) ) )
-    ( json_obj_set info `version` ( json_str_lit ( string_data . r server_version ) ) )
-
+// Capability object: one entry per category that has any registered
+// entries. Empty object = "supported with no extra options".
+@ __mcp_registry_caps McpRegistry r → Json {
     : Json caps ( json_obj_new )
-    // Declare capability per category that has any registered entries.
-    // Empty object = "supported with no extra options".
     ? > ( vec_len [McpTool] . r tools ) 0
     { ( json_obj_set caps `tools` ( json_obj_new ) ) } {}
     ? > ( vec_len [McpPrompt] . r prompts ) 0
@@ -292,12 +295,54 @@ $ `stdlib/ext/http_response.nu`
     { ( json_obj_set caps `resources` ( json_obj_new ) ) } {}
     ? > ( vec_len [McpCompletion] . r completions ) 0
     { ( json_obj_set caps `completions` ( json_obj_new ) ) } {}
+    ^ caps
+}
+
+// initialize (legacy handshake): returns server capabilities + info.
+// Version negotiation per the handshake-era spec: echo the client's
+// requested `protocolVersion` when we support it, else answer with
+// the newest handshake-era revision we do support (a legacy client
+// would disconnect on a non-handshake revision like 2026-07-28).
+@ __mcp_dispatch_initialize McpRegistry r ? Json params → Json {
+    : Json info ( json_obj_new )
+    ( json_obj_set info `name` ( json_str_lit ( string_data . r server_name ) ) )
+    ( json_obj_set info `version` ( json_str_lit ( string_data . r server_version ) ) )
+
+    : Json caps ( __mcp_registry_caps r )
+
+    : ~ s ver ( mcp_protocol_version_initialize )
+    ?? params {
+        T p → {
+            : ?Json rv ( json_obj_get p `protocolVersion` )
+            ?? rv {
+                T jv → {
+                    : s req_ver ( json_as_str jv )
+                    // Only handshake-era revisions can be echoed here.
+                    ? & ( mcp_version_supported req_ver )
+                    == 0 ( nurl_str_eq req_ver ( mcp_protocol_version ) )
+                    { = ver req_ver } {}
+                }
+                F _ → {}
+            }
+        }
+        F _ → {}
+    }
 
     : Json out ( json_obj_new )
-    ( json_obj_set out `protocolVersion` ( json_str_lit ( mcp_protocol_version ) ) )
+    ( json_obj_set out `protocolVersion` ( json_str_lit ver ) )
     ( json_obj_set out `capabilities` caps )
     ( json_obj_set out `serverInfo` info )
     ^ out
+}
+
+// server/discover (2026-07-28, MUST): supported versions + caps +
+// identity. The registry has no instructions channel yet — empty.
+@ __mcp_dispatch_discover McpRegistry r → Json {
+    ^ ( mcp_discover_result
+    ( string_data . r server_name )
+    ( string_data . r server_version )
+    ( __mcp_registry_caps r )
+    `` )
 }
 
 // tools/list: build the array of {name, description, inputSchema}.
@@ -317,6 +362,9 @@ $ `stdlib/ext/http_response.nu`
     }
     : Json out ( json_obj_new )
     ( json_obj_set out `tools` arr )
+    // CacheableResult (2026-07-28): the registry is fixed after
+    // startup but may sit behind auth — modest TTL, private scope.
+    ( mcp_result_set_cacheable out 60000 `private` )
     ^ out
 }
 
@@ -402,6 +450,7 @@ $ `stdlib/ext/http_response.nu`
     }
     : Json out ( json_obj_new )
     ( json_obj_set out `prompts` arr )
+    ( mcp_result_set_cacheable out 60000 `private` )
     ^ out
 }
 
@@ -485,6 +534,7 @@ $ `stdlib/ext/http_response.nu`
     }
     : Json out ( json_obj_new )
     ( json_obj_set out `resources` arr )
+    ( mcp_result_set_cacheable out 60000 `private` )
     ^ out
 }
 
@@ -555,6 +605,9 @@ $ `stdlib/ext/http_response.nu`
     ( json_arr_push arr content )
     : Json out ( json_obj_new )
     ( json_obj_set out `contents` arr )
+    // resources/read is also a CacheableResult in 2026-07-28. Content
+    // comes from a live handler — short TTL, private scope.
+    ( mcp_result_set_cacheable out 5000 `private` )
     ^ out
 }
 
@@ -646,8 +699,11 @@ $ `stdlib/ext/http_response.nu`
 // `__error__` field — caller turns that into a JSON-RPC error response
 // (method not found / internal error).
 @ mcp_registry_dispatch McpRegistry r s method ? Json params → Json {
+    ? != 0 ( nurl_str_eq method `server/discover` ) {
+        ^ ( __mcp_dispatch_discover r )
+    } {}
     ? != 0 ( nurl_str_eq method `initialize` ) {
-        ^ ( __mcp_dispatch_initialize r )
+        ^ ( __mcp_dispatch_initialize r params )
     } {}
     ? != 0 ( nurl_str_eq method `tools/list` ) {
         ^ ( __mcp_dispatch_tools_list r )
@@ -753,25 +809,22 @@ $ `stdlib/ext/http_response.nu`
 
 // Single iteration of the stdio main loop. Returns T when EOF reached
 // (caller terminates the loop), F otherwise.
+//
+// Routes through `mcp_registry_envelope` so the stdio transport gets
+// the same dual-era behavior as HTTP (version gate, `server/discover`,
+// modern `_meta` decorations). This also fixed a latent double-free:
+// the old inline path called `json_free resp` after `mcp_send_message`
+// — which already CONSUMES its message.
 @ __mcp_serve_stdio_once McpRegistry r → b {
     : ?Json req ( mcp_read_request )
     ?? req {
         T jr → {
-            : String method ( __mcp_extract_method jr )
-            : Json id ( __mcp_extract_id_or_null jr )
-            : b had_id ( __mcp_has_id jr )
-            : ?Json mparams ( json_obj_get jr `params` )
-            : Json result ( mcp_registry_dispatch r ( string_data method ) mparams )
-            ? had_id {
-                : Json resp ( __mcp_envelope_response result id )
-                ( mcp_send_message resp )
-                ( json_free resp )
-            } {
+            : ?Json resp_o ( mcp_registry_envelope r jr )
+            ?? resp_o {
+                T resp → { ( mcp_send_message resp ) }
                 // Notification — no response (per JSON-RPC 2.0 §4.1).
-                ( json_free result )
-                ( json_free id )
+                F e → { ( json_free e ) }
             }
-            ( string_free method )
             ( json_free jr )
             ^ F
         }
@@ -810,9 +863,38 @@ $ `stdlib/ext/http_response.nu`
     : String method ( __mcp_extract_method req )
     : b had_id ( __mcp_has_id req )
     : Json id ( __mcp_extract_id_or_null req )
+
+    // Modern-era version gate (2026-07-28): a request that DECLARES a
+    // protocol version we don't support MUST get the spec-shaped
+    // UnsupportedProtocolVersionError — the client picks a mutual
+    // revision from `data.supported` and retries. A request with no
+    // `_meta` version is legacy-era and served as before.
+    : s req_ver ( mcp_request_protocol_version req )
+    : b is_modern > ( nurl_str_len req_ver ) 0
+    ? & is_modern ! ( mcp_version_supported req_ver ) {
+        ( string_free method )
+        ? had_id {
+            : Json resp ( mcp_unsupported_version_response id req_ver )
+            ( json_free id )
+            ^ @ ?Json { T resp }
+        } {
+            ( json_free id )
+            ^ @ ?Json { F }
+        }
+    } {}
+
     : ?Json mparams ( json_obj_get req `params` )
     : Json result ( mcp_registry_dispatch r ( string_data method ) mparams )
     ( string_free method )
+    // Modern-era servers SHOULD identify themselves in each result's
+    // `_meta`. Skip error sub-shapes (they become JSON-RPC errors).
+    ? & is_modern ( json_is_obj result ) {
+        ? ( json_obj_has result `__error__` ) {} {
+            ( mcp_result_set_server_info result
+            ( string_data . r server_name )
+            ( string_data . r server_version ) )
+        }
+    } {}
     ? had_id {
         : Json resp ( __mcp_envelope_response result id )
         ^ @ ?Json { T resp }

--- a/stdlib/ext/mcp_stdio.nu
+++ b/stdlib/ext/mcp_stdio.nu
@@ -281,10 +281,24 @@ $ `stdlib/core/vec.nu`
     ( json_obj_set info `name` ( json_str_lit client_name ) )
     ( json_obj_set info `version` ( json_str_lit client_version ) )
     : Json params ( json_obj_new )
-    ( json_obj_set params `protocolVersion` ( json_str_lit ( mcp_protocol_version ) ) )
+    // Handshake-era revision — `initialize` IS the legacy path; the
+    // modern (2026-07-28) revision has no handshake, see
+    // mcp_stdio_discover.
+    ( json_obj_set params `protocolVersion` ( json_str_lit ( mcp_protocol_version_initialize ) ) )
     ( json_obj_set params `capabilities` caps )
     ( json_obj_set params `clientInfo` info )
     ^ ( mcp_stdio_call c `initialize` @ ?Json { T params } 0 )
+}
+
+// server/discover (2026-07-28) — ALSO the stdio backward-compat probe:
+// a dual-era client SHOULD send this first; a DiscoverResult (or a
+// recognized modern error like -32022) identifies a modern server,
+// anything else (e.g. -32601 method not found) identifies a legacy
+// server → fall back to mcp_stdio_initialize.
+@ mcp_stdio_discover McpStdioClient c s client_name s client_version → !Json McpStdioErr {
+    : Json params ( json_obj_new )
+    ( json_obj_set params `_meta` ( mcp_client_meta client_name client_version ) )
+    ^ ( mcp_stdio_call c `server/discover` @ ?Json { T params } 0 )
 }
 
 @ mcp_stdio_ping McpStdioClient c → !Json McpStdioErr {


### PR DESCRIPTION
## What

The MCP spec moved: revision **2026-07-28** removes the `initialize`/`notifications/initialized` handshake and protocol-level sessions. Modern requests carry protocol version + client identity + capabilities in `params._meta` (`io.modelcontextprotocol/*` keys), and servers **MUST** implement `server/discover`.

This makes the stdlib MCP stack **dual-era** per the spec's own compatibility matrix ([versioning page](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning)): one endpoint serves both modern (per-request `_meta`) and legacy (handshake) clients. **Nothing is removed** — every existing legacy client keeps working; the legacy surface rides out the spec's 12-month deprecation window.

## How

- **`mcp.nu`** — `mcp_protocol_version` → `2026-07-28`; new `mcp_protocol_version_initialize` (2025-11-25) is what handshake responses advertise (echoing a handshake-less revision would strand a legacy client). New helpers: `mcp_version_supported`, `mcp_supported_versions_json`, `_meta` readers, `mcp_client_meta`, `mcp_discover_result`, `mcp_result_set_cacheable`/`_set_server_info`, `mcp_response_error_data`/`mcp_unsupported_version_response`, error codes −32020…−32022. Every `mcp_response_result` now carries `resultType: "complete"` (required in 2026-07-28; additive for older clients — their spec requires treating the absent field as "complete", so presence is tolerated). `mcp_tools_list_result` fills the required CacheableResult fields.
- **`mcp_registry.nu`** — `server/discover` dispatch; declared-but-unsupported `_meta` version → spec-shaped `UnsupportedProtocolVersionError` (−32022 + `data.supported`); `_meta` serverInfo on modern results; `initialize` echoes the client's requested handshake-era revision when supported; list/read results carry `ttlMs`+`cacheScope`. The stdio serve loop now routes through `mcp_registry_envelope` — which also fixes a latent **double-free** (`json_free` after the consuming `mcp_send_message`).
- **`mcp_http.nu`** — `Mcp-Method`/`Mcp-Name` header-routing validation when present (mismatch → `HeaderMismatchError` −32020; absent = legacy client, still legal); CORS-allows the new headers.
- **`mcp_client.nu` / `mcp_stdio.nu`** — modern call paths (`mcp_call_modern`, `mcp_tools_call_modern`), `mcp_discover` + `mcp_stdio_discover`, and the dual-era probe `mcp_server_is_modern` implementing the spec's fallback flow (DiscoverResult ⇒ modern; other error ⇒ fall back to `initialize`).
- **`examples/mcp_echo_server.nu`** — demonstrates the `server/discover` handler for hand-rolled dispatch loops (the shape swarm-mcp/nurlapi follow).

## Tests

- New offline regression **`mcp_dual_era`** locks the wire shapes byte-for-byte: DiscoverResult, −32022 error with `data.supported`, modern `_meta` serverInfo (and its absence on legacy requests), initialize version echo + downgrade, CacheableResult fields.
- `mcp_http` grows header-match/mismatch scenarios.
- Goldens refreshed for the additive `resultType`/`ttlMs`/`cacheScope` fields — every diff inspected, all additive.
- Full suite: **PASS 570 / FAIL 0**. `tools/mcp_spec_drift_check.sh`: **OK** (pinned 2026-07-28 == spec current).

Downstream follow-ups (separate PRs): packages/nurl-mcp, packages/swarm-mcp, nurlapi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ