### PR TITLE
release: 0.42.0 — the second-owner release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] — 2026-08-14
+
+The second-owner release. A heap handle in NURL has exactly one owner,
+and the borrow checker's job is to notice when a second name acquires
+it. It recognised exactly one way for that to happen — the copy
+`: T b a` — and five other ways were invisible: a `?` or `??` that
+selects between handles, an assignment that hands one over, a callee
+that hands an argument back, and a generic wrapper that consumes its
+parameter. Every one of them compiled clean and double-freed under
+AddressSanitizer.
+
+Neither bug was the analysis reaching a wrong answer. Both were the
+analysis never being asked: the ownership question was asked at one
+syntactic shape, and values arrive by more routes than that. What made
+the generic case worse than a gap is that it was a *regression under
+abstraction* — the non-generic wrapper was rejected correctly, so adding
+`[T]` to a working program silently removed its checking.
+
+**Upgrading:** code that this release rejects was double-freeing before.
+The default checker now errors on the unconditional shapes; the
+conditional ones need `--strict-borrowck`, because refusing them by
+default would also refuse the mutually-exclusive-frees pattern, which is
+correct code. If a rejection is a false positive, it is a bug worth
+reporting — the default checker is meant to have none, and the whole
+first-party tree (stdlib, examples, 320 package files) compiles with no
+acceptance change in either mode.
+
 ### Fixed
 
 - **A heap handle can reach a second name without being copied — the
@@ -75,6 +102,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   template scan reads the first argument of a call rather than every
   argument position, so it can miss, never invent.
   (`borrow_generic_sink_wrapper`, `borrow_strict_generic_maybe_double_free`)
+
+- **`http_server_pipelined` no longer races its own client.** The test
+  spawned the client with `&` from a shell that then exits — orphaning
+  it — and later ran `wait $(cat pid)` in a *different* shell, where that
+  pid is not a child. The wait failed instantly (hence the `2>/dev/null`
+  hiding it) and only a fixed `sleep 0.10` made the test pass, which is
+  not enough on a loaded CI runner. The client now writes a `.part` file
+  and renames it when done — `rename(2)` is atomic, so the collector sees
+  all or nothing — and the collector polls for it instead of assuming it
+  has arrived. Verified against the real failure mode: under 32-way CPU
+  saturation the old test dropped its client's output 1 run in 10, the
+  new one 0 in 10.
 
 ## [0.41.0] — 2026-08-14
 
@@ -12633,7 +12672,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.41.0...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.42.0...HEAD
+[0.42.0]: https://github.com/nurl-lang/nurl/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/nurl-lang/nurl/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/nurl-lang/nurl/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/nurl-lang/nurl/compare/v0.38.0...v0.39.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-14 · Current release: **0.41.0** · Language: **Grammar
+_Last reviewed: 2026-08-14 · Current release: **0.42.0** · Language: **Grammar
 v2.5** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
## What this is

Release prep for **v0.42.0**: CHANGELOG section, compare links, ROADMAP header. No code.

Contents: PRs #898 and #899 — the only two merged since v0.41.0.

## The theme

A heap handle in NURL has exactly one owner, and the borrow checker's job is to notice when a second name acquires it. It recognised exactly **one** way for that to happen — the copy `: T b a`. Five other ways were invisible:

```
: ( Vec i ) chosen ? flag a ( make )   // a `?` selects between handles
: ( Vec i ) chosen ?? f { 1 → a … }    // so does a `??`
= prev t                               // an assignment hands one over
: ( Vec i ) c ( pick a 1 )             // a callee hands an argument back
( dispose [i] xs ) ( dispose [i] xs )  // a generic wrapper consumes it
```

Every one compiled clean and double-freed under AddressSanitizer.

Neither bug was the analysis reaching a wrong answer — both were the analysis never being asked. The generic case was worse than a gap: the non-generic wrapper was rejected correctly, so adding `[T]` to a working program silently removed its checking. A regression under abstraction.

## Why MINOR and not patch

The default checker now rejects code it previously accepted. Same reasoning as v0.38.0 and v0.41.0 (a diagnostic that rejects previously-accepted code is not a patch).

Every such rejection was double-freeing before. The conditional shapes stay behind `--strict-borrowck`, because rejecting them by default would also reject the mutually-exclusive-frees pattern — correct code.

## Release checklist

- [x] `[Unreleased]` populated — **not empty this time** (the trap that hit v0.34.0, v0.38.0, v0.41.0); both PRs wrote their entries as they landed
- [x] Compare links: `[Unreleased]` → `v0.42.0...HEAD`, added `[0.42.0]: v0.41.0...v0.42.0`
- [x] Previous release's links verified — v0.41.0's were already correct, nothing to repair (the recurring 0.30.0-style omission did not happen)
- [x] ROADMAP header bumped 0.41.0 → 0.42.0
- [x] No other version pins — `nurlc --version` derives from `git describe` via `tools/version.sh`; `ROADMAP.md:300`'s "Since 0.41.0" is a historical reference and stays
- [x] No new public API or platform to document (both entries are checker behaviour, already in `docs/MEMORY.md` §2.2 / §1 from the source PRs)

## Verification carried in from #898/#899

| gate | result |
|---|---|
| test corpus | 801 PASS · 0 FAIL |
| ASan/UBSan corpus | 801 PASS · 0 SAN_FAIL |
| LSan-pinned subset | 31/31 |
| `leakgate.sh` (self-compile) | zero leaks, both emission modes |
| `leakcheck/run.sh` | zero leaks across 21 requests |
| memgate / dcegate | 19 MB · OK |
| examples | 100 PASS · 0 FAIL |
| nurlfmt `--check` | 1092 canonical |
| stdlib + examples + 320 package files | zero acceptance change, default **and** strict |

## After merge

Lightweight tag on the merge commit once CI is green on that SHA; `release.yml` builds linux-x86_64 / linux-arm64 / freebsd-x86_64 / windows-x86_64 and attaches archives + `.sha256` + `.minisig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU
