### PR TITLE
nurlc: close the last two metamorph gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A struct/handle in a payload slot declared as a number.** The
+  pointer form was rejected earlier, and the user-enum form after that.
+  A `Vec` reaches the option/result payload path as `%Vec__i64` — a
+  *named struct*, not a raw pointer — so it took the struct-handle
+  branch, which folds the value to an i64 and hands it to the slot. The
+  `??` arm read it back as the declared type: `@ ?i { T d }` with a Vec
+  `d` returned **192**, the low byte of a heap address. Same lie as the
+  first two, one branch over.
+
+- **Mutating an iterated container one call deep.** A `~ x xs` foreach
+  holds a borrow of `xs` (§2.5) and the direct `( vec_push xs … )` in
+  the body has been rejected for a long time; the same push inside a
+  helper was not, which reads as "wrap it in a function" being a cure
+  for a borrow violation. A per-function summary records which
+  parameters' containers a body mutates, inferred in codegen order like
+  the sink / escape / shared-mutation summaries, and the call site
+  consults it. Measured, this shape is not memory-unsafe today — a Vec
+  is a handle to a control block, so a forced realloc mid-iteration does
+  not dangle — but a guard that applies to one spelling and not its twin
+  teaches the wrong cure.
+  (`diag_payload_struct_into_number`, `diag_foreach_mutate_one_call_deep`)
+
+  With these, `tools/metamorph` reports **zero gaps**: every spelling of
+  every class now gets the same verdict as its siblings.
+
+### Fixed
+
 - **A user enum's payload slot is a number, and a pointer folded into
   it is read back as arithmetic.** The option/result form of this was
   fixed earlier; the user-enum side kept the hole. `@ E { A `s` }` where

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -1215,6 +1215,16 @@
 // sink/escape summaries, so a helper defined above its caller is seen.
 : ~ i g_fn_arc_mut 0
 
+// Per-function container-mutation summary (docs/MEMORY.md §2.5).
+// `g_fn_mutates[fname]` lists the 0-based parameter indices whose
+// CONTAINER the body mutates. A `~ x xs` foreach holds a borrow of xs,
+// and `( grow xs )` inside the body invalidates it exactly as an inline
+// `( vec_push xs … )` does — the mutation simply moved one call away,
+// which is where the direct check stopped looking. Inferred in codegen
+// order like the sink / escape / arc summaries.
+: ~ i g_fn_mutates 0
+: ~ s g_fn_mutates_witness ``
+
 // Noreturn registry. `g_fn_noreturn[fname]` is `1` when a call to
 // fname never returns to its caller. Seeded with the runtime's true
 // noreturn primitives (nurl_exit, nurl_panic) and grown by inference in
@@ -7591,7 +7601,15 @@
             : b fe_iterated ( str_contains_word
             ( nurl_sym_get g_bck `iter_containers` ) bck_arg_root )
             : b fe_mutates & == arg_idx 0 ( bck_is_container_mutator fname )
-            ? & fe_iterated | is_inout_arg fe_mutates
+            // …or the callee is a HELPER whose summary says it mutates
+            // the container handed to this parameter. Passing an
+            // iterated container one call deep invalidates the loop's
+            // cursor exactly as an inline mutator does; without this the
+            // direct `( vec_push xs … )` warned and `( grow xs )` did
+            // not, which reads as "wrap it in a function" being a cure.
+            : b fe_helper_mutates ( str_contains_word
+            ( nurl_sym_get g_fn_mutates call_name ) ( nurl_str_int arg_idx ) )
+            ? & fe_iterated | is_inout_arg | fe_mutates fe_helper_mutates
             { ( bck_esc_warn lex bck_arg_line ( nurl_str_cat3
                 `cannot mutate '` bck_arg_root
                 `' while iterating over it — the '~' loop holds a borrow of the container; move the mutation out of the loop body` ) ) }
@@ -8291,6 +8309,23 @@
     //     thread_spawn call site decides, because only there is it known
     //     that this closure actually crosses a thread boundary — the same
     //     closure mutated on ONE thread is ordinary correct code.
+    // Container-mutation summary (§2.5): this function mutates the
+    // container it was handed — record which parameter, so a caller
+    // iterating that container is warned one call away. A global, not a
+    // symbol-table key: the mutation is usually inside a loop body and
+    // `nurl_sym_def` writes the innermost scope, so the flag would be
+    // popped with it (the trap that silently emptied the arc summary).
+    // Not gated on lock depth — a lock says nothing about a loop cursor.
+    ? & ( bck_is_container_mutator fname ) != 0 ( nurl_str_len __sm_a0 )
+    { : i __mu_i ( str_word_index ( nurl_sym_get syms `__fn_param_names__` ) __sm_a0 )
+        ? >= __mu_i 0
+        { : s __mu_w ( nurl_str_int __mu_i )
+            ? ( str_contains_word g_fn_mutates_witness __mu_w ) {}
+            { = g_fn_mutates_witness ? == 0 ( nurl_str_len g_fn_mutates_witness )
+                ( nurl_str_cat __mu_w `` )
+                ( nurl_str_cat3 g_fn_mutates_witness ` ` __mu_w ) } }
+        {} }
+    {}
     ? & & == g_lock_depth 0 ( bck_is_container_mutator fname )
     != 0 ( nurl_str_len __sm_a0 )
     { : s __sm_v ( nurl_str_cat __sm_a0 `` )
@@ -16497,7 +16532,26 @@
                         = actual_fty `i64`
                     }
                     ? == ( nurl_str_get fty 0 ) 37
-                    {  // Named type (starts with '%'). Only treat as struct
+                    {  // …but a struct has no business in a slot declared
+                        // as a NUMBER. Every path below folds the value to
+                        // an i64 — inline-f0, or a heap box — and the `??`
+                        // arm reads the slot back as the declared type, so
+                        // `@ ?i { T d }` with a Vec `d` returned 192, the
+                        // low byte of a heap address, from an arm the
+                        // writer expected to yield a number.
+                        //
+                        // The pointer form of this was rejected in #901;
+                        // a Vec reaches here as `%Vec__i64`, a NAMED
+                        // struct rather than a raw pointer, so that guard
+                        // did not see it. Same lie, one branch over.
+                        ? > ( int_width payload_ty ) 0
+                        { ( die lex ( nurl_str_cat4
+                            ( nurl_str_cat3 `payload of this option/result literal is a struct/handle ('` ( llvm_to_nurl fty ) `')` )
+                            ( nurl_str_cat3 ` but the declared payload type is '` ( llvm_to_nurl payload_ty ) `', a number` )
+                            `. The slot is a numeric word and the '?? T v →' arm reads it back as that type, so the handle would be returned as arithmetic. `
+                            `Declare the option/result over the type you are storing ('@ ?( Vec i ) { T v }'), or store a number.` ) ) }
+                        {}
+                        // Only treat as struct
                         // handle when the type is NOT an enum — enum payload
                         // slots in `! T E` should stay as the whole enum
                         // value (its i64 tag is extracted by the caller via
@@ -18305,6 +18359,8 @@
     // would be rejected — a false positive built out of a true fact.
     : s __cl_arcmut_saved ( nurl_str_cat g_fn_arc_mut_witness `` )
     = g_fn_arc_mut_witness ``
+    : s __cl_mut_saved ( nurl_str_cat g_fn_mutates_witness `` )
+    = g_fn_mutates_witness ``
     : i __cl_lock_saved g_lock_depth
     = g_lock_depth 0
     : s __cl_consumed_saved ( nurl_str_cat g_closure_consumed `` )
@@ -18342,6 +18398,7 @@
     : s __cl_tail_lt ( nurl_get_last_type )
     = g_bck_closure_depth - g_bck_closure_depth 1
     = g_fn_arc_mut_witness __cl_arcmut_saved
+    = g_fn_mutates_witness __cl_mut_saved
     = g_lock_depth __cl_lock_saved
     // Replay what the body consumed against what it CAPTURED: a
     // consumed capture is a handle this closure may free, so the
@@ -20383,6 +20440,9 @@
     // Shared-mutation summary (§6.5): set by gen_call if this body
     // mutates the contents of an arc_get result.
     = g_fn_arc_mut_witness ``
+    // Container-mutation summary (§2.5): which parameters' containers
+    // this body mutates.
+    = g_fn_mutates_witness ``
     = g_fn_ret_count 0
     : ~ s last ( gen_block_ret lex syms cg )
     // Type of the value the body actually falls off with. A body whose
@@ -20522,6 +20582,9 @@
     // is rejected too. Authoritative per function — the body is compiled.
     ? != 0 ( nurl_str_len g_fn_arc_mut_witness )
     { ( nurl_sym_def g_fn_arc_mut fname `1` ) }
+    {}
+    ? != 0 ( nurl_str_len g_fn_mutates_witness )
+    { ( nurl_sym_def g_fn_mutates fname g_fn_mutates_witness ) }
     {}
     // Implicit return — route through defer chain if defers are active
     : s dtop ( nurl_sym_get g_fn_escapes `__defer_top_fn__` )
@@ -26696,6 +26759,7 @@
     = g_fn_ret_param ( nurl_sym_new )
     = g_fn_ret_alias ( nurl_sym_new )
     = g_fn_arc_mut ( nurl_sym_new )
+    = g_fn_mutates ( nurl_sym_new )
     = g_fn_noreturn ( nurl_sym_new )
     ( nurl_sym_def g_fn_noreturn `nurl_exit` `1` )
     ( nurl_sym_def g_fn_noreturn `nurl_panic` `1` )
@@ -26848,6 +26912,7 @@
     ( nurl_sym_free g_fn_ret_param )
     ( nurl_sym_free g_fn_ret_alias )
     ( nurl_sym_free g_fn_arc_mut )
+    ( nurl_sym_free g_fn_mutates )
     ( nurl_sym_free g_pending_escape )
     ( nurl_sym_free g_bck )
     ( nurl_sym_free g_ptrtab )

--- a/compiler/tests/diag_foreach_mutate_one_call_deep.nu
+++ b/compiler/tests/diag_foreach_mutate_one_call_deep.nu
@@ -1,0 +1,37 @@
+// diag_foreach_mutate_one_call_deep.nu — mutating an iterated container
+// through a helper function.
+//
+// (Named "one_call_deep", not "via_helper": test_skips.sh skips any test
+// whose name ends in `_mod`, `_helper` or `_lib` as an importable
+// module with no main(), so the `_helper` spelling made this file
+// silently never run — it showed up only as the SKIP count moving.)
+//
+// A `~ x xs` foreach holds a borrow of xs (docs/MEMORY.md §2.5), and the
+// direct `( vec_push xs … )` inside the body has warned for a long time.
+// The same push one call away did not, which reads as "wrap it in a
+// function" being a cure for a borrow violation. A per-function summary
+// (`g_fn_mutates`) records which parameters' containers a body mutates,
+// inferred in codegen order like the sink / escape / arc summaries, and
+// the call site consults it.
+//
+// Rejected, matching the direct case exactly — the point is that both
+// spellings of one thing now get one answer.
+//
+// Measured, this shape is not memory-unsafe today: a Vec is a handle to
+// a control block and the loop reads through it, so a forced realloc
+// mid-iteration does not dangle, and both spellings return the correct
+// sum. §2.5 is a conservative guard, which is why tools/metamorph ranks
+// a gap here below anything that corrupts memory — but a guard that
+// applies to one spelling and not its twin teaches the wrong cure.
+
+$ `stdlib/core/vec.nu`
+
+@ grow ( Vec i ) v → v { ( vec_push [i] v 2 ) }
+
+@ main → i {
+    : ( Vec i ) xs ( vec_new [i] )
+    ( vec_push [i] xs 1 )
+    ~ y xs { ( grow xs ) }
+    ( vec_free [i] xs )
+    ^ 0
+}

--- a/compiler/tests/diag_payload_struct_into_number.nu
+++ b/compiler/tests/diag_payload_struct_into_number.nu
@@ -1,0 +1,24 @@
+// diag_payload_struct_into_number.nu — a struct/handle in a payload slot
+// declared as a number.
+//
+// The pointer form was rejected in #901 and the user-enum form in #908.
+// A `Vec` reaches the payload path as `%Vec__i64` — a NAMED struct, not
+// a raw pointer — so it took the struct-handle branch, which folds the
+// value to an i64 (inline-f0 or a heap box) and hands it to the slot.
+// The `??` arm then reads that slot back as the declared type:
+//
+//     : ?i o @ ?i { T d }        // d is a ( Vec i )
+//     ^ ?? o { T v → v  F → 0 }  // returned 192 — a heap address's low byte
+//
+// Same lie as #901, one branch over. Found by tools/metamorph, whose
+// IR-validity invariant does NOT catch it: the module verifies fine, the
+// VALUE is wrong.
+
+$ `stdlib/core/vec.nu`
+
+@ main → i {
+    : ( Vec i ) d ( vec_new [i] )
+    ( vec_push [i] d 7 )
+    : ?i o @ ?i { T d }
+    ^ ?? o { T v → v F → 0 }
+}

--- a/compiler/tests/outputs/diag_foreach_mutate_one_call_deep.txt
+++ b/compiler/tests/outputs/diag_foreach_mutate_one_call_deep.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_foreach_mutate_one_call_deep.nu:34: error: cannot mutate 'xs' while iterating over it — the '~' loop holds a borrow of the container; move the mutation out of the loop body
+    ~ y xs { ( grow xs ) }
+error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/diag_payload_struct_into_number.txt
+++ b/compiler/tests/outputs/diag_payload_struct_into_number.txt
@@ -1,0 +1,7 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_payload_struct_into_number.nu:22:23: error: payload of this option/result literal is a struct/handle ('Vec__i64') but the declared payload type is 'i', a number. The slot is a numeric word and the '?? T v →' arm reads it back as that type, so the handle would be returned as arithmetic. Declare the option/result over the type you are storing ('@ ?( Vec i ) { T v }'), or store a number.
+    : ?i o @ ?i { T d }
+                      ^
+error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.


### PR DESCRIPTION
The two items left on the worklist, both closed. **`tools/metamorph` now reports zero gaps** — every spelling of every class gets the same verdict as its siblings.

## 1. A struct/handle in a numeric payload slot

The pointer form was rejected in #901 and the user-enum form in #908. A `Vec` reaches the option/result payload path as `%Vec__i64` — a **named struct**, not a raw pointer — so it took the struct-handle branch, which folds the value to an i64 and hands it to the slot:

```nurl
: ?i o @ ?i { T d }          // d is a ( Vec i )
^ ?? o { T v → v  F → 0 }    // returned 192 — a heap address's low byte
```

Same lie as the first two, one branch over.

## 2. Mutating an iterated container one call deep

`~ x xs` holds a borrow of `xs`, and the direct `( vec_push xs … )` in the body has been rejected for a long time. The same push inside a helper was not — which reads as *"wrap it in a function"* being a cure for a borrow violation.

A per-function summary (`g_fn_mutates`) records which parameters' containers a body mutates, inferred in codegen order like the sink / escape / shared-mutation summaries.

Worth being explicit about severity: **measured, this shape is not memory-unsafe today.** A Vec is a handle to a control block and the loop reads through it, so a forced realloc mid-iteration does not dangle — both spellings return the right sum. §2.5 is a conservative guard. But a guard that applies to one spelling and not its twin teaches the wrong cure, which is why it is worth closing even at that severity.

## Two process notes, both mine

**A `.replace()` without an assert silently no-opped.** I asserted every other edit in that batch and not this one; the pattern had gained a lock-depth guard in #902 and no longer matched. The summary was never recorded, and nothing said so — I found it by instrumenting, not by reading. A replace that does not match does nothing and reports nothing.

**A test that never ran.** The second test was named `..._via_helper`, and `test_skips.sh` skips anything ending in `_mod`/`_helper`/`_lib` as an importable module with no `main()`. It silently never ran; the only visible sign was the SKIP count moving 16 → 17. Renamed, and the reason is recorded in the file.

## Verification

| gate | result |
|---|---|
| test corpus | 811 PASS · 0 FAIL |
| ASan/UBSan corpus | 811 PASS · 0 SAN_FAIL |
| `leakgate.sh` | zero leaks, both emission modes |
| examples | 100 PASS · 0 FAIL |
| stdlib + examples + 320 package files | zero acceptance change |
| corpus IR | 534 byte-identical, 0 differ |
| **metamorph** | **0 gaps** · 0 control regressions · 0 invalid-IR escapes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU
