### PR TITLE
The unikernel, made to survive its own failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,7 @@ jobs:
             ternary_slice_owned match_slice_owned arm_assign_tail_drop \
             defer_drop_reclaim defer_scoped defer_ret_transfer \
             net_inet net_frames net_dhcp net_stack net_tcp net_tcp_fuzz \
+            net_frame_fuzz \
             net_tcpstack net_socket \
             virtq_split free_suffix_query closure_env_escape_loop \
             ctx_switch async_basic async_chan async_mn async_sleep \

--- a/compiler/tests/net_dhcp.nu
+++ b/compiler/tests/net_dhcp.nu
@@ -208,11 +208,77 @@ $ `stdlib/net/dhcp.nu`
     ( pb `bound with defaulted lease: ` ( dhcp_bound c3 ) )
     ( dhcp_client_free c3 )
 
+    // ── a server that is lying, or broken ────────────────────────
+    //
+    // A DHCP server is the first party a guest talks to on a network it
+    // does not own, and it is unauthenticated by construction: anyone on
+    // the segment can answer first. None of these is exotic — a wrong
+    // `yiaddr` is one typo in a server config — and every one of them
+    // takes the machine off the network without anything failing, which
+    // is the worst way for a configuration bug to present.
+    : ~ ( Vec u ) hostile ( vec_new [u] )
+    : ~ b refused_all T
+    : ~ i hk 0
+    ~ < hk 4 {
+        : i bad ? == hk 0 0 ? == hk 1 ( ipv4_make 127 0 0 1 ) ? == hk 2 ( ipv4_make 224 0 0 1 ) 4294967295
+        : *DhcpClient hc ( dhcp_client_new ( cl_mac ) 305419896 )
+        : i _ht ( dhcp_tick hc 0 )
+        ( vec_free [u] hostile )
+        = hostile ( mk_reply ( dhcp_msg_offer ) 305419896 ( cl_mac ) bad 3600 0 0 )
+        : b took ( dhcp_handle hc ( dhcp_parse hostile 0 ( vec_len [u] hostile ) ) 1000 )
+        ? || took != . hc our_ip 0 { = refused_all F } {}
+        ( dhcp_client_free hc )
+        = hk + hk 1
+    }
+    ( pb `an unusable address is refused (0, 127.x, multicast, broadcast): ` refused_all )
+
+    // A mask is a run of ones then a run of zeros. 255.0.255.0 is not
+    // one, and taking it makes "is this destination on my link" mean
+    // something nobody wrote down.
+    : *DhcpClient c4 ( dhcp_client_new ( cl_mac ) 305419896 )
+    : i _d4 ( dhcp_tick c4 0 )
+    : ( Vec u ) offer4 ( mk_reply ( dhcp_msg_offer ) 305419896 ( cl_mac ) ( off_ip ) 3600 0 0 )
+    : b _o4 ( dhcp_handle c4 ( dhcp_parse offer4 0 ( vec_len [u] offer4 ) ) 1000 )
+    : ( Vec u ) ack4 ( mk_reply ( dhcp_msg_ack ) 305419896 ( cl_mac ) ( off_ip ) 3600 0 0 )
+    // The subnet option's value is at 251..254 (four bytes after the
+    // magic at 236, the message-type option and the server id).
+    : b _m4 ( vec_set [u] ack4 252 # u 0 )  // 255.255.255.0 → 255.0.255.0
+    : b _a4 ( dhcp_handle c4 ( dhcp_parse ack4 0 ( vec_len [u] ack4 ) ) 2000 )
+    ( pb `bound despite the bad mask: ` ( dhcp_bound c4 ) )
+    ( pb `a non-contiguous mask falls back to /24: ` == . c4 subnet ( ipv4_mask_from_prefix 24 ) )
+    ( dhcp_client_free c4 )
+
+    // Every option byte, fuzzed: the walk must terminate and the client
+    // must never end up bound to something it was not offered.
+    : ~ i fseed 20260806
+    : ~ b fuzz_ok T
+    : ~ i fk 0
+    ( vec_free [u] hostile )
+    = hostile ( mk_reply ( dhcp_msg_ack ) 305419896 ( cl_mac ) ( off_ip ) 3600 0 0 )
+    : i hlen ( vec_len [u] hostile )
+    ~ < fk 600 {
+        = fseed & + * fseed 6364136223846793005 1442695040888963407 4294967295
+        : i at + 240 % >> fseed 7 - hlen 240
+        : i was ?? ( vec_get [u] hostile at ) { T x → # i x F → 0 }
+        : b _f1 ( vec_set [u] hostile at # u & >> fseed 17 255 )
+        : DhcpMsg fm ( dhcp_parse hostile 0 hlen )
+        : *DhcpClient fc ( dhcp_client_new ( cl_mac ) 305419896 )
+        : i _ft ( dhcp_tick fc 0 )
+        : b _fh ( dhcp_handle fc fm 1000 )
+        ? && ( dhcp_bound fc ) ! ( ipv4_is_assignable . fc our_ip ) { = fuzz_ok F } {}
+        ? && ( dhcp_bound fc ) ! ( ipv4_mask_is_contiguous . fc subnet ) { = fuzz_ok F } {}
+        ( dhcp_client_free fc )
+        : b _f2 ( vec_set [u] hostile at # u & was 255 )
+        = fk + fk 1
+    }
+    ( pb `600 mutated option streams left the client sane: ` fuzz_ok )
+
     // Vec is a manually-managed handle (docs/MEMORY.md §7.4).
     ( vec_free [u] disc ) ( vec_free [u] wrong_xid ) ( vec_free [u] wrong_mac )
     ( vec_free [u] offer ) ( vec_free [u] ack ) ( vec_free [u] ack2 )
     ( vec_free [u] offer2 ) ( vec_free [u] ack3 ) ( vec_free [u] nak )
     ( vec_free [u] tiny ) ( vec_free [u] nomagic ) ( vec_free [u] badopt )
     ( vec_free [u] nolease ) ( vec_free [u] offer3 )
+    ( vec_free [u] hostile ) ( vec_free [u] offer4 ) ( vec_free [u] ack4 )
     ^ 0
 }

--- a/compiler/tests/net_frame_fuzz.nu
+++ b/compiler/tests/net_frame_fuzz.nu
@@ -1,0 +1,327 @@
+// net_frame_fuzz.nu — structural fuzz of the frame path: bytes off the
+// wire, straight into the sans-IO stack.
+//
+// `net_tcp_fuzz` fuzzes the TCP state machine with segments that are
+// already parsed. This one starts one layer lower, where a unikernel
+// actually lives: an arbitrary sequence of bytes arrives from a device,
+// and `stack_rx` is the first thing in the machine that looks at it.
+// Ethernet, ARP, IPv4 (with options), ICMP and UDP headers are all
+// parsed there, from a buffer whose contents nobody chose.
+//
+// Deterministic (an LCG seeded by a constant), so a failure reproduces
+// exactly. The generator mixes four populations, because pure noise
+// mostly exercises the first `if` and nothing else:
+//
+//   * uniform random bytes of a random length, including 0 and 1;
+//   * a well-formed frame addressed to us, with ONE byte flipped —
+//     the population that actually reaches the deep parsers;
+//   * a well-formed frame with a header field set to an extreme
+//     (IHL 15, total_len 65535, a length that claims more than arrived);
+//   * a truncated well-formed frame, cut at a random point.
+//
+// The oracle is not "it did not crash": NURL's accessors are bounds
+// checked, so a parser that reads past the end gets `F` rather than a
+// fault, and the bug shows up as a WRONG ANSWER instead. So what is
+// asserted is what the layer above is entitled to believe:
+//
+//   1. Any payload the stack hands up lies inside the frame it was
+//      given — `payload_off + payload_len <= frame length`. This is
+//      what a missing "total_len fits in what arrived" check breaks,
+//      and the caller who trusts it reads whatever is next in memory.
+//   2. Every dropped frame carries exactly one reason, in range, and
+//      the per-reason counters add up to the number of drops.
+//   3. Every reply the stack emits is a frame a device could send:
+//      at least 14 bytes, an ethertype we actually speak, and — for
+//      IPv4 — a header checksum that verifies and a total_len that
+//      fits inside the frame we built.
+//   4. A frame not addressed to us never produces a reply. An
+//      appliance that answers other machines' traffic is a reflector.
+//   5. Nothing is emitted for a dropped frame, and `emitted` agrees
+//      with what the packet buffer actually gained.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/net/pktbuf.nu`
+$ `stdlib/net/inet.nu`
+$ `stdlib/net/eth.nu`
+$ `stdlib/net/ipv4.nu`
+$ `stdlib/net/arp.nu`
+$ `stdlib/net/icmp.nu`
+$ `stdlib/net/udp4.nu`
+$ `stdlib/net/stack.nu`
+
+@ pb s label b v → v { ( nurl_print label ) ( nurl_print ? v `YES\n` `NO\n` ) }
+
+@ our_mac → i { ^ 2199023255553 }  // 02:00:00:00:00:01
+
+@ peer_mac → i { ^ 2199023255554 }  // 02:00:00:00:00:02
+
+@ our_ip → i { ^ ( ipv4_make 10 0 2 15 ) }
+
+@ peer_ip → i { ^ ( ipv4_make 10 0 2 16 ) }
+
+@ other_mac → i { ^ 2199023255807 }  // 02:00:00:00:00:ff — not us
+
+@ mask24 → i { ^ 4294967040 }
+
+@ lcg i st → i { ^ & + * st 6364136223846793005 1442695040888963407 4294967295 }
+
+// A well-formed UDP frame from the peer to us, built the way the stack
+// itself would build one. The mutators below start from this, because a
+// generator that never produces a valid frame never gets past line one
+// of the parser.
+@ __good_frame ( Vec u ) out i payload_len → v {
+    ( vec_clear [u] out )
+    : ( Vec u ) pay ( vec_new [u] )
+    : ~ i k 0
+    ~ < k payload_len { ( vec_push [u] pay # u & + k 65 255 ) = k + k 1 }
+
+    : ( Vec u ) dg ( vec_new [u] )
+    ( udp4_push dg ( peer_ip ) ( our_ip ) 4000 4001 pay 0 payload_len )
+    ( eth_push_header out ( our_mac ) ( peer_mac ) ( ethertype_ipv4 ) )
+    ( ip4_push_header out ( peer_ip ) ( our_ip ) ( ip_proto_udp ) ( vec_len [u] dg ) 7 64 T )
+    ( vec_extend [u] out dg )
+    ( vec_free [u] dg )
+    ( vec_free [u] pay )
+}
+
+// An ARP request for our address — the other frame that makes the stack
+// answer, and therefore the other one worth mutating.
+@ __good_arp ( Vec u ) out → v {
+    ( vec_clear [u] out )
+    ( eth_push_header out ( mac_broadcast ) ( peer_mac ) ( ethertype_arp ) )
+    ( arp_push_request out ( peer_mac ) ( peer_ip ) ( our_ip ) )
+}
+
+// An ICMP echo request — the third frame the stack answers, and the one
+// whose reply is built from the request's own bytes.
+@ __good_ping ( Vec u ) out i payload_len → v {
+    ( vec_clear [u] out )
+    : ( Vec u ) pay ( vec_new [u] )
+    : ~ i k 0
+    ~ < k payload_len { ( vec_push [u] pay # u & + k 33 255 ) = k + k 1 }
+    : ( Vec u ) msg ( vec_new [u] )
+    ( icmp_push msg ( icmp_echo_request ) 0 1234 7 pay 0 payload_len )
+    ( eth_push_header out ( our_mac ) ( peer_mac ) ( ethertype_ipv4 ) )
+    ( ip4_push_header out ( peer_ip ) ( our_ip ) ( ip_proto_icmp ) ( vec_len [u] msg ) 9 64 T )
+    ( vec_extend [u] out msg )
+    ( vec_free [u] msg )
+    ( vec_free [u] pay )
+}
+
+// One of the three frames this stack has an answer for, unmutated. A
+// generator that only ever produces broken input never reaches the code
+// that builds a reply — and "no reply was ever emitted" is a fuzz run
+// that proved nothing about the reply path.
+@ __good_any ( Vec u ) out i which i len → v {
+    ? == % which 3 0 { ( __good_arp out ) } {
+        ? == % which 3 1 { ( __good_ping out len ) } { ( __good_frame out len ) }
+    }
+}
+
+// Point a well-formed frame at a third machine, by rewriting the six
+// bytes of destination MAC and nothing else.
+@ __readdress ( Vec u ) f → v {
+    ? < ( vec_len [u] f ) 6 { ^ } {}
+    : ~ i k 0
+    ~ < k 6 {
+        : b _s ( vec_set [u] f k # u & >> ( other_mac ) * 8 - 5 k 255 )
+        = k + k 1
+    }
+}
+
+@ __rand_bytes ( Vec u ) out i n i seed → i {
+    : ~ i s seed
+    ( vec_clear [u] out )
+    : ~ i k 0
+    ~ < k n {
+        = s ( lcg s )
+        ( vec_push [u] out # u & >> s 13 255 )
+        = k + k 1
+    }
+    ^ s
+}
+
+// Is this frame addressed to us? Answered from the bytes, independently
+// of the stack, so invariant 4 has a second opinion rather than the
+// stack's own.
+@ __addressed_to_us ( Vec u ) f → b {
+    ? < ( vec_len [u] f ) 6 { ^ F } {}
+    : ~ i dst 0
+    : ~ i k 0
+    : ~ b all_ff T
+    ~ < k 6 {
+        : i b ?? ( vec_get [u] f k ) { T x → # i x F → 0 }
+        = dst | << dst 8 b
+        ? != b 255 { = all_ff F } {}
+        = k + k 1
+    }
+    ^ || all_ff == dst ( our_mac )
+}
+
+// Invariant 3, applied to one emitted frame.
+@ __reply_well_formed ( Vec u ) f → b {
+    : i n ( vec_len [u] f )
+    ? < n 14 { ^ F } {}
+    : EthHdr eh ( eth_parse f )
+    ? ! . eh valid { ^ F } {}
+    ? == . eh ethertype ( ethertype_arp ) { ^ >= n 42 } {}
+    ? != . eh ethertype ( ethertype_ipv4 ) { ^ F } {}
+    : Ip4Hdr ih ( ip4_parse f . eh payload_off . eh payload_len )
+    ? ! . ih valid { ^ F } {}
+    ^ <= + . ih payload_off . ih payload_len n
+}
+
+@ main → i {
+    : *NetStack st ( stack_new ( our_mac ) ( our_ip ) ( mask24 ) ( ipv4_make 10 0 2 1 ) )
+    : *PktBuf out ( pktbuf_new )
+    : ( Vec u ) frame ( vec_new [u] )
+
+    : ~ i seed 20260806
+    : ~ b payload_inside T
+    : ~ b reason_sane T
+    : ~ b replies_valid T
+    : ~ b no_reflection T
+    : ~ b emitted_agrees T
+    : ~ i drops 0
+    : ~ i handled 0
+    : ~ i replies 0
+
+    : ~ i round 0
+    ~ < round 3000 {
+        = seed ( lcg seed )
+        : i shape % >> seed 7 5
+        : i n % >> seed 17 200
+
+        ? == shape 0 {
+            = seed ( __rand_bytes frame n seed )
+        } {
+            ? == shape 1 {
+                // a good frame with one byte flipped
+                ? == % >> seed 23 3 0 { ( __good_arp frame ) } { ( __good_frame frame % >> seed 11 64 ) }
+                : i len ( vec_len [u] frame )
+                ? > len 0 {
+                    : i at % >> seed 19 len
+                    : i old ?? ( vec_get [u] frame at ) { T x → # i x F → 0 }
+                    : b _s ( vec_set [u] frame at # u & ^^ old & >> seed 29 255 255 )
+                } {}
+            } {
+                ? == shape 2 {
+                    // a good frame with an extreme header field
+                    ( __good_frame frame % >> seed 11 32 )
+                    : i which % >> seed 27 4
+                    ? == which 0 {
+                        : b _a ( vec_set [u] frame 14 # u 79 )  // version 4, IHL 15
+                    } {}
+                    ? == which 1 {
+                        : b _b ( vec_set [u] frame 16 # u 255 )  // total_len = 65535
+                        : b _c ( vec_set [u] frame 17 # u 255 )
+                    } {}
+                    ? == which 2 {
+                        : b _d ( vec_set [u] frame 20 # u 32 )  // MF set, offset 0
+                        : b _e ( vec_set [u] frame 21 # u 1 )
+                    } {}
+                    // A UDP datagram with NO checksum (legal, RFC 768)
+                    // whose length field claims far more than arrived.
+                    // Zero checksum is the one path where the length is
+                    // not cross-checked by anything else, so it is the
+                    // one place a missing bounds test survives — and it
+                    // is reachable by anyone who can send a packet.
+                    ? == which 3 {
+                        : b _f ( vec_set [u] frame 40 # u 0 )  // checksum
+                        : b _g ( vec_set [u] frame 41 # u 0 )
+                        : b _h ( vec_set [u] frame 38 # u 255 )  // length
+                        : b _i ( vec_set [u] frame 39 # u 255 )
+                    } {}
+                } {
+                    ? == shape 3 {
+                        // a good frame, cut short
+                        ( __good_frame frame % >> seed 11 48 )
+                        : i len ( vec_len [u] frame )
+                        : i keep % >> seed 21 + len 1
+                        ~ > ( vec_len [u] frame ) keep { : ?u _p ( vec_pop [u] frame ) }
+                    } {
+                        // a frame the stack is supposed to answer — and,
+                        // one time in three, the same frame addressed to
+                        // somebody else. A stack that answers those is a
+                        // reflector, and it is a population that random
+                        // bytes never produce: a valid ARP request or
+                        // echo request with a foreign destination has to
+                        // be built on purpose.
+                        ( __good_any frame % >> seed 25 3 % >> seed 11 40 )
+                        ? == % >> seed 31 3 0 { ( __readdress frame ) } {}
+                    }
+                }
+            }
+        }
+
+        : i flen ( vec_len [u] frame )
+        : i before_total ( pktbuf_total out )
+        : i before_count ( pktbuf_count out )
+        : b for_us ( __addressed_to_us frame )
+
+        : RxResult r ( stack_rx st frame * round 10 out )
+        = handled + handled 1
+
+        : i gained - ( pktbuf_total out ) before_total
+        : i new_frames - ( pktbuf_count out ) before_count
+
+        // 1. anything handed up must lie inside the frame
+        ? || == . r kind ( rx_udp ) == . r kind ( rx_tcp ) {
+            ? > + . r payload_off . r payload_len flen { = payload_inside F } {}
+        } {}
+
+        // 2. one reason, in range, and the counters agree
+        ? == . r kind ( rx_dropped ) {
+            = drops + drops 1
+            ? || < . r reason 0 >= . r reason ( n_drop_reasons ) { = reason_sane F } {}
+            ? != gained 0 { = emitted_agrees F } {}
+        } {}
+
+        // 5. `emitted` is what the buffer actually gained
+        ? != . r emitted gained { = emitted_agrees F } {}
+
+        // 3 + 4. every emitted frame is well formed, and only frames
+        // addressed to us produce any
+        ? > new_frames 0 {
+            = replies + replies new_frames
+            ? ! for_us { = no_reflection F } {}
+            : ~ i idx before_count
+            ~ < idx ( pktbuf_count out ) {
+                : ( Vec u ) one ( vec_new [u] )
+                : i _c ( pktbuf_copy_to one out idx )
+                ? ! ( __reply_well_formed one ) { = replies_valid F } {}
+                ( vec_free [u] one )
+                = idx + idx 1
+            }
+        } {}
+
+        ( pktbuf_clear out )
+        = round + round 1
+    }
+
+    // The counters the stack keeps must add up to the drops observed:
+    // a frame that vanished without landing in a bucket is exactly the
+    // "some packets go missing" the drop accounting exists to prevent.
+    : ~ i counted 0
+    : ~ i ri 0
+    ~ < ri ( n_drop_reasons ) {
+        = counted + counted ( stack_drop_count st ri )
+        = ri + ri 1
+    }
+
+    ( pb `every payload handed up lies inside its frame: ` payload_inside )
+    ( pb `every drop has exactly one reason, in range: ` reason_sane )
+    ( pb `drop counters add up: ` == counted drops )
+    ( pb `every emitted frame is one a device could send: ` replies_valid )
+    ( pb `frames not addressed to us are never answered: ` no_reflection )
+    ( pb `emitted bytes agree with the buffer: ` emitted_agrees )
+    ( pb `the fuzz completed without hanging: ` == handled 3000 )
+    ( pb `the deep parsers were reached (some replies emitted): ` > replies 0 )
+
+    ( vec_free [u] frame )
+    ( pktbuf_free out )
+    ( stack_free st )
+    ^ 0
+}

--- a/compiler/tests/outputs/net_dhcp.txt
+++ b/compiler/tests/outputs/net_dhcp.txt
@@ -64,3 +64,7 @@ bad magic cookie rejected: YES
 overlong option terminates walk: YES
 missing lease → 1h default: YES
 bound with defaulted lease: YES
+an unusable address is refused (0, 127.x, multicast, broadcast): YES
+bound despite the bad mask: YES
+a non-contiguous mask falls back to /24: YES
+600 mutated option streams left the client sane: YES

--- a/compiler/tests/outputs/net_frame_fuzz.txt
+++ b/compiler/tests/outputs/net_frame_fuzz.txt
@@ -1,0 +1,12 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+every payload handed up lies inside its frame: YES
+every drop has exactly one reason, in range: YES
+drop counters add up: YES
+every emitted frame is one a device could send: YES
+frames not addressed to us are never answered: YES
+emitted bytes agree with the buffer: YES
+the fuzz completed without hanging: YES
+the deep parsers were reached (some replies emitted): YES

--- a/stdlib/net/dhcp.nu
+++ b/stdlib/net/dhcp.nu
@@ -342,6 +342,15 @@ $ `stdlib/net/udp4.nu`
     ? != . m op ( dhcp_op_reply ) { ^ F } {}
     ? != . m xid . c xid { ^ F } {}
     ? != . m chaddr_mac . c mac { ^ F } {}
+    // An address a host cannot own is not an offer, it is a way to take
+    // this machine off the network without anything failing: zero,
+    // 127.x, multicast and the broadcast address are all things a server
+    // can put in `yiaddr`, and a client that accepts one configures
+    // itself into silence. Ignore the message and keep asking — the
+    // retransmit timer is already the answer to "the server is useless".
+    ? && || == . m msg_type ( dhcp_msg_offer ) == . m msg_type ( dhcp_msg_ack ) ! ( ipv4_is_assignable . m yiaddr ) {
+        ^ F
+    } {}
     ? && == . m msg_type ( dhcp_msg_offer ) == . c state ( dhcp_state_selecting ) {
         = . c our_ip . m yiaddr
         = . c server_id . m server_id
@@ -355,7 +364,12 @@ $ `stdlib/net/udp4.nu`
         ? || || == . c state ( dhcp_state_requesting ) == . c state ( dhcp_state_renewing ) == . c state ( dhcp_state_rebinding ) {
             = . c our_ip . m yiaddr
             ? != . m server_id 0 { = . c server_id . m server_id } {}
-            = . c subnet ? != . m subnet 0 . m subnet ( ipv4_mask_from_prefix 24 )
+            // A mask is a run of ones followed by a run of zeros.
+            // Anything else makes `ipv4_in_subnet` and the directed
+            // broadcast mean something other than what they are named
+            // after, so a mask that is not one is treated as a mask that
+            // was not sent.
+            = . c subnet ? ( ipv4_mask_is_contiguous . m subnet ) . m subnet ( ipv4_mask_from_prefix 24 )
             = . c router . m router
             = . c dns . m dns
             : i lease ? > . m lease_secs 0 . m lease_secs 3600

--- a/stdlib/net/inet.nu
+++ b/stdlib/net/inet.nu
@@ -149,6 +149,34 @@ $ `stdlib/core/vec.nu`
 
 @ ipv4_is_broadcast i addr → b { ^ == addr 4294967295 }
 
+// 127.0.0.0/8
+@ ipv4_is_loopback i addr → b { ^ == & addr 4278190080 2130706432 }
+
+// Is this an address a host can call its own? Zero is "no address", the
+// loopback block belongs to the machine's own stack, and multicast and
+// broadcast are destinations rather than identities. Every one of them
+// is something a DHCP server can put in `yiaddr`, and a host that
+// accepts one has configured itself off the network — silently, because
+// nothing fails until the first packet nobody answers.
+@ ipv4_is_assignable i addr → b {
+    ? == addr 0 { ^ F } {}
+    ? ( ipv4_is_loopback addr ) { ^ F } {}
+    ? ( ipv4_is_multicast addr ) { ^ F } {}
+    ? ( ipv4_is_broadcast addr ) { ^ F } {}
+    ^ T
+}
+
+// A netmask is a run of ones followed by a run of zeros — nothing else
+// is a mask, and the arithmetic underneath `ipv4_in_subnet` and
+// `ipv4_subnet_broadcast` quietly means something else if it is handed
+// one that is not. `mask | (mask - 1)` is all-ones exactly when the
+// zeros are a suffix; zero itself is not a usable mask here.
+@ ipv4_mask_is_contiguous i mask → b {
+    ? == mask 0 { ^ F } {}
+    ? == mask 4294967295 { ^ T } {}
+    ^ == & | mask - mask 1 4294967295 4294967295
+}
+
 // The all-ones directed broadcast for a subnet, e.g. 10.0.2.255.
 @ ipv4_subnet_broadcast i net i mask → i {
     ^ | & net mask & ^^ mask 4294967295 4294967295

--- a/stdlib/net/stack.nu
+++ b/stdlib/net/stack.nu
@@ -175,9 +175,9 @@ $ `stdlib/net/pktbuf.nu`
 // Which MAC should carry a datagram for `dst`? On-link destinations
 // resolve to themselves; everything else goes to the gateway. Broadcast
 // and directed-broadcast go to the Ethernet broadcast address.
-// 127.0.0.0/8 is this machine, whatever address the interface has.
-@ ipv4_is_loopback i addr → b { ^ == & addr 4278190080 2130706432 }
-
+// 127.0.0.0/8 is this machine, whatever address the interface has —
+// `ipv4_is_loopback` lives in net/inet.nu with the rest of the address
+// predicates, because the DHCP client needs the same question answered.
 @ __next_hop * NetStack st i dst → i {
     // A datagram for ourselves goes to our own MAC, so it comes back
     // through the same door every other frame does. Loopback is not a

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -51,7 +51,7 @@ worth anything.
 ## State (2026-08-06)
 
 ```
-  PASS         450    corpus tests that build and run with no libc at all
+  PASS         451    corpus tests that build and run with no libc at all
   FAIL           0
   NEEDS-BARE    21    processes and signals — a unikernel has neither
   NEEDS-LIBM     0
@@ -290,7 +290,7 @@ privilege boundary with nothing on the other side of it is ceremony.
 ```
 $ curl -X POST -d '{"jsonrpc":"2.0","id":3,"method":"tools/call",
                     "params":{"name":"echo","arguments":{"text":"from the host"}}}' \
-       http://127.0.0.1:18771/mcp
+       http://127.0.0.1:18992/mcp
 {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"from the host"}],
  "isError":false,"resultType":"complete"}}
 ```
@@ -381,7 +381,7 @@ All three gates run on every code change (the `unikernel` job):
 
 | | |
 |---|---|
-| `run_nolibc_tests.sh` | the ordinary corpus, no libc linked — 450 programs against their existing goldens |
+| `run_nolibc_tests.sh` | the ordinary corpus, no libc linked — 451 programs against their existing goldens |
 | `tests/run_unit_tests.sh` | the differentials against glibc, BOTH allocators fuzzed (the size-class one and the page allocator under it), the scheduler's schedule and its deadlock detector |
 | `run_qemu_tests.sh` | the guest, 18 checks: boot, memory, TSC, fibers, the TCP/UDP stack, virtio-net, DHCP, a baked-in filesystem, two deliberate CPU faults and their reports, a 200-request soak with the heap watched, and three servers answering a client on the host — plaintext, MCP and TLS 1.3 |
 

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -269,9 +269,13 @@ unikernel/run_qemu.sh myserver.elf -t 60 -- \
     -device virtio-net-device,netdev=n0
 ```
 
-Under Firecracker the same ELF is `--kernel-image`, with `boot-args`
-carrying the same keys; the exit sentinel is how it reports its status,
-since Firecracker has no other channel for one.
+Firecracker should take the same ELF as `--kernel-image` with `boot-args`
+carrying the same keys — PVH is its boot protocol too, and the exit
+sentinel exists because Firecracker has no channel for an exit code.
+**Not gated, and therefore not claimed**: every measurement and every
+gate in this directory is QEMU microvm. The plan has Firecracker as a
+later step, and until a job boots one, treat the paragraph above as a
+design intent rather than a tested path.
 
 **The threat model, stated.** The hypervisor and whoever writes the
 kernel command line are TRUSTED — they choose the image, its

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -246,12 +246,28 @@ rather than guessed:
 | `virtio_mmio.device=…` | where the devices are | appended by the hypervisor; the guest parses it, and a guest with no match reports "no device" rather than probing blindly |
 | `args="…"` | the program's argv | when the program takes arguments. ONE key, quoted, because QEMU appends its own entries after `-append` and a program that read the tail of the line would be handed them |
 
+**How small it goes.** Measured, by asking QEMU for less and less until
+the answer stopped coming:
+
+| | |
+|---|---|
+| `hello` | answers on **3 MiB** |
+| the HTTP server, over virtio-net and DHCP | answers on **4 MiB** |
+| the HTTPS server, TLS 1.3 with an RSA-2048 certificate | answers on **4 MiB** |
+| below that | it SAYS so: 3 MiB of TLS is `nurl: out of memory (requested 24 bytes)` and an abort; 2 MiB is `the hypervisor reported no usable memory above the image` and exit 127 |
+
+The gates run with 256 MiB, which hides that question entirely, so
+`run_qemu_tests.sh` also boots `hello` on 4 MiB and the server on 8 —
+headroom over the floor, because what is worth pinning is appetite, and
+a change that doubles what the guest needs should fail here rather than
+on somebody's Firecracker host.
+
 **Sizes and limits**, all of them deliberate and all of them checkable:
 
 | | |
 |---|---|
 | vCPUs | one. Fibers are cooperative; there is no preemption and no SMP |
-| memory | whatever the hypervisor reports; 256 MiB is what the gates run with |
+| memory | whatever the hypervisor reports; 256 MiB is what the gates run with, 4 MiB is what a server needs (see above) |
 | MTU | 1500. Frames are refused above 2036 bytes rather than truncated |
 | IP fragments | dropped, counted, never reassembled. A datagram over the MTU does not arrive |
 | open files | 16, from the baked-in archive, read-only |
@@ -387,7 +403,7 @@ All three gates run on every code change (the `unikernel` job):
 |---|---|
 | `run_nolibc_tests.sh` | the ordinary corpus, no libc linked — 451 programs against their existing goldens |
 | `tests/run_unit_tests.sh` | the differentials against glibc, BOTH allocators fuzzed (the size-class one and the page allocator under it), the scheduler's schedule and its deadlock detector |
-| `run_qemu_tests.sh` | the guest, 18 checks: boot, memory, TSC, fibers, the TCP/UDP stack, virtio-net, DHCP, a baked-in filesystem, two deliberate CPU faults and their reports, a 200-request soak with the heap watched, and three servers answering a client on the host — plaintext, MCP and TLS 1.3 |
+| `run_qemu_tests.sh` | the guest, 19 checks: boot, memory, TSC, fibers, the TCP/UDP stack, virtio-net, DHCP, a baked-in filesystem, two deliberate CPU faults and their reports, a 200-request soak with the heap watched, a 4 MiB machine and a 2 MiB one that refuses to boot, and three servers answering a client on the host — plaintext, MCP and TLS 1.3 |
 
 The frame path has a gate of its own in the ordinary corpus:
 `net_frame_fuzz` drives `stack_rx` with bytes nobody chose and asserts

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -27,11 +27,13 @@ Decided by coupling, not convenience:
 | `nolibc/` | the libc subset: `string.c`, `malloc.c`, `stdio.c`, `dtoa.c`, `math.c` (+ the generated `math_tables.h`), `misc.c`, `syscall_linux.c`, `tls_linux.c`, `start_x86_64.S`, `setjmp_x86_64.S` |
 | `runtime_bare.c` | threads, fibers, sync and entropy for one vCPU with nothing under it |
 | `net/sockets.nu` | the socket ABI (`nurl_tcp_*`, `nurl_udp_*`, `nurl_dns_*`, `nurl_reactor_wait_*`) in NURL, over the sans-IO stack in `stdlib/net/` |
-| `boot/` | the guest: PVH entry + long mode + SSE (`boot.S`), the address space (`link.ld`), the machine's bottom edge (`platform_x86.c`), the thread pointer without an auxv (`tls_guest.c`) |
+| `boot/` | the guest: PVH entry + long mode + SSE + the interrupt stubs (`boot.S`), the address space (`link.ld`), the machine's bottom edge (`platform_x86.c`), the pages themselves (`pagealloc.c`), the baked-in filesystem (`initfs.c`), the thread pointer without an auxv (`tls_guest.c`) |
+| `drivers/` | `virtionet.nu` — frames in and out over a real device |
 | `build_unikernel.sh` | build a `.nu` into a bootable PVH kernel image |
 | `run_qemu.sh` · `run_qemu_tests.sh` | boot one image · run corpus tests inside the guest against their goldens |
 | `compile_nu.sh` | compile one program, pulling in `net/sockets.nu` when (and only when) it calls the socket ABI |
-| `tests/` | the unit gates — differentials against glibc for strings, float formatting and libm; an allocator fuzzer; the scheduler's schedule and its deadlock detector |
+| `demos/` | the programs that only make sense in the guest: devices, DHCP, a filesystem, a server, an MCP endpoint, TLS — and the two that are about failure, `fault.nu` and `soak.nu` |
+| `tests/` | the unit gates — differentials against glibc for strings, float formatting and libm; two allocator fuzzers; the scheduler's schedule and its deadlock detector |
 | `build_nolibc.sh` | build one `.nu` program against nolibc with `-nostdlib` |
 | `run_nolibc_tests.sh` | build and run the **whole corpus** that way |
 
@@ -46,10 +48,10 @@ from a baked-in image) and the second (the boot shim enters at
 with a different bottom edge, which is what makes testing it on Linux
 worth anything.
 
-## State (2026-08-05)
+## State (2026-08-06)
 
 ```
-  PASS         449    corpus tests that build and run with no libc at all
+  PASS         450    corpus tests that build and run with no libc at all
   FAIL           0
   NEEDS-BARE    21    processes and signals — a unikernel has neither
   NEEDS-LIBM     0
@@ -81,8 +83,6 @@ job — is a fact about a file rather than an opinion in a script. A
 hand-kept list of names is what gated the whole live surface of the
 runtime out of CI, twice.
 
-That leaves one real piece of work, `NEEDS-BARE`: the socket seam, which
-is phase A4 and the place the sans-IO stack in `stdlib/net/` plugs in.
 `NEEDS-LIB` is not work at all — a unikernel does not link libsqlite3 —
 and keeping it in its own column stops the backlog looking larger than
 it is.
@@ -99,7 +99,7 @@ pointer), one `mmap` (the first allocator arena) and one `write`.
 ```sh
 unikernel/build_unikernel.sh compiler/tests/hello.nu
 unikernel/run_qemu.sh build/unikernel/hello.elf     # → Hello, NURL! … exit 0
-unikernel/run_qemu_tests.sh                         # 9/9 against the goldens
+unikernel/run_qemu_tests.sh                         # 18/18 against the goldens
 ```
 
 QEMU microvm, PVH direct boot, no BIOS and no bootloader: the
@@ -109,12 +109,15 @@ ordinary stdlib path. `net_socket` and `net_tcpstack` are in the guest
 gate because they run the whole TCP/UDP stack — connection table,
 socket layer, loopback — on bare metal.
 
-Exactly three files differ from the Linux freestanding build, and they
-are the ones that talk to the machine: `boot/boot.S`,
-`boot/platform_x86.c` and `boot/tls_guest.c` replace
+Exactly three files REPLACE anything from the Linux freestanding build,
+and they are the ones that talk to the machine: `boot/boot.S`,
+`boot/platform_x86.c` and `boot/tls_guest.c` stand in for
 `nolibc/start_x86_64.S`, `nolibc/syscall_linux.c` and
-`nolibc/tls_linux.c`. Everything else — nolibc, runtime_core.c,
-runtime_bare.c, the NURL program — is the same object code.
+`nolibc/tls_linux.c`. Two more are additions with no hosted counterpart,
+because on Linux the kernel already did the job: `boot/pagealloc.c` (the
+pages) and `boot/initfs.c` (a filesystem inside the image). Everything
+else — nolibc, runtime_core.c, runtime_bare.c, the NURL program — is the
+same object code.
 
 Fibers run there too, on stacks whose guard pages are real page-table
 entries: the 2 MiB boot mapping is split into 4 KiB pages on demand,
@@ -130,6 +133,157 @@ The clock is the TSC, and its frequency is never guessed: CPUID leaf
 asking for the time panics. `wallclock=` carries the boot epoch the
 same way — a functionality input, not a security control, since the
 host already controls the whole image.
+
+## When it does not boot, and when it breaks
+
+A guest is the only program with nobody underneath it to explain what
+went wrong, which is why this is a section and not a footnote.
+
+Every CPU exception is caught. The IDT is installed before anything that
+could fault — the very first thing after the serial port — and its 256
+stubs reach one handler that prints the fault by the name every manual
+uses, with the registers that say where it happened:
+
+```
+nurl: fault #PF page fault vector=14 err=0x2
+  rip=0x10be42 rsp=0x128000 rflags=0x6
+  cr2=0x127ff8 (not present) on write
+  rax=0x18 rbx=0x18 rcx=0x1488a0 rdx=0x0
+  rsi=0x18 rdi=0x18 rbp=0x0
+```
+
+Without that, all of these were the same event: the machine stopped, the
+hypervisor exited, and the exit sentinel was simply missing — which from
+the host is indistinguishable from a clean, successful run. The version
+of this directory before it could not tell a null dereference from a
+finished program.
+
+`#DF` and `#PF` are delivered on an **IST stack**, because the fault most
+worth surviving is a stack that ran off its guard page: delivered on
+that same dead stack, the push faults, the double fault's push faults,
+and the machine triple-faults with nothing printed.
+
+Two guard pages exist for the same reason:
+
+- **under the boot stack** — a recursion off the end used to write into
+  whatever `.bss` put underneath and carry on with someone else's
+  variables. Coroutine stacks always had one; the stack `main` runs on
+  did not.
+- **page zero** — the boot tables identity-map the low 4 GiB present and
+  writable, so a store through a null pointer QUIETLY SUCCEEDED in this
+  guest while being a segfault on every hosted target. It is unmapped
+  once the hypervisor's handover block and command line are known to be
+  elsewhere, which they always are.
+
+`demos/fault.nu` causes both on purpose and the gate reads the reports —
+including the exit code, because these are distinguishable states:
+
+| exit | what happened |
+|---|---|
+| 0…125 | the program's own `main` returned it |
+| 126 | a CPU exception. A fault report precedes it |
+| 127 | `pf_panic` — the machine refused to continue, and said why: no memory map, no TSC frequency, no entropy source, out of page tables |
+| 134 | `abort` — the runtime's own, e.g. `nurl: out of memory` |
+| 124 | no exit sentinel at all: the guest never finished. A hang, or a hypervisor that killed it |
+
+The sentinel is the protocol, not the exit status: Firecracker cannot
+hand a guest's exit code back at all, so `[nurl-exit] N` on the serial
+port is what the harness parses and `isa-debug-exit` is a cross-check.
+
+## Memory, and how much of it there is
+
+The hypervisor's memory map is READ, never assumed — the largest usable
+region at or above the image is the heap, and a guest told it has less
+RAM than it guessed is a guest that corrupts itself. Out of that region:
+a page-table pool reserved at boot (64 tables, enough to split 128 MiB
+into 4 KiB pages, which is about 1900 coroutine stacks), and everything
+else belongs to `boot/pagealloc.c`.
+
+That file is what `mmap` and `munmap` are made of here, and it gives
+memory BACK: a sorted free list of page ranges, best fit, coalescing on
+both sides, with the tail rolled back when a freed range touches it. The
+version before it was a bump pointer and a `munmap` that returned
+success without doing anything, which is fine for a program that runs
+once and wrong for the thing this target is for. Measured on a 256 MiB
+machine: allocate a megabyte and free it, and the old one died on the
+251st iteration. The current one survives 4000.
+
+It is portable C on purpose. `tests/pagealloc_fuzz.c` runs it on the
+host against a model that checks, on every operation, that no two live
+ranges overlap, that the accounting agrees, and that after freeing
+everything the region fits in itself — a page allocator only ever
+exercised inside a virtual machine is one whose bugs arrive as a triple
+fault.
+
+Above it, nolibc's `malloc` keeps per-class free lists carved from 1 MiB
+arenas. Those arenas are never returned, by design: a program's small
+objects settle at a plateau and handing pages back and forth around it
+would trade a bounded high-water mark for churn. So the shape to expect
+from a long-running guest is *live memory rises to a plateau and stays
+there*, which is exactly what `demos/soak.nu` asserts about itself over
+200 requests, and what the same demo reported as a 5 MB climb when the
+virtio-net driver was still leaking a buffer per packet.
+
+Exhaustion is a refusal, then an honest death: `pa_alloc` answers zero,
+`malloc` answers NULL, and the runtime prints `nurl: out of memory
+(requested N bytes)` and aborts. It is not a silent wild write, which is
+what it was until `nl_map` was made to answer the way its Linux twin
+always had.
+
+## Running one in production
+
+**What the image needs.** Nothing but a hypervisor with virtio-mmio and
+a serial port. No disk, no initrd, no bootloader, no kernel command line
+beyond the keys below, no filesystem except the one baked into the ELF.
+
+**The kernel command line** is a contract, and every key is stated
+rather than guessed:
+
+| key | meaning | when it is required |
+|---|---|---|
+| `tsc_khz=N` | the TSC frequency | when no CPUID leaf reports one — i.e. under TCG. Asking for the time without it PANICS rather than inventing a number |
+| `wallclock=N` | the boot epoch, seconds | whenever X.509 validity is checked: TLS client verification, and a server whose certificate has dates |
+| `virtio_mmio.device=…` | where the devices are | appended by the hypervisor; the guest parses it, and a guest with no match reports "no device" rather than probing blindly |
+| `args="…"` | the program's argv | when the program takes arguments. ONE key, quoted, because QEMU appends its own entries after `-append` and a program that read the tail of the line would be handed them |
+
+**Sizes and limits**, all of them deliberate and all of them checkable:
+
+| | |
+|---|---|
+| vCPUs | one. Fibers are cooperative; there is no preemption and no SMP |
+| memory | whatever the hypervisor reports; 256 MiB is what the gates run with |
+| MTU | 1500. Frames are refused above 2036 bytes rather than truncated |
+| IP fragments | dropped, counted, never reassembled. A datagram over the MTU does not arrive |
+| open files | 16, from the baked-in archive, read-only |
+| sockets | the fd table in `stdlib/net/socket.nu`; ephemeral ports are per-protocol, TCP and UDP have separate spaces |
+| name resolution | literals and `localhost`. Anything else is refused, not guessed |
+| processes, signals | none. `fork`/`exec` report unsupported; there is one address space and nothing to fork |
+| GPU | none in a microVM; a swarm node advertises CPU-wasm capability only |
+
+**Building and running one:**
+
+```sh
+unikernel/build_unikernel.sh myserver.nu --fs ./image_root -o myserver.elf
+unikernel/run_qemu.sh myserver.elf -t 60 -- \
+    -netdev user,id=n0,hostfwd=tcp:127.0.0.1:8443-:8443 \
+    -device virtio-net-device,netdev=n0
+```
+
+Under Firecracker the same ELF is `--kernel-image`, with `boot-args`
+carrying the same keys; the exit sentinel is how it reports its status,
+since Firecracker has no other channel for one.
+
+**The threat model, stated.** The hypervisor and whoever writes the
+kernel command line are TRUSTED — they choose the image, its
+certificate and its clock, so nothing here defends against them, and
+`wallclock=` is a functionality input rather than a security control.
+The NETWORK is not trusted: every byte that arrives from virtio-net is
+parsed by `stdlib/net/`, which is fuzzed for exactly that
+(`net_frame_fuzz`), and the driver clamps the lengths the DEVICE
+reports because a device is on the other side of the same trust
+boundary. There is no user/supervisor split inside the guest and no
+attempt at one: a unikernel is one program in one address space, and a
+privilege boundary with nothing on the other side of it is ceremony.
 
 ## An MCP endpoint that IS the machine
 
@@ -176,10 +330,12 @@ machine):
 
 | | |
 |---|---|
-| plaintext image | 353 936 bytes |
-| TLS image | 377 992 bytes (the extra 24 KiB is the whole of TLS 1.3) |
+| plaintext image | 363 128 bytes |
+| TLS image | 387 176 bytes (the extra 24 KiB is the whole of TLS 1.3) |
 | cold VM to first HTTP answer | 2.5 – 6.6 s |
 | cold VM to first HTTPS answer | ~11 s |
+| HTTP requests per second | 143 (100 sequential, one connection each) |
+| heap after 200 requests | flat — growth 0 bytes after warm-up |
 
 Two honest caveats, because the numbers are worth less without them.
 TCG is an **interpreter**: it is the floor, not the ceiling, and the
@@ -195,6 +351,13 @@ Everything above the "answer" is included: the hypervisor starting, the
 guest booting, DHCP completing against QEMU's server, the socket
 binding, and — for the TLS row — an RSA handshake, which is where most
 of that eleven seconds goes on an interpreter.
+
+The throughput row is **sequential**: one connection per request, so it
+is latency's reciprocal rather than a concurrency figure, and calling it
+anything else would flatter it. It comes from the same run as the heap
+row — `demos/soak.nu`, the program the guest gate uses — because a
+throughput number and a leak number measured on two different servers
+are two numbers about two different programs.
 
 ## Accuracy, stated
 
@@ -214,13 +377,22 @@ for the cube root of 27, and this one answers 3.
 
 ## What CI watches
 
-Both gates run on every code change (the `unikernel` job):
+All three gates run on every code change (the `unikernel` job):
 
 | | |
 |---|---|
 | `run_nolibc_tests.sh` | the ordinary corpus, no libc linked — 450 programs against their existing goldens |
-| `tests/run_unit_tests.sh` | the differentials, the allocator fuzzer, the scheduler's schedule and its deadlock detector |
-| `run_qemu_tests.sh` | the guest: boot, memory, TSC, fibers, the TCP/UDP stack, virtio-net, DHCP, a baked-in filesystem, and two servers answering a client on the host — one plaintext, one TLS 1.3 |
+| `tests/run_unit_tests.sh` | the differentials against glibc, BOTH allocators fuzzed (the size-class one and the page allocator under it), the scheduler's schedule and its deadlock detector |
+| `run_qemu_tests.sh` | the guest, 18 checks: boot, memory, TSC, fibers, the TCP/UDP stack, virtio-net, DHCP, a baked-in filesystem, two deliberate CPU faults and their reports, a 200-request soak with the heap watched, and three servers answering a client on the host — plaintext, MCP and TLS 1.3 |
+
+The frame path has a gate of its own in the ordinary corpus:
+`net_frame_fuzz` drives `stack_rx` with bytes nobody chose and asserts
+what the layer above is entitled to believe — that a payload handed up
+lies inside the frame it came from, that every drop is counted exactly
+once, that every emitted frame is one a device could send, and that a
+frame addressed to another machine is never answered. It is
+mutation-validated against five injected parser bugs and runs in the
+LSan leak gate.
 
 The QEMU job runs under TCG because no runner has `/dev/kvm`. Slower,
 identical otherwise — except for the TSC frequency, which no leaf
@@ -234,10 +406,18 @@ and 11), which is why these are jobs rather than instructions.
 ## Running the gates
 
 ```sh
-unikernel/tests/run_unit_tests.sh        # string / float-format / allocator
+unikernel/tests/run_unit_tests.sh        # strings / float format / libm /
+                                         # both allocators / the scheduler
 unikernel/run_nolibc_tests.sh            # the corpus, with no libc
-unikernel/build_nolibc.sh prog.nu        # one program
+unikernel/run_qemu_tests.sh              # the guest, under a hypervisor
+unikernel/run_qemu_tests.sh hello        # one of them
+unikernel/build_nolibc.sh prog.nu        # build one program, no libc
+unikernel/build_unikernel.sh prog.nu     # build one bootable image
 ```
+
+QEMU is the only thing the guest gate needs that a checkout does not
+bring; without it the gate SKIPS with a message rather than failing, so
+a developer without a hypervisor can still run everything else.
 
 ## What is deliberately missing
 

--- a/unikernel/bench_boot.sh
+++ b/unikernel/bench_boot.sh
@@ -74,9 +74,38 @@ rm -f "$out"
 echo "boot to first answer:  $(( (end - start) / 1000000 )) ms  (cold VM, includes DHCP)"
 
 # ── requests per second ─────────────────────────────────────────
-# The demo exits after one answer, so a throughput number needs a
-# server that keeps serving. Rather than a second demo, the httpd one
-# is rebuilt with a large answer count — measured, not extrapolated
-# from a single request.
-echo "note: throughput needs a long-running demo; the one in tree exits after"
-echo "      one answer by design (it is a gate, not a benchmark)."
+# Measured against demos/soak.nu, which answers 200 requests and then
+# reports what its own page allocator did — the same program the guest
+# gate uses, so the throughput number and the "does it leak" number come
+# from one run of one server rather than from two servers that might
+# differ. Sequential, one connection each: this is latency's reciprocal,
+# not a concurrency figure, and calling it anything else would flatter it.
+if [ "$TLS" = 0 ]; then
+    "$ROOT/unikernel/build_unikernel.sh" "$ROOT/unikernel/demos/soak.nu" >/dev/null || exit 2
+    out=$(mktemp)
+    ( "$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/soak.elf" -t 300 -- \
+        -netdev "user,id=n0,hostfwd=tcp:127.0.0.1:18090-:8080" \
+        -device virtio-net-device,netdev=n0 > "$out" 2>&1 ) &
+    qpid=$!
+    for _ in $(seq 1 200); do
+        curl -sS --max-time 15 http://127.0.0.1:18090/ >/dev/null 2>&1 && break
+        sleep 0.2
+    done
+    tstart=$(date +%s%N)
+    ok=0
+    for _ in $(seq 1 "$N"); do
+        curl -sS --max-time 15 http://127.0.0.1:18090/ >/dev/null 2>&1 && ok=$((ok + 1))
+    done
+    tend=$(date +%s%N)
+    ms=$(( (tend - tstart) / 1000000 ))
+    [ "$ms" -gt 0 ] || ms=1
+    echo "requests per second:   $(( ok * 1000 / ms ))  ($ok sequential requests in ${ms} ms, one connection each)"
+    # Let the guest finish its 200 so its own verdict lands in the log.
+    for _ in $(seq 1 200); do curl -sS --max-time 15 http://127.0.0.1:18090/ >/dev/null 2>&1; done
+    wait $qpid
+    grep -E '^soak: (live at the end|verdict)' "$out" | sed 's/^soak: /heap:                  /'
+    rm -f "$out"
+else
+    echo "note: throughput is measured on the plaintext run; a TLS number here"
+    echo "      would be an RSA handshake benchmark under an interpreter."
+fi

--- a/unikernel/boot/boot.S
+++ b/unikernel/boot/boot.S
@@ -31,6 +31,11 @@
  * The start_info pointer is saved before any of that, because %ebx is
  * not preserved across the transition and it is the only handle on the
  * memory map, the command line and the modules.
+ *
+ * This file also holds the 256 interrupt stubs the IDT points at (see
+ * `idt_init` in platform_x86.c). They are here rather than in C because
+ * an entry point that must not touch a register before saving it is not
+ * something a compiler can be asked for.
  */
 
 /* ── the PVH note ─────────────────────────────────────────────────
@@ -160,12 +165,80 @@ long_entry:
     hlt
     jmp     3b
 
-    .section .rodata
+/* ── the interrupt stubs ──────────────────────────────────────────
+ *
+ * One entry per vector, all the same size, so the IDT can be filled in
+ * C with `isr_stubs + 16 * n` instead of a 256-line table of symbols
+ * that has to be kept in step with itself.
+ *
+ * Ten vectors push an error code and the rest do not. The stub for the
+ * rest pushes a zero in its place, so `isr_common` and the C handler
+ * see one frame shape and neither has to know which kind it got.
+ *
+ * Nothing here touches a register before it is saved: the whole point
+ * of a fault handler is to report what the machine was doing, and a
+ * handler that clobbers %rax first has destroyed part of the evidence.
+ */
+    .section .text
+    .code64
     .align 16
+    .globl isr_stubs
+isr_stubs:
+    .set    vec, 0
+    .rept   256
+    .align  16
+    .if (vec == 8) || (vec == 10) || (vec == 11) || (vec == 12) || \
+        (vec == 13) || (vec == 14) || (vec == 17) || (vec == 21) || \
+        (vec == 29) || (vec == 30)
+    /* the CPU already pushed an error code */
+    .else
+    pushq   $0
+    .endif
+    pushq   $vec
+    jmp     isr_common
+    .set    vec, vec + 1
+    .endr
+
+/* The saved frame, low address first — this order IS `struct
+ * fault_frame` in platform_x86.c, and the two are read together. */
+isr_common:
+    pushq   %rax
+    pushq   %rbx
+    pushq   %rcx
+    pushq   %rdx
+    pushq   %rsi
+    pushq   %rdi
+    pushq   %rbp
+    pushq   %r8
+    pushq   %r9
+    pushq   %r10
+    pushq   %r11
+    pushq   %r12
+    pushq   %r13
+    pushq   %r14
+    pushq   %r15
+
+    movq    %cr2, %rsi              /* the faulting address, if there is one */
+    movq    %rsp, %rdi              /* the frame we just built */
+    call    pf_exception            /* does not return */
+1:  cli
+    hlt
+    jmp     1b
+
+    .section .data
+    .align 16
+    .globl gdt64
 gdt64:
     .quad   0                                   /* null */
     .quad   0x00AF9A000000FFFF                  /* 0x08: 64-bit code */
     .quad   0x00CF92000000FFFF                  /* 0x10: data */
+    /* 0x18: the TSS descriptor, sixteen bytes and filled in at run time
+     * by `tss_init`. It cannot be written here: its base is a link-time
+     * symbol and the descriptor wants that address in three separate
+     * fields, which is not a relocation any assembler can emit. That is
+     * also why this table lives in .data now rather than .rodata. */
+    .quad   0
+    .quad   0
 gdt64_end:
 gdt64_ptr:
     .word   gdt64_end - gdt64 - 1
@@ -179,10 +252,35 @@ pd0:    .skip 4096 * 4
     .align 8
 boot_start_info: .skip 8
 
-    /* 64 KiB, the same size a coroutine gets. This is the only stack
-     * until the fiber runtime hands out its own. */
+    /* The task-state segment exists for one field: IST1, the stack a
+     * double fault and a page fault switch to. Without it, a fault
+     * caused by a stack that ran off its guard page is delivered on
+     * that same dead stack — the push faults, the double fault's push
+     * faults, and the machine triple-faults with nothing printed,
+     * which is precisely the failure the handler exists to describe. */
     .align 16
+    .globl tss64
+tss64:  .skip 104
+tss64_end:
+
+    .align 16
+    .skip 16 * 1024
+    .globl fault_stack_top
+fault_stack_top:
+
+    /* 64 KiB, the same size a coroutine gets. This is the only stack
+     * until the fiber runtime hands out its own.
+     *
+     * Page-aligned with its bottom exported, because a coroutine's
+     * stack gets a guard page and this one deserves the same: without
+     * it, a recursion that runs off the end writes into whatever .bss
+     * put underneath and the program carries on with someone else's
+     * variables. `pf_guard_boot_stack` arms it once memory is up. */
+    .align 4096
+    .globl boot_stack_bottom
+boot_stack_bottom:
     .skip 64 * 1024
+    .align 16
 boot_stack_top:
 
     .section .note.GNU-stack, "", @progbits

--- a/unikernel/boot/initfs.c
+++ b/unikernel/boot/initfs.c
@@ -60,9 +60,16 @@ static fs_size_t tar_octal(const char *p, int n) {
     return v;
 }
 
-static int fs_streq(const char *a, const char *b) {
-    while (*a && *a == *b) { a++; b++; }
-    return *a == *b;
+/* Name comparison, with the archive side BOUNDED: a tar name field
+ * is 100 bytes and is only NUL-terminated when the name is shorter than
+ * that. A plain `strcmp` against a full-width name walks out of the
+ * field and into the mode digits, so a 100-character name would be
+ * compared against something that is not a name at all. */
+static int fs_streq_n(const char *hdr, int n, const char *want) {
+    int i = 0;
+    for (; i < n && hdr[i] && want[i] && hdr[i] == want[i]; i++) { }
+    if (i == n) return want[i] == 0;             /* the field ran out */
+    return hdr[i] == want[i];
 }
 
 /* Leading "./" and a leading "/" are the same file: `tar cf` writes
@@ -87,13 +94,24 @@ static const unsigned char *fs_lookup(const char *name, fs_size_t *size_out) {
         fs_size_t size = tar_octal(hdr + 124, 12);
         char type = hdr[156];
         const unsigned char *body = p + 512;
-        fs_size_t stride = 512 + ((size + 511) & ~(fs_size_t)511);
+        fs_size_t stride;
+
+        /* A size field is twelve octal digits and can name a number no
+         * archive this size could hold. Rounding it up would then wrap,
+         * `p += stride` would move BACKWARDS, and the walk would never
+         * end. The archive is built by our own build script, so this is
+         * a corrupt-image check rather than a hostile-input one — and a
+         * corrupt image is exactly when a loop that never ends is the
+         * worst possible behaviour. */
+        if (size > (fs_size_t)(end - body)) return 0;
+        stride = 512 + ((size + 511) & ~(fs_size_t)511);
 
         /* '0' and '\0' are both "regular file"; anything else (a
          * directory, a symlink) is skipped rather than served, because
          * serving a directory's zero bytes as a file is how a missing
          * certificate becomes an empty one. */
-        if ((type == '0' || type == 0) && fs_streq(fs_norm(hdr), want)) {
+        if ((type == '0' || type == 0) &&
+            fs_streq_n(fs_norm(hdr), 100 - (int)(fs_norm(hdr) - hdr), want)) {
             if (body + size > end) return 0;    /* truncated archive */
             if (size_out) *size_out = size;
             return body;

--- a/unikernel/boot/pagealloc.c
+++ b/unikernel/boot/pagealloc.c
@@ -1,0 +1,206 @@
+/*
+ * NURL unikernel — unikernel/boot/pagealloc.c
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * The guest's page allocator: what `mmap` and `munmap` are made of when
+ * there is no kernel underneath to keep a page table of who owns what.
+ *
+ * WHY THIS FILE EXISTS. The first version was a bump pointer and a
+ * `munmap` that returned success without doing anything. That is fine
+ * for a program that runs once and exits, and wrong for the thing this
+ * target is for: a server. Measured, before this file: a guest with 256
+ * MiB that allocates a megabyte and frees it, four hundred times over,
+ * dies on the two hundred and fiftieth — every large allocation the
+ * program gave back was gone for good. A unikernel that cannot serve its
+ * two-hundred-and-fifty-first request is not a unikernel.
+ *
+ * WHAT IT IS. A sorted free list of page-aligned ranges over one
+ * contiguous region, best fit, with coalescing on both sides. Nothing
+ * cleverer, on purpose: the allocator above this one (nolibc's
+ * size-class malloc) already handles small objects and asks for
+ * megabyte arenas, so this one sees few, large, long-lived requests —
+ * exactly the shape first fit and best fit disagree about least, and
+ * exactly the shape where a bug is a corrupted heap rather than a slow
+ * one.
+ *
+ * PORTABLE C, and that is the point: it has no idea what a page table
+ * or a hypervisor is, so `unikernel/tests/pagealloc_fuzz.c` runs it on
+ * the host against a model that tracks every live range and checks, on
+ * every operation, that no two of them overlap. A page allocator that is
+ * only ever exercised inside a virtual machine is a page allocator whose
+ * bugs arrive as a triple fault.
+ *
+ * SPLITTING RANGES COSTS A SLOT. The free list is a fixed array because
+ * an allocator that allocates is a bootstrapping problem. If it fills —
+ * 256 disjoint holes, which needs a pathological pattern — a freed range
+ * that cannot be recorded is COUNTED in `pa_lost` rather than dropped
+ * silently, and `pa_stats` reports it. A leak you can see is a bug
+ * report; a leak you cannot is a mystery six months later.
+ */
+
+typedef unsigned long pa_size_t;
+
+#define PA_PAGE      4096UL
+#define PA_MAX_FREE  256
+
+struct pa_range {
+    pa_size_t base;
+    pa_size_t len;
+};
+
+static struct pa_range pa_free_list[PA_MAX_FREE];
+static int             pa_nfree;
+
+static pa_size_t pa_base;        /* the region, as given to pa_init */
+static pa_size_t pa_next;        /* the tail nobody has ever been handed */
+static pa_size_t pa_end;
+static pa_size_t pa_live;        /* bytes currently handed out */
+static pa_size_t pa_peak;        /* the most that was ever live at once */
+static pa_size_t pa_lost_bytes;  /* freed, but the list had no room */
+
+static pa_size_t pa_round(pa_size_t n) {
+    return (n + PA_PAGE - 1) & ~(PA_PAGE - 1);
+}
+
+/* The region is [base, base+len), page-aligned by the caller's own
+ * rounding. Called once, before anything asks for memory. */
+void pa_init(pa_size_t base, pa_size_t len) {
+    pa_base = pa_round(base);
+    pa_next = pa_base;
+    pa_end  = base + len;
+    if (pa_end < pa_next) pa_end = pa_next;
+    pa_nfree = 0;
+    pa_live = 0;
+    pa_peak = 0;
+    pa_lost_bytes = 0;
+}
+
+static void pa_insert(int at, pa_size_t base, pa_size_t len) {
+    for (int i = pa_nfree; i > at; i--) pa_free_list[i] = pa_free_list[i - 1];
+    pa_free_list[at].base = base;
+    pa_free_list[at].len  = len;
+    pa_nfree++;
+}
+
+static void pa_remove(int at) {
+    for (int i = at; i < pa_nfree - 1; i++) pa_free_list[i] = pa_free_list[i + 1];
+    pa_nfree--;
+}
+
+/* Best fit: the smallest hole that still fits. With few, large requests
+ * the difference from first fit is small, and it is in this direction —
+ * first fit shaves the front of the biggest hole and leaves the next big
+ * request without one. */
+pa_size_t pa_alloc(pa_size_t want) {
+    pa_size_t need = pa_round(want);
+    if (need == 0) return 0;
+
+    int best = -1;
+    for (int i = 0; i < pa_nfree; i++) {
+        if (pa_free_list[i].len < need) continue;
+        if (best < 0 || pa_free_list[i].len < pa_free_list[best].len) best = i;
+    }
+    if (best >= 0) {
+        pa_size_t p = pa_free_list[best].base;
+        if (pa_free_list[best].len == need) pa_remove(best);
+        else {
+            pa_free_list[best].base += need;
+            pa_free_list[best].len  -= need;
+        }
+        pa_live += need;
+        if (pa_live > pa_peak) pa_peak = pa_live;
+        return p;
+    }
+
+    /* Nothing reusable: carve from the tail. */
+    if (pa_end - pa_next < need) return 0;
+    pa_size_t p = pa_next;
+    pa_next += need;
+    pa_live += need;
+    if (pa_live > pa_peak) pa_peak = pa_live;
+    return p;
+}
+
+/* A free range that ends where the tail begins IS the tail: rolling it
+ * back keeps the list short and, more importantly, keeps the region's
+ * end in one piece. Without this the last hole and the untouched tail
+ * are adjacent and never merge, and a request for "almost all of it"
+ * fails on a machine that is entirely free. */
+static void pa_absorb_tail(void) {
+    while (pa_nfree > 0 &&
+           pa_free_list[pa_nfree - 1].base + pa_free_list[pa_nfree - 1].len == pa_next) {
+        pa_next = pa_free_list[pa_nfree - 1].base;
+        pa_nfree--;
+    }
+}
+
+/* Give a range back. `len` is the length that was asked for, rounded the
+ * same way the allocation rounded it — a caller that frees a different
+ * length than it allocated is a bug in the caller, and this allocator
+ * has no header to check it against, which is the price of not spending
+ * a word on every page. */
+int pa_free(pa_size_t p, pa_size_t len) {
+    pa_size_t n = pa_round(len);
+    if (p == 0 || n == 0) return 0;
+    /* Outside the region, or wrapped: not ours, and recording it would
+     * hand it out later. */
+    if (p < pa_base || p + n > pa_end || p + n < p) return -1;
+
+    pa_live = pa_live >= n ? pa_live - n : 0;
+
+    /* Returning the tail is not a hole at all: it is the tail again.
+     * Checked before the list is consulted, so a program that allocates
+     * and frees in order never fills the list — and, at the other end,
+     * so a full list cannot lose a range that did not need a slot. */
+    if (p + n == pa_next) {
+        pa_next = p;
+        pa_absorb_tail();
+        return 0;
+    }
+
+    /* Sorted insert, coalescing with the neighbour on each side. */
+    int at = 0;
+    while (at < pa_nfree && pa_free_list[at].base < p) at++;
+
+    int join_prev = at > 0 &&
+        pa_free_list[at - 1].base + pa_free_list[at - 1].len == p;
+    int join_next = at < pa_nfree && p + n == pa_free_list[at].base;
+
+    if (join_prev && join_next) {
+        pa_free_list[at - 1].len += n + pa_free_list[at].len;
+        pa_remove(at);
+    } else if (join_prev) {
+        pa_free_list[at - 1].len += n;
+    } else if (join_next) {
+        pa_free_list[at].base = p;
+        pa_free_list[at].len += n;
+    } else if (pa_nfree < PA_MAX_FREE) {
+        pa_insert(at, p, n);
+    } else {
+        pa_lost_bytes += n;
+        return -1;
+    }
+    pa_absorb_tail();
+    return 0;
+}
+
+/* What the machine can still hand out, in bytes: the untouched tail plus
+ * every hole. A caller that wants to know whether the next megabyte will
+ * work wants the largest hole instead, which is why both are here. */
+void pa_stats(pa_size_t *live, pa_size_t *peak, pa_size_t *avail,
+              pa_size_t *largest, pa_size_t *lost, int *holes) {
+    pa_size_t sum = pa_end - pa_next;
+    pa_size_t big = pa_end - pa_next;
+    for (int i = 0; i < pa_nfree; i++) {
+        sum += pa_free_list[i].len;
+        if (pa_free_list[i].len > big) big = pa_free_list[i].len;
+    }
+    if (live)    *live    = pa_live;
+    if (peak)    *peak    = pa_peak;
+    if (avail)   *avail   = sum;
+    if (largest) *largest = big;
+    if (lost)    *lost    = pa_lost_bytes;
+    if (holes)   *holes   = pa_nfree;
+}

--- a/unikernel/boot/platform_x86.c
+++ b/unikernel/boot/platform_x86.c
@@ -123,6 +123,16 @@ static void uart_putu(unsigned long v) {
     while (n) uart_putc(b[--n]);
 }
 
+static void uart_puthex(u64 v) {
+    static const char digits[] = "0123456789abcdef";
+    char b[16];
+    int n = 0;
+    uart_puts("0x");
+    if (!v) { uart_putc('0'); return; }
+    while (v) { b[n++] = digits[v & 15]; v >>= 4; }
+    while (n) uart_putc(b[--n]);
+}
+
 /* ── panic ───────────────────────────────────────────────────────── */
 
 static void pf_shutdown(int code);
@@ -135,10 +145,183 @@ void pf_panic(const char *msg) {
     for (;;) __asm__ __volatile__("cli; hlt");
 }
 
+/* ── faults ──────────────────────────────────────────────────────
+ *
+ * A machine with no IDT answers every exception the same way: the CPU
+ * cannot deliver it, cannot deliver the double fault either, and shuts
+ * down. From outside that is indistinguishable from a clean exit —
+ * QEMU quits, the exit sentinel is simply absent — so the first thing
+ * anyone knows about a null dereference is that the output stopped.
+ * Every fault below is a bug in something above; the machine's job is
+ * to say which one, where, and stop.
+ *
+ * IST1 for #DF and #PF, because the fault this most needs to survive is
+ * a stack that hit its guard page: delivering that on the same stack
+ * faults again, and the second fault is the last thing that happens.
+ */
+
+/* The register file `isr_common` in boot.S pushes, low address first.
+ * The two files are read together; changing one without the other is a
+ * fault report that describes the wrong registers. */
+struct fault_frame {
+    u64 r15, r14, r13, r12, r11, r10, r9, r8;
+    u64 rbp, rdi, rsi, rdx, rcx, rbx, rax;
+    u64 vector, errcode;
+    u64 rip, cs, rflags, rsp, ss;
+};
+
+struct idt_entry {
+    unsigned short off_lo;
+    unsigned short sel;
+    unsigned char  ist;
+    unsigned char  type_attr;
+    unsigned short off_mid;
+    u32            off_hi;
+    u32            zero;
+} __attribute__((packed));
+
+extern char isr_stubs[];              /* boot.S: 256 stubs, 16 bytes each */
+extern char fault_stack_top[];
+extern unsigned char tss64[];
+extern u64 gdt64[];
+
+static struct idt_entry idt[256];
+
+/* The names are the ones every manual and every search result uses.
+ * "vector 14" is a number; "#PF" is a thing someone can look up. */
+static const char *fault_name(u64 v) {
+    switch (v) {
+    case 0:  return "#DE divide error";
+    case 1:  return "#DB debug";
+    case 2:  return "NMI";
+    case 3:  return "#BP breakpoint";
+    case 4:  return "#OF overflow";
+    case 5:  return "#BR bound range";
+    case 6:  return "#UD invalid opcode";
+    case 7:  return "#NM device not available";
+    case 8:  return "#DF double fault";
+    case 10: return "#TS invalid TSS";
+    case 11: return "#NP segment not present";
+    case 12: return "#SS stack fault";
+    case 13: return "#GP general protection";
+    case 14: return "#PF page fault";
+    case 16: return "#MF x87 exception";
+    case 17: return "#AC alignment check";
+    case 18: return "#MC machine check";
+    case 19: return "#XM SIMD exception";
+    default: return "unexpected interrupt";
+    }
+}
+
+/* Called from isr_common with the frame it built and CR2 as read at
+ * entry — reading CR2 here would be too late if anything in between
+ * faulted, and nothing in between may. */
+void pf_exception(struct fault_frame *f, u64 cr2);
+
+void pf_exception(struct fault_frame *f, u64 cr2) {
+    uart_puts("\nnurl: fault ");
+    uart_puts(fault_name(f->vector));
+    uart_puts(" vector=");
+    uart_putu((unsigned long)f->vector);
+    uart_puts(" err=");
+    uart_puthex(f->errcode);
+    uart_puts("\n  rip=");
+    uart_puthex(f->rip);
+    uart_puts(" rsp=");
+    uart_puthex(f->rsp);
+    uart_puts(" rflags=");
+    uart_puthex(f->rflags);
+    if (f->vector == 14) {
+        uart_puts("\n  cr2=");
+        uart_puthex(cr2);
+        /* The error code's bits are the difference between "wrote to a
+         * page that is not there" and "read one that is" — the first
+         * question anyone asks, answered without a manual. */
+        uart_puts(f->errcode & 1 ? " (protection)" : " (not present)");
+        uart_puts(f->errcode & 2 ? " on write" : " on read");
+        if (f->errcode & 16) uart_puts(" on instruction fetch");
+    }
+    uart_puts("\n  rax="); uart_puthex(f->rax);
+    uart_puts(" rbx=");    uart_puthex(f->rbx);
+    uart_puts(" rcx=");    uart_puthex(f->rcx);
+    uart_puts(" rdx=");    uart_puthex(f->rdx);
+    uart_puts("\n  rsi="); uart_puthex(f->rsi);
+    uart_puts(" rdi=");    uart_puthex(f->rdi);
+    uart_puts(" rbp=");    uart_puthex(f->rbp);
+    uart_putc('\n');
+    /* 126, not 127: a fault is not the same event as a panic, and a
+     * harness that can tell them apart can say which one it saw. */
+    pf_shutdown(126);
+    for (;;) __asm__ __volatile__("cli; hlt");
+}
+
+static void idt_set(int n, unsigned long handler, unsigned char ist) {
+    idt[n].off_lo    = (unsigned short)(handler & 0xFFFF);
+    idt[n].sel       = 0x08;                    /* the 64-bit code segment */
+    idt[n].ist       = ist;
+    idt[n].type_attr = 0x8E;                    /* present, DPL 0, interrupt gate */
+    idt[n].off_mid   = (unsigned short)((handler >> 16) & 0xFFFF);
+    idt[n].off_hi    = (u32)(handler >> 32);
+    idt[n].zero      = 0;
+}
+
+/* The TSS descriptor is sixteen bytes in long mode and its base is
+ * split across three fields, which is why it is written here rather
+ * than in the assembler's table. Type 9 = available 64-bit TSS. */
+static void tss_init(void) {
+    unsigned long base  = (unsigned long)tss64;
+    unsigned long limit = 104 - 1;
+
+    /* IST1, at offset 36 in the TSS: the stack #DF and #PF arrive on. */
+    u64 top = (u64)(unsigned long)fault_stack_top;
+    for (int i = 0; i < 104; i++) tss64[i] = 0;
+    tss64[36] = (unsigned char)(top      & 0xFF);
+    tss64[37] = (unsigned char)((top >> 8)  & 0xFF);
+    tss64[38] = (unsigned char)((top >> 16) & 0xFF);
+    tss64[39] = (unsigned char)((top >> 24) & 0xFF);
+    tss64[40] = (unsigned char)((top >> 32) & 0xFF);
+    tss64[41] = (unsigned char)((top >> 40) & 0xFF);
+    tss64[42] = (unsigned char)((top >> 48) & 0xFF);
+    tss64[43] = (unsigned char)((top >> 56) & 0xFF);
+    /* No I/O permission bitmap: the limit says where it would start and
+     * it starts past the end, which is how a TSS says "none". */
+    tss64[102] = (unsigned char)(104 & 0xFF);
+    tss64[103] = (unsigned char)((104 >> 8) & 0xFF);
+
+    gdt64[3] = (u64)(limit & 0xFFFF)
+             | ((u64)(base & 0xFFFFFF) << 16)
+             | ((u64)0x9 << 40)                 /* type: available 64-bit TSS */
+             | ((u64)1 << 47)                   /* present */
+             | ((u64)((limit >> 16) & 0xF) << 48)
+             | ((u64)((base >> 24) & 0xFF) << 56);
+    gdt64[4] = (u64)(base >> 32);
+
+    __asm__ __volatile__("ltr %w0" :: "r"((unsigned short)0x18));
+}
+
+static void idt_init(void) {
+    for (int n = 0; n < 256; n++) {
+        unsigned char ist = (n == 8 || n == 14) ? 1 : 0;
+        idt_set(n, (unsigned long)(isr_stubs + 16 * n), ist);
+    }
+    struct { unsigned short limit; unsigned long base; } __attribute__((packed))
+        idtr = { (unsigned short)(sizeof idt - 1), (unsigned long)idt };
+    __asm__ __volatile__("lidt %0" :: "m"(idtr));
+}
+
 /* ── memory ──────────────────────────────────────────────────────── */
 
 static unsigned char *heap_next;
 static unsigned char *heap_end;
+
+/* unikernel/boot/pagealloc.c — the pages themselves. Portable C, tested
+ * on the host, so the one thing a guest cannot debug is the one thing
+ * that is not written here. */
+void          pa_init(unsigned long base, unsigned long len);
+unsigned long pa_alloc(unsigned long want);
+int           pa_free(unsigned long p, unsigned long len);
+void          pa_stats(unsigned long *live, unsigned long *peak, unsigned long *avail,
+                       unsigned long *largest, unsigned long *lost, int *holes);
 
 #define PT_POOL_TABLES 64
 static u64 *pt_pool;              /* PT_POOL_TABLES × 512 entries */
@@ -176,13 +359,18 @@ static void mem_init(const struct hvm_start_info *si) {
     heap_next += (unsigned long)PT_POOL_TABLES * 4096;
     if (heap_next > heap_end) pf_panic("not enough memory for the page-table pool");
     for (unsigned long i = 0; i < (unsigned long)PT_POOL_TABLES * 512; i++) pt_pool[i] = 0;
+
+    /* Everything past the pool is the program's, and from here on it is
+     * the page allocator's to hand out and take back. */
+    pa_init((unsigned long)heap_next, (unsigned long)(heap_end - heap_next));
 }
 
-/* mmap, as much of it as a guest needs: anonymous, private, and never
- * unmapped. munmap is a no-op that reports success, which is honest
- * here — a bump allocator cannot return a hole in the middle, and the
- * one caller that unmaps (a finished coroutine's stack) is reclaimed by
- * runtime_bare's own free list rather than by the kernel. */
+/* mmap and munmap, over the page allocator in boot/pagealloc.c: the
+ * region the hypervisor reported, handed out in pages and TAKEN BACK.
+ * The version this replaced was a bump pointer with a munmap that
+ * reported success and did nothing, which is fine for a program that
+ * runs once and wrong for a server — measured, it died on the 251st
+ * megabyte of allocate-and-free on a 256 MiB machine. */
 /* unikernel/boot/initfs.c — the baked-in filesystem. Declared here
  * because every one of these is reached from the POSIX names below,
  * which are what NURL's FFI actually calls. */
@@ -197,20 +385,40 @@ void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off)
     /* A file-backed mapping of the baked-in filesystem is a pointer
      * into it — the image is already in memory, and read-only is
      * exactly what the mapping asked for. Anonymous mappings fall
-     * through to the bump allocator below. */
+     * through to the page allocator below. */
     if (fd >= 0 && fs_is_file_fd(fd)) {
         const unsigned char *p = fs_map_fd(fd, (unsigned long)off);
         return p ? (void *)p : (void *)-1;
     }
-    unsigned long need = (len + 4095) & ~4095UL;
-    if (!heap_next || (unsigned long)(heap_end - heap_next) < need)
-        return (void *)-1;                  /* MAP_FAILED — the caller checks */
-    unsigned char *p = heap_next;
-    heap_next += need;
-    return p;
+    unsigned long p = pa_alloc(len);
+    return p ? (void *)p : (void *)-1;      /* MAP_FAILED — the caller checks */
 }
 
-int munmap(void *p, unsigned long len) { (void)p; (void)len; return 0; }
+int munmap(void *p, unsigned long len) {
+    /* A mapping of the baked-in filesystem points into the image, not
+     * into the heap; pa_free rejects it by address, which is exactly the
+     * check that keeps the image out of the free list. */
+    return pa_free((unsigned long)p, len) == 0 ? 0 : 0;
+}
+
+/* What the machine has and what it is using — the numbers a long-running
+ * guest is judged by, and the reason `mem_stats` exists at all: a soak
+ * test that cannot see the heap can only report "it did not crash yet".
+ * Reported through the same FFI shape everything else here uses. */
+long long nurl_guest_mem(int which) {
+    unsigned long live = 0, peak = 0, avail = 0, largest = 0, lost = 0;
+    int holes = 0;
+    pa_stats(&live, &peak, &avail, &largest, &lost, &holes);
+    switch (which) {
+    case 0:  return (long long)live;
+    case 1:  return (long long)peak;
+    case 2:  return (long long)avail;
+    case 3:  return (long long)largest;
+    case 4:  return (long long)lost;
+    case 5:  return (long long)holes;
+    default: return 0;
+    }
+}
 
 /* ── page protection ─────────────────────────────────────────────
  *
@@ -286,6 +494,40 @@ int mprotect(void *p, unsigned long len, int prot) {
     return 0;
 }
 
+/* The boot stack gets the same treatment a coroutine's does. It is the
+ * stack every program starts on and the one `main` recurses on, and
+ * until this call the page under it was ordinary .bss: a recursion that
+ * ran off the end overwrote the page tables' neighbours and the program
+ * kept going with someone else's variables. Now it faults, and the
+ * handler says where.
+ *
+ * Called after mem_init, because splitting a 2 MiB mapping needs the
+ * page-table pool that mem_init reserves. */
+extern unsigned char boot_stack_bottom[];
+
+static void pf_guard_boot_stack(void) {
+    (void)mprotect(boot_stack_bottom, 4096, 0);
+}
+
+/* The other guard page, and the one every C programmer already expects
+ * to exist. The boot tables identity-map the low 4 GiB present and
+ * writable, page zero included, so a store through a null pointer in
+ * this guest QUIETLY SUCCEEDED: it wrote a word into physical page zero
+ * and the program carried on with a bug that would have been a segfault
+ * on any hosted target. Unmapping the page turns it back into the fault
+ * every caller's error handling was written against.
+ *
+ * Only the first page, and only if nothing we still need lives in it:
+ * the hypervisor chooses where the handover block and the command line
+ * go, and this guest keeps reading the command line long after boot. */
+static const char *cmdline;              /* set in kmain, read for ever after */
+
+static void pf_guard_null_page(const void *si) {
+    if ((unsigned long)si < 4096) return;
+    if (cmdline && (unsigned long)cmdline < 4096) return;
+    (void)mprotect((void *)0, 4096, 0);
+}
+
 /* ── time ────────────────────────────────────────────────────────── */
 
 static u64 tsc_khz;            /* 0 = nobody told us */
@@ -302,7 +544,6 @@ static u64 wall_base_sec;      /* CLOCK_REALTIME epoch at boot, 0 = unset */
  * program's argument parser is how a boot flag becomes a mysterious
  * command-line error.
  */
-static const char *cmdline;
 const char *nurl_boot_cmdline(void);
 
 static u64 cmdline_u64(const char *key) {
@@ -495,7 +736,18 @@ int fs_close_fd(int fd);
 pf_ssize_t nl_read(int fd, void *buf, pf_size_t n) { return (pf_ssize_t)read(fd, buf, n); }
 int nl_close(int fd) { return close(fd); }
 long long nl_lseek(int fd, long long off, int whence) { return lseek(fd, off, whence); }
-void *nl_map(pf_size_t len) { return mmap(0, len, 0, 0, -1, 0); }
+/* ZERO on failure, not MAP_FAILED. `mmap` answers the POSIX way and
+ * `nl_map` answers the way nolibc's allocator asks — `if (!p)` is the
+ * check in malloc.c, and the Linux twin (syscall_linux.c) has always
+ * converted. This one did not, so a guest that ran out of memory handed
+ * back (void *)-1 and the first write through it faulted at
+ * 0xffffffffffffffff: exhaustion turned into a wild store instead of an
+ * "out of memory" line. Twins that drift is what this whole directory
+ * is arranged to prevent; here it drifted. */
+void *nl_map(pf_size_t len) {
+    void *p = mmap(0, len, 0, 0, -1, 0);
+    return p == (void *)-1 ? 0 : p;
+}
 int nl_unmap(void *p, pf_size_t len) { return munmap(p, len); }
 /* Straight to the machine. nolibc's `exit` flushes stdio and then
  * calls THIS — routing it back through `exit` is an infinite
@@ -629,12 +881,18 @@ void kmain(unsigned long start_info_paddr) {
         (const struct hvm_start_info *)start_info_paddr;
 
     uart_init();
+    /* Before anything that can fault, which is everything: an IDT
+     * installed after the first mistake describes nothing. */
+    tss_init();
+    idt_init();
     if (!si || si->magic != HVM_START_MAGIC)
         pf_panic("not a PVH boot — no hvm_start_info at the handover "
                  "address (was this image loaded with -kernel?)");
 
     cmdline = si->cmdline_paddr ? (const char *)(unsigned long)si->cmdline_paddr : 0;
     mem_init(si);
+    pf_guard_boot_stack();
+    pf_guard_null_page(si);
     time_init();
     nl_tls_init_guest();          /* before the first __thread access */
 

--- a/unikernel/build_unikernel.sh
+++ b/unikernel/build_unikernel.sh
@@ -70,6 +70,7 @@ for f in string malloc stdio dtoa math misc; do
 done
 $CC $KFLAGS -c "$BOOT/platform_x86.c" -o "$OUTDIR/platform.o"
 $CC $KFLAGS -c "$BOOT/initfs.c"       -o "$OUTDIR/boot_initfs.o"
+$CC $KFLAGS -c "$BOOT/pagealloc.c"    -o "$OUTDIR/boot_pagealloc.o"
 
 # The baked-in filesystem: a directory becomes a tar, and the tar
 # becomes an object with two symbols around it. With no --fs the
@@ -97,7 +98,7 @@ $CC -nostdlib -static -no-pie -Wl,-T,"$BOOT/link.ld" -Wl,--build-id=none \
     "$OUTDIR/boot.o" "$OUTDIR/$base.o" \
     "$OUTDIR/runtime_core.o" "$OUTDIR/runtime_ctx.o" "$OUTDIR/runtime_bare.o" \
     "$OUTDIR/platform.o" "$OUTDIR/tls_guest.o" \
-    "$OUTDIR/boot_initfs.o" "$OUTDIR/initfs_data.o" \
+    "$OUTDIR/boot_initfs.o" "$OUTDIR/boot_pagealloc.o" "$OUTDIR/initfs_data.o" \
     "$OUTDIR"/nl_*.o
 
 echo "built $OUT"

--- a/unikernel/demos/fault.nu
+++ b/unikernel/demos/fault.nu
@@ -1,0 +1,66 @@
+// unikernel/demos/fault.nu — the machine, asked to describe its own
+// worst day.
+//
+// A guest with no IDT answers every CPU exception identically: it
+// cannot deliver the fault, cannot deliver the double fault either,
+// and shuts down. From the host that is indistinguishable from a clean
+// exit — the hypervisor quits and the exit sentinel is simply missing —
+// so the first thing anyone learns about a null dereference is that the
+// output stopped. This demo makes two of them happen on purpose so the
+// gate can read what the machine says about them.
+//
+//   args="null 0"       a store through address 0        → #PF at 0
+//   args="stack 100000000"  a recursion deeper than the boot stack
+//                       → #PF on its guard page, delivered on the IST
+//                       stack, because the ordinary one is exactly
+//                       what ran out
+//
+// BOTH ADDRESSES COME FROM THE COMMAND LINE, and that is not decoration.
+// A store through a literal null and a provably infinite recursion are
+// both undefined behaviour, and LLVM answers undefined behaviour by
+// deleting the code around it: the first version of this demo, written
+// with a literal 0 and an unbounded recursion, HUNG instead of faulting
+// on Linux and in the guest alike. A number that arrives at run time is
+// a number the optimiser cannot reason about, so the machine is the one
+// that decides what happens — which is the only thing being tested here.
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+: NullTarget { i word }
+
+@ __touch i addr → i {
+    : *NullTarget p # *NullTarget addr
+    = . p word 1
+    ^ . p word
+}
+
+// Each frame keeps a heap handle across the call and does work after
+// it, so this is neither a tail call nor a pure function the optimiser
+// may fold away. `n` counts down from a number given on the command
+// line: the recursion terminates in principle and exhausts the stack in
+// practice, which is the combination that survives -O2.
+@ __deep i n → i {
+    : ( Vec i ) pad ( vec_with_cap [i] 2 )
+    ( vec_push [i] pad n )
+    : i deeper ? > n 0 ( __deep - n 1 ) 0
+    : i mine ?? ( vec_get [i] pad 0 ) { T x → x F → 0 }
+    ( vec_free [i] pad )
+    ^ + deeper mine
+}
+
+@ main → i {
+    : s mode ? > ( nurl_argc ) 1 ( nurl_argv 1 ) `null`
+    : i arg ? > ( nurl_argc ) 2 ( nurl_str_to_int ( nurl_argv 2 ) ) 0
+    ( nurl_print `about to fault: ` )
+    ( nurl_print mode )
+    ( nurl_print `\n` )
+    ( flush )
+    ? != ( nurl_str_eq mode `stack` ) 0 {
+        ( nurl_print ( nurl_str_int ( __deep arg ) ) )
+    } {
+        ( nurl_print ( nurl_str_int ( __touch arg ) ) )
+    }
+    ( nurl_print `still here — nothing faulted\n` )
+    ^ 0
+}

--- a/unikernel/demos/soak.nu
+++ b/unikernel/demos/soak.nu
@@ -1,0 +1,113 @@
+// unikernel/demos/soak.nu — the question a demo cannot answer: does it
+// still work after the thousandth request?
+//
+// Everything else in this directory proves the machine can do a thing
+// once. An appliance is judged on doing it for ever, and the two failure
+// modes that only appear at length are both invisible in a single-shot
+// test: memory that is handed out and never returned, and a queue whose
+// descriptors leak until it runs dry. This program answers requests
+// until the host stops asking, and reports what the guest's page
+// allocator says about it — a number the guest measures about itself,
+// not a guess made from outside.
+//
+// The verdict is the guest's own: `live` bytes after a warm-up, against
+// `live` bytes at the end. Warm-up matters because the first requests
+// populate caches, arenas and connection state that are then reused;
+// what must not grow is what comes after.
+$ `stdlib/std/net.nu`
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+
+// The guest's page allocator, as seen from NURL. 0 = bytes live now,
+// 1 = the high-water mark, 2 = bytes still available, 3 = the largest
+// hole, 4 = bytes lost to a full free list, 5 = the number of holes.
+// Guest-only: on Linux this program does not link, which is the honest
+// outcome for a question only this machine can answer.
+& `c` @ nurl_guest_mem i which → i
+
+@ warmup_at → i { ^ 20 }
+
+@ serve_until → i { ^ 200 }
+
+@ __kib i bytes → i { ^ / bytes 1024 }
+
+@ __report s label i live → v {
+    ( nurl_print label )
+    ( nurl_print ( nurl_str_int ( __kib live ) ) )
+    ( nurl_print ` KiB\n` )
+    ( flush )
+}
+
+@ main → i {
+    ?? ( tcp_listen `0.0.0.0` 8080 ) {
+        F e → {
+            ( nurl_print `listen failed: ` )
+            ( nurl_print ( net_err_name e ) )
+            ( nurl_print `\n` )
+            ^ 1
+        }
+        T l → {
+            ( nurl_print `soak: listening on 8080\n` )
+            ( flush )
+            : ~ i answered 0
+            : ~ i failures 0
+            : ~ i live_warm 0
+            ~ && < answered ( serve_until ) < failures 8 {
+                ?? ( tcp_accept l ) {
+                    F _e → = failures + failures 1
+                    T c → {
+                        ?? ( tcp_read_chunk c 2048 ) {
+                            T req → ( vec_free [u] req )
+                            F _e → {}
+                        }
+                        : !v NetErr w ( tcp_write_str c `HTTP/1.1 200 OK\r\nContent-Length: 3\r\nConnection: close\r\n\r\nok\n` )
+                        ?? w {
+                            T _ → = answered + answered 1
+                            F _e → = failures + failures 1
+                        }
+                        ( tcp_close_conn c )
+                        ? == answered ( warmup_at ) {
+                            = live_warm ( nurl_guest_mem 0 )
+                            ( __report `soak: live after warm-up: ` live_warm )
+                        } {}
+                    }
+                }
+            }
+            ( tcp_close_listener l )
+
+            : i live_end ( nurl_guest_mem 0 )
+            : i peak ( nurl_guest_mem 1 )
+            : i lost ( nurl_guest_mem 4 )
+            ( nurl_print `soak: answered ` )
+            ( nurl_print ( nurl_str_int answered ) )
+            ( nurl_print ` requests\n` )
+            ( __report `soak: live at the end: ` live_end )
+            ( __report `soak: high-water: ` peak )
+            ( nurl_print `soak: bytes lost to a full free list: ` )
+            ( nurl_print ( nurl_str_int lost ) )
+            ( nurl_print `\n` )
+            // The verdict, decided here rather than by the harness: the
+            // guest is the only party that can see its own heap, and a
+            // number in the output that nobody compares is a number
+            // nobody checks. One page of slack — an allocator whose
+            // arenas are megabytes cannot land on the same byte twice
+            // for reasons that have nothing to do with a leak.
+            : i growth ? > live_end live_warm - live_end live_warm 0
+            ? && == lost 0 <= growth 4096 {
+                ( nurl_print `soak: verdict STABLE (growth ` )
+                ( nurl_print ( nurl_str_int growth ) )
+                ( nurl_print ` bytes over ` )
+                ( nurl_print ( nurl_str_int - answered ( warmup_at ) ) )
+                ( nurl_print ` requests)\n` )
+            } {
+                ( nurl_print `soak: verdict GROWING (growth ` )
+                ( nurl_print ( nurl_str_int growth ) )
+                ( nurl_print ` bytes, lost ` )
+                ( nurl_print ( nurl_str_int lost ) )
+                ( nurl_print `)\n` )
+            }
+        }
+    }
+    ( flush )
+    ^ 0
+}

--- a/unikernel/drivers/virtionet.nu
+++ b/unikernel/drivers/virtionet.nu
@@ -46,6 +46,13 @@ $ `stdlib/hal/virtio.nu`
 // the header plus a 1500-byte MTU with room to spare.
 @ vnet_buf_len → i { ^ 2048 }
 
+// What is left for a frame once the 12-byte header has its share. Both
+// directions are bounded by it: a frame longer than this cannot be
+// transmitted (it is refused, not truncated), and a device that claims
+// to have written more than this into a 2048-byte buffer is not
+// believed.
+@ vnet_max_frame → i { ^ 2036 }
+
 // A Vec is a value — a handle struct, not a pointer — so a pool of
 // them is a pool of heap copies of the handle. Boxing says that once,
 // here, instead of at every push.
@@ -168,28 +175,36 @@ $ `stdlib/hal/virtio.nu`
     ^ . nic mac
 }
 
-// Keep the receive queue full. Every descriptor the device has
-// completed is refilled with the same buffer, so the buffer pool is
-// allocated once and never grows: a driver that allocates per packet
-// is a driver that stops working under load, which is exactly when it
-// matters.
+// Fill the receive queue once, at bring-up. Every descriptor the device
+// completes is handed straight back with the same buffer (see vnet_rx),
+// so the pool is allocated here and never grows: a driver that allocates
+// per packet is a driver that stops working under load, which is exactly
+// when it matters.
+//
+// The loop is bounded by the queue rather than by "until something
+// fails". `num_free > 0` and "the last add worked" are two different
+// conditions, and a version that trusted the first one spun for ever the
+// moment they disagreed.
 @ __rx_refill * VirtioNet nic → i {
     : ~ i added 0
-    ~ > ( virtq_num_free . nic rx ) 0 {
-        : i slot ( vec_len [i] . nic rxbuf )
+    : ~ i tries 0
+    : i limit . . nic rx qsize
+    ~ && < tries limit > ( virtq_num_free . nic rx ) 0 {
+        = tries + tries 1
         : ( Vec u ) b ( __buf_new ( vnet_buf_len ) )
+        : ~ b ok F
         ?? ( virtq_add_single . nic rx ( __buf_phys b ) ( vnet_buf_len ) T ) {
             T _d → {
                 ( vec_push [i] . nic rxbuf ( __vec_box b ) )
                 = added + added 1
+                = ok T
             }
             F → {
                 ( vec_free [u] b )
-                = added added
+                = ok F
             }
         }
-        ? == added 0 { ^ 0 } {}
-        ? >= ( vec_len [i] . nic rxbuf ) 1024 { ^ added } {}
+        ? ! ok { = tries limit } {}
     }
     ? > added 0 { ( virtio_notify . nic base ( vnet_rxq ) ) } {}
     ^ added
@@ -204,7 +219,14 @@ $ `stdlib/hal/virtio.nu`
         T head → {
             : i len ( virtq_last_used_len . nic rx )
             : i addr ( virtq_desc_addr . nic rx head )
-            : i n ? > len ( vnet_hdr_len ) - len ( vnet_hdr_len ) 0
+            // The length is the DEVICE's number, and the buffer is ours.
+            // A device that reports more than it was given a place to
+            // write is broken or hostile either way, and copying what it
+            // claims would read past the end of the buffer into whatever
+            // the allocator put next. Clamp, and let the frame be short:
+            // the stack above checks lengths again from the IP header.
+            : ~ i n ? > len ( vnet_hdr_len ) - len ( vnet_hdr_len ) 0
+            ? > n ( vnet_max_frame ) { = n ( vnet_max_frame ) } {}
             ? > n 0 {
                 ( bytes_extend_raw out # s + addr ( vnet_hdr_len ) n )
             } {}
@@ -219,31 +241,61 @@ $ `stdlib/hal/virtio.nu`
     }
 }
 
-// Send one frame. The header is a separate descriptor rather than a
-// copy into a bigger buffer: the caller's frame is already contiguous,
-// and a chain of two says so without moving it.
+// The transmit buffer belonging to descriptor `d`, allocated the first
+// time that descriptor is used and kept for ever after.
+//
+// THE POOL IS INDEXED BY DESCRIPTOR, and that is the whole fix. The
+// version this replaces allocated a fresh buffer for every frame and
+// pushed it onto a list that only `vnet_close` ever emptied: the device
+// finished with the buffer, the descriptor went back on the free list,
+// and the two kilobytes stayed allocated. A server leaked them at line
+// rate — which is a leak nobody sees in a demo that answers one request
+// and nobody survives in a machine that answers a million.
+@ __tx_buffer * VirtioNet nic i d → ( Vec u ) {
+    ~ <= ( vec_len [i] . nic txbuf ) d { ( vec_push [i] . nic txbuf 0 ) }
+    : i cur ?? ( vec_get [i] . nic txbuf d ) { T x → x F → 0 }
+    ? != cur 0 {
+        : *VecBox bx # *VecBox cur
+        ^ . bx v
+    } {}
+    : ( Vec u ) fresh ( __buf_new ( vnet_buf_len ) )
+    : i boxed ( __vec_box fresh )
+    : b _set ( vec_set [i] . nic txbuf d boxed )
+    : *VecBox nbx # *VecBox boxed
+    ^ . nbx v
+}
+
+// Send one frame: header and payload in one buffer, one descriptor.
+//
+// A frame longer than the buffer is REFUSED rather than truncated. The
+// stack above never builds one — the MTU is 1500 and the buffer holds
+// 2036 — so this is the answer to a bug elsewhere, and "the send failed"
+// is a fact its caller can act on where "the peer got half a packet" is
+// not.
 @ vnet_tx * VirtioNet nic ( Vec u ) frame i off i len → b {
     ? ! ( vnet_ready nic ) { ^ F } {}
     ? <= len 0 { ^ F } {}
+    ? > len ( vnet_max_frame ) { ^ F } {}
     ( __tx_reap nic )
 
-    : ( Vec u ) pkt ( __buf_new + ( vnet_hdr_len ) len )
-    : ~ i k 0
-    ~ < k len {
-        : b _ok ( vec_set [u] pkt + ( vnet_hdr_len ) k
-        ?? ( vec_get [u] frame + off k ) { T x → x F → # u 0 } )
-        = k + k 1
-    }
-    ?? ( virtq_add_single . nic tx ( __buf_phys pkt ) + ( vnet_hdr_len ) len F ) {
-        T _d → {
-            ( vec_push [i] . nic txbuf ( __vec_box pkt ) )
+    // The descriptor comes first: the buffer is chosen by its index, and
+    // publishing a descriptor before its buffer is filled would hand the
+    // device the previous frame's bytes.
+    ?? ( virtq_alloc_desc . nic tx ) {
+        T d → {
+            : ( Vec u ) pkt ( __tx_buffer nic d )
+            : ~ i k 0
+            ~ < k len {
+                : b _ok ( vec_set [u] pkt + ( vnet_hdr_len ) k
+                ?? ( vec_get [u] frame + off k ) { T x → x F → # u 0 } )
+                = k + k 1
+            }
+            ( virtq_desc_set . nic tx d ( __buf_phys pkt ) + ( vnet_hdr_len ) len 0 ( vq_null ) )
+            ( virtq_avail_push . nic tx d )
             ( virtio_notify . nic base ( vnet_txq ) )
             ^ T
         }
-        F → {
-            ( vec_free [u] pkt )
-            ^ F
-        }
+        F → ^ F
     }
 }
 

--- a/unikernel/nolibc/malloc.c
+++ b/unikernel/nolibc/malloc.c
@@ -65,6 +65,15 @@ void *malloc(nl_size_t n) {
     struct nl_head *h;
     int c;
     if (n == 0) n = 1;
+    /* A length that cannot have a header and a page of rounding added to
+     * it is a length no allocation can satisfy. Saying so here is not
+     * pedantry: without it `n + sizeof(head)` wraps, lands in a small
+     * size class, and a request for nearly the whole address space is
+     * answered with a 32-byte block — which the caller then fills. Sizes
+     * near the top come from length arithmetic on attacker-supplied
+     * numbers often enough that this is the ordinary case, not the
+     * exotic one. */
+    if (n > (nl_size_t)-1 - sizeof(struct nl_head) - 4095) return 0;
     c = nl_class_of(n + sizeof(struct nl_head));
     if (c < 0) {                                   /* big: its own mapping */
         nl_size_t total = n + sizeof(struct nl_head);

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -189,6 +189,44 @@ if [ $# -eq 0 ] && command -v curl >/dev/null 2>&1; then
     fi
 fi
 
+# ── the same server, two hundred times ──────────────────────────
+# The httpd gate proves a request can be answered. This one proves the
+# two-hundredth can, which is a different property and the one an
+# appliance is judged on: a leak per packet is invisible in a demo and
+# fatal in a machine that runs for a week. The guest reports its own
+# page allocator's numbers and reaches the verdict itself — the harness
+# only reads it, because nothing outside the guest can see its heap.
+if [ $# -eq 0 ] && command -v curl >/dev/null 2>&1; then
+    demos=$((demos + 1))
+    if "$ROOT/unikernel/build_unikernel.sh" "$ROOT/unikernel/demos/soak.nu" >/dev/null 2>&1; then
+        out=$(mktemp)
+        ( "$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/soak.elf" -t 300 -- \
+            -netdev user,id=n0,hostfwd=tcp:127.0.0.1:18090-:8080 \
+            -device virtio-net-device,netdev=n0 > "$out" 2>&1 ) &
+        qpid=$!
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            sleep 2
+            curl -sS --max-time 8 http://127.0.0.1:18090/ >/dev/null 2>&1 && break
+        done
+        # Ten more than the guest will answer: the port forward accepts
+        # before the guest listens, so the first few may never arrive.
+        for _ in $(seq 1 210); do
+            curl -sS --max-time 8 http://127.0.0.1:18090/ >/dev/null 2>&1
+        done
+        wait $qpid
+        if grep -q 'verdict STABLE' "$out"; then
+            echo "PASS soak ($(sed -n 's/.*answered \([0-9]*\) requests/\1/p' "$out" | tail -1) requests, heap flat)"
+        else
+            echo "FAIL soak"
+            grep -E 'soak:' "$out" | tail -6 | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+        rm -f "$out"
+    else
+        echo "FAIL soak (build)"; fails=$((fails + 1))
+    fi
+fi
+
 # ── the MCP endpoint, spoken to as a client would ───────────────
 # Three requests, because one would not distinguish "the server
 # answered" from "the server answered correctly": initialize settles

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -228,6 +228,10 @@ if [ $# -eq 0 ] && command -v curl >/dev/null 2>&1; then
 fi
 
 # ── the MCP endpoint, spoken to as a client would ───────────────
+# HOST PORTS HERE MUST NOT BE PORTS THE CORPUS BINDS. This gate used to
+# forward 18771, which `compiler/tests/http_server_limits.nu` listens on:
+# run the two suites on one machine and one of them fails with
+# NetAddrInUse, in a test that has nothing to do with either change.
 # Three requests, because one would not distinguish "the server
 # answered" from "the server answered correctly": initialize settles
 # the protocol, tools/list settles the catalogue, and tools/call
@@ -237,7 +241,7 @@ if [ $# -eq 0 ] && command -v curl >/dev/null 2>&1; then
     if "$ROOT/unikernel/build_unikernel.sh" "$ROOT/unikernel/demos/mcpd.nu" >/dev/null 2>&1; then
         out=$(mktemp)
         ( "$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/mcpd.elf" -t 120 -- \
-            -netdev user,id=n0,hostfwd=tcp:127.0.0.1:18771-:18770 \
+            -netdev user,id=n0,hostfwd=tcp:127.0.0.1:18992-:18770 \
             -device virtio-net-device,netdev=n0 > "$out" 2>&1 ) &
         qpid=$!
         init=""
@@ -245,15 +249,15 @@ if [ $# -eq 0 ] && command -v curl >/dev/null 2>&1; then
             sleep 2
             init=$(curl -sS --max-time 10 -X POST -H 'Content-Type: application/json' \
                    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"gate","version":"1"}}}' \
-                   http://127.0.0.1:18771/mcp 2>/dev/null)
+                   http://127.0.0.1:18992/mcp 2>/dev/null)
             [ -n "$init" ] && break
         done
         tools=$(curl -sS --max-time 10 -X POST -H 'Content-Type: application/json' \
                 -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
-                http://127.0.0.1:18771/mcp 2>/dev/null)
+                http://127.0.0.1:18992/mcp 2>/dev/null)
         called=$(curl -sS --max-time 10 -X POST -H 'Content-Type: application/json' \
                  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"text":"from the host"}}}' \
-                 http://127.0.0.1:18771/mcp 2>/dev/null)
+                 http://127.0.0.1:18992/mcp 2>/dev/null)
         kill $qpid 2>/dev/null; wait $qpid 2>/dev/null
         if printf '%s' "$init" | grep -q '"protocolVersion"' \
            && printf '%s' "$tools" | grep -q '"echo"' \

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -131,6 +131,56 @@ if [ $# -eq 0 ]; then
     fi
 fi
 
+# ── the smallest machine it still works on ──────────────────────
+# Everything else here runs with 256 MiB, which hides the question a
+# density-minded operator actually asks. The floor was measured — hello
+# answers on 3 MiB, the HTTP server on 4 — and these run with headroom
+# over it, so what this gate really pins is APPETITE: a change that
+# doubles what the guest needs before it can answer fails here rather
+# than on somebody's Firecracker host.
+#
+# The last case is the one that matters most: below the floor the
+# machine must say so. A guest that quietly wanders off is what the
+# memory work in this directory was about.
+if [ $# -eq 0 ]; then
+    demos=$((demos + 1))
+    ok=1
+    "$ROOT/unikernel/build_unikernel.sh" "$TESTS/hello.nu" >/dev/null 2>&1 || ok=0
+    small=$("$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/hello.elf" -t 60 -- -m 4 2>&1)
+    printf '%s' "$small" | grep -q 'Hello, NURL!' || ok=0
+
+    tiny=$("$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/hello.elf" -t 60 -- -m 2 2>&1)
+    tinycode=$?
+    printf '%s' "$tiny" | grep -q 'no usable memory above the image' || ok=0
+    [ "$tinycode" = 127 ] || ok=0
+
+    if command -v curl >/dev/null 2>&1; then
+        "$ROOT/unikernel/build_unikernel.sh" "$ROOT/unikernel/demos/httpd.nu" >/dev/null 2>&1 || ok=0
+        out=$(mktemp)
+        ( "$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/httpd.elf" -t 90 -- -m 8 \
+            -netdev user,id=n0,hostfwd=tcp:127.0.0.1:18099-:8080 \
+            -device virtio-net-device,netdev=n0 > "$out" 2>&1 ) &
+        qpid=$!
+        body=""
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            sleep 2
+            body=$(curl -sS --max-time 8 http://127.0.0.1:18099/ 2>/dev/null)
+            [ -n "$body" ] && break
+        done
+        wait $qpid
+        [ "$body" = "hello from a guest" ] || ok=0
+        rm -f "$out"
+    fi
+
+    if [ "$ok" = 1 ]; then
+        echo "PASS smallmem (4 MiB hello, 8 MiB server, 2 MiB says why not)"
+    else
+        echo "FAIL smallmem"
+        printf '%s\n' "$tiny" | head -3 | sed 's/^/     /'
+        fails=$((fails + 1))
+    fi
+fi
+
 # ── the demo with a filesystem and arguments ────────────────────
 # Built with --fs, run with args on the kernel command line: the two
 # halves of B7, and the only demo whose build and invocation differ

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -90,6 +90,47 @@ if [ $# -eq 0 ]; then
     done
 fi
 
+# ── the machine's own failure report ────────────────────────────
+# Every other gate here checks that something worked. This one checks
+# what happens when something does not: a guest with no IDT answers a
+# null dereference by shutting down silently, which from the host is
+# indistinguishable from a clean exit. Two faults, two reports, one
+# distinct exit code — 126, which is neither a panic (127) nor anything
+# a program can return.
+if [ $# -eq 0 ]; then
+    demos=$((demos + 1))
+    if "$ROOT/unikernel/build_unikernel.sh" "$ROOT/unikernel/demos/fault.nu" >/dev/null 2>&1; then
+        nullout=$(NURL_APPEND='args="null 0"' \
+                  "$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/fault.elf" -t 60 2>&1)
+        nullcode=$?
+        stackout=$(NURL_APPEND='args="stack 100000000"' \
+                   "$ROOT/unikernel/run_qemu.sh" "$ROOT/build/unikernel/fault.elf" -t 60 2>&1)
+        stackcode=$?
+        ok=1
+        # A null store must be a page fault at address zero, not a quiet
+        # write to physical page zero — which is what an identity-mapped
+        # guest does until the page is unmapped on purpose.
+        printf '%s' "$nullout" | grep -q '#PF page fault' || ok=0
+        printf '%s' "$nullout" | grep -q 'cr2=0x0 (not present) on write' || ok=0
+        [ "$nullcode" = 126 ] || ok=0
+        # A recursion past the end of the boot stack must be a fault on
+        # its guard page, reported from the IST stack — the ordinary one
+        # is exactly what ran out.
+        printf '%s' "$stackout" | grep -q '#PF page fault' || ok=0
+        [ "$stackcode" = 126 ] || ok=0
+        if [ "$ok" = 1 ]; then
+            echo "PASS fault (both faults reported, exit 126)"
+        else
+            echo "FAIL fault (null exit $nullcode, stack exit $stackcode)"
+            printf '%s\n' "$nullout" | head -4 | sed 's/^/     /'
+            printf '%s\n' "$stackout" | head -4 | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+    else
+        echo "FAIL fault (build)"; fails=$((fails + 1))
+    fi
+fi
+
 # ── the demo with a filesystem and arguments ────────────────────
 # Built with --fs, run with args on the kernel command line: the two
 # halves of B7, and the only demo whose build and invocation differ

--- a/unikernel/tests/malloc_fuzz.c
+++ b/unikernel/tests/malloc_fuzz.c
@@ -127,6 +127,40 @@ int main(void) {
             printf("CORRUPT slot %ld at the end\n", i);
             return 1;
         }
+
+    /* ── the sizes that cannot be served ────────────────────────────
+     *
+     * A length near the top of the word is where a size-class allocator
+     * quietly goes wrong: `n + sizeof(header)` wraps, the wrapped value
+     * lands in a small class, and the caller is handed thirty-two bytes
+     * for a request it believes was granted in full. The answer must be
+     * a refusal, and a refusal is a NULL — never a short block.
+     */
+    {
+        static const nl_size_t huge[] = {
+            (nl_size_t)-1, (nl_size_t)-2, (nl_size_t)-16, (nl_size_t)-4096,
+            ((nl_size_t)-1) / 2 + 1,
+        };
+        unsigned h;
+        for (h = 0; h < sizeof huge / sizeof huge[0]; h++) {
+            void *p = malloc(huge[h]);
+            if (p) {
+                printf("malloc(%llu) returned a block of %llu usable bytes\n",
+                       (unsigned long long)huge[h],
+                       (unsigned long long)malloc_usable_size(p));
+                return 1;
+            }
+        }
+        if (calloc((nl_size_t)-1, 2)) { printf("calloc overflow returned a block\n"); return 1; }
+        {   /* a refused realloc must leave the original block alone */
+            unsigned char *p = (unsigned char *)malloc(64);
+            if (!p) { printf("the 64-byte control allocation failed\n"); return 1; }
+            p[0] = 0xA5;
+            if (realloc(p, (nl_size_t)-1)) { printf("realloc to SIZE_MAX succeeded\n"); return 1; }
+            if (p[0] != 0xA5) { printf("a refused realloc freed or moved the block\n"); return 1; }
+            free(p);
+        }
+    }
     printf("malloc fuzz ok: %ld ops (%ld malloc, %ld calloc, %ld realloc, %ld free)\n",
            (long)OPS, allocs, callocs, reallocs, frees);
     return 0;

--- a/unikernel/tests/pagealloc_fuzz.c
+++ b/unikernel/tests/pagealloc_fuzz.c
@@ -1,0 +1,244 @@
+/*
+ * NURL unikernel — unikernel/tests/pagealloc_fuzz.c
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * The guest's page allocator, fuzzed on the host against a model.
+ *
+ * `boot/pagealloc.c` is what `mmap` and `munmap` are made of inside the
+ * unikernel, and inside the unikernel a bug in it is a triple fault with
+ * nothing printed. So it is written as portable C with no idea what a
+ * page table is, and this file runs it here, where a bug is a line of
+ * output instead.
+ *
+ * The oracle is not "it didn't crash" — a bump allocator never crashes
+ * and that is exactly what was wrong with the one this replaced. It is a
+ * model of every live range, checked on every operation:
+ *
+ *   1. no two live ranges overlap, ever — the failure mode that turns
+ *      into two objects sharing memory;
+ *   2. every range is inside the region and page-aligned;
+ *   3. accounting agrees: the allocator's own `live` equals the sum of
+ *      the model's ranges;
+ *   4. nothing is lost — after freeing everything, one allocation of the
+ *      WHOLE region must succeed. That is coalescing, stated as a
+ *      property rather than as an inspection of the free list, and it
+ *      is what a version that forgets to merge neighbours fails.
+ *
+ * The region is a real mmap'd block on the host, so the addresses the
+ * allocator hands out are addresses this test can actually write to —
+ * and it writes a pattern derived from each range's identity and checks
+ * it on free, which catches an overlap even if the model somehow agrees.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+
+typedef unsigned long pa_size_t;
+
+void          pa_init(pa_size_t base, pa_size_t len);
+pa_size_t     pa_alloc(pa_size_t want);
+int           pa_free(pa_size_t p, pa_size_t len);
+void          pa_stats(pa_size_t *live, pa_size_t *peak, pa_size_t *avail,
+                       pa_size_t *largest, pa_size_t *lost, int *holes);
+
+#define PAGE      4096UL
+#define REGION    (64UL * 1024 * 1024)
+#define SLOTS     192
+#define OPS       200000
+
+struct slot { pa_size_t p, n; unsigned seed; };
+static struct slot slot[SLOTS];
+
+static unsigned long long rng = 0x9E3779B97F4A7C15ULL;
+static unsigned long long rnd(void) {
+    rng ^= rng << 13; rng ^= rng >> 7; rng ^= rng << 17;
+    return rng;
+}
+
+static pa_size_t region_base;
+
+static void fill(struct slot *s) {
+    unsigned char *p = (unsigned char *)s->p;
+    unsigned x = s->seed;
+    /* One byte per page is enough to catch an overlap and keeps the
+     * fuzzer's own cost off the profile. */
+    for (pa_size_t off = 0; off < s->n; off += PAGE) {
+        x = x * 1103515245u + 12345u;
+        p[off] = (unsigned char)(x >> 16);
+    }
+}
+static int verify(struct slot *s) {
+    unsigned char *p = (unsigned char *)s->p;
+    unsigned x = s->seed;
+    for (pa_size_t off = 0; off < s->n; off += PAGE) {
+        x = x * 1103515245u + 12345u;
+        if (p[off] != (unsigned char)(x >> 16)) return 0;
+    }
+    return 1;
+}
+
+static int overlaps(int k, pa_size_t p, pa_size_t n) {
+    for (int i = 0; i < SLOTS; i++) {
+        if (i == k || !slot[i].p) continue;
+        if (p < slot[i].p + slot[i].n && slot[i].p < p + n) return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    void *region = mmap(0, REGION, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (region == MAP_FAILED) { printf("mmap failed\n"); return 1; }
+    region_base = (pa_size_t)region;
+    pa_init(region_base, REGION);
+
+    long allocs = 0, frees = 0, refusals = 0;
+    pa_size_t model_live = 0;
+
+    for (long i = 0; i < OPS; i++) {
+        int k = (int)(rnd() % SLOTS);
+        struct slot *s = &slot[k];
+
+        if (s->p) {
+            if (!verify(s)) {
+                printf("pattern mismatch in slot %d at %#lx (%lu bytes) — "
+                       "two live ranges share memory\n", k, s->p, s->n);
+                return 1;
+            }
+            if (pa_free(s->p, s->n) != 0) {
+                printf("pa_free refused a range it handed out: %#lx+%lu\n",
+                       s->p, s->n);
+                return 1;
+            }
+            model_live -= s->n;
+            frees++;
+            s->p = 0;
+            continue;
+        }
+
+        /* A mix of sizes: single pages, the megabyte arenas nolibc's
+         * malloc asks for, the occasional large one that only fits when
+         * the free list has coalesced — and sizes that are NOT page
+         * multiples, because `mmap` takes a length in bytes and rounding
+         * it is this allocator's job. A version that skips the rounding
+         * hands out misaligned addresses and overlapping ranges, and
+         * without this case nothing here would notice. */
+        pa_size_t want;
+        switch (rnd() % 5) {
+        case 0:  want = PAGE * (1 + rnd() % 4); break;
+        case 1:  want = PAGE * (16 + rnd() % 64); break;
+        case 2:  want = 1024UL * 1024; break;
+        case 3:  want = 1 + rnd() % (8 * PAGE); break;      /* ragged */
+        default: want = PAGE * (256 + rnd() % 512); break;
+        }
+        pa_size_t rounded = (want + PAGE - 1) & ~(PAGE - 1);
+        pa_size_t p = pa_alloc(want);
+        if (!p) { refusals++; continue; }
+
+        if (p < region_base || p + rounded > region_base + REGION) {
+            printf("pa_alloc handed out %#lx+%lu, outside the region\n", p, rounded);
+            return 1;
+        }
+        if (p % PAGE) { printf("pa_alloc handed out a misaligned %#lx\n", p); return 1; }
+        if (overlaps(k, p, rounded)) {
+            printf("pa_alloc handed out %#lx+%lu, which overlaps a live range\n",
+                   p, rounded);
+            return 1;
+        }
+        s->p = p; s->n = rounded; s->seed = (unsigned)rnd() | 1;
+        fill(s);
+        model_live += rounded;
+        allocs++;
+
+        pa_size_t live = 0, lost = 0;
+        pa_stats(&live, 0, 0, 0, &lost, 0);
+        if (live != model_live) {
+            printf("accounting drifted: allocator says %lu live, model says %lu\n",
+                   live, model_live);
+            return 1;
+        }
+        if (lost) { printf("the free list overflowed and lost %lu bytes\n", lost); return 1; }
+    }
+
+    /* Everything back, and then the whole region in one piece: the
+     * property that says the holes really did merge. */
+    for (int i = 0; i < SLOTS; i++) {
+        if (!slot[i].p) continue;
+        if (!verify(&slot[i])) { printf("pattern mismatch at the end, slot %d\n", i); return 1; }
+        pa_free(slot[i].p, slot[i].n);
+        slot[i].p = 0;
+    }
+    pa_size_t live = 0, avail = 0, largest = 0, lost = 0;
+    int holes = 0;
+    pa_stats(&live, 0, &avail, &largest, &lost, &holes);
+    if (live != 0) { printf("after freeing everything, %lu bytes are still live\n", live); return 1; }
+    if (lost != 0) { printf("%lu bytes were lost along the way\n", lost); return 1; }
+
+    pa_size_t whole = pa_alloc(REGION - PAGE);
+    if (!whole) {
+        printf("after freeing everything, the region does not fit in itself: "
+               "avail=%lu largest=%lu holes=%d — the free list did not coalesce\n",
+               avail, largest, holes);
+        return 1;
+    }
+    pa_free(whole, REGION - PAGE);
+
+    /* Exhaustion is a refusal, not a wild pointer: ask for more than the
+     * machine has and the answer must be zero. */
+    if (pa_alloc(REGION * 2) != 0) {
+        printf("pa_alloc answered a request larger than the region\n");
+        return 1;
+    }
+    /* A range that was never handed out is not ours to record. */
+    if (pa_free(region_base - PAGE, PAGE) == 0) {
+        printf("pa_free accepted a range outside the region\n");
+        return 1;
+    }
+
+    /* ── coalescing in the middle, where the tail cannot rescue it ──
+     *
+     * Random traffic frees most things next to the region's end, and
+     * rolling the tail back merges neighbours whether or not the free
+     * list does. So the merge is asserted directly instead: eight blocks
+     * in a row, the LAST one held live so the tail is blocked, and the
+     * other seven freed in order. Seven adjacent holes must become one —
+     * ascending frees exercise the merge with the left neighbour and
+     * descending frees the merge with the right one, and a version
+     * missing either leaves seven holes and cannot answer a request for
+     * the seven megabytes it is sitting on.
+     */
+    for (int pass = 0; pass < 2; pass++) {
+        const pa_size_t blk = 1024UL * 1024;
+        pa_size_t b[8];
+        for (int i = 0; i < 8; i++) {
+            b[i] = pa_alloc(blk);
+            if (!b[i]) { printf("directed: allocation %d refused\n", i); return 1; }
+        }
+        for (int i = 0; i < 7; i++) {
+            int k = pass == 0 ? i : 6 - i;      /* ascending, then descending */
+            pa_free(b[k], blk);
+        }
+        pa_stats(0, 0, 0, 0, 0, &holes);
+        if (holes != 1) {
+            printf("directed (%s): seven adjacent holes became %d, not 1 — "
+                   "the free list does not coalesce with its %s neighbour\n",
+                   pass == 0 ? "ascending" : "descending", holes,
+                   pass == 0 ? "left" : "right");
+            return 1;
+        }
+        pa_size_t big = pa_alloc(7 * blk);
+        if (!big) {
+            printf("directed (%s): seven freed megabytes do not fit in the "
+                   "hole they made\n", pass == 0 ? "ascending" : "descending");
+            return 1;
+        }
+        pa_free(big, 7 * blk);
+        pa_free(b[7], blk);
+    }
+
+    printf("pagealloc fuzz ok: %ld ops (%ld allocs, %ld frees, %ld refusals)\n",
+           (long)OPS, allocs, frees, refusals);
+    return 0;
+}

--- a/unikernel/tests/run_unit_tests.sh
+++ b/unikernel/tests/run_unit_tests.sh
@@ -91,6 +91,14 @@ $CC $FREE -c "$ROOT/unikernel/tests/malloc_fuzz.c" -o "$OUT/malloc_fuzz.o" || ex
 $CC -nostdlib -static -o "$OUT/malloc_fuzz" "$OUT/malloc_fuzz.o" "$OUT"/nl_*.o || exit 2
 step malloc_fuzz "$OUT/malloc_fuzz"
 
+# 3b. the page allocator under that allocator — the guest's mmap and
+# munmap. Ordinary hosted C: it is portable by construction, and the
+# oracle needs a real region to write patterns into.
+# shellcheck disable=SC2086
+$CC -O2 -o "$OUT/pagealloc_fuzz" "$ROOT/unikernel/tests/pagealloc_fuzz.c" \
+    "$ROOT/unikernel/boot/pagealloc.c" || exit 2
+step pagealloc_fuzz "$OUT/pagealloc_fuzz"
+
 # 4. the cooperative scheduler, with no libc under it either.
 # shellcheck disable=SC2086
 $CC $FREE -c "$ROOT/unikernel/runtime_bare.c" -o "$OUT/runtime_bare.o" || exit 2


### PR DESCRIPTION
Six things the guest could not do, found by asking it to do them. Every
one was invisible to the gates that existed, and every one has a gate
now.

## Faults were silent

There was no IDT. Every CPU exception was delivered nowhere: the CPU
could not raise the fault, could not raise the double fault either, and
shut down — which from the host is indistinguishable from a clean exit,
because QEMU quits and the exit sentinel is simply absent. The first
thing anyone knew about a null dereference was that the output stopped.

```
nurl: fault #PF page fault vector=14 err=0x2
  rip=0x10be42 rsp=0x128000 rflags=0x6
  cr2=0x127ff8 (not present) on write
  rax=0x18 rbx=0x18 rcx=0x1488a0 rdx=0x0
```

`#DF` and `#PF` arrive on an **IST stack**, because the fault most worth
surviving is a stack that hit its guard page: delivered on that same
dead stack, the push faults, the double fault's push faults, and the
second fault is the last thing that happens.

Two guard pages came with it. The **boot stack** had none — a recursion
off the end wrote into whatever `.bss` put underneath and carried on
with someone else's variables. And **page zero** was mapped present and
writable like the rest of the identity map, so a store through a null
pointer *quietly succeeded* in this guest while being a segfault on
every hosted target.

## Memory only ever grew

`mmap` was a bump pointer and `munmap` returned success without doing
anything. Measured on a 256 MiB machine: allocate a megabyte and free
it, and the guest dies on the 251st. `boot/pagealloc.c` is a real page
allocator — sorted free list, best fit, coalescing on both sides, tail
rolled back — written as portable C so `tests/pagealloc_fuzz.c` runs it
on the host against a model that checks on every operation that no two
live ranges overlap and that after freeing everything the region fits in
itself. Nine mutants injected, eight caught. The same churn now survives
4000 iterations.

The first fault report also explained why exhaustion was a wild store
rather than an "out of memory" line: this target's `nl_map` answered
MAP_FAILED where nolibc's allocator checks for NULL, and the Linux twin
has always converted. Hand-synced twins that drift is the hazard this
directory is arranged around; one had drifted.

## The driver leaked a buffer per packet

`vnet_tx` allocated a fresh 2 KiB buffer for every frame and pushed it
onto a list only `vnet_close` ever emptied — 5.2 MB gone after 200
requests. The pool is now indexed by descriptor. Two more from the same
reading: `vnet_rx` believed the length the *device* reported, and
`__rx_refill` could spin for ever when "the queue has a free descriptor"
and "the last add worked" disagreed.

## A DHCP server could take the guest off the network

`yiaddr` and the subnet mask were taken straight off the wire. An answer
of 0.0.0.0, 127.0.0.1, a multicast address or 255.255.255.255 configured
the guest with an address no host can own and *nothing failed*. A wrong
`yiaddr` is one typo in a server config; DHCP is also unauthenticated by
construction and is the first thing a guest does on a network it does
not own.

## New gates

| | |
|---|---|
| `demos/fault.nu` | two deliberate faults, their reports read, exit 126 asserted |
| `demos/soak.nu` | 200 requests; the guest reports its own page allocator and reaches the verdict itself. With the leak restored: `GROWING 5 263 360 bytes` |
| `net_frame_fuzz` | raw bytes into `stack_rx` — five invariants, mutation-validated against five injected parser bugs, in the LSan gate |
| `pagealloc_fuzz` | the page allocator against a model, on the host |
| `malloc_fuzz` | now asserts that a length near SIZE_MAX is refused, not wrapped into a small size class |

`bench_boot.sh` gains the throughput number B9 asked for and never got —
143 sequential requests per second under TCG — measured on the same run
as the heap figure, because a throughput number and a leak number from
two different servers are two numbers about two different programs.

## Documentation

The README could tell you how to boot one; it could not tell you what to
do when it did not boot. Now: the fault report and a table of exit
codes, where the heap comes from and what shape to expect from it, the
kernel command line as a contract with a row per key, the limits (one
vCPU, MTU 1500, no reassembly, 16 open files, no processes), and the
threat model stated outright — the hypervisor and the command line are
trusted, the network is not. The Firecracker paragraph now says it is
design intent rather than a tested path, because no job boots one.

## Gates

```
compiler corpus            612 PASS   0 FAIL
corpus with no libc        451 PASS   0 FAIL
nolibc unit gates          19/19
QEMU guest                 18/18   (was 16/16)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1