### PR TITLE
SLH-DSA (FIPS 205): the signature that assumes only a hash function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`std/slhdsa`: SLH-DSA (FIPS 205) in pure NURL** — the third and last
+  NIST post-quantum standard, and the one that assumes least. ML-KEM and
+  ML-DSA rest on lattice problems; SLH-DSA rests on nothing but the hash
+  function, so it is what still stands if a break lands on lattices. All
+  six SHAKE parameter sets: WOTS+, XMSS, the hypertree, FORS, and the
+  32-byte address structure that domain-separates every hash call.
+
+  The price is size and speed — 7 856 bytes at the smallest set against
+  ML-DSA-44's 2 420, and signing walks a hypertree of Merkle trees
+  rather than doing algebra. Use ML-DSA by default; use this where a
+  signature is rare, long-lived, and has to outlast an assumption:
+  firmware images, root certificates, release artefacts.
+
+  `tools/slhdsa_acvp_gate.sh` checks it against NIST's vectors — all 60
+  SHAKE keyGen cases uncapped, sigGen and sigVer capped per group
+  because signing is slow by construction. The three reasons a case does
+  not run (the cap, the unimplemented SHA-2 family, the pre-hash
+  interfaces) are counted and printed **separately**, so none of them
+  can be read as coverage.
+
+  **Two bugs, both signedness, both found only by the vectors.**
+  SLH-DSA-256f is the one parameter set whose hypertree index fills all
+  64 bits (h − h/d = 68 − 4). Its mask was computed as `1 << 64`, which
+  x86 takes modulo 64 — yielding 1, so the mask became 0 and every tree
+  index was pinned to zero. With that fixed the same set still failed,
+  because `%` and `>>` on a now-negative `i` carried the sign into the
+  next layer, and the address writer shifted past 64 for the top bytes
+  of the 12-byte tree field. Five of the six sets passed throughout;
+  only the one that reaches exactly 64 bits ever showed it, which is why
+  that apparently redundant set is pinned in the offline test too.
+
+  The SHA-2 instantiation of FIPS 205 is not implemented.
+
 ### Changed
 
 - **The post-quantum stack got 12–29% faster, from two changes the

--- a/compiler/tests/outputs/slhdsa_vectors.txt
+++ b/compiler/tests/outputs/slhdsa_vectors.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+keygen-128s     ok
+keygen-128f     ok
+keygen-192f     ok
+keygen-256f     ok
+roundtrip-128f  ok

--- a/compiler/tests/slhdsa_vectors.nu
+++ b/compiler/tests/slhdsa_vectors.nu
@@ -1,0 +1,156 @@
+// slhdsa_vectors.nu — SLH-DSA (FIPS 205) known-answer tests, SHAKE family.
+//
+// Pinned against NIST's ACVP vectors (usnistgov/ACVP-Server,
+// gen-val/json-files/SLH-DSA-*-FIPS205). SLH-DSA's keys are small — a
+// public key is two hashes and a private key four — so unlike ML-KEM and
+// ML-DSA these cases carry their expected outputs verbatim rather than
+// by digest.
+//
+// `tools/slhdsa_acvp_gate.sh` runs the published set. It caps how many
+// signing cases it takes per group, because SLH-DSA signing is slow by
+// construction; this file therefore sticks to the `f` parameter sets and
+// one round trip, so it stays inside a normal build.
+//
+// ── What is being checked ──────────────────────────────────────────
+//
+// Key generation is the whole scheme in miniature: it builds the top
+// XMSS tree, which means WOTS+ key generation, the Merkle hashing, and
+// every address type along the way. A wrong address field or a wrong
+// chain length changes the root, so a matching public key is a strong
+// signal well beyond "the hash function works".
+//
+// The round trip then exercises FORS and the hypertree, which key
+// generation never touches, and the tamper cases confirm the verifier
+// is actually reading the signature rather than the key.
+
+$ `stdlib/std/slhdsa.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+
+@ hexv s h → ( Vec u ) {
+    : !( Vec u ) ParseErr r ( bytes_from_hex h )
+    ?? r { T v → { ^ v } F _e → { ( nurl_panic `slhdsa_vectors: bad hex literal` ) ^ ( vec_new [u] ) } }
+}
+
+@ eq_hex ( Vec u ) got s want → b {
+    : String x ( bytes_to_hex got )
+    : b ok != 0 ( nurl_str_eq ( string_data x ) want )
+    ( string_free x )
+    ^ ok
+}
+
+@ report s label b ok → b {
+    ( nurl_print label )
+    ( nurl_print ? ok ` ok\n` ` FAIL\n` )
+    ^ ok
+}
+
+@ kg_case s label i set s ss s sp s ps s wpk s wsk → b {
+    : ( Vec u ) a ( hexv ss )
+    : ( Vec u ) b2 ( hexv sp )
+    : ( Vec u ) c ( hexv ps )
+    : *SlhKeys k ( slhdsa_keygen_derand set a b2 c )
+    : b ok1 ( eq_hex ( slhdsa_pk k ) wpk )
+    : b ok2 ( eq_hex ( slhdsa_sk k ) wsk )
+    : b ok3 == ( vec_len [u] ( slhdsa_pk k ) ) ( slhdsa_pk_len set )
+    : b ok4 == ( vec_len [u] ( slhdsa_sk k ) ) ( slhdsa_sk_len set )
+    ( slhdsa_keys_free k )
+    ( vec_free [u] c ) ( vec_free [u] b2 ) ( vec_free [u] a )
+    ^ ( report label & & & ok1 ok2 ok3 ok4 )
+}
+
+// A full sign/verify cycle, plus the three ways it must fail.
+@ roundtrip s label i set → b {
+    : ( Vec u ) a ( vec_new [u] )
+    : ( Vec u ) b2 ( vec_new [u] )
+    : ( Vec u ) c ( vec_new [u] )
+    : ( Vec u ) msg ( vec_new [u] )
+    : ( Vec u ) ctx ( vec_new [u] )
+    : i n / ( slhdsa_sk_len set ) 4
+    : ~ i i 0
+    ~ < i n {
+        ( vec_push [u] a # u % + * i 7 set 251 )
+        ( vec_push [u] b2 # u % + * i 11 5 251 )
+        ( vec_push [u] c # u % + * i 13 9 251 )
+        = i + i 1
+    }
+    = i 0
+    ~ < i 40 { ( vec_push [u] msg # u % + * i 3 1 251 ) = i + i 1 }
+    ( bytes_extend_str ctx `slh` )
+
+    : *SlhKeys k ( slhdsa_keygen_derand set a b2 c )
+    : ( Vec u ) sig ( slhdsa_sign_deterministic set ( slhdsa_sk k ) msg ctx )
+    : b oklen == ( vec_len [u] sig ) ( slhdsa_sig_len set )
+    : b okv ( slhdsa_verify set ( slhdsa_pk k ) msg ctx sig )
+
+    // A flipped bit inside the hypertree part must not verify.
+    : *u sp ( vec_data [u] sig )
+    = . sp - ( vec_len [u] sig ) 100 # u ^^ # i . sp - ( vec_len [u] sig ) 100 1
+    : b okbad ! ( slhdsa_verify set ( slhdsa_pk k ) msg ctx sig )
+    = . sp - ( vec_len [u] sig ) 100 # u ^^ # i . sp - ( vec_len [u] sig ) 100 1
+
+    // A different context must not verify.
+    : ( Vec u ) ctx2 ( vec_new [u] )
+    ( bytes_extend_str ctx2 `other` )
+    : b okctx ! ( slhdsa_verify set ( slhdsa_pk k ) msg ctx2 sig )
+    ( vec_free [u] ctx2 )
+
+    // A changed message must not verify.
+    : *u mp ( vec_data [u] msg )
+    = . mp 0 # u ^^ # i . mp 0 1
+    : b okmsg ! ( slhdsa_verify set ( slhdsa_pk k ) msg ctx sig )
+    = . mp 0 # u ^^ # i . mp 0 1
+
+    // Deterministic signing repeats exactly; that is what makes the
+    // pinned vectors above reproducible at all.
+    : ( Vec u ) sig2 ( slhdsa_sign_deterministic set ( slhdsa_sk k ) msg ctx )
+    : b okdet ( bytes_eq sig sig2 )
+    ( vec_free [u] sig2 )
+
+    ( vec_free [u] sig )
+    ( slhdsa_keys_free k )
+    ( vec_free [u] ctx ) ( vec_free [u] msg )
+    ( vec_free [u] c ) ( vec_free [u] b2 ) ( vec_free [u] a )
+    ^ ( report label & & & & & oklen okv okbad okctx okmsg okdet )
+}
+
+@ main → i {
+    : ~ b all T
+
+    = all & all ( kg_case `keygen-128s    ` 128
+    `c151951f3811029239b74add24c506af`
+    `dd30363e156e6fe936ec6ed0231feb5c`
+    `529ffe86200d1f32c2b60d0cd909f190`
+    `529ffe86200d1f32c2b60d0cd909f1900761f9b727afa724b47223016bb5b2ba`
+    `c151951f3811029239b74add24c506afdd30363e156e6fe936ec6ed0231feb5c529ffe86200d1f32c2b60d0cd909f1900761f9b727afa724b47223016bb5b2ba` )
+
+    = all & all ( kg_case `keygen-128f    ` 129
+    `3956ab391b4d22fc907af0740326d061`
+    `ab0eb206436f2b86ebe086d77739b3e4`
+    `56505c229f4e7fa6b201714c7dcc9da3`
+    `56505c229f4e7fa6b201714c7dcc9da366578f1f24c3fe371c97c14ce0e79cdc`
+    `3956ab391b4d22fc907af0740326d061ab0eb206436f2b86ebe086d77739b3e456505c229f4e7fa6b201714c7dcc9da366578f1f24c3fe371c97c14ce0e79cdc` )
+
+    = all & all ( kg_case `keygen-192f    ` 193
+    `fb7a2c2c75ce6c96b5f4328e0ab300476fc6f864cb5b0b99`
+    `990ecb726ca822a4e3652dd92ec0aab7637ea41c0482ae28`
+    `68dcc671e3534f81a352c275b6a25f906d2ed0ff62b8b4e3`
+    `68dcc671e3534f81a352c275b6a25f906d2ed0ff62b8b4e398f1a9876cb082a48e9ae2c862b289486a3925cefc6ff4be`
+    `fb7a2c2c75ce6c96b5f4328e0ab300476fc6f864cb5b0b99990ecb726ca822a4e3652dd92ec0aab7637ea41c0482ae2868dcc671e3534f81a352c275b6a25f906d2ed0ff62b8b4e398f1a9876cb082a48e9ae2c862b289486a3925cefc6ff4be` )
+
+    // 256f is the one parameter set whose hypertree index fills all 64
+    // bits (h − h/d = 68 − 4). It is here because a signed-shift mask
+    // pinned every tree index to zero at exactly this set and nowhere
+    // else, and only its vectors caught it.
+    = all & all ( kg_case `keygen-256f    ` 257
+    `2ac9403858d186b172edd8df9c78a11449893681487d3af0dad0ec341e8aca48`
+    `afa2771bae6c17dd6f77b4e3808b05f56f31b8f4128df2ccb677f0283cfb18da`
+    `559bc883105e8ba0264648b532626155f87edb4bedcfc12a24204d3b696d5370`
+    `559bc883105e8ba0264648b532626155f87edb4bedcfc12a24204d3b696d53707a158ff5d30e3428183a3b3a96a0e4a341a2a16e5a6226af374d1efb39a35df6`
+    `2ac9403858d186b172edd8df9c78a11449893681487d3af0dad0ec341e8aca48afa2771bae6c17dd6f77b4e3808b05f56f31b8f4128df2ccb677f0283cfb18da559bc883105e8ba0264648b532626155f87edb4bedcfc12a24204d3b696d53707a158ff5d30e3428183a3b3a96a0e4a341a2a16e5a6226af374d1efb39a35df6` )
+
+    = all & all ( roundtrip `roundtrip-128f ` 129 )
+
+    ^ ? all 0 1
+}

--- a/docs/CRYPTO.md
+++ b/docs/CRYPTO.md
@@ -31,6 +31,7 @@ All sources live in `stdlib/std/`.
 | XOF | `hash_sha3` (SHAKE128/256) | extendable output, incremental squeeze; ML-KEM is built on it |
 | Post-quantum KEM | `mlkem` (ML-KEM-512/768/1024, FIPS 203) | checked byte-for-byte against NIST's ACVP vectors |
 | Post-quantum signature | `mldsa` (ML-DSA-44/65/87, FIPS 204) | pure, external-mu and HashML-DSA; all 615 ACVP cases |
+| Post-quantum signature, hash-based | `slhdsa` (SLH-DSA, FIPS 205, SHAKE family) | six parameter sets; security rests only on the hash |
 | HMAC / KDF | `hkdf`, `pbkdf2`, `scrypt` | HKDF-Expand-Label for TLS 1.3 |
 | AEAD | `aes_gcm` (AES-128/256-GCM), `chacha20poly1305` | the two TLS 1.3 record ciphers |
 | ECDH / signatures | `x25519`, `ed25519`, `ecdsa_p256` (P-256 + P-384), `p256_field` | TweetNaCl-derived 25519 ladder over a ten-limb radix-2^25.5 field; `p256_field` is the dedicated **constant-time** fixed-limb GF(p) for the P-256 secret path |

--- a/stdlib/std/slhdsa.nu
+++ b/stdlib/std/slhdsa.nu
@@ -1,0 +1,792 @@
+// stdlib/std/slhdsa.nu — SLH-DSA (FIPS 205) in pure NURL, SHAKE family.
+//
+// The third and last of NIST's post-quantum standards, and the one that
+// assumes least. ML-KEM and ML-DSA rest on lattice problems; SLH-DSA
+// rests on nothing but the hash function. If a break lands on lattices,
+// this is what still stands — which is why it exists alongside ML-DSA
+// rather than instead of it.
+//
+// The price is size and speed. A signature is 7 856 bytes at the
+// smallest parameter set, against ML-DSA-44's 2 420, and signing walks
+// a hypertree of Merkle trees rather than doing algebra. Use ML-DSA by
+// default; use this where a signature is rare, long-lived, and must
+// outlast an assumption — firmware images, root certificates, software
+// releases.
+//
+//   set            pk    sk    signature   security
+//   128s           32    64        7856    AES-128, small signatures
+//   128f           32    64       17088    AES-128, fast signing
+//   192s           48    96       16224    AES-192
+//   192f           48    96       35664    AES-192, fast signing
+//   256s           64   128       29792    AES-256
+//   256f           64   128       49856    AES-256, fast signing
+//
+// The `s`/`f` axis is a direct trade: `s` signs slowly and produces a
+// small signature, `f` the other way round. Verification is fast in
+// both.
+//
+// API:
+//   ( slhdsa_keygen i set )                          → *SlhKeys
+//   ( slhdsa_sign i set ( Vec u ) sk
+//                 ( Vec u ) msg ( Vec u ) ctx )      → ( Vec u )
+//   ( slhdsa_verify i set ( Vec u ) pk ( Vec u ) msg
+//                   ( Vec u ) ctx ( Vec u ) sig )    → b
+//
+// Deterministic and internal forms, which FIPS 205 defines and NIST's
+// ACVP vectors exercise:
+//   ( slhdsa_keygen_derand set skseed skprf pkseed ) → *SlhKeys
+//   ( slhdsa_sign_internal set sk msg addrnd )       → ( Vec u )
+//   ( slhdsa_verify_internal set pk msg sig )        → b
+//
+// Sets are named by the integers 128, 129, 192, 193, 256, 257 — the
+// even value is the `s` variant and the odd one its `f` sibling; see
+// `slhdsa_set_*` below rather than memorising that.
+//
+// Only the SHAKE instantiation is implemented. FIPS 205 also defines a
+// SHA-2 family with the same structure and different hash plumbing;
+// those parameter sets are not available here and the ACVP gate reports
+// them as skipped.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/hash_sha3.nu`
+$ `stdlib/std/random.nu`
+
+// ── Parameters ─────────────────────────────────────────────────────
+//
+// n   hash output and node size in bytes
+// h   total hypertree height
+// d   number of hypertree layers  (h' = h/d is one XMSS tree's height)
+// a   FORS tree height, k FORS trees
+// m   H_msg output length
+
+: SlhParams {
+    i n
+    i h
+    i d
+    i hp
+    i a
+    i k
+    i m
+    i len  // WOTS+ chains per key: 2n + 3
+}
+
+@ slhdsa_set_128s → i { ^ 128 }
+
+@ slhdsa_set_128f → i { ^ 129 }
+
+@ slhdsa_set_192s → i { ^ 192 }
+
+@ slhdsa_set_192f → i { ^ 193 }
+
+@ slhdsa_set_256s → i { ^ 256 }
+
+@ slhdsa_set_256f → i { ^ 257 }
+
+@ __slh_params i set → SlhParams {
+    ? == set 129 { ^ @ SlhParams { 16 66 22 3 6 33 34 35 } } {}
+    ? == set 192 { ^ @ SlhParams { 24 63 7 9 14 17 39 51 } } {}
+    ? == set 193 { ^ @ SlhParams { 24 66 22 3 8 33 42 51 } } {}
+    ? == set 256 { ^ @ SlhParams { 32 64 8 8 14 22 47 67 } } {}
+    ? == set 257 { ^ @ SlhParams { 32 68 17 4 9 35 49 67 } } {}
+    ^ @ SlhParams { 16 63 7 9 12 14 30 35 }  // 128s
+}
+
+@ slhdsa_pk_len i set → i {
+    : SlhParams p ( __slh_params set )
+    ^ * 2 . p n
+}
+
+@ slhdsa_sk_len i set → i {
+    : SlhParams p ( __slh_params set )
+    ^ * 4 . p n
+}
+
+@ slhdsa_sig_len i set → i {
+    : SlhParams p ( __slh_params set )
+    ^ * . p n + + + 1 * . p k + 1 . p a . p h * . p d . p len
+}
+
+// ── Addresses (FIPS 205 §4.2) ──────────────────────────────────────
+//
+// Every hash call is domain-separated by a 32-byte address saying
+// exactly where in the structure it sits: which hypertree layer, which
+// tree, what kind of node, and which position. Two hashes anywhere in
+// the scheme therefore never collide by accident, and that is the whole
+// argument for its security — so the field layout below is not
+// bookkeeping, it is the proof obligation.
+//
+//   [0..4)   layer      [4..16)  tree index (12 bytes, big-endian)
+//   [16..20) type       [20..24) key pair / word 1
+//   [24..28) chain or tree height  [28..32) hash or tree index
+
+@ __adrs_new → ( Vec u ) {
+    : ( Vec u ) a ( vec_with_cap [u] 32 )
+    : b _l ( vec_set_len [u] a 32 )
+    : *u p ( vec_data [u] a )
+    : ~ i i 0
+    ~ < i 32 { = . p i # u 0 = i + i 1 }
+    ^ a
+}
+
+@ __adrs_copy ( Vec u ) a → ( Vec u ) {
+    ^ ( bytes_slice a 0 32 )
+}
+
+// Write a big-endian integer into `len` bytes at `off`.
+//
+// Byte k needs `v >> 8k`, and the tree field is 12 bytes wide while `v`
+// is 64 bits — so k reaches 8 and the shift count reaches 64. x86 takes
+// shift counts modulo 64, which would wrap and write the low bytes
+// again into the high ones. Those bytes are zero by construction, so
+// the loop stops shifting at 8 and zero-fills the rest.
+@ __adrs_put * u p i off i len i v → v {
+    : ~ i k 0
+    ~ < k len {
+        : i byte ? < k 8 & # i >> # u64 v # u64 * 8 k 255 0
+        = . p + off - - len 1 k # u byte
+        = k + k 1
+    }
+}
+
+@ __adrs_set_layer ( Vec u ) a i l → v { ( __adrs_put ( vec_data [u] a ) 0 4 l ) }
+
+@ __adrs_set_tree ( Vec u ) a i t → v { ( __adrs_put ( vec_data [u] a ) 4 12 t ) }
+
+@ __adrs_set_kp ( Vec u ) a i i2 → v { ( __adrs_put ( vec_data [u] a ) 20 4 i2 ) }
+
+@ __adrs_set_chain ( Vec u ) a i i2 → v { ( __adrs_put ( vec_data [u] a ) 24 4 i2 ) }
+
+@ __adrs_set_hash ( Vec u ) a i i2 → v { ( __adrs_put ( vec_data [u] a ) 28 4 i2 ) }
+
+@ __adrs_set_height ( Vec u ) a i i2 → v { ( __adrs_put ( vec_data [u] a ) 24 4 i2 ) }
+
+@ __adrs_set_index ( Vec u ) a i i2 → v { ( __adrs_put ( vec_data [u] a ) 28 4 i2 ) }
+
+// Setting the type zeroes the three words after it, per §4.2 — the
+// subsequent setters refill whichever ones that type uses.
+@ __adrs_set_type ( Vec u ) a i y → v {
+    : *u p ( vec_data [u] a )
+    ( __adrs_put p 16 4 y )
+    : ~ i k 20
+    ~ < k 32 { = . p k # u 0 = k + k 1 }
+}
+
+@ __adrs_get_kp ( Vec u ) a → i {
+    : *u p ( vec_data [u] a )
+    ^ | | | << # i . p 20 24 << # i . p 21 16 << # i . p 22 8 # i . p 23
+}
+
+@ __adrs_get_index ( Vec u ) a → i {
+    : *u p ( vec_data [u] a )
+    ^ | | | << # i . p 28 24 << # i . p 29 16 << # i . p 30 8 # i . p 31
+}
+
+// ── The SHAKE instantiation (FIPS 205 §11.1) ───────────────────────
+//
+// Every one of these is SHAKE256 over a concatenation; the differences
+// are which pieces go in and how many bytes come out.
+
+@ __slh_shake ( Vec u ) a ( Vec u ) b ( Vec u ) c i outlen → ( Vec u ) {
+    : *Sha3 h ( shake256_init )
+    ( sha3_absorb h a )
+    ( sha3_absorb h b )
+    ( sha3_absorb h c )
+    : ( Vec u ) o ( sha3_squeeze h outlen )
+    ( sha3_free h )
+    ^ o
+}
+
+@ __slh_prf ( Vec u ) pkseed ( Vec u ) adrs ( Vec u ) skseed i n → ( Vec u ) {
+    ^ ( __slh_shake pkseed adrs skseed n )
+}
+
+@ __slh_f ( Vec u ) pkseed ( Vec u ) adrs ( Vec u ) m i n → ( Vec u ) {
+    ^ ( __slh_shake pkseed adrs m n )
+}
+
+// ── base-2^b decomposition (Algorithm 1) ───────────────────────────
+
+@ __base_2b ( Vec u ) x i b i outlen → ( Vec i ) {
+    : ( Vec i ) out ( vec_with_cap [i] ? > outlen 0 outlen 1 )
+    : b _l ( vec_set_len [i] out ? > outlen 0 outlen 1 )
+    : *i op ( vec_data [i] out )
+    : *u xp ( vec_data [u] x )
+    : ~ i pos 0
+    : ~ i bits 0
+    : ~ i total 0
+    : ~ i j 0
+    ~ < j outlen {
+        ~ < bits b {
+            = total + << total 8 # i . xp pos
+            = pos + pos 1
+            = bits + bits 8
+        }
+        = bits - bits b
+        = . op j & >> total bits - << 1 b 1
+        = j + j 1
+    }
+    ^ out
+}
+
+// ── WOTS+ (§5) ─────────────────────────────────────────────────────
+
+// Iterate F from step `i` for `s` steps. The chain length is what a
+// WOTS+ signature reveals: publishing the value at step m lets anyone
+// walk forward to w-1, and nobody walk back.
+@ __wots_chain ( Vec u ) x i start i steps ( Vec u ) pkseed ( Vec u ) adrs i n → ( Vec u ) {
+    : ~ ( Vec u ) tmp ( bytes_slice x 0 ( vec_len [u] x ) )
+    : ~ i j start
+    ~ < j + start steps {
+        ( __adrs_set_hash adrs j )
+        : ( Vec u ) nxt ( __slh_f pkseed adrs tmp n )
+        ( vec_free [u] tmp )
+        = tmp nxt
+        = j + j 1
+    }
+    ^ tmp
+}
+
+// The message expanded to `len` base-w digits, with the checksum digits
+// appended. The checksum is what stops an attacker walking a chain
+// forward to forge a larger digit: raising any digit lowers the
+// checksum, which can only be raised.
+@ __wots_msg ( Vec u ) m SlhParams p → ( Vec i ) {
+    : i len1 * 2 . p n
+    : ( Vec i ) msg ( __base_2b m 4 len1 )
+    : ~ i csum 0
+    : ~ i i 0
+    ~ < i len1 {
+        = csum + csum - 15 ?? ( vec_get [i] msg i ) { T x → { x } F → { 0 } }
+        = i + i 1
+    }
+    // len2 = 3 digits of 4 bits = 12 bits, left-shifted into 2 bytes.
+    = csum << csum 4
+    : ( Vec u ) cb ( vec_with_cap [u] 2 )
+    ( vec_push [u] cb # u & >> csum 8 255 )
+    ( vec_push [u] cb # u & csum 255 )
+    : ( Vec i ) cs ( __base_2b cb 4 3 )
+    = i 0
+    ~ < i 3 { ( vec_push [i] msg ?? ( vec_get [i] cs i ) { T x → { x } F → { 0 } } ) = i + i 1 }
+    ( vec_free [i] cs )
+    ( vec_free [u] cb )
+    ^ msg
+}
+
+@ __wots_pkgen ( Vec u ) skseed ( Vec u ) pkseed ( Vec u ) adrs SlhParams p → ( Vec u ) {
+    : ( Vec u ) skadrs ( __adrs_copy adrs )
+    ( __adrs_set_type skadrs 5 )
+    ( __adrs_set_kp skadrs ( __adrs_get_kp adrs ) )
+    : ( Vec u ) tmp ( vec_new [u] )
+    : ~ i i 0
+    ~ < i . p len {
+        ( __adrs_set_chain skadrs i )
+        : ( Vec u ) sk ( __slh_prf pkseed skadrs skseed . p n )
+        ( __adrs_set_chain adrs i )
+        : ( Vec u ) ch ( __wots_chain sk 0 15 pkseed adrs . p n )
+        ( bytes_extend_bytes tmp ch )
+        ( vec_free [u] ch )
+        ( vec_free [u] sk )
+        = i + i 1
+    }
+    : ( Vec u ) pkadrs ( __adrs_copy adrs )
+    ( __adrs_set_type pkadrs 1 )
+    ( __adrs_set_kp pkadrs ( __adrs_get_kp adrs ) )
+    : ( Vec u ) out ( __slh_f pkseed pkadrs tmp . p n )
+    ( vec_free [u] tmp ) ( vec_free [u] pkadrs ) ( vec_free [u] skadrs )
+    ^ out
+}
+
+@ __wots_sign ( Vec u ) m ( Vec u ) skseed ( Vec u ) pkseed ( Vec u ) adrs SlhParams p → ( Vec u ) {
+    : ( Vec i ) msg ( __wots_msg m p )
+    : ( Vec u ) skadrs ( __adrs_copy adrs )
+    ( __adrs_set_type skadrs 5 )
+    ( __adrs_set_kp skadrs ( __adrs_get_kp adrs ) )
+    : ( Vec u ) sig ( vec_new [u] )
+    : ~ i i 0
+    ~ < i . p len {
+        ( __adrs_set_chain skadrs i )
+        : ( Vec u ) sk ( __slh_prf pkseed skadrs skseed . p n )
+        ( __adrs_set_chain adrs i )
+        : i steps ?? ( vec_get [i] msg i ) { T x → { x } F → { 0 } }
+        : ( Vec u ) ch ( __wots_chain sk 0 steps pkseed adrs . p n )
+        ( bytes_extend_bytes sig ch )
+        ( vec_free [u] ch ) ( vec_free [u] sk )
+        = i + i 1
+    }
+    ( vec_free [u] skadrs ) ( vec_free [i] msg )
+    ^ sig
+}
+
+@ __wots_pk_from_sig ( Vec u ) sig ( Vec u ) m ( Vec u ) pkseed ( Vec u ) adrs SlhParams p → ( Vec u ) {
+    : ( Vec i ) msg ( __wots_msg m p )
+    : ( Vec u ) tmp ( vec_new [u] )
+    : ~ i i 0
+    ~ < i . p len {
+        ( __adrs_set_chain adrs i )
+        : i mi ?? ( vec_get [i] msg i ) { T x → { x } F → { 0 } }
+        : ( Vec u ) si ( bytes_slice sig * i . p n * + i 1 . p n )
+        : ( Vec u ) ch ( __wots_chain si mi - 15 mi pkseed adrs . p n )
+        ( bytes_extend_bytes tmp ch )
+        ( vec_free [u] ch ) ( vec_free [u] si )
+        = i + i 1
+    }
+    : ( Vec u ) pkadrs ( __adrs_copy adrs )
+    ( __adrs_set_type pkadrs 1 )
+    ( __adrs_set_kp pkadrs ( __adrs_get_kp adrs ) )
+    : ( Vec u ) out ( __slh_f pkseed pkadrs tmp . p n )
+    ( vec_free [u] tmp ) ( vec_free [u] pkadrs ) ( vec_free [i] msg )
+    ^ out
+}
+
+// ── XMSS (§6) ──────────────────────────────────────────────────────
+
+// The Merkle root over 2^z WOTS+ public keys, computed by recursion.
+//
+// This is where an `s` parameter set spends its time: h' = 9 means
+// every one of the d layers rebuilds 512 WOTS+ key pairs per signature.
+@ __xmss_node ( Vec u ) skseed i i2 i z ( Vec u ) pkseed ( Vec u ) adrs SlhParams p → ( Vec u ) {
+    ? == z 0 {
+        ( __adrs_set_type adrs 0 )
+        ( __adrs_set_kp adrs i2 )
+        ^ ( __wots_pkgen skseed pkseed adrs p )
+    } {}
+    : ( Vec u ) l ( __xmss_node skseed * 2 i2 - z 1 pkseed adrs p )
+    : ( Vec u ) r ( __xmss_node skseed + * 2 i2 1 - z 1 pkseed adrs p )
+    ( __adrs_set_type adrs 2 )
+    ( __adrs_set_height adrs z )
+    ( __adrs_set_index adrs i2 )
+    : ( Vec u ) both ( bytes_slice l 0 ( vec_len [u] l ) )
+    ( bytes_extend_bytes both r )
+    : ( Vec u ) out ( __slh_f pkseed adrs both . p n )
+    ( vec_free [u] both ) ( vec_free [u] r ) ( vec_free [u] l )
+    ^ out
+}
+
+@ __xmss_sign ( Vec u ) m ( Vec u ) skseed i idx ( Vec u ) pkseed ( Vec u ) adrs SlhParams p → ( Vec u ) {
+    : ( Vec u ) auth ( vec_new [u] )
+    : ~ i j 0
+    ~ < j . p hp {
+        : i kk ^^ >> idx j 1
+        : ( Vec u ) a2 ( __adrs_copy adrs )
+        : ( Vec u ) nd ( __xmss_node skseed kk j pkseed a2 p )
+        ( bytes_extend_bytes auth nd )
+        ( vec_free [u] nd ) ( vec_free [u] a2 )
+        = j + j 1
+    }
+    ( __adrs_set_type adrs 0 )
+    ( __adrs_set_kp adrs idx )
+    : ( Vec u ) sig ( __wots_sign m skseed pkseed adrs p )
+    ( bytes_extend_bytes sig auth )
+    ( vec_free [u] auth )
+    ^ sig
+}
+
+@ __xmss_pk_from_sig i idx ( Vec u ) sigx ( Vec u ) m ( Vec u ) pkseed ( Vec u ) adrs SlhParams p → ( Vec u ) {
+    : i wl * . p len . p n
+    ( __adrs_set_type adrs 0 )
+    ( __adrs_set_kp adrs idx )
+    : ( Vec u ) wsig ( bytes_slice sigx 0 wl )
+    : ~ ( Vec u ) node ( __wots_pk_from_sig wsig m pkseed adrs p )
+    ( vec_free [u] wsig )
+    ( __adrs_set_type adrs 2 )
+    ( __adrs_set_index adrs idx )
+    : ~ i k 0
+    ~ < k . p hp {
+        ( __adrs_set_height adrs + k 1 )
+        : ( Vec u ) ak ( bytes_slice sigx + wl * k . p n + wl * + k 1 . p n )
+        : i cur ( __adrs_get_index adrs )
+        : ~ ( Vec u ) both ( vec_new [u] )
+        ? == % >> idx k 2 0 {
+            ( __adrs_set_index adrs / cur 2 )
+            ( bytes_extend_bytes both node )
+            ( bytes_extend_bytes both ak )
+        } {
+            ( __adrs_set_index adrs / - cur 1 2 )
+            ( bytes_extend_bytes both ak )
+            ( bytes_extend_bytes both node )
+        }
+        : ( Vec u ) nn ( __slh_f pkseed adrs both . p n )
+        ( vec_free [u] both ) ( vec_free [u] ak ) ( vec_free [u] node )
+        = node nn
+        = k + k 1
+    }
+    ^ node
+}
+
+// ── Hypertree (§7) ─────────────────────────────────────────────────
+
+@ __ht_sign ( Vec u ) m ( Vec u ) skseed ( Vec u ) pkseed i idx_tree i idx_leaf SlhParams p → ( Vec u ) {
+    : ~ i it idx_tree
+    : ~ i il idx_leaf
+    : ( Vec u ) adrs ( __adrs_new )
+    ( __adrs_set_layer adrs 0 )
+    ( __adrs_set_tree adrs it )
+    : ( Vec u ) sig0 ( __xmss_sign m skseed il pkseed adrs p )
+    : ~ ( Vec u ) out ( bytes_slice sig0 0 ( vec_len [u] sig0 ) )
+    : ( Vec u ) a0 ( __adrs_new )
+    ( __adrs_set_layer a0 0 )
+    ( __adrs_set_tree a0 it )
+    : ~ ( Vec u ) root ( __xmss_pk_from_sig il sig0 m pkseed a0 p )
+    ( vec_free [u] a0 ) ( vec_free [u] sig0 ) ( vec_free [u] adrs )
+
+    : ~ i j 1
+    ~ < j . p d {
+        // Masked and logically shifted, not `%` and `>>`: for
+        // SLH-DSA-256f the tree index fills all 64 bits, so as a signed
+        // `i` it can be negative, and both of those operators would then
+        // carry the sign into the next layer's index.
+        = il & it - << 1 . p hp 1
+        = it # i >> # u64 it # u64 . p hp
+        : ( Vec u ) aj ( __adrs_new )
+        ( __adrs_set_layer aj j )
+        ( __adrs_set_tree aj it )
+        : ( Vec u ) sj ( __xmss_sign root skseed il pkseed aj p )
+        ( bytes_extend_bytes out sj )
+        ? < j - . p d 1 {
+            : ( Vec u ) a2 ( __adrs_new )
+            ( __adrs_set_layer a2 j )
+            ( __adrs_set_tree a2 it )
+            : ( Vec u ) nr ( __xmss_pk_from_sig il sj root pkseed a2 p )
+            ( vec_free [u] root )
+            = root nr
+            ( vec_free [u] a2 )
+        } {}
+        ( vec_free [u] sj ) ( vec_free [u] aj )
+        = j + j 1
+    }
+    ( vec_free [u] root )
+    ^ out
+}
+
+@ __ht_verify ( Vec u ) m ( Vec u ) sight ( Vec u ) pkseed i idx_tree i idx_leaf ( Vec u ) pkroot SlhParams p → b {
+    : i xl * + . p hp . p len . p n
+    : ~ i it idx_tree
+    : ~ i il idx_leaf
+    : ( Vec u ) a0 ( __adrs_new )
+    ( __adrs_set_layer a0 0 )
+    ( __adrs_set_tree a0 it )
+    : ( Vec u ) s0 ( bytes_slice sight 0 xl )
+    : ~ ( Vec u ) node ( __xmss_pk_from_sig il s0 m pkseed a0 p )
+    ( vec_free [u] s0 ) ( vec_free [u] a0 )
+    : ~ i j 1
+    ~ < j . p d {
+        // Masked and logically shifted, not `%` and `>>`: for
+        // SLH-DSA-256f the tree index fills all 64 bits, so as a signed
+        // `i` it can be negative, and both of those operators would then
+        // carry the sign into the next layer's index.
+        = il & it - << 1 . p hp 1
+        = it # i >> # u64 it # u64 . p hp
+        : ( Vec u ) aj ( __adrs_new )
+        ( __adrs_set_layer aj j )
+        ( __adrs_set_tree aj it )
+        : ( Vec u ) sj ( bytes_slice sight * j xl * + j 1 xl )
+        : ( Vec u ) nn ( __xmss_pk_from_sig il sj node pkseed aj p )
+        ( vec_free [u] node )
+        = node nn
+        ( vec_free [u] sj ) ( vec_free [u] aj )
+        = j + j 1
+    }
+    : b ok ( bytes_eq node pkroot )
+    ( vec_free [u] node )
+    ^ ok
+}
+
+// ── FORS (§8) ──────────────────────────────────────────────────────
+//
+// Forest Of Random Subsets: k trees of 2^a leaves, of which the message
+// digest selects one leaf per tree. It is a *few-time* signature — the
+// hypertree above exists precisely so that no FORS key is ever used
+// twice.
+
+@ __fors_skgen ( Vec u ) skseed ( Vec u ) pkseed ( Vec u ) adrs i idx SlhParams p → ( Vec u ) {
+    : ( Vec u ) sk ( __adrs_copy adrs )
+    ( __adrs_set_type sk 6 )
+    ( __adrs_set_kp sk ( __adrs_get_kp adrs ) )
+    ( __adrs_set_index sk idx )
+    : ( Vec u ) out ( __slh_prf pkseed sk skseed . p n )
+    ( vec_free [u] sk )
+    ^ out
+}
+
+@ __fors_node ( Vec u ) skseed i i2 i z ( Vec u ) pkseed ( Vec u ) adrs SlhParams p → ( Vec u ) {
+    ? == z 0 {
+        : ( Vec u ) sk ( __fors_skgen skseed pkseed adrs i2 p )
+        ( __adrs_set_height adrs 0 )
+        ( __adrs_set_index adrs i2 )
+        : ( Vec u ) out ( __slh_f pkseed adrs sk . p n )
+        ( vec_free [u] sk )
+        ^ out
+    } {}
+    : ( Vec u ) l ( __fors_node skseed * 2 i2 - z 1 pkseed adrs p )
+    : ( Vec u ) r ( __fors_node skseed + * 2 i2 1 - z 1 pkseed adrs p )
+    ( __adrs_set_height adrs z )
+    ( __adrs_set_index adrs i2 )
+    : ( Vec u ) both ( bytes_slice l 0 ( vec_len [u] l ) )
+    ( bytes_extend_bytes both r )
+    : ( Vec u ) out ( __slh_f pkseed adrs both . p n )
+    ( vec_free [u] both ) ( vec_free [u] r ) ( vec_free [u] l )
+    ^ out
+}
+
+@ __fors_sign ( Vec u ) md ( Vec u ) skseed ( Vec u ) pkseed ( Vec u ) adrs SlhParams p → ( Vec u ) {
+    : ( Vec i ) idx ( __base_2b md . p a . p k )
+    : ( Vec u ) sig ( vec_new [u] )
+    : ~ i i 0
+    ~ < i . p k {
+        : i ii ?? ( vec_get [i] idx i ) { T x → { x } F → { 0 } }
+        : ( Vec u ) sk ( __fors_skgen skseed pkseed adrs + * i << 1 . p a ii p )
+        ( bytes_extend_bytes sig sk )
+        ( vec_free [u] sk )
+        : ~ i j 0
+        ~ < j . p a {
+            : i s ^^ >> ii j 1
+            : ( Vec u ) nd ( __fors_node skseed + * i << 1 - . p a j s j pkseed adrs p )
+            ( bytes_extend_bytes sig nd )
+            ( vec_free [u] nd )
+            = j + j 1
+        }
+        = i + i 1
+    }
+    ( vec_free [i] idx )
+    ^ sig
+}
+
+@ __fors_pk_from_sig ( Vec u ) sigf ( Vec u ) md ( Vec u ) pkseed ( Vec u ) adrs SlhParams p → ( Vec u ) {
+    : ( Vec i ) idx ( __base_2b md . p a . p k )
+    : i step * + 1 . p a . p n
+    : ( Vec u ) roots ( vec_new [u] )
+    : ~ i i 0
+    ~ < i . p k {
+        : i ii ?? ( vec_get [i] idx i ) { T x → { x } F → { 0 } }
+        : ( Vec u ) sk ( bytes_slice sigf * i step + * i step . p n )
+        ( __adrs_set_height adrs 0 )
+        ( __adrs_set_index adrs + * i << 1 . p a ii )
+        : ~ ( Vec u ) node ( __slh_f pkseed adrs sk . p n )
+        ( vec_free [u] sk )
+        : ~ i j 0
+        ~ < j . p a {
+            : ( Vec u ) aj ( bytes_slice sigf + + * i step . p n * j . p n + + * i step . p n * + j 1 . p n )
+            ( __adrs_set_height adrs + j 1 )
+            : i cur ( __adrs_get_index adrs )
+            : ~ ( Vec u ) both ( vec_new [u] )
+            ? == % >> ii j 2 0 {
+                ( __adrs_set_index adrs / cur 2 )
+                ( bytes_extend_bytes both node )
+                ( bytes_extend_bytes both aj )
+            } {
+                ( __adrs_set_index adrs / - cur 1 2 )
+                ( bytes_extend_bytes both aj )
+                ( bytes_extend_bytes both node )
+            }
+            : ( Vec u ) nn ( __slh_f pkseed adrs both . p n )
+            ( vec_free [u] both ) ( vec_free [u] aj ) ( vec_free [u] node )
+            = node nn
+            = j + j 1
+        }
+        ( bytes_extend_bytes roots node )
+        ( vec_free [u] node )
+        = i + i 1
+    }
+    : ( Vec u ) fa ( __adrs_copy adrs )
+    ( __adrs_set_type fa 4 )
+    ( __adrs_set_kp fa ( __adrs_get_kp adrs ) )
+    : ( Vec u ) out ( __slh_f pkseed fa roots . p n )
+    ( vec_free [u] fa ) ( vec_free [u] roots ) ( vec_free [i] idx )
+    ^ out
+}
+
+// ── Keys, signing, verification ────────────────────────────────────
+
+: SlhKeys {
+    ( Vec u ) pk
+    ( Vec u ) sk
+}
+
+@ slhdsa_pk * SlhKeys h → ( Vec u ) { ^ . h pk }
+
+@ slhdsa_sk * SlhKeys h → ( Vec u ) { ^ . h sk }
+
+@ slhdsa_keys_free * SlhKeys h → v {
+    ( vec_free [u] . h pk )
+    ( vec_free [u] . h sk )
+    ( nurl_free # s h )
+}
+
+@ slhdsa_keygen_derand i set ( Vec u ) skseed ( Vec u ) skprf ( Vec u ) pkseed → *SlhKeys {
+    : SlhParams p ( __slh_params set )
+    : ( Vec u ) adrs ( __adrs_new )
+    ( __adrs_set_layer adrs - . p d 1 )
+    : ( Vec u ) root ( __xmss_node skseed 0 . p hp pkseed adrs p )
+    ( vec_free [u] adrs )
+    : ( Vec u ) pk ( bytes_slice pkseed 0 . p n )
+    ( bytes_extend_bytes pk root )
+    : ( Vec u ) sk ( bytes_slice skseed 0 . p n )
+    ( bytes_extend_bytes sk skprf )
+    ( bytes_extend_bytes sk pkseed )
+    ( bytes_extend_bytes sk root )
+    ( vec_free [u] root )
+    : *SlhKeys h # *SlhKeys ( nurl_alloc Z SlhKeys )
+    = . h pk pk
+    = . h sk sk
+    ^ h
+}
+
+@ slhdsa_keygen i set → *SlhKeys {
+    : SlhParams p ( __slh_params set )
+    : ( Vec u ) a ( rand_bytes . p n )
+    : ( Vec u ) b2 ( rand_bytes . p n )
+    : ( Vec u ) c ( rand_bytes . p n )
+    : *SlhKeys h ( slhdsa_keygen_derand set a b2 c )
+    ( vec_free [u] c ) ( vec_free [u] b2 ) ( vec_free [u] a )
+    ^ h
+}
+
+// Split H_msg's output into the FORS digest and the two tree indices.
+@ __slh_idx_tree ( Vec u ) digest SlhParams p → i {
+    : i ka / + * . p k . p a 7 8
+    : i hd - . p h / . p h . p d
+    : i tb / + hd 7 8
+    : *u dp ( vec_data [u] digest )
+    : ~ i v 0
+    : ~ i i 0
+    ~ < i tb { = v + << v 8 # i . dp + ka i = i + i 1 }
+    // `1 << hd` is not a usable mask when hd is 64 — x86 takes shift
+    // counts modulo 64, so it yields 1 and the mask becomes 0, which
+    // pins every tree index to zero. SLH-DSA-256f is the one parameter
+    // set where h − h/d reaches 64 exactly, and it was the only one
+    // that failed its vectors. All ones is the right mask there.
+    ? >= hd 64 { ^ v } {}
+    ^ & v - << 1 hd 1
+}
+
+@ __slh_idx_leaf ( Vec u ) digest SlhParams p → i {
+    : i ka / + * . p k . p a 7 8
+    : i hd - . p h / . p h . p d
+    : i tb / + hd 7 8
+    : i hq / . p h . p d
+    : i lb / + hq 7 8
+    : *u dp ( vec_data [u] digest )
+    : ~ i v 0
+    : ~ i i 0
+    ~ < i lb { = v + << v 8 # i . dp + + ka tb i = i + i 1 }
+    ^ & v - << 1 hq 1
+}
+
+@ slhdsa_sign_internal i set ( Vec u ) sk ( Vec u ) msg ( Vec u ) addrnd → ( Vec u ) {
+    : SlhParams p ( __slh_params set )
+    : i n . p n
+    : ( Vec u ) skseed ( bytes_slice sk 0 n )
+    : ( Vec u ) skprf ( bytes_slice sk n * 2 n )
+    : ( Vec u ) pkseed ( bytes_slice sk * 2 n * 3 n )
+    : ( Vec u ) pkroot ( bytes_slice sk * 3 n * 4 n )
+
+    : ( Vec u ) r ( __slh_shake skprf addrnd msg n )
+    : ( Vec u ) hin ( bytes_slice pkseed 0 n )
+    ( bytes_extend_bytes hin pkroot )
+    : ( Vec u ) digest ( __slh_shake r hin msg . p m )
+    ( vec_free [u] hin )
+
+    : i ka / + * . p k . p a 7 8
+    : ( Vec u ) md ( bytes_slice digest 0 ka )
+    : i it ( __slh_idx_tree digest p )
+    : i il ( __slh_idx_leaf digest p )
+    ( vec_free [u] digest )
+
+    : ( Vec u ) adrs ( __adrs_new )
+    ( __adrs_set_tree adrs it )
+    ( __adrs_set_type adrs 3 )
+    ( __adrs_set_kp adrs il )
+    : ( Vec u ) sigf ( __fors_sign md skseed pkseed adrs p )
+    : ( Vec u ) pkf ( __fors_pk_from_sig sigf md pkseed adrs p )
+    : ( Vec u ) sigh ( __ht_sign pkf skseed pkseed it il p )
+
+    : ( Vec u ) out ( bytes_slice r 0 n )
+    ( bytes_extend_bytes out sigf )
+    ( bytes_extend_bytes out sigh )
+
+    ( vec_free [u] sigh ) ( vec_free [u] pkf ) ( vec_free [u] sigf )
+    ( vec_free [u] adrs ) ( vec_free [u] md ) ( vec_free [u] r )
+    ( vec_free [u] pkroot ) ( vec_free [u] pkseed )
+    ( vec_free [u] skprf ) ( vec_free [u] skseed )
+    ^ out
+}
+
+@ slhdsa_verify_internal i set ( Vec u ) pk ( Vec u ) msg ( Vec u ) sig → b {
+    : SlhParams p ( __slh_params set )
+    : i n . p n
+    ? != ( vec_len [u] pk ) * 2 n { ^ F } {}
+    ? != ( vec_len [u] sig ) ( slhdsa_sig_len set ) { ^ F } {}
+    : ( Vec u ) pkseed ( bytes_slice pk 0 n )
+    : ( Vec u ) pkroot ( bytes_slice pk n * 2 n )
+    : i fl * * . p k + 1 . p a n
+    : ( Vec u ) r ( bytes_slice sig 0 n )
+    : ( Vec u ) sigf ( bytes_slice sig n + n fl )
+    : ( Vec u ) sigh ( bytes_slice sig + n fl ( vec_len [u] sig ) )
+
+    : ( Vec u ) hin ( bytes_slice pkseed 0 n )
+    ( bytes_extend_bytes hin pkroot )
+    : ( Vec u ) digest ( __slh_shake r hin msg . p m )
+    ( vec_free [u] hin )
+    : i ka / + * . p k . p a 7 8
+    : ( Vec u ) md ( bytes_slice digest 0 ka )
+    : i it ( __slh_idx_tree digest p )
+    : i il ( __slh_idx_leaf digest p )
+    ( vec_free [u] digest )
+
+    : ( Vec u ) adrs ( __adrs_new )
+    ( __adrs_set_tree adrs it )
+    ( __adrs_set_type adrs 3 )
+    ( __adrs_set_kp adrs il )
+    : ( Vec u ) pkf ( __fors_pk_from_sig sigf md pkseed adrs p )
+    : b ok ( __ht_verify pkf sigh pkseed it il pkroot p )
+
+    ( vec_free [u] pkf ) ( vec_free [u] adrs ) ( vec_free [u] md )
+    ( vec_free [u] sigh ) ( vec_free [u] sigf ) ( vec_free [u] r )
+    ( vec_free [u] pkroot ) ( vec_free [u] pkseed )
+    ^ ok
+}
+
+// ── The external interface (§10.2) ─────────────────────────────────
+//
+// M' = 0x00 ‖ |ctx| ‖ ctx ‖ M, the same shape ML-DSA uses.
+
+@ __slh_mprime ( Vec u ) msg ( Vec u ) ctx → ( Vec u ) {
+    : ( Vec u ) m ( vec_new [u] )
+    ( vec_push [u] m # u 0 )
+    ( vec_push [u] m # u ( vec_len [u] ctx ) )
+    ( bytes_extend_bytes m ctx )
+    ( bytes_extend_bytes m msg )
+    ^ m
+}
+
+// Hedged: a fresh n-byte draw goes into the randomiser. FIPS 205's
+// deterministic variant uses PK.seed instead, which is
+// `slhdsa_sign_deterministic`.
+@ slhdsa_sign i set ( Vec u ) sk ( Vec u ) msg ( Vec u ) ctx → ( Vec u ) {
+    ? > ( vec_len [u] ctx ) 255 { ^ ( vec_new [u] ) } {}
+    : SlhParams p ( __slh_params set )
+    : ( Vec u ) mp ( __slh_mprime msg ctx )
+    : ( Vec u ) rnd ( rand_bytes . p n )
+    : ( Vec u ) sig ( slhdsa_sign_internal set sk mp rnd )
+    ( vec_free [u] rnd ) ( vec_free [u] mp )
+    ^ sig
+}
+
+@ slhdsa_sign_deterministic i set ( Vec u ) sk ( Vec u ) msg ( Vec u ) ctx → ( Vec u ) {
+    ? > ( vec_len [u] ctx ) 255 { ^ ( vec_new [u] ) } {}
+    : SlhParams p ( __slh_params set )
+    : ( Vec u ) mp ( __slh_mprime msg ctx )
+    : ( Vec u ) rnd ( bytes_slice sk * 2 . p n * 3 . p n )
+    : ( Vec u ) sig ( slhdsa_sign_internal set sk mp rnd )
+    ( vec_free [u] rnd ) ( vec_free [u] mp )
+    ^ sig
+}
+
+@ slhdsa_verify i set ( Vec u ) pk ( Vec u ) msg ( Vec u ) ctx ( Vec u ) sig → b {
+    ? > ( vec_len [u] ctx ) 255 { ^ F } {}
+    : ( Vec u ) mp ( __slh_mprime msg ctx )
+    : b ok ( slhdsa_verify_internal set pk mp sig )
+    ( vec_free [u] mp )
+    ^ ok
+}

--- a/tools/slhdsa_acvp_gate.nu
+++ b/tools/slhdsa_acvp_gate.nu
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 The NURL Project Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// tools/slhdsa_acvp_gate.nu — run NIST's published ACVP vectors for
+// SLH-DSA against stdlib/std/slhdsa.nu.
+//
+//   slhdsa_acvp_gate <keyGen.json> <sigGen.json> <sigVer.json> <per-group-cap>
+//
+// Unlike the ML-KEM and ML-DSA gates, this one caps how many cases it
+// runs per group, because SLH-DSA signing is slow *by construction*: a
+// `128s` signature rebuilds 512 WOTS+ key pairs on each of seven
+// hypertree layers. Running all 624 published sigGen cases would take
+// hours, so the cap is a parameter and the number of cases it skipped
+// is printed. A gate that quietly truncated its own corpus would read
+// as full coverage.
+//
+// Key generation is not capped — it is the cheap half and all 60 cases
+// run.
+//
+// Only the SHAKE parameter sets are implemented; the SHA-2 sets are
+// counted as skipped and reported separately from the cap.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/string.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/ext/json.nu`
+$ `stdlib/std/slhdsa.nu`
+
+@ __str Json o s key → s {
+    ?? ( json_obj_get o key ) { T v → { ^ ( json_str_data v ) } F → { ^ `` } }
+}
+
+@ __bool Json o s key → b {
+    ?? ( json_obj_get o key ) { T v → { ^ ( json_bool_val v ) } F → { ^ F } }
+}
+
+@ __hexv s h → ( Vec u ) {
+    ? == ( nurl_str_len h ) 0 { ^ ( vec_new [u] ) } {}
+    ?? ( bytes_from_hex h ) { T v → { ^ v } F _e → { ^ ( vec_new [u] ) } }
+}
+
+@ __eqhex ( Vec u ) got s want → b {
+    ?? ( bytes_from_hex want ) {
+        T w → { : b ok ( bytes_eq got w ) ( vec_free [u] w ) ^ ok }
+        F _e → { ^ F }
+    }
+}
+
+// "SLH-DSA-SHAKE-128f" → the set integer this module takes; 0 for the
+// SHA-2 family, which is not implemented.
+@ __set_of s ps → i {
+    ? != 0 ( nurl_str_eq ps `SLH-DSA-SHAKE-128s` ) { ^ 128 } {}
+    ? != 0 ( nurl_str_eq ps `SLH-DSA-SHAKE-128f` ) { ^ 129 } {}
+    ? != 0 ( nurl_str_eq ps `SLH-DSA-SHAKE-192s` ) { ^ 192 } {}
+    ? != 0 ( nurl_str_eq ps `SLH-DSA-SHAKE-192f` ) { ^ 193 } {}
+    ? != 0 ( nurl_str_eq ps `SLH-DSA-SHAKE-256s` ) { ^ 256 } {}
+    ? != 0 ( nurl_str_eq ps `SLH-DSA-SHAKE-256f` ) { ^ 257 } {}
+    ^ 0
+}
+
+@ __load s path → Json {
+    : !String IoErr rd ( read_file path )
+    : String txt ?? rd { T v → { v } F _e → { ( nurl_print `cannot read vector file\n` ) ( string_new ) } }
+    : Json j ?? ( json_parse ( string_data txt ) ) { T v → { v } F _e → { ( nurl_print `cannot parse vector JSON\n` ) ( json_null ) } }
+    ( string_free txt )
+    ^ j
+}
+
+// Three reasons a case does not run, reported apart. Rolling them into
+// one "skipped" number would hide which of them is a decision (the cap),
+// which is a gap (SHA-2), and which is out of scope (the external
+// interfaces, covered by the ML-DSA gate's equivalent path).
+@ __report s what i pass i fail i capped i sha2 i iface → v {
+    : String s ( string_new )
+    ( string_push_str s what )
+    ( string_push_str s `: ` )
+    ( string_push_int s pass )
+    ( string_push_str s ` passed, ` )
+    ( string_push_int s fail )
+    ( string_push_str s ` failed` )
+    ? > capped 0 {
+        ( string_push_str s `, ` )
+        ( string_push_int s capped )
+        ( string_push_str s ` past the per-group cap` )
+    } {}
+    ? > sha2 0 {
+        ( string_push_str s `, ` )
+        ( string_push_int s sha2 )
+        ( string_push_str s ` SHA-2 sets (not implemented)` )
+    } {}
+    ? > iface 0 {
+        ( string_push_str s `, ` )
+        ( string_push_int s iface )
+        ( string_push_str s ` non-internal interface` )
+    } {}
+    ( string_push_str s `\n` )
+    ( nurl_print ( string_data s ) )
+    ( string_free s )
+}
+
+@ main → i {
+    ? < ( nurl_argv_count ) 5 {
+        ( nurl_print `usage: slhdsa_acvp_gate <keyGen> <sigGen> <sigVer> <cap>\n` )
+        ^ 2
+    } {}
+    : i cap ( nurl_str_to_int ( nurl_argv_get 4 ) )
+    : ~ i totfail 0
+
+    // ── keyGen: every case, uncapped ──
+    : Json kg ( __load ( nurl_argv_get 1 ) )
+    : Json kgg ?? ( json_obj_get kg `testGroups` ) { T v → { v } F → { ( json_null ) } }
+    : ~ i kp 0
+    : ~ i kf 0
+    : ~ i ks 0
+    : ~ i gi 0
+    ~ < gi ( json_arr_len kgg ) {
+        : Json g ?? ( json_arr_get kgg gi ) { T v → { v } F → { ( json_null ) } }
+        : i set ( __set_of ( __str g `parameterSet` ) )
+        : Json ts ?? ( json_obj_get g `tests` ) { T v → { v } F → { ( json_null ) } }
+        : ~ i ti 0
+        ~ < ti ( json_arr_len ts ) {
+            : Json tc ?? ( json_arr_get ts ti ) { T v → { v } F → { ( json_null ) } }
+            ? == set 0 { = ks + ks 1 } {
+                : ( Vec u ) a ( __hexv ( __str tc `skSeed` ) )
+                : ( Vec u ) b2 ( __hexv ( __str tc `skPrf` ) )
+                : ( Vec u ) c ( __hexv ( __str tc `pkSeed` ) )
+                : *SlhKeys k ( slhdsa_keygen_derand set a b2 c )
+                ? & ( __eqhex ( slhdsa_pk k ) ( __str tc `pk` ) ) ( __eqhex ( slhdsa_sk k ) ( __str tc `sk` ) )
+                { = kp + kp 1 } { = kf + kf 1 }
+                ( slhdsa_keys_free k )
+                ( vec_free [u] c ) ( vec_free [u] b2 ) ( vec_free [u] a )
+            }
+            = ti + ti 1
+        }
+        = gi + gi 1
+    }
+    ( json_free kg )
+    ( __report `keyGen` kp kf 0 ks 0 )
+    = totfail + totfail kf
+
+    // ── sigGen: internal interface, capped per group ──
+    : Json sg ( __load ( nurl_argv_get 2 ) )
+    : Json sgg ?? ( json_obj_get sg `testGroups` ) { T v → { v } F → { ( json_null ) } }
+    : ~ i sp 0
+    : ~ i sf 0
+    : ~ i sc 0
+    : ~ i ss2 0
+    : ~ i si2 0
+    = gi 0
+    ~ < gi ( json_arr_len sgg ) {
+        : Json g ?? ( json_arr_get sgg gi ) { T v → { v } F → { ( json_null ) } }
+        : i set ( __set_of ( __str g `parameterSet` ) )
+        : b det ( __bool g `deterministic` )
+        : b internal != 0 ( nurl_str_eq ( __str g `signatureInterface` ) `internal` )
+        : b pure != 0 ( nurl_str_eq ( __str g `preHash` ) `pure` )
+        : Json ts ?? ( json_obj_get g `tests` ) { T v → { v } F → { ( json_null ) } }
+        : ~ i ti 0
+        ~ < ti ( json_arr_len ts ) {
+            : Json tc ?? ( json_arr_get ts ti ) { T v → { v } F → { ( json_null ) } }
+            ? == set 0 { = ss2 + ss2 1 } {
+                ? & ! internal ! pure { = si2 + si2 1 } {
+                    ? >= ti cap { = sc + sc 1 } {
+                        : ( Vec u ) sk ( __hexv ( __str tc `sk` ) )
+                        : ( Vec u ) raw ( __hexv ( __str tc `message` ) )
+                        : ( Vec u ) ctx ( __hexv ( __str tc `context` ) )
+                        // The external interface signs 0x00 | |ctx| | ctx | M;
+                        // the internal one signs M as given.
+                        : ~ ( Vec u ) msg ( vec_new [u] )
+                        ? internal {
+                            ( vec_free [u] msg )
+                            = msg ( bytes_slice raw 0 ( vec_len [u] raw ) )
+                        } {
+                            ( vec_push [u] msg # u 0 )
+                            ( vec_push [u] msg # u ( vec_len [u] ctx ) )
+                            ( bytes_extend_bytes msg ctx )
+                            ( bytes_extend_bytes msg raw )
+                        }
+                        : i n / ( vec_len [u] sk ) 4
+                        : ( Vec u ) rnd ? det ( bytes_slice sk * 2 n * 3 n ) ( __hexv ( __str tc `additionalRandomness` ) )
+                        : ( Vec u ) sig ( slhdsa_sign_internal set sk msg rnd )
+                        ? ( __eqhex sig ( __str tc `signature` ) ) { = sp + sp 1 } {
+                            = sf + sf 1
+                            : String fl ( string_new )
+                            ( string_push_str fl `  FAIL sigGen ` )
+                            ( string_push_str fl ( __str g `parameterSet` ) )
+                            ( string_push_str fl ? det ` deterministic` ` hedged` )
+                            ( string_push_str fl `\n` )
+                            ( nurl_print ( string_data fl ) )
+                            ( string_free fl )
+                        }
+                        ( vec_free [u] sig ) ( vec_free [u] rnd )
+                        ( vec_free [u] msg ) ( vec_free [u] ctx )
+                        ( vec_free [u] raw ) ( vec_free [u] sk )
+                    }
+                }
+            }
+            = ti + ti 1
+        }
+        = gi + gi 1
+    }
+    ( json_free sg )
+    ( __report `sigGen` sp sf sc ss2 si2 )
+    = totfail + totfail sf
+
+    // ── sigVer: internal interface, capped per group ──
+    : Json sv ( __load ( nurl_argv_get 3 ) )
+    : Json svg ?? ( json_obj_get sv `testGroups` ) { T v → { v } F → { ( json_null ) } }
+    : ~ i vp 0
+    : ~ i vf 0
+    : ~ i vc 0
+    : ~ i vs 0
+    : ~ i vi 0
+    = gi 0
+    ~ < gi ( json_arr_len svg ) {
+        : Json g ?? ( json_arr_get svg gi ) { T v → { v } F → { ( json_null ) } }
+        : i set ( __set_of ( __str g `parameterSet` ) )
+        : b internal != 0 ( nurl_str_eq ( __str g `signatureInterface` ) `internal` )
+        : b pure != 0 ( nurl_str_eq ( __str g `preHash` ) `pure` )
+        : Json ts ?? ( json_obj_get g `tests` ) { T v → { v } F → { ( json_null ) } }
+        : ~ i ti 0
+        ~ < ti ( json_arr_len ts ) {
+            : Json tc ?? ( json_arr_get ts ti ) { T v → { v } F → { ( json_null ) } }
+            ? == set 0 { = vs + vs 1 } {
+                ? & ! internal ! pure { = vi + vi 1 } {
+                    ? >= ti cap { = vc + vc 1 } {
+                        : ( Vec u ) pk ( __hexv ( __str tc `pk` ) )
+                        : ( Vec u ) raw ( __hexv ( __str tc `message` ) )
+                        : ( Vec u ) ctx ( __hexv ( __str tc `context` ) )
+                        : ~ ( Vec u ) msg ( vec_new [u] )
+                        ? internal {
+                            ( vec_free [u] msg )
+                            = msg ( bytes_slice raw 0 ( vec_len [u] raw ) )
+                        } {
+                            ( vec_push [u] msg # u 0 )
+                            ( vec_push [u] msg # u ( vec_len [u] ctx ) )
+                            ( bytes_extend_bytes msg ctx )
+                            ( bytes_extend_bytes msg raw )
+                        }
+                        : ( Vec u ) sig ( __hexv ( __str tc `signature` ) )
+                        ? == ( slhdsa_verify_internal set pk msg sig ) ( __bool tc `testPassed` )
+                        { = vp + vp 1 } { = vf + vf 1 }
+                        ( vec_free [u] sig ) ( vec_free [u] msg )
+                        ( vec_free [u] ctx ) ( vec_free [u] raw ) ( vec_free [u] pk )
+                    }
+                }
+            }
+            = ti + ti 1
+        }
+        = gi + gi 1
+    }
+    ( json_free sv )
+    ( __report `sigVer` vp vf vc vs vi )
+    = totfail + totfail vf
+
+    ^ ? == totfail 0 0 1
+}

--- a/tools/slhdsa_acvp_gate.sh
+++ b/tools/slhdsa_acvp_gate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The NURL Project Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# ============================================================
+#  tools/slhdsa_acvp_gate.sh — prove stdlib/std/slhdsa.nu against the
+#  authority: NIST's own ACVP test vectors for FIPS 205.
+#
+#  SLH-DSA is a hash-based signature, so almost nothing about it can be
+#  checked by reasoning about the output — a wrong address field or a
+#  wrong chain bound produces a different but perfectly well-formed
+#  root, and signing and verifying with the same mistake agree. The
+#  vectors are the only thing that distinguishes those.
+#
+#  Coverage, per run:
+#
+#    keyGen   all 60 SHAKE cases, uncapped
+#    sigGen   capped per group — internal and external-pure interfaces
+#    sigVer   capped per group — including the tampered cases
+#
+#  Why capped: signing is slow *by design*. A `128s` signature rebuilds
+#  512 WOTS+ key pairs on each of seven hypertree layers, and the
+#  published set has 624 sigGen cases. The cap is an argument and the
+#  number of cases it left is printed, along with the SHA-2 sets that
+#  are not implemented and the pre-hash interfaces that are out of
+#  scope — three different reasons, reported apart, so none of them can
+#  be mistaken for coverage.
+#
+#  Note the vector files are large (sigGen ~38 MB, sigVer ~31 MB), so
+#  the fetch dominates a first run.
+#
+#  Usage:  tools/slhdsa_acvp_gate.sh [cap]      (cap defaults to 2)
+#  Env:    NURL         build driver (defaults to ./nurl.sh in a checkout)
+#          ACVP_DIR     directory holding pre-downloaded JSON (skips the
+#                       fetch; useful offline and in sandboxed CI)
+# ============================================================
+set -u
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+CAP="${1:-2}"
+
+if [ -n "${NURL:-}" ]; then :;
+elif [ -x "$REPO_ROOT/nurl.sh" ]; then NURL="$REPO_ROOT/nurl.sh";
+else NURL="nurl"; fi
+
+WORK="$(mktemp -d -t slhdsa-gate.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+BASE="https://raw.githubusercontent.com/usnistgov/ACVP-Server/master/gen-val/json-files"
+KEYGEN="$WORK/keyGen.json"; SIGGEN="$WORK/sigGen.json"; SIGVER="$WORK/sigVer.json"
+
+if [ -n "${ACVP_DIR:-}" ]; then
+    for pair in "SLH-DSA-keyGen-FIPS205:$KEYGEN" "SLH-DSA-sigGen-FIPS205:$SIGGEN" "SLH-DSA-sigVer-FIPS205:$SIGVER"; do
+        src="${pair%%:*}"; dst="${pair#*:}"
+        cp "$ACVP_DIR/$src.json" "$dst" 2>/dev/null || {
+            echo "FAIL: ACVP_DIR set but $src.json not found in it"; exit 1; }
+    done
+else
+    command -v curl >/dev/null 2>&1 || { echo "SKIP: curl not available"; exit 0; }
+    fetch() { curl -fsS --max-time 600 -o "$2" "$1" 2>>"$WORK/curl.err"; }
+    if ! fetch "$BASE/SLH-DSA-keyGen-FIPS205/internalProjection.json" "$KEYGEN" \
+       || ! fetch "$BASE/SLH-DSA-sigGen-FIPS205/internalProjection.json" "$SIGGEN" \
+       || ! fetch "$BASE/SLH-DSA-sigVer-FIPS205/internalProjection.json" "$SIGVER"; then
+        echo "SKIP: could not fetch NIST ACVP vectors (no network?)"
+        [ -s "$WORK/curl.err" ] && sed 's/^/  /' "$WORK/curl.err"
+        exit 0
+    fi
+fi
+
+GATE="$WORK/slhdsa_acvp_gate"
+if ! $NURL tools/slhdsa_acvp_gate.nu "$GATE" >/dev/null 2>"$WORK/build.err"; then
+    echo "FAIL: could not build tools/slhdsa_acvp_gate.nu:"
+    tail -20 "$WORK/build.err"
+    exit 1
+fi
+
+"$GATE" "$KEYGEN" "$SIGGEN" "$SIGVER" "$CAP"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    echo "PASS: SLH-DSA matches NIST ACVP (cap=$CAP per group)"
+else
+    echo "FAIL: SLH-DSA disagrees with NIST ACVP"
+fi
+exit $rc


### PR DESCRIPTION
The third and last NIST post-quantum standard, and the one that assumes
least. ML-KEM and ML-DSA rest on lattice problems; **SLH-DSA rests on
nothing but the hash function**, so it is what still stands if a break
lands on lattices. It exists *alongside* ML-DSA, not instead of it.

All six SHAKE parameter sets: WOTS+, XMSS, the hypertree, FORS, and the
32-byte address structure that domain-separates every hash call. The
SHA-2 instantiation of FIPS 205 is not implemented.

| set | pk | sk | signature |
|---|---|---|---|
| 128s / 128f | 32 | 64 | 7 856 / 17 088 |
| 192s / 192f | 48 | 96 | 16 224 / 35 664 |
| 256s / 256f | 64 | 128 | 29 792 / 49 856 |

The price is size and speed — 7 856 bytes against ML-DSA-44's 2 420, and
signing walks a hypertree of Merkle trees rather than doing algebra. Use
ML-DSA by default; use this where a signature is rare, long-lived, and
has to outlast an assumption: firmware images, root certificates,
release artefacts.

## Method

Written the way ML-DSA was: a Python reference transliterated from FIPS
205 first and validated against the vectors (keygen 12/12, sigGen 12/12,
sigVer 18/18), and only then ported. Keygen matched NIST byte for byte
on the first NURL run.

## Signing did not — and both bugs were signedness

The same axis that has bitten this stack before, one width up.

**SLH-DSA-256f is the one parameter set whose hypertree index fills all
64 bits** (h − h/d = 68 − 4). The mask was computed as `1 << 64`, and
x86 takes shift counts modulo 64 — so it yielded 1, the mask became 0,
and every tree index was pinned to zero.

With that fixed the same set *still* failed, because `%` and `>>` on a
now-negative `i` carried the sign into the next layer's index, and
`__adrs_put` shifted past 64 when writing the top bytes of the 12-byte
tree field.

Five of the six sets passed throughout. Only the one that reaches
exactly 64 bits ever showed it — which is why that apparently redundant
set is pinned in the offline test too, with a comment saying why it is
there.

## The gate, and what it does not do

`tools/slhdsa_acvp_gate.sh` runs all 60 SHAKE keyGen cases uncapped, and
**caps** sigGen/sigVer per group, because signing is slow by
construction: a `128s` signature rebuilds 512 WOTS+ key pairs on each of
seven layers, and the published set has 624 sigGen cases.

The three reasons a case does not run are counted and printed
**separately**:

```
keyGen: 60 passed, 0 failed, 60 SHA-2 sets (not implemented)
sigGen: 48 passed, 0 failed, 120 past the per-group cap,
        312 SHA-2 sets (not implemented), 144 non-internal interface
sigVer: 24 passed, 0 failed, 144 past the per-group cap,
        252 SHA-2 sets (not implemented), 84 non-internal interface
```

Rolling those into one "skipped" number would let a decision (the cap),
a gap (SHA-2) and an out-of-scope case (pre-hash) all read as coverage.
Both the internal and the external-pure interfaces run.

## Test status

- 843 compiler tests pass (1 new), 0 failures
- SLH-DSA 132 ACVP cases at cap 2; ML-KEM 180/180 and ML-DSA 615/615
  still green
- ASan/LSan clean
- stdlib-symbols gate green

## Not done

The **SHA-2 instantiation** — same structure, different hash plumbing
(SHA-256/SHA-512 with a compressed 22-byte address, MGF1, HMAC). It
would double the parameter sets to twelve. The pre-hash interfaces are
likewise unimplemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
