### PR TITLE
A machine can talk to itself, and a sleeping main does not stop it

### DIFF
--- a/compiler/tests/net_stack.nu
+++ b/compiler/tests/net_stack.nu
@@ -54,7 +54,7 @@ $ `stdlib/net/stack.nu`
 
     // ── A sends UDP to B: ARP must resolve first ─────────────────
     : *PktBuf w1 ( pktbuf_new )
-    : TxResult t1 ( stack_tx_udp a ( ip_b ) 4000 7000 payload 0 15 1000 w1 )
+    : TxResult t1 ( stack_tx_udp a 0 ( ip_b ) 4000 7000 payload 0 15 1000 w1 )
     ( pb `first send is ARP-pending: ` == . t1 status ( tx_arp_pending ) )
     ( pb `an ARP request was emitted: ` > . t1 emitted 0 )
     ( pb `one frame out, and it is the 42-byte ARP request: ` && == ( pktbuf_count w1 ) 1 == ( pktbuf_len w1 0 ) 42 )
@@ -75,7 +75,7 @@ $ `stdlib/net/stack.nu`
 
     // ── retry: now the datagram actually goes out ────────────────
     : *PktBuf w4 ( pktbuf_new )
-    : TxResult t2 ( stack_tx_udp a ( ip_b ) 4000 7000 payload 0 15 1000 w4 )
+    : TxResult t2 ( stack_tx_udp a 0 ( ip_b ) 4000 7000 payload 0 15 1000 w4 )
     ( pb `retry sends for real: ` == . t2 status ( tx_sent ) )
     // 14 eth + 20 ip + 8 udp + 15 payload = 57
     ( pb `frame is 57 bytes: ` && == ( pktbuf_count w4 ) 1 == ( pktbuf_len w4 0 ) 57 )
@@ -100,7 +100,7 @@ $ `stdlib/net/stack.nu`
 
     // ── B replies to A: no ARP needed, B already learned A ───────
     : *PktBuf w6 ( pktbuf_new )
-    : TxResult t3 ( stack_tx_udp b ( ip_a ) 7000 4000 payload 0 15 1100 w6 )
+    : TxResult t3 ( stack_tx_udp b 0 ( ip_a ) 7000 4000 payload 0 15 1100 w6 )
     ( pb `reply needs no new ARP: ` == . t3 status ( tx_sent ) )
     : *PktBuf w7 ( pktbuf_new )
     : RxResult r4 ( deliver a . w6 bytes 1100 w7 )
@@ -146,7 +146,7 @@ $ `stdlib/net/stack.nu`
 
     // ── routing: an off-link destination goes via the gateway ────
     : *PktBuf w8 ( pktbuf_new )
-    : TxResult t4 ( stack_tx_udp a ( ipv4_make 8 8 8 8 ) 4000 53 payload 0 15 2000 w8 )
+    : TxResult t4 ( stack_tx_udp a 0 ( ipv4_make 8 8 8 8 ) 4000 53 payload 0 15 2000 w8 )
     ( pb `off-link send is ARP-pending: ` == . t4 status ( tx_arp_pending ) )
     : EthHdr geh ( eth_parse . w8 bytes )
     : ArpPkt gap ( arp_parse . w8 bytes . geh payload_off . geh payload_len )
@@ -157,7 +157,7 @@ $ `stdlib/net/stack.nu`
     // MAC but 8.8.8.8 still in the IP header.
     ( arp_cache_insert . a arp ( ip_gw ) ( mac_gw ) 2000 )
     : *PktBuf w9 ( pktbuf_new )
-    : TxResult t5 ( stack_tx_udp a ( ipv4_make 8 8 8 8 ) 4000 53 payload 0 15 2000 w9 )
+    : TxResult t5 ( stack_tx_udp a 0 ( ipv4_make 8 8 8 8 ) 4000 53 payload 0 15 2000 w9 )
     ( pb `off-link send now succeeds: ` == . t5 status ( tx_sent ) )
     : EthHdr feh ( eth_parse . w9 bytes )
     ( pb `ethernet dst is the gateway MAC: ` == . feh dst ( mac_gw ) )
@@ -166,11 +166,11 @@ $ `stdlib/net/stack.nu`
 
     // ── unreachable: ARP gives up rather than queueing forever ───
     : *PktBuf w10 ( pktbuf_new )
-    : TxResult u1 ( stack_tx_udp a ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 3000 w10 )
+    : TxResult u1 ( stack_tx_udp a 0 ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 3000 w10 )
     ( pb `unknown host: first attempt ARPs: ` == . u1 status ( tx_arp_pending ) )
-    : TxResult u2 ( stack_tx_udp a ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 4100 w10 )
-    : TxResult u3 ( stack_tx_udp a ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 5200 w10 )
-    : TxResult u4 ( stack_tx_udp a ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 6300 w10 )
+    : TxResult u2 ( stack_tx_udp a 0 ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 4100 w10 )
+    : TxResult u3 ( stack_tx_udp a 0 ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 5200 w10 )
+    : TxResult u4 ( stack_tx_udp a 0 ( ipv4_make 10 0 2 99 ) 4000 9 payload 0 15 6300 w10 )
     ( pb `after max retries: unreachable: ` == . u4 status ( tx_unreachable ) )
 
     // ── drop accounting ─────────────────────────────────────────
@@ -217,7 +217,7 @@ $ `stdlib/net/stack.nu`
     // ── addressless stack (pre-DHCP) ────────────────────────────
     : *NetStack c ( stack_new ( mac_gw ) 0 0 0 )
     : *PktBuf w11 ( pktbuf_new )
-    : TxResult t6 ( stack_tx_udp c ( ip_a ) 68 67 payload 0 15 100 w11 )
+    : TxResult t6 ( stack_tx_udp c 0 ( ip_a ) 68 67 payload 0 15 100 w11 )
     ( pb `no address → tx refused: ` == . t6 status ( tx_no_address ) )
     // …but a broadcast datagram from 0.0.0.0 still goes out: that is
     // exactly the shape DHCP DISCOVER needs.

--- a/compiler/tests/outputs/sleep_in_main.txt
+++ b/compiler/tests/outputs/sleep_in_main.txt
@@ -1,0 +1,5 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+the server ran while main slept: YES

--- a/compiler/tests/sleep_in_main.nu
+++ b/compiler/tests/sleep_in_main.nu
@@ -1,0 +1,59 @@
+// sleep_in_main.nu — a sleep in the main context must not stop the world.
+//
+// On a cooperative runtime — the freestanding one, where every "thread"
+// is a coroutine on one vCPU — `sleep_ms` in main used to be a plain
+// nanosleep. That is not a wait, it is a freeze: the server this program
+// spawns never ran, never bound its port, and the connect below was
+// refused by a machine that was merely asleep.
+//
+// The shape is ordinary enough to be a habit: spawn a worker, give it a
+// moment, then talk to it.
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+
+@ serve → v {
+    ?? ( tcp_listen `127.0.0.1` 19701 ) {
+        F _e → ( nurl_print `listen failed\n` )
+        T l → {
+            ?? ( tcp_accept l ) {
+                F _e → ( nurl_print `accept failed\n` )
+                T c → {
+                    : !v NetErr w ( tcp_write_str c `pong` )
+                    ?? w { T _ → {} F _e → {} }
+                    ( tcp_close_conn c )
+                }
+            }
+            ( tcp_close_listener l )
+        }
+    }
+}
+
+@ main → i {
+    : !Thread ThreadErr t ( thread_spawn \ → v { ( serve ) } )
+    // The server has not run yet; this sleep is its only chance to.
+    ( sleep_ms 200 )
+    ?? ( tcp_connect `127.0.0.1` 19701 ) {
+        F e → {
+            ( nurl_print `connect failed: ` )
+            ( nurl_print ( net_err_name e ) )
+            ( nurl_print `\n` )
+        }
+        T c → {
+            ?? ( tcp_read_chunk c 16 ) {
+                T got → {
+                    ( nurl_print `the server ran while main slept: ` )
+                    ( nurl_print ? == ( vec_len [u] got ) 4 `YES\n` `NO\n` )
+                    ( vec_free [u] got )
+                }
+                F _e → ( nurl_print `read failed\n` )
+            }
+            ( tcp_close_conn c )
+        }
+    }
+    ?? t { T th → { : i _j ( thread_join th ) } F _e → {} }
+    ^ 0
+}

--- a/stdlib/net/socket.nu
+++ b/stdlib/net/socket.nu
@@ -680,7 +680,9 @@ $ `stdlib/net/tcpstack.nu`
         = . s err ( sock_err_closed )
         ^ - 0 ( sock_err_closed )
     } {}
-    : TxResult t ( stack_tx_udp . . st ts net ip . s local_port port src off len now . st out )
+    // A socket bound to loopback sends FROM loopback; an unbound one
+    // passes 0 and gets the interface's address.
+    : TxResult t ( stack_tx_udp . . st ts net . s local_ip ip . s local_port port src off len now . st out )
     ? == . t status ( tx_sent ) {
         = . s err 0
         ^ len

--- a/stdlib/net/stack.nu
+++ b/stdlib/net/stack.nu
@@ -243,7 +243,9 @@ $ `stdlib/net/pktbuf.nu`
     : ( Vec u ) msg ( vec_new [u] )
     ( icmp_push_echo_reply msg im frame )
     ( eth_push_header . out bytes . ( eth_parse frame ) src . st our_mac ( ethertype_ipv4 ) )
-    ( ip4_push_header . out bytes . st our_ip . ih src ( ip_proto_icmp ) ( vec_len [u] msg ) ( __next_id st ) 64 T )
+    // From the address it was sent TO — a ping to 127.0.0.1 is answered
+    // by 127.0.0.1, not by whatever DHCP handed the interface.
+    ( ip4_push_header . out bytes . ih dst . ih src ( ip_proto_icmp ) ( vec_len [u] msg ) ( __next_id st ) 64 T )
     ( vec_extend [u] . out bytes msg )
     ( vec_free [u] msg )
     ( pktbuf_mark out )
@@ -327,8 +329,20 @@ $ `stdlib/net/pktbuf.nu`
 // retry is the caller's to schedule — which for TCP is free, because a
 // segment that did not go out is exactly what its retransmit timer is
 // already for.
-@ stack_tx_ip4 * NetStack st i dst_ip i proto ( Vec u ) dg i dg_off i dg_len i now * PktBuf out → TxResult {
-    ? == . st our_ip 0 { ^ @ TxResult { ( tx_no_address ) 0 } } {}
+//
+// `src_ip` is the address the datagram is sent FROM, and it is a
+// parameter rather than always `our_ip` because a machine has more than
+// one address. A reply to something addressed to 127.0.0.1 must come
+// FROM 127.0.0.1: the sender checksummed it over that pseudo-header, so
+// a datagram that says otherwise is a datagram the receiver computes a
+// different checksum for and silently discards as corrupt. That is
+// exactly what happened — a guest with an interface address could not
+// talk to itself over loopback at all, and nothing anywhere reported a
+// drop, because a TCP segment failing its checksum is not a frame-level
+// drop. Zero means "whatever this interface's address is".
+@ stack_tx_ip4 * NetStack st i src_ip i dst_ip i proto ( Vec u ) dg i dg_off i dg_len i now * PktBuf out → TxResult {
+    : i src ? != src_ip 0 src_ip . st our_ip
+    ? == src 0 { ^ @ TxResult { ( tx_no_address ) 0 } } {}
     : i hop ( __next_hop st dst_ip )
     : ~ i dst_mac 0
     ? || ( ipv4_is_broadcast hop ) ( ipv4_is_multicast hop ) {
@@ -350,17 +364,21 @@ $ `stdlib/net/pktbuf.nu`
     } {}
     : i before ( pktbuf_total out )
     ( eth_push_header . out bytes dst_mac . st our_mac ( ethertype_ipv4 ) )
-    ( ip4_push_header . out bytes . st our_ip dst_ip proto dg_len ( __next_id st ) 64 T )
+    ( ip4_push_header . out bytes src dst_ip proto dg_len ( __next_id st ) 64 T )
     ( vec_extend_range [u] . out bytes dg dg_off dg_len )
     ( pktbuf_mark out )
     = . st tx_frames + . st tx_frames 1
     ^ @ TxResult { ( tx_sent ) - ( pktbuf_total out ) before }
 }
 
-@ stack_tx_udp * NetStack st i dst_ip i src_port i dst_port ( Vec u ) payload i pay_off i pay_len i now * PktBuf out → TxResult {
+// `src_ip` as above: zero means this interface's address, and a socket
+// bound to loopback passes 127.0.0.1 so its datagrams checksum the way
+// their receiver — itself — expects.
+@ stack_tx_udp * NetStack st i src_ip i dst_ip i src_port i dst_port ( Vec u ) payload i pay_off i pay_len i now * PktBuf out → TxResult {
+    : i src ? != src_ip 0 src_ip . st our_ip
     : ( Vec u ) dg ( vec_new [u] )
-    ( udp4_push dg . st our_ip dst_ip src_port dst_port payload pay_off pay_len )
-    : TxResult r ( stack_tx_ip4 st dst_ip ( ip_proto_udp ) dg 0 ( vec_len [u] dg ) now out )
+    ( udp4_push dg src dst_ip src_port dst_port payload pay_off pay_len )
+    : TxResult r ( stack_tx_ip4 st src dst_ip ( ip_proto_udp ) dg 0 ( vec_len [u] dg ) now out )
     ( vec_free [u] dg )
     ^ r
 }

--- a/stdlib/net/tcpstack.nu
+++ b/stdlib/net/tcpstack.nu
@@ -331,7 +331,12 @@ $ `stdlib/net/stack.nu`
         : i n ( pktbuf_len o k )
         // Straight from the PktBuf buffer — no temporary Vec, because
         // the segment is already sitting there as a range.
-        : TxResult r ( stack_tx_ip4 . ts net . c remote_ip ( ip_proto_tcp ) . o bytes s n now out )
+        // FROM the address this connection was checksummed with. A
+        // connection to 127.0.0.1 is sourced from 127.0.0.1 even on a
+        // machine whose interface has an address of its own; sending it
+        // from the interface's address instead makes the pseudo-header
+        // disagree with the receiver's and the segment vanishes.
+        : TxResult r ( stack_tx_ip4 . ts net . c local_ip . c remote_ip ( ip_proto_tcp ) . o bytes s n now out )
         = emitted + emitted . r emitted
         = k + k 1
     }
@@ -385,7 +390,10 @@ $ `stdlib/net/stack.nu`
         ( seq_add . s seq ( tcpseg_seq_len s ) ) 20 0 0 -1 empty 0 0 )
     }
     ( vec_free [u] empty )
-    : TxResult r ( stack_tx_ip4 . ts net src_ip ( ip_proto_tcp ) dg 0 ( vec_len [u] dg ) now out )
+    // The refusal comes from the address the offending segment was sent
+    // TO — including 127.0.0.1, whose RST must not claim to come from
+    // the interface.
+    : TxResult r ( stack_tx_ip4 . ts net dst_ip src_ip ( ip_proto_tcp ) dg 0 ( vec_len [u] dg ) now out )
     ( vec_free [u] dg )
     ^ . r emitted
 }

--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -3579,6 +3579,15 @@ void      nurl_runtime_shutdown(void) {}
 
 long long nurl_reactor_wait_read(long long fd, long long timeout_ms);
 long long nurl_reactor_wait_write(long long fd, long long timeout_ms);
+/* Does this runtime multiplex everything onto the caller's thread?
+ * Here: no. There is an operating system underneath and the fibers ride
+ * real threads, so a thread that blocks blocks only itself. The
+ * freestanding twin (unikernel/runtime_bare.c) answers 1, and
+ * `std/time.nu`'s `sleep_ms` is the caller that needs to know: a plain
+ * sleep in the main context is harmless here and stops the whole
+ * machine there. */
+long long nurl_runtime_is_cooperative(void) { return 0; }
+
 long long nurl_fiber_sleep_ms(long long ms);
 
 /* The reactor is built on the fiber primitives, so it lives or dies with

--- a/stdlib/std/time.nu
+++ b/stdlib/std/time.nu
@@ -74,6 +74,13 @@ $ `stdlib/std/async_ffi.nu`
 
 & `c` @ nanosleep *u req *u rem → i32
 
+// Does this runtime multiplex EVERYTHING onto the calling thread? 1 on
+// the freestanding runtime, where "threads" are coroutines on one vCPU;
+// 0 wherever the operating system schedules for us. It is the only
+// question `sleep_ms` needs to answer below, and only the runtime can
+// answer it.
+& `c` @ nurl_runtime_is_cooperative → i
+
 @ now_ms → i {
     : s ts ( nurl_zalloc 16 )
     : i32 rc ( clock_gettime # i32 ( posix_const `CLOCK_REALTIME` ) # *u ts )
@@ -140,13 +147,27 @@ $ `stdlib/std/async_ffi.nu`
 // WASI / Windows where the fiber runtime is stubbed), falls back to
 // `nanosleep`-style blocking. The dispatch is invisible to the
 // caller — same name, same signature, same observable wait time.
+//
+// THE MAIN CONTEXT ON A COOPERATIVE RUNTIME IS THE THIRD CASE, and it
+// used to take the second one. There, "threads" are coroutines on one
+// vCPU, so a `nanosleep` in main does not merely wait — it stops every
+// other coroutine for the duration. Measured, on the freestanding
+// runtime: a program that spawns a server thread, sleeps 500 ms in main
+// and then connects gets its connection REFUSED, because the server
+// never ran and never bound. The runtime's own fiber sleep already
+// handles the main context correctly (it runs whatever is runnable
+// while the clock catches up); it was simply never reached from there.
 @ sleep_ms i ms → v {
     : i fcur ( nurl_fiber_current )
     ? != fcur 0 {
         : i unused ( nurl_fiber_sleep_ms ms )
-    } {
-        ( __sleep_ms_blocking ms )
-    }
+        ^
+    } {}
+    ? != ( nurl_runtime_is_cooperative ) 0 {
+        : i unused2 ( nurl_fiber_sleep_ms ms )
+        ^
+    } {}
+    ( __sleep_ms_blocking ms )
 }
 
 @ elapsed_ms_since i t0 → i {

--- a/unikernel/boot/initfs.c
+++ b/unikernel/boot/initfs.c
@@ -199,6 +199,17 @@ const unsigned char *fs_map_fd(int fd, fs_size_t off) {
     return f->data + off;
 }
 
+/* Is this path a file in the image? `access(2)` is how a program asks —
+ * `std/fs.nu`'s `file_exists` is exactly that call — and answering "no"
+ * for a file the image demonstrably contains is the kind of stub that
+ * becomes somebody's bug report: swarm-mcp asked whether its baked-in
+ * certificate was there, was told no, and tried to generate one onto a
+ * read-only filesystem. */
+int fs_exists(const char *path) {
+    fs_size_t size = 0;
+    return fs_lookup(path, &size) != 0;
+}
+
 /* Does the image contain anything at all? The boot banner uses it, and
  * so does the decision not to look for a certificate that cannot be
  * there. */

