### PR TITLE
feat: TLS works on RISC-V — entropy from a virtio-rng device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,10 @@ jobs:
           mkdir -p /opt/zig && sudo tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1
 
       - name: The guest, on the THIRD architecture
+        # …including the entropy gate: this ISA has no instruction for
+        # randomness, so the RISC-V guest drives a virtio-rng device
+        # and the gate checks both halves — real bytes with the device,
+        # a refusal BY NAME without it.
         # RISC-V, QEMU's virt board with OpenSBI underneath. The third
         # port is the one that proves the second was not a coincidence:
         # by now the per-architecture surface is four files and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TLS works on RISC-V: entropy from a virtio-rng device**
+  (`unikernel/boot/virtio_rng.c`). This architecture has no entropy
+  INSTRUCTION — the `seed` CSR is the optional Zkr extension and
+  QEMU's rv64 CPU does not implement it — so the answer comes from a
+  device, at the same layer x86 answers with RDRAND and AArch64 with
+  RNDR. With `-device virtio-rng-device` an RSA-2048 TLS 1.3 handshake
+  against the guest completes (84 s under TCG — the interpreter's
+  price, not the protocol's); without it the machine refuses BY NAME
+  rather than inventing anything, because "your TLS handshake failed"
+  is a much worse way to learn a device is missing.
+
+  The driver is C in the boot layer and deliberately not the NURL
+  virtqueue: `getrandom` must work with no NURL module linked, for a
+  program that never touches the socket layer. One queue, one buffer,
+  no negotiation beyond the version bit. It trusts the device for
+  bytes and not for the count — one claiming to have written more than
+  the buffer holds is refused. The gate checks both halves, because a
+  fake source passes the obvious one: with the device a draw must be
+  neither all zeroes nor equal to the next draw, and without it the
+  refusal must name the device.
+
 - **The AArch64 image now boots on Firecracker and cloud-hypervisor
   too** — as a flat `Image`, the container those two take on this
   architecture where x86 gives them the ELF's PVH note.

--- a/unikernel/README.md
+++ b/unikernel/README.md
@@ -408,7 +408,7 @@ address agree.
 | memory from | PVH memmap | device tree | device tree |
 | devices from | kernel command line | device tree | device tree |
 | clock | TSC, frequency **told** | CNTFRQ_EL0 | `rdtime`, tree's rate |
-| entropy | RDRAND | RNDR | **none — refuses** |
+| entropy | RDRAND | RNDR | **virtio-rng** (no instruction exists) |
 | hello image | 132 760 B (ELF) | 131 784 B (ELF) · 102 632 B (Image) | 155 344 B (ELF) |
 
 The per-architecture files are the bottom edge and nothing else:
@@ -457,12 +457,30 @@ Three things this port had to say out loud rather than assume:
   (`[nurl-boot]`) and the run script drops everything up to it. The
   rule belongs to us rather than to whatever the banner looks like
   this year.
-- **There is no entropy source.** RISC-V's `seed` CSR is the optional
-  Zkr extension and QEMU's rv64 CPU does not implement it, so this
-  port PANICS on a request for randomness, naming what is missing.
-  Everything else works; a TLS handshake here waits for a virtio-rng
-  driver. That is the plan's absolute rule applied to an architecture
-  that cannot satisfy it — refuse, do not invent.
+- **There is no entropy INSTRUCTION**, so the answer comes from a
+  device. RISC-V's `seed` CSR is the optional Zkr extension and QEMU's
+  rv64 CPU does not implement it, so `boot/virtio_rng.c` drives a
+  virtio-rng device instead — the same layer the other two answer
+  from, a different source. A machine started without `-device
+  virtio-rng-device` is told so BY NAME: the rule stays absolute, no
+  source is a panic and never a fallback, because "your TLS handshake
+  failed" is a much worse way to learn it. With the device, **TLS 1.3
+  works on this architecture** — an RSA-2048 handshake against the
+  guest completes in 84 s under TCG, which is the interpreter's price
+  rather than the protocol's.
+
+  The driver is C in the boot layer and deliberately not
+  `stdlib/hal/virtq.nu`: `getrandom` is a libc-level call that must
+  work with no NURL module linked, for a program that never touches
+  the socket layer. One queue, one buffer, no negotiation beyond the
+  version bit — the same protocol as the network driver at a different
+  layer, not a second implementation of it. It trusts the device for
+  BYTES and not for the count: a device claiming to have written more
+  than the buffer holds is refused rather than believed.
+
+  The gate checks both halves, because a fake source passes the
+  obvious one: with the device, a draw must be neither all zeroes nor
+  equal to the next draw; without it, the machine must refuse by name.
 
 `unikernel/run_qemu_riscv64_tests.sh` is the gate — **15/15**, the
 same corpus programs against the same hosted goldens, the device

--- a/unikernel/boot/fdt.c
+++ b/unikernel/boot/fdt.c
@@ -46,12 +46,20 @@ typedef unsigned int       u32;
  * `nurl_boot_cmdline`: bootargs first, then the synthesized device
  * entries, so a program's `args="…"` is found before them and QEMU's
  * device list never reaches an argument parser. */
+#define FDT_MAX_DEVS 32
+
 struct fdt_facts {
     u64   ram_base;
     u64   ram_size;
     char  cmdline[2048];
     unsigned long cmdline_len;
     int   devices;            /* how many virtio-mmio nodes were seen */
+    /* …and where they are. The synthesized cmdline is for the NURL
+     * layer, which parses the x86 spelling; the boot layer has a
+     * driver of its own (boot/virtio_rng.c — this architecture may
+     * have no entropy instruction) and re-parsing a string it just
+     * produced would be one format conversion too many. */
+    u64   dev_base[FDT_MAX_DEVS];
 };
 
 static u32 fdt_be32(const unsigned char *p) {
@@ -184,6 +192,8 @@ int fdt_probe(const void *fdt_p, struct fdt_facts *out) {
                     cl_puthex(&devs, lvl[depth].reg_base);
                     cl_puts(&devs, ":");
                     cl_putu(&devs, lvl[depth].irq + 32);
+                    if (out->devices < FDT_MAX_DEVS)
+                        out->dev_base[out->devices] = lvl[depth].reg_base;
                     out->devices++;
                 }
                 if (lvl[depth].is_memory && lvl[depth].reg_size && !out->ram_size) {

--- a/unikernel/boot/platform_arm64.c
+++ b/unikernel/boot/platform_arm64.c
@@ -188,12 +188,18 @@ void pf_exception(u64 vector, struct fault_frame *f) {
  * parsing one tree separately is where two machines start disagreeing
  * about what it says. This file keeps only what is machine-specific.
  */
+#define FDT_MAX_DEVS 32
 struct fdt_facts {
     unsigned long long ram_base;
     unsigned long long ram_size;
     char  cmdline[2048];
     unsigned long cmdline_len;
     int   devices;
+    /* Where they are. This port answers entropy from RNDR and does not
+     * need the list, but the struct is fdt.c's and a declaration that
+     * drifts from it would read the wrong fields — the twin-file rule
+     * this directory exists to enforce. */
+    unsigned long long dev_base[FDT_MAX_DEVS];
 };
 int fdt_is_tree(const void *p);
 int fdt_probe(const void *fdt, struct fdt_facts *out);

--- a/unikernel/boot/platform_riscv64.c
+++ b/unikernel/boot/platform_riscv64.c
@@ -51,12 +51,14 @@ typedef unsigned int       u32;
 extern unsigned char __heap_start[];
 
 /* ── the device tree, in boot/fdt.c ──────────────────────────────── */
+#define FDT_MAX_DEVS 32
 struct fdt_facts {
     u64   ram_base;
     u64   ram_size;
     char  cmdline[2048];
     unsigned long cmdline_len;
     int   devices;
+    u64   dev_base[FDT_MAX_DEVS];
 };
 int fdt_is_tree(const void *p);
 int fdt_probe(const void *fdt, struct fdt_facts *out);
@@ -476,20 +478,41 @@ int nanosleep(const void *req, void *rem) {
 
 /* ── entropy ─────────────────────────────────────────────────────
  *
- * There is no entropy instruction in this machine's profile: the Zkr
+ * There is no entropy INSTRUCTION in this machine's profile: the Zkr
  * extension's `seed` CSR is optional and QEMU's rv64 CPU does not
- * implement it, so reading it is an illegal instruction rather than a
- * weak number. The plan's rule is absolute — no source is a panic,
- * never a fallback — and this port applies it by refusing, naming what
- * is missing. Everything except key generation works; a TLS handshake
- * on this architecture waits for a virtio-rng driver.
+ * implement it, so reading it would be an illegal instruction rather
+ * than a weak number. The answer therefore comes from a DEVICE —
+ * virtio-rng, driven by boot/virtio_rng.c — which is the same layer
+ * the other two architectures answer from, just a different source.
+ *
+ * The rule stays absolute: no source is a panic, never a fallback.
+ * A machine started without `-device virtio-rng-device` is told so by
+ * name, because "your TLS handshake failed" is a much worse way to
+ * learn it than "this machine has no entropy device".
  */
+int virtio_rng_start(const u64 *bases, int n);
+long long virtio_rng_read(void *dst, unsigned long len);
+
 long long getrandom(void *buf, unsigned long len, unsigned int flags) {
-    (void)buf; (void)len; (void)flags;
-    pf_panic("no entropy source on this machine — RISC-V's seed CSR (Zkr) "
-             "is optional and absent here, and there is no virtio-rng "
-             "driver yet. Refusing to generate keys from nothing.");
-    return 0;
+    unsigned char *p = (unsigned char *)buf;
+    unsigned long done = 0;
+    (void)flags;
+
+    if (!virtio_rng_start(facts.dev_base, facts.devices))
+        pf_panic("no entropy source on this machine — RISC-V's seed CSR "
+                 "(Zkr) is optional and absent here, and no virtio-rng "
+                 "device was found. Start the guest with "
+                 "`-device virtio-rng-device`. Refusing to generate keys "
+                 "from nothing.");
+
+    while (done < len) {
+        long long got = virtio_rng_read(p + done, len - done);
+        if (got <= 0)
+            pf_panic("the virtio-rng device stopped answering — refusing "
+                     "to continue with partial entropy");
+        done += (unsigned long)got;
+    }
+    return (long long)len;
 }
 
 /* ── the file surface nolibc expects ─────────────────────────────── */

--- a/unikernel/boot/virtio_rng.c
+++ b/unikernel/boot/virtio_rng.c
@@ -1,0 +1,249 @@
+/*
+ * NURL unikernel — unikernel/boot/virtio_rng.c
+ *
+ * Copyright (c) 2026 The NURL Project Developers
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * Entropy from a virtio-rng device, for a machine whose instruction
+ * set does not have any.
+ *
+ * WHY THIS IS C, AND IN THE BOOT LAYER
+ *
+ * `getrandom` is a libc-level call: NURL asks the runtime, the runtime
+ * asks the platform, and the platform answers from the machine. On
+ * x86 that answer is RDRAND and on AArch64 it is RNDR — two
+ * instructions, both in platform_<arch>.c. RISC-V has neither (the
+ * `seed` CSR is the optional Zkr extension and QEMU's rv64 CPU does
+ * not implement it), so on that machine the answer has to come from a
+ * DEVICE, and it has to be available at exactly the same layer the
+ * other two answers are: below the runtime, with no NURL module
+ * linked, before anything above has been arranged.
+ *
+ * That is why this does not use `stdlib/hal/virtq.nu`, which is the
+ * project's real virtqueue implementation and the one the network
+ * driver uses. This is one queue, one buffer, no negotiation beyond
+ * the version bit, and it must work for a program that never links
+ * the socket layer. The two are the same protocol at different
+ * layers, not two implementations of one thing — and the modern MMIO
+ * register offsets below are the same numbers `hal/virtio.nu` names,
+ * kept in the same order so the two can be read side by side.
+ *
+ * The device is trusted for BYTES, not for the count: it is asked for
+ * n bytes and told how many it wrote, and a device claiming to have
+ * written more than the buffer holds is refused rather than believed.
+ */
+
+typedef unsigned long long u64;
+typedef unsigned int       u32;
+typedef unsigned short     u16;
+typedef unsigned char      u8;
+
+/* ── the modern virtio-mmio register file ───────────────────────── */
+#define R_MAGIC          0x000
+#define R_VERSION        0x004
+#define R_DEVICE_ID      0x008
+#define R_DEV_FEATURES   0x010
+#define R_DEV_FEAT_SEL   0x014
+#define R_DRV_FEATURES   0x020
+#define R_DRV_FEAT_SEL   0x024
+#define R_QUEUE_SEL      0x030
+#define R_QUEUE_NUM_MAX  0x034
+#define R_QUEUE_NUM      0x038
+#define R_QUEUE_READY    0x044
+#define R_QUEUE_NOTIFY   0x050
+#define R_INT_STATUS     0x060
+#define R_INT_ACK        0x064
+#define R_STATUS         0x070
+#define R_Q_DESC_LO      0x080
+#define R_Q_DESC_HI      0x084
+#define R_Q_DRIVER_LO    0x090
+#define R_Q_DRIVER_HI    0x094
+#define R_Q_DEVICE_LO    0x0a0
+#define R_Q_DEVICE_HI    0x0a4
+
+#define VIRTIO_MAGIC     0x74726976   /* "virt" */
+#define DEV_ID_ENTROPY   4
+
+#define S_ACKNOWLEDGE    1
+#define S_DRIVER         2
+#define S_DRIVER_OK      4
+#define S_FEATURES_OK    8
+#define S_FAILED         128
+
+#define F_VERSION_1_BIT  32           /* in the high feature word     */
+
+#define VRING_DESC_F_WRITE 2
+
+#define QSIZE 8                        /* one request at a time; the
+                                        * queue exists because the
+                                        * protocol has one, not because
+                                        * this driver pipelines */
+
+struct vring_desc {
+    u64 addr;
+    u32 len;
+    u16 flags;
+    u16 next;
+};
+struct vring_avail {
+    u16 flags;
+    u16 idx;
+    u16 ring[QSIZE];
+    u16 used_event;
+};
+struct vring_used_elem {
+    u32 id;
+    u32 len;
+};
+struct vring_used {
+    u16 flags;
+    u16 idx;
+    struct vring_used_elem ring[QSIZE];
+    u16 avail_event;
+};
+
+/* The rings live in .bss, which is identity-mapped RAM on every board
+ * this runs on — the device is handed physical addresses and there is
+ * no IOMMU in the picture. Alignment is the spec's: 16 for the
+ * descriptor table, 2 for the available ring, 4 for the used ring;
+ * page alignment costs nothing here and satisfies all three. */
+static struct vring_desc  rng_desc[QSIZE]  __attribute__((aligned(4096)));
+static struct vring_avail rng_avail        __attribute__((aligned(4096)));
+static struct vring_used  rng_used         __attribute__((aligned(4096)));
+static u8                 rng_buf[256]     __attribute__((aligned(64)));
+
+static u64 rng_base;            /* 0 = no device found (or not looked) */
+static int rng_ready;
+static u16 rng_last_used;
+
+static inline u32 mmio_r32(u64 base, u32 off) {
+    return *(volatile u32 *)(unsigned long)(base + off);
+}
+static inline void mmio_w32(u64 base, u32 off, u32 v) {
+    *(volatile u32 *)(unsigned long)(base + off) = v;
+}
+
+/* Bring one device up. 1 on success. Every failure leaves FAILED in
+ * the status register, which is what the spec asks a driver to do and
+ * what makes a half-initialised device visible to anyone looking. */
+static int rng_init_at(u64 base) {
+    if (mmio_r32(base, R_MAGIC) != VIRTIO_MAGIC) return 0;
+    if (mmio_r32(base, R_VERSION) != 2) return 0;      /* legacy: refuse */
+    if (mmio_r32(base, R_DEVICE_ID) != DEV_ID_ENTROPY) return 0;
+
+    mmio_w32(base, R_STATUS, 0);                        /* reset        */
+    while (mmio_r32(base, R_STATUS) != 0) { }
+    mmio_w32(base, R_STATUS, S_ACKNOWLEDGE);
+    mmio_w32(base, R_STATUS, S_ACKNOWLEDGE | S_DRIVER);
+
+    /* Features: the entropy device offers nothing this driver wants,
+     * but VIRTIO_F_VERSION_1 must be accepted or a modern device
+     * refuses FEATURES_OK — which is the whole difference between the
+     * modern and legacy protocols. */
+    mmio_w32(base, R_DEV_FEAT_SEL, 1);
+    u32 hi = mmio_r32(base, R_DEV_FEATURES);
+    mmio_w32(base, R_DRV_FEAT_SEL, 1);
+    mmio_w32(base, R_DRV_FEATURES, hi & (1u << (F_VERSION_1_BIT - 32)));
+    mmio_w32(base, R_DRV_FEAT_SEL, 0);
+    mmio_w32(base, R_DRV_FEATURES, 0);
+
+    mmio_w32(base, R_STATUS, S_ACKNOWLEDGE | S_DRIVER | S_FEATURES_OK);
+    if (!(mmio_r32(base, R_STATUS) & S_FEATURES_OK)) {
+        mmio_w32(base, R_STATUS, S_FAILED);
+        return 0;
+    }
+
+    mmio_w32(base, R_QUEUE_SEL, 0);
+    if (mmio_r32(base, R_QUEUE_READY) != 0) {           /* already up?  */
+        mmio_w32(base, R_STATUS, S_FAILED);
+        return 0;
+    }
+    u32 max = mmio_r32(base, R_QUEUE_NUM_MAX);
+    if (max == 0) { mmio_w32(base, R_STATUS, S_FAILED); return 0; }
+    u32 n = max < QSIZE ? max : QSIZE;
+    mmio_w32(base, R_QUEUE_NUM, n);
+
+    for (int i = 0; i < QSIZE; i++) {
+        rng_desc[i].addr = 0; rng_desc[i].len = 0;
+        rng_desc[i].flags = 0; rng_desc[i].next = 0;
+    }
+    rng_avail.flags = 0; rng_avail.idx = 0;
+    rng_used.flags = 0;  rng_used.idx = 0;
+    rng_last_used = 0;
+
+    u64 d = (u64)(unsigned long)&rng_desc[0];
+    u64 a = (u64)(unsigned long)&rng_avail;
+    u64 u = (u64)(unsigned long)&rng_used;
+    mmio_w32(base, R_Q_DESC_LO,   (u32)d);
+    mmio_w32(base, R_Q_DESC_HI,   (u32)(d >> 32));
+    mmio_w32(base, R_Q_DRIVER_LO, (u32)a);
+    mmio_w32(base, R_Q_DRIVER_HI, (u32)(a >> 32));
+    mmio_w32(base, R_Q_DEVICE_LO, (u32)u);
+    mmio_w32(base, R_Q_DEVICE_HI, (u32)(u >> 32));
+    mmio_w32(base, R_QUEUE_READY, 1);
+
+    mmio_w32(base, R_STATUS, S_ACKNOWLEDGE | S_DRIVER | S_FEATURES_OK | S_DRIVER_OK);
+    return 1;
+}
+
+/* Find and initialise the first virtio-rng device among the bases the
+ * device tree reported. Returns 1 when one is ready. Called lazily, on
+ * the first request: a program that never asks for entropy pays
+ * nothing, and one that asks on a machine without a device gets an
+ * answer rather than a boot-time panic it did not cause. */
+int virtio_rng_start(const u64 *bases, int n) {
+    if (rng_ready) return 1;
+    for (int i = 0; i < n; i++) {
+        if (!bases[i]) continue;
+        if (rng_init_at(bases[i])) {
+            rng_base = bases[i];
+            rng_ready = 1;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Ask the device for up to `len` bytes; returns how many it wrote, or
+ * -1 if there is no device. Polls the used ring — this runtime takes
+ * no interrupts, and an entropy read happens a handful of times in a
+ * program's life. */
+long long virtio_rng_read(void *dst, unsigned long len) {
+    if (!rng_ready) return -1;
+    if (len == 0) return 0;
+    if (len > sizeof rng_buf) len = sizeof rng_buf;
+
+    rng_desc[0].addr  = (u64)(unsigned long)rng_buf;
+    rng_desc[0].len   = (u32)len;
+    rng_desc[0].flags = VRING_DESC_F_WRITE;   /* the DEVICE writes it */
+    rng_desc[0].next  = 0;
+
+    /* Publish, then tell the device. The barrier is not decoration:
+     * the device may read the ring the instant the index moves, and
+     * the descriptor has to be visible first. */
+    rng_avail.ring[rng_avail.idx % QSIZE] = 0;
+    __asm__ __volatile__("" ::: "memory");
+    rng_avail.idx++;
+    __asm__ __volatile__("" ::: "memory");
+    mmio_w32(rng_base, R_QUEUE_NOTIFY, 0);
+
+    /* Bounded wait. A device that never answers is a broken device,
+     * and spinning forever inside a key generation is the worst place
+     * to hang; the caller's panic path is a better answer. */
+    unsigned long spins = 0;
+    while (rng_used.idx == rng_last_used) {
+        if (++spins > 100000000UL) return -1;
+        __asm__ __volatile__("" ::: "memory");
+    }
+    u32 got = rng_used.ring[rng_last_used % QSIZE].len;
+    rng_last_used++;
+    mmio_w32(rng_base, R_INT_ACK, mmio_r32(rng_base, R_INT_STATUS));
+
+    /* The device says how much it wrote. Believe the bytes, not the
+     * count: a device claiming more than the buffer holds is refused
+     * rather than allowed to describe a copy past the end of it. */
+    if (got > len) return -1;
+    u8 *d = (u8 *)dst;
+    for (u32 i = 0; i < got; i++) d[i] = rng_buf[i];
+    return (long long)got;
+}

--- a/unikernel/build_unikernel_riscv64.sh
+++ b/unikernel/build_unikernel_riscv64.sh
@@ -102,7 +102,7 @@ cache_inputs() {
         "$NOLIBC"/dtoa.c "$NOLIBC"/math.c "$NOLIBC"/misc.c \
         "$NOLIBC"/setjmp_riscv64.S \
         "$BOOT"/platform_riscv64.c "$BOOT"/initfs.c "$BOOT"/pagealloc.c \
-        "$BOOT"/nosys.c "$BOOT"/fdt.c \
+        "$BOOT"/nosys.c "$BOOT"/fdt.c "$BOOT"/virtio_rng.c \
         "$BOOT"/tls_guest_riscv64.c "$BOOT"/boot_riscv64.S \
         "${BASH_SOURCE[0]}"
 }
@@ -120,6 +120,7 @@ cache_build() {
     $ZIG cc $KFLAGS -c "$BOOT/pagealloc.c"       -o "$CACHE/boot_pagealloc.o"
     $ZIG cc $KFLAGS -c "$BOOT/nosys.c"           -o "$CACHE/boot_nosys.o"
     $ZIG cc $KFLAGS -c "$BOOT/fdt.c"             -o "$CACHE/boot_fdt.o"
+    $ZIG cc $KFLAGS -c "$BOOT/virtio_rng.c"      -o "$CACHE/boot_virtio_rng.o"
     $ZIG cc $KFLAGS -c "$BOOT/tls_guest_riscv64.c" -o "$CACHE/tls_guest.o"
     $ZIG cc $KFLAGS -c "$BOOT/boot_riscv64.S"      -o "$CACHE/boot.o"
     $ZIG cc $KFLAGS -c "$NOLIBC/setjmp_riscv64.S" -o "$CACHE/nl_setjmp.o"
@@ -194,7 +195,7 @@ $ZIG cc -target $TARGET -nostdlib -static -Wl,-T,"$BOOT/link_riscv64.ld" \
     "$CACHE/runtime_core.o" "$CACHE/runtime_ctx.o" "$CACHE/runtime_bare.o" \
     "$CACHE/platform.o" "$CACHE/tls_guest.o" \
     "$CACHE/boot_initfs.o" "$CACHE/boot_pagealloc.o" "$CACHE/boot_nosys.o" \
-    "$CACHE/boot_fdt.o" \
+    "$CACHE/boot_fdt.o" "$CACHE/boot_virtio_rng.o" \
     "$OUTDIR/$base.initfs_data.o" \
     "$CACHE"/nl_*.o
 

--- a/unikernel/run_qemu_riscv64_tests.sh
+++ b/unikernel/run_qemu_riscv64_tests.sh
@@ -107,6 +107,34 @@ if [ $# -eq 0 ]; then
         echo "FAIL fault (build)"; fails=$((fails + 1))
     fi
 
+    # Entropy from a device, because this ISA has no instruction for
+    # it: with `-device virtio-rng-device` a draw must return bytes
+    # that are neither all zero nor equal to the next draw, and WITHOUT
+    # the device the guest must refuse by name rather than invent
+    # anything. Both halves matter — a fake entropy source passes the
+    # first check and fails nothing.
+    demos=$((demos + 1))
+    if build "$ROOT/unikernel/tests/entropy_rv.nu" >/dev/null 2>&1; then
+        withdev=$(boot "$OUTDIR/entropy_rv.elf" -t 120 -- -device virtio-rng-device 2>&1)
+        wrc=$?
+        nodev=$(boot "$OUTDIR/entropy_rv.elf" -t 120 2>&1)
+        nrc=$?
+        if [ "$wrc" = 0 ] \
+           && printf '%s' "$withdev" | grep -q '^zeros=0$' \
+           && printf '%s' "$withdev" | grep -q '^same_bytes=0$' \
+           && [ "$nrc" = 127 ] \
+           && printf '%s' "$nodev" | grep -q 'virtio-rng'; then
+            echo "PASS entropy (device gives bytes; absence is refused by name)"
+        else
+            echo "FAIL entropy (with-device exit $wrc, without exit $nrc)"
+            printf '%s\n' "$withdev" | head -4 | sed 's/^/     /'
+            printf '%s\n' "$nodev" | head -2 | sed 's/^/     /'
+            fails=$((fails + 1))
+        fi
+    else
+        echo "FAIL entropy (build)"; fails=$((fails + 1))
+    fi
+
     # An HTTP server in the guest, answering a client on the host.
     if command -v curl >/dev/null 2>&1; then
         demos=$((demos + 1))

--- a/unikernel/tests/entropy_rv.nu
+++ b/unikernel/tests/entropy_rv.nu
@@ -1,0 +1,36 @@
+// unikernel/tests/entropy_rv.nu — is the entropy real?
+//
+// Two draws, and the two ways a fake source looks plausible: all
+// zeroes (a device that answered without writing), and two draws that
+// match (a source that is a constant, or a buffer read twice). The
+// gate also runs this WITHOUT a virtio-rng device, where the machine
+// must refuse by name instead of returning something.
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/io.nu`
+
+& `c` @ nurl_rand_fill *u buf i n → i
+
+@ main → i {
+    : ( Vec u ) b ( vec_with_cap [u] 32 )
+    ( vec_set_len [u] b 32 )
+    : i r ( nurl_rand_fill ( vec_data [u] b ) 32 )
+    ( nurl_print `rand_fill=` ) ( nurl_print_int r ) ( nurl_print `\n` )
+    // Two draws must differ, and neither may be all zeroes — the two
+    // ways a fake entropy source looks plausible.
+    : ~ i zeros 0
+    : ~ i k 0
+    ~ < k 32 { ? == # i . ( vec_data [u] b ) k 0 { = zeros + zeros 1 } {} = k + k 1 }
+    ( nurl_print `zeros=` ) ( nurl_print_int zeros ) ( nurl_print `\n` )
+    : ( Vec u ) c ( vec_with_cap [u] 32 )
+    ( vec_set_len [u] c 32 )
+    : i r2 ( nurl_rand_fill ( vec_data [u] c ) 32 )
+    : ~ i same 0
+    : ~ i j 0
+    ~ < j 32 {
+        ? == # i . ( vec_data [u] b ) j # i . ( vec_data [u] c ) j { = same + same 1 } {}
+        = j + j 1
+    }
+    ( nurl_print `same_bytes=` ) ( nurl_print_int same ) ( nurl_print `\n` )
+    ( vec_free [u] b ) ( vec_free [u] c )
+    ^ 0
+}


### PR DESCRIPTION
The RISC-V port shipped with an honest refusal: no entropy
**instruction** exists there (the `seed` CSR is optional Zkr, absent in
QEMU's rv64), so `getrandom` panicked and named what was missing. The
answer it was waiting for is a **device**.

- `boot/virtio_rng.c` — C in the boot layer, the same layer x86
  answers with RDRAND and AArch64 with RNDR. Deliberately **not**
  `hal/virtq.nu`: `getrandom` must work with no NURL module linked,
  for a program that never touches the socket layer. One queue, one
  buffer, version bit only.
- Trusts the device for **bytes, not the count** — one claiming to
  have written past the buffer is refused. A device that never answers
  ends the wait instead of spinning inside a key generation.
- `boot/fdt.c` now reports **where** the virtio devices are (the boot
  layer has its own driver; re-parsing the cmdline it just synthesized
  would be one conversion too many). The AArch64 twin declaration was
  updated in the same commit — a drifting twin reads the wrong fields.

**Measured**: with `-device virtio-rng-device`, an RSA-2048 **TLS 1.3
handshake completes in 84 s under TCG** — the interpreter's price, not
the protocol's. The first attempt looked like a broken handshake and
was a 10 s *client* timeout: on this emulator the guest is slow, not
wrong.

**Gate checks both halves** (a fake source passes the obvious one):
with the device, 32 bytes, none zero, a second draw sharing no byte
with the first; without it, exit 127 and a refusal naming the device.

RV64 gate **16/16**; AArch64 stayed **15/15**; x86 corpus **452 / 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1