### PR TITLE
A4.0: TCP over the sans-IO stack — the connection table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,10 @@ jobs:
         # defer_drop_reclaim + defer_scoped + defer_ret_transfer pin the
         # defer-vs-auto-drop fix (a `;` defer used to disable every owned
         # drop in the function; scoped defers emitted invalid IR).
+        # net_tcpstack is the layer where the connection TABLE lives, so
+        # it is the one that can leak a Tcb: a connection reclaimed on
+        # RST, on FIN, or by the TIME_WAIT timer takes three different
+        # paths out, and each has to return the same allocation.
         # net_inet + net_frames + net_dhcp pin the sans-IO net stack's
         # manual-handle discipline (§7.4): per-iteration Vec frees in a
         # 65k-datagram sweep, String results from the address formatters,
@@ -361,6 +365,7 @@ jobs:
             ternary_slice_owned match_slice_owned arm_assign_tail_drop \
             defer_drop_reclaim defer_scoped defer_ret_transfer \
             net_inet net_frames net_dhcp net_stack net_tcp net_tcp_fuzz \
+            net_tcpstack \
             virtq_split free_suffix_query closure_env_escape_loop \
             ctx_switch async_basic async_chan async_mn async_sleep \
             select_basic

--- a/compiler/tests/net_tcpstack.nu
+++ b/compiler/tests/net_tcpstack.nu
@@ -1,0 +1,257 @@
+// net_tcpstack.nu — Phase A4.0: TCP over the sans-IO IPv4 stack.
+//
+// net_tcp.nu already drives two Tcbs against each other with segments.
+// This is the layer under that: two whole stacks wired frame-to-frame,
+// so every segment travels as a real Ethernet frame with a real IPv4
+// header and a checksum computed over the real pseudo-header, and the
+// connection it belongs to is found by demultiplexing rather than by
+// the test handing it over.
+//
+// What is asserted here is what only exists at this layer:
+//
+//   * the passive open — a SYN to a listening port creates a NEW
+//     connection and leaves the listener listening;
+//   * the ARP wait — the very first SYN to an unresolved peer cannot
+//     be framed, and the retransmit timer is what sends it. No queue;
+//   * demultiplexing by four-tuple, including two connections from the
+//     same peer to the same port, which is the case a table keyed on
+//     anything less would get wrong;
+//   * a segment for no connection gets a RST, and a RST for no
+//     connection does not (or two hosts trade them forever);
+//   * a full-duplex transfer and an orderly close, end to end.
+//
+// Scripted clock throughout: no sockets, no device, no wall clock.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/eth.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/arp.nu`
+$ `stdlib/net/icmp.nu`
+$ `stdlib/net/udp4.nu`
+$ `stdlib/net/stack.nu`
+$ `stdlib/net/tcpseg.nu`
+$ `stdlib/net/tcp.nu`
+$ `stdlib/net/tcpstack.nu`
+
+@ mac_a → i { ^ 2199023255553 }  // 02:00:00:00:00:01
+
+@ mac_b → i { ^ 2199023255554 }  // 02:00:00:00:00:02
+
+@ ip_a → i { ^ ( ipv4_make 10 0 0 1 ) }
+
+@ ip_b → i { ^ ( ipv4_make 10 0 0 2 ) }
+
+@ mask24 → i { ^ ( ipv4_make 255 255 255 0 ) }
+
+@ ip_gw → i { ^ ( ipv4_make 10 0 0 254 ) }
+
+: ~ i g_fail 0
+
+@ pb s label b ok → v {
+    ( nurl_print label )
+    ( nurl_print ? ok `ok` `FAIL` )
+    ( nurl_print `\n` )
+    ? ! ok { = g_fail + g_fail 1 } {}
+}
+
+// Deliver every frame sitting in `wire` to `dst`, collecting whatever
+// it answers into `back`. Frames are concatenated in `wire`, so they
+// are split the way a device splits them: by parsing each header and
+// stepping over the datagram it describes.
+@ deliver_all * TcpStack dst ( Vec u ) wire i now ( Vec u ) back → i {
+    : ~ i off 0
+    : ~ i n 0
+    : i total ( vec_len [u] wire )
+    ~ < off total {
+        : i flen ( __frame_len wire off total )
+        ? <= flen 0 { = off total } {
+            : ( Vec u ) f ( vec_new [u] )
+            ( vec_extend_range [u] f wire off flen )
+            : TRx r ( tstack_rx dst f now back )
+            ( vec_free [u] f )
+            = n + n 1
+            = off + off flen
+        }
+    }
+    ^ n
+}
+
+// The length of the frame starting at `off`. Ethernet gives no length,
+// so it comes from the IPv4 header — and ARP frames are the fixed 42
+// bytes the stack emits.
+@ __frame_len ( Vec u ) w i off i total → i {
+    ? < - total off 14 { ^ 0 } {}
+    : i et + * 256 ?? ( vec_get [u] w + off 12 ) { T x → # i x F → 0 } ?? ( vec_get [u] w + off 13 ) { T x → # i x F → 0 }
+    ? == et 2054 { ^ ? >= - total off 42 42 - total off } {}
+    ? != et 2048 { ^ - total off } {}
+    : i tl + * 256 ?? ( vec_get [u] w + off 16 ) { T x → # i x F → 0 } ?? ( vec_get [u] w + off 17 ) { T x → # i x F → 0 }
+    ? <= tl 0 { ^ - total off } {}
+    ^ ? >= - total off + 14 tl + 14 tl - total off
+}
+
+// Run the two stacks against each other until neither has anything to
+// say, or `rounds` is up. Returns how many frames crossed.
+//
+// CONSUMES `from_a`: it becomes the first wire and is freed with every
+// other buffer the exchange produces. Vec is outside auto-drop
+// (docs/MEMORY.md §7.4), so saying who frees what is the whole
+// contract, and a caller that also freed it would double-free.
+@ settle * TcpStack a * TcpStack b ( Vec u ) from_a i now i rounds → i {
+    : ~ i crossed 0
+    : ~ ( Vec u ) wire from_a
+    : ~ i side 0
+    : ~ i k 0
+    ~ && < k rounds > ( vec_len [u] wire ) 0 {
+        : ( Vec u ) back ( vec_new [u] )
+        : i n ? == side 0 ( deliver_all b wire now back ) ( deliver_all a wire now back )
+        = crossed + crossed n
+        ( vec_free [u] wire )
+        = wire back
+        = side ? == side 0 1 0
+        = k + k 1
+    }
+    ( vec_free [u] wire )
+    ^ crossed
+}
+
+@ main → i {
+    : *NetStack na ( stack_new ( mac_a ) ( ip_a ) ( mask24 ) ( ip_gw ) )
+    : *NetStack nb ( stack_new ( mac_b ) ( ip_b ) ( mask24 ) ( ip_gw ) )
+    : *TcpStack a ( tstack_new na 1000 )
+    : *TcpStack b ( tstack_new nb 500000 )
+
+    // ── B listens ────────────────────────────────────────────────
+    : i lst ( tstack_listen b ( ip_b ) 80 4 )
+    ( pb `listener created: ` >= lst 0 )
+    ( pb `nothing pending yet: ` == 0 ( tstack_pending_count b lst ) )
+
+    // ── A connects: the first SYN cannot be framed ───────────────
+    // A has never spoken to B, so ARP has not resolved. What goes on
+    // the wire is an ARP request, NOT the SYN — and the connection is
+    // nonetheless open, waiting on its own retransmit timer.
+    : ( Vec u ) w1 ( vec_new [u] )
+    : i ca ( tstack_connect a ( ip_b ) 80 0 1000 w1 )
+    ( pb `connection allocated: ` >= ca 0 )
+    ( pb `A is in SYN_SENT: ` == ( tstack_conn_state a ca ) ( tcp_syn_sent ) )
+    ( pb `first frame out is ARP, not the SYN: ` == ( vec_len [u] w1 ) 42 )
+    ( pb `B has still seen nothing: ` == 0 ( tstack_pending_count b lst ) )
+
+    // ARP resolves.
+    ( settle a b w1 1000 4 )
+    ( pb `A resolved B's MAC: ` ?? ( arp_cache_lookup . na arp ( ip_b ) 1000 ) { T m → == m ( mac_b ) F → F } )
+
+    // The retransmit timer sends the SYN that ARP held up. This is the
+    // whole argument for not queueing it: TCP already owns this timer.
+    : ( Vec u ) w2 ( vec_new [u] )
+    ( tstack_tick a 2100 w2 )
+    ( pb `the RTO resent the SYN: ` > ( vec_len [u] w2 ) 0 )
+    ( settle a b w2 2100 6 )
+
+    ( pb `A is ESTABLISHED: ` == ( tstack_conn_state a ca ) ( tcp_established ) )
+    ( pb `B queued a connection: ` == 1 ( tstack_pending_count b lst ) )
+    : i cb ( tstack_accept b lst )
+    ( pb `B accepted it: ` >= cb 0 )
+    ( pb `and it is ESTABLISHED: ` == ( tstack_conn_state b cb ) ( tcp_established ) )
+    ( pb `accept consumed the queue entry: ` == 0 ( tstack_pending_count b lst ) )
+    ( pb `the listener is still listening: ` >= ( tstack_listen b ( ip_b ) 80 4 ) 0 )
+    ( pb `B sees A's address: ` == ( tstack_conn_peer_ip b cb ) ( ip_a ) )
+    ( pb `B sees A's port: ` == ( tstack_conn_peer_port b cb ) ( tstack_conn_local_port a ca ) )
+
+    // ── data, both ways ──────────────────────────────────────────
+    : ( Vec u ) msg ( vec_new [u] )
+    ( bytes_extend_str msg `GET /unikernel HTTP/1.0` )
+    : ( Vec u ) w3 ( vec_new [u] )
+    : i wrote ( tstack_write a ca msg 0 ( vec_len [u] msg ) 3000 w3 )
+    ( pb `A queued the request: ` == wrote ( vec_len [u] msg ) )
+    ( settle a b w3 3000 6 )
+
+    : ( Vec u ) got ( vec_new [u] )
+    : i nread ( tstack_read b cb got ( vec_len [u] msg ) )
+    ( pb `B read the whole request: ` == nread ( vec_len [u] msg ) )
+    ( pb `and the bytes match: ` ( bytes_eq got msg ) )
+
+    : ( Vec u ) reply ( vec_new [u] )
+    ( bytes_extend_str reply `HTTP/1.0 200 OK` )
+    : ( Vec u ) w4 ( vec_new [u] )
+    ( tstack_write b cb reply 0 ( vec_len [u] reply ) 3100 w4 )
+    ( settle b a w4 3100 6 )
+    : ( Vec u ) got2 ( vec_new [u] )
+    : i nread2 ( tstack_read a ca got2 ( vec_len [u] reply ) )
+    ( pb `A read the whole reply: ` == nread2 ( vec_len [u] reply ) )
+    ( pb `and those bytes match too: ` ( bytes_eq got2 reply ) )
+
+    // ── a second connection from the same peer to the same port ──
+    // The case a table keyed on anything less than the four-tuple gets
+    // wrong: same source address, same destination port, different
+    // source port.
+    : ( Vec u ) w5 ( vec_new [u] )
+    : i ca2 ( tstack_connect a ( ip_b ) 80 0 4000 w5 )
+    ( settle a b w5 4000 8 )
+    ( pb `the second connection is ESTABLISHED: ` == ( tstack_conn_state a ca2 ) ( tcp_established ) )
+    ( pb `it is a different connection: ` != ca2 ca )
+    ( pb `with a different local port: ` != ( tstack_conn_local_port a ca2 ) ( tstack_conn_local_port a ca ) )
+    ( pb `B queued the second one: ` == 1 ( tstack_pending_count b lst ) )
+    : i cb2 ( tstack_accept b lst )
+    ( pb `and it is not the first: ` != cb2 cb )
+    ( pb `the first is still ESTABLISHED: ` == ( tstack_conn_state b cb ) ( tcp_established ) )
+
+    // ── a segment for nothing gets a RST ─────────────────────────
+    : ( Vec u ) w6 ( vec_new [u] )
+    : i cx ( tstack_connect a ( ip_b ) 9999 0 5000 w6 )
+    : ( Vec u ) back ( vec_new [u] )
+    ( deliver_all b w6 5000 back )
+    ( pb `a SYN to a closed port is refused: ` > ( vec_len [u] back ) 0 )
+    ( pb `B counted it: ` == 1 . b no_conn )
+    // …and A's connection dies on the RST rather than retrying forever.
+    : ( Vec u ) w7 ( vec_new [u] )
+    ( deliver_all a back 5000 w7 )
+    ( pb `A gave up on the refused connection: ` != ( tstack_conn_state a cx ) ( tcp_syn_sent ) )
+    ( pb `the RST drew no reply: ` == 0 ( vec_len [u] w7 ) )
+
+    // ── orderly close ────────────────────────────────────────────
+    : ( Vec u ) w8 ( vec_new [u] )
+    ( tstack_close a ca 6000 w8 )
+    ( settle a b w8 6000 8 )
+    ( pb `B saw the FIN: ` || == ( tstack_conn_state b cb ) ( tcp_close_wait ) == ( tstack_conn_state b cb ) ( tcp_closed ) )
+    : ( Vec u ) w9 ( vec_new [u] )
+    ( tstack_close b cb 6100 w9 )
+    ( settle b a w9 6100 8 )
+    ( pb `A reached TIME_WAIT: ` || == ( tstack_conn_state a ca ) ( tcp_time_wait ) == ( tstack_conn_state a ca ) ( tcp_closed ) )
+    // 2MSL later the connection is reclaimed by the timer, not by a
+    // caller remembering to.
+    : ( Vec u ) w10 ( vec_new [u] )
+    ( tstack_tick a + 6100 ( tcp_2msl_ms ) w10 )
+    ( pb `TIME_WAIT expired into CLOSED: ` == ( tstack_conn_state a ca ) ( tcp_closed ) )
+    ( pb `and the slot is reusable: ` ! ( tstack_conn_live a ca ( tstack_conn_gen a ca ) ) )
+
+    // ── the event loop's question ────────────────────────────────
+    // With a connection still open and a retransmit armed, "how long
+    // may I sleep?" must have an answer; with nothing armed it must
+    // say so rather than return 0 and spin.
+    : i tmo ( tstack_next_timeout b 7000 )
+    ( pb `next timeout is a real deadline or none: ` >= tmo -1 )
+
+    // ── teardown ─────────────────────────────────────────────────
+    // Everything here is a manually-managed handle. This stack is bound
+    // for a unikernel, where there is no process exit to sweep up after
+    // a leak, so it is held leak-clean from its first commit — the CI
+    // leak gate runs this test under LSan.
+    //
+    // The `w*` buffers handed to `settle` are gone already: it consumes
+    // its wire. The rest are ours.
+    ( vec_free [u] w6 ) ( vec_free [u] w7 ) ( vec_free [u] w10 )
+    ( vec_free [u] back )
+    ( vec_free [u] msg ) ( vec_free [u] got )
+    ( vec_free [u] reply ) ( vec_free [u] got2 )
+    ( tstack_free a )
+    ( tstack_free b )
+    ( stack_free na )
+    ( stack_free nb )
+
+    ( nurl_print ? == g_fail 0 `net_tcpstack: all ok\n` `net_tcpstack: FAILURES\n` )
+    ^ ? == g_fail 0 0 1
+}

--- a/compiler/tests/outputs/net_tcpstack.txt
+++ b/compiler/tests/outputs/net_tcpstack.txt
@@ -1,0 +1,41 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+listener created: ok
+nothing pending yet: ok
+connection allocated: ok
+A is in SYN_SENT: ok
+first frame out is ARP, not the SYN: ok
+B has still seen nothing: ok
+A resolved B's MAC: ok
+the RTO resent the SYN: ok
+A is ESTABLISHED: ok
+B queued a connection: ok
+B accepted it: ok
+and it is ESTABLISHED: ok
+accept consumed the queue entry: ok
+the listener is still listening: ok
+B sees A's address: ok
+B sees A's port: ok
+A queued the request: ok
+B read the whole request: ok
+and the bytes match: ok
+A read the whole reply: ok
+and those bytes match too: ok
+the second connection is ESTABLISHED: ok
+it is a different connection: ok
+with a different local port: ok
+B queued the second one: ok
+and it is not the first: ok
+the first is still ESTABLISHED: ok
+a SYN to a closed port is refused: ok
+B counted it: ok
+A gave up on the refused connection: ok
+the RST drew no reply: ok
+B saw the FIN: ok
+A reached TIME_WAIT: ok
+TIME_WAIT expired into CLOSED: ok
+and the slot is reusable: ok
+next timeout is a real deadline or none: ok
+net_tcpstack: all ok

--- a/stdlib/core/vec.nu
+++ b/stdlib/core/vec.nu
@@ -380,6 +380,41 @@
     }
 }
 
+// Append `src[off .. off+n)` to `dst` (bitwise), with the same
+// trivial-element-type rule as vec_extend below.
+//
+// The whole-vector form makes a caller who has only a sub-range build a
+// temporary Vec to pass it — a full copy of the data, plus an
+// allocation and a free, to move bytes it already had. net/tcpstack.nu
+// hits this on every outgoing segment (TCP carries no length field, so
+// the segments arrive as offsets into one buffer), which is the wrong
+// place to be allocating.
+//
+// Out-of-range requests are clamped rather than trapped: `off` past the
+// end appends nothing, and a length running past the end appends what
+// is there. A caller computing a range from a parsed header should not
+// have to re-verify what the vector can already answer.
+@ vec_extend_range [A] ( Vec A ) dst ( Vec A ) src i off i n → v {
+    : s sctl . src ctl
+    : i slen ( __vec_len_raw sctl )
+    : i start ? < off 0 0 off
+    ? >= start slen { ^ } {}
+    : i want ? < n 0 0 n
+    : i cnt ? > + start want slen - slen start want
+    ? <= cnt 0 { ^ } {}
+    : s dctl . dst ctl
+    : i dlen ( __vec_len_raw dctl )
+    ( __vec_grow [A] dctl + dlen cnt )
+    : *A ddata # *A ( nurl_peek dctl 0 )
+    : *A sdata # *A ( nurl_peek sctl 0 )
+    : ~ i i 0
+    ~ < i cnt {
+        = . ddata + dlen i . sdata + start i
+        = i + i 1
+    }
+    ( nurl_poke dctl 1 + dlen cnt )
+}
+
 // Append every element of `src` to `dst` (bitwise). Like vec_map, this
 // is safe only for trivial element types (i, f, b, raw s, slice). For
 // owned element types the caller must clone manually with vec_each +

--- a/stdlib/net/stack.nu
+++ b/stdlib/net/stack.nu
@@ -52,6 +52,13 @@ $ `stdlib/net/udp4.nu`
 
 @ rx_dropped → i { ^ 4 }
 
+// A TCP segment for us. This layer stops here on purpose: demultiplexing
+// to a connection is the business of net/tcpstack.nu, which owns the
+// table. What comes back is the IP payload's extent plus the addresses
+// the pseudo-header checksum needs — everything the TCP parse requires
+// and nothing it would have to be told twice.
+@ rx_tcp → i { ^ 5 }
+
 // drop reasons — every discarded frame lands in exactly one bucket
 @ drop_not_for_us → i { ^ 0 }
 
@@ -264,6 +271,11 @@ $ `stdlib/net/udp4.nu`
         ^ ( __rx_drop ( drop_not_our_ip ) )
     } {}
     ? == . ih proto ( ip_proto_icmp ) { ^ ( __rx_icmp st frame ih now out ) } {}
+    ? == . ih proto ( ip_proto_tcp ) {
+        ^ @ RxResult {
+            ( rx_tcp ) 0 . ih src . ih dst 0 0 . ih payload_off . ih payload_len 0
+        }
+    } {}
     ? == . ih proto ( ip_proto_udp ) {
         : Udp4Hdr uh ( udp4_parse frame . ih payload_off . ih payload_len . ih src . ih dst )
         ? ! . uh valid {
@@ -285,7 +297,18 @@ $ `stdlib/net/udp4.nu`
 // caller retries after the reply arrives. Returning "pending" rather
 // than queueing internally keeps the buffer-ownership story simple:
 // this module never holds on to the caller's payload.
-@ stack_tx_udp * NetStack st i dst_ip i src_port i dst_port ( Vec u ) payload i pay_off i pay_len i now ( Vec u ) out → TxResult {
+// Frame and send an already-built layer-4 datagram. Routing, ARP and
+// the Ethernet/IPv4 headers live here and nowhere else, so TCP and UDP
+// resolve their next hop by the same code and a fix to it fixes both.
+// `dg` is BORROWED — the caller built it and the caller frees it.
+//
+// On a cache miss this emits an ARP request and answers `tx_arp_pending`
+// rather than queueing the datagram. Keeping the queue outside means
+// this module never holds a pointer to someone else's buffer, and the
+// retry is the caller's to schedule — which for TCP is free, because a
+// segment that did not go out is exactly what its retransmit timer is
+// already for.
+@ stack_tx_ip4 * NetStack st i dst_ip i proto ( Vec u ) dg i dg_off i dg_len i now ( Vec u ) out → TxResult {
     ? == . st our_ip 0 { ^ @ TxResult { ( tx_no_address ) 0 } } {}
     : i hop ( __next_hop st dst_ip )
     : ~ i dst_mac 0
@@ -306,14 +329,19 @@ $ `stdlib/net/udp4.nu`
         ^ @ TxResult { ( tx_arp_pending ) 0 }
     } {}
     : i before ( vec_len [u] out )
-    : ( Vec u ) dg ( vec_new [u] )
-    ( udp4_push dg . st our_ip dst_ip src_port dst_port payload pay_off pay_len )
     ( eth_push_header out dst_mac . st our_mac ( ethertype_ipv4 ) )
-    ( ip4_push_header out . st our_ip dst_ip ( ip_proto_udp ) ( vec_len [u] dg ) ( __next_id st ) 64 T )
-    ( vec_extend [u] out dg )
-    ( vec_free [u] dg )
+    ( ip4_push_header out . st our_ip dst_ip proto dg_len ( __next_id st ) 64 T )
+    ( vec_extend_range [u] out dg dg_off dg_len )
     = . st tx_frames + . st tx_frames 1
     ^ @ TxResult { ( tx_sent ) - ( vec_len [u] out ) before }
+}
+
+@ stack_tx_udp * NetStack st i dst_ip i src_port i dst_port ( Vec u ) payload i pay_off i pay_len i now ( Vec u ) out → TxResult {
+    : ( Vec u ) dg ( vec_new [u] )
+    ( udp4_push dg . st our_ip dst_ip src_port dst_port payload pay_off pay_len )
+    : TxResult r ( stack_tx_ip4 st dst_ip ( ip_proto_udp ) dg 0 ( vec_len [u] dg ) now out )
+    ( vec_free [u] dg )
+    ^ r
 }
 
 // Broadcast a UDP datagram from 0.0.0.0 — the shape DHCP needs before

--- a/stdlib/net/tcp.nu
+++ b/stdlib/net/tcp.nu
@@ -434,6 +434,29 @@ $ `stdlib/net/tcpseg.nu`
 
 // Returns bytes emitted. Drives retransmission, the persist timer and
 // the 2MSL wait.
+// When does this connection next need attention, in milliseconds from
+// `now`, or -1 if it is waiting on the peer alone?
+//
+// A Tcb keeps three absolute deadlines and `tcb_tick` acts on whichever
+// have passed. That is all a scripted test needs, but an event loop
+// needs the other direction: with nothing runnable, how long may it
+// sleep? Without this it can only poll, which on a guest with one vCPU
+// is the difference between idling and burning it. Deadlines already
+// past answer 0 — there is work now.
+@ tcb_next_timeout * Tcb c i now → i {
+    : ~ i best -1
+    : ~ i k 0
+    ~ < k 3 {
+        : i d ? == k 0 . c rtx_deadline ? == k 1 . c probe_deadline . c tw_deadline
+        ? != d 0 {
+            : i delta ? > d now - d now 0
+            ? || < best 0 < delta best { = best delta } {}
+        } {}
+        = k + k 1
+    }
+    ^ best
+}
+
 @ tcb_tick * Tcb c i now * TcpOut out → i {
     : i before ( vec_len [u] . out bytes )
     // TIME_WAIT expiry
@@ -586,9 +609,12 @@ $ `stdlib/net/tcpseg.nu`
     ? == . c state ( tcp_listen_st ) {
         ? has_rst { ^ 0 } {}
         // An ACK to a LISTEN socket is bogus — RST it (RFC 793 §3.4).
+        // The comment said so; the body assigned a field to itself and
+        // returned, so the peer got silence and kept retransmitting into
+        // a socket that was never going to answer.
         ? has_ack {
-            = . c remote_ip . c remote_ip
-            ^ 0
+            ( __emit_empty c out ( tcp_rst ) . s ack 0 )
+            ^ - ( vec_len [u] . out bytes ) before
         } {}
         ? has_syn {
             = . c remote_port . s src_port

--- a/stdlib/net/tcpstack.nu
+++ b/stdlib/net/tcpstack.nu
@@ -1,0 +1,583 @@
+// stdlib/net/tcpstack.nu — TCP over the sans-IO IPv4 stack.
+//
+// net/tcp.nu owns one connection's state machine and speaks in
+// segments. net/stack.nu owns Ethernet, ARP, routing and IPv4 and
+// speaks in frames. This is the layer between them: the table that says
+// which connection a segment belongs to, and the code that wraps a
+// segment in a datagram and hands it down.
+//
+// It is still sans-IO. Frames in, frames out, `now` supplied by the
+// caller:
+//
+//     ( tstack_rx  ts frame now out )  → TRx
+//     ( tstack_tick ts now out )       → i    (segments the timers produced)
+//
+// Nothing here allocates a socket, blocks, or reads a clock — the same
+// property that lets the whole stack run under a scripted clock on the
+// host also lets it run unmodified inside a unikernel. The socket shims
+// (phase A4) sit ON TOP of this and are where blocking appears.
+//
+// WHAT THIS LAYER ADDS OVER tcp.nu
+//
+//   * demultiplexing. A segment belongs to the connection whose
+//     four-tuple it matches; failing that, to a listener on its
+//     destination port; failing that, to nothing — and a segment that
+//     matches nothing gets a RST, because silence there is how a
+//     half-open peer is left retransmitting into a void.
+//   * the passive open. `tcp.nu` has a LISTEN state but no notion of
+//     "a listener spawns connections": a SYN to a listening port
+//     creates a NEW connection in SYN_RCVD and leaves the listener
+//     listening.
+//   * addressing. A Tcb emits segments; segments need a source and
+//     destination address to be checksummed at all, so the four-tuple
+//     lives here rather than in the state machine.
+//   * the ARP wait. The first segment to a new peer may leave before
+//     the peer's MAC is known. It is not queued — TCP already owns a
+//     retransmit timer, and using it is both less code and more honest
+//     than a second queue with its own drop policy.
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/tcpseg.nu`
+$ `stdlib/net/tcp.nu`
+$ `stdlib/net/stack.nu`
+
+// ── rx outcomes ──────────────────────────────────────────────────
+//
+// What the caller above (the socket layer) needs to know after a frame
+// went in. Anything not TCP-shaped is reported as `trx_other` with the
+// underlying RxResult kind, so a caller can still run UDP and ICMP
+// through the same door.
+
+@ trx_other → i { ^ 0 }  // not TCP — `kind` carries stack.nu's verdict
+
+@ trx_none → i { ^ 1 }  // TCP, consumed, nothing for the caller yet
+
+@ trx_data → i { ^ 2 }  // a connection has readable bytes
+
+@ trx_accepted → i { ^ 3 }  // a listener produced a new connection
+
+@ trx_closed → i { ^ 4 }  // a connection reached CLOSED
+
+@ trx_reset → i { ^ 5 }  // the peer reset us
+
+@ trx_no_conn → i { ^ 6 }  // matched nothing; a RST went out
+
+: TRx {
+    i result  // trx_*
+    i kind  // stack.nu's RxResult kind when result == trx_other
+    i conn  // index into the connection table, or -1
+    i emitted  // bytes appended to `out`
+}
+
+@ __trx i result i kind i conn i emitted → TRx {
+    ^ @ TRx { result kind conn emitted }
+}
+
+// ── the connection table ─────────────────────────────────────────
+//
+// A flat vector with a free list. Connections are identified to the
+// caller by INDEX, not by pointer: an index stays valid across a
+// reallocation and can cross the FFI boundary as an integer, which is
+// what the socket shims need. A generation counter makes a stale index
+// detectable rather than silently aliasing a recycled slot — the
+// use-after-close bug this table would otherwise invite.
+
+: TConn {
+    * Tcb tcb
+    i local_ip
+    i local_port
+    i remote_ip
+    i remote_port
+    i gen  // bumped on every reuse of this slot
+    b used
+    b passive  // arrived through a listener
+    i listener  // index of the listener that spawned it, or -1
+}
+
+: TListener {
+    i local_ip
+    i local_port
+    i backlog
+    ( Vec i ) pending  // connection indices waiting to be accepted
+    b used
+    i gen
+}
+
+: TcpStack {
+    * NetStack net
+    ( Vec i ) conns  // *TConn, as integers — NURL has no Vec of pointers
+    ( Vec i ) listeners  // *TListener, likewise
+    i iss  // initial send sequence, advanced per connection
+    i ephemeral  // next ephemeral local port
+    i rst_sent
+    i no_conn
+}
+
+@ __tconn_ptr * TcpStack ts i idx → *TConn {
+    ^ # *TConn ?? ( vec_get [i] . ts conns idx ) { T p → p F → 0 }
+}
+
+@ __tlisten_ptr * TcpStack ts i idx → *TListener {
+    ^ # *TListener ?? ( vec_get [i] . ts listeners idx ) { T p → p F → 0 }
+}
+
+@ tstack_new * NetStack net i iss_seed → *TcpStack {
+    : *TcpStack ts # *TcpStack ( nurl_alloc Z TcpStack )
+    = . ts net net
+    = . ts conns ( vec_new [i] )
+    = . ts listeners ( vec_new [i] )
+    = . ts iss iss_seed
+    = . ts ephemeral 49152
+    = . ts rst_sent 0
+    = . ts no_conn 0
+    ^ ts
+}
+
+@ tstack_free * TcpStack ts → v {
+    : i n ( vec_len [i] . ts conns )
+    : ~ i k 0
+    ~ < k n {
+        : *TConn c ( __tconn_ptr ts k )
+        ? != # i c 0 {
+            ? . c used { ( tcb_free . c tcb ) } {}
+            ( nurl_free # s c )
+        } {}
+        = k + k 1
+    }
+    ( vec_free [i] . ts conns )
+    : i m ( vec_len [i] . ts listeners )
+    : ~ i j 0
+    ~ < j m {
+        : *TListener l ( __tlisten_ptr ts j )
+        ? != # i l 0 {
+            ( vec_free [i] . l pending )
+            ( nurl_free # s l )
+        } {}
+        = j + j 1
+    }
+    ( vec_free [i] . ts listeners )
+    ( nurl_free # s ts )
+}
+
+// Take a free slot, or grow the table. The freed slots keep their
+// allocation so an index that was handed out and closed can still be
+// looked up and rejected by generation, rather than pointing at
+// whatever was allocated next.
+@ __conn_alloc * TcpStack ts → i {
+    : i n ( vec_len [i] . ts conns )
+    : ~ i k 0
+    ~ < k n {
+        : *TConn c ( __tconn_ptr ts k )
+        ? ! . c used {
+            = . c used T
+            = . c gen + . c gen 1
+            = . c tcb ( tcb_new )
+            = . c listener -1
+            = . c passive F
+            ^ k
+        } {}
+        = k + k 1
+    }
+    : *TConn c # *TConn ( nurl_alloc Z TConn )
+    = . c used T
+    = . c gen 1
+    = . c tcb ( tcb_new )
+    = . c listener -1
+    = . c passive F
+    ( vec_push [i] . ts conns # i c )
+    ^ n
+}
+
+@ __conn_release * TcpStack ts i idx → v {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ } {}
+    ? ! . c used { ^ } {}
+    ( tcb_free . c tcb )
+    = . c tcb # *Tcb 0
+    = . c used F
+}
+
+// Generation-checked accessor: the socket layer holds (index, gen)
+// pairs and every lookup goes through here, so a read on a closed
+// connection is an error rather than a read of the next connection to
+// take that slot.
+@ tstack_conn_live * TcpStack ts i idx i gen → b {
+    ? || < idx 0 >= idx ( vec_len [i] . ts conns ) { ^ F } {}
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ F } {}
+    ^ && . c used == . c gen gen
+}
+
+@ tstack_conn_gen * TcpStack ts i idx → i {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ 0 } {}
+    ^ . c gen
+}
+
+@ tstack_conn_tcb * TcpStack ts i idx → *Tcb {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ # *Tcb 0 } {}
+    ^ . c tcb
+}
+
+@ tstack_conn_state * TcpStack ts i idx → i {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ ( tcp_closed ) } {}
+    ? ! . c used { ^ ( tcp_closed ) } {}
+    ^ . . c tcb state
+}
+
+@ tstack_conn_peer_ip * TcpStack ts i idx → i {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ 0 } {}
+    ^ . c remote_ip
+}
+
+@ tstack_conn_peer_port * TcpStack ts i idx → i {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ 0 } {}
+    ^ . c remote_port
+}
+
+@ tstack_conn_local_port * TcpStack ts i idx → i {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ 0 } {}
+    ^ . c local_port
+}
+
+// ── listeners ────────────────────────────────────────────────────
+
+@ tstack_listen * TcpStack ts i local_ip i port i backlog → i {
+    : i n ( vec_len [i] . ts listeners )
+    : ~ i slot -1
+    : ~ i k 0
+    ~ < k n {
+        : *TListener l ( __tlisten_ptr ts k )
+        ? ! . l used { = slot k = k n } { = k + k 1 }
+    }
+    ? < slot 0 {
+        : *TListener l # *TListener ( nurl_alloc Z TListener )
+        = . l pending ( vec_new [i] )
+        = . l gen 0
+        ( vec_push [i] . ts listeners # i l )
+        = slot n
+    } {}
+    : *TListener l ( __tlisten_ptr ts slot )
+    = . l local_ip local_ip
+    = . l local_port port
+    = . l backlog ? > backlog 0 backlog 16
+    = . l used T
+    = . l gen + . l gen 1
+    ( vec_clear [i] . l pending )
+    ^ slot
+}
+
+@ tstack_listener_close * TcpStack ts i idx → v {
+    : *TListener l ( __tlisten_ptr ts idx )
+    ? == # i l 0 { ^ } {}
+    ( vec_clear [i] . l pending )
+    = . l used F
+}
+
+// Hand back the next connection this listener has completed, or -1.
+// A connection is only offered once — it moves out of `pending` here.
+@ tstack_accept * TcpStack ts i idx → i {
+    : *TListener l ( __tlisten_ptr ts idx )
+    ? == # i l 0 { ^ -1 } {}
+    ? ! . l used { ^ -1 } {}
+    ? == 0 ( vec_len [i] . l pending ) { ^ -1 } {}
+    : i c ?? ( vec_get [i] . l pending 0 ) { T v → v F → -1 }
+    ( vec_remove [i] . l pending 0 )
+    ^ c
+}
+
+@ tstack_pending_count * TcpStack ts i idx → i {
+    : *TListener l ( __tlisten_ptr ts idx )
+    ? == # i l 0 { ^ 0 } {}
+    ^ ( vec_len [i] . l pending )
+}
+
+// ── sending ──────────────────────────────────────────────────────
+
+// Drain a connection's TcpOut into `out` as IPv4 datagrams — one
+// datagram per SEGMENT, which is why TcpOut carries end offsets at all:
+// TCP has no length field of its own and concatenating segments into
+// one buffer is irreversible.
+@ __flush * TcpStack ts i idx * TcpOut o i now ( Vec u ) out → i {
+    : *TConn c ( __tconn_ptr ts idx )
+    : i nseg ( tcpout_count o )
+    : ~ i emitted 0
+    : ~ i k 0
+    ~ < k nseg {
+        : i s ( tcpout_seg_start o k )
+        : i n ( tcpout_seg_len o k )
+        // Straight from the TcpOut buffer — no temporary Vec, because
+        // the segment is already sitting there as a range.
+        : TxResult r ( stack_tx_ip4 . ts net . c remote_ip ( ip_proto_tcp ) . o bytes s n now out )
+        = emitted + emitted . r emitted
+        = k + k 1
+    }
+    ( tcpout_clear o )
+    ^ emitted
+}
+
+// ── receive ──────────────────────────────────────────────────────
+
+@ __find_conn * TcpStack ts i local_ip i local_port i remote_ip i remote_port → i {
+    : i n ( vec_len [i] . ts conns )
+    : ~ i k 0
+    ~ < k n {
+        : *TConn c ( __tconn_ptr ts k )
+        ? && . c used && == . c local_port local_port && == . c remote_port remote_port && == . c remote_ip remote_ip || == . c local_ip local_ip == . c local_ip 0 {
+            ^ k
+        } {}
+        = k + k 1
+    }
+    ^ -1
+}
+
+@ __find_listener * TcpStack ts i local_ip i port → i {
+    : i n ( vec_len [i] . ts listeners )
+    : ~ i k 0
+    ~ < k n {
+        : *TListener l ( __tlisten_ptr ts k )
+        ? && . l used && == . l local_port port || == . l local_ip local_ip == . l local_ip 0 {
+            ^ k
+        } {}
+        = k + k 1
+    }
+    ^ -1
+}
+
+// RFC 793: a segment that belongs to no connection is answered with a
+// RST, unless it IS a RST — which would loop forever between two hosts
+// that each think the other is confused.
+@ __send_rst * TcpStack ts i src_ip i dst_ip TcpSeg s i now ( Vec u ) out → i {
+    ? == & . s flags 4 4 { ^ 0 } {}
+    = . ts rst_sent + . ts rst_sent 1
+    : ( Vec u ) dg ( vec_new [u] )
+    : ( Vec u ) empty ( vec_new [u] )
+    // An ACKed segment is refused from its own ACK number and carries no
+    // ACK of its own; an unACKed one is refused with ACK = its sequence
+    // plus its length, which is what the peer is waiting to hear.
+    ? == & . s flags 16 16 {
+        ( tcpseg_push dg dst_ip src_ip . s dst_port . s src_port . s ack 0 4 0 0 -1 empty 0 0 )
+    } {
+        ( tcpseg_push dg dst_ip src_ip . s dst_port . s src_port 0
+        ( seq_add . s seq ( tcpseg_seq_len s ) ) 20 0 0 -1 empty 0 0 )
+    }
+    ( vec_free [u] empty )
+    : TxResult r ( stack_tx_ip4 . ts net src_ip ( ip_proto_tcp ) dg 0 ( vec_len [u] dg ) now out )
+    ( vec_free [u] dg )
+    ^ . r emitted
+}
+
+// A SYN to a listening port. The listener stays listening; a new
+// connection is created in SYN_RCVD and queued for accept.
+@ __passive_open * TcpStack ts i lidx i local_ip i local_port TcpSeg s i src_ip i now ( Vec u ) frame * TcpOut o ( Vec u ) out → TRx {
+    : *TListener l ( __tlisten_ptr ts lidx )
+    ? >= ( vec_len [i] . l pending ) . l backlog {
+        // The backlog is full. Dropping the SYN is what a listening
+        // socket does under load — the peer retransmits, and by then
+        // the queue may have drained. Answering RST would tell it the
+        // port is closed, which is a different and false thing.
+        ^ ( __trx ( trx_none ) 0 -1 0 )
+    } {}
+    : i idx ( __conn_alloc ts )
+    : *TConn c ( __tconn_ptr ts idx )
+    = . c local_ip local_ip
+    = . c local_port local_port
+    = . c remote_ip src_ip
+    = . c remote_port . s src_port
+    = . c passive T
+    = . c listener lidx
+    ( tcb_listen . c tcb local_ip local_port )
+    // The Tcb keeps its OWN four-tuple — it has to, because that is what
+    // the pseudo-header checksum is computed over — and tcb_input can
+    // only learn the ports from the segment: a TcpSeg carries no
+    // addresses, those live in the IP header this layer already parsed.
+    // Filling in TConn's copy and not the Tcb's leaves every segment the
+    // connection emits checksummed against 0.0.0.0, which the peer
+    // silently drops as corrupt. That is what it did.
+    = . . c tcb remote_ip src_ip
+    = . . c tcb remote_port . s src_port
+    = . . c tcb iss ( __next_iss ts )
+    : i r ( tcb_input . c tcb s frame now o )
+    : i emitted ( __flush ts idx o now out )
+    ( vec_push [i] . l pending idx )
+    ^ ( __trx ( trx_accepted ) 0 idx emitted )
+}
+
+@ __next_iss * TcpStack ts → i {
+    // A per-connection ISS that advances. RFC 793's clock-driven ISS is
+    // about old-duplicate protection across incarnations; TIME_WAIT
+    // covers that here, and a monotone step keeps the unit tests
+    // reproducible, which a clock-derived value would not.
+    = . ts iss ( seq_add . ts iss 64000 )
+    ^ . ts iss
+}
+
+// Feed one frame in. Non-TCP frames are handed to stack.nu and their
+// verdict passed straight through, so a caller can run one loop for
+// everything rather than two that disagree about which is authoritative.
+@ tstack_rx * TcpStack ts ( Vec u ) frame i now ( Vec u ) out → TRx {
+    : RxResult rr ( stack_rx . ts net frame now out )
+    ? != . rr kind ( rx_tcp ) {
+        ^ ( __trx ( trx_other ) . rr kind -1 . rr emitted )
+    } {}
+    : TcpSeg s ( tcpseg_parse frame . rr payload_off . rr payload_len . rr src_ip . rr dst_ip )
+    ? ! . s valid { ^ ( __trx ( trx_none ) 0 -1 0 ) } {}
+
+    : i idx ( __find_conn ts . rr dst_ip . s dst_port . rr src_ip . s src_port )
+    : *TcpOut o ( tcpout_new )
+    ? >= idx 0 {
+        : *TConn c ( __tconn_ptr ts idx )
+        : i before ( tcb_recv_queue_len . c tcb )
+        : i r ( tcb_input . c tcb s frame now o )
+        : i emitted ( __flush ts idx o now out )
+        ( tcpout_free o )
+        : i st . . c tcb state
+        ? . . c tcb reset {
+            ( __conn_release ts idx )
+            ^ ( __trx ( trx_reset ) 0 idx emitted )
+        } {}
+        ? == st ( tcp_closed ) {
+            ( __conn_release ts idx )
+            ^ ( __trx ( trx_closed ) 0 idx emitted )
+        } {}
+        ? > ( tcb_recv_queue_len . c tcb ) before {
+            ^ ( __trx ( trx_data ) 0 idx emitted )
+        } {}
+        ^ ( __trx ( trx_none ) 0 idx emitted )
+    } {}
+
+    // No connection. A SYN with no ACK may open one; anything else is
+    // addressed to a connection that does not exist.
+    ? && == & . s flags 2 2 != & . s flags 16 16 {
+        : i lidx ( __find_listener ts . rr dst_ip . s dst_port )
+        ? >= lidx 0 {
+            : TRx res ( __passive_open ts lidx . rr dst_ip . s dst_port s . rr src_ip now frame o out )
+            ( tcpout_free o )
+            ^ res
+        } {}
+    } {}
+    ( tcpout_free o )
+    = . ts no_conn + . ts no_conn 1
+    : i em ( __send_rst ts . rr src_ip . rr dst_ip s now out )
+    ^ ( __trx ( trx_no_conn ) 0 -1 em )
+}
+
+// ── active open ──────────────────────────────────────────────────
+
+@ __next_ephemeral * TcpStack ts → i {
+    = . ts ephemeral + . ts ephemeral 1
+    ? > . ts ephemeral 65535 { = . ts ephemeral 49152 } {}
+    ^ . ts ephemeral
+}
+
+// Start a connection. Returns its index; the caller polls
+// `tstack_conn_state` (or waits for the socket layer's wakeup) for
+// ESTABLISHED. A SYN that could not be framed because ARP has not
+// resolved yet is NOT an error — the retransmit timer will send it.
+@ tstack_connect * TcpStack ts i remote_ip i remote_port i local_port i now ( Vec u ) out → i {
+    : i idx ( __conn_alloc ts )
+    : *TConn c ( __tconn_ptr ts idx )
+    = . c local_ip . . ts net our_ip
+    = . c local_port ? > local_port 0 local_port ( __next_ephemeral ts )
+    = . c remote_ip remote_ip
+    = . c remote_port remote_port
+    : *TcpOut o ( tcpout_new )
+    ( tcb_connect . c tcb . c local_ip . c local_port remote_ip remote_port ( __next_iss ts ) now o )
+    ( __flush ts idx o now out )
+    ( tcpout_free o )
+    ^ idx
+}
+
+// ── the rest of the socket surface, as pure logic ────────────────
+
+@ tstack_write * TcpStack ts i idx ( Vec u ) data i off i len i now ( Vec u ) out → i {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ -1 } {}
+    ? ! . c used { ^ -1 } {}
+    : i n ( tcb_write . c tcb data off len 65536 )
+    : *TcpOut o ( tcpout_new )
+    ( tcb_pump . c tcb now o )
+    ( __flush ts idx o now out )
+    ( tcpout_free o )
+    ^ n
+}
+
+@ tstack_read * TcpStack ts i idx ( Vec u ) dst i n → i {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ -1 } {}
+    ? ! . c used { ^ -1 } {}
+    ^ ( tcb_read . c tcb dst n )
+}
+
+@ tstack_close * TcpStack ts i idx i now ( Vec u ) out → v {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ } {}
+    ? ! . c used { ^ } {}
+    : *TcpOut o ( tcpout_new )
+    ( tcb_close . c tcb now o )
+    ( __flush ts idx o now out )
+    ( tcpout_free o )
+    ? == . . c tcb state ( tcp_closed ) { ( __conn_release ts idx ) } {}
+}
+
+@ tstack_abort * TcpStack ts i idx i now ( Vec u ) out → v {
+    : *TConn c ( __tconn_ptr ts idx )
+    ? == # i c 0 { ^ } {}
+    ? ! . c used { ^ } {}
+    : *TcpOut o ( tcpout_new )
+    ( tcb_abort . c tcb o )
+    ( __flush ts idx o now out )
+    ( tcpout_free o )
+    ( __conn_release ts idx )
+}
+
+// ── timers ───────────────────────────────────────────────────────
+//
+// Every connection's retransmit, persist and TIME_WAIT timer, plus the
+// ARP cache's own expiry. Returns the number of frames emitted, so a
+// caller that wants to know whether the loop did anything does not have
+// to diff the output buffer.
+@ tstack_tick * TcpStack ts i now ( Vec u ) out → i {
+    ( stack_tick . ts net now out )
+    : i n ( vec_len [i] . ts conns )
+    : ~ i emitted 0
+    : ~ i k 0
+    ~ < k n {
+        : *TConn c ( __tconn_ptr ts k )
+        ? && != # i c 0 . c used {
+            : *TcpOut o ( tcpout_new )
+            : i fired ( tcb_tick . c tcb now o )
+            = emitted + emitted ( __flush ts k o now out )
+            ( tcpout_free o )
+            ? == . . c tcb state ( tcp_closed ) { ( __conn_release ts k ) } {}
+        } {}
+        = k + k 1
+    }
+    ^ emitted
+}
+
+// The earliest deadline any connection is waiting on, or -1 when none
+// is. An event loop that has nothing else to do sleeps until this
+// rather than spinning — the difference between a guest that idles and
+// one that burns its only vCPU.
+@ tstack_next_timeout * TcpStack ts i now → i {
+    : i n ( vec_len [i] . ts conns )
+    : ~ i best -1
+    : ~ i k 0
+    ~ < k n {
+        : *TConn c ( __tconn_ptr ts k )
+        ? && != # i c 0 . c used {
+            : i d ( tcb_next_timeout . c tcb now )
+            ? >= d 0 { ? || < best 0 < d best { = best d } {} } {}
+        } {}
+        = k + k 1
+    }
+    ^ best
+}


### PR DESCRIPTION
`net/tcp.nu` owns one connection and speaks in segments. `net/stack.nu`
owns Ethernet, ARP, routing and IPv4 and speaks in frames. Nothing
joined them: `stack_rx` answered proto 6 with `drop_unknown_proto`, and
a Tcb emitting a segment had no way to get it onto a wire.

`net/tcpstack.nu` is that layer, and it is still sans-IO — frames in,
frames out, `now` from the caller. What it adds is what neither
neighbour could:

* **demultiplexing** by four-tuple, with a listener table under it;
* **the passive open** — `tcp.nu` has a LISTEN state but no notion of a
  listener *spawning* connections;
* **addressing**, because a segment cannot be checksummed without one;
* **a RST for a segment that belongs to nothing** — and no RST for a
  RST, or two hosts trade them forever.

`stack.nu` gains `stack_tx_ip4`, factored out of `stack_tx_udp`:
routing, ARP and the two headers now happen in one place, so TCP and
UDP resolve a next hop by the same code and a fix to it fixes both.

The first segment to an unresolved peer is **not queued**. TCP already
owns a retransmit timer, and using it is both less code and more honest
than a second queue with its own drop policy — the test asserts that
the first frame out of `tstack_connect` is an ARP request and that the
RTO is what finally sends the SYN.

Connections are identified by **index with a generation counter**, not
by pointer: an index survives a table reallocation, crosses an FFI
boundary as an integer (which the A4.2 shims need), and a stale one is
detectably stale rather than silently aliasing whatever took the slot.

## Three findings

**A passively-opened connection checksummed every segment against
0.0.0.0.** A `TcpSeg` carries no addresses — they live in the IP header
— so `tcb_input` can learn the peer's *ports* from a SYN and never its
address. The table's copy of the four-tuple was filled and the Tcb's
was not, so B's SYN-ACK went out with a checksum over the wrong
pseudo-header and A dropped it as corrupt: a silent handshake failure
with no error anywhere. Only an end-to-end frame-level rig catches
this; `net_tcp.nu` hands segments over directly and never computes the
checksum the receiver will check.

**`tcp.nu` promised a RST it did not send.** The LISTEN branch's ACK
case carried the comment "An ACK to a LISTEN socket is bogus — RST it
(RFC 793 §3.4)" over a body that assigned a field to itself and
returned. The peer got silence and kept retransmitting into a socket
that was never going to answer.

**`vec_extend` could only copy whole vectors**, so a caller holding a
sub-range had to build a temporary Vec to pass it — a full copy plus an
allocation and a free, to move bytes it already had. Every outgoing TCP
segment hit this, because TCP has no length field and the segments
arrive as offsets into one buffer. `vec_extend_range` removes the copy;
out-of-range requests clamp rather than trap, since a caller computing
a range from a parsed header should not have to re-verify what the
vector can already answer.

`tcp.nu` also gains `tcb_next_timeout`: it kept three absolute
deadlines and could act on them, but could not answer the question an
event loop asks — with nothing runnable, how long may I sleep? Without
it a guest with one vCPU can only poll.

## Gate

`net_tcpstack`: 36 assertions over two stacks wired frame-to-frame
under a scripted clock, including two connections from the same peer to
the same port (the case a table keyed on less than the four-tuple gets
wrong) and reclamation by all three routes out — RST, FIN, and the
TIME_WAIT timer. Leak-clean under LSan and pinned in the CI leak gate:
this stack is bound for a machine with no process exit to sweep up
after it.

Corpus 607 PASS. Zero FFI in `stdlib/net/` protocol modules, still
grep-checkable.

Next in A4: the event loop and the fiber park/wake seam, which the plan
calls the riskiest joint in the whole design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1