### PR TITLE
perf: the PQ stack is 12-29% faster, from two changes the profile picked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The post-quantum stack got 12–29% faster, from two changes the
+  profile picked.** Nothing was guessed: `perf --call-graph lbr` put
+  `__keccakf1600` at **40.6%** of all PQ time — everything in both
+  schemes rides on SHAKE — and a disassembly histogram showed the round
+  compiling to **191 `mov`s against ~155 real ALU instructions**. More
+  than half the work was spilling.
+
+  The cause: materialising all 25 ρ+π results and then running χ over
+  them leaves 35 values live on a 16-register machine. χ cannot consume
+  them a row at a time in place, because ρ+π scatters lanes across rows
+  and χ's first row would overwrite lanes its fourth row still needs.
+  Writing each χ row into a *second* buffer removes the conflict, so
+  only one row's five values need to exist at once — live set drops to
+  ten. The buffers ping-pong; 24 rounds is even, so the state lands back
+  where the caller left it. Round: 367 → 249 instructions, `mov`s 191 →
+  73, with `rol`/`xor`/`not`/`and` counts unchanged. SHAKE128 squeeze:
+  **260 → 354 MB/s**.
+
+  Then ML-DSA's rounding. `Decompose`, `Power2Round` and `UseHint` were
+  written in the spec's `mod±` form, which reads as a remainder and
+  compiles to `idiv`; they run 256·k times per signing attempt and
+  signing retries several times. The reciprocal-multiply forms are
+  division-free, and `MakeHint` now derives the hint from the decomposed
+  pair the signer already has rather than calling `HighBits` twice per
+  coefficient.
+
+  | | before | after |
+  |---|---|---|
+  | ML-KEM-768 keygen | 18.3k/s | 20.8k/s |
+  | ML-KEM-1024 keygen | 11.9k/s | 14.2k/s |
+  | ML-DSA-65 keygen | 4.8k/s | 6.1k/s |
+  | ML-DSA-65 sign | 1356/s | 1737/s |
+  | ML-DSA-44 verify | 7.7k/s | 9.8k/s |
+
+  Every ACVP vector still passes byte-for-byte — 180 ML-KEM and 615
+  ML-DSA — which is the point of having them: a rewrite of the
+  permutation and of three rounding routines is exactly the change that
+  needs an oracle it cannot influence.
+
 ### Added
 
 - **HashML-DSA (FIPS 204 §5.4), and the three SHA-2 variants it needed.**

--- a/stdlib/std/hash_sha3.nu
+++ b/stdlib/std/hash_sha3.nu
@@ -33,6 +33,10 @@
 // byte) automatically; absorbing after that is a programming error and
 // is ignored. The one-shot entries above are thin compositions of the
 // streaming ones, so the two paths cannot drift.
+//
+// A sponge carries a 25-lane scratch buffer alongside its state, which
+// the permutation ping-pongs against; see __keccakf1600 for why. That
+// is the only reason `sha3_new` allocates more than the state itself.
 
 $ `stdlib/core/vec.nu`
 $ `stdlib/std/bytes.nu`
@@ -66,83 +70,106 @@ $ `stdlib/std/bytes.nu`
     ^ v
 }
 
-// The permutation, in place over 25 lanes.
+// The permutation, over 25 lanes, ping-ponging between two buffers.
 //
 // θ's D-values are folded straight into ρ+π rather than written back to
 // the state first: b[dst] = rotl(a[src] ^ d[src mod 5], r[src]) does in
-// one pass what the spec describes as two. The 25 lanes are held in
-// named locals across the round so the whole body stays in registers —
-// spelled as loops over the state array instead, every lane would be
-// re-loaded three times a round, 24 rounds deep, for a permutation that
-// is otherwise pure ALU.
-@ __keccakf1600 * u64 a * u64 rc → v {
+// one pass what the spec describes as two.
+//
+// The reason for the second buffer is register pressure. Written the
+// obvious way — materialise all 25 ρ+π results, then run χ over them —
+// 35 values are live at once on a machine with 16 general registers,
+// and the round becomes 191 `mov`s against 155 real ALU instructions:
+// more than half the work is spilling. χ cannot simply consume them a
+// row at a time in place either, because ρ+π scatters lanes across
+// rows, so χ's first row would overwrite lanes its fourth row still
+// needs.
+//
+// Writing each χ row into a *different* buffer removes that conflict,
+// and then only one row's five values need to exist at a time. Live
+// set drops to the five D-values plus five row temporaries, which fits
+// in registers. The buffers swap every round; 24 is even, so the result
+// lands back where the caller left the state.
+@ __keccakf1600 * u64 a * u64 b * u64 rc → v {
     : ~ i rnd 0
     ~ < rnd 24 {
-        // θ — column parities
-        : u64 c0 ^^ ^^ ^^ ^^ . a 0 . a 5 . a 10 . a 15 . a 20
-        : u64 c1 ^^ ^^ ^^ ^^ . a 1 . a 6 . a 11 . a 16 . a 21
-        : u64 c2 ^^ ^^ ^^ ^^ . a 2 . a 7 . a 12 . a 17 . a 22
-        : u64 c3 ^^ ^^ ^^ ^^ . a 3 . a 8 . a 13 . a 18 . a 23
-        : u64 c4 ^^ ^^ ^^ ^^ . a 4 . a 9 . a 14 . a 19 . a 24
+        // Even rounds read a and write b; odd rounds the other way.
+        : b even == % rnd 2 0
+        : *u64 s ? even a b
+        : *u64 o ? even b a
+
+        // θ — column parities, then the five D-values. C is dead after
+        // this, so only D stays live across the rows below.
+        : u64 c0 ^^ ^^ ^^ ^^ . s 0 . s 5 . s 10 . s 15 . s 20
+        : u64 c1 ^^ ^^ ^^ ^^ . s 1 . s 6 . s 11 . s 16 . s 21
+        : u64 c2 ^^ ^^ ^^ ^^ . s 2 . s 7 . s 12 . s 17 . s 22
+        : u64 c3 ^^ ^^ ^^ ^^ . s 3 . s 8 . s 13 . s 18 . s 23
+        : u64 c4 ^^ ^^ ^^ ^^ . s 4 . s 9 . s 14 . s 19 . s 24
         : u64 d0 ^^ c4 ( __k_rotl c1 1 )
         : u64 d1 ^^ c0 ( __k_rotl c2 1 )
         : u64 d2 ^^ c1 ( __k_rotl c3 1 )
         : u64 d3 ^^ c2 ( __k_rotl c4 1 )
         : u64 d4 ^^ c3 ( __k_rotl c0 1 )
 
-        // ρ + π, with θ applied on the way in
-        : u64 b0 ^^ . a 0 d0
-        : u64 b1 ( __k_rotl ^^ . a 6 d1 44 )
-        : u64 b2 ( __k_rotl ^^ . a 12 d2 43 )
-        : u64 b3 ( __k_rotl ^^ . a 18 d3 21 )
-        : u64 b4 ( __k_rotl ^^ . a 24 d4 14 )
-        : u64 b5 ( __k_rotl ^^ . a 3 d3 28 )
-        : u64 b6 ( __k_rotl ^^ . a 9 d4 20 )
-        : u64 b7 ( __k_rotl ^^ . a 10 d0 3 )
-        : u64 b8 ( __k_rotl ^^ . a 16 d1 45 )
-        : u64 b9 ( __k_rotl ^^ . a 22 d2 61 )
-        : u64 b10 ( __k_rotl ^^ . a 1 d1 1 )
-        : u64 b11 ( __k_rotl ^^ . a 7 d2 6 )
-        : u64 b12 ( __k_rotl ^^ . a 13 d3 25 )
-        : u64 b13 ( __k_rotl ^^ . a 19 d4 8 )
-        : u64 b14 ( __k_rotl ^^ . a 20 d0 18 )
-        : u64 b15 ( __k_rotl ^^ . a 4 d4 27 )
-        : u64 b16 ( __k_rotl ^^ . a 5 d0 36 )
-        : u64 b17 ( __k_rotl ^^ . a 11 d1 10 )
-        : u64 b18 ( __k_rotl ^^ . a 17 d2 15 )
-        : u64 b19 ( __k_rotl ^^ . a 23 d3 56 )
-        : u64 b20 ( __k_rotl ^^ . a 2 d2 62 )
-        : u64 b21 ( __k_rotl ^^ . a 8 d3 55 )
-        : u64 b22 ( __k_rotl ^^ . a 14 d4 39 )
-        : u64 b23 ( __k_rotl ^^ . a 15 d0 41 )
-        : u64 b24 ( __k_rotl ^^ . a 21 d1 2 )
+        // Row 0 ← lanes 0, 6, 12, 18, 24
+        : u64 r00 ^^ . s 0 d0
+        : u64 r01 ( __k_rotl ^^ . s 6 d1 44 )
+        : u64 r02 ( __k_rotl ^^ . s 12 d2 43 )
+        : u64 r03 ( __k_rotl ^^ . s 18 d3 21 )
+        : u64 r04 ( __k_rotl ^^ . s 24 d4 14 )
+        = . o 0 ^^ ^^ r00 & ~ r01 r02 . rc rnd
+        = . o 1 ^^ r01 & ~ r02 r03
+        = . o 2 ^^ r02 & ~ r03 r04
+        = . o 3 ^^ r03 & ~ r04 r00
+        = . o 4 ^^ r04 & ~ r00 r01
 
-        // χ — row-wise, then ι on lane 0
-        = . a 0 ^^ ^^ b0 & ~ b1 b2 . rc rnd
-        = . a 1 ^^ b1 & ~ b2 b3
-        = . a 2 ^^ b2 & ~ b3 b4
-        = . a 3 ^^ b3 & ~ b4 b0
-        = . a 4 ^^ b4 & ~ b0 b1
-        = . a 5 ^^ b5 & ~ b6 b7
-        = . a 6 ^^ b6 & ~ b7 b8
-        = . a 7 ^^ b7 & ~ b8 b9
-        = . a 8 ^^ b8 & ~ b9 b5
-        = . a 9 ^^ b9 & ~ b5 b6
-        = . a 10 ^^ b10 & ~ b11 b12
-        = . a 11 ^^ b11 & ~ b12 b13
-        = . a 12 ^^ b12 & ~ b13 b14
-        = . a 13 ^^ b13 & ~ b14 b10
-        = . a 14 ^^ b14 & ~ b10 b11
-        = . a 15 ^^ b15 & ~ b16 b17
-        = . a 16 ^^ b16 & ~ b17 b18
-        = . a 17 ^^ b17 & ~ b18 b19
-        = . a 18 ^^ b18 & ~ b19 b15
-        = . a 19 ^^ b19 & ~ b15 b16
-        = . a 20 ^^ b20 & ~ b21 b22
-        = . a 21 ^^ b21 & ~ b22 b23
-        = . a 22 ^^ b22 & ~ b23 b24
-        = . a 23 ^^ b23 & ~ b24 b20
-        = . a 24 ^^ b24 & ~ b20 b21
+        // Row 1 ← lanes 3, 9, 10, 16, 22
+        : u64 r10 ( __k_rotl ^^ . s 3 d3 28 )
+        : u64 r11 ( __k_rotl ^^ . s 9 d4 20 )
+        : u64 r12 ( __k_rotl ^^ . s 10 d0 3 )
+        : u64 r13 ( __k_rotl ^^ . s 16 d1 45 )
+        : u64 r14 ( __k_rotl ^^ . s 22 d2 61 )
+        = . o 5 ^^ r10 & ~ r11 r12
+        = . o 6 ^^ r11 & ~ r12 r13
+        = . o 7 ^^ r12 & ~ r13 r14
+        = . o 8 ^^ r13 & ~ r14 r10
+        = . o 9 ^^ r14 & ~ r10 r11
+
+        // Row 2 ← lanes 1, 7, 13, 19, 20
+        : u64 r20 ( __k_rotl ^^ . s 1 d1 1 )
+        : u64 r21 ( __k_rotl ^^ . s 7 d2 6 )
+        : u64 r22 ( __k_rotl ^^ . s 13 d3 25 )
+        : u64 r23 ( __k_rotl ^^ . s 19 d4 8 )
+        : u64 r24 ( __k_rotl ^^ . s 20 d0 18 )
+        = . o 10 ^^ r20 & ~ r21 r22
+        = . o 11 ^^ r21 & ~ r22 r23
+        = . o 12 ^^ r22 & ~ r23 r24
+        = . o 13 ^^ r23 & ~ r24 r20
+        = . o 14 ^^ r24 & ~ r20 r21
+
+        // Row 3 ← lanes 4, 5, 11, 17, 23
+        : u64 r30 ( __k_rotl ^^ . s 4 d4 27 )
+        : u64 r31 ( __k_rotl ^^ . s 5 d0 36 )
+        : u64 r32 ( __k_rotl ^^ . s 11 d1 10 )
+        : u64 r33 ( __k_rotl ^^ . s 17 d2 15 )
+        : u64 r34 ( __k_rotl ^^ . s 23 d3 56 )
+        = . o 15 ^^ r30 & ~ r31 r32
+        = . o 16 ^^ r31 & ~ r32 r33
+        = . o 17 ^^ r32 & ~ r33 r34
+        = . o 18 ^^ r33 & ~ r34 r30
+        = . o 19 ^^ r34 & ~ r30 r31
+
+        // Row 4 ← lanes 2, 8, 14, 15, 21
+        : u64 r40 ( __k_rotl ^^ . s 2 d2 62 )
+        : u64 r41 ( __k_rotl ^^ . s 8 d3 55 )
+        : u64 r42 ( __k_rotl ^^ . s 14 d4 39 )
+        : u64 r43 ( __k_rotl ^^ . s 15 d0 41 )
+        : u64 r44 ( __k_rotl ^^ . s 21 d1 2 )
+        = . o 20 ^^ r40 & ~ r41 r42
+        = . o 21 ^^ r41 & ~ r42 r43
+        = . o 22 ^^ r42 & ~ r43 r44
+        = . o 23 ^^ r43 & ~ r44 r40
+        = . o 24 ^^ r44 & ~ r40 r41
 
         = rnd + rnd 1
     }
@@ -152,6 +179,7 @@ $ `stdlib/std/bytes.nu`
 
 : Sha3 {
     ( Vec u64 ) st  // 25 lanes
+    ( Vec u64 ) scr  // 25-lane ping-pong buffer for the permutation
     ( Vec u64 ) rc  // ι constants
     i rate  // bytes absorbed/squeezed per permutation
     i pos  // byte offset into the current block
@@ -170,6 +198,9 @@ $ `stdlib/std/bytes.nu`
     : ~ i i 0
     ~ < i 25 { = . sp i # u64 0 = i + i 1 }
     = . h st st
+    : ( Vec u64 ) scr ( vec_with_cap [u64] 25 )
+    : b _s ( vec_set_len [u64] scr 25 )
+    = . h scr scr
     = . h rc ( __keccak_rc )
     = . h rate rate
     = . h pos 0
@@ -180,6 +211,7 @@ $ `stdlib/std/bytes.nu`
 
 @ sha3_free * Sha3 h → v {
     ( vec_free [u64] . h st )
+    ( vec_free [u64] . h scr )
     ( vec_free [u64] . h rc )
     ( nurl_free # s h )
 }
@@ -221,7 +253,7 @@ $ `stdlib/std/bytes.nu`
             = pos + pos 1
         }
         ? >= pos rate {
-            ( __keccakf1600 sp ( vec_data [u64] . h rc ) )
+            ( __keccakf1600 sp ( vec_data [u64] . h scr ) ( vec_data [u64] . h rc ) )
             = pos 0
         } {}
     }
@@ -245,7 +277,7 @@ $ `stdlib/std/bytes.nu`
     = . sp / pos 8 ^^ . sp / pos 8 << # u64 . h dom # u64 * 8 % pos 8
     : i last - rate 1
     = . sp / last 8 ^^ . sp / last 8 << # u64 128 # u64 * 8 % last 8
-    ( __keccakf1600 sp ( vec_data [u64] . h rc ) )
+    ( __keccakf1600 sp ( vec_data [u64] . h scr ) ( vec_data [u64] . h rc ) )
     = . h pos 0
     = . h squeezing T
 }
@@ -266,7 +298,7 @@ $ `stdlib/std/bytes.nu`
     : ~ i pos . h pos
     ~ < off n {
         ? >= pos rate {
-            ( __keccakf1600 sp ( vec_data [u64] . h rc ) )
+            ( __keccakf1600 sp ( vec_data [u64] . h scr ) ( vec_data [u64] . h rc ) )
             = pos 0
         } {}
         ? & == % pos 8 0 & <= + pos 8 rate <= + off 8 n {

--- a/stdlib/std/mldsa.nu
+++ b/stdlib/std/mldsa.nu
@@ -374,13 +374,20 @@ $ `stdlib/std/subtle.nu`
 
 // Power2Round: split r into high bits r1 and centred low bits r0 with
 // r = r1·2^13 + r0.
+//
+// Division-free. The spec states these in terms of `mod±`, which reads
+// as a remainder; every one of them is a shift and a mask on a power of
+// two, or a reciprocal multiply where the modulus is not one. That
+// matters here because rounding runs 256·k times per signing attempt
+// and signing retries several times: a 25-cycle `idiv` in that loop
+// costs more than the polynomial arithmetic around it.
 @ __poly_power2round * i32 a1 i o1 * i32 a0 i o0 * i32 a i oa → v {
     : ~ i i 0
     ~ < i 256 {
-        : i r ( __caddq . a + oa i )
-        : i r0 ( __modpm r 8192 )
-        = . a1 + o1 i # i32 >> - r r0 13
-        = . a0 + o0 i # i32 r0
+        : i32 x ( __caddq . a + oa i )
+        : i32 t1 >> + x # i32 4095 # i32 13
+        = . a1 + o1 i t1
+        = . a0 + o0 i - x << t1 # i32 13
         = i + i 1
     }
 }
@@ -388,39 +395,74 @@ $ `stdlib/std/subtle.nu`
 // Decompose: r = r1·2γ2 + r0 with r0 centred, except at the wrap point
 // where r1 is forced to 0 — the case that makes HighBits take only
 // (q−1)/(2γ2) distinct values.
+//
+// The two parameter sets need different reciprocals, so the branch is
+// hoisted out of the loop. 1025/2^22 approximates 1/(2·261888) and
+// 11275/2^24 approximates 1/(2·95232), each chosen so the truncating
+// shift lands on the exact quotient over the whole input range. The
+// wrap case falls out of the arithmetic rather than needing a compare:
+// for γ2=(q−1)/32 the mask `& 15` wraps 16 to 0, and for (q−1)/88 the
+// `^` folds 44 back to 0.
 @ __poly_decompose * i32 a1 i o1 * i32 a0 i o0 * i32 a i oa i g2 → v {
     : ~ i i 0
-    ~ < i 256 {
-        : i r ( __caddq . a + oa i )
-        : i r0 ( __modpm r * 2 g2 )
-        ? == - r r0 8380416 {
-            = . a1 + o1 i # i32 0
-            = . a0 + o0 i # i32 - r0 1
-        } {
-            = . a1 + o1 i # i32 / - r r0 * 2 g2
-            = . a0 + o0 i # i32 r0
+    ? == g2 261888 {
+        ~ < i 256 {
+            : i32 x ( __caddq . a + oa i )
+            : ~ i32 t1 >> + x # i32 127 # i32 7
+            = t1 & >> + * t1 # i32 1025 # i32 2097152 # i32 22 # i32 15
+            : ~ i32 t0 - x * t1 # i32 523776
+            = t0 - t0 & >> - # i32 4190208 t0 # i32 31 # i32 8380417
+            = . a1 + o1 i t1
+            = . a0 + o0 i t0
+            = i + i 1
         }
-        = i + i 1
+    } {
+        ~ < i 256 {
+            : i32 x ( __caddq . a + oa i )
+            : ~ i32 t1 >> + x # i32 127 # i32 7
+            = t1 >> + * t1 # i32 11275 # i32 8388608 # i32 24
+            = t1 ^^ t1 & >> - # i32 43 t1 # i32 31 t1
+            : ~ i32 t0 - x * t1 # i32 190464
+            = t0 - t0 & >> - # i32 4190208 t0 # i32 31 # i32 8380417
+            = . a1 + o1 i t1
+            = . a0 + o0 i t0
+            = i + i 1
+        }
     }
 }
 
-@ __highbits i r i g2 → i {
-    : i x ( __caddq # i32 r )
-    : i r0 ( __modpm x * 2 g2 )
-    ? == - x r0 8380416 { ^ 0 } {}
-    ^ / - x r0 * 2 g2
+// MakeHint, from the decomposed pair rather than from two HighBits
+// calls.
+//
+// The spec writes it as `HighBits(r) ≠ HighBits(r + z)`, which is two
+// decompositions per coefficient. Given `a0` — the low part after the
+// signer has already folded in −⟨⟨c·s2⟩⟩ and ⟨⟨c·t0⟩⟩ — and `a1`, the
+// high part of w, the same predicate is a range test on a0 alone.
+@ __makehint i32 a0 i32 a1 i g2 → i {
+    ^ ? | | > # i a0 g2 < # i a0 - 0 g2 & == # i a0 - 0 g2 != # i a1 0 1 0
 }
 
 // UseHint: recover HighBits(r + z) from HighBits(r) and one bit.
 @ __usehint i h i r i g2 → i {
-    : i m / 8380416 * 2 g2
-    : i x ( __caddq # i32 r )
-    : i r0 ( __modpm x * 2 g2 )
-    : ~ i r1 0
-    ? == - x r0 8380416 { = r1 0 } { = r1 / - x r0 * 2 g2 }
-    ? == h 0 { ^ r1 } {}
-    ? > r0 0 { ^ % + r1 1 m } {}
-    ^ % + - r1 1 m m
+    : i32 x ( __caddq # i32 r )
+    : ~ i32 t1 >> + x # i32 127 # i32 7
+    : ~ i32 t0 # i32 0
+    ? == g2 261888 {
+        = t1 & >> + * t1 # i32 1025 # i32 2097152 # i32 22 # i32 15
+        = t0 - x * t1 # i32 523776
+    } {
+        = t1 >> + * t1 # i32 11275 # i32 8388608 # i32 24
+        = t1 ^^ t1 & >> - # i32 43 t1 # i32 31 t1
+        = t0 - x * t1 # i32 190464
+    }
+    = t0 - t0 & >> - # i32 4190208 t0 # i32 31 # i32 8380417
+    ? == h 0 { ^ # i t1 } {}
+    ? == g2 261888 {
+        ? > # i t0 0 { ^ & + # i t1 1 15 } {}
+        ^ & - # i t1 1 15
+    } {}
+    ? > # i t0 0 { ^ ? == # i t1 43 0 + # i t1 1 } {}
+    ^ ? == # i t1 0 43 - # i t1 1
 }
 
 // ── Bit packing ────────────────────────────────────────────────────
@@ -1056,15 +1098,10 @@ MldsaParams p ( Vec u ) out → v {
                 ( __md_poly_add w0p * 256 i w0p * 256 i ct0p * 256 i )
                 : ~ i j 0
                 ~ < j 256 {
-                    // MakeHint(z, r) with z = −ct0 and r = w0 + ct0:
-                    // HighBits(r) differs from HighBits(r + z), where
-                    // r + z is the low part alone.
-                    : i r0 # i . w0p + * 256 i j
-                    : i r1 # i . w1p + * 256 i j
-                    : i zz - # i32 0 . ct0p + * 256 i j
-                    : i hb0 ( __highbits + r0 * r1 * 2 g2 g2 )
-                    : i hb1 ( __highbits + + r0 * r1 * 2 g2 zz g2 )
-                    : i bit ? != hb0 hb1 1 0
+                    // w0 now holds LowBits(w) − ⟨⟨c·s2⟩⟩ + ⟨⟨c·t0⟩⟩ and
+                    // w1 holds HighBits(w), so the hint is a range test
+                    // on w0 — no second decomposition needed.
+                    : i bit ( __makehint . w0p + * 256 i j . w1p + * 256 i j g2 )
                     = . hp + * 256 i j # i32 bit
                     = ones + ones bit
                     = j + j 1


### PR DESCRIPTION
Nothing here was guessed. `perf --call-graph lbr` put `__keccakf1600` at
**40.6% of all PQ time** — everything in both schemes rides on SHAKE —
and a disassembly histogram showed one round compiling to **191 `mov`s
against ~155 real ALU instructions**. More than half the work was
spilling.

## Keccak: the second buffer

Materialising all 25 ρ+π results and then running χ over them leaves 35
values live on a machine with 16 general registers.

χ cannot simply consume them a row at a time in place either: ρ+π
scatters lanes across rows, so χ's first row would overwrite lanes its
fourth row still needs. Writing each χ row into a **second buffer**
removes that conflict, and then only one row's five values need to exist
at a time — the live set drops from 35 to ten. The buffers ping-pong;
24 rounds is even, so the state lands back where the caller left it.

| | before | after |
|---|---|---|
| round instructions | 367 | 249 |
| `mov` | 191 | 73 |
| `rol` / `xor` / `not` / `and` | 29/77/25/25 | unchanged |
| SHAKE128 squeeze | 260 MB/s | **354 MB/s** |

The real work is identical — only the spill traffic went away. Cost: one
25-lane scratch buffer per sponge, allocated once in `sha3_new`.

## ML-DSA rounding: no `idiv` in the inner loop

`Decompose`, `Power2Round` and `UseHint` were written in the spec's
`mod±` form, which reads as a remainder and compiles to `idiv`. They run
256·k times per signing attempt and signing retries several times, so
the divisions cost more than the polynomial arithmetic around them. I
noted at the time that this was correctness-first and could be revisited
with measurement; this is that.

The reciprocal-multiply forms are division-free — `1025/2^22` for
γ2=(q−1)/32 and `11275/2^24` for (q−1)/88, each chosen so the truncating
shift lands on the exact quotient, with the wrap case falling out of a
mask rather than a compare.

`MakeHint` also stopped calling `HighBits` twice per coefficient. The
spec writes it as `HighBits(r) ≠ HighBits(r + z)` — two decompositions;
given the low part the signer has already folded −⟨⟨c·s2⟩⟩ and ⟨⟨c·t0⟩⟩
into, plus the high part of w, the same predicate is a range test on one
value.

## Results

| | before | after | |
|---|---|---|---|
| ML-KEM-768 keygen | 18.3k/s | 20.8k/s | +14% |
| ML-KEM-768 decaps | 13.9k/s | 15.6k/s | +12% |
| ML-KEM-1024 keygen | 11.9k/s | 14.2k/s | +19% |
| ML-DSA-65 keygen | 4.8k/s | 6.1k/s | +26% |
| ML-DSA-65 sign | 1356/s | 1737/s | +28% |
| ML-DSA-87 sign | 1149/s | 1477/s | +29% |
| ML-DSA-44 verify | 7.7k/s | 9.8k/s | +27% |

## Why the vectors matter here

Every ACVP case still passes byte for byte — 180 ML-KEM and 615 ML-DSA.

That is the whole point of having them. Rewriting the permutation and
three rounding routines is exactly the change that needs an oracle it
cannot influence: a round trip would have agreed with any of the wrong
versions I could plausibly have written, because both halves would have
used the same wrong arithmetic. Two bugs in this stack have already had
that shape.

## Test status

- 842 compiler tests pass, 0 failures
- ML-KEM 180/180, ML-DSA 615/615 ACVP cases
- ASan/LSan clean on the SHA-3, ML-KEM and ML-DSA vector tests

## Not done

Keccak is still 31% of the profile after this. Going further means lane
complementing or SIMD, which is a bigger change than the one the numbers
currently justify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
