### PR TITLE
fix(windows): honour fs_rename's replace contract; complete the CUDA stubs

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -112,6 +112,28 @@ if defined ZLIB_LIBNAME (
 REM zstd is pure NURL over stdlib\std\zstd.nu now - no library, no sentinel.
 if exist stdlib\runtime.zstd del /q stdlib\runtime.zstd
 
+REM ── CUDA driver + NVRTC sentinels (ALWAYS on — stub-backed) ──
+REM Mirrors build.sh §"CUDA driver + NVRTC sentinels". packages\gpu binds
+REM the CUDA Driver API (& `cuda` @ cu…) and NVRTC (& `nvrtc` @ nvrtc…)
+REM directly, with no runtime.c bridge. These are the two FFI libs that
+REM have FALLBACK STUB SOURCES (stdlib\{cuda,nvrtc}_stubs.c), which
+REM nurl.bat compiles into the image when no CUDA Toolkit is installed —
+REM so a gpu-importing program links and runs on a driverless box and
+REM packages\gpu falls back to its CPU backend. Because the fallback always
+REM exists, the COMPILE-TIME sentinel must not depend on any probe: gate it
+REM on the host and every Windows user without a Toolkit gets 40-odd
+REM "no build-time sentinel 'stdlib/runtime.cuda'" errors from nurlc for a
+REM package (anomaly, tensor, gpukit) that never needed a GPU in the first
+REM place. Stub-backed libs get an unconditional sentinel; nurl.bat decides
+REM real-vs-stub at LINK time, where the answer actually matters.
+> stdlib\runtime.cuda echo 1
+> stdlib\runtime.nvrtc echo 1
+if defined CUDA_PATH (
+    echo [info] CUDA Toolkit at "%CUDA_PATH%" - nurl.bat links the real driver + NVRTC
+) else (
+    echo [info] no CUDA Toolkit - cu*/nvrtc* link against stubs; packages\gpu uses its CPU backend
+)
+
 REM ── version header (mirrors build.sh) ────────────────────────
 REM Bake the toolchain version into runtime.o so `nurlc --version` /
 REM `nurlpkg --version` report the real version instead of "unknown".

--- a/nurl.bat
+++ b/nurl.bat
@@ -284,6 +284,97 @@ if not errorlevel 1 (
     )
 )
 
+REM ── Auto-link the CUDA Driver API + NVRTC ────────────────────
+REM Mirrors nurl.sh §"Auto-link the CUDA Driver API (libcuda) and NVRTC".
+REM packages\gpu binds the driver (& `cuda` @ cu…) and NVRTC
+REM (& `nvrtc` @ nvrtc…) directly, with no runtime.c bridge, so those ~40
+REM symbols must come from somewhere at link time or lld reports every one
+REM as undefined. Two sources:
+REM   - a CUDA Toolkit (cuda.lib + nvrtc.lib under %CUDA_PATH%\lib\x64) —
+REM     GPU compute runs for real. Both are needed: packages\gpu has no
+REM     precompiled kernels, it feeds CUDA-C through NVRTC at runtime
+REM     (cuda_compile → PTX/CUBIN → cuModuleLoadData), so the driver alone
+REM     buys nothing. The driver's own nvcuda.dll is NOT a substitute: it
+REM     ships no NVRTC, and its export directory names itself
+REM     `nvcuda_loader.dll`, so linking the DLL directly yields an import of
+REM     a file that does not exist and the exe dies at load with a missing-
+REM     DLL error rather than anything diagnosable.
+REM   - the fallback stubs (stdlib\{cuda,nvrtc}_stubs.c) otherwise: the
+REM     program links and loads, every CUDA call returns a non-zero
+REM     CUresult, and gpu_open falls back to the CPU backend
+REM     (packages\gpu\src\cpu.nu). This is the path a package that only
+REM     pulls in gpu transitively — anomaly → tensor → gpukit → gpu — takes,
+REM     and it wants no GPU at all.
+REM The stubs go in as SOURCE rather than a prebuilt object because this
+REM script links MSVC-ABI under clang and MinGW-ABI under the bundled zig;
+REM handing %CC% the .c compiles the translation unit with whichever ABI
+REM this particular link is using, so one file serves both.
+REM `set NURL_GPU_STUBS=1` forces the stub path (same knob as nurl.sh).
+set "CUDA_LIBDIR="
+if not defined NURL_GPU_STUBS if defined CUDA_PATH if exist "%CUDA_PATH%\lib\x64\nvrtc.lib" (
+    REM Those are MSVC import libs, so they can only go into an MSVC-ABI
+    REM image — the same constraint canvas.o + SDL2.lib carry above. Under
+    REM the bundled zig, say so and fall through to the stubs rather than
+    REM emit a link the user cannot act on.
+    if "!MINGW_ABI!"=="1" (
+        echo [info] CUDA Toolkit found, but its import libs are MSVC-ABI and the
+        echo        bundled zig links MinGW — using the CPU-fallback stubs. For real
+        echo        GPU compute, build with clang instead: install LLVM and re-run
+        echo        with NURL_ZIG pointing at a path that does not exist, e.g.
+        echo            set NURL_ZIG=none
+    ) else (
+        set "CUDA_LIBDIR=%CUDA_PATH%\lib\x64"
+    )
+)
+findstr /R /C:"@cu[A-Z]" "%LLFILE%" >nul 2>&1
+if not errorlevel 1 (
+    if defined CUDA_LIBDIR (
+        set EXTRA_LIBS=!EXTRA_LIBS! -L"!CUDA_LIBDIR!" -lcuda
+        echo [info] CUDA driver linked from "!CUDA_LIBDIR!"
+    ) else (
+        if not exist "%SCRIPTDIR%stdlib\cuda_stubs.c" (
+            echo ERROR: program uses the CUDA FFI but %SCRIPTDIR%stdlib\cuda_stubs.c
+            echo        is missing. Run build.bat to build the NURL stdlib first.
+            exit /b 1
+        )
+        set EXTRA_OBJS=!EXTRA_OBJS! "%SCRIPTDIR%stdlib\cuda_stubs.c"
+        echo [info] no linkable CUDA Toolkit - cu* uses stubs; packages\gpu runs on the CPU
+    )
+)
+findstr /R /C:"@nvrtc[A-Z]" "%LLFILE%" >nul 2>&1
+if not errorlevel 1 (
+    if defined CUDA_LIBDIR (
+        set EXTRA_LIBS=!EXTRA_LIBS! -lnvrtc
+    ) else (
+        if not exist "%SCRIPTDIR%stdlib\nvrtc_stubs.c" (
+            echo ERROR: program uses the NVRTC FFI but %SCRIPTDIR%stdlib\nvrtc_stubs.c
+            echo        is missing. Run build.bat to build the NURL stdlib first.
+            exit /b 1
+        )
+        set EXTRA_OBJS=!EXTRA_OBJS! "%SCRIPTDIR%stdlib\nvrtc_stubs.c"
+    )
+)
+
+REM ── Win32 dynamic-loader shims (dlopen / dlsym / dlclose) ────
+REM packages\gpu's CPU backend binds the POSIX loader (& `c` @ dlopen …) to
+REM load the host object it JIT-builds its kernels into. Those three symbols
+REM are in libdl/libc on any POSIX host, so nurl.sh needs no equivalent of
+REM this block; Windows has none of them, and a program that merely IMPORTS
+REM packages\gpu — anomaly → tensor → gpukit → gpu, none of which asks for a
+REM GPU — died with "undefined symbol: dlopen" out of cpu_compile. Compile
+REM the LoadLibraryA forwarders in when the IR reaches for them. Source, not
+REM an object, for the same ABI reason as the CUDA stubs above.
+findstr /R /C:"@dlopen\>" /C:"@dlsym\>" /C:"@dlclose\>" "%LLFILE%" >nul 2>&1
+if not errorlevel 1 (
+    if not exist "%SCRIPTDIR%stdlib\dl_win32.c" (
+        echo ERROR: program uses the POSIX dynamic loader ^(dlopen/dlsym/dlclose^)
+        echo        but %SCRIPTDIR%stdlib\dl_win32.c is missing. Run build.bat
+        echo        to build the NURL stdlib first.
+        exit /b 1
+    )
+    set EXTRA_OBJS=!EXTRA_OBJS! "%SCRIPTDIR%stdlib\dl_win32.c"
+)
+
 REM Auto-link the FFI libs build.bat detected (issue #229). These are for
 REM programs whose own IR declares an FFI; the runtime itself no longer
 REM needs them, since gzip/deflate became pure NURL in §8 P6 and zstd in

--- a/packages/cli/src/cli.nu
+++ b/packages/cli/src/cli.nu
@@ -50,6 +50,24 @@ $ `prompt.nu`
     String env  // environment-variable fallback (empty = none)
 }
 
+// Passed to every command handler; wraps the parsed args plus a back-ref to
+// the Cli so accessors can resolve env fallbacks and defaults.
+//
+// Declared BEFORE CliCmd on purpose. CliCmd's `handler` field is a function
+// type taking a CliCtx BY VALUE, and nurlc emits `%Name = type` as it parses,
+// so declaration order here IS emission order in the .ll. Some LLVM IR
+// parsers reject a forward-referenced named struct in that position with
+// "invalid type for function argument" — observed on Windows, where moving
+// this below CliCmd fails every binary that links cli. clang 18 on Linux
+// accepts the forward reference, so the ordering is belt-and-braces there
+// rather than load-bearing; keep it anyway, it costs nothing and the
+// by-pointer back-ref to Cli below stays legal in either direction.
+: CliCtx {
+    ArgParser parser
+    * Cli cli
+    String cmdname
+}
+
 : CliCmd {
     String name
     String help
@@ -62,14 +80,6 @@ $ `prompt.nu`
     String version
     ( Vec CliFlag ) globals
     ( Vec CliCmd ) cmds
-}
-
-// Passed to every command handler; wraps the parsed args plus a back-ref to
-// the Cli so accessors can resolve env fallbacks and defaults.
-: CliCtx {
-    ArgParser parser
-    * Cli cli
-    String cmdname
 }
 
 // ── Colour (decided once per run: stdout is a TTY and $NO_COLOR unset) ──

--- a/stdlib/cuda_stubs.c
+++ b/stdlib/cuda_stubs.c
@@ -1,26 +1,105 @@
-/* stdlib/cuda_stubs.c — weak-free fallback definitions of the CUDA Driver API
- * symbols packages/gpu/src/cuda.nu binds. nurl.sh links THIS object instead of
- * -lcuda when libcuda is not available on the build host, so a program that
- * references the CUDA backend still LINKS and LOADS on a machine with no
- * NVIDIA driver — every call returns a non-zero CUresult, which makes
- * gpu_open fall back to the CPU backend (packages/gpu/src/cpu.nu).
+/* stdlib/cuda_stubs.c — fallback definitions of the CUDA Driver API symbols
+ * packages/gpu/src/cuda.nu binds. nurl.sh / nurl.bat link THIS translation
+ * unit instead of -lcuda when libcuda (nvcuda.dll on Windows) is not
+ * available at link time, so a program that references the CUDA backend
+ * still LINKS and LOADS on a machine with no NVIDIA driver — every call
+ * returns a non-zero CUresult, which makes gpu_open fall back to the CPU
+ * backend (packages/gpu/src/cpu.nu).
+ *
+ * THIS LIST MUST COVER EVERY `& `cuda` @ …` DECLARATION IN cuda.nu. A symbol
+ * bound there but missing here is not a compile error — it is an undefined
+ * symbol at link time, on every host without a driver. When you add an FFI
+ * binding to cuda.nu, add its stub here in the same commit:
+ *     grep -o '@ cu[A-Za-z0-9_]*' packages/gpu/src/cuda.nu | sort -u
  *
  * Empty parameter lists (K&R, no prototype) so each stub is callable with the
- * driver's real argument counts. Never linked alongside the real libcuda (that
- * would be a duplicate-symbol error) — nurl.sh picks exactly one. */
-int cuInit()                { return 100; }  /* CUDA_ERROR_NO_DEVICE-ish */
-int cuDeviceGetCount(void *c){ if (c) *(int*)c = 0; return 100; }
-int cuDeviceGet()           { return 100; }
-int cuDeviceGetName()       { return 100; }
-int cuCtxCreate()           { return 100; }
-int cuCtxDestroy()          { return 100; }
-int cuCtxSynchronize()      { return 100; }
-int cuModuleLoadData()      { return 100; }
-int cuModuleUnload()        { return 100; }
-int cuModuleGetFunction()   { return 100; }
-int cuMemAlloc()            { return 100; }
-int cuMemFree()             { return 100; }
-int cuMemcpyHtoD()          { return 100; }
-int cuMemcpyDtoH()          { return 100; }
-int cuLaunchKernel()        { return 100; }
-int cuGetErrorName()        { return 100; }
+ * driver's real argument counts; the few that must zero an out-parameter
+ * declare just the leading arguments they touch, which is ABI-safe on both
+ * SysV and Win64 (the caller cleans up). Never linked alongside the real
+ * libcuda (that would be a duplicate-symbol error) — the launcher picks
+ * exactly one. */
+
+#define CUDA_ERROR_NO_DEVICE 100
+
+/* ── init / device query ─────────────────────────────────────── */
+int cuInit()                 { return CUDA_ERROR_NO_DEVICE; }
+int cuDeviceGetCount(void *c){ if (c) *(int *)c = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuDeviceGet()            { return CUDA_ERROR_NO_DEVICE; }
+int cuDeviceGetName()        { return CUDA_ERROR_NO_DEVICE; }
+int cuDeviceGetAttribute(void *o) { if (o) *(int *)o = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuDeviceTotalMem_v2(void *b)  { if (b) *(unsigned long long *)b = 0; return CUDA_ERROR_NO_DEVICE; }
+
+/* ── contexts ────────────────────────────────────────────────── */
+int cuCtxCreate_v2(void *p)  { if (p) *(void **)p = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuCtxDestroy_v2()        { return CUDA_ERROR_NO_DEVICE; }
+int cuCtxSetCurrent()        { return CUDA_ERROR_NO_DEVICE; }
+int cuCtxSynchronize()       { return CUDA_ERROR_NO_DEVICE; }
+int cuDevicePrimaryCtxRetain(void *p) { if (p) *(void **)p = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuDevicePrimaryCtxRelease_v2()    { return CUDA_ERROR_NO_DEVICE; }
+
+/* ── modules / kernels ───────────────────────────────────────── */
+int cuModuleLoadData(void *m){ if (m) *(void **)m = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuModuleUnload()         { return CUDA_ERROR_NO_DEVICE; }
+int cuModuleGetFunction(void *f) { if (f) *(void **)f = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuLaunchKernel()         { return CUDA_ERROR_NO_DEVICE; }
+
+/* ── device memory ───────────────────────────────────────────── */
+int cuMemAlloc_v2(void *d)   { if (d) *(unsigned long long *)d = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuMemFree_v2()           { return CUDA_ERROR_NO_DEVICE; }
+int cuMemGetInfo_v2(void *f, void *t) {
+    if (f) *(unsigned long long *)f = 0;
+    if (t) *(unsigned long long *)t = 0;
+    return CUDA_ERROR_NO_DEVICE;
+}
+int cuMemcpyHtoD_v2()        { return CUDA_ERROR_NO_DEVICE; }
+int cuMemcpyDtoH_v2()        { return CUDA_ERROR_NO_DEVICE; }
+int cuMemcpyDtoD_v2()        { return CUDA_ERROR_NO_DEVICE; }
+int cuMemcpyHtoDAsync_v2()   { return CUDA_ERROR_NO_DEVICE; }
+
+/* ── pinned / registered host memory ─────────────────────────── */
+int cuMemHostAlloc(void *pp) { if (pp) *(void **)pp = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuMemFreeHost()          { return CUDA_ERROR_NO_DEVICE; }
+int cuMemHostRegister_v2()   { return CUDA_ERROR_NO_DEVICE; }
+int cuMemHostUnregister()    { return CUDA_ERROR_NO_DEVICE; }
+
+/* ── streams ─────────────────────────────────────────────────── */
+int cuStreamCreate(void *o)  { if (o) *(void **)o = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuStreamSynchronize()    { return CUDA_ERROR_NO_DEVICE; }
+int cuStreamBeginCapture_v2(){ return CUDA_ERROR_NO_DEVICE; }
+int cuStreamEndCapture(void *s, void *g) { (void)s; if (g) *(void **)g = 0; return CUDA_ERROR_NO_DEVICE; }
+
+/* ── graphs ──────────────────────────────────────────────────── */
+int cuGraphInstantiateWithFlags(void *e) { if (e) *(void **)e = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuGraphLaunch()          { return CUDA_ERROR_NO_DEVICE; }
+int cuGraphExecDestroy()     { return CUDA_ERROR_NO_DEVICE; }
+int cuGraphDestroy()         { return CUDA_ERROR_NO_DEVICE; }
+
+/* ── events ──────────────────────────────────────────────────── */
+int cuEventCreate(void *p)   { if (p) *(void **)p = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuEventRecord()          { return CUDA_ERROR_NO_DEVICE; }
+int cuEventSynchronize()     { return CUDA_ERROR_NO_DEVICE; }
+int cuEventElapsedTime(void *ms) { if (ms) *(float *)ms = 0.0f; return CUDA_ERROR_NO_DEVICE; }
+int cuEventDestroy_v2()      { return CUDA_ERROR_NO_DEVICE; }
+
+/* ── diagnostics ─────────────────────────────────────────────── */
+/* Unlike the rest, this one SUCCEEDS: a caller that reports an error
+ * dereferences the string it hands back, so returning a failure with the
+ * out-pointer untouched would turn a clean CPU-fallback message into a
+ * null dereference. Hand out a real static string and return CUDA_SUCCESS. */
+int cuGetErrorName(int err, void *pstr) {
+    static const char *name = "CUDA_ERROR_NO_DEVICE (no driver; CPU fallback)";
+    (void)err;
+    if (pstr) *(const char **)pstr = name;
+    return 0;
+}
+
+/* ── legacy aliases ──────────────────────────────────────────── */
+/* Pre-_v2 spellings, kept so an older pinned packages/gpu that binds the
+ * un-suffixed names still links against this same object. */
+int cuCtxCreate()            { return CUDA_ERROR_NO_DEVICE; }
+int cuCtxDestroy()           { return CUDA_ERROR_NO_DEVICE; }
+int cuDeviceTotalMem(void *b){ if (b) *(unsigned long long *)b = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuMemAlloc(void *d)      { if (d) *(unsigned long long *)d = 0; return CUDA_ERROR_NO_DEVICE; }
+int cuMemFree()              { return CUDA_ERROR_NO_DEVICE; }
+int cuMemcpyHtoD()           { return CUDA_ERROR_NO_DEVICE; }
+int cuMemcpyDtoH()           { return CUDA_ERROR_NO_DEVICE; }

--- a/stdlib/dl_win32.c
+++ b/stdlib/dl_win32.c
@@ -1,0 +1,66 @@
+/* stdlib/dl_win32.c — Win32 implementations of the three POSIX dynamic-loader
+ * entry points packages/gpu/src/cpu.nu binds (& `c` @ dlopen / dlsym /
+ * dlclose). They live in libdl / libc on every POSIX host, so nurl.sh needs
+ * nothing; Windows has no such symbols at all, and a program that merely
+ * IMPORTS packages/gpu — anomaly → tensor → gpukit → gpu, none of which asks
+ * for a GPU — died at link with "undefined symbol: dlopen" referenced from
+ * cpu_compile / cpu_function. nurl.bat compiles this translation unit into
+ * the image when the IR references them, the same way it handles
+ * stdlib/cuda_stubs.c.
+ *
+ * These are real forwarders, not failing stubs: LoadLibraryA / GetProcAddress
+ * / FreeLibrary are the exact Win32 analogues, so the mapping costs nothing
+ * and stays honest. It does NOT make the CPU backend work on Windows —
+ * cpu_compile generates C++ over ucontext_t / makecontext / swapcontext and
+ * OpenMP and builds it into a .so with the system c++, none of which exists
+ * here. That path fails earlier, at its own system() call, and returns 0 the
+ * way it does for any compile failure. What this file buys is the link. */
+#ifdef _WIN32
+#include <windows.h>
+
+/* POSIX RTLD_* flags have no Win32 counterpart: LoadLibraryA resolves
+ * everything eagerly and its handles are process-global, so RTLD_NOW (2) and
+ * RTLD_LAZY (1) are already the behaviour and RTLD_GLOBAL / RTLD_LOCAL have
+ * nothing to select. Ignore the argument rather than reject unknown bits. */
+void *dlopen(const char *path, int flags) {
+    (void)flags;
+    /* dlopen(NULL, …) means "the running program"; GetModuleHandleA(NULL) is
+     * its Win32 equivalent. Do not FreeLibrary that one — see dlclose. */
+    if (!path) return (void *)GetModuleHandleA(NULL);
+    return (void *)LoadLibraryA(path);
+}
+
+void *dlsym(void *handle, const char *name) {
+    if (!handle || !name) return 0;
+    return (void *)(unsigned long long)GetProcAddress((HMODULE)handle, name);
+}
+
+int dlclose(void *handle) {
+    /* dlclose returns 0 on success, FreeLibrary returns non-zero. Refuse to
+     * free the pseudo-handle dlopen(NULL) hands back: GetModuleHandleA does
+     * not take a reference, so freeing it would decrement a count this
+     * process never incremented. */
+    if (!handle || handle == (void *)GetModuleHandleA(NULL)) return 0;
+    return FreeLibrary((HMODULE)handle) ? 0 : -1;
+}
+
+/* Not bound by cpu.nu today, but any caller that reaches for dlopen reaches
+ * for this next. Formats the last Win32 error into a static buffer, matching
+ * dlerror's contract that the caller neither frees nor holds the string. */
+char *dlerror(void) {
+    static char buf[256];
+    DWORD e = GetLastError();
+    if (e == 0) return 0;
+    DWORD n = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
+                             FORMAT_MESSAGE_IGNORE_INSERTS,
+                             0, e, 0, buf, (DWORD)sizeof buf - 1, 0);
+    if (n == 0) {
+        buf[0] = '?'; buf[1] = 0;
+    } else {
+        buf[n] = 0;
+        while (n && (buf[n - 1] == '\n' || buf[n - 1] == '\r')) buf[--n] = 0;
+    }
+    SetLastError(0);
+    return buf;
+}
+#endif /* _WIN32 */

--- a/stdlib/std/fs.nu
+++ b/stdlib/std/fs.nu
@@ -994,8 +994,37 @@ $ `stdlib/core/posix.nu`  // open / lseek / mmap / munmap + posix_const
 // existing `to` is replaced (POSIX rename semantics). Cross-device
 // moves surface as IoErr {Other} (EXDEV) — copy + delete instead.
 @ fs_rename s from s to → !v IoErr {
-    : i32 rc ( rename from to )
+    : ~ i32 rc ( rename from to )
     ? == rc # i32 0 { ^ @ !v IoErr { T 0 } } {}
+    // Windows' CRT rename(2) does not implement the POSIX replace: handed an
+    // existing `to` it fails EEXIST and leaves BOTH files where they were.
+    // That breaks the write-to-`.tmp`-then-rename-over pattern this function
+    // exists to serve — and breaks it silently, because the caller sees a
+    // successful write followed by a stale file and a `.tmp` accumulating
+    // beside it. Every atomic writer in the tree rides on this (packages
+    // anomaly, cas, gpu's kernel cache, hub, lsmdb, nurllama, nwasm,
+    // wasmbuilder), so the divergence has to be absorbed here rather than at
+    // each call site. Drop the destination and retry.
+    //
+    // Gated on EEXIST specifically, and not on "did it fail": the only POSIX
+    // rename that reports EEXIST is a directory onto a NON-EMPTY directory,
+    // and `remove` refuses exactly that (it unlinks files and empty
+    // directories only), so the retry cannot destroy a `to` here either. A
+    // real failure — EXDEV, EACCES, EBUSY — maps to a different kind and
+    // never reaches this branch, leaving `to` alone.
+    //
+    // The retry is NOT atomic the way rename(2) is: a crash in the window
+    // between the remove and the rename loses `to`. `from` is untouched
+    // there, so the new content is still on disk under the temp name; a
+    // reader is the one that loses, seeing neither file. Win32 MoveFileExA
+    // with MOVEFILE_REPLACE_EXISTING closes that window, but it is a
+    // kernel32 FFI, and its declaration would need a build-time sentinel
+    // that no POSIX build has any reason to produce.
+    ? == ( errno_kind ) 2 {
+        : i32 _rm ( remove to )
+        = rc ( rename from to )
+        ? == rc # i32 0 { ^ @ !v IoErr { T 0 } } {}
+    } {}
     ^ @ !v IoErr { F ( _io_err_of_kind ( errno_kind ) ) }
 }
 


### PR DESCRIPTION
## Why

Six defects found while getting `packages/anomaly` to run on Windows. **Two of them are not Windows-specific and were latent on Linux as well.**

**`fs_rename` breaks its own documented contract on Windows.** The doc comment promises *"an existing `to` is replaced (POSIX rename semantics)"*, but it calls the CRT's `rename(2)`, which on Windows fails `EEXIST` and leaves **both** files where they were (measured on the reporting machine: `rc=-1 errno=17`, destination unchanged). That silently breaks every write-to-`.tmp`-then-rename-over writer in the tree: anomaly, cas, gpu's kernel cache, hub, lsmdb, nurllama, nwasm, wasmbuilder. The observed symptom in anomaly: it collected data and trained successfully, then crashed with `0xC0000005`, because the metadata never reached disk and scoring read zero features against a forest trained on 81 points.

**`stdlib/cuda_stubs.c` is missing 31 of the 41 symbols it must define — and this breaks Linux too.** `packages/gpu/src/cuda.nu` binds 41 ``& `cuda` `` symbols; the stubs defined 16. Reproduced here on Linux with no driver:

```
/usr/bin/ld: undefined reference to `cuDevicePrimaryCtxRetain'
/usr/bin/ld: undefined reference to `cuMemGetInfo_v2'
/usr/bin/ld: undefined reference to `cuEventCreate'
/usr/bin/ld: undefined reference to `cuStreamCreate'
/usr/bin/ld: undefined reference to `cuCtxSetCurrent'
/usr/bin/ld: undefined reference to `cuStreamBeginCapture_v2'   (12 refs, 8 distinct symbols)
clang: error: linker command failed with exit code 1
```

This was invisible until now only because dead-code elimination drops the uncalled `declare`s: a program that *imports* gpu links fine, one that actually calls `gpu_open` does not.

**A program that merely imports gpu dies at link on Windows** with `undefined symbol: dlopen` — gpu's CPU backend binds the POSIX loader, and the chain `anomaly → tensor → gpukit → gpu` reaches it without anyone asking for a GPU.

**`build.bat` never wrote the `runtime.cuda` / `runtime.nvrtc` sentinels**, so `nurlc` rejected every ``& `cuda` `` declaration on any Windows box without a CUDA Toolkit — ~40 errors for packages that never needed a GPU. `build.sh` writes both unconditionally.

**`nurl.bat` had no CUDA link handling at all**, so even with sentinels present there was nothing to resolve the symbols against.

**`packages/cli/src/cli.nu` declares `CliCtx` after `CliCmd`**, which references it by value; the resulting forward reference in the emitted IR is rejected on the Windows toolchain with `invalid type for function argument`.

## What

Read in this order:

- **`stdlib/std/fs.nu`** *(load-bearing, affects Linux)* — `fs_rename` retries after dropping the destination, **gated on `EEXIST` alone** (`errno_kind == 2`), never on "did it fail". `errno_kind` maps *only* `EEXIST` to kind 2, so `EXDEV`/`EACCES`/`EBUSY` (kind 7) never enter the branch and leave `to` alone.
- **`stdlib/cuda_stubs.c`** *(load-bearing, affects Linux)* — 16 → 41 definitions, covering every bound symbol, plus 7 legacy pre-`_v2` aliases for an older pinned `packages/gpu`. Carries the `grep` that keeps the list in sync. `cuGetErrorName` still deliberately *succeeds* and hands back a static string, since callers dereference it.
- **`stdlib/dl_win32.c`** *(new, Windows-only)* — real `LoadLibraryA`/`GetProcAddress`/`FreeLibrary` forwarders, not failing stubs. Entirely inside `#ifdef _WIN32`.
- **`build.bat`** *(+22, Windows-only)* — unconditional `runtime.cuda`/`runtime.nvrtc` sentinels, mirroring `build.sh` §"CUDA driver + NVRTC sentinels"; the Toolkit probe is informational only.
- **`nurl.bat`** *(+91, Windows-only)* — mirrors `nurl.sh`. Toolkit → `-lcuda -lnvrtc`; otherwise the stubs go on the link line **as source**, so the ABI follows whether clang (MSVC) or the bundled zig (MinGW) is linking.
- **`packages/cli/src/cli.nu`** *(reorder + comment)* — `CliCtx` moved above `CliCmd`.

Observable behaviour changes: `fs_rename` now replaces an existing destination on Windows (which is what it always documented). No change on POSIX — see Proof. No goldens moved.

Two notes where I deliberately did **not** follow the original report:

1. Its comment claimed POSIX `rename` never returns `EEXIST`, making the branch dead code on Linux. That is not quite right — POSIX permits `EEXIST` for a directory onto a **non-empty** directory. The safety argument is still sound, but for a different reason, so I rewrote the comment to state the real one: `remove(3)` refuses exactly that case, so the retry cannot destroy a destination. Verified: `remove("non-empty dir") rc=-1 errno=39 (ENOTEMPTY)`.
2. Its comment asserted LLVM rejects by-value forward-referenced named structs outright. **clang 18 on Linux accepts it** (checked with the real `demo.ll` and a minimal repro; a genuinely undefined type gives a *different* error, `use of undefined type`). The reorder is kept because it is free and fixes the reported Windows failure, but the comment now says it is defensive on Linux rather than stating a rule I could not reproduce.

## Proof

```
./build.sh
BUILD DIDN'T FAIL but TESTS FAILED
PASS 869 · FAIL 1 · MISSING 0 · ORPHAN 0 · SKIP 23  (jobs=4)
```

The single failure is **`udp_basic`** (`wildcard_local_nonempty=T` → `wildcard_bind=NetBind`). **It is not a regression** — I stashed every change and re-ran it on a clean tree, where it fails identically. This sandbox blocks the UDP wildcard bind. Bootstrap fixed point reached in both runs.

`fs_rename` — purpose-built test over four cases, run against the patched **and** unpatched `fs.nu`:

```
1 rename over existing => OK      1 dest content=NEW   1 source gone (good)
2 rename fresh         => OK      2 dest content=AAA
3 missing source       => NotFound
4 dir onto non-empty dir => Other  4 precious content=DO-NOT-LOSE
```

`diff` of the two outputs: **identical**. No POSIX behaviour change, error classification preserved, and the destination survives the one case that reaches near the new branch.

CUDA stubs — a gpu program that actually calls `gpu_open`/`gpu_mem_free`/`gpu_timer_*`/`gpu_graph_begin`, built with `NURL_GPU_STUBS=1` on this driverless Linux box:

- **before:** link fails, 12 undefined references (pasted above)
- **after:** links, runs, exits 0, reports `name=CPU (host C++)` — the CPU fallback working as intended

`dl_win32.c` on Linux: compiles clean, `nm --defined-only` → **0 symbols** (empty TU, zero Linux impact).
`cli.nu`: `demo` builds and runs; IR now emits `%CliCtx` before `%CliCmd`; `demo hello --name Tero` → `hello, Tero`, `demo add 2 3 4` → `9`.
Symbol audit: bound-vs-defined diff is empty for both `cuda` (41/41) and `nvrtc` (9/9, already correct).

**Not run:** anything on Windows — no Windows host in this environment. Every Windows-side claim in the Why section is from the reporter's machine, not re-measured by me; what I verified independently is the Linux half, which is where the two latent bugs live. `build.bat`/`nurl.bat` are unexecuted here and reviewed by diff against their `.sh` counterparts only.

## Known remaining

- **Root cause in nurlc is untouched.** `gen_struct_decl` (`compiler/nurlc.nu:22996`) writes `%Name = type` at parse time in source order with no topological sort. `cli` is a symptom; the same trap is available to anyone. The real fix buffers and sorts type definitions, which needs a bootstrap rebuild — out of scope here, and worth its own issue.
- **`nurlpkg install anomaly` from the registry still fails**, because it fetches `cli 0.2.0`, which has the old declaration order. Needs a `cli` release (0.2.1). The local repo path already works.
- **`nurlpkg install` with local path dependencies fails on Windows** (`failed to create symlink`) without Developer Mode. Untouched.
- **The retry is not atomic** the way `rename(2)` is: a crash between the `remove` and the `rename` loses `to`. `from` survives, so the content is still on disk under the temp name; a concurrent reader is what loses. `MoveFileExA` with `MOVEFILE_REPLACE_EXISTING` would close the window but needs a kernel32 FFI behind a build-time sentinel no POSIX build would produce. Documented in the code rather than fixed.
- **Line endings:** the reporter found `build.bat`/`nurl.bat` as LF in their Windows **working tree**. That is a local checkout artifact, not a repo defect — `.gitattributes` sets `*.bat text eol=crlf`, so git stores LF in the blob and checks out CRLF. Verified: all four `.bat` blobs are LF today and the worktree here is CRLF. Nothing to commit; `git add --renormalize .` or a fresh clone fixes their tree. This PR's `.bat` blobs stay LF, so the diff carries no line-ending churn.

---

Machine-authored (Claude Code), from a Windows bug report by the repo owner. The Linux verification, the two corrections to the original report's reasoning, and the `.gitattributes` finding are mine; the Windows measurements are theirs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmBHowW9155wKMhoGrjkjA)_