### PR TITLE
B6: curl gets an answer from a machine with no operating system

### DIFF
--- a/stdlib/net/socket.nu
+++ b/stdlib/net/socket.nu
@@ -419,8 +419,21 @@ $ `stdlib/net/tcpstack.nu`
 @ sock_seed_self * SockTab st i now → v {
     : *NetStack net . . st ts net
     ? == . net our_ip 0 { ^ } {}
-    ( arp_cache_insert . net arp . net our_ip . net our_mac now )
+    ( sock_seed_addr st . net our_ip now )
 }
+
+// The same, for an address we answer to that is not the interface's:
+// 127.0.0.1 is ours whatever DHCP later says, and a loopback frame has
+// to find a MAC for it before the interface has an address at all.
+@ sock_seed_addr * SockTab st i ip i now → v {
+    : *NetStack net . . st ts net
+    ( arp_cache_insert . net arp ip . net our_mac now )
+}
+
+// The address the socket layer reports as local. DHCP changes it after
+// the fact, and an fd table that kept the boot-time answer would hand
+// out a source address the peer cannot reply to.
+@ sock_set_our_ip * SockTab st i ip → v { = . st our_ip ip }
 
 // ── binding ──────────────────────────────────────────────────────
 

--- a/unikernel/demos/httpd.nu
+++ b/unikernel/demos/httpd.nu
@@ -1,0 +1,72 @@
+// unikernel/demos/httpd.nu — a server on a machine with no operating
+// system, answering a client that is not on it.
+//
+// The whole stack, from the socket call down: std/net.nu → the socket
+// ABI in NURL → net/socket.nu → net/tcpstack.nu → net/tcp.nu →
+// net/ipv4.nu → virtio-net → the host's curl. Nothing above the shim
+// knows any of that; this program is the same one that would run on
+// Linux.
+$ `stdlib/std/net.nu`
+$ `stdlib/core/io.nu`
+
+@ main → i {
+    ?? ( tcp_listen `0.0.0.0` 8080 ) {
+        F e → {
+            ( nurl_print `listen failed: ` )
+            ( nurl_print ( net_err_name e ) )
+            ( nurl_print `\n` )
+            ^ 1
+        }
+        T l → {
+            ( nurl_print `listening on 8080\n` )
+            // Three, not one. QEMU's port forward ACCEPTS on the
+            // host side before the guest is listening, so a client
+            // that arrives while DHCP is still running gets a
+            // connection the guest has not seen yet — and if the
+            // guest only ever serves one, that early arrival is the
+            // one it serves, to a client that has already given up.
+            // Serve until one client actually gets an answer, not
+            // until N connections happen. QEMU's port forward ACCEPTS
+            // on the host side before the guest is listening, so a
+            // client that arrives while DHCP is still running leaves a
+            // connection the guest sees later and nobody is waiting
+            // on — counting connections would count that one.
+            : ~ i answered 0
+            : ~ i tries 0
+            ~ && == answered 0 < tries 8 {
+                = tries + tries 1
+                ?? ( tcp_accept l ) {
+                    F e → {
+                        ( nurl_print `accept failed: ` )
+                        ( nurl_print ( net_err_name e ) )
+                        ( nurl_print `\n` )
+                        = tries 8
+                    }
+                    T c → {
+                        ?? ( tcp_read_chunk c 2048 ) {
+                            T req → {
+                                ( nurl_print `request bytes: ` )
+                                ( nurl_print ? > ( vec_len [u] req ) 0 `yes` `no` )
+                                ( nurl_print `\n` )
+                                ( vec_free [u] req )
+                            }
+                            F _e → {}
+                        }
+                        : !v NetErr w ( tcp_write_str c `HTTP/1.1 200 OK\r\nContent-Length: 18\r\nConnection: close\r\n\r\nhello from a guest` )
+                        ?? w {
+                            T _ → {
+                                ( nurl_print `response written\n` )
+                                = answered 1
+                            }
+                            F _e → ( nurl_print `write failed\n` )
+                        }
+                        ( tcp_close_conn c )
+                    }
+                }
+            }
+            ( tcp_close_listener l )
+        }
+    }
+    ( nurl_print `done\n` )
+    ^ 0
+}

--- a/unikernel/net/sockets.nu
+++ b/unikernel/net/sockets.nu
@@ -51,6 +51,7 @@ $ `stdlib/net/ipv4.nu`
 $ `stdlib/net/arp.nu`
 $ `stdlib/net/icmp.nu`
 $ `stdlib/net/udp4.nu`
+$ `stdlib/net/dhcp.nu`
 $ `stdlib/net/stack.nu`
 $ `stdlib/net/tcpseg.nu`
 $ `stdlib/net/tcp.nu`
@@ -119,7 +120,16 @@ $ `stdlib/net/socket.nu`
     ? != g_shim 0 { ^ # *Shim g_shim } {}
     : *Shim sh # *Shim ( nurl_alloc Z Shim )
     : i now ( __ms )
-    = . sh net ( stack_new ( __lo_mac ) ( __lo_ip ) ( __lo_mask ) 0 )
+    : i have ( netdev_open )
+    // With an interface the machine's MAC is the DEVICE's — the one in
+    // its config space, which the hypervisor's filters and the peer's
+    // ARP table already know. Inventing one makes every frame we send
+    // unanswerable.
+    : i mac ? != have 0 ( netdev_mac ) ( __lo_mac )
+    // …and its address is whatever DHCP says, which is not known yet.
+    // Loopback works throughout regardless: 127.0.0.0/8 is ours before
+    // any interface has an address (net/stack.nu).
+    = . sh net ( stack_new mac ? != have 0 0 ( __lo_ip ) ? != have 0 0 ( __lo_mask ) 0 )
     // The ISS seed is the clock. RFC 793 wants a clock-driven initial
     // sequence number so an old duplicate from a previous incarnation
     // cannot be mistaken for live data, and a machine that boots into
@@ -130,13 +140,79 @@ $ `stdlib/net/socket.nu`
     = . sh w_fd ( vec_new [i] )
     = . sh w_wr ( vec_new [i] )
     = . sh w_coro ( vec_new [i] )
-    = . sh has_device ( netdev_open )
+    = . sh has_device have
     // An interface knows its own MAC. Without this the first connect
     // to 127.0.0.1 ARPs for itself and waits a retransmit timeout for
     // the answer.
+    ( sock_seed_addr . sh st ( __lo_ip ) now )
     ( sock_seed_self . sh st now )
     = g_shim # i sh
+    // The address comes from the network, and it has to be there
+    // before the first bind: a listener with a source address of
+    // 0.0.0.0 checksums every segment against the wrong pseudo-header
+    // and goes unanswered.
+    ? != have 0 { ( __dhcp_configure sh ) } {}
     ^ sh
+}
+
+// Run the DHCP client — the same state machine `net/dhcp.nu` covers
+// with 62 host assertions — until it holds a lease or the deadline
+// passes. Bounded by the CLOCK, not by a round count: the retransmit
+// backoff is measured in seconds and a busy loop gets through a
+// hundred thousand rounds in the time a server takes to answer once.
+@ __dhcp_configure * Shim sh → v {
+    : *NetStack net . sh net
+    : *DhcpClient c ( dhcp_client_new . net our_mac & ( __ms ) 4294967295 )
+    : i deadline + ( __ms ) 10000
+    ~ && ! ( dhcp_bound c ) < ( __ms ) deadline {
+        ( __dhcp_turn sh c ( __ms ) )
+    }
+    ? ( dhcp_bound c ) {
+        ( stack_set_address net . c our_ip . c subnet . c router )
+        ( sock_set_our_ip . sh st . c our_ip )
+        ( sock_seed_addr . sh st . c our_ip ( __ms ) )
+    } {}
+    ( dhcp_client_free c )
+}
+
+@ __dhcp_turn * Shim sh * DhcpClient c i now → v {
+    : *PktBuf out ( pktbuf_new )
+    : i want ( dhcp_tick c now )
+    ? != want 0 {
+        : ( Vec u ) msg ( vec_new [u] )
+        ( dhcp_push_message msg want . c xid . c mac 0
+        ? == want ( dhcp_msg_request ) . c our_ip 0
+        ? == want ( dhcp_msg_request ) . c server_id 0 )
+        : i _n ( stack_tx_udp_broadcast . sh net ( dhcp_src_ip c ) ( dhcp_client_port )
+        ( dhcp_server_port ) ( dhcp_dest_ip c ) msg 0 ( vec_len [u] msg ) out )
+        ( vec_free [u] msg )
+        : i n ( pktbuf_count out )
+        : ~ i k 0
+        ~ < k n {
+            : ( Vec u ) f ( vec_new [u] )
+            ( pktbuf_copy_to f out k )
+            : i _t ( netdev_tx # s ( vec_data [u] f ) ( vec_len [u] f ) )
+            ( vec_free [u] f )
+            = k + k 1
+        }
+        ( pktbuf_clear out )
+    } {}
+    : ~ b more T
+    ~ more {
+        : ( Vec u ) in ( vec_with_cap [u] 2048 )
+        ( vec_set_len [u] in 2048 )
+        : i len ( netdev_rx # s ( vec_data [u] in ) 2048 )
+        ? > len 0 {
+            ( vec_set_len [u] in len )
+            : RxResult r ( stack_rx . sh net in now out )
+            ? && == . r kind ( rx_udp ) == . r dst_port ( dhcp_client_port ) {
+                : DhcpMsg m ( dhcp_parse in . r payload_off . r payload_len )
+                ? . m valid { : b _h ( dhcp_handle c m now ) } {}
+            } {}
+        } { = more F }
+        ( vec_free [u] in )
+    }
+    ( pktbuf_free out )
 }
 
 @ __tab → *SockTab { ^ . ( __shim ) st }

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -90,5 +90,41 @@ if [ $# -eq 0 ]; then
     done
 fi
 
+# ── the one demo with a client on the other end ─────────────────
+# The rest of the gate reads what the guest printed. This one needs
+# something to talk TO it, through QEMU's port forward, which is the
+# whole point: the server is in the guest and the client is not on the
+# machine at all.
+if [ $# -eq 0 ] && command -v curl >/dev/null 2>&1; then
+    demos=$((demos + 1))
+    if "$ROOT/unikernel/build_unikernel.sh" "$ROOT/unikernel/demos/httpd.nu" >/dev/null 2>&1; then
+        out=$(mktemp)
+        ( "$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/httpd.elf" -t 90 -- \
+            -netdev user,id=n0,hostfwd=tcp:127.0.0.1:18080-:8080 \
+            -device virtio-net-device,netdev=n0 > "$out" 2>&1 ) &
+        qpid=$!
+        # The guest boots, then leases an address, and only then
+        # binds. Retry rather than guess how long that takes on a
+        # machine running QEMU under TCG.
+        body=""
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            sleep 2
+            body=$(curl -sS --max-time 8 http://127.0.0.1:18080/ 2>/dev/null)
+            [ -n "$body" ] && break
+        done
+        wait $qpid
+        if [ "$body" = "hello from a guest" ] && grep -q "response written" "$out"; then
+            echo "PASS httpd (guest server, host client)"
+        else
+            echo "FAIL httpd (curl got \"$body\")"
+            head -6 "$out" | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+        rm -f "$out"
+    else
+        echo "FAIL httpd (build)"; fails=$((fails + 1))
+    fi
+fi
+
 echo "── QEMU guest run: $((${#names[@]} + demos - fails))/$((${#names[@]} + demos)) ──"
 [ "$fails" -eq 0 ]


### PR DESCRIPTION
```
$ curl http://127.0.0.1:18080/
hello from a guest
```

The client is on the host. The server is a NURL program running as its own kernel, and every layer between the two is NURL: `std/net.nu` → the socket ABI in NURL → `net/socket.nu` → `net/tcpstack.nu` → `net/tcp.nu` → `net/ipv4.nu` → the virtio-net driver → QEMU's port forward. Nothing above the shim knows any of that — `unikernel/demos/httpd.nu` is the same program that would run on Linux.

That is B6's exit criterion for the plaintext half.

## What it needed: an address

The shim now runs the DHCP client at socket-layer init when there is an interface — the exchange proven over this device in #785, the state machine 62 host assertions cover — and hands what it learns to the stack and to the fd table. A listener that kept 0.0.0.0 as its source address would checksum every segment against the wrong pseudo-header and go unanswered, which is a failure with no error message anywhere.

The MAC comes from the device's config space for the same reason: the hypervisor's filters and the peer's ARP table already know it, and a MAC invented at boot makes every frame we send unanswerable.

## Two things the harness had to learn, both real

- **QEMU's port forward accepts before the guest is listening.** A client that arrives while DHCP is still running leaves a connection the guest sees later and nobody is waiting on. The demo serves until one client actually gets an answer, rather than until N connections have happened — counting connections counts that one.
- A gate that curls once and gives up measures how fast the host is. It retries, because the guest boots, then leases, and only then binds.

## Verification

```
  unikernel/run_qemu_tests.sh    →  13/13   (incl. the guest server with a host client)
  unikernel/run_nolibc_tests.sh  →  449 PASS / 0 FAIL
  ./build.sh                     →  green, bootstrap fixed point held
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1