### PR TITLE
fix(ax): the fingerprint was long where it should have been discriminating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Coverage fingerprints now discriminate rather than merely being
+  long.** Picking the longest literal at a site is the obvious rule and
+  the wrong one: the longest run is usually the shared explainer tail
+  two sibling messages both end with, while the sentence that differs —
+  the one naming which construct was rejected — is shorter and got
+  discarded. Nine sites read as indistinguishable for that reason alone,
+  which was the instrument's fault and not the compiler's. The tool now
+  prefers a literal no other site carries. **Six real gaps came out from
+  behind a sibling's hit**, having been counted as exercised for as long
+  as the tool has existed.
+
 - **The diagnostic-coverage number was overstated, and now is not.**
   Matching is by message text, so two sites emitting the *same sentence*
   are indistinguishable — one test made both read as exercised. Eleven
@@ -106,6 +117,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   eight passes.
 
 ### Fixed
+
+- **Three pairs of diagnostics were word-for-word identical, so neither
+  member said which construct it meant.** A closure's parameter list and
+  a declaration's printed the same sentence; a repeated variant inside an
+  or-pattern was reported as "a match arm already covers" it; and the
+  unresolved-operand message for `&` and for `|` did not name the
+  operator. Each now identifies itself — which a reader needs
+  independently of any tooling, since the two members are reached by
+  different mistakes.
 
 - **Six element-store diagnostics never said what type the element
   was.** They named the value's type and then said "into this element",

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -3744,7 +3744,7 @@
             { ( die lex `FFI declaration inside a function body — an '&' library import ('& <lib> @ name args → ret') is a top-level form; move it to the top of the file next to the '$' imports` ) }
             {}
             : s msg ( nurl_str_cat `operator & requires matching types — got ` ( llvm_to_nurl lt ) )
-            ( die lex ( nurl_str_cat msg ` and unknown — the operand types could not be resolved, which usually means an earlier error in this expression. Fix the first diagnostic and re-run.` ) )
+            ( die lex ( nurl_str_cat msg ` and unknown — the operands of '&' could not both be resolved, which usually means an earlier error in this expression. Fix the first diagnostic and re-run.` ) )
             ^ ( nurl_str_cat `error` `` )
         }
     }
@@ -3763,7 +3763,7 @@
     { ? > ( int_width lt ) 0
         { ^ ( gen_bitwise_binary lv lt lex syms cg TT_PIPE ) }
         { : s msg ( nurl_str_cat `operator | requires matching types — got ` ( llvm_to_nurl lt ) )
-            ( die lex ( nurl_str_cat msg ` and unknown — the operand types could not be resolved, which usually means an earlier error in this expression. Fix the first diagnostic and re-run.` ) )
+            ( die lex ( nurl_str_cat msg ` and unknown — the operands of '|' could not both be resolved, which usually means an earlier error in this expression. Fix the first diagnostic and re-run.` ) )
             ^ ( nurl_str_cat `error` `` )
         }
     }
@@ -9239,7 +9239,7 @@
                             : s vn ( str_first_word orr )
                             = orr ( str_skip_word orr )
                             ? ( str_contains_word seen_variants vn )
-                            { ( die lex ( nurl_str_cat3 `a match arm already covers variant '` vn `' — each variant may appear once. Remove the duplicate, or fold the two bodies together.` ) ) } {}
+                            { ( die lex ( nurl_str_cat3 `this or-pattern repeats variant '` vn `' — an or-pattern lists each alternative once, and a repeat is either a typo or a variant the arms above already took. Remove it.` ) ) } {}
                             = seen_variants ? == 0 ( nurl_str_len seen_variants )
                             vn ( nurl_str_cat3 seen_variants ` ` vn )
                         }
@@ -16720,8 +16720,8 @@
 
         ? ! ( is_ident_tok ( nurl_lex_type lex ) )
         { ( die lex ( nurl_str_cat3
-            `expected a parameter name after its type, found ` ( tok_here lex )
-            `. Parameters are written 'type name', repeated, with no commas: '@ f i a i b → i'. A parenthesised type keeps the pair shape: '( Vec i ) v'.` ) ) }
+            `expected a parameter name after its type in this closure's parameter list, found ` ( tok_here lex )
+            `. Parameters are written 'type name', repeated, with no commas: '@ f i a i b → i'. A parenthesised type keeps the pair shape: '( Vec i ) v'. A closure spells them the same way, between the '\\' and the arrow: '\\ i x i y → i { ... }'.` ) ) }
         {}
 
         : s pname ( nurl_lex_val lex )
@@ -19268,7 +19268,7 @@
         ( nurl_set_last_type ( nurl_str_cat3 cur_params `, ` entry ) )
     }
     { ( die lex ( nurl_str_cat3
-        `expected a parameter name after its type, found ` ( tok_here lex )
+        `expected a parameter name after its type in this declaration's parameter list, found ` ( tok_here lex )
         `. Parameters are written 'type name', repeated, with no commas: '@ f i a i b → i'. A parenthesised type keeps the pair shape: '( Vec i ) v'.` ) ) }
 }
 

--- a/compiler/tests/diag_closure_param_no_name.nu
+++ b/compiler/tests/diag_closure_param_no_name.nu
@@ -1,0 +1,10 @@
+// diag_closure_param_no_name.nu — a closure parameter type with no name.
+//
+// The message used to be word-for-word the one gen_fn_param prints, so
+// neither said which list it meant and the tool could not tell them
+// apart. Each now names its own construct, and the closure's adds the
+// spelling between the '\' and the arrow.
+@ main → i {
+    : ( @ i i i ) f \ i x i → i { ^ x }
+    ^ 0
+}

--- a/compiler/tests/diag_orpattern_repeat.nu
+++ b/compiler/tests/diag_orpattern_repeat.nu
@@ -1,0 +1,13 @@
+// diag_orpattern_repeat.nu — a variant listed twice in one or-pattern.
+//
+// This shared its text with the plain-arm duplicate check in the same
+// function. Both said "a match arm already covers variant" — true of
+// the arm case, and a poor description of an alternative repeated
+// inside a single pattern.
+: | D { N S E W }
+
+@ main → i {
+    : D d @ D { N }
+    : i r ?? d { N | S | N → 1 E → 2 W → 3 }
+    ^ r
+}

--- a/compiler/tests/diag_select_arm_no_arrow.nu
+++ b/compiler/tests/diag_select_arm_no_arrow.nu
@@ -1,0 +1,15 @@
+// diag_select_arm_no_arrow.nu — a select arm with no '→' after the
+// channel. The scan runs to end of input looking for one, so the
+// message carries the whole arm shape rather than pointing at a token.
+//
+// This site was hiding behind a sibling: it shares its explainer tail
+// with two other select-arm messages, and the coverage tool used to
+// fingerprint on the LONGEST literal — which was that shared tail. One
+// test on any of the three marked all three exercised.
+$ `stdlib/std/channel.nu`
+
+@ main → i {
+    : ( Channel i ) c ( chan_new [i] )
+    ?? { [i] c v {} }
+    ^ 0
+}

--- a/compiler/tests/diag_select_arm_no_name.nu
+++ b/compiler/tests/diag_select_arm_no_name.nu
@@ -1,0 +1,10 @@
+// diag_select_arm_no_name.nu — a select arm whose '→' is followed
+// straight by the body, with no name for the received value.
+// Exposed by the same fingerprint fix as diag_select_arm_no_arrow.
+$ `stdlib/std/channel.nu`
+
+@ main → i {
+    : ( Channel i ) c ( chan_new [i] )
+    ?? { [i] c → {} }
+    ^ 0
+}

--- a/compiler/tests/outputs/diag_closure_param_no_name.txt
+++ b/compiler/tests/outputs/diag_closure_param_no_name.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_closure_param_no_name.nu:8:29: error: expected a parameter name after its type in this closure's parameter list, found '→'. Parameters are written 'type name', repeated, with no commas: '@ f i a i b → i'. A parenthesised type keeps the pair shape: '( Vec i ) v'. A closure spells them the same way, between the '\' and the arrow: '\ i x i y → i { ... }'.
+    : ( @ i i i ) f \ i x i → i { ^ x }
+                            ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_orpattern_repeat.txt
+++ b/compiler/tests/outputs/diag_orpattern_repeat.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_orpattern_repeat.nu:11:32: error: this or-pattern repeats variant 'N' — an or-pattern lists each alternative once, and a repeat is either a typo or a variant the arms above already took. Remove it.
+    : i r ?? d { N | S | N → 1 E → 2 W → 3 }
+                               ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_param_no_name.txt
+++ b/compiler/tests/outputs/diag_param_no_name.txt
@@ -1,6 +1,6 @@
 COMPILE FAIL
 ERRORS
-compiler/tests/diag_param_no_name.nu:4:7: error: expected a parameter name after its type, found '→'. Parameters are written 'type name', repeated, with no commas: '@ f i a i b → i'. A parenthesised type keeps the pair shape: '( Vec i ) v'.
+compiler/tests/diag_param_no_name.nu:4:7: error: expected a parameter name after its type in this declaration's parameter list, found '→'. Parameters are written 'type name', repeated, with no commas: '@ f i a i b → i'. A parenthesised type keeps the pair shape: '( Vec i ) v'.
 @ f i → i { ^ 0 }
       ^
 error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_select_arm_no_arrow.txt
+++ b/compiler/tests/outputs/diag_select_arm_no_arrow.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_select_arm_no_arrow.nu:16:1: error: expected '→' after the channel in this select arm, found end of input. A select arm is '[T] chan → name { body }' — the element type in brackets, the channel, then the name the received value binds to. The default arm is '_ → { body }'. E.g. '?? { [i] c → v { ( use v ) }  _ → { ( idle ) } }'.
+
+^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_select_arm_no_name.txt
+++ b/compiler/tests/outputs/diag_select_arm_no_name.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_select_arm_no_name.nu:8:20: error: expected the received value's name after '→', found '{'. A select arm is '[T] chan → name { body }' — the element type in brackets, the channel, then the name the received value binds to. The default arm is '_ → { body }'. E.g. '?? { [i] c → v { ( use v ) }  _ → { ( idle ) } }'.
+    ?? { [i] c → {} }
+                   ^
+error: aborting due to 1 previous error

--- a/tools/diag_coverage.py
+++ b/tools/diag_coverage.py
@@ -94,8 +94,9 @@ def scan_sites(path):
             "emitter": m.group(1),
             "line": src.count("\n", 0, m.start()) + 1,
             "text": norm(" ".join(lits)),
-            "fingerprint": fingerprint(lits),
+            "candidates": candidates(lits),
         })
+    assign_fingerprints(sites)
     return sites
 
 
@@ -103,16 +104,36 @@ def norm(s):
     return re.sub(r"\s+", " ", s).strip()
 
 
-def fingerprint(lits):
-    """The longest literal run in a message — what to grep stderr for.
+def candidates(lits):
+    """Every literal at a site long enough to identify it, longest first."""
+    return [c for c in sorted((norm(l) for l in lits), key=len, reverse=True)
+            if len(c) >= MIN_FINGERPRINT]
 
-    None when every fragment is short or the whole message arrives in a
-    variable: those sites are unmatchable by text and are reported
-    separately rather than counted as uncovered, because a false "never
-    fired" is worse than an honest gap in the instrument.
+
+def fingerprint(lits):
+    """Back-compat single-site pick: the longest usable literal."""
+    return next(iter(candidates(lits)), None)
+
+
+def assign_fingerprints(sites):
+    """Choose each site's fingerprint to DISCRIMINATE, not merely to be long.
+
+    Picking the longest literal is the obvious rule and the wrong one:
+    the longest run is usually the shared explainer tail two sibling
+    messages both end with, while the sentence that differs — the one
+    that actually says which construct was rejected — is shorter and got
+    discarded. Nine sites read as indistinguishable for that reason
+    alone, which is the instrument's fault and not the compiler's.
+
+    So: prefer a literal no other site carries, and fall back to the
+    longest only when every candidate is shared. What remains ambiguous
+    after this really is duplicated text.
     """
-    cands = sorted((norm(l) for l in lits), key=len, reverse=True)
-    return next((c for c in cands if len(c) >= MIN_FINGERPRINT), None)
+    seen = Counter(c for s in sites for c in s["candidates"])
+    for s in sites:
+        uniq = [c for c in s["candidates"] if seen[c] == 1]
+        s["fingerprint"] = (uniq[0] if uniq
+                            else (s["candidates"][0] if s["candidates"] else None))
 
 
 def site_key(site):

--- a/tools/diag_coverage_baseline.txt
+++ b/tools/diag_coverage_baseline.txt
@@ -3,14 +3,15 @@
 265709a49431  argument to ' ' has enum type ' ' but the parameter is declared enum ' ' — two enums are distinct no
 3cc2e514ea86  inout field argument to ' ' must be '. <binding> <field>' naming a plain struct binding
 3ef3446b70cc  ' ' is a compiler-auto-dropped value; passing it to a 'sink' parameter is not yet supported - pass a
+4e42515f9201  and unknown — the operands of '|' could not both be resolved, which usually means an earlier error i
+4fd2d2fa785d  expected a parameter name after its type in this closure's parameter list, found . Parameters are wr
+6b1dab732ec2  and unknown — the operands of '&' could not both be resolved, which usually means an earlier error i
 737e4e2f64a2  an or-pattern's variants cannot bind payloads — the arms would disagree about what the name holds. L
 812c266928da  a supertrait ':' clause belongs on the trait DECLARATION ('% Name : Base { ... }'), not on an impl. 
 88d59a9c07fe  element of this slice literal has type ' ' but the slice's declared element type is ' ' — pointer-vs
 89608f397d6c  cannot mutate immutable parameter ' ' — parameters are immutable bindings. Copy it into a ': ~' loca
 8fa0e2858d9c  unexpected where a value was required. Every NURL operator has FIXED arity and no closing bracket, s
 a7b912fa462f  expected '→' after the match guard, found . A guarded arm is 'Variant payload ? guard → body' — the 
-ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
-ac66e0e045a5  and unknown — the operand types could not be resolved, which usually means an earlier error in this 
 af5a83d74d0f  cannot cast ' ' to an integer — '# i expr' converts numbers and pointers, not this type. There are n
 d82fbf1f85b6  an or-pattern cannot mix a literal constraint with variant names — write the literal case as its own
 e13f6093bfb5  expected '{' to open the closure body, found . A closure is '\\ params → ret { body }' — the body is


### PR DESCRIPTION
## Why

Tenth pass, continuing #858's audit of the instrument.

#858 established that sites sharing a sentence cannot be told apart, and reported them honestly as `ambiguous`. **This round found that most of that ambiguity was the tool's own doing.**

The fingerprint was the *longest* literal at a site. That is the obvious rule and the wrong one — the longest run is usually the shared explainer tail two sibling messages both end with:

```
expected '→' after the channel in this select arm, found …
   ← the sentence that differs, and identifies the site
. A select arm is '[T] chan → name { body }' — the element type in brackets, the channel, then …
   ← the shared tail, longer, and what got picked
```

Nine sites read as indistinguishable for that reason alone.

## What

**Fingerprints now prefer a literal no other site carries**, falling back to the longest only when every candidate is shared.

| | before | after |
|---|---|---|
| exercised | 177 | **190** |
| ambiguous | 28 | **14** |
| never fired | 16 | **17** |

**Six never-fired sites came out from behind a sibling's hit** — counted as exercised for as long as the tool has existed. Two select-arm shapes, a closure parameter without a name, a repeated or-pattern variant, and both unresolved-operand messages. All six now have tests.

**Then the compiler half — three pairs that were genuinely word-for-word identical and could be told apart from the code:**

- `gen_closure_expr` and `gen_fn_param` printed the same sentence about a missing parameter name. Each now names its own list, and the closure's adds the spelling between the `\` and the arrow.
- A variant repeated inside an **or-pattern** was reported as *"a match arm already covers"* it — true of the arm case, and a poor description of an alternative repeated inside one pattern.
- The unresolved-operand message did not say whether `&` or `|` was the operator whose operands would not resolve.

Each pair is reached by a different mistake, so a reader needs the distinction independently of any tooling.

## Proof

```
./compiler/tests/run_tests.sh
PASS 750 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this branch and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

Same set and count as #847 onward on this container. An intermediate run showed FAIL 15 — `diag_param_no_name`, whose golden holds the message that now names the declaration's list; re-minted after checking the new text.

**One mistake of my own, caught before it shipped:** the closure message first went in carrying a literal `→` escape. NURL does not interpret that, so the message printed the escape where the arrow belonged — the same class of defect this series exists to find, introduced while fixing one. Caught by reading the probe output rather than by any gate.

```
./build.sh --no-tests           BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check                 compiler/nurlc.nu and all 4 new tests canonical
./tools/check_strict_arity.sh   OK — 1115 files, no arity trap
./tools/check_examples.sh       clean (1 skipped: optional FFI lib absent)
./tools/check_diag_anchor.sh    every baselined diagnostic points at real code
./tools/check_diag_coverage.sh  clean
```

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs.

## Known remaining

**190 exercised, 17 never fired, 14 ambiguous, 7 unmatchable, of 228.**

**What stays ambiguous is now one of three things, and only one of them is a defect:**

1. **Deliberate.** The two enum-name messages are identical on purpose — #852 made them so, precisely so both spellings answer alike.
2. **Undetermined.** The six element stores. Distinguishing them means naming six container shapes I could not establish reliably from the code, and guessing would put a false claim in a message.
3. **Below the floor.** Two pairs whose distinguishing sentence is shorter than the 18-character fingerprint minimum. Lowering the floor trades this for false matches against ordinary prose; not obviously worth it.

**The tail is now genuinely thin.** Nine passes found a false claim or a silent miscompile every time; this one found the instrument lying to itself instead. That is the signal I flagged in #857 — when sweeping stops finding compiler defects and starts finding tooling artifacts, the next round should pick a different instrument rather than sweep again.

**Carried, unchanged:** four messages are written for programs that cannot reach them (all preempted by an earlier check — reordering is a refactor, not a diagnostics fix); an incomplete impl still reports "call to unknown function" (language-surface — wants an issue); `spec/grammar.ebnf` still has no `assoc_decl` production; `%` in a const expression stays preempted by a type error; the literal-range check still ignores signedness (documented); the unknown-associated-type anchor is still a line late by design.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_