### PR TITLE
perf(p256): native 4x64 limb storage + Jacobian fixed-base comb

### DIFF
--- a/compiler/tests/outputs/p256_scalarmult_base_kat.txt
+++ b/compiler/tests/outputs/p256_scalarmult_base_kat.txt
@@ -1,0 +1,5 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+scalarmult_base KAT 18/18

--- a/compiler/tests/p256_ct_field.nu
+++ b/compiler/tests/p256_ct_field.nu
@@ -20,11 +20,17 @@ $ `stdlib/std/p256_field.nu`
 
 @ to_limbs BigInt x → ( Vec i ) {
     : ( Vec u ) be ( bigint_to_bytes_be x 32 )
-    : ( Vec i ) out ( vec_with_cap [i] 8 )
+    : ( Vec i ) out ( vec_with_cap [i] 4 )
     : ~ i k 0
-    ~ < k 8 {
-        ( vec_push [i] out | | | ( __bg be - 31 * 4 k ) << ( __bg be - 30 * 4 k ) 8
-        << ( __bg be - 29 * 4 k ) 16 << ( __bg be - 28 * 4 k ) 24 )
+    ~ < k 4 {
+        : i base - 24 * 8 k
+        : ~ u64 acc 0
+        : ~ i j 0
+        ~ < j 8 {
+            = acc | << acc 8 # u64 ( __bg be + base j )
+            = j + j 1
+        }
+        ( vec_push [i] out # i acc )
         = k + k 1
     }
     ( vec_free [u] be ) ^ out
@@ -32,11 +38,14 @@ $ `stdlib/std/p256_field.nu`
 
 @ from_limbs ( Vec i ) v → BigInt {
     : ( Vec u ) be ( vec_with_cap [u] 32 )
-    : ~ i k 7
+    : ~ i k 3
     ~ >= k 0 {
-        : i lk ?? ( vec_get [i] v k ) { T x → x F _ → 0 }
-        ( vec_push [u] be # u & >> lk 24 255 ) ( vec_push [u] be # u & >> lk 16 255 )
-        ( vec_push [u] be # u & >> lk 8 255 ) ( vec_push [u] be # u & lk 255 )
+        : u64 lk # u64 ?? ( vec_get [i] v k ) { T x → x F _ → 0 }
+        : ~ i sh 56
+        ~ >= sh 0 {
+            ( vec_push [u] be # u & # i >> lk sh 255 )
+            = sh - sh 8
+        }
         = k - k 1
     }
     : BigInt r ( bigint_from_bytes_be be ) ( vec_free [u] be ) ^ r

--- a/compiler/tests/p256_scalarmult_base_kat.nu
+++ b/compiler/tests/p256_scalarmult_base_kat.nu
@@ -1,0 +1,51 @@
+// p256_scalarmult_base_kat.nu — fixed-base comb KATs for the Jacobian
+// path (std/ecdsa_p256 p256ct_scalarmult_base). Eighteen scalars, each
+// expected X||Y verified against an independent Python implementation:
+// eight pseudorandom, plus the structured edges that exercise the
+// masked exceptional cases the Jacobian formulas do NOT absorb the way
+// the complete projective ones did — k = 1/2/3 (accumulator starts at
+// infinity, first commits through the inf mask), scalars whose teeth
+// are zero for long runs (the keep mask), single-tooth and
+// tooth-aligned patterns, and n − 1.
+
+$ `stdlib/core/string.nu`
+$ `stdlib/std/bytes.nu`
+$ `stdlib/std/ecdsa_p256.nu`
+
+@ kat_one s schex s exphex → i {
+    : ( Vec u ) sc ?? ( bytes_from_hex schex ) { T v → v F _ → ( vec_new [u] ) }
+    : ( Vec u ) xy ( p256ct_scalarmult_base sc )
+    : String got ( bytes_to_hex xy )
+    : i ok ( nurl_str_eq ( string_data got ) exphex )
+    ? == ok 0 {
+        ( nurl_print `FAIL k=` ) ( nurl_print schex ) ( nurl_print `\n` )
+    } {}
+    ( string_free got ) ( vec_free [u] sc ) ( vec_free [u] xy )
+    ^ ok
+}
+
+@ main → i {
+    : ~ i pass 0
+    = pass + pass ( kat_one `25303b46515c67727d88939ea9b4bfcad5e0ebf6010c17222d38434e59646f7a` `c17a141373231a534196d1a5c9c139bd02298a040f2c373447458fc28e55566f2145b433c2a2df147a8c81fe82fdab2b96d7792ff83c1871eec8abf5f279141b` )
+    = pass + pass ( kat_one `4a55606b76818c97a2adb8c3ced9e4effa05101b26313c47525d68737e89949f` `24da362f506ac17769b2b78f8ab385bef981e9eaf753066873a4c21d6ec23167f6590d799b0c85801c00c0744f81bdf2efb0df166c0753d35abcd47228a1b092` )
+    = pass + pass ( kat_one `6f7a85909ba6b1bcc7d2dde8f3fe09141f2a35404b56616c77828d98a3aeb9c4` `794185b9905e9f2a3a45fc00e20232c3818fe83cd69b3101a5a8441766ceb89858a7461da24e83d7e16548a7fa905f548ad713d2be300445db9f98c34b98f68c` )
+    = pass + pass ( kat_one `949faab5c0cbd6e1ecf7020d18232e39444f5a65707b86919ca7b2bdc8d3dee9` `3afe05c85fe8eb2f3a2c7aa910dc21dcbe4d054733d6400c3ba184be2595a16d4ff87fcc8d6b5ef623b66af03fe0a4cd663e4fa4021cf205bd52409b0e4a969b` )
+    = pass + pass ( kat_one `b9c4cfdae5f0fb06111c27323d48535e69747f8a95a0abb6c1ccd7e2edf8030e` `111d8927ac922d22e5ff5dbe928b189a289e6e7d2c7766c6d53990c1c728987503cc97d2f2c03e72d8ba572cc4ef729df575fc853c57dac0d56ec940d6a32d24` )
+    = pass + pass ( kat_one `dee9f4ff0a15202b36414c57626d78838e99a4afbac5d0dbe6f1fc07121d2833` `b08445863fd3ee622750c4d9f5849e5d15faf642bfaa0c4230a58d6e88ce6bd5cc35acc55fc081a0924886764bedff3799e02258f68fd9e6f0f43a1f7394f9fb` )
+    = pass + pass ( kat_one `030e19242f3a45505b66717c87929da8b3bec9d4dfeaf5000b16212c37424d58` `c7f320d36fb3de7f2365ead7a9b724b18222cf26b04b37a8abe07a2b88392949e49ff23c3428db9bb63090e70bcce60493c7b2ac422c6036c2214040da3b867a` )
+    = pass + pass ( kat_one `28333e49545f6a75808b96a1acb7c2cdd8e3eef9040f1a25303b46515c67727d` `5efe3c91fd8392659a5daa4586d213322facf049ed15ca9fbc9d171c71492c4b28c870ac5872fc22c1e733f5b9a5f1b7cb8b211f2ec8d4a9b1f50c50f04902ff` )
+    = pass + pass ( kat_one `0000000000000000000000000000000000000000000000000000000000000001` `6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5` )
+    = pass + pass ( kat_one `0000000000000000000000000000000000000000000000000000000000000002` `7cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997807775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d1` )
+    = pass + pass ( kat_one `0000000000000000000000000000000000000000000000000000000000000003` `5ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d5032` )
+    = pass + pass ( kat_one `0000000000000000000000000000000100000000000000000000000000000000` `447d739beedb5e67fb982fd588c6766efc35ff7dc297eac357c84fc9d789bd852d4825ab834131eee12e9d953a4aaff73d349b95a7fae5000c7e33c972e25b32` )
+    = pass + pass ( kat_one `0000000000000000000000000000000100000000000000000000000000000001` `ef9519328a9c72ffddc6068bb91dfc60ef7fbd2b1a0a11b713949c932a1d367f611e9fc37dbb2c9bc1ee9807022c219c23183b0895ca1740196035a77376d8a8` )
+    = pass + pass ( kat_one `8000000000000000000000000000000000000000000000000000000000000000` `77b20a912e6b23135066e911891524bc4efe3560e3e92350b52dec8f375f2b54a3dc291825cea3f7f7b10bfcdd038a72df623da1e850e0f1caa801fcd6cc67ff` )
+    = pass + pass ( kat_one `0000000000000000000000000000000000000000000000000000000100000001` `e35798220cedc02a608548c24aa7358f830895e4fccc3ac216fc51ff8101e6e4700f948e1f433a2df3e4b396768a3299f0570bedc523e6efaad2b99852c392c3` )
+    = pass + pass ( kat_one `ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550` `6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a` )
+    = pass + pass ( kat_one `00000000000000000000000000000000000000000000000000000000ffffffff` `618466bcb739585c20c44b7fc962d8671d94867054859361a18293ffe4a720e134587f80988db9bd798cb5da178ec512db9aec2fe35f85e0678b4e91f7c873b4` )
+    = pass + pass ( kat_one `0000000100000001000000010000000100000001000000010000000100000001` `daf3f4f19bf107063b239e560e25bd0dc5f4cef51ee27deb2be3f5f5564efa227ffa38df051194cde06424031e312dcb1bc79c9ebf83cb15788294b55b919a7d` )
+    ( nurl_print `scalarmult_base KAT ` )
+    ( nurl_print ( nurl_str_int pass ) )
+    ( nurl_print `/18\n` )
+    ^ ? == pass 18 0 1
+}

--- a/stdlib/std/ecdsa_p256.nu
+++ b/stdlib/std/ecdsa_p256.nu
@@ -282,19 +282,10 @@ $ `stdlib/std/p256_scalar.nu`  // fixed-width GF(n) for the signing scalar arith
     ^ y
 }
 
-// bigint (0 ≤ x < p, ≤ 256 bits) → 8 little-endian 32-bit plain limbs.
+// bigint (0 ≤ x < p, ≤ 256 bits) → 4 little-endian 64-bit plain limbs.
 @ __big_to_limbs8 BigInt x → ( Vec i ) {
     : ( Vec u ) be ( bigint_to_bytes_be x 32 )
-    : ( Vec i ) out ( vec_with_cap [i] 8 )
-    : ~ i k 0
-    ~ < k 8 {
-        : i b0 ?? ( vec_get [u] be - 31 * 4 k ) { T b → # i b F _ → 0 }
-        : i b1 ?? ( vec_get [u] be - 30 * 4 k ) { T b → # i b F _ → 0 }
-        : i b2 ?? ( vec_get [u] be - 29 * 4 k ) { T b → # i b F _ → 0 }
-        : i b3 ?? ( vec_get [u] be - 28 * 4 k ) { T b → # i b F _ → 0 }
-        ( vec_push [i] out | | | b0 << b1 8 << b2 16 << b3 24 )
-        = k + k 1
-    }
+    : ( Vec i ) out ( __p256_be32_to_limbs be 0 )
     ( vec_free [u] be )
     ^ out
 }
@@ -320,16 +311,21 @@ $ `stdlib/std/p256_scalar.nu`  // fixed-width GF(n) for the signing scalar arith
 // Montgomery projective once per call. Verified against k·G in Python.
 @ __p256_comb_tbl_hex → s { ^ `6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f57fe36b40af22af8921656b32262c71da1ab919365c65dfb63a5a9e22185a5943e697d45825b636249f09f40407dca6f174b3d5867b8af212d50d152c699ca101e35798220cedc02a608548c24aa7358f830895e4fccc3ac216fc51ff8101e6e4700f948e1f433a2df3e4b396768a3299f0570bedc523e6efaad2b99852c392c30fa822bc2811aaa58492592e326e25de29493baaad651f7e90e75cb48e14db63bff44ae8f5dba80d6f4ad4bcb3df188b34b1a65050fe82f5e41124545f462ee7300a4bbc89d6726fb257c0de95e02789e96c98fd0d35f1fa93391ce2097992af72aac7e0d09b46447f1ddb25ff1e3c6f5bb1eeada9d806a5aa54a291c08127a014cb5692606a4a62a9cad33b680a7daae0d3eb336c224571d6e260f8ee4039a053098cfa3e1e4663878487ed997a9a3b5205ef8d8039927cfe93d3159d83bc01a5ab9e10958f1608c22c48c5ffea17c1585a137ef5c4ad4230368cb6d945111ed3ebc6118b1aa09a629e17ebad0648f446ed771c49a10f77c34a47b8785b4ed94a5b506612a677a657880b3a18a2e902e9a521b074ca0141a84aa9397512218eeb13461ceac089f1c42604fbe1627d40626db15419e26d9d0beada7a4c4f3840418d68dea064219700d1a0a5fd208dfb48f9c1875e98c12dc761c1fecc0497865d7b26f6a5ba6dd4435639622ef8d32017429c50c16caad0481eef5551b507590781b8291c6a220ac342967aa815c8575e52c4144103ecbcf9faed0927a43281690cde8df015159397b2a14f1291643488f80eeee54a05e35a8343ceeac55f8057f62eeca7b5d4fb54a0fe5274647ebe82d789a6dd561becc52c00cae38e38205e5ff8bf89bfe2ad60e9c067efea8f480d300594ec356dceaa60759d48f8146091c821d488e9843c27035d2627caa74754d5dad9289944395920d7b0fa3289d5db7aecc78f879f44919adc3734938dac7b7df6ea0408ebade130dead9aa8a56606f0afdb90422d81c9c6f5415bf70c35eddf9c6c7e1c792ebc499ee7c6fae6d777f9e8f73f9804c47bab8955dde6464641a7cf1aaf7ae617214f0ad04dbc747abc07bb82d6536c0292052d44bcdf6567f0698ff75e4ec9655d01a765c96900d8eb165f9c1d90902aa17bf29fc7b19a1e635f210ec2e7ba735fe58ccf83762c71e018aaa22086a46c269843f16b47957bd86848c84760c41eaf972b45f2159928383f4db07f10ee50f2fe8863ba0dbc83d36d88b34fed7bb921a0332299698420447d739beedb5e67fb982fd588c6766efc35ff7dc297eac357c84fc9d789bd852d4825ab834131eee12e9d953a4aaff73d349b95a7fae5000c7e33c972e25b328a535f566ec73617f5622df4373713269e4c35874afdf43aaee9c75df7f82f2a0455c08468b08bd737e02819085a92bfcde533864c8c7669c5f9a0ac223094b7ff25f55a2c214cd923fe7442010729acef8bf285dfd6c3f34193640bfbb7f12d94f114d38a40510000c15ba774a58d771a08ebc72ab82b74d77bf411f30f0fc8a6d39677a78492762736ff8344315fc596439591a3c6b94a6cf20ffb313728be674f84749b0b881666b8babd2d27ecdf824a920c2284059bf2bab833c357f5f468f344af6b317466efe0a423083e49f343a0a28c42ba792fe96a79fb3e72ad0c31b9c405f8540a20604ed93c24d67ff3668bfc2271f5c626cdfe17db3fb24d4a0ac9835f0e6155faeb3df8bf9d6b4a9b60ff39edff736545270a098d637d797dd6882b263d00d534d8ac7b195c6872b2fa24f7333fe89b0850c04b69640bc0e96a25fb201b4084ce8a404541b1f23d69561d30f51dc2d82e7b3068d03765581e5a0aebfc19cfb424f5763393d06a40071e15941a5cf443d550180e1b6020632968f6b8542783dfeeeb5b06e70ce08ffefd75f3fa01876bd86a703f10e895df07cbe1feba92e40ce6fbc8044dfda45028cf5293d2f310bf7f90c76f8a78712655bd6058b07b81568e83fb2d63c62cd05550d19d86abc96fedcc38452ef202481af78e1fbef8467e379ee514e409ef7dd9c51419ed83f257d4628271f170737bb6e51f547c5972a107b422d1e7bd6f85147ed031a0e45c2258eee44b35702476b51c309a2b25bb1387a62f98b3a9fe9a068ca922ee097c184ea25bcd6fc9cf343d86699898a60bcd7758e0a73c3879d7d86da147f00d75821e9baf4d7aaac4170ac0d84aeca4b075f432ca235d2af12355428dede80187f877ae7cd4da598a46ebfb0249aa28a8a8fbb7fbe79e03e042ea3478e062311cb1f3dceafeb7328fb9ef172f46339c5fbc3e48e514e109aa13a20e540e9f3d15281350b4bb44b8ee1b8bebc3d35e8855a59acbbd5f2012ca3c26846730ad139ad48c2ffbcf19dc0b10615290bec161ce30304b3c37853fe325890da658f5f8f4be3a18644a975b93e742a176c395ae64d73870e00c7531905283d7768c940d8a6fb01e3081abb7f6be1f9ebdec88947b45f151ab984b9feeea5c087565ce611fe5069e5850bc1fa3578c681d6be2b2567ac59de1e8e76080e0f8dadf6dcec6ad55f11bcb36a57bca0bc11dfcab92c48087f3263f2166cf14e1b02a6a766ee58790f1deb1edd4763f4fcb` }
 
-// 32 big-endian bytes at offset `off` → eight little-endian 2^32 limbs.
+// 32 big-endian bytes at offset `off` → four little-endian 2^64 limbs.
 @ __p256_be32_to_limbs ( Vec u ) src i off → ( Vec i ) {
-    : ( Vec i ) out ( vec_with_cap [i] 8 )
+    : ( Vec i ) out ( vec_with_cap [i] 4 )
     : ~ i k 0
-    ~ < k 8 {
-        : i b0 ?? ( vec_get [u] src + off - 31 * 4 k ) { T b → # i b F _ → 0 }
-        : i b1 ?? ( vec_get [u] src + off - 30 * 4 k ) { T b → # i b F _ → 0 }
-        : i b2 ?? ( vec_get [u] src + off - 29 * 4 k ) { T b → # i b F _ → 0 }
-        : i b3 ?? ( vec_get [u] src + off - 28 * 4 k ) { T b → # i b F _ → 0 }
-        ( vec_push [i] out | | | b0 << b1 8 << b2 16 << b3 24 )
+    ~ < k 4 {
+        // limb k = bytes [off + 24−8k … off + 31−8k], big-endian.
+        : i base + off - 24 * 8 k
+        : ~ u64 acc 0
+        : ~ i j 0
+        ~ < j 8 {
+            : u64 bj # u64 ?? ( vec_get [u] src + base j ) { T b → # i b F _ → 0 }
+            = acc | << acc 8 bj
+            = j + j 1
+        }
+        ( vec_push [i] out # i acc )
         = k + k 1
     }
     ^ out
@@ -355,22 +351,26 @@ $ `stdlib/std/p256_scalar.nu`  // fixed-width GF(n) for the signing scalar arith
 @ __p256_comb_build → v {
     : P256Scratch scr ( _p256_scr_new )
     : ( Vec u ) tbytes ?? ( bytes_from_hex ( __p256_comb_tbl_hex ) ) { T v → v F _ → ( vec_new [u] ) }
-    : P256Pt tmp ( _p256_pt_mag )
+    : ( Vec i ) mx ( _mag4 )
+    : ( Vec i ) my ( _mag4 )
     : ~ i t 0
     ~ < t 2 {
-        : ( Vec i ) tbl ( _magn 384 )
-        ( _p256_set_identity_d scr tmp )
-        ( _p256_tbl_put tbl 0 tmp )
+        // AFFINE Montgomery entries (x‖y, 8 limbs) — the Jacobian comb's
+        // mixed addition wants Z = 1 implicitly. Entry 0 stays all-zero
+        // (never committed; see _p256_jmadd_d's keep mask).
+        : ( Vec i ) tbl ( _magn 128 )
+        : *i zp ( vec_data [i] tbl )
+        = . zp 0 0 = . zp 1 0 = . zp 2 0 = . zp 3 0
+        = . zp 4 0 = . zp 5 0 = . zp 6 0 = . zp 7 0
         : ~ i s 1
         ~ < s 16 {
             // T1 points sit at blob offsets 0‥14·64, T2 at 15·64‥29·64.
             : i off * + * t 15 - s 1 64
             : ( Vec i ) xl ( __p256_be32_to_limbs tbytes off )
             : ( Vec i ) yl ( __p256_be32_to_limbs tbytes + off 32 )
-            ( _p256_to_mont_d scr . tmp x xl )
-            ( _p256_to_mont_d scr . tmp y yl )
-            ( _p256_one_mont_d scr . tmp z )
-            ( _p256_tbl_put tbl s tmp )
+            ( _p256_to_mont_d scr mx xl )
+            ( _p256_to_mont_d scr my yl )
+            ( _p256_atbl_put tbl s mx my )
             ( vec_free [i] xl ) ( vec_free [i] yl )
             = s + s 1
         }
@@ -378,7 +378,7 @@ $ `stdlib/std/p256_scalar.nu`  // fixed-width GF(n) for the signing scalar arith
         = t + t 1
     }
     ( vec_free [u] tbytes )
-    ( p256pt_free tmp )
+    ( vec_free [i] mx ) ( vec_free [i] my )
     ( _p256_scr_free scr )
 }
 
@@ -392,30 +392,35 @@ $ `stdlib/std/p256_scalar.nu`  // fixed-width GF(n) for the signing scalar arith
     ^ @ ( Vec i ) { # s g_p256_comb_tbl2 }
 }
 
-// scalar · G → 64 bytes X‖Y, constant-time fixed-base comb.
+// scalar · G → 64 bytes X‖Y, constant-time fixed-base comb on JACOBIAN
+// coordinates with affine table entries: 32 × (3M+5S) doublings +
+// 64 × (8M+3S) mixed additions, against the projective complete
+// formula's 14 multiplies for every one of those 96 operations. The
+// exceptional cases the complete formula absorbed are handled by
+// constant-time masks — see the Jacobian-layer header in
+// std/p256_field.nu for the case analysis and the ~2⁻²²⁴ bound on the
+// one it (deliberately, like ecp_nistz256) does not cover.
 @ p256ct_scalarmult_base ( Vec u ) kbytes → ( Vec u ) {
     : P256Scratch scr ( _p256_scr_new )
-    : ( Vec i ) aplain ( _p256_a_plain )
-    : ( Vec i ) am ( _p256_to_mont_s scr aplain ) ( vec_free [i] aplain )
-    : ( Vec i ) b3plain ( _p256_b3_plain )
-    : ( Vec i ) b3m ( _p256_to_mont_s scr b3plain ) ( vec_free [i] b3plain )
     // Shared, lazily-built tables of G multiples — BORROWED from the
     // global cache; must not be freed here.
     : ( Vec i ) tbl1 ( __p256_comb_tbl_mont )
     : ( Vec i ) tbl2 ( __p256_comb_tbl2_mont )
+    : ( Vec i ) onem ( _p256_one_mont_s scr )
+    : ( Vec i ) ex ( _mag4 )
+    : ( Vec i ) ey ( _mag4 )
+    // acc = ∞: Z = 0 (X/Y values are irrelevant while Z = 0; the
+    // doubling keeps Z at 0 and the first committed add replaces all
+    // three coordinates via the ∞ mask).
     : P256Pt acc ( _p256_pt_mag )
     ( _p256_set_identity_d scr acc )
-    : P256Pt selp ( _p256_pt_mag )
     // Eight-tooth Lim–Lee comb as two 4-tooth halves: iteration i
     // (31‥0) doubles once, then adds T1[bits i,i+32,i+64,i+96] and
-    // T2[bits i+128,…,i+224]. 32 doublings + 64 additions, against the
-    // 4-tooth layout's 64 + 64 — the doubling half of the work gone
-    // for one more 3 KB public table. Same constant-time properties:
-    // fixed trip count, masked table scans, complete additions (digit
-    // 0 reads the identity, which the formula absorbs).
+    // T2[bits i+128,…,i+224]. Constant-time: fixed trip count, masked
+    // table scans, masked exceptional-case commits.
     : ~ i i 31
     ~ >= i 0 {
-        ( p256ct_padd_d scr acc acc acc am b3m )
+        ( _p256_jdbl_d scr acc )
         : ~ i idx1 0
         : ~ i idx2 0
         : ~ i j 0
@@ -430,23 +435,30 @@ $ `stdlib/std/p256_scalar.nu`  // fixed-width GF(n) for the signing scalar arith
             = idx2 | idx2 << b2 j
             = j + j 1
         }
-        ( _p256_tbl_get_d selp tbl1 idx1 )
-        ( p256ct_padd_d scr acc acc selp am b3m )
-        ( _p256_tbl_get_d selp tbl2 idx2 )
-        ( p256ct_padd_d scr acc acc selp am b3m )
+        // keep-mask: −1 exactly when the digit is 0 (branch-free).
+        : i k1 - # i >> # u64 | idx1 - 0 idx1 63 1
+        : i k2 - # i >> # u64 | idx2 - 0 idx2 63 1
+        ( _p256_atbl_get_d ex ey tbl1 idx1 )
+        ( _p256_jmadd_d scr acc ex ey onem k1 )
+        ( _p256_atbl_get_d ex ey tbl2 idx2 )
+        ( _p256_jmadd_d scr acc ex ey onem k2 )
         = i - i 1
     }
-    : ( Vec i ) zinv ( _mag8 )
+    // Jacobian → affine: x = X/Z², y = Y/Z³ (Z = 0 → zinv = 0 → the
+    // all-zero identity output, as before).
+    : ( Vec i ) zinv ( _mag4 )
     ( _p256_inv_d scr zinv . acc z )
-    ( _p256_mul_d scr . acc x . acc x zinv )
-    ( _p256_mul_d scr . acc y . acc y zinv )
+    ( _p256_mul_d scr . acc z zinv zinv )
+    ( _p256_mul_d scr . acc x . acc x . acc z )
+    ( _p256_mul_d scr . acc z . acc z zinv )
+    ( _p256_mul_d scr . acc y . acc y . acc z )
     ( _p256_from_mont_d scr . acc x . acc x )
     ( _p256_from_mont_d scr . acc y . acc y )
     : ( Vec u ) out ( vec_with_cap [u] 64 )
     ( _p256_limbs_to_be out . acc x )
     ( _p256_limbs_to_be out . acc y )
-    ( p256pt_free acc ) ( p256pt_free selp )
-    ( vec_free [i] am ) ( vec_free [i] b3m ) ( vec_free [i] zinv )
+    ( p256pt_free acc )
+    ( vec_free [i] ex ) ( vec_free [i] ey ) ( vec_free [i] onem ) ( vec_free [i] zinv )
     ( _p256_scr_free scr )
     ^ out
 }

--- a/stdlib/std/p256_field.nu
+++ b/stdlib/std/p256_field.nu
@@ -1,21 +1,20 @@
 // stdlib/std/p256_field.nu — constant-time GF(p) arithmetic for NIST P-256.
 //
-// A dedicated FIXED-WIDTH field: every element is exactly 8 little-endian
-// 32-bit limbs (256 bits), NEVER normalized/trimmed, so no operation's
-// duration depends on the value. This is the constant-time core the generic
-// std/bigint.nu cannot be (it trims leading-zero limbs → operand-time-
-// dependent). Multiplication is Montgomery CIOS; add/sub use a constant-time
-// conditional ±p; inversion is a fixed Fermat chain (a^(p-2)). All loops are
-// fixed-count and branch-free in the data.
+// A dedicated FIXED-WIDTH field: every element is exactly 4 little-endian
+// 64-bit limbs (256 bits, stored as i64 bit patterns), NEVER normalized/
+// trimmed, so no operation's duration depends on the value. This is the
+// constant-time core the generic std/bigint.nu cannot be (it trims
+// leading-zero limbs → operand-time-dependent). Multiplication is
+// Montgomery CIOS; add/sub use a constant-time conditional ±p; inversion
+// is a fixed Fermat chain (a^(p-2)). All loops are fixed-count and
+// branch-free in the data.
 //
-// Elements are STORED as eight 32-bit limbs, but the multiply works in
-// four 64-bit ones: it packs its inputs to 4×64 on entry and unpacks the
-// result on exit, so each partial product is a full 64×64 → 128 multiply
-// (nurl_umulhi gives the high half) and the schoolbook body is 4×4 = 16
-// products against the 8×8 = 64 the 32-bit radix ran. Add/sub/conditional-
-// subtract stay on the 32-bit limbs, where a 32×32 sum needs no wide type.
-// Every limb is stored masked to 32 bits, so reading one back as `u64` is
-// exact.
+// Storage USED to be eight 32-bit limbs with the multiply packing to
+// 4×64 on entry and unpacking on exit — ~24 pack/unpack operations
+// riding along on EVERY field multiply, i.e. on each of the ~1500
+// multiplies of one scalar multiplication. With nurl_addc/nurl_subb
+// carrying 64-bit adds and subtracts directly, the 4×64 form is now the
+// storage form and the packing is gone.
 //
 // Every operation comes in two forms: an allocating `p256ct_*` for callers
 // that just want a value, and a `_d` worker that WRITES INTO a destination
@@ -30,33 +29,32 @@
 
 $ `stdlib/core/vec.nu`
 
-// p = 2^256 − 2^224 + 2^192 + 2^96 − 1, little-endian 32-bit limbs.
+// p = 2^256 − 2^224 + 2^192 + 2^96 − 1, little-endian 64-bit limbs.
 @ __p256_mod → ( Vec i ) {
     // Filled by index, not pushed: a push carries a capacity check the
-    // fixed eight limbs do not need.
-    : ( Vec i ) v ( _mag8 )
+    // fixed four limbs do not need.
+    : ( Vec i ) v ( _mag4 )
     : *i q ( vec_data [i] v )
-    = . q 0 0xFFFFFFFF = . q 1 0xFFFFFFFF = . q 2 0xFFFFFFFF = . q 3 0
-    = . q 4 0 = . q 5 0 = . q 6 1 = . q 7 0xFFFFFFFF
+    = . q 0 # i 0xFFFFFFFFFFFFFFFF = . q 1 # i 0x00000000FFFFFFFF
+    = . q 2 0 = . q 3 # i 0xFFFFFFFF00000001
     ^ v
 }
 
 // R^2 mod p (= 2^512 mod p) — multiply by this (Montgomery) to enter the domain.
 @ __p256_r2 → ( Vec i ) {
-    : ( Vec i ) v ( _mag8 )
+    : ( Vec i ) v ( _mag4 )
     : *i q ( vec_data [i] v )
-    = . q 0 3 = . q 1 0 = . q 2 0xFFFFFFFF = . q 3 0xFFFFFFFB
-    = . q 4 0xFFFFFFFE = . q 5 0xFFFFFFFF = . q 6 0xFFFFFFFD = . q 7 4
+    = . q 0 3 = . q 1 # i 0xFFFFFFFBFFFFFFFF
+    = . q 2 # i 0xFFFFFFFFFFFFFFFE = . q 3 # i 0x00000004FFFFFFFD
     ^ v
 }
 
 // 1 in plain (non-Montgomery) form: [1, 0, …]. Montgomery-multiplying by this
 // leaves the domain (montmul(ā, 1) = a).
 @ __p256_one → ( Vec i ) {
-    : ( Vec i ) v ( _mag8 )
+    : ( Vec i ) v ( _mag4 )
     : *i q ( vec_data [i] v )
     = . q 0 1 = . q 1 0 = . q 2 0 = . q 3 0
-    = . q 4 0 = . q 5 0 = . q 6 0 = . q 7 0
     ^ v
 }
 
@@ -66,13 +64,13 @@ $ `stdlib/core/vec.nu`
 
 @ __ctl ( Vec i ) v i k → i { ?? ( vec_get [i] v k ) { T x → ^ x F _ → ^ 0 } }
 
-// An 8-limb magnitude, uninitialised. The hot routines below fill every
+// A 4-limb magnitude, uninitialised. The hot routines below fill every
 // limb through a raw `*i` before anyone reads one, so there is nothing to
 // zero first — and unlike a push loop, filling by index costs no capacity
 // check per limb.
-@ _mag8 → ( Vec i ) {
-    : ( Vec i ) v ( vec_with_cap [i] 8 )
-    : b _l ( vec_set_len [i] v 8 )
+@ _mag4 → ( Vec i ) {
+    : ( Vec i ) v ( vec_with_cap [i] 4 )
+    : b _l ( vec_set_len [i] v 4 )
     ^ v
 }
 
@@ -109,10 +107,10 @@ $ `stdlib/core/vec.nu`
 
 @ _p256_scr_new → P256Scratch {
     ^ @ P256Scratch {
-        ( __p256_mod ) ( _magn 10 ) ( _mag8 )
-        ( _mag8 ) ( _mag8 ) ( _mag8 )
-        ( _mag8 ) ( _mag8 ) ( _mag8 )
-        ( _mag8 )
+        ( __p256_mod ) ( _mag4 ) ( _mag4 )
+        ( _mag4 ) ( _mag4 ) ( _mag4 )
+        ( _mag4 ) ( _mag4 ) ( _mag4 )
+        ( _mag4 )
     }
 }
 
@@ -131,11 +129,10 @@ $ `stdlib/core/vec.nu`
 // 61% of a TLS handshake. Constant time is unaffected: the loops keep
 // their fixed trip counts and stay branch-free in the data.
 
-@ __zeros8 → ( Vec i ) {
-    : ( Vec i ) v ( _mag8 )
+@ __zeros4 → ( Vec i ) {
+    : ( Vec i ) v ( _mag4 )
     : *i q ( vec_data [i] v )
-    : ~ i k 0
-    ~ < k 8 { = . q k 0 = k + k 1 }
+    = . q 0 0 = . q 1 0 = . q 2 0 = . q 3 0
     ^ v
 }
 
@@ -157,7 +154,7 @@ $ `stdlib/core/vec.nu`
 }
 
 @ __p256_mul_s P256Scratch scr ( Vec i ) a ( Vec i ) b → ( Vec i ) {
-    : ( Vec i ) out ( _mag8 )
+    : ( Vec i ) out ( _mag4 )
     ( _p256_mul_d scr out a b )
     ^ out
 }
@@ -178,15 +175,15 @@ $ `stdlib/core/vec.nu`
 @ _p256_mul_d P256Scratch scr ( Vec i ) dst ( Vec i ) a ( Vec i ) b → v {
     : *i ap ( vec_data [i] a )
     : *i bp ( vec_data [i] b )
-    // Pack the eight 32-bit limbs into four 64-bit ones (little-endian).
-    : u64 a0 | # u64 . ap 0 << # u64 . ap 1 32
-    : u64 a1 | # u64 . ap 2 << # u64 . ap 3 32
-    : u64 a2 | # u64 . ap 4 << # u64 . ap 5 32
-    : u64 a3 | # u64 . ap 6 << # u64 . ap 7 32
-    : u64 b0 | # u64 . bp 0 << # u64 . bp 1 32
-    : u64 b1 | # u64 . bp 2 << # u64 . bp 3 32
-    : u64 b2 | # u64 . bp 4 << # u64 . bp 5 32
-    : u64 b3 | # u64 . bp 6 << # u64 . bp 7 32
+    // Limbs load directly — the field IS 4×64 now (no pack step).
+    : u64 a0 # u64 . ap 0
+    : u64 a1 # u64 . ap 1
+    : u64 a2 # u64 . ap 2
+    : u64 a3 # u64 . ap 3
+    : u64 b0 # u64 . bp 0
+    : u64 b1 # u64 . bp 1
+    : u64 b2 # u64 . bp 2
+    : u64 b3 # u64 . bp 3
     // Accumulator t[0..5]; the top two words hold the CIOS overflow.
     : ~ u64 t0 0
     : ~ u64 t1 0
@@ -369,7 +366,7 @@ $ `stdlib/core/vec.nu`
     = t4 ( nurl_addc_lo t4 cr 0 )
     = t0 t1 = t1 t2 = t2 t3 = t3 t4 = t4 t5 = t5 0
     // t0..t3 is the 256-bit result, t4 the extra top word; value < 2p.
-    // Conditional subtract p (4×64), then unpack the winner to 8×32 in dst.
+    // Conditional subtract p (4×64); the winner IS the stored form.
     : u64 d0 ( nurl_subb_lo t0 18446744073709551615 0 )
     : ~ u64 bb ( nurl_subb_hi t0 18446744073709551615 0 )
     : u64 d1 ( nurl_subb_lo t1 4294967295 bb )
@@ -387,48 +384,14 @@ $ `stdlib/core/vec.nu`
     : u64 o2 | & mask d2 & imask t2
     : u64 o3 | & mask d3 & imask t3
     : *i op ( vec_data [i] dst )
-    = . op 0 # i & o0 4294967295
-    = . op 1 # i & >> o0 32 4294967295
-    = . op 2 # i & o1 4294967295
-    = . op 3 # i & >> o1 32 4294967295
-    = . op 4 # i & o2 4294967295
-    = . op 5 # i & >> o2 32 4294967295
-    = . op 6 # i & o3 4294967295
-    = . op 7 # i & >> o3 32 4294967295
+    = . op 0 # i o0
+    = . op 1 # i o1
+    = . op 2 # i o2
+    = . op 3 # i o3
 }
 
-// Given a 9-limb t in [0, 2p), write (t mod p) as 8 limbs into dst,
-// constant-time: compute t − p with borrow; if it underflows (t < p) keep
-// t, else keep t−p. `modp` comes from the scratch rather than being
-// rebuilt: every caller already holds it, and building it cost eight
-// stores into a fresh allocation on each of the ~3000 field operations a
-// scalar multiply performs.
-@ __p256_cond_sub_d P256Scratch scr ( Vec i ) dst ( Vec i ) t → v {
-    : ( Vec i ) diff . scr diff
-    : *i tp ( vec_data [i] t )
-    : *i pp ( vec_data [i] . scr modp )
-    : *i dp ( vec_data [i] diff )
-    : ~ i borrow 0
-    : ~ i k 0
-    ~ < k 8 {
-        : ~ i d - - . tp k . pp k borrow
-        ? < d 0 { = d + d 4294967296 = borrow 1 } { = borrow 0 }
-        = . dp k d
-        = k + k 1
-    }
-    // top limb t[8] minus the final borrow: if negative, t < p.
-    : i topb - . tp 8 borrow
-    // mask = 0xffffffff if (t >= p) i.e. topb >= 0, else 0 (keep t).
-    : i tge & 1 ? >= topb 0 1 0
-    : i mask & 0xFFFFFFFF - 0 tge
-    : i imask & 0xFFFFFFFF - 0 - 1 tge
-    : *i op ( vec_data [i] dst )
-    : ~ i j 0
-    ~ < j 8 {
-        = . op j | & mask . dp j & imask . tp j
-        = j + j 1
-    }
-}
+// (kept: the 9-limb staging cond-sub is gone — add/sub carry in
+// registers now and fold the conditional ±p inline, like the multiply.)
 
 // (a + b) mod p, constant-time. a, b < p ⇒ a+b < 2p ⇒ one conditional sub.
 @ p256ct_add ( Vec i ) a ( Vec i ) b → ( Vec i ) {
@@ -439,27 +402,50 @@ $ `stdlib/core/vec.nu`
 }
 
 @ __p256_add_s P256Scratch scr ( Vec i ) a ( Vec i ) b → ( Vec i ) {
-    : ( Vec i ) out ( _mag8 )
+    : ( Vec i ) out ( _mag4 )
     ( __p256_add_d scr out a b )
     ^ out
 }
 
+// (a + b) then one constant-time conditional subtract of p, all in
+// registers: a, b < p ⇒ a+b < 2p ⇒ one masked subtract suffices. `dst`
+// may alias a and/or b — everything is read before dst is written.
 @ __p256_add_d P256Scratch scr ( Vec i ) dst ( Vec i ) a ( Vec i ) b → v {
-    // The 10-limb accumulator doubles as the 9-limb sum.
-    : ( Vec i ) t . scr t
     : *i ap ( vec_data [i] a )
     : *i bp ( vec_data [i] b )
-    : *i tp ( vec_data [i] t )
-    : ~ i carry 0
-    : ~ i k 0
-    ~ < k 8 {
-        : i s + + . ap k . bp k carry
-        = . tp k & s 0xFFFFFFFF
-        = carry >> s 32
-        = k + k 1
-    }
-    = . tp 8 carry
-    ( __p256_cond_sub_d scr dst t )
+    : u64 a0 # u64 . ap 0
+    : u64 a1 # u64 . ap 1
+    : u64 a2 # u64 . ap 2
+    : u64 a3 # u64 . ap 3
+    : u64 b0 # u64 . bp 0
+    : u64 b1 # u64 . bp 1
+    : u64 b2 # u64 . bp 2
+    : u64 b3 # u64 . bp 3
+    : u64 t0 ( nurl_addc_lo a0 b0 0 )
+    : ~ u64 cc ( nurl_addc_hi a0 b0 0 )
+    : u64 t1 ( nurl_addc_lo a1 b1 cc )
+    = cc ( nurl_addc_hi a1 b1 cc )
+    : u64 t2 ( nurl_addc_lo a2 b2 cc )
+    = cc ( nurl_addc_hi a2 b2 cc )
+    : u64 t3 ( nurl_addc_lo a3 b3 cc )
+    = cc ( nurl_addc_hi a3 b3 cc )
+    // conditional subtract p, exactly the multiply's tail.
+    : u64 d0 ( nurl_subb_lo t0 18446744073709551615 0 )
+    : ~ u64 bb ( nurl_subb_hi t0 18446744073709551615 0 )
+    : u64 d1 ( nurl_subb_lo t1 4294967295 bb )
+    = bb ( nurl_subb_hi t1 4294967295 bb )
+    : u64 d2 ( nurl_subb_lo t2 0 bb )
+    = bb ( nurl_subb_hi t2 0 bb )
+    : u64 d3 ( nurl_subb_lo t3 18446744069414584321 bb )
+    = bb ( nurl_subb_hi t3 18446744069414584321 bb )
+    : i topb - # i cc # i bb
+    : u64 mask ? < topb 0 0 18446744073709551615
+    : u64 imask ^^ mask 18446744073709551615
+    : *i op ( vec_data [i] dst )
+    = . op 0 # i | & mask d0 & imask t0
+    = . op 1 # i | & mask d1 & imask t1
+    = . op 2 # i | & mask d2 & imask t2
+    = . op 3 # i | & mask d3 & imask t3
 }
 
 // (a − b) mod p, constant-time: a − b, and if it borrows add p back.
@@ -471,37 +457,49 @@ $ `stdlib/core/vec.nu`
 }
 
 @ __p256_sub_s P256Scratch scr ( Vec i ) a ( Vec i ) b → ( Vec i ) {
-    : ( Vec i ) out ( _mag8 )
+    : ( Vec i ) out ( _mag4 )
     ( __p256_sub_d scr out a b )
     ^ out
 }
 
+// a − b with borrow, then a masked add-back of p when it underflowed.
+// `dst` may alias a and/or b.
 @ __p256_sub_d P256Scratch scr ( Vec i ) dst ( Vec i ) a ( Vec i ) b → v {
-    : ( Vec i ) modp . scr modp
-    : ( Vec i ) d . scr diff
     : *i ap ( vec_data [i] a )
     : *i bp ( vec_data [i] b )
-    : *i pp ( vec_data [i] modp )
-    : *i dp ( vec_data [i] d )
-    : ~ i borrow 0
-    : ~ i k 0
-    ~ < k 8 {
-        : ~ i x - - . ap k . bp k borrow
-        ? < x 0 { = x + x 4294967296 = borrow 1 } { = borrow 0 }
-        = . dp k x
-        = k + k 1
-    }
-    // if borrow (a < b), add p (masked).
-    : i mask & 0xFFFFFFFF - 0 borrow
+    : u64 a0 # u64 . ap 0
+    : u64 a1 # u64 . ap 1
+    : u64 a2 # u64 . ap 2
+    : u64 a3 # u64 . ap 3
+    : u64 b0 # u64 . bp 0
+    : u64 b1 # u64 . bp 1
+    : u64 b2 # u64 . bp 2
+    : u64 b3 # u64 . bp 3
+    : u64 d0 ( nurl_subb_lo a0 b0 0 )
+    : ~ u64 bb ( nurl_subb_hi a0 b0 0 )
+    : u64 d1 ( nurl_subb_lo a1 b1 bb )
+    = bb ( nurl_subb_hi a1 b1 bb )
+    : u64 d2 ( nurl_subb_lo a2 b2 bb )
+    = bb ( nurl_subb_hi a2 b2 bb )
+    : u64 d3 ( nurl_subb_lo a3 b3 bb )
+    = bb ( nurl_subb_hi a3 b3 bb )
+    // if it borrowed (a < b), add p back — masked, no branch.
+    : u64 mask ? == # i bb 0 0 18446744073709551615
+    : u64 p0 & mask 18446744073709551615
+    : u64 p1 & mask 4294967295
+    : u64 p3 & mask 18446744069414584321
+    : u64 r0 ( nurl_addc_lo d0 p0 0 )
+    : ~ u64 cc ( nurl_addc_hi d0 p0 0 )
+    : u64 r1 ( nurl_addc_lo d1 p1 cc )
+    = cc ( nurl_addc_hi d1 p1 cc )
+    : u64 r2 ( nurl_addc_lo d2 0 cc )
+    = cc ( nurl_addc_hi d2 0 cc )
+    : u64 r3 ( nurl_addc_lo d3 p3 cc )
     : *i op ( vec_data [i] dst )
-    : ~ i c2 0
-    : ~ i j 0
-    ~ < j 8 {
-        : i s + + . dp j & mask . pp j c2
-        = . op j & s 0xFFFFFFFF
-        = c2 >> s 32
-        = j + j 1
-    }
+    = . op 0 # i r0
+    = . op 1 # i r1
+    = . op 2 # i r2
+    = . op 3 # i r3
 }
 
 @ p256ct_sqr ( Vec i ) a → ( Vec i ) { ^ ( p256ct_mul a a ) }
@@ -514,7 +512,7 @@ $ `stdlib/core/vec.nu`
 }
 
 @ _p256_to_mont_s P256Scratch scr ( Vec i ) a → ( Vec i ) {
-    : ( Vec i ) out ( _mag8 )
+    : ( Vec i ) out ( _mag4 )
     ( _p256_to_mont_d scr out a )
     ^ out
 }
@@ -533,7 +531,7 @@ $ `stdlib/core/vec.nu`
 }
 
 @ __p256_from_mont_s P256Scratch scr ( Vec i ) a → ( Vec i ) {
-    : ( Vec i ) out ( _mag8 )
+    : ( Vec i ) out ( _mag4 )
     ( _p256_from_mont_d scr out a )
     ^ out
 }
@@ -548,20 +546,20 @@ $ `stdlib/core/vec.nu`
 @ p256ct_is_zero ( Vec i ) a → b {
     : ~ i acc 0
     : ~ i k 0
-    ~ < k 8 { = acc | acc ( __ctl a k ) = k + k 1 }
+    ~ < k 4 { = acc | acc ( __ctl a k ) = k + k 1 }
     ^ == acc 0
 }
 
 // Montgomery 1 (= R mod p), the field identity in Montgomery form.
 @ p256ct_one_mont → ( Vec i ) {
     : P256Scratch scr ( _p256_scr_new )
-    : ( Vec i ) r ( __p256_one_mont_s scr )
+    : ( Vec i ) r ( _p256_one_mont_s scr )
     ( _p256_scr_free scr )
     ^ r
 }
 
-@ __p256_one_mont_s P256Scratch scr → ( Vec i ) {
-    : ( Vec i ) out ( _mag8 )
+@ _p256_one_mont_s P256Scratch scr → ( Vec i ) {
+    : ( Vec i ) out ( _mag4 )
     ( _p256_one_mont_d scr out )
     ^ out
 }
@@ -584,7 +582,7 @@ $ `stdlib/core/vec.nu`
 }
 
 @ __p256_inv_s P256Scratch scr ( Vec i ) a → ( Vec i ) {
-    : ( Vec i ) out ( _mag8 )
+    : ( Vec i ) out ( _mag4 )
     ( _p256_inv_d scr out a )
     ^ out
 }
@@ -601,25 +599,25 @@ $ `stdlib/core/vec.nu`
     : ~ i bit 255
     ~ >= bit 0 {
         ( _p256_mul_d scr dst dst dst )
-        : i li / bit 32
-        : i bp % bit 32
-        : i b1 & 1 >> ( __ctl e li ) bp
+        : i li / bit 64
+        : i bp % bit 64
+        : i b1 & 1 # i >> # u64 ( __ctl e li ) bp
         ( _p256_mul_d scr prod dst a )
         // constant-time select prod (if bit) else the running value
-        : i mask & 0xFFFFFFFF - 0 b1
-        : i imask & 0xFFFFFFFF - 0 - 1 b1
+        : i mask - 0 b1
+        : i imask - 0 - 1 b1
         ( __p256_lmerge_d dst mask imask prod dst )
         = bit - bit 1
     }
     ( vec_free [i] e )
 }
 
-// p − 2, little-endian 32-bit limbs.
+// p − 2, little-endian 64-bit limbs.
 @ __p256_pm2 → ( Vec i ) {
-    : ( Vec i ) v ( _mag8 )
+    : ( Vec i ) v ( _mag4 )
     : *i q ( vec_data [i] v )
-    = . q 0 0xFFFFFFFD = . q 1 0xFFFFFFFF = . q 2 0xFFFFFFFF = . q 3 0
-    = . q 4 0 = . q 5 0 = . q 6 1 = . q 7 0xFFFFFFFF
+    = . q 0 # i 0xFFFFFFFFFFFFFFFD = . q 1 # i 0x00000000FFFFFFFF
+    = . q 2 0 = . q 3 # i 0xFFFFFFFF00000001
     ^ v
 }
 
@@ -642,23 +640,23 @@ $ `stdlib/core/vec.nu`
 
 // An uninitialised point (three 8-limb magnitudes) — a ladder register.
 @ _p256_pt_mag → P256Pt {
-    ^ @ P256Pt { ( _mag8 ) ( _mag8 ) ( _mag8 ) }
+    ^ @ P256Pt { ( _mag4 ) ( _mag4 ) ( _mag4 ) }
 }
 
 // a (= −3 mod p) and b3 (= 3·b mod p), plain (non-Montgomery) limbs.
 @ _p256_a_plain → ( Vec i ) {
-    : ( Vec i ) v ( _mag8 )
+    : ( Vec i ) v ( _mag4 )
     : *i q ( vec_data [i] v )
-    = . q 0 0xFFFFFFFC = . q 1 0xFFFFFFFF = . q 2 0xFFFFFFFF = . q 3 0
-    = . q 4 0 = . q 5 0 = . q 6 1 = . q 7 0xFFFFFFFF
+    = . q 0 # i 0xFFFFFFFFFFFFFFFC = . q 1 # i 0x00000000FFFFFFFF
+    = . q 2 0 = . q 3 # i 0xFFFFFFFF00000001
     ^ v
 }
 
 @ _p256_b3_plain → ( Vec i ) {
-    : ( Vec i ) v ( _mag8 )
+    : ( Vec i ) v ( _mag4 )
     : *i q ( vec_data [i] v )
-    = . q 0 0x777720E2 = . q 1 0xB36AB4BA = . q 2 0x64FB12E2 = . q 3 0x2F571411
-    = . q 4 0x63C99435 = . q 5 0x1BC33800 = . q 6 0xFEAFBBB6 = . q 7 0x1052A18A
+    = . q 0 # i 0xB36AB4BA777720E2 = . q 1 # i 0x2F57141164FB12E2
+    = . q 2 # i 0x1BC3380063C99435 = . q 3 # i 0x1052A18AFEAFBBB6
     ^ v
 }
 
@@ -734,8 +732,8 @@ $ `stdlib/core/vec.nu`
 // `dst` may alias `a` or `b`: the merge reads and writes one limb index at
 // a time.
 @ p256ct_pt_select_d P256Pt dst i bit P256Pt a P256Pt b → v {
-    : i mask & 0xFFFFFFFF - 0 bit
-    : i imask & 0xFFFFFFFF - 0 - 1 bit
+    : i mask - 0 bit
+    : i imask - 0 - 1 bit
     ( __p256_lmerge_d . dst x mask imask . a x . b x )
     ( __p256_lmerge_d . dst y mask imask . a y . b y )
     ( __p256_lmerge_d . dst z mask imask . a z . b z )
@@ -745,16 +743,18 @@ $ `stdlib/core/vec.nu`
     : *i op ( vec_data [i] dst )
     : *i ap ( vec_data [i] a )
     : *i bp ( vec_data [i] b )
-    : ~ i k 0
-    ~ < k 8 { = . op k | & mask . ap k & imask . bp k = k + k 1 }
+    = . op 0 | & mask . ap 0 & imask . bp 0
+    = . op 1 | & mask . ap 1 & imask . bp 1
+    = . op 2 | & mask . ap 2 & imask . bp 2
+    = . op 3 | & mask . ap 3 & imask . bp 3
 }
 
 @ p256ct_pt_clone P256Pt p → P256Pt {
-    ^ @ P256Pt { ( __mag8_clone . p x ) ( __mag8_clone . p y ) ( __mag8_clone . p z ) }
+    ^ @ P256Pt { ( __mag4_clone . p x ) ( __mag4_clone . p y ) ( __mag4_clone . p z ) }
 }
 
-@ __mag8_clone ( Vec i ) a → ( Vec i ) {
-    : ( Vec i ) out ( _mag8 )
+@ __mag4_clone ( Vec i ) a → ( Vec i ) {
+    : ( Vec i ) out ( _mag4 )
     ( __p256_copy_d out a )
     ^ out
 }
@@ -762,15 +762,17 @@ $ `stdlib/core/vec.nu`
 @ __p256_copy_d ( Vec i ) dst ( Vec i ) a → v {
     : *i op ( vec_data [i] dst )
     : *i ap ( vec_data [i] a )
-    : ~ i k 0
-    ~ < k 8 { = . op k . ap k = k + k 1 }
+    = . op 0 . ap 0
+    = . op 1 . ap 1
+    = . op 2 . ap 2
+    = . op 3 . ap 3
 }
 
 // Identity point (0 : 1 : 0) in Montgomery form.
 @ p256ct_identity → P256Pt {
-    : ( Vec i ) z0 ( __zeros8 )
+    : ( Vec i ) z0 ( __zeros4 )
     : ( Vec i ) one ( p256ct_one_mont )
-    : ( Vec i ) z0b ( __zeros8 )
+    : ( Vec i ) z0b ( __zeros4 )
     ^ @ P256Pt { z0 one z0b }
 }
 
@@ -778,8 +780,8 @@ $ `stdlib/core/vec.nu`
 @ _p256_set_identity_d P256Scratch scr P256Pt dst → v {
     : *i xp ( vec_data [i] . dst x )
     : *i zp ( vec_data [i] . dst z )
-    : ~ i k 0
-    ~ < k 8 { = . xp k 0 = . zp k 0 = k + k 1 }
+    = . xp 0 0 = . xp 1 0 = . xp 2 0 = . xp 3 0
+    = . zp 0 0 = . zp 1 0 = . zp 2 0 = . zp 3 0
     ( _p256_one_mont_d scr . dst y )
 }
 
@@ -789,9 +791,188 @@ $ `stdlib/core/vec.nu`
     ( __p256_copy_d . dst z . a z )
 }
 
+// ── Jacobian fixed-base machinery ──────────────────────────────────────
+// The FIXED-BASE comb (k·G: ECDSA nonce, ECDH keygen) runs on Jacobian
+// coordinates (x = X/Z², y = Y/Z³, ∞ ⇔ Z = 0) with an AFFINE table of
+// G-multiples: doubling is 3M+5S (dbl-2001-b, a = −3) and mixed addition
+// 8M+3S, against the complete projective formula's 14 multiplies for
+// BOTH. The completeness the RCB formula buys is replaced case by case:
+//
+//   * acc = ∞  (leading zero teeth): the mixed add's result is fixed up
+//     by a constant-time select of (x2, y2, 1) — Z1 = 0 is detected with
+//     a branch-free mask, and the doubling formula keeps Z = 0 on its
+//     own (Z3 = (Y+Z)² − Y² − Z² = 0 when Z = 0).
+//   * digit = 0 (no affine entry exists for ∞): the caller keeps the
+//     old accumulator through the same masked select — the add still
+//     RUNS, against the table's zero entry, so the trace is identical.
+//   * acc = −entry: H = 0, R ≠ 0 → Z3 = Z1·H = 0 — the formula itself
+//     yields ∞, which is the right answer.
+//   * acc = entry (the doubling case, H = 0, R = 0): the formula
+//     degenerates. For this to trigger, the partial sum (a multiple of
+//     G determined by the scalar's higher teeth) must equal the table
+//     entry's multiple mod n — for the secret, (pseudo)random scalars
+//     this path serves (RFC 6979 nonces, ephemeral ECDH keys) that is a
+//     ~2⁻²²⁴ event per addition, the same bound production
+//     implementations (e.g. ecp_nistz256) accept. Adversarial scalars
+//     never reach this path: the VARIABLE-base ladder keeps the
+//     complete formula.
+//
+// All limb traffic stays masked and fixed-count: same constant-time
+// discipline as the projective path.
+
+// Jacobian doubling in place, a = −3 (dbl-2001-b): 3M+5S.
+// Registers: g0=delta g1=gamma g2=beta g3=alpha g4/g5=temps.
+@ _p256_jdbl_d P256Scratch scr P256Pt pt → v {
+    : ( Vec i ) xr . pt x
+    : ( Vec i ) yr . pt y
+    : ( Vec i ) zr . pt z
+    : ( Vec i ) delta . scr g0
+    : ( Vec i ) gamma . scr g1
+    : ( Vec i ) beta . scr g2
+    : ( Vec i ) alpha . scr g3
+    : ( Vec i ) t4 . scr g4
+    : ( Vec i ) t5 . scr g5
+    ( _p256_mul_d scr delta zr zr )
+    ( _p256_mul_d scr gamma yr yr )
+    ( _p256_mul_d scr beta xr gamma )
+    // alpha = 3·(xr − delta)·(xr + delta)
+    ( __p256_sub_d scr t4 xr delta )
+    ( __p256_add_d scr t5 xr delta )
+    ( _p256_mul_d scr alpha t4 t5 )
+    ( __p256_add_d scr t4 alpha alpha )
+    ( __p256_add_d scr alpha t4 alpha )
+    // Z3 = (yr + zr)² − gamma − delta   (before xr/yr are overwritten)
+    ( __p256_add_d scr t4 yr zr )
+    ( _p256_mul_d scr t4 t4 t4 )
+    ( __p256_sub_d scr t4 t4 gamma )
+    ( __p256_sub_d scr zr t4 delta )
+    // X3 = alpha² − 8·beta
+    ( _p256_mul_d scr t4 alpha alpha )
+    ( __p256_add_d scr t5 beta beta )
+    ( __p256_add_d scr t5 t5 t5 )
+    ( __p256_add_d scr delta t5 t5 )
+    ( __p256_sub_d scr xr t4 delta )
+    // Y3 = alpha·(4·beta − X3) − 8·gamma²
+    ( __p256_sub_d scr t4 t5 xr )
+    ( _p256_mul_d scr t4 alpha t4 )
+    ( _p256_mul_d scr t5 gamma gamma )
+    ( __p256_add_d scr t5 t5 t5 )
+    ( __p256_add_d scr t5 t5 t5 )
+    ( __p256_add_d scr t5 t5 t5 )
+    ( __p256_sub_d scr yr t4 t5 )
+}
+
+// Branch-free "all four limbs zero" mask: −1 when v == 0, else 0.
+@ __p256_zmask ( Vec i ) v → i {
+    : *i vp ( vec_data [i] v )
+    : i zz | | | . vp 0 . vp 1 | . vp 2 . vp 3 0
+    // (zz | −zz) has its top bit set exactly when zz ≠ 0.
+    : i nz # i >> # u64 | zz - 0 zz 63
+    ^ - 0 - 1 nz
+}
+
+// Mixed Jacobian += affine (x2, y2), with the masked fixups the header
+// describes. `keep` is a FULL-WIDTH mask (−1 keeps the old accumulator —
+// the digit-0 case; 0 commits normally); acc = ∞ is detected here and
+// commits (x2, y2, 1) instead. `one_m` is the Montgomery 1, owned by the
+// caller. The accumulator is NOT touched until the masked commit at the
+// end, so both fixup paths still see the old point. Uses every scratch
+// register (g0..g5 + gp).
+@ _p256_jmadd_d P256Scratch scr P256Pt acc ( Vec i ) x2 ( Vec i ) y2 ( Vec i ) one_m i keep → v {
+    : ( Vec i ) X1 . acc x
+    : ( Vec i ) Y1 . acc y
+    : ( Vec i ) Z1 . acc z
+    : ( Vec i ) z3 . scr g0
+    : ( Vec i ) hreg . scr g1
+    : ( Vec i ) rreg . scr g2
+    : ( Vec i ) hh . scr g3
+    : ( Vec i ) x3 . scr g4
+    : ( Vec i ) vv . scr g5
+    : ( Vec i ) t . scr gp
+    : i inf_mask ( __p256_zmask Z1 )
+    // zz = Z1²; u2 = x2·zz; s2 = y2·Z1·zz
+    ( _p256_mul_d scr z3 Z1 Z1 )
+    ( _p256_mul_d scr hreg x2 z3 )
+    ( _p256_mul_d scr t z3 Z1 )
+    ( _p256_mul_d scr rreg y2 t )
+    // H = u2 − X1; R = s2 − Y1
+    ( __p256_sub_d scr hreg hreg X1 )
+    ( __p256_sub_d scr rreg rreg Y1 )
+    // Z3 = Z1·H (into its own register — acc stays whole until commit)
+    ( _p256_mul_d scr z3 Z1 hreg )
+    // hh = H²; V = X1·hh; X3 = R² − H³ − 2V
+    ( _p256_mul_d scr hh hreg hreg )
+    ( _p256_mul_d scr vv X1 hh )
+    ( _p256_mul_d scr x3 rreg rreg )
+    ( _p256_mul_d scr hh hreg hh )
+    ( __p256_sub_d scr x3 x3 hh )
+    ( __p256_sub_d scr x3 x3 vv )
+    ( __p256_sub_d scr x3 x3 vv )
+    // Y3 = R·(V − X3) − Y1·H³
+    ( __p256_sub_d scr vv vv x3 )
+    ( _p256_mul_d scr vv rreg vv )
+    ( _p256_mul_d scr t Y1 hh )
+    ( __p256_sub_d scr vv vv t )
+    // Masked two-stage commit: result ← (∞ ? affine : computed), then
+    // acc ← (keep ? acc : result). Element-wise merges, no branches.
+    : i ninf ^^ inf_mask - 0 1
+    : i nkeep ^^ keep - 0 1
+    ( __p256_lmerge_d x3 inf_mask ninf x2 x3 )
+    ( __p256_lmerge_d vv inf_mask ninf y2 vv )
+    ( __p256_lmerge_d z3 inf_mask ninf one_m z3 )
+    ( __p256_lmerge_d X1 nkeep keep x3 X1 )
+    ( __p256_lmerge_d Y1 nkeep keep vv Y1 )
+    ( __p256_lmerge_d Z1 nkeep keep z3 Z1 )
+}
+
+// ── affine window table (fixed-base comb) ─────────────────────────────
+// Affine Montgomery multiples of G: entry d occupies [d·8, d·8+8) as
+// x‖y. Entry 0 is all-zero — the comb never COMMITS it (digit 0 keeps
+// the accumulator via _p256_jmadd_d's mask), but the scan still reads
+// it so the trace is digit-independent.
+
+@ _p256_atbl_put ( Vec i ) tbl i d ( Vec i ) ax ( Vec i ) ay → v {
+    : *i tp ( vec_data [i] tbl )
+    : *i xp ( vec_data [i] ax )
+    : *i yp ( vec_data [i] ay )
+    : i base * d 8
+    = . tp + base 0 . xp 0
+    = . tp + base 1 . xp 1
+    = . tp + base 2 . xp 2
+    = . tp + base 3 . xp 3
+    = . tp + base 4 . yp 0
+    = . tp + base 5 . yp 1
+    = . tp + base 6 . yp 2
+    = . tp + base 7 . yp 3
+}
+
+// Constant-time masked read of entry `digit` into (ex, ey): reads all
+// sixteen entries, merges under an arithmetic equality mask — same
+// discipline as _p256_tbl_get_d.
+@ _p256_atbl_get_d ( Vec i ) ex ( Vec i ) ey ( Vec i ) tbl i digit → v {
+    : *i tp ( vec_data [i] tbl )
+    : *i xp ( vec_data [i] ex )
+    : *i yp ( vec_data [i] ey )
+    = . xp 0 0 = . xp 1 0 = . xp 2 0 = . xp 3 0
+    = . yp 0 0 = . yp 1 0 = . yp 2 0 = . yp 3 0
+    : ~ i d 0
+    ~ < d 16 {
+        : u64 z ^^ # u64 d # u64 digit
+        : i mask - 0 # i >> - z 1 63
+        : i base * d 8
+        : ~ i j 0
+        ~ < j 4 {
+            = . xp j | . xp j & mask . tp + base j
+            = . yp j | . yp j & mask . tp + + base 4 j
+            = j + j 1
+        }
+        = d + d 1
+    }
+}
+
 // ── the window table ──────────────────────────────────────────────────
 // Sixteen projective multiples of the base point, 0·B … 15·B, in one flat
-// limb vector: entry d occupies [d·24, d·24+24) as x‖y‖z. Flat because the
+// limb vector: entry d occupies [d·12, d·12+12) as x‖y‖z. Flat because the
 // constant-time read below has to walk EVERY entry, and a straight run of
 // limbs is what that walk wants.
 
@@ -800,12 +981,12 @@ $ `stdlib/core/vec.nu`
     : *i xp ( vec_data [i] . p x )
     : *i yp ( vec_data [i] . p y )
     : *i zp ( vec_data [i] . p z )
-    : i base * d 24
+    : i base * d 12
     : ~ i k 0
-    ~ < k 8 {
+    ~ < k 4 {
         = . tp + base k . xp k
-        = . tp + + base 8 k . yp k
-        = . tp + + base 16 k . zp k
+        = . tp + + base 4 k . yp k
+        = . tp + + base 8 k . zp k
         = k + k 1
     }
 }
@@ -822,18 +1003,19 @@ $ `stdlib/core/vec.nu`
     : *i xp ( vec_data [i] . dst x )
     : *i yp ( vec_data [i] . dst y )
     : *i zp ( vec_data [i] . dst z )
-    : ~ i k 0
-    ~ < k 8 { = . xp k 0 = . yp k 0 = . zp k 0 = k + k 1 }
+    = . xp 0 0 = . xp 1 0 = . xp 2 0 = . xp 3 0
+    = . yp 0 0 = . yp 1 0 = . yp 2 0 = . yp 3 0
+    = . zp 0 0 = . zp 1 0 = . zp 2 0 = . zp 3 0
     : ~ i d 0
     ~ < d 16 {
         : u64 z ^^ # u64 d # u64 digit
-        : i mask & 0xFFFFFFFF - 0 # i >> - z 1 63
-        : i base * d 24
+        : i mask - 0 # i >> - z 1 63
+        : i base * d 12
         : ~ i j 0
-        ~ < j 8 {
+        ~ < j 4 {
             = . xp j | . xp j & mask . tp + base j
-            = . yp j | . yp j & mask . tp + + base 8 j
-            = . zp j | . zp j & mask . tp + + base 16 j
+            = . yp j | . yp j & mask . tp + + base 4 j
+            = . zp j | . zp j & mask . tp + + base 8 j
             = j + j 1
         }
         = d + d 1
@@ -882,7 +1064,7 @@ $ `stdlib/core/vec.nu`
     : P256Pt acc ( _p256_pt_mag )
     : P256Pt added ( _p256_pt_mag )
     // window table: T[0] = identity, T[d] = T[d-1] + B.
-    : ( Vec i ) tbl ( _magn 384 )
+    : ( Vec i ) tbl ( _magn 192 )
     ( _p256_set_identity_d scr acc )
     ( _p256_tbl_put tbl 0 acc )
     ( _p256_tbl_put tbl 1 base )
@@ -909,7 +1091,7 @@ $ `stdlib/core/vec.nu`
         = w + w 1
     }
     // affine: x = X/Z, y = Y/Z (de-Montgomery via inverse).
-    : ( Vec i ) zinv ( _mag8 )
+    : ( Vec i ) zinv ( _mag4 )
     ( _p256_inv_d scr zinv . acc z )
     ( _p256_mul_d scr . acc x . acc x zinv )
     ( _p256_mul_d scr . acc y . acc y zinv )
@@ -925,15 +1107,16 @@ $ `stdlib/core/vec.nu`
     ^ out
 }
 
-// Append an 8-limb field element as 32 big-endian bytes to `out`.
+// Append a 4-limb field element as 32 big-endian bytes to `out`.
 @ _p256_limbs_to_be ( Vec u ) out ( Vec i ) v → v {
-    : ~ i k 7
+    : ~ i k 3
     ~ >= k 0 {
-        : i lk ( __ctl v k )
-        ( vec_push [u] out # u & >> lk 24 255 )
-        ( vec_push [u] out # u & >> lk 16 255 )
-        ( vec_push [u] out # u & >> lk 8 255 )
-        ( vec_push [u] out # u & lk 255 )
+        : u64 lk # u64 ( __ctl v k )
+        : ~ i sh 56
+        ~ >= sh 0 {
+            ( vec_push [u] out # u & # i >> lk sh 255 )
+            = sh - sh 8
+        }
         = k - k 1
     }
 }


### PR DESCRIPTION
## Why

The remaining cold-TLS-handshake gap to rustls (CI: 4 598 vs 7 504 handshakes/s) is P-256 arithmetic depth: server CPU was 775 µs/handshake vs rustls' 332, dominated by ECDSA signing.

## What

**Native 4×64 limb storage.** The constant-time field stored elements as eight 32-bit limbs and packed/unpacked to 4×64 inside *every* Montgomery multiply (~24 extra ops × ~1500 multiplies per scalar-mult), with 8-limb manual-carry loops in add/sub. Elements are now four 64-bit limbs end to end; add/sub/cond-sub are `nurl_addc`/`nurl_subb` register chains. `ecdsa_sign` 168→134 µs, keygen 130→96 µs from the repr change alone — bit-identical outputs.

**Jacobian fixed-base comb.** k·G (ECDSA nonce, ECDH keygen) moves from complete RCB projective addition — 14 muls for every doubling *and* addition — to Jacobian coordinates with an affine table: dbl-2001-b (3M+5S) + mixed add (8M+3S). Completeness is replaced case by case with constant-time masks:
- acc = ∞ → commits (x₂, y₂, 1) via a branch-free Z==0 mask
- digit = 0 → keeps the accumulator through the same masked select (the add still runs, trace stays digit-independent)
- acc = −entry → the formula itself yields ∞ (Z₃ = Z₁·H = 0)
- acc = entry (doubling case) → ~2⁻²²⁴ event for the secret pseudorandom scalars this path serves; same bound ecp_nistz256 accepts. Adversarial inputs never reach this path — the variable-base ladder keeps the complete formula.

`ecdsa_sign` 134→96 µs, keygen 96→62 µs.

**Measured-and-removed:** a dedicated Montgomery squaring (10 products vs 16) was implemented and verified over 200k differential inputs — and benched at parity with the interleaved multiply on this µarch, so it was deleted rather than kept as unproven complexity.

## Verification

- `p256_ct_field`: 400 field-op trials + 60 variable-base scalar-mult trials vs the bigint reference — PASS
- New `p256_scalarmult_base_kat`: 18 vectors cross-checked against an independent Python implementation, including the structured edges that exercise every masked exceptional path (k = 1/2/3, long zero-teeth runs, single-tooth and tooth-aligned scalars, n−1)
- ECDSA sign/verify KATs, PEM/CSR/x509 tests, TLS interop suite — full suite green

## Handshake effect (local i7-5930K; rustls same host in parens)

| metric | before | after |
|---|---:|---:|
| server CPU / handshake | 775 µs | **659 µs** (332) |
| cold handshakes/s c=1 | 705 | **853** (1 751) |
| cold handshakes/s c=20 | 7 664 | **8 753** (12 145) |

Remaining gap is now spread across x25519 (~120 µs, 10×26-bit limb field), hashing/HKDF, per-handshake allocations, and kernel time — each scoped as follow-up in the session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU