### PR TITLE
nurlc: a user enum's numeric payload slot rejects a pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A user enum's payload slot is a number, and a pointer folded into
+  it is read back as arithmetic.** The option/result form of this was
+  fixed earlier; the user-enum side kept the hole. `@ E { A `s` }` where
+  `A` declares an `i` payload compiled clean, linked, ran, and returned
+  **96** — the low byte of a `.rodata` address — from an arm the writer
+  expected to yield a number.
+
+  `docs/MEMORY.md` has carried a "user enums: SCALAR payloads only"
+  gotcha for exactly this. A gotcha in prose is what a compiler says
+  when it has no diagnostic; this is the diagnostic.
+
+  Found by `tools/metamorph`'s invalid-input class — and *not* by its
+  IR-validity invariant, because the emitted module verifies fine. It is
+  a wrong value, not malformed IR, which is why that class enumerates
+  plausible-wrong inputs as well as checking what gets lowered.
+  (`diag_enum_payload_ptr_into_int`)
+
+### Added
+
+- **Two measured semantics pinned as `tools/metamorph` controls.** Both
+  were suspected bugs and turned out to be defined behaviour, so they
+  are now guarded against silent drift rather than "fixed": a partially
+  filled struct literal **zero-fills** (the aggregate starts as
+  `zeroinitializer` — `@ P { 7 }` gives `7, 0, 0`, not garbage), and a
+  match arm may bind a **prefix** of a variant's payloads and ignore the
+  rest. An under-fill check written before measuring rejected the first
+  and broke five tests that rely on it deliberately.
+
 ### Added
 
 - **`tools/metamorph` gains an `invalid-input` class and an IR-validity

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -16743,6 +16743,30 @@
 
                 ? is_enum
                 {  // enum payload: convert values to the uniform i64 slot
+                    // …but only for values that BELONG in a numeric slot.
+                    // The slot is uniformly i64 by design and the arm
+                    // reads it back as the variant's declared type, so a
+                    // pointer folded in here is read as arithmetic:
+                    // `@ E { A `s` }` where A's payload is `i` returned
+                    // 96 — the low byte of a .rodata address — from an
+                    // arm the writer expected to yield a number. The
+                    // option/result twin of this was fixed in #901; the
+                    // user-enum side kept the hole, and docs/MEMORY.md
+                    // has carried a "user enums: SCALAR payloads only"
+                    // gotcha rather than a diagnostic. Found by
+                    // tools/metamorph's invalid-input class.
+                    : s __ep_decl ? & != 0 ( nurl_str_len enum_vname ) >= idx 1
+                    ( nurl_sym_get syms ( nurl_str_cat3 enum_vname `__payload__` ( nurl_str_int - idx 1 ) ) )
+                    ( nurl_str_cat `` `` )
+                    ? & & != 0 ( nurl_str_len __ep_decl )
+                    | ( seq fty `sref` ) ( is_ptr_ty fty )
+                    > ( int_width __ep_decl ) 0
+                    { ( die lex ( nurl_str_cat4
+                        ( nurl_str_cat3 `payload ` ( nurl_str_int idx ) ` of enum variant '` )
+                        ( nurl_str_cat3 enum_vname `' is a pointer/string, but the variant declares it as '` ( llvm_to_nurl __ep_decl ) )
+                        `', a number. The payload slot is a numeric word and the '??' arm reads it back as that type, so the address would be returned as arithmetic. `
+                        `Declare the payload as the type you are storing, or store a number.` ) ) }
+                    {}
                     ? ( seq fty `i1` )
                     {  // Convert boolean to i64
                         : s conv_reg1 ( nurl_cg_reg cg )

--- a/compiler/tests/diag_enum_payload_ptr_into_int.nu
+++ b/compiler/tests/diag_enum_payload_ptr_into_int.nu
@@ -1,0 +1,23 @@
+// diag_enum_payload_ptr_into_int.nu — a user enum's payload slot is a
+// numeric word, and a pointer folded into it is read back as arithmetic.
+//
+// The option/result form of this was fixed in #901; the user-enum side
+// kept the hole. `@ E { A `s` }` where A declares an `i` payload
+// compiled clean, linked, ran, and returned 96 — the low byte of a
+// .rodata address — from an arm the writer expected to yield a number.
+//
+// docs/MEMORY.md has carried a "user enums: SCALAR payloads only"
+// gotcha for exactly this. A gotcha in prose is what a compiler says
+// when it has no diagnostic; this is the diagnostic.
+//
+// Found by tools/metamorph's invalid-input class, whose IR-validity
+// invariant did NOT catch it — the emitted module verifies fine. It is
+// a wrong VALUE, not malformed IR, which is why the class enumerates
+// plausible-wrong inputs as well as checking what gets lowered.
+
+: | E { A i B }
+
+@ main → i {
+    : E e @ E { A `s` }
+    ^ ?? e { A v → v B → 0 }
+}

--- a/compiler/tests/http_server_limits.nu
+++ b/compiler/tests/http_server_limits.nu
@@ -45,7 +45,7 @@ $ `stdlib/ext/http_server.nu`
             // Build a request with one large X-Big header that pushes the
             // head past 256 bytes. python3 client extracts the status line.
             : s shell_cmd
-            `python3 -c "import socket,sys
+            `rm -f /tmp/http_server_limits1.out /tmp/http_server_limits1.part; { python3 -c "import socket,sys
 s=socket.socket();s.connect(('127.0.0.1',18770))
 big='X'*600
 req='GET / HTTP/1.1\\r\\nHost: t\\r\\nX-Big: '+big+'\\r\\n\\r\\n'
@@ -57,7 +57,7 @@ while True:
     if not c: break
     buf+=c
 first=buf.split(b'\\r\\n',1)[0].decode('latin-1')
-sys.stdout.write('case1_status='+first+chr(10))" > /tmp/http_server_limits1.out 2>&1 & echo $! > /tmp/http_server_limits1.pid; sleep 0.10`
+sys.stdout.write('case1_status='+first+chr(10))" > /tmp/http_server_limits1.part 2>&1; mv /tmp/http_server_limits1.part /tmp/http_server_limits1.out; } >/dev/null 2>&1 &`
             : !Output ProcessErr bg ( process_run_shell shell_cmd )
             ?? bg {
                 T bgo → ( output_free bgo )
@@ -74,7 +74,7 @@ sys.stdout.write('case1_status='+first+chr(10))" > /tmp/http_server_limits1.out 
             }
             ( server_stop srv )
 
-            : !Output ProcessErr wait_r ( process_run_shell `wait $(cat /tmp/http_server_limits1.pid 2>/dev/null) 2>/dev/null; cat /tmp/http_server_limits1.out` )
+            : !Output ProcessErr wait_r ( process_run_shell `for _ in $(seq 1 200); do [ -f /tmp/http_server_limits1.out ] && break; sleep 0.05; done; cat /tmp/http_server_limits1.out 2>/dev/null` )
             ?? wait_r {
                 T wo → { ( nurl_print ( output_stdout wo ) ) ( output_free wo ) }
                 F e → ( println_label `case1_wait` ( process_err_name e ) )
@@ -91,7 +91,7 @@ sys.stdout.write('case1_status='+first+chr(10))" > /tmp/http_server_limits1.out 
     ?? lr {
         T listener → {
             : s shell_cmd
-            `python3 -c "import socket,sys
+            `rm -f /tmp/http_server_limits2.out /tmp/http_server_limits2.part; { python3 -c "import socket,sys
 s=socket.socket();s.connect(('127.0.0.1',18771))
 s.sendall(b'GET / HTTP/1.1\\r\\nHost: t\\r\\n\\r\\n')
 s.shutdown(socket.SHUT_WR)
@@ -101,7 +101,7 @@ while True:
     if not c: break
     buf+=c
 first=buf.split(b'\\r\\n',1)[0].decode('latin-1')
-sys.stdout.write('case2_status='+first+chr(10))" > /tmp/http_server_limits2.out 2>&1 & echo $! > /tmp/http_server_limits2.pid; sleep 0.10`
+sys.stdout.write('case2_status='+first+chr(10))" > /tmp/http_server_limits2.part 2>&1; mv /tmp/http_server_limits2.part /tmp/http_server_limits2.out; } >/dev/null 2>&1 &`
             : !Output ProcessErr bg ( process_run_shell shell_cmd )
             ?? bg {
                 T bgo → ( output_free bgo )
@@ -118,7 +118,7 @@ sys.stdout.write('case2_status='+first+chr(10))" > /tmp/http_server_limits2.out 
             }
             ( server_stop srv )
 
-            : !Output ProcessErr wait_r ( process_run_shell `wait $(cat /tmp/http_server_limits2.pid 2>/dev/null) 2>/dev/null; cat /tmp/http_server_limits2.out` )
+            : !Output ProcessErr wait_r ( process_run_shell `for _ in $(seq 1 200); do [ -f /tmp/http_server_limits2.out ] && break; sleep 0.05; done; cat /tmp/http_server_limits2.out 2>/dev/null` )
             ?? wait_r {
                 T wo → { ( nurl_print ( output_stdout wo ) ) ( output_free wo ) }
                 F e → ( println_label `case2_wait` ( process_err_name e ) )

--- a/compiler/tests/http_server_seq.nu
+++ b/compiler/tests/http_server_seq.nu
@@ -77,7 +77,7 @@ $ `stdlib/ext/http_server.nu`
             //    `-w '\nstatus=%{http_code}'` so we can see curl's view of
             //    the response status as a separate line.
             : s shell_cmd
-            `curl -s --max-time 2 -X POST -H 'X-From: nurl-test' --data 'hello srv' http://127.0.0.1:18766/echo > /tmp/http_server_seq_client.out 2>&1 & echo $! > /tmp/http_server_seq_client.pid; sleep 0.05`
+            `rm -f /tmp/http_server_seq_client.out /tmp/http_server_seq_client.part; { curl -s --max-time 2 -X POST -H 'X-From: nurl-test' --data 'hello srv' http://127.0.0.1:18766/echo > /tmp/http_server_seq_client.part 2>&1; mv /tmp/http_server_seq_client.part /tmp/http_server_seq_client.out; } >/dev/null 2>&1 &`
             : !Output ProcessErr bg ( process_run_shell shell_cmd )
             ?? bg {
                 T bgo → ( output_free bgo )
@@ -98,7 +98,7 @@ $ `stdlib/ext/http_server.nu`
             ( server_stop srv )
 
             // 4. Reap the curl client and dump what it saw.
-            : !Output ProcessErr wait_r ( process_run_shell `wait $(cat /tmp/http_server_seq_client.pid 2>/dev/null) 2>/dev/null; cat /tmp/http_server_seq_client.out` )
+            : !Output ProcessErr wait_r ( process_run_shell `for _ in $(seq 1 200); do [ -f /tmp/http_server_seq_client.out ] && break; sleep 0.05; done; cat /tmp/http_server_seq_client.out 2>/dev/null` )
             ?? wait_r {
                 T wo → {
                     : s client_out ( output_stdout wo )

--- a/compiler/tests/http_server_tls.nu
+++ b/compiler/tests/http_server_tls.nu
@@ -51,7 +51,7 @@ $ `stdlib/ext/http_server.nu`
     ?? lr {
         T listener → {
             : s shell_cmd
-            `python3 -c "import ssl,socket,sys
+            `rm -f /tmp/http_server_tls_client.out /tmp/http_server_tls_client.part; { python3 -c "import ssl,socket,sys
 ctx=ssl.create_default_context()
 ctx.check_hostname=False
 ctx.verify_mode=ssl.CERT_NONE
@@ -66,7 +66,7 @@ while True:
 first=buf.split(b'\\r\\n',1)[0].decode('latin-1')
 body=buf.rsplit(b'\\r\\n\\r\\n',1)[-1].decode('latin-1',errors='replace')
 sys.stdout.write('tls_status='+first+chr(10))
-sys.stdout.write('tls_body='+body)" > /tmp/http_server_tls_client.out 2>&1 & echo $! > /tmp/http_server_tls_client.pid; sleep 0.20`
+sys.stdout.write('tls_body='+body)" > /tmp/http_server_tls_client.part 2>&1; mv /tmp/http_server_tls_client.part /tmp/http_server_tls_client.out; } >/dev/null 2>&1 &`
             : !Output ProcessErr bg ( process_run_shell shell_cmd )
             ?? bg {
                 T bgo → ( output_free bgo )
@@ -82,7 +82,7 @@ sys.stdout.write('tls_body='+body)" > /tmp/http_server_tls_client.out 2>&1 & ech
             }
             ( server_stop srv )
 
-            : !Output ProcessErr wait_r ( process_run_shell `wait $(cat /tmp/http_server_tls_client.pid 2>/dev/null) 2>/dev/null; cat /tmp/http_server_tls_client.out` )
+            : !Output ProcessErr wait_r ( process_run_shell `for _ in $(seq 1 200); do [ -f /tmp/http_server_tls_client.out ] && break; sleep 0.05; done; cat /tmp/http_server_tls_client.out 2>/dev/null` )
             ?? wait_r {
                 T wo → { ( nurl_print ( output_stdout wo ) ) ( output_free wo ) }
                 F e → ( println_label `wait_client` ( process_err_name e ) )

--- a/compiler/tests/net_loopback.nu
+++ b/compiler/tests/net_loopback.nu
@@ -100,7 +100,7 @@ sys.stdout.write(buf.decode())
             //    Capture the bg pid via a temp file the wrapper writes.
             : s pyclient ( python_client_src )
             : s shell_cmd ( nurl_str_cat3
-            `python3 -c "$NURL_PYCLIENT" > /tmp/net_loopback_client.out 2> /tmp/net_loopback_client.err & echo $! > /tmp/net_loopback_client.pid; sleep 0.05`
+            `rm -f /tmp/net_loopback_client.out /tmp/net_loopback_client.part; { python3 -c "$NURL_PYCLIENT" > /tmp/net_loopback_client.part 2> /tmp/net_loopback_client.err; mv /tmp/net_loopback_client.part /tmp/net_loopback_client.out; } >/dev/null 2>&1 &`
             ``
             `` )
             // Stash python source in env so quoting stays simple.
@@ -142,7 +142,7 @@ sys.stdout.write(buf.decode())
             ( tcp_close_listener listener )
 
             // 6. Reap the bg client + verify it printed "pong".
-            : !Output ProcessErr wait_r ( process_run_shell `wait $(cat /tmp/net_loopback_client.pid 2>/dev/null) 2>/dev/null; cat /tmp/net_loopback_client.out` )
+            : !Output ProcessErr wait_r ( process_run_shell `for _ in $(seq 1 200); do [ -f /tmp/net_loopback_client.out ] && break; sleep 0.05; done; cat /tmp/net_loopback_client.out 2>/dev/null` )
             ?? wait_r {
                 T wo → {
                     : s client_out ( output_stdout wo )

--- a/compiler/tests/outputs/diag_enum_payload_ptr_into_int.txt
+++ b/compiler/tests/outputs/diag_enum_payload_ptr_into_int.txt
@@ -1,0 +1,7 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_enum_payload_ptr_into_int.nu:21:23: error: payload 1 of enum variant 'A' is a pointer/string, but the variant declares it as 'i', a number. The payload slot is a numeric word and the '??' arm reads it back as that type, so the address would be returned as arithmetic. Declare the payload as the type you are storing, or store a number.
+    : E e @ E { A `s` }
+                      ^
+error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/tls_large_record.nu
+++ b/compiler/tests/tls_large_record.nu
@@ -54,7 +54,7 @@ $ `stdlib/ext/http_server.nu`
     ?? lr {
         T listener → {
             : s shell_cmd
-            `python3 -c "import ssl,socket,sys
+            `rm -f /tmp/nurl_tls_large_record.out /tmp/nurl_tls_large_record.part; { python3 -c "import ssl,socket,sys
 ctx=ssl.create_default_context()
 ctx.check_hostname=False
 ctx.verify_mode=ssl.CERT_NONE
@@ -68,7 +68,7 @@ while True:
     buf+=c
 body=buf.rsplit(b'\\r\\n\\r\\n',1)[-1]
 sys.stdout.write('body_len='+str(len(body))+chr(10))
-sys.stdout.write('body_ok='+str(body==b'0123456789'*10000)+chr(10))" > /tmp/nurl_tls_large_record.out 2>&1 & echo $! > /tmp/nurl_tls_large_record.pid; sleep 0.20`
+sys.stdout.write('body_ok='+str(body==b'0123456789'*10000)+chr(10))" > /tmp/nurl_tls_large_record.part 2>&1; mv /tmp/nurl_tls_large_record.part /tmp/nurl_tls_large_record.out; } >/dev/null 2>&1 &`
             : !Output ProcessErr bg ( process_run_shell shell_cmd )
             ?? bg {
                 T bgo → ( output_free bgo )
@@ -84,7 +84,7 @@ sys.stdout.write('body_ok='+str(body==b'0123456789'*10000)+chr(10))" > /tmp/nurl
             }
             ( server_stop srv )
 
-            : !Output ProcessErr wait_r ( process_run_shell `wait $(cat /tmp/nurl_tls_large_record.pid 2>/dev/null) 2>/dev/null; cat /tmp/nurl_tls_large_record.out` )
+            : !Output ProcessErr wait_r ( process_run_shell `for _ in $(seq 1 200); do [ -f /tmp/nurl_tls_large_record.out ] && break; sleep 0.05; done; cat /tmp/nurl_tls_large_record.out 2>/dev/null` )
             ?? wait_r {
                 T wo → { ( nurl_print ( output_stdout wo ) ) ( output_free wo ) }
                 F e → ( println_label `wait_client` ( process_err_name e ) )

--- a/tools/metamorph/spellings.py
+++ b/tools/metamorph/spellings.py
@@ -453,6 +453,10 @@ CLASSES = [
             "string-into-int-binding": prog(
                 "    : i k `x`\n"
                 "    ( nurl_print_int k )", prelude=""),
+            "enum-payload-string-into-int": prog(
+                "    : E e @ E { A `s` }\n"
+                "    ^ ?? e { A v → v  B → 0 }",
+                prelude="", extra=": | E { A i  B }\n"),
             "wrong-arg-count": prog(
                 "    : ( Vec i ) v ( vec_new [i] )\n"
                 "    ( vec_push [i] v )"),
@@ -538,6 +542,22 @@ CLASSES = [
                 "    ( vec_push [i] xs 1 )\n"
                 "    ~ y xs { ( nurl_print ( nurl_str_int y ) ) }\n"
                 "    ( vec_free [i] xs )"),
+            # Both of these were SUSPECTED bugs and measured to be
+            # defined behaviour. They are controls now so the semantics
+            # cannot drift silently: a partially-filled struct literal
+            # zero-fills (the aggregate starts as `zeroinitializer`,
+            # giving 7/0/0 rather than garbage), and a match arm may bind
+            # a PREFIX of a variant's payloads and ignore the rest.
+            # An earlier draft of an under-fill check rejected the first
+            # and broke five tests that use it deliberately.
+            "struct-partial-init": prog(
+                "    : P p @ P { 7 }\n"
+                "    ( nurl_print_int . p z )",
+                prelude="", extra=": P { i x  i y  i z }\n"),
+            "match-binds-payload-prefix": prog(
+                "    : E e @ E { A 11 22 }\n"
+                "    ^ ?? e { A x → x  B → 0 }",
+                prelude="", extra=": | E { A i i  B }\n"),
             "option-payload-matches": prog(
                 "    : ?i o @ ?i { T 42 }\n"
                 "    ?? o { T v → ^ v  F → ^ 0 }", prelude=""),


### PR DESCRIPTION
## The bug

The option/result form of this was fixed in #901. The **user-enum** side kept the hole:

```nurl
: | E { A i  B }
@ main → i {
    : E e @ E { A `s` }        // A declares an `i` payload
    ^ ?? e { A v → v  B → 0 }
}
```

Compiled clean, linked, ran — and returned **96**, the low byte of a `.rodata` address, from an arm the writer expected to yield a number.

`docs/MEMORY.md` has carried a *"user enums: SCALAR payloads only"* gotcha for exactly this. A gotcha in prose is what a compiler says when it has no diagnostic.

Notably this was **not** caught by the IR-validity invariant added in #907 — the emitted module verifies fine. It is a wrong *value*, not malformed IR, which is why the invalid-input class enumerates plausible-wrong inputs as well as checking what gets lowered.

## Two suspects that turned out to be correct

From the same 18-program sweep. Both are now **controls**, not fixes:

| suspected | measured |
|---|---|
| partial struct literal leaves garbage | **zero-fills** — the aggregate starts as `zeroinitializer`; `@ P { 7 }` gives `7, 0, 0` |
| match arm binding fewer names than payloads | **binds a prefix**, ignores the rest — returns 11 from `A 11 22` |

I wrote an under-fill check for the first *before* measuring it. It broke five tests that use partial init deliberately, and its message claimed the missing slots "would carry whatever the register held" — which is false. Reverted, and both semantics are pinned as controls so they cannot drift silently.

## On the yield

**1 real bug in 18 plausible-wrong programs, and 2 of my 3 suspicions were wrong.**

That is the useful signal from this round. The earlier sweeps found bugs at a much higher rate; this one did not, and the two misses were caught by measuring rather than by assuming. This area is no longer yielding easily.

## Verification

| gate | result |
|---|---|
| test corpus | 809 PASS · 0 FAIL |
| ASan/UBSan corpus | 809 PASS · 0 SAN_FAIL |
| `leakgate.sh` | zero leaks, both emission modes |
| examples | 100 PASS · 0 FAIL |
| stdlib + examples + 320 package files | zero acceptance change |
| corpus IR | 534 byte-identical, 0 differ |
| metamorph | 0 new gaps · 0 control regressions · 0 invalid-IR escapes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU
