### PR TITLE
fix: unikernel link warnings, json_float integral drift, stale vec_get workaround notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`nurlfmt` no longer breaks a `simd @` declaration across lines** — the
   formatter glues the prefix to its decl-starter exactly as it does `pub`.
 
+- **`json_float` keeps the float-ness in the text: `85.0` serialises as
+  `85.0`, not `85`.** An integral double printed as bare digits, which a
+  strictly typed consumer reads back as an integer field — real schema
+  drift the moment an ETL value lands on a whole number. Digits-only
+  raw text now gets `.0` appended; fractional, exponent and non-finite
+  forms pass through untouched. The fix propagates to every JNum
+  producer built on it: a CBOR half-float `1.0` now stringifies as
+  `1.0` (the old golden had baked the bug in as `1`). Pinned by
+  `compiler/tests/json_float_integral.nu`.
+
+- **The unikernel build is warning-clean again.** Three link-stage
+  warnings, one of them living on borrowed time: the initfs data
+  object was built with `ld -r -b binary`, which emits no
+  `.note.GNU-stack` section, so GNU ld assumed an executable stack and
+  warned the assumption will be removed from future linkers. x86 now
+  embeds the archive the way arm64/riscv64 always did — a generated
+  `.S` with `.incbin` and an explicit empty GNU-stack note — which
+  also names the symbols directly instead of the objcopy rename dance
+  (and drops the dead `_size` symbol nothing read). The `.ll` compile
+  gets `-Wno-override-module` (nurlc emits no triple; same silencing
+  as every other driver), and the redundant `-no-pie` clang 18 warns
+  about is gone from the unikernel and nolibc links — `-static`
+  already implies it.
+
+- **The stdlib's `vec_get`-miscompile workaround notes were three
+  months stale — the compiler bug they cite was fixed 2026-05-14.**
+  `http_multipart`, `http_router` and `http_response` still documented
+  "multi-field `vec_get` miscompiles" / "multi-field structs can't
+  ride `! T E` Ok arms" as live facts (http_request.nu's twin note was
+  already updated). Both shapes verified correct today — including the
+  exact String+String+closure struct the router note feared, the
+  4-field owned struct multipart uses, and the out-of-range
+  None default-construction path the comments blamed — clean under
+  ASan+LSan, and pinned by `compiler/tests/vec_get_multifield.nu`.
+  The pointer iteration stays (it is the zero-copy borrow); the
+  comments now say why honestly.
+
 ## [0.45.0] — 2026-08-18
 
 ### Added

--- a/compiler/tests/json_float_integral.nu
+++ b/compiler/tests/json_float_integral.nu
@@ -1,0 +1,19 @@
+$ `stdlib/ext/json.nu`
+
+@ show s label Json j → v {
+    : String out ( json_stringify j )
+    ( printf `%s: %s\n` label ( string_data out ) )
+    ( string_free out )
+    ( json_free j )
+}
+
+@ main → i {
+    ( show `integral` ( json_float 85.0 ) )
+    ( show `neg integral` ( json_float -3.0 ) )
+    ( show `zero` ( json_float 0.0 ) )
+    ( show `fractional` ( json_float 2.5 ) )
+    ( show `exponent` ( json_float 1.0e300 ) )
+    ( show `tiny` ( json_float 0.001 ) )
+    ( show `neg fractional` ( json_float -0.25 ) )
+    ^ 0
+}

--- a/compiler/tests/outputs-windows/cbor.txt
+++ b/compiler/tests/outputs-windows/cbor.txt
@@ -23,11 +23,11 @@ false: false
 true: true
 null: null
 undef: null
-half_1.0: 1
+half_1.0: 1.0
 half_1.5: 1.5
-half_neg4: -4
-half_0: 0
-single_100000: 100000
+half_neg4: -4.0
+half_0: 0.0
+single_100000: 100000.0
 double_1.1: 1.1
 double_pi: 3.141592653589793
 bytestring: unsupported

--- a/compiler/tests/outputs/cbor.txt
+++ b/compiler/tests/outputs/cbor.txt
@@ -23,11 +23,11 @@ false: false
 true: true
 null: null
 undef: null
-half_1.0: 1
+half_1.0: 1.0
 half_1.5: 1.5
-half_neg4: -4
-half_0: 0
-single_100000: 100000
+half_neg4: -4.0
+half_0: 0.0
+single_100000: 100000.0
 double_1.1: 1.1
 double_pi: 3.141592653589793
 bytestring: unsupported

--- a/compiler/tests/outputs/json_float_integral.txt
+++ b/compiler/tests/outputs/json_float_integral.txt
@@ -1,0 +1,11 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+integral: 85.0
+neg integral: -3.0
+zero: 0.0
+fractional: 2.5
+exponent: 1e+300
+tiny: 0.001
+neg fractional: -0.25

--- a/compiler/tests/outputs/vec_get_multifield.txt
+++ b/compiler/tests/outputs/vec_get_multifield.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+owned: beta len=2
+owned oob: None
+closure: POST /b h(4)=40
+closure oob: None
+ok arm: ayy bee 7

--- a/compiler/tests/vec_get_multifield.nu
+++ b/compiler/tests/vec_get_multifield.nu
@@ -1,0 +1,61 @@
+// vec_get / ! T E with MULTI-FIELD payloads — the shapes the HTTP
+// stdlib modules worked around by pointer iteration until 2026-05-14,
+// when the multi-field Option Some-arm boxing fix shipped. This test
+// pins the fix: a Vec element type with several fields (owned Strings,
+// a Vec, a closure) must survive the vec_get copy + ?? unwrap, and a
+// multi-field struct must ride an ! T E Ok arm. The out-of-range arm
+// exercises the None default-construction path the old workaround
+// comments blamed.
+$ `stdlib/core/string.nu`
+$ `stdlib/core/vec.nu`
+
+: MPart {
+    String name
+    String filename
+    String content_type
+    ( Vec u ) data
+}
+
+: CRoute { String method String pattern ( @ i i ) handler }
+
+: Wide { String a String b i c }
+
+@ mk_part s nm i nbytes → MPart {
+    : ( Vec u ) d ( vec_new [u] )
+    : ~ i k 0
+    ~ < k nbytes { ( vec_push [u] d # u + 65 k ) = k + k 1 }
+    ^ @ MPart { ( string_from nm ) ( string_from `f.txt` ) ( string_from `text/plain` ) d }
+}
+
+@ free_part MPart p → v {
+    ( string_free . p name ) ( string_free . p filename )
+    ( string_free . p content_type ) ( vec_free [u] . p data )
+}
+
+@ mk_wide s x → !Wide s {
+    ^ @ !Wide s { T @ Wide { ( string_from x ) ( string_from `bee` ) 7 } }
+}
+
+@ main → i {
+    : ( Vec MPart ) v ( vec_new [MPart] )
+    ( vec_push [MPart] v ( mk_part `alpha` 4 ) )
+    ( vec_push [MPart] v ( mk_part `beta` 2 ) )
+    : ?MPart g ( vec_get [MPart] v 1 )
+    ?? g { T p → ( printf `owned: %s len=%d\n` ( string_data . p name ) ( vec_len [u] . p data ) ) F _ → ( puts `miss` ) }
+    : ?MPart g9 ( vec_get [MPart] v 9 )
+    ?? g9 { T _ → ( puts `BUG oob hit` ) F _ → ( puts `owned oob: None` ) }
+    ( vec_free_with [MPart] v \ MPart p → v { ( free_part p ) } )
+
+    : ( Vec CRoute ) rs ( vec_new [CRoute] )
+    ( vec_push [CRoute] rs @ CRoute { ( string_from `GET` ) ( string_from `/a` ) \ i x → i { + x 1 } } )
+    ( vec_push [CRoute] rs @ CRoute { ( string_from `POST` ) ( string_from `/b` ) \ i x → i { * x 10 } } )
+    : ?CRoute rg ( vec_get [CRoute] rs 1 )
+    ?? rg { T r → { : ( @ i i ) h . r handler ( printf `closure: %s %s h(4)=%d\n` ( string_data . r method ) ( string_data . r pattern ) ( h 4 ) ) } F _ → ( puts `miss` ) }
+    : ?CRoute rg9 ( vec_get [CRoute] rs 99 )
+    ?? rg9 { T _ → ( puts `BUG oob hit` ) F _ → ( puts `closure oob: None` ) }
+    ( vec_free_with [CRoute] rs \ CRoute r → v { ( string_free . r method ) ( string_free . r pattern ) } )
+
+    : !Wide s w ( mk_wide `ayy` )
+    ?? w { T ww → { ( printf `ok arm: %s %s %d\n` ( string_data . ww a ) ( string_data . ww b ) . ww c ) ( string_free . ww a ) ( string_free . ww b ) } F e → ( puts e ) }
+    ^ 0
+}

--- a/stdlib/ext/http_multipart.nu
+++ b/stdlib/ext/http_multipart.nu
@@ -103,8 +103,13 @@ $ `stdlib/ext/http_request.nu`
 // Linear scan returning the first index where the part's `name`
 // matches `target` (case-sensitive — form fields keep their wire
 // casing). -1 when no part matches. Caller pulls the part out via
-// `vec_data [MultipartPart]` + pointer indexing (the multi-field
-// `vec_get [MultipartPart]` default-construction path miscompiles).
+// `vec_data [MultipartPart]` + pointer indexing. (Historical note:
+// this used to be forced — the multi-field `vec_get` default-
+// construction path miscompiled before the Option Some-arm boxing fix
+// shipped 2026-05-14; `compiler/tests/vec_get_multifield.nu` pins the
+// fixed behaviour on exactly this struct shape. The pointer view is
+// kept because it also skips a per-iteration copy of four owned
+// fields, same as http_request.nu's header_get.)
 @ multipart_find_first ( Vec MultipartPart ) parts s target → i {
     : i n ( vec_len [MultipartPart] parts )
     : *MultipartPart data ( vec_data [MultipartPart] parts )

--- a/stdlib/ext/http_response.nu
+++ b/stdlib/ext/http_response.nu
@@ -59,15 +59,17 @@
 //     bytes; nothing is moved. The transition Connection: close is
 //     not implied — caller manages keep-alive separately.
 //
-// Notes on inherited language gaps:
+// Notes on formerly-inherited language gaps (fixed 2026-05-14 by the
+// multi-field payload boxing fix; `compiler/tests/vec_get_multifield.nu`
+// pins both):
 //
-//   * Multi-field structs can't ride `! T E` Ok arms. `response_*`
-//     constructors return HttpResponse directly (it's a pure
-//     allocation, no failure mode). Streaming helpers DO use
-//     `! v NetErr` because `v` (i64-fits) and `NetErr` (enum) both
-//     ride the encoding fine.
-//   * `vec_get [Header]` miscompiles for multi-field Header. Iteration
-//     over headers uses `vec_data` + `*Header` direct-pointer access.
+//   * Multi-field structs ride `! T E` Ok arms fine now. `response_*`
+//     constructors still return HttpResponse directly because it's a
+//     pure allocation with no failure mode, not because the encoding
+//     couldn't carry it. Streaming helpers use `! v NetErr` as before.
+//   * `vec_get [Header]` is compiler-correct now. Iteration over
+//     headers keeps `vec_data` + `*Header` direct-pointer access for
+//     the zero-copy borrow (same as http_request.nu's `header_get`).
 
 $ `stdlib/std/net.nu`
 $ `stdlib/std/bytes.nu`
@@ -277,7 +279,8 @@ $ `stdlib/ext/json.nu`
 }
 
 // Case-insensitive header presence check. Direct *Header iteration —
-// see http_request.nu's note re. the `vec_get [Header]` miscompile.
+// a zero-copy borrow, not a workaround; see http_request.nu's note
+// (the old `vec_get [Header]` miscompile was fixed 2026-05-14).
 @ __has_header_ci ( Vec Header ) hs s name → b {
     : i n ( vec_len [Header] hs )
     : *Header hdata ( vec_data [Header] hs )

--- a/stdlib/ext/http_router.nu
+++ b/stdlib/ext/http_router.nu
@@ -59,15 +59,20 @@
 //     a fresh closure handle. The caller owns the resulting closure
 //     identically to a hand-written one — no extra cleanup.
 //
-// Notes on inherited language gaps:
+// Notes on formerly-inherited language gaps (both fixed 2026-05-14 by
+// the multi-field payload boxing fix; `compiler/tests/
+// vec_get_multifield.nu` pins both — including the exact String,
+// String, closure shape Route had then):
 //
-//   * Multi-field structs can't ride `! T E` Ok arms. `router_handle`
-//     can't fail (it always either dispatches or 404s) so it returns
-//     HttpResponse directly.
-//   * `vec_get [Route]` would miscompile for a multi-field Route
-//     (String, String, closure). Iteration uses `vec_data + *Route`
-//     direct-pointer access, mirroring the convention from
-//     `http_request.nu`'s `header_get`.
+//   * Multi-field structs ride `! T E` Ok arms fine now.
+//     `router_handle` still returns HttpResponse directly, but because
+//     it can't fail (it always either dispatches or 404s), not because
+//     the encoding couldn't carry it.
+//   * `vec_get [Route]` is compiler-correct now (and Route is a
+//     single-field handle these days anyway). Iteration keeps
+//     `vec_data + *Route` direct-pointer access for the zero-copy
+//     borrow, mirroring the convention from `http_request.nu`'s
+//     `header_get`.
 //   * Route-level middleware (per-route filter chain) would need a
 //     `Vec[Middleware]` of closure-handle-shaped structs, which the
 //     current generic instantiator handles awkwardly. The handler-level

--- a/stdlib/ext/json.nu
+++ b/stdlib/ext/json.nu
@@ -172,6 +172,24 @@ $ `stdlib/core/vec.nu`
 @ json_float f x → Json {
     : s raw ( nurl_str_float x )
     : String s ( string_from raw )
+    // An integral double prints as bare digits (`85.0` → `85`), which a
+    // strictly typed consumer reads as an integer field — real schema
+    // drift when the value happens to land on a whole number. Keep the
+    // float-ness in the text: when the raw form is digits (with an
+    // optional leading `-`) and nothing else, append `.0`. Anything
+    // with a `.`, an exponent, or a non-finite spelling (inf/nan)
+    // already reads as a float and passes through untouched.
+    : i n ( nurl_str_len raw )
+    : *u bp # *u raw
+    : ~ b plain > n 0
+    : ~ i k 0
+    ~ < k n {
+        : i c # i . bp k
+        : b ok | != 0 ( is_digit c ) & == c 45 == k 0
+        ? ok {} { = plain F }
+        = k + k 1
+    }
+    ? plain { ( string_push_str s `.0` ) } {}
     ^ @ Json { JNum s }
 }
 

--- a/unikernel/build_nolibc.sh
+++ b/unikernel/build_nolibc.sh
@@ -73,8 +73,10 @@ for f in start_x86_64 setjmp_x86_64; do
     "$CC" -c "$NOLIBC/$f.S" -o "$OUTDIR/nl_$f.o"
 done
 
-# 5. Link with no libc, no crt, no dynamic loader.
-"$CC" -nostdlib -static -no-pie -o "$OUT" \
+# 5. Link with no libc, no crt, no dynamic loader. (No -no-pie:
+# -static already makes the driver skip -pie, and clang 18 warns the
+# flag is unused here.)
+"$CC" -nostdlib -static -o "$OUT" \
       "$OUTDIR/$base.o" "$OUTDIR/runtime_core.o" "$OUTDIR/runtime_ctx.o" \
       "$OUTDIR/runtime_bare.o" "$OUTDIR"/nl_*.o
 

--- a/unikernel/build_unikernel.sh
+++ b/unikernel/build_unikernel.sh
@@ -154,7 +154,10 @@ NURL_NETDEV="$ROOT/unikernel/net/netdev_virtio.nu" \
 # compile_nu.sh leaves a hosted-flavoured object; recompile the IR with
 # the kernel flags. `zig cc` drops -O for .ll inputs (#644) and plain
 # clang needs the target flags spelled out for IR input too.
-$CC $KFLAGS -c "$OUTDIR/$base.ll" -o "$OUTDIR/$base.o"
+# -Wno-override-module: nurlc emits no target triple, so clang announces
+# it is supplying one — on every build, with nothing to act on (same
+# silencing as nurl.sh and the arm64/riscv64 scripts).
+$CC $KFLAGS -Wno-override-module -c "$OUTDIR/$base.ll" -o "$OUTDIR/$base.o"
 
 # The baked-in filesystem: a directory becomes a tar, and the tar
 # becomes an object with two symbols around it. With no --fs the
@@ -165,17 +168,31 @@ $CC $KFLAGS -c "$OUTDIR/$base.ll" -o "$OUTDIR/$base.o"
 if [ -n "$FSDIR" ]; then
     tar cf "$OUTDIR/$base.initfs.tar" -C "$FSDIR" .
 fi
-( cd "$OUTDIR" && ld -r -b binary -o "$base.initfs_data.o" "$base.initfs.tar" )
-# `ld -b binary` names its symbols after the path it was given; rename
-# them to something a C file can declare without knowing that path.
-sym="$(printf '%s' "$base.initfs.tar" | tr -c 'A-Za-z0-9' '_')"
-objcopy \
-    --redefine-sym "_binary_${sym}_start=nurl_initfs_start" \
-    --redefine-sym "_binary_${sym}_end=nurl_initfs_end" \
-    --redefine-sym "_binary_${sym}_size=nurl_initfs_size_sym" \
-    "$OUTDIR/$base.initfs_data.o"
+# The archive becomes an object with two symbols around it — the same
+# .incbin spelling the arm64/riscv64 scripts use, rather than the old
+# `ld -r -b binary` + objcopy rename dance. Two things this buys: the
+# symbols are named directly instead of renamed after the path, and the
+# .S can declare an empty .note.GNU-stack section — `ld -b binary`
+# emits no such note, and a final link containing one note-less object
+# makes GNU ld assume an executable stack and warn that the assumption
+# is deprecated. (@progbits: x86 as uses '@' as the type sigil where
+# ARM/RISC-V use '%'.)
+cat > "$OUTDIR/$base.initfs.S" <<EOF
+    .section .rodata
+    .globl nurl_initfs_start
+    .globl nurl_initfs_end
+    .align 8
+nurl_initfs_start:
+    .incbin "$OUTDIR/$base.initfs.tar"
+nurl_initfs_end:
+    .section .note.GNU-stack, "", @progbits
+EOF
+$CC $KFLAGS -c "$OUTDIR/$base.initfs.S" -o "$OUTDIR/$base.initfs_data.o"
 
-$CC -nostdlib -static -no-pie -Wl,-T,"$BOOT/link.ld" -Wl,--build-id=none \
+# No -no-pie: -static already makes the driver skip -pie, and clang 18
+# warns the flag is unused on exactly this line. The custom link.ld
+# owns the layout either way.
+$CC -nostdlib -static -Wl,-T,"$BOOT/link.ld" -Wl,--build-id=none \
     -o "$OUT" \
     "$CACHE/boot.o" "$OUTDIR/$base.o" \
     "$CACHE/runtime_core.o" "$CACHE/runtime_ctx.o" "$CACHE/runtime_bare.o" \


### PR DESCRIPTION
Three small fixes:

## 1. Unikernel link stage is warning-clean

The serious one: the initfs data object was built with `ld -r -b binary`, which emits no `.note.GNU-stack` section — GNU ld assumes an executable stack and warns that this behaviour **will be removed from future linkers**. x86 now embeds the archive the way arm64/riscv64 always did: a generated `.S` with `.incbin` and an explicit empty GNU-stack note. This also names `nurl_initfs_start/end` directly instead of the objcopy rename dance (and drops the dead `_size` symbol nothing read).

Also: `-Wno-override-module` on the `.ll` compile (same silencing as every other driver), and the redundant `-no-pie` removed from the unikernel + nolibc links (`-static` already implies it; clang 18 warned it unused).

Verified locally: zero warnings, EXEC entry intact, initfs span exact with and without `--fs` (0 bytes empty / 10240 with a file, content embedded). QEMU boot gates run in CI (no qemu on this box).

## 2. `json_float` keeps float-ness in the text

`json_float 85.0` serialised as `"85"` — valid JSON, but a strictly typed consumer reads it back as an integer field: real schema drift in an ETL context. Digits-only raw text now gets `.0` appended; fractional (`2.5`), exponent (`1e+300`) and non-finite forms pass through untouched.

The fix propagates to every JNum producer built on it — a decoded CBOR half-float `1.0` now stringifies as `"1.0"` (the old cbor golden had baked the bug in as `1`; wire-typed floats staying floats is the correct round-trip). Pinned by `compiler/tests/json_float_integral.nu`.

## 3. Stale `vec_get`-miscompile workaround notes

`http_multipart`, `http_router` and `http_response` documented "multi-field `vec_get` miscompiles" / "multi-field structs can't ride `! T E` Ok arms" as live facts — the compiler bug they cite was fixed **2026-05-14** (`http_request.nu`'s twin note was already updated back then; these three weren't).

Both shapes verified correct today: the 4-field owned struct multipart uses, the exact String+String+closure shape the router note feared, the out-of-range None default-construction path the comments blamed, and a multi-field `! T E` Ok arm — all correct, clean under ASan+LSan, and now pinned by `compiler/tests/vec_get_multifield.nu` so the claim can never go stale-in-reverse. The pointer iteration itself stays: it's the zero-copy borrow, and the comments now say so honestly.

## Validation

- `./build.sh`: full corpus **851/851 PASS** (incl. two new regression tests)
- cbor golden updated with the corrected float round-trip
- unikernel: warning count 3 → 0, ELF verified statically; CI QEMU gates cover boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CSENqvFreiyzrt6EpXiEN