### PR TITLE
fix: reject the silent aggregate, enum and payload shape mismatches

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -397,6 +397,24 @@
     ^ # s ( nurl_strdup t )
 }
 
+// Copy of `t` with every space removed. Different lowering paths spell
+// the same function-aggregate type with different whitespace
+// (`{ void(i8*)*, i8* }` vs `{ void (i8*)*, i8* }`), so the closure
+// comparison below must be whitespace-blind.
+@ __strip_spaces s t → s {
+    : i n ( nurl_str_len t )
+    : ~ s out ``
+    : ~ i p 0
+    ~ < p n {
+        : i c ( nurl_str_get t p )
+        ? != c 32
+        { = out ( nurl_str_cat out ( nurl_str_slice t p 1 ) ) }
+        {}
+        = p + p 1
+    }
+    ^ out
+}
+
 @ parse_type i lex → s {
     : i tt ( nurl_lex_type lex )
     ? == tt TT_STAR { ^ ( parse_type_ptr lex ) } {}
@@ -2627,6 +2645,21 @@
         { ( die lex ( nurl_str_cat ( nurl_str_cat4
             `return value type '` ( llvm_to_nurl lt ) `' does not match the declared return type '` ( llvm_to_nurl fn_rt ) )
             `' — a float width widens into a BINDING (': f x f32val' is fine), but a return type is a contract and must match exactly. Convert with '# f expr' (widen, lossless) or '# f32 expr' (narrow).` ) ) }
+        {}
+        // Anonymous/function AGGREGATE spelling mismatch — `^ @ ? f { T x }`
+        // out of a `→ ?i` function (`ret { i1, double }` from a
+        // `{ i1, i64 }` one: invalid IR only the LLVM verifier saw, three
+        // build stages later), or a closure returned from a fn whose
+        // declared `(@ …)` return has a different signature (that one
+        // ASSEMBLES — and every later invoke reinterprets its arguments).
+        // Compared whitespace-blind: the spellings' spacing is not
+        // canonical across lowering paths.
+        ? & & == ( nurl_str_get ( nurl_llty lt ) 0 ) 123
+        == ( nurl_str_get ( nurl_llty fn_rt ) 0 ) 123
+        ! ( seq ( __strip_spaces ( nurl_llty lt ) ) ( __strip_spaces ( nurl_llty fn_rt ) ) )
+        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+            `return value type '` ( nurl_llty lt ) `' does not match the declared return type '` ( nurl_llty fn_rt ) )
+            `' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.` ) ) }
         {}
         // Return the wrong named struct by value (the return-position dual of
         // the call-site struct check): `^ b` from a `→ A` fn where b is a B.
@@ -5911,6 +5944,25 @@
     ``
 }
 
+// Copy of `src` with every space-separated word equal to `from`
+// replaced by `to`. Used by the generic call path to substitute a
+// tparam into a parameter's SOURCE spelling wherever it appears —
+// including inside a compound like `( Box T )`, which the former
+// whole-word compare could not reach.
+@ __subst_word s src s from s to → s {
+    : ~ s out ``
+    : ~ s rest ( nurl_str_cat src `` )
+    ~ != 0 ( nurl_str_len rest ) {
+        : s w ( str_first_word rest )
+        = rest ( str_skip_word rest )
+        : s rw ? ( seq w from ) to w
+        = out ? == 0 ( nurl_str_len out )
+        ( nurl_str_cat rw `` )
+        ( nurl_str_cat3 out ` ` rw )
+    }
+    ^ out
+}
+
 // The float dual of src_int_ty: map a SOURCE- or LLVM-spelling scalar
 // to its LLVM float type, `` when the token is not float-family. Used
 // by the same call-argument agreement path.
@@ -5970,16 +6022,61 @@
 // binding would never free the coerced pair (LSan caught exactly that).
 // Pointer-typed arguments are left alone: the pointer-vs-value checks
 // and the FFI inttoptr/ptrtoint paths own that territory.
-@ __call_arg_scalar i lex i cg s fname i arg_idx s psrc s at s av → s {
+@ __call_arg_scalar i lex i syms i cg s fname i arg_idx s psrc s at s av → s {
     ? == 0 ( nurl_str_len psrc ) { ^ ( nurl_str_cat `` `` ) } {}
     : s want_i ( src_int_ty psrc )
     : s want_f ( src_float_ty psrc )
-    ? & == 0 ( nurl_str_len want_i ) == 0 ( nurl_str_len want_f ) { ^ ( nurl_str_cat `` `` ) } {}
     : s at_ll ( nurl_llty at )
-    ? ( is_ptr_ty at_ll ) { ^ ( nurl_str_cat `` `` ) } {}
     : b have_f ( is_float_ty at_ll )
     : ~ i hw ( int_width at )
     ? == hw 0 { = hw ( int_width ( src_int_ty at ) ) } {}
+    // Enums are NOMINAL: an i64 under the hood, but the set of legal
+    // values is the variant list, so no numeric value converts in and
+    // the tag does not convert out. Before these checks a float slid in
+    // as a mismatched call register (`call i64 @show(double …)` — the
+    // t4_type shape again), an integer slid in as an out-of-range "tag"
+    // (`( show 7 )` against three variants), and an enum slid OUT into a
+    // numeric parameter as `call @f(%Color …)` — a struct where the
+    // callee reads a scalar register.
+    : ~ s at_enum ``
+    ? == ( nurl_str_get at_ll 0 ) 37 {
+        : s __aen ( nurl_str_slice at_ll 1 - ( nurl_str_len at_ll ) 1 )
+        ? != 0 ( nurl_sym_len2 syms __aen `__variants` ) { = at_enum ( nurl_str_cat __aen `` ) } {}
+    } {}
+    ? & & == 0 ( nurl_str_len want_i ) == 0 ( nurl_str_len want_f )
+    != 0 ( nurl_sym_len2 syms psrc `__variants` )
+    {  // Enum-declared parameter.
+        ? != 0 ( nurl_str_len at_enum ) {
+            ? ( seq at_enum psrc ) { ^ ( nurl_str_cat `` `` ) } {}
+            ( die lex ( nurl_str_cat3
+            ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
+            ( nurl_str_cat4 `' has enum type '` at_enum `' but the parameter is declared enum '` psrc )
+            `' — two enums are distinct nominal types even when their tags overlap; the callee would read this value's tag as the OTHER enum's variants. Pass a variant of the declared enum.` ) ) }
+        {}
+        ? | > hw 0 have_f
+        {  // A bare tag-only VARIANT of the declared enum evaluates to its
+            // i64 tag — that is the legal way to pass one. Only reject a
+            // numeric value that is not spelled as a variant name.
+            : s __vident ( nurl_sym_get syms `__last_ident_name__` )
+            ? & & > hw 0 != 0 ( nurl_str_len __vident )
+            ( str_contains_word ( nurl_sym_get2 syms psrc `__variants` ) __vident )
+            { ^ ( nurl_str_cat `` `` ) }
+            {}
+            ( die lex ( nurl_str_cat3
+            ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
+            ( nurl_str_cat4 `' has numeric type '` ( llvm_to_nurl at_ll ) `' but the parameter is declared enum '` psrc )
+            `' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Pass a variant by name (e.g. the enum's first variant), or change the parameter to a numeric type.` ) ) }
+        {}
+        ^ ( nurl_str_cat `` `` )
+    } {}
+    ? & != 0 ( nurl_str_len at_enum ) | != 0 ( nurl_str_len want_i ) != 0 ( nurl_str_len want_f )
+    { ( die lex ( nurl_str_cat3
+        ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
+        ( nurl_str_cat4 `' has enum type '` at_enum `' but the parameter is declared '` psrc )
+        `' — an enum's tag is not a number without an explicit conversion; the emitted call would pass the whole enum value where the callee reads a scalar register. Convert intentionally with '# i x', or declare the parameter to take the enum.` ) ) }
+    {}
+    ? & == 0 ( nurl_str_len want_i ) == 0 ( nurl_str_len want_f ) { ^ ( nurl_str_cat `` `` ) } {}
+    ? ( is_ptr_ty at_ll ) { ^ ( nurl_str_cat `` `` ) } {}
     ? & != 0 ( nurl_str_len want_f ) > hw 0
     { ( die lex ( nurl_str_cat3
         ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
@@ -6093,7 +6190,7 @@
     : s __kdroster ( nurl_sym_get2 syms fname `__ptypes_src` )
     ? != 0 ( nurl_str_len __kdroster ) {
         : s __kdpsrc ( __kw_trim ( __ptypes_nth __kdroster k ) )
-        : s __kdsc ( __call_arg_scalar lex cg fname k __kdpsrc __kdt __kdv )
+        : s __kdsc ( __call_arg_scalar lex syms cg fname k __kdpsrc __kdt __kdv )
         ? != 0 ( nurl_str_len __kdsc ) {
             = __kdt ( str_first_word __kdsc )
             = __kdv ( str_skip_word __kdsc )
@@ -6158,7 +6255,7 @@
                     : s __kwpllvm ( parse_type __kwplx )
                     ( nurl_lex_free __kwplx )
                     ( __arg_param_checks lex fname slot at __kwpllvm )
-                    : s __ksc ( __call_arg_scalar lex cg fname slot __kwpsrc at av )
+                    : s __ksc ( __call_arg_scalar lex syms cg fname slot __kwpsrc at av )
                     ? != 0 ( nurl_str_len __ksc ) {
                         = at ( str_first_word __ksc )
                         = av ( str_skip_word __ksc )
@@ -6323,24 +6420,6 @@
     : s pt_ll ( nurl_llty pt )
     ? | ( __is_named_agg at_ll ) ( __is_named_agg pt_ll ) { ^ F } {}
     ^ != ( is_ptr_ty at_ll ) ( is_ptr_ty pt_ll )
-}
-
-// Copy of `t` with every space removed. Different lowering paths spell
-// the same function-aggregate type with different whitespace
-// (`{ void(i8*)*, i8* }` vs `{ void (i8*)*, i8* }`), so the closure
-// comparison below must be whitespace-blind.
-@ __strip_spaces s t → s {
-    : i n ( nurl_str_len t )
-    : ~ s out ``
-    : ~ i p 0
-    ~ < p n {
-        : i c ( nurl_str_get t p )
-        ? != c 32
-        { = out ( nurl_str_cat out ( nurl_str_slice t p 1 ) ) }
-        {}
-        = p + p 1
-    }
-    ^ out
 }
 
 // Both spellings are closure/function aggregates (`{ <ret> (<params>…)*,
@@ -7131,7 +7210,7 @@
                     // clang assembled and the callee misread). Returns ``
                     // when it neither died nor coerced — the pointer cases,
                     // which the inttoptr/ptrtoint branches below own.
-                    : s __fsc ( __call_arg_scalar lex cg fname arg_idx __want at av )
+                    : s __fsc ( __call_arg_scalar lex syms cg fname arg_idx __want at av )
                     ? != 0 ( nurl_str_len __fsc ) {
                         = at ( str_first_word __fsc )
                         = av ( str_skip_word __fsc )
@@ -7190,15 +7269,33 @@
                             = __tpr ( str_skip_word __tpr )
                             : s __ta ( str_first_word __tar )
                             = __tar ( str_skip_word __tar )
-                            ? ( seq __psrc __tp ) { = __psrc __ta } {}
+                            // Tokenwise, not whole-word: a tparam INSIDE a
+                            // compound spelling (`( Box T )` → `( Box i )`)
+                            // must substitute too, or the inout receiver
+                            // check below sees an uncomparable template.
+                            = __psrc ( __subst_word __psrc __tp __ta )
                         }
                     } {}
-                    // Non-generic callees only: the whole-word substitution
-                    // above does not reach a tparam INSIDE a compound
-                    // spelling (`( Stack T )` stays unsubstituted), and
-                    // parse_type on that would fabricate a false clash for
-                    // every generic inout receiver.
-                    ? & is_inout_arg ( seq call_name fname ) {
+                    // Generic callees included: the tokenwise substitution
+                    // above reaches tparams inside compound spellings
+                    // (`( Box T )` → `( Box i )`), so a generic inout
+                    // receiver compares like a concrete one — `( put [i]
+                    // bf 3 )` with bf: (Box f) used to emit `call
+                    // @put__i64(%Box__f64* …)` and the callee rewrote the
+                    // caller's double field with an i64. Belt-and-braces:
+                    // if any tparam survives in __psrc (an arity edge the
+                    // substitution walk missed), skip rather than
+                    // parse_type a template spelling into a false clash.
+                    : ~ b __io_sub_ok T
+                    ? ! ( seq call_name fname ) {
+                        : ~ s __tpr2 ( nurl_sym_get2 g_generic_syms fname `__tparams` )
+                        ~ != 0 ( nurl_str_len __tpr2 ) {
+                            : s __tp2 ( str_first_word __tpr2 )
+                            = __tpr2 ( str_skip_word __tpr2 )
+                            ? ( str_contains_word __psrc __tp2 ) { = __io_sub_ok F } {}
+                        }
+                    } {}
+                    ? & is_inout_arg __io_sub_ok {
                         // An `inout` argument passes the binding's ADDRESS,
                         // so the binding's type must equal the declared
                         // parameter type EXACTLY — there is no register to
@@ -7223,7 +7320,7 @@
                             {}
                         } {}
                     } {
-                        : s __nsc ( __call_arg_scalar lex cg fname arg_idx __psrc at av )
+                        : s __nsc ( __call_arg_scalar lex syms cg fname arg_idx __psrc at av )
                         ? != 0 ( nurl_str_len __nsc ) {
                             = at ( str_first_word __nsc )
                             = av ( str_skip_word __nsc )
@@ -14750,16 +14847,28 @@
                             = actual_fty `i64`
                         }
                     }
-                    ? ( seq fty `double` )
-                    {  // double → i64 via bitcast (payload slot is i64).
-                        // The receiving ?? match arm does the inverse via
-                        // bitcast i64→double when reconstructing the value.
-                        : s db_bc ( nurl_cg_reg cg )
-                        ( nurl_print `  ` ) ( nurl_print db_bc )
-                        ( nurl_print ` = bitcast double ` ) ( nurl_print fval )
-                        ( nurl_print ` to i64\n` )
-                        = actual_fval db_bc
-                        = actual_fty `i64`
+                    ? ( is_float_ty ( nurl_llty fty ) )
+                    {  // Float value into the payload slot: legal ONLY when
+                        // the declared payload is float-family (width-bridge
+                        // it) or the i64 box of a NURL-typed slot whose
+                        // reader bitcasts back (payload_ty i64 with the
+                        // recorded NURL payload type also `f` — the `! f E`
+                        // shape; its ?? arm reconstructs via bitcast). A
+                        // float into a genuinely-INTEGER payload (`@ ? i
+                        // { T 1.5 }`) used to bitcast 1.5's BITS into the
+                        // slot — the match arm then read 4609434218613702656,
+                        // silently.
+                        : s __pfl ( src_float_ty payload_ty )
+                        ? != 0 ( nurl_str_len __pfl )
+                        { ? ( seq ( nurl_llty fty ) __pfl )
+                            {}  // exact match handled by payload_matches above; width differs:
+                            { : s __fw ( __emit_fwiden cg fval ( nurl_llty fty ) __pfl )
+                                = actual_fval __fw
+                                = actual_fty ( nurl_str_cat payload_ty `` ) } }
+                        { ( die lex ( nurl_str_cat3
+                            ( nurl_str_cat `payload of this option/result literal has float type '` ( llvm_to_nurl ( nurl_llty fty ) ) )
+                            ( nurl_str_cat3 `' but the declared payload type is '` ( llvm_to_nurl payload_ty ) `' — NURL has no implicit float↔integer conversions` )
+                            `; storing the bits anyway would make the '??' match arm read the float's raw bit pattern as an integer. Convert explicitly ('# i expr' truncates toward zero), or declare the payload 'f'.` ) ) }
                     }
                     {  // Integer payload whose width differs from the value's.
                         // For `! T E` the payload slot is always i64, so an
@@ -14784,7 +14893,17 @@
                             ( nurl_print `\n` )
                             = actual_fval __cv
                             = actual_fty payload_ty }
-                        {  // payload_ty is not an int. The one remaining
+                        {  // Integer value into a FLOAT payload (`@ ? f
+                            // { T 3 }`) — the dual of the float→int die
+                            // above; the raw insertvalue was invalid IR
+                            // only clang reported.
+                            ? & > __vw 0 ( is_float_ty ( nurl_llty payload_ty ) )
+                            { ( die lex ( nurl_str_cat3
+                                ( nurl_str_cat `payload of this option/result literal has integer type '` ( llvm_to_nurl ( nurl_llty fty ) ) )
+                                ( nurl_str_cat3 `' but the declared payload type is '` ( llvm_to_nurl payload_ty ) `' (a float) — NURL has no implicit integer↔float conversions` )
+                                `. Write the payload as a float ('2.0', not '2'), or convert with '# f expr'.` ) ) }
+                            {}
+                            // payload_ty is not an int. The one remaining
                             // shape is an OPTION whose payload is a named
                             // enum (`? E`, payload field `%E`) carrying a
                             // bare no-payload variant — which evaluates to
@@ -15504,10 +15623,29 @@
         // rejected.
         : b csv_agg & > ( int_width from_ty ) 0
         == ( nurl_str_get ( nurl_llty to_ty ) 0 ) 123
-        ? | | != csv_sf csv_tf & ( is_ptr_ty from_ty ) ! ( is_ptr_ty to_ty ) csv_agg
+        // Two anonymous/function aggregates spelled differently — a
+        // `{ i1, double }` option bound to a ': ?i' declaration, or a
+        // '(@ f f)' closure bound to '(@ i i)'. The store is invalid IR
+        // for the option shapes (only clang saw it), and for closures it
+        // ASSEMBLES — every later invoke then reinterprets its arguments.
+        // Whitespace-blind: aggregate spacing is not canonical.
+        : b csv_agg2 & & == ( nurl_str_get ( nurl_llty from_ty ) 0 ) 123
+        == ( nurl_str_get ( nurl_llty to_ty ) 0 ) 123
+        ! ( seq ( __strip_spaces ( nurl_llty from_ty ) ) ( __strip_spaces ( nurl_llty to_ty ) ) )
+        // An aggregate value into a plain scalar binding (`: i x` from an
+        // option/result/slice value) — the legal unwraps all returned
+        // above, so what reaches here would be `store i64 { i1, i64 }…`.
+        : b csv_agg_src & == ( nurl_str_get ( nurl_llty from_ty ) 0 ) 123
+        | > ( int_width ( nurl_llty to_ty ) ) 0 ( is_float_ty ( nurl_llty to_ty ) )
+        // The cure differs by shape: an aggregate value wants '??'
+        // destructuring (or matching shapes), a scalar wants a cast.
+        : s __csv_cure ? | csv_agg2 csv_agg_src
+        `' — NURL has no implicit conversions between differently-shaped aggregates; make the option/result/closure shapes match exactly, or destructure with '??' and bind the payload`
+        `' — NURL has no implicit conversions; use a matching value or convert with '# T expr'`
+        ? | | | | != csv_sf csv_tf & ( is_ptr_ty from_ty ) ! ( is_ptr_ty to_ty ) csv_agg csv_agg2 csv_agg_src
         { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
             `value of type '` from_ty `' cannot initialise / assign a binding of type '` to_ty )
-            `' — NURL has no implicit conversions; use a matching value or convert with '# T expr'` ) ) }
+            __csv_cure ) ) }
         {}
     }
     {}

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -711,19 +711,30 @@
 // word — `nurl_lex_val` alone would grab only the leading `?`. Paren-
 // compound args are handled separately by the caller.
 @ capture_type_arg_src i lex → s {
+    // Every return path allocates, and each recursive result is BOUND
+    // before the cat (an owned temp passed straight into an arg list is
+    // never collected — LSan, 31 objects per generic-option compile).
+    // The old bare-`^ v` tail made this a mixed owned/borrowed return,
+    // which classifies as not-owned so no caller freed the cat paths.
     : i tt ( nurl_lex_type lex )
     ? == tt TT_QUEST
-    { ( nurl_lex_advance lex ) ^ ( nurl_str_cat `?` ( capture_type_arg_src lex ) ) }
+    { ( nurl_lex_advance lex )
+        : s __in ( capture_type_arg_src lex )
+        ^ ( nurl_str_cat `?` __in ) }
     {}
     ? == tt TT_QUESTQUEST
-    { ( nurl_lex_advance lex ) ^ ( nurl_str_cat `??` ( capture_type_arg_src lex ) ) }
+    { ( nurl_lex_advance lex )
+        : s __in ( capture_type_arg_src lex )
+        ^ ( nurl_str_cat `??` __in ) }
     {}
     ? == tt TT_STAR
-    { ( nurl_lex_advance lex ) ^ ( nurl_str_cat `*` ( capture_type_arg_src lex ) ) }
+    { ( nurl_lex_advance lex )
+        : s __in ( capture_type_arg_src lex )
+        ^ ( nurl_str_cat `*` __in ) }
     {}
     : s v ( nurl_lex_val lex )
     ( nurl_lex_advance lex )
-    ^ v
+    ^ ( nurl_str_cat v `` )
 }
 
 // [ T  →  { T*, i64 }
@@ -2570,7 +2581,7 @@
     // taken a different path — e.g. a literal or operator — that
     // never reached gen_call to consume it).
     ( nurl_sym_def syms `__tail_call_pending__` `` )
-    : s lt ( nurl_get_last_type )
+    : ~ s lt ( nurl_get_last_type )
     // Escape analysis: warn if the returned value
     // is a stack reference — a closure capturing a binding by pointer,
     // an aggregate holding one, or a binding holding either. The
@@ -2684,6 +2695,39 @@
             ( die lex ( nurl_str_cat ( nurl_str_cat4
             `return value type '` ( llvm_to_nurl lt ) `' does not match the declared return type '` ( llvm_to_nurl fn_rt ) )
             cure ) ) }
+        {}
+        // Enum return type. A bare variant (`^ Green` from a `→ Color`
+        // fn) evaluates to its i64 tag, so the ret was `ret i64` out of
+        // a `define %Color` function — invalid IR only clang saw, three
+        // build stages later. Wrap the tag into the enum shape (the
+        // return-position dual of the binding wrap in coerce_store_val).
+        // Any OTHER integer dies: an enum is a closed set of named
+        // variants, and no number converts into one.
+        ? & & == ( nurl_str_get fn_rt 0 ) 37 ( is_int_ty lt ) ! ( is_ptr_ty fn_rt )
+        { : s __ren ( nurl_str_slice fn_rt 1 - ( nurl_str_len fn_rt ) 1 )
+            : s __rvl ( nurl_sym_get2 syms __ren `__variants` )
+            ? != 0 ( nurl_str_len __rvl )
+            {  // A variant is recognised from the return expression's
+                // FIRST token (already snapshotted for the §2.8 passthrough
+                // check — `__last_ident_name__` would also bless
+                // `^ ( f Red )`-shaped stale idents), or from a `?`-join
+                // both of whose arms gen_cond proved variants of this
+                // enum (`^ ? cond Red Green`). Consume-once channel.
+                : s __rjve ( nurl_str_cat ( nurl_sym_get syms `__last_join_variant_enum__` ) `` )
+                ( nurl_sym_def syms `__last_join_variant_enum__` `` )
+                ? | & & == ( int_width lt ) 64 ( is_ident_tok ret_first_tt )
+                ( str_contains_word __rvl ret_first_val )
+                & == ( int_width lt ) 64 ( seq __rjve __ren )
+                { : s __ewr ( nurl_cg_reg cg )
+                    ( nurl_print `  ` ) ( nurl_print __ewr )
+                    ( nurl_print ` = insertvalue ` ) ( nurl_print ( nurl_llty fn_rt ) )
+                    ( nurl_print ` undef, i64 ` ) ( nurl_print val ) ( nurl_print `, 0\n` )
+                    = val __ewr
+                    = lt ( nurl_str_cat fn_rt `` ) }
+                { ( die lex ( nurl_str_cat ( nurl_str_cat4
+                    `return value type '` ( llvm_to_nurl lt ) `' does not match the declared return type: enum '` __ren )
+                    `' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Return a variant by name ('^ Red'), or declare a numeric return type.` ) ) } }
+            {} }
         {}
     }
     {}
