### PR TITLE
main was red for two reasons, neither of them the code

### DIFF
--- a/compiler/tests/run_tests.ps1
+++ b/compiler/tests/run_tests.ps1
@@ -21,7 +21,7 @@
 #
 #  Record shapes (the golden holds exactly these lines):
 #
-#    normal test          should_fail_* / borrow_*
+#    normal test          should_fail_* / borrow_* / arity_strict_* / lint_*
 #    ───────────          ────────────────────────
 #    COMPILE OK           COMPILE FAIL
 #    LINK OK              ERRORS              (borrow_* only, if any)
@@ -325,6 +325,34 @@ $results = $names | ForEach-Object -ThrottleLimit $Jobs -Parallel {
         if ($name -like 'borrow_strict_*') { $nargs += '--strict-borrowck' }
         $nargs += $src
         $r = Run-Proc $Nurlc $nargs $RootDir
+        if ($r.Code -eq 0) {
+            $act = "COMPILE OK`n(expected COMPILE FAIL but compiler accepted it)`n"
+        } else {
+            $act = "COMPILE FAIL`n"
+            $e = Normalize $r.Err
+            if ($e.Length -gt 0) { $act += "ERRORS`n" + (Cap-Lines (Strip-Root $e)) }
+        }
+    }
+    elseif ($name -like 'lint_*') {
+        # lint_* — diagnostics that only fire under --lint. Compiles
+        # clean (the program is valid); it is the WARNINGS that are
+        # baselined. Mirrors run_tests.sh.
+        $r = Run-Proc $Nurlc @('--lint', $src) $RootDir
+        if ($r.Code -eq 0) {
+            $act = "COMPILE OK`n"
+            $e = Normalize $r.Err
+            if ($e.Length -gt 0) { $act += "WARNINGS`n" + (Cap-Lines (Strip-Root $e)) }
+        } else {
+            $act = "COMPILE FAIL`n(expected COMPILE OK)`n"
+            $e = Normalize $r.Err
+            if ($e.Length -gt 0) { $act += (Cap-Lines (Strip-Root $e)) }
+        }
+    }
+    elseif ($name -like 'arity_strict_*') {
+        # arity_strict_* — the n-ary '&'/'|' trap, an error only under
+        # --strict-arity. The diagnostic TEXT is baselined because where
+        # it points is the point. Mirrors run_tests.sh.
+        $r = Run-Proc $Nurlc @('--strict-arity', $src) $RootDir
         if ($r.Code -eq 0) {
             $act = "COMPILE OK`n(expected COMPILE FAIL but compiler accepted it)`n"
         } else {

--- a/unikernel/tests/hypervisor_gate.sh
+++ b/unikernel/tests/hypervisor_gate.sh
@@ -212,6 +212,26 @@ boot_ch() {
         say "PASS cloud-hypervisor booted the unchanged image"
         booted="$booted cloud-hypervisor"
         ;;
+      *"Failed to set Cpuid"*|*"VcpuConfiguration"*|*"SetSupportedCpusFailed"*)
+        # The host declined to give the VM a vCPU. This says nothing
+        # about the image: the failure is before any guest instruction
+        # runs, and the structural PVH check above — the part that IS
+        # about our artifact — already passed.
+        #
+        # The gate's KVM test above asks whether this process can OPEN
+        # /dev/kvm, which a runner can allow while still refusing to
+        # host a VM (nested virtualisation off, KVM_GET_SUPPORTED_CPUID
+        # unavailable). That is the same "present is not usable" lesson
+        # the readability check above was written for, one step further
+        # along, and it turned main red for an environment property.
+        #
+        # An image defect looks different and is still caught: the VM
+        # starts and the guest never prints its exit line, or the loader
+        # complains about the ELF or the PVH note.
+        say "SKIP boot: cloud-hypervisor could not configure a vCPU on this host"
+        say "     (KVM opens but will not host a VM — nested virt off?)"
+        skipped="$skipped cloud-hypervisor"
+        ;;
       *)
         say "FAIL cloud-hypervisor"
         printf '%s\n' "$out" | head -6 | sed 's/^/     /' || true
@@ -239,6 +259,14 @@ EOF
       *"[nurl-exit] 0"*)
         say "PASS firecracker booted the unchanged image"
         booted="$booted firecracker"
+        ;;
+      *"Failed to set Cpuid"*|*"VcpuConfiguration"*|*"SetSupportedCpusFailed"*|*"Cannot create Vcpu"*)
+        # Same host-declined-a-vCPU case as cloud-hypervisor above, in
+        # the other loader's wording. Both are given the exclusion, or
+        # the next runner without nested virt fails on whichever one it
+        # happens to have installed.
+        say "SKIP boot: firecracker could not configure a vCPU on this host"
+        skipped="$skipped firecracker"
         ;;
       *)
         say "FAIL firecracker"


### PR DESCRIPTION
`main` is red on two workflows. Neither failure is about the compiler or the library.

## 1. Windows corpus runner did not know two prefixes

`compiler/tests/run_tests.ps1` is the **fourth** place in this repo that knows how to run a test, and it had not been taught the two prefixes that carry a compiler flag:

- `arity_strict_*` → needs `--strict-arity`
- `lint_*` → needs `--lint`

Without the flag both compile differently than their goldens describe, so both mismatch — 2 failures on a tree whose Linux corpus is 620/620.

```
- COMPILE FAIL
- ERRORS
- compiler/tests/arity_strict_nary.nu:20:5: error: '?' consumed bare then/else values…
PASS 586 · FAIL 2
```

The bash runner grew those branches when the tests landed. This adds the same two, in the same order, to the PowerShell one.

**The recurring shape is the point.** This logic lives in `run_tests.sh`, `run_tests.ps1`, `run_san_tests.sh` and `unikernel/run_nolibc_tests.sh`, and every fixture kind added since has broken whichever copy was forgotten — three times in this batch alone. The two shell runners were already moved to asking the **golden** (an `EXIT` line means "this describes a run"), so they need no list at all. PowerShell still needs the flag mapping, because only the runner can know which flag a prefix implies.

## 2. The hypervisor gate blamed the image for the host's refusal

```
hypervisor_gate: PVH note OK — type 18, 4-byte descriptor, address == ELF entry
hypervisor_gate: FAIL cloud-hypervisor
     Error booting VM: … SetSupportedCpusFailed(Failed to set Cpuid: failed to create CpuId)
```

That is the **host** declining to give the VM a vCPU. It says nothing about our artifact: the failure happens before any guest instruction runs, and the structural PVH check — the part that *is* about the image — passes on the line above.

The gate already skips loudly when `/dev/kvm` cannot be opened, and its own comment records why that check had to become about usability rather than existence: *"A GitHub runner HAS /dev/kvm and denies the job user access to it."* This is the same lesson one step further along — a runner can allow the open and still refuse to host a VM (nested virtualisation off, `KVM_GET_SUPPORTED_CPUID` unavailable).

Now skipped by name, with the reason printed, for **both** loaders — otherwise the next runner without nested virt fails on whichever one it happens to have installed.

An image defect still fails, and looks different: the VM starts and the guest never prints its exit line, or the loader rejects the ELF or the PVH note.

## Testing

Corpus 620/620, `nurlfmt --check` 908 files, and the hypervisor gate exercised locally (no KVM here, so it takes the existing skip path and still verifies the PVH note). The Windows branches are verified by this PR's own CI, which is the only place they run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2RiWTSaoydkCaimceEkys
