### PR TITLE
borrowck: a generic function that frees its parameter is a sink again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A generic function that frees its parameter is a `sink` again.** The
+  borrow checker infers an auto-`sink` when a body consumes a parameter,
+  so the caller of a wrapper loses the binding and a second call is a
+  use-after-move. That inference is a by-product of *compiling the body*
+  — and a generic body is not compiled where it is written. It is stored
+  and instantiated later, under a mangled name, so the summary reached
+  neither the generic name nor any call site that preceded the deferred
+  instantiation. The result was a hole with no diagnostic at all:
+
+  ```
+  @ dispose [T] ( Vec T ) xs → v { ( vec_free [T] xs ) }
+  ( dispose [i] xs ) ( dispose [i] xs )     // compiled clean; double free
+  ```
+
+  The identical non-generic wrapper was rejected. `compute_generic_inout_sink`
+  now reads the stored template's body for the auto-`sink` case as well as
+  the declared markers, so the generic and ordinary forms are checked
+  alike — under the default checker for the unconditional shape, and under
+  `--strict-borrowck` when the first free is on one arm of a `?`. The
+  template scan reads the first argument of a call rather than every
+  argument position, so it can miss, never invent.
+  (`borrow_generic_sink_wrapper`, `borrow_strict_generic_maybe_double_free`)
+
 ## [0.41.0] — 2026-08-14
 
 The honest-failure release. Nothing here is a new capability; every entry

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -18635,6 +18635,86 @@
     r
 }
 
+// generic_body_auto_sink: the auto-sink inference (critic v0.9.0 §2)
+// for a GENERIC template, run over the stored template source.
+//
+// For an ordinary function the inference is a by-product of compiling
+// the body: gen_call stashes the move and bck_record_inferred_sink
+// notes the parameter index, which gen_fn_decl_concrete merges into
+// g_fn_sink[fname]. A generic body is not compiled where it is
+// written — it is stored and instantiated later, under a MANGLED
+// name — so that summary reached neither the generic name nor any
+// call site that came before the deferred instantiation. The result
+// was a hole with no diagnostic at all: a generic wrapper that frees
+// its parameter left the caller's binding Owned, so
+//
+//     @ dispose [T] ( Vec T ) xs → v { ( vec_free [T] xs ) }
+//     ( dispose [i] xs ) ( dispose [i] xs )
+//
+// compiled clean and double-freed at runtime, while the identical
+// non-generic wrapper was rejected. This closes it by reading the
+// template text — the only form of the body available this early.
+//
+// The scan is deliberately narrower than the codegen inference: it
+// fires only on `( callee [<targs>] <param> …` — a call whose FIRST
+// argument is a bare identifier naming a parameter, where the callee
+// is a typed destructor or is already known to sink its argument 0.
+// An identifier in that position IS the first argument (a prefix
+// operator would lex as an operator token there), so no arity
+// reasoning is needed; anything more involved is left to miss rather
+// than risk a false positive on a borrowed argument.
+//
+// `lexp` must be positioned at the return type / body; the walk runs
+// it to EOF. Returns `sa` with any inferred indices merged in.
+@ generic_body_auto_sink i lexp i syms s pnames s sa → s {
+    : ~ s out ( nurl_str_cat sa `` )
+    ? == 0 ( nurl_str_len pnames ) { ^ out } {}
+    ~ != ( nurl_lex_type lexp ) TT_EOF {
+        ? != ( nurl_lex_type lexp ) TT_LPAREN
+        { ( nurl_lex_advance lexp ) }
+        { ( nurl_lex_advance lexp )  // consume '('
+            ? ( is_ident_tok ( nurl_lex_type lexp ) )
+            { : s cal ( nurl_lex_val lexp )
+                ( nurl_lex_advance lexp )
+                // Skip an explicit type-argument list `[ … ]`. Nested
+                // brackets (a slice type argument) are counted, so the
+                // walk resumes at the first real argument.
+                ? == ( nurl_lex_type lexp ) TT_LBRACK
+                { : ~ i bd 0
+                    : ~ b bdone F
+                    ~ ! bdone {
+                        : i bt ( nurl_lex_type lexp )
+                        ? == bt TT_EOF { = bdone T }
+                        { ? == bt TT_LBRACK { = bd + bd 1 } {}
+                            ? == bt TT_RBRACK { = bd - bd 1 } {}
+                            ( nurl_lex_advance lexp )
+                            ? == bd 0 { = bdone T } {} }
+                    } }
+                {}
+                ? ( is_ident_tok ( nurl_lex_type lexp ) )
+                { : s a0 ( nurl_lex_val lexp )
+                    : i pidx ( str_word_index pnames a0 )
+                    // A destructor consumes argument 0; so does any
+                    // callee whose own summary already lists index 0 as
+                    // a sink — that is the wrapper-of-wrapper cascade,
+                    // the same one bck_record_inferred_sink handles at
+                    // the sink-argument site.
+                    ? & >= pidx 0
+                    | ( bck_is_destructor_call cal ( nurl_sym_get syms cal ) )
+                    ( str_contains_word ( nurl_sym_get g_fn_sink cal ) `0` )
+                    { : s w ( nurl_str_int pidx )
+                        ? ! ( str_contains_word out w )
+                        { = out ? == 0 ( nurl_str_len out )
+                            ( nurl_str_cat w `` )
+                            ( nurl_str_cat3 out ` ` w ) }
+                        {} }
+                    {} }
+                {} }
+            {} }
+    }
+    out
+}
+
 // compute_generic_inout_sink: derive a generic function's `inout` and
 // `sink` parameter index sets from its stored template and publish
 // them under the GENERIC name in g_fn_inout / g_fn_sink.
@@ -18650,7 +18730,7 @@
 // instantiation — the scan_generic_structs pre-pass owns that — so
 // walking the raw template here, tparam tokens (`A` / `T` …) and all,
 // is side-effect-free.
-@ compute_generic_inout_sink s fname → v {
+@ compute_generic_inout_sink i syms s fname → v {
     : s gsrc ( nurl_sym_get2 g_generic_syms fname `__gsrc` )
     ? != 0 ( nurl_str_len gsrc )
     {  // Substitute every type parameter with a concrete primitive (`i`)
@@ -18669,6 +18749,9 @@
         : i lexp ( nurl_lex_new probe `<gsig>` )
         : ~ s ia ``
         : ~ s sa ``
+        // Parameter NAMES, in order — the key the body scan below
+        // resolves a bare-identifier argument back to an index with.
+        : ~ s pnames ``
         : ~ i pc 0
         // Walk the parameter region only — stop at `→` (or, defensively,
         // at the body `{` if a malformed template lacks the arrow).
@@ -18692,10 +18775,17 @@
             : s __psig_ty ( parse_type lexp )
             ? != 0 ( nurl_str_len __psig_ty ) {} {}
             ? ( is_ident_tok ( nurl_lex_type lexp ) )
-            { ( nurl_lex_advance lexp ) }
+            { : s __psig_nm ( nurl_lex_val lexp )
+                = pnames ? == 0 ( nurl_str_len pnames )
+                ( nurl_str_cat __psig_nm `` )
+                ( nurl_str_cat3 pnames ` ` __psig_nm )
+                ( nurl_lex_advance lexp ) }
             {}
             = pc + pc 1
         }
+        // Auto-sink inference over the body — a generic body is never
+        // compiled here, so the codegen-time inference cannot see it.
+        = sa ( generic_body_auto_sink lexp syms pnames sa )
         ( nurl_sym_def g_fn_inout fname ia )
         ( nurl_sym_def g_fn_sink fname sa )
         ( nurl_lex_free lexp )
@@ -18782,7 +18872,7 @@
     // parameter index sets (keyed by the generic name) so a call site
     // can pass `inout` arguments by address and move-mark `sink` ones
     // without waiting for the deferred instantiation to be compiled.
-    ( compute_generic_inout_sink fname )
+    ( compute_generic_inout_sink syms fname )
 }
 
 // compute_generic_ret_ty: determine return type of a generic instantiation

--- a/compiler/tests/borrow_generic_sink_wrapper.nu
+++ b/compiler/tests/borrow_generic_sink_wrapper.nu
@@ -1,0 +1,47 @@
+// borrow_generic_sink_wrapper.nu — auto-sink inference through a
+// GENERIC wrapper.
+//
+// A function that frees its parameter is a sink: its caller loses the
+// binding. For an ordinary function the checker learns this while
+// compiling the body (bck_record_inferred_sink → g_fn_sink). A generic
+// body is not compiled where it is written — it is stored and
+// instantiated later under a mangled name — so the summary reached
+// neither the generic name nor any call site preceding the deferred
+// instantiation, and this exact program compiled clean and
+// double-freed at runtime while the identical non-generic wrapper was
+// rejected. compute_generic_inout_sink now reads the template body.
+//
+// One positive (the second `dispose` is a use-after-move) plus a
+// control: `borrow` takes the same parameter and does NOT free it, so
+// reading `ys` after the call must stay legal.
+
+$ `stdlib/core/vec.nu`
+
+// Sink: consumes its argument.
+@ dispose [T] ( Vec T ) xs → v {
+    ( vec_free [T] xs )
+}
+
+// Borrow: reads its argument and leaves it to the caller.
+@ peek [T] ( Vec T ) xs → i {
+    ^ ( vec_len [T] xs )
+}
+
+@ main → i {
+    // CONTROL — a generic that only READS its parameter is not a sink;
+    // `ys` is still owned after the call and freeing it here is right.
+    : ( Vec i ) ys ( vec_new [i] )
+    ( vec_push [i] ys 7 )
+    : i m ( peek [i] ys )
+    ? > m 100 { ( nurl_print `big\n` ) } {}
+    ( vec_free [i] ys )
+
+    // POSITIVE — the first `dispose` consumes `xs`; the second one is
+    // a double free of the same Vec.
+    : ( Vec i ) xs ( vec_new [i] )
+    ( vec_push [i] xs 123 )
+    ( dispose [i] xs )
+    ( dispose [i] xs )
+
+    ^ 0
+}

--- a/compiler/tests/borrow_strict_generic_maybe_double_free.nu
+++ b/compiler/tests/borrow_strict_generic_maybe_double_free.nu
@@ -1,0 +1,46 @@
+// borrow_strict_generic_maybe_double_free.nu — the conditional
+// double-free (docs/MEMORY.md §6.2/§6.5) reached through a GENERIC
+// wrapper instead of a second `vec_free` at the same site.
+//
+// `xs` is freed on one arm of a `?` and then handed to `dispose`,
+// which frees it again: a real double-free on the path where the first
+// free ran (confirmed under ASan — SEGV inside free from vec_free via
+// dispose). Both halves had to work for this to be caught:
+//
+//   * the generic template's auto-sink summary, so `( dispose [i] xs )`
+//     counts as a consume at all — without it the call was invisible
+//     to the checker and even the UNCONDITIONAL double free through a
+//     generic wrapper compiled clean (borrow_generic_sink_wrapper);
+//   * the strict-mode rule that consuming a MAYBE-moved binding is an
+//     error, which is what makes the conditional shape reportable.
+//
+// Strict-only, like borrow_strict_maybe_double_free: the default
+// checker deliberately keeps the no-false-positive property and lets
+// the conditional shape through.
+//
+// One positive + one rebind control.
+
+$ `stdlib/core/vec.nu`
+
+@ dispose [T] ( Vec T ) xs → v {
+    ( vec_free [T] xs )
+}
+
+@ main → i {
+    // POSITIVE — freed when the condition held, then consumed again by
+    // the generic wrapper.
+    : ( Vec i ) xs ( vec_new [i] )
+    ( vec_push [i] xs 123 )
+    : i n ( vec_len [i] xs )
+    ? > n 0 { ( vec_free [i] xs ) } {}
+    ( dispose [i] xs )
+
+    // CONTROL — conditionally freed but REBOUND before the wrapper
+    // call, so the binding is Owned again and must NOT be flagged.
+    : ~ ( Vec i ) ys ( vec_new [i] )
+    ( vec_push [i] ys 4 )
+    ? > n 0 { ( vec_free [i] ys ) = ys ( vec_new [i] ) } {}
+    ( dispose [i] ys )
+
+    ^ 0
+}

--- a/compiler/tests/outputs/borrow_generic_sink_wrapper.txt
+++ b/compiler/tests/outputs/borrow_generic_sink_wrapper.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/borrow_generic_sink_wrapper.nu:44: error: use of moved value 'xs' — a heap handle has exactly one owner, and this one was consumed at line 43 by dispose. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
+    ( dispose [i] xs )
+error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_strict_generic_maybe_double_free.txt
+++ b/compiler/tests/outputs/borrow_strict_generic_maybe_double_free.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/borrow_strict_generic_maybe_double_free.nu:36: error: 'xs' may already be freed here — it was conditionally consumed (one branch only) at line 35; this second free double-frees on that path (strict-borrowck; restructure so exactly one path frees it)
+    ( dispose [i] xs )
+error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -136,6 +136,30 @@ the caller's scope drop it. `compiler/tests/should_fail_sink_autodrop.nu`
 pins the diagnostic. Generic functions may take `sink` parameters
 (`@ consume [A] sink ( Box A ) b → v`).
 
+A parameter does not have to be *spelled* `sink` to be one. When a
+function's body consumes a parameter — passes it to a typed destructor,
+or on to another function's `sink` position — the checker records that
+index as an **auto-`sink`**, so the caller of the wrapper loses the
+binding exactly as if the marker had been written:
+
+```
+@ dispose ( Vec i ) xs → v { ( vec_free [i] xs ) }   // param 0 is a sink
+...
+( dispose xs ) ( dispose xs )     // use-after-move at the second call
+```
+
+For an ordinary function this falls out of compiling the body. A
+**generic** template is not compiled where it is written — it is stored
+and instantiated later under a mangled name — so its summary is instead
+derived from the stored template at declaration time
+(`compute_generic_inout_sink`), covering the auto-`sink` case by reading
+the body for a call whose first argument is a bare parameter. Without
+it, `@ dispose [T] ( Vec T ) xs → v { ( vec_free [T] xs ) }` was invisible
+to the checker and the double free above compiled clean
+(`compiler/tests/borrow_generic_sink_wrapper.nu`). The template scan is
+narrower than the codegen inference — it reads the first argument of a
+call, not every argument position — so it can miss, never invent.
+
 ## 2. The borrow checker
 
 The borrow checker is a **diagnostic-only** static analysis. It is
@@ -611,10 +635,14 @@ get right:
   be reused) but not their *freeing* — forget the `vec_free` and it leaks.
 - **Definition order, for the residual checks.** Summaries are built in
   codegen order. The *interprocedural escape* check (§2.7) no longer
-  depends on order — it is parked and replayed after the module compiles
-  — but the *return-escape* (§2.8) and *sink* checks still consult the
-  summary inline, so a forward / generic call to such a callee misses the
-  diagnostic (§3). Never miscompiled — only unchecked.
+  depends on order — it is parked and replayed after the module compiles.
+  The *sink* check no longer misses a **generic** callee either: a
+  generic function's `inout` / `sink` index sets, auto-`sink` included,
+  are derived from the stored template as it is declared, so a call site
+  sees them before any instantiation exists (§1). What still consults the
+  summary inline is the *return-escape* check (§2.8), and every check
+  still needs the callee *defined above its call site* — a forward call
+  misses the diagnostic (§3). Never miscompiled — only unchecked.
 
 ### 6.5 This is not Rust
 


### PR DESCRIPTION
## The hole

The borrow checker infers an **auto-`sink`** when a function's body consumes a parameter: the caller of the wrapper loses the binding, and a second call is a use-after-move. That inference is a by-product of *compiling the body* — and a generic body is not compiled where it is written. It is stored and instantiated later, under a mangled name, so the summary reached neither the generic name nor any call site that preceded the deferred instantiation.

The result was a hole with **no diagnostic at all**:

```nurl
@ dispose [T] ( Vec T ) xs → v { ( vec_free [T] xs ) }
...
( dispose [i] xs )
( dispose [i] xs )        // compiled clean
```

Under ASan that is a SEGV inside `free`:

```
#1 free
#2 vec_free__i64
#3 dispose__i64
#4 _nurl_main
```

The identical **non-generic** wrapper was already rejected. Adding `[T]` to a correct program silently removed its checking.

| shape | before | after |
|---|---|---|
| non-generic wrapper, two calls | error (default) | error (default) |
| **generic wrapper, two calls** | **compiled clean → double free** | error (default) |
| non-generic, freed on one `?` arm + call | error (strict) | error (strict) |
| **generic, freed on one `?` arm + call** | **nothing, either mode** | error (strict) |

The last row is the reproducer this started from — the conditional shape only *looked* like the documented §6.2/§6.5 strict-mode hole. It was actually invisible to both checkers, because the consuming call was never recorded as a consume in the first place.

## The fix

`compute_generic_inout_sink` read only the declared `inout` / `sink` markers from the stored template's signature. It now also scans the template **body** (`generic_body_auto_sink`): a call whose first argument is a bare parameter name, where the callee is a typed destructor or is already known to sink its argument 0, marks that parameter.

An identifier in that position *is* the first argument — a prefix operator would lex as an operator token there — so no arity reasoning is needed. The scan is deliberately narrower than the codegen inference (first argument only, not every position): **it can miss, never invent.**

The conditional shape stays behind `--strict-borrowck`, unchanged. The default checker's no-false-positive contract cannot reject mutually-exclusive frees (docs/MEMORY.md §6.2/§6.5). What changes is that the generic call is now *visible* to both checkers, so the strict rule finally has something to fire on.

## Diagnostic-only, verified as such

The borrow checker never lowers anything, and this stays true:

- **529** corpus files lower to **byte-identical IR**; **0** differ.
- Exactly **one** acceptance change in the whole tree — the new positive test (`0 → 1`).
- stdlib, examples and **320 package files**: zero acceptance changes.

## Tests

- `borrow_generic_sink_wrapper` — the unconditional double free through a generic wrapper (default checker), plus a control: a generic that only *reads* its parameter is not a sink and freeing it afterwards stays legal.
- `borrow_strict_generic_maybe_double_free` — the conditional shape through a generic wrapper (strict only), plus a rebind control.

## Verification

| gate | result |
|---|---|
| `run_tests.sh` | 797 PASS · 0 FAIL |
| `run_san_tests.sh` (ASan/UBSan/LSan) | 797 PASS · **0 SAN_FAIL** |
| `check_examples.sh` | 100 PASS · 0 FAIL |
| stdlib sweep | all modules compile |
| packages sweep | 223 files clean, 0 new borrow errors |
| nurlfmt `--check` | 1088 files canonical |
| diag-coverage / strict-arity | green |

## Docs

`docs/MEMORY.md` §1 was missing any description of the auto-`sink` summary even though §2.7 referred to it — added. §6.4's definition-order caveat claimed a *generic* call misses the sink check; that is no longer true, so it now names what actually remains (forward calls, and the §2.8 return-escape summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU
