### PR TITLE
feat: the AArch64 image boots on Firecracker and cloud-hypervisor too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The AArch64 image now boots on Firecracker and cloud-hypervisor
+  too** — as a flat `Image`, the container those two take on this
+  architecture where x86 gives them the ELF's PVH note.
+  `boot/boot_arm64.S` carries the format's 64-byte header at offset 0
+  and `build_unikernel_arm64.sh` emits `prog.Image` beside `prog.elf`;
+  `POST /build_unikernel` returns it as `image_artifact`. One program,
+  two wrappers, no second build: `code0` is a branch over the header,
+  so a loader jumping to offset 0 and an ELF loader jumping to the
+  entry point arrive at the same instruction. `text_offset` is 2 MiB
+  because the image is **not** position-independent — the field is
+  what makes a loader place it where its absolute addresses already
+  point — and `image_size` covers `.bss`. The hypervisor gate checks
+  the header the way it checks the PVH note (magic, `code0` really a
+  branch, `text_offset` equal to the link offset, `image_size` ≥ the
+  file), with four mutations caught; QEMU boots the flat Image, which
+  is what proves the branch and the load address agree. Booting the
+  other two on this container needs an AArch64 **host** — neither
+  emulates — and the gate says so instead of implying coverage.
+
 - **A NURL program boots as its own kernel on RISC-V too** — the third
   architecture, and the one that proves the second was not a
   coincidence. QEMU's `virt` board with OpenSBI underneath, four files

--- a/nurlapi/e2e_test.py
+++ b/nurlapi/e2e_test.py
@@ -815,6 +815,20 @@ def t_build_unikernel_rest(c: Client) -> None:
                     (j.get("boot") or {}).get("qemu") or "")
         assert_true("aarch64 boot command has no tsc_khz (self-describing clock)",
                     "tsc_khz" not in ((j.get("boot") or {}).get("qemu") or ""), "")
+        art = j.get("image_artifact") or {}
+        assert_true("aarch64 build also emits the flat Image",
+                    (art.get("name") or "").endswith(".Image"), str(j)[:200])
+        assert_true("the Image is smaller than the ELF it came from",
+                    0 < (art.get("bytes") or 0) < (j.get("image_bytes") or 0), str(art))
+        istat, _, ibody = c.get(f"/download/{art.get('token')}")
+        assert_eq("Image downloads", istat, 200)
+        # The 64-byte ARM64 image header: magic "ARM\x64" at 0x38, and
+        # code0 a branch so a loader jumping to offset 0 reaches the
+        # boot code. Firecracker and cloud-hypervisor dispatch on this.
+        assert_true("Image carries the ARM64 header magic",
+                    ibody[0x38:0x3c] == b"ARM\x64", repr(ibody[0x38:0x3c]))
+        assert_true("Image code0 is a branch",
+                    ibody[3] in (0x14, 0x94), hex(ibody[3]) if ibody else "empty")
         br = j.get("boot_result") or {}
         if br.get("ran") is False and "not available" in (br.get("error") or ""):
             print("  aarch64 boot skipped: qemu not in this deployment")

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -4503,6 +4503,29 @@ s combined_stdout s combined_stderr → v {
                                 ( json_obj_set res `elf_artifact`
                                 ( make_artifact_json ( string_data elf_name ) ebytes ( string_data build_id ) ) )
                                 ( json_obj_set res `image_bytes` ( json_int ebytes ) )
+                                // On AArch64 the build also emits the flat
+                                // `Image` — the container Firecracker and
+                                // cloud-hypervisor take on this architecture,
+                                // where x86 gives them the ELF's PVH note.
+                                // Same program, second wrapper; offered only
+                                // when the build actually produced one.
+                                ? ( __uk_is_arm arch ) {
+                                    : ~ String img_name ( string_from ( string_data elf_name ) )
+                                    ? ( string_ends_with img_name `.elf` ) {
+                                        : String t2 ( string_substr img_name 0 - ( string_len img_name ) 4 )
+                                        ( string_free img_name ) = img_name t2
+                                    } {}
+                                    ( string_push_str img_name `.Image` )
+                                    : String img_path ( path_join ( string_data build_dir ) ( string_data img_name ) )
+                                    ? ( file_exists ( string_data img_path ) ) {
+                                        : !i IoErr isz ( file_size ( string_data img_path ) )
+                                        ( json_obj_set res `image_artifact`
+                                        ( make_artifact_json ( string_data img_name )
+                                        ?? isz { T sz → sz F _ → 0 } ( string_data build_id ) ) )
+                                    } {}
+                                    ( string_free img_path )
+                                    ( string_free img_name )
+                                } {}
                                 // How to run it: the plain command, and the
                                 // networked variant for a program that serves
                                 // (virtio-net + a host port forward).
@@ -4511,7 +4534,9 @@ s combined_stdout s combined_stderr → v {
                                 : String bn ( __uk_boot_cmd arch ( string_data elf_name ) uargs T )
                                 ( json_obj_set boot `qemu` ( json_str_lit ( string_data bc ) ) )
                                 ( json_obj_set boot `qemu_net` ( json_str_lit ( string_data bn ) ) )
-                                ( json_obj_set boot `notes` ( json_str_lit `Use -accel tcg on a machine without /dev/kvm. Memory floor: a hello answers on -m 3, an HTTPS server on -m 4; -m 64 leaves headroom. The hostfwd in qemu_net forwards host 127.0.0.1:8080 to guest port 8080 — edit both to your program's port.` ) )
+                                ( json_obj_set boot `notes` ( json_str_lit ? ( __uk_is_arm arch )
+                                `Use -accel tcg on a machine without /dev/kvm. The hostfwd in qemu_net forwards host 127.0.0.1:8080 to guest port 8080 — edit both to your program's port. QEMU takes the .elf shown here; Firecracker and cloud-hypervisor take the .Image beside it (the flat container this architecture uses, where x86 uses the ELF's PVH note) and need an AArch64 host.`
+                                `Use -accel tcg on a machine without /dev/kvm. Memory floor: a hello answers on -m 3, an HTTPS server on -m 4; -m 64 leaves headroom. The hostfwd in qemu_net forwards host 127.0.0.1:8080 to guest port 8080 — edit both to your program's port. The same .elf boots under Firecracker and cloud-hypervisor unchanged — all three read its PVH note.` ) )
                                 ( string_free bc )
                                 ( string_free bn )
                                 ( json_obj_set res `boot` boot )

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -375,11 +375,29 @@ than passing quietly. Three deliberate mutations — the entry point
 moved, the note's type changed, the section renamed away — are all
 caught by the structure half.
 
-On AArch64 the honest answer is different, and the gate gives it:
-PVH is x86-only. QEMU's `virt` board loads the ELF directly (which is
-what the AArch64 guest gate boots), while Firecracker and
-cloud-hypervisor want a PE-format `Image` there — a packaging step
-this target has not taken, rather than a property it has.
+On AArch64 the container differs and the build now produces both.
+PVH is x86-only; what Firecracker and cloud-hypervisor take there is a
+flat **`Image`** — the format a Linux arm64 kernel ships in — so
+`boot_arm64.S` puts that format's 64-byte header at offset 0 of the
+same build and `build_unikernel_arm64.sh` emits `prog.Image` beside
+`prog.elf`. One program, two wrappers: `code0` is a branch over the
+header, so a loader that jumps to offset 0 and an ELF loader that
+jumps to the entry point arrive at the same instruction. `text_offset`
+is 2 MiB because this image is **not** position-independent — the
+field is what makes a loader place it where its absolute addresses
+already point — and `image_size` covers `.bss`, so the loader reserves
+what the program grows into rather than what the file holds.
+
+The gate checks the header the same way it checks the PVH note (magic,
+`code0` really a branch, `text_offset` equal to where the image is
+linked inside its region, `image_size` ≥ the file), and four
+mutations — magic cleared, `code0` zeroed, offset zeroed, size shrunk
+— are all caught. Booting Firecracker or cloud-hypervisor on this
+container needs an **AArch64 host**: neither emulates, so there is
+nothing on an x86 developer machine to run them on, and the gate says
+that rather than implying coverage it does not have. QEMU boots the
+flat Image here, which is what proves the header's branch and its load
+address agree.
 
 ## Three architectures, and what a port actually costs
 
@@ -391,7 +409,7 @@ this target has not taken, rather than a property it has.
 | devices from | kernel command line | device tree | device tree |
 | clock | TSC, frequency **told** | CNTFRQ_EL0 | `rdtime`, tree's rate |
 | entropy | RDRAND | RNDR | **none — refuses** |
-| hello image | 132 760 B | 131 784 B | 155 344 B |
+| hello image | 132 760 B (ELF) | 131 784 B (ELF) · 102 632 B (Image) | 155 344 B (ELF) |
 
 The per-architecture files are the bottom edge and nothing else:
 `boot_<arch>.S`, `platform_<arch>.c`, `tls_guest_<arch>.c`,

--- a/unikernel/boot/boot_arm64.S
+++ b/unikernel/boot/boot_arm64.S
@@ -36,6 +36,42 @@
  */
 
     .section .text.boot, "ax", %progbits
+
+/* ── the AArch64 image header ─────────────────────────────────────
+ *
+ * 64 bytes, at offset 0 of the image, exactly as
+ * Documentation/arch/arm64/booting.rst specifies. It is what turns
+ * this ELF into something Firecracker and cloud-hypervisor will load:
+ * on x86 those two read the PVH note out of the ELF, and on THIS
+ * architecture they take a flat `Image` — the format a Linux arm64
+ * kernel ships in — and this header is that format.
+ *
+ * The header costs nothing on the paths that do not use it: `code0`
+ * is a real instruction (a branch over the header), so a loader that
+ * jumps to offset 0 lands in the same boot code an ELF loader reaches
+ * through the ELF entry point. One image, two ways in.
+ *
+ * `text_offset` is 2 MiB, and that is not decoration: this image is
+ * NOT position-independent — the linker script fixes it at
+ * 0x4020_0000, which is 2 MiB above the start of QEMU virt's RAM. The
+ * field says exactly that, so a loader places the image where its
+ * absolute addresses already point. `image_size` covers .bss too, so
+ * the loader reserves the memory the program will grow into rather
+ * than the bytes the file happens to hold.
+ */
+    .globl _arm64_image_header
+_arm64_image_header:
+    b       _arm64_start            /* code0: branch over the header  */
+    .long   0                       /* code1                          */
+    .quad   0x200000                /* text_offset: 2 MiB above base  */
+    .quad   __image_size            /* image_size, .bss included      */
+    .quad   0                       /* flags: LE, 2 MiB-aligned base  */
+    .quad   0                       /* res2                           */
+    .quad   0                       /* res3                           */
+    .quad   0                       /* res4                           */
+    .ascii  "ARM\x64"               /* magic                          */
+    .long   0                       /* res5: no PE/COFF header        */
+
     .globl _arm64_start
 _arm64_start:
     mov     x21, x0                 /* the possible DTB pointer        */

--- a/unikernel/boot/link_arm64.ld
+++ b/unikernel/boot/link_arm64.ld
@@ -48,5 +48,11 @@ SECTIONS
     . = ALIGN(2M);
     __heap_start = .;
 
+    /* What the image header tells a loader to reserve: everything from
+     * the first byte of the image through .bss, so the program's
+     * zero-initialised data is memory the loader has kept for it
+     * rather than memory it happens not to have used yet. */
+    __image_size = . - 0x40200000;
+
     /DISCARD/ : { *(.comment) *(.note.GNU-stack) *(.eh_frame) }
 }

--- a/unikernel/build_unikernel_arm64.sh
+++ b/unikernel/build_unikernel_arm64.sh
@@ -194,4 +194,26 @@ $ZIG cc -target $TARGET -nostdlib -static -Wl,-T,"$BOOT/link_arm64.ld" \
     "$OUTDIR/$base.initfs_data.o" \
     "$CACHE"/nl_*.o
 
-echo "built $OUT"
+# ── the flat Image, beside the ELF ───────────────────────────────
+#
+# Two containers, one program. QEMU's virt board loads the ELF with
+# -kernel; Firecracker and cloud-hypervisor take a flat `Image` on this
+# architecture — the format a Linux arm64 kernel ships in — and
+# `boot/boot_arm64.S` puts that format's 64-byte header at offset 0, so
+# the same build answers both. `code0` is a branch over the header, so
+# a loader that jumps to offset 0 and an ELF loader that jumps to the
+# entry point arrive at the same instruction.
+OBJCOPY="${NURL_OBJCOPY:-}"
+if [ -z "$OBJCOPY" ]; then
+    for c in llvm-objcopy llvm-objcopy-16 aarch64-linux-gnu-objcopy; do
+        command -v "$c" >/dev/null 2>&1 && { OBJCOPY="$c"; break; }
+    done
+fi
+if [ -n "$OBJCOPY" ]; then
+    "$OBJCOPY" -O binary "$OUT" "${OUT%.elf}.Image"
+    echo "built $OUT and ${OUT%.elf}.Image"
+else
+    # Plain binutils objcopy is built per-target and usually cannot read
+    # a foreign ELF; saying so beats writing a file that is not an image.
+    echo "built $OUT (no llvm-objcopy — skipped the flat Image; set NURL_OBJCOPY)" >&2
+fi

