### PR TITLE
The borrow checker did not know vec_free_with frees its Vec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The borrow checker did not know `vec_free_with` frees its Vec.** The
+  destructor rule keyed on a `_free` SUFFIX, so `vec_free` consumed its
+  argument and `vec_free_with` did not — even though it releases
+  strictly more: the container, and every element through the dropper it
+  is handed. That is how the stdlib frees every `Vec` of owned elements,
+  so the blind spot sat on the most common shape. A Vec read after
+  `vec_free_with` compiled clean, with no diagnostic, and ran on freed
+  memory. It is now a `use of moved value` error like every other
+  use-after-free, with a `borrow_vec_free_with` regression.
+
 ### Added
 
 - **`--strict-arity`, and a CI gate that runs it over the whole tree.**

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -10463,8 +10463,15 @@
 // the return-type test below existed.
 @ bck_is_destructor_name s name → b {
     : i len ( nurl_str_len name )
-    ? < len 5 { ^ F } {}
-    ( seq ( nurl_str_slice name - len 5 5 ) `_free` )
+    ? & >= len 5 ( seq ( nurl_str_slice name - len 5 5 ) `_free` ) { ^ T } {}
+    // `vec_free_with` releases the container AND every element through
+    // the dropper it is handed — the same consumption as `vec_free`,
+    // spelled with a suffix the `_free`-ending rule did not reach. It is
+    // how the stdlib frees every Vec of owned elements, so the checker
+    // was blind to the use-after-free that follows one: a Vec read after
+    // vec_free_with compiled clean and ran on freed memory.
+    ? & >= len 10 ( seq ( nurl_str_slice name - len 10 10 ) `_free_with` ) { ^ T } {}
+    ^ F
 }
 
 // True when a call to `name` really consumes its first argument.

--- a/compiler/tests/borrow_vec_free_with.nu
+++ b/compiler/tests/borrow_vec_free_with.nu
@@ -1,0 +1,20 @@
+// borrow_vec_free_with.nu — vec_free_with consumes its Vec.
+//
+// The destructor rule keyed on a `_free` SUFFIX, so `vec_free` was a
+// consuming call and `vec_free_with` was not — even though it releases
+// strictly more: the container and, through the dropper it is handed,
+// every element. That is how the stdlib frees every Vec of owned
+// elements, so the blind spot sat on the most common shape: reading a
+// Vec after vec_free_with compiled clean and ran on freed memory.
+//
+// Expected: COMPILE FAIL — use of moved value 'v'.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+@ main → i {
+    : ( Vec String ) v ( vec_new [String] )
+    ( vec_push [String] v ( string_from `a` ) )
+    ( vec_free_with [String] v \ String s → v { ( string_free s ) } )
+    ^ ( vec_len [String] v )
+}

--- a/compiler/tests/outputs/borrow_vec_free_with.txt
+++ b/compiler/tests/outputs/borrow_vec_free_with.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/borrow_vec_free_with.nu:19: error: use of moved value 'v' — it was consumed at line 18 (pass a fresh value or rebind it before reuse)
+    ^ ( vec_len [String] v )
+error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)


### PR DESCRIPTION
## The gap

`bck_is_destructor_name` keyed on a `_free` **suffix**. So `vec_free` consumed its argument and `vec_free_with` did not — even though it releases strictly more: the container, *and* every element through the dropper it is handed.

That is how the stdlib frees every `Vec` of owned elements. The blind spot sat on the most common shape:

```nurl
( vec_free_with [String] v \ String s → v { ( string_free s ) } )
^ ( vec_len [String] v )        // compiled clean, ran on freed memory
```

Before this PR that program compiled with **no diagnostic at all**. Now:

```
borrow_vec_free_with.nu:19: error: use of moved value 'v' — it was consumed at line 18
    ^ ( vec_len [String] v )
```

## How it turned up

While measuring an unfreed-handle lint against the stdlib, the names it reported as leaked in `ext/mcp_search.nu` — `parts`, `terms`, `lines` — are all freed. With `vec_free_with`. The checker had never counted that as a free, so the leak report was right about the checker and wrong about the code.

The lint itself is not ready and is not part of this PR. This fix is independent of it and stands on its own: it closes a real use-after-free hole in the default, on-by-default borrow checker.

## Scope

The change is two lines of rule plus a comment. `bck_is_destructor_call`'s existing `void`-return test still applies on top, so a `_free_with`-suffixed function that returns a value is still not treated as a destructor — the same protection that keeps `virtq_num_free` from being misread.

Making the checker stricter risks flagging existing code that reads a Vec after freeing it. Nothing in the tree does: corpus **616/616** with the new golden, `nurlfmt --check` 904 files, `strict-arity` clean, bootstrap fixed point holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2RiWTSaoydkCaimceEkys
