### PR TITLE
B10: what swarm-mcp actually needs, measured

### DIFF
--- a/unikernel/compile_nu.sh
+++ b/unikernel/compile_nu.sh
@@ -36,10 +36,29 @@ SHIM="$ROOT/unikernel/net/sockets.nu"
 CC="${CC:-clang}"
 
 SRC="$1"; OUT_LL="$2"; WORK="$3"
+# Absolute, before anything cds anywhere: the workdir below is chosen
+# per source, and a relative path stops meaning the same thing the
+# moment it changes.
+SRC="$(cd "$(dirname "$SRC")" && pwd)/$(basename "$SRC")"
+case "$OUT_LL" in /*) ;; *) OUT_LL="$PWD/$OUT_LL" ;; esac
+case "$WORK" in /*) ;; *) WORK="$PWD/$WORK" ;; esac
 name="$(basename "${OUT_LL%.ll}")"
 OBJ="$WORK/$name.o"
 
-cd "$ROOT" || exit 2
+# Where nurlc runs from decides how a program's `$` imports resolve. A
+# package writes them relative to its own root ("deps/x/src/y.nu"), a
+# program in this repo writes them relative to the repo. So: the
+# nearest directory at or above the source that has a nurl.toml, else
+# the repo root. Guessing wrong is not a subtle failure — nurlc says
+# "cannot open deps/…" and stops.
+srcdir="$(dirname "$SRC")"
+workdir="$ROOT"
+probe="$srcdir"
+while [ "$probe" != "/" ]; do
+    if [ -f "$probe/nurl.toml" ]; then workdir="$probe"; break; fi
+    probe="$(dirname "$probe")"
+done
+cd "$workdir" || exit 2
 
 "$ROOT/build/nurlc" "$SRC" > "$OUT_LL" 2>"$WORK/compile.err" || exit 3
 "$CC" -O2 -c "$OUT_LL" -o "$OBJ" 2>"$WORK/cc.err" || exit 4


### PR DESCRIPTION
## The fix

`compile_nu.sh` ran nurlc from the repository root, because everything it had compiled so far lived there. A package writes its imports relative to its **own** root — `deps/wasmbuilder/src/build.nu` — so the first package handed to the unikernel build stopped at "cannot open deps/…", which is a true statement about the wrong directory.

The workdir is now the nearest directory at or above the source that has a `nurl.toml`, and the repo root when there is none. Paths are made absolute before anything `cd`s anywhere, because a relative path stops meaning the same thing the moment the working directory changes — the first version of this fix broke on exactly that.

## What it measured

With that fixed, **swarm-mcp compiles for the freestanding target**: 3.9 MB of IR, no errors. It does not *link*, and what it wants is precise:

```
dup2 execvp fcntl fork mkstemp nurl_proc_err_kind nurl_proc_exit_code
nurl_proc_free nurl_proc_run nurl_proc_stderr nurl_proc_stdout pipe
poll rename rmdir signal waitpid
```

Processes. Every one of them comes from **one feature** — swarm-mcp compiles kernels locally, spawning nurlc and `zig cc` through the wasmbuilder package — and processes are a plan non-goal for exactly the reason this demonstrates: a machine with one address space has nothing to fork.

## What that means for B10

B10 is not blocked on the transport, which is done and gated (16/16 in the guest, including a TLS 1.3 endpoint and an MCP server answering `initialize`/`tools/list`/`tools/call` from the host).

It is blocked on a build-time choice inside swarm-mcp: a node that **accepts** pre-compiled wasm modules and does not **build** them is precisely what the plan already specifies for the unikernel worker ("wasm chunks on the pure-NURL wasmtime, CPU host imports only"), and it is the version that can exist here. That is a change to the package, not to this target — and the package left this repo's CI by policy, so it is recorded here rather than attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1