### PR TITLE
Windows is a per-PR merge gate — tier 1

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -6,12 +6,24 @@ name: windows-tests
 #
 # This is what backs docs/PLATFORMS.md's Windows tier: without this
 # workflow the 447 Windows goldens were exercised only on a developer's
-# machine. Runs on pushes to main (not per-PR: the Windows leg is the
-# slowest runner and PRs are already gated by the Linux+FreeBSD corpus;
-# a main breakage surfaces here within one push) and on demand.
+# machine.
+#
+# It used to run on main pushes only, reasoning that PRs are already
+# gated by the Linux+FreeBSD corpus and "a main breakage surfaces here
+# within one push". That rationale was falsified: run_tests.ps1 is a
+# separate implementation of "how do I run this test", so two corpus
+# additions that carry a compiler flag (arity_strict_* → --strict-arity,
+# lint_* → --lint) passed every PR gate and turned main red the moment
+# they merged. Surfacing within one push is not the same as being
+# caught, and it cost a second PR to undo each time.
+#
+# So: PRs too. That is what makes Windows a per-PR merge gate, and what
+# moves it to tier 1 in docs/PLATFORMS.md.
 
 on:
   push:
+    branches: [main]
+  pull_request:
     branches: [main]
   workflow_dispatch:
     inputs:
@@ -23,8 +35,39 @@ on:
         type: boolean
         default: false
 
+# The Windows leg is the slowest runner in the repo; do not leave a
+# superseded run burning it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  changes:
+    name: classify changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Same shape as ci.yml, and for the same reason recorded there: the
+      # skip is an `if:` on the job rather than workflow-level
+      # `paths-ignore`, because a skipped job still satisfies a branch
+      # -protection required check while a path-filtered workflow that
+      # never starts would leave a docs-only PR blocked forever.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!webdocs/**'
+
   windows:
+    needs: changes
+    # On a push or a manual dispatch there is no PR base to diff against,
+    # so the filter has nothing to say — run. On a PR, skip a docs-only
+    # change rather than spend an hour of the slowest runner on it.
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' }}
     runs-on: windows-latest
     timeout-minutes: 60
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Windows is a per-PR merge gate — tier 1.** The `windows-tests`
+  workflow ran on `main` pushes only, reasoning that PRs were already
+  gated by the Linux+FreeBSD corpus and that "a main breakage surfaces
+  here within one push". That rationale was falsified twice in one
+  batch: `run_tests.ps1` is a separate implementation of *how do I run
+  this test*, so two corpus additions carrying a compiler flag
+  (`arity_strict_*` → `--strict-arity`, `lint_*` → `--lint`) passed
+  every PR gate and turned `main` red on merge. Surfacing within one
+  push is not the same as being caught, and each cost a second PR to
+  undo.
+
+  It now runs on PRs as well, with a `changes` classify job so a
+  docs-only PR does not spend an hour of the slowest runner, and a
+  concurrency group so a superseded run is cancelled.
+  `docs/PLATFORMS.md` moves Windows from tier 2 to tier 1 on both
+  tables, which is what the tier definition has always said: tier 1 is
+  "every push and PR".
+
+  `RELEASING.md` claimed no test corpus ran on Windows in CI at all.
+  That stopped being true when the workflow landed and is now corrected.
+
 ### Added
 
 - **`nurl_build_native run=true` — compile and run in one call.** The

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -177,11 +177,13 @@ the Actions tab.
 - The Linux client path (download → verify → unpack → run) is verified
   end to end against a local mirror; the relocatable prefix is verified by
   moving it after install.
-- The Windows job builds and verifies the bootstrap fixed point on
-  `windows-latest` and ships in releases, but **no test corpus or smoke
-  test runs on Windows in CI** — the Windows goldens
-  (`compiler/tests/outputs-windows/`) are exercised only by a local
-  `build.bat` with PowerShell 7.
+- The Windows release job builds with `--no-tests`, but Windows is not
+  untested: the separate `windows-tests` workflow runs `build.bat` — the
+  bootstrap fixed point plus the full Windows golden corpus
+  (`compiler/tests/outputs-windows/`, via `run_tests.ps1`) — on every
+  push to `main` and every PR. (This entry previously said no corpus ran
+  on Windows in CI at all; that stopped being true when the workflow
+  landed, and it now gates PRs too.)
 - The FreeBSD release leg is best-effort (`continue-on-error`); a release
   can ship without the FreeBSD archive.
 - macOS is not built yet (the installer rejects it with a clear message);

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,8 +43,9 @@ What is solid today:
 - **Standard library.** A broad pure-NURL stdlib (see the inventory below)
   spanning collections, hashing, serialization, a full HTTP/1.1+2 + WebSocket
   stack, database clients, distributed systems (p2p overlay, CRDTs), MCP, and the Anthropic Claude API.
-- **Targets.** Linux x86_64 (primary, CI-tested), Windows x86_64 (CI-built,
-  corpus runs locally), macOS x86_64/ARM64 (cross-compiled Mach-O — no CI, no
+- **Targets.** Linux x86_64 (primary, CI-tested), Windows x86_64 (CI-tested:
+  bootstrap fixed point + the Windows golden corpus on every push and PR),
+  macOS x86_64/ARM64 (cross-compiled Mach-O — no CI, no
   prebuilt toolchain), `wasm32-wasi`, static Linux ARM64 / RISC-V64
   (musl), and **bootable unikernel images** — a NURL program as its own
   kernel on x86_64, AArch64 and RISC-V64, no host OS and no libc.
@@ -154,7 +155,7 @@ platform-specific shims.
 
 ### Targets & tooling
 
-- Native: Linux x86_64 (CI-tested), Windows x86_64 (CI-built), macOS
+- Native: Linux x86_64 (CI-tested), Windows x86_64 (CI-tested), macOS
   x86_64/ARM64 (cross-compiled, not CI-tested, no prebuilt toolchain).
 - WebAssembly `wasm32-wasi` (WASI SDK), including the compiler itself running
   in the browser playground, and **whole neural networks running client-side

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -22,7 +22,7 @@ verifies — not by intent:
 | Linux x86_64 (glibc ≥ 2.28) | **1** | `build.sh` bootstrap fixed point + full corpus + examples gate + ASan/UBSan/LSan + peak-RSS / symbol-collision / leak gates, every push and PR; release artifact smoke-tested | `install.sh` |
 | FreeBSD x86_64 | **1** | build + bootstrap + full corpus on a FreeBSD 14.2 VM in CI (hard gate); the *release* artifact leg is best-effort (`continue-on-error`) | `install.sh` |
 | Linux ARM64 (glibc) | **2** | release workflow builds natively on an ARM64 runner (`--no-tests`) and smoke-tests a hello-world; not in `ci.yml` | `install.sh` |
-| Windows x86_64 | **2** | the `windows-tests` workflow runs `build.bat` — bootstrap fixed point + the full Windows golden corpus (`run_tests.ps1`) — on every push to `main` (not a per-PR merge gate); the release job builds with `--no-tests` | `install.ps1` |
+| Windows x86_64 | **1** | the `windows-tests` workflow runs `build.bat` — bootstrap fixed point + the full Windows golden corpus (`run_tests.ps1`) — on every push to `main` **and every PR**, so a Windows-only regression cannot reach `main`; the release job builds with `--no-tests` | `install.ps1` |
 | macOS (x86_64 / ARM64) | **3** | expected to build from source with Homebrew LLVM; unverified — no CI job, no release artifact, and the installer rejects Darwin | build from source |
 | Alpine / musl | **3** | build from source only. The shipped Linux archives are glibc-linked and do **not** load under musl | build from source |
 
@@ -51,7 +51,7 @@ container's cross-compile endpoints (see [`PLAYGROUND.md`](PLAYGROUND.md)).
 | Target | Backend | Tier | Notes |
 |---|---|---|---|
 | Linux x86_64 | LLVM | 1 | primary target — `build.sh` + full corpus |
-| Windows x86_64 | LLVM (mingw-w64) | 2 | separate Windows goldens (`compiler/tests/outputs-windows/`); corpus runs on `main` pushes via the `windows-tests` workflow |
+| Windows x86_64 | LLVM (mingw-w64) | 1 | separate Windows goldens (`compiler/tests/outputs-windows/`); corpus runs on every push and PR via the `windows-tests` workflow |
 | macOS x86_64 | LLVM + zig cc | 3 | `POST /build_macos`; Mach-O links only libSystem (no Apple SDK). Runs on Apple Silicon via Rosetta 2. canvas/audio/libcurl-HTTP not supported |
 | macOS ARM64 | LLVM + zig cc | 3 | `POST /build_target` (`target=macos-arm64`) — native Apple Silicon Mach-O, links only libSystem. Unsigned: clear quarantine before running |
 | WebAssembly | wasm32-wasi | 3 | via the `nurlapi/` container (WASI SDK 24.0); browser execution via `browser_wasi_shim`. The self-hosting compiler itself also builds to wasm — see [`PLAYGROUND.md`](PLAYGROUND.md) |


### PR DESCRIPTION
`windows-tests` ran on `main` pushes only. The stated reason, in the workflow's own header:

> Runs on pushes to main (not per-PR: the Windows leg is the slowest runner and PRs are already gated by the Linux+FreeBSD corpus; **a main breakage surfaces here within one push**)

That was falsified twice in one batch.

`run_tests.ps1` is a separate implementation of *"how do I run this test"*, so two corpus additions carrying a compiler flag — `arity_strict_*` needing `--strict-arity`, `lint_*` needing `--lint` — passed every PR gate and turned `main` red the moment they merged. **Surfacing within one push is not the same as being caught.** Each cost a second PR to undo, and `main` sat red in between.

## What this changes

`pull_request` added, with the two pieces that make it affordable:

- **A `changes` classify job**, same shape as `ci.yml`, so a docs-only PR does not spend an hour of the slowest runner in the repo. The skip is an `if:` on the job rather than workflow-level `paths-ignore`, for the reason `ci.yml` already records: a skipped job satisfies a branch-protection required check, while a path-filtered workflow that never starts leaves a docs-only PR blocked forever.
- **A concurrency group**, so a superseded run is cancelled rather than left burning.

The `if:` lets `push` and `workflow_dispatch` through unconditionally — neither has a PR base for the filter to diff against.

## The tier

`docs/PLATFORMS.md` moves Windows from **2** to **1** on both tables. That is not a promotion so much as bookkeeping catching up: the tier definitions have always said tier 1 is *"every push and PR"*, and the tier 2 row for Windows read *"not a per-PR merge gate"* — the exact property this removes.

## Two stale claims fixed while here

Both predate this change and were wrong already:

- `RELEASING.md` said **"no test corpus or smoke test runs on Windows in CI"** and that the goldens are *"exercised only by a local `build.bat`"*. That stopped being true when the workflow landed.
- `ROADMAP.md` described Windows as `CI-built` with the *"corpus runs locally"*.

## Verification

The workflow change verifies itself: this PR is the first one Windows gates, so a green `windows` job here is the feature working. The path filter is exercised by the fact that this PR touches no `webdocs/**`, so `code` is true and the job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2RiWTSaoydkCaimceEkys
