### PR TITLE
tools/metamorph: invalid-input class + IR-validity invariant; two escapes fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`tools/metamorph` gains an `invalid-input` class and an IR-validity
+  invariant.** The classes so far asked "the same situation spelled N
+  ways — does the verdict agree?". This adds the other question: *bad
+  input must be diagnosed, never lowered.* Two shipped bugs escaped
+  exactly there, and both times nurlc exited 0 and clang reported the
+  problem against generated IR rather than the line to change.
+
+  The invariant is the stronger half and applies to **every** spelling in
+  every class, not just the new one: whenever nurlc exits 0, the module
+  must pass the LLVM verifier (`llvm-as`). Unlike everything else in the
+  harness this is never a template bug — whatever a program says, if the
+  compiler accepted it then what it emitted has to verify.
+
+### Fixed
+
+- **Returning a handle where a number is declared.** `^ ( vec_new [i] )`
+  from a `→ i` function lowered `ret %Vec__i64 %r1` out of a
+  `define i64`. The return-type chain asked about every pair of shapes it
+  knew — float/float, int/int, `{…}`/`{…}`, struct/struct, int/enum — and
+  a struct beside a plain number matched none of them, so it fell through
+  to the emit.
+
+- **A generic called with the wrong number of arguments.** The call-site
+  arity check was conditioned on `call_name == fname`, which is false for
+  a generic, and generics recorded no parameter count anyway:
+  `( vec_push [i] v )`, one argument short, was accepted, and a missing
+  argument reads an unset ABI register — the same silent failure the FFI
+  arity check exists to prevent. The template's count is now recorded
+  under `__garity`, deliberately not the shared `__arity`: a file may
+  define its own non-generic function with the same name as an imported
+  generic, and writing the template's count into the shared key made
+  every call to the *local* function look one argument short.
+  (`diag_ret_struct_and_generic_arity`)
+
 ### Fixed
 
 - **A `??` arm must name something the scrutinee can be.** Nothing

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -2719,6 +2719,23 @@
             `return value type '` ( nurl_llty lt ) `' does not match the declared return type '` ( nurl_llty fn_rt ) )
             `' — the payload/signature inside the aggregate differs, and NURL has no implicit conversions between option/result/slice/closure shapes. Construct the declared shape ('@ ? i { T … }' for '→ ?i'), or fix the declaration.` ) ) }
         {}
+        // A named aggregate returned where a SCALAR is declared —
+        // `^ ( vec_new [i] )` from a `→ i` function, which lowered
+        // `ret %Vec__i64 %r1` out of a `define i64`. Every branch here
+        // asked about a pair of shapes it knew (float/float,
+        // int/int, `{…}`/`{…}`, struct/struct, int/enum); a struct
+        // beside a plain number matched none of them and fell through
+        // to the emit, so nurlc exited 0 and the LLVM verifier reported
+        // it against generated IR. Found by tools/metamorph's
+        // invalid-input class.
+        ? & & & == ( nurl_str_get ( nurl_llty lt ) 0 ) 37
+        ! ( is_ptr_ty lt )
+        | ( is_int_ty fn_rt ) | ( seq fn_rt `double` ) ( seq fn_rt `float` )
+        ! ( seq ( nurl_llty lt ) ( nurl_llty fn_rt ) )
+        { ( die_stmt lex ( nurl_str_cat ( nurl_str_cat4
+            `return value type '` ( llvm_to_nurl lt ) `' does not match the declared return type '` ( llvm_to_nurl fn_rt ) )
+            `' — a struct/handle value is not a number and does not convert to one. Return the declared type, read the field you mean ('. v field'), or declare the function to return this type.` ) ) }
+        {}
         // Return the wrong named struct by value (the return-position dual of
         // the call-site struct check): `^ b` from a `→ A` fn where b is a B.
         ? ( __arg_named_struct_mismatch lt fn_rt )
@@ -8173,8 +8190,21 @@
     // skip explicit against a same-named local.
     // `ar_s` is `?` when scan_fn_sigs saw conflicting definitions of
     // the name (different parameter counts) — skip the check then.
-    : s ar_s ( nurl_sym_get2 syms fname `__arity` )
-    ? & & & & ( seq call_name fname ) ! is_variadic
+    // The generic skip is gone: `( vec_push [i] v )` — one argument
+    // short — was accepted, because a generic call has call_name !=
+    // fname and the whole check was conditioned on them being equal.
+    // The guard was unnecessary: when a callee has no `__arity` entry
+    // the length test below already skips it, so a generic that
+    // registered one is simply checked like everything else, and one
+    // that did not is no worse off than before. Found by
+    // tools/metamorph's invalid-input class.
+    // A generic call (call_name is the mangled name) is measured
+    // against the TEMPLATE's count; anything else against the
+    // ordinary one. Keeping them apart is what lets a file shadow an
+    // imported generic with a non-generic function of the same name.
+    : s ar_s ? ( seq call_name fname ) ( nurl_sym_get2 syms fname `__arity` )
+    ( nurl_sym_get2 syms fname `__garity` )
+    ? & & & ! is_variadic
     != 0 ( nurl_str_len ar_s ) ! ( seq ar_s `?` )
     == 0 ( nurl_sym_len2 syms fname `__ptr` )
     { : i ar_want ( nurl_str_to_int ar_s )
@@ -19546,6 +19576,20 @@
         // Auto-sink inference over the body — a generic body is never
         // compiled here, so the codegen-time inference cannot see it.
         = sa ( generic_body_auto_sink lexp syms pnames sa )
+        // The template's parameter COUNT, so the call site's arity
+        // check has something to compare against: a generic was the one
+        // callee shape that could be called with the wrong number of
+        // arguments and say nothing (`( vec_push [i] v )`, one short,
+        // was accepted). The walk above already counted them.
+        //
+        // Under `__garity`, NOT `__arity`. A file may define its own
+        // non-generic function with the same name as an imported
+        // generic — compiler/tests/ws_permessage_deflate.nu has a
+        // 2-parameter `vec_eq` beside the stdlib's 3-parameter generic
+        // one — and writing the template's count into the shared key
+        // made every call to the LOCAL function look one argument
+        // short. Two namespaces, no clobber.
+        ( nurl_sym_def syms ( nurl_str_cat fname `__garity` ) ( nurl_str_int pc ) )
         ( nurl_sym_def g_fn_inout fname ia )
         ( nurl_sym_def g_fn_sink fname sa )
         ( nurl_lex_free lexp )

--- a/compiler/tests/diag_ret_struct_and_generic_arity.nu
+++ b/compiler/tests/diag_ret_struct_and_generic_arity.nu
@@ -1,0 +1,47 @@
+// diag_ret_struct_and_generic_arity.nu — two shapes that reached past
+// nurlc, both found by tools/metamorph's invalid-input class.
+//
+// 1. RETURNING A HANDLE WHERE A NUMBER IS DECLARED. `^ ( vec_new [i] )`
+//    from a `→ i` function lowered `ret %Vec__i64 %r1` out of a
+//    `define i64`, so nurlc exited 0 and the LLVM verifier reported
+//    "value doesn't match function result type" against generated IR.
+//    The return-type chain asked about every pair of shapes it knew —
+//    float/float, int/int, `{…}`/`{…}`, struct/struct, int/enum — and a
+//    struct beside a plain number matched none of them, so it fell
+//    through to the emit.
+//
+// 2. A GENERIC CALLED WITH THE WRONG NUMBER OF ARGUMENTS. The call-site
+//    arity check was conditioned on `call_name == fname`, which is false
+//    for a generic (call_name is the mangled name), and generics
+//    recorded no parameter count anyway. `( vec_push [i] v )` — one
+//    argument short — was accepted. A missing argument reads an unset
+//    ABI register, which is the same silent failure the FFI arity check
+//    exists to prevent.
+//
+//    The count is recorded under `__garity`, not `__arity`: a file may
+//    define its own non-generic function with the same name as an
+//    imported generic (compiler/tests/ws_permessage_deflate.nu has a
+//    2-parameter `vec_eq` beside the stdlib's 3-parameter generic one),
+//    and writing the template's count into the shared key made every
+//    call to the LOCAL function look one argument short. That false
+//    positive is why the two keys are separate.
+//
+// Two functions, because recovery is per declaration: one error each.
+
+$ `stdlib/core/vec.nu`
+
+@ returns_a_handle_as_a_number → i {
+    ^ ( vec_new [i] )
+}
+
+@ generic_missing_an_argument → i {
+    : ( Vec i ) v ( vec_new [i] )
+    ( vec_push [i] v )
+    ^ 0
+}
+
+@ main → i {
+    : i a ( returns_a_handle_as_a_number )
+    : i b ( generic_missing_an_argument )
+    ^ + a b
+}

--- a/compiler/tests/outputs/diag_ret_struct_and_generic_arity.txt
+++ b/compiler/tests/outputs/diag_ret_struct_and_generic_arity.txt
@@ -1,0 +1,8 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_ret_struct_and_generic_arity.nu:34:5: error: return value type 'Vec__i64' does not match the declared return type 'i' — a struct/handle value is not a number and does not convert to one. Return the declared type, read the field you mean ('. v field'), or declare the function to return this type.
+compiler/tests/diag_ret_struct_and_generic_arity.nu:39:22: error: call to 'vec_push' has the wrong number of arguments: expected 2, got 1 — every NURL operator has fixed arity, so a missing or extra argument shifts every token after it; check this call.
+    ( vec_push [i] v )
+                     ^
+error: aborting due to 2 previous errors
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/tools/metamorph/spellings.py
+++ b/tools/metamorph/spellings.py
@@ -403,6 +403,62 @@ CLASSES = [
         },
     },
     {
+        "name": "invalid-input",
+        "severity": "invalid-ir",
+        "doc": "Programs that are simply WRONG. A different axis from "
+               "the rest of this file: not 'the same situation spelled N "
+               "ways' but 'bad input must be diagnosed, never lowered'. "
+               "Two shipped bugs escaped exactly here — #901 lowered a "
+               "type-mismatched option payload and #906 lowered a match "
+               "arm naming a variant that does not exist — and in both "
+               "cases nurlc exited 0 and clang reported the problem, "
+               "about generated IR rather than about the line to fix. "
+               "Every spelling must produce a NURL diagnostic; and the "
+               "universal IR check above catches any that is lowered "
+               "anyway, whatever this class concludes.",
+        "expect": REJECT_DEFAULT,
+        "spellings": {
+            "match-arm-rust-habit": prog(
+                "    : i n ?? ( int_parse `12` ) { Ok v → v  _ → -1 }\n"
+                "    ( nurl_print_int n )", prelude="$ `stdlib/std/int`\n"),
+            "match-arm-unknown-variant": prog(
+                "    : Color c Red\n"
+                "    : i n ?? c { Red → 1  Purple → 2  _ → 0 }\n"
+                "    ( nurl_print_int n )",
+                prelude="", extra=": | Color { Red Green Blue }\n"),
+            "payload-int-into-string": prog(
+                "    : ?s o @ ?s { T 42 }\n"
+                "    ?? o { T v → ^ 1  F → ^ 0 }", prelude=""),
+            "payload-string-into-int": prog(
+                "    : ?i o @ ?i { T `x` }\n"
+                "    ?? o { T v → ^ v  F → ^ 0 }", prelude=""),
+            "cast-to-a-binding": prog(
+                "    : ~ i d 2\n"
+                "    = d # d + d 1", prelude=""),
+            "cast-aggregate-to-float": prog(
+                "    : ?i o @ ?i { T 1 }\n"
+                "    : f x # f o\n"
+                "    ( nurl_print_int # i x )", prelude=""),
+            "unknown-function": prog(
+                "    ( no_such_function_here 1 )", prelude=""),
+            "assign-to-immutable": prog(
+                "    : i k 1\n"
+                "    = k 2\n"
+                "    ( nurl_print_int k )", prelude=""),
+            "return-type-mismatch": prog(
+                "    ^ ( vec_new [i] )"),
+            "aggregate-literal-on-pointer": prog(
+                "    : *i p @ *i { 1 }\n"
+                "    ( nurl_print_int # i p )", prelude=""),
+            "string-into-int-binding": prog(
+                "    : i k `x`\n"
+                "    ( nurl_print_int k )", prelude=""),
+            "wrong-arg-count": prog(
+                "    : ( Vec i ) v ( vec_new [i] )\n"
+                "    ( vec_push [i] v )"),
+        },
+    },
+    {
         "name": "controls",
         "doc": "Correct programs. A class of its own because a checker "
                "that rejects these is worse than one that misses a bug — "
@@ -503,6 +559,34 @@ def compile_verdict(src_path, strict):
 
 
 INVALID = "invalid"          # the template is broken, not the compiler
+
+
+def ir_is_valid(src_path):
+    """Does the module nurlc just emitted actually verify?
+
+    The strongest invariant this harness has, and the one two shipped
+    bugs broke: **whenever nurlc exits 0, the IR must be valid.** #901
+    emitted `insertvalue { i1, i8* } …, i64 42, 1` and #906 emitted
+    `alloca` with no type plus a load from a global that was never
+    defined — both times nurlc reported success and clang delivered the
+    news, about generated IR rather than about the line to change.
+
+    Unlike everything else here this is never a template bug. Whatever
+    a program says, if the compiler accepted it then the module it
+    produced has to verify; a failure is the compiler's, always."""
+    with tempfile.TemporaryDirectory() as td:
+        ll = pathlib.Path(td) / "m.ll"
+        r = subprocess.run([str(NURLC), str(src_path)],
+                           stdout=open(ll, "wb"), stderr=subprocess.DEVNULL,
+                           cwd=ROOT)
+        if r.returncode != 0:
+            return True, ""          # rejected: nothing was emitted to verify
+        v = subprocess.run(["llvm-as", str(ll), "-o", "/dev/null"],
+                           capture_output=True, cwd=ROOT)
+        if v.returncode == 0:
+            return True, ""
+        err = v.stderr.decode("utf-8", "replace").strip().splitlines()
+        return False, (err[0][:110] if err else "llvm-as rejected the module")
 
 
 def verdict_of(src_path, want_msg, default_only=False):
@@ -627,6 +711,7 @@ def main():
         known = {tuple(x) for x in json.loads(KNOWN.read_text())["gaps"]}
 
     gaps, new_gaps, control_breaks, found, invalid = [], [], [], [], []
+    bad_ir = []
     tmp = pathlib.Path(tempfile.mkdtemp(prefix="nurl-metamorph-"))
 
     for cls in CLASSES:
@@ -648,6 +733,14 @@ def main():
             # correct code compiles clean, so `reject` fails it. Using
             # `>=` here let a false positive pass as "better than asked",
             # which is the one direction this class exists to catch.
+            # The universal invariant, checked for EVERY spelling the
+            # compiler accepted, whatever its class says: an accepted
+            # program must produce a module that verifies. This is never
+            # a template bug — see ir_is_valid.
+            if got in (ACCEPT, WARN):
+                ir_ok, ir_why = ir_is_valid(p)
+                if not ir_ok:
+                    bad_ir.append((cls["name"], name, ir_why))
             ok = (got == ACCEPT) if want == ACCEPT \
                 else STRENGTH[got] >= STRENGTH[want]
             mark = "ok " if ok else "GAP"
@@ -682,17 +775,21 @@ def main():
 
     print(f"\n── summary: {len(gaps)} gap(s), {len(new_gaps)} new, "
           f"{len(control_breaks)} control regression(s), "
-          f"{len(invalid)} invalid template(s)")
+          f"{len(invalid)} invalid template(s), "
+          f"{len(bad_ir)} invalid-IR escape(s)")
     for c, n in invalid:
         print(f"   INVALID    {c}/{n}: fix the template")
+    for c, n, why in bad_ir:
+        print(f"   INVALID IR {c}/{n}: nurlc exited 0 but the module does "
+              f"not verify\n              {why}")
     for c, n, g in control_breaks:
         print(f"   REGRESSION {c}/{n}: correct code now rejected ({g})")
     for c, n in new_gaps:
         print(f"   NEW GAP    {c}/{n}")
     if args.verify:
         print("\n── worklist (most severe first)")
-        rank = {"memory-unsafety": 0, "silent-wrong-value": 1,
-                "diagnostic-consistency": 2}
+        rank = {"invalid-ir": 0, "memory-unsafety": 1,
+                "silent-wrong-value": 2, "diagnostic-consistency": 3}
         sev_of = {c["name"]: c.get("severity", "unknown") for c in CLASSES}
         confirmed = {(c, n): why for c, n, why in found}
         rows = sorted(gaps, key=lambda g: (rank.get(sev_of.get(g[0]), 9), g[0]))
@@ -704,7 +801,7 @@ def main():
             print(f"   [{sev_of.get(c,'?'):22}] {c}/{n}\n"
                   f"       {state}")
 
-    return 1 if (new_gaps or control_breaks or invalid) else 0
+    return 1 if (new_gaps or control_breaks or invalid or bad_ir) else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
You asked for a way to dig these out. This is it, and it found two on the first run.

## The new axis

The classes so far ask *"the same situation spelled N ways — does the verdict agree?"*. This adds the other question: **bad input must be diagnosed, never lowered.**

The stronger half is an invariant that applies to **every** spelling in every class, not just the new one:

> whenever nurlc exits 0, the module must pass the LLVM verifier

Unlike everything else in the harness, this is **never a template bug**. Whatever a program says, if the compiler accepted it then what it emitted has to verify. Checked with `llvm-as`, which costs nothing.

That is precisely what #901 and #906 violated — and what "code escaping to clang" means in practice.

## Two escapes, found immediately

**1. Returning a handle where a number is declared**

```nurl
@ main → i { ^ ( vec_new [i] ) }
```
→ `ret %Vec__i64 %r1` out of a `define i64`; `llvm-as: value doesn't match function result type 'i64'`.

The return-type chain asked about every pair of shapes it knew — float/float, int/int, `{…}`/`{…}`, struct/struct, int/enum — and a struct beside a plain number matched none of them, so it fell through to the emit.

**2. A generic called with the wrong number of arguments**

```nurl
( vec_push [i] v )        // one argument short — accepted
```

The arity check was conditioned on `call_name == fname`, false for a generic, and generics recorded no parameter count anyway. A missing argument reads an unset ABI register — the same silent failure the FFI arity check exists to prevent.

## The second fix took two attempts

Worth recording, because the first attempt was mine and I misread it.

Writing the template's count into the shared `__arity` key made every call to a **local** function of the same name look one argument short — `ws_permessage_deflate.nu` defines its own 2-parameter `vec_eq` beside the stdlib's 3-parameter generic one.

I read that failure as a latent bug in the test and "fixed" the test. It was my regression. The count now lives under `__garity`, and the call site consults it only for calls that are actually generic — so a file can still shadow an imported generic.

## Verification

| gate | result |
|---|---|
| test corpus | 808 PASS · 0 FAIL |
| ASan/UBSan corpus | 807 PASS · 0 SAN_FAIL |
| `leakgate.sh` | zero leaks, both emission modes |
| examples | 100 PASS · 0 FAIL |
| stdlib + examples + 320 package files | zero acceptance change |
| corpus IR | 534 byte-identical, 0 differ |
| metamorph | 0 new gaps · 0 control regressions · **0 invalid-IR escapes** |

## On the broader question

Fuzzing this area further has diminishing returns: `tools/fuzz` already hunts wrong *values* against an oracle, and the bugs you have been hitting are not wrong values — they are inputs the compiler should have refused. Those are found by enumerating what a writer plausibly gets wrong and asserting a NURL diagnostic comes back, which is what this class now does. The IR-validity invariant is the backstop underneath it: it cannot enumerate anything, but nothing that gets lowered can escape it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU
