### PR TITLE
feat(ax): where a diagnostic points, not only what it says

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blocks every PR — so macOS x86_64 stays tier 3 rather than being
   claimed on a gate that never reports.
 
+- **`tools/check_diag_anchor.sh` — a diagnostic must point at the
+  mistake.** Coverage answers "has anything ever printed this?"; it
+  cannot answer "did it point at the right thing?", and the two are not
+  equally bad. A precise message against the wrong line is worse for a
+  reader than a vague one against the right line, because it sends them
+  somewhere real to look for a problem that is not there.
+
+  No annotation is needed to catch the mechanical case. Many checks can
+  only fire once their operands are consumed, and by then the lexer sits
+  past the statement — so `die lex` anchors on whatever came next. When
+  the mistake is a function's LAST statement, what came next is the
+  closing brace, and the compiler prints a caret under a `}`. The gate
+  reads the committed goldens (they already hold the location, the
+  echoed line and the caret) and rejects two shapes: an anchor line
+  holding nothing but closing delimiters, and a caret column past the
+  end of the line it echoes. Unterminated-construct messages are exempt
+  — there, end-of-input really is the subject.
+
+  **It found nine on its first run**, and a tenth once the column rule
+  was added. Fixed and held at zero, so this one gates rather than
+  ratchets.
+
 ### Fixed
+
+- **Ten diagnostics pointed somewhere the mistake could not be.** Nine
+  printed a caret under a bare `}` — closure and fn-pointer call arity,
+  dyn and impl method arity, the no-impl dispatch miss, three
+  return-type mismatches and enum arithmetic — and one printed a caret
+  two columns past the end of the line it echoed. All ten are the same
+  cause the three fixed in the previous release had: the check runs
+  after `gen_expr` has consumed the operands. Anchored with `die_stmt`,
+  which now has 17 callers, up from 7.
+
+- **A top-level sum type with no name got the generic message.**
+  `: | { A B }` answered "expected '{' but found 'A'" and blamed the
+  fixed-arity operand trap, which is not what happened: `gen_enum_decl`
+  took the name on trust, registered whatever `{` renders as, and then
+  failed at the brace it had already eaten. `parse_type_enum` had
+  carried the right message all along, but it only sees `: |` in TYPE
+  position — the top-level declaration is a different path and never
+  consulted it. Both spellings now answer alike.
 
 - **A binding's type was the one type position nothing validated.**
   `check_type_known` already guarded parameter, struct-field, return and

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -2658,7 +2658,7 @@
     { : b ret_vf | ( seq lt `double` ) ( seq lt `float` )
         : b ret_df | ( seq fn_rt `double` ) ( seq fn_rt `float` )
         ? | != ret_vf ret_df & ( is_ptr_ty lt ) ! ( is_ptr_ty fn_rt )
-        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+        { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
             `return value type '` lt `' does not match the declared return type '` fn_rt )
             `' — NURL has no implicit conversions; return a value of the declared type or convert with '# T expr'` ) ) }
         {}
@@ -2668,7 +2668,7 @@
         // accepted (rc 0) and only the LLVM verifier rejected, with a .ll
         // line number and no source location.
         ? & & ret_vf ret_df ! ( seq lt fn_rt )
-        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+        { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
             `return value type '` ( llvm_to_nurl lt ) `' does not match the declared return type '` ( llvm_to_nurl fn_rt ) )
             `' — a float width widens into a BINDING (': f x f32val' is fine), but a return type is a contract and must match exactly. Convert with '# f expr' (widen, lossless) or '# f32 expr' (narrow).` ) ) }
         {}
@@ -2683,14 +2683,14 @@
         ? & & == ( nurl_str_get ( nurl_llty lt ) 0 ) 123
         == ( nurl_str_get ( nurl_llty fn_rt ) 0 ) 123
         ! ( seq ( __strip_spaces ( nurl_llty lt ) ) ( __strip_spaces ( nurl_llty fn_rt ) ) )
-        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+        { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
             `return value type '` ( nurl_llty lt ) `' does not match the declared return type '` ( nurl_llty fn_rt ) )
             `' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.` ) ) }
         {}
         // Return the wrong named struct by value (the return-position dual of
         // the call-site struct check): `^ b` from a `→ A` fn where b is a B.
         ? ( __arg_named_struct_mismatch lt fn_rt )
-        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+        { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
             `return value type '` lt `' does not match the declared return type '` fn_rt )
             `' — wrong struct type returned by value (the fields would be silently reinterpreted)` ) ) }
         {}
@@ -2707,7 +2707,7 @@
             ? ( seq lt `i1` )
             `' — a bool widens into an integer BINDING (': i n ( > a b )' is fine), but a return type is a contract and must match exactly. Select the value you mean: '^ ? cond 1 0'.`
             `' — NURL has no implicit conversions; convert with '# T expr'`
-            ( die lex ( nurl_str_cat ( nurl_str_cat4
+            ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
             `return value type '` ( llvm_to_nurl lt ) `' does not match the declared return type '` ( llvm_to_nurl fn_rt ) )
             cure ) ) }
         {}
@@ -2739,7 +2739,7 @@
                     ( nurl_print ` undef, i64 ` ) ( nurl_print val ) ( nurl_print `, 0\n` )
                     = val __ewr
                     = lt ( nurl_str_cat fn_rt `` ) }
-                { ( die lex ( nurl_str_cat ( nurl_str_cat4
+                { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
                     `return value type '` ( llvm_to_nurl lt ) `' does not match the declared return type: enum '` __ren )
                     `' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Return a variant by name ('^ Red'), or declare a numeric return type.` ) ) } }
             {} }
@@ -3335,7 +3335,7 @@
     {}
     ? | != 0 ( nurl_str_len __eln ) != 0 ( nurl_str_len __ern ) {
         ? ! | == tt TT_EQEQ == tt TT_NE
-        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+        { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
             `operator applied to an enum operand: left is '` ( llvm_to_nurl lt )
             `', right is '` ( llvm_to_nurl rt ) )
             `' — an enum is a closed set of named variants, not a number: arithmetic and ordering have no meaning on it. Compare with '==' against a variant, match with '??', or read the tag intentionally with '# i x'.` ) ) }
@@ -3940,7 +3940,7 @@
     { ? == % __pc 2 1 { = want + want 1 } {} }
     {}
     ? != want argc
-    { ( die lex ( nurl_str_cat ( nurl_str_cat4
+    { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
         `call to '` call_name `' passes ` ( nurl_str_int argc ) )
         ( nurl_str_cat4 ` argument(s) but the declared closure/function type takes ` ( nurl_str_int want )
         ` — the emitted call would leave parameter registers unset (or drop values); the callee reads garbage. Match the declaration.` `` ) ) ) }
@@ -7953,7 +7953,7 @@
     == 0 ( nurl_sym_len2 syms fname `__arity` )
     == 0 ( nurl_sym_len2 syms fname `__ptr` )
     == 0 ( nurl_sym_len2 syms fname `__ffi` )
-    { ( die lex ( nurl_str_cat ( nurl_str_cat4
+    { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
         `method '` fname `' has no impl for receiver type '` ( llvm_to_nurl first_arg_type ) )
         `' — the name is implemented for other type(s) only. Add a '% Trait <Type> { … }' impl for this type, or pass a value of an implementing type as the first argument.` ) ) }
     {}
@@ -7964,7 +7964,7 @@
         // callee read an unset register for volume, silently.
         : s __im_ar ( nurl_sym_get g_impl_ret_syms ( nurl_str_cat impl_key `__arity` ) )
         ? & != 0 ( nurl_str_len __im_ar ) != ( nurl_str_to_int __im_ar ) arg_idx
-        { ( die lex ( nurl_str_cat ( nurl_str_cat4
+        { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
             `call to method '` fname `' for receiver type '` ( llvm_to_nurl first_arg_type ) )
             ( nurl_str_cat4 `' passes ` ( nurl_str_int arg_idx ) ` argument(s) but the impl declares ` ( nurl_str_cat ( nurl_str_int ( nurl_str_to_int __im_ar ) ) ` (receiver included) — match the declaration.` ) ) ) ) }
         {}
@@ -20235,6 +20235,18 @@
 
 @ gen_enum_decl i lex i syms → v {
     ( nurl_lex_advance lex )  // consume '|'
+    // The name was taken on trust, so `: | { A B }` registered whatever
+    // `{` renders as and then failed at the brace it had already eaten,
+    // as "expected '{' but found 'A'" blaming the fixed-arity operand
+    // trap — which is not what happened. parse_type_enum has carried the
+    // right message all along, but it only sees `: |` in TYPE position;
+    // the top-level declaration is a different path and never consulted
+    // it. Same text in both, so the two spellings answer alike.
+    ? ! ( is_ident_tok ( nurl_lex_type lex ) )
+    { ( die lex ( nurl_str_cat3
+        `expected the enum's name after ': |', found ` ( tok_here lex )
+        `. A sum type is ': | Name { Variant Variant Payload ... }' — the name comes before the brace and each variant may carry one payload type. E.g. ': | Shape { Circle f  Rect f f }'.` ) ) }
+    {}
     : s ename ( nurl_lex_val lex )
     // Same flat-namespace guard as struct types (`ty##`, shared key
     // space so a struct and an enum cannot collide either): a second

--- a/compiler/tests/README.md
+++ b/compiler/tests/README.md
@@ -53,6 +53,29 @@ gaps do not fail, a **new** die site with no test that fires it does.
 Adding a diagnostic and adding the program that triggers it are one
 change, not two.
 
+## Diagnostic anchors
+
+Coverage answers "has anything ever printed this?". It cannot answer
+"did it point at the right thing?", and the two are not equally bad: a
+precise message against the wrong line is worse than a vague one against
+the right line, because it sends the reader somewhere real to look for a
+problem that is not there.
+
+`./tools/check_diag_anchor.sh` reads the goldens — they already carry
+the location, the echoed line and the caret — and rejects two shapes
+that are wrong whatever the message says:
+
+* the anchor line holds nothing but closing delimiters (a caret under a
+  bare `}`), and
+* the caret column falls past the end of the line it echoes.
+
+Both mean the same thing: the check fired after its operands were
+consumed, so `die lex` recorded whatever came next. Use `die_stmt` (the
+statement's own start) or `die_pos` (a position captured before
+advancing) at those sites. Unterminated-construct messages are exempt —
+when the closer is what went missing, end-of-input really is the
+subject.
+
 ## Golden files (`outputs/`)
 
 One file per test, holding exactly the record the runner builds:

--- a/compiler/tests/diag_enum_decl_no_name.nu
+++ b/compiler/tests/diag_enum_decl_no_name.nu
@@ -1,0 +1,11 @@
+// diag_enum_decl_no_name.nu — a top-level sum type with no name.
+//
+// gen_enum_decl took the name on trust, so this registered whatever '{'
+// renders as and then failed at the brace it had already eaten — as
+// "expected '{' but found 'A'", blaming the fixed-arity operand trap,
+// which is not what happened. parse_type_enum had carried the right
+// message all along, but it only sees ': |' in TYPE position; the
+// top-level declaration is a different path and never consulted it.
+: | { A B }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/outputs/diag_closure_arity_few.txt
+++ b/compiler/tests/outputs/diag_closure_arity_few.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_closure_arity_few.nu:9:1: error: call to 'f' passes 1 argument(s) but the declared closure/function type takes 2 — the emitted call would leave parameter registers unset (or drop values); the callee reads garbage. Match the declaration.
-}
-^
+compiler/tests/diag_closure_arity_few.nu:8:5: error: call to 'f' passes 1 argument(s) but the declared closure/function type takes 2 — the emitted call would leave parameter registers unset (or drop values); the callee reads garbage. Match the declaration.
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_closure_arity_many.txt
+++ b/compiler/tests/outputs/diag_closure_arity_many.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_closure_arity_many.nu:8:1: error: call to 'f' passes 2 argument(s) but the declared closure/function type takes 1 — the emitted call would leave parameter registers unset (or drop values); the callee reads garbage. Match the declaration.
-}
-^
+compiler/tests/diag_closure_arity_many.nu:7:5: error: call to 'f' passes 2 argument(s) but the declared closure/function type takes 1 — the emitted call would leave parameter registers unset (or drop values); the callee reads garbage. Match the declaration.
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_dyn_call_arity.txt
+++ b/compiler/tests/outputs/diag_dyn_call_arity.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_dyn_call_arity.nu:15:1: error: call to 'speak' passes 0 argument(s) but the declared closure/function type takes 1 — the emitted call would leave parameter registers unset (or drop values); the callee reads garbage. Match the declaration.
-}
-^
+compiler/tests/diag_dyn_call_arity.nu:14:5: error: call to 'speak' passes 0 argument(s) but the declared closure/function type takes 1 — the emitted call would leave parameter registers unset (or drop values); the callee reads garbage. Match the declaration.
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_enum_arith.txt
+++ b/compiler/tests/outputs/diag_enum_arith.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_enum_arith.nu:10:1: error: operator applied to an enum operand: left is 'Color', right is 'i' — an enum is a closed set of named variants, not a number: arithmetic and ordering have no meaning on it. Compare with '==' against a variant, match with '??', or read the tag intentionally with '# i x'.
-}
-^
+compiler/tests/diag_enum_arith.nu:9:5: error: operator applied to an enum operand: left is 'Color', right is 'i' — an enum is a closed set of named variants, not a number: arithmetic and ordering have no meaning on it. Compare with '==' against a variant, match with '??', or read the tag intentionally with '# i x'.
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_enum_decl_no_name.txt
+++ b/compiler/tests/outputs/diag_enum_decl_no_name.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_enum_decl_no_name.nu:9:5: error: expected the enum's name after ': |', found '{'. A sum type is ': | Name { Variant Variant Payload ... }' — the name comes before the brace and each variant may carry one payload type. E.g. ': | Shape { Circle f  Rect f f }'.
+: | { A B }
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_impl_call_arity.txt
+++ b/compiler/tests/outputs/diag_impl_call_arity.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_impl_call_arity.nu:16:1: error: call to method 'speak' for receiver type 'Dog' passes 1 argument(s) but the impl declares 2 (receiver included) — match the declaration.
-}
-^
+compiler/tests/diag_impl_call_arity.nu:15:5: error: call to method 'speak' for receiver type 'Dog' passes 1 argument(s) but the impl declares 2 (receiver included) — match the declaration.
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_method_no_impl.txt
+++ b/compiler/tests/outputs/diag_method_no_impl.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_method_no_impl.nu:18:1: error: method 'speak' has no impl for receiver type 'Cat' — the name is implemented for other type(s) only. Add a '% Trait <Type> { … }' impl for this type, or pass a value of an implementing type as the first argument.
-}
-^
+compiler/tests/diag_method_no_impl.nu:17:5: error: method 'speak' has no impl for receiver type 'Cat' — the name is implemented for other type(s) only. Add a '% Trait <Type> { … }' impl for this type, or pass a value of an implementing type as the first argument.
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ret_closure_shape.txt
+++ b/compiler/tests/outputs/diag_ret_closure_shape.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_ret_closure_shape.nu:9:1: error: return value type '{ double (i8*, double)*, i8* }' does not match the declared return type '{ i64 (i8*, i64)*, i8* }' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.
-}
-^
+compiler/tests/diag_ret_closure_shape.nu:8:5: error: return value type '{ double (i8*, double)*, i8* }' does not match the declared return type '{ i64 (i8*, i64)*, i8* }' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ret_f32_width.txt
+++ b/compiler/tests/outputs/diag_ret_f32_width.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_ret_f32_width.nu:6:25: error: return value type 'f32' does not match the declared return type 'f' — a float width widens into a BINDING (': f x f32val' is fine), but a return type is a contract and must match exactly. Convert with '# f expr' (widen, lossless) or '# f32 expr' (narrow).
-@ get f32 x → f { ^ x }
-                        ^
+compiler/tests/diag_ret_f32_width.nu:6:21: error: return value type 'f32' does not match the declared return type 'f' — a float width widens into a BINDING (': f x f32val' is fine), but a return type is a contract and must match exactly. Convert with '# f expr' (widen, lossless) or '# f32 expr' (narrow).
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ret_int_to_enum.txt
+++ b/compiler/tests/outputs/diag_ret_int_to_enum.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_ret_int_to_enum.nu:9:1: error: return value type 'i' does not match the declared return type: enum 'Color' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Return a variant by name ('^ Red'), or declare a numeric return type.
-}
-^
+compiler/tests/diag_ret_int_to_enum.nu:8:5: error: return value type 'i' does not match the declared return type: enum 'Color' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Return a variant by name ('^ Red'), or declare a numeric return type.
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ret_option_shape.txt
+++ b/compiler/tests/outputs/diag_ret_option_shape.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_ret_option_shape.nu:8:1: error: return value type '{ i1, double }' does not match the declared return type '{ i1, i64 }' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.
-}
-^
+compiler/tests/diag_ret_option_shape.nu:7:5: error: return value type '{ i1, double }' does not match the declared return type '{ i1, i64 }' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.
 error: aborting due to 1 previous error

--- a/tools/check_diag_anchor.py
+++ b/tools/check_diag_anchor.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Dual-licensed under MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE) at your option.
+# ============================================================
+#  check_diag_anchor.py — the analysis half of check_diag_anchor.sh.
+#
+#  Reads the committed goldens (they already hold `file:line:col:` plus
+#  the echoed source line and caret) and reports diagnostics anchored
+#  somewhere the mistake cannot be.
+#
+#  Runnable directly for the report:
+#     python3 tools/check_diag_anchor.py compiler/tests report
+# ============================================================
+"""Where a diagnostic points, not what it says.
+
+check_diag_coverage.sh answers "has anything ever printed this?".
+It cannot answer "did it point at the right thing?" — and a precise
+message against the wrong line is worse for a reader than a vague one
+against the right line, because it sends them somewhere real to look for
+a problem that is not there.
+
+The objectively-wrong case is mechanical: an anchor line whose entire
+content is closing delimiters. `}` is never the subject of a diagnostic;
+it is where the parser noticed, one statement after the cause. Checks
+that fire only once their operands are consumed land here by default,
+which is what `die_stmt` and `die_pos` exist to prevent.
+
+The second rule catches the same cause where the first cannot see it: a
+caret printed past the end of the line it echoes points at nothing at
+all, and that survives whenever the offending statement is not the last
+one in its block.
+
+Genuinely unterminated constructs are the exception to both and are
+exempted by message text: when the closer is what went missing,
+end-of-input IS the subject.
+"""
+import os
+import re
+import sys
+
+# The whole content of an anchor line, when it is only structure.
+CLOSERS_ONLY = re.compile(r"^[)\]}\s]+$")
+
+# Messages whose subject really is the end of the input.
+AT_EOF_OK = re.compile(
+    r"\b(unterminated|unclosed|end of (file|input)|reached EOF|missing '\}')",
+    re.I)
+
+# `<path>:<line>:<col>: error|warning: <msg>` — the shape all four
+# emitters print. die_at has no column and is skipped: with no column
+# there is no caret to misplace.
+DIAG = re.compile(r"^(?P<path>[^\s:]+\.nu):(?P<line>\d+):(?P<col>\d+): "
+                  r"(?P<sev>error|warning): (?P<msg>.*)$")
+
+
+def anchors(golden_path, tests_dir):
+    """Every (test, line, col, msg) a golden records."""
+    out = []
+    with open(golden_path, encoding="utf-8", errors="replace") as fh:
+        for rec in fh:
+            m = DIAG.match(rec.rstrip("\n"))
+            if not m:
+                continue
+            out.append({
+                "golden": os.path.basename(golden_path),
+                # repo-relative as the runner strips it; resolved by the caller
+                "src": m.group("path"),
+                "line": int(m.group("line")),
+                "col": int(m.group("col")),
+                "msg": m.group("msg"),
+            })
+    return out
+
+
+def source_line(path, n):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for i, text in enumerate(fh, 1):
+                if i == n:
+                    return text.rstrip("\n")
+    except OSError:
+        return None
+    return None
+
+
+def check(tests_dir, repo_root):
+    bad = []
+    outdir = os.path.join(tests_dir, "outputs")
+    for fn in sorted(os.listdir(outdir)):
+        if not fn.endswith(".txt"):
+            continue
+        for a in anchors(os.path.join(outdir, fn), tests_dir):
+            src = a["src"] if os.path.isabs(a["src"]) \
+                else os.path.join(repo_root, a["src"])
+            text = source_line(src, a["line"])
+            if text is None:
+                continue  # the diagnostic names a file the golden does not carry
+            if AT_EOF_OK.search(a["msg"]):
+                continue
+            if CLOSERS_ONLY.match(text) and text.strip():
+                a["text"] = text.strip()
+                a["why"] = f'anchored on "{text.strip()}"'
+                bad.append(a)
+            elif a["col"] > len(text):
+                # The caret is printed past the end of the line it echoes,
+                # so it points at nothing at all. Same cause as the `}`
+                # case — the check ran after the token was consumed — but
+                # it survives when the statement is not the last one, so
+                # the closing-delimiter rule alone does not see it.
+                a["text"] = text.strip()
+                a["why"] = (f'column {a["col"]} is past the end of a '
+                            f'{len(text)}-character line')
+                bad.append(a)
+    return bad
+
+
+def main():
+    tests_dir = sys.argv[1] if len(sys.argv) > 1 else "compiler/tests"
+    mode = sys.argv[2] if len(sys.argv) > 2 else "check"
+    repo_root = os.path.abspath(os.path.join(tests_dir, "..", ".."))
+
+    bad = check(tests_dir, repo_root)
+    if mode == "keys":
+        for a in sorted(bad, key=lambda x: (x["golden"], x["line"])):
+            print(f'{a["golden"]}:{a["line"]}')
+        return 0
+
+    for a in sorted(bad, key=lambda x: (x["golden"], x["line"])):
+        print(f'{a["src"]}:{a["line"]}:{a["col"]}: {a["why"]}')
+        print(f'    {a["msg"][:150]}')
+    print(f"\nmis-anchored diagnostics: {len(bad)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_diag_anchor.sh
+++ b/tools/check_diag_anchor.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Dual-licensed under MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE) at your option.
+# ============================================================
+#  check_diag_anchor.sh — a diagnostic must point at the mistake.
+#
+#  check_diag_coverage.sh answers "has anything ever printed this?".
+#  It cannot answer "did it point at the right thing?", and the two
+#  failures are not equally bad: a precise message against the wrong
+#  line is worse for a reader than a vague message against the right
+#  one, because it sends them somewhere real to look for a problem that
+#  is not there.
+#
+#  The mechanically-wrong case needs no annotation to detect. Many
+#  checks can only fire once their operands have been consumed, and by
+#  then the lexer sits past the statement — so `die lex` anchors on
+#  whatever came next. When the mistake is in a function's LAST
+#  statement, what came next is the closing brace, and the compiler
+#  prints a caret under a `}`:
+#
+#      diag_closure_arity_few.nu:9:1: error: call to 'f' passes 1 …
+#      }
+#      ^
+#
+#  `}` is never the subject of a diagnostic. `die_stmt` (anchor at the
+#  statement) and `die_pos` (anchor at a captured token) exist to
+#  prevent exactly this; nine sites had not been told to use them.
+#
+#  Reads the committed goldens rather than recompiling — they already
+#  hold the location, the echoed line and the caret, so the check is
+#  instant and runs on every diagnostic the corpus has baselined.
+#
+#  Genuinely unterminated constructs are exempt by message text: when
+#  the closer is what went missing, end-of-input IS the subject.
+#
+#  Usage:
+#    ./tools/check_diag_anchor.sh             # gate
+#    ./tools/check_diag_anchor.sh --report    # list offenders
+#
+#  Exit codes:
+#    0 — every baselined diagnostic anchors on real code
+#    1 — at least one anchors on a closing delimiter (listed)
+#    2 — environment problem (no python3)
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+command -v python3 >/dev/null 2>&1 || { echo "error: python3 not on PATH" >&2; exit 2; }
+
+OUT="$(python3 "$SCRIPT_DIR/check_diag_anchor.py" compiler/tests report)" || exit 2
+COUNT="$(sed -n 's/^mis-anchored diagnostics: //p' <<< "$OUT")"
+
+if [[ "${COUNT:-1}" -ne 0 ]]; then
+    echo "$OUT"
+    echo
+    echo "error: $COUNT diagnostic(s) do not point at the mistake."
+    echo "  The check fires after its operands are consumed, so 'die lex' lands"
+    echo "  on the next token — the '}' when the mistake is the last statement."
+    echo "  Switch the site to 'die_stmt' (anchors at the statement start) or to"
+    echo "  'die_pos' (anchors at a position captured before advancing), then"
+    echo "  re-mint the golden with run_tests.sh --update."
+    exit 1
+fi
+
+[[ "${1:-}" == "--report" ]] && echo "$OUT"
+echo "diagnostic anchors: every baselined diagnostic points at real code."
+exit 0

--- a/tools/diag_coverage_baseline.txt
+++ b/tools/diag_coverage_baseline.txt
@@ -3,7 +3,6 @@
 1919b534d625  volatile_store expects a typed pointer '*T' first, so it knows the width to write. Write '( volatile
 248dd68fff80  'inout' is a parameter CONVENTION, not a name: it goes before the type, as in '@ f inout ( Vec i ) v
 265709a49431  argument to ' ' has enum type ' ' but the parameter is declared enum ' ' — two enums are distinct no
-34501728d174  expected the enum's name after ': |', found . A sum type is ': | Name { Variant Variant Payload ... 
 3842aa6639a4  method ' ' of trait ' ' has a 'sink' (by-value consuming) receiver — not object-safe for '% ' dispat
 39986b65138d  expected a field name or an index after '.', found . Field access is '. obj field' and element acces
 39cb62532ea8  the expression produces no value to bind or assign, but a ' ' was required. A call returning 'v', an


### PR DESCRIPTION
## Why

The last three passes (#847, #848, #851) each ended with the same line in Known remaining: **caret placement has no instrument.** Coverage answers "has anything ever printed this?" — it cannot answer "did it point at the right thing?", and the two failures are not equally bad. A precise message against the wrong line is worse for a reader than a vague one against the right line, because it sends them somewhere real to look for a problem that is not there.

This is what the compiler printed for a call with the wrong argument count:

```
diag_closure_arity_few.nu:9:1: error: call to 'f' passes 1 argument(s) but the declared closure/function type takes 2 …
}
^
```

The mistake is `( f 1 )` on line 8. The caret is under the closing brace of `main`. **The message is excellent, the test exists, the golden is committed, and the coverage gate is perfectly happy** — because the site *is* covered. Every instrument built so far was blind to this by construction.

The cause is structural and recurring: many checks can only fire once `gen_expr` has consumed their operands, and by then the lexer sits past the statement, so `die lex` records whatever came next. When the mistake is a function's last statement, what came next is `}`.

## What

**`tools/check_diag_anchor.sh` + `check_diag_anchor.py`.** No annotation needed — `}` is never the subject of a diagnostic, which is mechanical. And the goldens already hold everything required: location, echoed source line, caret. So the gate reads them rather than recompiling, and covers every diagnostic the corpus has ever baselined, instantly.

Two rules, both wrong whatever the message says:
- the anchor line holds nothing but closing delimiters;
- the caret column falls past the end of the line it echoes.

Unterminated-construct messages are exempt by message text — there, end-of-input really *is* the subject.

**Nine offenders on the first run:** closure and fn-pointer call arity, dyn and impl method arity, the no-impl dispatch miss, three return-type mismatches, enum arithmetic. All the same cause as the three fixed in #847. Anchored with `die_stmt`, whose caller count goes 7 → 17.

**The tenth arrived by accident, and is the more interesting one.** Re-minting the nine goldens broke `diag_ret_f32_width`, which shared a converted site — and its *old* golden had a caret at **column 25 of a 23-character line**, pointing past the end of the line entirely. The instrument had missed it: the closing-delimiter rule only looks at the line's content, and that statement was not the last in its block. Hence the second rule. The gate found one more defect by being wrong once.

**Held at zero rather than baselined.** There is no reason for this number to be anything but zero, and a ratchet would only make room for it not to be. Verified by reintroducing one of the fixed sites: the gate fails and names it.

**Also:** `: | { A B }` answered *"expected '{' but found 'A'"* and blamed the fixed-arity operand trap, which is not what happened. `gen_enum_decl` took the name on trust, registered whatever `{` renders as, then failed at the brace it had already eaten. `parse_type_enum` has carried the right message all along but only sees `: |` in *type* position — the top-level declaration is a different path and never consulted it. Same text in both now. (Carried from #851's Known remaining.)

**Coverage: 155 of 223 exercised, up from 153. Never-fired 63 → 62.**

## Proof

```
./compiler/tests/run_tests.sh
PASS 699 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this branch and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

Same set and count as #847, #848 and #851 on this container.

An intermediate run showed **FAIL 15** — `diag_ret_f32_width`, the stale golden described above. That was a real failure caused by this change, it is named here rather than smoothed over, and the fix was to re-mint it after confirming the new anchor is better (column 21, the returned value) than the old one (column 25, past the end of the line).

```
./build.sh --no-tests           BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check                 compiler/nurlc.nu and the new test canonical
./tools/check_strict_arity.sh   OK — 1115 files, no arity trap
./tools/check_diag_coverage.sh  clean
./tools/check_diag_anchor.sh    every baselined diagnostic points at real code
```

Ten goldens moved, all in the same direction — each diff replaces a `}`-anchored (or off-the-end) location with the offending statement's own. `die_stmt` prints no source echo or caret, which is why those goldens lose two lines each.

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs.

## Known remaining

**62 sites still never fire.**

**The anchor gate is deliberately conservative** and only catches what is wrong without knowing intent. A caret on the right line but the wrong *token* — pointing at the operator when the operand is at fault, say — still passes. Catching that needs the test to declare where it means, which is a marker convention and a bigger change; worth doing only if the conservative rules stop finding things.

**`die_stmt` trades a caret for a correct line.** It anchors at the statement start and prints no source echo, so for a call nested inside a larger statement the line is right and the column is the statement's, not the call's. `die_pos` keeps the caret but needs each site to capture a position before advancing. The ten sites converted here all take a whole statement, so the trade is clean; a future pass could promote the ones where it is not.

**Carried, unchanged:** an incomplete impl still reports "call to unknown function" (a language-surface question — wants an issue first, per CONTRIBUTING); `spec/grammar.ebnf` still has no `assoc_decl` production; and the or-pattern bool-arm message still names a program (`T | F`) that cannot reach it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_