### PR TITLE
perf(tls,runtime): TLS handshake and record-path speedups — https C=1 and cold-handshake work

### DIFF
--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -3982,7 +3982,13 @@ static int nurl__reactor_wait(int fd, short events, long long timeout_ms) {
      * from registration on. */
     if (fd >= 0 &&
         __atomic_load_n(&nurl__sched.pending, __ATOMIC_RELAXED) <= 4) {
-        for (int i = 0; i < 64; i++) {
+        /* 256 probes ≈ 80-250 µs: sized for a TLS peer's turnaround
+         * (decrypt + handle + encrypt ≈ 35-45 µs on loopback), which
+         * the previous 64-probe window (~25 µs) missed — every
+         * keep-alive HTTPS request then paid the full park/wake chain
+         * even at c=1 with idle cores. The ≤4-live-fibers gate above
+         * still keeps loaded servers off this path entirely. */
+        for (int i = 0; i < 256; i++) {
             if (__atomic_load_n(&w->rq_len, __ATOMIC_RELAXED) > 0) break;
             if (__atomic_load_n(&nurl__sched.global_head,
                                 __ATOMIC_RELAXED)) break;

--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -759,7 +759,17 @@ typedef struct NurlTcp {
      * this copy is for the fiber path, which cannot use SO_RCVTIMEO —
      * it parks on the reactor instead, and has to be told how long. */
     long long     timeout_ms;
+    /* SO_RCVTIMEO/SO_SNDTIMEO not yet pushed to the kernel. Set by
+     * nurl_tcp_set_timeout, consumed by the first BLOCKING read/write:
+     * a fiber-served connection never blocks, so eagerly issuing the
+     * two setsockopt() calls there was two wasted syscalls on every
+     * accepted connection (the fiber path reads timeout_ms directly). */
+    int           timeo_dirty;
 } NurlTcp;
+
+/* Defined next to nurl_tcp_set_timeout below; used by the blocking
+ * read/write paths to apply a deferred timeout. */
+static void nurl__tcp_apply_timeo(NurlTcp *h);
 
 /* Wake the async reactor (if running) so it re-polls. Called after a fd is
  * closed: a fiber parked on that fd would otherwise never wake (poll does
@@ -1289,6 +1299,7 @@ long long nurl_tcp_read(long long handle, const char *buf, long long n) {
         h->err_kind = NURL_NET_ERR_READ;
         return -1;
     }
+    if (h->timeo_dirty && !h->nonblock) nurl__tcp_apply_timeo(h);
 #ifdef _WIN32
     int rd = recv(h->fd, (char*)buf, (n > 0x40000000 ? 0x40000000 : (int)n), 0);
 #else
@@ -1323,6 +1334,7 @@ long long nurl_tcp_write(long long handle, const char *buf, long long n) {
         h->err_kind = NURL_NET_ERR_WRITE;
         return -1;
     }
+    if (h->timeo_dirty && !h->nonblock) nurl__tcp_apply_timeo(h);
     long long total = 0;
     /* SO_SNDTIMEO (set by nurl_tcp_set_timeout for the keep-alive idle
      * deadline) also caps every blocking send(): when a SLOW-BUT-ALIVE
@@ -1562,10 +1574,14 @@ long long nurl_tcp_timeout_ms(long long handle) {
     return h ? h->timeout_ms : 0;
 }
 
-void nurl_tcp_set_timeout(long long handle, long long ms) {
-    NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
-    if (!h || h->fd == NURL_INVALID_SOCK) return;
-    h->timeout_ms = ms > 0 ? ms : 0;
+/* Push the stored timeout to the kernel socket options. Only a BLOCKING
+ * read/write needs SO_RCVTIMEO/SO_SNDTIMEO (a non-blocking socket
+ * returns EAGAIN regardless and the fiber path parks on the reactor
+ * with timeout_ms), so nurl_tcp_set_timeout defers this until the first
+ * blocking operation actually happens — see timeo_dirty. */
+static void nurl__tcp_apply_timeo(NurlTcp *h) {
+    long long ms = h->timeout_ms;
+    h->timeo_dirty = 0;
 #ifdef _WIN32
     /* Win32 SO_RCVTIMEO is a DWORD of ms (not a timeval). */
     DWORD tv = (ms > 0) ? (DWORD)ms : 0;
@@ -1585,6 +1601,13 @@ void nurl_tcp_set_timeout(long long handle, long long ms) {
     setsockopt(h->fd, SOL_SOCKET, SO_RCVTIMEO, &tv, (socklen_t)sizeof(tv));
     setsockopt(h->fd, SOL_SOCKET, SO_SNDTIMEO, &tv, (socklen_t)sizeof(tv));
 #endif
+}
+
+void nurl_tcp_set_timeout(long long handle, long long ms) {
+    NurlTcp *h = (NurlTcp*)(uintptr_t)handle;
+    if (!h || h->fd == NURL_INVALID_SOCK) return;
+    h->timeout_ms = ms > 0 ? ms : 0;
+    h->timeo_dirty = 1;
 }
 
 /* ── §18b  UDP sockets (dual-stack IPv4/IPv6 + multicast) ──────── */

--- a/stdlib/std/ecdsa_p256.nu
+++ b/stdlib/std/ecdsa_p256.nu
@@ -318,7 +318,7 @@ $ `stdlib/std/p256_scalar.nu`  // fixed-width GF(n) for the signing scalar arith
 //
 // The table is affine (x‖y, 32-byte big-endian each), converted to
 // Montgomery projective once per call. Verified against k·G in Python.
-@ __p256_comb_tbl_hex → s { ^ `6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f50fa822bc2811aaa58492592e326e25de29493baaad651f7e90e75cb48e14db63bff44ae8f5dba80d6f4ad4bcb3df188b34b1a65050fe82f5e41124545f462ee7300a4bbc89d6726fb257c0de95e02789e96c98fd0d35f1fa93391ce2097992af72aac7e0d09b46447f1ddb25ff1e3c6f5bb1eeada9d806a5aa54a291c08127a0447d739beedb5e67fb982fd588c6766efc35ff7dc297eac357c84fc9d789bd852d4825ab834131eee12e9d953a4aaff73d349b95a7fae5000c7e33c972e25b32ef9519328a9c72ffddc6068bb91dfc60ef7fbd2b1a0a11b713949c932a1d367f611e9fc37dbb2c9bc1ee9807022c219c23183b0895ca1740196035a77376d8a8550663797b51f5d87dea6482e11238bf2936df5ec6c9bc36cae2b1920b57f4bc157164848aecb8510afa40018d9d50e59fb3d576dbdefbe144ffe216348a964ceb5d7745b21141eaa2e8f483f43e43917ccd84e70d715f26e48ecafffc5cde01eafd72ebdbecc17b0990e6a158006cee85f22cfe2844b645cac917e2731a3479a6d39677a78492762736ff8344315fc596439591a3c6b94a6cf20ffb313728be674f84749b0b881666b8babd2d27ecdf824a920c2284059bf2bab833c357f5f44e769e7672c9ddad31855f7db8c7fedb74e02f080203a56b2df48c04677c8a3e42b99082de8306631ec0057206947281fb9ae16f3b9122a5a4c36165b824bbb078878ef61c6ce04d7fdc1ca008a1c478d1f89e799c0ce1316ef95150dda868b9b6cb3f5d7b72c321de53142c12309def6ace570ebde08d4f9c62b9121fe0d9760c88bc4d716b1287595c5220812ffcae5b82dd5bd54fb4967f991ed2c31a3573dd5ddea3f3901dc618d1b5b39c04e6aa7c8181f4df2564f33a57bf635f48aca868f344af6b317466efe0a423083e49f343a0a28c42ba792fe96a79fb3e72ad0c31b9c405f8540a20604ed93c24d67ff3668bfc2271f5c626cdfe17db3fb24d4a4052bf4b6f461db9663c62c3edbad7a00d1a10144ec39c28d36b4789a2582e7ffecf4d5190b0fc61862be6bd71d70cc8e724f33999bfcc5b235a27c3188d25eb1eddbae2c802e41a123202a8f62bff7aafdf5cc08526a7a474346c10a1d4cfac43104d86560ebcfc0c45f45273db33a036e06b7e4c7019178fa0af2dd603f844b48e26b484f7a21c0a4a46fb6aaf363a66b0de3225c4744b9615b5110d1d78e5fac015404d4d3dab64131bcdfed6f668c004e4048b7b0f9806ebb0f621a01b2d` }
+@ __p256_comb_tbl_hex → s { ^ `6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f57fe36b40af22af8921656b32262c71da1ab919365c65dfb63a5a9e22185a5943e697d45825b636249f09f40407dca6f174b3d5867b8af212d50d152c699ca101e35798220cedc02a608548c24aa7358f830895e4fccc3ac216fc51ff8101e6e4700f948e1f433a2df3e4b396768a3299f0570bedc523e6efaad2b99852c392c30fa822bc2811aaa58492592e326e25de29493baaad651f7e90e75cb48e14db63bff44ae8f5dba80d6f4ad4bcb3df188b34b1a65050fe82f5e41124545f462ee7300a4bbc89d6726fb257c0de95e02789e96c98fd0d35f1fa93391ce2097992af72aac7e0d09b46447f1ddb25ff1e3c6f5bb1eeada9d806a5aa54a291c08127a014cb5692606a4a62a9cad33b680a7daae0d3eb336c224571d6e260f8ee4039a053098cfa3e1e4663878487ed997a9a3b5205ef8d8039927cfe93d3159d83bc01a5ab9e10958f1608c22c48c5ffea17c1585a137ef5c4ad4230368cb6d945111ed3ebc6118b1aa09a629e17ebad0648f446ed771c49a10f77c34a47b8785b4ed94a5b506612a677a657880b3a18a2e902e9a521b074ca0141a84aa9397512218eeb13461ceac089f1c42604fbe1627d40626db15419e26d9d0beada7a4c4f3840418d68dea064219700d1a0a5fd208dfb48f9c1875e98c12dc761c1fecc0497865d7b26f6a5ba6dd4435639622ef8d32017429c50c16caad0481eef5551b507590781b8291c6a220ac342967aa815c8575e52c4144103ecbcf9faed0927a43281690cde8df015159397b2a14f1291643488f80eeee54a05e35a8343ceeac55f8057f62eeca7b5d4fb54a0fe5274647ebe82d789a6dd561becc52c00cae38e38205e5ff8bf89bfe2ad60e9c067efea8f480d300594ec356dceaa60759d48f8146091c821d488e9843c27035d2627caa74754d5dad9289944395920d7b0fa3289d5db7aecc78f879f44919adc3734938dac7b7df6ea0408ebade130dead9aa8a56606f0afdb90422d81c9c6f5415bf70c35eddf9c6c7e1c792ebc499ee7c6fae6d777f9e8f73f9804c47bab8955dde6464641a7cf1aaf7ae617214f0ad04dbc747abc07bb82d6536c0292052d44bcdf6567f0698ff75e4ec9655d01a765c96900d8eb165f9c1d90902aa17bf29fc7b19a1e635f210ec2e7ba735fe58ccf83762c71e018aaa22086a46c269843f16b47957bd86848c84760c41eaf972b45f2159928383f4db07f10ee50f2fe8863ba0dbc83d36d88b34fed7bb921a0332299698420447d739beedb5e67fb982fd588c6766efc35ff7dc297eac357c84fc9d789bd852d4825ab834131eee12e9d953a4aaff73d349b95a7fae5000c7e33c972e25b328a535f566ec73617f5622df4373713269e4c35874afdf43aaee9c75df7f82f2a0455c08468b08bd737e02819085a92bfcde533864c8c7669c5f9a0ac223094b7ff25f55a2c214cd923fe7442010729acef8bf285dfd6c3f34193640bfbb7f12d94f114d38a40510000c15ba774a58d771a08ebc72ab82b74d77bf411f30f0fc8a6d39677a78492762736ff8344315fc596439591a3c6b94a6cf20ffb313728be674f84749b0b881666b8babd2d27ecdf824a920c2284059bf2bab833c357f5f468f344af6b317466efe0a423083e49f343a0a28c42ba792fe96a79fb3e72ad0c31b9c405f8540a20604ed93c24d67ff3668bfc2271f5c626cdfe17db3fb24d4a0ac9835f0e6155faeb3df8bf9d6b4a9b60ff39edff736545270a098d637d797dd6882b263d00d534d8ac7b195c6872b2fa24f7333fe89b0850c04b69640bc0e96a25fb201b4084ce8a404541b1f23d69561d30f51dc2d82e7b3068d03765581e5a0aebfc19cfb424f5763393d06a40071e15941a5cf443d550180e1b6020632968f6b8542783dfeeeb5b06e70ce08ffefd75f3fa01876bd86a703f10e895df07cbe1feba92e40ce6fbc8044dfda45028cf5293d2f310bf7f90c76f8a78712655bd6058b07b81568e83fb2d63c62cd05550d19d86abc96fedcc38452ef202481af78e1fbef8467e379ee514e409ef7dd9c51419ed83f257d4628271f170737bb6e51f547c5972a107b422d1e7bd6f85147ed031a0e45c2258eee44b35702476b51c309a2b25bb1387a62f98b3a9fe9a068ca922ee097c184ea25bcd6fc9cf343d86699898a60bcd7758e0a73c3879d7d86da147f00d75821e9baf4d7aaac4170ac0d84aeca4b075f432ca235d2af12355428dede80187f877ae7cd4da598a46ebfb0249aa28a8a8fbb7fbe79e03e042ea3478e062311cb1f3dceafeb7328fb9ef172f46339c5fbc3e48e514e109aa13a20e540e9f3d15281350b4bb44b8ee1b8bebc3d35e8855a59acbbd5f2012ca3c26846730ad139ad48c2ffbcf19dc0b10615290bec161ce30304b3c37853fe325890da658f5f8f4be3a18644a975b93e742a176c395ae64d73870e00c7531905283d7768c940d8a6fb01e3081abb7f6be1f9ebdec88947b45f151ab984b9feeea5c087565ce611fe5069e5850bc1fa3578c681d6be2b2567ac59de1e8e76080e0f8dadf6dcec6ad55f11bcb36a57bca0bc11dfcab92c48087f3263f2166cf14e1b02a6a766ee58790f1deb1edd4763f4fcb` }
 
 // 32 big-endian bytes at offset `off` → eight little-endian 2^32 limbs.
 @ __p256_be32_to_limbs ( Vec u ) src i off → ( Vec i ) {
@@ -335,6 +335,63 @@ $ `stdlib/std/p256_scalar.nu`  // fixed-width GF(n) for the signing scalar arith
     ^ out
 }
 
+// One-time (per process) Montgomery-form comb tables, cached in two
+// globals. Building them — the hex parse plus 60 to-Montgomery
+// multiplies plus the limb conversions — used to run on EVERY
+// p256ct_scalarmult_base call, i.e. every ECDSA sign and every P-256
+// ECDH keygen: measurable as bytes_from_hex showing up inside the TLS
+// handshake profile. The tables are public constants (multiples of G),
+// so caching leaks no secret. Benign init race: two first callers may
+// both build; one pointer wins each global, the losing copy leaks 3 KB
+// once — an acceptable one-time cost against a lock on every
+// signature.
+//
+// Two tables because the comb has EIGHT teeth split as two 4-tooth
+// halves (see p256ct_scalarmult_base): T1 covers scalar bits
+// {i, i+32, i+64, i+96}, T2 covers {i+128, …, i+224}.
+: ~ i g_p256_comb_tbl 0
+: ~ i g_p256_comb_tbl2 0
+
+@ __p256_comb_build → v {
+    : P256Scratch scr ( _p256_scr_new )
+    : ( Vec u ) tbytes ?? ( bytes_from_hex ( __p256_comb_tbl_hex ) ) { T v → v F _ → ( vec_new [u] ) }
+    : P256Pt tmp ( _p256_pt_mag )
+    : ~ i t 0
+    ~ < t 2 {
+        : ( Vec i ) tbl ( _magn 384 )
+        ( _p256_set_identity_d scr tmp )
+        ( _p256_tbl_put tbl 0 tmp )
+        : ~ i s 1
+        ~ < s 16 {
+            // T1 points sit at blob offsets 0‥14·64, T2 at 15·64‥29·64.
+            : i off * + * t 15 - s 1 64
+            : ( Vec i ) xl ( __p256_be32_to_limbs tbytes off )
+            : ( Vec i ) yl ( __p256_be32_to_limbs tbytes + off 32 )
+            ( _p256_to_mont_d scr . tmp x xl )
+            ( _p256_to_mont_d scr . tmp y yl )
+            ( _p256_one_mont_d scr . tmp z )
+            ( _p256_tbl_put tbl s tmp )
+            ( vec_free [i] xl ) ( vec_free [i] yl )
+            = s + s 1
+        }
+        ? == t 0 { = g_p256_comb_tbl # i . tbl ctl } { = g_p256_comb_tbl2 # i . tbl ctl }
+        = t + t 1
+    }
+    ( vec_free [u] tbytes )
+    ( p256pt_free tmp )
+    ( _p256_scr_free scr )
+}
+
+@ __p256_comb_tbl_mont → ( Vec i ) {
+    ? == g_p256_comb_tbl 0 { ( __p256_comb_build ) } {}
+    ^ @ ( Vec i ) { # s g_p256_comb_tbl }
+}
+
+@ __p256_comb_tbl2_mont → ( Vec i ) {
+    ? == g_p256_comb_tbl2 0 { ( __p256_comb_build ) } {}
+    ^ @ ( Vec i ) { # s g_p256_comb_tbl2 }
+}
+
 // scalar · G → 64 bytes X‖Y, constant-time fixed-base comb.
 @ p256ct_scalarmult_base ( Vec u ) kbytes → ( Vec u ) {
     : P256Scratch scr ( _p256_scr_new )
@@ -342,40 +399,40 @@ $ `stdlib/std/p256_scalar.nu`  // fixed-width GF(n) for the signing scalar arith
     : ( Vec i ) am ( _p256_to_mont_s scr aplain ) ( vec_free [i] aplain )
     : ( Vec i ) b3plain ( _p256_b3_plain )
     : ( Vec i ) b3m ( _p256_to_mont_s scr b3plain ) ( vec_free [i] b3plain )
-    : ( Vec u ) tbytes ?? ( bytes_from_hex ( __p256_comb_tbl_hex ) ) { T v → v F _ → ( vec_new [u] ) }
-    : ( Vec i ) tbl ( _magn 384 )
+    // Shared, lazily-built tables of G multiples — BORROWED from the
+    // global cache; must not be freed here.
+    : ( Vec i ) tbl1 ( __p256_comb_tbl_mont )
+    : ( Vec i ) tbl2 ( __p256_comb_tbl2_mont )
     : P256Pt acc ( _p256_pt_mag )
     ( _p256_set_identity_d scr acc )
-    ( _p256_tbl_put tbl 0 acc )
-    : P256Pt tmp ( _p256_pt_mag )
-    : ~ i s 1
-    ~ < s 16 {
-        : i off * - s 1 64
-        : ( Vec i ) xl ( __p256_be32_to_limbs tbytes off )
-        : ( Vec i ) yl ( __p256_be32_to_limbs tbytes + off 32 )
-        ( _p256_to_mont_d scr . tmp x xl )
-        ( _p256_to_mont_d scr . tmp y yl )
-        ( _p256_one_mont_d scr . tmp z )
-        ( _p256_tbl_put tbl s tmp )
-        ( vec_free [i] xl ) ( vec_free [i] yl )
-        = s + s 1
-    }
-    ( vec_free [u] tbytes )
-    ( _p256_set_identity_d scr acc )
     : P256Pt selp ( _p256_pt_mag )
-    : ~ i i 63
+    // Eight-tooth Lim–Lee comb as two 4-tooth halves: iteration i
+    // (31‥0) doubles once, then adds T1[bits i,i+32,i+64,i+96] and
+    // T2[bits i+128,…,i+224]. 32 doublings + 64 additions, against the
+    // 4-tooth layout's 64 + 64 — the doubling half of the work gone
+    // for one more 3 KB public table. Same constant-time properties:
+    // fixed trip count, masked table scans, complete additions (digit
+    // 0 reads the identity, which the formula absorbs).
+    : ~ i i 31
     ~ >= i 0 {
         ( p256ct_padd_d scr acc acc acc am b3m )
-        : ~ i idx 0
+        : ~ i idx1 0
+        : ~ i idx2 0
         : ~ i j 0
         ~ < j 4 {
-            : i bitpos + * 64 j i
-            : i byteidx - 31 >> bitpos 3
-            : i bit & 1 >> ?? ( vec_get [u] kbytes byteidx ) { T b → # i b F _ → 0 } & bitpos 7
-            = idx | idx << bit j
+            : i bp1 + * 32 j i
+            : i by1 - 31 >> bp1 3
+            : i b1 & 1 >> ?? ( vec_get [u] kbytes by1 ) { T b → # i b F _ → 0 } & bp1 7
+            = idx1 | idx1 << b1 j
+            : i bp2 + 128 bp1
+            : i by2 - 31 >> bp2 3
+            : i b2 & 1 >> ?? ( vec_get [u] kbytes by2 ) { T b → # i b F _ → 0 } & bp2 7
+            = idx2 | idx2 << b2 j
             = j + j 1
         }
-        ( _p256_tbl_get_d selp tbl idx )
+        ( _p256_tbl_get_d selp tbl1 idx1 )
+        ( p256ct_padd_d scr acc acc selp am b3m )
+        ( _p256_tbl_get_d selp tbl2 idx2 )
         ( p256ct_padd_d scr acc acc selp am b3m )
         = i - i 1
     }
@@ -388,8 +445,8 @@ $ `stdlib/std/p256_scalar.nu`  // fixed-width GF(n) for the signing scalar arith
     : ( Vec u ) out ( vec_with_cap [u] 64 )
     ( _p256_limbs_to_be out . acc x )
     ( _p256_limbs_to_be out . acc y )
-    ( p256pt_free acc ) ( p256pt_free tmp ) ( p256pt_free selp )
-    ( vec_free [i] tbl ) ( vec_free [i] am ) ( vec_free [i] b3m ) ( vec_free [i] zinv )
+    ( p256pt_free acc ) ( p256pt_free selp )
+    ( vec_free [i] am ) ( vec_free [i] b3m ) ( vec_free [i] zinv )
     ( _p256_scr_free scr )
     ^ out
 }

--- a/stdlib/std/hash_sha256.nu
+++ b/stdlib/std/hash_sha256.nu
@@ -253,6 +253,22 @@ $ `stdlib/std/bytes.nu`
     ^ out
 }
 
+// Digest-so-far WITHOUT consuming the stream: clones the running state
+// and finalises the clone; `h` stays live and can keep absorbing. This
+// is what an incremental transcript hash needs — TLS 1.3 reads the
+// transcript digest at five points while the transcript keeps growing,
+// and re-hashing the whole transcript from scratch at each point costs
+// ~5× the bytes this pays.
+@ sha256_snapshot * Sha256 h → ( Vec u ) {
+    : *Sha256 c # *Sha256 ( nurl_alloc Z Sha256 )
+    = . c state ( vec_clone [u32] . h state )
+    = . c buf ( vec_clone [u] . h buf )
+    = . c total . h total
+    = . c k ( vec_clone [u32] . h k )
+    = . c m ( vec_clone [u32] . h m )
+    ^ ( sha256_final c )
+}
+
 // One-shot over the streaming core.
 @ sha256_pure ( Vec u ) data → ( Vec u ) {
     : *Sha256 h ( sha256_init )

--- a/stdlib/std/tls.nu
+++ b/stdlib/std/tls.nu
@@ -272,9 +272,15 @@ $ `stdlib/std/async_ffi.nu`
     : b on_fiber != ( nurl_fiber_current ) 0
     ? on_fiber { ( nurl_tcp_set_nonblock raw 1 ) } {}
     ~ < ( vec_len [u] . c rxbuf ) n {
-        : ( Vec u ) tmp ( vec_with_cap [u] 16384 )
-        : *u p ( vec_data [u] tmp )
-        : s pbuf # s p
+        // Read straight into rxbuf's spare capacity — the previous
+        // per-fill 16 KB scratch Vec + copy-append + free was pure
+        // overhead on the record hot path (once per record read, i.e.
+        // once per keep-alive HTTPS request). Capacity settles at
+        // ~len+16 K and is reused for the connection's lifetime.
+        ( vec_reserve [u] . c rxbuf 16384 )
+        : i len ( vec_len [u] . c rxbuf )
+        : *u p ( vec_data [u] . c rxbuf )
+        : s pbuf # s + # i p len
         : ~ i got ( nurl_tcp_read raw pbuf 16384 )
         : ~ b timed_out F
         ~ & ! timed_out & on_fiber & < got 0 == ( nurl_tcp_err_kind raw ) 7 {
@@ -282,22 +288,25 @@ $ `stdlib/std/async_ffi.nu`
                 = got ( nurl_tcp_read raw pbuf 16384 )
             } { = timed_out T }
         }
-        ? < got 0 { ( vec_free [u] tmp ) ^ @ !i TlsErr { F # TlsErr TlsRead } } {}
-        ? == got 0 { ( vec_free [u] tmp ) ^ @ !i TlsErr { F # TlsErr TlsClosed } } {}
-        : b _ok ( vec_set_len [u] tmp got )
-        ( _tls_cat . c rxbuf tmp )
-        ( vec_free [u] tmp )
+        ? < got 0 { ^ @ !i TlsErr { F # TlsErr TlsRead } } {}
+        ? == got 0 { ^ @ !i TlsErr { F # TlsErr TlsClosed } } {}
+        : b _ok ( vec_set_len [u] . c rxbuf + len got )
     }
     ^ @ !i TlsErr { T 1 }
 }
 
-// Drop the first `n` bytes of rxbuf (consume them).
+// Drop the first `n` bytes of rxbuf (consume them). In place: shift the
+// tail down and shrink len — the old slice-copy allocated (and freed) a
+// fresh Vec per consumed record. The tail is empty in the common case
+// (one record per read), so the memmove is usually zero bytes.
 @ __consume * TlsConn c i n → v {
-    : ( Vec u ) old . c rxbuf
-    : i total ( vec_len [u] old )
-    : ( Vec u ) rest ( bytes_slice old n total )
-    ( vec_free [u] old )
-    = . c rxbuf rest
+    : ( Vec u ) buf . c rxbuf
+    : i total ( vec_len [u] buf )
+    ? >= n total { ( vec_clear [u] buf ) ^ v } {}
+    : i remaining - total n
+    : *u p ( vec_data [u] buf )
+    ( nurl_memmove # s p # s # *u + # i p n remaining )
+    : b _ok ( vec_set_len [u] buf remaining )
 }
 
 // Record = type(1) ver(2) length(2) body. Returns (type, body); body is

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -347,16 +347,21 @@ $ `stdlib/std/aes_gcm.nu`
     = . c kx_group 0
     = . c alpn_sel ( vec_new [u] )
 
-    : ( Vec u ) tr ( vec_new [u] )
+    // Incremental transcript hash: absorb each handshake message as it
+    // is appended and SNAPSHOT the digest at the checkpoints, instead of
+    // accumulating a transcript Vec and re-hashing it from scratch at
+    // every checkpoint (~4.3 KB hashed per handshake where ~1.3 KB
+    // suffices).
+    : *Sha256 trh ( sha256_init )
 
     // ── ClientHello ──
     : !( Vec u ) TlsErr chr ( __srv_next_hs c )
     : ( Vec u ) ch ?? chr { T m → m F _ → ( vec_new [u] ) }
     ? | == ( vec_len [u] ch ) 0 != ( _t_bget ch 0 ) 1 {
-        ( vec_free [u] ch ) ( vec_free [u] tr ) ( nurl_free # s c )
+        ( vec_free [u] ch ) ( __trh_abort trh ) ( nurl_free # s c )
         ^ ( __srv_fail raw )
     } {}
-    ( _tls_cat tr ch )
+    ( sha256_update trh ch )
 
     : ( Vec u ) crand ( bytes_slice ch 6 38 )
     : i sidlen ( _t_bget ch 38 )
@@ -398,7 +403,7 @@ $ `stdlib/std/aes_gcm.nu`
     // key_share (0x0033): pick x25519 (0x001d) if offered, else secp256r1.
     : i ks ( __srv_find_ext ch es ee 51 )
     ? < ks 0 {
-        ( vec_free [u] ch ) ( vec_free [u] crand ) ( vec_free [u] tr ) ( nurl_free # s c )
+        ( vec_free [u] ch ) ( vec_free [u] crand ) ( __trh_abort trh ) ( nurl_free # s c )
         ^ ( __srv_fail raw )
     } {}
     : i kslen ( _rdint ch ks 2 )  // client_shares length (first 2 bytes of ext body)
@@ -437,7 +442,7 @@ $ `stdlib/std/aes_gcm.nu`
     } {}
     = kp ksend
     ? == grp 0 {
-        ( vec_free [u] ch ) ( vec_free [u] crand ) ( vec_free [u] cpub ) ( vec_free [u] tr ) ( nurl_free # s c )
+        ( vec_free [u] ch ) ( vec_free [u] crand ) ( vec_free [u] cpub ) ( __trh_abort trh ) ( nurl_free # s c )
         ^ ( __srv_fail raw )
     } {}
 
@@ -485,7 +490,8 @@ $ `stdlib/std/aes_gcm.nu`
     // H3: RFC 8446 §7.4.2 — reject a degenerate (all-zero) ECDHE secret from a
     // low-order client key_share before it can seed the key schedule.
     ? ( _all_zero ecdhe ) {
-        ( __srv_cleanup_accept ch crand cpub eph spub ecdhe ( vec_new [u] ) ( vec_new [u] ) tr )
+        ( __srv_cleanup_accept ch crand cpub eph spub ecdhe ( vec_new [u] ) ( vec_new [u] ) )
+        ( __trh_abort trh )
         ( nurl_free # s c ) ^ ( __srv_fail raw )
     } {}
 
@@ -500,7 +506,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) flight ( vec_with_cap [u] 2048 )
     : ( Vec u ) srand ( __srv_rand 32 )
     : ( Vec u ) sh ( __srv_build_sh srand ch sidlen suite grp spub )
-    ( _tls_cat tr sh )
+    ( sha256_update trh sh )
     ( __srv_plain_rec_to flight 22 sh )
 
     // optional CCS for middlebox compatibility
@@ -516,7 +522,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) early ( hkdf_extract empty z32 )
     : ( Vec u ) derived1 ( derive_secret early `derived` ehash )
     : ( Vec u ) hs_secret ( hkdf_extract derived1 ecdhe )
-    : ( Vec u ) th_sh ( sha256_pure tr )
+    : ( Vec u ) th_sh ( sha256_snapshot trh )
     : ( Vec u ) c_hs ( derive_secret hs_secret `c hs traffic` th_sh )
     : ( Vec u ) s_hs ( derive_secret hs_secret `s hs traffic` th_sh )
     ( _set_keys c 0 s_hs )  // server write keys
@@ -529,7 +535,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) eebody ( vec_new [u] )
     ( _tls_u16 eebody 0 )
     : ( Vec u ) ee ( __srv_hs_wrap 8 eebody )
-    ( _tls_cat tr ee )
+    ( sha256_update trh ee )
     ( __srv_enc_rec_to c flight 22 ee )
     ( vec_free [u] eebody )
 
@@ -542,26 +548,26 @@ $ `stdlib/std/aes_gcm.nu`
     ( _u24 certbody ( vec_len [u] cert_chain ) )  // certificate_list length
     ( _tls_cat certbody cert_chain )
     : ( Vec u ) certmsg ( __srv_hs_wrap 11 certbody )
-    ( _tls_cat tr certmsg )
+    ( sha256_update trh certmsg )
     ( __srv_enc_rec_to c flight 22 certmsg )
     ( vec_free [u] certbody )
 
     // ── CertificateVerify ──
-    : ( Vec u ) th_cert ( sha256_pure tr )
+    : ( Vec u ) th_cert ( sha256_snapshot trh )
     : ( Vec u ) cvc ( __srv_cv_content th_cert )
     : ( Vec u ) cvdig ( sha256_pure cvc )
     : ( Vec u ) cvbody ( __srv_cv_body keytype ec_priv rsa_n rsa_e rsa_d cvdig cvc ml_level )
     : ( Vec u ) cvmsg ( __srv_hs_wrap 15 cvbody )
-    ( _tls_cat tr cvmsg )
+    ( sha256_update trh cvmsg )
     ( __srv_enc_rec_to c flight 22 cvmsg )
     ( vec_free [u] th_cert ) ( vec_free [u] cvc ) ( vec_free [u] cvdig )
     ( vec_free [u] cvbody )
 
     // ── server Finished ──
-    : ( Vec u ) th_cv ( sha256_pure tr )
+    : ( Vec u ) th_cv ( sha256_snapshot trh )
     : ( Vec u ) sfin ( _finished_mac s_hs th_cv )
     : ( Vec u ) sfmsg ( __srv_hs_wrap 20 sfin )
-    ( _tls_cat tr sfmsg )
+    ( sha256_update trh sfmsg )
     ( __srv_enc_rec_to c flight 22 sfmsg )
     // The complete first flight, one send().
     : b fw ( _tls_sock_write . c fd flight )
@@ -571,7 +577,7 @@ $ `stdlib/std/aes_gcm.nu`
     ( vec_free [u] sfin )
 
     // ── application keys (transcript through server Finished) ──
-    : ( Vec u ) th_sf ( sha256_pure tr )
+    : ( Vec u ) th_sf ( sha256_final trh )
     : ( Vec u ) c_ap ( derive_secret master `c ap traffic` th_sf )
     : ( Vec u ) s_ap ( derive_secret master `s ap traffic` th_sf )
 
@@ -597,7 +603,7 @@ $ `stdlib/std/aes_gcm.nu`
     ( vec_free [u] ch ) ( vec_free [u] crand ) ( vec_free [u] cpub ) ( vec_free [u] eph )
     ( vec_free [u] spub ) ( vec_free [u] ecdhe ) ( vec_free [u] srand ) ( vec_free [u] sh )
     ( vec_free [u] ee ) ( vec_free [u] certmsg ) ( vec_free [u] cvmsg ) ( vec_free [u] sfmsg )
-    ( vec_free [u] tr ) ( vec_free [u] z32 ) ( vec_free [u] empty ) ( vec_free [u] ehash )
+    ( vec_free [u] z32 ) ( vec_free [u] empty ) ( vec_free [u] ehash )
     ( vec_free [u] early ) ( vec_free [u] derived1 ) ( vec_free [u] hs_secret ) ( vec_free [u] th_sh )
     ( vec_free [u] c_hs ) ( vec_free [u] s_hs ) ( vec_free [u] derived2 ) ( vec_free [u] master )
     ( vec_free [u] th_sf ) ( vec_free [u] c_ap ) ( vec_free [u] s_ap )
@@ -651,10 +657,15 @@ $ `stdlib/std/aes_gcm.nu`
     ^ r
 }
 
-@ __srv_cleanup_accept ( Vec u ) ch ( Vec u ) crand ( Vec u ) cpub ( Vec u ) eph ( Vec u ) spub ( Vec u ) ecdhe ( Vec u ) srand ( Vec u ) sh ( Vec u ) tr → v {
+@ __srv_cleanup_accept ( Vec u ) ch ( Vec u ) crand ( Vec u ) cpub ( Vec u ) eph ( Vec u ) spub ( Vec u ) ecdhe ( Vec u ) srand ( Vec u ) sh → v {
     ( vec_free [u] ch ) ( vec_free [u] crand ) ( vec_free [u] cpub ) ( vec_free [u] eph )
     ( vec_free [u] spub ) ( vec_free [u] ecdhe ) ( vec_free [u] srand ) ( vec_free [u] sh )
-    ( vec_free [u] tr )
+}
+
+// Discard a live transcript hasher (error paths).
+@ __trh_abort * Sha256 h → v {
+    : ( Vec u ) d ( sha256_final h )
+    ( vec_free [u] d )
 }
 
 @ __srv_rand i n → ( Vec u ) {

--- a/stdlib/std/tls_server.nu
+++ b/stdlib/std/tls_server.nu
@@ -52,8 +52,12 @@ $ `stdlib/std/aes_gcm.nu`
 
 // ── server-direction record I/O ─────────────────────────────────────
 
-// Encrypt + send one record under the SERVER write keys (s_key/s_iv/s_seq).
-@ __srv_send_enc * TlsConn c i content_type ( Vec u ) content → !v TlsErr {
+// Encrypt one record under the SERVER write keys (s_key/s_iv/s_seq) and
+// APPEND its wire bytes to `out` — no socket write. The handshake path
+// batches its whole first flight (SH‥Finished) into one buffer and one
+// send() through this; __srv_send_enc below wraps it for the callers
+// that do want an immediate write (application data, alerts).
+@ __srv_enc_rec_to * TlsConn c ( Vec u ) out i content_type ( Vec u ) content → v {
     : ( Vec u ) inner ( vec_with_cap [u] + ( vec_len [u] content ) 1 )
     ( _tls_cat inner content )
     ( vec_push [u] inner # u content_type )
@@ -65,19 +69,34 @@ $ `stdlib/std/aes_gcm.nu`
     ( _tls_u16 aad total )
     : ( Vec u ) nonce ( _nonce . c s_iv . c s_seq )
     : ( Vec u ) sealed ( _aead_seal . c cipher . c s_key nonce aad inner )
-    : ( Vec u ) rec ( vec_with_cap [u] + total 5 )
-    ( vec_push [u] rec # u 23 )
-    ( vec_push [u] rec # u 3 )
-    ( vec_push [u] rec # u 3 )
-    ( _tls_u16 rec total )
-    ( _tls_cat rec sealed )
-    : b w ( _tls_sock_write . c fd rec )
+    ( vec_push [u] out # u 23 )
+    ( vec_push [u] out # u 3 )
+    ( vec_push [u] out # u 3 )
+    ( _tls_u16 out total )
+    ( _tls_cat out sealed )
     ( vec_free [u] inner )
     ( vec_free [u] aad )
     ( vec_free [u] nonce )
     ( vec_free [u] sealed )
-    ( vec_free [u] rec )
     = . c s_seq + . c s_seq 1
+}
+
+// Append one PLAINTEXT record (rtype, body) to `out` — the unencrypted
+// ServerHello / CCS legs of the batched first flight.
+@ __srv_plain_rec_to ( Vec u ) out i rtype ( Vec u ) body → v {
+    ( vec_push [u] out # u rtype )
+    ( vec_push [u] out # u 3 )
+    ( vec_push [u] out # u 3 )
+    ( _tls_u16 out ( vec_len [u] body ) )
+    ( _tls_cat out body )
+}
+
+// Encrypt + send one record under the SERVER write keys (s_key/s_iv/s_seq).
+@ __srv_send_enc * TlsConn c i content_type ( Vec u ) content → !v TlsErr {
+    : ( Vec u ) rec ( vec_new [u] )
+    ( __srv_enc_rec_to c rec content_type content )
+    : b w ( _tls_sock_write . c fd rec )
+    ( vec_free [u] rec )
     ^ ? w @ !v TlsErr { T 0 } @ !v TlsErr { F # TlsErr TlsWrite }
 }
 
@@ -471,20 +490,23 @@ $ `stdlib/std/aes_gcm.nu`
     } {}
 
     // ── ServerHello ──
+    // The whole first flight — SH, CCS, EE, Certificate, CertificateVerify,
+    // server Finished — is batched into `flight` and leaves in ONE send()
+    // after the Finished is built. Six separate writes cost six syscalls
+    // and six client-side wakeups per handshake; one flight is also what
+    // rustls/OpenSSL put on the wire. A write failure surfaces exactly
+    // like any torn handshake: the client-Finished read below fails and
+    // the handshake ends in TlsHandshake.
+    : ( Vec u ) flight ( vec_with_cap [u] 2048 )
     : ( Vec u ) srand ( __srv_rand 32 )
     : ( Vec u ) sh ( __srv_build_sh srand ch sidlen suite grp spub )
     ( _tls_cat tr sh )
-    : !v TlsErr shw ( _send_plain c 22 sh )
-    ?? shw { T _ → {} F _ → {
-            ( __srv_cleanup_accept ch crand cpub eph spub ecdhe srand sh tr )
-            ( nurl_free # s c ) ^ ( __srv_fail raw )
-        } }
+    ( __srv_plain_rec_to flight 22 sh )
 
     // optional CCS for middlebox compatibility
     : ( Vec u ) ccs ( vec_with_cap [u] 1 )
     ( vec_push [u] ccs # u 1 )
-    : !v TlsErr _ccw ( _send_plain c 20 ccs )
-    ?? _ccw { T _ → {} F _ → {} }
+    ( __srv_plain_rec_to flight 20 ccs )
     ( vec_free [u] ccs )
 
     // ── key schedule (handshake) ──
@@ -508,8 +530,7 @@ $ `stdlib/std/aes_gcm.nu`
     ( _tls_u16 eebody 0 )
     : ( Vec u ) ee ( __srv_hs_wrap 8 eebody )
     ( _tls_cat tr ee )
-    : !v TlsErr eew ( __srv_send_enc c 22 ee )
-    ?? eew { T _ → {} F _ → {} }
+    ( __srv_enc_rec_to c flight 22 ee )
     ( vec_free [u] eebody )
 
     // ── Certificate ──
@@ -522,8 +543,7 @@ $ `stdlib/std/aes_gcm.nu`
     ( _tls_cat certbody cert_chain )
     : ( Vec u ) certmsg ( __srv_hs_wrap 11 certbody )
     ( _tls_cat tr certmsg )
-    : !v TlsErr cw ( __srv_send_enc c 22 certmsg )
-    ?? cw { T _ → {} F _ → {} }
+    ( __srv_enc_rec_to c flight 22 certmsg )
     ( vec_free [u] certbody )
 
     // ── CertificateVerify ──
@@ -533,8 +553,7 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) cvbody ( __srv_cv_body keytype ec_priv rsa_n rsa_e rsa_d cvdig cvc ml_level )
     : ( Vec u ) cvmsg ( __srv_hs_wrap 15 cvbody )
     ( _tls_cat tr cvmsg )
-    : !v TlsErr cvw ( __srv_send_enc c 22 cvmsg )
-    ?? cvw { T _ → {} F _ → {} }
+    ( __srv_enc_rec_to c flight 22 cvmsg )
     ( vec_free [u] th_cert ) ( vec_free [u] cvc ) ( vec_free [u] cvdig )
     ( vec_free [u] cvbody )
 
@@ -543,8 +562,11 @@ $ `stdlib/std/aes_gcm.nu`
     : ( Vec u ) sfin ( _finished_mac s_hs th_cv )
     : ( Vec u ) sfmsg ( __srv_hs_wrap 20 sfin )
     ( _tls_cat tr sfmsg )
-    : !v TlsErr sfw ( __srv_send_enc c 22 sfmsg )
-    ?? sfw { T _ → {} F _ → {} }
+    ( __srv_enc_rec_to c flight 22 sfmsg )
+    // The complete first flight, one send().
+    : b fw ( _tls_sock_write . c fd flight )
+    ( vec_free [u] flight )
+    ? fw {} { ( nurl_eprintln `tls: server flight write failed` ) }
     ( vec_free [u] th_cv )
     ( vec_free [u] sfin )
 


### PR DESCRIPTION
## Why

After #947, the CI bench showed the last C=1 cell going to rustls: **https C=1 10 377 vs 11 844 req/s** — despite NURL winning plaintext C=1 — and cold TLS handshakes at 3 392/s vs rustls 5 010. Goal: win https C=1 and push the cold-handshake rate toward rustls.

## Root causes found and fixed

**The https C=1 loss was latency, not crypto.** CPU-per-request measurement showed NURL's TLS record path is already *cheaper* than rustls (+10 µs/req over plaintext vs rustls' +18 µs). The loss came from the reactor's spin-then-park window: 64 probes (~25 µs) covers a plaintext peer's turnaround but not a TLS peer's (~35–45 µs decrypt+handle+encrypt), so every keep-alive HTTPS request at low concurrency paid the full two-thread park/wake chain. The window is now 256 probes, still gated to ≤ 4 live fibers so loaded servers never spin. **https c=1: 13–15k → 18–20k req/s locally** (p50 0.069 → 0.046 ms); plaintext c=1 also improved (→ 27k in the final sweep); c=10/50/200 cells unchanged.

**Cold handshake, protocol side:**
- The server's first flight (SH/CCS/EE/Cert/CertVerify/Finished) went out as **six separate send()s**; it now leaves in one write, like rustls — new `__srv_enc_rec_to`/`__srv_plain_rec_to` record builders, `__srv_send_enc` wraps them for post-handshake use.
- The TLS 1.3 transcript was **re-hashed from scratch at every checkpoint** (~4.3 KB hashed where 1.3 KB suffices; worse with real cert chains). New `sha256_snapshot` (digest-so-far off a cloned state) makes the transcript incremental.
- `nurl_tcp_set_timeout` issued **two setsockopt() per accepted connection** that fiber-served sockets never use (they park on the reactor with the stored deadline). The options are now applied lazily by the first *blocking* read/write.

**Cold handshake, crypto side:**
- The fixed-base comb tables were **rebuilt on every scalar-mult**: a 1.5 KB hex parse + 30 to-Montgomery multiplies per ECDSA sign / P-256 ECDH keygen. They are now built once per process (lazy, cached in globals).
- The comb itself widened **4 → 8 teeth** (two 4-tooth halves): 32 doublings + 64 complete additions per k·G, against 64 + 64. Table generated by an independent Python implementation (self-verified over 20 random scalars) and KAT-checked 8/8 against the NURL side; same constant-time discipline (fixed trip counts, masked table scans, complete additions). `ecdsa_sign` 210 → 168 µs, `p256_keygen` 172 → 130 µs.
- TLS record read buffering: `__fill` read into a throwaway 16 KB Vec and copy-appended (alloc+copy+free per record), `__consume` sliced the tail into a fresh Vec per record. Now: read in place into `rxbuf` spare capacity, consume by in-place shift. −2–4 µs CPU per keep-alive HTTPS request.

## Measured (local 12-core i7-5930K; CI numbers will come from the bench workflow)

| metric | before (this branch's base) | after | rustls same host |
|---|---:|---:|---:|
| https C=1 keep-alive | 14.9k | **18–20k** | 10.2k |
| cold handshakes/s c=1 | 576 | **705** | 1 751 |
| cold handshakes/s c=20 | 7 079 | **7 664–7 883** | 12 145 |
| server CPU / handshake | ~840 µs | **775 µs** | 332 µs |
| CPU / https request (c=4) | 49 µs | **45 µs** | 59 µs |

The remaining cold-handshake gap to rustls is P-256 arithmetic depth (complete RCB additions on a 8×32-limb-stored field): closing it needs Jacobian-coordinate constant-time formulas with a dedicated Montgomery squaring and 4×64 native storage — follow-up work, scoped in the session notes.

Full suite passes after each commit; TLS client interop tests exercise the transcript/record changes from the peer side, and `async_http_server_tls.nu` covers the fiber TLS path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU