### PR TITLE
net: sans-IO IPv4/TCP stack in stdlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,12 +305,19 @@ jobs:
         # defer_drop_reclaim + defer_scoped + defer_ret_transfer pin the
         # defer-vs-auto-drop fix (a `;` defer used to disable every owned
         # drop in the function; scoped defers emitted invalid IR).
+        # net_inet + net_frames + net_dhcp pin the sans-IO net stack's
+        # manual-handle discipline (§7.4): per-iteration Vec frees in a
+        # 65k-datagram sweep, String results from the address formatters,
+        # and the ARP cache's owned entry table. That stack is destined
+        # for a unikernel, where there is no process exit to sweep up
+        # after a leak — so it is held leak-clean from its first commit.
         run: |
           LSAN_DETECT_LEAKS=1 ./compiler/tests/run_san_tests.sh \
             struct_nested_field_drop arm_local_drop arm_local_trailing_drop \
             recover_unwind loop_drop_reclaim closure_env_reclaim closure_env_binding \
             ternary_slice_owned match_slice_owned arm_assign_tail_drop \
-            defer_drop_reclaim defer_scoped defer_ret_transfer
+            defer_drop_reclaim defer_scoped defer_ret_transfer \
+            net_inet net_frames net_dhcp net_stack net_tcp net_tcp_fuzz
 
   webdocs-build:
     name: web docs build (fumadocs)

--- a/compiler/tests/net_dhcp.nu
+++ b/compiler/tests/net_dhcp.nu
@@ -1,0 +1,218 @@
+// net_dhcp.nu — offline test for stdlib/net/dhcp.nu. The whole lease
+// life cycle — DISCOVER/OFFER/REQUEST/ACK, T1 renew, T2 rebind, expiry
+// and NAK — driven by a scripted clock, so hours of lease time run in
+// microseconds. No sockets.
+//
+// The renewal timers are the part that only fails after a lease has
+// been held for a while, i.e. never during manual testing; a scripted
+// clock is the only way they get covered at all.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/eth.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/udp4.nu`
+$ `stdlib/net/dhcp.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ cl_mac → i { ^ 2199023255553 }
+
+@ srv_ip → i { ^ ( ipv4_make 10 0 2 2 ) }
+
+@ off_ip → i { ^ ( ipv4_make 10 0 2 15 ) }
+
+// A minimal DHCP server reply: BOOTP header + the options we consume.
+@ mk_reply i msg_type i xid i mac i yiaddr i lease i t1 i t2 → ( Vec u ) {
+    : ( Vec u ) m ( vec_new [u] )
+    ( vec_push [u] m # u ( dhcp_op_reply ) )
+    ( vec_push [u] m # u 1 ) ( vec_push [u] m # u 6 ) ( vec_push [u] m # u 0 )
+    ( bytes_push_u32_be m # u32 & xid 4294967295 )
+    ( bytes_push_u16_be m # u16 0 ) ( bytes_push_u16_be m # u16 0 )
+    ( bytes_push_u32_be m # u32 0 )  // ciaddr
+    ( bytes_push_u32_be m # u32 & yiaddr 4294967295 )  // yiaddr
+    ( bytes_push_u32_be m # u32 & ( srv_ip ) 4294967295 )  // siaddr
+    ( bytes_push_u32_be m # u32 0 )  // giaddr
+    ( eth_push_mac m mac )
+    : ~ i pad 0
+    ~ < pad 202 { ( vec_push [u] m # u 0 ) = pad + pad 1 }
+    ( bytes_push_u32_be m # u32 ( dhcp_magic ) )
+    ( vec_push [u] m # u ( dhcp_opt_msg_type ) )
+    ( vec_push [u] m # u 1 )
+    ( vec_push [u] m # u & msg_type 255 )
+    ( vec_push [u] m # u ( dhcp_opt_server_id ) )
+    ( vec_push [u] m # u 4 )
+    ( bytes_push_u32_be m # u32 & ( srv_ip ) 4294967295 )
+    ( vec_push [u] m # u ( dhcp_opt_subnet ) )
+    ( vec_push [u] m # u 4 )
+    ( bytes_push_u32_be m # u32 4294967040 )
+    ( vec_push [u] m # u ( dhcp_opt_router ) )
+    ( vec_push [u] m # u 4 )
+    ( bytes_push_u32_be m # u32 & ( srv_ip ) 4294967295 )
+    ( vec_push [u] m # u ( dhcp_opt_dns ) )
+    ( vec_push [u] m # u 4 )
+    ( bytes_push_u32_be m # u32 & ( ipv4_make 10 0 2 3 ) 4294967295 )
+    ? > lease 0 {
+        ( vec_push [u] m # u ( dhcp_opt_lease ) )
+        ( vec_push [u] m # u 4 )
+        ( bytes_push_u32_be m # u32 & lease 4294967295 )
+    } {}
+    ? > t1 0 {
+        ( vec_push [u] m # u ( dhcp_opt_renewal ) )
+        ( vec_push [u] m # u 4 )
+        ( bytes_push_u32_be m # u32 & t1 4294967295 )
+    } {}
+    ? > t2 0 {
+        ( vec_push [u] m # u ( dhcp_opt_rebind ) )
+        ( vec_push [u] m # u 4 )
+        ( bytes_push_u32_be m # u32 & t2 4294967295 )
+    } {}
+    ( vec_push [u] m # u ( dhcp_opt_end ) )
+    ^ m
+}
+
+@ main → i {
+    : *DhcpClient c ( dhcp_client_new ( cl_mac ) 305419896 )
+    ( pb `starts unbound: ` ! ( dhcp_bound c ) )
+
+    // ── INIT → SELECTING ─────────────────────────────────────────
+    ( pb `first tick sends DISCOVER: ` == ( dhcp_tick c 0 ) ( dhcp_msg_discover ) )
+    ( pb `discover broadcasts: ` == ( dhcp_dest_ip c ) 4294967295 )
+    ( pb `discover src is 0.0.0.0: ` == ( dhcp_src_ip c ) 0 )
+    ( pb `no immediate resend: ` == ( dhcp_tick c 100 ) 0 )
+    ( pb `resend after backoff: ` == ( dhcp_tick c 4000 ) ( dhcp_msg_discover ) )
+    ( pb `backoff doubled (no send at 6s): ` == ( dhcp_tick c 6000 ) 0 )
+    ( pb `resend at 12s: ` == ( dhcp_tick c 12000 ) ( dhcp_msg_discover ) )
+
+    // Our own DISCOVER must round-trip through the parser.
+    : ( Vec u ) disc ( vec_new [u] )
+    ( dhcp_push_message disc ( dhcp_msg_discover ) 305419896 ( cl_mac ) 0 0 0 )
+    : DhcpMsg dm ( dhcp_parse disc 0 ( vec_len [u] disc ) )
+    ( pb `own discover parses: ` . dm valid )
+    ( pb `discover op is request: ` == . dm op ( dhcp_op_request ) )
+    ( pb `discover xid: ` == . dm xid 305419896 )
+    ( pb `discover carries our mac: ` == . dm chaddr_mac ( cl_mac ) )
+    ( pb `discover msg type: ` == . dm msg_type ( dhcp_msg_discover ) )
+
+    // ── foreign replies are ignored ──────────────────────────────
+    : ( Vec u ) wrong_xid ( mk_reply ( dhcp_msg_offer ) 4008636142 ( cl_mac ) ( off_ip ) 3600 0 0 )
+    : DhcpMsg wx ( dhcp_parse wrong_xid 0 ( vec_len [u] wrong_xid ) )
+    ( pb `foreign xid parses as a message: ` . wx valid )
+    ( pb `foreign xid ignored: ` ! ( dhcp_handle c wx 13000 ) )
+    : ( Vec u ) wrong_mac ( mk_reply ( dhcp_msg_offer ) 305419896 2199023255599 ( off_ip ) 3600 0 0 )
+    : DhcpMsg wm ( dhcp_parse wrong_mac 0 ( vec_len [u] wrong_mac ) )
+    ( pb `foreign chaddr ignored: ` ! ( dhcp_handle c wm 13000 ) )
+    ( pb `still selecting: ` ! ( dhcp_bound c ) )
+
+    // ── OFFER → REQUESTING ───────────────────────────────────────
+    : ( Vec u ) offer ( mk_reply ( dhcp_msg_offer ) 305419896 ( cl_mac ) ( off_ip ) 3600 0 0 )
+    : DhcpMsg om ( dhcp_parse offer 0 ( vec_len [u] offer ) )
+    ( pb `offer parses: ` . om valid )
+    ( pb `offer yiaddr: ` == . om yiaddr ( off_ip ) )
+    ( pb `offer server id: ` == . om server_id ( srv_ip ) )
+    ( pb `offer accepted: ` ( dhcp_handle c om 13000 ) )
+    ( pb `now requesting: ` == . c state ( dhcp_state_requesting ) )
+    ( pb `not bound yet: ` ! ( dhcp_bound c ) )
+    ( pb `request retransmits: ` == ( dhcp_tick c 17000 ) ( dhcp_msg_request ) )
+
+    // ── ACK → BOUND ──────────────────────────────────────────────
+    // lease 3600 s, no explicit T1/T2 → RFC defaults 1800 / 3150.
+    : ( Vec u ) ack ( mk_reply ( dhcp_msg_ack ) 305419896 ( cl_mac ) ( off_ip ) 3600 0 0 )
+    : DhcpMsg am ( dhcp_parse ack 0 ( vec_len [u] ack ) )
+    ( pb `ack accepted: ` ( dhcp_handle c am 20000 ) )
+    ( pb `bound: ` ( dhcp_bound c ) )
+    ( pb `got our address: ` == . c our_ip ( off_ip ) )
+    ( pb `got subnet mask: ` == . c subnet 4294967040 )
+    ( pb `got router: ` == . c router ( srv_ip ) )
+    ( pb `got dns: ` == . c dns ( ipv4_make 10 0 2 3 ) )
+    ( pb `T1 defaults to lease/2: ` == . c t1_ms + 20000 1800000 )
+    ( pb `T2 defaults to 7/8 lease: ` == . c t2_ms + 20000 3150000 )
+    ( pb `lease deadline: ` == . c lease_ms + 20000 3600000 )
+    ( pb `bound is quiet: ` == ( dhcp_tick c 100000 ) 0 )
+    ( pb `still quiet just before T1: ` == ( dhcp_tick c 1819999 ) 0 )
+
+    // ── T1 → RENEWING ────────────────────────────────────────────
+    ( pb `T1 triggers renew: ` == ( dhcp_tick c 1820000 ) ( dhcp_msg_request ) )
+    ( pb `state renewing: ` == . c state ( dhcp_state_renewing ) )
+    ( pb `renew unicasts to server: ` == ( dhcp_dest_ip c ) ( srv_ip ) )
+    ( pb `renew src is our address: ` == ( dhcp_src_ip c ) ( off_ip ) )
+    ( pb `renew still counts as bound: ` ( dhcp_bound c ) )
+
+    // Renewal ACK extends the lease from the new "now".
+    : ( Vec u ) ack2 ( mk_reply ( dhcp_msg_ack ) 305419896 ( cl_mac ) ( off_ip ) 3600 1800 3150 )
+    : DhcpMsg am2 ( dhcp_parse ack2 0 ( vec_len [u] ack2 ) )
+    ( pb `renewal ack accepted: ` ( dhcp_handle c am2 1830000 ) )
+    ( pb `back to bound: ` == . c state ( dhcp_state_bound ) )
+    ( pb `lease extended: ` == . c lease_ms + 1830000 3600000 )
+    ( pb `explicit T1 honoured: ` == . c t1_ms + 1830000 1800000 )
+
+    // ── T2 → REBINDING (server silent) ───────────────────────────
+    : i _r1 ( dhcp_tick c 3630000 )  // T1 again → RENEWING
+    ( pb `renewing again at T1: ` == . c state ( dhcp_state_renewing ) )
+    : i r2 ( dhcp_tick c 4980000 )  // T2 → REBINDING
+    ( pb `T2 triggers rebind: ` == r2 ( dhcp_msg_request ) )
+    ( pb `state rebinding: ` == . c state ( dhcp_state_rebinding ) )
+    ( pb `rebind broadcasts: ` == ( dhcp_dest_ip c ) 4294967295 )
+    ( pb `rebind keeps our address as src: ` == ( dhcp_src_ip c ) ( off_ip ) )
+
+    // ── expiry → INIT ────────────────────────────────────────────
+    : i _r3 ( dhcp_tick c 5430001 )
+    ( pb `expiry drops the address: ` == . c our_ip 0 )
+    ( pb `expiry returns to INIT: ` == . c state ( dhcp_state_init ) )
+    ( pb `no longer bound: ` ! ( dhcp_bound c ) )
+    ( pb `INIT re-discovers: ` == ( dhcp_tick c 5430002 ) ( dhcp_msg_discover ) )
+    ( dhcp_client_free c )
+
+    // ── NAK drops the claim immediately ──────────────────────────
+    : *DhcpClient c2 ( dhcp_client_new ( cl_mac ) 305419896 )
+    : i _d ( dhcp_tick c2 0 )
+    : ( Vec u ) offer2 ( mk_reply ( dhcp_msg_offer ) 305419896 ( cl_mac ) ( off_ip ) 3600 0 0 )
+    : b _o ( dhcp_handle c2 ( dhcp_parse offer2 0 ( vec_len [u] offer2 ) ) 1000 )
+    : ( Vec u ) ack3 ( mk_reply ( dhcp_msg_ack ) 305419896 ( cl_mac ) ( off_ip ) 3600 0 0 )
+    : b _a ( dhcp_handle c2 ( dhcp_parse ack3 0 ( vec_len [u] ack3 ) ) 2000 )
+    ( pb `bound before nak: ` ( dhcp_bound c2 ) )
+    : ( Vec u ) nak ( mk_reply ( dhcp_msg_nak ) 305419896 ( cl_mac ) 0 0 0 0 )
+    ( pb `nak accepted: ` ( dhcp_handle c2 ( dhcp_parse nak 0 ( vec_len [u] nak ) ) 3000 ) )
+    ( pb `nak drops address at once: ` == . c2 our_ip 0 )
+    ( pb `nak returns to INIT: ` == . c2 state ( dhcp_state_init ) )
+    ( dhcp_client_free c2 )
+
+    // ── codec robustness ─────────────────────────────────────────
+    : ( Vec u ) tiny ( vec_new [u] )
+    ( vec_push [u] tiny # u 2 )
+    ( pb `short message rejected: ` ! . ( dhcp_parse tiny 0 1 ) valid )
+
+    : ( Vec u ) nomagic ( mk_reply ( dhcp_msg_ack ) 305419896 ( cl_mac ) ( off_ip ) 3600 0 0 )
+    : b _nm ( vec_set [u] nomagic 236 # u 0 )
+    ( pb `bad magic cookie rejected: ` ! . ( dhcp_parse nomagic 0 ( vec_len [u] nomagic ) ) valid )
+
+    // A truncated option length must terminate the walk, not run off
+    // the end or spin — this is the classic parser DoS in DHCP.
+    : ( Vec u ) badopt ( mk_reply ( dhcp_msg_ack ) 305419896 ( cl_mac ) ( off_ip ) 3600 0 0 )
+    : b _b1 ( vec_set [u] badopt 240 # u 53 )
+    : b _b2 ( vec_set [u] badopt 241 # u 200 )  // claims 200 bytes, has ~30
+    : DhcpMsg bm ( dhcp_parse badopt 0 ( vec_len [u] badopt ) )
+    ( pb `overlong option terminates walk: ` && . bm valid == . bm msg_type 0 )
+
+    // Zero-length lease → the client's own default, never a zero lease
+    // (a zero lease would expire the address on the next tick).
+    : ( Vec u ) nolease ( mk_reply ( dhcp_msg_ack ) 305419896 ( cl_mac ) ( off_ip ) 0 0 0 )
+    : *DhcpClient c3 ( dhcp_client_new ( cl_mac ) 305419896 )
+    : i _d3 ( dhcp_tick c3 0 )
+    : ( Vec u ) offer3 ( mk_reply ( dhcp_msg_offer ) 305419896 ( cl_mac ) ( off_ip ) 0 0 0 )
+    : b _o3 ( dhcp_handle c3 ( dhcp_parse offer3 0 ( vec_len [u] offer3 ) ) 1000 )
+    : b _a3 ( dhcp_handle c3 ( dhcp_parse nolease 0 ( vec_len [u] nolease ) ) 2000 )
+    ( pb `missing lease → 1h default: ` == . c3 lease_ms + 2000 3600000 )
+    ( pb `bound with defaulted lease: ` ( dhcp_bound c3 ) )
+    ( dhcp_client_free c3 )
+
+    // Vec is a manually-managed handle (docs/MEMORY.md §7.4).
+    ( vec_free [u] disc ) ( vec_free [u] wrong_xid ) ( vec_free [u] wrong_mac )
+    ( vec_free [u] offer ) ( vec_free [u] ack ) ( vec_free [u] ack2 )
+    ( vec_free [u] offer2 ) ( vec_free [u] ack3 ) ( vec_free [u] nak )
+    ( vec_free [u] tiny ) ( vec_free [u] nomagic ) ( vec_free [u] badopt )
+    ( vec_free [u] nolease ) ( vec_free [u] offer3 )
+    ^ 0
+}

--- a/compiler/tests/net_frames.nu
+++ b/compiler/tests/net_frames.nu
@@ -1,0 +1,267 @@
+// net_frames.nu — offline test for the sans-IO frame layers:
+// stdlib/net/{eth,ipv4,arp,icmp,udp4}.nu. Deterministic, no sockets,
+// no clock — every timing input is scripted.
+//
+// The load-bearing cases here are the ones that silently corrupt a
+// hand-rolled stack rather than failing loudly:
+//   * Ethernet pads short frames to 60 bytes → the IP payload length
+//     must come from total_len, never from the frame length.
+//   * A UDP checksum that computes to 0 must go on the wire as 0xffff.
+//   * Fragments must be rejected distinctly, not parsed as whole
+//     datagrams.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/eth.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/arp.nu`
+$ `stdlib/net/icmp.nu`
+$ `stdlib/net/udp4.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ our_mac → i { ^ 2199023255553 }  // 02:00:00:00:00:01
+
+@ peer_mac → i { ^ 2199023255554 }  // 02:00:00:00:00:02
+
+@ our_ip → i { ^ ( ipv4_make 10 0 2 15 ) }
+
+@ peer_ip → i { ^ ( ipv4_make 10 0 2 2 ) }
+
+// Build a full Ethernet+IPv4 frame carrying `payload`, as a peer would.
+@ mk_ip_frame i proto ( Vec u ) payload i pad_to → ( Vec u ) {
+    : ( Vec u ) f ( vec_new [u] )
+    ( eth_push_header f ( our_mac ) ( peer_mac ) ( ethertype_ipv4 ) )
+    ( ip4_push_header f ( peer_ip ) ( our_ip ) proto ( vec_len [u] payload ) 4660 64 T )
+    ( vec_extend [u] f payload )
+    // Ethernet pads to a 60-byte minimum frame — emulate the wire.
+    ~ < ( vec_len [u] f ) pad_to { ( vec_push [u] f # u 0 ) }
+    ^ f
+}
+
+@ main → i {
+    // ── Ethernet ─────────────────────────────────────────────────
+    : ( Vec u ) small ( vec_new [u] )
+    ( eth_push_header small ( our_mac ) ( peer_mac ) ( ethertype_arp ) )
+    : EthHdr eh ( eth_parse small )
+    ( pb `eth parse valid: ` . eh valid )
+    ( pb `eth dst: ` == . eh dst ( our_mac ) )
+    ( pb `eth src: ` == . eh src ( peer_mac ) )
+    ( pb `eth type arp: ` == . eh ethertype ( ethertype_arp ) )
+    ( pb `eth payload off: ` == . eh payload_off 14 )
+    : ( Vec u ) runt ( vec_new [u] )
+    ( vec_push [u] runt # u 1 )
+    ( pb `eth runt rejected: ` ! . ( eth_parse runt ) valid )
+    ( pb `addressed to us: ` ( eth_addressed_to_us ( our_mac ) ( our_mac ) ) )
+    ( pb `broadcast to us: ` ( eth_addressed_to_us ( mac_broadcast ) ( our_mac ) ) )
+    ( pb `other unicast not ours: ` ! ( eth_addressed_to_us ( peer_mac ) ( our_mac ) ) )
+
+    // ── IPv4 with Ethernet padding (the trap) ────────────────────
+    // 4-byte UDP payload → 12-byte UDP datagram → 32-byte IP datagram
+    // → 46-byte frame, padded to 60. total_len says 32.
+    : ( Vec u ) udp_pay ( vec_new [u] )
+    ( vec_push [u] udp_pay # u 222 ) ( vec_push [u] udp_pay # u 173 )
+    ( vec_push [u] udp_pay # u 190 ) ( vec_push [u] udp_pay # u 239 )
+    : ( Vec u ) udp_dg ( vec_new [u] )
+    ( udp4_push udp_dg ( peer_ip ) ( our_ip ) 4242 53 udp_pay 0 4 )
+    : ( Vec u ) padded ( mk_ip_frame ( ip_proto_udp ) udp_dg 60 )
+    ( pb `padded frame is 60 bytes: ` == ( vec_len [u] padded ) 60 )
+    : EthHdr peh ( eth_parse padded )
+    : Ip4Hdr ph ( ip4_parse padded . peh payload_off . peh payload_len )
+    ( pb `ip parse valid: ` . ph valid )
+    ( pb `ip src: ` == . ph src ( peer_ip ) )
+    ( pb `ip dst: ` == . ph dst ( our_ip ) )
+    ( pb `ip proto udp: ` == . ph proto ( ip_proto_udp ) )
+    // THE TRAP: eth payload_len is 46, but the IP payload is 12.
+    ( pb `eth payload_len is padded (46): ` == . peh payload_len 46 )
+    ( pb `ip payload_len from total_len (12): ` == . ph payload_len 12 )
+    : Udp4Hdr uh ( udp4_parse padded . ph payload_off . ph payload_len . ph src . ph dst )
+    ( pb `udp parse valid: ` . uh valid )
+    ( pb `udp src port: ` == . uh src_port 4242 )
+    ( pb `udp dst port: ` == . uh dst_port 53 )
+    ( pb `udp payload_len is 4, not padding: ` == . uh payload_len 4 )
+    ( pb `udp payload byte 0: ` == ?? ( vec_get [u] padded . uh payload_off ) { T x → # i x F → 0 } 222 )
+    ( pb `udp payload byte 3: ` == ?? ( vec_get [u] padded + . uh payload_off 3 ) { T x → # i x F → 0 } 239 )
+
+    // Feeding the *padded* length to udp4_parse must still work — the
+    // length rule lives in the UDP header too.
+    : Udp4Hdr uh2 ( udp4_parse padded . ph payload_off 46 . ph src . ph dst )
+    ( pb `udp ignores trailing padding: ` && . uh2 valid == . uh2 payload_len 4 )
+
+    // ── IPv4 rejections ──────────────────────────────────────────
+    : ( Vec u ) bad ( mk_ip_frame ( ip_proto_udp ) udp_dg 60 )
+    : b _c ( vec_set [u] bad 24 # u 255 )  // corrupt the IP checksum field
+    ( pb `bad ip checksum rejected: ` == . ( ip4_parse bad 14 46 ) reason ( ip4_err_checksum ) )
+
+    : ( Vec u ) frag ( mk_ip_frame ( ip_proto_udp ) udp_dg 60 )
+    : b _f ( vec_set [u] frag 20 # u 32 )  // set MF in flags/frag field
+    // recompute the header checksum so it fails *as a fragment*, not
+    // as a checksum error — otherwise the test proves nothing.
+    : b _f2 ( vec_set [u] frag 24 # u 0 )
+    : b _f3 ( vec_set [u] frag 25 # u 0 )
+    : i fck ( inet_checksum frag 14 20 )
+    : b _f4 ( vec_set [u] frag 24 # u & >> fck 8 255 )
+    : b _f5 ( vec_set [u] frag 25 # u & fck 255 )
+    ( pb `fragment rejected distinctly: ` == . ( ip4_parse frag 14 46 ) reason ( ip4_err_fragment ) )
+
+    : ( Vec u ) trunc ( vec_new [u] )
+    ( eth_push_header trunc ( our_mac ) ( peer_mac ) ( ethertype_ipv4 ) )
+    ( ip4_push_header trunc ( peer_ip ) ( our_ip ) ( ip_proto_udp ) 100 4660 64 T )
+    ( pb `truncated (total_len > avail) rejected: ` == . ( ip4_parse trunc 14 20 ) reason ( ip4_err_truncated ) )
+
+    // ── ICMP echo round-trip ─────────────────────────────────────
+    : ( Vec u ) echo_pay ( vec_new [u] )
+    : ~ i k 0
+    ~ < k 32 { ( vec_push [u] echo_pay # u + 97 % k 26 ) = k + k 1 }
+    : ( Vec u ) icmp_msg ( vec_new [u] )
+    ( icmp_push icmp_msg ( icmp_echo_request ) 0 4919 7 echo_pay 0 32 )
+    : ( Vec u ) ping ( mk_ip_frame ( ip_proto_icmp ) icmp_msg 60 )
+    : EthHdr peh2 ( eth_parse ping )
+    : Ip4Hdr pih ( ip4_parse ping . peh2 payload_off . peh2 payload_len )
+    : IcmpMsg im ( icmp_parse ping . pih payload_off . pih payload_len )
+    ( pb `icmp parse valid: ` . im valid )
+    ( pb `icmp is echo request: ` == . im mtype ( icmp_echo_request ) )
+    ( pb `icmp id: ` == . im id 4919 )
+    ( pb `icmp seq: ` == . im seq 7 )
+    ( pb `icmp payload_len: ` == . im payload_len 32 )
+
+    // Build the reply the way the stack will, then parse it back.
+    : ( Vec u ) reply_icmp ( vec_new [u] )
+    ( icmp_push_echo_reply reply_icmp im ping )
+    : ( Vec u ) reply ( vec_new [u] )
+    ( eth_push_header reply ( peer_mac ) ( our_mac ) ( ethertype_ipv4 ) )
+    ( ip4_push_header reply ( our_ip ) ( peer_ip ) ( ip_proto_icmp ) ( vec_len [u] reply_icmp ) 4661 64 T )
+    ( vec_extend [u] reply reply_icmp )
+    : EthHdr reh ( eth_parse reply )
+    : Ip4Hdr rih ( ip4_parse reply . reh payload_off . reh payload_len )
+    : IcmpMsg rim ( icmp_parse reply . rih payload_off . rih payload_len )
+    ( pb `reply parses (checksum ok): ` . rim valid )
+    ( pb `reply is echo reply: ` == . rim mtype ( icmp_echo_reply ) )
+    ( pb `reply mirrors id: ` == . rim id 4919 )
+    ( pb `reply mirrors seq: ` == . rim seq 7 )
+    ( pb `reply mirrors payload len: ` == . rim payload_len 32 )
+    : ~ b same T
+    : ~ i j 0
+    ~ < j 32 {
+        : i a ?? ( vec_get [u] ping + . im payload_off j ) { T x → # i x F → -1 }
+        : i b ?? ( vec_get [u] reply + . rim payload_off j ) { T x → # i x F → -2 }
+        ? != a b { = same F } {}
+        = j + j 1
+    }
+    ( pb `reply mirrors payload bytes: ` same )
+    ( pb `reply src/dst swapped: ` && == . rih src ( our_ip ) == . rih dst ( peer_ip ) )
+
+    // Corrupting the ICMP payload must break its checksum.
+    : b _ic ( vec_set [u] reply + . rim payload_off 5 # u 0 )
+    ( pb `corrupt icmp rejected: ` ! . ( icmp_parse reply . rih payload_off . rih payload_len ) valid )
+
+    // ── UDP checksum: the 0 → 0xffff rule ────────────────────────
+    // Sweep 2-byte payloads. Two invariants: the transmitted checksum
+    // is never 0x0000, and every datagram we emit verifies on receive.
+    // The sweep must also actually HIT the substitution case, or it
+    // would pass on a stack that never implemented the rule.
+    : ~ b never_zero T
+    : ~ b all_verify T
+    : ~ i hits 0
+    : ~ i p 0
+    ~ < p 65536 {
+        : ( Vec u ) sp ( vec_new [u] )
+        ( vec_push [u] sp # u >> p 8 )
+        ( vec_push [u] sp # u & p 255 )
+        : ( Vec u ) dg ( vec_new [u] )
+        ( udp4_push dg ( peer_ip ) ( our_ip ) 1234 5678 sp 0 2 )
+        : i ck ?? ( bytes_read_u16_be dg 6 ) { T x → # i x F → -1 }
+        ? == ck 0 { = never_zero F } {}
+        ? == ck 65535 { = hits + hits 1 } {}
+        : Udp4Hdr vh ( udp4_parse dg 0 10 ( peer_ip ) ( our_ip ) )
+        ? ! . vh valid { = all_verify F } {}
+        ( vec_free [u] sp )
+        ( vec_free [u] dg )
+        = p + p 1
+    }
+    ( pb `udp checksum never transmitted as 0: ` never_zero )
+    ( pb `every emitted udp datagram verifies: ` all_verify )
+    ( pb `sweep exercised the 0xffff substitution: ` > hits 0 )
+
+    // Receive side: checksum 0 means "not computed" and is accepted.
+    : ( Vec u ) nock ( vec_new [u] )
+    ( udp4_push nock ( peer_ip ) ( our_ip ) 1 2 udp_pay 0 4 )
+    : b _n1 ( vec_set [u] nock 6 # u 0 )
+    : b _n2 ( vec_set [u] nock 7 # u 0 )
+    ( pb `udp checksum 0 accepted unverified: ` . ( udp4_parse nock 0 12 ( peer_ip ) ( our_ip ) ) valid )
+    // …but a WRONG non-zero checksum is rejected.
+    : b _n3 ( vec_set [u] nock 6 # u 1 )
+    ( pb `wrong udp checksum rejected: ` == . ( udp4_parse nock 0 12 ( peer_ip ) ( our_ip ) ) reason ( udp4_err_checksum ) )
+    // A length field larger than the bytes present is rejected.
+    : b _n4 ( vec_set [u] nock 4 # u 255 )
+    ( pb `udp bogus length rejected: ` == . ( udp4_parse nock 0 12 ( peer_ip ) ( our_ip ) ) reason ( udp4_err_length ) )
+
+    // ── ARP wire format ──────────────────────────────────────────
+    : ( Vec u ) req ( vec_new [u] )
+    ( arp_push_request req ( our_mac ) ( our_ip ) ( peer_ip ) )
+    ( pb `arp request frame len 42: ` == ( vec_len [u] req ) 42 )
+    : EthHdr aeh ( eth_parse req )
+    ( pb `arp request is broadcast: ` ( mac_is_broadcast . aeh dst ) )
+    ( pb `arp ethertype: ` == . aeh ethertype ( ethertype_arp ) )
+    : ArpPkt ap ( arp_parse req . aeh payload_off . aeh payload_len )
+    ( pb `arp parse valid: ` . ap valid )
+    ( pb `arp op request: ` == . ap op ( arp_op_request ) )
+    ( pb `arp sender mac: ` == . ap sender_mac ( our_mac ) )
+    ( pb `arp sender ip: ` == . ap sender_ip ( our_ip ) )
+    ( pb `arp target ip: ` == . ap target_ip ( peer_ip ) )
+    ( pb `arp target mac unknown: ` == . ap target_mac 0 )
+
+    : ( Vec u ) rep ( vec_new [u] )
+    ( arp_push_reply rep ( peer_mac ) ( peer_ip ) ( our_mac ) ( our_ip ) )
+    : EthHdr reh2 ( eth_parse rep )
+    ( pb `arp reply unicast to us: ` == . reh2 dst ( our_mac ) )
+    : ArpPkt ap2 ( arp_parse rep . reh2 payload_off . reh2 payload_len )
+    ( pb `arp reply op: ` == . ap2 op ( arp_op_reply ) )
+    ( pb `arp reply sender is peer: ` && == . ap2 sender_mac ( peer_mac ) == . ap2 sender_ip ( peer_ip ) )
+    ( pb `arp reply target is us: ` && == . ap2 target_mac ( our_mac ) == . ap2 target_ip ( our_ip ) )
+
+    // Non-Ethernet/IPv4 ARP must be rejected, not mis-parsed.
+    : b _a1 ( vec_set [u] rep 14 # u 0 )
+    : b _a2 ( vec_set [u] rep 15 # u 6 )  // hardware type 6 = token ring
+    ( pb `foreign arp htype rejected: ` ! . ( arp_parse rep 14 28 ) valid )
+
+    // ── ARP cache with a scripted clock ──────────────────────────
+    : *ArpCache c ( arp_cache_new 4 )
+    ( pb `cold lookup misses: ` ?? ( arp_cache_lookup c ( peer_ip ) 1000 ) { T m → F F → T } )
+    ( pb `first send asks: ` ( arp_cache_should_request c ( peer_ip ) 1000 ) )
+    ( pb `immediate retry suppressed: ` ! ( arp_cache_should_request c ( peer_ip ) 1100 ) )
+    ( pb `retry after 1s allowed: ` ( arp_cache_should_request c ( peer_ip ) 2000 ) )
+    ( pb `not failed yet: ` ! ( arp_cache_failed c ( peer_ip ) 2000 ) )
+    ( pb `third retry allowed: ` ( arp_cache_should_request c ( peer_ip ) 3100 ) )
+    ( pb `fourth suppressed (max retries): ` ! ( arp_cache_should_request c ( peer_ip ) 4200 ) )
+    ( pb `now reported failed: ` ( arp_cache_failed c ( peer_ip ) 4200 ) )
+    ( arp_cache_insert c ( peer_ip ) ( peer_mac ) 5000 )
+    ( pb `resolved lookup hits: ` ?? ( arp_cache_lookup c ( peer_ip ) 5000 ) { T m → == m ( peer_mac ) F → F } )
+    ( pb `resolved stops requests: ` ! ( arp_cache_should_request c ( peer_ip ) 9000 ) )
+    ( pb `no longer failed: ` ! ( arp_cache_failed c ( peer_ip ) 9000 ) )
+    ( pb `lookup after ttl misses: ` ?? ( arp_cache_lookup c ( peer_ip ) 70000 ) { T m → F F → T } )
+    ( pb `expire reclaims 1: ` == ( arp_cache_expire c 70000 ) 1 )
+    ( pb `expire again reclaims 0: ` == ( arp_cache_expire c 70000 ) 0 )
+
+    // The table is bounded: filling past `max` must not grow it, so a
+    // remote peer cannot drive the cache into the whole heap.
+    : ~ i q 0
+    ~ < q 20 {
+        ( arp_cache_insert c ( ipv4_make 10 0 9 q ) + 1000 q 80000 )
+        = q + q 1
+    }
+    ( pb `cache stays bounded at max: ` == ( vec_len [ArpEntry] . c entries ) 4 )
+    ( pb `most recent insert survived: ` ?? ( arp_cache_lookup c ( ipv4_make 10 0 9 19 ) 80000 ) { T m → == m 1019 F → F } )
+    ( arp_cache_free c )
+
+    // Vec is a manually-managed handle (docs/MEMORY.md §7.4).
+    ( vec_free [u] small ) ( vec_free [u] runt ) ( vec_free [u] udp_pay )
+    ( vec_free [u] udp_dg ) ( vec_free [u] padded ) ( vec_free [u] bad )
+    ( vec_free [u] frag ) ( vec_free [u] trunc ) ( vec_free [u] echo_pay )
+    ( vec_free [u] icmp_msg ) ( vec_free [u] ping ) ( vec_free [u] reply_icmp )
+    ( vec_free [u] reply ) ( vec_free [u] nock ) ( vec_free [u] req )
+    ( vec_free [u] rep )
+    ^ 0
+}

--- a/compiler/tests/net_inet.nu
+++ b/compiler/tests/net_inet.nu
@@ -1,0 +1,110 @@
+// net_inet.nu — offline test for stdlib/net/inet.nu. Deterministic: RFC 1071
+// checksum against a real IPv4 header capture, plus the address parsers'
+// accept/reject boundaries. No sockets, no clock.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ hex s h → ( Vec u ) {
+    ^ ?? ( bytes_from_hex h ) { T v → v F e → ( vec_new [u] ) }
+}
+
+@ main → i {
+    // ── RFC 1071 checksum, real IPv4 header ──────────────────────
+    // 45 00 00 73 00 00 40 00 40 11 c0a80001 c0a800c7, checksum b861.
+    // Header with the checksum field zeroed → the checksum must come
+    // out as 0xb861.
+    : ( Vec u ) hdr ( hex `450000730000400040110000c0a80001c0a800c7` )
+    ( pb `ipv4 header checksum = 0xb861: ` == ( inet_checksum hdr 0 20 ) 47201 )
+
+    // Verification property: summing the header *including* a correct
+    // checksum folds to 0xffff. This is the receive-side check, and it
+    // is a different code path than generation — worth its own case.
+    : ( Vec u ) hdr2 ( hex `45000073000040004011b861c0a80001c0a800c7` )
+    ( pb `verify folds to 0xffff: ` == ( inet_fold ( inet_sum hdr2 0 20 ) ) 65535 )
+
+    // Odd length: trailing byte is right-padded with zero.
+    : ( Vec u ) odd ( hex `0102030405` )
+    // 0x0102 + 0x0304 + 0x0500 = 0x0906 → complement 0xf6f9
+    ( pb `odd-length pad: ` == ( inet_checksum odd 0 5 ) 63225 )
+
+    // Empty range sums to zero → checksum 0xffff.
+    ( pb `empty range: ` == ( inet_checksum odd 0 0 ) 65535 )
+
+    // Carry folding: two words that overflow 16 bits.
+    // 0xffff + 0xffff = 0x1fffe → fold → 0xffff → complement 0
+    : ( Vec u ) carry ( hex `ffffffff` )
+    ( pb `carry folds: ` == ( inet_checksum carry 0 4 ) 0 )
+
+    // Incremental accumulation must equal one-shot over the whole
+    // buffer — this is what makes pseudo-header checksums possible.
+    : i split ( inet_sum_add ( inet_sum hdr 0 8 ) hdr 8 12 )
+    ( pb `split sum == one-shot: ` == ( inet_finish split ) ( inet_checksum hdr 0 20 ) )
+
+    // Pseudo-header helpers accumulate the same way as raw bytes would.
+    // u32 0xc0a80001 == bytes c0 a8 00 01.
+    : ( Vec u ) a4 ( hex `c0a80001` )
+    ( pb `sum_u32 == byte sum: ` == ( inet_sum_u32 0 3232235521 ) ( inet_sum a4 0 4 ) )
+    : ( Vec u ) p16 ( hex `0011` )
+    ( pb `sum_u16 == byte sum: ` == ( inet_sum_u16 0 17 ) ( inet_sum p16 0 2 ) )
+
+    // Vec is a manually-managed handle (docs/MEMORY.md §7.4) — freeing
+    // here keeps this test clean under LSAN_DETECT_LEAKS=1.
+    ( vec_free [u] hdr ) ( vec_free [u] hdr2 ) ( vec_free [u] odd )
+    ( vec_free [u] carry ) ( vec_free [u] a4 ) ( vec_free [u] p16 )
+
+    // ── IPv4 addresses ───────────────────────────────────────────
+    ( pb `make 10.0.2.15: ` == ( ipv4_make 10 0 2 15 ) 167772687 )
+    ( pb `octet 0: ` == ( ipv4_octet ( ipv4_make 10 0 2 15 ) 0 ) 10 )
+    ( pb `octet 3: ` == ( ipv4_octet ( ipv4_make 10 0 2 15 ) 3 ) 15 )
+    : String astr ( ipv4_str ( ipv4_make 192 168 1 200 ) )
+    ( pb `str round-trip: ` ( nurl_str_eq ( string_data astr ) `192.168.1.200` ) )
+    ( string_free astr )
+
+    ( pb `parse 10.0.2.15: ` ?? ( ipv4_parse `10.0.2.15` ) { T a → == a 167772687 F → F } )
+    ( pb `parse 0.0.0.0: ` ?? ( ipv4_parse `0.0.0.0` ) { T a → == a 0 F → F } )
+    ( pb `parse 255.255.255.255: ` ?? ( ipv4_parse `255.255.255.255` ) { T a → == a 4294967295 F → F } )
+
+    // Rejections — a lax parser here would silently connect elsewhere.
+    ( pb `reject 256.0.0.1: ` ?? ( ipv4_parse `256.0.0.1` ) { T a → F F → T } )
+    ( pb `reject 1.2.3: ` ?? ( ipv4_parse `1.2.3` ) { T a → F F → T } )
+    ( pb `reject 1.2.3.4.5: ` ?? ( ipv4_parse `1.2.3.4.5` ) { T a → F F → T } )
+    ( pb `reject 1.2.3.: ` ?? ( ipv4_parse `1.2.3.` ) { T a → F F → T } )
+    ( pb `reject .1.2.3: ` ?? ( ipv4_parse `.1.2.3` ) { T a → F F → T } )
+    ( pb `reject 1..2.3: ` ?? ( ipv4_parse `1..2.3` ) { T a → F F → T } )
+    ( pb `reject empty: ` ?? ( ipv4_parse `` ) { T a → F F → T } )
+    ( pb `reject 1.2.3.4x: ` ?? ( ipv4_parse `1.2.3.4x` ) { T a → F F → T } )
+    ( pb `reject 0300.1.2.3: ` ?? ( ipv4_parse `0300.1.2.3` ) { T a → F F → T } )
+
+    // ── subnets ──────────────────────────────────────────────────
+    ( pb `mask /24: ` == ( ipv4_mask_from_prefix 24 ) 4294967040 )
+    ( pb `mask /0: ` == ( ipv4_mask_from_prefix 0 ) 0 )
+    ( pb `mask /32: ` == ( ipv4_mask_from_prefix 32 ) 4294967295 )
+    ( pb `in subnet: ` ( ipv4_in_subnet ( ipv4_make 10 0 2 15 ) ( ipv4_make 10 0 2 0 ) 4294967040 ) )
+    ( pb `not in subnet: ` ! ( ipv4_in_subnet ( ipv4_make 10 0 3 15 ) ( ipv4_make 10 0 2 0 ) 4294967040 ) )
+    ( pb `subnet broadcast: ` == ( ipv4_subnet_broadcast ( ipv4_make 10 0 2 0 ) 4294967040 ) ( ipv4_make 10 0 2 255 ) )
+    ( pb `is broadcast: ` ( ipv4_is_broadcast 4294967295 ) )
+    ( pb `is multicast 224.0.0.251: ` ( ipv4_is_multicast ( ipv4_make 224 0 0 251 ) ) )
+    ( pb `not multicast 10.0.0.1: ` ! ( ipv4_is_multicast ( ipv4_make 10 0 0 1 ) ) )
+
+    // ── MAC ──────────────────────────────────────────────────────
+    ( pb `parse mac: ` ?? ( mac_parse `02:00:00:00:00:01` ) { T m → == m 2199023255553 F → F } )
+    ( pb `parse mac dashes: ` ?? ( mac_parse `02-00-00-00-00-01` ) { T m → == m 2199023255553 F → F } )
+    ( pb `parse mac upper: ` ?? ( mac_parse `AA:BB:CC:DD:EE:FF` ) { T m → == m 187723572702975 F → F } )
+    ( pb `reject short mac: ` ?? ( mac_parse `02:00:00:00:01` ) { T m → F F → T } )
+    ( pb `reject bad sep: ` ?? ( mac_parse `02x00:00:00:00:01` ) { T m → F F → T } )
+    ( pb `reject non-hex: ` ?? ( mac_parse `0g:00:00:00:00:01` ) { T m → F F → T } )
+    : String mstr ( mac_str 2199023255553 )
+    ( pb `mac str round-trip: ` ( nurl_str_eq ( string_data mstr ) `02:00:00:00:00:01` ) )
+    ( string_free mstr )
+    ( pb `mac octet 0: ` == ( mac_octet 2199023255553 0 ) 2 )
+    ( pb `mac octet 5: ` == ( mac_octet 2199023255553 5 ) 1 )
+    ( pb `broadcast mac: ` ( mac_is_broadcast ( mac_broadcast ) ) )
+    ( pb `broadcast is multicast: ` ( mac_is_multicast ( mac_broadcast ) ) )
+    ( pb `unicast not multicast: ` ! ( mac_is_multicast 2199023255553 ) )
+    ^ 0
+}

--- a/compiler/tests/net_stack.nu
+++ b/compiler/tests/net_stack.nu
@@ -1,0 +1,239 @@
+// net_stack.nu — Phase A1a acceptance test for stdlib/net/stack.nu.
+//
+// Two sans-IO stacks are wired frame-to-frame in memory, with a
+// scripted clock, and made to complete the exchanges a real host does:
+// ARP resolution, a UDP round-trip, a ping answered, and routing via a
+// gateway for an off-link destination. No sockets, no device, no
+// wall clock — the same code that will later sit behind virtio-net.
+//
+// Also pins the drop accounting: every frame the stack discards must
+// land in exactly one labelled bucket, so a driver can report honest
+// counters instead of "some packets go missing".
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/eth.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/arp.nu`
+$ `stdlib/net/icmp.nu`
+$ `stdlib/net/udp4.nu`
+$ `stdlib/net/stack.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ mac_a → i { ^ 2199023255553 }  // 02:00:00:00:00:01
+
+@ mac_b → i { ^ 2199023255554 }  // 02:00:00:00:00:02
+
+@ mac_gw → i { ^ 2199023255807 }  // 02:00:00:00:00:ff
+
+@ ip_a → i { ^ ( ipv4_make 10 0 2 15 ) }
+
+@ ip_b → i { ^ ( ipv4_make 10 0 2 16 ) }
+
+@ ip_gw → i { ^ ( ipv4_make 10 0 2 1 ) }
+
+@ mask24 → i { ^ 4294967040 }
+
+// Move everything in `wire` into `dst` stack, returning the number of
+// frames delivered. One frame per buffer keeps the harness honest —
+// the real driver hands over one frame at a time too.
+@ deliver * NetStack dst ( Vec u ) wire i now ( Vec u ) reply → RxResult {
+    ^ ( stack_rx dst wire now reply )
+}
+
+@ main → i {
+    : *NetStack a ( stack_new ( mac_a ) ( ip_a ) ( mask24 ) ( ip_gw ) )
+    : *NetStack b ( stack_new ( mac_b ) ( ip_b ) ( mask24 ) ( ip_gw ) )
+
+    : ( Vec u ) payload ( vec_new [u] )
+    ( bytes_extend_str payload `hello unikernel` )
+
+    // ── A sends UDP to B: ARP must resolve first ─────────────────
+    : ( Vec u ) w1 ( vec_new [u] )
+    : TxResult t1 ( stack_tx_udp a ( ip_b ) 4000 7000 payload 0 15 1000 w1 )
+    ( pb `first send is ARP-pending: ` == . t1 status ( tx_arp_pending ) )
+    ( pb `an ARP request was emitted: ` > . t1 emitted 0 )
+    ( pb `ARP request is 42 bytes: ` == ( vec_len [u] w1 ) 42 )
+
+    // B receives the ARP request and answers it.
+    : ( Vec u ) w2 ( vec_new [u] )
+    : RxResult r1 ( deliver b w1 1000 w2 )
+    ( pb `B handled the ARP: ` == . r1 kind ( rx_arp_handled ) )
+    ( pb `B emitted a reply: ` > ( vec_len [u] w2 ) 0 )
+    ( pb `B learned A's address: ` ?? ( arp_cache_lookup . b arp ( ip_a ) 1000 ) { T m → == m ( mac_a ) F → F } )
+
+    // A receives the reply and learns B.
+    : ( Vec u ) w3 ( vec_new [u] )
+    : RxResult r2 ( deliver a w2 1000 w3 )
+    ( pb `A handled the ARP reply: ` == . r2 kind ( rx_arp_handled ) )
+    ( pb `A emitted nothing back: ` == ( vec_len [u] w3 ) 0 )
+    ( pb `A learned B's address: ` ?? ( arp_cache_lookup . a arp ( ip_b ) 1000 ) { T m → == m ( mac_b ) F → F } )
+
+    // ── retry: now the datagram actually goes out ────────────────
+    : ( Vec u ) w4 ( vec_new [u] )
+    : TxResult t2 ( stack_tx_udp a ( ip_b ) 4000 7000 payload 0 15 1000 w4 )
+    ( pb `retry sends for real: ` == . t2 status ( tx_sent ) )
+    // 14 eth + 20 ip + 8 udp + 15 payload = 57
+    ( pb `frame is 57 bytes: ` == ( vec_len [u] w4 ) 57 )
+
+    : ( Vec u ) w5 ( vec_new [u] )
+    : RxResult r3 ( deliver b w4 1000 w5 )
+    ( pb `B received a UDP datagram: ` == . r3 kind ( rx_udp ) )
+    ( pb `src ip is A: ` == . r3 src_ip ( ip_a ) )
+    ( pb `dst ip is B: ` == . r3 dst_ip ( ip_b ) )
+    ( pb `src port: ` == . r3 src_port 4000 )
+    ( pb `dst port: ` == . r3 dst_port 7000 )
+    ( pb `payload length: ` == . r3 payload_len 15 )
+    : ~ b pay_ok T
+    : ~ i k 0
+    ~ < k 15 {
+        : i got ?? ( vec_get [u] w4 + . r3 payload_off k ) { T x → # i x F → -1 }
+        : i want ?? ( vec_get [u] payload k ) { T x → # i x F → -2 }
+        ? != got want { = pay_ok F } {}
+        = k + k 1
+    }
+    ( pb `payload bytes survive the round trip: ` pay_ok )
+
+    // ── B replies to A: no ARP needed, B already learned A ───────
+    : ( Vec u ) w6 ( vec_new [u] )
+    : TxResult t3 ( stack_tx_udp b ( ip_a ) 7000 4000 payload 0 15 1100 w6 )
+    ( pb `reply needs no new ARP: ` == . t3 status ( tx_sent ) )
+    : ( Vec u ) w7 ( vec_new [u] )
+    : RxResult r4 ( deliver a w6 1100 w7 )
+    ( pb `A received the reply: ` == . r4 kind ( rx_udp ) )
+    ( pb `reply ports swapped: ` && == . r4 src_port 7000 == . r4 dst_port 4000 )
+
+    // ── ping: B pings A, A must answer ───────────────────────────
+    : ( Vec u ) echo_pay ( vec_new [u] )
+    : ~ i e 0
+    ~ < e 24 { ( vec_push [u] echo_pay # u + 65 % e 26 ) = e + e 1 }
+    : ( Vec u ) icmp_msg ( vec_new [u] )
+    ( icmp_push icmp_msg ( icmp_echo_request ) 0 999 3 echo_pay 0 24 )
+    : ( Vec u ) ping ( vec_new [u] )
+    ( eth_push_header ping ( mac_a ) ( mac_b ) ( ethertype_ipv4 ) )
+    ( ip4_push_header ping ( ip_b ) ( ip_a ) ( ip_proto_icmp ) ( vec_len [u] icmp_msg ) 77 64 T )
+    ( vec_extend [u] ping icmp_msg )
+
+    : ( Vec u ) pong ( vec_new [u] )
+    : RxResult r5 ( deliver a ping 1200 pong )
+    ( pb `A answered the ping: ` == . r5 kind ( rx_icmp_echo ) )
+    ( pb `a reply frame was emitted: ` > ( vec_len [u] pong ) 0 )
+
+    // Parse the answer the way the pinging host would.
+    : EthHdr peh ( eth_parse pong )
+    ( pb `pong addressed to B: ` == . peh dst ( mac_b ) )
+    : Ip4Hdr pih ( ip4_parse pong . peh payload_off . peh payload_len )
+    ( pb `pong ip valid (checksum ok): ` . pih valid )
+    ( pb `pong from A to B: ` && == . pih src ( ip_a ) == . pih dst ( ip_b ) )
+    : IcmpMsg pim ( icmp_parse pong . pih payload_off . pih payload_len )
+    ( pb `pong icmp valid (checksum ok): ` . pim valid )
+    ( pb `pong is an echo reply: ` == . pim mtype ( icmp_echo_reply ) )
+    ( pb `pong mirrors id and seq: ` && == . pim id 999 == . pim seq 3 )
+    ( pb `pong mirrors payload length: ` == . pim payload_len 24 )
+    : ~ b echo_ok T
+    : ~ i j 0
+    ~ < j 24 {
+        : i got ?? ( vec_get [u] pong + . pim payload_off j ) { T x → # i x F → -1 }
+        : i want ?? ( vec_get [u] echo_pay j ) { T x → # i x F → -2 }
+        ? != got want { = echo_ok F } {}
+        = j + j 1
+    }
+    ( pb `pong mirrors payload bytes: ` echo_ok )
+
+    // ── routing: an off-link destination goes via the gateway ────
+    : ( Vec u ) w8 ( vec_new [u] )
+    : TxResult t4 ( stack_tx_udp a ( ipv4_make 8 8 8 8 ) 4000 53 payload 0 15 2000 w8 )
+    ( pb `off-link send is ARP-pending: ` == . t4 status ( tx_arp_pending ) )
+    : EthHdr geh ( eth_parse w8 )
+    : ArpPkt gap ( arp_parse w8 . geh payload_off . geh payload_len )
+    // THE POINT: we must ARP for the GATEWAY, not for 8.8.8.8.
+    ( pb `ARPs for the gateway, not the destination: ` == . gap target_ip ( ip_gw ) )
+
+    // Once the gateway answers, the datagram leaves with the gateway's
+    // MAC but 8.8.8.8 still in the IP header.
+    ( arp_cache_insert . a arp ( ip_gw ) ( mac_gw ) 2000 )
+    : ( Vec u ) w9 ( vec_new [u] )
+    : TxResult t5 ( stack_tx_udp a ( ipv4_make 8 8 8 8 ) 4000 53 payload 0 15 2000 w9 )
+    ( pb `off-link send now succeeds: ` == . t5 status ( tx_sent ) )
+    : EthHdr feh ( eth_parse w9 )
+    ( pb `ethernet dst is the gateway MAC: ` == . feh dst ( mac_gw ) )
+    : Ip4Hdr fih ( ip4_parse w9 . feh payload_off . feh payload_len )
+    ( pb `ip dst is still 8.8.8.8: ` == . fih dst ( ipv4_make 8 8 8 8 ) )
+
+    // ── unreachable: ARP gives up rather than queueing forever ───
+    : ( Vec u ) w10 ( vec_new [u] )
+    : TxResult u1 ( stack_tx_udp a ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 3000 w10 )
+    ( pb `unknown host: first attempt ARPs: ` == . u1 status ( tx_arp_pending ) )
+    : TxResult u2 ( stack_tx_udp a ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 4100 w10 )
+    : TxResult u3 ( stack_tx_udp a ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 5200 w10 )
+    : TxResult u4 ( stack_tx_udp a ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 6300 w10 )
+    ( pb `after max retries: unreachable: ` == . u4 status ( tx_unreachable ) )
+
+    // ── drop accounting ─────────────────────────────────────────
+    : ( Vec u ) junk ( vec_new [u] )
+    ( vec_push [u] junk # u 1 ) ( vec_push [u] junk # u 2 )
+    : ( Vec u ) sink ( vec_new [u] )
+    : RxResult d1 ( deliver a junk 5000 sink )
+    ( pb `runt frame dropped as bad_eth: ` && == . d1 kind ( rx_dropped ) == . d1 reason ( drop_bad_eth ) )
+
+    : ( Vec u ) elsewhere ( vec_new [u] )
+    ( eth_push_header elsewhere ( mac_gw ) ( mac_b ) ( ethertype_ipv4 ) )
+    ( ip4_push_header elsewhere ( ip_b ) ( ip_gw ) ( ip_proto_udp ) 0 1 64 T )
+    : RxResult d2 ( deliver a elsewhere 5000 sink )
+    ( pb `frame for another MAC dropped: ` == . d2 reason ( drop_not_for_us ) )
+
+    : ( Vec u ) v6 ( vec_new [u] )
+    ( eth_push_header v6 ( mac_a ) ( mac_b ) ( ethertype_ipv6 ) )
+    ( vec_push [u] v6 # u 96 )
+    : RxResult d3 ( deliver a v6 5000 sink )
+    ( pb `IPv6 dropped as unknown ethertype: ` == . d3 reason ( drop_unknown_ethertype ) )
+
+    // A fragment must be counted as a fragment, not as a bad packet —
+    // the two mean very different things when reading counters.
+    : ( Vec u ) fr ( vec_new [u] )
+    ( eth_push_header fr ( mac_a ) ( mac_b ) ( ethertype_ipv4 ) )
+    ( ip4_push_header fr ( ip_b ) ( ip_a ) ( ip_proto_udp ) 8 5 64 F )
+    : b _s1 ( vec_set [u] fr 20 # u 32 )  // MF
+    : b _s2 ( vec_set [u] fr 24 # u 0 )
+    : b _s3 ( vec_set [u] fr 25 # u 0 )
+    : i fck ( inet_checksum fr 14 20 )
+    : b _s4 ( vec_set [u] fr 24 # u & >> fck 8 255 )
+    : b _s5 ( vec_set [u] fr 25 # u & fck 255 )
+    : ~ i pad 0
+    ~ < pad 8 { ( vec_push [u] fr # u 0 ) = pad + pad 1 }
+    : RxResult d4 ( deliver a fr 5000 sink )
+    ( pb `fragment counted as fragment: ` == . d4 reason ( drop_fragment ) )
+
+    ( pb `bad_eth counter is 1: ` == ( stack_drop_count a ( drop_bad_eth ) ) 1 )
+    ( pb `not_for_us counter is 1: ` == ( stack_drop_count a ( drop_not_for_us ) ) 1 )
+    ( pb `unknown_ethertype counter is 1: ` == ( stack_drop_count a ( drop_unknown_ethertype ) ) 1 )
+    ( pb `fragment counter is 1: ` == ( stack_drop_count a ( drop_fragment ) ) 1 )
+    ( pb `no spurious bad_udp drops: ` == ( stack_drop_count a ( drop_bad_udp ) ) 0 )
+
+    // ── addressless stack (pre-DHCP) ────────────────────────────
+    : *NetStack c ( stack_new ( mac_gw ) 0 0 0 )
+    : ( Vec u ) w11 ( vec_new [u] )
+    : TxResult t6 ( stack_tx_udp c ( ip_a ) 68 67 payload 0 15 100 w11 )
+    ( pb `no address → tx refused: ` == . t6 status ( tx_no_address ) )
+    // …but a broadcast datagram from 0.0.0.0 still goes out: that is
+    // exactly the shape DHCP DISCOVER needs.
+    : i n_bc ( stack_tx_udp_broadcast c 0 68 67 4294967295 payload 0 15 w11 )
+    ( pb `broadcast from 0.0.0.0 works: ` > n_bc 0 )
+    : EthHdr bceh ( eth_parse w11 )
+    ( pb `DHCP-shaped frame is broadcast: ` ( mac_is_broadcast . bceh dst ) )
+    ( stack_free c )
+
+    ( stack_free a )
+    ( stack_free b )
+    ( vec_free [u] payload ) ( vec_free [u] w1 ) ( vec_free [u] w2 )
+    ( vec_free [u] w3 ) ( vec_free [u] w4 ) ( vec_free [u] w5 )
+    ( vec_free [u] w6 ) ( vec_free [u] w7 ) ( vec_free [u] w8 )
+    ( vec_free [u] w9 ) ( vec_free [u] w10 ) ( vec_free [u] w11 )
+    ( vec_free [u] echo_pay ) ( vec_free [u] icmp_msg ) ( vec_free [u] ping )
+    ( vec_free [u] pong ) ( vec_free [u] junk ) ( vec_free [u] sink )
+    ( vec_free [u] elsewhere ) ( vec_free [u] v6 ) ( vec_free [u] fr )
+    ^ 0
+}

--- a/compiler/tests/net_tcp.nu
+++ b/compiler/tests/net_tcp.nu
@@ -1,0 +1,343 @@
+// net_tcp.nu — Phase A1b test for stdlib/net/{tcpseg,tcp}.nu.
+//
+// Two sans-IO TCP connections wired segment-to-segment in memory under
+// a scripted clock. Covers the paths that only misbehave after hours
+// of real traffic — sequence wraparound, retransmission timeouts,
+// zero-window deadlock, TIME_WAIT — in microseconds.
+//
+// The harness delivers ONE segment at a time and can drop segments on
+// demand, which is how loss recovery gets tested without a network.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/tcpseg.nu`
+$ `stdlib/net/tcp.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ ip_c → i { ^ ( ipv4_make 10 0 2 15 ) }
+
+@ ip_s → i { ^ ( ipv4_make 10 0 2 16 ) }
+
+// Deliver segment `idx` of `from` into connection `to`. Returns how
+// many bytes `to` emitted in response.
+@ hand * TcpOut from i idx * TcpConn to * TcpOut reply i now i src_ip i dst_ip → i {
+    : i start ( tcpout_seg_start from idx )
+    : i len ( tcpout_seg_len from idx )
+    : TcpSeg sg ( tcpseg_parse . from bytes start len src_ip dst_ip )
+    ? ! . sg valid { ^ -1 } {}
+    ^ ( tcp_input to sg . from bytes now reply )
+}
+
+// Deliver every segment in `from` to `to`, then clear `from`.
+@ hand_all * TcpOut from * TcpConn to * TcpOut reply i now i src_ip i dst_ip → i {
+    : i n ( tcpout_count from )
+    : ~ i k 0
+    : ~ i bad 0
+    ~ < k n {
+        ? < ( hand from k to reply now src_ip dst_ip ) 0 { = bad + bad 1 } {}
+        = k + k 1
+    }
+    ( tcpout_clear from )
+    ^ bad
+}
+
+@ main → i {
+    // ── sequence arithmetic, including wraparound ────────────────
+    ( pb `seq_lt basic: ` ( seq_lt 100 200 ) )
+    ( pb `seq_gt basic: ` ( seq_gt 200 100 ) )
+    ( pb `seq_lt not reflexive: ` ! ( seq_lt 100 100 ) )
+    ( pb `seq_leq reflexive: ` ( seq_leq 100 100 ) )
+    // Across the 2^32 wrap: 0xFFFFFFF0 precedes 0x00000010.
+    ( pb `wrap: ffffff f0 < 10: ` ( seq_lt 4294967280 16 ) )
+    ( pb `wrap: 10 > fffffff0: ` ( seq_gt 16 4294967280 ) )
+    ( pb `wrap add crosses zero: ` == ( seq_add 4294967280 32 ) 16 )
+    ( pb `wrap diff is small: ` == ( seq_diff 16 4294967280 ) 32 )
+    ( pb `wrap diff negative: ` == ( seq_diff 4294967280 16 ) -32 )
+    // Half-space boundary: exactly 2^31 apart is "greater" one way.
+    ( pb `half-space boundary: ` ( seq_lt 0 2147483647 ) )
+    ( pb `beyond half-space flips: ` ( seq_gt 0 2147483649 ) )
+    ( pb `in window basic: ` ( seq_in_window 105 100 10 ) )
+    ( pb `window excludes end: ` ! ( seq_in_window 110 100 10 ) )
+    ( pb `window includes start: ` ( seq_in_window 100 100 10 ) )
+    ( pb `zero window holds nothing: ` ! ( seq_in_window 100 100 0 ) )
+    ( pb `window wraps: ` ( seq_in_window 5 4294967290 16 ) )
+
+    // ── segment codec ────────────────────────────────────────────
+    : ( Vec u ) buf ( vec_new [u] )
+    : ( Vec u ) pay ( vec_new [u] )
+    ( bytes_extend_str pay `GET / HTTP/1.1` )
+    ( tcpseg_push buf ( ip_c ) ( ip_s ) 12345 80 1000 2000 | ( tcp_ack ) ( tcp_psh ) 65535 1460 0 pay 0 14 )
+    : TcpSeg ps ( tcpseg_parse buf 0 ( vec_len [u] buf ) ( ip_c ) ( ip_s ) )
+    ( pb `segment parses: ` . ps valid )
+    ( pb `src port: ` == . ps src_port 12345 )
+    ( pb `dst port: ` == . ps dst_port 80 )
+    ( pb `seq: ` == . ps seq 1000 )
+    ( pb `ack: ` == . ps ack 2000 )
+    ( pb `payload len: ` == . ps payload_len 14 )
+    ( pb `no options on non-SYN: ` == . ps data_off 20 )
+    ( pb `seq_len counts payload: ` == ( tcpseg_seq_len ps ) 14 )
+    // Corrupting a payload byte must break the checksum.
+    : b _cp ( vec_set [u] buf 25 # u 0 )
+    ( pb `corrupt segment rejected: ` ! . ( tcpseg_parse buf 0 ( vec_len [u] buf ) ( ip_c ) ( ip_s ) ) valid )
+
+    // SYN carries MSS + window scale.
+    : ( Vec u ) synbuf ( vec_new [u] )
+    : ( Vec u ) empty ( vec_new [u] )
+    ( tcpseg_push synbuf ( ip_c ) ( ip_s ) 12345 80 5000 0 ( tcp_syn ) 65535 1460 7 empty 0 0 )
+    : TcpSeg syn ( tcpseg_parse synbuf 0 ( vec_len [u] synbuf ) ( ip_c ) ( ip_s ) )
+    ( pb `SYN parses: ` . syn valid )
+    ( pb `SYN carries options: ` == . syn data_off 28 )
+    ( pb `MSS option read: ` == . syn mss 1460 )
+    ( pb `window scale read: ` == . syn wscale 7 )
+    ( pb `SYN occupies 1 seq: ` == ( tcpseg_seq_len syn ) 1 )
+    ( pb `absent wscale is -1, not 0: ` == . ps wscale -1 )
+
+    // ── three-way handshake ──────────────────────────────────────
+    : *TcpConn cl ( tcp_new )
+    : *TcpConn sv ( tcp_new )
+    : *TcpOut oc ( tcpout_new )
+    : *TcpOut os ( tcpout_new )
+    ( tcp_listen sv ( ip_s ) 80 )
+    = . sv iss 700000
+    = . sv remote_ip ( ip_c )
+    ( tcp_connect cl ( ip_c ) 12345 ( ip_s ) 80 100000 0 oc )
+    ( pb `client sends one SYN: ` == ( tcpout_count oc ) 1 )
+    ( pb `client is SYN_SENT: ` == . cl state ( tcp_syn_sent ) )
+
+    : i _h1 ( hand_all oc sv os 1 ( ip_c ) ( ip_s ) )
+    ( pb `server is SYN_RCVD: ` == . sv state ( tcp_syn_rcvd ) )
+    ( pb `server sends SYN-ACK: ` == ( tcpout_count os ) 1 )
+    ( pb `server learned client MSS: ` == . sv mss 1460 )
+
+    : i _h2 ( hand_all os cl oc 2 ( ip_s ) ( ip_c ) )
+    ( pb `client is ESTABLISHED: ` ( tcp_is_established cl ) )
+    ( pb `client ACKs the SYN-ACK: ` == ( tcpout_count oc ) 1 )
+
+    : i _h3 ( hand_all oc sv os 3 ( ip_c ) ( ip_s ) )
+    ( pb `server is ESTABLISHED: ` ( tcp_is_established sv ) )
+    ( pb `handshake produced an RTT sample: ` > . cl srtt 0 )
+
+    // ── data transfer ────────────────────────────────────────────
+    : ( Vec u ) msg ( vec_new [u] )
+    ( bytes_extend_str msg `hello from the unikernel` )
+    ( pb `write accepts all 24 bytes: ` == ( tcp_write cl msg 0 24 65536 ) 24 )
+    : i _p1 ( tcp_pump cl 10 oc )
+    ( pb `one data segment emitted: ` == ( tcpout_count oc ) 1 )
+    : i _d1 ( hand_all oc sv os 10 ( ip_c ) ( ip_s ) )
+    ( pb `server queued 24 bytes: ` == ( tcp_recv_queue_len sv ) 24 )
+    : ( Vec u ) got ( vec_new [u] )
+    ( pb `read drains 24: ` == ( tcp_read sv got 100 ) 24 )
+    ( pb `receive queue now empty: ` == ( tcp_recv_queue_len sv ) 0 )
+    : ~ b same T
+    : ~ i k 0
+    ~ < k 24 {
+        : i a ?? ( vec_get [u] got k ) { T x → # i x F → -1 }
+        : i b ?? ( vec_get [u] msg k ) { T x → # i x F → -2 }
+        ? != a b { = same F } {}
+        = k + k 1
+    }
+    ( pb `bytes arrive intact: ` same )
+    // The server's ACK releases the client's send buffer.
+    : i _a1 ( hand_all os cl oc 12 ( ip_s ) ( ip_c ) )
+    ( pb `client send queue drained by ACK: ` == ( tcp_send_queue_len cl ) 0 )
+    ( pb `retransmit timer disarmed: ` == . cl rtx_deadline 0 )
+
+    // ── retransmission after loss ────────────────────────────────
+    ( pb `write 10 more: ` == ( tcp_write cl msg 0 10 65536 ) 10 )
+    : i _p2 ( tcp_pump cl 100 oc )
+    ( pb `data segment emitted: ` == ( tcpout_count oc ) 1 )
+    ( pb `rtx timer armed on send: ` > . cl rtx_deadline 0 )
+    // DROP it: clear the buffer without delivering.
+    ( tcpout_clear oc )
+    // Bind the timing to the connection's own RTO — a hard-coded
+    // millisecond here would only be testing the test's guess about
+    // Jacobson's estimator, not the retransmit logic.
+    : i deadline . cl rtx_deadline
+    : i rto_before . cl rto_ms
+    : i srtt_before_loss . cl srtt
+    ( pb `nothing retransmits before RTO: ` == ( tcp_tick cl - deadline 1 oc ) 0 )
+    : i rtx ( tcp_tick cl deadline oc )
+    ( pb `RTO fires a retransmit: ` > rtx 0 )
+    ( pb `retransmit count incremented: ` == . cl rtx_count 1 )
+    ( pb `RTO doubled on backoff: ` == . cl rto_ms * rto_before 2 )
+    ( pb `RTO respects the 200ms floor: ` >= rto_before ( tcp_rto_min_ms ) )
+    // This time let it through.
+    : i _d2 ( hand_all oc sv os deadline ( ip_c ) ( ip_s ) )
+    ( pb `server got the retransmitted data: ` == ( tcp_recv_queue_len sv ) 10 )
+    : i _a2 ( hand_all os cl oc deadline ( ip_s ) ( ip_c ) )
+    ( pb `client queue drained after recovery: ` == ( tcp_send_queue_len cl ) 0 )
+    ( pb `rtx count reset by good ACK: ` == . cl rtx_count 0 )
+    : i _dr ( tcp_read sv got 100 )
+
+    // Karn's rule: the ACK that finally arrives after a retransmit
+    // must NOT feed the RTT estimator — its timing is ambiguous (was
+    // it the original or the copy that got through?). Sampling it
+    // inflates SRTT without bound on a lossy path.
+    ( pb `retransmit cleared the RTT sample: ` == . cl rtt_seq -1 )
+    ( pb `SRTT unchanged by ambiguous ACK: ` == . cl srtt srtt_before_loss )
+
+    // ── zero window → persist probe ──────────────────────────────
+    // Force the peer's advertised window to zero, then queue data: it
+    // must not be sent, and a probe must eventually go out.
+    = . cl snd_wnd 0
+    ( pb `write while window is zero: ` == ( tcp_write cl msg 0 8 65536 ) 8 )
+    ( tcpout_clear oc )
+    : i _p3 ( tcp_pump cl 3000 oc )
+    ( pb `zero window blocks transmission: ` == ( tcpout_count oc ) 0 )
+    = . cl probe_deadline 3500
+    : i probe ( tcp_tick cl 3600 oc )
+    ( pb `persist timer emits a probe: ` > probe 0 )
+    ( pb `probe is exactly one byte: ` == ( tcpseg_seq_len ( tcpseg_parse . oc bytes ( tcpout_seg_start oc 0 ) ( tcpout_seg_len oc 0 ) ( ip_c ) ( ip_s ) ) ) 1 )
+    ( pb `probe interval backs off: ` > . cl probe_deadline 3600 )
+    ( tcpout_clear oc )
+    // Window reopens → the queued data flows.
+    = . cl snd_wnd 65535
+    : i _p4 ( tcp_pump cl 4000 oc )
+    ( pb `reopened window releases data: ` == ( tcpout_count oc ) 1 )
+
+    // ── out-of-window segment is ACKed, not swallowed ────────────
+    : ( Vec u ) oldbuf ( vec_new [u] )
+    ( tcpseg_push oldbuf ( ip_s ) ( ip_c ) 80 12345 ( seq_sub . cl rcv_nxt 5000 ) . cl snd_nxt ( tcp_ack ) 65535 0 0 empty 0 0 )
+    : TcpSeg oldseg ( tcpseg_parse oldbuf 0 ( vec_len [u] oldbuf ) ( ip_s ) ( ip_c ) )
+    ( tcpout_clear oc )
+    : i oldn ( tcp_input cl oldseg oldbuf 5000 oc )
+    ( pb `stale segment answered with an ACK: ` > oldn 0 )
+    ( pb `stale segment did not close us: ` ( tcp_is_established cl ) )
+
+    // ── RST on an ESTABLISHED connection ─────────────────────────
+    // Distinct code path from the SYN_SENT reset above: this one goes
+    // through the synchronised-state handler.
+    : ( Vec u ) rst2 ( vec_new [u] )
+    ( tcpseg_push rst2 ( ip_s ) ( ip_c ) 80 12345 . cl rcv_nxt . cl snd_nxt | ( tcp_rst ) ( tcp_ack ) 0 0 0 empty 0 0 )
+    : TcpSeg rseg2 ( tcpseg_parse rst2 0 ( vec_len [u] rst2 ) ( ip_s ) ( ip_c ) )
+    ( pb `established connection is up before RST: ` ( tcp_is_established cl ) )
+    ( tcpout_clear oc )
+    : i _rs ( tcp_input cl rseg2 rst2 5100 oc )
+    ( pb `in-window RST tears it down: ` ( tcp_is_closed cl ) )
+    ( pb `RST is not answered with a segment: ` == ( tcpout_count oc ) 0 )
+
+    // ── malformed TCP option must not hang the parser ────────────
+    // A length byte below 2 does not advance the option cursor. A
+    // parser that trusts it loops forever on a hostile SYN — a remote
+    // hang, reachable before any connection exists.
+    : ( Vec u ) badopt ( vec_new [u] )
+    ( tcpseg_push badopt ( ip_c ) ( ip_s ) 12345 80 5000 0 ( tcp_syn ) 65535 1460 3 empty 0 0 )
+    : b _o1 ( vec_set [u] badopt 20 # u 2 )  // kind = MSS
+    : b _o2 ( vec_set [u] badopt 21 # u 0 )  // length = 0 → must stop
+    // recompute the checksum so this is an OPTION test, not a
+    // checksum test
+    : b _o3 ( vec_set [u] badopt 16 # u 0 )
+    : b _o4 ( vec_set [u] badopt 17 # u 0 )
+    : i bs ( inet_sum_add ( ip4_pseudo_sum ( ip_c ) ( ip_s ) ( ip_proto_tcp ) ( vec_len [u] badopt ) ) badopt 0 ( vec_len [u] badopt ) )
+    : i bck ( inet_finish bs )
+    : b _o5 ( vec_set [u] badopt 16 # u & >> bck 8 255 )
+    : b _o6 ( vec_set [u] badopt 17 # u & bck 255 )
+    : TcpSeg bseg ( tcpseg_parse badopt 0 ( vec_len [u] badopt ) ( ip_c ) ( ip_s ) )
+    ( pb `zero-length option terminates the walk: ` && . bseg valid == . bseg mss 0 )
+
+    // ── stale window update must not shrink the window ───────────
+    // A reordered ACK carrying an old, smaller window would otherwise
+    // stall the sender permanently (RFC 793 SND.WL1/WL2 rule).
+    : *TcpConn w ( tcp_new )
+    : *TcpOut ow ( tcpout_new )
+    : *TcpConn wp ( tcp_new )
+    : *TcpOut owp ( tcpout_new )
+    ( tcp_listen wp ( ip_s ) 80 )
+    = . wp iss 950000
+    = . wp remote_ip ( ip_c )
+    ( tcp_connect w ( ip_c ) 8888 ( ip_s ) 80 250000 0 ow )
+    : i _w1 ( hand_all ow wp owp 1 ( ip_c ) ( ip_s ) )
+    : i _w2 ( hand_all owp w ow 2 ( ip_s ) ( ip_c ) )
+    : i _w3 ( hand_all ow wp owp 3 ( ip_c ) ( ip_s ) )
+    // Fresh window update: large.
+    : ( Vec u ) big ( vec_new [u] )
+    ( tcpseg_push big ( ip_s ) ( ip_c ) 80 8888 . w rcv_nxt . w snd_nxt ( tcp_ack ) 60000 0 0 empty 0 0 )
+    : i _wb ( tcp_input w ( tcpseg_parse big 0 ( vec_len [u] big ) ( ip_s ) ( ip_c ) ) big 10 ow )
+    ( pb `window update applied: ` == . w snd_wnd 60000 )
+    // Now a STALE segment (older seq, older ack) advertising a tiny
+    // window arrives late. It must be ignored for window purposes.
+    : ( Vec u ) stale ( vec_new [u] )
+    // NOTE: seq must equal rcv_nxt so the segment is *acceptable* —
+    // otherwise it is rejected before the window rule is ever reached
+    // and this would test nothing. What makes it stale is the older ACK.
+    ( tcpseg_push stale ( ip_s ) ( ip_c ) 80 8888 . w rcv_nxt ( seq_sub . w snd_nxt 1 ) ( tcp_ack ) 1 0 0 empty 0 0 )
+    : i _ws ( tcp_input w ( tcpseg_parse stale 0 ( vec_len [u] stale ) ( ip_s ) ( ip_c ) ) stale 11 ow )
+    ( pb `stale ACK does not shrink the window: ` == . w snd_wnd 60000 )
+    ( tcp_free w ) ( tcp_free wp ) ( tcpout_free ow ) ( tcpout_free owp )
+    ( vec_free [u] big ) ( vec_free [u] stale )
+
+    // ── graceful close: FIN → TIME_WAIT → CLOSED ────────────────
+    : *TcpConn a ( tcp_new )
+    : *TcpConn b ( tcp_new )
+    : *TcpOut oa ( tcpout_new )
+    : *TcpOut ob ( tcpout_new )
+    ( tcp_listen b ( ip_s ) 80 )
+    = . b iss 900000
+    = . b remote_ip ( ip_c )
+    ( tcp_connect a ( ip_c ) 5555 ( ip_s ) 80 200000 0 oa )
+    : i _c1 ( hand_all oa b ob 1 ( ip_c ) ( ip_s ) )
+    : i _c2 ( hand_all ob a oa 2 ( ip_s ) ( ip_c ) )
+    : i _c3 ( hand_all oa b ob 3 ( ip_c ) ( ip_s ) )
+    ( pb `second pair established: ` && ( tcp_is_established a ) ( tcp_is_established b ) )
+
+    ( tcpout_clear oa ) ( tcpout_clear ob )
+    ( tcp_close a 100 oa )
+    ( pb `active close sends FIN: ` == ( tcpout_count oa ) 1 )
+    ( pb `closer is FIN_WAIT_1: ` == . a state ( tcp_fin_wait_1 ) )
+    : i _f1 ( hand_all oa b ob 100 ( ip_c ) ( ip_s ) )
+    ( pb `peer is CLOSE_WAIT: ` == . b state ( tcp_close_wait ) )
+    ( pb `peer saw the FIN: ` . b fin_rcvd )
+    : i _f2 ( hand_all ob a oa 100 ( ip_s ) ( ip_c ) )
+    ( pb `closer is FIN_WAIT_2: ` == . a state ( tcp_fin_wait_2 ) )
+    ( tcpout_clear ob )
+    ( tcp_close b 200 ob )
+    ( pb `peer sends its FIN: ` == ( tcpout_count ob ) 1 )
+    ( pb `peer is LAST_ACK: ` == . b state ( tcp_last_ack ) )
+    : i _f3 ( hand_all ob a oa 200 ( ip_s ) ( ip_c ) )
+    ( pb `closer is TIME_WAIT: ` == . a state ( tcp_time_wait ) )
+    : i _f4 ( hand_all oa b ob 200 ( ip_c ) ( ip_s ) )
+    ( pb `peer is CLOSED: ` == . b state ( tcp_closed ) )
+    // TIME_WAIT must persist for 2MSL, then reap itself.
+    : i _t1 ( tcp_tick a 210 oa )
+    ( pb `TIME_WAIT holds before 2MSL: ` == . a state ( tcp_time_wait ) )
+    : i _t2 ( tcp_tick a 40000 oa )
+    ( pb `TIME_WAIT expires after 2MSL: ` == . a state ( tcp_closed ) )
+
+    // ── RST tears the connection down ────────────────────────────
+    : *TcpConn r ( tcp_new )
+    : *TcpOut orr ( tcpout_new )
+    ( tcp_connect r ( ip_c ) 6666 ( ip_s ) 80 300000 0 orr )
+    : ( Vec u ) rstbuf ( vec_new [u] )
+    ( tcpseg_push rstbuf ( ip_s ) ( ip_c ) 80 6666 0 ( seq_add 300000 1 ) | ( tcp_rst ) ( tcp_ack ) 0 0 0 empty 0 0 )
+    : TcpSeg rseg ( tcpseg_parse rstbuf 0 ( vec_len [u] rstbuf ) ( ip_s ) ( ip_c ) )
+    : i _r1 ( tcp_input r rseg rstbuf 10 orr )
+    ( pb `RST to SYN_SENT closes it: ` ( tcp_is_closed r ) )
+
+    // ── give-up: endless retransmits eventually reset ────────────
+    : *TcpConn g ( tcp_new )
+    : *TcpOut og ( tcpout_new )
+    ( tcp_connect g ( ip_c ) 7777 ( ip_s ) 80 400000 0 og )
+    : ~ i t 1000
+    : ~ i guard 0
+    ~ && ! ( tcp_is_closed g ) < guard 40 {
+        : i _tk ( tcp_tick g t og )
+        = t + t 120000
+        = guard + guard 1
+    }
+    ( pb `unanswered SYN gives up eventually: ` ( tcp_is_closed g ) )
+    ( pb `gave up within max retries: ` <= . g rtx_count + ( tcp_max_rtx ) 1 )
+
+    ( tcp_free cl ) ( tcp_free sv ) ( tcp_free a ) ( tcp_free b )
+    ( tcp_free r ) ( tcp_free g )
+    ( tcpout_free oc ) ( tcpout_free os ) ( tcpout_free oa )
+    ( tcpout_free ob ) ( tcpout_free orr ) ( tcpout_free og )
+    ( vec_free [u] buf ) ( vec_free [u] pay ) ( vec_free [u] synbuf )
+    ( vec_free [u] empty ) ( vec_free [u] msg ) ( vec_free [u] got )
+    ( vec_free [u] oldbuf ) ( vec_free [u] rstbuf )
+    ( vec_free [u] rst2 ) ( vec_free [u] badopt )
+    ^ 0
+}

--- a/compiler/tests/net_tcp.nu
+++ b/compiler/tests/net_tcp.nu
@@ -24,16 +24,16 @@ $ `stdlib/net/tcp.nu`
 
 // Deliver segment `idx` of `from` into connection `to`. Returns how
 // many bytes `to` emitted in response.
-@ hand * TcpOut from i idx * TcpConn to * TcpOut reply i now i src_ip i dst_ip → i {
+@ hand * TcpOut from i idx * Tcb to * TcpOut reply i now i src_ip i dst_ip → i {
     : i start ( tcpout_seg_start from idx )
     : i len ( tcpout_seg_len from idx )
     : TcpSeg sg ( tcpseg_parse . from bytes start len src_ip dst_ip )
     ? ! . sg valid { ^ -1 } {}
-    ^ ( tcp_input to sg . from bytes now reply )
+    ^ ( tcb_input to sg . from bytes now reply )
 }
 
 // Deliver every segment in `from` to `to`, then clear `from`.
-@ hand_all * TcpOut from * TcpConn to * TcpOut reply i now i src_ip i dst_ip → i {
+@ hand_all * TcpOut from * Tcb to * TcpOut reply i now i src_ip i dst_ip → i {
     : i n ( tcpout_count from )
     : ~ i k 0
     : ~ i bad 0
@@ -97,14 +97,14 @@ $ `stdlib/net/tcp.nu`
     ( pb `absent wscale is -1, not 0: ` == . ps wscale -1 )
 
     // ── three-way handshake ──────────────────────────────────────
-    : *TcpConn cl ( tcp_new )
-    : *TcpConn sv ( tcp_new )
+    : *Tcb cl ( tcb_new )
+    : *Tcb sv ( tcb_new )
     : *TcpOut oc ( tcpout_new )
     : *TcpOut os ( tcpout_new )
-    ( tcp_listen sv ( ip_s ) 80 )
+    ( tcb_listen sv ( ip_s ) 80 )
     = . sv iss 700000
     = . sv remote_ip ( ip_c )
-    ( tcp_connect cl ( ip_c ) 12345 ( ip_s ) 80 100000 0 oc )
+    ( tcb_connect cl ( ip_c ) 12345 ( ip_s ) 80 100000 0 oc )
     ( pb `client sends one SYN: ` == ( tcpout_count oc ) 1 )
     ( pb `client is SYN_SENT: ` == . cl state ( tcp_syn_sent ) )
 
@@ -114,24 +114,24 @@ $ `stdlib/net/tcp.nu`
     ( pb `server learned client MSS: ` == . sv mss 1460 )
 
     : i _h2 ( hand_all os cl oc 2 ( ip_s ) ( ip_c ) )
-    ( pb `client is ESTABLISHED: ` ( tcp_is_established cl ) )
+    ( pb `client is ESTABLISHED: ` ( tcb_is_established cl ) )
     ( pb `client ACKs the SYN-ACK: ` == ( tcpout_count oc ) 1 )
 
     : i _h3 ( hand_all oc sv os 3 ( ip_c ) ( ip_s ) )
-    ( pb `server is ESTABLISHED: ` ( tcp_is_established sv ) )
+    ( pb `server is ESTABLISHED: ` ( tcb_is_established sv ) )
     ( pb `handshake produced an RTT sample: ` > . cl srtt 0 )
 
     // ── data transfer ────────────────────────────────────────────
     : ( Vec u ) msg ( vec_new [u] )
     ( bytes_extend_str msg `hello from the unikernel` )
-    ( pb `write accepts all 24 bytes: ` == ( tcp_write cl msg 0 24 65536 ) 24 )
-    : i _p1 ( tcp_pump cl 10 oc )
+    ( pb `write accepts all 24 bytes: ` == ( tcb_write cl msg 0 24 65536 ) 24 )
+    : i _p1 ( tcb_pump cl 10 oc )
     ( pb `one data segment emitted: ` == ( tcpout_count oc ) 1 )
     : i _d1 ( hand_all oc sv os 10 ( ip_c ) ( ip_s ) )
-    ( pb `server queued 24 bytes: ` == ( tcp_recv_queue_len sv ) 24 )
+    ( pb `server queued 24 bytes: ` == ( tcb_recv_queue_len sv ) 24 )
     : ( Vec u ) got ( vec_new [u] )
-    ( pb `read drains 24: ` == ( tcp_read sv got 100 ) 24 )
-    ( pb `receive queue now empty: ` == ( tcp_recv_queue_len sv ) 0 )
+    ( pb `read drains 24: ` == ( tcb_read sv got 100 ) 24 )
+    ( pb `receive queue now empty: ` == ( tcb_recv_queue_len sv ) 0 )
     : ~ b same T
     : ~ i k 0
     ~ < k 24 {
@@ -143,12 +143,12 @@ $ `stdlib/net/tcp.nu`
     ( pb `bytes arrive intact: ` same )
     // The server's ACK releases the client's send buffer.
     : i _a1 ( hand_all os cl oc 12 ( ip_s ) ( ip_c ) )
-    ( pb `client send queue drained by ACK: ` == ( tcp_send_queue_len cl ) 0 )
+    ( pb `client send queue drained by ACK: ` == ( tcb_send_queue_len cl ) 0 )
     ( pb `retransmit timer disarmed: ` == . cl rtx_deadline 0 )
 
     // ── retransmission after loss ────────────────────────────────
-    ( pb `write 10 more: ` == ( tcp_write cl msg 0 10 65536 ) 10 )
-    : i _p2 ( tcp_pump cl 100 oc )
+    ( pb `write 10 more: ` == ( tcb_write cl msg 0 10 65536 ) 10 )
+    : i _p2 ( tcb_pump cl 100 oc )
     ( pb `data segment emitted: ` == ( tcpout_count oc ) 1 )
     ( pb `rtx timer armed on send: ` > . cl rtx_deadline 0 )
     // DROP it: clear the buffer without delivering.
@@ -159,19 +159,19 @@ $ `stdlib/net/tcp.nu`
     : i deadline . cl rtx_deadline
     : i rto_before . cl rto_ms
     : i srtt_before_loss . cl srtt
-    ( pb `nothing retransmits before RTO: ` == ( tcp_tick cl - deadline 1 oc ) 0 )
-    : i rtx ( tcp_tick cl deadline oc )
+    ( pb `nothing retransmits before RTO: ` == ( tcb_tick cl - deadline 1 oc ) 0 )
+    : i rtx ( tcb_tick cl deadline oc )
     ( pb `RTO fires a retransmit: ` > rtx 0 )
     ( pb `retransmit count incremented: ` == . cl rtx_count 1 )
     ( pb `RTO doubled on backoff: ` == . cl rto_ms * rto_before 2 )
     ( pb `RTO respects the 200ms floor: ` >= rto_before ( tcp_rto_min_ms ) )
     // This time let it through.
     : i _d2 ( hand_all oc sv os deadline ( ip_c ) ( ip_s ) )
-    ( pb `server got the retransmitted data: ` == ( tcp_recv_queue_len sv ) 10 )
+    ( pb `server got the retransmitted data: ` == ( tcb_recv_queue_len sv ) 10 )
     : i _a2 ( hand_all os cl oc deadline ( ip_s ) ( ip_c ) )
-    ( pb `client queue drained after recovery: ` == ( tcp_send_queue_len cl ) 0 )
+    ( pb `client queue drained after recovery: ` == ( tcb_send_queue_len cl ) 0 )
     ( pb `rtx count reset by good ACK: ` == . cl rtx_count 0 )
-    : i _dr ( tcp_read sv got 100 )
+    : i _dr ( tcb_read sv got 100 )
 
     // Karn's rule: the ACK that finally arrives after a retransmit
     // must NOT feed the RTT estimator — its timing is ambiguous (was
@@ -184,19 +184,19 @@ $ `stdlib/net/tcp.nu`
     // Force the peer's advertised window to zero, then queue data: it
     // must not be sent, and a probe must eventually go out.
     = . cl snd_wnd 0
-    ( pb `write while window is zero: ` == ( tcp_write cl msg 0 8 65536 ) 8 )
+    ( pb `write while window is zero: ` == ( tcb_write cl msg 0 8 65536 ) 8 )
     ( tcpout_clear oc )
-    : i _p3 ( tcp_pump cl 3000 oc )
+    : i _p3 ( tcb_pump cl 3000 oc )
     ( pb `zero window blocks transmission: ` == ( tcpout_count oc ) 0 )
     = . cl probe_deadline 3500
-    : i probe ( tcp_tick cl 3600 oc )
+    : i probe ( tcb_tick cl 3600 oc )
     ( pb `persist timer emits a probe: ` > probe 0 )
     ( pb `probe is exactly one byte: ` == ( tcpseg_seq_len ( tcpseg_parse . oc bytes ( tcpout_seg_start oc 0 ) ( tcpout_seg_len oc 0 ) ( ip_c ) ( ip_s ) ) ) 1 )
     ( pb `probe interval backs off: ` > . cl probe_deadline 3600 )
     ( tcpout_clear oc )
     // Window reopens → the queued data flows.
     = . cl snd_wnd 65535
-    : i _p4 ( tcp_pump cl 4000 oc )
+    : i _p4 ( tcb_pump cl 4000 oc )
     ( pb `reopened window releases data: ` == ( tcpout_count oc ) 1 )
 
     // ── out-of-window segment is ACKed, not swallowed ────────────
@@ -204,9 +204,9 @@ $ `stdlib/net/tcp.nu`
     ( tcpseg_push oldbuf ( ip_s ) ( ip_c ) 80 12345 ( seq_sub . cl rcv_nxt 5000 ) . cl snd_nxt ( tcp_ack ) 65535 0 0 empty 0 0 )
     : TcpSeg oldseg ( tcpseg_parse oldbuf 0 ( vec_len [u] oldbuf ) ( ip_s ) ( ip_c ) )
     ( tcpout_clear oc )
-    : i oldn ( tcp_input cl oldseg oldbuf 5000 oc )
+    : i oldn ( tcb_input cl oldseg oldbuf 5000 oc )
     ( pb `stale segment answered with an ACK: ` > oldn 0 )
-    ( pb `stale segment did not close us: ` ( tcp_is_established cl ) )
+    ( pb `stale segment did not close us: ` ( tcb_is_established cl ) )
 
     // ── RST on an ESTABLISHED connection ─────────────────────────
     // Distinct code path from the SYN_SENT reset above: this one goes
@@ -214,10 +214,10 @@ $ `stdlib/net/tcp.nu`
     : ( Vec u ) rst2 ( vec_new [u] )
     ( tcpseg_push rst2 ( ip_s ) ( ip_c ) 80 12345 . cl rcv_nxt . cl snd_nxt | ( tcp_rst ) ( tcp_ack ) 0 0 0 empty 0 0 )
     : TcpSeg rseg2 ( tcpseg_parse rst2 0 ( vec_len [u] rst2 ) ( ip_s ) ( ip_c ) )
-    ( pb `established connection is up before RST: ` ( tcp_is_established cl ) )
+    ( pb `established connection is up before RST: ` ( tcb_is_established cl ) )
     ( tcpout_clear oc )
-    : i _rs ( tcp_input cl rseg2 rst2 5100 oc )
-    ( pb `in-window RST tears it down: ` ( tcp_is_closed cl ) )
+    : i _rs ( tcb_input cl rseg2 rst2 5100 oc )
+    ( pb `in-window RST tears it down: ` ( tcb_is_closed cl ) )
     ( pb `RST is not answered with a segment: ` == ( tcpout_count oc ) 0 )
 
     // ── malformed TCP option must not hang the parser ────────────
@@ -242,21 +242,21 @@ $ `stdlib/net/tcp.nu`
     // ── stale window update must not shrink the window ───────────
     // A reordered ACK carrying an old, smaller window would otherwise
     // stall the sender permanently (RFC 793 SND.WL1/WL2 rule).
-    : *TcpConn w ( tcp_new )
+    : *Tcb w ( tcb_new )
     : *TcpOut ow ( tcpout_new )
-    : *TcpConn wp ( tcp_new )
+    : *Tcb wp ( tcb_new )
     : *TcpOut owp ( tcpout_new )
-    ( tcp_listen wp ( ip_s ) 80 )
+    ( tcb_listen wp ( ip_s ) 80 )
     = . wp iss 950000
     = . wp remote_ip ( ip_c )
-    ( tcp_connect w ( ip_c ) 8888 ( ip_s ) 80 250000 0 ow )
+    ( tcb_connect w ( ip_c ) 8888 ( ip_s ) 80 250000 0 ow )
     : i _w1 ( hand_all ow wp owp 1 ( ip_c ) ( ip_s ) )
     : i _w2 ( hand_all owp w ow 2 ( ip_s ) ( ip_c ) )
     : i _w3 ( hand_all ow wp owp 3 ( ip_c ) ( ip_s ) )
     // Fresh window update: large.
     : ( Vec u ) big ( vec_new [u] )
     ( tcpseg_push big ( ip_s ) ( ip_c ) 80 8888 . w rcv_nxt . w snd_nxt ( tcp_ack ) 60000 0 0 empty 0 0 )
-    : i _wb ( tcp_input w ( tcpseg_parse big 0 ( vec_len [u] big ) ( ip_s ) ( ip_c ) ) big 10 ow )
+    : i _wb ( tcb_input w ( tcpseg_parse big 0 ( vec_len [u] big ) ( ip_s ) ( ip_c ) ) big 10 ow )
     ( pb `window update applied: ` == . w snd_wnd 60000 )
     // Now a STALE segment (older seq, older ack) advertising a tiny
     // window arrives late. It must be ignored for window purposes.
@@ -265,27 +265,27 @@ $ `stdlib/net/tcp.nu`
     // otherwise it is rejected before the window rule is ever reached
     // and this would test nothing. What makes it stale is the older ACK.
     ( tcpseg_push stale ( ip_s ) ( ip_c ) 80 8888 . w rcv_nxt ( seq_sub . w snd_nxt 1 ) ( tcp_ack ) 1 0 0 empty 0 0 )
-    : i _ws ( tcp_input w ( tcpseg_parse stale 0 ( vec_len [u] stale ) ( ip_s ) ( ip_c ) ) stale 11 ow )
+    : i _ws ( tcb_input w ( tcpseg_parse stale 0 ( vec_len [u] stale ) ( ip_s ) ( ip_c ) ) stale 11 ow )
     ( pb `stale ACK does not shrink the window: ` == . w snd_wnd 60000 )
-    ( tcp_free w ) ( tcp_free wp ) ( tcpout_free ow ) ( tcpout_free owp )
+    ( tcb_free w ) ( tcb_free wp ) ( tcpout_free ow ) ( tcpout_free owp )
     ( vec_free [u] big ) ( vec_free [u] stale )
 
     // ── graceful close: FIN → TIME_WAIT → CLOSED ────────────────
-    : *TcpConn a ( tcp_new )
-    : *TcpConn b ( tcp_new )
+    : *Tcb a ( tcb_new )
+    : *Tcb b ( tcb_new )
     : *TcpOut oa ( tcpout_new )
     : *TcpOut ob ( tcpout_new )
-    ( tcp_listen b ( ip_s ) 80 )
+    ( tcb_listen b ( ip_s ) 80 )
     = . b iss 900000
     = . b remote_ip ( ip_c )
-    ( tcp_connect a ( ip_c ) 5555 ( ip_s ) 80 200000 0 oa )
+    ( tcb_connect a ( ip_c ) 5555 ( ip_s ) 80 200000 0 oa )
     : i _c1 ( hand_all oa b ob 1 ( ip_c ) ( ip_s ) )
     : i _c2 ( hand_all ob a oa 2 ( ip_s ) ( ip_c ) )
     : i _c3 ( hand_all oa b ob 3 ( ip_c ) ( ip_s ) )
-    ( pb `second pair established: ` && ( tcp_is_established a ) ( tcp_is_established b ) )
+    ( pb `second pair established: ` && ( tcb_is_established a ) ( tcb_is_established b ) )
 
     ( tcpout_clear oa ) ( tcpout_clear ob )
-    ( tcp_close a 100 oa )
+    ( tcb_close a 100 oa )
     ( pb `active close sends FIN: ` == ( tcpout_count oa ) 1 )
     ( pb `closer is FIN_WAIT_1: ` == . a state ( tcp_fin_wait_1 ) )
     : i _f1 ( hand_all oa b ob 100 ( ip_c ) ( ip_s ) )
@@ -294,7 +294,7 @@ $ `stdlib/net/tcp.nu`
     : i _f2 ( hand_all ob a oa 100 ( ip_s ) ( ip_c ) )
     ( pb `closer is FIN_WAIT_2: ` == . a state ( tcp_fin_wait_2 ) )
     ( tcpout_clear ob )
-    ( tcp_close b 200 ob )
+    ( tcb_close b 200 ob )
     ( pb `peer sends its FIN: ` == ( tcpout_count ob ) 1 )
     ( pb `peer is LAST_ACK: ` == . b state ( tcp_last_ack ) )
     : i _f3 ( hand_all ob a oa 200 ( ip_s ) ( ip_c ) )
@@ -302,37 +302,37 @@ $ `stdlib/net/tcp.nu`
     : i _f4 ( hand_all oa b ob 200 ( ip_c ) ( ip_s ) )
     ( pb `peer is CLOSED: ` == . b state ( tcp_closed ) )
     // TIME_WAIT must persist for 2MSL, then reap itself.
-    : i _t1 ( tcp_tick a 210 oa )
+    : i _t1 ( tcb_tick a 210 oa )
     ( pb `TIME_WAIT holds before 2MSL: ` == . a state ( tcp_time_wait ) )
-    : i _t2 ( tcp_tick a 40000 oa )
+    : i _t2 ( tcb_tick a 40000 oa )
     ( pb `TIME_WAIT expires after 2MSL: ` == . a state ( tcp_closed ) )
 
     // ── RST tears the connection down ────────────────────────────
-    : *TcpConn r ( tcp_new )
+    : *Tcb r ( tcb_new )
     : *TcpOut orr ( tcpout_new )
-    ( tcp_connect r ( ip_c ) 6666 ( ip_s ) 80 300000 0 orr )
+    ( tcb_connect r ( ip_c ) 6666 ( ip_s ) 80 300000 0 orr )
     : ( Vec u ) rstbuf ( vec_new [u] )
     ( tcpseg_push rstbuf ( ip_s ) ( ip_c ) 80 6666 0 ( seq_add 300000 1 ) | ( tcp_rst ) ( tcp_ack ) 0 0 0 empty 0 0 )
     : TcpSeg rseg ( tcpseg_parse rstbuf 0 ( vec_len [u] rstbuf ) ( ip_s ) ( ip_c ) )
-    : i _r1 ( tcp_input r rseg rstbuf 10 orr )
-    ( pb `RST to SYN_SENT closes it: ` ( tcp_is_closed r ) )
+    : i _r1 ( tcb_input r rseg rstbuf 10 orr )
+    ( pb `RST to SYN_SENT closes it: ` ( tcb_is_closed r ) )
 
     // ── give-up: endless retransmits eventually reset ────────────
-    : *TcpConn g ( tcp_new )
+    : *Tcb g ( tcb_new )
     : *TcpOut og ( tcpout_new )
-    ( tcp_connect g ( ip_c ) 7777 ( ip_s ) 80 400000 0 og )
+    ( tcb_connect g ( ip_c ) 7777 ( ip_s ) 80 400000 0 og )
     : ~ i t 1000
     : ~ i guard 0
-    ~ && ! ( tcp_is_closed g ) < guard 40 {
-        : i _tk ( tcp_tick g t og )
+    ~ && ! ( tcb_is_closed g ) < guard 40 {
+        : i _tk ( tcb_tick g t og )
         = t + t 120000
         = guard + guard 1
     }
-    ( pb `unanswered SYN gives up eventually: ` ( tcp_is_closed g ) )
+    ( pb `unanswered SYN gives up eventually: ` ( tcb_is_closed g ) )
     ( pb `gave up within max retries: ` <= . g rtx_count + ( tcp_max_rtx ) 1 )
 
-    ( tcp_free cl ) ( tcp_free sv ) ( tcp_free a ) ( tcp_free b )
-    ( tcp_free r ) ( tcp_free g )
+    ( tcb_free cl ) ( tcb_free sv ) ( tcb_free a ) ( tcb_free b )
+    ( tcb_free r ) ( tcb_free g )
     ( tcpout_free oc ) ( tcpout_free os ) ( tcpout_free oa )
     ( tcpout_free ob ) ( tcpout_free orr ) ( tcpout_free og )
     ( vec_free [u] buf ) ( vec_free [u] pay ) ( vec_free [u] synbuf )

--- a/compiler/tests/net_tcp_fuzz.nu
+++ b/compiler/tests/net_tcp_fuzz.nu
@@ -16,7 +16,7 @@
 //      undefined value through some arithmetic path.
 //   5. `reset` and CLOSED stay paired. Resurrection after a reset is
 //      structurally impossible today — every site that sets `reset`
-//      also sets CLOSED, and tcp_input returns immediately in CLOSED —
+//      also sets CLOSED, and tcb_input returns immediately in CLOSED —
 //      so the useful check is the pairing itself: if a future edit sets
 //      one without the other, a reset connection becomes reachable
 //      again and this trips.
@@ -60,12 +60,12 @@ $ `stdlib/net/tcp.nu`
         // A fresh connection every few rounds, alternating between an
         // active open and a listening socket so both entry paths get
         // hammered.
-        : *TcpConn c ( tcp_new )
+        : *Tcb c ( tcb_new )
         : *TcpOut out ( tcpout_new )
         ? == % round 2 0 {
-            ( tcp_connect c ( ip_c ) 12345 ( ip_s ) 80 + 100000 * round 7 0 out )
+            ( tcb_connect c ( ip_c ) 12345 ( ip_s ) 80 + 100000 * round 7 0 out )
         } {
-            ( tcp_listen c ( ip_c ) 12345 )
+            ( tcb_listen c ( ip_c ) 12345 )
             = . c iss + 500000 * round 13
             = . c remote_ip ( ip_s )
             = . c remote_port 80
@@ -111,7 +111,7 @@ $ `stdlib/net/tcp.nu`
             ? . sg valid {
                 = accepted + accepted 1
                 ( tcpout_clear out )
-                : i _n ( tcp_input c sg sb + 1000 * step 50 out )
+                : i _n ( tcb_input c sg sb + 1000 * step 50 out )
                 = handled + handled 1
 
                 // (2) every emitted segment must acknowledge only data
@@ -136,20 +136,20 @@ $ `stdlib/net/tcp.nu`
                 // latter is vacuous while the pairing holds — and it is
                 // the pairing that a future edit could break.
                 ? && . c reset != . c state ( tcp_closed ) { = no_resurrect F } {}
-                ? && was_reset ( tcp_is_established c ) { = no_resurrect F } {}
+                ? && was_reset ( tcb_is_established c ) { = no_resurrect F } {}
 
                 // (3) in-order-only delivery bounds the receive queue.
-                ? > ( tcp_recv_queue_len c ) . c rcv_wnd { = rcvq_bounded F } {}
+                ? > ( tcb_recv_queue_len c ) . c rcv_wnd { = rcvq_bounded F } {}
             } {}
             ( vec_free [u] sb )
 
             // Interleave timer work — retransmits and probes have to
             // survive hostile input too.
-            : i _t ( tcp_tick c + 2000 * step 100 out )
+            : i _t ( tcb_tick c + 2000 * step 100 out )
             ? || < . c state 0 > . c state 10 { = state_sane F } {}
             = step + step 1
         }
-        ( tcp_free c )
+        ( tcb_free c )
         ( tcpout_free out )
         = round + round 1
     }

--- a/compiler/tests/net_tcp_fuzz.nu
+++ b/compiler/tests/net_tcp_fuzz.nu
@@ -1,0 +1,168 @@
+// net_tcp_fuzz.nu — structural fuzz of the TCP state machine.
+//
+// Deterministic (an LCG seeded by a constant), so a failure reproduces
+// exactly and the golden file stays stable. Hostile segments are
+// generated against a live connection and the stack is required to
+// uphold its invariants no matter what arrives:
+//
+//   1. It must never hang. Every segment is processed in bounded work
+//      — the malformed-option loop guard is the case that matters, and
+//      it is a remote hang reachable from an unauthenticated SYN.
+//   2. It must never emit a segment claiming to acknowledge data the
+//      peer never sent (ack beyond snd_nxt).
+//   3. The receive queue may only grow with in-order data, so it can
+//      never exceed the advertised window.
+//   4. State must stay inside the RFC 793 set — no wandering into an
+//      undefined value through some arithmetic path.
+//   5. `reset` and CLOSED stay paired. Resurrection after a reset is
+//      structurally impossible today — every site that sets `reset`
+//      also sets CLOSED, and tcp_input returns immediately in CLOSED —
+//      so the useful check is the pairing itself: if a future edit sets
+//      one without the other, a reset connection becomes reachable
+//      again and this trips.
+//
+// This is the "oracle = state invariants" shape from the structural
+// fuzzer campaign, applied to a protocol instead of to a compiler.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/tcpseg.nu`
+$ `stdlib/net/tcp.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ ip_c → i { ^ ( ipv4_make 10 0 2 15 ) }
+
+@ ip_s → i { ^ ( ipv4_make 10 0 2 16 ) }
+
+// A tiny LCG — the point is reproducibility, not randomness quality.
+@ lcg i st → i { ^ & + * st 6364136223846793005 1442695040888963407 4294967295 }
+
+@ main → i {
+    : ~ i seed 20260804
+    : ~ b no_bad_ack T
+    : ~ b state_sane T
+    : ~ b no_resurrect T
+    : ~ b rcvq_bounded T
+    : ~ i handled 0
+    : ~ i accepted 0
+
+    : ( Vec u ) empty ( vec_new [u] )
+    : ( Vec u ) pay ( vec_new [u] )
+    : ~ i pk 0
+    ~ < pk 64 { ( vec_push [u] pay # u & pk 255 ) = pk + pk 1 }
+
+    : ~ i round 0
+    ~ < round 400 {
+        // A fresh connection every few rounds, alternating between an
+        // active open and a listening socket so both entry paths get
+        // hammered.
+        : *TcpConn c ( tcp_new )
+        : *TcpOut out ( tcpout_new )
+        ? == % round 2 0 {
+            ( tcp_connect c ( ip_c ) 12345 ( ip_s ) 80 + 100000 * round 7 0 out )
+        } {
+            ( tcp_listen c ( ip_c ) 12345 )
+            = . c iss + 500000 * round 13
+            = . c remote_ip ( ip_s )
+            = . c remote_port 80
+        }
+
+        : ~ i step 0
+        ~ < step 12 {
+            = seed ( lcg seed )
+            : i r seed
+            // Build a segment from the fuzzed word. Sequence and ack
+            // are drawn both from near the connection's real values
+            // (to get past the acceptability test often enough to
+            // exercise the interesting paths) and from anywhere in the
+            // 32-bit space (to probe the rejection paths).
+            : i near & >> r 28 1
+            : i sq ? == near 1 ( seq_add . c rcv_nxt - & >> r 4 7 3 ) & r 4294967295
+            : i ak ? == near 1 ( seq_add . c snd_nxt - & >> r 8 7 3 ) & >> r 3 4294967295
+            : i fl & >> r 12 63
+            : i wn & >> r 16 65535
+            : i plen % & >> r 24 15 9
+            : ( Vec u ) sb ( vec_new [u] )
+            ( tcpseg_push sb ( ip_s ) ( ip_c ) 80 12345 sq ak fl wn 1460 0 pay 0 plen )
+            // Corrupt an option byte now and then — this is the path
+            // where a missing length guard becomes an infinite loop.
+            ? == & >> r 20 7 0 {
+                ? > ( vec_len [u] sb ) 21 {
+                    : b _m1 ( vec_set [u] sb 20 # u & >> r 5 255 )
+                    : b _m2 ( vec_set [u] sb 21 # u & >> r 9 3 )
+                    // fix the checksum so the segment reaches the
+                    // option parser instead of being rejected early
+                    : b _m3 ( vec_set [u] sb 16 # u 0 )
+                    : b _m4 ( vec_set [u] sb 17 # u 0 )
+                    : i ss ( inet_sum_add ( ip4_pseudo_sum ( ip_s ) ( ip_c ) ( ip_proto_tcp ) ( vec_len [u] sb ) ) sb 0 ( vec_len [u] sb ) )
+                    : i ck ( inet_finish ss )
+                    : b _m5 ( vec_set [u] sb 16 # u & >> ck 8 255 )
+                    : b _m6 ( vec_set [u] sb 17 # u & ck 255 )
+                } {}
+            } {}
+
+            : b was_reset . c reset
+            : i snd_nxt_before . c snd_nxt
+            : TcpSeg sg ( tcpseg_parse sb 0 ( vec_len [u] sb ) ( ip_s ) ( ip_c ) )
+            ? . sg valid {
+                = accepted + accepted 1
+                ( tcpout_clear out )
+                : i _n ( tcp_input c sg sb + 1000 * step 50 out )
+                = handled + handled 1
+
+                // (2) every emitted segment must acknowledge only data
+                // that actually exists.
+                : i nseg ( tcpout_count out )
+                : ~ i si 0
+                ~ < si nseg {
+                    : TcpSeg es ( tcpseg_parse . out bytes ( tcpout_seg_start out si ) ( tcpout_seg_len out si ) ( ip_c ) ( ip_s ) )
+                    ? . es valid {
+                        ? == & . es flags 16 16 {
+                            ? ( seq_gt . es ack . c rcv_nxt ) { = no_bad_ack F } {}
+                        } {}
+                    } {}
+                    = si + si 1
+                }
+
+                // (4) the state must stay in the RFC 793 set.
+                ? || < . c state 0 > . c state 10 { = state_sane F } {}
+
+                // (5) reset ⇒ CLOSED, always. Checked as the pairing
+                // rather than as "never re-establishes", because the
+                // latter is vacuous while the pairing holds — and it is
+                // the pairing that a future edit could break.
+                ? && . c reset != . c state ( tcp_closed ) { = no_resurrect F } {}
+                ? && was_reset ( tcp_is_established c ) { = no_resurrect F } {}
+
+                // (3) in-order-only delivery bounds the receive queue.
+                ? > ( tcp_recv_queue_len c ) . c rcv_wnd { = rcvq_bounded F } {}
+            } {}
+            ( vec_free [u] sb )
+
+            // Interleave timer work — retransmits and probes have to
+            // survive hostile input too.
+            : i _t ( tcp_tick c + 2000 * step 100 out )
+            ? || < . c state 0 > . c state 10 { = state_sane F } {}
+            = step + step 1
+        }
+        ( tcp_free c )
+        ( tcpout_free out )
+        = round + round 1
+    }
+
+    // Reaching here at all is invariant (1): 400 connections × 12
+    // hostile segments each, no hang.
+    ( pb `fuzz completed without hanging: ` T )
+    ( pb `segments were actually accepted: ` > accepted 100 )
+    ( pb `no ACK beyond what the peer sent: ` no_bad_ack )
+    ( pb `state stayed inside RFC 793: ` state_sane )
+    ( pb `reset and CLOSED stay paired: ` no_resurrect )
+    ( pb `receive queue stayed within the window: ` rcvq_bounded )
+    ( vec_free [u] empty )
+    ( vec_free [u] pay )
+    ^ 0
+}

--- a/compiler/tests/outputs/net_dhcp.txt
+++ b/compiler/tests/outputs/net_dhcp.txt
@@ -1,0 +1,66 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+starts unbound: YES
+first tick sends DISCOVER: YES
+discover broadcasts: YES
+discover src is 0.0.0.0: YES
+no immediate resend: YES
+resend after backoff: YES
+backoff doubled (no send at 6s): YES
+resend at 12s: YES
+own discover parses: YES
+discover op is request: YES
+discover xid: YES
+discover carries our mac: YES
+discover msg type: YES
+foreign xid parses as a message: YES
+foreign xid ignored: YES
+foreign chaddr ignored: YES
+still selecting: YES
+offer parses: YES
+offer yiaddr: YES
+offer server id: YES
+offer accepted: YES
+now requesting: YES
+not bound yet: YES
+request retransmits: YES
+ack accepted: YES
+bound: YES
+got our address: YES
+got subnet mask: YES
+got router: YES
+got dns: YES
+T1 defaults to lease/2: YES
+T2 defaults to 7/8 lease: YES
+lease deadline: YES
+bound is quiet: YES
+still quiet just before T1: YES
+T1 triggers renew: YES
+state renewing: YES
+renew unicasts to server: YES
+renew src is our address: YES
+renew still counts as bound: YES
+renewal ack accepted: YES
+back to bound: YES
+lease extended: YES
+explicit T1 honoured: YES
+renewing again at T1: YES
+T2 triggers rebind: YES
+state rebinding: YES
+rebind broadcasts: YES
+rebind keeps our address as src: YES
+expiry drops the address: YES
+expiry returns to INIT: YES
+no longer bound: YES
+INIT re-discovers: YES
+bound before nak: YES
+nak accepted: YES
+nak drops address at once: YES
+nak returns to INIT: YES
+short message rejected: YES
+bad magic cookie rejected: YES
+overlong option terminates walk: YES
+missing lease → 1h default: YES
+bound with defaulted lease: YES

--- a/compiler/tests/outputs/net_frames.txt
+++ b/compiler/tests/outputs/net_frames.txt
@@ -1,0 +1,79 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+eth parse valid: YES
+eth dst: YES
+eth src: YES
+eth type arp: YES
+eth payload off: YES
+eth runt rejected: YES
+addressed to us: YES
+broadcast to us: YES
+other unicast not ours: YES
+padded frame is 60 bytes: YES
+ip parse valid: YES
+ip src: YES
+ip dst: YES
+ip proto udp: YES
+eth payload_len is padded (46): YES
+ip payload_len from total_len (12): YES
+udp parse valid: YES
+udp src port: YES
+udp dst port: YES
+udp payload_len is 4, not padding: YES
+udp payload byte 0: YES
+udp payload byte 3: YES
+udp ignores trailing padding: YES
+bad ip checksum rejected: YES
+fragment rejected distinctly: YES
+truncated (total_len > avail) rejected: YES
+icmp parse valid: YES
+icmp is echo request: YES
+icmp id: YES
+icmp seq: YES
+icmp payload_len: YES
+reply parses (checksum ok): YES
+reply is echo reply: YES
+reply mirrors id: YES
+reply mirrors seq: YES
+reply mirrors payload len: YES
+reply mirrors payload bytes: YES
+reply src/dst swapped: YES
+corrupt icmp rejected: YES
+udp checksum never transmitted as 0: YES
+every emitted udp datagram verifies: YES
+sweep exercised the 0xffff substitution: YES
+udp checksum 0 accepted unverified: YES
+wrong udp checksum rejected: YES
+udp bogus length rejected: YES
+arp request frame len 42: YES
+arp request is broadcast: YES
+arp ethertype: YES
+arp parse valid: YES
+arp op request: YES
+arp sender mac: YES
+arp sender ip: YES
+arp target ip: YES
+arp target mac unknown: YES
+arp reply unicast to us: YES
+arp reply op: YES
+arp reply sender is peer: YES
+arp reply target is us: YES
+foreign arp htype rejected: YES
+cold lookup misses: YES
+first send asks: YES
+immediate retry suppressed: YES
+retry after 1s allowed: YES
+not failed yet: YES
+third retry allowed: YES
+fourth suppressed (max retries): YES
+now reported failed: YES
+resolved lookup hits: YES
+resolved stops requests: YES
+no longer failed: YES
+lookup after ttl misses: YES
+expire reclaims 1: YES
+expire again reclaims 0: YES
+cache stays bounded at max: YES
+most recent insert survived: YES

--- a/compiler/tests/outputs/net_inet.txt
+++ b/compiler/tests/outputs/net_inet.txt
@@ -1,0 +1,49 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+ipv4 header checksum = 0xb861: YES
+verify folds to 0xffff: YES
+odd-length pad: YES
+empty range: YES
+carry folds: YES
+split sum == one-shot: YES
+sum_u32 == byte sum: YES
+sum_u16 == byte sum: YES
+make 10.0.2.15: YES
+octet 0: YES
+octet 3: YES
+str round-trip: YES
+parse 10.0.2.15: YES
+parse 0.0.0.0: YES
+parse 255.255.255.255: YES
+reject 256.0.0.1: YES
+reject 1.2.3: YES
+reject 1.2.3.4.5: YES
+reject 1.2.3.: YES
+reject .1.2.3: YES
+reject 1..2.3: YES
+reject empty: YES
+reject 1.2.3.4x: YES
+reject 0300.1.2.3: YES
+mask /24: YES
+mask /0: YES
+mask /32: YES
+in subnet: YES
+not in subnet: YES
+subnet broadcast: YES
+is broadcast: YES
+is multicast 224.0.0.251: YES
+not multicast 10.0.0.1: YES
+parse mac: YES
+parse mac dashes: YES
+parse mac upper: YES
+reject short mac: YES
+reject bad sep: YES
+reject non-hex: YES
+mac str round-trip: YES
+mac octet 0: YES
+mac octet 5: YES
+broadcast mac: YES
+broadcast is multicast: YES
+unicast not multicast: YES

--- a/compiler/tests/outputs/net_stack.txt
+++ b/compiler/tests/outputs/net_stack.txt
@@ -1,0 +1,54 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+first send is ARP-pending: YES
+an ARP request was emitted: YES
+ARP request is 42 bytes: YES
+B handled the ARP: YES
+B emitted a reply: YES
+B learned A's address: YES
+A handled the ARP reply: YES
+A emitted nothing back: YES
+A learned B's address: YES
+retry sends for real: YES
+frame is 57 bytes: YES
+B received a UDP datagram: YES
+src ip is A: YES
+dst ip is B: YES
+src port: YES
+dst port: YES
+payload length: YES
+payload bytes survive the round trip: YES
+reply needs no new ARP: YES
+A received the reply: YES
+reply ports swapped: YES
+A answered the ping: YES
+a reply frame was emitted: YES
+pong addressed to B: YES
+pong ip valid (checksum ok): YES
+pong from A to B: YES
+pong icmp valid (checksum ok): YES
+pong is an echo reply: YES
+pong mirrors id and seq: YES
+pong mirrors payload length: YES
+pong mirrors payload bytes: YES
+off-link send is ARP-pending: YES
+ARPs for the gateway, not the destination: YES
+off-link send now succeeds: YES
+ethernet dst is the gateway MAC: YES
+ip dst is still 8.8.8.8: YES
+unknown host: first attempt ARPs: YES
+after max retries: unreachable: YES
+runt frame dropped as bad_eth: YES
+frame for another MAC dropped: YES
+IPv6 dropped as unknown ethertype: YES
+fragment counted as fragment: YES
+bad_eth counter is 1: YES
+not_for_us counter is 1: YES
+unknown_ethertype counter is 1: YES
+fragment counter is 1: YES
+no spurious bad_udp drops: YES
+no address → tx refused: YES
+broadcast from 0.0.0.0 works: YES
+DHCP-shaped frame is broadcast: YES

--- a/compiler/tests/outputs/net_tcp.txt
+++ b/compiler/tests/outputs/net_tcp.txt
@@ -1,0 +1,94 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+seq_lt basic: YES
+seq_gt basic: YES
+seq_lt not reflexive: YES
+seq_leq reflexive: YES
+wrap: ffffff f0 < 10: YES
+wrap: 10 > fffffff0: YES
+wrap add crosses zero: YES
+wrap diff is small: YES
+wrap diff negative: YES
+half-space boundary: YES
+beyond half-space flips: YES
+in window basic: YES
+window excludes end: YES
+window includes start: YES
+zero window holds nothing: YES
+window wraps: YES
+segment parses: YES
+src port: YES
+dst port: YES
+seq: YES
+ack: YES
+payload len: YES
+no options on non-SYN: YES
+seq_len counts payload: YES
+corrupt segment rejected: YES
+SYN parses: YES
+SYN carries options: YES
+MSS option read: YES
+window scale read: YES
+SYN occupies 1 seq: YES
+absent wscale is -1, not 0: YES
+client sends one SYN: YES
+client is SYN_SENT: YES
+server is SYN_RCVD: YES
+server sends SYN-ACK: YES
+server learned client MSS: YES
+client is ESTABLISHED: YES
+client ACKs the SYN-ACK: YES
+server is ESTABLISHED: YES
+handshake produced an RTT sample: YES
+write accepts all 24 bytes: YES
+one data segment emitted: YES
+server queued 24 bytes: YES
+read drains 24: YES
+receive queue now empty: YES
+bytes arrive intact: YES
+client send queue drained by ACK: YES
+retransmit timer disarmed: YES
+write 10 more: YES
+data segment emitted: YES
+rtx timer armed on send: YES
+nothing retransmits before RTO: YES
+RTO fires a retransmit: YES
+retransmit count incremented: YES
+RTO doubled on backoff: YES
+RTO respects the 200ms floor: YES
+server got the retransmitted data: YES
+client queue drained after recovery: YES
+rtx count reset by good ACK: YES
+retransmit cleared the RTT sample: YES
+SRTT unchanged by ambiguous ACK: YES
+write while window is zero: YES
+zero window blocks transmission: YES
+persist timer emits a probe: YES
+probe is exactly one byte: YES
+probe interval backs off: YES
+reopened window releases data: YES
+stale segment answered with an ACK: YES
+stale segment did not close us: YES
+established connection is up before RST: YES
+in-window RST tears it down: YES
+RST is not answered with a segment: YES
+zero-length option terminates the walk: YES
+window update applied: YES
+stale ACK does not shrink the window: YES
+second pair established: YES
+active close sends FIN: YES
+closer is FIN_WAIT_1: YES
+peer is CLOSE_WAIT: YES
+peer saw the FIN: YES
+closer is FIN_WAIT_2: YES
+peer sends its FIN: YES
+peer is LAST_ACK: YES
+closer is TIME_WAIT: YES
+peer is CLOSED: YES
+TIME_WAIT holds before 2MSL: YES
+TIME_WAIT expires after 2MSL: YES
+RST to SYN_SENT closes it: YES
+unanswered SYN gives up eventually: YES
+gave up within max retries: YES

--- a/compiler/tests/outputs/net_tcp_fuzz.txt
+++ b/compiler/tests/outputs/net_tcp_fuzz.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+fuzz completed without hanging: YES
+segments were actually accepted: YES
+no ACK beyond what the peer sent: YES
+state stayed inside RFC 793: YES
+reset and CLOSED stay paired: YES
+receive queue stayed within the window: YES

--- a/compiler/tests/run_tests.sh
+++ b/compiler/tests/run_tests.sh
@@ -147,6 +147,23 @@ http_needs_net() {
     return 1
 }
 
+# Same idea for the net_ prefix: gate on what a test actually DOES,
+# not on its name. Most net_ tests are pure wire-format / state-machine
+# logic (the sans-IO stack) and must run on every commit — that is the
+# whole point of writing them sans-IO. Only the ones that open a real
+# socket are opt-in.
+#
+# Listing the socket-using tests explicitly, rather than exempting the
+# offline ones one by one, keeps the default SAFE: a new net_ test runs
+# by default, and a test that forgets to declare its socket use fails
+# loudly on a sandboxed host instead of silently never running.
+net_needs_net() {
+    case "$1" in
+        net_loopback) return 0 ;;
+    esac
+    return 1
+}
+
 # Decide whether a test is skipped in the current environment.
 # Echoes "skip" if so. Kept in sync with the golden-bijection check
 # below (skipped tests are exempt from missing/orphan accounting).
@@ -174,7 +191,7 @@ is_skipped() {
             echo skip; return
         fi
     fi
-    if [[ "$name" == net_* && "$name" != "net_basic" && "$ENABLE_NET_TESTS" != "1" ]]; then
+    if [[ "$name" == net_* ]] && net_needs_net "$name" && [[ "$ENABLE_NET_TESTS" != "1" ]]; then
         echo skip; return
     fi
 }
@@ -297,7 +314,7 @@ run_one() {
         echo FAIL
     fi
 }
-export -f run_one is_skipped append_capped strip_root http_runs_by_default http_needs_net
+export -f run_one is_skipped append_capped strip_root http_runs_by_default http_needs_net net_needs_net
 export NURLC RUNTIME OUTDIR WORKDIR SCRIPT_DIR ROOT_DIR CLANG LINK_LIBS
 export ENABLE_HTTP_TESTS ENABLE_NET_TESTS MAX_OUT_LINES TIMEOUT UPDATE
 

--- a/stdlib/net/arp.nu
+++ b/stdlib/net/arp.nu
@@ -1,0 +1,294 @@
+// stdlib/net/arp.nu — ARP for IPv4-over-Ethernet (RFC 826), sans-IO.
+//
+// PURE — parse, build, and a cache whose expiry is driven by a clock
+// the caller passes in. Nothing here reads a timer or a socket, so the
+// whole resolve/expire life cycle is testable with a scripted clock.
+//
+// CACHE DESIGN
+//
+// Entries are scalar-only, so the table is a `( Vec ArpEntry )` and an
+// update is read-modify-`vec_set` — no pointers, no per-entry
+// allocation, no ownership dance on lookup (the hot path).
+//
+// An entry is INCOMPLETE while a request is outstanding, RESOLVED once
+// a reply arrives. The distinction is what keeps a single unreachable
+// destination from emitting one ARP request per outbound packet: the
+// caller queues the packet, and the INCOMPLETE entry rate-limits
+// retries to one per `arp_retry_ms`.
+//
+// SECURITY NOTE — deliberate, not an oversight: this cache updates
+// only from replies to requests we sent, and from requests addressed
+// to our own IP (the standard "he's asking for me, so learn him" case
+// in RFC 826). It does NOT learn from arbitrary broadcast traffic.
+// Gratuitous-ARP learning is the classic LAN spoofing vector, and a
+// unikernel with one gateway gains nothing from it.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/eth.nu`
+
+// ── constants ────────────────────────────────────────────────────
+
+@ arp_op_request → i { ^ 1 }
+
+@ arp_op_reply → i { ^ 2 }
+
+@ arp_pkt_len → i { ^ 28 }
+
+// An entry with no traffic dies after this long; a resolved entry is
+// refreshed by any reply, so a busy gateway never expires.
+@ arp_ttl_ms → i { ^ 60000 }
+
+// One outstanding request per destination per this interval.
+@ arp_retry_ms → i { ^ 1000 }
+
+// Give up on an unanswered address after this many retries.
+@ arp_max_retries → i { ^ 3 }
+
+@ arp_state_free → i { ^ 0 }
+
+@ arp_state_incomplete → i { ^ 1 }
+
+@ arp_state_resolved → i { ^ 2 }
+
+// ── parse / build ────────────────────────────────────────────────
+
+: ArpPkt {
+    i op
+    i sender_mac
+    i sender_ip
+    i target_mac
+    i target_ip
+    b valid
+}
+
+@ __arp_mac ( Vec u ) v i off → i {
+    : ~ i acc 0
+    : ~ i k 0
+    ~ < k 6 {
+        : i b ?? ( vec_get [u] v + off k ) { T x → # i x F → 0 }
+        = acc | << acc 8 b
+        = k + k 1
+    }
+    ^ acc
+}
+
+// Parse an ARP packet at `off`, with `avail` bytes present. Only
+// Ethernet/IPv4 ARP is accepted; every other hardware/protocol pair is
+// rejected rather than mis-parsed.
+@ arp_parse ( Vec u ) buf i off i avail → ArpPkt {
+    ? < avail 28 { ^ @ ArpPkt { 0 0 0 0 0 F } } {}
+    : i htype ?? ( bytes_read_u16_be buf off ) { T x → # i x F → 0 }
+    : i ptype ?? ( bytes_read_u16_be buf + off 2 ) { T x → # i x F → 0 }
+    : i hlen ?? ( vec_get [u] buf + off 4 ) { T x → # i x F → 0 }
+    : i plen ?? ( vec_get [u] buf + off 5 ) { T x → # i x F → 0 }
+    ? || != htype 1 || != ptype ( ethertype_ipv4 ) || != hlen 6 != plen 4 {
+        ^ @ ArpPkt { 0 0 0 0 0 F }
+    } {}
+    : i op ?? ( bytes_read_u16_be buf + off 6 ) { T x → # i x F → 0 }
+    ? && != op 1 != op 2 { ^ @ ArpPkt { 0 0 0 0 0 F } } {}
+    ^ @ ArpPkt {
+        op
+        ( __arp_mac buf + off 8 )
+        ?? ( bytes_read_u32_be buf + off 14 ) { T x → # i x F → 0 }
+        ( __arp_mac buf + off 18 )
+        ?? ( bytes_read_u32_be buf + off 24 ) { T x → # i x F → 0 }
+        T
+    }
+}
+
+// Append a complete Ethernet frame carrying one ARP packet.
+@ arp_push_frame ( Vec u ) out i op i eth_dst i sender_mac i sender_ip i target_mac i target_ip → v {
+    ( eth_push_header out eth_dst sender_mac ( ethertype_arp ) )
+    ( bytes_push_u16_be out # u16 1 )  // hardware type: Ethernet
+    ( bytes_push_u16_be out # u16 ( ethertype_ipv4 ) )
+    ( vec_push [u] out # u 6 )
+    ( vec_push [u] out # u 4 )
+    ( bytes_push_u16_be out # u16 & op 65535 )
+    ( eth_push_mac out sender_mac )
+    ( bytes_push_u32_be out # u32 & sender_ip 4294967295 )
+    ( eth_push_mac out target_mac )
+    ( bytes_push_u32_be out # u32 & target_ip 4294967295 )
+}
+
+// "Who has target_ip? Tell sender." Broadcast, target MAC zero.
+@ arp_push_request ( Vec u ) out i sender_mac i sender_ip i target_ip → v {
+    ( arp_push_frame out ( arp_op_request ) ( mac_broadcast ) sender_mac sender_ip 0 target_ip )
+}
+
+@ arp_push_reply ( Vec u ) out i sender_mac i sender_ip i target_mac i target_ip → v {
+    ( arp_push_frame out ( arp_op_reply ) target_mac sender_mac sender_ip target_mac target_ip )
+}
+
+// ── cache ────────────────────────────────────────────────────────
+
+: ArpEntry {
+    i ip
+    i mac
+    i state
+    i expires_at  // RESOLVED: entry death. INCOMPLETE: next retry due.
+    i retries
+}
+
+: ArpCache {
+    ( Vec ArpEntry ) entries
+    i max
+}
+
+@ arp_cache_new i max → *ArpCache {
+    : *ArpCache c # *ArpCache ( nurl_alloc Z ArpCache )
+    = . c entries ( vec_new [ArpEntry] )
+    = . c max ? > max 0 max 64
+    ^ c
+}
+
+@ arp_cache_free * ArpCache c → v {
+    ( vec_free [ArpEntry] . c entries )
+    ( free c )
+}
+
+@ __arp_find * ArpCache c i ip → i {
+    : i n ( vec_len [ArpEntry] . c entries )
+    : ~ i k 0
+    ~ < k n {
+        : ArpEntry e ?? ( vec_get [ArpEntry] . c entries k ) {
+            T x → x
+            F → @ ArpEntry { 0 0 0 0 0 }
+        }
+        ? && == . e ip ip != . e state ( arp_state_free ) { ^ k } {}
+        = k + k 1
+    }
+    ^ -1
+}
+
+// Resolved MAC for `ip`, if the entry is present and unexpired.
+@ arp_cache_lookup * ArpCache c i ip i now → ?i {
+    : i idx ( __arp_find c ip )
+    ? < idx 0 { ^ @ ?i { F 0 } } {}
+    : ArpEntry e ?? ( vec_get [ArpEntry] . c entries idx ) {
+        T x → x
+        F → @ ArpEntry { 0 0 0 0 0 }
+    }
+    ? != . e state ( arp_state_resolved ) { ^ @ ?i { F 0 } } {}
+    ? > now . e expires_at { ^ @ ?i { F 0 } } {}
+    ^ @ ?i { T . e mac }
+}
+
+// Evict the oldest slot when the table is full. A fixed-size table is
+// the point: an unbounded cache is a remote memory-exhaustion vector,
+// and a unikernel's whole heap is its budget.
+@ __arp_slot * ArpCache c i now → i {
+    : i n ( vec_len [ArpEntry] . c entries )
+    : ~ i k 0
+    ~ < k n {
+        : ArpEntry e ?? ( vec_get [ArpEntry] . c entries k ) {
+            T x → x
+            F → @ ArpEntry { 0 0 0 0 0 }
+        }
+        ? || == . e state ( arp_state_free ) > now . e expires_at { ^ k } {}
+        = k + k 1
+    }
+    ? < n . c max {
+        ( vec_push [ArpEntry] . c entries @ ArpEntry { 0 0 0 0 0 } )
+        ^ n
+    } {}
+    // Full and nothing expired — evict the entry closest to death.
+    : ~ i best 0
+    : ~ i best_exp -1
+    : ~ i j 0
+    ~ < j n {
+        : ArpEntry e ?? ( vec_get [ArpEntry] . c entries j ) {
+            T x → x
+            F → @ ArpEntry { 0 0 0 0 0 }
+        }
+        ? || < best_exp 0 < . e expires_at best_exp {
+            = best j
+            = best_exp . e expires_at
+        } {}
+        = j + j 1
+    }
+    ^ best
+}
+
+// Record a resolved binding. Called for replies we asked for and for
+// requests addressed to us — never for arbitrary observed traffic.
+@ arp_cache_insert * ArpCache c i ip i mac i now → v {
+    : ~ i idx ( __arp_find c ip )
+    ? < idx 0 { = idx ( __arp_slot c now ) } {}
+    : b _ok ( vec_set [ArpEntry] . c entries idx @ ArpEntry {
+        ip
+        mac
+        ( arp_state_resolved )
+        + now ( arp_ttl_ms )
+        0
+    } )
+}
+
+// Should we emit a request for `ip` right now?
+//
+// Returns T at most once per `arp_retry_ms` per destination, and stops
+// after `arp_max_retries` — the rate limit lives in the cache rather
+// than in the caller precisely so every send path inherits it.
+@ arp_cache_should_request * ArpCache c i ip i now → b {
+    : i idx ( __arp_find c ip )
+    ? < idx 0 {
+        : i slot ( __arp_slot c now )
+        : b _ok ( vec_set [ArpEntry] . c entries slot @ ArpEntry {
+            ip
+            0
+            ( arp_state_incomplete )
+            + now ( arp_retry_ms )
+            1
+        } )
+        ^ T
+    } {}
+    : ArpEntry e ?? ( vec_get [ArpEntry] . c entries idx ) {
+        T x → x
+        F → @ ArpEntry { 0 0 0 0 0 }
+    }
+    ? == . e state ( arp_state_resolved ) { ^ F } {}
+    ? < now . e expires_at { ^ F } {}
+    ? >= . e retries ( arp_max_retries ) { ^ F } {}
+    : b _ok ( vec_set [ArpEntry] . c entries idx @ ArpEntry {
+        ip
+        0
+        ( arp_state_incomplete )
+        + now ( arp_retry_ms )
+        + . e retries 1
+    } )
+    ^ T
+}
+
+// Has resolution of `ip` failed for good? The send path turns this
+// into a "host unreachable" error instead of queueing forever.
+@ arp_cache_failed * ArpCache c i ip i now → b {
+    : i idx ( __arp_find c ip )
+    ? < idx 0 { ^ F } {}
+    : ArpEntry e ?? ( vec_get [ArpEntry] . c entries idx ) {
+        T x → x
+        F → @ ArpEntry { 0 0 0 0 0 }
+    }
+    ^ && && == . e state ( arp_state_incomplete ) >= . e retries ( arp_max_retries ) >= now . e expires_at
+}
+
+// Drop expired entries. Optional hygiene — lookup already treats an
+// expired entry as absent — but it frees slots for new destinations.
+@ arp_cache_expire * ArpCache c i now → i {
+    : i n ( vec_len [ArpEntry] . c entries )
+    : ~ i freed 0
+    : ~ i k 0
+    ~ < k n {
+        : ArpEntry e ?? ( vec_get [ArpEntry] . c entries k ) {
+            T x → x
+            F → @ ArpEntry { 0 0 0 0 0 }
+        }
+        ? && != . e state ( arp_state_free ) > now . e expires_at {
+            : b _ok ( vec_set [ArpEntry] . c entries k @ ArpEntry { 0 0 0 0 0 } )
+            = freed + freed 1
+        } {}
+        = k + k 1
+    }
+    ^ freed
+}

--- a/stdlib/net/dhcp.nu
+++ b/stdlib/net/dhcp.nu
@@ -1,0 +1,399 @@
+// stdlib/net/dhcp.nu — DHCPv4 client (RFC 2131/2132), sans-IO.
+//
+// PURE — the client is a state machine plus a message codec. It never
+// reads a clock or a socket: `dhcp_tick(client, now)` is told the
+// time, and returns whether a message should be sent. That is what
+// makes lease timing (T1/T2/expiry, retransmit backoff) testable in
+// microseconds with a scripted clock instead of in real minutes.
+//
+// STATE MACHINE (RFC 2131 §4.4)
+//
+//   INIT ──discover──▶ SELECTING ──offer──▶ REQUESTING ──ack──▶ BOUND
+//                                                │                │
+//                                                nak              │ T1
+//                                                ▼                ▼
+//                                              INIT ◀──expiry── RENEWING
+//                                                                 │ T2
+//                                                                 ▼
+//                                                            REBINDING
+//
+// The renewal timers are the part hand-rolled clients skip, and the
+// failure mode is nasty: everything works for the lease duration
+// (typically hours in a test lab, minutes in a hypervisor), then the
+// address silently goes stale. A unikernel appliance is exactly the
+// thing left running past its first T1, so RENEWING/REBINDING are in
+// v1 scope, not deferred.
+//
+// XID DISCIPLINE: the transaction id is chosen per exchange and every
+// reply is matched against it AND against our MAC in the chaddr field.
+// A reply with a foreign xid is another guest's lease landing in our
+// broadcast domain — accepting it means fighting over an address.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/eth.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/udp4.nu`
+
+// ── constants ────────────────────────────────────────────────────
+
+@ dhcp_server_port → i { ^ 67 }
+
+@ dhcp_client_port → i { ^ 68 }
+
+@ dhcp_op_request → i { ^ 1 }
+
+@ dhcp_op_reply → i { ^ 2 }
+
+@ dhcp_magic → i { ^ 1669485411 }  // 99.130.83.99
+
+@ dhcp_msg_discover → i { ^ 1 }
+
+@ dhcp_msg_offer → i { ^ 2 }
+
+@ dhcp_msg_request → i { ^ 3 }
+
+@ dhcp_msg_ack → i { ^ 5 }
+
+@ dhcp_msg_nak → i { ^ 6 }
+
+@ dhcp_opt_subnet → i { ^ 1 }
+
+@ dhcp_opt_router → i { ^ 3 }
+
+@ dhcp_opt_dns → i { ^ 6 }
+
+@ dhcp_opt_lease → i { ^ 51 }
+
+@ dhcp_opt_msg_type → i { ^ 53 }
+
+@ dhcp_opt_server_id → i { ^ 54 }
+
+@ dhcp_opt_param_list → i { ^ 55 }
+
+@ dhcp_opt_renewal → i { ^ 58 }  // T1
+
+@ dhcp_opt_rebind → i { ^ 59 }  // T2
+
+@ dhcp_opt_end → i { ^ 255 }
+
+@ dhcp_state_init → i { ^ 0 }
+
+@ dhcp_state_selecting → i { ^ 1 }
+
+@ dhcp_state_requesting → i { ^ 2 }
+
+@ dhcp_state_bound → i { ^ 3 }
+
+@ dhcp_state_renewing → i { ^ 4 }
+
+@ dhcp_state_rebinding → i { ^ 5 }
+
+// Retransmit backoff, doubling from 4 s and capped — RFC 2131 §4.1
+// asks for randomised backoff; we have no entropy at this layer, so
+// the caller may perturb `dhcp_retry_base_ms` per boot instead.
+@ dhcp_retry_base_ms → i { ^ 4000 }
+
+@ dhcp_retry_max_ms → i { ^ 64000 }
+
+// ── message codec ────────────────────────────────────────────────
+
+: DhcpMsg {
+    i op
+    i xid
+    i yiaddr  // the address being offered/assigned to us
+    i siaddr
+    i chaddr_mac
+    i msg_type
+    i server_id
+    i subnet
+    i router
+    i dns
+    i lease_secs
+    i t1_secs
+    i t2_secs
+    b valid
+}
+
+@ __dhcp_empty → DhcpMsg { ^ @ DhcpMsg { 0 0 0 0 0 0 0 0 0 0 0 0 0 F } }
+
+// Walk the options field, collecting the ones we act on. Unknown
+// options are skipped by length — a malformed length must terminate
+// the walk rather than loop or read past the end.
+@ dhcp_parse ( Vec u ) buf i off i len → DhcpMsg {
+    ? < len 240 { ^ ( __dhcp_empty ) } {}
+    : i magic ?? ( bytes_read_u32_be buf + off 236 ) { T x → # i x F → 0 }
+    ? != magic ( dhcp_magic ) { ^ ( __dhcp_empty ) } {}
+    : ~ i msg_type 0
+    : ~ i server_id 0
+    : ~ i subnet 0
+    : ~ i router 0
+    : ~ i dns 0
+    : ~ i lease 0
+    : ~ i t1 0
+    : ~ i t2 0
+    : ~ i k 240
+    : ~ b done F
+    ~ && ! done < k len {
+        : i code ?? ( vec_get [u] buf + off k ) { T x → # i x F → 255 }
+        ? == code 255 { = done T } {
+            ? == code 0 { = k + k 1 } {
+                ? >= + k 2 len { = done T } {
+                    : i olen ?? ( vec_get [u] buf + off + k 1 ) { T x → # i x F → 0 }
+                    : i vstart + k 2
+                    ? > + vstart olen len { = done T } {
+                        ? && == code ( dhcp_opt_msg_type ) >= olen 1 {
+                            = msg_type ?? ( vec_get [u] buf + off vstart ) { T x → # i x F → 0 }
+                        } {}
+                        ? && == code ( dhcp_opt_server_id ) >= olen 4 {
+                            = server_id ?? ( bytes_read_u32_be buf + off vstart ) { T x → # i x F → 0 }
+                        } {}
+                        ? && == code ( dhcp_opt_subnet ) >= olen 4 {
+                            = subnet ?? ( bytes_read_u32_be buf + off vstart ) { T x → # i x F → 0 }
+                        } {}
+                        ? && == code ( dhcp_opt_router ) >= olen 4 {
+                            = router ?? ( bytes_read_u32_be buf + off vstart ) { T x → # i x F → 0 }
+                        } {}
+                        ? && == code ( dhcp_opt_dns ) >= olen 4 {
+                            = dns ?? ( bytes_read_u32_be buf + off vstart ) { T x → # i x F → 0 }
+                        } {}
+                        ? && == code ( dhcp_opt_lease ) >= olen 4 {
+                            = lease ?? ( bytes_read_u32_be buf + off vstart ) { T x → # i x F → 0 }
+                        } {}
+                        ? && == code ( dhcp_opt_renewal ) >= olen 4 {
+                            = t1 ?? ( bytes_read_u32_be buf + off vstart ) { T x → # i x F → 0 }
+                        } {}
+                        ? && == code ( dhcp_opt_rebind ) >= olen 4 {
+                            = t2 ?? ( bytes_read_u32_be buf + off vstart ) { T x → # i x F → 0 }
+                        } {}
+                        = k + vstart olen
+                    }
+                }
+            }
+        }
+    }
+    : ~ i mac 0
+    : ~ i j 0
+    ~ < j 6 {
+        = mac | << mac 8 ?? ( vec_get [u] buf + off + 28 j ) { T x → # i x F → 0 }
+        = j + j 1
+    }
+    ^ @ DhcpMsg {
+        ?? ( vec_get [u] buf off ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u32_be buf + off 4 ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u32_be buf + off 16 ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u32_be buf + off 20 ) { T x → # i x F → 0 }
+        mac
+        msg_type
+        server_id
+        subnet
+        router
+        dns
+        lease
+        t1
+        t2
+        T
+    }
+}
+
+@ __push_opt_u32 ( Vec u ) out i code i value → v {
+    ( vec_push [u] out # u code )
+    ( vec_push [u] out # u 4 )
+    ( bytes_push_u32_be out # u32 & value 4294967295 )
+}
+
+// Build the BOOTP/DHCP message body (no UDP/IP headers).
+@ dhcp_push_message ( Vec u ) out i msg_type i xid i mac i ciaddr i requested_ip i server_id → v {
+    ( vec_push [u] out # u ( dhcp_op_request ) )
+    ( vec_push [u] out # u 1 )  // htype: Ethernet
+    ( vec_push [u] out # u 6 )  // hlen
+    ( vec_push [u] out # u 0 )  // hops
+    ( bytes_push_u32_be out # u32 & xid 4294967295 )
+    ( bytes_push_u16_be out # u16 0 )  // secs
+    // Broadcast flag: we cannot receive a unicast reply before we own
+    // an address, because the reply's destination IP would not match
+    // anything we accept. Asking the server to broadcast is what makes
+    // the first exchange work at all on a stack without a raw-socket
+    // bypass.
+    ( bytes_push_u16_be out # u16 32768 )
+    ( bytes_push_u32_be out # u32 & ciaddr 4294967295 )
+    ( bytes_push_u32_be out # u32 0 )  // yiaddr
+    ( bytes_push_u32_be out # u32 0 )  // siaddr
+    ( bytes_push_u32_be out # u32 0 )  // giaddr
+    ( eth_push_mac out mac )
+    : ~ i pad 0
+    ~ < pad 202 { ( vec_push [u] out # u 0 ) = pad + pad 1 }  // chaddr tail + sname + file
+    ( bytes_push_u32_be out # u32 ( dhcp_magic ) )
+    ( vec_push [u] out # u ( dhcp_opt_msg_type ) )
+    ( vec_push [u] out # u 1 )
+    ( vec_push [u] out # u & msg_type 255 )
+    ? != requested_ip 0 { ( __push_opt_u32 out 50 requested_ip ) } {}
+    ? != server_id 0 { ( __push_opt_u32 out ( dhcp_opt_server_id ) server_id ) } {}
+    ( vec_push [u] out # u ( dhcp_opt_param_list ) )
+    ( vec_push [u] out # u 4 )
+    ( vec_push [u] out # u ( dhcp_opt_subnet ) )
+    ( vec_push [u] out # u ( dhcp_opt_router ) )
+    ( vec_push [u] out # u ( dhcp_opt_dns ) )
+    ( vec_push [u] out # u ( dhcp_opt_lease ) )
+    ( vec_push [u] out # u ( dhcp_opt_end ) )
+}
+
+// ── client state machine ─────────────────────────────────────────
+
+: DhcpClient {
+    i state
+    i mac
+    i xid
+    i our_ip
+    i server_id
+    i subnet
+    i router
+    i dns
+    i lease_ms  // absolute deadline: lease expiry
+    i t1_ms  // absolute: renew
+    i t2_ms  // absolute: rebind
+    i next_send_ms  // absolute: next (re)transmit
+    i backoff_ms
+    i sends
+}
+
+@ dhcp_client_new i mac i xid → *DhcpClient {
+    : *DhcpClient c # *DhcpClient ( nurl_alloc Z DhcpClient )
+    = . c state ( dhcp_state_init )
+    = . c mac mac
+    = . c xid xid
+    = . c our_ip 0
+    = . c server_id 0
+    = . c subnet 0
+    = . c router 0
+    = . c dns 0
+    = . c lease_ms 0
+    = . c t1_ms 0
+    = . c t2_ms 0
+    = . c next_send_ms 0
+    = . c backoff_ms ( dhcp_retry_base_ms )
+    = . c sends 0
+    ^ c
+}
+
+@ dhcp_client_free * DhcpClient c → v { ( free c ) }
+
+@ dhcp_bound * DhcpClient c → b {
+    ^ || || == . c state ( dhcp_state_bound ) == . c state ( dhcp_state_renewing ) == . c state ( dhcp_state_rebinding )
+}
+
+// What the caller should transmit now, if anything: 0 = nothing,
+// otherwise a DHCP message type. Advances retransmit backoff and the
+// lease timers. Call it on every event-loop turn.
+@ dhcp_tick * DhcpClient c i now → i {
+    ? == . c state ( dhcp_state_init ) {
+        = . c state ( dhcp_state_selecting )
+        = . c next_send_ms + now ( dhcp_retry_base_ms )
+        = . c backoff_ms ( dhcp_retry_base_ms )
+        = . c sends 1
+        ^ ( dhcp_msg_discover )
+    } {}
+    // Lease expiry outranks everything: an expired address must not be
+    // used for another packet, so we fall all the way back to INIT.
+    ? && ( dhcp_bound c ) >= now . c lease_ms {
+        = . c state ( dhcp_state_init )
+        = . c our_ip 0
+        = . c server_id 0
+        = . c next_send_ms now
+        ^ 0
+    } {}
+    ? && == . c state ( dhcp_state_bound ) >= now . c t1_ms {
+        = . c state ( dhcp_state_renewing )
+        = . c next_send_ms + now ( dhcp_retry_base_ms )
+        = . c backoff_ms ( dhcp_retry_base_ms )
+        = . c sends 1
+        ^ ( dhcp_msg_request )
+    } {}
+    ? && == . c state ( dhcp_state_renewing ) >= now . c t2_ms {
+        // T2: the leasing server is not answering — broadcast to any.
+        = . c state ( dhcp_state_rebinding )
+        = . c server_id 0
+        = . c next_send_ms + now ( dhcp_retry_base_ms )
+        = . c backoff_ms ( dhcp_retry_base_ms )
+        = . c sends 1
+        ^ ( dhcp_msg_request )
+    } {}
+    ? < now . c next_send_ms { ^ 0 } {}
+    // Retransmit whatever this state sends.
+    = . c backoff_ms ? >= * . c backoff_ms 2 ( dhcp_retry_max_ms ) ( dhcp_retry_max_ms ) * . c backoff_ms 2
+    = . c next_send_ms + now . c backoff_ms
+    = . c sends + . c sends 1
+    ? == . c state ( dhcp_state_selecting ) { ^ ( dhcp_msg_discover ) } {}
+    ? || || == . c state ( dhcp_state_requesting ) == . c state ( dhcp_state_renewing ) == . c state ( dhcp_state_rebinding ) {
+        ^ ( dhcp_msg_request )
+    } {}
+    ^ 0
+}
+
+// Feed a parsed reply. Returns T if it changed our state.
+//
+// Every reply is matched on xid AND chaddr: a foreign xid is another
+// client's lease arriving in the same broadcast domain, and honouring
+// it means two guests claiming one address.
+@ dhcp_handle * DhcpClient c DhcpMsg m i now → b {
+    ? ! . m valid { ^ F } {}
+    ? != . m op ( dhcp_op_reply ) { ^ F } {}
+    ? != . m xid . c xid { ^ F } {}
+    ? != . m chaddr_mac . c mac { ^ F } {}
+    ? && == . m msg_type ( dhcp_msg_offer ) == . c state ( dhcp_state_selecting ) {
+        = . c our_ip . m yiaddr
+        = . c server_id . m server_id
+        = . c state ( dhcp_state_requesting )
+        = . c backoff_ms ( dhcp_retry_base_ms )
+        = . c next_send_ms + now ( dhcp_retry_base_ms )
+        = . c sends 1
+        ^ T
+    } {}
+    ? == . m msg_type ( dhcp_msg_ack ) {
+        ? || || == . c state ( dhcp_state_requesting ) == . c state ( dhcp_state_renewing ) == . c state ( dhcp_state_rebinding ) {
+            = . c our_ip . m yiaddr
+            ? != . m server_id 0 { = . c server_id . m server_id } {}
+            = . c subnet ? != . m subnet 0 . m subnet ( ipv4_mask_from_prefix 24 )
+            = . c router . m router
+            = . c dns . m dns
+            : i lease ? > . m lease_secs 0 . m lease_secs 3600
+            // T1/T2 default to RFC 2131's 0.5 / 0.875 of the lease
+            // when the server does not send them explicitly.
+            : i t1 ? > . m t1_secs 0 . m t1_secs / lease 2
+            : i t2 ? > . m t2_secs 0 . m t2_secs / * lease 7 8
+            = . c lease_ms + now * lease 1000
+            = . c t1_ms + now * t1 1000
+            = . c t2_ms + now * t2 1000
+            = . c state ( dhcp_state_bound )
+            = . c backoff_ms ( dhcp_retry_base_ms )
+            = . c sends 0
+            ^ T
+        } {}
+        ^ F
+    } {}
+    ? == . m msg_type ( dhcp_msg_nak ) {
+        // NAK at any point means our claim is invalid — the address
+        // must be dropped immediately, not used until expiry.
+        = . c state ( dhcp_state_init )
+        = . c our_ip 0
+        = . c server_id 0
+        = . c lease_ms 0
+        = . c next_send_ms now
+        ^ T
+    } {}
+    ^ F
+}
+
+// The destination for a message in the current state: RENEWING
+// unicasts to the leasing server, everything else broadcasts.
+@ dhcp_dest_ip * DhcpClient c → i {
+    ? && == . c state ( dhcp_state_renewing ) != . c server_id 0 { ^ . c server_id } {}
+    ^ 4294967295
+}
+
+@ dhcp_src_ip * DhcpClient c → i {
+    ? || == . c state ( dhcp_state_renewing ) == . c state ( dhcp_state_rebinding ) { ^ . c our_ip } {}
+    ^ 0
+}

--- a/stdlib/net/eth.nu
+++ b/stdlib/net/eth.nu
@@ -1,0 +1,112 @@
+// stdlib/net/eth.nu — Ethernet II framing for the sans-IO stack.
+//
+// PURE — parse and build only; nothing here touches a device.
+//
+// ZERO-COPY PARSE. `eth_parse` does not copy the payload: it returns
+// the header fields plus the payload's offset and length *into the
+// caller's buffer*. The caller owns the frame for the whole parse
+// chain (eth → ipv4 → udp/tcp), so every layer is a scalar struct and
+// a pair of indices — no per-packet allocation, and no ownership
+// transfer between layers. A stack that allocated a fresh buffer per
+// layer would do four allocations per received frame.
+//
+// A parse failure is a value, not a panic: `valid = F` with a reason
+// code. Malformed frames arrive from the network by definition, so
+// rejecting them is normal control flow, and the reason code lets the
+// device layer keep honest counters instead of dropping silently.
+//
+// NOT SUPPORTED IN v1 (deliberate, documented): 802.1Q VLAN tags and
+// 802.3/LLC framing. Both parse as an unknown ethertype and are
+// dropped by the layer above. The unikernel target sees a virtio-net
+// device on a hypervisor-side switch, where neither appears.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+
+// ── constants ────────────────────────────────────────────────────
+
+@ eth_hdr_len → i { ^ 14 }
+
+@ ethertype_ipv4 → i { ^ 2048 }
+
+@ ethertype_arp → i { ^ 2054 }
+
+@ ethertype_ipv6 → i { ^ 34525 }
+
+// The largest payload an Ethernet II frame carries without jumbo
+// frames. The stack's IPv4 MTU derives from this.
+@ eth_mtu → i { ^ 1500 }
+
+// Reason codes for a rejected frame — kept as small ints so the
+// device layer can index a counter array directly.
+@ eth_ok → i { ^ 0 }
+
+@ eth_err_short → i { ^ 1 }
+
+// ── parse ────────────────────────────────────────────────────────
+
+: EthHdr {
+    i dst
+    i src
+    i ethertype
+    i payload_off
+    i payload_len
+    b valid
+    i reason
+}
+
+@ __mac_at ( Vec u ) v i off → i {
+    : ~ i acc 0
+    : ~ i k 0
+    ~ < k 6 {
+        : i b ?? ( vec_get [u] v + off k ) { T x → # i x F → 0 }
+        = acc | << acc 8 b
+        = k + k 1
+    }
+    ^ acc
+}
+
+@ eth_parse ( Vec u ) frame → EthHdr {
+    : i n ( vec_len [u] frame )
+    ? < n 14 {
+        ^ @ EthHdr { 0 0 0 0 0 F ( eth_err_short ) }
+    } {}
+    : i et ?? ( bytes_read_u16_be frame 12 ) { T x → # i x F → 0 }
+    ^ @ EthHdr {
+        ( __mac_at frame 0 )
+        ( __mac_at frame 6 )
+        et
+        14
+        - n 14
+        T
+        ( eth_ok )
+    }
+}
+
+// ── build ────────────────────────────────────────────────────────
+
+@ eth_push_mac ( Vec u ) out i mac → v {
+    : ~ i k 0
+    ~ < k 6 {
+        ( vec_push [u] out # u & >> mac * 8 - 5 k 255 )
+        = k + k 1
+    }
+}
+
+// Append a 14-byte Ethernet II header to `out`. The payload is the
+// caller's to append next — keeping them separate is what lets the
+// IPv4 layer write its header directly after this one with no splice.
+@ eth_push_header ( Vec u ) out i dst i src i ethertype → v {
+    ( eth_push_mac out dst )
+    ( eth_push_mac out src )
+    ( bytes_push_u16_be out # u16 & ethertype 65535 )
+}
+
+// Does this frame's destination address concern us? Accepts our
+// unicast address, broadcast, and multicast (the stack above filters
+// multicast groups it did not join).
+@ eth_addressed_to_us i dst i our_mac → b {
+    ^ || == dst our_mac || ( mac_is_broadcast dst ) ( mac_is_multicast dst )
+}

--- a/stdlib/net/icmp.nu
+++ b/stdlib/net/icmp.nu
@@ -1,0 +1,93 @@
+// stdlib/net/icmp.nu — ICMPv4 echo + error messages, sans-IO.
+//
+// PURE — parse and build only.
+//
+// v1 handles echo request/reply (so the guest answers ping, the first
+// end-to-end proof that rx and tx both work) and *parses* the error
+// messages that matter to a stack with no fragmentation: destination
+// unreachable, in particular code 4 "fragmentation needed", which is
+// how a path-MTU black hole announces itself when we set DF.
+//
+// ICMPv4 checksums cover the ICMP message only — no pseudo-header
+// (that is ICMPv6, and the difference is a classic silent-corruption
+// bug when porting between the two).
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/ipv4.nu`
+
+// ── constants ────────────────────────────────────────────────────
+
+@ icmp_echo_reply → i { ^ 0 }
+
+@ icmp_dest_unreach → i { ^ 3 }
+
+@ icmp_echo_request → i { ^ 8 }
+
+@ icmp_time_exceeded → i { ^ 11 }
+
+// Code 4 of destination-unreachable: "fragmentation needed and DF set".
+@ icmp_code_frag_needed → i { ^ 4 }
+
+@ icmp_hdr_len → i { ^ 8 }
+
+// ── parse ────────────────────────────────────────────────────────
+
+: IcmpMsg {
+    i mtype
+    i code
+    i id  // echo: identifier. errors: unused/next-hop MTU high half.
+    i seq  // echo: sequence. dest-unreach code 4: next-hop MTU.
+    i payload_off
+    i payload_len
+    b valid
+}
+
+@ icmp_parse ( Vec u ) buf i off i len → IcmpMsg {
+    ? < len 8 { ^ @ IcmpMsg { 0 0 0 0 0 0 F } } {}
+    ? != ( inet_fold ( inet_sum buf off len ) ) 65535 {
+        ^ @ IcmpMsg { 0 0 0 0 0 0 F }
+    } {}
+    ^ @ IcmpMsg {
+        ?? ( vec_get [u] buf off ) { T x → # i x F → 0 }
+        ?? ( vec_get [u] buf + off 1 ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u16_be buf + off 4 ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u16_be buf + off 6 ) { T x → # i x F → 0 }
+        + off 8
+        - len 8
+        T
+    }
+}
+
+// ── build ────────────────────────────────────────────────────────
+
+// Append a complete ICMP message (header + payload) and fix up its
+// checksum. Unlike the other layers, the payload is passed in rather
+// than appended by the caller afterwards: the ICMP checksum covers
+// header *and* payload, so the bytes must be present before the
+// prefix field can be filled in.
+@ icmp_push ( Vec u ) out i mtype i code i id i seq ( Vec u ) payload i pay_off i pay_len → v {
+    : i start ( vec_len [u] out )
+    ( vec_push [u] out # u & mtype 255 )
+    ( vec_push [u] out # u & code 255 )
+    ( bytes_push_u16_be out # u16 0 )  // checksum placeholder
+    ( bytes_push_u16_be out # u16 & id 65535 )
+    ( bytes_push_u16_be out # u16 & seq 65535 )
+    : ~ i k 0
+    ~ < k pay_len {
+        ( vec_push [u] out ?? ( vec_get [u] payload + pay_off k ) { T x → x F → # u 0 } )
+        = k + k 1
+    }
+    : i ck ( inet_checksum out start + 8 pay_len )
+    : b _a ( vec_set [u] out + start 2 # u & >> ck 8 255 )
+    : b _b ( vec_set [u] out + start 3 # u & ck 255 )
+}
+
+// An echo reply mirrors the request's identifier, sequence AND payload
+// (RFC 792) — ping measures RTT by embedding a timestamp in the
+// payload, so dropping it makes every ping report nonsense.
+@ icmp_push_echo_reply ( Vec u ) out IcmpMsg req ( Vec u ) src → v {
+    ( icmp_push out ( icmp_echo_reply ) 0 . req id . req seq src . req payload_off . req payload_len )
+}

--- a/stdlib/net/inet.nu
+++ b/stdlib/net/inet.nu
@@ -1,0 +1,218 @@
+// stdlib/net/inet.nu — shared primitives for the sans-IO network stack.
+//
+// The bottom of the unikernel net tower: the RFC 1071 internet checksum
+// and scalar address representations that every layer above (eth, arp,
+// ipv4, icmp, udp, tcp) needs.
+//
+// PURE — no FFI, no sockets, no clock. Everything here is a total
+// function over bytes and integers, so it is unit-testable offline and
+// linkable into a freestanding target.
+//
+// ADDRESS REPRESENTATION
+//
+//   IPv4 address → `i`, host order, low 32 bits. 10.0.2.15 is
+//                  0x0A00020F. Zero is "unspecified", not a valid host.
+//   MAC address  → `i`, low 48 bits, first wire byte most significant.
+//                  02:00:00:00:00:01 is 0x020000000001.
+//
+// Scalars, deliberately: addresses are copied, compared and stored in
+// tables constantly, and a `( Vec u )` for each would mean an owned
+// allocation per lookup plus the ownership dance on every match arm.
+// Fixed-width identities are values, not buffers.
+//
+// OWNERSHIP: everything in this module is a scalar except `ipv4_str`
+// and `mac_str`, which return a `String` — a manually-managed handle
+// (docs/MEMORY.md §7.4). The caller frees it with `string_free`. Both
+// are diagnostic helpers; nothing on the packet hot path allocates.
+//
+// CHECKSUM
+//
+//   `inet_sum` accumulates a 32-bit one's-complement sum over a byte
+//   range; `inet_sum_add`/`inet_sum_u16` extend one over non-contiguous
+//   data (a TCP/UDP pseudo-header is not adjacent to its payload), and
+//   `inet_fold` collapses the accumulator to 16 bits. Splitting the
+//   accumulation from the folding is what makes the pseudo-header case
+//   work without building a temporary buffer.
+//
+//   The sum is endian-agnostic in the classic way: it is computed on
+//   big-endian 16-bit words and stored big-endian, so a receiver that
+//   sums the whole datagram including the checksum field gets 0xFFFF.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+// ── checksum ─────────────────────────────────────────────────────
+
+// Accumulate the big-endian 16-bit words of v[off .. off+len) into an
+// existing 32-bit accumulator. A trailing odd byte is padded on the
+// right with zero, per RFC 1071 §1.
+@ inet_sum_add i acc ( Vec u ) v i off i len → i {
+    : ~ i s acc
+    : ~ i k 0
+    ~ <= + k 2 len {
+        : i hi ?? ( vec_get [u] v + off k ) { T b → # i b F → 0 }
+        : i lo ?? ( vec_get [u] v + off + k 1 ) { T b → # i b F → 0 }
+        = s + s | << hi 8 lo
+        = k + k 2
+    }
+    ? == & len 1 1 {
+        : i hi ?? ( vec_get [u] v + off - len 1 ) { T b → # i b F → 0 }
+        = s + s << hi 8
+    } {}
+    ^ s
+}
+
+// Accumulate a single 16-bit value (pseudo-header fields).
+@ inet_sum_u16 i acc i x → i { ^ + acc & x 65535 }
+
+// Accumulate a 32-bit value as two 16-bit words (pseudo-header addrs).
+@ inet_sum_u32 i acc i x → i { ^ + + acc & >> x 16 65535 & x 65535 }
+
+// Sum a byte range from scratch.
+@ inet_sum ( Vec u ) v i off i len → i { ^ ( inet_sum_add 0 v off len ) }
+
+// Collapse carries into 16 bits.
+@ inet_fold i acc → i {
+    : ~ i x acc
+    ~ > x 65535 { = x + & x 65535 >> x 16 }
+    ^ x
+}
+
+// Final checksum from an accumulator: fold, then one's complement.
+@ inet_finish i acc → i { ^ ^^ ( inet_fold acc ) 65535 }
+
+// One-shot checksum over a byte range.
+@ inet_checksum ( Vec u ) v i off i len → i { ^ ( inet_finish ( inet_sum v off len ) ) }
+
+// ── IPv4 addresses ───────────────────────────────────────────────
+
+@ ipv4_make i a i b i c i d → i {
+    ^ | | | << & a 255 24 << & b 255 16 << & c 255 8 & d 255
+}
+
+@ ipv4_octet i addr i n → i { ^ & >> addr * 8 - 3 n 255 }
+
+// Dotted-quad → address. Strict: exactly four decimal octets, each
+// 0..255, no leading '+'/'-', no empty component, nothing trailing.
+// Strictness matters — a lax parser here turns a typo in a relay
+// address into a silent connection to the wrong host.
+@ ipv4_parse s text → ?i {
+    : i n ( nurl_str_len text )
+    ? == n 0 { ^ @ ?i { F 0 } } {}
+    : ~ i acc 0
+    : ~ i octet 0
+    : ~ i digits 0
+    : ~ i parts 0
+    : ~ b ok T
+    : ~ i k 0
+    ~ && ok < k n {
+        : i c ( nurl_str_at text n k )
+        ? == c 46 {
+            // '.' — close the current octet
+            ? || == digits 0 == parts 3 { = ok F } {
+                = acc | << acc 8 octet
+                = parts + parts 1
+                = octet 0
+                = digits 0
+            }
+        } {
+            ? && >= c 48 <= c 57 {
+                = octet + * octet 10 - c 48
+                = digits + digits 1
+                // >3 digits or >255 is malformed; both are rejected here
+                ? || > digits 3 > octet 255 { = ok F } {}
+            } { = ok F }
+        }
+        = k + k 1
+    }
+    ? || ! ok || == digits 0 != parts 3 { ^ @ ?i { F 0 } } {}
+    = acc | << acc 8 octet
+    ^ @ ?i { T acc }
+}
+
+@ ipv4_str i addr → String {
+    : String out ( string_new )
+    : ~ i g 0
+    ~ < g 4 {
+        ? > g 0 { ( string_push_str out `.` ) } {}
+        ( string_push_int out ( ipv4_octet addr g ) )
+        = g + g 1
+    }
+    ^ out
+}
+
+// Is `addr` inside the network `net`/`mask` (both host-order)?
+@ ipv4_in_subnet i addr i net i mask → b { ^ == & addr mask & net mask }
+
+// 224.0.0.0/4
+@ ipv4_is_multicast i addr → b { ^ == & addr 4026531840 3758096384 }
+
+@ ipv4_is_broadcast i addr → b { ^ == addr 4294967295 }
+
+// The all-ones directed broadcast for a subnet, e.g. 10.0.2.255.
+@ ipv4_subnet_broadcast i net i mask → i {
+    ^ | & net mask & ^^ mask 4294967295 4294967295
+}
+
+// Prefix length → mask. 24 → 255.255.255.0. Out-of-range clamps.
+@ ipv4_mask_from_prefix i bits → i {
+    ? <= bits 0 { ^ 0 } {}
+    ? >= bits 32 { ^ 4294967295 } {}
+    ^ & << 4294967295 - 32 bits 4294967295
+}
+
+// ── MAC addresses ────────────────────────────────────────────────
+
+@ mac_broadcast → i { ^ 281474976710655 }
+
+@ mac_is_broadcast i mac → b { ^ == mac 281474976710655 }
+
+// A multicast MAC has the low bit of the first octet set.
+@ mac_is_multicast i mac → b { ^ == & >> mac 40 1 1 }
+
+@ mac_octet i mac i n → i { ^ & >> mac * 8 - 5 n 255 }
+
+@ __hexdig i c → i {
+    ? && >= c 48 <= c 57 { ^ - c 48 } {}
+    ? && >= c 97 <= c 102 { ^ - c 87 } {}
+    ? && >= c 65 <= c 70 { ^ - c 55 } {}
+    ^ -1
+}
+
+// "02:00:00:00:00:01" → 0x020000000001. Accepts ':' or '-' separators
+// and either case; requires exactly six two-digit groups.
+@ mac_parse s text → ?i {
+    : i n ( nurl_str_len text )
+    ? != n 17 { ^ @ ?i { F 0 } } {}
+    : ~ i acc 0
+    : ~ b ok T
+    : ~ i g 0
+    ~ && ok < g 6 {
+        : i base * g 3
+        : i hi ( __hexdig ( nurl_str_at text n base ) )
+        : i lo ( __hexdig ( nurl_str_at text n + base 1 ) )
+        ? || < hi 0 < lo 0 { = ok F } { = acc | << acc 8 | << hi 4 lo }
+        ? < g 5 {
+            : i sep ( nurl_str_at text n + base 2 )
+            ? && != sep 58 != sep 45 { = ok F } {}
+        } {}
+        = g + g 1
+    }
+    ? ! ok { ^ @ ?i { F 0 } } {}
+    ^ @ ?i { T acc }
+}
+
+@ __hexchar i v → i { ^ ? < v 10 + 48 v + 87 v }
+
+@ mac_str i mac → String {
+    : String out ( string_new )
+    : ~ i g 0
+    ~ < g 6 {
+        ? > g 0 { ( string_push_str out `:` ) } {}
+        : i o ( mac_octet mac g )
+        ( string_push_char out ( __hexchar >> o 4 ) )
+        ( string_push_char out ( __hexchar & o 15 ) )
+        = g + g 1
+    }
+    ^ out
+}

--- a/stdlib/net/ipv4.nu
+++ b/stdlib/net/ipv4.nu
@@ -1,0 +1,156 @@
+// stdlib/net/ipv4.nu — IPv4 header parse/build for the sans-IO stack.
+//
+// PURE — zero-copy parse in the same shape as net/eth (scalar header
+// struct + payload offset/length into the caller's buffer).
+//
+// TWO CORRECTNESS POINTS THAT BITE EVERY HAND-ROLLED STACK
+//
+// 1. The payload length comes from the IP header's `total_len`, NEVER
+//    from the received frame length. Ethernet pads frames to a 60-byte
+//    minimum, so a 4-byte UDP payload arrives in a frame with 18 bytes
+//    of trailing garbage. A stack that trusts the frame length hands
+//    that padding to the application, and — worse — computes the UDP
+//    checksum over it and rejects a perfectly good datagram.
+//
+// 2. Fragments are detected explicitly, not ignored. v1 does not
+//    reassemble (see the unikernel plan), so a fragment must be
+//    dropped with a distinct reason code. Silently parsing the first
+//    fragment as a whole datagram would hand truncated data upward as
+//    if it were complete — a correctness hole that looks like a flaky
+//    peer for months.
+//
+// Header options (IHL > 5) are parsed and skipped, not rejected: the
+// payload offset follows IHL. We never *emit* options.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+
+// ── constants ────────────────────────────────────────────────────
+
+@ ip_proto_icmp → i { ^ 1 }
+
+@ ip_proto_tcp → i { ^ 6 }
+
+@ ip_proto_udp → i { ^ 17 }
+
+@ ip4_min_hdr → i { ^ 20 }
+
+@ ip4_ok → i { ^ 0 }
+
+@ ip4_err_short → i { ^ 1 }
+
+@ ip4_err_version → i { ^ 2 }
+
+@ ip4_err_ihl → i { ^ 3 }
+
+@ ip4_err_checksum → i { ^ 4 }
+
+@ ip4_err_truncated → i { ^ 5 }
+
+@ ip4_err_fragment → i { ^ 6 }
+
+// ── parse ────────────────────────────────────────────────────────
+
+: Ip4Hdr {
+    i ihl  // header length in BYTES, options included
+    i tos
+    i total_len
+    i id
+    i flags  // bit 0 = MF, bit 1 = DF (as carried, not shifted)
+    i frag_off  // in 8-byte units, as carried
+    i ttl
+    i proto
+    i src
+    i dst
+    i payload_off  // absolute offset into the buffer handed to ip4_parse
+    i payload_len
+    b valid
+    i reason
+}
+
+@ __ip4_bad i reason → Ip4Hdr {
+    ^ @ Ip4Hdr { 0 0 0 0 0 0 0 0 0 0 0 0 F reason }
+}
+
+// Parse the IPv4 datagram starting at `off` in `buf`, where `avail`
+// bytes are actually present from `off` on (the Ethernet payload
+// length — which may exceed total_len because of frame padding).
+@ ip4_parse ( Vec u ) buf i off i avail → Ip4Hdr {
+    ? < avail 20 { ^ ( __ip4_bad ( ip4_err_short ) ) } {}
+    : i b0 ?? ( vec_get [u] buf off ) { T x → # i x F → 0 }
+    ? != >> b0 4 4 { ^ ( __ip4_bad ( ip4_err_version ) ) } {}
+    : i ihl * & b0 15 4
+    ? || < ihl 20 > ihl avail { ^ ( __ip4_bad ( ip4_err_ihl ) ) } {}
+    : i total ?? ( bytes_read_u16_be buf + off 2 ) { T x → # i x F → 0 }
+    // total_len must cover the header and must not claim more bytes
+    // than the link layer delivered.
+    ? || < total ihl > total avail { ^ ( __ip4_bad ( ip4_err_truncated ) ) } {}
+    ? != ( inet_fold ( inet_sum buf off ihl ) ) 65535 {
+        ^ ( __ip4_bad ( ip4_err_checksum ) )
+    } {}
+    : i ff ?? ( bytes_read_u16_be buf + off 6 ) { T x → # i x F → 0 }
+    : i flags >> ff 13
+    : i frag & ff 8191
+    // MF set or a non-zero offset ⇒ this is a fragment. v1 has no
+    // reassembly; report it distinctly so the caller can count it.
+    ? || == & flags 1 1 != frag 0 { ^ ( __ip4_bad ( ip4_err_fragment ) ) } {}
+    ^ @ Ip4Hdr {
+        ihl
+        ?? ( vec_get [u] buf + off 1 ) { T x → # i x F → 0 }
+        total
+        ?? ( bytes_read_u16_be buf + off 4 ) { T x → # i x F → 0 }
+        flags
+        frag
+        ?? ( vec_get [u] buf + off 8 ) { T x → # i x F → 0 }
+        ?? ( vec_get [u] buf + off 9 ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u32_be buf + off 12 ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u32_be buf + off 16 ) { T x → # i x F → 0 }
+        + off ihl
+        - total ihl
+        T
+        ( ip4_ok )
+    }
+}
+
+// ── build ────────────────────────────────────────────────────────
+
+// Append a 20-byte IPv4 header with a correct checksum. `payload_len`
+// is the length of what the caller appends next.
+//
+// `df` sets Don't-Fragment. We set it on everything we originate: this
+// stack cannot reassemble replies to its own fragmented output either,
+// so DF turns a silent black hole into an ICMP "fragmentation needed"
+// the path-MTU logic above can actually see.
+@ ip4_push_header ( Vec u ) out i src i dst i proto i payload_len i id i ttl b df → v {
+    : i start ( vec_len [u] out )
+    ( vec_push [u] out # u 69 )  // version 4, IHL 5
+    ( vec_push [u] out # u 0 )  // TOS
+    ( bytes_push_u16_be out # u16 & + 20 payload_len 65535 )
+    ( bytes_push_u16_be out # u16 & id 65535 )
+    ( bytes_push_u16_be out # u16 ? df 16384 0 )
+    ( vec_push [u] out # u & ttl 255 )
+    ( vec_push [u] out # u & proto 255 )
+    ( bytes_push_u16_be out # u16 0 )  // checksum placeholder
+    ( bytes_push_u32_be out # u32 & src 4294967295 )
+    ( bytes_push_u32_be out # u32 & dst 4294967295 )
+    : i ck ( inet_checksum out start 20 )
+    : b _a ( vec_set [u] out + start 10 # u & >> ck 8 255 )
+    : b _b ( vec_set [u] out + start 11 # u & ck 255 )
+}
+
+// ── pseudo-header ────────────────────────────────────────────────
+
+// The 12-byte IPv4 pseudo-header sum used by UDP and TCP checksums:
+// src, dst, zero, protocol, transport length. Returned as a partial
+// accumulator so the caller folds it together with the real payload —
+// no temporary buffer is ever built.
+@ ip4_pseudo_sum i src i dst i proto i transport_len → i {
+    : ~ i s 0
+    = s ( inet_sum_u32 s src )
+    = s ( inet_sum_u32 s dst )
+    = s ( inet_sum_u16 s & proto 255 )
+    = s ( inet_sum_u16 s & transport_len 65535 )
+    ^ s
+}

--- a/stdlib/net/stack.nu
+++ b/stdlib/net/stack.nu
@@ -1,0 +1,338 @@
+// stdlib/net/stack.nu — the sans-IO IPv4 stack: frames in, frames out.
+//
+// THE SANS-IO SEAM. This is the object a device driver talks to, and
+// it is deliberately ignorant of devices, sockets, threads and clocks:
+//
+//     ( stack_rx st frame now out )   → RxResult   (may append a reply to `out`)
+//     ( stack_tx_udp st … now out )   → TxResult   (may append an ARP request)
+//     ( stack_tick st now out )       → i          (timers → frames)
+//
+// `now` is milliseconds from a monotonic source the *caller* owns, and
+// every emitted frame is appended to a caller-owned buffer. Nothing in
+// this file allocates a socket, blocks, or reads a clock — which is
+// what lets the whole stack run under a scripted clock in a unit test
+// on the host, and unmodified inside a unikernel against virtio-net.
+//
+// WHAT IT HANDLES (v1)
+//   * ARP: answers requests for our address, learns from replies to
+//     our own requests, resolves destinations before sending.
+//   * ICMP: answers echo requests (this is what makes `ping` work).
+//   * UDP: verifies and hands datagrams up; builds and addresses
+//     outbound ones.
+//   * Routing: on-link destinations go direct, everything else goes
+//     via the gateway — the smallest routing table that is still a
+//     routing table.
+//
+// WHAT IT REFUSES, ON PURPOSE
+//   * IP fragments (no reassembly in v1) — counted, not silently
+//     mis-parsed.
+//   * Frames not addressed to us, foreign ARP, bad checksums — all
+//     counted so a driver can expose honest statistics instead of a
+//     vague "packet loss" feeling.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/eth.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/arp.nu`
+$ `stdlib/net/icmp.nu`
+$ `stdlib/net/udp4.nu`
+
+// ── rx outcomes ──────────────────────────────────────────────────
+
+@ rx_none → i { ^ 0 }  // consumed internally, nothing for the caller
+
+@ rx_udp → i { ^ 1 }  // a UDP datagram is ready
+
+@ rx_icmp_echo → i { ^ 2 }  // we answered a ping
+
+@ rx_arp_handled → i { ^ 3 }
+
+@ rx_dropped → i { ^ 4 }
+
+// drop reasons — every discarded frame lands in exactly one bucket
+@ drop_not_for_us → i { ^ 0 }
+
+@ drop_bad_eth → i { ^ 1 }
+
+@ drop_unknown_ethertype → i { ^ 2 }
+
+@ drop_bad_ip → i { ^ 3 }
+
+@ drop_fragment → i { ^ 4 }
+
+@ drop_not_our_ip → i { ^ 5 }
+
+@ drop_bad_udp → i { ^ 6 }
+
+@ drop_bad_icmp → i { ^ 7 }
+
+@ drop_unknown_proto → i { ^ 8 }
+
+@ drop_foreign_arp → i { ^ 9 }
+
+@ n_drop_reasons → i { ^ 10 }
+
+: RxResult {
+    i kind
+    i reason  // valid when kind == rx_dropped
+    i src_ip
+    i dst_ip
+    i src_port
+    i dst_port
+    i payload_off  // into the frame passed to stack_rx
+    i payload_len
+    i emitted  // bytes appended to `out`
+}
+
+@ __rx_drop i reason → RxResult { ^ @ RxResult { ( rx_dropped ) reason 0 0 0 0 0 0 0 } }
+
+// ── tx outcomes ──────────────────────────────────────────────────
+
+@ tx_sent → i { ^ 0 }
+
+@ tx_arp_pending → i { ^ 1 }  // an ARP request went out; retry later
+
+@ tx_unreachable → i { ^ 2 }  // ARP gave up — report it, don't queue forever
+
+@ tx_no_address → i { ^ 3 }  // we have no IP yet (DHCP still running)
+
+: TxResult {
+    i status
+    i emitted
+}
+
+// ── the stack ────────────────────────────────────────────────────
+
+: NetStack {
+    i our_mac
+    i our_ip
+    i netmask
+    i gateway
+    * ArpCache arp
+    i ip_id  // IPv4 identification counter for outbound datagrams
+    i rx_frames
+    i tx_frames
+    ( Vec i ) drops  // indexed by drop reason
+}
+
+@ stack_new i mac i ip i netmask i gateway → *NetStack {
+    : *NetStack st # *NetStack ( nurl_alloc Z NetStack )
+    = . st our_mac mac
+    = . st our_ip ip
+    = . st netmask netmask
+    = . st gateway gateway
+    = . st arp ( arp_cache_new 64 )
+    = . st ip_id 1
+    = . st rx_frames 0
+    = . st tx_frames 0
+    = . st drops ( vec_with_cap [i] ( n_drop_reasons ) )
+    : ~ i k 0
+    ~ < k ( n_drop_reasons ) { ( vec_push [i] . st drops 0 ) = k + k 1 }
+    ^ st
+}
+
+@ stack_free * NetStack st → v {
+    ( arp_cache_free . st arp )
+    ( vec_free [i] . st drops )
+    ( free st )
+}
+
+// DHCP hands the address over once the lease is bound.
+@ stack_set_address * NetStack st i ip i netmask i gateway → v {
+    = . st our_ip ip
+    = . st netmask netmask
+    = . st gateway gateway
+}
+
+@ stack_drop_count * NetStack st i reason → i {
+    ^ ?? ( vec_get [i] . st drops reason ) { T x → x F → 0 }
+}
+
+@ __count_drop * NetStack st i reason → v {
+    : b _ok ( vec_set [i] . st drops reason + ( stack_drop_count st reason ) 1 )
+}
+
+@ __next_id * NetStack st → i {
+    : i id . st ip_id
+    = . st ip_id & + id 1 65535
+    ^ id
+}
+
+// Which MAC should carry a datagram for `dst`? On-link destinations
+// resolve to themselves; everything else goes to the gateway. Broadcast
+// and directed-broadcast go to the Ethernet broadcast address.
+@ __next_hop * NetStack st i dst → i {
+    ? ( ipv4_is_broadcast dst ) { ^ dst } {}
+    ? && != . st netmask 0 == dst ( ipv4_subnet_broadcast . st our_ip . st netmask ) { ^ 4294967295 } {}
+    ? && != . st netmask 0 ( ipv4_in_subnet dst . st our_ip . st netmask ) { ^ dst } {}
+    ? != . st gateway 0 { ^ . st gateway } {}
+    ^ dst
+}
+
+// ── receive ──────────────────────────────────────────────────────
+
+@ __rx_arp * NetStack st ( Vec u ) frame EthHdr eh i now ( Vec u ) out → RxResult {
+    : ArpPkt ap ( arp_parse frame . eh payload_off . eh payload_len )
+    ? ! . ap valid {
+        ( __count_drop st ( drop_foreign_arp ) )
+        ^ ( __rx_drop ( drop_foreign_arp ) )
+    } {}
+    // Learn only from traffic that concerns us: a reply we asked for,
+    // or a request for our own address. Never from broadcast chatter —
+    // that is the classic ARP-spoofing surface.
+    ? == . ap op ( arp_op_reply ) {
+        ? == . ap target_ip . st our_ip {
+            ( arp_cache_insert . st arp . ap sender_ip . ap sender_mac now )
+            ^ @ RxResult { ( rx_arp_handled ) 0 . ap sender_ip . st our_ip 0 0 0 0 0 }
+        } {}
+        ( __count_drop st ( drop_foreign_arp ) )
+        ^ ( __rx_drop ( drop_foreign_arp ) )
+    } {}
+    // A request for us: learn the asker, then answer.
+    ? && == . ap op ( arp_op_request ) && != . st our_ip 0 == . ap target_ip . st our_ip {
+        ( arp_cache_insert . st arp . ap sender_ip . ap sender_mac now )
+        : i before ( vec_len [u] out )
+        ( arp_push_reply out . st our_mac . st our_ip . ap sender_mac . ap sender_ip )
+        = . st tx_frames + . st tx_frames 1
+        ^ @ RxResult { ( rx_arp_handled ) 0 . ap sender_ip . st our_ip 0 0 0 0 - ( vec_len [u] out ) before }
+    } {}
+    ( __count_drop st ( drop_foreign_arp ) )
+    ^ ( __rx_drop ( drop_foreign_arp ) )
+}
+
+@ __rx_icmp * NetStack st ( Vec u ) frame Ip4Hdr ih i now ( Vec u ) out → RxResult {
+    : IcmpMsg im ( icmp_parse frame . ih payload_off . ih payload_len )
+    ? ! . im valid {
+        ( __count_drop st ( drop_bad_icmp ) )
+        ^ ( __rx_drop ( drop_bad_icmp ) )
+    } {}
+    ? != . im mtype ( icmp_echo_request ) {
+        // Errors and other types are handed up: the caller may care
+        // about "fragmentation needed", and silently eating ICMP is
+        // how path-MTU black holes become permanent.
+        ^ @ RxResult { ( rx_none ) 0 . ih src . ih dst . im mtype . im code . im payload_off . im payload_len 0 }
+    } {}
+    // Answer the ping. The reply goes to the sender's MAC directly —
+    // it just spoke to us, so no ARP round-trip is needed.
+    : i before ( vec_len [u] out )
+    : ( Vec u ) msg ( vec_new [u] )
+    ( icmp_push_echo_reply msg im frame )
+    ( eth_push_header out . ( eth_parse frame ) src . st our_mac ( ethertype_ipv4 ) )
+    ( ip4_push_header out . st our_ip . ih src ( ip_proto_icmp ) ( vec_len [u] msg ) ( __next_id st ) 64 T )
+    ( vec_extend [u] out msg )
+    ( vec_free [u] msg )
+    = . st tx_frames + . st tx_frames 1
+    ^ @ RxResult { ( rx_icmp_echo ) 0 . ih src . ih dst . im id . im seq . im payload_off . im payload_len - ( vec_len [u] out ) before }
+}
+
+// Feed one received frame. Any reply is appended to `out`; the caller
+// transmits whatever `out` gained.
+@ stack_rx * NetStack st ( Vec u ) frame i now ( Vec u ) out → RxResult {
+    = . st rx_frames + . st rx_frames 1
+    : EthHdr eh ( eth_parse frame )
+    ? ! . eh valid {
+        ( __count_drop st ( drop_bad_eth ) )
+        ^ ( __rx_drop ( drop_bad_eth ) )
+    } {}
+    ? ! ( eth_addressed_to_us . eh dst . st our_mac ) {
+        ( __count_drop st ( drop_not_for_us ) )
+        ^ ( __rx_drop ( drop_not_for_us ) )
+    } {}
+    ? == . eh ethertype ( ethertype_arp ) { ^ ( __rx_arp st frame eh now out ) } {}
+    ? != . eh ethertype ( ethertype_ipv4 ) {
+        ( __count_drop st ( drop_unknown_ethertype ) )
+        ^ ( __rx_drop ( drop_unknown_ethertype ) )
+    } {}
+    : Ip4Hdr ih ( ip4_parse frame . eh payload_off . eh payload_len )
+    ? ! . ih valid {
+        : i reason ? == . ih reason ( ip4_err_fragment ) ( drop_fragment ) ( drop_bad_ip )
+        ( __count_drop st reason )
+        ^ ( __rx_drop reason )
+    } {}
+    // Accept datagrams for our address, for broadcast, and (before
+    // DHCP completes) for 255.255.255.255 — the DHCP reply itself
+    // arrives before we own an address, so a strict "must match our
+    // IP" test here would make the lease unobtainable.
+    : b for_us ? != . st our_ip 0 {
+        || || == . ih dst . st our_ip ( ipv4_is_broadcast . ih dst ) && != . st netmask 0 == . ih dst ( ipv4_subnet_broadcast . st our_ip . st netmask )
+    } ( ipv4_is_broadcast . ih dst )
+    ? ! for_us {
+        ( __count_drop st ( drop_not_our_ip ) )
+        ^ ( __rx_drop ( drop_not_our_ip ) )
+    } {}
+    ? == . ih proto ( ip_proto_icmp ) { ^ ( __rx_icmp st frame ih now out ) } {}
+    ? == . ih proto ( ip_proto_udp ) {
+        : Udp4Hdr uh ( udp4_parse frame . ih payload_off . ih payload_len . ih src . ih dst )
+        ? ! . uh valid {
+            ( __count_drop st ( drop_bad_udp ) )
+            ^ ( __rx_drop ( drop_bad_udp ) )
+        } {}
+        ^ @ RxResult {
+            ( rx_udp ) 0 . ih src . ih dst . uh src_port . uh dst_port . uh payload_off . uh payload_len 0
+        }
+    } {}
+    ( __count_drop st ( drop_unknown_proto ) )
+    ^ ( __rx_drop ( drop_unknown_proto ) )
+}
+
+// ── transmit ─────────────────────────────────────────────────────
+
+// Send a UDP datagram. If the next hop is not in the ARP cache, an ARP
+// request is emitted instead and `tx_arp_pending` is returned — the
+// caller retries after the reply arrives. Returning "pending" rather
+// than queueing internally keeps the buffer-ownership story simple:
+// this module never holds on to the caller's payload.
+@ stack_tx_udp * NetStack st i dst_ip i src_port i dst_port ( Vec u ) payload i pay_off i pay_len i now ( Vec u ) out → TxResult {
+    ? == . st our_ip 0 { ^ @ TxResult { ( tx_no_address ) 0 } } {}
+    : i hop ( __next_hop st dst_ip )
+    : ~ i dst_mac 0
+    ? || ( ipv4_is_broadcast hop ) ( ipv4_is_multicast hop ) {
+        = dst_mac ( mac_broadcast )
+    } {
+        : ?i found ( arp_cache_lookup . st arp hop now )
+        = dst_mac ?? found { T m → m F → 0 }
+    }
+    ? == dst_mac 0 {
+        ? ( arp_cache_failed . st arp hop now ) { ^ @ TxResult { ( tx_unreachable ) 0 } } {}
+        ? ( arp_cache_should_request . st arp hop now ) {
+            : i before ( vec_len [u] out )
+            ( arp_push_request out . st our_mac . st our_ip hop )
+            = . st tx_frames + . st tx_frames 1
+            ^ @ TxResult { ( tx_arp_pending ) - ( vec_len [u] out ) before }
+        } {}
+        ^ @ TxResult { ( tx_arp_pending ) 0 }
+    } {}
+    : i before ( vec_len [u] out )
+    : ( Vec u ) dg ( vec_new [u] )
+    ( udp4_push dg . st our_ip dst_ip src_port dst_port payload pay_off pay_len )
+    ( eth_push_header out dst_mac . st our_mac ( ethertype_ipv4 ) )
+    ( ip4_push_header out . st our_ip dst_ip ( ip_proto_udp ) ( vec_len [u] dg ) ( __next_id st ) 64 T )
+    ( vec_extend [u] out dg )
+    ( vec_free [u] dg )
+    = . st tx_frames + . st tx_frames 1
+    ^ @ TxResult { ( tx_sent ) - ( vec_len [u] out ) before }
+}
+
+// Broadcast a UDP datagram from 0.0.0.0 — the shape DHCP needs before
+// an address exists, which the ordinary send path cannot express.
+@ stack_tx_udp_broadcast * NetStack st i src_ip i src_port i dst_port i dst_ip ( Vec u ) payload i pay_off i pay_len ( Vec u ) out → i {
+    : i before ( vec_len [u] out )
+    : ( Vec u ) dg ( vec_new [u] )
+    ( udp4_push dg src_ip dst_ip src_port dst_port payload pay_off pay_len )
+    ( eth_push_header out ( mac_broadcast ) . st our_mac ( ethertype_ipv4 ) )
+    ( ip4_push_header out src_ip dst_ip ( ip_proto_udp ) ( vec_len [u] dg ) ( __next_id st ) 64 T )
+    ( vec_extend [u] out dg )
+    ( vec_free [u] dg )
+    = . st tx_frames + . st tx_frames 1
+    ^ - ( vec_len [u] out ) before
+}
+
+// Periodic maintenance: expire stale ARP entries. Returns how many
+// were reclaimed. Timers that emit frames (ARP retry) are driven by
+// the send path, so this stays cheap enough to call every turn.
+@ stack_tick * NetStack st i now ( Vec u ) out → i {
+    ^ ( arp_cache_expire . st arp now )
+}

--- a/stdlib/net/tcp.nu
+++ b/stdlib/net/tcp.nu
@@ -1,15 +1,27 @@
 // stdlib/net/tcp.nu — the TCP connection state machine, sans-IO.
 //
+// NAMING. The connection object is a `Tcb` — RFC 793's Transmission
+// Control Block — and its operations are `tcb_*`, NOT `tcp_*`. NURL's
+// namespace is flat, and `stdlib/std/net.nu` already owns `tcp_connect`
+// / `tcp_listen` / `TcpConn` for the host *socket* API. Two different
+// things called the same name in one flat namespace is a link-time
+// collision at best and a silent link-order-dependent pick at worst.
+// The protocol's own vocabulary (`tcp_syn`, `tcp_established`,
+// `tcp_2msl_ms`, …) keeps the `tcp_` prefix: those name the protocol
+// rather than this API, and they collide with nothing. `tcp_listen_st`
+// carries its suffix for exactly this reason — the socket API owns the
+// unsuffixed name.
+//
 // PURE. Segments in, segments out, `now` supplied by the caller:
 //
-//     ( tcp_connect c … now out )   client open  → emits SYN
-//     ( tcp_listen  c … )           server open
-//     ( tcp_input   c seg buf now out )   one received segment
-//     ( tcp_write   c bytes … )     queue application data
-//     ( tcp_pump    c now out )     emit what may be sent now
-//     ( tcp_tick    c now out )     timers → retransmits, probes, 2MSL
-//     ( tcp_read    c dst n )       drain received data
-//     ( tcp_close   c now out )     half-close (FIN)
+//     ( tcb_connect c … now out )   client open  → emits SYN
+//     ( tcb_listen  c … )           server open
+//     ( tcb_input   c seg buf now out )   one received segment
+//     ( tcb_write   c bytes … )     queue application data
+//     ( tcb_pump    c now out )     emit what may be sent now
+//     ( tcb_tick    c now out )     timers → retransmits, probes, 2MSL
+//     ( tcb_read    c dst n )       drain received data
+//     ( tcb_close   c now out )     half-close (FIN)
 //
 // Because the clock is an argument, an RTO backoff sequence or a
 // 2MSL wait is a few integer comparisons in a unit test rather than a
@@ -147,7 +159,7 @@ $ `stdlib/net/tcpseg.nu`
     ^ - ( tcpout_seg_end o idx ) ( tcpout_seg_start o idx )
 }
 
-: TcpConn {
+: Tcb {
     i state
     i local_ip
     i local_port
@@ -187,8 +199,8 @@ $ `stdlib/net/tcpseg.nu`
     b close_requested
 }
 
-@ tcp_new → *TcpConn {
-    : *TcpConn c # *TcpConn ( nurl_alloc Z TcpConn )
+@ tcb_new → *Tcb {
+    : *Tcb c # *Tcb ( nurl_alloc Z Tcb )
     = . c state ( tcp_closed )
     = . c local_ip 0
     = . c local_port 0
@@ -226,7 +238,7 @@ $ `stdlib/net/tcpseg.nu`
     ^ c
 }
 
-@ tcp_free * TcpConn c → v {
+@ tcb_free * Tcb c → v {
     ( vec_free [u] . c sndbuf )
     ( vec_free [u] . c rcvbuf )
     ( free c )
@@ -235,30 +247,30 @@ $ `stdlib/net/tcpseg.nu`
 // ── helpers ─────────────────────────────────────────────────────
 
 // Bytes queued but not yet sent.
-@ __unsent * TcpConn c → i {
+@ __unsent * Tcb c → i {
     : i inflight ( seq_diff . c snd_nxt . c snd_una )
     : i total ( vec_len [u] . c sndbuf )
     ^ ? > - total inflight 0 - total inflight 0
 }
 
-@ tcp_send_queue_len * TcpConn c → i { ^ ( vec_len [u] . c sndbuf ) }
+@ tcb_send_queue_len * Tcb c → i { ^ ( vec_len [u] . c sndbuf ) }
 
-@ tcp_recv_queue_len * TcpConn c → i { ^ ( vec_len [u] . c rcvbuf ) }
+@ tcb_recv_queue_len * Tcb c → i { ^ ( vec_len [u] . c rcvbuf ) }
 
-@ tcp_is_established * TcpConn c → b { ^ == . c state ( tcp_established ) }
+@ tcb_is_established * Tcb c → b { ^ == . c state ( tcp_established ) }
 
 // A connection is "done" when it can be reaped by the owner.
-@ tcp_is_closed * TcpConn c → b {
+@ tcb_is_closed * Tcb c → b {
     ^ || == . c state ( tcp_closed ) . c reset
 }
 
-@ __emit * TcpConn c * TcpOut out i flags i seq i ack ( Vec u ) payload i pay_off i pay_len → v {
+@ __emit * Tcb c * TcpOut out i flags i seq i ack ( Vec u ) payload i pay_off i pay_len → v {
     ( tcpseg_push . out bytes . c local_ip . c remote_ip . c local_port . c remote_port
     seq ack flags . c rcv_wnd . c mss . c snd_wscale payload pay_off pay_len )
     ( vec_push [i] . out ends ( vec_len [u] . out bytes ) )
 }
 
-@ __emit_empty * TcpConn c * TcpOut out i flags i seq i ack → v {
+@ __emit_empty * Tcb c * TcpOut out i flags i seq i ack → v {
     : ( Vec u ) none ( vec_new [u] )
     ( __emit c out flags seq ack none 0 0 )
     ( vec_free [u] none )
@@ -266,7 +278,7 @@ $ `stdlib/net/tcpseg.nu`
 
 // Jacobson/Karn RTO update. Karn's rule — never sample a retransmitted
 // segment — is enforced by the caller clearing rtt_seq on retransmit.
-@ __rtt_update * TcpConn c i sample → v {
+@ __rtt_update * Tcb c i sample → v {
     ? <= sample 0 { ^ } {}
     ? == . c srtt 0 {
         = . c srtt sample
@@ -281,13 +293,13 @@ $ `stdlib/net/tcpseg.nu`
     = . c rto_ms ? < rto ( tcp_rto_min_ms ) ( tcp_rto_min_ms ) ? > rto ( tcp_rto_max_ms ) ( tcp_rto_max_ms ) rto
 }
 
-@ __arm_rtx * TcpConn c i now → v {
+@ __arm_rtx * Tcb c i now → v {
     = . c rtx_deadline + now . c rto_ms
 }
 
 // ── open ────────────────────────────────────────────────────────
 
-@ tcp_listen * TcpConn c i local_ip i local_port → v {
+@ tcb_listen * Tcb c i local_ip i local_port → v {
     = . c local_ip local_ip
     = . c local_port local_port
     = . c state ( tcp_listen_st )
@@ -296,7 +308,7 @@ $ `stdlib/net/tcpseg.nu`
 // Active open. `iss` is the initial send sequence — the caller
 // supplies it because a good ISS needs entropy this layer must not
 // invent (RFC 6528); a predictable ISS is a connection-hijack vector.
-@ tcp_connect * TcpConn c i local_ip i local_port i remote_ip i remote_port i iss i now * TcpOut out → v {
+@ tcb_connect * Tcb c i local_ip i local_port i remote_ip i remote_port i iss i now * TcpOut out → v {
     = . c local_ip local_ip
     = . c local_port local_port
     = . c remote_ip remote_ip
@@ -317,7 +329,7 @@ $ `stdlib/net/tcpseg.nu`
 // Queue bytes for transmission. Returns how many were accepted — the
 // send buffer is bounded, and reporting a short write is how
 // back-pressure reaches the application instead of the heap.
-@ tcp_write * TcpConn c ( Vec u ) data i off i len i max_queue → i {
+@ tcb_write * Tcb c ( Vec u ) data i off i len i max_queue → i {
     ? || . c reset ! || == . c state ( tcp_established ) == . c state ( tcp_close_wait ) { ^ 0 } {}
     : i have ( vec_len [u] . c sndbuf )
     : i room ? > - max_queue have 0 - max_queue have 0
@@ -331,7 +343,7 @@ $ `stdlib/net/tcpseg.nu`
 }
 
 // Drain up to `n` received bytes into `dst`. Returns how many moved.
-@ tcp_read * TcpConn c ( Vec u ) dst i n → i {
+@ tcb_read * Tcb c ( Vec u ) dst i n → i {
     : i have ( vec_len [u] . c rcvbuf )
     : i take ? < n have n have
     : ~ i k 0
@@ -356,7 +368,7 @@ $ `stdlib/net/tcpseg.nu`
 
 // Emit whatever may legally be sent right now: new data within the
 // peer's window, and a FIN once the queue has drained.
-@ tcp_pump * TcpConn c i now * TcpOut out → i {
+@ tcb_pump * Tcb c i now * TcpOut out → i {
     ? . c reset { ^ 0 } {}
     : i before ( vec_len [u] . out bytes )
     : ~ b sent_any F
@@ -398,17 +410,17 @@ $ `stdlib/net/tcpseg.nu`
     ^ - ( vec_len [u] . out bytes ) before
 }
 
-// Ask for a graceful close. The FIN itself leaves via tcp_pump once
+// Ask for a graceful close. The FIN itself leaves via tcb_pump once
 // the send queue drains — a close must never truncate queued data.
-@ tcp_close * TcpConn c i now * TcpOut out → v {
+@ tcb_close * Tcb c i now * TcpOut out → v {
     = . c close_requested T
     ? == . c state ( tcp_listen_st ) { = . c state ( tcp_closed ) ^ } {}
     ? == . c state ( tcp_syn_sent ) { = . c state ( tcp_closed ) ^ } {}
-    : i _n ( tcp_pump c now out )
+    : i _n ( tcb_pump c now out )
 }
 
 // Abort: send RST and drop the connection.
-@ tcp_abort * TcpConn c * TcpOut out → v {
+@ tcb_abort * Tcb c * TcpOut out → v {
     ? || == . c state ( tcp_closed ) == . c state ( tcp_listen_st ) {
         = . c state ( tcp_closed )
         ^
@@ -422,7 +434,7 @@ $ `stdlib/net/tcpseg.nu`
 
 // Returns bytes emitted. Drives retransmission, the persist timer and
 // the 2MSL wait.
-@ tcp_tick * TcpConn c i now * TcpOut out → i {
+@ tcb_tick * Tcb c i now * TcpOut out → i {
     : i before ( vec_len [u] . out bytes )
     // TIME_WAIT expiry
     ? && == . c state ( tcp_time_wait ) && != . c tw_deadline 0 >= now . c tw_deadline {
@@ -484,7 +496,7 @@ $ `stdlib/net/tcpseg.nu`
 
 // ── receive path ────────────────────────────────────────────────
 
-@ __accept_data * TcpConn c TcpSeg s ( Vec u ) buf → i {
+@ __accept_data * Tcb c TcpSeg s ( Vec u ) buf → i {
     : i n . s payload_len
     ? <= n 0 { ^ 0 } {}
     : ~ i k 0
@@ -498,7 +510,7 @@ $ `stdlib/net/tcpseg.nu`
 
 // Process an ACK: advance snd_una, release acknowledged bytes, update
 // RTT/RTO, and count duplicates for fast retransmit.
-@ __process_ack * TcpConn c TcpSeg s i now → v {
+@ __process_ack * Tcb c TcpSeg s i now → v {
     : i ack . s ack
     ? ( seq_gt ack . c snd_nxt ) { ^ } {}
     ? ( seq_lt ack . c snd_una ) { ^ } {}
@@ -541,7 +553,7 @@ $ `stdlib/net/tcpseg.nu`
     } { ( __arm_rtx c now ) }
 }
 
-@ __update_window * TcpConn c TcpSeg s → v {
+@ __update_window * Tcb c TcpSeg s → v {
     : i w << . s window . c rcv_wscale
     // RFC 793: only accept a window update from a segment that is not
     // older than the last one used, or the window can go backwards on
@@ -561,7 +573,7 @@ $ `stdlib/net/tcpseg.nu`
 
 // Feed one parsed segment. `buf` is the buffer it was parsed from.
 // Returns bytes emitted into `out`.
-@ tcp_input * TcpConn c TcpSeg s ( Vec u ) buf i now * TcpOut out → i {
+@ tcb_input * Tcb c TcpSeg s ( Vec u ) buf i now * TcpOut out → i {
     ? ! . s valid { ^ 0 } {}
     : i before ( vec_len [u] . out bytes )
     : b has_rst == & . s flags 4 4
@@ -750,6 +762,6 @@ $ `stdlib/net/tcpseg.nu`
         } {}
     } {}
 
-    : i _p ( tcp_pump c now out )
+    : i _p ( tcb_pump c now out )
     ^ - ( vec_len [u] . out bytes ) before
 }

--- a/stdlib/net/tcp.nu
+++ b/stdlib/net/tcp.nu
@@ -1,0 +1,755 @@
+// stdlib/net/tcp.nu — the TCP connection state machine, sans-IO.
+//
+// PURE. Segments in, segments out, `now` supplied by the caller:
+//
+//     ( tcp_connect c … now out )   client open  → emits SYN
+//     ( tcp_listen  c … )           server open
+//     ( tcp_input   c seg buf now out )   one received segment
+//     ( tcp_write   c bytes … )     queue application data
+//     ( tcp_pump    c now out )     emit what may be sent now
+//     ( tcp_tick    c now out )     timers → retransmits, probes, 2MSL
+//     ( tcp_read    c dst n )       drain received data
+//     ( tcp_close   c now out )     half-close (FIN)
+//
+// Because the clock is an argument, an RTO backoff sequence or a
+// 2MSL wait is a few integer comparisons in a unit test rather than a
+// minute of wall time — which is the only reason these paths get
+// tested at all.
+//
+// ── IN SCOPE (v1) ───────────────────────────────────────────────
+//   * Full RFC 793 state machine including TIME_WAIT (2MSL).
+//   * Retransmission with Jacobson/Karn RTO estimation and
+//     exponential backoff; fast retransmit on 3 duplicate ACKs.
+//   * Zero-window probes (persist timer).
+//   * MSS clamping from the peer's option, window scaling honoured on
+//     receive.
+//   * RST generation and handling.
+//
+// ── OUT OF SCOPE, DELIBERATELY ──────────────────────────────────
+//   * SACK. Not negotiated, not emitted.
+//   * Out-of-order reassembly: a segment above `rcv_nxt` is dropped
+//     and an immediate ACK of `rcv_nxt` is sent instead. This is
+//     correct — it is exactly the duplicate ACK that drives the
+//     peer's fast retransmit — and it costs throughput on a lossy
+//     path, not correctness. A reassembly queue is the natural first
+//     upgrade once measurements justify it.
+//   * Delayed ACK: v1 acknowledges immediately. More ACK traffic,
+//     never a wrong answer, and no 200 ms interaction with a peer's
+//     Nagle to debug.
+//   * Nagle: off. For request/response JSON-RPC (what this stack
+//     carries first) coalescing only adds latency.
+//   * Our *sent* window-scale factor is fixed at 0; the peer's is
+//     always parsed and honoured. Those are different things, and
+//     ignoring the peer's shift would misread every window it sends.
+//
+// ── WHY TIME_WAIT AND ZERO-WINDOW PROBES ARE NOT OPTIONAL ───────
+// Without TIME_WAIT, a delayed segment from a closed connection is
+// accepted into a new connection reusing the same port pair — silent
+// data corruption that looks like a peer bug. Without a persist
+// timer, a peer that advertises a zero window and later reopens it
+// with a lost window-update deadlocks the connection forever. Both
+// failure modes appear only under reconnect churn and buffer
+// pressure — i.e. exactly what a long-running appliance does.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/tcpseg.nu`
+
+// ── states (RFC 793 §3.2) ───────────────────────────────────────
+
+@ tcp_closed → i { ^ 0 }
+
+@ tcp_listen_st → i { ^ 1 }
+
+@ tcp_syn_sent → i { ^ 2 }
+
+@ tcp_syn_rcvd → i { ^ 3 }
+
+@ tcp_established → i { ^ 4 }
+
+@ tcp_fin_wait_1 → i { ^ 5 }
+
+@ tcp_fin_wait_2 → i { ^ 6 }
+
+@ tcp_close_wait → i { ^ 7 }
+
+@ tcp_closing → i { ^ 8 }
+
+@ tcp_last_ack → i { ^ 9 }
+
+@ tcp_time_wait → i { ^ 10 }
+
+// 2·MSL. RFC 793 says MSL = 2 minutes; every real stack uses far less
+// because nothing survives 4 minutes in a modern network. 30 s keeps
+// the protection while bounding how long a port pair stays reserved.
+@ tcp_2msl_ms → i { ^ 30000 }
+
+@ tcp_rto_min_ms → i { ^ 200 }
+
+@ tcp_rto_max_ms → i { ^ 60000 }
+
+@ tcp_rto_initial_ms → i { ^ 1000 }
+
+// Give up on a segment after this many retransmits and reset.
+@ tcp_max_rtx → i { ^ 8 }
+
+@ tcp_default_window → i { ^ 65535 }
+
+// ── segment output ──────────────────────────────────────────────
+//
+// A TCP segment carries no length field — its length comes from the
+// enclosing IP datagram. Concatenating emitted segments into one flat
+// buffer would therefore be irreversible: the consumer could not tell
+// where one ends and the next begins. So emission records boundaries
+// alongside the bytes, and the IP layer wraps each segment in its own
+// datagram. This is not a test convenience; it is what the real
+// integration needs, and finding it out at the seam rather than in
+// the driver is the point of building sans-IO.
+
+: TcpOut {
+    ( Vec u ) bytes
+    ( Vec i ) ends  // end offset of each emitted segment
+}
+
+@ tcpout_new → *TcpOut {
+    : *TcpOut o # *TcpOut ( nurl_alloc Z TcpOut )
+    = . o bytes ( vec_new [u] )
+    = . o ends ( vec_new [i] )
+    ^ o
+}
+
+@ tcpout_free * TcpOut o → v {
+    ( vec_free [u] . o bytes )
+    ( vec_free [i] . o ends )
+    ( free o )
+}
+
+@ tcpout_clear * TcpOut o → v {
+    ( vec_clear [u] . o bytes )
+    ( vec_clear [i] . o ends )
+}
+
+@ tcpout_count * TcpOut o → i { ^ ( vec_len [i] . o ends ) }
+
+@ tcpout_seg_end * TcpOut o i idx → i {
+    ^ ?? ( vec_get [i] . o ends idx ) { T x → x F → 0 }
+}
+
+@ tcpout_seg_start * TcpOut o i idx → i {
+    ? <= idx 0 { ^ 0 } {}
+    ^ ( tcpout_seg_end o - idx 1 )
+}
+
+@ tcpout_seg_len * TcpOut o i idx → i {
+    ^ - ( tcpout_seg_end o idx ) ( tcpout_seg_start o idx )
+}
+
+: TcpConn {
+    i state
+    i local_ip
+    i local_port
+    i remote_ip
+    i remote_port
+    // send sequence space (RFC 793 §3.2). sndbuf[0] corresponds to snd_una.
+    i snd_una
+    i snd_nxt
+    i snd_wnd  // peer's advertised window, already scaled
+    i snd_wl1
+    i snd_wl2
+    i iss
+    // receive sequence space
+    i rcv_nxt
+    i rcv_wnd
+    i irs
+    i mss
+    i snd_wscale  // what WE send (fixed 0 in v1)
+    i rcv_wscale  // the peer's shift, honoured
+    ( Vec u ) sndbuf
+    ( Vec u ) rcvbuf
+    // timers — absolute ms deadlines; 0 means disarmed
+    i rtx_deadline
+    i probe_deadline
+    i tw_deadline
+    i rto_ms
+    i rtx_count
+    i srtt
+    i rttvar
+    i rtt_seq  // sequence being timed, -1 when no sample in flight
+    i rtt_start
+    i dupacks
+    b fin_sent
+    b fin_acked
+    b fin_rcvd
+    b reset
+    b close_requested
+}
+
+@ tcp_new → *TcpConn {
+    : *TcpConn c # *TcpConn ( nurl_alloc Z TcpConn )
+    = . c state ( tcp_closed )
+    = . c local_ip 0
+    = . c local_port 0
+    = . c remote_ip 0
+    = . c remote_port 0
+    = . c snd_una 0
+    = . c snd_nxt 0
+    = . c snd_wnd 0
+    = . c snd_wl1 0
+    = . c snd_wl2 0
+    = . c iss 0
+    = . c rcv_nxt 0
+    = . c rcv_wnd ( tcp_default_window )
+    = . c irs 0
+    = . c mss ( tcp_fallback_mss )
+    = . c snd_wscale 0
+    = . c rcv_wscale 0
+    = . c sndbuf ( vec_new [u] )
+    = . c rcvbuf ( vec_new [u] )
+    = . c rtx_deadline 0
+    = . c probe_deadline 0
+    = . c tw_deadline 0
+    = . c rto_ms ( tcp_rto_initial_ms )
+    = . c rtx_count 0
+    = . c srtt 0
+    = . c rttvar 0
+    = . c rtt_seq -1
+    = . c rtt_start 0
+    = . c dupacks 0
+    = . c fin_sent F
+    = . c fin_acked F
+    = . c fin_rcvd F
+    = . c reset F
+    = . c close_requested F
+    ^ c
+}
+
+@ tcp_free * TcpConn c → v {
+    ( vec_free [u] . c sndbuf )
+    ( vec_free [u] . c rcvbuf )
+    ( free c )
+}
+
+// ── helpers ─────────────────────────────────────────────────────
+
+// Bytes queued but not yet sent.
+@ __unsent * TcpConn c → i {
+    : i inflight ( seq_diff . c snd_nxt . c snd_una )
+    : i total ( vec_len [u] . c sndbuf )
+    ^ ? > - total inflight 0 - total inflight 0
+}
+
+@ tcp_send_queue_len * TcpConn c → i { ^ ( vec_len [u] . c sndbuf ) }
+
+@ tcp_recv_queue_len * TcpConn c → i { ^ ( vec_len [u] . c rcvbuf ) }
+
+@ tcp_is_established * TcpConn c → b { ^ == . c state ( tcp_established ) }
+
+// A connection is "done" when it can be reaped by the owner.
+@ tcp_is_closed * TcpConn c → b {
+    ^ || == . c state ( tcp_closed ) . c reset
+}
+
+@ __emit * TcpConn c * TcpOut out i flags i seq i ack ( Vec u ) payload i pay_off i pay_len → v {
+    ( tcpseg_push . out bytes . c local_ip . c remote_ip . c local_port . c remote_port
+    seq ack flags . c rcv_wnd . c mss . c snd_wscale payload pay_off pay_len )
+    ( vec_push [i] . out ends ( vec_len [u] . out bytes ) )
+}
+
+@ __emit_empty * TcpConn c * TcpOut out i flags i seq i ack → v {
+    : ( Vec u ) none ( vec_new [u] )
+    ( __emit c out flags seq ack none 0 0 )
+    ( vec_free [u] none )
+}
+
+// Jacobson/Karn RTO update. Karn's rule — never sample a retransmitted
+// segment — is enforced by the caller clearing rtt_seq on retransmit.
+@ __rtt_update * TcpConn c i sample → v {
+    ? <= sample 0 { ^ } {}
+    ? == . c srtt 0 {
+        = . c srtt sample
+        = . c rttvar / sample 2
+    } {
+        : i err - sample . c srtt
+        : i abserr ? < err 0 - 0 err err
+        = . c rttvar / + * 3 . c rttvar abserr 4
+        = . c srtt / + * 7 . c srtt sample 8
+    }
+    : i rto + . c srtt * 4 . c rttvar
+    = . c rto_ms ? < rto ( tcp_rto_min_ms ) ( tcp_rto_min_ms ) ? > rto ( tcp_rto_max_ms ) ( tcp_rto_max_ms ) rto
+}
+
+@ __arm_rtx * TcpConn c i now → v {
+    = . c rtx_deadline + now . c rto_ms
+}
+
+// ── open ────────────────────────────────────────────────────────
+
+@ tcp_listen * TcpConn c i local_ip i local_port → v {
+    = . c local_ip local_ip
+    = . c local_port local_port
+    = . c state ( tcp_listen_st )
+}
+
+// Active open. `iss` is the initial send sequence — the caller
+// supplies it because a good ISS needs entropy this layer must not
+// invent (RFC 6528); a predictable ISS is a connection-hijack vector.
+@ tcp_connect * TcpConn c i local_ip i local_port i remote_ip i remote_port i iss i now * TcpOut out → v {
+    = . c local_ip local_ip
+    = . c local_port local_port
+    = . c remote_ip remote_ip
+    = . c remote_port remote_port
+    = . c iss iss
+    = . c snd_una iss
+    = . c snd_nxt ( seq_add iss 1 )
+    = . c state ( tcp_syn_sent )
+    = . c mss ( tcp_default_mss )
+    = . c rtt_seq iss
+    = . c rtt_start now
+    ( __emit_empty c out ( tcp_syn ) iss 0 )
+    ( __arm_rtx c now )
+}
+
+// ── application data ────────────────────────────────────────────
+
+// Queue bytes for transmission. Returns how many were accepted — the
+// send buffer is bounded, and reporting a short write is how
+// back-pressure reaches the application instead of the heap.
+@ tcp_write * TcpConn c ( Vec u ) data i off i len i max_queue → i {
+    ? || . c reset ! || == . c state ( tcp_established ) == . c state ( tcp_close_wait ) { ^ 0 } {}
+    : i have ( vec_len [u] . c sndbuf )
+    : i room ? > - max_queue have 0 - max_queue have 0
+    : i take ? < len room len room
+    : ~ i k 0
+    ~ < k take {
+        ( vec_push [u] . c sndbuf ?? ( vec_get [u] data + off k ) { T x → x F → # u 0 } )
+        = k + k 1
+    }
+    ^ take
+}
+
+// Drain up to `n` received bytes into `dst`. Returns how many moved.
+@ tcp_read * TcpConn c ( Vec u ) dst i n → i {
+    : i have ( vec_len [u] . c rcvbuf )
+    : i take ? < n have n have
+    : ~ i k 0
+    ~ < k take {
+        ( vec_push [u] dst ?? ( vec_get [u] . c rcvbuf k ) { T x → x F → # u 0 } )
+        = k + k 1
+    }
+    // Shift the remainder down. A ring buffer would avoid the copy;
+    // for v1 the simple form is worth more than the memmove.
+    : ( Vec u ) rest ( vec_new [u] )
+    : ~ i j take
+    ~ < j have {
+        ( vec_push [u] rest ?? ( vec_get [u] . c rcvbuf j ) { T x → x F → # u 0 } )
+        = j + j 1
+    }
+    ( vec_free [u] . c rcvbuf )
+    = . c rcvbuf rest
+    ^ take
+}
+
+// ── transmit ────────────────────────────────────────────────────
+
+// Emit whatever may legally be sent right now: new data within the
+// peer's window, and a FIN once the queue has drained.
+@ tcp_pump * TcpConn c i now * TcpOut out → i {
+    ? . c reset { ^ 0 } {}
+    : i before ( vec_len [u] . out bytes )
+    : ~ b sent_any F
+    ? || == . c state ( tcp_established ) || == . c state ( tcp_close_wait ) == . c state ( tcp_fin_wait_1 ) {
+        : ~ b more T
+        ~ more {
+            : i inflight ( seq_diff . c snd_nxt . c snd_una )
+            : i unsent ( __unsent c )
+            // Usable window: what the peer allows minus what is
+            // already in flight.
+            : i usable ? > - . c snd_wnd inflight 0 - . c snd_wnd inflight 0
+            : ~ i chunk ? < unsent usable unsent usable
+            ? > chunk . c mss { = chunk . c mss } {}
+            ? <= chunk 0 { = more F } {
+                : i off inflight
+                ( __emit c out | ( tcp_ack ) ( tcp_psh ) . c snd_nxt . c rcv_nxt . c sndbuf off chunk )
+                // Start an RTT sample if none is in flight (Karn).
+                ? < . c rtt_seq 0 {
+                    = . c rtt_seq . c snd_nxt
+                    = . c rtt_start now
+                } {}
+                = . c snd_nxt ( seq_add . c snd_nxt chunk )
+                = sent_any T
+                ? == . c rtx_deadline 0 { ( __arm_rtx c now ) } {}
+            }
+        }
+    } {}
+    // FIN goes out once everything queued has been sent.
+    ? && && . c close_requested ! . c fin_sent == ( __unsent c ) 0 {
+        ? || || == . c state ( tcp_established ) == . c state ( tcp_close_wait ) F {
+            ( __emit_empty c out | ( tcp_fin ) ( tcp_ack ) . c snd_nxt . c rcv_nxt )
+            = . c fin_sent T
+            = . c snd_nxt ( seq_add . c snd_nxt 1 )
+            = . c state ? == . c state ( tcp_close_wait ) ( tcp_last_ack ) ( tcp_fin_wait_1 )
+            = sent_any T
+            ( __arm_rtx c now )
+        } {}
+    } {}
+    ^ - ( vec_len [u] . out bytes ) before
+}
+
+// Ask for a graceful close. The FIN itself leaves via tcp_pump once
+// the send queue drains — a close must never truncate queued data.
+@ tcp_close * TcpConn c i now * TcpOut out → v {
+    = . c close_requested T
+    ? == . c state ( tcp_listen_st ) { = . c state ( tcp_closed ) ^ } {}
+    ? == . c state ( tcp_syn_sent ) { = . c state ( tcp_closed ) ^ } {}
+    : i _n ( tcp_pump c now out )
+}
+
+// Abort: send RST and drop the connection.
+@ tcp_abort * TcpConn c * TcpOut out → v {
+    ? || == . c state ( tcp_closed ) == . c state ( tcp_listen_st ) {
+        = . c state ( tcp_closed )
+        ^
+    } {}
+    ( __emit_empty c out ( tcp_rst ) . c snd_nxt . c rcv_nxt )
+    = . c state ( tcp_closed )
+    = . c reset T
+}
+
+// ── timers ──────────────────────────────────────────────────────
+
+// Returns bytes emitted. Drives retransmission, the persist timer and
+// the 2MSL wait.
+@ tcp_tick * TcpConn c i now * TcpOut out → i {
+    : i before ( vec_len [u] . out bytes )
+    // TIME_WAIT expiry
+    ? && == . c state ( tcp_time_wait ) && != . c tw_deadline 0 >= now . c tw_deadline {
+        = . c state ( tcp_closed )
+        = . c tw_deadline 0
+        ^ 0
+    } {}
+    ? . c reset { ^ 0 } {}
+    // Zero-window persist probe: one byte beyond the window, which the
+    // peer must answer with an ACK carrying its current window. This
+    // is what breaks the deadlock when a window update is lost.
+    ? && && == . c snd_wnd 0 > ( __unsent c ) 0 && != . c probe_deadline 0 >= now . c probe_deadline {
+        : i off ( seq_diff . c snd_nxt . c snd_una )
+        ( __emit c out ( tcp_ack ) . c snd_nxt . c rcv_nxt . c sndbuf off 1 )
+        // Back off the probe interval, but never stop probing.
+        = . c rto_ms ? >= * . c rto_ms 2 ( tcp_rto_max_ms ) ( tcp_rto_max_ms ) * . c rto_ms 2
+        = . c probe_deadline + now . c rto_ms
+        ^ - ( vec_len [u] . out bytes ) before
+    } {}
+    // Retransmission
+    ? && != . c rtx_deadline 0 >= now . c rtx_deadline {
+        = . c rtx_count + . c rtx_count 1
+        ? > . c rtx_count ( tcp_max_rtx ) {
+            ( __emit_empty c out ( tcp_rst ) . c snd_nxt . c rcv_nxt )
+            = . c state ( tcp_closed )
+            = . c reset T
+            ^ - ( vec_len [u] . out bytes ) before
+        } {}
+        // Karn: a retransmitted segment yields no RTT sample.
+        = . c rtt_seq -1
+        // Exponential backoff.
+        = . c rto_ms ? >= * . c rto_ms 2 ( tcp_rto_max_ms ) ( tcp_rto_max_ms ) * . c rto_ms 2
+        ? == . c state ( tcp_syn_sent ) {
+            ( __emit_empty c out ( tcp_syn ) . c iss 0 )
+        } {
+            ? == . c state ( tcp_syn_rcvd ) {
+                ( __emit_empty c out | ( tcp_syn ) ( tcp_ack ) . c iss . c rcv_nxt )
+            } {
+                : i inflight ( seq_diff . c snd_nxt . c snd_una )
+                : i have ( vec_len [u] . c sndbuf )
+                : i n ? < inflight have inflight have
+                ? > n 0 {
+                    : i chunk ? > n . c mss . c mss n
+                    // Go-back-N: resume from snd_una.
+                    ( __emit c out | ( tcp_ack ) ( tcp_psh ) . c snd_una . c rcv_nxt . c sndbuf 0 chunk )
+                    = . c snd_nxt ( seq_add . c snd_una chunk )
+                } {
+                    ? . c fin_sent {
+                        ( __emit_empty c out | ( tcp_fin ) ( tcp_ack ) ( seq_sub . c snd_nxt 1 ) . c rcv_nxt )
+                    } {}
+                }
+            }
+        }
+        ( __arm_rtx c now )
+        ^ - ( vec_len [u] . out bytes ) before
+    } {}
+    ^ - ( vec_len [u] . out bytes ) before
+}
+
+// ── receive path ────────────────────────────────────────────────
+
+@ __accept_data * TcpConn c TcpSeg s ( Vec u ) buf → i {
+    : i n . s payload_len
+    ? <= n 0 { ^ 0 } {}
+    : ~ i k 0
+    ~ < k n {
+        ( vec_push [u] . c rcvbuf ?? ( vec_get [u] buf + . s payload_off k ) { T x → x F → # u 0 } )
+        = k + k 1
+    }
+    = . c rcv_nxt ( seq_add . c rcv_nxt n )
+    ^ n
+}
+
+// Process an ACK: advance snd_una, release acknowledged bytes, update
+// RTT/RTO, and count duplicates for fast retransmit.
+@ __process_ack * TcpConn c TcpSeg s i now → v {
+    : i ack . s ack
+    ? ( seq_gt ack . c snd_nxt ) { ^ } {}
+    ? ( seq_lt ack . c snd_una ) { ^ } {}
+    ? == ack . c snd_una {
+        // A pure duplicate ACK — no new data, no window change.
+        ? && == . s payload_len 0 == . c snd_wnd << . s window . c rcv_wscale {
+            = . c dupacks + . c dupacks 1
+            ^
+        } {}
+        ^
+    } {}
+    : i acked ( seq_diff ack . c snd_una )
+    = . c dupacks 0
+    // Release acknowledged bytes from the send buffer. A FIN occupies
+    // one sequence number but no buffer byte, so cap by what is there.
+    : i have ( vec_len [u] . c sndbuf )
+    : i drop ? > acked have have acked
+    ? > drop 0 {
+        : ( Vec u ) rest ( vec_new [u] )
+        : ~ i j drop
+        ~ < j have {
+            ( vec_push [u] rest ?? ( vec_get [u] . c sndbuf j ) { T x → x F → # u 0 } )
+            = j + j 1
+        }
+        ( vec_free [u] . c sndbuf )
+        = . c sndbuf rest
+    } {}
+    = . c snd_una ack
+    ? && . c fin_sent ( seq_geq ack . c snd_nxt ) { = . c fin_acked T } {}
+    // RTT sample (Karn: only when this ACK covers the timed segment
+    // and that segment was never retransmitted).
+    ? && >= . c rtt_seq 0 ( seq_gt ack . c rtt_seq ) {
+        ( __rtt_update c - now . c rtt_start )
+        = . c rtt_seq -1
+    } {}
+    = . c rtx_count 0
+    // Everything acknowledged → stop the retransmit timer.
+    ? ( seq_geq . c snd_una . c snd_nxt ) {
+        = . c rtx_deadline 0
+    } { ( __arm_rtx c now ) }
+}
+
+@ __update_window * TcpConn c TcpSeg s → v {
+    : i w << . s window . c rcv_wscale
+    // RFC 793: only accept a window update from a segment that is not
+    // older than the last one used, or the window can go backwards on
+    // a reordered ACK and stall the sender.
+    // RFC 793 §3.7 SND.WL1/WL2. Note there is deliberately no
+    // "wl1 == 0 means uninitialised" sentinel: 0 is a perfectly legal
+    // sequence number after a wrap, and such a sentinel would re-enable
+    // stale window updates exactly once per 4 GB — the kind of bug that
+    // only ever reproduces in production. wl1/wl2 are seeded when the
+    // connection synchronises instead.
+    ? || ( seq_lt . c snd_wl1 . s seq ) && == . c snd_wl1 . s seq ( seq_leq . c snd_wl2 . s ack ) {
+        = . c snd_wnd w
+        = . c snd_wl1 . s seq
+        = . c snd_wl2 . s ack
+    } {}
+}
+
+// Feed one parsed segment. `buf` is the buffer it was parsed from.
+// Returns bytes emitted into `out`.
+@ tcp_input * TcpConn c TcpSeg s ( Vec u ) buf i now * TcpOut out → i {
+    ? ! . s valid { ^ 0 } {}
+    : i before ( vec_len [u] . out bytes )
+    : b has_rst == & . s flags 4 4
+    : b has_syn == & . s flags 2 2
+    : b has_ack == & . s flags 16 16
+    : b has_fin == & . s flags 1 1
+
+    // ── CLOSED / LISTEN ──
+    ? == . c state ( tcp_closed ) { ^ 0 } {}
+    ? == . c state ( tcp_listen_st ) {
+        ? has_rst { ^ 0 } {}
+        // An ACK to a LISTEN socket is bogus — RST it (RFC 793 §3.4).
+        ? has_ack {
+            = . c remote_ip . c remote_ip
+            ^ 0
+        } {}
+        ? has_syn {
+            = . c remote_port . s src_port
+            = . c irs . s seq
+            = . c rcv_nxt ( seq_add . s seq 1 )
+            = . c rcv_wscale ? >= . s wscale 0 . s wscale 0
+            = . c mss ? > . s mss 0 ? < . s mss ( tcp_default_mss ) . s mss ( tcp_default_mss ) ( tcp_fallback_mss )
+            = . c snd_una . c iss
+            = . c snd_nxt ( seq_add . c iss 1 )
+            = . c snd_wnd << . s window . c rcv_wscale
+            = . c snd_wl1 . s seq
+            = . c snd_wl2 . s ack
+            = . c state ( tcp_syn_rcvd )
+            ( __emit_empty c out | ( tcp_syn ) ( tcp_ack ) . c iss . c rcv_nxt )
+            ( __arm_rtx c now )
+            ^ - ( vec_len [u] . out bytes ) before
+        } {}
+        ^ 0
+    } {}
+
+    // ── SYN_SENT ──
+    ? == . c state ( tcp_syn_sent ) {
+        ? has_ack {
+            // The ACK must acknowledge exactly our SYN.
+            ? || ( seq_leq . s ack . c iss ) ( seq_gt . s ack . c snd_nxt ) {
+                ? ! has_rst { ( __emit_empty c out ( tcp_rst ) . s ack 0 ) } {}
+                ^ - ( vec_len [u] . out bytes ) before
+            } {}
+        } {}
+        ? has_rst {
+            ? has_ack { = . c state ( tcp_closed ) = . c reset T } {}
+            ^ 0
+        } {}
+        ? has_syn {
+            = . c irs . s seq
+            = . c rcv_nxt ( seq_add . s seq 1 )
+            = . c rcv_wscale ? >= . s wscale 0 . s wscale 0
+            = . c mss ? > . s mss 0 ? < . s mss ( tcp_default_mss ) . s mss ( tcp_default_mss ) ( tcp_fallback_mss )
+            ? has_ack {
+                = . c snd_una . s ack
+                // Seed the window-update guard before the first update.
+                = . c snd_wnd << . s window . c rcv_wscale
+                = . c snd_wl1 . s seq
+                = . c snd_wl2 . s ack
+                = . c state ( tcp_established )
+                = . c rtx_deadline 0
+                ? && >= . c rtt_seq 0 ( seq_gt . s ack . c rtt_seq ) {
+                    ( __rtt_update c - now . c rtt_start )
+                    = . c rtt_seq -1
+                } {}
+                ( __emit_empty c out ( tcp_ack ) . c snd_nxt . c rcv_nxt )
+            } {
+                // Simultaneous open.
+                = . c state ( tcp_syn_rcvd )
+                ( __emit_empty c out | ( tcp_syn ) ( tcp_ack ) . c iss . c rcv_nxt )
+            }
+            ^ - ( vec_len [u] . out bytes ) before
+        } {}
+        ^ 0
+    } {}
+
+    // ── all synchronised states: acceptability test first ──
+    // A segment outside the receive window is old or forged; the reply
+    // is an ACK of what we actually expect, never silence — silence is
+    // what turns one lost ACK into a stalled connection.
+    : i seglen ( tcpseg_seq_len s )
+    : b acceptable ? == seglen 0 {
+        ? == . c rcv_wnd 0 { == . s seq . c rcv_nxt } { ( seq_in_window . s seq . c rcv_nxt . c rcv_wnd ) }
+    } {
+        ? == . c rcv_wnd 0 { F } {
+            || ( seq_in_window . s seq . c rcv_nxt . c rcv_wnd )
+            ( seq_in_window ( seq_add . s seq - seglen 1 ) . c rcv_nxt . c rcv_wnd )
+        }
+    }
+    ? ! acceptable {
+        ? ! has_rst { ( __emit_empty c out ( tcp_ack ) . c snd_nxt . c rcv_nxt ) } {}
+        ^ - ( vec_len [u] . out bytes ) before
+    } {}
+
+    ? has_rst {
+        = . c state ( tcp_closed )
+        = . c reset T
+        ^ 0
+    } {}
+
+    // A SYN inside the window on an established connection is a
+    // protocol violation (or an injection attempt) — reset.
+    ? has_syn {
+        ( __emit_empty c out ( tcp_rst ) . c snd_nxt . c rcv_nxt )
+        = . c state ( tcp_closed )
+        = . c reset T
+        ^ - ( vec_len [u] . out bytes ) before
+    } {}
+
+    ? ! has_ack { ^ 0 } {}
+
+    // SYN_RCVD: the handshake's third segment completes the open.
+    ? == . c state ( tcp_syn_rcvd ) {
+        ? && ( seq_leq . c snd_una . s ack ) ( seq_leq . s ack . c snd_nxt ) {
+            = . c snd_una . s ack
+            ( __update_window c s )
+            = . c state ( tcp_established )
+            = . c rtx_deadline 0
+            = . c rtx_count 0
+        } {
+            ( __emit_empty c out ( tcp_rst ) . s ack 0 )
+            ^ - ( vec_len [u] . out bytes ) before
+        }
+    } {
+        ( __process_ack c s now )
+        ( __update_window c s )
+    }
+
+    // FIN_WAIT_1 → FIN_WAIT_2 once our FIN is acknowledged.
+    ? && == . c state ( tcp_fin_wait_1 ) . c fin_acked { = . c state ( tcp_fin_wait_2 ) } {}
+    ? && == . c state ( tcp_closing ) . c fin_acked {
+        = . c state ( tcp_time_wait )
+        = . c tw_deadline + now ( tcp_2msl_ms )
+    } {}
+    ? && == . c state ( tcp_last_ack ) . c fin_acked {
+        = . c state ( tcp_closed )
+        ^ - ( vec_len [u] . out bytes ) before
+    } {}
+
+    // ── data ──
+    : ~ b need_ack F
+    ? > . s payload_len 0 {
+        ? == . s seq . c rcv_nxt {
+            : i _n ( __accept_data c s buf )
+            = need_ack T
+        } {
+            // Out of order (or a duplicate). v1 keeps no reassembly
+            // queue: drop it and ACK rcv_nxt. That duplicate ACK is
+            // precisely what triggers the peer's fast retransmit.
+            = need_ack T
+        }
+    } {}
+
+    // ── FIN ──
+    ? && has_fin == . s seq . c rcv_nxt {
+        = . c fin_rcvd T
+        = . c rcv_nxt ( seq_add . c rcv_nxt 1 )
+        = need_ack T
+        ? == . c state ( tcp_established ) { = . c state ( tcp_close_wait ) } {}
+        ? == . c state ( tcp_fin_wait_1 ) {
+            = . c state ? . c fin_acked ( tcp_time_wait ) ( tcp_closing )
+            ? . c fin_acked { = . c tw_deadline + now ( tcp_2msl_ms ) } {}
+        } {}
+        ? == . c state ( tcp_fin_wait_2 ) {
+            = . c state ( tcp_time_wait )
+            = . c tw_deadline + now ( tcp_2msl_ms )
+        } {}
+    } {}
+
+    // Arm or disarm the persist timer as the peer's window changes.
+    ? && == . c snd_wnd 0 > ( __unsent c ) 0 {
+        ? == . c probe_deadline 0 { = . c probe_deadline + now . c rto_ms } {}
+    } { = . c probe_deadline 0 }
+
+    ? need_ack { ( __emit_empty c out ( tcp_ack ) . c snd_nxt . c rcv_nxt ) } {}
+
+    // Fast retransmit: three duplicate ACKs mean a hole the peer has
+    // been staring at for three segments. Do not wait for the RTO.
+    ? >= . c dupacks 3 {
+        = . c dupacks 0
+        : i have ( vec_len [u] . c sndbuf )
+        ? > have 0 {
+            : i chunk ? > have . c mss . c mss have
+            ( __emit c out | ( tcp_ack ) ( tcp_psh ) . c snd_una . c rcv_nxt . c sndbuf 0 chunk )
+            ( __arm_rtx c now )
+        } {}
+    } {}
+
+    : i _p ( tcp_pump c now out )
+    ^ - ( vec_len [u] . out bytes ) before
+}

--- a/stdlib/net/tcpseg.nu
+++ b/stdlib/net/tcpseg.nu
@@ -1,0 +1,206 @@
+// stdlib/net/tcpseg.nu — TCP segment codec + sequence arithmetic.
+//
+// PURE. Split out from the connection state machine (net/tcp.nu) on
+// purpose: the wire format and the sequence-number algebra are the two
+// pieces that must be *provably* right before any state machine built
+// on them can be trusted, and they are testable exhaustively on their
+// own.
+//
+// SEQUENCE ARITHMETIC IS THE SUBTLE PART
+//
+// TCP sequence numbers live in a 32-bit space that wraps. "Is this
+// segment newer?" is therefore NOT `a < b` — after a wrap, the newer
+// number is numerically smaller. RFC 1323 §4.II states the rule: work
+// with the *signed* 32-bit difference, so ordering is defined over the
+// half-space (2^31) and wraps correctly.
+//
+// A stack that compares raw magnitudes works perfectly for hours and
+// then, exactly once per 4 GB transferred, silently discards live data
+// or accepts an ancient duplicate. That is the archetypal "flaky
+// network" bug, and it is entirely avoidable by never writing a bare
+// comparison on a sequence number.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/ipv4.nu`
+
+// ── flags ────────────────────────────────────────────────────────
+
+@ tcp_fin → i { ^ 1 }
+
+@ tcp_syn → i { ^ 2 }
+
+@ tcp_rst → i { ^ 4 }
+
+@ tcp_psh → i { ^ 8 }
+
+@ tcp_ack → i { ^ 16 }
+
+@ tcp_urg → i { ^ 32 }
+
+@ tcp_min_hdr → i { ^ 20 }
+
+// The largest segment we will ever emit or accept as an MSS, derived
+// from the Ethernet MTU: 1500 - 20 (IP) - 20 (TCP).
+@ tcp_default_mss → i { ^ 1460 }
+
+// A peer that offers no MSS option gets RFC 1122's default of 536.
+@ tcp_fallback_mss → i { ^ 536 }
+
+// ── 32-bit sequence arithmetic ───────────────────────────────────
+
+@ seq_mask → i { ^ 4294967295 }
+
+@ seq_add i a i b → i { ^ & + a b 4294967295 }
+
+@ seq_sub i a i b → i { ^ & - a b 4294967295 }
+
+// The signed 32-bit difference a - b. Everything else is built on it.
+@ seq_diff i a i b → i {
+    : i d & - a b 4294967295
+    ^ ? >= d 2147483648 - d 4294967296 d
+}
+
+@ seq_lt i a i b → b { ^ < ( seq_diff a b ) 0 }
+
+@ seq_leq i a i b → b { ^ <= ( seq_diff a b ) 0 }
+
+@ seq_gt i a i b → b { ^ > ( seq_diff a b ) 0 }
+
+@ seq_geq i a i b → b { ^ >= ( seq_diff a b ) 0 }
+
+// Is `s` inside the half-open window [start, start+len)?
+@ seq_in_window i s i start i len → b {
+    ? == len 0 { ^ F } {}
+    ^ && ( seq_geq s start ) ( seq_lt s ( seq_add start len ) )
+}
+
+// ── segment ──────────────────────────────────────────────────────
+
+: TcpSeg {
+    i src_port
+    i dst_port
+    i seq
+    i ack
+    i data_off  // header length in BYTES
+    i flags
+    i window  // as carried, BEFORE window-scale is applied
+    i urgent
+    i mss  // from options, 0 if absent
+    i wscale  // from options, -1 if absent (distinct from a scale of 0)
+    b sack_permitted
+    i payload_off
+    i payload_len
+    b valid
+}
+
+@ __seg_bad → TcpSeg { ^ @ TcpSeg { 0 0 0 0 0 0 0 0 0 -1 F 0 0 F } }
+
+// Parse a TCP segment, verifying the checksum against the enclosing
+// IPv4 addresses. `len` is the TCP length from the IP header — never
+// the frame length (see net/ipv4.nu on Ethernet padding).
+@ tcpseg_parse ( Vec u ) buf i off i len i src_ip i dst_ip → TcpSeg {
+    ? < len 20 { ^ ( __seg_bad ) } {}
+    : i doff * >> ?? ( vec_get [u] buf + off 12 ) { T x → # i x F → 0 } 4 4
+    ? || < doff 20 > doff len { ^ ( __seg_bad ) } {}
+    : i s ( inet_sum_add ( ip4_pseudo_sum src_ip dst_ip ( ip_proto_tcp ) len ) buf off len )
+    ? != ( inet_fold s ) 65535 { ^ ( __seg_bad ) } {}
+    // ── options ──
+    : ~ i mss 0
+    : ~ i wscale -1
+    : ~ b sack_ok F
+    : ~ i k 20
+    : ~ b done F
+    ~ && ! done < k doff {
+        : i kind ?? ( vec_get [u] buf + off k ) { T x → # i x F → 0 }
+        ? == kind 0 { = done T } {
+            ? == kind 1 { = k + k 1 } {
+                ? >= + k 2 doff { = done T } {
+                    : i olen ?? ( vec_get [u] buf + off + k 1 ) { T x → # i x F → 0 }
+                    // A length < 2 would not advance — that is an
+                    // infinite loop on hostile input, so stop.
+                    ? || < olen 2 > + k olen doff { = done T } {
+                        ? && == kind 2 == olen 4 {
+                            = mss ?? ( bytes_read_u16_be buf + off + k 2 ) { T x → # i x F → 0 }
+                        } {}
+                        ? && == kind 3 == olen 3 {
+                            : i sh ?? ( vec_get [u] buf + off + k 2 ) { T x → # i x F → 0 }
+                            // RFC 7323 §2.3: a shift above 14 is
+                            // clamped, not honoured.
+                            = wscale ? > sh 14 14 sh
+                        } {}
+                        ? && == kind 4 == olen 2 { = sack_ok T } {}
+                        = k + k olen
+                    }
+                }
+            }
+        }
+    }
+    ^ @ TcpSeg {
+        ?? ( bytes_read_u16_be buf off ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u16_be buf + off 2 ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u32_be buf + off 4 ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u32_be buf + off 8 ) { T x → # i x F → 0 }
+        doff
+        & ?? ( vec_get [u] buf + off 13 ) { T x → # i x F → 0 } 63
+        ?? ( bytes_read_u16_be buf + off 14 ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u16_be buf + off 18 ) { T x → # i x F → 0 }
+        mss
+        wscale
+        sack_ok
+        + off doff
+        - len doff
+        T
+    }
+}
+
+// How much sequence space a segment occupies: payload plus one for
+// each of SYN and FIN. This is the quantity every ACK and window
+// calculation is expressed in, so it gets a name rather than being
+// open-coded at each site.
+@ tcpseg_seq_len TcpSeg s → i {
+    : ~ i n . s payload_len
+    ? == & . s flags 2 2 { = n + n 1 } {}
+    ? == & . s flags 1 1 { = n + n 1 } {}
+    ^ n
+}
+
+// Append a TCP segment with a correct checksum. Options are emitted
+// only on SYN segments, which is where they are meaningful.
+@ tcpseg_push ( Vec u ) out i src_ip i dst_ip i src_port i dst_port i seq i ack i flags i window i mss i wscale ( Vec u ) payload i pay_off i pay_len → v {
+    : i start ( vec_len [u] out )
+    : b is_syn == & flags 2 2
+    // options: MSS (4) + wscale (3) + 1 pad = 8 bytes on SYN
+    : i optlen ? is_syn 8 0
+    : i doff + 20 optlen
+    ( bytes_push_u16_be out # u16 & src_port 65535 )
+    ( bytes_push_u16_be out # u16 & dst_port 65535 )
+    ( bytes_push_u32_be out # u32 & seq 4294967295 )
+    ( bytes_push_u32_be out # u32 & ack 4294967295 )
+    ( vec_push [u] out # u << / doff 4 4 )
+    ( vec_push [u] out # u & flags 63 )
+    ( bytes_push_u16_be out # u16 & window 65535 )
+    ( bytes_push_u16_be out # u16 0 )  // checksum placeholder
+    ( bytes_push_u16_be out # u16 0 )  // urgent pointer
+    ? is_syn {
+        ( vec_push [u] out # u 2 ) ( vec_push [u] out # u 4 )
+        ( bytes_push_u16_be out # u16 & ? > mss 0 mss ( tcp_default_mss ) 65535 )
+        ( vec_push [u] out # u 3 ) ( vec_push [u] out # u 3 )
+        ( vec_push [u] out # u & ? >= wscale 0 wscale 0 255 )
+        ( vec_push [u] out # u 0 )  // end-of-options pad to a 4-byte boundary
+    } {}
+    : ~ i k 0
+    ~ < k pay_len {
+        ( vec_push [u] out ?? ( vec_get [u] payload + pay_off k ) { T x → x F → # u 0 } )
+        = k + k 1
+    }
+    : i total + doff pay_len
+    : i s ( inet_sum_add ( ip4_pseudo_sum src_ip dst_ip ( ip_proto_tcp ) total ) out start total )
+    : i ck ( inet_finish s )
+    // Unlike UDP, a TCP checksum of zero is a real value — there is no
+    // "no checksum" encoding to collide with, so no substitution here.
+    : b _a ( vec_set [u] out + start 16 # u & >> ck 8 255 )
+    : b _b ( vec_set [u] out + start 17 # u & ck 255 )
+}

--- a/stdlib/net/udp4.nu
+++ b/stdlib/net/udp4.nu
@@ -1,0 +1,98 @@
+// stdlib/net/udp4.nu — UDP over IPv4 (RFC 768), sans-IO.
+//
+// PURE — parse and build. Named `udp4` to keep it distinct from
+// `stdlib/std/udp.nu`, which is the host socket API; this module is
+// the wire format the sans-IO stack speaks.
+//
+// TWO RULES THAT ARE EASY TO GET SUBTLY WRONG
+//
+// 1. Transmitted checksum 0 means "not computed". So when the computed
+//    checksum happens to be 0x0000, the sender must transmit 0xFFFF
+//    instead — the two are equal in one's-complement arithmetic, and
+//    the substitution is what keeps a real checksum from being read as
+//    "none". Roughly one datagram in 65536 hits this; a stack missing
+//    it looks perfect in testing and corrupts rarely in production.
+//
+// 2. The checksum covers a pseudo-header (src, dst, proto, UDP length)
+//    that is not on the wire. We accumulate it via `ip4_pseudo_sum`
+//    and fold it together with the real bytes, so no scratch buffer is
+//    built per datagram.
+//
+// On receive, checksum 0 means the sender skipped it and we accept the
+// datagram unverified — mandatory per RFC 768 over IPv4.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/ipv4.nu`
+
+@ udp4_hdr_len → i { ^ 8 }
+
+@ udp4_ok → i { ^ 0 }
+
+@ udp4_err_short → i { ^ 1 }
+
+@ udp4_err_length → i { ^ 2 }
+
+@ udp4_err_checksum → i { ^ 3 }
+
+: Udp4Hdr {
+    i src_port
+    i dst_port
+    i length  // header + payload, as carried
+    i checksum
+    i payload_off
+    i payload_len
+    b valid
+    i reason
+}
+
+// Parse the UDP datagram at `off`, `avail` bytes present, verifying
+// the checksum against the enclosing IPv4 addresses.
+@ udp4_parse ( Vec u ) buf i off i avail i src_ip i dst_ip → Udp4Hdr {
+    ? < avail 8 { ^ @ Udp4Hdr { 0 0 0 0 0 0 F ( udp4_err_short ) } } {}
+    : i len ?? ( bytes_read_u16_be buf + off 4 ) { T x → # i x F → 0 }
+    ? || < len 8 > len avail { ^ @ Udp4Hdr { 0 0 0 0 0 0 F ( udp4_err_length ) } } {}
+    : i ck ?? ( bytes_read_u16_be buf + off 6 ) { T x → # i x F → 0 }
+    ? != ck 0 {
+        : i s ( inet_sum_add ( ip4_pseudo_sum src_ip dst_ip ( ip_proto_udp ) len ) buf off len )
+        ? != ( inet_fold s ) 65535 {
+            ^ @ Udp4Hdr { 0 0 0 0 0 0 F ( udp4_err_checksum ) }
+        } {}
+    } {}
+    ^ @ Udp4Hdr {
+        ?? ( bytes_read_u16_be buf off ) { T x → # i x F → 0 }
+        ?? ( bytes_read_u16_be buf + off 2 ) { T x → # i x F → 0 }
+        len
+        ck
+        + off 8
+        - len 8
+        T
+        ( udp4_ok )
+    }
+}
+
+// Append a complete UDP datagram (header + payload) with a correct
+// checksum. Like ICMP, the payload is passed in because the checksum
+// is a prefix field over suffix bytes.
+@ udp4_push ( Vec u ) out i src_ip i dst_ip i src_port i dst_port ( Vec u ) payload i pay_off i pay_len → v {
+    : i start ( vec_len [u] out )
+    : i total + 8 pay_len
+    ( bytes_push_u16_be out # u16 & src_port 65535 )
+    ( bytes_push_u16_be out # u16 & dst_port 65535 )
+    ( bytes_push_u16_be out # u16 & total 65535 )
+    ( bytes_push_u16_be out # u16 0 )  // checksum placeholder
+    : ~ i k 0
+    ~ < k pay_len {
+        ( vec_push [u] out ?? ( vec_get [u] payload + pay_off k ) { T x → x F → # u 0 } )
+        = k + k 1
+    }
+    : i s ( inet_sum_add ( ip4_pseudo_sum src_ip dst_ip ( ip_proto_udp ) total ) out start total )
+    : ~ i ck ( inet_finish s )
+    // RFC 768: a computed zero is transmitted as all-ones, because a
+    // transmitted zero means "no checksum".
+    ? == ck 0 { = ck 65535 } {}
+    : b _a ( vec_set [u] out + start 6 # u & >> ck 8 255 )
+    : b _b ( vec_set [u] out + start 7 # u & ck 255 )
+}

--- a/tools/check_stdlib_symbols.sh
+++ b/tools/check_stdlib_symbols.sh
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # ============================================================
 #  tools/check_stdlib_symbols.sh — assert that no two top-level
-#  @-functions in the stdlib share a name.
+#  @-functions, and no two top-level type declarations, in the stdlib
+#  share a name.
 #
 #  NURL's `$`-include is a flat inline-include into one LLVM module,
 #  so two stdlib modules that define the same top-level `@` name
@@ -16,9 +17,18 @@
 #  Rule: every top-level `@` function name in stdlib/ is globally
 #  unique. Prefix per-module for private helpers (e.g. `__stun_u32`).
 #
+#  The same rule applies to top-level TYPE declarations (`: Name {`),
+#  and for the same reason — a flat namespace does not care whether the
+#  colliding symbol is a function or a struct. This half of the gate was
+#  added after `net/tcp.nu` introduced a `TcpConn` that collided with
+#  `std/net.nu`'s socket-API `TcpConn`: the function half caught the
+#  accompanying `tcp_connect` / `tcp_listen` clash, while the type
+#  slipped through and would only have surfaced as a confusing error in
+#  whichever program first imported both modules.
+#
 #  Scope: stdlib/ only (the shared library). Package/test programs are
 #  each their own compilation, so their names don't share this
-#  namespace. Type / enum / const names are not yet checked here.
+#  namespace. Enum variants and const names are still not checked.
 # ============================================================
 set -euo pipefail
 
@@ -42,4 +52,22 @@ if [ -n "$dups" ]; then
     exit 1
 fi
 
-echo "stdlib symbol check: no duplicate top-level @-function names."
+# Type declarations: `: Name {` or `: Name [A] {` (generic). The `{` is
+# what separates a type declaration from an ordinary `: i x 5` binding.
+type_dups="$(grep -rhoE '^: [A-Z][A-Za-z0-9_]*( *\[[^]]*\])? *\{' stdlib --include='*.nu' \
+  | sed -E 's/^: ([A-Za-z0-9_]+).*/\1/' | sort | uniq -d)"
+
+if [ -n "$type_dups" ]; then
+    echo "error: duplicate top-level type names in stdlib" >&2
+    echo "       (a flat namespace collides types exactly like functions):" >&2
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        echo "  $name" >&2
+        grep -rnE "^: ${name}([^A-Za-z0-9_]|\$)" stdlib --include='*.nu' \
+          | sed 's/^/    /' >&2
+    done <<< "$type_dups"
+    echo "Fix: rename per module (e.g. the sans-IO TCB is 'Tcb', not 'TcpConn')." >&2
+    exit 1
+fi
+
+echo "stdlib symbol check: no duplicate top-level @-function or type names."


### PR DESCRIPTION
## What

`stdlib/net/` gains a complete IPv4 stack written as pure logic: frames
and a caller-supplied clock in, frames and events out. **No FFI, no
sockets, no timers, no device** — ten modules, zero foreign declarations.

| Module | Contents |
|---|---|
| `inet` | RFC 1071 checksum (accumulate/fold split so pseudo-headers need no scratch buffer) + scalar address types |
| `eth` | Ethernet II, zero-copy parse |
| `ipv4` | header codec; fragments rejected distinctly, not mis-parsed |
| `arp` | codec + bounded cache with retry rate limiting |
| `icmp` | echo request/reply, error parsing |
| `udp4` | RFC 768 incl. the computed-zero → `0xffff` rule |
| `dhcp` | full client: DISCOVER/OFFER/REQUEST/ACK, T1 renew, T2 rebind, expiry, NAK |
| `stack` | the seam a driver talks to: rx/tx/tick + labelled drop counters |
| `tcpseg` | segment codec + wrap-safe sequence algebra |
| `tcp` | RFC 793 state machine incl. TIME_WAIT, Jacobson/Karn RTO, fast retransmit, zero-window probes, MSS clamping, RST |

## Why sans-IO

The same code has to run in two places: on Linux against a TUN/TAP
harness, and inside a freestanding target with virtio-net underneath.
Anything that reaches for a socket or a clock only works in the first.

Keeping the clock as an argument also means lease timers, retransmission
backoff and a 2MSL wait are integer comparisons in a unit test rather
than minutes of wall time — which is the only reason those paths are
covered at all.

## Scope decisions

**In, deliberately:** TIME_WAIT and the persist timer. Without the
first, a delayed segment from a closed connection lands in a new one
reusing the port pair; without the second, a lost window update
deadlocks the connection forever. Both only bite under reconnect churn
and buffer pressure.

**Out, documented:** SACK; out-of-order reassembly (dropped with an
immediate ACK of `rcv_nxt` — that duplicate ACK is what drives the
peer's fast retransmit); delayed ACK; Nagle. Our *sent* window-scale
factor is fixed at 0; the peer's is always parsed and honoured.

## Tests

`net_{inet,frames,dhcp,stack,tcp,tcp_fuzz}` — **328 assertions**, all
offline and deterministic. Full suite **PASS 585 · FAIL 0**.

- `net_stack` wires two stacks frame-to-frame and completes ARP
  resolution, a UDP round-trip, an answered ping and gateway routing.
- `net_tcp_fuzz` drives 400 connections through 12 hostile segments each
  from a seeded LCG, with state invariants as the oracle.

Two traps that silently corrupt hand-rolled stacks have their own cases:
Ethernet pads frames to 60 bytes, so the IP payload length must come
from `total_len` and never the frame length; and a UDP checksum that
computes to zero must go on the wire as `0xffff` (~1 datagram in 65536).

### Every oracle is mutation-validated: 26 injected bugs, 26 caught

The first TCP run had **four escapes**, each a blind spot in the *test*
rather than the code — Karn's rule, RST on ESTABLISHED (a different code
path from RST in SYN_SENT), the malformed-option guard, and the
stale-window rule. All four now have cases.

Removing the option-length guard shows up as an **infinite loop** — a
remote hang reachable from an unauthenticated SYN — so the harness
treats a timeout as a catch.

## Changes outside `stdlib/net/`

**`run_tests.sh` skipped every `net_*` test** unless
`ENABLE_NET_TESTS=1`, with `net_basic` hardcoded as the lone exception.
Gating on the name rather than on behaviour would have kept this entire
stack out of CI. Now a `net_needs_net()` predicate names the tests that
actually open a socket (only `net_loopback`), mirroring the existing
`http_needs_net()`. The default is safe: a new offline net test runs on
every commit.

**Leak gate** gains the six new tests. `Vec`/`String` are
manually-managed handles outside auto-drop (MEMORY.md §7.4), and this
stack is headed for a target with no process exit to sweep up after it,
so it is held leak-clean from its first commit. All six are LSan- and
UBSan-clean under `run_san_tests.sh`.

## One bug found in this branch's own code

Via an escaped mutation: the SND.WL1/WL2 window-update guard used
`wl1 == 0` as an "uninitialised" sentinel. Sequence numbers wrap, so 0
is legal — the sentinel would have re-enabled stale window updates
exactly once per 4 GB transferred. `wl1`/`wl2` are now seeded when the
connection synchronises.

## Verification

- `./compiler/tests/run_tests.sh` → PASS 585 · FAIL 0
- `LSAN_DETECT_LEAKS=1 ./compiler/tests/run_san_tests.sh net_inet net_frames net_dhcp net_stack net_tcp net_tcp_fuzz` → 5+1 PASS, 0 SAN_FAIL
- `grep` for FFI declarations across the ten modules → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ
