### PR TITLE
feat: the playground UI builds and boots unikernels, and knows which examples can

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The playground UI builds and boots unikernels** (plan phase U4).
+  The target dropdown gains **Unikernel x86_64 · bootable image**: one
+  Build click compiles the editor's program into a PVH image, boots it
+  in the playground, and renders the guest console with its exit
+  status, the image download, and both ready-to-paste QEMU commands. A
+  guest-args field appears for the kernel command line's `args="…"`.
+  The examples dropdown greys out what cannot boot — **measured, not
+  listed**: `unikernel/measure_capability.sh` links every bundled
+  example at image-build time exactly as a request would (42/64
+  capable today) and GET /examples serves each verdict with the
+  missing symbols as the reason, so the tooltip says *why* (signals,
+  canvas/audio, hosted-HTTP FFI). A deployment that never measured
+  skips the annotation instead of faking it.
+
 - **`boot: true` — the playground proves the image boots** (plan phase
   U3). `POST /build_unikernel` can now boot the image it just built,
   inside the container: TCG (no /dev/kvm there), no network device,

--- a/nurlapi/Dockerfile
+++ b/nurlapi/Dockerfile
@@ -293,6 +293,15 @@ test -s /tmp/uout/uhello.elf && test -s /tmp/uout/ulisten.elf
 rm -rf /tmp/uhello.nu /tmp/ulisten.nu /tmp/uout
 SMOKE
 
+# Which bundled examples build as unikernel images — MEASURED here, at
+# image-build time, by linking each one exactly as a request would
+# (U4). GET /examples serves the verdicts so the playground can grey
+# out what cannot boot, with the missing symbols as the reason. A
+# hand-kept list would rot; this one is remeasured on every image.
+ENV NURL_UNIKERNEL_EXAMPLES=/opt/nurl/unikernel-examples.json
+RUN /opt/nurl/unikernel/measure_capability.sh /opt/nurl/examples \
+        /opt/nurl/unikernel-examples.json
+
 # ── Run unprivileged (M11) ────────────────────────────────────────────
 # The server compiles untrusted source with nurlc/clang/zig; none of that
 # needs root. Writable surface is exactly what the tools touch at request

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -1894,6 +1894,39 @@ s combined_stdout s combined_stderr → v {
 
 // ── Examples handler ────────────────────────────────────────────────
 
+// The measured unikernel capability of the bundled examples — written
+// at image-build time by unikernel/measure_capability.sh, absent in a
+// deployment that never measured (annotation is skipped, not faked).
+@ get_uk_examples_path → String {
+    ^ ( env_var_or `NURL_UNIKERNEL_EXAMPLES` `/opt/nurl/unikernel-examples.json` )
+}
+
+// Borrowed lookup into the parsed manifest: T when `name` is listed as
+// capable; reason (borrowed) via the out param convention is avoided —
+// the caller re-asks with __uk_example_reason. Two O(n) scans over a
+// 64-entry array cost nothing next to the dir listing around them.
+@ __uk_example_entry Json man s name → ?Json {
+    : i n ( json_arr_len man )
+    : ~ i k 0
+    ~ < k n {
+        ?? ( json_arr_get man k ) {
+            T e → {
+                ?? ( json_obj_get e `name` ) {
+                    T nj → {
+                        ? != 0 ( nurl_str_eq ( json_str_data nj ) name ) {
+                            ^ @ ?Json { T e }
+                        } {}
+                    }
+                    F → {}
+                }
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ^ @ ?Json { F 0 }
+}
+
 @ h_examples HttpRequest req Params params → HttpResponse {
     ( nurl_print `[srv] GET /examples\n` )
     : String edir ( get_examples_dir )
@@ -1901,14 +1934,34 @@ s combined_stdout s combined_stderr → v {
     ?? dr {
         T files → {
             : Json arr ( json_arr_new )
+            // The capability manifest, when this deployment has one.
+            // Json is an enum with owned payloads — held in a plain
+            // mutable binding plus a flag, never smuggled through an
+            // integer cast.
+            : String mpath ( get_uk_examples_path )
+            : ~ b have_man F
+            : ~ Json man ( json_null )
+            ? ( file_exists ( string_data mpath ) ) {
+                : !String IoErr mr ( read_file ( string_data mpath ) )
+                ?? mr {
+                    T mtxt → {
+                        : !Json JsonError mj ( json_parse ( string_data mtxt ) )
+                        ?? mj { T m → { ( json_free man ) = man m = have_man T } F _ → {} }
+                        ( string_free mtxt )
+                    }
+                    F _ → {}
+                }
+            } {}
+            ( string_free mpath )
             : ~ i i 0 ~ < i ( vec_len [String] files ) {
                 : ?String fs_opt ( vec_get [String] files i )
-                ?? fs_opt { T f → { ? ( string_ends_with f `.nu` ) { : String fpath ( path_join ( string_data edir ) ( string_data f ) ) : !i IoErr szr ( file_size ( string_data fpath ) ) : Json obj ( json_obj_new ) ( json_obj_set obj `name` ( json_str_lit ( string_data f ) ) ) ( json_obj_set obj `path` ( json_str_lit ( string_data f ) ) ) ( json_obj_set obj `bytes` ( json_int ?? szr { T s → s F _ → 0 } ) ) ( json_arr_push arr obj ) ( string_free fpath ) } {} } F → {} }
+                ?? fs_opt { T f → { ? ( string_ends_with f `.nu` ) { : String fpath ( path_join ( string_data edir ) ( string_data f ) ) : !i IoErr szr ( file_size ( string_data fpath ) ) : Json obj ( json_obj_new ) ( json_obj_set obj `name` ( json_str_lit ( string_data f ) ) ) ( json_obj_set obj `path` ( json_str_lit ( string_data f ) ) ) ( json_obj_set obj `bytes` ( json_int ?? szr { T s → s F _ → 0 } ) ) ? have_man { ?? ( __uk_example_entry man ( string_data f ) ) { T e → { ?? ( json_obj_get e `unikernel` ) { T uj → { ( json_obj_set obj `unikernel` ( json_bool ( json_as_bool uj ) ) ) } F → {} } ?? ( json_obj_get e `reason` ) { T rj → { ( json_obj_set obj `unikernel_reason` ( json_str_lit ( json_str_data rj ) ) ) } F → {} } } F _ → {} } } {} ( json_arr_push arr obj ) ( string_free fpath ) } {} } F → {} }
                 = i + i 1
             }
             : String body ( json_stringify arr )
             : HttpResponse res ( response_text 200 ( string_data body ) ) ( response_set_header res `Content-Type` `application/json` )
             ( json_free arr )
+            ( json_free man )
             : ~ i k 0 ~ < k ( vec_len [String] files ) { ?? ( vec_get [String] files k ) { T fs → ( string_free fs ) F → {} } = k + k 1 } ( vec_free [String] files ) ( string_free edir ) ( string_free body )
             ^ res
         }
@@ -3934,6 +3987,7 @@ s combined_stdout s combined_stderr → v {
     ( __push_target arr `macos-x64` `macOS x86_64 · Intel` `macOS` `/build_target` F `libSystem only · no HTTP/canvas/audio` )
     ( __push_target arr `macos-arm64` `macOS ARM64 · Apple Silicon` `macOS` `/build_target` F `libSystem only · no HTTP/canvas/audio` )
     ( __push_target arr `windows-x64` `Windows x86_64 · .exe (mingw-w64)` `Windows` `/build_windows` F `static libcurl HTTP · no canvas/audio` )
+    ( __push_target arr `unikernel-x64` `Unikernel x86_64 · bootable image (QEMU microvm)` `Unikernel` `/build_unikernel` F `boots as its own kernel · pure-NURL TCP/IP + TLS · no fork/exec/signals, no sqlite/canvas` )
     : String body ( json_stringify arr )
     : HttpResponse r ( response_text 200 ( string_data body ) )
     ( response_set_header r `Content-Type` `application/json; charset=utf-8` )

--- a/nurlapi/static/index.html
+++ b/nurlapi/static/index.html
@@ -173,6 +173,8 @@
     <input id="filename" type="text" value="main.nu" size="12" title="Filename used for diagnostics" />
     <label for="target">Target:</label>
     <select id="target" title="Compile target — see the hint to the right"></select>
+    <input id="ukargs" type="text" size="16" placeholder="guest args" style="display:none"
+           title="The guest program&#39;s argv — passed on the kernel command line as args=&quot;…&quot;" />
     <button id="build" class="primary" type="button">Build ⌘B</button>
     <button id="run" class="run" type="button" disabled>Run ⌘R</button>
     <button id="stop" class="stop" type="button" disabled>Stop</button>
@@ -236,6 +238,7 @@ const examples  = $("#examples");
 const filename  = $("#filename");
 const buildBtn  = $("#build");
 const targetSel = $("#target");
+const ukArgs    = $("#ukargs");
 const runBtn    = $("#run");
 const dlBtn     = $("#download");
 const output    = $("#output");
@@ -464,8 +467,13 @@ async function loadExamples() {
       const opt = document.createElement("option");
       opt.value = ex.name;
       opt.textContent = `${ex.name}  (${ex.bytes} B)`;
+      // Measured at image-build time by unikernel/measure_capability.sh;
+      // absent (= unknown) on a deployment that never measured.
+      opt.dataset.uk = ex.unikernel === undefined ? "unknown" : (ex.unikernel ? "yes" : "no");
+      opt.dataset.ukReason = ex.unikernel_reason || "";
       examples.appendChild(opt);
     }
+    applyExampleCapability(isUnikernelTarget());
   } catch (e) { /* no-op */ }
 }
 examples.addEventListener("change", async () => {
@@ -1039,10 +1047,30 @@ async function loadTargets() {
 
 // Surface the selected target's constraints in the build-info slot so
 // "no HTTP/canvas" is visible without hovering the dropdown.
+function isUnikernelTarget() {
+  const meta = targetMeta.get(targetSel.value);
+  return !!meta && meta.endpoint === "/build_unikernel";
+}
+
+// When the unikernel target is selected, examples the image build
+// MEASURED as incapable grey out, with the missing symbols as the
+// tooltip. Unknown (no manifest in this deployment) stays selectable.
+function applyExampleCapability(isUk) {
+  for (const opt of examples.options) {
+    if (!opt.value) continue;
+    const incapable = isUk && opt.dataset.uk === "no";
+    opt.disabled = incapable;
+    opt.title = incapable ? opt.dataset.ukReason : "";
+  }
+}
+
 function onTargetChange() {
   const meta = targetMeta.get(targetSel.value);
   buildInfo.textContent = (meta && meta.notes) || "";
   targetSel.title = (meta && meta.notes) || "Compile target";
+  const uk = isUnikernelTarget();
+  ukArgs.style.display = uk ? "" : "none";
+  applyExampleCapability(uk);
 }
 targetSel.addEventListener("change", onTargetChange);
 
@@ -1149,11 +1177,115 @@ async function buildBinary(meta) {
   targetSel.disabled = false;
 }
 
+// ── Unikernel build: image + in-playground boot ────────────────
+//
+// The server builds a PVH image, boots it under TCG with no network
+// device, and returns the guest console — so the browser user sees
+// their program RUN as a kernel without owning qemu. The ready-to-
+// paste commands cover taking it home.
+async function buildUnikernel(meta) {
+  clearOutput();
+  buildBtn.disabled = true;
+  targetSel.disabled = true;
+  runBtn.disabled = true;
+  dlBtn.disabled = true;
+  currentWasm = null;
+  buildInfo.textContent = `building ${meta.label}… (boots in the playground — allow ~10 s)`;
+
+  const payload = {
+    source: editorAPI.getValue(),
+    filename: filename.value || "main.nu",
+    boot: true,
+  };
+  const a = ukArgs.value.trim();
+  if (a) payload.args = a;
+
+  const t0 = performance.now();
+  let resp, body;
+  try {
+    resp = await fetch("/build_unikernel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    body = await resp.json();
+  } catch (e) {
+    logLine("network error: " + e.message, "stderr");
+    buildBtn.disabled = false;
+    targetSel.disabled = false;
+    buildInfo.textContent = "";
+    return;
+  }
+  const ms = Math.round(performance.now() - t0);
+
+  if (!resp.ok) {
+    section("BUILD FAILED (unikernel)");
+    logLine(typeof body.error === "string" ? body.error : JSON.stringify(body, null, 2), "stderr");
+    buildInfo.textContent = `failed in ${ms} ms`;
+    buildBtn.disabled = false;
+    targetSel.disabled = false;
+    return;
+  }
+
+  const ok = body.status === "ok";
+  section(ok ? "BUILD OK (unikernel image)" : "BUILD FAILED (unikernel)");
+  if (body.message) logLine(body.message, ok ? "ok" : "stderr");
+
+  if (ok) {
+    logLine(`image ${(body.image_bytes ?? 0).toLocaleString()} B · ${ms} ms total`, "dim");
+    const br = body.boot_result;
+    if (br && br.ran) {
+      section("GUEST CONSOLE (booted in the playground, TCG, no network)");
+      log(br.log || "(no output before the boot window closed)");
+      log("\n");
+      if (br.exit === 0) logLine("guest exit 0", "ok");
+      else if (typeof br.exit === "number") logLine(`guest exit ${br.exit}`, "warn");
+      else logLine(br.timed_out
+        ? "still running when the boot window closed (a server would — see the commands below to run it with a network)"
+        : "no exit recorded", "dim");
+      if (br.truncated) logLine("(console truncated at 64 KB)", "dim");
+    } else if (br && br.error) {
+      logLine("boot skipped: " + br.error, "warn");
+    }
+    if (body.elf_artifact) {
+      section("DOWNLOADS");
+      const art = body.elf_artifact;
+      const link = document.createElement("a");
+      link.href = art.download_url;
+      link.download = art.name;
+      link.textContent = `↓ bootable image  (${art.name}, ${art.bytes.toLocaleString()} B)`;
+      link.style.color = "var(--accent)";
+      link.style.display = "block";
+      link.style.margin = ".15rem 0";
+      output.appendChild(link);
+      log("\n");
+    }
+    if (body.boot) {
+      section("RUN IT YOURSELF");
+      logLine("plain (prints to your terminal):", "dim");
+      log(body.boot.qemu + "\n\n");
+      logLine("with a network (edit both 8080s to your program's port):", "dim");
+      log(body.boot.qemu_net + "\n");
+      if (body.boot.notes) logLine(body.boot.notes, "info");
+    }
+  } else if (body.stderr) {
+    section("stderr");
+    log(body.stderr, "stderr");
+  }
+
+  buildInfo.textContent = ok
+    ? `unikernel · ${(body.image_bytes ?? 0).toLocaleString()} B · ${ms} ms`
+    : `failed in ${ms} ms`;
+  buildBtn.disabled = false;
+  targetSel.disabled = false;
+}
+
 // ── Dispatch: build the currently selected target ─────────────
 function doBuild() {
   const meta = targetMeta.get(targetSel.value);
   if (!meta) { build(); return; }            // pre-/targets fallback
   if (meta.endpoint === "/build_wasm") build();
+  else if (meta.endpoint === "/build_unikernel") buildUnikernel(meta);
   else buildBinary(meta);
 }
 

--- a/unikernel/measure_capability.sh
+++ b/unikernel/measure_capability.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/measure_capability.sh — which of these programs build as
+#  unikernel images? MEASURED, not listed.
+#
+#  Usage:  measure_capability.sh <dir-of-.nu-programs> <out.json>
+#
+#  Each program is built with build_unikernel.sh exactly as a
+#  playground request would build it. The verdict is the link's: a
+#  program that produces an ELF is capable; one that does not is
+#  reported with the missing symbols that stopped it — `fork`,
+#  `sqlite3_open`, `nurl_canvas_init` say more than any category label,
+#  and a hand-kept list of "known incapable" names is exactly the kind
+#  of list that rots (it has cost this repo its CI coverage twice).
+#
+#  Output: a JSON array of {"name": "x.nu", "unikernel": bool,
+#  "reason": "…"} — consumed by nurlapi's GET /examples so the
+#  playground can grey out what cannot boot, with the reason visible.
+#
+#  NURL_UNIKERNEL_CACHE / NURL_JOBS respected. Programs are built in
+#  parallel; the shared object cache is flocked (U0), so the first
+#  builder populates it and the rest read it.
+# ============================================================
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIR="${1:?usage: measure_capability.sh <dir> <out.json>}"
+OUT="${2:?usage: measure_capability.sh <dir> <out.json>}"
+JOBS="${NURL_JOBS:-$(nproc 2>/dev/null || echo 4)}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+one() {
+    f="$1"
+    name="$(basename "$f")"
+    o="$work/${name%.nu}"
+    mkdir -p "$o"
+    if NURL_COMPILE_QUIET=1 "$ROOT/unikernel/build_unikernel.sh" "$f" \
+            --out-dir "$o" -o "$o/img.elf" >/dev/null 2>"$o/err"; then
+        printf '{"name":%s,"unikernel":true,"reason":""}\n' "\"$name\"" > "$o/verdict"
+        return 0
+    fi
+    # Why not: the missing symbols if it was the link, else the first
+    # error line. Symbol names are [A-Za-z0-9_$.] — safe to embed.
+    missing=$(grep -oE "undefined (reference to \`|symbol: )[A-Za-z0-9_]+" "$o/err" \
+              | sed -E "s/undefined (reference to \`|symbol: )//" | sort -u | head -6 \
+              | tr '\n' ' ' | sed 's/ $//; s/ /, /g')
+    if [ -n "$missing" ]; then
+        reason="needs symbols a unikernel does not provide: $missing"
+    else
+        # A compile error — one line, JSON-escaped the crude safe way:
+        # strip quotes/backslashes/control bytes rather than quote them.
+        reason=$(head -2 "$o/err" | tail -1 | tr -d '"\\' | tr -c 'A-Za-z0-9 _.:/()+,-' ' ' | cut -c1-160)
+        [ -n "$reason" ] || reason="does not build standalone"
+    fi
+    printf '{"name":%s,"unikernel":false,"reason":%s}\n' "\"$name\"" "\"$reason\"" > "$o/verdict"
+}
+export -f one
+export ROOT work
+
+find "$DIR" -maxdepth 1 -name '*.nu' -print0 | sort -z \
+    | xargs -0 -P "$JOBS" -I{} bash -c 'one "$@"' _ {}
+
+{
+    echo '['
+    first=1
+    while IFS= read -r v; do
+        [ "$first" = 1 ] || printf ',\n'
+        first=0
+        printf '%s' "$(cat "$v")"
+    done < <(find "$work" -name verdict | sort)
+    echo
+    echo ']'
+} > "$OUT"
+
+caps=$(grep -c '"unikernel":true' "$OUT" || true)
+total=$(grep -c '"name"' "$OUT" || true)
+echo "measure_capability: $caps/$total programs build as unikernel images → $OUT"


### PR DESCRIPTION
Phase U4 (U0 #801, U1 #802, U2 #803, U3 #804). The browser closes the
loop: **Unikernel x86_64** in the target dropdown → Build → the page
renders the guest console (the program running as its own kernel), the
image download, and both ready-to-paste QEMU commands. A guest-args
field feeds the kernel command line's `args="…"`.

Example capability is **measured, not listed**:
`unikernel/measure_capability.sh` links every bundled example at
image-build time exactly as a request would — 42/64 capable, ~60 s —
and the verdict's *reason is the missing symbols* (`fork`,
`canvas_close`, `nurl_signal_install…`), served via `GET /examples`
and shown as the tooltip on the greyed-out entries. No manifest → no
annotation, never a fake one.

Verified with a headless browser on the real page: args field appears,
exactly the 22 measured-incapable examples disabled, collatz.nu builds
and boots with `[nurl-exit] 0` rendered, zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1