### PR TITLE
perf: HTTP serve path — per-request allocations and syscalls removed at the root

### DIFF
--- a/bench/HTTP_RESULTS.md
+++ b/bench/HTTP_RESULTS.md
@@ -1,10 +1,10 @@
 # NURL HTTP-server peer-comparison
 
 > Hardware: Intel Core i7-5930K @ 3.50 GHz (6 physical / 12 logical
-> cores), Ubuntu 24.04 (kernel 6.17), Linux x86_64, all loopback.
+> cores), Ubuntu 24.04 (kernel 7.0), Linux x86_64, all loopback.
 > Compilers: Rust 1.82.0 (hyper 1.9.0, tokio 1.52, `lto=fat`), Node
 > v24.15.0 (built-in `http`). Load generator: oha 1.8.0 (HTTP/1.1,
-> keep-alive enabled).
+> keep-alive enabled). Measured 2026-08-11.
 >
 > Numbers are **median of 3 × 10 s runs per cell**. Reproduce with
 > `bench/run_http.sh --concurrencies "1 10 50 200" --duration 10`
@@ -13,21 +13,24 @@
 ## Headline numbers
 
 The path under test is a `GET /` returning `Hello, World!\n` (14 bytes,
-`text/plain; charset=utf-8`). No router middleware, no JSON, no
-metrics. All three implementations accept a TCP connection, parse one
-HTTP/1.1 request, write the 14-byte body, keep-alive.
+`text/plain; charset=utf-8`). No JSON, no metrics. All three
+implementations accept a TCP connection, parse one HTTP/1.1 request,
+write the 14-byte body, keep-alive. The NURL server is built on the
+`packages/http` HttpApp facade — the surface a real NURL service
+deploys — with a 10-thread worker pool (see `bench/http_server.nu`);
+routing goes through the stdlib router, exactly as in production use.
 
 |              | Server  | C = 1   | C = 10   | C = 50   | C = 200  |
 |--------------|---------|--------:|---------:|---------:|---------:|
-| **req/s**    | NURL    | 14 451  | **68 960** |  60 897  |  59 044  |
-|              | Rust    | 14 507  |  47 703  | **86 699** | **114 694** |
-|              | Node    |  8 708  |  16 726  |  17 108  |  15 555  |
-| **p50 (ms)** | NURL    | **0.06**| **0.08** | **0.10** | **0.11** |
-|              | Rust    |   0.07  |   0.15   |   0.41   |   1.33   |
-|              | Node    |   0.11  |   0.54   |   2.90   |  12.89   |
-| **p99 (ms)** | NURL    | **0.14**|   0.56   |   0.67   |   0.62   |
-|              | Rust    |   0.11  |   1.16   |   2.82   |   6.19   |
-|              | Node    |   0.22  |   1.98   |   6.13   |  20.95   |
+| **req/s**    | NURL    | **15 270** | **166 096** | 144 465  | 150 606  |
+|              | Rust    | 13 411  | 148 354  | **210 024** | **294 381** |
+|              | Node    | 10 013  |  25 026  |  25 839  |  25 949  |
+| **p50 (ms)** | NURL    | **0.06**| **0.06** | **0.06** | **0.06** |
+|              | Rust    |   0.07  |   0.06   |   0.20   |   0.63   |
+|              | Node    |   0.09  |   0.33   |   1.80   |   7.45   |
+| **p99 (ms)** | NURL    | **0.13**| **0.09** | **0.12** | **0.13** |
+|              | Rust    |   0.14  |   0.13   |   0.73   |   1.62   |
+|              | Node    |   0.18  |   0.77   |   3.85   |  14.73   |
 
 (Best per row in **bold**. Higher is better for req/s; lower for
 latency.)
@@ -36,30 +39,35 @@ latency.)
 
 ### Single client (C = 1)
 
-The three implementations are dominated by per-request CPU work. NURL
-and Rust hyper land within < 1 % of each other (14 451 vs 14 507).
-Node trails ~1.7×.
+Dominated by per-request round-trip cost. NURL leads Rust hyper 15.3 k
+vs 13.4 k (~14 %); Node trails ~1.5×.
 
 ### Light parallel (C = 10)
 
-NURL's `server_run_pool` runs 10 worker threads (see
-`bench/http_server.nu`); 10 in-flight connections fit inside that
-pool. Rust's tokio multi-thread runtime defaults to one worker per
-logical core (12 here); at C = 10 the runtime is over-provisioned.
-NURL: 69 k/s, p99 0.56 ms. Rust: 48 k/s, p99 1.16 ms.
+NURL's 10 worker threads match the 10 in-flight connections one-to-one:
+166 k/s at p99 0.09 ms — ahead of Rust's 148 k (tokio runs one worker
+per logical core, 12 here, so it is over-provisioned at this depth) and
+6.6× Node.
 
-### Moderate parallel (C = 50)
+### Moderate and high parallel (C = 50 / 200)
 
-NURL's 10-worker pool is saturated (~62 k/s). Rust's multi-thread
-scheduler reaches 87 k/s. NURL p50 stays at 0.10 ms; Rust p50 0.41 ms.
+NURL's 10 blocking workers are the ceiling: each worker serves one
+connection at a time and idles while the response's ACK/next request
+round-trips the loopback (~14.6 k req/s per worker; total CPU use is
+~3.3 of 12 cores at C = 200). Throughput therefore plateaus at
+~145–151 k/s while p50/p99 stay flat at 0.06/0.13 ms for the
+connections being served. Rust multiplexes all 200 connections over 12
+epoll-driven workers and reaches 294 k/s, trading latency for it (p99
+1.62 ms).
 
-### High parallel (C = 200)
+Measured scaling of the same NURL binary with a bigger pool
+(single 6 s runs, C = 200): 24 workers → 191 k, 64 → 221 k,
+200 (thread-per-connection) → 245 k/s at p99 1.78 ms. The fiber-based
+`server_run_async` (12 workers + reactor) reaches 250 k/s at p99
+3.1 ms; its per-request CPU cost (~2× the blocking path's — scheduler
+overhead, see critic.md 2026-08-11) is the current gap to hyper.
 
-Rust hyper reaches 115 k/s by saturating every core. NURL holds 59 k/s
-— its 10-worker pool is the throughput ceiling. NURL p50 0.11 ms, p99
-0.62 ms. Rust p99 6.19 ms.
-
-Node plateaus at ~16 k/s with rising latency.
+Node plateaus at ~26 k/s with rising latency.
 
 ## Configuration notes
 
@@ -71,3 +79,19 @@ Node plateaus at ~16 k/s with rising latency.
   `bench/http_server.go`.
 - The hardware is 11 years old; absolute numbers will differ on a
   modern CPU.
+
+## History
+
+- **2026-08-11** — table refreshed (the previous one was months stale:
+  NURL 14.5 k / 69.0 k / 60.9 k / 59.0 k across C = 1/10/50/200 —
+  the 2.2–2.6× improvement since accumulated across the intervening
+  stdlib/runtime performance work, not one change). The server now
+  runs on the packages/http facade. Same-day root fixes, A/B-measured
+  against that morning's HEAD: stdlib keep-alive loop no longer builds
+  a fallback 500 response per request (hoisted to per-connection),
+  Connection-header checks stopped allocating, carry-buffer compaction
+  became one memmove, header serialisation lost its O(n²)
+  `nurl_str_get` walk, the packages/http facade dropped a duplicate
+  recover layer (−4 % CPU/request on the pool path, 21.8 → 20.9 µs),
+  and the async net path stopped issuing 4 fcntl syscalls per request
+  (async hello 237 k → 250 k rps at C = 200, CPU 44.4 → 41.7 µs/req).

--- a/bench/http_server.nu
+++ b/bench/http_server.nu
@@ -1,60 +1,29 @@
 // bench/http_server.nu — minimal hello-world HTTP server for the
-// peer-comparison benchmark (Tier D #3).
+// peer-comparison benchmark (Tier D #3), built on the packages/http
+// facade (the unified HTTP server interface — what a real NURL service
+// would use), so the bench measures the surface users actually deploy.
 //
 // Listens on 127.0.0.1:18080. Serves "Hello, World!\n" (14 bytes,
-// text/plain) on `/`. No router middleware, no metrics, no access log
-// — apples-to-apples with the Go/Rust/Node sibling files in this
-// directory. Ctrl+C (or SIGTERM) shuts down cleanly.
+// text/plain) on `/`. No metrics, no access log — apples-to-apples
+// with the Go/Rust/Node sibling files in this directory. Ctrl+C (or
+// SIGTERM) shuts down cleanly.
 //
-// Run: ./bench/http_server.sh  (compiles + starts; see that script
-//                               for the bench driver glue).
+// Run: ./bench/run_http.sh  (compiles + starts; see that script
+//                            for the bench driver glue).
 
-$ `stdlib/ext/http_full.nu`
-
-@ hello HttpRequest req Params params → HttpResponse {
-    ^ ( response_text 200 `Hello, World!\n` )
-}
+$ `packages/http/src/http.nu`
 
 @ main → i {
-    : !TcpListener NetErr lr ( tcp_listen `127.0.0.1` 18080 )
-    ?? lr {
-        T listener → {
-            : Router r ( router_new )
-            ( router_get r `/` \ HttpRequest req Params params → HttpResponse { ^ ( hello req params ) } )
-            : ( @ HttpResponse HttpRequest ) base
-            \ HttpRequest req → HttpResponse { ^ ( router_handle r req ) }
-
-            ( signal_install_shutdown listener )
-
-            ( nurl_print `nurl http_server listening on http://127.0.0.1:18080/\n` )
-            ( nurl_flush_stdout )
-
-            : HttpServer srv ( server_new listener base )
-            // Drive a thread pool so the bench measures the full server
-            // surface rather than a single accept loop. 10 workers is a
-            // reasonable default for ~12-core hosts (tokio's default
-            // multi-thread runtime in the Rust peer uses every core).
-            : !v NetErr rr ( server_run_pool srv 10 )
-
-            ( signal_clear_shutdown )
-            ( server_stop srv )
-            ( router_free r )
-
-            ?? rr {
-                T _ → ^ 0
-                F e → {
-                    ( nurl_eprint `nurl http_server: ` )
-                    ( nurl_eprint ( net_err_name e ) )
-                    ( nurl_eprint `\n` )
-                    ^ 1
-                }
-            }
-        }
-        F e → {
-            ( nurl_eprint `nurl http_server: bind failed: ` )
-            ( nurl_eprint ( net_err_name e ) )
-            ( nurl_eprint `\n` )
-            ^ 1
-        }
-    }
+    : *HttpApp a ( http_app_new )
+    ( http_app_get a `/` \ HttpRequest req Params params → HttpResponse {
+        ^ ( response_text 200 `Hello, World!\n` )
+    } )
+    // Worker pool so the bench measures the full server surface rather
+    // than a single accept loop. 10 workers is a reasonable default for
+    // ~12-core hosts (tokio's default multi-thread runtime in the Rust
+    // peer uses every core).
+    ( http_app_workers a 10 )
+    : i rc ( http_app_listen a `127.0.0.1` 18080 )
+    ( http_app_free a )
+    ^ rc
 }

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -62,7 +62,7 @@ Configuration (call before serving):
 | `( http_app_static_dir a dir )` | off | serve files for unmatched GET/HEAD (traversal-safe) |
 | `( http_app_cors a )` | off | permissive CORS + 204 OPTIONS preflight |
 | `( http_app_logging a )` | off | access log (method path → status) to stderr |
-| `( http_app_recover a on )` | **on** | handler panic → 500 instead of a dropped connection |
+| `( http_app_recover a on )` | — | deprecated no-op: panic → 500 is an unconditional stdlib-server guarantee |
 | `( http_app_workers a n )` | 0 | 0 = single-threaded keep-alive; n > 0 = worker pool |
 | `( http_app_idle_ms a ms )` | 5000 | keep-alive idle timeout |
 | `( http_app_body_max a bytes )` | 10 MiB | request-body cap (parser answers 413 above it) — raise for upload endpoints |

--- a/packages/http/nurl.toml
+++ b/packages/http/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http"
-version = "0.3.1"
+version = "0.3.2"
 description = "The unified HTTP server interface for NURL — one dependency for anything that needs to SERVE HTTP. A single importable facade over the stdlib HTTP stack (sockets + TLS, request parser, response builder, keep-alive server with worker pools and DoS limits, router, static-file serving, auth / jwt / multipart / middleware / websocket / streaming SSE-NDJSON responses). Where the stdlib ships the building blocks, `http` ships the glue: an ergonomic `HttpApp` that collapses bind → router → shutdown-signal → logging / CORS / panic-recovery → keep-alive loop into a few calls, so `( http_app_new )`, a handful of `( http_get a ... )` registrations, and `( http_listen a host port )` stand up a complete server — over plain TCP or TLS."
 license = "MIT OR Apache-2.0"
 

--- a/packages/http/src/app.nu
+++ b/packages/http/src/app.nu
@@ -42,7 +42,6 @@ $ `stdlib/ext/http_static.nu`
     Router router
     i idle_ms  // keep-alive idle timeout (ms) for the server
     i workers  // 0 → single-threaded server_run; >0 → server_run_pool(n)
-    b recover_panics  // wrap dispatch in `recover`, turning a panic into 500
     b log_requests  // access log (method/path/status) to stderr
     b cors  // permissive CORS + OPTIONS preflight
     b quiet  // suppress the "serving on host:port" banner
@@ -61,7 +60,6 @@ $ `stdlib/ext/http_static.nu`
     = . a router ( router_new )
     = . a idle_ms 5000
     = . a workers 0
-    = . a recover_panics T
     = . a log_requests F
     = . a cors F
     = . a quiet F
@@ -103,9 +101,14 @@ $ `stdlib/ext/http_static.nu`
 // closes the connection (0 = disabled).
 @ http_app_request_timeout * HttpApp a i ms → v { = . a req_timeout_ms ms }
 
-// Toggle panic→500 recovery (on by default). A handler that panics then
-// yields a 500 instead of tearing down the connection loop.
-@ http_app_recover * HttpApp a b on → v { = . a recover_panics on }
+// DEPRECATED (0.3.2): panic→500 is an unconditional guarantee of the
+// stdlib server itself — its keep-alive loop wraps every handler call
+// (including this facade's whole dispatch + middleware chain) in
+// `recover` and answers 500 on panic. The facade used to duplicate
+// that wrapper here, which cost a throwaway 500-response build and a
+// second `recover` on EVERY request for zero added safety. The knob
+// is kept for API compatibility and is a no-op.
+@ http_app_recover * HttpApp a b on → v {}
 
 // Log every request (method path → status) to stderr.
 @ http_app_logging * HttpApp a → v { = . a log_requests T }
@@ -194,28 +197,12 @@ $ `stdlib/ext/http_static.nu`
     ^ resp
 }
 
-// Optional panic→500 wrapper. `recover` sits directly in this top-level
-// function body (not inside another closure), the shape the runtime wants.
-@ __httpapp_dispatch * HttpApp a HttpRequest req → HttpResponse {
-    ? . a recover_panics {
-        // `placeholder` is returned only when the handler panics. On
-        // the success path the closure overwrites `resp`, so the
-        // placeholder must be freed there or every request leaks it.
-        // (recover itself frees the closure's env — panic.nu contract.)
-        : HttpResponse placeholder ( response_text 500 `internal error: handler panicked\n` )
-        : ~ HttpResponse resp placeholder
-        : !v PanicInfo pr ( recover \ → v { = resp ( __httpapp_route_and_static a req ) } )
-        ?? pr {
-            T _ → { ( http_response_free placeholder ) }
-            F p → { ( panic_info_free p ) }
-        }
-        ^ resp
-    } {
-        ^ ( __httpapp_route_and_static a req )
-    }
-}
-
 // ── Serving ───────────────────────────────────────────────────────────
+//
+// Panic safety: the stdlib server's keep-alive loop wraps every handler
+// invocation (= this facade's full dispatch + middleware chain) in
+// `recover` and turns a panic into a 500, so the facade adds no wrapper
+// of its own.
 
 @ __httpapp_banner * HttpApp a s scheme s host i port → v {
     ? . a quiet { ^ v } {}
@@ -258,7 +245,7 @@ $ `stdlib/ext/http_static.nu`
     // Each middleware layer is held in its own binding so every closure
     // env can be released after the server returns (closures have no
     // drop-glue — envs are manual).
-    : ( @ HttpResponse HttpRequest ) disp \ HttpRequest req → HttpResponse { ^ ( __httpapp_dispatch a req ) }
+    : ( @ HttpResponse HttpRequest ) disp \ HttpRequest req → HttpResponse { ^ ( __httpapp_route_and_static a req ) }
     : ~ ( @ HttpResponse HttpRequest ) base disp
     : ~ ( @ HttpResponse HttpRequest ) corsw disp
     : ~ b has_cors F

--- a/stdlib/ext/http_response.nu
+++ b/stdlib/ext/http_response.nu
@@ -111,7 +111,7 @@ $ `stdlib/ext/json.nu`
     : ~ b found F
     ~ & ! found < k n {
         : Header h . hdata k
-        ? ( __header_name_eq_ci . h name name ) {
+        ? ( _header_name_eq_ci . h name name ) {
             ( header_free h )
             ( vec_set [Header] . r headers k ( header_new name value ) )
             = found T
@@ -209,11 +209,26 @@ $ `stdlib/ext/json.nu`
 // lossless for any well-formed header.
 @ __push_header_no_crlf ( Vec u ) out s str → v {
     : i n ( nurl_str_len str )
+    : *u p # *u str
+    // Fast path — no CR/LF present (every well-formed header): one
+    // scan + one memcpy, instead of a per-byte push (which re-checked
+    // capacity per byte) driven by nurl_str_get (which re-ran strlen
+    // per call — O(n²) on the header string).
     : ~ i k 0
-    ~ < k n {
-        : i c & 255 ( nurl_str_get str k )
-        ? | == c 13 == c 10 {} { ( vec_push [u] out # u c ) }
-        = k + k 1
+    : ~ b clean T
+    ~ & clean < k n {
+        : i c & 255 # i . p k
+        ? | == c 13 == c 10 { = clean F } { = k + k 1 }
+    }
+    ? clean {
+        ( bytes_extend_raw out str n )
+    } {
+        = k 0
+        ~ < k n {
+            : i c & 255 # i . p k
+            ? | == c 13 == c 10 {} { ( vec_push [u] out # u c ) }
+            = k + k 1
+        }
     }
 }
 
@@ -269,7 +284,7 @@ $ `stdlib/ext/json.nu`
     : ~ i k 0
     ~ < k n {
         : Header h . hdata k
-        ? ( __header_name_eq_ci . h name name ) { ^ T } {}
+        ? ( _header_name_eq_ci . h name name ) { ^ T } {}
         = k + k 1
     }
     ^ F
@@ -278,14 +293,16 @@ $ `stdlib/ext/json.nu`
 // Case-insensitive ASCII compare between an owned String and a
 // NUL-terminated raw `s`. Mirrors `__string_eq_ci` in http_request.nu;
 // kept inline here so this module doesn't depend on http_request.
-@ __header_name_eq_ci String name s raw → b {
+@ _header_name_eq_ci String name s raw → b {
     : i la ( string_len name )
     : i lb ( nurl_str_len raw )
     ? != la lb { ^ F } {}
+    : *u pa # *u ( string_data name )
+    : *u pb # *u raw
     : ~ i k 0
     ~ < k la {
-        : ~ i ca ( string_get name k )
-        : ~ i cb ( nurl_str_get raw k )
+        : ~ i ca & 255 # i . pa k
+        : ~ i cb & 255 # i . pb k
         ? & >= ca 65 <= ca 90 { = ca + ca 32 } {}
         ? & >= cb 65 <= cb 90 { = cb + cb 32 } {}
         ? != ca cb { ^ F } {}

--- a/stdlib/ext/http_server.nu
+++ b/stdlib/ext/http_server.nu
@@ -293,16 +293,9 @@ $ `stdlib/ext/http_response.nu`
             ( vec_clear [u] buf )
         } {
             : i remaining - total n
-            : ( Vec u ) tail ( vec_with_cap [u] remaining )
             : *u p ( vec_data [u] buf )
-            : ~ i k 0
-            ~ < k remaining {
-                ( vec_push [u] tail . p + n k )
-                = k + k 1
-            }
-            ( vec_clear [u] buf )
-            ( vec_extend [u] buf tail )
-            ( vec_free [u] tail )
+            ( nurl_memmove # s p # s # *u + # i p n remaining )
+            ( vec_set_len [u] buf remaining )
         }
     }
 }
@@ -605,10 +598,12 @@ $ `stdlib/ext/http_response.nu`
     : i la ( string_len value )
     : i lb ( nurl_str_len lit )
     ? != la lb { ^ F } {}
+    : *u pa # *u ( string_data value )
+    : *u pb # *u lit
     : ~ i k 0
     ~ < k la {
-        : ~ i ca ( string_get value k )
-        : ~ i cb ( nurl_str_get lit k )
+        : ~ i ca & 255 # i . pa k
+        : ~ i cb & 255 # i . pb k
         ? & >= ca 65 <= ca 90 { = ca + ca 32 } {}
         ? & >= cb 65 <= cb 90 { = cb + cb 32 } {}
         ? != ca cb { ^ F } {}
@@ -625,33 +620,34 @@ $ `stdlib/ext/http_response.nu`
 //     need persistent connections must speak 1.1.
 //   * HTTP/1.1 + bare `Connection: close` value → close.
 //   * HTTP/1.1 + missing or other Connection header → keep-alive.
+// Borrowed scan for `Connection: close` — walks the Header vec in
+// place (first name match wins, mirroring header_get) instead of
+// materialising an owned String copy of the value per request.
+@ __conn_header_says_close ( Vec Header ) hs → b {
+    : i n ( vec_len [Header] hs )
+    : *Header hdata ( vec_data [Header] hs )
+    : ~ i k 0
+    ~ < k n {
+        : Header h . hdata k
+        ? ( _header_name_eq_ci . h name `Connection` ) {
+            ^ ( __header_value_eq_ci . h value `close` )
+        } {}
+        = k + k 1
+    }
+    ^ F
+}
+
 @ __request_says_close HttpRequest req → b {
     : s ver ( string_data . req version )
     ? == 0 ( nurl_str_eq ver `HTTP/1.1` ) { ^ T } {}
-    : ?String hv ( header_get . req headers `Connection` )
-    ?? hv {
-        T value → {
-            : b says_close ( __header_value_eq_ci value `close` )
-            ( string_free value )
-            ^ says_close
-        }
-        F empty → { ( string_free empty ) ^ F }
-    }
+    ^ ( __conn_header_says_close . req headers )
 }
 
 // Returns T if the response carries `Connection: close`. The handler
 // can opt this connection out of keep-alive by setting that header
 // explicitly.
 @ __response_says_close HttpResponse r → b {
-    : ?String hv ( header_get . r headers `Connection` )
-    ?? hv {
-        T value → {
-            : b says_close ( __header_value_eq_ci value `close` )
-            ( string_free value )
-            ^ says_close
-        }
-        F empty → { ( string_free empty ) ^ F }
-    }
+    ^ ( __conn_header_says_close . r headers )
 }
 
 // ── server_run_once ──────────────────────────────────────────────────
@@ -757,6 +753,13 @@ $ `stdlib/ext/http_response.nu`
     // visible to the next _read_request_head call without re-reading
     // from the socket.
     : ( Vec u ) carry ( vec_with_cap [u] 4096 )
+    // Pre-allocated panic fallback response, hoisted OUT of the request
+    // loop: on the success path the handler's response replaces it and
+    // it survives untouched into the next iteration, so a keep-alive
+    // connection builds it once instead of once per request. It is
+    // rebuilt below only after a panic (or panic+timeout) actually
+    // consumed it — a cold path — and freed at connection end.
+    : ~ HttpResponse panic_resp ( response_text 500 `internal server error\n` )
     : ~ b done F
     : ~ i n_served 0
     ~ ! done {
@@ -795,17 +798,12 @@ $ `stdlib/ext/http_response.nu`
                         : ( @ HttpResponse HttpRequest ) f . s handler
                         // Wrap the handler in `recover` so a panic inside
                         // the handler doesn't kill the worker thread. On
-                        // panic the default `resp` (500) flows out to the
-                        // client; the captured message is logged to stderr.
-                        // Owned allocations inside the handler that didn't
-                        // run their auto-drop leak — see
-                        // stdlib/std/panic.nu's header for the cost model.
-                        //
-                        // `panic_resp` keeps a handle on the pre-allocated
-                        // 500 so it can be freed once the handler replaces
-                        // `resp` — without it the default leaked (headers
-                        // Vec + body Vec + strings) on EVERY successful
-                        // request.
+                        // panic the connection-level `panic_resp` (500)
+                        // flows out to the client; the captured message is
+                        // logged to stderr. Owned allocations inside the
+                        // handler that didn't run their auto-drop leak —
+                        // see stdlib/std/panic.nu's header for the cost
+                        // model.
                         //
                         // Replacement is detected by comparing the body-Vec
                         // DATA pointers, not via a captured flag: closures
@@ -816,8 +814,9 @@ $ `stdlib/ext/http_response.nu`
                         // share a body allocation, so pointer inequality
                         // is exact; and if `= resp` ever failed to
                         // propagate, the compare degrades to "not
-                        // replaced" — a leak, never a use-after-free.
-                        : HttpResponse panic_resp ( response_text 500 `internal server error\n` )
+                        // replaced" — treated as a panic, so `panic_resp`
+                        // is written out and rebuilt: never a double free
+                        // or use-after-free.
                         : ~ HttpResponse resp panic_resp
                         : !v PanicInfo pr ( recover \ → v { = resp ( f req ) } )
                         ?? pr {
@@ -827,8 +826,7 @@ $ `stdlib/ext/http_response.nu`
                                 ( panic_info_free p )
                             }
                         }
-                        ? != # i ( vec_data [u] . resp body ) # i ( vec_data [u] . panic_resp body )
-                        { ( http_response_free panic_resp ) } {}
+                        : b replaced != # i ( vec_data [u] . resp body ) # i ( vec_data [u] . panic_resp body )
                         // Per-request total timeout enforcement: free the
                         // handler's response and substitute 504 if we blew
                         // the budget. `should_close` forces `Connection:
@@ -850,6 +848,10 @@ $ `stdlib/ext/http_response.nu`
                         : b should_close | | | req_close resp_close at_cap timed_out
                         : !v NetErr wr ( __write_response conn final_resp should_close )
                         ( request_free req )
+                        // A panic (or panic+timeout) consumed the
+                        // connection-level fallback — rebuild it. Cold
+                        // path: never taken on a successful request.
+                        ? ! replaced { = panic_resp ( response_text 500 `internal server error\n` ) } {}
                         ?? wr {
                             T _ → {
                                 ? should_close { = done T } {}
@@ -888,6 +890,7 @@ $ `stdlib/ext/http_response.nu`
             }
         }
     }
+    ( http_response_free panic_resp )
     ( vec_free [u] carry )
 }
 

--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -1394,6 +1394,14 @@ long long nurl_tcp_get_fd(long long handle) {
 void nurl_tcp_set_nonblock(long long handle, long long on) {
     NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
     if (!h || h->fd < 0) return;
+    /* Memoized on h->nonblock — every mutation of the fd's O_NONBLOCK
+     * goes through here (or through the accept path, which normalises
+     * the flag AND the cache together), so a matching cache means the
+     * kernel flag already agrees. The async net wrappers call this at
+     * the top of EVERY read/write; without the memo that was 2 fcntl
+     * syscalls per operation = 4 per HTTP request, 46% of the async
+     * server's syscall time. */
+    if (h->nonblock == (on ? 1 : 0)) return;
 #if defined(_WIN32)
     u_long mode = on ? 1 : 0;
     ioctlsocket(h->fd, FIONBIO, &mode);
@@ -1603,6 +1611,8 @@ typedef struct NurlUdp {
     nurl_sockfd_t fd;
     long long     err_kind;
     int           family;     /* AF_INET / AF_INET6 / AF_UNSPEC */
+    int           nonblock;   /* cache of the fd's O_NONBLOCK — see
+                                 nurl_udp_set_nonblock's memo note */
     char         *peer;       /* owned "ip:port" of last peer; NULL if none */
 } NurlUdp;
 
@@ -1975,6 +1985,12 @@ long long nurl_udp_family(long long handle) {
 void nurl_udp_set_nonblock(long long handle, long long on) {
     NurlUdp *h = (NurlUdp*)(uintptr_t)handle;
     if (!h || h->fd == NURL_INVALID_SOCK) return;
+    /* Memoized like nurl_tcp_set_nonblock: the async wrappers call
+     * this per operation; the fd's flag only ever changes through this
+     * function, so a matching cache skips both fcntl syscalls. UDP
+     * sockets are created blocking (nonblock=0 via calloc), matching
+     * the fresh fd. */
+    if (h->nonblock == (on ? 1 : 0)) return;
 #ifdef _WIN32
     u_long mode = on ? 1 : 0;
     ioctlsocket(h->fd, FIONBIO, &mode);
@@ -1985,6 +2001,7 @@ void nurl_udp_set_nonblock(long long handle, long long on) {
     else    fl &= ~O_NONBLOCK;
     fcntl(h->fd, F_SETFL, fl);
 #endif
+    h->nonblock = on ? 1 : 0;
 }
 
 void nurl_udp_set_timeout(long long handle, long long ms) {


### PR DESCRIPTION
## What

Profiled the `packages/http` hello server under `oha` load (perf lbr + `strace -c` + `/proc` CPU accounting) and fixed every per-request cost that was structural rather than essential. The bench server now runs on the packages/http facade — the surface a real NURL service deploys.

## Root fixes

**stdlib/ext/http_server.nu**
- `_serve_keepalive_loop` built **and freed a full fallback-500 response on every request**; hoisted to per-connection, rebuilt only after a panic actually consumed it (cold path).
- `__request_says_close` / `__response_says_close` allocated an owned String copy of the Connection header per request (even on a miss) — now an allocation-free in-place scan of the Header vec.
- `__vec_drop_front_u` compacted the carry buffer with a per-byte `vec_push` into a temp Vec plus two more copies — now one `nurl_memmove` + `vec_set_len`.
- `__header_value_eq_ci` indexed the literal via `nurl_str_get` (strlen per call) — now a hoisted pointer walk.

**stdlib/ext/http_response.nu**
- `__push_header_no_crlf` was O(n²) (`nurl_str_get` = strlen per byte) and pushed byte-at-a-time — now one scan + one memcpy on the clean path.
- `_header_name_eq_ci` (renamed from `__`-private for the cross-file convention): same fix.

**stdlib/runtime_ffi.c**
- `nurl_tcp_set_nonblock` / `nurl_udp_set_nonblock` memoized on the handle's `nonblock` cache. The async wrappers call them per operation → **4 fcntl syscalls per HTTP request, 46 % of the async server's syscall time** (200,619 fcntl / 50 k requests). Every flag mutation already flows through these functions (or the accept path, which normalises flag + cache together), so a matching cache safely skips both syscalls. Async hello: 44.4 → 41.7 µs CPU/req, C=200 237 k → 250 k rps; **syscalls/request now 2.09**.

**packages/http 0.3.1 → 0.3.2**
- The facade duplicated the stdlib server's unconditional panic→500 `recover` with its own wrapper + per-request placeholder-500 build, for zero added safety. Removed; `http_app_recover` stays as a documented deprecated no-op so existing callers (embed, whisper) keep compiling with identical semantics.

## Measurements (i7-5930K, oha 1.8.0, median 3×10 s)

| req/s | C=1 | C=10 | C=50 | C=200 |
|---|---:|---:|---:|---:|
| **NURL** | **15 270** | **166 096** | 144 465 | 150 606 |
| Rust hyper | 13 411 | 148 354 | 210 024 | 294 381 |
| Node | 10 013 | 25 026 | 25 839 | 25 949 |

NURL now leads hyper at C=1 and C=10 with flat 0.06 ms p50 / 0.13 ms p99 everywhere. The C≥50 gap is the blocking-pool ceiling (10 workers × ~14.6 k/s per-conn ping-pong; CPU idles at 3.3/12 cores), not per-request cost — the async scheduler's 2× CPU/req is recorded in critic.md as the next lever. Pool path A/B vs same-day HEAD: 21.8 → 20.9 µs CPU/request.

## Verification

- Full corpus: **766 PASS** (the panic-path test caught a double free in an intermediate version — auto-drop owns `s` temporaries; the explicit free was wrong and is not in this diff)
- packages/http suite: **9/9** incl. panic→500 and keep-alive-after-panic
- **ASan+UBSan clean** over 20 k keep-alive requests + pipelined requests + 404 + panic + SIGTERM shutdown
- `bench/HTTP_RESULTS.md` refreshed with an honest history note (the old table was months stale; the 2.2–2.6× vs it accumulated across prior work, not this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU