### PR TITLE
Change-based Windows golden-twin gate: hook auto-sync + exact per-PR CI check

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,7 +27,6 @@ fi
 
 # Staged, added/copied/modified *.nu files, minus bench/.
 mapfile -t FILES < <(git diff --cached --name-only --diff-filter=ACM -- '*.nu' | grep -v '^bench/' || true)
-(( ${#FILES[@]} == 0 )) && exit 0
 
 blocked=()
 fixed=()
@@ -58,6 +57,52 @@ if (( ${#blocked[@]} > 0 )); then
     for f in "${blocked[@]}"; do echo "  $f" >&2; done
     echo "Fix: build/nurlfmt --write <file>  then re-stage." >&2
     exit 1
+fi
+
+# ── Windows golden twins ─────────────────────────────────────
+# The change-based rule of tools/check_golden_twins.sh, applied to the
+# staged diff: a staged compiler/tests/outputs/X.txt change whose
+# outputs-windows/ twin was byte-identical BEFORE the change proves the
+# test's output is platform-independent — so the twin gets the SAME
+# content, auto-copied from the staged blob and re-staged. Twins that
+# already differed are platform-specific; those get a note (the right
+# Windows bytes need a Windows runner — windows-tests.yml has an
+# `update_goldens` dispatch input). This is what the MCP dual-era
+# change needed: its two stale twins broke the Windows run on main.
+WIN_DIR="compiler/tests/outputs-windows"
+copied=()
+platform_note=()
+while IFS= read -r f; do
+    b="$(basename "$f")"
+    w="$WIN_DIR/$b"
+    [[ -f "$w" ]] || continue
+    old_l="$(git rev-parse --quiet --verify "HEAD:$f" 2>/dev/null || true)"
+    old_w="$(git rev-parse --quiet --verify "HEAD:$w" 2>/dev/null || true)"
+    staged_l="$(git rev-parse --quiet --verify ":$f" 2>/dev/null || true)"
+    staged_w="$(git rev-parse --quiet --verify ":$w" 2>/dev/null || true)"
+    if [[ -n "$old_l" && "$old_l" == "$old_w" ]]; then
+        # Identical before → must stay identical. Copy the staged Linux
+        # content over the twin unless it already matches.
+        if [[ "$staged_l" != "$staged_w" ]]; then
+            git show ":$f" > "$w"
+            git add -- "$w"
+            copied+=("$w")
+        fi
+    else
+        [[ "$staged_l" != "$staged_w" ]] && platform_note+=("$w")
+    fi
+done < <(git diff --cached --name-only --diff-filter=ACM -- "compiler/tests/outputs/*.txt")
+
+if (( ${#copied[@]} > 0 )); then
+    echo "pre-commit: Windows golden twins auto-synced (twin was byte-identical" >&2
+    echo "to the Linux golden — platform-independent output):" >&2
+    for f in "${copied[@]}"; do echo "  $f" >&2; done
+fi
+if (( ${#platform_note[@]} > 0 )); then
+    echo "pre-commit note: platform-SPECIFIC Windows twins exist for changed" >&2
+    echo "goldens — verify on a Windows runner if the change touches shared" >&2
+    echo "output (windows-tests.yml dispatch input 'update_goldens'):" >&2
+    for f in "${platform_note[@]}"; do echo "  $f" >&2; done
 fi
 
 exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,19 @@ jobs:
         # without a Windows machine.
         run: ./tools/check_windows_goldens.sh
 
+      - name: Windows golden twins carry this PR's changes (change-based, exact)
+        # The state-based check above cannot see line MUTATIONS: the MCP
+        # dual-era change rewrote result lines, the stale twins diffed
+        # with both < and > lines — indistinguishable from a legitimate
+        # platform difference — and the break landed on main. The exact
+        # rule needs the change: a golden touched by this PR whose twin
+        # was byte-identical BEFORE it (platform-independent output)
+        # must keep the twin identical. The pre-commit hook auto-copies;
+        # this is the same rule for whoever skipped the hook.
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha || github.event.before }}" || true
+          ./tools/check_golden_twins.sh "${{ github.event.pull_request.base.sha || github.event.before }}"
+
       - name: no packages/… self-imports (breaks registry installs)
         # In this repo every build runs from the root, so a
         # `$ \`packages/<name>/src/x.nu\`` import resolves and every test

--- a/tools/check_golden_twins.sh
+++ b/tools/check_golden_twins.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/check_golden_twins.sh — a CHANGE-based gate for the Windows
+#  golden corpus, exact where check_windows_goldens.sh is heuristic.
+#
+#  check_windows_goldens.sh catches the pure-growth shape (the Windows
+#  golden is missing lines, adds none). It cannot catch line MUTATIONS:
+#  when the MCP dual-era change rewrote result lines in mcp_basic /
+#  mcp_http, the stale Windows twins differed with both '<' and '>'
+#  lines — indistinguishable from a legitimate platform difference by
+#  state alone, so the drift sailed through and broke the Windows run
+#  on main.
+#
+#  The exact rule needs the CHANGE, not the state: for every golden
+#  this commit range touches whose outputs-windows/ twin exists,
+#
+#    * twins byte-identical BEFORE the change  →  they must be
+#      byte-identical AFTER it. Identical-before proves the test's
+#      output is platform-independent, so the Linux update applies to
+#      Windows verbatim — a copy the author forgot. HARD FAIL.
+#
+#    * twins already differed before  →  nothing can be verified from
+#      Linux (the right Windows content needs a Windows runner). WARN
+#      with the dispatch instructions, never fail.
+#
+#  Usage:   tools/check_golden_twins.sh [BASE_REF]
+#  BASE_REF defaults to the merge base with origin/main. The pre-commit
+#  hook applies the same rule to the staged diff (and auto-copies).
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+
+LINUX_DIR=compiler/tests/outputs
+WIN_DIR=compiler/tests/outputs-windows
+
+BASE="${1:-}"
+if [ -z "$BASE" ]; then
+    BASE="$(git merge-base HEAD origin/main 2>/dev/null)" || BASE=""
+    [ -n "$BASE" ] || BASE="HEAD~1"
+fi
+# The rule is vacuous when there is nothing between BASE and HEAD.
+[ "$(git rev-parse "$BASE" 2>/dev/null)" = "$(git rev-parse HEAD)" ] && {
+    echo "golden twins OK (no commits against $BASE)"; exit 0; }
+
+fail=0
+warned=0
+while IFS= read -r f; do
+    b="$(basename "$f")"
+    w="$WIN_DIR/$b"
+    [ -f "$w" ] || git cat-file -e "$BASE:$w" 2>/dev/null || continue
+    old_l="$(git rev-parse --quiet --verify "$BASE:$f" 2>/dev/null || true)"
+    old_w="$(git rev-parse --quiet --verify "$BASE:$w" 2>/dev/null || true)"
+    if [ -n "$old_l" ] && [ "$old_l" = "$old_w" ]; then
+        # Platform-independent output (twins identical before) — the
+        # Windows twin must carry the same update.
+        if ! cmp -s "$f" "$w"; then
+            if [ "$fail" -eq 0 ]; then
+                echo "Windows golden twins left behind by this change:" >&2
+                echo "(twin was byte-identical to the Linux golden before the" >&2
+                echo "change — the test's output is platform-independent, so" >&2
+                echo "the update applies verbatim; copy it)" >&2
+                echo >&2
+            fi
+            echo "  cp $f $w" >&2
+            fail=1
+        fi
+    else
+        # Twins differed already — a platform-specific test changed on
+        # the Linux side. Can't be verified from Linux; say so once.
+        if ! cmp -s "$f" "$w"; then
+            if [ "$warned" -eq 0 ]; then
+                echo "note: platform-specific goldens changed on the Linux side;" >&2
+                echo "verify their Windows twins on a runner if the change touches" >&2
+                echo "shared output (windows-tests.yml has a workflow_dispatch" >&2
+                echo "input 'update_goldens' that regenerates the corpus):" >&2
+                warned=1
+            fi
+            echo "  $w" >&2
+        fi
+    fi
+done < <(git diff --name-only --diff-filter=ACM "$BASE"...HEAD -- "$LINUX_DIR/*.txt" 2>/dev/null \
+         || git diff --name-only --diff-filter=ACM "$BASE" HEAD -- "$LINUX_DIR/*.txt")
+
+if [ "$fail" -ne 0 ]; then
+    echo >&2
+    echo "Copy the Linux golden over each listed twin (the commit message" >&2
+    echo "can say the output is platform-independent) and re-commit." >&2
+    exit 1
+fi
+echo "golden twins OK"


### PR DESCRIPTION
## What

The commit-hook gate idea from review: make it impossible to forget the `outputs-windows/` twin when a Linux golden changes — or at least impossible *silently*.

`check_windows_goldens.sh` (state-based, already in CI) catches only the pure-growth shape: the Windows golden missing lines and adding none. It cannot see line **mutations** — when the MCP dual-era change rewrote result lines in `mcp_basic`/`mcp_http`, the stale twins diffed with both `<` and `>` lines, indistinguishable from a legitimate platform difference, and the break landed on the Windows run on main (#758).

The exact rule needs the **change**, not the state:

> A golden whose `outputs-windows/` twin was **byte-identical before** the change has platform-independent output — so the twin must carry the same update. A twin that already differed is platform-specific; the right Windows bytes need a Windows runner, so that case warns and points at the `update_goldens` dispatch instead of guessing.

## Pieces

- **`.githooks/pre-commit`** — for staged `outputs/X.txt` changes with an identical-before twin, auto-copies the staged content onto the twin and re-stages it: the forgotten `cp`, done for you at commit time. Also fixes the hook's early exit when no `.nu` files are staged (a golden-only commit would have skipped the new section entirely).
- **`tools/check_golden_twins.sh`** — the same rule over a commit range: hard-fail on a left-behind identical-before twin, warn on platform-specific ones.
- **`ci.yml`** — runs the range check per PR against the PR base, so the gate holds for whoever skipped the hook (`--no-verify`, GUI commits, direct edits).

## Verified

Synthetic drift on a throwaway branch: the hook auto-syncs and re-stages the twin; the range check exits 1 on an identical-before twin left behind and exits 0 with a note for platform-specific twins. The MCP case replays exactly as the hard-fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