### PR TITLE
fix: a local callable now shadows a same-named trait/impl method at call sites

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -7961,16 +7961,38 @@
         }
         {} }
     {}
-    // Group F: impl method dispatch based on first arg's LLVM type
+    // Group F: impl method dispatch based on first arg's LLVM type.
+    //
+    // A LOCAL callable shadows a same-named trait/impl method: a
+    // function-typed parameter (`__param`, e.g. vec_free_with's
+    // `( @ v A ) drop` callback) or a stored closure binding (`__ptr`)
+    // must win over impl dispatch, exactly as it already wins over the
+    // bare-@fn arity check above. Without this, importing ANY file
+    // with a `% Drop <T>` impl (sqlite.nu) made every call through a
+    // parameter named `drop` resolve as trait dispatch — path.nu's
+    // vec_free_with then died with "no impl for receiver type
+    // 'String'" in whatever program linked the two, and a program
+    // whose receiver type DID have an impl would have silently called
+    // the impl instead of the parameter. Callable-ness is judged by
+    // the binding's LLVM type shape — a closure struct or bare fn
+    // pointer, the same discriminators the stored-closure call path
+    // below uses — so a scalar or plain-struct local with a method's
+    // name still dispatches. (The stored type is the LLVM spelling,
+    // e.g. `{ void (i8*, i64)*, i8* }` for `( @ v i )`.)
+    : s __cal_ll ( nurl_llty ( nurl_sym_get syms fname ) )
+    : b __cal_fnish | | | | != 0 ( nurl_str_starts __cal_ll `i64 (` ) != 0 ( nurl_str_starts __cal_ll `void (` ) != 0 ( nurl_str_starts __cal_ll `i8* (` ) != 0 ( nurl_str_starts __cal_ll `i8*(` ) != 0 ( nurl_str_starts __cal_ll `{` )
+    : b __callee_shadowed & | != 0 ( nurl_sym_len2 syms fname `__ptr` )
+    != 0 ( nurl_sym_len2 syms fname `__param` )
+    __cal_fnish
     : ~ s impl_key ( nurl_str_cat fname ( nurl_str_cat `##` first_arg_type ) )
-    : ~ s impl_mangle_key ( nurl_sym_get g_impl_name_syms impl_key )
+    : ~ s impl_mangle_key ? __callee_shadowed `` ( nurl_sym_get g_impl_name_syms impl_key )
     // `inout` receiver: the first argument is passed as `%T*`, but impls
     // are registered by the value type `%T` (g_impl_name_syms key
     // `method##%T`). On a miss with a pointer-typed first arg, retry with
     // the trailing `*` stripped so an `inout`/`sink` impl method still
     // dispatches. (Without this, applying `inout` pointerised the arg and
     // the dispatch fell through to an undefined bare `@method`.)
-    ? & == 0 ( nurl_str_len impl_mangle_key )
+    ? & & ! __callee_shadowed == 0 ( nurl_str_len impl_mangle_key )
     & > ( nurl_str_len first_arg_type ) 1
     == ( nurl_str_get first_arg_type - ( nurl_str_len first_arg_type ) 1 ) 42
     { : s __fa_base ( nurl_str_slice first_arg_type 0 - ( nurl_str_len first_arg_type ) 1 )
@@ -7982,7 +8004,7 @@
     // exists for THIS receiver type, and nothing else defines the bare
     // name: the fall-through emitted `call @speak(%Cat …)` against an
     // undefined symbol — an error only clang reported, far from here.
-    ? & & & & == 0 ( nurl_str_len impl_mangle_key )
+    ? & & & & & ! __callee_shadowed == 0 ( nurl_str_len impl_mangle_key )
     != 0 ( nurl_sym_len2 g_impl_name_syms fname `__impl_seen` )
     == 0 ( nurl_sym_len2 syms fname `__arity` )
     == 0 ( nurl_sym_len2 syms fname `__ptr` )

--- a/compiler/tests/outputs/trait_method_param_shadow.txt
+++ b/compiler/tests/outputs/trait_method_param_shadow.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+param-cb 7
+gen-i 1
+gen-i 2
+gen-s aa
+binding-cb 9
+impl-drop 8

--- a/compiler/tests/trait_method_param_shadow.nu
+++ b/compiler/tests/trait_method_param_shadow.nu
@@ -1,0 +1,85 @@
+// trait_method_param_shadow.nu — a LOCAL callable shadows a same-named
+// trait/impl method at a call site (regression, 2026-08-11).
+//
+// The real-world break: `vec_free_with [A] v ( @ v A ) drop` calls its
+// CALLBACK PARAMETER as `( drop . buf i )`. Importing any file with a
+// `% Drop <T>` impl (stdlib/ext/sqlite.nu) registered `drop` as an impl
+// method, and Group F's impl dispatch intercepted the call before the
+// parameter was consulted: `path.nu`'s vec_free_with__String then died
+// with "method 'drop' has no impl for receiver type 'String'" in any
+// program importing both — which `nurlpkg install nurllama` does
+// (history.nu → sqlite, everything → path). Worse than the error: a
+// receiver type that DID have an impl would have silently dispatched to
+// the impl instead of the parameter.
+//
+// Covered here, with a `% Drop Res` impl in scope the whole time:
+//   1. non-generic fn with a fn-typed param named `drop`  → param wins
+//   2. generic fn, same shape, instantiated at two types  → param wins
+//      (String instantiation = the exact vec_free_with__String shape)
+//   3. a stored closure BINDING named `drop`              → binding wins
+//   4. the impl itself stays wired: auto-drop at scope exit still runs
+//      the real destructor (a shadow gate that over-matched would have
+//      broken dispatch for everyone)
+//
+// Each case lives in its own function so case 3's binding cannot
+// shadow anything outside its scope.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+: Res { i id }
+
+% Drop Res {
+    @ drop Res r → v {
+        ( nurl_print `impl-drop ` ) ( nurl_print ( nurl_str_int . r id ) ) ( nurl_print `\n` )
+    }
+}
+
+// 1. Non-generic: the parameter named `drop` must be called, not the impl.
+@ run_cb ( @ v i ) drop → v {
+    ( drop 7 )
+}
+
+// 2. Generic: same, through instantiation (the shape vec_free_with has).
+@ run_each [A] ( Vec A ) v ( @ v A ) drop → v {
+    : i n ( vec_len [A] v )
+    : *A buf # *A ( vec_data [A] v )
+    : ~ i k 0
+    ~ < k n {
+        ( drop . buf k )
+        = k + k 1
+    }
+}
+
+// 3. A stored closure BINDING named `drop` shadows the impl method too.
+@ binding_case → v {
+    : ( @ v i ) drop \ i x → v { ( nurl_print `binding-cb ` ) ( nurl_print ( nurl_str_int x ) ) ( nurl_print `\n` ) }
+    ( drop 9 )
+    : *u __dropenv # *u drop 1
+    ( nurl_free # s __dropenv )
+}
+
+// 4. No shadow in this scope: the destructor still runs via auto-drop.
+@ impl_case → v {
+    : Res r8 @ Res { 8 }
+}
+
+@ main → i {
+    ( run_cb \ i x → v { ( nurl_print `param-cb ` ) ( nurl_print ( nurl_str_int x ) ) ( nurl_print `\n` ) } )
+
+    : ( Vec i ) vi ( vec_new [i] )
+    ( vec_push [i] vi 1 )
+    ( vec_push [i] vi 2 )
+    ( run_each [i] vi \ i x → v { ( nurl_print `gen-i ` ) ( nurl_print ( nurl_str_int x ) ) ( nurl_print `\n` ) } )
+    ( vec_free [i] vi )
+
+    : ( Vec String ) vs ( vec_new [String] )
+    ( vec_push [String] vs ( string_from `aa` ) )
+    ( run_each [String] vs \ String s → v { ( nurl_print `gen-s ` ) ( nurl_print ( string_data s ) ) ( nurl_print `\n` ) ( string_free s ) } )
+    ( vec_free [String] vs )
+
+    ( binding_case )
+    ( impl_case )
+    ^ 0
+}


### PR DESCRIPTION
## What broke

`nurlpkg install nurllama` fails on the **released v0.37.1** toolchain:

```
<generic vec_free_with__String from stdlib/std/path.nu:352>: error:
method 'drop' has no impl for receiver type 'String'
```

Minimal repro (7 lines): import `stdlib/std/path.nu` + `stdlib/ext/sqlite.nu`, call `path_normalize`.

## Root cause

`vec_free_with [A] v ( @ v A ) drop` calls its callback **parameter** as `( drop . buf i )`. Function-typed parameters resolve via the `__param` marker (SSA `%name`), not `__ptr` — and Group F's impl dispatch only excused `__ptr`/`__arity`/`__ffi` names. The moment any file with a `% Drop <T>` impl enters the import closure (nurllama 0.16.0's new `history.nu` imports `sqlite.nu`, which impls `% Drop Database`), every call through a parameter named `drop` was treated as trait dispatch. Worse than the error: a receiver type that *did* have an impl would have **silently called the impl instead of the parameter**.

## Fix

At Group F entry the callee is checked for a local callable — `__ptr` or `__param` set AND the binding's LLVM type shaped like a closure struct / fn pointer (the same discriminators the stored-closure call path uses) — and impl dispatch (lookup, inout retry, and the no-impl diagnostic) is skipped for it, exactly as locals already shadow the bare-@fn arity check. Scalar or named-struct locals sharing a method's name still dispatch.

## Verification

- New regression test `trait_method_param_shadow.nu`: non-generic param named `drop`, generic instantiation at i64 **and String** (the exact `vec_free_with__String` shape), a stored closure binding named `drop`, and the real destructor still firing via auto-drop — all with a `% Drop` impl in scope.
- **Differential sweep of all 1437 tracked `.nu` files** against the pristine HEAD compiler: IR, stderr and exit codes byte-identical everywhere except `packages/nurllama/src/history.nu` and `packages/registry/src/db.nu`, which flip from compile-error to compiling (same sqlite+path combination).
- Full corpus **767 PASS**, bootstrap fixed point reached.

## Release note

v0.37.1 remains broken for `nurlpkg install nurllama` (and any package combining a `% Drop` impl with `path.nu`) until this ships — **a 0.37.2 patch release is warranted** once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU