### PR TITLE
release: 0.44.0 — the order-independent release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,201 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.0] — 2026-08-16
+
+The order-independent release. Every entry started from the same
+question, asked once and then asked again of each rule in turn: *does
+this check answer a question, or does it recognise a shape?* Three
+things turned out to be shapes.
+
+A stack reference was safe until it rode a `?`. `^ f` was an error and
+`^ ? c f f` compiled clean — a branch that cannot change the answer,
+since both arms hand the caller the same dead frame. The same was true
+of a field store, and of a join nested inside a `??` arm. Every one is
+a confirmed `stack-use-after-return` or heap use-after-free under
+AddressSanitizer.
+
+And *where you wrote a function* still decided two verdicts. A helper
+defined below its caller has no summary yet, and an empty summary reads
+as "does not mutate" rather than "not compiled yet". Both rules that
+still consulted one inline now park what they cannot answer and resolve
+it after the module — §2.10 by parking the finished report rather than
+the question, because its diagnostic fires at a later read of the
+pointer and there is no call site to park at. **No rule in the memory
+model depends on definition order any more.**
+
+Underneath both is one method: §2.3 was the only default-on rule with
+no `tools/metamorph` class, which is exactly why its interprocedural
+cousins had been swept twice and the rule they build on never had. Ask
+what is *not* in the harness, not what is. The harness itself gained a
+second axis for the one part of the model no compile verdict can
+answer — the panic-unwind journal, whose question is an LSan run — and
+that oracle was found broken by mutation-testing it before it was
+trusted.
+
+### Fixed
+
+- **The same reference, however it leaves the function.**
+  `docs/MEMORY.md` listed four boundaries around the two
+  interprocedural escape checks. Enumerating the spellings found
+  **eleven**, and every one had the shape the whole 0.43.0 cycle had:
+  the check asked its question at one syntax and said nothing at the
+  others. Out through the result (§2.8) missed a nested aggregate, a
+  closure that captured the reference, a local name given to it, a
+  second helper, a ternary, and a callee defined below the call or
+  written generically. In through a parameter (§2.7) missed a whole
+  chain defined below its caller, a helper whose own escaping callee
+  sat below it, a generic escaping parameter, and a *field* of the
+  parameter reaching `thread_spawn`. ASan reports
+  `stack-use-after-return` on all of them.
+
+  Three mechanisms close them. A binding carries the parameters its
+  initialiser carried, and a call result carries those at the callee's
+  returned positions, so a reference does not lose provenance by being
+  given a name or taking another hop. Propagation between summaries is
+  parked as an implication and run to a **fixed point** before any
+  parked check replays — which is what makes a forward chain behave
+  like the same functions written bottom-up. And the return-escape
+  check parks what it cannot answer at a forward or generic call.
+
+  §2.4 and §2.10 were the two checks with no coverage class at all, and
+  each turned out to have one gap: strict-mode aliased mutation knew
+  `. c n` but not `( peek c )`, so the *depth* of the expression
+  decided the verdict; and the stale-borrow rule knew only a direct
+  stdlib mutator, so `( grow v )` was silent where `( vec_push v … )`
+  warned — which reads as "wrap the push in a function" being the cure
+  for the diagnostic rather than for the bug.
+
+- **`tools/metamorph` was not running in CI, and its baseline was
+  stale.** The harness had run only by hand. `known_gaps.json` still
+  listed two gaps that had already been fixed, and a stale baseline is
+  not cosmetic — it would have absorbed the regression had either hole
+  come back. It is a CI step now and the baseline is empty. Separately,
+  `--verify` could not see a stack bug at all: ASan instruments only
+  functions carrying `sanitize_address`, which the C frontend adds and
+  nurlc's hand-written IR does not, so escalations saw only what the
+  runtime's malloc interceptors caught and every dangling stack
+  reference ran clean and was filed UNCONFIRMED. The escalation now
+  stamps the attribute on the generated module and runs with
+  `detect_stack_use_after_return=1`. The gate also fails loudly when
+  `llvm-as` is missing rather than quietly reporting every module
+  valid.
+
+- **A stack reference stopped being safe the moment it rode a `?`.**
+  Reference-ness propagated through closure literals, aggregate
+  literals, copies and `=` assignments — but not through the phi of a
+  conditional, so `^ f` was an error and `^ ? c f f` compiled clean. The
+  branch cannot change the answer: both arms hand the caller a pointer
+  into the frame that is about to disappear. AddressSanitizer reports
+  `stack-use-after-return` on every spelling — the ternary, the `??`,
+  the join bound to a local first, a struct literal built from one, a
+  ternary between two structs, and the same join reaching `vec_push` or
+  `thread_spawn` instead of a return.
+
+  Two more of the same shape came with it. `= . box cb f` — a field
+  store — walked a stack reference into a longer-lived struct with
+  nothing said, and returning that struct handed out the dead frame;
+  the field form now has the two effects the whole-binding form always
+  had (the struct inherits the reference, and a store into a struct
+  that outlives the referent is reported at the store). And a join
+  nested inside a `??` arm dropped the handle candidates `gen_cond` has
+  carried up since 0.42.0, so `?? c { 1 → ? d a a  _ → ( make ) }`
+  handed `a`'s buffer over with nothing recorded: freeing both names
+  compiled clean into a heap use-after-free.
+
+  §2.3 was the only default-on rule with no `tools/metamorph` class,
+  which is why its interprocedural cousins had been swept twice and the
+  rule they build on never had. It has one now — eighteen spellings —
+  and so does the strict `# *T` escape check, which found no gap and
+  now cannot grow one. Four new controls pin the other direction: a
+  join between closures that capture nothing, a join that stays in its
+  frame, a same-region field store, an ordinary scalar field store.
+  (`borrow_escape_join`, `borrow_escape_field_store`,
+  `borrow_strict_nested_join_alias`)
+
+- **Iterator invalidation stopped depending on definition order too.**
+  §2.5 follows a container mutation one call deep through the
+  per-function mutation summary, and that summary is built in codegen
+  order — so `~ y xs { ( grow xs ) }` was diagnosed when `grow` sat
+  above the loop and silent when it sat below. The call now parks the
+  question and replays it against the final summary.
+
+- **Definition order can no longer change any verdict the borrow
+  checker gives.** §2.10 was the last rule where it could: a pointer
+  borrowed with `vec_data` goes stale when the container is grown
+  through a helper, and that was reported when the helper sat above the
+  borrow and silent when it sat below, because an empty mutation
+  summary reads as "does not mutate" rather than "not compiled yet".
+
+  §2.5 parks that question at the call, where its diagnostic fires.
+  This one fires at a later *read* of the pointer, so there is no
+  single site to park; what is parked is the finished report plus the
+  callee it is conditional on. The call kills the pointer
+  provisionally, and the condition rides *inside* the stale-set entry
+  rather than in a side table — a question parked before a `?` and a
+  certain kill inside one arm are precisely the pair that meet at the
+  join, and a side table does not survive the union. A certain mutation
+  supersedes a parked one, entry and line together, so the report names
+  the call that really reallocates.
+  (`should_warn_stale_borrow_forward`)
+
+- **`anomaly --version` told the truth for the first time since 0.5.2.**
+  `cli_new` takes the version as a string literal and nothing derived
+  it from `nurl.toml`, so the two drifted the moment a release bumped
+  one and forgot the other — invisibly, because no test ran `--version`
+  and compared it to anything. anomaly shipped 0.5.3 and 0.5.4 while
+  `--version` kept answering 0.5.2; a version can be yanked, never
+  replaced. `tools/check_package_version_strings.sh` now compares every
+  package's manifest against the literal it passes to `cli_new` and
+  fails on a mismatch, with comments stripped so the doc example in
+  `packages/cli` is not mistaken for a real call. All 45 packages
+  audited; anomaly was the only real drift.
+
+- **A regression test that had never run once.** `test_skips.sh`
+  skipped any test whose *name* ended in `_mod` / `_helper` / `_lib`,
+  on the theory that those are importable modules with no `main()`.
+  `diag_thread_arc_shared_mutation_helper.nu` — the regression test for
+  the Arc shared-mutation race one call deep — has a `main()` and was
+  skipped by name. It had no golden either, and neither the
+  MISSING-golden check nor the ORPHAN check fires for a skipped test,
+  so the only trace was the SKIP count. The rule now asks the *file*
+  whether it has a `main()`.
+
+- **~1.2 MB of generated test scratch had been committed to
+  `packages/anomaly`.** Model blobs and `data.jsonl` written by
+  `timevector_test.nu`, swept in by a `git add -A` and about to go into
+  a published tarball — the same class as the packer defect fixed in
+  0.41.0. Removed, and `.gitignore` now excludes the directory the test
+  writes to.
+
+### Added
+
+- **`tools/metamorph` grew a second axis, for the one part of the
+  memory model no compile verdict can answer.** Every class in the
+  harness asks the compiler a question and compares verdicts across
+  spellings. The panic-unwind allocation journal is a *runtime*
+  mechanism: a `panic` longjmps past the scope-exit frees the compiler
+  queued, and the journal reclaims what it skipped, so the question is
+  whether the program leaks — or frees something the caller still owns.
+  The `panic-reclaim` class asks it as an LSan run over nine spellings
+  of one abandoned allocation: a `?` arm, a `??` arm, a loop body, two
+  frames deep, a nested extent (the inner unwind must not touch the
+  outer's scratch), a second extent after the first (a stale journal
+  would drain twice), an extent that never panics, and the escape case
+  where a value moved into a caller's binding must *not* be freed. All
+  nine come back clean — the journal is uniform across them, measured
+  rather than assumed.
+
+  The oracle was broken first, and mutation-testing it is what found
+  that: under LSan's defaults a deliberately-leaking control reported
+  CLEAN, because the buffer's only owner is a live `main` frame and so
+  it reads as still reachable. With `use_stacks=0` the control reads
+  `leak` and a double free reads `crash`. At process exit an allocation
+  the program still owns *is* the leak being asked about; the stack
+  must not launder it. The gate runs in the sanitizers job, where the
+  `--san` build has already produced the runtime it needs, and it skips
+  *loudly* without one.
+
 ### Changed
 
 - **The cross-file `__` path is obsolete, and nothing first-party uses
@@ -13136,7 +13331,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.43.0...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.44.0...HEAD
+[0.44.0]: https://github.com/nurl-lang/nurl/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/nurl-lang/nurl/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/nurl-lang/nurl/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/nurl-lang/nurl/compare/v0.40.0...v0.41.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-15 · Current release: **0.43.0** · Language: **Grammar
+_Last reviewed: 2026-08-16 · Current release: **0.44.0** · Language: **Grammar
 v2.5** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---
@@ -46,6 +46,10 @@ What is solid today:
   catches use-after-move, alias double-free, escaping closure captures,
   interprocedural/return escape, loop-carried double-frees, and
   iterator invalidation as hard errors without changing generated code.
+  Since 0.44.0 **no rule depends on definition order**: every check that
+  consults a per-function summary parks what it cannot answer and
+  resolves it after the module, so where a helper is written can no
+  longer change a verdict.
 - **Concurrency.** A stackful M:N work-stealing async runtime with **no
   `async`/`await` colouring** — ordinary code runs unchanged under the
   scheduler — plus threads/mutex/cond, typed channels, and Go-style `??`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1523,7 +1523,10 @@ A closure capturing a `: ~`-mutable multi-field struct binding by
 pointer (see §8.4) is a *stack reference*. Returning it, pushing it
 into a longer-lived container, spawning a thread that holds it, or
 assigning it into a longer-lived binding is rejected. The escape rule
-also covers an aggregate (struct) literal that holds such a closure.
+also covers an aggregate (struct) literal that holds such a closure,
+a `= . obj field` store into one (the struct inherits the reference),
+and the phi of a `?` / `??` — a join carries the deepest referent depth
+any live arm carries, so `^ ? c f f` is rejected exactly as `^ f` is.
 
 ### 9.4 Exclusive access at a call site
 
@@ -1538,7 +1541,8 @@ writer" rule scoped to a single call.
 ```
 
 A read of the same binding through a *nested sub-expression* argument
-(`( f inout c (g c) )`, `( f inout c . c n )`) is **not** flagged — by
+(`( f inout c (g c) )`, `( f inout c . c n )`) is **not** flagged by
+default — by
 the language's left-to-right evaluation order and Option B's
 call-scoped borrow lifetime, that read completes before the `inout`
 borrow goes live (§6.2).
@@ -1574,13 +1578,15 @@ detaches it onto a thread. The checker computes a per-function *escape
 summary* (which parameters the body lets escape, transitively) and
 rejects passing a stack reference to an escaping parameter. Forward and
 generic calls are handled by parking the check and replaying it after the
-whole module compiles, so definition order does not matter; the one
-residual is a *pure forward chain* of helpers (§9.9).
+whole module compiles, so definition order does not matter — including a
+*pure forward chain* of helpers, whose summaries are propagated as
+implications and run to a fixed point before any parked check replays.
 
 ### 9.8 Return escape
 
-A helper that **returns one of its parameters** (directly, or inside a
-returned struct) hands the reference back out. The checker records a
+A helper that **returns one of its parameters** — directly, inside a
+returned struct at any nesting depth, inside a closure that captured it,
+or after binding it to a local first — hands the reference back out. The checker records a
 second summary of returned-parameter positions; the result of such a call
 carries the max referent depth of the arguments at those positions, so
 the existing escape sinks (§9.3 / §9.7) fire on it. A helper that returns
@@ -1590,15 +1596,13 @@ a *fresh* value is not a passthrough and stays legal.
 
 - `*T` raw pointer lifetimes (the FFI escape hatch) — except the one
   narrow `# *T`-escape check `--strict-borrowck` adds (§9 intro).
-- Aliased mutation beyond a single call (longer-range "exclusive
-  reference" analysis is not currently implemented), and a binding read
-  through a *nested* sub-expression argument (§6.2) — though
-  `--strict-borrowck` does flag aliased mutation through a `. obj field`
-  argument.
-- A *pure forward chain* of escaping helpers (§9.7) and a parameter
-  returned through a closure *capture* rather than a struct field (§9.8) —
-  the residual interprocedural gaps. Both degrade the *diagnostic* only,
-  never a miscompile.
+- Aliased mutation beyond a single call: longer-range "exclusive
+  reference" analysis is not implemented. Within one call,
+  `--strict-borrowck` flags a sibling read however it is spelled — a
+  `. obj field` projection, a read nested inside another call, at any
+  depth and in either argument order; the default mode reports only the
+  bare-identifier form, deliberately, because every sibling read is a
+  snapshot taken before the callee runs (§6.2).
 - Panic / `recover` control flow: the checker treats `recover` as an
   ordinary call and does not model panic unwind. It does not need to —
   the owned allocations a panic `longjmp` would skip are reclaimed at the


### PR DESCRIPTION
## What is in it

Eight merges since v0.43.0. `[Unreleased]` carried **one** of them, so the section was audited against the merge history rather than trusted — the standing lesson from 0.34.0/0.38.0/0.41.0.

| PR | entry |
|---|---|
| #913 | ~1.2 MB of generated test scratch committed to `packages/anomaly`, about to go into a published tarball |
| #914 | `anomaly --version` had answered 0.5.2 since 0.5.2 — two releases shipped wrong, plus the CI gate so it cannot drift again |
| #915 | eleven escape spellings the two interprocedural checks missed; the harness into CI; ASan's blind spot on nurlc's own IR |
| #916 | §2.5 loses its order dependence — and a regression test skipped by *name* that had never run once |
| #917 | §2.3 stops at the phi and at the dot: a stack reference riding a `?`/`??` join, or written into a struct field |
| #918 | §2.10 stops depending on definition order — the last rule that did |
| #919 | the harness gains a runtime axis, for the one part of the model no compile verdict can answer |
| #912 | the cross-file `__` path is obsolete (already in `[Unreleased]`) |

## Why MINOR

The default checker now rejects code it used to accept: a stack reference riding a join, one written into a struct field, and a handle selected by a join nested in a `??` arm. Same reasoning as 0.38.0 / 0.41.0 / 0.42.0.

Compare links were already correct going in — fourth release running.

## Docs

Audited against what shipped, not against memory. `spec.md` §9.7 and §9.9 still listed a *pure forward chain* of escaping helpers and a parameter returned through a closure capture as the residual interprocedural gaps; #915 closed both, and the metamorph classes that pin them report `reject`. §9.9 also still said a nested-argument aliased read was unchecked — strict mode flags it at any depth since #915. §9.3 gained the two carriers §2.3 learned this cycle, §9.8 the three shapes a returned reference can wear.

ROADMAP: header bumped, and the memory bullet now states the property that became true this cycle — **no rule depends on definition order**.

`MEMORY.md` and `LIMITATIONS.md` were already current: MEMORY.md was updated in the PRs that changed it, and LIMITATIONS.md's memory rows are cross-references to it plus the Send/Sync table from 0.43.0, which nothing this cycle touched.

## Checks

`check_builtins_doc.sh`, `check_package_version_strings.sh`, `check_installer_sync.sh` all clean. Docs-only change on top of a green main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU