### PR TITLE
B5.1: the guest finds its devices

### DIFF
--- a/unikernel/boot/platform_x86.c
+++ b/unikernel/boot/platform_x86.c
@@ -278,6 +278,7 @@ static u64 wall_base_sec;      /* CLOCK_REALTIME epoch at boot, 0 = unset */
  * command-line error.
  */
 static const char *cmdline;
+const char *nurl_boot_cmdline(void);
 
 static u64 cmdline_u64(const char *key) {
     const char *p = cmdline;
@@ -511,6 +512,19 @@ static void pf_shutdown(int code) {
  * Defining them here would duplicate the symbols AND skip both. The
  * machine's part is nl_exit_group, above. */
 void _exit(int code) { pf_shutdown(code); for (;;) { } }
+
+/* ── the command line, for NURL ──────────────────────────────────
+ *
+ * Device discovery happens in NURL (hal/virtio.nu parses the
+ * `virtio_mmio.device=` entries), so the string has to cross the
+ * boundary. Borrowed, not copied: it lives in memory the hypervisor
+ * placed and nothing here writes to it.
+ *
+ * The Linux freestanding build has no such thing and does not define
+ * this symbol — a program that reaches for the guest's command line
+ * fails to LINK there rather than reading an empty string and
+ * concluding there are no devices. */
+const char *nurl_boot_cmdline(void) { return cmdline ? cmdline : ""; }
 
 /* ── entry ───────────────────────────────────────────────────────── */
 

--- a/unikernel/demos/devices.expected
+++ b/unikernel/demos/devices.expected
@@ -1,0 +1,4 @@
+cmdline devices: 1
+device 0: id=1 (net) irq=yes queues=yes
+  features negotiated: yes
+probed ok: 1

--- a/unikernel/demos/devices.nu
+++ b/unikernel/demos/devices.nu
@@ -1,0 +1,65 @@
+// unikernel/demos/devices.nu — what did the hypervisor give us?
+//
+// The first program that talks to hardware: it reads the kernel
+// command line, walks the `virtio_mmio.device=` entries QEMU microvm
+// publishes there (acpi=off, so there is no ACPI table to walk), and
+// drives each device far enough to prove the transport works —
+// through the feature handshake, which is where a legacy device or a
+// disagreement about VERSION_1 shows up.
+//
+// It stops before DRIVER_OK: a device is not ready until its queues
+// are, and queues are the next piece of work. What this establishes is
+// that discovery, the register window and the handshake are right on
+// the real machine and not only against the buffer in virtio_mmio.nu.
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/hal/mmio.nu`
+$ `stdlib/hal/virtio.nu`
+
+& `c` @ nurl_boot_cmdline → s
+
+@ name_of i id → s {
+    ? == id ( vio_id_net ) { ^ `net` } {}
+    ? == id ( vio_id_block ) { ^ `block` } {}
+    ? == id ( vio_id_console ) { ^ `console` } {}
+    ? == id ( vio_id_rng ) { ^ `rng` } {}
+    ^ `other`
+}
+
+@ main → i {
+    : s cl ( nurl_boot_cmdline )
+    : i n ( virtio_mmio_count cl )
+    ( nurl_print `cmdline devices: ` ) ( nurl_print ( nurl_str_int n ) ) ( nurl_print `\n` )
+
+    : ~ i found 0
+    : ~ i k 0
+    ~ < k n {
+        : VioMmioDev d ( virtio_mmio_from_cmdline cl k )
+        : i id ( virtio_probe . d base )
+        ? != id 0 {
+            = found + found 1
+            ( nurl_print `device ` ) ( nurl_print ( nurl_str_int k ) )
+            ( nurl_print `: id=` ) ( nurl_print ( nurl_str_int id ) )
+            ( nurl_print ` (` ) ( nurl_print ( name_of id ) ) ( nurl_print `)` )
+            // The base address and the IRQ are the hypervisor's to
+            // choose and its version's to change, so what is printed
+            // is that they are THERE — a golden that pins QEMU's
+            // current layout would fail on the next QEMU.
+            ( nurl_print ` irq=` ) ( nurl_print ? > . d irq 0 `yes` `no` )
+            ( nurl_print ` queues=` ) ( nurl_print ? > ( virtio_queue_max . d base 0 ) 0 `yes` `no` )
+            ( nurl_print `\n` )
+            // The handshake, exactly VERSION_1 and no device-specific
+            // bits: this driver has no use for any of them yet, and
+            // taking a feature it does not implement is how a device
+            // starts delivering a format nobody parses.
+            : b ok ( virtio_init . d base 0 )
+            ( nurl_print `  features negotiated: ` )
+            ( nurl_print ? ok `yes` `no` )
+            ( nurl_print `\n` )
+        } {}
+        = k + k 1
+    }
+    ( nurl_print `probed ok: ` ) ( nurl_print ( nurl_str_int found ) ) ( nurl_print `\n` )
+    ^ ? > found 0 0 1
+}

--- a/unikernel/run_qemu.sh
+++ b/unikernel/run_qemu.sh
@@ -41,6 +41,13 @@ done
 [ -n "$IMG" ] || { echo "usage: run_qemu.sh image.elf [-t seconds]" >&2; exit 2; }
 command -v "$QEMU" >/dev/null 2>&1 || { echo "run_qemu.sh: $QEMU not found" >&2; exit 3; }
 
+# QEMU's virtio-mmio defaults to force-legacy=true, and a legacy device
+# is a different protocol: 10-byte net header, PFN-based queue
+# registers, guest-endian fields. hal/virtio.nu refuses one rather than
+# driving it wrong, so the guest reports "no device" against a default
+# QEMU — correctly, and confusingly. The flag is the host's half of
+# that decision.
+#
 # The clock, stated rather than guessed. Under KVM the guest reads the
 # TSC frequency from CPUID leaf 0x40000010 and ignores what we say here;
 # under TCG no leaf reports one, QEMU's virtual TSC ticks at 1 GHz, and
@@ -61,6 +68,7 @@ timeout -k 5s "${TIMEOUT}s" "$QEMU" \
     -M microvm,acpi=off,rtc=off \
     -accel "$ACCEL" -cpu max -m 256 \
     -nodefaults -no-reboot -no-user-config \
+    -global virtio-mmio.force-legacy=false \
     -kernel "$IMG" -append "tsc_khz=${NURL_TSC_KHZ:-1000000} wallclock=$(date +%s)" \
     -serial stdio -display none \
     ${EXTRA[@]+"${EXTRA[@]}"} > "$out" 2>&1

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -62,5 +62,33 @@ for name in "${names[@]}"; do
     fi
 done
 
-echo "── QEMU guest run: $((${#names[@]} - fails))/${#names[@]} ──"
+# ── the demos, which only exist in the guest ────────────────────
+# A corpus test cannot cover these: they talk to hardware, so there is
+# no hosted golden to compare against and no host on which to produce
+# one. Each demo carries its own expected output beside it, and the
+# QEMU arguments it needs are named here — a virtio-net device for the
+# one that goes looking for devices.
+demos=0
+if [ $# -eq 0 ]; then
+    for demo in devices; do
+        src="$ROOT/unikernel/demos/$demo.nu"
+        exp="$ROOT/unikernel/demos/$demo.expected"
+        [ -f "$src" ] && [ -f "$exp" ] || continue
+        demos=$((demos + 1))
+        if ! "$ROOT/unikernel/build_unikernel.sh" "$src" >/dev/null 2>&1; then
+            echo "FAIL $demo (build)"; fails=$((fails + 1)); continue
+        fi
+        got=$("$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/$demo.elf" -t 60 -- \
+              -netdev user,id=n0 -device virtio-net-device,netdev=n0 2>&1)
+        if [ "$got" = "$(cat "$exp")" ]; then
+            echo "PASS $demo (guest-only demo)"
+        else
+            echo "FAIL $demo"
+            diff "$exp" <(printf '%s\n' "$got") | head -6 | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+    done
+fi
+
+echo "── QEMU guest run: $((${#names[@]} + demos - fails))/$((${#names[@]} + demos)) ──"
 [ "$fails" -eq 0 ]


### PR DESCRIPTION
A real virtio-net device, discovered from the kernel command line, probed and feature-negotiated by NURL code on bare metal:

```
cmdline devices: 1
device 0: id=1 (net) irq=yes queues=yes
  features negotiated: yes
probed ok: 1
```

`unikernel/demos/devices.nu` is the first program in this repo that talks to hardware. It reads the command line through `nurl_boot_cmdline` — the guest's only new symbol, and one the Linux freestanding build deliberately does **not** define, so a program that reaches for it there fails to LINK rather than reading an empty string and concluding there are no devices — walks the `virtio_mmio.device=` entries, and drives each device through the feature handshake.

It stops before DRIVER_OK, because a device is not ready until its queues are, and queues are the next piece. What this establishes is that discovery, the register window and the negotiation are right on the real machine and not only against the buffer in `virtio_mmio.nu`.

## QEMU's virtio-mmio is legacy by default

`force-legacy=true` is the default, and a legacy device is a different protocol: 10-byte net header, PFN-based queue registers, guest-endian fields. `hal/virtio.nu` refuses one rather than driving it wrong — so against a default QEMU the guest reported "no device", correctly and confusingly, since the magic value matched and only the version register said 1. `-global virtio-mmio.force-legacy=false` is the host's half of that decision and now lives in `run_qemu.sh` with the reason beside it.

## The demo carries its own golden

A program that talks to hardware has no hosted golden to compare against and no host on which to produce one, so the expected output lives next to the demo. What it prints is chosen to survive a QEMU upgrade: the base address and the IRQ number are the hypervisor's to choose and its version's to change, so the golden pins that they are *there* rather than what they are.

```
  unikernel/run_qemu_tests.sh    →  10/10
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1