### PR TITLE
feat: a NURL program boots as its own kernel on AArch64 too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            clang binutils qemu-system-x86 curl
+            clang binutils qemu-system-x86 qemu-system-arm curl
 
       - name: Build the compiler
         run: ./build.sh --no-tests
@@ -269,6 +269,27 @@ jobs:
         # reports there, so run_qemu.sh states it on the kernel command
         # line the way the plan says the host states the epoch.
         run: ./unikernel/run_qemu_tests.sh
+
+      - name: Fetch zig (the AArch64 cross toolchain)
+        # The same zig the ecosystem's install ships and the playground
+        # image carries; the aarch64 image is built with it rather than
+        # with a distro cross-gcc, so the toolchain in CI is the one a
+        # user gets.
+        run: |
+          ZIG_VERSION=0.13.0
+          curl -fsSL --retry 5 -o /tmp/zig.tar.xz \
+            "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
+          mkdir -p /opt/zig && sudo tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1
+
+      - name: The guest, on the OTHER architecture
+        # The claim the aarch64 port makes is that nothing above the
+        # bottom edge changed: the same corpus programs against the same
+        # hosted goldens, plus the device demos, on QEMU's virt board.
+        # A second architecture is what turns "portable" from a design
+        # intention into a measured property.
+        env:
+          NURL_ZIG: /opt/zig/zig
+        run: ./unikernel/run_qemu_arm64_tests.sh
 
   freebsd:
     name: FreeBSD (build + bootstrap fixed point + tests, in a VM)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A NURL program boots as its own kernel on AArch64 too** (unikernel
+  plan phase U6). QEMU's `virt` board, and the port is the size the
+  design predicted: **four files** differ — `boot/boot_arm64.S`
+  (EL2→EL1, FP/SIMD, vector table, stacks, `.bss`),
+  `boot/platform_arm64.c` (PL011, device tree, MMU, generic timer,
+  RNDR, PSCI), `boot/tls_guest_arm64.c` (the thread pointer) and
+  `nolibc/setjmp_aarch64.S`. Everything above that bottom edge is the
+  same code the x86_64 image runs, which the gate proves rather than
+  claims: `unikernel/run_qemu_arm64_tests.sh` is **15/15** — the same
+  corpus programs against the same hosted goldens, the device demos,
+  faults reported with exit 126, and an HTTP server in the guest
+  answering curl on the host. A hello image is 131 784 bytes, within a
+  kilobyte of the x86_64 one; the memory floor is 5 MiB. CI builds and
+  boots it on every commit, with zig as the cross toolchain — the same
+  zig the ecosystem installs.
+
+  `stdlib/runtime_ctx.c` gained an AArch64 fiber switch (AAPCS64:
+  x19–x28, x29/x30, d8–d15 and FPCR) beside the x86 one, so fibers,
+  channels and the M:N runtime work there natively rather than falling
+  back to ucontext.
+
+  Three machine differences are absorbed in the port rather than
+  pushed upward: `virt` announces its virtio-mmio devices in the DEVICE
+  TREE, so `platform_arm64.c` parses the tree and synthesizes the same
+  `virtio_mmio.device=` entries the x86 guest reads off its command
+  line; `virt` defaults to LEGACY virtio-mmio exactly as microvm does
+  (the guest read `version=1` and refused every device — correctly);
+  and the clock states its own frequency in `CNTFRQ_EL0`, so the
+  `tsc_khz=` handshake turns out to be an x86 quirk rather than part
+  of the contract. The TLS image's offset from the thread pointer is
+  MEASURED, not assumed: the boot code places the image, reads a
+  canary `__thread` back through the compiler's own addressing, and
+  refuses to run if the value is not there — a thread-local block off
+  by sixteen bytes reads plausible garbage.
+
+### Fixed
+
+- **nolibc was missing `getchar`** and nothing noticed, because
+  glibc's `<stdio.h>` defines it as a macro (`getc(stdin)`) — every
+  x86 build resolved the call in the preprocessor and never reached
+  the library. A libc whose completeness depends on which headers
+  happen to be installed is not complete; the AArch64 port, whose
+  headers declare it as a function, found it at the link line.
+  `nolibc/math.c`'s `sqrt` likewise assumed `sqrtsd`; it now selects
+  the architecture's instruction and refuses to compile (rather than
+  answer differently) on one where neither is known.
+
 - **MCP tool `nurl_build_unikernel`** (plan phase U5). An agent builds
   a bootable image and — because the tool's `boot` defaults ON, and an
   agent cannot run qemu — gets the guest console and exit status back

--- a/stdlib/runtime_ctx.c
+++ b/stdlib/runtime_ctx.c
@@ -55,6 +55,13 @@
 
 #if defined(__x86_64__) && !defined(_WIN32)
 #  define NURL_CTX_X86_64 1
+#elif defined(__aarch64__) && !defined(_WIN32)
+/* AArch64 (AAPCS64). Callee-saved: x19–x28, fp (x29), lr (x30), sp,
+ * the low 64 bits of v8–v15 (d8–d15), and FPCR — the rounding-mode
+ * register, this architecture's half of what MXCSR+x87cw are on x86
+ * (there is no separate mask register to seed: FPCR's trap-enable
+ * bits default to off and live in the same register). */
+#  define NURL_CTX_AARCH64 1
 #endif
 
 /* Mach-O gives every C symbol a leading underscore; ELF does not. A
@@ -227,7 +234,96 @@ void nurl_ctx_init(nurl_ctx_t *ctx, void *stack, unsigned long size,
 
 int nurl_ctx_available(void) { return 1; }
 
-#else /* !NURL_CTX_X86_64 — other architectures still use ucontext */
+#elif defined(NURL_CTX_AARCH64)
+
+/* The switch. Frame, from ctx->sp upward (11 pairs, 176 bytes, so sp
+ * stays 16-aligned — AAPCS64 requires it at every public interface,
+ * with none of x86's +8 asymmetry):
+ *
+ *     +0    fpcr           +8   (pad)
+ *     +16   d8  d9         +32  d10 d11
+ *     +48   d12 d13        +64  d14 d15
+ *     +80   x19 x20   <- entry arg / entry fn on first entry
+ *     +96   x21 x22        +112 x23 x24
+ *     +128  x25 x26        +144 x27 x28
+ *     +160  x29 x30   <- lr = where the restored context resumes
+ *
+ * The first switch into a fresh context `ret`s into the trampoline,
+ * which moves x19/x20 into place and calls the entry. */
+__attribute__((naked, noinline))
+void nurl_ctx_switch(nurl_ctx_t *save, nurl_ctx_t *restore)
+{
+    __asm__ volatile(
+        "stp x29, x30, [sp, #-16]!\n\t"
+        "stp x27, x28, [sp, #-16]!\n\t"
+        "stp x25, x26, [sp, #-16]!\n\t"
+        "stp x23, x24, [sp, #-16]!\n\t"
+        "stp x21, x22, [sp, #-16]!\n\t"
+        "stp x19, x20, [sp, #-16]!\n\t"
+        "stp d14, d15, [sp, #-16]!\n\t"
+        "stp d12, d13, [sp, #-16]!\n\t"
+        "stp d10, d11, [sp, #-16]!\n\t"
+        "stp d8,  d9,  [sp, #-16]!\n\t"
+        "mrs x2, fpcr\n\t"
+        "str x2, [sp, #-16]!\n\t"
+        "mov x2, sp\n\t"
+        "str x2, [x0]\n\t"            /* save->sp = sp                 */
+        "ldr x2, [x1]\n\t"
+        "mov sp, x2\n\t"              /* sp = restore->sp              */
+        "ldr x2, [sp], #16\n\t"
+        "msr fpcr, x2\n\t"
+        "ldp d8,  d9,  [sp], #16\n\t"
+        "ldp d10, d11, [sp], #16\n\t"
+        "ldp d12, d13, [sp], #16\n\t"
+        "ldp d14, d15, [sp], #16\n\t"
+        "ldp x19, x20, [sp], #16\n\t"
+        "ldp x21, x22, [sp], #16\n\t"
+        "ldp x23, x24, [sp], #16\n\t"
+        "ldp x25, x26, [sp], #16\n\t"
+        "ldp x27, x28, [sp], #16\n\t"
+        "ldp x29, x30, [sp], #16\n\t"
+        "ret\n\t"
+    );
+}
+
+/* First-entry trampoline: x19 holds the argument, x20 the entry point.
+ * `brk #0` and not a call to a diagnostic helper, for the same LTO
+ * reason the x86 version uses `ud2`: a fiber entry must never return,
+ * and below this frame is the bottom of a fresh stack, not a caller. */
+__attribute__((naked, noinline))
+static void nurl__ctx_trampoline(void)
+{
+    __asm__ volatile(
+        "mov x0, x19\n\t"
+        "blr x20\n\t"
+        "brk #0\n\t"
+    );
+}
+
+void nurl_ctx_init(nurl_ctx_t *ctx, void *stack, unsigned long size,
+                   void (*entry)(void *), void *arg)
+{
+    unsigned char *top = (unsigned char *)stack + size;
+    unsigned long  t   = (unsigned long)top & ~(unsigned long)15;
+    unsigned long *fp  = (unsigned long *)(t - 176);
+    unsigned long  i;
+
+    for (i = 0; i < 22; i++) fp[i] = 0;
+    /* Seed FPCR from the CURRENT thread so a fresh fiber starts in the
+     * process's rounding mode — the x86 lesson (a zeroed control word
+     * is a different machine), applied before it can bite here. */
+    __asm__ volatile("mrs %0, fpcr" : "=r"(fp[0]));
+    fp[10] = (unsigned long)arg;                 /* x19 */
+    fp[11] = (unsigned long)entry;               /* x20 */
+    fp[20] = 0;                                  /* x29 — ends the chain */
+    fp[21] = (unsigned long)&nurl__ctx_trampoline; /* x30 = lr          */
+
+    ctx->sp = (void *)fp;
+}
+
+int nurl_ctx_available(void) { return 1; }
+
+#else /* neither x86_64 nor aarch64 — other architectures still use ucontext */
 
 void nurl_ctx_switch(nurl_ctx_t *save, nurl_ctx_t *restore)
 {
@@ -258,7 +354,7 @@ static long nurl__ctx_counter;
 static long nurl__ctx_switches;
 static long nurl__ctx_arg_seen;
 
-#ifdef NURL_CTX_X86_64
+#if defined(NURL_CTX_X86_64) || defined(NURL_CTX_AARCH64)
 
 static void nurl__ctx_fpbounce(void *arg);
 
@@ -325,6 +421,7 @@ static void nurl__ctx_test_from_fiber(void)
  * `subq $8` is not decoration: a function is entered with rsp ≡ 8
  * (mod 16), so calling out from here without it would hand every callee
  * a misaligned stack. */
+#ifdef NURL_CTX_X86_64
 __attribute__((naked, noinline))
 static void nurl__ctx_bounce(void *arg)
 {
@@ -345,6 +442,31 @@ static void nurl__ctx_bounce(void *arg)
         "jmp 1b\n\t"
     );
 }
+#else /* NURL_CTX_AARCH64 — same fiber, this ISA's callee-saved set.
+       * `bl` clobbers lr, which is fine: this fiber never returns. */
+__attribute__((naked, noinline))
+static void nurl__ctx_bounce(void *arg)
+{
+    __asm__ volatile(
+        "bl " NURL_CTX_SYM(nurl__ctx_test_enter) "\n\t"
+        "movz x19, #0xbeef\n\t" "movk x19, #0xdead, lsl #16\n\t"
+        "movk x19, #0xbeef, lsl #32\n\t" "movk x19, #0xdead, lsl #48\n\t"
+        "mov x20, x19\n\t"
+        "mov x21, x19\n\t"
+        "mov x22, x19\n\t"
+        "mov x23, x19\n\t"
+        "1:\n\t"
+        "bl " NURL_CTX_SYM(nurl__ctx_test_leave) "\n\t"
+        "adrp x0, " NURL_CTX_SYM(nurl__ctx_fiber) "\n\t"
+        "add  x0, x0, :lo12:" NURL_CTX_SYM(nurl__ctx_fiber) "\n\t"
+        "adrp x1, " NURL_CTX_SYM(nurl__ctx_main) "\n\t"
+        "add  x1, x1, :lo12:" NURL_CTX_SYM(nurl__ctx_main) "\n\t"
+        "bl " NURL_CTX_SYM(nurl_ctx_switch) "\n\t"
+        "bl " NURL_CTX_SYM(nurl__ctx_test_enter) "\n\t"
+        "b 1b\n\t"
+    );
+}
+#endif
 
 /* Hand control back to whoever switched us in, annotated. Every C test
  * fiber below yields through this. */
@@ -360,10 +482,15 @@ static void nurl__ctx_fpbounce(void *arg)
 {
     (void)arg;
     nurl__ctx_test_enter();
+#ifdef NURL_CTX_X86_64
     unsigned       mx = 0x1f80u;              /* default, all masked   */
     unsigned short cw = 0x037fu;              /* x87 default           */
     __asm__ volatile("ldmxcsr %0" :: "m"(mx));
     __asm__ volatile("fldcw   %0" :: "m"(cw));
+#else
+    unsigned long fpcr = 0;                   /* RN, no traps — default */
+    __asm__ volatile("msr fpcr, %0" :: "r"(fpcr));
+#endif
     for (;;) nurl__ctx_test_yield();
 }
 
@@ -377,6 +504,7 @@ static void nurl__ctx_fpbounce(void *arg)
  * the comparison happens without the compiler touching any of it; the
  * clobber list makes it save whatever it had in those registers.
  */
+#ifdef NURL_CTX_X86_64
 long nurl_ctx_test_preserve(void)
 {
     nurl__ctx_test_init(nurl__ctx_bounce, (void *)0UL);
@@ -413,10 +541,61 @@ long nurl_ctx_test_preserve(void)
     nurl__ctx_test_from_fiber();
     return ok;
 }
+#else /* NURL_CTX_AARCH64 */
+long nurl_ctx_test_preserve(void)
+{
+    nurl__ctx_test_init(nurl__ctx_bounce, (void *)0UL);
+    long ok;
+    nurl__ctx_test_to_fiber();
+    /* Sentinels in x19–x23, switch, compare — one asm block for the
+     * same reason as the x86 version: register variables are not
+     * guaranteed to survive a call, so a C-level test would measure
+     * the compiler's spill choices rather than the switch. */
+    __asm__ volatile(
+        "movz x19, #0x1111\n\t" "movk x19, #0x1111, lsl #16\n\t"
+        "movk x19, #0x1111, lsl #32\n\t" "movk x19, #0x1111, lsl #48\n\t"
+        "movz x20, #0x2222\n\t" "movk x20, #0x2222, lsl #16\n\t"
+        "movk x20, #0x2222, lsl #32\n\t" "movk x20, #0x2222, lsl #48\n\t"
+        "movz x21, #0x3333\n\t" "movk x21, #0x3333, lsl #16\n\t"
+        "movk x21, #0x3333, lsl #32\n\t" "movk x21, #0x3333, lsl #48\n\t"
+        "movz x22, #0x4444\n\t" "movk x22, #0x4444, lsl #16\n\t"
+        "movk x22, #0x4444, lsl #32\n\t" "movk x22, #0x4444, lsl #48\n\t"
+        "movz x23, #0x5555\n\t" "movk x23, #0x5555, lsl #16\n\t"
+        "movk x23, #0x5555, lsl #32\n\t" "movk x23, #0x5555, lsl #48\n\t"
+        "mov x0, %[m]\n\t"
+        "mov x1, %[f]\n\t"
+        "bl " NURL_CTX_SYM(nurl_ctx_switch) "\n\t"
+        "mov %[ok], #0\n\t"
+        "movz x9, #0x1111\n\t" "movk x9, #0x1111, lsl #16\n\t"
+        "movk x9, #0x1111, lsl #32\n\t" "movk x9, #0x1111, lsl #48\n\t"
+        "cmp x19, x9\n\t" "b.ne 1f\n\t"
+        "movz x9, #0x2222\n\t" "movk x9, #0x2222, lsl #16\n\t"
+        "movk x9, #0x2222, lsl #32\n\t" "movk x9, #0x2222, lsl #48\n\t"
+        "cmp x20, x9\n\t" "b.ne 1f\n\t"
+        "movz x9, #0x3333\n\t" "movk x9, #0x3333, lsl #16\n\t"
+        "movk x9, #0x3333, lsl #32\n\t" "movk x9, #0x3333, lsl #48\n\t"
+        "cmp x21, x9\n\t" "b.ne 1f\n\t"
+        "movz x9, #0x4444\n\t" "movk x9, #0x4444, lsl #16\n\t"
+        "movk x9, #0x4444, lsl #32\n\t" "movk x9, #0x4444, lsl #48\n\t"
+        "cmp x22, x9\n\t" "b.ne 1f\n\t"
+        "movz x9, #0x5555\n\t" "movk x9, #0x5555, lsl #16\n\t"
+        "movk x9, #0x5555, lsl #32\n\t" "movk x9, #0x5555, lsl #48\n\t"
+        "cmp x23, x9\n\t" "b.ne 1f\n\t"
+        "mov %[ok], #1\n\t"
+        "1:\n\t"
+        : [ok] "=r"(ok)
+        : [m] "r"(&nurl__ctx_main), [f] "r"(&nurl__ctx_fiber)
+        : "x0", "x1", "x9", "x19", "x20", "x21", "x22", "x23", "x30",
+          "memory", "cc");
+    nurl__ctx_test_from_fiber();
+    return ok;
+}
+#endif
 
 /* Same question for the floating-point control words: set a non-default
  * rounding mode, bounce through a fiber that sets its own, and check we
  * get ours back. */
+#ifdef NURL_CTX_X86_64
 long nurl_ctx_test_fpcw(void)
 {
     nurl__ctx_test_init(nurl__ctx_fpbounce, (void *)0UL);
@@ -440,6 +619,26 @@ long nurl_ctx_test_fpcw(void)
     __asm__ volatile("fldcw   %0" :: "m"(cw_before));
     return (mx_after == mx_ours) && (cw_after == cw_ours);
 }
+#else /* NURL_CTX_AARCH64 — FPCR's RMode field plays both control words' part */
+long nurl_ctx_test_fpcw(void)
+{
+    nurl__ctx_test_init(nurl__ctx_fpbounce, (void *)0UL);
+    unsigned long fpcr_before, fpcr_after;
+    __asm__ volatile("mrs %0, fpcr" : "=r"(fpcr_before));
+
+    /* RMode [23:22] = 0b11, round toward zero. */
+    unsigned long fpcr_ours = (fpcr_before & ~(3UL << 22)) | (3UL << 22);
+    __asm__ volatile("msr fpcr, %0" :: "r"(fpcr_ours));
+
+    nurl__ctx_test_to_fiber();
+    nurl_ctx_switch(&nurl__ctx_main, &nurl__ctx_fiber);
+    nurl__ctx_test_from_fiber();
+
+    __asm__ volatile("mrs %0, fpcr" : "=r"(fpcr_after));
+    __asm__ volatile("msr fpcr, %0" :: "r"(fpcr_before));
+    return fpcr_after == fpcr_ours;
+}
+#endif
 
 /* Plain ping-pong, to count switches and prove the entry argument and
  * the fresh-frame path work. */

--- a/tools/check_nolibc_symbols.sh
+++ b/tools/check_nolibc_symbols.sh
@@ -42,8 +42,24 @@ for f in "$NOLIBC"/*.c; do
         exit 2
     }
 done
+# The assembly is per-architecture by name — start_x86_64.S,
+# setjmp_x86_64.S, setjmp_aarch64.S — and only THIS host's files
+# assemble with THIS host's compiler. Selecting by suffix keeps the
+# gate a statement about the machine it runs on; compiling all of them
+# would fail on whichever architecture the runner is not, which is
+# exactly what the aarch64 port did to this gate on an x86 runner.
+case "$(uname -m)" in
+    x86_64|amd64) arch_sfx=x86_64 ;;
+    aarch64|arm64) arch_sfx=aarch64 ;;
+    *) arch_sfx="" ;;
+esac
 for f in "$NOLIBC"/*.S; do
-    "$CC" -c "$f" -o "$TMP/nl/$(basename "${f%.S}").o" || exit 2
+    b="$(basename "${f%.S}")"
+    case "$b" in
+        *_x86_64|*_aarch64|*_riscv64)
+            [ -n "$arch_sfx" ] && [ "${b%_$arch_sfx}" != "$b" ] || continue ;;
+    esac
+    "$CC" -c "$f" -o "$TMP/nl/$b.o" || exit 2
 done
 
 nm -u "$TMP/core.o" | sed 's/^ *U //' | sort -u > "$TMP/needed"

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -27,10 +27,12 @@ Decided by coupling, not convenience:
 | `nolibc/` | the libc subset: `string.c`, `malloc.c`, `stdio.c`, `dtoa.c`, `math.c` (+ the generated `math_tables.h`), `misc.c`, `syscall_linux.c`, `tls_linux.c`, `start_x86_64.S`, `setjmp_x86_64.S` |
 | `runtime_bare.c` | threads, fibers, sync and entropy for one vCPU with nothing under it |
 | `net/sockets.nu` | the socket ABI (`nurl_tcp_*`, `nurl_udp_*`, `nurl_dns_*`, `nurl_reactor_wait_*`) in NURL, over the sans-IO stack in `stdlib/net/` |
-| `boot/` | the guest: PVH entry + long mode + SSE + the interrupt stubs (`boot.S`), the address space (`link.ld`), the machine's bottom edge (`platform_x86.c`), the pages themselves (`pagealloc.c`), the baked-in filesystem (`initfs.c`), the thread pointer without an auxv (`tls_guest.c`) |
+| `boot/` | the guest: PVH entry + long mode + SSE + the interrupt stubs (`boot.S`), the address space (`link.ld`), the machine's bottom edge (`platform_x86.c`), the pages themselves (`pagealloc.c`), the baked-in filesystem (`initfs.c`), the thread pointer without an auxv (`tls_guest.c`) — and their AArch64 counterparts `boot_arm64.S`, `link_arm64.ld`, `platform_arm64.c`, `tls_guest_arm64.c` (`pagealloc.c` and `initfs.c` are shared: portable C, one copy) |
 | `drivers/` | `virtionet.nu` — frames in and out over a real device |
-| `build_unikernel.sh` | build a `.nu` into a bootable PVH kernel image |
+| `build_unikernel.sh` | build a `.nu` into a bootable PVH kernel image (x86_64) |
+| `build_unikernel_arm64.sh` | the same, for AArch64 / QEMU `virt` |
 | `run_qemu.sh` · `run_qemu_tests.sh` | boot one image · run corpus tests inside the guest against their goldens |
+| `run_qemu_arm64.sh` · `run_qemu_arm64_tests.sh` | the AArch64 twins of those two |
 | `compile_nu.sh` | compile one program, pulling in `net/sockets.nu` when (and only when) it calls the socket ABI |
 | `demos/` | the programs that only make sense in the guest: devices, DHCP, a filesystem, a server, an MCP endpoint, TLS — and the two that are about failure, `fault.nu` and `soak.nu` |
 | `tests/` | the unit gates — differentials against glibc for strings, float formatting and libm; two allocator fuzzers; the scheduler's schedule and its deadlock detector |
@@ -350,6 +352,59 @@ bytes travel over the pure TCP stack and the virtio-net driver. The
 handshake is `stdlib/std/tls.nu` — pure NURL, no libssl, which is why
 it links here at all.
 
+## The second architecture (AArch64, QEMU `virt`)
+
+A second machine is what turns "portable" from an intention into a
+measured property, and the port is the size the design predicted:
+**four files** differ, and they are the four that talk to the machine.
+
+| | |
+|---|---|
+| `boot/boot_arm64.S` | EL2→EL1, FP/SIMD un-trapped, the vector table, `.bss`, the two stacks |
+| `boot/platform_arm64.c` | PL011 UART, the device tree, the MMU, the generic timer, RNDR, PSCI shutdown |
+| `boot/tls_guest_arm64.c` | the thread pointer — variant I, and **measured**, not assumed |
+| `nolibc/setjmp_aarch64.S` | `panic`/`recover`'s callee-saved set (which here includes `d8`–`d15`) |
+
+Everything else is the same code the x86_64 image runs: the runtime,
+nolibc, the sans-IO TCP/IP stack, the socket ABI, the virtio driver,
+the NURL program. `stdlib/runtime_ctx.c` gained an AArch64 fiber
+switch (AAPCS64: `x19`–`x28`, `x29`/`x30`, `d8`–`d15` and FPCR) beside
+the x86 one; the two are read together.
+
+The gate is `unikernel/run_qemu_arm64_tests.sh` — **15/15**: the same
+corpus programs against the same hosted goldens, the device demos,
+faults reported with exit 126, and an HTTP server in the guest
+answering `curl` on the host. A hello image is **131 784 bytes**, which
+is within a kilobyte of the x86_64 one (132 760) — the same program,
+the same runtime, two instruction sets. The floor is **5 MiB** (4 fails
+with `no usable memory above the image`: `virt` starts RAM at 1 GiB and
+the image links 2 MiB in).
+
+Three differences worth stating, because each was a debugging round:
+
+- **The device tree replaces the command line.** microvm announces its
+  virtio-mmio devices on the kernel command line; `virt` announces them
+  in the DTB. `platform_arm64.c` parses the tree and SYNTHESIZES the
+  same `virtio_mmio.device=size@base:irq` entries, so the NURL layer
+  above sees one format on both machines. `/chosen/bootargs` becomes
+  the command line the same way.
+- **`virt` is legacy virtio-mmio by default**, exactly as microvm is —
+  the guest read `version=1` off the register and refused every device,
+  correctly. `-global virtio-mmio.force-legacy=false` is as necessary
+  here as there.
+- **The clock is self-describing.** `CNTFRQ_EL0` states the frequency,
+  so there is no `tsc_khz=` handshake — that flag is an x86 quirk, not
+  part of the contract. `wallclock=` stays: a wall clock is the host's
+  to state on any machine.
+
+And one thing that is deliberately not assumed: the TLS image's offset
+from the thread pointer depends on the PT_TLS alignment the LINKER
+chose. `tls_guest_arm64.c` places the image, reads a canary
+`__thread` variable back through the compiler's own addressing, and
+accepts the placement only when the value is there — otherwise it says
+so and stops. A thread-local block that is off by sixteen bytes reads
+plausible garbage, which is the worst way for a port to be wrong.
+
 ## Measured
 
 `unikernel/bench_boot.sh` (QEMU 8.2, **TCG** — no `/dev/kvm` on this
@@ -438,8 +493,10 @@ unikernel/tests/run_unit_tests.sh        # strings / float format / libm /
 unikernel/run_nolibc_tests.sh            # the corpus, with no libc
 unikernel/run_qemu_tests.sh              # the guest, under a hypervisor
 unikernel/run_qemu_tests.sh hello        # one of them
+unikernel/run_qemu_arm64_tests.sh        # the guest, on the other architecture
 unikernel/build_nolibc.sh prog.nu        # build one program, no libc
-unikernel/build_unikernel.sh prog.nu     # build one bootable image
+unikernel/build_unikernel.sh prog.nu     # build one bootable image (x86_64)
+unikernel/build_unikernel_arm64.sh p.nu  # …and for AArch64 (needs zig)
 ```
 
 QEMU is the only thing the guest gate needs that a checkout does not

--- a/unikernel/boot/boot_arm64.S
+++ b/unikernel/boot/boot_arm64.S
@@ -1,0 +1,191 @@
+/*
+ * NURL unikernel — unikernel/boot/boot_arm64.S
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * From the first instruction to `kmain`, AArch64 (QEMU virt).
+ *
+ * The x86 twin has to build page tables and change CPU modes before a
+ * line of C can run; this architecture starts in a 64-bit exception
+ * level with the MMU off and C runs fine that way, so everything that
+ * can move to C has (the MMU comes up in platform_arm64.c, where it
+ * can print about what went wrong). What CANNOT wait:
+ *
+ *   1. dropping from EL2 to EL1, if the machine started us at EL2 —
+ *      every system register this port touches is the EL1 copy;
+ *   2. un-trapping the FP/SIMD unit (CPACR_EL1.FPEN): LLVM uses SIMD
+ *      for memcpy, so the first NURL instruction would trap before
+ *      the UART works — the same reason the x86 boot enables SSE
+ *      before calling C;
+ *   3. the vector table, before anything can fault (an exception with
+ *      VBAR unset lands at address 0 and the machine wanders off with
+ *      nothing printed — the x86 pass proved a silent fault is the
+ *      most expensive kind);
+ *   4. .bss cleared, while nothing lives in it, with x0 (the possible
+ *      DTB pointer) parked in a callee-saved register;
+ *   5. the two stacks. The kernel runs on SP_EL0 and exceptions are
+ *      taken on SP_EL1 — the hardware swaps stack pointers on entry,
+ *      which is the x86 TSS/IST design for free: a fault caused by a
+ *      stack that hit its guard page arrives on a stack that works.
+ *
+ * The DTB pointer: QEMU's virt board leaves the device tree at the
+ * start of RAM for bare-metal ELF kernels and does not promise x0;
+ * kmain probes x0 first (the Linux-boot convention costs nothing to
+ * honour) and then 0x4000_0000.
+ */
+
+    .section .text.boot, "ax", %progbits
+    .globl _arm64_start
+_arm64_start:
+    mov     x21, x0                 /* the possible DTB pointer        */
+
+    /* ── EL2 → EL1, when we start high ──────────────────────────── */
+    mrs     x1, CurrentEL
+    lsr     x1, x1, #2
+    cmp     x1, #2
+    b.ne    el1_entry
+
+    /* EL1 is AArch64, all the EL2 traps off. */
+    mov     x1, #(1 << 31)          /* HCR_EL2.RW = 1                  */
+    msr     HCR_EL2, x1
+    /* A sane SCTLR_EL1 before eret: MMU off, caches off, RES1 bits
+     * set the way the reset value has them. */
+    mov     x1, #0x0838
+    movk    x1, #0x30d0, lsl #16
+    msr     SCTLR_EL1, x1
+    /* No EL2 timer traps; the virtual counter is the one we read. */
+    mov     x1, #3
+    msr     CNTHCTL_EL2, x1
+    msr     CNTVOFF_EL2, xzr
+    /* Return "from" an exception into EL1h, everything masked until
+     * the vectors are up. */
+    mov     x1, #0x3c5              /* DAIF masked | EL1h              */
+    msr     SPSR_EL2, x1
+    adr     x1, el1_entry
+    msr     ELR_EL2, x1
+    eret
+
+el1_entry:
+    /* ── FP/SIMD on, vectors up ─────────────────────────────────── */
+    mov     x1, #(3 << 20)          /* CPACR_EL1.FPEN = no trapping    */
+    msr     CPACR_EL1, x1
+    adr     x1, vectors
+    msr     VBAR_EL1, x1
+    isb
+
+    /* ── .bss, before anything is kept in it ────────────────────── */
+    ldr     x1, =__bss_start
+    ldr     x2, =__bss_end
+1:  cmp     x1, x2
+    b.hs    2f
+    str     xzr, [x1], #8
+    b       1b
+2:
+
+    /* ── the two stacks ─────────────────────────────────────────────
+     * We are on SPSel=1 (SP_EL1) now: point it at the fault stack,
+     * then switch to SP_EL0 for the kernel proper. On any exception
+     * the hardware sets SPSel=1 again — the fault handler always has
+     * a stack that works, whatever the kernel did to its own. */
+    ldr     x1, =fault_stack_top
+    mov     sp, x1
+    msr     SPSel, #0
+    ldr     x1, =boot_stack_top
+    and     x1, x1, #~15
+    mov     sp, x1
+    mov     x29, xzr                /* end of the frame-pointer chain  */
+
+    mov     x0, x21
+    bl      kmain
+
+    /* kmain does not return. */
+3:  wfi
+    b       3b
+
+/* ── the vector table ─────────────────────────────────────────────
+ *
+ * Sixteen entries, 128 bytes apart, 2 KiB aligned. Each entry has
+ * room for four instructions of its own, so the stubs push the first
+ * register pair, record which entry fired, and merge; vec_common
+ * saves the rest and calls C. The frame layout is `struct
+ * fault_frame` in platform_arm64.c — the two are read together.
+ *
+ * Every entry reports. The ones that "cannot happen" (an exception
+ * from AArch32, an SError) are exactly the ones worth a report when
+ * they do.
+ */
+    .macro VEC n
+    .align 7
+    sub     sp, sp, #288
+    stp     x0, x1, [sp, #0]
+    mov     x0, #\n
+    b       vec_common
+    .endm
+
+    .align 11
+    .globl vectors
+vectors:
+    VEC 0   /* Sync,   current EL, SP_EL0 — the kernel faulted        */
+    VEC 1   /* IRQ,    current EL, SP_EL0                             */
+    VEC 2   /* FIQ,    current EL, SP_EL0                             */
+    VEC 3   /* SError, current EL, SP_EL0                             */
+    VEC 4   /* Sync,   current EL, SP_ELx — the fault handler faulted */
+    VEC 5   /* IRQ,    current EL, SP_ELx                             */
+    VEC 6   /* FIQ,    current EL, SP_ELx                             */
+    VEC 7   /* SError, current EL, SP_ELx                             */
+    VEC 8   /* Sync,   lower EL, AArch64 — nothing runs below EL1     */
+    VEC 9
+    VEC 10
+    VEC 11
+    VEC 12  /* Sync,   lower EL, AArch32                              */
+    VEC 13
+    VEC 14
+    VEC 15
+
+vec_common:
+    stp     x2, x3,   [sp, #16]
+    stp     x4, x5,   [sp, #32]
+    stp     x6, x7,   [sp, #48]
+    stp     x8, x9,   [sp, #64]
+    stp     x10, x11, [sp, #80]
+    stp     x12, x13, [sp, #96]
+    stp     x14, x15, [sp, #112]
+    stp     x16, x17, [sp, #128]
+    stp     x18, x19, [sp, #144]
+    stp     x20, x21, [sp, #160]
+    stp     x22, x23, [sp, #176]
+    stp     x24, x25, [sp, #192]
+    stp     x26, x27, [sp, #208]
+    stp     x28, x29, [sp, #224]
+    str     x30,      [sp, #240]
+    mrs     x1, ELR_EL1
+    str     x1,       [sp, #248]
+    mrs     x1, SPSR_EL1
+    str     x1,       [sp, #256]
+    mrs     x1, ESR_EL1
+    str     x1,       [sp, #264]
+    mrs     x1, FAR_EL1
+    str     x1,       [sp, #272]
+    mov     x1, sp                  /* the frame                       */
+    bl      pf_exception            /* (vector, frame) — does not return */
+1:  wfi
+    b       1b
+
+    .section .bss
+    .align 16
+    .skip 16 * 1024
+    .globl fault_stack_top
+fault_stack_top:
+
+    /* 64 KiB, the same size a coroutine gets, page-aligned with its
+     * bottom exported so it can be given the same guard page — see
+     * the x86 twin for the recursion this catches. */
+    .align 12
+    .globl boot_stack_bottom
+boot_stack_bottom:
+    .skip 64 * 1024
+    .align 16
+boot_stack_top:
+
+    .section .note.GNU-stack, "", %progbits

--- a/unikernel/boot/link_arm64.ld
+++ b/unikernel/boot/link_arm64.ld
@@ -1,0 +1,52 @@
+/* unikernel/boot/link_arm64.ld — the guest's address space, AArch64.
+ *
+ * QEMU's virt machine puts RAM at 0x4000_0000 and, for a bare-metal
+ * ELF -kernel, the device tree at the very start of it (the virt
+ * board doc states the DTB is limited to 1 MiB). The image therefore
+ * links 2 MiB in: clear of the DTB with room to spare, and 2 MiB-
+ * aligned so the identity map's block entries line up with the
+ * sections.
+ *
+ * Same section contract as the x86_64 script — the TLS image bounds,
+ * __bss_start/__bss_end for the boot code's clear, __heap_start as
+ * the floor of the allocator's arena. The ceiling comes from the
+ * device tree's /memory node, never from a guess.
+ */
+ENTRY(_arm64_start)
+
+SECTIONS
+{
+    . = 0x40200000;
+
+    .text : ALIGN(4096) {
+        *(.text.boot)
+        *(.text .text.*)
+    }
+
+    .rodata : ALIGN(4096) { *(.rodata .rodata.*) }
+
+    .data : ALIGN(4096) { *(.data .data.*) }
+
+    .tdata : ALIGN(64) {
+        __tls_image_start = .;
+        *(.tdata .tdata.*)
+        __tls_image_end = .;
+    }
+    .tbss : ALIGN(8) {
+        *(.tbss .tbss.*)
+        *(.tcommon)
+        __tls_memsz_end = .;
+    }
+
+    .bss : ALIGN(4096) {
+        __bss_start = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        __bss_end = .;
+    }
+
+    . = ALIGN(2M);
+    __heap_start = .;
+
+    /DISCARD/ : { *(.comment) *(.note.GNU-stack) *(.eh_frame) }
+}

--- a/unikernel/boot/platform_arm64.c
+++ b/unikernel/boot/platform_arm64.c
@@ -1,0 +1,864 @@
+/*
+ * NURL unikernel — unikernel/boot/platform_arm64.c
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * The guest's bottom edge on AArch64 (QEMU virt) — the twin of
+ * platform_x86.c, and hand-synced with it the way that file is
+ * hand-synced with nolibc/syscall_linux.c. The five services are the
+ * same; the machinery under each one differs:
+ *
+ *   write        a PL011 UART at 0x0900_0000.
+ *   memory       the /memory node of the device tree, never a guess,
+ *                over the same boot/pagealloc.c.
+ *   time         the generic timer: CNTVCT_EL0 counts, CNTFRQ_EL0
+ *                states the frequency — this machine's clock is
+ *                self-describing, so the x86 `tsc_khz=` handshake is
+ *                an x86 quirk, not part of the contract. `wallclock=`
+ *                stays: a wall clock is the host's to state.
+ *   entropy      RNDR, ID-register-gated. No source is a panic,
+ *                never a fallback — same absolute rule.
+ *   exit         the sentinel line, then PSCI SYSTEM_OFF (HVC, then
+ *                SMC for a conduit that wants it), then WFI.
+ *
+ * Plus the one thing x86 got from its hypervisor for free: microvm
+ * announces virtio-mmio devices on the kernel command line, virt
+ * announces them in the device tree. The NURL side (hal/virtio.nu)
+ * parses `virtio_mmio.device=` entries, so this file reads the tree
+ * and SYNTHESIZES those entries onto the command line — one format
+ * for the layer above, whatever the machine spoke below.
+ */
+
+void exit(int code);          /* nolibc/misc.c */
+long long write(int fd, const void *buf, unsigned long n);
+long long read(int fd, void *buf, unsigned long n);
+int open(const char *p, int fl, int mode);
+int close(int fd);
+long long lseek(int fd, long long off, int whence);
+void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off);
+int munmap(void *p, unsigned long len);
+
+struct nl_file;
+extern struct nl_file *stdout;
+int *nl_file_flags(struct nl_file *f);
+#define PF_F_LINEBUF 0x20
+
+typedef unsigned long      pf_size_t;
+typedef long               pf_ssize_t;
+typedef unsigned long long u64;
+typedef unsigned int       u32;
+
+extern unsigned char __heap_start[];
+
+/* ── the serial port ─────────────────────────────────────────────── */
+
+#define PL011_BASE 0x09000000UL
+#define PL011_DR   (*(volatile u32 *)(PL011_BASE + 0x00))
+#define PL011_FR   (*(volatile u32 *)(PL011_BASE + 0x18))
+#define PL011_CR   (*(volatile u32 *)(PL011_BASE + 0x30))
+
+static void uart_init(void) {
+    /* QEMU's PL011 comes up usable; setting UARTEN|TXE is stating what
+     * we rely on rather than trusting the reset state. */
+    PL011_CR = (1u << 0) | (1u << 8);
+}
+
+static void uart_putc(char c) {
+    if (c == '\n') {
+        while (PL011_FR & (1u << 5)) { }     /* TXFF */
+        PL011_DR = '\r';
+    }
+    while (PL011_FR & (1u << 5)) { }
+    PL011_DR = (u32)(unsigned char)c;
+}
+
+static void uart_puts(const char *s) { while (*s) uart_putc(*s++); }
+
+static void uart_putu(unsigned long v) {
+    char b[21];
+    int i = 20;
+    b[i] = 0;
+    if (!v) b[--i] = '0';
+    while (v) { b[--i] = (char)('0' + v % 10); v /= 10; }
+    uart_puts(&b[i]);
+}
+
+static void uart_puthex(u64 v) {
+    static const char hex[] = "0123456789abcdef";
+    uart_puts("0x");
+    for (int i = 60; i >= 0; i -= 4) uart_putc(hex[(v >> i) & 0xF]);
+}
+
+static void pf_shutdown(int code);
+
+void pf_panic(const char *msg) {
+    uart_puts("nurl: ");
+    uart_puts(msg);
+    uart_putc('\n');
+    pf_shutdown(127);
+    for (;;) __asm__ __volatile__("wfi");
+}
+
+/* ── faults ──────────────────────────────────────────────────────
+ *
+ * The frame vec_common in boot_arm64.S builds, low address first. The
+ * two files are read together; changing one without the other is a
+ * fault report that describes the wrong registers. */
+struct fault_frame {
+    u64 x[31];                /* x0–x30 */
+    u64 elr, spsr, esr, far;
+};
+
+static const char *vec_name(u64 v) {
+    switch (v) {
+    case 0:  return "sync (kernel)";
+    case 1:  return "IRQ";
+    case 2:  return "FIQ";
+    case 3:  return "SError";
+    case 4:  return "sync IN THE FAULT HANDLER";
+    case 5:  return "IRQ on the fault stack";
+    case 6:  return "FIQ on the fault stack";
+    case 7:  return "SError on the fault stack";
+    default: return "from a lower EL (nothing should run there)";
+    }
+}
+
+/* ESR_EL1.EC — the exception class. The names are the manual's, so a
+ * report is something someone can look up rather than a number. */
+static const char *esr_class(u64 esr) {
+    switch ((esr >> 26) & 0x3F) {
+    case 0x00: return "unknown reason";
+    case 0x07: return "FP/SIMD access trapped (CPACR misconfigured?)";
+    case 0x0E: return "illegal execution state";
+    case 0x15: return "SVC (no syscalls exist on this machine)";
+    case 0x18: return "trapped system-register access";
+    case 0x20: return "instruction abort (exec of unmapped/forbidden page)";
+    case 0x21: return "instruction abort (kernel)";
+    case 0x22: return "PC alignment";
+    case 0x24: return "data abort";
+    case 0x25: return "data abort (kernel)";
+    case 0x26: return "SP alignment";
+    case 0x2C: return "FP exception";
+    case 0x3C: return "BRK";
+    default:   return "see ESR.EC in the ARM ARM";
+    }
+}
+
+void pf_exception(u64 vector, struct fault_frame *f);
+
+void pf_exception(u64 vector, struct fault_frame *f) {
+    u64 ec = (f->esr >> 26) & 0x3F;
+    uart_puts("\nnurl: fault ");
+    uart_puts(vec_name(vector));
+    uart_puts(" — ");
+    uart_puts(esr_class(f->esr));
+    uart_puts("\n  esr=");
+    uart_puthex(f->esr);
+    uart_puts(" elr=");
+    uart_puthex(f->elr);
+    uart_puts(" spsr=");
+    uart_puthex(f->spsr);
+    if (ec == 0x20 || ec == 0x21 || ec == 0x24 || ec == 0x25) {
+        uart_puts("\n  far=");
+        uart_puthex(f->far);
+        /* WnR is only meaningful for data aborts. */
+        if (ec == 0x24 || ec == 0x25)
+            uart_puts((f->esr >> 6) & 1 ? " on write" : " on read");
+        else
+            uart_puts(" on instruction fetch");
+    }
+    uart_puts("\n  x0=");  uart_puthex(f->x[0]);
+    uart_puts(" x1=");     uart_puthex(f->x[1]);
+    uart_puts(" x2=");     uart_puthex(f->x[2]);
+    uart_puts(" x3=");     uart_puthex(f->x[3]);
+    uart_puts("\n  x19="); uart_puthex(f->x[19]);
+    uart_puts(" x29=");    uart_puthex(f->x[29]);
+    uart_puts(" x30=");    uart_puthex(f->x[30]);
+    uart_putc('\n');
+    /* 126, not 127: a fault is not a panic, and the harness can tell. */
+    pf_shutdown(126);
+    for (;;) __asm__ __volatile__("wfi");
+}
+
+/* ── the device tree ─────────────────────────────────────────────
+ *
+ * The one authoritative statement of what this machine is. A minimal
+ * walker, not a library: the flattened format is four token types and
+ * big-endian integers, and this file needs exactly three answers from
+ * it — /chosen/bootargs, /memory reg, and every "virtio,mmio" node's
+ * reg + interrupts.
+ */
+#define FDT_MAGIC       0xd00dfeed
+#define FDT_BEGIN_NODE  1
+#define FDT_END_NODE    2
+#define FDT_PROP        3
+#define FDT_NOP         4
+#define FDT_END         9
+
+static u32 be32(const unsigned char *p) {
+    return ((u32)p[0] << 24) | ((u32)p[1] << 16) | ((u32)p[2] << 8) | (u32)p[3];
+}
+static u64 be64(const unsigned char *p) {
+    return ((u64)be32(p) << 32) | be32(p + 4);
+}
+
+static int str_eq(const char *a, const char *b) {
+    while (*a && *a == *b) { a++; b++; }
+    return *a == *b;
+}
+static int str_prefix(const char *s, const char *pre) {
+    while (*pre && *s == *pre) { s++; pre++; }
+    return *pre == 0;
+}
+
+/* What the walk fills in. */
+static u64 fdt_ram_base, fdt_ram_size;
+static const char *fdt_bootargs;
+
+/* The synthesized command line: the DTB's bootargs plus one
+ * `virtio_mmio.device=` entry per device node, so the NURL layer sees
+ * the exact format microvm's auto-cmdline gives the x86 guest. */
+static char cmdline_buf[2048];
+static unsigned long cmdline_len;
+
+static void cl_puts(const char *s) {
+    while (*s && cmdline_len < sizeof cmdline_buf - 1)
+        cmdline_buf[cmdline_len++] = *s++;
+    cmdline_buf[cmdline_len] = 0;
+}
+static void cl_puthex(u64 v) {
+    static const char hex[] = "0123456789abcdef";
+    char b[17];
+    int i = 16;
+    b[i] = 0;
+    if (!v) b[--i] = '0';
+    while (v) { b[--i] = hex[v & 0xF]; v >>= 4; }
+    cl_puts("0x");
+    cl_puts(&b[i]);
+}
+static void cl_putu(u64 v) {
+    char b[21];
+    int i = 20;
+    b[i] = 0;
+    if (!v) b[--i] = '0';
+    while (v) { b[--i] = (char)('0' + v % 10); v /= 10; }
+    cl_puts(&b[i]);
+}
+
+/* One pass over the structure block. Depth-1 node names decide what a
+ * property means; #address-cells/#size-cells are read from the root
+ * (virt says 2/2, and the walker believes the tree, not the doc). */
+static void fdt_parse(const unsigned char *fdt) {
+    u32 off_struct  = be32(fdt + 8);
+    u32 off_strings = be32(fdt + 12);
+    const unsigned char *p = fdt + off_struct;
+    const char *strings = (const char *)fdt + off_strings;
+
+    int depth = 0;
+    u32 addr_cells = 2, size_cells = 2;
+    /* Per-node state for the virtio nodes: reg and irq arrive as
+     * separate properties, compatible may come after either, so the
+     * node is judged at its END. */
+    int  node_is_virtio = 0, node_is_memory = 0;
+    u64  node_reg_base = 0, node_reg_size = 0;
+    u64  node_irq = 0;
+    int  node_depth = -1;
+
+    for (;;) {
+        u32 tok = be32(p); p += 4;
+        if (tok == FDT_END) break;
+        if (tok == FDT_NOP) continue;
+        if (tok == FDT_BEGIN_NODE) {
+            const char *name = (const char *)p;
+            unsigned long n = 0;
+            while (name[n]) n++;
+            p += (n + 1 + 3) & ~3UL;
+            depth++;
+            if (depth == 2) {
+                node_is_virtio = str_prefix(name, "virtio_mmio@");
+                node_is_memory = str_prefix(name, "memory@") || str_eq(name, "memory");
+                node_reg_base = node_reg_size = node_irq = 0;
+                node_depth = depth;
+            }
+            continue;
+        }
+        if (tok == FDT_END_NODE) {
+            if (depth == node_depth) {
+                if (node_is_virtio && node_reg_size) {
+                    /* The x86 format: size@base:irq. The IRQ is the
+                     * GIC SPI number plus the SPI base (32) — the
+                     * number Linux would print — though the polling
+                     * driver above never uses it. */
+                    cl_puts(" virtio_mmio.device=");
+                    cl_puthex(node_reg_size);
+                    cl_puts("@");
+                    cl_puthex(node_reg_base);
+                    cl_puts(":");
+                    cl_putu(node_irq + 32);
+                }
+                if (node_is_memory && node_reg_size && !fdt_ram_size) {
+                    fdt_ram_base = node_reg_base;
+                    fdt_ram_size = node_reg_size;
+                }
+                node_is_virtio = node_is_memory = 0;
+                node_depth = -1;
+            }
+            depth--;
+            continue;
+        }
+        if (tok == FDT_PROP) {
+            u32 len  = be32(p);
+            u32 noff = be32(p + 4);
+            const unsigned char *val = p + 8;
+            const char *pname = strings + noff;
+            p += 8 + ((len + 3) & ~3UL);
+
+            if (depth == 1) {
+                if (str_eq(pname, "#address-cells")) addr_cells = be32(val);
+                if (str_eq(pname, "#size-cells"))    size_cells = be32(val);
+            }
+            if (depth == 2 && str_eq(pname, "bootargs")) {
+                /* /chosen/bootargs — only /chosen carries it at this
+                 * depth on virt, and believing a stray one elsewhere
+                 * would take a device's property as the command line. */
+                fdt_bootargs = (const char *)val;
+            }
+            if (depth == node_depth && str_eq(pname, "reg") &&
+                len >= (addr_cells + size_cells) * 4) {
+                node_reg_base = addr_cells == 2 ? be64(val) : be32(val);
+                node_reg_size = size_cells == 2 ? be64(val + addr_cells * 4)
+                                                : be32(val + addr_cells * 4);
+            }
+            if (depth == node_depth && str_eq(pname, "interrupts") && len >= 12) {
+                node_irq = be32(val + 4);        /* <type irq flags>   */
+            }
+            continue;
+        }
+        /* An unknown token means the walk is lost; stop rather than
+         * interpret noise as devices. */
+        break;
+    }
+}
+
+/* ── the kernel command line ─────────────────────────────────────── */
+
+static const char *cmdline;
+const char *nurl_boot_cmdline(void);
+const char *nurl_boot_cmdline(void) { return cmdline ? cmdline : ""; }
+
+static u64 cmdline_u64(const char *key) {
+    const char *p = cmdline;
+    unsigned long klen = 0;
+    if (!p) return 0;
+    while (key[klen]) klen++;
+    while (*p) {
+        const char *k = p;
+        unsigned long n = 0;
+        while (p[n] && p[n] != ' ' && p[n] != '=') n++;
+        if (n == klen && p[n] == '=') {
+            unsigned long i = 0;
+            for (; i < klen; i++) if (k[i] != key[i]) break;
+            if (i == klen) {
+                u64 v = 0;
+                const char *d = p + n + 1;
+                if (*d < '0' || *d > '9') return 0;
+                while (*d >= '0' && *d <= '9') { v = v * 10 + (u64)(*d - '0'); d++; }
+                return v;
+            }
+        }
+        while (*p && *p != ' ') p++;
+        while (*p == ' ') p++;
+    }
+    return 0;
+}
+
+/* ── memory ──────────────────────────────────────────────────────── */
+
+static unsigned char *heap_next;
+static unsigned char *heap_end;
+
+void          pa_init(unsigned long base, unsigned long len);
+unsigned long pa_alloc(unsigned long want);
+int           pa_free(unsigned long p, unsigned long len);
+void          pa_stats(unsigned long *live, unsigned long *peak, unsigned long *avail,
+                       unsigned long *largest, unsigned long *lost, int *holes);
+
+#define PT_POOL_TABLES 64
+static u64 *pt_pool;
+static u32  pt_pool_used;
+
+static void mem_init(void) {
+    u64 img = (u64)(unsigned long)__heap_start;
+    if (!fdt_ram_size)
+        pf_panic("the device tree reported no memory — refusing to guess "
+                 "how much RAM this machine has");
+    u64 base = fdt_ram_base, len = fdt_ram_size;
+    if (base + len <= img)
+        pf_panic("no usable memory above the image");
+    if (base < img) { len -= (img - base); base = img; }
+
+    heap_next = (unsigned char *)(unsigned long)base;
+    heap_end  = heap_next + len;
+
+    heap_next = (unsigned char *)(((unsigned long)heap_next + 4095) & ~4095UL);
+    pt_pool = (u64 *)heap_next;
+    heap_next += (unsigned long)PT_POOL_TABLES * 4096;
+    if (heap_next > heap_end) pf_panic("not enough memory for the page-table pool");
+    for (unsigned long i = 0; i < (unsigned long)PT_POOL_TABLES * 512; i++) pt_pool[i] = 0;
+
+    pa_init((unsigned long)heap_next, (unsigned long)(heap_end - heap_next));
+}
+
+int fs_is_file_fd(int fd);
+pf_ssize_t fs_read_fd(int fd, void *buf, pf_size_t n);
+long long fs_lseek_fd(int fd, long long off, int whence);
+int fs_close_fd(int fd);
+const unsigned char *fs_map_fd(int fd, unsigned long off);
+int fs_exists(const char *path);
+
+void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off) {
+    (void)addr; (void)prot; (void)flags;
+    if (fd >= 0 && fs_is_file_fd(fd)) {
+        const unsigned char *p = fs_map_fd(fd, (unsigned long)off);
+        return p ? (void *)p : (void *)-1;
+    }
+    unsigned long p = pa_alloc(len);
+    return p ? (void *)p : (void *)-1;
+}
+
+int munmap(void *p, unsigned long len) {
+    return pa_free((unsigned long)p, len) == 0 ? 0 : 0;
+}
+
+long long nurl_guest_mem(int which) {
+    unsigned long live = 0, peak = 0, avail = 0, largest = 0, lost = 0;
+    int holes = 0;
+    pa_stats(&live, &peak, &avail, &largest, &lost, &holes);
+    switch (which) {
+    case 0:  return (long long)live;
+    case 1:  return (long long)peak;
+    case 2:  return (long long)avail;
+    case 3:  return (long long)largest;
+    case 4:  return (long long)lost;
+    case 5:  return (long long)holes;
+    default: return 0;
+    }
+}
+
+/* ── the MMU ──────────────────────────────────────────────────────
+ *
+ * Up in C, where a mistake can still print. Identity map, 39-bit VA,
+ * 4 KiB granule: L1 covers 1 GiB per entry, L2 2 MiB, L3 4 KiB.
+ *
+ *   [0, 1G)    device memory, via an L2 table of 2 MiB blocks — a
+ *              table and not one big block so the null guard can
+ *              later split its first 2 MiB down to pages.
+ *   RAM        Normal write-back cacheable, 2 MiB L2 blocks, as many
+ *              L1 slots as the /memory node says the machine has.
+ *
+ * The MMU is not optional here even though C runs without it: the
+ * exclusive-access instructions the runtime's atomics compile to are
+ * only architecturally defined on cacheable memory, and mprotect —
+ * the guard pages under every coroutine stack — needs pages to
+ * protect. The x86 twin runs on 2 MiB pages split on demand from a
+ * boot-reserved pool; this one does exactly the same, from the same
+ * pool design, for the same reason (splitting must not allocate).
+ */
+#define PTE_VALID   (1UL << 0)
+#define PTE_TABLE   (1UL << 1)   /* L1/L2: next level. L3: page entry */
+#define PTE_AF      (1UL << 10)
+#define PTE_SH_IS   (3UL << 8)
+#define PTE_ATTR(n) ((u64)(n) << 2)
+#define PTE_RO      (1UL << 7)   /* AP[2]: read-only at EL1           */
+#define PTE_UXN     (1UL << 54)
+
+#define ATTR_NORMAL 0            /* MAIR slot 0: normal WB            */
+#define ATTR_DEV    1            /* MAIR slot 1: Device-nGnRE         */
+
+#define BLK_RAM  (PTE_VALID | PTE_AF | PTE_SH_IS | PTE_ATTR(ATTR_NORMAL) | PTE_UXN)
+#define BLK_DEV  (PTE_VALID | PTE_AF | PTE_ATTR(ATTR_DEV) | PTE_UXN)
+#define PG_RAM   (BLK_RAM | PTE_TABLE)   /* an L3 page sets bit 1     */
+#define PG_DEV   (BLK_DEV | PTE_TABLE)
+
+#define MAX_RAM_L2 8             /* 8 GiB of RAM is the map's ceiling */
+
+static u64 l1_table[512]  __attribute__((aligned(4096)));
+static u64 l2_dev[512]    __attribute__((aligned(4096)));
+static u64 l2_ram[MAX_RAM_L2][512] __attribute__((aligned(4096)));
+
+static void mmu_init(void) {
+    /* Device gigabyte: 512 × 2 MiB blocks. Execute-never, uncached. */
+    for (u64 i = 0; i < 512; i++)
+        l2_dev[i] = (i << 21) | BLK_DEV;
+    l1_table[0] = ((u64)(unsigned long)l2_dev) | PTE_VALID | PTE_TABLE;
+
+    /* RAM, from where the tree says it starts to where it says it
+     * ends, one L2 table per gigabyte. */
+    u64 ram_end = fdt_ram_base + fdt_ram_size;
+    u64 gb_first = fdt_ram_base >> 30;
+    u64 gb_last  = (ram_end - 1) >> 30;
+    if (gb_last - gb_first + 1 > MAX_RAM_L2)
+        pf_panic("more RAM than the boot page tables cover (raise MAX_RAM_L2)");
+    for (u64 g = gb_first; g <= gb_last; g++) {
+        u64 *l2 = l2_ram[g - gb_first];
+        for (u64 i = 0; i < 512; i++) {
+            u64 pa = (g << 30) | (i << 21);
+            l2[i] = pa < ram_end ? (pa | BLK_RAM) : 0;
+        }
+        l1_table[g] = ((u64)(unsigned long)l2) | PTE_VALID | PTE_TABLE;
+    }
+
+    /* MAIR: slot 0 normal WB (0xFF), slot 1 Device-nGnRE (0x04). */
+    u64 mair = 0xFFUL | (0x04UL << 8);
+    /* TCR: 39-bit VA (T0SZ=25), 4 KiB granule, WB WA cacheable walks,
+     * inner shareable, TTBR1 walks off, 40-bit IPA. */
+    u64 tcr = 25UL | (1UL << 8) | (1UL << 10) | (3UL << 12)
+            | (0UL << 14) | (1UL << 23) | (2UL << 32);
+
+    __asm__ __volatile__(
+        "msr MAIR_EL1, %0\n\t"
+        "msr TCR_EL1, %1\n\t"
+        "msr TTBR0_EL1, %2\n\t"
+        "isb\n\t"
+        :: "r"(mair), "r"(tcr), "r"((u64)(unsigned long)l1_table));
+
+    u64 sctlr;
+    __asm__ __volatile__("mrs %0, SCTLR_EL1" : "=r"(sctlr));
+    sctlr |= (1UL << 0) | (1UL << 2) | (1UL << 12);   /* M | C | I */
+    __asm__ __volatile__(
+        "dsb sy\n\t"
+        "msr SCTLR_EL1, %0\n\t"
+        "isb\n\t"
+        "tlbi vmalle1\n\t"
+        "dsb sy\n\t"
+        "isb\n\t" :: "r"(sctlr));
+}
+
+/* ── page protection ─────────────────────────────────────────────
+ * Same contract, same pool discipline as the x86 twin; the tree is
+ * one level deeper. */
+static u64 *l2_entry_for(u64 va) {
+    u64 l1i = (va >> 30) & 511;
+    if (!(l1_table[l1i] & PTE_VALID)) return 0;
+    u64 *l2 = (u64 *)(unsigned long)(l1_table[l1i] & 0x0000FFFFFFFFF000UL);
+    return &l2[(va >> 21) & 511];
+}
+
+static void split_2m(u64 *l2e) {
+    if (*l2e & PTE_TABLE) return;                    /* already a table */
+    if (pt_pool_used >= PT_POOL_TABLES)
+        pf_panic("out of page tables — more coroutine stacks than the "
+                 "boot-time pool was sized for");
+    u64 base = *l2e & 0x0000FFFFFFE00000UL;
+    u64 attrs = (*l2e & ~0x0000FFFFFFE00000UL) | PTE_TABLE;
+    u64 *l3 = pt_pool + (unsigned long)pt_pool_used * 512;
+    pt_pool_used++;
+    for (int i = 0; i < 512; i++) l3[i] = (base + (u64)i * 4096) | attrs;
+    *l2e = ((u64)(unsigned long)l3) | PTE_VALID | PTE_TABLE;
+    __asm__ __volatile__("dsb ish" ::: "memory");
+}
+
+int madvise(void *p, unsigned long len, int advice) {
+    (void)p; (void)len; (void)advice;
+    return 0;
+}
+
+int mprotect(void *p, unsigned long len, int prot) {
+    u64 va = (u64)(unsigned long)p & ~0xFFFUL;
+    u64 end = ((u64)(unsigned long)p + len + 4095) & ~0xFFFUL;
+
+    if (!pt_pool) return -1;
+    for (; va < end; va += 4096) {
+        u64 *l2e = l2_entry_for(va);
+        if (!l2e || !(*l2e & PTE_VALID)) return -1;
+        split_2m(l2e);
+        u64 *l3 = (u64 *)(unsigned long)(*l2e & 0x0000FFFFFFFFF000UL);
+        u64 *pte = &l3[(va >> 12) & 511];
+        u64 frame = *pte & 0x0000FFFFFFFFF000UL;
+        if (prot == 0)       *pte = frame;                    /* invalid */
+        else if (prot & 0x2) *pte = frame | PG_RAM;
+        else                 *pte = frame | PG_RAM | PTE_RO;
+        __asm__ __volatile__(
+            "dsb ishst\n\t"
+            "tlbi vaae1, %0\n\t"
+            "dsb ish\n\t"
+            "isb\n\t" :: "r"(va >> 12) : "memory");
+    }
+    return 0;
+}
+
+extern unsigned char boot_stack_bottom[];
+
+static void pf_guard_boot_stack(void) {
+    (void)mprotect(boot_stack_bottom, 4096, 0);
+}
+
+/* Page zero sits in the device gigabyte; unmapping it makes a null
+ * dereference the fault every caller's error handling was written
+ * against, exactly as on x86. Nothing this port needs lives below
+ * 4096 — the DTB is at the start of RAM, not at zero. */
+static void pf_guard_null_page(void) {
+    (void)mprotect((void *)0, 4096, 0);
+}
+
+/* ── time ────────────────────────────────────────────────────────── */
+
+static u64 cnt_freq;
+static u64 cnt_base;
+static u64 wall_base_sec;
+
+static inline u64 cntvct(void) {
+    u64 v;
+    __asm__ __volatile__("isb; mrs %0, CNTVCT_EL0" : "=r"(v));
+    return v;
+}
+
+static void time_init(void) {
+    __asm__ __volatile__("mrs %0, CNTFRQ_EL0" : "=r"(cnt_freq));
+    /* Self-describing hardware, but firmware is what programs CNTFRQ
+     * and broken firmware exists; the command line may override, the
+     * same trust model as x86's tsc_khz= (the host controls the whole
+     * image anyway). */
+    u64 told = cmdline_u64("cntfrq");
+    if (told) cnt_freq = told;
+    wall_base_sec = cmdline_u64("wallclock");
+    cnt_base = cntvct();
+}
+
+int clock_gettime(int clk, void *tsp) {
+    u64 *ts = (u64 *)tsp;
+    if (!cnt_freq)
+        pf_panic("CNTFRQ_EL0 reads zero and no cntfrq= on the command "
+                 "line — refusing to invent a clock");
+    u64 ticks = cntvct() - cnt_base;
+    u64 sec  = ticks / cnt_freq;
+    u64 rem  = ticks % cnt_freq;
+    ts[0] = sec;
+    ts[1] = rem * 1000000000ULL / cnt_freq;
+    if (clk == 0) ts[0] += wall_base_sec;
+    return 0;
+}
+
+int nanosleep(const void *req, void *rem) {
+    const u64 *ts = (const u64 *)req;
+    (void)rem;
+    if (!cnt_freq) return 0;
+    u64 want_ns = ts[0] * 1000000000ULL + ts[1];
+    u64 ticks = want_ns / 1000 * cnt_freq / 1000000ULL;
+    u64 start = cntvct();
+    while (cntvct() - start < ticks) __asm__ __volatile__("yield");
+    return 0;
+}
+
+/* ── entropy ─────────────────────────────────────────────────────── */
+
+long long getrandom(void *buf, unsigned long len, unsigned int flags) {
+    unsigned char *p = (unsigned char *)buf;
+    unsigned long done = 0;
+    u64 isar0;
+    (void)flags;
+
+    __asm__ __volatile__("mrs %0, ID_AA64ISAR0_EL1" : "=r"(isar0));
+    if (((isar0 >> 60) & 0xF) == 0)
+        pf_panic("no RNDR on this vCPU and no virtio-rng — refusing to "
+                 "generate keys (use -cpu max)");
+
+    while (done < len) {
+        u64 v;
+        u64 ok;
+        int tries = 0;
+        do {
+            /* RNDR — s3_3_c2_c4_0; NZCV.Z set on failure. */
+            __asm__ __volatile__(
+                "mrs %0, s3_3_c2_c4_0\n\t"
+                "cset %1, ne\n\t" : "=r"(v), "=r"(ok) :: "cc");
+        } while (!ok && ++tries < 32);
+        if (!ok) pf_panic("RNDR failed repeatedly — refusing to continue");
+        for (int i = 0; i < 8 && done < len; i++, done++)
+            p[done] = (unsigned char)(v >> (i * 8));
+    }
+    return (long long)len;
+}
+
+/* ── the file surface nolibc expects ─────────────────────────────── */
+
+int nl_errno_slot;
+int *__errno_location(void) { return &nl_errno_slot; }
+
+long long write(int fd, const void *buf, unsigned long n) {
+    const char *p = (const char *)buf;
+    (void)fd;
+    for (unsigned long i = 0; i < n; i++) uart_putc(p[i]);
+    return (long long)n;
+}
+
+long long read(int fd, void *buf, unsigned long n) {
+    if (fs_is_file_fd(fd)) return (long long)fs_read_fd(fd, buf, n);
+    (void)buf; (void)n;
+    return 0;
+}
+
+int nl_open(const char *path, int flags, int mode);
+int open(const char *p, int fl, int mode) { return nl_open(p, fl, mode); }
+int close(int fd) {
+    if (fs_is_file_fd(fd)) return fs_close_fd(fd);
+    return 0;
+}
+long long lseek(int fd, long long off, int whence) {
+    if (fs_is_file_fd(fd)) return fs_lseek_fd(fd, off, whence);
+    (void)off; (void)whence;
+    return -1;
+}
+
+pf_ssize_t nl_write(int fd, const void *buf, pf_size_t n) { return (pf_ssize_t)write(fd, buf, n); }
+pf_ssize_t nl_read(int fd, void *buf, pf_size_t n) { return (pf_ssize_t)read(fd, buf, n); }
+int nl_close(int fd) { return close(fd); }
+long long nl_lseek(int fd, long long off, int whence) { return lseek(fd, off, whence); }
+
+void *nl_map(pf_size_t len) {
+    void *p = mmap(0, len, 0, 0, -1, 0);
+    return p == (void *)-1 ? 0 : p;      /* the nolibc convention — see the x86 twin */
+}
+int nl_unmap(void *p, pf_size_t len) { return munmap(p, len); }
+void nl_exit_group(int code) { pf_shutdown(code); for (;;) { } }
+
+int unlink(const char *p) { (void)p; return -1; }
+
+long nl_syscall6(long n, long a, long b, long c, long d, long e, long f) {
+    (void)n; (void)a; (void)b; (void)c; (void)d; (void)e; (void)f;
+    return -38;                                        /* -ENOSYS */
+}
+
+long nl_ret(long r) {
+    if (r < 0 && r > -4096) { nl_errno_slot = (int)-r; return -1; }
+    return r;
+}
+int mkdir(const char *p, int mode) { (void)p; (void)mode; return -1; }
+
+int access(const char *p, int mode) {
+    if (!p) return -1;
+    if (mode & 3) { nl_errno_slot = 13 /* EACCES */; return -1; }
+    if (!fs_exists(p)) { nl_errno_slot = 2 /* ENOENT */; return -1; }
+    return 0;
+}
+int getpid(void) { return 1; }
+
+/* ── shutdown ────────────────────────────────────────────────────── */
+
+static void pf_shutdown(int code) {
+    /* The sentinel line is the primary protocol on every arch — see
+     * the x86 twin for why. */
+    uart_puts("[nurl-exit] ");
+    uart_putu((unsigned long)(code & 0xff));
+    uart_putc('\n');
+
+    /* PSCI SYSTEM_OFF (0x8400_0008). QEMU's virt board implements PSCI
+     * for a guest that starts at EL1 over HVC, which is the conduit
+     * this port uses (boot_arm64.S drops to EL1 immediately). SMC would
+     * be the other conduit, and it is not attempted: assembling it
+     * needs `.arch armv8-a+sm4`-class permission the freestanding build
+     * does not grant, and a machine whose PSCI is behind SMC has
+     * firmware this guest is not running under.
+     *
+     * If PSCI is absent the call returns and the loop below parks the
+     * CPU — the sentinel line above has already told the harness what
+     * happened, which is why that line and not this call is the
+     * protocol. */
+    register u64 x0 __asm__("x0") = 0x84000008;
+    __asm__ __volatile__("hvc #0" :: "r"(x0) : "memory");
+    for (;;) __asm__ __volatile__("wfi");
+}
+
+void _exit(int code) { pf_shutdown(code); for (;;) { } }
+
+/* ── entry ───────────────────────────────────────────────────────── */
+
+extern char **nl_environ;
+extern void nl_tls_init_guest(void);
+extern int main(int argc, char **argv);
+
+#define ARGV_MAX 32
+static char *guest_argv[ARGV_MAX + 1];
+static char  argv_buf[1024];
+
+static int build_argv(const char *cl) {
+    int argc = 1;
+    guest_argv[0] = (char *)"nurl";
+    if (!cl) return argc;
+
+    const char *p = cl;
+    while (*p) {
+        if (p[0] == 'a' && p[1] == 'r' && p[2] == 'g' && p[3] == 's' &&
+            p[4] == '=' && p[5] == '"') {
+            const char *q = p + 6;
+            unsigned long n = 0;
+            while (*q && *q != '"' && n < sizeof argv_buf - 1) argv_buf[n++] = *q++;
+            argv_buf[n] = 0;
+            unsigned long i = 0;
+            while (i < n && argc < ARGV_MAX) {
+                while (i < n && argv_buf[i] == ' ') argv_buf[i++] = 0;
+                if (i >= n) break;
+                guest_argv[argc++] = &argv_buf[i];
+                while (i < n && argv_buf[i] != ' ') i++;
+            }
+            break;
+        }
+        while (*p && *p != ' ') p++;
+        while (*p == ' ') p++;
+    }
+    guest_argv[argc] = 0;
+    return argc;
+}
+
+void kmain(unsigned long x0);
+
+void kmain(unsigned long x0) {
+    static char *no_argv[2];
+
+    uart_init();
+    *nl_file_flags(stdout) |= PF_F_LINEBUF;
+
+    /* The device tree: x0 if whoever started us honoured the Linux
+     * convention, the start of RAM otherwise (where QEMU's virt board
+     * puts it for a bare-metal ELF). Without one this port knows
+     * neither its memory nor its devices, and says so. */
+    const unsigned char *fdt = 0;
+    if (x0 && be32((const unsigned char *)x0) == FDT_MAGIC)
+        fdt = (const unsigned char *)x0;
+    else if (be32((const unsigned char *)0x40000000UL) == FDT_MAGIC)
+        fdt = (const unsigned char *)0x40000000UL;
+    if (!fdt)
+        pf_panic("no device tree in x0 or at the start of RAM — was this "
+                 "image started with qemu-system-aarch64 -M virt -kernel?");
+    fdt_parse(fdt);
+
+    /* The command line the layers above see: the DTB's bootargs, then
+     * the virtio entries the walk synthesized (fdt_parse appended them
+     * to cmdline_buf already — bootargs go in FRONT of them now). */
+    {
+        char tail[sizeof cmdline_buf];
+        unsigned long tn = cmdline_len;
+        for (unsigned long i = 0; i < tn; i++) tail[i] = cmdline_buf[i];
+        cmdline_len = 0;
+        cmdline_buf[0] = 0;
+        if (fdt_bootargs) cl_puts(fdt_bootargs);
+        for (unsigned long i = 0; i < tn && cmdline_len < sizeof cmdline_buf - 1; i++)
+            cmdline_buf[cmdline_len++] = tail[i];
+        cmdline_buf[cmdline_len] = 0;
+        cmdline = cmdline_buf;
+    }
+
+    mem_init();
+    mmu_init();
+    pf_guard_boot_stack();
+    pf_guard_null_page();
+    time_init();
+    nl_tls_init_guest();
+
+    no_argv[0] = 0;
+    nl_environ = no_argv;
+
+    int argc = build_argv(cmdline);
+    exit(main(argc, guest_argv));
+}

--- a/unikernel/boot/tls_guest_arm64.c
+++ b/unikernel/boot/tls_guest_arm64.c
@@ -1,0 +1,74 @@
+/*
+ * NURL unikernel — unikernel/boot/tls_guest_arm64.c
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * The thread pointer, for a machine with no auxv — AArch64.
+ *
+ * Same job as tls_guest.c, different ABI. AArch64 uses TLS variant I:
+ * the thread pointer (TPIDR_EL0) points at a two-word reserved block
+ * and the thread's image sits ABOVE it, at tp + 16 rounded up to the
+ * image's own alignment. x86-64's variant II has the image BELOW the
+ * pointer with tp[0] pointing at itself. Get this backwards and every
+ * `__thread` read lands in the reserved words or past the block — a
+ * wrong value, not a crash, which is the worst way to be wrong.
+ *
+ * And the rounding is exactly the part that is easy to get wrong from
+ * the documentation: the offset depends on the PT_TLS alignment the
+ * LINKER chose, which depends on this program's own variables and on
+ * the linker script. So it is MEASURED, not derived: a canary
+ * `__thread` variable is read back after the image is placed, and the
+ * placement is accepted only when the compiler's own addressing finds
+ * the value the image says is there. If no candidate works the machine
+ * says so and stops, rather than running with every thread-local off
+ * by sixteen bytes.
+ *
+ * TPIDR_EL0 is written directly; there is no set_thread_area syscall
+ * to make on a machine with no kernel.
+ */
+
+extern unsigned char __tls_image_start[];
+extern unsigned char __tls_image_end[];
+extern unsigned char __tls_memsz_end[];
+
+void pf_panic(const char *msg);
+
+#define TLS_MAX 8192
+static unsigned char tls_block[TLS_MAX] __attribute__((aligned(64)));
+
+/* The canary. Its value is in the .tdata image, so reading it through
+ * the compiler's own TLS addressing is a direct test of "is the image
+ * where the compiler thinks it is". Volatile so the read is not
+ * constant-folded from the initializer. */
+static __thread volatile unsigned long tls_canary = 0x4E55524CC0FFEEULL;
+
+void nl_tls_init_guest(void) {
+    unsigned long filesz = (unsigned long)(__tls_image_end - __tls_image_start);
+    unsigned long memsz  = (unsigned long)(__tls_memsz_end - __tls_image_start);
+    unsigned char *tp = tls_block;
+    unsigned long cand;
+    unsigned long i;
+
+    ((void **)tp)[0] = 0;              /* the two reserved words */
+    ((void **)tp)[1] = 0;
+    __asm__ __volatile__("msr TPIDR_EL0, %0" :: "r"((unsigned long)tp));
+
+    /* tp + 16 rounded up to the alignment the linker picked. 16 is the
+     * unrounded case; the rest are the alignments a PT_TLS segment
+     * plausibly has, smallest first, so the first hit is the right one
+     * rather than a larger one that happens to also contain the
+     * canary. */
+    static const unsigned long candidates[] = { 16, 32, 64, 128, 256, 512, 1024, 4096 };
+    for (unsigned long c = 0; c < sizeof candidates / sizeof candidates[0]; c++) {
+        cand = candidates[c];
+        if (cand + memsz > TLS_MAX) break;
+        unsigned char *img = tp + cand;
+        for (i = 0; i < filesz; i++) img[i] = __tls_image_start[i];
+        for (i = filesz; i < memsz; i++) img[i] = 0;
+        if (tls_canary == 0x4E55524CC0FFEEULL) return;   /* the compiler agrees */
+    }
+    pf_panic("cannot place the TLS image where this build addresses it "
+             "— no candidate offset from the thread pointer holds the "
+             "canary (a linker with an unexpected PT_TLS alignment?)");
+}

--- a/unikernel/build_unikernel_arm64.sh
+++ b/unikernel/build_unikernel_arm64.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/build_unikernel_arm64.sh — build a NURL program into a
+#  bootable AArch64 kernel image for QEMU's `virt` machine.
+#
+#  Usage:  build_unikernel_arm64.sh prog.nu [-o out.elf]
+#              [--fs dir] [--out-dir dir]
+#
+#  Everything above the bottom edge is the SAME code the x86_64 image
+#  runs — runtime_core.c, runtime_bare.c, nolibc, the NURL program.
+#  Exactly four files differ, and they are the ones that talk to the
+#  machine:
+#
+#    boot/boot_arm64.S        EL2→EL1, FP/SIMD, vectors, stacks, .bss
+#    boot/platform_arm64.c    PL011, device tree, MMU, generic timer,
+#                             RNDR, PSCI shutdown
+#    boot/tls_guest_arm64.c   the thread pointer (variant I, measured)
+#    nolibc/setjmp_aarch64.S  panic/recover's callee-saved set
+#
+#  which is the whole point of the arrangement: a second architecture
+#  is a bottom edge, not a port of the system.
+#
+#  The cross toolchain is zig cc (already in the ecosystem's install and
+#  in the playground image) targeting aarch64-freestanding-none. Same
+#  --out-dir / cache contract as the x86_64 script, and the cache is
+#  keyed separately so both architectures can be built side by side.
+# ============================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BOOT="$ROOT/unikernel/boot"
+NOLIBC="$ROOT/unikernel/nolibc"
+ZIG="${NURL_ZIG:-${ZIG:-zig}}"
+command -v "$ZIG" >/dev/null 2>&1 || ZIG="$HOME/.nurl/zig/zig"
+SRC=""
+OUT=""
+FSDIR=""
+OUTDIR="${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel-arm64}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -o) OUT="$2"; shift 2 ;;
+        --fs) FSDIR="$2"; shift 2 ;;
+        --out-dir) OUTDIR="$2"; shift 2 ;;
+        *)  SRC="$1"; shift ;;
+    esac
+done
+[ -n "$SRC" ] || {
+    echo "usage: build_unikernel_arm64.sh prog.nu [-o out.elf] [--fs dir] [--out-dir dir]" >&2
+    exit 2
+}
+[ -x "$ROOT/build/nurlc" ] || {
+    echo "build_unikernel_arm64.sh: $ROOT/build/nurlc not found — run ./build.sh first" >&2
+    exit 2
+}
+command -v "$ZIG" >/dev/null 2>&1 || {
+    echo "build_unikernel_arm64.sh: no zig on PATH and none at ~/.nurl/zig/zig — set NURL_ZIG" >&2
+    exit 2
+}
+if [ -n "$FSDIR" ] && [ ! -d "$FSDIR" ]; then
+    echo "build_unikernel_arm64.sh: --fs $FSDIR is not a directory" >&2
+    exit 2
+fi
+
+CACHE="${NURL_UNIKERNEL_CACHE:-$OUTDIR/cache}"
+mkdir -p "$OUTDIR" "$CACHE"
+base="$(basename "${SRC%.nu}")"
+OUT="${OUT:-$OUTDIR/$base.elf}"
+
+# Two triples, deliberately. Compiling uses aarch64-linux-musl so the
+# C files can #include <stdio.h> and friends — runtime_core.c does, and
+# nolibc supplies the DEFINITIONS while some libc's headers supply the
+# declarations. That is exactly what the x86_64 build does implicitly by
+# using the host clang (host headers, nolibc objects); saying it out
+# loud is the difference between the two scripts, not a difference in
+# the model. Linking uses -nostdlib, so not one byte of musl is in the
+# image — `nm` on the result proves it, and the gate checks.
+TARGET=aarch64-linux-musl
+# -mgeneral-regs-only is NOT set: the runtime uses floating point, and
+# the boot code un-traps FP/SIMD before C runs. What IS set is the same
+# freestanding discipline as x86 — no stack protector, no builtins that
+# assume a libc, small code model to match the linker script's single
+# 2 MiB-aligned load address.
+KFLAGS="-target $TARGET -ffreestanding -fno-stack-protector -fno-builtin
+        -mcmodel=small -fno-pie -O2"
+
+cache_inputs() {
+    printf '%s\n' \
+        "$ROOT/stdlib/runtime_core.c" "$ROOT/stdlib/runtime_ctx.c" \
+        "$ROOT/unikernel/runtime_bare.c" \
+        "$NOLIBC"/string.c "$NOLIBC"/malloc.c "$NOLIBC"/stdio.c \
+        "$NOLIBC"/dtoa.c "$NOLIBC"/math.c "$NOLIBC"/misc.c \
+        "$NOLIBC"/setjmp_aarch64.S \
+        "$BOOT"/platform_arm64.c "$BOOT"/initfs.c "$BOOT"/pagealloc.c \
+        "$BOOT"/nosys.c "$BOOT"/tls_guest_arm64.c "$BOOT"/boot_arm64.S \
+        "${BASH_SOURCE[0]}"
+}
+
+cache_build() {
+    # shellcheck disable=SC2086
+    $ZIG cc $KFLAGS -c "$ROOT/stdlib/runtime_core.c" -o "$CACHE/runtime_core.o"
+    $ZIG cc $KFLAGS -c "$ROOT/stdlib/runtime_ctx.c"  -o "$CACHE/runtime_ctx.o"
+    $ZIG cc $KFLAGS -c "$ROOT/unikernel/runtime_bare.c" -o "$CACHE/runtime_bare.o"
+    for f in string malloc stdio dtoa math misc; do
+        $ZIG cc $KFLAGS -c "$NOLIBC/$f.c" -o "$CACHE/nl_$f.o"
+    done
+    $ZIG cc $KFLAGS -c "$BOOT/platform_arm64.c"  -o "$CACHE/platform.o"
+    $ZIG cc $KFLAGS -c "$BOOT/initfs.c"          -o "$CACHE/boot_initfs.o"
+    $ZIG cc $KFLAGS -c "$BOOT/pagealloc.c"       -o "$CACHE/boot_pagealloc.o"
+    $ZIG cc $KFLAGS -c "$BOOT/nosys.c"           -o "$CACHE/boot_nosys.o"
+    $ZIG cc $KFLAGS -c "$BOOT/tls_guest_arm64.c" -o "$CACHE/tls_guest.o"
+    $ZIG cc $KFLAGS -c "$BOOT/boot_arm64.S"      -o "$CACHE/boot.o"
+    $ZIG cc $KFLAGS -c "$NOLIBC/setjmp_aarch64.S" -o "$CACHE/nl_setjmp.o"
+}
+
+stamp="$CACHE/stamp"
+want_key="ZIG=$ZIG KFLAGS=$(echo $KFLAGS)"
+(
+    flock 9
+    fresh=1
+    if [ ! -f "$stamp" ] || [ "$(head -1 "$stamp" 2>/dev/null)" != "$want_key" ]; then
+        fresh=0
+    else
+        while IFS= read -r f; do
+            [ "$f" -nt "$stamp" ] && { fresh=0; break; }
+        done < <(cache_inputs)
+    fi
+    if [ "$fresh" = 0 ]; then
+        cache_build
+        printf '%s\n' "$want_key" > "$stamp"
+    fi
+) 9>"$CACHE/.lock"
+
+# The program. compile_nu.sh links in the NURL socket layer when `nm`
+# says the program needs it; NURL_NM points it at a cross-capable nm so
+# the measurement is made on THIS architecture's object.
+NURL_NETDEV="$ROOT/unikernel/net/netdev_virtio.nu" \
+NURL_TARGET_CC="$ZIG cc -target $TARGET" \
+    "$ROOT/unikernel/compile_nu.sh" "$SRC" "$OUTDIR/$base.ll" "$OUTDIR"
+# shellcheck disable=SC2086
+$ZIG cc $KFLAGS -Wno-override-module -c "$OUTDIR/$base.ll" -o "$OUTDIR/$base.o"
+
+: > "$OUTDIR/$base.initfs.tar"
+if [ -n "$FSDIR" ]; then
+    tar cf "$OUTDIR/$base.initfs.tar" -C "$FSDIR" .
+fi
+# The archive becomes an object with two symbols around it. `ld -r -b
+# binary` is x86-only output; the portable spelling is a tiny .S that
+# .incbin's the file, which also lets the symbols be named directly
+# instead of renamed afterwards.
+cat > "$OUTDIR/$base.initfs.S" <<EOF
+    .section .rodata
+    .globl nurl_initfs_start
+    .globl nurl_initfs_end
+    .align 8
+nurl_initfs_start:
+    .incbin "$OUTDIR/$base.initfs.tar"
+nurl_initfs_end:
+    .section .note.GNU-stack, "", %progbits
+EOF
+# shellcheck disable=SC2086
+$ZIG cc $KFLAGS -c "$OUTDIR/$base.initfs.S" -o "$OUTDIR/$base.initfs_data.o"
+
+# shellcheck disable=SC2086
+# -Wl,-e: zig cc hands the linker its own default entry (_start) after
+# our script, and lld's "cannot find entry symbol _start" left the ELF
+# header's entry point at ZERO — an image QEMU would jump to address 0
+# for. The script's ENTRY() is still there and still right; this makes
+# the command line agree with it.
+# max-page-size=4096: lld's aarch64 default is 64 KiB, which pads every
+# LOAD segment's file offset to a boundary this machine has no use for —
+# the guest's own page tables use the 4 KiB granule. It cost 300 KB of
+# padding in a 500 KB image. -S strips the debug info zig cc emits by
+# default (another 80 KB), which a boot image cannot use: the fault
+# handler reports registers, and the ELF a developer debugs is the one
+# in the build directory, not the one the hypervisor loads.
+$ZIG cc -target $TARGET -nostdlib -static -Wl,-T,"$BOOT/link_arm64.ld" \
+    -Wl,-e,_arm64_start -Wl,--build-id=none \
+    -Wl,-z,max-page-size=4096 -Wl,-S \
+    -o "$OUT" \
+    "$CACHE/boot.o" "$OUTDIR/$base.o" \
+    "$CACHE/runtime_core.o" "$CACHE/runtime_ctx.o" "$CACHE/runtime_bare.o" \
+    "$CACHE/platform.o" "$CACHE/tls_guest.o" \
+    "$CACHE/boot_initfs.o" "$CACHE/boot_pagealloc.o" "$CACHE/boot_nosys.o" \
+    "$OUTDIR/$base.initfs_data.o" \
+    "$CACHE"/nl_*.o
+
+echo "built $OUT"

--- a/unikernel/compile_nu.sh
+++ b/unikernel/compile_nu.sh
@@ -33,7 +33,22 @@ set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SHIM="$ROOT/unikernel/net/sockets.nu"
-CC="${CC:-clang}"
+# The compiler for the OBJECT this script produces. NURL_TARGET_CC lets
+# a cross build pass a whole command ("zig cc -target aarch64-…"): the
+# nm measurement below has to be made on the object for the TARGET,
+# because "which symbols are undefined" is an answer about the machine
+# the program will run on.
+CC="${NURL_TARGET_CC:-${CC:-clang}}"
+# nm reads whatever the CC above produced. llvm-nm handles every target
+# clang can emit; plain nm on a foreign object says "file format not
+# recognized" and the socket layer would then be linked in never or
+# always, silently.
+NM="${NURL_NM:-}"
+if [ -z "$NM" ]; then
+    if command -v llvm-nm >/dev/null 2>&1; then NM="llvm-nm"
+    elif command -v llvm-nm-16 >/dev/null 2>&1; then NM="llvm-nm-16"
+    else NM="nm"; fi
+fi
 
 # The stdlib is HERE, and this script knows it. Without this a package
 # build (cwd = the package root, see below) resolved `stdlib/…` imports
@@ -85,14 +100,14 @@ done
 cd "$workdir" || exit 2
 
 "$ROOT/build/nurlc" "$SRC" > "$OUT_LL" 2>"$WORK/compile.err" || fail 3 "$WORK/compile.err" "nurlc"
-"$CC" -O2 -c "$OUT_LL" -o "$OBJ" 2>"$WORK/cc.err" || fail 4 "$WORK/cc.err" "$CC"
+$CC -O2 -c "$OUT_LL" -o "$OBJ" 2>"$WORK/cc.err" || fail 4 "$WORK/cc.err" "$CC"
 
 # What does the shim define? Its own `@ nurl_*` definitions, read from
 # the file that defines them.
 shim_syms=$(grep -oE '^@ nurl_[A-Za-z0-9_]+' "$SHIM" | awk '{print $2}' | sort -u)
 [ -n "$shim_syms" ] || exit 0
 
-undef=$(nm -u "$OBJ" 2>/dev/null | awk '{print $NF}' | sort -u)
+undef=$($NM -u "$OBJ" 2>/dev/null | awk '{print $NF}' | sort -u)
 need=$(comm -12 <(printf '%s\n' "$undef") <(printf '%s\n' "$shim_syms"))
 [ -n "$need" ] || exit 0
 
@@ -111,5 +126,5 @@ root_nu="$WORK/__with_sockets.nu"
 } > "$root_nu"
 
 "$ROOT/build/nurlc" "$root_nu" > "$OUT_LL" 2>"$WORK/compile.err" || fail 3 "$WORK/compile.err" "nurlc (with socket shim)"
-"$CC" -O2 -c "$OUT_LL" -o "$OBJ" 2>"$WORK/cc.err" || fail 4 "$WORK/cc.err" "$CC (with socket shim)"
+$CC -O2 -c "$OUT_LL" -o "$OBJ" 2>"$WORK/cc.err" || fail 4 "$WORK/cc.err" "$CC (with socket shim)"
 exit 0

--- a/unikernel/demos/devices.arm64.expected
+++ b/unikernel/demos/devices.arm64.expected
@@ -1,0 +1,4 @@
+cmdline devices: 32
+device 31: id=1 (net) irq=yes queues=yes
+  features negotiated: yes
+probed ok: 1

--- a/unikernel/nolibc/math.c
+++ b/unikernel/nolibc/math.c
@@ -76,10 +76,18 @@ double copysign(double x, double y) {
 /* The hardware square root is correctly rounded, so there is nothing to
  * approximate. Written as asm rather than __builtin_sqrt because
  * -fno-builtin is on for this directory and the builtin would lower to
- * a call to this very function. */
+ * a call to this very function. Every target this file is built for
+ * has the instruction; one that does not would need an algorithm here,
+ * not a silently different answer, so the #error says so. */
 double sqrt(double x) {
     double r;
+#if defined(__x86_64__)
     __asm__("sqrtsd %1, %0" : "=x"(r) : "x"(x));
+#elif defined(__aarch64__)
+    __asm__("fsqrt %d0, %d1" : "=w"(r) : "w"(x));
+#else
+#  error "nolibc sqrt: no hardware square root known for this target"
+#endif
     return r;
 }
 

--- a/unikernel/nolibc/setjmp_aarch64.S
+++ b/unikernel/nolibc/setjmp_aarch64.S
@@ -1,0 +1,71 @@
+/*
+ * NURL nolibc — unikernel/nolibc/setjmp_aarch64.S
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * setjmp/longjmp for NURL's panic/recover (§20), AArch64. Saves
+ * exactly the AAPCS64 callee-saved set — x19–x28, fp (x29), lr (x30),
+ * sp, and d8–d15 — and nothing else, for the same reason the x86_64
+ * twin stops at the SysV set: that is all the ABI lets a caller assume
+ * survives a call, and a freestanding target has no signal mask to
+ * make `setjmp` differ from `_setjmp`.
+ *
+ * Unlike x86 — where the FP state lives in separate control registers
+ * this file deliberately skips — d8–d15 ARE callee-saved registers
+ * here and a frame reached through a float-heavy path keeps live
+ * values in them, so they are part of the set. FPCR itself is not:
+ * longjmp lands in a frame on this same stack, reached without
+ * changing the rounding mode.
+ *
+ * jmp_buf layout (8-byte slots):
+ *   0–9   x19–x28    10 x29    11 x30    12 sp    13–20 d8–d15
+ * 21 slots = 168 bytes. glibc's aarch64 jmp_buf is larger, so the
+ * runtime's buffers have room to spare, same as on x86.
+ */
+    .text
+    .globl _setjmp
+    .globl setjmp
+    .type _setjmp, %function
+    .type setjmp, %function
+_setjmp:
+setjmp:
+    stp x19, x20, [x0, #0]
+    stp x21, x22, [x0, #16]
+    stp x23, x24, [x0, #32]
+    stp x25, x26, [x0, #48]
+    stp x27, x28, [x0, #64]
+    stp x29, x30, [x0, #80]
+    mov x9, sp
+    str x9, [x0, #96]
+    stp d8,  d9,  [x0, #104]
+    stp d10, d11, [x0, #120]
+    stp d12, d13, [x0, #136]
+    stp d14, d15, [x0, #152]
+    mov w0, #0                  /* setjmp itself returns 0 */
+    ret
+    .size _setjmp, .-_setjmp
+
+    .globl longjmp
+    .globl _longjmp
+    .type longjmp, %function
+    .type _longjmp, %function
+longjmp:
+_longjmp:
+    ldp x19, x20, [x0, #0]
+    ldp x21, x22, [x0, #16]
+    ldp x23, x24, [x0, #32]
+    ldp x25, x26, [x0, #48]
+    ldp x27, x28, [x0, #64]
+    ldp x29, x30, [x0, #80]
+    ldr x9, [x0, #96]
+    mov sp, x9
+    ldp d8,  d9,  [x0, #104]
+    ldp d10, d11, [x0, #120]
+    ldp d12, d13, [x0, #136]
+    ldp d14, d15, [x0, #152]
+    cmp w1, #0                  /* longjmp(buf, 0) must return 1 */
+    csinc w0, w1, wzr, ne
+    ret                         /* to the saved lr — setjmp's caller */
+    .size longjmp, .-longjmp
+    .section .note.GNU-stack,"",%progbits

--- a/unikernel/nolibc/stdio.c
+++ b/unikernel/nolibc/stdio.c
@@ -310,6 +310,16 @@ int fgetc(FILE *f) {
 
 int getc(FILE *f) { return fgetc(f); }
 
+/* getchar was MISSING here until the aarch64 port asked for it, and
+ * nothing noticed because glibc's <stdio.h> defines it as a macro
+ * (`getc(stdin)`) — so every x86 build resolved the call in the
+ * preprocessor and never reached the library. musl declares it as a
+ * function, the way the standard describes it, and the link failed on
+ * runtime_core.c's `nurl_read_int`. A libc that provides getc and
+ * fgetc but not getchar is a libc whose completeness depended on which
+ * headers happened to be installed. */
+int getchar(void) { return fgetc(stdin); }
+
 int ungetc(int c, FILE *f) {
     if (c < 0) return -1;
     f->ungot = c & 0xff;

--- a/unikernel/run_qemu_arm64.sh
+++ b/unikernel/run_qemu_arm64.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/run_qemu_arm64.sh — boot an AArch64 NURL unikernel image
+#  and report what it printed and how it ended.
+#
+#  Usage:  run_qemu_arm64.sh image.elf [-t seconds] [-- extra qemu args]
+#
+#  Same contract as run_qemu.sh, one machine down: QEMU's `virt` board,
+#  ELF loaded with -kernel, the device tree QEMU generates left at the
+#  start of RAM for the guest to read. What differs from the x86 twin
+#  and why:
+#
+#    - no `acpi=off`: virt publishes its virtio-mmio devices in the
+#      DEVICE TREE, which the guest parses and turns into the same
+#      `virtio_mmio.device=` entries the x86 guest reads off its
+#      command line.
+#    - `virtio-mmio.force-legacy=false` is still needed, and finding
+#      that out cost a debugging round: the virt board defaults to the
+#      LEGACY transport exactly as microvm does (the guest read
+#      version=1 straight off the register). A legacy device is a
+#      different protocol — 10-byte net header, PFN queue registers,
+#      guest-endian fields — and hal/virtio.nu refuses one rather than
+#      driving it wrong, so a default QEMU makes every device
+#      disappear, correctly and confusingly.
+#    - no `tsc_khz=`: this architecture's clock states its own
+#      frequency in CNTFRQ_EL0. `wallclock=` stays — a wall clock is
+#      the host's to state, on any machine.
+#    - the program's argv still arrives as one `args="…"` key, in the
+#      DTB's /chosen/bootargs rather than on a cmdline; -append is how
+#      QEMU fills that node, so the spelling here is identical.
+#
+#  Exit status: the guest's, or 124 if the deadline passed with no
+#  sentinel line.
+# ============================================================
+set -uo pipefail
+
+QEMU="${QEMU_ARM64:-${QEMU:-qemu-system-aarch64}}"
+TIMEOUT=20
+IMG=""
+read -r -a EXTRA <<< "${QEMU_ARGS:-}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -t) TIMEOUT="$2"; shift 2 ;;
+        --) shift; EXTRA+=("$@"); break ;;
+        *)  IMG="$1"; shift ;;
+    esac
+done
+[ -n "$IMG" ] || { echo "usage: run_qemu_arm64.sh image.elf [-t seconds]" >&2; exit 2; }
+command -v "$QEMU" >/dev/null 2>&1 || { echo "run_qemu_arm64.sh: $QEMU not found" >&2; exit 3; }
+
+# KVM only when the HOST is also aarch64 — an x86 developer machine
+# runs this under TCG, which is slower and otherwise identical.
+ACCEL=tcg
+if [ -w /dev/kvm ] && [ "$(uname -m)" = "aarch64" ]; then ACCEL=kvm; fi
+# `max` publishes the FEAT_RNG bit the guest's entropy check requires;
+# a lesser CPU model makes the guest refuse to generate keys, which is
+# the correct refusal and a confusing one to debug.
+CPU="${NURL_ARM64_CPU:-max}"
+
+out="$(mktemp)"
+timeout -k 5s "${TIMEOUT}s" "$QEMU" \
+    -M virt \
+    -accel "$ACCEL" -cpu "$CPU" -m 256 \
+    -nodefaults -no-reboot -no-user-config \
+    -global virtio-mmio.force-legacy=false \
+    -kernel "$IMG" -append "wallclock=$(date +%s) ${NURL_APPEND:-}" \
+    -serial stdio -display none \
+    ${EXTRA[@]+"${EXTRA[@]}"} > "$out" 2>&1
+qemu_status=$?
+
+sed -i 's/\r$//' "$out"
+grep -v '^\[nurl-exit\] ' "$out"
+
+code=$(sed -n 's/^\[nurl-exit\] \([0-9]*\)$/\1/p' "$out" | tail -1)
+rm -f "$out"
+if [ -z "$code" ]; then
+    echo "run_qemu_arm64.sh: no [nurl-exit] line — the guest did not finish (qemu $qemu_status)" >&2
+    exit 124
+fi
+exit "$code"

--- a/unikernel/run_qemu_arm64_tests.sh
+++ b/unikernel/run_qemu_arm64_tests.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/run_qemu_arm64_tests.sh — the AArch64 guest gate.
+#
+#  The same programs the x86_64 guest gate boots, on the other
+#  architecture: corpus tests against their ORDINARY hosted goldens
+#  (the whole claim of the port is that nothing above the bottom edge
+#  changed), then the guest-only demos that need a device.
+#
+#  Usage:  run_qemu_arm64_tests.sh [name …]     (default: all)
+#
+#  Skips itself, loudly, when qemu-system-aarch64 is absent — the same
+#  contract the x86 gate has, so a developer without it still gets a
+#  green run of everything else.
+# ============================================================
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TESTS="$ROOT/compiler/tests"
+OUTDIR="${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel-arm64}"
+QEMU="${QEMU_ARM64:-${QEMU:-qemu-system-aarch64}}"
+
+command -v "$QEMU" >/dev/null 2>&1 || {
+    echo "run_qemu_arm64_tests.sh: $QEMU not found — skipping the AArch64 guest gate"
+    exit 0
+}
+[ -x "$ROOT/build/nurlc" ] || { echo "run ./build.sh first" >&2; exit 2; }
+
+build() { NURL_UNIKERNEL_OUT="$OUTDIR" "$ROOT/unikernel/build_unikernel_arm64.sh" "$@"; }
+boot()  { "$ROOT/unikernel/run_qemu_arm64.sh" "$@"; }
+
+names=("$@")
+[ ${#names[@]} -gt 0 ] || names=(hello vec_basic float_format
+                                 net_socket net_tcpstack
+                                 async_basic async_chan async_mn async_sleep)
+
+fails=0
+for name in "${names[@]}"; do
+    golden="$TESTS/outputs/$name.txt"
+    [ -f "$golden" ] || { echo "SKIP $name (no golden)"; continue; }
+    if ! build "$TESTS/$name.nu" >/dev/null 2>&1; then
+        echo "FAIL $name (build)"; fails=$((fails + 1)); continue
+    fi
+    want_exit=$(sed -n 's/^EXIT //p' "$golden" | head -1)
+    want_out=$(sed -n '/^OUTPUT$/,$p' "$golden" | tail -n +2)
+    got_out=$(boot "$OUTDIR/$name.elf" -t 120 2>&1)
+    got_exit=$?
+    if [ "$got_out" = "$want_out" ] && [ "$got_exit" = "$want_exit" ]; then
+        echo "PASS $name"
+    else
+        echo "FAIL $name (exit $got_exit, want ${want_exit:-?})"
+        diff <(printf '%s\n' "$want_out") <(printf '%s\n' "$got_out") | head -6 | sed 's/^/     /'
+        fails=$((fails + 1))
+    fi
+done
+
+# ── the demos, which only exist in the guest ────────────────────
+demos=0
+if [ $# -eq 0 ]; then
+    for demo in devices netdev dhcp loopback; do
+        src="$ROOT/unikernel/demos/$demo.nu"
+        # A machine-specific expectation when the machines genuinely
+        # differ, the shared one otherwise. `virt` publishes 32 static
+        # virtio-mmio slots and fills them from the top; microvm
+        # publishes exactly the devices that exist. A demo that reports
+        # what it found is right on both, and the difference belongs in
+        # the expectation, not in the demo.
+        exp="$ROOT/unikernel/demos/$demo.arm64.expected"
+        [ -f "$exp" ] || exp="$ROOT/unikernel/demos/$demo.expected"
+        [ -f "$src" ] && [ -f "$exp" ] || continue
+        demos=$((demos + 1))
+        if ! build "$src" >/dev/null 2>&1; then
+            echo "FAIL $demo (build)"; fails=$((fails + 1)); continue
+        fi
+        # virt's virtio-mmio slots are in the device tree; the guest
+        # finds them there instead of on a command line.
+        got=$(boot "$OUTDIR/$demo.elf" -t 120 -- \
+                -netdev user,id=n0 -device virtio-net-device,netdev=n0 2>&1)
+        if [ "$got" = "$(cat "$exp")" ]; then
+            echo "PASS $demo (guest-only demo)"
+        else
+            echo "FAIL $demo"
+            diff <(cat "$exp") <(printf '%s\n' "$got") | head -8 | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+    done
+
+    # A fault must be REPORTED, not silently survived — the property
+    # the x86 pass proved matters most, checked here from the start.
+    demos=$((demos + 1))
+    if build "$ROOT/unikernel/demos/fault.nu" >/dev/null 2>&1; then
+        nullout=$(NURL_APPEND='args="null 0"' boot "$OUTDIR/fault.elf" -t 60 2>&1)
+        nullrc=$?
+        stackout=$(NURL_APPEND='args="stack 100000000"' boot "$OUTDIR/fault.elf" -t 60 2>&1)
+        stackrc=$?
+        if [ "$nullrc" = 126 ] && [ "$stackrc" = 126 ] \
+           && printf '%s' "$nullout" | grep -q "nurl: fault" \
+           && printf '%s' "$stackout" | grep -q "nurl: fault"; then
+            echo "PASS fault (both faults reported, exit 126)"
+        else
+            echo "FAIL fault (null exit $nullrc, stack exit $stackrc)"
+            printf '%s\n' "$nullout" | head -3 | sed 's/^/     /'
+            printf '%s\n' "$stackout" | head -3 | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+    else
+        echo "FAIL fault (build)"; fails=$((fails + 1))
+    fi
+
+    # An HTTP server in the guest, answering a client on the host.
+    if command -v curl >/dev/null 2>&1; then
+        demos=$((demos + 1))
+        if build "$ROOT/unikernel/demos/httpd.nu" >/dev/null 2>&1; then
+            out=$(mktemp)
+            ( boot "$OUTDIR/httpd.elf" -t 120 -- \
+                -netdev user,id=n0,hostfwd=tcp:127.0.0.1:18771-:8080 \
+                -device virtio-net-device,netdev=n0 > "$out" 2>&1 ) &
+            qpid=$!
+            body=""
+            for _ in 1 2 3 4 5 6 7 8 9 10; do
+                sleep 3
+                body=$(curl -sS --max-time 10 http://127.0.0.1:18771/ 2>/dev/null)
+                [ -n "$body" ] && break
+            done
+            kill $qpid 2>/dev/null; wait $qpid 2>/dev/null
+            if printf '%s' "$body" | grep -q "hello from a guest"; then
+                echo "PASS httpd (guest server, host client)"
+            else
+                echo "FAIL httpd (curl got \"$body\")"
+                head -6 "$out" | sed 's/^/     /'
+                fails=$((fails + 1))
+            fi
+            rm -f "$out"
+        else
+            echo "FAIL httpd (build)"; fails=$((fails + 1))
+        fi
+    fi
+fi
+
+total=$(( ${#names[@]} + demos ))
+echo "── QEMU AArch64 guest run: $(( total - fails ))/$total ──"
+exit $(( fails > 0 ? 1 : 0 ))


### PR DESCRIPTION
Phase U6. QEMU's `virt` board — and the port is the size the design
predicted: **four files** differ, and they are the four that talk to
the machine.

| | |
|---|---|
| `boot/boot_arm64.S` | EL2→EL1, FP/SIMD un-trapped, vector table, `.bss`, the two stacks |
| `boot/platform_arm64.c` | PL011, device tree, MMU, generic timer, RNDR, PSCI |
| `boot/tls_guest_arm64.c` | the thread pointer (variant I, **measured**) |
| `nolibc/setjmp_aarch64.S` | `panic`/`recover`'s callee-saved set (incl. `d8`–`d15`) |

Everything above that edge is the same code the x86_64 image runs, and
the gate proves it: **`run_qemu_arm64_tests.sh` = 15/15** — the same
corpus programs against the same *hosted* goldens, the device demos,
both deliberate faults reported with exit 126, and an HTTP server in
the guest answering `curl` on the host. Hello image **131 784 B** vs
x86_64's 132 760; floor **5 MiB**. CI builds and boots it every commit
(zig as the cross toolchain — the same zig the ecosystem installs).

`runtime_ctx.c` gained an AArch64 fiber switch (AAPCS64: x19–x28,
x29/x30, **d8–d15**, FPCR), so fibers/channels/M:N are native there.

**Three machine differences absorbed in the port**, each a debugging
round: `virt` announces virtio-mmio in the *device tree* (the port
walks it and synthesizes the same `virtio_mmio.device=` entries the
x86 guest reads off its cmdline); `virt` is **legacy** virtio-mmio by
default exactly as microvm is (guest read `version=1` and refused
every device — correctly); the clock states its own frequency in
`CNTFRQ_EL0`, making `tsc_khz=` an x86 quirk rather than contract.

**Not assumed:** the TLS offset from the thread pointer depends on the
linker's PT_TLS alignment, so the boot code places the image, reads a
canary `__thread` back through the compiler's own addressing, and
refuses to run if it isn't there.

**Two root-level fixes the port surfaced**, both in shared code:
`nolibc` was missing **`getchar`** (glibc's header defines it as a
macro, so no x86 build ever reached the library), and `sqrt` assumed
`sqrtsd` (now per-architecture, `#error` where unknown).

x86_64 gates re-run and unaffected: nolibc corpus **452 PASS / 0 FAIL**,
unit gates all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1