--- a/unikernel/boot/nosys.c
+++ b/unikernel/boot/nosys.c
@@ -1,0 +1,114 @@
+/*
+ * NURL unikernel — unikernel/boot/nosys.c
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * The calls this machine does not have, said out loud.
+ *
+ * A unikernel is ONE program in ONE address space: there is nothing to
+ * fork, nothing to exec, no signals to deliver and no writable
+ * filesystem to make a temporary file in. The plan lists all of that
+ * under non-goals and the whole directory agrees with it.
+ *
+ * But "the machine has no processes" and "a program that mentions
+ * processes cannot be built for it" are different statements, and only
+ * the first one is true. A real program — swarm-mcp is the case that
+ * forced this file — is a compute node that also knows how to compile a
+ * kernel by running the toolchain. Nothing about the node needs a
+ * subprocess; one leaf of one feature does. Without these symbols the
+ * whole image fails to LINK, and the answer "then port fork to a
+ * unikernel" is the wrong one.
+ *
+ * So each of these refuses the way its callers already handle:
+ *
+ *   pipe/fork/execvp/waitpid/dup2/fcntl/poll   -1, which is what
+ *       std/process.nu's POSIX path checks first — a failed `pipe` is
+ *       reported as ProcessIo before a fork is ever attempted.
+ *   nurl_proc_run                              a zero handle, which
+ *       std/process.nu maps to ProcessOther (its `raw == 0` branch).
+ *   signal                                     SIG_ERR.
+ *   mkstemp/rename/rmdir                       -1: the filesystem is
+ *       the tar inside the image and it is read-only, which `unlink`
+ *       and `mkdir` in platform_x86.c already answer the same way.
+ *
+ * NONE of them succeeds while doing nothing. That is the rule this
+ * directory is built on, and it is what makes the failure a caller's
+ * ordinary error path instead of a mystery: swarm-mcp asked to build a
+ * wasm kernel in the guest reports that it could not run the compiler,
+ * which is exactly what happened.
+ *
+ * LINKED ONLY INTO GUEST IMAGES (build_unikernel.sh), never into the
+ * Linux -nostdlib build. That build's corpus runner buckets a test by
+ * the symbols it cannot resolve, so defining these there would turn 21
+ * honest NEEDS-BARE results — processes and signals, which that build
+ * genuinely does not have either — into 21 failures.
+ */
+
+typedef unsigned long ns_size_t;
+
+extern int nl_errno_slot;
+
+#define NS_ENOSYS 38
+#define NS_EROFS  30
+
+static int ns_refuse(int err) { nl_errno_slot = err; return -1; }
+
+/* ── processes ───────────────────────────────────────────────── */
+
+int pipe(int fds[2]) {
+    /* The fds are left untouched: std/process.nu reads them only after
+     * a non-negative return, and writing -1 into a caller's array on
+     * the failure path is one more thing to get wrong. */
+    (void)fds;
+    return ns_refuse(NS_ENOSYS);
+}
+
+int fork(void)                          { return ns_refuse(NS_ENOSYS); }
+int execvp(const char *f, char *const a[]) { (void)f; (void)a; return ns_refuse(NS_ENOSYS); }
+int waitpid(int pid, int *st, int opt)  { (void)pid; (void)st; (void)opt; return ns_refuse(NS_ENOSYS); }
+int dup2(int a, int b)                  { (void)a; (void)b; return ns_refuse(NS_ENOSYS); }
+int fcntl(int fd, int cmd, long arg)    { (void)fd; (void)cmd; (void)arg; return ns_refuse(NS_ENOSYS); }
+
+/* poll over pipes to a child. The guest's own readiness lives in
+ * unikernel/net/sockets.nu and never comes through here. */
+int poll(void *fds, unsigned long n, int timeout_ms) {
+    (void)fds; (void)n; (void)timeout_ms;
+    return ns_refuse(NS_ENOSYS);
+}
+
+/* SIG_ERR is (void*)-1 — "this signal could not be handled", which is
+ * the honest answer on a machine that delivers none. */
+void *signal(int signum, void *handler) {
+    (void)signum; (void)handler;
+    nl_errno_slot = NS_ENOSYS;
+    return (void *)-1;
+}
+
+int kill(int pid, int sig)   { (void)pid; (void)sig; return ns_refuse(NS_ENOSYS); }
+
+/* ── the runtime's process API ───────────────────────────────── */
+
+/* Zero, not a result block with an error in it: std/process.nu's
+ * `__process_dispatch` has a `raw == 0` branch that answers
+ * ProcessOther, so this needs no allocation on a path that exists
+ * because something already went wrong. */
+long long nurl_proc_run(const char *cmd, const char *argv_buf,
+                        long long argc, const char *stdin_blob) {
+    (void)cmd; (void)argv_buf; (void)argc; (void)stdin_blob;
+    return 0;
+}
+
+long long nurl_proc_exit_code(long long h) { (void)h; return -1; }
+long long nurl_proc_err_kind(long long h)  { (void)h; return 4; }  /* OTHER */
+const char *nurl_proc_stdout(long long h)  { (void)h; return ""; }
+const char *nurl_proc_stderr(long long h)  { (void)h; return ""; }
+long long nurl_proc_stdout_len(long long h) { (void)h; return 0; }
+long long nurl_proc_stderr_len(long long h) { (void)h; return 0; }
+void nurl_proc_free(long long h)           { (void)h; }
+
+/* ── writing to a filesystem that is inside the executable ───── */
+
+int mkstemp(char *tmpl)                     { (void)tmpl; return ns_refuse(NS_EROFS); }
+int rename(const char *a, const char *b)    { (void)a; (void)b; return ns_refuse(NS_EROFS); }
+int rmdir(const char *p)                    { (void)p; return ns_refuse(NS_EROFS); }

--- a/unikernel/boot/platform_x86.c
+++ b/unikernel/boot/platform_x86.c
@@ -44,6 +44,14 @@ long long lseek(int fd, long long off, int whence);
 void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off);
 int munmap(void *p, unsigned long len);
 
+/* The two things this file needs from nolibc's stdio: the stream and
+ * the flag that makes a console behave like one. Declared rather than
+ * included, the way the rest of this file declares what it uses. */
+struct nl_file;
+extern struct nl_file *stdout;
+int *nl_file_flags(struct nl_file *f);
+#define PF_F_LINEBUF 0x20
+
 typedef unsigned long      pf_size_t;
 typedef long               pf_ssize_t;
 typedef unsigned long long u64;
@@ -379,6 +387,7 @@ pf_ssize_t fs_read_fd(int fd, void *buf, pf_size_t n);
 long long fs_lseek_fd(int fd, long long off, int whence);
 int fs_close_fd(int fd);
 const unsigned char *fs_map_fd(int fd, unsigned long off);
+int fs_exists(const char *path);
 
 void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off) {
     (void)addr; (void)prot; (void)flags;
@@ -778,7 +787,23 @@ long nl_ret(long r) {
     return r;
 }
 int mkdir(const char *p, int mode) { (void)p; (void)mode; return -1; }
-int access(const char *p, int mode) { (void)p; (void)mode; return -1; }
+
+/* access(2), against the filesystem this machine actually has. F_OK (0)
+ * and R_OK (4) are answerable — the image either contains the file or it
+ * does not — and W_OK (2) and X_OK (1) are refused, because the archive
+ * lives in the text segment and nothing in it is writable or runnable.
+ *
+ * The version that refused everything was worse than useless: a program
+ * that checks `file_exists` before reading its certificate was told the
+ * certificate was not there, and went off to write a new one onto a
+ * read-only filesystem. A stub that lies about the machine's own
+ * contents produces exactly that shape of bug. */
+int access(const char *p, int mode) {
+    if (!p) return -1;
+    if (mode & 3) { nl_errno_slot = 13 /* EACCES */; return -1; }
+    if (!fs_exists(p)) { nl_errno_slot = 2 /* ENOENT */; return -1; }
+    return 0;
+}
 int getpid(void) { return 1; }
 
 /* ── shutdown ────────────────────────────────────────────────────── */
@@ -881,6 +906,19 @@ void kmain(unsigned long start_info_paddr) {
         (const struct hvm_start_info *)start_info_paddr;
 
     uart_init();
+    /* This machine's stdout is a SERIAL CONSOLE, so it is line
+     * buffered — the flag nolibc has always had and nothing ever set.
+     *
+     * Fully buffered was the wrong default here in the way that only
+     * shows up on the programs this target is for: a server does not
+     * exit, so it never flushes, so a guest that printed a startup
+     * banner and then spent an hour answering requests had printed
+     * NOTHING as far as anyone watching the console could tell. The
+     * first thing an operator does with an appliance is read its log.
+     * Guest only: the Linux -nostdlib build keeps libc's rule (a
+     * redirected stdout is fully buffered), which is what its goldens
+     * are written against. */
+    *nl_file_flags(stdout) |= PF_F_LINEBUF;
     /* Before anything that can fault, which is everything: an IDT
      * installed after the first mistake describes nothing. */
     tss_init();

--- a/unikernel/build_unikernel.sh
+++ b/unikernel/build_unikernel.sh
@@ -71,6 +71,7 @@ done
 $CC $KFLAGS -c "$BOOT/platform_x86.c" -o "$OUTDIR/platform.o"
 $CC $KFLAGS -c "$BOOT/initfs.c"       -o "$OUTDIR/boot_initfs.o"
 $CC $KFLAGS -c "$BOOT/pagealloc.c"    -o "$OUTDIR/boot_pagealloc.o"
+$CC $KFLAGS -c "$BOOT/nosys.c"        -o "$OUTDIR/boot_nosys.o"
 
 # The baked-in filesystem: a directory becomes a tar, and the tar
 # becomes an object with two symbols around it. With no --fs the
@@ -98,7 +99,8 @@ $CC -nostdlib -static -no-pie -Wl,-T,"$BOOT/link.ld" -Wl,--build-id=none \
     "$OUTDIR/boot.o" "$OUTDIR/$base.o" \
     "$OUTDIR/runtime_core.o" "$OUTDIR/runtime_ctx.o" "$OUTDIR/runtime_bare.o" \
     "$OUTDIR/platform.o" "$OUTDIR/tls_guest.o" \
-    "$OUTDIR/boot_initfs.o" "$OUTDIR/boot_pagealloc.o" "$OUTDIR/initfs_data.o" \
+    "$OUTDIR/boot_initfs.o" "$OUTDIR/boot_pagealloc.o" "$OUTDIR/boot_nosys.o" \
+    "$OUTDIR/initfs_data.o" \
     "$OUTDIR"/nl_*.o
 
 echo "built $OUT"

--- a/unikernel/demos/loopback.expected
+++ b/unikernel/demos/loopback.expected
@@ -1,0 +1,2 @@
+listening on 19700
+loopback round trip: YES

--- a/unikernel/demos/loopback.nu
+++ b/unikernel/demos/loopback.nu
@@ -1,0 +1,70 @@
+// unikernel/demos/loopback.nu — 127.0.0.1 on a machine that also has an
+// interface.
+//
+// Every other network demo here talks to the outside. This one talks to
+// itself while an interface is up, which is a different code path and
+// was a broken one: the stack had no way to say what address a datagram
+// was sent FROM, so a reply to something addressed to 127.0.0.1 went out
+// with the interface's address in its header. The receiver — the same
+// machine — then computed the TCP checksum over a different
+// pseudo-header, decided the segment was corrupt, and dropped it. No
+// counter moved; a connection to 127.0.0.1 simply never completed.
+//
+// It matters because that is how a node made of parts talks to itself: a
+// relay, a worker and a control endpoint in one program, meeting on
+// loopback. Nothing in the hosted corpus can catch it — a hosted program
+// uses the kernel's loopback — and nothing in the guest gate did either,
+// because every other demo has exactly one endpoint.
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/time.nu`
+
+@ serve → v {
+    ?? ( tcp_listen `0.0.0.0` 19700 ) {
+        F e → {
+            ( nurl_print `listen failed: ` ) ( nurl_print ( net_err_name e ) ) ( nurl_print `\n` )
+        }
+        T l → {
+            ( nurl_print `listening on 19700\n` )
+            ?? ( tcp_accept l ) {
+                F e → {
+                    ( nurl_print `accept failed: ` ) ( nurl_print ( net_err_name e ) ) ( nurl_print `\n` )
+                }
+                T c → {
+                    : !v NetErr w ( tcp_write_str c `pong` )
+                    ?? w { T _ → {} F _e → {} }
+                    ( tcp_close_conn c )
+                }
+            }
+            ( tcp_close_listener l )
+        }
+    }
+}
+
+@ main → i {
+    : !Thread ThreadErr t ( thread_spawn \ → v { ( serve ) } )
+    ( sleep_ms 300 )
+    ?? ( tcp_connect `127.0.0.1` 19700 ) {
+        F e → {
+            ( nurl_print `connect failed: ` ) ( nurl_print ( net_err_name e ) ) ( nurl_print `\n` )
+        }
+        T c → {
+            ?? ( tcp_read_chunk c 16 ) {
+                T got → {
+                    ( nurl_print `loopback round trip: ` )
+                    ( nurl_print ? == ( vec_len [u] got ) 4 `YES\n` `NO\n` )
+                    ( vec_free [u] got )
+                }
+                F e → {
+                    ( nurl_print `read failed: ` ) ( nurl_print ( net_err_name e ) ) ( nurl_print `\n` )
+                }
+            }
+            ( tcp_close_conn c )
+        }
+    }
+    ?? t { T th → { : i _j ( thread_join th ) } F _e → {} }
+    ^ 0
+}

--- a/unikernel/demos/netdev.nu
+++ b/unikernel/demos/netdev.nu
@@ -87,7 +87,7 @@ $ `unikernel/drivers/virtionet.nu`
     // whole path back.
     : ( Vec u ) payload ( vec_new [u] )
     ( bytes_extend_str payload `nurl` )
-    : TxResult t ( stack_tx_udp st ( gw_ip ) 4000 9 payload 0 4 ( ms ) out )
+    : TxResult t ( stack_tx_udp st 0 ( gw_ip ) 4000 9 payload 0 4 ( ms ) out )
     ( nurl_print `first send is ARP-pending: ` )
     ( nurl_print ? == . t status ( tx_arp_pending ) `yes` `no` )
     ( nurl_print `\n` )
@@ -107,7 +107,7 @@ $ `unikernel/drivers/virtionet.nu`
     // answers port 9 (discard), so what is asserted is that the send
     // path completed rather than that anything replied.
     ? resolved {
-        : TxResult t2 ( stack_tx_udp st ( gw_ip ) 4000 9 payload 0 4 ( ms ) out )
+        : TxResult t2 ( stack_tx_udp st 0 ( gw_ip ) 4000 9 payload 0 4 ( ms ) out )
         ( nurl_print `datagram sent: ` )
         ( nurl_print ? == . t2 status ( tx_sent ) `yes` `no` )
         ( nurl_print `\n` )

--- a/unikernel/net/sockets.nu
+++ b/unikernel/net/sockets.nu
@@ -91,6 +91,11 @@ $ `stdlib/net/socket.nu`
 
 & `c` @ nurl_fiber_unpark i handle → v
 
+// The device poller below is a coroutine like any other; spawning one
+// is the two halves of a closure handed to the runtime, exactly as
+// std/async.nu does it.
+& `c` @ nurl_fiber_spawn *u fn *u env → i
+
 : Shim {
     * NetStack net
     * TcpStack ts
@@ -152,7 +157,36 @@ $ `stdlib/net/socket.nu`
     // 0.0.0.0 checksums every segment against the wrong pseudo-header
     // and goes unanswered.
     ? != have 0 { ( __dhcp_configure sh ) } {}
+    ? != have 0 { ( __start_poller ) } {}
     ^ sh
+}
+
+// A device needs somebody to ask it. Every socket wait drives the
+// machine while it waits, which is enough for a program that is always
+// waiting for something — and not enough for a server whose every
+// coroutine is parked: then nobody is left to call `netdev_rx`, the run
+// queue is empty, no timer is armed, and the runtime correctly concludes
+// that nothing can ever happen and aborts. It is wrong only because the
+// world is bigger than this program, and the machine has an interface
+// the world can knock on.
+//
+// So the interface gets a coroutine of its own: drive, then sleep a
+// millisecond, forever. It costs one 68 KiB stack and a 1 kHz tick on a
+// machine that polls its driver anyway, and it exists ONLY when there is
+// a device — a loopback-only program keeps the deadlock detector's proof
+// intact, because for it "nothing runnable, no timer" really is the end.
+@ __poll_forever → v {
+    ~ T {
+        : i _m ( __drive ( __ms ) )
+        ( nurl_fiber_sleep_ms 1 )
+    }
+}
+
+@ __start_poller → v {
+    : ( @ v ) body \ → v { ( __poll_forever ) }
+    : *u fnp # *u body 0
+    : *u env # *u body 1
+    : i _f ( nurl_fiber_spawn fnp env )
 }
 
 // Run the DHCP client — the same state machine `net/dhcp.nu` covers

--- a/unikernel/nolibc/stdio.c
+++ b/unikernel/nolibc/stdio.c
@@ -31,6 +31,12 @@ static FILE nl_stdin  = { 0, NL_F_READ,  -1, 0, 0, { 0 } };
 static FILE nl_stdout = { 1, NL_F_WRITE, -1, 0, 0, { 0 } };
 static FILE nl_stderr = { 2, NL_F_WRITE | NL_F_UNBUF, -1, 0, 0, { 0 } };
 
+/* The flags word of a stream, for a caller that has no business seeing
+ * the struct. The unikernel's boot code uses it to say what only it
+ * knows: this machine's stdout is a serial console, so it is line
+ * buffered. */
+int *nl_file_flags(FILE *f) { return &f->flags; }
+
 FILE *stdin  = &nl_stdin;
 FILE *stdout = &nl_stdout;
 FILE *stderr = &nl_stderr;

--- a/unikernel/run_qemu_tests.sh
+++ b/unikernel/run_qemu_tests.sh
@@ -70,7 +70,7 @@ done
 # one that goes looking for devices.
 demos=0
 if [ $# -eq 0 ]; then
-    for demo in devices netdev dhcp; do
+    for demo in devices netdev dhcp loopback; do
         src="$ROOT/unikernel/demos/$demo.nu"
         exp="$ROOT/unikernel/demos/$demo.expected"
         [ -f "$src" ] && [ -f "$exp" ] || continue

--- a/unikernel/runtime_bare.c
+++ b/unikernel/runtime_bare.c
@@ -970,6 +970,15 @@ void nurl_fiber_join(long long h) {
  * exists in this file — see the header on why the fd half is a link
  * error rather than a stub. */
 
+/* Yes: one vCPU, no preemption, and every "thread" in this program is a
+ * coroutine on it. `std/time.nu` asks so that a sleep in the MAIN
+ * context routes to `nurl_fiber_sleep_ms` below — which runs whatever is
+ * runnable while the clock catches up — instead of a `nanosleep` that
+ * stops every coroutine for the duration. A program that spawned a
+ * server, slept in main and then connected to it found the port closed:
+ * the server had never run. */
+long long nurl_runtime_is_cooperative(void) { return 1; }
+
 long long nurl_fiber_sleep_ms(long long ms) {
     if (ms <= 0) { nurl_fiber_yield(); return 0; }
     long long deadline = nb_now_ms() + ms;


### PR DESCRIPTION
Five bugs, found by taking the **swarm-mcp** package — a real
distributed node, not a demo — and asking it to run as a unikernel
image. Three are in the language's own runtime and stdlib; none is
specific to the guest, and none was reachable by anything in the corpus.

## A sleep in the main context stopped the whole machine

On the freestanding runtime every "thread" is a coroutine on one vCPU,
so `sleep_ms` routing the non-fiber case to `nanosleep` was not a wait
but a freeze. Measured: a program that spawns a server thread, sleeps
500 ms in main and then connects is **refused** — the server never ran
and never bound. The runtime's own fiber sleep already handled the main
context correctly and was simply never reached from there.

Regression test `sleep_in_main`; revert the fix and it fails with
NetClosed and a deadlock abort.

## The stack could not say what address a datagram came FROM

Every reply went out with the interface's address — so a reply to
something addressed to `127.0.0.1` arrived at its own machine with a
pseudo-header the receiver disagreed with, failed its TCP checksum, and
was dropped as corrupt. **No counter moved.** A guest with an interface
could not talk to itself at all, which is exactly how a node made of
parts (a relay, a worker and a control endpoint in one program) meets
itself.

`stack_tx_ip4` / `stack_tx_udp` take a source address now: TCP passes
the connection's own `local_ip`, a RST answers from the address the
offending segment was sent to, an echo reply comes from the address that
was pinged. `demos/loopback.nu` gates it — no hosted test can, because a
hosted program's loopback belongs to the kernel.

## A machine with a device was declared deadlocked while waiting for the network

"Nothing runnable and no timer armed" proves nothing can happen only for
a program whose events all come from inside it. With an interface a
frame can arrive unprompted — and when every coroutine is parked, nobody
is left to poll the device either. The interface gets a coroutine of its
own: drive, sleep a millisecond, repeat. It exists only when a device
does, so a loopback-only program keeps the deadlock proof it depends on.

## `access()` lied about the machine's own contents

It refused everything, so `file_exists` reported that a certificate
baked into the image was not there, and the program went off to write a
new one onto a read-only filesystem. It now answers from the initfs.

## The guest console was fully buffered

A server does not exit, so it never flushed: a guest that printed a
banner and then served for an hour had printed nothing as far as the
console was concerned. nolibc has always had the line-buffered flag and
nothing ever set it; the boot code sets it now, because it is the one
place that knows this stdout is a serial console.

## `boot/nosys.c` — the calls this machine does not have

fork, execvp, waitpid, pipe, poll, signal, mkstemp, rename, rmdir and
the runtime's process API, each **refusing** the way its callers already
handle. A unikernel has no processes and never will — but "the machine
has no processes" and "a program that mentions them cannot be built for
it" are different statements, and only the first is true. swarm-mcp is a
compute node that also knows how to compile a kernel by running the
toolchain; one leaf of one feature needs a subprocess, and without these
symbols the whole image failed to link.

Guest images only: the Linux `-nostdlib` corpus buckets a test by the
symbols it cannot resolve, so defining them there would turn 21 honest
NEEDS-BARE results into 21 failures.

## Where swarm-mcp stands in the guest

It builds, boots, and **forms its cluster**:

```
swarm-mcp node starting — roles: relay worker mcp
  relay   listening 0.0.0.0:47700
  worker  x1 -> 1 relay(s), first 127.0.0.1:47700
  mcp     https://0.0.0.0:8443/  -> relay 127.0.0.1:47700
swarm-mcp worker 1287054180429065882 on relay 0 ready
relay: + peer cf397135
relay: + peer 47c1f009
```

The HTTPS control endpoint does not answer yet: the coordinator does not
get past `swarm_discover`'s relay pump to its `tcp_listen_tls`. That is
the next thing to chase, and it is one loop.

## Gates

```
compiler corpus       613 PASS  0 FAIL
corpus with no libc   452 PASS  0 FAIL
nolibc unit gates     19/19
QEMU guest            20/20   (loopback new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1