### PR TITLE
fix(ax): a supertrait ':' that deleted an impl, and the arrow lie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A supertrait ':' written on an impl silently deleted the impl.**
+  `% Speaker : Dog { @ speak Dog self → i { ^ 1 } }` consumes `Dog` as a
+  supertrait name, which leaves the lexer on `{` — so the declaration is
+  read as a *re-declaration of the trait*, and the impl body vanishes.
+  No `speak` was emitted at all, and the program still compiled and
+  linked. The supertrait-on-impl message that exists for this can never
+  fire for that shape, because by then it is not being read as an impl.
+
+  The hole underneath was that structs, enums and impls each guard
+  against a duplicate declaration and **traits did not** — so a second
+  `% Name { … }` quietly replaced the first. Traits now carry the same
+  position-keyed guard, which makes import replay idempotent and this
+  shape an error that names both the duplicate and the impl spelling.
+
+- **`->` where NURL's `→` belongs said "expected a type".** The ASCII
+  pair does not lex as an arrow at all: `-` and `>` are two separate
+  operators, so the parse died asking for a type and never mentioned the
+  arrow. A model that cannot emit U+2192 had no way to learn that from
+  the answer. The token table was telling the same lie from the other
+  side — it rendered `TT_ARROW` as `'->'`, naming a spelling that cannot
+  produce that token, so "found '->'" sent the reader looking for two
+  characters their source does not contain. Both now say `'→'`, and the
+  minus-then-greater-than pair gets a message of its own.
+
 - **Ten diagnostics pointed somewhere the mistake could not be.** Nine
   printed a caret under a bare `}` — closure and fn-pointer call arity,
   dyn and impl method arity, the no-impl dispatch miss, three

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -472,7 +472,15 @@
         {}
         ^ lt
     }
-    { ( die lex ( nurl_str_cat3
+    {  // `@ f i x -> i` — the ASCII arrow. It is not the token: `-` and
+        // `>` lex separately, so the parse dies asking for a TYPE and the
+        // arrow is never mentioned. NURL's arrow is one character, U+2192,
+        // and a model that cannot emit it has no way to learn that from
+        // "expected a type, found '-'".
+        ? & == ( nurl_lex_type lex ) TT_MINUS == ( nurl_lex_peek_type lex ) TT_GT
+        { ( die lex `NURL's arrow is '→' (U+2192, a single character), not the two-character '->'. Write '@ f i x → i { ... }'. The ASCII pair does not lex as an arrow at all — '-' and '>' are read as two separate operators, which is why the parse asks for a type here.` ) }
+        {}
+        ( die lex ( nurl_str_cat3
         `expected a type, found ` ( tok_here lex )
         `. Types are the single-letter keywords 'i u f b s v', a fixed width like 'i32' / 'u64', a declared struct or enum name, or a parenthesised form: '( Vec i )', '( @ i i )' for a closure, '*T' for a pointer, '?T' for an option, '!T E' for a result.` ) ) }
 }
@@ -2986,7 +2994,7 @@
     ? == tt TT_LBRACK { ^ ( nurl_str_cat `'['` `` ) } {}
     ? == tt TT_AT { ^ ( nurl_str_cat `'@'` `` ) } {}
     ? == tt TT_EOF { ^ ( nurl_str_cat `end of input` `` ) } {}
-    ? == tt TT_ARROW { ^ ( nurl_str_cat `'->'` `` ) } {}
+    ? == tt TT_ARROW { ^ ( nurl_str_cat `'→'` `` ) } {}
     // Prefix operators a reader is likely to have mistyped, and the two
     // loop keywords. Without these each falls through to the value test
     // below, which is empty for punctuation, and the diagnostic ends up
@@ -21917,6 +21925,26 @@
     // Disambiguate: '{' → trait_decl, else → impl_decl
     ? == ( nurl_lex_type lex ) TT_LBRACE
     {  // trait: remember its type param and scan for default methods
+        // Structs (`ty##`), enums and impls all guard against a second
+        // declaration of the same name. Traits did not, and the hole is
+        // not merely cosmetic: `% Speaker : Dog { @ speak … }` — a
+        // supertrait clause written on what was meant to be an IMPL —
+        // consumes `Dog` as a supertrait, leaves the lexer on `{`, and
+        // so lands HERE instead of the impl branch. The impl silently
+        // vanished: no `speak` was emitted at all, and the program
+        // still compiled and linked. The supertrait-on-impl message
+        // below can never fire for that shape, because by then it is
+        // not being read as an impl.
+        // Same position twice is import replay, not a duplicate.
+        : s __tpos ( nurl_str_cat ( vis_current_src_file )
+        ( nurl_str_cat `:` ( nurl_str_int ( nurl_lex_line lex ) ) ) )
+        : s __tkey ( nurl_str_cat `tr##` tname )
+        : s __tprev ( nurl_sym_get g_fn_pos_syms __tkey )
+        ? & != 0 ( nurl_str_len __tprev ) ! ( seq __tprev __tpos )
+        { ( die lex ( nurl_str_cat `duplicate trait '% `
+            ( nurl_str_cat tname
+            ( nurl_str_cat3 `' — already declared at ` __tprev `. NURL has no overloading and no shadowing at file scope: rename one, or delete the duplicate. If you meant to IMPLEMENT the trait, an impl names the trait and the type with no ':' between them — '% Trait Type { ... }'; a ':' here is the supertrait clause, which belongs on the declaration.` ) ) ) ) }
+        { ( nurl_sym_def g_fn_pos_syms __tkey __tpos ) }
         ( nurl_sym_def g_trait_syms ( nurl_str_cat tname `__tparam` ) tparam )
         ( nurl_sym_def g_trait_syms ( nurl_str_cat tname `__istrait` ) `1` )
         ? != 0 ( nurl_str_len supers )

--- a/compiler/tests/diag_ascii_arrow.nu
+++ b/compiler/tests/diag_ascii_arrow.nu
@@ -1,0 +1,19 @@
+// diag_ascii_arrow.nu — '->' where NURL's '→' belongs.
+//
+// The ASCII pair does not lex as an arrow at all: '-' and '>' are two
+// separate operators, so the parse died asking for a TYPE and never
+// mentioned the arrow. A model that cannot emit U+2192 had no way to
+// learn that from "expected a type, found '-'".
+//
+// The token table was telling the same lie from the other side: it
+// rendered TT_ARROW as '->', naming a spelling that cannot produce that
+// token, so "found '->'" sent the reader looking for two characters
+// their source does not contain.
+//
+// The line below reads '- >' rather than '->' because nurlfmt made it
+// so, and that is the whole point restated by the formatter: it sees a
+// minus and a greater-than, spaces them as the two operators they are,
+// and never considers them an arrow. Both spellings reach the check.
+@ f i x - > i { ^ x }
+
+@ main → i { ^ ( f 1 ) }

--- a/compiler/tests/diag_assoc_unknown_name.nu
+++ b/compiler/tests/diag_assoc_unknown_name.nu
@@ -1,0 +1,15 @@
+// diag_assoc_unknown_name.nu — an impl binding an associated type the
+// trait never declared.
+//
+// Note the anchor: this check runs after the whole impl is scanned, so
+// it reports the line of the NEXT declaration rather than the binding's
+// own. It has no captured position to use, unlike the die_pos sites.
+// Left as found — the message names the trait, the type and the binding,
+// so it identifies itself without the line.
+: IntBox { i v }
+
+% Boxed [T] { type Elem @ unwrap T self → Elem }
+
+% Boxed IntBox { type Zzz i @ unwrap IntBox self → i { ^ . self v } }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_bind_void_call.nu
+++ b/compiler/tests/diag_bind_void_call.nu
@@ -1,0 +1,7 @@
+// diag_bind_void_call.nu — binding the result of a call that returns 'v'.
+@ nothing → v {}
+
+@ main → i {
+    : i n ( nothing )
+    ^ n
+}

--- a/compiler/tests/diag_closure_body_unbraced.nu
+++ b/compiler/tests/diag_closure_body_unbraced.nu
@@ -1,0 +1,6 @@
+// diag_closure_body_unbraced.nu — a closure body written bare. Always
+// braced, even for a single expression.
+@ main → i {
+    : ( @ i i ) f \ i x → i ^ + x 1
+    ^ 0
+}

--- a/compiler/tests/diag_cond_struct.nu
+++ b/compiler/tests/diag_cond_struct.nu
@@ -1,0 +1,8 @@
+// diag_cond_struct.nu — a struct used directly as a condition.
+: S { i a }
+
+@ main → i {
+    : S s @ S { 1 }
+    ? s { ^ 1 } {}
+    ^ 0
+}

--- a/compiler/tests/diag_cond_void_call.nu
+++ b/compiler/tests/diag_cond_void_call.nu
@@ -1,0 +1,7 @@
+// diag_cond_void_call.nu — a 'v'-returning call as a condition.
+@ nothing → v {}
+
+@ main → i {
+    ? ( nothing ) { ^ 1 } {}
+    ^ 0
+}

--- a/compiler/tests/diag_dup_trait.nu
+++ b/compiler/tests/diag_dup_trait.nu
@@ -1,0 +1,20 @@
+// diag_dup_trait.nu — a supertrait ':' clause written on what was meant
+// to be an impl.
+//
+// This was a silent miscompile, not just a missing message. The ':'
+// consumes 'Dog' as a supertrait name, which leaves the lexer on '{',
+// so the declaration is read as a re-declaration of the TRAIT rather
+// than an impl — and the impl body vanished. No 'speak' was emitted at
+// all, and the program still compiled and linked. The
+// supertrait-on-impl message can never fire for this shape, because by
+// then it is not being read as an impl.
+//
+// Structs, enums and impls all guarded against a duplicate declaration.
+// Traits were the one kind that did not, which is what let this through.
+: Dog { i age }
+
+% Speaker [T] { @ speak T self → i }
+
+% Speaker : Dog { @ speak Dog self → i { ^ 1 } }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_fn_no_name.nu
+++ b/compiler/tests/diag_fn_no_name.nu
@@ -1,0 +1,5 @@
+// diag_fn_no_name.nu — '@' followed by something that cannot name a
+// function.
+@ 5 i x → i { ^ x }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_impl_method_no_name.nu
+++ b/compiler/tests/diag_impl_method_no_name.nu
@@ -1,0 +1,9 @@
+// diag_impl_method_no_name.nu — '@' in an impl body followed by
+// something that cannot name a method.
+: Dog { i age }
+
+% Speaker [T] { @ speak T self → i }
+
+% Speaker Dog { @ 5 Dog self → i { ^ 1 } }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_param_name_entry.nu
+++ b/compiler/tests/diag_param_name_entry.nu
@@ -1,0 +1,6 @@
+// diag_param_name_entry.nu — 'entry' as a parameter name. It collides
+// with the LLVM block label the function prologue emits, so the clash
+// is real rather than stylistic.
+@ f i entry → i { ^ entry }
+
+@ main → i { ^ ( f 1 ) }

--- a/compiler/tests/diag_param_name_inout.nu
+++ b/compiler/tests/diag_param_name_inout.nu
@@ -1,0 +1,6 @@
+// diag_param_name_inout.nu — 'inout' used as a parameter NAME. It is a
+// convention that goes before the type, so this reads as a type with no
+// name after it.
+@ f i inout → i { ^ 0 }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_param_no_name.nu
+++ b/compiler/tests/diag_param_no_name.nu
@@ -1,0 +1,6 @@
+// diag_param_no_name.nu — a parameter type with no name after it.
+// Also the first test to hold the arrow's token label: it renders '→'
+// now, not the ASCII '->' that cannot produce the token.
+@ f i → i { ^ 0 }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/outputs/diag_ascii_arrow.txt
+++ b/compiler/tests/outputs/diag_ascii_arrow.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_ascii_arrow.nu:17:9: error: NURL's arrow is '→' (U+2192, a single character), not the two-character '->'. Write '@ f i x → i { ... }'. The ASCII pair does not lex as an arrow at all — '-' and '>' are read as two separate operators, which is why the parse asks for a type here.
+@ f i x - > i { ^ x }
+        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_assoc_unknown_name.txt
+++ b/compiler/tests/outputs/diag_assoc_unknown_name.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_assoc_unknown_name.nu:15:1: error: trait 'Boxed' has no associated type 'Zzz' to bind for type 'IntBox'. An impl may only bind the associated types the trait declares — check the name, or add 'type Zzz' to the trait declaration.
+@ main → i { ^ 0 }
+^

--- a/compiler/tests/outputs/diag_bind_void_call.txt
+++ b/compiler/tests/outputs/diag_bind_void_call.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bind_void_call.nu:5:5: error: the expression produces no value to bind or assign, but a 'i64' was required. A call returning 'v', an assignment or a bare block yields nothing — bind the result of an expression that produces one.
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_closure_body_unbraced.txt
+++ b/compiler/tests/outputs/diag_closure_body_unbraced.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_closure_body_unbraced.nu:4:31: error: expected '{' to open the closure body, found '^' (return). A closure is '\ params → ret { body }' — the body is ALWAYS braced, even for one expression: '\ i x → i { ^ + x 1 }'. Its type is written '( @ ret params )', e.g. '( @ i i )' for that closure.
+    : ( @ i i ) f \ i x → i ^ + x 1
+                              ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_cond_struct.txt
+++ b/compiler/tests/outputs/diag_cond_struct.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cond_struct.nu:6:9: error: this condition has type 'S' which has no truth value — a condition must be 'b', or an integer (tested non-zero). An aggregate cannot be tested directly; extract or compute the scalar you mean to test first.
+    ? s { ^ 1 } {}
+        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_cond_void_call.txt
+++ b/compiler/tests/outputs/diag_cond_void_call.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cond_void_call.nu:5:19: error: this condition produces no value (the expression is 'v'/void — a call that returns nothing?) — a condition must be 'b', or an integer tested against zero. Call something that returns a value, or bind the state you want to test first.
+    ? ( nothing ) { ^ 1 } {}
+                  ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_dup_trait.txt
+++ b/compiler/tests/outputs/diag_dup_trait.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_dup_trait.nu:18:17: error: duplicate trait '% Speaker' — already declared at compiler/tests/diag_dup_trait.nu:16. NURL has no overloading and no shadowing at file scope: rename one, or delete the duplicate. If you meant to IMPLEMENT the trait, an impl names the trait and the type with no ':' between them — '% Trait Type { ... }'; a ':' here is the supertrait clause, which belongs on the declaration.
+% Speaker : Dog { @ speak Dog self → i { ^ 1 } }
+                ^

--- a/compiler/tests/outputs/diag_fn_no_name.txt
+++ b/compiler/tests/outputs/diag_fn_no_name.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_fn_no_name.nu:3:3: error: expected a function name after '@', found '5'. A declaration is '@ name params → ret { body }' — parameters are 'type name' pairs and the return type follows '→'. E.g. '@ add i a i b → i { ^ + a b }'. For a generic, the type list goes right after the name: '@ push [A] ( Vec A ) v A x → v { ... }'.
+@ 5 i x → i { ^ x }
+  ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_impl_method_no_name.txt
+++ b/compiler/tests/outputs/diag_impl_method_no_name.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_impl_method_no_name.nu:7:19: error: expected a method name after '@' in this impl block, found '5'. An impl is '% Trait Type { @ name params → ret { body } ... }' — every method repeats the '@ name' form the trait declared.
+% Speaker Dog { @ 5 Dog self → i { ^ 1 } }
+                  ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_param_name_entry.txt
+++ b/compiler/tests/outputs/diag_param_name_entry.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_param_name_entry.nu:4:7: error: parameter name 'entry' collides with LLVM's reserved entry: block label. Rename (e.g. 'ent', 'tab_entry').
+@ f i entry → i { ^ entry }
+      ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_param_name_inout.txt
+++ b/compiler/tests/outputs/diag_param_name_inout.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_param_name_inout.nu:4:7: error: 'inout' is a parameter CONVENTION, not a name: it goes before the type, as in '@ f inout ( Vec i ) v → v'. Rename this parameter to something else.
+@ f i inout → i { ^ 0 }
+      ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_param_no_name.txt
+++ b/compiler/tests/outputs/diag_param_no_name.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_param_no_name.nu:4:7: error: expected a parameter name after its type, found '→'. Parameters are written 'type name', repeated, with no commas: '@ f i a i b → i'. A parenthesised type keeps the pair shape: '( Vec i ) v'.
+@ f i → i { ^ 0 }
+      ^
+error: aborting due to 1 previous error

--- a/tools/diag_coverage_baseline.txt
+++ b/tools/diag_coverage_baseline.txt
@@ -1,14 +1,10 @@
 080b833f7959  unknown field or variable ' ' — it is not a field of the struct being accessed, nor a binding in sco
-0837ccd0b702  trait ' ' has no associated type ' ' to bind for type ' '. An impl may only bind the associated type
 1919b534d625  volatile_store expects a typed pointer '*T' first, so it knows the width to write. Write '( volatile
-248dd68fff80  'inout' is a parameter CONVENTION, not a name: it goes before the type, as in '@ f inout ( Vec i ) v
 265709a49431  argument to ' ' has enum type ' ' but the parameter is declared enum ' ' — two enums are distinct no
 3842aa6639a4  method ' ' of trait ' ' has a 'sink' (by-value consuming) receiver — not object-safe for '% ' dispat
 39986b65138d  expected a field name or an index after '.', found . Field access is '. obj field' and element acces
-39cb62532ea8  the expression produces no value to bind or assign, but a ' ' was required. A call returning 'v', an
 3cc2e514ea86  inout field argument to ' ' must be '. <binding> <field>' naming a plain struct binding
 3ef3446b70cc  ' ' is a compiler-auto-dropped value; passing it to a 'sink' parameter is not yet supported - pass a
-40719efb1dd5  expected a function name after '@', found . A declaration is '@ name params → ret { body }' — parame
 43a9804d1c0b  inout argument ' ' is not a binding in scope. An 'inout' argument must be a plain binding in scope, 
 46beb4c87199  method ' ' of trait ' ' mentions Self beyond the receiver (a parameter or the return type) — not obj
 4dcc1518b953  integer literal does not fit the ' ' operand it is combined with (that type holds .. ) — NURL evalua
@@ -21,12 +17,10 @@
 6a7a475738c9  an or-pattern cannot carry a guard — 'A | B ? cond → body' would have to hold for both variants and 
 70153c509a6c  inout field argument: ' ' is not a named-struct binding — the field form needs a struct with declare
 737e4e2f64a2  an or-pattern's variants cannot bind payloads — the arms would disagree about what the name holds. L
-74249aa6574f  expected a method name after '@' in this impl block, found . An impl is '% Trait Type { @ name param
 7f5fb5327ef2  element of this slice literal has type ' ' but the slice's declared element type is ' ' — a value of
 812c266928da  a supertrait ':' clause belongs on the trait DECLARATION ('% Name : Base { ... }'), not on an impl. 
 88d59a9c07fe  element of this slice literal has type ' ' but the slice's declared element type is ' ' — pointer-vs
 89608f397d6c  cannot mutate immutable parameter ' ' — parameters are immutable bindings. Copy it into a ': ~' loca
-8f1f18d7ebfd  parameter name 'entry' collides with LLVM's reserved entry: block label. Rename (e.g. 'ent', 'tab_en
 8f8423944aed  const expression must be integer literals combined with + - * / << >> & | ^^ (use a precomputed lite
 8fa0e2858d9c  unexpected where a value was required. Every NURL operator has FIXED arity and no closing bracket, s
 90e2e7e59d8d  return expression has no value (expected
@@ -41,9 +35,6 @@ ac66e0e045a5  and unknown — the operand types could not be resolved, which usu
 ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
 ae69b52c99bd  element of this slice literal has integer type ' ' but the slice's declared element type is ' ' (a f
 af5a83d74d0f  cannot cast ' ' to an integer — '# i expr' converts numbers and pointers, not this type. There are n
-b21046aab91d  this condition has type ' ' which has no truth value — a condition must be 'b', or an integer (teste
-b37f1893c8a8  expected a parameter name after its type, found . Parameters are written 'type name', repeated, with
-b37f1893c8a8  expected a parameter name after its type, found . Parameters are written 'type name', repeated, with
 bde8adc30e81  inout field argument: ' ' is not a struct binding in scope. An 'inout' argument must be a plain bind
 c5d859907bb0  operator '&&' requires bool operands and the left one is not bool. '&&' and '||' short-circuit and a
 c6d6dadc45c0  operator mixes float operands of different widths: left is ' ', right is ' ' — NURL has no implicit 
@@ -53,7 +44,6 @@ d82fbf1f85b6  an or-pattern cannot mix a literal constraint with variant names �
 dbb6645738fc  ( in type position must be followed by @ or type name
 e13f6093bfb5  expected '{' to open the closure body, found . A closure is '\\ params → ret { body }' — the body is
 ea01dc19d4df  volatile_load expects a typed pointer '*T', so it knows the width to read. Write '( volatile_load p 
-ea026f9d2966  this condition produces no value (the expression is 'v'/void — a call that returns nothing?) — a con
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic


### PR DESCRIPTION
## Why

Fifth pass over the never-fired list. It turned up a **silent miscompile**, which is a better outcome than a wording fix and not what the round was looking for.

```nurl
: Dog { i age }
% Speaker [T] { @ speak T self → i }
% Speaker : Dog { @ speak Dog self → i { ^ 1 } }   // meant as an impl
@ main → i { ^ 0 }
```

This **compiles, links, and emits no `speak` at all.** The `:` consumes `Dog` as a supertrait name, which leaves the lexer on `{`, so the whole declaration parses as a *re-declaration of the trait* and the impl body is discarded. The message written for exactly this case — *"a supertrait ':' clause belongs on the trait DECLARATION"* — can never fire for that shape, because by the time it would run the thing is not being read as an impl.

The hole underneath is a missing guard, not a missing message: **structs guard against a duplicate declaration, enums guard, impls guard, and traits did not.** A second `% Name { … }` quietly replaced the first.

**And the arrow was lying in both directions.** `@ f i x -> i` answered:

```
error: expected a type, found '-'
```

The ASCII pair does not lex as an arrow at all — `-` and `>` are two separate operators — so the parse asks for a type and never mentions the arrow. A model that cannot emit U+2192 has no way to learn that from the answer. Meanwhile `__tok_label` rendered `TT_ARROW` as `'->'`, **naming a spelling that cannot produce that token**, so every *"found '->'"* sent the reader hunting for two characters their source does not contain.

## What

- **Traits carry the same position-keyed duplicate guard** as enums, so import replay stays idempotent and the shape above becomes an error naming both the duplicate and the impl spelling the writer wanted.
- **The arrow's token label says `'→'`**, and minus-followed-by-greater-than in type position gets a message of its own.

`nurlfmt` has the last word on that second one: asked to canonicalise the new test, it rewrote `->` to `- >`, spacing the two operators as what they are. The test keeps the formatter's version — both spellings reach the check, and the rewrite states the point better than the comment does.

**Twelve `diag_*` tests.** Ten cover messages that were already right and had never been printed: struct and void conditions, binding a void call, a nameless parameter, an unbraced closure body, a nameless function, the `entry` and `inout` parameter-name clashes, a nameless impl method, an unknown associated-type binding.

**Coverage: 171 of 223 exercised, up from 155. Never-fired 62 → 52.**

## Proof

```
./compiler/tests/run_tests.sh
PASS 711 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this branch and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

Same set and count as #847, #848, #851 and #852 on this container; pass count moved 699 → 711 exactly as the twelve tests were added.

**The duplicate-trait guard was the regression risk worth naming.** A guard that fires on re-registration breaks every trait reachable through two import paths, so it is position-keyed the way the enum guard is, and `trait_assoc_import` / `trait_assoc_import_mod` are precisely that case in the corpus. Both stayed green, and the examples gate — which compiles the wider first-party tree — was run for the same reason.

```
./build.sh --no-tests           BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check                 compiler/nurlc.nu and all 12 new tests canonical
./tools/check_strict_arity.sh   OK — 1115 files, no arity trap
./tools/check_examples.sh       clean (2 skipped: optional FFI lib absent)
./tools/check_diag_anchor.sh    every baselined diagnostic points at real code
./tools/check_diag_coverage.sh  clean
```

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs.

## Known remaining

**52 sites still never fire.**

**A fifth instrument was investigated and deliberately not built.** The worst defects found across these five passes were messages teaching syntax the compiler rejects (the kwargs defaults claim, three assoc-type messages), so the obvious next gate is: *the cures a diagnostic prints must be valid NURL*. Extracting them gives 32 syntactically checkable fragments — and 30 of those use metavariables (`# T expr`, `( fn args )`, `?? x { … }`) that need a synthesised context with free names declared before they can compile. The two that are literal enough to compile standalone were checked by hand and both do. That is a large build for a small yield today; noted rather than started, and worth revisiting if the message set grows more concrete cures.

**One anchor is a line late and stays that way.** The unknown-associated-type check runs after the whole impl is scanned, so it reports the line of the *next* declaration. It has no captured position to use, unlike the `die_pos` sites, and the message names the trait, the type and the binding — so it identifies itself without the line. Documented in `diag_assoc_unknown_name.nu`. The anchor gate does not catch this class by design (right file, wrong line, real code on it); catching it needs the test to declare where it means, which is the marker convention deferred in #852.

**Carried, unchanged:** an incomplete impl still reports "call to unknown function" (a language-surface question — wants an issue first, per CONTRIBUTING); `spec/grammar.ebnf` still has no `assoc_decl` production; the or-pattern bool-arm message still names a program (`T | F`) that cannot reach it; and `%` in a const expression (`: i K % 7 2`) is read as a trait-object sigil, so the const-expression message is preempted by a type error.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_