### PR TITLE
tests: close the listeners the PQ handshake tests leaked

### DIFF
--- a/compiler/tests/tls_pq_certificate.nu
+++ b/compiler/tests/tls_pq_certificate.nu
@@ -51,6 +51,8 @@ $ `stdlib/std/time.nu`
 
 & `c` @ nurl_tcp_accept i lraw → i
 
+& `c` @ nurl_tcp_close i fd → i
+
 : ~ i g_listen 0
 : ~ i g_served 0
 
@@ -151,6 +153,7 @@ $ `stdlib/std/time.nu`
         F _ → { = all ( chk `spawn                ` F ) }
     }
     = all & all ( chk `server_accepted      ` == g_served 1 )
+    ( nurl_tcp_close g_listen )
 
     ( vec_free [u] sk ) ( vec_free [u] chain )
     ( mldsa_keys_free ks )

--- a/compiler/tests/tls_pq_hybrid.nu
+++ b/compiler/tests/tls_pq_hybrid.nu
@@ -104,6 +104,7 @@ $ `stdlib/std/time.nu`
             }
             ( label `server_group` ? == server_group 4588 `X25519MLKEM768` `NOT-PQ` )
             ( label `server_echo` ? == server_ok 1 `OK` `FAIL` )
+            ( tcp_close_listener listener )
         }
         F _e → { ( label `tls_listen` `FAIL` ) }
     }


### PR DESCRIPTION
Follow-up to the leak I flagged in #933.

`tls_pq_hybrid.nu` and `tls_pq_certificate.nu` opened a listener and
never closed it. Under LSan that accounted for **435 of the 611 bytes**
the hybrid test leaked — the listener plus everything reachable only
from it. My bug, from #932 and #933.

## The rest of the investigation mostly un-found things

The write-up I left in `critic.md` blamed `x509_gen` and the P-256
modules on the strength of ASan allocation stacks. Looping each suspect
and comparing against a single call clears all of them:

| suspect | test | result |
|---|---|---|
| `ecdsa_p256_sign` | 5 calls, varying digests | clean |
| `p256_ecdh_keygen` | looped | clean |
| `bytes_from_hex` + `??` + free | 50 calls | clean |
| `x509_selfsigned_p256` | standalone | clean |
| `x509_selfsigned_mldsa_*` | standalone | clean |

Nothing accumulates per signature, which was the actual worry I raised —
"a leak inside a signing routine is the kind that would accumulate if
anything ever signs in a loop." It does not.

## One result was worthless, and that is worth naming

An early "no leaks per call" came from a harness that never ran: `pub` is
a reserved word, the build failed, `&&` swallowed it, and grep found no
`SUMMARY` line — which reads exactly like a passing leak check.

**A leak harness that reports clean is indistinguishable from one that
did not execute.** Check for the program's own output as a positive
marker, not for the absence of a failure line. I only caught it because
a later edit to the same file surfaced the compile error.

## Still open

176 bytes (hybrid) and 32 bytes (certificate) remain, one-shot, and I
have **not** root-caused them. They do not reproduce when the same
functions run standalone — only inside a program that also spawns a
thread and completes a handshake — and they are not the `use_stacks=0`
root-scanning artifact, since the same bytes appear with stacks enabled.
The count also varied between early runs (613 vs 611), pointing at a
randomness-dependent path; `x509_selfsigned_p256` retries until
`__xg_scalar_ok` accepts a random scalar.

Most likely the `-O1` frames are approximate and the real site is one
frame away from where the stacks point. `critic.md` now records this
accurately in place of the earlier over-claim, with the next step: an
`-O0` ASan build for honest frames.

Severity is Minor — one-shot, bounded by certificates generated, and the
primitives that would accumulate are clean — so I did not want to hold
the fix that *is* verified behind the part that is not.

## Test status

841 compiler tests pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)