### PR TITLE
fix(ax): an empty GEP operand, and a range that was not the type's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Assigning to a field of a by-value struct parameter emitted invalid
+  IR, silently.** A by-value struct parameter has no alloca to GEP from,
+  so `= . s a 5` printed `getelementptr %S, %S* , i32 0, i32 0` — with
+  an **empty pointer operand** — and nurlc exited 0. Only clang objected,
+  as "expected value token" against generated IR the author never wrote.
+  Rejected at the source now, naming both cures: take the argument as
+  `inout` if the caller should see the write, or copy it into a `: ~`
+  local first.
+
+- **"that type holds -128..255" is not true of `i8`.** The narrow-operand
+  literal check accepts the signed range *union* the unsigned one,
+  because it does not read the operand's signedness — so the window is a
+  fact about eight bits, not about `i8`, which holds -128..127. Stating
+  it as the type's range taught a rule the language does not have. The
+  semantics are unchanged; only the claim is.
+
 - **A supertrait ':' written on an impl silently deleted the impl.**
   `% Speaker : Dog { @ speak Dog self → i { ^ 1 } }` consumes `Dog` as a
   supertrait name, which leaves the lexer on `{` — so the declaration is

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -597,7 +597,7 @@
             {}
             ^ ( nurl_str_cat `%` ( nurl_str_cat sname mangle_sfx ) )
         }
-        { ( die lex `( in type position must be followed by @ or type name` ) ^ ( nurl_str_cat `i64` `` ) }
+        { ( die lex ( nurl_str_cat3 `a parenthesised type must open with '@' or a type name, found ` ( tok_here lex ) `. There are exactly two parenthesised forms: a closure type '( @ ret params )' — the RETURN type first, as in '( @ i i )' for a closure taking an i and returning one — and a generic instantiation '( Name T )', as in '( Vec i )' or '( Channel String )'. Parentheses are not grouping here; a plain type needs none.` ) ) ^ ( nurl_str_cat `i64` `` ) }
     }
 }
 
@@ -3527,8 +3527,8 @@
                 ? | < __cv __rlo > __cv __rhi
                 { ( die lex ( nurl_str_cat ( nurl_str_cat4
                     `integer literal ` ( nurl_str_int __cv ) ` does not fit the '` ( llvm_to_nurl ? __l_reg lt rt ) )
-                    ( nurl_str_cat3 `' operand it is combined with (that type holds ` ( nurl_str_int __rlo )
-                    ( nurl_str_cat3 `..` ( nurl_str_int __rhi ) `) — NURL evaluates the operator at the typed operand's width. Widen the typed operand with '# i expr', or use a literal in range.` ) ) ) ) }
+                    ( nurl_str_cat3 `' operand it is combined with. NURL evaluates the operator at the typed operand's width, and ` ( nurl_str_int __regw )
+                    ( nurl_str_cat3 ` bits accept ` ( nurl_str_cat4 ( nurl_str_int __rlo ) `..` ( nurl_str_int __rhi ) ` — the signed range union the unsigned one, since the check does not read the operand's signedness. Widen the typed operand with '# i expr', or use a literal in range.` ) `` ) ) ) ) }
                 { = __arith_ty ? __l_reg ( nurl_str_cat lt `` ) ( nurl_str_cat rt `` ) }
             } {}
         }
@@ -14070,6 +14070,19 @@
             }
             {  // Struct by value "%T": use alloca ptr from obj_name__ptr as GEP base
                 : s alloca_ptr ( nurl_sym_get2 syms obj_name `__ptr` )
+                // No alloca means the object has no storage to write
+                // through: a by-value struct PARAMETER (parameters are
+                // immutable bindings and arrive in registers), or a
+                // temporary. The GEP was emitted with an empty pointer
+                // operand — `getelementptr %S, %S* , i32 0, i32 0` —
+                // which nurlc printed with status 0 and only clang
+                // rejected, as "expected value token" against generated
+                // IR. Reject it at the source instead.
+                ? == 0 ( nurl_str_len alloca_ptr )
+                { ( die lex ( nurl_str_cat ( nurl_str_cat4
+                    `cannot assign to a field of '` obj_name `': it is a by-value ` ( llvm_to_nurl pt ) )
+                    ` with no storage to write through — a parameter (parameters are immutable bindings and arrive by value), or a temporary. Take the argument as 'inout' if the caller should see the write ('@ f inout S s → v'), or copy it into a mutable local first (': ~ S t s', then '= . t <field> <value>').` ) ) }
+                {}
                 : s pt_ptr ( nurl_str_cat pt `*` )
                 : s sname ( nurl_str_slice pt 1 - ptlen 1 )
                 : s fname ( nurl_lex_val lex )

--- a/compiler/tests/diag_dyn_no_impl.nu
+++ b/compiler/tests/diag_dyn_no_impl.nu
@@ -1,0 +1,13 @@
+// diag_dyn_no_impl.nu — 'dyn' over a type with no impl of the trait.
+% Speaker [T] { @ speak T self → i }
+
+: Dog { i pitch }
+: Cat { i lives }
+
+% Speaker Dog { @ speak Dog d → i { ^ . d pitch } }
+
+@ main → i {
+    : Cat c @ Cat { 9 }
+    : %Speaker s ( dyn Speaker c )
+    ^ 0
+}

--- a/compiler/tests/diag_dyn_not_generic.nu
+++ b/compiler/tests/diag_dyn_not_generic.nu
@@ -1,0 +1,11 @@
+// diag_dyn_not_generic.nu — a '%Trait' object over a trait that is not
+// generic over Self.
+% Speaker { @ speak i self → i }
+
+: Dog { i pitch }
+
+% Speaker Dog { @ speak Dog d → i { ^ . d pitch } }
+
+@ announce %Speaker s → i { ^ ( speak s ) }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_dyn_self_in_return.nu
+++ b/compiler/tests/diag_dyn_self_in_return.nu
@@ -1,0 +1,12 @@
+// diag_dyn_self_in_return.nu — a trait method naming Self past the
+// receiver. The vtable has one entry per method and no way to say which
+// concrete type comes back, so the trait is not object-safe.
+% Maker [T] { @ make T self → T }
+
+: Dog { i pitch }
+
+% Maker Dog { @ make Dog d → Dog { ^ d } }
+
+@ use %Maker m → i { ^ 0 }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_field_store_by_value_param.nu
+++ b/compiler/tests/diag_field_store_by_value_param.nu
@@ -1,0 +1,22 @@
+// diag_field_store_by_value_param.nu — assigning to a field of a
+// by-value struct parameter.
+//
+// This was a silent invalid-IR bug, not a missing message. A by-value
+// struct parameter has no alloca to GEP from, so the store emitted
+//
+//     %r1 = getelementptr %S, %S* , i32 0, i32 0
+//
+// with an EMPTY pointer operand. nurlc printed it with status 0 and
+// only clang objected, as "expected value token" against generated IR
+// the author never wrote.
+: S { i a }
+
+@ f S s → i {
+    = . s a 5
+    ^ . s a
+}
+
+@ main → i {
+    : S s @ S { 1 }
+    ^ ( f s )
+}

--- a/compiler/tests/diag_float_width_mix.nu
+++ b/compiler/tests/diag_float_width_mix.nu
@@ -1,0 +1,9 @@
+// diag_float_width_mix.nu — f32 and f in one operator. Both directions
+// of the cure are named, since which one is right depends on whether
+// the caller can afford the narrowing.
+@ main → i {
+    : f32 a 1.5
+    : f b 2.5
+    : f r + a b
+    ^ 0
+}

--- a/compiler/tests/diag_int_lit_width_range.nu
+++ b/compiler/tests/diag_int_lit_width_range.nu
@@ -1,0 +1,14 @@
+// diag_int_lit_width_range.nu — a literal too large for the narrow
+// operand it is combined with.
+//
+// The message used to report the accepted window as "that type holds
+// -128..255", which is false of 'i8': i8 holds -128..127. The window is
+// the signed range UNION the unsigned one, because the check does not
+// read the operand's signedness — so it is a fact about eight bits, not
+// about i8. Stating it as the type's range taught a model a rule the
+// language does not have. The semantics are unchanged; only the claim is.
+@ main → i {
+    : i8 n 5
+    : i8 r + n 9999
+    ^ 0
+}

--- a/compiler/tests/diag_paren_type_bad.nu
+++ b/compiler/tests/diag_paren_type_bad.nu
@@ -1,0 +1,8 @@
+// diag_paren_type_bad.nu — parentheses in type position used as
+// grouping. They are not: there are exactly two parenthesised type
+// forms, and the message now names both rather than only listing what
+// was expected.
+@ main → i {
+    : ( 5 ) x 0
+    ^ 0
+}

--- a/compiler/tests/diag_pct_not_trait.nu
+++ b/compiler/tests/diag_pct_not_trait.nu
@@ -1,0 +1,5 @@
+// diag_pct_not_trait.nu — '%' in type position followed by something
+// that cannot name a trait.
+@ f %5 x → i { ^ 0 }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_slice_elem_int_for_float.nu
+++ b/compiler/tests/diag_slice_elem_int_for_float.nu
@@ -1,0 +1,6 @@
+// diag_slice_elem_int_for_float.nu — integer literals in a float slice.
+// The cure is the spelling ('2.0', not '2'), which the message shows.
+@ main → i {
+    : [f xs [f | 1 2 3]
+    ^ 0
+}

--- a/compiler/tests/outputs/diag_dyn_no_impl.txt
+++ b/compiler/tests/outputs/diag_dyn_no_impl.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_dyn_no_impl.nu:12:5: error: type '%Cat' does not implement trait 'Speaker', so it cannot be made into a '%Speaker' object. Write the impl first: '% Speaker <Type> { ... }', supplying every method the trait declares.
+    ^ 0
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_dyn_not_generic.txt
+++ b/compiler/tests/outputs/diag_dyn_not_generic.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_dyn_not_generic.nu:9:21: error: trait 'Speaker' is not object-safe: a dynamic object needs the trait to be generic over Self ('% Name [T] { ... }'). Add the parameter, or dispatch statically. Wanted '%Speaker'
+@ announce %Speaker s → i { ^ ( speak s ) }
+                    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_dyn_self_in_return.txt
+++ b/compiler/tests/outputs/diag_dyn_self_in_return.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_dyn_self_in_return.nu:10:14: error: method 'make' of trait 'Maker' mentions Self beyond the receiver (a parameter or the return type) — not object-safe for '%Maker'
+@ use %Maker m → i { ^ 0 }
+             ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_field_store_by_value_param.txt
+++ b/compiler/tests/outputs/diag_field_store_by_value_param.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_field_store_by_value_param.nu:15:11: error: cannot assign to a field of 's': it is a by-value S with no storage to write through — a parameter (parameters are immutable bindings and arrive by value), or a temporary. Take the argument as 'inout' if the caller should see the write ('@ f inout S s → v'), or copy it into a mutable local first (': ~ S t s', then '= . t <field> <value>').
+    = . s a 5
+          ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_float_width_mix.txt
+++ b/compiler/tests/outputs/diag_float_width_mix.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_float_width_mix.nu:8:5: error: operator mixes float operands of different widths: left is 'f32', right is 'f' — NURL has no implicit numeric conversions; widen with '# f expr' (lossless) or narrow with '# f32 expr'
+    ^ 0
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_int_lit_width_range.txt
+++ b/compiler/tests/outputs/diag_int_lit_width_range.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_int_lit_width_range.nu:13:5: error: integer literal 9999 does not fit the 'i8' operand it is combined with. NURL evaluates the operator at the typed operand's width, and 8 bits accept -128..255 — the signed range union the unsigned one, since the check does not read the operand's signedness. Widen the typed operand with '# i expr', or use a literal in range.
+    ^ 0
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_paren_type_bad.txt
+++ b/compiler/tests/outputs/diag_paren_type_bad.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_paren_type_bad.nu:6:9: error: a parenthesised type must open with '@' or a type name, found '5'. There are exactly two parenthesised forms: a closure type '( @ ret params )' — the RETURN type first, as in '( @ i i )' for a closure taking an i and returning one — and a generic instantiation '( Name T )', as in '( Vec i )' or '( Channel String )'. Parentheses are not grouping here; a plain type needs none.
+    : ( 5 ) x 0
+        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_pct_not_trait.txt
+++ b/compiler/tests/outputs/diag_pct_not_trait.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_pct_not_trait.nu:3:6: error: '%' in a type position must be followed by a trait name (dynamic trait object '%Trait')
+@ f %5 x → i { ^ 0 }
+     ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_slice_elem_int_for_float.txt
+++ b/compiler/tests/outputs/diag_slice_elem_int_for_float.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_slice_elem_int_for_float.nu:4:20: error: element 1 of this slice literal has integer type 'i' but the slice's declared element type is 'f' (a float) — NURL has no implicit integer↔float conversions. Write the element as a float ('2.0', not '2'), or convert with '# f expr'.
+    : [f xs [f | 1 2 3]
+                   ^
+error: aborting due to 1 previous error

--- a/tools/diag_coverage_baseline.txt
+++ b/tools/diag_coverage_baseline.txt
@@ -6,8 +6,6 @@
 3cc2e514ea86  inout field argument to ' ' must be '. <binding> <field>' naming a plain struct binding
 3ef3446b70cc  ' ' is a compiler-auto-dropped value; passing it to a 'sink' parameter is not yet supported - pass a
 43a9804d1c0b  inout argument ' ' is not a binding in scope. An 'inout' argument must be a plain binding in scope, 
-46beb4c87199  method ' ' of trait ' ' mentions Self beyond the receiver (a parameter or the return type) — not obj
-4dcc1518b953  integer literal does not fit the ' ' operand it is combined with (that type holds .. ) — NURL evalua
 50c9a5e6a8a5  cannot cast ' ' to an integer: its first field is itself an aggregate, so there is no scalar to take
 52d29a5350d6  select has no channel arms — a '?? { ... }' with only a default '_' arm would spin without ever wait
 554c34e0f923  a guard (? cond) on a wildcard arm is not supported - guard a specific pattern instead
@@ -24,24 +22,18 @@
 8f8423944aed  const expression must be integer literals combined with + - * / << >> & | ^^ (use a precomputed lite
 8fa0e2858d9c  unexpected where a value was required. Every NURL operator has FIXED arity and no closing bracket, s
 90e2e7e59d8d  return expression has no value (expected
-95e02910fae6  trait ' ' is not object-safe: a dynamic object needs the trait to be generic over Self ('% Name [T] 
 996c90fa8fe7  select has more than one default '_' arm — only one is allowed, and it runs when no channel is ready
-9a6844424ec4  type ' ' does not implement trait ' ', so it cannot be made into a '% ' object. Write the impl first
 a000cdd254fc  '#' is the cast operator; struct/enum literals use '@'. Write '@ { ... }' instead.
 a7b912fa462f  expected '→' after the match guard, found . A guarded arm is 'Variant payload ? guard → body' — the 
 aba81704d0f4  inout argument to ' ' must be a mutable ': ~' binding or a '. binding field' field target, not an ex
-abd79dec9f97  '%' in a type position must be followed by a trait name (dynamic trait object '%Trait')
 ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
 ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
-ae69b52c99bd  element of this slice literal has integer type ' ' but the slice's declared element type is ' ' (a f
 af5a83d74d0f  cannot cast ' ' to an integer — '# i expr' converts numbers and pointers, not this type. There are n
 bde8adc30e81  inout field argument: ' ' is not a struct binding in scope. An 'inout' argument must be a plain bind
 c5d859907bb0  operator '&&' requires bool operands and the left one is not bool. '&&' and '||' short-circuit and a
-c6d6dadc45c0  operator mixes float operands of different widths: left is ' ', right is ' ' — NURL has no implicit 
 ca92cb54d21f  expected at least one trait name after the supertrait ':', found . A trait requiring others is '% Na
 cfe21e33fd77  inout field argument: expected a field name after '. '. The form is '( f inout . s field )' — object
 d82fbf1f85b6  an or-pattern cannot mix a literal constraint with variant names — write the literal case as its own
-dbb6645738fc  ( in type position must be followed by @ or type name
 e13f6093bfb5  expected '{' to open the closure body, found . A closure is '\\ params → ret { body }' — the body is
 ea01dc19d4df  volatile_load expects a typed pointer '*T', so it knows the width to read. Write '( volatile_load p 
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic


### PR DESCRIPTION
## Why

Sixth pass over the never-fired list. Two of the three findings are the **silent-compile shape** rather than a wording problem.

**A field store on a by-value struct parameter emitted invalid IR and exited 0.**

```nurl
: S { i a }
@ f S s → i { = . s a 5  ^ . s a }
```

```llvm
%r1 = getelementptr %S, %S* , i32 0, i32 0
```

That is an **empty pointer operand**. A by-value struct parameter has no alloca to GEP from, so the base came back empty and was printed as nothing at all. nurlc exits 0; only clang objects — `expected value token` — against generated IR the author never wrote. The message that exists for this (`cannot mutate immutable parameter`) covers scalars and never saw the field-store path.

**And the narrow-operand literal check told a model that `i8` holds `-128..255`.**

```
error: integer literal 9999 does not fit the 'i8' operand it is combined with (that type holds -128..255)
```

`i8` holds -128..127. The window the check actually accepts is the signed range **union** the unsigned one, because it never reads the operand's signedness — so that number is a fact about eight bits, not about `i8`. This is the same failure as the kwargs "NURL has no defaults" claim in #847: a true implementation detail stated as a language rule.

## What

- **The field store is rejected at the source**, naming both cures: take the argument `inout` if the caller should see the write, or copy it into a `: ~` local first.
- **The range message describes what the check enforces** rather than claiming it is the type's range. Semantics deliberately unchanged — narrowing the window to the signed range would reject programs that compile today, which is a language question and not a diagnostics one.
- **One thin message widened.** Parentheses in type position listed what was expected and not what the two forms *are*. It now names both — the closure type `( @ ret params )`, return type first, and the generic instantiation `( Name T )` — and says outright that parentheses are not grouping here, which is the assumption that produces the mistake.

**Nine `diag_*` tests.** Six cover messages that were already right and had never been printed: the three object-safety refusals, `%` followed by a non-trait, an integer element in a float slice literal, mixed float widths.

**Coverage: 179 of 223 exercised, up from 171. Never-fired 52 → 44.**

## Proof

```
./compiler/tests/run_tests.sh
PASS 720 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this branch and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

Same set and count as #847, #848, #851, #852 and #853 on this container; pass count moved 711 → 720 exactly as the nine tests were added.

**The field-store guard was the regression risk worth naming** — it sits on the path every `= . obj field` takes, including the `inout` field targets and every struct test in the corpus. It was run against the full suite before anything else was added to the branch (711 pass, unchanged), and the examples gate was run for the same reason: a guard that fires one case too wide would break the wider first-party tree, not the corpus.

```
./build.sh --no-tests           BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check                 compiler/nurlc.nu and all 9 new tests canonical
./tools/check_strict_arity.sh   OK — 1115 files, no arity trap
./tools/check_examples.sh       clean (1 skipped: optional FFI lib absent)
./tools/check_diag_anchor.sh    every baselined diagnostic points at real code
./tools/check_diag_coverage.sh  clean
```

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs.

## Known remaining

**44 sites still never fire.** Six passes in, the list has yielded a false claim or a silent miscompile every single time, so it is still worth walking rather than closing out.

**The literal-range check does not read signedness, and that is now documented rather than fixed.** `+ n 200` against an `i8` compiles today. Making the window signedness-aware would reject it — correctly, arguably — but that changes what compiles and belongs in an issue first.

**Carried, unchanged:** an incomplete impl still reports "call to unknown function" (language-surface — wants an issue); `spec/grammar.ebnf` still has no `assoc_decl` production; the or-pattern bool-arm message still names a program (`T | F`) that cannot reach it; `%` in a const expression is read as a trait-object sigil, so the const-expression message stays preempted by a type error; and the unknown-associated-type anchor is still a line late by design.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_