### PR TITLE
compiler: unclosed brace in generic/closure bodies is an error, not a hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A missing `}` in a generic template or a closure body no longer
+  hangs the compiler.** `collect_fn_body` (generic function/struct
+  template capture) and `simple_capture_analysis` (closure capture
+  pre-scan) walked braces with no EOF guard, so `nurlc file.nu` spun
+  forever on an unclosed body — the drop-close-brace mutation hung on
+  every generic-using corpus program (9/9). Both loops now stop at EOF
+  with a hard error anchored at the opening `{` that never closed,
+  naming the cure (add the `}`; an extra `{` inside skews the count
+  the same way) and pointing at nurlfmt, whose re-indent makes the
+  runaway nesting visible.
+
 - **Every value a function hands back is now type-checked — the
   implicit fall-off tail and closure tails included, and the
   integer→pointer hole is closed at all four value positions.** A

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -17522,6 +17522,9 @@
 @ simple_capture_analysis i lex i outer_syms s closure_params → s {
     : ~ s captured_vars ( nurl_str_cat `` `` )
     : ~ i captured_count 0
+    // Anchor for the unclosed-brace diagnostic below: the opening '{'.
+    : i sca_open_line ( nurl_lex_line lex )
+    : i sca_open_col ( nurl_lex_col lex )
     ( nurl_lex_advance lex )  // consume opening '{'
 
     // Scan tokens in closure body until closing brace
@@ -17529,6 +17532,13 @@
     ~ > brace_depth 0 {
         : i tt ( nurl_lex_type lex )
 
+        // Unbalanced braces used to spin this loop at EOF forever — the
+        // capture pre-scan runs before the body parse, so a closure
+        // whose '}' is missing HUNG the compiler instead of erroring.
+        ? == tt TT_EOF
+        { ( die_pos lex sca_open_line sca_open_col
+            `end of file inside this closure body — the '{' here is never closed. Add the missing '}' (an extra '{' somewhere inside pushes the count off the same way); running nurlfmt shows where the nesting runs away.` ) }
+        {}
         ? == tt TT_LBRACE
         { = brace_depth + brace_depth 1 }
         {
@@ -18316,12 +18326,26 @@
 // Returns space-separated, source-faithful token text (string literals
 // keep their backticks via __tok_src_text), so the result re-lexes to the
 // identical token stream — safe for generic template bodies.
-@ collect_fn_body i lex → s {
+@ collect_fn_body i lex s what → s {
+    // Anchor for the unclosed-brace diagnostic: the opening '{' itself.
+    // Reported there, not at EOF — EOF has no useful source line, and
+    // the brace that never closed is the thing the user must find.
+    : i open_line ( nurl_lex_line lex )
+    : i open_col ( nurl_lex_col lex )
     : ~ s result ( nurl_str_cat ( __tok_src_text lex ) ` ` )
     ( nurl_lex_advance lex )
     : ~ i depth 1
     ~ != depth 0 {
         : i tt2 ( nurl_lex_type lex )
+        // Unbalanced braces used to spin this loop at EOF forever — the
+        // compiler HUNG on `nurlc file.nu` with a missing '}' in any
+        // generic template. EOF inside the body is a hard error at the
+        // opening brace.
+        ? == tt2 TT_EOF
+        { ( die_pos lex open_line open_col ( nurl_str_cat3
+            `end of file inside this ` what
+            ` body — the '{' here is never closed. Add the missing '}' (an extra '{' somewhere inside pushes the count off the same way); running nurlfmt shows where the nesting runs away.` ) ) }
+        {}
         ? == tt2 TT_LBRACE { = depth + depth 1 } {}
         ? == tt2 TT_RBRACE { = depth - depth 1 } {}
         = result ( nurl_str_cat result ( nurl_str_cat ( __tok_src_text lex ) ` ` ) )
@@ -18450,7 +18474,7 @@
         ( nurl_lex_advance lex )
     }
     ? != ( nurl_lex_type lex ) TT_EOF
-    { = src ( nurl_str_cat src ( collect_fn_body lex ) ) }
+    { = src ( nurl_str_cat src ( collect_fn_body lex `generic function` ) ) }
     {}
     ( nurl_sym_def g_generic_syms ( nurl_str_cat fname `__tparams` ) tparams )
     ( nurl_sym_def g_generic_syms ( nurl_str_cat fname `__gsrc` ) src )
@@ -23150,7 +23174,7 @@
                     }
                     ? == ( nurl_lex_type lex ) TT_RBRACK { ( nurl_lex_advance lex ) } {}
                     ? == ( nurl_lex_type lex ) TT_LBRACE {
-                        : s body ( collect_fn_body lex )
+                        : s body ( collect_fn_body lex `generic struct` )
                         ( nurl_sym_def g_generic_struct_syms ( nurl_str_cat sname `__stparams` ) tparams )
                         ( nurl_sym_def g_generic_struct_syms ( nurl_str_cat sname `__sbody` ) body )
                         // Lint: generic struct templates never reach

--- a/compiler/tests/diag_closure_body_unclosed.nu
+++ b/compiler/tests/diag_closure_body_unclosed.nu
@@ -1,0 +1,9 @@
+// diag_closure_body_unclosed.nu — a closure literal whose body '{' is
+// never closed. The capture pre-scan (simple_capture_analysis) walks
+// the body before it is parsed and had no EOF guard — this shape hung
+// the compiler. Now a hard error anchored at the closure's '{'.
+
+@ main → i {
+    : ( @ v ) f \ → v { ( nurl_print `x` )
+        ( f )
+        ^ 0

--- a/compiler/tests/diag_generic_fn_unclosed.nu
+++ b/compiler/tests/diag_generic_fn_unclosed.nu
@@ -1,0 +1,14 @@
+// diag_generic_fn_unclosed.nu — a generic function template whose
+// body brace count never reaches zero (the inner '?' arm is missing
+// its '}', so the function's own '}' closes the arm instead and EOF
+// arrives at depth 1). Same collect_fn_body EOF hang as the generic
+// struct twin; same cure in the message.
+
+@ pick [T] T a T b i which → T {
+    ? > which 0 { ^ a
+        ^ b
+    }
+
+    @ main → i {
+        ^ ( pick [i] 1 2 0 )
+    }

--- a/compiler/tests/diag_generic_struct_unclosed.nu
+++ b/compiler/tests/diag_generic_struct_unclosed.nu
@@ -1,0 +1,13 @@
+// diag_generic_struct_unclosed.nu — a generic struct template whose
+// '{' is never closed. collect_fn_body's depth loop had no EOF guard,
+// so `nurlc file.nu` HUNG forever on this shape (found by the
+// drop-close-brace mutation across every generic-using corpus
+// program). Now a hard error anchored at the opening brace.
+
+: Pair [A B] {
+    A first
+    B second
+
+    @ main → i {
+        ^ 0
+    }

--- a/compiler/tests/outputs/diag_closure_body_unclosed.txt
+++ b/compiler/tests/outputs/diag_closure_body_unclosed.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_closure_body_unclosed.nu:7:25: error: end of file inside this closure body — the '{' here is never closed. Add the missing '}' (an extra '{' somewhere inside pushes the count off the same way); running nurlfmt shows where the nesting runs away.
+    : ( @ v ) f \ → v { ( nurl_print `x` )
+                        ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_generic_fn_unclosed.txt
+++ b/compiler/tests/outputs/diag_generic_fn_unclosed.txt
@@ -1,0 +1,6 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_generic_fn_unclosed.nu:7:34: error: end of file inside this generic function body — the '{' here is never closed. Add the missing '}' (an extra '{' somewhere inside pushes the count off the same way); running nurlfmt shows where the nesting runs away.
+@ pick [T] T a T b i which → T {
+                                 ^
+error: aborting due to 1 previous error

--- a/compiler/tests/outputs/diag_generic_struct_unclosed.txt
+++ b/compiler/tests/outputs/diag_generic_struct_unclosed.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_generic_struct_unclosed.nu:7:14: error: end of file inside this generic struct body — the '{' here is never closed. Add the missing '}' (an extra '{' somewhere inside pushes the count off the same way); running nurlfmt shows where the nesting runs away.
+: Pair [A B] {
+             ^


### PR DESCRIPTION
## What

`nurlc file.nu` **hung forever** on a missing `}` in any generic function template, generic struct template, or closure body — the drop-close-brace mutation from the corpus-wide probe hung on 9/9 generic-using programs. An unclosed brace is among the most common mistakes a model makes; an infinite loop is the worst possible AX for it.

## Root cause

`collect_fn_body` (generic function/struct template capture) and `simple_capture_analysis` (closure capture pre-scan) walk braces by depth with **no EOF guard**: at EOF, `nurl_lex_advance` stays at EOF and depth never reaches zero. Every other depth-scanner in the compiler already guards EOF; these two were missed.

## Fix

Both loops now stop at EOF with a hard error **anchored at the opening `{` that never closed** (die_pos — EOF has no useful source line), naming the cure: add the missing `}` (an extra `{` inside skews the count the same way), and pointing at nurlfmt — its re-indent makes the runaway nesting visible (verified: nurlfmt handles the broken source and the mis-indentation shows exactly where the nesting escapes).

## Verification

- All 9 previously-hanging mutants now die instantly with the anchored diagnostic.
- New text-pinned tests: `diag_generic_struct_unclosed`, `diag_generic_fn_unclosed`, `diag_closure_body_unclosed`.
- 778 tests pass; diag coverage ratchet clean; windows-golden twin check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CSENqvFreiyzrt6EpXiEN