### PR TITLE
B5.2/B6.0: a frame leaves the machine, and one comes back

### DIFF
--- a/unikernel/demos/netdev.expected
+++ b/unikernel/demos/netdev.expected
@@ -1,0 +1,6 @@
+nic ready: yes
+mac from config space: yes
+first send is ARP-pending: yes
+gateway MAC learned over the wire: yes
+datagram sent: yes
+frames received: yes

--- a/unikernel/demos/netdev.nu
+++ b/unikernel/demos/netdev.nu
@@ -1,0 +1,126 @@
+// unikernel/demos/netdev.nu — the sans-IO stack, on a real NIC.
+//
+// Everything below has been true for a while in pieces: the stack has
+// run under a scripted clock since A1, over a loopback since A4, and
+// the device has been discovered and negotiated since B5.1. This is
+// the first program in which a frame the stack built leaves the
+// machine and a frame from outside comes back.
+//
+// The proof is an ARP exchange with QEMU's user-mode network. It is
+// deliberately the smallest thing that cannot happen by accident: the
+// gateway only answers a well-formed request addressed to it, the
+// reply only reaches us if the receive queue was posted correctly, and
+// the cache only fills if what came back parsed.
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/net/pktbuf.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/eth.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/arp.nu`
+$ `stdlib/net/icmp.nu`
+$ `stdlib/net/udp4.nu`
+$ `stdlib/net/stack.nu`
+$ `stdlib/hal/mmio.nu`
+$ `stdlib/hal/virtq.nu`
+$ `stdlib/hal/virtio.nu`
+$ `unikernel/drivers/virtionet.nu`
+
+// QEMU's user-mode network hands out this address space whatever the
+// host looks like: the guest is .15, the gateway .2, the DNS server .3.
+@ my_ip → i { ^ ( ipv4_make 10 0 2 15 ) }
+
+@ gw_ip → i { ^ ( ipv4_make 10 0 2 2 ) }
+
+@ mask24 → i { ^ ( ipv4_make 255 255 255 0 ) }
+
+@ ms → i { ^ / ( monotonic_ns ) 1000000 }
+
+// Move whatever the stack has queued onto the wire, then whatever the
+// wire has for us into the stack. One turn.
+@ pump * VirtioNet nic * NetStack st * PktBuf out → i {
+    : i n ( pktbuf_count out )
+    : ~ i k 0
+    ~ < k n {
+        : ( Vec u ) f ( vec_new [u] )
+        ( pktbuf_copy_to f out k )
+        : b _ok ( vnet_tx nic f 0 ( vec_len [u] f ) )
+        ( vec_free [u] f )
+        = k + k 1
+    }
+    ( pktbuf_clear out )
+
+    : ~ i got 0
+    : ~ b more T
+    ~ more {
+        : ( Vec u ) in ( vec_new [u] )
+        : i len ( vnet_rx nic in )
+        ? > len 0 {
+            : RxResult r ( stack_rx st in ( ms ) out )
+            = got + got 1
+        } { = more F }
+        ( vec_free [u] in )
+    }
+    ^ got
+}
+
+@ main → i {
+    : *VirtioNet nic ( vnet_open 64 )
+    ? ! ( vnet_ready nic ) {
+        ( nurl_print `no virtio-net device\n` )
+        ^ 1
+    } {}
+    ( nurl_print `nic ready: yes\n` )
+    ( nurl_print `mac from config space: ` )
+    ( nurl_print ? != ( vnet_mac nic ) 0 `yes` `no` )
+    ( nurl_print `\n` )
+
+    : *NetStack st ( stack_new ( vnet_mac nic ) ( my_ip ) ( mask24 ) ( gw_ip ) )
+    : *PktBuf out ( pktbuf_new )
+
+    // A UDP datagram to the gateway is the smallest thing that makes
+    // the stack want a MAC address it does not have — so the first
+    // frame out is an ARP request, and the answer has to travel the
+    // whole path back.
+    : ( Vec u ) payload ( vec_new [u] )
+    ( bytes_extend_str payload `nurl` )
+    : TxResult t ( stack_tx_udp st ( gw_ip ) 4000 9 payload 0 4 ( ms ) out )
+    ( nurl_print `first send is ARP-pending: ` )
+    ( nurl_print ? == . t status ( tx_arp_pending ) `yes` `no` )
+    ( nurl_print `\n` )
+
+    : ~ b resolved F
+    : ~ i rounds 0
+    ~ && ! resolved < rounds 2000 {
+        ( pump nic st out )
+        = resolved ?? ( arp_cache_lookup . st arp ( gw_ip ) ( ms ) ) { T _m → T F → F }
+        = rounds + rounds 1
+    }
+    ( nurl_print `gateway MAC learned over the wire: ` )
+    ( nurl_print ? resolved `yes` `no` )
+    ( nurl_print `\n` )
+
+    // With the address known the datagram goes for real. Nothing
+    // answers port 9 (discard), so what is asserted is that the send
+    // path completed rather than that anything replied.
+    ? resolved {
+        : TxResult t2 ( stack_tx_udp st ( gw_ip ) 4000 9 payload 0 4 ( ms ) out )
+        ( nurl_print `datagram sent: ` )
+        ( nurl_print ? == . t2 status ( tx_sent ) `yes` `no` )
+        ( nurl_print `\n` )
+        ( pump nic st out )
+    } {}
+
+    ( nurl_print `frames received: ` )
+    ( nurl_print ? > . st rx_frames 0 `yes` `no` )
+    ( nurl_print `\n` )
+
+    ( vec_free [u] payload )
+    ( pktbuf_free out )
+    ( stack_free st )
+    ( vnet_close nic )
+    ^ ? resolved 0 1
+}

--- a/unikernel/drivers/virtionet.nu
+++ b/unikernel/drivers/virtionet.nu
@@ -1,0 +1,291 @@
+// unikernel/drivers/virtionet.nu — frames in, frames out, over a real
+// device.
+//
+// This is the glue B5 exists to write, and it is deliberately thin:
+// the ring bookkeeping is `hal/virtq.nu` (A2, mutation-tested), the
+// register protocol is `hal/virtio.nu` (B5.0, tested against a
+// buffer), and everything above the frame is the sans-IO stack in
+// `net/`. What is left for this file is the part that can only be
+// written where the hardware is — buffers, their physical addresses,
+// and the two queues' rhythm.
+//
+// PHYSICAL ADDRESSES. The device is a bus master: it does not go
+// through our page tables, so every address it is handed must be
+// physical. The guest identity-maps the low 4 GiB, so virtual equals
+// physical here — and saying that out loud is the point, because it is
+// a property of this target and not of virtio. When B2's memory work
+// grows a mapping that is not the identity, every `# i ( vec_data … )`
+// below becomes a translation, and they are all in this file.
+//
+// THE HEADER. With exactly VIRTIO_F_VERSION_1 negotiated and no
+// device-specific bits, every packet carries a fixed 12-byte
+// `virtio_net_hdr`: all zeros on transmit, ignorable on receive. No
+// checksum offload, no TSO, no MRG_RXBUF — every checksum is computed
+// by the pure stack, which is what it was built for.
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/hal/mmio.nu`
+$ `stdlib/hal/virtq.nu`
+$ `stdlib/hal/virtio.nu`
+
+& `c` @ nurl_boot_cmdline → s
+
+// virtio-net's queue 0 is receive, queue 1 is transmit (spec §5.1.2).
+@ vnet_rxq → i { ^ 0 }
+
+@ vnet_txq → i { ^ 1 }
+
+// The modern header, fixed size, zero-filled on transmit.
+@ vnet_hdr_len → i { ^ 12 }
+
+// One receive buffer per descriptor: no MRG_RXBUF was negotiated, so
+// the device puts each frame in exactly one buffer and a frame that
+// does not fit is dropped by the device rather than split. 2048 holds
+// the header plus a 1500-byte MTU with room to spare.
+@ vnet_buf_len → i { ^ 2048 }
+
+// A Vec is a value — a handle struct, not a pointer — so a pool of
+// them is a pool of heap copies of the handle. Boxing says that once,
+// here, instead of at every push.
+: VecBox { ( Vec u ) v }
+
+@ __vec_box ( Vec u ) v → i {
+    : *VecBox bx # *VecBox ( nurl_alloc Z VecBox )
+    = . bx v v
+    ^ # i bx
+}
+
+: VirtioNet {
+    i base
+    i mac  // read from config space, big-endian in the wire sense
+    * Virtq rx
+    * Virtq tx
+    ( Vec i ) rxbuf  // one *(Vec u) per descriptor, as an integer
+    ( Vec i ) txbuf
+    i rx_posted
+    b ready
+}
+
+@ __cfg_u8 i base i off → i {
+    // Config space is byte-addressable; a 32-bit read at the aligned
+    // word and a shift is what a device that only answers word reads
+    // needs, and works either way.
+    : i word ( mmio_read32 + + base ( vio_reg_config ) & off ~ 3 )
+    ^ & >> word * 8 & off 3 255
+}
+
+// Six bytes of MAC, most significant first, packed into an integer the
+// way net/eth.nu spells one.
+@ __read_mac i base → i {
+    : ~ i m 0
+    : ~ i k 0
+    ~ < k 6 {
+        = m | << m 8 ( __cfg_u8 base k )
+        = k + k 1
+    }
+    ^ m
+}
+
+@ __buf_new i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] n )
+    : ~ i k 0
+    ~ < k n { ( vec_push [u] v # u 0 ) = k + k 1 }
+    ^ v
+}
+
+@ __buf_phys ( Vec u ) v → i { ^ # i ( vec_data [u] v ) }
+
+@ __vq_phys * Virtq q i off → i { ^ + # i ( vec_data [u] . q mem ) off }
+
+// Find the first virtio-net device the command line names, bring it
+// up, and hand back a driver with both queues live. A null pointer
+// means there is no such device — which is a fact about the machine,
+// not an error, and the caller decides what to do about it.
+@ vnet_open i qsize → *VirtioNet {
+    : s cl ( nurl_boot_cmdline )
+    : i n ( virtio_mmio_count cl )
+    : ~ i k 0
+    ~ < k n {
+        : VioMmioDev d ( virtio_mmio_from_cmdline cl k )
+        ? == ( virtio_probe . d base ) ( vio_id_net ) {
+            : *VirtioNet nic ( __vnet_bring_up . d base qsize )
+            ? != # i nic 0 { ^ nic } {}
+        } {}
+        = k + k 1
+    }
+    ^ # *VirtioNet 0
+}
+
+@ __vnet_bring_up i base i qsize → *VirtioNet {
+    // No device-specific features: not even MAC. The address is read
+    // from config space either way, and a feature this driver does not
+    // implement is a format it would then have to parse.
+    ? ! ( virtio_init base 0 ) { ^ # *VirtioNet 0 } {}
+
+    : i maxq ( virtio_queue_max base ( vnet_rxq ) )
+    ? == maxq 0 { ^ # *VirtioNet 0 } {}
+    : i qs ? > qsize maxq maxq qsize
+
+    : *VirtioNet nic # *VirtioNet ( nurl_alloc Z VirtioNet )
+    = . nic base base
+    = . nic mac ( __read_mac base )
+    = . nic rx ( virtq_new qs )
+    = . nic tx ( virtq_new qs )
+    = . nic rxbuf ( vec_new [i] )
+    = . nic txbuf ( vec_new [i] )
+    = . nic rx_posted 0
+    = . nic ready F
+
+    ? ! ( __queue_live base ( vnet_rxq ) . nic rx qs ) { ^ nic } {}
+    ? ! ( __queue_live base ( vnet_txq ) . nic tx qs ) { ^ nic } {}
+
+    // DRIVER_OK last, and only once both queues are live: it is the
+    // driver telling the device it may start using them, and a device
+    // that starts using a queue that is not there writes into whatever
+    // address the register still held.
+    ( virtio_driver_ok base )
+    = . nic ready T
+    ( __rx_refill nic )
+    ^ nic
+}
+
+@ __queue_live i base i qidx * Virtq q i qs → b {
+    ^ ( virtio_queue_setup base qidx qs
+    ( __vq_phys q ( vq_desc_off ) )
+    ( __vq_phys q ( vq_avail_off qs ) )
+    ( __vq_phys q ( vq_used_off qs ) ) )
+}
+
+@ vnet_ready * VirtioNet nic → b {
+    ? == # i nic 0 { ^ F } {}
+    ^ . nic ready
+}
+
+@ vnet_mac * VirtioNet nic → i {
+    ? == # i nic 0 { ^ 0 } {}
+    ^ . nic mac
+}
+
+// Keep the receive queue full. Every descriptor the device has
+// completed is refilled with the same buffer, so the buffer pool is
+// allocated once and never grows: a driver that allocates per packet
+// is a driver that stops working under load, which is exactly when it
+// matters.
+@ __rx_refill * VirtioNet nic → i {
+    : ~ i added 0
+    ~ > ( virtq_num_free . nic rx ) 0 {
+        : i slot ( vec_len [i] . nic rxbuf )
+        : ( Vec u ) b ( __buf_new ( vnet_buf_len ) )
+        ?? ( virtq_add_single . nic rx ( __buf_phys b ) ( vnet_buf_len ) T ) {
+            T _d → {
+                ( vec_push [i] . nic rxbuf ( __vec_box b ) )
+                = added + added 1
+            }
+            F → {
+                ( vec_free [u] b )
+                = added added
+            }
+        }
+        ? == added 0 { ^ 0 } {}
+        ? >= ( vec_len [i] . nic rxbuf ) 1024 { ^ added } {}
+    }
+    ? > added 0 { ( virtio_notify . nic base ( vnet_rxq ) ) } {}
+    ^ added
+}
+
+// One received frame, or 0 bytes. The 12-byte header is stripped here
+// — nothing above this file has any use for it, and a stack that had
+// to skip it would be a stack that knows which device it is on.
+@ vnet_rx * VirtioNet nic ( Vec u ) out → i {
+    ? ! ( vnet_ready nic ) { ^ 0 } {}
+    ?? ( virtq_get_used . nic rx ) {
+        T head → {
+            : i len ( virtq_last_used_len . nic rx )
+            : i addr ( virtq_desc_addr . nic rx head )
+            : i n ? > len ( vnet_hdr_len ) - len ( vnet_hdr_len ) 0
+            ? > n 0 {
+                ( bytes_extend_raw out # s + addr ( vnet_hdr_len ) n )
+            } {}
+            // Hand the descriptor straight back: the buffer is still
+            // ours and still the right size.
+            ( virtq_desc_set . nic rx head addr ( vnet_buf_len ) 2 ( vq_null ) )
+            ( virtq_avail_push . nic rx head )
+            ( virtio_notify . nic base ( vnet_rxq ) )
+            ^ n
+        }
+        F → 0
+    }
+}
+
+// Send one frame. The header is a separate descriptor rather than a
+// copy into a bigger buffer: the caller's frame is already contiguous,
+// and a chain of two says so without moving it.
+@ vnet_tx * VirtioNet nic ( Vec u ) frame i off i len → b {
+    ? ! ( vnet_ready nic ) { ^ F } {}
+    ? <= len 0 { ^ F } {}
+    ( __tx_reap nic )
+
+    : ( Vec u ) pkt ( __buf_new + ( vnet_hdr_len ) len )
+    : ~ i k 0
+    ~ < k len {
+        : b _ok ( vec_set [u] pkt + ( vnet_hdr_len ) k
+        ?? ( vec_get [u] frame + off k ) { T x → x F → # u 0 } )
+        = k + k 1
+    }
+    ?? ( virtq_add_single . nic tx ( __buf_phys pkt ) + ( vnet_hdr_len ) len F ) {
+        T _d → {
+            ( vec_push [i] . nic txbuf ( __vec_box pkt ) )
+            ( virtio_notify . nic base ( vnet_txq ) )
+            ^ T
+        }
+        F → {
+            ( vec_free [u] pkt )
+            ^ F
+        }
+    }
+}
+
+// Reclaim descriptors the device has finished transmitting. The
+// buffers stay in the pool: they are reused by index, and freeing one
+// the device has not finished with is the bug this reaping exists to
+// avoid.
+@ __tx_reap * VirtioNet nic → i {
+    : ~ i n 0
+    ~ ( virtq_has_used . nic tx ) {
+        ?? ( virtq_get_used . nic tx ) {
+            T head → {
+                : i _f ( virtq_free_chain . nic tx head )
+                = n + n 1
+            }
+            F → { ^ n }
+        }
+    }
+    ^ n
+}
+
+@ vnet_close * VirtioNet nic → v {
+    ? == # i nic 0 { ^ } {}
+    ( virtio_reset . nic base )
+    ( __free_pool . nic rxbuf )
+    ( __free_pool . nic txbuf )
+    ( vec_free [i] . nic rxbuf )
+    ( vec_free [i] . nic txbuf )
+    ( virtq_free . nic rx )
+    ( virtq_free . nic tx )
+    ( nurl_free # s nic )
+}
+
+@ __free_pool ( Vec i ) pool → v {
+    : i n ( vec_len [i] pool )
+    : ~ i k 0
+    ~ < k n {
+        : *VecBox b # *VecBox ?? ( vec_get [i] pool k ) { T x → x F → 0 }
+        ? != # i b 0 {
+            ( vec_free [u] . b v )
+            ( nurl_free # s b )
+        } {}
+        = k + k 1
+    }
+}

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -70,7 +70,7 @@ done
 # one that goes looking for devices.
 demos=0
 if [ $# -eq 0 ]; then
-    for demo in devices; do
+    for demo in devices netdev; do
         src="$ROOT/unikernel/demos/$demo.nu"
         exp="$ROOT/unikernel/demos/$demo.expected"
         [ -f "$src" ] && [ -f "$exp" ] || continue


### PR DESCRIPTION
The stack has run under a scripted clock since A1, over a loopback since A4, and the device has been discovered and negotiated since B5.1. This is the first program in which a frame the sans-IO stack built **leaves the machine**, and a frame from outside comes back.

```
nic ready: yes
mac from config space: yes
first send is ARP-pending: yes
gateway MAC learned over the wire: yes
datagram sent: yes
frames received: yes
```

## The driver is thin, and that is the point

`unikernel/drivers/virtionet.nu`: the ring bookkeeping is `hal/virtq.nu` (A2, 53 assertions, 8/8 mutations), the register protocol is `hal/virtio.nu` (B5.0, tested against a buffer), and everything above the frame is `net/`. What is left for the driver is the part that can only be written where the hardware is — buffers, their physical addresses, and the two queues' rhythm.

Three things it says out loud rather than assuming:

- **Physical addresses.** The device is a bus master and does not go through our page tables. The guest identity-maps the low 4 GiB, so virtual equals physical — a property of *this target*, not of virtio. When the mapping stops being the identity, every translation is in this one file.
- **The header is 12 bytes and always zero.** That follows from accepting exactly `VIRTIO_F_VERSION_1` and no device-specific bits: no checksum offload, no TSO, no MRG_RXBUF, so every checksum is the pure stack's to compute — which is what it was built for. The header is stripped in the driver; a stack that had to skip it would be a stack that knows which device it is on.
- **DRIVER_OK last, and only once both queues are live.** It is the driver telling the device it may start using them, and a device that starts using a queue that is not there writes into whatever address the register still held.

## The proof

`unikernel/demos/netdev.nu` does an ARP exchange with QEMU's user-mode network — deliberately the smallest thing that cannot happen by accident. The gateway only answers a well-formed request addressed to it; the reply only arrives if the receive queue was posted correctly; the cache only fills if what came back parsed. All three have to be right for one line of output to change.

```
  unikernel/run_qemu_tests.sh    →  11/11
```

Hosted corpus green, `run_nolibc_tests.sh` unaffected (the driver is guest-only: it reaches for `nurl_boot_cmdline`, which the Linux freestanding build deliberately does not define).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1