### PR TITLE
A4.3: a socket wait parks on its fd — the livelock is gone, 446 PASS / 0 FAIL with no libc

### DIFF
--- a/stdlib/net/socket.nu
+++ b/stdlib/net/socket.nu
@@ -658,6 +658,14 @@ $ `stdlib/net/tcpstack.nu`
 @ sock_close * SockTab st i fd i now → v {
     : *Sock s ( __sock st fd )
     ? == # i s 0 { ^ } {}
+    // Closed is closed, whoever else still holds a reference. A pooled
+    // server retains its listener for the spawn→join window precisely
+    // so a concurrent stop cannot free the handle underneath the
+    // workers — and those workers are parked in accept, waiting for
+    // this fd to say something. Marking it shut is what says it: the
+    // waiters wake, `sock_accept` refuses, and the last reference
+    // releases the connection.
+    = . s shut T
     = . s refs - . s refs 1
     ? > . s refs 0 { ^ } {}
     ? == . s kind ( sock_kind_listener ) {

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -46,8 +46,8 @@ worth anything.
 ## State (2026-08-05)
 
 ```
-  PASS         444    corpus tests that build and run with no libc at all
-  FAIL           2    http2_client, http_server_stop_direct — see below
+  PASS         446    corpus tests that build and run with no libc at all
+  FAIL           0
   NEEDS-BARE    24    processes, signals, UDP, DNS
   NEEDS-LIBM     0
   NEEDS-NOLIBC   7    realpath, mkstemp, inotify, execvp, unix sockets
@@ -55,23 +55,14 @@ worth anything.
   SKIP         144    compile-fail tests and tests with no standalone build
 ```
 
-TCP is in that PASS column now. `async_tcp`, `async_http_server`,
-`http_server_pool`, `websocket_client`, `net_basic` and the rest run a
-real client and a real server against each other with no kernel
-sockets anywhere: `unikernel/net/sockets.nu` implements the socket ABI
-in NURL over the sans-IO stack, the frames go around a loopback that is
-literally "what this stack emits, it receives", and the blocking reads
-park on the cooperative scheduler.
-
-The two FAILs are one open problem, and it is named rather than
-counted: **two waiters can livelock**. A wait on the main context and a
-wait inside a coroutine each conclude the other is making progress —
-main's scheduler step returns "something ran" because it ran the
-coroutine, and the coroutine yields because main is not parked in the
-scheduler — so neither ever reports the wait as hopeless. The fix is
-for a socket wait to PARK on the fd rather than poll, which also gives
-the virtio-net driver the wake-up path it will want; until then those
-two tests spin until the runner's timeout.
+TCP is in that PASS column. `async_tcp`, `async_http_server`,
+`http_server_pool`, `http_server_stop_direct`, `websocket_client`,
+`http2_client`, `net_basic` and the rest run a real client and a real
+server against each other with no kernel sockets anywhere:
+`unikernel/net/sockets.nu` implements the socket ABI in NURL over the
+sans-IO stack, the frames go around a loopback that is literally "what
+this stack emits, it receives", and a blocking read PARKS on its fd —
+so the scheduler can still say "nothing can run" and mean it.
 
 The bucket a blocked test lands in is **measured**, not listed: each
 missing symbol is looked up with `nm` in the hosted `stdlib/runtime.o`

--- a/unikernel/net/sockets.nu
+++ b/unikernel/net/sockets.nu
@@ -78,11 +78,25 @@ $ `stdlib/net/socket.nu`
 
 & `c` @ nurl_fiber_sleep_ms i ms → i
 
+// Park the current coroutine until it is unparked or `ms` pass
+// (ms < 0 = no deadline). 1 = woken, 0 = the deadline passed, -1 = not
+// on a coroutine. This is what a socket wait uses INSTEAD of polling.
+& `c` @ nurl_bare_park_ms i ms → i
+
+& `c` @ nurl_fiber_unpark i handle → v
+
 : Shim {
     * NetStack net
     * TcpStack ts
     * SockTab st
     ( Vec i ) peer  // cached "ip:port" per fd slot — see nurl_tcp_peer_addr
+    // The waiter registry: who is parked on which fd. Three parallel
+    // vectors rather than a vector of structs, because a Vec of
+    // pointers is not a thing here and the three are always written
+    // together. `coro` 0 means the slot is free.
+    ( Vec i ) w_fd
+    ( Vec i ) w_wr
+    ( Vec i ) w_coro
     i has_device
 }
 
@@ -108,6 +122,9 @@ $ `stdlib/net/socket.nu`
     = . sh ts ( tstack_new . sh net & now 4294967295 )
     = . sh st ( sock_new . sh ts ( __lo_ip ) )
     = . sh peer ( vec_new [i] )
+    = . sh w_fd ( vec_new [i] )
+    = . sh w_wr ( vec_new [i] )
+    = . sh w_coro ( vec_new [i] )
     = . sh has_device 0
     // An interface knows its own MAC. Without this the first connect
     // to 127.0.0.1 ARPs for itself and waits a retransmit timeout for
@@ -119,14 +136,71 @@ $ `stdlib/net/socket.nu`
 
 @ __tab → *SockTab { ^ . ( __shim ) st }
 
+// ── the waiter registry ──────────────────────────────────────────
+//
+// A coroutine waiting on an fd PARKS, and whoever moves the stack wakes
+// it. The alternative — polling — is what this file did first, and the
+// cost is not efficiency: a polling waiter is RUNNABLE, so the
+// scheduler can never say "nothing can run", which is the one statement
+// this runtime exists to be able to make. Two pollers then each
+// conclude the other is making progress and neither ever gives up.
+
+@ __waiter_add i fd i for_write → i {
+    : *Shim sh ( __shim )
+    : i me ( nurl_fiber_current )
+    ? == me 0 { ^ -1 } {}  // the main context cannot park inside itself
+    : i n ( vec_len [i] . sh w_coro )
+    : ~ i k 0
+    ~ < k n {
+        ? == 0 ?? ( vec_get [i] . sh w_coro k ) { T x → x F → 1 } {
+            : b _a ( vec_set [i] . sh w_fd k fd )
+            : b _b ( vec_set [i] . sh w_wr k for_write )
+            : b _c ( vec_set [i] . sh w_coro k me )
+            ^ k
+        } {}
+        = k + k 1
+    }
+    ( vec_push [i] . sh w_fd fd )
+    ( vec_push [i] . sh w_wr for_write )
+    ( vec_push [i] . sh w_coro me )
+    ^ n
+}
+
+@ __waiter_del i slot → v {
+    ? < slot 0 { ^ } {}
+    : *Shim sh ( __shim )
+    ? >= slot ( vec_len [i] . sh w_coro ) { ^ } {}
+    : b _ok ( vec_set [i] . sh w_coro slot 0 )
+}
+
+// Wake every parked waiter whose fd has become ready. Called after
+// anything that can change readiness — frames delivered, a timer fired,
+// a shutdown. Unparking a coroutine that is not parked is banked as a
+// permit by the runtime, so waking one that is mid-check is harmless.
+@ __wake_ready → v {
+    : *Shim sh ( __shim )
+    : i me ( nurl_fiber_current )
+    : i n ( vec_len [i] . sh w_coro )
+    : ~ i k 0
+    ~ < k n {
+        : i coro ?? ( vec_get [i] . sh w_coro k ) { T x → x F → 0 }
+        ? && != coro 0 != coro me {
+            : i fd ?? ( vec_get [i] . sh w_fd k ) { T x → x F → 0 }
+            : i wr ?? ( vec_get [i] . sh w_wr k ) { T x → x F → 0 }
+            ? ( __ready fd wr ) { ( nurl_fiber_unpark coro ) } {}
+        } {}
+        = k + k 1
+    }
+}
+
 // ── driving the machine ──────────────────────────────────────────
 
 // One turn of the event loop: deliver what the stack has queued, then
 // let its timers run. Returns 1 if anything happened.
 @ __drive i now → i {
     : *SockTab st ( __tab )
-    ? > ( sock_loopback st now ) 0 { ^ 1 } {}
-    ? > ( sock_tick st now ) 0 { ^ 1 } {}
+    ? > ( sock_loopback st now ) 0 { ( __wake_ready ) ^ 1 } {}
+    ? > ( sock_tick st now ) 0 { ( __wake_ready ) ^ 1 } {}
     ^ 0
 }
 
@@ -136,58 +210,60 @@ $ `stdlib/net/socket.nu`
     ^ ( sock_readable st fd )
 }
 
+// How long may this waiter park? The earliest of the stack's own next
+// deadline (a retransmit, a persist probe, TIME_WAIT) and whatever is
+// left of the caller's timeout. -1 = neither: park until woken, and if
+// nobody ever does, the scheduler's own detector says so — with every
+// waiter parked and no timer armed, "nothing is runnable" is a proof
+// again rather than a symptom.
+@ __park_ms i now i timeout_ms i start → i {
+    : i tmo ( sock_next_timeout ( __tab ) now )
+    : ~ i d -1
+    ? >= tmo 0 { = d ? > tmo 0 tmo 1 } {}
+    ? > timeout_ms 0 {
+        : i left - timeout_ms - now start
+        : i l ? > left 0 left 0
+        ? || < d 0 < l d { = d l } {}
+    } {}
+    ^ d
+}
+
 // Wait until `fd` is ready. 1 = ready, 0 = the deadline passed,
 // -1 = nothing can ever make it ready (see the header).
+//
+// On a coroutine this PARKS: it registers on the fd, and whoever moves
+// the stack wakes it. On the main context — which cannot park inside
+// the scheduler it is — it drives the scheduler a step at a time, and a
+// step that runs nothing, with no frames queued and no device, is the
+// end of the road for this wait.
 @ __wait i fd i for_write i timeout_ms → i {
     : i start ( __ms )
-    ~ T {
-        ? ( __ready fd for_write ) { ^ 1 } {}
-        : i now ( __ms )
-        ? == ( __drive now ) 0 {
-            // The stack is quiet. Somebody else may still produce work.
-            ? != ( nurl_fiber_current ) 0 {
-                // On a coroutine, yielding is right whenever ANYTHING
-                // else can run — and the main context counts even
-                // though it is never in the run queue. Reading only the
-                // run queue here declared a deadlock in the commonest
-                // shape there is: a server coroutine waiting for a
-                // request while the client on the main context was
-                // still writing it.
-                ? || > ( nurl_bare_runnable ) 0 == ( nurl_bare_blocked ) 0 {
-                    ( nurl_fiber_yield )
+    : i slot ( __waiter_add fd for_write )
+    : ~ i rc -1
+    : ~ b again T
+    ~ again {
+        ? ( __ready fd for_write ) { = rc 1 = again F } {
+            : i now ( __ms )
+            : i moved ( __drive now )
+            ? ( __ready fd for_write ) { = rc 1 = again F } {
+                ? >= slot 0 {
+                    : i unused ( nurl_bare_park_ms ( __park_ms now timeout_ms start ) )
                 } {
-                    // Main is parked in the scheduler and the run queue
-                    // is empty: yielding would hand control to a
-                    // context that hands it straight back, and a run
-                    // queue that never empties is one whose idle path
-                    // never sleeps. Park on the earliest deadline
-                    // instead — with no frames queued and nothing
-                    // runnable, nothing can change this fd's readiness
-                    // before then.
-                    : i t ( nurl_bare_timer_ms )
-                    ? >= t 0 {
-                        : i unused ( nurl_fiber_sleep_ms ? > t 1 t 1 )
-                    } {
-                        // Nothing runnable, no timer, main blocked, no
-                        // device: this fd will never be ready.
-                        ? == . ( __shim ) has_device 0 { ^ -1 } {}
-                        ( nurl_fiber_yield )
-                    }
-                } {}
-            } {
-                // On the main context a step also SLEEPS when the only
-                // pending work is a timer, so an idle machine idles
-                // rather than burning its one vCPU.
-                ? == ( nurl_bare_poll ) 0 {
-                    ? == . ( __shim ) has_device 0 { ^ -1 } {}
+                    ? == ( nurl_bare_poll ) 0 {
+                        ? && == 0 ( sock_pending_frames ( __tab ) ) == 0 . ( __shim ) has_device {
+                            = rc -1
+                            = again F
+                        } {}
+                    } {}
+                }
+                ? && again > timeout_ms 0 {
+                    ? >= - ( __ms ) start timeout_ms { = rc 0 = again F } {}
                 } {}
             }
-        } {}
-        ? > timeout_ms 0 {
-            ? >= - ( __ms ) start timeout_ms { ^ 0 } {}
-        } {}
+        }
     }
-    ^ 0
+    ( __waiter_del slot )
+    ^ rc
 }
 
 // The blocking/non-blocking decision, in one place. Returns 1 when the
@@ -220,12 +296,23 @@ $ `stdlib/net/socket.nu`
 
 @ nurl_tcp_unref i handle → v { ( nurl_tcp_close handle ) }
 
-@ nurl_tcp_shutdown i handle → v { ( sock_shutdown ( __tab ) handle ) }
+@ nurl_tcp_shutdown i handle → v {
+    ( sock_shutdown ( __tab ) handle )
+    // A shut fd reports itself ready so a waiter wakes and finds the
+    // error — but only if something wakes it. Nothing else will: this
+    // path emits no frames.
+    ( __wake_ready )
+}
 
 @ nurl_tcp_close i handle → v {
     : *Shim sh ( __shim )
     ( __peer_forget sh handle )
     ( sock_close . sh st handle ( __ms ) )
+    // Anyone parked on this fd has to wake and find it gone. Closing a
+    // listener from another context IS how a server is stopped — the
+    // workers are parked in accept and nothing else is going to move
+    // the stack on their behalf.
+    ( __wake_ready )
     // Give the FIN a chance to leave and be answered. A close that
     // returns before its own frames are on the wire would strand the
     // peer on a connection this side has already forgotten — on a

--- a/unikernel/runtime_bare.c
+++ b/unikernel/runtime_bare.c
@@ -176,6 +176,8 @@ struct NbCoro {
                                    * one such list at a time           */
     void        *pending_unlock;  /* NbMutex* released after swap-out  */
     int          last_park_result;
+    int          wake_pending;    /* an unpark that arrived before the
+                                   * park — consumed by the next park   */
 };
 
 /* Defined in §8 — named here because §7's scheduler step performs the
@@ -266,6 +268,20 @@ static void nb_timer_add(NbCoro *c, long long at) {
 }
 
 /* Move every expired timer back to the run queue. Returns how many. */
+/* Take `c` off the timer list, if it is on it. Needed the moment a
+ * coroutine can be woken by something OTHER than its own deadline: a
+ * wake that only pushed it to the run queue would leave it on the timer
+ * list too, and the later expiry would push it a SECOND time — one
+ * coroutine on the run queue twice, which is the same object running in
+ * two places as far as the scheduler is concerned. */
+static void nb_timer_remove(NbCoro *c) {
+    NbCoro **pp = &nb_timers;
+    while (*pp) {
+        if (*pp == c) { *pp = c->tnext; c->tnext = 0; return; }
+        pp = &(*pp)->tnext;
+    }
+}
+
 static int nb_timers_expire(long long now) {
     int n = 0;
     while (nb_timers && nb_timers->wake_at_ms <= now) {
@@ -858,6 +874,14 @@ long long nurl_fiber_worker_id(void) { return nb_current ? 0 : -1; }
 
 void nurl_fiber_park_with_mutex(long long mutex_h) {
     if (!nb_current) return;             /* same as hosted: no-op off-fiber */
+    if (nb_current->wake_pending) {
+        /* Already woken. Do not park — but the mutex still has to be
+         * released, because the caller handed it over expecting the
+         * scheduler to drop it on the way out. */
+        nb_current->wake_pending = 0;
+        if (mutex_h) nurl__bare_mutex_release((void *)(unsigned long)mutex_h);
+        return;
+    }
     nb_current->pending_unlock = (void *)(unsigned long)mutex_h;
     nb_park();
 }
@@ -865,8 +889,46 @@ void nurl_fiber_park_with_mutex(long long mutex_h) {
 void nurl_fiber_unpark(long long h) {
     NbCoro *c = (NbCoro *)(unsigned long)h;
     if (!c) return;
+    /* Only a PARKED coroutine goes back on the run queue. Unparking one
+     * that is already runnable (or running) would enqueue it twice — the
+     * same object running in two places as far as the scheduler is
+     * concerned — and a waiter that several parties may wake gets
+     * exactly that unless the state is checked here, once, rather than
+     * at every call site.
+     *
+     * An unpark that arrives BEFORE the park is not lost, it is banked:
+     * the coroutine that is about to park consumes the permit and does
+     * not park at all. Without that, "decide to wait" and "wait" are two
+     * steps with a window between them, which is the lost-wakeup hang
+     * every park/unpark pair has to answer for. */
+    if (c->state != NB_PARKED) { c->wake_pending = 1; return; }
+    nb_timer_remove(c);               /* it may have parked with a deadline */
+    c->last_park_result = 1;          /* woken, not timed out */
     c->state = NB_RUNNABLE;
     nb_rq_push(c);
+}
+
+/* Park until someone unparks this coroutine, or until `ms` have passed
+ * (ms < 0 = no deadline). 1 = woken by an unpark, 0 = the deadline
+ * passed — the reactor ABI, which is what the socket layer above needs:
+ * a wait on an fd is woken by whoever makes it ready, and by the
+ * protocol's own retransmit timer when nobody does.
+ *
+ * This is what a socket wait uses INSTEAD of polling, and the
+ * difference is not efficiency. A polling waiter is RUNNABLE, so the
+ * scheduler can never say "nothing can run" — the one statement this
+ * runtime exists to be able to make. Parked, it is invisible to the run
+ * queue, and a machine whose every waiter is parked with no timer armed
+ * is provably stuck rather than merely quiet. */
+long long nurl_bare_park_ms(long long ms) {
+    NbCoro *c = nb_current;
+    if (!c) return -1;                /* main cannot park inside itself */
+    if (c->wake_pending) { c->wake_pending = 0; return 1; }
+    c->last_park_result = 0;
+    if (ms >= 0) nb_timer_add(c, nb_now_ms() + ms);
+    nb_park();
+    if (ms >= 0) nb_timer_remove(c);  /* no-op unless the wake beat it */
+    return c->last_park_result;
 }
 
 void nurl_fiber_join(long long h) {


### PR DESCRIPTION
Follow-up to #777, which left one problem named rather than counted: two waiters could **livelock**. This closes it.

```
  nolibc corpus:  PASS 444 → 446,  FAIL 2 → 0
```

`http2_client` and `http_server_stop_direct` used to spin until the runner killed them. They pass.

## Why polling was the wrong shape, not just the slow one

The socket wait loop polled: drive the stack, yield, re-test. A polling waiter is RUNNABLE, so the scheduler can never say "nothing can run" — the one statement this runtime exists to be able to make. Two pollers then each conclude the other is progressing: main's scheduler step returns "something ran" because it ran the coroutine, and the coroutine yields because main is not parked in the scheduler. Neither ever gives up.

A waiting coroutine now registers on its fd and **parks**. Whoever moves the stack — delivers frames, expires a timer, closes a handle, shuts a listener down — wakes the waiters whose fd has become ready. Parked waiters are invisible to the run queue, so an empty run queue with no timer armed is a proof again rather than a symptom.

## Three pieces, each at its own level

**`runtime_bare.c` — park with a deadline, and an unpark that cannot lose or duplicate a wakeup.** `nurl_bare_park_ms(ms)` parks until unparked or until the deadline (the reactor ABI: 1 = woken, 0 = timed out). Two things had to become true for that to be safe:

- a wake has to take the coroutine **off the timer list**, or the later expiry pushes it to the run queue a second time — one coroutine on the run queue twice is the same object running in two places as far as the scheduler is concerned;
- an unpark that arrives **before** the park has to be banked as a permit rather than dropped. "Decide to wait" and "wait" are two steps, and the window between them is where every park/unpark pair loses a wakeup.

The previous unpark did neither. It happened to be safe only because nothing could yet wake a sleeper.

**`stdlib/net/socket.nu` — closed is closed, whoever else holds a reference.** A pooled server retains its listener for the spawn→join window precisely so a concurrent `server_stop` cannot free the handle underneath the workers (critic B19), and those workers are parked in accept waiting for that fd to say something. `sock_close` decremented the refcount and returned, saying nothing, so the wake never came — and the machine correctly reported a deadlock rather than hanging, which is how this was found. It now marks the handle shut on the way down: the waiters wake, `sock_accept` refuses, and the last reference releases the connection. That is what the hosted runtime does with its `shutting_down` flag and its self-pipe.

**`unikernel/net/sockets.nu` — the waiter registry.** Who is parked on which fd, plus a wake after anything that can change readiness. A waiter parks until the earliest of the stack's own next deadline (retransmit, persist probe, TIME_WAIT) and whatever is left of the caller's timeout; with neither, it parks until woken, and if nobody ever does, the scheduler's own detector says so.

## Verification

- `unikernel/run_nolibc_tests.sh`: **446 PASS / 0 FAIL**; what remains is processes, signals, UDP and DNS (NEEDS-BARE 24), plus the third-party libraries a unikernel never links.
- `./build.sh` green — hosted corpus 608 PASS, bootstrap fixed point held.
- `unikernel/tests/run_unit_tests.sh` green, including the timer-starvation gate added in #777.
- `net_socket`, `net_tcpstack`, `async_basic` clean under LSan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1