### PR TITLE
B8: the unikernel gates run on every commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,56 @@ jobs:
           sudo apt-get install -y --no-install-recommends gdb
           ./tools/dwarf_test.sh
 
+  unikernel:
+    name: unikernel (no libc, and then no operating system)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    # Two gates, and they are different questions. The first asks
+    # whether the ordinary test corpus still runs with no libc linked —
+    # 450 programs against their existing goldens, which is what keeps
+    # the freestanding twin honest without a hypervisor in the loop.
+    # The second boots the result under QEMU and asks whether it still
+    # does with no operating system either: the boot path, the UART,
+    # the memory map, the TSC, the virtio-net device, DHCP, and a
+    # server that answers a client on the host.
+    #
+    # Neither was watched by CI until now, and both are exactly the
+    # shape this repo has been bitten by twice — a gate that exists on
+    # a developer's machine is a gate that drifts.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            clang binutils qemu-system-x86 curl
+
+      - name: Build the compiler
+        run: ./build.sh --no-tests
+
+      - name: The corpus, with no libc at all
+        # A FAIL here is a nolibc or runtime_bare bug: the program
+        # linked and ran and disagreed with the golden the hosted build
+        # produces. NEEDS-* columns are not failures — they are work
+        # that has not been done or, for the third-party libraries a
+        # unikernel never links, work that never will be.
+        run: ./unikernel/run_nolibc_tests.sh
+
+      - name: nolibc + runtime_bare unit gates
+        run: ./unikernel/tests/run_unit_tests.sh
+
+      - name: The guest, under QEMU
+        # TCG, because no runner has /dev/kvm. Slower, identical
+        # otherwise — except for the TSC frequency, which no leaf
+        # reports there, so run_qemu.sh states it on the kernel command
+        # line the way the plan says the host states the epoch.
+        run: ./unikernel/run_qemu_tests.sh
+
   freebsd:
     name: FreeBSD (build + bootstrap fixed point + tests, in a VM)
     needs: changes

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -147,6 +147,25 @@ checked against arithmetic instead of against glibc, because glibc's
 `cbrt` is the less accurate of the two: it answers 3.0000000000000004
 for the cube root of 27, and this one answers 3.
 
+## What CI watches
+
+Both gates run on every code change (the `unikernel` job):
+
+| | |
+|---|---|
+| `run_nolibc_tests.sh` | the ordinary corpus, no libc linked — 450 programs against their existing goldens |
+| `tests/run_unit_tests.sh` | the differentials, the allocator fuzzer, the scheduler's schedule and its deadlock detector |
+| `run_qemu_tests.sh` | the guest: boot, memory, TSC, fibers, the TCP/UDP stack, virtio-net, DHCP, a baked-in filesystem, and a server answering a client on the host |
+
+The QEMU job runs under TCG because no runner has `/dev/kvm`. Slower,
+identical otherwise — except for the TSC frequency, which no leaf
+reports there, so `run_qemu.sh` states it on the kernel command line
+the way the plan says the host states the epoch.
+
+A gate that only exists on a developer's machine is a gate that
+drifts; this repo has been bitten by that twice (the plan's findings 1
+and 11), which is why these are jobs rather than instructions.
+
 ## Running the gates
 
 ```sh


### PR DESCRIPTION
Everything Track A and Track B have built has been verified by hand, on one machine, by whoever happened to run the script. That is exactly the shape this repo has been bitten by twice — a hand-kept gate that drifted until the thing it guarded had quietly stopped working (the plan's findings 1 and 11).

Three steps, in one job, asking three different questions:

- **the corpus with no libc** — 450 programs linked with `-nostdlib` against nolibc and `runtime_bare`, compared to the goldens the hosted build produces. A FAIL here is a nolibc or runtime_bare bug: the program ran and disagreed. The NEEDS-* columns are not failures; they are work not done, or — for the third-party libraries a unikernel never links — work that never will be.
- **the unit gates** — the differentials against glibc, the allocator fuzzer, the scheduler's schedule as a trace, and the negative half: four deadlocks, a stack overflow, a guard-page write and a refusing entropy source, each of which must *end the process* in bounded time.
- **the guest, under QEMU** — boot, the memory map, the TSC, fibers on real guard pages, the TCP/UDP stack, virtio-net discovery and rx/tx, DHCP against QEMU's server, a filesystem baked into the image, and a server in the guest answering `curl` on the host.

TCG rather than KVM, because no runner has `/dev/kvm`. Slower, identical otherwise — except for the TSC frequency, which no leaf reports there, so the runner states it on the kernel command line exactly as the plan has the host state the wall-clock epoch.

Verified locally against a QEMU that is *not* on the PATH (14/14), which is also what proves the `command -v` skip works for a developer who has none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1