### PR TITLE
AX: a probe suite over 30 realistic mistakes, and its findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A 30-case probe suite over realistic mistakes, and what it found.**
+  Counting cue words in the source had reached its limit, so the next
+  pass wrote thirty programs an agent plausibly writes wrong — wrong
+  arity, wrong types, unwrapped options, missing arms, generics without
+  brackets, assignment to a parameter — and read every answer.
+
+  Most already taught well. Three did not and were rewritten: assignment
+  to an immutable parameter (which named neither ': ~' nor 'inout'),
+  parameter shadowing, and field access on a scalar.
+
+  One taught something **false**. Returning a bool from an `→ i`
+  function said *"NURL has no implicit conversions"* — but a bool DOES
+  widen into an integer binding, deliberately and by design, so
+  `': i n ( > a b )'` is fine. An agent that took the sentence at its
+  word would have learned a rule the compiler does not enforce. It now
+  states the real one: a bool widens into a binding, a return type is a
+  contract and must match exactly.
+
+  The probe also found nine programs that compile clean where an error
+  seemed likely. Seven turn out to be legal or to fail later by design;
+  the remaining two are recorded for a separate look, because a missing
+  diagnostic is a type-system question and not a wording one.
+
 - **The use-after-move error now names what consumed the value.** It
   said "consumed at line 3", which makes a reader scan that line for the
   operation and, on a line with several calls, guess. It now says "by

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -2635,7 +2635,7 @@
         { : s cure ? ( seq fn_rt `i1` )
             `' — NURL has no implicit conversions; compare the value to get a b, e.g. '^ != 0 ( … )'`
             ? ( seq lt `i1` )
-            `' — NURL has no implicit conversions; select to widen the b, e.g. '^ ? cond 1 0'`
+            `' — a bool widens into an integer BINDING (': i n ( > a b )' is fine), but a return type is a contract and must match exactly. Select the value you mean: '^ ? cond 1 0'.`
             `' — NURL has no implicit conversions; convert with '# T expr'`
             ( die lex ( nurl_str_cat ( nurl_str_cat4
             `return value type '` ( llvm_to_nurl lt ) `' does not match the declared return type '` ( llvm_to_nurl fn_rt ) )
@@ -11859,7 +11859,7 @@
 @ __warn_if_shadows_param i lex i syms s name → v {
     : s param_names ( nurl_sym_get syms `__fn_param_names__` )
     ? & != 0 ( nurl_str_len param_names ) ( str_contains_word param_names name )
-    { ( warn lex ( nurl_str_cat3 `'` name `' shadows the enclosing function's parameter - rename` ) ) }
+    { ( warn lex ( nurl_str_cat3 `'` name `' shadows the enclosing function's parameter — the inner binding hides it for the rest of the scope, which is almost never intended. Rename one of them.` ) ) }
     {}
 }
 
@@ -12502,7 +12502,8 @@
             ``
             : s kind ? != 0 ( nurl_str_len param_check ) `parameter`
             ? != 0 ( nurl_str_len glb ) `global` `variable`
-            ( die lex ( nurl_str_cat3 ( nurl_str_cat `cannot assign to immutable ` kind ) ( nurl_str_cat `: ` name ) where ) )
+            ( die lex ( nurl_str_cat3 ( nurl_str_cat `cannot assign to immutable ` kind ) ( nurl_str_cat3 ` '` name `'` )
+            ( nurl_str_cat where `. Bindings are immutable unless declared ': ~', and parameters are always immutable: add the tilde at the declaration, copy the parameter into a ': ~' local, or take it as 'inout' if the caller should see the write.` ) ) )
         }
         {}
         // Silent-snapshot footgun: assigning to a binding the enclosing
@@ -13783,7 +13784,7 @@
         // operand must be aggregate type"). Reject it at the source.
         ? != 0 ( nurl_str_len ot )
         { ? & != ( nurl_str_get ot 0 ) 123 != ( nurl_str_get ot 0 ) 37
-            { ( die lex ( nurl_str_cat3 `cannot access a field or element of '` ( llvm_to_nurl ot ) `' — it is not a struct, enum, slice, or pointer` ) ) }
+            { ( die lex ( nurl_str_cat3 `cannot access a field or element of '` ( llvm_to_nurl ot ) `' — it is not a struct, enum, slice, or pointer, so it has no fields and no elements. Field access is prefix ('. obj field'); indexing needs a slice or pointer.` ) ) }
             {} }
         {}
         ? == ( nurl_lex_type lex ) TT_INT

--- a/compiler/tests/outputs-windows/should_warn_param_shadow.txt
+++ b/compiler/tests/outputs-windows/should_warn_param_shadow.txt
@@ -1,6 +1,6 @@
 COMPILE OK
 WARNINGS
-compiler/tests/should_warn_param_shadow.nu:19:9: warning: 'z' shadows the enclosing function's parameter - rename
+compiler/tests/should_warn_param_shadow.nu:19:9: warning: 'z' shadows the enclosing function's parameter — the inner binding hides it for the rest of the scope, which is almost never intended. Rename one of them.
     : i z + z 7  // ← warns: 'z' shadows parameter z
         ^
 LINK OK

--- a/compiler/tests/outputs/should_warn_param_shadow.txt
+++ b/compiler/tests/outputs/should_warn_param_shadow.txt
@@ -1,6 +1,6 @@
 COMPILE OK
 WARNINGS
-compiler/tests/should_warn_param_shadow.nu:19:9: warning: 'z' shadows the enclosing function's parameter - rename
+compiler/tests/should_warn_param_shadow.nu:19:9: warning: 'z' shadows the enclosing function's parameter — the inner binding hides it for the rest of the scope, which is almost never intended. Rename one of them.
     : i z + z 7  // ← warns: 'z' shadows parameter z
         ^
 LINK OK


### PR DESCRIPTION
Counting cue words in the source had reached its limit. It passes any message that is long and confident — including, in the last batch, one that pointed the wrong way.

So this pass wrote **thirty programs an agent plausibly writes wrong** — wrong arity, wrong types, unwrapped options, missing match arms, generics without brackets, assignment to a parameter, field access on a scalar — and read every answer.

## Most already taught well

`wrong arg count`, `unknown type name`, `non-exhaustive match`, `generic without brackets`, the conversion errors: all name the rule and the cure. That is the first pass and the existing work holding up.

## Three did not, and are rewritten

- **assignment to an immutable parameter** — said `cannot assign to immutable parameter: x` and named neither `': ~'` nor `'inout'`.
- **parameter shadowing** — `'x' shadows the enclosing function's parameter - rename`, with no statement of what shadowing costs.
- **field access on a scalar** — named what the type is not, never what to write.

## One taught something *false*

Returning a bool from an `→ i` function said:

> return value type `'b'` does not match the declared return type `'i'` — **NURL has no implicit conversions**; select to widen the b, e.g. `'^ ? cond 1 0'`

But a bool **does** widen into an integer binding. Deliberately, with the coercion documented at the site that performs it:

```nurl
: i n ( > a b )     // fine, and idiomatic
@ f → i { ^ T }     // rejected
```

The return path and the binding path give opposite answers about the same conversion, and the message asserted the stricter one as a universal. An agent that believed the sentence would have learned a rule the compiler does not enforce — the exact failure this goal names.

**Fixed by correcting the message, not the semantics.** The widen is a documented feature; changing it was not the task and would be a language change made sideways. Now:

> return value type `'b'` does not match the declared return type `'i'` — a bool widens into an integer BINDING (`': i n ( > a b )'` is fine), but a return type is a contract and must match exactly. Select the value you mean: `'^ ? cond 1 0'`.

## Nine compiled clean

The suite also found nine programs that compile with no diagnostic where one looked likely. Seven are legal, or fail later by design (`option unwrapped`, `call a non-function` — both caught at link). The remaining two — `: i n T` and comparing an int with a string — are **noted, not changed**: a missing diagnostic is a type-system question, and inventing one here would be a language change made sideways, the same reasoning as above.

## Testing

Corpus **622/622**, `nurlfmt --check` 910 files, `strict-arity` clean, bootstrap fixed point holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2RiWTSaoydkCaimceEkys
