### PR TITLE
--strict-arity, and the gate that found a real bug with it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,18 @@ jobs:
         # nurlfmt IR-transparent (compiler/tests/nurlfmt_idempotent.sh).
         run: ./compiler/tests/nurlfmt_check.sh
 
+      - name: strict-arity gate (the n-ary '&'/'|' trap)
+        # `? & a b c d { then } { else }` reads as a four-way AND and is
+        # not one: `&` is BINARY, so `c` and `d` become the bare
+        # then/else values and the two blocks run as plain statements.
+        # The conditional logic is wrong and the compiler still emits a
+        # working binary, so nothing downstream can notice. nurlc warns
+        # by default and errors under --strict-arity; this runs the
+        # strict compiler over the whole first-party tree. Its first run
+        # found examples/audio_sparcles2.nu culling every particle on
+        # every frame, which is the class of bug it exists to stop.
+        run: ./tools/check_strict_arity.sh
+
       - name: HTTP-server per-request leak gate
         # Builds the leakcheck HTTP server with ASan+LSan and fails on ANY
         # leak across 21 requests. Uses the normal build/nurlc from ./build.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--strict-arity`, and a CI gate that runs it over the whole tree.**
+  The n-ary `&`/`|` foot-gun is the language's one remaining
+  source-level trap, and its outcome is the worst available: `? & a b c
+  d { … } { … }` reads as `? (& a b) c d`, so the last two comparisons
+  become the bare then/else values, both blocks run as ordinary
+  statements, the conditional logic is wrong — and the compiler emits a
+  working binary with `status: ok`, so nothing downstream can notice.
+  `nurlc --strict-arity` makes it an error; the default stays a warning
+  (now naming the flag) so existing trees keep building.
+  `tools/check_strict_arity.sh` runs the strict compiler over every
+  first-party `.nu` file and is wired into CI.
+
+  The gate found the shape it was written for on its first run.
+  `examples/audio_sparcles2.nu` had `? & >= x 0 < x W & >= y 0 < y H {}
+  { = . plife i 0 }` for "kill particles that wander off-screen": the
+  condition was only the x test, the y test was swallowed as the bare
+  then-value, and the kill ran unconditionally — culling **every**
+  particle on **every** frame. Fixed with the third `&` it always needed.
+
 ### Fixed
 
 - **`ext/json` string parsing now follows RFC 8259, and the module's own

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ mutation with `: ~`). A **static borrow checker** — on by default,
 `--no-borrowck` to disable, `--strict-borrowck` to tighten — catches
 use-after-move, alias-double-free, escaping closure-captures, and iterator
 invalidation as hard compile errors, without ever changing generated code.
