### PR TITLE
feat(nurlc): break and continue inside a foreach body

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -11676,6 +11676,14 @@
     : s lc ( nurl_cg_lbl cg `foreach_check` )
     : s lb ( nurl_cg_lbl cg `foreach_body` )
     : s le ( nurl_cg_lbl cg `foreach_exit` )
+    // The index bump is a block of its own — the `continue` landing pad.
+    // A while loop can send `continue` straight at its check block
+    // because the induction variable is the program's own binding; a
+    // foreach owns a hidden index, and the bump used to live in the
+    // body's fall-through. Branching a `continue` at `lc` would skip it
+    // and spin forever, which is why `continue` was rejected here at
+    // all. Give the bump its own label and both paths reach it.
+    : s lcont ( nurl_cg_lbl cg `foreach_cont` )
     ( nurl_print `  br label %` ) ( nurl_print lc ) ( emit_dbg_eol )
     // Check: idx < len
     ( emit ( nurl_str_cat lc `:` ) )
@@ -11721,6 +11729,26 @@
         ( nurl_sym_push syms )
     } {}
     = g_did_ret 0
+    // Publish this loop's exit / continue labels and the drop snapshots
+    // taken above, exactly as gen_loop does, so a `break` or `continue`
+    // anywhere in the body emits the same drop sequence the normal
+    // fall-through emits below and then branches. Saved and restored
+    // around the body so the innermost loop wins — a foreach nested in
+    // a while (or vice versa) shadows the outer one and restores it.
+    : s old_bc_exit ( nurl_sym_get syms `__loop_exit__` )
+    : s old_bc_check ( nurl_sym_get syms `__loop_check__` )
+    : s old_bc_strs ( nurl_sym_get syms `__loop_snap_strs__` )
+    : s old_bc_structs ( nurl_sym_get syms `__loop_snap_structs__` )
+    : s old_bc_user ( nurl_sym_get syms `__loop_snap_user__` )
+    : s old_bc_slices ( nurl_sym_get syms `__loop_snap_slices__` )
+    : s old_bc_cenv ( nurl_sym_get syms `__loop_snap_cenv__` )
+    ( nurl_sym_def syms `__loop_exit__` le )
+    ( nurl_sym_def syms `__loop_check__` lcont )
+    ( nurl_sym_def syms `__loop_snap_strs__` old_strs_fe )
+    ( nurl_sym_def syms `__loop_snap_structs__` old_structs_fe )
+    ( nurl_sym_def syms `__loop_snap_user__` old_user_fe )
+    ( nurl_sym_def syms `__loop_snap_slices__` old_slices_fe )
+    ( nurl_sym_def syms `__loop_snap_cenv__` old_closure_fe )
     // Borrow checker (Phase 0c): a `~ x xs` body is a back-edge, and
     // (Phase 6) borrows the iterated container `xs` for the body's
     // duration — bck_iter_enter records it so gen_call rejects any
@@ -11729,6 +11757,13 @@
     : s fe_iter_saved ( bck_iter_enter fe_cont )
     ( gen_block_stmts lex syms cg )
     ( bck_iter_exit fe_iter_saved )
+    ( nurl_sym_def syms `__loop_exit__` old_bc_exit )
+    ( nurl_sym_def syms `__loop_check__` old_bc_check )
+    ( nurl_sym_def syms `__loop_snap_strs__` old_bc_strs )
+    ( nurl_sym_def syms `__loop_snap_structs__` old_bc_structs )
+    ( nurl_sym_def syms `__loop_snap_user__` old_bc_user )
+    ( nurl_sym_def syms `__loop_snap_slices__` old_bc_slices )
+    ( nurl_sym_def syms `__loop_snap_cenv__` old_bc_cenv )
     ? == g_did_ret 0
     { ? != 0 g_auto_drop_strings
         { ( mem_drop_new_strings syms cg old_strs_fe )
@@ -11736,15 +11771,25 @@
             ( mem_drop_new_user_drops syms cg old_user_fe )
             ? != 0 g_fn_slice_decls { ( mem_drop_new_slices syms cg old_slices_fe ) } {} } {}
         ( mem_drop_new_closure_envs syms cg old_closure_fe )
-        : s next_idx ( nurl_cg_reg cg )
-        ( nurl_print `  ` ) ( nurl_print next_idx )
-        ( nurl_print ` = add i64 ` ) ( nurl_print idx_cur ) ( nurl_print `, 1\n` )
-        ( nurl_print `  store i64 ` ) ( nurl_print next_idx )
-        ( nurl_print `, i64* ` ) ( nurl_print idx_ptr ) ( nurl_print `\n` )
-        ( nurl_print `  br label %` ) ( nurl_print lc ) ( emit_dbg_eol )
+        ( nurl_print `  br label %` ) ( nurl_print lcont ) ( emit_dbg_eol )
     }
     {}
     ? != 0 g_auto_drop_strings { ( nurl_sym_pop syms ) } {}
+    // The bump. Reached by the body's fall-through and by every
+    // `continue`; re-loads the index rather than reusing `idx_cur` from
+    // the check block, so the block reads correctly on its own terms
+    // whichever predecessor arrived (-O2 folds the reload away).
+    ( emit ( nurl_str_cat lcont `:` ) )
+    ( nurl_sym_def syms `__cur_lbl__` lcont )
+    : s idx_now ( nurl_cg_reg cg )
+    ( nurl_print `  ` ) ( nurl_print idx_now )
+    ( nurl_print ` = load i64, i64* ` ) ( nurl_print idx_ptr ) ( nurl_print `\n` )
+    : s next_idx ( nurl_cg_reg cg )
+    ( nurl_print `  ` ) ( nurl_print next_idx )
+    ( nurl_print ` = add i64 ` ) ( nurl_print idx_now ) ( nurl_print `, 1\n` )
+    ( nurl_print `  store i64 ` ) ( nurl_print next_idx )
+    ( nurl_print `, i64* ` ) ( nurl_print idx_ptr ) ( nurl_print `\n` )
+    ( nurl_print `  br label %` ) ( nurl_print lc ) ( emit_dbg_eol )
     ( emit ( nurl_str_cat le `:` ) )
     ( nurl_sym_def syms `__cur_lbl__` le )
     ( nurl_set_last_type `void` )

--- a/compiler/tests/foreach_break_continue.nu
+++ b/compiler/tests/foreach_break_continue.nu
@@ -1,0 +1,94 @@
+// foreach_break_continue.nu — `break` / `continue` inside a `~ x xs` body.
+//
+// docs/spec.md §5.4.1 scopes both to "the innermost enclosing `~` loop body",
+// and a foreach IS a `~` loop body — but only the while form published the
+// labels `gen_loop_jump` reads, so every foreach rejected both with
+//
+//     'continue' outside a loop — there is no next iteration.
+//
+// The reason it was never wired up is real: a while loop can send `continue`
+// straight at its check block because the induction variable is the program's
+// own binding, while a foreach owns a hidden index whose bump lived in the
+// body's fall-through. A `continue` branching at the check block would skip
+// the bump and spin forever. The bump now has its own label — the continue
+// landing pad — which both the fall-through and every `continue` reach.
+//
+// Pinned below: continue, break, the two together, drops on both jump paths
+// (a `% Drop` value built per iteration must be released exactly once on
+// every path out of the body), both nestings against a while loop (the
+// innermost loop must win, and the outer one must be restored afterwards),
+// and a foreach over a Vec carrier as well as a slice.
+//
+// Expected output:
+//   odds=9
+//   mixed=8
+//   drops=5
+//   fe-in-while=18
+//   while-in-fe=24
+//   vec=10
+//   done
+
+$ `stdlib/core/vec.nu`
+
+: ~ i g_drops 0
+
+: DH { i tag }
+
+% Drop ( DH ) { @ drop DH h → v { = g_drops + g_drops 1 } }
+
+@ main → i {
+    : [i xs [i | 1 2 3 4 5 6]
+
+    // continue: skip the evens.
+    : ~ i odds 0
+    ~ x xs { ? == % x 2 0 { continue } {} = odds + odds x }
+    ( nurl_print `odds=` ) ( nurl_print ( nurl_str_int odds ) ) ( nurl_print `\n` )
+
+    // continue and break in one body: skip 2, stop at 5 → 1 + 3 + 4.
+    : ~ i mixed 0
+    ~ x xs {
+        ? == x 2 { continue } {}
+        ? == x 5 { break } {}
+        = mixed + mixed x
+    }
+    ( nurl_print `mixed=` ) ( nurl_print ( nurl_str_int mixed ) ) ( nurl_print `\n` )
+
+    // A %Drop value per iteration, released on the continue path (x=3,6),
+    // the break path (x=5) and the fall-through (x=1,2,4). The loop runs
+    // iterations 1..5, so exactly 5 destructors fire.
+    ~ x xs {
+        : DH h @ DH { x }
+        ? == % x 3 0 { continue } {}
+        ? == x 5 { break } {}
+    }
+    ( nurl_print `drops=` ) ( nurl_print ( nurl_str_int g_drops ) ) ( nurl_print `\n` )
+
+    // foreach nested in a while: the inner break leaves only the foreach.
+    : ~ i s3 0
+    : ~ i a 0
+    ~ < a 3 {
+        = a + a 1
+        ~ x xs { ? > x 2 { break } {} = s3 + s3 * a x }
+    }
+    ( nurl_print `fe-in-while=` ) ( nurl_print ( nurl_str_int s3 ) ) ( nurl_print `\n` )
+
+    // while nested in a foreach: the inner continue belongs to the while,
+    // and the outer foreach's labels are restored for the next iteration.
+    : ~ i s4 0
+    ~ x xs {
+        ? > x 3 { break } {}
+        : ~ i b 0
+        ~ < b 3 { = b + b 1 ? == b 2 { continue } {} = s4 + s4 * x b }
+    }
+    ( nurl_print `while-in-fe=` ) ( nurl_print ( nurl_str_int s4 ) ) ( nurl_print `\n` )
+
+    // The Vec carrier reaches the same code path as the slice carrier.
+    : ( Vec i ) nums ( vec_iota 0 8 )
+    : ~ i s5 0
+    ~ y nums { ? > y 4 { break } {} = s5 + s5 y }
+    ( vec_free [i] nums )
+    ( nurl_print `vec=` ) ( nurl_print ( nurl_str_int s5 ) ) ( nurl_print `\n` )
+
+    ( nurl_print `done\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs/foreach_break_continue.txt
+++ b/compiler/tests/outputs/foreach_break_continue.txt
@@ -1,0 +1,11 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+odds=9
+mixed=8
+drops=5
+fe-in-while=18
+while-in-fe=24
+vec=10
+done


### PR DESCRIPTION
## What

`break` and `continue` were rejected in every `~ x xs { … }` body:

```
~ x xs { ? > x 3 { break } {}  = s + s x }
                   ^ 'break' outside a loop — there is nothing to leave.
                     It is valid only inside a '~' loop body.
```

A foreach *is* a `~` loop body — [spec §5.4.1](docs/spec.md) scopes both to "the innermost enclosing `~` loop body" — so the diagnostic contradicted the spec, and the only way to leave an iteration early was to rewrite the loop as an index-counted `~ < k ( vec_len [T] v )`.

## Why it wasn't wired up

The obstacle is real. A while loop can send `continue` straight at its check block because the induction variable is the program's own binding. A foreach owns a *hidden* index whose bump lived in the body's fall-through — branching a `continue` at the check block would skip the bump and spin forever.

## Fix

Give the bump its own label: a continue landing pad reached by both the fall-through and every `continue`. It re-loads the index rather than reusing the check block's register, so the block reads correctly whichever predecessor arrived (`-O2` folds the reload away).

With that in place `gen_foreach` publishes the exit/continue labels and the five drop snapshots exactly as `gen_loop` does, saved and restored around the body so the innermost loop wins and the outer one comes back afterwards. That is what makes the existing `gen_loop_jump` drop machinery apply unchanged: a jump skips the block's own cleanup, so it must emit the body's whole drop sequence before branching.

## Test

`compiler/tests/foreach_break_continue.nu` pins:

- `continue`, `break`, and both in one body;
- a `% Drop` value built per iteration, released **exactly once** on each of the three paths out of the body (continue, break, fall-through);
- foreach nested in a while and while nested in a foreach — the innermost loop must win and the outer labels must be restored;
- the `Vec` carrier as well as the slice carrier.

Full suite: PASS 871 · FAIL 0 · MISSING 0 · ORPHAN 0. Bootstrap fixed point holds.

## Provenance

Found while extending `tools/fuzz/genprog.py` to generate loop control — the structural fuzzer had no `break`/`continue` in its grammar at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU