### PR TITLE
yoloe: declare the packages its build actually needs

### DIFF
--- a/packages/yoloe-demo/nurl.toml
+++ b/packages/yoloe-demo/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoloe-demo"
-version = "0.2.5"
+version = "0.2.6"
 description = "Live YOLOE in the browser, served by pure NURL — open your webcam on a web page and watch open-vocabulary detection + instance segmentation stream back at you. The browser posts JPEG frames to a NURL HTTP(S) server; every frame runs through the onnx package on the GPU (each layer a CUDA-C kernel compiled at runtime via NVRTC), the segmentation masks are composited onto the frame, and the masked JPEG + a JSON detection list come back — the page draws boxes/labels on top and loops. Interactive: toggle prompted classes, drag the confidence slider, flip masks on/off, or drop a still image. --tls generates a self-signed P-256 certificate at startup (std/x509_gen) so the camera also works from other machines on the LAN (getUserMedia needs a secure origin). Everything in the path is NURL: the HTTP/TLS server (http package), the page template (template package), the JPEG/PNG codecs (image package), the ONNX runtime (onnx package) and the YOLOE decode/mask stages (yoloe package). No Python, no OpenCV, no inference engine, no web framework."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl-lang"

--- a/packages/yoloe/nurl.toml
+++ b/packages/yoloe/nurl.toml
@@ -8,3 +8,8 @@ license = "MIT OR Apache-2.0"
 onnx = { path = "../onnx", version = "^0.8" }
 image = { path = "../image", version = "^0.6" }
 cli = { path = "../cli", version = "^0.2" }
+# Reached through onnx, but present in this package's build either way —
+# declared so the resolver never has to infer them.
+tensor = { path = "../tensor", version = "^0.4" }
+gpukit = { path = "../gpukit", version = "^0.6" }
+gpu = { path = "../gpu", version = "^0.11" }


### PR DESCRIPTION
`nurlpkg publish` refuses yoloe unless `tensor`, `gpukit` and `gpu` are in `[dependencies]`.

Those are **exactly onnx's three dependencies**, and no file in yoloe's own tree mentions them — its sources import only `deps/onnx`, `deps/image` and `deps/cli`, all declared. `nurlpkg install` resolves them transitively without help: the sweep's `deps/` tree carried `tensor`, `gpu` and `gpukit` in from onnx's manifest and the build proceeded. So the gate's stated reason — *"an undeclared dependency breaks every registry install"* — does not hold for a transitive one.

Declared anyway, because the statement is **true**: building yoloe requires those packages present, and saying so costs nothing.

What is left is a gate whose message names a cause I could not reproduce — the complaint survives deleting `deps/` entirely, and I did not pin the mechanism. So this PR fixes the manifest and files the observation, rather than guessing at a scanner change.

Published as yoloe 0.6.7, which installs and runs against the released v0.44.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU