### PR TITLE
No ordering between an address and a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **No ordering between an address and a number.** The pointer/scalar
+  operand check exempted all comparisons, for a reason that is only
+  about equality: `== ptr 0` is a null check and pointer-to-pointer
+  compares in i64. Written as "comparisons", the exemption also covered
+  `<` `>` `<=` `>=`, where a pointer against an integer means nothing —
+  so `? > 1 \`s\`` compiled clean, linked, and produced a running binary
+  that silently compared an i64 against an address.
+
+  Found by the diagnostic probe suite, in the group that compiled with
+  no diagnostic at all. A missing check is the worst AX outcome there
+  is: no wording can teach what the compiler never says.
+
+  Ordering comparisons are checked now; equality keeps the exemption
+  exactly as before, pinned from the other side by `cmp_ptr_null_ok`.
+
 ### Changed
 
 - **A 30-case probe suite over realistic mistakes, and what it found.**

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -3240,11 +3240,19 @@
     {}
     : b lp ( is_ptr_ty lt )
     : b rp ( is_ptr_ty rt )
-    ? & ! is_cmp != lp rp
+    // ORDERING comparisons join the arithmetic ops here. The exemption
+    // above exists for `== ptr 0` and ptr↔ptr, which are equality; it was
+    // written as "comparisons" and so also covered '<' '>' '<=' '>=',
+    // where a pointer against an integer means nothing. `? > 1 \`s\`` —
+    // an int literal against a string — compiled clean and produced a
+    // running binary that silently compared an i64 with an address.
+    // Equality keeps the exemption exactly as before.
+    : b is_order | | == tt TT_LT == tt TT_GT | == tt TT_LE == tt TT_GE
+    ? & | ! is_cmp is_order != lp rp
     { ( die lex ( nurl_str_cat ( nurl_str_cat4
-        `arithmetic operator mixes a pointer/string and a non-pointer operand: left is '` lt
+        `operator mixes a pointer/string and a non-pointer operand: left is '` lt
         `', right is '` rt )
-        `' — operator-level pointer arithmetic is not supported; index with '. ptr idx' or convert explicitly` ) ) }
+        `' — there is no ordering between an address and a number, and operator-level pointer arithmetic is not supported. Index with '. ptr idx', compare like with like, or convert explicitly with '# i expr'. (Equality against 0 for a null check is allowed.)` ) ) }
     {}
     // Bool (i1) vs non-bool. NURL has no implicit bool↔int conversion, so an
     // operator with exactly one i1 operand emitted e.g. `icmp slt i1 %f, %n`

--- a/compiler/tests/cmp_ptr_null_ok.nu
+++ b/compiler/tests/cmp_ptr_null_ok.nu
@@ -1,0 +1,22 @@
+// cmp_ptr_null_ok.nu — the null-check shapes the operand check must
+// keep accepting.
+//
+// The negative control for should_fail_cmp_ptr_int: extending the
+// pointer/scalar check to ordering comparisons must not touch equality,
+// which is how a null check is written, nor pointer-to-pointer
+// ordering, which compares two addresses.
+//
+// Expected output:
+//   null checks ok
+
+@ main → i {
+    : s p `x`
+    : s q `y`
+    : ~ i hits 0
+    ? == p 0 { = hits + hits 1 } {}
+    ? != p 0 { = hits + hits 1 } {}
+    ? < p q { = hits + hits 1 } {}
+    ? > p q { = hits + hits 1 } {}
+    ( nurl_print `null checks ok\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs/cmp_ptr_null_ok.txt
+++ b/compiler/tests/outputs/cmp_ptr_null_ok.txt
@@ -1,0 +1,5 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+null checks ok

--- a/compiler/tests/outputs/should_fail_cmp_ptr_int.txt
+++ b/compiler/tests/outputs/should_fail_cmp_ptr_int.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_cmp_ptr_int.nu
+++ b/compiler/tests/should_fail_cmp_ptr_int.nu
@@ -1,0 +1,19 @@
+// should_fail_cmp_ptr_int.nu — no ordering between an address and a
+// number.
+//
+// The pointer/scalar operand check exempted ALL comparisons, for a
+// reason that is only about equality: `== ptr 0` is a null check and
+// ptr↔ptr compares in i64. Written as "comparisons", the exemption also
+// covered '<' '>' '<=' '>=', where a pointer against an integer means
+// nothing — so `? > 1 \`s\`` compiled clean and produced a running
+// binary that silently compared an i64 with an address.
+//
+// Ordering comparisons are checked now. Equality keeps the exemption,
+// which cmp_ptr_null_ok pins from the other side.
+//
+// Expected: COMPILE FAIL.
+
+@ main → i {
+    ? > 1 `s` { ^ 1 } {}
+    ^ 0
+}


### PR DESCRIPTION
The pointer/scalar operand check exempted **all** comparisons. Its own comment gives the reason, and the reason is only about equality:

> Comparison ops stay exempt for the pointer cases — the ptrtoint coercion below compares `== ptr 0` and ptr↔ptr in i64

Written as "comparisons", the exemption also covered `<` `>` `<=` `>=`, where a pointer against an integer means nothing. So this:

```nurl
? > 1 `s` { ^ 1 } {}
```

compiled clean, linked, and produced a **running binary** that silently compared an i64 against an address.

## The fix

Ordering comparisons now go through the same check the arithmetic operators already did. Equality keeps the exemption exactly as before.

| | before | after |
|---|---|---|
| `> 1 \`s\`` | accepted, ran | rejected |
| `== p 0` (null check) | accepted | accepted |
| `!= p 0` | accepted | accepted |
| `< p q` (ptr↔ptr) | accepted | accepted |
| `< 1 2` | accepted | accepted |

**This is not a new rule.** It is the existing rule reaching the operators it was always meant to cover — the same shape as `vec_free_with` not being in the destructor set (#820): a check written for one spelling that missed the others.

The message names the cure:

> operator mixes a pointer/string and a non-pointer operand: left is `'i64'`, right is `'i8*'` — there is no ordering between an address and a number, and operator-level pointer arithmetic is not supported. Index with `'. ptr idx'`, compare like with like, or convert explicitly with `'# i expr'`. (Equality against 0 for a null check is allowed.)

## Why this one and not the other

The probe suite found two programs that compiled with no diagnostic. This is the one that was a **defect**: a check that exists, with a stated rationale that does not extend to the operators it silenced.

The other — `: i n T`, a bool into an integer binding — is a **documented, deliberate coercion**, described at the site that performs it. Changing it would be a language change, not a bug fix, so it stays; what was actually broken there was the *return* diagnostic asserting the coercion impossible, and that was fixed in #829.

## Testing

`should_fail_cmp_ptr_int` pins the gap closed; `cmp_ptr_null_ok` pins the legal shapes open, so a future tightening cannot quietly take the null check with it. Corpus **624/624**, `nurlfmt --check` 912, `strict-arity`, `leakcheck` and the examples gate all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2RiWTSaoydkCaimceEkys
