### PR TITLE
borrowck: §2.3 stops at the phi, and at the dot

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -11194,8 +11194,18 @@
         ( seq ( nurl_llty phi_type ) `i8*` ) `1` `` )
         // Handle provenance (gen_cond's twin): the bindings this value
         // may have come from, and whether it definitely came from one.
-        ( nurl_sym_def syms `__last_phi_idents__`
-        ( __phi_ids_union m_phi_ids m_inner_ids ) )
+        // Fold the inherited candidates into the accumulator rather than
+        // passing the union's result straight into nurl_sym_def: a fresh
+        // owned call result handed to a builtin as an argument is not
+        // collected, and `__phi_ids_union` is defined below this function
+        // so the call site has no ownership summary to work from either.
+        // One publish per value-bearing `??` leaked its buffer — 67 of
+        // them compiling net_tcpstack, caught by the LSan-pinned tests.
+        // Assigning into the `~ s` accumulator is the idiom gen_cond
+        // already uses for the same call, and it frees the old value.
+        ? != 0 ( nurl_str_len m_inner_ids )
+        { = m_phi_ids ( __phi_ids_union m_phi_ids m_inner_ids ) } {}
+        ( nurl_sym_def syms `__last_phi_idents__` m_phi_ids )
         ( nurl_sym_def syms `__last_phi_cause__`
         `its handle is one of the values a '??' selected between` )
         // An INHERITED candidate came from a join that already had a

--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -9108,6 +9108,12 @@
     // saw no alias, and a nested ternary was a hole in a rule the
     // one-level form has closed since #899.
     ( nurl_sym_def syms `__last_phi_idents__` `` )
+    // Stack-reference provenance (docs/MEMORY.md §2.3) gets the same
+    // per-arm reset+snapshot discipline. Reference-ness rides a phi
+    // exactly as ownership does: `^ ? c f f` hands the caller the same
+    // dead frame `^ f` does. Reset first, so an arm cannot inherit what
+    // the CONDITION published.
+    ( nurl_sym_def syms `__last_expr_refdepth__` `` )
     // Owned-STRING provenance gets the same per-arm reset+snapshot
     // discipline. Without it, `__last_call_ret_owned__` after the whole
     // `?` was simply the LAST arm's residue — `: s x ? c `lit` ( getter )`
@@ -9134,6 +9140,9 @@
     : b t_alias != 0 ( nurl_sym_len syms `__last_value_alias__` )
     : s t_retid ( nurl_str_cat ( nurl_sym_get syms `__last_ident_name__` ) `` )
     : s t_inner_ids ( nurl_str_cat ( nurl_sym_get syms `__last_phi_idents__` ) `` )
+    // Referent depth of this arm's value, read while the arm's scope is
+    // still on the symbol table (the pop below takes its entries with it).
+    : i t_refdep ( bck_expr_refdepth syms t_retid )
     // A tracked-owned-string ident arm hands the phi a COPY, emitted
     // here inside the arm's own block (it must only run on this path).
     // The old protocol cancelled the binding's scheduled drop instead —
@@ -9252,6 +9261,8 @@
     ( nurl_sym_def syms `__last_call_ret_owned__` `` )
     ( nurl_sym_def syms `__last_value_alias__` `` )
     ( nurl_sym_def syms `__last_join_variant_enum__` `` )
+    ( nurl_sym_def syms `__last_expr_refdepth__` `` )
+    ( nurl_sym_def syms `__last_phi_idents__` `` )
     : i e_tt0 ( nurl_lex_type lex )
     : s e_v0 ( nurl_str_cat ( nurl_lex_val lex ) `` )
     : ~ s ev ( gen_expr lex syms cg )
@@ -9261,6 +9272,8 @@
     : b e_alias != 0 ( nurl_sym_len syms `__last_value_alias__` )
     : s e_retid ( nurl_str_cat ( nurl_sym_get syms `__last_ident_name__` ) `` )
     : s e_inner_ids ( nurl_str_cat ( nurl_sym_get syms `__last_phi_idents__` ) `` )
+    // Mirror of the then-arm's referent-depth snapshot.
+    : i e_refdep ( bck_expr_refdepth syms e_retid )
     // Mirror of the then-arm's tracked-ident copy (see above) — plus the
     // one case where a LITERAL else-arm still copies eagerly: the
     // then-arm is already a live fresh owner, so uniform ownership needs
@@ -9552,6 +9565,27 @@
     : b __alias_res & & & __t_alias_ok __e_alias_ok __slice_live
     ( seq ( nurl_llty phi_ty ) `i8*` )
     ( nurl_sym_def syms `__last_value_alias__` ? __alias_res `1` `` )
+    // ── Stack-reference provenance of the `?`-result (§2.3) ──────────
+    // A phi carries a stack reference exactly as it carries a handle:
+    // `^ ? c f f` returns the same pointer into the dead frame that
+    // `^ f` does, and every §2.3 sink (return, `vec_push`,
+    // `thread_spawn`, an `=` into a shallower region) consumes it the
+    // same way. Only the transient was reset per arm, so the depth an
+    // arm published was gone by the join and the whole family —
+    // `?`, `??`, a ternary bound to a local first, a struct literal
+    // built from one — compiled clean. Confirmed
+    // stack-use-after-return under ASan for six spellings.
+    //
+    // The deepest LIVE arm wins: an arm that returned never reaches
+    // this phi (and was checked at its own `^`), and one arm carrying
+    // the reference is enough — the result dangles on that path. A
+    // valueless join publishes nothing.
+    : ~ i __join_refdep 0
+    ? & == 0 tdr > t_refdep __join_refdep { = __join_refdep t_refdep } {}
+    ? & == 0 edr > e_refdep __join_refdep { = __join_refdep e_refdep } {}
+    ( nurl_sym_def syms `__last_expr_refdepth__`
+    ? & > __join_refdep 0 ! ( seq ( nurl_get_last_type ) `void` )
+    ( nurl_str_int __join_refdep ) `` )
     result
 }
 
@@ -9920,6 +9954,17 @@
     // `??` may hand to whoever receives its value, and whether every
     // live arm hands the same one.
     : ~ s m_phi_ids ``
+    // …plus the candidates a live arm INHERITED from a join of its own.
+    // gen_cond has carried these up since #899 (`? c ? c a ( make ) …`);
+    // the `??` twin did not, so `?? c { 1 → ? d a a  _ → ( make ) }`
+    // handed `a`'s buffer over with nothing recorded and freeing both
+    // names compiled clean — a confirmed heap use-after-free.
+    : ~ s m_inner_ids ``
+    // Stack-reference provenance across the arms (§2.3), gen_cond's
+    // twin: the deepest referent depth any LIVE arm's value carries. A
+    // `??` selecting a closure that captured a caller frame by pointer
+    // hands that frame out exactly as a bare `^ f` would.
+    : ~ i m_refdep 0
     : ~ i m_live_arms 0
     : ~ i m_alias_arms 0
     : ~ i m_distinct 0
@@ -10875,6 +10920,12 @@
             // come from the token itself, not a stale last-ident
             // (`( f Red )` must not bless).
             ( nurl_sym_def syms `__last_join_variant_enum__` `` )
+            // Reset the escape side-channel too, so this arm's referent
+            // depth is this arm's and not the scrutinee's residue.
+            ( nurl_sym_def syms `__last_expr_refdepth__` `` )
+            // …and the inherited-handle channel, so an arm's snapshot is
+            // its own rather than the previous arm's leftovers.
+            ( nurl_sym_def syms `__last_phi_idents__` `` )
             : i arm_tt0 ( nurl_lex_type lex )
             : s arm_v0 ( nurl_lex_val lex )
             : ~ s arm_result ( gen_stmt lex syms cg )
@@ -10885,6 +10936,11 @@
             : s arm_slice_flag ( nurl_str_cat ( nurl_sym_get syms `__last_slice_owned__` ) `` )
             : s arm_str_flag ( nurl_str_cat ( nurl_sym_get syms `__last_call_ret_owned__` ) `` )
             : s arm_retid ( nurl_str_cat ( nurl_sym_get syms `__last_ident_name__` ) `` )
+            // Referent depth of this arm's value, read before the arm
+            // scope's pop takes the binding's `__refdepth` with it.
+            : i arm_refdep ( bck_expr_refdepth syms arm_retid )
+            : s arm_inner_ids ( nurl_str_cat
+            ( nurl_sym_get syms `__last_phi_idents__` ) `` )
             : b arm_alias != 0 ( nurl_sym_len syms `__last_value_alias__` )
             // Tracked-ident arm value → hand the phi a COPY, emitted in
             // this arm's block (gen_cond's t_dup twin): the old cancel-
@@ -11007,6 +11063,16 @@
                     // arm_retid alone may name the last ident loaded
                     // inside a trailing call), and collect the name.
                     = m_live_arms + m_live_arms 1
+                    // Stack-reference provenance: one live arm carrying
+                    // the reference is enough — the join dangles on that
+                    // path. A `^`-arm never reaches this phi and was
+                    // checked at its own return.
+                    ? > arm_refdep m_refdep { = m_refdep arm_refdep } {}
+                    // Whatever a nested join in this arm could have
+                    // produced, this join can produce too.
+                    ? != 0 ( nurl_str_len arm_inner_ids )
+                    { = m_inner_ids ( __phi_ids_union m_inner_ids arm_inner_ids ) }
+                    {}
                     ? & & ( is_ident_tok arm_tt0 ) ( seq arm_v0 arm_retid )
                     != 0 ( nurl_str_len arm_retid )
                     { = m_alias_arms + m_alias_arms 1
@@ -11128,12 +11194,16 @@
         ( seq ( nurl_llty phi_type ) `i8*` ) `1` `` )
         // Handle provenance (gen_cond's twin): the bindings this value
         // may have come from, and whether it definitely came from one.
-        ( nurl_sym_def syms `__last_phi_idents__` m_phi_ids )
+        ( nurl_sym_def syms `__last_phi_idents__`
+        ( __phi_ids_union m_phi_ids m_inner_ids ) )
         ( nurl_sym_def syms `__last_phi_cause__`
         `its handle is one of the values a '??' selected between` )
+        // An INHERITED candidate came from a join that already had a
+        // choice, so this join cannot promise it on every path — the
+        // same rule gen_cond applies to its `t_inner_ids`/`e_inner_ids`.
         ( nurl_sym_def syms `__last_phi_definite__`
-        ? & & > m_live_arms 0 == m_alias_arms m_live_arms
-        == 1 m_distinct `1` `` )
+        ? & & & > m_live_arms 0 == m_alias_arms m_live_arms
+        == 1 m_distinct == 0 ( nurl_str_len m_inner_ids ) `1` `` )
         // Borrow propagation only matters when the match YIELDS an auto-Drop
         // enum (the value a `:`-binding might wrongly drop). For any other
         // result type — String, i, … — reset so a match on a borrowed param
@@ -11161,6 +11231,13 @@
         // residue must not leak out as this match's proof.
         ( nurl_sym_def syms `__last_join_variant_enum__`
         ? & m_ven_ok != 0 ( nurl_str_len m_ven ) m_ven `` )
+        // Stack-reference provenance of the `??`-result (§2.3). Every
+        // exit of this function publishes it, because the per-arm reset
+        // above otherwise leaves the LAST arm's depth standing as the
+        // whole match's answer — the residue bug the ownership channels
+        // above were each fixed for in turn.
+        ( nurl_sym_def syms `__last_expr_refdepth__`
+        ? > m_refdep 0 ( nurl_str_int m_refdep ) `` )
         ^ final_reg
     } {}
     // Arms of DIFFERENT integer widths: join losslessly at 64 bits over the
@@ -11187,6 +11264,8 @@
         ( nurl_sym_def syms `__last_phi_idents__` `` )
         ( nurl_sym_def syms `__last_phi_cause__` `` )
         ( nurl_sym_def syms `__last_phi_definite__` `` )
+        // …nor a stack reference.
+        ( nurl_sym_def syms `__last_expr_refdepth__` `` )
         ^ final64
     } {}
     ( nurl_set_last_type `void` )
@@ -11194,6 +11273,8 @@
     ( nurl_sym_def syms `__last_phi_idents__` `` )
     ( nurl_sym_def syms `__last_phi_cause__` `` )
     ( nurl_sym_def syms `__last_phi_definite__` `` )
+    // A valueless `??` hands nothing out — clear the per-arm residue.
+    ( nurl_sym_def syms `__last_expr_refdepth__` `` )
     ^ ( nurl_str_cat `undef` `` )
 }
 
@@ -15427,6 +15508,41 @@
     ( __arg_named_struct_mismatch vt dt ) ( __arg_str_cstr_mismatch vt dt )
 }
 
+// Escape analysis for `= . obj field rhs` (docs/MEMORY.md §2.3). The
+// whole-binding form `= obj rhs` has always been checked (bck_esc_assign);
+// the FIELD form was not, so `= . box cb f` walked a stack reference into
+// a longer-lived struct with nothing said, and returning that struct
+// handed the caller a pointer into the dead frame — confirmed
+// stack-use-after-return under ASan.
+//
+// Two effects, matching bck_esc_assign: the struct INHERITS the
+// reference (so a later `^ obj` / `vec_push obj` fires), and a store
+// into a struct that outlives the referent is reported here. The
+// inherit-only-upwards rule is deliberate: a field store overwrites one
+// field, so a non-reference RHS cannot prove the OTHER fields stopped
+// referencing anything. Missing a diagnostic is the safe direction;
+// clearing the mark would invent a clean bill of health.
+@ bck_esc_field_store i lex i syms i line i refdepth → v {
+    ? | == g_borrowck 0 == refdepth 0 {} {
+        : s obj ( nurl_str_cat ( nurl_sym_get syms `__last_field_obj__` ) `` )
+        ? == 0 ( nurl_str_len obj ) {} {
+            : s rd ( nurl_sym_get2 syms obj `__refdepth` )
+            : i rdv ? == 0 ( nurl_str_len rd ) 0 ( nurl_str_to_int rd )
+            ? > refdepth rdv
+            { ( nurl_sym_def syms ( nurl_str_cat obj `__refdepth` )
+                ( nurl_str_int refdepth ) ) }
+            {}
+            : s bd ( nurl_sym_get2 syms obj `__bdepth` )
+            : i bdv ? == 0 ( nurl_str_len bd ) 1 ( nurl_str_to_int bd )
+            ? < bdv refdepth
+            { ( bck_esc_warn lex line ( nurl_str_cat3
+                `storing into a field of '` obj
+                `' a value that references a more deeply scoped binding by pointer — it dangles once that inner scope exits` ) ) }
+            {}
+        }
+    }
+}
+
 // The value side of a field store, wherever the store lands. There are
 // eight of those sites in gen_field_store — one per shape (slice,
 // pointer-to-struct, struct-by-value, indexed, …) — and a bare
@@ -15438,13 +15554,30 @@
 @ gen_field_rhs i lex i syms i cg → s {
     ? ( is_ident_tok ( nurl_lex_type lex ) )
     { ( lint_note_released ( nurl_lex_val lex ) ) } {}
-    ^ ( gen_expr lex syms cg )
+    // §2.3: snapshot the RHS's first token, then clear the escape
+    // side-channel so the depth read after gen_expr is this RHS's own
+    // and not the OBJECT expression's residue. Every field-store branch
+    // in gen_field_store routes its RHS through here, so hooking the one
+    // shared entry point covers the named-field, slice-element and
+    // pointer-index spellings alike.
+    : i __fs_tt ( nurl_lex_type lex )
+    : s __fs_val ( nurl_str_cat ( nurl_lex_val lex ) `` )
+    : i __fs_line ( nurl_lex_line lex )
+    ( nurl_sym_def syms `__last_expr_refdepth__` `` )
+    : s __fs_v ( gen_expr lex syms cg )
+    ( bck_esc_field_store lex syms __fs_line ( bck_expr_refdepth syms
+    ? ( is_ident_tok __fs_tt ) __fs_val `` ) )
+    ^ __fs_v
 }
 
 @ gen_field_store i lex i syms i cg → s {
     ( nurl_lex_advance lex )  // consume '.'
     // Save object name before gen_expr consumes the token (needed for struct-by-value alloca lookup)
     : s obj_name ? ( is_ident_tok ( nurl_lex_type lex ) ) ( nurl_lex_val lex ) ``
+    // …and publish it for gen_field_rhs's escape hook (§2.3), which sees
+    // only the RHS. Every branch below routes its RHS through that one
+    // function, so the target binding has to travel on a side-channel.
+    ( nurl_sym_def syms `__last_field_obj__` obj_name )
     : s pv ( gen_expr lex syms cg )  // pointer/aggregate value
     : s pt ( nurl_get_last_type )  // LLVM type, e.g. "%Node*", "i64*", "{ T*, i64 }", or "%Pair"
 

--- a/compiler/tests/borrow_escape_field_store.nu
+++ b/compiler/tests/borrow_escape_field_store.nu
@@ -1,0 +1,67 @@
+// borrow_escape_field_store.nu — a stack reference written into a
+// longer-lived struct's FIELD (docs/MEMORY.md §2.3).
+//
+// `= holder f` (whole binding) has been checked since the region
+// analysis landed; `= . holder cb f` was not, so the reference walked
+// into a struct that outlives the block it points into, and returning
+// that struct handed the caller a pointer to the dead frame —
+// confirmed stack-use-after-return under AddressSanitizer.
+//
+// The field store has the same two effects the whole-binding form has:
+// the struct INHERITS the reference (so a later `^ holder` fires) and a
+// store into a struct declared in a shallower region is reported at the
+// store itself.
+
+: Counter { i n i max }
+: Slot { ( @ v ) cb }
+
+// POSITIVE — `box` lives at the function body (depth 1); `c` and the
+// closure over it live inside the `?` block (depth 2). The store makes
+// `box` outlive its referent.
+@ leak_via_field_store → v {
+    : ~ Slot box @ Slot { \ → v {} }
+    ? > 1 0 {
+        : ~ Counter c @ Counter { 0 10 }
+        : ( @ v ) f \ → v { = . c n + . c n 1 }
+        = . box cb f
+    } {}
+    : ( @ v ) g . box cb
+    ( g )
+}
+
+// POSITIVE — same region, so the store itself is silent; what the store
+// does is make `box` a stack reference, and RETURNING it dangles.
+@ ret_after_field_store → Slot {
+    : ~ Counter c @ Counter { 0 10 }
+    : ( @ v ) f \ → v { = . c n + . c n 1 }
+    : ~ Slot box @ Slot { \ → v {} }
+    = . box cb f
+    ^ box
+}
+
+// CONTROL — the struct and the referent share a region and the struct
+// never leaves the frame. Flagging this would be a false positive.
+@ no_escape_same_region_field → i {
+    : ~ Counter c @ Counter { 0 10 }
+    : ( @ v ) f \ → v { = . c n + . c n 1 }
+    : ~ Slot box @ Slot { \ → v {} }
+    = . box cb f
+    : ( @ v ) g . box cb
+    ( g )
+    ^ . c n
+}
+
+// CONTROL — an ordinary scalar field store carries no reference at all.
+@ no_escape_scalar_field → i {
+    : ~ Counter c @ Counter { 0 10 }
+    = . c n 7
+    ^ . c n
+}
+
+@ main → i {
+    ( leak_via_field_store )
+    : Slot _a ( ret_after_field_store )
+    : i _b ( no_escape_same_region_field )
+    : i _c ( no_escape_scalar_field )
+    ^ 0
+}

--- a/compiler/tests/borrow_escape_join.nu
+++ b/compiler/tests/borrow_escape_join.nu
@@ -1,0 +1,101 @@
+// borrow_escape_join.nu — a stack reference riding a `?` / `??` JOIN
+// (docs/MEMORY.md §2.3).
+//
+// Reference-ness propagated through closure literals, aggregate
+// literals, copies and `=` assignments — but not through the phi of a
+// conditional. So `^ f` was an error and `^ ? c f f` compiled clean,
+// which is the same program with a branch that cannot change the
+// answer: both arms hand the caller a pointer into the frame that is
+// about to disappear. Every spelling below was confirmed
+// stack-use-after-return under AddressSanitizer before the fix.
+//
+// The join publishes the DEEPEST live arm's referent depth: one arm
+// carrying the reference is enough, because the result dangles on that
+// path. An arm that returns never reaches the phi and was already
+// checked at its own `^`.
+
+$ `stdlib/core/vec.nu`
+
+: Counter { i n i max }
+: Slot { ( @ v ) cb }
+
+// POSITIVE — the reference leaves through a ternary's phi.
+@ ret_via_ternary → ( @ v ) {
+    : ~ Counter c @ Counter { 0 10 }
+    : ( @ v ) f \ → v { = . c n + . c n 1 }
+    ^ ? > . c n 0 f f
+}
+
+// POSITIVE — same through a match's phi.
+@ ret_via_match → ( @ v ) {
+    : ~ Counter c @ Counter { 0 10 }
+    : ( @ v ) f \ → v { = . c n + . c n 1 }
+    ^ ?? . c n { 0 → f _ → f }
+}
+
+// POSITIVE — the join is bound to a local first. The binding inherits
+// the depth exactly as `: ( @ v ) t f` does.
+@ ret_via_bound_join → ( @ v ) {
+    : ~ Counter c @ Counter { 0 10 }
+    : ( @ v ) f \ → v { = . c n + . c n 1 }
+    : ( @ v ) t ? > . c n 0 f f
+    ^ t
+}
+
+// POSITIVE — the join feeds an aggregate literal's field, and the
+// aggregate is what leaves.
+@ ret_struct_of_join → Slot {
+    : ~ Counter c @ Counter { 0 10 }
+    : ( @ v ) f \ → v { = . c n + . c n 1 }
+    ^ @ Slot { ? > . c n 0 f f }
+}
+
+// POSITIVE — a non-return §2.3 sink: the join goes into a heap
+// container, which outlives the frame just as a caller does.
+@ join_into_heap ( Vec Slot ) heap → v {
+    : ~ Counter c @ Counter { 0 10 }
+    : ( @ v ) f \ → v { = . c n + . c n 1 }
+    ( vec_push [Slot] heap @ Slot { ? > . c n 0 f f } )
+}
+
+// CONTROL — a helper that merely INVOKES the closure retains nothing,
+// so handing it a join of stack references is correct code.
+@ run ( @ v ) cb → v { ( cb ) }
+
+@ join_into_invoker → i {
+    : ~ Counter c @ Counter { 0 10 }
+    : ( @ v ) f \ → v { = . c n + . c n 1 }
+    ( run ? > . c n 0 f f )
+    ^ . c n
+}
+
+// CONTROL — a join between two closures that capture NOTHING is not a
+// stack reference, and returning it is ordinary code.
+@ no_escape_plain_join → ( @ v ) {
+    : i k 1
+    ^ ? > k 0 \ → v {} \ → v {}
+}
+
+// CONTROL — the join stays inside the frame it references. Nothing
+// outlives anything, so no diagnostic may fire.
+@ no_escape_local_join → i {
+    : ~ Counter c @ Counter { 0 10 }
+    : ( @ v ) f \ → v { = . c n + . c n 1 }
+    : ( @ v ) g ? > . c n 0 f f
+    ( g )
+    ^ . c n
+}
+
+@ main → i {
+    : ( @ v ) _a ( ret_via_ternary )
+    : ( @ v ) _b ( ret_via_match )
+    : ( @ v ) _c ( ret_via_bound_join )
+    : Slot _d ( ret_struct_of_join )
+    : ( Vec Slot ) heap ( vec_new [Slot] )
+    ( join_into_heap heap )
+    ( vec_free [Slot] heap )
+    : i _g ( join_into_invoker )
+    : ( @ v ) _e ( no_escape_plain_join )
+    : i _f ( no_escape_local_join )
+    ^ 0
+}

--- a/compiler/tests/borrow_strict_nested_join_alias.nu
+++ b/compiler/tests/borrow_strict_nested_join_alias.nu
@@ -1,0 +1,62 @@
+// borrow_strict_nested_join_alias.nu — handle provenance through a
+// join nested inside a `??` arm (docs/MEMORY.md §2.2).
+//
+// A `?` / `??` can SELECT a manually-managed handle, so the join
+// publishes which bindings its result may have come from and the `:`
+// that receives it records a (conditional) move. gen_cond has carried
+// a nested join's candidates up since #899 — `? c ? c a ( make ) …`
+// — but the `??` twin dropped them, so
+//
+//     : ( Vec i ) b ?? c { 1 → ? d a a  _ → ( vec_new [i] ) }
+//
+// handed `a`'s buffer to `b` with nothing recorded, and freeing both
+// names compiled clean: a confirmed heap use-after-free under
+// AddressSanitizer. The one-level spellings (`?? c { 1 → a … }`, and
+// the mirror `? c ?? … ( vec_new )`) were already reported; only the
+// nesting was missing, which is what makes it a coverage gap rather
+// than a rule change.
+//
+// Conditional, so `--strict-borrowck`: the join MAY have selected `a`,
+// and the default checker reports only definite faults (§6.3).
+
+$ `stdlib/core/vec.nu`
+
+// POSITIVE — a ternary nested in a match arm.
+@ match_of_ternary → i {
+    : ( Vec i ) a ( vec_new [i] )
+    : i c 1
+    : ( Vec i ) b ?? c { 1 → ? > c 0 a a _ → ( vec_new [i] ) }
+    ( vec_free [i] b )
+    ( vec_free [i] a )
+    ^ 0
+}
+
+// POSITIVE — a match nested in a match arm. Same situation, one more
+// level of braces.
+@ match_of_match → i {
+    : ( Vec i ) a ( vec_new [i] )
+    : i c 1
+    : ( Vec i ) b ?? c { 1 → ?? c { 1 → a _ → a } _ → ( vec_new [i] ) }
+    ( vec_free [i] b )
+    ( vec_free [i] a )
+    ^ 0
+}
+
+// CONTROL — the join selects between two FRESH containers, so `b` owns
+// its own buffer and freeing both names is correct.
+@ no_alias_fresh_arms → i {
+    : ( Vec i ) a ( vec_new [i] )
+    : i c 1
+    : ( Vec i ) b ?? c { 1 → ? > c 0 ( vec_new [i] ) ( vec_new [i] )
+        _ → ( vec_new [i] ) }
+    ( vec_free [i] b )
+    ( vec_free [i] a )
+    ^ 0
+}
+
+@ main → i {
+    : i _a ( match_of_ternary )
+    : i _b ( match_of_match )
+    : i _c ( no_alias_fresh_arms )
+    ^ 0
+}

--- a/compiler/tests/outputs/borrow_escape_field_store.txt
+++ b/compiler/tests/outputs/borrow_escape_field_store.txt
@@ -1,0 +1,7 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/borrow_escape_field_store.nu:26: error: storing into a field of 'box' a value that references a more deeply scoped binding by pointer — it dangles once that inner scope exits
+        = . box cb f
+compiler/tests/borrow_escape_field_store.nu:39: error: returning a value that references a stack binding by pointer — it dangles after this function returns (move the captured data to a heap-backed handle)
+    ^ box
+error: compilation aborted — 2 borrow-checker violations (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_escape_join.txt
+++ b/compiler/tests/outputs/borrow_escape_join.txt
@@ -1,0 +1,13 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/borrow_escape_join.nu:26: error: returning a value that references a stack binding by pointer — it dangles after this function returns (move the captured data to a heap-backed handle)
+    ^ ? > . c n 0 f f
+compiler/tests/borrow_escape_join.nu:33: error: returning a value that references a stack binding by pointer — it dangles after this function returns (move the captured data to a heap-backed handle)
+    ^ ?? . c n { 0 → f _ → f }
+compiler/tests/borrow_escape_join.nu:42: error: returning a value that references a stack binding by pointer — it dangles after this function returns (move the captured data to a heap-backed handle)
+    ^ t
+compiler/tests/borrow_escape_join.nu:50: error: returning a value that references a stack binding by pointer — it dangles after this function returns (move the captured data to a heap-backed handle)
+    ^ @ Slot { ? > . c n 0 f f }
+compiler/tests/borrow_escape_join.nu:58: error: passing a value that references a stack binding by pointer to 'vec_push' — it escapes the current stack frame and dangles (move it to a heap-backed handle)
+    ( vec_push [Slot] heap @ Slot { ? > . c n 0 f f } )
+error: compilation aborted — 5 borrow-checker violations (re-run with --no-borrowck to bypass)

--- a/compiler/tests/outputs/borrow_strict_nested_join_alias.txt
+++ b/compiler/tests/outputs/borrow_strict_nested_join_alias.txt
@@ -1,0 +1,7 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/borrow_strict_nested_join_alias.nu:30: error: 'a' may already be freed here — its handle is one of the values a '??' selected between at line 28; this second free double-frees on that path (strict-borrowck; restructure so exactly one path frees it)
+    ( vec_free [i] a )
+compiler/tests/borrow_strict_nested_join_alias.nu:41: error: 'a' may already be freed here — its handle is one of the values a '??' selected between at line 39; this second free double-frees on that path (strict-borrowck; restructure so exactly one path frees it)
+    ( vec_free [i] a )
+error: compilation aborted — 2 borrow-checker violations (re-run with --no-borrowck to bypass)

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -262,8 +262,12 @@ points into. The checker assigns every binding a **region** (its
 block-nesting depth — the function body is depth 1, each nested
 `?`/`~`/`??`/`{ }` one deeper, the caller depth 0) and tags a stack
 reference with the deepest region it points into. Reference-ness
-propagates through closure and aggregate literals, `let` copies, and
-`=` assignments. An escape is reported when a stack reference reaches:
+propagates through closure and aggregate literals, `let` copies, `=`
+assignments, `= . obj field` **field stores** (the struct inherits the
+reference, so returning it later fires), and the **phi of a `?` / `??`**
+— the join publishes the deepest depth any *live* arm carries, since one
+arm holding the reference is enough to dangle on that path. An escape is
+reported when a stack reference reaches:
 
 - `^`-return (it would dangle the moment the function returns),
 - `vec_push` / `vec_insert` / `vec_set` / `thread_spawn` (it outlives
@@ -580,9 +584,11 @@ hits in practice. It deliberately does **not** cover:
   `--strict-borrowck` reports a `# *T` escape from an owned binding
   (§2.9).
 - **Aliased mutation beyond a single call.** The exclusive-access
-  check (§2.4) covers a binding aliased among one call's arguments.
-  A binding read through a *nested* sub-expression argument, and
-  any longer-range aliased-mutation analysis, is not done. (Escape
+  check (§2.4) covers a binding aliased among one call's arguments —
+  by default the bare-identifier spelling, and under
+  `--strict-borrowck` a sibling read at any depth (a field projection,
+  a read nested inside another call). What is *not* done is any
+  longer-range aliased-mutation analysis across statements. (Escape
   across a forward or generic call used to be listed here; it is not a
   boundary any more — §2.7 and §2.8 park what they cannot answer and
   resolve it after the module, so definition order no longer changes a
@@ -630,7 +636,8 @@ hits in practice. It deliberately does **not** cover:
 | Loop-carried move (free an outer binding inside a `~` loop) | yes (`error:`) |
 | Interprocedural escape (stack ref stored by a helper) | yes (`error:`) |
 | Return escape (helper returns a passed-in stack ref) | yes (`error:`) |
-| Aliased mutation via nested-argument reads | no |
+| Aliased mutation via nested-argument reads | yes (`--strict-borrowck`, §2.9) |
+| Escape through a `?` / `??` join, or into a struct field | yes (`error:`) |
 | Return escape (through a field, a nested field, a closure env, a local name, a second helper, a forward / generic callee) | yes (`error:`) |
 | Returned borrows / general lifetime inference | partial (§2.8) |
 | `*T` raw pointers | no (by design) |
@@ -678,8 +685,10 @@ class:
   defined above or below the call (§6.4). The conditional forms of the
   alias case need `--strict-borrowck`; §2.2 says which and why.
 - **Dangling stack references** reaching a return, a heap container, a
-  thread, a longer-lived binding, or — interprocedurally — a helper
-  that stores or returns one (§2.3, §2.7, §2.8).
+  thread, a longer-lived binding, a longer-lived binding's *field*, or
+  — interprocedurally — a helper that stores or returns one (§2.3,
+  §2.7, §2.8), and reaching any of those through a `?` / `??` join
+  rather than directly.
 - **Iterator-invalidating mutation** of a container under a `~ x xs`
   foreach (§2.5), and an **aliased `inout` writer** sharing a call with
   another reader of the same binding (§2.4).
@@ -900,11 +909,12 @@ on; they are not two separate tools or two separate builds.
 3. **Diagnostic-coverage gate** — `tools/metamorph/spellings.py`, in
    the build-test job. Not a memory gate but a *consistency* one: it
    writes the same semantic situation N ways and requires the same
-   verdict from the checker for all of them, across nine classes
+   verdict from the checker for all of them, across sixteen classes
    (handle-second-name, use-after-free, loop-carried-free,
    iterator-invalidation, arc-shared-mutation, thread-nonsend /
-   -nonsync, option-payload-type, ret-escape, escape-into-callee,
-   aliased-mutation, stale-borrow, forward-callee-move) plus a
+   -nonsync, option-payload-type, invalid-input, intraproc-escape,
+   ret-escape, escape-into-callee, aliased-mutation, stale-borrow,
+   raw-ptr-escape, forward-callee-move) plus a
    `controls` class of correct programs, which must keep compiling. Its
    baseline (`known_gaps.json`) is **empty**: any new gap fails.
    It also checks one invariant on every accepted program, whatever its

--- a/tools/metamorph/spellings.py
+++ b/tools/metamorph/spellings.py
@@ -173,6 +173,30 @@ CLASSES = [
                 "    : ( @ v ) f \\ → v { ( vec_free [i] a ) }\n"
                 "    ( f )\n"
                 "    ( vec_free [i] a )"),
+            # A join nested inside a `??` arm. gen_cond carried a nested
+            # join's candidates up; gen_match dropped them, so exactly
+            # this pair — and not their one-level spellings — compiled
+            # clean into a heap use-after-free.
+            "match-of-ternary": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    : i c 1\n"
+                "    : ( Vec i ) b ?? c { 1 → ? > c 0 a a  _ → ( vec_new [i] ) }\n"
+                "    ( vec_free [i] b )\n"
+                "    ( vec_free [i] a )"),
+            "match-of-match": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    : i c 1\n"
+                "    : ( Vec i ) b ?? c { 1 → ?? c { 1 → a  _ → a }  "
+                "_ → ( vec_new [i] ) }\n"
+                "    ( vec_free [i] b )\n"
+                "    ( vec_free [i] a )"),
+            "ternary-of-match": prog(
+                "    : ( Vec i ) a ( vec_new [i] )\n"
+                "    : i c 1\n"
+                "    : ( Vec i ) b ? > c 0 ?? c { 1 → a  _ → a } "
+                "( vec_new [i] )\n"
+                "    ( vec_free [i] b )\n"
+                "    ( vec_free [i] a )"),
         },
     },
     {
@@ -822,6 +846,160 @@ CLASSES = [
         },
     },
     {
+        "name": "intraproc-escape",
+        "severity": "memory-unsafety",
+        "doc": "A stack reference reaches a §2.3 sink WITHOUT crossing a "
+               "function boundary: `^`-return, a heap container, an "
+               "assignment into a longer-lived binding. ret-escape and "
+               "escape-into-callee cover the interprocedural halves; this "
+               "is the base rule they build on, and it had no class of "
+               "its own. What varies between spellings is only the route "
+               "the reference takes to the sink — bare, through a `?` or "
+               "`??` phi, bound to a local first, inside an aggregate "
+               "literal, or written into a struct FIELD.",
+        "expect": REJECT_DEFAULT,
+        "expect_msg": ["references a stack binding",
+                       "more deeply scoped", "storing into a field"],
+        "spellings": {
+            "ret-bare": prog(
+                "    : ( @ v ) g ( caller )\n    ( g )",
+                prelude="",
+                extra=ESC_CTR + "@ caller → ( @ v ) {\n" + ESC_MKREF
+                      + "    ^ f\n}\n"),
+            "ret-via-local": prog(
+                "    : ( @ v ) g ( caller )\n    ( g )",
+                prelude="",
+                extra=ESC_CTR + "@ caller → ( @ v ) {\n" + ESC_MKREF
+                      + "    : ( @ v ) t f\n    ^ t\n}\n"),
+            # The phi family. Every one of these ran clean before the
+            # join carried referent depth, and every one is a confirmed
+            # stack-use-after-return.
+            "ret-ternary": prog(
+                "    : ( @ v ) g ( caller )\n    ( g )",
+                prelude="",
+                extra=ESC_CTR + "@ caller → ( @ v ) {\n" + ESC_MKREF
+                      + "    ^ ? > . c n 0 f f\n}\n"),
+            "ret-match": prog(
+                "    : ( @ v ) g ( caller )\n    ( g )",
+                prelude="",
+                extra=ESC_CTR + "@ caller → ( @ v ) {\n" + ESC_MKREF
+                      + "    ^ ?? . c n { 0 → f  _ → f }\n}\n"),
+            "ret-bound-ternary": prog(
+                "    : ( @ v ) g ( caller )\n    ( g )",
+                prelude="",
+                extra=ESC_CTR + "@ caller → ( @ v ) {\n" + ESC_MKREF
+                      + "    : ( @ v ) t ? > . c n 0 f f\n    ^ t\n}\n"),
+            "ret-bound-match": prog(
+                "    : ( @ v ) g ( caller )\n    ( g )",
+                prelude="",
+                extra=ESC_CTR + "@ caller → ( @ v ) {\n" + ESC_MKREF
+                      + "    : ( @ v ) t ?? . c n { 0 → f  _ → f }\n"
+                        "    ^ t\n}\n"),
+            "ret-aggregate-of-ternary": prog(
+                "    : Slot s ( caller )\n    : ( @ v ) g . s cb\n    ( g )",
+                prelude="",
+                extra=ESC_CTR + ESC_SLOT + "@ caller → Slot {\n" + ESC_MKREF
+                      + "    ^ @ Slot { ? > . c n 0 f f }\n}\n"),
+            "ret-ternary-of-aggregate": prog(
+                "    : Slot s ( caller )\n    : ( @ v ) g . s cb\n    ( g )",
+                prelude="",
+                extra=ESC_CTR + ESC_SLOT + "@ caller → Slot {\n" + ESC_MKREF
+                      + "    : Slot s @ Slot { f }\n"
+                        "    ^ ? > . c n 0 s s\n}\n"),
+            # Assignment into a longer-lived binding: bare, and through
+            # a field of one.
+            "assign-outer": prog(
+                "    ( caller )",
+                prelude="",
+                extra=ESC_CTR + "@ caller → v {\n"
+                      "    : ~ ( @ v ) out \\ → v { }\n"
+                      "    ? > 1 0 {\n" + ESC_MKREF
+                      + "        = out f\n    } {}\n    ( out )\n}\n"),
+            "assign-outer-ternary": prog(
+                "    ( caller )",
+                prelude="",
+                extra=ESC_CTR + "@ caller → v {\n"
+                      "    : ~ ( @ v ) out \\ → v { }\n"
+                      "    ? > 1 0 {\n" + ESC_MKREF
+                      + "        = out ? > . c n 0 f f\n    } {}\n"
+                        "    ( out )\n}\n"),
+            "assign-outer-field": prog(
+                "    ( caller )",
+                prelude="",
+                extra=ESC_CTR + ESC_SLOT + "@ caller → v {\n"
+                      "    : ~ Slot box @ Slot { \\ → v { } }\n"
+                      "    ? > 1 0 {\n" + ESC_MKREF
+                      + "        = . box cb f\n    } {}\n"
+                        "    : ( @ v ) g . box cb\n    ( g )\n}\n"),
+            # The field store makes the STRUCT a stack reference; the
+            # `^` is what dangles. Same situation as ret-via-local, one
+            # aggregate in the way.
+            "field-store-then-return": prog(
+                "    : Slot s ( caller )\n    : ( @ v ) g . s cb\n    ( g )",
+                prelude="",
+                extra=ESC_CTR + ESC_SLOT + "@ caller → Slot {\n" + ESC_MKREF
+                      + "    : ~ Slot box @ Slot { \\ → v { } }\n"
+                        "    = . box cb f\n    ^ box\n}\n"),
+            # Heap-container sinks, reached through the phi and through
+            # a struct field.
+            "push-ternary": prog(
+                "    : ( Vec Slot ) h ( vec_new [Slot] )\n"
+                "    ( caller h )\n"
+                "    ( vec_free [Slot] h )",
+                prelude=PRELUDE_VEC,
+                extra=ESC_CTR + ESC_SLOT
+                      + "@ caller ( Vec Slot ) heap → v {\n" + ESC_MKREF
+                      + "    ( vec_push [Slot] heap @ Slot "
+                        "{ ? > . c n 0 f f } )\n}\n"),
+            "push-vec-in-field": prog(
+                "    : Holder h @ Holder { ( vec_new [Slot] ) }\n"
+                "    ( caller h )\n"
+                "    ( vec_free [Slot] . h items )",
+                prelude=PRELUDE_VEC,
+                extra=ESC_CTR + ESC_SLOT
+                      + ": Holder { ( Vec Slot ) items }\n"
+                      + "@ caller Holder h → v {\n" + ESC_MKREF
+                      + "    ( vec_push [Slot] . h items @ Slot { f } )\n}\n"),
+            "vec-set": prog(
+                "    : ( Vec Slot ) h ( vec_new [Slot] )\n"
+                "    ( caller h )\n"
+                "    ( vec_free [Slot] h )",
+                prelude=PRELUDE_VEC,
+                extra=ESC_CTR + ESC_SLOT
+                      + "@ caller ( Vec Slot ) heap → v {\n" + ESC_MKREF
+                      + "    : Slot s @ Slot { f }\n"
+                        "    ( vec_set [Slot] heap 0 s )\n}\n"),
+            "vec-insert": prog(
+                "    : ( Vec Slot ) h ( vec_new [Slot] )\n"
+                "    ( caller h )\n"
+                "    ( vec_free [Slot] h )",
+                prelude=PRELUDE_VEC,
+                extra=ESC_CTR + ESC_SLOT
+                      + "@ caller ( Vec Slot ) heap → v {\n" + ESC_MKREF
+                      + "    : Slot s @ Slot { f }\n"
+                        "    ( vec_insert [Slot] heap 0 s )\n}\n"),
+            "vec-extend": prog(
+                "    : ( Vec Slot ) h ( vec_new [Slot] )\n"
+                "    ( caller h )\n"
+                "    ( vec_free [Slot] h )",
+                prelude=PRELUDE_VEC,
+                extra=ESC_CTR + ESC_SLOT
+                      + "@ caller ( Vec Slot ) heap → v {\n" + ESC_MKREF
+                      + "    : ( Vec Slot ) local ( vec_new [Slot] )\n"
+                        "    ( vec_push [Slot] local @ Slot { f } )\n"
+                        "    ( vec_extend [Slot] heap local )\n"
+                        "    ( vec_free [Slot] local )\n}\n"),
+            "thread-ternary": prog(
+                "    ( caller )",
+                prelude=PRELUDE_THREAD,
+                extra=ESC_CTR + "@ caller → v {\n" + ESC_MKREF
+                      + "    : !Thread ThreadErr t ( thread_spawn "
+                        "? > . c n 0 f f )\n"
+                        "    ?? t { T th → { : i _r ( thread_join th ) } "
+                        "F _ → {} }\n}\n"),
+        },
+    },
+    {
         "name": "escape-into-callee",
         "severity": "memory-unsafety",
         "doc": "The mirror image of ret-escape: a stack reference passed "
@@ -912,6 +1090,66 @@ CLASSES = [
                         "    ?? t { T th → { : i _r ( thread_join th ) } F _ → {} }\n}\n"
                       + "@ leaky → v {\n" + ESC_MKREF
                       + "    : Slot s @ Slot { f }\n    ( detachs s )\n}\n"),
+        },
+    },
+    {
+        "name": "raw-ptr-escape",
+        "severity": "diagnostic-consistency",
+        "doc": "A `# *T` cast that reaches inside an OWNED binding's "
+               "allocation (docs/MEMORY.md §2.9 check 2). The binding is "
+               "auto-dropped at scope exit, so any pointer derived from "
+               "the cast outlives its referent — whether the cast is "
+               "bound, copied, passed straight to a callee, taken in a "
+               "branch, or selected by a phi. Strict-only by design: `*T` "
+               "is the trusted FFI surface (§3), and the default checker "
+               "leaves it alone. This class found no gap when it was "
+               "written — the check fires at the cast itself, where "
+               "spelling cannot vary — and exists to keep it that way.",
+        "expect": REJECT_STRICT,
+        "expect_msg": ["casts an owned binding to a raw pointer"],
+        "spellings": {
+            "cast-string-data": (
+                "$ `stdlib/core/string.nu`\n"
+                "@ main → i {\n"
+                "    : String s ( string_from `hello` )\n"
+                "    : *u p # *u ( string_data s )\n"
+                "    ^ # i . p 0\n}\n"),
+            "cast-then-copy": (
+                "$ `stdlib/core/string.nu`\n"
+                "@ main → i {\n"
+                "    : String s ( string_from `hello` )\n"
+                "    : *u p # *u ( string_data s )\n"
+                "    : *u q p\n"
+                "    ^ # i . q 0\n}\n"),
+            "cast-in-branch": (
+                "$ `stdlib/core/string.nu`\n"
+                "@ main → i {\n"
+                "    : String s ( string_from `hello` )\n"
+                "    ? > 1 0 {\n"
+                "        : *u p # *u ( string_data s )\n"
+                "        ^ # i . p 0\n    } {}\n"
+                "    ^ 0\n}\n"),
+            "cast-through-ternary": (
+                "$ `stdlib/core/string.nu`\n"
+                "@ main → i {\n"
+                "    : String s ( string_from `hello` )\n"
+                "    : *u p ? > 1 0 # *u ( string_data s ) "
+                "# *u ( string_data s )\n"
+                "    ^ # i . p 0\n}\n"),
+            "cast-vec-data": (
+                "$ `stdlib/core/vec.nu`\n"
+                "@ main → i {\n"
+                "    : ( Vec u ) v ( vec_new [u] )\n"
+                "    ( vec_push [u] v # u 1 )\n"
+                "    : *u p # *u ( vec_data [u] v )\n"
+                "    ( vec_free [u] v )\n"
+                "    ^ # i . p 0\n}\n"),
+            "cast-as-argument": (
+                "$ `stdlib/core/string.nu`\n"
+                "@ take *u p → i { ^ # i . p 0 }\n"
+                "@ main → i {\n"
+                "    : String s ( string_from `hello` )\n"
+                "    ^ ( take # *u ( string_data s ) )\n}\n"),
         },
     },
     {
@@ -1261,6 +1499,45 @@ CLASSES = [
                       "    : ( Vec i ) xs ( vec_new [i] )\n"
                       "    : ( @ v ) f \\ → v { ( vec_push [i] xs 1 ) }\n"
                       "    ^ f\n}\n"),
+            # §2.3 join controls. A phi is only as dangerous as what it
+            # selects between: closures that capture NOTHING are values,
+            # and returning a join of them is ordinary code. This is the
+            # control the join-carries-referent-depth rule has to keep
+            # passing — publishing the depth unconditionally, or reading
+            # the condition's residue as an arm's, breaks it.
+            "plain-closure-join-returned": prog(
+                "    : ( @ v ) g ( caller )\n"
+                "    ( g )",
+                prelude="",
+                extra="@ caller → ( @ v ) {\n"
+                      "    : i k 1\n"
+                      "    ^ ? > k 0 \\ → v { } \\ → v { }\n}\n"),
+            # The join never leaves the frame it references, so nothing
+            # outlives anything.
+            "join-stays-in-frame": prog(
+                "    : i n ( caller )",
+                prelude="",
+                extra=ESC_CTR + "@ caller → i {\n" + ESC_MKREF
+                      + "    : ( @ v ) g ? > . c n 0 f f\n"
+                        "    ( g )\n    ^ . c n\n}\n"),
+            # A field store at the SAME region as its referent: the
+            # struct and the frame it points into die together.
+            "field-store-same-region": prog(
+                "    : i n ( caller )",
+                prelude="",
+                extra=ESC_CTR + ESC_SLOT + "@ caller → i {\n" + ESC_MKREF
+                      + "    : ~ Slot box @ Slot { \\ → v { } }\n"
+                        "    = . box cb f\n"
+                        "    : ( @ v ) g . box cb\n    ( g )\n"
+                        "    ^ . c n\n}\n"),
+            # An ordinary scalar field store carries no reference at all
+            # — the spelling the field-store hook sees most often.
+            "scalar-field-store": prog(
+                "    : i n ( caller )",
+                prelude="",
+                extra=ESC_CTR + "@ caller → i {\n"
+                      "    : ~ Counter c @ Counter { 0 10 }\n"
+                      "    = . c n 7\n    ^ . c n\n}\n"),
             # A helper returning a FRESH value, having merely borrowed
             # the reference, is not a passthrough — its result may be
             # returned freely.


### PR DESCRIPTION
`docs/MEMORY.md` §2.3 said reference-ness propagates through closure and aggregate literals, copies and assignments. Listing the spellings it does **not** propagate through found three families, every one confirmed under AddressSanitizer:

| spelling | verdict before | ASan |
|---|---|---|
| `^ ? c f f` · `^ ?? … { → f }` · bound first · ternary-of-struct · struct-of-ternary | accept | `stack-use-after-return` |
| `= . box cb f` then `^ box` | accept | `stack-use-after-return` |
| `?? c { 1 → ? d a a  _ → ( make ) }` (§2.2 handle twin) | accept | `heap-use-after-free` |

Same shape as #898–#916: the checker asked its question at one spelling and missed the others. `^ f` was an error and `^ ? c f f` compiled clean — a branch that cannot change the answer, since both arms hand back the same dead frame.

## What changed

- **A `?` / `??` join publishes the deepest LIVE arm's referent depth**, with the per-arm reset+snapshot discipline the ownership channels beside it already had. One arm carrying the reference is enough — the result dangles on that path; an arm that returned never reaches the phi and was checked at its own `^`. Every exit of `gen_match` publishes, otherwise the *last* arm's depth stands as the whole match's answer — the residue bug each ownership channel there was fixed for in turn.
- **`= . obj field rhs` gets the two effects `= obj rhs` always had**: the struct inherits the reference (so a later `^ obj` fires), and a store into a struct that outlives the referent is reported at the store. Hooked in `gen_field_rhs`, the one function all eight store shapes route their RHS through. Inherits upwards only — a field store overwrites one field and cannot prove the others stopped referencing anything.
- **`gen_match` carries up a nested join's handle candidates**, as `gen_cond` has since #899, and an inherited candidate makes the join non-definite exactly as it does there.

## Gates

- **Corpus differential**: 1019 files (compiler, stdlib, examples, tools, packages) compile to **byte-identical IR** against `main`, and **not one new rejection** — the pass still lowers nothing and the no-false-positive property holds.
- `run_san_tests.sh` → `SAN_FAIL: 0` · `tools/leakgate.sh` → zero leaks · bootstrap fixed point unchanged · goldens, diagnostic-coverage and Windows-golden gates clean.

## Coverage

§2.3 was the **only default-on rule with no metamorph class** — which is why its interprocedural cousins §2.7/§2.8 had been swept twice and the rule they build on never had. New `intraproc-escape` class (18 spellings) plus `raw-ptr-escape` for §2.9 check 2 (found no gap; now cannot grow one). Four new controls pin the no-false-positive side of the join and field-store rules. Sixteen classes, baseline still empty.

Docs: §2.3, §5's table, §6.2 and §6.6 updated — and two stale rows went with them, since §3 and §5 still said nested-argument aliased reads were unchecked after #915 had fixed them under `--strict-borrowck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU