### PR TITLE
release: 0.37.1 — the fast path is measured too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.37.1] — 2026-08-11
 
 ### Fixed
 
@@ -11861,7 +11861,9 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.36.0...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.37.1...HEAD
+[0.37.1]: https://github.com/nurl-lang/nurl/compare/v0.37.0...v0.37.1
+[0.37.0]: https://github.com/nurl-lang/nurl/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/nurl-lang/nurl/compare/v0.35.1...v0.36.0
 [0.35.1]: https://github.com/nurl-lang/nurl/compare/v0.35.0...v0.35.1
 [0.35.0]: https://github.com/nurl-lang/nurl/compare/v0.34.0...v0.35.0


### PR DESCRIPTION
Cut 0.37.1: the json_parse quadratic-scan fix (#863) and the playground "container is not running" recovery, both already on main.

Also repairs the compare-link section: the 0.37.0 release PR never added `[0.37.0]:` and left `[Unreleased]` at `v0.36.0...HEAD` — the recurring slip the flow notes have warned about since 0.30.0.

After merge: wait for green CI on the merge SHA, then tag `v0.37.1` (release.yml + api-deploy.yml + web-deploy.yml all fire on the tag, so the playground gets both the fixed Worker policy and the fixed image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZmx17om4vH9bWrzVMsuiz