@@ -3236,12 +3280,104 @@
     ? == tt TT_PIPE ^ ( gen_logical_or_bitwise_or lex syms cg )
     // Original binary operation logic for other operators
     ( nurl_lex_advance lex )
+    // Snapshot each operand's FIRST token before gen_operand consumes
+    // it: the enum rules below need to know whether an operand was
+    // spelled as a bare VARIANT name, and the lexer is the only place
+    // that can say so without touching the `__last_ident_name__`
+    // side-channel (whose stale value is load-bearing elsewhere).
+    : i __ltok ( nurl_lex_type lex )
+    : s __lvid ( nurl_str_cat ( nurl_lex_val lex ) `` )
     : ~ s lv ( gen_operand lex syms cg )
-    : s lt ( nurl_get_last_type )
+    : ~ s lt ( nurl_get_last_type )
+    : i __rtok ( nurl_lex_type lex )
+    : s __rvid ( nurl_str_cat ( nurl_lex_val lex ) `` )
     : ~ s rv ( gen_operand lex syms cg )
-    : s rt ( nurl_get_last_type )
+    : ~ s rt ( nurl_get_last_type )
     ( die_if_void lex lv `binary operator's left` )
     ( die_if_void lex rv `binary operator's right` )
+    // ── Enum operands are NOMINAL ─────────────────────────────────────
+    // `== c Green` used to emit `icmp eq %Color %r4, %r5` with %r5 an
+    // i64 tag — invalid IR only clang saw (so the diag_cond_enum cure
+    // text recommended a comparison that could not compile). Every other
+    // mix — `== c 7`, a cross-enum `==`, `+ c 1`, `< c d` — likewise
+    // emitted invalid IR, or assembled into a silent tag/number pun.
+    //   * ==/!= between two values of the SAME payload-free enum
+    //     compares their tags (extractvalue slot 0 each side).
+    //   * ==/!= against a bare VARIANT of the operand's own enum
+    //     compares the tag against that variant's tag.
+    //   * everything else dies: arithmetic/ordering has no meaning on a
+    //     closed set of names, a payload-carrying enum compares by '??'
+    //     match, and a number or an unrelated enum never converts in.
+    : ~ s __eln ``
+    ? & != 0 ( nurl_str_len lt ) == ( nurl_str_get lt 0 ) 37
+    { : s __en0 ( nurl_str_slice lt 1 - ( nurl_str_len lt ) 1 )
+        ? != 0 ( nurl_sym_len2 syms __en0 `__variants` ) { = __eln ( nurl_str_cat __en0 `` ) } {} }
+    {}
+    : ~ s __ern ``
+    ? & != 0 ( nurl_str_len rt ) == ( nurl_str_get rt 0 ) 37
+    { : s __en1 ( nurl_str_slice rt 1 - ( nurl_str_len rt ) 1 )
+        ? != 0 ( nurl_sym_len2 syms __en1 `__variants` ) { = __ern ( nurl_str_cat __en1 `` ) } {} }
+    {}
+    ? | != 0 ( nurl_str_len __eln ) != 0 ( nurl_str_len __ern ) {
+        ? ! | == tt TT_EQEQ == tt TT_NE
+        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+            `operator applied to an enum operand: left is '` ( llvm_to_nurl lt )
+            `', right is '` ( llvm_to_nurl rt ) )
+            `' — an enum is a closed set of named variants, not a number: arithmetic and ordering have no meaning on it. Compare with '==' against a variant, match with '??', or read the tag intentionally with '# i x'.` ) ) }
+        {}
+        : ~ s __een ``
+        ? != 0 ( nurl_str_len __eln ) { = __een ( nurl_str_cat __eln `` ) } { = __een ( nurl_str_cat __ern `` ) }
+        ? > ( nurl_str_to_int ( nurl_sym_get2 syms __een `__max_payloads` ) ) 0
+        { ( die lex ( nurl_str_cat3
+            `'==' on enum '` __een
+            `' whose variants carry payloads — tag equality would ignore the payloads. Match with '?? x { … }' and compare what the variants carry.` ) ) }
+        {}
+        ? & != 0 ( nurl_str_len __eln ) != 0 ( nurl_str_len __ern )
+        { ? ! ( seq __eln __ern )
+            { ( die lex ( nurl_str_cat ( nurl_str_cat4
+                `'==' between two DIFFERENT enums: left is '` __eln
+                `', right is '` __ern )
+                `' — two enums are distinct nominal types even when their tags overlap; equality between them would compare unrelated variant sets. Compare values of one enum, or match each with '??'.` ) ) }
+            {}
+            : s __exl ( nurl_cg_reg cg )
+            ( nurl_print `  ` ) ( nurl_print __exl ) ( nurl_print ` = extractvalue ` )
+            ( nurl_print ( nurl_llty lt ) ) ( nurl_print ` ` ) ( nurl_print lv ) ( nurl_print `, 0\n` )
+            = lv __exl
+            = lt ( nurl_str_cat `i64` `` )
+            : s __exr ( nurl_cg_reg cg )
+            ( nurl_print `  ` ) ( nurl_print __exr ) ( nurl_print ` = extractvalue ` )
+            ( nurl_print ( nurl_llty rt ) ) ( nurl_print ` ` ) ( nurl_print rv ) ( nurl_print `, 0\n` )
+            = rv __exr
+            = rt ( nurl_str_cat `i64` `` ) }
+        { : ~ s __evid ``
+            : ~ i __othw 0
+            : ~ b __evok F
+            ? != 0 ( nurl_str_len __eln )
+            { = __evid ( nurl_str_cat __rvid `` ) = __othw ( int_width rt ) = __evok ( is_ident_tok __rtok ) }
+            { = __evid ( nurl_str_cat __lvid `` ) = __othw ( int_width lt ) = __evok ( is_ident_tok __ltok ) }
+            ? & & & __evok == __othw 64 != 0 ( nurl_str_len __evid )
+            ( str_contains_word ( nurl_sym_get2 syms __een `__variants` ) __evid )
+            { ? != 0 ( nurl_str_len __eln )
+                { : s __exv ( nurl_cg_reg cg )
+                    ( nurl_print `  ` ) ( nurl_print __exv ) ( nurl_print ` = extractvalue ` )
+                    ( nurl_print ( nurl_llty lt ) ) ( nurl_print ` ` ) ( nurl_print lv ) ( nurl_print `, 0\n` )
+                    = lv __exv
+                    = lt ( nurl_str_cat `i64` `` ) }
+                { : s __exv ( nurl_cg_reg cg )
+                    ( nurl_print `  ` ) ( nurl_print __exv ) ( nurl_print ` = extractvalue ` )
+                    ( nurl_print ( nurl_llty rt ) ) ( nurl_print ` ` ) ( nurl_print rv ) ( nurl_print `, 0\n` )
+                    = rv __exv
+                    = rt ( nurl_str_cat `i64` `` ) } }
+            { : ~ s __eot ``
+                ? != 0 ( nurl_str_len __eln )
+                { = __eot ( nurl_str_cat ( llvm_to_nurl rt ) `` ) }
+                { = __eot ( nurl_str_cat ( llvm_to_nurl lt ) `` ) }
+                ( die lex ( nurl_str_cat ( nurl_str_cat4
+                `'==' between enum '` __een
+                `' and a value of type '` __eot )
+                `' — an enum is a closed set of named variants, and no number converts into one implicitly. Compare against a variant by name ('== c Red'), match with '?? c { … }', or read the tag intentionally with '# i x'.` ) ) } }
+    }
+    {}
     : s res ( nurl_cg_reg cg )
     : b isf | ( seq lt `double` ) ( seq lt `float` )
     // `^^` (XOR) is integer/bool-only — LLVM has no float `xor`.
@@ -7853,10 +7989,18 @@
     // path's scope-exit drop then freed .rodata (SEGV).
     ( nurl_sym_def syms `__last_call_ret_owned__` `` )
     ( nurl_sym_def syms `__last_value_alias__` `` )
+    // Variant-join blessing gets the same per-arm reset+snapshot
+    // discipline as the ownership channels above: a nested `?`-join of
+    // variants publishes into it, and stale residue must not bless an
+    // unrelated arm.
+    ( nurl_sym_def syms `__last_join_variant_enum__` `` )
     // First token of the arm: a bare string-literal arm's value is a
     // .rodata GEP — provably non-null, so it can be copied to make a
-    // MIXED join uniformly owned (see the dup blocks below).
+    // MIXED join uniformly owned (see the dup blocks below). The token
+    // VALUE says whether the arm is a bare identifier (`Red`) — the only
+    // spelling the variant blessing below may trust.
     : i t_tt0 ( nurl_lex_type lex )
+    : s t_v0 ( nurl_str_cat ( nurl_lex_val lex ) `` )
     : ~ s tv ( gen_expr lex syms cg )
     : s tt2 ( nurl_get_last_type )
     : s t_slice_flag ( nurl_str_cat ( nurl_sym_get syms `__last_slice_owned__` ) `` )
@@ -7902,6 +8046,13 @@
         = tv __td
         = t_dup T
     } {}
+    // Which enum this arm's value is a variant TAG of, if any: a bare
+    // variant name (`Red` — token and last-ident agree), or a nested
+    // `?`-join that already proved both ITS arms variants of one enum.
+    : ~ s t_ven ``
+    ? & ( is_ident_tok t_tt0 ) & ( seq t_v0 t_retid ) != 0 ( nurl_str_len t_retid )
+    { = t_ven ( nurl_str_cat ( nurl_sym_get2 syms t_retid `__enum_of` ) `` ) }
+    { = t_ven ( nurl_str_cat ( nurl_sym_get syms `__last_join_variant_enum__` ) `` ) }
     : s tlbl ( nurl_sym_get syms `__cur_lbl__` )
     : i tdr g_did_ret
     // Lossless 64-bit shadow of an integer branch value, emitted while
@@ -7968,7 +8119,9 @@
     ( nurl_sym_def syms `__last_slice_owned__` `` )
     ( nurl_sym_def syms `__last_call_ret_owned__` `` )
     ( nurl_sym_def syms `__last_value_alias__` `` )
+    ( nurl_sym_def syms `__last_join_variant_enum__` `` )
     : i e_tt0 ( nurl_lex_type lex )
+    : s e_v0 ( nurl_str_cat ( nurl_lex_val lex ) `` )
     : ~ s ev ( gen_expr lex syms cg )
     : s et2 ( nurl_get_last_type )
     : s e_slice_flag ( nurl_str_cat ( nurl_sym_get syms `__last_slice_owned__` ) `` )
@@ -7991,6 +8144,11 @@
         = ev __ed
         = e_dup T
     } {}
+    // Mirror of t_ven above.
+    : ~ s e_ven ``
+    ? & ( is_ident_tok e_tt0 ) & ( seq e_v0 e_retid ) != 0 ( nurl_str_len e_retid )
+    { = e_ven ( nurl_str_cat ( nurl_sym_get2 syms e_retid `__enum_of` ) `` ) }
+    { = e_ven ( nurl_str_cat ( nurl_sym_get syms `__last_join_variant_enum__` ) `` ) }
     : s elbl ( nurl_sym_get syms `__cur_lbl__` )
     : i edr g_did_ret
     : ~ s ev64 ( nurl_str_cat ev `` )
@@ -8040,6 +8198,16 @@
     // `br`, producing label cascades with no terminators (LLVM error
     // "expected instruction opcode").
     ? & != 0 tdr != 0 edr { ( emit_call_term `unreachable` ) = g_did_ret 1 } { = g_did_ret 0 }
+    // A `?`-join whose BOTH arms are variants of the same enum yields
+    // the tag of whichever arm ran — publish which enum, so the enum
+    // wrap sites (binding init/assign, return) can bless
+    // `= ferr ? cond ResolveConflict ResolveNoMatch` exactly as they
+    // bless a bare `= ferr ResolveConflict`. Consume-once: readers
+    // clear it, and each arm above resets it against stale residue.
+    ( nurl_sym_def syms `__last_join_variant_enum__` `` )
+    ? & != 0 ( nurl_str_len t_ven ) ( seq t_ven e_ven )
+    { ( nurl_sym_def syms `__last_join_variant_enum__` t_ven ) }
+    {}
     // Prefix-arity grammar: `?` consumed bare expressions for
     // then/else, but the very next token is `{`. Almost always the
     // n-ary `&`/`|` foot-gun: user wrote `? & a b c d { then } { else }`
@@ -12856,6 +13024,12 @@
 
                 // Widen i1 short-circuit / comparison results to the declared
                 // integer width before storing (`: i can_l & …` etc.).
+                // Hand the RHS's first-token evidence to the enum-wrap
+                // gate (consume-once; branch form, not a `?`-join of a
+                // tracked ident — that join leaks its phi copy).
+                ? ( is_ident_tok bck_rhs_tt )
+                { ( nurl_sym_def syms `__store_rhs_tok__` bck_rhs_val ) }
+                { ( nurl_sym_def syms `__store_rhs_tok__` `-` ) }
                 : s widened_val ( coerce_store_val lex val vt ptype syms cg )
                 // Handle closure to function pointer conversion
                 : s store_val ( convert_closure_arg widened_val vt ptype cg )
@@ -13227,6 +13401,13 @@
         // Widen i1 short-circuit / comparison results to the LHS's
         // declared integer width, so `= myi64 & a b` stores cleanly.
         : s rhs_ty ( nurl_get_last_type )
+        // RHS first-token evidence for the enum-wrap gate (see the
+        // binding-init site): a non-ident RHS must VETO the stale
+        // last-ident heuristic (`= c 7` after `: Color c Red` wrapped 7
+        // on Red's residue, silently).
+        ? ( is_ident_tok bck_rhs_tt )
+        { ( nurl_sym_def syms `__store_rhs_tok__` bck_rhs_val ) }
+        { ( nurl_sym_def syms `__store_rhs_tok__` `-` ) }
         : s store_val ( coerce_store_val lex val rhs_ty vt syms cg )
         ? != 0 ( nurl_str_len ptr )
         { ( nurl_print `  store ` ) ( nurl_print ( nurl_llty vt ) ) ( nurl_print ` ` )
@@ -15475,6 +15656,14 @@
 // no-op in every other case. Placed here so both the let-binding and
 // `=`-assign paths can share it.
 @ coerce_store_val i lex s val s from_ty s to_ty i syms i cg → s {
+    // RHS first-token evidence from the binding-init / assignment call
+    // sites, consume-once: `` = no evidence (fall back to the last-ident
+    // heuristic), `-` = the RHS was NOT a bare identifier (a stale
+    // last-ident must not bless the enum wrap — `: Color c Red` followed
+    // by `= c 7` used to wrap 7 on Red's residue), anything else = the
+    // identifier the RHS was spelled as.
+    : s __srv ( nurl_str_cat ( nurl_sym_get syms `__store_rhs_tok__` ) `` )
+    ( nurl_sym_def syms `__store_rhs_tok__` `` )
     // The void/unit value (a bare type keyword `v`) is never storable —
     // `: i y v` / `= x v` used to emit `store i64 void`. Reject at the source.
     ( die_if_void lex val `initialiser / assignment` )
@@ -15510,7 +15699,24 @@
     { : s tname ( nurl_str_slice to_ty 1 - ( nurl_str_len to_ty ) 1 )
         : s vlist ( nurl_sym_get2 syms tname `__variants` )
         ? != 0 ( nurl_str_len vlist )
-        { : s r ( nurl_cg_reg cg )
+        {  // Only a VARIANT of the declared enum may wrap: a bare variant
+            // name, or a `?`-join both of whose arms gen_cond proved
+            // variants of this enum. Any other i64 (`: Color c 7`,
+            // `= c 7`, an int binding) used to wrap silently — a number
+            // became an enum value whose tag may name no variant at all,
+            // and every later match walked past it.
+            : s __wvid ( nurl_sym_get syms `__last_ident_name__` )
+            : s __wjve ( nurl_str_cat ( nurl_sym_get syms `__last_join_variant_enum__` ) `` )
+            ( nurl_sym_def syms `__last_join_variant_enum__` `` )
+            ? | | & != 0 ( nurl_str_len __srv ) ( str_contains_word vlist __srv )
+            ( seq __wjve tname )
+            & & == 0 ( nurl_str_len __srv ) != 0 ( nurl_str_len __wvid )
+            ( str_contains_word vlist __wvid )
+            {}
+            { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
+                `value of numeric type '` ( llvm_to_nurl ( nurl_llty from_ty ) ) `' cannot initialise / assign a binding of enum type '` tname )
+                `' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Assign a variant by name (': Color c Red'), or declare the binding numeric.` ) ) }
+            : s r ( nurl_cg_reg cg )
             ( nurl_print `  ` ) ( nurl_print r )
             ( nurl_print ` = insertvalue ` ) ( nurl_print ( nurl_llty to_ty ) )
             ( nurl_print ` undef, i64 ` ) ( nurl_print val ) ( nurl_print `, 0\n` )
@@ -15642,12 +15848,25 @@
         // above, so what reaches here would be `store i64 { i1, i64 }…`.
         : b csv_agg_src & == ( nurl_str_get ( nurl_llty from_ty ) 0 ) 123
         | > ( int_width ( nurl_llty to_ty ) ) 0 ( is_float_ty ( nurl_llty to_ty ) )
+        // NAMED types (`%A` — a struct or enum, by value: pointers are
+        // excluded) are NOMINAL: a `%Fruit` value stored into a `%Color`
+        // binding, a `%B` into a `: A`, a narrow int into a `%S`, or a
+        // `%S` into a `: i` all reached the raw `store` — cross-enum and
+        // cross-struct stores were invalid IR only clang saw, and the
+        // enum ones share a layout, one silent reinterpretation away.
+        // Every legal wrap (variant tag, single-handle) returned above.
+        : b csv_named & & ! ( is_ptr_ty from_ty ) ! ( is_ptr_ty to_ty )
+        | == ( nurl_str_get ( nurl_llty from_ty ) 0 ) 37
+        == ( nurl_str_get ( nurl_llty to_ty ) 0 ) 37
         // The cure differs by shape: an aggregate value wants '??'
-        // destructuring (or matching shapes), a scalar wants a cast.
+        // destructuring (or matching shapes), a named type is nominal,
+        // a scalar wants a cast.
         : s __csv_cure ? | csv_agg2 csv_agg_src
         `' — NURL has no implicit conversions between differently-shaped aggregates; make the option/result/closure shapes match exactly, or destructure with '??' and bind the payload`
+        ? csv_named
+        `' — NURL named types are NOMINAL: no value converts into or out of one implicitly (two enums stay distinct even when their tags overlap). Construct/pass the declared type; an enum takes a variant by name, and '# i x' reads an enum's tag intentionally.`
         `' — NURL has no implicit conversions; use a matching value or convert with '# T expr'`
-        ? | | | | != csv_sf csv_tf & ( is_ptr_ty from_ty ) ! ( is_ptr_ty to_ty ) csv_agg csv_agg2 csv_agg_src
+        ? | | | | | != csv_sf csv_tf & ( is_ptr_ty from_ty ) ! ( is_ptr_ty to_ty ) csv_agg csv_agg2 csv_agg_src csv_named
         { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
             `value of type '` from_ty `' cannot initialise / assign a binding of type '` to_ty )
             __csv_cure ) ) }
@@ -19650,6 +19869,11 @@
         ( nurl_print ( nurl_str_int tag ) ) ( nurl_print `\n` )
         ( nurl_sym_def syms vname `i64` )
         ( nurl_sym_def syms ( nurl_str_cat vname `__global` ) `1` )
+        // Reverse map variant → owning enum, for the `?`-join variant
+        // blessing (gen_cond) and any future "which enum is this tag
+        // from" query. First writer wins on a (reported-elsewhere)
+        // duplicate variant name.
+        ( nurl_sym_def syms ( nurl_str_cat vname `__enum_of` ) ename )
         // Per-variant visibility = enum's visibility. Records origin so
         // a bare-variant use site (`# NetErr NetBind`) can be cross-
         // file-checked the same way @-fn calls are.

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -5950,15 +5950,20 @@
 // including inside a compound like `( Box T )`, which the former
 // whole-word compare could not reach.
 @ __subst_word s src s from s to → s {
-    : ~ s out ``
+    // Every temp is TRACKED and no `?`-join carries a bare tracked
+    // ident: the arm protocol hands such a join a strdup'd COPY that no
+    // scope owns — one leaked word per substitution step (LSan, 154
+    // objects per test compile). Reassigning `w` in a branch instead
+    // keeps a single tracked owner throughout.
+    : ~ s out ( nurl_str_cat `` `` )
     : ~ s rest ( nurl_str_cat src `` )
     ~ != 0 ( nurl_str_len rest ) {
-        : s w ( str_first_word rest )
+        : ~ s w ( str_first_word rest )
         = rest ( str_skip_word rest )
-        : s rw ? ( seq w from ) to w
+        ? ( seq w from ) { = w ( nurl_str_cat to `` ) } {}
         = out ? == 0 ( nurl_str_len out )
-        ( nurl_str_cat rw `` )
-        ( nurl_str_cat3 out ` ` rw )
+        ( nurl_str_cat w `` )
+        ( nurl_str_cat3 out ` ` w )
     }
     ^ out
 }

--- a/compiler/tests/diag_assign_int_to_enum.nu
+++ b/compiler/tests/diag_assign_int_to_enum.nu
@@ -1,0 +1,13 @@
+// diag_assign_int_to_enum.nu — assigning a bare number into an enum
+// binding. `= c 7` wrapped the 7 into the enum shape and ASSEMBLED —
+// a number became an enum value whose tag names no variant, and every
+// later match walked past it, silently. The regression shape is the
+// sharp one: the preceding `Red` initialiser used to leave an ident
+// residue that blessed the wrap.
+: | Color { Red Green Blue }
+
+@ main → i {
+    : ~ Color c Red
+    = c 7
+    ^ 0
+}

--- a/compiler/tests/diag_bind_agg_to_scalar.nu
+++ b/compiler/tests/diag_bind_agg_to_scalar.nu
@@ -1,0 +1,10 @@
+// diag_bind_agg_to_scalar.nu — binding an option value to a plain
+// scalar declaration. Every legal unwrap ('??', '.  0/1' field access)
+// is handled upstream, so what reached the store was
+// 'store i64 { i1, i64 } …' — an aggregate into a scalar slot. The
+// diagnostic points at '??' destructuring, not at a cast.
+@ main → i {
+    : ?i o @ ?i { T 7 }
+    : i x o
+    ^ x
+}

--- a/compiler/tests/diag_bind_closure_shape.nu
+++ b/compiler/tests/diag_bind_closure_shape.nu
@@ -1,0 +1,9 @@
+// diag_bind_closure_shape.nu — binding a closure to a declaration with
+// a DIFFERENT signature. Both sides are { ptr, ptr } at the store
+// level, so this ASSEMBLED — and every later invoke through the
+// declared type reinterpreted its arguments (': ( @ i )' promised a
+// zero-param closure; calling it as one leaves x's slot unset).
+@ main → i {
+    : ( @ i ) f \ i x → i { ^ * x x }
+    ^ 0
+}

--- a/compiler/tests/diag_bind_enum_cross.nu
+++ b/compiler/tests/diag_bind_enum_cross.nu
@@ -1,0 +1,12 @@
+// diag_bind_enum_cross.nu — binding a value of one enum to a
+// declaration of another. Both lower to `{ i64 }`, so the store was
+// invalid IR only clang saw — and one silent reinterpretation away
+// (Pear's tag arriving as Green) had the layouts been merged.
+: | Color { Red Green Blue }
+: | Fruit { Apple Pear }
+
+@ main → i {
+    : Fruit x Pear
+    : Color c x
+    ^ 0
+}

--- a/compiler/tests/diag_bind_option_shape.nu
+++ b/compiler/tests/diag_bind_option_shape.nu
@@ -1,0 +1,9 @@
+// diag_bind_option_shape.nu — binding a '?f' value to a ': ?i'
+// declaration. The store between the differently-spelled aggregates
+// ('{ i1, double }' into '{ i1, i64 }') was invalid IR that only clang
+// saw; the cure is matching shapes or '??' destructuring, not a cast.
+@ main → i {
+    : ?f a @ ?f { T 1.5 }
+    : ?i b a
+    ^ 0
+}

--- a/compiler/tests/diag_bind_struct_cross.nu
+++ b/compiler/tests/diag_bind_struct_cross.nu
@@ -1,0 +1,12 @@
+// diag_bind_struct_cross.nu — binding a value of one named struct to a
+// declaration of another. The binding-position dual of the call-site
+// and return-site wrong-struct checks: `store %B … into %A*` was
+// invalid IR only clang reported.
+: A { i x }
+: B { i y }
+
+@ main → i {
+    : B b @ B { 3 }
+    : A a b
+    ^ 0
+}

--- a/compiler/tests/diag_call_enum_cross_enum.nu
+++ b/compiler/tests/diag_call_enum_cross_enum.nu
@@ -1,0 +1,15 @@
+// diag_call_enum_cross_enum.nu — passing a value of one enum where a
+// DIFFERENT enum is declared. Both lower to an i64 tag, so the call
+// used to assemble and the callee read this value's tag as the OTHER
+// enum's variants (here: Pear's tag 1 arriving as Green).
+: | Color { Red Green Blue }
+: | Fruit { Apple Pear }
+
+@ show Color c → i {
+    ^ 0
+}
+
+@ main → i {
+    : Fruit x Pear
+    ^ ( show x )
+}

--- a/compiler/tests/diag_call_enum_to_int_param.nu
+++ b/compiler/tests/diag_call_enum_to_int_param.nu
@@ -1,0 +1,15 @@
+// diag_call_enum_to_int_param.nu — passing an enum value where a
+// numeric parameter is declared. The enum's tag is not a number
+// without an explicit conversion: the emitted call used to pass the
+// whole enum value ('call @f(%Color …)') where the callee reads a
+// scalar register.
+: | Color { Red Green Blue }
+
+@ f i x → i {
+    ^ x
+}
+
+@ main → i {
+    : Color c Green
+    ^ ( f c )
+}

--- a/compiler/tests/diag_call_int_to_enum_param.nu
+++ b/compiler/tests/diag_call_int_to_enum_param.nu
@@ -1,0 +1,13 @@
+// diag_call_int_to_enum_param.nu — passing a bare number where an enum
+// is declared. An enum is a closed set of named variants: '( show 7 )'
+// against three variants used to assemble into an out-of-range "tag"
+// the callee's match could never hit, silently.
+: | Color { Red Green Blue }
+
+@ show Color c → i {
+    ^ 0
+}
+
+@ main → i {
+    ^ ( show 7 )
+}

--- a/compiler/tests/diag_cmp_enum_cross.nu
+++ b/compiler/tests/diag_cmp_enum_cross.nu
@@ -1,0 +1,13 @@
+// diag_cmp_enum_cross.nu — '==' between values of two different enums.
+// The emitted icmp mixed `%Color` and `%Fruit` — invalid IR only clang
+// saw; had it assembled, it would have compared unrelated variant sets
+// by tag.
+: | Color { Red Green Blue }
+: | Fruit { Apple Pear }
+
+@ main → i {
+    : Color c Green
+    : Fruit x Pear
+    ? == c x { ^ 1 } {}
+    ^ 0
+}

--- a/compiler/tests/diag_cmp_enum_int.nu
+++ b/compiler/tests/diag_cmp_enum_int.nu
@@ -1,0 +1,11 @@
+// diag_cmp_enum_int.nu — comparing an enum against a bare number.
+// `== c 7` emitted `icmp eq %Color %r4, 7` — invalid IR only clang
+// reported, three build stages later; the tag is not a number without
+// an explicit conversion.
+: | Color { Red Green Blue }
+
+@ main → i {
+    : Color c Green
+    ? == c 7 { ^ 1 } {}
+    ^ 0
+}

--- a/compiler/tests/diag_cmp_enum_payload.nu
+++ b/compiler/tests/diag_cmp_enum_payload.nu
@@ -1,0 +1,15 @@
+// diag_cmp_enum_payload.nu — '==' on a payload-carrying enum. Tag
+// equality would silently ignore the payloads (`Num 1.5` == `Num 2.5`
+// would be "true"); the compare must be written as a '??' match on
+// what the variants carry.
+: | E {
+    Num f
+    Nothing
+}
+
+@ main → i {
+    : E a @ E { Num 1.5 }
+    : E b @ E { Num 2.5 }
+    ? == a b { ^ 1 } {}
+    ^ 0
+}

--- a/compiler/tests/diag_enum_arith.nu
+++ b/compiler/tests/diag_enum_arith.nu
@@ -1,0 +1,10 @@
+// diag_enum_arith.nu — arithmetic on an enum operand. `+ c 1` emitted
+// `add %Color …` — invalid IR only clang saw; an enum is a closed set
+// of named variants, not a number, and ordering/arithmetic have no
+// meaning on it ('# i c' reads the tag intentionally).
+: | Color { Red Green Blue }
+
+@ main → i {
+    : Color c Green
+    ^ + c 1
+}

--- a/compiler/tests/diag_init_int_to_enum.nu
+++ b/compiler/tests/diag_init_int_to_enum.nu
@@ -1,0 +1,10 @@
+// diag_init_int_to_enum.nu — initialising an enum binding from a bare
+// number. `: Color c 7` wrapped the 7 into the enum shape and
+// ASSEMBLED — the tag names no variant and every later match walked
+// past it, silently.
+: | Color { Red Green Blue }
+
+@ main → i {
+    : Color c 7
+    ^ 0
+}

--- a/compiler/tests/diag_optlit_float_to_int_payload.nu
+++ b/compiler/tests/diag_optlit_float_to_int_payload.nu
@@ -1,0 +1,8 @@
+// diag_optlit_float_to_int_payload.nu — a float payload in an option
+// literal whose declared payload type is integer. '@ ?i { T 1.5 }'
+// used to bitcast 1.5's BITS into the i64 slot — the '??' match arm
+// then read 4609434218613702656, silently.
+@ main → i {
+    : ?i o @ ?i { T 1.5 }
+    ^ 0
+}

--- a/compiler/tests/diag_optlit_int_to_float_payload.nu
+++ b/compiler/tests/diag_optlit_int_to_float_payload.nu
@@ -1,0 +1,9 @@
+// diag_optlit_int_to_float_payload.nu — an integer payload in an
+// option literal whose declared payload type is float: the dual of the
+// float→int case. '@ ?f { T 3 }' emitted a raw insertvalue of an i64
+// into a double slot — invalid IR only clang reported, three build
+// stages later.
+@ main → i {
+    : ?f o @ ?f { T 3 }
+    ^ 0
+}

--- a/compiler/tests/diag_ret_closure_shape.nu
+++ b/compiler/tests/diag_ret_closure_shape.nu
@@ -1,0 +1,14 @@
+// diag_ret_closure_shape.nu — returning a '( @ f f )' closure out of a
+// function declared '→ ( @ i i )'. Unlike the option-shape dual this
+// ASSEMBLES — the aggregates are both { ptr, ptr } at the store level —
+// and every later invoke through the declared type reinterprets its
+// argument and return bit patterns (an i64 read as a double).
+@ make → ( @ i i ) {
+    : ( @ f f ) g \ f a → f { ^ a }
+    ^ g
+}
+
+@ main → i {
+    : ( @ i i ) h ( make )
+    ^ ( h 3 )
+}

--- a/compiler/tests/diag_ret_int_to_enum.nu
+++ b/compiler/tests/diag_ret_int_to_enum.nu
@@ -1,0 +1,14 @@
+// diag_ret_int_to_enum.nu — returning a bare number out of an
+// enum-returning function. `^ 7` from a `→ Color` fn emitted `ret i64`
+// out of a `define %Color` — invalid IR only the LLVM verifier saw;
+// and no number converts into a closed set of named variants anyway.
+: | Color { Red Green Blue }
+
+@ pick → Color {
+    ^ 7
+}
+
+@ main → i {
+    : Color c ( pick )
+    ^ 0
+}

--- a/compiler/tests/diag_ret_option_shape.nu
+++ b/compiler/tests/diag_ret_option_shape.nu
@@ -1,0 +1,13 @@
+// diag_ret_option_shape.nu — returning a '?f' value out of a '→ ?i'
+// function. The two option aggregates are spelled '{ i1, double }' and
+// '{ i1, i64 }': the ret was invalid IR that only the LLVM verifier
+// saw, three build stages later. NURL has no implicit conversions
+// between option/result/slice/closure shapes.
+@ get → ?i {
+    ^ @ ?f { T 1.5 }
+}
+
+@ main → i {
+    : ?i o ( get )
+    ^ 0
+}

--- a/compiler/tests/enum_nominal_ops.nu
+++ b/compiler/tests/enum_nominal_ops.nu
@@ -1,0 +1,41 @@
+// enum_nominal_ops.nu — the LEGAL enum operations, now that enums are
+// enforced as nominal: '=='/'!=' against a bare variant and between two
+// values of the same payload-free enum (tag compare via extractvalue —
+// `== c Green` used to emit an icmp on the struct type, invalid IR that
+// made the diag_cond_enum cure text uncompilable), a bare variant
+// return out of a `→ Color` fn (used to `ret i64` out of a `define
+// %Color`), and the `?`-join variant blessing on init, assign and
+// return positions (`= c ? cond Green Blue` — both arms proven
+// variants of the declared enum).
+: | Color { Red Green Blue }
+
+@ pick_ret i n → Color {
+    ^ ? > n 3 Green Blue
+}
+
+@ flip Color c → Color {
+    ? == c Red { ^ Green } {}
+    ^ Red
+}
+
+@ main → i {
+    : Color c Green
+    ? == c Green { ( nurl_print `eq_variant\n` ) } {}
+    ? != c Red { ( nurl_print `ne_variant\n` ) } {}
+    : Color d Green
+    ? == c d { ( nurl_print `eq_same_enum\n` ) } {}
+    ? == Red ( flip d ) { ( nurl_print `eq_call_lhs_variant\n` ) } {}
+    : ~ Color e Red
+    = e ? == c d Green Blue
+    ? == e Green { ( nurl_print `join_assign\n` ) } {}
+    : Color f ? != c d Red Blue
+    ? == f Blue { ( nurl_print `join_init\n` ) } {}
+    : Color g ( pick_ret 5 )
+    ? == g Green { ( nurl_print `join_ret\n` ) } {}
+    ?? g {
+        Red → { ( nurl_print `match_red\n` ) }
+        Green → { ( nurl_print `match_green\n` ) }
+        Blue → { ( nurl_print `match_blue\n` ) }
+    }
+    ^ 0
+}

--- a/compiler/tests/outputs/diag_assign_int_to_enum.txt
+++ b/compiler/tests/outputs/diag_assign_int_to_enum.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_assign_int_to_enum.nu:11:5: error: value of numeric type 'i' cannot initialise / assign a binding of enum type 'Color' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Assign a variant by name (': Color c Red'), or declare the binding numeric.
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_bind_agg_to_scalar.txt
+++ b/compiler/tests/outputs/diag_bind_agg_to_scalar.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bind_agg_to_scalar.nu:8:5: error: value of type '{ i1, i64 }' cannot initialise / assign a binding of type 'i64' — NURL has no implicit conversions between differently-shaped aggregates; make the option/result/closure shapes match exactly, or destructure with '??' and bind the payload
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_bind_closure_shape.txt
+++ b/compiler/tests/outputs/diag_bind_closure_shape.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bind_closure_shape.nu:7:31: error: value of type '{ i64(i8*, i64)*, i8* }' cannot initialise / assign a binding of type '{ i64 (i8*)*, i8* }' — NURL has no implicit conversions between differently-shaped aggregates; make the option/result/closure shapes match exactly, or destructure with '??' and bind the payload
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_bind_enum_cross.txt
+++ b/compiler/tests/outputs/diag_bind_enum_cross.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bind_enum_cross.nu:10:5: error: value of type '%Fruit' cannot initialise / assign a binding of type '%Color' — NURL named types are NOMINAL: no value converts into or out of one implicitly (two enums stay distinct even when their tags overlap). Construct/pass the declared type; an enum takes a variant by name, and '# i x' reads an enum's tag intentionally.
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_bind_option_shape.txt
+++ b/compiler/tests/outputs/diag_bind_option_shape.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bind_option_shape.nu:7:5: error: value of type '{ i1, double }' cannot initialise / assign a binding of type '{ i1, i64 }' — NURL has no implicit conversions between differently-shaped aggregates; make the option/result/closure shapes match exactly, or destructure with '??' and bind the payload
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_bind_struct_cross.txt
+++ b/compiler/tests/outputs/diag_bind_struct_cross.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bind_struct_cross.nu:10:5: error: value of type '%B' cannot initialise / assign a binding of type '%A' — NURL named types are NOMINAL: no value converts into or out of one implicitly (two enums stay distinct even when their tags overlap). Construct/pass the declared type; an enum takes a variant by name, and '# i x' reads an enum's tag intentionally.
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_call_enum_cross_enum.txt
+++ b/compiler/tests/outputs/diag_call_enum_cross_enum.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_call_enum_cross_enum.nu:14:16: error: argument 1 to 'show': value of type '%Fruit' passed where parameter expects '%Color' — wrong struct type passed by value (a value of one named type where a different one is declared); the call would silently reinterpret its fields
+    ^ ( show x )
+               ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_call_enum_to_int_param.txt
+++ b/compiler/tests/outputs/diag_call_enum_to_int_param.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_call_enum_to_int_param.nu:14:13: error: argument 1 to 'f' has enum type 'Color' but the parameter is declared 'i' — an enum's tag is not a number without an explicit conversion; the emitted call would pass the whole enum value where the callee reads a scalar register. Convert intentionally with '# i x', or declare the parameter to take the enum.
+    ^ ( f c )
+            ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_call_int_to_enum_param.txt
+++ b/compiler/tests/outputs/diag_call_int_to_enum_param.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_call_int_to_enum_param.nu:12:16: error: argument 1 to 'show' has numeric type 'i' but the parameter is declared enum 'Color' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Pass a variant by name (e.g. the enum's first variant), or change the parameter to a numeric type.
+    ^ ( show 7 )
+               ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_cmp_enum_cross.txt
+++ b/compiler/tests/outputs/diag_cmp_enum_cross.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cmp_enum_cross.nu:11:14: error: '==' between two DIFFERENT enums: left is 'Color', right is 'Fruit' — two enums are distinct nominal types even when their tags overlap; equality between them would compare unrelated variant sets. Compare values of one enum, or match each with '??'.
+    ? == c x { ^ 1 } {}
+             ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_cmp_enum_int.txt
+++ b/compiler/tests/outputs/diag_cmp_enum_int.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cmp_enum_int.nu:9:14: error: '==' between enum 'Color' and a value of type 'i' — an enum is a closed set of named variants, and no number converts into one implicitly. Compare against a variant by name ('== c Red'), match with '?? c { … }', or read the tag intentionally with '# i x'.
+    ? == c 7 { ^ 1 } {}
+             ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_cmp_enum_payload.txt
+++ b/compiler/tests/outputs/diag_cmp_enum_payload.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cmp_enum_payload.nu:13:14: error: '==' on enum 'E' whose variants carry payloads — tag equality would ignore the payloads. Match with '?? x { … }' and compare what the variants carry.
+    ? == a b { ^ 1 } {}
+             ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_enum_arith.txt
+++ b/compiler/tests/outputs/diag_enum_arith.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_enum_arith.nu:10:1: error: operator applied to an enum operand: left is 'Color', right is 'i' — an enum is a closed set of named variants, not a number: arithmetic and ordering have no meaning on it. Compare with '==' against a variant, match with '??', or read the tag intentionally with '# i x'.
+}
+^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_init_int_to_enum.txt
+++ b/compiler/tests/outputs/diag_init_int_to_enum.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_init_int_to_enum.nu:8:5: error: value of numeric type 'i' cannot initialise / assign a binding of enum type 'Color' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Assign a variant by name (': Color c Red'), or declare the binding numeric.
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_optlit_float_to_int_payload.txt
+++ b/compiler/tests/outputs/diag_optlit_float_to_int_payload.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_optlit_float_to_int_payload.nu:6:25: error: payload of this option/result literal has float type 'f' but the declared payload type is 'i' — NURL has no implicit float↔integer conversions; storing the bits anyway would make the '??' match arm read the float's raw bit pattern as an integer. Convert explicitly ('# i expr' truncates toward zero), or declare the payload 'f'.
+    : ?i o @ ?i { T 1.5 }
+                        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_optlit_int_to_float_payload.txt
+++ b/compiler/tests/outputs/diag_optlit_int_to_float_payload.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_optlit_int_to_float_payload.nu:7:23: error: payload of this option/result literal has integer type 'i' but the declared payload type is 'f' (a float) — NURL has no implicit integer↔float conversions. Write the payload as a float ('2.0', not '2'), or convert with '# f expr'.
+    : ?f o @ ?f { T 3 }
+                      ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ret_closure_shape.txt
+++ b/compiler/tests/outputs/diag_ret_closure_shape.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_ret_closure_shape.nu:9:1: error: return value type '{ double (i8*, double)*, i8* }' does not match the declared return type '{ i64 (i8*, i64)*, i8* }' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.
+}
+^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ret_int_to_enum.txt
+++ b/compiler/tests/outputs/diag_ret_int_to_enum.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_ret_int_to_enum.nu:9:1: error: return value type 'i' does not match the declared return type: enum 'Color' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Return a variant by name ('^ Red'), or declare a numeric return type.
+}
+^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ret_option_shape.txt
+++ b/compiler/tests/outputs/diag_ret_option_shape.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_ret_option_shape.nu:8:1: error: return value type '{ i1, double }' does not match the declared return type '{ i1, i64 }' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.
+}
+^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/enum_nominal_ops.txt
+++ b/compiler/tests/outputs/enum_nominal_ops.txt
@@ -1,0 +1,12 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+eq_variant
+ne_variant
+eq_same_enum
+eq_call_lhs_variant
+join_assign
+join_init
+join_ret
+match_green

--- a/compiler/tests/test_memory_mgmt.nu
+++ b/compiler/tests/test_memory_mgmt.nu
@@ -3,7 +3,11 @@
     ( nurl_print `Testing memory management...\n` )
 
     // Manually test the reference counting infrastructure by creating a simple closure
-    : ( @ i ) simple_func \ i x → i { ^ * x x }
+    // The closure takes one 'i' parameter, so the declared type must say
+    // so — ': ( @ i )' declared a ZERO-param closure and the compiler now
+    // rejects binding a differently-shaped closure to it (any later
+    // invoke through the declared type would reinterpret its arguments).
+    : ( @ i i ) simple_func \ i x → i { ^ * x x }
 
     ( nurl_print `Created simple closure\n` )
     ^ 0

--- a/examples/enigma.nu
+++ b/examples/enigma.nu
@@ -51,7 +51,7 @@
     }
 }
 
-@ alg::r [i s ( @ i i i i ) m i z → i {
+@ alg::r [i s ( @ i i i ) m i z → i {
     : ~ i o z
     : ~ i i 0
     : i n . s length
@@ -95,7 +95,7 @@
     }
 
     // A closure doing chaotic math via prefix-notation
-    : ( @ i i i i ) cl \ i a i e → i {
+    : ( @ i i i ) cl \ i a i e → i {
         ^ ? > e 4
         + a * e 2
         - a e


### PR DESCRIPTION
Five more places where nurlc compiled silently and should have errored, continuing the silent-scalar-agreement work from #833:

- **Return-site aggregate shapes** — returning a `?f` out of a `→ ?i` (invalid IR only the LLVM verifier saw, three build stages later), or a differently-signed closure out of a declared `(@ …)` return type (which *assembled* — every later invoke reinterpreted its arguments). Compared whitespace-blind since aggregate spacing is not canonical across lowering paths.
- **Enums are nominal** — a number no longer converts into an enum parameter, an enum's tag no longer slides into a numeric parameter, and a cross-enum pass is rejected. Bare variants of the declared enum still pass as their tag, which is the legal way.
- **Option/result literal payloads** — a float payload into a declared integer payload used to bitcast the *bits* into the slot (the `??` arm then read 4609434218613702656, silently); the int→float dual was invalid IR. Both now die with a cure; float↔float width bridging is preserved.
- **Binding stores between differently-shaped aggregates** (option spellings, closure signatures) and aggregate-into-scalar bindings now die — with a `??`-destructuring cure for the aggregate cases, the scalar cast cure preserved for the rest (existing goldens unchanged).
- **Generic inout receivers** — tparam substitution is now tokenwise, so a tparam inside a compound spelling (`( Box T )` → `( Box i )`) substitutes and the inout exact-type check reaches generic callees. `( put [i] bf 3 )` with `bf: (Box f)` used to emit `call @put__i64(%Box__f64* …)` and rewrite the caller's double field. Belt-and-braces: skip if any tparam survives substitution rather than parse a template spelling into a false clash.

Found along the way, fixed without workarounds: `test_memory_mgmt.nu` declared `: ( @ i )` (a zero-param closure) for a one-param closure, and `enigma.nu` declared `( @ i i i i )` for a two-param closure — both silently accepted before, both now compile errors, both fixed to say what they mean.

Ten new `diag_*` tests bake the diagnostics. Full suite: 651 PASS / 0 FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gG9JrqcaEhDDMh2SDUGFh