### PR TITLE
Release v0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.45.0] — 2026-08-18
+
 ### Added
+
+- **`std/csr`: PKCS#10 Certificate Signing Requests (RFC 2986) in pure NURL** —
+  RFC 2986 ASN.1 DER parser (`csr_parse`), generator (`csr_generate_p256`,
+  `csr_generate_ed25519`), self-signature verifier (`csr_verify` supporting
+  ECDSA P-256 + SHA-256, Ed25519, RSA PKCS#1 v1.5 + SHA-256, and ML-DSA-44/65/87),
+  PEM encoding/decoding (`csr_to_pem`, `csr_from_pem`), and CA certificate issuance
+  from verified CSRs (`x509_issue_from_csr`). Devices can generate keys locally
+  and request certificates without private keys ever traversing the network.
+  Two-way interoperability is verified against OpenSSL via
+  `compiler/tests/csr_openssl_gate.sh`.
+
+- **`ext/jwt` & `ext/http_jwt`: ES256 (ECDSA P-256 + SHA-256) support** —
+  `jwt_es256_sign`, `jwt_es256_verify_at`, and `jwt_es256_verify` (RFC 7515 /
+  RFC 7518 §3.1), plus HTTP authentication middleware `with_jwt_es256`, enabling
+  direct interoperability with modern OAuth2 / OIDC providers (Apple, Google,
+  Okta, GitHub, WebAuthn).
+
+- **`std/x509`: SLH-DSA (FIPS 205) SHAKE OID recognition** —
+  OIDs `2.16.840.1.101.3.4.3.{21,23,25,27,29,31}` for SHAKE SLH-DSA parameter sets.
+
+- **`packages/pki-server` (v0.2.0) — Pure-NURL Private PKI Certificate Authority and Service** —
+  A complete, native re-implementation of a Private PKI CA microservice in pure NURL with
+  zero external dependencies. Features ECDSA P-256 key generation, automated CA setup,
+  two-tier device lifecycle (`POST /init` enrollment, `POST /renew_initial_cert` renewal,
+  `POST /request-cert` operational issuance), Zero-Trust PKCS#10 CSR enrollment
+  (`POST /request-csr`), RFC 5280 CRL generation (`POST /revoke`, `GET /crl`),
+  OpenSSL `index.txt` compatibility, API key authentication, and responsive modern
+  server-rendered Web UI dashboard.
 
 - **`std/slhdsa`: SLH-DSA (FIPS 205) in pure NURL** — the third and last
   NIST post-quantum standard, and the one that assumes least. ML-KEM and
@@ -13836,7 +13866,8 @@ releases are measured.
   compile-server (`api/`), browser playground (`nurlweb/`).
 * Dual license: MIT (LICENSE-MIT) or Apache-2.0 (LICENSE-APACHE).
 
-[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.44.2...HEAD
+[Unreleased]: https://github.com/nurl-lang/nurl/compare/v0.45.0...HEAD
+[0.45.0]: https://github.com/nurl-lang/nurl/compare/v0.44.2...v0.45.0
 [0.44.2]: https://github.com/nurl-lang/nurl/compare/v0.44.1...v0.44.2
 [0.44.1]: https://github.com/nurl-lang/nurl/compare/v0.44.0...v0.44.1
 [0.44.0]: https://github.com/nurl-lang/nurl/compare/v0.43.0...v0.44.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Anything marked done here has a regression test in
 [`compiler/tests/`](compiler/tests/) and is covered by the bootstrap fixed
 point.
 
-_Last reviewed: 2026-08-16 · Current release: **0.44.2** · Language: **Grammar
+_Last reviewed: 2026-08-18 · Current release: **0.45.0** · Language: **Grammar
 v2.5** ([`spec/grammar.ebnf`](spec/grammar.ebnf))._
 
 ---
@@ -158,7 +158,7 @@ small C runtime (`stdlib/runtime.c`) for the bootstrap surface and a few
 platform-specific shims.
 
 - **core** — `string`, `vec`, `option`, `result`, `errors`, `char`, `slice`,
-  `pair`, `box`, `cell`, `mem`, `io`, `symtab`, `posix`.
+  `pair`, `box`, `cell`, `mem`, `io` (`write_bytes`, `read_all_stdin_bytes`), `symtab`, `posix`.
 - **std/collections & algorithms** — `hashmap`, `set`, `deque`, `heap`,
   `ordmap`, `btree`, `lru`, `bitset`, `iter`, `sort`, `cmp`, `bytes`, `bufio`, `fmt`, `int`, `float`,
   `bigint` (arbitrary-precision integers), `decimal` (exact fixed-point).
@@ -166,17 +166,22 @@ platform-specific shims.
   `arena`, `signal`, `panic`/`recover`, `process`, `unixsock` (local IPC),
   `log` (text + JSON), `time` (incl. timezone/DST, HTTP/RFC 2822 dates), `args` (CLI parser),
   `term` (POSIX termios, ANSI).
-- **std/crypto & encoding** — `hash` (SHA-1/256/512, MD5, HMAC),
-  `hash_blake3`, `encode` (hex, base64, base32), `random` (OS CSPRNG),
-  `rng` (seedable, deterministic xoshiro256\*\*).
-- **std/IO & net** — `fs` (incl. streaming + `readlink`), `path` (typed),
+- **std/crypto & encoding** — **Post-Quantum Cryptography**: `mlkem` (ML-KEM-512/768/1024, FIPS 203),
+  `mldsa` (ML-DSA-44/65/87 & HashML-DSA, FIPS 204), `slhdsa` (SLH-DSA, FIPS 205, SHAKE & SHA-2 families),
+  `hash_sha3` (SHA-3 & SHAKE128/256, FIPS 202). **Classical & symmetric**: `x25519`, `ed25519`,
+  `ecdsa_p256` (P-256 + P-384 constant-time), `rsa` (PKCS#1 v1.5 + PSS), `aes_gcm`, `chacha20poly1305`,
+  `hash` (SHA-1/224/256/384/512, SHA-512/224, SHA-512/256, MD5, HMAC), `hash_blake3`, `hash_xxh64` (XXH64),
+  `hkdf`, `pbkdf2`, `scrypt`, `encode` (hex, base64, base32), `random` (OS CSPRNG `rand_bytes`), `rng` (xoshiro256\*\*).
+- **std/PKI & certificates** — `x509` (DER parser + chain/host validation, ML-DSA & SLH-DSA OIDs), `x509_gen` (self-signed P-256 & ML-DSA certificates, PKCS#8), `csr` (PKCS#10 RFC 2986 parser, generator, self-signature verifier, PEM round-trip, CA issuance from CSR).
+- **std/compression** — `zstd` (pure-NURL RFC 8878 Zstandard decompressor & compressor up to level 19 optimal parser, no libzstd), `deflate` (RFC 1951 + table-driven CRC-32).
+- **std/IO & net** — `fs` (incl. streaming, `readlink`, `file_sync`, `dir_sync`, `file_truncate`), `path` (typed),
   `net` (TCP/TLS), `udp`, `dns`, `dos`.
 - **ext/serialization** — `json`, `toml`, `csv`, `msgpack`, `cbor`, `xml`, `yaml`,
   `serde`, `regex`.
 - **ext/web stack** — full HTTP/1.1 server (keep-alive, pipelining, static,
-  auth, JWT bearer-auth, cookies, forms, multipart, router, middleware, access log + Prometheus
+  auth, JWT bearer-auth with HS256/EdDSA/**ES256**, cookies, forms, multipart, router, middleware, access log + Prometheus
   metrics, DoS caps, graceful shutdown, per-request timeouts, panic recovery),
-  HTTP client (with cookie jar), **TLS** (SNI + ALPN + mTLS + live cert reload; the pure ChaCha20-Poly1305 record path serves past gigabit wire speed, and since 0.40.0 the pure-NURL handshake — X25519 + P-256 ECDHE, ECDSA sign/verify, no assembly and no OpenSSL — runs at 4 894 handshakes/s, 2× its 0.39.0 rate), **HTTP/2**
+  HTTP client (with cookie jar), **Post-Quantum TLS 1.3** (client & server: `X25519MLKEM768` hybrid & pure ML-KEM key exchange, ML-DSA certificate support, SNI + ALPN + mTLS + live cert reload), **HTTP/2**
   (RFC 9113 + HPACK, **server and client**), **WebSocket** (RFC 6455, **server
   and client**, with **permessage-deflate** compression — RFC 7692),
   reverse proxy with binary-safe streaming. The stack has had a
@@ -197,7 +202,7 @@ platform-specific shims.
   streaming SSE + tool-use deltas).
 - **ext/packaging** — `semver`, `manifest`, `lockfile`, `resolver`,
   `registry_index`, `pkg_fetch`, `pkg_publish` (the `nurlpkg` backend).
-- **ext/misc** — `compress` (zlib/zstd/gzip), `zip` (archives), `tar`, `uuid` (v4/v7),
+- **ext/misc** — `compress` (pure zlib/zstd/gzip), `zip` (archives), `tar`, `uuid` (v4/v7),
   `credentials`, `env`.
 - **dist/distributed systems** — secure pubkey-addressed p2p overlay, STUN,
   NAT traversal, DERP relay, SWIM membership, state-based CRDTs (PN-Counter,

--- a/docs/CRYPTO.md
+++ b/docs/CRYPTO.md
@@ -38,6 +38,8 @@ All sources live in `stdlib/std/`.
 | RSA | `rsa` (PKCS#1 v1.5 verify, PSS verify + sign) | built on `bigint` |
 | Bignum | `bigint` | sign-magnitude, schoolbook mul / long division, `modpow`, `modinv` |
 | X.509 | `x509`, `tls_verify`, `x509_gen` | DER parser + chain/host/policy verification; generates self-signed P-256 and ML-DSA certificates |
+| CSR | `csr` | PKCS#10 (RFC 2986) parser, generator (ECDSA P-256, Ed25519), self-signature verifier (ECDSA P-256, Ed25519, RSA, ML-DSA), and CA certificate issuance |
+| JWT | `ext/jwt`, `ext/http_jwt` | HS256, EdDSA (Ed25519), ES256 (ECDSA P-256 + SHA-256, RFC 7518 §3.1), HTTP bearer-auth middleware |
 | TLS | `tls` (client, 1.3 + 1.2 fallback), `tls_server` (1.3) | record layer, key schedule, handshake; the client offers `X25519MLKEM768` first |
 | Randomness | `random` (CSPRNG), `rng` (xoshiro256\*\*, **not** crypto) | |
 | Constant-time | `subtle` | length-independent secret comparison |


### PR DESCRIPTION
## Why

Prepare release v0.45.0 of NURL and its toolchain. This release delivers major standard library, post-quantum cryptography, compression, database, and PKI ecosystem enhancements accumulated since v0.44.2.

## What

- **`CHANGELOG.md`**: Cut release `[0.45.0] — 2026-08-18` documenting all additions and improvements since v0.44.2:
  - `std/csr`: PKCS#10 Certificate Signing Requests (RFC 2986) parser, generator (ECDSA P-256, Ed25519), self-signature verifier (ECDSA P-256, Ed25519, RSA, ML-DSA), PEM encoding/decoding, and CA issuance from CSR.
  - `ext/jwt` & `ext/http_jwt`: ES256 (ECDSA P-256 + SHA-256) signing/verification (RFC 7518 §3.1) and HTTP bearer-auth middleware.
  - `packages/pki-server` (v0.2.0): Pure-NURL Private PKI Certificate Authority and Service with Zero-Trust CSR enrollment (`POST /request-csr`), device lifecycle management, RFC 5280 CRL generation, and Web UI.
  - `std/slhdsa`: SLH-DSA (FIPS 205) stateless hash-based post-quantum digital signatures (SHAKE and SHA-2 parameter sets).
  - Post-quantum stack performance optimizations (12–29% speedup across ML-KEM and ML-DSA).
  - `HashML-DSA` (FIPS 204 §5.4) and SHA-224, SHA-512/224, SHA-512/256 variants.
  - Post-quantum TLS 1.3: `X25519MLKEM768` hybrid & pure ML-KEM key exchange, ML-DSA certificates and full post-quantum handshake.
  - `std/mlkem`: ML-KEM (FIPS 203) at 512/768/1024 parameter sets.
  - `std/mldsa`: ML-DSA (FIPS 204) at 44/65/87 parameter sets.
  - `std/hash_sha3`: SHA-3 and SHAKE128/256 (FIPS 202).
  - `std/zstd` & `packages/zst`: Pure-NURL Zstandard (RFC 8878) decompressor and compressor up to level 19 optimal parser, zero libzstd dependency.
  - `packages/lsmdb`: Pure-NURL embedded, crash-safe LSM-tree key/value database.
  - `core/io` & `std/fs`: `write_bytes`, `read_all_stdin_bytes`, `file_sync`, `dir_sync`, `file_truncate`.
- **`ROADMAP.md`**: Updated current release to 0.45.0, updated stdlib crypto, PKI, compression, IO and web stack inventory.
- **`docs/CRYPTO.md`**: Added `std/csr` and `ext/jwt` (ES256) entries to the cryptographic inventory table.

## Proof

```text
==> ./compiler/tests/run_tests.sh
PASS 844 · FAIL 0 · MISSING 0 · ORPHAN 0 · SKIP 23  (jobs=12)
TESTS PASSED

==> ./compiler/tests/csr_openssl_gate.sh
--> Test 1: OpenSSL verifying NURL-generated ECDSA P-256 CSR... verify OK
--> Test 2: OpenSSL verifying NURL-generated Ed25519 CSR... verify OK
--> Test 3: NURL verifying OpenSSL-generated ECDSA CSR... VERIFY_OK
--> Test 4: NURL verifying OpenSSL-generated Ed25519 CSR... VERIFY_OK
==========================================
  ALL CSR OPENSSL INTEROP TESTS PASSED!   
==========================================

==> ./packages/pki-server/tests/pki_test.sh
--> Test 10: POST /request-csr (PKCS#10 CSR issuance)
    OpenSSL CSR cert verification: OK (Zero Trust issuance verified)
==================================================
  ALL E2E INTEGRATION TESTS PASSED SUCCESSFULLY!  
==================================================
```

## Known remaining

Release git tag `v0.45.0` will be cut and pushed after this PR is merged to `main` and main CI is green.
