### PR TITLE
fix: nurlc leaked the value of every `select` it compiled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,13 @@ jobs:
         # consumer must, so the gate catches either way that can break:
         # the compiler freeing it too (a double free, not a leak) or the
         # program losing the ability to free it at all.
+        # select_basic is here for what it makes the COMPILER do: it is
+        # the only test in the corpus that compiles a `select`, so it is
+        # the only input under which gen_select runs at all. The
+        # self-compile gate cannot cover that path — nurlc.nu contains no
+        # select — and a leak lived there unseen because of it. This step
+        # leak-checks nurlc's own compile as well as the program's run,
+        # so pinning the one test that reaches that code closes the hole.
         run: |
           LSAN_DETECT_LEAKS=1 ./compiler/tests/run_san_tests.sh \
             struct_nested_field_drop arm_local_drop arm_local_trailing_drop \
@@ -332,7 +339,8 @@ jobs:
             defer_drop_reclaim defer_scoped defer_ret_transfer \
             net_inet net_frames net_dhcp net_stack net_tcp net_tcp_fuzz \
             virtq_split free_suffix_query closure_env_escape_loop \
-            ctx_switch async_basic async_chan async_mn async_sleep
+            ctx_switch async_basic async_chan async_mn async_sleep \
+            select_basic
 
   webdocs-build:
     name: web docs build (fumadocs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **nurlc leaked while compiling a `select`.** `gen_select` builds the
+  construct's real body as source and compiles it through a sub-lexer;
+  `gen_stmt` returns that statement's IR value, which for a block is an
+  owned string, and the call was left unbound — 6 bytes per `select`
+  compiled. The self-compile leak gate could not see it: `nurlc.nu`
+  contains no `select`, so `gen_select` never runs on its own input.
+  `select_basic` — the only test in the corpus that compiles one — is
+  now pinned in the CI leak gate, which leak-checks nurlc's compile as
+  well as the program's run. (Its own producer closure, escaped through
+  `thread_spawn`, is freed the way §7.4 says a consumer must.)
 - **SIGINT could not stop a server's accept loop on FreeBSD or macOS.**
   The listener-shutdown bridge woke the accepting thread by calling
   `shutdown(2)` on the *listening* socket — a Linux extension. Linux

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -7539,8 +7539,19 @@
     = src ( nurl_str_cat src `}\n` )
 
     // ── Compile the synthesised block through a sub-lexer ──
+    // gen_stmt returns the statement's IR value, and for a block that is
+    // an owned string. Called for its effects and left unbound, that
+    // buffer had no owner: 6 bytes per `select` compiled — 30 in
+    // select_basic, which is the only test in the corpus that compiles a
+    // select, and therefore the only place the self-compile leak gate
+    // could never see it (nurlc.nu contains no select). Bind it and let
+    // the scope-exit drop take it. Do NOT free it by hand: reassignment
+    // and scope exit already drop a tracked owned string, so a manual
+    // free is a double free, and the runtime's small-block freelist
+    // hides the second one from ASan until the compiler hangs on some
+    // later input.
     : i sub ( nurl_lex_new src `<select>` )
-    ( gen_stmt sub syms cg )
+    : s __sub_rv ( gen_stmt sub syms cg )
     ( nurl_lex_free sub )
     ( nurl_set_last_type `void` )
     ^ ( nurl_str_cat `` `` )

--- a/compiler/tests/select_basic.nu
+++ b/compiler/tests/select_basic.nu
@@ -32,6 +32,11 @@ $ `stdlib/core/string.nu`
         }
         F e → { ( nurl_print `spawn fail\n` ) }
     }
+    // The producer has joined, so its heap-captured env is dead — release
+    // it. `thread_spawn` borrows the env and never frees it (§7.4: an
+    // escaped closure's env belongs to the consumer).
+    : *u prod_env # *u prod 1
+    ( nurl_free # s prod_env )
     ( chan_close [i] ints ) ( chan_close [String] strs )
     ( chan_free [i] ints ) ( chan_free [String] strs )
 }


### PR DESCRIPTION
`gen_select` builds the construct's real body as source and compiles it through a sub-lexer. `gen_stmt` returns that statement's IR value — for a block, an owned string — and the call was left unbound, so the buffer had no owner: **6 bytes per `select` compiled**, 30 in `select_basic`.

```nurl
: i sub ( nurl_lex_new src `<select>` )
( gen_stmt sub syms cg )        // ← owned return value, discarded
```

## Why nothing caught it

The self-compile leak gate holds nurlc to zero leaks compiling its own source, and it could never have caught this: `nurlc.nu` contains no `select`, so `gen_select` does not run on that input. The only test in the corpus that reaches the code is `select_basic` — and until this week that test never ran at all, which is how the leak surfaced in the first place.

So the fix comes with the gate. `select_basic` is now pinned in the leak-gate step, which leak-checks nurlc's compile as well as the program's run, putting the one input that exercises `gen_select` under LSan on every commit.

## Bound, not freed

The value is bound to a local and left to the scope-exit drop. Freeing it by hand is a **double free**: reassignment and scope exit already drop a tracked owned string. That is not theoretical — it is how the first attempt at this fix presented, and it presented badly: the runtime recycles small blocks through a freelist, so the second free neither traps nor registers with ASan, and the symptom was the rebuilt compiler *hanging* on the next input, with a leak count that had not moved.

Diagnosing it took a `-g` + ASan nurlc so the leak stack carried `nurlc.nu` line numbers, plus `fast_unwind_on_malloc=0` for the full chain of custody. The first candidate — an accumulator loop in `gen_select` that looks exactly like the documented string-reassign leak — was wrong for the same reason.

`select_basic` also frees its producer closure's env, escaped through `thread_spawn`, the way §7.4 says a consumer must.

## Verification

- `run_tests.sh`: 604 PASS / 0 FAIL
- `run_san_tests.sh`: 604 PASS / 0 SAN_FAIL / 0 TIMEOUT
- leak gate, now 28 tests: clean under LSan
- `tools/leakgate.sh`: still zero leaks in both emission modes
- bootstrap fixed point holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1