### PR TITLE
lsmdb: a database the standard library could not have written

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,16 @@ jobs:
         # Two seconds, and it uses the build/nurlc from ./build.sh above.
         run: ./tools/metamorph/spellings.py
 
+      - name: CRC-32 gate (two code paths, one answer)
+        # std/deflate computes CRC-32 bitwise below 512 bytes and with a
+        # Sarwate table above it — the table costs 2048 steps to build and
+        # only pays for itself on a real payload, so both paths ship. Two
+        # paths are two chances to disagree, with a gzip member, a tar
+        # archive or a database block riding on the answer. This checks
+        # every length across the threshold, and chained updates, against
+        # python3's zlib.crc32.
+        run: ./tools/crc32_gate.sh
+
       - name: HTTP-server per-request leak gate
         # Builds the leakcheck HTTP server with ASan+LSan and fails on ANY
         # leak across 21 requests. Uses the normal build/nurlc from ./build.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`packages/lsmdb` — an embedded, crash-safe key/value store in pure
+  NURL.** A real LSM tree: a write-ahead log, a skip-list memtable over
+  a byte arena, immutable SSTables (CRC-32 per block, Bloom filter,
+  block index, 48-byte footer), ordered range scans, compaction, and
+  snapshot reads. A write is fsynced before `put` returns; every crash
+  point in the flush and compact sequences recovers to a correct state;
+  a torn log tail loses exactly the write that was never acknowledged;
+  a block that fails its checksum fails the read rather than returning
+  something wrong. Ships as a CLI and as a library.
+
+- **`file_sync` / `dir_sync` (`std/fs`) — there was no fsync at all.**
+  `file_flush` pushes libc's buffer into the kernel, which survives the
+  process dying and not the machine dying, so nothing in the tree could
+  promise a write had reached the device. `file_sync` is the barrier a
+  write-ahead log needs, and `dir_sync` is what makes a
+  publish-by-rename durable: the file's bytes and the directory entry
+  naming them are separate writes, and syncing only the file can leave
+  a recovered tree where the data is on disk and the name reaching it
+  is not. One runtime shim behind both (`fsync` on unix, `_commit` on
+  Windows, a no-op on WASI).
+
+- **`file_truncate` (`std/fs`).** The operation an append-only file
+  cannot do without: after a crash, recovery keeps the records up to
+  the last intact one and the file has to END there. Leaving the torn
+  bytes in place is not untidiness — replay stops at them, so every
+  later append lands behind bytes the next replay refuses to walk past
+  and is silently invisible from then on.
+
+- **`write_bytes` (`core/io`) — binary stdout.** NURL could read binary
+  from stdin (`read_n_bytes`) but not write it back out: every print
+  takes a NUL-terminated string, so a program holding arbitrary bytes —
+  a value out of a database, a decoded image, a proxied response body —
+  had its output silently truncated at the first zero byte.
+  `write_bytes` emits the buffer exactly, sharing stdout's buffer and
+  tty-flush rule with the ordinary prints so mixing the two never
+  reorders output.
+
+### Changed
+
+- **`std/deflate`'s CRC-32 is table-driven.** It computed the checksum
+  bitwise — eight shift-mask-xor rounds per byte — which a profile
+  found taking 66 % of the cycles of a database point read. It now
+  builds a Sarwate table for inputs from 512 bytes up (2048 steps to
+  build, then one lookup per byte; the two break even near 300) and
+  keeps the bitwise path for short inputs, which would otherwise pay
+  the setup to checksum a gzip header. A new `Crc32` context
+  (`crc32_ctx` / `crc32_ctx_hash`) holds the table for callers that
+  checksum thousands of buffers instead of one. Same values as before:
+  `tools/crc32_gate.sh` checks 610 of them — every length across the
+  threshold, plus chained updates — against python3's `zlib.crc32`, and
+  now runs in CI. Measured on a 4 KiB block: 7.8x. Every gzip, tar and
+  PNG user gets it.
+
 ## [0.44.2] — 2026-08-16
 
 The last package that could not be installed, and the three defects

--- a/compiler/tests/fs_durability.nu
+++ b/compiler/tests/fs_durability.nu
@@ -1,0 +1,116 @@
+// Test: the durability + truncation primitives (stdlib/std/fs.nu) and
+// binary stdout (stdlib/core/io.nu).
+//
+// file_flush pushes libc's buffer into the kernel; file_sync pushes the
+// kernel's onto the device. Anything with a write-ahead log needs the
+// second one, and needs file_truncate to cut a torn tail back off after
+// a crash — leave the torn bytes in place and every later append hides
+// behind them. write_bytes is the write-side dual of read_n_bytes: a
+// print takes a NUL-terminated string, so binary output had no route out.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/env.nu`
+
+: ~ s TPATH ``
+: ~ s TDIR ``
+
+@ __dur_tmpdir → String {
+    : ~ String tdir ( env_var_or `TMPDIR` `` )
+    ? == ( string_len tdir ) 0 {
+        ( string_free tdir )
+        = tdir ( env_var_or `TEMP` `/tmp` )
+    } {}
+    ^ tdir
+}
+
+@ ck b ok s name → v {
+    ? ok { ( nurl_print `PASS ` ) } { ( nurl_print `FAIL ` ) }
+    ( nurl_print name )
+    ( nurl_print `\n` )
+}
+
+@ __size_of s path → i {
+    ^ ?? ( file_size path ) { T n → n F _ → -1 }
+}
+
+@ main → i {
+    : String __td ( __dur_tmpdir )
+    = TDIR ( strdup ( string_data __td ) )
+    ( string_push_str __td `/nurl_fsdur_test.bin` )
+    = TPATH ( strdup ( string_data __td ) )
+    ( string_free __td )
+    ( file_delete TPATH )
+
+    // 100 bytes, then fsync: the call has to succeed on a real handle.
+    : ( Vec u ) data ( vec_new [u] )
+    : ~ i i 0
+    ~ < i 100 { ( vec_push [u] data # u & 255 i ) = i + i 1 }
+    ?? ( file_create TPATH ) {
+        T f → {
+            : ~ b ok T
+            ?? ( file_write_chunk f data ) { T _ → {} F _ → { = ok F } }
+            ?? ( file_sync f ) { T _ → {} F _ → { = ok F } }
+            ( file_close f )
+            ( ck ok `file_sync on a written handle` )
+        }
+        F _ → { ( ck F `file_sync on a written handle` ) }
+    }
+    ( vec_free [u] data )
+    ( ck == ( __size_of TPATH ) 100 `100 bytes landed` )
+
+    // Cut it back — the crash-recovery move.
+    ?? ( file_truncate TPATH 40 ) {
+        T _ → { ( ck == ( __size_of TPATH ) 40 `file_truncate shortens` ) }
+        F _ → { ( ck F `file_truncate shortens` ) }
+    }
+    // …and the surviving prefix is still the original bytes, not zeros.
+    ?? ( read_file_bytes TPATH ) {
+        T kept → {
+            : ~ i b39 -1
+            ?? ( vec_get [u] kept 39 ) { T x → { = b39 # i x } F → {} }
+            ( ck & == ( vec_len [u] kept ) 40 == b39 39 `truncation keeps the prefix intact` )
+            ( vec_free [u] kept )
+        }
+        F _ → { ( ck F `truncation keeps the prefix intact` ) }
+    }
+    ?? ( file_truncate TPATH 0 ) {
+        T _ → { ( ck == ( __size_of TPATH ) 0 `file_truncate to empty` ) }
+        F _ → { ( ck F `file_truncate to empty` ) }
+    }
+
+    // A path that does not exist has nothing to truncate.
+    : String gone ( string_from TDIR )
+    ( string_push_str gone `/nurl_fsdur_absent.bin` )
+    ( file_delete ( string_data gone ) )
+    ?? ( file_truncate ( string_data gone ) 8 ) {
+        T _ → { ( ck F `file_truncate rejects a missing path` ) }
+        F _ → { ( ck T `file_truncate rejects a missing path` ) }
+    }
+    ( string_free gone )
+
+    // dir_sync is what makes a publish-by-rename durable. It is a no-op
+    // on Windows/WASI, so "succeeds on a real directory" is the contract
+    // everywhere.
+    ?? ( dir_sync TDIR ) {
+        T _ → { ( ck T `dir_sync on a directory` ) }
+        F _ → { ( ck F `dir_sync on a directory` ) }
+    }
+
+    // write_bytes emits the buffer exactly — length, not termination,
+    // decides what goes out.
+    : ( Vec u ) out ( vec_new [u] )
+    ( bytes_extend_str out `bytes:` )
+    ( vec_push [u] out # u 226 ) ( vec_push [u] out # u 154 ) ( vec_push [u] out # u 161 )
+    ( bytes_extend_str out `:end` )
+    ( nurl_print `write_bytes ` )
+    ( write_bytes out )
+    ( nurl_print `\n` )
+    ( vec_free [u] out )
+
+    ( file_delete TPATH )
+    ^ 0
+}

--- a/compiler/tests/outputs/fs_durability.txt
+++ b/compiler/tests/outputs/fs_durability.txt
@@ -1,0 +1,12 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+PASS file_sync on a written handle
+PASS 100 bytes landed
+PASS file_truncate shortens
+PASS truncation keeps the prefix intact
+PASS file_truncate to empty
+PASS file_truncate rejects a missing path
+PASS dir_sync on a directory
+write_bytes bytes:⚡:end

--- a/packages/README.md
+++ b/packages/README.md
@@ -141,6 +141,35 @@ Modes: `spark` (sparkline), `bar` (one `<label> <value>` per line), `hist`
 (`--bins N`), and `line` (`--width`/`--height`). See
 [`chart/README.md`](chart/README.md) for the full CLI and library API.
 
+## `lsmdb/` — a crash-safe key/value store (installable program **and** library)
+
+A real LSM tree in pure NURL: a write-ahead log, a skip-list memtable over
+a byte arena, immutable SSTables with a CRC-32 per block, a Bloom filter
+and a block index, ordered range scans, compaction, and snapshot reads.
+An acknowledged write is fsynced before `put` returns; every crash point
+in the flush and compact sequences recovers to a correct state; a torn log
+tail loses exactly the write that was never acknowledged; and a block that
+fails its checksum fails the read rather than returning something wrong.
+
+```
+nurlpkg install lsmdb
+lsmdb put user:42 '{"name":"ada"}'   # durable when it returns
+lsmdb scan --from user: --limit 20   # ordered, half-open range
+lsmdb get user:42 --at 7             # the database as of write #7
+lsmdb compact                        # merge tables, reclaim space
+
+# …or depend on the store itself:
+#   [dependencies]
+#   lsmdb = "^0.1"
+#   $ `deps/lsmdb/src/lsmdb.nu`
+#   : !*Lsm String db ( lsm_open `/var/db/things` )
+```
+
+Opening a table reads only its index and filter, and a get reads exactly
+the one block it needs, so a table larger than RAM is an ordinary table.
+Leak-clean under ASan/LSan across every path. See
+[`lsmdb/README.md`](lsmdb/README.md) for the file format and the guarantees.
+
 ## `nurl-mcp/` — a local MCP server for the toolchain (installable program)
 
 The LLM-facing counterpart of `nurl-lsp`: a [Model Context

--- a/packages/lsmdb/CHANGELOG.md
+++ b/packages/lsmdb/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## 0.1.0 — 2026-08-16
+
+First release. An embedded LSM-tree key/value store in pure NURL.
+
+- Write-ahead log with a CRC-32 per record, fsynced before a write is
+  acknowledged. Replay stops at the first torn record, keeps everything
+  before it, and **truncates the log back to that point** so later writes
+  are never stranded behind bytes replay refuses to walk past.
+- Skip-list memtable over a single byte arena — index-based nodes, so
+  nothing is allocated per key and the arena may grow under a node.
+- Immutable SSTables: ~4 KiB blocks with a CRC-32 each, a block index
+  keyed by each block's *last* key (correct when a key's versions
+  straddle a boundary), a Bloom filter, and a 48-byte footer. Opening a
+  table reads only the index and the filter; a get reads one block.
+- 32-slot block cache per open table: a hit skips both the read and the
+  checksum, so a scan verifies once per block rather than once per key.
+- Compaction merges every table into one, keeping the newest version of
+  each key and dropping tombstones.
+- Snapshot reads: `--at SEQ` / `lsm_get_at` see the database exactly as
+  it was after write SEQ.
+- CLI: `put`, `get`, `del`, `scan`, `load`, `flush`, `compact`, `stats`,
+  `bench`. Values are raw bytes end to end.
+
+Three gaps in the standard library were closed to make this possible,
+rather than worked around in the package: `file_sync` / `dir_sync`
+(there was no fsync at all — only `fflush`), `file_truncate`, and
+`write_bytes` (NURL could read binary from stdin but not write it to
+stdout; `nurl_print` stopped at the first NUL byte, silently). The same
+work made `std/deflate`'s CRC-32 table-driven and added a reusable
+`Crc32` context, which took this store's point reads from 47 500/s to
+~600 000/s and speeds up every gzip, tar and PNG user in the ecosystem.

--- a/packages/lsmdb/README.md
+++ b/packages/lsmdb/README.md
@@ -1,0 +1,218 @@
+# lsmdb
+
+An embedded key/value store in pure NURL — **a real LSM tree**, not a
+file with a hash map in it: a write-ahead log, a skip-list memtable,
+immutable CRC-checked SSTables with a Bloom filter and a block index,
+ordered range scans, compaction, and snapshot reads.
+
+```sh
+nurlpkg install lsmdb
+
+lsmdb put user:42 '{"name":"ada"}'   # fsynced before this returns
+lsmdb get user:42
+lsmdb scan --from user: --limit 20   # ordered, half-open range
+lsmdb get user:42 --at 7             # the database as it was after write #7
+lsmdb compact                        # merge tables, reclaim space
+```
+
+It is also a library — `src/lsmdb.nu` is the whole store behind ten
+functions, and `src/memtable.nu`, `src/sst.nu` and `src/wal.nu` are
+usable on their own if you need a sorted arena, a table format or a log.
+
+## What it guarantees
+
+**A write that returned is on the disk.** `lsm_put` appends to the log
+and fsyncs it *before* the memtable is touched, so `kill -9`, a panic or
+a power cut cannot lose an acknowledged write. (`--no-sync` trades that
+away deliberately, for bulk imports.)
+
+**A crash never leaves a state that reads wrong.** The flush and compact
+sequences are ordered so that every point you can be killed at recovers:
+
+| killed after… | on the next open |
+| --- | --- |
+| a log append | the write is there |
+| a *partial* log append | the torn record is dropped, the log is truncated back to it, everything before it stays |
+| writing a table, before the manifest | the table is an orphan file; its writes are still in the log |
+| publishing the manifest, before the log reset | the log replays the same versions on top of the table — identical values at identical sequence numbers, so nothing doubles |
+| compaction, before the manifest | the old tables are still named and still complete |
+
+**Corruption is an error, never data.** Every block carries a CRC-32.
+A block that fails it fails the read, loudly, naming the file — a store
+you can rsync, snapshot or restore from a backup you do not fully trust
+and still know that what comes back is what went in.
+
+**Reads are versioned.** Every write gets a sequence number, versions of
+a key sort newest-first, and `--at N` reads the database exactly as it
+was after write N. Time travel is not a feature bolted on; it is the
+ordering the tree already needed.
+
+## The shape of it
+
+```
+        put/del                            get/scan
+           │                                   │
+           ▼                                   ▼
+    ┌─────────────┐  fsync             ┌───────────────┐
+    │  WAL (log)  │───────► disk       │   memtable    │  newest
+    └─────────────┘                    ├───────────────┤
+           │                           │  table 000003 │
+           ▼                           ├───────────────┤
+    ┌─────────────┐   flush            │  table 000002 │
+    │  memtable   │──────────────►     ├───────────────┤
+    │ (skip list) │                    │  table 000001 │  oldest
+    └─────────────┘                    └───────────────┘
+                                        first hit wins —
+                                        including a tombstone
+```
+
+The **memtable** is a skip list over one byte arena: keys and values are
+appended to a single growable buffer and a node is a row of integers
+(offsets, lengths, sequence, kind) plus its forward links. Nothing is
+allocated per node, so the arena can grow under a node without
+invalidating it, and dropping a memtable is a handful of frees.
+
+An **SSTable** is what a memtable becomes when it stops changing:
+
+```
+[data block 0][data block 1]…[index block][bloom block][footer 48B]
+
+data block  entries sorted by (key ↑, sequence ↓), then [u32 crc32]
+   entry    [u32 klen][u32 vlen][u64 seq][u8 kind][key][value]
+index       one entry per block, holding that block's LAST key
+bloom       [u32 nbits][u32 k][bits] — 10 bits/key, k=7
+footer      index/bloom offsets + lengths, entry count, max sequence,
+            and the magic "LSMDBv1\n"
+```
+
+Opening a table reads only the index and the filter; a get reads exactly
+the one block it needs. **A table larger than RAM is an ordinary table.**
+
+The index holds each block's *last* key rather than its first, which is
+what makes the search correct when a key's versions straddle a block
+boundary: "first block whose last key ≥ probe" always lands on the block
+with the newest version, and the reader walks into the next block for the
+rest of the run. Getting that backwards returns a *stale value* — no
+crash, no checksum failure, just the wrong answer — which is the kind of
+bug a test suite has to be built to catch on purpose.
+
+**Compaction** merges every table into one, keeping the newest version of
+each key and dropping tombstones. That is where space comes back, and it
+deliberately throws history away: a snapshot older than a compaction can
+no longer be served. LevelDB makes the same trade for the same reason.
+
+## Speed
+
+On one Linux x86-64 box, 50 000 keys of ~50 bytes (`lsmdb bench -n 50000`
+— run it yourself, the numbers are the point, not the machine):
+
+| | ops/s |
+| --- | --- |
+| durable writes (one fsync per write) | ~900 |
+| batched writes (`--no-sync`, one fsync at the end) | ~350 000 |
+| point reads after a flush | ~600 000 |
+| reads of absent keys (Bloom filter, no disk touched) | ~3 000 000 |
+
+The durable number is a property of the disk, not of this code: it is one
+fsync per write, and that is what a fsync costs. Everything else is the
+tree doing its job — the Bloom filter answers an absent key without ever
+reading a block, and the block cache means a workload with locality pays
+one checksum per block instead of one per key.
+
+Two of those numbers moved a long way during development, and both
+diagnoses came from a profile rather than a guess: `crc32` was 66 % of
+every point read (the standard library computed it bitwise, eight rounds
+per byte — now table-driven, [upstreamed to
+`std/deflate`](../../stdlib/std/deflate.nu)), and after that the block
+cache took the remaining per-read verification out of scans and any
+workload with locality. Point reads went from 47 500/s to ~600 000/s.
+
+## CLI
+
+```
+lsmdb [OPTIONS] <command> [args]
+
+  put <key> <value>     store a value (durable when it returns)
+  get <key>             print the value; exit 1 if the key is absent
+  del <key>             delete a key
+  scan                  print key<TAB>value for a range, in order
+  load                  bulk import key<TAB>value lines from stdin
+  flush                 force the memtable out into a table
+  compact               merge every table into one, dropping dead data
+  stats                 tables, entries, bytes, sequence
+  bench                 measure writes/s and reads/s on this machine
+
+  -d, --dir DIR         database directory ($LSMDB_DIR, else ./lsmdb)
+  -f, --from KEY        scan: start key (inclusive)
+  -t, --to KEY          scan: end key (exclusive)
+  -l, --limit N         scan: stop after N rows
+      --at SEQ          read as of sequence number SEQ (a snapshot)
+  -r, --raw             get: no trailing newline after the value
+      --no-sync         do not fsync each write (faster, unsafe)
+```
+
+Exit codes: `0` fine, `1` key absent, `2` usage, `3` database error
+(corruption, I/O). Values are read and written as raw bytes, so binary
+values round-trip byte for byte.
+
+## Library
+
+```nurl
+$ `lsmdb.nu`
+
+: !*Lsm String opened ( lsm_open `/var/db/things` )
+?? opened {
+    T db → {
+        : ( Vec u ) k ( bytes_from_str `hello` )
+        : ( Vec u ) v ( bytes_from_str `world` )
+        ?? ( lsm_put db k v ) { T _ → {} F e → { ( string_free e ) } }
+
+        ?? ( lsm_get db k ) {
+            T g → { ? == . g found 1 { ( write_bytes . g val ) } {} ( lsm_get_free g ) }
+            F e → { ( string_free e ) }
+        }
+        ( vec_free [u] k ) ( vec_free [u] v )
+        ( lsm_close db )
+    }
+    F e → { ( string_free e ) }
+}
+```
+
+| | |
+| --- | --- |
+| `( lsm_open dir )` | `!*Lsm String` — creates, recovers and replays |
+| `( lsm_put db key val )` | `!v String` — durable on return |
+| `( lsm_del db key )` | `!v String` |
+| `( lsm_get db key )` | `!LsmGet String` — `.found`, `.seq`, `.val` |
+| `( lsm_get_at db key snap )` | as of sequence `snap` |
+| `( lsm_scan db from to limit snap )` | `!LsmScan String` — ordered, half-open |
+| `( lsm_flush db )` / `( lsm_compact db )` | `!i String` |
+| `( lsm_stats db )` | `LsmStats` |
+| `( lsm_set_durable db F )` | batch mode; pair with `( lsm_sync db )` |
+| `( lsm_close db )` | |
+
+Keys and values are `( Vec u )` — arbitrary bytes, borrowed by the store
+(it copies what it keeps). The empty key is rejected.
+
+## Tests
+
+```sh
+./tests/lsmdb_test.sh      # 30 behaviour + crash + corruption assertions
+./tests/stress_test.sh     # differential: the database vs a sorted text file
+```
+
+Every CLI command in the test runs as its own process, so persistence and
+recovery are exercised by construction. The two that matter most:
+`lsmdb_test.sh` appends a half record to the log (what `kill -9` during an
+append leaves behind) and flips a byte inside a table, and asserts that
+the first loses exactly one write while the second is refused as an error.
+`stress_test.sh` feeds identical writes to the database and to a plain
+sorted text file across four tables, deletes a seventh of the keys,
+overwrites another seventh, compacts, and diffs the entire contents —
+which checks ordering, versioning, tombstones, block boundaries, the
+index search, the Bloom filter and the merge all at once, rather than
+whatever properties someone thought to name.
+
+## License
+
+MIT OR Apache-2.0

--- a/packages/lsmdb/nurl.toml
+++ b/packages/lsmdb/nurl.toml
@@ -1,0 +1,7 @@
+[package]
+name = "lsmdb"
+version = "0.1.0"
+description = "An embedded, crash-safe key/value store in pure NURL — a real LSM tree: write-ahead log, skip-list memtable, immutable CRC-checked SSTables with a Bloom filter and a block index, ordered range scans, compaction, and snapshot reads. Every write is fsynced before it returns and every crash point in the flush/compact sequence recovers to a correct state; a torn log tail is dropped, never half-applied, and a block that fails its checksum is an error, never data. Sequence numbers make time travel free: read the database exactly as it was after write N. Ships as a library and as a CLI (put/get/del/scan/load/flush/compact/stats/bench)."
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/packages/lsmdb/src/lsmdb.nu
+++ b/packages/lsmdb/src/lsmdb.nu
@@ -1,0 +1,835 @@
+// packages/lsmdb/src/lsmdb.nu — the store: an LSM tree that survives
+// being killed.
+//
+// Writes go to the write-ahead log (fsynced), then into the memtable.
+// When the memtable fills it is flushed into an immutable SSTable and the
+// log is reset. Reads consult the memtable first, then the tables from
+// newest to oldest, and stop at the first version they find — including a
+// tombstone, which means "deleted here, look no further". Compaction
+// merges every table into one, keeping only the newest version of each
+// key and dropping tombstones.
+//
+// Crash safety comes from the ORDER of those steps, not from hoping:
+//
+//   put      → log append → fsync → memtable      (acknowledged = durable)
+//   flush    → write table → fsync → publish manifest (rename+dir fsync)
+//              → reset log
+//   compact  → write merged table → fsync → publish manifest → unlink old
+//
+// Every crash point in that sequence lands on a state the next open()
+// reads correctly. A table written but not yet named by the manifest is
+// an orphan file and its writes are still in the log; a manifest naming a
+// table whose writes are ALSO still in the log replays them into the
+// memtable at their original sequence numbers, where they shadow the
+// identical versions in the table. Nothing is lost, nothing is doubled.
+//
+// Sequence numbers are the other half of the design: every write gets
+// one, versions of a key sort newest-first, and a read at sequence S sees
+// the database exactly as it was after write S — a snapshot, for free.
+//
+//   ( lsm_open dir )                     → !*Lsm String
+//   ( lsm_put db key val )               → !v String
+//   ( lsm_del db key )                   → !v String
+//   ( lsm_get db key )                   → !LsmGet String
+//   ( lsm_get_at db key snap )           → !LsmGet String   time travel
+//   ( lsm_scan db from to limit snap )   → !LsmScan String
+//   ( lsm_flush db ) / ( lsm_compact db ) → !i String
+//   ( lsm_stats db )                     → LsmStats
+//   ( lsm_close db )
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `memtable.nu`
+$ `sst.nu`
+$ `wal.nu`
+
+: i LSM_MEMLIMIT 4194304  // 4 MiB of memtable before an auto-flush
+
+: Lsm {
+    String dir
+    String walpath
+    String manpath
+    * MemTable mem
+    ( Vec String ) names  // table file names, NEWEST FIRST
+    ( Vec * SstReader ) tables  // parallel to names
+    * Wal wal
+    i seq
+    i nextfile
+    i memlimit
+    i durable
+    i flushes
+    i compactions
+}
+
+: LsmGet {
+    i found
+    i seq
+    ( Vec u ) val
+}
+
+: LsmStats {
+    i tables
+    i entries
+    i memcount
+    i membytes
+    i seq
+    i filebytes
+    i blockreads
+    i filtered
+}
+
+@ lsm_get_free LsmGet g → v { ( vec_free [u] . g val ) }
+
+@ __lsm_err s what → String { ^ ( string_from what ) }
+
+// ── paths ───────────────────────────────────────────────────────────
+
+@ __lsm_path * Lsm db s name → String {
+    ^ ( path_join ( string_data . db dir ) name )
+}
+
+// Zero-padded so the table files sort the way they were created.
+@ __lsm_table_name i n → String {
+    : String s ( string_with_cap 16 )
+    : String digits ( string_with_cap 16 )
+    ( string_push_int digits n )
+    : ~ i pad - 6 ( string_len digits )
+    ~ > pad 0 { ( string_push_char s 48 ) = pad - pad 1 }
+    ( string_push_str s ( string_data digits ) )
+    ( string_free digits )
+    ( string_push_str s `.sst` )
+    ^ s
+}
+
+// ── manifest ────────────────────────────────────────────────────────
+//
+// The manifest is the only thing that decides which tables exist. It is
+// replaced by rename, never edited in place, so a reader either sees the
+// whole old list or the whole new one.
+
+@ __lsm_manifest_write * Lsm db → !v String {
+    : String tmp ( __lsm_path db `MANIFEST.tmp` )
+    : String body ( string_with_cap 256 )
+    ( string_push_str body `lsmdb-manifest v1
+seq ` )
+    ( string_push_int body . db seq )
+    ( string_push_str body `
+next ` )
+    ( string_push_int body . db nextfile )
+    ( string_push_char body 10 )
+    : ~ i k 0
+    ~ < k ( vec_len [String] . db names ) {
+        ?? ( vec_get [String] . db names k ) {
+            T nm → {
+                ( string_push_str body `sst ` )
+                ( string_push_str body ( string_data nm ) )
+                ( string_push_char body 10 )
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    : ~ b ok T
+    ?? ( file_create ( string_data tmp ) ) {
+        T f → {
+            : ( Vec u ) bytes ( bytes_from_str ( string_data body ) )
+            ?? ( file_write_chunk f bytes ) { T _ → {} F _ → { = ok F } }
+            ?? ( file_sync f ) { T _ → {} F _ → { = ok F } }
+            ( file_close f )
+            ( vec_free [u] bytes )
+        }
+        F _ → { = ok F }
+    }
+    ( string_free body )
+    ? ok {} {
+        ( string_free tmp )
+        ^ @ !v String { F ( __lsm_err `lsmdb: cannot write the manifest` ) }
+    }
+    ?? ( fs_rename ( string_data tmp ) ( string_data . db manpath ) ) {
+        T _ → {}
+        F _ → { = ok F }
+    }
+    ( string_free tmp )
+    ? ok {} { ^ @ !v String { F ( __lsm_err `lsmdb: cannot publish the manifest` ) } }
+    // The rename itself has to reach the disk, or a crash can leave the
+    // table on disk with the old manifest still naming the world.
+    ?? ( dir_sync ( string_data . db dir ) ) { T _ → {} F _ → {} }
+    ^ @ !v String { T 0 }
+}
+
+// The rest of a manifest line after its `keyword ` prefix.
+@ __lsm_after String ln i n → String {
+    : i len ( string_len ln )
+    ? >= n len { ^ ( string_new ) } {}
+    ^ ( string_substr ln n - len n )
+}
+
+@ __lsm_manifest_read * Lsm db → !v String {
+    ? ( file_exists ( string_data . db manpath ) ) {} { ^ @ !v String { T 0 } }
+    : !String IoErr rr ( read_file ( string_data . db manpath ) )
+    : ~ String text ( string_new )
+    ?? rr { T s → { ( string_free text ) = text s } F _ → {
+            ^ @ !v String { F ( __lsm_err `lsmdb: cannot read the manifest` ) } } }
+    : ( Vec String ) lines ( string_split text `
+` )
+    ( string_free text )
+    : ~ b bad F
+    : ~ i k 0
+    ~ < k ( vec_len [String] lines ) {
+        ?? ( vec_get [String] lines k ) {
+            T ln → {
+                ? == k 0 {
+                    ? ( string_starts_with ln `lsmdb-manifest v1` ) {} { = bad T }
+                } {
+                    ? ( string_starts_with ln `seq ` ) {
+                        : String rest ( __lsm_after ln 4 )
+                        = . db seq ( nurl_str_to_int ( string_data rest ) )
+                        ( string_free rest )
+                    } {
+                        ? ( string_starts_with ln `next ` ) {
+                            : String rest ( __lsm_after ln 5 )
+                            = . db nextfile ( nurl_str_to_int ( string_data rest ) )
+                            ( string_free rest )
+                        } {
+                            ? ( string_starts_with ln `sst ` ) {
+                                ( vec_push [String] . db names ( __lsm_after ln 4 ) )
+                            } {}
+                        }
+                    }
+                }
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( vec_free_with [String] lines \ String s → v { ( string_free s ) } )
+    ? bad { ^ @ !v String { F ( __lsm_err `lsmdb: not an lsmdb manifest` ) } } {}
+    ^ @ !v String { T 0 }
+}
+
+// ── open / close ────────────────────────────────────────────────────
+
+@ lsm_open s dir → !*Lsm String {
+    ?? ( dir_create_all dir ) {
+        T _ → {}
+        F _ → {
+            : String msg ( string_from `lsmdb: cannot create database directory ` )
+            ( string_push_str msg dir )
+            ^ @ !*Lsm String { F msg }
+        }
+    }
+    : *Lsm db # *Lsm ( nurl_alloc Z Lsm )
+    = . db dir ( string_from dir )
+    = . db walpath ( path_join dir `WAL` )
+    = . db manpath ( path_join dir `MANIFEST` )
+    = . db mem ( mt_new 0 )
+    = . db names ( vec_new [String] )
+    = . db tables ( vec_new [* SstReader] )
+    = . db seq 0
+    = . db nextfile 1
+    = . db memlimit LSM_MEMLIMIT
+    = . db durable 1
+    = . db flushes 0
+    = . db compactions 0
+
+    ?? ( __lsm_manifest_read db ) {
+        T _ → {}
+        F e → { ( __lsm_free db ) ^ @ !*Lsm String { F e } }
+    }
+    // Open every named table. A table the manifest names but the
+    // directory does not have is a broken database, not a warning.
+    : ~ i k 0
+    ~ < k ( vec_len [String] . db names ) {
+        : ~ String nm ( string_new )
+        ?? ( vec_get [String] . db names k ) { T s → { ( string_free nm ) = nm s } F → {} }
+        : String full ( __lsm_path db ( string_data nm ) )
+        : !*SstReader String orr ( sst_open ( string_data full ) )
+        ( string_free full )
+        ?? orr {
+            T r → { ( vec_push [* SstReader] . db tables r ) }
+            F e → { ( __lsm_free db ) ^ @ !*Lsm String { F e } }
+        }
+        = k + k 1
+    }
+
+    // Replay whatever the log still holds on top of the tables.
+    : !WalStat String wr ( wal_replay ( string_data . db walpath ) . db mem )
+    ?? wr {
+        T st → {
+            ? > . st maxseq . db seq { = . db seq . st maxseq } {}
+            // A crash mid-append leaves a torn record at the tail. It was
+            // never acknowledged, so replay dropped it — but the bytes
+            // have to GO, or the next replay would stop at them again and
+            // every write made from now on would be stranded behind them.
+            ? == . st truncated 1 {
+                ?? ( wal_truncate ( string_data . db walpath ) . st bytes ) {
+                    T _ → {}
+                    F e → { ( __lsm_free db ) ^ @ !*Lsm String { F e } }
+                }
+            } {}
+        }
+        F e → { ( __lsm_free db ) ^ @ !*Lsm String { F e } }
+    }
+    : !*Wal String wo ( wal_open ( string_data . db walpath ) )
+    ?? wo {
+        T w → { = . db wal w }
+        F e → { ( __lsm_free db ) ^ @ !*Lsm String { F e } }
+    }
+    ^ @ !*Lsm String { T db }
+}
+
+// Free everything a partially-built handle may own. The wal field is the
+// one that may still be unset, so it is never touched here — lsm_close
+// closes it and then calls this.
+@ __lsm_free * Lsm db → v {
+    ( string_free . db dir )
+    ( string_free . db walpath )
+    ( string_free . db manpath )
+    ( mt_free . db mem )
+    ( vec_free_with [String] . db names \ String s → v { ( string_free s ) } )
+    ( vec_free_with [* SstReader] . db tables \ * SstReader r → v { ( sst_close r ) } )
+    ( nurl_free # s db )
+}
+
+@ lsm_close * Lsm db → v {
+    ( wal_close . db wal )
+    ( __lsm_free db )
+}
+
+@ lsm_seq * Lsm db → i { ^ . db seq }
+
+// Force everything written so far to the device. Only needed after
+// running with durability switched off — a bulk import that wants one
+// fsync at the end instead of one per row.
+@ lsm_sync * Lsm db → !v String { ^ ( wal_sync . db wal ) }
+
+@ lsm_set_durable * Lsm db b on → v { = . db durable ? on 1 0 }
+
+@ lsm_set_memlimit * Lsm db i n → v { = . db memlimit ? > n 1024 n 1024 }
+
+// ── writes ──────────────────────────────────────────────────────────
+
+@ __lsm_write * Lsm db ( Vec u ) key ( Vec u ) val i kind → !v String {
+    = . db seq + . db seq 1
+    : i seq . db seq
+    ?? ( wal_append . db wal key val seq kind ) { T _ → {} F e → { ^ @ !v String { F e } } }
+    ? == . db durable 1 {
+        ?? ( wal_sync . db wal ) { T _ → {} F e → { ^ @ !v String { F e } } }
+    } {}
+    ( mt_put . db mem key val seq kind )
+    ? >= ( mt_bytes . db mem ) . db memlimit {
+        ?? ( lsm_flush db ) { T _ → {} F e → { ^ @ !v String { F e } } }
+    } {}
+    ^ @ !v String { T 0 }
+}
+
+@ lsm_put * Lsm db ( Vec u ) key ( Vec u ) val → !v String {
+    ? == ( vec_len [u] key ) 0 {
+        ^ @ !v String { F ( __lsm_err `lsmdb: the empty key is not a key` ) }
+    } {}
+    ^ ( __lsm_write db key val MT_PUT )
+}
+
+@ lsm_del * Lsm db ( Vec u ) key → !v String {
+    : ( Vec u ) empty ( vec_new [u] )
+    : !v String r ( __lsm_write db key empty MT_DEL )
+    ( vec_free [u] empty )
+    ^ r
+}
+
+// ── reads ───────────────────────────────────────────────────────────
+
+@ lsm_get * Lsm db ( Vec u ) key → !LsmGet String {
+    ^ ( lsm_get_at db key . db seq )
+}
+
+// The read path in full: memtable, then tables newest to oldest. The
+// FIRST version found wins, and a tombstone counts as found — that is
+// what stops an older table's stale value from resurrecting a deleted key.
+@ lsm_get_at * Lsm db ( Vec u ) key i snap → !LsmGet String {
+    : i node ( mt_find . db mem key snap )
+    ? != node 0 {
+        ? == ( mt_kind . db mem node ) MT_DEL {
+            ^ @ !LsmGet String { T @ LsmGet { 0 0 ( vec_new [u] ) } }
+        } {}
+        ^ @ !LsmGet String { T @ LsmGet { 1 ( mt_seq . db mem node ) ( mt_val . db mem node ) } }
+    } {}
+    : ~ i k 0
+    : i n ( vec_len [* SstReader] . db tables )
+    ~ < k n {
+        ?? ( vec_get [* SstReader] . db tables k ) {
+            T r → {
+                : !SstHit String hr ( sst_get r key snap )
+                ?? hr {
+                    T hit → {
+                        ? == . hit found 1 {
+                            ? == . hit kind MT_DEL {
+                                ( sst_hit_free hit )
+                                ^ @ !LsmGet String { T @ LsmGet { 0 0 ( vec_new [u] ) } }
+                            } {}
+                            ^ @ !LsmGet String { T @ LsmGet { 1 . hit seq . hit val } }
+                        } {}
+                        ( sst_hit_free hit )
+                    }
+                    F e → { ^ @ !LsmGet String { F e } }
+                }
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ @ !LsmGet String { T @ LsmGet { 0 0 ( vec_new [u] ) } }
+}
+
+// ── merged iteration ────────────────────────────────────────────────
+//
+// One ordered view over the memtable and every table at once. Each
+// source is already sorted by (key ascending, sequence descending), so
+// the merge is a repeated "which head sorts first" — and because the
+// sequence half of that order puts newer versions first, the FIRST time
+// a key appears is always its newest visible version.
+
+: LsmIter {
+    * MemTable mem
+    i usemem
+    i mnode
+    ( Vec * SstCursor ) curs
+    i src  // -1 memtable, >=0 cursor index, -2 exhausted
+    i failed
+    String err
+}
+
+@ __it_new * Lsm db b usemem ( Vec u ) from i snap → *LsmIter {
+    : *LsmIter it # *LsmIter ( nurl_alloc Z LsmIter )
+    = . it mem . db mem
+    = . it usemem ? usemem 1 0
+    = . it curs ( vec_new [* SstCursor] )
+    = . it src -2
+    = . it failed 0
+    = . it err ( string_new )
+    : b seeking > ( vec_len [u] from ) 0
+    = . it mnode ? usemem ? seeking ( mt_seek . db mem from snap ) ( mt_first . db mem ) 0
+    : ~ i k 0
+    ~ < k ( vec_len [* SstReader] . db tables ) {
+        ?? ( vec_get [* SstReader] . db tables k ) {
+            T r → {
+                : *SstCursor c ( sst_cursor r )
+                ? seeking { ( sc_seek c from snap ) } { ( sc_first c ) }
+                ( vec_push [* SstCursor] . it curs c )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ it
+}
+
+@ __it_free * LsmIter it → v {
+    ( vec_free_with [* SstCursor] . it curs \ * SstCursor c → v { ( sc_free c ) } )
+    ( string_free . it err )
+    ( nurl_free # s it )
+}
+
+// Select the source whose head sorts first. Returns -2 when every source
+// is exhausted.
+@ __it_pick * LsmIter it → i {
+    : ~ i best -2
+    : ~ * u bp # *u 0
+    : ~ i boff 0
+    : ~ i blen 0
+    : ~ i bseq 0
+    ? & == . it usemem 1 != . it mnode 0 {
+        = best -1
+        = bp ( mt_kptr . it mem )
+        = boff ( mt_koff . it mem . it mnode )
+        = blen ( mt_klen . it mem . it mnode )
+        = bseq ( mt_seq . it mem . it mnode )
+    } {}
+    : ~ i k 0
+    ~ < k ( vec_len [* SstCursor] . it curs ) {
+        ?? ( vec_get [* SstCursor] . it curs k ) {
+            T c → {
+                ? ( sc_failed c ) {
+                    = . it failed 1
+                    ( string_free . it err )
+                    = . it err ( string_from ( sc_err c ) )
+                } {}
+                ? ( sc_valid c ) {
+                    : *u cp ( sc_kptr c )
+                    : i coff ( sc_koff c )
+                    : i clen ( sc_klen c )
+                    : i cseq ( sc_seq c )
+                    : ~ b take == best -2
+                    ? take {} {
+                        : i cmp ( lsm_bytes_cmp_raw cp coff clen bp boff blen )
+                        = take | < cmp 0 & == cmp 0 > cseq bseq
+                    }
+                    ? take {
+                        = best k = bp cp = boff coff = blen clen = bseq cseq
+                    } {}
+                } {}
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    = . it src best
+    ^ best
+}
+
+@ __it_advance * LsmIter it → v {
+    ? == . it src -1 { = . it mnode ( mt_next . it mem . it mnode ) } {
+        ? >= . it src 0 {
+            ?? ( vec_get [* SstCursor] . it curs . it src ) {
+                T c → { ( sc_next c ) }
+                F _ → {}
+            }
+        } {}
+    }
+}
+
+// Key of the currently selected head, as an owned copy.
+@ __it_key * LsmIter it → ( Vec u ) {
+    ? == . it src -1 { ^ ( mt_key . it mem . it mnode ) } {}
+    ?? ( vec_get [* SstCursor] . it curs . it src ) {
+        T c → { ^ ( sc_key c ) }
+        F _ → { ^ ( vec_new [u] ) }
+    }
+}
+
+@ __it_val * LsmIter it → ( Vec u ) {
+    ? == . it src -1 { ^ ( mt_val . it mem . it mnode ) } {}
+    ?? ( vec_get [* SstCursor] . it curs . it src ) {
+        T c → { ^ ( sc_val c ) }
+        F _ → { ^ ( vec_new [u] ) }
+    }
+}
+
+@ __it_seq * LsmIter it → i {
+    ? == . it src -1 { ^ ( mt_seq . it mem . it mnode ) } {}
+    ^ ?? ( vec_get [* SstCursor] . it curs . it src ) { T c → ( sc_seq c ) F _ → 0 }
+}
+
+@ __it_kind * LsmIter it → i {
+    ? == . it src -1 { ^ ( mt_kind . it mem . it mnode ) } {}
+    ^ ?? ( vec_get [* SstCursor] . it curs . it src ) { T c → ( sc_kind c ) F _ → MT_PUT }
+}
+
+// ── scan ────────────────────────────────────────────────────────────
+
+: LsmScan {
+    ( Vec u ) keys
+    ( Vec i ) koff
+    ( Vec i ) klen
+    ( Vec u ) vals
+    ( Vec i ) voff
+    ( Vec i ) vlen
+    i count
+}
+
+@ lsm_scan_free LsmScan s → v {
+    ( vec_free [u] . s keys ) ( vec_free [i] . s koff ) ( vec_free [i] . s klen )
+    ( vec_free [u] . s vals ) ( vec_free [i] . s voff ) ( vec_free [i] . s vlen )
+}
+
+@ lsm_scan_count LsmScan s → i { ^ . s count }
+
+@ lsm_scan_key LsmScan s i k → ( Vec u ) {
+    ^ ( _mt_slice . s keys ?? ( vec_get [i] . s koff k ) { T x → x F _ → 0 }
+    ?? ( vec_get [i] . s klen k ) { T x → x F _ → 0 } )
+}
+
+@ lsm_scan_val LsmScan s i k → ( Vec u ) {
+    ^ ( _mt_slice . s vals ?? ( vec_get [i] . s voff k ) { T x → x F _ → 0 }
+    ?? ( vec_get [i] . s vlen k ) { T x → x F _ → 0 } )
+}
+
+// Every live key in [from, to) as of `snap`, in order. An empty `from`
+// starts at the beginning; an empty `to` runs to the end; limit <= 0
+// means no limit.
+@ lsm_scan * Lsm db ( Vec u ) from ( Vec u ) to i limit i snap → !LsmScan String {
+    : *LsmIter it ( __it_new db T from snap )
+    : ( Vec u ) keys ( vec_new [u] )
+    : ( Vec i ) koff ( vec_new [i] )
+    : ( Vec i ) klen ( vec_new [i] )
+    : ( Vec u ) vals ( vec_new [u] )
+    : ( Vec i ) voff ( vec_new [i] )
+    : ( Vec i ) vlen ( vec_new [i] )
+    : ~ i count 0
+    : ~ b stop F
+    : ~ b failed F
+    : ~ String err ( string_new )
+    : ~ ( Vec u ) prev ( vec_new [u] )
+    : ~ b haveprev F
+    : b bounded > ( vec_len [u] to ) 0
+
+    ~ ! stop {
+        : i src ( __it_pick it )
+        ? == . it failed 1 {
+            = failed T ( string_free err ) = err ( string_from ( string_data . it err ) )
+            = stop T
+        } {
+            ? == src -2 { = stop T } {
+                : ( Vec u ) key ( __it_key it )
+                : i seq ( __it_seq it )
+                : b samekey & haveprev == 0 ( lsm_bytes_cmp key prev )
+                ? & bounded >= ( lsm_bytes_cmp key to ) 0 { = stop T ( vec_free [u] key ) } {
+                    ? | samekey > seq snap {
+                        // an older version of a key already emitted, or a
+                        // version newer than the snapshot: skip it
+                        ( vec_free [u] key )
+                    } {
+                        // first visible version of this key
+                        ? == ( __it_kind it ) MT_PUT {
+                            : ( Vec u ) val ( __it_val it )
+                            ( vec_push [i] koff ( vec_len [u] keys ) )
+                            ( vec_push [i] klen ( vec_len [u] key ) )
+                            ( vec_extend [u] keys key )
+                            ( vec_push [i] voff ( vec_len [u] vals ) )
+                            ( vec_push [i] vlen ( vec_len [u] val ) )
+                            ( vec_extend [u] vals val )
+                            ( vec_free [u] val )
+                            = count + count 1
+                            ? & > limit 0 >= count limit { = stop T } {}
+                        } {}
+                        ( vec_free [u] prev )
+                        = prev key
+                        = haveprev T
+                    }
+                }
+                ? stop {} { ( __it_advance it ) }
+            }
+        }
+    }
+    ( vec_free [u] prev )
+    ( __it_free it )
+    ? failed {
+        ( vec_free [u] keys ) ( vec_free [i] koff ) ( vec_free [i] klen )
+        ( vec_free [u] vals ) ( vec_free [i] voff ) ( vec_free [i] vlen )
+        ^ @ !LsmScan String { F err }
+    } {}
+    ( string_free err )
+    ^ @ !LsmScan String { T @ LsmScan { keys koff klen vals voff vlen count } }
+}
+
+// ── flush ───────────────────────────────────────────────────────────
+
+// Turn the memtable into a table. EVERY version is written, not just the
+// newest — the memtable is the newest data in the database, and throwing
+// away its history here would silently break snapshot reads that the
+// tables themselves still support.
+@ lsm_flush * Lsm db → !i String {
+    : i n ( mt_count . db mem )
+    ? == n 0 { ^ @ !i String { T 0 } } {}
+    : String name ( __lsm_table_name . db nextfile )
+    : String full ( __lsm_path db ( string_data name ) )
+    : !*SstWriter String cw ( sst_create ( string_data full ) )
+    : ~ * SstWriter w # *SstWriter 0
+    ?? cw { T x → { = w x } F e → {
+            ( string_free name ) ( string_free full )
+            ^ @ !i String { F e } } }
+
+    : ~ i node ( mt_first . db mem )
+    : ~ b failed F
+    : ~ String err ( string_new )
+    ~ & != node 0 ! failed {
+        : ( Vec u ) k ( mt_key . db mem node )
+        : ( Vec u ) v ( mt_val . db mem node )
+        ?? ( sst_add w k v ( mt_seq . db mem node ) ( mt_kind . db mem node ) ) {
+            T _ → {}
+            F e → { = failed T ( string_free err ) = err e }
+        }
+        ( vec_free [u] k ) ( vec_free [u] v )
+        = node ( mt_next . db mem node )
+    }
+    : !i String fin ( sst_finish w )
+    ?? fin { T _ → {} F e → { ? failed { ( string_free e ) } { = failed T ( string_free err ) = err e } } }
+    ? failed {
+        ?? ( file_delete ( string_data full ) ) { T _ → {} F _ → {} }
+        ( string_free name ) ( string_free full )
+        ^ @ !i String { F err }
+    } {}
+    ( string_free err )
+
+    // The table is on disk and fsynced. Only now may the manifest name it.
+    : !*SstReader String orr ( sst_open ( string_data full ) )
+    ( string_free full )
+    ?? orr {
+        T r → {
+            ( vec_insert [String] . db names 0 name )
+            : b _ok ( vec_insert [* SstReader] . db tables 0 r )
+        }
+        F e → { ( string_free name ) ^ @ !i String { F e } }
+    }
+    = . db nextfile + . db nextfile 1
+    ?? ( __lsm_manifest_write db ) { T _ → {} F e → { ^ @ !i String { F e } } }
+
+    // Published — the log's job is done and the memtable can go.
+    ?? ( wal_reset ( string_data . db walpath ) ) { T _ → {} F e → { ^ @ !i String { F e } } }
+    ( wal_close . db wal )
+    ?? ( wal_open ( string_data . db walpath ) ) {
+        T nw → { = . db wal nw }
+        F e → { ^ @ !i String { F e } }
+    }
+    ( mt_free . db mem )
+    = . db mem ( mt_new 0 )
+    = . db flushes + . db flushes 1
+    ^ @ !i String { T n }
+}
+
+// ── compaction ──────────────────────────────────────────────────────
+
+// Merge every table into one, keeping only the newest version of each
+// key and dropping tombstones. This is where space actually comes back:
+// overwritten values and deleted keys stop existing.
+//
+// It also throws history away, deliberately — a snapshot read older than
+// this point can no longer be served, exactly as in LevelDB. Compaction
+// is a choice to trade the past for space.
+@ lsm_compact * Lsm db → !i String {
+    : i ntables ( vec_len [* SstReader] . db tables )
+    ? < ntables 1 { ^ @ !i String { T 0 } } {}
+
+    : String name ( __lsm_table_name . db nextfile )
+    : String full ( __lsm_path db ( string_data name ) )
+    : !*SstWriter String cw ( sst_create ( string_data full ) )
+    : ~ * SstWriter w # *SstWriter 0
+    ?? cw { T x → { = w x } F e → {
+            ( string_free name ) ( string_free full )
+            ^ @ !i String { F e } } }
+
+    : ( Vec u ) nokey ( vec_new [u] )
+    : *LsmIter it ( __it_new db F nokey . db seq )
+    : ~ ( Vec u ) prev ( vec_new [u] )
+    : ~ b haveprev F
+    : ~ i kept 0
+    : ~ b stop F
+    : ~ b failed F
+    : ~ String err ( string_new )
+
+    ~ ! stop {
+        : i src ( __it_pick it )
+        ? == . it failed 1 {
+            = failed T ( string_free err ) = err ( string_from ( string_data . it err ) )
+            = stop T
+        } {
+            ? == src -2 { = stop T } {
+                : ( Vec u ) key ( __it_key it )
+                : b samekey & haveprev == 0 ( lsm_bytes_cmp key prev )
+                ? samekey { ( vec_free [u] key ) } {
+                    ? == ( __it_kind it ) MT_PUT {
+                        : ( Vec u ) val ( __it_val it )
+                        ?? ( sst_add w key val ( __it_seq it ) MT_PUT ) {
+                            T _ → {}
+                            F e → { = failed T = stop T ( string_free err ) = err e }
+                        }
+                        ( vec_free [u] val )
+                        = kept + kept 1
+                    } {}
+                    ( vec_free [u] prev )
+                    = prev key
+                    = haveprev T
+                }
+                ? stop {} { ( __it_advance it ) }
+            }
+        }
+    }
+    ( vec_free [u] prev )
+    ( vec_free [u] nokey )
+    ( __it_free it )
+
+    : !i String fin ( sst_finish w )
+    ?? fin { T _ → {} F e → { ? failed { ( string_free e ) } { = failed T ( string_free err ) = err e } } }
+    ? failed {
+        ?? ( file_delete ( string_data full ) ) { T _ → {} F _ → {} }
+        ( string_free name ) ( string_free full )
+        ^ @ !i String { F err }
+    } {}
+    ( string_free err )
+
+    // Take the old tables out of the live set before publishing, but do
+    // not unlink them until the new manifest is on disk: a crash in
+    // between must find either the old list or the new one, both intact.
+    : ( Vec String ) old ( vec_new [String] )
+    : ~ i k 0
+    ~ < k ( vec_len [String] . db names ) {
+        ?? ( vec_get [String] . db names k ) { T s → { ( vec_push [String] old s ) } F → {} }
+        = k + k 1
+    }
+    ( vec_clear [String] . db names )
+    ( vec_free_with [* SstReader] . db tables \ * SstReader r → v { ( sst_close r ) } )
+    = . db tables ( vec_new [* SstReader] )
+
+    : !*SstReader String orr ( sst_open ( string_data full ) )
+    ( string_free full )
+    ?? orr {
+        T r → {
+            ( vec_push [String] . db names name )
+            ( vec_push [* SstReader] . db tables r )
+        }
+        F e → {
+            ( string_free name )
+            ( vec_free_with [String] old \ String s → v { ( string_free s ) } )
+            ^ @ !i String { F e }
+        }
+    }
+    = . db nextfile + . db nextfile 1
+    ?? ( __lsm_manifest_write db ) {
+        T _ → {}
+        F e → {
+            ( vec_free_with [String] old \ String s → v { ( string_free s ) } )
+            ^ @ !i String { F e }
+        }
+    }
+
+    : ~ i j 0
+    ~ < j ( vec_len [String] old ) {
+        ?? ( vec_get [String] old j ) {
+            T nm → {
+                : String p ( __lsm_path db ( string_data nm ) )
+                ?? ( file_delete ( string_data p ) ) { T _ → {} F _ → {} }
+                ( string_free p )
+            }
+            F → {}
+        }
+        = j + j 1
+    }
+    ( vec_free_with [String] old \ String s → v { ( string_free s ) } )
+    = . db compactions + . db compactions 1
+    ^ @ !i String { T kept }
+}
+
+// ── stats ───────────────────────────────────────────────────────────
+
+@ lsm_stats * Lsm db → LsmStats {
+    : ~ i entries 0
+    : ~ i filebytes 0
+    : ~ i reads 0
+    : ~ i filtered 0
+    : ~ i k 0
+    ~ < k ( vec_len [* SstReader] . db tables ) {
+        ?? ( vec_get [* SstReader] . db tables k ) {
+            T r → {
+                = entries + entries ( sst_entries r )
+                = filebytes + filebytes ( sst_filesize r )
+                = reads + reads ( sst_reads r )
+                = filtered + filtered ( sst_filtered r )
+            }
+            F _ → {}
+        }
+        = k + k 1
+    }
+    ^ @ LsmStats {
+        ( vec_len [* SstReader] . db tables )
+        entries
+        ( mt_count . db mem )
+        ( mt_bytes . db mem )
+        . db seq
+        filebytes
+        reads
+        filtered
+    }
+}

--- a/packages/lsmdb/src/main.nu
+++ b/packages/lsmdb/src/main.nu
@@ -1,0 +1,443 @@
+// lsmdb — a crash-safe embedded key/value store on the command line.
+//
+//   lsmdb put user:42 '{"name":"ada"}'      # write (fsynced before it returns)
+//   lsmdb get user:42                       # read
+//   lsmdb del user:42                       # delete
+//   lsmdb scan --from user: --limit 20      # ordered range
+//   lsmdb load < dump.tsv                   # bulk import, key<TAB>value lines
+//   lsmdb get user:42 --at 7                # read the database as of write #7
+//   lsmdb compact                           # merge tables, reclaim space
+//   lsmdb stats                             # what is on disk
+//   lsmdb bench -n 100000                   # writes/s and reads/s here
+//
+// The database is a directory (-d, $LSMDB_DIR, or ./lsmdb). Values are
+// written and printed as raw bytes, so binary values survive the round
+// trip; `get` exits 1 when the key is absent, which makes it usable in a
+// shell conditional.
+
+$ `stdlib/core/io.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/ext/env.nu`
+$ `stdlib/std/args.nu`
+$ `memtable.nu`
+$ `sst.nu`
+$ `wal.nu`
+$ `lsmdb.nu`
+
+// ── small helpers ───────────────────────────────────────────────────
+
+@ __opt_int ArgParser p s name i dflt → i {
+    ?? ( args_value p name ) {
+        T v → { : i n ( nurl_str_to_int ( string_data v ) ) ( string_free v ) ^ n }
+        F _ → { ^ dflt }
+    }
+}
+
+@ __opt_str ArgParser p s name s dflt → String {
+    ?? ( args_value p name ) {
+        T v → { ^ v }
+        F _ → { ^ ( string_from dflt ) }
+    }
+}
+
+@ __pos ( Vec String ) ps i k → s {
+    ^ ?? ( vec_get [String] ps k ) { T s → ( string_data s ) F _ → `` }
+}
+
+@ __free_strvec ( Vec String ) v → v {
+    ( vec_free_with [String] v \ String s → v { ( string_free s ) } )
+}
+
+@ __die s msg → v {
+    ( nurl_eprint `lsmdb: ` )
+    ( nurl_eprintln msg )
+}
+
+// ── commands ────────────────────────────────────────────────────────
+
+@ __cmd_put * Lsm db s key s val → i {
+    : ( Vec u ) k ( bytes_from_str key )
+    : ( Vec u ) v ( bytes_from_str val )
+    : ~ i rc 0
+    ?? ( lsm_put db k v ) {
+        T _ → {}
+        F e → { ( __die ( string_data e ) ) ( string_free e ) = rc 3 }
+    }
+    ( vec_free [u] k ) ( vec_free [u] v )
+    ^ rc
+}
+
+@ __cmd_del * Lsm db s key → i {
+    : ( Vec u ) k ( bytes_from_str key )
+    : ~ i rc 0
+    ?? ( lsm_del db k ) {
+        T _ → {}
+        F e → { ( __die ( string_data e ) ) ( string_free e ) = rc 3 }
+    }
+    ( vec_free [u] k )
+    ^ rc
+}
+
+// Absent key → exit 1 with nothing on stdout, so `lsmdb get k || …`
+// works in a shell.
+@ __cmd_get * Lsm db s key i snap b raw → i {
+    : ( Vec u ) k ( bytes_from_str key )
+    : ~ i rc 0
+    ?? ( lsm_get_at db k snap ) {
+        T g → {
+            ? == . g found 1 {
+                ( write_bytes . g val )
+                ? raw {} { ( nurl_print `
+` ) }
+            } { = rc 1 }
+            ( lsm_get_free g )
+        }
+        F e → { ( __die ( string_data e ) ) ( string_free e ) = rc 3 }
+    }
+    ( vec_free [u] k )
+    ^ rc
+}
+
+@ __cmd_scan * Lsm db s from s to i limit i snap → i {
+    : ( Vec u ) f ( bytes_from_str from )
+    : ( Vec u ) t ( bytes_from_str to )
+    : ~ i rc 0
+    ?? ( lsm_scan db f t limit snap ) {
+        T sc → {
+            : ~ i k 0
+            ~ < k ( lsm_scan_count sc ) {
+                : ( Vec u ) key ( lsm_scan_key sc k )
+                : ( Vec u ) val ( lsm_scan_val sc k )
+                ( write_bytes key )
+                ( nurl_print `	` )
+                ( write_bytes val )
+                ( nurl_print `
+` )
+                ( vec_free [u] key ) ( vec_free [u] val )
+                = k + k 1
+            }
+            ( lsm_scan_free sc )
+        }
+        F e → { ( __die ( string_data e ) ) ( string_free e ) = rc 3 }
+    }
+    ( vec_free [u] f ) ( vec_free [u] t )
+    ^ rc
+}
+
+// Bulk import: `key<TAB>value` lines on stdin. One fsync at the end
+// instead of one per row — an import is a single unit of work, and the
+// log still makes the whole batch replayable if it dies midway.
+@ __cmd_load * Lsm db → i {
+    ( lsm_set_durable db F )
+    : String text ( read_all_stdin )
+    : ( Vec String ) lines ( string_split text `
+` )
+    ( string_free text )
+    : ~ i n 0
+    : ~ i rc 0
+    : ~ i k 0
+    ~ < k ( vec_len [String] lines ) {
+        ?? ( vec_get [String] lines k ) {
+            T ln → {
+                ?? ( string_index_of ln `	` ) {
+                    T tab → {
+                        : String kk ( string_substr ln 0 tab )
+                        : String vv ( string_substr ln + tab 1 - - ( string_len ln ) tab 1 )
+                        ? > ( string_len kk ) 0 {
+                            ? == 0 ( __cmd_put db ( string_data kk ) ( string_data vv ) ) {
+                                = n + n 1
+                            } { = rc 1 }
+                        } {}
+                        ( string_free kk ) ( string_free vv )
+                    }
+                    F → {}
+                }
+            }
+            F → {}
+        }
+        = k + k 1
+    }
+    ( __free_strvec lines )
+    ( lsm_set_durable db T )
+    ?? ( lsm_sync db ) { T _ → {} F e → { ( __die ( string_data e ) ) ( string_free e ) = rc 3 } }
+    : String out ( string_with_cap 32 )
+    ( string_push_int out n )
+    ( string_push_str out ` rows
+` )
+    ( nurl_print ( string_data out ) )
+    ( string_free out )
+    ^ rc
+}
+
+@ __cmd_stats * Lsm db → i {
+    : LsmStats st ( lsm_stats db )
+    : String out ( string_with_cap 256 )
+    ( string_push_str out `tables      ` ) ( string_push_int out . st tables )
+    ( string_push_str out `
+entries     ` ) ( string_push_int out . st entries )
+    ( string_push_str out `
+table bytes ` ) ( string_push_int out . st filebytes )
+    ( string_push_str out `
+memtable    ` ) ( string_push_int out . st memcount )
+    ( string_push_str out ` entries, ` ) ( string_push_int out . st membytes )
+    ( string_push_str out ` bytes
+sequence    ` ) ( string_push_int out . st seq )
+    ( string_push_char out 10 )
+    ( nurl_print ( string_data out ) )
+    ( string_free out )
+    ^ 0
+}
+
+// ── benchmark ───────────────────────────────────────────────────────
+
+@ __bench_key String buf i n → v {
+    ( string_clear buf )
+    ( string_push_str buf `key:` )
+    : String d ( string_with_cap 16 )
+    ( string_push_int d n )
+    : ~ i pad - 9 ( string_len d )
+    ~ > pad 0 { ( string_push_char buf 48 ) = pad - pad 1 }
+    ( string_push_str buf ( string_data d ) )
+    ( string_free d )
+}
+
+@ __rate i ops i ns → i {
+    ? <= ns 0 { ^ 0 } {}
+    ^ / * ops 1000000000 ns
+}
+
+@ __report s label i ops i ns → v {
+    : String out ( string_with_cap 64 )
+    ( string_push_str out label )
+    ( string_push_int out ( __rate ops ns ) )
+    ( string_push_str out ` ops/s  (` )
+    ( string_push_int out / ns 1000000 )
+    ( string_push_str out ` ms for ` )
+    ( string_push_int out ops )
+    ( string_push_str out `)
+` )
+    ( nurl_print ( string_data out ) )
+    ( string_free out )
+}
+
+// Three numbers that actually describe an LSM tree: the durable write
+// rate (one fsync per write), the batched write rate (fsync once), and
+// the point-read rate after the data has been flushed to tables — the
+// last is the one the Bloom filter and the block index exist for.
+@ __cmd_bench * Lsm db i n → i {
+    : String kb ( string_with_cap 32 )
+    : ( Vec u ) val ( bytes_from_str `0123456789abcdef0123456789abcdef0123456789abcdef` )
+    : ~ i rc 0
+
+    : i durable_n ? > n 2000 2000 n
+    : i t0 ( monotonic_ns )
+    : ~ i i 0
+    ~ < i durable_n {
+        ( __bench_key kb i )
+        : ( Vec u ) k ( bytes_from_str ( string_data kb ) )
+        ?? ( lsm_put db k val ) { T _ → {} F e → { ( string_free e ) = rc 3 } }
+        ( vec_free [u] k )
+        = i + i 1
+    }
+    : i t1 ( monotonic_ns )
+    ( __report `durable writes  ` durable_n - t1 t0 )
+
+    ( lsm_set_durable db F )
+    : i t2 ( monotonic_ns )
+    : ~ i j 0
+    ~ < j n {
+        ( __bench_key kb + j 1000000 )
+        : ( Vec u ) k ( bytes_from_str ( string_data kb ) )
+        ?? ( lsm_put db k val ) { T _ → {} F e → { ( string_free e ) = rc 3 } }
+        ( vec_free [u] k )
+        = j + j 1
+    }
+    : i t3 ( monotonic_ns )
+    ( __report `batched writes  ` n - t3 t2 )
+    ( lsm_set_durable db T )
+
+    ?? ( lsm_flush db ) { T _ → {} F e → { ( string_free e ) = rc 3 } }
+
+    : i t4 ( monotonic_ns )
+    : ~ i hits 0
+    : ~ i q 0
+    ~ < q n {
+        ( __bench_key kb + q 1000000 )
+        : ( Vec u ) k ( bytes_from_str ( string_data kb ) )
+        ?? ( lsm_get db k ) {
+            T g → { ? == . g found 1 { = hits + hits 1 } {} ( lsm_get_free g ) }
+            F e → { ( string_free e ) = rc 3 }
+        }
+        ( vec_free [u] k )
+        = q + q 1
+    }
+    : i t5 ( monotonic_ns )
+    ( __report `point reads     ` n - t5 t4 )
+
+    : i t6 ( monotonic_ns )
+    : ~ i misses 0
+    : ~ i m 0
+    ~ < m n {
+        ( __bench_key kb + m 9000000 )
+        : ( Vec u ) k ( bytes_from_str ( string_data kb ) )
+        ?? ( lsm_get db k ) {
+            T g → { ? == . g found 0 { = misses + misses 1 } {} ( lsm_get_free g ) }
+            F e → { ( string_free e ) = rc 3 }
+        }
+        ( vec_free [u] k )
+        = m + m 1
+    }
+    : i t7 ( monotonic_ns )
+    ( __report `absent reads    ` n - t7 t6 )
+
+    ? != hits n { ( __die `benchmark read-back mismatch` ) = rc 1 } {}
+    ? != misses n { ( __die `benchmark absent-key mismatch` ) = rc 1 } {}
+    ( string_free kb )
+    ( vec_free [u] val )
+    ^ rc
+}
+
+// ── entry point ─────────────────────────────────────────────────────
+
+@ __usage ArgParser p → v {
+    : String h ( args_usage p )
+    ( nurl_print `lsmdb — a crash-safe embedded key/value store
+
+Commands:
+  put <key> <value>     store a value (durable when it returns)
+  get <key>             print the value; exit 1 if the key is absent
+  del <key>             delete a key
+  scan                  print key<TAB>value for a range, in order
+  load                  bulk import key<TAB>value lines from stdin
+  flush                 force the memtable out into a table
+  compact               merge every table into one, dropping dead data
+  stats                 tables, entries, bytes, sequence
+  bench                 measure writes/s and reads/s on this machine
+
+` )
+    ( nurl_print ( string_data h ) )
+    ( string_free h )
+}
+
+@ main → i {
+    : ArgParser p ( args_new `lsmdb` `a crash-safe embedded key/value store` )
+    ( args_flag p `help` 104 `show this help` )  // -h
+    ( args_flag p `raw` 114 `get: no trailing newline after the value` )  // -r
+    ( args_flag p `no-sync` 0 `do not fsync each write (faster, unsafe)` )
+    ( args_opt p `dir` 100 `DIR` `database directory ($LSMDB_DIR, else ./lsmdb)` )  // -d
+    ( args_opt p `from` 102 `KEY` `scan: start key (inclusive)` )  // -f
+    ( args_opt p `to` 116 `KEY` `scan: end key (exclusive)` )  // -t
+    ( args_opt p `limit` 108 `N` `scan: stop after N rows` )  // -l
+    ( args_opt p `at` 0 `SEQ` `read as of sequence number SEQ (a snapshot)` )
+    ( args_opt p `num` 110 `N` `bench: operations per phase (default 20000)` )  // -n
+
+    // argv[1..] — env_args_list includes the program name.
+    : ( Vec String ) argv ( vec_new [String] )
+    : i ac ( env_args_count )
+    : ~ i ai 1
+    ~ < ai ac {
+        ( vec_push [String] argv ( env_arg ai ) )
+        = ai + ai 1
+    }
+    : ~ i rc 0
+    ? ( args_parse p argv ) {} {
+        ( __die ( args_error p ) )
+        ( args_free p ) ( __free_strvec argv )
+        ^ 2
+    }
+    ? | ( args_present p `help` ) == 0 ( args_positional_count p ) {
+        ( __usage p )
+        ( args_free p ) ( __free_strvec argv )
+        ^ 0
+    } {}
+
+    : ( Vec String ) ps ( args_positionals p )
+    : s cmd ( __pos ps 0 )
+
+    : ~ String dirstr ( __opt_str p `dir` `` )
+    ? == 0 ( string_len dirstr ) {
+        ( string_free dirstr )
+        = dirstr ( env_var_or `LSMDB_DIR` `lsmdb` )
+    } {}
+
+    : !*Lsm String opened ( lsm_open ( string_data dirstr ) )
+    : ~ * Lsm db # *Lsm 0
+    ?? opened {
+        T h → { = db h }
+        F e → {
+            ( __die ( string_data e ) ) ( string_free e )
+            ( string_free dirstr ) ( args_free p ) ( __free_strvec argv )
+            ^ 1
+        }
+    }
+    ( string_free dirstr )
+    ? ( args_present p `no-sync` ) { ( lsm_set_durable db F ) } {}
+    : i snap ( __opt_int p `at` ( lsm_seq db ) )
+
+    ? ( nurl_str_eq cmd `put` ) {
+        ? < ( args_positional_count p ) 3 {
+            ( __die `put needs a key and a value` ) = rc 2
+        } { = rc ( __cmd_put db ( __pos ps 1 ) ( __pos ps 2 ) ) }
+    } {
+        ? ( nurl_str_eq cmd `get` ) {
+            ? < ( args_positional_count p ) 2 {
+                ( __die `get needs a key` ) = rc 2
+            } { = rc ( __cmd_get db ( __pos ps 1 ) snap ( args_present p `raw` ) ) }
+        } {
+            ? ( nurl_str_eq cmd `del` ) {
+                ? < ( args_positional_count p ) 2 {
+                    ( __die `del needs a key` ) = rc 2
+                } { = rc ( __cmd_del db ( __pos ps 1 ) ) }
+            } {
+                ? ( nurl_str_eq cmd `scan` ) {
+                    : String from ( __opt_str p `from` `` )
+                    : String to ( __opt_str p `to` `` )
+                    = rc ( __cmd_scan db ( string_data from ) ( string_data to )
+                    ( __opt_int p `limit` 0 ) snap )
+                    ( string_free from ) ( string_free to )
+                } {
+                    ? ( nurl_str_eq cmd `load` ) { = rc ( __cmd_load db ) } {
+                        ? ( nurl_str_eq cmd `stats` ) { = rc ( __cmd_stats db ) } {
+                            ? ( nurl_str_eq cmd `flush` ) {
+                                ?? ( lsm_flush db ) {
+                                    T n → {
+                                        : String out ( string_with_cap 32 )
+                                        ( string_push_int out n )
+                                        ( string_push_str out ` entries flushed
+` )
+                                        ( nurl_print ( string_data out ) )
+                                        ( string_free out )
+                                    }
+                                    F e → { ( __die ( string_data e ) ) ( string_free e ) = rc 3 }
+                                }
+                            } {
+                                ? ( nurl_str_eq cmd `compact` ) {
+                                    ?? ( lsm_compact db ) {
+                                        T n → {
+                                            : String out ( string_with_cap 32 )
+                                            ( string_push_int out n )
+                                            ( string_push_str out ` live entries kept
+` )
+                                            ( nurl_print ( string_data out ) )
+                                            ( string_free out )
+                                        }
+                                        F e → { ( __die ( string_data e ) ) ( string_free e ) = rc 3 }
+                                    }
+                                } {
+                                    ? ( nurl_str_eq cmd `bench` ) {
+                                        = rc ( __cmd_bench db ( __opt_int p `num` 20000 ) )
+                                    } {
+                                        ( __die `unknown command (try --help)` )
+                                        = rc 2
+                                    } } } } } } } } }
+
+    ( lsm_close db )
+    ( args_free p )
+    ( __free_strvec argv )
+    ( flush )
+    ^ rc
+}

--- a/packages/lsmdb/src/memtable.nu
+++ b/packages/lsmdb/src/memtable.nu
@@ -1,0 +1,298 @@
+// packages/lsmdb/src/memtable.nu — the write buffer of the LSM tree: a
+// skip list over a byte arena.
+//
+// Every write lands here first (after the WAL). The structure has to be
+// three things at once: ordered (so a flush emits a sorted SSTable and a
+// range scan needs no sorting), versioned (so a snapshot read can see the
+// database as it was N writes ago), and cheap to build (a database does
+// millions of these).
+//
+// The layout is index-based, not pointer-based: keys and values are
+// appended to ONE growable arena, and a node is a row of integers —
+// (key offset, key length, value offset, value length, sequence, kind)
+// plus its forward links. Nothing is individually allocated or freed, so
+// dropping the whole memtable is a handful of vec_frees, and a node is
+// never invalidated by the arena growing under it (offsets, not pointers).
+//
+// Ordering is LevelDB's: key ascending, and for equal keys sequence
+// DESCENDING — the newest version of a key sorts first. That single rule
+// gives both "get the current value" (take the first match) and "get the
+// value as of sequence S" (take the first match with seq <= S) from the
+// same search.
+//
+//   ( mt_new seed )                       → *MemTable
+//   ( mt_put m key val seq kind )         → v      kind: MT_PUT / MT_DEL
+//   ( mt_find m key snap )                → i      node index, 0 = miss
+//   ( mt_seek m key snap )                → i      first node >= key
+//   ( mt_first m ) / ( mt_next m n )      → i      ordered walk, 0 = end
+//   ( mt_key m n ) / ( mt_val m n )       → ( Vec u )   owned copies
+//   ( mt_seq m n ) / ( mt_kind m n )      → i
+//   ( mt_count m ) / ( mt_bytes m )       → i
+//   ( mt_free m )
+
+$ `stdlib/core/vec.nu`
+
+: i MT_MAXLVL 12
+: i MT_PUT 1
+: i MT_DEL 0
+
+: MemTable {
+    ( Vec u ) arena
+    ( Vec i ) koff
+    ( Vec i ) klen
+    ( Vec i ) voff
+    ( Vec i ) vlen
+    ( Vec i ) nseq
+    ( Vec i ) nkind
+    ( Vec i ) nlvl
+    ( Vec i ) links
+    i level
+    i count
+    i rng
+}
+
+// ── raw byte compare ────────────────────────────────────────────────
+//
+// Bytewise, unsigned, shorter-is-smaller — the total order the whole
+// package agrees on: memtable, SSTable, merge, scan.
+
+@ lsm_bytes_cmp_raw * u ap i aoff i alen * u bp i boff i blen → i {
+    : i lim ? < alen blen alen blen
+    : ~ i k 0
+    ~ < k lim {
+        : i ca # i . ap + aoff k
+        : i cb # i . bp + boff k
+        ? != ca cb { ^ ? < ca cb -1 1 } {}
+        = k + k 1
+    }
+    ? == alen blen { ^ 0 } {}
+    ^ ? < alen blen -1 1
+}
+
+// Compare two whole byte vectors.
+@ lsm_bytes_cmp ( Vec u ) a ( Vec u ) b → i {
+    ^ ( lsm_bytes_cmp_raw ( vec_data [u] a ) 0 ( vec_len [u] a )
+    ( vec_data [u] b ) 0 ( vec_len [u] b ) )
+}
+
+// ── construction ────────────────────────────────────────────────────
+
+@ mt_new i seed → *MemTable {
+    : *MemTable m # *MemTable ( nurl_alloc Z MemTable )
+    = . m arena ( vec_new [u] )
+    = . m koff ( vec_new [i] )
+    = . m klen ( vec_new [i] )
+    = . m voff ( vec_new [i] )
+    = . m vlen ( vec_new [i] )
+    = . m nseq ( vec_new [i] )
+    = . m nkind ( vec_new [i] )
+    = . m nlvl ( vec_new [i] )
+    = . m links ( vec_new [i] )
+    = . m level 1
+    = . m count 0
+    = . m rng ? == seed 0 88172645463325252 seed
+    // Node 0 is the head sentinel, so index 0 doubles as "nil" — a link
+    // can never legitimately point back at the head.
+    : i _head ( __mt_alloc_node m 0 0 0 0 0 MT_PUT MT_MAXLVL )
+    ^ m
+}
+
+@ mt_free * MemTable m → v {
+    ( vec_free [u] . m arena )
+    ( vec_free [i] . m koff )
+    ( vec_free [i] . m klen )
+    ( vec_free [i] . m voff )
+    ( vec_free [i] . m vlen )
+    ( vec_free [i] . m nseq )
+    ( vec_free [i] . m nkind )
+    ( vec_free [i] . m nlvl )
+    ( vec_free [i] . m links )
+    ( nurl_free # s m )
+}
+
+@ __mt_alloc_node * MemTable m i ko i kl i vo i vl i seq i kind i lvl → i {
+    : i idx ( vec_len [i] . m koff )
+    ( vec_push [i] . m koff ko )
+    ( vec_push [i] . m klen kl )
+    ( vec_push [i] . m voff vo )
+    ( vec_push [i] . m vlen vl )
+    ( vec_push [i] . m nseq seq )
+    ( vec_push [i] . m nkind kind )
+    ( vec_push [i] . m nlvl lvl )
+    : ~ i l 0
+    ~ < l MT_MAXLVL {
+        ( vec_push [i] . m links 0 )
+        = l + l 1
+    }
+    ^ idx
+}
+
+// ── accessors ───────────────────────────────────────────────────────
+
+@ _mt_iat ( Vec i ) v i idx → i {
+    ^ ?? ( vec_get [i] v idx ) { T x → x F _ → 0 }
+}
+
+@ __mt_link * MemTable m i node i lvl → i {
+    ^ ( _mt_iat . m links + * node MT_MAXLVL lvl )
+}
+
+@ __mt_set_link * MemTable m i node i lvl i to → v {
+    : b _ok ( vec_set [i] . m links + * node MT_MAXLVL lvl to )
+}
+
+@ mt_seq * MemTable m i node → i { ^ ( _mt_iat . m nseq node ) }
+
+@ mt_kind * MemTable m i node → i { ^ ( _mt_iat . m nkind node ) }
+
+@ mt_count * MemTable m → i { ^ . m count }
+
+// Bytes held: the arena plus the per-node integer rows. The store
+// compares this against its memtable budget, so it has to count the
+// index too — a million tiny keys is mostly index.
+@ mt_bytes * MemTable m → i {
+    : i nodes ( vec_len [i] . m koff )
+    ^ + ( vec_len [u] . m arena ) * nodes * 8 + 7 MT_MAXLVL
+}
+
+@ _mt_slice ( Vec u ) src i off i n → ( Vec u ) {
+    : i cap ? > n 0 n 1
+    : ( Vec u ) out ( vec_with_cap [u] cap )
+    ? > n 0 { ( vec_extend_range [u] out src off n ) } {}
+    ^ out
+}
+
+@ mt_key * MemTable m i node → ( Vec u ) {
+    ^ ( _mt_slice . m arena ( _mt_iat . m koff node ) ( _mt_iat . m klen node ) )
+}
+
+@ mt_val * MemTable m i node → ( Vec u ) {
+    ^ ( _mt_slice . m arena ( _mt_iat . m voff node ) ( _mt_iat . m vlen node ) )
+}
+
+// ── ordering ────────────────────────────────────────────────────────
+
+// Compare node `node` against the probe (key, seq) in memtable order:
+// key ascending, sequence descending. <0 means the node sorts first.
+@ __mt_cmp_node * MemTable m i node * u pp i poff i plen i pseq → i {
+    : *u ap ( vec_data [u] . m arena )
+    : i c ( lsm_bytes_cmp_raw ap ( _mt_iat . m koff node ) ( _mt_iat . m klen node )
+    pp poff plen )
+    ? != c 0 { ^ c } {}
+    : i ns ( _mt_iat . m nseq node )
+    ? == ns pseq { ^ 0 } {}
+    ^ ? > ns pseq -1 1
+}
+
+// xorshift64 — deterministic level draws, so a given write sequence
+// always builds the same structure and tests can rely on it.
+@ __mt_rand * MemTable m → i {
+    : ~ i x . m rng
+    = x ^^ x << x 13
+    = x ^^ x >> x 7
+    = x ^^ x << x 17
+    = . m rng x
+    ^ & x 9223372036854775807
+}
+
+@ __mt_pick_level * MemTable m → i {
+    : ~ i lvl 1
+    : ~ b climb T
+    ~ climb {
+        ? & < lvl MT_MAXLVL == 0 & ( __mt_rand m ) 3 { = lvl + lvl 1 } { = climb F }
+    }
+    ^ lvl
+}
+
+// Walk down the levels to the last node that sorts BEFORE the probe,
+// recording the path in `prev` when it is non-empty.
+@ __mt_descend * MemTable m * u pp i poff i plen i pseq ( Vec i ) prev → i {
+    : ~ i x 0
+    : ~ i lv - . m level 1
+    ~ >= lv 0 {
+        : ~ b more T
+        ~ more {
+            : i nx ( __mt_link m x lv )
+            ? == nx 0 { = more F } {
+                ? < ( __mt_cmp_node m nx pp poff plen pseq ) 0 { = x nx } { = more F }
+            }
+        }
+        ? > ( vec_len [i] prev ) lv { : b _ok ( vec_set [i] prev lv x ) } {}
+        = lv - lv 1
+    }
+    ^ x
+}
+
+// ── insert ──────────────────────────────────────────────────────────
+
+// Append (key, val) as a new version. Both are COPIED into the arena;
+// the caller keeps ownership of the vectors it passed in.
+@ mt_put * MemTable m ( Vec u ) key ( Vec u ) val i seq i kind → v {
+    : i kl ( vec_len [u] key )
+    : i vl ? == kind MT_PUT ( vec_len [u] val ) 0
+    : i ko ( vec_len [u] . m arena )
+    ( vec_extend [u] . m arena key )
+    : i vo ( vec_len [u] . m arena )
+    ? > vl 0 { ( vec_extend [u] . m arena val ) } {}
+
+    : ( Vec i ) prev ( vec_with_cap [i] MT_MAXLVL )
+    : ~ i l 0
+    ~ < l MT_MAXLVL { ( vec_push [i] prev 0 ) = l + l 1 }
+
+    // The probe is the key we just copied in — take the arena pointer
+    // AFTER the extends above, which may have moved the buffer.
+    : *u ap ( vec_data [u] . m arena )
+    : i _x ( __mt_descend m ap ko kl seq prev )
+
+    : i lvl ( __mt_pick_level m )
+    ? > lvl . m level {
+        : ~ i j . m level
+        ~ < j lvl { : b _o ( vec_set [i] prev j 0 ) = j + j 1 }
+        = . m level lvl
+    } {}
+
+    : i node ( __mt_alloc_node m ko kl vo vl seq kind lvl )
+    : ~ i q 0
+    ~ < q lvl {
+        : i p ( _mt_iat prev q )
+        ( __mt_set_link m node q ( __mt_link m p q ) )
+        ( __mt_set_link m p q node )
+        = q + q 1
+    }
+    = . m count + . m count 1
+    ( vec_free [i] prev )
+}
+
+// ── lookup / iteration ──────────────────────────────────────────────
+
+// First node with (key, seq) >= (probe, snap) — i.e. the newest version
+// of `key` no newer than `snap`, or the next key after it. 0 = end.
+@ mt_seek * MemTable m ( Vec u ) key i snap → i {
+    : ( Vec i ) none ( vec_new [i] )
+    : i x ( __mt_descend m ( vec_data [u] key ) 0 ( vec_len [u] key ) snap none )
+    ( vec_free [i] none )
+    ^ ( __mt_link m x 0 )
+}
+
+// The node holding `key` as of `snap`, or 0. The caller still has to ask
+// mt_kind: a tombstone is a hit that means "deleted", not "not found".
+@ mt_find * MemTable m ( Vec u ) key i snap → i {
+    : i cand ( mt_seek m key snap )
+    ? == cand 0 { ^ 0 } {}
+    : i c ( lsm_bytes_cmp_raw ( vec_data [u] . m arena )
+    ( _mt_iat . m koff cand ) ( _mt_iat . m klen cand )
+    ( vec_data [u] key ) 0 ( vec_len [u] key ) )
+    ^ ? == c 0 cand 0
+}
+
+@ mt_first * MemTable m → i { ^ ( __mt_link m 0 0 ) }
+
+@ mt_next * MemTable m i node → i { ^ ( __mt_link m node 0 ) }
+
+// Borrowed view of a node's key, for merge comparisons that must not
+// allocate. Valid until the next mt_put (which may move the arena).
+@ mt_kptr * MemTable m → *u { ^ ( vec_data [u] . m arena ) }
+
+@ mt_koff * MemTable m i node → i { ^ ( _mt_iat . m koff node ) }
+
+@ mt_klen * MemTable m i node → i { ^ ( _mt_iat . m klen node ) }

--- a/packages/lsmdb/src/sst.nu
+++ b/packages/lsmdb/src/sst.nu
@@ -1,0 +1,744 @@
+// packages/lsmdb/src/sst.nu — the immutable on-disk table.
+//
+// An SSTable is what a memtable becomes when it stops changing: entries
+// sorted by (key ascending, sequence descending), cut into ~4 KiB blocks,
+// each block CRC-32'd, with a block index and a Bloom filter at the tail
+// and a fixed 48-byte footer that names them.
+//
+//   [data block 0][data block 1]…[index block][bloom block][footer 48B]
+//
+// Data block payload — entries back to back, sorted:
+//   [u32 klen][u32 vlen][u64 seq][u8 kind][key bytes][value bytes]
+// followed on disk by [u32 crc32(payload)]. A block is closed once its
+// payload reaches SST_BLOCK bytes, so one oversized value still gets a
+// block of its own rather than being rejected.
+//
+// Index block payload — one entry per data block, carrying that block's
+// LAST key:
+//   [u32 nblocks] then [u32 klen][key][u64 off][u32 payload_len]…
+// The last key (not the first) is what makes the search correct when a
+// key's versions straddle a block boundary: "first block whose last key
+// >= probe" always lands on the block holding the NEWEST version, and the
+// reader then continues into the next block for the rest of the run.
+//
+// Bloom block payload: [u32 nbits][u32 k][bit bytes]. A negative lookup
+// that the filter rejects costs no disk read at all — the reason a get
+// for an absent key does not have to touch every table in the tree.
+//
+// Footer: [u64 index_off][u32 index_len][u64 bloom_off][u32 bloom_len]
+//         [u64 nentries][u64 max_seq]["LSMDBv1\n"]
+//
+// Nothing here is read wholesale: open() loads only the index and the
+// filter, and every get pulls exactly the one block it needs. A table
+// larger than RAM is an ordinary table.
+//
+//   ( sst_create path )            → !*SstWriter String
+//   ( sst_add w key val seq kind ) → !v String     keys must arrive sorted
+//   ( sst_finish w )               → !i String     entries written
+//   ( sst_open path )              → !*SstReader String
+//   ( sst_get r key snap )         → !SstHit String
+//   ( sst_cursor r ) / ( sc_seek ) / ( sc_next ) / ( sc_valid ) …
+//   ( sst_close r ) / ( sc_free c )
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/deflate.nu`
+$ `memtable.nu`
+
+: i SST_BLOCK 4096
+: i SST_HDR 17  // u32 klen + u32 vlen + u64 seq + u8 kind
+: i SST_FOOTER 48
+: i SST_BLOOM_BITS 10  // bits per key → ~1 % false positives at k=7
+: i SST_BLOOM_K 7
+: i SST_CACHE 32  // resident data blocks per open table
+
+@ __sst_magic → s { ^ `LSMDBv1
+` }
+
+// ── Bloom filter ────────────────────────────────────────────────────
+
+// FNV-1a over the key, folded to 64 bits. The filter needs two
+// independent hashes; the second is derived by odd-shifting the first
+// (Kirsch–Mitzenmacher), which is standard and keeps one pass over the key.
+@ lsm_key_hash * u p i off i len → i {
+    : ~ i h 1469598103934665603
+    : ~ i k 0
+    ~ < k len {
+        = h ^^ h # i . p + off k
+        = h * h 1099511628211
+        = k + k 1
+    }
+    ^ & h 9223372036854775807
+}
+
+@ __bloom_bits i nkeys → i {
+    : i want * ? > nkeys 0 nkeys 1 SST_BLOOM_BITS
+    : i rounded * + / want 8 1 8
+    ^ ? < rounded 64 64 rounded
+}
+
+// Set the k bit positions of one hash into `bits`.
+@ __bloom_set ( Vec u ) bits i nbits i h → v {
+    : i h2 | >> h 33 1
+    : *u p ( vec_data [u] bits )
+    : ~ i i 0
+    ~ < i SST_BLOOM_K {
+        : i pos % & + h * i h2 9223372036854775807 nbits
+        : i byte / pos 8
+        : i cur # i . p byte
+        = . p byte # u | cur << 1 % pos 8
+        = i + i 1
+    }
+}
+
+@ __bloom_test ( Vec u ) bits i nbits i h → b {
+    ? <= nbits 0 { ^ T } {}
+    : i h2 | >> h 33 1
+    : *u p ( vec_data [u] bits )
+    : ~ i i 0
+    ~ < i SST_BLOOM_K {
+        : i pos % & + h * i h2 9223372036854775807 nbits
+        : i byte / pos 8
+        ? == 0 & # i . p byte << 1 % pos 8 { ^ F } {}
+        = i + i 1
+    }
+    ^ T
+}
+
+// ── writer ──────────────────────────────────────────────────────────
+
+: SstWriter {
+    File f
+    ( Vec u ) buf  // current block payload
+    ( Vec u ) index  // index payload so far
+    ( Vec i ) hashes  // one key hash per entry, for the filter
+    i off  // next file offset to write at
+    i blkoff  // file offset of the block being built
+    i count
+    i maxseq
+    i nblocks
+    i lastkoff  // offset of the last entry's key inside buf
+    i lastklen
+    i failed
+    Crc32 crc
+}
+
+@ sst_create s path → !*SstWriter String {
+    : !File IoErr fr ( file_create path )
+    ?? fr {
+        T f → {
+            : *SstWriter w # *SstWriter ( nurl_alloc Z SstWriter )
+            = . w f f
+            = . w buf ( vec_with_cap [u] + SST_BLOCK 1024 )
+            = . w index ( vec_new [u] )
+            = . w hashes ( vec_new [i] )
+            = . w off 0
+            = . w blkoff 0
+            = . w count 0
+            = . w maxseq 0
+            = . w nblocks 0
+            = . w lastkoff 0
+            = . w lastklen 0
+            = . w failed 0
+            = . w crc ( crc32_ctx )
+            ^ @ !*SstWriter String { T w }
+        }
+        F _ → {
+            : String msg ( string_from `lsmdb: cannot create table ` )
+            ( string_push_str msg path )
+            ^ @ !*SstWriter String { F msg }
+        }
+    }
+}
+
+@ __sstw_free * SstWriter w → v {
+    ( crc32_ctx_free . w crc )
+    ( vec_free [u] . w buf )
+    ( vec_free [u] . w index )
+    ( vec_free [i] . w hashes )
+    ( nurl_free # s w )
+}
+
+// Close the current block: append its CRC trailer, write it, and record
+// (last key, offset, payload length) in the index.
+@ __sst_flush_block * SstWriter w → !v String {
+    : i plen ( vec_len [u] . w buf )
+    ? == plen 0 { ^ @ !v String { T 0 } } {}
+    : i crc ( crc32_ctx_hash . w crc . w buf )
+
+    // Index entry first — it reads the last key out of the payload,
+    // before the CRC trailer lands on the end of the same buffer.
+    ( bytes_push_u32_le . w index # u32 . w lastklen )
+    ( vec_extend_range [u] . w index . w buf . w lastkoff . w lastklen )
+    ( bytes_push_u64_le . w index # u64 . w blkoff )
+    ( bytes_push_u32_le . w index # u32 plen )
+
+    ( bytes_push_u32_le . w buf # u32 crc )
+    : !v IoErr wr ( file_write_chunk . w f . w buf )
+    ?? wr {
+        T _ → {}
+        F _ → {
+            = . w failed 1
+            ^ @ !v String { F ( string_from `lsmdb: table write failed (disk full?)` ) }
+        }
+    }
+    = . w off + . w off + plen 4
+    = . w blkoff . w off
+    = . w nblocks + . w nblocks 1
+    ( vec_clear [u] . w buf )
+    ^ @ !v String { T 0 }
+}
+
+// Append one entry. Keys must arrive in the package's total order —
+// the memtable walk and the compaction merge both produce exactly that.
+@ sst_add * SstWriter w ( Vec u ) key ( Vec u ) val i seq i kind → !v String {
+    : i kl ( vec_len [u] key )
+    : i vl ? == kind MT_PUT ( vec_len [u] val ) 0
+    ( bytes_push_u32_le . w buf # u32 kl )
+    ( bytes_push_u32_le . w buf # u32 vl )
+    ( bytes_push_u64_le . w buf # u64 seq )
+    ( vec_push [u] . w buf # u kind )
+    = . w lastkoff ( vec_len [u] . w buf )
+    = . w lastklen kl
+    ( vec_extend [u] . w buf key )
+    ? > vl 0 { ( vec_extend [u] . w buf val ) } {}
+
+    ( vec_push [i] . w hashes ( lsm_key_hash ( vec_data [u] key ) 0 kl ) )
+    = . w count + . w count 1
+    ? > seq . w maxseq { = . w maxseq seq } {}
+
+    ? >= ( vec_len [u] . w buf ) SST_BLOCK { ^ ( __sst_flush_block w ) } {}
+    ^ @ !v String { T 0 }
+}
+
+@ __sst_write_tail * SstWriter w ( Vec u ) payload → !i String {
+    : i at . w off
+    : i crc ( crc32_ctx_hash . w crc payload )
+    ( bytes_push_u32_le payload # u32 crc )
+    : !v IoErr wr ( file_write_chunk . w f payload )
+    ?? wr {
+        T _ → { = . w off + . w off ( vec_len [u] payload ) ^ @ !i String { T at } }
+        F _ → { ^ @ !i String { F ( string_from `lsmdb: table write failed (disk full?)` ) } }
+    }
+}
+
+// Flush the tail block, emit the filter, the index and the footer, then
+// fsync. When this returns the table is durable and self-describing;
+// only after that may a manifest name it.
+@ sst_finish * SstWriter w → !i String {
+    : !v String fb ( __sst_flush_block w )
+    ?? fb { T _ → {} F e → { ( file_close . w f ) ( __sstw_free w ) ^ @ !i String { F e } } }
+
+    : i nkeys ( vec_len [i] . w hashes )
+    : i nbits ( __bloom_bits nkeys )
+    : ( Vec u ) bloom ( vec_new [u] )
+    ( bytes_push_u32_le bloom # u32 nbits )
+    ( bytes_push_u32_le bloom # u32 SST_BLOOM_K )
+    : i nbytes / nbits 8
+    : ( Vec u ) bits ( vec_with_cap [u] nbytes )
+    : ~ i z 0
+    ~ < z nbytes { ( vec_push [u] bits # u 0 ) = z + z 1 }
+    : ~ i h 0
+    ~ < h nkeys {
+        ( __bloom_set bits nbits ?? ( vec_get [i] . w hashes h ) { T x → x F _ → 0 } )
+        = h + h 1
+    }
+    ( vec_extend [u] bloom bits )
+    ( vec_free [u] bits )
+
+    : ( Vec u ) idx ( vec_new [u] )
+    ( bytes_push_u32_le idx # u32 . w nblocks )
+    ( vec_extend [u] idx . w index )
+    : i idx_payload ( vec_len [u] idx )
+
+    : !i String ir ( __sst_write_tail w idx )
+    ( vec_free [u] idx )
+    : ~ i index_off 0
+    ?? ir { T o → { = index_off o } F e → {
+            ( vec_free [u] bloom ) ( file_close . w f ) ( __sstw_free w )
+            ^ @ !i String { F e } } }
+
+    : i bloom_payload ( vec_len [u] bloom )
+    : !i String br ( __sst_write_tail w bloom )
+    ( vec_free [u] bloom )
+    : ~ i bloom_off 0
+    ?? br { T o → { = bloom_off o } F e → {
+            ( file_close . w f ) ( __sstw_free w )
+            ^ @ !i String { F e } } }
+
+    : ( Vec u ) foot ( vec_with_cap [u] SST_FOOTER )
+    ( bytes_push_u64_le foot # u64 index_off )
+    ( bytes_push_u32_le foot # u32 idx_payload )
+    ( bytes_push_u64_le foot # u64 bloom_off )
+    ( bytes_push_u32_le foot # u32 bloom_payload )
+    ( bytes_push_u64_le foot # u64 . w count )
+    ( bytes_push_u64_le foot # u64 . w maxseq )
+    ( bytes_extend_str foot ( __sst_magic ) )
+    : !v IoErr fw ( file_write_chunk . w f foot )
+    ( vec_free [u] foot )
+    : i n . w count
+    : ~ b ok T
+    ?? fw { T _ → {} F _ → { = ok F } }
+    ?? ( file_sync . w f ) { T _ → {} F _ → { = ok F } }
+    ( file_close . w f )
+    ( __sstw_free w )
+    ? ok {} { ^ @ !i String { F ( string_from `lsmdb: table write failed (disk full?)` ) } }
+    ^ @ !i String { T n }
+}
+
+// ── reader ──────────────────────────────────────────────────────────
+
+: SstReader {
+    File f
+    String path
+    ( Vec u ) ikeys  // concatenated per-block last keys
+    ( Vec i ) ikoff
+    ( Vec i ) iklen
+    ( Vec i ) iboff  // block offset in the file
+    ( Vec i ) iblen  // block payload length
+    ( Vec u ) bloom  // bit bytes only
+    i nbits
+    i nblocks
+    i nentries
+    i maxseq
+    i filesize
+    i reads  // blocks actually pulled off disk
+    i filtered  // gets the filter answered without a read
+    i hits  // blocks served from the cache
+    Crc32 crc  // one CRC table for the life of the reader
+    ( Vec ( Vec u ) ) cache  // SST_CACHE slots, direct-mapped by block index
+    ( Vec i ) cache_bi  // which block each slot holds, -1 = empty
+}
+
+: SstHit {
+    i found
+    i kind
+    i seq
+    ( Vec u ) val
+}
+
+@ sst_hit_free SstHit h → v { ( vec_free [u] . h val ) }
+
+@ __sst_err s path s what → String {
+    : String msg ( string_from `lsmdb: ` )
+    ( string_push_str msg path )
+    ( string_push_str msg `: ` )
+    ( string_push_str msg what )
+    ^ msg
+}
+
+// Read `n` bytes at `off` and prove them against their CRC trailer.
+// Returns the payload only. A checksum mismatch is an error — never
+// data: a torn or rotted block must not surface as a value.
+@ __sst_read_verified * SstReader r i off i plen → !( Vec u ) String {
+    : !( Vec u ) IoErr rr ( file_read_at . r f off + plen 4 )
+    ?? rr {
+        T raw → {
+            ? != ( vec_len [u] raw ) + plen 4 {
+                ( vec_free [u] raw )
+                ^ @ !( Vec u ) String { F ( __sst_err ( string_data . r path ) `truncated block (file shorter than its index says)` ) }
+            } {}
+            : i want ?? ( bytes_read_u32_le raw plen ) { T x → # i x F _ → 0 }
+            : ( Vec u ) payload ( _mt_slice raw 0 plen )
+            ( vec_free [u] raw )
+            : i got ( crc32_ctx_hash . r crc payload )
+            ? == got want { ^ @ !( Vec u ) String { T payload } } {}
+            ( vec_free [u] payload )
+            ^ @ !( Vec u ) String { F ( __sst_err ( string_data . r path ) `CHECKSUM MISMATCH — block is corrupt` ) }
+        }
+        F _ → {
+            ^ @ !( Vec u ) String { F ( __sst_err ( string_data . r path ) `cannot read block` ) }
+        }
+    }
+}
+
+@ sst_open s path → !*SstReader String {
+    : !File IoErr fr ( file_open path )
+    : ~ File f @ File { # s 0 }
+    ?? fr { T h → { = f h } F _ → {
+            ^ @ !*SstReader String { F ( __sst_err path `cannot open table` ) } } }
+
+    : *SstReader r # *SstReader ( nurl_alloc Z SstReader )
+    = . r f f
+    = . r path ( string_from path )
+    = . r ikeys ( vec_new [u] )
+    = . r ikoff ( vec_new [i] )
+    = . r iklen ( vec_new [i] )
+    = . r iboff ( vec_new [i] )
+    = . r iblen ( vec_new [i] )
+    = . r bloom ( vec_new [u] )
+    = . r nbits 0
+    = . r nblocks 0
+    = . r nentries 0
+    = . r maxseq 0
+    = . r filesize 0
+    = . r reads 0
+    = . r filtered 0
+    = . r hits 0
+    = . r crc ( crc32_ctx )
+    = . r cache ( vec_with_cap [( Vec u )] SST_CACHE )
+    = . r cache_bi ( vec_with_cap [i] SST_CACHE )
+    : ~ i cs 0
+    ~ < cs SST_CACHE {
+        ( vec_push [( Vec u )] . r cache ( vec_new [u] ) )
+        ( vec_push [i] . r cache_bi -1 )
+        = cs + cs 1
+    }
+
+    : !i IoErr sr ( file_seek f 0 FS_SEEK_END )
+    ?? sr { T sz → { = . r filesize sz } F _ → {
+            ( sst_close r )
+            ^ @ !*SstReader String { F ( __sst_err path `cannot size table` ) } } }
+    ? < . r filesize SST_FOOTER {
+        ( sst_close r )
+        ^ @ !*SstReader String { F ( __sst_err path `too short to be a table` ) }
+    } {}
+
+    : !( Vec u ) IoErr foot ( file_read_at f - . r filesize SST_FOOTER SST_FOOTER )
+    : ~ ( Vec u ) fb ( vec_new [u] )
+    ?? foot { T v → { ( vec_free [u] fb ) = fb v } F _ → {
+            ( sst_close r )
+            ^ @ !*SstReader String { F ( __sst_err path `cannot read footer` ) } } }
+    ? != ( vec_len [u] fb ) SST_FOOTER {
+        ( vec_free [u] fb ) ( sst_close r )
+        ^ @ !*SstReader String { F ( __sst_err path `short footer` ) }
+    } {}
+    : s magic ( __sst_magic )
+    : ~ b good T
+    : ~ i mi 0
+    ~ < mi 8 {
+        : i c ?? ( vec_get [u] fb + 40 mi ) { T x → # i x F _ → 0 }
+        ? != c ( nurl_str_get magic mi ) { = good F } {}
+        = mi + mi 1
+    }
+    ? good {} {
+        ( vec_free [u] fb ) ( sst_close r )
+        ^ @ !*SstReader String { F ( __sst_err path `not an lsmdb table (bad magic)` ) }
+    }
+    : i index_off ?? ( bytes_read_u64_le fb 0 ) { T x → # i x F _ → 0 }
+    : i index_len ?? ( bytes_read_u32_le fb 8 ) { T x → # i x F _ → 0 }
+    : i bloom_off ?? ( bytes_read_u64_le fb 12 ) { T x → # i x F _ → 0 }
+    : i bloom_len ?? ( bytes_read_u32_le fb 20 ) { T x → # i x F _ → 0 }
+    = . r nentries ?? ( bytes_read_u64_le fb 24 ) { T x → # i x F _ → 0 }
+    = . r maxseq ?? ( bytes_read_u64_le fb 32 ) { T x → # i x F _ → 0 }
+    ( vec_free [u] fb )
+
+    : !( Vec u ) String ir ( __sst_read_verified r index_off index_len )
+    : ~ ( Vec u ) idx ( vec_new [u] )
+    ?? ir { T v → { ( vec_free [u] idx ) = idx v } F e → {
+            ( sst_close r ) ^ @ !*SstReader String { F e } } }
+    : !v String pr ( __sst_parse_index r idx )
+    ( vec_free [u] idx )
+    ?? pr { T _ → {} F e → { ( sst_close r ) ^ @ !*SstReader String { F e } } }
+
+    : !( Vec u ) String br ( __sst_read_verified r bloom_off bloom_len )
+    ?? br {
+        T bl → {
+            = . r nbits ?? ( bytes_read_u32_le bl 0 ) { T x → # i x F _ → 0 }
+            ( vec_extend_range [u] . r bloom bl 8 - ( vec_len [u] bl ) 8 )
+            ( vec_free [u] bl )
+        }
+        F e → { ( sst_close r ) ^ @ !*SstReader String { F e } }
+    }
+    ^ @ !*SstReader String { T r }
+}
+
+@ __sst_parse_index * SstReader r ( Vec u ) idx → !v String {
+    : i n ( vec_len [u] idx )
+    ? < n 4 { ^ @ !v String { F ( __sst_err ( string_data . r path ) `malformed index` ) } } {}
+    : i nb ?? ( bytes_read_u32_le idx 0 ) { T x → # i x F _ → 0 }
+    : ~ i pos 4
+    : ~ i k 0
+    ~ < k nb {
+        ? > + pos 4 n { ^ @ !v String { F ( __sst_err ( string_data . r path ) `malformed index` ) } } {}
+        : i kl ?? ( bytes_read_u32_le idx pos ) { T x → # i x F _ → 0 }
+        = pos + pos 4
+        ? > + pos + kl 12 n { ^ @ !v String { F ( __sst_err ( string_data . r path ) `malformed index` ) } } {}
+        ( vec_push [i] . r ikoff ( vec_len [u] . r ikeys ) )
+        ( vec_push [i] . r iklen kl )
+        ( vec_extend_range [u] . r ikeys idx pos kl )
+        = pos + pos kl
+        ( vec_push [i] . r iboff ?? ( bytes_read_u64_le idx pos ) { T x → # i x F _ → 0 } )
+        = pos + pos 8
+        ( vec_push [i] . r iblen ?? ( bytes_read_u32_le idx pos ) { T x → # i x F _ → 0 } )
+        = pos + pos 4
+        = k + k 1
+    }
+    = . r nblocks nb
+    ^ @ !v String { T 0 }
+}
+
+@ sst_close * SstReader r → v {
+    ( crc32_ctx_free . r crc )
+    ( vec_free_with [( Vec u )] . r cache \ ( Vec u ) b → v { ( vec_free [u] b ) } )
+    ( vec_free [i] . r cache_bi )
+    ( file_close . r f )
+    ( string_free . r path )
+    ( vec_free [u] . r ikeys )
+    ( vec_free [i] . r ikoff )
+    ( vec_free [i] . r iklen )
+    ( vec_free [i] . r iboff )
+    ( vec_free [i] . r iblen )
+    ( vec_free [u] . r bloom )
+    ( nurl_free # s r )
+}
+
+@ sst_entries * SstReader r → i { ^ . r nentries }
+
+@ sst_maxseq * SstReader r → i { ^ . r maxseq }
+
+@ sst_blocks * SstReader r → i { ^ . r nblocks }
+
+@ sst_filesize * SstReader r → i { ^ . r filesize }
+
+@ sst_reads * SstReader r → i { ^ . r reads }
+
+@ sst_filtered * SstReader r → i { ^ . r filtered }
+
+@ sst_hits * SstReader r → i { ^ . r hits }
+
+// First block whose LAST key >= probe, or nblocks if the probe is past
+// the end of the table. Binary search over the index.
+@ __sst_find_block * SstReader r * u kp i klen → i {
+    : *u ip ( vec_data [u] . r ikeys )
+    : ~ i lo 0
+    : ~ i hi . r nblocks
+    ~ < lo hi {
+        : i mid / + lo hi 2
+        : i c ( lsm_bytes_cmp_raw ip ( _mt_iat . r ikoff mid ) ( _mt_iat . r iklen mid ) kp 0 klen )
+        ? < c 0 { = lo + mid 1 } { = hi mid }
+    }
+    ^ lo
+}
+
+// Load a data block, from the cache when it is there.
+//
+// A read that hits the cache skips both the syscall and the checksum —
+// the block was verified when it was read, and nothing can rot in RAM
+// that would not equally rot in the copy we would re-verify. That is the
+// same rule LevelDB's block cache follows, and it is why a scan (or any
+// workload with locality) costs one verification per block rather than
+// one per key: at ~100 entries to a 4 KiB block, that is the difference
+// between checksumming 4 KiB per read and 40 bytes.
+@ __sst_load_block * SstReader r i bi → !( Vec u ) String {
+    : i slot % bi SST_CACHE
+    ? == ( _mt_iat . r cache_bi slot ) bi {
+        ?? ( vec_get [( Vec u )] . r cache slot ) {
+            T cached → {
+                = . r hits + . r hits 1
+                ^ @ !( Vec u ) String { T ( vec_clone [u] cached ) }
+            }
+            F _ → {}
+        }
+    } {}
+    = . r reads + . r reads 1
+    : !( Vec u ) String rr ( __sst_read_verified r ( _mt_iat . r iboff bi ) ( _mt_iat . r iblen bi ) )
+    ?? rr {
+        T blk → {
+            ?? ( vec_get [( Vec u )] . r cache slot ) {
+                T old → { ( vec_free [u] old ) }
+                F _ → {}
+            }
+            : b _ok ( vec_set [( Vec u )] . r cache slot ( vec_clone [u] blk ) )
+            : b _ok2 ( vec_set [i] . r cache_bi slot bi )
+            ^ @ !( Vec u ) String { T blk }
+        }
+        F e → { ^ @ !( Vec u ) String { F e } }
+    }
+}
+
+// Decode the entry at `pos`; returns the total entry length, or 0 if the
+// block does not hold a whole entry there.
+@ __sst_entry_len ( Vec u ) blk i pos → i {
+    : i n ( vec_len [u] blk )
+    ? > + pos SST_HDR n { ^ 0 } {}
+    : i kl ?? ( bytes_read_u32_le blk pos ) { T x → # i x F _ → 0 }
+    : i vl ?? ( bytes_read_u32_le blk + pos 4 ) { T x → # i x F _ → 0 }
+    : i total + SST_HDR + kl vl
+    ? > + pos total n { ^ 0 } {}
+    ^ total
+}
+
+// ── point lookup ────────────────────────────────────────────────────
+
+// The newest version of `key` with seq <= snap. `found` is 0 when the
+// table has nothing for the key; a tombstone comes back as found=1 with
+// kind=MT_DEL, which the store must honour as "deleted here, stop".
+@ sst_get * SstReader r ( Vec u ) key i snap → !SstHit String {
+    : i klen ( vec_len [u] key )
+    : *u kp ( vec_data [u] key )
+    ? ( __bloom_test . r bloom . r nbits ( lsm_key_hash kp 0 klen ) ) {} {
+        = . r filtered + . r filtered 1
+        ^ @ !SstHit String { T @ SstHit { 0 MT_PUT 0 ( vec_new [u] ) } }
+    }
+    : ~ i bi ( __sst_find_block r kp klen )
+    : ~ b scanning T
+    ~ & scanning < bi . r nblocks {
+        : !( Vec u ) String br ( __sst_load_block r bi )
+        ?? br {
+            T blk → {
+                : i n ( vec_len [u] blk )
+                : ~ i pos 0
+                : ~ b past F
+                ~ & ! past < pos n {
+                    : i total ( __sst_entry_len blk pos )
+                    ? == total 0 { = past T } {
+                        : i kl ?? ( bytes_read_u32_le blk pos ) { T x → # i x F _ → 0 }
+                        : i vl ?? ( bytes_read_u32_le blk + pos 4 ) { T x → # i x F _ → 0 }
+                        : i seq ?? ( bytes_read_u64_le blk + pos 8 ) { T x → # i x F _ → 0 }
+                        : i kind ?? ( vec_get [u] blk + pos 16 ) { T x → # i x F _ → 0 }
+                        : i koff + pos SST_HDR
+                        : i c ( lsm_bytes_cmp_raw ( vec_data [u] blk ) koff kl kp 0 klen )
+                        ? > c 0 {
+                            // past the key entirely — no older versions anywhere
+                            = past T = scanning F
+                        } {
+                            ? & == c 0 <= seq snap {
+                                : ( Vec u ) val ( _mt_slice blk + koff kl vl )
+                                ( vec_free [u] blk )
+                                ^ @ !SstHit String { T @ SstHit { 1 kind seq val } }
+                            } {}
+                        }
+                        = pos + pos total
+                    }
+                }
+                ( vec_free [u] blk )
+                // Ran off the end of the block still inside (or before)
+                // the key's run: the older versions continue in the next
+                // block. This is the boundary case the last-key index is
+                // built to make safe.
+                ? scanning { = bi + bi 1 } {}
+            }
+            F e → { ^ @ !SstHit String { F e } }
+        }
+    }
+    ^ @ !SstHit String { T @ SstHit { 0 MT_PUT 0 ( vec_new [u] ) } }
+}
+
+// ── cursor (ordered iteration, one block resident at a time) ────────
+
+: SstCursor {
+    * SstReader r
+    ( Vec u ) blk
+    i bi
+    i pos
+    i valid
+    i kl
+    i vl
+    i seq
+    i kind
+    i koff
+    i failed
+    String err
+}
+
+@ sst_cursor * SstReader r → *SstCursor {
+    : *SstCursor c # *SstCursor ( nurl_alloc Z SstCursor )
+    = . c r r
+    = . c blk ( vec_new [u] )
+    = . c bi 0
+    = . c pos 0
+    = . c valid 0
+    = . c kl 0
+    = . c vl 0
+    = . c seq 0
+    = . c kind MT_PUT
+    = . c koff 0
+    = . c failed 0
+    = . c err ( string_new )
+    ^ c
+}
+
+@ sc_free * SstCursor c → v {
+    ( vec_free [u] . c blk )
+    ( string_free . c err )
+    ( nurl_free # s c )
+}
+
+@ sc_valid * SstCursor c → b { ^ == . c valid 1 }
+
+@ sc_failed * SstCursor c → b { ^ == . c failed 1 }
+
+@ sc_err * SstCursor c → s { ^ ( string_data . c err ) }
+
+@ sc_seq * SstCursor c → i { ^ . c seq }
+
+@ sc_kind * SstCursor c → i { ^ . c kind }
+
+@ sc_klen * SstCursor c → i { ^ . c kl }
+
+@ sc_kptr * SstCursor c → *u { ^ ( vec_data [u] . c blk ) }
+
+@ sc_koff * SstCursor c → i { ^ . c koff }
+
+@ sc_key * SstCursor c → ( Vec u ) { ^ ( _mt_slice . c blk . c koff . c kl ) }
+
+@ sc_val * SstCursor c → ( Vec u ) { ^ ( _mt_slice . c blk + . c koff . c kl . c vl ) }
+
+@ __sc_fail * SstCursor c String e → v {
+    = . c failed 1
+    = . c valid 0
+    ( string_free . c err )
+    = . c err e
+}
+
+// Decode the entry the cursor's `pos` points at.
+@ __sc_decode * SstCursor c → b {
+    : i total ( __sst_entry_len . c blk . c pos )
+    ? == total 0 { ^ F } {}
+    = . c kl ?? ( bytes_read_u32_le . c blk . c pos ) { T x → # i x F _ → 0 }
+    = . c vl ?? ( bytes_read_u32_le . c blk + . c pos 4 ) { T x → # i x F _ → 0 }
+    = . c seq ?? ( bytes_read_u64_le . c blk + . c pos 8 ) { T x → # i x F _ → 0 }
+    = . c kind ?? ( vec_get [u] . c blk + . c pos 16 ) { T x → # i x F _ → 0 }
+    = . c koff + . c pos SST_HDR
+    = . c valid 1
+    ^ T
+}
+
+@ __sc_load * SstCursor c i bi → b {
+    : *SstReader rr . c r
+    ? >= bi . rr nblocks { = . c valid 0 ^ F } {}
+    : !( Vec u ) String br ( __sst_load_block . c r bi )
+    ?? br {
+        T blk → {
+            ( vec_free [u] . c blk )
+            = . c blk blk
+            = . c bi bi
+            = . c pos 0
+            ^ ( __sc_decode c )
+        }
+        F e → { ( __sc_fail c e ) ^ F }
+    }
+}
+
+@ sc_first * SstCursor c → v {
+    = . c valid 0
+    : b _ok ( __sc_load c 0 )
+}
+
+@ sc_next * SstCursor c → v {
+    ? == . c valid 1 {} { ^ }
+    = . c pos + . c pos + SST_HDR + . c kl . c vl
+    ? ( __sc_decode c ) {} {
+        : b _ok ( __sc_load c + . c bi 1 )
+    }
+}
+
+// Position at the first entry >= (key, snap).
+@ sc_seek * SstCursor c ( Vec u ) key i snap → v {
+    = . c valid 0
+    : i klen ( vec_len [u] key )
+    : *u kp ( vec_data [u] key )
+    : i bi ( __sst_find_block . c r kp klen )
+    ? ( __sc_load c bi ) {} { ^ }
+    : ~ b searching T
+    ~ searching {
+        ? == . c valid 1 {} { = searching F }
+        ? searching {
+            : i cc ( lsm_bytes_cmp_raw ( vec_data [u] . c blk ) . c koff . c kl kp 0 klen )
+            ? | > cc 0 & == cc 0 <= . c seq snap { = searching F } { ( sc_next c ) }
+        } {}
+    }
+}

--- a/packages/lsmdb/src/wal.nu
+++ b/packages/lsmdb/src/wal.nu
@@ -1,0 +1,193 @@
+// packages/lsmdb/src/wal.nu — the write-ahead log.
+//
+// The memtable lives in RAM, so between a write being acknowledged and
+// the next flush there is nothing on disk that remembers it. The log is
+// that memory: every write is appended here and fsynced BEFORE the
+// memtable is touched, so a database that is killed — kill -9, power
+// loss, a full disk mid-write — comes back holding exactly the writes it
+// said yes to.
+//
+// Record framing:
+//   [u32 crc32(payload)][u32 payload_len][payload]
+//   payload = [u64 seq][u8 kind][u32 klen][key][u32 vlen][value]
+//
+// The checksum is what makes the tail case safe. A crash in the middle
+// of an append leaves a short or half-written record, and replay MUST
+// treat that as "this write never happened" rather than as corruption of
+// the whole log or, worse, as a record with a garbage length. Replay
+// therefore stops at the first record that is short, over-long or fails
+// its CRC, keeps everything before it, and reports the truncation.
+//
+//   ( wal_open path )                  → !*Wal String     append mode
+//   ( wal_append w key val seq kind )  → !v String
+//   ( wal_sync w )                     → !v String        durability point
+//   ( wal_bytes w )                    → i
+//   ( wal_close w )                    → v
+//   ( wal_replay path m )              → !WalStat String  → memtable
+//   ( wal_reset path )                 → !v String        truncate to empty
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/path.nu`
+$ `stdlib/std/deflate.nu`
+$ `memtable.nu`
+
+: Wal {
+    File f
+    ( Vec u ) buf
+    i bytes
+    Crc32 crc
+}
+
+: WalStat {
+    i records
+    i maxseq
+    i truncated  // 1 if a torn tail was dropped
+    i bytes
+}
+
+@ wal_open s path → !*Wal String {
+    : !File IoErr fr ( file_append path )
+    ?? fr {
+        T f → {
+            : *Wal w # *Wal ( nurl_alloc Z Wal )
+            = . w f f
+            = . w buf ( vec_with_cap [u] 256 )
+            = . w bytes ?? ( file_size path ) { T n → n F _ → 0 }
+            = . w crc ( crc32_ctx )
+            ^ @ !*Wal String { T w }
+        }
+        F _ → {
+            : String msg ( string_from `lsmdb: cannot open the write-ahead log ` )
+            ( string_push_str msg path )
+            ^ @ !*Wal String { F msg }
+        }
+    }
+}
+
+@ wal_bytes * Wal w → i { ^ . w bytes }
+
+@ wal_close * Wal w → v {
+    ( crc32_ctx_free . w crc )
+    ( file_close . w f )
+    ( vec_free [u] . w buf )
+    ( nurl_free # s w )
+}
+
+@ wal_append * Wal w ( Vec u ) key ( Vec u ) val i seq i kind → !v String {
+    : i kl ( vec_len [u] key )
+    : i vl ? == kind MT_PUT ( vec_len [u] val ) 0
+    ( vec_clear [u] . w buf )
+    ( bytes_push_u64_le . w buf # u64 seq )
+    ( vec_push [u] . w buf # u kind )
+    ( bytes_push_u32_le . w buf # u32 kl )
+    ( vec_extend [u] . w buf key )
+    ( bytes_push_u32_le . w buf # u32 vl )
+    ? > vl 0 { ( vec_extend [u] . w buf val ) } {}
+
+    : i plen ( vec_len [u] . w buf )
+    : i crc ( crc32_ctx_hash . w crc . w buf )
+    : ( Vec u ) rec ( vec_with_cap [u] + plen 8 )
+    ( bytes_push_u32_le rec # u32 crc )
+    ( bytes_push_u32_le rec # u32 plen )
+    ( vec_extend [u] rec . w buf )
+    : !v IoErr wr ( file_write_chunk . w f rec )
+    ( vec_free [u] rec )
+    ?? wr {
+        T _ → { = . w bytes + . w bytes + plen 8 ^ @ !v String { T 0 } }
+        F _ → { ^ @ !v String { F ( string_from `lsmdb: write-ahead log append failed (disk full?)` ) } }
+    }
+}
+
+// The durability point. Returning from here means the OS has the bytes
+// on the device — everything appended so far survives a power cut.
+@ wal_sync * Wal w → !v String {
+    ?? ( file_sync . w f ) {
+        T _ → { ^ @ !v String { T 0 } }
+        F _ → { ^ @ !v String { F ( string_from `lsmdb: cannot fsync the write-ahead log` ) } }
+    }
+}
+
+// Cut the log back to `len` bytes — the end of the last intact record.
+//
+// Recovery MUST do this before appending again. A torn tail left in
+// place is not merely untidy: replay stops there, so every write made
+// after the crash would land behind bytes that the next replay refuses
+// to walk past, and would be silently invisible from then on.
+@ wal_truncate s path i len → !v String {
+    ?? ( file_truncate path len ) {
+        T _ → {
+            : String parent ( path_dirname path )
+            ?? ( dir_sync ( string_data parent ) ) { T _ → {} F _ → {} }
+            ( string_free parent )
+            ^ @ !v String { T 0 }
+        }
+        F _ → { ^ @ !v String { F ( string_from `lsmdb: cannot truncate the torn tail of the write-ahead log` ) } }
+    }
+}
+
+@ wal_reset s path → !v String {
+    ?? ( file_create path ) {
+        T f → {
+            ?? ( file_sync f ) { T _ → {} F _ → {} }
+            ( file_close f )
+            ^ @ !v String { T 0 }
+        }
+        F _ → { ^ @ !v String { F ( string_from `lsmdb: cannot truncate the write-ahead log` ) } }
+    }
+}
+
+// Replay every intact record into `m`. A missing log is an empty one —
+// a database that has never been written to is not an error.
+@ wal_replay s path * MemTable m → !WalStat String {
+    ? ( file_exists path ) {} {
+        ^ @ !WalStat String { T @ WalStat { 0 0 0 0 } }
+    }
+    : !( Vec u ) IoErr rr ( read_file_bytes path )
+    : ~ ( Vec u ) data ( vec_new [u] )
+    ?? rr { T v → { ( vec_free [u] data ) = data v } F _ → {
+            ^ @ !WalStat String { F ( string_from `lsmdb: cannot read the write-ahead log` ) } } }
+
+    : i n ( vec_len [u] data )
+    : ~ i pos 0
+    : ~ i records 0
+    : ~ i maxseq 0
+    : ~ i truncated 0
+    : ~ b going T
+    ~ & going < pos n {
+        ? > + pos 8 n { = truncated 1 = going F } {
+            : i crc ?? ( bytes_read_u32_le data pos ) { T x → # i x F _ → 0 }
+            : i plen ?? ( bytes_read_u32_le data + pos 4 ) { T x → # i x F _ → 0 }
+            ? | < plen 13 > + pos + 8 plen n { = truncated 1 = going F } {
+                : ( Vec u ) payload ( _mt_slice data + pos 8 plen )
+                ? != ( crc32 payload ) crc {
+                    // A half-written record at the tail: the write was
+                    // never acknowledged, so dropping it is exactly right.
+                    = truncated 1 = going F
+                } {
+                    : i seq ?? ( bytes_read_u64_le payload 0 ) { T x → # i x F _ → 0 }
+                    : i kind ?? ( vec_get [u] payload 8 ) { T x → # i x F _ → 0 }
+                    : i kl ?? ( bytes_read_u32_le payload 9 ) { T x → # i x F _ → 0 }
+                    ? > + 13 kl plen { = truncated 1 = going F } {
+                        : i vl ?? ( bytes_read_u32_le payload + 13 kl ) { T x → # i x F _ → 0 }
+                        ? > + + 17 kl vl plen { = truncated 1 = going F } {
+                            : ( Vec u ) key ( _mt_slice payload 13 kl )
+                            : ( Vec u ) val ( _mt_slice payload + 17 kl vl )
+                            ( mt_put m key val seq kind )
+                            ( vec_free [u] key )
+                            ( vec_free [u] val )
+                            = records + records 1
+                            ? > seq maxseq { = maxseq seq } {}
+                            = pos + pos + 8 plen
+                        }
+                    }
+                }
+                ( vec_free [u] payload )
+            }
+        }
+    }
+    ( vec_free [u] data )
+    ^ @ !WalStat String { T @ WalStat { records maxseq truncated pos } }
+}

--- a/packages/lsmdb/tests/lsmdb_test.sh
+++ b/packages/lsmdb/tests/lsmdb_test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tests/lsmdb_test.sh — end-to-end test of the lsmdb CLI.
+#
+#  Every command is a separate process, so persistence and reopen are
+#  exercised by construction: if a write did not reach disk, the NEXT
+#  assertion in this file fails.
+#
+#    1. put / get round-trip, including binary-ish and empty values
+#    2. overwrite wins; delete really deletes (and stays deleted after a
+#       flush, i.e. the tombstone shadows the older table)
+#    3. ordered scans: full, range, limit
+#    4. flush → the same answers come out of an SSTable instead of RAM
+#    5. bulk load from stdin
+#    6. snapshot reads: --at N sees the database as it was after write N
+#    7. compaction keeps every live key, drops the dead ones, and leaves
+#       exactly one table behind
+#    8. THE POINT, part 1 — crash safety: truncating the log mid-record
+#       (what kill -9 during an append leaves) loses only the torn write;
+#       everything acknowledged before it is still there
+#    9. THE POINT, part 2 — corruption is an error, never data: flipping
+#       one byte inside a table makes reads FAIL loudly instead of
+#       returning something wrong
+#
+#  Run from the package dir:  ./tests/lsmdb_test.sh
+#  Env: NURL (build driver; defaults to ../../nurl.sh in a checkout)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t lsmdb-test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+eq()  { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (got '$2', want '$3')"; fi; }
+
+echo "[1/3] build lsmdb"
+if ! $NURL src/main.nu "$WORK/lsmdb" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build lsmdb:"; tail -20 "$WORK/build.err"; exit 1
+fi
+DB="$WORK/db"
+L() { "$WORK/lsmdb" -d "$DB" "$@"; }
+
+echo "[2/3] behaviour"
+
+# ── 1. put / get ────────────────────────────────────────────────────
+L put alpha "first value" || bad "put alpha"
+L put beta  "second"      || bad "put beta"
+L put gamma ""            || bad "put gamma (empty value)"
+eq "get returns the value"        "$(L get alpha)" "first value"
+eq "get returns an empty value"   "$(L get gamma)" ""
+L get nosuchkey >/dev/null 2>&1 && bad "absent key reported as found" || ok "absent key exits 1"
+
+# Values with spaces, tabs, quotes, UTF-8 and a newline survive.
+printf 'weird\tvalue "with" ⚡ bytes' > "$WORK/weird.txt"
+L put weird "$(cat "$WORK/weird.txt")" || bad "put weird"
+L get weird -r > "$WORK/weird.out"
+cmp -s "$WORK/weird.txt" "$WORK/weird.out" && ok "binary-ish value round-trips byte for byte" || bad "weird value round-trip"
+
+# ── 2. overwrite + delete ───────────────────────────────────────────
+L put alpha "second value"
+eq "overwrite wins" "$(L get alpha)" "second value"
+L del beta
+L get beta >/dev/null 2>&1 && bad "deleted key still readable" || ok "delete removes the key"
+
+# ── 3. scans ────────────────────────────────────────────────────────
+for k in s01 s02 s03 s04 s05; do L put "$k" "v-$k"; done
+eq "scan is ordered"       "$(L scan --from s01 --to s99 | cut -f1 | tr '\n' ' ')" "s01 s02 s03 s04 s05 "
+eq "scan honours --limit"  "$(L scan --from s01 --limit 2 | cut -f1 | tr '\n' ' ')" "s01 s02 "
+eq "scan range is half-open" "$(L scan --from s02 --to s04 | cut -f1 | tr '\n' ' ')" "s02 s03 "
+eq "scan carries values"   "$(L scan --from s03 --limit 1)" "$(printf 's03\tv-s03')"
+
+# ── 4. flush: the same answers, now from a table ────────────────────
+BEFORE="$(L scan)"
+L flush >/dev/null || bad "flush"
+[ "$(ls "$DB"/*.sst 2>/dev/null | wc -l)" -ge 1 ] && ok "flush wrote a table" || bad "no table after flush"
+eq "flushed data reads back identically" "$(L scan)" "$BEFORE"
+eq "get works from a table"              "$(L get alpha)" "second value"
+L get beta >/dev/null 2>&1 && bad "tombstone lost across flush" || ok "tombstone survives the flush"
+
+# ── 5. bulk load ────────────────────────────────────────────────────
+printf 'l1\tone\nl2\ttwo\nl3\tthree\n' | L load >/dev/null || bad "load"
+eq "bulk load stored every row" "$(L scan --from l1 --to l9 | wc -l | tr -d ' ')" "3"
+eq "bulk loaded value"          "$(L get l2)" "two"
+
+# ── 6. snapshot reads ───────────────────────────────────────────────
+L put snap v1
+SEQ1="$(L stats | awk '/^sequence/{print $2}')"
+L put snap v2
+eq "current read sees the new value" "$(L get snap)" "v2"
+eq "snapshot read sees the old one"  "$(L get snap --at "$SEQ1")" "v1"
+eq "snapshot scan sees the old one"  "$(L scan --from snap --to snapz --at "$SEQ1")" "$(printf 'snap\tv1')"
+
+# ── 7. compaction ───────────────────────────────────────────────────
+L flush >/dev/null
+BEFORE="$(L scan)"
+L compact >/dev/null || bad "compact"
+eq "compaction keeps exactly the live data" "$(L scan)" "$BEFORE"
+eq "compaction leaves one table"            "$(ls "$DB"/*.sst | wc -l | tr -d ' ')" "1"
+L get beta >/dev/null 2>&1 && bad "deleted key resurrected by compaction" || ok "deleted key stays deleted"
+
+# ── 8. crash safety: a torn log tail ────────────────────────────────
+CRASH="$WORK/crash"
+C() { "$WORK/lsmdb" -d "$CRASH" "$@"; }
+C put k1 alive1 && C put k2 alive2 && C put k3 alive3 || bad "crash-setup writes"
+# Simulate kill -9 in the middle of the NEXT append: add a half record.
+printf '\xde\xad\xbe\xef\x40\x00\x00\x00partial' >> "$CRASH/WAL"
+eq "committed writes survive a torn tail (1)" "$(C get k1)" "alive1"
+eq "committed writes survive a torn tail (3)" "$(C get k3)" "alive3"
+C put k4 alive4 || bad "database still writable after recovery"
+eq "database keeps working after recovery"    "$(C get k4)" "alive4"
+eq "the torn record did not become a key"     "$(C scan | wc -l | tr -d ' ')" "4"
+
+# A log truncated mid-record (the other half of the same crash) is the
+# same story: the partial write is dropped, the rest is kept.
+C flush >/dev/null
+C put k5 alive5
+SZ=$(wc -c < "$CRASH/WAL")
+dd if="$CRASH/WAL" of="$CRASH/WAL.cut" bs=1 count=$((SZ - 3)) 2>/dev/null
+mv "$CRASH/WAL.cut" "$CRASH/WAL"
+C get k5 >/dev/null 2>&1 && bad "a truncated write was applied anyway" || ok "a truncated write is dropped"
+eq "everything before it is intact" "$(C get k1)" "alive1"
+
+# ── 9. corruption is an error, never data ───────────────────────────
+ROT="$WORK/rot"
+R() { "$WORK/lsmdb" -d "$ROT" "$@"; }
+for k in r1 r2 r3 r4 r5; do R put "$k" "value-of-$k"; done
+R flush >/dev/null
+SST=$(ls "$ROT"/*.sst | head -1)
+printf 'X' | dd of="$SST" bs=1 seek=5 conv=notrunc 2>/dev/null
+if R scan >/dev/null 2>&1; then bad "corrupt table read as if it were fine"; else ok "corrupt block fails the read"; fi
+R scan 2>&1 | grep -qi "checksum" && ok "the error names the checksum" || bad "unhelpful corruption error"
+
+echo "[3/3] done"
+echo "== lsmdb tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" = 0 ]

--- a/packages/lsmdb/tests/stress_test.sh
+++ b/packages/lsmdb/tests/stress_test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tests/stress_test.sh — the differential test: an lsmdb database and a
+#  plain sorted text file are fed exactly the same writes, and the whole
+#  contents of the database must equal the text file, byte for byte,
+#  after every phase.
+#
+#  It is the shape that finds real bugs, because it does not check a
+#  property someone thought of — it checks EVERYTHING at once:
+#  ordering, versioning, tombstones, block boundaries, the index binary
+#  search, the Bloom filter, the merge across N tables, and compaction.
+#
+#  Phases: 4 loads with a flush after each (so reads must merge four
+#  tables plus the memtable) → delete a seventh of the keys → overwrite
+#  another seventh → compact → reopen. The oracle is recomputed with
+#  sort/awk at every step.
+#
+#  Run from the package dir:  ./tests/stress_test.sh [rows_per_chunk]
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(cd ../.. && pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh"; export NURL_STDLIB="${NURL_STDLIB:-$REPO_ROOT}";
+else NURL="nurl"; fi
+
+N="${1:-5000}"
+WORK="$(mktemp -d -t lsmdb-stress.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { echo "  PASS $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+
+echo "[1/3] build"
+if ! $NURL src/main.nu "$WORK/lsmdb" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build lsmdb:"; tail -20 "$WORK/build.err"; exit 1
+fi
+DB="$WORK/db"
+L() { "$WORK/lsmdb" -d "$DB" "$@"; }
+
+# The oracle: model.tsv holds the current key<TAB>value of every live
+# key. `expect` sorts it the way the database orders keys (bytewise) and
+# diffs it against a full scan.
+MODEL="$WORK/model.tsv"
+: > "$MODEL"
+expect() {
+    LC_ALL=C sort -u -k1,1 "$MODEL" > "$WORK/want.tsv"
+    L scan > "$WORK/got.tsv" || { bad "$1 (scan failed)"; return; }
+    if diff -q "$WORK/want.tsv" "$WORK/got.tsv" >/dev/null; then
+        ok "$1 ($(wc -l < "$WORK/got.tsv" | tr -d ' ') keys)"
+    else
+        bad "$1"
+        echo "    first differences:"; diff "$WORK/want.tsv" "$WORK/got.tsv" | head -6 | sed 's/^/    /'
+    fi
+}
+
+# Values are long enough that a few thousand rows span many 4 KiB blocks,
+# and vary in length so entries do not align to a convenient boundary.
+gen() {  # gen <start> <count> <tag>
+    awk -v s="$1" -v n="$2" -v tag="$3" 'BEGIN{
+        for (i = s; i < s + n; i++) {
+            pad = ""
+            for (j = 0; j < (i % 37); j++) pad = pad "x"
+            printf "key:%08d\tval-%s-%d-%s\n", i, tag, i, pad
+        }
+    }'
+}
+
+echo "[2/3] phases"
+
+# ── four chunks, a flush after each → four tables ───────────────────
+for c in 0 1 2 3; do
+    gen $((c * N)) "$N" "c$c" > "$WORK/chunk.tsv"
+    L load < "$WORK/chunk.tsv" >/dev/null || bad "load chunk $c"
+    cat "$WORK/chunk.tsv" >> "$MODEL"
+    L flush >/dev/null || bad "flush $c"
+done
+TABLES=$(ls "$DB"/*.sst | wc -l | tr -d ' ')
+[ "$TABLES" = 4 ] && ok "four tables on disk" || bad "expected 4 tables, got $TABLES"
+expect "merged scan over 4 tables matches the model"
+
+# ── point reads: every key, from whichever table holds it ───────────
+MISS=0
+while IFS=$'\t' read -r k v; do
+    got=$(L get "$k") || { MISS=$((MISS+1)); continue; }
+    [ "$got" = "$v" ] || MISS=$((MISS+1))
+done < <(LC_ALL=C sort -u -k1,1 "$MODEL" | awk 'NR % 97 == 1')
+[ "$MISS" = 0 ] && ok "sampled point reads all agree" || bad "$MISS sampled point reads disagreed"
+
+# ── absent keys must be absent (Bloom filter + index path) ──────────
+GHOST=0
+for i in 1 2 3 4 5 6 7 8; do
+    L get "nope:$i" >/dev/null 2>&1 && GHOST=$((GHOST+1))
+done
+[ "$GHOST" = 0 ] && ok "absent keys stay absent" || bad "$GHOST absent keys came back"
+
+# ── delete a seventh of the keys ────────────────────────────────────
+LC_ALL=C sort -u -k1,1 "$MODEL" | awk 'NR % 7 == 0 {print $1}' > "$WORK/dead.txt"
+while read -r k; do L del "$k"; done < "$WORK/dead.txt"
+grep -vFf <(sed 's/$/\t/' "$WORK/dead.txt") "$MODEL" > "$WORK/model2" || true
+awk 'NR==FNR{d[$1]=1;next} !($1 in d)' "$WORK/dead.txt" "$MODEL" > "$WORK/model2"
+mv "$WORK/model2" "$MODEL"
+expect "deletes are reflected in the merged view"
+
+# ── overwrite another seventh ───────────────────────────────────────
+LC_ALL=C sort -u -k1,1 "$MODEL" | awk 'NR % 7 == 3 {print $1"\tREWRITTEN-"NR}' > "$WORK/over.tsv"
+L load < "$WORK/over.tsv" >/dev/null || bad "overwrite load"
+awk 'NR==FNR{o[$1]=$2;next} {if ($1 in o) print $1"\t"o[$1]; else print}' \
+    "$WORK/over.tsv" "$MODEL" > "$WORK/model2"
+mv "$WORK/model2" "$MODEL"
+expect "overwrites shadow the older tables"
+
+# ── flush, reopen, compact ──────────────────────────────────────────
+L flush >/dev/null
+expect "after a flush of the deletes and overwrites"
+
+KEPT=$(L compact | awk '{print $1}')
+[ "$(ls "$DB"/*.sst | wc -l | tr -d ' ')" = 1 ] && ok "compaction left one table" || bad "compaction table count"
+[ "$KEPT" = "$(wc -l < "$MODEL" | tr -d ' ')" ] && ok "compaction kept exactly the live keys ($KEPT)" \
+    || bad "compaction kept $KEPT, model has $(wc -l < "$MODEL" | tr -d ' ')"
+expect "after compaction"
+
+# ── the deleted keys must not come back ─────────────────────────────
+BACK=0
+while read -r k; do L get "$k" >/dev/null 2>&1 && BACK=$((BACK+1)); done < "$WORK/dead.txt"
+[ "$BACK" = 0 ] && ok "no deleted key resurrected" || bad "$BACK deleted keys came back"
+
+# ── ranges land on the right boundaries ─────────────────────────────
+FROM=$(awk 'NR==1{print $1}' "$WORK/want.tsv")
+MID=$(awk 'NR==int(FNR/2)+1{print $1; exit}' "$WORK/want.tsv")
+L scan --from "$MID" > "$WORK/tail.tsv"
+awk -v m="$MID" '$1 >= m' "$WORK/want.tsv" > "$WORK/tailwant.tsv"
+diff -q "$WORK/tailwant.tsv" "$WORK/tail.tsv" >/dev/null && ok "range scan from a mid key" || bad "range scan boundary"
+[ "$(L scan --from "$FROM" --limit 3 | wc -l | tr -d ' ')" = 3 ] && ok "limit applies" || bad "limit"
+
+echo "[3/3] done"
+echo "== lsmdb stress: PASS=$PASS FAIL=$FAIL  (rows/chunk=$N)"
+[ "$FAIL" = 0 ]

--- a/stdlib/core/io.nu
+++ b/stdlib/core/io.nu
@@ -167,6 +167,24 @@ $ `stdlib/core/posix.nu`  // read(2) for the pure-NURL stdin slurp
     ^ != 0 ( nurl_stdin_eof )
 }
 
+// ── Binary stdout ───────────────────────────────────────────────────
+//
+// The write-side dual of read_n_bytes. Every print in the language takes
+// a NUL-terminated string, so a program holding arbitrary bytes — a value
+// read out of a database, a decoded image, a response body being
+// proxied — could not emit them: output stopped at the first zero byte,
+// silently. write_bytes writes the buffer exactly, NULs and all.
+//
+// It shares stdout's stdio buffer and tty-flush rule with the ordinary
+// prints, so mixing the two never reorders output (unlike a raw write(2)
+// on fd 1, which would need an explicit ( flush ) first).
+& `c` @ nurl_print_bytes s p i n → v
+
+@ write_bytes ( Vec u ) v → v {
+    : i n ( vec_len [u] v )
+    ? > n 0 { ( nurl_print_bytes # s ( vec_data [u] v ) n ) } {}
+}
+
 @ flush → v {
     ( nurl_flush_stdout )
 }

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -1621,11 +1621,18 @@ long long nurl_file_truncate(const char *path, long long len) {
     if (!path || len < 0) return -1;
 #ifdef _WIN32
     {
-        int fd = _open(path, _O_RDWR | _O_BINARY);
-        if (fd < 0) return -1;
-        int rc = _chsize_s(fd, (__int64)len);
-        _close(fd);
-        return rc == 0 ? 0 : -1;
+        /* Win32 rather than the CRT's _chsize_s: this file is built for
+         * both the MSVC and the MinGW runtime, and the CRT spelling of
+         * truncation differs between them. SetEndOfFile does not. */
+        HANDLE h = CreateFileA(path, GENERIC_WRITE,
+                               FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+                               OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        if (h == INVALID_HANDLE_VALUE) return -1;
+        LARGE_INTEGER li;
+        li.QuadPart = (LONGLONG)len;
+        int ok = SetFilePointerEx(h, li, NULL, FILE_BEGIN) && SetEndOfFile(h);
+        CloseHandle(h);
+        return ok ? 0 : -1;
     }
 #elif defined(__wasi__)
     (void)len;

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -530,6 +530,28 @@ void nurl_print(const char *s) {
         if (g_stdout_tty) fflush(stdout);
     }
 }
+/* Write `n` raw bytes to stdout — NUL bytes included.
+ *
+ * nurl_print takes a NUL-terminated string, so a program holding binary
+ * data (a value read out of a database, a decoded image, a response body
+ * being proxied) had no way to emit it: everything from the first zero
+ * byte was silently dropped, and stdin's side of that already had
+ * read_n_bytes. Routed through the same capture buffer and tty-flush
+ * rule as nurl_print, so ordering and output capture are identical. */
+void nurl_print_bytes(const char *p, long long n) {
+    if (!p || n <= 0) return;
+    if (g_outbuf_mode) {
+        outbuf_reserve((size_t)n);
+        memcpy(g_outbuf + g_outbuf_len, p, (size_t)n);
+        g_outbuf_len += (size_t)n;
+        g_outbuf[g_outbuf_len] = '\0';
+    } else {
+        if (g_stdout_tty < 0) g_stdout_tty = nurl_stdout_isatty() ? 1 : 0;
+        fwrite(p, 1, (size_t)n, stdout);
+        if (g_stdout_tty) fflush(stdout);
+    }
+}
+
 /* Print with a trailing newline. Routed through nurl_print so the
  * output-capture buffer (nurl_print_buf_*) sees it too. */
 void nurl_println(const char *s)  { nurl_print(s); nurl_print("\n"); }
@@ -1562,6 +1584,75 @@ long long nurl_path_type_follow(const char *path) {
     if (S_ISDIR(st.st_mode)) return 2;
     if (S_ISREG(st.st_mode)) return 1;
     return 4;
+}
+
+/* Force a file's bytes out of the kernel's page cache onto the storage
+ * device. fflush() only pushes libc's userspace buffer into the kernel —
+ * a crash between that and writeback still loses the data, which is
+ * exactly the difference between "written" and "durable" for anything
+ * keeping a write-ahead log. Returns 0 on success, -1 on failure.
+ *
+ * macOS note: fsync(2) there hands the data to the drive but does not
+ * force the drive's own cache (F_FULLFSYNC does). That matches what
+ * every mainstream database ships by default, and is what "durable
+ * against process crash and OS crash" means here. */
+long long nurl_file_sync(void *h) {
+    if (!h) return -1;
+    FILE *f = (FILE *)h;
+    if (fflush(f) != 0) return -1;
+#ifdef _WIN32
+    return _commit(_fileno(f)) == 0 ? 0 : -1;
+#elif defined(__wasi__)
+    return 0;   /* no durability barrier to reach for */
+#else
+    return fsync(fileno(f)) == 0 ? 0 : -1;
+#endif
+}
+
+/* Cut a file down to `len` bytes (or extend it with zeros). Returns 0 on
+ * success, -1 on failure.
+ *
+ * The operation an append-only log cannot do without: after a crash,
+ * recovery keeps the records up to the last intact one and has to make
+ * the file END there. Rewriting the good prefix would work for a small
+ * log and not at all for a large one, and leaving the torn bytes in
+ * place makes every later append unreachable behind them. */
+long long nurl_file_truncate(const char *path, long long len) {
+    if (!path || len < 0) return -1;
+#ifdef _WIN32
+    {
+        int fd = _open(path, _O_RDWR | _O_BINARY);
+        if (fd < 0) return -1;
+        int rc = _chsize_s(fd, (__int64)len);
+        _close(fd);
+        return rc == 0 ? 0 : -1;
+    }
+#elif defined(__wasi__)
+    (void)len;
+    return -1;
+#else
+    return truncate(path, (off_t)len) == 0 ? 0 : -1;
+#endif
+}
+
+/* fsync a DIRECTORY — what makes a rename durable. A file's bytes and
+ * the directory entry naming them are two separate writes, so syncing
+ * the file alone can leave a crash-recovered tree where the data is on
+ * disk and the name that reaches it is not. Anything that publishes by
+ * rename (a manifest, an atomically-replaced config) needs this after
+ * the rename. Returns 0 on success, -1 on failure. */
+long long nurl_dir_sync(const char *path) {
+#if defined(_WIN32) || defined(__wasi__)
+    (void)path;
+    return 0;   /* no directory handle to sync through the CRT */
+#else
+    if (!path) return -1;
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) return -1;
+    int rc = fsync(fd);
+    close(fd);
+    return rc == 0 ? 0 : -1;
+#endif
 }
 
 /* ── §9  Memory allocation ─────────────────────────────────────── */

--- a/stdlib/std/deflate.nu
+++ b/stdlib/std/deflate.nu
@@ -39,29 +39,121 @@ $ `stdlib/std/bytes.nu`
 
 // ── checksums ───────────────────────────────────────────────────────
 
-// CRC-32 (IEEE, reflected, poly 0xEDB88320) computed bytewise without a
-// precomputed table (small + dependency-free; the inner 8-iter loop is
-// fine for the tarball / gzip sizes this serves).
+// Sarwate's byte table: entry b is the CRC of the single byte b, which
+// is exactly the 8-iteration inner loop run once per possible byte. 256
+// entries × 8 shifts = 2048 steps to build, after which a byte costs one
+// lookup instead of eight shift-mask-xor rounds.
+@ __crc32_table → ( Vec i ) {
+    : ( Vec i ) t ( vec_with_cap [i] 256 )
+    : b _l ( vec_set_len [i] t 256 )
+    : *i tp ( vec_data [i] t )
+    : ~ i b 0
+    ~ < b 256 {
+        : ~ i c b
+        : ~ i k 0
+        ~ < k 8 {
+            : i mask - 0 & c 1  // -(c & 1) → all-ones when low bit set
+            = c ^^ >> c 1 & 3988292384 mask  // 0xEDB88320
+            = k + k 1
+        }
+        = . tp b c
+        = b + b 1
+    }
+    ^ t
+}
+
+// CRC-32 (IEEE, reflected, poly 0xEDB88320).
+//
+// Two implementations of the same function, chosen by input size. The
+// bitwise loop runs eight shift-mask-xor rounds per byte and needs no
+// setup; the table-driven loop costs 2048 steps to build its table and
+// then one lookup per byte. They break even around 300 bytes, so
+// anything from 512 up takes the table — and that is where the callers
+// that matter live: a gzip member, a tar payload, a PNG chunk, a
+// database block. Measured on a 4 KiB block, the table is 7.8x faster
+// (2048 + 4096 steps against 32768), and it took an LSM store's point
+// reads — 66 % of their cycles were inside this function — down with it.
+//
+// The small path is kept rather than always building the table because a
+// short input (a gzip header, a 4-byte trailer) would otherwise pay
+// 2048 steps to checksum 8 bytes. Both paths are the same algorithm and
+// produce identical output for every input; std/deflate's own tests and
+// tools/crc32_gate.sh check that against an independent implementation.
 @ crc32_update i crc0 ( Vec u ) data → i {
     : ~ i crc ^^ crc0 4294967295  // crc ^ 0xFFFFFFFF
     : i n ( vec_len [u] data )
     : *u d ( vec_data [u] data )
-    : ~ i i 0
-    ~ < i n {
-        = crc ^^ crc # i . d i
-        : ~ i k 0
-        ~ < k 8 {
-            : i mask - 0 & crc 1  // -(crc & 1) → all-ones when low bit set
-            = crc ^^ >> crc 1 & 3988292384 mask  // 0xEDB88320
-            = k + k 1
+    ? < n 512 {
+        : ~ i i 0
+        ~ < i n {
+            = crc ^^ crc # i . d i
+            : ~ i k 0
+            ~ < k 8 {
+                : i mask - 0 & crc 1  // -(crc & 1) → all-ones when low bit set
+                = crc ^^ >> crc 1 & 3988292384 mask  // 0xEDB88320
+                = k + k 1
+            }
+            = i + i 1
         }
-        = i + i 1
+    } {
+        : ( Vec i ) t ( __crc32_table )
+        : *i tp ( vec_data [i] t )
+        : ~ i i 0
+        ~ < i n {
+            : i idx & 255 ^^ crc # i . d i
+            : i tv . tp idx
+            = crc ^^ tv >> crc 8
+            = i + i 1
+        }
+        ( vec_free [i] t )
     }
     ^ & ^^ crc 4294967295 4294967295  // (crc ^ 0xFFFFFFFF) & 0xFFFFFFFF
 }
 
 @ crc32 ( Vec u ) data → i {
     ^ ( crc32_update 0 data )
+}
+
+// ── reusable CRC-32 context ─────────────────────────────────────────
+//
+// crc32_update above rebuilds its table on every call that is big enough
+// to want one. That is the right trade for a caller that checksums one
+// payload, and the wrong one for a caller that checksums thousands: a
+// database verifying a 4 KiB block per read spends a third of the
+// checksum on building the same 256 entries again.
+//
+// So hold the table: build it once, hand it to every call.
+//
+//   : Crc32 c ( crc32_ctx )
+//   : i sum ( crc32_ctx_hash c block )     // per block, no setup cost
+//   ( crc32_ctx_free c )
+//
+// Same algorithm, same values as crc32 / crc32_update — the context is
+// purely about where the table lives.
+
+: Crc32 { ( Vec i ) tbl }
+
+@ crc32_ctx → Crc32 { ^ @ Crc32 { ( __crc32_table ) } }
+
+@ crc32_ctx_free Crc32 c → v { ( vec_free [i] . c tbl ) }
+
+@ crc32_ctx_update Crc32 c i crc0 ( Vec u ) data → i {
+    : ~ i crc ^^ crc0 4294967295
+    : i n ( vec_len [u] data )
+    : *u d ( vec_data [u] data )
+    : *i tp ( vec_data [i] . c tbl )
+    : ~ i i 0
+    ~ < i n {
+        : i idx & 255 ^^ crc # i . d i
+        : i tv . tp idx
+        = crc ^^ tv >> crc 8
+        = i + i 1
+    }
+    ^ & ^^ crc 4294967295 4294967295
+}
+
+@ crc32_ctx_hash Crc32 c ( Vec u ) data → i {
+    ^ ( crc32_ctx_update c 0 data )
 }
 
 @ adler32 ( Vec u ) data → i {

--- a/stdlib/std/fs.nu
+++ b/stdlib/std/fs.nu
@@ -810,6 +810,50 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
     ^ @ !v IoErr { F ( _io_err_of_kind ( errno_kind ) ) }
 }
 
+// Runtime durability barriers (see nurl_file_sync / nurl_dir_sync in
+// stdlib/runtime_core.c — one shim because the call is fsync(2) on unix
+// and _commit on Windows). Both return 0 on success, -1 on failure.
+& `c` @ nurl_file_sync *v h → i
+
+& `c` @ nurl_dir_sync s path → i
+
+& `c` @ nurl_file_truncate s path i len → i
+
+// Flush AND fsync: return only once the bytes are on the storage device.
+//
+// file_flush pushes libc's buffer into the kernel, which survives the
+// process dying but not the machine dying — the page cache is still
+// volatile. Anything that has to survive power loss in a known state
+// (a write-ahead log before acknowledging a write, a data file before a
+// manifest is allowed to name it) needs this instead. It costs a device
+// round-trip, so it is a deliberate call, not the default on every write.
+@ file_sync File f → !v IoErr {
+    : s hp . f raw
+    ? == 0 # i hp { ^ @ !v IoErr { F @ IoErr { Other } } } {}
+    ? == 0 ( nurl_file_sync # *v hp ) { ^ @ !v IoErr { T 0 } } {}
+    ^ @ !v IoErr { F ( _io_err_of_kind ( errno_kind ) ) }
+}
+
+// Cut `path` down to `len` bytes (or extend it with zeros). The
+// operation an append-only file cannot do without: after a crash,
+// recovery keeps the records up to the last intact one and the file has
+// to END there — otherwise the torn bytes stay at the tail forever and
+// every later append hides behind them. Not available on WASI.
+@ file_truncate s path i len → !v IoErr {
+    ? == 0 ( nurl_file_truncate path len ) { ^ @ !v IoErr { T 0 } } {}
+    ^ @ !v IoErr { F ( _io_err_of_kind ( errno_kind ) ) }
+}
+
+// fsync a directory — what makes a rename durable. A file's contents and
+// the directory entry naming it are separate writes: fsync the file, and
+// a crash can still leave the bytes on disk with no name reaching them.
+// Call this on the parent directory after an atomic publish-by-rename.
+// A no-op on Windows and WASI, which expose no directory handle.
+@ dir_sync s path → !v IoErr {
+    ? == 0 ( nurl_dir_sync path ) { ^ @ !v IoErr { T 0 } } {}
+    ^ @ !v IoErr { F ( _io_err_of_kind ( errno_kind ) ) }
+}
+
 // Seek to `off` relative to `whence`; returns the new ABSOLUTE offset
 // (so `( file_seek f 0 FS_SEEK_END )` doubles as "how big is this").
 @ file_seek File f i off i whence → !i IoErr {

--- a/tools/crc32_gate.nu
+++ b/tools/crc32_gate.nu
@@ -1,0 +1,86 @@
+// tools/crc32_gate.nu — emit CRC-32 values for a deterministic byte
+// sequence so tools/crc32_gate.sh can check them against an independent
+// implementation (python3's zlib.crc32).
+//
+// std/deflate's crc32_update has two code paths — a bitwise loop for
+// short inputs and a table-driven one from 512 bytes up — and they must
+// agree with each other and with the world for every length. So the
+// lengths below deliberately bracket that threshold byte by byte, and
+// the chained cases prove that splitting an input across several
+// crc32_update calls (what a streaming gzip reader does) produces the
+// same answer as one call over the whole thing.
+//
+// Output, one record per line:
+//   one <len> <crc>
+//   chain <len> <split> <crc>
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/deflate.nu`
+
+// A cheap deterministic byte sequence the shell side can reproduce.
+@ __vec_of i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] ? > n 0 n 1 )
+    : ~ i i 0
+    ~ < i n {
+        ( vec_push [u] v # u & 255 + * i 37 11 )
+        = i + i 1
+    }
+    ^ v
+}
+
+@ __emit_one i n → v {
+    : ( Vec u ) v ( __vec_of n )
+    : String out ( string_with_cap 32 )
+    ( string_push_str out `one ` )
+    ( string_push_int out n )
+    ( string_push_char out 32 )
+    ( string_push_int out ( crc32 v ) )
+    ( string_push_char out 10 )
+    ( nurl_print ( string_data out ) )
+    ( string_free out )
+    ( vec_free [u] v )
+}
+
+// crc32_update fed in two pieces must equal crc32 of the whole.
+@ __emit_chain i n i split → v {
+    : ( Vec u ) whole ( __vec_of n )
+    : ( Vec u ) head ( vec_with_cap [u] ? > split 0 split 1 )
+    : ( Vec u ) tail ( vec_with_cap [u] ? > - n split 0 - n split 1 )
+    : ~ i i 0
+    ~ < i n {
+        : i byte ?? ( vec_get [u] whole i ) { T x → # i x F _ → 0 }
+        ? < i split { ( vec_push [u] head # u byte ) } { ( vec_push [u] tail # u byte ) }
+        = i + i 1
+    }
+    : i c ( crc32_update ( crc32_update 0 head ) tail )
+    : String out ( string_with_cap 40 )
+    ( string_push_str out `chain ` )
+    ( string_push_int out n )
+    ( string_push_char out 32 )
+    ( string_push_int out split )
+    ( string_push_char out 32 )
+    ( string_push_int out c )
+    ( string_push_char out 10 )
+    ( nurl_print ( string_data out ) )
+    ( string_free out )
+    ( vec_free [u] whole ) ( vec_free [u] head ) ( vec_free [u] tail )
+}
+
+@ main → i {
+    // Every length from 0 to 600 walks the small path, the threshold and
+    // the table path, including all the block-boundary neighbours.
+    : ~ i n 0
+    ~ <= n 600 { ( __emit_one n ) = n + n 1 }
+    ( __emit_one 1000 )
+    ( __emit_one 4096 )
+    ( __emit_one 65536 )
+
+    ( __emit_chain 600 1 )
+    ( __emit_chain 600 511 )
+    ( __emit_chain 600 512 )
+    ( __emit_chain 1024 512 )
+    ( __emit_chain 4096 3 )
+    ( __emit_chain 65536 32768 )
+    ^ 0
+}

--- a/tools/crc32_gate.sh
+++ b/tools/crc32_gate.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/crc32_gate.sh — prove stdlib/std/deflate.nu's CRC-32 against an
+#  independent implementation (python3's zlib.crc32).
+#
+#  crc32_update has two code paths — bitwise below 512 bytes, table-driven
+#  from 512 up — because the table costs 2048 steps to build and only pays
+#  for itself on real payloads. Two paths mean two chances to be wrong, so
+#  this checks every length across the threshold, plus chained updates (a
+#  streaming reader splitting one payload over several calls).
+#
+#  Usage:  tools/crc32_gate.sh
+#  Env:    NURL (build driver; defaults to ./nurl.sh in a checkout)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh";
+else NURL="nurl"; fi
+
+command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 not available"; exit 0; }
+
+WORK="$(mktemp -d -t crc32-gate.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+if ! $NURL tools/crc32_gate.nu "$WORK/crc32_gate" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build tools/crc32_gate.nu:"; tail -20 "$WORK/build.err"; exit 1
+fi
+
+"$WORK/crc32_gate" > "$WORK/got.txt" || { echo "FAIL: crc32_gate crashed"; exit 1; }
+
+python3 - "$WORK/got.txt" <<'PY'
+import sys, zlib
+
+def seq(n):
+    return bytes(((i * 37 + 11) & 255) for i in range(n))
+
+bad = 0
+checked = 0
+for line in open(sys.argv[1]):
+    parts = line.split()
+    if not parts:
+        continue
+    if parts[0] == "one":
+        n, got = int(parts[1]), int(parts[2])
+        want = zlib.crc32(seq(n)) & 0xFFFFFFFF
+    elif parts[0] == "chain":
+        n, split, got = int(parts[1]), int(parts[2]), int(parts[3])
+        want = zlib.crc32(seq(n)) & 0xFFFFFFFF
+    else:
+        continue
+    checked += 1
+    if got != want:
+        bad += 1
+        if bad <= 10:
+            print(f"  MISMATCH {line.strip()} — want {want}")
+if bad:
+    print(f"== crc32 gate: {bad} of {checked} WRONG")
+    sys.exit(1)
+print(f"== crc32 gate: {checked} values match zlib.crc32")
+PY

--- a/unikernel/boot/nosys.c
+++ b/unikernel/boot/nosys.c
@@ -112,3 +112,18 @@ void nurl_proc_free(long long h)           { (void)h; }
 int mkstemp(char *tmpl)                     { (void)tmpl; return ns_refuse(NS_EROFS); }
 int rename(const char *a, const char *b)    { (void)a; (void)b; return ns_refuse(NS_EROFS); }
 int rmdir(const char *p)                    { (void)p; return ns_refuse(NS_EROFS); }
+
+/* Durability, on a filesystem that is a tar inside the image.
+ *
+ * Both refuse rather than succeed quietly, for the reason the whole file
+ * exists: fsync's contract is "what you wrote is on the device", and a
+ * caller that reaches it here never got to write anything — `open` for
+ * writing was refused first. Answering 0 would tell a write-ahead log
+ * that its records are durable on a machine with nowhere to put them,
+ * which is the one lie this directory refuses to tell. truncate is the
+ * same read-only story as rename and rmdir above.
+ *
+ * A guest that grows a writable device (virtio-blk) implements these
+ * there, and every caller stays put. */
+int fsync(int fd)                           { (void)fd; return ns_refuse(NS_EROFS); }
+int truncate(const char *p, long long len)  { (void)p; (void)len; return ns_refuse(NS_EROFS); }

--- a/unikernel/nolibc/syscall_linux.c
+++ b/unikernel/nolibc/syscall_linux.c
@@ -119,6 +119,8 @@ void nl_exit_group(int code) {
 #define SYS_clock_gettime_ 228
 #define SYS_mprotect_  10
 #define SYS_getrandom_ 318
+#define SYS_fsync_     74
+#define SYS_truncate_  76
 
 long long read(int fd, void *buf, unsigned long n)  { return nl_read(fd, buf, n); }
 long long write(int fd, const void *buf, unsigned long n) { return nl_write(fd, buf, n); }
@@ -147,6 +149,14 @@ int   rename(const char *a, const char *b)          { return (int)nl_ret(nl_sysc
 int   chdir(const char *p)                          { return (int)nl_ret(nl_syscall6(SYS_chdir_, (long)p, 0, 0, 0, 0, 0)); }
 int   chmod(const char *p, int mode)                { return (int)nl_ret(nl_syscall6(SYS_chmod_, (long)p, mode, 0, 0, 0, 0)); }
 int   madvise(void *p, unsigned long len, int adv)  { return (int)nl_ret(nl_syscall6(SYS_madvise_, (long)p, (long)len, adv, 0, 0, 0)); }
+/* The two durability primitives. A freestanding target cannot borrow
+ * them from a host, and they are exactly one syscall each: fsync(2) is
+ * the barrier a write-ahead log needs before it may acknowledge a write,
+ * and truncate(2) is how recovery cuts a torn tail back off. Under the
+ * unikernel both become device work (a virtio-blk flush, a metadata
+ * update) and every caller stays put. */
+int   fsync(int fd)                                 { return (int)nl_ret(nl_syscall6(SYS_fsync_, fd, 0, 0, 0, 0, 0)); }
+int   truncate(const char *p, long long len)        { return (int)nl_ret(nl_syscall6(SYS_truncate_, (long)p, (long)len, 0, 0, 0, 0)); }
 int   mprotect(void *p, unsigned long len, int prot) { return (int)nl_ret(nl_syscall6(SYS_mprotect_, (long)p, (long)len, prot, 0, 0, 0)); }
 /* The kernel's own CSPRNG. runtime_bare.c's nurl_rand_fill is the only
  * caller and it treats any failure as fatal, so nothing here needs a


### PR DESCRIPTION
`packages/lsmdb` is an embedded, crash-safe key/value store in pure NURL —
a real LSM tree, not a file with a hash map in it: a write-ahead log, a
skip-list memtable over a byte arena, immutable SSTables (CRC-32 per
block, Bloom filter, block index, 48-byte footer), ordered range scans,
compaction, and snapshot reads.

```sh
lsmdb put user:42 '{"name":"ada"}'   # fsynced before this returns
lsmdb scan --from user: --limit 20   # ordered, half-open range
lsmdb get user:42 --at 7             # the database as of write #7
lsmdb compact                        # merge tables, reclaim space
```

## What writing it found

Three things the standard library could not do. Each is fixed where it was
missing rather than worked around in the package:

- **There was no fsync — at all.** `file_flush` pushes libc's buffer into
  the kernel, which survives the process dying and not the machine dying,
  so nothing in the tree could promise a write had reached the device.
  `file_sync` is the barrier a write-ahead log needs; `dir_sync` is what
  makes a publish-by-rename durable, because a file's bytes and the
  directory entry naming them are separate writes and syncing only the
  file can leave a recovered tree where the data is on disk and the name
  reaching it is not. One runtime shim behind both (`fsync` / `_commit` /
  no-op on WASI).

- **There was no truncate.** Recovery keeps the records up to the last
  intact one and the file has to END there. This was a live bug in the
  store until a test wrote past a torn tail and could not read it back:
  leave the torn bytes in place and replay stops at them every time, so
  every later append is stranded behind them, silently, forever.

- **Binary could be read from stdin and not written to stdout.** Every
  print takes a NUL-terminated string, so a value out of a database, a
  decoded image or a proxied response body lost everything from its first
  zero byte, with no error anywhere. `write_bytes` emits the buffer
  exactly, sharing stdout's buffer and tty-flush rule with the ordinary
  prints so mixing the two never reorders output.

And one thing that was slow rather than missing: **`std/deflate` computed
CRC-32 bitwise**, eight shift-mask-xor rounds per byte, which a profile
put at **66 % of the cycles of a point read**. It is table-driven from 512
bytes up (the two paths break even near 300, and a gzip header should not
pay 2048 steps of setup), with a reusable `Crc32` context for callers that
checksum thousands of blocks instead of one. 7.8x on a 4 KiB block — and
every gzip, tar and PNG user in the tree gets it.

## Guarantees, and how they are tested

| killed after… | on the next open |
| --- | --- |
| a log append | the write is there |
| a *partial* log append | the torn record is dropped, the log truncated back to it, everything before it kept |
| writing a table, before the manifest | orphan file; its writes are still in the log |
| publishing the manifest, before the log reset | the log replays identical versions at identical sequence numbers — nothing doubles |
| compaction, before the manifest | the old tables are still named and complete |

- `packages/lsmdb/tests/lsmdb_test.sh` — 30 assertions. It appends a half
  record to the log (what `kill -9` mid-append leaves) and flips a byte
  inside a table, and asserts that the first loses exactly one write while
  the second is **refused as an error, never returned as data**. Every CLI
  command runs as its own process, so persistence and reopen are exercised
  by construction.
- `packages/lsmdb/tests/stress_test.sh` — **differential**: the database
  and a plain sorted text file get identical writes across four tables,
  then deletes of a seventh of the keys, overwrites of another seventh,
  and a compaction, and the entire contents are diffed at every step.
  That checks ordering, versioning, tombstones, block boundaries, the
  index search, the Bloom filter and the merge at once, rather than
  whatever properties someone thought to name.
- `compiler/tests/fs_durability.nu` (+ golden) covers `file_sync`,
  `file_truncate`, `dir_sync` and `write_bytes`.
- `tools/crc32_gate.sh` proves 610 CRC values against python3's
  `zlib.crc32` — every length across the threshold, plus chained updates —
  and now runs in CI. The stdlib's gzip output was separately checked
  against the system `gunzip` on 300 KB of random binary.
- Leak-clean under ASan/LSan on every path (`put`/`get`/`del`/`flush`/
  `scan`/`compact`/`load`/`bench`/recovery), with the oracle
  mutation-tested against a deliberate leak so it is not blind.
- `./build.sh` green: full suite plus the bootstrap's byte-identical
  second pass.

## Numbers

50 000 keys, one Linux x86-64 box (`lsmdb bench -n 50000`):

| | ops/s |
| --- | --- |
| durable writes (one fsync each) | ~900 |
| batched writes | ~350 000 |
| point reads after a flush | ~600 000 |
| absent keys (Bloom filter, no disk touched) | ~3 000 000 |

Point reads started at 47 500/s. The CRC fix and then a 32-slot block
cache — whose hits skip the read *and* the checksum, LevelDB's rule — took
them the rest of the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
