### PR TITLE
swarm-mcp: widen the wasmtime pin to ^0.9.0

### DIFF
--- a/packages/swarm-mcp/nurl.toml
+++ b/packages/swarm-mcp/nurl.toml
@@ -6,4 +6,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 wasmbuilder = { path = "../wasmbuilder", version = "^0.1.5" }
-wasmtime = { path = "../wasmtime", version = "^0.8.2" }
+wasmtime = { path = "../wasmtime", version = "^0.9.0" }


### PR DESCRIPTION
`wasmtime` 0.9.0 is the operand-forwarding release (#968) — 36–60 % faster on the wasm benchmark corpus. `swarm-mcp` runs CPU wasm kernels **in-process** on that interpreter, so this is its hot path, not a transitive detail.

The pin said `^0.8.2`, which under 0.x semver excludes 0.9.0, and `nurlpkg publish` refused the package for it:

```
dependency 'wasmtime' requires '^0.8.2' but the local copy is 0.9.0
  You build against the local source; everyone else resolves the requirement
  from the registry — they would compile against different code. Widen the
  requirement (and publish that version) before publishing this package.
```

Exactly right: 0.25.0 was unpublishable, and publishing it against `^0.8.2` would have shipped a package that builds here from the new interpreter and builds for everyone else from the old one.

`nurlpkg publish --dry-run` passes every gate with the widened pin (compile against the installed toolchain included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CSENqvFreiyzrt6EpXiEN