### PR TITLE
feat(ax): the gate that finds unread diagnostics — and the false one it found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`tools/check_diag_coverage.sh` — a diagnostic is not finished when it
+  is written, it is finished when something has read it.** The `ax` work
+  scored diagnostics by scanning `compiler/nurlc.nu`: does the message
+  name a cure, state the rule, show a spelling. That instrument is blind
+  to the one thing that decides whether a message is any good — whether
+  it is ever REACHED. The new gate compiles the corpus, matches every
+  emitted diagnostic back to its source site, and reports the sites
+  nothing made speak. **132 of 220 sites are exercised; 81 are not.**
+
+  An unfired message is unverified in every way that matters. Its wording
+  has never been read next to the program that caused it, which is how
+  the one FALSE message found in `ecc058c` survived a source scan that
+  scored it as excellent. Its caret has never been checked. It may be
+  dead outright, preempted by a looser check upstream — so the good
+  message exists and the user still gets the generic one.
+
+  The count ratchets against `tools/diag_coverage_baseline.txt`: existing
+  gaps do not fail the build, a new die site with no test that fires it
+  does. Adding a diagnostic and adding the program that triggers it are
+  one change, not two.
+
 - **macOS is a host platform CI actually checks (Apple Silicon, tier 1).**
   `docs/PLATFORMS.md` used to say macOS was "expected to build from
   source with Homebrew LLVM; unverified". Expected-to-build was a claim
@@ -30,6 +51,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   claimed on a gate that never reports.
 
 ### Fixed
+
+- **"NURL has no defaults and no overloading" — said by the function
+  named `__kw_default_or_die`.** NURL has had default parameter values
+  since kwargs landed (`@ box s label i width = 10 → v`), and this error
+  fires *precisely* when the skipped parameter has none. The message
+  asserted the opposite as a language rule, so a model that read it
+  learned to never use a feature the language has. It now names the
+  parameter, states the real rule (optional iff the declaration gives it
+  a default), and offers all three cures including adding one.
+
+  The first thing the coverage gate found, and the second message of this
+  shape after the bool-widening one in `ecc058c` — both shipped because
+  nothing ever printed them.
+
+- **Three diagnostics printed a correct message against the wrong line.**
+  The bool-mix checks in `gen_logical_or` / `gen_logical_and` and the
+  missing-argument check in `__kw_default_or_die` all fire only after
+  `gen_expr` has consumed the operands, by which point the lexer sits on
+  the NEXT statement — `die lex` blamed it. Anchored with `die_stmt`,
+  which exists for exactly this and already had four callers. A model
+  reading a precise message about the wrong line is worse off than with a
+  vague message about the right one.
 
 - **Five defects the macOS leg found, three of which were never about
   macOS.** Bringing the platform under CI turned up:

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -3625,7 +3625,7 @@
     : s rt ( nurl_get_last_type )
     // Check type compatibility
     ? ! ( seq rt `i1` )
-    ( die lex `operator '&' has a bool on the left, so the right operand must be bool too — NURL does not mix bool and integer operands. Every operator is BINARY: for n conditions write n-1 of them, '& & a b c'.` )
+    ( die_stmt lex `operator '&' has a bool on the left, so the right operand must be bool too — NURL does not mix bool and integer operands. Every operator is BINARY: for n conditions write n-1 of them, '& & a b c'.` )
     {}
     : s right_lbl ( nurl_sym_get syms `__cur_lbl__` )
     ( nurl_print `  br label %` ) ( nurl_print lend ) ( emit_dbg_eol )
@@ -3656,7 +3656,7 @@
     : s rt ( nurl_get_last_type )
     // Check type compatibility
     ? ! ( seq rt `i1` )
-    ( die lex `operator '|' has a bool on the left, so the right operand must be bool too — NURL does not mix bool and integer operands. Every operator is BINARY: for n conditions write n-1 of them, '| | a b c'.` )
+    ( die_stmt lex `operator '|' has a bool on the left, so the right operand must be bool too — NURL does not mix bool and integer operands. Every operator is BINARY: for n conditions write n-1 of them, '| | a b c'.` )
     {}
     : s right_lbl ( nurl_sym_get syms `__cur_lbl__` )
     ( nurl_print `  br label %` ) ( nurl_print lend ) ( emit_dbg_eol )
@@ -6510,10 +6510,10 @@
 @ __kw_default_or_die i lex i syms i cg s fname i k → s {
     : s dsrc ( nurl_sym_get syms ( __kw_key fname `pd` k ) )
     ? == 0 ( nurl_str_len dsrc )
-    { ( die lex ( nurl_str_cat3
+    { ( die_stmt lex ( nurl_str_cat3
         `call to '` fname
         ( nurl_str_cat3 `' is missing required argument '`
-        ( nurl_sym_get syms ( __kw_key fname `pn` k ) ) `'. Every parameter must be supplied — NURL has no defaults and no overloading. Pass it positionally in declaration order, or name it: 'name: value'.` ) ) ) }
+        ( nurl_sym_get syms ( __kw_key fname `pn` k ) ) `', and that parameter declares no default. A parameter is optional only when its declaration gives it one ('@ f i width = 10 → v'); every other parameter must be supplied, and there is no overloading to fall back on. Pass it positionally in declaration order, name it ('name : value'), or give it a default at the declaration.` ) ) ) }
     {}
     : ~ s __kdp ( __kw_emit_default syms cg dsrc )
     // The default's value is spliced verbatim into the call's argument

--- a/compiler/tests/README.md
+++ b/compiler/tests/README.md
@@ -19,11 +19,39 @@ is missing, and no golden is orphaned. Wall-clock target: under 3 min
 | Prefix              | Expected outcome                                   |
 |---------------------|----------------------------------------------------|
 | *(none)*            | compiles, links, runs — golden records exit + stdout |
-| `should_fail_*`     | compile **fails** (golden: `COMPILE FAIL`)         |
+| `should_fail_*`     | compile **fails** (golden: `COMPILE FAIL` — the text is *not* kept) |
+| `diag_*`            | compile fails and the **diagnostic text is baselined** — use this whenever the wording is the point |
 | `borrow_*`          | borrow-checker rejects it; the diagnostic is baselined. `borrow_strict_*` only fire under `--strict-borrowck` |
 | `should_warn_*`     | compiles, but the warning text is baselined        |
 | `*_mod` `*_helper` `*_lib` | not a test — a module `$`-imported by another test (skipped) |
 | `http_*` `net_*`    | network-dependent; most are skipped unless `NURL_HTTP_TESTS=1` / `NURL_NET_TESTS=1` |
+
+### `should_fail_*` vs `diag_*`
+
+`should_fail_*` records one word: `COMPILE FAIL`. It proves the compiler
+*rejects* the program and nothing about what it says while doing it, so a
+message can be gutted down to "expected ')'" without a single golden
+moving. `diag_*` keeps the whole diagnostic.
+
+The `ax` goal — a model handed a compile error learns the rule and the
+fix from the message alone — lives entirely in text `should_fail_*`
+throws away. **New negative tests should be `diag_*` unless the wording
+genuinely does not matter.**
+
+## Diagnostic coverage
+
+`./tools/check_diag_coverage.sh` compiles the corpus, matches every
+emitted diagnostic back to its site in `compiler/nurlc.nu`, and lists
+the sites nothing made speak. An unfired message is unverified in every
+way that matters: its wording has never been read next to the program
+that caused it, its caret placement has never been checked, and it may
+be dead outright — preempted by a looser check upstream, so the good
+message exists and the user still gets the generic one.
+
+The check ratchets against `tools/diag_coverage_baseline.txt`: existing
+gaps do not fail, a **new** die site with no test that fires it does.
+Adding a diagnostic and adding the program that triggers it are one
+change, not two.
 
 ## Golden files (`outputs/`)
 

--- a/compiler/tests/diag_assign_immutable_param.nu
+++ b/compiler/tests/diag_assign_immutable_param.nu
@@ -1,0 +1,14 @@
+// diag_assign_immutable_param.nu — writing to a parameter. Parameters
+// are immutable bindings; the cure is a ': ~' local copy or an 'inout'
+// parameter, and the message must name both because they differ in
+// whether the caller sees the write.
+//
+// This message was rewritten in ecc058c after a probe found it named
+// neither cure — and then shipped with nothing exercising it. That is
+// the gap check_diag_coverage.sh exists to make visible.
+@ f i p → i {
+    = p + p 1
+    ^ p
+}
+
+@ main → i { ^ ( f 1 ) }

--- a/compiler/tests/diag_assign_missing_target.nu
+++ b/compiler/tests/diag_assign_missing_target.nu
@@ -1,0 +1,9 @@
+// diag_assign_missing_target.nu — '=' with the value where the target
+// belongs. Assignment is prefix ('= name value'), so a model carrying
+// infix habits writes '= 5 n' or 'n = 5'; the message has to name the
+// form rather than only reject the token.
+@ main → i {
+    : ~ i n 0
+    = 5 n
+    ^ n
+}

--- a/compiler/tests/diag_binop_bool_and_int.nu
+++ b/compiler/tests/diag_binop_bool_and_int.nu
@@ -1,0 +1,13 @@
+// diag_binop_bool_and_int.nu — '&' sibling of diag_binop_bool_or_int.
+// Both checks fire only after gen_expr has consumed the right operand,
+// by which point the lexer sits on the NEXT statement — so they are
+// anchored with die_stmt. Before that they printed a correct message
+// against the wrong line, which for a model reading the output is
+// worse than a vague message against the right one.
+@ main → i {
+    : b a T
+    : i n 3
+    : b r & a n
+    ? r { ^ 1 } {}
+    ^ 0
+}

--- a/compiler/tests/diag_binop_bool_or_int.nu
+++ b/compiler/tests/diag_binop_bool_or_int.nu
@@ -1,0 +1,11 @@
+// diag_binop_bool_or_int.nu — '|' with a bool on the left and an
+// integer on the right. '|' is bitwise-or on integers and or on bools,
+// never a mix, and the n-ary shape ('| | a b c') is the thing a model
+// reaches for when it wants three conditions.
+@ main → i {
+    : b a T
+    : i n 3
+    : b r | a n
+    ? r { ^ 1 } {}
+    ^ 0
+}

--- a/compiler/tests/diag_call_missing_required_arg.nu
+++ b/compiler/tests/diag_call_missing_required_arg.nu
@@ -1,0 +1,23 @@
+// diag_call_missing_required_arg.nu — a named-argument call that skips a
+// parameter which declares no default.
+//
+// NURL *does* have default parameter values ('i width = 10', see
+// kwargs.nu) — this error fires only for a parameter that has none, from
+// a function literally named __kw_default_or_die. The message used to
+// assert the opposite, "NURL has no defaults and no overloading", so a
+// model that read it learned to never use a feature the language has.
+// Nothing exercised the message, which is how it shipped saying that;
+// this test is why it cannot again.
+//
+// The positional route ('( box )') does not reach here — it is caught
+// first by the plain arity check, which reports the DECLARED count and
+// not the minimum, so a defaulted callee reads as "expected 2, got 0".
+@ box s label i width = 10 → v {
+    ( nurl_print label )
+    ( nurl_print ( nurl_str_int width ) )
+}
+
+@ main → i {
+    ( box width : 5 )
+    ^ 0
+}

--- a/compiler/tests/diag_call_named_after_positional.nu
+++ b/compiler/tests/diag_call_named_after_positional.nu
@@ -1,0 +1,12 @@
+// diag_call_named_after_positional.nu — a named argument followed by a
+// positional one. Once `name: value` appears, argument position stops
+// meaning anything, so the compiler refuses rather than guess which
+// parameter the trailing value was for. Baselines the diagnostic TEXT:
+// the rule ("name them all from that point, or none of them") is the
+// half a model needs, and should_fail_* would not hold it.
+@ add i x i y → i { ^ + x y }
+
+@ main → i {
+    : i r ( add x : 1 2 )
+    ^ r
+}

--- a/compiler/tests/diag_call_unknown_named_arg.nu
+++ b/compiler/tests/diag_call_unknown_named_arg.nu
@@ -1,0 +1,9 @@
+// diag_call_unknown_named_arg.nu — a named argument whose name is not a
+// declared parameter. NURL matches named arguments by exact spelling,
+// so a typo is an error and not a silently-dropped keyword.
+@ add i x i y → i { ^ + x y }
+
+@ main → i {
+    : i r ( add x : 1 z : 2 )
+    ^ r
+}

--- a/compiler/tests/diag_lex_malformed_hex.nu
+++ b/compiler/tests/diag_lex_malformed_hex.nu
@@ -1,0 +1,7 @@
+// diag_lex_malformed_hex.nu — '0x' with no digits after it. A lexer
+// diagnostic, so it is fail-fast (outside the per-declaration recovery
+// frame) and prints exactly one error.
+@ main → i {
+    : i n 0x
+    ^ n
+}

--- a/compiler/tests/outputs/diag_assign_immutable_param.txt
+++ b/compiler/tests/outputs/diag_assign_immutable_param.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_assign_immutable_param.nu:10:9: error: cannot assign to immutable parameter 'p'. Bindings are immutable unless declared ': ~', and parameters are always immutable: add the tilde at the declaration, copy the parameter into a ': ~' local, or take it as 'inout' if the caller should see the write.
+    = p + p 1
+        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_assign_missing_target.txt
+++ b/compiler/tests/outputs/diag_assign_missing_target.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_assign_missing_target.nu:7:7: error: expected the target of '=', found '5'. Assignment is '= name value' or '= . obj field value' — the target comes first, then the value, with no '=' between them. E.g. '= i + i 1', '= . p x 3'. Only a ': ~' binding can be assigned to.
+    = 5 n
+      ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_binop_bool_and_int.txt
+++ b/compiler/tests/outputs/diag_binop_bool_and_int.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_binop_bool_and_int.nu:10:5: error: operator '&' has a bool on the left, so the right operand must be bool too — NURL does not mix bool and integer operands. Every operator is BINARY: for n conditions write n-1 of them, '& & a b c'.
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_binop_bool_or_int.txt
+++ b/compiler/tests/outputs/diag_binop_bool_or_int.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_binop_bool_or_int.nu:8:5: error: operator '|' has a bool on the left, so the right operand must be bool too — NURL does not mix bool and integer operands. Every operator is BINARY: for n conditions write n-1 of them, '| | a b c'.
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_call_missing_required_arg.txt
+++ b/compiler/tests/outputs/diag_call_missing_required_arg.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_call_missing_required_arg.nu:21:5: error: call to 'box' is missing required argument 'label', and that parameter declares no default. A parameter is optional only when its declaration gives it one ('@ f i width = 10 → v'); every other parameter must be supplied, and there is no overloading to fall back on. Pass it positionally in declaration order, name it ('name : value'), or give it a default at the declaration.
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_call_named_after_positional.txt
+++ b/compiler/tests/outputs/diag_call_named_after_positional.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_call_named_after_positional.nu:10:23: error: a positional argument cannot follow a named one — once you write 'name: value', every later argument must be named too. Either name them all from that point, or pass them all positionally in declaration order.
+    : i r ( add x : 1 2 )
+                      ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_call_unknown_named_arg.txt
+++ b/compiler/tests/outputs/diag_call_unknown_named_arg.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_call_unknown_named_arg.nu:7:27: error: call to 'add' has no parameter named 'z'. Named arguments must match the declared parameter names exactly — check the declaration, or pass them positionally in declaration order.
+    : i r ( add x : 1 z : 2 )
+                          ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_lex_malformed_hex.txt
+++ b/compiler/tests/outputs/diag_lex_malformed_hex.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_lex_malformed_hex.nu:5:9: error: malformed hex literal — '0x' must be followed by at least one hex digit (0-9, a-f, A-F). E.g. '0xFF', '0x1a2b'.
+    : i n 0x
+        ^

--- a/tools/check_diag_coverage.sh
+++ b/tools/check_diag_coverage.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Dual-licensed under MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE) at your option.
+# ============================================================
+#  check_diag_coverage.sh — every diagnostic nurlc can print must be
+#  something a test has actually made it print.
+#
+#  The `ax` goal is that a model handed a compile error learns the rule
+#  and the fix from the message alone. Source scans got that goal most
+#  of the way: they can count whether a message names a cure, states a
+#  rule, shows a spelling. What they cannot see is whether the message
+#  is ever REACHED — and an unreached message is unverified in every way
+#  that matters:
+#
+#    * its wording has never been read next to the program that caused
+#      it, which is how the one FALSE message (bool→int return, fixed in
+#      ecc058c) survived a source scan that scored it as excellent;
+#    * its line and caret placement have never been checked;
+#    * it may be dead outright, preempted by a looser check upstream, in
+#      which case the good message is written but the user gets the
+#      generic one;
+#    * nothing stops a later edit from gutting it, because no golden
+#      holds its text.
+#
+#  So this gate compiles the corpus, captures every diagnostic, and
+#  matches them back to their source sites. Sites nobody made speak are
+#  listed. The count is RATCHETED against a committed baseline: existing
+#  gaps do not fail the build, but a new die site added without a test
+#  that fires it does. A diagnostic is not finished when it is written —
+#  it is finished when something has read it.
+#
+#  Usage:
+#    ./tools/check_diag_coverage.sh              # ratchet check
+#    ./tools/check_diag_coverage.sh --report     # list the gaps
+#    ./tools/check_diag_coverage.sh --update     # re-baseline
+#
+#  Exit codes:
+#    0 — coverage at or better than the baseline
+#    1 — new never-fired diagnostics appeared (they are listed)
+#    2 — environment problem (nurlc missing, no python3)
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+NURLC="$ROOT_DIR/build/nurlc"
+SRC="$ROOT_DIR/compiler/nurlc.nu"
+ERRDIR="$ROOT_DIR/build/diagcov"
+BASELINE="$SCRIPT_DIR/diag_coverage_baseline.txt"
+ANALYZE="$SCRIPT_DIR/diag_coverage.py"
+
+MODE="check"
+case "${1:-}" in
+    --report) MODE="report" ;;
+    --update) MODE="update" ;;
+    "")       ;;
+    *) echo "usage: $0 [--report|--update]" >&2; exit 2 ;;
+esac
+
+[[ -x "$NURLC" ]] || { echo "error: $NURLC not built — run ./build.sh" >&2; exit 2; }
+command -v python3 >/dev/null 2>&1 || { echo "error: python3 not on PATH" >&2; exit 2; }
+
+# ── capture ─────────────────────────────────────────────────────
+# The corpus is compiler/tests: it is the set whose outcomes are
+# already baselined, so every diagnostic it raises is one the project
+# has committed to. --lint is on so the lint-only diagnostics count as
+# exercised too. Failures are the point here, so no `set -e`.
+rm -rf "$ERRDIR"
+mkdir -p "$ERRDIR"
+for src in "$ROOT_DIR"/compiler/tests/*.nu; do
+    name="$(basename "$src" .nu)"
+    "$NURLC" --lint "$src" >/dev/null 2>"$ERRDIR/$name.err"
+done
+
+# Probe programs live beside the corpus and exist only to make a
+# diagnostic speak; they are not compiled by the test runner.
+if [[ -d "$ROOT_DIR/compiler/tests/diagprobes" ]]; then
+    for src in "$ROOT_DIR"/compiler/tests/diagprobes/*.nu; do
+        [[ -e "$src" ]] || continue
+        name="probe_$(basename "$src" .nu)"
+        "$NURLC" --lint "$src" >/dev/null 2>"$ERRDIR/$name.err"
+    done
+fi
+
+# ── analyse ─────────────────────────────────────────────────────
+if [[ "$MODE" == "update" ]]; then
+    python3 "$ANALYZE" "$SRC" "$ERRDIR" fingerprints > "$BASELINE" || exit 2
+    python3 "$ANALYZE" "$SRC" "$ERRDIR" summary
+    echo "baseline updated: $BASELINE"
+    exit 0
+fi
+
+python3 "$ANALYZE" "$SRC" "$ERRDIR" "$MODE" || exit 2
+
+[[ -f "$BASELINE" ]] || { echo "error: no baseline — run $0 --update" >&2; exit 2; }
+
+# Ratchet on identity, not on count: a message may be rewritten (its key
+# changes) without the total moving, and that new wording is just as
+# unread as a brand-new site. Compare the key sets.
+CUR="$(mktemp)"; trap 'rm -f "$CUR"' EXIT
+python3 "$ANALYZE" "$SRC" "$ERRDIR" fingerprints > "$CUR" || exit 2
+
+NEW="$(comm -13 <(cut -d' ' -f1 "$BASELINE" | sort) <(cut -d' ' -f1 "$CUR" | sort))"
+if [[ -n "$NEW" ]]; then
+    echo
+    echo "error: diagnostics that no test makes the compiler print:"
+    while read -r key; do
+        [[ -n "$key" ]] && grep -- "^$key " "$CUR" | sed 's/^/    /'
+    done <<< "$NEW"
+    echo
+    echo "  Write a program in compiler/tests/ that triggers each one, read what"
+    echo "  the compiler actually says, and keep it as a diag_* test (the runner"
+    echo "  baselines the diagnostic TEXT for that prefix — should_fail_* records"
+    echo "  only COMPILE FAIL and would not hold the wording)."
+    echo "  If a message is genuinely unreachable, delete it rather than baseline it."
+    echo "  To accept deliberately: ./tools/check_diag_coverage.sh --update"
+    exit 1
+fi
+
+FIXED="$(comm -23 <(cut -d' ' -f1 "$BASELINE" | sort) <(cut -d' ' -f1 "$CUR" | sort) | wc -l)"
+if [[ "$FIXED" -gt 0 ]]; then
+    echo
+    echo "$FIXED baselined gap(s) now covered — re-baseline with --update to lock it in."
+fi
+echo "diagnostic coverage: no new never-fired sites."
+exit 0

--- a/tools/diag_coverage.py
+++ b/tools/diag_coverage.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Dual-licensed under MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE) at your option.
+# ============================================================
+#  diag_coverage.py — the analysis half of check_diag_coverage.sh.
+#
+#  Enumerates every diagnostic emission site in compiler/nurlc.nu and
+#  reports which ones the test corpus has actually made speak.
+#
+#  Called by tools/check_diag_coverage.sh, which supplies the captured
+#  stderr. Runnable directly for the long report:
+#
+#     python3 tools/diag_coverage.py compiler/nurlc.nu <errdir> report
+#
+#  Modes: summary | report | fingerprints | thin | json
+# ============================================================
+"""Diagnostic coverage over compiler/nurlc.nu.
+
+A die site whose text never appears in any test's stderr is a message
+nobody has read against a real program. Its wording is unverified, its
+line/caret placement is unverified, and it may not even be reachable —
+an earlier check can preempt it, leaving a written diagnostic dead.
+Scanning the source cannot see any of that; only running the compiler
+can. This is the half the source scan is blind to.
+"""
+import hashlib
+import json
+import os
+import re
+import sys
+from collections import Counter
+
+# Every emitter that puts a diagnostic in front of the user. die_if_void
+# is not listed: it wraps `die` and its text is scanned at that site.
+EMITTERS = ("die", "die_at", "die_stmt", "die_pos", "warn")
+
+# A fingerprint has to be long enough not to collide with ordinary prose
+# in some other message. 18 characters is past the point where two
+# independently written diagnostics share a run by accident.
+MIN_FINGERPRINT = 18
+
+
+def mask_source(src):
+    """Return a per-character map: 'c' code, 's' string, '#' comment.
+
+    Paren balancing has to ignore parens inside backtick strings and
+    `//` comments — a message that says "(the parenthesised form)" would
+    otherwise close the call early and truncate the extracted text.
+    """
+    m = bytearray(b"c" * len(src))
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == "`":
+            j = src.find("`", i + 1)
+            j = n if j < 0 else j + 1
+            for k in range(i, j):
+                m[k] = ord("s")
+            i = j
+        elif c == "/" and i + 1 < n and src[i + 1] == "/":
+            j = src.find("\n", i)
+            j = n if j < 0 else j
+            for k in range(i, j):
+                m[k] = ord("#")
+            i = j
+        else:
+            i += 1
+    return m.decode()
+
+
+def scan_sites(path):
+    """Every diagnostic call site in `path`, with the text it can print."""
+    src = open(path, encoding="utf-8").read()
+    mask = mask_source(src)
+    sites = []
+    for m in re.finditer(r"\(\s*(%s)\s" % "|".join(EMITTERS), src):
+        if mask[m.start()] != "c":
+            continue  # the emitter's own name inside a comment or message
+        depth, i = 0, m.start()
+        while i < len(src):
+            if mask[i] == "c":
+                if src[i] == "(":
+                    depth += 1
+                elif src[i] == ")":
+                    depth -= 1
+                    if depth == 0:
+                        break
+            i += 1
+        body = src[m.start():i + 1]
+        lits = re.findall(r"`([^`]*)`", body)
+        sites.append({
+            "emitter": m.group(1),
+            "line": src.count("\n", 0, m.start()) + 1,
+            "text": norm(" ".join(lits)),
+            "fingerprint": fingerprint(lits),
+        })
+    return sites
+
+
+def norm(s):
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def fingerprint(lits):
+    """The longest literal run in a message — what to grep stderr for.
+
+    None when every fragment is short or the whole message arrives in a
+    variable: those sites are unmatchable by text and are reported
+    separately rather than counted as uncovered, because a false "never
+    fired" is worse than an honest gap in the instrument.
+    """
+    cands = sorted((norm(l) for l in lits), key=len, reverse=True)
+    return next((c for c in cands if len(c) >= MIN_FINGERPRINT), None)
+
+
+def site_key(site):
+    """Line-independent identity, so the baseline survives edits above."""
+    return hashlib.sha256(site["fingerprint"].encode("utf-8")).hexdigest()[:12]
+
+
+def load_stderr(errdir):
+    out = {}
+    for fn in sorted(os.listdir(errdir)):
+        if fn.endswith(".err"):
+            with open(os.path.join(errdir, fn), encoding="utf-8",
+                      errors="replace") as fh:
+                out[fn[:-4]] = norm(fh.read())
+    return out
+
+
+def classify(sites, captured):
+    covered, uncovered, unmatchable = [], [], []
+    for s in sites:
+        if s["fingerprint"] is None:
+            unmatchable.append(s)
+            continue
+        s["hits"] = [k for k, v in captured.items() if s["fingerprint"] in v]
+        (covered if s["hits"] else uncovered).append(s)
+    return covered, uncovered, unmatchable
+
+
+def main():
+    src = sys.argv[1] if len(sys.argv) > 1 else "compiler/nurlc.nu"
+    errdir = sys.argv[2] if len(sys.argv) > 2 else "build/diagcov"
+    mode = sys.argv[3] if len(sys.argv) > 3 else "summary"
+
+    sites = scan_sites(src)
+    captured = load_stderr(errdir)
+    covered, uncovered, unmatchable = classify(sites, captured)
+
+    if mode == "fingerprints":
+        # The baseline format: one `key  text` line per never-fired site,
+        # sorted by key so the file is diff-stable across source edits.
+        for s in sorted(uncovered, key=site_key):
+            print(f"{site_key(s)}  {s['text'][:100]}")
+        return 0
+
+    if mode == "json":
+        json.dump({"covered": covered, "uncovered": uncovered,
+                   "unmatchable": unmatchable}, sys.stdout, indent=1)
+        return 0
+
+    if mode == "report":
+        print(f"── never-fired diagnostics ({len(uncovered)}) "
+              "─────────────────────────────")
+        for s in sorted(uncovered, key=lambda x: x["line"]):
+            print(f"{src}:{s['line']}: {s['emitter']}: {s['text'][:150]}")
+        if unmatchable:
+            print(f"\n── unmatchable by text ({len(unmatchable)}) "
+                  "— message is built in a variable ──")
+            for s in sorted(unmatchable, key=lambda x: x["line"]):
+                print(f"{src}:{s['line']}: {s['emitter']}: "
+                      f"{s['text'][:80] or '(no literal)'}")
+        print()
+
+    total = len(sites)
+    print(f"diagnostic sites : {total}")
+    print(f"  exercised      : {len(covered)}"
+          f"  ({100 * len(covered) // max(total, 1)}%)")
+    print(f"  never fired    : {len(uncovered)}")
+    print(f"  unmatchable    : {len(unmatchable)}")
+    print(f"  by emitter     : {dict(Counter(s['emitter'] for s in sites))}")
+    print(f"  corpus files   : {len(captured)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/diag_coverage_baseline.txt
+++ b/tools/diag_coverage_baseline.txt
@@ -1,0 +1,81 @@
+080b833f7959  unknown field or variable ' ' — it is not a field of the struct being accessed, nor a binding in sco
+0837ccd0b702  trait ' ' has no associated type ' ' to bind for type ' '. An impl may only bind the associated type
+1919b534d625  volatile_store expects a typed pointer '*T' first, so it knows the width to write. Write '( volatile
+248dd68fff80  'inout' is a parameter CONVENTION, not a name: it goes before the type, as in '@ f inout ( Vec i ) v
+259c3b2d89fe  expected a type, found . Types are the single-letter keywords 'i u f b s v', a fixed width like 'i32
+262c483387aa  nurl_str_len expects 's' (i8* C-string), got %String. Use 'string_len' for String values.
+263055d8df9b  expected variable name in let — 'T' and 'F' are the boolean literals and cannot name a binding; pick
+265709a49431  argument to ' ' has enum type ' ' but the parameter is declared enum ' ' — two enums are distinct no
+34501728d174  expected the enum's name after ': |', found . A sum type is ': | Name { Variant Variant Payload ... 
+3842aa6639a4  method ' ' of trait ' ' has a 'sink' (by-value consuming) receiver — not object-safe for '% ' dispat
+39986b65138d  expected a field name or an index after '.', found . Field access is '. obj field' and element acces
+39cb62532ea8  the expression produces no value to bind or assign, but a ' ' was required. A call returning 'v', an
+3cc2e514ea86  inout field argument to ' ' must be '. <binding> <field>' naming a plain struct binding
+3ef3446b70cc  ' ' is a compiler-auto-dropped value; passing it to a 'sink' parameter is not yet supported - pass a
+40719efb1dd5  expected a function name after '@', found . A declaration is '@ name params → ret { body }' — parame
+43a9804d1c0b  inout argument ' ' is not a binding in scope. An 'inout' argument must be a plain binding in scope, 
+4611dc344430  expected a variant name after '|', found . An or-pattern lists bare variant names: 'A | B | C → body
+46beb4c87199  method ' ' of trait ' ' mentions Self beyond the receiver (a parameter or the return type) — not obj
+4c454d4ae69a  expected '→' or a payload name after the variant, found . A match arm binds its payload before the a
+4dcc1518b953  integer literal does not fit the ' ' operand it is combined with (that type holds .. ) — NURL evalua
+50c9a5e6a8a5  cannot cast ' ' to an integer: its first field is itself an aggregate, so there is no scalar to take
+52d29a5350d6  select has no channel arms — a '?? { ... }' with only a default '_' arm would spin without ever wait
+554c34e0f923  a guard (? cond) on a wildcard arm is not supported - guard a specific pattern instead
+5ad763372c6c  method ' ' of trait ' ' has no Self receiver as its first parameter — not object-safe for '% '
+5dfdf7d4ec64  expected '{' to open the default arm's body, found . The default arm is '_ → { body }'.
+6490ab011ef9  expected '{' to open this select arm's body, found . A select arm's body is always braced. A select 
+66899da59bce  expected an associated-type name after 'type', found . A trait declares one as 'type Name', and each
+697d73c26332  expected a binding name, found . A binding is ': type name value' — the TYPE comes before the name, 
+6a7a475738c9  an or-pattern cannot carry a guard — 'A | B ? cond → body' would have to hold for both variants and 
+70153c509a6c  inout field argument: ' ' is not a named-struct binding — the field form needs a struct with declare
+737e4e2f64a2  an or-pattern's variants cannot bind payloads — the arms would disagree about what the name holds. L
+74249aa6574f  expected a method name after '@' in this impl block, found . An impl is '% Trait Type { @ name param
+7f5fb5327ef2  element of this slice literal has type ' ' but the slice's declared element type is ' ' — a value of
+802e2cc68a45  string_len expects %String, got 'i8*' (raw C-string). Use 'nurl_str_len' for raw C-string pointers.
+812c266928da  a supertrait ':' clause belongs on the trait DECLARATION ('% Name : Base { ... }'), not on an impl. 
+863b07109626  expected an associated-type name after 'type', found . An impl binds what the trait declared: 'type 
+88d59a9c07fe  element of this slice literal has type ' ' but the slice's declared element type is ' ' — pointer-vs
+89608f397d6c  cannot mutate immutable parameter ' ' — parameters are immutable bindings. Copy it into a ': ~' loca
+8f1f18d7ebfd  parameter name 'entry' collides with LLVM's reserved entry: block label. Rename (e.g. 'ent', 'tab_en
+8f8423944aed  const expression must be integer literals combined with + - * / << >> & | ^^ (use a precomputed lite
+8fa0e2858d9c  unexpected where a value was required. Every NURL operator has FIXED arity and no closing bracket, s
+90e2e7e59d8d  return expression has no value (expected
+95e02910fae6  trait ' ' is not object-safe: a dynamic object needs the trait to be generic over Self ('% Name [T] 
+996c90fa8fe7  select has more than one default '_' arm — only one is allowed, and it runs when no channel is ready
+9a6844424ec4  type ' ' does not implement trait ' ', so it cannot be made into a '% ' object. Write the impl first
+a000cdd254fc  '#' is the cast operator; struct/enum literals use '@'. Write '@ { ... }' instead.
+a193bc7b84db  inout field argument: struct ' ' has no field '
+a76c19aaaa52  associated type ' ' must be bound to a simple type name — write 'type Name = i' or 'type Name = MySt
+a7b912fa462f  expected '→' after the match guard, found . A guarded arm is 'Variant payload ? guard → body' — the 
+aba81704d0f4  inout argument to ' ' must be a mutable ': ~' binding or a '. binding field' field target, not an ex
+abd79dec9f97  '%' in a type position must be followed by a trait name (dynamic trait object '%Trait')
+ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
+ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
+aca2603b8e6a  unterminated '[' in a select arm — expected ']' after the element type. A select arm is '[T] chan → 
+ae69b52c99bd  element of this slice literal has integer type ' ' but the slice's declared element type is ' ' (a f
+af5a83d74d0f  cannot cast ' ' to an integer — '# i expr' converts numbers and pointers, not this type. There are n
+b21046aab91d  this condition has type ' ' which has no truth value — a condition must be 'b', or an integer (teste
+b37f1893c8a8  expected a parameter name after its type, found . Parameters are written 'type name', repeated, with
+b37f1893c8a8  expected a parameter name after its type, found . Parameters are written 'type name', repeated, with
+b76f8600bceb  malformed binary literal — '0b' must be followed by at least one 0 or 1. E.g. '0b1011'.
+bde8adc30e81  inout field argument: ' ' is not a struct binding in scope. An 'inout' argument must be a plain bind
+c5d859907bb0  operator '&&' requires bool operands and the left one is not bool. '&&' and '||' short-circuit and a
+c6d6dadc45c0  operator mixes float operands of different widths: left is ' ', right is ' ' — NURL has no implicit 
+ca92cb54d21f  expected at least one trait name after the supertrait ':', found . A trait requiring others is '% Na
+cfe21e33fd77  inout field argument: expected a field name after '. '. The form is '( f inout . s field )' — object
+d82fbf1f85b6  an or-pattern cannot mix a literal constraint with variant names — write the literal case as its own
+dbb6645738fc  ( in type position must be followed by @ or type name
+e13f6093bfb5  expected '{' to open the closure body, found . A closure is '\\ params → ret { body }' — the body is
+ea01dc19d4df  volatile_load expects a typed pointer '*T', so it knows the width to read. Write '( volatile_load p 
+ea026f9d2966  this condition produces no value (the expression is 'v'/void — a call that returns nothing?) — a con
+eb8fe812ca4f  expected '→' after the channel in this select arm, found . A select arm is '[T] chan → name { body }
+eb8fe812ca4f  expected the received value's name after '→', found . A select arm is '[T] chan → name { body }' — t
+eb8fe812ca4f  expected '[' or '_' to start a select arm, found . A select arm is '[T] chan → name { body }' — the 
+f61ec29769e4  an or-pattern lists named enum variants; 'T' and 'F' are the option/result arms and there are only t
+f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
+f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
+f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
+f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
+f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
+f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
+f88236bbf2cf  operator '||' requires bool operands and the left one is not bool. '||' and '&&' short-circuit and a


### PR DESCRIPTION
## Why

The `ax` work scored diagnostics by **scanning `nurlc.nu`**: does the message name a cure, state the rule, show a spelling. #838 already recorded where that instrument stops — it *"passes any message that is long and confident, including one that pointed the wrong way"* — and answered by hand-writing thirty broken programs. Thirty is not 220, and the next contributor has to think of the thirty.

The blind spot is not text quality. It is **reachability**. A source scan cannot see whether a message is ever printed, and an unfired message is unverified in every way that matters:

* its wording has never been read next to the program that caused it — which is exactly how the one FALSE message in #838 survived a scan that scored it as excellent;
* its line and caret placement have never been checked;
* it may be dead outright, preempted by a looser check upstream, so the good message exists and the user still gets the generic one;
* nothing stops a later edit from gutting it, because no golden holds its text.

**132 of 220 diagnostic sites are exercised by the corpus. 81 are not.** That number is the answer to "what is left", and nothing in the repo could produce it before.

## What

**`tools/check_diag_coverage.sh` + `tools/diag_coverage.py`** — compiles the corpus, matches every emitted diagnostic back to its site in `nurlc.nu` by its longest literal fragment, and reports the sites nothing made speak. Ratchets against `tools/diag_coverage_baseline.txt` on message **identity**, not count: existing gaps do not fail the build, a new die site with no test that fires it does. A rewritten message changes key and is just as unread as a new one, so the ratchet catches that too.

Verified the ratchet works by planting a die site nothing reaches — it was reported and the check exited 1.

**The first thing it found was a message asserting the opposite of the truth.** `__kw_default_or_die` — the function that runs precisely when a parameter has *no* default — told the reader:

> Every parameter must be supplied — **NURL has no defaults and no overloading.**

NURL has had default parameter values since kwargs landed (`@ box s label i width = 10 → v`, `compiler/tests/kwargs.nu:6`). A model that believed it would never use a feature the language has. This is the **second** message of that exact shape after the bool-widening one in #838, and both shipped for the same reason: nothing ever printed them. Rewritten to name the parameter, state the real rule (optional iff the declaration gives it a default), and offer all three cures including adding one.

**Three diagnostics printed a correct message against the wrong line.** The bool-mix checks in `gen_logical_or` / `gen_logical_and` and the missing-argument check all fire only after `gen_expr` has consumed the operands — by which point the lexer sits on the NEXT statement and `die lex` blamed it. Anchored with `die_stmt`, which exists for exactly this and already had four callers; it has seven now. A model reading a precise message about the wrong line is worse off than with a vague message about the right one.

**Eight `diag_*` tests**, and `diag_*` on purpose. `should_fail_*` records the single word `COMPILE FAIL`, so a message behind one can be gutted to `expected ')'` without a golden moving — which is why 60-odd negative tests exercise die sites and not one holds the wording. `should_fail_binop_bool_int` has a three-sentence diagnostic and a one-word golden. `compiler/tests/README.md` now documents the `diag_*` row it was missing and says which prefix to reach for.

## Proof

```
./compiler/tests/run_tests.sh
PASS 678 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this change and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

The same set failed before any edit in this branch, none of their goldens is touched by the diff, and pass count tracked new tests exactly (676 → 677 → 678 as tests were added). An earlier run showed FAIL 15 — one network test is flaky here.

Also run and clean:

```
./build.sh --no-tests        BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check              compiler/nurlc.nu and all 8 new tests canonical
./tools/check_strict_arity.sh  OK — 1115 files, no arity trap
./tools/check_diag_coverage.sh no new never-fired sites
```

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs. The compiler diff is three diagnostic call sites and one message string, so codegen is untouched.

## Known remaining

**81 sites still never fire.** By area: parser `expected` 22, the `cannot` family 9, `inout` forms 7, `select` arms 8, or-patterns 5, traits and associated types 8, operators 4. The baseline file lists all of them; each wants a program that triggers it and a reading of what comes out. Deliberately not done here — writing 81 tests blind is how you get 81 tests that pass and no messages that improved.

**Two gaps this tool structurally cannot find.** Probing found both by hand:

* `@ S { a: 1 b: 2 }` (Rust-style named struct fields) → *"use of undefined identifier 'a'"*. Struct literals are positional; the message says nothing about that.
* `@ E A 1` (variant outside the braces) → the generic *"expected '{' but found 'A'"*.

Neither has a die site to score or to cover — the compiler falls through to a generic message, so **both are invisible to the scanner and to this gate alike**. They need the third layer: write the mistake a model actually makes, read the answer. Left for a follow-up rather than bolted on here.

**A fourth instrument is missing: caret placement.** A message can be covered and still point at the wrong token — `should_fail_binop_bool_int` does today, carets at the `^` rather than the operator. The three fixed here were found by reading new goldens, not by a check. Nothing yet compares where a diagnostic points against where the test meant it to.

**One wording imprecision left alone.** The plain arity check reports the *declared* parameter count, so a defaulted callee reads as `expected 2, got 0` when 1 would do. Fixing it means threading a minimum arity through `scan_fn_sigs` — real regression surface, its own change. Noted in `diag_call_missing_required_arg.nu` so the next reader finds it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_