### PR TITLE
nurl_build_native run=true — compile and run in one call, opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`nurl_build_native run=true` — compile and run in one call.** The
+  hosted playground could build a native binary and hand back a download
+  link, but the only way to see a program's OUTPUT was
+  `nurl_build_unikernel`: boot it as its own kernel under QEMU and read
+  the guest console. That works and stays the sandboxed path, but it is
+  a heavyweight answer to "what does this print".
+
+  `run=true` executes the program under the same `timeout(1)` wrapper
+  every build tool uses and returns exit code, stdout and stderr.
+
+  It ships **off**. Executing a freshly compiled binary is unsandboxed
+  code execution against the container's filesystem, network and
+  environment, and the hosted instance is an unauthenticated public
+  compile farm. `NURL_ALLOW_RUN=1` is the operator saying otherwise —
+  the same switch, and the same reasoning, as `nurl-mcp --allow-run`
+  over HTTP. Asking for a run while it is off returns an error naming
+  both the switch and the sandboxed alternative, rather than a build
+  with no output, which a caller would read as "it printed nothing".
+
+### Added
+
 - **`--lint` reports a `Vec` or `String` nobody releases.** Those two
   are the handles the compiler deliberately does *not* auto-drop
   (docs/MEMORY.md §7.4), so forgetting one leaks with no diagnostic

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -159,6 +159,19 @@ Cursor, Windsurf, Zed and other MCP-capable IDEs accept the same URL
 run the server binary directly. `nurlapi/main.nu` is a NURL program — no
 Python or Node runtime involved.
 
+**Running what you built.** `nurl_build_native` takes `run=true` to
+execute the program and return its exit code, stdout and stderr in the
+same call — one round trip from source to output. It is **off** on the
+hosted instance and returns an error saying so, because executing a
+freshly compiled binary is unsandboxed: it gets the container's
+filesystem, network and environment. A self-hosted deployment enables it
+with `NURL_ALLOW_RUN=1`, the same switch and the same reasoning as
+`nurl-mcp --allow-run` over HTTP.
+
+The sandboxed way to see output needs no switch: `nurl_build_unikernel`
+boots the program as its own kernel under QEMU, with no network and a
+time cap, and hands back the guest console.
+
 **Caveats:**
 - Open and unauthenticated. The hosted instance is a free public endpoint —
   don't push secrets through it; assume the source is logged. For

--- a/nurlapi/e2e_test.py
+++ b/nurlapi/e2e_test.py
@@ -390,6 +390,37 @@ def t_tools_call_changelog(c: Client) -> None:
     assert_true("no-match has guidance", "No matches" in text)
 
 
+def t_build_native_run_optin(c: Client) -> None:
+    print("\n[MCP] nurl_build_native run= (opt-in, off by default)")
+
+    src = "@ main \u2192 i { ( nurl_print `run opt-in\\n` ) ^ 4 }"
+    env = _tool_call(c, "nurl_build_native", {"source": src, "run": True})
+    try:
+        payload = json.loads(_tool_text(env))
+    except json.JSONDecodeError:
+        bad("build_native run returns JSON", "reply was not JSON")
+        return
+
+    run = payload.get("run")
+    assert_true("run= is answered, never ignored", run is not None,
+                "no 'run' key: a caller that asked to run must not get silence")
+
+    if os.environ.get("E2E_EXPECT_RUN_ENABLED") == "1":
+        # Operator turned it on: the program's own output comes back.
+        assert_eq("exit code round-trips", run.get("exit_code"), 4)
+        assert_true("stdout round-trips", "run opt-in" in (run.get("stdout") or ""))
+    else:
+        # Default posture. The refusal has to say what to do about it —
+        # both the switch and the sandboxed alternative — or the caller
+        # is left guessing why an artifact appeared and no output did.
+        err = run.get("error") or ""
+        assert_true("run refused by default", bool(err))
+        assert_true("refusal names the switch", "NURL_ALLOW_RUN" in err)
+        assert_true("refusal names the sandboxed path", "unikernel" in err)
+        assert_true("build itself still succeeded",
+                    payload.get("binary_artifact") is not None)
+
+
 def t_tools_call_docs(c: Client) -> None:
     print("\n[MCP] tools/call nurl_docs (index / read / forgiving names / paging)")
 
@@ -1114,6 +1145,7 @@ def main() -> int:
     t_tools_call_listing(c)
     t_tools_call_reads(c)
     t_tools_call_changelog(c)
+    t_build_native_run_optin(c)
     t_tools_call_docs(c)
     t_tools_call_api(c)
     t_tools_call_grep(c)

--- a/nurlapi/main.nu
+++ b/nurlapi/main.nu
@@ -66,6 +66,46 @@ $ `nurlapi/pptws.nu`
 // The docs/ prose tree behind nurl_docs and the /docs/* routes.
 @ get_docs_dir → String { ^ ( env_var_or `NURL_DOCS_DIR` `/opt/nurl/docs` ) }
 
+// Running a freshly compiled program is UNSANDBOXED code execution: the
+// binary gets this container's filesystem, its network and its
+// environment. The playground is an unauthenticated public compile
+// farm, so the capability ships OFF and the hosted deployment leaves it
+// off. `NURL_ALLOW_RUN=1` is the operator saying otherwise — the same
+// switch, and the same reasoning, as nurl-mcp's `--allow-run` over HTTP.
+//
+// The one sandboxed execution path the server already offers stays the
+// recommended one: nurl_build_unikernel boots the program as its own
+// kernel under QEMU with no network and a time cap.
+@ run_allowed → b {
+    : String v ( env_var_or `NURL_ALLOW_RUN` `` )
+    : b r | != 0 ( nurl_str_eq ( string_data v ) `1` ) != 0 ( nurl_str_eq ( string_data v ) `true` )
+    ( string_free v )
+    ^ r
+}
+
+// Execute a just-built binary under the same timeout(1) wrapper every
+// build tool uses, and fold the result into the response.
+@ __run_built_binary Json res s bin_path → v {
+    : ( Vec s ) noargs ( vec_new [s] )
+    : !Output ProcessErr r ( run_tool bin_path noargs )
+    ( vec_free [s] noargs )
+    ?? r {
+        T o → {
+            : Json run ( json_obj_new )
+            ( json_obj_set run `exit_code` ( json_int ( output_exit_code o ) ) )
+            ( json_obj_set run `stdout` ( json_str_lit ( output_stdout o ) ) )
+            ( json_obj_set run `stderr` ( json_str_lit ( output_stderr o ) ) )
+            ( json_obj_set res `run` run )
+            ( output_free o )
+        }
+        F e → {
+            : Json run ( json_obj_new )
+            ( json_obj_set run `error` ( json_str_lit `the built binary could not be executed` ) )
+            ( json_obj_set res `run` run )
+        }
+    }
+}
+
 @ get_license_mit_path → String { ^ ( env_var_or `NURL_LICENSE_MIT_PATH` `/opt/nurl/LICENSE-MIT` ) }
 
 @ get_license_apache_path → String { ^ ( env_var_or `NURL_LICENSE_APACHE_PATH` `/opt/nurl/LICENSE-APACHE` ) }
@@ -1319,6 +1359,20 @@ s combined_stdout s combined_stderr → v {
                                             ( json_obj_set res `binary_artifact`
                                             ( make_artifact_json ( string_data bin_name )
                                             ?? bn_sz { T s → s F _ → 0 } ( string_data build_id ) ) )
+                                            // Compile-and-run in one call, when the
+                                            // operator has enabled it. Refusing loudly
+                                            // beats ignoring the flag: a caller that
+                                            // asked to run and got only a build would
+                                            // read the silence as "it printed nothing".
+                                            ? ( get_common_bool root `run` F ) {
+                                                ? ( run_allowed ) {
+                                                    ( __run_built_binary res ( string_data bin_path ) )
+                                                } {
+                                                    : Json rj ( json_obj_new )
+                                                    ( json_obj_set rj `error` ( json_str_lit `running built programs is disabled on this server - it is unsandboxed code execution against the container's filesystem, network and environment. Set NURL_ALLOW_RUN=1 to enable it, or use build_unikernel, which boots the program under QEMU with no network and a time cap.` ) )
+                                                    ( json_obj_set res `run` rj )
+                                                } }
+                                            {}
                                         } {}
 
                                         : String body ( json_stringify res )
@@ -4810,10 +4864,26 @@ s combined_stdout s combined_stderr → v {
     : Json body ( json_obj_new )
     ( json_obj_set body `source` ( json_str_lit source ) )
     ( json_obj_set body `filename` ( json_str_lit filename ) )
+    ? ( __mcp_args_get_bool `run` args F ) { ( json_obj_set body `run` ( json_bool T ) ) } {}
     ? links_only { ( json_obj_set body `links_only` ( json_bool T ) ) } {}
     : Json result ( __mcp_build_endpoint endpoint body )
     ( json_free body )
     ^ result
+}
+
+// The native build tool's schema, with the opt-in `run`.
+@ __mcp_schema_build_native → Json {
+    : Json schema ( json_obj_new )
+    ( json_obj_set schema `type` ( json_str_lit `object` ) )
+    : Json props ( json_obj_new )
+    ( json_obj_set props `source`
+    ( __mcp_prop `string` `NURL source code (full file contents)` ) )
+    ( json_obj_set props `filename`
+    ( __mcp_prop `string` `Logical filename for diagnostics (default main.nu)` ) )
+    ( json_obj_set props `run`
+    ( __mcp_prop `boolean` `Also RUN the compiled program and return its exit code, stdout and stderr, so one call gets you output instead of an artifact you cannot execute. Disabled on this server unless the operator set NURL_ALLOW_RUN=1 — running a freshly compiled program is unsandboxed code execution against the container's filesystem, network and environment, and asking for it while it is off returns an error saying so rather than a silent build. The sandboxed alternative is nurl_build_unikernel, which boots the program as its own kernel under QEMU with no network and a time cap.` ) )
+    ( json_obj_set schema `properties` props )
+    ^ schema
 }
 
 @ __mcp_schema_build_unikernel → Json {
@@ -5685,8 +5755,8 @@ s combined_stdout s combined_stderr → v {
 
     // Build tools.
     ( json_arr_push arr ( __mcp_tool_desc `nurl_build_native`
-    `Compile NURL source to a native x86_64 Linux ELF binary. Returns build status, nurlc+clang return codes, combined stderr, download URLs for the generated .ll and the binary. Equivalent to POST /build.`
-    ( __mcp_schema_source_filename ) ) )
+    `Compile NURL source to a native x86_64 Linux ELF binary. Returns build status, nurlc+clang return codes, combined stderr, download URLs for the generated .ll and the binary. Pass run=true to also EXECUTE it and get back exit code, stdout and stderr in the same call — the difference between an artifact you cannot run and an answer. That is unsandboxed code execution, so it is off unless the operator set NURL_ALLOW_RUN=1, and asking for it while it is off returns an error saying so rather than a silent build; nurl_build_unikernel is the sandboxed way to see output (QEMU, no network, time cap). Equivalent to POST /build.`
+    ( __mcp_schema_build_native ) ) )
     ( json_arr_push arr ( __mcp_tool_desc `nurl_build_wasm`
     `Compile NURL source to a wasm32-wasi WebAssembly module. Returns build status, compile logs, and download URLs for the generated .wasm module (wasm_artifact) and the LLVM IR (ll_artifact) — no inline base64. Runs in-browser via a WASI shim or with wasmtime. Equivalent to POST /build_wasm with links_only:true.`
     ( __mcp_schema_source_filename ) ) )


### PR DESCRIPTION
The hosted playground could build a native binary and hand back a download link, but the only way to see a program's **output** was `nurl_build_unikernel` — boot it as its own kernel under QEMU and read the guest console. That works, and it stays the sandboxed path, but it is a heavyweight answer to "what does this print".

```
run: {"exit_code": 7, "stdout": "hello from a run\n", "stderr": ""}
```

## It ships off

Executing a freshly compiled binary is unsandboxed code execution against the container's filesystem, network and environment. The hosted instance is an unauthenticated public compile farm — the server's own hardening comment says exactly that.

So `NURL_ALLOW_RUN=1` is the operator saying otherwise: the same switch, and the same reasoning, as `nurl-mcp --allow-run` over HTTP. **This PR does not change what the hosted deployment exposes.** It adds the capability, off, behind the project's existing precedent for the same risk.

## Refusing beats ignoring

Asking to run while it is off returns an error naming both the switch and the sandboxed alternative:

```json
{"run": {"error": "running built programs is disabled on this server - it is
unsandboxed code execution against the container's filesystem, network and
environment. Set NURL_ALLOW_RUN=1 to enable it, or use build_unikernel, which
boots the program under QEMU with no network and a time cap."}}
```

Silently building instead would be worse than refusing. A caller that asked for output and got an artifact reads the silence as *"it printed nothing"* — a wrong answer is more expensive than a refusal that says what to do.

The build itself still succeeds either way; only the `run` field carries the refusal.

## Verified

Against a live server in **both** postures, over REST and through the MCP tool:

| | `run` field |
|---|---|
| default | the refusal above; `binary_artifact` still present |
| `NURL_ALLOW_RUN=1` | `exit_code: 7`, `stdout: "hello from a run\n"` |
| MCP `nurl_build_native` | `exit_code: 3`, `stdout: "mcp run\n"` |

Execution reuses `run_tool`, the `timeout(1)` wrapper every build tool already goes through, so a hanging program cannot hold the compile gate.

New e2e test asserts both halves, selected by `E2E_EXPECT_RUN_ENABLED`: that `run=` is never silently ignored, and — in the default posture — that the refusal names the switch, names the sandboxed path, and leaves the build intact.

Corpus 620/620, `nurlfmt --check` 908 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2RiWTSaoydkCaimceEkys
