### PR TITLE
fix: the AArch64 fiber asm now speaks Mach-O too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,23 @@ jobs:
             "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
           mkdir -p /opt/zig && sudo tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1
 
+      - name: runtime.c compiles for every playground cross target
+        # The playground image warms stdlib/runtime.<target>.o for six
+        # zig targets at docker-build time (nurlapi/Dockerfile), two of
+        # them Mach-O — an object format nothing else in this workflow
+        # assembles. The v0.35.0 deploy found that out: the AArch64
+        # fiber switch's adrp/:lo12: pair is ELF spelling, and the
+        # release tag was the first build to feed it to a Mach-O
+        # assembler. Compile the same file for the same targets here,
+        # so the next such mismatch fails the PR instead of the deploy.
+        run: |
+          set -eux
+          for t in x86_64-macos-none aarch64-macos-none \
+                   x86_64-linux-musl aarch64-linux-musl \
+                   aarch64-linux-gnu.2.31 riscv64-linux-musl; do
+            /opt/zig/zig cc -target "$t" -O2 -c stdlib/runtime.c -o /tmp/rt-gate.o
+          done
+
       - name: The guest, on the THIRD architecture
         # …including the entropy gate: this ISA has no instruction for
         # randomness, so the RISC-V guest drives a virtio-rng device

--- a/stdlib/runtime_ctx.c
+++ b/stdlib/runtime_ctx.c
@@ -84,6 +84,19 @@
 #  define NURL_CTX_SYM(name) #name
 #endif
 
+/* The adrp/add pair that materialises a symbol's address needs the same
+ * treatment: ELF spells the two halves `sym` and `:lo12:sym`, Mach-O
+ * spells them `sym@PAGE` and `sym@PAGEOFF` — each assembler rejects the
+ * other's form. Both symbols this is used on are static locals of this
+ * file, so no GOT indirection is needed on either format. */
+#if defined(__APPLE__)
+#  define NURL_CTX_PAGE(name)    NURL_CTX_SYM(name) "@PAGE"
+#  define NURL_CTX_PAGEOFF(name) NURL_CTX_SYM(name) "@PAGEOFF"
+#else
+#  define NURL_CTX_PAGE(name)    NURL_CTX_SYM(name)
+#  define NURL_CTX_PAGEOFF(name) ":lo12:" NURL_CTX_SYM(name)
+#endif
+
 typedef struct { void *sp; } nurl_ctx_t;
 
 /* ── ASan fiber annotations ──────────────────────────────────────────
@@ -583,10 +596,10 @@ static void nurl__ctx_bounce(void *arg)
         "mov x23, x19\n\t"
         "1:\n\t"
         "bl " NURL_CTX_SYM(nurl__ctx_test_leave) "\n\t"
-        "adrp x0, " NURL_CTX_SYM(nurl__ctx_fiber) "\n\t"
-        "add  x0, x0, :lo12:" NURL_CTX_SYM(nurl__ctx_fiber) "\n\t"
-        "adrp x1, " NURL_CTX_SYM(nurl__ctx_main) "\n\t"
-        "add  x1, x1, :lo12:" NURL_CTX_SYM(nurl__ctx_main) "\n\t"
+        "adrp x0, " NURL_CTX_PAGE(nurl__ctx_fiber) "\n\t"
+        "add  x0, x0, " NURL_CTX_PAGEOFF(nurl__ctx_fiber) "\n\t"
+        "adrp x1, " NURL_CTX_PAGE(nurl__ctx_main) "\n\t"
+        "add  x1, x1, " NURL_CTX_PAGEOFF(nurl__ctx_main) "\n\t"
         "bl " NURL_CTX_SYM(nurl_ctx_switch) "\n\t"
         "bl " NURL_CTX_SYM(nurl__ctx_test_enter) "\n\t"
         "b 1b\n\t"


### PR DESCRIPTION
**Deploy playground API failed on the v0.35.0 tag** — reproduced locally with `startdev.sh`'s `docker build`, same six errors at builder step 15/16 (`aarch64-macos-none`).

## Root cause

`runtime_ctx.c`'s AArch64 test fiber (added with the AArch64 unikernel port, #807) materialises `nurl__ctx_fiber`/`nurl__ctx_main` addresses with `adrp x0, sym` + `add x0, x0, :lo12:sym` — ELF spelling. Mach-O's assembler requires `sym@PAGE` / `sym@PAGEOFF`. The `_` symbol prefix was already handled (`NURL_CTX_SYM`); the relocation operand was not. No repo gate assembles this file for Mach-O AArch64 — the playground Dockerfile's warm step (six zig cross targets, triggered by the release tag) was the first to try.

## Fix

- `NURL_CTX_PAGE` / `NURL_CTX_PAGEOFF` macros beside `NURL_CTX_SYM`: `@PAGE`/`@PAGEOFF` on `__APPLE__`, previous text verbatim on ELF (byte-identical asm on every already-passing target).
- New ci.yml gate in the unikernel job: compile `stdlib/runtime.c` for the same six targets the Dockerfile warms (`x86_64/aarch64-macos-none`, `x86_64/aarch64/riscv64-linux-musl`, `aarch64-linux-gnu.2.31`). ~10 s; zig is already fetched in that job.

## Verified

- All six warm targets compile with the bundled zig 0.13.0.
- `docker build -f nurlapi/Dockerfile` completes (previously failed at 15/16).
- Container starts under startdev.sh's hardening flags, `/health` OK, `POST /build_unikernel {boot:true}` boots a hello guest to exit 0.

After merge: re-run **Deploy playground API** via workflow_dispatch (no new tag needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSFvDeM5bViW3ZTNmNbnW1