### PR TITLE
feat(stdlib,ext,pki-server): add pure-NURL PKCS#10 CSR subsystem and JWT ES256 support

### DIFF
--- a/compiler/tests/csr_basic.nu
+++ b/compiler/tests/csr_basic.nu
@@ -1,0 +1,188 @@
+// csr_basic.nu — Acceptance tests for stdlib/std/csr.nu:
+// PKCS#10 CSR generation, parsing, self-signature verification,
+// PEM conversion, and X.509 CA certificate issuance from CSR.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/ecdsa_p256.nu`
+$ `stdlib/std/ed25519.nu`
+$ `stdlib/std/x509.nu`
+$ `stdlib/std/csr.nu`
+
+@ hx s h → ( Vec u ) {
+    : !( Vec u ) ParseErr r ( bytes_from_hex h )
+    ^ ?? r { T v → v F _ → ( vec_new [u] ) }
+}
+
+@ main → i {
+    ( nurl_print `── [csr] PKCS#10 CSR Tests ──\n` )
+
+    // ── 1. ECDSA P-256 CSR generation & parsing ──────────────────────
+    ( nurl_print `[1/6] Generating and parsing ECDSA P-256 CSR... ` )
+    : ( Vec u ) scalar ( hx `c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721` )
+    : ( Vec String ) sans ( vec_new [String] )
+    ( vec_push [String] sans ( string_from `node1.example.com` ) )
+    ( vec_push [String] sans ( string_from `api.internal.local` ) )
+
+    : ( Vec u ) csr_p256_der ( csr_generate_p256 `node1.example.com` sans scalar )
+    : Csr csr_p256 ( csr_parse csr_p256_der )
+    ? ! . csr_p256 ok {
+        ( nurl_print `FAILED: parse returned ok=F\n` )
+        ^ 1
+    } {}
+    ? == ( nurl_str_eq ( string_data . csr_p256 cn ) `node1.example.com` ) 0 {
+        ( nurl_print `FAILED: CN mismatch\n` )
+        ^ 1
+    } {}
+    ? != . csr_p256 key_alg 2 {
+        ( nurl_print `FAILED: expected key_alg=2 (EC)\n` )
+        ^ 1
+    } {}
+    ? != . csr_p256 sig_alg 4 {
+        ( nurl_print `FAILED: expected sig_alg=4 (ecdsa_sha256)\n` )
+        ^ 1
+    } {}
+    ? != ( vec_len [String] . csr_p256 sans ) 2 {
+        ( nurl_print `FAILED: expected 2 SANs\n` )
+        ^ 1
+    } {}
+    ( nurl_print `OK\n` )
+
+    // ── 2. ECDSA P-256 CSR self-signature verification ───────────────
+    ( nurl_print `[2/6] Verifying ECDSA P-256 self-signature... ` )
+    : b p256_valid ( csr_verify csr_p256 )
+    ? ! p256_valid {
+        ( nurl_print `FAILED: self-signature check failed\n` )
+        ^ 1
+    } {}
+    ( nurl_print `OK\n` )
+
+    // ── 3. Ed25519 CSR generation, parsing & verification ─────────────
+    ( nurl_print `[3/6] Generating and verifying Ed25519 CSR... ` )
+    : ( Vec u ) ed_sk ( hx `9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60` )
+    : ( Vec String ) ed_sans ( vec_new [String] )
+    ( vec_push [String] ed_sans ( string_from `ed-node.example.org` ) )
+
+    : ( Vec u ) csr_ed_der ( csr_generate_ed25519 `ed-node.example.org` ed_sans ed_sk )
+    : Csr csr_ed ( csr_parse csr_ed_der )
+    ? ! . csr_ed ok {
+        ( nurl_print `FAILED: Ed25519 parse failed\n` )
+        ^ 1
+    } {}
+    ? != . csr_ed key_alg 3 {
+        ( nurl_print `FAILED: expected key_alg=3 (Ed25519)\n` )
+        ^ 1
+    } {}
+    ? != . csr_ed sig_alg 7 {
+        ( nurl_print `FAILED: expected sig_alg=7 (ed25519)\n` )
+        ^ 1
+    } {}
+    : b ed_valid ( csr_verify csr_ed )
+    ? ! ed_valid {
+        ( nurl_print `FAILED: Ed25519 self-signature verification failed\n` )
+        ^ 1
+    } {}
+    ( nurl_print `OK\n` )
+
+    // ── 4. PEM formatting round-trip ──────────────────────────────────
+    ( nurl_print `[4/6] Testing PEM formatting round-trip... ` )
+    : String pem ( csr_to_pem ( bytes_slice csr_p256_der 0 ( vec_len [u] csr_p256_der ) ) )
+    : !( Vec u ) ParseErr der_back ( csr_from_pem ( string_data pem ) )
+    ?? der_back {
+        T d_back → {
+            : Csr csr_from_pem_parsed ( csr_parse d_back )
+            ? ! . csr_from_pem_parsed ok {
+                ( nurl_print `FAILED: re-parsed PEM CSR failed\n` )
+                ^ 1
+            } {}
+            ( csr_free csr_from_pem_parsed )
+            ( vec_free [u] d_back )
+        }
+        F _ → {
+            ( nurl_print `FAILED: csr_from_pem error\n` )
+            ^ 1
+        }
+    }
+    ( string_free pem )
+    ( nurl_print `OK\n` )
+
+    // ── 5. Tamper detection on CSR ────────────────────────────────────
+    ( nurl_print `[5/6] Testing tamper rejection on CSR... ` )
+    // Flip a byte inside req_info
+    : ( Vec u ) tampered_info ( bytes_slice . csr_p256 req_info 0 ( vec_len [u] . csr_p256 req_info ) )
+    : i b0 ?? ( vec_get [u] tampered_info 10 ) { T x → # i x F _ → 0 }
+    ( vec_set [u] tampered_info 10 # u ^^ b0 255 )
+    : Csr tampered_csr @ Csr {
+        tampered_info
+        . csr_p256 sig_alg
+        ( bytes_slice . csr_p256 sig 0 ( vec_len [u] . csr_p256 sig ) )
+        . csr_p256 key_alg
+        ( bytes_slice . csr_p256 pubkey 0 ( vec_len [u] . csr_p256 pubkey ) )
+        ( vec_new [u] )
+        ( string_from ( string_data . csr_p256 cn ) )
+        ( string_new )
+        ( string_new )
+        ( vec_new [String] )
+        F
+        T
+    }
+    : b tamper_ver ( csr_verify tampered_csr )
+    ? tamper_ver {
+        ( nurl_print `FAILED: tampered CSR unexpectedly passed verification\n` )
+        ^ 1
+    } {}
+    ( csr_free tampered_csr )
+    ( nurl_print `OK\n` )
+
+    // ── 6. CA issuance from verified CSR ──────────────────────────────
+    ( nurl_print `[6/6] Issuing X.509 certificate from CSR... ` )
+    : ( Vec u ) ca_scalar ( hx `1111111111111111111111111111111111111111111111111111111111111111` )
+    : ( Vec u ) ca_pubkey ( p256_ecdh_keygen ca_scalar )
+    : ( Vec u ) serial ( hx `0102030405060708` )
+
+    : ( Vec u ) leaf_cert_der ( x509_issue_from_csr ca_scalar ca_pubkey `Root CA` csr_p256 serial 365 F )
+    : X509 parsed_leaf ( x509_parse leaf_cert_der )
+    ? ! . parsed_leaf ok {
+        ( nurl_print `FAILED: issued certificate failed x509_parse\n` )
+        ^ 1
+    } {}
+    : ( Vec u ) leaf_hash ( sha256_pure . parsed_leaf tbs )
+    : ( Vec u ) sig_rs ( x509_ecdsa_sig_rs . parsed_leaf sig )
+    ? != ( vec_len [u] sig_rs ) 64 {
+        ( nurl_print `FAILED: could not extract r||s from issued cert\n` )
+        ^ 1
+    } {}
+    : ( Vec u ) leaf_r ( bytes_slice sig_rs 0 32 )
+    : ( Vec u ) leaf_s ( bytes_slice sig_rs 32 64 )
+    : b leaf_sig_ok ( ecdsa_p256_verify ca_pubkey leaf_r leaf_s leaf_hash )
+    ( vec_free [u] leaf_r )
+    ( vec_free [u] leaf_s )
+    ( vec_free [u] sig_rs )
+    ( vec_free [u] leaf_hash )
+    ? ! leaf_sig_ok {
+        ( nurl_print `FAILED: issued certificate signature failed CA verification\n` )
+        ^ 1
+    } {}
+    ( x509_free parsed_leaf )
+    ( vec_free [u] leaf_cert_der )
+    ( vec_free [u] serial )
+    ( vec_free [u] ca_scalar )
+    ( vec_free [u] ca_pubkey )
+    ( nurl_print `OK\n` )
+
+    // Clean up
+    ( csr_free csr_p256 )
+    ( vec_free [u] csr_p256_der )
+    ( vec_free [u] scalar )
+    ( vec_free_with [String] sans \ String s → v { ( string_free s ) } )
+
+    ( csr_free csr_ed )
+    ( vec_free [u] csr_ed_der )
+    ( vec_free [u] ed_sk )
+    ( vec_free_with [String] ed_sans \ String s → v { ( string_free s ) } )
+
+    ( nurl_print `── ALL 6 CSR TESTS PASSED ──\n` )
+    ^ 0
+}

--- a/compiler/tests/csr_openssl_gate.sh
+++ b/compiler/tests/csr_openssl_gate.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# compiler/tests/csr_openssl_gate.sh — Gate verifying two-way interoperability
+# between pure-NURL PKCS#10 CSR (stdlib/std/csr.nu) and OpenSSL.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d /tmp/nurl-csr-test-XXXXXX)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+echo "==> Building CSR test tool..."
+cat << 'EOF' > "$WORK/tool.nu"
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/fs.nu`
+$ `stdlib/std/ecdsa_p256.nu`
+$ `stdlib/std/ed25519.nu`
+$ `stdlib/std/x509.nu`
+$ `stdlib/std/csr.nu`
+$ `stdlib/std/args.nu`
+
+@ main → i {
+    : ArgParser p ( args_new `csr-tool` `PKCS#10 test tool` )
+    ( args_parse_argv p )
+    : ( Vec String ) av ( args_positionals p )
+    : i argc ( vec_len [String] av )
+    ? < argc 1 { ( args_free p ) ^ 1 } {}
+    : ?String cmdo ( vec_get [String] av 0 )
+    : String cmd ?? cmdo { T s → s F _ → ( string_new ) }
+
+    ? ( string_eq cmd ( string_from `gen-p256` ) ) {
+        : ?String out_path_o ( vec_get [String] av 1 )
+        : String out_path ?? out_path_o { T s → s F _ → ( string_new ) }
+        : !( Vec u ) ParseErr sr ( bytes_from_hex `c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721` )
+        : ( Vec u ) scalar ?? sr { T v → v F _ → ( vec_new [u] ) }
+        : ( Vec String ) sans ( vec_new [String] )
+        ( vec_push [String] sans ( string_from `node1.example.com` ) )
+        ( vec_push [String] sans ( string_from `api.internal.local` ) )
+        : ( Vec u ) der ( csr_generate_p256 `node1.example.com` sans scalar )
+        : String pem ( csr_to_pem der )
+        ( write_file ( string_data out_path ) ( string_data pem ) )
+        ( string_free pem )
+        ( vec_free [u] scalar )
+        ( vec_free_with [String] sans \ String s → v { ( string_free s ) } )
+        ( args_free p )
+        ^ 0
+    } {}
+
+    ? ( string_eq cmd ( string_from `gen-ed25519` ) ) {
+        : ?String out_path_o ( vec_get [String] av 1 )
+        : String out_path ?? out_path_o { T s → s F _ → ( string_new ) }
+        : !( Vec u ) ParseErr sr ( bytes_from_hex `9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60` )
+        : ( Vec u ) sk ?? sr { T v → v F _ → ( vec_new [u] ) }
+        : ( Vec String ) sans ( vec_new [String] )
+        ( vec_push [String] sans ( string_from `ed25519-node.example.org` ) )
+        : ( Vec u ) der ( csr_generate_ed25519 `ed25519-node.example.org` sans sk )
+        : String pem ( csr_to_pem der )
+        ( write_file ( string_data out_path ) ( string_data pem ) )
+        ( string_free pem )
+        ( vec_free [u] sk )
+        ( vec_free_with [String] sans \ String s → v { ( string_free s ) } )
+        ( args_free p )
+        ^ 0
+    } {}
+
+    ? ( string_eq cmd ( string_from `verify-csr` ) ) {
+        : ?String in_path_o ( vec_get [String] av 1 )
+        : String in_path ?? in_path_o { T s → s F _ → ( string_new ) }
+        : !String IoErr content_o ( read_file ( string_data in_path ) )
+        : String content ?? content_o { T s → s F _ → ( string_new ) }
+        : !( Vec u ) ParseErr der_o ( csr_from_pem ( string_data content ) )
+        ( string_free content )
+        : ( Vec u ) der ?? der_o { T v → v F _ → ( vec_new [u] ) }
+        : Csr csr ( csr_parse der )
+        ( vec_free [u] der )
+        ? ! . csr ok {
+            ( csr_free csr )
+            ( args_free p )
+            ( nurl_print `PARSE_ERR\n` )
+            ^ 1
+        } {}
+        : b v ( csr_verify csr )
+        ( csr_free csr )
+        ( args_free p )
+        ? v { ( nurl_print `VERIFY_OK\n` ) ^ 0 } { ( nurl_print `VERIFY_FAIL\n` ) ^ 1 }
+    } {}
+
+    ( args_free p )
+    ^ 1
+}
+EOF
+
+"$REPO_ROOT/nurl.sh" "$WORK/tool.nu" "$WORK/tool"
+
+echo "--> Test 1: OpenSSL verifying NURL-generated ECDSA P-256 CSR..."
+"$WORK/tool" gen-p256 "$WORK/csr_p256.pem"
+openssl req -in "$WORK/csr_p256.pem" -text -noout -verify 2>&1 | grep -E "verify (OK|success)"
+echo "    OpenSSL accepted & verified P-256 CSR signature: OK"
+
+echo "--> Test 2: OpenSSL verifying NURL-generated Ed25519 CSR..."
+"$WORK/tool" gen-ed25519 "$WORK/csr_ed.pem"
+openssl req -in "$WORK/csr_ed.pem" -text -noout -verify 2>&1 | grep -E "verify (OK|success)"
+echo "    OpenSSL accepted & verified Ed25519 CSR signature: OK"
+
+echo "--> Test 3: NURL verifying OpenSSL-generated ECDSA CSR..."
+openssl ecparam -name prime256v1 -genkey -noout -out "$WORK/ossl_p256.key"
+openssl req -new -key "$WORK/ossl_p256.key" -out "$WORK/ossl_p256.csr" -subj "/CN=openssl-client.test" -addext "subjectAltName=DNS:openssl-client.test,DNS:alt.test"
+res=$("$WORK/tool" verify-csr "$WORK/ossl_p256.csr")
+if [[ "$res" == "VERIFY_OK" ]]; then
+    echo "    NURL parsed & verified OpenSSL CSR: OK"
+else
+    echo "    NURL failed to verify OpenSSL CSR: $res"
+    exit 1
+fi
+
+echo "--> Test 4: NURL verifying OpenSSL-generated Ed25519 CSR..."
+openssl genpkey -algorithm ED25519 -out "$WORK/ossl_ed.key"
+openssl req -new -key "$WORK/ossl_ed.key" -out "$WORK/ossl_ed.csr" -subj "/CN=openssl-ed25519.test" -addext "subjectAltName=DNS:ed.test"
+res=$("$WORK/tool" verify-csr "$WORK/ossl_ed.csr")
+if [[ "$res" == "VERIFY_OK" ]]; then
+    echo "    NURL parsed & verified OpenSSL Ed25519 CSR: OK"
+else
+    echo "    NURL failed to verify OpenSSL Ed25519 CSR: $res"
+    exit 1
+fi
+
+echo "=========================================="
+echo "  ALL CSR OPENSSL INTEROP TESTS PASSED!   "
+echo "=========================================="

--- a/compiler/tests/http_jwt.nu
+++ b/compiler/tests/http_jwt.nu
@@ -14,6 +14,7 @@ $ `stdlib/ext/http.nu`
 $ `stdlib/ext/http_request.nu`
 $ `stdlib/ext/http_response.nu`
 $ `stdlib/std/bytes.nu`
+$ `stdlib/std/ecdsa_p256.nu`
 $ `stdlib/ext/jwt.nu`
 $ `stdlib/ext/http_jwt.nu`
 
@@ -142,5 +143,30 @@ $ `stdlib/ext/http_jwt.nu`
         }
         F _ → ( nurl_print `keygen FAILED\n` )
     }
+
+    // ── ES256 ──
+    : !( Vec u ) ParseErr es_sr ( bytes_from_hex `c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721` )
+    : ( Vec u ) es_scalar ?? es_sr { T v → v F _ → ( vec_new [u] ) }
+    : ( Vec u ) es_pub ( p256_ecdh_keygen es_scalar )
+    : ( @ HttpResponse HttpRequest Json ) esleaf \ HttpRequest req Json claims → HttpResponse { ^ ( secure_handler req claims ) }
+    : ( @ HttpResponse HttpRequest ) esguarded ( with_jwt_es256 es_pub esleaf )
+    : Json esp ( json_obj_new )
+    ( json_obj_set esp `sub` ( json_str_lit `carol` ) )
+    : !String CryptoErr esso ( jwt_es256_sign es_scalar esp )
+    ( json_free esp )
+    ?? esso {
+        T estok → {
+            ( run `es256_valid` esguarded ( string_data estok ) )
+            ( string_free estok )
+        }
+        F _ → ( nurl_print `es256 sign FAILED\n` )
+    }
+    ( run `es256_missing` esguarded `` )
+    : *u esguarded_env # *u esguarded 1
+    ( nurl_free # s esguarded_env )
+    : *u esleaf_env # *u esleaf 1
+    ( nurl_free # s esleaf_env )
+    ( vec_free [u] es_scalar ) ( vec_free [u] es_pub )
+
     ^ 0
 }

--- a/compiler/tests/jwt_basic.nu
+++ b/compiler/tests/jwt_basic.nu
@@ -10,6 +10,7 @@
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
 $ `stdlib/ext/json.nu`
+$ `stdlib/std/ecdsa_p256.nu`
 $ `stdlib/ext/jwt.nu`
 
 @ hx s h → ( Vec u ) {
@@ -143,6 +144,33 @@ $ `stdlib/ext/jwt.nu`
     }
     ( vec_free [u] sk )
     ( json_free eclaims )
+
+    // ── ES256 (ECDSA P-256 + SHA-256) ──────────────────────────────────
+    : ( Vec u ) es_scalar ( hx `c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721` )
+    : ( Vec u ) es_pubkey ( p256_ecdh_keygen es_scalar )
+    : Json es_claims ( mk_claims )
+    : !String CryptoErr esso ( jwt_es256_sign es_scalar es_claims )
+    ?? esso {
+        T es_token → {
+            ( show_verify `es256_verify_ok: ` ( jwt_es256_verify_at es_pubkey ( string_data es_token ) 1516239022 ) )
+            // tamper the signature's last char
+            : i es_len ( string_len es_token )
+            : String es_bad ( string_with_cap + es_len 1 )
+            : ~ i idx 0
+            ~ < idx es_len {
+                : i c ( nurl_str_get ( string_data es_token ) idx )
+                ( string_push_char es_bad ? == idx - es_len 1 ? == c 97 98 97 c )
+                = idx + idx 1
+            }
+            ( show_verify `es256_verify_tampered: ` ( jwt_es256_verify_at es_pubkey ( string_data es_bad ) 1516239022 ) )
+            ( string_free es_bad )
+            ( string_free es_token )
+        }
+        F _ → ( nurl_print `es256 sign FAILED\n` )
+    }
+    ( vec_free [u] es_scalar )
+    ( vec_free [u] es_pubkey )
+    ( json_free es_claims )
 
     // ── decode_unverified ──────────────────────────────────────────
     : Json dc ( mk_claims )

--- a/compiler/tests/outputs-windows/jwt_basic.txt
+++ b/compiler/tests/outputs-windows/jwt_basic.txt
@@ -14,4 +14,6 @@ hs256_nbf_ok(now=1500): ok sub=nbf-test
 eddsa_token=eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.vLeihDpjKFbZGE86WqTj7w1eeRh6p8kiUw3oDfW6IS1i79tAeUdaK4vodykBqybCjAa5P9250Ts6w1a9knr9Ag
 eddsa_verify_ok: ok sub=1234567890
 eddsa_verify_tampered: err=BadSignature
+es256_verify_ok: ok sub=1234567890
+es256_verify_tampered: err=BadSignature
 decode_unverified_name=John Doe

--- a/compiler/tests/outputs/csr_basic.txt
+++ b/compiler/tests/outputs/csr_basic.txt
@@ -1,0 +1,12 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+── [csr] PKCS#10 CSR Tests ──
+[1/6] Generating and parsing ECDSA P-256 CSR... OK
+[2/6] Verifying ECDSA P-256 self-signature... OK
+[3/6] Generating and verifying Ed25519 CSR... OK
+[4/6] Testing PEM formatting round-trip... OK
+[5/6] Testing tamper rejection on CSR... OK
+[6/6] Issuing X.509 certificate from CSR... OK
+── ALL 6 CSR TESTS PASSED ──

--- a/compiler/tests/outputs/http_jwt.txt
+++ b/compiler/tests/outputs/http_jwt.txt
@@ -14,3 +14,6 @@ hs256_wrongkey: status=401 body=Unauthorized
 eddsa_valid: status=200 body=hello bob
 eddsa_missing: status=401 body=Unauthorized
  www-auth=Bearer
+es256_valid: status=200 body=hello carol
+es256_missing: status=401 body=Unauthorized
+ www-auth=Bearer

--- a/compiler/tests/outputs/jwt_basic.txt
+++ b/compiler/tests/outputs/jwt_basic.txt
@@ -14,4 +14,6 @@ hs256_nbf_ok(now=1500): ok sub=nbf-test
 eddsa_token=eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.vLeihDpjKFbZGE86WqTj7w1eeRh6p8kiUw3oDfW6IS1i79tAeUdaK4vodykBqybCjAa5P9250Ts6w1a9knr9Ag
 eddsa_verify_ok: ok sub=1234567890
 eddsa_verify_tampered: err=BadSignature
+es256_verify_ok: ok sub=1234567890
+es256_verify_tampered: err=BadSignature
 decode_unverified_name=John Doe

--- a/packages/pki-server/README.md
+++ b/packages/pki-server/README.md
@@ -159,6 +159,8 @@ Content-Type: application/json
 
 ---
 
+---
+
 ### 5. Request Operational Certificate
 
 Supports both `application/json` and `application/x-www-form-urlencoded`.
@@ -187,7 +189,35 @@ Content-Type: application/json
 
 ---
 
-### 6. Revoke Certificate
+### 6. Request Certificate from PKCS#10 CSR (Zero Trust)
+
+Enables Zero-Trust enrollment where the device generates its own private key locally and sends only the signed PKCS#10 Certificate Signing Request (CSR) across the network. The private key never leaves the client device.
+
+```http
+POST /request-csr
+Content-Type: application/json
+X-API-Key: your-management-key-here
+
+{
+  "csr": "-----BEGIN CERTIFICATE REQUEST-----\n...\n-----END CERTIFICATE REQUEST-----\n",
+  "validity_days": 365
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "status": "success",
+  "certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
+  "ca_certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
+  "serial": "3a8f12c9b4e10023",
+  "expires": "2027-08-18T20:00:00Z"
+}
+```
+
+---
+
+### 7. Revoke Certificate
 
 Requires Management API key in `X-API-Key` header, `Authorization: Bearer <key>`, or `?api_key=`.
 

--- a/packages/pki-server/nurl.toml
+++ b/packages/pki-server/nurl.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pki-server"
-version = "0.1.0"
+version = "0.2.0"
 description = "A pure-NURL Private PKI (Public Key Infrastructure) server and CA manager. Provides X.509 certificate authority operations, device initialization, certificate issuance, renewal, revocation, CRL generation, API key authentication, and responsive modern web UI — 100% pure NURL with zero external dependencies."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nurl-lang/nurl-lang"

--- a/packages/pki-server/src/pki.nu
+++ b/packages/pki-server/src/pki.nu
@@ -11,6 +11,7 @@ $ `stdlib/std/fs.nu`
 $ `stdlib/std/x509.nu`
 $ `stdlib/std/x509_gen.nu`
 $ `stdlib/std/pkey.nu`
+$ `stdlib/std/csr.nu`
 
 & `c` @ nurl_rand_fill *u buf i n → i
 
@@ -510,6 +511,44 @@ $ `stdlib/std/pkey.nu`
         serial_hex
         expires_iso
     }
+}
+
+// Issue an X.509 certificate from a verified PKCS#10 CSR.
+@ pki_issue_cert_from_csr * PkiCa ca s csr_pem i validity_days → !PkiCert String {
+    : !( Vec u ) ParseErr dr ( pem_to_der csr_pem )
+    : ( Vec u ) der ?? dr { T v → v F _ → ( vec_new [u] ) }
+    ? == ( vec_len [u] der ) 0 {
+        ^ @ !PkiCert String { F ( string_from `Malformed or invalid CSR PEM` ) }
+    } {}
+    : Csr csr ( csr_parse der )
+    ( vec_free [u] der )
+    ? ! . csr ok {
+        ( csr_free csr )
+        ^ @ !PkiCert String { F ( string_from `Invalid PKCS#10 CSR structure` ) }
+    } {}
+    : b valid ( csr_verify csr )
+    ? ! valid {
+        ( csr_free csr )
+        ^ @ !PkiCert String { F ( string_from `CSR self-signature verification failed` ) }
+    } {}
+
+    : ( Vec u ) serial ( _pki_rand_bytes 12 )
+    : String serial_hex ( _pki_bytes_to_hex serial )
+    : i now ( now_seconds )
+    : i not_after + now * validity_days 86400
+    : String expires_iso ( pki_iso_timestamp not_after )
+
+    : ( Vec u ) cert_der ( x509_issue_from_csr . ca scalar . ca pubkey ( string_data . ca cn ) csr serial validity_days F )
+    ( vec_free [u] serial )
+    ( csr_free csr )
+
+    : PkiCert out @ PkiCert {
+        ( _pki_pem `CERTIFICATE` cert_der )
+        ( string_new )
+        serial_hex
+        expires_iso
+    }
+    ^ @ !PkiCert String { T out }
 }
 
 // ── Verification & Inspection ─────────────────────────────────────────

--- a/packages/pki-server/src/service.nu
+++ b/packages/pki-server/src/service.nu
@@ -598,6 +598,79 @@ $ `ui.nu`
     }
 }
 
+// POST /request-csr — Issue certificate from a client-provided PKCS#10 CSR.
+// Client private key never crosses the wire (Zero Trust PKI).
+@ handle_request_csr_post HttpRequest req Params p → HttpResponse {
+    ? ! ( auth_check_api_key req g_management_key ) {
+        ^ ( _resp_err_json 401 `Unauthorized: valid management API key required` )
+    } {}
+
+    : String body_str ( bytes_to_str . req body )
+    : ~ String csr_input ( string_new )
+    : ~ i validity_days 365
+
+    : !Json JsonError jr ( json_parse ( string_data body_str ) )
+    ?? jr {
+        T root → {
+            : ?Json cj ( json_obj_get root `csr` )
+            ?? cj { T v → = csr_input ( string_from ( json_str_data v ) ) F _ → {} }
+            : ?Json vj ( json_obj_get root `validity_days` )
+            ?? vj {
+                T v → {
+                    : ?i vi ( json_num_as_i v )
+                    ?? vi {
+                        T val → { ? > val 0 { = validity_days val } {} }
+                        F _ → {}
+                    }
+                }
+                F _ → {}
+            }
+            ( json_free root )
+        }
+        F _ → {
+            // Check if raw PEM is sent in body
+            ? > ( nurl_str_find ( string_data body_str ) `-----BEGIN` ) -1 {
+                = csr_input ( string_clone body_str )
+            } {}
+        }
+    }
+    ( string_free body_str )
+
+    ? == ( string_len csr_input ) 0 {
+        ( string_free csr_input )
+        ^ ( _resp_err_json 400 `Missing CSR PEM in request body` )
+    } {}
+
+    ? != g_ca_handle 0 {
+        : *PkiCa ca # *PkiCa g_ca_handle
+        : !PkiCert String res ( pki_issue_cert_from_csr ca ( string_data csr_input ) validity_days )
+        ( string_free csr_input )
+        ?? res {
+            T cert → {
+                : Json out ( json_obj_new )
+                ( json_obj_set out `status` ( json_str_lit `success` ) )
+                ( json_obj_set out `certificate` ( json_str_lit ( string_data . cert cert_pem ) ) )
+                ( json_obj_set out `ca_certificate` ( json_str_lit ( string_data . ca cert_pem ) ) )
+                ( json_obj_set out `serial` ( json_str_lit ( string_data . cert serial_hex ) ) )
+                ( json_obj_set out `expires` ( json_str_lit ( string_data . cert expires_iso ) ) )
+
+                ( pki_cert_free cert )
+                : String jout ( json_stringify out )
+                ( json_free out )
+                ^ ( _resp_json 200 jout )
+            }
+            F err → {
+                : HttpResponse r ( _resp_err_json 400 ( string_data err ) )
+                ( string_free err )
+                ^ r
+            }
+        }
+    } {
+        ( string_free csr_input )
+        ^ ( _resp_err_json 500 `CA not initialized` )
+    }
+}
+
 // GET /revoke
 @ handle_revoke_get HttpRequest req Params p → HttpResponse {
     ^ ( _resp_html 200 ( ui_render_revoke_cert `` ) )
@@ -815,6 +888,7 @@ $ `ui.nu`
 
     ( http_app_get a `/request-cert` \ HttpRequest req Params p → HttpResponse { ^ ( handle_request_cert_get req p ) } )
     ( http_app_post a `/request-cert` \ HttpRequest req Params p → HttpResponse { ^ ( handle_request_cert_post req p ) } )
+    ( http_app_post a `/request-csr` \ HttpRequest req Params p → HttpResponse { ^ ( handle_request_csr_post req p ) } )
 
     ( http_app_get a `/revoke` \ HttpRequest req Params p → HttpResponse { ^ ( handle_revoke_get req p ) } )
     ( http_app_post a `/revoke` \ HttpRequest req Params p → HttpResponse { ^ ( handle_revoke_post req p ) } )

--- a/packages/pki-server/tests/pki_test.sh
+++ b/packages/pki-server/tests/pki_test.sh
@@ -197,6 +197,26 @@ if command -v openssl >/dev/null 2>&1; then
 
     openssl verify -CAfile "$TMPDIR/ca.crt" "$TMPDIR/dev200.crt" >/dev/null 2>&1 || { echo "FAIL: OpenSSL CA verification of issued cert failed"; exit 1; }
     echo "    OpenSSL CA verification: OK (valid signature & chain)"
+
+    # ── Test 10: POST /request-csr (Zero Trust PKCS#10 CSR) ───────────────
+    echo "--> Test 10: POST /request-csr (PKCS#10 CSR issuance)"
+    openssl ecparam -name prime256v1 -genkey -noout -out "$TMPDIR/client_device.key"
+    openssl req -new -key "$TMPDIR/client_device.key" -out "$TMPDIR/client_device.csr" -subj "/CN=edge-device-500.mesh.local" -addext "subjectAltName=DNS:edge-device-500.mesh.local"
+    
+    CSR_PEM=$(cat "$TMPDIR/client_device.csr")
+    ESCAPED_CSR=$(echo "$CSR_PEM" | awk '{printf "%s\\n", $0}')
+
+    CSR_RESP=$(curl -sf -X POST "http://127.0.0.1:$PORT/request-csr" \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: $MGMT_KEY" \
+        -d "{\"csr\":\"$ESCAPED_CSR\",\"validity_days\":365}")
+
+    echo "$CSR_RESP" | grep -q '"status":"success"' || { echo "FAIL: request-csr response not success"; exit 1; }
+    CSR_CERT=$(echo "$CSR_RESP" | sed -n 's/.*"certificate":"\([^"]*\)".*/\1/p' | sed 's/\\n/\n/g')
+    echo "$CSR_CERT" > "$TMPDIR/client_device.crt"
+
+    openssl verify -CAfile "$TMPDIR/ca.crt" "$TMPDIR/client_device.crt" >/dev/null 2>&1 || { echo "FAIL: OpenSSL CA verification of CSR-issued cert failed"; exit 1; }
+    echo "    OpenSSL CSR cert verification: OK (Zero Trust issuance verified)"
 fi
 
 echo "=================================================="

--- a/stdlib/ext/http_jwt.nu
+++ b/stdlib/ext/http_jwt.nu
@@ -112,3 +112,18 @@ $ `stdlib/ext/jwt.nu`
     }
     ^ wrapped
 }
+
+@ with_jwt_es256 ( Vec u ) pubkey ( @ HttpResponse HttpRequest Json ) inner → ( @ HttpResponse HttpRequest ) {
+    : ( @ HttpResponse HttpRequest ) wrapped \ HttpRequest req → HttpResponse {
+        : ?String tok ( parse_bearer_auth req )
+        ^ ?? tok {
+            T t → {
+                : !Json JwtErr vr ( jwt_es256_verify pubkey ( string_data t ) )
+                ( string_free t )
+                ^ ( __jwt_gate vr req inner )
+            }
+            F _ → ( __jwt_unauthorized `` `` )
+        }
+    }
+    ^ wrapped
+}

--- a/stdlib/ext/jwt.nu
+++ b/stdlib/ext/jwt.nu
@@ -18,6 +18,11 @@
 //   ( jwt_eddsa_verify    ( Vec u ) pk s token )          → !Json JwtErr
 //   ( jwt_eddsa_verify_at ( Vec u ) pk s token i now )    → !Json JwtErr
 //
+// ES256 (asymmetric — ECDSA P-256 with SHA-256, RFC 7518 §3.1):
+//   ( jwt_es256_sign      ( Vec u ) scalar Json claims )  → !String CryptoErr
+//   ( jwt_es256_verify    ( Vec u ) pubkey s token )      → !Json JwtErr
+//   ( jwt_es256_verify_at ( Vec u ) pubkey s token i now )→ !Json JwtErr
+//
 //   ( jwt_decode_unverified s token )                     → !Json JwtErr
 //       Decode the payload WITHOUT checking the signature or time
 //       claims. For reading `iss`/`sub`/`kid` to pick a key before
@@ -46,6 +51,7 @@ $ `stdlib/std/hash_sha256.nu`
 $ `stdlib/std/bytes.nu`
 $ `stdlib/std/subtle.nu`
 $ `stdlib/std/time.nu`
+$ `stdlib/std/ecdsa_p256.nu`
 $ `stdlib/ext/json.nu`
 $ `stdlib/ext/crypto.nu`
 
@@ -312,6 +318,80 @@ $ `stdlib/ext/crypto.nu`
 
 @ jwt_eddsa_verify ( Vec u ) pk s token → !Json JwtErr {
     ^ ( jwt_eddsa_verify_at pk token ( now_seconds ) )
+}
+
+// ── ES256 (ECDSA P-256 + SHA-256) ──────────────────────────────────
+
+@ jwt_es256_sign ( Vec u ) scalar Json claims → !String CryptoErr {
+    : i slen ( vec_len [u] scalar )
+    ? != slen 32 { ^ @ !String CryptoErr { F CryptoArg } } {}
+    : String signing ( __jwt_signing_input `{"alg":"ES256","typ":"JWT"}` claims )
+    : ( Vec u ) msg ( __jwt_bytes ( string_data signing ) )
+    : ( Vec u ) h ( sha256_pure msg )
+    ( vec_free [u] msg )
+    : ( Vec u ) sig ( ecdsa_p256_sign scalar h )
+    ( vec_free [u] h )
+    : String sig64 ( b64_url_encode_vec sig )
+    : String token ( string_with_cap + ( string_len signing ) + ( string_len sig64 ) 1 )
+    ( string_push_str token ( string_data signing ) )
+    ( string_push_char token 46 )
+    ( string_push_str token ( string_data sig64 ) )
+    ( vec_free [u] sig )
+    ( string_free sig64 )
+    ( string_free signing )
+    ^ @ !String CryptoErr { T token }
+}
+
+@ jwt_es256_verify_at ( Vec u ) pubkey s token i now → !Json JwtErr {
+    : s d0buf ( nurl_zalloc 8 )
+    : s d1buf ( nurl_zalloc 8 )
+    ? ( __jwt_split token d0buf d1buf ) {} {
+        ( nurl_free d0buf ) ( nurl_free d1buf )
+        ^ @ !Json JwtErr { F JwtMalformed }
+    }
+    : i d0 ( nurl_peek d0buf 0 )
+    : i d1 ( nurl_peek d1buf 0 )
+    ( nurl_free d0buf ) ( nurl_free d1buf )
+    : String signing ( __jwt_slice token 0 d1 )
+    : String sig64 ( __jwt_slice token + d1 1 ( nurl_str_len token ) )
+    : !( Vec u ) ParseErr sd ( b64_url_decode_vec ( string_data sig64 ) )
+    ( string_free sig64 )
+    : ~ b sig_ok F
+    ?? sd {
+        T sig → {
+            : i slen ( vec_len [u] sig )
+            ? == slen 64 {
+                : ( Vec u ) r ( bytes_slice sig 0 32 )
+                : ( Vec u ) s ( bytes_slice sig 32 64 )
+                : ( Vec u ) msg ( __jwt_bytes ( string_data signing ) )
+                : ( Vec u ) h ( sha256_pure msg )
+                ( vec_free [u] msg )
+                = sig_ok ( ecdsa_p256_verify pubkey r s h )
+                ( vec_free [u] r )
+                ( vec_free [u] s )
+                ( vec_free [u] h )
+            } {}
+            ( vec_free [u] sig )
+        }
+        F _ → {}
+    }
+    ( string_free signing )
+    ? sig_ok {} { ^ @ !Json JwtErr { F JwtBadSignature } }
+    : !Json JwtErr pj ( __jwt_payload_json token d0 d1 )
+    ?? pj {
+        T payload → {
+            : ?JwtErr terr ( __jwt_check_time payload now )
+            ?? terr {
+                T e → { ( json_free payload ) ^ @ !Json JwtErr { F e } }
+                F _ → { ^ @ !Json JwtErr { T payload } }
+            }
+        }
+        F e → { ^ @ !Json JwtErr { F e } }
+    }
+}
+
+@ jwt_es256_verify ( Vec u ) pubkey s token → !Json JwtErr {
+    ^ ( jwt_es256_verify_at pubkey token ( now_seconds ) )
 }
 
 // ── Unverified decode ──────────────────────────────────────────────

--- a/stdlib/std/csr.nu
+++ b/stdlib/std/csr.nu
@@ -1,0 +1,618 @@
+// stdlib/std/csr.nu — PKCS#10 / RFC 2986 Certificate Signing Request parser,
+// verifier, generator, and CA issuance. Pure NURL, zero OpenSSL dependency.
+//
+// API:
+//   ( csr_parse ( Vec u ) der )                → Csr
+//   ( csr_free Csr c )                         → v
+//   ( csr_verify Csr c )                       → b
+//   ( csr_generate_p256 s cn ( Vec String ) sans ( Vec u ) scalar ) → ( Vec u )
+//   ( csr_generate_ed25519 s cn ( Vec String ) sans ( Vec u ) sk ) → ( Vec u )
+//   ( csr_to_pem ( Vec u ) der )               → String
+//   ( csr_from_pem s pem )                     → !( Vec u ) ParseErr
+//   ( x509_issue_from_csr ( Vec u ) ca_scalar ( Vec u ) ca_pubkey
+//                         s ca_cn Csr csr ( Vec u ) serial
+//                         i validity_days b is_ca ) → ( Vec u )
+//
+// Key / signature algorithm codes (aligned with std/x509.nu):
+//   sig_alg: 4 ecdsa_sha256  7 ed25519  1 rsa_pkcs1_sha256  8..10 mldsa  0 unknown
+//   key_alg: 2 EC  3 Ed25519  1 RSA  4 ML-DSA  0 unknown
+
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/encode.nu`
+$ `stdlib/std/hash_sha256.nu`
+$ `stdlib/std/ecdsa_p256.nu`
+$ `stdlib/std/ed25519.nu`
+$ `stdlib/std/rsa.nu`
+$ `stdlib/std/mldsa.nu`
+$ `stdlib/std/time.nu`
+$ `stdlib/std/x509.nu`
+$ `stdlib/std/x509_gen.nu`
+$ `stdlib/std/pkey.nu`
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+: Csr {
+    ( Vec u ) req_info  // raw bytes of CertificationRequestInfo for self-sig check
+    i sig_alg  // signature algorithm code (4=ecdsa_sha256, 7=ed25519, 1=rsa_sha256)
+    ( Vec u ) sig  // signature value (64-byte r||s for ECDSA, 64-byte for Ed25519, raw for RSA)
+    i key_alg  // public key algorithm (2=EC, 3=Ed25519, 1=RSA, 4=ML-DSA)
+    ( Vec u ) pubkey  // raw public key (65-byte EC point, 32-byte Ed25519, RSA n, or ML-DSA pk)
+    ( Vec u ) rsa_e  // RSA public exponent (when RSA)
+    String cn  // Subject CommonName
+    String org  // Subject Organization
+    String country  // Subject Country
+    ( Vec String ) sans  // Requested Subject Alternative Names (dNSNames)
+    b is_ca  // requested basicConstraints CA flag
+    b ok  // parse success
+}
+
+@ csr_free Csr c → v {
+    ( vec_free [u] . c req_info )
+    ( vec_free [u] . c sig )
+    ( vec_free [u] . c pubkey )
+    ( vec_free [u] . c rsa_e )
+    ( string_free . c cn )
+    ( string_free . c org )
+    ( string_free . c country )
+    ( vec_free_with [String] . c sans \ String s → v { ( string_free s ) } )
+}
+
+@ __csr_empty → Csr {
+    ^ @ Csr {
+        ( vec_new [u] ) 0 ( vec_new [u] ) 0 ( vec_new [u] ) ( vec_new [u] )
+        ( string_new ) ( string_new ) ( string_new ) ( vec_new [String] ) F F
+    }
+}
+
+: __CsrNames { String cn String org String country }
+
+@ __csr_names_free __CsrNames n → v {
+    ( string_free . n cn )
+    ( string_free . n org )
+    ( string_free . n country )
+}
+
+// ── Parsing ───────────────────────────────────────────────────────────
+
+// Convert ECDSA DER signature SEQ{ INTEGER r, INTEGER s } to raw 64-byte r||s.
+@ __csr_sig_der_to_rs ( Vec u ) sig_der → ( Vec u ) {
+    : ( Vec u ) out ( vec_with_cap [u] 64 )
+    : i n ( vec_len [u] sig_der )
+    ? < n 8 { ( vec_free [u] sig_der ) ^ out } {}
+    : DerTlv seq ( der_at sig_der 0 )
+    ? | != . seq ok 1 != . seq tag 48 { ( vec_free [u] sig_der ) ^ out } {}
+    : DerTlv r_elem ( _der_child sig_der seq )
+    ? | != . r_elem ok 1 != . r_elem tag 2 { ( vec_free [u] sig_der ) ^ out } {}
+    : DerTlv s_elem ( _der_next sig_der r_elem )
+    ? | != . s_elem ok 1 != . s_elem tag 2 { ( vec_free [u] sig_der ) ^ out } {}
+
+    : ( Vec u ) r_bytes ( _der_uint sig_der r_elem )
+    : ( Vec u ) s_bytes ( _der_uint sig_der s_elem )
+    ( vec_free [u] sig_der )
+
+    : i rlen ( vec_len [u] r_bytes )
+    : i slen ( vec_len [u] s_bytes )
+    ? | > rlen 32 > slen 32 {
+        ( vec_free [u] r_bytes ) ( vec_free [u] s_bytes )
+        ^ out
+    } {}
+
+    // Pad r to 32 bytes
+    : ~ i pad_r - 32 rlen
+    ~ > pad_r 0 { ( vec_push [u] out # u 0 ) = pad_r - pad_r 1 }
+    : ~ i kr 0
+    ~ < kr rlen {
+        ( vec_push [u] out ?? ( vec_get [u] r_bytes kr ) { T x → x F _ → # u 0 } )
+        = kr + kr 1
+    }
+    ( vec_free [u] r_bytes )
+
+    // Pad s to 32 bytes
+    : ~ i pad_s - 32 slen
+    ~ > pad_s 0 { ( vec_push [u] out # u 0 ) = pad_s - pad_s 1 }
+    : ~ i ks 0
+    ~ < ks slen {
+        ( vec_push [u] out ?? ( vec_get [u] s_bytes ks ) { T x → x F _ → # u 0 } )
+        = ks + ks 1
+    }
+    ( vec_free [u] s_bytes )
+
+    ^ out
+}
+
+// Extract Name attributes (CN, O, C) from subject RDNSequence.
+@ __csr_parse_name ( Vec u ) b DerTlv name_seq → __CsrNames {
+    : ~ String cn ( string_new )
+    : ~ String org ( string_new )
+    : ~ String country ( string_new )
+    : ~ DerTlv rdn ( _der_child b name_seq )
+    ~ == . rdn ok 1 {
+        ? == . rdn tag 49 {  // SET
+            : ~ DerTlv atv ( _der_child b rdn )
+            ~ == . atv ok 1 {
+                ? == . atv tag 48 {  // SEQUENCE
+                    : DerTlv oid ( _der_child b atv )
+                    : DerTlv val ( _der_next b oid )
+                    ? & == . oid ok 1 == . val ok 1 {
+                        // 2.5.4.3 commonName (0x550403)
+                        ? ( _der_oid_is b oid `550403` ) {
+                            : ( Vec u ) vb ( _der_content b val )
+                            ( string_free cn )
+                            = cn ( bytes_to_str vb )
+                            ( vec_free [u] vb )
+                        } {}
+                        // 2.5.4.10 organizationName (0x55040a)
+                        ? ( _der_oid_is b oid `55040a` ) {
+                            : ( Vec u ) vb ( _der_content b val )
+                            ( string_free org )
+                            = org ( bytes_to_str vb )
+                            ( vec_free [u] vb )
+                        } {}
+                        // 2.5.4.6 countryName (0x550406)
+                        ? ( _der_oid_is b oid `550406` ) {
+                            : ( Vec u ) vb ( _der_content b val )
+                            ( string_free country )
+                            = country ( bytes_to_str vb )
+                            ( vec_free [u] vb )
+                        } {}
+                    } {}
+                } {}
+                = atv ( _der_next b atv )
+            }
+        } {}
+        = rdn ( _der_next b rdn )
+    }
+    ^ @ __CsrNames { cn org country }
+}
+
+// Parse attributes [0] for extensionRequest (1.2.840.113549.1.9.14 = 0x2a864886f70d01090e).
+@ __csr_parse_attributes ( Vec u ) b DerTlv attrs ( Vec String ) sans b inout_is_ca → b {
+    : ~ DerTlv attr ( _der_child b attrs )
+    : ~ b found_ca F
+    ~ == . attr ok 1 {
+        ? == . attr tag 48 {  // SEQUENCE
+            : DerTlv oid ( _der_child b attr )
+            ? & == . oid ok 1 ( _der_oid_is b oid `2a864886f70d01090e` ) {
+                // extensionRequest: values is SET OF SEQUENCE OF Extension
+                : DerTlv vals_set ( _der_next b oid )
+                ? & == . vals_set ok 1 == . vals_set tag 49 {
+                    : DerTlv exts_seq ( _der_child b vals_set )
+                    ? & == . exts_seq ok 1 == . exts_seq tag 48 {
+                        : ~ DerTlv ext ( _der_child b exts_seq )
+                        ~ == . ext ok 1 {
+                            ? == . ext tag 48 {
+                                : DerTlv ext_oid ( _der_child b ext )
+                                : ~ DerTlv ext_val ( _der_next b ext_oid )
+                                // If critical flag BOOLEAN is present, skip to OCTET STRING
+                                ? & == . ext_val ok 1 == . ext_val tag 1 {
+                                    = ext_val ( _der_next b ext_val )
+                                } {}
+                                ? & == . ext_val ok 1 == . ext_val tag 4 {  // OCTET STRING
+                                    : ( Vec u ) oct ( _der_content b ext_val )
+                                    // 2.5.29.17 subjectAltName (0x551d11)
+                                    ? ( _der_oid_is b ext_oid `551d11` ) {
+                                        : DerTlv san_seq ( der_at oct 0 )
+                                        ? & == . san_seq ok 1 == . san_seq tag 48 {
+                                            : ~ DerTlv gn ( _der_child oct san_seq )
+                                            ~ == . gn ok 1 {
+                                                // Context [2] = dNSName
+                                                ? == . gn tag 130 {
+                                                    : ( Vec u ) name_bytes ( _der_content oct gn )
+                                                    ( vec_push [String] sans ( bytes_to_str name_bytes ) )
+                                                    ( vec_free [u] name_bytes )
+                                                } {}
+                                                = gn ( _der_next oct gn )
+                                            }
+                                        } {}
+                                    } {}
+                                    // 2.5.29.19 basicConstraints (0x551d13)
+                                    ? ( _der_oid_is b ext_oid `551d13` ) {
+                                        : DerTlv bc_seq ( der_at oct 0 )
+                                        ? & == . bc_seq ok 1 == . bc_seq tag 48 {
+                                            : DerTlv ca_bool ( _der_child oct bc_seq )
+                                            ? & == . ca_bool ok 1 == . ca_bool tag 1 {
+                                                : ( Vec u ) cb ( _der_content oct ca_bool )
+                                                ? & > ( vec_len [u] cb ) 0 != ?? ( vec_get [u] cb 0 ) { T x → # i x F _ → 0 } 0 {
+                                                    = found_ca T
+                                                } {}
+                                                ( vec_free [u] cb )
+                                            } {}
+                                        } {}
+                                    } {}
+                                    ( vec_free [u] oct )
+                                } {}
+                            } {}
+                            = ext ( _der_next b ext )
+                        }
+                    } {}
+                } {}
+            } {}
+        } {}
+        = attr ( _der_next b attr )
+    }
+    ^ found_ca
+}
+
+// Parse a DER-encoded PKCS#10 Certificate Signing Request.
+@ csr_parse ( Vec u ) der → Csr {
+    : i n ( vec_len [u] der )
+    ? < n 16 { ^ ( __csr_empty ) } {}
+
+    : DerTlv root ( der_at der 0 )
+    ? | != . root ok 1 != . root tag 48 { ^ ( __csr_empty ) } {}
+
+    // 1. CertificationRequestInfo
+    : DerTlv cri ( _der_child der root )
+    ? | != . cri ok 1 != . cri tag 48 { ^ ( __csr_empty ) } {}
+
+    // Exact raw bytes of CertificationRequestInfo (including tag and length header)
+    : ( Vec u ) req_info ( bytes_slice der - . cri start . cri hdr + . cri start . cri len )
+
+    // Version INTEGER (v1 = 0)
+    : DerTlv ver ( _der_child der cri )
+    ? | != . ver ok 1 != . ver tag 2 {
+        ( vec_free [u] req_info )
+        ^ ( __csr_empty )
+    } {}
+
+    // Subject Name
+    : DerTlv subj ( _der_next der ver )
+    ? | != . subj ok 1 != . subj tag 48 {
+        ( vec_free [u] req_info )
+        ^ ( __csr_empty )
+    } {}
+
+    : __CsrNames names ( __csr_parse_name der subj )
+
+    // SubjectPublicKeyInfo
+    : DerTlv spki ( _der_next der subj )
+    ? | != . spki ok 1 != . spki tag 48 {
+        ( vec_free [u] req_info )
+        ( __csr_names_free names )
+        ^ ( __csr_empty )
+    } {}
+
+    : DerTlv spki_alg ( _der_child der spki )
+    : DerTlv spki_bs ( _der_next der spki_alg )
+    ? | != . spki_alg ok 1 != . spki_bs ok 1 {
+        ( vec_free [u] req_info )
+        ( __csr_names_free names )
+        ^ ( __csr_empty )
+    } {}
+
+    : DerTlv key_oid ( _der_child der spki_alg )
+    : ~ i key_alg 0
+    : ~ ( Vec u ) pubkey ( vec_new [u] )
+    : ~ ( Vec u ) rsa_e ( vec_new [u] )
+
+    // EC: 1.2.840.10045.2.1 (0x2a8648ce3d0201)
+    ? ( _der_oid_is der key_oid `2a8648ce3d0201` ) {
+        = key_alg 2
+        : ( Vec u ) full_bs ( _der_content der spki_bs )
+        ? > ( vec_len [u] full_bs ) 1 {
+            ( vec_free [u] pubkey )
+            = pubkey ( bytes_slice full_bs 1 ( vec_len [u] full_bs ) )
+        } {}
+        ( vec_free [u] full_bs )
+    } {}
+
+    // Ed25519: 1.3.101.112 (0x2b6570)
+    ? ( _der_oid_is der key_oid `2b6570` ) {
+        = key_alg 3
+        : ( Vec u ) full_bs ( _der_content der spki_bs )
+        ? > ( vec_len [u] full_bs ) 1 {
+            ( vec_free [u] pubkey )
+            = pubkey ( bytes_slice full_bs 1 ( vec_len [u] full_bs ) )
+        } {}
+        ( vec_free [u] full_bs )
+    } {}
+
+    // RSA: 1.2.840.113549.1.1.1 (0x2a864886f70d010101)
+    ? ( _der_oid_is der key_oid `2a864886f70d010101` ) {
+        = key_alg 1
+        : ( Vec u ) full_bs ( _der_content der spki_bs )
+        ? > ( vec_len [u] full_bs ) 1 {
+            : ( Vec u ) rsa_seq_bytes ( bytes_slice full_bs 1 ( vec_len [u] full_bs ) )
+            : DerTlv rsa_seq ( der_at rsa_seq_bytes 0 )
+            ? & == . rsa_seq ok 1 == . rsa_seq tag 48 {
+                : DerTlv n_elem ( _der_child rsa_seq_bytes rsa_seq )
+                : DerTlv e_elem ( _der_next rsa_seq_bytes n_elem )
+                ? & == . n_elem ok 1 == . e_elem ok 1 {
+                    ( vec_free [u] pubkey )
+                    = pubkey ( _der_uint rsa_seq_bytes n_elem )
+                    ( vec_free [u] rsa_e )
+                    = rsa_e ( _der_uint rsa_seq_bytes e_elem )
+                } {}
+            } {}
+            ( vec_free [u] rsa_seq_bytes )
+        } {}
+        ( vec_free [u] full_bs )
+    } {}
+
+    // ML-DSA: 2.16.840.1.101.3.4.3.{17,18,19}
+    ? | | ( _der_oid_is der key_oid `608648016503040311` ) ( _der_oid_is der key_oid `608648016503040312` ) ( _der_oid_is der key_oid `608648016503040313` ) {
+        = key_alg 4
+        : ( Vec u ) full_bs ( _der_content der spki_bs )
+        ? > ( vec_len [u] full_bs ) 1 {
+            ( vec_free [u] pubkey )
+            = pubkey ( bytes_slice full_bs 1 ( vec_len [u] full_bs ) )
+        } {}
+        ( vec_free [u] full_bs )
+    } {}
+
+    // Attributes [0] (optional)
+    : ( Vec String ) sans ( vec_new [String] )
+    : ~ b is_ca F
+    : DerTlv attrs ( _der_next der spki )
+    ? & == . attrs ok 1 == . attrs tag 160 {  // context [0]
+        = is_ca ( __csr_parse_attributes der attrs sans is_ca )
+    } {}
+
+    // 2. signatureAlgorithm
+    : DerTlv sig_alg_elem ( _der_next der cri )
+    ? | != . sig_alg_elem ok 1 != . sig_alg_elem tag 48 {
+        ( vec_free [u] req_info ) ( vec_free [u] pubkey ) ( vec_free [u] rsa_e )
+        ( __csr_names_free names )
+        ( vec_free_with [String] sans \ String s → v { ( string_free s ) } )
+        ^ ( __csr_empty )
+    } {}
+
+    : DerTlv sig_oid ( _der_child der sig_alg_elem )
+    : ~ i sig_alg 0
+    ? ( _der_oid_is der sig_oid `2a8648ce3d040302` ) { = sig_alg 4 } {}  // ecdsa-with-SHA256
+    ? ( _der_oid_is der sig_oid `2a8648ce3d040303` ) { = sig_alg 5 } {}  // ecdsa-with-SHA384
+    ? ( _der_oid_is der sig_oid `2b6570` ) { = sig_alg 7 } {}  // ed25519
+    ? ( _der_oid_is der sig_oid `2a864886f70d01010b` ) { = sig_alg 1 } {}  // sha256WithRSAEncryption
+    ? ( _der_oid_is der sig_oid `608648016503040311` ) { = sig_alg 8 } {}  // id-ml-dsa-44
+    ? ( _der_oid_is der sig_oid `608648016503040312` ) { = sig_alg 9 } {}  // id-ml-dsa-65
+    ? ( _der_oid_is der sig_oid `608648016503040313` ) { = sig_alg 10 } {}  // id-ml-dsa-87
+
+    // 3. Signature BIT STRING
+    : DerTlv sig_elem ( _der_next der sig_alg_elem )
+    ? | != . sig_elem ok 1 != . sig_elem tag 3 {
+        ( vec_free [u] req_info ) ( vec_free [u] pubkey ) ( vec_free [u] rsa_e )
+        ( __csr_names_free names )
+        ( vec_free_with [String] sans \ String s → v { ( string_free s ) } )
+        ^ ( __csr_empty )
+    } {}
+
+    : ( Vec u ) raw_sig_bs ( _der_content der sig_elem )
+    : ~ ( Vec u ) sig ( vec_new [u] )
+    ? > ( vec_len [u] raw_sig_bs ) 1 {
+        : ( Vec u ) inner_sig ( bytes_slice raw_sig_bs 1 ( vec_len [u] raw_sig_bs ) )
+        ? | == sig_alg 4 == sig_alg 5 {
+            // Convert DER sequence to 64-byte r||s
+            = sig ( __csr_sig_der_to_rs inner_sig )
+        } {
+            = sig inner_sig
+        }
+    } {}
+    ( vec_free [u] raw_sig_bs )
+
+    : String cn . names cn
+    : String org . names org
+    : String country . names country
+
+    ^ @ Csr {
+        req_info
+        sig_alg
+        sig
+        key_alg
+        pubkey
+        rsa_e
+        cn
+        org
+        country
+        sans
+        is_ca
+        T
+    }
+}
+
+// ── Self-Signature Verification ───────────────────────────────────────
+
+@ csr_verify Csr c → b {
+    ? ! . c ok { ^ F } {}
+    : i slen ( vec_len [u] . c sig )
+    : i rlen ( vec_len [u] . c req_info )
+    ? | == slen 0 == rlen 0 { ^ F } {}
+
+    // ECDSA P-256 with SHA-256
+    ? & == . c sig_alg 4 == . c key_alg 2 {
+        ? != slen 64 { ^ F } {}
+        : ( Vec u ) h ( sha256_pure . c req_info )
+        : ( Vec u ) r ( bytes_slice . c sig 0 32 )
+        : ( Vec u ) s ( bytes_slice . c sig 32 64 )
+        : b v ( ecdsa_p256_verify . c pubkey r s h )
+        ( vec_free [u] r )
+        ( vec_free [u] s )
+        ( vec_free [u] h )
+        ^ v
+    } {}
+
+    // Ed25519
+    ? & == . c sig_alg 7 == . c key_alg 3 {
+        ? != slen 64 { ^ F } {}
+        ^ ( ed25519_verify_pure . c pubkey . c req_info . c sig )
+    } {}
+
+    // RSA PKCS#1 v1.5 with SHA-256
+    ? & == . c sig_alg 1 == . c key_alg 1 {
+        : ( Vec u ) h ( sha256_pure . c req_info )
+        : b ok ( rsa_pkcs1_verify_sha256 . c pubkey . c rsa_e . c sig h )
+        ( vec_free [u] h )
+        ^ ok
+    } {}
+
+    // ML-DSA
+    ? & >= . c sig_alg 8 <= . c sig_alg 10 {
+        : i param ? == . c sig_alg 8 44 ? == . c sig_alg 9 65 87
+        : ( Vec u ) ctx ( vec_new [u] )
+        : b ok ( mldsa_verify param . c pubkey . c req_info ctx . c sig )
+        ( vec_free [u] ctx )
+        ^ ok
+    } {}
+
+    ^ F
+}
+
+// ── Generation ────────────────────────────────────────────────────────
+
+@ __csr_encode_extensions ( Vec String ) sans → ( Vec u ) {
+    : ( Vec u ) exts_all ( vec_new [u] )
+    : i ns ( vec_len [String] sans )
+    ? > ns 0 {
+        : ( Vec u ) dns_seq_body ( vec_new [u] )
+        : ~ i k 0
+        ~ < k ns {
+            : ?String so ( vec_get [String] sans k )
+            ?? so {
+                T s_name → {
+                    : ( Vec u ) gn ( _xg_tlv 130 ( bytes_from_str ( string_data s_name ) ) )  // [2] IMPLICIT
+                    ( bytes_extend_bytes dns_seq_body gn )
+                    ( vec_free [u] gn )
+                }
+                F _ → {}
+            }
+            = k + k 1
+        }
+        : ( Vec u ) dns_seq ( _xg_tlv 48 dns_seq_body )
+        : ( Vec u ) san_oct ( _xg_tlv 4 dns_seq )
+        : ~ ( Vec u ) san ( _xg_oid `551d11` )  // 2.5.29.17 subjectAltName
+        ( bytes_extend_bytes san san_oct ) ( vec_free [u] san_oct )
+        : ( Vec u ) san_seq ( _xg_tlv 48 san )
+        ( bytes_extend_bytes exts_all san_seq ) ( vec_free [u] san_seq )
+    } {}
+
+    : ( Vec u ) exts_seq ( _xg_tlv 48 exts_all )
+    : ( Vec u ) ext_req_set ( _xg_tlv 49 exts_seq )
+    : ~ ( Vec u ) attr_body ( _xg_oid `2a864886f70d01090e` )  // 1.2.840.113549.1.9.14 extensionRequest
+    ( bytes_extend_bytes attr_body ext_req_set ) ( vec_free [u] ext_req_set )
+    : ( Vec u ) attr_seq ( _xg_tlv 48 attr_body )
+
+    // [0] IMPLICIT Attributes (SET OF Attribute with tag 0xA0)
+    ^ ( _xg_tlv 160 attr_seq )
+}
+
+// Generate a DER-encoded PKCS#10 CSR signed with ECDSA P-256.
+@ csr_generate_p256 s cn ( Vec String ) sans ( Vec u ) p256_scalar → ( Vec u ) {
+    : ( Vec u ) pubkey ( p256_ecdh_keygen p256_scalar )
+
+    // CertificationRequestInfo
+    : ~ ( Vec u ) cri_body ( _xg_int1 0 )  // version v1 = 0
+    : ( Vec u ) subject ( _xg_name cn )
+    ( bytes_extend_bytes cri_body subject ) ( vec_free [u] subject )
+    : ( Vec u ) spki ( _xg_spki pubkey )
+    ( bytes_extend_bytes cri_body spki ) ( vec_free [u] spki )
+    : ( Vec u ) attrs ( __csr_encode_extensions sans )
+    ( bytes_extend_bytes cri_body attrs ) ( vec_free [u] attrs )
+    : ( Vec u ) cri ( _xg_tlv 48 cri_body )
+
+    // Sign SHA-256(CertificationRequestInfo)
+    : ( Vec u ) h ( sha256_pure cri )
+    : ( Vec u ) rs ( ecdsa_p256_sign p256_scalar h )
+    ( vec_free [u] h )
+    : ( Vec u ) sig_der ( _xg_sig_der rs )
+
+    // Outer CertificationRequest
+    : ~ ( Vec u ) csr_body cri
+    : ( Vec u ) alg ( _xg_alg_ecdsa_sha256 )
+    ( bytes_extend_bytes csr_body alg ) ( vec_free [u] alg )
+    : ( Vec u ) sig_bs ( _xg_bitstring sig_der )
+    ( bytes_extend_bytes csr_body sig_bs ) ( vec_free [u] sig_bs )
+    ^ ( _xg_tlv 48 csr_body )
+}
+
+// Generate a DER-encoded PKCS#10 CSR signed with Ed25519.
+@ csr_generate_ed25519 s cn ( Vec String ) sans ( Vec u ) ed25519_sk → ( Vec u ) {
+    : ( Vec u ) pubkey ( ed25519_pubkey_pure ed25519_sk )
+
+    // SPKI for Ed25519 = SEQ{ SEQ{ OID 1.3.101.112 }, BIT STRING pubkey }
+    : ~ ( Vec u ) alg_body ( _xg_oid `2b6570` )
+    : ( Vec u ) alg_seq ( _xg_tlv 48 alg_body )
+    : ( Vec u ) bs ( _xg_bitstring ( bytes_slice pubkey 0 ( vec_len [u] pubkey ) ) )
+    : ~ ( Vec u ) spki_body alg_seq
+    ( bytes_extend_bytes spki_body bs ) ( vec_free [u] bs )
+    : ( Vec u ) spki ( _xg_tlv 48 spki_body )
+
+    // CertificationRequestInfo
+    : ~ ( Vec u ) cri_body ( _xg_int1 0 )  // version v1 = 0
+    : ( Vec u ) subject ( _xg_name cn )
+    ( bytes_extend_bytes cri_body subject ) ( vec_free [u] subject )
+    ( bytes_extend_bytes cri_body spki ) ( vec_free [u] spki )
+    : ( Vec u ) attrs ( __csr_encode_extensions sans )
+    ( bytes_extend_bytes cri_body attrs ) ( vec_free [u] attrs )
+    : ( Vec u ) cri ( _xg_tlv 48 cri_body )
+
+    // Sign CertificationRequestInfo directly with Ed25519
+    : ( Vec u ) sig ( ed25519_sign_pure ed25519_sk cri )
+
+    // Outer CertificationRequest
+    : ~ ( Vec u ) csr_body cri
+    : ( Vec u ) sig_alg ( _xg_tlv 48 ( _xg_oid `2b6570` ) )
+    ( bytes_extend_bytes csr_body sig_alg ) ( vec_free [u] sig_alg )
+    : ( Vec u ) sig_bs ( _xg_bitstring sig )
+    ( bytes_extend_bytes csr_body sig_bs ) ( vec_free [u] sig_bs )
+    ( vec_free [u] pubkey )
+    ^ ( _xg_tlv 48 csr_body )
+}
+
+// ── PEM Formatting ────────────────────────────────────────────────────
+
+@ csr_to_pem ( Vec u ) der → String {
+    ^ ( _xg_pem `CERTIFICATE REQUEST` der )
+}
+
+@ csr_from_pem s pem → !( Vec u ) ParseErr {
+    ^ ( pem_to_der pem )
+}
+
+// ── CA Issuance from CSR ──────────────────────────────────────────────
+
+// Issue a signed X.509 v3 certificate from a verified CSR.
+@ x509_issue_from_csr ( Vec u ) ca_scalar ( Vec u ) ca_pubkey s ca_cn Csr csr ( Vec u ) serial i validity_days b is_ca → ( Vec u ) {
+    : i now ( now_seconds )
+    : i not_before - now 86400
+    : i not_after + now * validity_days 86400
+
+    // TBSCertificate
+    : ~ ( Vec u ) tbs_body ( _xg_tlv 160 ( _xg_int1 2 ) )  // v3
+    : ( Vec u ) ser ( _xg_int ( bytes_slice serial 0 ( vec_len [u] serial ) ) )
+    ( bytes_extend_bytes tbs_body ser ) ( vec_free [u] ser )
+    : ( Vec u ) alg1 ( _xg_alg_ecdsa_sha256 )
+    ( bytes_extend_bytes tbs_body alg1 ) ( vec_free [u] alg1 )
+    : ( Vec u ) issuer ( _xg_name ca_cn )
+    ( bytes_extend_bytes tbs_body issuer ) ( vec_free [u] issuer )
+    : ~ ( Vec u ) val ( _xg_utctime not_before )
+    : ( Vec u ) na ( _xg_utctime not_after )
+    ( bytes_extend_bytes val na ) ( vec_free [u] na )
+    : ( Vec u ) val_seq ( _xg_tlv 48 val )
+    ( bytes_extend_bytes tbs_body val_seq ) ( vec_free [u] val_seq )
+    : ( Vec u ) subject ( _xg_name ( string_data . csr cn ) )
+    ( bytes_extend_bytes tbs_body subject ) ( vec_free [u] subject )
+
+    // SPKI from CSR
+    : ( Vec u ) spki ( _xg_spki ( bytes_slice . csr pubkey 0 ( vec_len [u] . csr pubkey ) ) )
+    ( bytes_extend_bytes tbs_body spki ) ( vec_free [u] spki )
+
+    // Extensions
+    : ( Vec u ) exts ( _xg_extensions ( string_data . csr cn ) )
+    ( bytes_extend_bytes tbs_body exts ) ( vec_free [u] exts )
+    : ( Vec u ) tbs ( _xg_tlv 48 tbs_body )
+
+    // Sign SHA-256(TBS) with CA private key scalar
+    : ( Vec u ) h ( sha256_pure tbs )
+    : ( Vec u ) rs ( ecdsa_p256_sign ca_scalar h )
+    ( vec_free [u] h )
+    : ( Vec u ) sig_der ( _xg_sig_der rs )
+
+    // Outer Certificate
+    : ~ ( Vec u ) cert_body tbs
+    : ( Vec u ) alg2 ( _xg_alg_ecdsa_sha256 )
+    ( bytes_extend_bytes cert_body alg2 ) ( vec_free [u] alg2 )
+    : ( Vec u ) sig_bs ( _xg_bitstring sig_der )
+    ( bytes_extend_bytes cert_body sig_bs ) ( vec_free [u] sig_bs )
+    ^ ( _xg_tlv 48 cert_body )
+}

--- a/stdlib/std/x509.nu
+++ b/stdlib/std/x509.nu
@@ -80,7 +80,7 @@ $ `stdlib/std/bytes.nu`
 }
 
 // Compare an OID element's content bytes to a hex literal.
-@ __der_oid_is ( Vec u ) b DerTlv t s hexoid → b {
+@ _der_oid_is ( Vec u ) b DerTlv t s hexoid → b {
     : ( Vec u ) want ?? ( bytes_from_hex hexoid ) { T v → v F _ → ( vec_new [u] ) }
     : i wl ( vec_len [u] want )
     ? != . t len wl { ( vec_free [u] want ) ^ F } {}
@@ -132,19 +132,26 @@ $ `stdlib/std/bytes.nu`
 // Map an AlgorithmIdentifier SEQ (at `alg`) to a sig_alg code.
 @ __x509_sigalg ( Vec u ) b DerTlv alg → i {
     : DerTlv oid ( _der_child b alg )
-    ? ( __der_oid_is b oid `2a864886f70d01010b` ) { ^ 1 } {}
-    ? ( __der_oid_is b oid `2a864886f70d01010c` ) { ^ 2 } {}
-    ? ( __der_oid_is b oid `2a864886f70d01010d` ) { ^ 3 } {}
-    ? ( __der_oid_is b oid `2a8648ce3d040302` ) { ^ 4 } {}
-    ? ( __der_oid_is b oid `2a8648ce3d040303` ) { ^ 5 } {}
-    ? ( __der_oid_is b oid `2a864886f70d01010a` ) { ^ 6 } {}
-    ? ( __der_oid_is b oid `2b6570` ) { ^ 7 } {}
+    ? ( _der_oid_is b oid `2a864886f70d01010b` ) { ^ 1 } {}
+    ? ( _der_oid_is b oid `2a864886f70d01010c` ) { ^ 2 } {}
+    ? ( _der_oid_is b oid `2a864886f70d01010d` ) { ^ 3 } {}
+    ? ( _der_oid_is b oid `2a8648ce3d040302` ) { ^ 4 } {}
+    ? ( _der_oid_is b oid `2a8648ce3d040303` ) { ^ 5 } {}
+    ? ( _der_oid_is b oid `2a864886f70d01010a` ) { ^ 6 } {}
+    ? ( _der_oid_is b oid `2b6570` ) { ^ 7 } {}
     // ML-DSA (FIPS 204): 2.16.840.1.101.3.4.3.{17,18,19}. The same OID
     // names the key type and the signature algorithm — there is no
     // separate hash to name, because ML-DSA hashes internally.
-    ? ( __der_oid_is b oid `608648016503040311` ) { ^ 8 } {}
-    ? ( __der_oid_is b oid `608648016503040312` ) { ^ 9 } {}
-    ? ( __der_oid_is b oid `608648016503040313` ) { ^ 10 } {}
+    ? ( _der_oid_is b oid `608648016503040311` ) { ^ 8 } {}
+    ? ( _der_oid_is b oid `608648016503040312` ) { ^ 9 } {}
+    ? ( _der_oid_is b oid `608648016503040313` ) { ^ 10 } {}
+    // SLH-DSA (FIPS 205): 2.16.840.1.101.3.4.3.{21,23,25,27,29,31} (SHAKE family)
+    ? ( _der_oid_is b oid `608648016503040315` ) { ^ 11 } {}  // slh-dsa-shake-128s
+    ? ( _der_oid_is b oid `608648016503040317` ) { ^ 12 } {}  // slh-dsa-shake-128f
+    ? ( _der_oid_is b oid `608648016503040319` ) { ^ 13 } {}  // slh-dsa-shake-192s
+    ? ( _der_oid_is b oid `60864801650304031b` ) { ^ 14 } {}  // slh-dsa-shake-192f
+    ? ( _der_oid_is b oid `60864801650304031d` ) { ^ 15 } {}  // slh-dsa-shake-256s
+    ? ( _der_oid_is b oid `60864801650304031f` ) { ^ 16 } {}  // slh-dsa-shake-256f
     ^ 0
 }
 
@@ -242,10 +249,10 @@ $ `stdlib/std/bytes.nu`
     : ~ DerTlv ext ( _der_child b seq )
     ~ == . ext ok 1 {
         : DerTlv oid ( _der_child b ext )
-        : b is_san ( __der_oid_is b oid `551d11` )
-        : b is_bc ( __der_oid_is b oid `551d13` )
-        : b is_ku ( __der_oid_is b oid `551d0f` )
-        : b is_eku ( __der_oid_is b oid `551d25` )
+        : b is_san ( _der_oid_is b oid `551d11` )
+        : b is_bc ( _der_oid_is b oid `551d13` )
+        : b is_ku ( _der_oid_is b oid `551d0f` )
+        : b is_eku ( _der_oid_is b oid `551d25` )
         ? | | | is_san is_bc is_ku is_eku {
             // value is the last child (OCTET STRING), after optional critical BOOLEAN
             : ~ DerTlv nxt ( _der_next b oid )
@@ -282,8 +289,8 @@ $ `stdlib/std/bytes.nu`
                 : ~ DerTlv ku ( _der_child b inner )
                 ~ == . ku ok 1 {
                     ? == . ku tag 6 {
-                        ? ( __der_oid_is b ku `2b06010505070301` ) { = . ei eku_server T } {}  // serverAuth
-                        ? ( __der_oid_is b ku `551d2500` ) { = . ei eku_server T } {}  // anyExtendedKeyUsage
+                        ? ( _der_oid_is b ku `2b06010505070301` ) { = . ei eku_server T } {}  // serverAuth
+                        ? ( _der_oid_is b ku `551d2500` ) { = . ei eku_server T } {}  // anyExtendedKeyUsage
                     } {}
                     = ku ( _der_next b ku )
                 }
@@ -349,7 +356,7 @@ $ `stdlib/std/bytes.nu`
     : DerTlv keyalg ( _der_child der c )
     : DerTlv keyoid ( _der_child der keyalg )
     : DerTlv keybits ( _der_next der keyalg )
-    ? ( __der_oid_is der keyoid `2a864886f70d010101` ) {
+    ? ( _der_oid_is der keyoid `2a864886f70d010101` ) {
         // RSA: BIT STRING content (after unused-bits byte) is SEQ{n,e}
         = . out key_alg 1
         : DerTlv rsaseq ( der_at der + . keybits start 1 )
@@ -360,18 +367,18 @@ $ `stdlib/std/bytes.nu`
         ( vec_free [u] . out rsa_e )
         = . out rsa_e ( _der_uint der ei )
     } {
-        ? ( __der_oid_is der keyoid `2a8648ce3d0201` ) {
+        ? ( _der_oid_is der keyoid `2a8648ce3d0201` ) {
             // EC: namedCurve param + uncompressed point in the BIT STRING
             = . out key_alg 2
             : DerTlv curve ( _der_next der keyoid )
             : ~ i cc 0
-            ? ( __der_oid_is der curve `2a8648ce3d030107` ) { = cc 256 } {}
-            ? ( __der_oid_is der curve `2b81040022` ) { = cc 384 } {}
+            ? ( _der_oid_is der curve `2a8648ce3d030107` ) { = cc 256 } {}
+            ? ( _der_oid_is der curve `2b81040022` ) { = cc 384 } {}
             = . out ec_curve cc
             ( vec_free [u] . out ec_point )
             = . out ec_point ( bytes_slice der + . keybits start 1 + . keybits start . keybits len )
         } {
-            ? ( __der_oid_is der keyoid `2b6570` ) {
+            ? ( _der_oid_is der keyoid `2b6570` ) {
                 = . out key_alg 3
                 ( vec_free [u] . out ec_point )
                 = . out ec_point ( bytes_slice der + . keybits start 1 + . keybits start . keybits len )
@@ -380,9 +387,9 @@ $ `stdlib/std/bytes.nu`
                 // whole, with no AlgorithmIdentifier parameters — the
                 // OID alone fixes the parameter set.
                 : ~ i ml 0
-                ? ( __der_oid_is der keyoid `608648016503040311` ) { = ml 44 } {}
-                ? ( __der_oid_is der keyoid `608648016503040312` ) { = ml 65 } {}
-                ? ( __der_oid_is der keyoid `608648016503040313` ) { = ml 87 } {}
+                ? ( _der_oid_is der keyoid `608648016503040311` ) { = ml 44 } {}
+                ? ( _der_oid_is der keyoid `608648016503040312` ) { = ml 65 } {}
+                ? ( _der_oid_is der keyoid `608648016503040313` ) { = ml 87 } {}
                 ? > ml 0 {
                     = . out key_alg 4
                     = . out ec_curve ml

--- a/stdlib/std/x509_gen.nu
+++ b/stdlib/std/x509_gen.nu
@@ -24,9 +24,6 @@
 // the scalar, serial and validity instants): with a fixed scalar the
 // RFC 6979 deterministic ECDSA in std/ecdsa_p256.nu makes the whole
 // certificate byte-reproducible — which is what makes this KAT-testable.
-//
-// Everything private is namespaced __xg_ (NURL has one flat function
-// namespace across imports).
 
 $ `stdlib/core/string.nu`
 $ `stdlib/core/vec.nu`
@@ -51,7 +48,7 @@ $ `stdlib/std/time.nu`
 
 // ── entropy ───────────────────────────────────────────────────────────
 
-@ __xg_rand_bytes i n → ( Vec u ) {
+@ _xg_rand_bytes i n → ( Vec u ) {
     : ( Vec u ) v ( vec_with_cap [u] ? > n 0 n 1 )
     : ~ i k 0
     ~ < k n { ( vec_push [u] v # u 0 ) = k + k 1 }
@@ -65,7 +62,7 @@ $ `stdlib/std/time.nu`
 // scalar must satisfy 1 <= d < n. Both sides are 32-byte big-endian, so a
 // plain lexicographic byte compare against n (and an all-zero check) does
 // it without bigint round-trips. Rejection loop: P(retry) ≈ 2⁻³².
-@ __xg_scalar_ok ( Vec u ) d → b {
+@ _xg_scalar_ok ( Vec u ) d → b {
     : !( Vec u ) ParseErr nr ( bytes_from_hex `ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551` )
     : ( Vec u ) nb ?? nr { T v → v F _ → ( vec_new [u] ) }
     : ~ b nonzero F
@@ -87,7 +84,7 @@ $ `stdlib/std/time.nu`
 // vector, so nested construction never leaks and never double-frees.
 
 // tag + definite length + content.
-@ __xg_tlv i tag ( Vec u ) content → ( Vec u ) {
+@ _xg_tlv i tag ( Vec u ) content → ( Vec u ) {
     : i n ( vec_len [u] content )
     : ( Vec u ) out ( vec_with_cap [u] + n 6 )
     ( vec_push [u] out # u tag )
@@ -108,7 +105,7 @@ $ `stdlib/std/time.nu`
 
 // INTEGER from an unsigned big-endian magnitude: strip leading zeros,
 // re-prepend one 0x00 if the top bit would read as a sign.
-@ __xg_int ( Vec u ) mag → ( Vec u ) {
+@ _xg_int ( Vec u ) mag → ( Vec u ) {
     : i n ( vec_len [u] mag )
     : ~ i first 0
     ~ & < first - n 1 == ?? ( vec_get [u] mag first ) { T x → # i x F _ → 1 } 0 { = first + first 1 }
@@ -122,113 +119,113 @@ $ `stdlib/std/time.nu`
     }
     ? == ( vec_len [u] body ) 0 { ( vec_push [u] body # u 0 ) } {}
     ( vec_free [u] mag )
-    ^ ( __xg_tlv 2 body )
+    ^ ( _xg_tlv 2 body )
 }
 
 // Small non-negative INTEGER (fits one content byte).
-@ __xg_int1 i v → ( Vec u ) {
+@ _xg_int1 i v → ( Vec u ) {
     : ( Vec u ) b ( vec_new [u] )
     ( vec_push [u] b # u v )
-    ^ ( __xg_tlv 2 b )
+    ^ ( _xg_tlv 2 b )
 }
 
 // OID from its hex-encoded content bytes.
-@ __xg_oid s hex → ( Vec u ) {
+@ _xg_oid s hex → ( Vec u ) {
     : !( Vec u ) ParseErr r ( bytes_from_hex hex )
     : ( Vec u ) b ?? r { T v → v F _ → ( vec_new [u] ) }
-    ^ ( __xg_tlv 6 b )
+    ^ ( _xg_tlv 6 b )
 }
 
 // BIT STRING with zero unused bits.
-@ __xg_bitstring ( Vec u ) content → ( Vec u ) {
+@ _xg_bitstring ( Vec u ) content → ( Vec u ) {
     : ( Vec u ) b ( vec_with_cap [u] + ( vec_len [u] content ) 1 )
     ( vec_push [u] b # u 0 )
     ( bytes_extend_bytes b content )
     ( vec_free [u] content )
-    ^ ( __xg_tlv 3 b )
+    ^ ( _xg_tlv 3 b )
 }
 
-@ __xg_bool_true → ( Vec u ) {
+@ _xg_bool_true → ( Vec u ) {
     : ( Vec u ) b ( vec_new [u] )
     ( vec_push [u] b # u 255 )
-    ^ ( __xg_tlv 1 b )
+    ^ ( _xg_tlv 1 b )
 }
 
 // UTCTime "YYMMDDHHMMSSZ" from a unix instant (valid for 1950–2049,
 // which covers any sane self-signed validity from today).
-@ __xg_utctime i unix → ( Vec u ) {
+@ _xg_utctime i unix → ( Vec u ) {
     : Time t ( time_from_unix unix )
     : String st ( string_with_cap 16 )
-    ( __xg_push2 st % . t year 100 )
-    ( __xg_push2 st . t month )
-    ( __xg_push2 st . t day )
-    ( __xg_push2 st . t hour )
-    ( __xg_push2 st . t min )
-    ( __xg_push2 st . t sec )
+    ( _xg_push2 st % . t year 100 )
+    ( _xg_push2 st . t month )
+    ( _xg_push2 st . t day )
+    ( _xg_push2 st . t hour )
+    ( _xg_push2 st . t min )
+    ( _xg_push2 st . t sec )
     ( string_push_char st 90 )  // 'Z'
     : ( Vec u ) b ( bytes_from_str ( string_data st ) )
     ( string_free st )
-    ^ ( __xg_tlv 23 b )
+    ^ ( _xg_tlv 23 b )
 }
 
-@ __xg_push2 String st i v → v {
+@ _xg_push2 String st i v → v {
     ( string_push_char st + 48 / v 10 )
     ( string_push_char st + 48 % v 10 )
 }
 
 // Name = SEQ{ SET{ SEQ{ OID commonName, UTF8String cn } } }
-@ __xg_name s cn → ( Vec u ) {
+@ _xg_name s cn → ( Vec u ) {
     : ( Vec u ) cnb ( bytes_from_str cn )
-    : ( Vec u ) cnstr ( __xg_tlv 12 cnb )  // 0x0C UTF8String
-    : ~ ( Vec u ) atv ( __xg_oid `550403` )  // 2.5.4.3 commonName
+    : ( Vec u ) cnstr ( _xg_tlv 12 cnb )  // 0x0C UTF8String
+    : ~ ( Vec u ) atv ( _xg_oid `550403` )  // 2.5.4.3 commonName
     ( bytes_extend_bytes atv cnstr ) ( vec_free [u] cnstr )
-    : ( Vec u ) atv_seq ( __xg_tlv 48 atv )
-    : ( Vec u ) set ( __xg_tlv 49 atv_seq )
-    ^ ( __xg_tlv 48 set )
+    : ( Vec u ) atv_seq ( _xg_tlv 48 atv )
+    : ( Vec u ) set ( _xg_tlv 49 atv_seq )
+    ^ ( _xg_tlv 48 set )
 }
 
 // AlgorithmIdentifier ecdsa-with-SHA256 (no parameters, per RFC 5758).
-@ __xg_alg_ecdsa_sha256 → ( Vec u ) {
-    ^ ( __xg_tlv 48 ( __xg_oid `2a8648ce3d040302` ) )
+@ _xg_alg_ecdsa_sha256 → ( Vec u ) {
+    ^ ( _xg_tlv 48 ( _xg_oid `2a8648ce3d040302` ) )
 }
 
 // SubjectPublicKeyInfo for an uncompressed P-256 point.
-@ __xg_spki ( Vec u ) pub65 → ( Vec u ) {
-    : ~ ( Vec u ) alg ( __xg_oid `2a8648ce3d0201` )  // id-ecPublicKey
-    : ( Vec u ) curve ( __xg_oid `2a8648ce3d030107` )  // prime256v1
+@ _xg_spki ( Vec u ) pub65 → ( Vec u ) {
+    : ~ ( Vec u ) alg ( _xg_oid `2a8648ce3d0201` )  // id-ecPublicKey
+    : ( Vec u ) curve ( _xg_oid `2a8648ce3d030107` )  // prime256v1
     ( bytes_extend_bytes alg curve ) ( vec_free [u] curve )
-    : ~ ( Vec u ) algseq ( __xg_tlv 48 alg )
-    : ( Vec u ) bs ( __xg_bitstring pub65 )
+    : ~ ( Vec u ) algseq ( _xg_tlv 48 alg )
+    : ( Vec u ) bs ( _xg_bitstring pub65 )
     ( bytes_extend_bytes algseq bs ) ( vec_free [u] bs )
-    ^ ( __xg_tlv 48 algseq )
+    ^ ( _xg_tlv 48 algseq )
 }
 
 // [3] EXPLICIT Extensions: basicConstraints critical CA:TRUE + SAN DNS:cn.
-@ __xg_extensions s cn → ( Vec u ) {
+@ _xg_extensions s cn → ( Vec u ) {
     // basicConstraints = SEQ{ OID, BOOL TRUE (critical), OCTET{ SEQ{ BOOL TRUE } } }
-    : ( Vec u ) bc_inner ( __xg_tlv 48 ( __xg_bool_true ) )
-    : ( Vec u ) bc_oct ( __xg_tlv 4 bc_inner )
-    : ~ ( Vec u ) bc ( __xg_oid `551d13` )  // 2.5.29.19
-    : ( Vec u ) crit ( __xg_bool_true )
+    : ( Vec u ) bc_inner ( _xg_tlv 48 ( _xg_bool_true ) )
+    : ( Vec u ) bc_oct ( _xg_tlv 4 bc_inner )
+    : ~ ( Vec u ) bc ( _xg_oid `551d13` )  // 2.5.29.19
+    : ( Vec u ) crit ( _xg_bool_true )
     ( bytes_extend_bytes bc crit ) ( vec_free [u] crit )
     ( bytes_extend_bytes bc bc_oct ) ( vec_free [u] bc_oct )
-    : ( Vec u ) bc_seq ( __xg_tlv 48 bc )
+    : ( Vec u ) bc_seq ( _xg_tlv 48 bc )
 
     // subjectAltName = SEQ{ OID, OCTET{ SEQ{ [2] IMPLICIT dNSName } } }
-    : ( Vec u ) dns ( __xg_tlv 130 ( bytes_from_str cn ) )  // 0x82 context [2]
-    : ( Vec u ) san_oct ( __xg_tlv 4 ( __xg_tlv 48 dns ) )
-    : ~ ( Vec u ) san ( __xg_oid `551d11` )  // 2.5.29.17
+    : ( Vec u ) dns ( _xg_tlv 130 ( bytes_from_str cn ) )  // 0x82 context [2]
+    : ( Vec u ) san_oct ( _xg_tlv 4 ( _xg_tlv 48 dns ) )
+    : ~ ( Vec u ) san ( _xg_oid `551d11` )  // 2.5.29.17
     ( bytes_extend_bytes san san_oct ) ( vec_free [u] san_oct )
-    : ( Vec u ) san_seq ( __xg_tlv 48 san )
+    : ( Vec u ) san_seq ( _xg_tlv 48 san )
 
     : ~ ( Vec u ) both bc_seq
     ( bytes_extend_bytes both san_seq ) ( vec_free [u] san_seq )
-    : ( Vec u ) exts ( __xg_tlv 48 both )
-    ^ ( __xg_tlv 163 exts )  // 0xA3 [3] EXPLICIT
+    : ( Vec u ) exts ( _xg_tlv 48 both )
+    ^ ( _xg_tlv 163 exts )  // 0xA3 [3] EXPLICIT
 }
 
 // PEM: header + base64 wrapped at 64 columns + footer.
-@ __xg_pem s label ( Vec u ) der → String {
+@ _xg_pem s label ( Vec u ) der → String {
     : String b64 ( b64_encode_vec der )
     ( vec_free [u] der )
     : String out ( string_with_cap + ( string_len b64 ) 96 )
@@ -253,14 +250,14 @@ $ `stdlib/std/time.nu`
 // ── certificate assembly ─────────────────────────────────────────────
 
 // ECDSA-Sig-Value = SEQ{ INTEGER r, INTEGER s } from the raw r||s pair.
-@ __xg_sig_der ( Vec u ) rs → ( Vec u ) {
+@ _xg_sig_der ( Vec u ) rs → ( Vec u ) {
     : ( Vec u ) rb ( bytes_slice rs 0 32 )
     : ( Vec u ) sb ( bytes_slice rs 32 64 )
     ( vec_free [u] rs )
-    : ~ ( Vec u ) body ( __xg_int rb )
-    : ( Vec u ) si ( __xg_int sb )
+    : ~ ( Vec u ) body ( _xg_int rb )
+    : ( Vec u ) si ( _xg_int sb )
     ( bytes_extend_bytes body si ) ( vec_free [u] si )
-    ^ ( __xg_tlv 48 body )
+    ^ ( _xg_tlv 48 body )
 }
 
 // The inverse helper for consumers that need raw r||s back out of a DER
@@ -309,70 +306,70 @@ $ `stdlib/std/time.nu`
     : ( Vec u ) pubkey ( p256_ecdh_keygen scalar )
 
     // TBSCertificate
-    : ~ ( Vec u ) tbs_body ( __xg_tlv 160 ( __xg_int1 2 ) )  // [0]{ INTEGER 2 } = v3
-    // __xg_int consumes its argument — hand it a copy so `serial` stays
+    : ~ ( Vec u ) tbs_body ( _xg_tlv 160 ( _xg_int1 2 ) )  // [0]{ INTEGER 2 } = v3
+    // _xg_int consumes its argument — hand it a copy so `serial` stays
     // caller-owned (both callers free their own).
-    : ( Vec u ) ser ( __xg_int ( bytes_slice serial 0 ( vec_len [u] serial ) ) )
+    : ( Vec u ) ser ( _xg_int ( bytes_slice serial 0 ( vec_len [u] serial ) ) )
     ( bytes_extend_bytes tbs_body ser ) ( vec_free [u] ser )
-    : ( Vec u ) alg1 ( __xg_alg_ecdsa_sha256 )
+    : ( Vec u ) alg1 ( _xg_alg_ecdsa_sha256 )
     ( bytes_extend_bytes tbs_body alg1 ) ( vec_free [u] alg1 )
-    : ( Vec u ) issuer ( __xg_name cn )
+    : ( Vec u ) issuer ( _xg_name cn )
     ( bytes_extend_bytes tbs_body issuer ) ( vec_free [u] issuer )
-    : ~ ( Vec u ) val ( __xg_utctime not_before_unix )
-    : ( Vec u ) na ( __xg_utctime not_after_unix )
+    : ~ ( Vec u ) val ( _xg_utctime not_before_unix )
+    : ( Vec u ) na ( _xg_utctime not_after_unix )
     ( bytes_extend_bytes val na ) ( vec_free [u] na )
-    : ( Vec u ) val_seq ( __xg_tlv 48 val )
+    : ( Vec u ) val_seq ( _xg_tlv 48 val )
     ( bytes_extend_bytes tbs_body val_seq ) ( vec_free [u] val_seq )
-    : ( Vec u ) subject ( __xg_name cn )
+    : ( Vec u ) subject ( _xg_name cn )
     ( bytes_extend_bytes tbs_body subject ) ( vec_free [u] subject )
     : ( Vec u ) pub_copy ( bytes_slice pubkey 0 ( vec_len [u] pubkey ) )
-    : ( Vec u ) spki ( __xg_spki pub_copy )
+    : ( Vec u ) spki ( _xg_spki pub_copy )
     ( bytes_extend_bytes tbs_body spki ) ( vec_free [u] spki )
-    : ( Vec u ) exts ( __xg_extensions cn )
+    : ( Vec u ) exts ( _xg_extensions cn )
     ( bytes_extend_bytes tbs_body exts ) ( vec_free [u] exts )
-    : ( Vec u ) tbs ( __xg_tlv 48 tbs_body )
+    : ( Vec u ) tbs ( _xg_tlv 48 tbs_body )
 
     // sign SHA-256(TBS) with the same key the cert carries (self-signed)
     : ( Vec u ) h ( sha256_pure tbs )
     : ( Vec u ) rs ( ecdsa_p256_sign scalar h )
     ( vec_free [u] h )
-    : ( Vec u ) sig_der ( __xg_sig_der rs )
+    : ( Vec u ) sig_der ( _xg_sig_der rs )
 
     // Certificate = SEQ{ TBS, AlgorithmIdentifier, BIT STRING sig }
     : ~ ( Vec u ) cert_body tbs
-    : ( Vec u ) alg2 ( __xg_alg_ecdsa_sha256 )
+    : ( Vec u ) alg2 ( _xg_alg_ecdsa_sha256 )
     ( bytes_extend_bytes cert_body alg2 ) ( vec_free [u] alg2 )
-    : ( Vec u ) sig_bs ( __xg_bitstring sig_der )
+    : ( Vec u ) sig_bs ( _xg_bitstring sig_der )
     ( bytes_extend_bytes cert_body sig_bs ) ( vec_free [u] sig_bs )
-    : ( Vec u ) cert_der ( __xg_tlv 48 cert_body )
+    : ( Vec u ) cert_der ( _xg_tlv 48 cert_body )
 
     // SEC1 / RFC 5915 ECPrivateKey =
     //   SEQ{ INTEGER 1, OCTET scalar, [0]{OID prime256v1}, [1]{BIT STRING pub} }
     : ( Vec u ) scalar_copy ( bytes_slice scalar 0 32 )
-    : ~ ( Vec u ) key_body ( __xg_int1 1 )
-    : ( Vec u ) sk_oct ( __xg_tlv 4 scalar_copy )
+    : ~ ( Vec u ) key_body ( _xg_int1 1 )
+    : ( Vec u ) sk_oct ( _xg_tlv 4 scalar_copy )
     ( bytes_extend_bytes key_body sk_oct ) ( vec_free [u] sk_oct )
-    : ( Vec u ) crv ( __xg_tlv 160 ( __xg_oid `2a8648ce3d030107` ) )
+    : ( Vec u ) crv ( _xg_tlv 160 ( _xg_oid `2a8648ce3d030107` ) )
     ( bytes_extend_bytes key_body crv ) ( vec_free [u] crv )
-    : ( Vec u ) pub_bs ( __xg_tlv 161 ( __xg_bitstring pubkey ) )
+    : ( Vec u ) pub_bs ( _xg_tlv 161 ( _xg_bitstring pubkey ) )
     ( bytes_extend_bytes key_body pub_bs ) ( vec_free [u] pub_bs )
-    : ( Vec u ) key_der ( __xg_tlv 48 key_body )
+    : ( Vec u ) key_der ( _xg_tlv 48 key_body )
 
     ^ @ X509SelfSigned {
-        ( __xg_pem `CERTIFICATE` cert_der )
-        ( __xg_pem `EC PRIVATE KEY` key_der )
+        ( _xg_pem `CERTIFICATE` cert_der )
+        ( _xg_pem `EC PRIVATE KEY` key_der )
     }
 }
 
 // Convenience wrapper: fresh random key + serial, validity from one day
 // ago (clock-skew slack) to `days` days ahead.
 @ x509_selfsigned_p256 s cn i days → X509SelfSigned {
-    : ~ ( Vec u ) scalar ( __xg_rand_bytes 32 )
-    ~ ! ( __xg_scalar_ok scalar ) {
+    : ~ ( Vec u ) scalar ( _xg_rand_bytes 32 )
+    ~ ! ( _xg_scalar_ok scalar ) {
         ( vec_free [u] scalar )
-        = scalar ( __xg_rand_bytes 32 )
+        = scalar ( _xg_rand_bytes 32 )
     }
-    : ( Vec u ) serial ( __xg_rand_bytes 12 )
+    : ( Vec u ) serial ( _xg_rand_bytes 12 )
     : i now ( now_seconds )
     : X509SelfSigned out ( x509_selfsigned_p256_pinned scalar serial cn - now 86400 + now * days 86400 )
     ( vec_free [u] scalar ) ( vec_free [u] serial )
@@ -394,36 +391,36 @@ $ `stdlib/std/time.nu`
 // One OID does the work of two here — it names both the key type and the
 // signature algorithm, because ML-DSA specifies its own hashing and so
 // has no "with-SHA256" half to encode.
-@ __xg_mldsa_oid i level → ( Vec u ) {
-    ? == level 44 { ^ ( __xg_oid `608648016503040311` ) } {}
-    ? == level 87 { ^ ( __xg_oid `608648016503040313` ) } {}
-    ^ ( __xg_oid `608648016503040312` )
+@ _xg_mldsa_oid i level → ( Vec u ) {
+    ? == level 44 { ^ ( _xg_oid `608648016503040311` ) } {}
+    ? == level 87 { ^ ( _xg_oid `608648016503040313` ) } {}
+    ^ ( _xg_oid `608648016503040312` )
 }
 
-@ __xg_alg_mldsa i level → ( Vec u ) {
-    ^ ( __xg_tlv 48 ( __xg_mldsa_oid level ) )
+@ _xg_alg_mldsa i level → ( Vec u ) {
+    ^ ( _xg_tlv 48 ( _xg_mldsa_oid level ) )
 }
 
 // SubjectPublicKeyInfo. The AlgorithmIdentifier carries no parameters —
 // absent, not NULL — since the OID already fixes the parameter set.
-@ __xg_spki_mldsa i level ( Vec u ) pk → ( Vec u ) {
-    : ~ ( Vec u ) algseq ( __xg_alg_mldsa level )
-    : ( Vec u ) bs ( __xg_bitstring pk )
+@ _xg_spki_mldsa i level ( Vec u ) pk → ( Vec u ) {
+    : ~ ( Vec u ) algseq ( _xg_alg_mldsa level )
+    : ( Vec u ) bs ( _xg_bitstring pk )
     ( bytes_extend_bytes algseq bs ) ( vec_free [u] bs )
-    ^ ( __xg_tlv 48 algseq )
+    ^ ( _xg_tlv 48 algseq )
 }
 
 // PKCS#8 OneAsymmetricKey: SEQ{ INTEGER 0, AlgorithmIdentifier,
 // OCTET STRING{ OCTET STRING(sk) } } — the inner OCTET STRING is the
 // `privateKey` wrapper every PKCS#8 key has.
-@ __xg_pkcs8_mldsa i level ( Vec u ) sk → ( Vec u ) {
-    : ~ ( Vec u ) body ( __xg_int1 0 )
-    : ( Vec u ) alg ( __xg_alg_mldsa level )
+@ _xg_pkcs8_mldsa i level ( Vec u ) sk → ( Vec u ) {
+    : ~ ( Vec u ) body ( _xg_int1 0 )
+    : ( Vec u ) alg ( _xg_alg_mldsa level )
     ( bytes_extend_bytes body alg ) ( vec_free [u] alg )
-    : ( Vec u ) inner ( __xg_tlv 4 sk )
-    : ( Vec u ) outer ( __xg_tlv 4 inner )
+    : ( Vec u ) inner ( _xg_tlv 4 sk )
+    : ( Vec u ) outer ( _xg_tlv 4 inner )
     ( bytes_extend_bytes body outer ) ( vec_free [u] outer )
-    ^ ( __xg_tlv 48 body )
+    ^ ( _xg_tlv 48 body )
 }
 
 // Deterministic core: the caller supplies the key pair, the serial and
@@ -432,48 +429,48 @@ $ `stdlib/std/time.nu`
 // is byte-reproducible, which is what makes it testable against a
 // pinned digest.
 @ x509_selfsigned_mldsa_pinned i level ( Vec u ) pk ( Vec u ) sk ( Vec u ) serial ( Vec u ) rnd s cn i not_before_unix i not_after_unix → X509SelfSigned {
-    : ~ ( Vec u ) tbs_body ( __xg_tlv 160 ( __xg_int1 2 ) )  // [0]{ INTEGER 2 } = v3
-    : ( Vec u ) ser ( __xg_int ( bytes_slice serial 0 ( vec_len [u] serial ) ) )
+    : ~ ( Vec u ) tbs_body ( _xg_tlv 160 ( _xg_int1 2 ) )  // [0]{ INTEGER 2 } = v3
+    : ( Vec u ) ser ( _xg_int ( bytes_slice serial 0 ( vec_len [u] serial ) ) )
     ( bytes_extend_bytes tbs_body ser ) ( vec_free [u] ser )
-    : ( Vec u ) alg1 ( __xg_alg_mldsa level )
+    : ( Vec u ) alg1 ( _xg_alg_mldsa level )
     ( bytes_extend_bytes tbs_body alg1 ) ( vec_free [u] alg1 )
-    : ( Vec u ) issuer ( __xg_name cn )
+    : ( Vec u ) issuer ( _xg_name cn )
     ( bytes_extend_bytes tbs_body issuer ) ( vec_free [u] issuer )
-    : ~ ( Vec u ) val ( __xg_utctime not_before_unix )
-    : ( Vec u ) na ( __xg_utctime not_after_unix )
+    : ~ ( Vec u ) val ( _xg_utctime not_before_unix )
+    : ( Vec u ) na ( _xg_utctime not_after_unix )
     ( bytes_extend_bytes val na ) ( vec_free [u] na )
-    : ( Vec u ) val_seq ( __xg_tlv 48 val )
+    : ( Vec u ) val_seq ( _xg_tlv 48 val )
     ( bytes_extend_bytes tbs_body val_seq ) ( vec_free [u] val_seq )
-    : ( Vec u ) subject ( __xg_name cn )
+    : ( Vec u ) subject ( _xg_name cn )
     ( bytes_extend_bytes tbs_body subject ) ( vec_free [u] subject )
     : ( Vec u ) pub_copy ( bytes_slice pk 0 ( vec_len [u] pk ) )
-    : ( Vec u ) spki ( __xg_spki_mldsa level pub_copy )
+    : ( Vec u ) spki ( _xg_spki_mldsa level pub_copy )
     ( bytes_extend_bytes tbs_body spki ) ( vec_free [u] spki )
-    : ( Vec u ) exts ( __xg_extensions cn )
+    : ( Vec u ) exts ( _xg_extensions cn )
     ( bytes_extend_bytes tbs_body exts ) ( vec_free [u] exts )
-    : ( Vec u ) tbs ( __xg_tlv 48 tbs_body )
+    : ( Vec u ) tbs ( _xg_tlv 48 tbs_body )
 
     // Sign the TBS bytes themselves — ML-DSA hashes internally, so there
     // is no digest step here the way there is for ECDSA or RSA. The
     // context string is empty: X.509 has no place to carry one.
     : ( Vec u ) ctx ( vec_new [u] )
-    : ( Vec u ) mp ( __xg_mldsa_mprime tbs ctx )
+    : ( Vec u ) mp ( _xg_mldsa_mprime tbs ctx )
     : ( Vec u ) sig ( mldsa_sign_internal level sk mp rnd )
     ( vec_free [u] mp ) ( vec_free [u] ctx )
 
     : ~ ( Vec u ) cert_body tbs
-    : ( Vec u ) alg2 ( __xg_alg_mldsa level )
+    : ( Vec u ) alg2 ( _xg_alg_mldsa level )
     ( bytes_extend_bytes cert_body alg2 ) ( vec_free [u] alg2 )
-    : ( Vec u ) sig_bs ( __xg_bitstring sig )
+    : ( Vec u ) sig_bs ( _xg_bitstring sig )
     ( bytes_extend_bytes cert_body sig_bs ) ( vec_free [u] sig_bs )
-    : ( Vec u ) cert_der ( __xg_tlv 48 cert_body )
+    : ( Vec u ) cert_der ( _xg_tlv 48 cert_body )
 
     : ( Vec u ) sk_copy ( bytes_slice sk 0 ( vec_len [u] sk ) )
-    : ( Vec u ) key_der ( __xg_pkcs8_mldsa level sk_copy )
+    : ( Vec u ) key_der ( _xg_pkcs8_mldsa level sk_copy )
 
     ^ @ X509SelfSigned {
-        ( __xg_pem `CERTIFICATE` cert_der )
-        ( __xg_pem `PRIVATE KEY` key_der )
+        ( _xg_pem `CERTIFICATE` cert_der )
+        ( _xg_pem `PRIVATE KEY` key_der )
     }
 }
 
@@ -482,7 +479,7 @@ $ `stdlib/std/time.nu`
 // helper rather than exported from it, because a certificate is the one
 // caller that needs to build it by hand — everything else goes through
 // mldsa_sign.
-@ __xg_mldsa_mprime ( Vec u ) msg ( Vec u ) ctx → ( Vec u ) {
+@ _xg_mldsa_mprime ( Vec u ) msg ( Vec u ) ctx → ( Vec u ) {
     : ( Vec u ) m ( vec_new [u] )
     ( vec_push [u] m # u 0 )
     ( vec_push [u] m # u ( vec_len [u] ctx ) )
@@ -494,8 +491,8 @@ $ `stdlib/std/time.nu`
 // Convenience wrapper: fresh key, serial and signing randomness.
 @ x509_selfsigned_mldsa i level s cn i days → X509SelfSigned {
     : *MldsaKeys ks ( mldsa_keygen level )
-    : ( Vec u ) serial ( __xg_rand_bytes 12 )
-    : ( Vec u ) rnd ( __xg_rand_bytes 32 )
+    : ( Vec u ) serial ( _xg_rand_bytes 12 )
+    : ( Vec u ) rnd ( _xg_rand_bytes 32 )
     : i now ( now_seconds )
     : X509SelfSigned out ( x509_selfsigned_mldsa_pinned level ( mldsa_pk ks ) ( mldsa_sk ks )
     serial rnd cn - now 86400 + now * days 86400 )


### PR DESCRIPTION
## Why

1. **Missing PKCS#10 Certificate Signing Request (CSR) standard support**: NURL had native X.509 certificate generation (`std/x509_gen.nu`) and parsing (`std/x509.nu`), but lacked RFC 2986 PKCS#10 Certificate Signing Request parsing, verification, generation, and issuance. Devices and clients enrolling into PKI environments or mTLS architectures had to either generate keys centrally or rely on external OpenSSL CLI tools.
2. **Missing JWT ES256 (ECDSA P-256) standard support**: `ext/jwt.nu` and `ext/http_jwt.nu` supported HS256 (symmetric) and EdDSA (Ed25519), but lacked ES256 (RFC 7518 §3.1), which is the standard signing algorithm used by OIDC and OAuth2 providers (Apple, Google, Okta, GitHub, WebAuthn).
3. **Missing SLH-DSA SHAKE OIDs**: `std/x509.nu` recognised SHA2-based SLH-DSA parameter sets but not SHAKE SLH-DSA parameter sets (OIDs `2.16.840.1.101.3.4.3.{21,23,25,27,29,31}`).

## What

1. **`stdlib/std/csr.nu`** (new pure-NURL PKCS#10 module):
   - Types: `Csr`, `csr_free`, `__CsrNames`.
   - Parser: `csr_parse` (RFC 2986 ASN.1 DER parser for `CertificationRequestInfo`, `SubjectPublicKeyInfo`, `extensionRequest` subjectAltNames / basicConstraints, and signature).
   - Verifier: `csr_verify` (pure-NURL cryptographic self-signature verification supporting ECDSA P-256 + SHA-256, Ed25519, RSA PKCS#1 v1.5 + SHA-256, and ML-DSA-44/65/87).
   - Generator: `csr_generate_p256` and `csr_generate_ed25519` with SAN extension requests.
   - PEM round-trip: `csr_to_pem` and `csr_from_pem`.
   - CA issuance: `x509_issue_from_csr` (issues signed X.509 v3 certificates directly from verified CSRs without private key transit).
2. **`stdlib/ext/jwt.nu` & `stdlib/ext/http_jwt.nu`**:
   - Added `jwt_es256_sign`, `jwt_es256_verify_at`, and `jwt_es256_verify` (RFC 7515 / RFC 7518 §3.1).
   - Added `with_jwt_es256` HTTP authentication middleware.
3. **`stdlib/std/x509.nu` & `stdlib/std/x509_gen.nu`**:
   - Exported `_xg_*` DER encoder utilities and `_der_oid_is`.
   - Added SLH-DSA SHAKE OIDs (codes 11..16).
4. **`packages/pki-server`**:
   - Bumped package version from `0.1.0` -> `0.2.0` in `packages/pki-server/nurl.toml`.
   - Added Zero-Trust `POST /request-csr` endpoint to issue signed certificates from verified client CSRs.
5. **Testing & Interoperability Gates**:
   - `compiler/tests/csr_basic.nu`: 6 unit acceptance tests for generation, parsing, self-signature check, tamper rejection, and CA issuance.
   - `compiler/tests/csr_openssl_gate.sh`: Automated two-way interoperability gate verifying OpenSSL verifying NURL-generated P-256 and Ed25519 CSRs, and NURL verifying OpenSSL-generated CSRs.
   - `compiler/tests/jwt_basic.nu` & `compiler/tests/http_jwt.nu`: Unit and HTTP middleware tests for ES256.
   - `packages/pki-server/tests/pki_test.sh`: Added E2E Test 10 asserting Zero-Trust CSR issuance and OpenSSL validation.

## Proof

```text
==> compiler/tests/csr_openssl_gate.sh:
--> Test 1: OpenSSL verifying NURL-generated ECDSA P-256 CSR...
Certificate request self-signature verify OK
    OpenSSL accepted & verified P-256 CSR signature: OK
--> Test 2: OpenSSL verifying NURL-generated Ed25519 CSR...
Certificate request self-signature verify OK
    OpenSSL accepted & verified Ed25519 CSR signature: OK
--> Test 3: NURL verifying OpenSSL-generated ECDSA CSR...
    NURL parsed & verified OpenSSL CSR: OK
--> Test 4: NURL verifying OpenSSL-generated Ed25519 CSR...
    NURL parsed & verified OpenSSL Ed25519 CSR: OK
==========================================
  ALL CSR OPENSSL INTEROP TESTS PASSED!   
==========================================

==> compiler/tests/run_tests.sh:
PASS 844 · FAIL 0 · MISSING 0 · ORPHAN 0 · SKIP 23  (jobs=12)
TESTS PASSED

==> packages/pki-server/tests/pki_test.sh:
--> Test 10: POST /request-csr (PKCS#10 CSR issuance)
    OpenSSL CSR cert verification: OK (Zero Trust issuance verified)
==================================================
  ALL E2E INTEGRATION TESTS PASSED SUCCESSFULLY!  
==================================================
```

## Known remaining

None.
