### PR TITLE
fix(ax): an off-by-one that spared every newtype, and the gate's own miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`# S { 1 }` was accepted silently for every single-field struct.**
+  The guard that catches `'#' is the cast operator; struct/enum literals
+  use '@'` tested whether the name is a struct by reading the key for
+  field **index 1** — the *second* field. A struct with one field failed
+  that test and the literal went through unremarked, while a two-field
+  struct was caught all along, which is what kept the gap invisible. A
+  single-field struct is the newtype wrapper, one of the commonest
+  shapes there is.
+
 - **A forgotten `→` on a guarded match arm was reported as a
   non-exhaustive match.** The guard scan ran to the next `→` at paren
   depth 0, and braces do not affect that depth — so `A v ? > v 0 { ^ v }

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -3179,7 +3179,7 @@
         // wrap-in-closure-literal cure.
         ? & & & == 0 ( nurl_str_len ptr ) == 0 ( nurl_str_len glb ) == 0 ( nurl_sym_len2 syms name `__param` ) != 0 ( nurl_sym_len2 g_vis_syms name `__src_file` )
         { : s tail ( nurl_str_cat name ` args ) }' — but that is the rarer reading.` )
-            ( die lex ( nurl_str_cat4
+            ( die_stmt lex ( nurl_str_cat4
             `bare function name '` name
             `' used as a value. If you meant to CALL it, calls need parentheses: '( `
             ( nurl_str_cat3 name ` args )', never '` ( nurl_str_cat3 name ` args'. If you really wanted the function AS a value, a bare name does not auto-coerce to a closure — wrap it: '\ args → R { ( ` tail ) ) ) ) }
@@ -14270,7 +14270,11 @@
     ? & == ( nurl_lex_type lex ) TT_LBRACE & > ( nurl_str_len dt ) 1 == ( nurl_str_get dt 0 ) 37
     { : s tname ( nurl_str_slice dt 1 - ( nurl_str_len dt ) 1 )
         : s is_enum ( nurl_sym_get2 syms tname `__variants` )
-        : s is_struct ( nurl_sym_get syms ( nurl_str_cat3 tname `__idx_1` `__type` ) )
+        // Field INDEX 0, not 1. Reading the second field's key meant
+        // every single-field struct failed the "is this a struct" test
+        // and slipped through silently — and a single-field struct is
+        // the newtype wrapper, one of the commonest shapes there is.
+        : s is_struct ( nurl_sym_get syms ( nurl_str_cat3 tname `__idx_0` `__type` ) )
         ? | != 0 ( nurl_str_len is_enum ) != 0 ( nurl_str_len is_struct )
         { ( die lex ( nurl_str_cat3
             `'#' is the cast operator; struct/enum literals use '@'. Write '@ `

--- a/compiler/tests/diag_assign_immutable_scalar_param.nu
+++ b/compiler/tests/diag_assign_immutable_scalar_param.nu
@@ -1,0 +1,9 @@
+// diag_assign_immutable_scalar_param.nu — assigning to a scalar
+// parameter. The struct-field sibling of this lives in
+// diag_field_store_by_value_param; this is the plain path.
+@ f i p → i {
+    = p 5
+    ^ p
+}
+
+@ main → i { ^ ( f 1 ) }

--- a/compiler/tests/diag_bind_name_paren.nu
+++ b/compiler/tests/diag_bind_name_paren.nu
@@ -1,0 +1,5 @@
+// diag_bind_name_paren.nu — parentheses where a binding name belongs.
+@ main → i {
+    : i ( x ) 0
+    ^ 0
+}

--- a/compiler/tests/diag_cast_nested_aggregate.nu
+++ b/compiler/tests/diag_cast_nested_aggregate.nu
@@ -1,0 +1,10 @@
+// diag_cast_nested_aggregate.nu — casting a struct whose first field is
+// itself a struct. '# i s' takes the first scalar, and there isn't one.
+: Inner { i a i b }
+: Outer { Inner i1 i c }
+
+@ main → i {
+    : Outer o @ Outer { @ Inner { 1 2 } 3 }
+    : i n # i o
+    ^ n
+}

--- a/compiler/tests/diag_cast_struct_literal.nu
+++ b/compiler/tests/diag_cast_struct_literal.nu
@@ -1,0 +1,14 @@
+// diag_cast_struct_literal.nu — '#' used where '@' builds a literal.
+//
+// A SINGLE-FIELD struct used to slip through: the "is this a registered
+// struct" test read the key for field index 1 — the SECOND field — so
+// every struct with one field failed it and the literal was accepted
+// silently. A single-field struct is the newtype wrapper, one of the
+// commonest shapes there is, and a two-field struct was caught all
+// along, which is what made the gap invisible.
+: S { i a }
+
+@ main → i {
+    : S s # S { 1 }
+    ^ 0
+}

--- a/compiler/tests/diag_const_expr_call.nu
+++ b/compiler/tests/diag_const_expr_call.nu
@@ -1,0 +1,6 @@
+// diag_const_expr_call.nu — a call in a top-level constant's value. A
+// constant is folded at compile time, so only integer literals and the
+// listed operators can appear.
+: i K + 1 ( f )
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_dangling_operand_caret.nu
+++ b/compiler/tests/diag_dangling_operand_caret.nu
@@ -1,0 +1,7 @@
+// diag_dangling_operand_caret.nu — a binary operator one operand short,
+// which swallows the '^' that follows. The message has to explain the
+// fixed-arity trap, since nothing in the source looks wrong locally.
+@ main → i {
+    : i n + 1
+    ^ n
+}

--- a/compiler/tests/diag_dot_no_field_name.nu
+++ b/compiler/tests/diag_dot_no_field_name.nu
@@ -1,0 +1,9 @@
+// diag_dot_no_field_name.nu — '. obj' with the field left off. The
+// message is the one that has to state prefix order, since the mistake
+// usually comes from expecting 'obj.field'.
+: S { i a }
+
+@ main → i {
+    : S s @ S { 1 }
+    ^ . s
+}

--- a/compiler/tests/diag_elem_store_clash.nu
+++ b/compiler/tests/diag_elem_store_clash.nu
@@ -1,0 +1,8 @@
+// diag_elem_store_clash.nu — storing a float into an integer slice
+// element. Six sites in the compiler emit this same sentence for
+// different container shapes; this covers the slice-element one.
+@ main → i {
+    : [i xs [i | 1 2 3]
+    = . xs 0 1.5
+    ^ 0
+}

--- a/compiler/tests/diag_inout_arg_not_in_scope.nu
+++ b/compiler/tests/diag_inout_arg_not_in_scope.nu
@@ -1,0 +1,7 @@
+// diag_inout_arg_not_in_scope.nu — an inout argument naming nothing.
+@ bump inout i x → v { = x + x 1 }
+
+@ main → i {
+    ( bump zzz )
+    ^ 0
+}

--- a/compiler/tests/diag_objsafe_no_self_receiver.nu
+++ b/compiler/tests/diag_objsafe_no_self_receiver.nu
@@ -1,0 +1,11 @@
+// diag_objsafe_no_self_receiver.nu — a trait method whose first
+// parameter is not Self, so dynamic dispatch has nothing to dispatch on.
+% Maker [T] { @ make i n → i }
+
+: Dog { i age }
+
+% Maker Dog { @ make i n → i { ^ n } }
+
+@ use %Maker m → i { ^ 0 }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_objsafe_sink_receiver.nu
+++ b/compiler/tests/diag_objsafe_sink_receiver.nu
@@ -1,0 +1,11 @@
+// diag_objsafe_sink_receiver.nu — a trait method that consumes its
+// receiver. A '%Trait' object cannot hand ownership through a vtable.
+% Eater [T] { @ eat sink T self → i }
+
+: Dog { i age }
+
+% Eater Dog { @ eat sink Dog d → i { ^ 1 } }
+
+@ use %Eater e → i { ^ 0 }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/diag_select_default_body_unbraced.nu
+++ b/compiler/tests/diag_select_default_body_unbraced.nu
@@ -1,0 +1,9 @@
+// diag_select_default_body_unbraced.nu — the default arm's body written
+// bare. Every select arm body is braced.
+$ `stdlib/std/channel.nu`
+
+@ main → i {
+    : ( Channel i ) c ( chan_new [i] )
+    ?? { [i] c → v {} _ → ^ 0 }
+    ^ 0
+}

--- a/compiler/tests/diag_slice_elem_wrong_struct.nu
+++ b/compiler/tests/diag_slice_elem_wrong_struct.nu
@@ -1,0 +1,11 @@
+// diag_slice_elem_wrong_struct.nu — a value of one named struct type in
+// a slice literal declared for another.
+: A { i x }
+: B { i y }
+
+@ main → i {
+    : A a @ A { 1 }
+    : B b @ B { 2 }
+    : [A xs [A | a b]
+    ^ 0
+}

--- a/compiler/tests/diag_supertrait_empty.nu
+++ b/compiler/tests/diag_supertrait_empty.nu
@@ -1,0 +1,4 @@
+// diag_supertrait_empty.nu — a supertrait ':' with no trait after it.
+% Speaker : { @ speak i self → i }
+
+@ main → i { ^ 0 }

--- a/compiler/tests/outputs/diag_assign_immutable_scalar_param.txt
+++ b/compiler/tests/outputs/diag_assign_immutable_scalar_param.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_assign_immutable_scalar_param.nu:5:9: error: cannot assign to immutable parameter 'p'. Bindings are immutable unless declared ': ~', and parameters are always immutable: add the tilde at the declaration, copy the parameter into a ': ~' local, or take it as 'inout' if the caller should see the write.
+    = p 5
+        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_ax_cures_2.txt
+++ b/compiler/tests/outputs/diag_ax_cures_2.txt
@@ -1,6 +1,4 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_ax_cures_2.nu:16:20: error: bare function name 'f' used as a value. If you meant to CALL it, calls need parentheses: '( f args )', never 'f args'. If you really wanted the function AS a value, a bare name does not auto-coerce to a closure — wrap it: '\ args → R { ( f args ) }' — but that is the rarer reading.
-@ main → i { ^ f 1 }
-                   ^
+compiler/tests/diag_ax_cures_2.nu:16:16: error: bare function name 'f' used as a value. If you meant to CALL it, calls need parentheses: '( f args )', never 'f args'. If you really wanted the function AS a value, a bare name does not auto-coerce to a closure — wrap it: '\ args → R { ( f args ) }' — but that is the rarer reading.
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_bind_name_paren.txt
+++ b/compiler/tests/outputs/diag_bind_name_paren.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_bind_name_paren.nu:3:9: error: expected a binding name, found '('. A binding is ': type name value' — the TYPE comes before the name, and ': ~' makes it mutable. E.g. ': i n 0', ': ~ String s ( string_new )'. The type may be omitted only when the value's type is inferable: ': n 0'.
+    : i ( x ) 0
+        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_cast_nested_aggregate.txt
+++ b/compiler/tests/outputs/diag_cast_nested_aggregate.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cast_nested_aggregate.nu:9:5: error: cannot cast '%Outer' to an integer: its first field is itself an aggregate, so there is no scalar to take. Convert the inner field explicitly.
+    ^ n
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_cast_struct_literal.txt
+++ b/compiler/tests/outputs/diag_cast_struct_literal.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_cast_struct_literal.nu:12:15: error: '#' is the cast operator; struct/enum literals use '@'. Write '@ S { ... }' instead.
+    : S s # S { 1 }
+              ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_const_expr_call.txt
+++ b/compiler/tests/outputs/diag_const_expr_call.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_const_expr_call.nu:4:11: error: const expression must be integer literals combined with + - * / << >> & | ^^ (use a precomputed literal for %)
+: i K + 1 ( f )
+          ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_dangling_operand_caret.txt
+++ b/compiler/tests/outputs/diag_dangling_operand_caret.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_dangling_operand_caret.nu:6:5: error: '^' (return) cannot appear here — it is being read as a value operand. A preceding prefix operator is short an argument and consumed this '^': every NURL operator has fixed arity and no closing bracket, so a missing operand silently swallows what follows. Count the operands on the operator before this '^'.
+    ^ n
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_dot_no_field_name.txt
+++ b/compiler/tests/outputs/diag_dot_no_field_name.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_dot_no_field_name.nu:9:1: error: expected a field name or an index after '.', found '}' (the enclosing block ends here). Field access is '. obj field' and element access is '. arr index' — the object comes FIRST, prefix style, not 'obj.field'. E.g. '. p x', '. buf 0'.
+}
+^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_elem_store_clash.txt
+++ b/compiler/tests/outputs/diag_elem_store_clash.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_elem_store_clash.nu:7:5: error: cannot store a value of type 'double' into this element — the element type differs and NURL has no implicit conversions
+    ^ 0
+    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_inout_arg_not_in_scope.txt
+++ b/compiler/tests/outputs/diag_inout_arg_not_in_scope.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_inout_arg_not_in_scope.nu:5:12: error: inout argument 'zzz' is not a binding in scope. An 'inout' argument must be a plain binding in scope, or one of its fields — the call site names the value plainly, '( f v )' or '( f . s field )'; the 'inout' marker appears only in the DECLARATION. The callee writes through it, so a temporary or an expression has nowhere to write back to.
+    ( bump zzz )
+           ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_objsafe_no_self_receiver.txt
+++ b/compiler/tests/outputs/diag_objsafe_no_self_receiver.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_objsafe_no_self_receiver.nu:9:14: error: method 'make' of trait 'Maker' has no Self receiver as its first parameter — not object-safe for '%Maker'
+@ use %Maker m → i { ^ 0 }
+             ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_objsafe_sink_receiver.txt
+++ b/compiler/tests/outputs/diag_objsafe_sink_receiver.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_objsafe_sink_receiver.nu:9:14: error: method 'eat' of trait 'Eater' has a 'sink' (by-value consuming) receiver — not object-safe for '%Eater' dispatch; use a by-value or 'inout' receiver
+@ use %Eater e → i { ^ 0 }
+             ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_select_default_body_unbraced.txt
+++ b/compiler/tests/outputs/diag_select_default_body_unbraced.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_select_default_body_unbraced.nu:7:31: error: expected '{' to open the default arm's body, found '^' (return). The default arm is '_ → { body }'.
+    ?? { [i] c → v {} _ → ^ 0 }
+                              ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_slice_elem_wrong_struct.txt
+++ b/compiler/tests/outputs/diag_slice_elem_wrong_struct.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_slice_elem_wrong_struct.nu:9:21: error: element 2 of this slice literal has type 'B' but the slice's declared element type is 'A' — a value of one named struct type where a different one is declared; the store would silently reinterpret its fields.
+    : [A xs [A | a b]
+                    ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_supertrait_empty.txt
+++ b/compiler/tests/outputs/diag_supertrait_empty.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_supertrait_empty.nu:2:13: error: expected at least one trait name after the supertrait ':', found '{'. A trait requiring others is '% Name : Base1 Base2 { ... }'; drop the ':' if there are none.
+% Speaker : { @ speak i self → i }
+            ^

--- a/tools/check_diag_anchor.py
+++ b/tools/check_diag_anchor.py
@@ -47,6 +47,12 @@ AT_EOF_OK = re.compile(
     r"\b(unterminated|unclosed|end of (file|input)|reached EOF|missing '\}')",
     re.I)
 
+# A message that reports FINDING the closing delimiter is anchored on its
+# own subject, not on the token after it. `^ . s` at the end of a block
+# really does run out of source at the '}', and "found '}'" is the honest
+# answer — so the closing-delimiter rule must not fire on it.
+NAMES_CLOSER = re.compile(r"found '[)\]}]'")
+
 # `<path>:<line>:<col>: error|warning: <msg>` — the shape all four
 # emitters print. die_at has no column and is skipped: with no column
 # there is no caret to misplace.
@@ -96,7 +102,7 @@ def check(tests_dir, repo_root):
             text = source_line(src, a["line"])
             if text is None:
                 continue  # the diagnostic names a file the golden does not carry
-            if AT_EOF_OK.search(a["msg"]):
+            if AT_EOF_OK.search(a["msg"]) or NAMES_CLOSER.search(a["msg"]):
                 continue
             if CLOSERS_ONLY.match(text) and text.strip():
                 a["text"] = text.strip()

--- a/tools/diag_coverage_baseline.txt
+++ b/tools/diag_coverage_baseline.txt
@@ -1,33 +1,16 @@
 080b833f7959  unknown field or variable ' ' — it is not a field of the struct being accessed, nor a binding in sco
 1919b534d625  volatile_store expects a typed pointer '*T' first, so it knows the width to write. Write '( volatile
 265709a49431  argument to ' ' has enum type ' ' but the parameter is declared enum ' ' — two enums are distinct no
-3842aa6639a4  method ' ' of trait ' ' has a 'sink' (by-value consuming) receiver — not object-safe for '% ' dispat
-39986b65138d  expected a field name or an index after '.', found . Field access is '. obj field' and element acces
 3cc2e514ea86  inout field argument to ' ' must be '. <binding> <field>' naming a plain struct binding
 3ef3446b70cc  ' ' is a compiler-auto-dropped value; passing it to a 'sink' parameter is not yet supported - pass a
-43a9804d1c0b  inout argument ' ' is not a binding in scope. An 'inout' argument must be a plain binding in scope, 
-50c9a5e6a8a5  cannot cast ' ' to an integer: its first field is itself an aggregate, so there is no scalar to take
-5ad763372c6c  method ' ' of trait ' ' has no Self receiver as its first parameter — not object-safe for '% '
-5dfdf7d4ec64  expected '{' to open the default arm's body, found . The default arm is '_ → { body }'.
-697d73c26332  expected a binding name, found . A binding is ': type name value' — the TYPE comes before the name, 
 737e4e2f64a2  an or-pattern's variants cannot bind payloads — the arms would disagree about what the name holds. L
-7f5fb5327ef2  element of this slice literal has type ' ' but the slice's declared element type is ' ' — a value of
 812c266928da  a supertrait ':' clause belongs on the trait DECLARATION ('% Name : Base { ... }'), not on an impl. 
 88d59a9c07fe  element of this slice literal has type ' ' but the slice's declared element type is ' ' — pointer-vs
 89608f397d6c  cannot mutate immutable parameter ' ' — parameters are immutable bindings. Copy it into a ': ~' loca
-8f8423944aed  const expression must be integer literals combined with + - * / << >> & | ^^ (use a precomputed lite
 8fa0e2858d9c  unexpected where a value was required. Every NURL operator has FIXED arity and no closing bracket, s
-a000cdd254fc  '#' is the cast operator; struct/enum literals use '@'. Write '@ { ... }' instead.
 a7b912fa462f  expected '→' after the match guard, found . A guarded arm is 'Variant payload ? guard → body' — the 
 ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
 ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
 af5a83d74d0f  cannot cast ' ' to an integer — '# i expr' converts numbers and pointers, not this type. There are n
-ca92cb54d21f  expected at least one trait name after the supertrait ':', found . A trait requiring others is '% Na
 d82fbf1f85b6  an or-pattern cannot mix a literal constraint with variant names — write the literal case as its own
 e13f6093bfb5  expected '{' to open the closure body, found . A closure is '\\ params → ret { body }' — the body is
-f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
-f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
-f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
-f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
-f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic
-f79c4038b6f2  cannot store a value of type ' ' into this element — the element type differs and NURL has no implic


### PR DESCRIPTION
## Why

Eighth pass. **205 of 229 diagnostics are now exercised**, against 173 unmeasured when this began.

**`# S { 1 }` was accepted silently — but only when `S` had exactly one field.**

```nurl
: S  { i a }         →  # S  { 1 }    compiled clean
: S2 { i a i b }     →  # S2 { 1 2 }  error: '#' is the cast operator; …use '@'
```

The guard tests "is this name a registered struct" by reading the key for field **index 1** — the *second* field. A one-field struct has no such key, fails the test, and sails through. A two-field struct was caught all along, which is exactly what kept the gap invisible: the message existed, a test of it would have passed, and the shape that slipped is the **newtype wrapper** — one of the commonest declarations there is.

## What

- **The struct test reads field index 0**, which every struct has.
- **Thirteen `diag_*` tests** for messages that were already right and had never been printed: the slice-element store clash, the nested-aggregate cast refusal, `.` with no field name, an immutable scalar parameter, a call inside a const expression, an empty supertrait clause, both remaining object-safety refusals, a wrong struct type in a slice literal, parentheses where a binding name goes, an inout argument naming nothing, an unbraced select default body, the dangling-operand caret.

**Coverage: 205 of 229 exercised (89%), up from 188. Never-fired 33 → 16.**

## Proof

```
./compiler/tests/run_tests.sh
PASS 746 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this branch and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

Same set and count as #847 onward on this container.

**The anchor gate failed the build twice on this commit's own tests, and the second failure was the gate's mistake, not the compiler's.** Both are worth naming:

1. *"bare function name 'K' used as a value"* printed its caret past the end of the line — a real mis-anchor, now `die_stmt`. Re-minting it moved `diag_ax_cures_2`'s caret **off the closing brace and onto the bare name itself** — a defect this series flagged back in #852 and left alone for want of a reason to touch that site.
2. *"expected a field name or an index after '.', found '}'"* was flagged for anchoring on a `}`. **It should not have been.** The message *names* the brace as what it found, and `^ . s` at the end of a block really does run out of source there. The rule was "a `}` is never the subject" — and this is the case where it is. The gate now exempts any message that reports finding a closing delimiter.

An intermediate run also broke `diag_ax_cures_2` (the anchor change above); its golden was re-minted after confirming the new column lands on `f` rather than on `}`.

One test was **rewritten rather than baselined**: `diag_const_expr_call` referenced the failed constant, so its golden captured a cascade message calling `K` a bare function name. The test is about the const-expression refusal; the cascade is noise and does not belong in a baseline.

```
./build.sh --no-tests           BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check                 compiler/nurlc.nu and every new test canonical
./tools/check_strict_arity.sh   OK — 1115 files, no arity trap
./tools/check_examples.sh       clean (1 skipped: optional FFI lib absent)
./tools/check_diag_anchor.sh    every baselined diagnostic points at real code
./tools/check_diag_coverage.sh  clean
```

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs.

## Known remaining

**16 sites never fire**, and the character of what is left has changed. Most are now either genuinely hard to reach or preempted by design rather than by accident — the tail is thinning, and a pass that finds nothing is the signal to stop sweeping and pick a different instrument.

**Four messages are written for programs that cannot reach them.** The enum-specific argument mismatch, the or-pattern payload refusal, the or-pattern bool-arm example (`T | F`), and the supertrait-on-impl message. Each states a true rule; none is reachable by the program its own text describes, because an earlier check gets there first. Making them reachable means reordering checks across passes — a refactor, not a diagnostics fix, and worth doing deliberately rather than inside a sweep.

**Six sites emit the identical sentence** (`cannot store a value of type ' ' into this element`) for six different container shapes. A reader cannot tell which fired, and neither can the coverage tool — one test marks all six covered by fingerprint. Worth distinguishing, but it is a wording project rather than a bug.

**Carried, unchanged:** an incomplete impl still reports "call to unknown function" (language-surface — wants an issue); `spec/grammar.ebnf` still has no `assoc_decl` production; `%` in a const expression stays preempted by a type error; the literal-range check still ignores signedness (documented); and the unknown-associated-type anchor is still a line late by design.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_