### PR TITLE
The RISC-V entropy gate rejected correct entropy one run in 4.5

### DIFF
--- a/unikernel/run_qemu_riscv64_tests.sh
+++ b/unikernel/run_qemu_riscv64_tests.sh
@@ -119,14 +119,29 @@ if [ $# -eq 0 ]; then
         wrc=$?
         nodev=$(boot "$OUTDIR/entropy_rv.elf" -t 120 2>&1)
         nrc=$?
+        # The two ways a FAKE source looks plausible are the ones the
+        # guest counts: a draw that is ALL zeroes (a device that
+        # answered without writing), and two draws that are IDENTICAL
+        # (a constant, or one buffer read twice). So the thresholds are
+        # 32, not 0.
+        #
+        # Asserting zeros=0 and same_bytes=0 — "no byte is zero, and no
+        # position matches" — is not a property of randomness but of
+        # unlikely randomness. With 32 uniform bytes each has
+        # probability 1-(255/256)^32 = 11.8%, so the gate rejected
+        # CORRECT entropy on ~22% of runs, about one in 4.5. That is
+        # what it was doing: the same commit passed and failed hours
+        # apart with nothing between the two runs but the dice.
+        wz=$(printf '%s' "$withdev" | sed -n 's/^zeros=\([0-9]*\)$/\1/p')
+        ws=$(printf '%s' "$withdev" | sed -n 's/^same_bytes=\([0-9]*\)$/\1/p')
         if [ "$wrc" = 0 ] \
-           && printf '%s' "$withdev" | grep -q '^zeros=0$' \
-           && printf '%s' "$withdev" | grep -q '^same_bytes=0$' \
+           && [ -n "$wz" ] && [ "$wz" != 32 ] \
+           && [ -n "$ws" ] && [ "$ws" != 32 ] \
            && [ "$nrc" = 127 ] \
            && printf '%s' "$nodev" | grep -q 'virtio-rng'; then
             echo "PASS entropy (device gives bytes; absence is refused by name)"
         else
-            echo "FAIL entropy (with-device exit $wrc, without exit $nrc)"
+            echo "FAIL entropy (with-device exit $wrc, without exit $nrc; zeros=${wz:-?}/32, same_bytes=${ws:-?}/32 — 32 means a fake source)"
             printf '%s\n' "$withdev" | head -4 | sed 's/^/     /'
             printf '%s\n' "$nodev" | head -2 | sed 's/^/     /'
             fails=$((fails + 1))


### PR DESCRIPTION
## What was happening

Four red builds today with no defect behind any of them:

| when | commit | failed on |
|---|---|---|
| 19:50 | `fad6c02` (main) | — passed |
| 22:27 | PR #817 | cloud-hypervisor CPUID |
| 22:35 | PR #817 (re-run) | cloud-hypervisor CPUID |
| 22:46 | `fad6c02` **re-run, unchanged** | `zeros=1` |
| 22:57 | PR #817 (re-run) | `same_bytes` |

The same commit passing and failing hours apart, with nothing between the runs, is the tell.

## The cause

The entropy gate asserted:

```sh
grep -q '^zeros=0$'  &&  grep -q '^same_bytes=0$'
```

That reads: *no byte of a 32-byte draw is zero, and no byte position matches between two draws*. Neither is a property of randomness — each holds only with probability `(255/256)^32 ≈ 88.2%`:

```
P(at least one zero byte in 32)   = 0.1177
P(at least one matching position) = 0.1177
P(gate fails on CORRECT entropy)  = 0.2216   ≈ one run in 4.5
```

## The fix

The guest program already counts the right quantities, and its own comment says what they are for:

> the two ways a fake entropy source looks plausible: all zeroes (a device that answered without writing), and two draws that match (a source that is a constant, or a buffer read twice)

"All zeroes" is `zeros == 32`. "Two draws that match" is `same_bytes == 32`. The thresholds were on the wrong end of the range. The gate now rejects **32**, not 0.

It still catches both fake-source shapes it was built for — a device that writes nothing, and a constant source — and no longer fails on the dice. The FAIL line now prints both counts out of 32, so the next real failure reads as one.

## Note on the cloud-hypervisor failures

Two of the five runs above failed earlier, at `hypervisor_gate`, with `Failed to set Cpuid: failed to create CpuId` — cloud-hypervisor unable to configure a vCPU on the runner. That is a separate, environment-level flake and is **not** addressed here; the same job passed that step on other attempts. Worth watching, but it is a different problem from this one and shouldn't be folded into a fix that has a proof behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2RiWTSaoydkCaimceEkys
