### PR TITLE
docs: a PR template, aimed at the contributors this repo actually has

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,76 @@
+## Why
+
+<!-- The problem, concretely. What breaks, what is missing, what is
+     silently wrong. Name the observed behaviour — the wrong output, the
+     measured number, the program that fails — not the intention.
+
+     "Improve error messages" is not a Why. "__kw_default_or_die told the
+     reader NURL has no default parameter values, which it has had since
+     kwargs" is: a reviewer can check it. -->
+
+## What
+
+<!-- The change. Enough that a reviewer can read the diff in the order
+     you wrote it and can tell which parts are load-bearing. Call out
+     anything that alters observable behaviour, and say why the goldens
+     moved if they moved. -->
+
+## Proof
+
+<!-- What you ran, and what it actually said. Paste the real summary
+     line rather than a paraphrase of it:
+
+       ./build.sh                     # bootstrap fixed point + corpus
+       ./compiler/tests/run_tests.sh  # PASS n · FAIL n · MISSING n · ORPHAN n
+
+     If something failed for reasons that predate your change — a missing
+     optional dependency, no network, a flaky test — list those failures
+     BY NAME and say so. A reviewer cannot tell an environment failure
+     from a regression at a glance, and you can.
+
+     Do not report a gate you did not run. "Not run locally, left to CI"
+     is a perfectly good answer.
+
+     Compiler changes: docs/dev/COMPILER_INTERNALS.md §5 gives the gates
+     and the order to run them in. -->
+
+## Known remaining
+
+<!-- What this change deliberately does NOT fix, and why. Delete the
+     heading only if the answer is genuinely nothing.
+
+     Scoping work down is fine and often right. Scoping it down silently
+     is what costs a reviewer their afternoon. -->
+
+---
+
+<!-- ─────────────────────────────────────────────────────────────────
+     For automated contributors — read this before filling in the
+     sections above. It renders as nothing, so leave it in or delete
+     it as you prefer.
+
+  * Do not claim a gate passed unless you ran it and read the output.
+    A PR body asserting a green suite over a red one is the single
+    failure mode that costs a maintainer the most time.
+
+  * Report what you actually did, including the parts that did not
+    work. "The third case is still wrong, here is why" is worth more
+    than a clean-looking PR that quietly dropped it.
+
+  * Stay inside the scope you were given. Unrelated fixes you noticed
+    along the way belong in their own PR — CONTRIBUTING.md asks for
+    small, focused PRs and means it.
+
+  * Language-surface changes — new syntax, grammar, type-system rules —
+    need an issue FIRST. The grammar is deliberately small and every
+    addition has to earn its keep. Do not land one sideways inside a
+    bug fix.
+
+  * A rejected program is a test, and the prefix decides what is kept:
+    `diag_*.nu` baselines the diagnostic TEXT, `should_fail_*.nu`
+    records only that compilation failed. If the wording is the point —
+    and for an error message it usually is — use `diag_*`.
+
+  * Disclose that the change was machine-authored. Every PR in this
+    repo already does.
+     ───────────────────────────────────────────────────────────────── -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,8 +91,12 @@ enough — we'll iterate on the design in the issue thread.
   golden under `compiler/tests/outputs/` (record it with
   `compiler/tests/run_tests.sh --update <name>`; run a single test with
   `run_tests.sh <name>`). Programs that must be *rejected* go in as
-  `should_fail_*.nu` / `borrow_*.nu`, with their expected diagnostic as
-  the golden.
+  `diag_*.nu`, `should_fail_*.nu` or `borrow_*.nu` — and the prefix
+  decides what the golden keeps. `diag_*` and `borrow_*` baseline the
+  **diagnostic text**; `should_fail_*` records only the single word
+  `COMPILE FAIL`, so a message behind one can be gutted without a golden
+  moving. If the wording is the point — and for an error message it
+  usually is — use `diag_*`.
 - **Update docs** if you change observable behaviour. The README is a
   thin overview that links to topic docs under [`docs/`](docs/); update
   the relevant one (`docs/spec.md`, `docs/LIMITATIONS.md`,


### PR DESCRIPTION
## Why

Every PR here since #835 was machine-authored, and the good ones converged on the same shape by hand — Why / What / Proof, where the Why names an observed failure and the Proof names real commands with real counts (#843, #844 are the clearest). Nothing in the repo captured that, so each agent re-derives it and the weaker bodies go straight to restating the title.

There is also a live trap that CI cannot close. `ci.yml` hard-gates about fifteen checks, so a "did you run X" checklist adds nothing a reviewer can trust — it only invites ticking a box that was never run. What CI cannot see is the failure mode that actually costs review time: **a PR body claiming a green suite over a red one.** The session that wrote this hit exactly that shape — 14 corpus failures from a missing `libzstd` and no loopback network — and telling those apart from a regression took a second full run plus a golden audit. The author knew instantly; the reviewer would not have.

And `CONTRIBUTING.md` was pointing contributors at the wrong test prefix, which is a factual error with a measurable cost (below).

## What

**`.github/PULL_REQUEST_TEMPLATE.md`** — Why / What / Proof / Known remaining, every instruction in an HTML comment so a filled-in body renders clean. Unfilled, it shows the four headings and nothing else.

- **Proof** asks for the pasted summary line rather than a paraphrase, and asks explicitly that failures predating the change be listed **by name**. It also says in as many words that "not run locally, left to CI" is a good answer — the goal is to make honesty cheaper than a plausible claim.
- **Known remaining** generalises the "Known remaining, documented" paragraph #842 wrote by hand. Scoping work down is fine and often right; scoping it down silently is not.
- A closing comment block addressed to automated contributors: do not claim a gate you did not run, stay in scope, language-surface changes need an issue first, pick the test prefix that keeps the wording, disclose machine authorship.

**`CONTRIBUTING.md`** — one factual fix. It said rejected programs go in as `should_fail_*.nu` / `borrow_*.nu` "with their expected diagnostic as the golden". True of `borrow_*` and `diag_*`; **false of `should_fail_*`**, whose golden is the single word `COMPILE FAIL` — the message is discarded. Following it left 60-odd negative tests holding no diagnostic text at all, which is how a carefully written message can be gutted to `expected ')'` without a golden moving. The bullet now states what each prefix keeps.

## Proof

Two documentation files; nothing to build and nothing CI's path classifier gates on, so no build or corpus run was performed for this PR.

What was verified:

- Rendering — stripping HTML comments from the template leaves exactly `## Why`, `## What`, `## Proof`, `## Known remaining` and the `---` rule.
- The `CONTRIBUTING.md` claim, before rewriting it — `cat compiler/tests/outputs/should_fail_call_arity_few.txt` returns one line, `COMPILE FAIL`, against a test whose diagnostic is three sentences long.

This body is written in the template's own shape, since GitHub only auto-fills bodies for PRs opened after the template lands.

## Known remaining

- **No `AGENTS.md` / `CLAUDE.md`.** How the project wants to steer agents in general is a larger decision that overlaps `CONTRIBUTING.md`, and it should not arrive as a side effect of adding a PR template.
- **No issue templates.** `CONTRIBUTING.md` § "Filing a good bug report" already covers that ground in prose.
- **No CI check that the template was filled in.** It would fire on human PRs too, and the thing it would be guarding against — a plausible lie — is not mechanically detectable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_