### PR TITLE
MCP: nurl_docs, and nurl_api answers concept queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP tool `nurl_docs` — the documentation tree an agent could not
+  reach.** `nurl_api` answers "what is the signature"; it never answers
+  "who frees this", "which cipher suites ship", or "does this target
+  have threads". Those answers live in `docs/MEMORY.md`,
+  `docs/CRYPTO.md` and `docs/PLATFORMS.md`, and until now exactly one of
+  the fourteen documents had a tool (`nurl_read_gotchas`) — so a model
+  driving NURL through MCP guessed at precisely the questions the
+  project has already written down. `nurl_docs` with no argument lists
+  the tree (path, size, title); with `name=` it returns one document.
+  The name is matched forgivingly — `MEMORY`, `memory.md`,
+  `docs/MEMORY.md` and `./memory.md` all reach the same file, and a bare
+  basename reaches a nested one (`COMPILER_INTERNALS` →
+  `dev/COMPILER_INTERNALS.md`) — because a model that has to guess the
+  exact spelling will spend calls guessing it. Documents are capped at
+  48 KB per call and the truncation line prints the exact `offset` to
+  pass for the rest, so `spec.md` is reachable in two calls instead of
+  being silently cut. A name that matches nothing answers with the index
+  rather than a bare error, which turns a wrong guess into the right
+  next call. Both servers expose it: the hosted playground
+  (`NURL_DOCS_DIR`, default `/opt/nurl/docs`) and the local `nurl-mcp`
+  package (`$NURL_DOCS`, else `$NURL_STDLIB/docs`) —
+  `install-toolchain.{sh,bat}` now ship `docs/` into the prefix, so an
+  installed toolchain carries its own documentation.
+
+### Changed
+
+- **`nurl_api` answers concept queries instead of shrugging at them.**
+  The query search AND-matches its terms, which is right when a model
+  names one thing two ways and wrong when it names a concept: nothing in
+  the stdlib is one declaration that contains all of `string`, `builder`
+  and `append`, and `vec_push new string_new` is three *different*
+  functions. Both used to return zero and jump straight to examples and
+  the package registry — past `string_push_str`, which was sitting right
+  there. Now a zero-hit query is re-run as an OR over the same
+  declaration blocks, with two rules that keep the result small. Terms
+  match as WHOLE words (the adjacent byte must not be a letter, so
+  `string` hits `string_push_str`, `string_new` and "a string", and
+  misses `substring`), and each hit is ranked by how much of the query it
+  covers — terms weighted by LENGTH, since `new` is three characters half
+  the constructors contain while `vec_push` is eight that name one
+  function, and a term in the declaration's own name outranks one in its
+  prose. The top twelve come back labelled `[2/3 terms]`. Only if the OR
+  pass finds nothing does the reply widen to examples and the registry as
+  before, so the corpus fallback no longer buries a real answer. Shared
+  engine (`stdlib/ext/mcp_search.nu`), so the playground and the local
+  `nurl-mcp` gained it together.
+
 ## [0.35.0] — 2026-08-07
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,8 +39,10 @@ FreeBSD archive if that VM build fails. Use the `workflow_dispatch` input
 for a dry run that builds the artifacts without publishing.
 
 An archive is just the `~/.nurl` layout (`bin/`, `build/`, `stdlib/`,
-`nurl.{sh,bat}`, `env`) with shims that resolve their own location, so it
-works wherever it is unpacked.
+`docs/`, `nurl.{sh,bat}`, `env`) with shims that resolve their own
+location, so it works wherever it is unpacked. `docs/` is the prose tree
+the nurl-mcp `nurl_docs` tool serves, so an installed toolchain answers
+questions about ownership, crypto and platforms without the network.
 
 ## Runtime dependencies (dynamic linking)
 

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -132,6 +132,19 @@ Cursor, Windsurf, Zed and other MCP-capable IDEs accept the same URL
   native Linux / Windows / macOS / cross targets / wasm), *browse* (list
   examples, stdlib, tests), and *read* (examples, stdlib, tests, grammar,
   readme, roadmap, gotchas).
+- **Search** — `nurl_api` (a module's or a registry package's API surface,
+  or a term search over every stdlib declaration) and `nurl_grep` (ranked
+  substring search across stdlib, examples, tests and the registry).
+  A `nurl_api` query no single declaration satisfies is re-run as a
+  whole-word OR ranked by coverage, so a concept-shaped query — the kind a
+  model actually types, `string builder append` or `vec_push new
+  string_new` — lands on the real functions instead of an empty result.
+- **`nurl_docs`** — this documentation tree, the questions the API surface
+  cannot answer: `MEMORY.md` (who frees what, and when), `CRYPTO.md`,
+  `ASYNC.md`, `PLATFORMS.md`, `spec.md`, `dev/COMPILER_INTERNALS.md`, …
+  No argument lists everything with its size and title; `name=` returns one
+  document (the `docs/` prefix and `.md` suffix optional), `offset=` pages
+  past 48 KB.
 - **Resources** mirroring the read-tools as `nurl://` URIs (`nurl://grammar`,
   `nurl://readme`, `nurl://stdlib/<path>`, `nurl://example/<name>`, …) for
   clients that prefer resource semantics.

--- a/nurlapi/e2e_test.py
+++ b/nurlapi/e2e_test.py
@@ -188,12 +188,13 @@ def t_mcp_info(c: Client) -> None:
     assert_eq("transport", j.get("transport"), "streamable-http")
     assert_eq("url_path", j.get("url_path"), "/mcp")
     tools = j.get("tools", [])
-    assert_eq("18 tools advertised", len(tools), 18)
+    assert_eq("20 tools advertised", len(tools), 20)
     for t in (
         "nurl_build_native",
         "nurl_build_wasm",
         "nurl_list_examples",
         "nurl_read_grammar",
+        "nurl_docs",
         "nurl_changelog",
         "nurl_api",
         "nurl_grep",
@@ -267,7 +268,7 @@ def t_tools_list(c: Client) -> None:
     print("\n[MCP] tools/list")
     _, _, env = c.rpc({"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
     tools = env.get("result", {}).get("tools", [])
-    assert_eq("18 tools", len(tools), 18)
+    assert_eq("20 tools", len(tools), 20)
     names = {t.get("name") for t in tools}
     for required in (
         "nurl_build_native",
@@ -285,6 +286,7 @@ def t_tools_list(c: Client) -> None:
         "nurl_read_readme",
         "nurl_read_roadmap",
         "nurl_read_gotchas",
+        "nurl_docs",
         "nurl_changelog",
         "nurl_api",
         "nurl_grep",
@@ -388,6 +390,56 @@ def t_tools_call_changelog(c: Client) -> None:
     assert_true("no-match has guidance", "No matches" in text)
 
 
+def t_tools_call_docs(c: Client) -> None:
+    print("\n[MCP] tools/call nurl_docs (index / read / forgiving names / paging)")
+
+    # No arguments → the index of everything under docs/.
+    env = _tool_call(c, "nurl_docs", {})
+    text = _tool_text(env)
+    assert_true("index reports a count", "document(s) under docs/" in text)
+    assert_true("index lists MEMORY.md", "MEMORY.md" in text)
+    assert_true("index lists a nested doc", "dev/COMPILER_INTERNALS.md" in text)
+    assert_true("index carries titles", "NURL Memory Model" in text)
+
+    # Exact name.
+    env = _tool_call(c, "nurl_docs", {"name": "CRYPTO.md"})
+    text = _tool_text(env)
+    assert_true("read echoes the path", text.startswith("docs/CRYPTO.md"))
+    assert_true("read returns the body", "Cryptography & TLS" in text)
+
+    # The 'docs/' prefix, the '.md' suffix and the case are all optional,
+    # and a basename reaches a nested document.
+    for name in ("memory", "MEMORY.md", "docs/MEMORY.md", "./memory.md"):
+        env = _tool_call(c, "nurl_docs", {"name": name})
+        text = _tool_text(env)
+        assert_true(f"name {name!r} resolves to MEMORY.md", text.startswith("docs/MEMORY.md"))
+    env = _tool_call(c, "nurl_docs", {"name": "COMPILER_INTERNALS"})
+    assert_true(
+        "basename reaches the nested doc",
+        _tool_text(env).startswith("docs/dev/COMPILER_INTERNALS.md"),
+    )
+
+    # spec.md is past the 48 KB cap: the reply says where it stopped and
+    # the printed offset returns the rest.
+    env = _tool_call(c, "nurl_docs", {"name": "spec"})
+    text = _tool_text(env)
+    assert_true("oversize doc is truncated", "truncated at" in text)
+    assert_true("truncation names the next offset", "continue with offset=" in text)
+    off = int(text.split("continue with offset=")[1].split()[0])
+    env = _tool_call(c, "nurl_docs", {"name": "spec", "offset": off})
+    text = _tool_text(env)
+    assert_true("offset page reports its range", f"[bytes {off}" in text)
+
+    # Traversal is refused, and an unknown name answers with the index
+    # rather than a bare error.
+    env = _tool_call(c, "nurl_docs", {"name": "../../etc/passwd"})
+    assert_true("traversal refused", bool(env.get("result", {}).get("isError")))
+    env = _tool_call(c, "nurl_docs", {"name": "no-such-doc"})
+    res = env.get("result", {})
+    assert_true("unknown name errors", bool(res.get("isError")))
+    assert_true("unknown name lists what exists", "document(s) under docs/" in _tool_text(env))
+
+
 def t_tools_call_api(c: Client) -> None:
     print("\n[MCP] tools/call nurl_api (module / query / errors)")
 
@@ -418,11 +470,39 @@ def t_tools_call_api(c: Client) -> None:
 
     # 0-hit widening: 'calculator' exists in examples but no stdlib
     # declaration carries it — the same reply must surface the example.
+    # One term, so the OR pass (which needs two) never runs.
     env = _tool_call(c, "nurl_api", {"query": "calculator"})
     text = _tool_text(env)
     assert_true("0-hit reports widening", "widened the search" in text)
     assert_true("0-hit lists the example", "examples/calculator.nu" in text)
     assert_true("example carries its blurb", "expression evaluator" in text)
+
+    # Concept queries: no declaration holds all the terms, so the same
+    # terms are re-run as a whole-word OR ranked by coverage. This has to
+    # answer with the real functions instead of jumping to the registry.
+    env = _tool_call(c, "nurl_api", {"query": "vec_push new string_new"})
+    text = _tool_text(env)
+    assert_true("OR pass announces itself", "matching ANY term as a whole word" in text)
+    assert_true("OR pass labels coverage", "[2/3 terms]" in text)
+    assert_true("OR pass finds string_new", "string_new" in text)
+    assert_true("OR pass finds vec_push", "vec_push" in text)
+    assert_true("OR hit suppresses the corpus widening", "widened the search" not in text)
+
+    env = _tool_call(c, "nurl_api", {"query": "hash map insert"})
+    text = _tool_text(env)
+    assert_true("OR pass reaches the hashmap module", "std/hashmap.nu" in text)
+
+    # Whole-word only: 'string' must reach string_push_str, never a
+    # declaration whose only claim is the word 'substring'.
+    env = _tool_call(c, "nurl_api", {"query": "string builder append"})
+    text = _tool_text(env)
+    assert_true("OR pass ranks by module", "core/string.nu" in text)
+
+    # Nothing anywhere: two terms, no whole-word hit either — the corpus
+    # widening still has to run.
+    env = _tool_call(c, "nurl_api", {"query": "zzzqqq wwwxxx"})
+    text = _tool_text(env)
+    assert_true("dead query still widens", "widened the search" in text)
 
     # Errors: unknown module, and neither argument.
     env = _tool_call(c, "nurl_api", {"module": "ext/zzz-nope.nu"})
@@ -986,6 +1066,7 @@ def main() -> int:
     t_tools_call_listing(c)
     t_tools_call_reads(c)
     t_tools_call_changelog(c)
+    t_tools_call_docs(c)
     t_tools_call_api(c)
     t_tools_call_grep(c)
     t_tools_call_traversal(c)

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -63,6 +63,9 @@ $ `nurlapi/pptws.nu`
 
 @ get_gotchas_path → String { ^ ( env_var_or `NURL_GOTCHAS_PATH` `/opt/nurl/docs/GOTCHAS.md` ) }
 
+// The docs/ prose tree behind nurl_docs and the /docs/* routes.
+@ get_docs_dir → String { ^ ( env_var_or `NURL_DOCS_DIR` `/opt/nurl/docs` ) }
+
 @ get_license_mit_path → String { ^ ( env_var_or `NURL_LICENSE_MIT_PATH` `/opt/nurl/LICENSE-MIT` ) }
 
 @ get_license_apache_path → String { ^ ( env_var_or `NURL_LICENSE_APACHE_PATH` `/opt/nurl/LICENSE-APACHE` ) }
@@ -2087,6 +2090,7 @@ s combined_stdout s combined_stderr → v {
     ( __mcp_info_push_str tools `nurl_read_readme` )
     ( __mcp_info_push_str tools `nurl_read_roadmap` )
     ( __mcp_info_push_str tools `nurl_read_gotchas` )
+    ( __mcp_info_push_str tools `nurl_docs` )
     ( __mcp_info_push_str tools `nurl_changelog` )
     ( __mcp_info_push_str tools `nurl_api` )
     ( __mcp_info_push_str tools `nurl_grep` )
@@ -5360,6 +5364,62 @@ s combined_stdout s combined_stderr → v {
     ^ result
 }
 
+// ── nurl_docs — the docs/ prose tree ─────────────────────────────────
+//
+// nurl_api answers "what is the signature", never "who frees this" or
+// "which cipher suites ship" — those live in docs/MEMORY.md and
+// docs/CRYPTO.md. Only GOTCHAS.md had a tool, so the other dozen
+// documents were invisible to an MCP-only agent, which then guessed.
+// No 'name' lists the tree (path, size, title); a 'name' returns that
+// document, matched forgivingly ('MEMORY', 'memory.md', 'docs/MEMORY.md'
+// all land on the same file) and paged with 'offset' when it is large.
+
+@ __mcp_tool_docs Json args → Json {
+    : s name ( __mcp_args_get `name` args `` )
+    : i offset ( __mcp_args_get_int `offset` args 0 )
+    : String dd ( get_docs_dir )
+    ? == ( nurl_str_len name ) 0 {
+        : String listing ( msearch_docs_list ( string_data dd ) )
+        ( string_free dd )
+        : Json r ( __mcp_result_text ( string_data listing ) )
+        ( string_free listing )
+        ^ r
+    } {}
+    : String text ( msearch_docs_read ( string_data dd ) name offset )
+    ? == ( string_len text ) 0 {
+        // Unknown name → answer with what DOES exist rather than a bare
+        // error, so the model's next call is the right one.
+        ( string_free text )
+        : String listing ( msearch_docs_list ( string_data dd ) )
+        ( string_free dd )
+        : String msg ( string_with_cap + ( string_len listing ) 128 )
+        ( string_push_str msg `no document matches '` )
+        ( string_push_str msg name )
+        ( string_push_str msg `'. ` )
+        ( string_push_str msg ( string_data listing ) )
+        ( string_free listing )
+        : Json e ( __mcp_result_error ( string_data msg ) )
+        ( string_free msg )
+        ^ e
+    } {}
+    ( string_free dd )
+    : Json result ( __mcp_result_text ( string_data text ) )
+    ( string_free text )
+    ^ result
+}
+
+@ __mcp_schema_docs → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    : Json props ( json_obj_new )
+    ( json_obj_set props `name`
+    ( __mcp_prop `string` `Which document to return, e.g. 'MEMORY.md', 'CRYPTO.md', 'dev/COMPILER_INTERNALS.md'. The 'docs/' prefix and the '.md' suffix are both optional and matching is case-insensitive. Omit to list every document with its size and title.` ) )
+    ( json_obj_set props `offset`
+    ( __mcp_prop `integer` `Byte offset to start from (default 0). Documents are capped at 48 KB per call; a truncated reply prints the exact offset to pass next.` ) )
+    ( json_obj_set schema `properties` props )
+    ^ schema
+}
+
 @ __mcp_schema_api → Json {
     : Json schema ( json_obj_new )
     ( json_obj_set schema `type` ( json_str_lit `object` ) )
@@ -5371,7 +5431,7 @@ s combined_stdout s combined_stderr → v {
     ( json_obj_set props `version`
     ( __mcp_prop `string` `Optional package version (e.g. '0.1.1'); defaults to the latest. Only meaningful with 'package'.` ) )
     ( json_obj_set props `query`
-    ( __mcp_prop `string` `Search every stdlib module's declarations instead: space-separated terms, ALL must occur (case-insensitive) in a declaration's signature + doc comment + module path. On zero hits the search widens automatically to example programs and registry packages (name + description) in the same reply. Ignored when 'module' or 'package' is set.` ) )
+    ( __mcp_prop `string` `Search every stdlib module's declarations instead: space-separated terms, ALL must occur (case-insensitive) in a declaration's signature + doc comment + module path. When no declaration has all of them, the terms are re-run as an OR — each matched as a WHOLE word (bounded by a digit or any non-letter, so 'string' hits string_push_str but not substring) — and the best-covering declarations come back ranked, most terms covered first. Only when that finds nothing does the reply widen to example programs and registry packages. So a concept-shaped query like 'string builder append' is fine here. Ignored when 'module' or 'package' is set.` ) )
     ( json_obj_set schema `properties` props )
     ^ schema
 }
@@ -5529,6 +5589,10 @@ s combined_stdout s combined_stderr → v {
         ( string_free fp ) ^ result
     } {}
 
+    ? != 0 ( nurl_str_eq name `nurl_docs` ) {
+        ^ ( __mcp_tool_docs args )
+    } {}
+
     // Targeted changelog retrieval.
     ? != 0 ( nurl_str_eq name `nurl_changelog` ) {
         ^ ( __mcp_tool_changelog args )
@@ -5609,13 +5673,17 @@ s combined_stdout s combined_stderr → v {
     `Return docs/GOTCHAS.md verbatim — known compiler quirks with workarounds.`
     ( __mcp_schema_empty ) ) )
 
+    ( json_arr_push arr ( __mcp_tool_desc `nurl_docs`
+    `The docs/ prose tree — the questions the API surface cannot answer: MEMORY.md (ownership: who frees what, and when), CRYPTO.md (the shipped cipher suites + TLS stack), ASYNC.md (stackful fibers), BUILDING.md, PLATFORMS.md, NETWORKING.md, DISTRIBUTED.md, FORMAT.md, LIMITATIONS.md, TOOLING.md, PLAYGROUND.md, spec.md (the full language reference), dev/COMPILER_INTERNALS.md. Call with NO arguments for the index (path, size, title); then name='MEMORY.md' for one document. The 'docs/' prefix and '.md' suffix are optional, matching is case-insensitive, and 'offset' pages a document longer than 48 KB. Read this before guessing at memory, crypto, or platform behaviour — every one of these topics is documented.`
+    ( __mcp_schema_docs ) ) )
+
     // Changelog.
     ( json_arr_push arr ( __mcp_tool_desc `nurl_changelog`
     `Targeted CHANGELOG.md retrieval — the changelog is large (240+ KB) and growing, so never fetch it whole. Call with NO arguments first to get a compact index (releases + entry counts). Then pass query (space-separated terms, ALL must occur, case-insensitive) and/or release (e.g. 0.9.6 or Unreleased) to get complete changelog entries, each prefixed with its '[release] — date › category' provenance, ranked by relevance (title hits first). The top 'limit' matches come in full; every further match is listed as a one-line title so nothing relevant is invisible. Pass compact=true for a titles-only overview. Use this to find out when/whether a feature, fix, or rename happened.`
     ( __mcp_schema_changelog ) ) )
 
     ( json_arr_push arr ( __mcp_tool_desc `nurl_api`
-    `A stdlib module's API surface, a published package's API surface, or a search across all stdlib modules — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders one stdlib module's signatures + doc comments + full type definitions, no function bodies. package='nn' renders a registry package's API the same way (streamed from its tarball) — the step after a registry hit to see the functions/types it exposes. query='csv quote' finds every stdlib declaration whose signature/doc/module-path contains ALL terms (0 hits widen to examples + registry). The import-free C-runtime builtins (nurl_println, nurl_str_float, …) are indexed too, as core/builtins.nu.`
+    `A stdlib module's API surface, a published package's API surface, or a search across all stdlib modules — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders one stdlib module's signatures + doc comments + full type definitions, no function bodies. package='nn' renders a registry package's API the same way (streamed from its tarball) — the step after a registry hit to see the functions/types it exposes. query='csv quote' finds every stdlib declaration whose signature/doc/module-path contains ALL terms; if nothing contains all of them the SAME terms are re-run as a whole-word OR, ranked by how many of them each declaration covers (so 'string builder append' or 'vec_push new string_new' still lands on the real functions), and only if that finds nothing too does the search widen to examples + registry. The import-free C-runtime builtins (nurl_println, nurl_str_float, …) are indexed too, as core/builtins.nu.`
     ( __mcp_schema_api ) ) )
 
     ( json_arr_push arr ( __mcp_tool_desc `nurl_grep`

--- a/nurlweb/public/install.ps1
+++ b/nurlweb/public/install.ps1
@@ -133,7 +133,7 @@ try {
         # registry token (credentials), the model cache (models\), tool
         # assets (share\), and any program installed with `nurlpkg install`
         # (bin\<other>). Only the toolchain's own paths are removed; the
-        # archive overwrites the rest. build\, stdlib\, zig\ and libexec\
+        # archive overwrites the rest. build\, stdlib\, docs\, zig\ and libexec\
         # go wholesale so a file deleted upstream cannot linger.
         #
         # Windows cannot DELETE a running executable — and `nurl upgrade`
@@ -148,7 +148,7 @@ try {
                         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
                 }
             }
-            foreach ($d in @("build", "stdlib", "zig", "libexec")) {
+            foreach ($d in @("build", "stdlib", "docs", "zig", "libexec")) {
                 Remove-ToolchainPath (Join-Path $Prefix $d)
             }
             foreach ($f in @("nurl.bat", "nurl.sh", "env",

--- a/nurlweb/public/install.sh
+++ b/nurlweb/public/install.sh
@@ -169,7 +169,7 @@ esac
 #   bin/<other tools>    programs installed via nurlpkg install
 # Wiping the whole prefix (as this did) silently logged the user out and
 # removed every installed tool. Remove only the toolchain's OWN paths —
-# the four shipped binaries, build/, stdlib/, zig/, libexec/, the shims —
+# the four shipped binaries, build/, stdlib/, docs/, zig/, libexec/, the shims —
 # and let tar overwrite the rest. Those directories are removed wholesale
 # so a file deleted upstream cannot linger.
 #
@@ -179,7 +179,7 @@ esac
 # Windows installer has to work around the same case differently.
 if [ -e "$PREFIX" ]; then
     if [ -x "$PREFIX/bin/nurl" ] || [ -x "$PREFIX/bin/nurlc" ] || [ -z "$(ls -A "$PREFIX" 2>/dev/null)" ]; then
-        rm -rf "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/zig" "$PREFIX/libexec"
+        rm -rf "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/docs" "$PREFIX/zig" "$PREFIX/libexec"
         rm -f  "$PREFIX/nurl.sh" "$PREFIX/nurl.bat" "$PREFIX/env" \
                "$PREFIX/bin/nurl" "$PREFIX/bin/nurlc" \
                "$PREFIX/bin/nurlfmt" "$PREFIX/bin/nurlpkg"

--- a/packages/nurl-mcp/README.md
+++ b/packages/nurl-mcp/README.md
@@ -55,8 +55,9 @@ For any other client, configure an MCP server whose `command` is
 | `nurl_fmt` | `source` *or* `path` | Format to canonical form (`nurlfmt`); return the formatted source. |
 | `nurl_list_stdlib` | — | List the `.nu` modules in the installed stdlib (`$NURL_STDLIB`). |
 | `nurl_read_stdlib` | `name` | Read one stdlib module by path relative to the stdlib root (e.g. `core/string.nu`). |
-| `nurl_api` | `module` \| `query` | A module's API surface via nurldoc (signatures + doc comments + type definitions, no bodies — `ext/csv.nu` is 63 KB, its surface 11 KB), or an AND-term search over every module's declarations. Zero hits widen to the package registry; an exact package-name term is footnoted regardless. |
+| `nurl_api` | `module` \| `package` \| `query` | A module's API surface via nurldoc (signatures + doc comments + type definitions, no bodies — `ext/csv.nu` is 63 KB, its surface 11 KB), or an AND-term search over every module's declarations. A query no single declaration satisfies is re-run as a **whole-word OR ranked by coverage** — `string builder append` still lands on `string_push_bytes`, `vec_push new string_new` on `string_new` and `vec_push` — and only if that finds nothing does the reply widen to the package registry; an exact package-name term is footnoted regardless. |
 | `nurl_grep` | `pattern`, `where?`, `word?` | Case-insensitive search over the installed stdlib (`path:line:` hits, word-boundary matches ranked first) and the registry's package names + descriptions — "is there a package for X" from any MCP-only editor. |
+| `nurl_docs` | `name?`, `offset?` | The shipped `docs/` tree — the questions the API surface cannot answer: `MEMORY.md` (who frees what, and when), `CRYPTO.md`, `ASYNC.md`, `PLATFORMS.md`, `spec.md`, `dev/COMPILER_INTERNALS.md`, … No `name` lists everything with its size and title; a `name` returns that document (the `docs/` prefix and `.md` suffix optional, case-insensitive), paged with `offset` past 48 KB. Served from `$NURL_DOCS`, else `$NURL_STDLIB/docs` — `install-toolchain.sh` puts it there. |
 
 `source` is inline NURL; `path` is a `.nu` file on the host. Inline source is
 written to a unique temp file that is deleted after the call (build artifacts
@@ -84,7 +85,7 @@ nurl-mcp --http [--host ADDR] [--port N] [--token TOK] [--read-only] [--allow-ru
 | `--host ADDR` | `127.0.0.1` | Bind address. |
 | `--port N` | `8080` | Bind port. |
 | `--token TOK` | none | Require `Authorization: Bearer TOK` on every request (401 otherwise). |
-| `--read-only` | off | Expose only `nurl_check`, `nurl_fmt`, `nurl_list_stdlib`, `nurl_read_stdlib`, `nurl_api`, `nurl_grep` — no build, no run. |
+| `--read-only` | off | Expose only `nurl_check`, `nurl_fmt`, `nurl_list_stdlib`, `nurl_read_stdlib`, `nurl_api`, `nurl_grep`, `nurl_docs` — no build, no run. |
 | `--allow-run` | off | Allow `nurl_run` over HTTP (see Security). |
 
 ```

--- a/packages/nurl-mcp/nurl.toml
+++ b/packages/nurl-mcp/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nurl-mcp"
-version = "0.8.0"
+version = "0.9.0"
 description = "Local MCP server for the NURL toolchain — dual-era MCP (the 2026-07-28 stateless revision with server/discover and per-request _meta, plus the legacy initialize handshake for older clients) — exposes the installed compiler over Model Context Protocol so an LLM agent on the host can build, run, type-check, format, and compile NURL to wasm32-wasi (fully local wasm builds via the wasmbuilder package), read the installed stdlib, browse its API surface — the stdlib's or a published registry package's (nurl_api, package=) — without function bodies, search stdlib + the package registry (by name, description, or exported symbol) with ranked word boundaries (nurl_grep), and compile a program that USES a registry package end to end, resolving its dependencies (nurl_build_project). Stdio by default; an optional token-authenticated HTTP transport (--http) gates code execution behind --allow-run. The editor-facing counterpart of nurl-lsp, for LLMs."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl/tree/main/packages/nurl-mcp"

--- a/packages/nurl-mcp/nurl.toml
+++ b/packages/nurl-mcp/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nurl-mcp"
-version = "0.9.0"
+version = "0.10.0"
 description = "Local MCP server for the NURL toolchain — dual-era MCP (the 2026-07-28 stateless revision with server/discover and per-request _meta, plus the legacy initialize handshake for older clients) — exposes the installed compiler over Model Context Protocol so an LLM agent on the host can build, run, type-check, format, and compile NURL to wasm32-wasi (fully local wasm builds via the wasmbuilder package), read the installed stdlib, browse its API surface — the stdlib's or a published registry package's (nurl_api, package=) — without function bodies, search stdlib + the package registry (by name, description, or exported symbol) with ranked word boundaries (nurl_grep), and compile a program that USES a registry package end to end, resolving its dependencies (nurl_build_project). Stdio by default; an optional token-authenticated HTTP transport (--http) gates code execution behind --allow-run. The editor-facing counterpart of nurl-lsp, for LLMs."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl/tree/main/packages/nurl-mcp"

--- a/packages/nurl-mcp/src/main.nu
+++ b/packages/nurl-mcp/src/main.nu
@@ -58,7 +58,7 @@ $ `deps/wasmbuilder/src/build.nu`
 // to bump (previously the banners drifted to a stale 0.2.0 while the
 // handshake reported 0.4.0).
 
-@ nm_version → s { ^ `0.9.0` }
+@ nm_version → s { ^ `0.10.0` }
 
 // Log a startup banner "nurl-mcp <version> <suffix>" through mcp_log,
 // building the line from the single-source version so the banners can

--- a/packages/nurl-mcp/src/main.nu
+++ b/packages/nurl-mcp/src/main.nu
@@ -58,7 +58,7 @@ $ `deps/wasmbuilder/src/build.nu`
 // to bump (previously the banners drifted to a stale 0.2.0 while the
 // handshake reported 0.4.0).
 
-@ nm_version → s { ^ `0.8.0` }
+@ nm_version → s { ^ `0.9.0` }
 
 // Log a startup banner "nurl-mcp <version> <suffix>" through mcp_log,
 // building the line from the single-source version so the banners can
@@ -776,6 +776,70 @@ version = "0.0.0"
     ^ ( env_var_or `NURL_STDLIB` `` )
 }
 
+// ── Tool: nurl_docs (shared engine: stdlib/ext/mcp_search) ──────────
+//
+// nurl_api answers "what is the signature", never "who frees this" or
+// "which cipher suites ship" — that is docs/MEMORY.md and
+// docs/CRYPTO.md. install-toolchain.sh ships the tree next to the
+// stdlib, so $NURL_STDLIB/docs is the default; $NURL_DOCS overrides it
+// (a source checkout, or a prefix assembled by hand).
+@ nm_docs_root → String {
+    : String explicit ( env_var_or `NURL_DOCS` `` )
+    ? > ( string_len explicit ) 0 { ^ explicit } {}
+    ( string_free explicit )
+    : String root ( nm_stdlib_root )
+    ? == ( string_len root ) 0 { ^ root } {}
+    : String d ( path_join ( string_data root ) `docs` )
+    ( string_free root )
+    ^ d
+}
+
+@ nm_tool_docs Json args → Json {
+    : ~ s name ``
+    ?? ( json_obj_get args `name` ) {
+        T nj → { ? ( json_is_str nj ) { = name ( json_as_str nj ) } {} }
+        F _ → {}
+    }
+    : ~ i offset 0
+    ?? ( json_obj_get args `offset` ) {
+        T oj → { ? ( json_is_num oj ) { = offset ( json_as_int oj ) } {} }
+        F _ → {}
+    }
+    : String dd ( nm_docs_root )
+    ? == ( string_len dd ) 0 {
+        ( string_free dd )
+        ^ ( mcp_tool_result_error `neither NURL_DOCS nor NURL_STDLIB is set — run via the installed toolchain shims, or export NURL_DOCS to a docs/ directory` )
+    } {}
+    ? == ( nurl_str_len name ) 0 {
+        : String listing ( msearch_docs_list ( string_data dd ) )
+        ( string_free dd )
+        : Json r ( mcp_tool_result_text ( string_data listing ) )
+        ( string_free listing )
+        ^ r
+    } {}
+    : String text ( msearch_docs_read ( string_data dd ) name offset )
+    ? == ( string_len text ) 0 {
+        // Unknown name → reply with what DOES exist, so the model's next
+        // call is the right one instead of another guess.
+        ( string_free text )
+        : String listing ( msearch_docs_list ( string_data dd ) )
+        ( string_free dd )
+        : String msg ( string_with_cap + ( string_len listing ) 128 )
+        ( string_push_str msg `no document matches '` )
+        ( string_push_str msg name )
+        ( string_push_str msg `'. ` )
+        ( string_push_str msg ( string_data listing ) )
+        ( string_free listing )
+        : Json e ( mcp_tool_result_error ( string_data msg ) )
+        ( string_free msg )
+        ^ e
+    } {}
+    ( string_free dd )
+    : Json r ( mcp_tool_result_text ( string_data text ) )
+    ( string_free text )
+    ^ r
+}
+
 @ nm_tool_api Json args → Json {
     : String root ( nm_stdlib_root )
     ? == ( string_len root ) 0 {
@@ -908,7 +972,7 @@ version = "0.0.0"
     ( nm_prop props `module` `Render ONE installed-stdlib module's API surface (signatures, doc comments, full type definitions — no function bodies). A nurl_list_stdlib path, e.g. 'ext/csv.nu'.` )
     ( nm_prop props `package` `Render a PUBLISHED registry package's API surface — nurldoc over its src/*.nu, streamed from the tarball. The name from a registry search, e.g. 'nn'. Use this after a registry hit to learn the functions/types a package exposes (their names are not otherwise searchable).` )
     ( nm_prop props `version` `Optional package version (e.g. '0.1.1'); defaults to the latest. Only meaningful with 'package'.` )
-    ( nm_prop props `query` `Search every installed-stdlib module's declarations: space-separated terms, ALL must occur (case-insensitive) in a declaration's signature + doc comment + module path. Zero hits widen to the package registry; an exact package-name term is noted regardless. Ignored when 'module' or 'package' is set.` )
+    ( nm_prop props `query` `Search every installed-stdlib module's declarations: space-separated terms, ALL must occur (case-insensitive) in a declaration's signature + doc comment + module path. When no declaration has all of them, the terms are re-run as an OR — each matched as a WHOLE word (bounded by a digit or any non-letter, so 'string' hits string_push_str but not substring) — and the best-covering declarations come back ranked, most terms covered first; only if that finds nothing too does the reply widen to the package registry. So a concept-shaped query like 'string builder append' is fine here. An exact package-name term is noted regardless. Ignored when 'module' or 'package' is set.` )
     ( json_obj_set schema `properties` props )
     ^ schema
 }
@@ -932,6 +996,23 @@ version = "0.0.0"
     ( json_obj_set p `type` ( json_str_lit `string` ) )
     ( json_obj_set p `description` ( json_str_lit desc ) )
     ( json_obj_set props name p )
+}
+
+@ nm_prop_int Json props s name s desc → v {
+    : Json p ( json_obj_new )
+    ( json_obj_set p `type` ( json_str_lit `integer` ) )
+    ( json_obj_set p `description` ( json_str_lit desc ) )
+    ( json_obj_set props name p )
+}
+
+@ nm_schema_docs → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    : Json props ( json_obj_new )
+    ( nm_prop props `name` `Which document to return, e.g. 'MEMORY.md', 'CRYPTO.md', 'dev/COMPILER_INTERNALS.md'. The 'docs/' prefix and the '.md' suffix are both optional and matching is case-insensitive. Omit to list every document with its size and title.` )
+    ( nm_prop_int props `offset` `Byte offset to start from (default 0). Documents are capped at 48 KB per call; a truncated reply prints the exact offset to pass next.` )
+    ( json_obj_set schema `properties` props )
+    ^ schema
 }
 
 @ nm_schema_src_path → Json {
@@ -1011,8 +1092,11 @@ version = "0.0.0"
     ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_read_stdlib`
     `Read one module from the installed standard library by relative path.`
     ( nm_schema_name ) ) )
+    ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_docs`
+    `The docs/ prose tree shipped with the toolchain — the questions the API surface cannot answer: MEMORY.md (ownership: who frees what, and when), CRYPTO.md (the shipped cipher suites + TLS stack), ASYNC.md (stackful fibers), BUILDING.md, PLATFORMS.md, NETWORKING.md, DISTRIBUTED.md, FORMAT.md, LIMITATIONS.md, TOOLING.md, spec.md (the full language reference), dev/COMPILER_INTERNALS.md. Call with NO arguments for the index (path, size, title); then name='MEMORY.md' for one document. The 'docs/' prefix and '.md' suffix are optional, matching is case-insensitive, and 'offset' pages a document longer than 48 KB. Read this before guessing at memory, crypto, or platform behaviour — every one of those topics is documented.`
+    ( nm_schema_docs ) ) )
     ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_api`
-    `A stdlib module's API surface, or a search across all of them — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders signatures + doc comments + type definitions; query='csv quote' finds matching declarations. The import-free C-runtime builtins (nurl_println, nurl_str_float, …) are indexed too, as core/builtins.nu. Zero hits widen to the package registry; an exact package-name term is footnoted regardless.`
+    `A stdlib module's API surface, or a search across all of them — strongly prefer this over nurl_read_stdlib (whole modules waste context; ext/csv.nu is 63 KB, its API surface 11 KB, one matching declaration ~0.3 KB). module='ext/csv.nu' renders signatures + doc comments + type definitions; query='csv quote' finds matching declarations. The import-free C-runtime builtins (nurl_println, nurl_str_float, …) are indexed too, as core/builtins.nu. A query no single declaration satisfies is re-run as a whole-word OR ranked by term coverage (so 'string builder append' still finds string_push_str), and only then widens to the package registry; an exact package-name term is footnoted regardless.`
     ( nm_schema_api ) ) )
     ( vec_push [Json] tools ( mcp_tool_descriptor `nurl_grep`
     `Case-insensitive search across the installed stdlib (path:line: text; word-boundary matches ranked first, in-word substring hits in a labeled tail) and the package registry (name + description) — "is there a package for X" works from any MCP-only editor. word=true for short acronyms.`
@@ -1041,6 +1125,7 @@ version = "0.0.0"
     ? != ( nurl_str_eq name `nurl_fmt` ) 0 { ^ ( nm_tool_fmt args ) } {}
     ? != ( nurl_str_eq name `nurl_list_stdlib` ) 0 { ^ ( nm_tool_list_stdlib args ) } {}
     ? != ( nurl_str_eq name `nurl_read_stdlib` ) 0 { ^ ( nm_tool_read_stdlib args ) } {}
+    ? != ( nurl_str_eq name `nurl_docs` ) 0 { ^ ( nm_tool_docs args ) } {}
     ? != ( nurl_str_eq name `nurl_api` ) 0 { ^ ( nm_tool_api args ) } {}
     ? != ( nurl_str_eq name `nurl_grep` ) 0 { ^ ( nm_tool_grep args ) } {}
     ^ ( mcp_tool_result_error `unknown tool` )
@@ -1066,7 +1151,7 @@ version = "0.0.0"
     ( json_obj_set caps `tools` ( json_obj_new ) )
     : Json result ( mcp_discover_result `nurl-mcp` ( nm_version )
     caps
-    `Local NURL toolchain: build/run/check/format NURL code, compile to wasm32-wasi, read the installed stdlib, browse API surfaces (nurl_api), search stdlib + the package registry (nurl_grep), and build registry-dependent projects (nurl_build_project). Start with nurl_api or nurl_grep to discover symbols, then nurl_check to validate code cheaply before nurl_build.` )
+    `Local NURL toolchain: build/run/check/format NURL code, compile to wasm32-wasi, read the installed stdlib, browse API surfaces (nurl_api), search stdlib + the package registry (nurl_grep), read the shipped documentation (nurl_docs), and build registry-dependent projects (nurl_build_project). Start with nurl_api or nurl_grep to discover symbols, nurl_docs for how the language behaves (ownership, crypto, async, platforms), then nurl_check to validate code cheaply before nurl_build.` )
     ^ ( mcp_response_result id result )
 }
 

--- a/stdlib/ext/mcp_search.nu
+++ b/stdlib/ext/mcp_search.nu
@@ -5,15 +5,20 @@
 //   * msearch_api_module — one module's API surface via nurldoc
 //     (signatures + doc comments + full type definitions, no bodies)
 //   * msearch_api_query  — AND-term search over every module's
-//     declaration blocks; zero hits widen automatically to example
-//     programs and the package registry; an exact package-name term is
-//     noted in a footer regardless of hit count
+//     declaration blocks; zero hits re-run the terms as a whole-word OR
+//     ranked by coverage, and only if THAT finds nothing does the search
+//     widen to example programs and the package registry; an exact
+//     package-name term is noted in a footer regardless of hit count
 //   * msearch_grep       — case-insensitive substring grep with
 //     word-boundary RANKING (boundary-clean lines first, in-word tail
 //     labeled; word=T drops the tail), plus registry name+description
 //     search
-//   * msearch_walk_nu_files — recursive .nu lister ({name,path,bytes}
-//     into a Json array), shared by the corpus walkers and list tools
+//   * msearch_docs_list / msearch_docs_resolve / msearch_docs_read —
+//     the docs/ prose tree (MEMORY.md, CRYPTO.md, …): what exists, and
+//     one document by a forgiving name
+//   * msearch_walk_nu_files / msearch_walk_md_files — recursive
+//     listers ({name,path,bytes} into a Json array), shared by the
+//     corpus walkers and list tools
 //
 // All entry points take explicit directory paths and a registry base
 // URL ("" skips that part) — no environment reads in here; resolve
@@ -54,14 +59,14 @@ $ `stdlib/ext/nurldoc.nu`
     ^ ( string_from root )
 }
 
-// Walk `root_dir` recursively. For every regular .nu file found,
-// append { name: <rel>, path: <rel>, bytes: N } to `arr`. `rel` is
-// the path relative to root_dir (POSIX-style, "/" separator).
+// Walk `root_dir` recursively. For every regular file whose name ends
+// in `ext`, append { name: <rel>, path: <rel>, bytes: N } to `arr`.
+// `rel` is the path relative to root_dir (POSIX-style, "/" separator).
 // Subdirectories are entered if dir_list succeeds on them. Entries
 // at each level are sorted alphabetically before walking, which gives
 // a globally sorted output (top-level "foo.nu" comes before subdir
 // "g/bar.nu" iff "foo.nu" < "g" lexicographically).
-@ msearch_walk_nu_files Json arr s root_dir s rel_prefix → v {
+@ __ms_walk_ext Json arr s root_dir s rel_prefix s ext → v {
     : String full ( __ms_join_or_root root_dir rel_prefix )
     : !( Vec String ) IoErr dr ( dir_list ( string_data full ) )
     ?? dr {
@@ -76,7 +81,7 @@ $ `stdlib/ext/nurldoc.nu`
                     T name → {
                         : String child_rel ( __ms_join_or_root rel_prefix ( string_data name ) )
                         : String child_full ( path_join ( string_data full ) ( string_data name ) )
-                        ? ( string_ends_with name `.nu` ) {
+                        ? ( string_ends_with name ext ) {
                             : !i IoErr sz ( file_size ( string_data child_full ) )
                             ?? sz {
                                 T bytes → {
@@ -90,7 +95,7 @@ $ `stdlib/ext/nurldoc.nu`
                             }
                         } {
                             // Try to recurse — if it's a directory, dir_list succeeds.
-                            ( msearch_walk_nu_files arr root_dir ( string_data child_rel ) )
+                            ( __ms_walk_ext arr root_dir ( string_data child_rel ) ext )
                         }
                         ( string_free child_full )
                         ( string_free child_rel )
@@ -109,6 +114,16 @@ $ `stdlib/ext/nurldoc.nu`
         F _ → {}
     }
     ( string_free full )
+}
+
+// The .nu corpus walker every search path uses.
+@ msearch_walk_nu_files Json arr s root_dir s rel_prefix → v {
+    ( __ms_walk_ext arr root_dir rel_prefix `.nu` )
+}
+
+// The .md corpus walker behind nurl_docs.
+@ msearch_walk_md_files Json arr s root_dir s rel_prefix → v {
+    ( __ms_walk_ext arr root_dir rel_prefix `.md` )
 }
 
 // Render one stdlib module's doc surface; "" when unreadable.
@@ -746,6 +761,300 @@ $ `stdlib/ext/nurldoc.nu`
     ( json_free files )
 }
 
+// ── nurl_api: OR widening when every term together matches nothing ──
+//
+// A model that asks for "string builder append" or "vec_push new
+// string_new" is naming a CONCEPT, not a conjunction any single
+// declaration satisfies — and the AND search answers 0. Jumping
+// straight from there to examples + registry throws away the fact that
+// the stdlib does have string_push_str and vec_push; it just never has
+// them in one declaration.
+//
+// So before widening the corpus, widen the OPERATOR: re-run the same
+// terms as an OR over the same declaration blocks — but counting only
+// WHOLE-word occurrences (the adjacent byte must not be a letter, so
+// `string` hits string_push_str, string_new and `a string`, and misses
+// substring), and rank each block by how much of the query it covers —
+// see __ms_or_score2 for the weighting. That floats vec_push and
+// string_new to the top of a three-term query instead of burying them
+// under the ~200 declarations that merely say `new`.
+
+// How many blocks the OR pass shows. Small on purpose: the point is the
+// two or three declarations the model actually meant, not a corpus dump.
+@ __ms_api_or_cap → i { ^ 12 }
+
+// Terms shorter than this are dropped from the OR pass — a one-letter
+// whole word matches half the corpus and tells the model nothing.
+@ __ms_or_min_term → i { ^ 2 }
+
+@ __ms_or_usable_terms ( Vec String ) terms → i {
+    : i n ( vec_len [String] terms )
+    : ~ i c 0
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] terms k ) {
+            T t → { ? >= ( string_len t ) ( __ms_or_min_term ) { = c + c 1 } {} }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ c
+}
+
+// Whole-word occurrences of `pat` in `hay` (both already lowercase) —
+// the counting twin of __ms_grep_line_class, same boundary rule.
+@ __ms_word_occ s hay s pat → i {
+    : i n ( nurl_str_len hay )
+    : i m ( nurl_str_len pat )
+    ? | == m 0 > m n { ^ 0 } {}
+    : ~ i cnt 0
+    : ~ i k 0
+    ~ <= k - n m {
+        : ~ b hit T
+        : ~ i j 0
+        ~ & hit < j m {
+            ? != ( nurl_str_get hay + k j ) ( nurl_str_get pat j ) { = hit F } {}
+            = j + j 1
+        }
+        ? hit {
+            : ~ b lb T
+            ? > k 0 { = lb ! ( __ms_grep_alpha ( nurl_str_get hay - k 1 ) ) } {}
+            : ~ b rb T
+            ? < + k m n { = rb ! ( __ms_grep_alpha ( nurl_str_get hay + k m ) ) } {}
+            ? & lb rb { = cnt + cnt 1 } {}
+        } {}
+        = k + k 1
+    }
+    ^ cnt
+}
+
+// Coverage score for one declaration, packed into a single sortable i:
+//
+//   coverage: Σ length of the distinct terms found  × 100000
+//   the same sum restricted to `sig_lc`             ×   1000
+//   total occurrences (clamped to 999)                        tiebreak
+//
+// Terms are weighted by LENGTH, not counted: `new` is three characters
+// that half the stdlib constructors contain, `vec_push` is eight that
+// name one function, and a ranking that scores them equally buries the
+// exact hit under the generic ones. `sig_lc` — module path + the
+// declaration's signature line — then separates a term in the NAME from
+// a term in the prose, so "string builder append" reaches
+// string_push_bytes before the ArgParser struct, which wins on raw
+// repetition alone (its body says String eight times).
+//
+// `stats` (≥ 1 element) receives the distinct-term count at [0] for the
+// "[2/3 terms]" label. Pass "" as sig_lc for a plain any-term test.
+// Returns 0 ⇔ no term occurs at all.
+@ __ms_or_score2 s sig_lc s hay_lc ( Vec String ) terms ( Vec i ) stats → i {
+    : i n ( vec_len [String] terms )
+    : ~ i hits 0
+    : ~ i cov 0
+    : ~ i sig_cov 0
+    : ~ i total 0
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [String] terms k ) {
+            T t → {
+                : i tl ( string_len t )
+                ? >= tl ( __ms_or_min_term ) {
+                    : i c ( __ms_word_occ hay_lc ( string_data t ) )
+                    ? > c 0 {
+                        = hits + hits 1
+                        = cov + cov tl
+                        = total + total c
+                    } {}
+                    ? > ( nurl_str_len sig_lc ) 0 {
+                        ? > ( __ms_word_occ sig_lc ( string_data t ) ) 0 { = sig_cov + sig_cov tl } {}
+                    } {}
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_set [i] stats 0 hits )
+    ? == hits 0 { ^ 0 } {}
+    ^ + + * cov 100000 * sig_cov 1000 ? > total 999 999 total
+}
+
+// Keep the `cap` highest-scoring snippets, best first. `scores`/`texts`
+// stay parallel and sorted descending; a snippet that cannot make the
+// cut is simply not copied.
+@ __ms_topk_push ( Vec i ) scores ( Vec String ) texts i cap i score s text → v {
+    : i n ( vec_len [i] scores )
+    : ~ i pos n
+    : ~ i k 0
+    ~ < k n {
+        ?? ( vec_get [i] scores k ) {
+            T sv → { ? & == pos n > score sv { = pos k } {} }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ? | < n cap < pos cap {
+        ( vec_insert [i] scores pos score )
+        ( vec_insert [String] texts pos ( string_from text ) )
+        ? > ( vec_len [i] scores ) cap {
+            ( vec_remove [i] scores cap )
+            ?? ( vec_remove [String] texts cap ) { T old → ( string_free old ) F _ → {} }
+        } {}
+    } {}
+}
+
+// Score one rendered module's declaration blocks against the OR terms
+// and offer each hit to the top-K. ctr = [matched].
+@ __ms_or_match_blocks String md s rel ( Vec String ) terms i nterms ( Vec i ) scores ( Vec String ) texts ( Vec i ) ctr ( Vec i ) stats → v {
+    : ( Vec String ) parts ( string_split md `\n### ` )
+    : i np ( vec_len [String] parts )
+    : ~ i k 1  // part 0 = title + module header, not a declaration block
+    ~ < k np {
+        ?? ( vec_get [String] parts k ) {
+            T blk → {
+                : String hay ( string_with_cap + ( string_len blk ) 64 )
+                ( string_push_str hay rel )
+                ( string_push_char hay 32 )
+                ( string_push_str hay ( string_data blk ) )
+                : String hay_lc ( string_to_lower hay )
+                ( string_free hay )
+                // The signature haystack: module path + the block's first
+                // line, which nurldoc renders as the declaration itself.
+                : String sig ( string_with_cap 160 )
+                ( string_push_str sig rel )
+                ( string_push_char sig 32 )
+                : s braw ( string_data blk )
+                : i bl ( string_len blk )
+                : ~ i si 0
+                ~ & < si bl != ( nurl_str_get braw si ) 10 {
+                    ( string_push_char sig ( nurl_str_get braw si ) )
+                    = si + si 1
+                }
+                : String sig_lc ( string_to_lower sig )
+                ( string_free sig )
+                : i sc ( __ms_or_score2 ( string_data sig_lc ) ( string_data hay_lc ) terms stats )
+                ( string_free sig_lc )
+                ( string_free hay_lc )
+                ? > sc 0 {
+                    : i m ?? ( vec_get [i] ctr 0 ) { T v → v F _ → 0 }
+                    ( vec_set [i] ctr 0 + m 1 )
+                    : String snip ( string_with_cap 640 )
+                    ( string_push_str snip rel )
+                    ( string_push_str snip ` [` )
+                    ( string_push_int snip ?? ( vec_get [i] stats 0 ) { T v → v F _ → 0 } )
+                    ( string_push_char snip 47 )
+                    ( string_push_int snip nterms )
+                    ( string_push_str snip ` terms] › ` )
+                    : i bn ( string_len blk )
+                    : i keep ? > bn 500 500 bn
+                    : s raw ( string_data blk )
+                    : ~ i j 0
+                    ~ < j keep {
+                        ( string_push_char snip ( nurl_str_get raw j ) )
+                        = j + j 1
+                    }
+                    ? > bn keep { ( string_push_str snip `…` ) } {}
+                    ( __ms_topk_push scores texts ( __ms_api_or_cap ) sc ( string_data snip ) )
+                    ( string_free snip )
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [String] parts \ String p → v { ( string_free p ) } )
+}
+
+// Run the OR pass over every module under stdlib_dir, append the ranked
+// hits to `out`, and return how many declarations matched at least one
+// term (0 ⇒ nothing found; the caller falls through to the corpus
+// widening exactly as before).
+@ __ms_api_or_widen s stdlib_dir ( Vec String ) terms String out → i {
+    : i nterms ( __ms_or_usable_terms terms )
+    ? < nterms 2 { ^ 0 } {}
+    : ( Vec i ) scores ( vec_new [i] )
+    : ( Vec String ) texts ( vec_new [String] )
+    : ( Vec i ) ctr ( vec_new [i] )
+    ( vec_push [i] ctr 0 )
+    : ( Vec i ) stats ( vec_new [i] )
+    ( vec_push [i] stats 0 )
+    : String dir ( string_from stdlib_dir )
+    : Json files ( json_arr_new )
+    ( msearch_walk_nu_files files ( string_data dir ) `` )
+    : i nf ( json_arr_len files )
+    : ~ i k 0
+    ~ < k nf {
+        ?? ( json_arr_get files k ) {
+            T fo → {
+                : ~ s rel ``
+                ?? ( json_obj_get fo `path` ) {
+                    T pj → { ? ( json_is_str pj ) { = rel ( json_as_str pj ) } {} }
+                    F _ → {}
+                }
+                ? > ( nurl_str_len rel ) 0 {
+                    : String fp ( path_join ( string_data dir ) rel )
+                    : !( Vec u ) IoErr rd ( read_file_bytes ( string_data fp ) )
+                    ( string_free fp )
+                    ?? rd {
+                        T bytes → {
+                            : String src ( bytes_to_str bytes )
+                            ( vec_free [u] bytes )
+                            // Same raw-source pre-filter as the AND pass,
+                            // ORed: render only modules that can contribute.
+                            : String pre ( string_with_cap + ( string_len src ) 64 )
+                            ( string_push_str pre rel )
+                            ( string_push_char pre 32 )
+                            ( string_push_str pre ( string_data src ) )
+                            : String pre_lc ( string_to_lower pre )
+                            ( string_free pre )
+                            ? > ( __ms_or_score2 `` ( string_data pre_lc ) terms stats ) 0 {
+                                : String md ( nurldoc_render ( string_data src ) rel )
+                                ( __ms_or_match_blocks md rel terms nterms scores texts ctr stats )
+                                ( string_free md )
+                            } {}
+                            ( string_free pre_lc )
+                            ( string_free src )
+                        }
+                        F _ → {}
+                    }
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( json_free files )
+    ( string_free dir )
+
+    : i matched ?? ( vec_get [i] ctr 0 ) { T v → v F _ → 0 }
+    : i shown ( vec_len [String] texts )
+    ? > shown 0 {
+        ( string_push_str out `No declaration contains every term. Nearest declarations matching ANY term as a whole word, ranked by how much of the query they cover — a longer, more specific term counts for more than a short common one, and a term in the declaration's own name counts for more than one in its prose:\n\n` )
+        : ~ i j 0
+        ~ < j shown {
+            ?? ( vec_get [String] texts j ) {
+                T t → {
+                    ( string_push_str out ( string_data t ) )
+                    ( string_push_str out `\n\n` )
+                }
+                F _ → {}
+            }
+            = j + j 1
+        }
+        ? > matched shown {
+            ( string_push_str out `(` )
+            ( string_push_int out matched )
+            ( string_push_str out ` declarations match at least one term; the ` )
+            ( string_push_int out shown )
+            ( string_push_str out ` with the best coverage are above. Search one of the terms alone for the rest, or read a module with 'module'.)\n` )
+        } {}
+    } {}
+    ( vec_free [i] scores )
+    ( vec_free [i] ctr )
+    ( vec_free [i] stats )
+    ( vec_free_with [String] texts \ String t → v { ( string_free t ) } )
+    ^ matched
+}
+
 // One module's API surface (nurldoc render, byte-capped with a note);
 // "" when the module is unreadable/missing.
 @ msearch_api_module s stdlib_dir s rel → String {
@@ -827,17 +1136,29 @@ $ `stdlib/ext/nurldoc.nu`
     ( string_push_str hdr query )
     ( string_push_str hdr `'.\n\n` )
     ( string_push_str hdr ( string_data out ) )
+    // `widened` = the corpus fallback ran and already listed registry
+    // matches in full, so the one-line exact-name footer would repeat it.
+    : ~ b widened F
     ? == matched 0 {
-        // Widen rather than shrug: the same terms against example files
-        // and the package registry, in the same reply.
-        ( string_push_str hdr `No stdlib declaration matches — widened the search:\n\n` )
-        : ~ i ex_n 0
-        ? > ( nurl_str_len examples_dir ) 0 { = ex_n ( __ms_api_fallback_examples examples_dir terms hdr ) } {}
-        ? > ex_n 0 { ( string_push_char hdr 10 ) } {}
-        : ~ i pk_n 0
-        ? > ( nurl_str_len regbase ) 0 { = pk_n ( __ms_api_fallback_packages regbase terms hdr ) } {}
-        ? == + ex_n pk_n 0 {
-            ( string_push_str hdr `Nothing in examples or the registry either — terms are AND-ed substrings; try fewer or shorter terms, or nurl_grep for raw line search.\n` )
+        // Widen the OPERATOR first: the same terms ORed, whole-word,
+        // ranked by coverage. A multi-term concept query ("string builder
+        // append") lands on real declarations here, and when it does the
+        // corpus fallback stays out of the reply — the point of the pass
+        // is fewer, better hits, not more of them.
+        : i or_n ( __ms_api_or_widen stdlib_dir terms hdr )
+        ? == or_n 0 {
+            // Widen rather than shrug: the same terms against example files
+            // and the package registry, in the same reply.
+            = widened T
+            ( string_push_str hdr `No stdlib declaration matches — widened the search:\n\n` )
+            : ~ i ex_n 0
+            ? > ( nurl_str_len examples_dir ) 0 { = ex_n ( __ms_api_fallback_examples examples_dir terms hdr ) } {}
+            ? > ex_n 0 { ( string_push_char hdr 10 ) } {}
+            : ~ i pk_n 0
+            ? > ( nurl_str_len regbase ) 0 { = pk_n ( __ms_api_fallback_packages regbase terms hdr ) } {}
+            ? == + ex_n pk_n 0 {
+                ( string_push_str hdr `Nothing in examples or the registry either — terms are AND-ed substrings; try fewer or shorter terms, or nurl_grep for raw line search.\n` )
+            } {}
         } {}
     } {}
     ? > matched emitted {
@@ -845,9 +1166,8 @@ $ `stdlib/ext/nurldoc.nu`
         ( string_push_int hdr - matched emitted )
         ( string_push_str hdr ` more matching declarations omitted (byte cap) — narrow the query or read one module with 'module'.\n` )
     } {}
-    // The 0-hit path already listed registry matches in full; otherwise an
-    // exact package-name hit still deserves its one-line footer.
-    ? & > matched 0 > ( nurl_str_len regbase ) 0 { ( __ms_api_exact_pkg_note regbase terms hdr ) } {}
+    // An exact package-name hit still deserves its one-line footer.
+    ? & ! widened > ( nurl_str_len regbase ) 0 { ( __ms_api_exact_pkg_note regbase terms hdr ) } {}
     ( string_free out ) ( vec_free [i] ctr )
     ( vec_free_with [String] terms \ String t → v { ( string_free t ) } )
     ( string_free q_lc )
@@ -1053,6 +1373,271 @@ $ `stdlib/ext/nurldoc.nu`
         ^ cut
     } {}
     ^ md
+}
+
+// ── Documentation corpus (item: nurl_docs) ─────────────────────────
+//
+// docs/ is the prose the API surface cannot answer: MEMORY.md (who owns
+// what, and when it is freed), CRYPTO.md (which cipher suites ship),
+// GOTCHAS.md, spec.md, … An agent that can only reach nurl_api ends up
+// guessing at exactly the questions these files answer, so both servers
+// expose the tree as one tool: no `name` lists what exists, a `name`
+// returns that document verbatim.
+
+// Byte budget for one document. spec.md (63 KB) and MEMORY.md (45 KB)
+// are the outliers; the rest fit whole. `offset` pages past the cut.
+@ __ms_docs_cap → i { ^ 49152 }
+
+// A document's `# ` title, "" when the file has none in its first few
+// lines. Used as the one-line blurb in the listing.
+@ __ms_docs_title String src → String {
+    : s raw ( string_data src )
+    : i n ( string_len src )
+    : ~ i k 0
+    : ~ i lines 0
+    : String t ( string_new )
+    ~ & & < k n < lines 8 == ( string_len t ) 0 {
+        : ~ i e k
+        ~ & < e n != ( nurl_str_get raw e ) 10 { = e + e 1 }
+        // "# Title" — one hash, then the text after the spaces.
+        ? & & < + k 1 e == ( nurl_str_get raw k ) 35 != ( nurl_str_get raw + k 1 ) 35 {
+            : ~ i b + k 1
+            ~ & < b e == ( nurl_str_get raw b ) 32 { = b + b 1 }
+            : ~ i j b
+            ~ & < j e < - j b 110 {
+                ( string_push_char t ( nurl_str_get raw j ) )
+                = j + j 1
+            }
+            ? > - e b 110 { ( string_push_str t `…` ) } {}
+        } {}
+        = k + e 1
+        = lines + lines 1
+    }
+    ^ t
+}
+
+// Strip the decoration a model is likely to type around a doc name:
+// a leading "./", "/" or "docs/", and a trailing "/". Lowercased, so
+// callers compare case-insensitively. "" when `name` escapes the tree.
+@ __ms_docs_norm s name → String {
+    : ~ String w ( __ms_lc name )
+    ? >= ( nurl_str_find ( string_data w ) `..` ) 0 {
+        ( string_free w )
+        ^ ( string_new )
+    } {}
+    : ~ b more T
+    ~ more {
+        = more F
+        ? ( string_starts_with w `/` ) {
+            : String c1 ( string_substr w 1 - ( string_len w ) 1 )
+            ( string_free w ) = w c1 = more T
+        } {}
+        ? ( string_starts_with w `./` ) {
+            : String c2 ( string_substr w 2 - ( string_len w ) 2 )
+            ( string_free w ) = w c2 = more T
+        } {}
+        ? ( string_starts_with w `docs/` ) {
+            : String c3 ( string_substr w 5 - ( string_len w ) 5 )
+            ( string_free w ) = w c3 = more T
+        } {}
+    }
+    ~ ( string_ends_with w `/` ) {
+        : String c4 ( string_substr w 0 - ( string_len w ) 1 )
+        ( string_free w ) = w c4
+    }
+    ^ w
+}
+
+// How well `rel` (a path under docs/) answers a request for `want`
+// (already normalised + lowercased): 1 exact, 2 exact minus the .md
+// suffix, 3 basename, 4 basename minus .md, 0 no match. Lower wins, so
+// name='MEMORY' and name='docs/memory.md' both land on MEMORY.md while
+// a request that names a directory does not silently match a file.
+@ __ms_docs_rank s rel s want → i {
+    : String rl ( __ms_lc rel )
+    : String base ( __ms_basename ( string_data rl ) )
+    : ~ String rl_stem ( string_from ( string_data rl ) )
+    ? ( string_ends_with rl_stem `.md` ) {
+        : String cut ( string_substr rl_stem 0 - ( string_len rl_stem ) 3 )
+        ( string_free rl_stem )
+        = rl_stem cut
+    } {}
+    : ~ String base_stem ( string_from ( string_data base ) )
+    ? ( string_ends_with base_stem `.md` ) {
+        : String cut2 ( string_substr base_stem 0 - ( string_len base_stem ) 3 )
+        ( string_free base_stem )
+        = base_stem cut2
+    } {}
+    : ~ i rank 0
+    ? != 0 ( nurl_str_eq ( string_data rl ) want ) { = rank 1 } {}
+    ? & == rank 0 != 0 ( nurl_str_eq ( string_data rl_stem ) want ) { = rank 2 } {}
+    ? & == rank 0 != 0 ( nurl_str_eq ( string_data base ) want ) { = rank 3 } {}
+    ? & == rank 0 != 0 ( nurl_str_eq ( string_data base_stem ) want ) { = rank 4 } {}
+    ( string_free rl ) ( string_free base )
+    ( string_free rl_stem ) ( string_free base_stem )
+    ^ rank
+}
+
+// Resolve a requested document to its path relative to docs_dir; ""
+// when nothing matches (or the name tried to escape the tree).
+@ msearch_docs_resolve s docs_dir s name → String {
+    : String want ( __ms_docs_norm name )
+    : ~ String best ( string_new )
+    ? == ( string_len want ) 0 {
+        ( string_free want )
+        ^ best
+    } {}
+    : Json files ( json_arr_new )
+    ( msearch_walk_md_files files docs_dir `` )
+    : i nf ( json_arr_len files )
+    : ~ i best_rank 0
+    : ~ i k 0
+    ~ < k nf {
+        ?? ( json_arr_get files k ) {
+            T fo → {
+                ?? ( json_obj_get fo `path` ) {
+                    T pj → {
+                        ? ( json_is_str pj ) {
+                            : s rel ( json_as_str pj )
+                            : i rank ( __ms_docs_rank rel ( string_data want ) )
+                            ? & > rank 0 | == best_rank 0 < rank best_rank {
+                                = best_rank rank
+                                ( string_free best )
+                                = best ( string_from rel )
+                            } {}
+                        } {}
+                    }
+                    F _ → {}
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( json_free files )
+    ( string_free want )
+    ^ best
+}
+
+// The listing an agent gets when it calls nurl_docs with no `name`:
+// every document under docs_dir with its size and title.
+@ msearch_docs_list s docs_dir → String {
+    : Json files ( json_arr_new )
+    ( msearch_walk_md_files files docs_dir `` )
+    : i nf ( json_arr_len files )
+    : String out ( string_with_cap 2048 )
+    ( string_push_int out nf )
+    ( string_push_str out ` document(s) under docs/ — pass 'name' to read one (e.g. name='MEMORY.md').\n\n` )
+    : ~ i k 0
+    ~ < k nf {
+        ?? ( json_arr_get files k ) {
+            T fo → {
+                : ~ s rel ``
+                ?? ( json_obj_get fo `path` ) {
+                    T pj → { ? ( json_is_str pj ) { = rel ( json_as_str pj ) } {} }
+                    F _ → {}
+                }
+                ? > ( nurl_str_len rel ) 0 {
+                    ( string_push_str out `  ` )
+                    ( string_push_str out rel )
+                    // Pad to a column so the sizes line up.
+                    : ~ i pad ( nurl_str_len rel )
+                    ~ < pad 30 { ( string_push_char out 32 ) = pad + pad 1 }
+                    ?? ( json_obj_get fo `bytes` ) {
+                        T bj → {
+                            ( string_push_char out 32 )
+                            ( string_push_int out / ( json_as_int bj ) 1024 )
+                            ( string_push_str out ` KB` )
+                        }
+                        F _ → {}
+                    }
+                    : String fp ( path_join docs_dir rel )
+                    : !( Vec u ) IoErr rd ( read_file_bytes ( string_data fp ) )
+                    ( string_free fp )
+                    ?? rd {
+                        T bytes → {
+                            : String src ( bytes_to_str bytes )
+                            ( vec_free [u] bytes )
+                            : String t ( __ms_docs_title src )
+                            ? > ( string_len t ) 0 {
+                                ( string_push_str out ` — ` )
+                                ( string_push_str out ( string_data t ) )
+                            } {}
+                            ( string_free t )
+                            ( string_free src )
+                        }
+                        F _ → {}
+                    }
+                    ( string_push_char out 10 )
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ( json_free files )
+    ? == nf 0 {
+        ( string_push_str out `(no .md files under the configured docs directory)\n` )
+    } {}
+    ^ out
+}
+
+// One document, from byte `offset`, capped. "" when `name` resolves to
+// nothing — the caller turns that into an error listing what exists.
+@ msearch_docs_read s docs_dir s name i offset → String {
+    : String rel ( msearch_docs_resolve docs_dir name )
+    ? == ( string_len rel ) 0 {
+        ( string_free rel )
+        ^ ( string_new )
+    } {}
+    : String fp ( path_join docs_dir ( string_data rel ) )
+    : !( Vec u ) IoErr rd ( read_file_bytes ( string_data fp ) )
+    ( string_free fp )
+    : String out ( string_with_cap 4096 )
+    ?? rd {
+        T bytes → {
+            : String src ( bytes_to_str bytes )
+            ( vec_free [u] bytes )
+            : i n ( string_len src )
+            : ~ i from ? < offset 0 0 offset
+            ? > from n { = from n } {}
+            : i left - n from
+            : i keep ? > left ( __ms_docs_cap ) ( __ms_docs_cap ) left
+            ( string_push_str out `docs/` )
+            ( string_push_str out ( string_data rel ) )
+            ? > from 0 {
+                ( string_push_str out ` [bytes ` )
+                ( string_push_int out from )
+                ( string_push_str out `–` )
+                ( string_push_int out + from keep )
+                ( string_push_str out ` of ` )
+                ( string_push_int out n )
+                ( string_push_char out 93 )
+            } {}
+            ( string_push_char out 10 )
+            ( string_push_char out 10 )
+            : String slice ( string_substr src from keep )
+            ( string_push_str out ( string_data slice ) )
+            ( string_free slice )
+            ( string_free src )
+            ? > left keep {
+                ( string_push_str out `\n… truncated at ` )
+                ( string_push_int out + from keep )
+                ( string_push_str out ` of ` )
+                ( string_push_int out n )
+                ( string_push_str out ` bytes — continue with offset=` )
+                ( string_push_int out + from keep )
+                ( string_push_char out 10 )
+            } {}
+        }
+        F _ → {
+            ( string_push_str out `docs/` )
+            ( string_push_str out ( string_data rel ) )
+            ( string_push_str out ` could not be read.\n` )
+        }
+    }
+    ( string_free rel )
+    ^ out
 }
 
 // basename after the last '/'

--- a/tools/get-nurl.ps1
+++ b/tools/get-nurl.ps1
@@ -133,7 +133,7 @@ try {
         # registry token (credentials), the model cache (models\), tool
         # assets (share\), and any program installed with `nurlpkg install`
         # (bin\<other>). Only the toolchain's own paths are removed; the
-        # archive overwrites the rest. build\, stdlib\, zig\ and libexec\
+        # archive overwrites the rest. build\, stdlib\, docs\, zig\ and libexec\
         # go wholesale so a file deleted upstream cannot linger.
         #
         # Windows cannot DELETE a running executable — and `nurl upgrade`
@@ -148,7 +148,7 @@ try {
                         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
                 }
             }
-            foreach ($d in @("build", "stdlib", "zig", "libexec")) {
+            foreach ($d in @("build", "stdlib", "docs", "zig", "libexec")) {
                 Remove-ToolchainPath (Join-Path $Prefix $d)
             }
             foreach ($f in @("nurl.bat", "nurl.sh", "env",

--- a/tools/get-nurl.sh
+++ b/tools/get-nurl.sh
@@ -169,7 +169,7 @@ esac
 #   bin/<other tools>    programs installed via nurlpkg install
 # Wiping the whole prefix (as this did) silently logged the user out and
 # removed every installed tool. Remove only the toolchain's OWN paths —
-# the four shipped binaries, build/, stdlib/, zig/, libexec/, the shims —
+# the four shipped binaries, build/, stdlib/, docs/, zig/, libexec/, the shims —
 # and let tar overwrite the rest. Those directories are removed wholesale
 # so a file deleted upstream cannot linger.
 #
@@ -179,7 +179,7 @@ esac
 # Windows installer has to work around the same case differently.
 if [ -e "$PREFIX" ]; then
     if [ -x "$PREFIX/bin/nurl" ] || [ -x "$PREFIX/bin/nurlc" ] || [ -z "$(ls -A "$PREFIX" 2>/dev/null)" ]; then
-        rm -rf "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/zig" "$PREFIX/libexec"
+        rm -rf "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/docs" "$PREFIX/zig" "$PREFIX/libexec"
         rm -f  "$PREFIX/nurl.sh" "$PREFIX/nurl.bat" "$PREFIX/env" \
                "$PREFIX/bin/nurl" "$PREFIX/bin/nurlc" \
                "$PREFIX/bin/nurlfmt" "$PREFIX/bin/nurlpkg"

--- a/tools/install-toolchain.bat
+++ b/tools/install-toolchain.bat
@@ -18,6 +18,7 @@ REM  Layout (%NURL_HOME%, default %USERPROFILE%\.nurl):
 REM    %PREFIX%\build\nurlc.exe          the compiler
 REM    %PREFIX%\build\nurlpkg.exe        the package manager
 REM    %PREFIX%\stdlib\                  the stdlib tree (+ runtime.o)
+REM    %PREFIX%\docs\                    the documentation tree (nurl_docs)
 REM    %PREFIX%\nurl.bat                 the .nu -> native build driver
 REM    %PREFIX%\bin\{nurl,nurlc,nurlpkg}.bat   PATH shims (set NURL_STDLIB)
 REM    %PREFIX%\env.bat                  sets NURL_STDLIB + PATH for a session
@@ -69,6 +70,10 @@ if exist "%ROOT%\build\nurlfmt.exe" (
 
 REM Stdlib tree (incl. runtime.o, runtime.<feature> link sentinels, canvas.o).
 xcopy /e /i /y /q "%ROOT%\stdlib" "%PREFIX%\stdlib" >nul
+
+REM Documentation tree - what the nurl-mcp nurl_docs tool serves
+REM (%NURL_STDLIB%\docs, i.e. right here). Text only, a few hundred KB.
+xcopy /e /i /y /q "%ROOT%\docs" "%PREFIX%\docs" >nul
 
 REM Build driver (resolves build\nurlc.exe + stdlib\runtime.o relative to itself).
 copy /y "%ROOT%\nurl.bat" "%PREFIX%\nurl.bat" >nul
@@ -149,6 +154,7 @@ if "%HAVE_NURLFMT%"=="1" (
   echo   installed:  nurl, nurlc, nurlpkg  -^> %PREFIX%\bin
 )
 echo   stdlib:     %%NURL_STDLIB%%        -^> %PREFIX%\stdlib
+echo   docs:                             -^> %PREFIX%\docs
 echo.
 echo Activate it in this shell:
 echo     call "%PREFIX%\env.bat"
@@ -165,6 +171,7 @@ exit /b 0
 if exist "%PREFIX%\bin"      rmdir /s /q "%PREFIX%\bin"
 if exist "%PREFIX%\build"    rmdir /s /q "%PREFIX%\build"
 if exist "%PREFIX%\stdlib"   rmdir /s /q "%PREFIX%\stdlib"
+if exist "%PREFIX%\docs"     rmdir /s /q "%PREFIX%\docs"
 if exist "%PREFIX%\zig"      rmdir /s /q "%PREFIX%\zig"
 if exist "%PREFIX%\nurl.bat" del /q "%PREFIX%\nurl.bat"
 if exist "%PREFIX%\env.bat"  del /q "%PREFIX%\env.bat"

--- a/tools/install-toolchain.sh
+++ b/tools/install-toolchain.sh
@@ -18,6 +18,7 @@
 #    $PREFIX/build/nurlc            the compiler
 #    $PREFIX/build/nurlpkg          the package manager
 #    $PREFIX/stdlib/                the stdlib tree (+ runtime.o, sentinels)
+#    $PREFIX/docs/                  the documentation tree (nurl-mcp nurl_docs)
 #    $PREFIX/nurl.sh               the .nu → native build driver
 #    $PREFIX/bin/{nurl,nurlc,nurlpkg}   PATH shims (export NURL_STDLIB)
 #    $PREFIX/env                   sourceable: exports NURL_STDLIB + PATH
@@ -33,7 +34,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PREFIX="${NURL_HOME:-$HOME/.nurl}"
 
 if [[ "${1:-}" == "--uninstall" ]]; then
-    rm -rf "$PREFIX/bin" "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/zig" "$PREFIX/nurl.sh" "$PREFIX/env"
+    rm -rf "$PREFIX/bin" "$PREFIX/build" "$PREFIX/stdlib" "$PREFIX/docs" "$PREFIX/zig" "$PREFIX/nurl.sh" "$PREFIX/env"
     echo "Removed NURL toolchain from $PREFIX"
     echo "(You may want to drop the 'source $PREFIX/env' line from your shell rc.)"
     exit 0
@@ -67,6 +68,14 @@ fi
 # nurl.sh consults, and any canvas.o. Copy the whole directory so the
 # installed driver links exactly like the in-tree one.
 cp -a "$ROOT/stdlib/." "$PREFIX/stdlib/"
+
+# Documentation tree — MEMORY.md, CRYPTO.md, spec.md, … This is what the
+# nurl-mcp `nurl_docs` tool serves ($NURL_STDLIB/docs, i.e. right here),
+# so an agent driving the installed toolchain can read how ownership,
+# crypto or async actually behave instead of inferring it from
+# signatures. Text only; a few hundred KB.
+mkdir -p "$PREFIX/docs"
+cp -a "$ROOT/docs/." "$PREFIX/docs/"
 
 # Build driver (resolves build/nurlc + stdlib/runtime.o relative to itself).
 install -m755 "$ROOT/nurl.sh" "$PREFIX/nurl.sh"
@@ -189,6 +198,7 @@ else
     echo "  installed:  nurl, nurlc, nurlpkg  → $PREFIX/bin"
 fi
 echo "  stdlib:     \$NURL_STDLIB                  → $PREFIX/stdlib"
+echo "  docs:                                     → $PREFIX/docs"
 echo
 echo "Activate it in this shell and future ones:"
 echo "    source $PREFIX/env"


### PR DESCRIPTION
Two gaps in the MCP search surface. One shared engine (`stdlib/ext/mcp_search.nu`), so the hosted playground and the local `nurl-mcp` gain both together.

## `nurl_docs` — the documentation an agent could not reach

`nurl_api` answers "what is the signature". It never answers "who frees this", "which cipher suites ship", or "does this target have threads". Those answers are written down in `docs/MEMORY.md`, `docs/CRYPTO.md` and `docs/PLATFORMS.md` — and exactly one of the fourteen documents had a tool (`nurl_read_gotchas`). A model driving NURL through MCP was guessing at precisely the questions the project has already answered.

- No argument → the index: path, size, title.
- `name=` → one document. Matched forgivingly: `MEMORY`, `memory.md`, `docs/MEMORY.md`, `./memory.md` and a bare basename for a nested file (`COMPILER_INTERNALS` → `dev/COMPILER_INTERNALS.md`) all land on the same file. A model that has to guess the exact spelling spends calls guessing it.
- 48 KB per call; the truncation line prints the exact `offset` for the rest, so `spec.md` (63 KB) is two calls rather than silently cut.
- A name that matches nothing answers **with the index**, turning a wrong guess into the right next call.
- `..` is refused.

`install-toolchain.{sh,bat}` now ship `docs/` into the prefix, so the local server resolves `$NURL_DOCS`, else `$NURL_STDLIB/docs`, and an installed toolchain carries its own documentation. `get-nurl.{sh,ps1}` clear `docs/` on upgrade alongside the other toolchain-owned paths (served copies re-synced; `check_installer_sync.sh` passes).

## `nurl_api` — OR widening before the corpus widening

The query search AND-matches its terms. That is right when a model names one thing two ways, and wrong when it names a *concept*: nothing in the stdlib is one declaration containing all of `string`, `builder` and `append`, and `vec_push new string_new` is three different functions. Both returned zero and jumped to examples + registry — straight past `string_push_str`, which was sitting right there.

A zero-hit query is now re-run as an OR over the same declaration blocks, with two rules that keep the answer small:

- **Whole words only.** The adjacent byte must not be a letter, so `string` hits `string_push_str`, `string_new` and "a string", and misses `substring`. Same boundary rule `nurl_grep` already ranks by.
- **Ranked by coverage, terms weighted by length.** `new` is three characters half the constructors contain; `vec_push` is eight that name one function. A term in the declaration's own *name* outranks one in its prose. Top twelve, labelled `[2/3 terms]`.

Only if the OR pass finds nothing does the reply widen to examples and the registry, so the corpus fallback no longer buries a real answer.

| query | before | after |
|---|---|---|
| `string builder append` | 0 hits → registry | `zip_finish`, `core/string.nu › string_push_bytes`, … |
| `vec_push new string_new` | 0 hits → registry | `string_new`, then `vec_push`, `vec_insert` |
| `hash map insert` | 0 hits → registry | the whole of `std/hashmap.nu` |
| `zzzqqq wwwxxx` | widens | widens (unchanged) |

The pass costs ~38 ms over the whole stdlib and only runs on the zero-hit path. The exact-package-name footer still fires when the corpus widening does not.

## Also

`nm_version` said `0.8.0` while `nurl.toml` said `0.9.0`, so the handshake misreported the package it shipped as. The comment above that constant asks for exactly one string to bump; this is that string.

## Testing

- 40 new/updated e2e assertions in `nurlapi/e2e_test.py` — the `nurl_docs` index, forgiving names, paging, traversal refusal, unknown-name-returns-index; the OR pass, its coverage labels, and that an OR hit suppresses the corpus widening. All green against a live `nurlapi`; the wider MCP suite is 76/76.
- `nurl_docs` verified end to end through the real `nurl-mcp` stdio binary against a clean `install-toolchain.sh` prefix.
- The advertised tool count was **already stale** — the test asserted 18 against a 19-tool server, drift dating to `nurl_build_unikernel`. Now 20 in both places it is checked.
- `nurlfmt --check` (901 files), `tools/leakcheck/run.sh`, and `check_{stdlib_symbols,package_imports,builtins_doc,installer_sync}.sh` all pass. ASan + LSan clean on every new path.

## Note on release ordering

`nurl-mcp` 0.9.0 is **already published** to the registry and needs the `msearch_docs_*` functions this PR adds to the stdlib. Until a toolchain release carries them, `nurlpkg install nurl-mcp` fails to compile for anyone on ≤ 0.35.0. This should land before the next toolchain release, or the package's `description` should state the minimum the way `swarm-mcp` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2RiWTSaoydkCaimceEkys
