### PR TITLE
nurlc: a `??` arm must name something the scrutinee can be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `??` arm must name something the scrutinee can be.** Nothing
+  checked that, and the consequence was not a diagnostic: an
+  unrecognised name fell through to the enum-variant path, which emits
+  `load i64, i64* @<name>` for a global that was never defined, and the
+  arm's payload binding got an empty type —
+
+  ```llvm
+  %r8 = alloca                    ; "Cannot allocate unsized type"
+  %r5 = load i64, i64* @Ok        ; a global that does not exist
+  ```
+
+  — so nurlc exited 0 and clang delivered the news, about generated IR
+  rather than about the arm the writer has to change.
+
+  The shape that surfaced it is the Rust habit rather than a typo:
+
+  ```
+  ?? ( int_parse `123` ) { Ok val → val  _ → -1 }
+  ```
+
+  so the message names the NURL spelling instead of only rejecting the
+  wrong one — `T` and `F`, not `Ok`/`Err`/`Some`/`None`. A misspelled
+  variant of a named enum is reported the same way, and lists the
+  variants that type actually has.
+  (`diag_match_arm_not_a_variant`)
+
+### Fixed
+
 - **Three more ways a heap handle acquires a second name.** #899 closed
   the copy, the `?` / `??` join, the assignment and the
   callee-returns-its-argument spellings. `tools/metamorph` enumerated the

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -9738,6 +9738,45 @@
                     ( nurl_print `, label %` ) ( nurl_print arm_label )
                     ( nurl_print `, label %` ) ( nurl_print next_label ) ( emit_dbg_eol )
                 } {
+                    // A named pattern has to name something the scrutinee
+                    // can actually BE. Nothing checked that, and the
+                    // consequence was not a diagnostic: the arm fell
+                    // through to the enum-variant path below, which emits
+                    // `load i64, i64* @<name>` for a global that was never
+                    // defined, and the payload binding got an empty type
+                    // (`alloca ` — "Cannot allocate unsized type"). nurlc
+                    // exited 0 and clang delivered the news, about
+                    // generated IR rather than about the arm.
+                    //
+                    // `?? ( int_parse … ) { Ok val → val  _ → -1 }` is the
+                    // shape that surfaced it, and it is the Rust habit
+                    // rather than a typo — so the message names the NURL
+                    // spelling instead of only rejecting the wrong one.
+                    ? ! ( seq pattern_name `_` ) {
+                        : b __mp_optres & >= ( nurl_str_len match_type ) 6
+                        ( seq ( nurl_str_slice match_type 0 6 ) `{ i1, ` )
+                        ? & __mp_optres ! | ( seq pattern_name `T` ) ( seq pattern_name `F` )
+                        { ( die lex ( nurl_str_cat4
+                            ( nurl_str_cat3 `'` pattern_name `' is not a match arm of an option/result. ` )
+                            `NURL spells them 'T' and 'F', not 'Ok'/'Err'/'Some'/'None': `
+                            `'?? r { T v → <v is the value / Ok payload>  F e → <e is the error> }' `
+                            `(an option's F arm binds nothing: 'F → …'). Add '_ → …' for a catch-all.` ) ) }
+                        {}
+                        // A named enum: the variant must be one of its own.
+                        ? & & ! __mp_optres > ( nurl_str_len match_type ) 1
+                        == ( nurl_str_get match_type 0 ) 37
+                        { : s __mp_en ( nurl_str_slice match_type 1 - ( nurl_str_len match_type ) 1 )
+                            : s __mp_vl ( nurl_sym_get2 syms __mp_en `__variants` )
+                            ? & != 0 ( nurl_str_len __mp_vl )
+                            ! ( str_contains_word __mp_vl pattern_name )
+                            { ( die lex ( nurl_str_cat4
+                                ( nurl_str_cat3 `'` pattern_name `' is not a variant of enum '` )
+                                ( nurl_str_cat3 __mp_en `'. Its variants are: ` __mp_vl )
+                                `. Check the spelling, or add '_ → body' to absorb the rest — a match must be `
+                                `exhaustive, and an unknown name here is not a catch-all.` ) ) }
+                            {} }
+                        {} }
+                    {}
                     // Named variant.  Literal-constrained arms (e.g. `Ok 200`) do NOT
                     // exhaustively cover the variant — only catch-all arms (no literals)
                     // count towards exhaustiveness and as duplicate-arm blockers.

--- a/compiler/tests/diag_match_arm_not_a_variant.nu
+++ b/compiler/tests/diag_match_arm_not_a_variant.nu
@@ -1,0 +1,48 @@
+// diag_match_arm_not_a_variant.nu — a `??` arm must name something the
+// scrutinee can actually BE.
+//
+// Nothing checked that, and the consequence was not a diagnostic. An
+// unrecognised name fell through to the enum-variant path, which emits
+// `load i64, i64* @<name>` for a global that was never defined, and the
+// arm's payload binding got an empty type:
+//
+//     %r8  = alloca                      ← "Cannot allocate unsized type"
+//     %r5  = load i64, i64* @Ok          ← a global that does not exist
+//
+// nurlc exited 0 and clang delivered the news, about generated IR rather
+// than about the arm the writer has to change.
+//
+// The shape that surfaced it is the Rust habit, not a typo:
+//
+//     ?? ( int_parse `123` ) { Ok val → val  _ → -1 }
+//
+// so the message names the NURL spelling rather than only rejecting the
+// wrong one — `T` and `F`, not `Ok`/`Err`/`Some`/`None`.
+//
+// Two functions, because recovery is per declaration: one error each,
+// the option/result form and the named-enum form.
+
+$ `stdlib/std/int`
+
+: | Color { Red Green Blue }
+
+@ rust_habit → i {
+    ^ ?? ( int_parse `123` ) {
+        Ok val → val
+        _ → -1
+    }
+}
+
+@ misspelled_variant Color c → i {
+    ^ ?? c {
+        Red → 1
+        Purple → 2
+        _ → 0
+    }
+}
+
+@ main → i {
+    : i a ( rust_habit )
+    : i b ( misspelled_variant Red )
+    ^ + a b
+}

--- a/compiler/tests/outputs/diag_match_arm_not_a_variant.txt
+++ b/compiler/tests/outputs/diag_match_arm_not_a_variant.txt
@@ -1,0 +1,10 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_match_arm_not_a_variant.nu:31:20: error: 'Ok' is not a match arm of an option/result. NURL spells them 'T' and 'F', not 'Ok'/'Err'/'Some'/'None': '?? r { T v → <v is the value / Ok payload>  F e → <e is the error> }' (an option's F arm binds nothing: 'F → …'). Add '_ → …' for a catch-all.
+        Ok val → val
+                   ^
+compiler/tests/diag_match_arm_not_a_variant.nu:39:20: error: 'Purple' is not a variant of enum 'Color'. Its variants are: Red Green Blue. Check the spelling, or add '_ → body' to absorb the rest — a match must be exhaustive, and an unknown name here is not a catch-all.
+        Purple → 2
+                   ^
+error: aborting due to 2 previous errors
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.


### PR DESCRIPTION
## The report

```nurl
$ `stdlib/std/int`

@ main → i {
  : i n ?? ( int_parse `123` ) {
      Ok val → val
      _      → -1
    }
  ( nurl_print_int n )
  ^ 0
}
```

nurlc exits **0**. clang then rejects the module:

```
error: Cannot allocate unsized type
  %r11 = alloca i64
```

## One cause, two symptoms

Nothing validated the arm pattern against the scrutinee. `Ok` is not `T`/`F`, so it fell through to the **enum-variant** path — which emits a tag load from a global named after the pattern, and leaves the payload binding with no type:

```llvm
%r8 = alloca                    ; ← "Cannot allocate unsized type"
%r5 = load i64, i64* @Ok        ; ← a global that does not exist
```

`Bogus val` reproduces identically. `T val` compiles and prints `123`.

## The fix

Two checks, placed where the arm is already known to be a named pattern (wildcards and integer literals are handled before it):

| scrutinee | admits |
|---|---|
| option / result (`{ i1, …`) | `T`, `F` |
| named enum | its own variants — and the message lists them |

```
error: 'Ok' is not a match arm of an option/result. NURL spells them 'T' and 'F',
not 'Ok'/'Err'/'Some'/'None': '?? r { T v → <v is the value / Ok payload>
F e → <e is the error> }' (an option's F arm binds nothing: 'F → …').
Add '_ → …' for a catch-all.

error: 'Purple' is not a variant of enum 'Color'. Its variants are: Red Green Blue.
Check the spelling, or add '_ → body' to absorb the rest — a match must be
exhaustive, and an unknown name here is not a catch-all.
```

The first is the **Rust habit, not a typo** — `Ok`/`Err`/`Some`/`None` is what a writer coming from Rust reaches for, and what a model trained on Rust will produce. So the message names the NURL spelling rather than only rejecting the wrong one.

Where the type is not determinable (a bare `i64` tag from a nested match) nothing is checked, so the rule can only miss, never invent.

## Verification

| gate | result |
|---|---|
| test corpus | 807 PASS · 0 FAIL |
| ASan/UBSan corpus | 807 PASS · 0 SAN_FAIL |
| `leakgate.sh` | zero leaks, both emission modes |
| examples | 100 PASS · 0 FAIL |
| stdlib + examples + 320 package files | zero acceptance change |
| corpus IR | 534 byte-identical, 0 differ |
| nurlfmt / diag-coverage / metamorph | green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU
