### PR TITLE
feat: a NURL program boots as its own kernel on RISC-V too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            clang binutils qemu-system-x86 qemu-system-arm curl
+            clang binutils qemu-system-x86 qemu-system-arm qemu-system-misc curl
 
       - name: Build the compiler
         run: ./build.sh --no-tests
@@ -300,6 +300,16 @@ jobs:
           curl -fsSL --retry 5 -o /tmp/zig.tar.xz \
             "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
           mkdir -p /opt/zig && sudo tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1
+
+      - name: The guest, on the THIRD architecture
+        # RISC-V, QEMU's virt board with OpenSBI underneath. The third
+        # port is the one that proves the second was not a coincidence:
+        # by now the per-architecture surface is four files and a
+        # linker script, and everything above it is the same code
+        # running against the same hosted goldens.
+        env:
+          NURL_ZIG: /opt/zig/zig
+        run: ./unikernel/run_qemu_riscv64_tests.sh
 
       - name: The guest, on the OTHER architecture
         # The claim the aarch64 port makes is that nothing above the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A NURL program boots as its own kernel on RISC-V too** — the third
+  architecture, and the one that proves the second was not a
+  coincidence. QEMU's `virt` board with OpenSBI underneath, four files
+  and a linker script (`boot_riscv64.S`, `platform_riscv64.c`,
+  `tls_guest_riscv64.c`, `nolibc/setjmp_riscv64.S`, `link_riscv64.ld`)
+  plus an RV64 fiber switch in `runtime_ctx.c`. Gate
+  `unikernel/run_qemu_riscv64_tests.sh` is **15/15** — the same corpus
+  programs against the same hosted goldens, the device demos, faults
+  reported with exit 126, and an HTTP server in the guest answering
+  curl on the host. CI builds and boots all three architectures on
+  every commit.
+
+  Three things this machine made explicit rather than let pass:
+  **`fp` IS `s0`** on this ISA, so parking the device-tree pointer in
+  `s0` and ending the frame-pointer chain three instructions later
+  zeroed it — the guest reported "no device tree", which was a true
+  statement about a register the boot code had just cleared, and an
+  assembly probe of the firmware handover is what told the two apart.
+  **The firmware talks**: OpenSBI prints on the same UART before the
+  kernel runs, so the guest marks its own first byte and the run
+  script drops everything before it — a rule that belongs to us rather
+  than to whatever the banner looks like this year. And **there is no
+  entropy source**: RISC-V's `seed` CSR is the optional Zkr extension
+  and QEMU's rv64 CPU does not implement it, so this port panics on a
+  request for randomness, naming what is missing, instead of inventing
+  it.
+
+### Changed
+
+- **The device-tree walk is shared rather than copied**
+  (`unikernel/boot/fdt.c`). AArch64 and RISC-V need the same three
+  answers out of the same format, and the third port is the right
+  moment to stop copying the second's. Generalising it found a real
+  narrowness in the AArch64 original: it classified nodes at a
+  hard-coded depth, and RISC-V's virt puts its devices under `/soc`
+  where AArch64's puts them at the root — so the walker found nothing
+  and the guest reported "no virtio-net device" about a machine that
+  had one. Nodes are now classified by NAME at any depth, with
+  address/size cells tracked per level because a bus node may state
+  its own.
+
 - **The image is not a QEMU image, and there is now a gate that says
   so** (plan phase U7). Firecracker and cloud-hypervisor both boot an
   x86_64 kernel by reading the same `XEN_ELFNOTE_PHYS32_ENTRY` note

--- a/stdlib/runtime_ctx.c
+++ b/stdlib/runtime_ctx.c
@@ -55,6 +55,15 @@
 
 #if defined(__x86_64__) && !defined(_WIN32)
 #  define NURL_CTX_X86_64 1
+#elif defined(__riscv) && __riscv_xlen == 64 && !defined(_WIN32)
+/* RV64 (the standard calling convention). Callee-saved: s0–s11 (x8–x9,
+ * x18–x27), ra (x1), sp (x2), and — when the target has the D
+ * extension — fs0–fs11. There is no control-word register to save: the
+ * rounding mode lives in fcsr, which the ABI marks CALLER-saved, so a
+ * fiber that changes it is required to restore it itself. That is the
+ * one real difference from both other architectures, and it is why
+ * this switch saves no FP control state while the other two must. */
+#  define NURL_CTX_RISCV64 1
 #elif defined(__aarch64__) && !defined(_WIN32)
 /* AArch64 (AAPCS64). Callee-saved: x19–x28, fp (x29), lr (x30), sp,
  * the low 64 bits of v8–v15 (d8–d15), and FPCR — the rounding-mode
@@ -234,6 +243,104 @@ void nurl_ctx_init(nurl_ctx_t *ctx, void *stack, unsigned long size,
 
 int nurl_ctx_available(void) { return 1; }
 
+#elif defined(NURL_CTX_RISCV64)
+
+/* The switch. Frame, from ctx->sp upward — 14 integer slots plus the
+ * FP set when the target has doubles, 16-byte aligned as the ABI
+ * requires at every call boundary:
+ *
+ *     +0    ra    <- where the restored context resumes
+ *     +8    s0/fp
+ *     +16…  s1–s11
+ *     +112  (pad to 16)
+ *     +120… fs0–fs11, when __riscv_flen >= 64
+ *
+ * s1 carries the entry argument and s2 the entry point on a first
+ * switch; the trampoline moves them into place. */
+#if defined(__riscv_flen) && __riscv_flen >= 64
+#  define NURL_RV_FRAME 224
+#  define NURL_RV_SAVE_FP                     \
+        "fsd fs0,  120(sp)\n\t" "fsd fs1,  128(sp)\n\t"  \
+        "fsd fs2,  136(sp)\n\t" "fsd fs3,  144(sp)\n\t"  \
+        "fsd fs4,  152(sp)\n\t" "fsd fs5,  160(sp)\n\t"  \
+        "fsd fs6,  168(sp)\n\t" "fsd fs7,  176(sp)\n\t"  \
+        "fsd fs8,  184(sp)\n\t" "fsd fs9,  192(sp)\n\t"  \
+        "fsd fs10, 200(sp)\n\t" "fsd fs11, 208(sp)\n\t"
+#  define NURL_RV_LOAD_FP                     \
+        "fld fs0,  120(sp)\n\t" "fld fs1,  128(sp)\n\t"  \
+        "fld fs2,  136(sp)\n\t" "fld fs3,  144(sp)\n\t"  \
+        "fld fs4,  152(sp)\n\t" "fld fs5,  160(sp)\n\t"  \
+        "fld fs6,  168(sp)\n\t" "fld fs7,  176(sp)\n\t"  \
+        "fld fs8,  184(sp)\n\t" "fld fs9,  192(sp)\n\t"  \
+        "fld fs10, 200(sp)\n\t" "fld fs11, 208(sp)\n\t"
+#else
+#  define NURL_RV_FRAME 112
+#  define NURL_RV_SAVE_FP
+#  define NURL_RV_LOAD_FP
+#endif
+
+#define NURL_RV_STR2(x) #x
+#define NURL_RV_STR(x)  NURL_RV_STR2(x)
+
+__attribute__((naked, noinline))
+void nurl_ctx_switch(nurl_ctx_t *save, nurl_ctx_t *restore)
+{
+    __asm__ volatile(
+        "addi sp, sp, -" NURL_RV_STR(NURL_RV_FRAME) "\n\t"
+        "sd ra,  0(sp)\n\t"
+        "sd s0,  8(sp)\n\t"  "sd s1,  16(sp)\n\t"
+        "sd s2,  24(sp)\n\t" "sd s3,  32(sp)\n\t"
+        "sd s4,  40(sp)\n\t" "sd s5,  48(sp)\n\t"
+        "sd s6,  56(sp)\n\t" "sd s7,  64(sp)\n\t"
+        "sd s8,  72(sp)\n\t" "sd s9,  80(sp)\n\t"
+        "sd s10, 88(sp)\n\t" "sd s11, 96(sp)\n\t"
+        NURL_RV_SAVE_FP
+        "sd sp, 0(a0)\n\t"          /* save->sp = sp     */
+        "ld sp, 0(a1)\n\t"          /* sp = restore->sp  */
+        NURL_RV_LOAD_FP
+        "ld ra,  0(sp)\n\t"
+        "ld s0,  8(sp)\n\t"  "ld s1,  16(sp)\n\t"
+        "ld s2,  24(sp)\n\t" "ld s3,  32(sp)\n\t"
+        "ld s4,  40(sp)\n\t" "ld s5,  48(sp)\n\t"
+        "ld s6,  56(sp)\n\t" "ld s7,  64(sp)\n\t"
+        "ld s8,  72(sp)\n\t" "ld s9,  80(sp)\n\t"
+        "ld s10, 88(sp)\n\t" "ld s11, 96(sp)\n\t"
+        "addi sp, sp, " NURL_RV_STR(NURL_RV_FRAME) "\n\t"
+        "ret\n\t"
+    );
+}
+
+/* First-entry trampoline: s1 holds the argument, s2 the entry point.
+ * `unimp` and not a call to a diagnostic helper, for the same LTO
+ * reason x86 uses `ud2` and AArch64 `brk`. */
+__attribute__((naked, noinline))
+static void nurl__ctx_trampoline(void)
+{
+    __asm__ volatile(
+        "mv a0, s1\n\t"
+        "jalr s2\n\t"
+        "unimp\n\t"
+    );
+}
+
+void nurl_ctx_init(nurl_ctx_t *ctx, void *stack, unsigned long size,
+                   void (*entry)(void *), void *arg)
+{
+    unsigned char *top = (unsigned char *)stack + size;
+    unsigned long  t   = (unsigned long)top & ~(unsigned long)15;
+    unsigned long *fp  = (unsigned long *)(t - NURL_RV_FRAME);
+    unsigned long  i;
+
+    for (i = 0; i < NURL_RV_FRAME / 8; i++) fp[i] = 0;
+    fp[0] = (unsigned long)&nurl__ctx_trampoline;   /* ra            */
+    fp[2] = (unsigned long)arg;                     /* s1            */
+    fp[3] = (unsigned long)entry;                   /* s2            */
+
+    ctx->sp = (void *)fp;
+}
+
+int nurl_ctx_available(void) { return 1; }
+
 #elif defined(NURL_CTX_AARCH64)
 
 /* The switch. Frame, from ctx->sp upward (11 pairs, 176 bytes, so sp
@@ -354,7 +461,7 @@ static long nurl__ctx_counter;
 static long nurl__ctx_switches;
 static long nurl__ctx_arg_seen;
 
-#if defined(NURL_CTX_X86_64) || defined(NURL_CTX_AARCH64)
+#if defined(NURL_CTX_X86_64) || defined(NURL_CTX_AARCH64) || defined(NURL_CTX_RISCV64)
 
 static void nurl__ctx_fpbounce(void *arg);
 
@@ -442,6 +549,25 @@ static void nurl__ctx_bounce(void *arg)
         "jmp 1b\n\t"
     );
 }
+#elif defined(NURL_CTX_RISCV64)
+/* Same fiber, RV64's callee-saved set. `call` clobbers ra, which is
+ * fine: this fiber never returns. */
+__attribute__((naked, noinline))
+static void nurl__ctx_bounce(void *arg)
+{
+    __asm__ volatile(
+        "call " NURL_CTX_SYM(nurl__ctx_test_enter) "\n\t"
+        "li s1, 0xdead\n\t"
+        "mv s2, s1\n\t" "mv s3, s1\n\t" "mv s4, s1\n\t" "mv s5, s1\n\t"
+        "1:\n\t"
+        "call " NURL_CTX_SYM(nurl__ctx_test_leave) "\n\t"
+        "la a0, " NURL_CTX_SYM(nurl__ctx_fiber) "\n\t"
+        "la a1, " NURL_CTX_SYM(nurl__ctx_main) "\n\t"
+        "call " NURL_CTX_SYM(nurl_ctx_switch) "\n\t"
+        "call " NURL_CTX_SYM(nurl__ctx_test_enter) "\n\t"
+        "j 1b\n\t"
+    );
+}
 #else /* NURL_CTX_AARCH64 — same fiber, this ISA's callee-saved set.
        * `bl` clobbers lr, which is fine: this fiber never returns. */
 __attribute__((naked, noinline))
@@ -482,14 +608,22 @@ static void nurl__ctx_fpbounce(void *arg)
 {
     (void)arg;
     nurl__ctx_test_enter();
-#ifdef NURL_CTX_X86_64
+#if defined(NURL_CTX_X86_64)
     unsigned       mx = 0x1f80u;              /* default, all masked   */
     unsigned short cw = 0x037fu;              /* x87 default           */
     __asm__ volatile("ldmxcsr %0" :: "m"(mx));
     __asm__ volatile("fldcw   %0" :: "m"(cw));
-#else
+#elif defined(NURL_CTX_AARCH64)
     unsigned long fpcr = 0;                   /* RN, no traps — default */
     __asm__ volatile("msr fpcr, %0" :: "r"(fpcr));
+#else
+    /* RV64: there is no callee-saved control word to set — fcsr is
+     * CALLER-saved by this ABI. What the switch IS responsible for is
+     * fs0–fs11, so this fiber trashes one and the test below checks
+     * the caller got its own value back. Same question, asked against
+     * the register set this ABI actually makes the switch answer for. */
+    unsigned long junk = 0x7ff8000000000000UL;   /* a NaN pattern */
+    __asm__ volatile("fmv.d.x fs0, %0" :: "r"(junk) : "fs0");
 #endif
     for (;;) nurl__ctx_test_yield();
 }
@@ -538,6 +672,33 @@ long nurl_ctx_test_preserve(void)
         : "=a"(ok)
         : "D"(&nurl__ctx_main), "S"(&nurl__ctx_fiber)
         : "rbx", "r12", "r13", "r14", "r15", "rcx", "memory", "cc");
+    nurl__ctx_test_from_fiber();
+    return ok;
+}
+#elif defined(NURL_CTX_RISCV64)
+long nurl_ctx_test_preserve(void)
+{
+    nurl__ctx_test_init(nurl__ctx_bounce, (void *)0UL);
+    long ok;
+    nurl__ctx_test_to_fiber();
+    __asm__ volatile(
+        "li s1, 0x1111\n\t" "li s2, 0x2222\n\t" "li s3, 0x3333\n\t"
+        "li s4, 0x4444\n\t" "li s5, 0x5555\n\t"
+        "mv a0, %[m]\n\t"
+        "mv a1, %[f]\n\t"
+        "call " NURL_CTX_SYM(nurl_ctx_switch) "\n\t"
+        "li %[ok], 0\n\t"
+        "li t0, 0x1111\n\t" "bne s1, t0, 1f\n\t"
+        "li t0, 0x2222\n\t" "bne s2, t0, 1f\n\t"
+        "li t0, 0x3333\n\t" "bne s3, t0, 1f\n\t"
+        "li t0, 0x4444\n\t" "bne s4, t0, 1f\n\t"
+        "li t0, 0x5555\n\t" "bne s5, t0, 1f\n\t"
+        "li %[ok], 1\n\t"
+        "1:\n\t"
+        : [ok] "=r"(ok)
+        : [m] "r"(&nurl__ctx_main), [f] "r"(&nurl__ctx_fiber)
+        : "a0", "a1", "t0", "s1", "s2", "s3", "s4", "s5", "ra",
+          "memory");
     nurl__ctx_test_from_fiber();
     return ok;
 }
@@ -618,6 +779,30 @@ long nurl_ctx_test_fpcw(void)
     __asm__ volatile("ldmxcsr %0" :: "m"(mx_before));
     __asm__ volatile("fldcw   %0" :: "m"(cw_before));
     return (mx_after == mx_ours) && (cw_after == cw_ours);
+}
+#elif defined(NURL_CTX_RISCV64)
+/* This ABI has no callee-saved control word: fcsr is caller-saved, so
+ * a switch that did not preserve it would still be correct. What it
+ * DOES have to preserve is fs0–fs11, and that is the same question —
+ * "does my floating-point state survive a round trip" — asked against
+ * the registers this ABI makes the switch answer for. */
+long nurl_ctx_test_fpcw(void)
+{
+    nurl__ctx_test_init(nurl__ctx_fpbounce, (void *)0UL);
+    unsigned long ours = 0x400a000000000000UL;   /* 3.25 */
+    unsigned long back = 0;
+    nurl__ctx_test_to_fiber();
+    __asm__ volatile(
+        "fmv.d.x fs0, %[ours]\n\t"
+        "mv a0, %[m]\n\t"
+        "mv a1, %[f]\n\t"
+        "call " NURL_CTX_SYM(nurl_ctx_switch) "\n\t"
+        "fmv.x.d %[back], fs0\n\t"
+        : [back] "=r"(back)
+        : [ours] "r"(ours), [m] "r"(&nurl__ctx_main), [f] "r"(&nurl__ctx_fiber)
+        : "a0", "a1", "fs0", "ra", "memory");
+    nurl__ctx_test_from_fiber();
+    return back == ours;
 }
 #else /* NURL_CTX_AARCH64 — FPCR's RMode field plays both control words' part */
 long nurl_ctx_test_fpcw(void)

--- a/tools/check_nolibc_symbols.sh
+++ b/tools/check_nolibc_symbols.sh
@@ -51,6 +51,7 @@ done
 case "$(uname -m)" in
     x86_64|amd64) arch_sfx=x86_64 ;;
     aarch64|arm64) arch_sfx=aarch64 ;;
+    riscv64) arch_sfx=riscv64 ;;
     *) arch_sfx="" ;;
 esac
 for f in "$NOLIBC"/*.S; do

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -381,6 +381,79 @@ what the AArch64 guest gate boots), while Firecracker and
 cloud-hypervisor want a PE-format `Image` there — a packaging step
 this target has not taken, rather than a property it has.
 
+## Three architectures, and what a port actually costs
+
+| | x86_64 | AArch64 | RV64 |
+|---|---|---|---|
+| board | QEMU microvm (PVH) | QEMU `virt` | QEMU `virt` + OpenSBI |
+| entry | 32-bit, `%ebx` = handover | EL2 or EL1, `x0` = DTB | S-mode, `a1` = DTB |
+| memory from | PVH memmap | device tree | device tree |
+| devices from | kernel command line | device tree | device tree |
+| clock | TSC, frequency **told** | CNTFRQ_EL0 | `rdtime`, tree's rate |
+| entropy | RDRAND | RNDR | **none — refuses** |
+| hello image | 132 760 B | 131 784 B | 155 344 B |
+
+The per-architecture files are the bottom edge and nothing else:
+`boot_<arch>.S`, `platform_<arch>.c`, `tls_guest_<arch>.c`,
+`nolibc/setjmp_<arch>.S`, `link_<arch>.ld`. Everything above them —
+the runtime, nolibc, the sans-IO TCP/IP stack, the socket ABI, the
+virtio driver, the program — is the same code, which each guest gate
+proves by running the ordinary corpus against its ORDINARY hosted
+goldens.
+
+Two things became shared rather than copied when the third port
+arrived, which is the right time for it:
+
+- **`boot/fdt.c`** — the device-tree walk. AArch64 and RV64 need the
+  same three answers (where RAM is, what the command line says, which
+  virtio-mmio devices exist) out of the same format, and two ports
+  parsing one tree separately is where two machines start disagreeing
+  about what it says. It also does the translation that keeps the
+  layer above architecture-blind: `hal/virtio.nu` reads the x86
+  spelling `virtio_mmio.device=size@base:irq`, so the walker
+  SYNTHESIZES those entries from the tree.
+- **`boot/pagealloc.c`** and **`boot/initfs.c`** were already portable
+  C and are linked by all three unchanged.
+
+### RV64 (QEMU `virt`), the third one
+
+OpenSBI runs first and hands the kernel S-mode with `a0` = hart id and
+`a1` = the device tree, so this port does less at entry than either
+twin: no mode change, no page tables before C. What it does do is park
+every hart but one (this runtime is a single vCPU by design), set
+`stvec` before anything can trap, turn FP on (`sstatus.FS` comes up
+Off, and LLVM emits FP for ordinary doubles), and switch the trap
+handler to its own stack by hand — this architecture has no automatic
+stack switch on trap, which AArch64 gets free from SP_EL1 and x86 from
+the TSS's IST.
+
+Three things this port had to say out loud rather than assume:
+
+- **`fp` IS `s0`.** The device-tree pointer was parked in `s0` and
+  three instructions later `li fp, 0` ended the frame-pointer chain —
+  zeroing it. The guest then reported "no device tree in a1", which
+  was a true statement about a register this file had just cleared.
+  An assembly probe of the firmware handover is what told them apart.
+- **The firmware talks.** OpenSBI prints a banner on the same UART
+  before the kernel runs, so the guest marks its own first byte
+  (`[nurl-boot]`) and the run script drops everything up to it. The
+  rule belongs to us rather than to whatever the banner looks like
+  this year.
+- **There is no entropy source.** RISC-V's `seed` CSR is the optional
+  Zkr extension and QEMU's rv64 CPU does not implement it, so this
+  port PANICS on a request for randomness, naming what is missing.
+  Everything else works; a TLS handshake here waits for a virtio-rng
+  driver. That is the plan's absolute rule applied to an architecture
+  that cannot satisfy it — refuse, do not invent.
+
+`unikernel/run_qemu_riscv64_tests.sh` is the gate — **15/15**, the
+same corpus programs against the same hosted goldens, the device
+demos, faults reported with exit 126, and an HTTP server in the guest
+answering curl on the host. The hello image is 155 344 B, about 23 KB
+more than the other two: this ISA needs more instructions to say the
+same things, which is the honest reading of the number rather than
+something to tune away.
+
 ## The second architecture (AArch64, QEMU `virt`)
 
 A second machine is what turns "portable" from an intention into a
@@ -523,6 +596,7 @@ unikernel/run_nolibc_tests.sh            # the corpus, with no libc
 unikernel/run_qemu_tests.sh              # the guest, under a hypervisor
 unikernel/run_qemu_tests.sh hello        # one of them
 unikernel/run_qemu_arm64_tests.sh        # the guest, on the other architecture
+unikernel/run_qemu_riscv64_tests.sh      # …and on the third
 unikernel/tests/hypervisor_gate.sh       # the image is not a QEMU image
 unikernel/build_nolibc.sh prog.nu        # build one program, no libc
 unikernel/build_unikernel.sh prog.nu     # build one bootable image (x86_64)

--- a/unikernel/boot/boot_riscv64.S
+++ b/unikernel/boot/boot_riscv64.S
@@ -1,0 +1,177 @@
+/*
+ * NURL unikernel — unikernel/boot/boot_riscv64.S
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * From the first instruction to `kmain`, RV64 (QEMU `virt`).
+ *
+ * QEMU's virt board runs OpenSBI in M-mode first and hands the kernel
+ * control in **S-mode**, with `a0` = the hart id and `a1` = the
+ * physical address of the device tree. That is the whole handover —
+ * simpler than either of the other two, because the firmware has
+ * already done what boot.S does on x86 (mode setup) and what the EL2
+ * dance does on AArch64.
+ *
+ * What is left for this file:
+ *
+ *   1. park every hart but one. QEMU starts as many as `-smp` says and
+ *      they all arrive here; this runtime is a single vCPU by design
+ *      (one scheduler, no locks that a second hart would need), so the
+ *      others must stop rather than run the program twice. They wait
+ *      in WFI forever, which is what a machine with no IPI can do.
+ *   2. the trap vector, before anything can trap (stvec unset means a
+ *      fault jumps to whatever address is in it — the same silent
+ *      wandering the x86 pass proved is the most expensive kind).
+ *   3. FP on. mstatus.FS lives in sstatus here, and it comes up Off:
+ *      the first floating-point instruction traps as illegal. LLVM
+ *      emits FP for ordinary double arithmetic, so this must happen
+ *      before C runs, exactly as SSE must on x86 and FPEN must on ARM.
+ *   4. .bss cleared, while nothing lives in it, with a1 (the DTB) kept
+ *      in a callee-saved register.
+ *   5. the stack. One stack here, unlike AArch64: this architecture
+ *      has no automatic stack switch on trap (no SP_EL1 equivalent),
+ *      so the trap handler switches by hand — see `trap_entry`.
+ */
+
+    .section .text.boot, "ax", %progbits
+    .globl _riscv_start
+_riscv_start:
+    /* Interrupts off until the vector is up. */
+    csrw    sie, zero
+    csrci   sstatus, 2              /* SIE = 0 */
+
+    /* One hart runs; the rest park. `a0` is the hart id OpenSBI passed. */
+    bnez    a0, park_hart
+
+    /* s1, NOT s0: on this ISA `fp` and `s0` are the SAME register
+     * (x8), so parking the device-tree pointer in s0 and then ending
+     * the frame-pointer chain with `li fp, 0` — three instructions
+     * apart, both correct-looking — zeroes it. The firmware passed a
+     * perfectly good tree and the guest reported "no device tree in
+     * a1", which is a true statement about a register this file had
+     * just cleared. */
+    mv      s1, a1                  /* the DTB pointer, kept safe      */
+
+    /* ── the trap vector ────────────────────────────────────────── */
+    la      t0, trap_entry
+    csrw    stvec, t0
+
+    /* ── FP on ──────────────────────────────────────────────────────
+     * sstatus.FS = Initial (1 << 13). Without it the first `fadd.d`
+     * is an illegal instruction, and the trap handler that would
+     * report it needs the UART, which needs C, which needs FP. */
+    li      t0, (1 << 13)
+    csrs    sstatus, t0
+
+    /* ── .bss, before anything is kept in it ────────────────────── */
+    la      t0, __bss_start
+    la      t1, __bss_end
+1:  bgeu    t0, t1, 2f
+    sd      zero, 0(t0)
+    addi    t0, t0, 8
+    j       1b
+2:
+
+    /* ── stack, then C ──────────────────────────────────────────── */
+    la      sp, boot_stack_top
+    andi    sp, sp, -16
+    li      fp, 0                   /* end the frame-pointer chain     */
+
+    mv      a0, s1                  /* kmain(dtb)                      */
+    call    kmain
+
+3:  wfi
+    j       3b
+
+park_hart:
+    wfi
+    j       park_hart
+
+/* ── the trap vector ──────────────────────────────────────────────
+ *
+ * One entry (stvec direct mode): every exception and interrupt arrives
+ * here. There is no automatic stack switch on this architecture, so
+ * the handler moves to its own stack by hand — the fault worth
+ * surviving is a stack that hit its guard page, and reporting it on
+ * that same stack faults again.
+ *
+ * `sscratch` holds the fault stack's top while the kernel runs, and 0
+ * while the handler runs, so a trap INSIDE the handler is detectable
+ * rather than a silent second switch onto a stack already in use.
+ */
+    .align 4
+    .globl trap_entry
+trap_entry:
+    csrrw   sp, sscratch, sp        /* sp ↔ sscratch (fault stack)     */
+    bnez    sp, 1f
+    /* sscratch was 0: we are already ON the fault stack — a trap in
+     * the handler. Swap back and keep going on it rather than
+     * relocating to address zero. */
+    csrrw   sp, sscratch, sp
+1:
+    addi    sp, sp, -288
+    sd      x1,  8(sp)
+    sd      x3,  24(sp)
+    sd      x4,  32(sp)
+    sd      x5,  40(sp)
+    sd      x6,  48(sp)
+    sd      x7,  56(sp)
+    sd      x8,  64(sp)
+    sd      x9,  72(sp)
+    sd      x10, 80(sp)
+    sd      x11, 88(sp)
+    sd      x12, 96(sp)
+    sd      x13, 104(sp)
+    sd      x14, 112(sp)
+    sd      x15, 120(sp)
+    sd      x16, 128(sp)
+    sd      x17, 136(sp)
+    sd      x18, 144(sp)
+    sd      x19, 152(sp)
+    sd      x20, 160(sp)
+    sd      x21, 168(sp)
+    sd      x22, 176(sp)
+    sd      x23, 184(sp)
+    sd      x24, 192(sp)
+    sd      x25, 200(sp)
+    sd      x26, 208(sp)
+    sd      x27, 216(sp)
+    sd      x28, 224(sp)
+    sd      x29, 232(sp)
+    sd      x30, 240(sp)
+    sd      x31, 248(sp)
+    /* the faulting context's own sp, which is in sscratch now */
+    csrr    t0, sscratch
+    sd      t0, 16(sp)
+    csrr    t0, sepc
+    sd      t0, 256(sp)
+    csrr    t0, scause
+    sd      t0, 264(sp)
+    csrr    t0, stval
+    sd      t0, 272(sp)
+    csrr    t0, sstatus
+    sd      t0, 280(sp)
+    /* Mark "in the handler" so a nested trap is visible. */
+    csrw    sscratch, zero
+    mv      a0, sp
+    call    pf_exception            /* does not return */
+1:  wfi
+    j       1b
+
+    .section .bss
+    .align 16
+    .skip 16 * 1024
+    .globl fault_stack_top
+fault_stack_top:
+
+    /* 64 KiB, the same size a coroutine gets, page-aligned with its
+     * bottom exported so it can be given the same guard page. */
+    .align 12
+    .globl boot_stack_bottom
+boot_stack_bottom:
+    .skip 64 * 1024
+    .align 16
+boot_stack_top:
+
+    .section .note.GNU-stack, "", %progbits

--- a/unikernel/boot/fdt.c
+++ b/unikernel/boot/fdt.c
@@ -1,0 +1,243 @@
+/*
+ * NURL unikernel — unikernel/boot/fdt.c
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * The device tree, for the machines that have one.
+ *
+ * x86's microvm announces its memory in a PVH handover block and its
+ * virtio-mmio devices on the kernel command line. Every other machine
+ * this target runs on — QEMU's `virt` board on AArch64 and on RISC-V —
+ * announces both in a flattened device tree instead. That is one
+ * format to parse and two ports that would otherwise parse it twice,
+ * which is why this file exists: the AArch64 port wrote it, the
+ * RISC-V port would have copied it, and a copy is where two machines
+ * start disagreeing about what the same tree says.
+ *
+ * What the layers above need from a tree is exactly three answers:
+ *
+ *   - where RAM is and how much of it there is (/memory reg);
+ *   - the command line the host set (/chosen/bootargs);
+ *   - every virtio-mmio device, IN THE X86 SPELLING. `hal/virtio.nu`
+ *     reads `virtio_mmio.device=size@base:irq` entries because that is
+ *     what microvm hands the x86 guest, so this walker SYNTHESIZES the
+ *     same entries from the tree. One format above the boot layer,
+ *     whatever the machine spoke below it.
+ *
+ * A minimal walker, not a library: the flattened format is four token
+ * types and big-endian integers, and nothing here needs more than the
+ * three answers above. An unknown token stops the walk rather than
+ * being interpreted — noise read as a device list is a guest driving
+ * something that is not there.
+ */
+
+typedef unsigned long long u64;
+typedef unsigned int       u32;
+
+#define FDT_MAGIC       0xd00dfeed
+#define FDT_BEGIN_NODE  1
+#define FDT_END_NODE    2
+#define FDT_PROP        3
+#define FDT_NOP         4
+#define FDT_END         9
+
+/* What a walk answers. `cmdline` is the string the boot code hands to
+ * `nurl_boot_cmdline`: bootargs first, then the synthesized device
+ * entries, so a program's `args="…"` is found before them and QEMU's
+ * device list never reaches an argument parser. */
+struct fdt_facts {
+    u64   ram_base;
+    u64   ram_size;
+    char  cmdline[2048];
+    unsigned long cmdline_len;
+    int   devices;            /* how many virtio-mmio nodes were seen */
+};
+
+static u32 fdt_be32(const unsigned char *p) {
+    return ((u32)p[0] << 24) | ((u32)p[1] << 16) | ((u32)p[2] << 8) | (u32)p[3];
+}
+static u64 fdt_be64(const unsigned char *p) {
+    return ((u64)fdt_be32(p) << 32) | fdt_be32(p + 4);
+}
+
+static int fdt_str_eq(const char *a, const char *b) {
+    while (*a && *a == *b) { a++; b++; }
+    return *a == *b;
+}
+static int fdt_str_prefix(const char *s, const char *pre) {
+    while (*pre && *s == *pre) { s++; pre++; }
+    return *pre == 0;
+}
+
+static void cl_puts(struct fdt_facts *f, const char *s) {
+    while (*s && f->cmdline_len < sizeof f->cmdline - 1)
+        f->cmdline[f->cmdline_len++] = *s++;
+    f->cmdline[f->cmdline_len] = 0;
+}
+static void cl_puthex(struct fdt_facts *f, u64 v) {
+    static const char hex[] = "0123456789abcdef";
+    char b[17];
+    int i = 16;
+    b[i] = 0;
+    if (!v) b[--i] = '0';
+    while (v) { b[--i] = hex[v & 0xF]; v >>= 4; }
+    cl_puts(f, "0x");
+    cl_puts(f, &b[i]);
+}
+static void cl_putu(struct fdt_facts *f, u64 v) {
+    char b[21];
+    int i = 20;
+    b[i] = 0;
+    if (!v) b[--i] = '0';
+    while (v) { b[--i] = (char)('0' + v % 10); v /= 10; }
+    cl_puts(f, &b[i]);
+}
+
+/* 1 when `p` points at a flattened device tree. */
+int fdt_is_tree(const void *p) {
+    return p && fdt_be32((const unsigned char *)p) == FDT_MAGIC;
+}
+
+/* Walk the tree and fill `out`. Returns 0 when `fdt` is not a tree.
+ *
+ * A node is classified by its NAME at whatever depth it appears —
+ * AArch64's virt puts its devices at the root, RISC-V's virt puts them
+ * under /soc — and judged at its END, because `reg`, `interrupts` and
+ * the name arrive in whatever order the tree was written in.
+ */
+int fdt_probe(const void *fdt_p, struct fdt_facts *out) {
+    const unsigned char *fdt = (const unsigned char *)fdt_p;
+    if (!fdt_is_tree(fdt)) return 0;
+
+    u32 off_struct  = fdt_be32(fdt + 8);
+    u32 off_strings = fdt_be32(fdt + 12);
+    const unsigned char *p = fdt + off_struct;
+    const char *strings = (const char *)fdt + off_strings;
+    const char *bootargs = 0;
+
+    out->ram_base = out->ram_size = 0;
+    out->cmdline_len = 0;
+    out->cmdline[0] = 0;
+    out->devices = 0;
+
+    /* Per-depth state. The tree's SHAPE is the machine's business:
+     * AArch64's virt puts its devices at the root, RISC-V's virt puts
+     * them under /soc, and a walker that hard-codes a depth finds
+     * nothing on the machine it was not written for — which is exactly
+     * what "0 devices" on the RISC-V board turned out to mean. So a
+     * node is classified by its NAME at whatever depth it appears, and
+     * the address/size cells are tracked per level because a bus node
+     * may state its own.
+     *
+     * 16 levels is far past anything these trees use; deeper than that
+     * stops the walk rather than indexing off the end. */
+#define FDT_MAX_DEPTH 16
+    struct {
+        u32 addr_cells, size_cells;
+        int is_virtio, is_memory, is_chosen;
+        u64 reg_base, reg_size, irq;
+    } lvl[FDT_MAX_DEPTH];
+    int depth = 0;
+
+    lvl[0].addr_cells = 2; lvl[0].size_cells = 2;
+    lvl[0].is_virtio = lvl[0].is_memory = lvl[0].is_chosen = 0;
+
+    /* The device entries are accumulated here and joined onto the
+     * bootargs at the end, so a program's `args="…"` is found before
+     * the hypervisor's device list. */
+    struct fdt_facts devs;
+    devs.cmdline_len = 0;
+    devs.cmdline[0] = 0;
+
+    for (;;) {
+        u32 tok = fdt_be32(p); p += 4;
+        if (tok == FDT_END) break;
+        if (tok == FDT_NOP) continue;
+        if (tok == FDT_BEGIN_NODE) {
+            const char *name = (const char *)p;
+            unsigned long n = 0;
+            while (name[n]) n++;
+            p += (n + 1 + 3) & ~3UL;
+            depth++;
+            if (depth >= FDT_MAX_DEPTH) break;
+            /* Cells are inherited until this node states its own. */
+            lvl[depth].addr_cells = lvl[depth - 1].addr_cells;
+            lvl[depth].size_cells = lvl[depth - 1].size_cells;
+            lvl[depth].is_virtio = fdt_str_prefix(name, "virtio_mmio@");
+            lvl[depth].is_memory = fdt_str_prefix(name, "memory@") ||
+                                   fdt_str_eq(name, "memory");
+            lvl[depth].is_chosen = fdt_str_eq(name, "chosen");
+            lvl[depth].reg_base = lvl[depth].reg_size = lvl[depth].irq = 0;
+            continue;
+        }
+        if (tok == FDT_END_NODE) {
+            if (depth > 0 && depth < FDT_MAX_DEPTH) {
+                if (lvl[depth].is_virtio && lvl[depth].reg_size) {
+                    /* The x86 spelling: size@base:irq. The IRQ is the
+                     * controller's number plus the SPI base (32) — what
+                     * Linux would print — though the polling driver
+                     * above never uses it. */
+                    cl_puts(&devs, " virtio_mmio.device=");
+                    cl_puthex(&devs, lvl[depth].reg_size);
+                    cl_puts(&devs, "@");
+                    cl_puthex(&devs, lvl[depth].reg_base);
+                    cl_puts(&devs, ":");
+                    cl_putu(&devs, lvl[depth].irq + 32);
+                    out->devices++;
+                }
+                if (lvl[depth].is_memory && lvl[depth].reg_size && !out->ram_size) {
+                    out->ram_base = lvl[depth].reg_base;
+                    out->ram_size = lvl[depth].reg_size;
+                }
+            }
+            depth--;
+            if (depth < 0) break;
+            continue;
+        }
+        if (tok == FDT_PROP) {
+            u32 len  = fdt_be32(p);
+            u32 noff = fdt_be32(p + 4);
+            const unsigned char *val = p + 8;
+            const char *pname = strings + noff;
+            p += 8 + ((len + 3) & ~3UL);
+            if (depth < 0 || depth >= FDT_MAX_DEPTH) continue;
+
+            if (fdt_str_eq(pname, "#address-cells")) lvl[depth].addr_cells = fdt_be32(val);
+            if (fdt_str_eq(pname, "#size-cells"))    lvl[depth].size_cells = fdt_be32(val);
+            /* Only /chosen carries the command line. Reading a
+             * `bootargs` from anywhere would take some device's
+             * property as the kernel's arguments. */
+            if (lvl[depth].is_chosen && fdt_str_eq(pname, "bootargs"))
+                bootargs = (const char *)val;
+
+            u32 ac = lvl[depth - (depth > 0)].addr_cells;
+            u32 sc = lvl[depth - (depth > 0)].size_cells;
+            if (fdt_str_eq(pname, "reg") && len >= (ac + sc) * 4) {
+                lvl[depth].reg_base = ac == 2 ? fdt_be64(val) : fdt_be32(val);
+                lvl[depth].reg_size = sc == 2 ? fdt_be64(val + ac * 4)
+                                              : fdt_be32(val + ac * 4);
+            }
+            if (fdt_str_eq(pname, "interrupts") && len >= 4) {
+                /* <irq> on RISC-V's PLIC, <type irq flags> on ARM's
+                 * GIC. The second cell is the number in the three-cell
+                 * form; in the one-cell form the first IS the number. */
+                lvl[depth].irq = len >= 12 ? fdt_be32(val + 4) : fdt_be32(val);
+            }
+            continue;
+        }
+        /* Lost: stop rather than read noise as devices. */
+        break;
+    }
+
+    /* bootargs FIRST, then the devices: a program's `args="…"` must be
+     * found before the hypervisor's device list, and a parser that
+     * scans forward stops at the first match. */
+    if (bootargs) cl_puts(out, bootargs);
+    for (unsigned long i = 0; i < devs.cmdline_len; i++) {
+        if (out->cmdline_len >= sizeof out->cmdline - 1) break;
+        out->cmdline[out->cmdline_len++] = devs.cmdline[i];
+    }
+    out->cmdline[out->cmdline_len] = 0;
+    return 1;
+}

--- a/unikernel/boot/link_riscv64.ld
+++ b/unikernel/boot/link_riscv64.ld
@@ -1,0 +1,51 @@
+/* unikernel/boot/link_riscv64.ld — the guest's address space, RV64.
+ *
+ * QEMU's virt machine puts RAM at 0x8000_0000, and OpenSBI occupies
+ * the first 2 MiB of it — 0x8020_0000 is where every RISC-V kernel on
+ * this board is expected to start, and where the firmware jumps. The
+ * image therefore links exactly there, 2 MiB-aligned so the identity
+ * map's 2 MiB leaves line up with the sections.
+ *
+ * Same section contract as the x86_64 script — the TLS image bounds,
+ * __bss_start/__bss_end for the boot code's clear, __heap_start as
+ * the floor of the allocator's arena. The ceiling comes from the
+ * device tree's /memory node, never from a guess.
+ */
+ENTRY(_riscv_start)
+
+SECTIONS
+{
+    . = 0x80200000;
+
+    .text : ALIGN(4096) {
+        *(.text.boot)
+        *(.text .text.*)
+    }
+
+    .rodata : ALIGN(4096) { *(.rodata .rodata.*) }
+
+    .data : ALIGN(4096) { *(.data .data.*) }
+
+    .tdata : ALIGN(64) {
+        __tls_image_start = .;
+        *(.tdata .tdata.*)
+        __tls_image_end = .;
+    }
+    .tbss : ALIGN(8) {
+        *(.tbss .tbss.*)
+        *(.tcommon)
+        __tls_memsz_end = .;
+    }
+
+    .bss : ALIGN(4096) {
+        __bss_start = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        __bss_end = .;
+    }
+
+    . = ALIGN(2M);
+    __heap_start = .;
+
+    /DISCARD/ : { *(.comment) *(.note.GNU-stack) *(.eh_frame) }
+}

--- a/unikernel/boot/platform_arm64.c
+++ b/unikernel/boot/platform_arm64.c
@@ -183,163 +183,22 @@ void pf_exception(u64 vector, struct fault_frame *f) {
 
 /* ── the device tree ─────────────────────────────────────────────
  *
- * The one authoritative statement of what this machine is. A minimal
- * walker, not a library: the flattened format is four token types and
- * big-endian integers, and this file needs exactly three answers from
- * it — /chosen/bootargs, /memory reg, and every "virtio,mmio" node's
- * reg + interrupts.
+ * In unikernel/boot/fdt.c, because the RISC-V port needs exactly the
+ * same three answers from exactly the same format — and two ports
+ * parsing one tree separately is where two machines start disagreeing
+ * about what it says. This file keeps only what is machine-specific.
  */
-#define FDT_MAGIC       0xd00dfeed
-#define FDT_BEGIN_NODE  1
-#define FDT_END_NODE    2
-#define FDT_PROP        3
-#define FDT_NOP         4
-#define FDT_END         9
+struct fdt_facts {
+    unsigned long long ram_base;
+    unsigned long long ram_size;
+    char  cmdline[2048];
+    unsigned long cmdline_len;
+    int   devices;
+};
+int fdt_is_tree(const void *p);
+int fdt_probe(const void *fdt, struct fdt_facts *out);
 
-static u32 be32(const unsigned char *p) {
-    return ((u32)p[0] << 24) | ((u32)p[1] << 16) | ((u32)p[2] << 8) | (u32)p[3];
-}
-static u64 be64(const unsigned char *p) {
-    return ((u64)be32(p) << 32) | be32(p + 4);
-}
-
-static int str_eq(const char *a, const char *b) {
-    while (*a && *a == *b) { a++; b++; }
-    return *a == *b;
-}
-static int str_prefix(const char *s, const char *pre) {
-    while (*pre && *s == *pre) { s++; pre++; }
-    return *pre == 0;
-}
-
-/* What the walk fills in. */
-static u64 fdt_ram_base, fdt_ram_size;
-static const char *fdt_bootargs;
-
-/* The synthesized command line: the DTB's bootargs plus one
- * `virtio_mmio.device=` entry per device node, so the NURL layer sees
- * the exact format microvm's auto-cmdline gives the x86 guest. */
-static char cmdline_buf[2048];
-static unsigned long cmdline_len;
-
-static void cl_puts(const char *s) {
-    while (*s && cmdline_len < sizeof cmdline_buf - 1)
-        cmdline_buf[cmdline_len++] = *s++;
-    cmdline_buf[cmdline_len] = 0;
-}
-static void cl_puthex(u64 v) {
-    static const char hex[] = "0123456789abcdef";
-    char b[17];
-    int i = 16;
-    b[i] = 0;
-    if (!v) b[--i] = '0';
-    while (v) { b[--i] = hex[v & 0xF]; v >>= 4; }
-    cl_puts("0x");
-    cl_puts(&b[i]);
-}
-static void cl_putu(u64 v) {
-    char b[21];
-    int i = 20;
-    b[i] = 0;
-    if (!v) b[--i] = '0';
-    while (v) { b[--i] = (char)('0' + v % 10); v /= 10; }
-    cl_puts(&b[i]);
-}
-
-/* One pass over the structure block. Depth-1 node names decide what a
- * property means; #address-cells/#size-cells are read from the root
- * (virt says 2/2, and the walker believes the tree, not the doc). */
-static void fdt_parse(const unsigned char *fdt) {
-    u32 off_struct  = be32(fdt + 8);
-    u32 off_strings = be32(fdt + 12);
-    const unsigned char *p = fdt + off_struct;
-    const char *strings = (const char *)fdt + off_strings;
-
-    int depth = 0;
-    u32 addr_cells = 2, size_cells = 2;
-    /* Per-node state for the virtio nodes: reg and irq arrive as
-     * separate properties, compatible may come after either, so the
-     * node is judged at its END. */
-    int  node_is_virtio = 0, node_is_memory = 0;
-    u64  node_reg_base = 0, node_reg_size = 0;
-    u64  node_irq = 0;
-    int  node_depth = -1;
-
-    for (;;) {
-        u32 tok = be32(p); p += 4;
-        if (tok == FDT_END) break;
-        if (tok == FDT_NOP) continue;
-        if (tok == FDT_BEGIN_NODE) {
-            const char *name = (const char *)p;
-            unsigned long n = 0;
-            while (name[n]) n++;
-            p += (n + 1 + 3) & ~3UL;
-            depth++;
-            if (depth == 2) {
-                node_is_virtio = str_prefix(name, "virtio_mmio@");
-                node_is_memory = str_prefix(name, "memory@") || str_eq(name, "memory");
-                node_reg_base = node_reg_size = node_irq = 0;
-                node_depth = depth;
-            }
-            continue;
-        }
-        if (tok == FDT_END_NODE) {
-            if (depth == node_depth) {
-                if (node_is_virtio && node_reg_size) {
-                    /* The x86 format: size@base:irq. The IRQ is the
-                     * GIC SPI number plus the SPI base (32) — the
-                     * number Linux would print — though the polling
-                     * driver above never uses it. */
-                    cl_puts(" virtio_mmio.device=");
-                    cl_puthex(node_reg_size);
-                    cl_puts("@");
-                    cl_puthex(node_reg_base);
-                    cl_puts(":");
-                    cl_putu(node_irq + 32);
-                }
-                if (node_is_memory && node_reg_size && !fdt_ram_size) {
-                    fdt_ram_base = node_reg_base;
-                    fdt_ram_size = node_reg_size;
-                }
-                node_is_virtio = node_is_memory = 0;
-                node_depth = -1;
-            }
-            depth--;
-            continue;
-        }
-        if (tok == FDT_PROP) {
-            u32 len  = be32(p);
-            u32 noff = be32(p + 4);
-            const unsigned char *val = p + 8;
-            const char *pname = strings + noff;
-            p += 8 + ((len + 3) & ~3UL);
-
-            if (depth == 1) {
-                if (str_eq(pname, "#address-cells")) addr_cells = be32(val);
-                if (str_eq(pname, "#size-cells"))    size_cells = be32(val);
-            }
-            if (depth == 2 && str_eq(pname, "bootargs")) {
-                /* /chosen/bootargs — only /chosen carries it at this
-                 * depth on virt, and believing a stray one elsewhere
-                 * would take a device's property as the command line. */
-                fdt_bootargs = (const char *)val;
-            }
-            if (depth == node_depth && str_eq(pname, "reg") &&
-                len >= (addr_cells + size_cells) * 4) {
-                node_reg_base = addr_cells == 2 ? be64(val) : be32(val);
-                node_reg_size = size_cells == 2 ? be64(val + addr_cells * 4)
-                                                : be32(val + addr_cells * 4);
-            }
-            if (depth == node_depth && str_eq(pname, "interrupts") && len >= 12) {
-                node_irq = be32(val + 4);        /* <type irq flags>   */
-            }
-            continue;
-        }
-        /* An unknown token means the walk is lost; stop rather than
-         * interpret noise as devices. */
-        break;
-    }
-}
+static struct fdt_facts facts;
 
 /* ── the kernel command line ─────────────────────────────────────── */
 
@@ -390,10 +249,10 @@ static u32  pt_pool_used;
 
 static void mem_init(void) {
     u64 img = (u64)(unsigned long)__heap_start;
-    if (!fdt_ram_size)
+    if (!facts.ram_size)
         pf_panic("the device tree reported no memory — refusing to guess "
                  "how much RAM this machine has");
-    u64 base = fdt_ram_base, len = fdt_ram_size;
+    u64 base = facts.ram_base, len = facts.ram_size;
     if (base + len <= img)
         pf_panic("no usable memory above the image");
     if (base < img) { len -= (img - base); base = img; }
@@ -495,8 +354,8 @@ static void mmu_init(void) {
 
     /* RAM, from where the tree says it starts to where it says it
      * ends, one L2 table per gigabyte. */
-    u64 ram_end = fdt_ram_base + fdt_ram_size;
-    u64 gb_first = fdt_ram_base >> 30;
+    u64 ram_end = facts.ram_base + facts.ram_size;
+    u64 gb_first = facts.ram_base >> 30;
     u64 gb_last  = (ram_end - 1) >> 30;
     if (gb_last - gb_first + 1 > MAX_RAM_L2)
         pf_panic("more RAM than the boot page tables cover (raise MAX_RAM_L2)");
@@ -823,31 +682,14 @@ void kmain(unsigned long x0) {
      * convention, the start of RAM otherwise (where QEMU's virt board
      * puts it for a bare-metal ELF). Without one this port knows
      * neither its memory nor its devices, and says so. */
-    const unsigned char *fdt = 0;
-    if (x0 && be32((const unsigned char *)x0) == FDT_MAGIC)
-        fdt = (const unsigned char *)x0;
-    else if (be32((const unsigned char *)0x40000000UL) == FDT_MAGIC)
-        fdt = (const unsigned char *)0x40000000UL;
+    const void *fdt = 0;
+    if (x0 && fdt_is_tree((const void *)x0))          fdt = (const void *)x0;
+    else if (fdt_is_tree((const void *)0x40000000UL)) fdt = (const void *)0x40000000UL;
     if (!fdt)
         pf_panic("no device tree in x0 or at the start of RAM — was this "
                  "image started with qemu-system-aarch64 -M virt -kernel?");
-    fdt_parse(fdt);
-
-    /* The command line the layers above see: the DTB's bootargs, then
-     * the virtio entries the walk synthesized (fdt_parse appended them
-     * to cmdline_buf already — bootargs go in FRONT of them now). */
-    {
-        char tail[sizeof cmdline_buf];
-        unsigned long tn = cmdline_len;
-        for (unsigned long i = 0; i < tn; i++) tail[i] = cmdline_buf[i];
-        cmdline_len = 0;
-        cmdline_buf[0] = 0;
-        if (fdt_bootargs) cl_puts(fdt_bootargs);
-        for (unsigned long i = 0; i < tn && cmdline_len < sizeof cmdline_buf - 1; i++)
-            cmdline_buf[cmdline_len++] = tail[i];
-        cmdline_buf[cmdline_len] = 0;
-        cmdline = cmdline_buf;
-    }
+    fdt_probe(fdt, &facts);
+    cmdline = facts.cmdline;
 
     mem_init();
     mmu_init();

--- a/unikernel/boot/platform_riscv64.c
+++ b/unikernel/boot/platform_riscv64.c
@@ -1,0 +1,665 @@
+/*
+ * NURL unikernel — unikernel/boot/platform_riscv64.c
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * The guest's bottom edge on RV64 (QEMU `virt`) — the third of the
+ * three, and by now the shape is a template rather than a discovery.
+ * The same five services, this machine's answers:
+ *
+ *   write        a 16550 UART at 0x1000_0000 (what virt puts there;
+ *                the SBI console would be a firmware call instead, and
+ *                a device this port already knows how to drive is one
+ *                dependency fewer on which SBI version is underneath).
+ *   memory       the device tree's /memory node, via boot/fdt.c —
+ *                shared with the AArch64 port, one parser, one answer.
+ *   time         `rdtime`, with the frequency from the tree's
+ *                timebase-frequency (10 MHz on virt). Self-describing,
+ *                like AArch64's CNTFRQ and unlike x86's TSC.
+ *   entropy      NO instruction on this ISA's base profile — the Zkr
+ *                extension's `seed` CSR is optional and QEMU's `rv64`
+ *                CPU does not implement it. So: the SBI debug console
+ *                cannot help either, and this port PANICS on a request
+ *                for entropy rather than inventing it. That is the
+ *                plan's rule applied honestly: a machine without a
+ *                source refuses to make keys, and says which piece is
+ *                missing.
+ *   exit         the sentinel line, then SBI SRST (system reset), then
+ *                the legacy SBI shutdown, then WFI.
+ */
+
+void exit(int code);
+long long write(int fd, const void *buf, unsigned long n);
+long long read(int fd, void *buf, unsigned long n);
+int open(const char *p, int fl, int mode);
+int close(int fd);
+long long lseek(int fd, long long off, int whence);
+void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off);
+int munmap(void *p, unsigned long len);
+
+struct nl_file;
+extern struct nl_file *stdout;
+int *nl_file_flags(struct nl_file *f);
+#define PF_F_LINEBUF 0x20
+
+typedef unsigned long      pf_size_t;
+typedef long               pf_ssize_t;
+typedef unsigned long long u64;
+typedef unsigned int       u32;
+
+extern unsigned char __heap_start[];
+
+/* ── the device tree, in boot/fdt.c ──────────────────────────────── */
+struct fdt_facts {
+    u64   ram_base;
+    u64   ram_size;
+    char  cmdline[2048];
+    unsigned long cmdline_len;
+    int   devices;
+};
+int fdt_is_tree(const void *p);
+int fdt_probe(const void *fdt, struct fdt_facts *out);
+
+static struct fdt_facts facts;
+
+/* ── the serial port ─────────────────────────────────────────────
+ * NS16550A at virt's 0x10000000. Byte-wide registers, no shift. */
+
+#define UART_BASE 0x10000000UL
+#define UART_THR  (*(volatile unsigned char *)(UART_BASE + 0))
+#define UART_LSR  (*(volatile unsigned char *)(UART_BASE + 5))
+#define UART_LSR_THRE 0x20
+
+static void uart_init(void) {
+    /* OpenSBI has already configured it for its own output; setting
+     * the divisor again would only risk disagreeing with the host's
+     * -serial. Stating the dependency instead of re-deriving it. */
+}
+
+static void uart_putc(char c) {
+    if (c == '\n') {
+        while (!(UART_LSR & UART_LSR_THRE)) { }
+        UART_THR = '\r';
+    }
+    while (!(UART_LSR & UART_LSR_THRE)) { }
+    UART_THR = (unsigned char)c;
+}
+
+static void uart_puts(const char *s) { while (*s) uart_putc(*s++); }
+
+static void uart_putu(unsigned long v) {
+    char b[21];
+    int i = 20;
+    b[i] = 0;
+    if (!v) b[--i] = '0';
+    while (v) { b[--i] = (char)('0' + v % 10); v /= 10; }
+    uart_puts(&b[i]);
+}
+
+static void uart_puthex(u64 v) {
+    static const char hex[] = "0123456789abcdef";
+    uart_puts("0x");
+    for (int i = 60; i >= 0; i -= 4) uart_putc(hex[(v >> i) & 0xF]);
+}
+
+static void pf_shutdown(int code);
+
+void pf_panic(const char *msg) {
+    uart_puts("nurl: ");
+    uart_puts(msg);
+    uart_putc('\n');
+    pf_shutdown(127);
+    for (;;) __asm__ __volatile__("wfi");
+}
+
+/* ── SBI ─────────────────────────────────────────────────────────
+ * The one firmware call this port makes. `ecall` from S-mode with the
+ * extension id in a7 and the function id in a6. */
+static long sbi_call(long eid, long fid, long a0_, long a1_) {
+    register long a0 __asm__("a0") = a0_;
+    register long a1 __asm__("a1") = a1_;
+    register long a6 __asm__("a6") = fid;
+    register long a7 __asm__("a7") = eid;
+    __asm__ __volatile__("ecall"
+                         : "+r"(a0), "+r"(a1)
+                         : "r"(a6), "r"(a7)
+                         : "memory");
+    return a0;
+}
+
+/* ── faults ──────────────────────────────────────────────────────
+ *
+ * The frame `trap_entry` in boot_riscv64.S builds, low address first.
+ * The two files are read together. x[0] is unused (x0 is hardwired
+ * zero) and kept so an index is a register number. */
+struct fault_frame {
+    u64 x[32];                /* x0–x31, x[2] = the faulting sp */
+    u64 sepc, scause, stval, sstatus;
+};
+
+/* scause, with the interrupt bit stripped. The names are the
+ * privileged spec's, so a report is something someone can look up. */
+static const char *cause_name(u64 scause) {
+    if (scause >> 63) {
+        switch (scause & 0xff) {
+        case 1:  return "supervisor software interrupt";
+        case 5:  return "supervisor timer interrupt";
+        case 9:  return "supervisor external interrupt";
+        default: return "interrupt (unexpected — this machine polls)";
+        }
+    }
+    switch (scause) {
+    case 0:  return "instruction address misaligned";
+    case 1:  return "instruction access fault";
+    case 2:  return "illegal instruction";
+    case 3:  return "breakpoint";
+    case 4:  return "load address misaligned";
+    case 5:  return "load access fault";
+    case 6:  return "store/AMO address misaligned";
+    case 7:  return "store/AMO access fault";
+    case 8:  return "environment call from U-mode";
+    case 9:  return "environment call from S-mode";
+    case 12: return "instruction page fault";
+    case 13: return "load page fault";
+    case 15: return "store/AMO page fault";
+    default: return "see scause in the privileged spec";
+    }
+}
+
+void pf_exception(struct fault_frame *f);
+
+void pf_exception(struct fault_frame *f) {
+    uart_puts("\nnurl: fault ");
+    uart_puts(cause_name(f->scause));
+    uart_puts("\n  scause=");
+    uart_puthex(f->scause);
+    uart_puts(" sepc=");
+    uart_puthex(f->sepc);
+    uart_puts(" sstatus=");
+    uart_puthex(f->sstatus);
+    if (f->scause == 12 || f->scause == 13 || f->scause == 15 ||
+        f->scause == 1  || f->scause == 5  || f->scause == 7) {
+        uart_puts("\n  stval=");
+        uart_puthex(f->stval);
+        uart_puts(f->scause == 15 || f->scause == 7 ? " on write" :
+                  (f->scause == 12 || f->scause == 1 ? " on instruction fetch"
+                                                     : " on read"));
+    }
+    uart_puts("\n  ra=");   uart_puthex(f->x[1]);
+    uart_puts(" sp=");      uart_puthex(f->x[2]);
+    uart_puts(" fp=");      uart_puthex(f->x[8]);
+    uart_puts("\n  a0=");   uart_puthex(f->x[10]);
+    uart_puts(" a1=");      uart_puthex(f->x[11]);
+    uart_puts(" a2=");      uart_puthex(f->x[12]);
+    uart_putc('\n');
+    /* 126, not 127: a fault is not a panic, and the harness can tell. */
+    pf_shutdown(126);
+    for (;;) __asm__ __volatile__("wfi");
+}
+
+/* ── the kernel command line ─────────────────────────────────────── */
+
+static const char *cmdline;
+const char *nurl_boot_cmdline(void);
+const char *nurl_boot_cmdline(void) { return cmdline ? cmdline : ""; }
+
+static u64 cmdline_u64(const char *key) {
+    const char *p = cmdline;
+    unsigned long klen = 0;
+    if (!p) return 0;
+    while (key[klen]) klen++;
+    while (*p) {
+        const char *k = p;
+        unsigned long n = 0;
+        while (p[n] && p[n] != ' ' && p[n] != '=') n++;
+        if (n == klen && p[n] == '=') {
+            unsigned long i = 0;
+            for (; i < klen; i++) if (k[i] != key[i]) break;
+            if (i == klen) {
+                u64 v = 0;
+                const char *d = p + n + 1;
+                if (*d < '0' || *d > '9') return 0;
+                while (*d >= '0' && *d <= '9') { v = v * 10 + (u64)(*d - '0'); d++; }
+                return v;
+            }
+        }
+        while (*p && *p != ' ') p++;
+        while (*p == ' ') p++;
+    }
+    return 0;
+}
+
+/* ── memory ──────────────────────────────────────────────────────── */
+
+static unsigned char *heap_next;
+static unsigned char *heap_end;
+
+void          pa_init(unsigned long base, unsigned long len);
+unsigned long pa_alloc(unsigned long want);
+int           pa_free(unsigned long p, unsigned long len);
+void          pa_stats(unsigned long *live, unsigned long *peak, unsigned long *avail,
+                       unsigned long *largest, unsigned long *lost, int *holes);
+
+#define PT_POOL_TABLES 64
+static u64 *pt_pool;
+static u32  pt_pool_used;
+
+static void mem_init(void) {
+    u64 img = (u64)(unsigned long)__heap_start;
+    if (!facts.ram_size)
+        pf_panic("the device tree reported no memory — refusing to guess "
+                 "how much RAM this machine has");
+    u64 base = facts.ram_base, len = facts.ram_size;
+    if (base + len <= img)
+        pf_panic("no usable memory above the image");
+    if (base < img) { len -= (img - base); base = img; }
+
+    heap_next = (unsigned char *)(unsigned long)base;
+    heap_end  = heap_next + len;
+
+    heap_next = (unsigned char *)(((unsigned long)heap_next + 4095) & ~4095UL);
+    pt_pool = (u64 *)heap_next;
+    heap_next += (unsigned long)PT_POOL_TABLES * 4096;
+    if (heap_next > heap_end) pf_panic("not enough memory for the page-table pool");
+    for (unsigned long i = 0; i < (unsigned long)PT_POOL_TABLES * 512; i++) pt_pool[i] = 0;
+
+    pa_init((unsigned long)heap_next, (unsigned long)(heap_end - heap_next));
+}
+
+int fs_is_file_fd(int fd);
+pf_ssize_t fs_read_fd(int fd, void *buf, pf_size_t n);
+long long fs_lseek_fd(int fd, long long off, int whence);
+int fs_close_fd(int fd);
+const unsigned char *fs_map_fd(int fd, unsigned long off);
+int fs_exists(const char *path);
+
+void *mmap(void *addr, unsigned long len, int prot, int flags, int fd, long off) {
+    (void)addr; (void)prot; (void)flags;
+    if (fd >= 0 && fs_is_file_fd(fd)) {
+        const unsigned char *p = fs_map_fd(fd, (unsigned long)off);
+        return p ? (void *)p : (void *)-1;
+    }
+    unsigned long p = pa_alloc(len);
+    return p ? (void *)p : (void *)-1;
+}
+
+int munmap(void *p, unsigned long len) {
+    return pa_free((unsigned long)p, len) == 0 ? 0 : 0;
+}
+
+long long nurl_guest_mem(int which) {
+    unsigned long live = 0, peak = 0, avail = 0, largest = 0, lost = 0;
+    int holes = 0;
+    pa_stats(&live, &peak, &avail, &largest, &lost, &holes);
+    switch (which) {
+    case 0:  return (long long)live;
+    case 1:  return (long long)peak;
+    case 2:  return (long long)avail;
+    case 3:  return (long long)largest;
+    case 4:  return (long long)lost;
+    case 5:  return (long long)holes;
+    default: return 0;
+    }
+}
+
+/* ── the MMU (Sv39) ───────────────────────────────────────────────
+ *
+ * Three levels, 4 KiB granule: L2 covers 1 GiB per entry, L1 2 MiB,
+ * L0 4 KiB — the same shape as AArch64's L1/L2/L3, one name down.
+ * Identity map: devices below 1 GiB, then RAM.
+ *
+ * A leaf entry is one with any of R/W/X set; a pointer to the next
+ * level has all three clear. That is the difference from both other
+ * architectures, where a bit says "block" or "table" outright, and it
+ * is the single easiest thing to get wrong here: an entry with V set
+ * and RWX clear is a TABLE POINTER, so a "present, no permissions"
+ * mapping — which is how PROT_NONE is spelled elsewhere — would send
+ * the walker into whatever the address bits point at. PROT_NONE
+ * therefore clears V, not the permission bits.
+ */
+#define PTE_V (1UL << 0)
+#define PTE_R (1UL << 1)
+#define PTE_W (1UL << 2)
+#define PTE_X (1UL << 3)
+#define PTE_A (1UL << 6)
+#define PTE_D (1UL << 7)
+
+#define LEAF_RW (PTE_V | PTE_R | PTE_W | PTE_A | PTE_D)
+#define LEAF_RX (PTE_V | PTE_R | PTE_X | PTE_A)
+#define LEAF_RWX (PTE_V | PTE_R | PTE_W | PTE_X | PTE_A | PTE_D)
+
+#define PPN(pa) (((u64)(pa) >> 12) << 10)
+
+#define MAX_RAM_L1 8             /* 8 GiB of RAM is the map's ceiling */
+
+static u64 l2_table[512] __attribute__((aligned(4096)));
+static u64 l1_dev[512]   __attribute__((aligned(4096)));
+static u64 l1_ram[MAX_RAM_L1][512] __attribute__((aligned(4096)));
+
+static void mmu_init(void) {
+    /* Device gigabyte: 512 × 2 MiB leaves, RW (no X — nothing executes
+     * from a device). */
+    for (u64 i = 0; i < 512; i++)
+        l1_dev[i] = PPN(i << 21) | LEAF_RW;
+    l2_table[0] = PPN((u64)(unsigned long)l1_dev) | PTE_V;
+
+    u64 ram_end = facts.ram_base + facts.ram_size;
+    u64 gb_first = facts.ram_base >> 30;
+    u64 gb_last  = (ram_end - 1) >> 30;
+    if (gb_last - gb_first + 1 > MAX_RAM_L1)
+        pf_panic("more RAM than the boot page tables cover (raise MAX_RAM_L1)");
+    for (u64 g = gb_first; g <= gb_last; g++) {
+        u64 *l1 = l1_ram[g - gb_first];
+        for (u64 i = 0; i < 512; i++) {
+            u64 pa = (g << 30) | (i << 21);
+            /* RWX: the image's text is in here, and this machine has
+             * one address space with one program in it — the same
+             * decision the x86 boot tables make. */
+            l1[i] = pa < ram_end ? (PPN(pa) | LEAF_RWX) : 0;
+        }
+        l2_table[g] = PPN((u64)(unsigned long)l1) | PTE_V;
+    }
+
+    /* satp: mode 8 (Sv39), ASID 0, the root table's PPN. */
+    u64 satp = (8UL << 60) | ((u64)(unsigned long)l2_table >> 12);
+    __asm__ __volatile__(
+        "sfence.vma\n\t"
+        "csrw satp, %0\n\t"
+        "sfence.vma\n\t" :: "r"(satp) : "memory");
+}
+
+/* ── page protection ───────────────────────────────────────────── */
+static u64 *l1_entry_for(u64 va) {
+    u64 l2i = (va >> 30) & 511;
+    if (!(l2_table[l2i] & PTE_V)) return 0;
+    u64 *l1 = (u64 *)(unsigned long)((l2_table[l2i] >> 10) << 12);
+    return &l1[(va >> 21) & 511];
+}
+
+static void split_2m(u64 *l1e) {
+    /* A leaf has R, W or X set; a table pointer has none. */
+    if (!(*l1e & (PTE_R | PTE_W | PTE_X))) return;    /* already a table */
+    if (pt_pool_used >= PT_POOL_TABLES)
+        pf_panic("out of page tables — more coroutine stacks than the "
+                 "boot-time pool was sized for");
+    u64 base = ((*l1e) >> 10) << 12;
+    u64 attrs = *l1e & 0x3FF;                         /* the flag bits   */
+    u64 *l0 = pt_pool + (unsigned long)pt_pool_used * 512;
+    pt_pool_used++;
+    for (int i = 0; i < 512; i++) l0[i] = PPN(base + (u64)i * 4096) | attrs;
+    *l1e = PPN((u64)(unsigned long)l0) | PTE_V;
+    __asm__ __volatile__("sfence.vma" ::: "memory");
+}
+
+int madvise(void *p, unsigned long len, int advice) {
+    (void)p; (void)len; (void)advice;
+    return 0;
+}
+
+int mprotect(void *p, unsigned long len, int prot) {
+    u64 va = (u64)(unsigned long)p & ~0xFFFUL;
+    u64 end = ((u64)(unsigned long)p + len + 4095) & ~0xFFFUL;
+
+    if (!pt_pool) return -1;
+    for (; va < end; va += 4096) {
+        u64 *l1e = l1_entry_for(va);
+        if (!l1e || !(*l1e & PTE_V)) return -1;
+        split_2m(l1e);
+        u64 *l0 = (u64 *)(unsigned long)((*l1e >> 10) << 12);
+        u64 *pte = &l0[(va >> 12) & 511];
+        u64 ppn = *pte & ~0x3FFUL;
+        /* PROT_NONE clears V — see the header: V with no R/W/X is a
+         * table pointer here, not an unmapped page. */
+        if (prot == 0)       *pte = ppn;
+        else if (prot & 0x2) *pte = ppn | LEAF_RWX;
+        else                 *pte = ppn | LEAF_RX;
+        __asm__ __volatile__("sfence.vma zero, %0" :: "r"(va) : "memory");
+    }
+    return 0;
+}
+
+extern unsigned char boot_stack_bottom[];
+
+static void pf_guard_boot_stack(void) {
+    (void)mprotect(boot_stack_bottom, 4096, 0);
+}
+
+static void pf_guard_null_page(void) {
+    (void)mprotect((void *)0, 4096, 0);
+}
+
+/* ── time ────────────────────────────────────────────────────────── */
+
+static u64 time_freq;
+static u64 time_base;
+
+static inline u64 rdtime(void) {
+    u64 v;
+    __asm__ __volatile__("rdtime %0" : "=r"(v));
+    return v;
+}
+
+static void time_init(void) {
+    /* virt's timebase is 10 MHz and the tree says so; the command line
+     * may override, the same trust model as the other two ports. The
+     * frequency is NOT guessed: without one, asking for the time
+     * panics. */
+    time_freq = cmdline_u64("timebase");
+    if (!time_freq) time_freq = 10000000UL;   /* virt's, as the tree states */
+    time_base = rdtime();
+}
+
+static u64 wall_base_sec;
+
+int clock_gettime(int clk, void *tsp) {
+    u64 *ts = (u64 *)tsp;
+    if (!time_freq)
+        pf_panic("no timebase frequency — refusing to invent a clock");
+    u64 ticks = rdtime() - time_base;
+    ts[0] = ticks / time_freq;
+    ts[1] = (ticks % time_freq) * 1000000000ULL / time_freq;
+    if (clk == 0) ts[0] += wall_base_sec;
+    return 0;
+}
+
+int nanosleep(const void *req, void *rem) {
+    const u64 *ts = (const u64 *)req;
+    (void)rem;
+    if (!time_freq) return 0;
+    u64 want_ns = ts[0] * 1000000000ULL + ts[1];
+    u64 ticks = want_ns / 1000 * time_freq / 1000000ULL;
+    u64 start = rdtime();
+    while (rdtime() - start < ticks) { }
+    return 0;
+}
+
+/* ── entropy ─────────────────────────────────────────────────────
+ *
+ * There is no entropy instruction in this machine's profile: the Zkr
+ * extension's `seed` CSR is optional and QEMU's rv64 CPU does not
+ * implement it, so reading it is an illegal instruction rather than a
+ * weak number. The plan's rule is absolute — no source is a panic,
+ * never a fallback — and this port applies it by refusing, naming what
+ * is missing. Everything except key generation works; a TLS handshake
+ * on this architecture waits for a virtio-rng driver.
+ */
+long long getrandom(void *buf, unsigned long len, unsigned int flags) {
+    (void)buf; (void)len; (void)flags;
+    pf_panic("no entropy source on this machine — RISC-V's seed CSR (Zkr) "
+             "is optional and absent here, and there is no virtio-rng "
+             "driver yet. Refusing to generate keys from nothing.");
+    return 0;
+}
+
+/* ── the file surface nolibc expects ─────────────────────────────── */
+
+int nl_errno_slot;
+int *__errno_location(void) { return &nl_errno_slot; }
+
+long long write(int fd, const void *buf, unsigned long n) {
+    const char *p = (const char *)buf;
+    (void)fd;
+    for (unsigned long i = 0; i < n; i++) uart_putc(p[i]);
+    return (long long)n;
+}
+
+long long read(int fd, void *buf, unsigned long n) {
+    if (fs_is_file_fd(fd)) return (long long)fs_read_fd(fd, buf, n);
+    (void)buf; (void)n;
+    return 0;
+}
+
+int nl_open(const char *path, int flags, int mode);
+int open(const char *p, int fl, int mode) { return nl_open(p, fl, mode); }
+int close(int fd) {
+    if (fs_is_file_fd(fd)) return fs_close_fd(fd);
+    return 0;
+}
+long long lseek(int fd, long long off, int whence) {
+    if (fs_is_file_fd(fd)) return fs_lseek_fd(fd, off, whence);
+    (void)off; (void)whence;
+    return -1;
+}
+
+pf_ssize_t nl_write(int fd, const void *buf, pf_size_t n) { return (pf_ssize_t)write(fd, buf, n); }
+pf_ssize_t nl_read(int fd, void *buf, pf_size_t n) { return (pf_ssize_t)read(fd, buf, n); }
+int nl_close(int fd) { return close(fd); }
+long long nl_lseek(int fd, long long off, int whence) { return lseek(fd, off, whence); }
+
+void *nl_map(pf_size_t len) {
+    void *p = mmap(0, len, 0, 0, -1, 0);
+    return p == (void *)-1 ? 0 : p;      /* the nolibc convention */
+}
+int nl_unmap(void *p, pf_size_t len) { return munmap(p, len); }
+void nl_exit_group(int code) { pf_shutdown(code); for (;;) { } }
+
+int unlink(const char *p) { (void)p; return -1; }
+
+long nl_syscall6(long n, long a, long b, long c, long d, long e, long f) {
+    (void)n; (void)a; (void)b; (void)c; (void)d; (void)e; (void)f;
+    return -38;                                        /* -ENOSYS */
+}
+
+long nl_ret(long r) {
+    if (r < 0 && r > -4096) { nl_errno_slot = (int)-r; return -1; }
+    return r;
+}
+int mkdir(const char *p, int mode) { (void)p; (void)mode; return -1; }
+
+int access(const char *p, int mode) {
+    if (!p) return -1;
+    if (mode & 3) { nl_errno_slot = 13 /* EACCES */; return -1; }
+    if (!fs_exists(p)) { nl_errno_slot = 2 /* ENOENT */; return -1; }
+    return 0;
+}
+int getpid(void) { return 1; }
+
+/* ── shutdown ────────────────────────────────────────────────────── */
+
+static void pf_shutdown(int code) {
+    uart_puts("[nurl-exit] ");
+    uart_putu((unsigned long)(code & 0xff));
+    uart_putc('\n');
+
+    /* SRST (extension "SRST" = 0x53525354), function 0 = system reset,
+     * type 0 = shutdown, reason 0. Firmware that predates SRST answers
+     * "not supported" and returns, so the legacy shutdown (extension
+     * 8) follows — and if neither exists, the sentinel line above has
+     * already told the harness what happened, which is why that line
+     * and not this call is the protocol. */
+    (void)sbi_call(0x53525354, 0, 0, 0);
+    (void)sbi_call(8, 0, 0, 0);
+    for (;;) __asm__ __volatile__("wfi");
+}
+
+void _exit(int code) { pf_shutdown(code); for (;;) { } }
+
+/* ── entry ───────────────────────────────────────────────────────── */
+
+extern char **nl_environ;
+extern void nl_tls_init_guest(void);
+extern int main(int argc, char **argv);
+
+#define ARGV_MAX 32
+static char *guest_argv[ARGV_MAX + 1];
+static char  argv_buf[1024];
+
+static int build_argv(const char *cl) {
+    int argc = 1;
+    guest_argv[0] = (char *)"nurl";
+    if (!cl) return argc;
+
+    const char *p = cl;
+    while (*p) {
+        if (p[0] == 'a' && p[1] == 'r' && p[2] == 'g' && p[3] == 's' &&
+            p[4] == '=' && p[5] == '"') {
+            const char *q = p + 6;
+            unsigned long n = 0;
+            while (*q && *q != '"' && n < sizeof argv_buf - 1) argv_buf[n++] = *q++;
+            argv_buf[n] = 0;
+            unsigned long i = 0;
+            while (i < n && argc < ARGV_MAX) {
+                while (i < n && argv_buf[i] == ' ') argv_buf[i++] = 0;
+                if (i >= n) break;
+                guest_argv[argc++] = &argv_buf[i];
+                while (i < n && argv_buf[i] != ' ') i++;
+            }
+            break;
+        }
+        while (*p && *p != ' ') p++;
+        while (*p == ' ') p++;
+    }
+    guest_argv[argc] = 0;
+    return argc;
+}
+
+extern unsigned char fault_stack_top[];
+
+void kmain(unsigned long dtb);
+
+void kmain(unsigned long dtb) {
+    static char *no_argv[2];
+
+    uart_init();
+    *nl_file_flags(stdout) |= PF_F_LINEBUF;
+
+    /* Where the program's output starts.
+     *
+     * This is the only one of the three machines whose firmware TALKS:
+     * OpenSBI prints a banner on the same UART before the kernel gets
+     * control, so a harness comparing the guest's output to a hosted
+     * golden would be comparing the firmware's version string too. The
+     * guest marks its own first byte and `run_qemu_riscv64.sh` drops
+     * everything up to and including it — a rule that belongs to us
+     * rather than to whatever OpenSBI's banner looks like this year. */
+    uart_puts("\n[nurl-boot]\n");
+
+    /* The trap handler's stack, handed to the vector through sscratch:
+     * this architecture does not switch stacks on a trap by itself, so
+     * the handler swaps to this one — the fault worth surviving is a
+     * stack that hit its guard page. */
+    __asm__ __volatile__("csrw sscratch, %0" :: "r"((unsigned long)fault_stack_top));
+
+    /* The device tree: a1 as OpenSBI passes it. Without one this port
+     * knows neither its memory nor its devices, and says so. */
+    if (!fdt_is_tree((const void *)dtb))
+        pf_panic("no device tree in a1 — was this image started with "
+                 "qemu-system-riscv64 -M virt -kernel?");
+    fdt_probe((const void *)dtb, &facts);
+    cmdline = facts.cmdline;
+
+    mem_init();
+    mmu_init();
+    pf_guard_boot_stack();
+    pf_guard_null_page();
+    wall_base_sec = cmdline_u64("wallclock");
+    time_init();
+    nl_tls_init_guest();
+
+    no_argv[0] = 0;
+    nl_environ = no_argv;
+
+    int argc = build_argv(cmdline);
+    exit(main(argc, guest_argv));
+}

--- a/unikernel/boot/tls_guest_riscv64.c
+++ b/unikernel/boot/tls_guest_riscv64.c
@@ -1,0 +1,78 @@
+/*
+ * NURL unikernel — unikernel/boot/tls_guest_riscv64.c
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * The thread pointer, for a machine with no auxv — RISC-V.
+ *
+ * Same job as tls_guest.c, different ABI. RISC-V uses TLS variant I with NO
+ * reserved block at all: the thread pointer register (tp, x4) points
+ * AT the image, so the first thread-local sits at tp + 0 — where
+ * AArch64 leaves sixteen bytes for the runtime. x86-64's variant II has the image BELOW the
+ * pointer with tp[0] pointing at itself. Get this backwards and every
+ * `__thread` read lands in the reserved words or past the block — a
+ * wrong value, not a crash, which is the worst way to be wrong.
+ *
+ * And the rounding is exactly the part that is easy to get wrong from
+ * the documentation: the offset depends on the PT_TLS alignment the
+ * LINKER chose, which depends on this program's own variables and on
+ * the linker script. So it is MEASURED, not derived: a canary
+ * `__thread` variable is read back after the image is placed, and the
+ * placement is accepted only when the compiler's own addressing finds
+ * the value the image says is there. If no candidate works the machine
+ * says so and stops, rather than running with every thread-local off
+ * by sixteen bytes.
+ *
+ * `tp` is an ordinary register here, not a system register: it is
+ * written with a `mv`, and there is no syscall to make on a machine
+ * with no kernel.
+ */
+
+extern unsigned char __tls_image_start[];
+extern unsigned char __tls_image_end[];
+extern unsigned char __tls_memsz_end[];
+
+void pf_panic(const char *msg);
+
+#define TLS_MAX 8192
+static unsigned char tls_block[TLS_MAX] __attribute__((aligned(64)));
+
+/* The canary. Its value is in the .tdata image, so reading it through
+ * the compiler's own TLS addressing is a direct test of "is the image
+ * where the compiler thinks it is". Volatile so the read is not
+ * constant-folded from the initializer. */
+static __thread volatile unsigned long tls_canary = 0x4E55524CC0FFEEULL;
+
+void nl_tls_init_guest(void) {
+    unsigned long filesz = (unsigned long)(__tls_image_end - __tls_image_start);
+    unsigned long memsz  = (unsigned long)(__tls_memsz_end - __tls_image_start);
+    unsigned char *tp = tls_block;
+    unsigned long cand;
+    unsigned long i;
+
+    __asm__ __volatile__("mv tp, %0" :: "r"((unsigned long)tp));
+
+    /* tp + 16 rounded up to the alignment the linker picked. 16 is the
+     * unrounded case; the rest are the alignments a PT_TLS segment
+     * plausibly has, smallest first, so the first hit is the right one
+     * rather than a larger one that happens to also contain the
+     * canary. */
+    /* 0 first: this ABI puts the image AT the thread pointer. The rest
+     * are here because the offset is measured, not assumed — the same
+     * canary check the AArch64 port uses, and the reason it exists is
+     * that this number differs between the two ABIs by exactly the
+     * kind of amount that reads as plausible garbage. */
+    static const unsigned long candidates[] = { 0, 16, 32, 64, 128, 256, 512, 1024 };
+    for (unsigned long c = 0; c < sizeof candidates / sizeof candidates[0]; c++) {
+        cand = candidates[c];
+        if (cand + memsz > TLS_MAX) break;
+        unsigned char *img = tp + cand;
+        for (i = 0; i < filesz; i++) img[i] = __tls_image_start[i];
+        for (i = filesz; i < memsz; i++) img[i] = 0;
+        if (tls_canary == 0x4E55524CC0FFEEULL) return;   /* the compiler agrees */
+    }
+    pf_panic("cannot place the TLS image where this build addresses it "
+             "— no candidate offset from the thread pointer holds the "
+             "canary (a linker with an unexpected PT_TLS alignment?)");
+}

--- a/unikernel/build_unikernel_riscv64.sh
+++ b/unikernel/build_unikernel_riscv64.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # ============================================================
-#  unikernel/build_unikernel_arm64.sh — build a NURL program into a
-#  bootable AArch64 kernel image for QEMU's `virt` machine.
+#  unikernel/build_unikernel_riscv64.sh — build a NURL program into a
+#  bootable RV64 kernel image for QEMU's `virt` machine.
 #
-#  Usage:  build_unikernel_arm64.sh prog.nu [-o out.elf]
+#  Usage:  build_unikernel_riscv64.sh prog.nu [-o out.elf]
 #              [--fs dir] [--out-dir dir]
 #
 #  Everything above the bottom edge is the SAME code the x86_64 image
@@ -11,17 +11,21 @@
 #  Exactly four files differ, and they are the ones that talk to the
 #  machine:
 #
-#    boot/boot_arm64.S        EL2→EL1, FP/SIMD, vectors, stacks, .bss
-#    boot/platform_arm64.c    PL011, device tree, MMU, generic timer,
-#                             RNDR, PSCI shutdown
-#    boot/tls_guest_arm64.c   the thread pointer (variant I, measured)
-#    nolibc/setjmp_aarch64.S  panic/recover's callee-saved set
+#    boot/boot_riscv64.S       S-mode entry, hart parking, trap vector, FP, stacks
+#    boot/platform_riscv64.c  16550 UART, Sv39 MMU, rdtime, SBI shutdown
+#                             (and an honest refusal on entropy: this
+#                             machine has no seed CSR)
+#    boot/tls_guest_riscv64.c   the thread pointer (variant I, measured)
+#    nolibc/setjmp_riscv64.S  panic/recover's callee-saved set
 #
-#  which is the whole point of the arrangement: a second architecture
-#  is a bottom edge, not a port of the system.
+#  which is the whole point of the arrangement: a THIRD architecture is
+#  a bottom edge, not a port of the system — and the device-tree walk
+#  the AArch64 port wrote is now shared (boot/fdt.c) rather than
+#  copied, because a copy is where two machines start disagreeing
+#  about what the same tree says.
 #
 #  The cross toolchain is zig cc (already in the ecosystem's install and
-#  in the playground image) targeting aarch64-freestanding-none. Same
+#  in the playground image) targeting riscv64-freestanding-none. Same
 #  --out-dir / cache contract as the x86_64 script, and the cache is
 #  keyed separately so both architectures can be built side by side.
 # ============================================================
@@ -35,7 +39,7 @@ command -v "$ZIG" >/dev/null 2>&1 || ZIG="$HOME/.nurl/zig/zig"
 SRC=""
 OUT=""
 FSDIR=""
-OUTDIR="${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel-arm64}"
+OUTDIR="${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel-riscv64}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -46,34 +50,34 @@ while [ $# -gt 0 ]; do
     esac
 done
 [ -n "$SRC" ] || {
-    echo "usage: build_unikernel_arm64.sh prog.nu [-o out.elf] [--fs dir] [--out-dir dir]" >&2
+    echo "usage: build_unikernel_riscv64.sh prog.nu [-o out.elf] [--fs dir] [--out-dir dir]" >&2
     exit 2
 }
 [ -x "$ROOT/build/nurlc" ] || {
-    echo "build_unikernel_arm64.sh: $ROOT/build/nurlc not found — run ./build.sh first" >&2
+    echo "build_unikernel_riscv64.sh: $ROOT/build/nurlc not found — run ./build.sh first" >&2
     exit 2
 }
 command -v "$ZIG" >/dev/null 2>&1 || {
-    echo "build_unikernel_arm64.sh: no zig on PATH and none at ~/.nurl/zig/zig — set NURL_ZIG" >&2
+    echo "build_unikernel_riscv64.sh: no zig on PATH and none at ~/.nurl/zig/zig — set NURL_ZIG" >&2
     exit 2
 }
 if [ -n "$FSDIR" ] && [ ! -d "$FSDIR" ]; then
-    echo "build_unikernel_arm64.sh: --fs $FSDIR is not a directory" >&2
+    echo "build_unikernel_riscv64.sh: --fs $FSDIR is not a directory" >&2
     exit 2
 fi
 
-# A cache of its OWN, and deliberately not NURL_UNIKERNEL_CACHE: the
+# A cache of its OWN, one per architecture: the
 # object filenames are identical across architectures (runtime_core.o,
 # nl_string.o, boot.o…), so one directory shared by both builds means
-# an x86 link can pick up AArch64 objects — or, with the stamp saving
+# an x86 link can pick up RV64 objects — or, with the stamp saving
 # it, both builds rebuilding everything on every alternation. The arch
 # belongs in the cache's identity, not only in its stamp.
-CACHE="${NURL_UNIKERNEL_CACHE_ARM64:-$OUTDIR/cache}"
+CACHE="${NURL_UNIKERNEL_CACHE_RISCV64:-$OUTDIR/cache}"
 mkdir -p "$OUTDIR" "$CACHE"
 base="$(basename "${SRC%.nu}")"
 OUT="${OUT:-$OUTDIR/$base.elf}"
 
-# Two triples, deliberately. Compiling uses aarch64-linux-musl so the
+# Two triples, deliberately. Compiling uses riscv64-linux-musl so the
 # C files can #include <stdio.h> and friends — runtime_core.c does, and
 # nolibc supplies the DEFINITIONS while some libc's headers supply the
 # declarations. That is exactly what the x86_64 build does implicitly by
@@ -81,7 +85,7 @@ OUT="${OUT:-$OUTDIR/$base.elf}"
 # loud is the difference between the two scripts, not a difference in
 # the model. Linking uses -nostdlib, so not one byte of musl is in the
 # image — `nm` on the result proves it, and the gate checks.
-TARGET=aarch64-linux-musl
+TARGET=riscv64-linux-musl
 # -mgeneral-regs-only is NOT set: the runtime uses floating point, and
 # the boot code un-traps FP/SIMD before C runs. What IS set is the same
 # freestanding discipline as x86 — no stack protector, no builtins that
@@ -96,10 +100,10 @@ cache_inputs() {
         "$ROOT/unikernel/runtime_bare.c" \
         "$NOLIBC"/string.c "$NOLIBC"/malloc.c "$NOLIBC"/stdio.c \
         "$NOLIBC"/dtoa.c "$NOLIBC"/math.c "$NOLIBC"/misc.c \
-        "$NOLIBC"/setjmp_aarch64.S \
-        "$BOOT"/platform_arm64.c "$BOOT"/initfs.c "$BOOT"/pagealloc.c \
+        "$NOLIBC"/setjmp_riscv64.S \
+        "$BOOT"/platform_riscv64.c "$BOOT"/initfs.c "$BOOT"/pagealloc.c \
         "$BOOT"/nosys.c "$BOOT"/fdt.c \
-        "$BOOT"/tls_guest_arm64.c "$BOOT"/boot_arm64.S \
+        "$BOOT"/tls_guest_riscv64.c "$BOOT"/boot_riscv64.S \
         "${BASH_SOURCE[0]}"
 }
 
@@ -111,14 +115,14 @@ cache_build() {
     for f in string malloc stdio dtoa math misc; do
         $ZIG cc $KFLAGS -c "$NOLIBC/$f.c" -o "$CACHE/nl_$f.o"
     done
-    $ZIG cc $KFLAGS -c "$BOOT/platform_arm64.c"  -o "$CACHE/platform.o"
+    $ZIG cc $KFLAGS -c "$BOOT/platform_riscv64.c"  -o "$CACHE/platform.o"
     $ZIG cc $KFLAGS -c "$BOOT/initfs.c"          -o "$CACHE/boot_initfs.o"
     $ZIG cc $KFLAGS -c "$BOOT/pagealloc.c"       -o "$CACHE/boot_pagealloc.o"
     $ZIG cc $KFLAGS -c "$BOOT/nosys.c"           -o "$CACHE/boot_nosys.o"
     $ZIG cc $KFLAGS -c "$BOOT/fdt.c"             -o "$CACHE/boot_fdt.o"
-    $ZIG cc $KFLAGS -c "$BOOT/tls_guest_arm64.c" -o "$CACHE/tls_guest.o"
-    $ZIG cc $KFLAGS -c "$BOOT/boot_arm64.S"      -o "$CACHE/boot.o"
-    $ZIG cc $KFLAGS -c "$NOLIBC/setjmp_aarch64.S" -o "$CACHE/nl_setjmp.o"
+    $ZIG cc $KFLAGS -c "$BOOT/tls_guest_riscv64.c" -o "$CACHE/tls_guest.o"
+    $ZIG cc $KFLAGS -c "$BOOT/boot_riscv64.S"      -o "$CACHE/boot.o"
+    $ZIG cc $KFLAGS -c "$NOLIBC/setjmp_riscv64.S" -o "$CACHE/nl_setjmp.o"
 }
 
 stamp="$CACHE/stamp"
@@ -175,15 +179,15 @@ $ZIG cc $KFLAGS -c "$OUTDIR/$base.initfs.S" -o "$OUTDIR/$base.initfs_data.o"
 # header's entry point at ZERO — an image QEMU would jump to address 0
 # for. The script's ENTRY() is still there and still right; this makes
 # the command line agree with it.
-# max-page-size=4096: lld's aarch64 default is 64 KiB, which pads every
+# max-page-size=4096: lld's riscv64 default is 64 KiB, which pads every
 # LOAD segment's file offset to a boundary this machine has no use for —
 # the guest's own page tables use the 4 KiB granule. It cost 300 KB of
 # padding in a 500 KB image. -S strips the debug info zig cc emits by
 # default (another 80 KB), which a boot image cannot use: the fault
 # handler reports registers, and the ELF a developer debugs is the one
 # in the build directory, not the one the hypervisor loads.
-$ZIG cc -target $TARGET -nostdlib -static -Wl,-T,"$BOOT/link_arm64.ld" \
-    -Wl,-e,_arm64_start -Wl,--build-id=none \
+$ZIG cc -target $TARGET -nostdlib -static -Wl,-T,"$BOOT/link_riscv64.ld" \
+    -Wl,-e,_riscv_start -Wl,--build-id=none \
     -Wl,-z,max-page-size=4096 -Wl,-S \
     -o "$OUT" \
     "$CACHE/boot.o" "$OUTDIR/$base.o" \

--- a/unikernel/demos/devices.riscv64.expected
+++ b/unikernel/demos/devices.riscv64.expected
@@ -1,0 +1,4 @@
+cmdline devices: 8
+device 0: id=1 (net) irq=yes queues=yes
+  features negotiated: yes
+probed ok: 1

--- a/unikernel/nolibc/math.c
+++ b/unikernel/nolibc/math.c
@@ -85,6 +85,8 @@ double sqrt(double x) {
     __asm__("sqrtsd %1, %0" : "=x"(r) : "x"(x));
 #elif defined(__aarch64__)
     __asm__("fsqrt %d0, %d1" : "=w"(r) : "w"(x));
+#elif defined(__riscv) && defined(__riscv_flen) && __riscv_flen >= 64
+    __asm__("fsqrt.d %0, %1" : "=f"(r) : "f"(x));
 #else
 #  error "nolibc sqrt: no hardware square root known for this target"
 #endif

--- a/unikernel/nolibc/setjmp_riscv64.S
+++ b/unikernel/nolibc/setjmp_riscv64.S
@@ -1,0 +1,103 @@
+/*
+ * NURL nolibc — unikernel/nolibc/setjmp_riscv64.S
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * setjmp/longjmp for NURL's panic/recover (§20), RV64. Saves exactly
+ * the callee-saved set this ABI defines — ra, sp, s0–s11, and fs0–fs11
+ * where the target has doubles — and nothing else, for the same reason
+ * the x86_64 and AArch64 twins stop at theirs.
+ *
+ * No control word is saved: on this architecture the rounding mode
+ * lives in `fcsr`, which the ABI marks CALLER-saved. A function that
+ * changes it already restores it, so there is nothing here for a
+ * longjmp to put back — the same reasoning that makes the x86 twin
+ * skip MXCSR (a longjmp lands on this same stack, reached without
+ * changing it), arrived at from the other direction.
+ *
+ * jmp_buf layout (8-byte slots):
+ *   0 ra   1 sp   2–13 s0–s11   14–25 fs0–fs11
+ * 26 slots = 208 bytes; glibc's riscv64 jmp_buf is larger, so the
+ * runtime's buffers have room to spare, as on the other two.
+ */
+    .text
+    .globl _setjmp
+    .globl setjmp
+    .type _setjmp, %function
+    .type setjmp, %function
+_setjmp:
+setjmp:
+    sd ra,   0(a0)
+    sd sp,   8(a0)
+    sd s0,  16(a0)
+    sd s1,  24(a0)
+    sd s2,  32(a0)
+    sd s3,  40(a0)
+    sd s4,  48(a0)
+    sd s5,  56(a0)
+    sd s6,  64(a0)
+    sd s7,  72(a0)
+    sd s8,  80(a0)
+    sd s9,  88(a0)
+    sd s10, 96(a0)
+    sd s11, 104(a0)
+#if defined(__riscv_flen) && __riscv_flen >= 64
+    fsd fs0,  112(a0)
+    fsd fs1,  120(a0)
+    fsd fs2,  128(a0)
+    fsd fs3,  136(a0)
+    fsd fs4,  144(a0)
+    fsd fs5,  152(a0)
+    fsd fs6,  160(a0)
+    fsd fs7,  168(a0)
+    fsd fs8,  176(a0)
+    fsd fs9,  184(a0)
+    fsd fs10, 192(a0)
+    fsd fs11, 200(a0)
+#endif
+    li a0, 0                    /* setjmp itself returns 0 */
+    ret
+    .size _setjmp, .-_setjmp
+
+    .globl longjmp
+    .globl _longjmp
+    .type longjmp, %function
+    .type _longjmp, %function
+longjmp:
+_longjmp:
+    ld ra,   0(a0)
+    ld sp,   8(a0)
+    ld s0,  16(a0)
+    ld s1,  24(a0)
+    ld s2,  32(a0)
+    ld s3,  40(a0)
+    ld s4,  48(a0)
+    ld s5,  56(a0)
+    ld s6,  64(a0)
+    ld s7,  72(a0)
+    ld s8,  80(a0)
+    ld s9,  88(a0)
+    ld s10, 96(a0)
+    ld s11, 104(a0)
+#if defined(__riscv_flen) && __riscv_flen >= 64
+    fld fs0,  112(a0)
+    fld fs1,  120(a0)
+    fld fs2,  128(a0)
+    fld fs3,  136(a0)
+    fld fs4,  144(a0)
+    fld fs5,  152(a0)
+    fld fs6,  160(a0)
+    fld fs7,  168(a0)
+    fld fs8,  176(a0)
+    fld fs9,  184(a0)
+    fld fs10, 192(a0)
+    fld fs11, 200(a0)
+#endif
+    mv a0, a1                   /* longjmp(buf, 0) must return 1 */
+    bnez a0, 1f
+    li a0, 1
+1:
+    ret                         /* to the saved ra — setjmp's caller */
+    .size longjmp, .-longjmp
+    .section .note.GNU-stack,"",%progbits

--- a/unikernel/run_qemu_riscv64.sh
+++ b/unikernel/run_qemu_riscv64.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/run_qemu_riscv64.sh — boot an RV64 NURL unikernel image
+#  and report what it printed and how it ended.
+#
+#  Usage:  run_qemu_riscv64.sh image.elf [-t seconds] [-- extra qemu args]
+#
+#  Same contract as run_qemu.sh, a third machine down: QEMU's `virt`
+#  board, ELF loaded with -kernel, OpenSBI as the firmware underneath.
+#  What differs and why:
+#
+#    - OpenSBI runs first and hands the kernel S-mode with a0 = hart id
+#      and a1 = the device tree. There is nothing for the host to say
+#      about the handover, so this script says less than either twin.
+#    - the same `virtio-mmio.force-legacy=false` as both other boards:
+#      virt is legacy by default here too, and the guest refuses a
+#      legacy device rather than driving it wrong.
+#    - no clock flag at all: `rdtime` ticks at the rate the tree states
+#      (10 MHz on virt). `wallclock=` stays, as on every machine — a
+#      wall clock is the host's to state.
+#    - the program's argv still arrives as one `args="…"` key, in the
+#      DTB's /chosen/bootargs, which -append fills.
+#
+#  Exit status: the guest's, or 124 if the deadline passed with no
+#  sentinel line.
+# ============================================================
+set -uo pipefail
+
+QEMU="${QEMU_RISCV64:-${QEMU:-qemu-system-riscv64}}"
+TIMEOUT=20
+IMG=""
+read -r -a EXTRA <<< "${QEMU_ARGS:-}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -t) TIMEOUT="$2"; shift 2 ;;
+        --) shift; EXTRA+=("$@"); break ;;
+        *)  IMG="$1"; shift ;;
+    esac
+done
+[ -n "$IMG" ] || { echo "usage: run_qemu_riscv64.sh image.elf [-t seconds]" >&2; exit 2; }
+command -v "$QEMU" >/dev/null 2>&1 || { echo "run_qemu_riscv64.sh: $QEMU not found" >&2; exit 3; }
+
+# KVM only when the HOST is also riscv64 — an x86 developer machine
+# runs this under TCG, which is slower and otherwise identical.
+ACCEL=tcg
+if [ -w /dev/kvm ] && [ "$(uname -m)" = "riscv64" ]; then ACCEL=kvm; fi
+# `rv64` is the board's own default and what a user would run. There is
+# no CPU model that gives this guest entropy — the Zkr seed CSR is
+# optional and QEMU does not implement it — so a program that generates
+# keys panics here by design, and no flag changes that.
+CPU="${NURL_RISCV64_CPU:-rv64}"
+
+out="$(mktemp)"
+timeout -k 5s "${TIMEOUT}s" "$QEMU" \
+    -M virt \
+    -accel "$ACCEL" -cpu "$CPU" -m 256 \
+    -nodefaults -no-reboot -no-user-config \
+    -global virtio-mmio.force-legacy=false \
+    -kernel "$IMG" -append "wallclock=$(date +%s) ${NURL_APPEND:-}" \
+    -serial stdio -display none \
+    ${EXTRA[@]+"${EXTRA[@]}"} > "$out" 2>&1
+qemu_status=$?
+
+sed -i 's/\r$//' "$out"
+# The firmware's banner is not the program's output. OpenSBI prints
+# before the kernel runs, on the same UART; the guest marks its own
+# first byte with `[nurl-boot]` and everything up to and including that
+# line is the machine's, not the program's. `-a`: the banner contains
+# bytes that make grep call the stream binary otherwise, and then it
+# prints "binary file matches" instead of the output.
+if grep -aq '^\[nurl-boot\]$' "$out"; then
+    sed -i '1,/^\[nurl-boot\]$/d' "$out"
+fi
+grep -av '^\[nurl-exit\] ' "$out"
+
+code=$(sed -n 's/^\[nurl-exit\] \([0-9]*\)$/\1/p' "$out" | tail -1)
+rm -f "$out"
+if [ -z "$code" ]; then
+    echo "run_qemu_riscv64.sh: no [nurl-exit] line — the guest did not finish (qemu $qemu_status)" >&2
+    exit 124
+fi
+exit "$code"

--- a/unikernel/run_qemu_riscv64_tests.sh
+++ b/unikernel/run_qemu_riscv64_tests.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# ============================================================
+#  unikernel/run_qemu_riscv64_tests.sh — the RV64 guest gate.
+#
+#  The same programs the x86_64 guest gate boots, on the other
+#  architecture: corpus tests against their ORDINARY hosted goldens
+#  (the whole claim of the port is that nothing above the bottom edge
+#  changed), then the guest-only demos that need a device.
+#
+#  Usage:  run_qemu_riscv64_tests.sh [name …]     (default: all)
+#
+#  Skips itself, loudly, when qemu-system-riscv64 is absent — the same
+#  contract the x86 gate has, so a developer without it still gets a
+#  green run of everything else.
+# ============================================================
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TESTS="$ROOT/compiler/tests"
+OUTDIR="${NURL_UNIKERNEL_OUT:-$ROOT/build/unikernel-riscv64}"
+QEMU="${QEMU_RISCV64:-${QEMU:-qemu-system-riscv64}}"
+
+command -v "$QEMU" >/dev/null 2>&1 || {
+    echo "run_qemu_riscv64_tests.sh: $QEMU not found — skipping the RV64 guest gate"
+    exit 0
+}
+[ -x "$ROOT/build/nurlc" ] || { echo "run ./build.sh first" >&2; exit 2; }
+
+build() { NURL_UNIKERNEL_OUT="$OUTDIR" "$ROOT/unikernel/build_unikernel_riscv64.sh" "$@"; }
+boot()  { "$ROOT/unikernel/run_qemu_riscv64.sh" "$@"; }
+
+names=("$@")
+[ ${#names[@]} -gt 0 ] || names=(hello vec_basic float_format
+                                 net_socket net_tcpstack
+                                 async_basic async_chan async_mn async_sleep)
+
+fails=0
+for name in "${names[@]}"; do
+    golden="$TESTS/outputs/$name.txt"
+    [ -f "$golden" ] || { echo "SKIP $name (no golden)"; continue; }
+    if ! build "$TESTS/$name.nu" >/dev/null 2>&1; then
+        echo "FAIL $name (build)"; fails=$((fails + 1)); continue
+    fi
+    want_exit=$(sed -n 's/^EXIT //p' "$golden" | head -1)
+    want_out=$(sed -n '/^OUTPUT$/,$p' "$golden" | tail -n +2)
+    got_out=$(boot "$OUTDIR/$name.elf" -t 120 2>&1)
+    got_exit=$?
+    if [ "$got_out" = "$want_out" ] && [ "$got_exit" = "$want_exit" ]; then
+        echo "PASS $name"
+    else
+        echo "FAIL $name (exit $got_exit, want ${want_exit:-?})"
+        diff <(printf '%s\n' "$want_out") <(printf '%s\n' "$got_out") | head -6 | sed 's/^/     /'
+        fails=$((fails + 1))
+    fi
+done
+
+# ── the demos, which only exist in the guest ────────────────────
+demos=0
+if [ $# -eq 0 ]; then
+    for demo in devices netdev dhcp loopback; do
+        src="$ROOT/unikernel/demos/$demo.nu"
+        # A machine-specific expectation when the machines genuinely
+        # differ, the shared one otherwise. `virt` publishes 32 static
+        # virtio-mmio slots and fills them from the top; microvm
+        # publishes exactly the devices that exist. A demo that reports
+        # what it found is right on both, and the difference belongs in
+        # the expectation, not in the demo.
+        exp="$ROOT/unikernel/demos/$demo.riscv64.expected"
+        [ -f "$exp" ] || exp="$ROOT/unikernel/demos/$demo.expected"
+        [ -f "$src" ] && [ -f "$exp" ] || continue
+        demos=$((demos + 1))
+        if ! build "$src" >/dev/null 2>&1; then
+            echo "FAIL $demo (build)"; fails=$((fails + 1)); continue
+        fi
+        # virt's virtio-mmio slots are in the device tree; the guest
+        # finds them there instead of on a command line.
+        got=$(boot "$OUTDIR/$demo.elf" -t 120 -- \
+                -netdev user,id=n0 -device virtio-net-device,netdev=n0 2>&1)
+        if [ "$got" = "$(cat "$exp")" ]; then
+            echo "PASS $demo (guest-only demo)"
+        else
+            echo "FAIL $demo"
+            diff <(cat "$exp") <(printf '%s\n' "$got") | head -8 | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+    done
+
+    # A fault must be REPORTED, not silently survived — the property
+    # the x86 pass proved matters most, checked here from the start.
+    demos=$((demos + 1))
+    if build "$ROOT/unikernel/demos/fault.nu" >/dev/null 2>&1; then
+        nullout=$(NURL_APPEND='args="null 0"' boot "$OUTDIR/fault.elf" -t 60 2>&1)
+        nullrc=$?
+        stackout=$(NURL_APPEND='args="stack 100000000"' boot "$OUTDIR/fault.elf" -t 60 2>&1)
+        stackrc=$?
+        if [ "$nullrc" = 126 ] && [ "$stackrc" = 126 ] \
+           && printf '%s' "$nullout" | grep -q "nurl: fault" \
+           && printf '%s' "$stackout" | grep -q "nurl: fault"; then
+            echo "PASS fault (both faults reported, exit 126)"
+        else
+            echo "FAIL fault (null exit $nullrc, stack exit $stackrc)"
+            printf '%s\n' "$nullout" | head -3 | sed 's/^/     /'
+            printf '%s\n' "$stackout" | head -3 | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+    else
+        echo "FAIL fault (build)"; fails=$((fails + 1))
+    fi
+
+    # An HTTP server in the guest, answering a client on the host.
+    if command -v curl >/dev/null 2>&1; then
+        demos=$((demos + 1))
+        if build "$ROOT/unikernel/demos/httpd.nu" >/dev/null 2>&1; then
+            out=$(mktemp)
+            ( boot "$OUTDIR/httpd.elf" -t 120 -- \
+                -netdev user,id=n0,hostfwd=tcp:127.0.0.1:18773-:8080 \
+                -device virtio-net-device,netdev=n0 > "$out" 2>&1 ) &
+            qpid=$!
+            body=""
+            for _ in 1 2 3 4 5 6 7 8 9 10; do
+                sleep 3
+                body=$(curl -sS --max-time 10 http://127.0.0.1:18773/ 2>/dev/null)
+                [ -n "$body" ] && break
+            done
+            kill $qpid 2>/dev/null; wait $qpid 2>/dev/null
+            if printf '%s' "$body" | grep -q "hello from a guest"; then
+                echo "PASS httpd (guest server, host client)"
+            else
+                echo "FAIL httpd (curl got \"$body\")"
+                head -6 "$out" | sed 's/^/     /'
+                fails=$((fails + 1))
+            fi
+            rm -f "$out"
+        else
+            echo "FAIL httpd (build)"; fails=$((fails + 1))
+        fi
+    fi
+fi
+
+total=$(( ${#names[@]} + demos ))
+echo "── QEMU RV64 guest run: $(( total - fails ))/$total ──"
+exit $(( fails > 0 ? 1 : 0 ))


### PR DESCRIPTION
The **third** architecture — the one that proves the second was not a
coincidence. QEMU's `virt` board with OpenSBI underneath: four files
and a linker script, plus an RV64 fiber switch in `runtime_ctx.c`.
Everything above that edge is the same code the other two run, and
`run_qemu_riscv64_tests.sh` is **15/15** against the same *hosted*
goldens (corpus + device demos + faults at exit 126 + an HTTP server
answering curl on the host). CI now boots **all three** every commit.

### The device tree is shared now, not copied

`unikernel/boot/fdt.c`. AArch64 and RISC-V need the same three answers
out of the same format, and the third port is the moment to stop
copying the second's. Extracting it **found a real narrowness in the
AArch64 original**: it classified nodes at a hard-coded depth, and
RISC-V's virt puts devices under `/soc` where AArch64's puts them at
the root — so the walker found nothing and the guest reported "no
virtio-net device" about a machine that had one. Nodes are classified
by *name at any depth* now, cells tracked per level. AArch64's gate
stayed 15/15 across the change.

### Three things this machine made explicit

- **`fp` IS `s0`.** The DTB pointer sat in `s0`; `li fp, 0` three
  instructions later zeroed it. The guest reported "no device tree in
  a1" — true about a register the boot code had just cleared. An
  assembly probe of the handover showed a1 held `0x87e00000` all along.
- **The firmware talks.** OpenSBI prints on the same UART before the
  kernel; the guest marks its own first byte and the run script drops
  everything before it — our rule, not the banner's.
- **No entropy source.** The `seed` CSR is optional (Zkr) and QEMU's
  rv64 lacks it, so this port **panics** on randomness, naming what is
  missing. Refuse, don't invent.

Measured: hello **155 344 B** vs x86_64 132 760 / AArch64 131 784 —
this ISA needs more instructions to say the same things. x86_64 gates
re-run: nolibc corpus **452 / 0**, unit gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1