### PR TITLE
fix: json span scan quadratic strlen + playground not-running recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`json_parse` back to fastest in the benchmark table — the RFC 8259
+  control-byte scan was accidentally quadratic.** The conformance fix
+  in 0.36.0 (#817) added `__jp_span_ctrl`, a linear scan over the
+  escape-free fast path's span, and indexed it with `nurl_str_get` —
+  whose bounds check re-runs `strlen` on every call. The span is a
+  pointer into the *middle* of the document, so every one of those
+  strlens walked to the document's end: the "linear" scan was
+  O(span × rest-of-document), and the benchmark's `json_parse` went
+  from fastest of the five languages (8.8 ms) to slowest of the
+  compiled three (42 ms). The scan now reads through a raw pointer,
+  the way the accessor's own documentation says every parser loop
+  must. Conformance is untouched — the same tests pass — and the row
+  is NURL's again.
+
+- **Playground: the "container is not running" rollout window no longer
+  reaches users.** During the v0.37.0 image rollout play.nurl-lang.org
+  served `Error proxying request to container: The container is not
+  running, consider calling start()` — the Durable Object proxied to an
+  instance that no longer existed, and the Worker's recovery policy,
+  which knows the *not listening* wedge and the transient restart
+  strings, did not know this one, so it passed through as a 500 instead
+  of triggering a teardown and cold-start retry. The string now
+  classifies as wedged: destroy clears the stale instance state and the
+  replay lands on a fresh container. Covered by `test:recovery` with
+  the literal production body.
+
 ## [0.37.0] — 2026-08-11
 
 ### Added

--- a/cloudflare/src/recovery.ts
+++ b/cloudflare/src/recovery.ts
@@ -12,13 +12,22 @@
 // emitted by the nurlapi app itself.
 
 // Substrings (matched case-insensitively) in a 500 body.
-//   wedged    — instance reachable but server not accepting on the port; the
-//               DO won't re-check on its own, so the instance must be torn down
-//               ("The container is not listening in the TCP address …").
+//   wedged    — the DO's picture of the instance is wrong, so the instance
+//               must be torn down before a retry can help:
+//               * "The container is not listening in the TCP address …" —
+//                 alive but the server stopped accepting; the DO never
+//                 re-checks the port on its own.
+//               * "The container is not running, consider calling start()" —
+//                 the DO proxied to an instance that no longer exists (seen
+//                 fleet-wide during the v0.37.0 image rollout, surfaced to
+//                 users as a 500 because this policy didn't know the string).
+//                 destroy() clears the stale state; the retry cold-starts.
 //   transient — instance is mid-restart; a plain retry suffices.
 export const WEDGE_MARKERS: readonly string[] = [
   "is not listening",
   "not listening in the tcp address",
+  "is not running",
+  "consider calling start",
 ];
 export const TRANSIENT_MARKERS: readonly string[] = [
   "network connection lost",

--- a/cloudflare/test-recovery.ts
+++ b/cloudflare/test-recovery.ts
@@ -13,8 +13,17 @@ import { classifyError, decideAction, stampAction } from "./src/recovery.ts";
 const PROD_WEDGE =
   "Error proxying request to container: The container is not listening in the TCP address 10.0.0.1:8000";
 
+// The literal string observed fleet-wide during the v0.37.0 image rollout —
+// the DO proxied to an instance that no longer existed.
+const PROD_NOT_RUNNING =
+  "Error proxying request to container: The container is not running, consider calling start()";
+
 test("classifyError: the production wedge body → 'wedged'", () => {
   assert.equal(classifyError(PROD_WEDGE), "wedged");
+});
+
+test("classifyError: the production not-running body → 'wedged'", () => {
+  assert.equal(classifyError(PROD_NOT_RUNNING), "wedged");
 });
 
 test("classifyError: case-insensitive marker match", () => {

--- a/stdlib/ext/json.nu
+++ b/stdlib/ext/json.nu
@@ -554,10 +554,17 @@ $ `stdlib/core/vec.nu`
 // escape-free fast path pays one linear scan for conformance. It still
 // skips the whole per-char push loop, which is where its speed came
 // from.
+//
+// The walk must read through a raw pointer: `span` points into the
+// middle of the document, so `nurl_str_get`'s per-call strlen runs to
+// the document's END on every byte — the scan that shipped with the
+// conformance fix did exactly that and took json_parse from fastest in
+// the benchmark table (8.8 ms) to slowest (42 ms).
 @ __jp_span_ctrl s span i n → i {
+    : *u p # *u span
     : ~ i k 0
     ~ < k n {
-        ? < ( nurl_str_get span k ) 32 { ^ k } {}
+        ? < & # i . p k 255 32 { ^ k } {}
         = k + k 1
     }
     ^ -1


### PR DESCRIPTION
Two release findings from v0.37.0, fixed at the root.

## json_parse regression (bench: 8.8 ms → 42 ms)

The RFC 8259 control-byte scan added by #817 indexed its span with `nurl_str_get`, whose bounds check re-runs `strlen` on every call. The span is a pointer into the *middle* of the document, so each strlen walked to the document's **end**: the "one linear scan for conformance" was O(span × rest-of-document). The bench history pins it exactly — last fast refresh 08-07 20:04 (NURL 8.8 ms, fastest of five), first slow one 08-07 23:23 (31 ms), with only #817/#818 in between.

Fix: read the span through a raw pointer, which is what `nurl_str_at`'s own documentation prescribes for every parser loop. Conformance unchanged — `json_basic` + `json_rfc8259_strings` pass as-is. Measured on this machine after the fix: NURL 10.1 ms vs C 12.3 / Rust 15.9 — fastest again.

## Playground "container is not running" surfaced to users

During the v0.37.0 image rollout play.nurl-lang.org served `Error proxying request to container: The container is not running, consider calling start()`. The exact production image runs clean locally (health + build_wasm verified), so this was purely the Worker's recovery gap: the policy knows the *not listening* wedge and the transient restart strings, but not this one — the 500 passed straight through. It now classifies as **wedged**: destroy the stale instance, cold-start on the replay. The literal production body is pinned in `test:recovery` (11/11 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZmx17om4vH9bWrzVMsuiz