+`--strict-arity` closes the one remaining source-level trap, the n-ary
+`&`/`|` foot-gun, which is a warning by default because the program it
+describes still compiles.
 Full model and the not-yet-checked list: [`docs/MEMORY.md`](docs/MEMORY.md).
 
 The type system is strong, static, inferred, algebraic (sum types `|`,

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -868,6 +868,14 @@
 // Disabled by default because the extensions have a meaningful
 // false-positive rate against existing stdlib code.
 : ~ i g_strict_borrowck 0  // 1 when --strict-borrowck passed on the CLI
+// --strict-arity: promote the n-ary `&`/`|` arity warning to an error.
+// The trap is the language's one documented foot-gun and it currently
+// produces `status: ok` plus a binary whose conditional logic is wrong
+// — the worst possible outcome, because nothing downstream can tell.
+// Default stays a warning so existing trees keep building; a project
+// that wants the guarantee turns it on in CI, which is what this repo
+// now does for its own corpus.
+: ~ i g_strict_arity 0  // 1 when --strict-arity passed on the CLI
 : ~ i g_ptrtab 0  // sym handle for the dangling-borrow tracker (unscoped)
 : ~ i g_bck 0  // sym handle for the borrow checker's per-function
 //  data (statement list etc.); allocated in main()
@@ -7311,7 +7319,9 @@
     // `{ ... }` blocks then run as side-effect statements. Warn —
     // the program compiles but the conditional logic is wrong.
     ? == ( nurl_lex_type lex ) TT_LBRACE
-    { ( warn_pos lex bck_cline bck_ccol `'?' consumed bare then/else values, but a '{ ... }' block follows. Likely too few '&'/'|' operators in the condition (each is BINARY — write '& & a b c d' for n-ary).` ) }
+    { ? != 0 g_strict_arity
+        { ( die_pos lex bck_cline bck_ccol `error: '?' consumed bare then/else values, but a '{ ... }' block follows. Likely too few '&'/'|' operators in the condition (each is BINARY — write '& & a b c d' for n-ary).` ) }
+        { ( warn_pos lex bck_cline bck_ccol `'?' consumed bare then/else values, but a '{ ... }' block follows. Likely too few '&'/'|' operators in the condition (each is BINARY — write '& & a b c d' for n-ary). Compile with --strict-arity to make this an error.` ) } }
     {}
     // pick a consistent phi type: prefer the non-void live branch type;
     // if both live and types differ, fall back to void (no phi needed).
@@ -22623,21 +22633,23 @@
                             { = g_borrowck 0 }
                             { ? ( seq a `--strict-borrowck` )
                                 { = g_borrowck 1 = g_strict_borrowck 1 }
-                                { ? ( seq a `--ffi-host-imports` )
-                                    { = g_ffi_host_imports 1 }
-                                    { ? ( seq a `--no-dce` )
-                                        { = g_dce 0 }
-                                        { ? != 0 ( nurl_str_starts a `--split=` )
-                                            { = g_split_max ( nurl_str_to_int ( nurl_str_slice a 8 - ( nurl_str_len a ) 8 ) ) }
-                                            { ? != 0 ( nurl_str_starts a `--split-out=` )
-                                                { = g_split_out ( nurl_str_slice a 12 - ( nurl_str_len a ) 12 ) }
-                                                { ? != 0 ( nurl_str_starts a `--split-min=` )
-                                                    { = g_split_min ( nurl_str_to_int ( nurl_str_slice a 12 - ( nurl_str_len a ) 12 ) ) }
-                                                    { = path a } } } } } } } } } } } }
+                                { ? ( seq a `--strict-arity` )
+                                    { = g_strict_arity 1 }
+                                    { ? ( seq a `--ffi-host-imports` )
+                                        { = g_ffi_host_imports 1 }
+                                        { ? ( seq a `--no-dce` )
+                                            { = g_dce 0 }
+                                            { ? != 0 ( nurl_str_starts a `--split=` )
+                                                { = g_split_max ( nurl_str_to_int ( nurl_str_slice a 8 - ( nurl_str_len a ) 8 ) ) }
+                                                { ? != 0 ( nurl_str_starts a `--split-out=` )
+                                                    { = g_split_out ( nurl_str_slice a 12 - ( nurl_str_len a ) 12 ) }
+                                                    { ? != 0 ( nurl_str_starts a `--split-min=` )
+                                                        { = g_split_min ( nurl_str_to_int ( nurl_str_slice a 12 - ( nurl_str_len a ) 12 ) ) }
+                                                        { = path a } } } } } } } } } } } } }
         = ai + ai 1
     }
     ? == 0 ( nurl_str_len path )
-    { ( nurl_eprintln `usage: nurlc [--version] [--g] [--lint] [--no-borrowck | --strict-borrowck] [--ffi-host-imports] [--no-dce] [--split=N --split-out=PREFIX] <file.nu>` ) ( nurl_exit 1 ) }
+    { ( nurl_eprintln `usage: nurlc [--version] [--g] [--lint] [--no-borrowck | --strict-borrowck] [--strict-arity] [--ffi-host-imports] [--no-dce] [--split=N --split-out=PREFIX] <file.nu>` ) ( nurl_exit 1 ) }
     {}
     // --split writes files, so it needs somewhere to write them. Cap it
     // at 64: past the core count the parts only get smaller, and each

--- a/compiler/tests/arity_strict_nary.nu
+++ b/compiler/tests/arity_strict_nary.nu
@@ -1,0 +1,28 @@
+// arity_strict_nary.nu — the n-ary `&` trap, as an error.
+//
+// `&` and `|` take exactly TWO operands. Four conditions therefore need
+// three of them. Written with one, `?` takes `& a b` as the condition
+// and then consumes the remaining two comparisons as its bare then/else
+// values — after which the `{ … } { … }` blocks run as ordinary
+// statements. The conditional logic is wrong and the program still
+// compiles, which is the entire reason this needs a flag and a gate:
+// nothing downstream of the compiler can tell.
+//
+// Baselined for the diagnostic TEXT, because where it points is the
+// point. The trap can only be DETECTED once the `{` after the
+// conditional is reached, and reporting the lexer's position at that
+// moment put the caret on the closing `} {}` — below the mistake,
+// pointing at the consequence. It must name the `?` on line 20.
+//
+// Expected: COMPILE FAIL under --strict-arity, caret at 20:5.
+
+@ f i a i b i c i d → i {
+    ? & >= a 0 < a b >= c 0 < c d {
+        ^ 1
+        // A body long enough that the closing brace is nowhere near the
+        // `?` — which is exactly when a caret on the brace misleads.
+    } {}
+    ^ 0
+}
+
+@ main → i { ^ ( f 1 2 3 4 ) }

--- a/compiler/tests/outputs/arity_strict_nary.txt
+++ b/compiler/tests/outputs/arity_strict_nary.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/arity_strict_nary.nu:20:5: error: '?' consumed bare then/else values, but a '{ ... }' block follows. Likely too few '&'/'|' operators in the condition (each is BINARY — write '& & a b c d' for n-ary).
+    ? & >= a 0 < a b >= c 0 < c d {
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/run_tests.sh
+++ b/compiler/tests/run_tests.sh
@@ -179,6 +179,18 @@ run_one() {
             { echo "COMPILE FAIL"; } > "$act"
             if [[ -s "$err" ]]; then strip_root "$err"; echo "ERRORS" >> "$act"; append_capped "$act" "$err"; fi
         fi
+    # ── arity_strict_* — the n-ary '&'/'|' trap, which is only an
+    #                     error under --strict-arity. The diagnostic
+    #                     text is baselined because WHERE it points is
+    #                     the point: it must name the `?`, not the `{}`
+    #                     that finally revealed the mistake.
+    elif [[ "$name" == arity_strict_* ]]; then
+        if "$NURLC" --strict-arity "$src" > "$ll" 2>"$err"; then
+            { echo "COMPILE OK"; echo "(expected COMPILE FAIL but compiler accepted it)"; } > "$act"
+        else
+            { echo "COMPILE FAIL"; } > "$act"
+            if [[ -s "$err" ]]; then strip_root "$err"; echo "ERRORS" >> "$act"; append_capped "$act" "$err"; fi
+        fi
     # ── should_fail_* — COMPILE FAIL is the expected outcome ──
     elif [[ "$name" == should_fail_* ]]; then
         if "$NURLC" "$src" > "$ll" 2>"$err"; then

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -11,6 +11,29 @@ and the concrete cure inline, so a wrong program tells you what to fix at the
 point you wrote it. If you hit a NURL compile error, the diagnostic is the
 source of truth — read it rather than guessing.
 
+One trap deserves naming because the compiler's report is a **warning**
+by default, and the program it describes still builds: every operator has
+a **fixed arity**, and `&` / `|` take exactly two operands. So
+
+```nurl
+? & a b c d { then } { else }        // NOT a four-way AND
+```
+
+reads as `? (& a b) c d`, leaving `c` and `d` consumed as the bare
+then/else values and the two blocks running as ordinary statements — the
+conditional logic is wrong and the binary works, which is why nothing
+downstream notices. Write n-1 operators for n conditions:
+
+```nurl
+? & & & a b c d { then } { else }    // (((a & b) & c) & d)
+```
+
+`nurlc` points its caret at the `?` and names the cure. Compile with
+`--strict-arity` to make it an error; this repo runs
+`tools/check_strict_arity.sh` over its whole first-party tree in CI, and
+that gate's first run found a shipped example culling every particle on
+every frame for exactly this reason.
+
 The few things that are *not* surprises but fixed properties of the language
 or its runtime live in their proper homes, not here:
 

--- a/examples/audio_sparcles2.nu
+++ b/examples/audio_sparcles2.nu
@@ -158,8 +158,11 @@
                         = . fb + * y W x col
                     } {}
                 } {}
-                // Kill particles that wander off‑screen.
-                ? & >= x 0 < x W & >= y 0 < y H {} { = . plife i 0 }
+                // Kill particles that wander off‑screen. Four conditions,
+                // so three `&` — with two, the y test was consumed as the
+                // bare then-value and the kill ran as an unconditional
+                // statement, culling every particle on every frame.
+                ? & & & >= x 0 < x W >= y 0 < y H {} { = . plife i 0 }
             } {}
             = i + i 1
         }

--- a/tools/check_strict_arity.sh
+++ b/tools/check_strict_arity.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Dual-licensed under MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE) at your option.
+# ============================================================
+#  check_strict_arity.sh — no first-party file may contain the
+#  n-ary `&`/`|` arity trap.
+#
+#  `? & a b c d { then } { else }` reads as a four-way AND and is
+#  not one: `&` is BINARY, so it takes `a b`, then `c` and `d` are
+#  consumed as the bare then/else values and the two blocks that
+#  follow run as plain statements. The conditional logic is wrong
+#  and the compiler still emits a working binary — nothing
+#  downstream can tell, which is what makes it worth a gate.
+#
+#  nurlc warns about this by default (so third-party trees keep
+#  building) and errors under --strict-arity. This script runs the
+#  strict compiler over every first-party .nu file.
+#
+#  It found the shape it was written for on its first run:
+#  examples/audio_sparcles2.nu culled EVERY particle on every frame
+#  because the off-screen test's second half had been swallowed and
+#  the kill ran unconditionally.
+#
+#  Usage:
+#    ./tools/check_strict_arity.sh            # whole first-party tree
+#    ./tools/check_strict_arity.sh FILE…      # just those files
+#
+#  Exit codes:
+#    0 — clean
+#    1 — at least one file carries the trap (offenders listed)
+#    2 — environment problem (nurlc missing)
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+NURLC="$ROOT_DIR/build/nurlc"
+if [[ ! -x "$NURLC" ]]; then
+    echo "ERROR: $NURLC not found. Run ./build.sh first." >&2
+    exit 2
+fi
+
+if [[ $# -ge 1 ]]; then
+    FILES=("$@")
+else
+    mapfile -t FILES < <(
+        {
+            find stdlib         -name '*.nu' -type f
+            find examples       -name '*.nu' -type f
+            find compiler/tests -name '*.nu' -type f
+            find tools          -name '*.nu' -type f
+            find nurlapi        -name '*.nu' -type f
+            find packages       -name '*.nu' -type f -not -path '*/deps/*'
+            echo compiler/nurlc.nu
+        } | sort -u
+    )
+fi
+
+# compiler/tests/ carries fixtures whose JOB is to be wrong: the runner
+# reads their name prefix and expects them to fail. `arity_strict_*` is
+# this diagnostic's own regression, so the gate would flag the test that
+# proves the gate works. Those prefixes are skipped — a fixture that
+# demonstrates the trap is not a file that ships it.
+is_deliberate_failure() {
+    case "$1" in
+        compiler/tests/should_fail_*|compiler/tests/borrow_*|\
+        compiler/tests/diag_*|compiler/tests/arity_strict_*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Only the arity diagnostic counts. A file that fails to compile for an
+# unrelated reason (a package module that needs its deps/ resolved, say)
+# is not this gate's business — it has its own.
+OFFENDERS=()
+SKIPPED=0
+for f in "${FILES[@]}"; do
+    [[ -f "$f" ]] || continue
+    if is_deliberate_failure "$f"; then SKIPPED=$((SKIPPED + 1)); continue; fi
+    hit="$("$NURLC" --strict-arity "$f" 2>&1 >/dev/null \
+           | grep -F "consumed bare then/else values" || true)"
+    if [[ -n "$hit" ]]; then
+        OFFENDERS+=("$hit")
+    fi
+done
+
+if (( ${#OFFENDERS[@]} > 0 )); then
+    echo "ERROR: the n-ary '&'/'|' arity trap is present in ${#OFFENDERS[@]} place(s):" >&2
+    printf '%s\n' "${OFFENDERS[@]}" >&2
+    echo >&2
+    echo "Each '&' and '|' takes exactly TWO operands. For n conditions write" >&2
+    echo "n-1 of them up front:  ? & & & a b c d { then } { else }" >&2
+    exit 1
+fi
+
+echo "strict-arity: OK — $(( ${#FILES[@]} - SKIPPED )) files carry no arity trap ($SKIPPED deliberate-failure fixtures skipped)."

--- a/tools/check_strict_arity.sh
+++ b/tools/check_strict_arity.sh
@@ -59,15 +59,27 @@ else
     )
 fi
 
-# compiler/tests/ carries fixtures whose JOB is to be wrong: the runner
-# reads their name prefix and expects them to fail. `arity_strict_*` is
-# this diagnostic's own regression, so the gate would flag the test that
-# proves the gate works. Those prefixes are skipped — a fixture that
-# demonstrates the trap is not a file that ships it.
+# compiler/tests/ carries fixtures whose JOB is to be wrong — including
+# this diagnostic's own regression, so without an exclusion the gate
+# flags the test that proves the gate works.
+#
+# Ask the GOLDEN, not the name. A golden whose first line is
+# "COMPILE FAIL" marks a test the corpus expects the compiler to reject;
+# run_san_tests.sh chose that rule for exactly this reason ("and
+# whatever tomorrow's negative test is called"). A name list would be
+# the fourth copy in this repo, and the copy that gets forgotten fails
+# in a way that reads as a real defect.
 is_deliberate_failure() {
     case "$1" in
-        compiler/tests/should_fail_*|compiler/tests/borrow_*|\
-        compiler/tests/diag_*|compiler/tests/arity_strict_*) return 0 ;;
+        compiler/tests/*) ;;
+        *) return 1 ;;
+    esac
+    local base golden
+    base="$(basename "$1" .nu)"
+    golden="$ROOT_DIR/compiler/tests/outputs/$base.txt"
+    [[ -f "$golden" ]] || return 1
+    case "$(head -n 1 "$golden")" in
+        "COMPILE FAIL"*) return 0 ;;
         *) return 1 ;;
     esac
 }

--- a/unikernel/run_nolibc_tests.sh
+++ b/unikernel/run_nolibc_tests.sh
@@ -61,9 +61,17 @@ one() {
     golden="$TESTS/outputs/$name.txt"
     work="$OUTDIR/work/$name"
     mkdir -p "$work"
-    # should_fail_* and friends never produce a binary; skip by shape.
-    case "$name" in should_*|borrow_*|diag_*) echo "SKIP $name (compile-fail test)"; return 0 ;; esac
     [ -f "$golden" ] || { echo "SKIP $name (no golden)"; return 0; }
+    # A negative test never produces a binary, so there is nothing to run
+    # here. Ask the GOLDEN, not the name: run_san_tests.sh settled this
+    # rule already — "should_fail_*, diag_*, borrow_*, and whatever
+    # tomorrow's negative test is called". A name list has to be updated
+    # in every runner that keeps one, and the one that gets forgotten
+    # fails confusingly: arity_strict_* was added to the corpus and this
+    # runner tried to execute a program that is meant not to compile.
+    case "$(head -n 1 "$golden")" in
+        "COMPILE FAIL"*) echo "SKIP $name (compile-fail test)"; return 0 ;;
+    esac
 
     # Compile, and link in the NURL socket layer if this program needs
     # it — see unikernel/compile_nu.sh for why that is a recompile


### PR DESCRIPTION
The n-ary `&`/`|` foot-gun is the language's last source-level trap, and its failure mode is the worst available.

```nurl
? & a b c d { then } { else }
```

reads as `? (& a b) c d`. The last two comparisons become the bare then/else values, both blocks then run as ordinary statements, the conditional logic is wrong — and nurlc emits a **working binary with `status: ok`**. There is nothing downstream of the compiler that can notice.

## The flag

`nurlc --strict-arity` makes it an error. The default stays a warning (now naming the flag), so third-party trees keep building — the same shape as the existing `--strict-borrowck`.

`tools/check_strict_arity.sh` runs the strict compiler over every first-party `.nu` file and is wired into CI, so this repo cannot regress.

## What the gate found on its first run

`examples/audio_sparcles2.nu`, under the comment *"Kill particles that wander off-screen"*:

```nurl
? & >= x 0 < x W & >= y 0 < y H {} { = . plife i 0 }
```

Two `&` for four conditions. So the condition was **only the x test**, the y test was swallowed as the bare then-value, and the kill ran as an **unconditional statement** — culling every particle on every frame. The off-screen cull had never worked since the example was written. Fixed with the third `&` it always needed.

That is the whole argument for the gate: the bug is invisible in review, invisible at runtime except as "the effect looks wrong", and the compiler had been reporting it all along as a warning nobody was failing on.

## Corpus

`arity_strict_*` joins the existing `borrow_strict_*` convention — a name prefix the runner turns into a compiler flag — with the diagnostic text baselined, because **where** it points is the point:

```
compiler/tests/arity_strict_nary.nu:20:5: error: '?' consumed bare then/else values…
    ? & >= a 0 < a b >= c 0 < c d {
    ^
```

Line 20 is the `?`. Before the caret fix that shipped in #817, this would have pointed at the closing `} {}` four lines below.

The gate skips `compiler/tests/{should_fail,borrow,diag,arity_strict}_*` — fixtures whose job is to be wrong. It flagged its own regression test before that exclusion existed, which is a reasonable way to find out you need one.

## Testing

1092 first-party files clean (132 deliberate-failure fixtures skipped), corpus 615/615, `nurlfmt --check` 903 files, bootstrap fixed point holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2RiWTSaoydkCaimceEkys
