### PR TITLE
fix: generic call type-argument arity is now checked

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -6842,6 +6842,20 @@
         ( expect lex TT_RBRACK )
         : s mangled ( nurl_str_cat fname mangle_sfx )
         = call_targs type_args
+        // Type-argument ARITY. A surplus type arg (`vec_get [i i] …`)
+        // was silently ignored: the mangle used every arg, the
+        // instantiation substituted only the declared tparams, and the
+        // call resolved to a monomorph whose name no other site shares
+        // — compiling clean while saying something the user didn't
+        // mean. A deficit died later with an unrelated substitution
+        // error. Count both sides here, where the list is complete.
+        : s __gtpr ( nurl_sym_get2 g_generic_syms fname `__tparams` )
+        : i __gtpn ( count_words __gtpr )
+        ? & > __gtpn 0 != ( count_words type_args ) __gtpn
+        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+            `generic function '` fname `' declares ` ( nurl_str_int __gtpn ) )
+            ( nurl_str_cat4 ` type parameter(s) (` __gtpr `) but this call supplies ` ( nurl_str_cat ( nurl_str_int ( count_words type_args ) ) ` — every tparam is substituted by position, so the counts must match exactly.` ) ) ) ) }
+        {}
         // Trait-bound check: each `A: Trait` tparam's concrete type must
         // have an impl of Trait (no-op for unbounded generics).
         ( check_generic_bounds lex fname type_args )

--- a/compiler/tests/diag_generic_targ_deficit.nu
+++ b/compiler/tests/diag_generic_targ_deficit.nu
@@ -1,0 +1,12 @@
+// diag_generic_targ_deficit.nu — fewer type arguments than the
+// generic declares. `opt_map [i]` (it takes [A B]) used to die later,
+// deep inside instantiation, with an unrelated substitution error;
+// the arity is checkable right at the call.
+$ `stdlib/core/option.nu`
+
+@ main → i {
+    : ?i o @ ?i { T 7 }
+    : ( @ i i ) sq \ i x → i { ^ * x x }
+    : ?i m ( opt_map [i] o sq )
+    ^ 0
+}

--- a/compiler/tests/diag_generic_targ_surplus.nu
+++ b/compiler/tests/diag_generic_targ_surplus.nu
@@ -1,0 +1,13 @@
+// diag_generic_targ_surplus.nu — more type arguments than the generic
+// declares. `vec_get [i i]` used to compile clean: the mangle used
+// every arg, substitution used only the declared tparam, and the call
+// resolved to a monomorph name no other site shares — silently saying
+// something the user didn't mean.
+$ `stdlib/core/vec.nu`
+
+@ main → i {
+    : ( Vec i ) v ( vec_new [i] )
+    : ?i o ( vec_get [i i] v 0 )
+    ( vec_free [i] v )
+    ^ 0
+}

--- a/compiler/tests/outputs/diag_generic_targ_deficit.txt
+++ b/compiler/tests/outputs/diag_generic_targ_deficit.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_generic_targ_deficit.nu:10:26: error: generic function 'opt_map' declares 2 type parameter(s) (A B) but this call supplies 1 — every tparam is substituted by position, so the counts must match exactly.
+    : ?i m ( opt_map [i] o sq )
+                         ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_generic_targ_surplus.txt
+++ b/compiler/tests/outputs/diag_generic_targ_surplus.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_generic_targ_surplus.nu:10:28: error: generic function 'vec_get' declares 1 type parameter(s) (A) but this call supplies 2 — every tparam is substituted by position, so the counts must match exactly.
+    : ?i o ( vec_get [i i] v 0 )
+                           ^
+error: aborting due to 1 previous error


### PR DESCRIPTION
Continuing the silent-compile sweep (#835, #837).

A surplus type argument (`vec_get [i i] …`) compiled clean: the mangle used every arg, substitution used only the declared tparams, and the call resolved to a monomorph whose name no other site shares — silently saying something the user didn't mean. A deficit (`opt_map [i] …` against `[A B]`) died later, deep inside instantiation, with an unrelated substitution error.

The counts are now compared right after the type-arg list closes, where the declared roster and the supplied list are both in hand. Type args on a non-generic function already had their own diagnostic (verified by probe).

Two diag tests bake the messages. Full suite green; leakgate and sanitized spot-set clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gG9JrqcaEhDDMh2SDUGFh