### PR TITLE
A flood of connections is refused, not fatal

### DIFF
--- a/compiler/tests/net_socket.nu
+++ b/compiler/tests/net_socket.nu
@@ -297,6 +297,56 @@ $ `stdlib/net/socket.nu`
     ( tstack_free ts2 )
     ( stack_free net2 )
 
+    // ── the ceiling on open sockets ──────────────────────────────
+    //
+    // A hosted program gets this from the kernel whether it asks or
+    // not: past RLIMIT_NOFILE, `accept` answers EMFILE and the server
+    // keeps serving what it already has. This layer had no such limit,
+    // so the fd table grew for every concurrent connection and a peer
+    // that opened enough of them did not get refused — it got the
+    // machine. Three things are asserted: that the refusal happens,
+    // that it does NOT consume the pending connection (which would
+    // orphan an established one nobody holds an fd for), and that the
+    // same accept succeeds once an fd is free.
+    : *NetStack net3 ( stack_new ( lo_mac ) ( lo_ip ) ( lo_mask ) 0 )
+    : *TcpStack ts3 ( tstack_new net3 7000 )
+    : *SockTab st3 ( sock_new ts3 ( lo_ip ) )
+    ( sock_seed_self st3 7000 )
+    ( pb `the default ceiling is a POSIX-shaped 1024: ` == ( sock_max_fds st3 ) 1024 )
+
+    : i l3 ( sock_listen st3 0 9100 8 )
+    : i k3 ( sock_connect st3 ( lo_ip ) 9100 0 7000 )
+    ( pump st3 7000 12 )
+    // Two fds are open (the listener and the client); a ceiling of two
+    // means the next accept has nowhere to put the connection.
+    ( sock_set_max_fds st3 2 )
+    : i refused ( sock_accept st3 l3 )
+    ( pb `accept past the ceiling is refused: ` == refused - 0 ( sock_err_accept ) )
+    ( pb `and the pending connection is still pending: ` == ( tstack_pending_count ts3 0 ) 1 )
+    ( pb `an established connection was not orphaned: ` == ( sock_open_count st3 ) 2 )
+
+    // Room again, and the same connection is accepted — nothing about
+    // it was consumed by the refusal.
+    ( sock_set_max_fds st3 8 )
+    : i a3 ( sock_accept st3 l3 )
+    ( pb `with room, the same connection accepts: ` > a3 0 )
+    ( pb `the pending queue drained: ` == ( tstack_pending_count ts3 0 ) 0 )
+
+    // The ceiling applies to what a program opens for itself, too.
+    ( sock_set_max_fds st3 3 )
+    : i denied ( sock_listen st3 0 9200 4 )
+    ( pb `listen past the ceiling reports an error: ` != ( sock_err st3 denied ) 0 )
+    ( sock_close st3 denied 7000 )
+    ( sock_set_max_fds st3 0 )
+    ( pb `a ceiling of 0 means no ceiling: ` ( sock_can_open st3 ) )
+
+    ( sock_close st3 a3 7000 ) ( sock_close st3 k3 7000 ) ( sock_close st3 l3 7000 )
+    ( pump st3 7000 24 )
+    ( sock_tick st3 + 7000 ( tcp_2msl_ms ) )
+    ( sock_free st3 )
+    ( tstack_free ts3 )
+    ( stack_free net3 )
+
     // ── teardown ─────────────────────────────────────────────────
     // Every handle here is manually managed and this stack is bound
     // for a machine with no process exit to sweep up after it, so the

--- a/compiler/tests/outputs/net_socket.txt
+++ b/compiler/tests/outputs/net_socket.txt
@@ -80,5 +80,13 @@ send without a peer is an error, not a silent drop: ok
 the seeded stack sends the SYN, not an ARP request: ok
 and connects with no retransmit at all: ok
 the far end accepted it: ok
+the default ceiling is a POSIX-shaped 1024: ok
+accept past the ceiling is refused: ok
+and the pending connection is still pending: ok
+an established connection was not orphaned: ok
+with room, the same connection accepts: ok
+the pending queue drained: ok
+listen past the ceiling reports an error: ok
+a ceiling of 0 means no ceiling: ok
 no fd is left open: ok
 net_socket: all ok

--- a/stdlib/net/socket.nu
+++ b/stdlib/net/socket.nu
@@ -137,7 +137,21 @@ $ `stdlib/net/tcpstack.nu`
     ( Vec i ) fds  // *Sock, as integers — NURL has no Vec of pointers
     i ephemeral  // next ephemeral port for an unbound listener
     i our_ip
+    i max_fds  // the ceiling; 0 means "no ceiling"
 }
+
+// How many sockets may be open at once. A hosted program has this
+// whether it asks for one or not — the kernel answers EMFILE and the
+// server keeps serving what it already has. This layer had no such
+// limit: the table grew for every concurrent connection, so a peer that
+// opens ten thousand of them against a small machine does not get
+// refused, it gets the machine. A ceiling turns that back into what
+// every server's accept loop is already written for.
+//
+// 1024 is the number a POSIX programmer expects, and the point of the
+// default is familiarity rather than tuning — `sock_set_max_fds` is
+// there for a machine that knows its own size.
+@ sock_default_max_fds → i { ^ 1024 }
 
 // fds start at 3. Not decoration: 0 is how the socket ABI spells a
 // failed handle, and a program that prints an fd should not be able to
@@ -152,6 +166,7 @@ $ `stdlib/net/tcpstack.nu`
     = . st fds ( vec_new [i] )
     = . st ephemeral 32768
     = . st our_ip our_ip
+    = . st max_fds ( sock_default_max_fds )
     ^ st
 }
 
@@ -223,7 +238,24 @@ $ `stdlib/net/tcpstack.nu`
     = . s opts 0
 }
 
-@ __alloc_fd * SockTab st → i {
+// The ceiling, and a way to raise or remove it (0 = no ceiling). A
+// machine that knows how much memory it has knows this number better
+// than the default does.
+@ sock_set_max_fds * SockTab st i n → v { = . st max_fds ? > n 0 n 0 }
+
+@ sock_max_fds * SockTab st → i { ^ . st max_fds }
+
+// Would one more socket fit? Asked BEFORE anything irreversible
+// happens — `sock_accept` in particular checks it before dequeuing a
+// pending connection, so a refusal leaves that connection in the
+// backlog for the next call instead of orphaning an established one
+// nobody holds an fd for.
+@ sock_can_open * SockTab st → b {
+    ? <= . st max_fds 0 { ^ T } {}
+    ^ < ( sock_open_count st ) . st max_fds
+}
+
+@ __alloc_fd_unbounded * SockTab st → i {
     : i n ( vec_len [i] . st fds )
     : ~ i k 0
     ~ < k n {
@@ -240,12 +272,26 @@ $ `stdlib/net/tcpstack.nu`
     ^ + n ( __fd_base )
 }
 
+// -1 when the table is full. Every caller turns that into the error its
+// own operation reports, because "too many open files" arrives at a
+// NURL program through whatever `accept` or `listen` answers.
+@ __alloc_fd * SockTab st → i {
+    ? ! ( sock_can_open st ) { ^ -1 } {}
+    ^ ( __alloc_fd_unbounded st )
+}
+
 // An fd that exists only to carry an error. The socket ABI reports a
 // failed `connect`/`listen`/`accept` as a HANDLE whose `err_kind` is
 // set — not as a null — because the caller closes it either way. This
 // is what the shims hand back on those paths.
+//
+// It IGNORES the ceiling, and has to: the ceiling's whole purpose is to
+// turn "the machine ran out" into an error the caller receives, and an
+// error that cannot be allocated is not an error the caller receives.
+// These handles are transient — every caller closes one immediately —
+// so the exemption is bounded by the number of failures in flight.
 @ sock_err_fd * SockTab st i err → i {
-    : i fd ( __alloc_fd st )
+    : i fd ( __alloc_fd_unbounded st )
     : *Sock s ( __sock st fd )
     = . s err err
     ^ fd
@@ -486,6 +532,10 @@ $ `stdlib/net/tcpstack.nu`
     } {}
     : i lidx ( tstack_listen . st ts ip p backlog )
     ? < lidx 0 { ^ ( sock_err_fd st ( sock_err_bind ) ) } {}
+    ? ! ( sock_can_open st ) {
+        ( tstack_listener_close . st ts lidx )
+        ^ ( sock_err_fd st ( sock_err_other ) )
+    } {}
     : i fd ( __alloc_fd st )
     : *Sock s ( __sock st fd )
     = . s kind ( sock_kind_listener )
@@ -507,6 +557,21 @@ $ `stdlib/net/tcpstack.nu`
         ^ - 0 ( sock_err_accept )
     } {}
     ? . l shut {
+        = . l err ( sock_err_accept )
+        ^ - 0 ( sock_err_accept )
+    } {}
+    // The ceiling is checked BEFORE the connection is dequeued. Taking
+    // it out of the backlog and then finding nowhere to put it would
+    // leave an established connection nobody holds an fd for — the peer
+    // thinks it is connected and nothing will ever read it. Left in the
+    // backlog it is simply not accepted yet, which is a state TCP and
+    // every accept loop already understand.
+    //
+    // The error is `accept`, not `again`: `again` means "ask me later"
+    // and a listener with a pending connection stays readable, so a
+    // reactor would hand the loop straight back and spin. A hard error
+    // stops that, and the connection is still there when an fd frees.
+    ? ! ( sock_can_open st ) {
         = . l err ( sock_err_accept )
         ^ - 0 ( sock_err_accept )
     } {}
@@ -558,6 +623,7 @@ $ `stdlib/net/tcpstack.nu`
     ? && != port 0 ( __port_taken_kind st ( sock_kind_udp ) p ) {
         ^ ( sock_err_fd st ( sock_err_addr_in_use ) )
     } {}
+    ? ! ( sock_can_open st ) { ^ ( sock_err_fd st ( sock_err_other ) ) } {}
     : i fd ( __alloc_fd st )
     : *Sock s ( __sock st fd )
     : *UdpBox b # *UdpBox ( nurl_alloc Z UdpBox )
@@ -716,6 +782,10 @@ $ `stdlib/net/tcpstack.nu`
 // an error: TCP's own retransmit timer sends it.
 @ sock_connect * SockTab st i ip i port i local_port i now → i {
     ? || <= port 0 > port 65535 { ^ ( sock_err_fd st ( sock_err_other ) ) } {}
+    // Before the connection exists, not after: a SYN sent for a socket
+    // that cannot be created is a connection the peer accepts and this
+    // machine has forgotten about.
+    ? ! ( sock_can_open st ) { ^ ( sock_err_fd st ( sock_err_other ) ) } {}
     : i cidx ( tstack_connect . st ts ip port local_port now . st out )
     ? < cidx 0 { ^ ( sock_err_fd st ( sock_err_other ) ) } {}
     : i fd ( __alloc_fd st )

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -278,7 +278,7 @@ on somebody's Firecracker host.
 | MTU | 1500. Frames are refused above 2036 bytes rather than truncated |
 | IP fragments | dropped, counted, never reassembled. A datagram over the MTU does not arrive |
 | open files | 16, from the baked-in archive, read-only |
-| sockets | the fd table in `stdlib/net/socket.nu`; ephemeral ports are per-protocol, TCP and UDP have separate spaces |
+| sockets | 1024 open at once (`sock_set_max_fds` to change it); past that `accept` refuses and leaves the connection in the backlog rather than the machine running out. Ephemeral ports are per-protocol; TCP and UDP have separate spaces |
 | name resolution | literals and `localhost`. Anything else is refused, not guessed |
 | processes, signals | none. `fork`/`exec` report unsupported; there is one address space and nothing to fork |
 | GPU | none in a microVM; a swarm node advertises CPU-wasm capability only |


### PR DESCRIPTION
`__alloc_fd` grew the socket table for every socket and never said no.

On a hosted target the kernel does that job — past `RLIMIT_NOFILE`,
`accept` answers EMFILE and the server keeps serving what it already
has. But `stdlib/net/socket.nu` **is** the fd table for a machine with
no kernel under it, so a peer that opens ten thousand connections
against a 256 MiB guest did not get refused: it got the machine.

There is now a ceiling — 1024 by default, because that is the number a
POSIX programmer expects — and `sock_set_max_fds` for a machine that
knows its own size (0 = no ceiling).

## Where it is checked is the point

`sock_accept` asks **before** dequeuing a pending connection. Taking one
out of the backlog and then finding nowhere to put it would leave an
established connection nobody holds an fd for: the peer believes it is
connected and nothing will ever read it. Left where it is, it is simply
not accepted yet — a state TCP and every accept loop already understand
— and it is still there when an fd frees.

`sock_connect` likewise asks before the SYN goes out (a connection the
peer accepts and this machine has forgotten about is the same bug from
the other end), and `sock_listen` releases the listener it just created
rather than leaking it into the stack.

## Why `accept` and not `again`

`again` means "ask me later", and a listener with a pending connection
stays readable — so a reactor would hand the loop straight back and
spin. That is the livelock shape this stack has been bitten by before. A
hard error stops it, and nothing is lost: the connection is still
pending.

`sock_err_fd` is exempt from the ceiling, and has to be. The ceiling
exists to turn "the machine ran out" into an error the caller receives,
and an error that cannot be allocated is not an error the caller
receives. Those handles are transient — every caller closes one at once.

## Tested

`net_socket` asserts the refusal, that the pending connection survives
it, that no established connection is orphaned, that the same connection
accepts once there is room, and that a ceiling of zero means none.

Mutation-validated:

| injected bug | result |
|---|---|
| the ceiling is never checked | 3 assertions fail |
| accept dequeues first, refuses after | the 2 assertions it exists for fail |

```
compiler corpus       612 PASS  0 FAIL
corpus with no libc   451 PASS  0 FAIL
QEMU guest            19/19
net_socket            leak-clean under LSan
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1