### PR TITLE
fix(ax): mutate a working program — and the arity trap that closed silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was added. Fixed and held at zero, so this one gates rather than
   ratchets.
 
+### Added
+
+- **`tools/diag_mutate.py` — one realistic mistake in a real program.**
+  Every negative test in the corpus is minimal by construction: the
+  mistake *is* the program, so there is nothing after it to go wrong. A
+  model writes a hundred lines and gets one of them wrong, usually not
+  the last one. This probe takes working programs, injects a single
+  mistake a model plausibly makes, and counts what comes out — one
+  diagnostic (good), several (a cascade to triage), or **none**.
+
+  Not a gate: the mutation set is a judgement about what models get
+  wrong, and the interesting result is a program to go and read, never a
+  number to enforce. Its first run reported six programs silently
+  accepted; every one was the mutation landing inside a comment, which
+  is the same masking lesson `diag_coverage.py` already carries, learned
+  the same way.
+
 ### Changed
 
 - **Coverage fingerprints now discriminate rather than merely being
@@ -117,6 +134,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   eight passes.
 
 ### Fixed
+
+- **A binary operator one operand short swallowed the next statement and
+  compiled.** `= n + n` followed by `( side )` took the call as its
+  second operand; a `v`-returning call's value is `undef`, so nurlc
+  emitted `add i64 %r2, undef` **with status 0**. The program linked,
+  ran, computed garbage, and still performed the swallowed call as a side
+  effect of an addition. `die_if_void` could not see it — it tests the
+  operand's *value* against `void`, and a void call's value is `undef`.
+  The rule now lives at the binary-operator site alone: an initialiser
+  may legitimately take a `?` whose arms both return, which also yields
+  `undef`.
+
+- **`stdlib/ext/json.nu` emitted the `:` separator unconditionally.**
+  Two lines read `? + k 1 < n {`, which in prefix form is the condition
+  `k + 1` — always true — followed by a dead `< n { … }`. The IR shows
+  it plainly: `icmp ne i64 %r4, 0` as the branch test, and
+  `icmp slt i64 %r6, undef` computed and discarded. Written `? < + k 1 n
+  {`. Found by the new probe, via the guard above: the object emitter had
+  been taking the value branch whether or not a value followed.
 
 - **Three pairs of diagnostics were word-for-word identical, so neither
   member said which construct it meant.** A closure's parameter list and

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -196,6 +196,21 @@
 // keyword emits the literal value `void`, which is what breaks. `ctx` names the
 // consuming construct.
 @ die_if_void i lex s val s ctx → v {
+    // `undef` is the second spelling, and the one that mattered. The
+    // header above says a `v`-returning CALL "yields a real register
+    // whose type is void but whose value is a valid SSA name", so the
+    // consuming instruction is well-formed. It is not: gen_call gives a
+    // void call the value `undef`, and `+ n ( side )` emitted
+    //
+    //     %r3 = add i64 %r2, undef
+    //
+    // with status 0. That shape arrives by ACCIDENT far more often than
+    // a bare `v` is written on purpose — a binary operator one operand
+    // short swallows the next statement, and if that statement is a
+    // `v`-returning call the arity trap closes silently and the program
+    // computes garbage. Found by mutating a working program: dropping
+    // one operand from `= shared_counter + shared_counter 1` compiled
+    // clean and unlocked a mutex as a side effect of an addition.
     ? ( seq val `void` )
     { ( die lex ( nurl_str_cat ctx ` operand is the void/unit value 'v' — a bare type keyword yields no value and cannot be used here` ) ) }
     {}
@@ -3318,6 +3333,17 @@
     : ~ s rt ( nurl_get_last_type )
     ( die_if_void lex lv `binary operator's left` )
     ( die_if_void lex rv `binary operator's right` )
+    // The OTHER spelling of "no value", and the one that arrives by
+    // accident. gen_call gives a `v`-returning call the value `undef`,
+    // so `+ n ( side )` emitted `add i64 %r2, undef` with status 0 —
+    // and a binary operator one operand short swallows the following
+    // statement, which is how a call lands in operand position at all.
+    // Only binary operators get this rule: an initialiser may take a
+    // '?' whose arms both return, which also yields undef and is legal
+    // (dead_store_both_arms_ret), so die_if_void itself stays value-only.
+    ? | & ( seq lv `undef` ) ( seq lt `void` ) & ( seq rv `undef` ) ( seq rt `void` )
+    { ( die_stmt lex `an operand of this binary operator is a call that returns 'v', so it has no value to combine. Usually the operator is one operand SHORT and has swallowed the following statement: every NURL operator has fixed arity and no closing bracket, so count the operands before this one. If the call was meant to run for its effect, put it on its own line.` ) }
+    {}
     // ── Enum operands are NOMINAL ─────────────────────────────────────
     // `== c Green` used to emit `icmp eq %Color %r4, %r5` with %r5 an
     // i64 tag — invalid IR only clang saw (so the diag_cond_enum cure

--- a/compiler/tests/diag_binop_void_call_operand.nu
+++ b/compiler/tests/diag_binop_void_call_operand.nu
@@ -1,0 +1,27 @@
+// diag_binop_void_call_operand.nu — a binary operator one operand short,
+// which swallows the following statement.
+//
+// This was a silent miscompile. `+ n` needs a second operand, so it took
+// the NEXT statement — a call returning 'v' — and gen_call gives a void
+// call the value `undef`:
+//
+//     %r3 = add i64 %r2, undef
+//
+// nurlc printed that with status 0. The program compiled, linked, ran,
+// and computed garbage while the swallowed call still happened, as a
+// side effect of an addition.
+//
+// die_if_void could not see it: it tests the operand's VALUE against
+// 'void', and a v-returning call's value is 'undef'. Widening that
+// helper is wrong — an initialiser may legitimately take a '?' whose
+// arms both return, which also yields undef (dead_store_both_arms_ret).
+// Only a BINARY operator can never have a valueless operand, so the rule
+// lives at that site alone.
+@ side → v { ( nurl_print `SIDE\n` ) }
+
+@ main → i {
+    : ~ i n 1
+    = n + n
+    ( side )
+    ^ 0
+}

--- a/compiler/tests/outputs/diag_binop_void_call_operand.txt
+++ b/compiler/tests/outputs/diag_binop_void_call_operand.txt
@@ -1,0 +1,4 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_binop_void_call_operand.nu:24:5: error: an operand of this binary operator is a call that returns 'v', so it has no value to combine. Usually the operator is one operand SHORT and has swallowed the following statement: every NURL operator has fixed arity and no closing bracket, so count the operands before this one. If the call was meant to run for its effect, put it on its own line.
+error: aborting due to 1 previous error

--- a/stdlib/ext/json.nu
+++ b/stdlib/ext/json.nu
@@ -1023,7 +1023,7 @@ $ `stdlib/core/vec.nu`
                     T jk → ( __js_emit_value out jk )
                     F → {}
                 }
-                ? + k 1 < n {
+                ? < + k 1 n {
                     ( string_push_char out 58 )
                     : ?Json ev ( vec_get [Json] v + k 1 )
                     ?? ev {
@@ -1264,7 +1264,7 @@ $ `stdlib/core/vec.nu`
                     T jk → {
                         ?? jk {
                             JStr ks → {
-                                ? + k 1 < n {
+                                ? < + k 1 n {
                                     : ?Json ev ( vec_get [Json] v + k 1 )
                                     ?? ev {
                                         T jv → ( f ( string_data ks ) jv )

--- a/tools/diag_mutate.py
+++ b/tools/diag_mutate.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Dual-licensed under MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE) at your option.
+# ============================================================
+#  diag_mutate.py — one realistic mistake in a real program.
+#
+#     python3 tools/diag_mutate.py thread_basic dist_ring …
+#
+#  Prints, per mutant, how many diagnostics came out. Three outcomes
+#  matter: exactly one (good), several (a cascade the reader must
+#  triage), and NONE — a broken program the compiler accepted.
+#
+#  Not a gate. It is a hunting tool: the mutation set is a judgement
+#  about what models get wrong, and the interesting result is always a
+#  program to go and read, never a number to enforce.
+# ============================================================
+"""Mutation probe: one realistic mistake in a real program.
+
+The corpus's negative tests are minimal by construction — the mistake IS
+the program, so there is nothing after it to cascade into. A model writes
+a hundred lines and gets one of them wrong, usually not the last one.
+That is the case nothing has measured: does the compiler say one useful
+thing, or does the broken parse state turn the rest of the file into
+noise the reader has to triage before finding the real error?
+"""
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, "tools")
+import importlib.util
+_spec = importlib.util.spec_from_file_location("dc", "tools/diag_coverage.py")
+_dc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_dc)
+
+
+def code_only_spans(text):
+    """Index ranges of `text` that are real code — not comment, not string.
+
+    The first run of this probe reported six programs "accepted silently"
+    after a mutation. Every one was the mutation landing inside a `//`
+    comment: the program was unchanged, so compiling clean was correct.
+    The instrument was wrong, not the compiler — the same masking lesson
+    diag_coverage.py already carries, arrived at the same way.
+    """
+    mask = _dc.mask_source(text)
+    return [i for i, m in enumerate(mask) if m == "c"]
+
+NURLC = "build/nurlc"
+DIAG = re.compile(r"^[^\s:]+\.nu:\d+:\d+: (error|warning): (.*)$")
+TMP = os.environ.get("NURL_MUTATE_DIR", "build/diagmutate")
+
+# Each mutation is (name, regex, replacement) applied to the FIRST match
+# in the body — the mistakes a model actually makes, not random damage.
+MUTATIONS = [
+    ("ascii-arrow",     r"→",                     "->"),
+    ("drop-arrow",      r" → ",                   " "),
+    ("named-field",     r"@ (\w+) \{ ",           r"@ \1 { x : "),
+    ("swap-type-name",  r"^(\s*): (i|b|f|s) (\w+) ", r"\1: \3 \2 "),
+    ("drop-operand",    r"\+ (\w+) (\w+)",        r"+ \1"),
+    ("drop-paren",      r"\( (\w+) ([^()]{0,20})\)", r"\1 \2"),
+    ("wrong-ret-type",  r"→ i \{",                "→ s {"),
+]
+
+
+def diags(path):
+    p = subprocess.run([NURLC, path], capture_output=True, text=True)
+    return [m.group(2) for m in
+            (DIAG.match(l) for l in p.stderr.splitlines()) if m]
+
+
+def main(names):
+    os.makedirs(TMP, exist_ok=True)
+    rows = []
+    for name in names:
+        src_path = f"compiler/tests/{name}.nu"
+        src = open(src_path, encoding="utf-8").read()
+        for mname, pat, rep in MUTATIONS:
+            # Mutate in the second half of the file's declarations, so the
+            # damage has something after it to cascade into.
+            lines = src.split("\n")
+            half = len(lines) // 3
+            head, tail = "\n".join(lines[:half]), "\n".join(lines[half:])
+            code = set(code_only_spans(tail))
+            new_tail, n = None, 0
+            for m in re.finditer(pat, tail, flags=re.M):
+                if m.start() not in code:
+                    continue  # inside a comment or a string literal
+                new_tail = tail[:m.start()] + m.expand(rep) + tail[m.end():]
+                n = 1
+                break
+            if not n:
+                continue
+            out = os.path.join(TMP, f"{name}__{mname}.nu")
+            open(out, "w", encoding="utf-8").write(head + "\n" + new_tail)
+            ds = diags(out)
+            rows.append((len(ds), name, mname, ds[0][:100] if ds else "(none)"))
+    rows.sort(reverse=True)
+    print(f"{'n':>3}  {'program':<22} {'mutation':<16} first diagnostic")
+    for n, name, mname, first in rows:
+        flag = "  ← cascade" if n > 1 else ("  ← SILENT" if n == 0 else "")
+        print(f"{n:>3}  {name:<22} {mname:<16} {first}{flag}")
+    print()
+    print(f"mutants: {len(rows)}   "
+          f"one diagnostic: {sum(1 for r in rows if r[0] == 1)}   "
+          f"cascades: {sum(1 for r in rows if r[0] > 1)}   "
+          f"accepted silently: {sum(1 for r in rows if r[0] == 0)}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Why

#857 and #859 both ended with the same conclusion: sweeping the never-fired list had stopped finding compiler defects and started finding tooling artifacts, so the next round should pick a **different instrument**. This is that round.

**Every negative test in the corpus is minimal by construction.** The mistake *is* the program, so there is nothing after it to go wrong. A model writes a hundred lines and gets one of them wrong — usually not the last one. Nothing measured that case.

`tools/diag_mutate.py` takes working programs from the corpus, injects one mistake a model plausibly makes (ASCII arrow, dropped operand, named struct fields, swapped type/name…), and counts what comes out: **one** diagnostic, **several** (a cascade to triage), or **none**.

Its first run said six programs were accepted silently. **All six were the mutation landing inside a comment** — the program was unchanged, so compiling clean was correct. The instrument was wrong, not the compiler; the same masking lesson `diag_coverage.py` already carries, arrived at the same way. Masked, four remained. Two were `→ s` returning `0`, which is NULL and legal.

**One was real.**

## What

**A binary operator one operand short swallows the next statement, and compiles.**

```nurl
= n + n
( side )        ← taken as the second operand
```
```llvm
%r3 = add i64 %r2, undef
```

Status 0. It links, runs, computes garbage — and still performs the swallowed call, as a side effect of an addition. `die_if_void` could not see it: it tests the operand's *value* against `void`, and `gen_call` gives a void call the value `undef`.

**Widening `die_if_void` to accept `undef` broke 72 tests, which is how the next two findings arrived.**

**56 of them traced to two lines of `stdlib/ext/json.nu`:**

```nurl
? + k 1 < n {
```

In prefix form that is the condition `k + 1` — always true — followed by a dead `< n { … }`. The IR is unambiguous:

```llvm
%r5 = icmp ne i64 %r4, 0       ; the branch test: (k+1) != 0
%r8 = icmp slt i64 %r6, undef  ; the "< n" — computed and discarded
```

**The object emitter has been taking the value branch whether or not a value follows.** Written `? < + k 1 n {`. Note `check_strict_arity.sh` does not catch this shape — it guards the n-ary `&`/`|` trap, not a short binary operator.

**The remaining failures showed the widening was wrong in itself.** An initialiser may legitimately take a `?` whose arms both return, which also yields `undef` — `dead_store_both_arms_ret` is that test, and `f5aca18` exists to support exactly that shape. So `die_if_void` keeps its value-only rule, and the new check lives at the **binary-operator site alone**, where an operand can never legitimately have no value.

## Proof

```
./compiler/tests/run_tests.sh
PASS 751 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
```

**All 14 failures predate this branch and are environmental in this container** — no `libzstd` (`/usr/include/zstd.h` and `stdlib/runtime.zstd` both absent) and no loopback networking:

`compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`

Same set and count as #847 onward on this container.

**The intermediate runs are the substance of this PR and are worth reading as a sequence:** `FAIL 72` (guard too wide) → `FAIL 16` after the two `json.nu` lines → `FAIL 14` once the guard moved to binary operators only. Each step was a different fact about the code, and none of them was visible from the first run alone.

The `json.nu` fix changes what the JSON object emitter produces for the branch it was mis-taking. The corpus's JSON, MCP, HTTP and serde tests — 56 of them — all pass on their existing goldens, unchanged, which is the evidence that the corrected branch produces the output those goldens always expected.

```
./build.sh --no-tests           BUILD SUCCESS (bootstrap fixed point holds)
nurlfmt --check                 compiler/nurlc.nu, stdlib/ext/json.nu, the new test
./tools/check_strict_arity.sh   OK — 1115 files, no arity trap
./tools/check_examples.sh       clean (2 skipped: optional FFI lib absent)
./tools/check_diag_anchor.sh    every baselined diagnostic points at real code
./tools/check_diag_coverage.sh  clean — 191 exercised, 17 never fired, 14 ambiguous
```

Not run locally, left to CI: `memgate.sh`, `dcegate.sh`, `leakcheck`, sanitizers, the unikernel legs. **`leakcheck` and the sanitizers are the ones to watch here** — the `json.nu` change alters which branch runs in the object emitter, and that branch pushes to a `String`.

## Known remaining

**The probe is not a gate, deliberately.** Its mutation set is a judgement about what models get wrong, and its interesting output is a program to go and read — never a number to enforce. Turning it into a threshold would invite tuning the mutations until the number looks good.

**`? + k 1 < n` is a shape no gate catches.** `check_strict_arity.sh` guards the n-ary `&`/`|` trap; the short *binary* operator is caught only when the swallowed operand happens to be void-typed (as of this PR) or a bare literal (already). A swallowed operand that is an ordinary value still compiles into working, wrong code. That is the general form of the trap and wants its own pass — plausibly a check that every statement's value is either used or `v`.

**Two mutants still compile silently and both are my probe's fault**, not the compiler's: `→ s` returning `0` is a NULL string and legal. Noted rather than tuned away.

**Carried, unchanged:** four messages are written for programs that cannot reach them; an incomplete impl still reports "call to unknown function" (language-surface — wants an issue); `spec/grammar.ebnf` still has no `assoc_decl` production; `%` in a const expression stays preempted; the literal-range check still ignores signedness; the unknown-associated-type anchor is still a line late by design.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_