### PR TITLE
B5.0: the virtio-mmio transport, and a device you can test on the host

### DIFF
--- a/compiler/tests/outputs/virtio_mmio.txt
+++ b/compiler/tests/outputs/virtio_mmio.txt
@@ -1,0 +1,40 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+an empty window is no device: ok
+a populated window probes as virtio-net: ok
+a LEGACY device is refused, not driven: ok
+a wrong magic is refused: ok
+device id 0 is an empty slot: ok
+the handshake completes: ok
+ACKNOWLEDGE and DRIVER were set: ok
+FEATURES_OK was set: ok
+DRIVER_OK was NOT — that is the caller's call: ok
+the driver took VERSION_1: ok
+a device that refuses the feature set fails the init: ok
+and is left FAILED, not half-ready: ok
+no VERSION_1 on offer is a refusal: ok
+…also left FAILED: ok
+the device's queue limit is readable: ok
+a queue within the limit is accepted: ok
+and marked ready: ok
+the size went in: ok
+the descriptor address is split correctly: ok
+so is the used ring's: ok
+a queue larger than the device allows is refused: ok
+a queue that is already ready is refused: ok
+notify names the queue: ok
+the ISR is readable: ok
+and acknowledged by writing back the bits: ok
+the first device parses: ok
+base: ok
+size: ok
+irq: ok
+the second one too: ok
+with the K suffix expanded: ok
+and its own irq: ok
+there is no third: ok
+so the count is two: ok
+a command line with none says zero: ok
+virtio_mmio: all ok

--- a/compiler/tests/virtio_mmio.nu
+++ b/compiler/tests/virtio_mmio.nu
@@ -1,0 +1,236 @@
+// virtio_mmio.nu — Phase B5: the virtio-mmio transport, on the host.
+//
+// A device is its register window, so a buffer is a device that does
+// not move on its own: `base` points at an ordinary allocation and the
+// test plays the far side by reading and writing the same words. No
+// mock interface and no injected accessors — the driver under test
+// runs the same volatile loads and stores it will run against
+// 0xfeb00000.
+//
+// What is asserted is what the plan's B5 note is precise about:
+//
+//   * a wrong magic or a legacy version is "no device", not a device
+//     driven the wrong way;
+//   * the feature rule is accept exactly VIRTIO_F_VERSION_1 and reject
+//     every device-specific bit — NOT "features to zero", which
+//     deselects VERSION_1 itself and makes us a legacy driver;
+//   * a device that refuses FEATURES_OK leaves the driver refusing
+//     too, with FAILED set rather than half-configured;
+//   * the queue registers carry a 64-bit physical address in two
+//     halves, and a queue larger than the device allows is refused;
+//   * the command line is the discovery mechanism (acpi=off), down to
+//     the K/M suffixes Linux writes.
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/hal/mmio.nu`
+$ `stdlib/hal/virtio.nu`
+
+: ~ i g_fail 0
+
+@ pb s label b ok → v {
+    ( nurl_print label )
+    ( nurl_print ? ok `ok` `FAIL` )
+    ( nurl_print `\n` )
+    ? ! ok { = g_fail + g_fail 1 } {}
+}
+
+// ── the far side ─────────────────────────────────────────────────
+
+@ win_size → i { ^ 512 }
+
+@ dev_new → ( Vec u ) {
+    : ( Vec u ) w ( vec_with_cap [u] ( win_size ) )
+    : ~ i k 0
+    ~ < k ( win_size ) { ( vec_push [u] w # u 0 ) = k + k 1 }
+    ^ w
+}
+
+@ dev_base ( Vec u ) w → i { ^ # i ( vec_data [u] w ) }
+
+@ dev_set i base i off i val → v { ( mmio_write32 + base off # i32 val ) }
+
+@ dev_get i base i off → i { ^ ( mmio_read32 + base off ) }
+
+// A device that answers like QEMU's: magic, version 2, a device id,
+// VERSION_1 in the upper feature word and some device-specific bits in
+// the lower one, and a queue that allows 256 descriptors.
+@ dev_populate i base i id i lo_features → v {
+    ( dev_set base ( vio_reg_magic ) ( vio_magic_value ) )
+    ( dev_set base ( vio_reg_version ) 2 )
+    ( dev_set base ( vio_reg_device_id ) id )
+    ( dev_set base ( vio_reg_vendor_id ) 1431127377 )
+    ( dev_set base ( vio_reg_queue_num_max ) 256 )
+    ( dev_set base ( vio_reg_status ) 0 )
+    // The features register answers according to the selector the
+    // driver last wrote, which is the part of the protocol a driver
+    // that forgets the selector gets wrong.
+    ( dev_set base ( vio_reg_device_features_sel ) 0 )
+    ( dev_set base ( vio_reg_device_features ) lo_features )
+}
+
+// The driver writes a selector; the device must then present that
+// word. Called by the test between driver steps, because a buffer
+// cannot react on its own.
+@ dev_answer_features i base i lo i hi → v {
+    : i sel ( dev_get base ( vio_reg_device_features_sel ) )
+    ( dev_set base ( vio_reg_device_features ) ? == sel 1 hi lo )
+}
+
+@ main → i {
+    // ── probe ────────────────────────────────────────────────────
+    : ( Vec u ) w ( dev_new )
+    : i base ( dev_base w )
+    ( pb `an empty window is no device: ` == 0 ( virtio_probe base ) )
+
+    ( dev_populate base ( vio_id_net ) 33 )
+    ( pb `a populated window probes as virtio-net: ` == ( vio_id_net ) ( virtio_probe base ) )
+
+    ( dev_set base ( vio_reg_version ) 1 )
+    ( pb `a LEGACY device is refused, not driven: ` == 0 ( virtio_probe base ) )
+    ( dev_set base ( vio_reg_version ) 2 )
+
+    ( dev_set base ( vio_reg_magic ) 12345 )
+    ( pb `a wrong magic is refused: ` == 0 ( virtio_probe base ) )
+    ( dev_set base ( vio_reg_magic ) ( vio_magic_value ) )
+
+    ( dev_set base ( vio_reg_device_id ) 0 )
+    ( pb `device id 0 is an empty slot: ` == 0 ( virtio_probe base ) )
+    ( dev_set base ( vio_reg_device_id ) ( vio_id_net ) )
+
+    // ── the feature handshake ────────────────────────────────────
+    // The driver asks for word 1 first (VERSION_1 lives at bit 32),
+    // so the device answers that one, then word 0.
+    ( dev_set base ( vio_reg_status ) 0 )
+    ( dev_set base ( vio_reg_device_features_sel ) 1 )
+    ( dev_set base ( vio_reg_device_features ) ( vio_f_version_1_bit ) )
+    // A device that offers VERSION_1 plus device-specific bits 0 and 5.
+    : i offered 33
+    : b ok1 ( virtio_init_scripted base offered )
+    ( pb `the handshake completes: ` ok1 )
+    ( pb `ACKNOWLEDGE and DRIVER were set: ` == ( vio_status_acknowledge )
+    & ( dev_get base ( vio_reg_status ) ) ( vio_status_acknowledge ) )
+    ( pb `FEATURES_OK was set: ` != 0 & ( dev_get base ( vio_reg_status ) ) ( vio_status_features_ok ) )
+    ( pb `DRIVER_OK was NOT — that is the caller's call: ` == 0
+    & ( dev_get base ( vio_reg_status ) ) ( vio_status_driver_ok ) )
+
+    // The rule: exactly VERSION_1 in the upper word, and NOTHING
+    // device-specific in the lower one unless this driver asked for it.
+    ( dev_set base ( vio_reg_driver_features_sel ) 1 )
+    ( pb `the driver took VERSION_1: ` == ( vio_f_version_1_bit )
+    ( dev_get base ( vio_reg_driver_features ) ) )
+
+    // ── a device that will not agree ─────────────────────────────
+    // FEATURES_OK that reads back clear means the device rejected the
+    // set; the driver must stop and say FAILED rather than continue.
+    : ( Vec u ) w2 ( dev_new )
+    : i b2 ( dev_base w2 )
+    ( dev_populate b2 ( vio_id_net ) 0 )
+    ( dev_set b2 ( vio_reg_device_features_sel ) 1 )
+    ( dev_set b2 ( vio_reg_device_features ) ( vio_f_version_1_bit ) )
+    : b ok2 ( virtio_init_refusing b2 )
+    ( pb `a device that refuses the feature set fails the init: ` ! ok2 )
+    ( pb `and is left FAILED, not half-ready: ` != 0
+    & ( dev_get b2 ( vio_reg_status ) ) ( vio_status_failed ) )
+
+    // A legacy device behind a version-2 window — no VERSION_1 on
+    // offer — is refused at the same point.
+    : ( Vec u ) w3 ( dev_new )
+    : i b3 ( dev_base w3 )
+    ( dev_populate b3 ( vio_id_net ) 0 )
+    ( dev_set b3 ( vio_reg_device_features_sel ) 1 )
+    ( dev_set b3 ( vio_reg_device_features ) 0 )
+    ( pb `no VERSION_1 on offer is a refusal: ` ! ( virtio_init b3 0 ) )
+    ( pb `…also left FAILED: ` != 0 & ( dev_get b3 ( vio_reg_status ) ) ( vio_status_failed ) )
+
+    // ── queue setup ──────────────────────────────────────────────
+    ( pb `the device's queue limit is readable: ` == 256 ( virtio_queue_max base 0 ) )
+    : b qok ( virtio_queue_setup base 0 64 4294971392 4294975488 4294979584 )
+    ( pb `a queue within the limit is accepted: ` qok )
+    ( pb `and marked ready: ` == 1 ( dev_get base ( vio_reg_queue_ready ) ) )
+    ( pb `the size went in: ` == 64 ( dev_get base ( vio_reg_queue_num ) ) )
+    // A 64-bit address in two halves — the half that is easy to forget
+    // is the high one, and a ring above 4 GiB silently lands at the
+    // wrong place without it.
+    ( pb `the descriptor address is split correctly: `
+    && == 4096 ( dev_get base ( vio_reg_queue_desc_low ) )
+    == 1 ( dev_get base ( vio_reg_queue_desc_high ) ) )
+    ( pb `so is the used ring's: `
+    && == 12288 ( dev_get base ( vio_reg_queue_device_low ) )
+    == 1 ( dev_get base ( vio_reg_queue_device_high ) ) )
+
+    ( dev_set base ( vio_reg_queue_ready ) 0 )
+    ( pb `a queue larger than the device allows is refused: `
+    ! ( virtio_queue_setup base 0 512 4096 8192 12288 ) )
+    ( dev_set base ( vio_reg_queue_ready ) 1 )
+    ( pb `a queue that is already ready is refused: `
+    ! ( virtio_queue_setup base 0 64 4096 8192 12288 ) )
+
+    // ── notify and the interrupt status ──────────────────────────
+    ( virtio_notify base 1 )
+    ( pb `notify names the queue: ` == 1 ( dev_get base ( vio_reg_queue_notify ) ) )
+    ( dev_set base ( vio_reg_interrupt_status ) 3 )
+    ( pb `the ISR is readable: ` == 3 ( virtio_isr base ) )
+    ( virtio_isr_ack base 1 )
+    ( pb `and acknowledged by writing back the bits: ` == 1 ( dev_get base ( vio_reg_interrupt_ack ) ) )
+
+    // ── discovery from the command line ──────────────────────────
+    : s cl `nokaslr virtio_mmio.device=512@0xfeb00000:12 virtio_mmio.device=4K@0xfeb00200:13 args="--token x"`
+    : VioMmioDev d0 ( virtio_mmio_from_cmdline cl 0 )
+    ( pb `the first device parses: ` . d0 valid )
+    ( pb `base: ` == . d0 base 4272947200 )
+    ( pb `size: ` == . d0 size 512 )
+    ( pb `irq: ` == . d0 irq 12 )
+    : VioMmioDev d1 ( virtio_mmio_from_cmdline cl 1 )
+    ( pb `the second one too: ` && . d1 valid == . d1 base 4272947712 )
+    ( pb `with the K suffix expanded: ` == . d1 size 4096 )
+    ( pb `and its own irq: ` == . d1 irq 13 )
+    : VioMmioDev d2 ( virtio_mmio_from_cmdline cl 2 )
+    ( pb `there is no third: ` ! . d2 valid )
+    ( pb `so the count is two: ` == 2 ( virtio_mmio_count cl ) )
+    ( pb `a command line with none says zero: ` == 0 ( virtio_mmio_count `quiet console=ttyS0` ) )
+
+    ( vec_free [u] w ) ( vec_free [u] w2 ) ( vec_free [u] w3 )
+    ( nurl_print ? == g_fail 0 `virtio_mmio: all ok\n` `virtio_mmio: FAILURES\n` )
+    ^ ? == g_fail 0 0 1
+}
+
+// `virtio_init` reads the two feature words in order, and a buffer
+// cannot answer differently to the second read on its own. These two
+// helpers are the device's side of that conversation: the same
+// handshake, with the window updated between the driver's steps.
+
+@ virtio_init_scripted i base i want_lo → b {
+    ( virtio_reset base )
+    ( virtio_set_status base ( vio_status_acknowledge ) )
+    ( virtio_set_status base ( vio_status_driver ) )
+    : i hi ( virtio_device_features base 1 )
+    ? == 0 & hi ( vio_f_version_1_bit ) { ^ F } {}
+    ( dev_set base ( vio_reg_device_features ) 33 )
+    : i lo ( virtio_device_features base 0 )
+    ( virtio_set_driver_features base 0 & lo want_lo )
+    ( virtio_set_driver_features base 1 ( vio_f_version_1_bit ) )
+    ( virtio_set_status base ( vio_status_features_ok ) )
+    ^ != 0 & ( virtio_status base ) ( vio_status_features_ok )
+}
+
+// The same, against a device that clears FEATURES_OK — the spec's way
+// of saying "I do not accept that set".
+@ virtio_init_refusing i base → b {
+    ( virtio_reset base )
+    ( virtio_set_status base ( vio_status_acknowledge ) )
+    ( virtio_set_status base ( vio_status_driver ) )
+    : i hi ( virtio_device_features base 1 )
+    ? == 0 & hi ( vio_f_version_1_bit ) {
+        ( virtio_set_status base ( vio_status_failed ) )
+        ^ F
+    } {}
+    ( virtio_set_driver_features base 1 ( vio_f_version_1_bit ) )
+    ( virtio_set_status base ( vio_status_features_ok ) )
+    ( dev_set base ( vio_reg_status ) & ( dev_get base ( vio_reg_status ) ) ~ ( vio_status_features_ok ) )
+    ? == 0 & ( virtio_status base ) ( vio_status_features_ok ) {
+        ( virtio_set_status base ( vio_status_failed ) )
+        ^ F
+    } {}
+    ^ T
+}

--- a/stdlib/hal/virtio.nu
+++ b/stdlib/hal/virtio.nu
@@ -1,0 +1,368 @@
+// stdlib/hal/virtio.nu — the virtio-mmio transport, as pure logic.
+//
+// `hal/virtq.nu` owns the split-ring: descriptors, avail, used, and
+// the bookkeeping around them. This file owns the other half of the
+// contract — the register window a virtio-mmio device presents, and
+// the handshake that turns "there is a device here" into "the queues
+// are live". Between them there is nothing device-specific: net, block
+// and console differ in their config space and their queue count, not
+// in any of this.
+//
+// PURE. Every access goes through `hal/mmio.nu`'s volatile load/store
+// against an address the caller supplies, which makes the whole thing
+// testable on the host by pointing `base` at an ordinary buffer and
+// letting the test play the device. No mock interface, no injected
+// function pointers: the device IS its register window, and a buffer
+// is a register window that does not move on its own.
+//
+// ── modern only, on purpose ──────────────────────────────────────
+//
+// Version 2 (VIRTIO_F_VERSION_1) and nothing else. The plan's B5 note
+// is precise about why "features to zero" is the wrong instinct: zero
+// deselects VERSION_1 itself and makes us a LEGACY driver — 10-byte
+// net header, PFN-based queue registers, guest-endian fields — and
+// virtio-mmio version 2 requires VERSION_1 anyway. So the rule is
+// "accept exactly VIRTIO_F_VERSION_1, reject every device-specific
+// bit", which yields the modern queue layout, a fixed 12-byte
+// virtio_net_hdr, no checksum offload and no MRG_RXBUF. Every checksum
+// is then computed by the pure stack in `net/`, which is what that
+// stack was built to do.
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/hal/mmio.nu`
+
+// ── the register window (spec §4.2.2) ────────────────────────────
+
+@ vio_reg_magic → i { ^ 0 }
+
+@ vio_reg_version → i { ^ 4 }
+
+@ vio_reg_device_id → i { ^ 8 }
+
+@ vio_reg_vendor_id → i { ^ 12 }
+
+@ vio_reg_device_features → i { ^ 16 }
+
+@ vio_reg_device_features_sel → i { ^ 20 }
+
+@ vio_reg_driver_features → i { ^ 32 }
+
+@ vio_reg_driver_features_sel → i { ^ 36 }
+
+@ vio_reg_queue_sel → i { ^ 48 }
+
+@ vio_reg_queue_num_max → i { ^ 52 }
+
+@ vio_reg_queue_num → i { ^ 56 }
+
+@ vio_reg_queue_ready → i { ^ 68 }
+
+@ vio_reg_queue_notify → i { ^ 80 }
+
+@ vio_reg_interrupt_status → i { ^ 96 }
+
+@ vio_reg_interrupt_ack → i { ^ 100 }
+
+@ vio_reg_status → i { ^ 112 }
+
+@ vio_reg_queue_desc_low → i { ^ 128 }
+
+@ vio_reg_queue_desc_high → i { ^ 132 }
+
+@ vio_reg_queue_driver_low → i { ^ 144 }
+
+@ vio_reg_queue_driver_high → i { ^ 148 }
+
+@ vio_reg_queue_device_low → i { ^ 160 }
+
+@ vio_reg_queue_device_high → i { ^ 164 }
+
+@ vio_reg_config_generation → i { ^ 252 }
+
+@ vio_reg_config → i { ^ 256 }
+
+// "virt", little-endian.
+@ vio_magic_value → i { ^ 1953655158 }
+
+// ── status bits (spec §2.1) ──────────────────────────────────────
+
+@ vio_status_acknowledge → i { ^ 1 }
+
+@ vio_status_driver → i { ^ 2 }
+
+@ vio_status_driver_ok → i { ^ 4 }
+
+@ vio_status_features_ok → i { ^ 8 }
+
+@ vio_status_needs_reset → i { ^ 64 }
+
+@ vio_status_failed → i { ^ 128 }
+
+// Feature bit 32. It lives in the upper word, which is why the
+// features registers are selected a word at a time.
+@ vio_f_version_1_word → i { ^ 1 }
+
+@ vio_f_version_1_bit → i { ^ 1 }
+
+// ── device ids we know by name ───────────────────────────────────
+
+@ vio_id_net → i { ^ 1 }
+
+@ vio_id_block → i { ^ 2 }
+
+@ vio_id_console → i { ^ 3 }
+
+@ vio_id_rng → i { ^ 4 }
+
+// ── probe ────────────────────────────────────────────────────────
+
+@ __rd i base i off → i { ^ ( mmio_read32 + base off ) }
+
+@ __wr i base i off i val → v { ( mmio_write32 + base off # i32 val ) }
+
+// What is at `base`? 0 means "nothing" — either no device (device_id
+// 0, which the spec uses for an empty slot) or something this driver
+// will not talk to. A wrong magic or a legacy version is reported as
+// absent rather than half-driven: a legacy device needs a different
+// queue layout and a different net header, and pretending otherwise
+// produces a device that accepts descriptors and delivers nothing.
+@ virtio_probe i base → i {
+    ? != ( __rd base ( vio_reg_magic ) ) ( vio_magic_value ) { ^ 0 } {}
+    ? != ( __rd base ( vio_reg_version ) ) 2 { ^ 0 } {}
+    ^ ( __rd base ( vio_reg_device_id ) )
+}
+
+@ virtio_vendor i base → i { ^ ( __rd base ( vio_reg_vendor_id ) ) }
+
+@ virtio_status i base → i { ^ ( __rd base ( vio_reg_status ) ) }
+
+@ virtio_set_status i base i bits → v {
+    ( __wr base ( vio_reg_status ) | ( __rd base ( vio_reg_status ) ) bits )
+}
+
+// A write of 0 to Status is the reset, and the spec requires waiting
+// for the device to answer 0 back before touching anything else.
+@ virtio_reset i base → v {
+    ( __wr base ( vio_reg_status ) 0 )
+    : ~ i spins 0
+    ~ && != ( __rd base ( vio_reg_status ) ) 0 < spins 1000000 {
+        = spins + spins 1
+    }
+}
+
+// The device's feature word `sel` (0 = bits 0-31, 1 = bits 32-63).
+@ virtio_device_features i base i sel → i {
+    ( __wr base ( vio_reg_device_features_sel ) sel )
+    ^ ( __rd base ( vio_reg_device_features ) )
+}
+
+@ virtio_set_driver_features i base i sel i bits → v {
+    ( __wr base ( vio_reg_driver_features_sel ) sel )
+    ( __wr base ( vio_reg_driver_features ) bits )
+}
+
+// The handshake, up to but not including DRIVER_OK: reset,
+// ACKNOWLEDGE, DRIVER, features, FEATURES_OK, and the re-read that
+// confirms the device accepted them.
+//
+// `want_lo` is the device-specific bits this driver is willing to take
+// from word 0; word 1 is always exactly VIRTIO_F_VERSION_1. Returns T
+// on success; on failure the device is left with FAILED set, because a
+// device the driver gave up on must not be left looking half-ready to
+// whatever runs next.
+@ virtio_init i base i want_lo → b {
+    ( virtio_reset base )
+    ( virtio_set_status base ( vio_status_acknowledge ) )
+    ( virtio_set_status base ( vio_status_driver ) )
+
+    : i dev_hi ( virtio_device_features base 1 )
+    ? == 0 & dev_hi ( vio_f_version_1_bit ) {
+        // No VERSION_1 means a legacy device behind a version-2
+        // register window — refuse rather than negotiate down.
+        ( virtio_set_status base ( vio_status_failed ) )
+        ^ F
+    } {}
+    : i dev_lo ( virtio_device_features base 0 )
+
+    ( virtio_set_driver_features base 0 & dev_lo want_lo )
+    ( virtio_set_driver_features base 1 ( vio_f_version_1_bit ) )
+
+    ( virtio_set_status base ( vio_status_features_ok ) )
+    ? == 0 & ( virtio_status base ) ( vio_status_features_ok ) {
+        ( virtio_set_status base ( vio_status_failed ) )
+        ^ F
+    } {}
+    ^ T
+}
+
+@ virtio_driver_ok i base → v {
+    ( virtio_set_status base ( vio_status_driver_ok ) )
+}
+
+// ── queues ───────────────────────────────────────────────────────
+
+@ virtio_queue_max i base i qidx → i {
+    ( __wr base ( vio_reg_queue_sel ) qidx )
+    ^ ( __rd base ( vio_reg_queue_num_max ) )
+}
+
+// Point queue `qidx` at a ring whose three parts live at the given
+// PHYSICAL addresses and mark it ready.
+//
+// Physical, not virtual: the device is a bus master and does not go
+// through our page tables. Under the identity map the two are equal,
+// which is a property of this target and not a property of virtio —
+// hence the parameter names saying which one they mean.
+@ virtio_queue_setup i base i qidx i qsize i desc_phys i driver_phys i device_phys → b {
+    ( __wr base ( vio_reg_queue_sel ) qidx )
+    ? != 0 ( __rd base ( vio_reg_queue_ready ) ) { ^ F } {}
+    : i maxq ( __rd base ( vio_reg_queue_num_max ) )
+    ? == maxq 0 { ^ F } {}
+    ? > qsize maxq { ^ F } {}
+    ( __wr base ( vio_reg_queue_num ) qsize )
+    ( __wr base ( vio_reg_queue_desc_low ) & desc_phys 4294967295 )
+    ( __wr base ( vio_reg_queue_desc_high ) & >> desc_phys 32 4294967295 )
+    ( __wr base ( vio_reg_queue_driver_low ) & driver_phys 4294967295 )
+    ( __wr base ( vio_reg_queue_driver_high ) & >> driver_phys 32 4294967295 )
+    ( __wr base ( vio_reg_queue_device_low ) & device_phys 4294967295 )
+    ( __wr base ( vio_reg_queue_device_high ) & >> device_phys 32 4294967295 )
+    ( __wr base ( vio_reg_queue_ready ) 1 )
+    ^ T
+}
+
+@ virtio_notify i base i qidx → v { ( __wr base ( vio_reg_queue_notify ) qidx ) }
+
+@ virtio_isr i base → i { ^ ( __rd base ( vio_reg_interrupt_status ) ) }
+
+@ virtio_isr_ack i base i bits → v { ( __wr base ( vio_reg_interrupt_ack ) bits ) }
+
+// Device configuration space, one byte at a time. The generation
+// counter is how a multi-byte field is read without tearing: read it,
+// read the field, read it again, and repeat if it changed.
+@ virtio_config_u8 i base i off → i {
+    ^ & ( __rd base + ( vio_reg_config ) & off ~ 3 ) 255
+}
+
+@ virtio_config_generation i base → i {
+    ^ ( __rd base ( vio_reg_config_generation ) )
+}
+
+// ── discovery from the kernel command line ───────────────────────
+//
+// With `acpi=off` QEMU microvm publishes its virtio-mmio devices as
+//
+//     virtio_mmio.device=512@0xfeb00000:12
+//                        size@base:irq
+//
+// on the kernel command line rather than in an ACPI table (plan B0).
+// Parsing that beats writing an AML interpreter by a wide margin, and
+// Firecracker uses the same convention, so this one path carries
+// through to the demos.
+//
+// `size` accepts the K/M suffixes Linux writes. The IRQ is parsed and
+// reported even though v1 polls every queue: a driver that discards it
+// cannot later become interrupt-driven without changing its discovery.
+
+: VioMmioDev {
+    i base
+    i size
+    i irq
+    b valid
+}
+
+@ __digit i c → i {
+    ? && >= c 48 <= c 57 { ^ - c 48 } {}
+    ? && >= c 97 <= c 102 { ^ - c 87 } {}
+    ? && >= c 65 <= c 70 { ^ - c 55 } {}
+    ^ -1
+}
+
+// Read a number at `off`, decimal or 0x-hex, stopping at the first
+// character that is not a digit. Returns the value; `end` is where it
+// stopped, via the caller's own scan.
+@ __num s text i off i len → i {
+    : ~ i k off
+    : ~ i base 10
+    ? && < + k 1 len && == ( nurl_str_get text k ) 48
+    || == ( nurl_str_get text + k 1 ) 120 == ( nurl_str_get text + k 1 ) 88 {
+        = base 16
+        = k + k 2
+    } {}
+    : ~ i v 0
+    ~ < k len {
+        : i d ( __digit ( nurl_str_get text k ) )
+        ? || < d 0 >= d base { = k len } {
+            = v + * v base d
+            = k + k 1
+        }
+    }
+    ^ v
+}
+
+@ __num_end s text i off i len → i {
+    : ~ i k off
+    ? && < + k 1 len && == ( nurl_str_get text k ) 48
+    || == ( nurl_str_get text + k 1 ) 120 == ( nurl_str_get text + k 1 ) 88 {
+        = k + k 2
+    } {}
+    : ~ i base ? > k off 16 10
+    : ~ b more T
+    ~ && more < k len {
+        : i d ( __digit ( nurl_str_get text k ) )
+        ? || < d 0 >= d base { = more F } { = k + k 1 }
+    }
+    ^ k
+}
+
+// The `idx`-th `virtio_mmio.device=` entry on the command line, or an
+// invalid device when there are fewer than that.
+@ virtio_mmio_from_cmdline s cmdline i idx → VioMmioDev {
+    : i n ( nurl_str_len cmdline )
+    : s key `virtio_mmio.device=`
+    : i klen ( nurl_str_len key )
+    : ~ i seen 0
+    : ~ i k 0
+    ~ <= k - n klen {
+        : ~ b match T
+        : ~ i j 0
+        ~ && match < j klen {
+            ? != ( nurl_str_get cmdline + k j ) ( nurl_str_get key j ) { = match F } {}
+            = j + j 1
+        }
+        ? match {
+            ? == seen idx {
+                : i p + k klen
+                : i size_v ( __num cmdline p n )
+                : i after ( __num_end cmdline p n )
+                : ~ i size size_v
+                : ~ i q after
+                ? < q n {
+                    : i c ( nurl_str_get cmdline q )
+                    ? || == c 75 == c 107 { = size * size 1024 = q + q 1 } {}
+                    ? || == c 77 == c 109 { = size * size 1048576 = q + q 1 } {}
+                } {}
+                // '@' then the base, ':' then the irq.
+                ? >= q n { ^ @ VioMmioDev { 0 0 0 F } } {}
+                ? != ( nurl_str_get cmdline q ) 64 { ^ @ VioMmioDev { 0 0 0 F } } {}
+                : i bstart + q 1
+                : i base_v ( __num cmdline bstart n )
+                : i bend ( __num_end cmdline bstart n )
+                : ~ i irq 0
+                ? && < bend n == ( nurl_str_get cmdline bend ) 58 {
+                    = irq ( __num cmdline + bend 1 n )
+                } {}
+                ^ @ VioMmioDev { base_v size irq T }
+            } {}
+            = seen + seen 1
+            = k + k klen
+        } { = k + k 1 }
+    }
+    ^ @ VioMmioDev { 0 0 0 F }
+}
+
+// How many entries the command line carries.
+@ virtio_mmio_count s cmdline → i {
+    : ~ i n 0
+    ~ . ( virtio_mmio_from_cmdline cmdline n ) valid { = n + n 1 }
+    ^ n
+}


### PR DESCRIPTION
`hal/virtq.nu` has owned the split-ring since A2 — descriptors, avail, used, 53 assertions and 8/8 mutations caught. What was missing is the other half of the contract: the register window a virtio-mmio device presents, and the handshake that turns "there is a device at this address" into "the queues are live".

`hal/virtio.nu` is that half, and it is **pure**: every access is a volatile load or store through `hal/mmio.nu` against an address the caller supplies. So a device is testable on the host with no mock interface and no injected accessors — point `base` at an ordinary buffer and let the test play the far side. The driver under test runs exactly the instructions it will run against `0xfeb00000`.

## Three decisions the plan pinned, now enforced by code

- **Modern only.** Version 2 and `VIRTIO_F_VERSION_1`, or the device is reported as *absent* rather than driven the wrong way. "Features to zero" is the wrong instinct and the plan says why: zero deselects VERSION_1 itself and makes us a legacy driver — 10-byte net header, PFN-based queue registers, guest-endian fields — while virtio-mmio v2 requires VERSION_1 anyway. With exactly VERSION_1 the queue layout is modern, the net header is a fixed 12 bytes, and there is no checksum offload — which is precisely what the pure stack in `net/` was built to handle.
- **A refusal is a refusal.** A device that clears FEATURES_OK, or one that offers no VERSION_1, leaves the driver stopped with FAILED set — not half-configured for whatever runs next.
- **Discovery is the command line.** With `acpi=off` QEMU microvm publishes `virtio_mmio.device=512@0xfeb00000:12` on the cmdline instead of in an ACPI table, and parsing that beats writing an AML interpreter. Firecracker uses the same convention, so this one path carries through to the B9/B10 demos. The IRQ is parsed and reported even though v1 polls every queue: a driver that discards it cannot become interrupt-driven later without changing its discovery.

## Test

`virtio_mmio`: 30 assertions over a buffer-as-device — probe (wrong magic, legacy version, empty slot), the feature handshake in both directions, a device that refuses the set, queue setup including **both halves of the 64-bit address** (a ring above 4 GiB lands somewhere else entirely if the high word is forgotten), a queue larger than the device allows, a queue that is already ready, notify, ISR acknowledge, and the cmdline parser down to the K/M suffixes Linux writes.

Hosted corpus 609 PASS, bootstrap fixed point held.

Next: the guest glue — the cmdline through to NURL, then virtio-net rx and tx against the ring logic that has been waiting since A2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1