### PR TITLE
Fix wasm-bench: the socket bridge must be opt-in per program, not per linker flag

### DIFF
--- a/packages/wasmbuilder/src/build.nu
+++ b/packages/wasmbuilder/src/build.nu
@@ -195,7 +195,24 @@ $ `toolchain.nu`
     : ~ WbCompiler cc @ WbCompiler { ( string_new ) T }
     ?? cr { T c → { ( wb_compiler_free cc ) = cc c } F e → { ( string_free ir_fixed ) ^ @ !v String { F e } } }
 
-    : !String String ror ( wb_ensure_wasm_obj_feat cc `runtime.c` ? . opts threads `threads` `` )
+    // Does this program reach the socket layer at all? The runtime object
+    // gets the `nurl_net` import bridge only then — otherwise the module
+    // would declare imports it never calls, and a runtime that cannot
+    // resolve them (the reference wasmtime, a browser) refuses to
+    // instantiate it. --gc-sections used to hide that by dropping the
+    // unused wrappers; --no-gc-sections did not, which is how a socket-free
+    // benchmark ended up unrunnable.
+    // A CALL, not a declare: nurlc's preamble declares the whole raw socket
+    // ABI in every program, so matching the declaration would turn the
+    // bridge on for a program that never opens anything.
+    : b uses_net ( __wb_ir_uses `call [^@\n]*@nurl_(tcp|udp|dns)_[a-z_0-9]+\(` ir_fixed )
+    : ~ String feat ( string_new )
+    ? uses_net { ( string_push_str feat `net` ) } {}
+    ? . opts threads {
+        ? > ( string_len feat ) 0 { ( string_push_char feat 45 ) } {}
+        ( string_push_str feat `threads` )
+    } {}
+    : !String String ror ( wb_ensure_wasm_obj_feat cc `runtime.c` ( string_data feat ) )
     : ~ String runtime_o ( string_new )
     ?? ror { T p → { ( string_free runtime_o ) = runtime_o p } F e → {
             ( string_free ir_fixed ) ( wb_compiler_free cc )

--- a/packages/wasmbuilder/src/toolchain.nu
+++ b/packages/wasmbuilder/src/toolchain.nu
@@ -577,9 +577,16 @@ $ `stdlib/ext/http_cli.nu`
     ? . cc is_zig { ( vec_push [s] args `cc` ) } {}
     ( vec_push [s] args `--target=wasm32-wasi` )
     ( vec_push [s] args `-O2` )
-    ? != 0 ( nurl_str_eq feat `threads` ) {
+    // Feature tags are `-`-joined, so a build can be both: `net-threads`.
+    ? ( string_contains ( string_from feat ) `threads` ) {
         ( vec_push [s] args `-matomics` )
         ( vec_push [s] args `-mbulk-memory` )
+    } {}
+    // The socket bridge is opt-in per PROGRAM, not per linker flag: a
+    // module that never opens a socket must carry no `nurl_net` import,
+    // or a runtime without one refuses to instantiate it.
+    ? ( string_contains ( string_from feat ) `net` ) {
+        ( vec_push [s] args `-DNURL_WASM_NET` )
     } {}
     ( vec_push [s] args `-c` )
     ( vec_push [s] args ( string_data csrc ) )

--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -2436,7 +2436,7 @@ char *nurl_dns_reverse(const char *ip) {
     return strdup(host);
 }
 
-#else  /* __wasi__ */
+#elif defined(NURL_WASM_NET)
 /*
  * WASI has no socket layer of its own (preview1 can only accept on a
  * socket the host preopened), so the sockets come from the host as wasm
@@ -2628,6 +2628,91 @@ char *nurl_dns_reverse(const char *ip) {
     return nurl__net_take(buf, n);
 }
 
+
+#else  /* __wasi__ without the socket bridge — every call returns NetOther.
+        * wasmbuilder links this variant unless the program actually uses
+        * std/net.nu: a module with no socket call must not carry a
+        * `nurl_net` import, or a runtime that does not provide one refuses
+        * to instantiate it — which is exactly what happened to every
+        * benchmark once --no-gc-sections stopped dropping the wrappers. */
+
+long long nurl_tcp_listen(const char *host, long long port, long long backlog) {
+    (void)host; (void)port; (void)backlog;
+    return 0;
+}
+long long nurl_tcp_listen_tls(const char *host, long long port, long long backlog,
+                              const char *cert, const char *key) {
+    (void)host; (void)port; (void)backlog; (void)cert; (void)key;
+    return 0;
+}
+long long nurl_tcp_accept(long long listener) { (void)listener; return 0; }
+long long nurl_tcp_read(long long h, const char *buf, long long n) {
+    (void)h; (void)buf; (void)n; return -1;
+}
+long long nurl_tcp_write(long long h, const char *buf, long long n) {
+    (void)h; (void)buf; (void)n; return -1;
+}
+void nurl_tcp_close(long long h) { (void)h; }
+void nurl_tcp_shutdown(long long h) { (void)h; }
+long long nurl_tcp_err_kind(long long h) { (void)h; return NURL_NET_ERR_OTHER; }
+const char *nurl_tcp_peer_addr(long long h) { (void)h; return ""; }
+char       *nurl_tcp_local_addr(long long h) { (void)h; return strdup(""); }
+void nurl_tcp_set_timeout(long long h, long long ms) { (void)h; (void)ms; }
+/* Async-runtime hooks. The non-WASI variants live above the #else gate;
+ * mirror them as no-ops here so wasm-ld doesn't fail with undefined
+ * symbols for any example that imports the async/HTTP-server stack
+ * (which references these unconditionally — they just never fire under
+ * WASI because the underlying tcp_listen/_accept returned 0). */
+long long nurl_tcp_get_fd(long long h)                 { (void)h; return -1; }
+void nurl_tcp_set_nonblock(long long h, long long on)  { (void)h; (void)on; }
+void nurl_tcp_ref(long long h)                         { (void)h; }
+void nurl_tcp_unref(long long h)                       { (void)h; }
+
+/* §18b / §18c WASI stubs — wasi-libc has no socket layer. */
+long long nurl_udp_bind(const char *h, long long p) {
+    (void)h; (void)p; return 0;
+}
+long long nurl_udp_connect(long long h, const char *host, long long p) {
+    (void)h; (void)host; (void)p; return -1;
+}
+long long nurl_udp_send_to(long long h, const char *b, long long n,
+                           const char *host, long long p) {
+    (void)h; (void)b; (void)n; (void)host; (void)p; return -1;
+}
+long long nurl_udp_recv_from(long long h, char *b, long long n) {
+    (void)h; (void)b; (void)n; return -1;
+}
+long long nurl_udp_send(long long h, const char *b, long long n) {
+    (void)h; (void)b; (void)n; return -1;
+}
+long long nurl_udp_recv(long long h, char *b, long long n) {
+    (void)h; (void)b; (void)n; return -1;
+}
+const char *nurl_udp_peer_addr(long long h)            { (void)h; return ""; }
+char       *nurl_udp_local_addr(long long h)           { (void)h; return strdup(""); }
+long long nurl_udp_err_kind(long long h)               { (void)h; return NURL_NET_ERR_OTHER; }
+long long nurl_udp_get_fd(long long h)                 { (void)h; return -1; }
+long long nurl_udp_family(long long h)                 { (void)h; return -1; }
+void nurl_udp_set_nonblock(long long h, long long on)  { (void)h; (void)on; }
+void nurl_udp_set_timeout(long long h, long long ms)   { (void)h; (void)ms; }
+void nurl_udp_close(long long h)                       { (void)h; }
+long long nurl_udp_set_broadcast(long long h, long long on)            { (void)h; (void)on; return -1; }
+long long nurl_udp_join_group(long long h, const char *g, const char *i){ (void)h; (void)g; (void)i; return -1; }
+long long nurl_udp_leave_group(long long h, const char *g, const char *i){ (void)h; (void)g; (void)i; return -1; }
+long long nurl_udp_set_multicast_ttl(long long h, long long t)         { (void)h; (void)t; return -1; }
+long long nurl_udp_set_multicast_loop(long long h, long long on)       { (void)h; (void)on; return -1; }
+char *nurl_dns_resolve(const char *h)                  { (void)h; return strdup(""); }
+char *nurl_dns_resolve_port(const char *h, long long p){ (void)h; (void)p; return strdup(""); }
+char *nurl_dns_reverse(const char *ip)                 { (void)ip; return strdup(""); }
+
+
+/* These two were missing from the original stub set, which is why they
+ * leaked out as `env` imports and made even a socket-free program need a
+ * host that could answer them. */
+long long nurl_tcp_connect(const char *host, long long port) {
+    (void)host; (void)port; return 0;
+}
+long long nurl_tcp_timeout_ms(long long h) { (void)h; return 0; }
 #endif /* __wasi__ guard for §18 */
 
 


### PR DESCRIPTION
`wasm-bench` went red on every row after #975:

```
sieve   verifying interpreter…
sieve   MISMATCH — NURL/wasm+nogc=<empty>
wasmbench.sh: at least one row failed the correctness gate
```

## What happened

The socket bridge from #975 puts one wasm import per raw socket call into
`runtime.wasm.o`. Unused wrappers are dropped by `--gc-sections`, which is
why the default builds were fine — but the bench also links a
`--no-gc-sections` variant, and there the wrappers survive. A benchmark
that never opens a socket then declares 38 `nurl_net` imports, and the
reference wasmtime refuses to instantiate a module whose imports it cannot
resolve:

```
Error: failed to run main module `sieve.nunogc.wasm`
```

No output, so the correctness gate reports `<empty>` and fails. Reproduced
locally against wasmtime 44.0.0 and fixed against it.

## The fix

Leaning on the linker to remove an import that should not have been
declared was the mistake. The runtime object now has a `net` flavour, and
wasmbuilder selects it only when the IR actually **calls** a socket entry
point — a call site, not a declaration, because nurlc's preamble declares
the whole raw socket ABI in every program. Without it the `__wasi__` build
keeps the sentinel stubs it always had, and the module carries no
`nurl_net` import under either linker setting.

Feature tags compose (`net`, `threads`, `net-threads`), so a threaded
networking program gets both and the object cache keys on the combination.

While here: `nurl_tcp_connect` and `nurl_tcp_timeout_ms` were missing from
the original stub set and leaked out as `env` imports even for socket-free
programs. They are stubbed too, so the no-bridge build is now genuinely
import-free.

## Verified

- `sieve`, `fib`, `collatz` built `--no-gc-sections` run correctly under
  the reference wasmtime; before this change they failed to instantiate
- `netprobe` still gets its 13 `nurl_net` imports and completes its
  loopback round trip
- wasmbuilder corpus 18/18, `net_test.sh` and `threads_test.sh` pass,
  native build and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU