### PR TITLE
hal: virtio split-ring virtqueue; fix borrowck reading `_free`-suffixed queries as destructors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,8 @@ jobs:
             recover_unwind loop_drop_reclaim closure_env_reclaim closure_env_binding \
             ternary_slice_owned match_slice_owned arm_assign_tail_drop \
             defer_drop_reclaim defer_scoped defer_ret_transfer \
-            net_inet net_frames net_dhcp net_stack net_tcp net_tcp_fuzz
+            net_inet net_frames net_dhcp net_stack net_tcp net_tcp_fuzz \
+            virtq_split free_suffix_query
 
   webdocs-build:
     name: web docs build (fumadocs)

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5921,8 +5921,10 @@
     ( seq fname `thread_spawn` )
     // A `*_free` destructor consumes (frees) its first argument.
     // `nurl_free` is excluded — it frees raw *T / i8* FFI memory,
-    // which the borrow checker does not track.
-    : b is_consume_call & ( bck_is_destructor_name fname )
+    // which the borrow checker does not track. The callee's return
+    // type is consulted too: a `_free`-suffixed function that returns
+    // a value is a free-space QUERY, not a destructor.
+    : b is_consume_call & ( bck_is_destructor_call fname ( nurl_sym_get syms fname ) )
     ! ( seq fname `nurl_free` )
     : ~ i arg_idx 0
     // Space-separated 0-based indices of the callee's `inout`
@@ -10290,16 +10292,40 @@
 // analyze walk transitions the binding Owned -> Moved; a `let` / `=`
 // of the binding revives it to Owned.
 
-// True when `name` ends with the literal suffix `_free` — i.e. the
-// callee is a typed heap destructor. NB: this predicate must NOT
-// itself be named with a `_free` (or `..._is_free`) suffix — the
-// Phase 1 move rule keys on a `_free`-suffixed callee, so such a
-// helper would be misread as a destructor and flag its own
-// bare-identifier argument as moved (a false positive in nurlc.nu).
+// True when `name` ends with the literal suffix `_free`.
+//
+// The suffix ALONE does not make a destructor — see
+// `bck_is_destructor_call`, which is what the move rule keys on. A
+// name-only rule misreads any query whose name happens to end in
+// `_free` (`virtq_num_free`, `pool_num_free`, `arena_bytes_free`) as
+// consuming its receiver, so the second read of that receiver is
+// reported as a use-after-move. That is a false positive with no
+// workaround other than renaming a correctly-named function — which
+// is exactly what this compiler had to do to its own helper before
+// the return-type test below existed.
 @ bck_is_destructor_name s name → b {
     : i len ( nurl_str_len name )
     ? < len 5 { ^ F } {}
     ( seq ( nurl_str_slice name - len 5 5 ) `_free` )
+}
+
+// True when a call to `name` really consumes its first argument.
+//
+// A typed heap destructor takes the value, releases it, and has
+// nothing left to report: every `_free` in the stdlib returns `v`
+// (`vec_free`, `string_free`, `x509_free`, …, audited). A `_free`-
+// suffixed function that RETURNS a value is therefore not a
+// destructor but a query about free space — it hands back a count,
+// which a destructor has no reason to do.
+//
+// `ret_ll` is the callee's recorded LLVM return type. When it is
+// empty the callee's signature is not visible here (a forward
+// reference); fall back to the name rule so this can only ever be
+// more permissive than before, never less safe.
+@ bck_is_destructor_call s name s ret_ll → b {
+    ? ! ( bck_is_destructor_name name ) { ^ F } {}
+    ? == 0 ( nurl_str_len ret_ll ) { ^ T } {}
+    ^ ( seq ret_ll `void` )
 }
 
 // ── Borrow checker — iterator invalidation ─────────────────────────

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5924,8 +5924,18 @@
     // which the borrow checker does not track. The callee's return
     // type is consulted too: a `_free`-suffixed function that returns
     // a value is a free-space QUERY, not a destructor.
-    : b is_consume_call & ( bck_is_destructor_call fname ( nurl_sym_get syms fname ) )
+    //
+    // The type lookup is guarded by the cheap name test, and its result
+    // is bound to a local: `nurl_sym_get` hands back a fresh string the
+    // caller owns, so calling it inline on the hot path of every call
+    // site would both strdup for nothing and leak the result.
+    : b __bck_free_name & ( bck_is_destructor_name fname )
     ! ( seq fname `nurl_free` )
+    : ~ b is_consume_call F
+    ? __bck_free_name
+    { : s __bck_callee_ret ( nurl_sym_get syms fname )
+        = is_consume_call ( bck_is_destructor_call fname __bck_callee_ret ) }
+    {}
     : ~ i arg_idx 0
     // Space-separated 0-based indices of the callee's `inout`
     // parameters (recorded into g_fn_inout by gen_fn_decl_concrete as

--- a/compiler/tests/free_suffix_query.nu
+++ b/compiler/tests/free_suffix_query.nu
@@ -1,0 +1,71 @@
+// free_suffix_query.nu — a `_free`-suffixed QUERY is not a destructor.
+//
+// The borrow checker's move rule keys on a `_free` callee suffix. On the
+// suffix alone, any function whose name ends in `_free` is read as a
+// destructor that consumes its first argument, so the second use of that
+// argument is reported as a use-after-move. That is a false positive
+// with no workaround except renaming a correctly-named function:
+// "how many free slots?" is naturally `_num_free`, and asking it twice
+// is not a double free.
+//
+// A real destructor releases the value and has nothing left to report —
+// every `_free` in the stdlib returns `v`. A `_free`-suffixed function
+// that returns a value is a query about free space, not a destructor.
+// That return-type test is what this pins.
+//
+// Both halves matter, so both are here: the query compiles, and a real
+// destructor still consumes (the last block would be a use-after-free
+// if the checker had gone blind).
+
+$ `stdlib/core/vec.nu`
+
+: Pool { i cap ( Vec i ) slots }
+
+@ pool_new i cap → *Pool {
+    : *Pool p # *Pool ( nurl_alloc Z Pool )
+    = . p cap cap
+    = . p slots ( vec_new [i] )
+    : ~ i k 0
+    ~ < k cap { ( vec_push [i] . p slots k ) = k + k 1 }
+    ^ p
+}
+
+// The query. Returns a count, so it is not a destructor.
+@ pool_num_free * Pool p → i { ^ ( vec_len [i] . p slots ) }
+
+// A second shape: takes an extra argument, still returns a value.
+@ pool_bytes_free * Pool p i unit → i { ^ * ( pool_num_free p ) unit }
+
+// The real destructor: returns v, consumes the pool.
+@ pool_free * Pool p → v {
+    ( vec_free [i] . p slots )
+    ( free p )
+}
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ main → i {
+    : *Pool p ( pool_new 4 )
+    // Calling the query repeatedly must not move `p`.
+    : i a ( pool_num_free p )
+    : i b ( pool_num_free p )
+    : i c ( pool_bytes_free p 8 )
+    ( pb `query is callable twice: ` == a b )
+    ( pb `query returns the count: ` == a 4 )
+    ( pb `second query shape works: ` == c 32 )
+    // …and the pool is still usable afterwards.
+    ( vec_push [i] . p slots 99 )
+    ( pb `pool still usable after queries: ` == ( pool_num_free p ) 5 )
+    // The real destructor consumes it; nothing touches `p` after this.
+    ( pool_free p )
+
+    // The same distinction for a stdlib handle: a query on the vector
+    // does not move it, the destructor does.
+    : ( Vec i ) v ( vec_new [i] )
+    ( vec_push [i] v 7 )
+    : i n1 ( vec_len [i] v )
+    : i n2 ( vec_len [i] v )
+    ( pb `vec query repeatable: ` && == n1 n2 == n1 1 )
+    ( vec_free [i] v )
+    ^ 0
+}

--- a/compiler/tests/outputs/free_suffix_query.txt
+++ b/compiler/tests/outputs/free_suffix_query.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+query is callable twice: YES
+query returns the count: YES
+second query shape works: YES
+pool still usable after queries: YES
+vec query repeatable: YES

--- a/compiler/tests/outputs/virtq_split.txt
+++ b/compiler/tests/outputs/virtq_split.txt
@@ -1,0 +1,57 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+qsize 8 valid: YES
+qsize 0 invalid: YES
+qsize 3 invalid (not a power of two): YES
+qsize 32768 valid (spec max): YES
+qsize 65536 invalid (over max): YES
+desc table at 0: YES
+avail after 16·qsize: YES
+used is 4-byte aligned: YES
+used after avail: YES
+total covers the used ring: YES
+all 8 descriptors free: YES
+ring starts zeroed: YES
+8 allocations all distinct: YES
+queue now empty: YES
+9th allocation fails: YES
+all returned to the free list: YES
+device idle initially: YES
+published a buffer: YES
+avail.idx advanced: YES
+one descriptor consumed: YES
+device sees work: YES
+device completed our head: YES
+used.idx advanced: YES
+driver sees a completion: YES
+reaped the same head: YES
+written length reported: YES
+nothing left to reap: YES
+descriptor returned: YES
+desc addr preserved: YES
+desc len preserved: YES
+device-writable flag set: YES
+three descriptors in use: YES
+device walked to our chain head: YES
+reaped the chain: YES
+free_chain walked all three: YES
+all descriptors back: YES
+idx_lt basic: YES
+idx_lt not reflexive: YES
+idx wraps: 65530 < 4: YES
+idx wrap not reversed: YES
+idx_add wraps: YES
+idx_diff across wrap: YES
+70000 buffers all completed: YES
+every completion matched its head: YES
+every written length round-tripped: YES
+avail.idx wrapped correctly: YES
+and did wrap (idx < pushes): YES
+queue is whole again: YES
+out-of-range used id refused: YES
+free list not corrupted: YES
+notify needed by default: YES
+device NO_NOTIFY honoured: YES
+avail NO_INTERRUPT set (polling driver): YES

