### PR TITLE
release: cut v0.32.0 — MCP 2026-07-28 dual-era

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] — 2026-08-03
+
+The MCP release. The Model Context Protocol shipped revision
+**2026-07-28**, which removes the `initialize` handshake and
+protocol-level sessions in favor of a stateless core — a
+backwards-incompatible change to the protocol every NURL MCP server and
+client speaks. NURL now implements it **dual-era**: one endpoint serves
+both the new stateless clients and every existing handshake-based one,
+so nothing that works today stops working.
+
 ### Added
 
 - **MCP 2026-07-28 (the stateless revision) — the stdlib MCP stack is
@@ -56,6 +66,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `examples/mcp_echo_server.nu` demonstrates the `server/discover`
     handler; new offline regression `compiler/tests/mcp_dual_era.nu`
     locks the dual-era wire shapes byte-for-byte.
+
+### Changed
+
+- **The playground's MCP endpoint is off its pinned revision.**
+  `nurlapi`'s `/mcp` hard-coded `protocolVersion: "2025-03-26"` (chosen
+  for FastMCP parity). It now negotiates: a client asking for
+  `2025-03-26` still gets exactly that, newer handshake clients get
+  theirs, and modern clients get `server/discover` plus per-request
+  `_meta`. Its static `tools/list`, `resources/list`, `prompts/list`
+  and `resources/read` results carry `cacheScope: "public"` with a
+  1-hour `ttlMs`, so shared intermediaries can cache them.
+- **`packages/nurl-mcp` 0.8.0** and **`packages/swarm-mcp` 0.22.0**
+  adopt the dual-era layer in their hand-rolled dispatch loops
+  (`server/discover`, the −32022 version gate, `_meta` serverInfo,
+  handshake-revision echo).
+
+### Fixed
+
+- **swarm-mcp's MCP handshake reported a stale version.**
+  `serverInfo.version` was a hand-written `0.20.0` while the package
+  was at 0.21.1. The handshake, `server/discover`, and the `--version`
+  banner now all read one `sm_version` source.
+- **A latent double-free in the registry's stdio serve loop.** It
+  called `json_free` on the response *after* `mcp_send_message`, which
+  already consumes its argument. Unifying the loop onto
+  `mcp_registry_envelope` removed the second free.
 
 ## [0.31.1] — 2026-08-03
 
@@ -10426,7 +10462,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.31.1...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.32.0...HEAD
+[0.32.0]: https://github.com/nurl-lang/nurl/compare/v0.31.1...v0.32.0
 [0.31.1]: https://github.com/nurl-lang/nurl/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/nurl-lang/nurl/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/nurl-lang/nurl/compare/v0.29.0...v0.30.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-03 · Current release: **0.31.1** · Language: **Grammar
+_Last reviewed: 2026-08-03 · Current release: **0.32.0** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
## v0.32.0 — the MCP release

The Model Context Protocol shipped revision **2026-07-28**, which removes the `initialize` handshake and protocol-level sessions in favor of a stateless core — a backwards-incompatible change to the protocol every NURL MCP server and client speaks.

NURL implements it **dual-era**: one endpoint serves both the new stateless clients and every existing handshake-based one, per the spec's own compatibility matrix. Nothing that works today stops working.

Shipped in #753 (stdlib) and #754 (nurl-mcp 0.8.0, swarm-mcp 0.22.0, playground). This PR is the CHANGELOG section + compare links + ROADMAP version line.

### Contents

- `server/discover` (MUST in 2026-07-28), per-request `_meta` version handling, `UnsupportedProtocolVersionError` (−32022), `HeaderMismatchError` (−32020) on `Mcp-Method`/`Mcp-Name`, `resultType: "complete"`, CacheableResult (`ttlMs`/`cacheScope`)
- Modern-era client calls + the dual-era probe (`mcp_server_is_modern`, `mcp_stdio_discover`)
- The playground's `/mcp` is off its hard-coded `2025-03-26` pin — it negotiates now, and its static lists are publicly cacheable for an hour
- Fixed: swarm-mcp's handshake reported a stale hand-written `0.20.0`; a latent double-free in the registry's stdio serve loop

After merge: tag `v0.32.0` on a green ci.yml run of the merge SHA, then publish nurl-mcp 0.8.0 and swarm-mcp 0.22.0 to the registry (they need the released stdlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