### PR TITLE
AX: the use-after-move error names what consumed the value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The use-after-move error now names what consumed the value.** It
+  said "consumed at line 3", which makes a reader scan that line for the
+  operation and, on a line with several calls, guess. It now says "by
+  string_free" or "by an alias copy" — the cause is stashed at the move
+  site under name+line, the pair the diagnostic already resolves. The
+  cure was also written for a move rather than a free ("pass a fresh
+  value or rebind it"); it now leads with the rule that explains both:
+  a heap handle has exactly one owner, so after the consuming operation
+  the binding is dead.
+
 - **Diagnostics, second pass: 33 more messages, one misleading cure
   fixed, and the two token tables merged into one.** The first pass took
   the twelve an agent is most likely to reach; this one works the list.

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -6734,7 +6734,7 @@
         // identifier, names a binding being consumed — stash it as a
         // move (flushed after the enclosing statement).
         ? & & is_consume_call == arg_idx 0 ( is_ident_tok bck_arg_tt )
-        { ( bck_stash_move bck_arg_val ( nurl_lex_line lex ) )
+        { ( bck_stash_move bck_arg_val ( nurl_lex_line lex ) fname )
             ( lint_note_released bck_arg_val )
             // Auto-sink inference: if the consumed bare-ident is the
             // enclosing fn's parameter, record its index so
@@ -6761,7 +6761,7 @@
             { ( die lex ( nurl_str_cat3
                 `'` bck_arg_val
                 `' is a compiler-auto-dropped value; passing it to a 'sink' parameter is not yet supported - pass a Vec or other manually-managed handle, or pass it as an ordinary parameter` ) ) }
-            { ( bck_stash_move bck_arg_val ( nurl_lex_line lex ) )
+            { ( bck_stash_move bck_arg_val ( nurl_lex_line lex ) fname )
                 ( lint_note_released bck_arg_val )
                 // Auto-sink cascade: if THIS fn passes its own
                 // parameter as a sink arg to another fn, mark this
@@ -10898,13 +10898,18 @@
 @ bck_let_alias i syms b is_mut i rhs_tt s rhs_val s vt i line → v {
     ? & & & ! is_mut ( is_ident_tok rhs_tt ) ( bck_is_heap_lty vt )
     ! ( str_contains_word ( nurl_sym_get syms `__fn_param_names__` ) rhs_val )
-    { ( bck_stash_move rhs_val line ) ( lint_note_released rhs_val ) }
+    { ( bck_stash_move rhs_val line `an alias copy` ) ( lint_note_released rhs_val ) }
     {}
 }
 
 // Stash `name` (consumed at `line`) for the current statement.
-@ bck_stash_move s name i line → v {
+@ bck_stash_move s name i line s cause → v {
     ? & != g_borrowck 0 == g_bck_closure_depth 0 {
+        // Remember WHAT consumed it, keyed by name+line — the pair the
+        // diagnostic already resolves. "consumed at line 3" makes a
+        // reader scan that line for the operation; naming it removes the
+        // scan, and on a line with several calls removes the guess.
+        ( nurl_sym_set g_bck ( nurl_str_cat3 `mc_` name ( nurl_str_int line ) ) cause )
         : s cur ( nurl_sym_get g_bck `pmoves` )
         : s add ( nurl_str_cat3 name ` ` ( nurl_str_int line ) )
         ( nurl_sym_set g_bck `pmoves`
@@ -11315,10 +11320,15 @@
         // binding's name — rv_ is the reverse mapping bck_intern kept.
         : s name ( nurl_sym_get2 g_bck `rv_` ids )
         : s ml ( nurl_sym_get2 g_bck `ml_` ids )
+        // Name the operation that consumed it, not just the line. The
+        // cause was stashed under name+line at the move site.
+        : s cause ( nurl_sym_get g_bck ( nurl_str_cat3 `mc_` name ml ) )
+        : s by ? == 0 ( nurl_str_len cause ) ( nurl_str_cat `` `` )
+        ( nurl_str_cat3 ` by ` cause `` )
         ( bck_emit_error ( nurl_sym_get g_bck `file` ) useline
         ( nurl_str_cat4 `use of moved value '` name
-        `' — it was consumed at line ` ( nurl_str_cat3 ml
-        ` (pass a fresh value or rebind it before reuse)` `` ) ) )
+        `' — a heap handle has exactly one owner, and this one was consumed at line ` ( nurl_str_cat3 ml
+        ( nurl_str_cat by `. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.` ) `` ) ) )
     }
 }
 

--- a/compiler/tests/outputs-windows/borrow_double_free.txt
+++ b/compiler/tests/outputs-windows/borrow_double_free.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_double_free.nu:12: error: use of moved value 'a' — it was consumed at line 11 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_double_free.nu:12: error: use of moved value 'a' — a heap handle has exactly one owner, and this one was consumed at line 11 by an alias copy. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
     ( vec_free [i] a )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs-windows/borrow_loop_carried_foreach.txt
+++ b/compiler/tests/outputs-windows/borrow_loop_carried_foreach.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_loop_carried_foreach.nu:15: error: use of moved value 'xs' — it was consumed at line 15 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_loop_carried_foreach.nu:15: error: use of moved value 'xs' — a heap handle has exactly one owner, and this one was consumed at line 15 by vec_free. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
         ( vec_free [i] xs )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs-windows/borrow_loop_carried_free.txt
+++ b/compiler/tests/outputs-windows/borrow_loop_carried_free.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_loop_carried_free.nu:14: error: use of moved value 'xs' — it was consumed at line 14 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_loop_carried_free.nu:14: error: use of moved value 'xs' — a heap handle has exactly one owner, and this one was consumed at line 14 by vec_free. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
         ( vec_free [i] xs )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs-windows/borrow_sink_use_after.txt
+++ b/compiler/tests/outputs-windows/borrow_sink_use_after.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_sink_use_after.nu:24: error: use of moved value 'xs' — it was consumed at line 23 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_sink_use_after.nu:24: error: use of moved value 'xs' — a heap handle has exactly one owner, and this one was consumed at line 23 by give_away. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
     : i n ( vec_len [i] xs )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs-windows/borrow_use_after_move.txt
+++ b/compiler/tests/outputs-windows/borrow_use_after_move.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_use_after_move.nu:11: error: use of moved value 'v' — it was consumed at line 10 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_use_after_move.nu:11: error: use of moved value 'v' — a heap handle has exactly one owner, and this one was consumed at line 10 by vec_free. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
     : i n ( vec_len [i] v )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_double_free.txt
+++ b/compiler/tests/outputs/borrow_double_free.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_double_free.nu:12: error: use of moved value 'a' — it was consumed at line 11 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_double_free.nu:12: error: use of moved value 'a' — a heap handle has exactly one owner, and this one was consumed at line 11 by an alias copy. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
     ( vec_free [i] a )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_loop_carried_foreach.txt
+++ b/compiler/tests/outputs/borrow_loop_carried_foreach.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_loop_carried_foreach.nu:15: error: use of moved value 'xs' — it was consumed at line 15 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_loop_carried_foreach.nu:15: error: use of moved value 'xs' — a heap handle has exactly one owner, and this one was consumed at line 15 by vec_free. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
         ( vec_free [i] xs )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_loop_carried_free.txt
+++ b/compiler/tests/outputs/borrow_loop_carried_free.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_loop_carried_free.nu:14: error: use of moved value 'xs' — it was consumed at line 14 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_loop_carried_free.nu:14: error: use of moved value 'xs' — a heap handle has exactly one owner, and this one was consumed at line 14 by vec_free. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
         ( vec_free [i] xs )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_sink_use_after.txt
+++ b/compiler/tests/outputs/borrow_sink_use_after.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_sink_use_after.nu:24: error: use of moved value 'xs' — it was consumed at line 23 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_sink_use_after.nu:24: error: use of moved value 'xs' — a heap handle has exactly one owner, and this one was consumed at line 23 by give_away. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
     : i n ( vec_len [i] xs )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_use_after_move.txt
+++ b/compiler/tests/outputs/borrow_use_after_move.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_use_after_move.nu:11: error: use of moved value 'v' — it was consumed at line 10 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_use_after_move.nu:11: error: use of moved value 'v' — a heap handle has exactly one owner, and this one was consumed at line 10 by vec_free. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
     : i n ( vec_len [i] v )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_vec_free_with.txt
+++ b/compiler/tests/outputs/borrow_vec_free_with.txt
@@ -1,5 +1,5 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/borrow_vec_free_with.nu:19: error: use of moved value 'v' — it was consumed at line 18 (pass a fresh value or rebind it before reuse)
+compiler/tests/borrow_vec_free_with.nu:19: error: use of moved value 'v' — a heap handle has exactly one owner, and this one was consumed at line 18 by vec_free_with. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
     ^ ( vec_len [String] v )
 error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)


### PR DESCRIPTION
The most common memory error in NURL said:

```
error: use of moved value 's' — it was consumed at line 3
       (pass a fresh value or rebind it before reuse)
```

Two problems.

**It does not say what consumed it.** A reader has to scan line 3 for the operation, and on a line with several calls — `( string_free a ) ( string_free b )` — they have to guess which one. That is the thing a diagnostic exists to prevent.

**The cure was written for a move, and reads oddly for a free.** "Pass a fresh value or rebind it before reuse" is advice about arguments; the reader had just released a value.

Now:

```
error: use of moved value 's' — a heap handle has exactly one owner, and this one
was consumed at line 3 by string_free. After that the binding is dead: free or
read the value through whatever owns it now, or rebind this name to a fresh value.
```

and for the aliasing form `: String b a`:

> … consumed at line 3 **by an alias copy**. …

## How

The cause is stashed at the move site under `name+line` — the pair the diagnostic already resolves — so nothing about the move-row format or the lattice walk changes. The three sites that create a move each pass what they are: the destructor's callee name, the sink's callee name, or `an alias copy`.

The rule now leads the message, because it explains both cases at once: *a heap handle has exactly one owner*. That is the sentence an agent needs to carry to the next program.

## Found the same way as the last batch

By writing the mistake and reading the answer. Static classification would have passed this message — it is specific, it names a line, it offers a cure. It just was not enough to act on without going back to the source.

## Testing

Corpus **622/622**, with six borrow goldens absorbing the new text. `nurlfmt --check` 910 files, bootstrap fixed point holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2RiWTSaoydkCaimceEkys
