### PR TITLE
fix(ax): the messages that taught a syntax the compiler rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Three messages taught an associated-type syntax the compiler
+  rejects.** The binding is three tokens — `type Elem i` — as
+  `docs/spec.md` §4.9, `docs/LIMITATIONS.md` and
+  `__parse_assoc_binding`'s own comment all say. All three diagnostics
+  about it said `type Name = ConcreteType`, and the one that fires on a
+  malformed binding said it *while rejecting the very form it asked
+  for*: write `type Elem = i` and the compiler answers "must be bound to
+  a simple type name — write `type Name = i`". A model that did what the
+  message said hit the same message again, with nothing in the text to
+  break the loop.
+
+  Found by probing the never-fired list, which is what it is for. The
+  coverage gate then flagged all three rewrites as unread — a rewritten
+  message has been read by nobody, which is why the ratchet keys on
+  message identity and not on a count.
+
+- **A select arm that lost its `[T]` was told about the default arm.**
+  The default-arm branch tested only "is this an identifier", so
+  `ints → oi { … }` was accepted *as* the `_` marker and the parse then
+  failed one token later with "expected '{' to open the default arm's
+  body" — a message about a construct the writer never used, offering a
+  cure (`_ → { body }`) with no bearing on the mistake. The marker must
+  literally be `_`; anything else is a channel arm missing its brackets,
+  and the arm-shape message that was already written for exactly this
+  now gets to say so.
+
+- **Two mistakes every other language teaches now get an answer.** Both
+  produced a message with no die site of its own — the compiler fell
+  through to something generic — so both were invisible to the source
+  scan and to the coverage gate alike, and only writing the wrong
+  program found them:
+
+  * `@ Point { x : 3 y : 4 }` (named struct-literal fields) died as
+    **"use of undefined identifier 'x'"**, pointing at the field name as
+    though it were a typo. It now states that literals are positional
+    and shows the declaration beside the literal that builds it.
+  * `@ E A 1` (the variant outside the braces, as in `E::A(1)`) died as
+    **"expected '{' but found 'A'"**, blaming the fixed-arity operand
+    trap — which is not what happened. It now names the variant and
+    shows where it goes. The check fires only when the ident really is a
+    declared variant, so a genuine stray token still gets the arity
+    message it deserves.
+
 - **"NURL has no defaults and no overloading" — said by the function
   named `__kw_default_or_die`.** NURL has had default parameter values
   since kwargs landed (`@ box s label i width = 10 → v`), and this error

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -8721,7 +8721,7 @@
             = bidx + bidx 1
         } {
             // ── _ → { body }  (default / non-blocking) ──
-            ? ! ( is_ident_tok ( nurl_lex_type lex ) )
+            ? | ! ( is_ident_tok ( nurl_lex_type lex ) ) ! ( seq ( nurl_lex_val lex ) `_` )
             { ( die lex ( nurl_str_cat3 `expected '[' or '_' to start a select arm, found ` ( tok_here lex ) `. A select arm is '[T] chan → name { body }' — the element type in brackets, the channel, then the name the received value binds to. The default arm is '_ → { body }'. E.g. '?? { [i] c → v { ( use v ) }  _ → { ( idle ) } }'.` ) ) } {}
             ? != 0 has_default { ( die lex ( nurl_str_cat `select has more than one default '_' arm — only one is allowed, and it runs when no channel is ready. Merge the two bodies into a single '_ → { ... }'.` `` ) ) } {}
             ( nurl_lex_advance lex )  // consume '_'
@@ -14897,7 +14897,37 @@
         : s tail ( nurl_str_cat3 ` ( nurl_alloc Z ` sname ` )', then '= . x <field> <value>' per field.` )
         ( die lex ( nurl_str_cat3 head mid tail ) ) }
     {}
+    // `@ E A 1` — the variant named OUTSIDE the braces, which is what
+    // every language with `E::A(1)` teaches. NURL puts it inside:
+    // `@ E { A 1 }`. Left to the generic `expect` this said "expected
+    // '{' but found 'A'", which names the token and not the rule — and
+    // the writer has no way to guess the variant belongs one bracket to
+    // the right. Only fires when the ident really is a variant of a
+    // declared enum, so a genuine stray token still gets the generic
+    // arity-trap message it deserves.
+    ? & != ( nurl_lex_type lex ) TT_LBRACE ( is_ident_tok ( nurl_lex_type lex ) )
+    { ? != 0 ( nurl_sym_len2 syms ( nurl_lex_val lex ) `__paycount` )
+        { ( die lex ( nurl_str_cat4
+            ( nurl_str_cat3 `enum variant '` ( nurl_lex_val lex ) `' belongs INSIDE the braces — write '@ ` )
+            ( nurl_str_slice agg_ty 1 - ( nurl_str_len agg_ty ) 1 )
+            ( nurl_str_cat3 ` { ` ( nurl_lex_val lex ) ` <payload> }'. ` )
+            `An enum literal is '@ EnumName { Variant payload }': the variant is the first item in the brace list, not a word between the name and the brace. A payload-less variant is just '@ EnumName { Variant }'.` ) ) }
+        {} }
+    {}
     ( expect lex TT_LBRACE )  // consume '{'
+    // `@ S { a : 1 b : 2 }` — field NAMES, the habit every other
+    // language teaches. NURL struct literals are positional: values in
+    // declaration order, no names. Left alone the name lexed as a value
+    // expression and died as "use of undefined identifier 'a'", which
+    // points at the field name as though it were a typo and says
+    // nothing about the rule. A ':' after a bare name at field position
+    // can only be this mistake — a keyword argument is a CALL form and
+    // its name sits inside parens, never at the head of a literal field.
+    ? & ( is_ident_tok ( nurl_lex_type lex ) ) == ( nurl_lex_peek_type lex ) TT_COLON
+    { ( die lex ( nurl_str_cat3
+        `struct literal fields are positional, and '` ( nurl_lex_val lex )
+        ` :' names one. NURL has no named-field literals: supply the values in DECLARATION order instead — ': Point { i x i y }' is built as '@ Point { 3 4 }'. (A ':' after a name is a keyword ARGUMENT, which is a call form: '( f width : 5 )'.)` ) ) }
+    {}
     // zeroinitializer (not undef) so fields the literal leaves out are
     // all-zero. Matters for payload-less None — `@ ?T { F }` — where the
     // payload slot must read as a NULL handle (the runtime and stdlib
@@ -21603,7 +21633,7 @@
         ? & == ( nurl_lex_type lex ) TT_IDENT ( seq ( nurl_lex_val lex ) `type` )
         { ( nurl_lex_advance lex )  // skip 'type'
             ? ! ( is_ident_tok ( nurl_lex_type lex ) )
-            { ( die lex ( nurl_str_cat3 `expected an associated-type name after 'type', found ` ( tok_here lex ) `. A trait declares one as 'type Name', and each impl binds it with 'type Name = ConcreteType'.` ) ) }
+            { ( die lex ( nurl_str_cat3 `expected an associated-type name after 'type', found ` ( tok_here lex ) `. A trait declares one as 'type Name', and each impl binds it with 'type Name ConcreteType' — three tokens, no '='.` ) ) }
             {}
             : s aname ( nurl_lex_val lex )
             ( nurl_lex_advance lex )  // consume the associated-type name
@@ -21755,13 +21785,13 @@
 @ __parse_assoc_binding i lex → s {
     ( nurl_lex_advance lex )  // skip 'type'
     ? ! ( is_ident_tok ( nurl_lex_type lex ) )
-    { ( die lex ( nurl_str_cat3 `expected an associated-type name after 'type', found ` ( tok_here lex ) `. An impl binds what the trait declared: 'type Name = ConcreteType'.` ) ) }
+    { ( die lex ( nurl_str_cat3 `expected an associated-type name after 'type', found ` ( tok_here lex ) `. An impl binds what the trait declared: 'type Name ConcreteType' — the keyword, the name, then the concrete type, with no '=' between them.` ) ) }
     {}
     : s aname ( nurl_lex_val lex )
     ( nurl_lex_advance lex )  // consume the name
     : s aval ( capture_impl_nurl_name lex )
     ? == 0 ( nurl_str_len aval )
-    { ( die lex ( nurl_str_cat3 `associated type '` aname `' must be bound to a simple type name — write 'type Name = i' or 'type Name = MyStruct', not a parenthesised or generic form.` ) ) }
+    { ( die lex ( nurl_str_cat3 `associated type '` aname `' must be bound to a simple type name — write 'type Elem i' or 'type Elem MyStruct', with no '=' and no parenthesised or generic form.` ) ) }
     {}
     ( nurl_lex_advance lex )  // consume the bound type
     ^ ( nurl_str_cat aname ( nurl_str_cat ` ` aval ) )

--- a/compiler/tests/diag_assoc_name_impl.nu
+++ b/compiler/tests/diag_assoc_name_impl.nu
@@ -1,0 +1,17 @@
+// diag_assoc_name_impl.nu — the same '=' habit on the IMPL side, where
+// the binding really does take a concrete type but still takes no '='.
+//
+// Both this message and its trait-side twin were rewritten to stop
+// teaching the '=' form; the coverage gate then flagged both as unread,
+// which is the point of keying the ratchet on message identity rather
+// than on a count. A rewritten message has been read by nobody.
+: IntBox { i v }
+
+% Boxed [T] { type Elem @ unwrap T self → Elem }
+
+% Boxed IntBox {
+    type = i
+    @ unwrap IntBox self → i { ^ . self v }
+}
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_assoc_name_trait.nu
+++ b/compiler/tests/diag_assoc_name_trait.nu
@@ -1,0 +1,14 @@
+// diag_assoc_name_trait.nu — 'type = Elem' in a TRAIT declaration.
+//
+// This is the program a model writes after reading the old message,
+// which told it the binding form was 'type Name = ConcreteType'. The
+// declaration side takes no concrete type at all — it is 'type Name',
+// two tokens — so the '=' lands where the name belongs.
+: IntBox { i v }
+
+% Boxed [T] {
+    type = Elem
+    @ unwrap T self → Elem
+}
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_assoc_type_eq_form.nu
+++ b/compiler/tests/diag_assoc_type_eq_form.nu
@@ -1,0 +1,25 @@
+// diag_assoc_type_eq_form.nu — an associated-type binding written with
+// '=', the form all three of the compiler's own messages used to teach.
+//
+// The binding is three tokens, 'type Name Concrete' (docs/spec.md §4,
+// docs/LIMITATIONS.md, and __parse_assoc_binding's own comment). Every
+// message about it said 'type Name = ConcreteType', so a model that hit
+// this error and did exactly what the message asked hit the SAME error
+// again — the diagnostic described a syntax the compiler rejects, and
+// rejected the input with it. Nothing exercised any of the three.
+: IntBox { i v }
+
+% Boxed [T] {
+    type Elem
+    @ unwrap T self → Elem
+}
+
+% Boxed IntBox {
+    type Elem = i
+    @ unwrap IntBox self → i { ^ . self v }
+}
+
+@ main → i {
+    : IntBox b @ IntBox { 7 }
+    ^ ( unwrap b )
+}

--- a/compiler/tests/diag_enum_variant_outside_braces.nu
+++ b/compiler/tests/diag_enum_variant_outside_braces.nu
@@ -1,0 +1,14 @@
+// diag_enum_variant_outside_braces.nu — the variant named between the
+// enum name and the brace, as in 'E::A(1)'.
+//
+// NURL writes it inside: '@ E { A 1 }'. The generic parser message
+// ("expected '{' but found 'A'") named the token and not the rule, and
+// blamed the arity trap — which is not what happened. The check fires
+// only when the ident really is a declared variant, so a genuine stray
+// token still gets the arity message it deserves.
+: | E { A i B }
+
+@ main → i {
+    : E e @ E A 1
+    ^ 0
+}

--- a/compiler/tests/diag_select_arm_missing_type.nu
+++ b/compiler/tests/diag_select_arm_missing_type.nu
@@ -1,0 +1,17 @@
+// diag_select_arm_missing_type.nu — a select channel arm without its
+// '[T]' element type.
+//
+// The default-arm branch tested only "is this an identifier", so a
+// channel arm's name was accepted AS the '_' marker and the parse then
+// failed one token later with "expected '{' to open the default arm's
+// body" — a message about a construct the writer had not used, naming a
+// cure ('_ → { body }') that has nothing to do with the mistake. The
+// marker must literally be '_'; anything else is a channel arm that
+// lost its brackets, and the arm-shape message says so.
+$ `stdlib/std/channel.nu`
+
+@ main → i {
+    : ( Channel i ) ints ( chan_new [i] )
+    ?? { ints → oi { ^ 0 } }
+    ^ 0
+}

--- a/compiler/tests/diag_struct_lit_named_fields.nu
+++ b/compiler/tests/diag_struct_lit_named_fields.nu
@@ -1,0 +1,14 @@
+// diag_struct_lit_named_fields.nu — a struct literal with Rust-style
+// named fields.
+//
+// NURL struct literals are positional. Every mainstream language a model
+// has read names the fields, so this is among the likeliest mistakes it
+// can make — and it used to land on "use of undefined identifier 'a'",
+// which points at the field name as though it were a typo and never
+// mentions that names are not part of the form.
+: Point { i x i y }
+
+@ main → i {
+    : Point p @ Point { x : 3 y : 4 }
+    ^ . p x
+}

--- a/compiler/tests/outputs/diag_assoc_name_impl.txt
+++ b/compiler/tests/outputs/diag_assoc_name_impl.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_assoc_name_impl.nu:13:10: error: expected an associated-type name after 'type', found '=' (an assignment starts here). An impl binds what the trait declared: 'type Name ConcreteType' — the keyword, the name, then the concrete type, with no '=' between them.
+    type = i
+         ^

--- a/compiler/tests/outputs/diag_assoc_name_trait.txt
+++ b/compiler/tests/outputs/diag_assoc_name_trait.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_assoc_name_trait.nu:10:10: error: expected an associated-type name after 'type', found '=' (an assignment starts here). A trait declares one as 'type Name', and each impl binds it with 'type Name ConcreteType' — three tokens, no '='.
+    type = Elem
+         ^

--- a/compiler/tests/outputs/diag_assoc_type_eq_form.txt
+++ b/compiler/tests/outputs/diag_assoc_type_eq_form.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_assoc_type_eq_form.nu:18:15: error: associated type 'Elem' must be bound to a simple type name — write 'type Elem i' or 'type Elem MyStruct', with no '=' and no parenthesised or generic form.
+    type Elem = i
+              ^

--- a/compiler/tests/outputs/diag_enum_variant_outside_braces.txt
+++ b/compiler/tests/outputs/diag_enum_variant_outside_braces.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_enum_variant_outside_braces.nu:12:15: error: enum variant 'A' belongs INSIDE the braces — write '@ E { A <payload> }'. An enum literal is '@ EnumName { Variant payload }': the variant is the first item in the brace list, not a word between the name and the brace. A payload-less variant is just '@ EnumName { Variant }'.
+    : E e @ E A 1
+              ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_select_arm_missing_type.txt
+++ b/compiler/tests/outputs/diag_select_arm_missing_type.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_select_arm_missing_type.nu:15:10: error: expected '[' or '_' to start a select arm, found 'ints'. A select arm is '[T] chan → name { body }' — the element type in brackets, the channel, then the name the received value binds to. The default arm is '_ → { body }'. E.g. '?? { [i] c → v { ( use v ) }  _ → { ( idle ) } }'.
+    ?? { ints → oi { ^ 0 } }
+         ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_struct_lit_named_fields.txt
+++ b/compiler/tests/outputs/diag_struct_lit_named_fields.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_struct_lit_named_fields.nu:12:25: error: struct literal fields are positional, and 'x :' names one. NURL has no named-field literals: supply the values in DECLARATION order instead — ': Point { i x i y }' is built as '@ Point { 3 4 }'. (A ':' after a name is a keyword ARGUMENT, which is a call form: '( f width : 5 )'.)
+    : Point p @ Point { x : 3 y : 4 }
+                        ^
+error: aborting due to 1 previous error

--- a/tools/diag_coverage_baseline.txt
+++ b/tools/diag_coverage_baseline.txt
@@ -24,7 +24,6 @@
 5ad763372c6c  method ' ' of trait ' ' has no Self receiver as its first parameter — not object-safe for '% '
 5dfdf7d4ec64  expected '{' to open the default arm's body, found . The default arm is '_ → { body }'.
 6490ab011ef9  expected '{' to open this select arm's body, found . A select arm's body is always braced. A select 
-66899da59bce  expected an associated-type name after 'type', found . A trait declares one as 'type Name', and each
 697d73c26332  expected a binding name, found . A binding is ': type name value' — the TYPE comes before the name, 
 6a7a475738c9  an or-pattern cannot carry a guard — 'A | B ? cond → body' would have to hold for both variants and 
 70153c509a6c  inout field argument: ' ' is not a named-struct binding — the field form needs a struct with declare
@@ -33,7 +32,6 @@
 7f5fb5327ef2  element of this slice literal has type ' ' but the slice's declared element type is ' ' — a value of
 802e2cc68a45  string_len expects %String, got 'i8*' (raw C-string). Use 'nurl_str_len' for raw C-string pointers.
 812c266928da  a supertrait ':' clause belongs on the trait DECLARATION ('% Name : Base { ... }'), not on an impl. 
-863b07109626  expected an associated-type name after 'type', found . An impl binds what the trait declared: 'type 
 88d59a9c07fe  element of this slice literal has type ' ' but the slice's declared element type is ' ' — pointer-vs
 89608f397d6c  cannot mutate immutable parameter ' ' — parameters are immutable bindings. Copy it into a ': ~' loca
 8f1f18d7ebfd  parameter name 'entry' collides with LLVM's reserved entry: block label. Rename (e.g. 'ent', 'tab_en
@@ -45,7 +43,6 @@
 9a6844424ec4  type ' ' does not implement trait ' ', so it cannot be made into a '% ' object. Write the impl first
 a000cdd254fc  '#' is the cast operator; struct/enum literals use '@'. Write '@ { ... }' instead.
 a193bc7b84db  inout field argument: struct ' ' has no field '
-a76c19aaaa52  associated type ' ' must be bound to a simple type name — write 'type Name = i' or 'type Name = MySt
 a7b912fa462f  expected '→' after the match guard, found . A guarded arm is 'Variant payload ? guard → body' — the 
 aba81704d0f4  inout argument to ' ' must be a mutable ': ~' binding or a '. binding field' field target, not an ex
 abd79dec9f97  '%' in a type position must be followed by a trait name (dynamic trait object '%Trait')
@@ -68,9 +65,6 @@ dbb6645738fc  ( in type position must be followed by @ or type name
 e13f6093bfb5  expected '{' to open the closure body, found . A closure is '\\ params → ret { body }' — the body is
 ea01dc19d4df  volatile_load expects a typed pointer '*T', so it knows the width to read. Write '( volatile_load p 
 ea026f9d2966  this condition produces no value (the expression is 'v'/void — a call that returns nothing?) — a con
-eb8fe812ca4f  expected '→' after the channel in this select arm, found . A select arm is '[T] chan → name { body }
-eb8fe812ca4f  expected the received value's name after '→', found . A select arm is '[T] chan → name { body }' — t
-eb8fe812ca4f  expected '[' or '_' to start a select arm, found . A select arm is '[T] chan → name { body }' — the 
 f61ec29769e4  an or-pattern lists named enum variants; 'T' and 'F' are the option/result arms and there are only t
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic


### PR DESCRIPTION
## Why

#847 shipped the gate and listed 81 never-fired diagnostics as the work remaining. This is the first pass through that list, and it found the shape the gate was built to find — plus one worse than the kwargs case.

**An associated-type binding is three tokens: `type Elem i`.** `docs/spec.md` §4.9, `docs/LIMITATIONS.md` and `__parse_assoc_binding`'s own comment all say so. All three diagnostics about it taught `type Name = ConcreteType` — and the one that fires on a malformed binding taught it *while rejecting the very form it asked for*:

```
    type Elem = i
              ^
error: associated type 'Elem' must be bound to a simple type name —
       write 'type Name = i' or 'type Name = MyStruct', …
```

A model that does exactly what the message says hits the same message again. The kwargs message in #847 asserted a false rule; **this one closes a cycle**, which is worse, because obeying it cannot terminate. None of the three had ever been printed.

**A select arm that lost its `[T]` was told about a construct it never used.** The default-arm branch tested only "is this an identifier", so `ints → oi { … }` was accepted *as* the `_` marker and the parse failed one token later:

```
    ?? { ints → oi { ^ 0 } }
                  ^
error: expected '{' to open the default arm's body, found 'oi'.
       The default arm is '_ → { body }'.
```

The writer wrote a channel arm. The cure offered is for a different arm. Meanwhile the correct message — "expected '[' or '_' to start a select arm … A select arm is `[T] chan → name { body }`" — was sitting one branch away, unreachable, on the never-fired list.

**And the two gaps #847 flagged as structurally invisible.** Neither has a die site of its own; the compiler falls through to something generic, so the source scan and the coverage gate are both blind to them. Only writing the wrong program finds these — the third layer:

| what a model writes | what it used to hear |
|---|---|
| `@ Point { x : 3 y : 4 }` | `use of undefined identifier 'x'` |
| `@ E A 1` | `expected '{' but found 'A'` |

The first points at a field name as though it were a typo. The second blames the fixed-arity operand trap, which is not what happened.

## What

- **Three assoc-type messages** now teach `type Elem i` — the keyword, the name, the concrete type, no `=`.
- **The select default-arm marker must literally be `_`.** Anything else is a channel arm missing its brackets, and the arm-shape message that was already written for exactly this now gets to say so.
- **Named struct-literal fields** get a message that states literals are positional and shows the declaration beside the literal that builds it.
- **A variant outside the braces** gets named, with where it goes. The check fires only when the ident really is a declared variant of the enum being built, so a genuine stray token still gets the arity message it deserves.

**Six `diag_*` tests.** Two of them — `diag_assoc_name_trait`, `diag_assoc_name_impl` — are the programs a model writes *after reading the old message*: `type = Elem`. That is the most direct evidence available that the wording mattered.

The coverage gate flagged all three rewrites as unread the moment they changed, which is the ratchet working as designed: keyed on message identity rather than a count, so a rewritten message is as unread as a new site. Tests were written for both rather than re-baselining past them.

**Coverage: 140 of 222 sites exercised, up from 132 of 220. Never-fired 81 → 75.**

## Proof

```
./compiler/tests/run_tests.sh
PASS 684 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this branch and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

Identical set and count to the pre-change run on this same container in #847; pass count moved 678 → 684 exactly as the six tests were added. The select and aggregate-literal paths are both hot and both stayed green, which is the regression risk that mattered here.

```
./build.sh --no-tests           BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check                 compiler/nurlc.nu and all 6 new tests canonical
./tools/check_strict_arity.sh   OK — 1115 files, no arity trap
./tools/check_diag_coverage.sh  clean after the two rewrite tests landed
```

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs.

## Known remaining

**75 sites still never fire.** The list keeps paying out — every pass so far has found either a false statement or a misdirect, so it is worth continuing rather than closing out.

**An incomplete impl still reports the wrong thing, and fixing it needs a decision first.** `% Speaker Dog { }` against a trait declaring `@ speak T self → i` compiles, and the call site then says:

> call to unknown function 'speak' — … Add the missing '$' import, or check the spelling.

Both cures are irrelevant; the trait and the impl are right there. The cause is structural: trait scanning stores *default* method bodies but records nothing for header-only **required** methods, so at the call site there is no way to know `speak` was declared by a trait at all. Two ways forward — register required-method names and improve only the message, or reject an incomplete impl outright — and the second changes what compiles. **That is a language-surface question and wants an issue first**, per CONTRIBUTING; inventing it inside a diagnostics PR is exactly the sideways change the guidance warns about.

**`spec/grammar.ebnf` has no `assoc_decl` production.** `trait_decl` is `'%' IDENT type_params? '{' ( fn_header | fn_decl )* '}'` — associated types are absent, though `grammar_v2.2.ebnf` had them. The grammar is stale here, which is likely how three messages drifted to a syntax nothing enforces. Not touched: the EBNF is a spec artifact and correcting it is its own change.

**Caret placement still has no instrument** (carried from #847). The select fix moved a caret onto the right token, but nothing checks that — it was noticed by reading the golden.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_