### PR TITLE
HashML-DSA, and the three SHA-2 variants it needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **HashML-DSA (FIPS 204 §5.4), and the three SHA-2 variants it needed.**
+  ML-DSA now covers every interface the standard defines, and all **615**
+  published ACVP cases pass with **none skipped** — up from 480 run and
+  135 skipped.
+
+  Pre-hash mode signs a digest instead of the message, so a signer can
+  handle a message it never holds whole, or a protocol that already has a
+  digest need not carry the message to the signer at all. All twelve
+  approved hashes are supported. `mldsa_ph_mprime` is public for callers
+  who already hold the digest or who must supply their own randomness.
+
+  `std/hash_sha256` gains **SHA-224**; `std/hash_sha512` gains
+  **SHA-512/224** and **SHA-512/256**. The last two are not truncations
+  of SHA-512: each has its own initial state, so `SHA-512/256(m)` and the
+  first 32 bytes of `SHA-512(m)` are different values, and a test asserts
+  exactly that — an implementation that truncates produces a hash that
+  looks entirely plausible and interoperates with nothing.
+
+  **The vectors earned their keep again.** The OID that goes into the
+  signed representative was written as bare content bytes rather than a
+  full DER encoding, missing the two-byte `06 09` tag and length. Signer
+  and verifier both used the same wrong bytes, so every round trip
+  agreed; only a vector produced elsewhere could show it. The offline
+  test now pins that encoding structurally, by building the
+  representative from a literal OID and requiring the module's pre-hash
+  signature to be byte-identical to a pure-mode signature over it.
+
+  That structural check exists because the obvious test does not work: a
+  "signature under hash A must not verify under hash B" case passes
+  whether the OID is right, wrong or absent, since two hashes give
+  different digests anyway. Both were mutation-tested — the offline test
+  catches a wrong or headerless OID, the ACVP gate catches a wrong
+  digest length — and neither catches the other's.
+
 - **A TLS 1.3 handshake with nothing classical in it.** The hybrid group
   made the key exchange post-quantum, so a recording made today survives
   a future quantum computer. That left the other half: authentication

--- a/compiler/tests/mldsa_vectors.nu
+++ b/compiler/tests/mldsa_vectors.nu
@@ -44,6 +44,7 @@
 
 $ `stdlib/std/mldsa.nu`
 $ `stdlib/std/hash_sha3.nu`
+$ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
@@ -218,6 +219,83 @@ $ `stdlib/core/string.nu`
     ^ ( report label & & & okgood okdup okpad okbig )
 }
 
+// ── HashML-DSA: the OID must bind the hash to the signature ────────
+//
+// Pre-hash mode signs `0x01 ‖ |ctx| ‖ ctx ‖ OID(hash) ‖ H(M)`. The OID
+// is inside the signed representative, which is the entire point: it
+// stops a signature over a SHA2-256 digest from being reinterpreted as
+// one over a SHA3-256 digest of some other message.
+//
+// So a round trip is not enough to test this. The case that matters is
+// the cross check — verifying under a *different* hash code must fail,
+// and it would pass if the OID were omitted or wrong. (A missing
+// two-byte DER header on that OID is exactly the bug the ACVP vectors
+// caught during development; nothing but a real vector or this check
+// would have.)
+@ prehash_cases s label i level → b {
+    : ( Vec u ) xi ( vec_new [u] )
+    : ( Vec u ) msg ( vec_new [u] )
+    : ( Vec u ) ctx ( vec_new [u] )
+    : ~ i i 0
+    ~ < i 32 { ( vec_push [u] xi # u % + * i 13 level 251 ) = i + i 1 }
+    = i 0
+    ~ < i 64 { ( vec_push [u] msg # u % + * i 3 9 251 ) = i + i 1 }
+    ( bytes_extend_str ctx `ph` )
+
+    : *MldsaKeys ks ( mldsa_keygen_derand level xi )
+    : ~ b ok T
+    // Every one of the twelve approved hashes round-trips.
+    : ~ i a 1
+    ~ <= a 12 {
+        : ( Vec u ) sig ( mldsa_sign_prehash level ( mldsa_sk ks ) msg ctx a )
+        = ok & ok > ( vec_len [u] sig ) 0
+        = ok & ok ( mldsa_verify_prehash level ( mldsa_pk ks ) msg ctx a sig )
+        // ...and does not verify under a different hash.
+        : i other ? == a 2 8 2
+        = ok & ok ! ( mldsa_verify_prehash level ( mldsa_pk ks ) msg ctx other sig )
+        // ...nor as a pure-mode signature over the same message.
+        = ok & ok ! ( mldsa_verify level ( mldsa_pk ks ) msg ctx sig )
+        ( vec_free [u] sig )
+        = a + a 1
+    }
+    // The OID must actually be in the signed representative, with its
+    // DER tag and length. The cross-hash check above cannot show this:
+    // two different hashes give different digests anyway, so it passes
+    // whether the OID is right, wrong, or absent. So build M' here from
+    // a literal OID and require the module's pre-hash signature to be
+    // byte-identical to a pure-mode signature over it.
+    //
+    //   M' = 0x01 ‖ |ctx| ‖ ctx ‖ 06 09 <oid> ‖ SHA2-256(M)
+    //
+    // 06 09 is the tag and length; omitting them is a real mistake this
+    // catches, and one only a byte-exact comparison ever would.
+    : ( Vec u ) oid ( hexv `0609608648016503040201` )
+    : ( Vec u ) dig ( sha256_pure msg )
+    : ( Vec u ) mp ( vec_new [u] )
+    ( vec_push [u] mp # u 1 )
+    ( vec_push [u] mp # u ( vec_len [u] ctx ) )
+    ( bytes_extend_bytes mp ctx )
+    ( bytes_extend_bytes mp oid )
+    ( bytes_extend_bytes mp dig )
+    : ( Vec u ) z32 ( vec_with_cap [u] 32 )
+    : ~ i zi 0
+    ~ < zi 32 { ( vec_push [u] z32 # u 0 ) = zi + zi 1 }
+    : ( Vec u ) byhand ( mldsa_sign_internal level ( mldsa_sk ks ) mp z32 )
+    : ( Vec u ) bymod ( mldsa_sign_prehash_deterministic level ( mldsa_sk ks ) msg ctx 2 )
+    = ok & ok ( bytes_eq byhand bymod )
+    ( vec_free [u] bymod ) ( vec_free [u] byhand ) ( vec_free [u] z32 )
+    ( vec_free [u] mp ) ( vec_free [u] dig ) ( vec_free [u] oid )
+
+    // An unknown hash code is refused rather than guessed at.
+    : ( Vec u ) bad ( mldsa_sign_prehash level ( mldsa_sk ks ) msg ctx 99 )
+    = ok & ok == ( vec_len [u] bad ) 0
+    ( vec_free [u] bad )
+
+    ( mldsa_keys_free ks )
+    ( vec_free [u] ctx ) ( vec_free [u] msg ) ( vec_free [u] xi )
+    ^ ( report label ok )
+}
+
 @ main → i {
     : ~ b all T
     = all & all ( kg_case `keygen-44#1    ` 44 `7194b13c95231010afd2c909992bd2003ba6f437c3886bdbe3f6b867a14ba161` `d8d9aa0403ddc91a7f2ab668fea9e85f59a6f519beb9499ffc937d6ed76442e3` `0772f7ccc3674b859c9ed70da44b3559cec44bbdf75b8ea31e04a23fa6871b24` )
@@ -246,5 +324,9 @@ $ `stdlib/core/string.nu`
     = all & all ( hint_cases `hint-44        ` 44 )
     = all & all ( hint_cases `hint-65        ` 65 )
     = all & all ( hint_cases `hint-87        ` 87 )
+    = all & all ( prehash_cases `prehash-44           ` 44 )
+    = all & all ( prehash_cases `prehash-65           ` 65 )
+    = all & all ( prehash_cases `prehash-87           ` 87 )
+
     ^ ? all 0 1
 }

--- a/compiler/tests/outputs/mldsa_vectors.txt
+++ b/compiler/tests/outputs/mldsa_vectors.txt
@@ -15,3 +15,6 @@ roundtrip-87    ok
 hint-44         ok
 hint-65         ok
 hint-87         ok
+prehash-44            ok
+prehash-65            ok
+prehash-87            ok

--- a/compiler/tests/outputs/sha2_variants.txt
+++ b/compiler/tests/outputs/sha2_variants.txt
@@ -1,0 +1,14 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+sha224     empty  ok
+sha224     abc    ok
+sha224     200x   ok
+sha512/224 empty  ok
+sha512/224 abc    ok
+sha512/224 200x   ok
+sha512/256 empty  ok
+sha512/256 abc    ok
+sha512/256 200x   ok
+not a truncation ok

--- a/compiler/tests/sha2_variants.nu
+++ b/compiler/tests/sha2_variants.nu
@@ -1,0 +1,90 @@
+// sha2_variants.nu — SHA-224, SHA-512/224 and SHA-512/256 (FIPS 180-4).
+//
+// Pinned against Python's hashlib. The two SHA-512/t variants are the
+// ones worth testing carefully: they are *not* truncations of SHA-512.
+// Each has its own initial state, derived by running SHA-512 with the
+// standard IV XOR 0xa5a5…, so `SHA-512/256(m)` and the first 32 bytes
+// of `SHA-512(m)` are different values. An implementation that
+// truncates instead produces a hash that looks entirely plausible and
+// interoperates with nothing — so the last case here asserts the two
+// really do differ.
+//
+// These exist for HashML-DSA, whose pre-hash mode names twelve approved
+// digests by OID; SHA2-224, SHA2-512/224 and SHA2-512/256 were the ones
+// stdlib could not compute.
+
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/hash_sha512.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+
+@ chk s label ( Vec u ) got s want → b {
+    : String h ( bytes_to_hex got )
+    : b ok != 0 ( nurl_str_eq ( string_data h ) want )
+    ( nurl_print label )
+    ( nurl_print ? ok ` ok\n` ` FAIL\n` )
+    ? ! ok {
+        ( nurl_print `  got:  ` ) ( nurl_print ( string_data h ) ) ( nurl_print `\n` )
+        ( nurl_print `  want: ` ) ( nurl_print want ) ( nurl_print `\n` )
+    } {}
+    ( string_free h )
+    ^ ok
+}
+
+@ rep i b i n → ( Vec u ) {
+    : ( Vec u ) v ( vec_with_cap [u] n )
+    : ~ i i 0
+    ~ < i n { ( vec_push [u] v # u b ) = i + i 1 }
+    ^ v
+}
+
+@ main → i {
+    : ~ b all T
+    : ( Vec u ) e ( vec_new [u] )
+    : ( Vec u ) abc ( bytes_from_str `abc` )
+    : ( Vec u ) x200 ( rep 120 200 )
+
+    : ( Vec u ) a1 ( sha224_pure e )
+    = all & all ( chk `sha224     empty ` a1 `d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f` )
+    ( vec_free [u] a1 )
+    : ( Vec u ) a2 ( sha224_pure abc )
+    = all & all ( chk `sha224     abc   ` a2 `23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7` )
+    ( vec_free [u] a2 )
+    : ( Vec u ) a3 ( sha224_pure x200 )
+    = all & all ( chk `sha224     200x  ` a3 `3ef8bae4a84311d748956ef862adec84a5745f44618cb3909def1e13` )
+    ( vec_free [u] a3 )
+
+    : ( Vec u ) b1 ( sha512_224_pure e )
+    = all & all ( chk `sha512/224 empty ` b1 `6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4` )
+    ( vec_free [u] b1 )
+    : ( Vec u ) b2 ( sha512_224_pure abc )
+    = all & all ( chk `sha512/224 abc   ` b2 `4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa` )
+    ( vec_free [u] b2 )
+    : ( Vec u ) b3 ( sha512_224_pure x200 )
+    = all & all ( chk `sha512/224 200x  ` b3 `7a97b076373229f0341132277f1b0abb554d4df0f5f9f1e6899626b0` )
+    ( vec_free [u] b3 )
+
+    : ( Vec u ) c1 ( sha512_256_pure e )
+    = all & all ( chk `sha512/256 empty ` c1 `c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a` )
+    ( vec_free [u] c1 )
+    : ( Vec u ) c2 ( sha512_256_pure abc )
+    = all & all ( chk `sha512/256 abc   ` c2 `53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23` )
+    ( vec_free [u] c2 )
+    : ( Vec u ) c3 ( sha512_256_pure x200 )
+    = all & all ( chk `sha512/256 200x  ` c3 `88a392dba7d9b7c883511ffcd41e54709cdb43b20dbb491a8a14beeae391aaa0` )
+    ( vec_free [u] c3 )
+
+    // SHA-512/t is not SHA-512 truncated — different IV, different value.
+    : ( Vec u ) full ( sha512_pure abc )
+    : ( Vec u ) head32 ( bytes_slice full 0 32 )
+    : ( Vec u ) t256 ( sha512_256_pure abc )
+    : b differ ! ( bytes_eq head32 t256 )
+    ( nurl_print `not a truncation ` )
+    ( nurl_print ? differ `ok\n` `FAIL\n` )
+    = all & all differ
+    ( vec_free [u] t256 ) ( vec_free [u] head32 ) ( vec_free [u] full )
+
+    ( vec_free [u] x200 ) ( vec_free [u] abc ) ( vec_free [u] e )
+    ^ ? all 0 1
+}

--- a/docs/CRYPTO.md
+++ b/docs/CRYPTO.md
@@ -27,10 +27,10 @@ All sources live in `stdlib/std/`.
 
 | Area | Module(s) | Notes |
 |---|---|---|
-| Hashes | `hash_sha256`, `hash_sha512`, `hash_sha3`, `hash_sha1`, `hash_md5`, `hash_blake3` | SHA-1/MD5 for legacy interop only (never trusted for signatures) |
+| Hashes | `hash_sha256` (SHA-224/256), `hash_sha512` (SHA-384/512, SHA-512/224, SHA-512/256), `hash_sha3`, `hash_sha1`, `hash_md5`, `hash_blake3` | SHA-1/MD5 for legacy interop only (never trusted for signatures) |
 | XOF | `hash_sha3` (SHAKE128/256) | extendable output, incremental squeeze; ML-KEM is built on it |
 | Post-quantum KEM | `mlkem` (ML-KEM-512/768/1024, FIPS 203) | checked byte-for-byte against NIST's ACVP vectors |
-| Post-quantum signature | `mldsa` (ML-DSA-44/65/87, FIPS 204) | pure and external-mu interfaces; HashML-DSA not implemented |
+| Post-quantum signature | `mldsa` (ML-DSA-44/65/87, FIPS 204) | pure, external-mu and HashML-DSA; all 615 ACVP cases |
 | HMAC / KDF | `hkdf`, `pbkdf2`, `scrypt` | HKDF-Expand-Label for TLS 1.3 |
 | AEAD | `aes_gcm` (AES-128/256-GCM), `chacha20poly1305` | the two TLS 1.3 record ciphers |
 | ECDH / signatures | `x25519`, `ed25519`, `ecdsa_p256` (P-256 + P-384), `p256_field` | TweetNaCl-derived 25519 ladder over a ten-limb radix-2^25.5 field; `p256_field` is the dedicated **constant-time** fixed-limb GF(p) for the P-256 secret path |

--- a/stdlib/std/hash_sha256.nu
+++ b/stdlib/std/hash_sha256.nu
@@ -335,3 +335,31 @@ $ `stdlib/std/bytes.nu`
     ( vec_free [u] kbuf )
     ^ mac
 }
+
+// ── SHA-224 (FIPS 180-4 §6.2) ──────────────────────────────────────
+//
+// The SHA-256 compression function with a different initial state,
+// truncated to 224 bits. Nothing else changes — same block size, same
+// round constants, same schedule — which is why this reuses the whole
+// machinery above rather than repeating it.
+//
+// It exists here for HashML-DSA: FIPS 204's pre-hash mode names twelve
+// approved digests by OID, and a caller who picks SHA2-224 needs the
+// signer to compute exactly that.
+@ sha224_pure ( Vec u ) data → ( Vec u ) {
+    : *Sha256 h ( sha256_init )
+    : *u32 sp ( vec_data [u32] . h state )
+    = . sp 0 # u32 3238371032
+    = . sp 1 # u32 914150663
+    = . sp 2 # u32 812702999
+    = . sp 3 # u32 4144912697
+    = . sp 4 # u32 4290775857
+    = . sp 5 # u32 1750603025
+    = . sp 6 # u32 1694076839
+    = . sp 7 # u32 3204075428
+    ( sha256_update h data )
+    : ( Vec u ) full ( sha256_final h )
+    : ( Vec u ) out ( bytes_slice full 0 28 )
+    ( vec_free [u] full )
+    ^ out
+}

--- a/stdlib/std/hash_sha512.nu
+++ b/stdlib/std/hash_sha512.nu
@@ -339,3 +339,40 @@ $ `stdlib/std/bytes.nu`
     ( vec_free [u] kbuf )
     ^ mac
 }
+
+// ── SHA-512/224 and SHA-512/256 (FIPS 180-4 §6.7) ──────────────────
+//
+// Not truncations of SHA-512: each has its own initial state, derived
+// by running SHA-512 with an IV of the standard one XOR 0xa5a5…, so
+// SHA-512/256(m) and the first 32 bytes of SHA-512(m) are different
+// values. Getting that wrong produces a hash that looks plausible and
+// interoperates with nothing.
+//
+// On a 64-bit machine these are faster than SHA-256 for the same output
+// width, because the compression function works on 64-bit words.
+
+@ sha512_224_pure ( Vec u ) data → ( Vec u ) {
+    : ( Vec u64 ) state ( vec_with_cap [u64] 8 )
+    ( vec_push [u64] state # u64 -8341449602262348382 )
+    ( vec_push [u64] state # u64 8350123849800275158 )
+    ( vec_push [u64] state # u64 2160240930085379202 )
+    ( vec_push [u64] state # u64 7466358040605728719 )
+    ( vec_push [u64] state # u64 1111592415079452072 )
+    ( vec_push [u64] state # u64 8638871050018654530 )
+    ( vec_push [u64] state # u64 4583966954114332360 )
+    ( vec_push [u64] state # u64 1230299281376055969 )
+    ^ ( __sha512_finish data state 28 )
+}
+
+@ sha512_256_pure ( Vec u ) data → ( Vec u ) {
+    : ( Vec u64 ) state ( vec_with_cap [u64] 8 )
+    ( vec_push [u64] state # u64 2463787394917988140 )
+    ( vec_push [u64] state # u64 -6965556091613846334 )
+    ( vec_push [u64] state # u64 2563595384472711505 )
+    ( vec_push [u64] state # u64 -7622211418569250115 )
+    ( vec_push [u64] state # u64 -7626776825740460061 )
+    ( vec_push [u64] state # u64 -4729309413028513390 )
+    ( vec_push [u64] state # u64 3098927326965381290 )
+    ( vec_push [u64] state # u64 1060366662362279074 )
+    ^ ( __sha512_finish data state 32 )
+}

--- a/stdlib/std/mldsa.nu
+++ b/stdlib/std/mldsa.nu
@@ -51,6 +51,8 @@
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/hash_sha3.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/hash_sha512.nu`
 $ `stdlib/std/random.nu`
 $ `stdlib/std/subtle.nu`
 
@@ -1300,6 +1302,160 @@ MldsaParams p ( Vec u ) out → v {
 @ mldsa_verify i level ( Vec u ) pk ( Vec u ) msg ( Vec u ) ctx ( Vec u ) sig → b {
     ? > ( vec_len [u] ctx ) 255 { ^ F } {}
     : ( Vec u ) mp ( __mldsa_mprime msg ctx )
+    : b ok ( mldsa_verify_internal level pk mp sig )
+    ( vec_free [u] mp )
+    ^ ok
+}
+
+// ── HashML-DSA (FIPS 204 §5.4) ─────────────────────────────────────
+//
+// The pre-hash variant: instead of signing the message, sign a digest
+// of it under a named hash. That lets a signer handle a message it
+// never holds whole — a multi-gigabyte file streamed past a hash — and
+// lets a protocol that already has a digest avoid carrying the message
+// to the signer at all.
+//
+// The named hash is not a free choice made at signing time and forgotten:
+// its OID goes *into* the signed message representative, so a signature
+// over a SHA2-256 digest cannot be reinterpreted as one over a SHA3-256
+// digest of some other message. That binding is the whole reason
+// HashML-DSA is a distinct mode rather than "just hash it yourself".
+//
+//   M' = 0x01 ‖ |ctx| ‖ ctx ‖ OID(hash) ‖ H(M)
+//
+// against the pure mode's `0x00 ‖ |ctx| ‖ ctx ‖ M`. The leading byte is
+// what keeps the two from ever colliding.
+//
+// The twelve approved hashes, by the code this module takes:
+//
+//   1 SHA2-224     2 SHA2-256     3 SHA2-384     4 SHA2-512
+//   5 SHA2-512/224 6 SHA2-512/256 7 SHA3-224     8 SHA3-256
+//   9 SHA3-384    10 SHA3-512    11 SHAKE-128   12 SHAKE-256
+//
+// SHAKE-128 and SHAKE-256 are squeezed to 32 and 64 bytes respectively,
+// the lengths FIPS 204 fixes for this use.
+
+@ MLDSA_SHA2_224 → i { ^ 1 }
+
+@ MLDSA_SHA2_256 → i { ^ 2 }
+
+@ MLDSA_SHA2_384 → i { ^ 3 }
+
+@ MLDSA_SHA2_512 → i { ^ 4 }
+
+@ MLDSA_SHA2_512_224 → i { ^ 5 }
+
+@ MLDSA_SHA2_512_256 → i { ^ 6 }
+
+@ MLDSA_SHA3_224 → i { ^ 7 }
+
+@ MLDSA_SHA3_256 → i { ^ 8 }
+
+@ MLDSA_SHA3_384 → i { ^ 9 }
+
+@ MLDSA_SHA3_512 → i { ^ 10 }
+
+@ MLDSA_SHAKE_128 → i { ^ 11 }
+
+@ MLDSA_SHAKE_256 → i { ^ 12 }
+
+// The full DER encoding of 2.16.840.1.101.3.4.2.n, as hex — tag 0x06,
+// length 0x09, then the nine content bytes. FIPS 204 §5.4 puts the
+// *encoded* OID into the message representative, not its content bytes;
+// dropping the two-byte header produces signatures that verify against
+// nothing and is invisible until you compare with a real vector.
+// Empty for an unknown code, which the callers turn into a refusal.
+@ __mldsa_ph_oid_hex i alg → s {
+    ? == alg 1 { ^ `0609608648016503040204` } {}
+    ? == alg 2 { ^ `0609608648016503040201` } {}
+    ? == alg 3 { ^ `0609608648016503040202` } {}
+    ? == alg 4 { ^ `0609608648016503040203` } {}
+    ? == alg 5 { ^ `0609608648016503040205` } {}
+    ? == alg 6 { ^ `0609608648016503040206` } {}
+    ? == alg 7 { ^ `0609608648016503040207` } {}
+    ? == alg 8 { ^ `0609608648016503040208` } {}
+    ? == alg 9 { ^ `0609608648016503040209` } {}
+    ? == alg 10 { ^ `060960864801650304020a` } {}
+    ? == alg 11 { ^ `060960864801650304020b` } {}
+    ? == alg 12 { ^ `060960864801650304020c` } {}
+    ^ ``
+}
+
+@ __mldsa_ph_digest i alg ( Vec u ) msg → ( Vec u ) {
+    ? == alg 1 { ^ ( sha224_pure msg ) } {}
+    ? == alg 2 { ^ ( sha256_pure msg ) } {}
+    ? == alg 3 { ^ ( sha384_pure msg ) } {}
+    ? == alg 4 { ^ ( sha512_pure msg ) } {}
+    ? == alg 5 { ^ ( sha512_224_pure msg ) } {}
+    ? == alg 6 { ^ ( sha512_256_pure msg ) } {}
+    ? == alg 7 { ^ ( sha3_224_pure msg ) } {}
+    ? == alg 8 { ^ ( sha3_256_pure msg ) } {}
+    ? == alg 9 { ^ ( sha3_384_pure msg ) } {}
+    ? == alg 10 { ^ ( sha3_512_pure msg ) } {}
+    ? == alg 11 { ^ ( shake128_pure msg 32 ) } {}
+    ? == alg 12 { ^ ( shake256_pure msg 64 ) } {}
+    ^ ( vec_new [u] )
+}
+
+// The HashML-DSA message representative, `0x01 ‖ |ctx| ‖ ctx ‖ OID ‖
+// H(M)`. Returns an empty Vec when the hash code is not one of the
+// twelve.
+//
+// Public because two real callers need it and neither is served by
+// `mldsa_sign_prehash`: something that wants to sign with a specific
+// `rnd` rather than a fresh draw (the ACVP vectors, a deterministic
+// build), and something that already holds the digest and never had
+// the message.
+@ mldsa_ph_mprime i alg ( Vec u ) msg ( Vec u ) ctx → ( Vec u ) {
+    : s oidhex ( __mldsa_ph_oid_hex alg )
+    ? == ( nurl_str_len oidhex ) 0 { ^ ( vec_new [u] ) } {}
+    : !( Vec u ) ParseErr r ( bytes_from_hex oidhex )
+    : ( Vec u ) oid ?? r { T v → { v } F _e → { ( vec_new [u] ) } }
+    : ( Vec u ) dig ( __mldsa_ph_digest alg msg )
+    : ( Vec u ) m ( vec_new [u] )
+    ( vec_push [u] m # u 1 )
+    ( vec_push [u] m # u ( vec_len [u] ctx ) )
+    ( bytes_extend_bytes m ctx )
+    ( bytes_extend_bytes m oid )
+    ( bytes_extend_bytes m dig )
+    ( vec_free [u] dig )
+    ( vec_free [u] oid )
+    ^ m
+}
+
+// Sign a digest of `msg` under the named hash, bound to `ctx`. Hedged,
+// like `mldsa_sign`. Returns an empty Vec for an unknown hash code or a
+// context longer than 255 bytes.
+@ mldsa_sign_prehash i level ( Vec u ) sk ( Vec u ) msg ( Vec u ) ctx i alg → ( Vec u ) {
+    ? > ( vec_len [u] ctx ) 255 { ^ ( vec_new [u] ) } {}
+    : ( Vec u ) mp ( mldsa_ph_mprime alg msg ctx )
+    ? == ( vec_len [u] mp ) 0 { ( vec_free [u] mp ) ^ ( vec_new [u] ) } {}
+    : ( Vec u ) rnd ( rand_bytes 32 )
+    : ( Vec u ) sig ( mldsa_sign_internal level sk mp rnd )
+    ( vec_free [u] rnd )
+    ( vec_free [u] mp )
+    ^ sig
+}
+
+// Deterministic HashML-DSA, for interoperability and for the ACVP
+// vectors; `mldsa_sign_prehash` is the better default.
+@ mldsa_sign_prehash_deterministic i level ( Vec u ) sk ( Vec u ) msg ( Vec u ) ctx i alg → ( Vec u ) {
+    ? > ( vec_len [u] ctx ) 255 { ^ ( vec_new [u] ) } {}
+    : ( Vec u ) mp ( mldsa_ph_mprime alg msg ctx )
+    ? == ( vec_len [u] mp ) 0 { ( vec_free [u] mp ) ^ ( vec_new [u] ) } {}
+    : ( Vec u ) rnd ( vec_with_cap [u] 32 )
+    : ~ i i 0
+    ~ < i 32 { ( vec_push [u] rnd # u 0 ) = i + i 1 }
+    : ( Vec u ) sig ( mldsa_sign_internal level sk mp rnd )
+    ( vec_free [u] rnd )
+    ( vec_free [u] mp )
+    ^ sig
+}
+
+@ mldsa_verify_prehash i level ( Vec u ) pk ( Vec u ) msg ( Vec u ) ctx i alg ( Vec u ) sig → b {
+    ? > ( vec_len [u] ctx ) 255 { ^ F } {}
+    : ( Vec u ) mp ( mldsa_ph_mprime alg msg ctx )
+    ? == ( vec_len [u] mp ) 0 { ( vec_free [u] mp ) ^ F } {}
     : b ok ( mldsa_verify_internal level pk mp sig )
     ( vec_free [u] mp )
     ^ ok

--- a/tools/mldsa_acvp_gate.nu
+++ b/tools/mldsa_acvp_gate.nu
@@ -9,11 +9,14 @@
 // The JSON is NIST's own `internalProjection.json`, carrying expected
 // outputs beside the inputs, so every case is a byte-exact comparison.
 //
-//   keyGen   seed        -> pk, sk
-//   sigGen   sk, message -> signature   (deterministic and hedged,
-//                                        internal and external, and the
-//                                        external-mu interface)
-//   sigVer   pk, message, signature -> accept / reject
+//   keyGen    75  seed        -> pk, sk
+//   sigGen   360  sk, message -> signature
+//   sigVer   180  pk, message, signature -> accept / reject
+//
+// sigGen and sigVer each cover every interface FIPS 204 defines:
+// deterministic and hedged, internal and external, external-mu, and
+// HashML-DSA across all twelve approved pre-hash algorithms. Nothing is
+// skipped.
 //
 // The sigVer set is the valuable half: only a fifth of its cases are
 // valid signatures. The rest are tampered in one of four specific ways
@@ -21,8 +24,11 @@
 // hint — and a verifier that accepts any of them is broken in a way no
 // amount of round-tripping would reveal.
 //
-// HashML-DSA (the `preHash` groups) is not implemented, so those cases
-// are counted as skipped and the count is printed rather than hidden.
+// The pre-hash cases earn their place: they are what caught the OID in
+// the message representative being written as bare content bytes rather
+// than a full DER encoding (missing the two-byte 06 09 tag and length).
+// Signing and verifying both used the same wrong bytes, so every round
+// trip agreed and nothing but a foreign vector could have noticed.
 $ `stdlib/core/vec.nu`
 $ `stdlib/core/string.nu`
 $ `stdlib/std/bytes.nu`
@@ -48,6 +54,24 @@ $ `stdlib/std/mldsa.nu`
 @ __hexv s h → ( Vec u ) {
     ? == ( nurl_str_len h ) 0 { ^ ( vec_new [u] ) } {}
     ?? ( bytes_from_hex h ) { T v → { ^ v } F _e → { ^ ( vec_new [u] ) } }
+}
+
+// ACVP names the pre-hash algorithm as a string; map it to the code
+// std/mldsa.nu takes. 0 = not one we implement.
+@ __ph_alg s h → i {
+    ? != 0 ( nurl_str_eq h `SHA2-224` ) { ^ 1 } {}
+    ? != 0 ( nurl_str_eq h `SHA2-256` ) { ^ 2 } {}
+    ? != 0 ( nurl_str_eq h `SHA2-384` ) { ^ 3 } {}
+    ? != 0 ( nurl_str_eq h `SHA2-512` ) { ^ 4 } {}
+    ? != 0 ( nurl_str_eq h `SHA2-512/224` ) { ^ 5 } {}
+    ? != 0 ( nurl_str_eq h `SHA2-512/256` ) { ^ 6 } {}
+    ? != 0 ( nurl_str_eq h `SHA3-224` ) { ^ 7 } {}
+    ? != 0 ( nurl_str_eq h `SHA3-256` ) { ^ 8 } {}
+    ? != 0 ( nurl_str_eq h `SHA3-384` ) { ^ 9 } {}
+    ? != 0 ( nurl_str_eq h `SHA3-512` ) { ^ 10 } {}
+    ? != 0 ( nurl_str_eq h `SHAKE-128` ) { ^ 11 } {}
+    ? != 0 ( nurl_str_eq h `SHAKE-256` ) { ^ 12 } {}
+    ^ 0
 }
 
 @ __level Json g → i {
@@ -109,9 +133,9 @@ $ `stdlib/std/mldsa.nu`
     ( __report `keyGen` kp kf 0 )
     = totfail + totfail kf
 
-    // ── sigGen: internal interface and external pure only.
-    // preHash needs SHA-2, which is a different module's job; those
-    // groups are counted as skipped rather than silently ignored.
+    // ── sigGen: every interface, including HashML-DSA. A group whose
+    // pre-hash algorithm this module does not know is counted as
+    // skipped rather than silently passed over.
     : Json sg ( __load ( nurl_argv_get 2 ) )
     : Json sgg ?? ( json_obj_get sg `testGroups` ) { T v → { v } F → { ( json_null ) } }
     : ~ i sp 0
@@ -139,22 +163,27 @@ $ `stdlib/std/mldsa.nu`
                 ? ( __eqhex sig ( __str tc `signature` ) ) { = sp + sp 1 } { = sf + sf 1 }
                 ( vec_free [u] sig ) ( vec_free [u] rnd ) ( vec_free [u] mu ) ( vec_free [u] sk )
             } {
-                ? ! | internal pure { = ss + ss 1 } {
+                ? & ! | internal pure == 0 ( __ph_alg ( __str tc `hashAlg` ) ) { = ss + ss 1 } {
                     : ( Vec u ) sk ( __hexv ( __str tc `sk` ) )
                     : ( Vec u ) msg ( __hexv ( __str tc `message` ) )
                     : ( Vec u ) rnd ? det ( __hexv `0000000000000000000000000000000000000000000000000000000000000000` ) ( __hexv ( __str tc `rnd` ) )
+                    : ( Vec u ) ctx ( __hexv ( __str tc `context` ) )
                     : ~ ( Vec u ) mp ( vec_new [u] )
                     ? internal {
                         ( vec_free [u] mp )
                         = mp ( bytes_slice msg 0 ( vec_len [u] msg ) )
                     } {
-                        : ( Vec u ) ctx ( __hexv ( __str tc `context` ) )
-                        ( vec_push [u] mp # u 0 )
-                        ( vec_push [u] mp # u ( vec_len [u] ctx ) )
-                        ( bytes_extend_bytes mp ctx )
-                        ( bytes_extend_bytes mp msg )
-                        ( vec_free [u] ctx )
+                        ? pure {
+                            ( vec_push [u] mp # u 0 )
+                            ( vec_push [u] mp # u ( vec_len [u] ctx ) )
+                            ( bytes_extend_bytes mp ctx )
+                            ( bytes_extend_bytes mp msg )
+                        } {
+                            ( vec_free [u] mp )
+                            = mp ( mldsa_ph_mprime ( __ph_alg ( __str tc `hashAlg` ) ) msg ctx )
+                        }
                     }
+                    ( vec_free [u] ctx )
                     : ( Vec u ) sig ( mldsa_sign_internal level sk mp rnd )
                     ? ( __eqhex sig ( __str tc `signature` ) ) { = sp + sp 1 } { = sf + sf 1 }
                     ( vec_free [u] sig )
@@ -197,22 +226,27 @@ $ `stdlib/std/mldsa.nu`
                 ? == ( mldsa_verify_mu level pk mu sig ) ( __bool tc `testPassed` ) { = vp + vp 1 } { = vf + vf 1 }
                 ( vec_free [u] sig ) ( vec_free [u] mu ) ( vec_free [u] pk )
             } {
-                ? ! | internal pure { = vs + vs 1 } {
+                ? & ! | internal pure == 0 ( __ph_alg ( __str tc `hashAlg` ) ) { = vs + vs 1 } {
                     : ( Vec u ) pk ( __hexv ( __str tc `pk` ) )
                     : ( Vec u ) msg ( __hexv ( __str tc `message` ) )
                     : ( Vec u ) sig ( __hexv ( __str tc `signature` ) )
+                    : ( Vec u ) ctx ( __hexv ( __str tc `context` ) )
                     : ~ ( Vec u ) mp ( vec_new [u] )
                     ? internal {
                         ( vec_free [u] mp )
                         = mp ( bytes_slice msg 0 ( vec_len [u] msg ) )
                     } {
-                        : ( Vec u ) ctx ( __hexv ( __str tc `context` ) )
-                        ( vec_push [u] mp # u 0 )
-                        ( vec_push [u] mp # u ( vec_len [u] ctx ) )
-                        ( bytes_extend_bytes mp ctx )
-                        ( bytes_extend_bytes mp msg )
-                        ( vec_free [u] ctx )
+                        ? pure {
+                            ( vec_push [u] mp # u 0 )
+                            ( vec_push [u] mp # u ( vec_len [u] ctx ) )
+                            ( bytes_extend_bytes mp ctx )
+                            ( bytes_extend_bytes mp msg )
+                        } {
+                            ( vec_free [u] mp )
+                            = mp ( mldsa_ph_mprime ( __ph_alg ( __str tc `hashAlg` ) ) msg ctx )
+                        }
                     }
+                    ( vec_free [u] ctx )
                     : b got ( mldsa_verify_internal level pk mp sig )
                     : b want ( __bool tc `testPassed` )
                     ? == got want { = vp + vp 1 } { = vf + vf 1 }

--- a/tools/mldsa_acvp_gate.sh
+++ b/tools/mldsa_acvp_gate.sh
@@ -11,9 +11,10 @@
 #  someone else's output, and NIST publishes both.
 #
 #    keyGen   75   seed → pk, sk, byte for byte
-#    sigGen  270   sk, message → signature, deterministic and hedged,
-#                  internal and external interfaces, and external-mu
-#    sigVer  135   pk, message, signature → accept / reject
+#    sigGen  360   sk, message → signature; deterministic and hedged,
+#                  internal and external, external-mu, and HashML-DSA
+#                  across all twelve approved pre-hash algorithms
+#    sigVer  180   pk, message, signature → accept / reject
 #
 #  The sigVer set carries the weight. Only a fifth of its cases are
 #  valid signatures; the rest are tampered in four specific ways —
@@ -23,8 +24,11 @@
 #  hint encoding, which is a forgery derived from a genuine signature
 #  rather than a broken signature.
 #
-#  HashML-DSA (the `preHash` groups) is not implemented; those cases
-#  are reported as skipped rather than passed over silently.
+#  The pre-hash cases earn their place. They caught the OID inside the
+#  message representative being written as bare content bytes instead of
+#  a full DER encoding — the two-byte 06 09 tag and length were missing.
+#  Signer and verifier both used the same wrong bytes, so every round
+#  trip agreed; only a vector produced elsewhere could show it.
 #
 #  Usage:  tools/mldsa_acvp_gate.sh
 #  Env:    NURL         build driver (defaults to ./nurl.sh in a checkout)


### PR DESCRIPTION
ML-DSA now covers every interface FIPS 204 defines. **All 615 published
ACVP cases pass with none skipped** — up from 480 run and 135 skipped in
#932.

```
keyGen:  75 passed, 0 failed, 0 skipped
sigGen: 360 passed, 0 failed, 0 skipped
sigVer: 180 passed, 0 failed, 0 skipped
```

## HashML-DSA (FIPS 204 §5.4)

Pre-hash mode signs a digest instead of the message, so a signer can
handle a message it never holds whole — a large file streamed past a
hash — or a protocol that already has a digest need not carry the
message to the signer at all. All twelve approved hashes are supported.

`mldsa_ph_mprime` is public for callers who already hold the digest or
who must supply their own signing randomness. It was file-private and
the gate reached across files for it, which the compiler rightly warns
is obsolete.

## The SHA-2 variants

`std/hash_sha256` gains **SHA-224**; `std/hash_sha512` gains
**SHA-512/224** and **SHA-512/256**.

The last two are *not* truncations of SHA-512. Each has its own initial
state, derived by running SHA-512 with the standard IV XOR `0xa5a5…`, so
`SHA-512/256(m)` and the first 32 bytes of `SHA-512(m)` are different
values. A test asserts exactly that, because an implementation that
truncates produces a hash that looks entirely plausible and
interoperates with nothing.

## The vectors earned their keep again

The OID that goes into the signed representative was written as bare
content bytes rather than a full DER encoding — the two-byte `06 09` tag
and length were missing. Signer and verifier both used the same wrong
bytes, so **every round trip agreed and every self-consistency check
passed**. Only a vector produced elsewhere could show it.

### And the obvious test for it does not work

My first attempt asserted that a signature made under hash A must not
verify under hash B. That passes whether the OID is right, wrong, or
absent — two different hashes give different digests anyway, so the OID
never has to do any work. I wrote it, watched both OID mutations survive
it, and replaced it.

The offline test now pins the encoding **structurally**: it builds the
message representative from a literal OID —

```
M' = 0x01 || |ctx| || ctx || 06 09 <oid> || SHA2-256(M)
```

— and requires the module's pre-hash signature to be byte-identical to a
pure-mode signature over it.

Both layers are mutation-tested, and neither subsumes the other:

| mutation | offline test | ACVP gate |
|---|---|---|
| OID DER header dropped | **caught** | caught |
| all OIDs made identical | **caught** | caught |
| SHAKE-128 squeezed to 64 not 32 | missed | **caught** (9 sigGen, 1 sigVer) |

## A process note worth carrying

An edit applied by string replacement matched nothing after `nurlfmt`
had reindented the target, so the gate kept reporting `PASS` while
silently skipping every pre-hash group. The skip counts were the only
tell.

Same shape as the leak harness in #934 that never compiled: **a check
that reports success is not evidence it ran the thing you changed.**
Twice in two sessions, so it is going in the method notes.

## Test status

- 842 compiler tests pass (1 new), 0 failures
- ML-DSA 615/615 and ML-KEM 180/180 ACVP cases
- ASan/LSan clean on both new tests
- strict-arity, stdlib-symbols, package-imports gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
