### PR TITLE
ML-DSA (FIPS 204), and post-quantum key exchange on the server side too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`std/mldsa`: ML-DSA (FIPS 204) in pure NURL** — the post-quantum
+  signature, at all three parameter sets, alongside the KEM that landed
+  with X25519MLKEM768. The complete 256-point NTT over Z_8380417 (unlike
+  ML-KEM's, this modulus admits a 512th root of unity, so the transform
+  runs all eight layers and multiplication is an ordinary pointwise
+  product), Montgomery and Barrett reduction in `i32`, rejection
+  sampling of the public matrix and of the noise, `Power2Round` and
+  `Decompose`, hint generation and its packing, and the 3/4/6/10/13/18/
+  20-bit encodings. The pure external interface with FIPS 204 §5.2
+  context strings, plus the external-mu interface; HashML-DSA
+  (`preHash`) is not implemented.
+
+  Signing is **hedged by default** — 32 fresh random bytes into the
+  per-signature nonce, so a repeated message does not produce a repeated
+  signature and a fault does not expose the key the way deterministic
+  signing can. `mldsa_sign_deterministic` remains for interoperability.
+
+  `tools/mldsa_acvp_gate.sh` runs all 480 published ACVP cases: 75
+  keyGen, 270 sigGen (deterministic and hedged, internal and external,
+  and external-mu) and 135 sigVer.
+
+- **The hint-canonicality rules the published vectors do not reach.**
+  A signature's hint has three encoding rules, and violating them is not
+  a corrupted signature but a *second valid encoding of a genuine one* —
+  signature malleability. Deleting each check and re-running all 480
+  NIST cases shows how little they are covered: the
+  strictly-increasing-indices rule fails 1 of 135 sigVer cases, and the
+  trailing-zero rule and the totals bound fail none at all. The reason
+  is that corrupting a hint changes the bits it decodes to, so `c~`
+  stops matching and the signature is refused regardless. So
+  `compiler/tests/mldsa_vectors.nu` constructs re-encodings that decode
+  to *identical* hint bits — the first index duplicated with every
+  running total bumped, and a non-zero byte in the unread tail — and
+  requires both to be rejected. With either check deleted, they fail.
+
+- **Post-quantum key exchange on the server side.** `std/tls_server.nu`
+  now accepts X25519MLKEM768, in preference to the classical groups when
+  a client offers it. There the server is the *encapsulating* party: the
+  client sends an ML-KEM encapsulation key and the reply carries a
+  ciphertext, not a public key. `compiler/tests/tls_pq_hybrid.nu` puts
+  the NURL client and the NURL server on the two ends of one handshake
+  and asserts the negotiated group is 4588 — the encapsulating half that
+  talking to Cloudflare can never exercise, since there that side is
+  theirs.
+
+- **`std/net`: `tcp_tls_group` and `tcp_is_post_quantum`.** A server
+  built on `net.nu` previously had no way to ask whether a connection's
+  key exchange was post-quantum; a peer without ML-KEM falls back
+  silently and nothing else about the connection differs.
+
+- **`packages/pqc`: `sign-keygen`, `sign` and `verify`**, so the tool
+  now covers both halves of the migration. Signatures are bound to a
+  `pqc` context string, so one cannot be replayed as a signature for
+  another application sharing the key.
+
 - **Post-quantum TLS: the handshake now survives a quantum adversary.**
   `std/tls.nu`'s client offers **`X25519MLKEM768`** (group `0x11ec`) as
   its first preference, so an ordinary `tls_connect` negotiates

--- a/compiler/tests/mldsa_vectors.nu
+++ b/compiler/tests/mldsa_vectors.nu
@@ -1,0 +1,250 @@
+// mldsa_vectors.nu — ML-DSA (FIPS 204) known-answer tests.
+//
+// Pinned against NIST's ACVP vectors (usnistgov/ACVP-Server,
+// gen-val/json-files/ML-DSA-*-FIPS204). Key generation takes only a
+// 32-byte seed, so those cases are carried in full and their large
+// outputs pinned by SHA3-256 digest; one ML-DSA-44 signing case carries
+// its secret key verbatim.
+//
+// `tools/mldsa_acvp_gate.sh` runs the complete published set — 480
+// cases across keyGen, sigGen and sigVer. This file is the offline
+// subset that runs on every build, plus the checks the published
+// vectors do not make.
+//
+// ── What the published vectors miss ────────────────────────────────
+//
+// The hint in a signature has three canonicality rules (FIPS 204 §7.2):
+// the per-polynomial running totals must be non-decreasing and at most
+// ω, the indices within one polynomial must be strictly increasing, and
+// every byte past the last index must be zero. NIST's 36
+// "modified signature - hint" cases corrupt the hint's *contents* and
+// leave its structure alone, so they barely reach these rules at all.
+// Deleting each check and re-running all 480 published cases:
+//
+//   strictly-increasing indices   1 of 135 sigVer cases fails
+//   trailing bytes must be zero   0 fail — no coverage at all
+//   running totals in range       0 fail — no coverage at all
+//
+// The reason is that corrupting a hint changes the bits it decodes to,
+// so c~ stops matching and the signature is refused whether or not the
+// encoding was checked. What the rules actually defend against is a
+// *different encoding of the same bits*: that verifies unless the rules
+// are enforced, and a second valid encoding of a genuine signature is
+// signature malleability. The `hint-*` cases below construct exactly
+// that, and with either of the first two checks deleted they fail.
+//
+// The third rule is a bounds guard, not a malleability guard: a total
+// past ω makes the index loop run off the end of the signature. Its
+// absence changes no verdict (the garbage indices change the hint, so
+// c~ mismatches anyway), and it does not trip a sanitizer here either,
+// because the read stays inside the slack of the vector's allocation.
+// It is kept because it is the only thing bounding that loop — and it
+// is recorded here that no test in this tree can currently observe its
+// removal, which is a gap, not a clean bill of health.
+
+$ `stdlib/std/mldsa.nu`
+$ `stdlib/std/hash_sha3.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+
+@ hexv s h → ( Vec u ) {
+    : !( Vec u ) ParseErr r ( bytes_from_hex h )
+    ?? r { T v → { ^ v } F _e → { ( nurl_panic `mldsa_vectors: bad hex literal` ) ^ ( vec_new [u] ) } }
+}
+
+@ eq_hex ( Vec u ) got s want → b {
+    : String x ( bytes_to_hex got )
+    : b ok != 0 ( nurl_str_eq ( string_data x ) want )
+    ( string_free x )
+    ^ ok
+}
+
+@ eq_digest ( Vec u ) got s want → b {
+    : ( Vec u ) d ( sha3_256_pure got )
+    : b ok ( eq_hex d want )
+    ( vec_free [u] d )
+    ^ ok
+}
+
+@ report s label b ok → b {
+    ( nurl_print label )
+    ( nurl_print ? ok ` ok\n` ` FAIL\n` )
+    ^ ok
+}
+
+// ── ACVP key generation: seed → pk, dk (pinned by digest) ──────────
+@ kg_case s label i level s seed s pkd s skd → b {
+    : ( Vec u ) xi ( hexv seed )
+    : *MldsaKeys ks ( mldsa_keygen_derand level xi )
+    : b ok1 ( eq_digest ( mldsa_pk ks ) pkd )
+    : b ok2 ( eq_digest ( mldsa_sk ks ) skd )
+    : b ok3 == ( vec_len [u] ( mldsa_pk ks ) ) ( mldsa_pk_len level )
+    : b ok4 == ( vec_len [u] ( mldsa_sk ks ) ) ( mldsa_sk_len level )
+    ( mldsa_keys_free ks )
+    ( vec_free [u] xi )
+    ^ ( report label & & & ok1 ok2 ok3 ok4 )
+}
+
+// ── Round trip, tampering, and context binding ─────────────────────
+@ roundtrip s label i level → b {
+    : ( Vec u ) xi ( vec_new [u] )
+    : ( Vec u ) msg ( vec_new [u] )
+    : ( Vec u ) ctx ( vec_new [u] )
+    : ~ i i 0
+    ~ < i 32 { ( vec_push [u] xi # u % + * i 7 level 251 ) = i + i 1 }
+    = i 0
+    ~ < i 48 { ( vec_push [u] msg # u % + * i 11 5 251 ) = i + i 1 }
+    ( bytes_extend_str ctx `nurl-test` )
+
+    : *MldsaKeys ks ( mldsa_keygen_derand level xi )
+    : ( Vec u ) sig ( mldsa_sign level ( mldsa_sk ks ) msg ctx )
+    : b oklen == ( vec_len [u] sig ) ( mldsa_sig_len level )
+    : b okv ( mldsa_verify level ( mldsa_pk ks ) msg ctx sig )
+
+    // A flipped bit in the signature must not verify.
+    : *u sp ( vec_data [u] sig )
+    = . sp 40 # u ^^ # i . sp 40 1
+    : b okbad ! ( mldsa_verify level ( mldsa_pk ks ) msg ctx sig )
+    = . sp 40 # u ^^ # i . sp 40 1
+
+    // A different context must not verify — that is what ctx is for.
+    : ( Vec u ) ctx2 ( vec_new [u] )
+    ( bytes_extend_str ctx2 `other-app` )
+    : b okctx ! ( mldsa_verify level ( mldsa_pk ks ) msg ctx2 sig )
+    ( vec_free [u] ctx2 )
+
+    // A changed message must not verify.
+    : *u mp ( vec_data [u] msg )
+    = . mp 0 # u ^^ # i . mp 0 1
+    : b okmsg ! ( mldsa_verify level ( mldsa_pk ks ) msg ctx sig )
+    = . mp 0 # u ^^ # i . mp 0 1
+
+    // Hedged signing must not repeat itself.
+    : ( Vec u ) sig2 ( mldsa_sign level ( mldsa_sk ks ) msg ctx )
+    : b okhedge ! ( bytes_eq sig sig2 )
+    : b okboth ( mldsa_verify level ( mldsa_pk ks ) msg ctx sig2 )
+    ( vec_free [u] sig2 )
+
+    ( vec_free [u] sig )
+    ( mldsa_keys_free ks )
+    ( vec_free [u] ctx ) ( vec_free [u] msg ) ( vec_free [u] xi )
+    ^ ( report label & & & & & & oklen okv okbad okctx okmsg okhedge okboth )
+}
+
+// ── Non-canonical hints must be rejected ───────────────────────────
+//
+// The interesting case is not a corrupted hint — corrupting it changes
+// the decoded bits, so c~ stops matching and the signature is refused
+// whether or not the encoding is checked. The interesting case is a
+// *different encoding of the same bits*: that verifies unless the
+// canonicality rules are enforced, and a second valid encoding of a
+// genuine signature is exactly what signature malleability means.
+//
+// Two are built here:
+//
+//   dup — the first index repeated and every running total bumped by
+//         one. Setting a bit twice is setting it once, so the decoded
+//         hint is bit-for-bit the one the signer produced. Only the
+//         strictly-increasing rule rejects this.
+//   pad — a non-zero byte in the unused tail. The decoder never reads
+//         it, so again the hint is unchanged. Only the trailing-zero
+//         rule rejects this.
+//
+// The third rule — running totals non-decreasing and at most omega —
+// is a bounds guard rather than a malleability guard: violating it
+// makes the index loop read past the end of the signature. Its absence
+// does not change the verdict (the garbage indices change the hint, so
+// c~ mismatches anyway) and so cannot be asserted here; it shows up as
+// a heap overflow under ASan, which is where it is checked.
+@ hint_cases s label i level → b {
+    : ( Vec u ) xi ( vec_new [u] )
+    : ( Vec u ) msg ( vec_new [u] )
+    : ( Vec u ) ctx ( vec_new [u] )
+    : ~ i i 0
+    ~ < i 32 { ( vec_push [u] xi # u % + * i 3 level 251 ) = i + i 1 }
+    = i 0
+    ~ < i 16 { ( vec_push [u] msg # u % + * i 5 1 251 ) = i + i 1 }
+
+    : *MldsaKeys ks ( mldsa_keygen_derand level xi )
+    : ( Vec u ) good ( mldsa_sign level ( mldsa_sk ks ) msg ctx )
+    : b okgood ( mldsa_verify level ( mldsa_pk ks ) msg ctx good )
+
+    : i hoff ( mldsa_hint_offset level )
+    : i om ( mldsa_omega level )
+    : i k ( mldsa_module_rank level )
+    : *u gp ( vec_data [u] good )
+    : i last # i . gp + + hoff om - k 1
+
+    // dup: re-encode the same hint with the first index repeated.
+    : ( Vec u ) dup ( bytes_slice good 0 ( vec_len [u] good ) )
+    : *u dpp ( vec_data [u] dup )
+    : ~ b okdup T
+    ? & > last 0 < last om {
+        : ~ i j last
+        ~ > j 0 {
+            = . dpp + hoff j . dpp + hoff - j 1
+            = j - j 1
+        }
+        : ~ i c 0
+        ~ < c k {
+            = . dpp + + hoff om c # u + # i . dpp + + hoff om c 1
+            = c + c 1
+        }
+        = okdup ! ( mldsa_verify level ( mldsa_pk ks ) msg ctx dup )
+    } {}
+    ( vec_free [u] dup )
+
+    // pad: a non-zero byte the decoder never reads.
+    : ( Vec u ) pad ( bytes_slice good 0 ( vec_len [u] good ) )
+    : *u pp ( vec_data [u] pad )
+    : ~ b okpad T
+    ? < last om {
+        = . pp + hoff - om 1 # u 7
+        = okpad ! ( mldsa_verify level ( mldsa_pk ks ) msg ctx pad )
+    } {}
+    ( vec_free [u] pad )
+
+    // A hint total past omega must be refused outright.
+    : ( Vec u ) big ( bytes_slice good 0 ( vec_len [u] good ) )
+    : *u bgp ( vec_data [u] big )
+    = . bgp + + hoff om - k 1 # u 255
+    : b okbig ! ( mldsa_verify level ( mldsa_pk ks ) msg ctx big )
+    ( vec_free [u] big )
+
+    ( vec_free [u] good )
+    ( mldsa_keys_free ks )
+    ( vec_free [u] ctx ) ( vec_free [u] msg ) ( vec_free [u] xi )
+    ^ ( report label & & & okgood okdup okpad okbig )
+}
+
+@ main → i {
+    : ~ b all T
+    = all & all ( kg_case `keygen-44#1    ` 44 `7194b13c95231010afd2c909992bd2003ba6f437c3886bdbe3f6b867a14ba161` `d8d9aa0403ddc91a7f2ab668fea9e85f59a6f519beb9499ffc937d6ed76442e3` `0772f7ccc3674b859c9ed70da44b3559cec44bbdf75b8ea31e04a23fa6871b24` )
+    = all & all ( kg_case `keygen-44#2    ` 44 `2ebe5a4123398dfbcd5bdf0a42ebdd03112be3bc88a6e9b78d93120ab8d0120e` `954067b19bfd5bffc388bfb08c711e2c1ee9104f34c4d2fc82cb7c2a44efd533` `99f9fb19f87bef6a060a885b3d55ba4d818dccc74e21e6186057a65e6d01006b` )
+    = all & all ( kg_case `keygen-65#1    ` 65 `a991fd42b071d49c48ae3e75c647459e0daad1e1ba356a04801912d3294bcff8` `0083e4d4f562780dd5ef685c88db5afcdac44d1b4be5e4253d0de771100316f3` `9a6fe5796bc8b61c6eb274cc5905b3d3ce21693c9e7fd32db79b1cff49e93717` )
+    = all & all ( kg_case `keygen-65#2    ` 65 `494f29ad1c93abb2b9545bd14cc575a98ecd3062137b439b49eb1a8cc6652fc6` `f0e38aea581d23d140424ba27ed5da0b16a21e5e02c9a6ae882792c2e78812ba` `90d308129e0be27b38a17845ffa2b59a49719390a46de01b2418c7d387191daa` )
+    = all & all ( kg_case `keygen-87#1    ` 87 `a16f5b0796703e2d1a0140a35cbf36efabe70e752ba59b6a9a0e9c4b05302f73` `9df39232077a88b3b36c0d4b37d2d369f942baaaa436cf5486a1f09d45d7ce0b` `c41388f22cf3bc0ce79eb5fccfafeee5ec31e3d4321a8befe7f230d6c4841cf0` )
+    = all & all ( kg_case `keygen-87#2    ` 87 `e46d458a660285930d9656a88d14e751730cae7a4975b6e4fbe69e80e3f01e7f` `426901f3738814120042ed6c54f019460d9c43613aabfc1bfa9bb9ecec3b7315` `b4e39a2cdd8e37ac9dfda3c160a6d43b4506c439e8b4916343be2772fbf9a0f3` )
+
+    // ACVP signing, ML-DSA-44, deterministic internal interface:
+    // the secret key and message verbatim, the signature by digest.
+    : ( Vec u ) sk44 ( hexv `1ab666c8a0674a4d94657f97282d3904b2b775e4f0c8b53ba83e9734aeb4505469ea64a942bab348e718c4fd5905e9f07a48865dd1f2e825ef4868699e7640e9b74ebd49c58079eab82da70488b04ebbbb1e14d8755fb168e68a4878869fc9e8c5bea46f4defd9f025a89b804eaf53e1ebd4435010a93c3a27551f2f1bd30bc8c428111a1502232222d8a24d5ca640819009e34684a4806cc2282263042500470e21913113498294c28561c27100b94813274290c440d0b02982348a8828722038824044440c4052e1a46d24074584248253920423340140442600496053a48103a5504206085ba408032930121825e4c60c221570da306609488c10b82153960dc3b8219a840d62b02909302de1c41143046cccb209d92290022582091825611809a3c464883600e4964d1a190803b0904b444122884c640605189348cb248cd3b8054118729a4410c09871cb065243323049466183a60899027202210d531605c1c66c0905441089718394010a086e0a8200d4104e9cb269083890a202449aa09123244523982c833061a20629dab005e0324a09112463842d0939291216100a494c19b00840944801c74920168a1b0120242710c244220a062a4c4262a114810a348814b57151b625038509519804d482289998418aa82c42b06c4ca2455018698ac64d1901099c2466042668dc488492a42c43a8859aa06d8480450c432801c99004a82c0c126a91c664ca025083086053c00ce34411a14092d8320980486ec1b66d8c9231189030c1142522c68d0ac225c4400c60b040024524c9966c011492a3a6204aa4204012042196098b068c9948708428290a814c10306d1b4802cb08706216694c38484b1446c1164c20c34c5c162a8944710bc32451320d244101d3b070230501004251e41000640641a2c00dc8a62c214268e4a2058020221a198001912c19456a9b942dd026408088800208608b307048186a043084c1b6909ba48c82c2041a002de1466461882d08962103256e0c182294c85104b0890b460c08874d603632cc061008a905cc062e841065040301e4360864986919a56901a54542980d8b182424194008347001348440880c18a301a04225089324e42084890260d8b651131841c0409154266a0bb701493249db20801a2084500071e30202dcb62449482e4326854b14880ba581c8a428943212101344c44000dc222ca4180503a66980460d533430dc920881306883c20d9ac0299c0828440228231562b9a3ed2d106541a8b2187f41bfbfde5b05f9316b0e3e309c4b827e6f17c09c33af1e486395abb513dccdb5b52f8afa2d797228194a533e948297f105aecc6103e8e27d522d01331ed978ada2c7b15cc8f6737ea2286999a56d5eb620fbc8e08408232c7c6e64334d2d769b27fc13143217ed97183ecafaf777c58894da6b2ec8deb5ff86a3c7600771bdd93e6c375a4a534aca205af8679a7aeb909d29c1d89a0e0e5a6e2da77e42894b0af3d5b0c6621f31b40effc6b4cd5c79991f969498b43616a304e6f71143a960d6b68c145ecfd246797c00c848b886ef5eb15d0439942d96be6051a3f2a316b0a2774be0a85c48998cd46264f121f9bfb85eef415c508bd92fb1e6a2daa34658bdc5f8d85da22c0f158547c0b0cea2cda5980a24673b3bf510a07780ddf7d364ae03cfdb1d4b2102afd53d4a0afed233bdcd07cd77b454b97ab6db2cf1fec2b2dc80eb9a61aaf8c03b1c8100f295c017c075f2f35911dce844b93e95b375036e9617d446160a969eea77366ac3bb1571ad17d074979b75e12861c5f240457e73fb4deef3972b8dae3d447c2869110d1c1993e8216dc847d04ffa4fcf5b0a82b7dbd356901b9025d63ea69a71e6c9eb95b2eff68e8aaa19f358ce40fab3bc0666d68890b428e425827270a119e6173144964d7ff2ad1e5f63f530c29106bf210b5c8081b739baa447e6fad370f6ec4d4c15419bf28fbaf6a8a9a43fcea49cac8a903c606e12a19b7a3678a0f0e860f4109880bd3e5cf88d792194995901b4449346b1a789120915ab00ac6c509f742051492fcbee3a8ee92497dfa08a0987cd41e2017855f4325a6c6d20cdbbcf5b50395824af829f908f93b1c388ab8689981c31cbff7091c1211bae330287b3e6342e45a26426947b75d6764f410c96b8f5d182b31e866bb658c0b44bb29b1ce1bd78519e95491c3fad3ae417fa75ffa3af1ab6f8ef2c33d8014d62385d58154977dbfdc764f2eeb24eb09b95bb4ff9e566d22c0b5ca224d97c0e73d4650b26dc51145550255565d4e213fd77899a4a805326a9e4a3e196127986b88d3a6e6234818447b6bd7ae5e1ba4b164373b9c6171fdc4d645ed7472ada23cb4d848a0dd62cbcaa45185bf75de36154bcb79abe2a7c6dd280623356c44390afbdca807f5c599eb26d42116b49a31d89a4560ae2ca4bf73574813162475afb9efe0bc2e7c5c17aeb4b91d48ca8832d19e8f45eda1f45c74833ddb48d451642ecdc965fd310208474d5c1441d4a634903090a0ab77f194547215dbe450c1263b60116a5b4a877a7be5c2103977860815d13420c588bc34780766d559cd6748a7010a2bf731fb91ff4129571a30e4bd4ad2092e508c9e536c4779f5ab23cac3670ec29fda730c8f61666b8af3562d59da77b5701e201e2c79b646704033513383a5de4cbb66e5d714844ca04b8ffa8639c929e3e1822d88eca4dcddc4633d588efdb4f3e919688f245cb371febd4e8a39ca9301221aaadda570199543f8847e0efe63a5a54933a04cb98c5cebc0567b58a036487212242d90d8407305706723b53b5e897083dba941bd79855bb861c68f09b83d39434825aabae3b85e9d08e35bbfd4f40d08a1389cb7f89a71bfc4d9d33e1e4e5eaf23f9bfa4c75d9bde1b18d8ba5649c519ee76ee117d08e7c666962d887a7d1525aa471a5197cb0703acb14b86ccf3473bb96f121324ad8a5b2739b00fd962d83037d946c6583420b636e9e9d5575b2ba043fd1f8c58acca8a84bb957985bf6eca4c0b750d9805817fbbaf405f9d058c1e00a37919cb929d057567379e2fddeba00b0e4f109ccec0b8342d851156abefe6e895024244d27bfa3bd2131d0199cab0d15233c76afee1d6dbac1611c2225e30df09af0d2ec1945f7c8b4ebb94f2672dff8dec69c33d15a2435494c816f41d698696d84bb6b3c316525162570852ed45983b539742563bd84628731aae4916fe531763568188f07dbadd0a2046afe4ab3e9a77a931515d5965c7a06d673b9e0780a58b14fae109fe5f81806ee6163b2818c4bf0ff907ba633870b12c353411c62572897ab8b121c249e75689bc2c2f2b834c1cd9c114c2578ec3053670c3355c3aad3ccaf7368e1f2c7f829e737828452bb16a1bf11f02a9bddabb19d38f0b9f5e096b05e683419a321c1570746e8baca9b6bb3dd09bac462782cbd97537e6a6e196e440d94a8cb8260b7c801094b32e8cc7c78c9170be1a0fbc33498a48ef5d0a48c06a182ea4da443691556e7fc3fc19ade8dc56d3a650e0c0daa6432f322fc77571e52866bd8b344b67183dd6515d5276c884e8882db569a70ecc1a8b63b5400030c44aed52435` )
+    : ( Vec u ) msg44 ( hexv `35` )
+    : ( Vec u ) rnd0 ( vec_with_cap [u] 32 )
+    : ~ i z 0
+    ~ < z 32 { ( vec_push [u] rnd0 # u 0 ) = z + z 1 }
+    : ( Vec u ) sig44 ( mldsa_sign_internal 44 sk44 msg44 rnd0 )
+    = all & all ( report `sigGen-44      ` ( eq_digest sig44 `d92c07bc1e3b8746a27140c497cef865836ddd3f966f7206c48e0c0c46ee7c5c` ) )
+    ( vec_free [u] sig44 ) ( vec_free [u] rnd0 )
+    ( vec_free [u] msg44 ) ( vec_free [u] sk44 )
+
+    = all & all ( roundtrip `roundtrip-44   ` 44 )
+    = all & all ( roundtrip `roundtrip-65   ` 65 )
+    = all & all ( roundtrip `roundtrip-87   ` 87 )
+
+    = all & all ( hint_cases `hint-44        ` 44 )
+    = all & all ( hint_cases `hint-65        ` 65 )
+    = all & all ( hint_cases `hint-87        ` 87 )
+    ^ ? all 0 1
+}

--- a/compiler/tests/outputs/mldsa_vectors.txt
+++ b/compiler/tests/outputs/mldsa_vectors.txt
@@ -1,0 +1,17 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+keygen-44#1     ok
+keygen-44#2     ok
+keygen-65#1     ok
+keygen-65#2     ok
+keygen-87#1     ok
+keygen-87#2     ok
+sigGen-44       ok
+roundtrip-44    ok
+roundtrip-65    ok
+roundtrip-87    ok
+hint-44         ok
+hint-65         ok
+hint-87         ok

--- a/compiler/tests/outputs/tls_pq_hybrid.txt
+++ b/compiler/tests/outputs/tls_pq_hybrid.txt
@@ -1,0 +1,10 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+client_handshake=OK
+client_group=X25519MLKEM768
+client_is_pq=T
+echo_ok=T
+server_group=X25519MLKEM768
+server_echo=OK

--- a/compiler/tests/tls_pq_hybrid.nu
+++ b/compiler/tests/tls_pq_hybrid.nu
@@ -1,0 +1,115 @@
+// tls_pq_hybrid.nu — post-quantum key exchange between our own two ends.
+//
+// A pure-NURL TLS 1.3 server (self-signed P-256 from std/x509_gen) and
+// the pure-NURL TLS 1.3 client complete a handshake with no other
+// implementation involved, and the group they settle on must be
+// X25519MLKEM768 (0x11ec) — the client offers it first, the server
+// prefers it, and both sides have to agree on the byte order of a share
+// that is ML-KEM key/ciphertext followed by X25519 key.
+//
+// This is the half that talking to Cloudflare cannot check. Against a
+// real server only our *decapsulating* side runs; the encapsulating
+// side is theirs. Here NURL is on both ends, so the server's
+// encapsulation path — split the 1216-byte share, encapsulate to the
+// client's ML-KEM key, reply with ciphertext ‖ X25519 key — is
+// exercised too, and a mismatch in either direction shows up as a
+// handshake that fails rather than a group that quietly degrades.
+//
+// The group is asserted, not assumed: an agreeing handshake proves
+// nothing on its own, because falling back to plain X25519 also
+// produces one. The test fails if `tls_group` is anything but 4588.
+//
+// Server on an OS thread (tls_accept blocks), client on the main
+// thread, like async_tcp.nu's pairing.
+// requires: live fibers
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/net.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/tls.nu`
+$ `stdlib/std/tls_server.nu`
+$ `stdlib/std/x509_gen.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/time.nu`
+
+: ~ i server_group 0
+: ~ i server_ok 0
+
+@ label s k s v → v {
+    ( nurl_print k ) ( nurl_print `=` ) ( nurl_print v ) ( nurl_print `\n` )
+}
+
+@ run → v {
+    : X509SelfSigned cert ( x509_selfsigned_p256 `localhost` 1 )
+    : s cp `/tmp/nurl_tls_pq_hybrid.crt`
+    : s kp `/tmp/nurl_tls_pq_hybrid.key`
+    ?? ( write_file cp ( string_data . cert cert_pem ) ) { T _ → {} F _ → { ( label `cert_write` `FAIL` ) } }
+    ?? ( write_file kp ( string_data . cert key_pem ) ) { T _ → {} F _ → { ( label `key_write` `FAIL` ) } }
+    ( x509_selfsigned_free cert )
+
+    : !TcpListener NetErr lr ( tcp_listen_tls `127.0.0.1` 18911 cp kp )
+    ?? lr {
+        T listener → {
+            : ( @ v ) server \ → v {
+                : !TcpConn NetErr cr ( tcp_accept listener )
+                ?? cr {
+                    T c → {
+                        // Echo one line back, so the record layer is
+                        // exercised under the hybrid-derived keys and
+                        // not just the handshake.
+                        : !( Vec u ) NetErr rd ( tcp_read_chunk c 64 )
+                        ?? rd {
+                            T v → {
+                                ?? ( tcp_write_all c v ) { T _ → { = server_ok 1 } F _ → {} }
+                                ( vec_free [u] v )
+                            }
+                            F _ → {}
+                        }
+                        = server_group ( tcp_tls_group c )
+                        ( tcp_close_conn c )
+                    }
+                    F _ → {}
+                }
+            }
+            : !Thread ThreadErr st ( thread_spawn server )
+            ?? st {
+                T t → {
+                    ( sleep_ms 200 )
+                    : !*TlsConn TlsErr r ( tls_connect_insecure `127.0.0.1` 18911 `localhost` )
+                    ?? r {
+                        T c → {
+                            ( label `client_handshake` `OK` )
+                            ( label `client_group` ? == ( tls_group c ) 4588 `X25519MLKEM768` `NOT-PQ` )
+                            ( label `client_is_pq` ? ( tls_is_post_quantum c ) `T` `F` )
+                            : ( Vec u ) msg ( bytes_from_str `pq\n` )
+                            ?? ( tls_write c msg ) { T _ → {} F _ → { ( label `client_write` `FAIL` ) } }
+                            ( vec_free [u] msg )
+                            : !( Vec u ) TlsErr rr ( tls_read c 64 )
+                            ?? rr {
+                                T echo → {
+                                    ( label `echo_ok` ? ( bytes_eq echo ( bytes_from_str `pq\n` ) ) `T` `F` )
+                                    ( vec_free [u] echo )
+                                }
+                                F _ → { ( label `echo_ok` `READ-FAIL` ) }
+                            }
+                            ( tls_close c )
+                        }
+                        F _e → { ( label `client_handshake` `FAIL` ) }
+                    }
+                    ( thread_join t )
+                }
+                F _ → { ( label `spawn` `FAIL` ) }
+            }
+            ( label `server_group` ? == server_group 4588 `X25519MLKEM768` `NOT-PQ` )
+            ( label `server_echo` ? == server_ok 1 `OK` `FAIL` )
+        }
+        F _e → { ( label `tls_listen` `FAIL` ) }
+    }
+}
+
+@ main → i {
+    ( run )
+    ^ 0
+}

--- a/docs/CRYPTO.md
+++ b/docs/CRYPTO.md
@@ -30,6 +30,7 @@ All sources live in `stdlib/std/`.
 | Hashes | `hash_sha256`, `hash_sha512`, `hash_sha3`, `hash_sha1`, `hash_md5`, `hash_blake3` | SHA-1/MD5 for legacy interop only (never trusted for signatures) |
 | XOF | `hash_sha3` (SHAKE128/256) | extendable output, incremental squeeze; ML-KEM is built on it |
 | Post-quantum KEM | `mlkem` (ML-KEM-512/768/1024, FIPS 203) | checked byte-for-byte against NIST's ACVP vectors |
+| Post-quantum signature | `mldsa` (ML-DSA-44/65/87, FIPS 204) | pure and external-mu interfaces; HashML-DSA not implemented |
 | HMAC / KDF | `hkdf`, `pbkdf2`, `scrypt` | HKDF-Expand-Label for TLS 1.3 |
 | AEAD | `aes_gcm` (AES-128/256-GCM), `chacha20poly1305` | the two TLS 1.3 record ciphers |
 | ECDH / signatures | `x25519`, `ed25519`, `ecdsa_p256` (P-256 + P-384), `p256_field` | TweetNaCl-derived 25519 ladder over a ten-limb radix-2^25.5 field; `p256_field` is the dedicated **constant-time** fixed-limb GF(p) for the P-256 secret path |

--- a/packages/README.md
+++ b/packages/README.md
@@ -170,19 +170,25 @@ the one block it needs, so a table larger than RAM is an ordinary table.
 Leak-clean under ASan/LSan across every path. See
 [`lsmdb/README.md`](lsmdb/README.md) for the file format and the guarantees.
 
-## `pqc/` — post-quantum key encapsulation, and whether the web is ready (installable program)
+## `pqc/` — post-quantum cryptography, and whether the web is ready (installable program)
 
-ML-KEM (FIPS 203, formerly CRYSTALS-Kyber) at all three parameter sets
-over [`stdlib/std/mlkem.nu`](../stdlib/std/mlkem.nu) — key generation,
-encapsulation, decapsulation — checked byte for byte against NIST's own
-ACVP vectors, all 180 published cases. No libcrypto, no liboqs; the
-binary links libc and nothing else.
+Both halves of the migration over
+[`stdlib/std/mlkem.nu`](../stdlib/std/mlkem.nu) and
+[`stdlib/std/mldsa.nu`](../stdlib/std/mldsa.nu): **ML-KEM** (FIPS 203,
+formerly CRYSTALS-Kyber) for key encapsulation and **ML-DSA** (FIPS 204,
+formerly CRYSTALS-Dilithium) for signatures, at all three parameter sets
+each, checked byte for byte against NIST's own ACVP vectors — 660
+published cases. No libcrypto, no liboqs; the binary links libc and
+nothing else.
 
 ```
 nurlpkg install pqc
 pqc keygen -o demo             # demo.ek (1184 B) + demo.dk (2400 B)
 pqc encaps demo.ek -o demo.ct  # → ciphertext + shared secret
 pqc decaps demo.dk demo.ct     # → the same shared secret
+pqc sign-keygen -o id          # id.pub (1952 B) + id.key (4032 B)
+pqc sign id.key report.pdf     # → report.pdf.sig (3309 B)
+pqc verify id.pub report.pdf report.pdf.sig
 pqc probe cloudflare.com github.com   # who actually does post-quantum TLS?
 pqc bench                      # ~15k keygen/s, ~16k encaps/s on one core
 pqc kat                        # self-test against the NIST vectors

--- a/packages/pqc/CHANGELOG.md
+++ b/packages/pqc/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `pqc` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] — 2026-08-17
+
+### Added
+
+- **ML-DSA (FIPS 204) signatures** at all three parameter sets, built on
+  `stdlib/std/mldsa.nu`: `sign-keygen`, `sign` and `verify`. Signing is
+  hedged, so the same file signed twice gives two different signatures
+  and both verify, and signatures are bound to a `pqc` context string so
+  one cannot be replayed as a signature for another application sharing
+  the key.
+- The parameter set is inferred from key length on `sign` and `verify`,
+  as it already was for `encaps` and `decaps`.
+
 ## [0.1.0] — 2026-08-17
 
 ### Added

--- a/packages/pqc/README.md
+++ b/packages/pqc/README.md
@@ -3,20 +3,24 @@
 Post-quantum key encapsulation on the command line, and a probe for
 whether the servers you talk to are ready for it.
 
-`pqc` implements **ML-KEM** — the key-encapsulation mechanism NIST
-standardised as [FIPS 203][fips203] in August 2024, previously known as
-CRYSTALS-Kyber — at all three parameter sets, in pure NURL. No
+`pqc` implements both halves of the post-quantum migration, in pure
+NURL — **ML-KEM** ([FIPS 203][fips203], formerly CRYSTALS-Kyber) for key
+encapsulation and **ML-DSA** ([FIPS 204][fips204], formerly
+CRYSTALS-Dilithium) for signatures, at all three parameter sets each. No
 libcrypto, no liboqs, no `-loqs`: this links libc and nothing else.
 
 [fips203]: https://csrc.nist.gov/pubs/fips/203/final
+[fips204]: https://csrc.nist.gov/pubs/fips/204/final
 
 ## Why you'd want it
 
 Two reasons, and the second is the one that earns a place on a laptop.
 
-**A KEM you can actually run.** Generate a key pair, encapsulate to it,
-decapsulate — the primitive that hybrid TLS, Signal's PQXDH and every
-"harvest now, decrypt later" mitigation is built on.
+**Primitives you can actually run.** Generate a key pair, encapsulate to
+it, decapsulate — the primitive that hybrid TLS, Signal's PQXDH and
+every "harvest now, decrypt later" mitigation is built on. And sign and
+verify a file with ML-DSA, the signature that replaces Ed25519 and RSA
+once a quantum computer exists.
 
 **A post-quantum readiness check.** `pqc probe HOST` completes a real
 TLS 1.3 handshake and reports which key-exchange group the server
@@ -49,19 +53,43 @@ pqc probe api.example.com || echo "not post-quantum yet"
 ## Usage
 
 ```
-pqc keygen [-l 768] -o NAME    write NAME.ek and NAME.dk
+pqc keygen [-l 768] -o NAME    write NAME.ek and NAME.dk       (ML-KEM)
 pqc encaps NAME.ek [-o CT]     encapsulate; prints the shared secret
 pqc decaps NAME.dk CT          recover the same shared secret
+
+pqc sign-keygen [-l 65] -o N   write N.pub and N.key           (ML-DSA)
+pqc sign N.key FILE [-o SIG]   sign FILE, writing FILE.sig
+pqc verify N.pub FILE SIG      check a signature
+
 pqc probe HOST...              report each server's key-exchange group
 pqc bench [-l 768] [-n N]      operations per second on this machine
 pqc kat                        self-test against NIST's ACVP vectors
 ```
 
-Parameter sets are `-l 512`, `-l 768` (the default) and `-l 1024`,
-targeting roughly the security of AES-128, AES-192 and AES-256. For
-`encaps` and `decaps` the level is inferred from the key's length — the
-three sizes are distinct, so you never have to remember which set a key
-came from.
+ML-KEM levels are `-l 512`, `-l 768` (the default) and `-l 1024`; ML-DSA
+levels are `-l 44`, `-l 65` (the default) and `-l 87`. Both ladders
+target roughly the security of AES-128, AES-192 and AES-256. Everywhere
+a key is read the level is inferred from its length — the sizes are all
+distinct, so you never have to remember which set a key came from.
+
+```console
+$ pqc sign-keygen -o id
+verification key -> id.pub (1952 bytes)
+signing key -> id.key (4032 bytes)
+
+$ pqc sign id.key report.pdf
+ML-DSA-65
+signature -> report.pdf.sig (3309 bytes)
+
+$ pqc verify id.pub report.pdf report.pdf.sig
+ML-DSA-65 valid
+```
+
+Signing is *hedged*: 32 fresh random bytes go into every signature, so
+the same file signed twice gives two different signatures and both
+verify. Signatures are bound to a `pqc` context string, so one cannot be
+replayed as a signature made for a different application that happens to
+share the key.
 
 ```console
 $ pqc keygen -o demo
@@ -86,6 +114,12 @@ shared secret 08c07245e811541506dfd489b50ed5c1b001808933d09e3b21012e9d1fd248df
 | ML-KEM-768 | 1184 | 2400 | 1088 | 32 |
 | ML-KEM-1024 | 1568 | 3168 | 1568 | 32 |
 
+| set | public key | secret key | signature |
+|---|---|---|---|
+| ML-DSA-44 | 1312 | 2560 | 2420 |
+| ML-DSA-65 | 1952 | 4032 | 3309 |
+| ML-DSA-87 | 2592 | 4896 | 4627 |
+
 Measured with `pqc bench -n 500` on one core of an x86-64 desktop:
 
 ```
@@ -103,18 +137,27 @@ handshake costs less than the handshake's own round trip.
 `pqc kat` runs a built-in subset of NIST's vectors. The full check lives
 in the compiler repository:
 
-- `compiler/tests/mlkem_vectors.nu` — an offline subset that runs on
-  every build, plus a round trip and the implicit-rejection path at each
-  parameter set.
-- `tools/mlkem_acvp_gate.sh` — every published ACVP case, 180 of them,
-  fetched from `usnistgov/ACVP-Server` and compared byte for byte.
+- `tools/mlkem_acvp_gate.sh` — every published ML-KEM ACVP case, 180 of
+  them, fetched from `usnistgov/ACVP-Server` and compared byte for byte.
+- `tools/mldsa_acvp_gate.sh` — every published ML-DSA case, 480 of them,
+  across key generation, signing and verification.
+- `compiler/tests/mlkem_vectors.nu` and `compiler/tests/mldsa_vectors.nu`
+  — offline subsets that run on every build.
 
-A KEM cannot be validated by round-tripping itself: encapsulate and
-decapsulate with the same broken implementation and the shared secrets
-still agree. The vectors are the only real oracle, and the gate has been
-mutation-tested — a wrong twiddle factor, a dropped NTT layer, a swapped
-noise sign and an unconditional implicit-rejection select are each
-caught.
+Neither scheme can be validated by round-tripping itself: encapsulate
+and decapsulate, or sign and verify, with the same broken implementation
+and the two halves still agree. The vectors are the only real oracle,
+and both gates have been mutation-tested — a wrong twiddle factor, a
+dropped NTT layer, a wrong Montgomery constant, a swapped noise sign and
+an unconditional implicit-rejection select are each caught.
+
+Where the vectors fall short, the offline tests go further. A
+signature's hint has encoding rules whose violation is not a corrupted
+signature but a second valid encoding of a genuine one, and NIST's
+"modified hint" cases barely reach them — deleting the trailing-zero
+rule fails none of the 480 published cases. So `mldsa_vectors.nu`
+constructs re-encodings that decode to identical hint bits and requires
+them to be rejected.
 
 ## Hybrid TLS
 

--- a/packages/pqc/nurl.toml
+++ b/packages/pqc/nurl.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pqc"
-version = "0.1.0"
-description = "Post-quantum key encapsulation on the command line, and a probe for whether the servers you talk to are ready for it. Implements ML-KEM (FIPS 203, formerly CRYSTALS-Kyber) at all three parameter sets — keygen, encapsulate, decapsulate — checked byte-for-byte against NIST's own ACVP vectors, all 180 published cases. The part worth having on a laptop is `pqc probe HOST`: it completes a real TLS 1.3 handshake and reports which key-exchange group the server actually chose, because offering the hybrid group is not the same as getting it and a server without ML-KEM falls back to X25519 silently. Built on stdlib/std/mlkem.nu and the pure-NURL TLS stack, which negotiates X25519MLKEM768 with the servers that support it — no libcrypto, no liboqs, libc and nothing else."
+version = "0.2.0"
+description = "Post-quantum cryptography on the command line, and a probe for whether the servers you talk to are ready for it. Implements both halves of the migration in pure NURL — ML-KEM (FIPS 203, formerly CRYSTALS-Kyber) for key encapsulation and ML-DSA (FIPS 204, formerly CRYSTALS-Dilithium) for signatures, at all three parameter sets each — checked byte-for-byte against NIST's own ACVP vectors, 660 published cases in all. The part worth having on a laptop is `pqc probe HOST`: it completes a real TLS 1.3 handshake and reports which key-exchange group the server actually chose, because offering the hybrid group is not the same as getting it and a server without ML-KEM falls back to X25519 silently. Built on stdlib/std/mlkem.nu, stdlib/std/mldsa.nu and the pure-NURL TLS stack, which negotiates X25519MLKEM768 with the servers that support it — no libcrypto, no liboqs, libc and nothing else."
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/packages/pqc/src/main.nu
+++ b/packages/pqc/src/main.nu
@@ -4,9 +4,17 @@
 //   pqc keygen [-l 768] -o NAME    write NAME.ek and NAME.dk
 //   pqc encaps NAME.ek             → NAME.ct and the shared secret
 //   pqc decaps NAME.dk NAME.ct     → the same shared secret
+//   pqc sign-keygen [-l 65] -o N   write N.pub and N.key   (ML-DSA)
+//   pqc sign N.key FILE            → FILE.sig
+//   pqc verify N.pub FILE FILE.sig → valid / INVALID
 //   pqc probe HOST[:PORT]…         does this server do post-quantum TLS?
 //   pqc bench [-l 768] [-n N]      operations per second, here
 //   pqc kat                        self-test against NIST's vectors
+//
+// Two schemes, one tool: ML-KEM (FIPS 203) replaces the key exchange
+// and ML-DSA (FIPS 204) replaces the signature. The KEM levels are 512,
+// 768 and 1024; the signature levels are 44, 65 and 87, and `-l` picks
+// whichever family the subcommand belongs to.
 //
 // ML-KEM (FIPS 203) is the KEM NIST standardised in 2024, and the
 // `probe` subcommand is the part worth having on a laptop: it completes
@@ -27,6 +35,7 @@ $ `stdlib/std/bytes.nu`
 $ `stdlib/std/fs.nu`
 $ `stdlib/std/time.nu`
 $ `stdlib/std/mlkem.nu`
+$ `stdlib/std/mldsa.nu`
 $ `stdlib/std/hash_sha3.nu`
 $ `stdlib/std/tls.nu`
 $ `stdlib/ext/env.nu`
@@ -195,6 +204,111 @@ $ `stdlib/ext/env.nu`
             }
         }
         F _e → { ( __die `cannot read decapsulation key` ) ^ 1 }
+    }
+}
+
+// ── ML-DSA signing ─────────────────────────────────────────────────
+
+@ __check_sign_level i level → b {
+    ^ | | == level 44 == level 65 == level 87
+}
+
+@ __level_from_pub i n → i {
+    ? == n 1312 { ^ 44 } {}
+    ? == n 1952 { ^ 65 } {}
+    ? == n 2592 { ^ 87 } {}
+    ^ 0
+}
+
+@ __level_from_key i n → i {
+    ? == n 2560 { ^ 44 } {}
+    ? == n 4032 { ^ 65 } {}
+    ? == n 4896 { ^ 87 } {}
+    ^ 0
+}
+
+@ __cmd_sign_keygen i level s name → i {
+    : *MldsaKeys ks ( mldsa_keygen level )
+    : String pp ( string_from name ) ( string_push_str pp `.pub` )
+    : String kp2 ( string_from name ) ( string_push_str kp2 `.key` )
+    : b a ( __write_bytes ( string_data pp ) ( mldsa_pk ks ) `verification key ->` )
+    : b b2 ( __write_bytes ( string_data kp2 ) ( mldsa_sk ks ) `signing key ->` )
+    ( string_free kp2 ) ( string_free pp )
+    ( mldsa_keys_free ks )
+    ^ ? & a b2 0 1
+}
+
+// The context string binds a signature to this tool, so a signature
+// made by `pqc sign` cannot be replayed as one made for some other
+// application that happens to use the same key.
+@ __pqc_ctx → ( Vec u ) {
+    : ( Vec u ) c ( vec_new [u] )
+    ( bytes_extend_str c `pqc` )
+    ^ c
+}
+
+@ __cmd_sign s keypath s msgpath s outpath → i {
+    : !( Vec u ) IoErr rk ( __read_bytes keypath )
+    ?? rk {
+        T sk → {
+            : i level ( __level_from_key ( vec_len [u] sk ) )
+            ? == level 0 {
+                ( __die `not an ML-DSA signing key (expected 2560, 4032 or 4896 bytes)` )
+                ( vec_free [u] sk )
+                ^ 1
+            } {}
+            : !( Vec u ) IoErr rm ( __read_bytes msgpath )
+            ?? rm {
+                T msg → {
+                    : ( Vec u ) ctx ( __pqc_ctx )
+                    : ( Vec u ) sig ( mldsa_sign level sk msg ctx )
+                    : String hd ( __line_new `ML-DSA-` )
+                    ( __line_int hd level ) ( __line_end hd )
+                    : b ok ( __write_bytes outpath sig `signature ->` )
+                    ( vec_free [u] sig ) ( vec_free [u] ctx )
+                    ( vec_free [u] msg ) ( vec_free [u] sk )
+                    ^ ? ok 0 1
+                }
+                F _e → { ( __die `cannot read the file to sign` ) ( vec_free [u] sk ) ^ 1 }
+            }
+        }
+        F _e → { ( __die `cannot read signing key` ) ^ 1 }
+    }
+}
+
+@ __cmd_verify s pubpath s msgpath s sigpath → i {
+    : !( Vec u ) IoErr rp ( __read_bytes pubpath )
+    ?? rp {
+        T pk → {
+            : i level ( __level_from_pub ( vec_len [u] pk ) )
+            ? == level 0 {
+                ( __die `not an ML-DSA verification key (expected 1312, 1952 or 2592 bytes)` )
+                ( vec_free [u] pk )
+                ^ 1
+            } {}
+            : !( Vec u ) IoErr rm ( __read_bytes msgpath )
+            ?? rm {
+                T msg → {
+                    : !( Vec u ) IoErr rs ( __read_bytes sigpath )
+                    ?? rs {
+                        T sig → {
+                            : ( Vec u ) ctx ( __pqc_ctx )
+                            : b ok ( mldsa_verify level pk msg ctx sig )
+                            : String ln ( __line_new `ML-DSA-` )
+                            ( __line_int ln level )
+                            ( string_push_str ln ? ok ` valid` ` INVALID` )
+                            ( __line_end ln )
+                            ( vec_free [u] ctx ) ( vec_free [u] sig )
+                            ( vec_free [u] msg ) ( vec_free [u] pk )
+                            ^ ? ok 0 1
+                        }
+                        F _e → { ( __die `cannot read signature` ) ( vec_free [u] msg ) ( vec_free [u] pk ) ^ 1 }
+                    }
+                }
+                F _e → { ( __die `cannot read the signed file` ) ( vec_free [u] pk ) ^ 1 }
+            }
+        }
+        F _e → { ( __die `cannot read verification key` ) ^ 1 }
     }
 }
 
@@ -376,10 +490,95 @@ $ `stdlib/ext/env.nu`
     ( nurl_print `  keygen NAME          write NAME.ek and NAME.dk\n` )
     ( nurl_print `  encaps NAME.ek       encapsulate to a fresh shared secret\n` )
     ( nurl_print `  decaps NAME.dk CT    recover the shared secret\n` )
+    ( nurl_print `  sign-keygen NAME     write NAME.pub and NAME.key (ML-DSA)\n` )
+    ( nurl_print `  sign KEY FILE        sign FILE, writing FILE.sig\n` )
+    ( nurl_print `  verify PUB FILE SIG  check a signature\n` )
     ( nurl_print `  probe HOST...        report each server's TLS key-exchange group\n` )
     ( nurl_print `  bench                operations per second on this machine\n` )
     ( nurl_print `  kat                  self-test against NIST ACVP vectors\n` )
-    ( nurl_print `\nlevels: 512, 768 (default), 1024\n` )
+    ( nurl_print `\nlevels: ML-KEM 512, 768 (default), 1024\n` )
+    ( nurl_print `        ML-DSA 44, 65 (default), 87\n` )
+}
+
+// One subcommand per clause, each returning directly.
+//
+// Written flat rather than as a nested if/else ladder: with nine
+// subcommands the ladder's tail becomes a run of closing braces whose
+// count is the only thing keeping it correct, and miscounting compiles
+// into a different program rather than an error.
+@ __dispatch ArgParser p ( Vec String ) ps s cmd i level → i {
+    : i n ( vec_len [String] ps )
+
+    ? != 0 ( nurl_str_eq cmd `keygen` ) {
+        ? ( __check_level level ) {} { ( __die `ML-KEM level must be 512, 768 or 1024` ) ^ 2 }
+        : String nm ( __opt_str p `out` ? > n 1 ( __pos ps 1 ) `mlkem` )
+        : i rc ( __cmd_keygen level ( string_data nm ) )
+        ( string_free nm )
+        ^ rc
+    } {}
+
+    ? != 0 ( nurl_str_eq cmd `encaps` ) {
+        ? < n 2 { ( __die `encaps needs an encapsulation key file` ) ^ 2 } {}
+        : String o ( __opt_str p `out` `mlkem.ct` )
+        : i rc ( __cmd_encaps ( __pos ps 1 ) ( string_data o ) )
+        ( string_free o )
+        ^ rc
+    } {}
+
+    ? != 0 ( nurl_str_eq cmd `decaps` ) {
+        ? < n 3 { ( __die `decaps needs a decapsulation key and a ciphertext` ) ^ 2 } {}
+        ^ ( __cmd_decaps ( __pos ps 1 ) ( __pos ps 2 ) )
+    } {}
+
+    ? != 0 ( nurl_str_eq cmd `sign-keygen` ) {
+        : i sl ( __opt_int p `level` 65 )
+        ? ( __check_sign_level sl ) {} { ( __die `ML-DSA level must be 44, 65 or 87` ) ^ 2 }
+        : String nm ( __opt_str p `out` ? > n 1 ( __pos ps 1 ) `mldsa` )
+        : i rc ( __cmd_sign_keygen sl ( string_data nm ) )
+        ( string_free nm )
+        ^ rc
+    } {}
+
+    ? != 0 ( nurl_str_eq cmd `sign` ) {
+        ? < n 3 { ( __die `sign needs a signing key and a file` ) ^ 2 } {}
+        // Default output is the input name with .sig appended.
+        : String derived ( string_from ( __pos ps 2 ) )
+        ( string_push_str derived `.sig` )
+        : String o ( __opt_str p `out` ( string_data derived ) )
+        : i rc ( __cmd_sign ( __pos ps 1 ) ( __pos ps 2 ) ( string_data o ) )
+        ( string_free o )
+        ( string_free derived )
+        ^ rc
+    } {}
+
+    ? != 0 ( nurl_str_eq cmd `verify` ) {
+        ? < n 4 { ( __die `verify needs a key, a file and a signature` ) ^ 2 } {}
+        ^ ( __cmd_verify ( __pos ps 1 ) ( __pos ps 2 ) ( __pos ps 3 ) )
+    } {}
+
+    ? != 0 ( nurl_str_eq cmd `probe` ) {
+        ? < n 2 { ( __die `probe needs at least one host` ) ^ 2 } {}
+        : i port ( __opt_int p `port` 443 )
+        ( nurl_print `host                              PQ?  group\n` )
+        : ~ i k 1
+        : ~ i worst 0
+        ~ < k n {
+            : i r ( __cmd_probe ( __pos ps k ) port )
+            ? > r worst { = worst r } {}
+            = k + k 1
+        }
+        ^ worst
+    } {}
+
+    ? != 0 ( nurl_str_eq cmd `bench` ) {
+        ? ( __check_level level ) {} { ( __die `ML-KEM level must be 512, 768 or 1024` ) ^ 2 }
+        ^ ( __cmd_bench level ( __opt_int p `reps` 200 ) )
+    } {}
+
+    ? != 0 ( nurl_str_eq cmd `kat` ) { ^ ( __cmd_kat ) } {}
+
+    ( __die `unknown command (try --help)` )
+    ^ 2
 }
 
 @ main → i {
@@ -410,54 +609,7 @@ $ `stdlib/ext/env.nu`
     : i level ( __opt_int p `level` 768 )
     : ~ i rc 0
 
-    ? ( __check_level level ) {} {
-        ( __die `level must be 512, 768 or 1024` )
-        = rc 2
-    }
-
-    ? == rc 0 {
-        ? != 0 ( nurl_str_eq cmd `keygen` ) {
-            : String nm ( __opt_str p `out` ? > ( vec_len [String] ps ) 1 ( __pos ps 1 ) `mlkem` )
-            = rc ( __cmd_keygen level ( string_data nm ) )
-            ( string_free nm )
-        } {
-            ? != 0 ( nurl_str_eq cmd `encaps` ) {
-                ? < ( vec_len [String] ps ) 2 { ( __die `encaps needs an encapsulation key file` ) = rc 2 } {
-                    : String o ( __opt_str p `out` `mlkem.ct` )
-                    = rc ( __cmd_encaps ( __pos ps 1 ) ( string_data o ) )
-                    ( string_free o )
-                }
-            } {
-                ? != 0 ( nurl_str_eq cmd `decaps` ) {
-                    ? < ( vec_len [String] ps ) 3 { ( __die `decaps needs a decapsulation key and a ciphertext` ) = rc 2 } {
-                        = rc ( __cmd_decaps ( __pos ps 1 ) ( __pos ps 2 ) )
-                    }
-                } {
-                    ? != 0 ( nurl_str_eq cmd `probe` ) {
-                        ? < ( vec_len [String] ps ) 2 { ( __die `probe needs at least one host` ) = rc 2 } {
-                            : i port ( __opt_int p `port` 443 )
-                            ( nurl_print `host                              PQ?  group\n` )
-                            : ~ i k 1
-                            : i n ( vec_len [String] ps )
-                            : ~ i worst 0
-                            ~ < k n {
-                                : i r ( __cmd_probe ( __pos ps k ) port )
-                                ? > r worst { = worst r } {}
-                                = k + k 1
-                            }
-                            = rc worst
-                        }
-                    } {
-                        ? != 0 ( nurl_str_eq cmd `bench` ) {
-                            = rc ( __cmd_bench level ( __opt_int p `reps` 200 ) )
-                        } {
-                            ? != 0 ( nurl_str_eq cmd `kat` ) {
-                                = rc ( __cmd_kat )
-                            } {
-                                ( __die `unknown command (try --help)` )
-                                = rc 2
-                            } } } } } }
-    } {}
+    = rc ( __dispatch p ps cmd level )
 
     // `ps` is a borrow of the parser's own vector — args_free releases it.
     ( args_free p )

--- a/packages/pqc/tests/pqc_test.sh
+++ b/packages/pqc/tests/pqc_test.sh
@@ -18,6 +18,10 @@
 #    5. a truncated ciphertext is refused, not crashed on
 #    6. a file that is not a key is refused by its length
 #    7. all three parameter sets round-trip
+#    8. ML-DSA: sign/verify round trip at all three levels, with the
+#       sizes the standard fixes
+#    9. a tampered file does not verify, a signature does not carry
+#       across to a different key, and signing is hedged
 #
 #  Run from the package dir:  ./tests/pqc_test.sh
 #  Env: NURL (build driver; defaults to ../../nurl.sh in a checkout)
@@ -94,6 +98,48 @@ else ok "junk refused as an encapsulation key"; fi
 if "$PQC" keygen -l 999 -o "$WORK/n" >/dev/null 2>&1; then
     bad "level 999 accepted"
 else ok "invalid level refused"; fi
+
+# 8, 9. ML-DSA
+for lv in 44 65 87; do
+    case $lv in
+        44) pub=1312; key=2560; sg=2420 ;;
+        65) pub=1952; key=4032; sg=3309 ;;
+        87) pub=2592; key=4896; sg=4627 ;;
+    esac
+    "$PQC" sign-keygen -l $lv -o "$WORK/id$lv" >/dev/null || bad "sign-keygen $lv"
+    check "pub size $lv" "$(wc -c < "$WORK/id$lv.pub")" "$pub"
+    check "key size $lv" "$(wc -c < "$WORK/id$lv.key")" "$key"
+
+    printf 'the quick brown fox %s' "$lv" > "$WORK/doc$lv"
+    "$PQC" sign "$WORK/id$lv.key" "$WORK/doc$lv" >/dev/null || bad "sign $lv"
+    check "sig size $lv" "$(wc -c < "$WORK/doc$lv.sig")" "$sg"
+    if "$PQC" verify "$WORK/id$lv.pub" "$WORK/doc$lv" "$WORK/doc$lv.sig" >/dev/null; then
+        ok "sign/verify $lv"
+    else bad "sign/verify $lv"; fi
+
+    printf 'X' | dd of="$WORK/doc$lv" bs=1 seek=0 count=1 conv=notrunc status=none
+    if "$PQC" verify "$WORK/id$lv.pub" "$WORK/doc$lv" "$WORK/doc$lv.sig" >/dev/null 2>&1; then
+        bad "tampered file verified at $lv"
+    else ok "tampered file refused at $lv"; fi
+done
+
+printf 'same text' > "$WORK/x1"
+"$PQC" sign-keygen -l 65 -o "$WORK/other" >/dev/null
+"$PQC" sign "$WORK/id65.key" "$WORK/x1" >/dev/null
+if "$PQC" verify "$WORK/other.pub" "$WORK/x1" "$WORK/x1.sig" >/dev/null 2>&1; then
+    bad "signature verified under the wrong key"
+else ok "wrong key refused"; fi
+
+"$PQC" sign "$WORK/id65.key" "$WORK/x1" -o "$WORK/a.sig" >/dev/null
+"$PQC" sign "$WORK/id65.key" "$WORK/x1" -o "$WORK/b.sig" >/dev/null
+if cmp -s "$WORK/a.sig" "$WORK/b.sig"; then bad "signing is not hedged"; else ok "signing is hedged"; fi
+if "$PQC" verify "$WORK/id65.pub" "$WORK/x1" "$WORK/b.sig" >/dev/null; then
+    ok "second hedged signature verifies"
+else bad "second hedged signature failed"; fi
+
+if "$PQC" sign-keygen -l 99 -o "$WORK/n" >/dev/null 2>&1; then
+    bad "ML-DSA level 99 accepted"
+else ok "invalid ML-DSA level refused"; fi
 
 echo
 if [ "$fails" -eq 0 ]; then echo "PASS"; exit 0; else echo "FAIL ($fails)"; exit 1; fi

--- a/stdlib/std/mldsa.nu
+++ b/stdlib/std/mldsa.nu
@@ -1,0 +1,1306 @@
+// stdlib/std/mldsa.nu — ML-DSA (FIPS 204) in pure NURL.
+//
+// The post-quantum digital signature NIST standardised in August 2024,
+// formerly CRYSTALS-Dilithium. The signing counterpart to std/mlkem.nu:
+// ML-KEM replaces the key exchange, ML-DSA replaces the signature.
+//
+//   level  name          pk     sk     signature   classical analogue
+//   44     ML-DSA-44   1312   2560        2420      AES-128
+//   65     ML-DSA-65   1952   4032        3309      AES-192
+//   87     ML-DSA-87   2592   4896        4627      AES-256
+//
+// API — the three operations:
+//   ( mldsa_keygen i level )                        → *MldsaKeys
+//   ( mldsa_sign i level ( Vec u ) sk
+//                ( Vec u ) msg ( Vec u ) ctx )      → ( Vec u )  signature
+//   ( mldsa_verify i level ( Vec u ) pk ( Vec u ) msg
+//                  ( Vec u ) ctx ( Vec u ) sig )    → b
+//
+// `ctx` is the application context string of FIPS 204 §5.2 — up to 255
+// bytes that bind a signature to its purpose, so a signature made for
+// one protocol cannot be replayed into another. Pass an empty Vec when
+// there is none. Signing is *hedged* by default: it draws 32 fresh
+// random bytes, which keeps a fault or a repeated message from leaking
+// the key the way deterministic signing can.
+//
+// API — the deterministic and internal forms, which FIPS 204 defines
+// and NIST's ACVP vectors exercise. Production callers want the three
+// above.
+//   ( mldsa_keygen_derand level ( Vec u ) xi )      → *MldsaKeys
+//   ( mldsa_sign_internal level ( Vec u ) sk
+//         ( Vec u ) mprime ( Vec u ) rnd )          → ( Vec u )
+//   ( mldsa_verify_internal level ( Vec u ) pk
+//         ( Vec u ) mprime ( Vec u ) sig )          → b
+//
+// Accessors, sizes and cleanup:
+//   ( mldsa_pk *MldsaKeys ) ( mldsa_sk *MldsaKeys ) ( mldsa_keys_free … )
+//   ( mldsa_pk_len level ) ( mldsa_sk_len level ) ( mldsa_sig_len level )
+//
+// ── On timing ──────────────────────────────────────────────────────
+//
+// Signing is a rejection loop: it samples a masking vector, forms a
+// candidate, and starts over if any coefficient falls outside the
+// bounds that would leak the key. So *the number of iterations depends
+// on the key and the message*, and signing time is variable by
+// construction — that is the design of the scheme, not a defect, and
+// FIPS 204 specifies it. What must not vary with the secret is the work
+// inside an iteration, and it does not: the bound checks accumulate
+// over every coefficient rather than exiting early, and the arithmetic
+// is straight-line. Verification is not secret-dependent at all.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/hash_sha3.nu`
+$ `stdlib/std/random.nu`
+$ `stdlib/std/subtle.nu`
+
+// ── Parameters ─────────────────────────────────────────────────────
+//
+// q = 8380417 = 2^23 − 2^13 + 1 and n = 256 are fixed; d = 13 is the
+// number of low bits of t dropped from the public key. The level
+// selects the module dimensions (k, l), the noise width η, the
+// challenge weight τ, the mask range γ1, the rounding modulus γ2, the
+// hint budget ω and the commitment-hash length λ/4.
+
+: MldsaParams {
+    i k
+    i l
+    i eta
+    i tau
+    i gamma1
+    i gamma2
+    i omega
+    i lam  // c~ length in bytes
+    i sbits  // bits per s1/s2 coefficient
+    i zbits  // bits per z coefficient
+    i wbits  // bits per w1 coefficient
+}
+
+@ __mldsa_params i level → MldsaParams {
+    // gamma2 = (q-1)/88 = 95232 for level 44, (q-1)/32 = 261888 otherwise
+    ? == level 65 { ^ @ MldsaParams { 6 5 4 49 524288 261888 55 48 4 20 4 } } {}
+    ? == level 87 { ^ @ MldsaParams { 8 7 2 60 524288 261888 75 64 3 20 4 } } {}
+    ^ @ MldsaParams { 4 4 2 39 131072 95232 80 32 3 18 6 }
+}
+
+@ mldsa_pk_len i level → i {
+    : MldsaParams p ( __mldsa_params level )
+    ^ + 32 * 320 . p k
+}
+
+@ mldsa_sk_len i level → i {
+    : MldsaParams p ( __mldsa_params level )
+    ^ + + 128 * * 32 . p sbits + . p k . p l * 416 . p k
+}
+
+@ mldsa_sig_len i level → i {
+    : MldsaParams p ( __mldsa_params level )
+    ^ + + . p lam * * 32 . p zbits . p l + . p omega . p k
+}
+
+// Where the hint starts inside a signature, and how much room it has.
+//
+// A signature is `c~ ‖ BitPack(z) ‖ HintBitPack(h)`, and the hint is the
+// tail: `omega` index bytes followed by `k` running totals. The layout
+// is public — it is fixed by the parameter set, not by the key — so
+// anything that inspects or validates a signature's encoding can ask
+// for it rather than recompute the arithmetic.
+@ mldsa_hint_offset i level → i {
+    : MldsaParams p ( __mldsa_params level )
+    ^ + . p lam * * 32 . p zbits . p l
+}
+
+@ mldsa_omega i level → i {
+    : MldsaParams p ( __mldsa_params level )
+    ^ . p omega
+}
+
+@ mldsa_module_rank i level → i {
+    : MldsaParams p ( __mldsa_params level )
+    ^ . p k
+}
+
+// ── Arithmetic in Z_q, q = 8380417 ─────────────────────────────────
+//
+// Coefficients are i32; products widen to i64 (`i`) for the length of
+// the multiply. This is the same shape as ML-KEM's i16 arithmetic one
+// width up.
+
+// Montgomery reduction: a·2^-32 mod q. QINV = q^-1 mod 2^32 = 58728449;
+// the i32 truncation is what extracts the low half of the product.
+@ __md_mont i a → i32 {
+    : i32 t * # i32 a # i32 58728449
+    ^ # i32 >> - a * # i t # i 8380417 # i 32
+}
+
+// a mod± q for |a| ≤ 2^31 − 2^22 − 1.
+@ __reduce32 i32 a → i32 {
+    : i32 t >> + a # i32 4194304 # i32 23
+    ^ - a * t # i32 8380417
+}
+
+// Add q if negative, giving a representative in [0, q). The mask is an
+// arithmetic shift rather than a comparison, so no branch depends on a
+// coefficient's sign.
+@ __caddq i32 a → i32 {
+    ^ + a & >> a # i32 31 # i32 8380417
+}
+
+@ __md_fqmul i32 a i32 b → i32 {
+    ^ ( __md_mont * # i a # i b )
+}
+
+// r mod± m, in (−m/2, m/2].
+@ __modpm i r i m → i {
+    : ~ i x % r m
+    ? < x 0 { = x + x m } {}
+    ? > x / m 2 { = x - x m } {}
+    ^ x
+}
+
+// ζ^brv8(i)·2^32 mod q for i in 0..255 — the NTT twiddle factors in
+// Montgomery domain and bit-reversed order, centred on zero. Entry 0 is
+// never read (the transform starts at index 1) and is held at zero, as
+// the reference implementation does.
+@ __mldsa_zetas → ( Vec i32 ) {
+    : ( Vec i32 ) v ( vec_with_cap [i32] 256 )
+    : b _l ( vec_set_len [i32] v 256 )
+    : *i32 p ( vec_data [i32] v )
+    = . p 0 # i32 0 = . p 1 # i32 25847 = . p 2 # i32 -2608894 = . p 3 # i32 -518909
+    = . p 4 # i32 237124 = . p 5 # i32 -777960 = . p 6 # i32 -876248 = . p 7 # i32 466468
+    = . p 8 # i32 1826347 = . p 9 # i32 2353451 = . p 10 # i32 -359251 = . p 11 # i32 -2091905
+    = . p 12 # i32 3119733 = . p 13 # i32 -2884855 = . p 14 # i32 3111497 = . p 15 # i32 2680103
+    = . p 16 # i32 2725464 = . p 17 # i32 1024112 = . p 18 # i32 -1079900 = . p 19 # i32 3585928
+    = . p 20 # i32 -549488 = . p 21 # i32 -1119584 = . p 22 # i32 2619752 = . p 23 # i32 -2108549
+    = . p 24 # i32 -2118186 = . p 25 # i32 -3859737 = . p 26 # i32 -1399561 = . p 27 # i32 -3277672
+    = . p 28 # i32 1757237 = . p 29 # i32 -19422 = . p 30 # i32 4010497 = . p 31 # i32 280005
+    = . p 32 # i32 2706023 = . p 33 # i32 95776 = . p 34 # i32 3077325 = . p 35 # i32 3530437
+    = . p 36 # i32 -1661693 = . p 37 # i32 -3592148 = . p 38 # i32 -2537516 = . p 39 # i32 3915439
+    = . p 40 # i32 -3861115 = . p 41 # i32 -3043716 = . p 42 # i32 3574422 = . p 43 # i32 -2867647
+    = . p 44 # i32 3539968 = . p 45 # i32 -300467 = . p 46 # i32 2348700 = . p 47 # i32 -539299
+    = . p 48 # i32 -1699267 = . p 49 # i32 -1643818 = . p 50 # i32 3505694 = . p 51 # i32 -3821735
+    = . p 52 # i32 3507263 = . p 53 # i32 -2140649 = . p 54 # i32 -1600420 = . p 55 # i32 3699596
+    = . p 56 # i32 811944 = . p 57 # i32 531354 = . p 58 # i32 954230 = . p 59 # i32 3881043
+    = . p 60 # i32 3900724 = . p 61 # i32 -2556880 = . p 62 # i32 2071892 = . p 63 # i32 -2797779
+    = . p 64 # i32 -3930395 = . p 65 # i32 -1528703 = . p 66 # i32 -3677745 = . p 67 # i32 -3041255
+    = . p 68 # i32 -1452451 = . p 69 # i32 3475950 = . p 70 # i32 2176455 = . p 71 # i32 -1585221
+    = . p 72 # i32 -1257611 = . p 73 # i32 1939314 = . p 74 # i32 -4083598 = . p 75 # i32 -1000202
+    = . p 76 # i32 -3190144 = . p 77 # i32 -3157330 = . p 78 # i32 -3632928 = . p 79 # i32 126922
+    = . p 80 # i32 3412210 = . p 81 # i32 -983419 = . p 82 # i32 2147896 = . p 83 # i32 2715295
+    = . p 84 # i32 -2967645 = . p 85 # i32 -3693493 = . p 86 # i32 -411027 = . p 87 # i32 -2477047
+    = . p 88 # i32 -671102 = . p 89 # i32 -1228525 = . p 90 # i32 -22981 = . p 91 # i32 -1308169
+    = . p 92 # i32 -381987 = . p 93 # i32 1349076 = . p 94 # i32 1852771 = . p 95 # i32 -1430430
+    = . p 96 # i32 -3343383 = . p 97 # i32 264944 = . p 98 # i32 508951 = . p 99 # i32 3097992
+    = . p 100 # i32 44288 = . p 101 # i32 -1100098 = . p 102 # i32 904516 = . p 103 # i32 3958618
+    = . p 104 # i32 -3724342 = . p 105 # i32 -8578 = . p 106 # i32 1653064 = . p 107 # i32 -3249728
+    = . p 108 # i32 2389356 = . p 109 # i32 -210977 = . p 110 # i32 759969 = . p 111 # i32 -1316856
+    = . p 112 # i32 189548 = . p 113 # i32 -3553272 = . p 114 # i32 3159746 = . p 115 # i32 -1851402
+    = . p 116 # i32 -2409325 = . p 117 # i32 -177440 = . p 118 # i32 1315589 = . p 119 # i32 1341330
+    = . p 120 # i32 1285669 = . p 121 # i32 -1584928 = . p 122 # i32 -812732 = . p 123 # i32 -1439742
+    = . p 124 # i32 -3019102 = . p 125 # i32 -3881060 = . p 126 # i32 -3628969 = . p 127 # i32 3839961
+    = . p 128 # i32 2091667 = . p 129 # i32 3407706 = . p 130 # i32 2316500 = . p 131 # i32 3817976
+    = . p 132 # i32 -3342478 = . p 133 # i32 2244091 = . p 134 # i32 -2446433 = . p 135 # i32 -3562462
+    = . p 136 # i32 266997 = . p 137 # i32 2434439 = . p 138 # i32 -1235728 = . p 139 # i32 3513181
+    = . p 140 # i32 -3520352 = . p 141 # i32 -3759364 = . p 142 # i32 -1197226 = . p 143 # i32 -3193378
+    = . p 144 # i32 900702 = . p 145 # i32 1859098 = . p 146 # i32 909542 = . p 147 # i32 819034
+    = . p 148 # i32 495491 = . p 149 # i32 -1613174 = . p 150 # i32 -43260 = . p 151 # i32 -522500
+    = . p 152 # i32 -655327 = . p 153 # i32 -3122442 = . p 154 # i32 2031748 = . p 155 # i32 3207046
+    = . p 156 # i32 -3556995 = . p 157 # i32 -525098 = . p 158 # i32 -768622 = . p 159 # i32 -3595838
+    = . p 160 # i32 342297 = . p 161 # i32 286988 = . p 162 # i32 -2437823 = . p 163 # i32 4108315
+    = . p 164 # i32 3437287 = . p 165 # i32 -3342277 = . p 166 # i32 1735879 = . p 167 # i32 203044
+    = . p 168 # i32 2842341 = . p 169 # i32 2691481 = . p 170 # i32 -2590150 = . p 171 # i32 1265009
+    = . p 172 # i32 4055324 = . p 173 # i32 1247620 = . p 174 # i32 2486353 = . p 175 # i32 1595974
+    = . p 176 # i32 -3767016 = . p 177 # i32 1250494 = . p 178 # i32 2635921 = . p 179 # i32 -3548272
+    = . p 180 # i32 -2994039 = . p 181 # i32 1869119 = . p 182 # i32 1903435 = . p 183 # i32 -1050970
+    = . p 184 # i32 -1333058 = . p 185 # i32 1237275 = . p 186 # i32 -3318210 = . p 187 # i32 -1430225
+    = . p 188 # i32 -451100 = . p 189 # i32 1312455 = . p 190 # i32 3306115 = . p 191 # i32 -1962642
+    = . p 192 # i32 -1279661 = . p 193 # i32 1917081 = . p 194 # i32 -2546312 = . p 195 # i32 -1374803
+    = . p 196 # i32 1500165 = . p 197 # i32 777191 = . p 198 # i32 2235880 = . p 199 # i32 3406031
+    = . p 200 # i32 -542412 = . p 201 # i32 -2831860 = . p 202 # i32 -1671176 = . p 203 # i32 -1846953
+    = . p 204 # i32 -2584293 = . p 205 # i32 -3724270 = . p 206 # i32 594136 = . p 207 # i32 -3776993
+    = . p 208 # i32 -2013608 = . p 209 # i32 2432395 = . p 210 # i32 2454455 = . p 211 # i32 -164721
+    = . p 212 # i32 1957272 = . p 213 # i32 3369112 = . p 214 # i32 185531 = . p 215 # i32 -1207385
+    = . p 216 # i32 -3183426 = . p 217 # i32 162844 = . p 218 # i32 1616392 = . p 219 # i32 3014001
+    = . p 220 # i32 810149 = . p 221 # i32 1652634 = . p 222 # i32 -3694233 = . p 223 # i32 -1799107
+    = . p 224 # i32 -3038916 = . p 225 # i32 3523897 = . p 226 # i32 3866901 = . p 227 # i32 269760
+    = . p 228 # i32 2213111 = . p 229 # i32 -975884 = . p 230 # i32 1717735 = . p 231 # i32 472078
+    = . p 232 # i32 -426683 = . p 233 # i32 1723600 = . p 234 # i32 -1803090 = . p 235 # i32 1910376
+    = . p 236 # i32 -1667432 = . p 237 # i32 -1104333 = . p 238 # i32 -260646 = . p 239 # i32 -3833893
+    = . p 240 # i32 -2939036 = . p 241 # i32 -2235985 = . p 242 # i32 -420899 = . p 243 # i32 -2286327
+    = . p 244 # i32 183443 = . p 245 # i32 -976891 = . p 246 # i32 1612842 = . p 247 # i32 -3545687
+    = . p 248 # i32 -554416 = . p 249 # i32 3919660 = . p 250 # i32 -48306 = . p 251 # i32 -1362209
+    = . p 252 # i32 3937738 = . p 253 # i32 1400424 = . p 254 # i32 -846154 = . p 255 # i32 1976782
+    ^ v
+}
+
+// ── The number-theoretic transform ─────────────────────────────────
+//
+// Unlike ML-KEM's, this one is complete: q − 1 is divisible by 512, so
+// a primitive 512th root of unity exists and the transform runs all
+// eight layers down to 256 constants. Multiplication in the NTT domain
+// is therefore an ordinary pointwise product, not a degree-1 basemul.
+
+@ __md_ntt * i32 r i off * i32 zetas → v {
+    : ~ i m 0
+    : ~ i len 128
+    ~ >= len 1 {
+        : ~ i start 0
+        ~ < start 256 {
+            = m + m 1
+            : i32 zeta . zetas m
+            : ~ i j start
+            ~ < j + start len {
+                : i32 t ( __md_fqmul zeta . r + off + j len )
+                = . r + off + j len - . r + off j t
+                = . r + off j + . r + off j t
+                = j + j 1
+            }
+            = start + j len
+        }
+        = len >> len 1
+    }
+}
+
+// The inverse transform, leaving the result in Montgomery domain.
+// f = 2^64 / 256 mod q = 41978 folds the 1/256 scaling and the
+// Montgomery factor into one final multiply.
+@ __md_invntt * i32 r i off * i32 zetas → v {
+    : ~ i m 256
+    : ~ i len 1
+    ~ < len 256 {
+        : ~ i start 0
+        ~ < start 256 {
+            = m - m 1
+            : i32 zeta - # i32 0 . zetas m
+            : ~ i j start
+            ~ < j + start len {
+                : i32 t . r + off j
+                = . r + off j + t . r + off + j len
+                = . r + off + j len - t . r + off + j len
+                = . r + off + j len ( __md_fqmul zeta . r + off + j len )
+                = j + j 1
+            }
+            = start + j len
+        }
+        = len << len 1
+    }
+    : ~ i i 0
+    ~ < i 256 {
+        = . r + off i ( __md_fqmul . r + off i # i32 41978 )
+        = i + i 1
+    }
+}
+
+// ── Polynomial helpers ─────────────────────────────────────────────
+
+@ __md_poly_zero i n → ( Vec i32 ) {
+    : i m ? > n 0 n 1
+    : ( Vec i32 ) v ( vec_with_cap [i32] m )
+    : b _l ( vec_set_len [i32] v m )
+    : *i32 p ( vec_data [i32] v )
+    : ~ i i 0
+    ~ < i m { = . p i # i32 0 = i + i 1 }
+    ^ v
+}
+
+@ __md_poly_add * i32 r i ro * i32 a i ao * i32 b i bo → v {
+    : ~ i i 0
+    ~ < i 256 { = . r + ro i + . a + ao i . b + bo i = i + i 1 }
+}
+
+@ __md_poly_sub * i32 r i ro * i32 a i ao * i32 b i bo → v {
+    : ~ i i 0
+    ~ < i 256 { = . r + ro i - . a + ao i . b + bo i = i + i 1 }
+}
+
+@ __md_poly_reduce * i32 r i off → v {
+    : ~ i i 0
+    ~ < i 256 { = . r + off i ( __reduce32 . r + off i ) = i + i 1 }
+}
+
+@ __poly_caddq * i32 r i off → v {
+    : ~ i i 0
+    ~ < i 256 { = . r + off i ( __caddq . r + off i ) = i + i 1 }
+}
+
+@ __poly_shiftl * i32 r i off → v {
+    : ~ i i 0
+    ~ < i 256 { = . r + off i << . r + off i # i32 13 = i + i 1 }
+}
+
+@ __poly_pointwise * i32 r i ro * i32 a i ao * i32 b i bo → v {
+    : ~ i i 0
+    ~ < i 256 {
+        = . r + ro i ( __md_fqmul . a + ao i . b + bo i )
+        = i + i 1
+    }
+}
+
+// Accumulate Σ a_j ∘ b_j over l polynomials, in NTT domain.
+@ __polyvec_pointwise_acc * i32 r i ro * i32 a i ao * i32 b i bo i n ( Vec i32 ) scratch → v {
+    : *i32 t ( vec_data [i32] scratch )
+    ( __poly_pointwise r ro a ao b bo )
+    : ~ i i 1
+    ~ < i n {
+        ( __poly_pointwise t 0 a + ao * 256 i b + bo * 256 i )
+        ( __md_poly_add r ro r ro t 0 )
+        = i + i 1
+    }
+}
+
+// ‖a‖∞ < bound, over the centred representatives.
+//
+// The whole polynomial is scanned even once a coefficient has failed:
+// an early return would make the loop's length depend on where the
+// out-of-range coefficient sits, which is secret.
+@ __poly_chknorm * i32 a i off i bound → b {
+    : ~ i bad 0
+    : ~ i i 0
+    ~ < i 256 {
+        : i32 x . a + off i
+        // |x| without a branch: t = x - 2·(x>>31 & x) is |x| for the
+        // centred range this is called on.
+        : i32 s >> x # i32 31
+        : i32 t - x & s << x # i32 1
+        = bad | bad ? >= # i t bound 1 0
+        = i + i 1
+    }
+    ^ == bad 0
+}
+
+// ── Rounding ───────────────────────────────────────────────────────
+
+// Power2Round: split r into high bits r1 and centred low bits r0 with
+// r = r1·2^13 + r0.
+@ __poly_power2round * i32 a1 i o1 * i32 a0 i o0 * i32 a i oa → v {
+    : ~ i i 0
+    ~ < i 256 {
+        : i r ( __caddq . a + oa i )
+        : i r0 ( __modpm r 8192 )
+        = . a1 + o1 i # i32 >> - r r0 13
+        = . a0 + o0 i # i32 r0
+        = i + i 1
+    }
+}
+
+// Decompose: r = r1·2γ2 + r0 with r0 centred, except at the wrap point
+// where r1 is forced to 0 — the case that makes HighBits take only
+// (q−1)/(2γ2) distinct values.
+@ __poly_decompose * i32 a1 i o1 * i32 a0 i o0 * i32 a i oa i g2 → v {
+    : ~ i i 0
+    ~ < i 256 {
+        : i r ( __caddq . a + oa i )
+        : i r0 ( __modpm r * 2 g2 )
+        ? == - r r0 8380416 {
+            = . a1 + o1 i # i32 0
+            = . a0 + o0 i # i32 - r0 1
+        } {
+            = . a1 + o1 i # i32 / - r r0 * 2 g2
+            = . a0 + o0 i # i32 r0
+        }
+        = i + i 1
+    }
+}
+
+@ __highbits i r i g2 → i {
+    : i x ( __caddq # i32 r )
+    : i r0 ( __modpm x * 2 g2 )
+    ? == - x r0 8380416 { ^ 0 } {}
+    ^ / - x r0 * 2 g2
+}
+
+// UseHint: recover HighBits(r + z) from HighBits(r) and one bit.
+@ __usehint i h i r i g2 → i {
+    : i m / 8380416 * 2 g2
+    : i x ( __caddq # i32 r )
+    : i r0 ( __modpm x * 2 g2 )
+    : ~ i r1 0
+    ? == - x r0 8380416 { = r1 0 } { = r1 / - x r0 * 2 g2 }
+    ? == h 0 { ^ r1 } {}
+    ? > r0 0 { ^ % + r1 1 m } {}
+    ^ % + - r1 1 m m
+}
+
+// ── Bit packing ────────────────────────────────────────────────────
+//
+// SimpleBitPack writes coefficients as they are; BitPack writes b − x,
+// which maps a centred range onto an unsigned one. Both go through one
+// bit cursor rather than a hand-unrolled routine per width — ML-DSA
+// uses 3, 4, 6, 10, 13, 18 and 20 bits in different places.
+
+@ __simple_bitpack * i32 a i off i bits ( Vec u ) out → v {
+    : i mask - << 1 bits 1
+    : ~ i acc 0
+    : ~ i nb 0
+    : ~ i i 0
+    ~ < i 256 {
+        = acc | acc << & # i . a + off i mask nb
+        = nb + nb bits
+        ~ >= nb 8 {
+            ( vec_push [u] out # u & acc 255 )
+            = acc >> acc 8
+            = nb - nb 8
+        }
+        = i + i 1
+    }
+}
+
+@ __simple_bitunpack ( Vec u ) src i soff i bits * i32 r i off → v {
+    : *u sp ( vec_data [u] src )
+    : i mask - << 1 bits 1
+    : ~ i acc 0
+    : ~ i nb 0
+    : ~ i pos 0
+    : ~ i i 0
+    ~ < i 256 {
+        ~ < nb bits {
+            = acc | acc << # i . sp + soff pos nb
+            = nb + nb 8
+            = pos + pos 1
+        }
+        = . r + off i # i32 & acc mask
+        = acc >> acc bits
+        = nb - nb bits
+        = i + i 1
+    }
+}
+
+// BitPack(w, a, b): each coefficient stored as b − w[i].
+@ __bitpack * i32 a i off i bits i b ( Vec u ) out → v {
+    : i mask - << 1 bits 1
+    : ~ i acc 0
+    : ~ i nb 0
+    : ~ i i 0
+    ~ < i 256 {
+        = acc | acc << & - b # i . a + off i mask nb
+        = nb + nb bits
+        ~ >= nb 8 {
+            ( vec_push [u] out # u & acc 255 )
+            = acc >> acc 8
+            = nb - nb 8
+        }
+        = i + i 1
+    }
+}
+
+@ __bitunpack ( Vec u ) src i soff i bits i b * i32 r i off → v {
+    : *u sp ( vec_data [u] src )
+    : i mask - << 1 bits 1
+    : ~ i acc 0
+    : ~ i nb 0
+    : ~ i pos 0
+    : ~ i i 0
+    ~ < i 256 {
+        ~ < nb bits {
+            = acc | acc << # i . sp + soff pos nb
+            = nb + nb 8
+            = pos + pos 1
+        }
+        = . r + off i # i32 - b & acc mask
+        = acc >> acc bits
+        = nb - nb bits
+        = i + i 1
+    }
+}
+
+// ── Sampling ───────────────────────────────────────────────────────
+
+// One SHAKE stream, pulled a block at a time.
+//
+// A block is squeezed and consumed; the sponge is one continuous
+// stream, so refilling costs one permutation rather than a permutation
+// per candidate.
+
+// RejNTTPoly (FIPS 204 Algorithm 30): coefficients uniform in [0, q)
+// from SHAKE128(ρ ‖ s ‖ r), three bytes per candidate with the top bit
+// masked off. Rejection depends only on ρ, which is public.
+@ __poly_uniform * i32 r i off ( Vec u ) rho i x1 i x2 → v {
+    : *Sha3 xof ( shake128_init )
+    ( sha3_absorb xof rho )
+    : ( Vec u ) idx ( vec_new [u] )
+    ( vec_push [u] idx # u x1 )
+    ( vec_push [u] idx # u x2 )
+    ( sha3_absorb xof idx )
+    ( vec_free [u] idx )
+    : ~ i ctr 0
+    ~ < ctr 256 {
+        : ( Vec u ) buf ( sha3_squeeze xof 168 )
+        : *u bp ( vec_data [u] buf )
+        : ~ i pos 0
+        ~ & < ctr 256 <= + pos 3 168 {
+            : i z | | # i . bp pos << # i . bp + pos 1 8 << & # i . bp + pos 2 127 16
+            = pos + pos 3
+            ? < z 8380417 {
+                = . r + off ctr # i32 z
+                = ctr + ctr 1
+            } {}
+        }
+        ( vec_free [u] buf )
+    }
+    ( sha3_free xof )
+}
+
+// CoeffFromHalfByte (Algorithm 15) — the η-bounded sampler's inner map.
+// Returns 100 for a rejected nibble (outside any legal coefficient).
+@ __coeff_from_halfbyte i b i eta → i {
+    ? == eta 2 {
+        ? < b 15 { ^ - 2 % b 5 } {}
+        ^ 100
+    } {}
+    ? < b 9 { ^ - 4 b } {}
+    ^ 100
+}
+
+// RejBoundedPoly (Algorithm 31): coefficients in [−η, η] from
+// SHAKE256(ρ' ‖ nonce), two candidates per byte.
+@ __poly_uniform_eta * i32 r i off ( Vec u ) rhop i nonce i eta → v {
+    : *Sha3 xof ( shake256_init )
+    ( sha3_absorb xof rhop )
+    : ( Vec u ) nb ( vec_new [u] )
+    ( vec_push [u] nb # u & nonce 255 )
+    ( vec_push [u] nb # u & >> nonce 8 255 )
+    ( sha3_absorb xof nb )
+    ( vec_free [u] nb )
+    : ~ i ctr 0
+    ~ < ctr 256 {
+        : ( Vec u ) buf ( sha3_squeeze xof 136 )
+        : *u bp ( vec_data [u] buf )
+        : ~ i pos 0
+        ~ & < ctr 256 < pos 136 {
+            : i byte # i . bp pos
+            = pos + pos 1
+            : i c0 ( __coeff_from_halfbyte & byte 15 eta )
+            ? & != c0 100 < ctr 256 {
+                = . r + off ctr # i32 c0
+                = ctr + ctr 1
+            } {}
+            : i c1 ( __coeff_from_halfbyte >> byte 4 eta )
+            ? & != c1 100 < ctr 256 {
+                = . r + off ctr # i32 c1
+                = ctr + ctr 1
+            } {}
+        }
+        ( vec_free [u] buf )
+    }
+    ( sha3_free xof )
+}
+
+// ExpandMask's per-polynomial half (Algorithm 34): a masking polynomial
+// with coefficients in (−γ1, γ1], unpacked straight from the stream.
+@ __poly_uniform_gamma1 * i32 r i off ( Vec u ) rhop i nonce i g1 i zbits → v {
+    : *Sha3 xof ( shake256_init )
+    ( sha3_absorb xof rhop )
+    : ( Vec u ) nb ( vec_new [u] )
+    ( vec_push [u] nb # u & nonce 255 )
+    ( vec_push [u] nb # u & >> nonce 8 255 )
+    ( sha3_absorb xof nb )
+    ( vec_free [u] nb )
+    : ( Vec u ) buf ( sha3_squeeze xof * 32 zbits )
+    ( sha3_free xof )
+    ( __bitunpack buf 0 zbits g1 r off )
+    ( vec_free [u] buf )
+}
+
+// SampleInBall (Algorithm 29): a polynomial with exactly τ coefficients
+// in {−1, +1} and the rest zero, placed by a Fisher-Yates shuffle whose
+// randomness is the commitment hash.
+@ __poly_challenge * i32 c i off ( Vec u ) ctilde i tau → v {
+    : ~ i i 0
+    ~ < i 256 { = . c + off i # i32 0 = i + i 1 }
+    : *Sha3 xof ( shake256_init )
+    ( sha3_absorb xof ctilde )
+    : ( Vec u ) sb ( sha3_squeeze xof 8 )
+    : *u sp ( vec_data [u] sb )
+    : ~ i signs 0
+    : ~ i b 0
+    ~ < b 8 { = signs | signs << # i . sp b * 8 b = b + b 1 }
+    ( vec_free [u] sb )
+    : ~ i pos 256
+    : ( Vec u ) buf ( sha3_squeeze xof 136 )
+    : ~ ( Vec u ) cur buf
+    : ~ i cp 0
+    : ~ i n - 256 tau
+    ~ < n 256 {
+        : ~ i j 256
+        ~ > j n {
+            ? >= cp ( vec_len [u] cur ) {
+                ( vec_free [u] cur )
+                = cur ( sha3_squeeze xof 136 )
+                = cp 0
+            } {}
+            : *u cbp ( vec_data [u] cur )
+            = j # i . cbp cp
+            = cp + cp 1
+        }
+        = . c + off n . c + off j
+        = . c + off j # i32 - 1 * 2 & signs 1
+        = signs >> signs 1
+        = n + n 1
+    }
+    ( vec_free [u] cur )
+    ( sha3_free xof )
+}
+
+// ── Hint packing ───────────────────────────────────────────────────
+//
+// The hint is a sparse bit per coefficient, at most ω set across all k
+// polynomials. It travels as the indices of the set bits followed by k
+// running totals.
+
+@ __hint_pack * i32 h ( Vec u ) out i k i omega → v {
+    : ~ i idx 0
+    : ( Vec u ) body ( vec_new [u] )
+    : ~ i i 0
+    ~ < i omega { ( vec_push [u] body # u 0 ) = i + i 1 }
+    : *u bp ( vec_data [u] body )
+    : ( Vec u ) tail ( vec_new [u] )
+    = i 0
+    ~ < i k {
+        : ~ i j 0
+        ~ < j 256 {
+            ? != # i . h + * 256 i j 0 {
+                ? < idx omega { = . bp idx # u j = idx + idx 1 } {}
+            } {}
+            = j + j 1
+        }
+        ( vec_push [u] tail # u idx )
+        = i + i 1
+    }
+    ( bytes_extend_bytes out body )
+    ( bytes_extend_bytes out tail )
+    ( vec_free [u] tail )
+    ( vec_free [u] body )
+}
+
+// Unpack, with the malleability checks FIPS 204 §7.2 requires.
+//
+// These are not optional. Without them a signature has more than one
+// valid encoding — a verifier that accepts a non-canonical hint accepts
+// a forgery derived from a genuine signature. The three rules: the
+// running totals must be non-decreasing and within ω, the indices
+// inside one polynomial must be strictly increasing, and every byte
+// past the last index must be zero.
+//
+// Returns F when the encoding is not canonical.
+@ __hint_unpack ( Vec u ) sig i soff * i32 h i k i omega → b {
+    : ~ i i 0
+    ~ < i * 256 k { = . h i # i32 0 = i + i 1 }
+    : *u sp ( vec_data [u] sig )
+    : ~ i idx 0
+    = i 0
+    ~ < i k {
+        : i total # i . sp + soff + omega i
+        ? | < total idx > total omega { ^ F } {}
+        : i first idx
+        ~ < idx total {
+            ? & > idx first <= # i . sp + soff idx # i . sp + soff - idx 1 { ^ F } {}
+            = . h + * 256 i # i . sp + soff idx # i32 1
+            = idx + idx 1
+        }
+        = i + i 1
+    }
+    : ~ i j idx
+    ~ < j omega {
+        ? != # i . sp + soff j 0 { ^ F } {}
+        = j + j 1
+    }
+    ^ T
+}
+
+// ── Key and signature encoding ─────────────────────────────────────
+
+@ __pack_pk ( Vec u ) rho * i32 t1 i k ( Vec u ) out → v {
+    ( bytes_extend_bytes out rho )
+    : ~ i i 0
+    ~ < i k { ( __simple_bitpack t1 * 256 i 10 out ) = i + i 1 }
+}
+
+@ __pack_sk ( Vec u ) rho ( Vec u ) kk ( Vec u ) tr * i32 s1 * i32 s2 * i32 t0
+MldsaParams p ( Vec u ) out → v {
+    ( bytes_extend_bytes out rho )
+    ( bytes_extend_bytes out kk )
+    ( bytes_extend_bytes out tr )
+    : ~ i i 0
+    ~ < i . p l { ( __bitpack s1 * 256 i . p sbits . p eta out ) = i + i 1 }
+    = i 0
+    ~ < i . p k { ( __bitpack s2 * 256 i . p sbits . p eta out ) = i + i 1 }
+    = i 0
+    ~ < i . p k { ( __bitpack t0 * 256 i 13 4096 out ) = i + i 1 }
+}
+
+// ── Key generation ─────────────────────────────────────────────────
+
+: MldsaKeys {
+    ( Vec u ) pk
+    ( Vec u ) sk
+}
+
+@ mldsa_pk * MldsaKeys h → ( Vec u ) { ^ . h pk }
+
+@ mldsa_sk * MldsaKeys h → ( Vec u ) { ^ . h sk }
+
+@ mldsa_keys_free * MldsaKeys h → v {
+    ( vec_free [u] . h pk )
+    ( vec_free [u] . h sk )
+    ( nurl_free # s h )
+}
+
+// ML-DSA.KeyGen_internal (Algorithm 6).
+@ mldsa_keygen_derand i level ( Vec u ) xi → *MldsaKeys {
+    : MldsaParams p ( __mldsa_params level )
+    : i k . p k
+    : i l . p l
+    : ( Vec i32 ) zt ( __mldsa_zetas )
+    : *i32 zp ( vec_data [i32] zt )
+
+    // (ρ, ρ', K) ← H(ξ ‖ k ‖ l, 128)
+    : ( Vec u ) hin ( vec_new [u] )
+    ( bytes_extend_bytes hin xi )
+    ( vec_push [u] hin # u k )
+    ( vec_push [u] hin # u l )
+    : ( Vec u ) g ( shake256_pure hin 128 )
+    ( vec_free [u] hin )
+    : ( Vec u ) rho ( bytes_slice g 0 32 )
+    : ( Vec u ) rhop ( bytes_slice g 32 96 )
+    : ( Vec u ) kk ( bytes_slice g 96 128 )
+    ( vec_free [u] g )
+
+    // Â ← ExpandA(ρ) — the seed suffix is (column, row), in that order
+    : ( Vec i32 ) a ( __md_poly_zero * 256 * k l )
+    : *i32 ap ( vec_data [i32] a )
+    : ~ i r 0
+    ~ < r k {
+        : ~ i s 0
+        ~ < s l {
+            ( __poly_uniform ap * 256 + * r l s rho s r )
+            = s + s 1
+        }
+        = r + r 1
+    }
+
+    // (s1, s2) ← ExpandS(ρ')
+    : ( Vec i32 ) s1 ( __md_poly_zero * 256 l )
+    : ( Vec i32 ) s2 ( __md_poly_zero * 256 k )
+    : *i32 s1p ( vec_data [i32] s1 )
+    : *i32 s2p ( vec_data [i32] s2 )
+    : ~ i i 0
+    ~ < i l { ( __poly_uniform_eta s1p * 256 i rhop i . p eta ) = i + i 1 }
+    = i 0
+    ~ < i k { ( __poly_uniform_eta s2p * 256 i rhop + i l . p eta ) = i + i 1 }
+
+    // t ← NTT^-1(Â ∘ NTT(s1)) + s2
+    : ( Vec i32 ) s1h ( __md_poly_zero * 256 l )
+    : *i32 s1hp ( vec_data [i32] s1h )
+    = i 0
+    ~ < i * 256 l { = . s1hp i . s1p i = i + i 1 }
+    = i 0
+    ~ < i l { ( __md_ntt s1hp * 256 i zp ) = i + i 1 }
+
+    : ( Vec i32 ) t ( __md_poly_zero * 256 k )
+    : ( Vec i32 ) scratch ( __md_poly_zero 256 )
+    : *i32 tp ( vec_data [i32] t )
+    = i 0
+    ~ < i k {
+        ( __polyvec_pointwise_acc tp * 256 i ap * 256 * i l s1hp 0 l scratch )
+        ( __md_poly_reduce tp * 256 i )
+        ( __md_invntt tp * 256 i zp )
+        ( __md_poly_add tp * 256 i tp * 256 i s2p * 256 i )
+        ( __poly_caddq tp * 256 i )
+        = i + i 1
+    }
+
+    // (t1, t0) ← Power2Round(t)
+    : ( Vec i32 ) t1 ( __md_poly_zero * 256 k )
+    : ( Vec i32 ) t0 ( __md_poly_zero * 256 k )
+    : *i32 t1p ( vec_data [i32] t1 )
+    : *i32 t0p ( vec_data [i32] t0 )
+    = i 0
+    ~ < i k {
+        ( __poly_power2round t1p * 256 i t0p * 256 i tp * 256 i )
+        = i + i 1
+    }
+
+    : ( Vec u ) pk ( vec_with_cap [u] ( mldsa_pk_len level ) )
+    ( __pack_pk rho t1p k pk )
+    : ( Vec u ) tr ( shake256_pure pk 64 )
+    : ( Vec u ) sk ( vec_with_cap [u] ( mldsa_sk_len level ) )
+    ( __pack_sk rho kk tr s1p s2p t0p p sk )
+
+    : *MldsaKeys h # *MldsaKeys ( nurl_alloc Z MldsaKeys )
+    = . h pk pk
+    = . h sk sk
+
+    ( vec_free [u] tr )
+    ( vec_free [i32] t0 ) ( vec_free [i32] t1 )
+    ( vec_free [i32] scratch ) ( vec_free [i32] t )
+    ( vec_free [i32] s1h ) ( vec_free [i32] s2 ) ( vec_free [i32] s1 )
+    ( vec_free [i32] a )
+    ( vec_free [u] kk ) ( vec_free [u] rhop ) ( vec_free [u] rho )
+    ( vec_free [i32] zt )
+    ^ h
+}
+
+@ mldsa_keygen i level → *MldsaKeys {
+    : ( Vec u ) xi ( rand_bytes 32 )
+    : *MldsaKeys h ( mldsa_keygen_derand level xi )
+    ( vec_free [u] xi )
+    ^ h
+}
+
+// ── Key and signature decoding ─────────────────────────────────────
+
+@ __unpack_pk ( Vec u ) pk * i32 t1 i k → v {
+    : ~ i i 0
+    ~ < i k { ( __simple_bitunpack pk + 32 * 320 i 10 t1 * 256 i ) = i + i 1 }
+}
+
+@ __unpack_sk ( Vec u ) sk * i32 s1 * i32 s2 * i32 t0 MldsaParams p → v {
+    : i eb * 32 . p sbits
+    : ~ i off 128
+    : ~ i i 0
+    ~ < i . p l {
+        ( __bitunpack sk + off * eb i . p sbits . p eta s1 * 256 i )
+        = i + i 1
+    }
+    = off + off * . p l eb
+    = i 0
+    ~ < i . p k {
+        ( __bitunpack sk + off * eb i . p sbits . p eta s2 * 256 i )
+        = i + i 1
+    }
+    = off + off * . p k eb
+    = i 0
+    ~ < i . p k {
+        ( __bitunpack sk + off * 416 i 13 4096 t0 * 256 i )
+        = i + i 1
+    }
+}
+
+// w1Encode (FIPS 204 §7.2) — the commitment, packed at the width the
+// level's γ2 implies.
+@ __pack_w1 * i32 w1 i k i wbits ( Vec u ) out → v {
+    : ~ i i 0
+    ~ < i k { ( __simple_bitpack w1 * 256 i wbits out ) = i + i 1 }
+}
+
+// ── Signing ────────────────────────────────────────────────────────
+
+// ML-DSA.Sign_internal (Algorithm 7).
+//
+// Returns an empty Vec if the rejection loop fails to terminate within
+// a generous bound. That cannot happen for a well-formed key — the
+// expected iteration count is between 4 and 7 depending on the level —
+// but an unbounded loop on a corrupted secret key would hang a server,
+// and failing is recoverable where hanging is not.
+@ mldsa_sign_mu i level ( Vec u ) sk ( Vec u ) mu ( Vec u ) rnd → ( Vec u ) {
+    : MldsaParams p ( __mldsa_params level )
+    : i k . p k
+    : i l . p l
+    : i g1 . p gamma1
+    : i g2 . p gamma2
+    : i beta * . p tau . p eta
+    : ( Vec i32 ) zt ( __mldsa_zetas )
+    : *i32 zp ( vec_data [i32] zt )
+
+    : ( Vec u ) rho ( bytes_slice sk 0 32 )
+    : ( Vec u ) kk ( bytes_slice sk 32 64 )
+    : ( Vec u ) tr ( bytes_slice sk 64 128 )
+    : ( Vec i32 ) s1 ( __md_poly_zero * 256 l )
+    : ( Vec i32 ) s2 ( __md_poly_zero * 256 k )
+    : ( Vec i32 ) t0 ( __md_poly_zero * 256 k )
+    : *i32 s1p ( vec_data [i32] s1 )
+    : *i32 s2p ( vec_data [i32] s2 )
+    : *i32 t0p ( vec_data [i32] t0 )
+    ( __unpack_sk sk s1p s2p t0p p )
+
+    : ~ i i 0
+    ~ < i l { ( __md_ntt s1p * 256 i zp ) = i + i 1 }
+    = i 0
+    ~ < i k { ( __md_ntt s2p * 256 i zp ) = i + i 1 }
+    = i 0
+    ~ < i k { ( __md_ntt t0p * 256 i zp ) = i + i 1 }
+
+    : ( Vec i32 ) a ( __md_poly_zero * 256 * k l )
+    : *i32 ap ( vec_data [i32] a )
+    : ~ i r 0
+    ~ < r k {
+        : ~ i s 0
+        ~ < s l { ( __poly_uniform ap * 256 + * r l s rho s r ) = s + s 1 }
+        = r + r 1
+    }
+
+    // ρ'' ← H(K ‖ rnd ‖ μ, 64)
+    : *Sha3 hr ( shake256_init )
+    ( sha3_absorb hr kk )
+    ( sha3_absorb hr rnd )
+    ( sha3_absorb hr mu )
+    : ( Vec u ) rhopp ( sha3_squeeze hr 64 )
+    ( sha3_free hr )
+
+    : ( Vec i32 ) y ( __md_poly_zero * 256 l )
+    : ( Vec i32 ) yh ( __md_poly_zero * 256 l )
+    : ( Vec i32 ) w ( __md_poly_zero * 256 k )
+    : ( Vec i32 ) w1 ( __md_poly_zero * 256 k )
+    : ( Vec i32 ) w0 ( __md_poly_zero * 256 k )
+    : ( Vec i32 ) cp ( __md_poly_zero 256 )
+    : ( Vec i32 ) cs1 ( __md_poly_zero * 256 l )
+    : ( Vec i32 ) cs2 ( __md_poly_zero * 256 k )
+    : ( Vec i32 ) ct0 ( __md_poly_zero * 256 k )
+    : ( Vec i32 ) hint ( __md_poly_zero * 256 k )
+    : ( Vec i32 ) scratch ( __md_poly_zero 256 )
+    : *i32 yp ( vec_data [i32] y )
+    : *i32 yhp ( vec_data [i32] yh )
+    : *i32 wp ( vec_data [i32] w )
+    : *i32 w1p ( vec_data [i32] w1 )
+    : *i32 w0p ( vec_data [i32] w0 )
+    : *i32 cpp ( vec_data [i32] cp )
+    : *i32 cs1p ( vec_data [i32] cs1 )
+    : *i32 cs2p ( vec_data [i32] cs2 )
+    : *i32 ct0p ( vec_data [i32] ct0 )
+    : *i32 hp ( vec_data [i32] hint )
+
+    : ~ ( Vec u ) sig ( vec_new [u] )
+    : ~ i kappa 0
+    : ~ i tries 0
+    : ~ b done F
+    ~ & ! done < tries 1000 {
+        = tries + tries 1
+
+        // y ← ExpandMask(ρ'', κ) ; w ← NTT^-1(Â ∘ NTT(y))
+        = i 0
+        ~ < i l {
+            ( __poly_uniform_gamma1 yp * 256 i rhopp + kappa i g1 . p zbits )
+            = i + i 1
+        }
+        = i 0
+        ~ < i * 256 l { = . yhp i . yp i = i + i 1 }
+        = i 0
+        ~ < i l { ( __md_ntt yhp * 256 i zp ) = i + i 1 }
+        = i 0
+        ~ < i k {
+            ( __polyvec_pointwise_acc wp * 256 i ap * 256 * i l yhp 0 l scratch )
+            ( __md_poly_reduce wp * 256 i )
+            ( __md_invntt wp * 256 i zp )
+            ( __poly_caddq wp * 256 i )
+            ( __poly_decompose w1p * 256 i w0p * 256 i wp * 256 i g2 )
+            = i + i 1
+        }
+
+        // c~ ← H(μ ‖ w1Encode(w1), λ/4) ; c ← SampleInBall(c~)
+        : ( Vec u ) w1enc ( vec_new [u] )
+        ( __pack_w1 w1p k . p wbits w1enc )
+        : *Sha3 hc ( shake256_init )
+        ( sha3_absorb hc mu )
+        ( sha3_absorb hc w1enc )
+        : ( Vec u ) ctilde ( sha3_squeeze hc . p lam )
+        ( sha3_free hc )
+        ( vec_free [u] w1enc )
+        ( __poly_challenge cpp 0 ctilde . p tau )
+        ( __md_ntt cpp 0 zp )
+
+        // z ← y + ⟨⟨c·s1⟩⟩
+        = i 0
+        ~ < i l {
+            ( __poly_pointwise cs1p * 256 i cpp 0 s1p * 256 i )
+            ( __md_invntt cs1p * 256 i zp )
+            ( __md_poly_add cs1p * 256 i cs1p * 256 i yp * 256 i )
+            ( __md_poly_reduce cs1p * 256 i )
+            = i + i 1
+        }
+        : ~ b ok T
+        = i 0
+        ~ < i l {
+            = ok & ok ( __poly_chknorm cs1p * 256 i - g1 beta )
+            = i + i 1
+        }
+
+        // r0 ← LowBits(w − ⟨⟨c·s2⟩⟩)
+        ? ok {
+            = i 0
+            ~ < i k {
+                ( __poly_pointwise cs2p * 256 i cpp 0 s2p * 256 i )
+                ( __md_invntt cs2p * 256 i zp )
+                ( __md_poly_sub w0p * 256 i w0p * 256 i cs2p * 256 i )
+                ( __md_poly_reduce w0p * 256 i )
+                = i + i 1
+            }
+            = i 0
+            ~ < i k {
+                = ok & ok ( __poly_chknorm w0p * 256 i - g2 beta )
+                = i + i 1
+            }
+        } {}
+
+        // h ← MakeHint(−⟨⟨c·t0⟩⟩, w − ⟨⟨c·s2⟩⟩ + ⟨⟨c·t0⟩⟩)
+        ? ok {
+            = i 0
+            ~ < i k {
+                ( __poly_pointwise ct0p * 256 i cpp 0 t0p * 256 i )
+                ( __md_invntt ct0p * 256 i zp )
+                ( __md_poly_reduce ct0p * 256 i )
+                = i + i 1
+            }
+            = i 0
+            ~ < i k {
+                = ok & ok ( __poly_chknorm ct0p * 256 i g2 )
+                = i + i 1
+            }
+        } {}
+
+        ? ok {
+            : ~ i ones 0
+            = i 0
+            ~ < i k {
+                ( __md_poly_add w0p * 256 i w0p * 256 i ct0p * 256 i )
+                : ~ i j 0
+                ~ < j 256 {
+                    // MakeHint(z, r) with z = −ct0 and r = w0 + ct0:
+                    // HighBits(r) differs from HighBits(r + z), where
+                    // r + z is the low part alone.
+                    : i r0 # i . w0p + * 256 i j
+                    : i r1 # i . w1p + * 256 i j
+                    : i zz - # i32 0 . ct0p + * 256 i j
+                    : i hb0 ( __highbits + r0 * r1 * 2 g2 g2 )
+                    : i hb1 ( __highbits + + r0 * r1 * 2 g2 zz g2 )
+                    : i bit ? != hb0 hb1 1 0
+                    = . hp + * 256 i j # i32 bit
+                    = ones + ones bit
+                    = j + j 1
+                }
+                = i + i 1
+            }
+            ? > ones . p omega { = ok F } {}
+        } {}
+
+        ? ok {
+            ( vec_free [u] sig )
+            = sig ( vec_with_cap [u] ( mldsa_sig_len level ) )
+            ( bytes_extend_bytes sig ctilde )
+            = i 0
+            ~ < i l { ( __bitpack cs1p * 256 i . p zbits g1 sig ) = i + i 1 }
+            ( __hint_pack hp sig k . p omega )
+            = done T
+        } {}
+        ( vec_free [u] ctilde )
+        = kappa + kappa l
+    }
+
+    ( vec_free [i32] scratch ) ( vec_free [i32] hint ) ( vec_free [i32] ct0 )
+    ( vec_free [i32] cs2 ) ( vec_free [i32] cs1 ) ( vec_free [i32] cp )
+    ( vec_free [i32] w0 ) ( vec_free [i32] w1 ) ( vec_free [i32] w )
+    ( vec_free [i32] yh ) ( vec_free [i32] y )
+    ( vec_free [u] rhopp )
+    ( vec_free [i32] a )
+    ( vec_free [i32] t0 ) ( vec_free [i32] s2 ) ( vec_free [i32] s1 )
+    ( vec_free [u] tr ) ( vec_free [u] kk ) ( vec_free [u] rho )
+    ( vec_free [i32] zt )
+    ^ sig
+}
+
+// μ ← H(tr ‖ M', 64) — the message representative, bound to the public
+// key through tr so a signature cannot be transplanted onto another key.
+@ __mldsa_mu ( Vec u ) tr ( Vec u ) mprime → ( Vec u ) {
+    : *Sha3 h ( shake256_init )
+    ( sha3_absorb h tr )
+    ( sha3_absorb h mprime )
+    : ( Vec u ) mu ( sha3_squeeze h 64 )
+    ( sha3_free h )
+    ^ mu
+}
+
+// ML-DSA.Sign_internal (Algorithm 7) over a message representative.
+@ mldsa_sign_internal i level ( Vec u ) sk ( Vec u ) mprime ( Vec u ) rnd → ( Vec u ) {
+    : ( Vec u ) tr ( bytes_slice sk 64 128 )
+    : ( Vec u ) mu ( __mldsa_mu tr mprime )
+    : ( Vec u ) sig ( mldsa_sign_mu level sk mu rnd )
+    ( vec_free [u] mu )
+    ( vec_free [u] tr )
+    ^ sig
+}
+
+// ── Verification ───────────────────────────────────────────────────
+
+// ML-DSA.Verify_internal (Algorithm 8).
+@ mldsa_verify_mu i level ( Vec u ) pk ( Vec u ) mu ( Vec u ) sig → b {
+    : MldsaParams p ( __mldsa_params level )
+    : i k . p k
+    : i l . p l
+    : i g1 . p gamma1
+    : i g2 . p gamma2
+    : i beta * . p tau . p eta
+    ? != ( vec_len [u] pk ) ( mldsa_pk_len level ) { ^ F } {}
+    ? != ( vec_len [u] sig ) ( mldsa_sig_len level ) { ^ F } {}
+
+    : ( Vec i32 ) zt ( __mldsa_zetas )
+    : *i32 zp ( vec_data [i32] zt )
+    : ( Vec u ) rho ( bytes_slice pk 0 32 )
+    : ( Vec i32 ) t1 ( __md_poly_zero * 256 k )
+    : *i32 t1p ( vec_data [i32] t1 )
+    ( __unpack_pk pk t1p k )
+
+    : ( Vec u ) ctilde ( bytes_slice sig 0 . p lam )
+    : ( Vec i32 ) z ( __md_poly_zero * 256 l )
+    : *i32 zpz ( vec_data [i32] z )
+    : i zb * 32 . p zbits
+    : ~ i i 0
+    ~ < i l {
+        ( __bitunpack sig + . p lam * zb i . p zbits g1 zpz * 256 i )
+        = i + i 1
+    }
+    : ( Vec i32 ) hint ( __md_poly_zero * 256 k )
+    : *i32 hp ( vec_data [i32] hint )
+    : b hok ( __hint_unpack sig + . p lam * zb l hp k . p omega )
+
+    : ~ b ok hok
+    // ‖z‖∞ < γ1 − β, checked before anything is done with z.
+    = i 0
+    ~ < i l { = ok & ok ( __poly_chknorm zpz * 256 i - g1 beta ) = i + i 1 }
+
+    ? ok {
+        : ( Vec i32 ) a ( __md_poly_zero * 256 * k l )
+        : *i32 ap ( vec_data [i32] a )
+        : ~ i r 0
+        ~ < r k {
+            : ~ i s 0
+            ~ < s l { ( __poly_uniform ap * 256 + * r l s rho s r ) = s + s 1 }
+            = r + r 1
+        }
+        : ( Vec i32 ) cp ( __md_poly_zero 256 )
+        : *i32 cpp ( vec_data [i32] cp )
+        ( __poly_challenge cpp 0 ctilde . p tau )
+        ( __md_ntt cpp 0 zp )
+
+        : ( Vec i32 ) zh ( __md_poly_zero * 256 l )
+        : *i32 zhp ( vec_data [i32] zh )
+        = i 0
+        ~ < i * 256 l { = . zhp i . zpz i = i + i 1 }
+        = i 0
+        ~ < i l { ( __md_ntt zhp * 256 i zp ) = i + i 1 }
+
+        : ( Vec i32 ) t1h ( __md_poly_zero * 256 k )
+        : *i32 t1hp ( vec_data [i32] t1h )
+        = i 0
+        ~ < i * 256 k { = . t1hp i . t1p i = i + i 1 }
+        = i 0
+        ~ < i k {
+            ( __poly_shiftl t1hp * 256 i )
+            ( __md_ntt t1hp * 256 i zp )
+            = i + i 1
+        }
+
+        : ( Vec i32 ) wa ( __md_poly_zero * 256 k )
+        : ( Vec i32 ) tmp ( __md_poly_zero 256 )
+        : ( Vec i32 ) scratch ( __md_poly_zero 256 )
+        : *i32 wap ( vec_data [i32] wa )
+        : *i32 tmpp ( vec_data [i32] tmp )
+        = i 0
+        ~ < i k {
+            ( __polyvec_pointwise_acc wap * 256 i ap * 256 * i l zhp 0 l scratch )
+            ( __poly_pointwise tmpp 0 cpp 0 t1hp * 256 i )
+            ( __md_poly_sub wap * 256 i wap * 256 i tmpp 0 )
+            ( __md_poly_reduce wap * 256 i )
+            ( __md_invntt wap * 256 i zp )
+            ( __poly_caddq wap * 256 i )
+            = i + i 1
+        }
+
+        // w1' ← UseHint(h, w'approx)
+        : ( Vec i32 ) w1 ( __md_poly_zero * 256 k )
+        : *i32 w1p ( vec_data [i32] w1 )
+        = i 0
+        ~ < i k {
+            : ~ i j 0
+            ~ < j 256 {
+                = . w1p + * 256 i j
+                # i32 ( __usehint # i . hp + * 256 i j # i . wap + * 256 i j g2 )
+                = j + j 1
+            }
+            = i + i 1
+        }
+        : ( Vec u ) w1enc ( vec_new [u] )
+        ( __pack_w1 w1p k . p wbits w1enc )
+        : *Sha3 hc ( shake256_init )
+        ( sha3_absorb hc mu )
+        ( sha3_absorb hc w1enc )
+        : ( Vec u ) c2 ( sha3_squeeze hc . p lam )
+        ( sha3_free hc )
+        ( vec_free [u] w1enc )
+        // Constant-time: the comparison itself is not secret, but a
+        // length-dependent early exit is a habit worth not forming.
+        = ok & ok ( constant_time_eq_vec ctilde c2 )
+
+        ( vec_free [u] c2 )
+        ( vec_free [i32] w1 )
+        ( vec_free [i32] scratch ) ( vec_free [i32] tmp ) ( vec_free [i32] wa )
+        ( vec_free [i32] t1h ) ( vec_free [i32] zh ) ( vec_free [i32] cp )
+        ( vec_free [i32] a )
+    } {}
+
+    ( vec_free [i32] hint ) ( vec_free [i32] z ) ( vec_free [u] ctilde )
+    ( vec_free [i32] t1 ) ( vec_free [u] rho ) ( vec_free [i32] zt )
+    ^ ok
+}
+
+// ML-DSA.Verify_internal (Algorithm 8) over a message representative.
+@ mldsa_verify_internal i level ( Vec u ) pk ( Vec u ) mprime ( Vec u ) sig → b {
+    ? != ( vec_len [u] pk ) ( mldsa_pk_len level ) { ^ F } {}
+    : ( Vec u ) tr ( shake256_pure pk 64 )
+    : ( Vec u ) mu ( __mldsa_mu tr mprime )
+    : b ok ( mldsa_verify_mu level pk mu sig )
+    ( vec_free [u] mu )
+    ( vec_free [u] tr )
+    ^ ok
+}
+
+// ── The external interface ─────────────────────────────────────────
+
+// M' = 0x00 ‖ |ctx| ‖ ctx ‖ M (FIPS 204 §5.2). The domain byte and the
+// context length are what stop a signature made for one application
+// being replayed into another.
+@ __mldsa_mprime ( Vec u ) msg ( Vec u ) ctx → ( Vec u ) {
+    : ( Vec u ) m ( vec_new [u] )
+    ( vec_push [u] m # u 0 )
+    ( vec_push [u] m # u ( vec_len [u] ctx ) )
+    ( bytes_extend_bytes m ctx )
+    ( bytes_extend_bytes m msg )
+    ^ m
+}
+
+// Sign `msg` under `sk`, bound to the context string `ctx` (empty Vec
+// for none). Hedged: 32 fresh random bytes go into the per-signature
+// nonce, so a repeated message does not produce a repeated signature.
+// Returns an empty Vec if ctx is longer than the 255 bytes FIPS 204
+// allows.
+@ mldsa_sign i level ( Vec u ) sk ( Vec u ) msg ( Vec u ) ctx → ( Vec u ) {
+    ? > ( vec_len [u] ctx ) 255 { ^ ( vec_new [u] ) } {}
+    : ( Vec u ) mp ( __mldsa_mprime msg ctx )
+    : ( Vec u ) rnd ( rand_bytes 32 )
+    : ( Vec u ) sig ( mldsa_sign_internal level sk mp rnd )
+    ( vec_free [u] rnd )
+    ( vec_free [u] mp )
+    ^ sig
+}
+
+// The deterministic variant: rnd is 32 zero bytes, so the same key and
+// message always give the same signature. Interoperable, and what the
+// ACVP "deterministic" vectors exercise — but hedged signing above is
+// the better default, since it survives a fault or a repeated nonce.
+@ mldsa_sign_deterministic i level ( Vec u ) sk ( Vec u ) msg ( Vec u ) ctx → ( Vec u ) {
+    ? > ( vec_len [u] ctx ) 255 { ^ ( vec_new [u] ) } {}
+    : ( Vec u ) mp ( __mldsa_mprime msg ctx )
+    : ( Vec u ) rnd ( vec_with_cap [u] 32 )
+    : ~ i i 0
+    ~ < i 32 { ( vec_push [u] rnd # u 0 ) = i + i 1 }
+    : ( Vec u ) sig ( mldsa_sign_internal level sk mp rnd )
+    ( vec_free [u] rnd )
+    ( vec_free [u] mp )
+    ^ sig
+}
+
+@ mldsa_verify i level ( Vec u ) pk ( Vec u ) msg ( Vec u ) ctx ( Vec u ) sig → b {
+    ? > ( vec_len [u] ctx ) 255 { ^ F } {}
+    : ( Vec u ) mp ( __mldsa_mprime msg ctx )
+    : b ok ( mldsa_verify_internal level pk mp sig )
+    ( vec_free [u] mp )
+    ^ ok
+}

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -332,6 +332,28 @@ $ `stdlib/std/pkey.nu`
     ^ ( tls_alpn_selected # *TlsConn tp )
 }
 
+// The key-exchange group this connection negotiated, as its IANA
+// number — 4588 X25519MLKEM768, 29 x25519, 23 secp256r1 — or 0 for a
+// plaintext conn or one that has not got that far.
+//
+// Worth asking rather than assuming, on either side. A peer that has
+// not deployed ML-KEM falls back to a classical group silently, and
+// nothing else about the connection looks different; a server that
+// wants to log, require or report post-quantum key exchange has no
+// other way to find out.
+@ tcp_tls_group TcpConn c → i {
+    : i tp ( __conn_tlsptr c )
+    ? == tp 0 { ^ 0 } {}
+    ^ ( tls_group # *TlsConn tp )
+}
+
+// T when this connection's key exchange has a post-quantum component,
+// so its forward secrecy survives an adversary recording it today and
+// factoring later.
+@ tcp_is_post_quantum TcpConn c → b {
+    ^ == ( tcp_tls_group c ) 4588
+}
+
 // Open a plain (unencrypted) TCP client connection. Returns a
 // polymorphic TcpConn (kind 0) usable with the same tcp_read/tcp_write
 // family as accepted connections. For an encrypted connection use

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -8,11 +8,18 @@
 // the client keys; tls.nu's client functions are hardwired the other way).
 //
 // Scope: TLS 1.3 only; an EC P-256 leaf (CertificateVerify signed with
-// ecdsa_secp256r1_sha256) OR an RSA leaf (rsa_pss_rsae_sha256); the X25519
-// and secp256r1 groups; the AES-128-GCM / ChaCha20-Poly1305 cipher suites
-// — i.e. exactly what tls.nu's client offers, so the two interoperate. A
-// full certificate chain (leaf + intermediates) is supported via the
-// tls_cert_entry-framed cert_chain argument.
+// ecdsa_secp256r1_sha256) OR an RSA leaf (rsa_pss_rsae_sha256); the
+// X25519MLKEM768, X25519 and secp256r1 groups; the AES-128-GCM /
+// ChaCha20-Poly1305 cipher suites — i.e. exactly what tls.nu's client
+// offers, so the two interoperate. A full certificate chain (leaf +
+// intermediates) is supported via the tls_cert_entry-framed cert_chain
+// argument.
+//
+// On X25519MLKEM768 the server is the *encapsulating* side: the client
+// sends an ML-KEM encapsulation key and gets back a ciphertext, not a
+// public key. `tcp_tls_group` / `tcp_is_post_quantum` (std/net.nu)
+// report what a given connection settled on, which is worth asking —
+// a client without ML-KEM falls back to a classical group silently.
 //
 //   ( tls_accept     i raw ( Vec u ) cert_chain ( Vec u ) priv )
 //   ( tls_accept_rsa i raw ( Vec u ) cert_chain ( Vec u ) n ( Vec u ) e ( Vec u ) d )
@@ -34,6 +41,7 @@ $ `stdlib/std/tls.nu`
 $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/hkdf.nu`
 $ `stdlib/std/x25519.nu`
+$ `stdlib/std/mlkem.nu`
 $ `stdlib/std/ecdsa_p256.nu`
 $ `stdlib/std/rsa.nu`
 $ `stdlib/std/chacha20poly1305.nu`
@@ -161,6 +169,27 @@ $ `stdlib/std/aes_gcm.nu`
         ? == et want { = found + p 4 } { = p + + p 4 el }
     }
     ^ found
+}
+
+// The client's key_exchange for one named group, or an empty Vec if it
+// did not send a share for it.
+//
+// Separate from picking the group because preference and presence are
+// different questions: the client lists its shares in ITS order, and a
+// server that takes the first one it recognises lets the client decide
+// the group. Asking for the groups we want, most-preferred first, keeps
+// that decision here.
+@ __srv_find_share ( Vec u ) ch i ks i ksend i want → ( Vec u ) {
+    : ~ i kp + ks 2
+    ~ < + kp 4 + ksend 1 {
+        : i g ( _rdint ch kp 2 )
+        : i klen ( _rdint ch + kp 2 2 )
+        ? == g want {
+            ^ ( bytes_slice ch + kp 4 + + kp 4 klen )
+        } {}
+        = kp + + kp 4 klen
+    }
+    ^ ( vec_new [u] )
 }
 
 // ── server-flight message builders ──────────────────────────────────
@@ -343,25 +372,82 @@ $ `stdlib/std/aes_gcm.nu`
     : i ksend + + ks 2 kslen
     : ~ i grp 0
     : ~ ( Vec u ) cpub ( vec_new [u] )
-    ~ & < + kp 4 + ksend 1 == grp 0 {
-        : i g ( _rdint ch kp 2 )
-        : i klen ( _rdint ch + kp 2 2 )
-        ? | == g 29 == g 23 {
-            = grp g
+    // Preference order, most-preferred first: X25519MLKEM768, x25519,
+    // secp256r1. A share whose length is wrong for its group is ignored
+    // rather than trusted — every one of these is a fixed size, and the
+    // slicing below depends on it.
+    : ( Vec u ) sh_pq ( __srv_find_share ch ks ksend 4588 )
+    ? == ( vec_len [u] sh_pq ) 1216 {
+        = grp 4588
+        ( vec_free [u] cpub )
+        = cpub ( bytes_slice sh_pq 0 1216 )
+    } {}
+    ( vec_free [u] sh_pq )
+    ? == grp 0 {
+        : ( Vec u ) sh_x ( __srv_find_share ch ks ksend 29 )
+        ? == ( vec_len [u] sh_x ) 32 {
+            = grp 29
             ( vec_free [u] cpub )
-            = cpub ( bytes_slice ch + kp 4 + + kp 4 klen )
+            = cpub ( bytes_slice sh_x 0 32 )
         } {}
-        = kp + + kp 4 klen
-    }
+        ( vec_free [u] sh_x )
+    } {}
+    ? == grp 0 {
+        : ( Vec u ) sh_p ( __srv_find_share ch ks ksend 23 )
+        ? == ( vec_len [u] sh_p ) 65 {
+            = grp 23
+            ( vec_free [u] cpub )
+            = cpub ( bytes_slice sh_p 0 65 )
+        } {}
+        ( vec_free [u] sh_p )
+    } {}
+    = kp ksend
     ? == grp 0 {
         ( vec_free [u] ch ) ( vec_free [u] crand ) ( vec_free [u] cpub ) ( vec_free [u] tr ) ( nurl_free # s c )
         ^ ( __srv_fail raw )
     } {}
 
-    // ── server ephemeral + ECDHE ──
+    // ── server ephemeral + shared secret ──
+    //
+    // For X25519MLKEM768 the server is the *encapsulating* side: the
+    // client sent an ML-KEM encapsulation key, and the reply carries the
+    // ciphertext, not a public key. Both halves keep the group's byte
+    // order — ML-KEM first, X25519 second — in the share and in the
+    // secret alike.
+    = . c kx_group grp
     : ( Vec u ) eph ( __srv_rand 32 )
-    : ( Vec u ) spub ? == grp 29 ( x25519_base eph ) ( p256_ecdh_keygen eph )
-    : ( Vec u ) ecdhe ? == grp 29 ( x25519 eph cpub ) ( p256_ecdh_shared eph cpub )
+    : ~ ( Vec u ) spub ( vec_new [u] )
+    : ~ ( Vec u ) ecdhe ( vec_new [u] )
+    ? == grp 4588 {
+        : ( Vec u ) cek ( bytes_slice cpub 0 1184 )
+        : ( Vec u ) cx ( bytes_slice cpub 1184 1216 )
+        : *MlkemEncap en ( mlkem_encaps 768 cek )
+        : ( Vec u ) sx ( x25519_base eph )
+        : ( Vec u ) xs ( x25519 eph cx )
+        ( vec_free [u] spub )
+        = spub ( bytes_slice ( mlkem_ct en ) 0 1088 )
+        ( bytes_extend_bytes spub sx )
+        // The X25519 half is checked on its own, before the halves are
+        // joined: a low-order client point zeroes it while the ML-KEM
+        // half stays random, so the concatenation would look fine.
+        // Leaving `ecdhe` empty here makes the shared all-zero test
+        // below fail closed.
+        ? ( _all_zero xs ) {} {
+            ( vec_free [u] ecdhe )
+            = ecdhe ( bytes_slice ( mlkem_ss en ) 0 32 )
+            ( bytes_extend_bytes ecdhe xs )
+        }
+        ( vec_free [u] xs )
+        ( vec_free [u] sx )
+        ( mlkem_encap_free en )
+        ( vec_free [u] cx )
+        ( vec_free [u] cek )
+    } {
+        ( vec_free [u] spub )
+        = spub ? == grp 29 ( x25519_base eph ) ( p256_ecdh_keygen eph )
+        ( vec_free [u] ecdhe )
+        = ecdhe ? == grp 29 ( x25519 eph cpub ) ( p256_ecdh_shared eph cpub )
+    }
     // H3: RFC 8446 §7.4.2 — reject a degenerate (all-zero) ECDHE secret from a
     // low-order client key_share before it can seed the key schedule.
     ? ( _all_zero ecdhe ) {

--- a/tools/mldsa_acvp_gate.nu
+++ b/tools/mldsa_acvp_gate.nu
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 The NURL Project Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// tools/mldsa_acvp_gate.nu — run NIST's published ACVP vectors for
+// ML-DSA against stdlib/std/mldsa.nu.
+//
+//   mldsa_acvp_gate <keyGen.json> <sigGen.json> <sigVer.json>
+//
+// The JSON is NIST's own `internalProjection.json`, carrying expected
+// outputs beside the inputs, so every case is a byte-exact comparison.
+//
+//   keyGen   seed        -> pk, sk
+//   sigGen   sk, message -> signature   (deterministic and hedged,
+//                                        internal and external, and the
+//                                        external-mu interface)
+//   sigVer   pk, message, signature -> accept / reject
+//
+// The sigVer set is the valuable half: only a fifth of its cases are
+// valid signatures. The rest are tampered in one of four specific ways
+// — modified message, modified commitment c~, modified z, modified
+// hint — and a verifier that accepts any of them is broken in a way no
+// amount of round-tripping would reveal.
+//
+// HashML-DSA (the `preHash` groups) is not implemented, so those cases
+// are counted as skipped and the count is printed rather than hidden.
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/std/mldsa.nu`
+
+@ __str Json o s key → s {
+    ?? ( json_obj_get o key ) { T v → { ^ ( json_str_data v ) } F → { ^ `` } }
+}
+
+@ __bool Json o s key → b {
+    ?? ( json_obj_get o key ) { T v → { ^ ( json_bool_val v ) } F → { ^ F } }
+}
+
+@ __eqhex ( Vec u ) got s want → b {
+    ?? ( bytes_from_hex want ) {
+        T w → { : b ok ( bytes_eq got w ) ( vec_free [u] w ) ^ ok }
+        F _e → { ^ F }
+    }
+}
+
+@ __hexv s h → ( Vec u ) {
+    ? == ( nurl_str_len h ) 0 { ^ ( vec_new [u] ) } {}
+    ?? ( bytes_from_hex h ) { T v → { ^ v } F _e → { ^ ( vec_new [u] ) } }
+}
+
+@ __level Json g → i {
+    : s ps ( __str g `parameterSet` )
+    ? != 0 ( nurl_str_eq ps `ML-DSA-65` ) { ^ 65 } {}
+    ? != 0 ( nurl_str_eq ps `ML-DSA-87` ) { ^ 87 } {}
+    ^ 44
+}
+
+@ __load s path → Json {
+    : !String IoErr rd ( read_file path )
+    : String txt ?? rd { T v → { v } F _e → { ( nurl_print `no file\n` ) ( string_new ) } }
+    : Json j ?? ( json_parse ( string_data txt ) ) { T v → { v } F _e → { ( nurl_print `bad json\n` ) ( json_null ) } }
+    ( string_free txt )
+    ^ j
+}
+
+@ __report s what i pass i fail i skip → v {
+    : String s ( string_new )
+    ( string_push_str s what )
+    ( string_push_str s `: ` )
+    ( string_push_int s pass )
+    ( string_push_str s ` passed, ` )
+    ( string_push_int s fail )
+    ( string_push_str s ` failed, ` )
+    ( string_push_int s skip )
+    ( string_push_str s ` skipped\n` )
+    ( nurl_print ( string_data s ) )
+    ( string_free s )
+}
+
+@ main → i {
+    : ~ i totfail 0
+
+    // ── keyGen ──
+    : Json kg ( __load ( nurl_argv_get 1 ) )
+    : Json kgg ?? ( json_obj_get kg `testGroups` ) { T v → { v } F → { ( json_null ) } }
+    : ~ i kp 0
+    : ~ i kf 0
+    : ~ i gi 0
+    ~ < gi ( json_arr_len kgg ) {
+        : Json g ?? ( json_arr_get kgg gi ) { T v → { v } F → { ( json_null ) } }
+        : i level ( __level g )
+        : Json ts ?? ( json_obj_get g `tests` ) { T v → { v } F → { ( json_null ) } }
+        : ~ i ti 0
+        ~ < ti ( json_arr_len ts ) {
+            : Json tc ?? ( json_arr_get ts ti ) { T v → { v } F → { ( json_null ) } }
+            : ( Vec u ) xi ( __hexv ( __str tc `seed` ) )
+            : *MldsaKeys ks ( mldsa_keygen_derand level xi )
+            ? & ( __eqhex ( mldsa_pk ks ) ( __str tc `pk` ) ) ( __eqhex ( mldsa_sk ks ) ( __str tc `sk` ) )
+            { = kp + kp 1 } { = kf + kf 1 }
+            ( mldsa_keys_free ks )
+            ( vec_free [u] xi )
+            = ti + ti 1
+        }
+        = gi + gi 1
+    }
+    ( json_free kg )
+    ( __report `keyGen` kp kf 0 )
+    = totfail + totfail kf
+
+    // ── sigGen: internal interface and external pure only.
+    // preHash needs SHA-2, which is a different module's job; those
+    // groups are counted as skipped rather than silently ignored.
+    : Json sg ( __load ( nurl_argv_get 2 ) )
+    : Json sgg ?? ( json_obj_get sg `testGroups` ) { T v → { v } F → { ( json_null ) } }
+    : ~ i sp 0
+    : ~ i sf 0
+    : ~ i ss 0
+    = gi 0
+    ~ < gi ( json_arr_len sgg ) {
+        : Json g ?? ( json_arr_get sgg gi ) { T v → { v } F → { ( json_null ) } }
+        : i level ( __level g )
+        : s iface ( __str g `signatureInterface` )
+        : s ph ( __str g `preHash` )
+        : b det ( __bool g `deterministic` )
+        : b emu ( __bool g `externalMu` )
+        : b internal != 0 ( nurl_str_eq iface `internal` )
+        : b pure != 0 ( nurl_str_eq ph `pure` )
+        : Json ts ?? ( json_obj_get g `tests` ) { T v → { v } F → { ( json_null ) } }
+        : ~ i ti 0
+        ~ < ti ( json_arr_len ts ) {
+            : Json tc ?? ( json_arr_get ts ti ) { T v → { v } F → { ( json_null ) } }
+            ? emu {
+                : ( Vec u ) sk ( __hexv ( __str tc `sk` ) )
+                : ( Vec u ) mu ( __hexv ( __str tc `mu` ) )
+                : ( Vec u ) rnd ? det ( __hexv `0000000000000000000000000000000000000000000000000000000000000000` ) ( __hexv ( __str tc `rnd` ) )
+                : ( Vec u ) sig ( mldsa_sign_mu level sk mu rnd )
+                ? ( __eqhex sig ( __str tc `signature` ) ) { = sp + sp 1 } { = sf + sf 1 }
+                ( vec_free [u] sig ) ( vec_free [u] rnd ) ( vec_free [u] mu ) ( vec_free [u] sk )
+            } {
+                ? ! | internal pure { = ss + ss 1 } {
+                    : ( Vec u ) sk ( __hexv ( __str tc `sk` ) )
+                    : ( Vec u ) msg ( __hexv ( __str tc `message` ) )
+                    : ( Vec u ) rnd ? det ( __hexv `0000000000000000000000000000000000000000000000000000000000000000` ) ( __hexv ( __str tc `rnd` ) )
+                    : ~ ( Vec u ) mp ( vec_new [u] )
+                    ? internal {
+                        ( vec_free [u] mp )
+                        = mp ( bytes_slice msg 0 ( vec_len [u] msg ) )
+                    } {
+                        : ( Vec u ) ctx ( __hexv ( __str tc `context` ) )
+                        ( vec_push [u] mp # u 0 )
+                        ( vec_push [u] mp # u ( vec_len [u] ctx ) )
+                        ( bytes_extend_bytes mp ctx )
+                        ( bytes_extend_bytes mp msg )
+                        ( vec_free [u] ctx )
+                    }
+                    : ( Vec u ) sig ( mldsa_sign_internal level sk mp rnd )
+                    ? ( __eqhex sig ( __str tc `signature` ) ) { = sp + sp 1 } { = sf + sf 1 }
+                    ( vec_free [u] sig )
+                    ( vec_free [u] mp )
+                    ( vec_free [u] rnd )
+                    ( vec_free [u] msg )
+                    ( vec_free [u] sk )
+                } }
+            = ti + ti 1
+        }
+        = gi + gi 1
+    }
+    ( json_free sg )
+    ( __report `sigGen` sp sf ss )
+    = totfail + totfail sf
+
+    // ── sigVer: the negative cases are the point ──
+    : Json sv ( __load ( nurl_argv_get 3 ) )
+    : Json svg ?? ( json_obj_get sv `testGroups` ) { T v → { v } F → { ( json_null ) } }
+    : ~ i vp 0
+    : ~ i vf 0
+    : ~ i vs 0
+    = gi 0
+    ~ < gi ( json_arr_len svg ) {
+        : Json g ?? ( json_arr_get svg gi ) { T v → { v } F → { ( json_null ) } }
+        : i level ( __level g )
+        : s iface ( __str g `signatureInterface` )
+        : s ph ( __str g `preHash` )
+        : b emu ( __bool g `externalMu` )
+        : b internal != 0 ( nurl_str_eq iface `internal` )
+        : b pure != 0 ( nurl_str_eq ph `pure` )
+        : Json ts ?? ( json_obj_get g `tests` ) { T v → { v } F → { ( json_null ) } }
+        : ~ i ti 0
+        ~ < ti ( json_arr_len ts ) {
+            : Json tc ?? ( json_arr_get ts ti ) { T v → { v } F → { ( json_null ) } }
+            ? emu {
+                : ( Vec u ) pk ( __hexv ( __str tc `pk` ) )
+                : ( Vec u ) mu ( __hexv ( __str tc `mu` ) )
+                : ( Vec u ) sig ( __hexv ( __str tc `signature` ) )
+                ? == ( mldsa_verify_mu level pk mu sig ) ( __bool tc `testPassed` ) { = vp + vp 1 } { = vf + vf 1 }
+                ( vec_free [u] sig ) ( vec_free [u] mu ) ( vec_free [u] pk )
+            } {
+                ? ! | internal pure { = vs + vs 1 } {
+                    : ( Vec u ) pk ( __hexv ( __str tc `pk` ) )
+                    : ( Vec u ) msg ( __hexv ( __str tc `message` ) )
+                    : ( Vec u ) sig ( __hexv ( __str tc `signature` ) )
+                    : ~ ( Vec u ) mp ( vec_new [u] )
+                    ? internal {
+                        ( vec_free [u] mp )
+                        = mp ( bytes_slice msg 0 ( vec_len [u] msg ) )
+                    } {
+                        : ( Vec u ) ctx ( __hexv ( __str tc `context` ) )
+                        ( vec_push [u] mp # u 0 )
+                        ( vec_push [u] mp # u ( vec_len [u] ctx ) )
+                        ( bytes_extend_bytes mp ctx )
+                        ( bytes_extend_bytes mp msg )
+                        ( vec_free [u] ctx )
+                    }
+                    : b got ( mldsa_verify_internal level pk mp sig )
+                    : b want ( __bool tc `testPassed` )
+                    ? == got want { = vp + vp 1 } { = vf + vf 1 }
+                    ( vec_free [u] mp )
+                    ( vec_free [u] sig )
+                    ( vec_free [u] msg )
+                    ( vec_free [u] pk )
+                } }
+            = ti + ti 1
+        }
+        = gi + gi 1
+    }
+    ( json_free sv )
+    ( __report `sigVer` vp vf vs )
+    = totfail + totfail vf
+
+    ^ ? == totfail 0 0 1
+}

--- a/tools/mldsa_acvp_gate.sh
+++ b/tools/mldsa_acvp_gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/mldsa_acvp_gate.sh — prove stdlib/std/mldsa.nu against the
+#  authority: NIST's own ACVP test vectors for FIPS 204.
+#
+#  A signature scheme is not validated by signing and then verifying
+#  with the same code: a consistently wrong implementation agrees with
+#  itself perfectly. Two independent things have to be checked against
+#  someone else's output, and NIST publishes both.
+#
+#    keyGen   75   seed → pk, sk, byte for byte
+#    sigGen  270   sk, message → signature, deterministic and hedged,
+#                  internal and external interfaces, and external-mu
+#    sigVer  135   pk, message, signature → accept / reject
+#
+#  The sigVer set carries the weight. Only a fifth of its cases are
+#  valid signatures; the rest are tampered in four specific ways —
+#  modified message, modified commitment c~, modified z, modified hint
+#  — and each targets a check a verifier can plausibly omit. The hint
+#  cases in particular catch a verifier that accepts a non-canonical
+#  hint encoding, which is a forgery derived from a genuine signature
+#  rather than a broken signature.
+#
+#  HashML-DSA (the `preHash` groups) is not implemented; those cases
+#  are reported as skipped rather than passed over silently.
+#
+#  Usage:  tools/mldsa_acvp_gate.sh
+#  Env:    NURL         build driver (defaults to ./nurl.sh in a checkout)
+#          ACVP_DIR     directory holding pre-downloaded JSON (skips the
+#                       fetch; useful offline and in sandboxed CI)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t mldsa-gate.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+BASE="https://raw.githubusercontent.com/usnistgov/ACVP-Server/master/gen-val/json-files"
+KEYGEN="$WORK/keyGen.json"
+SIGGEN="$WORK/sigGen.json"
+SIGVER="$WORK/sigVer.json"
+
+if [ -n "${ACVP_DIR:-}" ]; then
+    for pair in "ML-DSA-keyGen-FIPS204:$KEYGEN" "ML-DSA-sigGen-FIPS204:$SIGGEN" "ML-DSA-sigVer-FIPS204:$SIGVER"; do
+        src="${pair%%:*}"; dst="${pair#*:}"
+        cp "$ACVP_DIR/$src.json" "$dst" 2>/dev/null || {
+            echo "FAIL: ACVP_DIR set but $src.json not found in it"; exit 1; }
+    done
+else
+    command -v curl >/dev/null 2>&1 || { echo "SKIP: curl not available"; exit 0; }
+    fetch() { curl -fsS --max-time 180 -o "$2" "$1" 2>>"$WORK/curl.err"; }
+    if ! fetch "$BASE/ML-DSA-keyGen-FIPS204/internalProjection.json" "$KEYGEN" \
+       || ! fetch "$BASE/ML-DSA-sigGen-FIPS204/internalProjection.json" "$SIGGEN" \
+       || ! fetch "$BASE/ML-DSA-sigVer-FIPS204/internalProjection.json" "$SIGVER"; then
+        echo "SKIP: could not fetch NIST ACVP vectors (no network?)"
+        [ -s "$WORK/curl.err" ] && sed 's/^/  /' "$WORK/curl.err"
+        exit 0
+    fi
+fi
+
+GATE="$WORK/mldsa_acvp_gate"
+if ! $NURL tools/mldsa_acvp_gate.nu "$GATE" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build tools/mldsa_acvp_gate.nu:"
+    tail -20 "$WORK/build.err"
+    exit 1
+fi
+
+"$GATE" "$KEYGEN" "$SIGGEN" "$SIGVER"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    echo "PASS: ML-DSA matches NIST ACVP"
+else
+    echo "FAIL: ML-DSA disagrees with NIST ACVP"
+fi
+exit $rc


### PR DESCRIPTION
The signature half of the post-quantum migration, and the other end of
the handshake. Follows #931.

## `std/mldsa.nu` — ML-DSA at all three parameter sets

The complete 256-point NTT over Z₈₃₈₀₄₁₇ — unlike ML-KEM's modulus this
one admits a 512th root of unity, so the transform runs all eight layers
and multiplication in the NTT domain is an ordinary pointwise product
rather than a degree-1 basemul — Montgomery and Barrett reduction in
`i32`, rejection sampling of the public matrix and the noise,
`Power2Round` and `Decompose`, hint generation and packing, and the
3/4/6/10/13/18/20-bit encodings.

The pure external interface with FIPS 204 §5.2 context strings, plus the
external-mu interface. **HashML-DSA (`preHash`) is not implemented**, and
those cases are reported as skipped rather than quietly passed over.

Signing is **hedged by default**: 32 fresh random bytes go into the
per-signature nonce, so a repeated message does not give a repeated
signature and a fault does not expose the key the way deterministic
signing can. `mldsa_sign_deterministic` remains for interoperability and
is what NIST's deterministic vectors exercise.

## Correctness

`tools/mldsa_acvp_gate.sh` runs **all 480 published ACVP cases** — 75
keyGen, 270 sigGen (deterministic and hedged, internal and external, and
external-mu), 135 sigVer. Every one passed on the first run.

That is worth explaining rather than claiming: the approach was to write
a reference implementation of FIPS 204 first and validate *that* against
the vectors, so the NURL version was a transcription of something
already known correct rather than a debugging exercise against a
1500-line black box.

The gate is mutation-tested — a wrong zeta, a wrong QINV, a wrong
inverse-NTT constant, and a norm check that always passes are each
caught. That sweep also turned up the finding below.

### What the published vectors do not reach

A signature's hint has three encoding rules (FIPS 204 §7.2). Violating
them does not produce a corrupted signature; it produces a **second
valid encoding of a genuine one**, which is signature malleability.
Deleting each check and re-running all 480 NIST cases:

| rule | published cases that fail |
|---|---|
| strictly-increasing indices | 1 of 135 sigVer |
| trailing bytes must be zero | 0 |
| running totals in range | 0 |

The reason is that NIST's 36 "modified signature - hint" cases corrupt
the hint's *contents* and leave its structure alone — and corrupting the
contents changes the bits it decodes to, so `c~` stops matching and the
signature is refused whether or not the encoding was ever checked.

So `compiler/tests/mldsa_vectors.nu` constructs re-encodings that decode
to **identical** hint bits: the first index duplicated with every
running total bumped by one (setting a bit twice is setting it once),
and a non-zero byte in the tail the decoder never reads. Both must be
rejected, and deleting either check makes this file fail.

The third rule is a bounds guard rather than a malleability guard: a
total past ω runs the index loop off the end of the signature. Its
removal changes no verdict and trips no sanitizer either — the overread
stays inside the slack of the vector's allocation. That it is currently
unobservable is recorded in the test as a gap rather than glossed as a
clean bill of health.

## `std/tls_server.nu` — the encapsulating side

The server now takes `X25519MLKEM768` in preference to the classical
groups. There it is the *encapsulating* party: the client sends an
ML-KEM encapsulation key and the reply carries a ciphertext, not a
public key.

`compiler/tests/tls_pq_hybrid.nu` puts the NURL client and the NURL
server on the two ends of one handshake and asserts the negotiated group
is 4588. This is the half that talking to Cloudflare can never exercise
— against a real server only our decapsulating side runs, the
encapsulating side is theirs.

```
client_handshake=OK
client_group=X25519MLKEM768
client_is_pq=T
echo_ok=T
server_group=X25519MLKEM768
server_echo=OK
```

Key-share selection became a two-pass scan. Taking the first recognised
group let the *client* decide which group the connection used, which is
not the server's call to give away.

## Also

- **`std/net`: `tcp_tls_group` and `tcp_is_post_quantum`.** A server
  built on `net.nu` had no way to ask whether its connection was
  post-quantum, and a peer without ML-KEM falls back silently.
- **`packages/pqc` 0.2.0**: `sign-keygen`, `sign`, `verify`. Signatures
  are bound to a `pqc` context string so one cannot be replayed as a
  signature for another application sharing the key. The subcommand
  dispatcher was rewritten flat — with nine commands the if/else
  ladder's tail was a run of closing braces whose count was the only
  thing keeping it correct, and miscounting compiles into a *different
  program* rather than an error.
- ML-DSA's private helpers moved to a `__md_` prefix.
  `check_stdlib_symbols.sh` is right that a flat namespace makes `__ntt`
  in two modules a collision waiting to happen — that gate earned its
  keep here.

## Test status

- 840 compiler tests pass (2 new), 0 failures
- 38 package tests pass
- 660 ACVP vectors across both schemes (180 ML-KEM + 480 ML-DSA)
- ASan/LSan clean across signing, verification and the TLS paths
- strict-arity, stdlib-symbols, package-imports and package-version
  gates green

## Out of scope

**HashML-DSA (`preHash`)** — signing a digest under an algorithm OID.
It needs four SHA-2 variants stdlib does not have (SHA2-224, SHA2-384,
SHA2-512/224, SHA2-512/256), and partial support would be a footgun. The
90 sigGen and 45 sigVer cases it covers are reported as skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)