### PR TITLE
fix(nurlc): a closure body must not drop the enclosing frame's values

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -19617,6 +19617,22 @@
     // only ITS closures — never the outer frame's (whose allocas don't
     // exist in this lifted function). Restored on sym_pop (§7.4).
     ( nurl_sym_def body_syms `__owned_closure_envs__` `` )
+    // …and the same argument for the other three owned-value rosters,
+    // which were left visible. A closure body is a SEPARATE function:
+    // its `^` runs gen_ret, gen_ret drains whatever these lists hold,
+    // and they held the ENCLOSING frame's values. A `% Drop` value (or
+    // an owned String, or an owned struct field) live at the point the
+    // literal appears therefore had its drop emitted inside the lifted
+    // function, against an alloca register that only exists in the
+    // caller — `%r7 = load %DH, %DH* %r2` where `%r2` is undefined
+    // here. clang rejected it as "use of undefined value"; had the
+    // register resolved it would have been a use-after-scope and a
+    // second drop of a value the outer frame drops again on its own
+    // exit. Only a closure body with an explicit `^` reached this,
+    // which is why an expression-bodied literal looked fine.
+    ( nurl_sym_def body_syms `__owned_strings__` `` )
+    ( nurl_sym_def body_syms `__owned_struct_fields__` `` )
+    ( nurl_sym_def body_syms `__user_drops__` `` )
     ( nurl_sym_def body_syms `__in_call_arg__` `` )
     // The closure body's `^` returns from the CLOSURE, not the enclosing
     // function — shadow the return-type key with the closure's own return

--- a/compiler/tests/closure_body_outer_drops.nu
+++ b/compiler/tests/closure_body_outer_drops.nu
@@ -1,0 +1,104 @@
+// closure_body_outer_drops.nu — a closure body must not drop the ENCLOSING
+// frame's owned values.
+//
+// A closure literal is lifted to a separate `define`, but it is emitted in the
+// middle of the enclosing function's emission and inherits its symbol table.
+// `gen_closure_expr` shadowed the slice and closure-env rosters with empty
+// lists for exactly that reason — and left the other three visible:
+// `__owned_strings__`, `__owned_struct_fields__` and `__user_drops__`.
+//
+// So a `^` inside the closure body ran gen_ret, gen_ret drained those lists,
+// and the lifted function ended with the OUTER frame's drop battery:
+//
+//     define i64 @__closure_1(i8* %__env, i64 %x) {
+//       …
+//       %r7 = load %DH, %DH* %r2        ; %r2 is main's alloca — not here
+//       call void @drop__DH(%DH %r7)
+//
+// clang rejected that as "use of undefined value". Had the register resolved
+// it would have been a use-after-scope plus a second drop of a value the outer
+// frame drops again on its own exit. Only a closure body with an explicit `^`
+// reached gen_ret, so an expression-bodied literal looked fine — which is why
+// this survived: the shape needs an owned value live at the point the literal
+// appears AND a `^` in its body.
+//
+// Pinned below: a `% Drop` value, an owned String and an owned struct field,
+// each live across a `^`-bodied closure literal — the drop must fire exactly
+// once, in the frame that owns the value.
+//
+// Expected output:
+//   noclosure=6 drops=1
+//   withclosure=8 drops=2
+//   string=2
+//   field=7 drops=3
+
+$ `stdlib/core/string.nu`
+
+: ~ i g_drops 0
+
+: DH { i tag }
+
+% Drop ( DH ) { @ drop DH h → v { = g_drops + g_drops 1 } }
+
+: Holder { String name }
+
+@ noclosure i n → i {
+    : DH h @ DH { n }
+    ^ * n 2
+}
+
+@ withclosure i n → i {
+    : DH h @ DH { n }
+    : ( @ i i ) cl \ i x → i { ^ * x 2 }
+    ^ ( cl n )
+}
+
+// An owned String live across the literal: the closure body must not free it.
+@ withstring i n → i {
+    : String s ( string_new )
+    ( string_push_char s 65 )
+    ( string_push_char s 66 )
+    : ( @ i i ) cl \ i x → i { ^ + x n }
+    : i r ( cl ( nurl_str_len ( string_data s ) ) )
+    ( string_free s )
+    ^ - r n
+}
+
+// An owned struct FIELD live across the literal, plus a %Drop value, so all
+// three rosters are non-empty at once.
+@ withfield i n → i {
+    : DH h @ DH { n }
+    : Holder hold @ Holder { ( string_new ) }
+    ( string_push_char . hold name 67 )
+    : ( @ i i ) cl \ i x → i { ^ + x 6 }
+    : i r ( cl ( nurl_str_len ( string_data . hold name ) ) )
+    // String is a manually-managed handle (docs/MEMORY.md §7.4) — released
+    // here so the test stays LeakSanitizer-clean on the fuzzer's ASan leg.
+    ( string_free . hold name )
+    ^ r
+}
+
+@ main → i {
+    ( nurl_print `noclosure=` )
+    ( nurl_print ( nurl_str_int ( noclosure 3 ) ) )
+    ( nurl_print ` drops=` )
+    ( nurl_print ( nurl_str_int g_drops ) )
+    ( nurl_print `\n` )
+
+    ( nurl_print `withclosure=` )
+    ( nurl_print ( nurl_str_int ( withclosure 4 ) ) )
+    ( nurl_print ` drops=` )
+    ( nurl_print ( nurl_str_int g_drops ) )
+    ( nurl_print `\n` )
+
+    ( nurl_print `string=` )
+    ( nurl_print ( nurl_str_int ( withstring 9 ) ) )
+    ( nurl_print `\n` )
+
+    ( nurl_print `field=` )
+    ( nurl_print ( nurl_str_int ( withfield 5 ) ) )
+    ( nurl_print ` drops=` )
+    ( nurl_print ( nurl_str_int g_drops ) )
+    ( nurl_print `\n` )
+    ^ 0
+}

--- a/compiler/tests/outputs/closure_body_outer_drops.txt
+++ b/compiler/tests/outputs/closure_body_outer_drops.txt
@@ -1,0 +1,8 @@
+COMPILE OK
+LINK OK
+EXIT 0
+OUTPUT
+noclosure=6 drops=1
+withclosure=8 drops=2
+string=2
+field=7 drops=3


### PR DESCRIPTION
## What

A closure literal with an explicit `^` in its body, written in a function that owns a droppable value, emitted **the enclosing function's drop battery inside the lifted closure**:

```llvm
define i64 @__closure_1(i8* %__env, i64 %x) {
  …
  %r7 = load %DH, %DH* %r2        ; %r2 is main's alloca — not in this function
  call void @drop__DH(%DH %r7)
```

clang rejected it as `use of undefined value`. Had the register resolved, it would have been a use-after-scope plus a **second drop** of a value the outer frame drops again on its own exit.

Minimal reproducer:

```
: DH { i tag }
% Drop ( DH ) { @ drop DH h → v { = g_drops + g_drops 1 } }

@ main → i {
    : DH h @ DH { 1 }
    : ( @ i i ) cl \ i x → i { ^ * x 2 }     // `^` is load-bearing
    ( phex ( cl 3 ) )
    ^ 0
}
```

## Why

A closure is lifted to its own `define`, but it is emitted in the middle of the enclosing function's emission and inherits its symbol table. `gen_closure_expr` already shadows `__owned_slices__`, `__slice_decls__` and `__owned_closure_envs__` with empty lists for exactly this reason — and left the other three visible: `__owned_strings__`, `__owned_struct_fields__`, `__user_drops__`. A `^` in the body runs `gen_ret`, and `gen_ret` drains whatever those lists hold.

The shape needs an owned value live at the point the literal appears **and** an explicit `^` in its body — an expression-bodied literal never reaches `gen_ret`. That combination was absent from the corpus, which is why it survived.

## Fix

Shadow all three the same way the other two already were.

## Test

`compiler/tests/closure_body_outer_drops.nu` — a `% Drop` value, an owned `String` and an owned struct field, each live across a `^`-bodied closure literal. The drop fires exactly once, in the frame that owns the value, and the program is LeakSanitizer-clean.

Full build: `BUILD SUCCESS & TESTS PASSED` (873 tests, bootstrap fixed point holds).

## Provenance

Found by the extended structural fuzzer (`tools/fuzz/genprog.py`) — 3 of the first 25 seeds — as soon as its generator started putting droppable aggregates at function scope. 300 seeds are clean with the fix. The generator extension follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU