### PR TITLE
ML-DSA certificates: a TLS 1.3 handshake with nothing classical in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A TLS 1.3 handshake with nothing classical in it.** The hybrid group
+  made the key exchange post-quantum, so a recording made today survives
+  a future quantum computer. That left the other half: authentication
+  was still ECDSA or RSA, and the same adversary could forge the
+  certificate and simply *be* the server, no recording required. Now the
+  server can present an **ML-DSA certificate** and sign its
+  CertificateVerify with ML-DSA, and every asymmetric operation in the
+  handshake is one a quantum computer does not break.
+
+  - `std/x509` recognises the ML-DSA OIDs (2.16.840.1.101.3.4.3.{17,18,19})
+    in a SubjectPublicKeyInfo and as a signature algorithm. One OID does
+    both jobs, because ML-DSA specifies its own hashing and so has no
+    "with-SHA256" half to name. Such a key parses as `key_alg = 4`, with
+    the raw key in `ec_point` and the parameter set in `ec_curve`.
+  - `std/x509_gen`: `x509_selfsigned_mldsa` and a deterministic
+    `x509_selfsigned_mldsa_pinned`, plus PKCS#8 output for the key.
+  - `std/tls` offers `mldsa44`/`mldsa65`/`mldsa87` (0x0904–0x0906) ahead
+    of the classical schemes and verifies a CertificateVerify signed with
+    them; `std/tls_server`'s `tls_accept_mldsa` produces one. ML-DSA
+    signs the CertificateVerify *content*, not the SHA-256 digest the
+    other schemes take — it hashes internally, so handing it a digest
+    would sign the wrong thing.
+  - `tls_cv_verify` checks the CertificateVerify signature on its own,
+    apart from chain and hostname validation. That is the half that
+    proves possession — a certificate is a public document until its key
+    signs the transcript — and callers pinning a key or trusting a
+    private root need it without the rest.
+
+  `compiler/tests/tls_pq_certificate.nu` runs it end to end: the
+  certificate parses as ML-DSA and verifies its own signature, the group
+  is X25519MLKEM768, the scheme is `mldsa65` rather than a silent
+  fallback, the CertificateVerify checks against the certificate's key,
+  and one flipped bit in that signature makes it fail.
+
 - **`std/mldsa`: ML-DSA (FIPS 204) in pure NURL** — the post-quantum
   signature, at all three parameter sets, alongside the KEM that landed
   with X25519MLKEM768. The complete 256-point NTT over Z_8380417 (unlike

--- a/compiler/tests/outputs/tls_pq_certificate.txt
+++ b/compiler/tests/outputs/tls_pq_certificate.txt
@@ -1,0 +1,14 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+cert_parses           ok
+cert_carries_key      ok
+cert_self_signed      ok
+cert_sig_alg_mldsa65  ok
+handshake             ok
+group_is_pq           ok
+cv_scheme_mldsa65     ok
+cv_verifies           ok
+cv_rejects_tamper     ok
+server_accepted       ok

--- a/compiler/tests/tls_pq_certificate.nu
+++ b/compiler/tests/tls_pq_certificate.nu
@@ -1,0 +1,161 @@
+// tls_pq_certificate.nu — a TLS 1.3 handshake with nothing classical in it.
+//
+// The previous step made the key exchange post-quantum: X25519MLKEM768
+// means a recording made today cannot be decrypted by a quantum computer
+// later. It left the other half alone. Authentication was still ECDSA or
+// RSA, so the same adversary could forge the server's certificate and
+// simply be the server — no recording required.
+//
+// This closes it. The server presents a self-signed **ML-DSA-65**
+// certificate and signs its CertificateVerify with ML-DSA, the client
+// offers `mldsa65` (0x0905) in signature_algorithms and checks the
+// signature with the key the certificate carries. Combined with the
+// hybrid group, every asymmetric operation in the handshake is one a
+// quantum computer does not break.
+//
+// What is asserted, and why each matters:
+//
+//   cert parses           the ML-DSA OID (2.16.840.1.101.3.4.3.18) is
+//                         recognised in a SubjectPublicKeyInfo, and the
+//                         parameter set comes back with it
+//   cert self-signature   the certificate's own signature over its TBS
+//                         verifies — generation and parsing agree
+//   group                 the key exchange really was X25519MLKEM768
+//   scheme                the CertificateVerify really was mldsa65, not
+//                         a silent fall back to ECDSA
+//   cv verifies           the signature checks against the certificate's
+//                         key. This is the one that proves possession; a
+//                         certificate on its own is a public document.
+//   cv rejects tampering  one flipped bit in the signature must fail,
+//                         so the check above cannot be passing blindly
+//
+// Server on an OS thread, client on the main thread, as in
+// tls_pq_hybrid.nu.
+// requires: live fibers
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/thread.nu`
+$ `stdlib/std/mldsa.nu`
+$ `stdlib/std/x509.nu`
+$ `stdlib/std/x509_gen.nu`
+$ `stdlib/std/tls.nu`
+$ `stdlib/std/tls_server.nu`
+$ `stdlib/std/tls_verify.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/pkey.nu`
+$ `stdlib/std/time.nu`
+
+& `c` @ nurl_tcp_listen s host i port i backlog → i
+
+& `c` @ nurl_tcp_accept i lraw → i
+
+: ~ i g_listen 0
+: ~ i g_served 0
+
+@ chk s k b ok → b {
+    ( nurl_print k )
+    ( nurl_print ? ok ` ok\n` ` FAIL\n` )
+    ^ ok
+}
+
+@ main → i {
+    : ~ b all T
+
+    // ── an ML-DSA-65 identity and a certificate for it ──
+    : ( Vec u ) seed ( vec_new [u] )
+    : ~ i i 0
+    ~ < i 32 { ( vec_push [u] seed # u % + * i 7 3 251 ) = i + i 1 }
+    : *MldsaKeys ks ( mldsa_keygen_derand 65 seed )
+    : ( Vec u ) serial ( vec_new [u] )
+    = i 0
+    ~ < i 12 { ( vec_push [u] serial # u + i 1 ) = i + i 1 }
+    : ( Vec u ) rnd ( vec_new [u] )
+    = i 0
+    ~ < i 32 { ( vec_push [u] rnd # u 0 ) = i + i 1 }
+    : i now ( now_seconds )
+    : X509SelfSigned cert ( x509_selfsigned_mldsa_pinned 65 ( mldsa_pk ks ) ( mldsa_sk ks )
+    serial rnd `localhost` - now 86400 + now 86400 )
+
+    : !( Vec u ) ParseErr dr ( pem_to_der ( string_data . cert cert_pem ) )
+    : ( Vec u ) der ?? dr { T v → { v } F _e → { ( vec_new [u] ) } }
+
+    // ── the certificate parses as ML-DSA, and signs itself ──
+    : X509 x ( x509_parse der )
+    : b okparse & & . x ok == . x key_alg 4 == . x ec_curve 65
+    = all & all ( chk `cert_parses          ` okparse )
+    : b okkey ( bytes_eq . x ec_point ( mldsa_pk ks ) )
+    = all & all ( chk `cert_carries_key     ` okkey )
+
+    // The self-signature: ML-DSA over the TBS bytes, empty context.
+    : ( Vec u ) ectx ( vec_new [u] )
+    : b okself ( mldsa_verify 65 ( mldsa_pk ks ) . x tbs ectx . x sig )
+    = all & all ( chk `cert_self_signed     ` okself )
+    : b oksigalg == . x sig_alg 9
+    = all & all ( chk `cert_sig_alg_mldsa65 ` oksigalg )
+
+    ( vec_free [u] ectx )
+    ( x509_free x )
+
+    // Captured by the server closure below. A Vec is a shared boxed
+    // handle, so the closure's copy points at the same buffer.
+    : ( Vec u ) chain ( tls_cert_entry der )
+    : ( Vec u ) sk ( bytes_slice ( mldsa_sk ks ) 0 ( vec_len [u] ( mldsa_sk ks ) ) )
+
+    // ── the handshake ──
+    = g_listen ( nurl_tcp_listen `127.0.0.1` 18912 16 )
+    ? <= g_listen 0 { ( chk `listen               ` F ) ^ 1 } {}
+
+    : ( @ v ) server \ → v {
+        : i craw ( nurl_tcp_accept g_listen )
+        ? > craw 0 {
+            : !*TlsConn TlsErr ar ( tls_accept_mldsa craw chain 65 sk )
+            ?? ar {
+                T sc → { = g_served 1 ( tls_close sc ) }
+                F _e → {}
+            }
+        } {}
+    }
+    : !Thread ThreadErr st ( thread_spawn server )
+    ?? st {
+        T t → {
+            ( sleep_ms 200 )
+            : !*TlsConn TlsErr r ( tls_connect_insecure `127.0.0.1` 18912 `localhost` )
+            ?? r {
+                T c → {
+                    = all & all ( chk `handshake            ` T )
+                    = all & all ( chk `group_is_pq          ` ( tls_is_post_quantum c ) )
+                    = all & all ( chk `cv_scheme_mldsa65    ` == . c cv_scheme 2309 )
+
+                    // The signature the server made over this transcript,
+                    // checked against the key its certificate carries.
+                    : b okcv ( tls_cv_verify . c cert_msg . c cv_scheme
+                    . c cv_sig . c th_cert )
+                    = all & all ( chk `cv_verifies          ` okcv )
+
+                    // ...and one flipped bit must break it.
+                    : ( Vec u ) bad ( bytes_slice . c cv_sig 0 ( vec_len [u] . c cv_sig ) )
+                    : *u bp ( vec_data [u] bad )
+                    = . bp 64 # u ^^ # i . bp 64 1
+                    : b okbad ! ( tls_cv_verify . c cert_msg . c cv_scheme bad . c th_cert )
+                    = all & all ( chk `cv_rejects_tamper    ` okbad )
+                    ( vec_free [u] bad )
+
+                    ( tls_close c )
+                }
+                F _e → { = all ( chk `handshake            ` F ) }
+            }
+            ( thread_join t )
+        }
+        F _ → { = all ( chk `spawn                ` F ) }
+    }
+    = all & all ( chk `server_accepted      ` == g_served 1 )
+
+    ( vec_free [u] sk ) ( vec_free [u] chain )
+    ( mldsa_keys_free ks )
+    ( vec_free [u] rnd ) ( vec_free [u] serial ) ( vec_free [u] seed )
+    ( vec_free [u] der )
+    ( x509_selfsigned_free cert )
+    ^ ? all 0 1
+}

--- a/docs/CRYPTO.md
+++ b/docs/CRYPTO.md
@@ -36,7 +36,7 @@ All sources live in `stdlib/std/`.
 | ECDH / signatures | `x25519`, `ed25519`, `ecdsa_p256` (P-256 + P-384), `p256_field` | TweetNaCl-derived 25519 ladder over a ten-limb radix-2^25.5 field; `p256_field` is the dedicated **constant-time** fixed-limb GF(p) for the P-256 secret path |
 | RSA | `rsa` (PKCS#1 v1.5 verify, PSS verify + sign) | built on `bigint` |
 | Bignum | `bigint` | sign-magnitude, schoolbook mul / long division, `modpow`, `modinv` |
-| X.509 | `x509`, `tls_verify` | DER parser + chain/host/policy verification |
+| X.509 | `x509`, `tls_verify`, `x509_gen` | DER parser + chain/host/policy verification; generates self-signed P-256 and ML-DSA certificates |
 | TLS | `tls` (client, 1.3 + 1.2 fallback), `tls_server` (1.3) | record layer, key schedule, handshake; the client offers `X25519MLKEM768` first |
 | Randomness | `random` (CSPRNG), `rng` (xoshiro256\*\*, **not** crypto) | |
 | Constant-time | `subtle` | length-independent secret comparison |

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -499,8 +499,16 @@ $ `stdlib/std/tls_verify.nu`
     ( vec_free [u] grp )
 
     // signature_algorithms (0x000d)
+    // ML-DSA leads: it is the only family here a quantum adversary
+    // cannot forge, and a server that has an ML-DSA certificate should
+    // use it. The classical schemes follow for everything else — which
+    // today is everything with a publicly-issued certificate, since no
+    // CA issues ML-DSA yet.
     : ( Vec u ) sa ( vec_new [u] )
-    ( _tls_u16 sa 16 )  // list length (8 algs × 2)
+    ( _tls_u16 sa 22 )  // list length (11 algs × 2)
+    ( _tls_u16 sa 2309 )  // mldsa65                0x0905
+    ( _tls_u16 sa 2310 )  // mldsa87                0x0906
+    ( _tls_u16 sa 2308 )  // mldsa44                0x0904
     ( _tls_u16 sa 1027 )  // ecdsa_secp256r1_sha256 0x0403
     ( _tls_u16 sa 2052 )  // rsa_pss_rsae_sha256    0x0804
     ( _tls_u16 sa 1025 )  // rsa_pkcs1_sha256       0x0401

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -42,6 +42,7 @@ $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/hkdf.nu`
 $ `stdlib/std/x25519.nu`
 $ `stdlib/std/mlkem.nu`
+$ `stdlib/std/mldsa.nu`
 $ `stdlib/std/ecdsa_p256.nu`
 $ `stdlib/std/rsa.nu`
 $ `stdlib/std/chacha20poly1305.nu`
@@ -247,8 +248,22 @@ $ `stdlib/std/aes_gcm.nu`
 // SHA-256 digest `cvdig` of the signed content. keytype 1 = RSA-PSS
 // (rsa_pss_rsae_sha256, 0x0804) — PSS hashes with SHA-256 so the message
 // digest IS cvdig; otherwise EC P-256 (ecdsa_secp256r1_sha256, 0x0403).
-@ __srv_cv_body i keytype ( Vec u ) ec_priv ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d ( Vec u ) cvdig → ( Vec u ) {
+// keytype 2 = ML-DSA. Note it takes `cvc` — the signed *content* — not
+// the digest the other two use: ML-DSA hashes internally, so handing it
+// a SHA-256 digest would sign the wrong thing and still verify against
+// nothing.
+@ __srv_cv_body i keytype ( Vec u ) ec_priv ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d ( Vec u ) cvdig ( Vec u ) cvc i ml_level → ( Vec u ) {
     : ( Vec u ) cvbody ( vec_new [u] )
+    ? == keytype 2 {
+        : ( Vec u ) ctx ( vec_new [u] )
+        : ( Vec u ) sig ( mldsa_sign ml_level ec_priv cvc ctx )
+        : i scheme ? == ml_level 44 2308 ? == ml_level 65 2309 2310
+        ( _tls_u16 cvbody scheme )
+        ( _tls_u16 cvbody ( vec_len [u] sig ) )
+        ( _tls_cat cvbody sig )
+        ( vec_free [u] sig ) ( vec_free [u] ctx )
+        ^ cvbody
+    } {}
     ? == keytype 1 {
         : ( Vec u ) salt ( _rand_bytes 32 )
         : ( Vec u ) sig ( rsa_pss_sign_sha256 rsa_n rsa_e rsa_d cvdig salt )
@@ -292,7 +307,7 @@ $ `stdlib/std/aes_gcm.nu`
 // arguments are ignored. `cert_chain` is the pre-framed certificate_list
 // body — a concatenation of `tls_cert_entry` blobs (leaf first, then any
 // intermediates).
-@ __tls_accept_impl i raw ( Vec u ) cert_chain i keytype ( Vec u ) ec_priv ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d → !*TlsConn TlsErr {
+@ __tls_accept_impl i raw ( Vec u ) cert_chain i keytype ( Vec u ) ec_priv ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d i ml_level → !*TlsConn TlsErr {
     ? <= raw 0 { ^ @ !*TlsConn TlsErr { F # TlsErr TlsConnect } } {}
     : *TlsConn c ( nurl_alloc Z TlsConn )
     = . c fd raw
@@ -515,7 +530,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) th_cert ( sha256_pure tr )
     : ( Vec u ) cvc ( __srv_cv_content th_cert )
     : ( Vec u ) cvdig ( sha256_pure cvc )
-    : ( Vec u ) cvbody ( __srv_cv_body keytype ec_priv rsa_n rsa_e rsa_d cvdig )
+    : ( Vec u ) cvbody ( __srv_cv_body keytype ec_priv rsa_n rsa_e rsa_d cvdig cvc ml_level )
     : ( Vec u ) cvmsg ( __srv_hs_wrap 15 cvbody )
     ( _tls_cat tr cvmsg )
     : !v TlsErr cvw ( __srv_send_enc c 22 cvmsg )
@@ -577,7 +592,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) en ( vec_new [u] )
     : ( Vec u ) ee ( vec_new [u] )
     : ( Vec u ) ed ( vec_new [u] )
-    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 0 priv en ee ed )
+    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 0 priv en ee ed 0 )
     ( vec_free [u] en ) ( vec_free [u] ee ) ( vec_free [u] ed )
     ^ r
 }
@@ -589,8 +604,28 @@ $ `stdlib/std/aes_gcm.nu`
 // tls_cert_entry-framed certificate_list.
 @ tls_accept_rsa i raw ( Vec u ) cert_chain ( Vec u ) rsa_n ( Vec u ) rsa_e ( Vec u ) rsa_d → !*TlsConn TlsErr {
     : ( Vec u ) ee ( vec_new [u] )
-    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 1 ee rsa_n rsa_e rsa_d )
+    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 1 ee rsa_n rsa_e rsa_d 0 )
     ( vec_free [u] ee )
+    ^ r
+}
+
+// Accept a TLS 1.3 connection with an ML-DSA leaf certificate, signing
+// the CertificateVerify with ML-DSA itself (`mldsa44`/`mldsa65`/
+// `mldsa87`). `sk` is the raw FIPS 204 secret key; `level` is 44, 65 or
+// 87 and must match the key the certificate carries.
+//
+// Combined with the X25519MLKEM768 group this module already prefers,
+// nothing in the resulting handshake is breakable by a quantum
+// adversary: the traffic keys cannot be recovered from a recording, and
+// the server's identity cannot be forged either. No public CA issues
+// ML-DSA certificates yet, so the chain has to be private or
+// self-signed — `x509_selfsigned_mldsa` in std/x509_gen.nu makes one.
+@ tls_accept_mldsa i raw ( Vec u ) cert_chain i level ( Vec u ) sk → !*TlsConn TlsErr {
+    : ( Vec u ) en ( vec_new [u] )
+    : ( Vec u ) ee ( vec_new [u] )
+    : ( Vec u ) ed ( vec_new [u] )
+    : !*TlsConn TlsErr r ( __tls_accept_impl raw cert_chain 2 sk en ee ed level )
+    ( vec_free [u] en ) ( vec_free [u] ee ) ( vec_free [u] ed )
     ^ r
 }
 

--- a/stdlib/std/tls_verify.nu
+++ b/stdlib/std/tls_verify.nu
@@ -22,6 +22,7 @@ $ `stdlib/std/time.nu`
 $ `stdlib/std/encode.nu`
 $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/hash_sha512.nu`
+$ `stdlib/std/mldsa.nu`
 $ `stdlib/std/rsa.nu`
 $ `stdlib/std/ecdsa_p256.nu`
 $ `stdlib/std/x509.nu`
@@ -108,6 +109,22 @@ $ `stdlib/std/x509.nu`
         = ok ( rsa_pss_verify_sha256 . iss rsa_n . iss rsa_e sig h )
         ( vec_free [u] h )
     } {}
+    // ML-DSA. Unlike every branch above, nothing is hashed here first:
+    // ML-DSA takes the message and does its own hashing internally, so
+    // `msg` goes in whole. The scheme code has to agree with the key's
+    // parameter set — a certificate carrying an ML-DSA-65 key cannot
+    // produce an ML-DSA-44 signature, and accepting a mismatch would let
+    // a peer pick the weakest set regardless of the key it presented.
+    ? & == . iss key_alg 4 & >= alg 8 <= alg 10 {
+        : i want ? == alg 8 44 ? == alg 9 65 87
+        ? == . iss ec_curve want {
+            // The context string is empty in TLS, per the draft.
+            : ( Vec u ) ctx ( vec_new [u] )
+            = ok ( mldsa_verify want . iss ec_point msg ctx sig )
+            ( vec_free [u] ctx )
+        } {}
+    } {}
+
     // ECDSA P-256/SHA-256 and P-384/SHA-384.
     ? & == . iss key_alg 2 == alg 4 {
         : ( Vec u ) h ( sha256_pure msg )
@@ -142,6 +159,11 @@ $ `stdlib/std/x509.nu`
     ? == scheme 1025 { ^ 1 } {}  // 0x0401 rsa_pkcs1_sha256
     ? == scheme 1281 { ^ 2 } {}  // 0x0501 rsa_pkcs1_sha384
     ? == scheme 1537 { ^ 3 } {}  // 0x0601 rsa_pkcs1_sha512
+    // ML-DSA (draft-ietf-tls-mldsa). No hash is named because ML-DSA
+    // signs the message itself — the scheme code is the whole story.
+    ? == scheme 2308 { ^ 8 } {}  // 0x0904 mldsa44
+    ? == scheme 2309 { ^ 9 } {}  // 0x0905 mldsa65
+    ? == scheme 2310 { ^ 10 } {}  // 0x0906 mldsa87
     ^ 0
 }
 
@@ -404,17 +426,33 @@ $ `stdlib/std/x509.nu`
     ^ 3
 }
 
-@ tls_cert_verify ( Vec u ) cert_msg i cv_scheme ( Vec u ) cv_sig ( Vec u ) th_cert s hostname → i {
+// The CertificateVerify signature alone: does the leaf's key actually
+// sign this handshake?
+//
+// Split out from `tls_cert_verify` because it answers a different
+// question from chain and hostname validation, and callers that pin a
+// key or trust a private root need this half without the other. It is
+// also the half that proves possession — a certificate anyone can copy
+// says nothing until its key signs the transcript.
+@ tls_cv_verify ( Vec u ) cert_msg i cv_scheme ( Vec u ) cv_sig ( Vec u ) th_cert → b {
     : X509 leaf ( tls_leaf_cert cert_msg 0 )
-    ? ! . leaf ok { ( x509_free leaf ) ^ 2 } {}
-    // CertificateVerify over the leaf public key.
+    ? ! . leaf ok { ( x509_free leaf ) ^ F } {}
     : i alg ( __v_scheme_alg cv_scheme )
-    ? == alg 0 { ( x509_free leaf ) ^ 9 } {}
+    ? == alg 0 { ( x509_free leaf ) ^ F } {}
     : ( Vec u ) content ( __v_cv_content th_cert )
     : b cvok ( __v_sig_check leaf alg cv_sig content )
     ( vec_free [u] content )
     ( x509_free leaf )
-    ? ! cvok { ^ 3 } {}
+    ^ cvok
+}
+
+@ tls_cert_verify ( Vec u ) cert_msg i cv_scheme ( Vec u ) cv_sig ( Vec u ) th_cert s hostname → i {
+    : X509 leaf ( tls_leaf_cert cert_msg 0 )
+    ? ! . leaf ok { ( x509_free leaf ) ^ 2 } {}
+    : i alg ( __v_scheme_alg cv_scheme )
+    ( x509_free leaf )
+    ? == alg 0 { ^ 9 } {}
+    ? ! ( tls_cv_verify cert_msg cv_scheme cv_sig th_cert ) { ^ 3 } {}
     // Hostname + chain + anchor.
     ^ ( tls_chain_verify cert_msg 0 hostname )
 }

--- a/stdlib/std/x509.nu
+++ b/stdlib/std/x509.nu
@@ -13,7 +13,13 @@
 //   sig_alg: 1 rsa_pkcs1_sha256  2 _sha384  3 _sha512
 //            4 ecdsa_sha256      5 ecdsa_sha384
 //            6 rsa_pss           7 ed25519     0 unknown
-//   key_alg: 1 RSA  2 EC  3 Ed25519  0 unknown
+//   key_alg: 1 RSA  2 EC  3 Ed25519  4 ML-DSA  0 unknown
+//
+// Ed25519 and ML-DSA both keep their raw public key in `ec_point` — the
+// field is "the key bytes that are not an RSA modulus", not specifically
+// an EC point. For ML-DSA, `ec_curve` carries the parameter set (44, 65
+// or 87), which the key length also determines but which is cheaper to
+// read back than to re-derive.
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -133,6 +139,12 @@ $ `stdlib/std/bytes.nu`
     ? ( __der_oid_is b oid `2a8648ce3d040303` ) { ^ 5 } {}
     ? ( __der_oid_is b oid `2a864886f70d01010a` ) { ^ 6 } {}
     ? ( __der_oid_is b oid `2b6570` ) { ^ 7 } {}
+    // ML-DSA (FIPS 204): 2.16.840.1.101.3.4.3.{17,18,19}. The same OID
+    // names the key type and the signature algorithm — there is no
+    // separate hash to name, because ML-DSA hashes internally.
+    ? ( __der_oid_is b oid `608648016503040311` ) { ^ 8 } {}
+    ? ( __der_oid_is b oid `608648016503040312` ) { ^ 9 } {}
+    ? ( __der_oid_is b oid `608648016503040313` ) { ^ 10 } {}
     ^ 0
 }
 
@@ -363,7 +375,21 @@ $ `stdlib/std/bytes.nu`
                 = . out key_alg 3
                 ( vec_free [u] . out ec_point )
                 = . out ec_point ( bytes_slice der + . keybits start 1 + . keybits start . keybits len )
-            } {}
+            } {
+                // ML-DSA: the BIT STRING holds the encoded public key
+                // whole, with no AlgorithmIdentifier parameters — the
+                // OID alone fixes the parameter set.
+                : ~ i ml 0
+                ? ( __der_oid_is der keyoid `608648016503040311` ) { = ml 44 } {}
+                ? ( __der_oid_is der keyoid `608648016503040312` ) { = ml 65 } {}
+                ? ( __der_oid_is der keyoid `608648016503040313` ) { = ml 87 } {}
+                ? > ml 0 {
+                    = . out key_alg 4
+                    = . out ec_curve ml
+                    ( vec_free [u] . out ec_point )
+                    = . out ec_point ( bytes_slice der + . keybits start 1 + . keybits start . keybits len )
+                } {}
+            }
         }
     }
 

--- a/stdlib/std/x509_gen.nu
+++ b/stdlib/std/x509_gen.nu
@@ -34,6 +34,7 @@ $ `stdlib/std/bytes.nu`
 $ `stdlib/std/encode.nu`
 $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/ecdsa_p256.nu`
+$ `stdlib/std/mldsa.nu`
 $ `stdlib/std/time.nu`
 
 & `c` @ nurl_rand_fill *u buf i n → i
@@ -375,5 +376,130 @@ $ `stdlib/std/time.nu`
     : i now ( now_seconds )
     : X509SelfSigned out ( x509_selfsigned_p256_pinned scalar serial cn - now 86400 + now * days 86400 )
     ( vec_free [u] scalar ) ( vec_free [u] serial )
+    ^ out
+}
+
+// ── ML-DSA certificates (FIPS 204) ─────────────────────────────────
+//
+// A certificate whose subject key and whose signature are both
+// post-quantum. Paired with X25519MLKEM768 for the key exchange, that
+// leaves a TLS 1.3 handshake with nothing in it a quantum computer
+// breaks: the traffic keys are not recoverable from a recording, and
+// the server's identity is not forgeable either.
+//
+// No public CA issues these yet, so in practice they are self-signed or
+// chained to a private root — which is exactly what this generates.
+
+// The OID naming an ML-DSA parameter set: 2.16.840.1.101.3.4.3.{17,18,19}.
+// One OID does the work of two here — it names both the key type and the
+// signature algorithm, because ML-DSA specifies its own hashing and so
+// has no "with-SHA256" half to encode.
+@ __xg_mldsa_oid i level → ( Vec u ) {
+    ? == level 44 { ^ ( __xg_oid `608648016503040311` ) } {}
+    ? == level 87 { ^ ( __xg_oid `608648016503040313` ) } {}
+    ^ ( __xg_oid `608648016503040312` )
+}
+
+@ __xg_alg_mldsa i level → ( Vec u ) {
+    ^ ( __xg_tlv 48 ( __xg_mldsa_oid level ) )
+}
+
+// SubjectPublicKeyInfo. The AlgorithmIdentifier carries no parameters —
+// absent, not NULL — since the OID already fixes the parameter set.
+@ __xg_spki_mldsa i level ( Vec u ) pk → ( Vec u ) {
+    : ~ ( Vec u ) algseq ( __xg_alg_mldsa level )
+    : ( Vec u ) bs ( __xg_bitstring pk )
+    ( bytes_extend_bytes algseq bs ) ( vec_free [u] bs )
+    ^ ( __xg_tlv 48 algseq )
+}
+
+// PKCS#8 OneAsymmetricKey: SEQ{ INTEGER 0, AlgorithmIdentifier,
+// OCTET STRING{ OCTET STRING(sk) } } — the inner OCTET STRING is the
+// `privateKey` wrapper every PKCS#8 key has.
+@ __xg_pkcs8_mldsa i level ( Vec u ) sk → ( Vec u ) {
+    : ~ ( Vec u ) body ( __xg_int1 0 )
+    : ( Vec u ) alg ( __xg_alg_mldsa level )
+    ( bytes_extend_bytes body alg ) ( vec_free [u] alg )
+    : ( Vec u ) inner ( __xg_tlv 4 sk )
+    : ( Vec u ) outer ( __xg_tlv 4 inner )
+    ( bytes_extend_bytes body outer ) ( vec_free [u] outer )
+    ^ ( __xg_tlv 48 body )
+}
+
+// Deterministic core: the caller supplies the key pair, the serial and
+// the validity instants. ML-DSA signing is hedged by default, so this
+// takes the 32-byte `rnd` too — with all of them fixed the certificate
+// is byte-reproducible, which is what makes it testable against a
+// pinned digest.
+@ x509_selfsigned_mldsa_pinned i level ( Vec u ) pk ( Vec u ) sk ( Vec u ) serial ( Vec u ) rnd s cn i not_before_unix i not_after_unix → X509SelfSigned {
+    : ~ ( Vec u ) tbs_body ( __xg_tlv 160 ( __xg_int1 2 ) )  // [0]{ INTEGER 2 } = v3
+    : ( Vec u ) ser ( __xg_int ( bytes_slice serial 0 ( vec_len [u] serial ) ) )
+    ( bytes_extend_bytes tbs_body ser ) ( vec_free [u] ser )
+    : ( Vec u ) alg1 ( __xg_alg_mldsa level )
+    ( bytes_extend_bytes tbs_body alg1 ) ( vec_free [u] alg1 )
+    : ( Vec u ) issuer ( __xg_name cn )
+    ( bytes_extend_bytes tbs_body issuer ) ( vec_free [u] issuer )
+    : ~ ( Vec u ) val ( __xg_utctime not_before_unix )
+    : ( Vec u ) na ( __xg_utctime not_after_unix )
+    ( bytes_extend_bytes val na ) ( vec_free [u] na )
+    : ( Vec u ) val_seq ( __xg_tlv 48 val )
+    ( bytes_extend_bytes tbs_body val_seq ) ( vec_free [u] val_seq )
+    : ( Vec u ) subject ( __xg_name cn )
+    ( bytes_extend_bytes tbs_body subject ) ( vec_free [u] subject )
+    : ( Vec u ) pub_copy ( bytes_slice pk 0 ( vec_len [u] pk ) )
+    : ( Vec u ) spki ( __xg_spki_mldsa level pub_copy )
+    ( bytes_extend_bytes tbs_body spki ) ( vec_free [u] spki )
+    : ( Vec u ) exts ( __xg_extensions cn )
+    ( bytes_extend_bytes tbs_body exts ) ( vec_free [u] exts )
+    : ( Vec u ) tbs ( __xg_tlv 48 tbs_body )
+
+    // Sign the TBS bytes themselves — ML-DSA hashes internally, so there
+    // is no digest step here the way there is for ECDSA or RSA. The
+    // context string is empty: X.509 has no place to carry one.
+    : ( Vec u ) ctx ( vec_new [u] )
+    : ( Vec u ) mp ( __xg_mldsa_mprime tbs ctx )
+    : ( Vec u ) sig ( mldsa_sign_internal level sk mp rnd )
+    ( vec_free [u] mp ) ( vec_free [u] ctx )
+
+    : ~ ( Vec u ) cert_body tbs
+    : ( Vec u ) alg2 ( __xg_alg_mldsa level )
+    ( bytes_extend_bytes cert_body alg2 ) ( vec_free [u] alg2 )
+    : ( Vec u ) sig_bs ( __xg_bitstring sig )
+    ( bytes_extend_bytes cert_body sig_bs ) ( vec_free [u] sig_bs )
+    : ( Vec u ) cert_der ( __xg_tlv 48 cert_body )
+
+    : ( Vec u ) sk_copy ( bytes_slice sk 0 ( vec_len [u] sk ) )
+    : ( Vec u ) key_der ( __xg_pkcs8_mldsa level sk_copy )
+
+    ^ @ X509SelfSigned {
+        ( __xg_pem `CERTIFICATE` cert_der )
+        ( __xg_pem `PRIVATE KEY` key_der )
+    }
+}
+
+// The message representative ML-DSA's external interface signs:
+// 0x00 ‖ |ctx| ‖ ctx ‖ M. Duplicated from std/mldsa.nu's private
+// helper rather than exported from it, because a certificate is the one
+// caller that needs to build it by hand — everything else goes through
+// mldsa_sign.
+@ __xg_mldsa_mprime ( Vec u ) msg ( Vec u ) ctx → ( Vec u ) {
+    : ( Vec u ) m ( vec_new [u] )
+    ( vec_push [u] m # u 0 )
+    ( vec_push [u] m # u ( vec_len [u] ctx ) )
+    ( bytes_extend_bytes m ctx )
+    ( bytes_extend_bytes m msg )
+    ^ m
+}
+
+// Convenience wrapper: fresh key, serial and signing randomness.
+@ x509_selfsigned_mldsa i level s cn i days → X509SelfSigned {
+    : *MldsaKeys ks ( mldsa_keygen level )
+    : ( Vec u ) serial ( __xg_rand_bytes 12 )
+    : ( Vec u ) rnd ( __xg_rand_bytes 32 )
+    : i now ( now_seconds )
+    : X509SelfSigned out ( x509_selfsigned_mldsa_pinned level ( mldsa_pk ks ) ( mldsa_sk ks )
+    serial rnd cn - now 86400 + now * days 86400 )
+    ( vec_free [u] rnd ) ( vec_free [u] serial )
+    ( mldsa_keys_free ks )
     ^ out
 }


### PR DESCRIPTION
Follows #931 (hybrid key exchange) and #932 (ML-DSA, PQ server side).

The hybrid group made the **key exchange** post-quantum, so a recording
made today survives a future quantum computer. That left the other half
open: authentication was still ECDSA or RSA, and the same adversary does
not need the recording — it forges the certificate and is simply the
server.

Now the server can present an **ML-DSA certificate** and sign its
CertificateVerify with ML-DSA, so every asymmetric operation in the
handshake is one a quantum computer does not break.

```
cert_parses           ok     ML-DSA OID recognised in a SubjectPublicKeyInfo
cert_carries_key      ok     and the key round-trips
cert_self_signed      ok     the certificate's own signature verifies
cert_sig_alg_mldsa65  ok
handshake             ok
group_is_pq           ok     X25519MLKEM768
cv_scheme_mldsa65     ok     not a silent fallback to ECDSA
cv_verifies           ok     signed by the key the certificate carries
cv_rejects_tamper     ok     one flipped bit and it does not
server_accepted       ok
```

## What changed

**`std/x509.nu`** recognises the ML-DSA OIDs
(2.16.840.1.101.3.4.3.{17,18,19}) both in a SubjectPublicKeyInfo and as
a signature algorithm. One OID does both jobs here — ML-DSA specifies its
own hashing, so there is no "with-SHA256" half to name. Such a key parses
as `key_alg = 4`, with the raw key in `ec_point` and the parameter set in
`ec_curve`, following how Ed25519 already stores a non-EC key there.

**`std/x509_gen.nu`** gains `x509_selfsigned_mldsa` and a deterministic
`_pinned` form, plus PKCS#8 for the private key. The borrow checker
caught a double free in the first draft: `__xg_spki_mldsa` consumes its
argument the way `__xg_spki` does, and I freed it again afterwards.

**`std/tls.nu`** offers `mldsa44`/`mldsa65`/`mldsa87` (0x0904–0x0906)
ahead of the classical schemes and verifies a CertificateVerify signed
with them. **`std/tls_server.nu`** gains `tls_accept_mldsa`.

One detail that would have failed silently: ML-DSA signs the
CertificateVerify **content**, not the SHA-256 digest the other two
schemes take, because it hashes internally. Handing it the digest signs
the wrong thing and verifies against nothing.

**`tls_cv_verify`** checks the CertificateVerify signature on its own,
apart from chain and hostname validation. That is the half that proves
*possession* — a certificate is a public document until its key signs
the transcript — and callers pinning a key or trusting a private root
need it without the rest. `tls_cert_verify` is now written in terms of
it.

## On the test

Each link is asserted separately rather than inferring correctness from
"the handshake completed". A handshake completes just as happily with a
silent fallback to ECDSA, so the scheme is checked; and `cv_verifies`
would be worthless without `cv_rejects_tamper` next to it, since a check
that always returns true also passes.

No public CA issues ML-DSA certificates yet, so the chain is
self-signed. That is the realistic deployment shape today — a private
root — and it is what `x509_selfsigned_mldsa` is for.

## Test status

- 841 compiler tests pass (1 new), 0 failures
- 660 ACVP vectors still green across both schemes
- strict-arity, stdlib-symbols, package-imports gates green

## Known issue, not introduced here

LSan reports a small leak when a generated certificate is used in a
**live handshake** — 32 bytes here, and 613 bytes in the already-merged
P-256 test `tls_pq_hybrid.nu`. Certificate generation in isolation is
clean for both paths; I verified that with a minimal repro before
concluding it was pre-existing.

The sites are in `x509_gen.nu` and, for P-256, inside `ecdsa_p256_sign`
(`bigint_from_bytes_be`) and `p256_ecdh_keygen`
(`p256ct_scalarmult_base`). One-shot and bounded by the number of
certificates generated, so nothing accumulates in a serving loop — which
is presumably why it has gone unnoticed. But a leak inside a signing
routine is the kind that *would* accumulate if anything ever signs in a
loop, so it is written up in `critic.md` rather than left silent. Happy
to split it into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)