### PR TITLE
borrowck: §2.5 stops depending on order — and a test that never ran

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -7790,6 +7790,24 @@
             { ( bck_esc_warn lex bck_arg_line ( nurl_str_cat3
                 `cannot mutate '` bck_arg_root
                 `' while iterating over it — the '~' loop holds a borrow of the container; move the mutation out of the loop body` ) ) }
+            {}
+            // …and the same question for a callee not compiled yet: its
+            // mutation summary is empty here, which is "not known", not
+            // "does not mutate". Park it; resolve_pending_iter_mut()
+            // replays it against the final summary after the module, so
+            // `~ y xs { ( grow xs ) }` is diagnosed whether `grow` sits
+            // above or below the loop.
+            ? & & & fe_iterated ! fe_helper_mutates
+            == 0 ( nurl_sym_len g_fn_compiled call_name )
+            & | != 0 ( nurl_sym_len2 syms fname `__arity` )
+            != 0 ( nurl_sym_len2 syms fname `__garity` )
+            == 0 ( nurl_sym_len2 syms fname `__ptr` )
+            { : s __im_rec ( nurl_str_cat3
+                ( nurl_str_cat3 call_name ` ` fname )
+                ( nurl_str_cat4 ` ` ( nurl_str_int arg_idx ) ` ` bck_arg_root )
+                ( nurl_str_cat4 ` ` ( nurl_str_int bck_arg_line ) ` `
+                ( nurl_lex_filename lex ) ) )
+                ( __park_append g_pending_escape `i` __im_rec ) }
             {} }
         {}
         : ~ s av ( nurl_str_cat `` `` )
@@ -20301,10 +20319,36 @@
     }
 }
 
+// Replay the parked iterator-invalidation checks (docs/MEMORY.md §2.5):
+// a container mutated inside a `~ x xs` foreach by a helper that had not
+// been compiled when the loop body did. The rule is a conservative guard
+// rather than a memory-unsafety one, but a guard that holds for
+// `( vec_push xs … )` and not for `( grow xs )` teaches the wrong fix.
+@ resolve_pending_iter_mut → v {
+    ? == g_borrowck 0 { ^ } {}
+    : ~ s rest ( nurl_sym_get g_pending_escape `i` )
+    ~ != 0 ( nurl_str_len rest ) {
+        : s cn ( str_first_word rest ) = rest ( str_skip_word rest )
+        : s fn ( str_first_word rest ) = rest ( str_skip_word rest )
+        : s ai ( str_first_word rest ) = rest ( str_skip_word rest )
+        : s nm ( str_first_word rest ) = rest ( str_skip_word rest )
+        : s ln ( str_first_word rest ) = rest ( str_skip_word rest )
+        : s file ( str_first_word rest ) = rest ( str_skip_word rest )
+        : ~ s mut ( nurl_sym_get g_fn_mutates cn )
+        ? == 0 ( nurl_str_len mut ) { = mut ( nurl_sym_get g_fn_mutates fn ) } {}
+        ? ( str_contains_word mut ai )
+        { ( bck_emit_error file ( nurl_str_to_int ln ) ( nurl_str_cat3
+            `cannot mutate '` nm
+            `' while iterating over it — the '~' loop holds a borrow of the container; move the mutation out of the loop body` ) ) }
+        {}
+    }
+}
+
 @ resolve_pending_escapes → v {
     ? == g_borrowck 0 {} {
         ( resolve_pending_impls )
         ( resolve_pending_ret_escapes )
+        ( resolve_pending_iter_mut )
         : ~ s rest ( nurl_sym_get g_pending_escape `l` )
         ~ != 0 ( nurl_str_len rest ) {
             : s cn ( str_first_word rest ) = rest ( str_skip_word rest )

--- a/compiler/tests/borrow_iter_forward_helper.nu
+++ b/compiler/tests/borrow_iter_forward_helper.nu
@@ -1,0 +1,25 @@
+// Borrow checker — iterator invalidation through a helper defined BELOW
+// the loop (docs/MEMORY.md §2.5). `grow` pushes to the container it is
+// handed, so calling it inside `~ y xs` invalidates the loop's cursor
+// exactly as an inline `( vec_push xs … )` does. The per-function
+// mutation summary that catches the one-call-deep form is built in
+// codegen order, so with `grow` defined after `main` the summary was
+// empty at the call — read as "does not mutate" rather than "not known
+// yet" — and the loop compiled clean.
+//
+// The check is now parked at the call and replayed against the final
+// summary after the whole module (resolve_pending_iter_mut). Which side
+// of the loop the helper is written on does not change the answer.
+$ `stdlib/core/vec.nu`
+
+@ main → i {
+    : ( Vec i ) xs ( vec_new [i] )
+    ( vec_push [i] xs 1 )
+    ~ y xs { ( grow xs ) }
+    ( vec_free [i] xs )
+    ^ 0
+}
+
+@ grow ( Vec i ) v → v {
+    ( vec_push [i] v 2 )
+}

--- a/compiler/tests/outputs/borrow_iter_forward_helper.txt
+++ b/compiler/tests/outputs/borrow_iter_forward_helper.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/borrow_iter_forward_helper.nu:18: error: cannot mutate 'xs' while iterating over it — the '~' loop holds a borrow of the container; move the mutation out of the loop body
+    ~ y xs { ( grow xs ) }
+error: compilation aborted — 1 borrow-checker violation (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/diag_thread_arc_shared_mutation_helper.txt
+++ b/compiler/tests/outputs/diag_thread_arc_shared_mutation_helper.txt
@@ -1,0 +1,7 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_thread_arc_shared_mutation_helper.nu:31:46: error: thread_spawn closure calls 'push_all', which mutates the contents of an Arc — 'Arc' makes the REFCOUNT atomic, not the payload. Two threads mutating one Arc's contents race on the container's length and backing pointer: lost updates, or a use-after-free of the buffer one thread reallocated while the other held it. Put the shared value behind a lock and mutate only while holding it — 'Mutex' + 'mutex_lock'/'mutex_unlock' (or 'mutex_with'), one Mutex shared by every worker — or give each thread its own copy and merge the results after 'thread_join'.
+    : !Thread ThreadErr r1 ( thread_spawn w1 )
+                                             ^
+error: aborting due to 1 previous error
+note: each error stopped its declaration — later statements in the same '@'/'%' were not checked, so this count is a lower bound. Fix these, then re-run.

--- a/compiler/tests/test_skips.sh
+++ b/compiler/tests/test_skips.sh
@@ -115,8 +115,20 @@ test_requires() {
 # check (skipped tests are exempt from missing/orphan accounting).
 is_skipped() {
     local name="$1"
-    # Helper modules imported by other tests: no main(), nothing to run.
-    case "$name" in *_mod|*_helper|*_lib) echo skip; return ;; esac
+    # Modules imported by other tests: no main(), nothing to run. ASK THE
+    # FILE, the way the rest of this script does — the rule used to be a
+    # NAME rule (*_mod / *_helper / *_lib), and a name rule silently
+    # swallows a real test that happens to end that way. It had:
+    # diag_thread_arc_shared_mutation_helper.nu, the regression test for
+    # the shared-mutation race one call deep (PR #902), has a main() and
+    # has never run once — it had no golden either, and neither the
+    # MISSING-golden check nor the ORPHAN check fires for a skipped
+    # test, so nothing anywhere said so. The only trace was the SKIP
+    # count.
+    if [[ -f "$NURL_TESTS_DIR/$name.nu" ]] \
+       && ! grep -qE '^@ main( |$)' "$NURL_TESTS_DIR/$name.nu"; then
+        echo skip; return
+    fi
     # FFI tests whose ext/ module needs an optional native library. build.sh
     # drops a sentinel (stdlib/runtime.<lib>) when pkg-config finds the lib;
     # without it the program legitimately fails to compile ("FFI library X is

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -324,7 +324,11 @@ The check fires for a stdlib container mutator applied to the
 iterated container (`vec_push` / `vec_insert` / `vec_remove` /
 `vec_pop` / `vec_clear` / `vec_set` / `vec_set_len` / `vec_reserve` /
 `vec_shrink_to_fit` / `vec_extend` / `vec_free` / `vec_free_with` /
-`vec_swap` / `vec_reverse`) and for any `inout` argument naming it.
+`vec_swap` / `vec_reverse`), for any `inout` argument naming it, and
+for a **helper** whose summary says it mutates the container handed to
+that parameter — whether that helper is defined above the loop or
+below it, since a call to a not-yet-compiled callee parks the question
+and replays it after the module.
 A counter loop (`~ k 0 ...`, a while-loop) borrows nothing, so
 `( vec_set xs k v )` in an index loop stays legal — only the
 element-borrowing `~ x xs` foreach form is guarded.
@@ -550,8 +554,12 @@ mutates the container handed to one of its parameters — the same
 per-function summary §2.5 consults. Without that, the inline
 `( vec_push v … )` warned and `( grow v )` did not, which reads as
 "wrap the push in a function" being the cure for the diagnostic rather
-than for the bug. (Like §2.5, this summary is built in codegen order,
-so a helper defined *below* its caller is missed — see §6.4.)
+than for the bug. One residual: that summary is built in codegen order
+and this rule reads it inline, because its diagnostic fires at a later
+*read* of the pointer rather than at the call — so a mutating helper
+defined *below* the borrow is missed here (§6.4). §2.5, whose
+diagnostic does fire at the call, parks the question instead and is
+order-independent.
 
 This hazard has nothing to do with `~` mutability — a `: *T` borrow
 dangles identically. (nurlc used to warn about `: ~ *T` bindings on the
@@ -739,10 +747,15 @@ get right:
   deferred to the end of the module, where both summaries are final.
   (Deferred rather than repeated: analysing a function twice would
   report every diagnostic it holds twice.) What is left consulting a
-  summary inline is the *mutation* half, `g_fn_mutates`, which §2.5 and
-  §2.10 read to follow a container mutation one call deep; there, a
-  callee defined below its call site still misses the diagnostic. Never
-  miscompiled — only unchecked.
+  summary inline is one half of one rule: `g_fn_mutates` as **§2.10**
+  reads it, to invalidate a container borrow through a helper. (§2.5's
+  use of the same summary is parked and replayed like the others, so
+  the loop rule does not depend on order either.) §2.10 cannot park it
+  the same way — the diagnostic fires at a *later read* of the pointer,
+  not at the call — so a mutating helper defined below the borrow still
+  misses that warning. It is a warning about a `*T` pointer, which is
+  the trusted surface anyway (above). Never miscompiled — only
+  unchecked.
 
 ### 6.5 This is not Rust
 

--- a/tools/metamorph/spellings.py
+++ b/tools/metamorph/spellings.py
@@ -422,6 +422,14 @@ CLASSES = [
                 "    ~ y xs { ( grow xs ) }\n"
                 "    ( vec_free [i] xs )",
                 extra="@ grow ( Vec i ) v → v { ( vec_push [i] v 2 ) }\n"),
+            # The helper defined BELOW the loop. Its mutation summary is
+            # empty at the call, which is "not known yet", not "does not
+            # mutate" — so definition order decided the verdict.
+            "push-via-forward-helper": prog(
+                "    : ( Vec i ) xs ( vec_new [i] )\n"
+                "    ( vec_push [i] xs 1 )\n"
+                "    ~ y xs { ( grow xs ) }\n"
+                "    ( vec_free [i] xs )") + "@ grow ( Vec i ) v → v { ( vec_push [i] v 2 ) }\n",
             "push-in-nested-foreach": prog(
                 "    : ( Vec i ) xs ( vec_new [i] )\n"
                 "    ( vec_push [i] xs 1 )\n"


### PR DESCRIPTION
Follow-up to #915: this commit was pushed after that PR had already been merged, so it never landed.

### §2.5 loses its order dependence

Iterator invalidation reads the per-function mutation summary to follow a container mutation one call deep. That summary is built in codegen order, so

```
~ y xs { ( grow xs ) }
```

was diagnosed when `grow` was defined **above** the loop and silent when it was defined **below** — definition order deciding the verdict, the same defect the escape and move summaries lost in #915. The call now parks the question and `resolve_pending_iter_mut()` replays it against the final summary.

§2.10 keeps the residual and now says so in `docs/MEMORY.md`: its diagnostic fires at a later *read* of the borrowed pointer rather than at the call, so there is nothing to park at the call site. It is a warning about a `*T` pointer, which is the trusted surface anyway (§6.4).

### A test that has never run

Writing the regression test surfaced a live one. `test_skips.sh` skipped any test whose **name** ended in `_mod` / `_helper` / `_lib`, on the theory that those are importable modules with no `main()`. One of them is not:

**`diag_thread_arc_shared_mutation_helper.nu`** — the regression test for the Arc shared-mutation race one call deep, from #902 — has a `main()` and has never run once. It had no golden either, and neither the MISSING-golden check nor the ORPHAN check fires for a skipped test, so nothing anywhere said so; the only trace was the SKIP count.

The rule now asks the **file** whether it has a `main()`, which is what the rest of that script already does. Both tests run, with goldens.

### Gates

828 pass · 0 fail · 0 missing · 0 orphan · metamorph 0 gaps across 12 classes · leakgate zero · `run_san_tests.sh` SAN_FAIL 0 · corpus IR byte-identical (diagnostics only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU