### PR TITLE
nurlc: type-check option/result payloads; say what an error did not check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **An option/result payload must be the type the option was declared
+  over.** Field 1 carries T's real type in both forms — `? i` lowers to
+  `{ i1, i64 }`, `! i s` to `{ i1, i64, i8* }` — but the payload
+  coercion believed a comment saying a result's slot "is always i64" and
+  folded *any* pointer into it with `ptrtoint`. That is the correct
+  representation for a slot which is an untyped box, and the wrong one
+  for a slot declared as a number. Two shapes got past nurlc:
+
+  ```
+  @ ?s { T 42 }     // nurlc exited 0; clang rejected the insertvalue
+  @ ?i { T `x` }    // compiled clean, linked, and RAN
+  ```
+
+  The second is the dangerous one. The fold made the address fit, so
+  `?? o { T v → ^ v }` returned the low byte of a `.rodata` address from
+  a `^ v` the writer expected to be a number — a silent miscompile with
+  no diagnostic anywhere. The first only ever failed at clang, in a
+  message about `{ i1, i8* }` and `i64` that named neither the option nor
+  the line to change.
+
+  The fold now asks what the slot *is* before reinterpreting an address
+  as arithmetic, and a backstop refuses to emit an `insertvalue` the
+  coercion chain could not legally bridge — so a payload mismatch is a
+  NURL diagnostic naming both types, not IR handed to the next tool.
+  (`diag_opt_payload_ptr_into_int`, `diag_opt_payload_type_mismatch`)
+
+### Changed
+
+- **The error summary says what was *not* checked.** Diagnostic recovery
+  is per top-level declaration: a reported error skips the rest of the
+  `@` it fired in, so two bad statements in one body produce one error
+  and `aborting due to 1 previous error`. Nothing there is false, but the
+  silence reads as "the rest was checked and passed" — and for anything
+  driving nurlc in a loop, an adversarial sweep or a model fixing its own
+  output, that inference is systematically wrong: nine of ten broken
+  constructs look accepted when nine were never examined. The summary now
+  adds one line saying the count is a lower bound.
+
+  Reporting every statement instead was implemented and reverted. With no
+  statement terminator to resync on and no poison bindings, the extra
+  errors were *derived*: a failed `: 5 n 0` made the next line's `^ n`
+  read as "undefined identifier 'n'", one fixture reported the same error
+  twice, and another desynchronised its braces into "unexpected '}' at
+  the top level". Naming an innocent line costs a reader more than
+  staying silent about it does; the real fix needs poison bindings and
+  derived-error suppression, and the reasoning is recorded at the site.
+
 ## [0.42.0] — 2026-08-14
 
 The second-owner release. A heap handle in NURL has exactly one owner,

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -16160,6 +16160,25 @@
                         // (which would heap-box it as if it were a by-value
                         // struct handle). The `?? T p` arm recovers it with a
                         // single inttoptr.
+                        //
+                        // …but ONLY into a slot that is a BOX. Field 1 carries
+                        // T's real type in both forms (`? i` is `{ i1, i64 }`,
+                        // `! i s` is `{ i1, i64, i8* }`), so a declared payload
+                        // of `i` is a NUMBER, not an untyped word — and folding
+                        // an address into it is not a representation choice, it
+                        // is a lie the `??` arm then reads as arithmetic.
+                        // `@ ?i { T `x` }` compiled clean and returned the low
+                        // byte of a .rodata address. The tag-carrying pointer
+                        // shapes (`?s`, `?*T`) match their slot and never reach
+                        // here; what reaches here with an integer slot is a
+                        // type error.
+                        ? > ( int_width payload_ty ) 0
+                        { ( die lex ( nurl_str_cat4
+                            ( nurl_str_cat3 `payload of this option/result literal is a pointer/string ('` ( llvm_to_nurl ( nurl_llty fty ) ) `')` )
+                            ( nurl_str_cat3 ` but the declared payload type is '` ( llvm_to_nurl payload_ty ) `', a number` )
+                            `. Storing the address in a numeric slot would make the '?? T v →' arm read a pointer as arithmetic — which is what this used to do, silently. `
+                            `Declare the payload as the type you are storing (write '@ ?s { T ... }' for a string), or store a number.` ) ) }
+                        {}
                         : s conv_reg ( nurl_cg_reg cg )
                         ( nurl_print `  ` ) ( nurl_print conv_reg )
                         ( nurl_print ` = ptrtoint ` ) ( nurl_print ( nurl_llty fty ) ) ( nurl_print ` ` )
@@ -16377,6 +16396,28 @@
                         }
                     }
                 }
+                // Nothing above could bridge the value to the declared
+                // payload slot. Every legal conversion has had its turn —
+                // exact match, pointer box, bool widen, struct handle,
+                // float width, integer width, enum-tag wrap — so what is
+                // left is a type the literal cannot hold, and emitting the
+                // insertvalue anyway produces IR only clang rejects, in a
+                // message about `{ i1, i8* }` and `i64` that names neither
+                // the option nor the line the writer has to change.
+                // `@ ?s { T 42 }` was exactly that: nurlc exited 0 and
+                // clang said "insertvalue operand and field disagree".
+                //
+                // This is the backstop, not the primary check: the branches
+                // above give the specific advice (float↔int, address↔number).
+                // Reaching here means a shape none of them named, so say
+                // plainly what was found and what was declared.
+                ? ! ( seq ( nurl_llty actual_fty ) ( nurl_llty payload_ty ) )
+                { ( die lex ( nurl_str_cat4
+                    ( nurl_str_cat3 `payload of this option/result literal has type '` ( llvm_to_nurl ( nurl_llty fty ) ) `'` )
+                    ( nurl_str_cat3 ` but the declared payload type is '` ( llvm_to_nurl payload_ty ) `'` )
+                    ` — NURL does not convert between them implicitly. `
+                    `Declare the option/result over the type you are storing, or convert the value first.` ) ) }
+                {}
             }
             {  // Check if this is actually an enum type
                 // Extract type name from agg_ty (e.g., "%Slice" from "%Slice")
@@ -26297,6 +26338,28 @@
     { ( nurl_eprintln ( nurl_str_cat ( nurl_str_cat3 `error: aborting due to `
         ( nurl_str_int g_err_count ) ` previous error` )
         ? > g_err_count 1 `s` `` ) )
+        // Say what was NOT checked. Recovery is per top-level
+        // declaration: a reported diagnostic skips the REST of the `@`
+        // it fired in, and the walk resumes at the next declaration. So
+        // the count above is a lower bound — two bad statements in one
+        // body yield one error, and a reader who assumes the untouched
+        // statements were checked and passed has been misled by silence
+        // rather than told anything false.
+        //
+        // That reading is the expensive one for anything driving nurlc
+        // in a loop — an adversarial sweep or a model fixing its own
+        // output concludes that nine of ten broken constructs are
+        // accepted, when nine were never examined. One line removes the
+        // inference. It is deliberately not a per-error note: the
+        // property is global to the run, and repeating it under each
+        // error would bury the errors.
+        //
+        // (Reporting every statement was tried and reverted: with no
+        // statement terminator to resync on and no poison bindings, the
+        // extra errors were derived — a failed `: 5 n 0` made the next
+        // line's `^ n` "undefined identifier 'n'". Naming an innocent
+        // line costs a reader more than staying silent about it does.)
+        ( nurl_eprintln `note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.` )
         ( nurl_exit 1 ) }
     {}
     // Stop recording new lint targets before flushing generic

--- a/compiler/tests/diag_opt_payload_ptr_into_int.nu
+++ b/compiler/tests/diag_opt_payload_ptr_into_int.nu
@@ -1,0 +1,21 @@
+// diag_opt_payload_ptr_into_int.nu — a string payload into an option
+// declared over a NUMBER. The dangerous half of the pair; see
+// diag_opt_payload_type_mismatch.nu for the other and for why the two
+// cannot share a file.
+//
+// This one did not fail at clang. It compiled clean, linked, and ran:
+// the address of the literal was folded into the i64 payload slot with
+// `ptrtoint`, and the match arm read it back as an integer. The program
+// below returned 4 — the low byte of a .rodata address — from a `^ v`
+// the writer expected to be a number they had put there.
+//
+// The fold exists for a reason: a payload slot that is an untyped box
+// stores pointers by design, and the `?? T p →` arm recovers them with
+// one inttoptr. What was missing is that `? i` does not have a box in
+// field 1, it has an `i64` that means a number — so the fold has to ask
+// what the slot is before reinterpreting an address as arithmetic.
+
+@ main → i {
+    : ?i o @ ?i { T `x` }
+    ?? o { T v → ^ v F → ^ 0 }
+}

--- a/compiler/tests/diag_opt_payload_type_mismatch.nu
+++ b/compiler/tests/diag_opt_payload_type_mismatch.nu
@@ -1,0 +1,28 @@
+// diag_opt_payload_type_mismatch.nu — the payload of an option /
+// result literal must be the type the option was declared over.
+//
+// Field 1 carries T's REAL type in both forms (`? i` lowers to
+// `{ i1, i64 }`, `! i s` to `{ i1, i64, i8* }`), so a payload of a
+// different type has nowhere to go. Two shapes reached past nurlc:
+//
+//   @ ?s { T 42 }    — nurlc exited 0 and CLANG said "insertvalue
+//                      operand and field disagree in type: 'i64'
+//                      instead of 'ptr'", naming neither the option
+//                      nor the line to change.
+//   @ ?i { T `x` }   — worse: compiled clean and RAN. The pointer was
+//                      folded into the numeric slot with ptrtoint, so
+//                      `?? o { T v → ^ v }` returned the low byte of a
+//                      .rodata address. A silent miscompile.
+//
+// The pointer fold is the right representation for a slot that is a
+// box, and the wrong one for a slot declared `i` — that distinction is
+// what was missing, not the fold itself.
+//
+// This file pins the first shape (int payload into a string option);
+// its twin diag_opt_payload_ptr_into_int.nu pins the second, because a
+// declaration-level abort means one file can only demonstrate one.
+
+@ main → i {
+    : ?s o @ ?s { T 42 }
+    ?? o { T v → ^ 1 F → ^ 0 }
+}

--- a/compiler/tests/outputs-windows/diag_did_you_mean.txt
+++ b/compiler/tests/outputs-windows/diag_did_you_mean.txt
@@ -13,3 +13,4 @@ compiler/tests/diag_did_you_mean.nu:27:20: error: call to unknown function 'zzqq
     ^ ( zzqqxxyy 1 )
                    ^
 error: aborting due to 4 previous errors
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs-windows/diag_multi_error.txt
+++ b/compiler/tests/outputs-windows/diag_multi_error.txt
@@ -6,3 +6,4 @@ compiler/tests/diag_multi_error.nu:14:22: error: call to unknown function 'no_su
                      ^
 compiler/tests/diag_multi_error.nu:18:5: error: value of type 'double' cannot initialise / assign a binding of type 'i64' — NURL has no implicit conversions; use a matching value or convert with '# T expr'
 error: aborting due to 3 previous errors
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/arity_strict_nary.txt
+++ b/compiler/tests/outputs/arity_strict_nary.txt
@@ -4,3 +4,4 @@ compiler/tests/arity_strict_nary.nu:20:5: error: '?' consumed bare then/else val
     ? & >= a 0 < a b >= c 0 < c d {
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/cast_to_binding.txt
+++ b/compiler/tests/outputs/cast_to_binding.txt
@@ -4,3 +4,4 @@ compiler/tests/cast_to_binding.nu:10:13: error: '# d' casts to the type 'd', but
         # d + d 1
             ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_agg_lit_too_many_values.txt
+++ b/compiler/tests/outputs/diag_agg_lit_too_many_values.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_agg_lit_too_many_values.nu:10:24: error: too many values in 
     ^ @ ?i { T + n 2 2 }
                        ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_arm_tail_dangling_lit.txt
+++ b/compiler/tests/outputs/diag_arm_tail_dangling_lit.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_arm_tail_dangling_lit.nu:18:27: error: a '?'/'??' arm ends i
         = fails + fails 1 1
                           ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ascii_arrow.txt
+++ b/compiler/tests/outputs/diag_ascii_arrow.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_ascii_arrow.nu:17:9: error: NURL's arrow is '→' (U+2192, a
 @ f i x - > i { ^ x }
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_assign_immutable_param.txt
+++ b/compiler/tests/outputs/diag_assign_immutable_param.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_assign_immutable_param.nu:10:9: error: cannot assign to immu
     = p + p 1
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_assign_immutable_scalar_param.txt
+++ b/compiler/tests/outputs/diag_assign_immutable_scalar_param.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_assign_immutable_scalar_param.nu:5:9: error: cannot assign t
     = p 5
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_assign_int_to_enum.txt
+++ b/compiler/tests/outputs/diag_assign_int_to_enum.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_assign_int_to_enum.nu:11:5: error: value of numeric type 'i' cannot initialise / assign a binding of enum type 'Color' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Assign a variant by name (': Color c Red'), or declare the binding numeric.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_assign_int_to_ptr.txt
+++ b/compiler/tests/outputs/diag_assign_int_to_ptr.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_assign_int_to_ptr.nu:9:5: error: value of type 'i64' cannot initialise / assign a binding of type 'i64*' — NURL has no implicit integer-to-pointer conversion; use a pointer-typed value, or cast an address intentionally with '# T expr' (the null pointer is '# T 0' for a pointer type T)
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_assign_missing_target.txt
+++ b/compiler/tests/outputs/diag_assign_missing_target.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_assign_missing_target.nu:7:7: error: expected the target of 
     = 5 n
       ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ax_cures_2.txt
+++ b/compiler/tests/outputs/diag_ax_cures_2.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_ax_cures_2.nu:16:16: error: bare function name 'f' used as a value. If you meant to CALL it, calls need parentheses: '( f args )', never 'f args'. If you really wanted the function AS a value, a bare name does not auto-coerce to a closure — wrap it: '\ args → R { ( f args ) }' — but that is the rarer reading.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ax_parser_cures.txt
+++ b/compiler/tests/outputs/diag_ax_parser_cures.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_ax_parser_cures.nu:25:36: error: expected the next match arm
         F e → ( nurl_print `a` ) ( nurl_print `b` )
                                    ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bad_type_token.txt
+++ b/compiler/tests/outputs/diag_bad_type_token.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_bad_type_token.nu:5:7: error: expected a type, found '5'. Ty
     : 5 n 0
       ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_agg_to_scalar.txt
+++ b/compiler/tests/outputs/diag_bind_agg_to_scalar.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_bind_agg_to_scalar.nu:8:5: error: value of type '{ i1, i64 }' cannot initialise / assign a binding of type 'i64' — NURL has no implicit conversions between differently-shaped aggregates; make the option/result/closure shapes match exactly, or destructure with '??' and bind the payload
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_bool_literal_name.txt
+++ b/compiler/tests/outputs/diag_bind_bool_literal_name.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_bind_bool_literal_name.nu:4:9: error: expected variable name
     : i T 5
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_closure_shape.txt
+++ b/compiler/tests/outputs/diag_bind_closure_shape.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_bind_closure_shape.nu:7:31: error: value of type '{ i64(i8*, i64)*, i8* }' cannot initialise / assign a binding of type '{ i64 (i8*)*, i8* }' — NURL has no implicit conversions between differently-shaped aggregates; make the option/result/closure shapes match exactly, or destructure with '??' and bind the payload
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_enum_cross.txt
+++ b/compiler/tests/outputs/diag_bind_enum_cross.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_bind_enum_cross.nu:10:5: error: value of type '%Fruit' cannot initialise / assign a binding of type '%Color' — NURL named types are NOMINAL: no value converts into or out of one implicitly (two enums stay distinct even when their tags overlap). Construct/pass the declared type; an enum takes a variant by name, and '# i x' reads an enum's tag intentionally.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_int_to_ptr.txt
+++ b/compiler/tests/outputs/diag_bind_int_to_ptr.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_bind_int_to_ptr.nu:8:5: error: value of type 'i64' cannot initialise / assign a binding of type 'i64*' — NURL has no implicit integer-to-pointer conversion; use a pointer-typed value, or cast an address intentionally with '# T expr' (the null pointer is '# T 0' for a pointer type T)
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_name_before_type.txt
+++ b/compiler/tests/outputs/diag_bind_name_before_type.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_bind_name_before_type.nu:11:9: error: 'i' is a type, and it 
     : n i 0
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_name_paren.txt
+++ b/compiler/tests/outputs/diag_bind_name_paren.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_bind_name_paren.nu:3:9: error: expected a binding name, foun
     : i ( x ) 0
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_option_shape.txt
+++ b/compiler/tests/outputs/diag_bind_option_shape.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_bind_option_shape.nu:7:5: error: value of type '{ i1, double }' cannot initialise / assign a binding of type '{ i1, i64 }' — NURL has no implicit conversions between differently-shaped aggregates; make the option/result/closure shapes match exactly, or destructure with '??' and bind the payload
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_struct_cross.txt
+++ b/compiler/tests/outputs/diag_bind_struct_cross.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_bind_struct_cross.nu:10:5: error: value of type '%B' cannot initialise / assign a binding of type '%A' — NURL named types are NOMINAL: no value converts into or out of one implicitly (two enums stay distinct even when their tags overlap). Construct/pass the declared type; an enum takes a variant by name, and '# i x' reads an enum's tag intentionally.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_unknown_ptr_type.txt
+++ b/compiler/tests/outputs/diag_bind_unknown_ptr_type.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_bind_unknown_ptr_type.nu:9:12: error: unknown type 'Foo' in 
     : *Foo p ( nurl_alloc 8 )
            ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_bind_void_call.txt
+++ b/compiler/tests/outputs/diag_bind_void_call.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_bind_void_call.nu:5:5: error: the expression produces no value to bind or assign, but a 'i64' was required. A call returning 'v', an assignment or a bare block yields nothing — bind the result of an expression that produces one.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_binop_agg_operand.txt
+++ b/compiler/tests/outputs/diag_binop_agg_operand.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_binop_agg_operand.nu:16:15: error: operator applied to an aggregate operand: left is 'i', right is '{ i1, i64 }' — an option/result/slice/struct value has no arithmetic or ordering; destructure with '??' (or read a field with '. value field') and combine the payload. If the aggregate is a whole '??'/'?' expression you meant as the NEXT statement, this operator is one operand short and swallowed it: every NURL operator has fixed arity and no closing bracket, so count the operands.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_binop_andand_int.txt
+++ b/compiler/tests/outputs/diag_binop_andand_int.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_binop_andand_int.nu:5:16: error: operator '&&' requires bool
     : b r && n T
                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_binop_bool_and_int.txt
+++ b/compiler/tests/outputs/diag_binop_bool_and_int.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_binop_bool_and_int.nu:10:5: error: operator '&' has a bool on the left, so the right operand must be bool too — NURL does not mix bool and integer operands. Every operator is BINARY: for n conditions write n-1 of them, '& & a b c'.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_binop_bool_or_int.txt
+++ b/compiler/tests/outputs/diag_binop_bool_or_int.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_binop_bool_or_int.nu:8:5: error: operator '|' has a bool on the left, so the right operand must be bool too — NURL does not mix bool and integer operands. Every operator is BINARY: for n conditions write n-1 of them, '| | a b c'.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_binop_oror_int.txt
+++ b/compiler/tests/outputs/diag_binop_oror_int.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_binop_oror_int.nu:6:16: error: operator '||' requires bool o
     : b r || n T
                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_binop_void_call_operand.txt
+++ b/compiler/tests/outputs/diag_binop_void_call_operand.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_binop_void_call_operand.nu:24:5: error: an operand of this binary operator is a call that returns 'v', so it has no value to combine. Usually the operator is one operand SHORT and has swallowed the following statement: every NURL operator has fixed arity and no closing bracket, so count the operands before this one. If the call was meant to run for its effect, put it on its own line.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_bool_to_float_param.txt
+++ b/compiler/tests/outputs/diag_call_bool_to_float_param.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_bool_to_float_param.nu:9:20: error: argument 1 to 'half
     : f z ( half y )
                    ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_closure_sig_mismatch.txt
+++ b/compiler/tests/outputs/diag_call_closure_sig_mismatch.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_closure_sig_mismatch.nu:11:17: error: argument 1 to 'ap
     ^ ( apply g 3 )
                 ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_enum_cross_enum.txt
+++ b/compiler/tests/outputs/diag_call_enum_cross_enum.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_enum_cross_enum.nu:24:16: error: argument 1 to 'show': 
     ^ ( show x )
                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_enum_to_int_param.txt
+++ b/compiler/tests/outputs/diag_call_enum_to_int_param.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_enum_to_int_param.nu:14:13: error: argument 1 to 'f' ha
     ^ ( f c )
             ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_ffi_float_to_int.txt
+++ b/compiler/tests/outputs/diag_call_ffi_float_to_int.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_ffi_float_to_int.nu:10:16: error: argument 1 to 'labs' 
     ^ ( labs y )
                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_float_to_int_param.txt
+++ b/compiler/tests/outputs/diag_call_float_to_int_param.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_float_to_int_param.nu:12:21: error: argument 1 to 'twic
     : i z ( twice y )
                     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_generic_float_arg.txt
+++ b/compiler/tests/outputs/diag_call_generic_float_arg.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_generic_float_arg.nu:12:23: error: argument 1 to 'gid' 
     : i z ( gid [i] y )
                       ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_inout_type_mismatch.txt
+++ b/compiler/tests/outputs/diag_call_inout_type_mismatch.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_inout_type_mismatch.nu:11:14: error: argument 1 to 'bum
     ( bump n )
              ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_int_to_bool_param.txt
+++ b/compiler/tests/outputs/diag_call_int_to_bool_param.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_int_to_bool_param.nu:12:16: error: argument 1 to 'pick'
     ^ ( pick y )
                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_int_to_enum_param.txt
+++ b/compiler/tests/outputs/diag_call_int_to_enum_param.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_int_to_enum_param.nu:12:16: error: argument 1 to 'show'
     ^ ( show 7 )
                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_int_to_float_param.txt
+++ b/compiler/tests/outputs/diag_call_int_to_float_param.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_int_to_float_param.nu:9:20: error: argument 1 to 'half'
     : f z ( half y )
                    ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_kwargs_float_arg.txt
+++ b/compiler/tests/outputs/diag_call_kwargs_float_arg.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_kwargs_float_arg.nu:10:21: error: argument 1 to 'scale'
     ^ ( scale x : y k : 2 )
                     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_missing_required_arg.txt
+++ b/compiler/tests/outputs/diag_call_missing_required_arg.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_call_missing_required_arg.nu:21:5: error: call to 'box' is missing required argument 'label', and that parameter declares no default. A parameter is optional only when its declaration gives it one ('@ f i width = 10 → v'); every other parameter must be supplied, and there is no overloading to fall back on. Pass it positionally in declaration order, name it ('name : value'), or give it a default at the declaration.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_named_after_positional.txt
+++ b/compiler/tests/outputs/diag_call_named_after_positional.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_named_after_positional.nu:10:23: error: a positional ar
     : i r ( add x : 1 2 )
                       ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_call_unknown_named_arg.txt
+++ b/compiler/tests/outputs/diag_call_unknown_named_arg.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_call_unknown_named_arg.nu:7:27: error: call to 'add' has no 
     : i r ( add x : 1 z : 2 )
                           ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cast_float_to_bool.txt
+++ b/compiler/tests/outputs/diag_cast_float_to_bool.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cast_float_to_bool.nu:6:5: error: '# b' of a float value is 
     ^ 0
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cast_float_to_string.txt
+++ b/compiler/tests/outputs/diag_cast_float_to_string.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cast_float_to_string.nu:6:5: error: a float value does not c
     ^ 0
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cast_nested_aggregate.txt
+++ b/compiler/tests/outputs/diag_cast_nested_aggregate.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cast_nested_aggregate.nu:9:5: error: cannot cast '%Outer' to
     ^ n
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cast_ptr_to_bool.txt
+++ b/compiler/tests/outputs/diag_cast_ptr_to_bool.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cast_ptr_to_bool.nu:9:5: error: cannot cast a pointer/string
     ^ 0
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cast_string_to_float.txt
+++ b/compiler/tests/outputs/diag_cast_string_to_float.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cast_string_to_float.nu:8:5: error: '# f' of a pointer/strin
     ^ 0
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cast_struct_literal.txt
+++ b/compiler/tests/outputs/diag_cast_struct_literal.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cast_struct_literal.nu:12:15: error: '#' is the cast operato
     : S s # S { 1 }
               ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cast_struct_to_float.txt
+++ b/compiler/tests/outputs/diag_cast_struct_to_float.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cast_struct_to_float.nu:9:5: error: '# f' of an aggregate va
     ^ 0
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_closure_arity_few.txt
+++ b/compiler/tests/outputs/diag_closure_arity_few.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_closure_arity_few.nu:8:5: error: call to 'f' passes 1 argument(s) but the declared closure/function type takes 2 — the emitted call would leave parameter registers unset (or drop values); the callee reads garbage. Match the declaration.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_closure_arity_many.txt
+++ b/compiler/tests/outputs/diag_closure_arity_many.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_closure_arity_many.nu:7:5: error: call to 'f' passes 2 argument(s) but the declared closure/function type takes 1 — the emitted call would leave parameter registers unset (or drop values); the callee reads garbage. Match the declaration.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_closure_body_unbraced.txt
+++ b/compiler/tests/outputs/diag_closure_body_unbraced.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_closure_body_unbraced.nu:4:31: error: expected '{' to open t
     : ( @ i i ) f \ i x → i ^ + x 1
                               ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_closure_body_unclosed.txt
+++ b/compiler/tests/outputs/diag_closure_body_unclosed.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_closure_body_unclosed.nu:7:25: error: end of file inside thi
     : ( @ v ) f \ → v { ( nurl_print `x` )
                         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_closure_param_no_name.txt
+++ b/compiler/tests/outputs/diag_closure_param_no_name.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_closure_param_no_name.nu:8:29: error: expected a parameter n
     : ( @ i i i ) f \ i x i → i { ^ x }
                             ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cmp_enum_cross.txt
+++ b/compiler/tests/outputs/diag_cmp_enum_cross.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cmp_enum_cross.nu:11:14: error: '==' between two DIFFERENT e
     ? == c x { ^ 1 } {}
              ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cmp_enum_int.txt
+++ b/compiler/tests/outputs/diag_cmp_enum_int.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cmp_enum_int.nu:9:14: error: '==' between enum 'Color' and a
     ? == c 7 { ^ 1 } {}
              ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cmp_enum_payload.txt
+++ b/compiler/tests/outputs/diag_cmp_enum_payload.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cmp_enum_payload.nu:13:14: error: '==' on enum 'E' whose var
     ? == a b { ^ 1 } {}
              ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cond_enum.txt
+++ b/compiler/tests/outputs/diag_cond_enum.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cond_enum.nu:8:9: error: this condition has enum type 'Color
     ? c { ^ 1 } {}
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cond_float.txt
+++ b/compiler/tests/outputs/diag_cond_float.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cond_float.nu:8:9: error: this condition has float type 'f' 
     ? y { ^ 1 } {}
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cond_string.txt
+++ b/compiler/tests/outputs/diag_cond_string.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cond_string.nu:8:9: error: this condition has pointer type '
     ? y { ^ 1 } {}
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cond_struct.txt
+++ b/compiler/tests/outputs/diag_cond_struct.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cond_struct.nu:6:9: error: this condition has type 'S' which
     ? s { ^ 1 } {}
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_cond_void_call.txt
+++ b/compiler/tests/outputs/diag_cond_void_call.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_cond_void_call.nu:5:19: error: this condition produces no va
     ? ( nothing ) { ^ 1 } {}
                   ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_const_expr_call.txt
+++ b/compiler/tests/outputs/diag_const_expr_call.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_const_expr_call.nu:4:11: error: const expression must be int
 : i K + 1 ( f )
           ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_const_type_name_swap.txt
+++ b/compiler/tests/outputs/diag_const_type_name_swap.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_const_type_name_swap.nu:8:12: error: unknown type 'PI_FIXED'
 : PI_FIXED i 314
            ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_dangling_operand_caret.txt
+++ b/compiler/tests/outputs/diag_dangling_operand_caret.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_dangling_operand_caret.nu:6:5: error: '^' (return) cannot ap
     ^ n
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_decl_inside_body.txt
+++ b/compiler/tests/outputs/diag_decl_inside_body.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_decl_inside_body.nu:13:17: error: this '@ name …' line rea
         @ inner b flag s name → v {
                 ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_did_you_mean.txt
+++ b/compiler/tests/outputs/diag_did_you_mean.txt
@@ -13,3 +13,4 @@ compiler/tests/diag_did_you_mean.nu:27:20: error: call to unknown function 'zzqq
     ^ ( zzqqxxyy 1 )
                    ^
 error: aborting due to 4 previous errors
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_dot_no_field_name.txt
+++ b/compiler/tests/outputs/diag_dot_no_field_name.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_dot_no_field_name.nu:9:1: error: expected a field name or an
 }
 ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_dup_enum_name.txt
+++ b/compiler/tests/outputs/diag_dup_enum_name.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_dup_enum_name.nu:6:5: error: duplicate type ': | A' — alre
 : | A { Z }
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_dup_variant_cross_enum.txt
+++ b/compiler/tests/outputs/diag_dup_variant_cross_enum.txt
@@ -5,3 +5,4 @@ compiler/tests/diag_dup_variant_cross_enum.nu:7:11: error: variant 'X' is alread
           ^
 compiler/tests/diag_dup_variant_cross_enum.nu:10:5: error: value of type 'i64' cannot initialise / assign a binding of type '%B' — NURL named types are NOMINAL: no value converts into or out of one implicitly (two enums stay distinct even when their tags overlap). Construct/pass the declared type; an enum takes a variant by name, and '# i x' reads an enum's tag intentionally.
 error: aborting due to 2 previous errors
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_dup_variant_same_enum.txt
+++ b/compiler/tests/outputs/diag_dup_variant_same_enum.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_dup_variant_same_enum.nu:6:5: error: duplicate variant 'X' â
     X
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration â€” later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_duplicate_type.txt
+++ b/compiler/tests/outputs/diag_duplicate_type.txt
@@ -7,3 +7,4 @@ compiler/tests/diag_duplicate_type.nu:16:7: error: duplicate global ': g_shared_
 : ~ i g_shared_count 5
       ^
 error: aborting due to 2 previous errors
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_dyn_call_arity.txt
+++ b/compiler/tests/outputs/diag_dyn_call_arity.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_dyn_call_arity.nu:14:5: error: call to 'speak' passes 0 argument(s) but the declared closure/function type takes 1 — the emitted call would leave parameter registers unset (or drop values); the callee reads garbage. Match the declaration.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_dyn_no_impl.txt
+++ b/compiler/tests/outputs/diag_dyn_no_impl.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_dyn_no_impl.nu:12:5: error: type '%Cat' does not implement t
     ^ 0
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_dyn_not_generic.txt
+++ b/compiler/tests/outputs/diag_dyn_not_generic.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_dyn_not_generic.nu:9:21: error: trait 'Speaker' is not objec
 @ announce %Speaker s → i { ^ ( speak s ) }
                     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_dyn_self_in_return.txt
+++ b/compiler/tests/outputs/diag_dyn_self_in_return.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_dyn_self_in_return.nu:10:14: error: method 'make' of trait '
 @ use %Maker m → i { ^ 0 }
              ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_dynsig_context.txt
+++ b/compiler/tests/outputs/diag_dynsig_context.txt
@@ -4,3 +4,4 @@ ERRORS
 Dog self - > s
          ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_elem_store_clash.txt
+++ b/compiler/tests/outputs/diag_elem_store_clash.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_elem_store_clash.nu:7:5: error: cannot store a value of type
     ^ 0
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_enum_arith.txt
+++ b/compiler/tests/outputs/diag_enum_arith.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_enum_arith.nu:9:5: error: operator applied to an enum operand: left is 'Color', right is 'i' — an enum is a closed set of named variants, not a number: arithmetic and ordering have no meaning on it. Compare with '==' against a variant, match with '??', or read the tag intentionally with '# i x'.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_enum_decl_no_name.txt
+++ b/compiler/tests/outputs/diag_enum_decl_no_name.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_enum_decl_no_name.nu:9:5: error: expected the enum's name af
 : | { A B }
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_enum_payload_bare_generic.txt
+++ b/compiler/tests/outputs/diag_enum_payload_bare_generic.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_enum_payload_bare_generic.nu:16:1: error: generic struct 'Pa
 }
 ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_enum_variant_outside_braces.txt
+++ b/compiler/tests/outputs/diag_enum_variant_outside_braces.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_enum_variant_outside_braces.nu:12:15: error: enum variant 'A
     : E e @ E A 1
               ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_falloff_no_value.txt
+++ b/compiler/tests/outputs/diag_falloff_no_value.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_falloff_no_value.nu:9:5: error: the function body ends without a return value (expected i) — the final statement yields nothing (a call returning 'v', an assignment, a loop or a bare block produce no value). End the body with an expression of the declared type, or return one explicitly with '^ <value>'. If the body LOOKS like it ends with a value, count the braces: an extra '}' closes the function early and strands the rest at the top level.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ffi_arity_few.txt
+++ b/compiler/tests/outputs/diag_ffi_arity_few.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_ffi_arity_few.nu:7:21: error: call to 'pow' has the wrong nu
     : f z ( pow 2.0 )
                     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ffi_arity_many.txt
+++ b/compiler/tests/outputs/diag_ffi_arity_many.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_ffi_arity_many.nu:8:25: error: call to 'sin' has the wrong n
     : f z ( sin 1.0 2.0 )
                         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_field_int_to_ptr.txt
+++ b/compiler/tests/outputs/diag_field_int_to_ptr.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_field_int_to_ptr.nu:11:19: error: field 0 of struct literal 
     : P a @ P { 0 }
                   ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_field_store_by_value_param.txt
+++ b/compiler/tests/outputs/diag_field_store_by_value_param.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_field_store_by_value_param.nu:15:11: error: cannot assign to
     = . s a 5
           ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_float_width_mix.txt
+++ b/compiler/tests/outputs/diag_float_width_mix.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_float_width_mix.nu:8:5: error: operator mixes float operands
     ^ 0
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_fn_no_name.txt
+++ b/compiler/tests/outputs/diag_fn_no_name.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_fn_no_name.nu:3:3: error: expected a function name after '@'
 @ 5 i x → i { ^ x }
   ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_generic_bare_type_use.txt
+++ b/compiler/tests/outputs/diag_generic_bare_type_use.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_generic_bare_type_use.nu:13:17: error: generic struct 'Pair'
 : Holder { Pair p }
                 ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_generic_fn_unclosed.txt
+++ b/compiler/tests/outputs/diag_generic_fn_unclosed.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_generic_fn_unclosed.nu:7:34: error: end of file inside this 
 @ pick [T] T a T b i which → T {
                                  ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_generic_targ_deficit.txt
+++ b/compiler/tests/outputs/diag_generic_targ_deficit.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_generic_targ_deficit.nu:10:26: error: generic function 'opt_
     : ?i m ( opt_map [i] o sq )
                          ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_generic_targ_surplus.txt
+++ b/compiler/tests/outputs/diag_generic_targ_surplus.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_generic_targ_surplus.nu:10:28: error: generic function 'vec_
     : ?i o ( vec_get [i i] v 0 )
                            ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_guard_on_wildcard.txt
+++ b/compiler/tests/outputs/diag_guard_on_wildcard.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_guard_on_wildcard.nu:6:26: error: a guard on the wildcard arm is not supported. '_' already means "everything not matched above", so '_ ? cond' would leave the remaining variants unhandled when the guard is false, and a match must be exhaustive. Guard a named variant instead ('A v ? > v 0 → body'), and let a plain '_ → body' absorb the rest.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_impl_call_arity.txt
+++ b/compiler/tests/outputs/diag_impl_call_arity.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_impl_call_arity.nu:15:5: error: call to method 'speak' for receiver type 'Dog' passes 1 argument(s) but the impl declares 2 (receiver included) — match the declaration.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_impl_method_no_name.txt
+++ b/compiler/tests/outputs/diag_impl_method_no_name.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_impl_method_no_name.nu:7:19: error: expected a method name a
 % Speaker Dog { @ 5 Dog self → i { ^ 1 } }
                   ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_init_int_to_enum.txt
+++ b/compiler/tests/outputs/diag_init_int_to_enum.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_init_int_to_enum.nu:8:5: error: value of numeric type 'i' cannot initialise / assign a binding of enum type 'Color' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Assign a variant by name (': Color c Red'), or declare the binding numeric.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_inout_arg_expression.txt
+++ b/compiler/tests/outputs/diag_inout_arg_expression.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_inout_arg_expression.nu:8:12: error: inout argument to 'bump
     ( bump + n 1 )
            ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_inout_arg_not_in_scope.txt
+++ b/compiler/tests/outputs/diag_inout_arg_not_in_scope.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_inout_arg_not_in_scope.nu:5:12: error: inout argument 'zzz' 
     ( bump zzz )
            ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_inout_field_no_field.txt
+++ b/compiler/tests/outputs/diag_inout_field_no_field.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_inout_field_no_field.nu:9:16: error: inout field argument: e
     ( bump . s )
                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_inout_field_not_binding.txt
+++ b/compiler/tests/outputs/diag_inout_field_not_binding.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_inout_field_not_binding.nu:8:17: error: inout field argument
     ( bump . zz a )
                 ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_inout_field_on_scalar.txt
+++ b/compiler/tests/outputs/diag_inout_field_on_scalar.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_inout_field_on_scalar.nu:7:16: error: inout field argument: 
     ( bump . n a )
                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_inout_field_unknown.txt
+++ b/compiler/tests/outputs/diag_inout_field_unknown.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_inout_field_unknown.nu:10:19: error: inout field argument: s
     ( bump . s zz )
                   ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_int_lit_width_range.txt
+++ b/compiler/tests/outputs/diag_int_lit_width_range.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_int_lit_width_range.nu:13:5: error: integer literal 9999 doe
     ^ 0
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_match_arm_no_arrow.txt
+++ b/compiler/tests/outputs/diag_match_arm_no_arrow.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_match_arm_no_arrow.nu:7:22: error: expected '→' or a paylo
     : i r ?? e { A v { ^ v } B → 0 }
                      ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_match_arm_recover.txt
+++ b/compiler/tests/outputs/diag_match_arm_recover.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_match_arm_recover_mod.nu:23:17: error: expected variable nam
             : i pub 5
                 ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_match_guard_no_arrow.txt
+++ b/compiler/tests/outputs/diag_match_guard_no_arrow.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_match_guard_no_arrow.nu:13:30: error: expected '→' after t
     : i r ?? e { A v ? > v 0 { ^ v } B → 0 }
                              ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_match_mixed_arms.txt
+++ b/compiler/tests/outputs/diag_match_mixed_arms.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_match_mixed_arms.nu:24:5: error: '# i64' has no value to con
     : i lo2 ?? ( vec_get [f] d 0 ) { T x → x F → 0 }
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_method_no_impl.txt
+++ b/compiler/tests/outputs/diag_method_no_impl.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_method_no_impl.nu:17:5: error: method 'speak' has no impl for receiver type 'Cat' — the name is implemented for other type(s) only. Add a '% Trait <Type> { … }' impl for this type, or pass a value of an implementing type as the first argument.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_multi_error.txt
+++ b/compiler/tests/outputs/diag_multi_error.txt
@@ -6,3 +6,4 @@ compiler/tests/diag_multi_error.nu:14:22: error: call to unknown function 'no_su
                      ^
 compiler/tests/diag_multi_error.nu:18:5: error: value of type 'double' cannot initialise / assign a binding of type 'i64' — NURL has no implicit conversions; use a matching value or convert with '# T expr'
 error: aborting due to 3 previous errors
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_objsafe_no_self_receiver.txt
+++ b/compiler/tests/outputs/diag_objsafe_no_self_receiver.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_objsafe_no_self_receiver.nu:9:14: error: method 'make' of tr
 @ use %Maker m → i { ^ 0 }
              ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_objsafe_sink_receiver.txt
+++ b/compiler/tests/outputs/diag_objsafe_sink_receiver.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_objsafe_sink_receiver.nu:9:14: error: method 'eat' of trait 
 @ use %Eater e → i { ^ 0 }
              ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_opt_payload_ptr_into_int.txt
+++ b/compiler/tests/outputs/diag_opt_payload_ptr_into_int.txt
@@ -1,0 +1,7 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_opt_payload_ptr_into_int.nu:19:25: error: payload of this option/result literal is a pointer/string ('s') but the declared payload type is 'i', a number. Storing the address in a numeric slot would make the '?? T v →' arm read a pointer as arithmetic — which is what this used to do, silently. Declare the payload as the type you are storing (write '@ ?s { T ... }' for a string), or store a number.
+    : ?i o @ ?i { T `x` }
+                        ^
+error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_opt_payload_type_mismatch.txt
+++ b/compiler/tests/outputs/diag_opt_payload_type_mismatch.txt
@@ -1,0 +1,7 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_opt_payload_type_mismatch.nu:26:24: error: payload of this option/result literal has type 'i' but the declared payload type is 's' — NURL does not convert between them implicitly. Declare the option/result over the type you are storing, or convert the value first.
+    : ?s o @ ?s { T 42 }
+                       ^
+error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_optlit_float_to_int_payload.txt
+++ b/compiler/tests/outputs/diag_optlit_float_to_int_payload.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_optlit_float_to_int_payload.nu:6:25: error: payload of this 
     : ?i o @ ?i { T 1.5 }
                         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_optlit_int_to_float_payload.txt
+++ b/compiler/tests/outputs/diag_optlit_int_to_float_payload.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_optlit_int_to_float_payload.nu:7:23: error: payload of this 
     : ?f o @ ?f { T 3 }
                       ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_orpattern_bool_arm.txt
+++ b/compiler/tests/outputs/diag_orpattern_bool_arm.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_orpattern_bool_arm.nu:13:28: error: an or-pattern lists name
     : i r ?? o { T | A → 1 _ → 0 }
                            ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_orpattern_guard.txt
+++ b/compiler/tests/outputs/diag_orpattern_guard.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_orpattern_guard.nu:7:32: error: an or-pattern cannot carry a
     : i r ?? d { N | S ? T → 1 E → 2 W → 3 }
                                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_orpattern_option_tf.txt
+++ b/compiler/tests/outputs/diag_orpattern_option_tf.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_orpattern_option_tf.nu:8:22: error: expected a variant name 
     : i r ?? o { T | F → 1 }
                      ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_orpattern_repeat.txt
+++ b/compiler/tests/outputs/diag_orpattern_repeat.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_orpattern_repeat.nu:11:32: error: this or-pattern repeats va
     : i r ?? d { N | S | N → 1 E → 2 W → 3 }
                                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_param_name_entry.txt
+++ b/compiler/tests/outputs/diag_param_name_entry.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_param_name_entry.nu:4:7: error: parameter name 'entry' colli
 @ f i entry → i { ^ entry }
       ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_param_name_inout.txt
+++ b/compiler/tests/outputs/diag_param_name_inout.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_param_name_inout.nu:4:7: error: 'inout' is a parameter CONVE
 @ f i inout → i { ^ 0 }
       ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_param_no_name.txt
+++ b/compiler/tests/outputs/diag_param_no_name.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_param_no_name.nu:4:7: error: expected a parameter name after
 @ f i → i { ^ 0 }
       ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_paren_type_bad.txt
+++ b/compiler/tests/outputs/diag_paren_type_bad.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_paren_type_bad.nu:6:9: error: a parenthesised type must open
     : ( 5 ) x 0
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_pct_not_trait.txt
+++ b/compiler/tests/outputs/diag_pct_not_trait.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_pct_not_trait.nu:3:6: error: '%' in a type position must be 
 @ f %5 x → i { ^ 0 }
      ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_priv_ambiguous.txt
+++ b/compiler/tests/outputs/diag_priv_ambiguous.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_priv_ambiguous.nu:8:9: error: private function '__amb' is de
     ^ ( __amb )
         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ret_closure_shape.txt
+++ b/compiler/tests/outputs/diag_ret_closure_shape.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_ret_closure_shape.nu:8:5: error: return value type '{ double (i8*, double)*, i8* }' does not match the declared return type '{ i64 (i8*, i64)*, i8* }' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ret_f32_width.txt
+++ b/compiler/tests/outputs/diag_ret_f32_width.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_ret_f32_width.nu:6:21: error: return value type 'f32' does not match the declared return type 'f' — a float width widens into a BINDING (': f x f32val' is fine), but a return type is a contract and must match exactly. Convert with '# f expr' (widen, lossless) or '# f32 expr' (narrow).
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ret_int_to_enum.txt
+++ b/compiler/tests/outputs/diag_ret_int_to_enum.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_ret_int_to_enum.nu:8:5: error: return value type 'i' does not match the declared return type: enum 'Color' — an enum is a closed set of named variants, and no number converts into one implicitly (the value could name no variant at all). Return a variant by name ('^ Red'), or declare a numeric return type.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ret_int_to_ptr.txt
+++ b/compiler/tests/outputs/diag_ret_int_to_ptr.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_ret_int_to_ptr.nu:9:5: error: return value type 'i' does not match the declared return type 's' — NURL has no implicit integer-to-pointer conversion; return a value of the declared type, or cast an address intentionally with '# T expr' (the null pointer is '# T 0' for a pointer type T)
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ret_option_shape.txt
+++ b/compiler/tests/outputs/diag_ret_option_shape.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_ret_option_shape.nu:7:5: error: return value type '{ i1, double }' does not match the declared return type '{ i1, i64 }' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_ret_void_call.txt
+++ b/compiler/tests/outputs/diag_ret_void_call.txt
@@ -2,3 +2,4 @@ COMPILE FAIL
 ERRORS
 compiler/tests/diag_ret_void_call.nu:8:16: error: return expression has no value (expected i) — the commonest cause is returning a call whose declared return type is 'v', which yields nothing to return; a conditional whose branches disagree on type does the same. Check what the '^' operand produces.
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_select_arm_body_unbraced.txt
+++ b/compiler/tests/outputs/diag_select_arm_body_unbraced.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_select_arm_body_unbraced.nu:7:22: error: expected '{' to ope
     ?? { [i] c → v ^ 0 }
                      ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_select_arm_missing_type.txt
+++ b/compiler/tests/outputs/diag_select_arm_missing_type.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_select_arm_missing_type.nu:15:10: error: expected '[' or '_'
     ?? { ints → oi { ^ 0 } }
          ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_select_arm_no_arrow.txt
+++ b/compiler/tests/outputs/diag_select_arm_no_arrow.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_select_arm_no_arrow.nu:16:1: error: expected '→' after the
 
 ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_select_arm_no_name.txt
+++ b/compiler/tests/outputs/diag_select_arm_no_name.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_select_arm_no_name.nu:8:20: error: expected the received val
     ?? { [i] c → {} }
                    ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_select_arm_unterminated.txt
+++ b/compiler/tests/outputs/diag_select_arm_unterminated.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_select_arm_unterminated.nu:11:1: error: unterminated '[' in 
 
 ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_select_default_body_unbraced.txt
+++ b/compiler/tests/outputs/diag_select_default_body_unbraced.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_select_default_body_unbraced.nu:7:31: error: expected '{' to
     ?? { [i] c → v {} _ → ^ 0 }
                               ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_select_no_channel_arms.txt
+++ b/compiler/tests/outputs/diag_select_no_channel_arms.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_select_no_channel_arms.nu:7:5: error: select has no channel 
     ^ 0
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_select_two_defaults.txt
+++ b/compiler/tests/outputs/diag_select_two_defaults.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_select_two_defaults.nu:6:34: error: select has more than one
     ?? { [i] c → v {} _ → {} _ → {} }
                                  ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_slice_elem_int_for_float.txt
+++ b/compiler/tests/outputs/diag_slice_elem_int_for_float.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_slice_elem_int_for_float.nu:4:20: error: element 1 of this s
     : [f xs [f | 1 2 3]
                    ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_slice_elem_wrong_struct.txt
+++ b/compiler/tests/outputs/diag_slice_elem_wrong_struct.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_slice_elem_wrong_struct.nu:9:21: error: element 2 of this sl
     : [A xs [A | a b]
                     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_slice_lit_float_elem.txt
+++ b/compiler/tests/outputs/diag_slice_lit_float_elem.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_slice_lit_float_elem.nu:7:24: error: element 2 of this slice
     : [i xs [i | 1 2.5 3]
                        ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_slice_lit_int_enum_elem.txt
+++ b/compiler/tests/outputs/diag_slice_lit_int_enum_elem.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_slice_lit_int_enum_elem.nu:9:32: error: element 2 of this sl
     : [Color cs [Color | Red 7 Blue]
                                ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_str_len_on_string.txt
+++ b/compiler/tests/outputs/diag_str_len_on_string.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_str_len_on_string.nu:8:28: error: nurl_str_len expects 's' (
     : i n ( nurl_str_len s )
                            ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_stray_rbrace_top_level.txt
+++ b/compiler/tests/outputs/diag_stray_rbrace_top_level.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_stray_rbrace_top_level.nu:13:1: error: unexpected '}' (the e
 }
 ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_string_len_on_cstr.txt
+++ b/compiler/tests/outputs/diag_string_len_on_cstr.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_string_len_on_cstr.nu:6:29: error: string_len expects %Strin
     : i n ( string_len `hi` )
                             ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_struct_lit_int_enum_field.txt
+++ b/compiler/tests/outputs/diag_struct_lit_int_enum_field.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_struct_lit_int_enum_field.nu:9:19: error: field 0 of struct 
     : S s @ S { 7 }
                   ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_struct_lit_named_fields.txt
+++ b/compiler/tests/outputs/diag_struct_lit_named_fields.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_struct_lit_named_fields.nu:12:25: error: struct literal fiel
     : Point p @ Point { x : 3 y : 4 }
                         ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_struct_lit_ptr_field.txt
+++ b/compiler/tests/outputs/diag_struct_lit_ptr_field.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_struct_lit_ptr_field.nu:10:22: error: field 0 of struct lite
     : P p @ P { `hi` 2 }
                      ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/diag_volatile_load_untyped.txt
+++ b/compiler/tests/outputs/diag_volatile_load_untyped.txt
@@ -4,3 +4,4 @@ compiler/tests/diag_volatile_load_untyped.nu:7:5: error: volatile_load expects a
     ^ v
     ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/outputs/struct_lit_int_field_clash.txt
+++ b/compiler/tests/outputs/struct_lit_int_field_clash.txt
@@ -4,3 +4,4 @@ compiler/tests/struct_lit_int_field_clash.nu:15:31: error: field 2 of struct lit
     : Outer o @ Outer { g g 0 }
                               ^
 error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.


### PR DESCRIPTION
Three reports: two fixes and one deliberate non-fix.

## 1 + 2 — the payload of an option/result was never type-checked

```nurl
@ main → i {
    : ?s o @ ?s { T 42 }        // escaped nurlc — clang rejected the IR
    ?? o { T v → ^ 1  F → ^ 0 }
}

@ main → i {
    : ?i o @ ?i { T `x` }       // compiled clean, linked, and RAN
    ?? o { T v → ^ v  F → ^ 0 }
}
```

The second is the dangerous one. It returned **4** — the low byte of a `.rodata` address — from a `^ v` the writer expected to be a number. No diagnostic anywhere.

The first only ever failed at clang:

```
error: insertvalue operand and field disagree in type: 'i64' instead of 'ptr'
  %r2 = insertvalue { i1, i8* } %r1, i64 42, 1
```

— a message naming neither the option nor the line to change.

### One root cause

A result is `{ i1, T, E }` and an option `{ i1, T }`. **Field 1 carries T's real type in both.** The payload coercion believed a comment claiming a result's slot "is always i64", and on that basis folded *any* pointer into it with `ptrtoint`:

| declared | value | before | after |
|---|---|---|---|
| `?s` (`i8*` slot) | `42` | no branch matched → raw `insertvalue` → **clang** | nurlc error |
| `?i` (`i64` slot) | `` `x` `` | `ptrtoint` → **silently wrong** | nurlc error |

The fold is the right representation for a slot which is an untyped box, and the wrong one for a slot declared as a number — the missing thing was the distinction, not the fold. It now asks what the slot *is* before reinterpreting an address as arithmetic, and a backstop refuses to emit an `insertvalue` the chain could not legally bridge.

Nothing in the tree relied on the fold: **zero acceptance change** across stdlib, examples and 320 package files; **532 corpus files still lower to byte-identical IR**.

## 3 — two bad calls in one body report one error

Recovery is per top-level declaration, so a reported error skips the rest of the `@` it fired in. Nothing printed is false, but the silence reads as *"the rest was checked and passed"* — and for anything driving nurlc in a loop, that inference is systematically wrong.

### I implemented statement-level recovery, measured it, and reverted it

It "worked" — 59 goldens gained a second error. The second errors were **derived, not independent**:

- `: 5 n 0` fails → `n` never bound → next line's `^ n` becomes *"undefined identifier 'n'"*
- one fixture reported **the same error twice**
- another desynchronised its braces into *"unexpected '}' at the top level"*

A reader would see 2–3 errors where 1 is real, with the extras pointing at innocent lines. **Naming an innocent line costs more than staying silent about it.** Doing this properly needs poison bindings and derived-error suppression; the reasoning is recorded at the site so the next attempt starts from there instead of rediscovering it.

### What was actually wrong was the silence

```
error: aborting due to 1 previous error
note: each error stopped its declaration — later statements in the same '@'/'%'
      were not checked, so this count is a lower bound. Fix these, then re-run.
```

Verified before claiming it: errors in *different* declarations are all reported; a second bad statement in the *same* body is not. So the note is exact, not hedging.

Cost: 153 goldens each gain that one identical line, **zero removals**.

## Verification

| gate | result |
|---|---|
| test corpus | 803 PASS · 0 FAIL |
| ASan/UBSan corpus | 803 PASS · 0 SAN_FAIL |
| LSan-pinned subset | 31/31 |
| `leakgate.sh` | zero leaks, both emission modes |
| examples | 100 PASS · 0 FAIL |
| stdlib + examples + 320 package files | zero acceptance change |
| corpus IR | 532 byte-identical, 0 differ |
| nurlfmt / diag-coverage / strict-arity / golden-twins | green |

Two acceptance changes in the whole tree, both the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU
