### PR TITLE
release: 0.44.1 — the compiler could not compile correct code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.1] — 2026-08-16
+
+A patch cut for one reason: 0.44.0 could not compile a correct program,
+and a published package was the proof.
+
+Installing all 48 registry packages with 0.44.0 — the standing rule that
+publishing proves nothing, so install it — turned up six that did not
+build. Five were the ecosystem's own defects and are fixed in the
+packages. The sixth was the compiler's.
+
+### Fixed
+
+- **A ternary may end a condition; the `{` after it is the body.** The
+  n-ary arity trap (0.37.0) fires when a `{` follows a completed
+  ternary: `? & a b c d { then } { else }` means an n-ary AND, `& a b`
+  takes two operands, `c` and `d` are eaten as the bare then/else, and
+  the blocks become stray statements. Real trap, worth the hard error
+  it became.
+
+  That signal has a second and entirely correct source:
+
+  ```
+  ~ & ok < i0 ? >= stopat 0 stopat N { body }
+  ```
+
+  Here the ternary is part of the **loop's** condition and the `{`
+  opens the loop body. Nothing is stray, there is no rewrite that
+  avoids the diagnostic, and it is an error by default — so a correct
+  program could not be compiled at all. The `?`-condition form has it
+  too. `packages/lingbot-map` had exactly this shape and could not be
+  installed by any toolchain.
+
+  The check now stays silent while a condition is being parsed and
+  fires exactly as before everywhere else. Inside a condition the two
+  cases are genuinely indistinguishable — the `{` is the enclosing
+  construct's block either way — so silence is the only answer that
+  keeps correct code compiling, and it is the direction every other
+  diagnostic here takes: miss, never invent. The corpus compiles to
+  byte-identical IR; the only exit-code change anywhere is the new test.
+  (`arity_ternary_in_condition`, with `arity_strict_nary` unmoved)
+
+- **Two published packages that could not be installed, and five that
+  announced the wrong version.** `gguf` passed an `i` where a `b` was
+  declared; `lingbot-map` carried stray fourth blocks on two `?`
+  statements. Both failed identically under 0.43.0 — they had simply
+  been uninstallable since publication, and nothing was looking,
+  because `nurlpkg publish` does not build what it publishes.
+
+  Then the freshly published `gguf 0.3.1` printed `gguf 0.3.0`: the
+  gate added days earlier to stop exactly that checks
+  `cli_new prog about VERSION`, and gguf prints its version with a bare
+  `nurl_print` of the literal `gguf 0.3.0`. It now also matches a literal
+  carrying the package's **own name** followed by a semver, went from
+  checking 1 literal to 13, and found four more drifted packages —
+  `safetensor` was two minors behind. All are bumped rather than
+  corrected in place: each had already shipped announcing the wrong
+  number, and a published version can be yanked, never replaced.
+
+
 ## [0.44.0] — 2026-08-16
 
 The order-independent release. Every entry started from the same
@@ -13331,7 +13390,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.44.0...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.44.1...HEAD
+[0.44.1]: https://github.com/nurl-lang/nurl/compare/v0.44.0...v0.44.1
 [0.44.0]: https://github.com/nurl-lang/nurl/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/nurl-lang/nurl/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/nurl-lang/nurl/compare/v0.41.0...v0.42.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-16 · Current release: **0.44.0** · Language: **Grammar
+_Last reviewed: 2026-08-16 · Current release: **0.44.1** · Language: **Grammar
 v2.5** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---


### PR DESCRIPTION
A patch cut for one reason: **0.44.0 rejected a correct program**, and a published package was the proof.

Installing all 48 registry packages with 0.44.0 — the standing rule that publishing proves nothing, so install it — turned up six that did not build. Five were the ecosystem's own defects (#922, #923); the sixth was the compiler's (#921):

```
~ & ok < i0 ? >= stopat 0 stopat N { body }
```

The ternary ends the **loop's** condition and the `{` opens the body — but the n-ary arity check saw "a `{` follows a completed ternary" and rejected it, as a hard error with no rewrite. `packages/lingbot-map` had exactly this shape and could not be installed by any toolchain.

## Why PATCH and not minor

#921 only **accepts** code the previous release rejected. No new API, and nothing that used to compile stops compiling — the opposite direction from 0.44.0, which is why that one was minor.

## Contents

| PR | |
|---|---|
| #921 | the arity check stays silent while a condition is being parsed |
| #922 | gguf and lingbot-map: uninstallable since publication |
| #923 | the version-string gate asked at one spelling too — 1 literal checked became 13, four more drifted packages found |

Compare links added for 0.44.0 → 0.44.1; ROADMAP header bumped.

## Known, and not fixed here

`yoloe` will still not install from a release: it needs the `X11` FFI sentinel, which is baked into the toolchain **at the toolchain's own build time** and the release runner has no libX11-dev. Shipping the sentinel unconditionally would turn a clean compile-time message into an undefined-symbol link failure on headless machines, so the right fix is to probe at install time — a design change, not something to rush into a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU