### PR TITLE
B7: a filesystem inside the image, and arguments from the command line

### DIFF
--- a/unikernel/boot/initfs.c
+++ b/unikernel/boot/initfs.c
@@ -1,0 +1,189 @@
+/*
+ * NURL unikernel — unikernel/boot/initfs.c
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * A read-only filesystem, baked into the image at link time.
+ *
+ * B10 needs this for one reason and it is a good one: a TLS server
+ * needs its certificate and its key, and a machine with no disk and no
+ * network filesystem has exactly one place to keep them — inside
+ * itself. The plan's scope for v1 is precise: read-only, no writes, no
+ * directories to speak of, and no block device.
+ *
+ * The archive is a POSIX tar, because `tar cf` is on every machine that
+ * will ever build one of these images and a custom format would be one
+ * more thing to write a tool for. Only what a lookup needs is parsed:
+ * the name, the size, and the file type. 512-byte header, payload
+ * rounded up to 512, repeat.
+ *
+ * WHERE IT PLUGS IN. nolibc's `fopen`/`fread`/`fseek` are already
+ * written against `nl_open`/`nl_read`/`nl_lseek`/`nl_close` — the same
+ * four functions the Linux build implements with syscalls. Implementing
+ * those four here means every reader above them works unchanged, from
+ * `fread` to `fs_read_file` to whatever the TLS code does to load a
+ * PEM. Nothing above knows the file came out of the binary.
+ */
+
+typedef unsigned long fs_size_t;
+typedef long          fs_ssize_t;
+
+/* The image, supplied by the linker. `build_unikernel.sh --fs <dir>`
+ * turns a directory into a tar and that tar into an object; with no
+ * --fs it emits an empty one, so these symbols always exist and the
+ * "no files" case is a zero-length archive rather than a #ifdef. */
+extern const unsigned char nurl_initfs_start[];
+extern const unsigned char nurl_initfs_end[];
+
+void pf_panic(const char *msg);
+extern int nl_errno_slot;
+
+#define FS_MAX_OPEN 16
+#define FS_FD_BASE  64          /* above stdin/stdout/stderr and clear of them */
+
+typedef struct {
+    const unsigned char *data;
+    fs_size_t            size;
+    fs_size_t            pos;
+    int                  used;
+} FsFile;
+
+static FsFile fs_open_files[FS_MAX_OPEN];
+
+static fs_size_t tar_octal(const char *p, int n) {
+    fs_size_t v = 0;
+    for (int i = 0; i < n; i++) {
+        if (p[i] < '0' || p[i] > '7') break;
+        v = v * 8 + (fs_size_t)(p[i] - '0');
+    }
+    return v;
+}
+
+static int fs_streq(const char *a, const char *b) {
+    while (*a && *a == *b) { a++; b++; }
+    return *a == *b;
+}
+
+/* Leading "./" and a leading "/" are the same file: `tar cf` writes
+ * "./certs/key.pem" and a program asks for "certs/key.pem" or
+ * "/certs/key.pem". Normalising here rather than at every caller is
+ * what keeps the program identical to its Linux self. */
+static const char *fs_norm(const char *p) {
+    if (p[0] == '.' && p[1] == '/') return p + 2;
+    if (p[0] == '/') return p + 1;
+    return p;
+}
+
+/* Find `name` in the archive. Returns its bytes and size, or 0. */
+static const unsigned char *fs_lookup(const char *name, fs_size_t *size_out) {
+    const unsigned char *p = nurl_initfs_start;
+    const unsigned char *end = nurl_initfs_end;
+    const char *want = fs_norm(name);
+
+    while (p + 512 <= end) {
+        const char *hdr = (const char *)p;
+        if (hdr[0] == 0) break;                 /* end-of-archive padding */
+        fs_size_t size = tar_octal(hdr + 124, 12);
+        char type = hdr[156];
+        const unsigned char *body = p + 512;
+        fs_size_t stride = 512 + ((size + 511) & ~(fs_size_t)511);
+
+        /* '0' and '\0' are both "regular file"; anything else (a
+         * directory, a symlink) is skipped rather than served, because
+         * serving a directory's zero bytes as a file is how a missing
+         * certificate becomes an empty one. */
+        if ((type == '0' || type == 0) && fs_streq(fs_norm(hdr), want)) {
+            if (body + size > end) return 0;    /* truncated archive */
+            if (size_out) *size_out = size;
+            return body;
+        }
+        p += stride;
+    }
+    return 0;
+}
+
+/* ── the four functions nolibc's stdio is written against ───────── */
+
+int nl_open(const char *path, int flags, int mode) {
+    (void)mode;
+    /* Read-only, and it says so: a write to a filesystem that lives in
+     * the text segment cannot be honoured, and a caller that opened
+     * for writing and got a descriptor would discover that later, at
+     * the write, with the data already gone. */
+    if ((flags & 3) != 0) { nl_errno_slot = 30 /* EROFS */; return -1; }
+
+    fs_size_t size = 0;
+    const unsigned char *data = fs_lookup(path, &size);
+    if (!data) { nl_errno_slot = 2 /* ENOENT */; return -1; }
+
+    for (int i = 0; i < FS_MAX_OPEN; i++) {
+        if (fs_open_files[i].used) continue;
+        fs_open_files[i].data = data;
+        fs_open_files[i].size = size;
+        fs_open_files[i].pos  = 0;
+        fs_open_files[i].used = 1;
+        return FS_FD_BASE + i;
+    }
+    nl_errno_slot = 24 /* EMFILE */;
+    return -1;
+}
+
+static FsFile *fs_file(int fd) {
+    int i = fd - FS_FD_BASE;
+    if (i < 0 || i >= FS_MAX_OPEN) return 0;
+    if (!fs_open_files[i].used) return 0;
+    return &fs_open_files[i];
+}
+
+int fs_is_file_fd(int fd) { return fs_file(fd) != 0; }
+
+fs_ssize_t fs_read_fd(int fd, void *buf, fs_size_t n) {
+    FsFile *f = fs_file(fd);
+    unsigned char *out = (unsigned char *)buf;
+    if (!f) { nl_errno_slot = 9 /* EBADF */; return -1; }
+    fs_size_t left = f->size - f->pos;
+    fs_size_t take = n < left ? n : left;
+    for (fs_size_t i = 0; i < take; i++) out[i] = f->data[f->pos + i];
+    f->pos += take;
+    return (fs_ssize_t)take;
+}
+
+long long fs_lseek_fd(int fd, long long off, int whence) {
+    FsFile *f = fs_file(fd);
+    long long base;
+    if (!f) { nl_errno_slot = 9; return -1; }
+    if (whence == 0) base = 0;
+    else if (whence == 1) base = (long long)f->pos;
+    else base = (long long)f->size;
+    long long pos = base + off;
+    if (pos < 0) { nl_errno_slot = 22 /* EINVAL */; return -1; }
+    if (pos > (long long)f->size) pos = (long long)f->size;
+    f->pos = (fs_size_t)pos;
+    return pos;
+}
+
+int fs_close_fd(int fd) {
+    FsFile *f = fs_file(fd);
+    if (!f) { nl_errno_slot = 9; return -1; }
+    f->used = 0;
+    return 0;
+}
+
+/* The bytes of an open file, in place. A file-backed `mmap` of an
+ * image that is already in memory is a pointer into it: read-only,
+ * shared with the archive, and free. `std/fs.nu`'s POSIX read path
+ * maps rather than reads, so without this every `read_file` on this
+ * machine returns whatever the bump allocator handed back. */
+const unsigned char *fs_map_fd(int fd, fs_size_t off) {
+    FsFile *f = fs_file(fd);
+    if (!f || off > f->size) return 0;
+    return f->data + off;
+}
+
+/* Does the image contain anything at all? The boot banner uses it, and
+ * so does the decision not to look for a certificate that cannot be
+ * there. */
+long long nurl_initfs_size(void) {
+    return (long long)(nurl_initfs_end - nurl_initfs_start);
+}

--- a/unikernel/boot/platform_x86.c
+++ b/unikernel/boot/platform_x86.c
@@ -183,8 +183,25 @@ static void mem_init(const struct hvm_start_info *si) {
  * here — a bump allocator cannot return a hole in the middle, and the
  * one caller that unmaps (a finished coroutine's stack) is reclaimed by
  * runtime_bare's own free list rather than by the kernel. */
+/* unikernel/boot/initfs.c — the baked-in filesystem. Declared here
+ * because every one of these is reached from the POSIX names below,
+ * which are what NURL's FFI actually calls. */
+int fs_is_file_fd(int fd);
+pf_ssize_t fs_read_fd(int fd, void *buf, pf_size_t n);
+long long fs_lseek_fd(int fd, long long off, int whence);
+int fs_close_fd(int fd);
+const unsigned char *fs_map_fd(int fd, unsigned long off);
+
 void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off) {
-    (void)addr; (void)prot; (void)flags; (void)fd; (void)off;
+    (void)addr; (void)prot; (void)flags;
+    /* A file-backed mapping of the baked-in filesystem is a pointer
+     * into it — the image is already in memory, and read-only is
+     * exactly what the mapping asked for. Anonymous mappings fall
+     * through to the bump allocator below. */
+    if (fd >= 0 && fs_is_file_fd(fd)) {
+        const unsigned char *p = fs_map_fd(fd, (unsigned long)off);
+        return p ? (void *)p : (void *)-1;
+    }
     unsigned long need = (len + 4095) & ~4095UL;
     if (!heap_next || (unsigned long)(heap_end - heap_next) < need)
         return (void *)-1;                  /* MAP_FAILED — the caller checks */
@@ -238,6 +255,14 @@ static void split_2m(u64 *pde) {
     pt_pool_used++;
     for (int i = 0; i < 512; i++) pt[i] = (frame + (u64)i * 4096) | 0x3;
     *pde = ((u64)(unsigned long)pt) | 0x3;           /* present | writable */
+}
+
+/* An advisory call about pages this machine does not reclaim. Success
+ * is the honest answer — the advice was heard and there is nothing to
+ * act on — and it is what every caller of madvise already handles. */
+int madvise(void *p, unsigned long len, int advice) {
+    (void)p; (void)len; (void)advice;
+    return 0;
 }
 
 int mprotect(void *p, unsigned long len, int prot) {
@@ -427,15 +452,31 @@ long long write(int fd, const void *buf, unsigned long n) {
 }
 
 /* No console input. 0 is EOF, which every reader already handles; -1
- * with an errno would make them retry forever. */
+ * with an errno would make them retry forever.
+ *
+ * The POSIX names are the ones NURL's FFI calls — `std/fs.nu` opens
+ * with `open` and sizes with `lseek` — so they are the ones that
+ * dispatch to the baked-in filesystem. Defining only the `nl_*` layer
+ * left `lseek` returning -1 for every file in the image, and
+ * `read_file` reported ENOENT about a file it had successfully
+ * opened. */
 long long read(int fd, void *buf, unsigned long n) {
-    (void)fd; (void)buf; (void)n;
+    if (fs_is_file_fd(fd)) return (long long)fs_read_fd(fd, buf, n);
+    (void)buf; (void)n;
     return 0;
 }
 
-int open(const char *p, int fl, int mode) { (void)p; (void)fl; (void)mode; return -1; }
-int close(int fd) { (void)fd; return 0; }
-long long lseek(int fd, long long off, int whence) { (void)fd; (void)off; (void)whence; return -1; }
+int nl_open(const char *path, int flags, int mode);
+int open(const char *p, int fl, int mode) { return nl_open(p, fl, mode); }
+int close(int fd) {
+    if (fs_is_file_fd(fd)) return fs_close_fd(fd);
+    return 0;
+}
+long long lseek(int fd, long long off, int whence) {
+    if (fs_is_file_fd(fd)) return fs_lseek_fd(fd, off, whence);
+    (void)off; (void)whence;
+    return -1;
+}
 
 static void pf_shutdown(int code);
 
@@ -443,8 +484,15 @@ static void pf_shutdown(int code);
  * that is the seam syscall_linux.c defines, so a guest that replaces
  * that file has to define it too. Same functions, one indirection up. */
 pf_ssize_t nl_write(int fd, const void *buf, pf_size_t n) { return (pf_ssize_t)write(fd, buf, n); }
+/* Reads come from the baked-in filesystem when the descriptor names a
+ * file in it, and from the console otherwise — which has nothing to
+ * say. `nl_open` lives in initfs.c: opening is entirely that file's
+ * business, and there is nothing else on this machine to open. */
+pf_ssize_t fs_read_fd(int fd, void *buf, pf_size_t n);
+long long fs_lseek_fd(int fd, long long off, int whence);
+int fs_close_fd(int fd);
+
 pf_ssize_t nl_read(int fd, void *buf, pf_size_t n) { return (pf_ssize_t)read(fd, buf, n); }
-int nl_open(const char *path, int flags, int mode) { return open(path, flags, mode); }
 int nl_close(int fd) { return close(fd); }
 long long nl_lseek(int fd, long long off, int whence) { return lseek(fd, off, whence); }
 void *nl_map(pf_size_t len) { return mmap(0, len, 0, 0, -1, 0); }
@@ -532,6 +580,49 @@ extern char **nl_environ;          /* nolibc/misc.c owns the storage */
 extern void nl_tls_init_guest(void);
 extern int main(int argc, char **argv);
 
+/* `args="…"` from the command line, split on spaces into argv.
+ *
+ * One key, not "everything after the last flag": QEMU's
+ * auto-kernel-cmdline APPENDS its virtio entries after -append, so a
+ * program that took the tail of the line would receive the
+ * hypervisor's device list as arguments (plan B0). The quotes are
+ * required for the same reason — they say where the program's
+ * arguments end. */
+#define ARGV_MAX 32
+static char *guest_argv[ARGV_MAX + 1];
+static char  argv_buf[1024];
+
+static int build_argv(const char *cl) {
+    int argc = 1;
+    guest_argv[0] = (char *)"nurl";
+    if (!cl) return argc;
+
+    const char *p = cl;
+    while (*p) {
+        if (p[0] == 'a' && p[1] == 'r' && p[2] == 'g' && p[3] == 's' &&
+            p[4] == '=' && p[5] == '"') {
+            const char *q = p + 6;
+            unsigned long n = 0;
+            while (*q && *q != '"' && n < sizeof argv_buf - 1) argv_buf[n++] = *q++;
+            argv_buf[n] = 0;
+            /* Split in place: every run of non-spaces is one argument,
+             * and the terminator goes where the space was. */
+            unsigned long i = 0;
+            while (i < n && argc < ARGV_MAX) {
+                while (i < n && argv_buf[i] == ' ') argv_buf[i++] = 0;
+                if (i >= n) break;
+                guest_argv[argc++] = &argv_buf[i];
+                while (i < n && argv_buf[i] != ' ') i++;
+            }
+            break;
+        }
+        while (*p && *p != ' ') p++;
+        while (*p == ' ') p++;
+    }
+    guest_argv[argc] = 0;
+    return argc;
+}
+
 void kmain(unsigned long start_info_paddr) {
     static char *no_argv[2];
     const struct hvm_start_info *si =
@@ -547,9 +638,9 @@ void kmain(unsigned long start_info_paddr) {
     time_init();
     nl_tls_init_guest();          /* before the first __thread access */
 
-    no_argv[0] = (char *)"nurl";
-    no_argv[1] = 0;
-    nl_environ = &no_argv[1];     /* an empty environment, terminated */
+    no_argv[0] = 0;
+    nl_environ = no_argv;         /* an empty environment, terminated */
 
-    exit(main(1, no_argv));
+    int argc = build_argv(cmdline);
+    exit(main(argc, guest_argv));
 }

--- a/unikernel/build_unikernel.sh
+++ b/unikernel/build_unikernel.sh
@@ -33,10 +33,12 @@ OUTDIR="${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel}"
 CC="${CC:-clang}"
 SRC=""
 OUT=""
+FSDIR=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
         -o) OUT="$2"; shift 2 ;;
+        --fs) FSDIR="$2"; shift 2 ;;
         *)  SRC="$1"; shift ;;
     esac
 done
@@ -67,6 +69,24 @@ for f in string malloc stdio dtoa math misc; do
     $CC $KFLAGS -c "$NOLIBC/$f.c" -o "$OUTDIR/nl_$f.o"
 done
 $CC $KFLAGS -c "$BOOT/platform_x86.c" -o "$OUTDIR/platform.o"
+$CC $KFLAGS -c "$BOOT/initfs.c"       -o "$OUTDIR/boot_initfs.o"
+
+# The baked-in filesystem: a directory becomes a tar, and the tar
+# becomes an object with two symbols around it. With no --fs the
+# archive is empty rather than absent, so "no files" is a zero-length
+# lookup instead of a conditional in every reader.
+: > "$OUTDIR/initfs.tar"
+if [ -n "$FSDIR" ]; then
+    tar cf "$OUTDIR/initfs.tar" -C "$FSDIR" .
+fi
+( cd "$OUTDIR" && ld -r -b binary -o initfs_data.o initfs.tar )
+# `ld -b binary` names its symbols after the path it was given; rename
+# them to something a C file can declare without knowing that path.
+objcopy \
+    --redefine-sym _binary_initfs_tar_start=nurl_initfs_start \
+    --redefine-sym _binary_initfs_tar_end=nurl_initfs_end \
+    --redefine-sym _binary_initfs_tar_size=nurl_initfs_size_sym \
+    "$OUTDIR/initfs_data.o"
 $CC $KFLAGS -c "$BOOT/tls_guest.c"    -o "$OUTDIR/tls_guest.o"
 $CC -c "$BOOT/boot.S"                 -o "$OUTDIR/boot.o"
 $CC $KFLAGS -c "$NOLIBC/setjmp_x86_64.S" -o "$OUTDIR/nl_setjmp.o" 2>/dev/null \
@@ -77,6 +97,7 @@ $CC -nostdlib -static -no-pie -Wl,-T,"$BOOT/link.ld" -Wl,--build-id=none \
     "$OUTDIR/boot.o" "$OUTDIR/$base.o" \
     "$OUTDIR/runtime_core.o" "$OUTDIR/runtime_ctx.o" "$OUTDIR/runtime_bare.o" \
     "$OUTDIR/platform.o" "$OUTDIR/tls_guest.o" \
+    "$OUTDIR/boot_initfs.o" "$OUTDIR/initfs_data.o" \
     "$OUTDIR"/nl_*.o
 
 echo "built $OUT"

--- a/unikernel/demos/initfs.expected
+++ b/unikernel/demos/initfs.expected
@@ -1,0 +1,6 @@
+argc: 4
+arg: --token
+arg: abc
+arg: --verbose
+file: hello from the baked-in filesystem
+a file that is not there: ENOENT

--- a/unikernel/demos/initfs.nu
+++ b/unikernel/demos/initfs.nu
@@ -1,0 +1,36 @@
+// unikernel/demos/initfs.nu — a file on a machine with no disk.
+//
+// The image carries a tar; `fopen` finds it there. Nothing in this
+// program knows that: it is the same `fs_read_file` a Linux build
+// would call, over the same `fopen`/`fread` nolibc already had.
+//
+// It also prints its arguments, which came from `args="…"` on the
+// kernel command line — the B0 grammar, where the program's arguments
+// are ONE key rather than the tail of the line, because QEMU appends
+// its own device entries after -append and a program that read the
+// tail would be handed them.
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/fs.nu`
+
+@ main → i {
+    ( nurl_print `argc: ` ) ( nurl_print ( nurl_str_int ( nurl_argc ) ) ) ( nurl_print `\n` )
+    : ~ i k 1
+    ~ < k ( nurl_argc ) {
+        ( nurl_print `arg: ` ) ( nurl_print ( nurl_argv k ) ) ( nurl_print `\n` )
+        = k + k 1
+    }
+    ?? ( read_file `etc/greeting.txt` ) {
+        T text → {
+            ( nurl_print `file: ` )
+            ( nurl_print ( string_data text ) )
+            ( string_free text )
+        }
+        F _e → ( nurl_print `file: MISSING\n` )
+    }
+    ?? ( read_file `etc/absent.txt` ) {
+        T t2 → { ( nurl_print `absent file read anyway\n` ) ( string_free t2 ) }
+        F _e → ( nurl_print `a file that is not there: ENOENT\n` )
+    }
+    ^ 0
+}

--- a/unikernel/demos/initfs_root/etc/greeting.txt
+++ b/unikernel/demos/initfs_root/etc/greeting.txt
@@ -1,0 +1,1 @@
+hello from the baked-in filesystem

--- a/unikernel/run_qemu.sh
+++ b/unikernel/run_qemu.sh
@@ -16,6 +16,9 @@
 #  code back at all. isa-debug-exit is a QEMU-side cross-check and is
 #  attached when the machine supports it.
 #
+#  NURL_APPEND is added to the kernel command line — that is where a
+#  program's own arguments go, as a single `args="…"` key (plan B0).
+#
 #  Exit status: the guest's, or 124 if the deadline passed with no
 #  sentinel line (a hang looks like a hang, not like a pass).
 # ============================================================
@@ -69,7 +72,7 @@ timeout -k 5s "${TIMEOUT}s" "$QEMU" \
     -accel "$ACCEL" -cpu max -m 256 \
     -nodefaults -no-reboot -no-user-config \
     -global virtio-mmio.force-legacy=false \
-    -kernel "$IMG" -append "tsc_khz=${NURL_TSC_KHZ:-1000000} wallclock=$(date +%s)" \
+    -kernel "$IMG" -append "tsc_khz=${NURL_TSC_KHZ:-1000000} wallclock=$(date +%s) ${NURL_APPEND:-}" \
     -serial stdio -display none \
     ${EXTRA[@]+"${EXTRA[@]}"} > "$out" 2>&1
 qemu_status=$?

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -90,6 +90,28 @@ if [ $# -eq 0 ]; then
     done
 fi
 
+# ── the demo with a filesystem and arguments ────────────────────
+# Built with --fs, run with args on the kernel command line: the two
+# halves of B7, and the only demo whose build and invocation differ
+# from the rest.
+if [ $# -eq 0 ]; then
+    demos=$((demos + 1))
+    if "$ROOT/unikernel/build_unikernel.sh" --fs "$ROOT/unikernel/demos/initfs_root" \
+            "$ROOT/unikernel/demos/initfs.nu" >/dev/null 2>&1; then
+        got=$(NURL_APPEND='args="--token abc --verbose"' \
+              "$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/initfs.elf" -t 60 2>&1)
+        if [ "$got" = "$(cat "$ROOT/unikernel/demos/initfs.expected")" ]; then
+            echo "PASS initfs (guest-only demo)"
+        else
+            echo "FAIL initfs"
+            diff "$ROOT/unikernel/demos/initfs.expected" <(printf '%s\n' "$got") | head -6 | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+    else
+        echo "FAIL initfs (build)"; fails=$((fails + 1))
+    fi
+fi
+
 # ── the one demo with a client on the other end ─────────────────
 # The rest of the gate reads what the guest printed. This one needs
 # something to talk TO it, through QEMU's port forward, which is the


### PR DESCRIPTION
```
argc: 4
arg: --token
arg: abc
arg: --verbose
file: hello from the baked-in filesystem
a file that is not there: ENOENT
```

Both halves of B7, and both are prerequisites for B10: a TLS server needs its certificate and its key, and swarm-mcp needs `--token`, `--connect` and `--mcp-listen` to reach its own argument parser unchanged.

## The filesystem is a tar, baked in at link time

`tar cf` is on every machine that will ever build one of these images, so a custom format would be one more tool to write. `build_unikernel.sh --fs <dir>` turns a directory into an archive and the archive into an object; with no `--fs` the archive is **empty rather than absent**, so "no files" is a zero-length lookup instead of a conditional in every reader.

It plugs in where nolibc already had a seam: `fopen`/`fread`/`fseek` are written against `open`/`read`/`lseek`/`close`, which the Linux build implements with syscalls and this one implements over the archive. Nothing above knows where the bytes came from — the demo calls the same `read_file` a Linux build would.

A file-backed `mmap` returns a pointer **into** the image, because the image is already in memory and read-only is exactly what the mapping asked for. `std/fs.nu`'s POSIX read path maps rather than reads, so without that every `read_file` on this machine returned whatever the bump allocator last handed out.

## Arguments come from one `args="…"` key

Not from the tail of the command line. QEMU's `auto-kernel-cmdline` appends its virtio entries after `-append`, so a program that read the tail would be handed the hypervisor's device list as arguments — the trap B0 pre-committed, now avoided by the grammar rather than by luck.

## One bug worth the name

**`open` succeeded and `lseek` returned -1.** The POSIX names are what NURL's FFI calls, and only the `nl_*` layer had been taught about the filesystem — so `read_file` reported ENOENT about a file it had just opened successfully. The dispatch now lives in the POSIX names and `nl_*` forwards to them, which is the direction the callers actually run in.

```
  unikernel/run_qemu_tests.sh    →  14/14
  unikernel/run_nolibc_tests.sh  →  450 PASS / 0 FAIL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1