### PR TITLE
fix: FFI call arity, float-cast guards, and the missing 'u8' spelling

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -289,6 +289,12 @@
     ? ( seq ty `i16` ) `i16`
     ? ( seq ty `i32` ) `i32`
     ? ( seq ty `i64` ) `i64`
+    // `u8` was MISSING from this ladder (only bare `u` mapped to it),
+    // so the documented `u8` spelling fell through to the named-type
+    // default and every `: u8 x` binding carried the phantom type
+    // `%u8` — undeclared in the module, surfacing as far-away invalid
+    // IR (or a wrong-type binding) at first real use.
+    ? ( seq ty `u8` ) `u8`
     ? ( seq ty `u16` ) `u16`
     ? ( seq ty `u32` ) `u32`
     ? ( seq ty `u64` ) `u64`
@@ -302,6 +308,7 @@
 @ nurl_type_is_unsigned s nt → b {
     ? == 0 ( nurl_str_len nt ) { ^ F } {}
     ? ( seq nt `u` ) { ^ T } {}
+    ? ( seq nt `u8` ) { ^ T } {}
     ? ( seq nt `u16` ) { ^ T } {}
     ? ( seq nt `u32` ) { ^ T } {}
     ? ( seq nt `u64` ) { ^ T } {}
@@ -14230,6 +14237,16 @@
         ? ( seq ( nurl_llty dt ) `i1` )
         { ( die lex `'# b' of a float value is not a truth test — an i1 holds only 0 or 1, so the conversion is poison for any other value (LLVM 'fptosi double 3.5 to i1'). Write the comparison you mean: ': b nz != 0.0 x' (non-zero), or compare against the threshold you have in mind.` ) }
         {}
+        // …and only an INTEGER target takes a float at all. A pointer or
+        // aggregate target emitted `fptosi double … to i8*` / `to %S` —
+        // invalid IR only clang reported, with no source location.
+        // (Width off the LLVM spelling: int_width does not read the
+        // `u8`/`u16`/`u32` source spellings.)
+        ? == 0 ( int_width ( nurl_llty dt ) )
+        { ( die lex ( nurl_str_cat3
+            `a float value does not cast to '` ( llvm_to_nurl dt )
+            `' — only integer targets take a float ('# i x' truncates toward zero). Format to text with ( nurl_str_float x ), or construct the aggregate you mean from its fields.` ) ) }
+        {}
         ( nurl_print `  ` ) ( nurl_print res )
         ( nurl_print ? dst_unsigned ` = fptoui ` ` = fptosi ` )
         ( nurl_print ( nurl_llty st ) ) ( nurl_print ` ` )
@@ -14245,6 +14262,22 @@
         // unsigned value with the high bit set must NOT be read as a
         // negative number), else sitofp. The source's signedness is in
         // its type (A1) — `u8`..`u64` stay distinct from the i-types.
+        // Only an INTEGER source converts. `# f a` of a struct emitted
+        // `sitofp %A … to double`, and of a string `sitofp i8* …` —
+        // invalid IR only clang reported, with no source location.
+        // REGISTER values only: a bare integer literal reaches here
+        // with whatever stale type the previous statement left (a
+        // literal sets no last-type), and a constant sitofp is valid
+        // at any spelled width — the invalid-IR shapes are all
+        // register-borne. (Width off the LLVM spelling — see the
+        // target-side note.)
+        ? & == ( nurl_str_get val 0 ) 37 == 0 ( int_width ( nurl_llty st ) )
+        { ? ( is_ptr_ty st )
+            { ( die lex `'# f' of a pointer/string value — an address's bytes have no numeric meaning. Parse a string's TEXT with ( nurl_str_to_float s ), or read the numeric field you mean first.` ) }
+            { ( die lex ( nurl_str_cat3
+                `'# f' of an aggregate value of type '` ( llvm_to_nurl st )
+                `' — an option/result/struct/enum does not convert to a number by cast. Extract or '??'-destructure the numeric payload first ('# i x' reads an ENUM's tag; a float payload needs no cast at all).` ) ) } }
+        {}
         ( nurl_print `  ` ) ( nurl_print res )
         ( nurl_print ? ( ty_is_unsigned st ) ` = uitofp ` ` = sitofp ` )
         ( nurl_print ( nurl_llty st ) )
@@ -19606,6 +19639,21 @@
         ( nurl_print ` @` ) ( nurl_print fname )
         ( nurl_print `(` ) ( nurl_print params_str ) ( nurl_print `)\n\n` )
     }
+    // Non-variadic FFI arity: register the same `__arity` key
+    // scan_fn_sigs writes for @-functions, so the existing call-site
+    // count check covers FFI too. `( sin 1.0 2.0 )` against a
+    // one-param declaration ASSEMBLED (an opaque-pointer call carries
+    // its own signature) and ran — the surplus ignored; a missing
+    // argument read an unset ABI register, silently. Registered LAST:
+    // the declare-suppression above reads `__arity` as "defined by a
+    // NURL @-function", so writing it any earlier suppressed every
+    // FFI declare in the module. A NURL definition of the same name
+    // (the unikernel-shim case) parses via scan_fn_sigs before any
+    // call site, so the count it registered stays authoritative —
+    // matching what the linker will actually bind.
+    ? & == 0 ( nurl_sym_len2 syms fname `__variadic` ) ! defined_in_nurl
+    { ( nurl_sym_def syms ( nurl_str_cat fname `__arity` ) ( nurl_str_int pct ) ) }
+    {}
 }
 
 // Check if current token could be a payload type (without consuming it)

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -14289,7 +14289,16 @@
         ( nurl_set_last_type dt )
         ^ res
     }
-    { ? & src_ptr == ( int_width dt ) 64
+    {  // A pointer converts to a 64-BIT int only (the ptrtoint below).
+        // A narrower integer target — `# b p` as a would-be null test,
+        // `# u8 p` — fell through every branch and emitted a nonsense
+        // cast only clang rejected, location-free.
+        ? & & src_ptr > ( int_width ( nurl_llty dt ) ) 0 != ( int_width ( nurl_llty dt ) ) 64
+        { ( die lex ( nurl_str_cat3
+            `cannot cast a pointer/string to '` ( llvm_to_nurl ( nurl_llty dt ) )
+            `' — an address converts to a 64-bit integer only ('# i p'), then narrow that if you mean the low bits. For a null test write the comparison: '!= 0 # i p'.` ) ) }
+        {}
+        ? & src_ptr == ( int_width dt ) 64
         {  // pointer → 64-bit int (i64 or u64): ptrtoint
             ( nurl_print `  ` ) ( nurl_print res )
             ( nurl_print ` = ptrtoint ` ) ( nurl_print ( nurl_llty st ) )

--- a/compiler/tests/diag_cast_float_to_string.nu
+++ b/compiler/tests/diag_cast_float_to_string.nu
@@ -1,0 +1,7 @@
+// diag_cast_float_to_string.nu — '# s' of a float value: the dual of
+// the string→float cast, `fptosi double … to i8*` — invalid IR only
+// clang reported. Formatting is a runtime call, not a cast.
+@ main → i {
+    : s z # s 1.5
+    ^ 0
+}

--- a/compiler/tests/diag_cast_ptr_to_bool.nu
+++ b/compiler/tests/diag_cast_ptr_to_bool.nu
@@ -1,0 +1,10 @@
+// diag_cast_ptr_to_bool.nu — '# b' of a string/pointer as a would-be
+// null test. A pointer converts to a 64-bit integer only; the narrower
+// target fell through every cast branch and emitted a nonsense cast
+// only clang rejected, location-free. The cure spells out the actual
+// null test.
+@ main → i {
+    : s t `x`
+    : b z # b t
+    ^ 0
+}

--- a/compiler/tests/diag_cast_string_to_float.nu
+++ b/compiler/tests/diag_cast_string_to_float.nu
@@ -1,0 +1,9 @@
+// diag_cast_string_to_float.nu — '# f' of a string value: an
+// address's bytes have no numeric meaning, and the emitted
+// `sitofp i8* … to double` was invalid IR only clang saw. The cure
+// names the runtime parse the user almost certainly meant.
+@ main → i {
+    : s t `3.14`
+    : f z # f t
+    ^ 0
+}

--- a/compiler/tests/diag_cast_struct_to_float.nu
+++ b/compiler/tests/diag_cast_struct_to_float.nu
@@ -1,0 +1,10 @@
+// diag_cast_struct_to_float.nu — '# f' of a struct value. The cast
+// path emitted `sitofp %A … to double` for ANY non-float source —
+// invalid IR only clang reported, with no source location.
+: A { i x }
+
+@ main → i {
+    : A a @ A { 3 }
+    : f z # f a
+    ^ 0
+}

--- a/compiler/tests/diag_ffi_arity_few.nu
+++ b/compiler/tests/diag_ffi_arity_few.nu
@@ -1,0 +1,9 @@
+// diag_ffi_arity_few.nu — an FFI call with fewer arguments than the
+// declaration: the sharper dual. `( pow 2.0 )` assembled AND ran — the
+// callee read an unset ABI register for y, silently.
+& `m` @ pow f x f y → f
+
+@ main → i {
+    : f z ( pow 2.0 )
+    ^ 0
+}

--- a/compiler/tests/diag_ffi_arity_many.nu
+++ b/compiler/tests/diag_ffi_arity_many.nu
@@ -1,0 +1,10 @@
+// diag_ffi_arity_many.nu — an FFI call with more arguments than the
+// declaration. Under opaque pointers the emitted call carries its own
+// signature, so `( sin 1.0 2.0 )` against a one-param declaration
+// ASSEMBLED and ran — the surplus silently ignored.
+& `m` @ sin f x → f
+
+@ main → i {
+    : f z ( sin 1.0 2.0 )
+    ^ 0
+}

--- a/compiler/tests/outputs/diag_cast_float_to_string.txt
+++ b/compiler/tests/outputs/diag_cast_float_to_string.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cast_float_to_string.nu:6:5: error: a float value does not cast to 's' — only integer targets take a float ('# i x' truncates toward zero). Format to text with ( nurl_str_float x ), or construct the aggregate you mean from its fields.
+    ^ 0
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_cast_ptr_to_bool.txt
+++ b/compiler/tests/outputs/diag_cast_ptr_to_bool.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cast_ptr_to_bool.nu:9:5: error: cannot cast a pointer/string to 'b' — an address converts to a 64-bit integer only ('# i p'), then narrow that if you mean the low bits. For a null test write the comparison: '!= 0 # i p'.
+    ^ 0
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_cast_string_to_float.txt
+++ b/compiler/tests/outputs/diag_cast_string_to_float.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cast_string_to_float.nu:8:5: error: '# f' of a pointer/string value — an address's bytes have no numeric meaning. Parse a string's TEXT with ( nurl_str_to_float s ), or read the numeric field you mean first.
+    ^ 0
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_cast_struct_to_float.txt
+++ b/compiler/tests/outputs/diag_cast_struct_to_float.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cast_struct_to_float.nu:9:5: error: '# f' of an aggregate value of type 'A' — an option/result/struct/enum does not convert to a number by cast. Extract or '??'-destructure the numeric payload first ('# i x' reads an ENUM's tag; a float payload needs no cast at all).
+    ^ 0
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ffi_arity_few.txt
+++ b/compiler/tests/outputs/diag_ffi_arity_few.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_ffi_arity_few.nu:7:21: error: call to 'pow' has the wrong number of arguments: expected 2, got 1 — every NURL operator has fixed arity, so a missing or extra argument shifts every token after it; check this call.
+    : f z ( pow 2.0 )
+                    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ffi_arity_many.txt
+++ b/compiler/tests/outputs/diag_ffi_arity_many.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_ffi_arity_many.nu:8:25: error: call to 'sin' has the wrong number of arguments: expected 1, got 2 — every NURL operator has fixed arity, so a missing or extra argument shifts every token after it; check this call.
+    : f z ( sin 1.0 2.0 )
+                        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/u8_spelling_ops.txt
+++ b/compiler/tests/outputs/u8_spelling_ops.txt
@@ -1,0 +1,6 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+200
+unsigned_ok

--- a/compiler/tests/u8_spelling_ops.nu
+++ b/compiler/tests/u8_spelling_ops.nu
@@ -1,0 +1,16 @@
+// u8_spelling_ops.nu — the `u8` TYPE SPELLING. llvm_type's ladder had
+// `u` → u8 but not `u8` itself, so the documented `u8` spelling fell
+// through to the named-type default: every `: u8 x` binding carried
+// the phantom type `%u8` (undeclared in the module), surfacing as
+// far-away invalid IR at first real use — and nothing in the tree
+// used the spelling, so nothing caught it. Locks: binding + cast at
+// the u8 spelling, ZERO-extension on widening (200 stays 200, not
+// -56), and uitofp on the float conversion.
+@ main → i {
+    : u8 hi # u8 200
+    : i wide # i hi
+    ( nurl_print ( nurl_str_int wide ) ) ( nurl_print `\n` )
+    : f asf # f hi
+    ? > asf 199.0 { ( nurl_print `unsigned_ok\n` ) } {}
+    ^ 0
+}


### PR DESCRIPTION
Continuing the silent-compile sweep (#835, #837, #839) — the FFI/cast probe round.

- **FFI calls never had an arity check**: `( sin 1.0 2.0 )` against a one-param declaration *assembled and ran* with the surplus ignored, and `( pow 2.0 )` read an unset ABI register — silently. Non-variadic FFI decls now register the same `__arity` key as @-functions, so the existing call-site count check covers them. Registered *after* the declare-suppression logic, which reads `__arity` as "defined by a NURL @-function" — writing it earlier suppressed every FFI declare in the module (caught by the bootstrap fixed point during development).
- **`# f x` emitted `sitofp <anything> to double`** — struct, enum or string source, all invalid IR only clang reported; the dual (`# s 1.5`) was equally unchecked. Both directions now die with cures (`nurl_str_to_float` / `nurl_str_float` for text, extract-or-`??` for aggregates). The source-side guard fires on register values only — a bare literal reaches the cast with stale last-type, and a constant sitofp is valid at any width.
- **The documented `u8` type spelling never worked**: missing from `llvm_type`'s ladder (only bare `u` mapped to u8), so every `: u8 x` binding carried the phantom named type `%u8`, surfacing as far-away invalid IR at first use; `nurl_type_is_unsigned` had the same gap. Nothing in the tree used the spelling, so nothing caught it — the cast-guard work exposed it. `u8_spelling_ops` locks binding, zero-extension and uitofp behaviour.

Five diag tests bake the messages. Full suite green; leakgate and sanitized spot-set clean; bootstrap fixed point holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gG9JrqcaEhDDMh2SDUGFh