### PR TITLE
B9: TLS 1.3, on a machine with no operating system

### DIFF
--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -131,6 +131,21 @@ asking for the time panics. `wallclock=` carries the boot epoch the
 same way — a functionality input, not a security control, since the
 host already controls the whole image.
 
+## The flagship, so far
+
+```
+$ curl --insecure https://127.0.0.1:18443/
+hello from a guest over TLS
+```
+
+A 369 KiB image, and everything the handshake needs it owns: the
+certificate and the key come out of the filesystem baked into it, the
+entropy is RDRAND with a panic and no fallback, the clock X.509
+validity is checked against arrives on the kernel command line, and the
+bytes travel over the pure TCP stack and the virtio-net driver. The
+handshake is `stdlib/std/tls.nu` — pure NURL, no libssl, which is why
+it links here at all.
+
 ## Accuracy, stated
 
 `nolibc/math.c` is a from-scratch libm and does not claim correct
@@ -155,7 +170,7 @@ Both gates run on every code change (the `unikernel` job):
 |---|---|
 | `run_nolibc_tests.sh` | the ordinary corpus, no libc linked — 450 programs against their existing goldens |
 | `tests/run_unit_tests.sh` | the differentials, the allocator fuzzer, the scheduler's schedule and its deadlock detector |
-| `run_qemu_tests.sh` | the guest: boot, memory, TSC, fibers, the TCP/UDP stack, virtio-net, DHCP, a baked-in filesystem, and a server answering a client on the host |
+| `run_qemu_tests.sh` | the guest: boot, memory, TSC, fibers, the TCP/UDP stack, virtio-net, DHCP, a baked-in filesystem, and two servers answering a client on the host — one plaintext, one TLS 1.3 |
 
 The QEMU job runs under TCG because no runner has `/dev/kvm`. Slower,
 identical otherwise — except for the TSC frequency, which no leaf

--- a/unikernel/demos/httpsd.nu
+++ b/unikernel/demos/httpsd.nu
@@ -1,0 +1,79 @@
+// unikernel/demos/httpsd.nu — TLS 1.3, on a machine with no operating
+// system.
+//
+// Everything the handshake needs, this machine now has and none of it
+// is borrowed: the certificate and the key come out of the filesystem
+// baked into the image (B7), the entropy comes from RDRAND with a
+// panic and no fallback if the vCPU has none (B3's rule), the clock
+// that X.509 validity is checked against comes from the kernel command
+// line (B2), and the bytes travel over the pure TCP stack and the
+// virtio-net driver.
+//
+// The handshake itself is `stdlib/std/tls.nu` — pure NURL, no libssl,
+// which is why it links here at all. The program is the same one that
+// would run on Linux; `tcp_listen_tls` reads two files and the layers
+// below do the rest.
+$ `stdlib/std/net.nu`
+$ `stdlib/core/io.nu`
+
+@ main → i {
+    ?? ( tcp_listen_tls `0.0.0.0` 8443 `etc/tls/cert.pem` `etc/tls/key.pem` ) {
+        F e → {
+            ( nurl_print `listen failed: ` )
+            ( nurl_print ( net_err_name e ) )
+            ( nurl_print `\n` )
+            ^ 1
+        }
+        T l → {
+            ( nurl_print `listening on 8443 (TLS)\n` )
+            // Three, not one. QEMU's port forward ACCEPTS on the
+            // host side before the guest is listening, so a client
+            // that arrives while DHCP is still running gets a
+            // connection the guest has not seen yet — and if the
+            // guest only ever serves one, that early arrival is the
+            // one it serves, to a client that has already given up.
+            // Serve until one client actually gets an answer, not
+            // until N connections happen. QEMU's port forward ACCEPTS
+            // on the host side before the guest is listening, so a
+            // client that arrives while DHCP is still running leaves a
+            // connection the guest sees later and nobody is waiting
+            // on — counting connections would count that one.
+            : ~ i answered 0
+            : ~ i tries 0
+            ~ && == answered 0 < tries 8 {
+                = tries + tries 1
+                ?? ( tcp_accept l ) {
+                    F e → {
+                        ( nurl_print `accept failed: ` )
+                        ( nurl_print ( net_err_name e ) )
+                        ( nurl_print `\n` )
+                        = tries 8
+                    }
+                    T c → {
+                        ?? ( tcp_read_chunk c 2048 ) {
+                            T req → {
+                                ( nurl_print `request bytes: ` )
+                                ( nurl_print ? > ( vec_len [u] req ) 0 `yes` `no` )
+                                ( nurl_print `\n` )
+                                ( vec_free [u] req )
+                            }
+                            F _e → {}
+                        }
+                        : !v NetErr w ( tcp_write_str c `HTTP/1.1 200 OK\r\nContent-Length: 27\r\nConnection: close\r\n\r\nhello from a guest over TLS` )
+                        ?? w {
+                            T _ → {
+                                ( nurl_print `response written\n` )
+                                = answered 1
+                            }
+                            F _e → ( nurl_print `write failed\n` )
+                        }
+                        ( tcp_close_conn c )
+                    }
+                }
+            }
+            ( tcp_close_listener l )
+        }
+    }
+    ( nurl_print `done\n` )
+    ^ 0
+}

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -148,5 +148,44 @@ if [ $# -eq 0 ] && command -v curl >/dev/null 2>&1; then
     fi
 fi
 
+# ── TLS, which needs a certificate that is not in the repo ──────
+# Generated here rather than committed: a private key in a git history
+# is a private key forever, even a throwaway one, and `openssl req` is
+# already required by the corpus's own TLS test.
+if [ $# -eq 0 ] && command -v curl >/dev/null 2>&1 && command -v openssl >/dev/null 2>&1; then
+    demos=$((demos + 1))
+    tlsdir=$(mktemp -d)
+    mkdir -p "$tlsdir/etc/tls"
+    openssl req -x509 -newkey rsa:2048 -keyout "$tlsdir/etc/tls/key.pem" \
+        -out "$tlsdir/etc/tls/cert.pem" -days 3650 -nodes -subj "/CN=nurl-guest" \
+        >/dev/null 2>&1
+    if "$ROOT/unikernel/build_unikernel.sh" --fs "$tlsdir" \
+            "$ROOT/unikernel/demos/httpsd.nu" >/dev/null 2>&1; then
+        out=$(mktemp)
+        ( "$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/httpsd.elf" -t 120 -- \
+            -netdev user,id=n0,hostfwd=tcp:127.0.0.1:18443-:8443 \
+            -device virtio-net-device,netdev=n0 > "$out" 2>&1 ) &
+        qpid=$!
+        body=""
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            sleep 3
+            body=$(curl -sS --insecure --max-time 10 https://127.0.0.1:18443/ 2>/dev/null)
+            [ -n "$body" ] && break
+        done
+        wait $qpid
+        if [ "$body" = "hello from a guest over TLS" ]; then
+            echo "PASS httpsd (TLS 1.3 in the guest, curl on the host)"
+        else
+            echo "FAIL httpsd (curl got \"$body\")"
+            head -6 "$out" | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+        rm -f "$out"
+    else
+        echo "FAIL httpsd (build)"; fails=$((fails + 1))
+    fi
+    rm -rf "$tlsdir"
+fi
+
 echo "── QEMU guest run: $((${#names[@]} + demos - fails))/$((${#names[@]} + demos)) ──"
 [ "$fails" -eq 0 ]


### PR DESCRIPTION
```
$ curl --insecure https://127.0.0.1:18443/
hello from a guest over TLS
```

A **369 KiB image**, and everything the handshake needs it owns rather than borrows:

- the certificate and the key come out of the filesystem baked into it (#788);
- the entropy is RDRAND, with a panic and no fallback if the vCPU has none — the plan's rule for the one place a "later TODO" becomes a weak key;
- the clock X.509 validity is checked against arrives on the kernel command line (#781), stated by the host rather than guessed;
- the bytes travel over the pure TCP stack and the virtio-net driver.

The handshake itself is `stdlib/std/tls.nu`: pure NURL, no libssl — which is exactly why it links on a target that has no libssl to link. `unikernel/demos/httpsd.nu` is the same program that would run on Linux; `tcp_listen_tls` reads two files and every layer below does what it already did.

The certificate is generated by the gate rather than committed. A private key in a git history is a private key forever, even a throwaway one, and `openssl req` is already required by the corpus's own TLS test.

```
  unikernel/run_qemu_tests.sh    →  15/15
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1