### PR TITLE
nurlpkg: reproducible tarballs, and publish reports why it failed

### DIFF
--- a/packages/nurlpkg-smoketest/README.md
+++ b/packages/nurlpkg-smoketest/README.md
@@ -1,0 +1,43 @@
+# nurlpkg-smoketest
+
+A deliberately trivial package whose only job is to exercise the registry
+end to end: **pack → publish → index → resolve → download → verify → extract
+→ build → run**.
+
+```sh
+cd packages/nurlpkg-smoketest
+nurlpkg publish --dry-run     # pack only: prints size + sha256
+nurlpkg publish               # upload to the registry
+
+nurlpkg install nurlpkg-smoketest
+./deps/nurlpkg-smoketest/nurlpkg-smoketest
+# nurlpkg-smoketest 0.1.0 — registry round-trip OK
+```
+
+## Why it exists
+
+When `nurlpkg publish` fails, the failure could be in the package, the
+packer, the transport, or the registry. This package removes the first
+possibility: it has no dependencies, no generated files, and a tarball of
+a few kilobytes. If publishing *this* fails, the problem is downstream of
+the package.
+
+It is also the canary for **packer determinism**. Two clean checkouts of
+the same commit must produce a byte-identical tarball and therefore the
+same sha256. If they don't, the packer is sweeping up untracked build
+output — which is exactly the bug that made `wasmbuilder` pack to 269 KB
+in one clone and 36 KB in another.
+
+```sh
+# From two separate clean clones of the same commit:
+nurlpkg publish --dry-run | grep sha256   # the two must match
+```
+
+Because the tarball is small, it also stays *under* one TCP segment on a
+path with a broken MTU — so a successful smoke test here alongside a
+failing real publish is a strong hint that the problem is packet size in
+the network path, not the registry.
+
+Versions of this package are disposable. Bump the patch number and
+republish whenever you need a fresh upload to test against; yanking old
+ones is fine.

--- a/packages/nurlpkg-smoketest/nurl.toml
+++ b/packages/nurlpkg-smoketest/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nurlpkg-smoketest"
-version = "0.1.0"
+version = "0.1.1"
 description = "Throwaway package used to exercise the registry end to end — pack, publish, resolve, install, run. Deliberately tiny and dependency-free so a publish is a couple of kilobytes and a failure points at the registry or the transport rather than at the package. Its tarball must be byte-identical from any clean checkout, which makes it the canary for packer non-determinism: if two clones produce different checksums, the packer is picking up untracked build output."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl-lang"

--- a/packages/nurlpkg-smoketest/nurl.toml
+++ b/packages/nurlpkg-smoketest/nurl.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nurlpkg-smoketest"
+version = "0.1.0"
+description = "Throwaway package used to exercise the registry end to end — pack, publish, resolve, install, run. Deliberately tiny and dependency-free so a publish is a couple of kilobytes and a failure points at the registry or the transport rather than at the package. Its tarball must be byte-identical from any clean checkout, which makes it the canary for packer non-determinism: if two clones produce different checksums, the packer is picking up untracked build output."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/nurl-lang/nurl-lang"
+
+[dependencies]

--- a/packages/nurlpkg-smoketest/src/main.nu
+++ b/packages/nurlpkg-smoketest/src/main.nu
@@ -1,0 +1,14 @@
+// nurlpkg-smoketest — prove a registry round-trip end to end.
+//
+// Publishing this package and then installing it back exercises every
+// stage nurlpkg has: pack → upload → index → resolve → download →
+// verify checksum → extract → build → run. It carries no dependencies
+// and no generated files, so anything that goes wrong is the registry
+// or the transport, never the package.
+
+$ `stdlib/core/io.nu`
+
+@ main → i {
+    ( nurl_print `nurlpkg-smoketest 0.1.0 — registry round-trip OK\n` )
+    ^ 0
+}

--- a/packages/nurlpkg-smoketest/src/main.nu
+++ b/packages/nurlpkg-smoketest/src/main.nu
@@ -9,6 +9,6 @@
 $ `stdlib/core/io.nu`
 
 @ main → i {
-    ( nurl_print `nurlpkg-smoketest 0.1.0 — registry round-trip OK\n` )
+    ( nurl_print `nurlpkg-smoketest 0.1.1 — registry round-trip OK\n` )
     ^ 0
 }

--- a/stdlib/ext/http_cli.nu
+++ b/stdlib/ext/http_cli.nu
@@ -154,6 +154,16 @@ $ `stdlib/ext/env.nu`
             : String mts ( string_from ( nurl_str_int ? > max_secs 0 max_secs ( httpc_default_max_time ) ) )
             ( vec_push [s] a ( string_data mts ) )
             ( vec_push [String] hold mts )
+            // Stall detection. --max-time alone is a poor deadline: a
+            // connection that dies mid-transfer sat here for the full 300 s
+            // before reporting anything, which reads as "nurlpkg hung". Abort
+            // once the transfer has moved < 1 byte/s for 30 s — a genuinely
+            // slow upload keeps its full --max-time, a dead one gives up in
+            // half a minute. curl reports this as exit 28, same as a timeout.
+            ( vec_push [s] a `--speed-limit` )
+            ( vec_push [s] a `1` )
+            ( vec_push [s] a `--speed-time` )
+            ( vec_push [s] a `30` )
             ( vec_push [s] a `-o` )
             ( vec_push [s] a ( string_data respfile ) )
             ( vec_push [s] a `-w` )

--- a/stdlib/ext/pkg_publish.nu
+++ b/stdlib/ext/pkg_publish.nu
@@ -18,8 +18,14 @@
 // immutability (a version may not be overwritten).
 //
 // Packaging excludes installed deps and VCS/build noise: `deps`, `.git`,
-// `nurl.lock`, `target`, `build`, and any dotfile/dotdir. Member paths use
-// the 100-byte USTAR `name` field (PackTooLong otherwise).
+// `nurl.lock`, `target`, `build`, any dotfile/dotdir, and compiler/linker
+// output by extension (`.ll`, `.o`, `.obj`, `.a`, `.so`, `.dylib`, `.dll`,
+// `.exe`). That last class is what keeps a tarball REPRODUCIBLE: without it
+// the bytes depend on whether anyone happened to build in that checkout.
+// Note the blacklist is still extension-based, so an extensionless compiled
+// binary left in the package root (what `nurlpkg build` emits) would still
+// be packed — `build`/`target` are the intended homes for it.
+// Member paths use the 100-byte USTAR `name` field (PackTooLong otherwise).
 //
 // API:
 //   ( pkg_pack root )                              → ! ( Vec u ) PackErr
@@ -42,7 +48,15 @@ $ `stdlib/ext/http_cli.nu`
 
 : | PublishErr {
     PubNoToken  // empty auth token
-    PubHttp  // transport failure
+    PubHttp  // transport failure, cause not classified
+    // The transport knows *why* it failed (curl's exit code, mapped to
+    // HttpcErr). Collapsing that into one PubHttp threw the diagnosis away
+    // and left `publish failed (PubHttp)` — indistinguishable between a
+    // dead registry, a broken proxy, and a stalled upload. Keep it.
+    PubTimeout  // no response within the deadline — request stalled mid-flight
+    PubConnect  // could not establish the connection
+    PubDns  // registry host does not resolve
+    PubTls  // TLS handshake / certificate failure
     PubAuth  // 401 — a real auth/token failure (expired, wrong, or missing)
     PubForbidden  // 403 — reserved name, typosquat lookalike, or the token's
     // package scope. NOT an auth problem, so it must not suggest re-login.
@@ -59,15 +73,56 @@ $ `stdlib/ext/http_cli.nu`
     }
 }
 
+// Carry the transport's own diagnosis through to the caller.
+@ __pub_transport_err HttpcErr e → PublishErr {
+    ^ ?? e {
+        HttpcTimeout → # PublishErr PubTimeout
+        HttpcConnect → # PublishErr PubConnect
+        HttpcDns → # PublishErr PubDns
+        HttpcTls → # PublishErr PubTls
+        _ → # PublishErr PubHttp
+    }
+}
+
 @ publish_err_name PublishErr e → s {
     ^ ?? e {
         PubNoToken → `PubNoToken`
         PubHttp → `PubHttp`
+        PubTimeout → `PubTimeout`
+        PubConnect → `PubConnect`
+        PubDns → `PubDns`
+        PubTls → `PubTls`
         PubAuth → `PubAuth`
         PubForbidden → `PubForbidden`
         PubConflict → `PubConflict`
         PubRejected → `PubRejected`
     }
+}
+
+// True iff `name` ends with `ext` (an extension, dot included).
+@ __pack_has_ext s name s ext → b {
+    : String ns ( string_from name )
+    : b r ( string_ends_with ns ext )
+    ( string_free ns )
+    ^ r
+}
+
+// Compiler and linker output. These are produced *inside* the package
+// directory by `nurlpkg build` / `nurlc` and are never package source, so
+// packing them makes the tarball depend on whether someone happened to
+// build in that checkout — two clean clones of one commit then publish
+// different bytes under different checksums. (Real case: a stray 1.4 MB
+// `wasmbuilder.ll` packed to 269 KB in one clone and 36 KB in another.)
+@ __pack_build_output s name → b {
+    ? ( __pack_has_ext name `.ll` ) { ^ T } {}
+    ? ( __pack_has_ext name `.o` ) { ^ T } {}
+    ? ( __pack_has_ext name `.obj` ) { ^ T } {}
+    ? ( __pack_has_ext name `.a` ) { ^ T } {}
+    ? ( __pack_has_ext name `.so` ) { ^ T } {}
+    ? ( __pack_has_ext name `.dylib` ) { ^ T } {}
+    ? ( __pack_has_ext name `.dll` ) { ^ T } {}
+    ? ( __pack_has_ext name `.exe` ) { ^ T } {}
+    ^ F
 }
 
 // Names never packaged (installed deps, VCS, build output, dotfiles).
@@ -76,6 +131,7 @@ $ `stdlib/ext/http_cli.nu`
     ? != 0 ( nurl_str_eq name `nurl.lock` ) { ^ T } {}
     ? != 0 ( nurl_str_eq name `target` ) { ^ T } {}
     ? != 0 ( nurl_str_eq name `build` ) { ^ T } {}
+    ? ( __pack_build_output name ) { ^ T } {}
     : i n ( nurl_str_len name )
     ? > n 0 { ? == ( nurl_str_get name 0 ) 46 { ^ T } {} } {}  // leading '.'
     ^ F
@@ -204,7 +260,7 @@ $ `stdlib/ext/http_cli.nu`
     ( string_free url )
     ( string_free hb )
     ?? rr {
-        F _ → ^ @ !i PublishErr { F # PublishErr PubHttp }
+        F he → ^ @ !i PublishErr { F ( __pub_transport_err he ) }
         T resp → {
             : i st ( httpc_status resp )
             ( httpc_resp_free resp )
@@ -247,7 +303,7 @@ $ `stdlib/ext/http_cli.nu`
     ( string_free url )
     ( string_free hb )
     ?? rr {
-        F _ → ^ @ !i PublishErr { F # PublishErr PubHttp }
+        F he → ^ @ !i PublishErr { F ( __pub_transport_err he ) }
         T resp → {
             : i st ( httpc_status resp )
             ( httpc_resp_free resp )
@@ -277,7 +333,7 @@ $ `stdlib/ext/http_cli.nu`
     ( string_free url )
     ( string_free hb )
     ?? rr {
-        F _ → ^ @ !i PublishErr { F # PublishErr PubHttp }
+        F he → ^ @ !i PublishErr { F ( __pub_transport_err he ) }
         T resp → {
             : i st ( httpc_status resp )
             ( httpc_resp_free resp )

--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -2965,6 +2965,31 @@ Usage: nurlpkg login   (paste the token from the registry; kept in ~/.nurl/crede
                                     PubConflict → {
                                         ( nurl_eprintln `nurlpkg: this version is already published (versions are immutable — bump the version)` )
                                     }
+                                    // The upload got a connection but no reply.
+                                    // Small requests (login, search, info) still
+                                    // work, so this reads as "the registry is up
+                                    // but publish is broken" — when the usual
+                                    // cause is a network path that drops
+                                    // full-size packets: a publish body is the
+                                    // only request big enough to need them.
+                                    PubTimeout → {
+                                        ( nurl_eprintln `nurlpkg: publish timed out — the upload stalled after connecting` )
+                                        ( nurl_eprintln `hint: if 'nurlpkg search' works but publish stalls, suspect the network path, not the registry — a broken path MTU drops full-size packets, and only the upload is big enough to send them. Test with:` )
+                                        ( nurl_eprintln `        ping -M do -s 1472 <registry-host>` )
+                                        ( nurl_eprintln `      and try a smaller MSS (sysctl net.ipv4.tcp_mtu_probing=1, or clamp MSS on the router) before assuming the registry is down` )
+                                    }
+                                    PubConnect → {
+                                        ( nurl_eprintln `nurlpkg: cannot connect to the registry` )
+                                        ( nurl_eprintln `hint: check the registry URL ($NURL_REGISTRY or [package].registry) and any proxy/firewall` )
+                                    }
+                                    PubDns → {
+                                        ( nurl_eprintln `nurlpkg: the registry host does not resolve` )
+                                        ( nurl_eprintln `hint: check the registry URL ($NURL_REGISTRY or [package].registry) and your DNS` )
+                                    }
+                                    PubTls → {
+                                        ( nurl_eprintln `nurlpkg: TLS handshake with the registry failed` )
+                                        ( nurl_eprintln `hint: check the system CA bundle and the clock; a TLS-intercepting proxy will also do this` )
+                                    }
                                     _ → {
                                         ( nurl_eprint `nurlpkg: publish failed (` )
                                         ( nurl_eprint ( publish_err_name ue ) )


### PR DESCRIPTION
`nurlpkg publish` failed with a bare `PubHttp` after a five-minute hang, and the same commit packed to **different bytes in different clones**. Three separate causes, none of them the registry.

## 1. The packer swept up build output

`__pack_ignored` was a fixed name blacklist (`deps`, `nurl.lock`, `target`, `build`, dotfiles) with no notion of compiler artifacts. A stray `wasmbuilder.ll` left by a local build got packed:

| clone | size | sha256 |
|---|---|---|
| with stray `.ll` | 269147 B | `78c67a68…` |
| clean | 35847 B | `d848505b…` |

Same commit. Tarballs — and therefore checksums — depended on whether anyone had built in that checkout. Now excluded by extension (`.ll .o .obj .a .so .dylib .dll .exe`); both clones produce `d848505b…` byte for byte.

Known remaining gap, documented in the source: an **extensionless** compiled binary left in the package root (what `nurlpkg build` emits) is still packed. `build/` and `target/` are the intended homes for it.

## 2. The transport's diagnosis was thrown away

`http_cli` already maps curl's exit code to `HttpcErr` (timeout / connect / DNS / TLS), but `pkg_publish` collapsed every variant into `PubHttp` — indistinguishable between a dead registry, a bad proxy, and a stalled upload. `PublishErr` gains `PubTimeout` / `PubConnect` / `PubDns` / `PubTls`, each with an actionable hint.

## 3. A stalled upload took the full 300 s to report

Added `curl --speed-limit 1 --speed-time 30`: a connection that dies mid-transfer gives up in ~30 s, while a genuinely slow upload keeps its full `--max-time`. Measured against the real fault: **300 s → 37 s**.

## What actually triggered it

A network path that drops full-size TCP segments toward this registry's Cloudflare prefix — effective MTU **1440**, not 1500. Not ours to fix, but worth recording because it is what made publish *look* like a registry outage:

| test | result |
|---|---|
| 4 KB POST, default MSS 1460 | 6/10 |
| 4 KB POST, MSS clamped 1400 | 10/10 |
| 40 KB POST, MSS 1460 | 1/5 |
| 40 KB POST, MSS 1400–1100 | 5/5 |

Controls that rule out the alternatives: `registry.npmjs.org` (**also Cloudflare**) took 4 KB 15/15; GET and small POST to `reg.` were 5/5, so no rate limit; 4 KB failed to `/` and to the `play.` host too, so no publish-specific WAF rule; same colo (HEL) both ways. The effect is per-prefix and intermittent.

Publish is the only nurlpkg request whose body needs multiple segments, which is why `search` / `info` / `login` kept working — exactly what the new `PubTimeout` hint now says out loud.

Setting `net.ipv4.tcp_mtu_probing=1` on the affected host (it was `0`, so Linux never recovered on its own) takes a 40 KB POST from 1/5 to **10/10** and `nurlpkg publish` completes in 5.3 s with no workaround.

## New: `packages/nurlpkg-smoketest`

A dependency-free ~1.8 KB package for exercising the registry end to end, and the canary for packer determinism — two clean clones must yield one checksum. It also removes the old trap of having to probe the publish endpoint with a real package.

## Verification

- `pkg_pack_basic` + `pkg_install_e2e` pass
- `wasmbuilder` packs byte-identically across both clones
- smoketest published, installed and run: `pack → publish → index → resolve → download → verify → extract → build → run`
- published: `wasmbuilder 0.1.5`, `nurl-mcp 0.10.1`, `swarm-mcp 0.24.0`, `nurlpkg-smoketest 0.1.1`

## Noted, not fixed here

`swarm-mcp/critic.md` is git-ignored yet still ships in the published tarball (confirmed against the registry's files endpoint). The extension filter does not catch it; it needs a rename, a move into `build/`, or an entry in the name blacklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)