### PR TITLE
feat(playground): persist build artifacts in R2 across container recycles

### DIFF
--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -6,6 +6,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "test:recovery": "node --test test-recovery.ts",
+    "test:artifacts": "node --test test-artifacts.ts",
     "cf-typegen": "wrangler types"
   },
   "dependencies": {

--- a/cloudflare/src/artifacts.ts
+++ b/cloudflare/src/artifacts.ts
@@ -1,0 +1,61 @@
+// artifacts.ts — pure policy for persisting build artifacts in R2.
+//
+// The container writes every build's outputs under <output_dir>/<build_id>/
+// on its own disk and hands out /download/<build_id>/<name> URLs. That disk
+// is ephemeral: the instance recycles on idle (sleepAfter), on deploy-stamp
+// mismatch, and on wedge recovery — and every recycle silently invalidates
+// every previously issued download URL. The Worker therefore mirrors
+// artifacts to R2 (keyed by their token) as they are produced and serves
+// downloads R2-first, so a URL keeps working across container generations.
+//
+// This module is cloudflare-import-free so it can be unit-tested under Node
+// (npm run test:artifacts), same as ./recovery.
+
+// A token is "<build_id>/<name>". Both segments are generated server-side
+// (build ids are timestamps, names derive from sanitized program names), so
+// a conservative charset loses nothing — and guarantees a token can never
+// traverse out of the bucket namespace or smuggle a sub-path.
+const SEGMENT_RE = /^[A-Za-z0-9_.-]{1,128}$/;
+
+export function isSafeToken(token: string): boolean {
+  const parts = token.split("/");
+  if (parts.length !== 2) return false;
+  // `.`/`..` pass the charset test but are path segments, not names.
+  return parts.every((p) => SEGMENT_RE.test(p) && !/^\.+$/.test(p));
+}
+
+// R2 key for a request path, or null when the path is not a well-formed
+// artifact download (null = just proxy it; the container owns the answer).
+export function downloadKey(pathname: string): string | null {
+  if (!pathname.startsWith("/download/")) return null;
+  const token = pathname.slice("/download/".length);
+  return isSafeToken(token) ? token : null;
+}
+
+// Scan a build response body for the artifacts it references. Works on both
+// shapes that mention them: the REST /build* JSON (ll_artifact /
+// binary_artifact / wasm_artifact objects with download_url + token) and the
+// MCP tool-call result, where the same URLs sit inside JSON-encoded text —
+// a URL substring match covers both without modelling either schema.
+// Capped so a hostile body can't fan out unbounded mirror traffic.
+export const MAX_TOKENS_PER_RESPONSE = 16;
+
+const TOKEN_RE = /\/download\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/g;
+
+export function extractArtifactTokens(text: string): string[] {
+  const seen = new Set<string>();
+  for (const m of text.matchAll(TOKEN_RE)) {
+    const token = m[1];
+    if (!isSafeToken(token)) continue;
+    seen.add(token);
+    if (seen.size >= MAX_TOKENS_PER_RESPONSE) break;
+  }
+  return [...seen];
+}
+
+// Should this request's response be scanned for artifact tokens? Builds
+// arrive as POST /build* (REST) or POST /mcp (tool calls).
+export function shouldScanForArtifacts(method: string, pathname: string): boolean {
+  if (method !== "POST") return false;
+  return pathname.startsWith("/build") || pathname === "/mcp";
+}

--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -1,5 +1,6 @@
 import { Container, getContainer } from "@cloudflare/containers";
 import { decideAction, stampAction } from "./recovery";
+import { downloadKey, extractArtifactTokens, shouldScanForArtifacts } from "./artifacts";
 
 // ── Why this file has a custom fetch override ─────────────────────────────
 //
@@ -167,13 +168,86 @@ export class NurlContainer extends Container<Env> {
   }
 }
 
+// Copy a set of build artifacts from the container's disk into R2. Runs in
+// waitUntil, racing the instance's idle recycle — which it wins by minutes.
+// Failures are logged and swallowed: mirroring is a durability upgrade, never
+// a reason to fail the build that produced the artifacts.
+async function mirrorArtifacts(
+  tokens: string[],
+  container: { fetch(request: Request): Promise<Response> },
+  env: Env,
+  origin: string,
+): Promise<void> {
+  await Promise.all(
+    tokens.map(async (token) => {
+      try {
+        if (await env.NURL_ARTIFACTS.head(token)) return;
+        const res = await container.fetch(new Request(`${origin}/download/${token}`));
+        if (res.status !== 200) return;
+        await env.NURL_ARTIFACTS.put(token, await res.arrayBuffer(), {
+          httpMetadata: {
+            contentType: res.headers.get("Content-Type") ?? "application/octet-stream",
+          },
+        });
+      } catch (e) {
+        console.error(`[nurl-artifacts] mirroring ${token} failed:`, e);
+      }
+    }),
+  );
+}
+
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     // Singleton: one container instance routes all requests. The fetch
     // override above makes that instance self-heal, so a wedge recovers
     // within a request instead of becoming a sticky outage. For horizontal
     // scaling swap to getRandom(env.NURL_CONTAINER, N) (uses max_instances).
     const container = getContainer(env.NURL_CONTAINER);
-    return container.fetch(request);
+    const url = new URL(request.url);
+
+    // Artifact downloads are served R2-first: the container's build dirs die
+    // with the instance (idle sleep, deploy adoption, wedge recovery), but a
+    // mirrored artifact keeps its URL alive across generations — and an R2
+    // hit doesn't wake a sleeping container at all. A miss falls through to
+    // the container (covers the build→mirror completion window) and mirrors
+    // what it finds, so even artifacts whose build-time mirror was missed
+    // become durable on first download.
+    const key = request.method === "GET" ? downloadKey(url.pathname) : null;
+    if (key) {
+      const stored = await env.NURL_ARTIFACTS.get(key);
+      if (stored) {
+        const headers = new Headers();
+        stored.writeHttpMetadata(headers);
+        if (!headers.has("Content-Type")) headers.set("Content-Type", "application/octet-stream");
+        return new Response(stored.body, { status: 200, headers });
+      }
+      const res = await container.fetch(request);
+      if (res.status !== 200) return res;
+      const body = await res.arrayBuffer();
+      ctx.waitUntil(
+        env.NURL_ARTIFACTS.put(key, body, {
+          httpMetadata: {
+            contentType: res.headers.get("Content-Type") ?? "application/octet-stream",
+          },
+        }),
+      );
+      return new Response(body, res);
+    }
+
+    const res = await container.fetch(request);
+
+    // Build responses (REST /build* and MCP tool calls alike) name the
+    // artifacts they produced by /download/ URL. Mirror them to R2 now,
+    // off the response path, before a recycle can take the disk with them.
+    if (shouldScanForArtifacts(request.method, url.pathname) && res.status === 200) {
+      const copy = res.clone();
+      ctx.waitUntil(
+        (async () => {
+          const tokens = extractArtifactTokens(await copy.text());
+          if (tokens.length > 0) await mirrorArtifacts(tokens, container, env, url.origin);
+        })(),
+      );
+    }
+    return res;
   },
 } satisfies ExportedHandler<Env>;

--- a/cloudflare/test-artifacts.ts
+++ b/cloudflare/test-artifacts.ts
@@ -1,0 +1,95 @@
+// test-artifacts.ts — unit tests for the artifact-persistence policy.
+// Run with: npm run test:artifacts  (Node 24 executes .ts natively)
+//
+// Covers the token shapes nurlapi actually emits (both the REST /build* JSON
+// and MCP tool-call text), the traversal/charset rejections the R2 keyspace
+// depends on, and the request-classification the fetch handler is built on.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isSafeToken,
+  downloadKey,
+  extractArtifactTokens,
+  shouldScanForArtifacts,
+  MAX_TOKENS_PER_RESPONSE,
+} from "./src/artifacts.ts";
+
+test("isSafeToken: real nurlapi tokens pass", () => {
+  assert.equal(isSafeToken("1754730000123456/main.wasm"), true);
+  assert.equal(isSafeToken("1754730000123456/prog"), true);
+  assert.equal(isSafeToken("1754730000123456/prog.ll"), true);
+  assert.equal(isSafeToken("1754730000123456/prog.exe"), true);
+});
+
+test("isSafeToken: traversal and malformed shapes are rejected", () => {
+  assert.equal(isSafeToken("../etc/passwd"), false);
+  assert.equal(isSafeToken("id/.."), false);
+  assert.equal(isSafeToken("id/."), false);
+  assert.equal(isSafeToken("id"), false);
+  assert.equal(isSafeToken("id/a/b"), false);
+  assert.equal(isSafeToken("id/"), false);
+  assert.equal(isSafeToken("/name"), false);
+  assert.equal(isSafeToken("id/na me"), false);
+  assert.equal(isSafeToken("id/na%2Fme"), false);
+  assert.equal(isSafeToken("x".repeat(129) + "/name"), false);
+});
+
+test("downloadKey: maps download paths, ignores everything else", () => {
+  assert.equal(downloadKey("/download/123/main.wasm"), "123/main.wasm");
+  assert.equal(downloadKey("/download/123/../secret"), null);
+  assert.equal(downloadKey("/download/123"), null);
+  assert.equal(downloadKey("/build"), null);
+  assert.equal(downloadKey("/"), null);
+});
+
+test("extractArtifactTokens: REST /build JSON shape", () => {
+  const body = JSON.stringify({
+    ok: true,
+    ll_artifact: {
+      name: "prog.ll",
+      bytes: 12345,
+      download_url: "https://play.nurl-lang.org/download/1754730000123456/prog.ll",
+      token: "1754730000123456/prog.ll",
+    },
+    binary_artifact: {
+      name: "prog",
+      bytes: 54321,
+      download_url: "https://play.nurl-lang.org/download/1754730000123456/prog",
+      token: "1754730000123456/prog",
+    },
+  });
+  assert.deepEqual(extractArtifactTokens(body), [
+    "1754730000123456/prog.ll",
+    "1754730000123456/prog",
+  ]);
+});
+
+test("extractArtifactTokens: MCP tool-call text (URLs inside JSON-encoded string)", () => {
+  const body =
+    '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":' +
+    '"BUILD OK\\nwasm: https://play.nurl-lang.org/download/175/m.wasm\\n' +
+    'll: https://play.nurl-lang.org/download/175/m.ll"}]}}';
+  assert.deepEqual(extractArtifactTokens(body), ["175/m.wasm", "175/m.ll"]);
+});
+
+test("extractArtifactTokens: duplicates collapse, no-match bodies yield nothing", () => {
+  const twice = "see /download/1/a and again /download/1/a";
+  assert.deepEqual(extractArtifactTokens(twice), ["1/a"]);
+  assert.deepEqual(extractArtifactTokens('{"error":"compile failed"}'), []);
+});
+
+test("extractArtifactTokens: fan-out is capped", () => {
+  const body = Array.from({ length: 40 }, (_, i) => `/download/1/f${i}`).join(" ");
+  assert.equal(extractArtifactTokens(body).length, MAX_TOKENS_PER_RESPONSE);
+});
+
+test("shouldScanForArtifacts: build + mcp POSTs only", () => {
+  assert.equal(shouldScanForArtifacts("POST", "/build"), true);
+  assert.equal(shouldScanForArtifacts("POST", "/build_wasm"), true);
+  assert.equal(shouldScanForArtifacts("POST", "/build_unikernel"), true);
+  assert.equal(shouldScanForArtifacts("POST", "/mcp"), true);
+  assert.equal(shouldScanForArtifacts("GET", "/mcp"), false);
+  assert.equal(shouldScanForArtifacts("POST", "/authorize"), false);
+  assert.equal(shouldScanForArtifacts("POST", "/"), false);
+});

--- a/cloudflare/wrangler.jsonc
+++ b/cloudflare/wrangler.jsonc
@@ -10,6 +10,15 @@
   "vars": {
     "NURL_API_URL": "https://play.nurl-lang.org"
   },
+  // Build artifacts are mirrored here so /download URLs survive container
+  // recycles (idle sleep, deploy adoption, wedge recovery) — the container's
+  // own disk is ephemeral. See src/artifacts.ts.
+  "r2_buckets": [
+    {
+      "binding": "NURL_ARTIFACTS",
+      "bucket_name": "nurl-playground-artifacts"
+    }
+  ],
   "containers": [
     {
       "class_name": "NurlContainer",


### PR DESCRIPTION
## Problem

The playground container writes every build's outputs under its own disk and hands out `/download/<build_id>/<name>` URLs. That disk is ephemeral: idle sleep (`sleepAfter=10m`), deploy-stamp adoption, and wedge recovery all recycle the instance — and every recycle silently invalidates every previously issued download URL.

## Fix (Worker-only, no image rebuild)

- **R2 bucket** `nurl-playground-artifacts`, bound as `NURL_ARTIFACTS` (bucket already created).
- **Mirror at build time:** successful `POST /build*` and `POST /mcp` responses are scanned in `ctx.waitUntil` (off the response path) for `/download/` tokens; each referenced artifact is fetched from the container and written to R2. Covers both the REST JSON shape and MCP tool-call text with one URL-substring scan.
- **Serve R2-first:** `GET /download/*` checks R2 before the container — a hit doesn't even wake a sleeping instance. A miss falls through to the container (covers the build→mirror window) and mirrors on read, so artifacts that missed the build-time mirror become durable on first download.
- **Safety:** conservative token charset + traversal rejection (`src/artifacts.ts`, cloudflare-import-free), fan-out capped at 16 tokens per response, mirror failures logged and swallowed — persistence is a durability upgrade, never a reason to fail a build.

## Tests

- `npm run test:artifacts` — 8/8 (token shapes nurlapi emits, traversal rejections, REST + MCP extraction, cap, request classification)
- `npm run test:recovery` — still green
- `tsc --noEmit` clean (`worker-configuration.d.ts` regenerated locally; it is gitignored)

After merge this needs an api-deploy run (`workflow_dispatch`) to ship the Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrbtkQQrniMxfVh7h9gRtE