### PR TITLE
feat: the unikernel build is a tool — callable from anywhere, safe to run twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`unikernel/build_unikernel.sh` is a tool now, not a repo-rooted
+  script** (unikernel-in-the-playground plan, phase U0). It takes
+  `--out-dir`, compiles the program-independent objects once into a
+  locked, stamped cache (`NURL_UNIKERNEL_CACHE`; warm rebuild of a
+  hello image: 0.14 s), names every per-program artifact after the
+  program so concurrent builds cannot clobber each other, and with
+  both directories pointed elsewhere never writes the repository at
+  all. `compile_nu.sh` defaults `NURL_STDLIB` to the repo it lives in
+  — a package build from a foreign cwd used to die with "cannot open
+  stdlib/core/string.nu", and die SILENTLY, because compile errors
+  went to a file nothing printed; failures now carry the compiler's
+  message on stderr (`NURL_COMPILE_QUIET=1` restores the silence for
+  the corpus runner, which classifies by exit code). All four
+  properties are pinned by a new unit gate
+  (`unikernel/tests/build_tool_gate.sh`): foreign-cwd build,
+  read-only repo, concurrent byte-identical ELFs, loud failure.
+
 ## [0.34.0] — 2026-08-07
 
 ### Added

--- a/unikernel/build_unikernel.sh
+++ b/unikernel/build_unikernel.sh
@@ -4,6 +4,7 @@
 #  x86_64 PVH kernel image.
 #
 #  Usage:  unikernel/build_unikernel.sh prog.nu [-o out.elf]
+#              [--fs dir] [--out-dir dir]
 #
 #  Same NURL, same runtime_core.c, same runtime_bare.c and the same
 #  nolibc as the Linux -nostdlib build. Exactly three files differ, and
@@ -23,37 +24,126 @@
 #  moving rsp first — an exception handler — silently corrupts it.
 #  v1 takes no device interrupts, but an exception handler is still an
 #  exception handler, and the flag costs nothing.
+#
+#  Two invocations may run CONCURRENTLY. The split that makes that
+#  true: everything program-independent (boot shim, nolibc, runtimes)
+#  compiles ONCE into a cache directory under an flock, keyed by a
+#  stamp that names every input and the flags — touch any of them and
+#  the cache rebuilds; and everything program-dependent (the .ll, the
+#  object, the initfs archive) is named after the program and lives in
+#  --out-dir, so two builds never write the same path unless they ARE
+#  the same build, in which case the ELFs come out byte-identical
+#  (--build-id=none, and tar's inputs are the caller's own files).
+#
+#  Directories:
+#    --out-dir DIR   per-program artifacts + the image (default
+#                    $NURL_UNIKERNEL_OUT, else <repo>/build/unikernel)
+#    cache           $NURL_UNIKERNEL_CACHE, else <out-dir>/cache.
+#                    With both flags pointed elsewhere the repo is
+#                    never written — it can be mounted read-only.
 # ============================================================
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BOOT="$ROOT/unikernel/boot"
 NOLIBC="$ROOT/unikernel/nolibc"
-OUTDIR="${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel}"
 CC="${CC:-clang}"
 SRC=""
 OUT=""
 FSDIR=""
+OUTDIR="${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
         -o) OUT="$2"; shift 2 ;;
         --fs) FSDIR="$2"; shift 2 ;;
+        --out-dir) OUTDIR="$2"; shift 2 ;;
         *)  SRC="$1"; shift ;;
     esac
 done
-[ -n "$SRC" ] || { echo "usage: build_unikernel.sh prog.nu [-o out.elf]" >&2; exit 2; }
+[ -n "$SRC" ] || {
+    echo "usage: build_unikernel.sh prog.nu [-o out.elf] [--fs dir] [--out-dir dir]" >&2
+    exit 2
+}
+[ -x "$ROOT/build/nurlc" ] || {
+    echo "build_unikernel.sh: $ROOT/build/nurlc not found — run ./build.sh first" >&2
+    exit 2
+}
+if [ -n "$FSDIR" ] && [ ! -d "$FSDIR" ]; then
+    echo "build_unikernel.sh: --fs $FSDIR is not a directory" >&2
+    exit 2
+fi
 
-mkdir -p "$OUTDIR"
+CACHE="${NURL_UNIKERNEL_CACHE:-$OUTDIR/cache}"
+mkdir -p "$OUTDIR" "$CACHE"
 base="$(basename "${SRC%.nu}")"
 OUT="${OUT:-$OUTDIR/$base.elf}"
 
 KFLAGS="-ffreestanding -fno-stack-protector -fno-builtin -mno-red-zone
         -mcmodel=small -fno-pie -march=x86-64 -mno-sse4 -O2"
 
-# The NURL program, plus the socket layer if it uses one. Same script as
-# the Linux freestanding build — the decision is measured there, and
-# duplicating it here is how the two would drift.
+# ── the program-independent objects, once, under a lock ─────────
+#
+# The stamp is the answer to "is the cache current": it names every
+# source these objects are built from, the flags and the compiler. If
+# any input is newer than the stamp, or the recorded flags/CC differ,
+# rebuild everything — the set is small enough that partial rebuilds
+# are a source of skew, not a saving. The flock makes two concurrent
+# first builds take turns instead of interleaving half-written objects.
+cache_inputs() {
+    printf '%s\n' \
+        "$ROOT/stdlib/runtime_core.c" "$ROOT/stdlib/runtime_ctx.c" \
+        "$ROOT/unikernel/runtime_bare.c" \
+        "$NOLIBC"/string.c "$NOLIBC"/malloc.c "$NOLIBC"/stdio.c \
+        "$NOLIBC"/dtoa.c "$NOLIBC"/math.c "$NOLIBC"/misc.c \
+        "$NOLIBC"/setjmp_x86_64.S \
+        "$BOOT"/platform_x86.c "$BOOT"/initfs.c "$BOOT"/pagealloc.c \
+        "$BOOT"/nosys.c "$BOOT"/tls_guest.c "$BOOT"/boot.S \
+        "${BASH_SOURCE[0]}"
+}
+
+cache_build() {
+    $CC $KFLAGS -c "$ROOT/stdlib/runtime_core.c" -o "$CACHE/runtime_core.o"
+    $CC $KFLAGS -c "$ROOT/stdlib/runtime_ctx.c"  -o "$CACHE/runtime_ctx.o"
+    $CC $KFLAGS -c "$ROOT/unikernel/runtime_bare.c" -o "$CACHE/runtime_bare.o"
+    for f in string malloc stdio dtoa math misc; do
+        $CC $KFLAGS -c "$NOLIBC/$f.c" -o "$CACHE/nl_$f.o"
+    done
+    $CC $KFLAGS -c "$BOOT/platform_x86.c" -o "$CACHE/platform.o"
+    $CC $KFLAGS -c "$BOOT/initfs.c"       -o "$CACHE/boot_initfs.o"
+    $CC $KFLAGS -c "$BOOT/pagealloc.c"    -o "$CACHE/boot_pagealloc.o"
+    $CC $KFLAGS -c "$BOOT/nosys.c"        -o "$CACHE/boot_nosys.o"
+    $CC $KFLAGS -c "$BOOT/tls_guest.c"    -o "$CACHE/tls_guest.o"
+    $CC -c "$BOOT/boot.S"                 -o "$CACHE/boot.o"
+    $CC $KFLAGS -c "$NOLIBC/setjmp_x86_64.S" -o "$CACHE/nl_setjmp.o" 2>/dev/null \
+        || $CC -c "$NOLIBC/setjmp_x86_64.S" -o "$CACHE/nl_setjmp.o"
+}
+
+stamp="$CACHE/stamp"
+want_key="CC=$CC KFLAGS=$(echo $KFLAGS)"
+(
+    flock 9
+    fresh=1
+    if [ ! -f "$stamp" ] || [ "$(head -1 "$stamp" 2>/dev/null)" != "$want_key" ]; then
+        fresh=0
+    else
+        while IFS= read -r f; do
+            [ "$f" -nt "$stamp" ] && { fresh=0; break; }
+        done < <(cache_inputs)
+    fi
+    if [ "$fresh" = 0 ]; then
+        cache_build
+        printf '%s\n' "$want_key" > "$stamp"
+    fi
+) 9>"$CACHE/.lock"
+
+# ── the program itself ──────────────────────────────────────────
+#
+# compile_nu.sh links in the NURL socket layer when `nm` says the
+# program needs it — see that script for why that is a recompile
+# rather than another object on the link line. It also owns stdlib
+# resolution (NURL_STDLIB) and prints the compiler's message when the
+# program does not compile.
 NURL_NETDEV="$ROOT/unikernel/net/netdev_virtio.nu" \
     "$ROOT/unikernel/compile_nu.sh" "$SRC" "$OUTDIR/$base.ll" "$OUTDIR"
 # compile_nu.sh leaves a hosted-flavoured object; recompile the IR with
@@ -61,46 +151,32 @@ NURL_NETDEV="$ROOT/unikernel/net/netdev_virtio.nu" \
 # clang needs the target flags spelled out for IR input too.
 $CC $KFLAGS -c "$OUTDIR/$base.ll" -o "$OUTDIR/$base.o"
 
-$CC $KFLAGS -c "$ROOT/stdlib/runtime_core.c" -o "$OUTDIR/runtime_core.o"
-$CC $KFLAGS -c "$ROOT/stdlib/runtime_ctx.c"  -o "$OUTDIR/runtime_ctx.o"
-$CC $KFLAGS -c "$ROOT/unikernel/runtime_bare.c" -o "$OUTDIR/runtime_bare.o"
-
-for f in string malloc stdio dtoa math misc; do
-    $CC $KFLAGS -c "$NOLIBC/$f.c" -o "$OUTDIR/nl_$f.o"
-done
-$CC $KFLAGS -c "$BOOT/platform_x86.c" -o "$OUTDIR/platform.o"
-$CC $KFLAGS -c "$BOOT/initfs.c"       -o "$OUTDIR/boot_initfs.o"
-$CC $KFLAGS -c "$BOOT/pagealloc.c"    -o "$OUTDIR/boot_pagealloc.o"
-$CC $KFLAGS -c "$BOOT/nosys.c"        -o "$OUTDIR/boot_nosys.o"
-
 # The baked-in filesystem: a directory becomes a tar, and the tar
 # becomes an object with two symbols around it. With no --fs the
 # archive is empty rather than absent, so "no files" is a zero-length
-# lookup instead of a conditional in every reader.
-: > "$OUTDIR/initfs.tar"
+# lookup instead of a conditional in every reader. Named after the
+# program: two concurrent builds must not share a tar.
+: > "$OUTDIR/$base.initfs.tar"
 if [ -n "$FSDIR" ]; then
-    tar cf "$OUTDIR/initfs.tar" -C "$FSDIR" .
+    tar cf "$OUTDIR/$base.initfs.tar" -C "$FSDIR" .
 fi
-( cd "$OUTDIR" && ld -r -b binary -o initfs_data.o initfs.tar )
+( cd "$OUTDIR" && ld -r -b binary -o "$base.initfs_data.o" "$base.initfs.tar" )
 # `ld -b binary` names its symbols after the path it was given; rename
 # them to something a C file can declare without knowing that path.
+sym="$(printf '%s' "$base.initfs.tar" | tr -c 'A-Za-z0-9' '_')"
 objcopy \
-    --redefine-sym _binary_initfs_tar_start=nurl_initfs_start \
-    --redefine-sym _binary_initfs_tar_end=nurl_initfs_end \
-    --redefine-sym _binary_initfs_tar_size=nurl_initfs_size_sym \
-    "$OUTDIR/initfs_data.o"
-$CC $KFLAGS -c "$BOOT/tls_guest.c"    -o "$OUTDIR/tls_guest.o"
-$CC -c "$BOOT/boot.S"                 -o "$OUTDIR/boot.o"
-$CC $KFLAGS -c "$NOLIBC/setjmp_x86_64.S" -o "$OUTDIR/nl_setjmp.o" 2>/dev/null \
-    || $CC -c "$NOLIBC/setjmp_x86_64.S" -o "$OUTDIR/nl_setjmp.o"
+    --redefine-sym "_binary_${sym}_start=nurl_initfs_start" \
+    --redefine-sym "_binary_${sym}_end=nurl_initfs_end" \
+    --redefine-sym "_binary_${sym}_size=nurl_initfs_size_sym" \
+    "$OUTDIR/$base.initfs_data.o"
 
 $CC -nostdlib -static -no-pie -Wl,-T,"$BOOT/link.ld" -Wl,--build-id=none \
     -o "$OUT" \
-    "$OUTDIR/boot.o" "$OUTDIR/$base.o" \
-    "$OUTDIR/runtime_core.o" "$OUTDIR/runtime_ctx.o" "$OUTDIR/runtime_bare.o" \
-    "$OUTDIR/platform.o" "$OUTDIR/tls_guest.o" \
-    "$OUTDIR/boot_initfs.o" "$OUTDIR/boot_pagealloc.o" "$OUTDIR/boot_nosys.o" \
-    "$OUTDIR/initfs_data.o" \
-    "$OUTDIR"/nl_*.o
+    "$CACHE/boot.o" "$OUTDIR/$base.o" \
+    "$CACHE/runtime_core.o" "$CACHE/runtime_ctx.o" "$CACHE/runtime_bare.o" \
+    "$CACHE/platform.o" "$CACHE/tls_guest.o" \
+    "$CACHE/boot_initfs.o" "$CACHE/boot_pagealloc.o" "$CACHE/boot_nosys.o" \
+    "$OUTDIR/$base.initfs_data.o" \
+    "$CACHE"/nl_*.o
 
 echo "built $OUT"

--- a/unikernel/compile_nu.sh
+++ b/unikernel/compile_nu.sh
@@ -35,6 +35,30 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SHIM="$ROOT/unikernel/net/sockets.nu"
 CC="${CC:-clang}"
 
+# The stdlib is HERE, and this script knows it. Without this a package
+# build (cwd = the package root, see below) resolved `stdlib/…` imports
+# against the package directory and died with "cannot open
+# stdlib/core/string.nu" — and worse, died SILENTLY, because the error
+# went to compile.err and nothing printed it. Callers may still point
+# NURL_STDLIB somewhere else; the default is the repo this script is in.
+export NURL_STDLIB="${NURL_STDLIB:-$ROOT}"
+
+# A failed step says WHY, on stderr, prefixed with whose voice it is.
+# The err files stay in the workdir for tooling; the human gets the
+# message at the moment of failure. This script cost its author twenty
+# minutes of "exit 3, no output" — never again.
+#
+# NURL_COMPILE_QUIET=1 restores the old silence for the one caller that
+# wants it: the corpus runner compiles a thousand tests and CLASSIFIES
+# failures by exit code — for it the noise would drown the report.
+fail() { # fail <exit-code> <errfile> <what>
+    if [ -z "${NURL_COMPILE_QUIET:-}" ]; then
+        echo "compile_nu.sh: $3 failed for $name:" >&2
+        sed 's/^/  /' "$2" >&2
+    fi
+    exit "$1"
+}
+
 SRC="$1"; OUT_LL="$2"; WORK="$3"
 # Absolute, before anything cds anywhere: the workdir below is chosen
 # per source, and a relative path stops meaning the same thing the
@@ -60,8 +84,8 @@ while [ "$probe" != "/" ]; do
 done
 cd "$workdir" || exit 2
 
-"$ROOT/build/nurlc" "$SRC" > "$OUT_LL" 2>"$WORK/compile.err" || exit 3
-"$CC" -O2 -c "$OUT_LL" -o "$OBJ" 2>"$WORK/cc.err" || exit 4
+"$ROOT/build/nurlc" "$SRC" > "$OUT_LL" 2>"$WORK/compile.err" || fail 3 "$WORK/compile.err" "nurlc"
+"$CC" -O2 -c "$OUT_LL" -o "$OBJ" 2>"$WORK/cc.err" || fail 4 "$WORK/cc.err" "$CC"
 
 # What does the shim define? Its own `@ nurl_*` definitions, read from
 # the file that defines them.
@@ -86,6 +110,6 @@ root_nu="$WORK/__with_sockets.nu"
     printf '$ `%s`\n' "${NURL_NETDEV:-$ROOT/unikernel/net/netdev_none.nu}"
 } > "$root_nu"
 
-"$ROOT/build/nurlc" "$root_nu" > "$OUT_LL" 2>"$WORK/compile.err" || exit 3
-"$CC" -O2 -c "$OUT_LL" -o "$OBJ" 2>"$WORK/cc.err" || exit 4
+"$ROOT/build/nurlc" "$root_nu" > "$OUT_LL" 2>"$WORK/compile.err" || fail 3 "$WORK/compile.err" "nurlc (with socket shim)"
+"$CC" -O2 -c "$OUT_LL" -o "$OBJ" 2>"$WORK/cc.err" || fail 4 "$WORK/cc.err" "$CC (with socket shim)"
 exit 0

--- a/unikernel/run_nolibc_tests.sh
+++ b/unikernel/run_nolibc_tests.sh
@@ -68,7 +68,7 @@ one() {
     # Compile, and link in the NURL socket layer if this program needs
     # it — see unikernel/compile_nu.sh for why that is a recompile
     # rather than another object on the link line.
-    "$ROOT/unikernel/compile_nu.sh" "$src" "$work/$name.ll" "$work"
+    NURL_COMPILE_QUIET=1 "$ROOT/unikernel/compile_nu.sh" "$src" "$work/$name.ll" "$work"
     case $? in
         0) ;;
         3) echo "SKIP $name (does not compile standalone)"; return 0 ;;

--- a/unikernel/tests/build_tool_gate.sh
+++ b/unikernel/tests/build_tool_gate.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/tests/build_tool_gate.sh — build_unikernel.sh is a TOOL,
+#  not a repo-rooted script. The properties U0 bought, each asserted:
+#
+#    1. builds from a foreign cwd, with the source outside the repo,
+#       stdlib imports resolving via the script's own NURL_STDLIB
+#       default (this exact shape failed silently before U0);
+#    2. never writes the repo when --out-dir and the cache point
+#       elsewhere (the repo could be mounted read-only);
+#    3. two concurrent builds of the same program produce
+#       byte-identical ELFs (shared cold cache, separate out-dirs);
+#    4. a program that does not compile fails LOUDLY — non-zero exit
+#       and the compiler's message on stderr, not a bare exit 3.
+#
+#  Usage: build_tool_gate.sh        (exit 0 = all hold)
+# ============================================================
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD="$ROOT/unikernel/build_unikernel.sh"
+
+if [ ! -x "$ROOT/build/nurlc" ]; then
+    echo "build_tool_gate: SKIP (no build/nurlc — run ./build.sh first)"
+    exit 0
+fi
+
+T="$(mktemp -d)"
+trap 'rm -rf "$T"' EXIT
+fail=0
+say() { echo "build_tool_gate: $*"; }
+
+# A program whose stdlib import only resolves if the SCRIPT supplies
+# NURL_STDLIB — the source lives outside the repo and so does the cwd.
+cat > "$T/prog.nu" <<'EOF'
+$ `stdlib/std/time.nu`
+
+@ main → i {
+    : i t ( now_ms )
+    ? >= t 0 { ( nurl_println `ok` ) } {}
+    ^ 0
+}
+EOF
+
+# 1 + 2: foreign cwd, everything outside the repo, repo untouched.
+marker="$T/marker"; touch "$marker"; sleep 1
+if ! ( cd "$T" && env -u NURL_STDLIB NURL_UNIKERNEL_CACHE="$T/cache" \
+        "$BUILD" "$T/prog.nu" --out-dir "$T/out1" >/dev/null 2>"$T/err1" ); then
+    say "FAIL: foreign-cwd build failed:"; sed 's/^/  /' "$T/err1"; fail=1
+fi
+wrote=$(find "$ROOT" -newer "$marker" -not -path "$ROOT/.git/*" 2>/dev/null | head -3)
+if [ -n "$wrote" ]; then
+    say "FAIL: the build wrote into the repo:"; printf '  %s\n' $wrote; fail=1
+fi
+
+# 3: concurrent, cold shared cache, byte-identical images.
+rm -rf "$T/cache2" "$T/out2" "$T/out3"
+( env -u NURL_STDLIB NURL_UNIKERNEL_CACHE="$T/cache2" \
+    "$BUILD" "$T/prog.nu" --out-dir "$T/out2" >/dev/null 2>&1 ) &
+( env -u NURL_STDLIB NURL_UNIKERNEL_CACHE="$T/cache2" \
+    "$BUILD" "$T/prog.nu" --out-dir "$T/out3" >/dev/null 2>&1 ) &
+wait
+if ! cmp -s "$T/out2/prog.elf" "$T/out3/prog.elf"; then
+    say "FAIL: concurrent builds differ (or one did not finish)"; fail=1
+fi
+
+# 4: a broken program fails loudly.
+printf '@ main → i {\n    ( nurl_println nope )\n    ^ 0\n}\n' > "$T/broken.nu"
+if env NURL_UNIKERNEL_CACHE="$T/cache" \
+        "$BUILD" "$T/broken.nu" --out-dir "$T/outb" >/dev/null 2>"$T/errb"; then
+    say "FAIL: a broken program built successfully"; fail=1
+elif ! grep -q "nurlc failed" "$T/errb"; then
+    say "FAIL: the failure said nothing (stderr below):"
+    sed 's/^/  /' "$T/errb"; fail=1
+fi
+
+if [ "$fail" = 0 ]; then
+    echo "build_tool_gate: all four tool properties hold"
+fi
+exit $fail

--- a/unikernel/tests/run_unit_tests.sh
+++ b/unikernel/tests/run_unit_tests.sh
@@ -154,7 +154,12 @@ for seed in 7 99 12345; do
     step "math_diff(seed $seed)" "$OUT/math_diff" 60000 "$seed"
 done
 
-# 6. the bare mutex/cond fit what the NURL side allocates for them.
+# 6. build_unikernel.sh is a tool: foreign cwd, read-only repo,
+#    concurrent byte-identical builds, loud failures. Skips itself
+#    when build/nurlc is absent (the other gates here need only $CC).
+step build_tool_gate "$ROOT/unikernel/tests/build_tool_gate.sh"
+
+# 7. the bare mutex/cond fit what the NURL side allocates for them.
 #    Hosted on purpose: the comparison needs the real <pthread.h>, which
 #    is precisely what the freestanding build does not have.
 $CC -O2 "$ROOT/unikernel/tests/pthread_layout.c" "$OUT/runtime_bare.o" \


### PR DESCRIPTION
Phase U0 of building unikernel images from the playground (the plan's
first cut line): before a server can call `build_unikernel.sh` per
request, the script has to stop assuming it is the only copy of
itself, running from the repo root, with the repo writable.

Four properties, each previously false, each now pinned by a new unit
gate (`unikernel/tests/build_tool_gate.sh`):

1. **Foreign cwd** — `compile_nu.sh` defaults `NURL_STDLIB` to the
   repository it lives in, so package builds compile instead of dying
   with "cannot open stdlib/core/string.nu".
2. **Loud failure** — that death was *silent* (errors went to
   `compile.err`, the caller saw a bare exit 3; it cost 20 minutes
   this week and would cost a playground user forever). Failures now
   print the compiler's message on stderr; `NURL_COMPILE_QUIET=1`
   keeps the corpus runner's report clean.
3. **Read-only repo** — `--out-dir` for per-program artifacts, and the
   program-independent objects build once into a locked, stamped
   cache (`NURL_UNIKERNEL_CACHE`). Warm hello rebuild: 0.14 s.
4. **Safe concurrency** — per-program initfs tar/object naming (the
   objcopy rename follows ld's own filename mangling); two concurrent
   builds of the same program produce byte-identical ELFs.

Gates: nolibc unit gates (incl. the new one) pass, nolibc corpus
**452 PASS / 0 FAIL**, QEMU guest gate **20/20**. CHANGELOG
`[Unreleased]` updated in this PR — the v0.34.0 release had to
reconstruct its whole section from merge history because no PR since
v0.33.0 had written an entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1