### PR TITLE
pkg: wasmbuilder 0.1.5, and pin swarm-mcp / nurl-mcp to it

### DIFF
--- a/packages/nurl-mcp/nurl.toml
+++ b/packages/nurl-mcp/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nurl-mcp"
-version = "0.10.0"
+version = "0.10.1"
 description = "Local MCP server for the NURL toolchain — dual-era MCP (the 2026-07-28 stateless revision with server/discover and per-request _meta, plus the legacy initialize handshake for older clients) — exposes the installed compiler over Model Context Protocol so an LLM agent on the host can build, run, type-check, format, and compile NURL to wasm32-wasi (fully local wasm builds via the wasmbuilder package), read the installed stdlib, browse its API surface — the stdlib's or a published registry package's (nurl_api, package=) — without function bodies, search stdlib + the package registry (by name, description, or exported symbol) with ranked word boundaries (nurl_grep), and compile a program that USES a registry package end to end, resolving its dependencies (nurl_build_project). Stdio by default; an optional token-authenticated HTTP transport (--http) gates code execution behind --allow-run. The editor-facing counterpart of nurl-lsp, for LLMs."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl/tree/main/packages/nurl-mcp"
@@ -11,4 +11,4 @@ repository = "https://github.com/nurl-lang/nurl/tree/main/packages/nurl-mcp"
 postinstall = "Register with Claude Code:  claude mcp add nurl -- ~/.nurl/bin/nurl-mcp"
 
 [dependencies]
-wasmbuilder = { path = "../wasmbuilder", version = "^0.1.0" }
+wasmbuilder = { path = "../wasmbuilder", version = "^0.1.5" }

--- a/packages/swarm-mcp/nurl.toml
+++ b/packages/swarm-mcp/nurl.toml
@@ -5,4 +5,4 @@ description = "An MCP-controlled distributed compute engine with real GPU comput
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-wasmbuilder = { path = "../wasmbuilder", version = "^0.1.0" }
+wasmbuilder = { path = "../wasmbuilder", version = "^0.1.5" }

--- a/packages/wasmbuilder/nurl.toml
+++ b/packages/wasmbuilder/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbuilder"
-version = "0.1.4"
+version = "0.1.5"
 description = "Compile NURL to wasm32-wasi locally — no wasi-sdk, no build service. Drives the installed toolchain end to end: nurlc emits LLVM IR, the production IR rewriter retargets it for wasm32-wasi (libc width shims, POSIX stubs, main rename), and the toolchain's bundled `zig cc` (wasi-libc + wasm-ld built in) links the .wasm. The NURL runtime is compiled from the installed stdlib's runtime.c on first use and cached by content hash, so it always matches your toolchain version. If no bundled zig is present (e.g. a Windows install), wasmbuilder downloads a pinned, sha256-verified zig into $NURL_HOME/zig once. Ships as both a CLI (`wasmbuilder file.nu -o file.wasm`, plus `--doctor` for setup diagnosis) and a library other packages embed to compile wasm in-process (swarm-mcp kernel builds, nurl-mcp). Modules link with --gc-sections by default (~25% smaller, and ~80% off a JIT runtime's module-load floor); --no-gc-sections is the escape hatch. Optional: `--asyncify` for browser canvas programs (needs binaryen's wasm-opt). Run the result with the pure-NURL `wasmtime` package or any wasm runtime."
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
The vararg-shim fix from #893 landed *inside* wasmbuilder 0.1.4, which is
already on the registry — so `nurlpkg install` still resolves the broken build
and every local wasm build whose IR declares `open`/`fcntl`/`printf` keeps
failing to link (all of swarm-mcp's CUDA tools, and nurl-mcp's wasm builds).

- `wasmbuilder` → **0.1.5** so the fix is publishable.
- Both consumers require **`^0.1.5`**: with `^0.1.0` a resolver could still
  pick 0.1.4.
- `nurl-mcp` → **0.10.1** so the tightened requirement actually reaches its
  users. `swarm-mcp` 0.24.0 is not yet published, so its manifest changes in
  place.

Publish order after merge: wasmbuilder 0.1.5 → nurl-mcp 0.10.1 → swarm-mcp
0.24.0, each verified by installing it, not just by a successful upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU