### PR TITLE
bench: compile C and Rust with the same optimisation pipeline as NURL

### DIFF
--- a/bench/bench.sh
+++ b/bench/bench.sh
@@ -35,6 +35,11 @@
 # ============================================================
 set -u
 
+# $EPOCHREALTIME's decimal separator and awk's %f output both follow the
+# locale; under e.g. fi_FI a comma where time_ms expects a dot turns
+# compile times negative. Pin the whole run to C.
+export LC_ALL=C
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BENCH="$ROOT/bench"
 BUILD="$BENCH/_build"
@@ -219,13 +224,35 @@ compile_nurl() {           # <src.nu> <outbase> -> "<frontend_ms> <total_ms> <wa
     echo "$(median "${fe[@]}") $(median "${tot[@]}") $(median "${wtot[@]}")"
 }
 
+# The C and Rust columns get the same optimisation pipeline the NURL
+# column gets, not a nominally-equal `-O2`. The NURL driver compiles at
+# $OPT but runs the ThinLTO *backend* at O3 (`-plugin-opt,O3`, see
+# compile_nurl above), and that backend pass is where LLVM makes its
+# biggest run-time decisions — e.g. on `nbody` it is what fully unrolls
+# the five-body loops and keeps the system state in registers, worth
+# 1.7x. So: C goes through the identical clang ThinLTO pipeline, and
+# Rust runs `-C opt-level=3` — rustc has no separate prelink/backend
+# knob, and opt-level 3 is what `cargo build --release` ships, so it is
+# both the closest equivalent and Rust's standard release setting.
 compile_c() {              # <src.c> <outbase> -> "<ms>" or FAIL
-    local src="$1" bin="$2.c.bin" out=() r t
+    local src="$1" obj="$2.c.o" bin="$2.c.bin" out=() r t l
     for ((r = 0; r < COMPILE_REPS; r++)); do
-        # shellcheck disable=SC2086
-        t="$(cd "$ROOT" && time_ms clang $OPT "$src" -lm -o "$bin")"
-        [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
-        out+=("$t")
+        if [[ "$(uname -s)" == Linux ]]; then
+            # shellcheck disable=SC2086
+            t="$(cd "$ROOT" && time_ms clang $OPT -flto=thin -c "$src" -o "$obj")"
+            [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
+            # shellcheck disable=SC2086
+            l="$(cd "$ROOT" && time_ms clang $OPT -flto=thin -Wl,-plugin-opt,O3 \
+                     -Wl,--as-needed "$obj" -lm -o "$bin")"
+            [[ "$l" == FAIL || "$l" == TIMEOUT ]] && { echo FAIL; return 1; }
+            out+=("$(awk -v a="$t" -v b="$l" 'BEGIN { printf "%.3f", a + b }')")
+        else
+            # Non-Linux fallback: full LTO, matching compile_nurl's.
+            # shellcheck disable=SC2086
+            t="$(cd "$ROOT" && time_ms clang $OPT -flto "$src" -lm -o "$bin")"
+            [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
+            out+=("$t")
+        fi
     done
     median "${out[@]}"
 }
@@ -233,7 +260,7 @@ compile_c() {              # <src.c> <outbase> -> "<ms>" or FAIL
 compile_rust() {           # <src.rs> <outbase> -> "<ms>" or FAIL
     local src="$1" bin="$2.rs.bin" out=() r t
     for ((r = 0; r < COMPILE_REPS; r++)); do
-        t="$(cd "$ROOT" && time_ms rustc -C opt-level=2 "$src" -o "$bin")"
+        t="$(cd "$ROOT" && time_ms rustc -C opt-level=3 "$src" -o "$bin")"
         [[ "$t" == FAIL || "$t" == TIMEOUT ]] && { echo FAIL; return 1; }
         out+=("$t")
     done
@@ -441,7 +468,7 @@ emit_md() {
     printf '| Python | %s |\n' "$PYTHON_VERSION"
     printf '\n'
     printf '| Setting | Value |\n|---|---|\n'
-    printf '| Optimisation | NURL/C `clang %s`, Rust `-C opt-level=2` |\n' "$OPT"
+    printf '| Optimisation | NURL/C `clang %s -flto=thin` + ThinLTO backend O3, Rust `-C opt-level=3` |\n' "$OPT"
     printf '| Timed runs per cell | up to %s, adaptive: as many as fit in %s ms |\n' "$MAX_REPS" "$BUDGET_MS"
     printf '| Timed compiles per cell | %s (median) |\n' "$COMPILE_REPS"
     printf '| Per-run timeout | %s s |\n' "$TIMEOUT_S"

--- a/bench/nbody.c
+++ b/bench/nbody.c
@@ -27,6 +27,11 @@
 //     `-mfma`-bearing flag is ever added to `bench.sh`, this row needs
 //     an explicit `-ffp-contract=off` or its gate will start failing.**
 //     Rust never contracts without `f64::mul_add`, so it is unaffected.
+//     Lacking FMA hardware is NOT full protection, either: clang still
+//     emits `llvm.fmuladd`, and LLVM constant-folds that *fused* — a
+//     variant of this file with the whole setup visible to the constant
+//     folder produced a different checksum at plain `-O2`, no `-march`
+//     involved. The gate catches it; this note explains what happened.
 //   * The five files evaluate the operations in the same order. IEEE
 //     addition is not associative, so a reordered sum is a different
 //     number, and the gate would catch it as a mismatch rather than
@@ -57,10 +62,14 @@
 // pointer per body instead of seven — but the layout has to be the same
 // in all five ports or the row measures struct layout as well as FP
 // throughput. Measured on this corpus: AoS C retires 274.0M
-// instructions, SoA C 290.1M, and NURL — which is SoA — 291.9M. Held to
-// one layout the backends agree to well under a per cent; held to two,
-// the row would have reported a 6% spread that has nothing to do with
-// floating point. SoA is the one layout that is natural in all five
+// instructions, SoA C 290.1M. (NURL and Rust retire ~185M on the same
+// source shape: their frontends' IR passes LLVM's full-unroll cost
+// model at the O3 backend stage, which flattens the five-body loops and
+// keeps the state in registers; clang's C-shaped IR does not, at any
+// flag level tried — -O3, -fno-math-errno, locals, LTO. The gap is an
+// LLVM cost-model artifact, not extra work in the C.) Held to two
+// layouts, the row would have added a 6% spread that has nothing to do
+// with floating point. SoA is the one layout that is natural in all five
 // languages at once: an AoS Python port would be a list of objects and
 // would measure the interpreter's object model instead of its float
 // path.

--- a/bench/nbody.rs
+++ b/bench/nbody.rs
@@ -4,7 +4,7 @@
 // print the total energy (see the C peer for the full rationale).
 //
 // Rust never contracts a multiply-add into an fma without an explicit
-// `f64::mul_add`, and `-C opt-level=2` implies no fast-math, so this
+// `f64::mul_add`, and no rustc opt-level implies fast-math, so this
 // port needs no flag to stay bit-identical with the other four.
 const NBODY: usize = 5;
 const STEPS: u32 = 500_000;


### PR DESCRIPTION
## Why

The NURL column is built by the standard driver pipeline (`clang -O2 -flto=thin` + ThinLTO backend at O3 via `-plugin-opt,O3` — the same link `nurl.sh` ships), while C was compiled at plain `-O2` and Rust at `-C opt-level=2`. The run-time table therefore compared a backend-O3 NURL binary against O2 peers.

On `nbody` that asymmetry was the entire 1.7× NURL lead: the O3 backend fully unrolls the five-body loops and SLP-vectorises the state into registers (0.7M vs 13.3M dynamic branches, 185M vs 290M retired instructions — same math, bit-identical checksum). Rust at its own release optimisation gets the same transformation and ties NURL (~119M vs ~123M cycles); the O2 pin hid that. C as written never unrolls this nest at any flag level tried (`-O3`, `-fno-math-errno`, local arrays, identical LTO pipeline) — an LLVM cost-model artifact of clang's C-shaped IR, now documented in the source.

## What

- `compile_c`: identical clang ThinLTO pipeline (`-O2 -flto=thin -c`, link with `-plugin-opt,O3`; full `-flto` fallback on non-Linux, mirroring `compile_nurl`), timed as the sum of both stages like the NURL column.
- `compile_rust`: `-C opt-level=3` — rustc has no prelink/backend split, and opt-level 3 is what `cargo build --release` ships, so it is both the closest equivalent and Rust's standard release setting.
- RESULTS.md Optimisation row now states the real settings.
- `export LC_ALL=C` at the top: `time_ms` splits `$EPOCHREALTIME` on a dot and awk prints `%f` per locale, so comma-decimal locales (e.g. fi_FI) produced negative compile times and comma-formatted tables in local runs. CI (C locale) was unaffected.
- `nbody.c`/`nbody.rs` comments: replaced the stale instruction-count parity claim and noted that missing FMA hardware does not fully rule out fp-contract drift — LLVM constant-folds `llvm.fmuladd` fused, which the checksum gate catches (verified experimentally).

The PQ peer suite (#952) already has parity — its Rust side builds with `opt-level=3` + fat LTO + `codegen-units=1` — so no change there.

## Verification

- Full suite `--quick` with the new flags: all 15 rows pass the correctness gate (identical output across the 5 languages).
- `nbody` full rerun: NURL 36.2 / Rust 38.2 / C 58.0 ms — NURL and Rust effectively tied, as the isolated perf counters predicted.

RESULTS.md / latest.json still carry the old numbers; the bench workflow regenerates and commits them on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU