### PR TITLE
fix(nurlpkg): publish gate typechecks against the released toolchain

### DIFF
--- a/tools/nurlpkg/main.nu
+++ b/tools/nurlpkg/main.nu
@@ -293,7 +293,8 @@ $ `stdlib/std/bytes.nu`
 ` )
         ( nurl_print `  2. every deps/... import is declared in [dependencies]
 ` )
-        ( nurl_print `  3. required stdlib symbols exist in the RELEASED toolchain
+        ( nurl_print `  3. every imported stdlib file exists in the RELEASED toolchain, and
+     src/main.nu typechecks against it
 ` )
         ( nurl_print `  4. path-deps carry a version requirement
 ` )
@@ -2448,6 +2449,16 @@ Usage: nurlpkg login   (paste the token from the registry; kept in ~/.nurl/crede
 // stdlib path a package imports must exist in the INSTALLED toolchain's stdlib
 // ($NURL_STDLIB, or ~/.nurl/stdlib), and publishing is refused when one does
 // not, with the release that is missing named.
+//
+// File existence is necessary and NOT sufficient, which the second half of
+// this gate exists to catch. A package can import only stdlib files that have
+// shipped for years and still call a FUNCTION added to one of them last week:
+// pki-server 0.3.0 imports std/fs.nu and std/pkey.nu — both ancient — while
+// calling `set_permissions` and `mldsa_priv_from_pem`, which the released
+// stdlib does not define. Every path existed, the gate passed, and the tarball
+// would have been unbuildable for every user of `nurlpkg install`. Publishing
+// is irreversible, so the check has to be the real one: typecheck `src/main.nu`
+// with the INSTALLED compiler against the INSTALLED stdlib, and believe it.
 @ __scan_stdlib_imports_file s path ( Vec String ) acc → v {
     ?? ( read_file path ) {
         T txt → {
@@ -2588,6 +2599,88 @@ Usage: nurlpkg login   (paste the token from the registry; kept in ~/.nurl/crede
     } {}
     ( string_free root )
     ^ ? > missing 0 1 0
+}
+
+// Typecheck the package's entry point with the toolchain the user will
+// actually install with: front-end only, no link step (nurlc writes IR to
+// stdout, which is discarded), so this needs no C toolchain and costs a
+// fraction of a build.
+//
+// Which toolchain that is comes from __toolchain_stdlib_root — $NURL_STDLIB
+// when set, else ~/.nurl. Pointing $NURL_STDLIB at a checkout therefore aims
+// the gate at that checkout, which is the documented escape hatch for "I am
+// publishing against this tree, not the release" and makes the check pass
+// trivially. That is deliberate; the default, with $NURL_STDLIB unset, is the
+// one that protects users.
+//
+// Two conditions leave the question unanswered rather than answered "yes":
+// no compiler at <root>/bin/nurlc, and a compiler that will not launch. Both
+// WARN on stderr and let the publish through — an unverifiable gate has to say
+// so out loud rather than pass quietly, and refusing would make the tool
+// unusable on a box that has no toolchain installed.
+@ __installed_nurlc String root → String {
+    : String p ( string_from ( string_data root ) )
+    ( string_push_str p ? ( __is_windows ) `/bin/nurlc.exe` `/bin/nurlc` )
+    ? ( file_exists ( string_data p ) ) { ^ p } {}
+    ( string_free p )
+    ^ ( string_new )
+}
+
+@ __check_builds_against_installed → i {
+    ? ! ( file_exists `src/main.nu` ) { ^ 0 } {}
+    : String root ( __toolchain_stdlib_root )
+    ? == 0 ( string_len root ) { ( string_free root ) ^ 0 } {}
+
+    : String cc ( __installed_nurlc root )
+    ? == 0 ( string_len cc ) {
+        ( nurl_eprint `nurlpkg: WARNING — no installed compiler at ` )
+        ( nurl_eprint ( string_data root ) )
+        ( nurl_eprintln `/bin/nurlc, so "does this build against the released toolchain?" went UNCHECKED.` )
+        ( nurl_eprintln `nurlpkg:          Install the toolchain you are targeting before publishing.` )
+        ( string_free cc )
+        ( string_free root )
+        ^ 0
+    } {}
+
+    : String cmd ( string_with_cap 160 )
+    ( string_push_str cmd `NURL_STDLIB=` )
+    ( string_push_str cmd ( string_data root ) )
+    ( string_push_char cmd 32 )
+    ( string_push_str cmd ( string_data cc ) )
+    ( string_push_str cmd ` src/main.nu >/dev/null` )
+
+    : ~ i bad 0
+    ?? ( process_run_shell ( string_data cmd ) ) {
+        T out → {
+            ? ( output_success out ) {} {
+                : s err ( output_stderr out )
+                ( nurl_eprint `nurlpkg: this package does not compile against the INSTALLED toolchain at ` )
+                ( nurl_eprintln ( string_data root ) )
+                ( nurl_eprint err )
+                // Two very different causes land here, and telling the
+                // publisher the wrong one wastes their afternoon: an
+                // unresolved deps/ tree is "run the build first", while
+                // anything else is "the released stdlib is too old".
+                ? > ( nurl_str_find err `cannot open import 'deps/` ) -1 {
+                    ( nurl_eprintln `nurlpkg: deps/ is not resolved in this working tree — run 'nurlpkg build' (or link the` )
+                    ( nurl_eprintln `nurlpkg: path deps) and try again. Nothing about the released toolchain was established.` )
+                } {
+                    ( nurl_eprintln `nurlpkg: every imported stdlib FILE exists there, but something the package calls does not.` )
+                    ( nurl_eprintln `nurlpkg: publishing is irreversible, so this is refused — cut a toolchain release that ships` )
+                    ( nurl_eprintln `nurlpkg: what this needs first, then publish.` )
+                }
+                = bad 1
+            }
+            ( output_free out )
+        }
+        F _ → {
+            ( nurl_eprintln `nurlpkg: WARNING — could not launch the installed compiler; the released-toolchain build went UNCHECKED.` )
+        }
+    }
+    ( string_free cmd )
+    ( string_free cc )
+    ( string_free root )
+    ^ bad
 }
 
 @ __check_declared_deps Manifest m → i {
@@ -2898,6 +2991,10 @@ Usage: nurlpkg login   (paste the token from the registry; kept in ~/.nurl/crede
                     ^ 1
                 } {}
                 ? != 0 ( __check_stdlib_available ) {
+                    ( manifest_free m )
+                    ^ 1
+                } {}
+                ? != 0 ( __check_builds_against_installed ) {
                     ( manifest_free m )
                     ^ 1
                 } {}


### PR DESCRIPTION
`nurlpkg publish --help` claimed gate 3 verified that *"required stdlib symbols exist in the RELEASED toolchain"*. It verified nothing of the sort. It checked that every imported stdlib **file** was present in the installed prefix — and nothing at all about what the package *called* inside those files.

## How that bites

`pki-server` 0.3.0 (#946) imports `stdlib/std/fs.nu` and `stdlib/std/pkey.nu`. Both are years old and present in every release. It also calls `set_permissions` and `mldsa_priv_from_pem`, which were added to those files **in the same PR**. Every imported path existed, every gate passed:

```
$ nurlpkg publish --dry-run
dry-run: would publish pki-server 0.3.0 (147779 bytes, sha256 f4fde610…)
to https://reg.nurl-lang.org/
dry-run: every gate passed; nothing was uploaded.
```

…and the tarball is unbuildable for every user of `nurlpkg install`:

```
$ NURL_STDLIB=~/.nurl ~/.nurl/bin/nurlc src/main.nu
src/pki.nu:721:31: error: unknown type 'MldsaPriv' …
src/pki.nu:830:54: error: call to unknown function 'set_permissions' …
error: aborting due to 5 previous errors
```

Publishing is irreversible — a version can be yanked, never replaced — so a gate that passes here is worse than no gate, because it is trusted.

## The fix

Do the real check rather than a proxy for it: compile `src/main.nu` with the **installed** compiler against the **installed** stdlib, and believe the answer. Front-end only, no link step (the IR goes to `/dev/null`), so it needs no C toolchain and costs a fraction of a build.

Two very different failures land in the same place and want opposite advice, so they are told apart by the compiler's own diagnostic:

- unresolved `deps/` → *"run `nurlpkg build` first — nothing about the released toolchain was established"*
- anything else → *"the released stdlib is too old — cut a toolchain release that ships what this needs, then publish"*

Getting that backwards wastes an afternoon, which is why it is not one generic message.

**Unanswerable is not the same as fine.** No compiler at `<root>/bin/nurlc`, or one that will not launch, WARNs on stderr and lets the publish through rather than passing quietly. Refusing would make the tool unusable on a box with no toolchain installed; passing silently would repeat the original sin.

`$NURL_STDLIB` still aims the gate wherever it points — the documented "I am publishing against this checkout" escape hatch — and the comment now says so plainly, since with it set the check passes trivially. The default, unset, is the one that protects users.

## Verification

| package | expected | result |
| --- | --- | --- |
| `pki-server` | refused, stdlib too old | exit 1, correct diagnosis |
| `objdet` | refused, deps unresolved | exit 1, deps diagnosis |
| `md2html` | publishes | exit 0 |
| `cas` | publishes | exit 0 |
| `image` | publishes | exit 0 |
| `template` | publishes | exit 0 |

`./build.sh` — **BUILD SUCCESS & TESTS PASSED**. `--help` now describes what actually runs.

## Note

This is the gate that was supposed to catch the `packages/audio` incident its own comment describes ("published against a stdlib/std/fft.nu that only existed on main"). It caught that class — a missing *file* — and was blind to the neighbouring one, a missing *symbol* in a file that exists. `pki-server` 0.3.0 remains unpublished pending a toolchain release that ships the two new stdlib functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CSENqvFreiyzrt6EpXiEN
