### PR TITLE
release: 0.35.0 — the three architectures release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] — 2026-08-07
+
 ### Added
 
 - **TLS works on RISC-V: entropy from a virtio-rng device**
@@ -77,49 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request for randomness, naming what is missing, instead of inventing
   it.
 
-### Changed
-
-- **The device-tree walk is shared rather than copied**
-  (`unikernel/boot/fdt.c`). AArch64 and RISC-V need the same three
-  answers out of the same format, and the third port is the right
-  moment to stop copying the second's. Generalising it found a real
-  narrowness in the AArch64 original: it classified nodes at a
-  hard-coded depth, and RISC-V's virt puts its devices under `/soc`
-  where AArch64's puts them at the root — so the walker found nothing
-  and the guest reported "no virtio-net device" about a machine that
-  had one. Nodes are now classified by NAME at any depth, with
-  address/size cells tracked per level because a bus node may state
-  its own.
-
-- **The image is not a QEMU image, and there is now a gate that says
-  so** (plan phase U7). Firecracker and cloud-hypervisor both boot an
-  x86_64 kernel by reading the same `XEN_ELFNOTE_PHYS32_ENTRY` note
-  QEMU reads, so the artifact needs no repackaging for either.
-  `unikernel/tests/hypervisor_gate.sh` checks the note structurally on
-  any machine — present, owned by `Xen`, type 18, four-byte
-  descriptor, and the address in it **equal to the ELF's entry point**,
-  which are set by two different files and whose disagreement is a
-  boot that works under one loader and not another — and then boots
-  the image under cloud-hypervisor and Firecracker where `/dev/kvm`
-  exists, skipping loudly where it does not (neither has an
-  interpreter fallback). Three mutations (entry moved, note type
-  changed, section renamed) are all caught. On AArch64 the gate gives
-  the honest answer instead: PVH is x86-only, QEMU's virt board loads
-  the ELF directly, and the other two want a PE-format `Image` there —
-  a packaging step not taken rather than a property claimed.
-
-- **The playground builds AArch64 unikernel images too.** `POST
-  /build_unikernel` takes `arch` (`"x86_64"` default, `"aarch64"`),
-  the MCP tool takes the same field, and the target dropdown gains
-  **Unikernel AArch64 · bootable image (QEMU virt)**. Everything the
-  x86_64 path already had follows the field: the smoke boot runs
-  `qemu-system-aarch64 -M virt`, the returned boot commands name the
-  right machine, and the AArch64 ones carry no `tsc_khz=` because that
-  clock states its own frequency. An unknown arch is a 400, never a
-  silent build for the default — an image that builds, downloads and
-  does not boot is the worst possible answer. e2e covers both
-  architectures end to end, including the guest console from each.
-
 - **A NURL program boots as its own kernel on AArch64 too** (unikernel
   plan phase U6). QEMU's `virt` board, and the port is the size the
   design predicted: **four files** differ — `boot/boot_arm64.S`
@@ -154,18 +113,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   canary `__thread` back through the compiler's own addressing, and
   refuses to run if the value is not there — a thread-local block off
   by sixteen bytes reads plausible garbage.
-
-### Fixed
-
-- **nolibc was missing `getchar`** and nothing noticed, because
-  glibc's `<stdio.h>` defines it as a macro (`getc(stdin)`) — every
-  x86 build resolved the call in the preprocessor and never reached
-  the library. A libc whose completeness depends on which headers
-  happen to be installed is not complete; the AArch64 port, whose
-  headers declare it as a function, found it at the link line.
-  `nolibc/math.c`'s `sqrt` likewise assumed `sqrtsd`; it now selects
-  the architecture's instruction and refuses to compile (rather than
-  answer differently) on one where neither is known.
 
 - **MCP tool `nurl_build_unikernel`** (plan phase U5). An agent builds
   a bootable image and — because the tool's `boot` defaults ON, and an
@@ -232,6 +179,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The device-tree walk is shared rather than copied**
+  (`unikernel/boot/fdt.c`). AArch64 and RISC-V need the same three
+  answers out of the same format, and the third port is the right
+  moment to stop copying the second's. Generalising it found a real
+  narrowness in the AArch64 original: it classified nodes at a
+  hard-coded depth, and RISC-V's virt puts its devices under `/soc`
+  where AArch64's puts them at the root — so the walker found nothing
+  and the guest reported "no virtio-net device" about a machine that
+  had one. Nodes are now classified by NAME at any depth, with
+  address/size cells tracked per level because a bus node may state
+  its own.
+
+- **The image is not a QEMU image, and there is now a gate that says
+  so** (plan phase U7). Firecracker and cloud-hypervisor both boot an
+  x86_64 kernel by reading the same `XEN_ELFNOTE_PHYS32_ENTRY` note
+  QEMU reads, so the artifact needs no repackaging for either.
+  `unikernel/tests/hypervisor_gate.sh` checks the note structurally on
+  any machine — present, owned by `Xen`, type 18, four-byte
+  descriptor, and the address in it **equal to the ELF's entry point**,
+  which are set by two different files and whose disagreement is a
+  boot that works under one loader and not another — and then boots
+  the image under cloud-hypervisor and Firecracker where `/dev/kvm`
+  exists, skipping loudly where it does not (neither has an
+  interpreter fallback). Three mutations (entry moved, note type
+  changed, section renamed) are all caught. On AArch64 the gate gives
+  the honest answer instead: PVH is x86-only, QEMU's virt board loads
+  the ELF directly, and the other two want a PE-format `Image` there —
+  a packaging step not taken rather than a property claimed.
+
+- **The playground builds AArch64 unikernel images too.** `POST
+  /build_unikernel` takes `arch` (`"x86_64"` default, `"aarch64"`),
+  the MCP tool takes the same field, and the target dropdown gains
+  **Unikernel AArch64 · bootable image (QEMU virt)**. Everything the
+  x86_64 path already had follows the field: the smoke boot runs
+  `qemu-system-aarch64 -M virt`, the returned boot commands name the
+  right machine, and the AArch64 ones carry no `tsc_khz=` because that
+  clock states its own frequency. An unknown arch is a 400, never a
+  silent build for the default — an image that builds, downloads and
+  does not boot is the worst possible answer. e2e covers both
+  architectures end to end, including the guest console from each.
+
 - **`unikernel/build_unikernel.sh` is a tool now, not a repo-rooted
   script** (unikernel-in-the-playground plan, phase U0). It takes
   `--out-dir`, compiles the program-independent objects once into a
@@ -248,6 +236,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   properties are pinned by a new unit gate
   (`unikernel/tests/build_tool_gate.sh`): foreign-cwd build,
   read-only repo, concurrent byte-identical ELFs, loud failure.
+
+### Fixed
+
+- **nolibc was missing `getchar`** and nothing noticed, because
+  glibc's `<stdio.h>` defines it as a macro (`getc(stdin)`) — every
+  x86 build resolved the call in the preprocessor and never reached
+  the library. A libc whose completeness depends on which headers
+  happen to be installed is not complete; the AArch64 port, whose
+  headers declare it as a function, found it at the link line.
+  `nolibc/math.c`'s `sqrt` likewise assumed `sqrtsd`; it now selects
+  the architecture's instruction and refuses to compile (rather than
+  answer differently) on one where neither is known.
 
 ## [0.34.0] — 2026-08-07
 
@@ -11057,7 +11057,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.34.0...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.35.0...HEAD
+[0.35.0]: https://github.com/nurl-lang/nurl/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/nurl-lang/nurl/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/nurl-lang/nurl/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/nurl-lang/nurl/compare/v0.31.1...v0.32.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NURL takes a few design positions that are uncommon together:
 - **Locally parseable** — a construct's shape (arity and nesting) is fixed by a short window of surrounding tokens, with no long-range parse dependencies. (A few operators — `.`, `&`, `|`, `#` — resolve their *lowering* by operand type; see [`docs/spec.md`](docs/spec.md) §4.9/§6.)
 - **Deterministic compiler** — the same source always produces identical output, with no platform-dependent codegen. The self-hosted compiler reaches a byte-identical fixed point on its own source. (Raw `*T` pointers and out-of-range shifts inherit LLVM semantics — spec §4.2, §6.1.)
 - **Single-owner memory + default-on static borrow checker** — auto-drop at scope exit, plus a diagnostic pass (on by default, `--no-borrowck` to disable) that catches use-after-move, alias-double-free, escaping closure-captures, and iterator invalidation as hard errors.
-- **LLVM-based codegen, broad platform reach** — one pipeline targets Linux, macOS, Windows, wasm32-wasi, RISC-V, and ARM64.
+- **LLVM-based codegen, broad platform reach** — one pipeline targets Linux, macOS, Windows, wasm32-wasi, RISC-V, and ARM64 — and a NURL program can **boot as its own kernel**: bootable unikernel images (no host OS, no libc) on x86_64, AArch64 and RISC-V64. See [`unikernel/README.md`](unikernel/README.md).
 
 A reproducible benchmark suite lives in [`bench/`](bench/): 15 benchmarks
 implemented five times each — NURL, C, Rust, Node and Python — with every row
@@ -208,6 +208,7 @@ pure-NURL runtime. Details: [`docs/TOOLING.md`](docs/TOOLING.md).
 | Distributed stack (NAT traversal, overlay, SWIM, CRDTs) | [`docs/DISTRIBUTED.md`](docs/DISTRIBUTED.md) |
 | HTTP API, playground & MCP server | [`docs/PLAYGROUND.md`](docs/PLAYGROUND.md) |
 | Platforms — codegen targets & host OSes (incl. FreeBSD) | [`docs/PLATFORMS.md`](docs/PLATFORMS.md) |
+| Unikernel — a NURL program as its own kernel | [`unikernel/README.md`](unikernel/README.md) |
 | Known limitations | [`docs/LIMITATIONS.md`](docs/LIMITATIONS.md) |
 | Gotchas (compiler-diagnosed) | [`docs/GOTCHAS.md`](docs/GOTCHAS.md) |
 | Compiler internals (for contributors) | [`docs/dev/COMPILER_INTERNALS.md`](docs/dev/COMPILER_INTERNALS.md) |
@@ -236,6 +237,7 @@ nurl/
 │   └── runtime.o, …      — runtime objects (build outputs of build.sh)
 ├── examples/               — curated .nu programs (see examples/README.md)
 ├── nurlapi/                — NURL-native container: compiler-as-a-service + playground + MCP
+├── unikernel/              — bootable unikernel images (x86_64 / AArch64 / RISC-V64)
 ├── tooling/vscode-nurl/    — editor extension (syntax + LSP client)
 ├── tools/                  — nurl-lsp, nurlfmt, nurlpkg build scripts
 ├── docs/                   — topic documentation (see the table above)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-03 · Current release: **0.32.0** · Language: **Grammar
+_Last reviewed: 2026-08-07 · Current release: **0.35.0** · Language: **Grammar
 v2.3** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---
@@ -45,8 +45,10 @@ What is solid today:
   stack, database clients, distributed systems (p2p overlay, CRDTs), MCP, and the Anthropic Claude API.
 - **Targets.** Linux x86_64 (primary, CI-tested), Windows x86_64 (CI-built,
   corpus runs locally), macOS x86_64/ARM64 (cross-compiled Mach-O — no CI, no
-  prebuilt toolchain), `wasm32-wasi`, and static Linux ARM64 / RISC-V64
-  (musl). Tier definitions: [`docs/PLATFORMS.md`](docs/PLATFORMS.md).
+  prebuilt toolchain), `wasm32-wasi`, static Linux ARM64 / RISC-V64
+  (musl), and **bootable unikernel images** — a NURL program as its own
+  kernel on x86_64, AArch64 and RISC-V64, no host OS and no libc.
+  Tier definitions: [`docs/PLATFORMS.md`](docs/PLATFORMS.md).
 - **Tooling.** `nurlc` (compiler), `nurlfmt` (canonical formatter), `nurl-lsp`
   (language server), `nurlpkg` (package manager + test/bench runner), `nurldoc`
   (API-doc generator), `tools/repl`, DWARF debug info (`--g`), a
@@ -170,6 +172,17 @@ platform-specific shims.
   under the reference `wasmtime` and under this pure-NURL runtime.
 - Static cross-compiles: Linux ARM64 / RISC-V64 (musl). Milk-V Duo (RISC-V
   C906) validated on-device.
+- **Unikernel: a NURL program boots as its own kernel** — no host OS, no
+  libc, no interpreter — on three architectures: x86_64 (QEMU microvm,
+  and the same PVH image boots under Firecracker and cloud-hypervisor),
+  AArch64 and RISC-V64 (QEMU virt; on AArch64 a flat `Image` wrapper
+  covers Firecracker/cloud-hypervisor). Per-arch QEMU gates run the
+  hosted corpus against the same goldens (15/15 each), with virtio
+  net/rng drivers, TLS handshakes in the guest, native fiber switches
+  on all three ISAs, and CI booting every architecture on every commit.
+  The playground builds and boots these images (`POST /build_unikernel`
+  + target dropdown), and agents do the same over MCP
+  (`nurl_build_unikernel`).
 - `nurlfmt` canonical formatter (idempotent, IR-preserving), `nurl-lsp`
   (completion, references, unused-symbol lint), `nurlpkg` package manager,
   DWARF debugging, VS Code extension, and the `nurlapi` compiler-as-a-service

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -56,6 +56,8 @@ container's cross-compile endpoints (see [`PLAYGROUND.md`](PLAYGROUND.md)).
 | macOS ARM64 | LLVM + zig cc | 3 | `POST /build_target` (`target=macos-arm64`) — native Apple Silicon Mach-O, links only libSystem. Unsigned: clear quarantine before running |
 | WebAssembly | wasm32-wasi | 3 | via the `nurlapi/` container (WASI SDK 24.0); browser execution via `browser_wasi_shim`. The self-hosting compiler itself also builds to wasm — see [`PLAYGROUND.md`](PLAYGROUND.md) |
 | Linux ARM64 / RISC-V64 | LLVM + zig cc | 3 | `POST /build_target` — fully-static `musl` ELFs (`linux-arm64-musl`, `linux-riscv64-musl`) or dynamic glibc (`linux-arm64-gnu`). Milk-V Duo (RISC-V C906) validated on-device (one-off, not CI) |
+| Unikernel x86_64 | LLVM + unikernel nolibc | 1 | the program **boots as its own kernel** — PVH ELF for QEMU microvm, and the same image boots under Firecracker and cloud-hypervisor. The guest gate (corpus subset against hosted goldens, device demos, faults, an HTTP server answering the host — not the full corpus) runs in CI on every change and blocks merge. `POST /build_unikernel` in the playground. See [`unikernel/README.md`](../unikernel/README.md) |
+| Unikernel AArch64 / RISC-V64 | LLVM + zig cc + unikernel nolibc | 1 | QEMU `virt`; AArch64 also emits a flat `Image` for Firecracker / cloud-hypervisor (those need an ARM64 host). Per-arch QEMU gates (same scope as x86_64's) run in CI on every change and block merge. AArch64 via `POST /build_unikernel` `arch` |
 | Android / iOS | LLVM cross | — | planned |
 | Embedded (no_std) | LLVM | — | planned |
 

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -34,7 +34,17 @@ and serves a public **MCP endpoint** at `/mcp`.
   `linux-{x64,arm64,riscv64}-musl` (fully-static ELF), `linux-arm64-gnu`
   (dynamic glibc), `macos-{x64,arm64}` (Mach-O incl. native Apple Silicon).
   Body adds `"target":"<id>"`. canvas/audio/HTTP unsupported on these targets.
-- `GET /targets` — list every selectable compile target (the playground's
+- `POST /build_unikernel` — build a **bootable unikernel image**: the
+  program compiled freestanding (unikernel nolibc + `runtime_bare`, no
+  host OS) into an x86_64 PVH ELF (QEMU microvm; the same image boots
+  under Firecracker and cloud-hypervisor) or, with `"arch":"aarch64"`,
+  an ELF + flat `Image` for QEMU `virt`. Optional `"args"` (the guest's
+  argv — returned inside the boot command, never executed server-side),
+  `"files"` (`{relative/path: base64}` baked in as a read-only
+  filesystem) and `"boot": true` (boot the image server-side and return
+  the guest console + exit status). The reply carries the artifact plus
+  ready-to-paste QEMU commands. The same build is exposed to agents as
+  MCP tool `nurl_build_unikernel`.
   **Target** dropdown is built from this).
 - `GET /download/{build_id}/{filename}` — stream a build artifact
   produced by a `/build*` endpoint. Artifacts expire automatically

--- a/nurlapi/README.md
+++ b/nurlapi/README.md
@@ -18,8 +18,11 @@
     - **WebAssembly** — WASI SDK 24 + `wasm-opt` (binaryen) for Asyncify
   - **Pure-NURL HTTP API** (`nurlapi/main.nu`, compiled to a native binary at image-build time) with `/build`, `/build_wasm`, `/build_windows`,
     `/build_macos`, `/build_target`, `/build_unikernel` (a bootable
-    x86_64 PVH image + ready-to-paste QEMU boot commands; `files` bakes
-    a read-only filesystem into the image) build endpoints and `/targets` (the
+    unikernel image — x86_64 PVH/microvm by default, AArch64 QEMU virt
+    via `arch` — plus ready-to-paste QEMU boot commands; `files` bakes
+    a read-only filesystem into the image, `boot: true` boots it
+    server-side and returns the guest console; also exposed as MCP tool
+    `nurl_build_unikernel`) build endpoints and `/targets` (the
     cross-compile target registry the playground's dropdown is built from). HTTP server, router, JSON, MCP transport — all stdlib (`stdlib/ext/http_*.nu`, `stdlib/ext/json.nu`, `stdlib/ext/mcp_*.nu`).
   - **Browser playground** at `/` — Monaco editor, examples dropdown, build+run in-page via
   [`@bjorn3/browser_wasi_shim`](https://github.com/bjorn3/browser_wasi_shim).

--- a/nurlweb/public/index.html
+++ b/nurlweb/public/index.html
@@ -445,6 +445,7 @@
       <div class="target"><span class="dot"></span><span class="name">WebAssembly</span><span class="meta">wasm32-wasi · in-browser</span></div>
       <div class="target"><span class="dot"></span><span class="name">Linux ARM64</span><span class="meta">musl + glibc · playground</span></div>
       <div class="target"><span class="dot"></span><span class="name">Linux RISC-V 64</span><span class="meta">static musl · playground</span></div>
+      <div class="target"><span class="dot"></span><span class="name">Unikernel (x64 · ARM64 · RISC-V)</span><span class="meta">boots as its own kernel · CI every push</span></div>
       <div class="target"><span class="dot"></span><span class="name">Milk-V Duo</span><span class="meta">riscv64 C906 · on-device</span></div>
       <div class="target"><span class="dot"></span><span class="name">ESP32 (Xtensa)</span><span class="meta">flashed &amp; verified</span></div>
       <div class="target"><span class="dot"></span><span class="name">ESP32-C3/C6</span><span class="meta">RISC-V firmware ELF</span></div>
@@ -465,6 +466,15 @@
       downloadable binaries for Linux (x86_64 / ARM64 / RISC-V), Windows, and macOS
       (x86_64 + ARM64). The self-hosting compiler itself also builds to wasm, so the
       entire toolchain can run in a sandbox.
+    </p>
+    <p class="section-note">
+      <strong>A NURL program can boot as its own kernel.</strong>
+      The playground's <code>/build_unikernel</code> endpoint links your program
+      freestanding — no host OS, no libc — into a bootable image for x86_64
+      (QEMU microvm, Firecracker, cloud-hypervisor) or AArch64 (QEMU virt), boots
+      it server-side, and shows you the guest console. RISC-V 64 boots in the
+      repository's QEMU gate. Pure-NURL TCP/IP and TLS run inside the guest.
+      Sources: <a href="https://github.com/nurl-lang/nurl/tree/main/unikernel" target="_blank" rel="noopener">unikernel/</a>.
     </p>
   </div>
 </section>


### PR DESCRIPTION
Cuts **v0.35.0** (2026-08-07).

## Highlights (already merged, #801–#812)

- **A NURL program boots as its own kernel on three architectures** — x86_64, AArch64, RISC-V64. Per-arch QEMU gates 15/15, CI boots all three on every commit.
- **Hypervisors**: the x86_64 PVH image boots unmodified under Firecracker and cloud-hypervisor (structural gate on the PVH note); AArch64 gets a flat `Image` wrapper for the same two.
- **TLS on RISC-V**: no entropy instruction on that ISA — entropy comes from a virtio-rng device, and a machine without one refuses by name.
- **The playground builds and boots unikernel images** (`POST /build_unikernel`, target dropdown, measured per-example capability) and so do agents over MCP (`nurl_build_unikernel`).

## What this PR does

- **CHANGELOG**: restructures `[Unreleased]` — the U1–U5 and U6 feature entries had accumulated under `### Fixed`/`### Changed`, and `### Changed` appeared twice; now Added/Changed/Fixed each once. Cuts the `[0.35.0]` section and adds compare links (previous release's links were already correct).
- **ROADMAP**: header `0.32.0 / 2026-08-03` → `0.35.0 / 2026-08-07`; the unikernel — absent from the document entirely — now appears in *Status at a glance* (Targets) and *Targets & tooling*.

After merge: verify clean CI on the merge SHA, then tag `v0.35.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1