### PR TITLE
feat: the image is not a QEMU image, and a gate says so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,13 @@ jobs:
           sudo curl -fsSL --retry 5 -o /usr/local/bin/cloud-hypervisor \
             https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v46.0/cloud-hypervisor-static
           sudo chmod +x /usr/local/bin/cloud-hypervisor
+          # The runner HAS /dev/kvm and denies the job user access to it
+          # (group kvm). Granting it turns the gate's boot half from a
+          # skip into a real boot on a real hypervisor — which is the
+          # whole point of the phase. `|| true`: on a runner without the
+          # device the gate skips and says so.
+          sudo chmod 0666 /dev/kvm 2>/dev/null || true
+          ls -l /dev/kvm 2>/dev/null || echo "no /dev/kvm on this runner"
 
       - name: nolibc + runtime_bare unit gates
         run: ./unikernel/tests/run_unit_tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,11 +260,24 @@ jobs:
         # unikernel never links, work that never will be.
         run: ./unikernel/run_nolibc_tests.sh
 
+      - name: Fetch cloud-hypervisor (the other PVH loader)
+        # 4.5 MB static binary, fetched BEFORE the unit gates because
+        # one of them (hypervisor_gate) uses it. It boots the SAME
+        # artifact QEMU does — both read the PVH note — so this is the
+        # cheapest possible check that the image is not secretly a QEMU
+        # image. Whether it actually boots depends on the runner having
+        # /dev/kvm; the gate reports which half it ran.
+        run: |
+          sudo curl -fsSL --retry 5 -o /usr/local/bin/cloud-hypervisor \
+            https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v46.0/cloud-hypervisor-static
+          sudo chmod +x /usr/local/bin/cloud-hypervisor
+
       - name: nolibc + runtime_bare unit gates
         run: ./unikernel/tests/run_unit_tests.sh
 
       - name: The guest, under QEMU
-        # TCG, because no runner has /dev/kvm. Slower, identical
+        # TCG, because a runner may or may not have /dev/kvm and the
+        # boot path must be covered either way. Slower, identical
         # otherwise — except for the TSC frequency, which no leaf
         # reports there, so run_qemu.sh states it on the kernel command
         # line the way the plan says the host states the epoch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The image is not a QEMU image, and there is now a gate that says
+  so** (plan phase U7). Firecracker and cloud-hypervisor both boot an
+  x86_64 kernel by reading the same `XEN_ELFNOTE_PHYS32_ENTRY` note
+  QEMU reads, so the artifact needs no repackaging for either.
+  `unikernel/tests/hypervisor_gate.sh` checks the note structurally on
+  any machine — present, owned by `Xen`, type 18, four-byte
+  descriptor, and the address in it **equal to the ELF's entry point**,
+  which are set by two different files and whose disagreement is a
+  boot that works under one loader and not another — and then boots
+  the image under cloud-hypervisor and Firecracker where `/dev/kvm`
+  exists, skipping loudly where it does not (neither has an
+  interpreter fallback). Three mutations (entry moved, note type
+  changed, section renamed) are all caught. On AArch64 the gate gives
+  the honest answer instead: PVH is x86-only, QEMU's virt board loads
+  the ELF directly, and the other two want a PE-format `Image` there —
+  a packaging step not taken rather than a property claimed.
+
 - **The playground builds AArch64 unikernel images too.** `POST
   /build_unikernel` takes `arch` (`"x86_64"` default, `"aarch64"`),
   the MCP tool takes the same field, and the target dropdown gains

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -352,6 +352,35 @@ bytes travel over the pure TCP stack and the virtio-net driver. The
 handshake is `stdlib/std/tls.nu` — pure NURL, no libssl, which is why
 it links here at all.
 
+## Which hypervisors, and what the artifact actually is
+
+The image is an ELF with a `XEN_ELFNOTE_PHYS32_ENTRY` note in it. That
+note is the whole PVH direct-boot protocol: a loader reads the address
+out of it and jumps there, in 32-bit protected mode, with the handover
+block in `%ebx`. **QEMU, Firecracker and cloud-hypervisor all do
+exactly that**, so the same file boots on all three with no
+repackaging — Firecracker documents PVH as the mode it picks when the
+note is present, and it is what FreeBSD boots there with.
+
+`unikernel/tests/hypervisor_gate.sh` is the check, and it has two
+halves because they answer different questions. The STRUCTURE half
+runs anywhere: the note exists, is owned by `Xen`, is type 18, carries
+a four-byte descriptor, and the address in it **equals the ELF's own
+entry point** — those last two are set by different files (`boot.S`
+and `link.ld`) and a mismatch is a boot that works under one loader
+and not another. The BOOT half runs cloud-hypervisor and Firecracker
+for real; both require `/dev/kvm` and neither has an interpreter
+fallback, so on a machine without it the gate says so and skips rather
+than passing quietly. Three deliberate mutations — the entry point
+moved, the note's type changed, the section renamed away — are all
+caught by the structure half.
+
+On AArch64 the honest answer is different, and the gate gives it:
+PVH is x86-only. QEMU's `virt` board loads the ELF directly (which is
+what the AArch64 guest gate boots), while Firecracker and
+cloud-hypervisor want a PE-format `Image` there — a packaging step
+this target has not taken, rather than a property it has.
+
 ## The second architecture (AArch64, QEMU `virt`)
 
 A second machine is what turns "portable" from an intention into a
@@ -494,6 +523,7 @@ unikernel/run_nolibc_tests.sh            # the corpus, with no libc
 unikernel/run_qemu_tests.sh              # the guest, under a hypervisor
 unikernel/run_qemu_tests.sh hello        # one of them
 unikernel/run_qemu_arm64_tests.sh        # the guest, on the other architecture
+unikernel/tests/hypervisor_gate.sh       # the image is not a QEMU image
 unikernel/build_nolibc.sh prog.nu        # build one program, no libc
 unikernel/build_unikernel.sh prog.nu     # build one bootable image (x86_64)
 unikernel/build_unikernel_arm64.sh p.nu  # …and for AArch64 (needs zig)

--- a/unikernel/tests/hypervisor_gate.sh
+++ b/unikernel/tests/hypervisor_gate.sh
@@ -134,12 +134,21 @@ boot_ch() {
         --cmdline "tsc_khz=1000000 wallclock=$(date +%s)" \
         --cpus boot=1 --memory size=64M \
         --console off --serial tty 2>&1)
-    if printf '%s' "$out" | grep -q '\[nurl-exit\] 0'; then
+    # `case`, not `printf | grep -q`: grep exits the moment it matches,
+    # printf then gets EPIPE, and under `set -o pipefail` the pipeline
+    # reports THAT — so a guest that booted perfectly was reported as a
+    # failed boot, with its own successful output printed underneath.
+    # A glob match needs no pipe and no subprocess.
+    case "$out" in
+      *"[nurl-exit] 0"*)
         say "PASS cloud-hypervisor booted the unchanged image"
-    else
-        say "FAIL cloud-hypervisor"; printf '%s\n' "$out" | head -6 | sed 's/^/     /'
+        ;;
+      *)
+        say "FAIL cloud-hypervisor"
+        printf '%s\n' "$out" | head -6 | sed 's/^/     /' || true
         fail=1
-    fi
+        ;;
+    esac
 }
 
 boot_fc() {
@@ -157,12 +166,16 @@ boot_fc() {
 EOF
     out=$(timeout -k 5s 60s "$FC" --no-api --config-file "$cfg" 2>&1)
     rm -f "$cfg" "$log"
-    if printf '%s' "$out" | grep -q '\[nurl-exit\] 0'; then
+    case "$out" in
+      *"[nurl-exit] 0"*)
         say "PASS firecracker booted the unchanged image"
-    else
-        say "FAIL firecracker"; printf '%s\n' "$out" | head -6 | sed 's/^/     /'
+        ;;
+      *)
+        say "FAIL firecracker"
+        printf '%s\n' "$out" | head -6 | sed 's/^/     /' || true
         fail=1
-    fi
+        ;;
+    esac
 }
 
 boot_ch

--- a/unikernel/tests/hypervisor_gate.sh
+++ b/unikernel/tests/hypervisor_gate.sh
@@ -107,9 +107,21 @@ fi
 [ "$fail" = 0 ] && say "PVH note OK — type 18, 4-byte descriptor, address == ELF entry"
 
 # ── the boot, when there is a machine to boot on ────────────────
-if [ ! -e /dev/kvm ]; then
-    say "SKIP boot: no /dev/kvm — Firecracker and cloud-hypervisor have no"
-    say "     interpreter fallback, so there is nothing to run them on here."
+#
+# USABILITY, not existence. A GitHub runner HAS /dev/kvm and denies the
+# job user access to it (group kvm), so `[ -e ]` said "boot it" and the
+# gate then reported a permission error as a defect in the image. What
+# the gate is asking is "can this process open KVM", and the honest
+# answer to "no" is a skip with the reason — an environment the gate
+# cannot run in is not a failing artifact.
+if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
+    if [ -e /dev/kvm ]; then
+        say "SKIP boot: /dev/kvm exists but this user cannot open it"
+        say "     (add the user to the 'kvm' group, or chmod it in CI)."
+    else
+        say "SKIP boot: no /dev/kvm — Firecracker and cloud-hypervisor have"
+        say "     no interpreter fallback, so there is nothing to run them on."
+    fi
     say "     (QEMU covers the boot path under TCG; this gate covers the"
     say "     artifact's portability to the other two.)"
     exit $fail

--- a/unikernel/tests/hypervisor_gate.sh
+++ b/unikernel/tests/hypervisor_gate.sh
@@ -124,11 +124,12 @@ if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
     fi
     say "     (QEMU covers the boot path under TCG; this gate covers the"
     say "     artifact's portability to the other two.)"
+    [ "$fail" = 0 ] && say "verified: PVH note (no usable KVM here to boot it under)"
     exit $fail
 fi
 
 boot_ch() {
-    command -v "$CH" >/dev/null 2>&1 || { say "SKIP cloud-hypervisor (not installed)"; return 0; }
+    command -v "$CH" >/dev/null 2>&1 || { skipped="$skipped cloud-hypervisor"; return 0; }
     out=$(timeout -k 5s 60s "$CH" \
         --kernel "$IMG" \
         --cmdline "tsc_khz=1000000 wallclock=$(date +%s)" \
@@ -142,6 +143,7 @@ boot_ch() {
     case "$out" in
       *"[nurl-exit] 0"*)
         say "PASS cloud-hypervisor booted the unchanged image"
+        booted="$booted cloud-hypervisor"
         ;;
       *)
         say "FAIL cloud-hypervisor"
@@ -152,7 +154,7 @@ boot_ch() {
 }
 
 boot_fc() {
-    command -v "$FC" >/dev/null 2>&1 || { say "SKIP firecracker (not installed)"; return 0; }
+    command -v "$FC" >/dev/null 2>&1 || { skipped="$skipped firecracker"; return 0; }
     # Firecracker is API-driven; the one-shot form takes a JSON config.
     cfg=$(mktemp); log=$(mktemp)
     cat > "$cfg" <<EOF
@@ -169,6 +171,7 @@ EOF
     case "$out" in
       *"[nurl-exit] 0"*)
         say "PASS firecracker booted the unchanged image"
+        booted="$booted firecracker"
         ;;
       *)
         say "FAIL firecracker"
@@ -178,6 +181,19 @@ EOF
     esac
 }
 
+booted=""
+skipped=""
 boot_ch
 boot_fc
+# One last line naming what actually ran. The unit-gate runner shows a
+# step's LAST line, and "SKIP firecracker (not installed)" is the least
+# informative thing this gate can say — the fact worth seeing is that a
+# hypervisor other than QEMU booted the image.
+if [ "$fail" = 0 ]; then
+    if [ -n "$booted" ]; then
+        say "verified: PVH note + booted under$booted${skipped:+ (skipped:$skipped)}"
+    else
+        say "verified: PVH note (no other hypervisor available to boot it)"
+    fi
+fi
 exit $fail

--- a/unikernel/tests/hypervisor_gate.sh
+++ b/unikernel/tests/hypervisor_gate.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/tests/hypervisor_gate.sh — the image is not a QEMU image.
+#
+#  QEMU is the hypervisor the guest gate boots under, and a target that
+#  runs on exactly one hypervisor is a target with a dependency it does
+#  not admit to. Firecracker and cloud-hypervisor both load an x86_64
+#  kernel by **PVH direct boot** — they read the XEN_ELFNOTE_PHYS32_ENTRY
+#  note out of the ELF and jump to the address in it — which is the
+#  same note `boot/boot.S` emits and the same entry QEMU uses. So the
+#  artifact needs no repackaging for either; what it needs is a check
+#  that says so, and a boot when there is a machine to boot on.
+#
+#  Two levels, because they answer different questions:
+#
+#    STRUCTURE (always)   the note is present, is owned by "Xen", is
+#                         type 18, carries a 4-byte descriptor, and the
+#                         address in it is the ELF's own entry point
+#                         inside a PT_LOAD segment. This is exactly what
+#                         a PVH loader dispatches on, and it is checkable
+#                         on any machine, with no hypervisor at all.
+#    BOOT (when possible) cloud-hypervisor and/or firecracker actually
+#                         start the image and it prints and exits. Both
+#                         REQUIRE /dev/kvm — neither has an interpreter
+#                         fallback — so without KVM this half SKIPS
+#                         loudly rather than passing quietly.
+#
+#  Usage:  hypervisor_gate.sh [image.elf]
+#          NURL_CLOUD_HYPERVISOR / NURL_FIRECRACKER name the binaries.
+# ============================================================
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMG="${1:-$ROOT/build/unikernel/hello.elf}"
+CH="${NURL_CLOUD_HYPERVISOR:-cloud-hypervisor}"
+FC="${NURL_FIRECRACKER:-firecracker}"
+fail=0
+say() { echo "hypervisor_gate: $*"; }
+
+if [ ! -f "$IMG" ]; then
+    if [ -x "$ROOT/build/nurlc" ]; then
+        "$ROOT/unikernel/build_unikernel.sh" "$ROOT/compiler/tests/hello.nu" >/dev/null 2>&1 \
+            || { say "SKIP (cannot build a test image)"; exit 0; }
+    else
+        say "SKIP (no build/nurlc — run ./build.sh first)"; exit 0
+    fi
+fi
+
+# ── which machine is this image for? ─────────────────────────────
+#
+# PVH is an x86 protocol. On AArch64 both Firecracker and
+# cloud-hypervisor take a PE-format `Image` (the shape a Linux
+# arm64 kernel is packaged in), not the ELF QEMU's virt board loads
+# with -kernel — so there is no note to check and no boot to attempt,
+# and the honest answer is to say which artifact this is and stop.
+# Wrapping the ELF in a PE header is a packaging step this target
+# could grow; claiming portability it does not have is not.
+machine=$(readelf -hW "$IMG" | awk -F: '/Machine:/ {print $2}' | sed 's/^ *//')
+case "$machine" in
+    *AArch64*)
+        say "AArch64 image — PVH is x86-only, so there is no note to check."
+        say "     QEMU virt loads this ELF directly (the AArch64 guest gate"
+        say "     boots it). Firecracker and cloud-hypervisor want a"
+        say "     PE-format Image on this architecture: a packaging step"
+        say "     this target has not taken, not a property it has."
+        exit 0
+        ;;
+esac
+
+# ── the note, read with the tools every toolchain ships ─────────
+#
+# `readelf -n` prints the owner, the descriptor size and the descriptor
+# bytes; the type is printed as a number when unrecognised, which is
+# what "Xen" type 18 is to binutils. Parsed rather than eyeballed so
+# the gate fails when the note stops being what a loader expects.
+notes=$(readelf -nW "$IMG" 2>/dev/null)
+if ! printf '%s' "$notes" | grep -q "\.note\.Xen"; then
+    say "FAIL: no .note.Xen section — a PVH loader (Firecracker,"
+    say "      cloud-hypervisor, QEMU -kernel) has nothing to dispatch on"
+    exit 1
+fi
+if ! printf '%s' "$notes" | grep -qE "Xen +0x0*4"; then
+    say "FAIL: the Xen note's descriptor is not 4 bytes (a 32-bit entry address)"
+    fail=1
+fi
+if ! printf '%s' "$notes" | grep -qiE "0x0*12|XEN_ELFNOTE_PHYS32_ENTRY"; then
+    say "FAIL: the Xen note is not type 18 (XEN_ELFNOTE_PHYS32_ENTRY)"
+    fail=1
+fi
+
+# The address in the descriptor must be the ELF's entry point: the two
+# are set independently (the note by boot.S, the entry by the linker
+# script) and a loader that uses one while a developer tests the other
+# is a boot that works under QEMU and not under Firecracker.
+desc=$(printf '%s' "$notes" | grep -A2 "Xen" | grep -oE "description data: [0-9a-f ]+" | head -1 |
+       sed 's/description data: //')
+if [ -n "$desc" ]; then
+    # little-endian bytes → an address
+    note_addr=$(printf '%s' "$desc" | awk '{printf "0x%s%s%s%s", $4, $3, $2, $1}')
+    entry=$(readelf -hW "$IMG" | awk '/Entry point/ {print $4}')
+    if [ "$((note_addr))" != "$((entry))" ]; then
+        say "FAIL: the PVH note says $note_addr but the ELF entry is $entry"
+        say "      — QEMU uses the note, and a mismatch boots two different addresses"
+        fail=1
+    fi
+fi
+[ "$fail" = 0 ] && say "PVH note OK — type 18, 4-byte descriptor, address == ELF entry"
+
+# ── the boot, when there is a machine to boot on ────────────────
+if [ ! -e /dev/kvm ]; then
+    say "SKIP boot: no /dev/kvm — Firecracker and cloud-hypervisor have no"
+    say "     interpreter fallback, so there is nothing to run them on here."
+    say "     (QEMU covers the boot path under TCG; this gate covers the"
+    say "     artifact's portability to the other two.)"
+    exit $fail
+fi
+
+boot_ch() {
+    command -v "$CH" >/dev/null 2>&1 || { say "SKIP cloud-hypervisor (not installed)"; return 0; }
+    out=$(timeout -k 5s 60s "$CH" \
+        --kernel "$IMG" \
+        --cmdline "tsc_khz=1000000 wallclock=$(date +%s)" \
+        --cpus boot=1 --memory size=64M \
+        --console off --serial tty 2>&1)
+    if printf '%s' "$out" | grep -q '\[nurl-exit\] 0'; then
+        say "PASS cloud-hypervisor booted the unchanged image"
+    else
+        say "FAIL cloud-hypervisor"; printf '%s\n' "$out" | head -6 | sed 's/^/     /'
+        fail=1
+    fi
+}
+
+boot_fc() {
+    command -v "$FC" >/dev/null 2>&1 || { say "SKIP firecracker (not installed)"; return 0; }
+    # Firecracker is API-driven; the one-shot form takes a JSON config.
+    cfg=$(mktemp); log=$(mktemp)
+    cat > "$cfg" <<EOF
+{
+  "boot-source": {
+    "kernel_image_path": "$IMG",
+    "boot_args": "tsc_khz=1000000 wallclock=$(date +%s)"
+  },
+  "machine-config": { "vcpu_count": 1, "mem_size_mib": 64 }
+}
+EOF
+    out=$(timeout -k 5s 60s "$FC" --no-api --config-file "$cfg" 2>&1)
+    rm -f "$cfg" "$log"
+    if printf '%s' "$out" | grep -q '\[nurl-exit\] 0'; then
+        say "PASS firecracker booted the unchanged image"
+    else
+        say "FAIL firecracker"; printf '%s\n' "$out" | head -6 | sed 's/^/     /'
+        fail=1
+    fi
+}
+
+boot_ch
+boot_fc
+exit $fail

--- a/unikernel/tests/run_unit_tests.sh
+++ b/unikernel/tests/run_unit_tests.sh
@@ -159,7 +159,13 @@ done
 #    when build/nurlc is absent (the other gates here need only $CC).
 step build_tool_gate "$ROOT/unikernel/tests/build_tool_gate.sh"
 
-# 7. the bare mutex/cond fit what the NURL side allocates for them.
+# 7. the image is not a QEMU image: the PVH note Firecracker and
+#    cloud-hypervisor dispatch on is present, well-formed, and agrees
+#    with the ELF's entry point. Boots under those two as well when
+#    the machine has KVM; says so and skips when it does not.
+step hypervisor_gate "$ROOT/unikernel/tests/hypervisor_gate.sh"
+
+# 8. the bare mutex/cond fit what the NURL side allocates for them.
 #    Hosted on purpose: the comparison needs the real <pthread.h>, which
 #    is precisely what the freestanding build does not have.
 $CC -O2 "$ROOT/unikernel/tests/pthread_layout.c" "$OUT/runtime_bare.o" \


### PR DESCRIPTION
Phase U7 — the last one in the plan. A target that runs on exactly one
hypervisor has a dependency it does not admit to.

**The fact**: Firecracker and cloud-hypervisor both boot x86_64 kernels
by PVH direct boot — the same `XEN_ELFNOTE_PHYS32_ENTRY` note `boot.S`
emits and QEMU uses. The artifact needs **no repackaging** for either.
(Firecracker documents PVH as the mode it picks when the note is
present; it's how FreeBSD boots there.)

**The gate** (`unikernel/tests/hypervisor_gate.sh`), two halves:

- **Structure, anywhere**: note present, owned by `Xen`, type 18,
  4-byte descriptor, and the address in it **== the ELF entry point**.
  Those two are set by different files (`boot.S` vs `link.ld`); their
  disagreement is a boot that works under one loader and not another.
- **Boot, where possible**: cloud-hypervisor + Firecracker actually
  start it. Both need `/dev/kvm` with no interpreter fallback, so the
  gate skips *loudly* without it. CI fetches cloud-hypervisor (4.5 MB
  static) so the boot half activates wherever the runner allows.

**Mutation-tested** (a gate that cannot fail is not a gate): entry
moved, note type → 17, section renamed away — **3/3 caught**.

**AArch64 gets the honest answer, not a verdict**: PVH is x86-only;
QEMU virt loads the ELF directly, while the other two want a PE-format
`Image` there — a packaging step not taken, rather than a property
claimed. "Boots on three hypervisors" would otherwise be true for one
architecture and silently false for the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1