### PR TITLE
tools/metamorph: four more classes, and stop the harness lying to itself

### DIFF
--- a/tools/metamorph/README.md
+++ b/tools/metamorph/README.md
@@ -39,7 +39,17 @@ tools/metamorph/spellings.py --class NAME    # one class
 tools/metamorph/spellings.py --update-known  # re-baseline after fixing one
 ```
 
-`--verify` wants a sanitized runtime: `./build.sh --san --no-tests` first.
+`--verify` wants a sanitized **runtime**, never a sanitized **compiler**.
+Leaving `build/nurlc` sanitized turns each of the ~80 compiles into an
+ASan+LSan run: the sweep goes from **1.5 seconds to ~50 minutes** and looks
+hung when it is only crawling. The tool warns when it detects this. Keep a
+sanitized runtime aside and point at it:
+
+```bash
+./build.sh --san --no-tests && cp stdlib/runtime.o /tmp/rt-san.o
+./build.sh                                  # normal compiler back
+NURL_SAN_RUNTIME=/tmp/rt-san.o tools/metamorph/spellings.py --verify
+```
 
 ## How a finding is judged
 
@@ -60,12 +70,30 @@ generator of plausible-looking noise.
 
 ## The classes
 
-- **`handle-second-name`** — a heap handle acquires a second name and both
-  are freed. However it is spelled, exactly one owner may free the buffer.
-- **`option-payload-type`** — an option/result payload that is not the type
-  the option was declared over.
-- **`arc-shared-mutation`** — a thread closure mutating the contents of an
-  `Arc` it did not create, with no lock held.
+Each carries a **severity**, and the worklist ranks by it. Not every
+disagreement is a memory-safety bug, and pretending otherwise would make
+the output useless for deciding what to fix first.
+
+- **`handle-second-name`** *(memory-unsafety)* — a heap handle acquires a
+  second name and both are freed.
+- **`use-after-free`** *(memory-unsafety)* — a handle is READ after being
+  freed. Nothing frees twice; the buffer is simply gone.
+- **`loop-carried-free`** *(memory-unsafety)* — an outer binding freed
+  inside a loop body (§2.6). Its documented exemptions are controls.
+- **`arc-shared-mutation`** *(memory-unsafety)* — a thread closure mutating
+  the contents of an `Arc` it did not create, unlocked.
+- **`thread-nonsend`** *(memory-unsafety)* — an `Rc` reaching a worker.
+- **`option-payload-type`** *(silent-wrong-value)* — a payload that is not
+  the type the option was declared over. ASan has nothing to say about
+  arithmetic on a boxed pointer, so these land in UNCONFIRMED by
+  construction; a value oracle is `tools/fuzz`'s job.
+- **`iterator-invalidation`** *(diagnostic-consistency)* — mutating a
+  container under a `~ x xs` foreach (§2.5). Deliberately **not** ranked as
+  unsafety: measured, a forced realloc mid-iteration does not dangle,
+  because a `Vec` is a handle to a control block and the loop reads through
+  it. The rule is a conservative guard, so a gap is an inconsistency in
+  what gets *diagnosed* — the direct push warns, the same push one call
+  deep does not.
 - **`controls`** — correct programs, in a class of their own. A checker that
   rejects these is worse than one that misses a bug: every entry is code
   someone would reasonably write, and one of them (`mutex-guarded-mutation`)

--- a/tools/metamorph/known_gaps.json
+++ b/tools/metamorph/known_gaps.json
@@ -10,6 +10,14 @@
       "struct-field"
     ],
     [
+      "handle-second-name",
+      "ternary-nested"
+    ],
+    [
+      "iterator-invalidation",
+      "push-via-helper"
+    ],
+    [
       "option-payload-type",
       "vec-into-int"
     ]

--- a/tools/metamorph/spellings.py
+++ b/tools/metamorph/spellings.py
@@ -55,14 +55,17 @@ KNOWN = pathlib.Path(__file__).resolve().parent / "known_gaps.json"
 
 # ── Verdicts ────────────────────────────────────────────────────────────
 # What the checker said, normalised so spellings are comparable.
-ACCEPT = "accept"           # compiles under both default and --strict-borrowck
-REJECT_DEFAULT = "reject"   # the default checker rejects it
+ACCEPT = "accept"           # compiles clean under both modes
+WARN = "warn"               # compiles, but the checker says something
 REJECT_STRICT = "strict"    # only --strict-borrowck rejects it
+REJECT_DEFAULT = "reject"   # the default checker rejects it
 
 # A class states the WEAKEST verdict it will accept. `reject` is stronger
 # than `strict` is stronger than `accept`; a spelling that does better
 # than its class demands is fine and is reported, not failed.
-STRENGTH = {ACCEPT: 0, REJECT_STRICT: 1, REJECT_DEFAULT: 2}
+STRENGTH = {ACCEPT: 0, WARN: 1, REJECT_STRICT: 2, REJECT_DEFAULT: 3}
+# INVALID never satisfies a class; it is a template bug.
+STRENGTH_INVALID = -1
 
 PRELUDE_VEC = "$ `stdlib/core/vec.nu`\n"
 PRELUDE_ARC = "$ `stdlib/std/arc.nu`\n$ `stdlib/std/thread.nu`\n$ `stdlib/core/vec.nu`\n"
@@ -77,11 +80,13 @@ def prog(body, prelude=PRELUDE_VEC, extra=""):
 CLASSES = [
     {
         "name": "handle-second-name",
+        "severity": "memory-unsafety",
         "doc": "A heap handle acquires a SECOND name and both names are "
                "freed. However the second name is spelled, exactly one "
                "owner may free the buffer, so every spelling here is a "
                "double free.",
         "expect": REJECT_STRICT,
+        "expect_msg": ["use of moved value", "may already be freed"],
         "spellings": {
             # Covered as of #899.
             "let-alias": prog(
@@ -137,7 +142,7 @@ CLASSES = [
             "ternary-nested": prog(
                 "    : ( Vec i ) a ( vec_new [i] )\n"
                 "    : i c 1\n"
-                "    : ( Vec i ) b ? > c 0 ( ? > c 0 a ( vec_new [i] ) ) ( vec_new [i] )\n"
+                "    : ( Vec i ) b ? > c 0 ? > c 0 a ( vec_new [i] ) ( vec_new [i] )\n"
                 "    ( vec_free [i] b )\n"
                 "    ( vec_free [i] a )"),
             "wrapper-two-deep": prog(
@@ -161,10 +166,16 @@ CLASSES = [
     },
     {
         "name": "option-payload-type",
+        "severity": "silent-wrong-value",
         "doc": "The payload of an option/result literal is not the type "
                "the option was declared over. Field 1 carries T's real "
                "type in both forms, so none of these has anywhere to go.",
         "expect": REJECT_DEFAULT,
+        # Either site is a correct catch: the option-literal check, or the
+        # general binding type-check the value hits on its way in. What
+        # must NOT count is a syntax error in the template.
+        "expect_msg": ["payload of this option/result literal",
+                       "cannot initialise / assign a binding"],
         "spellings": {
             "int-into-string": prog("    : ?s o @ ?s { T 42 }\n"
                                     "    ?? o { T v → ^ 1  F → ^ 0 }", prelude=""),
@@ -183,10 +194,12 @@ CLASSES = [
     },
     {
         "name": "arc-shared-mutation",
+        "severity": "memory-unsafety",
         "doc": "A thread closure mutates the CONTENTS of an Arc it did "
                "not create, with no lock held. Arc makes the refcount "
                "atomic and nothing else.",
         "expect": REJECT_DEFAULT,
+        "expect_msg": ["thread_spawn closure"],
         "spellings": {
             "inline-push": prog(
                 "    : ( Vec i ) d ( vec_new [i] )\n"
@@ -247,10 +260,160 @@ CLASSES = [
         },
     },
     {
+        "name": "use-after-free",
+        "severity": "memory-unsafety",
+        "doc": "A handle is READ after it has been freed. Distinct from "
+               "the double-free class: nothing frees twice here, the "
+               "buffer is simply gone by the time it is used.",
+        "expect": REJECT_DEFAULT,
+        "expect_msg": ["use of moved value", "may already be freed"],
+        "spellings": {
+            "read-len": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    ( vec_free [i] a )\n"
+                "    ( nurl_print ( nurl_str_int ( vec_len [i] a ) ) )"),
+            "read-after-wrapper": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    ( dispose a )\n"
+                "    ( nurl_print ( nurl_str_int ( vec_len [i] a ) ) )",
+                extra="@ dispose ( Vec i ) v → v { ( vec_free [i] v ) }\n"),
+            "read-after-generic-wrapper": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    ( dispose [i] a )\n"
+                "    ( nurl_print ( nurl_str_int ( vec_len [i] a ) ) )",
+                extra="@ dispose [T] ( Vec T ) v → v { ( vec_free [T] v ) }\n"),
+            "push-after-free": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    ( vec_free [i] a )\n"
+                "    ( vec_push [i] a 1 )"),
+            "read-in-loop-after-free": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    ( vec_free [i] a )\n"
+                "    : ~ i k 0\n"
+                "    ~ < k 2 { ( nurl_print ( nurl_str_int ( vec_len [i] a ) ) ) = k + k 1 }"),
+            "read-through-alias": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    : ( Vec i ) b a\n"
+                "    ( vec_free [i] b )\n"
+                "    ( nurl_print ( nurl_str_int ( vec_len [i] a ) ) )"),
+        },
+    },
+    {
+        "name": "loop-carried-free",
+        "severity": "memory-unsafety",
+        "doc": "An outer binding freed INSIDE a loop body: on the second "
+               "iteration the buffer is already gone (docs/MEMORY.md "
+               "§2.6). The documented exemptions live in `controls`.",
+        "expect": REJECT_DEFAULT,
+        "expect_msg": ["use of moved value", "may already be freed"],
+        "spellings": {
+            "while-loop": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    : ~ i k 0\n"
+                "    ~ < k 3 { ( vec_free [i] a ) = k + k 1 }"),
+            "while-loop-wrapper": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    : ~ i k 0\n"
+                "    ~ < k 3 { ( dispose a ) = k + k 1 }",
+                extra="@ dispose ( Vec i ) v → v { ( vec_free [i] v ) }\n"),
+            "nested-loop": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    : ~ i k 0\n"
+                "    ~ < k 2 { : ~ i j 0  ~ < j 2 { ( vec_free [i] a ) = j + j 1 } = k + k 1 }"),
+            "foreach-outer": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    : ( Vec i ) xs ( vec_new [i] )\n"
+                "    ( vec_push [i] xs 1 )\n"
+                "    ~ y xs { ( vec_free [i] a ) }\n"
+                "    ( vec_free [i] xs )"),
+        },
+    },
+    {
+        "name": "iterator-invalidation",
+        "severity": "diagnostic-consistency",
+        "doc": "Mutating a container while a `~ x xs` foreach holds a "
+               "borrow of it (docs/MEMORY.md §2.5). Severity is "
+               "deliberately NOT memory-unsafety: measured, a forced "
+               "realloc during iteration does not dangle, because a Vec "
+               "is a handle to a control block and the loop reads "
+               "through it. The rule is a conservative guard, so a gap "
+               "here is an inconsistency in what gets DIAGNOSED — the "
+               "direct push warns, the same push one call deep does not "
+               "— and belongs below anything that corrupts memory.",
+        "expect": WARN,
+        "expect_msg": ["while iterating over it"],
+        "spellings": {
+            "push-in-foreach": prog(
+                "    : ( Vec i ) xs ( vec_new [i] )\n"
+                "    ( vec_push [i] xs 1 )\n"
+                "    ~ y xs { ( vec_push [i] xs 2 ) }\n"
+                "    ( vec_free [i] xs )"),
+            "set-in-foreach": prog(
+                "    : ( Vec i ) xs ( vec_new [i] )\n"
+                "    ( vec_push [i] xs 1 )\n"
+                "    ~ y xs { ( vec_set [i] xs 0 9 ) }\n"
+                "    ( vec_free [i] xs )"),
+            "free-in-foreach": prog(
+                "    : ( Vec i ) xs ( vec_new [i] )\n"
+                "    ( vec_push [i] xs 1 )\n"
+                "    ~ y xs { ( vec_free [i] xs ) }"),
+            "push-via-helper": prog(
+                "    : ( Vec i ) xs ( vec_new [i] )\n"
+                "    ( vec_push [i] xs 1 )\n"
+                "    ~ y xs { ( grow xs ) }\n"
+                "    ( vec_free [i] xs )",
+                extra="@ grow ( Vec i ) v → v { ( vec_push [i] v 2 ) }\n"),
+            "push-in-nested-foreach": prog(
+                "    : ( Vec i ) xs ( vec_new [i] )\n"
+                "    ( vec_push [i] xs 1 )\n"
+                "    : ( Vec i ) ys ( vec_new [i] )\n"
+                "    ( vec_push [i] ys 1 )\n"
+                "    ~ y ys { ~ z xs { ( vec_push [i] xs 3 ) } }\n"
+                "    ( vec_free [i] xs )\n"
+                "    ( vec_free [i] ys )"),
+        },
+    },
+    {
+        "name": "thread-nonsend",
+        "severity": "memory-unsafety",
+        "doc": "An `Rc` (non-atomic refcount) reaching a worker thread. "
+               "Two threads racing on the control-block count is UB; "
+               "`Arc` is the thread-safe counterpart.",
+        "expect": REJECT_DEFAULT,
+        "expect_msg": ["which is an Rc"],
+        "spellings": {
+            "inline-closure": prog(
+                "    : ( Rc i ) r ( rc_new [i] 1 )\n"
+                "    : !Thread ThreadErr t ( thread_spawn \\ → v { ( rc_free [i] r ) } )\n"
+                "    ?? t { T h → { ( thread_join h ) } F e → {} }",
+                prelude="$ `stdlib/std/rc.nu`\n$ `stdlib/std/thread.nu`\n"),
+            "named-closure": prog(
+                "    : ( Rc i ) r ( rc_new [i] 1 )\n"
+                "    : ( @ v ) w \\ → v { ( rc_free [i] r ) }\n"
+                "    : !Thread ThreadErr t ( thread_spawn w )\n"
+                "    ?? t { T h → { ( thread_join h ) } F e → {} }",
+                prelude="$ `stdlib/std/rc.nu`\n$ `stdlib/std/thread.nu`\n"),
+            "via-helper": prog(
+                "    : ( Rc i ) r ( rc_new [i] 1 )\n"
+                "    : ( @ v ) w \\ → v { ( touch r ) }\n"
+                "    : !Thread ThreadErr t ( thread_spawn w )\n"
+                "    ?? t { T h → { ( thread_join h ) } F e → {} }",
+                prelude="$ `stdlib/std/rc.nu`\n$ `stdlib/std/thread.nu`\n",
+                extra="@ touch ( Rc i ) r → v { ( rc_free [i] r ) }\n"),
+        },
+    },
+    {
         "name": "controls",
         "doc": "Correct programs. A class of its own because a checker "
                "that rejects these is worse than one that misses a bug — "
-               "every entry here is code someone would reasonably write.",
+               "every entry here is code someone would reasonably write. "
+               "Judged against the DEFAULT checker only: the "
+               "no-false-positive contract is the default checker's, and "
+               "--strict-borrowck is documented to over-flag (it also "
+               "rejects the mutually-exclusive-frees pattern, and the "
+               "loop-fixpoint version of the same conservatism flags "
+               "freeing a foreach ELEMENT). Holding controls to strict "
+               "would encode that documented noise as a regression.",
         "expect": ACCEPT,
         "spellings": {
             "single-thread-arc-mutation": prog(
@@ -301,6 +464,24 @@ CLASSES = [
                 "    : i c 1\n"
                 "    ? > c 0 { ( vec_free [i] a ) = a ( vec_new [i] ) } {}\n"
                 "    ( vec_free [i] a )"),
+            "loop-elem-free": prog(
+                "    : ( Vec String ) xs ( vec_new [String] )\n"
+                "    ~ y xs { ( string_free y ) }\n"
+                "    ( vec_free [String] xs )",
+                prelude="$ `stdlib/core/vec.nu`\n$ `stdlib/core/string.nu`\n"),
+            "loop-inner-declared-free": prog(
+                "    : ~ i k 0\n"
+                "    ~ < k 2 { : ( Vec i ) tmp ( vec_new [i] ) ( vec_free [i] tmp ) = k + k 1 }"),
+            "loop-rebound-free": prog(
+                "    : ~ ( Vec i ) buf ( vec_new [i] )\n"
+                "    : ~ i k 0\n"
+                "    ~ < k 2 { ( vec_free [i] buf ) = buf ( vec_new [i] ) = k + k 1 }\n"
+                "    ( vec_free [i] buf )"),
+            "foreach-read-only": prog(
+                "    : ( Vec i ) xs ( vec_new [i] )\n"
+                "    ( vec_push [i] xs 1 )\n"
+                "    ~ y xs { ( nurl_print ( nurl_str_int y ) ) }\n"
+                "    ( vec_free [i] xs )"),
             "option-payload-matches": prog(
                 "    : ?i o @ ?i { T 42 }\n"
                 "    ?? o { T v → ^ v  F → ^ 0 }", prelude=""),
@@ -321,14 +502,39 @@ def compile_verdict(src_path, strict):
     return r.returncode != 0, r.stderr.decode("utf-8", "replace")
 
 
-def verdict_of(src_path):
-    """Normalised verdict + the diagnostic that produced it."""
+INVALID = "invalid"          # the template is broken, not the compiler
+
+
+def verdict_of(src_path, want_msg, default_only=False):
+    """Normalised verdict + the diagnostic that produced it.
+
+    A rejection only counts when it is the rejection this class is about.
+    Without that, a typo in a template compiles to a syntax error, the
+    harness reads "rejected" as "the checker caught it", and the gap it
+    was written to find is hidden by the very test meant to expose it —
+    a false negative that looks like coverage. `want_msg` is a substring
+    the diagnostic has to contain; anything else is INVALID and is
+    reported against the template, never against nurlc."""
+    wants = [want_msg] if isinstance(want_msg, str) else list(want_msg or [])
+
+    def says(text):
+        return (not wants) or any(w in text for w in wants)
+
     rej_def, err_def = compile_verdict(src_path, strict=False)
     if rej_def:
-        return REJECT_DEFAULT, err_def
+        return (REJECT_DEFAULT if says(err_def) else INVALID), err_def
+    # Not fatal, but the checker may still have spoken — an
+    # iterator-invalidation borrow is a warning, and a warning is the
+    # checker catching it, just without stopping the build.
+    if "warning:" in err_def and says(err_def):
+        return WARN, err_def
+    if default_only:
+        return ACCEPT, ""
     rej_str, err_str = compile_verdict(src_path, strict=True)
     if rej_str:
-        return REJECT_STRICT, err_str
+        return (REJECT_STRICT if says(err_str) else INVALID), err_str
+    if "warning:" in err_str and says(err_str):
+        return WARN, err_str
     return ACCEPT, ""
 
 
@@ -347,7 +553,12 @@ def runtime_is_broken(src_path, tmpdir):
     # runtime_san.o can be an older artifact, and linking IR against a
     # stale ABI produces confusing hangs that look like findings.
     san = None
-    for cand in (ROOT / "stdlib" / "runtime.o", ROOT / "stdlib" / "runtime_san.o"):
+    cands = []
+    env_rt = os.environ.get("NURL_SAN_RUNTIME")
+    if env_rt:
+        cands.append(pathlib.Path(env_rt))
+    cands += [ROOT / "stdlib" / "runtime.o", ROOT / "stdlib" / "runtime_san.o"]
+    for cand in cands:
         if cand.exists() and b"__asan_init" in subprocess.run(
                 ["nm", str(cand)], capture_output=True).stdout:
             san = cand
@@ -360,21 +571,30 @@ def runtime_is_broken(src_path, tmpdir):
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=ROOT)
     if link.returncode != 0:
         return None, "did not link"
-    env = dict(os.environ, ASAN_OPTIONS="detect_leaks=1")
+    # symbolize=0 matters: ASan's symbolizer can stall for tens of
+    # seconds on these binaries, and an early version of this harness
+    # timed out and reported "hung" — throwing away a perfectly clear
+    # "SEGV on 0xfffffffffffffff8, WRITE" that had already been printed.
+    # A weak label on strong evidence is its own kind of wrong answer.
+    env = dict(os.environ, ASAN_OPTIONS="detect_leaks=1:symbolize=0")
+    partial = b""
     try:
         run = subprocess.run([str(exe)], capture_output=True, timeout=30, env=env)
-    except subprocess.TimeoutExpired:
-        # Weaker evidence than a diagnosed report, but not nothing: a
-        # double free that corrupts the allocator's free list spins
-        # instead of aborting. Labelled so it is never mistaken for a
-        # clean ASan diagnosis.
-        return True, "hung (weak signal — inspect by hand)"
-    out = (run.stderr or b"").decode("utf-8", "replace")
+        err_bytes, rc = run.stderr or b"", run.returncode
+    except subprocess.TimeoutExpired as e:
+        # Scan what it managed to print BEFORE giving up on it.
+        partial = e.stderr or b""
+        err_bytes, rc = partial, None
+    out = err_bytes.decode("utf-8", "replace")
     for marker in ("AddressSanitizer", "LeakSanitizer", "runtime error:"):
         if marker in out:
-            return True, marker
-    if run.returncode < 0:
-        return True, f"killed by signal {-run.returncode}"
+            first = next((l for l in out.splitlines() if "ERROR:" in l), marker)
+            return True, first.strip()[:90]
+    if rc is None:
+        return True, "hung with no sanitizer output (inspect by hand)"
+    run_stub = None
+    if rc is not None and rc < 0:
+        return True, f"killed by signal {-rc}"
     return False, "ran clean"
 
 
@@ -389,12 +609,24 @@ def main():
     if not NURLC.exists():
         print(f"ERROR: {NURLC} not built — run ./build.sh first", file=sys.stderr)
         return 2
+    # A sanitized build/nurlc turns every one of the ~80 compiles below
+    # into an ASan+LSan run: the sweep goes from seconds to the better
+    # part of an hour and looks hung when it is only crawling. --verify
+    # needs a sanitized RUNTIME, never a sanitized COMPILER.
+    if b"__asan_init" in subprocess.run(["nm", str(NURLC)],
+                                        capture_output=True).stdout:
+        print("WARNING: build/nurlc is SANITIZED — every compile here will "
+              "run under ASan and this sweep will take ~50x longer.\n"
+              "         Run ./build.sh (no --san) first; --verify only needs "
+              "a sanitized runtime,\n"
+              "         which it finds via $NURL_SAN_RUNTIME or "
+              "stdlib/runtime*.o.", file=sys.stderr)
 
     known = set()
     if KNOWN.exists():
         known = {tuple(x) for x in json.loads(KNOWN.read_text())["gaps"]}
 
-    gaps, new_gaps, control_breaks, found = [], [], [], []
+    gaps, new_gaps, control_breaks, found, invalid = [], [], [], [], []
     tmp = pathlib.Path(tempfile.mkdtemp(prefix="nurl-metamorph-"))
 
     for cls in CLASSES:
@@ -405,8 +637,19 @@ def main():
         for name, src in cls["spellings"].items():
             p = tmp / f"{cls['name']}__{name}.nu"
             p.write_text(src)
-            got, _err = verdict_of(p)
-            ok = STRENGTH[got] >= STRENGTH[want]
+            got, _err = verdict_of(p, cls.get("expect_msg", ""),
+                                   default_only=(want == ACCEPT))
+            if got == INVALID:
+                invalid.append((cls["name"], name))
+                print(f"   {'INVALID':11} {name:26} → rejected for the wrong "
+                      f"reason (template bug, not a checker gap)")
+                continue
+            # For a control, STRONGER is WORSE: the whole point is that
+            # correct code compiles clean, so `reject` fails it. Using
+            # `>=` here let a false positive pass as "better than asked",
+            # which is the one direction this class exists to catch.
+            ok = (got == ACCEPT) if want == ACCEPT \
+                else STRENGTH[got] >= STRENGTH[want]
             mark = "ok " if ok else "GAP"
             extra = ""
             if not ok:
@@ -438,17 +681,30 @@ def main():
         return 0
 
     print(f"\n── summary: {len(gaps)} gap(s), {len(new_gaps)} new, "
-          f"{len(control_breaks)} control regression(s)")
+          f"{len(control_breaks)} control regression(s), "
+          f"{len(invalid)} invalid template(s)")
+    for c, n in invalid:
+        print(f"   INVALID    {c}/{n}: fix the template")
     for c, n, g in control_breaks:
         print(f"   REGRESSION {c}/{n}: correct code now rejected ({g})")
     for c, n in new_gaps:
         print(f"   NEW GAP    {c}/{n}")
-    if args.verify and found:
-        print(f"\n   {len(found)} gap(s) CONFIRMED broken at runtime:")
-        for c, n, why in found:
-            print(f"     {c}/{n}: {why}")
+    if args.verify:
+        print("\n── worklist (most severe first)")
+        rank = {"memory-unsafety": 0, "silent-wrong-value": 1,
+                "diagnostic-consistency": 2}
+        sev_of = {c["name"]: c.get("severity", "unknown") for c in CLASSES}
+        confirmed = {(c, n): why for c, n, why in found}
+        rows = sorted(gaps, key=lambda g: (rank.get(sev_of.get(g[0]), 9), g[0]))
+        if not rows:
+            print("   (none)")
+        for c, n in rows:
+            why = confirmed.get((c, n))
+            state = f"ASan: {why}" if why else "unconfirmed at runtime"
+            print(f"   [{sev_of.get(c,'?'):22}] {c}/{n}\n"
+                  f"       {state}")
 
-    return 1 if (new_gaps or control_breaks) else 0
+    return 1 if (new_gaps or control_breaks or invalid) else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #903. Expands the harness from 4 classes to 8 — and fixes three ways it could have handed back a confident wrong answer.

## Two new gaps

Both the same shape as every gap this harness has found:

| gap | works | doesn't |
|---|---|---|
| `handle-second-name/ternary-nested` | `? c a (make)` | `? c ? c a (make) (make)` |
| `iterator-invalidation/push-via-helper` | `~ y xs { ( vec_push xs 2 ) }` | `~ y xs { ( grow xs ) }` |

New classes `use-after-free` (6/6), `loop-carried-free` (4/4) and `thread-nonsend` (3/3) passed on first contact, along with four new controls for the documented §2.6 exemptions.

## Three fixes were to the harness itself

**A template typo read as coverage.** A syntax error made the program fail to compile, which the harness scored as *"rejected — the checker caught it"*: a false negative wearing coverage's clothes. Rejections must now match the diagnostic the class is about; anything else reports `INVALID` against the template, never against nurlc. It immediately caught three of my own new templates — including `( ? … )`, which in NURL is a call to a function named `?`.

**Controls used `>=`.** A control that got *rejected* counted as "better than asked" — precisely the false positive that class exists to catch, passing in silence. Fixing it exposed a second modelling error: controls were held to `--strict-borrowck`, which is *documented* to over-flag. The no-false-positive contract is the **default** checker's, so that is the bar now.

**"hung" was hiding a diagnosis.** Three gaps reported as `hung (weak signal)`. They were not hung — ASan had already printed `SEGV on 0xfffffffffffffff8, WRITE` and was stalling in its *symbolizer*, and the harness discarded that on timeout. It now scans partial output and runs `symbolize=0`. A weak label on strong evidence is its own kind of wrong answer.

## Severity, because not every disagreement is a memory-safety bug

`iterator-invalidation` is deliberately **not** ranked as unsafety. Measured, not assumed: a forced realloc mid-iteration does **not** dangle, because a `Vec` is a handle to a control block and the loop reads through it — both the direct and the via-helper versions return the correct answer. §2.5 is a conservative guard, so a gap there is an inconsistency in what gets *diagnosed*, not corruption. Ranking it beside the double frees would have sent the next person at the wrong thing first.

## The worklist this now produces

```
── worklist (most severe first)
   [memory-unsafety       ] handle-second-name/ternary-nested     ASan: SEGV … WRITE
   [memory-unsafety       ] handle-second-name/struct-field       ASan: SEGV … WRITE
   [memory-unsafety       ] handle-second-name/closure-capture    ASan: SEGV … WRITE
   [silent-wrong-value    ] option-payload-type/vec-into-int      unconfirmed at runtime
   [diagnostic-consistency] iterator-invalidation/push-via-helper unconfirmed at runtime
```

The top three are one family — a handle acquiring a second name through a nested ternary, a struct field, or a closure capture — and are likely one fix.

## Also documented: the sequencing trap

`--verify` needs a sanitized **runtime**, never a sanitized **compiler**. Leaving `build/nurlc` sanitized turns each of the ~80 compiles into an ASan+LSan run — the sweep goes from **1.5 s to ~50 min** and looks hung when it is only crawling. The tool now warns, and takes `$NURL_SAN_RUNTIME` so a sanitized runtime survives a normal rebuild.

## Verification

| gate | result |
|---|---|
| test corpus | 805 PASS · 0 FAIL |
| metamorph gate | 0 new gaps · 0 control regressions · 0 invalid templates |

Tooling only — no compiler change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU
