### PR TITLE
nolibc: cover what NURL programs call, not just what the runtime does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `%f`/`%e`/`%g`, `setjmp`/`longjmp`, and the thread-pointer setup
   `__thread` needs. **339 corpus tests build and run with `-nostdlib`
   and glibc nowhere in the link line**, matching their ordinary
-  goldens; 139 more still call into `runtime_ffi` (sockets, threads,
-  processes) and `unikernel/run_nolibc_tests.sh` prints the missing
-  symbols for each, so the remaining work is measured rather than
-  guessed. A hello-world built this way is a 75 KB static binary that
+  goldens (393 once the libc surface NURL *programs* call — `atoll`,
+  `strstr`, `strchr`, the mechanical syscall wrappers, real `readdir`
+  and `stat` — was added on top of the 49 the runtime itself needs);
+  85 more still call into `runtime_ffi` (sockets, threads, entropy) and
+  `unikernel/run_nolibc_tests.sh` prints the missing symbols for each,
+  so the remaining work is measured rather than guessed. A hello-world built this way is a 75 KB static binary that
   makes four syscalls in its whole life.
 
   Gated by three differentials, not by "it didn't crash":

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -39,15 +39,22 @@ from a baked-in image) and the second (the boot shim enters at
 with a different bottom edge, which is what makes testing it on Linux
 worth anything.
 
-## State (2026-08-04)
+## State (2026-08-05)
 
 ```
-  PASS       339      corpus tests that build and run with no libc at all
-  NEEDS-FFI  139      call into runtime_ffi — sockets, threads, processes.
+  PASS       393      corpus tests that build and run with no libc at all
+  NEEDS-FFI   85      call into runtime_ffi — sockets, threads, entropy.
                       That list is the remaining A3 work, measured.
   SKIP       143      compile-fail tests and tests with no standalone build
   FAIL         0
 ```
+
+What blocks the remaining 85, by how many tests each name blocks:
+`nurl_rand_fill` 35, the pthread mutex quartet 28, and the
+`nurl_tcp_*` / `nurl_reactor_*` / `nurl_fiber_*` family 20-28 each.
+All of it is `runtime_bare.c` — the cooperative sync shims and the
+socket seam — which is the next A3 item and, by A4, the place the
+sans-IO stack plugs in.
 
 `build/nolibc/results.txt` carries the per-test verdict, and every
 `NEEDS-FFI` line names the symbols that were missing, so the next piece

--- a/unikernel/nolibc/misc.c
+++ b/unikernel/nolibc/misc.c
@@ -20,6 +20,9 @@
 
 extern nl_ssize_t nl_write(int fd, const void *buf, nl_size_t n);
 extern void nl_exit_group(int code);
+extern int  nl_open(const char *path, int flags, int mode);
+extern int  nl_close(int fd);
+extern long nl_ret(long r);
 
 char **nl_environ;
 
@@ -87,11 +90,83 @@ int isatty(int fd) { (void)fd; return 0; }
 int tcgetattr(int fd, void *t) { (void)fd; (void)t; return -1; }
 int tcsetattr(int fd, int act, const void *t) { (void)fd; (void)act; (void)t; return -1; }
 
-/* ── directories and stat ───────────────────────────────────────── */
-void *opendir(const char *path) { (void)path; return 0; }
-void *readdir(void *d) { (void)d; return 0; }
-int   closedir(void *d) { (void)d; return -1; }
-int   lstat(const char *path, void *st) { (void)path; (void)st; return -1; }
+/* ── directories and stat ───────────────────────────────────────
+ * Real, over getdents64 and the stat syscalls, because the stubs that
+ * "refused honestly" turned out to refuse a test the corpus expects to
+ * work: fs_dir_list linked as soon as open/read existed and then
+ * reported "not found" for a directory that was right there. A stub is
+ * the right answer when the capability does not exist on the target;
+ * on Linux it does, and the freestanding version of this file is where
+ * the baked-in image reader will go (plan B7).
+ *
+ * The kernel's linux_dirent64 IS glibc's `struct dirent` field for
+ * field — d_ino, d_off, d_reclen, d_type, d_name — which is how glibc
+ * gets away with handing the raw buffer back, and why readdir can
+ * return a pointer into it here. Same for `struct stat`: on x86_64 the
+ * kernel's layout is the one the headers declare. runtime_core.o was
+ * compiled against those headers, so anything else would be silent
+ * corruption rather than a compile error. */
+#define NL_SYS_getdents64 217
+#define NL_SYS_stat        4
+#define NL_SYS_fstat       5
+#define NL_SYS_lstat       6
+#define NL_O_RDONLY_DIR   (0 | 0200000)   /* O_RDONLY | O_DIRECTORY */
+
+struct nl_dir {
+    int fd;
+    int pos;
+    int len;
+    char buf[8192];
+};
+
+void *opendir(const char *path) {
+    struct nl_dir *d;
+    int fd = nl_open(path, NL_O_RDONLY_DIR, 0);
+    if (fd < 0) return 0;
+    d = (struct nl_dir *)malloc(sizeof(struct nl_dir));
+    if (!d) { nl_close(fd); return 0; }
+    d->fd = fd; d->pos = 0; d->len = 0;
+    return d;
+}
+
+void *readdir(void *dp) {
+    struct nl_dir *d = (struct nl_dir *)dp;
+    if (!d) return 0;
+    if (d->pos >= d->len) {
+        long r = nl_syscall6(NL_SYS_getdents64, d->fd, (long)d->buf,
+                             (long)sizeof d->buf, 0, 0, 0);
+        if (r <= 0) return 0;                  /* end of directory, or error */
+        d->len = (int)r;
+        d->pos = 0;
+    }
+    {
+        char *ent = d->buf + d->pos;
+        unsigned short reclen;
+        memcpy(&reclen, ent + 16, sizeof reclen);   /* d_reclen */
+        if (reclen == 0) return 0;                  /* malformed: stop, do not spin */
+        d->pos += reclen;
+        return ent;
+    }
+}
+
+int closedir(void *dp) {
+    struct nl_dir *d = (struct nl_dir *)dp;
+    int r;
+    if (!d) return -1;
+    r = nl_close(d->fd);
+    free(d);
+    return r;
+}
+
+int lstat(const char *path, void *st) {
+    return (int)nl_ret(nl_syscall6(NL_SYS_lstat, (long)path, (long)st, 0, 0, 0, 0));
+}
+int stat(const char *path, void *st) {
+    return (int)nl_ret(nl_syscall6(NL_SYS_stat, (long)path, (long)st, 0, 0, 0, 0));
+}
+int fstat(int fd, void *st) {
+    return (int)nl_ret(nl_syscall6(NL_SYS_fstat, fd, (long)st, 0, 0, 0, 0));
+}
 
 /* ── backtrace ──────────────────────────────────────────────────── */
 /* glibc's backtrace walks .eh_frame; a -nostdlib link has no unwinder,
@@ -100,4 +175,76 @@ int   lstat(const char *path, void *st) { (void)path; (void)st; return -1; }
 int backtrace(void **buf, int size) { (void)buf; (void)size; return 0; }
 void backtrace_symbols_fd(void *const *buf, int size, int fd) {
     (void)buf; (void)size; (void)fd;
+}
+
+/* ── environment ────────────────────────────────────────────────
+ * setenv/unsetenv rewrite the vector `_start` captured. The strings
+ * are heap copies and the vector is reallocated, so the kernel's
+ * original block is never written to — that block is above the stack
+ * and shared with argv, and growing it in place is how a nolibc
+ * corrupts its own arguments. */
+static char **nl_env_owned;      /* our copy, once we have made one */
+static int nl_env_n, nl_env_cap;
+
+static int nl_env_adopt(void) {
+    int n = 0, i;
+    char **e;
+    if (nl_env_owned) return 1;
+    for (e = nl_environ; e && *e; e++) n++;
+    nl_env_cap = n + 8;
+    nl_env_owned = (char **)malloc((nl_size_t)(nl_env_cap + 1) * sizeof(char *));
+    if (!nl_env_owned) return 0;
+    for (i = 0; i < n; i++) nl_env_owned[i] = nl_environ[i];
+    nl_env_owned[n] = 0;
+    nl_env_n = n;
+    nl_environ = nl_env_owned;
+    return 1;
+}
+
+static int nl_env_find(const char *name, nl_size_t len) {
+    int i;
+    for (i = 0; i < nl_env_n; i++) {
+        nl_size_t j;
+        for (j = 0; j < len; j++) if (nl_env_owned[i][j] != name[j]) break;
+        if (j == len && nl_env_owned[i][len] == '=') return i;
+    }
+    return -1;
+}
+
+int setenv(const char *name, const char *value, int overwrite) {
+    nl_size_t nlen = strlen(name), vlen = strlen(value);
+    char *entry;
+    int at;
+    if (!nl_env_adopt()) return -1;
+    at = nl_env_find(name, nlen);
+    if (at >= 0 && !overwrite) return 0;
+    entry = (char *)malloc(nlen + vlen + 2);
+    if (!entry) return -1;
+    memcpy(entry, name, nlen);
+    entry[nlen] = '=';
+    memcpy(entry + nlen + 1, value, vlen);
+    entry[nlen + vlen + 1] = 0;
+    if (at >= 0) { nl_env_owned[at] = entry; return 0; }
+    if (nl_env_n + 1 >= nl_env_cap) {
+        int newcap = nl_env_cap * 2 + 8;
+        char **grown = (char **)realloc(nl_env_owned,
+                                        (nl_size_t)(newcap + 1) * sizeof(char *));
+        if (!grown) return -1;
+        nl_env_owned = grown;
+        nl_env_cap = newcap;
+        nl_environ = nl_env_owned;
+    }
+    nl_env_owned[nl_env_n++] = entry;
+    nl_env_owned[nl_env_n] = 0;
+    return 0;
+}
+
+int unsetenv(const char *name) {
+    int at;
+    if (!nl_env_adopt()) return -1;
+    at = nl_env_find(name, strlen(name));
+    if (at < 0) return 0;
+    for (; at < nl_env_n - 1; at++) nl_env_owned[at] = nl_env_owned[at + 1];
+    nl_env_owned[--nl_env_n] = 0;
+    return 0;
 }

--- a/unikernel/nolibc/stdio.c
+++ b/unikernel/nolibc/stdio.c
@@ -65,8 +65,19 @@ int fflush(FILE *f) {
     return 0;
 }
 
+/* Drop read-ahead before writing: the kernel offset is ahead of the
+ * caller's position by whatever we prefetched, and writing there would
+ * land the bytes in the wrong place. */
+static void nl_drop_readahead(FILE *f) {
+    if (f->buflen > f->bufpos)
+        nl_lseek(f->fd, -(nl_off_t)(f->buflen - f->bufpos), 1 /* SEEK_CUR */);
+    f->bufpos = f->buflen = 0;
+    f->ungot = -1;
+}
+
 static int nl_putb(FILE *f, unsigned char c) {
     if (!(f->flags & NL_F_WRITE)) { f->flags |= NL_F_ERR; return -1; }
+    if (f->buflen) nl_drop_readahead(f);
     f->buf[f->bufpos++] = c;
     if (f->bufpos == NL_BUFSZ || (f->flags & NL_F_UNBUF) ||
         ((f->flags & NL_F_LINEBUF) && c == '\n'))
@@ -277,6 +288,11 @@ int fileno(FILE *f) { return f ? f->fd : -1; }
 int fgetc(FILE *f) {
     if (f->ungot >= 0) { int c = f->ungot; f->ungot = -1; return c; }
     if (!(f->flags & NL_F_READ)) return -1;
+    /* An update stream shares one buffer between the directions, so a
+     * pending write has to reach the file before a read can see past
+     * it. buflen == 0 with bufpos > 0 is what "write-buffered" looks
+     * like here. */
+    if (f->buflen == 0 && f->bufpos > 0) fflush(f);
     if (f->bufpos >= f->buflen) {
         nl_ssize_t r = nl_read(f->fd, f->buf, NL_BUFSZ);
         if (r <= 0) { f->flags |= (r == 0) ? NL_F_EOF : NL_F_ERR; return -1; }
@@ -328,12 +344,22 @@ nl_size_t fread(void *p, nl_size_t sz, nl_size_t n, FILE *f) {
 #define NL_O_APPEND 02000
 
 FILE *fopen(const char *path, const char *mode) {
-    int flags = NL_O_RDONLY, wr = 0;
+    /* "+" anywhere after the first letter means update, and 'b' may sit
+     * on either side of it ("r+b" and "rb+" are the same stream). A
+     * mode parser that only looks at mode[1] gets "rb+" wrong, which
+     * shows up much later as a read returning nothing. */
+    int flags, sflags, plus = 0, i;
     FILE *f;
     int fd;
-    if (mode[0] == 'w') { flags = NL_O_WRONLY | NL_O_CREAT | NL_O_TRUNC; wr = 1; }
-    else if (mode[0] == 'a') { flags = NL_O_WRONLY | NL_O_CREAT | NL_O_APPEND; wr = 1; }
-    else if (mode[1] == '+' || (mode[1] == 'b' && mode[2] == '+')) flags = NL_O_RDWR;
+    for (i = 1; mode[i]; i++) if (mode[i] == '+') plus = 1;
+    switch (mode[0]) {
+    case 'w': flags = (plus ? NL_O_RDWR : NL_O_WRONLY) | NL_O_CREAT | NL_O_TRUNC;
+              sflags = plus ? (NL_F_READ | NL_F_WRITE) : NL_F_WRITE; break;
+    case 'a': flags = (plus ? NL_O_RDWR : NL_O_WRONLY) | NL_O_CREAT | NL_O_APPEND;
+              sflags = plus ? (NL_F_READ | NL_F_WRITE) : NL_F_WRITE; break;
+    default:  flags = plus ? NL_O_RDWR : NL_O_RDONLY;
+              sflags = plus ? (NL_F_READ | NL_F_WRITE) : NL_F_READ; break;
+    }
     fd = nl_open(path, flags, 0666);
     if (fd < 0) return 0;
     f = (FILE *)malloc(sizeof(FILE));
@@ -341,7 +367,7 @@ FILE *fopen(const char *path, const char *mode) {
     memset(f, 0, sizeof(FILE));
     f->fd = fd;
     f->ungot = -1;
-    f->flags = (wr ? NL_F_WRITE : NL_F_READ) | NL_F_ALLOC;
+    f->flags = sflags | NL_F_ALLOC;
     return f;
 }
 
@@ -356,8 +382,19 @@ int fclose(FILE *f) {
 
 int fseek(FILE *f, long off, int whence) {
     /* Whatever is buffered describes the old position. Drop it, both
-     * directions, or the next read returns bytes from before the seek. */
+     * directions, or the next read returns bytes from before the seek.
+     *
+     * SEEK_CUR needs more than dropping: the kernel's offset is ahead
+     * of the caller's by every byte we read ahead and have not handed
+     * out, so a relative seek must subtract them first. Without that,
+     * "read 11 bytes, then seek +9" lands at 4105 instead of 20 —
+     * which is exactly how fs_write_handle failed the moment the rest
+     * of nolibc was complete enough for it to link. */
     if (f->flags & NL_F_WRITE) fflush(f);
+    if (whence == 1 /* SEEK_CUR */) {
+        off -= (long)(f->buflen - f->bufpos);
+        if (f->ungot >= 0) off -= 1;
+    }
     f->bufpos = f->buflen = 0;
     f->ungot = -1;
     f->flags &= ~NL_F_EOF;
@@ -374,3 +411,9 @@ long ftell(FILE *f) {
     if (f->ungot >= 0) pos -= 1;
     return (long)pos;
 }
+
+/* ── the stdio names a program reaches that the runtime does not ── */
+int putchar(int c) { return fputc(c, stdout); }
+int feof(FILE *f)   { return (f->flags & NL_F_EOF) ? 1 : 0; }
+int ferror(FILE *f) { return (f->flags & NL_F_ERR) ? 1 : 0; }
+int remove(const char *path) { extern int unlink(const char *); return unlink(path); }

--- a/unikernel/nolibc/string.c
+++ b/unikernel/nolibc/string.c
@@ -96,3 +96,92 @@ int strcmp(const char *a, const char *b) {
     while (*x && *x == *y) { x++; y++; }
     return (int)*x - (int)*y;
 }
+
+/* ── the rest of what NURL PROGRAMS call ────────────────────────
+ * runtime_core needs only the seven above; the stdlib declares more
+ * of libc directly (`& `libc` @ strstr …` in stdlib/core/string.nu),
+ * so a program reaches these without the runtime ever doing so.
+ * Measured, not guessed: running the corpus under nolibc reported
+ * `atoll` blocking 49 tests, `strstr` 42 and `strchr` 26 — the list
+ * came out of the link errors, in that order. */
+
+char *strchr(const char *s, int c) {
+    unsigned char v = (unsigned char)c;
+    for (;; s++) {
+        if ((unsigned char)*s == v) return (char *)s;
+        if (!*s) return 0;              /* '\0' is findable, and only then */
+    }
+}
+
+char *strrchr(const char *s, int c) {
+    unsigned char v = (unsigned char)c;
+    const char *last = 0;
+    for (;; s++) {
+        if ((unsigned char)*s == v) last = s;
+        if (!*s) return (char *)last;
+    }
+}
+
+int strncmp(const char *a, const char *b, nl_size_t n) {
+    const unsigned char *x = (const unsigned char *)a;
+    const unsigned char *y = (const unsigned char *)b;
+    nl_size_t i;
+    for (i = 0; i < n; i++) {
+        if (x[i] != y[i]) return (int)x[i] - (int)y[i];
+        if (!x[i]) break;
+    }
+    return 0;
+}
+
+/* Plain search. glibc runs Two-Way, which wins on long needles and
+ * loses on the short ones this actually sees; nurl_byte_substr in the
+ * runtime made the same call for the same reason. */
+void *memmem(const void *hay, nl_size_t hlen, const void *needle, nl_size_t nlen) {
+    const unsigned char *h = (const unsigned char *)hay;
+    const unsigned char *n = (const unsigned char *)needle;
+    nl_size_t i;
+    if (nlen == 0) return (void *)h;
+    if (hlen < nlen) return 0;
+    for (i = 0; i + nlen <= hlen; i++)
+        if (h[i] == n[0] && memcmp(h + i, n, nlen) == 0) return (void *)(h + i);
+    return 0;
+}
+
+char *strstr(const char *hay, const char *needle) {
+    nl_size_t hl = strlen(hay), nl = strlen(needle);
+    if (nl == 0) return (char *)hay;
+    if (hl < nl) return 0;
+    return (char *)memmem(hay, hl, needle, nl);
+}
+
+char *strdup(const char *s) {
+    nl_size_t n = strlen(s) + 1;
+    char *p = (char *)malloc(n);
+    if (p) memcpy(p, s, n);
+    return p;
+}
+
+char *strncpy(char *d, const char *s, nl_size_t n) {
+    nl_size_t i = 0;
+    for (; i < n && s[i]; i++) d[i] = s[i];
+    for (; i < n; i++) d[i] = 0;       /* the padding is the contract */
+    return d;
+}
+
+/* Leading space, optional sign, decimal digits — and nothing else,
+ * because that is all the C standard promises atoll callers and all
+ * the stdlib asks for. Overflow is undefined in C; wrapping in an
+ * unsigned accumulator at least makes it deterministic. */
+long long atoll(const char *s) {
+    unsigned long long acc = 0;
+    int neg = 0;
+    while (*s == ' ' || (*s >= 9 && *s <= 13)) s++;
+    if (*s == '-') { neg = 1; s++; }
+    else if (*s == '+') s++;
+    while (*s >= '0' && *s <= '9') acc = acc * 10ULL + (unsigned)(*s++ - '0');
+    return neg ? -(long long)acc : (long long)acc;
+}
+long atol(const char *s) { return (long)atoll(s); }
+int  atoi(const char *s) { return (int)atoll(s); }
+int  abs(int v) { return v < 0 ? -v : v; }
+long long llabs(long long v) { return v < 0 ? -v : v; }

--- a/unikernel/nolibc/syscall_linux.c
+++ b/unikernel/nolibc/syscall_linux.c
@@ -45,12 +45,12 @@ long nl_syscall6(long n, long a, long b, long c, long d, long e, long f) {
 #define MAP_PRIVATE   0x02
 #define MAP_ANONYMOUS 0x20
 
-static int nl_errno_slot;
+int nl_errno_slot;
 int *__errno_location(void) { return &nl_errno_slot; }
 
 /* -errno in, -1 out with errno set — the libc convention the runtime
  * expects from read/write/open. */
-static long nl_ret(long r) {
+long nl_ret(long r) {
     if (r < 0 && r > -4096) { nl_errno_slot = (int)-r; return -1; }
     return r;
 }
@@ -83,3 +83,68 @@ void nl_exit_group(int code) {
     nl_syscall6(SYS_exit_group, code, 0, 0, 0, 0, 0);
     for (;;) { }                       /* unreachable; keeps `noreturn` true */
 }
+
+/* ── the libc-named wrappers ────────────────────────────────────
+ * Everything above is internal (nl_*); everything below carries the
+ * name the compiler emits, because NURL's `& `libc` @ …` declarations
+ * call these directly. They are one syscall each — no libc logic, no
+ * buffering, no errno translation beyond the -errno split above — so
+ * the unikernel replaces them with device work and keeps every caller.
+ *
+ * The list is measured: it is what the corpus asked for when run under
+ * nolibc, minus the ones that need more than a syscall (execvp's PATH
+ * search, realpath, mkstemp, sigaction's restorer trampoline), which
+ * are their own work rather than a line here.
+ */
+#define SYS_open_       2
+#define SYS_stat_       4
+#define SYS_poll_       7
+#define SYS_madvise_   28
+#define SYS_dup2_      33
+#define SYS_pipe_      22
+#define SYS_getpid_    39
+#define SYS_fork_      57
+#define SYS_wait4_     61
+#define SYS_fcntl_     72
+#define SYS_ioctl_     16
+#define SYS_access_    21
+#define SYS_nanosleep_ 35
+#define SYS_rename_    82
+#define SYS_mkdir_     83
+#define SYS_rmdir_     84
+#define SYS_unlink_    87
+#define SYS_chdir_     80
+#define SYS_chmod_     90
+#define SYS_exit_      60
+#define SYS_clock_gettime_ 228
+
+long long read(int fd, void *buf, unsigned long n)  { return nl_read(fd, buf, n); }
+long long write(int fd, const void *buf, unsigned long n) { return nl_write(fd, buf, n); }
+int   close(int fd)                                 { return nl_close(fd); }
+int   open(const char *p, int fl, int mode)         { return nl_open(p, fl, mode); }
+long long lseek(int fd, long long off, int whence)  { return nl_lseek(fd, off, whence); }
+int   munmap(void *p, unsigned long len)            { return nl_unmap(p, len); }
+void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off) {
+    long r = nl_syscall6(SYS_mmap, (long)addr, (long)len, prot, flags, fd, off);
+    if (r < 0 && r > -4096) { nl_errno_slot = (int)-r; return (void *)-1; }
+    return (void *)r;
+}
+int   getpid(void)                                  { return (int)nl_ret(nl_syscall6(SYS_getpid_,0,0,0,0,0,0)); }
+int   fork(void)                                    { return (int)nl_ret(nl_syscall6(SYS_fork_,0,0,0,0,0,0)); }
+int   waitpid(int pid, int *status, int opts)       { return (int)nl_ret(nl_syscall6(SYS_wait4_, pid, (long)status, opts, 0, 0, 0)); }
+int   pipe(int fds[2])                              { return (int)nl_ret(nl_syscall6(SYS_pipe_, (long)fds, 0, 0, 0, 0, 0)); }
+int   dup2(int a, int b)                            { return (int)nl_ret(nl_syscall6(SYS_dup2_, a, b, 0, 0, 0, 0)); }
+int   poll(void *fds, unsigned long n, int timeout) { return (int)nl_ret(nl_syscall6(SYS_poll_, (long)fds, (long)n, timeout, 0, 0, 0)); }
+int   fcntl(int fd, int cmd, long arg)              { return (int)nl_ret(nl_syscall6(SYS_fcntl_, fd, cmd, arg, 0, 0, 0)); }
+int   ioctl(int fd, unsigned long req, long arg)    { return (int)nl_ret(nl_syscall6(SYS_ioctl_, fd, (long)req, arg, 0, 0, 0)); }
+int   access(const char *p, int mode)               { return (int)nl_ret(nl_syscall6(SYS_access_, (long)p, mode, 0, 0, 0, 0)); }
+int   unlink(const char *p)                         { return (int)nl_ret(nl_syscall6(SYS_unlink_, (long)p, 0, 0, 0, 0, 0)); }
+int   mkdir(const char *p, int mode)                { return (int)nl_ret(nl_syscall6(SYS_mkdir_, (long)p, mode, 0, 0, 0, 0)); }
+int   rmdir(const char *p)                          { return (int)nl_ret(nl_syscall6(SYS_rmdir_, (long)p, 0, 0, 0, 0, 0)); }
+int   rename(const char *a, const char *b)          { return (int)nl_ret(nl_syscall6(SYS_rename_, (long)a, (long)b, 0, 0, 0, 0)); }
+int   chdir(const char *p)                          { return (int)nl_ret(nl_syscall6(SYS_chdir_, (long)p, 0, 0, 0, 0, 0)); }
+int   chmod(const char *p, int mode)                { return (int)nl_ret(nl_syscall6(SYS_chmod_, (long)p, mode, 0, 0, 0, 0)); }
+int   madvise(void *p, unsigned long len, int adv)  { return (int)nl_ret(nl_syscall6(SYS_madvise_, (long)p, (long)len, adv, 0, 0, 0)); }
+int   nanosleep(const void *req, void *rem)         { return (int)nl_ret(nl_syscall6(SYS_nanosleep_, (long)req, (long)rem, 0, 0, 0, 0)); }
+int   clock_gettime(int clk, void *ts)              { return (int)nl_ret(nl_syscall6(SYS_clock_gettime_, clk, (long)ts, 0, 0, 0, 0)); }
+void  _exit(int code)                               { nl_exit_group(code); for (;;) { } }

--- a/unikernel/run_nolibc_tests.sh
+++ b/unikernel/run_nolibc_tests.sh
@@ -54,8 +54,11 @@ one() {
     fi
     if ! clang -nostdlib -static -o "$work/$name" "$work/$name.o" \
             "$OUTDIR/runtime_core.o" "$OUTDIR"/nl_*.o 2>"$work/link.err"; then
-        missing=$(grep -oE "undefined symbol: [A-Za-z0-9_]+" "$work/link.err" \
-                  | sed 's/undefined symbol: //' | sort -u | tr '\n' ' ')
+        # GNU ld says "undefined reference to `name'"; lld says
+        # "undefined symbol: name". Match both, or the list this runner
+        # exists to produce is the string "<link error>" 139 times.
+        missing=$(grep -oE "undefined (reference to \`|symbol: )[A-Za-z0-9_]+" "$work/link.err" \
+                  | sed -E "s/undefined (reference to \`|symbol: )//" | sort -u | tr '\n' ' ')
         echo "NEEDS-FFI $name :: ${missing:-<link error>}"
         return 0
     fi

--- a/unikernel/tests/run_unit_tests.sh
+++ b/unikernel/tests/run_unit_tests.sh
@@ -47,7 +47,10 @@ echo "── nolibc unit gates ──"
 # shellcheck disable=SC2086
 $CC $FREE -Dmemcpy=nl_memcpy -Dmemmove=nl_memmove -Dmemset=nl_memset \
     -Dmemchr=nl_memchr -Dmemcmp=nl_memcmp -Dbcmp=nl_bcmp \
-    -Dstrlen=nl_strlen -Dstrcmp=nl_strcmp \
+    -Dstrlen=nl_strlen -Dstrcmp=nl_strcmp -Dstrchr=nl_strchr \
+    -Dstrrchr=nl_strrchr -Dstrncmp=nl_strncmp -Dmemmem=nl_memmem -Dstrstr=nl_strstr \
+    -Dstrncpy=nl_strncpy -Datoll=nl_atoll -Datol=nl_atol -Datoi=nl_atoi -Dabs=nl_abs \
+    -Dllabs=nl_llabs -Dstrdup=nl_strdup \
     -c "$NOLIBC/string.c" -o "$OUT/test_string_renamed.o" || exit 2
 $CC -O2 "$ROOT/unikernel/tests/string_diff.c" "$OUT/test_string_renamed.o" \
     -o "$OUT/string_diff" || exit 2

--- a/unikernel/tests/string_diff.c
+++ b/unikernel/tests/string_diff.c
@@ -14,6 +14,13 @@ void *nl_memchr(const void*,int,nl_size_t);
 int   nl_memcmp(const void*,const void*,nl_size_t);
 nl_size_t nl_strlen(const char*);
 int   nl_strcmp(const char*,const char*);
+char *nl_strchr(const char*,int);
+char *nl_strrchr(const char*,int);
+int   nl_strncmp(const char*,const char*,nl_size_t);
+void *nl_memmem(const void*,nl_size_t,const void*,nl_size_t);
+char *nl_strstr(const char*,const char*);
+char *nl_strncpy(char*,const char*,nl_size_t);
+long long nl_atoll(const char*);
 
 static long bad = 0, checked = 0;
 #define CHECK(cond, ...) do { checked++; if (!(cond)) { if (bad<10) fprintf(stderr, __VA_ARGS__); bad++; } } while (0)
@@ -66,6 +73,42 @@ int main(void) {
                   "strcmp- off %d len %d pos %d\n", off, len, i);
             t[off+i] = save;
         }
+    }
+    /* the functions NURL programs reach directly: same sweep, and the
+     * needle/haystack cases a hand-written search gets wrong (empty
+     * needle, needle longer than hay, match at the very end). */
+    {
+        static const char *hays[] = {"", "a", "abc", "abcabcabd", "aaaaab",
+            "the quick brown fox", "xxxxxxxxxxxxxxxxxxxxy", "\r\n\r\n"};
+        static const char *nees[] = {"", "a", "b", "abc", "abd", "abcabd",
+            "fox", "y", "\r\n", "zzz", "the quick brown fox "};
+        for (unsigned h = 0; h < sizeof hays/sizeof *hays; h++) {
+            for (unsigned n = 0; n < sizeof nees/sizeof *nees; n++) {
+                CHECK(strstr(hays[h], nees[n]) == nl_strstr(hays[h], nees[n]),
+                      "strstr(%s,%s)\n", hays[h], nees[n]);
+                CHECK(memmem(hays[h], strlen(hays[h]), nees[n], strlen(nees[n]))
+                      == nl_memmem(hays[h], strlen(hays[h]), nees[n], strlen(nees[n])),
+                      "memmem(%s,%s)\n", hays[h], nees[n]);
+                for (nl_size_t k = 0; k <= strlen(hays[h]) + 1; k++)
+                    CHECK(sgn(strncmp(hays[h], nees[n], k)) == sgn(nl_strncmp(hays[h], nees[n], k)),
+                          "strncmp(%s,%s,%lu)\n", hays[h], nees[n], (unsigned long)k);
+            }
+            for (int c = 0; c < 256; c++) {
+                CHECK(strchr(hays[h], c) == nl_strchr(hays[h], c), "strchr %d\n", c);
+                CHECK(strrchr(hays[h], c) == nl_strrchr(hays[h], c), "strrchr %d\n", c);
+            }
+            for (nl_size_t k = 0; k <= 24; k++) {
+                char x[32], y[32];
+                memset(x, 0x7E, sizeof x); memset(y, 0x7E, sizeof y);
+                strncpy(x, hays[h], k); nl_strncpy(y, hays[h], k);
+                CHECK(memcmp(x, y, sizeof x) == 0, "strncpy(%s,%lu)\n", hays[h], (unsigned long)k);
+            }
+        }
+        static const char *nums[] = {"0", "1", "-1", "+42", "  12", "\t-7", "999999999999",
+            "9223372036854775807", "-9223372036854775808", "12abc", "abc", "", "-", "007"};
+        for (unsigned i = 0; i < sizeof nums/sizeof *nums; i++)
+            CHECK(atoll(nums[i]) == nl_atoll(nums[i]), "atoll(%s): %lld vs %lld\n",
+                  nums[i], atoll(nums[i]), nl_atoll(nums[i]));
     }
     printf("string differential: %ld checks, %ld mismatches\n", checked, bad);
     return bad ? 1 : 0;


### PR DESCRIPTION
Follow-up to #770. That PR supplied the 49 libc symbols
`runtime_core.o` needs. Running the corpus under it showed that is not
the whole surface: the stdlib declares more of libc **directly**
(`& \`libc\` @ strstr …`), so a program reaches functions the runtime
never touches.

The link errors ranked them for me — `atoll` blocked 49 tests, `strstr`
42, `strchr` 26 — and that ranking, not a guess, is what this PR
implements.

```
  339 -> 393 PASS        139 -> 85 NEEDS-FFI        0 FAIL
```

## What was added

`strchr` `strrchr` `strstr` `strncmp` `strncpy` `strdup` `memmem`,
`atoll`/`atol`/`atoi`/`abs`/`llabs`, `putchar`/`feof`/`ferror`/`remove`,
`setenv`/`unsetenv`, and the mechanical syscall wrappers under their
libc names — `read`/`write`/`close`/`open`/`lseek`/`mmap`/`munmap`,
`fork`/`waitpid`/`pipe`/`dup2`/`poll`/`fcntl`/`ioctl`, the path calls,
`nanosleep`, `clock_gettime`. Each is one syscall, so the unikernel
replaces them with device work and keeps every caller.

`setenv` copies the environment vector rather than writing into the
kernel's block above the stack — argv lives there too, and growing it
in place is how a nolibc corrupts its own arguments.

## Two bugs the corpus caught that a unit test would not have

**`opendir`/`readdir`/`lstat` were stubs that "refused honestly."** That
is the right answer when the capability does not exist on the target —
but on Linux it does, and `fs_dir_list` linked the moment `open`/`read`
existed and then reported "not found" for a directory that was right
there. They are now real, over `getdents64` and the stat syscalls. The
kernel's `linux_dirent64` **is** glibc's `struct dirent` field for
field, which is how glibc hands the raw buffer back and why `readdir`
can return a pointer into it here.

**`fseek(SEEK_CUR)` ignored the read-ahead.** The kernel's offset is
ahead of the caller's by every prefetched byte not yet handed out, so
"read 11 bytes, then seek +9" landed at 4105 instead of 20.
`fs_write_handle` failed the moment the rest of nolibc was complete
enough for it to link. Fixed there and in the two neighbouring places
that share one buffer between directions: a write now drops read-ahead
(with the matching `lseek` back), and a read flushes a pending write.

`fopen`'s mode parser also only looked at `mode[1]`, so `"rb+"` opened
read-only — a stream that reads nothing much later, rather than an
error at open.

## Gate

The string differential grew to cover every new function: `strstr` and
`memmem` against glibc over the cases a hand-written search gets wrong
(empty needle, needle longer than hay, match at the very end), `strchr`
and `strrchr` over all 256 byte values, `strncmp` at every length
including past the terminator, `strncpy`'s padding contract, and
`atoll` at the 64-bit boundaries. **650 795 checks, 0 mismatches.**

## What is left

The 85 still blocked are `runtime_bare.c`, and the runner ranks that
too: `nurl_rand_fill` blocks 35, the pthread mutex quartet 28, and the
`nurl_tcp_*` / `nurl_reactor_*` / `nurl_fiber_*` family 20–28 each —
the cooperative sync shims and the socket seam, which is the next A3
item and where A4's sans-IO stack plugs in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1