--- a/compiler/tests/virtq_split.nu
+++ b/compiler/tests/virtq_split.nu
@@ -1,0 +1,242 @@
+// virtq_split.nu — Phase A2 test for stdlib/hal/virtq.nu.
+//
+// Drives the split-ring against an in-memory MOCK DEVICE that plays the
+// host side of virtio 1.1 §2.6: it reads `avail`, walks the descriptor
+// chain, writes into device-writable segments, and publishes into
+// `used`. No MMIO, no hypervisor — the ring is just memory, which is
+// exactly what it is on real hardware too (the registers are a separate
+// concern, see stdlib/hal/mmio.nu).
+//
+// The load-bearing cases are the ones that work for thousands of
+// buffers and then break:
+//   * avail.idx / used.idx are free-running 16-bit counters. They wrap
+//     at 65536 and are NOT reduced by the queue size — only the ring
+//     SLOT is. A stack that stores the reduced value desynchronises
+//     from the device exactly once per 65536 buffers.
+//   * Freeing only a chain's head leaks every continuation descriptor,
+//     so the queue silently runs dry after a few thousand packets.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/hal/virtq.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+// ── mock device ─────────────────────────────────────────────────
+//
+// Consumes one available buffer: walks its chain, "writes" `fill`
+// bytes worth of length into the first device-writable segment, and
+// publishes the head into used with a total written length.
+
+: MockDev { i last_avail }
+
+@ mock_new → *MockDev {
+    : *MockDev d # *MockDev ( nurl_alloc Z MockDev )
+    = . d last_avail 0
+    ^ d
+}
+
+@ mock_free * MockDev d → v { ( free d ) }
+
+@ mock_has_work * MockDev d * Virtq q → b {
+    ^ ( vq_idx_lt . d last_avail ( virtq_avail_idx q ) )
+}
+
+// Returns the chain head it completed, or -1 when idle.
+@ mock_service * MockDev d * Virtq q i written → i {
+    ? ! ( mock_has_work d q ) { ^ -1 } {}
+    : i slot % . d last_avail . q qsize
+    : i head ( virtq_avail_ring q slot )
+    = . d last_avail ( vq_idx_add . d last_avail 1 )
+    // Walk the chain the way a device does, counting its segments.
+    : ~ i idx head
+    : ~ i n 0
+    : ~ b more T
+    ~ && more < n . q qsize {
+        = n + n 1
+        ? == & ( virtq_desc_flags q idx ) ( vq_desc_next ) ( vq_desc_next ) {
+            = idx ( virtq_desc_next q idx )
+        } { = more F }
+    }
+    // Publish into used: slot = used.idx % qsize, then bump used.idx.
+    : i uslot % ( virtq_used_idx q ) . q qsize
+    : i ubase + + ( vq_used_off . q qsize ) 4 * 8 uslot
+    : ~ i k 0
+    ~ < k 4 {
+        : b _a ( vec_set [u] . q mem + ubase k # u & >> head * 8 k 255 )
+        : b _b ( vec_set [u] . q mem + + ubase 4 k # u & >> written * 8 k 255 )
+        = k + k 1
+    }
+    : i nidx ( vq_idx_add ( virtq_used_idx q ) 1 )
+    : b _c ( vec_set [u] . q mem + ( vq_used_off . q qsize ) 2 # u & nidx 255 )
+    : b _d ( vec_set [u] . q mem + ( vq_used_off . q qsize ) 3 # u & >> nidx 8 255 )
+    ^ head
+}
+
+@ main → i {
+    // ── layout arithmetic against the spec ───────────────────────
+    ( pb `qsize 8 valid: ` ( virtq_size_valid 8 ) )
+    ( pb `qsize 0 invalid: ` ! ( virtq_size_valid 0 ) )
+    ( pb `qsize 3 invalid (not a power of two): ` ! ( virtq_size_valid 3 ) )
+    ( pb `qsize 32768 valid (spec max): ` ( virtq_size_valid 32768 ) )
+    ( pb `qsize 65536 invalid (over max): ` ! ( virtq_size_valid 65536 ) )
+    // qsize 8: desc 128, avail at 128 (6+16=22 → used aligned to 4 → 152)
+    ( pb `desc table at 0: ` == ( vq_desc_off ) 0 )
+    ( pb `avail after 16·qsize: ` == ( vq_avail_off 8 ) 128 )
+    ( pb `used is 4-byte aligned: ` == % ( vq_used_off 8 ) 4 0 )
+    ( pb `used after avail: ` >= ( vq_used_off 8 ) + 128 22 )
+    ( pb `total covers the used ring: ` == ( vq_layout_size 8 ) + ( vq_used_off 8 ) 70 )
+
+    // ── free list ────────────────────────────────────────────────
+    : *Virtq q ( virtq_new 8 )
+    ( pb `all 8 descriptors free: ` == ( virtq_num_free q ) 8 )
+    ( pb `ring starts zeroed: ` && == ( virtq_avail_idx q ) 0 == ( virtq_used_idx q ) 0 )
+    : ~ i taken 0
+    : ~ b all_distinct T
+    : ( Vec i ) seen ( vec_new [i] )
+    ~ < taken 8 {
+        ?? ( virtq_alloc_desc q ) {
+            T d → {
+                : ~ i j 0
+                ~ < j ( vec_len [i] seen ) {
+                    ? == ?? ( vec_get [i] seen j ) { T x → x F → -1 } d { = all_distinct F } {}
+                    = j + j 1
+                }
+                ( vec_push [i] seen d )
+            }
+            F → { = all_distinct F }
+        }
+        = taken + taken 1
+    }
+    ( pb `8 allocations all distinct: ` all_distinct )
+    ( pb `queue now empty: ` == ( virtq_num_free q ) 0 )
+    ( pb `9th allocation fails: ` ?? ( virtq_alloc_desc q ) { T d → F F → T } )
+    // Return them all.
+    : ~ i r 0
+    ~ < r 8 {
+        : i _n ( virtq_free_chain q ?? ( vec_get [i] seen r ) { T x → x F → 0 } )
+        = r + r 1
+    }
+    ( pb `all returned to the free list: ` == ( virtq_num_free q ) 8 )
+
+    // ── single-buffer round trip through the mock device ─────────
+    : *MockDev dev ( mock_new )
+    ( pb `device idle initially: ` ! ( mock_has_work dev q ) )
+    : ?i h1 ( virtq_add_single q 4096 1500 T )
+    ( pb `published a buffer: ` ?? h1 { T d → T F → F } )
+    ( pb `avail.idx advanced: ` == ( virtq_avail_idx q ) 1 )
+    ( pb `one descriptor consumed: ` == ( virtq_num_free q ) 7 )
+    ( pb `device sees work: ` ( mock_has_work dev q ) )
+    : i head1 ( mock_service dev q 64 )
+    ( pb `device completed our head: ` == head1 ?? h1 { T d → d F → -1 } )
+    ( pb `used.idx advanced: ` == ( virtq_used_idx q ) 1 )
+    ( pb `driver sees a completion: ` ( virtq_has_used q ) )
+    : ?i got ( virtq_get_used q )
+    ( pb `reaped the same head: ` ?? got { T d → == d head1 F → F } )
+    ( pb `written length reported: ` == ( virtq_last_used_len q ) 64 )
+    ( pb `nothing left to reap: ` ! ( virtq_has_used q ) )
+    : i _f1 ( virtq_free_chain q head1 )
+    ( pb `descriptor returned: ` == ( virtq_num_free q ) 8 )
+
+    // Descriptor contents survived the round trip.
+    ( pb `desc addr preserved: ` == ( virtq_desc_addr q head1 ) 4096 )
+    ( pb `desc len preserved: ` == ( virtq_desc_len q head1 ) 1500 )
+    ( pb `device-writable flag set: ` == & ( virtq_desc_flags q head1 ) ( vq_desc_write ) ( vq_desc_write ) )
+
+    // ── a three-segment chain ───────────────────────────────────
+    // The shape virtio-net rx uses: a header segment plus data.
+    : ?i a0 ( virtq_alloc_desc q )
+    : ?i a1 ( virtq_alloc_desc q )
+    : ?i a2 ( virtq_alloc_desc q )
+    : i d0 ?? a0 { T x → x F → -1 }
+    : i d1 ?? a1 { T x → x F → -1 }
+    : i d2 ?? a2 { T x → x F → -1 }
+    ( virtq_desc_set q d0 8192 12 ( vq_desc_next ) d1 )
+    ( virtq_desc_set q d1 8204 1500 | ( vq_desc_next ) ( vq_desc_write ) d2 )
+    ( virtq_desc_set q d2 16384 4 ( vq_desc_write ) ( vq_null ) )
+    ( virtq_avail_push q d0 )
+    ( pb `three descriptors in use: ` == ( virtq_num_free q ) 5 )
+    : i head2 ( mock_service dev q 1000 )
+    ( pb `device walked to our chain head: ` == head2 d0 )
+    : ?i got2 ( virtq_get_used q )
+    ( pb `reaped the chain: ` ?? got2 { T d → == d d0 F → F } )
+    // THE TRAP: freeing the head alone leaks d1 and d2.
+    : i freed ( virtq_free_chain q d0 )
+    ( pb `free_chain walked all three: ` == freed 3 )
+    ( pb `all descriptors back: ` == ( virtq_num_free q ) 8 )
+
+    // ── 16-bit index arithmetic ─────────────────────────────────
+    ( pb `idx_lt basic: ` ( vq_idx_lt 5 9 ) )
+    ( pb `idx_lt not reflexive: ` ! ( vq_idx_lt 5 5 ) )
+    ( pb `idx wraps: 65530 < 4: ` ( vq_idx_lt 65530 4 ) )
+    ( pb `idx wrap not reversed: ` ! ( vq_idx_lt 4 65530 ) )
+    ( pb `idx_add wraps: ` == ( vq_idx_add 65535 1 ) 0 )
+    ( pb `idx_diff across wrap: ` == ( vq_idx_diff 4 65530 ) 10 )
+
+    // ── the wrap, driven for real ───────────────────────────────
+    // Push 70000 buffers through a queue of 8. avail.idx and used.idx
+    // both wrap past 65536 more than once. Every one must complete, in
+    // order, with the right length — this is the case that separates a
+    // correct index discipline from one that works in a demo.
+    : i avail_before ( virtq_avail_idx q )
+    : ~ i pushed 0
+    : ~ i reaped 0
+    : ~ b order_ok T
+    : ~ b len_ok T
+    ~ < pushed 70000 {
+        ?? ( virtq_add_single q + 65536 * 4 % pushed 8 128 T ) {
+            T d → {
+                : i h ( mock_service dev q + 1 % pushed 100 )
+                ? != h d { = order_ok F } {}
+                ?? ( virtq_get_used q ) {
+                    T g → {
+                        ? != g d { = order_ok F } {}
+                        ? != ( virtq_last_used_len q ) + 1 % pushed 100 { = len_ok F } {}
+                        : i _fc ( virtq_free_chain q g )
+                        = reaped + reaped 1
+                    }
+                    F → { = order_ok F }
+                }
+            }
+            F → { = order_ok F }
+        }
+        = pushed + pushed 1
+    }
+    ( pb `70000 buffers all completed: ` == reaped 70000 )
+    ( pb `every completion matched its head: ` order_ok )
+    ( pb `every written length round-tripped: ` len_ok )
+    // 70000 pushes past a counter that wraps at 65536: the index must
+    // land on (start + 70000) mod 65536, and must NOT be 70000 — the
+    // latter is what a driver that never wraps would show.
+    ( pb `avail.idx wrapped correctly: ` == ( virtq_avail_idx q ) % + avail_before 70000 65536 )
+    ( pb `and did wrap (idx < pushes): ` < ( virtq_avail_idx q ) 70000 )
+    ( pb `queue is whole again: ` == ( virtq_num_free q ) 8 )
+
+    // ── hostile device: a completion id outside the table ────────
+    // A broken or malicious device reporting id >= qsize must not be
+    // let through: that id would go onto the free list and corrupt the
+    // descriptor table on the next allocation.
+    : i ubase + + ( vq_used_off . q qsize ) 4 * 8 % ( virtq_used_idx q ) . q qsize
+    : b _h1 ( vec_set [u] . q mem ubase # u 99 )
+    : b _h2 ( vec_set [u] . q mem + ubase 1 # u 0 )
+    : b _h3 ( vec_set [u] . q mem + ubase 2 # u 0 )
+    : b _h4 ( vec_set [u] . q mem + ubase 3 # u 0 )
+    : i bad_idx ( vq_idx_add ( virtq_used_idx q ) 1 )
+    : b _h5 ( vec_set [u] . q mem + ( vq_used_off . q qsize ) 2 # u & bad_idx 255 )
+    : b _h6 ( vec_set [u] . q mem + ( vq_used_off . q qsize ) 3 # u & >> bad_idx 8 255 )
+    ( pb `out-of-range used id refused: ` ?? ( virtq_get_used q ) { T d → F F → T } )
+    ( pb `free list not corrupted: ` == ( virtq_num_free q ) 8 )
+
+    // ── notification suppression ────────────────────────────────
+    ( pb `notify needed by default: ` ( virtq_needs_notify q ) )
+    : b _n1 ( vec_set [u] . q mem ( vq_used_off . q qsize ) # u ( vq_used_no_notify ) )
+    ( pb `device NO_NOTIFY honoured: ` ! ( virtq_needs_notify q ) )
+    ( virtq_set_avail_flags q ( vq_avail_no_interrupt ) )
+    ( pb `avail NO_INTERRUPT set (polling driver): ` == ( virtq_avail_flags q ) ( vq_avail_no_interrupt ) )
+
+    ( mock_free dev )
+    ( virtq_free q )
+    ( vec_free [i] seen )
+    ^ 0
+}

--- a/stdlib/hal/esp32.nu
+++ b/stdlib/hal/esp32.nu
@@ -20,9 +20,12 @@
 //   ( esp32_uart_getc       ) → i blocking: wait for a byte, return 0..255
 //   ( esp32_uart_puts  s str ) → v write a NUL-terminated string
 //
-// NOTE: esp32_uart_putc/getc spin on an MMIO status read. NURL has no
-// `volatile`, so compile any program that calls them at -O0/-O1 or the spin
-// loop may be hoisted away (LICM). See examples/esp32/idf-uart.
+// NOTE: esp32_uart_putc/getc spin on an MMIO status read. That is safe at
+// any optimization level — stdlib/hal/mmio.nu emits `load volatile` /
+// `store volatile`, which LICM will not hoist out of the spin loop. (This
+// note used to say NURL had no `volatile` and to build at -O0/-O1; the
+// volatile intrinsics have since landed and that restriction is gone.)
+// See examples/esp32/idf-uart.
 
 $ `stdlib/hal/mmio.nu`
 

--- a/stdlib/hal/virtq.nu
+++ b/stdlib/hal/virtq.nu
@@ -1,0 +1,326 @@
+// stdlib/hal/virtq.nu — virtio split-ring virtqueue, as pure logic.
+//
+// PURE. The ring is a byte region the caller owns; this module only
+// reads and writes it. No MMIO, no allocation of device memory, no
+// notification — those are the driver's job (see `stdlib/hal/mmio.nu`
+// for the register side). That split is what lets the ring be driven
+// against an in-memory mock device in a unit test on the host, and
+// against a real device on a freestanding target, with the same code.
+//
+// It lives in hal/ rather than net/ because a virtqueue is not a
+// networking concept: the same ring carries console, block and RNG
+// traffic. net/ gets the virtio-net *device* logic later; this is the
+// transport underneath it.
+//
+// ── LAYOUT (virtio 1.1 §2.6, VERSION_1 / "modern") ──────────────
+//
+//   descriptor table   16 · qsize bytes   (le64 addr, le32 len,
+//                                          le16 flags, le16 next)
+//   available ring      6 + 2 · qsize     (le16 flags, le16 idx,
+//                                          le16 ring[qsize], le16 used_event)
+//   used ring           6 + 8 · qsize     (le16 flags, le16 idx,
+//                                          {le32 id, le32 len}[qsize],
+//                                          le16 avail_event)
+//
+// Everything is LITTLE-ENDIAN regardless of host byte order — that is
+// what VERSION_1 buys, and it is why this module uses the `_le`
+// accessors throughout. A legacy (pre-1.0) device would use guest
+// order instead; we do not negotiate legacy, so guest order never
+// enters the picture.
+//
+// The three regions are laid out contiguously here with the alignment
+// the spec requires (desc 16, avail 2, used 4). A driver that allocates
+// them separately can pass the offsets in instead.
+//
+// ── WRAPPING IS THE TRAP ────────────────────────────────────────
+//
+// `avail.idx` and `used.idx` are free-running 16-bit counters: they
+// wrap at 65536 and are NOT reduced modulo the queue size. Only the
+// ring *slot* is `idx % qsize`. Code that stores the reduced value into
+// idx works perfectly until the 65536th buffer and then desynchronises
+// from the device forever. Every comparison here is therefore done on
+// the 16-bit difference, never on raw magnitudes — the same discipline
+// as TCP sequence numbers in net/tcpseg.nu.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+
+// ── descriptor flags (virtio 1.1 §2.6.5) ────────────────────────
+
+@ vq_desc_next → i { ^ 1 }  // buffer continues in `next`
+
+@ vq_desc_write → i { ^ 2 }  // device writes it (else driver writes)
+
+@ vq_desc_indirect → i { ^ 4 }  // buffer is an indirect descriptor table
+
+// avail.flags: ask the device not to interrupt us. With a polling
+// driver (the unikernel plan's v1 execution model) this is set once at
+// setup and never cleared.
+@ vq_avail_no_interrupt → i { ^ 1 }
+
+// used.flags: the device telling us not to notify it.
+@ vq_used_no_notify → i { ^ 1 }
+
+@ vq_desc_size → i { ^ 16 }
+
+// A free-list terminator that cannot be a valid descriptor index,
+// since qsize is capped at 32768 by the spec.
+@ vq_null → i { ^ 65535 }
+
+// ── layout arithmetic ───────────────────────────────────────────
+
+@ __align_up i n i a → i { ^ * / + n - a 1 a a }
+
+@ vq_desc_off → i { ^ 0 }
+
+@ vq_avail_off i qsize → i { ^ ( __align_up * 16 qsize 2 ) }
+
+@ vq_used_off i qsize → i {
+    ^ ( __align_up + ( vq_avail_off qsize ) + 6 * 2 qsize 4 )
+}
+
+@ vq_layout_size i qsize → i {
+    ^ + ( vq_used_off qsize ) + 6 * 8 qsize
+}
+
+// ── the queue ───────────────────────────────────────────────────
+
+: Virtq {
+    i qsize
+    ( Vec u ) mem  // the whole ring region
+    i free_head  // head of the driver-side free descriptor list
+    i num_free
+    i last_used  // free-running: the used.idx we have consumed up to
+    i avail_shadow  // our own copy of avail.idx (the device may not be trusted)
+}
+
+// `qsize` must be a power of two, 1..32768 (spec §2.6). Returns a
+// queue whose descriptors are all on the free list.
+@ virtq_new i qsize → *Virtq {
+    : *Virtq q # *Virtq ( nurl_alloc Z Virtq )
+    = . q qsize qsize
+    = . q mem ( vec_with_cap [u] ( vq_layout_size qsize ) )
+    : ~ i k 0
+    ~ < k ( vq_layout_size qsize ) { ( vec_push [u] . q mem # u 0 ) = k + k 1 }
+    = . q free_head 0
+    = . q num_free qsize
+    = . q last_used 0
+    = . q avail_shadow 0
+    // Chain every descriptor onto the free list via its `next` field.
+    : ~ i d 0
+    ~ < d qsize {
+        ( __vq_set_next q d ? == d - qsize 1 ( vq_null ) + d 1 )
+        = d + d 1
+    }
+    ^ q
+}
+
+@ virtq_free * Virtq q → v {
+    ( vec_free [u] . q mem )
+    ( free q )
+}
+
+// Is `n` a power of two in the range the spec allows?
+@ virtq_size_valid i n → b {
+    ? || < n 1 > n 32768 { ^ F } {}
+    ^ == & n - n 1 0
+}
+
+// ── raw field accessors ─────────────────────────────────────────
+
+@ __vq_w16 * Virtq q i off i val → v {
+    : b _a ( vec_set [u] . q mem off # u & val 255 )
+    : b _b ( vec_set [u] . q mem + off 1 # u & >> val 8 255 )
+}
+
+@ __vq_r16 * Virtq q i off → i {
+    ^ ?? ( bytes_read_u16_le . q mem off ) { T x → # i x F → 0 }
+}
+
+@ __vq_w32 * Virtq q i off i val → v {
+    : ~ i k 0
+    ~ < k 4 {
+        : b _s ( vec_set [u] . q mem + off k # u & >> val * 8 k 255 )
+        = k + k 1
+    }
+}
+
+@ __vq_r32 * Virtq q i off → i {
+    ^ ?? ( bytes_read_u32_le . q mem off ) { T x → # i x F → 0 }
+}
+
+@ __vq_w64 * Virtq q i off i val → v {
+    : ~ i k 0
+    ~ < k 8 {
+        : b _s ( vec_set [u] . q mem + off k # u & >> val * 8 k 255 )
+        = k + k 1
+    }
+}
+
+@ __vq_r64 * Virtq q i off → i {
+    ^ ?? ( bytes_read_u64_le . q mem off ) { T x → # i x F → 0 }
+}
+
+@ __vq_desc_base i idx → i { ^ * 16 idx }
+
+@ __vq_set_next * Virtq q i idx i next → v {
+    ( __vq_w16 q + ( __vq_desc_base idx ) 14 next )
+}
+
+@ virtq_desc_addr * Virtq q i idx → i { ^ ( __vq_r64 q ( __vq_desc_base idx ) ) }
+
+@ virtq_desc_len * Virtq q i idx → i { ^ ( __vq_r32 q + ( __vq_desc_base idx ) 8 ) }
+
+@ virtq_desc_flags * Virtq q i idx → i { ^ ( __vq_r16 q + ( __vq_desc_base idx ) 12 ) }
+
+@ virtq_desc_next * Virtq q i idx → i { ^ ( __vq_r16 q + ( __vq_desc_base idx ) 14 ) }
+
+@ virtq_avail_flags * Virtq q → i { ^ ( __vq_r16 q ( vq_avail_off . q qsize ) ) }
+
+@ virtq_set_avail_flags * Virtq q i flags → v {
+    ( __vq_w16 q ( vq_avail_off . q qsize ) flags )
+}
+
+@ virtq_avail_idx * Virtq q → i { ^ ( __vq_r16 q + ( vq_avail_off . q qsize ) 2 ) }
+
+@ virtq_avail_ring * Virtq q i slot → i {
+    ^ ( __vq_r16 q + + ( vq_avail_off . q qsize ) 4 * 2 slot )
+}
+
+@ virtq_used_flags * Virtq q → i { ^ ( __vq_r16 q ( vq_used_off . q qsize ) ) }
+
+@ virtq_used_idx * Virtq q → i { ^ ( __vq_r16 q + ( vq_used_off . q qsize ) 2 ) }
+
+@ virtq_used_id * Virtq q i slot → i {
+    ^ ( __vq_r32 q + + ( vq_used_off . q qsize ) 4 * 8 slot )
+}
+
+@ virtq_used_len * Virtq q i slot → i {
+    ^ ( __vq_r32 q + + + ( vq_used_off . q qsize ) 4 * 8 slot 4 )
+}
+
+// ── 16-bit index arithmetic ─────────────────────────────────────
+//
+// idx counters wrap at 65536 and are never reduced by qsize. Compare
+// via the signed 16-bit difference, exactly as TCP compares sequence
+// numbers — a raw `<` breaks once per 65536 buffers.
+
+@ vq_idx_diff i a i b → i {
+    : i d & - a b 65535
+    ^ ? >= d 32768 - d 65536 d
+}
+
+@ vq_idx_lt i a i b → b { ^ < ( vq_idx_diff a b ) 0 }
+
+@ vq_idx_add i a i n → i { ^ & + a n 65535 }
+
+// ── descriptor allocation ───────────────────────────────────────
+
+// Take one descriptor off the free list.
+@ virtq_alloc_desc * Virtq q → ?i {
+    ? <= . q num_free 0 { ^ @ ?i { F 0 } } {}
+    : i head . q free_head
+    ? == head ( vq_null ) { ^ @ ?i { F 0 } } {}
+    = . q free_head ( virtq_desc_next q head )
+    = . q num_free - . q num_free 1
+    ^ @ ?i { T head }
+}
+
+// Return a whole chain to the free list, following NEXT links. The
+// chain — not just its head — is what the device hands back, so
+// freeing only the head leaks every continuation descriptor and the
+// queue silently runs dry after a few thousand packets.
+@ virtq_free_chain * Virtq q i head → i {
+    : ~ i idx head
+    : ~ i n 0
+    : ~ b more T
+    ~ && more < n . q qsize {
+        : i nxt ( virtq_desc_next q idx )
+        : i flags ( virtq_desc_flags q idx )
+        ( __vq_set_next q idx . q free_head )
+        = . q free_head idx
+        = . q num_free + . q num_free 1
+        = n + n 1
+        ? == & flags ( vq_desc_next ) ( vq_desc_next ) { = idx nxt } { = more F }
+    }
+    ^ n
+}
+
+@ virtq_num_free * Virtq q → i { ^ . q num_free }
+
+// ── publishing buffers ──────────────────────────────────────────
+
+// Describe one buffer segment into descriptor `idx`. `addr` is the
+// address the DEVICE will use, i.e. a physical address — translation
+// is the driver's job (identity-mapped in the unikernel's v1).
+@ virtq_desc_set * Virtq q i idx i addr i len i flags i next → v {
+    ( __vq_w64 q ( __vq_desc_base idx ) addr )
+    ( __vq_w32 q + ( __vq_desc_base idx ) 8 len )
+    ( __vq_w16 q + ( __vq_desc_base idx ) 12 flags )
+    ( __vq_w16 q + ( __vq_desc_base idx ) 14 next )
+}
+
+// Publish a chain head into the available ring and advance avail.idx.
+//
+// ORDER MATTERS: the ring slot must be written BEFORE idx is bumped,
+// or the device may read a slot we have not filled in. On a real target
+// a write barrier belongs between the two; here the sequence is at
+// least correct in program order, and the driver adds the fence.
+@ virtq_avail_push * Virtq q i head → v {
+    : i slot % . q avail_shadow . q qsize
+    ( __vq_w16 q + + ( vq_avail_off . q qsize ) 4 * 2 slot head )
+    = . q avail_shadow ( vq_idx_add . q avail_shadow 1 )
+    ( __vq_w16 q + ( vq_avail_off . q qsize ) 2 . q avail_shadow )
+}
+
+// Convenience: allocate, describe and publish a single-segment buffer.
+// Returns the descriptor index, or None when the queue is full.
+@ virtq_add_single * Virtq q i addr i len b device_writes → ?i {
+    ^ ?? ( virtq_alloc_desc q ) {
+        T d → {
+            ( virtq_desc_set q d addr len ? device_writes ( vq_desc_write ) 0 ( vq_null ) )
+            ( virtq_avail_push q d )
+            @ ?i { T d }
+        }
+        F → @ ?i { F 0 }
+    }
+}
+
+// ── reaping completions ─────────────────────────────────────────
+
+// Has the device completed anything we have not consumed?
+@ virtq_has_used * Virtq q → b {
+    ^ ( vq_idx_lt . q last_used ( virtq_used_idx q ) )
+}
+
+// Consume one completion. Returns the chain head; the caller reads the
+// written length with `virtq_last_used_len` before the next call.
+// Does NOT free the chain — the caller may still need the buffer, and
+// freeing is a separate, explicit step.
+@ virtq_get_used * Virtq q → ?i {
+    ? ! ( virtq_has_used q ) { ^ @ ?i { F 0 } } {}
+    : i slot % . q last_used . q qsize
+    : i id ( virtq_used_id q slot )
+    // A device that reports an out-of-range id is broken or hostile;
+    // refusing it keeps a bad id out of the free list, where it would
+    // corrupt the descriptor table on the next allocation.
+    ? >= id . q qsize { ^ @ ?i { F 0 } } {}
+    = . q last_used ( vq_idx_add . q last_used 1 )
+    ^ @ ?i { T id }
+}
+
+// Bytes the device wrote for the completion most recently returned by
+// `virtq_get_used`.
+@ virtq_last_used_len * Virtq q → i {
+    : i slot % ( vq_idx_add . q last_used 65535 ) . q qsize
+    ^ ( virtq_used_len q slot )
+}
+
+// Should the driver kick the device after publishing? The device sets
+// NO_NOTIFY when it is already polling; honouring it is a pure
+// throughput win, and getting it wrong the other way (never notifying)
+// stalls the queue.
+@ virtq_needs_notify * Virtq q → b {
+    ^ != & ( virtq_used_flags q ) ( vq_used_no_notify ) ( vq_used_no_notify )
+}


### PR DESCRIPTION
Phase A2 of the unikernel plan, plus a compiler fix that writing it surfaced.

## `stdlib/hal/virtq.nu` — the virtio split ring as pure logic

Descriptor / available / used bookkeeping (virtio 1.1 §2.6) over a byte
region the caller owns. No MMIO, no device-memory allocation, no
notification — those are the driver's job (`stdlib/hal/mmio.nu` covers
the register side). That split is what lets the ring be driven against
an in-memory mock device on the host and against a real device on a
freestanding target with the same code.

It lives in `hal/` rather than `net/` because a virtqueue is not a
networking concept — the same ring carries console, block and RNG
traffic. virtio-net itself lands later, on top.

**The two failure modes it is built around**, both of which work fine
for thousands of buffers before breaking:

- `avail.idx` / `used.idx` are free-running 16-bit counters. They wrap
  at 65536 and are **not** reduced by the queue size — only the ring
  *slot* is. Storing the reduced value desynchronises from the device
  exactly once per 65536 buffers. Every comparison goes through the
  signed 16-bit difference, the same discipline `net/tcpseg.nu` uses for
  TCP sequence numbers.
- Freeing only a chain's head leaks every continuation descriptor, so
  the queue silently runs dry after a few thousand packets.
  `virtq_free_chain` walks the NEXT links.

A device-reported completion id outside the descriptor table is refused
rather than pushed onto the free list, where it would corrupt the
descriptor table on the next allocation.

`virtq_split` drives all of it against a mock device that plays the host
side: **53 assertions**, including a 70 000-buffer run that carries both
counters past the wrap, plus the hostile-id and notification-suppression
paths. **Mutation-validated 8/8** — naive index compare, idx reduced by
qsize, head-only free, missing id bound, slot-after-idx ordering,
avail/used offset mixup, power-of-two check, free-list accounting.

## The borrow-checker bug this surfaced

`virtq_num_free` — "how many descriptors are free?" — was rejected: the
second call reported its receiver as a use-after-move.

The move rule keys on a `_free` callee **suffix alone**, so any function
whose name ends in `_free` is read as a destructor consuming its first
argument. `virtq_num_free`, `pool_num_free`, `arena_bytes_free` are
queries, and there is no workaround except renaming a correctly-named
function.

The compiler had already hit this and worked around it in its own
source: `bck_is_destructor_name` carries a comment warning that the
predicate must not itself be named with a `_free` suffix or it would
flag its own argument.

**The fix.** A real destructor releases the value and has nothing left
to report. Audited: every `_free` in the stdlib returns `v` —
`vec_free`, `string_free`, `x509_free`, and the rest. A `_free`-suffixed
function that *returns a value* is a query about free space, not a
destructor. The rule is now name **and** `void` return, via
`bck_is_destructor_call`. When the callee's signature is not visible (a
forward reference) it falls back to the name rule, so the change can
only ever be more permissive, never less safe.

`free_suffix_query` pins both halves: the query compiles, and a real
destructor still consumes. Verified it is not vacuous by rebuilding the
compiler with the fix reverted — the test is rejected without it.

## Also

`stdlib/hal/esp32.nu` carried a stale warning that NURL has no
`volatile` and that callers must build at `-O0`/`-O1` or LICM hoists the
UART spin loop. The volatile intrinsics have since landed and `mmio.nu`
uses them; verified by inspecting `-O2` IR, where the load is `load
volatile` and stays inside the loop. The note told users to cripple
their optimization level for no reason.

## Verification

- `./compiler/tests/run_tests.sh` → **PASS 587 · FAIL 0**
- Both new tests LSan- and UBSan-clean; added to the CI leak gate
- All local gates pass: symbols, examples, builtins doc, installer sync,
  windows goldens, golden twins, package imports, nurlfmt, dce, memgate
- Compiler rebuilt through the stage1 ≡ stage2 bootstrap fixed point

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGCHMU9n56VxM6eJs1wtdJ
