### PR TITLE
Fuzzing: wasm32-wasi differential leg (third execution environment)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,6 +10,10 @@ name: fuzz
 #      same oracle contract, plus an ASan+LSan leg on sampled seeds — leaks
 #      and UAF in generated ownership traffic are findings even when stdout
 #      matches.
+#      The structural and integer legs also sample seeds onto wasm32-wasi
+#      (packages/wasmbuilder + reference wasmtime) — a third independent
+#      execution environment against the same oracle, catching
+#      target-dependent codegen (32-bit pointers, i64 payload slots).
 #   3. mutational parser fuzzer (tools/fuzz/fuzz_parsers.sh): mutate seeds for
 #      the untrusted-input parsers (x509/DER, cbor, msgpack, json, yaml, xml,
 #      toml) against an ASan+UBSan harness; any crash / OOB / UB / hang is a
@@ -64,15 +68,35 @@ jobs:
       - name: Build toolchain
         run: ./build.sh --no-tests
 
+      - name: Install zig + wasmtime (wasm differential leg)
+        # zig carries its own wasi-libc and wasm-ld, so no wasi-sdk is
+        # needed (same recipe release.yml uses for the bundled backend).
+        run: |
+          ZIG_VER=0.13.0
+          curl -fsSL "https://ziglang.org/download/${ZIG_VER}/zig-linux-x86_64-${ZIG_VER}.tar.xz" -o /tmp/zig.tar.xz
+          mkdir -p "$HOME/zig-toolchain"
+          tar -xf /tmp/zig.tar.xz -C "$HOME/zig-toolchain" --strip-components=1
+          echo "$HOME/zig-toolchain" >> "$GITHUB_PATH"
+          "$HOME/zig-toolchain/zig" version
+          curl https://wasmtime.dev/install.sh -sSf | bash
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+          "$HOME/.wasmtime/bin/wasmtime" --version
+
+      - name: Build wasmbuilder (shared by both differential legs)
+        run: |
+          ./nurl.sh packages/wasmbuilder/src/main.nu "$RUNNER_TEMP/wasmbuilder"
+          echo "FUZZ_WASMBUILDER=$RUNNER_TEMP/wasmbuilder" >> "$GITHUB_ENV"
+
       - name: Differential miscompile fuzzer (integer)
         run: |
+          FUZZ_WASM_EVERY=10 \
           FUZZ_SUMMARY="$RUNNER_TEMP/fuzz-summaries/int.json" \
             ./tools/fuzz/fuzz.sh 1 "${{ github.event.inputs.diff_seeds || '1500' }}"
 
       - name: Differential miscompile fuzzer (structural + sanitizer leg)
         if: success() || failure()          # run even if the int leg found something
         run: |
-          FUZZ_GEN=struct FUZZ_SAN_EVERY=5 \
+          FUZZ_GEN=struct FUZZ_SAN_EVERY=5 FUZZ_WASM_EVERY=5 \
           FUZZ_SUMMARY="$RUNNER_TEMP/fuzz-summaries/struct.json" \
             ./tools/fuzz/fuzz.sh 1 "${{ github.event.inputs.struct_seeds || '600' }}" 14 3
 

--- a/FUZZRESULTS.md
+++ b/FUZZRESULTS.md
@@ -5,26 +5,27 @@
 > the same way `bench.yml` commits the benchmark numbers. Do not edit by hand;
 > curate the findings log in [`tools/fuzz/FINDINGS.json`](tools/fuzz/FINDINGS.json).
 
-_Last run: **2026-08-03** · toolchain `v0.32.0-3-gbaf5dd7` · commit `baf5dd7`_
+_Last run: **2026-08-03** · toolchain `v0.32.0-8-gcf10972` · commit `cf10972`_
 
 **Latest run:** ✅ **clean** — no findings
 
-| family | configuration | executions | pass | findings | sanitized runs |
-|---|---|---:|---:|---:|---:|
-| `differential-int` | seeds 1–1500, size=12, depth=4 | 1500 | 1500 | 0 | 0 |
-| `differential-struct` | seeds 1–1000, size=14, depth=3 | 1000 | 1000 | 0 | 200 |
-| `differential-struct` | seeds 2001–2300, size=25, depth=4 | 300 | 300 | 0 | 75 |
-| `parser-mutational` | iters=1500 rng-seed=1 | 1500 | 1500 | 0 | 1500 |
+| family | configuration | executions | pass | findings | sanitized runs | wasm runs |
+|---|---|---:|---:|---:|---:|---:|
+| `differential-int` | seeds 1–500, size=12, depth=4 | 500 | 500 | 0 | 0 | 100 |
+| `differential-struct` | seeds 1–400, size=14, depth=3 | 400 | 400 | 0 | 40 | 200 |
+| `parser-mutational` | iters=1500 rng-seed=1 | 1500 | 1500 | 0 | 1500 | 0 |
 
 ## What each family probes
 
 - **`differential-int`** — `gen.py` — random integer/float expression trees with a Python oracle; compiled at `-O0` and `-O2`, both outputs must equal the oracle bit for bit.
-- **`differential-struct`** — `genprog.py` — whole structural programs (enums with N-ary mixed payloads, match guards/or-patterns/literal constraints, struct field writes, closures, while/foreach, defer, `% Drop`, string/Vec/slice ownership, helper calls, recursion) with a statement-level oracle; `-O0` vs `-O2` vs oracle, plus an ASan+LSan leg on sampled seeds.
+- **`differential-struct`** — `genprog.py` — whole structural programs (enums with N-ary mixed payloads, match guards/or-patterns/literal constraints, struct field writes, closures, while/foreach, defer, `% Drop`, string/Vec/slice ownership, helper calls, recursion) with a statement-level oracle; `-O0` vs `-O2` vs oracle, plus an ASan+LSan leg and a wasm32-wasi/wasmtime leg on sampled seeds.
 - **`parser-mutational`** — `fuzz_parsers.py` — mutated inputs for the untrusted-input parsers (x509/DER, cbor, msgpack, json, yaml, xml, toml) against an ASan+UBSan harness; any crash / OOB / UB / hang is a finding.
 
 A **finding** is any of: output divergence from the oracle at either
-opt level, a build failure on a generated (always-valid) program, a
-nonzero exit, a hang, or an ASan/LSan/UBSan report. Reproducers are
+opt level or on the wasm32-wasi leg (a third, independent execution
+environment run under wasmtime), a build failure on a generated
+(always-valid) program, a nonzero exit, a hang, or an
+ASan/LSan/UBSan report. Reproducers are
 uploaded as workflow artifacts and land in `tools/fuzz/failures/`.
 
 ## Findings log — real bugs the fuzzers have caught
@@ -45,7 +46,7 @@ uploaded as workflow artifacts and land in `tools/fuzz/failures/`.
 ```bash
 ./build.sh --no-tests
 tools/fuzz/fuzz.sh 1 500                        # integer differential
-FUZZ_GEN=struct FUZZ_SAN_EVERY=5 \
-    tools/fuzz/fuzz.sh 1 300 14 3               # structural + sanitizer leg
+FUZZ_GEN=struct FUZZ_SAN_EVERY=5 FUZZ_WASM_EVERY=5 \
+    tools/fuzz/fuzz.sh 1 300 14 3               # structural + sanitizer + wasm legs
 tools/fuzz/fuzz_parsers.sh 1 4000 8             # parser mutational
 ```

--- a/tools/fuzz/README.md
+++ b/tools/fuzz/README.md
@@ -20,7 +20,11 @@ of real bugs lives in [`FINDINGS.json`](FINDINGS.json).
    the statement-level oracle. `FUZZ_SAN_EVERY=N` additionally builds every
    Nth seed with ASan+LSan+UBSan and runs it leak-detection-on: a leak or
    UAF in the generated ownership traffic is a finding even when stdout
-   matches — this is the leg that hunts auto-drop bugs.
+   matches — this is the leg that hunts auto-drop bugs. `FUZZ_WASM_EVERY=N`
+   compiles every Nth seed to wasm32-wasi (`packages/wasmbuilder`) and runs
+   it under the reference wasmtime — a THIRD independent execution
+   environment against the same oracle, hunting target-dependent codegen
+   (32-bit pointers, i64 payload slots). Requires zig + wasmtime.
 3. **Mutational parser fuzzer** (`fuzz_parsers.sh` + `fuzz_parsers.py` +
    `parse_harness.nu`) — mutates seeds for the untrusted-input parsers
    (x509/DER, cbor, msgpack, json, yaml, xml, toml) against an ASan+UBSan
@@ -137,7 +141,9 @@ match literal constraint disagree with the arm's own payload binding
 ## Scope / future
 
 Covers integer + int↔float value semantics (`gen.py`) and the structural
-surface (`genprog.py`). Natural extensions: float *arithmetic* with a
-rounding-aware oracle, generic-function instantiations in generated
-programs, `?T`/`!T E` construction + propagation chains, and trait-object
-dispatch.
+surface (`genprog.py`), each executed natively at `-O0`/`-O2` and, on
+sampled seeds, sanitized and on wasm32-wasi. Natural extensions (tracked
+in TODO.md): float *arithmetic* with a rounding-aware oracle,
+generic-function instantiations + `?T`/`!T E` propagation chains in
+generated programs, trait-object dispatch, and borrow-checker soundness
+fuzzing (generate programs that MUST be rejected).

--- a/tools/fuzz/fuzz.sh
+++ b/tools/fuzz/fuzz.sh
@@ -21,6 +21,15 @@
 # agree — this is what catches UAF/double-free/leaks in the generated
 # ownership traffic.
 #
+# Wasm leg: FUZZ_WASM_EVERY=N (default 0 = off) additionally compiles
+# every Nth seed to wasm32-wasi (packages/wasmbuilder: nurlc IR → retarget
+# → zig cc against wasi-libc) and runs it under the reference wasmtime —
+# a THIRD independent execution environment against the same oracle.
+# Catches target-dependent codegen bugs (the enum-payload-slot truncation
+# class: pointers are 32 bits on wasm32). Requires zig + wasmtime; the
+# wasmbuilder binary is built once per run (or set FUZZ_WASMBUILDER to a
+# prebuilt one).
+#
 # FUZZ_SUMMARY=path.json (optional): write a machine-readable run summary
 # consumed by tools/fuzz/report.py (the FUZZRESULTS.md generator).
 #
@@ -45,6 +54,7 @@ EXPRS="${3:-12}"
 DEPTH="${4:-4}"
 GEN_KIND="${FUZZ_GEN:-int}"
 SAN_EVERY="${FUZZ_SAN_EVERY:-0}"
+WASM_EVERY="${FUZZ_WASM_EVERY:-0}"
 SUMMARY="${FUZZ_SUMMARY:-}"
 RUN_TIMEOUT="${FUZZ_RUN_TIMEOUT:-40}"
 
@@ -60,6 +70,32 @@ fail=0
 buildfail=0
 san_runs=0
 san_findings=0
+wasm_runs=0
+wasm_findings=0
+
+# One-time wasm-leg setup: a wasmbuilder binary + wasmtime on the box.
+WASMBUILDER=""
+WASMTIME_BIN=""
+if [[ "$WASM_EVERY" != "0" ]]; then
+    if command -v wasmtime >/dev/null;              then WASMTIME_BIN="wasmtime"
+    elif [[ -x "$HOME/.wasmtime/bin/wasmtime" ]];   then WASMTIME_BIN="$HOME/.wasmtime/bin/wasmtime"
+    else echo "fuzz.sh: FUZZ_WASM_EVERY set but wasmtime not found" >&2; exit 2; fi
+    if [[ -n "${FUZZ_WASMBUILDER:-}" && -x "${FUZZ_WASMBUILDER:-}" ]]; then
+        WASMBUILDER="$FUZZ_WASMBUILDER"
+    else
+        WASMBUILDER="$TMP/wasmbuilder"
+        echo "[wasm] building packages/wasmbuilder …"
+        (cd "$ROOT" && "$NURL" packages/wasmbuilder/src/main.nu "$WASMBUILDER") >"$TMP/wb.log" 2>&1 \
+            || { echo "fuzz.sh: wasmbuilder build failed — see $TMP/wb.log" >&2; tail -5 "$TMP/wb.log" >&2; exit 2; }
+    fi
+    # wasmbuilder resolves nurlc + the stdlib from the environment; pin both
+    # to THIS repo so the wasm module comes out of the compiler under test.
+    export NURLC="$ROOT/build/nurlc"
+    export NURL_STDLIB="$ROOT"
+    # First use compiles runtime.c → runtime.wasm.o (content-hash cached);
+    # do it now so seed timings/timeouts don't carry it.
+    "$WASMBUILDER" --doctor >/dev/null 2>&1 || true
+fi
 
 end=$((START + COUNT - 1))
 for seed in $(seq "$START" "$end"); do
@@ -106,6 +142,24 @@ for seed in $(seq "$START" "$end"); do
         fi
     fi
 
+    # Wasm leg: the third execution environment against the same oracle.
+    if [[ $ok -eq 1 && "$WASM_EVERY" != "0" ]] && (( seed % WASM_EVERY == 0 )); then
+        wasm_runs=$((wasm_runs+1))
+        if "$WASMBUILDER" -q "$prog" -o "$TMP/p.wasm" >"$TMP/bwasm.log" 2>&1; then
+            timeout "$RUN_TIMEOUT" "$WASMTIME_BIN" run "$TMP/p.wasm" > "$TMP/outwasm" 2>/dev/null; rcw=$?
+            if [[ $rcw -ne 0 ]] || ! cmp -s "$TMP/outwasm" "$exp"; then
+                ok=0; reason="wasm leg (rc=$rcw)"
+                wasm_findings=$((wasm_findings+1))
+                cp "$TMP/outwasm" "$FAILDIR/${GEN_KIND}_seed_${seed}.outwasm" 2>/dev/null
+                diff "$exp" "$TMP/outwasm" > "$FAILDIR/${GEN_KIND}_seed_${seed}.diff_wasm" 2>&1
+            fi
+        else
+            ok=0; reason="wasm build fail"
+            wasm_findings=$((wasm_findings+1))
+            cp "$TMP/bwasm.log" "$FAILDIR/${GEN_KIND}_seed_${seed}.wasmlog"
+        fi
+    fi
+
     if [[ $ok -eq 1 ]]; then
         pass=$((pass+1))
     else
@@ -120,7 +174,7 @@ for seed in $(seq "$START" "$end"); do
 done
 
 echo "─────────────────────────────────────────"
-echo "[$GEN_KIND] seeds $START..$end   pass=$pass  findings=$fail  buildfail=$buildfail  san_runs=$san_runs  san_findings=$san_findings"
+echo "[$GEN_KIND] seeds $START..$end   pass=$pass  findings=$fail  buildfail=$buildfail  san_runs=$san_runs  san_findings=$san_findings  wasm_runs=$wasm_runs  wasm_findings=$wasm_findings"
 
 if [[ -n "$SUMMARY" ]]; then
     mkdir -p "$(dirname "$SUMMARY")"
@@ -136,7 +190,9 @@ if [[ -n "$SUMMARY" ]]; then
   "findings": $fail,
   "buildfail": $buildfail,
   "san_runs": $san_runs,
-  "san_findings": $san_findings
+  "san_findings": $san_findings,
+  "wasm_runs": $wasm_runs,
+  "wasm_findings": $wasm_findings
 }
 JSON
 fi

--- a/tools/fuzz/report.py
+++ b/tools/fuzz/report.py
@@ -32,7 +32,7 @@ FAMILY_DESC = {
         "field writes, closures, while/foreach, defer, `% Drop`, "
         "string/Vec/slice ownership, helper calls, recursion) with a "
         "statement-level oracle; `-O0` vs `-O2` vs oracle, plus an "
-        "ASan+LSan leg on sampled seeds",
+        "ASan+LSan leg and a wasm32-wasi/wasmtime leg on sampled seeds",
     "parser-mutational":
         "`fuzz_parsers.py` — mutated inputs for the untrusted-input "
         "parsers (x509/DER, cbor, msgpack, json, yaml, xml, toml) against "
@@ -83,8 +83,8 @@ def main():
     a("")
     a(f"**Latest run:** {status}")
     a("")
-    a("| family | configuration | executions | pass | findings | sanitized runs |")
-    a("|---|---|---:|---:|---:|---:|")
+    a("| family | configuration | executions | pass | findings | sanitized runs | wasm runs |")
+    a("|---|---|---:|---:|---:|---:|---:|")
     for r in runs:
         fam = r.get("family", "?")
         if fam.startswith("parser"):
@@ -96,7 +96,8 @@ def main():
                    f"size={r.get('size')}, depth={r.get('depth')}")
             execs = r.get("seed_count", 0)
         bad = r.get("findings", 0) + r.get("buildfail", 0)
-        a(f"| `{fam}` | {cfg} | {execs} | {r.get('pass', 0)} | {bad} | {r.get('san_runs', 0)} |")
+        a(f"| `{fam}` | {cfg} | {execs} | {r.get('pass', 0)} | {bad} | "
+          f"{r.get('san_runs', 0)} | {r.get('wasm_runs', 0)} |")
     a("")
     a("## What each family probes")
     a("")
@@ -104,8 +105,10 @@ def main():
         a(f"- **`{fam}`** — {desc}.")
     a("")
     a("A **finding** is any of: output divergence from the oracle at either")
-    a("opt level, a build failure on a generated (always-valid) program, a")
-    a("nonzero exit, a hang, or an ASan/LSan/UBSan report. Reproducers are")
+    a("opt level or on the wasm32-wasi leg (a third, independent execution")
+    a("environment run under wasmtime), a build failure on a generated")
+    a("(always-valid) program, a nonzero exit, a hang, or an")
+    a("ASan/LSan/UBSan report. Reproducers are")
     a("uploaded as workflow artifacts and land in `tools/fuzz/failures/`.")
     a("")
     a("## Findings log — real bugs the fuzzers have caught")
@@ -120,8 +123,8 @@ def main():
     a("```bash")
     a("./build.sh --no-tests")
     a("tools/fuzz/fuzz.sh 1 500                        # integer differential")
-    a("FUZZ_GEN=struct FUZZ_SAN_EVERY=5 \\")
-    a("    tools/fuzz/fuzz.sh 1 300 14 3               # structural + sanitizer leg")
+    a("FUZZ_GEN=struct FUZZ_SAN_EVERY=5 FUZZ_WASM_EVERY=5 \\")
+    a("    tools/fuzz/fuzz.sh 1 300 14 3               # structural + sanitizer + wasm legs")
     a("tools/fuzz/fuzz_parsers.sh 1 4000 8             # parser mutational")
     a("```")
     a("")


### PR DESCRIPTION
## What

`FUZZ_WASM_EVERY=N` in `tools/fuzz/fuzz.sh`: every Nth generated seed is also compiled to **wasm32-wasi** (`packages/wasmbuilder`: nurlc IR → retarget → zig cc against wasi-libc) and executed under the reference **wasmtime** — a third, independent execution environment whose output must equal the Python oracle bit for bit.

## Why

Native-only differential testing cannot see **target-dependent** codegen bugs. The known example of the class: enum payload slots used to ride `ptr`-typed fields, silently truncating f64 bit-patterns and ≥2³² integers on wasm32 where pointers are 32 bits (`enum_payload_64bit_slots`). This leg makes that whole class a routine finding instead of a lucky catch.

## Wiring

- `fuzz.yml` installs zig 0.13 (its bundled wasi-libc/wasm-ld makes a wasi-sdk unnecessary — same recipe as release.yml) + wasmtime, builds `wasmbuilder` once, and samples every 5th structural / 10th integer seed onto wasm.
- Run summaries, the FUZZRESULTS.md table, and `tools/fuzz/README.md` gain a *wasm runs* column.
- `TODO.md` records the next fuzzing depths as **F1** (generics + `?T`/`!T E` + `\`-propagation in genprog, including a suspected `\`-fail-path drop gap to check first) and **F2** (borrow-checker soundness fuzzing: generated must-reject programs, with the sanitizer leg proving any hole that slips through).

## Evidence

| leg | executions | wasm runs | findings |
|---|---:|---:|---:|
| structural | 400 | 200 | 0 |
| integer | 500 | 100 | 0 |

Clean — as expected on a surface whose native legs were just hardened in #756; the value is standing coverage from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