--- a/unikernel/tests/hypervisor_gate.sh
+++ b/unikernel/tests/hypervisor_gate.sh
@@ -58,12 +58,79 @@ fi
 machine=$(readelf -hW "$IMG" | awk -F: '/Machine:/ {print $2}' | sed 's/^ *//')
 case "$machine" in
     *AArch64*)
-        say "AArch64 image — PVH is x86-only, so there is no note to check."
-        say "     QEMU virt loads this ELF directly (the AArch64 guest gate"
-        say "     boots it). Firecracker and cloud-hypervisor want a"
-        say "     PE-format Image on this architecture: a packaging step"
-        say "     this target has not taken, not a property it has."
-        exit 0
+        # PVH is x86-only. What Firecracker and cloud-hypervisor take on
+        # THIS architecture is a flat `Image` — the format a Linux arm64
+        # kernel ships in — and boot_arm64.S puts its 64-byte header at
+        # offset 0 of the same build. So the question here is the same
+        # question, asked of the other container: is the header what a
+        # loader dispatches on?
+        img="${IMG%.elf}.Image"
+        if [ ! -f "$img" ]; then
+            objc="${NURL_OBJCOPY:-llvm-objcopy}"
+            command -v "$objc" >/dev/null 2>&1 || {
+                say "SKIP AArch64 Image check (no llvm-objcopy to flatten the ELF)"
+                exit 0
+            }
+            img="$(mktemp)"
+            "$objc" -O binary "$IMG" "$img" || { say "FAIL: could not flatten the ELF"; exit 1; }
+        fi
+        hdr=$(od -A n -t x1 -N 64 "$img" | tr -d ' \n')
+        # magic "ARM\x64" at offset 0x38, little-endian in the file as
+        # the four ASCII bytes 41 52 4d 64.
+        if [ "${hdr:112:8}" != "41524d64" ]; then
+            say "FAIL: no ARM64 image magic at offset 0x38 — Firecracker and"
+            say "      cloud-hypervisor have nothing to dispatch on"
+            exit 1
+        fi
+        # code0 must be a real instruction: a b/bl (top byte 0x14/0x94 in
+        # little-endian byte order → the 4th byte of the word). A zeroed
+        # code0 is what a header written as pure data looks like, and a
+        # loader jumping to offset 0 would execute it.
+        c0b3="${hdr:6:2}"
+        case "$c0b3" in
+            14|94) ;;
+            *) say "FAIL: code0 is not a branch (byte 3 = 0x$c0b3) — a loader"
+               say "      that jumps to offset 0 would not reach the boot code"
+               fail=1 ;;
+        esac
+        # text_offset (0x08) must match where the image is LINKED inside
+        # its 2 MiB-aligned region: this image is not position-independent
+        # and the field is what makes a loader put it where its absolute
+        # addresses already point.
+        toff=$(python3 -c "import sys;h=sys.argv[1];print(int.from_bytes(bytes.fromhex(h[16:32]),'little'))" "$hdr" 2>/dev/null || echo -1)
+        # The image's BASE, not its entry point: the header describes
+        # where byte 0 of the image goes, and the entry sits 64 bytes
+        # further on because the header itself is those 64 bytes. The
+        # first check written here used the entry and reported a 64-byte
+        # discrepancy as a defect — a gate being precise about which
+        # address a field means.
+        base=$(readelf -lW "$IMG" | awk '/LOAD/ {print $3; exit}')
+        # Offset within the gigabyte the image is linked into: RAM on
+        # this board starts at a gigabyte boundary, so this is the
+        # distance from DRAM start that the loader must reproduce.
+        region=$(( $((base)) - ($((base)) & ~0x3FFFFFFF) ))
+        if [ "$toff" -lt 0 ]; then
+            say "FAIL: could not read text_offset"
+            fail=1
+        elif [ "$toff" != "$region" ]; then
+            say "FAIL: text_offset is $toff but the image is linked $region bytes"
+            say "      into its region — a loader would place it where its own"
+            say "      absolute addresses do not point"
+            fail=1
+        fi
+        # image_size must cover the file, .bss included.
+        isize=$(python3 -c "import sys;h=sys.argv[1];print(int.from_bytes(bytes.fromhex(h[32:48]),'little'))" "$hdr" 2>/dev/null || echo 0)
+        fsize=$(stat -c %s "$img")
+        if [ "$isize" -lt "$fsize" ]; then
+            say "FAIL: image_size ($isize) is smaller than the image ($fsize)"
+            fail=1
+        fi
+        [ "$fail" = 0 ] && say "AArch64 Image header OK — magic, code0 is a branch, text_offset $toff, image_size $isize"
+        say "     (Firecracker and cloud-hypervisor take this container on"
+        say "     this architecture; booting them needs an AArch64 HOST —"
+        say "     neither emulates, so there is nothing here to run them on.)"
+        [ "$fail" = 0 ] && say "verified: AArch64 Image header (no AArch64 host to boot it under)"
+        exit $fail
         ;;
 esac
 


### PR DESCRIPTION
U7 left an honest gap: on x86 all three hypervisors read the same ELF's
PVH note; on AArch64 the other two want a flat **`Image`** — the
container a Linux arm64 kernel ships in — which this target did not
produce. It does now, **from the same build**.

- `boot/boot_arm64.S` carries the format's 64-byte header at offset 0;
  `build_unikernel_arm64.sh` emits `prog.Image` beside `prog.elf`.
  `code0` is a branch over the header, so a loader jumping to offset 0
  and an ELF loader jumping to the entry point reach the same
  instruction. **One program, two wrappers, no second build.**
- `text_offset` = 2 MiB because the image is **not** position-
  independent — the field is what makes a loader place it where its
  absolute addresses already point. `image_size` covers `.bss`.
- `POST /build_unikernel` returns it as `image_artifact` for aarch64;
  the boot notes say which container each hypervisor takes.

**Gate**: magic at 0x38, `code0` really a branch, `text_offset` equal to
the link offset, `image_size` ≥ the file — **4/4 mutations caught**
(magic cleared, code0 zeroed, offset zeroed, size shrunk). Writing it
caught my own imprecision first: the check compared against the ELF's
*entry* and called the 64-byte header a defect.

**Verified**: QEMU boots the flat Image (proving branch and load
address agree); the AArch64 guest gate stays **15/15** with the header
in place; an Image built over HTTP, downloaded from the playground and
booted prints and exits 0.

Booting Firecracker/cloud-hypervisor on this container needs an
AArch64 **host** — neither emulates — and the gate says so rather than
implying coverage it lacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1