### PR TITLE
fix(ax): audit the instrument — coverage was reporting its own best case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was added. Fixed and held at zero, so this one gates rather than
   ratchets.
 
+### Changed
+
+- **The diagnostic-coverage number was overstated, and now is not.**
+  Matching is by message text, so two sites emitting the *same sentence*
+  are indistinguishable — one test made both read as exercised. Eleven
+  such groups existed, covering 30 sites; the worst prints
+  `cannot store a value of type … into an element of type …` from **six**
+  places. Those are reported as **ambiguous** rather than folded into
+  "exercised", which moves the honest figure from 205 to **177 of 228**.
+  A number that flatters the instrument is worse than a smaller one that
+  is true, and this instrument had been reporting its own best case for
+  eight passes.
+
 ### Fixed
+
+- **Six element-store diagnostics never said what type the element
+  was.** They named the value's type and then said "into this element",
+  leaving the reader to find the container's declaration to learn what
+  was wanted. All six had the expected type in scope at the point of the
+  message. They print it now.
 
 - **`# S { 1 }` was accepted silently for every single-field struct.**
   The guard that catches `'#' is the cast operator; struct/enum literals

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -13825,7 +13825,7 @@
             // self-compile); a tracked local frees at scope exit.
             : s __fs_rt ( nurl_get_last_type )
             ? ( __store_type_clash __fs_rt elem_ty )
-            { ( die lex ( nurl_str_cat3 `cannot store a value of type '` __fs_rt `' into this element — the element type differs and NURL has no implicit conversions` ) ) }
+            { ( die lex ( nurl_str_cat ( nurl_str_cat4 `cannot store a value of type '` __fs_rt `' into an element of type '` elem_ty ) `' — the element type differs and NURL has no implicit conversions. Convert the value explicitly, or declare the container with the type you mean to store in it.` ) ) }
             {}
             : s rhsc ( coerce_store_val lex rhs __fs_rt elem_ty syms cg )
             : s gep ( nurl_cg_reg cg )
@@ -13859,7 +13859,7 @@
             // self-compile); a tracked local frees at scope exit.
             : s __fs_rt ( nurl_get_last_type )
             ? ( __store_type_clash __fs_rt elem_ty )
-            { ( die lex ( nurl_str_cat3 `cannot store a value of type '` __fs_rt `' into this element — the element type differs and NURL has no implicit conversions` ) ) }
+            { ( die lex ( nurl_str_cat ( nurl_str_cat4 `cannot store a value of type '` __fs_rt `' into an element of type '` elem_ty ) `' — the element type differs and NURL has no implicit conversions. Convert the value explicitly, or declare the container with the type you mean to store in it.` ) ) }
             {}
             : s rhsc ( coerce_store_val lex rhs __fs_rt elem_ty syms cg )
             : s gep ( nurl_cg_reg cg )
@@ -13893,7 +13893,7 @@
             // self-compile); a tracked local frees at scope exit.
             : s __fs_rt ( nurl_get_last_type )
             ? ( __store_type_clash __fs_rt elem_type )
-            { ( die lex ( nurl_str_cat3 `cannot store a value of type '` __fs_rt `' into this element — the element type differs and NURL has no implicit conversions` ) ) }
+            { ( die lex ( nurl_str_cat ( nurl_str_cat4 `cannot store a value of type '` __fs_rt `' into an element of type '` elem_type ) `' — the element type differs and NURL has no implicit conversions. Convert the value explicitly, or declare the container with the type you mean to store in it.` ) ) }
             {}
             : s rhsc ( coerce_store_val lex rhs __fs_rt elem_type syms cg )
             // Emit array indexing GEP + store
@@ -13963,7 +13963,7 @@
                         // self-compile); a tracked local frees at scope exit.
                         : s __fs_rt ( nurl_get_last_type )
                         ? ( __store_type_clash __fs_rt st )
-                        { ( die lex ( nurl_str_cat3 `cannot store a value of type '` __fs_rt `' into this element — the element type differs and NURL has no implicit conversions` ) ) }
+                        { ( die lex ( nurl_str_cat ( nurl_str_cat4 `cannot store a value of type '` __fs_rt `' into an element of type '` st ) `' — the element type differs and NURL has no implicit conversions. Convert the value explicitly, or declare the container with the type you mean to store in it.` ) ) }
                         {}
                         : s rhsc ( coerce_store_val lex rhs __fs_rt st syms cg )
                         : s gep ( nurl_cg_reg cg )
@@ -14031,7 +14031,7 @@
                                 // self-compile); a tracked local frees at scope exit.
                                 : s __fs_rt ( nurl_get_last_type )
                                 ? ( __store_type_clash __fs_rt st )
-                                { ( die lex ( nurl_str_cat3 `cannot store a value of type '` __fs_rt `' into this element — the element type differs and NURL has no implicit conversions` ) ) }
+                                { ( die lex ( nurl_str_cat ( nurl_str_cat4 `cannot store a value of type '` __fs_rt `' into an element of type '` st ) `' — the element type differs and NURL has no implicit conversions. Convert the value explicitly, or declare the container with the type you mean to store in it.` ) ) }
                                 {}
                                 : s rhsc ( coerce_store_val lex rhs __fs_rt st syms cg )
                                 : s gep ( nurl_cg_reg cg )
@@ -14062,7 +14062,7 @@
                     // self-compile); a tracked local frees at scope exit.
                     : s __fs_rt ( nurl_get_last_type )
                     ? ( __store_type_clash __fs_rt st )
-                    { ( die lex ( nurl_str_cat3 `cannot store a value of type '` __fs_rt `' into this element — the element type differs and NURL has no implicit conversions` ) ) }
+                    { ( die lex ( nurl_str_cat ( nurl_str_cat4 `cannot store a value of type '` __fs_rt `' into an element of type '` st ) `' — the element type differs and NURL has no implicit conversions. Convert the value explicitly, or declare the container with the type you mean to store in it.` ) ) }
                     {}
                     : s rhsc ( coerce_store_val lex rhs __fs_rt st syms cg )
                     : s gep ( nurl_cg_reg cg )

--- a/compiler/tests/README.md
+++ b/compiler/tests/README.md
@@ -53,6 +53,18 @@ gaps do not fail, a **new** die site with no test that fires it does.
 Adding a diagnostic and adding the program that triggers it are one
 change, not two.
 
+It also reports an **ambiguous** count, and that number is the tool
+being honest about its own method. Matching is by message text, so two
+sites emitting the *same sentence* are indistinguishable: one test makes
+both read as exercised. Six sites print `cannot store a value of type …
+into an element of type …` for six different container shapes, and there
+were eleven such groups in all. Those sites are counted separately
+rather than folded into "exercised" — a number that flatters the
+instrument is worse than a smaller one that is true.
+
+Two sites sharing a sentence is also a finding in its own right: a
+reader cannot tell which check rejected their program either.
+
 ## Diagnostic anchors
 
 Coverage answers "has anything ever printed this?". It cannot answer

--- a/compiler/tests/outputs/diag_elem_store_clash.txt
+++ b/compiler/tests/outputs/diag_elem_store_clash.txt
@@ -1,6 +1,6 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_elem_store_clash.nu:7:5: error: cannot store a value of type 'double' into this element — the element type differs and NURL has no implicit conversions
+compiler/tests/diag_elem_store_clash.nu:7:5: error: cannot store a value of type 'double' into an element of type 'i64' — the element type differs and NURL has no implicit conversions. Convert the value explicitly, or declare the container with the type you mean to store in it.
     ^ 0
     ^
 error: aborting due to 1 previous error

--- a/tools/diag_coverage.py
+++ b/tools/diag_coverage.py
@@ -29,6 +29,7 @@ import json
 import os
 import re
 import sys
+import collections
 from collections import Counter
 
 # Every emitter that puts a diagnostic in front of the user. die_if_void
@@ -130,14 +131,32 @@ def load_stderr(errdir):
 
 
 def classify(sites, captured):
-    covered, uncovered, unmatchable = [], [], []
+    """covered / uncovered / unmatchable / ambiguous.
+
+    `ambiguous` is the honest half of the instrument. Text matching
+    cannot tell two sites apart when they emit the SAME sentence — and
+    six of them did, for six different container shapes. One test made
+    all six read as exercised, so the covered count overstated by five.
+    Sites sharing a fingerprint are reported separately rather than
+    counted as independently reached: a number that flatters the tool is
+    worse than a smaller number that is true.
+    """
+    shared = collections.Counter(s["fingerprint"] for s in sites
+                                 if s["fingerprint"])
+    covered, uncovered, unmatchable, ambiguous = [], [], [], []
     for s in sites:
         if s["fingerprint"] is None:
             unmatchable.append(s)
             continue
         s["hits"] = [k for k, v in captured.items() if s["fingerprint"] in v]
-        (covered if s["hits"] else uncovered).append(s)
-    return covered, uncovered, unmatchable
+        s["shares_text_with"] = shared[s["fingerprint"]] - 1
+        if not s["hits"]:
+            uncovered.append(s)
+        elif s["shares_text_with"]:
+            ambiguous.append(s)
+        else:
+            covered.append(s)
+    return covered, uncovered, unmatchable, ambiguous
 
 
 def main():
@@ -147,7 +166,7 @@ def main():
 
     sites = scan_sites(src)
     captured = load_stderr(errdir)
-    covered, uncovered, unmatchable = classify(sites, captured)
+    covered, uncovered, unmatchable, ambiguous = classify(sites, captured)
 
     if mode == "fingerprints":
         # The baseline format: one `key  text` line per never-fired site,
@@ -158,7 +177,8 @@ def main():
 
     if mode == "json":
         json.dump({"covered": covered, "uncovered": uncovered,
-                   "unmatchable": unmatchable}, sys.stdout, indent=1)
+                   "unmatchable": unmatchable, "ambiguous": ambiguous},
+                  sys.stdout, indent=1)
         return 0
 
     if mode == "report":
@@ -166,6 +186,13 @@ def main():
               "─────────────────────────────")
         for s in sorted(uncovered, key=lambda x: x["line"]):
             print(f"{src}:{s['line']}: {s['emitter']}: {s['text'][:150]}")
+        if ambiguous:
+            print(f"── ambiguous ({len(ambiguous)}) — share their text with "
+                  "another site, so a hit cannot be attributed ──")
+            for a in sorted(ambiguous, key=lambda x: x["line"]):
+                print(f"{src}:{a['line']}: {a['emitter']}: "
+                      f"(+{a['shares_text_with']} twin) {a['text'][:110]}")
+            print()
         if unmatchable:
             print(f"\n── unmatchable by text ({len(unmatchable)}) "
                   "— message is built in a variable ──")
@@ -179,6 +206,8 @@ def main():
     print(f"  exercised      : {len(covered)}"
           f"  ({100 * len(covered) // max(total, 1)}%)")
     print(f"  never fired    : {len(uncovered)}")
+    print(f"  ambiguous      : {len(ambiguous)}"
+          f"  (a test printed this text, but so would sibling sites)")
     print(f"  unmatchable    : {len(unmatchable)}")
     print(f"  by emitter     : {dict(Counter(s['emitter'] for s in sites))}")
     print(f"  corpus files   : {len(captured)}")


### PR DESCRIPTION
## Why

Ninth pass, and this one turned on the tool rather than the compiler.

**Eight PRs have quoted a coverage figure from `check_diag_coverage.sh`. The figure was wrong, in the flattering direction.** The previous round's own Known-remaining note is what gave it away — it observed that six sites emit an identical sentence for six container shapes, and the consequence of that had not been followed through: **one test marks all six as exercised.**

Measured properly:

```
228 sites   ·   202 distinct fingerprints
30 sites share their text with at least one sibling, across 11 groups
```

Matching is by message text, so those sites are indistinguishable to the tool. That is not a bug to fix — it is a limit to state.

| | reported | honest |
|---|---|---|
| exercised | 205 | **177** |
| ambiguous | *(counted as exercised)* | 28 |
| never fired | 16 | 16 |

Nothing regressed. The instrument stopped rounding in its own favour.

**And two sites sharing a sentence is a finding about the diagnostics, not only about the tool** — a reader cannot tell which check rejected their program either.

## What

- **`ambiguous` is now its own category** in `check_diag_coverage.sh`, reported and documented rather than folded into "exercised". The ratchet is unaffected; only the honesty of the summary changed.
- **The six element-store messages now name the element type.** Every one of them printed the value's type and then said *"into this element"* — never what the element type actually was, leaving the reader to go find the container's declaration to learn what was wanted. All six had the expected type in a local at the point of the message:

```
- cannot store a value of type 'double' into this element — the element type differs …
+ cannot store a value of type 'double' into an element of type 'i64' — the element type differs …
```

They still share their wording, so they **stay ambiguous** — and that is the honest state. Distinguishing them means naming six container shapes I could not determine reliably from the code, and guessing at them would put a false claim in a message, which is the exact defect this series keeps finding.

- `compiler/tests/README.md` documents the category and why it exists.

## Proof

```
./compiler/tests/run_tests.sh
PASS 746 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this branch and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

Same set and count as #847 onward on this container. An intermediate run showed FAIL 15 — `diag_elem_store_clash`, whose golden holds the message that changed; re-minted after checking the new text.

```
./build.sh --no-tests           BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check                 compiler/nurlc.nu canonical
./tools/check_strict_arity.sh   OK — 1115 files, no arity trap
./tools/check_diag_anchor.sh    every baselined diagnostic points at real code
./tools/check_diag_coverage.sh  clean
```

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs.

## Known remaining

**177 exercised, 28 ambiguous, 16 never fired, 7 unmatchable** — that is the real state of the 228 sites, and it is the number future passes should be measured against rather than the 205 this PR retires.

**The 28 ambiguous sites are the largest remaining block, and clearing them is a wording project.** Eleven groups repeat a sentence: six element stores, four duplicate-declaration refusals, three select-arm shapes, three implicit-conversion refusals, and six pairs. Each group wants its members to say which construct they are about — useful to a reader independently of the tool. It is bigger than a sweep and wants doing deliberately.

**Carried, unchanged:** four messages are written for programs that cannot reach them (enum-specific argument mismatch, or-pattern payload refusal, the `T | F` example, supertrait-on-impl) — all preempted by an earlier check, and reordering them is a refactor rather than a diagnostics fix; an incomplete impl still reports "call to unknown function" (language-surface — wants an issue); `spec/grammar.ebnf` still has no `assoc_decl` production; `%` in a const expression stays preempted by a type error; the literal-range check still ignores signedness (documented); and the unknown-associated-type anchor is still a line late by design.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_