### PR TITLE
fix(nurlc): a struct named like a type parameter is still a concrete type

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -21539,6 +21539,28 @@
     ? & >= c1 48 <= c1 57 { ^ T } { ^ F }
 }
 
+// is_abstract_tparam: `is_tparam_like`, corrected by what is actually in
+// scope. The shape test above cannot tell a still-abstract type parameter
+// from a CONCRETE user type that happens to be spelled like one — `P`,
+// `Q3` and `A1` are perfectly legal struct/enum names. Treating those as
+// abstract skipped the instantiation entirely, so `( Vec P )` referenced a
+// `%Vec__P` nothing ever defined and the user got `type 'Vec__P' has no
+// field 'ctl'` pointing into stdlib/core/vec.nu — a name-length-dependent
+// failure with no hint of the real cause.
+//
+// A declared struct or enum maps to `%Name` in `syms` (the pre-scan sets
+// it, before any instantiation runs), so a `%`-valued lookup means the
+// token names a real type and the instantiation must proceed. A genuine
+// tparam has no binding at all: inside a template body the substitution
+// has not happened yet, and at a nested instantiation site (`( Vec A )`
+// within a generic function) `A` is not a type in scope.
+@ is_abstract_tparam i syms s tok → b {
+    ? ! ( is_tparam_like tok ) { ^ F } {}
+    : s sv ( nurl_sym_get syms tok )
+    ? & != 0 ( nurl_str_len sv ) == ( nurl_str_get sv 0 ) 37 { ^ F } {}
+    ^ T
+}
+
 // __has_dunder: true if `str` contains "__" — the mark of a compiler-mangled
 // name (a generic instantiation like `Vec__i64`, an aliased import). Such
 // names are always compiler-produced, never a user-typed type name.
@@ -21650,12 +21672,15 @@
         // where A/B are still abstract. The concrete instantiation emerges
         // when the function is called with concrete type args at parse
         // time and re-enters scan_generic_structs / parse_type_paren.
+        // `is_abstract_tparam` (not the bare spelling test) so a concrete
+        // struct whose NAME is tparam-shaped — `: P { … }`, `( Vec P )` —
+        // instantiates like any other type argument.
         : ~ s ta_chk ( nurl_str_cat ta_list `` )
         : ~ b skip F
         ~ & != 0 ( nurl_str_len ta_chk ) ! skip {
             : s ta ( str_first_word ta_chk )
             = ta_chk ( str_skip_word ta_chk )
-            ? ( is_tparam_like ta ) { = skip T } {}
+            ? ( is_abstract_tparam syms ta ) { = skip T } {}
         }
         ? ! skip {
             // Compute mangled name by walking tparams + ta_list in parallel.
@@ -29076,6 +29101,16 @@
     ( nurl_print_buf_start )
     ? != g_dbg_enabled 0 { ( dbg_init path ) } {}
     ( init_syms syms )
+    // Type NAMES first: the generic-struct scan below has to tell a
+    // still-abstract type argument (`( Vec A )` inside a template) from a
+    // concrete one, and the only sound test is "is this name a type in
+    // scope?" — a spelling heuristic silently skipped `( Vec P )` for
+    // every struct whose name is one or two tparam-shaped characters.
+    // scan_type_names is purely lexical (registers `Name → %Name`, prints
+    // no IR), so running it first is free and changes nothing else.
+    : i lex_tn ( nurl_lex_new src path )
+    ( scan_type_names lex_tn syms )
+    ( nurl_lex_free lex_tn )
     : i lex0 ( nurl_lex_new src path )
     ( scan_generic_structs lex0 syms )
     ( nurl_lex_free lex0 )
@@ -29091,9 +29126,6 @@
     // Every impl across the program is now registered — enforce that each
     // implemented subtrait's supertraits are implemented for the same type.
     ( verify_super_obligations )
-    : i lex_tn ( nurl_lex_new src path )
-    ( scan_type_names lex_tn syms )
-    ( nurl_lex_free lex_tn )
     // Dynamic trait objects (docs/spec.md §4.9): collect every trait used as a
     // `%Trait` object (body-aware, after __istrait markers exist) and emit the
     // `%dyn.<T>` fat-pointer type defs + synthesized Drop functions at module

--- a/compiler/tests/generic_short_type_name.nu
+++ b/compiler/tests/generic_short_type_name.nu
@@ -1,0 +1,73 @@
+// generic_short_type_name.nu — a CONCRETE type whose name is spelled like a
+// type parameter is still a concrete type argument.
+//
+// `is_tparam_like` answers a question about spelling: one uppercase letter,
+// optionally followed by a digit — the project's tparam convention (`[A]`,
+// `[K V]`, `[T1 T2]`). `ensure_struct_instantiated` used that answer to skip
+// "still abstract" instantiations, so a user struct named `P` or `Q3` — both
+// perfectly legal names — was mistaken for a type parameter and its
+// instantiation was never materialised. `( Vec P )` then referenced a
+// `%Vec__P` nothing defined, and the program died with
+//
+//     stdlib/core/vec.nu:201: type 'Vec__P' has no field 'ctl'
+//
+// pointing into the stdlib, with the real cause (the length of the user's own
+// struct name) nowhere in the message. A one-character rename made it work.
+//
+// The fix is to ask scope instead of spelling: `is_abstract_tparam` treats a
+// tparam-shaped token as abstract only when it is NOT a type in `syms`, which
+// required moving the purely-lexical `scan_type_names` pass ahead of
+// `scan_generic_structs` so the names are registered before the instantiation
+// scan consults them.
+//
+// Covered here: a short-named struct as the argument of a stdlib generic
+// (Vec), of a user generic struct, and of a user generic function.
+
+$ `stdlib/core/vec.nu`
+$ `stdlib/core/option.nu`
+
+: P { i8 a u16 b }
+: Q3 { i v }
+
+: Box [T] { T inner }
+
+@ mkbox [T] T x → ( Box T ) { ^ @ ( Box T ) { x } }
+
+@ psum P p → i { ^ + # i . p a # i . p b }
+
+@ main → i {
+    // A generic struct from the stdlib, instantiated at `P`.
+    : ( Vec P ) v ( vec_new [P] )
+    ( vec_push [P] v @ P { # i8 200 # u16 60000 } )
+    ( vec_push [P] v @ P { # i8 -1 # u16 7 } )
+    ( nurl_print `len=` )
+    ( nurl_print ( nurl_str_int ( vec_len [P] v ) ) )
+    ( nurl_print `\n` )
+
+    : ~ i k 0
+    : ~ i total 0
+    ~ < k ( vec_len [P] v ) {
+        : P e ( opt_unwrap [P] ( vec_get [P] v k ) )
+        = total + total ( psum e )
+        = k + k 1
+    }
+    ( nurl_print `total=` )
+    ( nurl_print ( nurl_str_int total ) )
+    ( nurl_print `\n` )
+    ( vec_free [P] v )
+
+    // A user generic struct + generic function, instantiated at `Q3`.
+    : ( Box Q3 ) b ( mkbox [Q3] @ Q3 { 41 } )
+    ( nurl_print `box=` )
+    ( nurl_print ( nurl_str_int . . b inner v ) )
+    ( nurl_print `\n` )
+
+    // …and at `P`, so the two short names do not share a monomorph.
+    : ( Box P ) b2 ( mkbox [P] @ P { # i8 3 # u16 4 } )
+    ( nurl_print `box2=` )
+    ( nurl_print ( nurl_str_int ( psum . b2 inner ) ) )
+    ( nurl_print `\n` )
+
+    ( nurl_print `done\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs/generic_short_type_name.txt
+++ b/compiler/tests/outputs/generic_short_type_name.txt
@@ -1,0 +1,9 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+len=2
+total=59950
+box=41
+box2=7
+done


### PR DESCRIPTION
## What

A user struct whose name is one or two tparam-shaped characters (`P`, `Q3`, `A1`) could not be used as a generic type argument. `( Vec P )` compiled to a reference to a `%Vec__P` that nothing ever defined:

```
stdlib/core/vec.nu:201: error: type 'Vec__P' has no field 'ctl'
  [while instantiating 'vec_len__P'; first call site: prog.nu:20]
```

The message points into the stdlib and never mentions the real cause — the length of the user's own struct name. Renaming `P` to `Quux` made the identical program compile and run.

## Why

`is_tparam_like` is a *spelling* test: one uppercase letter, optionally followed by a digit — the project's tparam naming convention. `ensure_struct_instantiated` used it to skip instantiations whose arguments are still abstract (`( Pair A B )` inside a generic template), and a concrete struct that happens to be spelled that way got skipped with them.

## Fix

Ask scope, not spelling. `is_abstract_tparam` treats a tparam-shaped token as abstract only when it is **not** a type in `syms`: a declared struct or enum maps to `%Name` there, while a genuine type parameter has no binding at all — neither inside a template body (substitution has not run yet) nor at a nested instantiation site like `( Vec A )` in a generic function.

That needs the names registered before the instantiation scan reads them, so the purely-lexical `scan_type_names` pass moves ahead of `scan_generic_structs`. It prints no IR and only writes `Name → %Name`, so nothing else changes.

## Test

`compiler/tests/generic_short_type_name.nu` — a short-named struct as the argument of a stdlib generic (`Vec`), of a user generic struct, and of a user generic function, with two distinct short names so the monomorphs stay separate.

Full suite: PASS 871 · FAIL 0 · MISSING 0 · ORPHAN 0.

## Provenance

Found while hand-probing the structural surface `tools/fuzz/genprog.py` does not yet generate (generic instantiation over user aggregates). The fuzzer extension that reaches this surface follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU