### PR TITLE
A4.4: UDP and name resolution over the sans-IO stack — 449 PASS / 0 FAIL with no libc

### DIFF
--- a/compiler/tests/net_socket.nu
+++ b/compiler/tests/net_socket.nu
@@ -219,6 +219,62 @@ $ `stdlib/net/socket.nu`
     ( sock_close st s3 6000 )
     ( pb `and is gone after the second: ` == ( sock_kind st s3 ) ( sock_kind_free ) )
 
+    // ── UDP: a mailbox, not a stream ─────────────────────────────
+    // Same fd semantics as TCP — ephemeral bind, ADDRINUSE, `again` on
+    // an empty mailbox — over a protocol with none of TCP's machinery.
+    : i us ( sock_udp_bind st ( lo_ip ) 0 )
+    : i uc ( sock_udp_bind st ( lo_ip ) 0 )
+    : i usp ( sock_local_port st us )
+    ( pb `a UDP bind picks a port: ` && > usp 0 != usp ( sock_local_port st uc ) )
+    ( pb `an empty mailbox says "again": ` == ( sock_udp_recv_from st us scratch 64 ) ( again ) )
+    ( pb `and is not readable: ` ! ( sock_readable st us ) )
+    ( pb `but a datagram socket is always writable: ` ( sock_writable st us ) )
+    : i udup ( sock_udp_bind st ( lo_ip ) usp )
+    ( pb `a second bind on a taken UDP port is refused: ` == ( sock_err st udup ) ( sock_err_addr_in_use ) )
+    ( sock_close st udup 8000 )
+    // …and TCP's port space is a different one: the same number is
+    // free for a listener.
+    : i tsame ( sock_listen st ( lo_ip ) usp 1 )
+    ( pb `the same number is free for TCP: ` == 0 ( sock_err st tsame ) )
+    ( sock_close st tsame 8000 )
+
+    : ( Vec u ) ping ( vec_new [u] )
+    ( bytes_extend_str ping `ping` )
+    ( pb `send_to reports what it sent: ` == 4 ( sock_udp_send_to st uc ( lo_ip ) usp ping 0 4 8000 ) )
+    ( pump st 8000 8 )
+    ( pb `the datagram arrived: ` == 1 ( sock_udp_pending st us ) )
+    ( pb `and the socket is readable: ` ( sock_readable st us ) )
+    : ( Vec u ) ugot ( vec_new [u] )
+    ( pb `recv_from returns the payload: ` == 4 ( sock_udp_recv_from st us ugot 64 ) )
+    ( pb `with the bytes intact: ` ( bytes_eq ugot ping ) )
+    ( pb `and the sender's port: ` == ( sock_udp_last_port st us ) ( sock_local_port st uc ) )
+    ( pb `the mailbox is empty again: ` == ( sock_udp_recv_from st us ugot 64 ) ( again ) )
+
+    // Datagram boundaries are the point: two sends are two receives,
+    // never one concatenation, and a short read truncates the rest of
+    // THAT datagram rather than leaving it queued.
+    ( sock_udp_send_to st uc ( lo_ip ) usp ping 0 4 8100 )
+    ( sock_udp_send_to st uc ( lo_ip ) usp ping 0 2 8100 )
+    ( pump st 8100 8 )
+    ( pb `two sends are two datagrams: ` == 2 ( sock_udp_pending st us ) )
+    : ( Vec u ) u1 ( vec_new [u] )
+    ( pb `a short read truncates its own datagram: ` == 2 ( sock_udp_recv_from st us u1 2 ) )
+    ( pb `and the next read is the NEXT datagram: ` == 2 ( sock_udp_recv_from st us u1 64 ) )
+    ( pb `not the remainder of the first: ` == 0 ( sock_udp_pending st us ) )
+
+    // connect() on a datagram socket records a default peer.
+    ( sock_udp_connect st uc ( lo_ip ) usp )
+    ( pb `connect records a peer: ` ( sock_udp_is_connected st uc ) )
+    ( pb `send with no address uses it: ` == 4 ( sock_udp_send st uc ping 0 4 8200 ) )
+    ( pump st 8200 8 )
+    ( pb `and it arrives: ` == 1 ( sock_udp_pending st us ) )
+    ( sock_udp_recv_from st us u1 64 )
+    ( pb `send without a peer is an error, not a silent drop: ` == ( sock_udp_send st us ping 0 4 8300 ) - 0 ( sock_err_write ) )
+
+    ( sock_close st us 8400 )
+    ( sock_close st uc 8400 )
+    ( vec_free [u] ping ) ( vec_free [u] ugot ) ( vec_free [u] u1 )
+
     // ── a stack that knows its own address ───────────────────────
     // Everything above resolved 127.0.0.1 by asking the wire for it and
     // waiting a retransmit timeout for the answer. An interface knows

--- a/compiler/tests/outputs/net_socket.txt
+++ b/compiler/tests/outputs/net_socket.txt
@@ -56,6 +56,27 @@ accept on a shut listener fails rather than waiting: ok
 and a shut fd reports itself readable: ok
 a referenced fd survives one close: ok
 and is gone after the second: ok
+a UDP bind picks a port: ok
+an empty mailbox says "again": ok
+and is not readable: ok
+but a datagram socket is always writable: ok
+a second bind on a taken UDP port is refused: ok
+the same number is free for TCP: ok
+send_to reports what it sent: ok
+the datagram arrived: ok
+and the socket is readable: ok
+recv_from returns the payload: ok
+with the bytes intact: ok
+and the sender's port: ok
+the mailbox is empty again: ok
+two sends are two datagrams: ok
+a short read truncates its own datagram: ok
+and the next read is the NEXT datagram: ok
+not the remainder of the first: ok
+connect records a peer: ok
+send with no address uses it: ok
+and it arrives: ok
+send without a peer is an error, not a silent drop: ok
 the seeded stack sends the SYN, not an ARP request: ok
 and connects with no retransmit at all: ok
 the far end accepted it: ok

--- a/stdlib/net/pktbuf.nu
+++ b/stdlib/net/pktbuf.nu
@@ -87,6 +87,18 @@ $ `stdlib/core/vec.nu`
     ( vec_push [i] . p ends n )
 }
 
+// Close the current packet even when it is EMPTY.
+//
+// `pktbuf_mark` treats "nothing appended" as "no packet", which is
+// right for a frame or a segment: an emitter that decided not to write
+// anything did not emit a packet. A zero-length DATAGRAM is a
+// different thing — it is a datagram, the receiver must be handed it,
+// and dropping it turns "the peer sent nothing" into "the peer has
+// sent nothing yet". UDP is the caller that needs this one.
+@ pktbuf_mark_empty * PktBuf p → v {
+    ( vec_push [i] . p ends ( vec_len [u] . p bytes ) )
+}
+
 // Append packet `idx` to `dst`. Returns how many bytes were appended.
 // The consuming half of the seam: a device driver walks 0..count and
 // hands each one to the hardware.

--- a/stdlib/net/socket.nu
+++ b/stdlib/net/socket.nu
@@ -89,6 +89,8 @@ $ `stdlib/net/tcpstack.nu`
 
 @ sock_kind_conn → i { ^ 2 }
 
+@ sock_kind_udp → i { ^ 3 }
+
 // ── connection status, as `connect` reports it ───────────────────
 
 @ sock_conn_pending → i { ^ 0 }
@@ -96,6 +98,18 @@ $ `stdlib/net/tcpstack.nu`
 @ sock_conn_ready → i { ^ 1 }
 
 @ sock_conn_failed → i { ^ 2 }
+
+// A bound UDP socket's mailbox. Datagram boundaries are the whole
+// point of UDP, so the payloads go in a PktBuf — the same "bytes plus
+// where each one ends" the frame path uses — and the sender's address
+// travels alongside, two integers per datagram.
+: UdpBox {
+    * PktBuf q
+    ( Vec i ) src  // stride 2: ip, port — one pair per datagram in `q`
+    i head  // datagrams already delivered; `q` is drained on read
+    i last_ip  // sender of the datagram the last recv returned
+    i last_port
+}
 
 : Sock {
     i kind
@@ -112,6 +126,9 @@ $ `stdlib/net/tcpstack.nu`
     b eof  // peer FIN seen AND the receive queue drained
     b shut  // sock_shutdown was called: wake and refuse
     b used
+    i udp  // *UdpBox for a UDP socket, 0 otherwise
+    b connected  // UDP: a default peer is set
+    i opts  // UDP: setsockopt bits, recorded and answered
 }
 
 : SockTab {
@@ -143,7 +160,18 @@ $ `stdlib/net/tcpstack.nu`
     : ~ i k 0
     ~ < k n {
         : *Sock s ( __sock_at st k )
-        ? != # i s 0 { ( nurl_free # s s ) } {}
+        ? != # i s 0 {
+            // A UDP socket still open at teardown owns its mailbox.
+            ? && . s used == . s kind ( sock_kind_udp ) {
+                : *UdpBox b # *UdpBox . s udp
+                ? != # i b 0 {
+                    ( pktbuf_free . b q )
+                    ( vec_free [i] . b src )
+                    ( nurl_free # s b )
+                } {}
+            } {}
+            ( nurl_free # s s )
+        } {}
         = k + k 1
     }
     ( vec_free [i] . st fds )
@@ -190,6 +218,9 @@ $ `stdlib/net/tcpstack.nu`
     = . s eof F
     = . s shut F
     = . s used T
+    = . s udp 0
+    = . s connected F
+    = . s opts 0
 }
 
 @ __alloc_fd * SockTab st → i {
@@ -317,7 +348,38 @@ $ `stdlib/net/tcpstack.nu`
 // wired to a callback.
 @ sock_rx * SockTab st ( Vec u ) frame i now → i {
     : TRx r ( tstack_rx . st ts frame now . st out )
+    ? && == . r result ( trx_other ) == . r kind ( rx_udp ) {
+        ( __udp_deliver st frame r )
+    } {}
     ^ . r result
+}
+
+// A received datagram belongs to the socket bound to its destination
+// port. No match is not an error here: ICMP port-unreachable is what a
+// host owes the sender, and this stack does not send it yet — dropping
+// it silently is at least honest about that, where inventing a reply
+// would not be.
+@ __udp_deliver * SockTab st ( Vec u ) frame TRx r → v {
+    : i n ( vec_len [i] . st fds )
+    : ~ i k 0
+    ~ < k n {
+        : *Sock s ( __sock_at st k )
+        ? && != # i s 0 && . s used && == . s kind ( sock_kind_udp )
+        && == . s local_port . r dst_port
+        || == . s local_ip 0 == . s local_ip . r dst_ip {
+            : *UdpBox b # *UdpBox . s udp
+            ? != # i b 0 {
+                ( vec_extend_range [u] . . b q bytes frame . r payload_off . r payload_len )
+                // …_empty, not _mark: a zero-length datagram is a
+                // datagram, and it has to arrive as one.
+                ( pktbuf_mark_empty . b q )
+                ( vec_push [i] . b src . r src_ip )
+                ( vec_push [i] . b src . r src_port )
+            } {}
+            ^
+        } {}
+        = k + k 1
+    }
 }
 
 @ sock_tick * SockTab st i now → i { ^ ( tstack_tick . st ts now . st out ) }
@@ -362,12 +424,15 @@ $ `stdlib/net/tcpstack.nu`
 
 // ── binding ──────────────────────────────────────────────────────
 
-@ __port_taken * SockTab st i port → b {
+// Is `port` already bound — in THIS protocol's port space? TCP and UDP
+// have separate ones, and a check that pooled them would refuse a DNS
+// client on 53 because something was listening on TCP 53.
+@ __port_taken_kind * SockTab st i kind i port → b {
     : i n ( vec_len [i] . st fds )
     : ~ i k 0
     ~ < k n {
         : *Sock s ( __sock_at st k )
-        ? && != # i s 0 && . s used && == . s kind ( sock_kind_listener ) == . s local_port port {
+        ? && != # i s 0 && . s used && == . s kind kind == . s local_port port {
             ^ T
         } {}
         = k + k 1
@@ -380,7 +445,11 @@ $ `stdlib/net/tcpstack.nu`
     ~ < tries 16384 {
         : i p . st ephemeral
         = . st ephemeral ? >= + p 1 49152 32768 + p 1
-        ? ! ( __port_taken st p ) { ^ p } {}
+        // An ephemeral port must be free in BOTH spaces: the caller
+        // asked for "a port nobody is using", and handing back one
+        // that the other protocol holds makes the next bind on it fail
+        // for a reason nobody can see.
+        ? && ! ( __port_taken_kind st ( sock_kind_listener ) p ) ! ( __port_taken_kind st ( sock_kind_udp ) p ) { ^ p } {}
         = tries + tries 1
     }
     ^ 0
@@ -399,7 +468,7 @@ $ `stdlib/net/tcpstack.nu`
     } {}
     : i p ? == port 0 ( __next_free_port st ) port
     ? == p 0 { ^ ( sock_err_fd st ( sock_err_bind ) ) } {}
-    ? && != port 0 ( __port_taken st p ) {
+    ? && != port 0 ( __port_taken_kind st ( sock_kind_listener ) p ) {
         ^ ( sock_err_fd st ( sock_err_addr_in_use ) )
     } {}
     : i lidx ( tstack_listen . st ts ip p backlog )
@@ -459,6 +528,171 @@ $ `stdlib/net/tcpstack.nu`
     : *Sock s ( __sock st fd )
     ? == # i s 0 { ^ F } {}
     ^ . s shut
+}
+
+// ── UDP ──────────────────────────────────────────────────────────
+//
+// A datagram socket has no state machine, no window and no timers —
+// what it has is a mailbox, and what this layer owes it is the same fd
+// semantics TCP gets: an ephemeral bind that reads back, ADDRINUSE,
+// `again` when the mailbox is empty, and readiness an event loop can
+// ask about.
+
+@ sock_udp_bind * SockTab st i ip i port → i {
+    ? || < port 0 > port 65535 { ^ ( sock_err_fd st ( sock_err_bind ) ) } {}
+    : i p ? == port 0 ( __next_free_port st ) port
+    ? == p 0 { ^ ( sock_err_fd st ( sock_err_bind ) ) } {}
+    ? && != port 0 ( __port_taken_kind st ( sock_kind_udp ) p ) {
+        ^ ( sock_err_fd st ( sock_err_addr_in_use ) )
+    } {}
+    : i fd ( __alloc_fd st )
+    : *Sock s ( __sock st fd )
+    : *UdpBox b # *UdpBox ( nurl_alloc Z UdpBox )
+    = . b q ( pktbuf_new )
+    = . b src ( vec_new [i] )
+    = . b head 0
+    = . b last_ip 0
+    = . b last_port 0
+    = . s kind ( sock_kind_udp )
+    = . s idx -1
+    = . s local_ip ip
+    = . s local_port p
+    = . s udp # i b
+    ^ fd
+}
+
+@ __udp_box * SockTab st i fd → *UdpBox {
+    : *Sock s ( __sock st fd )
+    ? == # i s 0 { ^ # *UdpBox 0 } {}
+    ? != . s kind ( sock_kind_udp ) { ^ # *UdpBox 0 } {}
+    ^ # *UdpBox . s udp
+}
+
+@ sock_udp_pending * SockTab st i fd → i {
+    : *UdpBox b ( __udp_box st fd )
+    ? == # i b 0 { ^ 0 } {}
+    ^ - ( pktbuf_count . b q ) . b head
+}
+
+// Set a default peer. UDP's `connect` filters nothing here — it
+// records where `sock_udp_send` goes, which is the half of the POSIX
+// contract a caller can actually observe on a host with one address.
+@ sock_udp_connect * SockTab st i fd i ip i port → i {
+    : *Sock s ( __sock st fd )
+    ? == # i s 0 { ^ - 0 ( sock_err_other ) } {}
+    ? != . s kind ( sock_kind_udp ) { ^ - 0 ( sock_err_other ) } {}
+    = . s peer_ip ip
+    = . s peer_port port
+    = . s connected T
+    ^ 0
+}
+
+@ sock_udp_is_connected * SockTab st i fd → b {
+    : *Sock s ( __sock st fd )
+    ? == # i s 0 { ^ F } {}
+    ^ . s connected
+}
+
+@ sock_udp_send_to * SockTab st i fd i ip i port ( Vec u ) src i off i len i now → i {
+    : *Sock s ( __sock st fd )
+    ? == # i s 0 { ^ - 0 ( sock_err_other ) } {}
+    ? != . s kind ( sock_kind_udp ) { ^ - 0 ( sock_err_write ) } {}
+    ? . s shut {
+        = . s err ( sock_err_closed )
+        ^ - 0 ( sock_err_closed )
+    } {}
+    : TxResult t ( stack_tx_udp . . st ts net ip . s local_port port src off len now . st out )
+    ? == . t status ( tx_sent ) {
+        = . s err 0
+        ^ len
+    } {}
+    // ARP has not resolved yet, or there is no route. A datagram
+    // socket has no retransmit timer to fall back on, so this is
+    // `again` rather than a loss the caller never hears about.
+    = . s err ( sock_err_again )
+    ^ - 0 ( sock_err_again )
+}
+
+@ sock_udp_send * SockTab st i fd ( Vec u ) src i off i len i now → i {
+    : *Sock s ( __sock st fd )
+    ? == # i s 0 { ^ - 0 ( sock_err_other ) } {}
+    ? ! . s connected {
+        = . s err ( sock_err_write )
+        ^ - 0 ( sock_err_write )
+    } {}
+    ^ ( sock_udp_send_to st fd . s peer_ip . s peer_port src off len now )
+}
+
+// Take the next datagram into `dst`, truncating to `max` — which is
+// what recvfrom(2) does, and the reason a caller passes a buffer at
+// least as large as the MTU. The sender's address is readable with
+// `sock_udp_last_ip` / `sock_udp_last_port` until the next recv.
+@ sock_udp_recv_from * SockTab st i fd ( Vec u ) dst i max → i {
+    : *Sock s ( __sock st fd )
+    ? == # i s 0 { ^ - 0 ( sock_err_other ) } {}
+    ? . s shut {
+        = . s err ( sock_err_closed )
+        ^ - 0 ( sock_err_closed )
+    } {}
+    : *UdpBox b ( __udp_box st fd )
+    ? == # i b 0 {
+        = . s err ( sock_err_read )
+        ^ - 0 ( sock_err_read )
+    } {}
+    ? >= . b head ( pktbuf_count . b q ) {
+        = . s err ( sock_err_again )
+        ^ - 0 ( sock_err_again )
+    } {}
+    : i idx . b head
+    : i start ( pktbuf_start . b q idx )
+    : i n ( pktbuf_len . b q idx )
+    : i take ? < max n max n
+    ? > take 0 { ( vec_extend_range [u] dst . . b q bytes start take ) } {}
+    = . b last_ip ?? ( vec_get [i] . b src * idx 2 ) { T x → x F → 0 }
+    = . b last_port ?? ( vec_get [i] . b src + * idx 2 1 ) { T x → x F → 0 }
+    = . b head + idx 1
+    // Drained: reclaim rather than grow a queue that is never reset.
+    // A socket that receives for a week would otherwise hold every
+    // datagram it ever saw.
+    ? >= . b head ( pktbuf_count . b q ) {
+        ( pktbuf_clear . b q )
+        ( vec_clear [i] . b src )
+        = . b head 0
+    } {}
+    = . s err 0
+    ^ take
+}
+
+@ sock_udp_last_ip * SockTab st i fd → i {
+    : *UdpBox b ( __udp_box st fd )
+    ? == # i b 0 { ^ 0 } {}
+    ^ . b last_ip
+}
+
+@ sock_udp_last_port * SockTab st i fd → i {
+    : *UdpBox b ( __udp_box st fd )
+    ? == # i b 0 { ^ 0 } {}
+    ^ . b last_port
+}
+
+// setsockopt, recorded rather than performed. Broadcast, multicast TTL
+// and multicast loopback are properties of a driver this build does
+// not have; answering OK and remembering the bit is what lets a
+// program that sets them run, and `sock_udp_opts` is how a future
+// driver reads what it was asked for. Nothing here pretends a
+// multicast datagram left the machine.
+@ sock_udp_setopt * SockTab st i fd i bit → i {
+    : *Sock s ( __sock st fd )
+    ? == # i s 0 { ^ - 0 ( sock_err_other ) } {}
+    ? != . s kind ( sock_kind_udp ) { ^ - 0 ( sock_err_other ) } {}
+    = . s opts | . s opts bit
+    ^ 0
+}
+
+@ sock_udp_opts * SockTab st i fd → i {
+    : *Sock s ( __sock st fd )
+    ? == # i s 0 { ^ 0 } {}
+    ^ . s opts
 }
 
 // ── connecting ───────────────────────────────────────────────────
@@ -624,6 +858,7 @@ $ `stdlib/net/tcpstack.nu`
     ? == . s kind ( sock_kind_listener ) {
         ^ > ( tstack_pending_count . st ts . s idx ) 0
     } {}
+    ? == . s kind ( sock_kind_udp ) { ^ > ( sock_udp_pending st fd ) 0 } {}
     ? ! ( __live st s ) { ^ T } {}
     : *Tcb c ( tstack_conn_tcb . st ts . s idx )
     ? == # i c 0 { ^ T } {}
@@ -634,6 +869,9 @@ $ `stdlib/net/tcpstack.nu`
     : *Sock s ( __sock st fd )
     ? == # i s 0 { ^ T } {}
     ? . s shut { ^ T } {}
+    // A datagram socket is always writable: there is no window to
+    // fill and nothing to wait for.
+    ? == . s kind ( sock_kind_udp ) { ^ T } {}
     ? != . s kind ( sock_kind_conn ) { ^ F } {}
     ? ! ( __live st s ) { ^ T } {}
     : i state ( tstack_conn_state . st ts . s idx )
@@ -668,6 +906,15 @@ $ `stdlib/net/tcpstack.nu`
     = . s shut T
     = . s refs - . s refs 1
     ? > . s refs 0 { ^ } {}
+    ? == . s kind ( sock_kind_udp ) {
+        : *UdpBox b # *UdpBox . s udp
+        ? != # i b 0 {
+            ( pktbuf_free . b q )
+            ( vec_free [i] . b src )
+            ( nurl_free # s b )
+        } {}
+        = . s udp 0
+    } {}
     ? == . s kind ( sock_kind_listener ) {
         ( tstack_listener_close . st ts . s idx )
     } {

--- a/stdlib/net/tcpstack.nu
+++ b/stdlib/net/tcpstack.nu
@@ -70,10 +70,25 @@ $ `stdlib/net/stack.nu`
     i kind  // stack.nu's RxResult kind when result == trx_other
     i conn  // index into the connection table, or -1
     i emitted  // bytes appended to `out`
+    // The verdict for everything that was not TCP, passed through
+    // intact. A caller that also speaks UDP would otherwise have to
+    // parse the frame a second time to learn what this layer already
+    // knows — and the two parses would be free to disagree.
+    i src_ip
+    i dst_ip
+    i src_port
+    i dst_port
+    i payload_off  // into the frame handed to tstack_rx
+    i payload_len
 }
 
 @ __trx i result i kind i conn i emitted → TRx {
-    ^ @ TRx { result kind conn emitted }
+    ^ @ TRx { result kind conn emitted 0 0 0 0 0 0 }
+}
+
+@ __trx_other RxResult rr → TRx {
+    ^ @ TRx { ( trx_other ) . rr kind -1 . rr emitted . rr src_ip . rr dst_ip
+        . rr src_port . rr dst_port . rr payload_off . rr payload_len }
 }
 
 // ── the connection table ─────────────────────────────────────────
@@ -425,9 +440,7 @@ $ `stdlib/net/stack.nu`
 // everything rather than two that disagree about which is authoritative.
 @ tstack_rx * TcpStack ts ( Vec u ) frame i now * PktBuf out → TRx {
     : RxResult rr ( stack_rx . ts net frame now out )
-    ? != . rr kind ( rx_tcp ) {
-        ^ ( __trx ( trx_other ) . rr kind -1 . rr emitted )
-    } {}
+    ? != . rr kind ( rx_tcp ) { ^ ( __trx_other rr ) } {}
     : TcpSeg s ( tcpseg_parse frame . rr payload_off . rr payload_len . rr src_ip . rr dst_ip )
     ? ! . s valid { ^ ( __trx ( trx_none ) 0 -1 0 ) } {}
 

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -46,23 +46,29 @@ worth anything.
 ## State (2026-08-05)
 
 ```
-  PASS         446    corpus tests that build and run with no libc at all
+  PASS         449    corpus tests that build and run with no libc at all
   FAIL           0
-  NEEDS-BARE    24    processes, signals, UDP, DNS
+  NEEDS-BARE    21    processes and signals — a unikernel has neither
   NEEDS-LIBM     0
   NEEDS-NOLIBC   7    realpath, mkstemp, inotify, execvp, unix sockets
   NEEDS-LIB      4    libsqlite3 x3, libzstd x1 — third-party C libraries
   SKIP         144    compile-fail tests and tests with no standalone build
 ```
 
-TCP is in that PASS column. `async_tcp`, `async_http_server`,
-`http_server_pool`, `http_server_stop_direct`, `websocket_client`,
-`http2_client`, `net_basic` and the rest run a real client and a real
-server against each other with no kernel sockets anywhere:
-`unikernel/net/sockets.nu` implements the socket ABI in NURL over the
-sans-IO stack, the frames go around a loopback that is literally "what
-this stack emits, it receives", and a blocking read PARKS on its fd —
-so the scheduler can still say "nothing can run" and mean it.
+TCP, UDP and name resolution are all in that PASS column. `async_tcp`,
+`async_http_server`, `http_server_pool`, `http_server_stop_direct`,
+`websocket_client`, `http2_client`, `udp_basic`, `dns_basic`,
+`net_basic` and the rest run real clients and real servers against each
+other with no kernel sockets anywhere: `unikernel/net/sockets.nu`
+implements the socket ABI in NURL over the sans-IO stack, the frames go
+around a loopback that is literally "what this stack emits, it
+receives", and a blocking read PARKS on its fd — so the scheduler can
+still say "nothing can run" and mean it.
+
+What is left in NEEDS-BARE is `fork`/`exec`, signals and the process
+API. That is not remaining work in the sense the other columns are: the
+plan's non-goals list processes explicitly, and a machine with one
+address space has nothing to fork.
 
 The bucket a blocked test lands in is **measured**, not listed: each
 missing symbol is looked up with `nm` in the hosted `stdlib/runtime.o`

--- a/unikernel/net/sockets.nu
+++ b/unikernel/net/sockets.nu
@@ -471,6 +471,25 @@ $ `stdlib/net/socket.nu`
     ^ ( __addr_string ( sock_local_ip st handle ) ( sock_local_port st handle ) )
 }
 
+// "ip:port" as a pointer the compiler does NOT track, for a cache that
+// outlives the call that filled it.
+//
+// This is the one place the distinction matters. `__addr_string`
+// returns a TRACKED owned string, and auto-drop releases it when the
+// function that made it returns — which is exactly right when the
+// value is returned, and exactly wrong when it is stashed in a table as
+// an integer, where the compiler cannot see that ownership moved. The
+// first version of the UDP cache did the second thing and handed
+// callers a pointer to freed memory: `peer=0Tp#~` where an address
+// belonged.
+@ __addr_own i ip i port → i {
+    : s a ( __addr_string ip port )
+    : i n ( nurl_str_len a )
+    : s p # s ( nurl_alloc + n 1 )
+    ( nurl_memcpy p a + n 1 )
+    ^ # i p
+}
+
 // BORROWED — the contract says the view lives as long as the
 // connection does, so the string is cached per fd and released by
 // close. A fresh allocation per call would leak on every caller that
@@ -482,8 +501,8 @@ $ `stdlib/net/socket.nu`
     ~ <= ( vec_len [i] . sh peer ) slot { ( vec_push [i] . sh peer 0 ) }
     : i cached ?? ( vec_get [i] . sh peer slot ) { T x → x F → 0 }
     ? != cached 0 { ^ # s cached } {}
-    : s a ( __addr_string ( sock_peer_ip . sh st conn ) ( sock_peer_port . sh st conn ) )
-    : b _ok ( vec_set [i] . sh peer slot # i a )
+    : i a ( __addr_own ( sock_peer_ip . sh st conn ) ( sock_peer_port . sh st conn ) )
+    : b _ok ( vec_set [i] . sh peer slot a )
     ^ # s a
 }
 
@@ -494,4 +513,242 @@ $ `stdlib/net/socket.nu`
     ? == cached 0 { ^ } {}
     ( nurl_free # s cached )
     : b _ok ( vec_set [i] . sh peer slot 0 )
+}
+
+// ── UDP ──────────────────────────────────────────────────────────
+//
+// Same shape as the TCP half: the socket layer answers `again` and
+// this file decides what waiting means. A datagram socket has less to
+// wait for — there is no handshake and no window — so only the receive
+// side ever blocks.
+
+@ nurl_udp_bind s host i port → i {
+    : *SockTab st ( __tab )
+    : i ip ( __resolve host )
+    // An empty host means "any address", the way `udp_bind \`\` 0` spells
+    // a wildcard bind.
+    : i want ? < ip 0 ? == 0 ( nurl_str_len host ) 0 -1 ip
+    ? < want 0 { ^ ( sock_err_fd st ( sock_err_bind ) ) } {}
+    ? && != want 0 != want ( __lo_ip ) { ^ ( sock_err_fd st ( sock_err_bind ) ) } {}
+    ^ ( sock_udp_bind st want port )
+}
+
+@ nurl_udp_close i handle → v {
+    : *Shim sh ( __shim )
+    ( __peer_forget sh handle )
+    ( sock_close . sh st handle ( __ms ) )
+    ( __wake_ready )
+}
+
+@ nurl_udp_err_kind i handle → i { ^ ( sock_err ( __tab ) handle ) }
+
+@ nurl_udp_get_fd i handle → i { ^ handle }
+
+// IPv4 only, and it says so rather than guessing: this stack has no
+// IPv6 and a caller that branches on the family should take the branch
+// that is true.
+@ nurl_udp_family i handle → i { ^ 4 }
+
+@ nurl_udp_set_nonblock i handle i on → v {
+    ( sock_set_nonblock ( __tab ) handle != on 0 )
+}
+
+@ nurl_udp_set_timeout i handle i ms → v { ( sock_set_timeout ( __tab ) handle ms ) }
+
+@ nurl_udp_connect i handle s host i port → i {
+    : *SockTab st ( __tab )
+    : i ip ( __resolve host )
+    ? < ip 0 { ^ -1 } {}
+    ? < ( sock_udp_connect st handle ip port ) 0 { ^ -1 } {}
+    ^ 0
+}
+
+@ __udp_send * SockTab st i handle i ip i port s buf i n → i {
+    // NOT `n <= 0 → 0`. A zero-length datagram is a datagram: it is
+    // sent, it arrives, and the receiver reads 0 bytes — which is a
+    // different fact from "nothing has arrived yet". Short-circuiting
+    // here sent nothing and reported success, so the peer's receive
+    // timed out with no explanation on either side.
+    ? < n 0 { ^ -1 } {}
+    : ( Vec u ) src ( vec_new [u] )
+    ( bytes_extend_raw src buf n )
+    : i r ? >= ip 0 ( sock_udp_send_to st handle ip port src 0 n ( __ms ) )
+    ( sock_udp_send st handle src 0 n ( __ms ) )
+    ( vec_free [u] src )
+    // Whatever went out is on the wire before this returns: on
+    // loopback the datagram IS delivered by the same call chain, and a
+    // send that left frames queued would make the peer's next receive
+    // depend on somebody else moving the stack.
+    ( __drive ( __ms ) )
+    ? < r 0 { ^ -1 } {}
+    ^ r
+}
+
+@ nurl_udp_send_to i handle s buf i n s host i port → i {
+    : *SockTab st ( __tab )
+    : i ip ( __resolve host )
+    ? < ip 0 {
+        ^ -1
+    } {}
+    ^ ( __udp_send st handle ip port buf n )
+}
+
+@ nurl_udp_send i handle s buf i n → i {
+    ^ ( __udp_send ( __tab ) handle -1 0 buf n )
+}
+
+@ __udp_recv i handle s buf i n → i {
+    : *SockTab st ( __tab )
+    ? <= n 0 { ^ 0 } {}
+    ~ T {
+        : ( Vec u ) tmp ( vec_new [u] )
+        : i got ( sock_udp_recv_from st handle tmp n )
+        ? > got 0 {
+            ( nurl_memcpy buf # s ( vec_data [u] tmp ) got )
+            ( vec_free [u] tmp )
+            ( __udp_cache_peer handle )
+            ^ got
+        } {}
+        ( vec_free [u] tmp )
+        // A zero-length datagram is a datagram: it must be delivered,
+        // not mistaken for "nothing arrived". That is the difference
+        // between UDP and a stream, and the test that pins it sends an
+        // empty payload on purpose.
+        ? == got 0 {
+            ( __udp_cache_peer handle )
+            ^ 0
+        } {}
+        : i err - 0 got
+        ? != err ( sock_err_again ) { ^ -1 } {}
+        ? == ( __should_retry handle 0 ) 0 { ^ -1 } {}
+    }
+    ^ -1
+}
+
+@ nurl_udp_recv_from i handle s buf i n → i { ^ ( __udp_recv handle buf n ) }
+
+@ nurl_udp_recv i handle s buf i n → i { ^ ( __udp_recv handle buf n ) }
+
+// The address the last received datagram came from, cached per fd so
+// the borrowed view outlives the call the way the ABI promises.
+@ __udp_cache_peer i handle → v {
+    : *Shim sh ( __shim )
+    ( __peer_forget sh handle )
+    : i slot - handle 3
+    ? < slot 0 { ^ } {}
+    ~ <= ( vec_len [i] . sh peer ) slot { ( vec_push [i] . sh peer 0 ) }
+    : i a ( __addr_own ( sock_udp_last_ip . sh st handle ) ( sock_udp_last_port . sh st handle ) )
+    : b _ok ( vec_set [i] . sh peer slot a )
+}
+
+@ nurl_udp_peer_addr i handle → s {
+    : *Shim sh ( __shim )
+    : i slot - handle 3
+    ? < slot 0 { ^ `` } {}
+    ? >= slot ( vec_len [i] . sh peer ) { ^ `` } {}
+    : i cached ?? ( vec_get [i] . sh peer slot ) { T x → x F → 0 }
+    ? == cached 0 { ^ `` } {}
+    ^ # s cached
+}
+
+@ nurl_udp_local_addr i handle → s {
+    : *SockTab st ( __tab )
+    ^ ( __addr_string ( sock_local_ip st handle ) ( sock_local_port st handle ) )
+}
+
+// Socket options this build records rather than performs — see
+// `sock_udp_setopt`. Bit per option so a driver can read back what it
+// was asked for instead of being told nothing was.
+@ nurl_udp_set_broadcast i handle i on → i { ^ ( sock_udp_setopt ( __tab ) handle 1 ) }
+
+@ nurl_udp_set_multicast_ttl i handle i ttl → i { ^ ( sock_udp_setopt ( __tab ) handle 2 ) }
+
+@ nurl_udp_set_multicast_loop i handle i on → i { ^ ( sock_udp_setopt ( __tab ) handle 4 ) }
+
+// Joining a group needs a driver that can accept multicast frames, and
+// this build has one interface that receives exactly what it sent.
+// Refusing is the honest answer: a join that silently succeeds is a
+// receiver that never receives, debugged much later.
+@ nurl_udp_join_group i handle s group s iface → i { ^ -1 }
+
+@ nurl_udp_leave_group i handle s group s iface → i { ^ -1 }
+
+// ── name resolution ──────────────────────────────────────────────
+//
+// There is no resolver on a machine whose only interface is a
+// loopback: no DNS server is reachable, and inventing an answer would
+// be worse than saying so. What CAN be answered is answered — an
+// address literal, and the one name every hosts file agrees on — and
+// everything else returns empty, which std/dns.nu turns into an error
+// the caller already handles.
+//
+// A real `net/dnsclient` over UDP is A1a's stub resolver, and it plugs
+// into the same seam: the socket half it needs now exists.
+
+// An IPv6 literal, syntactically. This stack has no IPv6 and never
+// will answer a NAME with one — but a literal is already an address,
+// and `getaddrinfo` hands it straight back. Refusing it here would
+// make a program that merely PARSES `::1` fail at the parse.
+@ __dns_is_v6_literal s host → b {
+    : i n ( nurl_str_len host )
+    ? == n 0 { ^ F } {}
+    : ~ b colon F
+    : ~ i k 0
+    ~ < k n {
+        : i c ( nurl_str_get host k )
+        ? == c 58 { = colon T } {}
+        ? ! || || == c 58 || == c 46 && >= c 48 <= c 57
+        || && >= c 97 <= c 102 && >= c 65 <= c 70 { ^ F } {}
+        = k + k 1
+    }
+    ^ colon
+}
+
+@ __dns_is_local s host → b {
+    ? ( nurl_str_eq host `localhost` ) { ^ T } {}
+    ? ( nurl_str_eq host `localhost.localdomain` ) { ^ T } {}
+    ^ F
+}
+
+@ nurl_dns_resolve s host → s {
+    ? ( __dns_is_local host ) { ^ ( nurl_str_cat `127.0.0.1` `\n` ) } {}
+    ? ( __dns_is_v6_literal host ) { ^ ( nurl_str_cat host `\n` ) } {}
+    ?? ( ipv4_parse host ) {
+        T _a → ( nurl_str_cat host `\n` )
+        F → ( nurl_str_cat `` `` )
+    }
+}
+
+@ nurl_dns_resolve_port s host i port → s {
+    : s base ( nurl_dns_resolve host )
+    ? == 0 ( nurl_str_len base ) { ^ base } {}
+    // "ip:port\n" — and "[v6]:port", because a colon inside the
+    // address and the colon before the port are the same character,
+    // and only the brackets tell them apart. Built from the answer
+    // already in hand rather than resolved a second time.
+    : b v6 ( __dns_is_v6_literal host )
+    : String out ( string_new )
+    : i n ( nurl_str_len base )
+    : ~ i k 0
+    ? v6 { ( string_push_char out 91 ) } {}
+    ~ < k n {
+        : i c ( nurl_str_get base k )
+        ? == c 10 {
+            ? v6 { ( string_push_char out 93 ) } {}
+            ( string_push_char out 58 )
+            ( string_push_int out port )
+        } {}
+        ( string_push_char out c )
+        = k + k 1
+    }
+    : s r ( nurl_str_cat ( string_data out ) `` )
+    ( string_free out )
+    ^ r
+}
+
+@ nurl_dns_reverse s ip → s {
+    ?? ( ipv4_parse ip ) {
+        T a → ? == a ( __lo_ip ) ( nurl_str_cat `localhost` `\n` ) ( nurl_str_cat `` `` )
+        F → ( nurl_str_cat `` `` )
+    }
 }


### PR DESCRIPTION
TCP (#777, #778) left `udp_basic`, `dns_basic` and `dist_job` waiting on the other half of the socket ABI. Both halves now go through the sans-IO stack.

```
  nolibc corpus:  PASS 446 → 449,  FAIL 0,  NEEDS-BARE 24 → 21
```

What is left in NEEDS-BARE is `fork`/`exec`, signals and the process API — which the plan lists as non-goals rather than as work. A machine with one address space has nothing to fork.

## Datagrams are not a stream, and the difference is the design

A UDP socket gets a **mailbox**, not a byte queue: payloads in a `PktBuf` — the same "bytes plus where each one ends" the frame path uses — with the sender's address alongside. So two sends are two receives, a short read truncates its own datagram instead of leaving a remainder queued, and a zero-length datagram arrives as one. Everything else is the fd semantics TCP already established: an ephemeral bind that reads back, ADDRINUSE, `again` on an empty mailbox, readiness an event loop can ask about without performing the operation.

**TCP and UDP have separate port spaces.** The bind check was written when only listeners existed and pooled them — a DNS client on UDP 53 would have been refused because something was listening on TCP 53. An ephemeral port is still chosen free in *both*, because "a port nobody is using" is what the caller asked for.

## Name resolution says what it can and refuses the rest

There is no resolver on a machine whose only interface is a loopback. An address literal is its own answer (v4 and v6 — a program that merely *parses* `::1` should not fail at the parse), `localhost` is 127.0.0.1, and everything else returns empty, which `std/dns.nu` turns into the error its callers already handle. `dns_resolve_port` brackets a v6 literal, because the colon inside the address and the colon before the port are the same character.

Multicast group joins **refuse** rather than pretend: this build has one interface that receives exactly what it sent, and a join that silently succeeds is a receiver that never receives, debugged much later. Broadcast and multicast TTL are recorded (`sock_udp_opts`) so a future driver can read back what it was asked for.

## Three defects fixed at their root

- **The cached peer address pointed at freed memory.** `__addr_string` returns a *tracked* owned string, which auto-drop releases when the function that made it returns — right when the value is returned, wrong when it is stashed in a table as an integer, where the compiler cannot see that ownership moved. The symptom was `peer=0Tp#~` where an address belonged. Both the TCP and UDP caches now allocate a pointer the compiler does not track, which says what they mean.
- **A zero-length datagram vanished.** `pktbuf_mark` treats "nothing appended" as "no packet" — right for a frame or a segment, wrong for a datagram, which is a datagram whether or not it carries bytes. `pktbuf_mark_empty` is the one caller that needs the other rule.
- **A zero-length send sent nothing and reported success.** The shim short-circuited on `n <= 0`, so the peer's receive timed out with no explanation on either side. Sending nothing and sending zero bytes are different acts.

## Verification

- `unikernel/run_nolibc_tests.sh`: **449 PASS / 0 FAIL**.
- `./build.sh` green — hosted corpus 608 PASS, bootstrap fixed point held.
- `unikernel/tests/run_unit_tests.sh` green.
- `net_socket` (now with a UDP section: the mailbox, two-sends-two-receives, the truncating short read, `connect` as a default peer, a send with no peer as an error rather than a silent drop, and the two port spaces), `net_tcpstack` and `net_stack` clean under LSan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1