### PR TITLE
nurlc: a NURL function may define a symbol an FFI declaration names

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -18071,6 +18071,24 @@
     // redefinition of function" error, so skip the emit — the symbol is
     // still registered above so callers resolve correctly.
     : b is_prelude_cfn | | | | ( seq fname `malloc` ) ( seq fname `free` ) ( seq fname `puts` ) ( seq fname `printf` ) ( seq fname `realpath` )
+    // A NURL @-function of the same name DEFINES this symbol, so the
+    // declare is both redundant and illegal — LLVM rejects a `declare`
+    // and a `define` of one name as "invalid redefinition". That is not
+    // a hypothetical: it is how a program supplies its own version of a
+    // runtime symbol, which is exactly what the unikernel's socket
+    // shims do (NURL code providing `nurl_tcp_*` over the sans-IO stack
+    // in stdlib/net/, where the hosted build has C). Before this, such
+    // a program compiled to IR that clang refused, with the error
+    // pointing at generated code — the worst place for a diagnostic.
+    //
+    // `__arity` and not `__src_file`: the latter is written for types
+    // and consts too, so a type sharing a name with an FFI symbol would
+    // have suppressed a declare that was still needed. `__arity` is set
+    // by scan_fn_sigs, a complete whole-program pre-pass, for real
+    // @-functions only — so a definition anywhere in the program,
+    // including in a file imported after this one, is already visible
+    // here.
+    : b defined_in_nurl != 0 ( nurl_sym_len2 syms fname `__arity` )
     // Dedupe `declare`s by symbol name across the whole compilation: two
     // imported modules may legitimately declare the same libc/runtime
     // extern (e.g. `nurl_rand_fill` in both std/random.nu and tls.nu), and
@@ -18081,7 +18099,7 @@
     // generalises the prelude-symbol skip.
     : s emitkey ( nurl_str_cat fname `__ffi_emitted` )
     : b already != 0 ( nurl_sym_len syms emitkey )
-    ? | is_prelude_cfn already
+    ? | | is_prelude_cfn already defined_in_nurl
     {}
     { ( nurl_sym_def syms emitkey `1` )
         ( nurl_print `declare ` ) ( nurl_print ( nurl_llty ret_ty ) )

--- a/compiler/tests/ffi_decl_shadowed.nu
+++ b/compiler/tests/ffi_decl_shadowed.nu
@@ -1,0 +1,39 @@
+// ffi_decl_shadowed — a NURL @-function may DEFINE a symbol that an FFI
+// declaration names.
+//
+// This is how a program supplies its own version of something the
+// runtime would otherwise provide, and it is the shape the unikernel's
+// socket shims take: `nurl_tcp_*` is a C symbol in the hosted runtime
+// and pure NURL over the sans-IO stack in stdlib/net/ when there is no
+// operating system underneath.
+//
+// nurlc used to emit BOTH `declare i64 @name(...)` (from the FFI
+// declaration) and `define i64 @name(...)` (from the @-function), which
+// LLVM rejects as "invalid redefinition of function". The program was
+// well-formed NURL; the error came out of clang, pointing at generated
+// code, which is the worst place a diagnostic can appear. A definition
+// now suppresses the declaration, exactly as it does in C.
+$ `stdlib/core/io.nu`
+
+// Declared as an external C symbol…
+& `c` @ nurl_test_shadowed_fn i x → i
+
+// …and defined here instead. The definition wins.
+@ nurl_test_shadowed_fn i x → i {
+    ^ + * x 10 7
+}
+
+// A second one, to show the suppression is per-symbol rather than a
+// global switch: this one is declared and NOT defined, so its declare
+// must survive. `strlen` is a real libc symbol, so the link proves it.
+& `c` @ strlen s p → i
+
+@ main → i {
+    ( nurl_print `shadowed(4)=` )
+    ( nurl_print ( nurl_str_int ( nurl_test_shadowed_fn 4 ) ) )
+    ( nurl_print `\n` )
+    ( nurl_print `strlen(hello)=` )
+    ( nurl_print ( nurl_str_int ( strlen `hello` ) ) )
+    ( nurl_print `\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs/ffi_decl_shadowed.txt
+++ b/compiler/tests/outputs/ffi_decl_shadowed.txt
@@ -1,0 +1,6 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+shadowed(4)=47
+strlen(hello)=5


### PR DESCRIPTION
nurlc emitted BOTH `declare i64 @name(...)` — from the FFI declaration —
and `define i64 @name(...)` — from the @-function — for the same
symbol. LLVM rejects that as "invalid redefinition of function", so a
well-formed NURL program failed in clang, with the error pointing at
generated code. That is the worst place a diagnostic can appear: the
line it names does not exist in anything the author wrote.

```
$ nurlc prog.nu > prog.ll && clang -c prog.ll
prog.ll:1384:12: error: invalid redefinition of function 'nurl_tcp_get_fd'
 1384 | define i64 @nurl_tcp_get_fd(i64 %handle) {
      |            ^
```

Defining a symbol something else declares is not an exotic case. It is
how a program supplies its own version of what the runtime would
otherwise provide, and it is the shape phase A4 needs: `nurl_tcp_*` is
a C symbol in the hosted runtime and is pure NURL over the sans-IO
stack in `stdlib/net/` when there is no operating system underneath.

`gen_ffi_decl` already suppressed the declare in two cases — a small
hardcoded list of prelude symbols, and a per-name key that dedupes two
imports declaring the same extern. This is the third: **a definition
suppresses the declaration, exactly as it does in C.**

The key is `__arity`, not `__src_file`. The latter is written for types
and consts as well, so a type sharing a name with an FFI symbol would
have suppressed a declare that was still needed. `__arity` is set by
`scan_fn_sigs`, a complete whole-program pre-pass, for real
@-functions only — which also means a definition in a file imported
*after* the declaration is already visible at the point the decision is
made.

## What this does not do

Let two definitions through. Overriding a symbol the hosted
`runtime.o` also defines still fails — now at the linker and with the
accurate message:

```
multiple definition of `nurl_tcp_get_fd'
```

rather than as an IR error. That is the right division: you can only
provide what nothing else already provides, which is exactly the
freestanding case, where `runtime_bare.c` leaves the socket surface
absent rather than stubbed.

## Gate

`ffi_decl_shadowed` pins both halves — the shadowed symbol resolves to
the NURL definition, and a second FFI symbol that is declared and not
defined keeps its declare and still links against libc. Verified
non-vacuous: the pre-fix compiler emits the invalid IR for this exact
input.

Corpus 607 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1