### PR TITLE
bench(http): honesty pass — flag closed-loop starvation, measure hand…

### DIFF
--- a/bench/HTTP_RESULTS.md
+++ b/bench/HTTP_RESULTS.md
@@ -1,8 +1,10 @@
 # NURL HTTP-server peer-comparison
 
-Generated `2026-08-12T16:32:07Z` by `bench/run_http.sh`. **Do not edit by hand** — the next run overwrites it.
+Generated `2026-08-12T18:13:38Z` by `bench/run_http.sh`. **Do not edit by hand** — the next run overwrites it.
 
-Each implementation accepts a TCP connection, parses one HTTP/1.1 request and writes a 14-byte `Hello, World!\n` body (`text/plain`), keep-alive. The TLS section runs the *same* servers and the same load over a self-signed EC (P-256) certificate; the load generator (`oha`) accepts it with `--insecure`. The NURL server is the `packages/http` HttpApp facade (`http_app_listen` / `http_app_listen_tls`) with a 10-thread worker pool — the surface a real NURL service deploys.
+Each implementation accepts a TCP connection, parses one HTTP/1.1 request and writes a 14-byte `Hello, World!\n` body (`text/plain`), keep-alive. The TLS section runs the *same* servers and the same load over a self-signed EC (P-256) certificate, which `oha` accepts with `--insecure`. The NURL server is the `packages/http` HttpApp facade (`http_app_listen` / `http_app_listen_tls`) with a 10-thread worker pool — the surface a real NURL service deploys.
+
+**Read the throughput columns, not the latency columns, at high concurrency.** These are *closed-loop* measurements: `oha` holds C connections open and fires the next request the instant one returns. When a server's in-flight work saturates below C (NURL's 10 blocking workers do, by design), the extra connections queue inside `oha` and never reach the server, so `req/s` is the server's true saturation throughput but the latency percentiles describe only the few connections in flight. Such cells are marked ‡ and left un-bold: their latency is not a service-level number (that needs an open-loop generator — see *Planned rigor*). The effective in-flight count is `req/s x mean-latency` (Little's law).
 
 ## Environment
 
@@ -12,7 +14,7 @@ Each implementation accepts a TCP connection, parses one HTTP/1.1 request and wr
 | Kernel | `Linux 7.0.0-28-generic x86_64` |
 | CPU | Intel(R) Core(TM) i7-5930K CPU @ 3.50GHz (12 logical cores) |
 | Memory | 32770952 KiB |
-| Commit | `3a75c2ec737b02e1de3352fad56335eb4d733bdc` |
+| Commit | `600939f970d4381e3934d94117513b8668a0541e` |
 | NURL | `v0.39.0-9-gdf2f443-dirty` |
 | Rust | rustc 1.97.1 (8bab26f4f 2026-07-14) |
 | Node | v24.15.0 |
@@ -20,42 +22,65 @@ Each implementation accepts a TCP connection, parses one HTTP/1.1 request and wr
 
 | Setting | Value |
 |---|---|
-| Measurement | median of 3 × 10 s runs per cell, HTTP/1.1 keep-alive |
+| Throughput/latency | median of 3 x 10 s closed-loop runs, keep-alive |
 | Concurrencies | 1 , 10 , 50 , 200 |
+| Connection-setup rate | 20000 connections at c=20, `--disable-keepalive` |
 | TLS cert | self-signed EC P-256, `CN=localhost` |
 
 ## 1. Plaintext HTTP
 
 |              | Server  | C = 1 | C = 10 | C = 50 | C = 200 |
 |--------------|---------|--------:|--------:|--------:|--------:|
-| **req/s**    | NURL    | **12 760** | **163 508** | 142 039 | 148 157 |
-|              | Rust    | 11 718 | 144 619 | **207 764** | **292 159** |
-|              | Node    | 9 625 | 26 943 | 28 145 | 27 485 |
-| **p50 (ms)** | NURL    | **0.08** | **0.06** | **0.06** | **0.06** |
-|              | Rust    | 0.09 | **0.06** | 0.20 | 0.63 |
-|              | Node    | 0.09 | 0.32 | 1.64 | 6.86 |
-| **p99 (ms)** | NURL    | **0.14** | **0.10** | **0.13** | **0.12** |
-|              | Rust    | 0.16 | 0.14 | 0.75 | 1.65 |
-|              | Node    | 0.19 | 0.73 | 3.62 | 13.40 |
+| **req/s**    | NURL    | **14 310** | **166 679** | 143 664 | 148 654 |
+|              | Rust    | 13 303 | 148 512 | **210 527** | **293 300** |
+|              | Node    | 8 390 | 26 724 | 28 003 | 27 236 |
+| **p50 (ms)** | NURL    | **0.07** | **0.06** | **0.06** | 0.06‡ |
+|              | Rust    | **0.07** | **0.06** | 0.20 | **0.63** |
+|              | Node    | 0.12 | 0.32 | 1.66 | 7.37 |
+| **p99 (ms)** | NURL    | **0.13** | **0.10** | **0.13** | 0.12‡ |
+|              | Rust    | 0.15 | 0.13 | 0.73 | **1.65** |
+|              | Node    | 0.19 | 0.75 | 3.60 | 14.26 |
+
+‡ closed-loop starved (NURL C=200: ~132.3 in flight).
 
 ## 2. TLS (HTTPS)
 
 |              | Server  | C = 1 | C = 10 | C = 50 | C = 200 |
 |--------------|---------|--------:|--------:|--------:|--------:|
-| **req/s**    | NURL    | 10 646 | **130 281** | 113 308 | 116 459 |
-|              | Rust    | **11 396** | 122 741 | **171 182** | **227 012** |
-|              | Node    | 8 027 | 20 162 | 20 994 | 18 880 |
-| **p50 (ms)** | NURL    | 0.09 | **0.07** | **0.07** | **0.07** |
-|              | Rust    | **0.08** | 0.08 | 0.25 | 0.83 |
-|              | Node    | 0.11 | 0.43 | 2.28 | 10.48 |
-| **p99 (ms)** | NURL    | 0.16 | **0.12** | **0.15** | **0.16** |
-|              | Rust    | **0.15** | 0.15 | 0.85 | 2.02 |
-|              | Node    | 0.21 | 0.98 | 3.07 | 12.84 |
+| **req/s**    | NURL    | 10 255 | **130 110** | 114 210 | 116 784 |
+|              | Rust    | **10 803** | 121 890 | **172 426** | **227 575** |
+|              | Node    | 8 759 | 19 667 | 20 372 | 19 131 |
+| **p50 (ms)** | NURL    | **0.09** | **0.07** | **0.07** | 0.07‡ |
+|              | Rust    | **0.09** | 0.08 | 0.25 | **0.82** |
+|              | Node    | 0.10 | 0.45 | 2.35 | 10.08 |
+| **p99 (ms)** | NURL    | 0.18 | **0.12** | **0.16** | 0.15‡ |
+|              | Rust    | **0.17** | 0.16 | 0.85 | **2.05** |
+|              | Node    | 0.21 | 0.99 | 3.05 | 13.09 |
 
-(Best per row in **bold**. Higher is better for req/s, lower for latency. `n/a` = tool absent at measurement time; `FAIL` = the server did not complete that cell.)
+‡ closed-loop starved (NURL C=200: ~130.8 in flight).
+
+(Best per row in **bold**; latency winners are chosen only among non-starved cells. ‡ = closed-loop starved. `n/a` = tool absent; `FAIL` = the server did not complete that cell.)
+
+## 3. Connection-setup rate (new connection per request)
+
+`--disable-keepalive`, so each request pays a fresh connection. For `http` that is the accept/teardown rate; for `https` it is **TLS handshakes per second** — the pure-NURL P-256 ECDHE + ECDSA-verify path (no OpenSSL, no AES-NI-tier handshake assembly) against rustls and Node. This is the cost a short-lived-connection edge deployment actually pays, and the one the keep-alive tables above amortise to nothing.
+
+| Server | http conn/s | https handshakes/s |
+|--------|------------:|-------------------:|
+| NURL   | **54 948** | 2 470 |
+| Rust   | 49 720 | **12 498** |
+| Node   | 9 643 | 1 653 |
 
 ## Notes
 
-- The TLS rows carry the full handshake + record-layer cost of NURL's pure-NURL TLS 1.3 stack (no OpenSSL); with keep-alive the handshake is amortised across a connection's requests, so the gap to plaintext is the per-record AEAD, not a per-request handshake.
-- Rust serves TLS through `tokio-rustls`; Node through its built-in `https` module. Each implementation uses its conventional stack, so the columns compare deployments, not just ciphers.
-- Loopback only, HTTP/1.1 only. No HTTP/2. Absolute numbers depend heavily on the host; compare columns within one run, not across machines.
+- **What the TLS tables measure.** With keep-alive, a connection handshakes once and then serves many requests, so the section-2 gap to plaintext is the per-record AEAD, *not* the handshake. The handshake cost lives in section 3, where every request is a new connection.
+- Rust serves TLS through `tokio-rustls`; Node through its built-in `https` module. Each uses its conventional stack, so the columns compare deployments, not just ciphers.
+- Loopback only, HTTP/1.1 only, 14-byte body. No HTTP/2. Absolute numbers depend heavily on the host; compare columns within one run, not across machines.
+
+### Planned rigor
+
+Known limits of this harness, in priority order — each is a measurement this run does **not** yet make, called out so a reader does not have to guess:
+1. **Open-loop latency.** Replace the closed-loop latency columns with a fixed-rate generator (`oha -q`, or `wrk2`/`vegeta`) at 50/80/95 % of each server's measured throughput, reporting p50/p99/p99.9/max. Closed loop cannot measure latency above capacity (coordinated omission), which is why saturated cells are marked ‡ rather than trusted.
+2. **Core isolation.** Pin the server and the load generator to disjoint core sets (`taskset`) and equalise pool sizes, so `oha`'s threads do not compete with the server for CPU.
+3. **CPU-time per request.** `getrusage(RUSAGE_SELF)` in each server → `(utime+stime)/requests`: the one figure immune to loopback, generator contention and pool size.
+4. **Record-layer throughput.** Re-run TLS with 16 KB and 1 MB bodies; a 14-byte body exercises the handshake and framing, not the AEAD stream.

--- a/bench/gen_http_results.py
+++ b/bench/gen_http_results.py
@@ -4,59 +4,92 @@
 # by hand; run_http.sh drives it and overwrites HTTP_RESULTS.md with the
 # result, the same way bench.sh generates bench/RESULTS.md.
 #
-# Input (tab-separated) on stdin:
-#   ENV<TAB>key<TAB>value        one per environment field
-#   ROW<TAB>scheme name c rps p50 p99   one per measured cell
-# where scheme is http|https, name is nurl|rust|node, and rps/p50/p99 are
-# numbers or the literal "n/a" / "FAIL".
+# Input (on stdin):
+#   ENV<TAB>key<TAB>value            one per environment field
+#   ROW scheme name c rps p50 p99 mean   one per closed-loop cell
+#   HS  scheme name conn_per_s       one connection-setup-rate cell/server
+# scheme is http|https, name is nurl|rust|node; numeric fields are numbers
+# or the literal "n/a" / "FAIL". Latencies are in ms, `mean` is the mean
+# latency in ms used for the effective-concurrency (Little's-law) check.
 
 import sys
 
 SERVERS = [("nurl", "NURL"), ("rust", "Rust"), ("node", "Node")]
 SCHEMES = [("http", "1. Plaintext HTTP"), ("https", "2. TLS (HTTPS)")]
+DAGGER = "‡"  # ‡ marks a closed-loop-starved latency cell
+
+
+def num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
 
 
 def main():
     env = {}
-    # cells[(scheme, name, c)] = (rps, p50, p99) as strings
-    cells = {}
+    cells = {}   # (scheme, name, c) -> (rps, p50, p99, mean) strings
+    conn = {}    # (scheme, name) -> conn_per_s string
     for line in sys.stdin:
-        parts = line.rstrip("\n").split("\t")
-        if not parts:
-            continue
-        if parts[0] == "ENV" and len(parts) >= 3:
-            env[parts[1]] = "\t".join(parts[2:])
-        elif parts[0] == "ROW" and len(parts) >= 2:
-            f = parts[1].split()
-            if len(f) == 6:
-                scheme, name, c, rps, p50, p99 = f
-                cells[(scheme, name, c)] = (rps, p50, p99)
+        line = line.rstrip("\n")
+        if line.startswith("ENV\t"):
+            parts = line.split("\t")
+            if len(parts) >= 3:
+                env[parts[1]] = "\t".join(parts[2:])
+        elif line.startswith("ROW "):
+            f = line.split()[1:]
+            if len(f) == 7:
+                scheme, name, c, rps, p50, p99, mean = f
+                cells[(scheme, name, c)] = (rps, p50, p99, mean)
+        elif line.startswith("HS "):
+            f = line.split()[1:]
+            if len(f) == 3:
+                conn[(f[0], f[1])] = f[2]
 
     concs = env.get("concurrencies", "1 10 50 200").split()
 
-    def num(v):
+    def starved(scheme, name, c):
+        # Little's law: the number of connections actually in flight is
+        # rps * mean_latency. A closed-loop cell that offered C but kept
+        # far fewer busy is measuring the latency of the served few, not
+        # of the C that were offered.
+        #
+        # Two conditions so low-C cells are not false-flagged: the ratio
+        # must be well under 1 AND at least ~2 offered connections must
+        # have failed to reach the server. At C=1 the ratio dips below 0.9
+        # from send-gap granularity alone (~0.8 in flight), but the
+        # absolute gap is a fraction of a connection, not real starvation.
+        cell = cells.get((scheme, name, c))
+        if not cell:
+            return False
+        rps, _, _, mean = cell
+        r, m = num(rps), num(mean)
+        if r is None or m is None:
+            return False
+        n_eff = r * (m / 1000.0)
         try:
-            return float(v)
-        except (TypeError, ValueError):
-            return None
+            offered = float(c)
+        except ValueError:
+            return False
+        return n_eff < 0.9 * offered and (offered - n_eff) >= 2.0
+
+    def n_eff_of(scheme, name, c):
+        cell = cells.get((scheme, name, c))
+        rps, _, _, mean = cell
+        return num(rps) * (num(mean) / 1000.0)
 
     def fmt_rps(v):
         n = num(v)
-        if n is None:
-            return v  # "n/a" / "FAIL"
-        # thousands separator with a thin space, matching the prior table
-        return f"{int(round(n)):,}".replace(",", " ")
+        return v if n is None else f"{int(round(n)):,}".replace(",", " ")
 
     def fmt_lat(v):
         n = num(v)
         return v if n is None else f"{n:.2f}"
 
     def best(values, want_max):
-        nums = [num(v) for v in values]
-        present = [x for x in nums if x is not None]
-        if not present:
-            return None
-        return max(present) if want_max else min(present)
+        present = [num(v) for v in values]
+        present = [x for x in present if x is not None]
+        return (max(present) if want_max else min(present)) if present else None
 
     out = []
     w = out.append
@@ -72,11 +105,25 @@ def main():
         "HTTP/1.1 request and writes a 14-byte `Hello, World!\\n` body "
         "(`text/plain`), keep-alive. The TLS section runs the *same* "
         "servers and the same load over a self-signed EC (P-256) "
-        "certificate; the load generator (`oha`) accepts it with "
-        "`--insecure`. The NURL server is the `packages/http` HttpApp "
-        "facade (`http_app_listen` / `http_app_listen_tls`) with a "
-        "10-thread worker pool — the surface a real NURL service "
-        "deploys."
+        "certificate, which `oha` accepts with `--insecure`. The NURL "
+        "server is the `packages/http` HttpApp facade (`http_app_listen` "
+        "/ `http_app_listen_tls`) with a 10-thread worker pool — the "
+        "surface a real NURL service deploys."
+    )
+    w("")
+    w(
+        "**Read the throughput columns, not the latency columns, at high "
+        "concurrency.** These are *closed-loop* measurements: `oha` holds "
+        "C connections open and fires the next request the instant one "
+        "returns. When a server's in-flight work saturates below C (NURL's "
+        "10 blocking workers do, by design), the extra connections queue "
+        "inside `oha` and never reach the server, so `req/s` is the "
+        "server's true saturation throughput but the latency percentiles "
+        f"describe only the few connections in flight. Such cells are "
+        f"marked {DAGGER} and left un-bold: their latency is not a "
+        "service-level number (that needs an open-loop generator — see "
+        "*Planned rigor*). The effective in-flight count is "
+        "`req/s x mean-latency` (Little's law)."
     )
     w("")
 
@@ -99,14 +146,18 @@ def main():
     w("| Setting | Value |")
     w("|---|---|")
     w(
-        f"| Measurement | median of {env.get('iters','3')} × "
-        f"{env.get('duration','10')} s runs per cell, HTTP/1.1 keep-alive |"
+        f"| Throughput/latency | median of {env.get('iters','3')} x "
+        f"{env.get('duration','10')} s closed-loop runs, keep-alive |"
     )
     w(f"| Concurrencies | {' , '.join(concs)} |")
+    w(
+        f"| Connection-setup rate | {env.get('hs_reqs','20000')} "
+        f"connections at c={env.get('hs_conc','20')}, `--disable-keepalive` |"
+    )
     w("| TLS cert | self-signed EC P-256, `CN=localhost` |")
     w("")
 
-    # ── one table per scheme ─────────────────────────────────────
+    # ── one throughput/latency table per scheme ──────────────────
     for scheme, title in SCHEMES:
         w(f"## {title}\n")
         header = "|              | Server  | " + " | ".join(
@@ -115,28 +166,35 @@ def main():
         sep = "|--------------|---------|" + "|".join(["--------:"] * len(concs)) + "|"
 
         rows = []
-        # For each metric block, compute best per column across servers.
-        for metric_label, idx, want_max, fmt in (
-            ("**req/s**", 0, True, fmt_rps),
-            ("**p50 (ms)**", 1, False, fmt_lat),
-            ("**p99 (ms)**", 2, False, fmt_lat),
+        for metric_label, idx, want_max, fmt, is_lat in (
+            ("**req/s**", 0, True, fmt_rps, False),
+            ("**p50 (ms)**", 1, False, fmt_lat, True),
+            ("**p99 (ms)**", 2, False, fmt_lat, True),
         ):
-            # best value per concurrency column
+            # Best per concurrency column, ignoring starved latency cells
+            # so a starved 0.06 ms never wins (or bolds) a latency row.
             col_best = {}
             for c in concs:
-                vals = [
-                    cells.get((scheme, name, c), ("n/a", "n/a", "n/a"))[idx]
-                    for name, _ in SERVERS
-                ]
+                vals = []
+                for name, _ in SERVERS:
+                    if is_lat and starved(scheme, name, c):
+                        continue
+                    cell = cells.get((scheme, name, c))
+                    if cell:
+                        vals.append(cell[idx])
                 col_best[c] = best(vals, want_max)
             for si, (name, disp) in enumerate(SERVERS):
                 left = metric_label if si == 0 else ""
                 out_cells = []
                 for c in concs:
-                    raw = cells.get((scheme, name, c), ("n/a", "n/a", "n/a"))[idx]
+                    cell = cells.get((scheme, name, c), ("n/a", "n/a", "n/a", "n/a"))
+                    raw = cell[idx]
                     txt = fmt(raw)
                     n = num(raw)
-                    if n is not None and col_best[c] is not None and abs(n - col_best[c]) < 1e-9:
+                    st = is_lat and starved(scheme, name, c)
+                    if st:
+                        txt = f"{txt}{DAGGER}"
+                    elif n is not None and col_best[c] is not None and abs(n - col_best[c]) < 1e-9:
                         txt = f"**{txt}**"
                     out_cells.append(txt)
                 rows.append(
@@ -149,30 +207,101 @@ def main():
             w(r)
         w("")
 
-    w("(Best per row in **bold**. Higher is better for req/s, lower for "
-      "latency. `n/a` = tool absent at measurement time; `FAIL` = the "
-      "server did not complete that cell.)")
+        # Per-scheme starvation footnote naming the effective in-flight
+        # count for every marked cell, so the number is on the page.
+        marks = []
+        for c in concs:
+            for name, disp in SERVERS:
+                if starved(scheme, name, c):
+                    marks.append(f"{disp} C={c}: ~{n_eff_of(scheme, name, c):.1f} in flight")
+        if marks:
+            w(f"{DAGGER} closed-loop starved ({'; '.join(marks)}).")
+            w("")
+
+    w(
+        "(Best per row in **bold**; latency winners are chosen only among "
+        f"non-starved cells. {DAGGER} = closed-loop starved. `n/a` = tool "
+        "absent; `FAIL` = the server did not complete that cell.)"
+    )
     w("")
 
-    # ── reading notes (generated, factual) ───────────────────────
+    # ── connection-setup / TLS-handshake rate ────────────────────
+    w("## 3. Connection-setup rate (new connection per request)\n")
+    w(
+        "`--disable-keepalive`, so each request pays a fresh connection. "
+        "For `http` that is the accept/teardown rate; for `https` it is "
+        "**TLS handshakes per second** — the pure-NURL P-256 ECDHE + "
+        "ECDSA-verify path (no OpenSSL, no AES-NI-tier handshake assembly) "
+        "against rustls and Node. This is the cost a short-lived-"
+        "connection edge deployment actually pays, and the one the keep-"
+        "alive tables above amortise to nothing."
+    )
+    w("")
+    w("| Server | http conn/s | https handshakes/s |")
+    w("|--------|------------:|-------------------:|")
+    for name, disp in SERVERS:
+        h = conn.get(("http", name), "n/a")
+        s = conn.get(("https", name), "n/a")
+        # bold the best of each column
+        hvals = [conn.get(("http", n), "n/a") for n, _ in SERVERS]
+        svals = [conn.get(("https", n), "n/a") for n, _ in SERVERS]
+        hb, sb = best(hvals, True), best(svals, True)
+        ht = fmt_rps(h); st = fmt_rps(s)
+        if num(h) is not None and hb is not None and abs(num(h) - hb) < 1e-9:
+            ht = f"**{ht}**"
+        if num(s) is not None and sb is not None and abs(num(s) - sb) < 1e-9:
+            st = f"**{st}**"
+        w(f"| {disp:<6} | {ht} | {st} |")
+    w("")
+
+    # ── notes ────────────────────────────────────────────────────
     w("## Notes\n")
     w(
-        "- The TLS rows carry the full handshake + record-layer cost of "
-        "NURL's pure-NURL TLS 1.3 stack (no OpenSSL); with keep-alive "
-        "the handshake is amortised across a connection's requests, so "
-        "the gap to plaintext is the per-record AEAD, not a per-request "
-        "handshake."
+        "- **What the TLS tables measure.** With keep-alive, a connection "
+        "handshakes once and then serves many requests, so the section-2 "
+        "gap to plaintext is the per-record AEAD, *not* the handshake. The "
+        "handshake cost lives in section 3, where every request is a new "
+        "connection."
     )
     w(
         "- Rust serves TLS through `tokio-rustls`; Node through its "
-        "built-in `https` module. Each implementation uses its "
-        "conventional stack, so the columns compare deployments, not "
-        "just ciphers."
+        "built-in `https` module. Each uses its conventional stack, so the "
+        "columns compare deployments, not just ciphers."
     )
     w(
-        "- Loopback only, HTTP/1.1 only. No HTTP/2. Absolute numbers "
-        "depend heavily on the host; compare columns within one run, "
-        "not across machines."
+        "- Loopback only, HTTP/1.1 only, 14-byte body. No HTTP/2. Absolute "
+        "numbers depend heavily on the host; compare columns within one "
+        "run, not across machines."
+    )
+    w("")
+    w("### Planned rigor\n")
+    w(
+        "Known limits of this harness, in priority order — each is a "
+        "measurement this run does **not** yet make, called out so a "
+        "reader does not have to guess:"
+    )
+    w(
+        "1. **Open-loop latency.** Replace the closed-loop latency columns "
+        "with a fixed-rate generator (`oha -q`, or `wrk2`/`vegeta`) at "
+        "50/80/95 % of each server's measured throughput, reporting "
+        "p50/p99/p99.9/max. Closed loop cannot measure latency above "
+        "capacity (coordinated omission), which is why saturated cells are "
+        f"marked {DAGGER} rather than trusted."
+    )
+    w(
+        "2. **Core isolation.** Pin the server and the load generator to "
+        "disjoint core sets (`taskset`) and equalise pool sizes, so `oha`'s "
+        "threads do not compete with the server for CPU."
+    )
+    w(
+        "3. **CPU-time per request.** `getrusage(RUSAGE_SELF)` in each "
+        "server → `(utime+stime)/requests`: the one figure immune to "
+        "loopback, generator contention and pool size."
+    )
+    w(
+        "4. **Record-layer throughput.** Re-run TLS with 16 KB and 1 MB "
+        "bodies; a 14-byte body exercises the handshake and framing, not "
+        "the AEAD stream."
     )
 
     sys.stdout.write("\n".join(out) + "\n")

--- a/bench/run_http.sh
+++ b/bench/run_http.sh
@@ -38,6 +38,8 @@ SETTLE_MS="${SETTLE_MS:-500}"           # post-start spin-up before bench
 WARMUP_SEC="${WARMUP_SEC:-2}"            # short pre-bench warmup load
 KILL_WAIT="${KILL_WAIT:-1}"             # post-bench grace before SIGKILL
 ITERS="${ITERS:-3}"                      # measurement runs per cell, median wins
+HS_REQS="${HS_REQS:-20000}"             # connections for the setup-rate cell
+HS_CONC="${HS_CONC:-20}"                # its concurrency (kept low to bound TIME_WAIT)
 MD_OUT="${MD_OUT:-$BENCH/HTTP_RESULTS.md}"
 
 while (( $# > 0 )); do
@@ -131,18 +133,39 @@ stop_pid() {
     wait "$pid" 2>/dev/null || true
 }
 
-# Run oha against <scheme>://127.0.0.1:<port>/ for $DURATION seconds at the
-# given concurrency, then echo `<rps> <p50_ms> <p99_ms>`. `scheme` is http
-# or https; an https run adds `--insecure` so oha accepts the self-signed
-# bench cert. The JSON report is parsed via Python (already a build-dep of
-# bench/gen_data.py, so a sibling reliance).
+# Parse an oha `-j` report into `<rps> <p50_ms> <p99_ms> <mean_ms>`, or
+# `FAIL FAIL FAIL FAIL` on a failed run. The mean latency is what the
+# effective-concurrency check (Little's law, N ≈ rps × mean) uses to flag
+# a closed-loop cell whose latency reflects fewer connections than were
+# offered — see gen_http_results.py.
+_parse_oha() {
+    python3 - "$1" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        r = json.load(f)
+except Exception:
+    print("FAIL FAIL FAIL FAIL"); raise SystemExit
+summary = r.get("summary", {})
+if (summary.get("successRate", 0.0) or 0.0) < 0.99:
+    print("FAIL FAIL FAIL FAIL"); raise SystemExit
+rps = summary.get("requestsPerSec", 0.0) or 0.0
+mean = summary.get("average", 0.0) or 0.0
+lat = r.get("latencyPercentiles", {})
+def ms(v):
+    return (v * 1000.0) if isinstance(v, (int, float)) else 0.0
+print(f"{rps:.0f} {ms(lat.get('p50')):.2f} {ms(lat.get('p99')):.2f} {mean*1000.0:.4f}")
+PY
+}
+
+# Closed-loop throughput/latency cell. Runs oha against
+# <scheme>://127.0.0.1:<port>/ for $DURATION seconds at the given
+# concurrency, keep-alive on, and echoes `<rps> <p50> <p99> <mean_ms>`.
+# `scheme` https adds `--insecure` so oha accepts the self-signed cert.
 run_oha() {
-    local scheme="$1"
-    local port="$2"
-    local concurrency="$3"
+    local scheme="$1" port="$2" concurrency="$3"
     local report="$BENCH/_build/oha-$scheme-$port-c$concurrency.json"
-    local insecure=()
-    [[ "$scheme" == https ]] && insecure=(--insecure)
+    local insecure=(); [[ "$scheme" == https ]] && insecure=(--insecure)
     mkdir -p "$BENCH/_build"
 
     # Warmup: hit it briefly so JIT / OS-level caches settle (matters
@@ -151,33 +174,36 @@ run_oha() {
     "$OHA" --no-tui "${insecure[@]}" -n 1000 -c "$concurrency" \
         "$scheme://127.0.0.1:$port/" >/dev/null 2>&1 || true
 
-    # Actual measurement. `-j` writes the report JSON to stdout, so
-    # capture stdout into the file; stderr is muted (oha prints a
-    # progress line that would otherwise contaminate the JSON).
     "$OHA" --no-tui "${insecure[@]}" -j -z "${DURATION}s" -c "$concurrency" \
         "$scheme://127.0.0.1:$port/" > "$report" 2>/dev/null \
-        || { echo "FAIL FAIL FAIL"; return; }
+        || { echo "FAIL FAIL FAIL FAIL"; return; }
+    _parse_oha "$report"
+}
 
-    python3 - "$report" <<'PY'
-import json, sys
-try:
-    with open(sys.argv[1]) as f:
-        r = json.load(f)
-except Exception:
-    print("FAIL FAIL FAIL")
-    raise SystemExit
-summary = r.get("summary", {})
-if (summary.get("successRate", 0.0) or 0.0) < 0.99:
-    print("FAIL FAIL FAIL")
-    raise SystemExit
-rps = summary.get("requestsPerSec", 0.0) or 0.0
-lat = r.get("latencyPercentiles", {})
-def ms(v):
-    return (v * 1000.0) if isinstance(v, (int, float)) else 0.0
-p50 = ms(lat.get("p50"))
-p99 = ms(lat.get("p99"))
-print(f"{rps:.0f} {p50:.2f} {p99:.2f}")
-PY
+# Connection-setup-rate cell. `--disable-keepalive` opens a fresh
+# connection per request, so oha's rps here IS connections/second — and
+# for an https run, TLS handshakes/second: the pure-NURL P-256 ECDHE +
+# ECDSA-verify cost against rustls, the one number a short-lived-
+# connection edge deployment actually pays and that the keep-alive tables
+# amortise away. Bounded by a fixed request count (not duration) so the
+# fast plaintext case cannot flood the loopback with TIME_WAIT sockets.
+# Echoes `<conn_per_s>` or `FAIL`.
+run_oha_conn() {
+    local scheme="$1" port="$2"
+    local report="$BENCH/_build/ohaconn-$scheme-$port.json"
+    local insecure=(); [[ "$scheme" == https ]] && insecure=(--insecure)
+    "$OHA" --no-tui "${insecure[@]}" --disable-keepalive -j -n "$HS_REQS" -c "$HS_CONC" \
+        "$scheme://127.0.0.1:$port/" > "$report" 2>/dev/null \
+        || { echo "FAIL"; return; }
+    _parse_oha "$report" | awk '{print $1}'
+}
+
+median3() {   # median of the numbers on argv, printed with 2 decimals
+    python3 -c "
+import sys
+vals=sorted(float(x) for x in sys.argv[1:])
+m=vals[len(vals)//2] if len(vals)%2 else (vals[len(vals)//2-1]+vals[len(vals)//2])/2
+print(f'{m:.2f}')" "$@"
 }
 
 median3() {   # median of the numbers on argv, printed with 2 decimals
@@ -245,7 +271,9 @@ run_server() {
     "${cmd[@]}" > "$BENCH/_build/${name}-${scheme}.stdout.log" 2> "$BENCH/_build/${name}-${scheme}.stderr.log" &
     local pid=$!
     if ! wait_listen "$port"; then
-        for c in $CONCURRENCIES; do echo "$scheme $name $c FAIL FAIL FAIL"; done
+        local c
+        for c in $CONCURRENCIES; do echo "ROW $scheme $name $c FAIL FAIL FAIL FAIL"; done
+        echo "HS $scheme $name FAIL"
         stop_pid "$pid"
         return
     fi
@@ -255,19 +283,19 @@ run_server() {
 
     for c in $CONCURRENCIES; do
         # Run ITERS measurements at each cell, pick the median of rps.
-        local rps_list=() p50_list=() p99_list=() i
+        local rps_list=() p50_list=() p99_list=() mean_list=() i
         for i in $(seq 1 "$ITERS"); do
-            local r rps p50 p99
+            local r rps p50 p99 mean
             r=$(run_oha "$scheme" "$port" "$c")
-            read -r rps p50 p99 <<<"$r"
+            read -r rps p50 p99 mean <<<"$r"
             if [[ "$rps" == "FAIL" ]]; then
-                echo "$scheme $name $c FAIL FAIL FAIL"
+                echo "ROW $scheme $name $c FAIL FAIL FAIL FAIL"
                 rps_list=(); break
             fi
-            rps_list+=("$rps"); p50_list+=("$p50"); p99_list+=("$p99")
+            rps_list+=("$rps"); p50_list+=("$p50"); p99_list+=("$p99"); mean_list+=("$mean")
         done
         (( ${#rps_list[@]} == 0 )) && continue
-        local rps_med p50_med p99_med
+        local rps_med p50_med p99_med mean_med
         rps_med=$(python3 -c "
 import sys
 vals=sorted(float(x) for x in sys.argv[1:])
@@ -275,20 +303,32 @@ m=vals[len(vals)//2] if len(vals)%2 else (vals[len(vals)//2-1]+vals[len(vals)//2
 print(int(round(m)))" "${rps_list[@]}")
         p50_med=$(median3 "${p50_list[@]}")
         p99_med=$(median3 "${p99_list[@]}")
-        echo "$scheme $name $c $rps_med $p50_med $p99_med"
+        mean_med=$(median3 "${mean_list[@]}")
+        echo "ROW $scheme $name $c $rps_med $p50_med $p99_med $mean_med"
     done
+
+    # Connection-setup rate (one bounded run, this server still up): plain
+    # conn/s for http, TLS handshakes/s for https.
+    local conn
+    conn=$(run_oha_conn "$scheme" "$port")
+    echo "HS $scheme $name $conn"
 
     stop_pid "$pid"
 }
 
 # ── run every (server × scheme) combination ─────────────────────────
-# Plaintext ports 1808x; TLS ports 1844x. Collect flat result rows:
-#   "<scheme> <name> <concurrency> <rps> <p50> <p99>"
+# Plaintext ports 1808x; TLS ports 1844x. run_server emits its own
+# tokenised lines (`ROW scheme name c rps p50 p99 mean` and
+# `HS scheme name conn_per_s`), collected verbatim.
 echo "# duration=${DURATION}s iters=${ITERS} concurrencies=\"$CONCURRENCIES\"" >&2
 
 results=()
 collect() { while read -r line; do results+=("$line"); done; }
-na_rows() { local scheme="$1" name="$2" c; for c in $CONCURRENCIES; do results+=("$scheme $name $c n/a n/a n/a"); done; }
+na_rows() {
+    local scheme="$1" name="$2" c
+    for c in $CONCURRENCIES; do results+=("ROW $scheme $name $c n/a n/a n/a n/a"); done
+    results+=("HS $scheme $name n/a")
+}
 
 nurl_ready=0; prep_nurl && nurl_ready=1
 rust_ready=0; prep_rust && rust_ready=1
@@ -329,8 +369,11 @@ fi
     printf 'ENV\tduration\t%s\n' "$DURATION"
     printf 'ENV\titers\t%s\n' "$ITERS"
     printf 'ENV\tconcurrencies\t%s\n' "$CONCURRENCIES"
+    printf 'ENV\ths_reqs\t%s\n' "$HS_REQS"
+    printf 'ENV\ths_conc\t%s\n' "$HS_CONC"
+    # run_server / na_rows lines already carry their ROW / HS tag.
     for row in "${results[@]}"; do
-        printf 'ROW\t%s\n' "$row"
+        printf '%s\n' "$row"
     done
 } | python3 "$BENCH/gen_http_results.py" > "$MD_OUT"
 


### PR DESCRIPTION
…shakes

Expert review flagged the report's central credibility hole: the high-concurrency latency cells are a closed-loop coordinated-omission artifact. At C=200 NURL's 10 blocking workers saturate, the other ~190 connections queue inside `oha` and never reach the server, so a p50 of 0.06 ms describes the handful in flight — not the 200 offered. Left unlabelled, that is the first thing a knowledgeable reader tears apart.

Changes to make the report honest rather than impressive:

* Effective-concurrency check (Little's law). Every closed-loop cell now carries its mean latency; the renderer computes N ≈ req/s × mean and marks a cell `‡` when the in-flight count falls ≥2 connections below the offered concurrency (the ≥2 guard keeps C=1 send-gap granularity from false-flagging). req/s stays — it is the server's true saturation throughput — but the starved latency figures are annotated and, per cell, the effective count is named in a footnote.

* Honest bold. Latency winners are chosen only among non-starved cells, so a starved 0.06 ms never bolds or beats a real one (Rust's genuine 0.63 ms at C=200 wins that row now, not NURL's queue-hidden 0.06).

* Connection-setup rate (new section 3). A `--disable-keepalive` run per server: http conn/s, and for https the TLS handshakes/s — the pure-NURL P-256 ECDHE + ECDSA-verify path (no OpenSSL, no AES-NI-tier assembly) vs rustls and Node. That is the cost a short-lived-connection edge deployment actually pays, which the keep-alive tables amortise away, and it corrects the old note that claimed the TLS tables measured the handshake and then contradicted itself.

* "Planned rigor" section: the harness now names what it does NOT yet do — open-loop latency, core isolation, µs/req via getrusage, large-body record throughput — in priority order, so the limits are on the page instead of left for a reader to discover.

The committed report is a full run on the same i7-5930K. Only NURL's C=200 cells are flagged; Rust (epoll) and every C≤50 cell measure their offered load and are trusted as-is.


Claude-Session: https://claude.ai/code/session_014CSENqvFreiyzrt6EpXiEN

## Why

<!-- The problem, concretely. What breaks, what is missing, what is
     silently wrong. Name the observed behaviour — the wrong output, the
     measured number, the program that fails — not the intention.

     "Improve error messages" is not a Why. "__kw_default_or_die told the
     reader NURL has no default parameter values, which it has had since
     kwargs" is: a reviewer can check it. -->

## What

<!-- The change. Enough that a reviewer can read the diff in the order
     you wrote it and can tell which parts are load-bearing. Call out
     anything that alters observable behaviour, and say why the goldens
     moved if they moved. -->

## Proof

<!-- What you ran, and what it actually said. Paste the real summary
     line rather than a paraphrase of it:

       ./build.sh                     # bootstrap fixed point + corpus
       ./compiler/tests/run_tests.sh  # PASS n · FAIL n · MISSING n · ORPHAN n

     If something failed for reasons that predate your change — a missing
     optional dependency, no network, a flaky test — list those failures
     BY NAME and say so. A reviewer cannot tell an environment failure
     from a regression at a glance, and you can.

     Do not report a gate you did not run. "Not run locally, left to CI"
     is a perfectly good answer.

     Compiler changes: docs/dev/COMPILER_INTERNALS.md §5 gives the gates
     and the order to run them in. -->

## Known remaining

<!-- What this change deliberately does NOT fix, and why. Delete the
     heading only if the answer is genuinely nothing.

     Scoping work down is fine and often right. Scoping it down silently
     is what costs a reviewer their afternoon. -->

---

<!-- ─────────────────────────────────────────────────────────────────
     For automated contributors — read this before filling in the
     sections above. It renders as nothing, so leave it in or delete
     it as you prefer.

  * Do not claim a gate passed unless you ran it and read the output.
    A PR body asserting a green suite over a red one is the single
    failure mode that costs a maintainer the most time.

  * Report what you actually did, including the parts that did not
    work. "The third case is still wrong, here is why" is worth more
    than a clean-looking PR that quietly dropped it.

  * Stay inside the scope you were given. Unrelated fixes you noticed
    along the way belong in their own PR — CONTRIBUTING.md asks for
    small, focused PRs and means it.

  * Language-surface changes — new syntax, grammar, type-system rules —
    need an issue FIRST. The grammar is deliberately small and every
    addition has to earn its keep. Do not land one sideways inside a
    bug fix.

  * A rejected program is a test, and the prefix decides what is kept:
    `diag_*.nu` baselines the diagnostic TEXT, `should_fail_*.nu`
    records only that compilation failed. If the wording is the point —
    and for an error message it usually is — use `diag_*`.

  * Disclose that the change was machine-authored. Every PR in this
    repo already does.
     ───────────────────────────────────────────────────────────────── -->
