### PR TITLE
fix(ax): three misdirects, and the anchor gate catching its author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A forgotten `→` on a guarded match arm was reported as a
+  non-exhaustive match.** The guard scan ran to the next `→` at paren
+  depth 0, and braces do not affect that depth — so `A v ? > v 0 { ^ v }
+  B → 0` swallowed the arm's body *and the whole next variant*, and the
+  failure surfaced as "no arm covers variant 'A'" about the arm the
+  writer had just finished writing. A guard is one expression and never
+  contains a brace at depth 0, so a `{` there is the missing arrow and
+  nothing else.
+
+- **Two enums were reported as a "wrong struct type".** The check that
+  runs first has no symbol table to test enum-ness with, so it described
+  every named-type mismatch as a struct one. Its parenthetical was
+  already accurate; the lead was not, and *struct* is the word a reader
+  takes away. Both kinds are nominal, which is the rule that matters and
+  is true of either.
+
+- **"likely a conditional with incompatible branch types" was a guess,
+  and the wrong one.** Returning a call whose declared return type is
+  `v` is the commonest way to reach that error and went unmentioned. It
+  is named first now.
+
 - **Assigning to a field of a by-value struct parameter emitted invalid
   IR, silently.** A by-value struct parameter has no alloca to GEP from,
   so `= . s a 5` printed `getelementptr %S, %S* , i32 0, i32 0` — with

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -2640,8 +2640,8 @@
     ? & & ( seq lt `void` ) != 0 ( nurl_str_len fn_rt ) ! ( seq fn_rt `void` )
     { : s hint ? returning_match
         `) — match arms contain '^' so '?? …' is statement-form, not an expression. Refactor to ': ~ T rc init / ?? mr { … = rc v } / ^ rc'.`
-        `) — likely a conditional with incompatible branch types`
-        ( die lex ( nurl_str_cat `return expression has no value (expected `
+        `) — the commonest cause is returning a call whose declared return type is 'v', which yields nothing to return; a conditional whose branches disagree on type does the same. Check what the '^' operand produces.`
+        ( die_stmt lex ( nurl_str_cat `return expression has no value (expected `
         ( nurl_str_cat ( llvm_to_nurl fn_rt ) hint ) ) ) }
     {}
     // Inverse of the above: the function is declared `→ v` (returns
@@ -6814,7 +6814,7 @@
         { ( die lex ( nurl_str_cat3
             ( nurl_str_cat4 `argument ` ( nurl_str_int + arg_idx 1 ) ` to '` fname )
             ( nurl_str_cat4 `': value of type '` at `' passed where parameter expects '` pllvm )
-            `' — wrong struct type passed by value (a value of one named type where a different one is declared); the call would silently reinterpret its fields` ) ) }
+            `' — wrong named type passed by value. Structs and enums are both NOMINAL: two of them are different types even when their fields or tags line up, and no conversion is implied. The call would reinterpret this value as the declared type's fields.` ) ) }
         {}
         ? ( __arg_named_ptr_mismatch at pllvm )
         { ( die lex ( nurl_str_cat3
@@ -9127,6 +9127,16 @@
                     ? == gt TT_EOF { ( die lex ( nurl_str_cat3
                         `expected '→' after the match guard, found ` ( tok_here lex )
                         `. A guarded arm is 'Variant payload ? guard → body' — the guard is one expression between the payload and the arrow. E.g. 'T n ? > n 0 → body'.` ) ) } {}
+                    // A '{' at depth 0 means the arrow was forgotten and
+                    // this is the arm's BODY. Without this the scan ran
+                    // on to the next arm's arrow, swallowing the body and
+                    // a whole variant with it — and the failure surfaced
+                    // as "non-exhaustive match: no arm covers 'A'" about
+                    // the arm the writer had just written. A guard is one
+                    // expression; it never contains a brace at depth 0.
+                    ? & == gt TT_LBRACE == gd 0 { ( die lex ( nurl_str_cat3
+                        `expected '→' after the match guard, found ` ( tok_here lex )
+                        `. A guarded arm is 'Variant payload ? guard → body' — the guard is one expression between the payload and the arrow, and the arrow is not optional. E.g. 'T n ? > n 0 → body', or with a braced body 'T n ? > n 0 → { ... }'.` ) ) } {}
                     ? | == gt TT_LPAREN == gt TT_LBRACK { = gd + gd 1 } {}
                     ? | == gt TT_RPAREN == gt TT_RBRACK { = gd - gd 1 } {}
                     ( nurl_lex_advance lex )
@@ -9144,7 +9154,7 @@
             // a contradiction anyway). Or-patterns + guards are kept
             // orthogonal for v1.
             ? & != 0 has_guard ( seq pattern_name `_` )
-            { ( die lex `a guard (? cond) on a wildcard arm is not supported - guard a specific pattern instead` ) } {}
+            { ( die_stmt lex `a guard on the wildcard arm is not supported. '_' already means "everything not matched above", so '_ ? cond' would leave the remaining variants unhandled when the guard is false, and a match must be exhaustive. Guard a named variant instead ('A v ? > v 0 → body'), and let a plain '_ → body' absorb the rest.` ) } {}
             ? & != 0 has_guard has_or
             { ( die lex ( nurl_str_cat `an or-pattern cannot carry a guard — 'A | B ? cond → body' would have to hold for both variants and the compiler cannot tell which matched. Write the arms separately: 'A ? cond → body  B ? cond → body'.` `` ) ) } {}
             ? ( seq pattern_name `_` ) {

--- a/compiler/tests/diag_binop_andand_int.nu
+++ b/compiler/tests/diag_binop_andand_int.nu
@@ -1,0 +1,8 @@
+// diag_binop_andand_int.nu — '&&' with an integer on the left, the
+// sibling of diag_binop_oror_int.
+@ main → i {
+    : i n 3
+    : b r && n T
+    ? r { ^ 1 } {}
+    ^ 0
+}

--- a/compiler/tests/diag_call_enum_cross_enum.nu
+++ b/compiler/tests/diag_call_enum_cross_enum.nu
@@ -2,6 +2,16 @@
 // DIFFERENT enum is declared. Both lower to an i64 tag, so the call
 // used to assemble and the callee read this value's tag as the OTHER
 // enum's variants (here: Pear's tag 1 arriving as Green).
+//
+// The message opened "wrong struct type passed by value" about two
+// ENUMS. Its parenthetical was accurate; the lead was not, and 'struct'
+// is the word a reader takes away. Both kinds are NOMINAL, which is true
+// of either and is the rule that matters here.
+//
+// The enum-specific message written for exactly this case is still
+// preempted: it lives in the scalar-agreement pass, and this check runs
+// first from __arg_param_checks, which has no 'syms' to test enum-ness
+// with. Naming the shared rule was the fix that did not need plumbing.
 : | Color { Red Green Blue }
 : | Fruit { Apple Pear }
 

--- a/compiler/tests/diag_guard_on_wildcard.nu
+++ b/compiler/tests/diag_guard_on_wildcard.nu
@@ -1,0 +1,8 @@
+// diag_guard_on_wildcard.nu — a guard on the wildcard arm.
+: | E { A i B }
+
+@ main → i {
+    : E e @ E { A 1 }
+    : i r ?? e { A v → v _ ? > 1 0 → 0 }
+    ^ r
+}

--- a/compiler/tests/diag_inout_arg_expression.nu
+++ b/compiler/tests/diag_inout_arg_expression.nu
@@ -1,0 +1,10 @@
+// diag_inout_arg_expression.nu — an expression at an inout parameter.
+// The callee writes through the argument, so a temporary has nowhere to
+// write back to.
+@ bump inout i x → v { = x + x 1 }
+
+@ main → i {
+    : ~ i n 5
+    ( bump + n 1 )
+    ^ n
+}

--- a/compiler/tests/diag_inout_field_no_field.nu
+++ b/compiler/tests/diag_inout_field_no_field.nu
@@ -1,0 +1,11 @@
+// diag_inout_field_no_field.nu — an inout field target with the object
+// named and the field left off.
+: S { i a }
+
+@ bump inout i x → v { = x + x 1 }
+
+@ main → i {
+    : ~ S s @ S { 1 }
+    ( bump . s )
+    ^ 0
+}

--- a/compiler/tests/diag_inout_field_not_binding.nu
+++ b/compiler/tests/diag_inout_field_not_binding.nu
@@ -1,0 +1,10 @@
+// diag_inout_field_not_binding.nu — an inout field target whose object
+// is not in scope at all.
+: S { i a }
+
+@ bump inout i x → v { = x + x 1 }
+
+@ main → i {
+    ( bump . zz a )
+    ^ 0
+}

--- a/compiler/tests/diag_inout_field_on_scalar.nu
+++ b/compiler/tests/diag_inout_field_on_scalar.nu
@@ -1,0 +1,9 @@
+// diag_inout_field_on_scalar.nu — an inout field target whose object is
+// a scalar, so it has no declared field names to reach for.
+@ bump inout i x → v { = x + x 1 }
+
+@ main → i {
+    : ~ i n 5
+    ( bump . n a )
+    ^ n
+}

--- a/compiler/tests/diag_match_guard_no_arrow.nu
+++ b/compiler/tests/diag_match_guard_no_arrow.nu
@@ -1,0 +1,15 @@
+// diag_match_guard_no_arrow.nu — a guarded arm whose '→' was forgotten.
+//
+// The guard scan ran until the next '→' at paren depth 0, and braces do
+// not affect that depth — so it swallowed this arm's body AND the whole
+// next variant, and the failure surfaced as "non-exhaustive match on
+// enum 'E' — no arm covers variant 'A'" about the arm the writer had
+// just written. A guard is one expression and never contains a brace at
+// depth 0, so a '{' there is the missing arrow and nothing else.
+: | E { A i B }
+
+@ main → i {
+    : E e @ E { A 1 }
+    : i r ?? e { A v ? > v 0 { ^ v } B → 0 }
+    ^ r
+}

--- a/compiler/tests/diag_orpattern_guard.nu
+++ b/compiler/tests/diag_orpattern_guard.nu
@@ -1,0 +1,9 @@
+// diag_orpattern_guard.nu — a guard on an or-pattern. It would have to
+// hold for both variants and the compiler cannot tell which matched.
+: | D { N S E W }
+
+@ main → i {
+    : D d @ D { N }
+    : i r ?? d { N | S ? T → 1 E → 2 W → 3 }
+    ^ r
+}

--- a/compiler/tests/diag_ret_void_call.nu
+++ b/compiler/tests/diag_ret_void_call.nu
@@ -1,0 +1,8 @@
+// diag_ret_void_call.nu — returning the result of a 'v' function.
+//
+// The hint used to read "likely a conditional with incompatible branch
+// types" and nothing else, which is a guess — and the wrong one for the
+// commonest way to reach this. Returning a void call is named first now.
+@ nothing → v {}
+
+@ main → i { ^ ( nothing ) }

--- a/compiler/tests/diag_select_no_channel_arms.nu
+++ b/compiler/tests/diag_select_no_channel_arms.nu
@@ -1,0 +1,8 @@
+// diag_select_no_channel_arms.nu — a select with only a default arm,
+// which would spin without ever waiting.
+$ `stdlib/std/channel.nu`
+
+@ main → i {
+    ?? { _ → {} }
+    ^ 0
+}

--- a/compiler/tests/diag_select_two_defaults.nu
+++ b/compiler/tests/diag_select_two_defaults.nu
@@ -1,0 +1,8 @@
+// diag_select_two_defaults.nu — two default arms in one select.
+$ `stdlib/std/channel.nu`
+
+@ main → i {
+    : ( Channel i ) c ( chan_new [i] )
+    ?? { [i] c → v {} _ → {} _ → {} }
+    ^ 0
+}

--- a/compiler/tests/diag_volatile_load_untyped.nu
+++ b/compiler/tests/diag_volatile_load_untyped.nu
@@ -1,0 +1,8 @@
+// diag_volatile_load_untyped.nu — volatile_load handed a plain integer.
+// The width to read comes from the pointer's type, so an untyped
+// address cannot say how much to load.
+@ main → i {
+    : i p 4096
+    : i v ( volatile_load p )
+    ^ v
+}

--- a/compiler/tests/outputs/diag_binop_andand_int.txt
+++ b/compiler/tests/outputs/diag_binop_andand_int.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_binop_andand_int.nu:5:16: error: operator '&&' requires bool operands and the left one is not bool. '&&' and '||' short-circuit and are bool-only; for bitwise work on integers use '&' and '|'. To test an integer, compare it: '&& != n 0 ( f )'.
+    : b r && n T
+               ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_call_enum_cross_enum.txt
+++ b/compiler/tests/outputs/diag_call_enum_cross_enum.txt
@@ -1,6 +1,6 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_call_enum_cross_enum.nu:14:16: error: argument 1 to 'show': value of type '%Fruit' passed where parameter expects '%Color' — wrong struct type passed by value (a value of one named type where a different one is declared); the call would silently reinterpret its fields
+compiler/tests/diag_call_enum_cross_enum.nu:24:16: error: argument 1 to 'show': value of type '%Fruit' passed where parameter expects '%Color' — wrong named type passed by value. Structs and enums are both NOMINAL: two of them are different types even when their fields or tags line up, and no conversion is implied. The call would reinterpret this value as the declared type's fields.
     ^ ( show x )
                ^
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_guard_on_wildcard.txt
+++ b/compiler/tests/outputs/diag_guard_on_wildcard.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_guard_on_wildcard.nu:6:26: error: a guard on the wildcard arm is not supported. '_' already means "everything not matched above", so '_ ? cond' would leave the remaining variants unhandled when the guard is false, and a match must be exhaustive. Guard a named variant instead ('A v ? > v 0 → body'), and let a plain '_ → body' absorb the rest.
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_inout_arg_expression.txt
+++ b/compiler/tests/outputs/diag_inout_arg_expression.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_inout_arg_expression.nu:8:12: error: inout argument to 'bump' must be a mutable ': ~' binding or a '. binding field' field target, not an expression
+    ( bump + n 1 )
+           ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_inout_field_no_field.txt
+++ b/compiler/tests/outputs/diag_inout_field_no_field.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_inout_field_no_field.nu:9:16: error: inout field argument: expected a field name after '. s'. The form is '( f inout . s field )' — object first, then the field name, prefix style.
+    ( bump . s )
+               ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_inout_field_not_binding.txt
+++ b/compiler/tests/outputs/diag_inout_field_not_binding.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_inout_field_not_binding.nu:8:17: error: inout field argument: 'zz' is not a struct binding in scope. An 'inout' argument must be a plain binding in scope, or one of its fields — the call site names the value plainly, '( f v )' or '( f . s field )'; the 'inout' marker appears only in the DECLARATION. The callee writes through it, so a temporary or an expression has nowhere to write back to.
+    ( bump . zz a )
+                ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_inout_field_on_scalar.txt
+++ b/compiler/tests/outputs/diag_inout_field_on_scalar.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_inout_field_on_scalar.nu:7:16: error: inout field argument: 'n' is not a named-struct binding — the field form needs a struct with declared field names. An 'inout' argument must be a plain binding in scope, or one of its fields — the call site names the value plainly, '( f v )' or '( f . s field )'; the 'inout' marker appears only in the DECLARATION. The callee writes through it, so a temporary or an expression has nowhere to write back to.
+    ( bump . n a )
+               ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_match_guard_no_arrow.txt
+++ b/compiler/tests/outputs/diag_match_guard_no_arrow.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_match_guard_no_arrow.nu:13:30: error: expected '→' after the match guard, found '{'. A guarded arm is 'Variant payload ? guard → body' — the guard is one expression between the payload and the arrow, and the arrow is not optional. E.g. 'T n ? > n 0 → body', or with a braced body 'T n ? > n 0 → { ... }'.
+    : i r ?? e { A v ? > v 0 { ^ v } B → 0 }
+                             ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_orpattern_guard.txt
+++ b/compiler/tests/outputs/diag_orpattern_guard.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_orpattern_guard.nu:7:32: error: an or-pattern cannot carry a guard — 'A | B ? cond → body' would have to hold for both variants and the compiler cannot tell which matched. Write the arms separately: 'A ? cond → body  B ? cond → body'.
+    : i r ?? d { N | S ? T → 1 E → 2 W → 3 }
+                               ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ret_void_call.txt
+++ b/compiler/tests/outputs/diag_ret_void_call.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_ret_void_call.nu:8:16: error: return expression has no value (expected i) — the commonest cause is returning a call whose declared return type is 'v', which yields nothing to return; a conditional whose branches disagree on type does the same. Check what the '^' operand produces.
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_select_no_channel_arms.txt
+++ b/compiler/tests/outputs/diag_select_no_channel_arms.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_select_no_channel_arms.nu:7:5: error: select has no channel arms — a '?? { ... }' with only a default '_' arm would spin without ever waiting. Add at least one '[T] chan → name { body }'.
+    ^ 0
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_select_two_defaults.txt
+++ b/compiler/tests/outputs/diag_select_two_defaults.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_select_two_defaults.nu:6:34: error: select has more than one default '_' arm — only one is allowed, and it runs when no channel is ready. Merge the two bodies into a single '_ → { ... }'.
+    ?? { [i] c → v {} _ → {} _ → {} }
+                                 ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_volatile_load_untyped.txt
+++ b/compiler/tests/outputs/diag_volatile_load_untyped.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_volatile_load_untyped.nu:7:5: error: volatile_load expects a typed pointer '*T', so it knows the width to read. Write '( volatile_load p )' where p is '*u32' or similar; cast with '# *u32 addr' if you hold a raw address.
+    ^ v
+    ^
+error: aborting due to 1 previous error

--- a/tools/diag_coverage_baseline.txt
+++ b/tools/diag_coverage_baseline.txt
@@ -7,13 +7,9 @@
 3ef3446b70cc  ' ' is a compiler-auto-dropped value; passing it to a 'sink' parameter is not yet supported - pass a
 43a9804d1c0b  inout argument ' ' is not a binding in scope. An 'inout' argument must be a plain binding in scope, 
 50c9a5e6a8a5  cannot cast ' ' to an integer: its first field is itself an aggregate, so there is no scalar to take
-52d29a5350d6  select has no channel arms — a '?? { ... }' with only a default '_' arm would spin without ever wait
-554c34e0f923  a guard (? cond) on a wildcard arm is not supported - guard a specific pattern instead
 5ad763372c6c  method ' ' of trait ' ' has no Self receiver as its first parameter — not object-safe for '% '
 5dfdf7d4ec64  expected '{' to open the default arm's body, found . The default arm is '_ → { body }'.
 697d73c26332  expected a binding name, found . A binding is ': type name value' — the TYPE comes before the name, 
-6a7a475738c9  an or-pattern cannot carry a guard — 'A | B ? cond → body' would have to hold for both variants and 
-70153c509a6c  inout field argument: ' ' is not a named-struct binding — the field form needs a struct with declare
 737e4e2f64a2  an or-pattern's variants cannot bind payloads — the arms would disagree about what the name holds. L
 7f5fb5327ef2  element of this slice literal has type ' ' but the slice's declared element type is ' ' — a value of
 812c266928da  a supertrait ':' clause belongs on the trait DECLARATION ('% Name : Base { ... }'), not on an impl. 
@@ -21,21 +17,14 @@
 89608f397d6c  cannot mutate immutable parameter ' ' — parameters are immutable bindings. Copy it into a ': ~' loca
 8f8423944aed  const expression must be integer literals combined with + - * / << >> & | ^^ (use a precomputed lite
 8fa0e2858d9c  unexpected where a value was required. Every NURL operator has FIXED arity and no closing bracket, s
-90e2e7e59d8d  return expression has no value (expected
-996c90fa8fe7  select has more than one default '_' arm — only one is allowed, and it runs when no channel is ready
 a000cdd254fc  '#' is the cast operator; struct/enum literals use '@'. Write '@ { ... }' instead.
 a7b912fa462f  expected '→' after the match guard, found . A guarded arm is 'Variant payload ? guard → body' — the 
-aba81704d0f4  inout argument to ' ' must be a mutable ': ~' binding or a '. binding field' field target, not an ex
 ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
 ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
 af5a83d74d0f  cannot cast ' ' to an integer — '# i expr' converts numbers and pointers, not this type. There are n
-bde8adc30e81  inout field argument: ' ' is not a struct binding in scope. An 'inout' argument must be a plain bind
-c5d859907bb0  operator '&&' requires bool operands and the left one is not bool. '&&' and '||' short-circuit and a
 ca92cb54d21f  expected at least one trait name after the supertrait ':', found . A trait requiring others is '% Na
-cfe21e33fd77  inout field argument: expected a field name after '. '. The form is '( f inout . s field )' — object
 d82fbf1f85b6  an or-pattern cannot mix a literal constraint with variant names — write the literal case as its own
 e13f6093bfb5  expected '{' to open the closure body, found . A closure is '\\ params → ret { body }' — the body is
-ea01dc19d4df  volatile_load expects a typed pointer '*T', so it knows the width to read. Write '( volatile_load p 
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
 f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic


### PR DESCRIPTION
## Why

Seventh pass. All three findings are the same shape — messages that fire, read well, and **send the reader somewhere else**.

**A forgotten `→` on a guarded arm was reported as a non-exhaustive match.**

```nurl
?? e { A v ? > v 0 { ^ v }  B → 0 }
```
```
error: non-exhaustive match on enum 'E' — no arm covers variant 'A'
```

The arm for `A` is right there. The guard scan runs to the next `→` at paren depth 0, and braces do not affect that depth — so it swallowed the arm's body *and the whole next variant*, and the compiler then complained about the arm the writer had just finished writing. The message written for this case existed and was reachable only at EOF.

**Two enums passed cross-wise were reported as a "wrong struct type".** The check that fires first, `__arg_param_checks`, has no symbol table to test enum-ness with, so it described every named-type mismatch as a struct one. Its parenthetical was already accurate; the lead was not, and *struct* is the word a reader takes away.

**"likely a conditional with incompatible branch types" was a guess, and the wrong one.** Returning a call declared `→ v` reaches that error far more often and went unmentioned entirely.

## What

- **A `{` at depth 0 inside a guard is the missing arrow**, and says so.
- **The named-type mismatch names the shared rule** — structs and enums are both nominal — which is true of either and needed no plumbing. The enum-specific message stays preempted; documented in the test rather than papered over.
- **The return hint names the void call first.**
- **The wildcard-guard refusal stopped saying "not supported"** and started saying *why* (`_` already means everything unmatched, so guarding it leaves the rest unhandled when the guard is false) and what to write instead.

**Thirteen `diag_*` tests.** Ten cover messages that were already right and had never been printed: `&&` on an integer, four inout-argument and inout-field shapes, `volatile_load` on an untyped address, the or-pattern guard, two select-arm refusals.

One test was written and then **deleted**: `diag_arg_enum_cross_named` duplicated `diag_call_enum_cross_enum`, which already covered that site. Its finding moved into that test's comment instead — one site, one test.

**Coverage: 188 of 229 exercised (82%), up from 179. Never-fired 44 → 33.**

## Proof

```
./compiler/tests/run_tests.sh
PASS 732 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this branch and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

Same set and count as #847 onward on this container.

**Two intermediate runs failed, and both are worth naming:**

1. **`diag_call_enum_cross_enum` broke** — an existing test whose golden held the old "wrong struct type" wording. It is precisely the case the reword fixes (two enums), so the golden was re-minted after checking the new text against it, not before.
2. **`./tools/check_diag_anchor.sh` failed the build on two tests added in *this* commit** — the wildcard-guard refusal and the return message, both printing a caret past the end of its line. That is the gate from #852 doing exactly what it was built for, against its own author, one round later. Both are now anchored with `die_stmt`.

```
./build.sh --no-tests           BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check                 compiler/nurlc.nu and every new test canonical
./tools/check_strict_arity.sh   OK — 1115 files, no arity trap
./tools/check_examples.sh       clean (1 skipped: optional FFI lib absent)
./tools/check_diag_anchor.sh    every baselined diagnostic points at real code
./tools/check_diag_coverage.sh  clean
```

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs.

## Known remaining

**33 sites still never fire** — down from 173 unmeasured when this work started, and every pass has still found something.

**Two messages are written for programs that cannot reach them.** The enum-specific argument mismatch (preempted by the named-type check, which runs first and lacks `syms`) and the or-pattern payload refusal (preempted by the arm parser, which rejects `|` after a payload name first). Both state true rules; neither is reachable by the program its text describes. Making either reachable means reordering checks across passes, which is a refactor rather than a diagnostics fix — worth doing deliberately, not inside a sweep.

**Carried, unchanged:** an incomplete impl still reports "call to unknown function" (language-surface — wants an issue); `spec/grammar.ebnf` still has no `assoc_decl` production; the or-pattern bool-arm message still names a program (`T | F`) that cannot reach it; `%` in a const expression stays preempted by a type error; the literal-range check still ignores signedness (documented, not fixed); and the unknown-associated-type anchor is still a line late by design.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_