### PR TITLE
B6.2: the socket layer reaches the wire

### DIFF
--- a/stdlib/net/stack.nu
+++ b/stdlib/net/stack.nu
@@ -175,7 +175,17 @@ $ `stdlib/net/pktbuf.nu`
 // Which MAC should carry a datagram for `dst`? On-link destinations
 // resolve to themselves; everything else goes to the gateway. Broadcast
 // and directed-broadcast go to the Ethernet broadcast address.
+// 127.0.0.0/8 is this machine, whatever address the interface has.
+@ ipv4_is_loopback i addr → b { ^ == & addr 4278190080 2130706432 }
+
 @ __next_hop * NetStack st i dst → i {
+    // A datagram for ourselves goes to our own MAC, so it comes back
+    // through the same door every other frame does. Loopback is not a
+    // special case in the stack — it is a destination that happens to
+    // be us, and the driver above decides that a frame addressed to
+    // our own MAC never reaches the wire.
+    ? ( ipv4_is_loopback dst ) { ^ dst } {}
+    ? == dst . st our_ip { ^ dst } {}
     ? ( ipv4_is_broadcast dst ) { ^ dst } {}
     ? && != . st netmask 0 == dst ( ipv4_subnet_broadcast . st our_ip . st netmask ) { ^ 4294967295 } {}
     ? && != . st netmask 0 ( ipv4_in_subnet dst . st our_ip . st netmask ) { ^ dst } {}
@@ -269,7 +279,10 @@ $ `stdlib/net/pktbuf.nu`
     // DHCP completes) for 255.255.255.255 — the DHCP reply itself
     // arrives before we own an address, so a strict "must match our
     // IP" test here would make the lease unobtainable.
-    : b for_us ? != . st our_ip 0 {
+    // Loopback is always ours, even before DHCP has given us anything
+    // else: a program that talks to 127.0.0.1 does not care whether
+    // the machine has an address on any network.
+    : b for_us ? ( ipv4_is_loopback . ih dst ) T ? != . st our_ip 0 {
         || || == . ih dst . st our_ip ( ipv4_is_broadcast . ih dst ) && != . st netmask 0 == . ih dst ( ipv4_subnet_broadcast . st our_ip . st netmask )
     } ( ipv4_is_broadcast . ih dst )
     ? ! for_us {

--- a/unikernel/build_unikernel.sh
+++ b/unikernel/build_unikernel.sh
@@ -52,7 +52,8 @@ KFLAGS="-ffreestanding -fno-stack-protector -fno-builtin -mno-red-zone
 # The NURL program, plus the socket layer if it uses one. Same script as
 # the Linux freestanding build — the decision is measured there, and
 # duplicating it here is how the two would drift.
-"$ROOT/unikernel/compile_nu.sh" "$SRC" "$OUTDIR/$base.ll" "$OUTDIR"
+NURL_NETDEV="$ROOT/unikernel/net/netdev_virtio.nu" \
+    "$ROOT/unikernel/compile_nu.sh" "$SRC" "$OUTDIR/$base.ll" "$OUTDIR"
 # compile_nu.sh leaves a hosted-flavoured object; recompile the IR with
 # the kernel flags. `zig cc` drops -O for .ll inputs (#644) and plain
 # clang needs the target flags spelled out for IR input too.

--- a/unikernel/compile_nu.sh
+++ b/unikernel/compile_nu.sh
@@ -60,6 +60,11 @@ root_nu="$WORK/__with_sockets.nu"
     echo "// $name needs:$(printf ' %s' $need)"
     printf '$ `%s`\n' "$(cd "$(dirname "$SRC")" && pwd)/$(basename "$SRC")"
     printf '$ `%s`\n' "$SHIM"
+    # The interface implementation, chosen by the target rather than by
+    # a conditional inside the shim: the guest has a virtio-net device,
+    # a Linux -nostdlib process has none, and both spellings of "the
+    # network" are the same three functions.
+    printf '$ `%s`\n' "${NURL_NETDEV:-$ROOT/unikernel/net/netdev_none.nu}"
 } > "$root_nu"
 
 "$ROOT/build/nurlc" "$root_nu" > "$OUT_LL" 2>"$WORK/compile.err" || exit 3

--- a/unikernel/net/netdev_none.nu
+++ b/unikernel/net/netdev_none.nu
@@ -1,0 +1,17 @@
+// unikernel/net/netdev_none.nu — the machine has no network interface.
+//
+// One of two implementations of the same three functions; the other is
+// netdev_virtio.nu, and the build picks one. This is not a stub in the
+// sense this directory distrusts: "there is no interface" is a true
+// statement about a Linux -nostdlib process, which reaches the network
+// through a kernel it is not allowed to call, and the socket layer
+// above answers it by running everything over loopback — which is
+// exactly what the 449 corpus tests exercise.
+
+@ netdev_open → i { ^ 0 }
+
+@ netdev_mac → i { ^ 0 }
+
+@ netdev_rx s buf i cap → i { ^ 0 }
+
+@ netdev_tx s buf i len → i { ^ 0 }

--- a/unikernel/net/netdev_virtio.nu
+++ b/unikernel/net/netdev_virtio.nu
@@ -1,0 +1,52 @@
+// unikernel/net/netdev_virtio.nu — the interface is a virtio-net
+// device.
+//
+// The guest's half of the pair whose other half is netdev_none.nu:
+// three functions, chosen by the build, so the socket layer above has
+// one seam rather than a conditional. Everything real is in
+// drivers/virtionet.nu; this file is the adapter that turns a driver
+// object into the four calls the shim makes.
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/hal/mmio.nu`
+$ `stdlib/hal/virtq.nu`
+$ `stdlib/hal/virtio.nu`
+$ `unikernel/drivers/virtionet.nu`
+
+: ~ i g_nic 0
+
+@ netdev_open → i {
+    ? != g_nic 0 { ^ 1 } {}
+    : *VirtioNet nic ( vnet_open 64 )
+    ? ! ( vnet_ready nic ) { ^ 0 } {}
+    = g_nic # i nic
+    ^ 1
+}
+
+@ netdev_mac → i {
+    ? == g_nic 0 { ^ 0 } {}
+    ^ ( vnet_mac # *VirtioNet g_nic )
+}
+
+// One frame into `buf`, or 0 when the device has none. The copy is
+// unavoidable at this seam: the driver owns the receive buffer and
+// hands it straight back to the device, so a caller that kept a
+// pointer into it would be reading a buffer the device is refilling.
+@ netdev_rx s buf i cap → i {
+    ? == g_nic 0 { ^ 0 } {}
+    : ( Vec u ) f ( vec_new [u] )
+    : i n ( vnet_rx # *VirtioNet g_nic f )
+    : i take ? > n cap cap n
+    ? > take 0 { ( nurl_memcpy buf # s ( vec_data [u] f ) take ) } {}
+    ( vec_free [u] f )
+    ^ take
+}
+
+@ netdev_tx s buf i len → i {
+    ? == g_nic 0 { ^ 0 } {}
+    : ( Vec u ) f ( vec_new [u] )
+    ( bytes_extend_raw f buf len )
+    : b ok ( vnet_tx # *VirtioNet g_nic f 0 len )
+    ( vec_free [u] f )
+    ^ ? ok len 0
+}

--- a/unikernel/net/sockets.nu
+++ b/unikernel/net/sockets.nu
@@ -57,6 +57,11 @@ $ `stdlib/net/tcp.nu`
 $ `stdlib/net/tcpstack.nu`
 $ `stdlib/net/socket.nu`
 
+// The interface, whichever one this build has: netdev_virtio.nu in the
+// guest, netdev_none.nu everywhere else. Two implementations of three
+// functions, chosen by the build, so this file has a seam rather than
+// a conditional — and so the loopback path is the same code on both.
+
 // One coroutine step, and whether anything ran. Main context only —
 // `nurl_bare_poll` answers 0 on a fiber rather than switching through
 // the loop context it would have to return through.
@@ -125,7 +130,7 @@ $ `stdlib/net/socket.nu`
     = . sh w_fd ( vec_new [i] )
     = . sh w_wr ( vec_new [i] )
     = . sh w_coro ( vec_new [i] )
-    = . sh has_device 0
+    = . sh has_device ( netdev_open )
     // An interface knows its own MAC. Without this the first connect
     // to 127.0.0.1 ARPs for itself and waits a retransmit timeout for
     // the answer.
@@ -197,9 +202,61 @@ $ `stdlib/net/socket.nu`
 
 // One turn of the event loop: deliver what the stack has queued, then
 // let its timers run. Returns 1 if anything happened.
+// Where a frame goes. A frame addressed to our own MAC is a frame for
+// us — that is what `net/stack.nu` routes 127.0.0.0/8 and our own
+// address to — and it never reaches the wire. Everything else does.
+//
+// One interface plus loopback, decided per frame by the destination
+// MAC, is the whole routing table. It is enough because it is the
+// truth about this machine.
+@ __frame_is_local ( Vec u ) f → b {
+    : *Shim sh ( __shim )
+    : EthHdr eh ( eth_parse f )
+    ? ! . eh valid { ^ T } {}
+    ^ == . eh dst . . sh net our_mac
+}
+
 @ __drive i now → i {
-    : *SockTab st ( __tab )
-    ? > ( sock_loopback st now ) 0 { ( __wake_ready ) ^ 1 } {}
+    : *Shim sh ( __shim )
+    : *SockTab st . sh st
+    : ~ i moved 0
+
+    // Out first: whatever the stack queued goes to the wire or back
+    // through the door, one frame at a time.
+    : *PktBuf w ( sock_take_out st )
+    : i n ( pktbuf_count w )
+    : ~ i k 0
+    ~ < k n {
+        : ( Vec u ) f ( vec_new [u] )
+        ( pktbuf_copy_to f w k )
+        ? ( __frame_is_local f ) {
+            : i _r ( sock_rx st f now )
+        } {
+            : i _t ( netdev_tx # s ( vec_data [u] f ) ( vec_len [u] f ) )
+        }
+        ( vec_free [u] f )
+        = moved + moved 1
+        = k + k 1
+    }
+    ( pktbuf_free w )
+
+    // Then in: everything the device has for us.
+    ? != . sh has_device 0 {
+        : ~ b more T
+        ~ more {
+            : ( Vec u ) in ( vec_with_cap [u] 2048 )
+            ( vec_set_len [u] in 2048 )
+            : i len ( netdev_rx # s ( vec_data [u] in ) 2048 )
+            ? > len 0 {
+                ( vec_set_len [u] in len )
+                : i _r ( sock_rx st in now )
+                = moved + moved 1
+            } { = more F }
+            ( vec_free [u] in )
+        }
+    } {}
+
+    ? > moved 0 { ( __wake_ready ) ^ 1 } {}
     ? > ( sock_tick st now ) 0 { ( __wake_ready ) ^ 1 } {}
     ^ 0
 }


### PR DESCRIPTION
The socket shim has pumped its frames around a loopback since A4.2. It now decides **per frame**: a frame addressed to our own MAC is a frame for us and goes back through the same door; everything else goes to the device.

One interface plus loopback, decided by the destination MAC, is the whole routing table — and it is enough because it is the truth about this machine. `net/stack.nu` supplies the other half: `127.0.0.0/8` is always ours, *before* DHCP has given us anything else, and a datagram for ourselves routes to our own MAC rather than to a gateway. A program that talks to 127.0.0.1 does not care whether the machine has an address on any network.

## The device is a seam, not a conditional

`netdev_open/mac/rx/tx` has two implementations — `netdev_virtio.nu` in the guest, `netdev_none.nu` everywhere else — and the build picks one. A Linux `-nostdlib` process genuinely has no interface (it reaches the network through a kernel it may not call), so "no device" is a true statement there rather than a stub, and the loopback path is the same code on both targets. That is what keeps the 449-test corpus meaningful as a test of the guest.

## Verified both ways

- `unikernel/run_nolibc_tests.sh` — 449 PASS / 0 FAIL, socket tests included (netdev_none).
- `net_socket` — 58 assertions of fd semantics, TCP and UDP over loopback — passes **inside the guest with a real virtio-net device attached**. That is the case that proves the per-frame decision: every loopback frame has to stay home while the device is right there.
- `unikernel/run_qemu_tests.sh` 12/12.

## Not yet

The shim still addresses itself as 127.0.0.1, so a listener is not reachable from the host. Running the DHCP client at socket-layer init — the exchange #785 already proves works over this device — is the next step, and after it the exit criterion is curl through a QEMU port-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1