### PR TITLE
bench: correct sort_window's malloc-window claim

### DIFF
--- a/bench/sort_window.nu
+++ b/bench/sort_window.nu
@@ -7,9 +7,16 @@
 // unroll the sort and if-convert every swap to cmov) with a loop-carried
 // dependency through the state.
 //
-// NURL has no fixed-size stack array: the window lives in a `malloc`ed
-// `*u64` block, where the C and Rust peers use `uint64_t window[8]` /
-// `[u64; 8]` on the stack.
+// NURL has no fixed-size stack array, so the source allocates the window
+// as a `malloc`ed `*u64` block where the C and Rust peers use
+// `uint64_t window[8]` / `[u64; 8]` on the stack. This does NOT survive
+// to the optimized artifacts: LLVM's -O2 heap-to-stack elides the
+// malloc/free pair, inlines the sort, and SROAs the window into
+// registers (native) / locals (wasm), so all five implementations run
+// the mill out of registers. Measured 2026-08-25: hand-promoting the
+// malloc to an alloca in nurlc changed nothing on the wasm artifact and
+// made the native binary ~19 % slower (LLVM picks a worse canonical
+// form for the pre-promoted IR).
 //
 // Contract: the process prints exactly one line — the checksum in
 // decimal, masked to 63 bits — and nothing else. `bench/bench.sh` gates


### PR DESCRIPTION
The sort_window header claimed the NURL implementation pays for a heap window where C/Rust use a stack array. Measured 2026-08-25 (nwasm + wasmtime/Cranelift + native, ABAB min-of-N):

- LLVM -O2 already elides the malloc/free pair, inlines the sort, and SROAs the window into registers (native) / wasm locals, in **both** the old and current artifacts. All five implementations run the mill out of registers; the wasm module's `_nurl_main` has zero window memory ops.
- A prototype heap-to-stack pass in nurlc (malloc(const)+free → alloca, escape-checked) confirmed the claim is stale: byte-different wasm modules measured **identical** on nwasm and Cranelift, and the **native** binary got ~19 % *slower* (623M vs 547M instructions — LLVM picks a worse canonical form for pre-promoted IR than for the malloc form it elides itself).
- The remaining sort_window engine gap (nwasm 106 ms vs Cranelift 60.6 ms on the *same* module) is therefore register allocation in the template JIT (~15 hot i64 locals vs 6 int pins), not module shape.

The prototype pass was dropped per measurement; this PR only corrects the documentation so the next reader doesn't chase the same ghost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU