### PR TITLE
release: 0.37.0 — the compiler is measured, not asserted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,27 +6,7 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-
-- **The n-ary `&`/`|` arity trap is a hard error by default;
-  `--no-strict-arity` demotes it back to a warning.** As a warning the
-  trap was the worst possible outcome: `? & a b c d { … } { … }`
-  compiled to `status: ok` and a binary whose conditional logic is
-  wrong, and nothing downstream could tell — the whole reason
-  `--strict-arity` and its CI gate existed. The first-party tree has
-  been strict-clean since that gate landed, so the default now matches
-  what the repo already enforced. `--strict-arity` stays accepted as a
-  no-op for compatibility.
-
-  The check has two known legitimate-but-flagged shapes — a `~` loop
-  whose condition is a bare-arm `?` (`~ ? flip < n 3 < n 5 { … }`), and
-  a bare `{ … }` scoping block immediately after a bare-arm `?` — both
-  with trivial rewrites (fold the ternary into `&`/`|` logic; drop or
-  move the scoping block). A tree that hits them faster than it can fix
-  them builds with `--no-strict-arity`, and the error message names
-  that escape hatch.
+## [0.37.0] — 2026-08-11
 
 ### Added
 
@@ -37,7 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the one thing that decides whether a message is any good — whether
   it is ever REACHED. The new gate compiles the corpus, matches every
   emitted diagnostic back to its source site, and reports the sites
-  nothing made speak. **132 of 220 sites are exercised; 81 are not.**
+  nothing made speak. It found **88 of 220 sites unread** on its first
+  run. At this release: **191 of 229 exercised, 17 never fired, 14
+  ambiguous, 7 unmatchable by text** — the three categories after
+  "exercised" are the tool declining to claim more than it can prove.
 
   An unfired message is unverified in every way that matters. Its wording
   has never been read next to the program that caused it, which is how
@@ -63,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `nurl.sh` driver end to end, and the examples gate. The corpus runs
   against the **same** `compiler/tests/outputs/` goldens as Linux and
   FreeBSD rather than a divergent `outputs-macos/` tree, so a macOS-only
-  miscompile cannot hide as a platform difference: 641 of 641.
+  miscompile cannot hide as a platform difference — it passed 641 of 641
+  when the leg landed, and the corpus has grown to 780 files since.
 
   Apple Silicon only. `macos-13`, GitHub's last Intel image, never left
   the queue across ten runs, and a required check that cannot schedule
@@ -92,8 +76,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was added. Fixed and held at zero, so this one gates rather than
   ratchets.
 
-### Added
-
 - **`tools/diag_mutate.py` — one realistic mistake in a real program.**
   Every negative test in the corpus is minimal by construction: the
   mistake *is* the program, so there is nothing after it to go wrong. A
@@ -110,6 +92,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same way.
 
 ### Changed
+
+- **The n-ary `&`/`|` arity trap is a hard error by default;
+  `--no-strict-arity` demotes it back to a warning.** As a warning the
+  trap was the worst possible outcome: `? & a b c d { … } { … }`
+  compiled to `status: ok` and a binary whose conditional logic is
+  wrong, and nothing downstream could tell — the whole reason
+  `--strict-arity` and its CI gate existed. The first-party tree has
+  been strict-clean since that gate landed, so the default now matches
+  what the repo already enforced. `--strict-arity` stays accepted as a
+  no-op for compatibility.
+
+  The check has two known legitimate-but-flagged shapes — a `~` loop
+  whose condition is a bare-arm `?` (`~ ? flip < n 3 < n 5 { … }`), and
+  a bare `{ … }` scoping block immediately after a bare-arm `?` — both
+  with trivial rewrites (fold the ternary into `&`/`|` logic; drop or
+  move the scoping block). A tree that hits them faster than it can fix
+  them builds with `--no-strict-arity`, and the error message names
+  that escape hatch.
 
 - **Coverage fingerprints now discriminate rather than merely being
   long.** Picking the longest literal at a site is the obvious rule and
@@ -128,12 +128,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   such groups existed, covering 30 sites; the worst prints
   `cannot store a value of type … into an element of type …` from **six**
   places. Those are reported as **ambiguous** rather than folded into
-  "exercised", which moves the honest figure from 205 to **177 of 228**.
-  A number that flatters the instrument is worse than a smaller one that
-  is true, and this instrument had been reporting its own best case for
-  eight passes.
+  "exercised". A number that flatters the instrument is worse than a
+  smaller one that is true, and this instrument had been reporting its
+  own best case for eight passes. The correction cost 28 sites at the
+  time; the entry above carries the figure as it stands at release,
+  since a later pass sharpened the matching again.
 
 ### Fixed
+
+- **Five silent-compile sweeps landed without release notes.** They were
+  merged after 0.36.0 was cut and each shipped its own tests, but none
+  wrote a `CHANGELOG` entry, so the release would have understated what
+  it contains. Recorded here from their commits:
+
+  * **Trait dispatch.** Calling a trait method with a receiver whose
+    type has no impl fell through dispatch and emitted a call against an
+    undefined symbol — an error only clang reported, far from the call.
+    Impl-method calls, static and through the vtable, never checked
+    arity at all: `( speak d )` against `speak Dog d i volume`
+    assembled, and the callee read an unset register. Five pre-existing
+    leaks in the dyn path went with it.
+  * **FFI call arity, float casts, and `u8`.** `( sin 1.0 2.0 )` against
+    a one-parameter declaration assembled and ran with the surplus
+    ignored; `( pow 2.0 )` read an unset ABI register. `# f x` emitted
+    `sitofp` from a struct, an enum or a string — invalid IR only clang
+    saw. And the documented `u8` spelling had never worked: it was
+    missing from `llvm_type`'s ladder, so every `: u8 x` carried a
+    phantom `%u8` type.
+  * **Generic call type-argument arity.** A surplus type argument
+    compiled clean and resolved to a monomorph no other site shares —
+    silently meaning something else. A deficit died deep inside
+    instantiation with an unrelated substitution error.
+  * **Aggregate, enum and payload shapes.** Returning a `?f` out of a
+    `→ ?i`, a differently-signed closure out of a declared closure
+    return, a number into an enum parameter, and a float payload into a
+    declared integer payload — the last bitcast the bits into the slot,
+    so the `??` arm read 4609434218613702656.
+  * **Dead-store clash checks fired on a `?` join whose arms both
+    return.** A store that can never execute was diagnosed as a type
+    error, which broke the playground image build.
 
 - **A binary operator one operand short swallowed the next statement and
   compiled.** `= n + n` followed by `( side )` took the call as its

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -129,8 +129,7 @@ Consequences worth knowing:
 `nurl.sh` also links a feature library (`-lcurl` / `-lssl` / `-lsqlite3` /
 `-lpq` / `-lz` / `-lzstd`) **only when the emitted IR actually references
 that back-end's symbols** — so a feature-free program (the common tool)
-links against libc only and never demands a library the box may lack
-— so a feature-free program never demands a library the box may lack.
+links against libc only and never demands a library the box may lack.
 
 (A prebuilt-binary package channel — install a tool with no local compile at
 all — remains the future bombproofing; see the registry roadmap.)
@@ -186,5 +185,12 @@ the Actions tab.
   landed, and it now gates PRs too.)
 - The FreeBSD release leg is best-effort (`continue-on-error`); a release
   can ship without the FreeBSD archive.
-- macOS is not built yet (the installer rejects it with a clear message);
-  add a `macos-14` (arm64) / `macos-13` (x86_64) matrix when wanted.
+- macOS ships no release artifact yet — the installer rejects Darwin with a
+  clear message and the install route stays build-from-source. It is *not*
+  untested: the `macos-tests` workflow runs `./build.sh` on Apple Silicon
+  (bootstrap fixed point + the full corpus against the same `outputs/`
+  goldens as Linux) on every push to `main` and every PR. Adding a release
+  leg means `macos-14` (arm64) only — the Intel `macos-13` image never left
+  GitHub's queue across ten attempted runs, which is why that leg was
+  removed rather than left permanently pending (see
+  [`docs/PLATFORMS.md`](docs/PLATFORMS.md)).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-08 · Current release: **0.36.0** · Language: **Grammar
+_Last reviewed: 2026-08-11 · Current release: **0.37.0** · Language: **Grammar
 v2.4** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---
@@ -29,7 +29,10 @@ What is solid today:
   `u` = byte/u8, plus sized `i8`/`i16`/`i32`, `u16`/`u32`/`u64`, `f` = f64
   and `f32`), tail-call optimization, and
   **variadic FFI** (the `printf` family callable directly). The grammar decision
-  for prefix-arity (no grouping delimiter) is formally locked.
+  for prefix-arity (no grouping delimiter) is formally locked, and since
+  0.37.0 the n-ary `&`/`|` arity trap it makes possible is a **hard error
+  by default** (`--no-strict-arity` demotes it to a warning) — the shape
+  compiled to working, wrong code before.
 - **Memory & safety.** Single-owner memory with compiler-inserted auto-drop at
   scope exit — no GC, no hidden boxing. A **static borrow checker, on
   by default** (`--no-borrowck` to disable, `--strict-borrowck` to tighten),
@@ -95,7 +98,14 @@ A high-level map of what exists. Dates and per-feature detail are in
   identifiers, call-arity mismatches, unbalanced braces / stray top-level
   tokens, and visibility violations are hard errors with source locations —
   nothing malformed reaches the backend silently.
-- Emission: only the functions `main` can reach reach the `.ll`
+- Diagnostics are *measured*, not asserted. `check_diag_coverage.sh` reports
+  which of the compiler's ~230 messages a test has ever made it print;
+  `check_diag_anchor.sh` gates that every baselined diagnostic points at the
+  mistake rather than at the token after it; `diag_mutate.py` injects one
+  realistic error into a working program and reads the answer. Between them
+  they have found messages that were false, messages that were unreachable,
+  and programs the compiler accepted and miscompiled.
+- Emission: only the functions `main` can reach the `.ll`
   (`--no-dce` to emit everything). Reachability is computed over the
   finished IR, so closures, monomorphs, drop glue and dyn vtable thunks
   need no special casing — worth 30–40% of the clang step on a


### PR DESCRIPTION
## Why

Release preparation for **0.37.0**. Docs only — no compiler, stdlib or tooling code is touched.

The `Unreleased` section had accumulated across 29 merged PRs and was not in releasable shape:

- **Duplicate headings.** Two `### Added` blocks and two `### Changed` blocks, because each round inserted its own. Keep-a-Changelog wants one of each, ordered Added → Changed → Fixed.
- **Five compiler fixes had no entry at all.** They merged after 0.36.0 was cut and each shipped its own tests, but none wrote a changelog entry — so the release would have understated what it contains. Recovered from their commits: trait dispatch (#842), FFI call arity + float-cast guards + the missing `u8` spelling (#840), generic call type-argument arity (#839), the aggregate/enum/payload shape sweep (#835), and the dead-store clash on a `?` join whose arms both return (#836).
- **Three different coverage figures and no current one.** `132 of 220`, then `205`, then `177 of 228` — each true when written, each superseded by a later entry in the same section. A reader would have had no way to know which was live. That is the exact failure the tooling in this release exists to prevent, reproduced in its own release notes.
- **A stale corpus count.** The macOS entry claimed `641 of 641`; the corpus is 780 files now.

## What

**`CHANGELOG.md`**
- `## [Unreleased]` → `## [0.37.0] — 2026-08-11`, sections merged and reordered.
- Five missing sweeps added under Fixed, attributed to their commits.
- Coverage figures reconciled: the entry introducing the tool now carries **the number at release** (191 of 229 exercised, 17 never fired, 14 ambiguous, 7 unmatchable) plus what it found on its first run; the later correction entry describes the *method change* without leaving a superseded absolute as the last word.
- The macOS corpus figure is dated rather than presented as current.

**`ROADMAP.md`**
- Header → `0.37.0` / reviewed 2026-08-11.
- `Status at a glance`: the n-ary arity trap is a hard error by default — the change most likely to reject a program that used to compile.
- `Shipped → Compiler & language`: diagnostics are now *measured*, with the three instruments named and what they have found.
- Fixed a doubled word (`can reach reach`).

**`RELEASING.md`**
- The macOS note said "not built yet; add a `macos-14` / `macos-13` matrix when wanted". Half stale: macOS is now CI-tested on Apple Silicon against the same goldens as Linux, and the **Intel `macos-13` leg was removed because it never left GitHub's queue across ten runs** — a future release engineer should not repeat that experiment.
- Removed a sentence duplicated in the `--as-needed` paragraph.

## Proof

```
./compiler/tests/run_tests.sh   PASS 751 · FAIL 14 · MISSING 0 · ORPHAN 0 · SKIP 15
./tools/check_diag_anchor.sh    every baselined diagnostic points at real code
./tools/check_diag_coverage.sh  no new never-fired sites
./tools/check_builtins_doc.sh   116 preamble builtins documented
```

The 14 failures predate this branch and are environmental in this container — no `libzstd` and no loopback networking: `compress_basic` · `compress_gzip` · `compress_rawdeflate` · `mqtt_codec` · `mqtt_qos2_dedup` · `pkg_install_e2e` · `pkg_pack_basic` · `tar_basic` · `udp_basic` · `websocket_basic` · `websocket_client` · `ws_permessage_deflate` · `zip64_read` · `zip_basic`. Same set and count as every PR since #847.

Version wiring verified rather than assumed: `tools/version.sh` resolves from `git describe`, and `tools/gen-site-facts.sh` reads the newest **released** section of `CHANGELOG.md` — so `0.37.0` is what `nurl-lang.org` will publish once tagged, and there is no hardcoded version anywhere to bump (`grep` over the tree finds `0.36.0` only in generated bench results and the roadmap header, now updated).

Docs-only diff; no build required, and none of the code gates could be affected. They were run anyway because the changelog makes claims about them.

## Known remaining

**The release title and the section's length are the maintainer's call.** 0.36.0 condensed its accumulated entries into a 230-line curated section; this one is 492 lines across 32 entries. I merged the headings, filled the gaps and reconciled the figures, but did not rewrite entries that are individually accurate — condensing 29 PRs into a narrative is an editorial act, not a mechanical one, and the commit subject here is a proposal rather than a decision.

**Package changelogs are untouched and four package PRs updated none.** `serve --weights`, `finetune --merge-only`, `--window-stride` and the qwen3 work wrote no entry in their own `packages/*/CHANGELOG.md`. The root changelog is toolchain-only by convention — 0.36.0 mentions no package at all — so that is out of scope here, but it means the package changelogs understate their releases.

**No `[Unreleased]` stub is left behind**, matching what `e4a5da2e` did for 0.36.0.

**Tagging is not done here.** Per `RELEASING.md` the release is cut by pushing `v0.37.0`, which fires `release.yml` (four archives + `.sha256` + `.minisig`) and `web-deploy.yml`. That is a maintainer action and this PR does not attempt it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fny2vhaWL2mob2wPUZBePi)_