### PR TITLE
release: v0.39.0 — the diagnostics-hardening release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.39.0] — 2026-08-12
+
+The diagnostics-hardening release. A corpus-wide mutation probe (one
+realistic mistake injected into each of the ~790 test programs, ~5 400
+mutants per run) drove six root-cause series (#874–#879): at the start it
+found 401 broken programs the compiler accepted and only the LLVM
+verifier/linker rejected, plus 9 inputs that hung the compiler forever;
+at the end it finds **zero** — every mutant either compiles correctly or
+dies with a single anchored `file:line:col: error:` naming the rule and
+the cure.
 
 ### Fixed
 
@@ -12103,7 +12112,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.37.1...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.39.0...HEAD
+[0.39.0]: https://github.com/nurl-lang/nurl/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/nurl-lang/nurl/compare/v0.37.1...v0.38.0
 [0.37.1]: https://github.com/nurl-lang/nurl/compare/v0.37.0...v0.37.1
 [0.37.0]: https://github.com/nurl-lang/nurl/compare/v0.36.0...v0.37.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -180,9 +180,7 @@ the Actions tab.
   untested: the separate `windows-tests` workflow runs `build.bat` — the
   bootstrap fixed point plus the full Windows golden corpus
   (`compiler/tests/outputs-windows/`, via `run_tests.ps1`) — on every
-  push to `main` and every PR. (This entry previously said no corpus ran
-  on Windows in CI at all; that stopped being true when the workflow
-  landed, and it now gates PRs too.)
+  push to `main` and every PR.
 - The FreeBSD release leg is best-effort (`continue-on-error`); a release
   can ship without the FreeBSD archive.
 - macOS ships no release artifact yet — the installer rejects Darwin with a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-11 · Current release: **0.38.0** · Language: **Grammar
+_Last reviewed: 2026-08-12 · Current release: **0.39.0** · Language: **Grammar
 v2.4** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---
@@ -97,7 +97,13 @@ A high-level map of what exists. Dates and per-feature detail are in
 - Front-end is diagnostic-first: malformed prefix-arity programs, undefined
   identifiers, call-arity mismatches, unbalanced braces / stray top-level
   tokens, and visibility violations are hard errors with source locations —
-  nothing malformed reaches the backend silently.
+  nothing malformed reaches the backend silently. Since 0.39.0 that claim
+  is measured corpus-wide: a mutation probe (one realistic mistake injected
+  into each of the ~790 test programs, ~5 400 mutants) produces **zero**
+  compiler hangs, zero crashes, and zero broken programs reaching the LLVM
+  verifier or linker; every return path is type-checked (implicit fall-off
+  and closure tails included), and errors inside generic/trait re-parses
+  point at the template's real file:line with the instantiation named.
 - Diagnostics are *measured*, not asserted. `check_diag_coverage.sh` reports
   which of the compiler's ~230 messages a test has ever made it print;
   `check_diag_anchor.sh` gates that every baselined diagnostic points at the

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -31,9 +31,7 @@ downstream notices. Write n-1 operators for n conditions:
 `nurlc` points its caret at the `?` and names the cure. The trap is a
 hard **error by default**; `--no-strict-arity` demotes it to a warning
 for trees that need to keep building. This repo additionally runs
-`tools/check_strict_arity.sh` over its whole first-party tree in CI, and
-that gate's first run found a shipped example culling every particle on
-every frame for exactly this reason.
+`tools/check_strict_arity.sh` over its whole first-party tree in CI.
 
 The few things that are *not* surprises but fixed properties of the language
 or its runtime live in their proper homes, not here:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -364,9 +364,8 @@ null pointer.
 
 A **condition** (`?` / `~`) must be `b` or an integer (tested non-zero).
 A float, pointer/string, enum, or aggregate condition is rejected with
-the comparison to write instead — none of them has a truth value, and
-the blind `icmp ne … 0` narrowing used to emit invalid IR that only
-clang reported. Likewise `# b` of a float is rejected (an `i1` holds
+the comparison to write instead — none of them has a truth value.
+Likewise `# b` of a float is rejected (an `i1` holds
 only 0 or 1, so the conversion is poison for any other value — write
 the comparison).
 
@@ -1504,6 +1503,15 @@ foo.nu:6:3: error: bare identifier 'nurl_print' as a statement has no
   nurl_print `oops`
   ^
 ```
+
+**Re-parsed contexts.** A diagnostic raised inside a generic
+instantiation's body is anchored at the **template's own** `file:line:col`
+(the re-lex buffer preserves the template's line structure), and the
+message carries a bracketed context suffix naming the instantiation and
+its first call site — `[while instantiating 'f__i64' — the error may
+depend on the concrete type arguments; first call site: main.nu:12]`.
+Trait-method signature and default-body re-parses carry the analogous
+suffix naming the method, the trait, and the Self/impl type.
 
 **Multi-error reporting.** One `nurlc` run reports the errors of *every*
 failing top-level declaration, not just the first: a diagnostic aborts


### PR DESCRIPTION
Release prep for **v0.39.0**:

- **CHANGELOG**: `[Unreleased]` → `[0.39.0] — 2026-08-12` with a lead paragraph summarising the #874–#879 diagnostics-hardening series (corpus-wide mutation probe: 401 invalid-IR escapes + 9 compiler hangs → **0/0** across ~5 400 mutants); compare-link refs fixed (`Unreleased` now v0.39.0…HEAD).
- **ROADMAP**: review line bumped to 0.39.0; the "nothing malformed reaches the backend silently" claim now cites the probe measurement.
- **docs/spec.md §10.2**: the re-parsed-context diagnostic shape is now normative — generic-body errors anchor at the template's real `file:line:col` and carry the bracketed instantiation context; trait sig/default re-parses name method, trait, and Self/impl type. One historical aside removed from the condition rule (the spec states rules, not history).
- **docs/GOTCHAS.md / RELEASING.md**: two historical asides trimmed — documentation stays factual.

After merge: `git tag v0.39.0 && git push origin v0.39.0` fires `release.yml` (artifacts for linux x86_64/arm64, windows, FreeBSD best-effort) and `web-deploy.yml` (site version from the top CHANGELOG section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CSENqvFreiyzrt6EpXiEN