### PR TITLE
fix: a socket's timeout survives being read from a fiber

### DIFF
--- a/stdlib/ext/http2_client.nu
+++ b/stdlib/ext/http2_client.nu
@@ -189,10 +189,16 @@ $ `stdlib/ext/http2_hpack.nu`
 // Underlying socket fd, for readiness polling (nurl_reactor_wait_*).
 @ __h2c_fd H2Client c → i { ^ ( nurl_tcp_get_fd # i . . c tcp raw ) }
 
-// Non-blocking readiness probes. `nurl_reactor_wait_{read,write}` return
-// >= 0 when the fd is ready and < 0 on timeout; a 0 ms timeout makes them
-// pure polls. (Runtime builtins, also used by std/net.nu's async path.)
-@ __h2c_readable i fd → b { ^ >= ( nurl_reactor_wait_read fd 0 ) 0 }
+// Non-blocking readiness probe: a 0 ms timeout makes the reactor wait
+// a pure poll. (Runtime builtin, also used by std/net.nu's async path.)
+//
+// Readable is rc == 1 and NOTHING ELSE. The reactor's poll answers
+// 1 ready / 0 not ready / -1 "this caller cannot wait" (a non-fiber
+// on the hosted runtime, a provably-dead fd on the freestanding one).
+// The old `>= 0` read "not ready" as "readable", so the drain loop
+// entered a frame read with no frame coming — and a blocking read
+// taken on a hunch holds the connection for the whole socket timeout.
+@ __h2c_readable i fd → b { ^ == ( nurl_reactor_wait_read fd 0 ) 1 }
 
 @ __h2c_goaway H2Client c → i { ^ ( nurl_peek . c st 7 ) }
 

--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -754,6 +754,11 @@ typedef struct NurlTcp {
      * server_stop from another thread) defers the struct free until the
      * parked accept fiber has resumed and stopped touching the handle. */
     int           refcount;
+    /* What `nurl_tcp_set_timeout` was last told, in milliseconds (0 =
+     * none). The socket option is the authority for a BLOCKING read;
+     * this copy is for the fiber path, which cannot use SO_RCVTIMEO —
+     * it parks on the reactor instead, and has to be told how long. */
+    long long     timeout_ms;
 } NurlTcp;
 
 /* Wake the async reactor (if running) so it re-polls. Called after a fd is
@@ -1540,9 +1545,19 @@ char *nurl_tcp_local_addr(long long handle) {
     return out ? out : strdup("");
 }
 
+/* The deadline a read on this socket should honour, in ms; 0 = wait for
+ * ever. `std/net.nu`'s fiber path asks, because a parked fiber does not
+ * go through SO_RCVTIMEO and would otherwise wait for ever on a socket
+ * whose owner asked for 150 ms. */
+long long nurl_tcp_timeout_ms(long long handle) {
+    NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
+    return h ? h->timeout_ms : 0;
+}
+
 void nurl_tcp_set_timeout(long long handle, long long ms) {
     NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
     if (!h || h->fd == NURL_INVALID_SOCK) return;
+    h->timeout_ms = ms > 0 ? ms : 0;
 #ifdef _WIN32
     /* Win32 SO_RCVTIMEO is a DWORD of ms (not a timeval). */
     DWORD tv = (ms > 0) ? (DWORD)ms : 0;

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -739,6 +739,11 @@ $ `stdlib/std/async_ffi.nu`
 
 & `c` @ nurl_tcp_get_fd i handle → i
 
+// What a read/write on this socket should wait for, in milliseconds;
+// 0 = for ever. The fiber paths below need it because they park on the
+// reactor instead of on SO_RCVTIMEO — see `__wait_ms`.
+& `c` @ nurl_tcp_timeout_ms i handle → i
+
 & `c` @ nurl_tcp_set_nonblock i handle i on → v
 
 & `c` @ nurl_tcp_ref i handle → v
@@ -777,6 +782,15 @@ $ `stdlib/std/async_ffi.nu`
     ( nurl_tcp_set_nonblock raw on )
 }
 
+// The deadline to hand the reactor for this socket: what the caller set
+// with `tcp_set_timeout`, or −1 ("no deadline") when they set none. The
+// reactor spells "for ever" as −1 and 0 would mean "do not wait at all",
+// so the translation lives here rather than at four call sites.
+@ __wait_ms i raw → i {
+    : i ms ( nurl_tcp_timeout_ms raw )
+    ^ ? > ms 0 ms - 0 1
+}
+
 // Non-blocking accept. Loops: try accept; if NetTimeout (EAGAIN),
 // wait_readable on listener fd, retry. On non-fiber callers,
 // wait_readable returns -1 immediately and we fall back to the
@@ -797,11 +811,14 @@ $ `stdlib/std/async_ffi.nu`
         } {
             ( nurl_tcp_close craw )
             ? == ek 7 {  // NetTimeout / EAGAIN
-                : i rc ( nurl_reactor_wait_read fd - 0 1 )
+                : i rc ( nurl_reactor_wait_read fd ( __wait_ms lraw ) )
                 // wait_readable returns -1 outside a fiber; in that
                 // case the sync accept already blocked, so EAGAIN
-                // shouldn't recur — bail to NetAccept.
+                // shouldn't recur — bail to NetAccept. A listener with
+                // a timeout set reports one; without, it waits, which
+                // is what an accept loop is for.
                 ? < rc 0 { ^ @ !TcpConn NetErr { F # NetErr NetAccept } } {}
+                ? == rc 0 { ^ @ !TcpConn NetErr { F # NetErr NetTimeout } } {}
             } {
                 ^ @ !TcpConn NetErr { F ( _net_err_of ek ) }
             }
@@ -836,8 +853,20 @@ $ `stdlib/std/async_ffi.nu`
         } {}
         : i ek ( nurl_tcp_err_kind raw )
         ? == ek 7 {
-            : i rc ( nurl_reactor_wait_read fd - 0 1 )
+            // The socket's OWN deadline, not "for ever". A blocking read
+            // gets it from SO_RCVTIMEO; a parked fiber has to be told,
+            // and a hard-coded −1 here silently discarded every
+            // `tcp_set_timeout` the caller had made. It cost a
+            // distributed node its startup: a relay read that should
+            // have given up after 150 ms waited for a message that was
+            // never going to come, and only on a runtime where threads
+            // ARE fibers — which is why no hosted test saw it.
+            : i rc ( nurl_reactor_wait_read fd ( __wait_ms raw ) )
             ? < rc 0 {
+                ( vec_free [u] v )
+                ^ @ !( Vec u ) NetErr { F # NetErr NetTimeout }
+            } {}
+            ? == rc 0 {
                 ( vec_free [u] v )
                 ^ @ !( Vec u ) NetErr { F # NetErr NetTimeout }
             } {}
@@ -873,8 +902,8 @@ $ `stdlib/std/async_ffi.nu`
             ? < n 0 {
                 : i ek ( nurl_tcp_err_kind raw )
                 ? == ek 7 {
-                    : i rc ( nurl_reactor_wait_write fd - 0 1 )
-                    ? < rc 0 {
+                    : i rc ( nurl_reactor_wait_write fd ( __wait_ms raw ) )
+                    ? <= rc 0 {
                         ^ @ !v NetErr { F # NetErr NetTimeout }
                     } {}
                 } {
@@ -883,8 +912,8 @@ $ `stdlib/std/async_ffi.nu`
             } {
                 // n == 0 — kernel says "wrote nothing" without error.
                 // Treat as EAGAIN to avoid spinning.
-                : i rc ( nurl_reactor_wait_write fd - 0 1 )
-                ? < rc 0 { ^ @ !v NetErr { F # NetErr NetTimeout } } {}
+                : i rc ( nurl_reactor_wait_write fd ( __wait_ms raw ) )
+                ? <= rc 0 { ^ @ !v NetErr { F # NetErr NetTimeout } } {}
             }
         }
     }

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -811,14 +811,16 @@ $ `stdlib/std/async_ffi.nu`
         } {
             ( nurl_tcp_close craw )
             ? == ek 7 {  // NetTimeout / EAGAIN
-                : i rc ( nurl_reactor_wait_read fd ( __wait_ms lraw ) )
+                // ACCEPT KEEPS WAITING. `tcp_set_timeout` is about a
+                // CONNECTION's reads and writes; a listener has no such
+                // deadline, and a server loop reads "the accept ended"
+                // as "we were stopped" — report a timeout there and
+                // every clean shutdown becomes an error.
+                : i rc ( nurl_reactor_wait_read fd - 0 1 )
                 // wait_readable returns -1 outside a fiber; in that
                 // case the sync accept already blocked, so EAGAIN
-                // shouldn't recur — bail to NetAccept. A listener with
-                // a timeout set reports one; without, it waits, which
-                // is what an accept loop is for.
+                // shouldn't recur — bail to NetAccept.
                 ? < rc 0 { ^ @ !TcpConn NetErr { F # NetErr NetAccept } } {}
-                ? == rc 0 { ^ @ !TcpConn NetErr { F # NetErr NetTimeout } } {}
             } {
                 ^ @ !TcpConn NetErr { F ( _net_err_of ek ) }
             }

--- a/unikernel/net/sockets.nu
+++ b/unikernel/net/sockets.nu
@@ -395,8 +395,22 @@ $ `stdlib/net/socket.nu`
     ^ d
 }
 
-// Wait until `fd` is ready. 1 = ready, 0 = the deadline passed,
-// -1 = nothing can ever make it ready (see the header).
+// Wait until `fd` is ready. The REACTOR contract, same as the hosted
+// runtime_ffi.c reactor: timeout_ms > 0 is a deadline, timeout_ms < 0
+// waits for ever, and timeout_ms == 0 is a POLL — answer "is it ready
+// right now" and return without waiting. 1 = ready, 0 = the deadline
+// passed (or a poll found nothing), -1 = nothing can ever make it
+// ready (see the header).
+//
+// The zero case is load-bearing, not a degenerate deadline: callers
+// probe readiness with 0 to decide whether a read would block (the
+// HTTP/2 pump drains frames while `wait_read(fd, 0)` says yes). Before
+// it was distinguished, 0 fell into "no deadline" — and the probe
+// blocked. Nobody noticed while nothing else armed a timer: with the
+// machine fully idle the deadlock detector answered -1, which reads as
+// "not readable" and let the pump continue by accident. The moment a
+// peer's read parked WITH a deadline, the probe really waited — for the
+// peer's whole timeout — and both sides starved each other into it.
 //
 // On a coroutine this PARKS: it registers on the fd, and whoever moves
 // the stack wakes it. On the main context — which cannot park inside
@@ -404,6 +418,14 @@ $ `stdlib/net/socket.nu`
 // step that runs nothing, with no frames queued and no device, is the
 // end of the road for this wait.
 @ __wait i fd i for_write i timeout_ms → i {
+    ? == timeout_ms 0 {
+        // A poll still drives once: readiness on this machine only
+        // changes when someone moves the stack, so "right now" means
+        // "after delivering what is already queued".
+        ? ( __ready fd for_write ) { ^ 1 } {}
+        : i _m ( __drive ( __ms ) )
+        ^ ? ( __ready fd for_write ) 1 0
+    } {}
     : i start ( __ms )
     : i slot ( __waiter_add fd for_write )
     : ~ i rc -1
@@ -433,12 +455,19 @@ $ `stdlib/net/socket.nu`
     ^ rc
 }
 
+// A socket's timeout in `__wait`'s reactor vocabulary: `sock_timeout`
+// says 0 for "none set", which to a blocking socket means "wait for
+// ever" — the reactor spells that -1, and its 0 means "do not wait at
+// all". Translate here, once, so no caller hands the reactor a poll
+// when it meant a block.
+@ __block_ms i tmo → i { ^ ? > tmo 0 tmo - 0 1 }
+
 // The blocking/non-blocking decision, in one place. Returns 1 when the
 // caller should retry the operation, 0 when it should report `err`.
 @ __should_retry i fd i for_write → i {
     : *SockTab st ( __tab )
     ? ( sock_is_nonblock st fd ) { ^ 0 } {}
-    : i tmo ( sock_timeout st fd )
+    : i tmo ( __block_ms ( sock_timeout st fd ) )
     : i r ( __wait fd for_write tmo )
     ? == r 1 { ^ 1 } {}
     // A deadline that passed is SO_RCVTIMEO firing, which the socket
@@ -547,7 +576,7 @@ $ `stdlib/net/socket.nu`
         } {}
         // Not there yet. A pending connection becomes writable exactly
         // when it is established, so the ordinary wait does the job.
-        : i r ( __wait fd 1 ( sock_timeout st fd ) )
+        : i r ( __wait fd 1 ( __block_ms ( sock_timeout st fd ) ) )
         ? != r 1 {
             ( sock_close st fd ( __ms ) )
             ^ ( sock_err_fd st ? == r 0 ( sock_err_again ) ( sock_err_closed ) )

--- a/unikernel/net/sockets.nu
+++ b/unikernel/net/sockets.nu
@@ -459,6 +459,11 @@ $ `stdlib/net/socket.nu`
 
 @ nurl_tcp_set_timeout i handle i ms → v { ( sock_set_timeout ( __tab ) handle ms ) }
 
+// What a read on this socket should wait for, in ms; 0 = for ever. The
+// fiber path in std/net.nu asks, because it parks on the reactor rather
+// than on SO_RCVTIMEO and has to be told the deadline.
+@ nurl_tcp_timeout_ms i handle → i { ^ ( sock_timeout ( __tab ) handle ) }
+
 @ nurl_tcp_ref i handle → v { ( sock_ref ( __tab ) handle ) }
 
 @ nurl_tcp_unref i handle → v { ( nurl_tcp_close handle ) }

--- a/unikernel/runtime_bare.c
+++ b/unikernel/runtime_bare.c
@@ -429,7 +429,19 @@ static void nb_wake_joiners(NbCoro *c) {
  * nb_loop_ctx, and a coroutine calling it would overwrite the very
  * context it must return through. Everything that could block from
  * inside a coroutine parks instead. */
-static int nurl__bare_step(void) {
+/* `budget_ms` bounds the IDLE SLEEP: -1 = sleep until the next timer,
+ * 0 = do not sleep at all, N = sleep at most N ms.
+ *
+ * The bound exists because the machine's idle branch used to sleep until
+ * the next COROUTINE timer, whoever was asking. A caller with a sooner
+ * deadline of its own — the main context waiting 300 ms, or a socket
+ * wait that has readiness to re-check — was put to sleep for as long as
+ * some other coroutine's park lasted. Measured: a reader parked for a
+ * second, and main's 300 ms sleep returned a second later, so the write
+ * it was about to make arrived after the reader had already timed out.
+ * The whole exchange then failed by the reader's own deadline, which is
+ * how a timed park could break what an infinite one did not. */
+static int nb_step_bounded(long long budget_ms) {
     /* A DUE timer is work, whether or not anything else is runnable.
      *
      * Expiring timers only in the idle branch below made `sleep_ms(50)`
@@ -456,8 +468,11 @@ static int nurl__bare_step(void) {
         if (nb_timers->wake_at_ms > now) {
             /* Nothing runnable and the earliest wake-up is in the
              * future: this is the only place the machine is allowed to
-             * be idle, and the only place a real sleep is correct. */
-            nb_sleep_ms(nb_timers->wake_at_ms - now);
+             * be idle, and the only place a real sleep is correct — for
+             * no longer than the caller's own budget. */
+            long long wait = nb_timers->wake_at_ms - now;
+            if (budget_ms >= 0 && wait > budget_ms) wait = budget_ms;
+            if (wait > 0) nb_sleep_ms(wait);
             now = nb_now_ms();
         }
         return nb_timers_expire(now) > 0;
@@ -488,6 +503,11 @@ static int nurl__bare_step(void) {
     }
     return 1;
 }
+
+/* The unbounded step: sleep until the next timer if there is nothing to
+ * do. What `runtime_run`, `join` and `chan_recv` want — they have no
+ * deadline of their own. */
+static int nurl__bare_step(void) { return nb_step_bounded(-1); }
 
 /* Depth of nb_drive_until: non-zero means the MAIN context is parked
  * inside the scheduler waiting for a predicate, and will do no further
@@ -988,12 +1008,15 @@ long long nurl_fiber_sleep_ms(long long ms) {
         return 0;
     }
     /* Main: run whatever is runnable while the clock catches up, and
-     * only actually sleep when nothing is. A busy-wait here would burn
-     * the one CPU the guest has. */
+     * only actually sleep when nothing is — and never past THIS
+     * deadline, however long the coroutines' own parks are. */
     for (;;) {
         long long now = nb_now_ms();
         if (now >= deadline) return 0;
-        if (!nurl__bare_step()) nb_sleep_ms(deadline - now);
+        if (!nb_step_bounded(deadline - now)) {
+            long long left = deadline - nb_now_ms();
+            if (left > 0) nb_sleep_ms(left);
+        }
     }
 }
 
@@ -1023,6 +1046,11 @@ long long nurl_fiber_sleep_ms(long long ms) {
 long long nurl_bare_poll(void) {
     if (nb_current) return 0;
     if (!nb_initialized) nurl_runtime_init(0);
+    /* UNBOUNDED, deliberately: the socket wait above this asks "can
+     * anything still happen?" and reads a zero as "no". A step that
+     * refused to wait for a timer that is about to fire would answer no
+     * while a coroutine was one millisecond from waking — and a server
+     * blocked in accept would call its own clean shutdown an error. */
     return nurl__bare_step() ? 1 : 0;
 }
 


### PR DESCRIPTION
## The bug

`std/net.nu`'s reads dispatch on context: on a fiber they take the async
path, which sets the socket non-blocking and parks on the reactor. That
path waited with a **hard-coded −1** — for ever — so every
`tcp_set_timeout` a caller had made was silently discarded the moment
the read happened inside a coroutine.

On a hosted target this hides: a program's threads are OS threads,
`nurl_fiber_current` is 0, and the blocking path applies `SO_RCVTIMEO`
as asked. **On the freestanding runtime a thread IS a coroutine**, so
the same program silently takes the other branch and waits for ever.

Measured, on swarm-mcp in a guest: the coordinator's third `relay_recv`
— a read on a connection with a 150 ms timeout — never returned. The
node formed its cluster and then never reached `tcp_listen_tls`.

The socket now keeps its deadline in the handle (`nurl_tcp_timeout_ms`,
both runtimes) and the fiber paths ask for it: 0 still means "wait for
ever", anything else is what the caller set.

## What it uncovered — three more root causes, all fixed here

Honouring the timeout made `http2_client` under nolibc fail at exactly
its server's 5 s deadline. Three separate bugs stacked under it:

1. **The machine's idle sleep ignored the caller's own deadline**
   (second commit). `nurl__bare_step`'s idle branch slept until the
   next *coroutine* timer, whoever was asking — main's 300 ms sleep
   returned a second late when a reader was parked for a second, and
   the write it was about to make landed after that reader had already
   timed out. Steps now take a budget; the main-context sleep passes
   its remaining time.

2. **The bare shim had no poll semantics** (third commit). The hosted
   reactor ABI is: `timeout_ms > 0` deadline, `< 0` for ever, `== 0`
   **poll** — answer "ready right now" without waiting. The shim's
   `__wait` read 0 as "no deadline" and blocked. It had always been
   wrong, and it passed anyway: with no timers armed, the deadlock
   detector answered −1, which callers read as "not readable" — the
   wrong wait exited through the right door. The moment a peer parked
   *with* a deadline, the "poll" really waited, for the peer's whole
   timeout, and the two sides starved each other. `__wait` now answers
   0 with check → drive once → check, no park; `__block_ms` translates
   the socket layer's `sock_timeout` 0 (= none = block) to the
   reactor's −1 at the blocking call sites.

3. **The HTTP/2 readiness probe counted "not ready" as readable**
   (third commit). `__h2c_readable` tested `>= 0`, written when the
   only sub-zero answer was the hosted "−1, not on a fiber". The
   poll's honest 0 therefore sent the drain loop into a blocking frame
   read with no frame coming. It is `== 1` now, with the 1/0/−1
   contract documented. The hosted runtime could never see this: off a
   fiber its reactor answers −1, so 613 hosted tests passed over it.

## Verified

- hosted corpus **613/613**
- nolibc corpus **452 PASS / 0 FAIL** (`http2_client` was the 1 FAIL)
- nolibc unit gates: all pass
- QEMU guest gate: **20/20**
- swarm-mcp as a unikernel appliance, driven from the host over HTTPS:
  initialize, tools/list, and a `compute_submit` of `x*x` over
  [0,1000) now returns `{"status":"done","result":332833500}` —
  the previously-stalled compute path completes with the correct sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1
