### PR TITLE
yoloe could not be installed by anyone — four defects deep

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -22993,6 +22993,12 @@
     // (forward-compat) but not enforced — FFI symbols are linker-
     // level ABI globals, the linker doesn't know about NURL files.
     ( vis_take_pending_pub )
+    // Position of the `&`, kept for the conflicting-signature diagnostic
+    // below: by the time it fires the lexer has consumed the whole
+    // declaration and `die` would put the caret on the NEXT one — the
+    // same "points at the consequence" defect arity_strict_nary pins.
+    : i __ffi_line ( nurl_lex_line lex )
+    : i __ffi_col ( nurl_lex_col lex )
     ( nurl_lex_advance lex )  // consume '&'
     // Library STR: skipped for IR emission (LLVM declare carries no
     // library name) but used for the build-time sentinel check so a
@@ -23097,6 +23103,29 @@
     // generalises the prelude-symbol skip.
     : s emitkey ( nurl_str_cat fname `__ffi_emitted` )
     : b already != 0 ( nurl_sym_len syms emitkey )
+    // …but a second declaration of the same symbol with a DIFFERENT
+    // signature is not a duplicate, it is a disagreement about the ABI
+    // of one linker symbol — and it used to compile. The first
+    // `declare` is the one emitted (above), while every later
+    // declaration overwrote the call-site metadata this function
+    // registers (`fname`, `__ffi_params`, `__variadic*`), so calls were
+    // lowered against a signature the module never declared:
+    // `stdlib/core/posix.nu` declares `open s path i32 flags ... → i32`
+    // and a package redeclaring it `s path i flags → i` produced
+    // `call i64 (i8*, i32, ...) @open(i8* %p, i64 %f)` — nurlc exited 0
+    // and clang rejected the module, which is the worst place for the
+    // news. Identical redeclarations stay harmless, which is what the
+    // dedup above exists for.
+    : s sigkey ( nurl_str_cat fname `__ffi_sig` )
+    : s newsig ( nurl_str_cat3 ret_ty `(` ( nurl_str_cat params_str `)` ) )
+    : s oldsig ( nurl_sym_get syms sigkey )
+    ? & != 0 ( nurl_str_len oldsig ) ! ( seq oldsig newsig )
+    { ( die_pos lex __ffi_line __ffi_col ( nurl_str_cat3
+        ( nurl_str_cat3 `FFI symbol '` fname `' is already declared with a different signature: '` )
+        ( nurl_str_cat3 oldsig `' here says '` newsig )
+        `'. One linker symbol has ONE ABI — the first declaration is the one the module declares, so a call written against this one would be lowered against a signature the program never declared (and clang, not nurlc, would report it). Make the declarations identical, or drop this one and import the file that has it.` ) ) }
+    {}
+    ( nurl_sym_def syms sigkey newsig )
     ? | | is_prelude_cfn already defined_in_nurl
     {}
     { ( nurl_sym_def syms emitkey `1` )

--- a/compiler/tests/outputs/should_fail_ffi_sig_conflict.txt
+++ b/compiler/tests/outputs/should_fail_ffi_sig_conflict.txt
@@ -1,0 +1,1 @@
+COMPILE FAIL

--- a/compiler/tests/should_fail_ffi_sig_conflict.nu
+++ b/compiler/tests/should_fail_ffi_sig_conflict.nu
@@ -1,0 +1,31 @@
+// should_fail_ffi_sig_conflict.nu — one linker symbol, one ABI.
+//
+// `stdlib/core/posix.nu` declares open(2) as C does:
+//
+//     & `c` @ open s path i32 flags ... → i32
+//
+// Restating it with `i` where C says `int`, and without the ellipsis,
+// describes a DIFFERENT function under the same linker name. Both
+// declarations cannot be emitted (LLVM rejects a redefinition), so the
+// first one wins the `declare` — while every later one silently
+// overwrote the call-site metadata. Calls were then lowered against a
+// signature the module never declared:
+//
+//     call i64 (i8*, i32, ...) @open(i8* %p, i64 %f)
+//
+// nurlc exited 0 and clang delivered the news, about generated IR.
+// packages/yoloe hit exactly this and could not be built at all.
+//
+// Identical redeclarations stay legal — two modules declaring the same
+// extern is ordinary, and the dedup exists for it. Only a DISAGREEMENT
+// is an error, and it points at the `&` rather than at the next
+// declaration the lexer had already reached.
+
+$ `stdlib/core/posix.nu`
+
+& `c` @ open s path i flags → i
+
+@ main → i {
+    : i fd ( open `/dev/null` 0 )
+    ^ ? > fd 0 0 1
+}

--- a/nurlweb/public/install.sh
+++ b/nurlweb/public/install.sh
@@ -230,6 +230,38 @@ smoke() {
 smoke "$PREFIX/build/nurlc"
 smoke "$PREFIX/build/nurlpkg"
 
+# ── FFI sentinels: probe THIS machine, not the build runner ────────────
+# `stdlib/runtime.<lib>` tells nurlc that an FFI library is available.
+# build.sh writes them by probing the machine it runs on — which for a
+# release archive is the CI runner, not yours. libX11 is not installed
+# there, so no `runtime.X11` ships and `nurlpkg install yoloe` fails at
+# compile time with "install libX11-dev and run build.sh again" on a box
+# that already HAS libX11 and cannot run build.sh at all.
+#
+# The sentinel has to describe the machine that will link your programs,
+# so probe it here, with the same test build.sh uses. Absent library →
+# sentinel removed → the existing clean compile-time message, which is
+# the right answer on a headless box (nurl.sh would otherwise reach the
+# linker and fail there instead).
+probe_ffi_sentinel() {
+    name="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        echo 1 > "$PREFIX/stdlib/runtime.$name"
+    else
+        rm -f "$PREFIX/stdlib/runtime.$name"
+    fi
+}
+have_lib() {
+    pkg-config --exists "$1" 2>/dev/null && return 0
+    ldconfig -p 2>/dev/null | grep -q "lib$2\.so " && return 0
+    [ -e "/usr/lib/x86_64-linux-gnu/lib$2.so" ] || [ -e "/usr/lib/lib$2.so" ]
+}
+if [ -d "$PREFIX/stdlib" ]; then
+    probe_ffi_sentinel X11 have_lib x11 X11
+    probe_ffi_sentinel opus have_lib opus opus
+fi
+
+
 # ── PATH setup ─────────────────────────────────────────────────────────
 info ""
 info "NURL $VERSION installed → $PREFIX"

--- a/packages/yoloe/nurl.toml
+++ b/packages/yoloe/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoloe"
-version = "0.6.6"
+version = "0.6.7"
 description = "Promptable, open-vocabulary object detection AND instance segmentation from pure NURL on the GPU — a NURL port of YOLOE (THU-MIG, 'Real-Time Seeing Anything', ICCV 2025), including live masking straight off a webcam. You name the classes you want ('dog', 'bicycle', 'a person on a bike') and the model finds them — drawing both boxes and per-object segmentation masks — without a fixed label set. The whole network runs on the GPU through the onnx package (every layer a CUDA-C kernel compiled at runtime via NVRTC — no external inference engine), including the YOLOE-seg mask-prototype branch (ConvTranspose 2× upsample) and the mask decode (coefficients · prototypes → threshold → overlay), all verified numerically against onnxruntime (proto max abs err ~6e-5). Promptability comes from YOLOE's region-text contrastive head, which scores each region's visual embedding against the text embeddings of the prompt words, with the MobileCLIP text path also in pure NURL. The webcam feed is captured in pure NURL via Video4Linux2 (open/ioctl/mmap, YUYV→RGB) — no ffmpeg, no OpenCV. Requires the NVIDIA driver + NVRTC (via the gpu package); a GPU-less host is unaffected."
 license = "MIT OR Apache-2.0"
 

--- a/packages/yoloe/src/display.nu
+++ b/packages/yoloe/src/display.nu
@@ -13,18 +13,24 @@
 $ `stdlib/core/string.nu`
 $ `image.nu`
 
-& `c` @ ioctl i fd i req *u argp → i
+// `ioctl` as C declares it — `int ioctl(int, unsigned long, ...)`.
+// stdlib/std/term.nu declares the same symbol, and one linker symbol
+// has one ABI: stating it with `i` where C says `int` is a different
+// function, which the compiler now rejects rather than miscompiling.
+& `c` @ ioctl i32 fd i req ... → i32
+
 & `c` @ nurl_poke_i32 *u base i idx i32 val → v
+
 & `c` @ nurl_peek_i32 *u base i idx → i32
 
-@ __TIOCGWINSZ → i { ^ 21523 }   // 0x5413; struct winsize { u16 row, col, xpx, ypx }
+@ __TIOCGWINSZ → i { ^ 21523 }  // 0x5413; struct winsize { u16 row, col, xpx, ypx }
 
 // Terminal (rows, cols) from ioctl on stdout; sensible fallback off a tty.
-@ __winsize *i rowcell → i {           // returns cols, writes rows via cell
+@ __winsize * i rowcell → i {  // returns cols, writes rows via cell
     : *u ws ( nurl_alloc 8 )
     ( nurl_poke_i32 ws 0 0 ) ( nurl_poke_i32 ws 1 0 )
-    : i r ( ioctl 1 ( __TIOCGWINSZ ) ws )
-    : i v ( nurl_peek_i32 ws 0 )       // [row:16][col:16] little-endian
+    : i r ( ioctl # i32 1 ( __TIOCGWINSZ ) ws )
+    : i v ( nurl_peek_i32 ws 0 )  // [row:16][col:16] little-endian
     ( nurl_free ws )
     : ~ i rows & v 65535
     : ~ i cols & >> v 16 65535
@@ -41,7 +47,7 @@ $ `image.nu`
 // 4-byte slots. This box filter (area average) is what makes the downscaled
 // preview look smooth instead of the aliased mess that point-sampling a
 // 640-wide frame into ~100 cells produces. At least one pixel is sampled.
-@ __avg3 Image im i x0 i x1 i y0 i y1 *u out → v {
+@ __avg3 Image im i x0 i x1 i y0 i y1 * u out → v {
     : i xb ? > x1 + x0 1 x1 + x0 1
     : i yb ? > y1 + y0 1 y1 + y0 1
     : ~ i sr 0
@@ -69,7 +75,7 @@ $ `image.nu`
 // Clear the screen and hide the cursor (call once before a live loop).
 @ term_enter → v {
     : String s ( string_with_cap 16 )
-    ( string_push_char s 27 ) ( string_push_str s `[2J` )    // clear
+    ( string_push_char s 27 ) ( string_push_str s `[2J` )  // clear
     ( string_push_char s 27 ) ( string_push_str s `[?25l` )  // hide cursor
     ( nurl_print ( string_data s ) ) ( string_free s )
 }
@@ -95,7 +101,7 @@ $ `image.nu`
     : ~ i out_w cols
     : i out_h_px0 / * out_w H W
     : ~ i out_rows / out_h_px0 2
-    : i max_rows - rows 2                 // leave a line for the status
+    : i max_rows - rows 2  // leave a line for the status
     ? > out_rows max_rows {
         = out_rows max_rows
         = out_w / * * 2 out_rows W H
@@ -108,7 +114,7 @@ $ `image.nu`
     : *u tcell ( nurl_alloc 16 )
     : *u bcell ( nurl_alloc 16 )
     : String s ( string_with_cap + 64 * * out_w out_rows 44 )
-    ( string_push_char s 27 ) ( string_push_str s `[H` )    // cursor home
+    ( string_push_char s 27 ) ( string_push_str s `[H` )  // cursor home
     : ~ i ry 0
     ~ < ry out_rows {
         : i syt0 / * * 2 ry H out_h_px
@@ -118,8 +124,8 @@ $ `image.nu`
         ~ < cx out_w {
             : i sx0 / * cx W out_w
             : i sx1 / * + cx 1 W out_w
-            ( __avg3 im sx0 sx1 syt0 syt1 tcell )    // top pixel (foreground)
-            ( __avg3 im sx0 sx1 syt1 syb1 bcell )    // bottom pixel (background)
+            ( __avg3 im sx0 sx1 syt0 syt1 tcell )  // top pixel (foreground)
+            ( __avg3 im sx0 sx1 syt1 syb1 bcell )  // bottom pixel (background)
             // ESC [ 38;2;tr;tg;tb;48;2;br;bg;bb m  ▀(U+2580 = 226 150 128)
             ( string_push_char s 27 ) ( string_push_str s `[38;2;` )
             ( __push_num s ( nurl_peek_i32 tcell 0 ) ) ( string_push_char s 59 )
@@ -129,12 +135,12 @@ $ `image.nu`
             ( __push_num s ( nurl_peek_i32 bcell 0 ) ) ( string_push_char s 59 )
             ( __push_num s ( nurl_peek_i32 bcell 1 ) ) ( string_push_char s 59 )
             ( __push_num s ( nurl_peek_i32 bcell 2 ) )
-            ( string_push_char s 109 )   // 'm'
+            ( string_push_char s 109 )  // 'm'
             ( string_push_char s 226 ) ( string_push_char s 150 ) ( string_push_char s 128 )
             = cx + cx 1
         }
-        ( string_push_char s 27 ) ( string_push_str s `[0m` )   // reset colours
-        ( string_push_char s 10 )                                // newline
+        ( string_push_char s 27 ) ( string_push_str s `[0m` )  // reset colours
+        ( string_push_char s 10 )  // newline
         = ry + ry 1
     }
     ( nurl_print ( string_data s ) )

--- a/packages/yoloe/src/main.nu
+++ b/packages/yoloe/src/main.nu
@@ -314,7 +314,7 @@ $ `window.nu`
 }
 
 @ main → i {
-    : *Cli c ( cli_new `yoloe` `promptable open-vocabulary detection & instance segmentation (pure NURL, GPU)` `0.6.0` )
+    : *Cli c ( cli_new `yoloe` `promptable open-vocabulary detection & instance segmentation (pure NURL, GPU)` `0.6.7` )
     ( cli_flag_str c `model` 109 `MODEL.onnx` `YOLOE-seg export from tools/export.py (~45 MB, not bundled)` `` `` )
     ( cli_flag_str c `classes` 99 `FILE` `vocabulary, one prompt word per line` `` `` )
     ( cli_flag_str c `image` 105 `IMG` `detect/seg input (PNG, JPEG or PPM)` `` `` )

--- a/packages/yoloe/src/v4l2.nu
+++ b/packages/yoloe/src/v4l2.nu
@@ -16,16 +16,18 @@
 
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
+// open / close / mmap / munmap come from the stdlib, which has the
+// REAL C prototypes (`int open(const char *, int, ...)` and friends).
+// This file used to restate them with `i` where C says `int`, which is
+// a different ABI for the same linker symbol — and the compiler now
+// says so instead of emitting a call the module never declared.
+$ `stdlib/core/posix.nu`
 
-& `c` @ open s path i flags → i
-
-& `c` @ close i fd → i
-
-& `c` @ ioctl i fd i req *u argp → i
-
-& `c` @ mmap *u addr i length i prot i flags i fd i offset → *u
-
-& `c` @ munmap *u addr i length → i
+// `ioctl` as C declares it — `int ioctl(int, unsigned long, ...)`.
+// stdlib/std/term.nu declares the same symbol, and one linker symbol
+// has one ABI: stating it with `i` where C says `int` is a different
+// function, which the compiler now rejects rather than miscompiling.
+& `c` @ ioctl i32 fd i req ... → i32
 
 & `c` @ nurl_peek_i32 *u base i idx → i32
 
@@ -62,7 +64,7 @@ $ `stdlib/core/string.nu`
 
 // Open a webcam and start YUYV streaming at w×h with `nbuf` ring buffers.
 @ cam_open s path i w i h i nbuf → Camera {
-    : i fd ( open path ( __O_RDWR ) )
+    : i fd # i ( open path # i32 ( __O_RDWR ) )
     ? < fd 0 { ^ @ Camera { - 0 1 w h 0 ( vec_new [i] ) ( vec_new [i] ) 0 } } {}
 
     // VIDIOC_S_FMT: request YUYV w×h, progressive.
@@ -73,7 +75,7 @@ $ `stdlib/core/string.nu`
     ( nurl_poke_i32 fmt 3 h )  // pix.height @12
     ( nurl_poke_i32 fmt 4 ( __PIXFMT_YUYV ) )  // pix.pixelformat @16
     ( nurl_poke_i32 fmt 5 ( __FIELD_NONE ) )  // pix.field @20
-    : i rf ( ioctl fd ( __VIDIOC_S_FMT ) fmt )
+    : i rf ( ioctl # i32 fd ( __VIDIOC_S_FMT ) fmt )
     ? < rf 0 { ( close fd ) ( nurl_free fmt )
         ^ @ Camera { - 0 1 w h 0 ( vec_new [i] ) ( vec_new [i] ) 0 } } {}
     // the driver may adjust geometry — read back what it granted
@@ -87,7 +89,7 @@ $ `stdlib/core/string.nu`
     ( nurl_poke_i32 rb 0 nbuf )  // count @0
     ( nurl_poke_i32 rb 1 ( __BUF_TYPE_CAPTURE ) )  // type @4
     ( nurl_poke_i32 rb 2 ( __MEMORY_MMAP ) )  // memory @8
-    : i rr ( ioctl fd ( __VIDIOC_REQBUFS ) rb )
+    : i rr ( ioctl # i32 fd ( __VIDIOC_REQBUFS ) rb )
     : i got ( nurl_peek_i32 rb 0 )
     ( nurl_free rb )
     ? | < rr 0 < got 1 { ( close fd )
@@ -104,16 +106,16 @@ $ `stdlib/core/string.nu`
         ( nurl_poke_i32 bf 0 bi )  // index @0
         ( nurl_poke_i32 bf 1 ( __BUF_TYPE_CAPTURE ) )  // type @4
         ( nurl_poke_i32 bf 15 ( __MEMORY_MMAP ) )  // memory @60
-        : i qr ( ioctl fd ( __VIDIOC_QUERYBUF ) bf )
+        : i qr ( ioctl # i32 fd ( __VIDIOC_QUERYBUF ) bf )
         : i moff ( nurl_peek_i32 bf 16 )  // m.offset @64
         : i blen ( nurl_peek_i32 bf 18 )  // length @72
         ? < qr 0 { = allok F } {
-            : *u m ( mmap # *u 0 blen ( __PROT_RW ) ( __MAP_SHARED ) fd moff )
+            : *u m ( mmap # *u 0 blen # i32 ( __PROT_RW ) # i32 ( __MAP_SHARED ) # i32 fd moff )
             ? | == # i m 0 == # i m - 0 1 { = allok F } {
                 ( vec_push [i] ptrs # i m )
                 ( vec_push [i] lens blen )
                 // queue the buffer for capture
-                ( ioctl fd ( __VIDIOC_QBUF ) bf )
+                ( ioctl # i32 fd ( __VIDIOC_QBUF ) bf )
             }
         }
         ( nurl_free bf )
@@ -123,7 +125,7 @@ $ `stdlib/core/string.nu`
     // STREAMON
     : *u t ( nurl_alloc 4 )
     ( nurl_poke_i32 t 0 ( __BUF_TYPE_CAPTURE ) )
-    : i so ( ioctl fd ( __VIDIOC_STREAMON ) t )
+    : i so ( ioctl # i32 fd ( __VIDIOC_STREAMON ) t )
     ( nurl_free t )
     ? | < so 0 ! allok { ( close fd )
         ^ @ Camera { - 0 1 aw ah got ptrs lens 0 } } {}
@@ -145,7 +147,7 @@ $ `stdlib/core/string.nu`
     ( __zero bf 22 )
     ( nurl_poke_i32 bf 1 ( __BUF_TYPE_CAPTURE ) )  // type @4
     ( nurl_poke_i32 bf 15 ( __MEMORY_MMAP ) )  // memory @60
-    : i dr ( ioctl . c fd ( __VIDIOC_DQBUF ) bf )
+    : i dr ( ioctl # i32 . c fd ( __VIDIOC_DQBUF ) bf )
     ? < dr 0 { ( nurl_free bf ) ^ F } {}
     : i idx ( nurl_peek_i32 bf 0 )  // index @0
     : *u src # *u ?? ( vec_get [i] . c bufptr idx ) { T x → x F _ → 0 }
@@ -179,7 +181,7 @@ $ `stdlib/core/string.nu`
         = gi + gi 1
     }
     // requeue this buffer
-    ( ioctl . c fd ( __VIDIOC_QBUF ) bf )
+    ( ioctl # i32 . c fd ( __VIDIOC_QBUF ) bf )
     ( nurl_free bf )
     ^ T
 }
@@ -187,7 +189,7 @@ $ `stdlib/core/string.nu`
 @ cam_close Camera c → v {
     : *u t ( nurl_alloc 4 )
     ( nurl_poke_i32 t 0 ( __BUF_TYPE_CAPTURE ) )
-    ( ioctl . c fd ( __VIDIOC_STREAMOFF ) t )
+    ( ioctl # i32 . c fd ( __VIDIOC_STREAMOFF ) t )
     ( nurl_free t )
     : ~ i k 0
     ~ < k . c nbuf {

--- a/tools/check_package_version_strings.sh
+++ b/tools/check_package_version_strings.sh
@@ -41,9 +41,16 @@ for toml in packages/*/nurl.toml; do
                 echo "MISMATCH: $pkg — nurl.toml says '$manifest' but $src passes '$lit' to cli_new"
                 fail=1
             fi
+        # `cli_new prog about VERSION`: take the LAST backticked semver on
+        # the line. The first cut of this used `cli_new[^)]*`, which stops
+        # at the first `)` — and yoloe's about-string is "…detection &
+        # instance segmentation (pure NURL, GPU)". The parenthesis inside
+        # the description hid the version from the very gate written to
+        # check it, and yoloe shipped 0.6.6 announcing 0.6.0.
         done < <(sed 's://.*::' "$src" \
-                 | grep -o 'cli_new[^)]*`[0-9]\+\.[0-9]\+\.[0-9]\+`' \
-                 | grep -o '`[0-9]\+\.[0-9]\+\.[0-9]\+`$' \
+                 | grep 'cli_new' \
+                 | grep -o '`[0-9]\+\.[0-9]\+\.[0-9]\+`' \
+                 | tail -1 \
                  | tr -d '`')
 
         # …and the OTHER spelling: a literal that prints the package's own

--- a/tools/get-nurl.sh
+++ b/tools/get-nurl.sh
@@ -230,6 +230,38 @@ smoke() {
 smoke "$PREFIX/build/nurlc"
 smoke "$PREFIX/build/nurlpkg"
 
+# ── FFI sentinels: probe THIS machine, not the build runner ────────────
+# `stdlib/runtime.<lib>` tells nurlc that an FFI library is available.
+# build.sh writes them by probing the machine it runs on — which for a
+# release archive is the CI runner, not yours. libX11 is not installed
+# there, so no `runtime.X11` ships and `nurlpkg install yoloe` fails at
+# compile time with "install libX11-dev and run build.sh again" on a box
+# that already HAS libX11 and cannot run build.sh at all.
+#
+# The sentinel has to describe the machine that will link your programs,
+# so probe it here, with the same test build.sh uses. Absent library →
+# sentinel removed → the existing clean compile-time message, which is
+# the right answer on a headless box (nurl.sh would otherwise reach the
+# linker and fail there instead).
+probe_ffi_sentinel() {
+    name="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        echo 1 > "$PREFIX/stdlib/runtime.$name"
+    else
+        rm -f "$PREFIX/stdlib/runtime.$name"
+    fi
+}
+have_lib() {
+    pkg-config --exists "$1" 2>/dev/null && return 0
+    ldconfig -p 2>/dev/null | grep -q "lib$2\.so " && return 0
+    [ -e "/usr/lib/x86_64-linux-gnu/lib$2.so" ] || [ -e "/usr/lib/lib$2.so" ]
+}
+if [ -d "$PREFIX/stdlib" ]; then
+    probe_ffi_sentinel X11 have_lib x11 X11
+    probe_ffi_sentinel opus have_lib opus opus
+fi
+
+
 # ── PATH setup ─────────────────────────────────────────────────────────
 info ""
 info "NURL $VERSION installed → $PREFIX"


### PR DESCRIPTION
Chasing the one package the post-release sweep could not install turned up a chain, each link hidden behind the one before it.

## 1. The FFI sentinel described the wrong machine

`runtime.X11` is written by `build.sh` probing the box it runs on — which for a release archive is the **CI runner**, and that runner has no libX11-dev. So no release ships it, and `nurlpkg install yoloe` failed at compile time telling the user to *install libX11-dev and re-run build.sh* — on a box that already had libX11 and cannot run build.sh at all.

The installer now probes the machine it is installing **onto**, with the same test build.sh uses. Absent library → sentinel removed → the existing clean compile-time message, which is the right answer on a headless box (`nurl.sh` would otherwise reach the linker and fail there instead).

## 2. Behind it, invalid IR

With the gate open, nurlc exited 0 and clang refused the module:

```
call i64 (i8*, i32, ...) @open(i8* %path, i64 %r1)
```

`stdlib/core/posix.nu` declares open(2) as C does (`i32 flags ... → i32`); yoloe restated it as `i flags → i`. Both cannot be emitted, so the **first** declaration wins the `declare` — while every later one overwrote the call-site metadata (`__ffi_params`, `__variadic_sig`, the return type), lowering calls against a signature the module never declared.

One linker symbol has one ABI, so a disagreement is now an error naming both signatures, pointing at the `&` rather than at the next declaration the lexer had already reached. **Identical redeclarations stay legal** — that is what the dedup exists for, and the stdlib relies on it.

## 3. yoloe's declarations were simply wrong

`open` / `mmap` / `munmap` now come from `stdlib/core/posix.nu`, and `ioctl` is stated as C declares it (`int ioctl(int, unsigned long, ...)`). Passing an i64 where C says `int` is not a style question on a variadic call.

## 4. And the version gate had a second hole

yoloe **does** use `cli_new` — the spelling the gate knows. But the matcher was `cli_new[^)]*`, and yoloe's about-string is *"…segmentation (pure NURL, GPU)"*. The parenthesis inside the description hid the version from the gate written to check it, and yoloe shipped 0.6.6 announcing 0.6.0. It now takes the last backticked semver on the line — 14 literals checked, up from 13.

## Verified end to end

yoloe compiles · its module passes `llvm-as` · it **links** (`-lX11` auto-added) · the binary runs. Full suite green, installer copies in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU