### PR TITLE
bench: PQ report explains where the NURL-vs-Rust ratios come from

### DIFF
--- a/bench/PQ_RESULTS.md
+++ b/bench/PQ_RESULTS.md
@@ -1,8 +1,8 @@
 # NURL post-quantum crypto peer-comparison
 
-Generated `2026-08-20T11:11:13Z` by `bench/run_pq.sh`. **Do not edit by hand** — the next run overwrites it.
+Generated `2026-08-20T13:12:24Z` by `bench/run_pq.sh`. **Do not edit by hand** — the next run overwrites it.
 
-Single-core µs/op for the three NIST post-quantum standards — ML-KEM (FIPS 203, the KEM in the X25519MLKEM768 hybrid TLS group), ML-DSA (FIPS 204, certificate signatures) and SLH-DSA (FIPS 205, the hash-based fallback) — plus the SHAKE128 bulk throughput they are all built from. NURL is the pure-NURL stdlib (`std/mlkem`, `std/mldsa`, `std/slhdsa`); Rust is the pure-Rust RustCrypto crates. Both sides are portable safe-language implementations with no hand-written assembly, measured by the same harness discipline (iteration-calibrated timed loops, per-op OS randomness, hedged signing, medians of 3 runs).
+Single-core µs/op for the three NIST post-quantum standards — ML-KEM (FIPS 203, the KEM in the X25519MLKEM768 hybrid TLS group), ML-DSA (FIPS 204, certificate signatures) and SLH-DSA (FIPS 205, the hash-based fallback) — plus the SHAKE128 bulk throughput they are all built from. NURL is the pure-NURL stdlib (`std/mlkem`, `std/mldsa`, `std/slhdsa`); Rust is the pure-Rust RustCrypto crates. Both sides are portable safe-language implementations with no hand-written assembly, measured by the same harness discipline (iteration-calibrated timed loops, per-op OS randomness, hedged signing, medians of 3 runs). The ratios compare those two implementations, not the two languages — "Where the ratios come from" below says what they do and do not show.
 
 ## Environment
 
@@ -12,8 +12,8 @@ Single-core µs/op for the three NIST post-quantum standards — ML-KEM (FIPS 20
 | Kernel | `Linux 7.0.0-28-generic x86_64` |
 | CPU | Intel(R) Core(TM) i7-5930K CPU @ 3.50GHz (12 logical cores) |
 | Memory | 32770952 KiB |
-| Commit | `3a6bb8fbe79bb466f0ac9a4d40bdbc0e493a34d5` |
-| NURL | `v0.45.0-23-g21ad5f25-dirty` |
+| Commit | `d8509c7d81045be34a29554a680f9030ef66c99f` |
+| NURL | `v0.45.0-20-g8257c78a-dirty` |
 | Rust | rustc 1.97.1 (8bab26f4f 2026-07-14) |
 
 | Implementation | Source |
@@ -27,59 +27,67 @@ Every scheme below spends most of its cycles in Keccak; this is the one-shot abs
 
 | | NURL | Rust |
 |---|---:|---:|
-| SHAKE128 absorb 8 MB | **354 MB/s** | 350 MB/s |
+| SHAKE128 absorb 8 MB | 345 MB/s | **348 MB/s** |
 
 ## ML-KEM (FIPS 203)
 
 | Operation | NURL µs/op | Rust µs/op | Rust / NURL |
 |---|---:|---:|---:|
-| ML-KEM-512 keygen | **18.7** | 29.8 | 1.59× |
-| ML-KEM-512 encaps | **20.2** | 28.2 | 1.40× |
-| ML-KEM-512 decaps | **25.3** | 35.1 | 1.39× |
-| ML-KEM-768 keygen | **29.6** | 50.6 | 1.71× |
-| ML-KEM-768 encaps | **29.9** | 47.1 | 1.58× |
-| ML-KEM-768 decaps | **36.6** | 58.6 | 1.60× |
-| ML-KEM-1024 keygen | **41.8** | 80.9 | 1.93× |
-| ML-KEM-1024 encaps | **41.1** | 73.5 | 1.79× |
-| ML-KEM-1024 decaps | **49.9** | 86.9 | 1.74× |
+| ML-KEM-512 keygen | **18.7** | 29.7 | 1.58× |
+| ML-KEM-512 encaps | **20.2** | 26.7 | 1.32× |
+| ML-KEM-512 decaps | **25.4** | 34.3 | 1.35× |
+| ML-KEM-768 keygen | **28.8** | 50.8 | 1.76× |
+| ML-KEM-768 encaps | **29.8** | 46.8 | 1.57× |
+| ML-KEM-768 decaps | **36.4** | 58.2 | 1.60× |
+| ML-KEM-1024 keygen | **42.1** | 80.2 | 1.90× |
+| ML-KEM-1024 encaps | **41.2** | 73.2 | 1.78× |
+| ML-KEM-1024 decaps | **50.3** | 87.1 | 1.73× |
 
 ## ML-DSA (FIPS 204)
 
 | Operation | NURL µs/op | Rust µs/op | Rust / NURL |
 |---|---:|---:|---:|
-| ML-DSA-44 keygen | **45.6** | 176 | 3.86× |
-| ML-DSA-44 sign | **157** | 404 | 2.58× |
-| ML-DSA-44 verify | **50.2** | 51.1 | 1.02× |
-| ML-DSA-65 keygen | **98.4** | 284 | 2.88× |
-| ML-DSA-65 sign | **266** | 600 | 2.26× |
-| ML-DSA-65 verify | 87.2 | **70.3** | 0.81× |
-| ML-DSA-87 keygen | **125** | 448 | 3.58× |
-| ML-DSA-87 sign | **305** | 745 | 2.45× |
-| ML-DSA-87 verify | 129 | **99.6** | 0.77× |
+| ML-DSA-44 keygen | **48.9** | 177 | 3.61× |
+| ML-DSA-44 sign | **162** | 439 | 2.71× |
+| ML-DSA-44 verify | **49.9** | 51.3 | 1.03× |
+| ML-DSA-65 keygen | **97.7** | 288 | 2.94× |
+| ML-DSA-65 sign | **262** | 689 | 2.64× |
+| ML-DSA-65 verify | 80.4 | **69.9** | 0.87× |
+| ML-DSA-87 keygen | **116** | 440 | 3.81× |
+| ML-DSA-87 sign | **301** | 660 | 2.19× |
+| ML-DSA-87 verify | 124 | **98.9** | 0.80× |
 
 ## SLH-DSA (FIPS 205)
 
 | Operation | NURL µs/op | Rust µs/op | Rust / NURL |
 |---|---:|---:|---:|
-| SLH-DSA-SHAKE-128s keygen | **39 981** | 281 113 | 7.03× |
-| SLH-DSA-SHAKE-128s sign | **331 650** | 2 140 089 | 6.45× |
-| SLH-DSA-SHAKE-128s verify | **570** | 2 023 | 3.55× |
-| SLH-DSA-SHAKE-128f keygen | **697** | 4 423 | 6.34× |
-| SLH-DSA-SHAKE-128f sign | **18 885** | 103 870 | 5.50× |
-| SLH-DSA-SHAKE-128f verify | **1 572** | 6 172 | 3.93× |
-| SLH-DSA-SHAKE-192f keygen | **966** | 6 491 | 6.72× |
-| SLH-DSA-SHAKE-192f sign | **36 021** | 164 480 | 4.57× |
-| SLH-DSA-SHAKE-192f verify | **2 314** | 8 988 | 3.89× |
-| SLH-DSA-SHAKE-256f keygen | **2 888** | 16 807 | 5.82× |
-| SLH-DSA-SHAKE-256f sign | **63 674** | 338 902 | 5.32× |
-| SLH-DSA-SHAKE-256f verify | **2 459** | 8 783 | 3.57× |
+| SLH-DSA-SHAKE-128s keygen | **47 170** | 281 027 | 5.96× |
+| SLH-DSA-SHAKE-128s sign | **368 241** | 2 116 265 | 5.75× |
+| SLH-DSA-SHAKE-128s verify | **526** | 2 153 | 4.09× |
+| SLH-DSA-SHAKE-128f keygen | **654** | 4 354 | 6.65× |
+| SLH-DSA-SHAKE-128f sign | **20 375** | 101 136 | 4.96× |
+| SLH-DSA-SHAKE-128f verify | **1 561** | 6 100 | 3.91× |
+| SLH-DSA-SHAKE-192f keygen | **970** | 6 517 | 6.72× |
+| SLH-DSA-SHAKE-192f sign | **33 635** | 164 762 | 4.90× |
+| SLH-DSA-SHAKE-192f verify | **2 263** | 8 808 | 3.89× |
+| SLH-DSA-SHAKE-256f keygen | **2 535** | 16 561 | 6.53× |
+| SLH-DSA-SHAKE-256f sign | **64 816** | 336 254 | 5.19× |
+| SLH-DSA-SHAKE-256f verify | **2 638** | 8 952 | 3.39× |
 
 (Best per row in **bold**. `Rust / NURL` > 1 means NURL is faster. `n/a` = toolchain absent or the harness failed.)
+
+## Where the ratios come from
+
+This table compares two implementations, not two languages. Before quoting a ratio, know what it is made of:
+
+- **Start from the control row.** Single-lane SHAKE128 is the closest thing here to a pure language-and-compiler comparison: the same scalar Keccak permutation, the same workload, no API or vectorisation asymmetry on either side. In this run the two columns are within 1% of each other. Ratios far above that elsewhere are implementation differences, not language ones — compare the ML-DSA verify rows (0.80–1.03× in this run), the least asymmetric scheme-level operations.
+- **SLH-DSA (3.4–6.7×): batched Keccak vs scalar Keccak.** SLH-DSA's cost is thousands of short, independent hash chains. NURL batches them four Keccak lanes at a time (`std/hash_sha3x4`: `simd`-prefixed NURL source the compiler vectorises to AVX2 behind a runtime CPU check); RustCrypto `slh-dsa` hashes one lane at a time. No assembly on either side, but these rows compare a batched implementation against a scalar one. A Rust port of the same four-lane strategy (e.g. via `std::simd`) should close most of this gap; no such crate path existed at measurement time.
+- **ML-KEM and ML-DSA (0.8–3.8×): a tuned implementation against young crates.** Both columns spend most of these cycles in the same scalar Keccak the control row measures directly, so the gaps live in what surrounds it — sampling, NTT, serialisation, memory traffic. The RustCrypto lattice crates are pre-1.0 and have not had a dedicated performance pass; the NURL stdlib has been profiled and tuned across several releases. These rows have not been root-caused one by one: read them as optimised-vs-not-yet-optimised implementations, with the language contribution bounded by the control row above.
+- **Neither column is the fastest known.** The scheme authors' AVX2 assembly implementations beat both columns on the lattice schemes; see the header of `bench/pq.nu` for that comparison.
 
 ## Notes
 
 - **Correctness is pinned elsewhere.** Every NURL algorithm here is byte-exact against NIST ACVP vectors (`tools/*_acvp_gate.nu`); this report only measures speed.
-- **Both sides are portable code.** No hand-written assembly on either side. NURL's edge in SLH-DSA comes from running four independent Keccak lanes at a time through `std/hash_sha3x4` behind the `simd` prefix — same source language, vectorised by the compiler. The scheme authors' AVX2 implementations are faster than both sides on the lattice schemes; see the header of `bench/pq.nu` for that comparison.
 - **API-surface caveat (ML-DSA sign).** RustCrypto signs from a pre-expanded signing key (expansion paid once at keygen); NURL's `mldsa_sign` takes the FIPS 204 byte-string secret key and expands per call. The NURL column pays that expansion inside every sign op, the Rust column does not.
 - **Randomness.** Keygen, encaps and hedged signing draw per-op OS entropy on both sides (NURL `nurl_rand_fill`, Rust `SysRng`), so the syscall cost is in both columns.
 - Single core, loopback-free, allocation costs included. Absolute numbers depend heavily on the host; compare columns within one run, not across machines.

--- a/bench/gen_pq_results.py
+++ b/bench/gen_pq_results.py
@@ -77,7 +77,9 @@ def main():
         "language implementations with no hand-written assembly, "
         "measured by the same harness discipline (iteration-calibrated "
         "timed loops, per-op OS randomness, hedged signing, medians "
-        f"of {env.get('runs','3')} runs)."
+        f"of {env.get('runs','3')} runs). The ratios compare those two "
+        "implementations, not the two languages — \"Where the ratios "
+        "come from\" below says what they do and do not show."
     )
     w("")
 
@@ -185,21 +187,106 @@ def main():
     )
     w("")
 
+    # ── where the ratios come from ───────────────────────────────
+    # This section is the report's honesty contract: it separates what
+    # the numbers say about the two implementations from what they do
+    # NOT say about the two languages. Everything quantitative in it is
+    # computed from this run's data so it can never drift out of date.
+    def ratio_range(prefix):
+        ratios = []
+        for n in row_names:
+            if not n.startswith(prefix):
+                continue
+            a, b = med(rows, n, "nurl"), med(rows, n, "rust")
+            if a and b:
+                ratios.append(b / a)
+        return (min(ratios), max(ratios)) if ratios else None
+
+    shake_pct = None
+    if thr_names:
+        a = med(thr, thr_names[0], "nurl")
+        b = med(thr, thr_names[0], "rust")
+        if a and b:
+            shake_pct = abs(a / b - 1) * 100
+
+    w("## Where the ratios come from\n")
+    w(
+        "This table compares two implementations, not two languages. "
+        "Before quoting a ratio, know what it is made of:"
+    )
+    w("")
+    if shake_pct is not None:
+        verify_ratios = [
+            med(rows, n, "rust") / med(rows, n, "nurl")
+            for n in row_names
+            if n.startswith("ML-DSA-") and "verify" in n
+            and med(rows, n, "nurl") and med(rows, n, "rust")
+        ]
+        vr = (
+            f" — compare the ML-DSA verify rows "
+            f"({min(verify_ratios):.2f}–{max(verify_ratios):.2f}× in "
+            "this run), the least asymmetric scheme-level operations"
+            if verify_ratios
+            else ""
+        )
+        w(
+            "- **Start from the control row.** Single-lane SHAKE128 is "
+            "the closest thing here to a pure language-and-compiler "
+            "comparison: the same scalar Keccak permutation, the same "
+            "workload, no API or vectorisation asymmetry on either "
+            f"side. In this run the two columns are within "
+            f"{shake_pct:.0f}% of each other. Ratios far above that "
+            "elsewhere are implementation differences, not language "
+            f"ones{vr}."
+        )
+    slh = ratio_range("SLH-DSA-")
+    slh_span = f" ({slh[0]:.1f}–{slh[1]:.1f}×)" if slh else ""
+    w(
+        f"- **SLH-DSA{slh_span}: batched Keccak vs scalar Keccak.** "
+        "SLH-DSA's cost is thousands of short, independent hash "
+        "chains. NURL batches them four Keccak lanes at a time "
+        "(`std/hash_sha3x4`: `simd`-prefixed NURL source the compiler "
+        "vectorises to AVX2 behind a runtime CPU check); RustCrypto "
+        "`slh-dsa` hashes one lane at a time. No assembly on either "
+        "side, but these rows compare a batched implementation "
+        "against a scalar one. A Rust port of the same four-lane "
+        "strategy (e.g. via `std::simd`) should close most of this "
+        "gap; no such crate path existed at measurement time."
+    )
+    kem = ratio_range("ML-KEM-")
+    dsa = ratio_range("ML-DSA-")
+    lattice_span = ""
+    if kem and dsa:
+        lo = min(kem[0], dsa[0])
+        hi = max(kem[1], dsa[1])
+        lattice_span = f" ({lo:.1f}–{hi:.1f}×)"
+    w(
+        f"- **ML-KEM and ML-DSA{lattice_span}: a tuned implementation "
+        "against young crates.** Both columns spend most of these "
+        "cycles in the same scalar Keccak the control row measures "
+        "directly, so the gaps live in what surrounds it — sampling, "
+        "NTT, serialisation, memory traffic. The RustCrypto lattice "
+        "crates are pre-1.0 and have not had a dedicated performance "
+        "pass; the NURL stdlib has been profiled and tuned across "
+        "several releases. These rows have not been root-caused "
+        "one by one: read them as optimised-vs-not-yet-optimised "
+        "implementations, with the language contribution bounded by "
+        "the control row above."
+    )
+    w(
+        "- **Neither column is the fastest known.** The scheme "
+        "authors' AVX2 assembly implementations beat both columns on "
+        "the lattice schemes; see the header of `bench/pq.nu` for "
+        "that comparison."
+    )
+    w("")
+
     # ── notes ────────────────────────────────────────────────────
     w("## Notes\n")
     w(
         "- **Correctness is pinned elsewhere.** Every NURL algorithm "
         "here is byte-exact against NIST ACVP vectors "
         "(`tools/*_acvp_gate.nu`); this report only measures speed."
-    )
-    w(
-        "- **Both sides are portable code.** No hand-written assembly "
-        "on either side. NURL's edge in SLH-DSA comes from running four "
-        "independent Keccak lanes at a time through `std/hash_sha3x4` "
-        "behind the `simd` prefix — same source language, vectorised by "
-        "the compiler. The scheme authors' AVX2 implementations are "
-        "faster than both sides on the lattice schemes; see the header "
-        "of `bench/pq.nu` for that comparison."
     )
     w(
         "- **API-surface caveat (ML-DSA sign).** RustCrypto signs from "


### PR DESCRIPTION
## Why

The PQ peer-comparison report presents large NURL-over-Rust ratios (up to ~7×) that are real measurements but invite a wrong conclusion — that they measure language speed. The report's own data says otherwise: the single-lane SHAKE128 control row has the two toolchains within ~1% on the shared Keccak core, and the ML-DSA verify rows sit at 0.80–1.03×. The big ratios come from implementation differences:

- **SLH-DSA (3.4–6.7×)**: NURL batches four independent Keccak lanes through `std/hash_sha3x4` (`simd`-prefixed source, compiler-vectorised AVX2 behind a runtime CPU check); RustCrypto `slh-dsa` hashes one lane at a time. Batched vs scalar, not NURL vs Rust.
- **ML-KEM / ML-DSA (0.8–3.8×)**: pre-1.0 RustCrypto crates with no dedicated performance pass, against a stdlib that has been profiled and tuned across releases.

A knowledgeable reader would spot this gap between the table and the framing; the report should spot it first.

## What

- New **"Where the ratios come from"** section in `gen_pq_results.py`, stating the above explicitly, plus: neither column is the fastest known (the scheme authors' AVX2 assembly beats both on the lattice schemes).
- Every quantitative claim in the section — the control-row spread, the per-family ratio ranges, the verify-row range — is **computed from the run's own data** at generation time, so the prose can never contradict the tables it sits next to, in this run or any future one.
- The intro paragraph now says up front that the ratios compare two implementations, not two languages, and points at the section.
- The old "Both sides are portable code" note folded into the new section (its content is there, expanded).
- `PQ_RESULTS.md` regenerated with the new generator (numbers moved only within noise; the SHAKE control row happened to flip to Rust's favour by 1%, which is the point of having it).

## Verification

Generator smoke-tested with synthetic input, then a full `bench/run_pq.sh` run (3 repetitions) produced the committed report; the new section's computed figures match the tables in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU