### PR TITLE
wasmtime: guard-page linear memory + f64 slot cache

### DIFF
--- a/packages/wasmtime/README.md
+++ b/packages/wasmtime/README.md
@@ -451,6 +451,17 @@ remains the semantic reference. `NURL_WT_JIT=0` turns the JIT off.
 - **Traps carry their real message** (`unreachable`, `integer divide by
   zero`, bounds), same text as the interpreter; JIT frames don't record
   positions, so backtraces come from interpreted frames only.
+- **Guard-page memory.** On Linux/x86-64 (glibc, non-ASan) a non-shared
+  linear memory is an 8 GiB `PROT_NONE` reservation with the live pages
+  committed in place, so the emitted code carries no bounds checks at
+  all: every address a masked 32-bit index plus a u32 offset can form
+  lands inside the reservation, an access past the committed pages
+  faults, and the runtime's `SIGSEGV` handler steers the faulting frame
+  to that function's out-of-bounds stub — the same trap, the same
+  message, the explicit check just never executes. Growth never moves
+  the base (`memory.grow` is an `mprotect`, not a realloc). Where the
+  plumbing is unavailable the memory falls back to a heap buffer and
+  the JIT emits its checks; `NURL_WT_GUARD=0` forces that path.
 
 Measured over `bench/wasmbench.sh`'s corpus (local, best-of-3): 0.41×
 the interpreter's wall clock — histogram/hash_join/bloom around 0.25×,

--- a/packages/wasmtime/src/interp.nu
+++ b/packages/wasmtime/src/interp.nu
@@ -3003,7 +3003,7 @@ inline @ __fr_setpos s tp i v → v {
 // The ops beyond the original tier set: extend/wrap, select, and the
 // fused memory/f64 records the predecoder emits. Falls through to the
 // plain ALU emitter for everything else.
-@ __jit_ext ( Vec u ) buf ( Vec i ) pat_at ( Vec i ) pat_rec i trap_rec i op i a i b i c i d i w5 i raxslot ( Vec i ) auxv ( Vec i ) pta_off ( Vec i ) pta_stub i chaincell i guard → v {
+@ __jit_ext ( Vec u ) buf ( Vec i ) pat_at ( Vec i ) pat_rec i trap_rec i op i a i b i c i d i w5 i raxslot ( Vec i ) auxv ( Vec i ) pta_off ( Vec i ) pta_stub i chaincell i guard i xmmslot → v {
     ? == op 36 {  // i32.wrap_i64: dst = sign-extended low 32 of src
         ? == raxslot b { ( __jit_movslq buf ) } {  // rax already holds the slot
             ( __jit_b buf 72 ) ( __jit_b buf 99 ) ( __jit_b buf 131 ) ( __jit_d buf * b 8 )  // movsxd rax,dword[rbx+b]
@@ -3045,20 +3045,20 @@ inline @ __fr_setpos s tp i v → v {
         ( __jit_movsd_st buf a ) ^ v
     } {}
     ? == op 197 {  // ADDSTOREF64: mem[a+off(d)] = s1(b) + s2(c)
-        ( __jit_movsd_ld buf b )
+        ? != xmmslot b { ( __jit_movsd_ld buf b ) } {}
         ( __jit_sd_op buf 88 c )  // addsd
         ( __jit_membc buf pat_at pat_rec trap_rec a d 8 raxslot guard )
         ( __jit_mem32 buf 242 1 17 0 d )  // movsd [mem],xmm0
         ^ v
     } {}
     ? | == op 198 == op 199 {  // MULADDF64 / MULSUBAF64: dst = (s1*s2) ± x
-        ( __jit_movsd_ld buf b )
+        ? != xmmslot b { ( __jit_movsd_ld buf b ) } {}
         ( __jit_sd_op buf 89 c )  // mulsd
         ( __jit_sd_op buf ? == op 198 88 92 d )  // addsd / subsd
         ( __jit_movsd_st buf a ) ^ v
     } {}
     ? == op 200 {  // MULSUBBF64: dst = x - (s1*s2)
-        ( __jit_movsd_ld buf b )
+        ? != xmmslot b { ( __jit_movsd_ld buf b ) } {}
         ( __jit_sd_op buf 89 c )  // mulsd
         ( __jit_movsd_x1x0 buf )
         ( __jit_movsd_ld buf d )
@@ -3066,13 +3066,14 @@ inline @ __fr_setpos s tp i v → v {
         ( __jit_movsd_st buf a ) ^ v
     } {}
     ? == op 201 {  // SUBMULF64: dst = (s1-s2) * x
-        ( __jit_movsd_ld buf b )
+        ? != xmmslot b { ( __jit_movsd_ld buf b ) } {}
         ( __jit_sd_op buf 92 c )  // subsd
         ( __jit_sd_op buf 89 d )  // mulsd
         ( __jit_movsd_st buf a ) ^ v
     } {}
     ? == op 131 {  // f64.sqrt
-        ( __jit_b buf 242 ) ( __jit_b buf 15 ) ( __jit_b buf 81 ) ( __jit_b buf 131 ) ( __jit_d buf * b 8 )  // sqrtsd xmm0,[rbx+b]
+        ? == xmmslot b { ( __jit_b buf 242 ) ( __jit_b buf 15 ) ( __jit_b buf 81 ) ( __jit_b buf 192 ) } {  // sqrtsd xmm0,xmm0
+            ( __jit_b buf 242 ) ( __jit_b buf 15 ) ( __jit_b buf 81 ) ( __jit_b buf 131 ) ( __jit_d buf * b 8 ) }  // sqrtsd xmm0,[rbx+b]
         ( __jit_movsd_st buf a ) ^ v
     } {}
     ? == op 93 {  // i32.clz — bsr+cmov (baseline x86-64, no lzcnt)
@@ -3293,6 +3294,21 @@ inline @ __fr_setpos s tp i v → v {
 
 // After a record is emitted, which slot does rax hold (-1 = none)?
 // Drives the one-register load-elision cache; must match the emitters.
+// After a record is emitted, which slot's value does xmm0 hold (-1 =
+// none)? The f64 twin of __jit_newrax: every f64 writer ends with a
+// movsd to its dst slot, so xmm0 = dst; a native call or any call-out
+// clobbers xmm0 (caller-saved); anything that writes the cached slot
+// through rax makes the cache stale.
+@ __jit_newxmm i op i a i b i prev → i {
+    ? | | & >= op 39 <= op 42 & >= op 194 <= op 196 | & >= op 198 <= op 201 == op 131 { ^ a } {}
+    ? == op 197 { ^ -1 } {}  // stored a sum to memory; no slot holds it
+    ? | | | == op 50 == op 210 | == op 170 == op 171 | == op 163 == op 169 { ^ -1 } {}  // calls / call-outs / br_table
+    ? | == op 55 == op 172 { ^ -1 } {}  // terminal
+    ? & | == op 38 == op 177 == b prev { ^ -1 } {}  // ADDBRIFC writes b
+    ? == a prev { ^ -1 } {}  // this record wrote the cached slot
+    ^ prev
+}
+
 @ __jit_newrax i op i a i b i prev → i {
     ? | | | == op 55 == op 172 | == op 50 == op 210 == op 170 { ^ -1 } {}  // terminal / call-out clobbers
     ? == op 163 { ^ -1 } {}  // memory.grow call-out
@@ -3429,10 +3445,11 @@ inline @ __fr_setpos s tp i v → v {
         = trr + trr 1
     }
     : ~ i raxslot -1
+    : ~ i xmmslot -1
     : ~ i r 0
     ~ < r n {
         ( vec_push [i] lab ( vec_len [u] buf ) )  // this record starts here
-        ? != 0 ?? ( vec_get [i] tgt r ) { T x → x F → 1 } { = raxslot -1 } {}
+        ? != 0 ?? ( vec_get [i] tgt r ) { T x → x F → 1 } { = raxslot -1 = xmmslot -1 } {}
         : i base * r 6
         : i op ?? ( vec_get [i] code base ) { T x → x F → 0 }
         : i a ?? ( vec_get [i] code + base 1 ) { T x → x F → 0 }
@@ -3460,7 +3477,7 @@ inline @ __fr_setpos s tp i v → v {
                         ( __jit_jmp buf pat_at pat_rec 233 + n 2 )
                     } {
                         ? & >= op 39 <= op 42 {  // f64 mul/add/sub/div
-                            ( __jit_movsd_ld buf b )
+                            ? != xmmslot b { ( __jit_movsd_ld buf b ) } {}
                             ( __jit_sd_op buf ? == op 39 89 ? == op 40 88 ? == op 41 92 94 c )
                             ( __jit_movsd_st buf a )
                         } {
@@ -3624,7 +3641,7 @@ inline @ __fr_setpos s tp i v → v {
                                                                             ( __jit_b buf 59 ) ( __jit_b buf 131 ) ( __jit_d buf * rhs 8 )  // cmp eax,[rbx+rhs]
                                                                         }
                                                                         ( __jit_jmp buf pat_at pat_rec ( __jit_jcc cctab cmpop ) / a 6 )
-                                                                    } { ( __jit_ext buf pat_at pat_rec n op a b c d w5 raxslot auxe pta_off pta_stub chaincell guard ) }
+                                                                    } { ( __jit_ext buf pat_at pat_rec n op a b c d w5 raxslot auxe pta_off pta_stub chaincell guard xmmslot ) }
                                                                 }
                                                             }
                                                         }
@@ -3641,6 +3658,7 @@ inline @ __fr_setpos s tp i v → v {
             }
         }
         = raxslot ( __jit_newrax op a b raxslot )
+        = xmmslot ( __jit_newxmm op a b xmmslot )
         = r + r 1
     }
     // The trap stub, at label index n (where every bounds check jumps):

--- a/packages/wasmtime/src/interp.nu
+++ b/packages/wasmtime/src/interp.nu
@@ -46,6 +46,28 @@ $ `module.nu`
 
 & `c` @ nurl_code_free *u p i n → v
 
+// Guard-page linear memory: an 8 GiB PROT_NONE reservation swallows every
+// address a 32-bit index + 32-bit offset can form, so JIT code needs no
+// bounds checks — an out-of-bounds access faults and the runtime's SIGSEGV
+// handler steers the faulting frame to its function's trap stub. Reserve
+// returning 0 means the platform has no fault-to-trap plumbing and the
+// bounds-checked path stays — a capability probe, like nurl_code_alloc.
+& `c` @ nurl_vmem_reserve i span → *u
+
+& `c` @ nurl_vmem_commit *u base i old i new → i
+
+& `c` @ nurl_vmem_release *u base i span → v
+
+& `c` @ nurl_guard_mem_add *u base i span → i
+
+& `c` @ nurl_guard_mem_del *u base → v
+
+& `c` @ nurl_guard_code_room → i
+
+& `c` @ nurl_guard_code_add *u code i len *u stub → i
+
+& `c` @ nurl_guard_code_del *u code → v
+
 // The one lock behind the 0xfe atomics (see __atom_init). Declared here
 // rather than taken from std/thread.nu because the handles live in file
 // globals, and a NURL global holds a pointer as an integer.
@@ -204,6 +226,11 @@ $ `module.nu`
     // what the guest may touch, and every bounds check reads this instead
     // of the Vec's length.
     i mem_bytes
+    // Guard-page mode: the raw base of an 8 GiB PROT_NONE reservation
+    // (0 = the memory lives in the `mem` Vec instead). Growth commits
+    // pages in place, so this address never moves; every reader goes
+    // through __mem_base, which picks whichever representation is live.
+    i mem_raw
     ( Vec i ) globals  // mutable global values
     ( Vec i ) table  // runtime funcref table (mutable via table.set/grow/…)
     ( Vec i ) data_dropped  // 1 per data segment once dropped / active
@@ -311,6 +338,22 @@ $ `module.nu`
 
 @ __page → i { ^ 65536 }
 
+// The guard reservation: 4 GiB of index + 4 GiB of constant offset + the
+// widest access, rounded up a page. Every address wasm32 can form from
+// a masked index and a u32 offset lands inside it.
+@ __vmem_span → i { ^ + 17179869184 65536 }
+
+// Guard-page memory is on wherever the runtime supports it; main.nu turns
+// it off for NURL_WT_GUARD=0 (the A/B and debugging escape).
+: ~ i g_guard 1
+
+@ interp_disable_guard → v { = g_guard 0 }
+
+// The linear memory's base address, whichever representation is live.
+inline @ __mem_base * Interp it → i {
+    ? != 0 . it mem_raw { ^ . it mem_raw } { ^ # i ( vec_data [u] . it mem ) }
+}
+
 @ interp_new * Module m → *Interp {
     : *Interp it # *Interp ( nurl_alloc Z Interp )
     = . it mod # s m
@@ -328,7 +371,23 @@ $ `module.nu`
     // reallocating grow would pull it out from under them.
     : i __mpages ? == . m has_mem 1 . m mem_min 0
     : i __mreserve ? & == . m has_mem 1 != . m mem_shared 0 . m mem_max __mpages
-    = . it mem ( vec_zeroed [u] * __mreserve ( __page ) )
+    // Guard-page mode first (non-shared memory only): reserve 8 GiB of
+    // PROT_NONE, commit the declared minimum, register the region with
+    // the fault-to-trap handler. Any step failing falls back to the Vec —
+    // the two representations are behaviour-identical, guard mode just
+    // lets the JIT drop its bounds checks.
+    = . it mem_raw 0
+    ? & & == . m has_mem 1 == . m mem_shared 0 != 0 g_guard {
+        : *u gbase ( nurl_vmem_reserve ( __vmem_span ) )
+        ? != # i gbase 0 {
+            ? == 0 ( nurl_vmem_commit gbase 0 * __mpages ( __page ) ) {
+                ? == 0 ( nurl_guard_mem_add gbase ( __vmem_span ) ) {
+                    = . it mem_raw # i gbase
+                } { ( nurl_vmem_release gbase ( __vmem_span ) ) }
+            } { ( nurl_vmem_release gbase ( __vmem_span ) ) }
+        } {}
+    } {}
+    = . it mem ? != 0 . it mem_raw ( vec_new [u] ) ( vec_zeroed [u] * __mreserve ( __page ) )
     = . it mem_pages __mpages
     = . it mem_bytes * __mpages ( __page )
     = . it globals ( vec_new [i] )
@@ -426,7 +485,7 @@ $ `module.nu`
                     ( __trap it `data segment does not fit in linear memory` )
                 } {
                     ? > dn 0 {
-                        : s dst # s + # i ( vec_data [u] . it mem ) off
+                        : s dst # s + ( __mem_base it ) off
                         ( nurl_memcpy dst # s ( vec_data [u] . ds bytes ) dn )
                     } {}
                 }
@@ -509,6 +568,11 @@ $ `module.nu`
     ( vec_free [i] . it thread_kids )
     ( vec_free [i] . it vs )
     ( vec_free [u] . it mem )
+    ? != 0 . it mem_raw {
+        ( nurl_guard_mem_del # *u . it mem_raw )
+        ( nurl_vmem_release # *u . it mem_raw ( __vmem_span ) )
+        = . it mem_raw 0
+    } {}
     ( vec_free [i] . it globals )
     ( vec_free [i] . it table )
     ( vec_free [i] . it data_dropped )
@@ -1007,7 +1071,7 @@ inline @ __mem_load * Interp it i ea i n i signed → i {
     // The memory Vec is always a whole number of 64 KiB pages, so any
     // in-bounds byte's containing 8-byte word is in-bounds too — word reads
     // below can never run past the buffer.
-    : s base # s ( vec_data [u] . it mem )
+    : s base # s ( __mem_base it )
     : i lo & ea 7
     : ~ i v 0
     ? <= + lo n 8 {
@@ -1033,9 +1097,10 @@ inline @ __mem_load * Interp it i ea i n i signed → i {
 // struct fields, a length beside a flag. The symptom is a heap that grows
 // a wrong size field and hands out a wild pointer somewhere else.
 @ __mem_store_bytes * Interp it i ea i n i val → v {
+    : *u mb # *u ( __mem_base it )
     : ~ i k 0
     ~ < k n {
-        ( vec_set [u] . it mem + ea k # u & ( __lshr64 val * 8 k ) 255 )
+        = . mb + ea k # u & ( __lshr64 val * 8 k ) 255
         = k + k 1
     }
 }
@@ -1049,7 +1114,7 @@ inline @ __mem_store * Interp it i ea i n i val → v {
     // A shared memory takes the byte-wise path for anything narrower than
     // the word it would otherwise rewrite.
     ? & . it shared_mem < n 8 { ( __mem_store_bytes it ea n val ) ^ v } {}
-    : s base # s ( vec_data [u] . it mem )
+    : s base # s ( __mem_base it )
     : i lo & ea 7
     ? <= + lo n 8 {
         // within one word: read-modify-write it once
@@ -1094,9 +1159,15 @@ inline @ __mem_store * Interp it i ea i n i val → v {
     : i old . it mem_pages
     ? == delta 0 { ^ old } {}
     ? | < delta 0 > + old delta limit { ^ -1 } {}
-    // One resize, zero-filling the new tail in a single memset, instead of
-    // a push per byte: growing by a single page was 65 536 pushes.
-    : b _ok ( vec_resize_zeroed [u] . it mem * + old delta ( __page ) )
+    ? != 0 . it mem_raw {
+        // Guard-page mode: commit the new pages in place — the base
+        // never moves, the pages arrive zeroed from the kernel.
+        ? != 0 ( nurl_vmem_commit # *u . it mem_raw * old ( __page ) * + old delta ( __page ) ) { ^ -1 } {}
+    } {
+        // One resize, zero-filling the new tail in a single memset, instead
+        // of a push per byte: growing by a single page was 65 536 pushes.
+        : b _ok ( vec_resize_zeroed [u] . it mem * + old delta ( __page ) )
+    }
     = . it mem_pages + old delta
     = . it mem_bytes * . it mem_pages ( __page )
     ^ old
@@ -1218,7 +1289,10 @@ inline @ __fr_setpos s tp i v → v {
     ( vec_free [i] . pf aux )
     ( vec_free [i] . pf kv )
     ( vec_free [i] . pf bytes )
-    ? > . pf jitlen 0 { ( nurl_code_free # *u . pf jit . pf jitlen ) } {}
+    ? > . pf jitlen 0 {
+        ( nurl_guard_code_del # *u . pf jit )  // no-op when never registered
+        ( nurl_code_free # *u . pf jit . pf jitlen )
+    } {}
     ( nurl_free # s pf )
 }
 
@@ -2669,6 +2743,17 @@ inline @ __fr_setpos s tp i v → v {
         : i base * r 6
         : i op ?? ( vec_get [i] code base ) { T x → x F → -1 }
         ? == 0 ( __jit_op_ok op ) { ^ 0 } {}
+        // Offset-magnitude gate for every memory template: the SIB access
+        // and the bounds check both encode the constant offset as a
+        // sign-extended disp32, so an offset at or past 2^31 (legal wasm —
+        // predecode also folds constant indexes in) would flip negative in
+        // the encoding. Those functions stay on the interpreter, which is
+        // exact at any offset.
+        : i offw ? == op 197 4 3  // ADDSTOREF64 keeps its offset in D, the rest in C
+        ? | >= ( __jit_memkind op ) 0 | | & >= op 194 <= op 197 & >= op 205 <= op 208 | == op 211 == op 212 {
+            : i moff ?? ( vec_get [i] code + base offw ) { T x → x F → 0 }
+            ? | < moff 0 > moff 2147483639 { ^ 0 } {}  // 2^31-1-8: off+wid must fit disp32
+        } {}
         ? | | | == op 48 == op 49 == op 54 | == op 45 | == op 38 == op 177 {
             : i tgt / ?? ( vec_get [i] code + base 1 ) { T x → x F → 0 } 6
             ? | < tgt 0 >= tgt n { ^ 0 } {}
@@ -2820,17 +2905,25 @@ inline @ __fr_setpos s tp i v → v {
 // Effective-address + bounds check shared by every memory template:
 // rax = r11 + ((slot & 0xffffffff) + off), trapping when off+wid runs
 // past r10 (the byte count). Mirrors the plain load/store emitters.
-@ __jit_membc ( Vec u ) buf ( Vec i ) pat_at ( Vec i ) pat_rec i trap_rec i baseslot i off i wid i raxslot → v {
+@ __jit_membc ( Vec u ) buf ( Vec i ) pat_at ( Vec i ) pat_rec i trap_rec i baseslot i off i wid i raxslot i guard → v {
     ? != raxslot baseslot { ( __jit_ldrax buf baseslot ) } {}
-    ( __jit_bc buf pat_at pat_rec trap_rec off wid )
+    ( __jit_bc buf pat_at pat_rec trap_rec off wid guard )
 }
 
 // The same check when the caller has already computed the unmasked
 // address into rax (the shifted-index load templates).
 // Leaves rax = the masked guest index; the access itself is one SIB
 // instruction [rax + r11 + off] emitted via __jit_mem below.
-@ __jit_bc ( Vec u ) buf ( Vec i ) pat_at ( Vec i ) pat_rec i trap_rec i off i wid → v {
+// Guard-page mode keeps only the index mask: with r11 the base of an
+// 8 GiB PROT_NONE reservation, every (masked index + u32 offset) lands
+// inside it, and an access past the committed pages faults into the
+// runtime's SIGSEGV handler, which steers this frame to the same trap
+// stub the explicit check jumps to. The mask is NOT optional — a slot
+// holds a canonically sign-extended i32, and a negative index without
+// it would reach 2 GiB below the reservation.
+@ __jit_bc ( Vec u ) buf ( Vec i ) pat_at ( Vec i ) pat_rec i trap_rec i off i wid i guard → v {
     ( __jit_b buf 137 ) ( __jit_b buf 192 )  // mov eax,eax (& 0xffffffff)
+    ? != 0 guard { ^ v } {}
     ( __jit_b buf 72 ) ( __jit_b buf 141 ) ( __jit_b buf 136 ) ( __jit_d buf + off wid )  // lea rcx,[rax+off+wid]
     ( __jit_b buf 73 ) ( __jit_b buf 57 ) ( __jit_b buf 202 )  // cmp r10,rcx
     ( __jit_jmp buf pat_at pat_rec 130 trap_rec )  // jb trap
@@ -2910,7 +3003,7 @@ inline @ __fr_setpos s tp i v → v {
 // The ops beyond the original tier set: extend/wrap, select, and the
 // fused memory/f64 records the predecoder emits. Falls through to the
 // plain ALU emitter for everything else.
-@ __jit_ext ( Vec u ) buf ( Vec i ) pat_at ( Vec i ) pat_rec i trap_rec i op i a i b i c i d i w5 i raxslot ( Vec i ) auxv ( Vec i ) pta_off ( Vec i ) pta_stub i chaincell → v {
+@ __jit_ext ( Vec u ) buf ( Vec i ) pat_at ( Vec i ) pat_rec i trap_rec i op i a i b i c i d i w5 i raxslot ( Vec i ) auxv ( Vec i ) pta_off ( Vec i ) pta_stub i chaincell i guard → v {
     ? == op 36 {  // i32.wrap_i64: dst = sign-extended low 32 of src
         ? == raxslot b { ( __jit_movslq buf ) } {  // rax already holds the slot
             ( __jit_b buf 72 ) ( __jit_b buf 99 ) ( __jit_b buf 131 ) ( __jit_d buf * b 8 )  // movsxd rax,dword[rbx+b]
@@ -2932,19 +3025,19 @@ inline @ __fr_setpos s tp i v → v {
         ( __jit_strax buf a ) ^ v
     } {}
     ? | == op 211 == op 212 {  // LOADMULI64 / LOADADDI64: dst = mem64[b+off] OP x(d)
-        ( __jit_membc buf pat_at pat_rec trap_rec b c 8 raxslot )
+        ( __jit_membc buf pat_at pat_rec trap_rec b c 8 raxslot guard )
         ( __jit_mem buf 0 0 139 0 c )  // mov rax,[mem]
         ? == op 211 { ( __jit_rax_imul_slot buf d ) } { ( __jit_rax_op_slot buf 1 d ) }
         ( __jit_strax buf a ) ^ v
     } {}
     ? | == op 194 == op 195 {  // LOADMULF64 / LOADADDF64: dst = mem[f64] OP x(d)
-        ( __jit_membc buf pat_at pat_rec trap_rec b c 8 raxslot )
+        ( __jit_membc buf pat_at pat_rec trap_rec b c 8 raxslot guard )
         ( __jit_mem32 buf 242 1 16 0 c )  // movsd xmm0,[mem]
         ( __jit_sd_op buf ? == op 194 89 88 d )  // mulsd / addsd
         ( __jit_movsd_st buf a ) ^ v
     } {}
     ? == op 196 {  // LOADSUBBF64: dst = x(d) - mem[f64]
-        ( __jit_membc buf pat_at pat_rec trap_rec b c 8 raxslot )
+        ( __jit_membc buf pat_at pat_rec trap_rec b c 8 raxslot guard )
         ( __jit_mem32 buf 242 1 16 0 c )  // movsd xmm0,[mem]
         ( __jit_movsd_x1x0 buf )
         ( __jit_movsd_ld buf d )
@@ -2954,7 +3047,7 @@ inline @ __fr_setpos s tp i v → v {
     ? == op 197 {  // ADDSTOREF64: mem[a+off(d)] = s1(b) + s2(c)
         ( __jit_movsd_ld buf b )
         ( __jit_sd_op buf 88 c )  // addsd
-        ( __jit_membc buf pat_at pat_rec trap_rec a d 8 raxslot )
+        ( __jit_membc buf pat_at pat_rec trap_rec a d 8 raxslot guard )
         ( __jit_mem32 buf 242 1 17 0 d )  // movsd [mem],xmm0
         ^ v
     } {}
@@ -3017,7 +3110,7 @@ inline @ __fr_setpos s tp i v → v {
         ( __jit_b buf 139 ) ( __jit_b buf 131 ) ( __jit_d buf * b 8 )  // mov eax,dword[rbx+b] (low 32 of x)
         ( __jit_b buf 211 ) ( __jit_b buf 224 )  // shl eax,cl
         ( __jit_movslq buf )  // __w32
-        ( __jit_bc buf pat_at pat_rec trap_rec c ? == op 205 8 4 )
+        ( __jit_bc buf pat_at pat_rec trap_rec c ? == op 205 8 4 guard )
         ? == op 205 { ( __jit_mem buf 0 0 139 0 c ) } { ( __jit_mem buf 0 0 99 0 c ) }  // mov rax,[mem] / movsxd rax,dword[mem]
         ( __jit_strax buf a ) ^ v
     } {}
@@ -3168,7 +3261,7 @@ inline @ __fr_setpos s tp i v → v {
         ( __jit_b buf 211 ) ( __jit_b buf 224 )  // shl eax,cl
         ( __jit_movslq buf )  // __w32
         ( __jit_b buf 72 ) ( __jit_b buf 3 ) ( __jit_b buf 131 ) ( __jit_d buf * b 8 )  // add rax,[rbx+base]
-        ( __jit_bc buf pat_at pat_rec trap_rec c ? == op 207 8 4 )
+        ( __jit_bc buf pat_at pat_rec trap_rec c ? == op 207 8 4 guard )
         ? == op 207 { ( __jit_mem buf 0 0 139 0 c ) } { ( __jit_mem buf 0 0 99 0 c ) }  // mov rax,[mem] / movsxd rax,dword[mem]
         ( __jit_strax buf a ) ^ v
     } {}
@@ -3218,6 +3311,11 @@ inline @ __fr_setpos s tp i v → v {
     ? != # i . pf jit 0 { ^ v } {}  // already tried (handle or -1)
     ? == 0 ( __jit_ok pf ) { = . pf jit # s -1 ^ v } {}
     ( __jit_state_init it m )
+    // Guard-page mode: bounds checks stay out of the emitted code, and the
+    // sealed page is registered with the fault-to-trap handler below. The
+    // registry pre-check keeps a full table from producing a function whose
+    // faults nobody converts — such a function keeps its explicit checks.
+    : i guard ? & != 0 . it mem_raw != 0 ( nurl_guard_code_room ) 1 0
     : i spcell . it jit_spcell
     : i chaincell . it jit_chain_cell
     : i slab_end . it jit_slab_end
@@ -3468,7 +3566,7 @@ inline @ __fr_setpos s tp i v → v {
                                             ? == 0 & mk 1 {  // ── load: a=dst b=base c=off d=index ──
                                                 ? != raxslot b { ( __jit_ldrax buf b ) } {}
                                                 ( __jit_b buf 72 ) ( __jit_b buf 3 ) ( __jit_b buf 131 ) ( __jit_d buf * d 8 )  // add rax,[rbx+d]
-                                                ( __jit_bc buf pat_at pat_rec n c wid )
+                                                ( __jit_bc buf pat_at pat_rec n c wid guard )
                                                 ? == wid 8 { ( __jit_mem buf 0 0 139 0 c ) } {}  // mov rax,[mem]
                                                 ? & == wid 4 == 0 & mk 2 { ( __jit_mem32 buf 0 0 139 0 c ) } {}  // mov eax,[mem] (zero-ext)
                                                 ? & == wid 4 != 0 & mk 2 { ( __jit_mem buf 0 0 99 0 c ) } {}  // movsxd rax,[mem]
@@ -3479,7 +3577,7 @@ inline @ __fr_setpos s tp i v → v {
                                                 ( __jit_strax buf a )
                                             } {  // ── store: a=addr b=val c=off ──
                                                 ? != raxslot a { ( __jit_ldrax buf a ) } {}
-                                                ( __jit_bc buf pat_at pat_rec n c wid )
+                                                ( __jit_bc buf pat_at pat_rec n c wid guard )
                                                 ( __jit_ldrcx buf b )  // value → rcx
                                                 ? == wid 8 { ( __jit_mem buf 0 0 137 1 c ) } {}  // mov [mem],rcx
                                                 ? == wid 4 { ( __jit_mem32 buf 0 0 137 1 c ) } {}  // mov [mem],ecx
@@ -3526,7 +3624,7 @@ inline @ __fr_setpos s tp i v → v {
                                                                             ( __jit_b buf 59 ) ( __jit_b buf 131 ) ( __jit_d buf * rhs 8 )  // cmp eax,[rbx+rhs]
                                                                         }
                                                                         ( __jit_jmp buf pat_at pat_rec ( __jit_jcc cctab cmpop ) / a 6 )
-                                                                    } { ( __jit_ext buf pat_at pat_rec n op a b c d w5 raxslot auxe pta_off pta_stub chaincell ) }
+                                                                    } { ( __jit_ext buf pat_at pat_rec n op a b c d w5 raxslot auxe pta_off pta_stub chaincell guard ) }
                                                                 }
                                                             }
                                                         }
@@ -3594,6 +3692,17 @@ inline @ __fr_setpos s tp i v → v {
         = ptk + ptk 1
     }
     ? != 0 ( nurl_code_seal page + len 16 ) { ( nurl_code_free page + len 16 ) = . pf jit # s -1 ^ v } {}
+    // Register the sealed page for fault-to-trap conversion: a guest
+    // access past the committed pages faults, and the handler steers the
+    // frame to this function's out-of-bounds stub (label n). Room was
+    // checked before emitting; failing here anyway would leave unguarded
+    // uncheckable code, so the page is dropped instead.
+    ? != 0 guard {
+        : i oobs ?? ( vec_get [i] lab n ) { T x → x F → 0 }
+        ? != 0 ( nurl_guard_code_add page + len 16 # *u + # i page oobs ) {
+            ( nurl_code_free page + len 16 ) = . pf jit # s -1 ^ v
+        } {}
+    } {}
     = . pf jit # s page
     = . pf jitlen + len 16
 }
@@ -3663,7 +3772,7 @@ inline @ __fr_setpos s tp i v → v {
         : i erbx . e 2
         : i eargs . e 3
         = . cd 0 erbx
-        = . cd 1 # i ( vec_data [u] . it mem )
+        = . cd 1 ( __mem_base it )
         = . cd 2 . it mem_bytes
         : i st ( nurl_call_code_at2 # *u ejh eres # *u cd # *u eargs )
         ? >= st 16 {
@@ -3696,7 +3805,7 @@ inline @ __fr_setpos s tp i v → v {
     : i sp0 . spc 0
     : i chain0 . chc 0
     = . cd 0 0  // the entry writes its own slab frame base here
-    = . cd 1 # i ( vec_data [u] . it mem )
+    = . cd 1 ( __mem_base it )
     = . cd 2 . it mem_bytes
     = . cd 3 # i ( vec_data [i] . it globals )
     = . cd 4 0 = . cd 5 0 = . cd 6 0 = . cd 7 0
@@ -5474,7 +5583,7 @@ inline @ __rcmp i op i a i b → i {  // the internal compare codes, i32 then i6
 
 // Host base address of the guest linear memory (recomputed per call — a
 // memory.grow between host calls may relocate the backing).
-@ __gpu_base * Interp it → i { ^ # i ( vec_data [u] . it mem ) }
+@ __gpu_base * Interp it → i { ^ ( __mem_base it ) }
 
 // Guest offset → host pointer (NULL stays NULL).
 @ __gpu_ptr * Interp it i off → *u {
@@ -5739,7 +5848,7 @@ inline @ __rcmp i op i a i b → i {  // the internal compare codes, i32 then i6
     : i o & off 4294967295
     : i n . it mem_bytes
     ? | < len 0 > + o len n { ^ # s 0 } {}
-    ^ # s + # i ( vec_data [u] . it mem ) o
+    ^ # s + ( __mem_base it ) o
 }
 
 // Guest pointer to a NUL-terminated string → host `s`. A string with no
@@ -5749,15 +5858,13 @@ inline @ __rcmp i op i a i b → i {  // the internal compare codes, i32 then i6
     : i o & off 4294967295
     : i n . it mem_bytes
     ? >= o n { ^ `` } {}
+    : *u mb # *u ( __mem_base it )
     : ~ i k o
     : ~ b term F
     ~ & < k n ! term {
-        ?? ( vec_get [u] . it mem k ) {
-            T c → { ? == # i c 0 { = term T } { = k + k 1 } }
-            F → { = k n }
-        }
+        ? == # i . mb k 0 { = term T } { = k + k 1 }
     }
-    ? term { ^ # s + # i ( vec_data [u] . it mem ) o } {}
+    ? term { ^ # s + ( __mem_base it ) o } {}
     ^ ``
 }
 
@@ -6117,13 +6224,13 @@ inline @ __rcmp i op i a i b → i {  // the internal compare codes, i32 then i6
 // nurl_memmove is the overlap-safe one — memory.copy allows aliasing.
 @ __mem_copy * Interp it i dst i src i n → v {
     ? <= n 0 { ^ v } {}
-    : s base # s ( vec_data [u] . it mem )
+    : s base # s ( __mem_base it )
     ( nurl_memmove # s + # i base dst # s + # i base src n )
 }
 
 @ __mem_fill * Interp it i dst i val i n → v {
     ? <= n 0 { ^ v } {}
-    : s base # s ( vec_data [u] . it mem )
+    : s base # s ( __mem_base it )
     ( nurl_memset # s + # i base dst & val 255 n )
 }
 
@@ -6333,9 +6440,10 @@ inline @ __rcmp i op i a i b → i {  // the internal compare codes, i32 then i6
         : *DataSeg ds # *DataSeg dp
         ? | > + src n ( vec_len [u] . ds bytes ) > + dst n . it mem_bytes {
             ( __trap it `out of bounds memory access` ) ^ v } {}
+        : *u mb # *u ( __mem_base it )
         : ~ i k 0
         ~ < k n {
-            ( vec_set [u] . it mem + dst k ?? ( vec_get [u] . ds bytes + src k ) { T x → x F → # u 0 } )
+            = . mb + dst k ?? ( vec_get [u] . ds bytes + src k ) { T x → x F → # u 0 }
             = k + k 1
         }
         ^ v

--- a/packages/wasmtime/src/main.nu
+++ b/packages/wasmtime/src/main.nu
@@ -72,6 +72,9 @@ $ `interp.nu`
                     ( nurl_print `wasmtime: no exported function '` ) ( nurl_print export ) ( nurl_print `'\n` )
                     ( module_free m ) = rc 1
                 } {
+                    // Guard-page memory is on wherever the runtime supports it;
+                    // NURL_WT_GUARD=0 keeps the bounds-checked Vec path (A/B, debug).
+                    ?? ( env_get `NURL_WT_GUARD` ) { T gv → { ? != 0 ( nurl_str_eq ( string_data gv ) `0` ) { ( interp_disable_guard ) } {} ( string_free gv ) } F → {} }
                     : *Interp it ( interp_new m )
                     ? != allow_gpu 0 { ( interp_allow_gpu it ) } {}
                     ? != allow_net 0 { ( interp_allow_net it ) } {}
@@ -133,6 +136,9 @@ $ `interp.nu`
                     ( nurl_eprintln `wasmtime: module has no _start export (not a WASI command)` )
                     ( module_free m ) = rc 1
                 } {
+                    // Guard-page memory is on wherever the runtime supports it;
+                    // NURL_WT_GUARD=0 keeps the bounds-checked Vec path (A/B, debug).
+                    ?? ( env_get `NURL_WT_GUARD` ) { T gv → { ? != 0 ( nurl_str_eq ( string_data gv ) `0` ) { ( interp_disable_guard ) } {} ( string_free gv ) } F → {} }
                     : *Interp it ( interp_new m )
                     ? > fuel 0 { = . it fuel fuel } {}
                     ? != allow_gpu 0 { ( interp_allow_gpu it ) } {}

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -3412,3 +3412,175 @@ long long nurl_call_code_at2(void *fn, long long off, void *a0, void *a1) {
     if (!fn) return 0;
     return ((long long (*)(void *, void *))((char *)fn + off))(a0, a1);
 }
+
+/* ── guard-page linear memory ───────────────────────────────────────
+ * A wasm32 effective address is a 32-bit index plus a 32-bit constant
+ * offset: with the base of an 8 GiB PROT_NONE reservation, every
+ * possible address the guest can form lands inside the reservation, so
+ * generated code needs no bounds check at all — an out-of-bounds access
+ * faults on a PROT_NONE page and the SIGSEGV handler converts it into
+ * the same trap the explicit check would have raised, by steering the
+ * faulting frame to its function's out-of-bounds stub. Growing commits
+ * pages in place; the base never moves.
+ *
+ * Platform gate: the fault-to-trap conversion is Linux/x86-64 signal
+ * plumbing, and under ASan the runtime's own SEGV reporting owns the
+ * handler — everywhere else nurl_vmem_reserve reports failure and the
+ * caller keeps its bounds-checked path (a capability probe, like
+ * nurl_code_alloc above). */
+#if defined(__SANITIZE_ADDRESS__)
+#define NURL__GUARD_ASAN 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define NURL__GUARD_ASAN 1
+#endif
+#endif
+#if defined(__linux__) && defined(__x86_64__) && !defined(_WIN32) && \
+    !defined(__wasm__) && !defined(NURL__GUARD_ASAN) && \
+    defined(__GLIBC__) && \
+    !(defined(__STDC_HOSTED__) && __STDC_HOSTED__ == 0)
+
+#include <signal.h>
+#include <ucontext.h>
+#ifndef REG_RIP /* glibc/musl expose it only under _GNU_SOURCE */
+#define REG_RIP 16
+#endif
+
+typedef struct { unsigned long long base, end; } nurl__gmem_t;
+typedef struct { unsigned long long base, end, stub; } nurl__gcode_t;
+#define NURL__GMEM_CAP 64
+#define NURL__GCODE_CAP 65536
+static nurl__gmem_t *nurl__gmems;
+static nurl__gcode_t *nurl__gcodes;
+static int nurl__gmem_n, nurl__gcode_n;
+static volatile int nurl__guard_spin;
+static int nurl__guard_installed;
+static struct sigaction nurl__guard_prev;
+
+/* A spinlock, not a mutex: the SEGV handler takes it too, and the only
+ * writers (register/unregister) never fault while holding it. */
+static void nurl__guard_lock(void) {
+    while (__sync_lock_test_and_set(&nurl__guard_spin, 1)) {}
+}
+static void nurl__guard_unlock(void) { __sync_lock_release(&nurl__guard_spin); }
+
+static void nurl__guard_handler(int sig, siginfo_t *si, void *uctx) {
+    (void)sig;
+    unsigned long long addr = (unsigned long long)si->si_addr;
+    ucontext_t *uc = (ucontext_t *)uctx;
+    unsigned long long rip = (unsigned long long)uc->uc_mcontext.gregs[REG_RIP];
+    nurl__guard_lock();
+    int inmem = 0;
+    for (int i = 0; i < nurl__gmem_n; i++)
+        if (addr >= nurl__gmems[i].base && addr < nurl__gmems[i].end) { inmem = 1; break; }
+    if (inmem)
+        for (int i = 0; i < nurl__gcode_n; i++)
+            if (rip >= nurl__gcodes[i].base && rip < nurl__gcodes[i].end) {
+                uc->uc_mcontext.gregs[REG_RIP] = (long long)nurl__gcodes[i].stub;
+                nurl__guard_unlock();
+                return;
+            }
+    nurl__guard_unlock();
+    /* Not a guest access: put the previous handler back and return, so
+     * the instruction re-faults into it — a real crash stays a crash. */
+    sigaction(SIGSEGV, &nurl__guard_prev, 0);
+}
+
+void *nurl_vmem_reserve(long long span) {
+    void *p = mmap(0, (size_t)span, PROT_NONE,
+                   MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+    return p == MAP_FAILED ? 0 : p;
+}
+long long nurl_vmem_commit(void *base, long long old_bytes, long long new_bytes) {
+    if (new_bytes <= old_bytes) return 0;
+    return mprotect((char *)base + old_bytes, (size_t)(new_bytes - old_bytes),
+                    PROT_READ | PROT_WRITE) == 0 ? 0 : -1;
+}
+void nurl_vmem_release(void *base, long long span) {
+    if (base) munmap(base, (size_t)span);
+}
+
+long long nurl_guard_mem_add(void *base, long long span) {
+    nurl__guard_lock();
+    if (!nurl__gmems) {
+        nurl__gmems = malloc(NURL__GMEM_CAP * sizeof *nurl__gmems);
+        nurl__gcodes = malloc(NURL__GCODE_CAP * sizeof *nurl__gcodes);
+        if (!nurl__gmems || !nurl__gcodes) {
+            free(nurl__gmems); free(nurl__gcodes);
+            nurl__gmems = 0; nurl__gcodes = 0;
+            nurl__guard_unlock();
+            return -1;
+        }
+    }
+    if (nurl__gmem_n >= NURL__GMEM_CAP) { nurl__guard_unlock(); return -1; }
+    if (!nurl__guard_installed) {
+        struct sigaction sa;
+        memset(&sa, 0, sizeof sa);
+        sa.sa_sigaction = nurl__guard_handler;
+        sa.sa_flags = SA_SIGINFO;
+        sigemptyset(&sa.sa_mask);
+        if (sigaction(SIGSEGV, &sa, &nurl__guard_prev) != 0) {
+            nurl__guard_unlock();
+            return -1;
+        }
+        nurl__guard_installed = 1;
+    }
+    nurl__gmems[nurl__gmem_n].base = (unsigned long long)base;
+    nurl__gmems[nurl__gmem_n].end = (unsigned long long)base + (unsigned long long)span;
+    nurl__gmem_n++;
+    nurl__guard_unlock();
+    return 0;
+}
+void nurl_guard_mem_del(void *base) {
+    nurl__guard_lock();
+    for (int i = 0; i < nurl__gmem_n; i++)
+        if (nurl__gmems[i].base == (unsigned long long)base) {
+            nurl__gmems[i] = nurl__gmems[--nurl__gmem_n];
+            break;
+        }
+    nurl__guard_unlock();
+}
+long long nurl_guard_code_room(void) {
+    return nurl__gcode_n < NURL__GCODE_CAP ? 1 : 0;
+}
+long long nurl_guard_code_add(void *code, long long len, void *stub) {
+    nurl__guard_lock();
+    if (!nurl__gcodes || nurl__gcode_n >= NURL__GCODE_CAP) {
+        nurl__guard_unlock();
+        return -1;
+    }
+    nurl__gcodes[nurl__gcode_n].base = (unsigned long long)code;
+    nurl__gcodes[nurl__gcode_n].end = (unsigned long long)code + (unsigned long long)len;
+    nurl__gcodes[nurl__gcode_n].stub = (unsigned long long)stub;
+    nurl__gcode_n++;
+    nurl__guard_unlock();
+    return 0;
+}
+void nurl_guard_code_del(void *code) {
+    nurl__guard_lock();
+    for (int i = 0; i < nurl__gcode_n; i++)
+        if (nurl__gcodes[i].base == (unsigned long long)code) {
+            nurl__gcodes[i] = nurl__gcodes[--nurl__gcode_n];
+            break;
+        }
+    nurl__guard_unlock();
+}
+
+#else /* no guard-page support: capability probe reports failure */
+
+void *nurl_vmem_reserve(long long span) { (void)span; return 0; }
+long long nurl_vmem_commit(void *base, long long old_bytes, long long new_bytes) {
+    (void)base; (void)old_bytes; (void)new_bytes; return -1;
+}
+void nurl_vmem_release(void *base, long long span) { (void)base; (void)span; }
+long long nurl_guard_mem_add(void *base, long long span) {
+    (void)base; (void)span; return -1;
+}
+void nurl_guard_mem_del(void *base) { (void)base; }
+long long nurl_guard_code_room(void) { return 0; }
+long long nurl_guard_code_add(void *code, long long len, void *stub) {
+    (void)code; (void)len; (void)stub; return -1;
+}
+void nurl_guard_code_del(void *code) { (void)code; }
+
+#endif /* guard-page linear memory */

--- a/stdlib/runtime_core.c
+++ b/stdlib/runtime_core.c
@@ -3515,10 +3515,9 @@ long long nurl_guard_mem_add(void *base, long long span) {
     if (nurl__gmem_n >= NURL__GMEM_CAP) { nurl__guard_unlock(); return -1; }
     if (!nurl__guard_installed) {
         struct sigaction sa;
-        memset(&sa, 0, sizeof sa);
+        memset(&sa, 0, sizeof sa);  /* zeroes sa_mask too — the empty set */
         sa.sa_sigaction = nurl__guard_handler;
         sa.sa_flags = SA_SIGINFO;
-        sigemptyset(&sa.sa_mask);
         if (sigaction(SIGSEGV, &sa, &nurl__guard_prev) != 0) {
             nurl__guard_unlock();
             return -1;

--- a/unikernel/nolibc/misc.c
+++ b/unikernel/nolibc/misc.c
@@ -44,6 +44,18 @@ void abort(void) {
     for (;;) { }
 }
 
+/* A freestanding target delivers no signals, so a handler can never be
+ * installed. Reporting failure makes the runtime's guard-page memory
+ * treat this like any other host without the plumbing (nurl_vmem_reserve
+ * already answers 0 there) and keep its bounds-checked path — the same
+ * capability-probe contract as the executable-page allocator. The
+ * struct layout is irrelevant to a call that only fails, so the
+ * prototype takes opaque pointers rather than dragging in signal.h. */
+int sigaction(int sig, const void *act, void *oldact) {
+    (void)sig; (void)act; (void)oldact;
+    return -1;
+}
+
 char *getenv(const char *name) {
     nl_size_t n = strlen(name);
     char **e = nl_environ;


### PR DESCRIPTION
Two JIT quality steps toward the theoretical maximum, plus one latent miscompile fixed where the audit surfaced it.

## Guard-page linear memory

A non-shared linear memory now lives in an 8 GiB `PROT_NONE` reservation (Linux/x86-64/glibc, non-ASan) with live pages committed in place. Every address a masked 32-bit index + u32 offset can form lands inside the reservation, so the memory templates emit **no bounds check at all** — an out-of-bounds access faults, and the runtime's SIGSEGV handler steers the faulting frame to the function's existing out-of-bounds stub: same trap, same message, the explicit check never executes. A fault that is not a guest access reinstalls the previous handler and re-faults, so a real crash stays a crash. `memory.grow` becomes an in-place `mprotect` — the base never moves, nothing reallocates (that part benefits the interpreter too). Platforms without the plumbing (and `NURL_WT_GUARD=0`) keep the Vec-backed memory and checked templates.

Measured: instructions retired drop 7–21 % on the memory-bound rows (matmul −21 %, sieve −17 %, bloom −9 %, binary −7 %); wall moves less because the checks ran in spare OoO slots, but bloom −17 %, histogram −11 %, hash_join/sort_window −4–5 % wall are real and no row regresses beyond known layout jitter.

## Latent offset miscompile (found by this audit)

A memory record whose constant offset reaches 2^31 sign-extends in the disp32 encoding: the emitted bounds check could pass while the SIB access wrapped below the buffer — legal wasm, wrong result, and in Vec mode a heap write outside the buffer. `__jit_ok` now rejects such functions to the interpreter, which is exact at any offset.

## xmm0 slot cache

The f64 twin of the rax slot cache: an f64 writer leaves xmm0 = dst, the next f64 record whose first operand is that slot skips its reload (and a cached `f64.sqrt` operand uses the register form). nbody −1.4 % instructions, wall unchanged — which is itself the measurement that the remaining f64 gap is store-forward latency through the slot file, i.e. the register-allocation tier this sets up.

## Gates

- corpus 15/15 byte-identical across guard / no-guard / pure interpreter / previous build
- OOB traps (load, store, negative index) byte-identical in all modes, and proven to take the fault path (gdb SIGSEGV catchpoint fires once, process still exits with the normal trap message)
- `nurlc.wasm` self-compile byte-identical under guard, no-guard and pure interpreter
- 8/8 package suites + threads + net e2e; `wasmc_gate` 8/8 byte-identical
- `runtime_core.c` cross-compiles for wasm32-wasi, x86_64-windows-gnu, riscv64/aarch64 linux-musl, aarch64-macos and ASan (guard self-disables under ASan and musl)

Noted separately (pre-existing, verified at `e8965c45` in a clean worktree): `NURL_SAN=1` wt crashes under the tier-6 JIT in `nurl_call_code2`; the ASan debugging path currently needs `NURL_WT_JIT=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU