### PR TITLE
feat: boot:true — the playground boots the image it just built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`boot: true` — the playground proves the image boots** (plan phase
+  U3). `POST /build_unikernel` can now boot the image it just built,
+  inside the container: TCG (no /dev/kvm there), no network device,
+  its own wall-clock bound via timeout(1) (`NURL_UNIKERNEL_BOOT_SECS`,
+  default 20 s), concurrency bounded by the compile permit the request
+  already holds. The reply's `boot_result` carries the guest console
+  (CR-stripped, capped at 64 KB), the parsed `[nurl-exit]` status,
+  `timed_out`, and qemu's own stderr — a failed boot is a diagnosis,
+  not an empty log. A server program that would listen forever still
+  proves it boots: the log holds what it printed, `exit` stays null.
+  qemu-system-x86 adds ~72 MB to the image. e2e: the booted guest's
+  print and exit 0 are asserted through the HTTP surface; a deployment
+  without qemu answers `ran: false` with a reason instead of failing.
+
 - **`POST /build_unikernel` — the playground builds bootable unikernel
   images** (plan phase U2). Body: `source` (+ `filename`), optional
   `args` (the guest's argv — returned inside the boot command, never

--- a/nurlapi/Dockerfile
+++ b/nurlapi/Dockerfile
@@ -167,6 +167,9 @@ FROM debian:bookworm-slim
 # binutils: the plain (non-mingw) ld/objcopy/nm — the unikernel build
 # embeds the initfs with `ld -r -b binary` + objcopy and measures a
 # program's undefined symbols with nm, all on the request path.
+# qemu-system-x86: the smoke boot (U3) — `boot: true` on
+# POST /build_unikernel boots the built image under TCG (the container
+# has no /dev/kvm), no network device, killed by timeout(1).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         clang-16 \
         libcurl4-openssl-dev \
@@ -178,6 +181,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         binaryen \
         binutils \
+        qemu-system-x86 \
         gcc-mingw-w64-x86-64 \
         binutils-mingw-w64-x86-64 \
     && rm -rf /var/lib/apt/lists/* \

--- a/nurlapi/e2e_test.py
+++ b/nurlapi/e2e_test.py
@@ -758,7 +758,26 @@ def t_build_unikernel_rest(c: Client) -> None:
         )
         assert_eq(f"files key {bad_key!r} rejected", status, 400)
 
-    # 3. A broken program answers with the compiler's message, loudly.
+    # 3. boot:true — the server boots the image and returns the console.
+    status, _, raw = c.post(
+        "/build_unikernel",
+        {"source": src, "boot": True},
+        timeout=240.0,
+    )
+    assert_eq("boot:true status 200", status, 200)
+    try:
+        j = json.loads(raw)
+        br = j.get("boot_result") or {}
+        if br.get("ran") is False and "not available" in (br.get("error") or ""):
+            print("  boot skipped: qemu not in this deployment")
+        else:
+            assert_true("boot ran", br.get("ran") is True, str(br)[:200])
+            assert_true("guest printed", "uk-e2e" in (br.get("log") or ""), (br.get("log") or "")[:200])
+            assert_eq("guest exited 0", br.get("exit"), 0)
+    except json.JSONDecodeError:
+        bad("boot result is JSON", f"got {raw[:200]!r}")
+
+    # 4. A broken program answers with the compiler's message, loudly.
     status, _, raw = c.post(
         "/build_unikernel",
         {"source": "@ main → i { ( nurl_println nope ) ^ 0 }"},

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -4149,6 +4149,139 @@ s combined_stdout s combined_stderr → v {
     ^ c
 }
 
+// ── Smoke boot (U3): prove the image boots, from inside the container ──
+//
+// TCG only — the container has no /dev/kvm — bounded by its own wall
+// clock via timeout(1) and run with NO network device, so the guest can
+// print and exit but never reach anything. A server program that would
+// listen forever still proves it boots: the log holds everything it
+// printed before the deadline and `exit` stays null. Concurrency is
+// bounded by the compile gate the request already holds (≤ 4 boots),
+// and the timeout's -k makes the kill unconditional.
+
+@ get_qemu_path → String { ^ ( env_var_or `NURL_QEMU` `/usr/bin/qemu-system-x86_64` ) }
+
+@ get_boot_secs → String { ^ ( env_var_or `NURL_UNIKERNEL_BOOT_SECS` `20` ) }
+
+// Last `[nurl-exit] N` in the console, -1 if the guest never exited.
+// nurl_str_find answers the FIRST hit, so the scan advances a borrowed
+// pointer past each one — the last hit wins, which matters because a
+// program's own output may legitimately contain the marker text.
+@ __uk_exit_code s log → i {
+    : ~ i best - 0 1
+    : ~ s cur log
+    : ~ b more T
+    ~ more {
+        : i at ( nurl_str_find cur `[nurl-exit] ` )
+        ? < at 0 { = more F } {
+            : s tail # s + # i cur + at 12
+            : i tn ( nurl_str_len tail )
+            : ~ i v 0
+            : ~ i k 0
+            : ~ b digits F
+            : ~ b run T
+            ~ & run < k tn {
+                : i c ( nurl_str_get tail k )
+                ? & >= c 48 <= c 57 {
+                    = v + * v 10 - c 48
+                    = digits T
+                    = k + k 1
+                } { = run F }
+            }
+            ? digits { = best v } {}
+            = cur # s + # i cur + at 1
+        }
+    }
+    ^ best
+}
+
+@ __uk_smoke_boot s elf_path s uargs → Json {
+    : Json o ( json_obj_new )
+    : String qemu ( get_qemu_path )
+    ? ! ( file_exists ( string_data qemu ) ) {
+        ( json_obj_set o `ran` ( json_bool F ) )
+        ( json_obj_set o `error` ( json_str_lit `qemu is not available in this deployment` ) )
+        ( string_free qemu )
+        ^ o
+    } {}
+    : String secs ( get_boot_secs )
+    : String append ( string_with_cap 256 )
+    ( string_push_str append `tsc_khz=1000000 wallclock=` )
+    ( string_push_str append ( nurl_str_int / ( now_ms ) 1000 ) )
+    ? > ( nurl_str_len uargs ) 0 {
+        ( string_push_str append ` args="` )
+        ( string_push_str append uargs )
+        ( string_push_str append `"` )
+    } {}
+    : ( Vec s ) qa ( vec_new [s] )
+    ( vec_push [s] qa `-k` )
+    ( vec_push [s] qa `5` )
+    ( vec_push [s] qa ( string_data secs ) )
+    ( vec_push [s] qa ( string_data qemu ) )
+    ( vec_push [s] qa `-M` ) ( vec_push [s] qa `microvm,acpi=off,rtc=off` )
+    ( vec_push [s] qa `-accel` ) ( vec_push [s] qa `tcg` )
+    ( vec_push [s] qa `-cpu` ) ( vec_push [s] qa `max` )
+    ( vec_push [s] qa `-m` ) ( vec_push [s] qa `64` )
+    ( vec_push [s] qa `-nodefaults` )
+    ( vec_push [s] qa `-no-reboot` )
+    ( vec_push [s] qa `-no-user-config` )
+    ( vec_push [s] qa `-global` ) ( vec_push [s] qa `virtio-mmio.force-legacy=false` )
+    ( vec_push [s] qa `-serial` ) ( vec_push [s] qa `stdio` )
+    ( vec_push [s] qa `-display` ) ( vec_push [s] qa `none` )
+    // A relocated qemu (not installed under /usr) finds its firmware
+    // only when told where — the packaged one never needs this.
+    : String share ( env_var_or `NURL_QEMU_SHARE` `` )
+    ? > ( string_len share ) 0 {
+        ( vec_push [s] qa `-L` ) ( vec_push [s] qa ( string_data share ) )
+    } {}
+    ( vec_push [s] qa `-kernel` ) ( vec_push [s] qa elf_path )
+    ( vec_push [s] qa `-append` ) ( vec_push [s] qa ( string_data append ) )
+    : !Output ProcessErr br ( process_run `/usr/bin/timeout` qa `` )
+    ( vec_free [s] qa )
+    ( string_free append )
+    ( string_free secs )
+    ( string_free qemu )
+    ( string_free share )
+    ?? br {
+        T bout → {
+            : i brc ( output_exit_code bout )
+            // The UART's CRLF is transport, not content; and a hostile
+            // program can print for ever, so the log is capped.
+            : s raw_log ( output_stdout bout )
+            : i rl ( nurl_str_len raw_log )
+            : i cap ? > rl 65536 65536 rl
+            : String log ( string_with_cap + cap 1 )
+            : ~ i k 0
+            ~ < k cap {
+                : i c ( nurl_str_get raw_log k )
+                ? != c 13 { ( string_push_char log c ) } {}
+                = k + k 1
+            }
+            : i gexit ( __uk_exit_code ( string_data log ) )
+            ( json_obj_set o `ran` ( json_bool T ) )
+            ( json_obj_set o `timed_out` ( json_bool ? == brc 124 T F ) )
+            ( json_obj_set o `log` ( json_str_lit ( string_data log ) ) )
+            ? >= gexit 0 {
+                ( json_obj_set o `exit` ( json_int gexit ) )
+            } {
+                ( json_obj_set o `exit` ( json_null ) )
+            }
+            ( json_obj_set o `truncated` ( json_bool ? > rl 65536 T F ) )
+            // qemu's OWN complaints (bad firmware path, bad flags) are
+            // stderr, not console — without this a failed boot is an
+            // empty log and nothing to debug with.
+            ( json_obj_set o `qemu_stderr` ( json_str_lit ( output_stderr bout ) ) )
+            ( string_free log )
+            ( output_free bout )
+        }
+        F _ → {
+            ( json_obj_set o `ran` ( json_bool F ) )
+            ( json_obj_set o `error` ( json_str_lit `boot process failed to start` ) )
+        }
+    }
+    ^ o
+}
+
 @ h_build_unikernel HttpRequest req Params params → HttpResponse {
     ( nurl_print `[srv] POST /build_unikernel\n` )
     : String body_str ( get_body_str req )
@@ -4159,6 +4292,8 @@ s combined_stdout s combined_stderr → v {
             ? == ( nurl_str_len source ) 0 { ( json_free root ) ( string_free body_str ) ^ ( response_text 400 `{"error":"source is required"}\n` ) } {}
             : s filename ( get_common_json root `filename` `main.nu` )
             : s uargs ( get_common_json root `args` `` )
+            : ~ b want_boot F
+            ?? ( json_obj_get root `boot` ) { T bj → { = want_boot ( json_as_bool bj ) } F → {} }
 
             : String build_id ( create_build_id )
             : String build_dir ( path_join ( string_data ( get_output_dir ) ) ( string_data build_id ) )
@@ -4248,6 +4383,10 @@ s combined_stdout s combined_stderr → v {
                             ( json_obj_set res `script_returncode` ( json_int t_rc ) )
                             ( json_obj_set res `stderr` ( json_str_lit ( output_stderr t_out ) ) )
                             ? == t_rc 0 {
+                                ? want_boot {
+                                    ( json_obj_set res `boot_result`
+                                    ( __uk_smoke_boot ( string_data elf_path ) uargs ) )
+                                } {}
                                 : !i IoErr esz ( file_size ( string_data elf_path ) )
                                 : i ebytes ?? esz { T sz → sz F _ → 0 }
                                 ( json_obj_set res `elf_artifact`


### PR DESCRIPTION
Phase U3 of unikernel-images-from-the-playground (U0 #801, U1 #802,
U2 #803). An ELF artifact alone is a dead end for a browser user and
for an MCP agent — so the server can now prove the boot.

- `POST /build_unikernel {"boot": true}` boots the built image inside
  the container: **TCG**, **no network device**, wall-clock bound via
  `timeout -k` (`NURL_UNIKERNEL_BOOT_SECS`, default 20 s — calibrated
  to the measured 2.5–6.6 s TCG floor), concurrency bounded by the
  compile permit already held.
- `boot_result`: guest console (CR-stripped, 64 KB cap), the **last**
  `[nurl-exit] N` (a program's own output may contain the marker),
  `timed_out`, and **qemu's own stderr** — learned the hard way: qemu
  complains on stderr, and without it a failed boot was an empty log.
- A forever-listening server still proves it boots: log filled, `exit`
  null. A deployment without qemu answers `ran: false` + reason.
- `qemu-system-x86` adds ~72 MB installed (budget was 150 MB).

Verified: e2e 22/22 locally (relocated qemu via `NURL_QEMU` /
`NURL_QEMU_SHARE`), and in the built container over HTTP as the
unprivileged user: `{"ran": true, "exit": 0}` with the guest's print
in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1