### PR TITLE
bench: fix PQ CI committing an all-n/a NURL column as a green run

### DIFF
--- a/bench/run_pq.sh
+++ b/bench/run_pq.sh
@@ -61,21 +61,29 @@ NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # ── build both harnesses ────────────────────────────────────────────
 NURL_BIN="$BENCH/_build/pq_compare"
 RUST_BIN="$BENCH/rust_pq/target/release/pq_bench"
+mkdir -p "$BENCH/_build"   # gitignored; absent on a fresh checkout (CI)
 
+# A missing toolchain downgrades its column to n/a — that is what the
+# report's n/a legend means, and a local run without cargo should still
+# produce the NURL half. A *failed build* is different: the toolchain is
+# present and something is broken, and an n/a column published by a
+# green run hides exactly the failure the run exists to surface (this
+# happened: the 2026-08-20 CI run committed an all-n/a NURL column to
+# main because nurl.sh could not create bench/_build). Fail hard.
 nurl_ready=0
 if (( have_nurl )); then
     # nurl.sh is the standard compile+link driver (resolves stdlib
     # imports relative to $ROOT, links runtime.o with the right libs).
-    if ( cd "$ROOT" && ./nurl.sh -O2 bench/pq_compare.nu "$NURL_BIN" >&2 ); then
-        nurl_ready=1
-    fi
+    ( cd "$ROOT" && ./nurl.sh -O2 bench/pq_compare.nu "$NURL_BIN" >&2 ) \
+        || { echo "run_pq.sh: NURL harness build failed" >&2; exit 1; }
+    nurl_ready=1
 fi
 
 rust_ready=0
 if (( have_rs )); then
-    if cargo build --release --manifest-path "$BENCH/rust_pq/Cargo.toml" >&2; then
-        rust_ready=1
-    fi
+    cargo build --release --manifest-path "$BENCH/rust_pq/Cargo.toml" >&2 \
+        || { echo "run_pq.sh: Rust harness build failed" >&2; exit 1; }
+    rust_ready=1
 fi
 
 # RustCrypto crate versions, for the report's implementation table.


### PR DESCRIPTION
## Why

The 2026-08-20 [pq-bench run](https://github.com/nurl-lang/nurl/actions/runs/32375360082) committed a PQ_RESULTS.md to main whose entire NURL column is `n/a` — from a green job. Root cause in the step log:

```
./nurl.sh: 295: cannot create .../bench/_build/pq_compare.ll: Directory nonexistent
```

`bench/_build/` is gitignored and `run_pq.sh` never creates it, so the NURL harness build fails on any fresh checkout. Locally the directory always exists from earlier `bench.sh` runs, which is why this only bit in CI. The failure then took the same `nurl_ready=0` path as "nurlc not installed", which renders as `n/a` — the exact comparison the run exists to produce vanished without failing anything.

## What

- `mkdir -p bench/_build` before building the harnesses (`run_http.sh` already does this).
- A failed harness build is now **fatal**, on both the NURL and Rust side. Only a genuinely absent toolchain downgrades its column to `n/a`, which is what the report legend says `n/a` means — and it keeps a local run without cargo producing the NURL half.

## Verification

From a wiped `bench/_build`, `RUNS=1` run: NURL harness builds, both columns populate, the only remaining "n/a" in the output is the legend text itself.

After merge, re-dispatch the pq-bench workflow to replace the all-n/a report currently on main with a full runner-measured one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU