### PR TITLE
fix(ax): the type position nothing checked, and a swap worth expecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A binding's type was the one type position nothing validated.**
+  `check_type_known` already guarded parameter, struct-field, return and
+  FFI types — and not the place a type is written most often. So
+  `: *Foo p …` against an undeclared `Foo` leaked `%Foo` into the IR,
+  nurlc exited 0, and clang objected a stage later about generated code.
+  Same helper, same wording as the parameter case, so the two now agree
+  instead of disagreeing by omission.
+
+- **`: n i 0` — the name first, then the type — said "use of undefined
+  identifier 'i'".** That is how Go and Rust spell a binding, so it is a
+  mistake worth expecting; the old answer named the token and then called
+  it the wrong thing, sending the reader to look for a binding that was
+  never the problem. A bare type keyword yields no value and so can never
+  open a legitimate initialiser: in the inference branch it is this swap
+  and nothing else, and the message now says which order NURL uses.
+
+- **An `inout` field diagnostic ended mid-quote.** `struct 'S' has no
+  field 'zz` — its `nurl_str_cat4` had no room left for the closing
+  quote, so the message trailed off exactly where the field name ended.
+
 - **Three messages taught an associated-type syntax the compiler
   rejects.** The binding is three tokens — `type Elem i` — as
   `docs/spec.md` §4.9, `docs/LIMITATIONS.md` and

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -4314,8 +4314,9 @@
     : s idx_s ( nurl_sym_get2 syms sname ( nurl_str_cat `__` ( nurl_str_cat fld `__idx` ) ) )
     : s fty ( nurl_sym_get2 syms sname ( nurl_str_cat `__` ( nurl_str_cat fld `__type` ) ) )
     ? == 0 ( nurl_str_len idx_s )
-    { ( die lex ( nurl_str_cat4
-        `inout field argument: struct '` sname `' has no field '` fld ) ) }
+    { ( die lex ( nurl_str_cat ( nurl_str_cat4
+        `inout field argument: struct '` sname `' has no field '` fld )
+        `'. The field form is '( f inout . <binding> <field> )' — check the spelling against the struct's declaration.` ) ) }
     {}
     : s gep ( nurl_cg_reg cg )
     ( nurl_print `  ` ) ( nurl_print gep )
@@ -12950,6 +12951,22 @@
         ( __warn_if_shadows_param lex syms name )
         ( lint_note_bind lex name )
         ( nurl_lex_advance lex )
+        // `: n i 0` — the name first and the type second, which is how
+        // Go and Rust spell it. NURL puts the TYPE first. Reaching this
+        // branch already means the first token was NOT a known type, so
+        // a type keyword sitting in the VALUE slot is that swap and
+        // nothing else: a bare type keyword yields no value, so it can
+        // never legitimately open an initialiser. Left alone it reached
+        // gen_ident and came back as "use of undefined identifier 'i'"
+        // — which names the token and then calls it the wrong thing,
+        // sending the reader to look for a binding that was never the
+        // problem.
+        ? == ( nurl_lex_type lex ) TT_TYPE_KW
+        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+            `'` ( nurl_lex_val lex ) `' is a type, and it is sitting where the VALUE belongs. A binding is ': type name value' — the type comes FIRST: write ': `
+            ( nurl_str_cat4 ( nurl_lex_val lex ) ` ` name ` <value>' ` ) )
+            `instead. The type may also be left out entirely when the value's type is inferable: ': n 0'.` ) ) }
+        {}
         : b rhs_is_slice_lit == ( nurl_lex_type lex ) TT_LBRACK
         // Borrow checker (Phase 2): snapshot the RHS's first token —
         // a bare identifier RHS is a binding-to-binding alias copy.
@@ -13134,6 +13151,12 @@
     // Explicit type annotation.
     { ( nurl_sym_def g_res_type_syms `__last_res_nurl__` `` )
         : s ptype ( parse_type lex )
+        // A binding's type went unchecked while parameter, field, return
+        // and FFI types were all validated — so `: Foo x 0` against an
+        // undeclared Foo built a `%Foo` binding and failed later as
+        // "use of undefined identifier 'x'", blaming the NAME. Same
+        // helper, same wording as the parameter case, so the two agree.
+        ( check_type_known lex syms ptype `a binding type` )
         // Capture the NURL form of `! T E` when present, so gen_match can
         // recover the inner T (e.g. `Json`) for struct-handle reconstruction.
         // parse_type's recursive descent through parse_type_res leaves the

--- a/compiler/tests/diag_bad_type_token.nu
+++ b/compiler/tests/diag_bad_type_token.nu
@@ -1,0 +1,7 @@
+// diag_bad_type_token.nu — a literal where the type belongs. The message
+// is the one place the whole type vocabulary is listed, so it is worth
+// holding against a golden.
+@ main → i {
+    : 5 n 0
+    ^ n
+}

--- a/compiler/tests/diag_bind_bool_literal_name.nu
+++ b/compiler/tests/diag_bind_bool_literal_name.nu
@@ -1,0 +1,6 @@
+// diag_bind_bool_literal_name.nu — 'T' as a binding name. Models reach
+// for T as a type variable, and in NURL it is the true literal.
+@ main → i {
+    : i T 5
+    ^ T
+}

--- a/compiler/tests/diag_bind_name_before_type.nu
+++ b/compiler/tests/diag_bind_name_before_type.nu
@@ -1,0 +1,13 @@
+// diag_bind_name_before_type.nu — ': name type value', the order Go and
+// Rust use. NURL puts the type first.
+//
+// The type keyword reached gen_ident and came back as "use of undefined
+// identifier 'i'" — naming the token and then calling it the wrong
+// thing, which sends the reader looking for a binding that was never the
+// problem. A bare type keyword yields no value, so it can never open a
+// legitimate initialiser; in the inference branch it is this swap and
+// nothing else.
+@ main → i {
+    : n i 0
+    ^ n
+}

--- a/compiler/tests/diag_bind_unknown_ptr_type.nu
+++ b/compiler/tests/diag_bind_unknown_ptr_type.nu
@@ -1,0 +1,11 @@
+// diag_bind_unknown_ptr_type.nu — a binding whose type names a struct
+// that was never declared.
+//
+// check_type_known already guarded parameter, struct-field, return and
+// FFI types; the binding — the place a type is written most often — was
+// the one position it never covered, so '%Foo' leaked into the IR and
+// only clang objected, far from the source.
+@ main → i {
+    : *Foo p ( nurl_alloc 8 )
+    ^ 0
+}

--- a/compiler/tests/diag_binop_oror_int.nu
+++ b/compiler/tests/diag_binop_oror_int.nu
@@ -1,0 +1,9 @@
+// diag_binop_oror_int.nu — '||' with an integer on the left. '||' and
+// '&&' are bool-only and short-circuit; '|' and '&' are the bitwise
+// pair. The cure is to compare the integer, not to cast it.
+@ main → i {
+    : i n 3
+    : b r || n T
+    ? r { ^ 1 } {}
+    ^ 0
+}

--- a/compiler/tests/diag_inout_field_unknown.nu
+++ b/compiler/tests/diag_inout_field_unknown.nu
@@ -1,0 +1,12 @@
+// diag_inout_field_unknown.nu — an inout field target naming a field the
+// struct does not have. The message used to end mid-quote ("has no field
+// 'zz") because its nurl_str_cat4 had no room left for the closing one.
+: S { i a }
+
+@ bump inout i x → v { = x + x 1 }
+
+@ main → i {
+    : ~ S s @ S { 1 }
+    ( bump . s zz )
+    ^ . s a
+}

--- a/compiler/tests/diag_lex_malformed_binary.nu
+++ b/compiler/tests/diag_lex_malformed_binary.nu
@@ -1,0 +1,6 @@
+// diag_lex_malformed_binary.nu — '0b' with no digits, the twin of
+// diag_lex_malformed_hex.
+@ main → i {
+    : i n 0b
+    ^ n
+}

--- a/compiler/tests/diag_match_arm_no_arrow.nu
+++ b/compiler/tests/diag_match_arm_no_arrow.nu
@@ -1,0 +1,9 @@
+// diag_match_arm_no_arrow.nu — a match arm that goes straight from the
+// payload binding to the body, with no '→'.
+: | E { A i B }
+
+@ main → i {
+    : E e @ E { A 1 }
+    : i r ?? e { A v { ^ v } B → 0 }
+    ^ r
+}

--- a/compiler/tests/diag_orpattern_bool_arm.nu
+++ b/compiler/tests/diag_orpattern_bool_arm.nu
@@ -1,0 +1,15 @@
+// diag_orpattern_bool_arm.nu — an or-pattern mixing an option arm 'T'
+// with a named variant.
+//
+// Note which program reaches this: NOT 'T | F', which the message names.
+// 'F' is a bool token, not an ident, so 'T | F' dies one check earlier
+// with "expected a variant name after '|'". The message is reachable
+// only through a mixed alternative like 'T | A', so its rule is right
+// and its example describes a case it never sees.
+: | E { A B }
+
+@ main → i {
+    : ?i o @ ?i { T 5 }
+    : i r ?? o { T | A → 1 _ → 0 }
+    ^ r
+}

--- a/compiler/tests/diag_orpattern_option_tf.nu
+++ b/compiler/tests/diag_orpattern_option_tf.nu
@@ -1,0 +1,10 @@
+// diag_orpattern_option_tf.nu — 'T | F' written as an or-pattern over an
+// option. T and F are the only two arms an option has, so the
+// or-pattern IS the wildcard and the message says to write '_'.
+$ `stdlib/core/string.nu`
+
+@ main → i {
+    : ?i o @ ?i { T 5 }
+    : i r ?? o { T | F → 1 }
+    ^ r
+}

--- a/compiler/tests/diag_select_arm_body_unbraced.nu
+++ b/compiler/tests/diag_select_arm_body_unbraced.nu
@@ -1,0 +1,9 @@
+// diag_select_arm_body_unbraced.nu — a select arm body written bare.
+// Every select arm body is braced, even a one-expression one.
+$ `stdlib/std/channel.nu`
+
+@ main → i {
+    : ( Channel i ) c ( chan_new [i] )
+    ?? { [i] c → v ^ 0 }
+    ^ 0
+}

--- a/compiler/tests/diag_select_arm_unterminated.nu
+++ b/compiler/tests/diag_select_arm_unterminated.nu
@@ -1,0 +1,10 @@
+// diag_select_arm_unterminated.nu — a select arm whose '[' never closes.
+// The scan runs to EOF, so the diagnostic has no useful token to point
+// at and must carry the whole arm shape in the text instead.
+$ `stdlib/std/channel.nu`
+
+@ main → i {
+    : ( Channel i ) c ( chan_new [i] )
+    ?? { [i c → v {} }
+    ^ 0
+}

--- a/compiler/tests/diag_str_len_on_string.nu
+++ b/compiler/tests/diag_str_len_on_string.nu
@@ -1,0 +1,11 @@
+// diag_str_len_on_string.nu — 'nurl_str_len' handed a %String. The two
+// length functions are not interchangeable and the names give no hint
+// which is which, so the message has to name the other one.
+$ `stdlib/core/string.nu`
+
+@ main → i {
+    : String s ( string_from `hi` )
+    : i n ( nurl_str_len s )
+    ( string_free s )
+    ^ n
+}

--- a/compiler/tests/diag_string_len_on_cstr.nu
+++ b/compiler/tests/diag_string_len_on_cstr.nu
@@ -1,0 +1,8 @@
+// diag_string_len_on_cstr.nu — the mirror of diag_str_len_on_string:
+// 'string_len' handed a raw C-string literal.
+$ `stdlib/core/string.nu`
+
+@ main → i {
+    : i n ( string_len `hi` )
+    ^ n
+}

--- a/compiler/tests/outputs/diag_bad_type_token.txt
+++ b/compiler/tests/outputs/diag_bad_type_token.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bad_type_token.nu:5:7: error: expected a type, found '5'. Types are the single-letter keywords 'i u f b s v', a fixed width like 'i32' / 'u64', a declared struct or enum name, or a parenthesised form: '( Vec i )', '( @ i i )' for a closure, '*T' for a pointer, '?T' for an option, '!T E' for a result.
+    : 5 n 0
+      ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_bind_bool_literal_name.txt
+++ b/compiler/tests/outputs/diag_bind_bool_literal_name.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bind_bool_literal_name.nu:4:9: error: expected variable name in let — 'T' and 'F' are the boolean literals and cannot name a binding; pick another name
+    : i T 5
+        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_bind_name_before_type.txt
+++ b/compiler/tests/outputs/diag_bind_name_before_type.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bind_name_before_type.nu:11:9: error: 'i' is a type, and it is sitting where the VALUE belongs. A binding is ': type name value' — the type comes FIRST: write ': i n <value>' instead. The type may also be left out entirely when the value's type is inferable: ': n 0'.
+    : n i 0
+        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_bind_unknown_ptr_type.txt
+++ b/compiler/tests/outputs/diag_bind_unknown_ptr_type.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bind_unknown_ptr_type.nu:9:12: error: unknown type 'Foo' in a binding type — no struct or enum with this name is declared (a typo, or a missing '$' import?)
+    : *Foo p ( nurl_alloc 8 )
+           ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_binop_oror_int.txt
+++ b/compiler/tests/outputs/diag_binop_oror_int.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_binop_oror_int.nu:6:16: error: operator '||' requires bool operands and the left one is not bool. '||' and '&&' short-circuit and are bool-only; for bitwise work on integers use '|' and '&'. To test an integer, compare it: '|| != n 0 ( f )'.
+    : b r || n T
+               ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_inout_field_unknown.txt
+++ b/compiler/tests/outputs/diag_inout_field_unknown.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_inout_field_unknown.nu:10:19: error: inout field argument: struct 'S' has no field 'zz'. The field form is '( f inout . <binding> <field> )' — check the spelling against the struct's declaration.
+    ( bump . s zz )
+                  ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_lex_malformed_binary.txt
+++ b/compiler/tests/outputs/diag_lex_malformed_binary.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_lex_malformed_binary.nu:4:9: error: malformed binary literal — '0b' must be followed by at least one 0 or 1. E.g. '0b1011'.
+    : i n 0b
+        ^

--- a/compiler/tests/outputs/diag_match_arm_no_arrow.txt
+++ b/compiler/tests/outputs/diag_match_arm_no_arrow.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_match_arm_no_arrow.nu:7:22: error: expected '→' or a payload name after the variant, found '{'. A match arm binds its payload before the arrow: '?? r { T v → body  F e → body }'. A payload-less variant goes straight to the arrow: 'JNull → body'.
+    : i r ?? e { A v { ^ v } B → 0 }
+                     ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_orpattern_bool_arm.txt
+++ b/compiler/tests/outputs/diag_orpattern_bool_arm.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_orpattern_bool_arm.nu:13:28: error: an or-pattern lists named enum variants; 'T' and 'F' are the option/result arms and there are only two of them, so 'T | F' is the wildcard. Write '_ → body' instead.
+    : i r ?? o { T | A → 1 _ → 0 }
+                           ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_orpattern_option_tf.txt
+++ b/compiler/tests/outputs/diag_orpattern_option_tf.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_orpattern_option_tf.nu:8:22: error: expected a variant name after '|', found 'F'. An or-pattern lists bare variant names: 'A | B | C → body'. The variants must belong to the same enum, carry no payload, and the arm takes no guard.
+    : i r ?? o { T | F → 1 }
+                     ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_select_arm_body_unbraced.txt
+++ b/compiler/tests/outputs/diag_select_arm_body_unbraced.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_select_arm_body_unbraced.nu:7:22: error: expected '{' to open this select arm's body, found '^' (return). A select arm's body is always braced. A select arm is '[T] chan → name { body }' — the element type in brackets, the channel, then the name the received value binds to. The default arm is '_ → { body }'. E.g. '?? { [i] c → v { ( use v ) }  _ → { ( idle ) } }'.
+    ?? { [i] c → v ^ 0 }
+                     ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_select_arm_unterminated.txt
+++ b/compiler/tests/outputs/diag_select_arm_unterminated.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_select_arm_unterminated.nu:11:1: error: unterminated '[' in a select arm — expected ']' after the element type. A select arm is '[T] chan → name { body }' — the element type in brackets, the channel, then the name the received value binds to. The default arm is '_ → { body }'. E.g. '?? { [i] c → v { ( use v ) }  _ → { ( idle ) } }'.
+
+^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_str_len_on_string.txt
+++ b/compiler/tests/outputs/diag_str_len_on_string.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_str_len_on_string.nu:8:28: error: nurl_str_len expects 's' (i8* C-string), got %String. Use 'string_len' for String values.
+    : i n ( nurl_str_len s )
+                           ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_string_len_on_cstr.txt
+++ b/compiler/tests/outputs/diag_string_len_on_cstr.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_string_len_on_cstr.nu:6:29: error: string_len expects %String, got 'i8*' (raw C-string). Use 'nurl_str_len' for raw C-string pointers.
+    : i n ( string_len `hi` )
+                            ^
+error: aborting due to 1 previous error

--- a/tools/diag_coverage_baseline.txt
+++ b/tools/diag_coverage_baseline.txt
@@ -2,9 +2,6 @@
 0837ccd0b702  trait ' ' has no associated type ' ' to bind for type ' '. An impl may only bind the associated type
 1919b534d625  volatile_store expects a typed pointer '*T' first, so it knows the width to write. Write '( volatile
 248dd68fff80  'inout' is a parameter CONVENTION, not a name: it goes before the type, as in '@ f inout ( Vec i ) v
-259c3b2d89fe  expected a type, found . Types are the single-letter keywords 'i u f b s v', a fixed width like 'i32
-262c483387aa  nurl_str_len expects 's' (i8* C-string), got %String. Use 'string_len' for String values.
-263055d8df9b  expected variable name in let — 'T' and 'F' are the boolean literals and cannot name a binding; pick
 265709a49431  argument to ' ' has enum type ' ' but the parameter is declared enum ' ' — two enums are distinct no
 34501728d174  expected the enum's name after ': |', found . A sum type is ': | Name { Variant Variant Payload ... 
 3842aa6639a4  method ' ' of trait ' ' has a 'sink' (by-value consuming) receiver — not object-safe for '% ' dispat
@@ -14,23 +11,19 @@
 3ef3446b70cc  ' ' is a compiler-auto-dropped value; passing it to a 'sink' parameter is not yet supported - pass a
 40719efb1dd5  expected a function name after '@', found . A declaration is '@ name params → ret { body }' — parame
 43a9804d1c0b  inout argument ' ' is not a binding in scope. An 'inout' argument must be a plain binding in scope, 
-4611dc344430  expected a variant name after '|', found . An or-pattern lists bare variant names: 'A | B | C → body
 46beb4c87199  method ' ' of trait ' ' mentions Self beyond the receiver (a parameter or the return type) — not obj
-4c454d4ae69a  expected '→' or a payload name after the variant, found . A match arm binds its payload before the a
 4dcc1518b953  integer literal does not fit the ' ' operand it is combined with (that type holds .. ) — NURL evalua
 50c9a5e6a8a5  cannot cast ' ' to an integer: its first field is itself an aggregate, so there is no scalar to take
 52d29a5350d6  select has no channel arms — a '?? { ... }' with only a default '_' arm would spin without ever wait
 554c34e0f923  a guard (? cond) on a wildcard arm is not supported - guard a specific pattern instead
 5ad763372c6c  method ' ' of trait ' ' has no Self receiver as its first parameter — not object-safe for '% '
 5dfdf7d4ec64  expected '{' to open the default arm's body, found . The default arm is '_ → { body }'.
-6490ab011ef9  expected '{' to open this select arm's body, found . A select arm's body is always braced. A select 
 697d73c26332  expected a binding name, found . A binding is ': type name value' — the TYPE comes before the name, 
 6a7a475738c9  an or-pattern cannot carry a guard — 'A | B ? cond → body' would have to hold for both variants and 
 70153c509a6c  inout field argument: ' ' is not a named-struct binding — the field form needs a struct with declare
 737e4e2f64a2  an or-pattern's variants cannot bind payloads — the arms would disagree about what the name holds. L
 74249aa6574f  expected a method name after '@' in this impl block, found . An impl is '% Trait Type { @ name param
 7f5fb5327ef2  element of this slice literal has type ' ' but the slice's declared element type is ' ' — a value of
-802e2cc68a45  string_len expects %String, got 'i8*' (raw C-string). Use 'nurl_str_len' for raw C-string pointers.
 812c266928da  a supertrait ':' clause belongs on the trait DECLARATION ('% Name : Base { ... }'), not on an impl. 
 88d59a9c07fe  element of this slice literal has type ' ' but the slice's declared element type is ' ' — pointer-vs
 89608f397d6c  cannot mutate immutable parameter ' ' — parameters are immutable bindings. Copy it into a ': ~' loca
@@ -42,19 +35,16 @@
 996c90fa8fe7  select has more than one default '_' arm — only one is allowed, and it runs when no channel is ready
 9a6844424ec4  type ' ' does not implement trait ' ', so it cannot be made into a '% ' object. Write the impl first
 a000cdd254fc  '#' is the cast operator; struct/enum literals use '@'. Write '@ { ... }' instead.
-a193bc7b84db  inout field argument: struct ' ' has no field '
 a7b912fa462f  expected '→' after the match guard, found . A guarded arm is 'Variant payload ? guard → body' — the 
 aba81704d0f4  inout argument to ' ' must be a mutable ': ~' binding or a '. binding field' field target, not an ex
 abd79dec9f97  '%' in a type position must be followed by a trait name (dynamic trait object '%Trait')
 ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
 ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
-aca2603b8e6a  unterminated '[' in a select arm — expected ']' after the element type. A select arm is '[T] chan → 
 ae69b52c99bd  element of this slice literal has integer type ' ' but the slice's declared element type is ' ' (a f
 af5a83d74d0f  cannot cast ' ' to an integer — '# i expr' converts numbers and pointers, not this type. There are n
 b21046aab91d  this condition has type ' ' which has no truth value — a condition must be 'b', or an integer (teste
 b37f1893c8a8  expected a parameter name after its type, found . Parameters are written 'type name', repeated, with
 b37f1893c8a8  expected a parameter name after its type, found . Parameters are written 'type name', repeated, with
-b76f8600bceb  malformed binary literal — '0b' must be followed by at least one 0 or 1. E.g. '0b1011'.
 bde8adc30e81  inout field argument: ' ' is not a struct binding in scope. An 'inout' argument must be a plain bind
 c5d859907bb0  operator '&&' requires bool operands and the left one is not bool. '&&' and '||' short-circuit and a
 c6d6dadc45c0  operator mixes float operands of different widths: left is ' ', right is ' ' — NURL has no implicit 
@@ -65,11 +55,9 @@ dbb6645738fc  ( in type position must be followed by @ or type name
 e13f6093bfb5  expected '{' to open the closure body, found . A closure is '\\ params → ret { body }' — the body is
 ea01dc19d4df  volatile_load expects a typed pointer '*T', so it knows the width to read. Write '( volatile_load p 
 ea026f9d2966  this condition produces no value (the expression is 'v'/void — a call that returns nothing?) — a con
-f61ec29769e4  an or-pattern lists named enum variants; 'T' and 'F' are the option/result arms and there are only t
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
-f88236bbf2cf  operator '||' requires bool operands and the left one is not bool. '||' and '&&' short-circuit and a


### PR DESCRIPTION
## Why

Third pass over the never-fired list (#847, #848). Three defects, and the first is a **hole rather than a wording problem** — the kind a source scan structurally cannot find, because there is no message at the site to score.

**`check_type_known` guards four type positions and skipped the one that matters most.** It runs on parameter types, struct field types, return types, and both FFI positions. Not on a binding — where a type gets written more often than all four combined:

```
@ f Bar b → i { … }      → unknown type 'Bar' in a parameter type …
: *Foo p ( nurl_alloc 8 ) → (nothing; %Foo leaks into the IR, exit 0)
```

nurlc emits the undefined `%Foo`, exits 0, and clang objects a stage later about generated code. The two positions disagreed only by omission.

**`: n i 0` said "use of undefined identifier 'i'".** Go writes `var n int`, Rust writes `let n: i64`; both put the name first, so this is a mistake to expect rather than be surprised by. The old answer names the token and then calls it the wrong kind of thing — the reader goes looking for a binding that was never the problem, while `i` is sitting right there as a type keyword.

**An `inout` field diagnostic ended mid-quote:**

```
error: inout field argument: struct 'S' has no field 'zz
```

Its `nurl_str_cat4` had run out of parts before the closing quote. Small, but it reads as a truncated stream rather than a finished sentence.

## What

- **`check_type_known` now runs on binding types too** — same helper, same wording as the parameter case, so the positions agree. Catches the compound forms (`*Foo`, `?Foo`, `( Vec Foo )`); a bare `: Foo x 0` still takes the inference branch by design, since an unknown leading ident *is* how `: name value` is spelled.
- **A type keyword in the value slot of an inferred binding** now names the swap and the order. Deliberately narrow: reaching that branch already means the first token was not a known type, and a bare type keyword yields no value, so it cannot be anything else.
- **The `inout` field message closes its quote** and adds the form.

**Fourteen `diag_*` tests.** Eleven cover messages that were already right and had simply never been printed: the type-vocabulary list, the bool-literal binding name, `||` on an integer, a match arm with no arrow, both string-length mix-ups, three select-arm shapes, the malformed binary literal, and the or-pattern bool arm.

**Coverage: 153 of 223 exercised, up from 140 of 222. Never-fired 75 → 63.**

## Proof

```
./compiler/tests/run_tests.sh
PASS 698 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this branch and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

Same set and count as #847 and #848 on this container; pass count moved 684 → 698 exactly as the fourteen tests were added. The binding-type check was the regression risk worth watching here — it runs on every `:` in the tree, including generic bodies and monomorphised instantiations — and the corpus stayed green, which is what `is_tparam_like` and the `__`-mangled exemption are there for.

```
./build.sh --no-tests           BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check                 compiler/nurlc.nu and all 14 new tests canonical
./tools/check_strict_arity.sh   OK — 1115 files, no arity trap
./tools/check_diag_coverage.sh  clean
```

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs.

## Known remaining

**63 sites still never fire.** Every pass so far has found either a false statement or a misdirect, so the list keeps earning the time.

**One message describes a program it can never receive.** The or-pattern bool arm names `'T | F'` — and `T | F` cannot reach it: `F` is a bool token, so it dies one check earlier as "expected a variant name after `|`". It is reachable only through a mixed alternative like `T | A`. The rule it states is correct; only the example is about an unreachable input. Left as found and documented in `diag_orpattern_bool_arm.nu`, because rewording it is a judgement call rather than a correctness fix — flagging it here rather than deciding it inside a batch.

**A top-level enum with no name still gets the generic message.** `: | { A B }` answers *"expected '{' but found 'A'"* and blames the fixed-arity operand trap. The good message — "expected the enum's name after `: |`" — lives in `parse_type_enum`, which handles `: |` in *type* position; the top-level declaration takes a different path that never consults it. Same preempted-good-message shape as the select default arm fixed in #848, but the fix is in the declaration parser rather than a one-token guard, so it wants its own pass.

**Carried from #847/#848, unchanged:** an incomplete impl still reports "call to unknown function" (needs an issue first — it is a language-surface question); `spec/grammar.ebnf` still has no `assoc_decl` production; and caret placement still has no instrument.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_