### PR TITLE
fuzz: reach the structural surface that was never generated, and shrink findings

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,6 +20,17 @@ name: fuzz
 #      finding.
 # Any finding fails the run and uploads the reproducer inputs as artifacts.
 #
+# Findings are SHRUNK before they are filed: tools/fuzz/reduce.py deletes
+# statements while the same failure survives, so the artifact carries a
+# `*.min.nu` of a few dozen lines beside the full 150–400-line seed. The
+# property is fingerprinted from the original failure (normalised error
+# message / ASan report kind / the specific expectation that disagreed) so the
+# reducer cannot drift onto an unrelated breakage of its own making.
+#
+# Every knob the legs take is a workflow_dispatch input. `seed_start` is the
+# one worth moving: a weekly run pinned at seed 1 re-tests the same programs
+# forever, while walking the start covers ground no run has seen.
+#
 # Every run also renders FUZZRESULTS.md (tools/fuzz/report.py) and commits it
 # to main — the same publish-the-evidence flow bench.yml uses for RESULTS.md —
 # so the repo always carries the latest fuzzing status + the curated findings
@@ -39,6 +50,27 @@ on:
       parser_iters:
         description: 'parser fuzzer: iterations per RNG seed'
         default: '4000'
+      # A weekly run that starts at seed 1 re-tests the same programs every
+      # week. Moving the start walks the corpus into ground no run has
+      # covered; keeping it pinned re-tests a range a finding came from.
+      seed_start:
+        description: 'first seed for both differential legs'
+        default: '1'
+      struct_stmts:
+        description: 'structural: statements per program (breadth per seed)'
+        default: '14'
+      struct_depth:
+        description: 'structural: expression depth'
+        default: '3'
+      san_every:
+        description: 'sanitize every Nth structural seed (0 = off)'
+        default: '5'
+      wasm_every:
+        description: 'run every Nth seed on wasm32-wasi (0 = off)'
+        default: '5'
+      reduce_tests:
+        description: 'reducer budget per finding, in compiles (0 = no reduction)'
+        default: '400'
 
 concurrency:
   group: fuzz-${{ github.ref }}
@@ -88,17 +120,32 @@ jobs:
           echo "FUZZ_WASMBUILDER=$RUNNER_TEMP/wasmbuilder" >> "$GITHUB_ENV"
 
       - name: Differential miscompile fuzzer (integer)
+        env:
+          SEED_START: ${{ github.event.inputs.seed_start || '1' }}
+          SEEDS: ${{ github.event.inputs.diff_seeds || '1500' }}
+          WASM_EVERY: ${{ github.event.inputs.wasm_every || '5' }}
+          REDUCE_TESTS: ${{ github.event.inputs.reduce_tests || '400' }}
         run: |
-          FUZZ_WASM_EVERY=10 \
+          FUZZ_WASM_EVERY=$(( WASM_EVERY == 0 ? 0 : WASM_EVERY * 2 )) \
+          FUZZ_REDUCE_TESTS="$REDUCE_TESTS" \
           FUZZ_SUMMARY="$RUNNER_TEMP/fuzz-summaries/int.json" \
-            ./tools/fuzz/fuzz.sh 1 "${{ github.event.inputs.diff_seeds || '1500' }}"
+            ./tools/fuzz/fuzz.sh "$SEED_START" "$SEEDS"
 
       - name: Differential miscompile fuzzer (structural + sanitizer leg)
         if: success() || failure()          # run even if the int leg found something
+        env:
+          SEED_START: ${{ github.event.inputs.seed_start || '1' }}
+          SEEDS: ${{ github.event.inputs.struct_seeds || '600' }}
+          STMTS: ${{ github.event.inputs.struct_stmts || '14' }}
+          DEPTH: ${{ github.event.inputs.struct_depth || '3' }}
+          SAN_EVERY: ${{ github.event.inputs.san_every || '5' }}
+          WASM_EVERY: ${{ github.event.inputs.wasm_every || '5' }}
+          REDUCE_TESTS: ${{ github.event.inputs.reduce_tests || '400' }}
         run: |
-          FUZZ_GEN=struct FUZZ_SAN_EVERY=5 FUZZ_WASM_EVERY=5 \
+          FUZZ_GEN=struct FUZZ_SAN_EVERY="$SAN_EVERY" FUZZ_WASM_EVERY="$WASM_EVERY" \
+          FUZZ_REDUCE_TESTS="$REDUCE_TESTS" \
           FUZZ_SUMMARY="$RUNNER_TEMP/fuzz-summaries/struct.json" \
-            ./tools/fuzz/fuzz.sh 1 "${{ github.event.inputs.struct_seeds || '600' }}" 14 3
+            ./tools/fuzz/fuzz.sh "$SEED_START" "$SEEDS" "$STMTS" "$DEPTH"
 
       - name: Parser fuzzer (ASan + UBSan)
         if: success() || failure()

--- a/tools/fuzz/FINDINGS.json
+++ b/tools/fuzz/FINDINGS.json
@@ -2,6 +2,27 @@
   "_comment": "Curated log of real compiler/runtime bugs found by the fuzzers. Newest first. report.py renders this into FUZZRESULTS.md — keep entries short; the fix commit/PR carries the detail.",
   "findings": [
     {
+      "date": "2026-08-26",
+      "family": "differential-struct",
+      "title": "A closure body emitted the ENCLOSING frame's drop battery: a `^`-bodied closure literal written after an owned value (`% Drop`, String, owned struct field) ended the lifted function with `load %DH, %DH* %r2` against an alloca that only exists in the caller — invalid IR at best, use-after-scope plus a double drop had the register resolved",
+      "severity": "miscompile",
+      "status": "fixed (3 of the first 25 seeds; closure_body_outer_drops)"
+    },
+    {
+      "date": "2026-08-26",
+      "family": "hand-probe",
+      "title": "`break` / `continue` were rejected in every foreach body — the spec scopes both to \"the innermost enclosing `~` loop body\" and a foreach is one, but only the while form published the labels; the foreach's hidden index bump lived in the body's fall-through, so a `continue` would have skipped it. The bump now has its own landing pad",
+      "severity": "language-gap",
+      "status": "fixed (foreach_break_continue)"
+    },
+    {
+      "date": "2026-08-26",
+      "family": "hand-probe",
+      "title": "A struct whose NAME is tparam-shaped (`P`, `Q3`) could not be a generic type argument: instantiation was decided by spelling, so `( Vec P )` was skipped as still-abstract and died on `type 'Vec__P' has no field 'ctl'` inside the stdlib. Now decided by scope",
+      "severity": "miscompile",
+      "status": "fixed (generic_short_type_name)"
+    },
+    {
       "date": "2026-08-03",
       "family": "differential-struct",
       "title": "Constant out-of-range shift in a match guard (`>> <i32-payload> 34`): -O0 \"worked\", -O1 aborted, -O2 segfaulted with a wild jump — branch-on-poison UB; now a compile error, and mixed-width binop registers (24 build-fails/1000 seeds as invalid IR) are rejected like the float/bool/pointer mixes",

--- a/tools/fuzz/README.md
+++ b/tools/fuzz/README.md
@@ -13,18 +13,28 @@ of real bugs lives in [`FINDINGS.json`](FINDINGS.json).
 2. **Differential miscompile fuzzer, structural** (`FUZZ_GEN=struct fuzz.sh`
    + `genprog.py`) — whole programs over the structural surface: enums with
    N-ary mixed payloads (`i8…u64`, `f`, `s`), match with guards / literal
-   constraints / or-patterns, struct field writes, closures (creation-time
-   scalar capture), while/foreach loops, `;` defer (reachability-armed,
-   LIFO), `% Drop` destructors across scope shapes, string/Vec/slice
-   ownership traffic, helper calls and self-recursion. The same script is
-   the statement-level oracle. `FUZZ_SAN_EVERY=N` additionally builds every
-   Nth seed with ASan+LSan+UBSan and runs it leak-detection-on: a leak or
-   UAF in the generated ownership traffic is a finding even when stdout
-   matches — this is the leg that hunts auto-drop bugs. `FUZZ_WASM_EVERY=N`
-   compiles every Nth seed to wasm32-wasi (`packages/wasmbuilder`) and runs
-   it under the reference wasmtime — a THIRD independent execution
-   environment against the same oracle, hunting target-dependent codegen
-   (32-bit pointers, i64 payload slots). Requires zig + wasmtime.
+   constraints / or-patterns, struct field writes, **nested aggregates and
+   struct-payload enums**, **generic functions and generic structs**
+   instantiated at every sized type (and at a concrete struct whose *name*
+   is tparam-shaped), **`?T` and `!T E` with `\` try-propagation**,
+   **traits** with a required method, a default method and a bounded
+   generic, closures (creation-time scalar capture), while/foreach loops
+   **with `break` and `continue`**, `;` defer (reachability-armed, LIFO),
+   `% Drop` destructors across scope shapes, string/Vec/slice ownership
+   traffic **including containers whose element is a struct**, helper calls
+   and self-recursion. The same script is the statement-level oracle.
+   `FUZZ_SAN_EVERY=N` additionally builds every Nth seed with
+   ASan+LSan+UBSan and runs it leak-detection-on: a leak or UAF in the
+   generated ownership traffic is a finding even when stdout matches — this
+   is the leg that hunts auto-drop bugs. `FUZZ_WASM_EVERY=N` compiles every
+   Nth seed to wasm32-wasi (`packages/wasmbuilder`) and runs it under the
+   reference wasmtime — a THIRD independent execution environment against
+   the same oracle, hunting target-dependent codegen (32-bit pointers, i64
+   payload slots). Requires zig + wasmtime.
+2b. **Reducer** (`reduce.py`) — not a fuzzer: the thing that makes a finding
+   usable. Called automatically by `fuzz.sh` on every finding; see
+   [Reducing a finding](#reducing-a-finding-reducepy) below.
+
 3. **Mutational parser fuzzer** (`fuzz_parsers.sh` + `fuzz_parsers.py` +
    `parse_harness.nu`) — mutates seeds for the untrusted-input parsers
    (x509/DER, cbor, msgpack, json, yaml, xml, toml) against an ASan+UBSan
@@ -34,6 +44,54 @@ of real bugs lives in [`FINDINGS.json`](FINDINGS.json).
 All are deterministic per seed, so a finding reproduces. Seed corpora live
 in-tree (`gen.py` / `genprog.py` generators; `fuzz_parsers.py`'s
 `TEXT_SEEDS`/`BINARY_SEEDS`).
+
+## Reducing a finding (`reduce.py`)
+
+A raw seed is 150–400 lines across a dozen unrelated features, and the bug is
+usually two of them interacting. Working out which two by hand costs more than
+the fix does, so `fuzz.sh` shrinks every finding before filing it: alongside
+`failures/struct_seed_N.nu` you get `failures/struct_seed_N.min.nu`, typically
+a few dozen lines. The closure-drop miscompile of 2026-08-26 came out of a
+397-line seed as 23 lines in 19 seconds — the enum, the closure and nothing
+else.
+
+Reduction is ddmin over **statements** (brace-balanced groups, so a five-line
+`??` block is one deletable item) and then over lines, repeated until a whole
+sweep changes nothing.
+
+The property must survive line deletion or the reducer converges on a
+different bug, so it is fingerprinted from the *original* failure — the
+normalised error message, the ASan report kind, or the specific expectation
+that disagreed — and every candidate must reproduce **that**. Without the
+fingerprint, "does not compile" is true of almost any mangled program and
+ddmin cheerfully reports a four-line file whose only problem is an undefined
+identifier it created itself.
+
+| mode | property | used for |
+|---|---|---|
+| `build` | fails to compile with the same error | build failures (the largest class) |
+| `crash` | compiles, exits with the same nonzero status | runtime aborts |
+| `diverge` | `-O0` and `-O2` disagree with each other | opt-sensitive miscompiles; needs no oracle |
+| `check` | the self-checking program reports the same failed expectation | oracle mismatches, including *wrong at every opt level* |
+| `sanitize` | same ASan/LSan/UBSan report under `NURL_SAN=1` | leaks, UAF, double free |
+
+`check` is why `genprog.py --selfcheck` exists. It emits the same program with
+each expected value embedded next to the expression that produces it, so the
+program is its own oracle and exits nonzero on a mismatch. Deleting a line
+then cannot desynchronise the checks that remain — which is exactly what
+deleting a line would do to the external oracle file, and why a "wrong at
+every optimisation level" miscompile could not be reduced before.
+
+```bash
+python3 tools/fuzz/genprog.py 684 --selfcheck > bug.nu
+tools/fuzz/reduce.py bug.nu --mode check -o bug.min.nu
+```
+
+`--max-tests` bounds the compile budget (default 400, ~20–60 s); it stops with
+whatever it has rather than running unbounded, so CI can always call it.
+`FUZZ_REDUCE=0` turns reduction off, `FUZZ_REDUCE_TESTS` sets the budget. The
+wasm leg is not reduced — its property needs wasmbuilder and wasmtime in the
+loop — so those findings keep the full program only.
 
 ## Differential fuzzer — how it works
 
@@ -138,12 +196,40 @@ cleanup block (invalid IR), field/element stores skipping width coercion
 match literal constraint disagree with the arm's own payload binding
 (miscompile class).
 
+## Bugs found (2026-08-26, structural surface wave 2)
+
+Extending `genprog.py` past scalars — nested aggregates, generic
+instantiation, `?T`/`!T E`, traits, loop control, containers of structs —
+turned up three more, each fixed at the root with its own regression test:
+
+1. **A closure body dropped the enclosing frame's values.** A `^`-bodied
+   closure literal written after an owned value (`% Drop`, String, owned
+   struct field) ended the *lifted* function with the outer frame's drop
+   battery, loading an alloca that only exists in the caller. Invalid IR at
+   best; use-after-scope plus a double drop had the register resolved. Found
+   in 3 of the first 25 seeds, as soon as the generator started putting
+   droppable aggregates at function scope. (`closure_body_outer_drops.nu`)
+2. **`break` / `continue` were rejected in every foreach body**, though the
+   spec scopes both to "the innermost enclosing `~` loop body". The foreach's
+   hidden index bump lived in the body's fall-through, so a `continue` would
+   have skipped it; the bump now has its own landing pad.
+   (`foreach_break_continue.nu`)
+3. **A struct whose NAME is tparam-shaped** (`P`, `Q3`) could not be a
+   generic type argument: instantiation was decided by spelling, so
+   `( Vec P )` was skipped as still-abstract and the program died on
+   `type 'Vec__P' has no field 'ctl'` pointing into the stdlib. Now decided
+   by scope. (`generic_short_type_name.nu`)
+
+The last two were found by hand-probing the surface while writing the
+generators for it — which is the honest reason to write the generators.
+
 ## Scope / future
 
 Covers integer + int↔float value semantics (`gen.py`) and the structural
 surface (`genprog.py`), each executed natively at `-O0`/`-O2` and, on
-sampled seeds, sanitized and on wasm32-wasi. Natural extensions (tracked
-in TODO.md): float *arithmetic* with a rounding-aware oracle,
-generic-function instantiations + `?T`/`!T E` propagation chains in
-generated programs, trait-object dispatch, and borrow-checker soundness
-fuzzing (generate programs that MUST be rejected).
+sampled seeds, sanitized and on wasm32-wasi, with every finding reduced
+before it is filed. Natural extensions (tracked in TODO.md): float
+*arithmetic* with a rounding-aware oracle, trait-object (`dyn`) dispatch,
+threads / `Arc` traffic against a deterministic oracle, and borrow-checker
+soundness fuzzing (generate programs that MUST be rejected — the inverse
+oracle, where a program that *compiles* is the finding).

--- a/tools/fuzz/fuzz.sh
+++ b/tools/fuzz/fuzz.sh
@@ -65,6 +65,68 @@ case "$GEN_KIND" in
 esac
 
 mkdir -p "$FAILDIR"
+
+# reduce_finding SEED REASON PROGRAM — shrink a finding to a reproducer a
+# human can read. A raw seed is 150–400 lines across a dozen unrelated
+# features and the bug is usually two of them interacting; working out which
+# two by hand costs more than the fix does. tools/fuzz/reduce.py deletes
+# statements while the failure survives, so what lands in failures/ is the
+# small program, next to the full one.
+#
+# The property has to survive line deletion or the reducer converges on a
+# different bug, so the mode is chosen from the reason:
+#
+#   build failure     → the program does not compile (no oracle needed)
+#   nonzero exit      → it compiles and exits nonzero (likewise)
+#   sanitizer leg     → an ASan/LSan/UBSan report under NURL_SAN=1
+#   oracle mismatch   → regenerate the seed with --selfcheck, which puts the
+#                       expected value INSIDE the program next to the
+#                       expression that produces it. Deleting a line then
+#                       cannot desynchronise the checks that remain, which
+#                       is exactly what deleting a line from the external
+#                       oracle file would do.
+#
+# The wasm leg is not reduced: its property needs wasmbuilder + wasmtime in
+# the loop, so those findings keep the full program only. FUZZ_REDUCE=0 turns
+# reduction off; FUZZ_REDUCE_TESTS bounds the compile budget per finding.
+REDUCE="${FUZZ_REDUCE:-1}"
+REDUCE_TESTS="${FUZZ_REDUCE_TESTS:-400}"
+
+reduce_finding() {
+    local seed="$1" reason="$2" prog="$3" opt="${4:--O0}"
+    # Either knob turns reduction off; a zero budget means "don't", not
+    # "unbounded" (reduce.py's own --max-tests 0 is the unbounded spelling,
+    # which is not a thing to hand a CI job).
+    [[ "$REDUCE" == "0" || "$REDUCE_TESTS" == "0" ]] && return 0
+    local base="$FAILDIR/${GEN_KIND}_seed_${seed}"
+    local mode="" src="$prog"
+    case "$reason" in
+        *"BUILD FAIL"*|*"build fail"*) mode="build" ;;
+        *"nonzero exit"*)              mode="crash" ;;
+        *"sanitizer leg"*)             mode="sanitize" ;;
+        *"wasm leg"*)                  return 0 ;;
+        *"oracle"*)
+            if [[ "$GEN_KIND" == "struct" ]]; then
+                mode="check"
+                src="$TMP/selfcheck.nu"
+                python3 "$GEN" "$seed" $SIZE_FLAG "$EXPRS" --depth "$DEPTH" \
+                    --selfcheck > "$src" 2>/dev/null || return 0
+            else
+                # gen.py has no --selfcheck; an expression-tree finding is
+                # reducible only when the two opt levels disagree with each
+                # other, which needs no oracle at all.
+                mode="diverge"
+            fi
+            ;;
+        *) return 0 ;;
+    esac
+    echo "  reducing (mode=$mode) …"
+    python3 "$ROOT/tools/fuzz/reduce.py" "$src" --mode "$mode" --opt "$opt" \
+        --max-tests "$REDUCE_TESTS" -o "${base}.min.nu" --quiet >/dev/null 2>&1 \
+        && echo "  → ${base}.min.nu ($(grep -c '' "${base}.min.nu") lines)" \
+        || echo "  → not reducible under mode=$mode (kept the full program)"
+}
+
 pass=0
 fail=0
 buildfail=0
@@ -107,11 +169,13 @@ for seed in $(seq "$START" "$end"); do
     if ! "$NURL" -O0 "$prog" "$TMP/o0" >"$TMP/b0.log" 2>&1; then
         echo "SEED $seed [$GEN_KIND]: -O0 BUILD FAIL"; buildfail=$((buildfail+1))
         cp "$prog" "$FAILDIR/${GEN_KIND}_seed_${seed}_buildfail.nu"; cp "$TMP/b0.log" "$FAILDIR/${GEN_KIND}_seed_${seed}_build.log"
+        reduce_finding "$seed" "BUILD FAIL" "$prog"
         continue
     fi
     if ! "$NURL" -O2 "$prog" "$TMP/o2" >"$TMP/b2.log" 2>&1; then
         echo "SEED $seed [$GEN_KIND]: -O2 BUILD FAIL"; buildfail=$((buildfail+1))
         cp "$prog" "$FAILDIR/${GEN_KIND}_seed_${seed}_buildfail.nu"; cp "$TMP/b2.log" "$FAILDIR/${GEN_KIND}_seed_${seed}_build.log"
+        reduce_finding "$seed" "BUILD FAIL" "$prog" -O2
         continue
     fi
 
@@ -170,6 +234,7 @@ for seed in $(seq "$START" "$end"); do
         cp "$TMP/out0" "$FAILDIR/${GEN_KIND}_seed_${seed}.out0" 2>/dev/null
         cp "$TMP/out2" "$FAILDIR/${GEN_KIND}_seed_${seed}.out2" 2>/dev/null
         diff "$exp" "$TMP/out0" > "$FAILDIR/${GEN_KIND}_seed_${seed}.diff_o0" 2>&1
+        reduce_finding "$seed" "$reason" "$prog"
     fi
 done
 

--- a/tools/fuzz/genprog.py
+++ b/tools/fuzz/genprog.py
@@ -62,9 +62,10 @@ def norm_ty(ty):
 
 
 class Prog:
-    def __init__(self, rng, depth):
+    def __init__(self, rng, depth, selfcheck=False):
         self.rng = rng
         self.depth = depth
+        self.selfcheck = selfcheck
         self.lines = []           # main body source lines
         self.decls = []           # top-level declaration lines
         self.out = []             # expected stdout lines (hex16)
@@ -75,6 +76,8 @@ class Prog:
         self.enums = []           # (ename, [(vname, [ptypes])])
         self.drop_used = False
         self.drops = 0            # oracle count of fired %Drop destructors
+        self.once = set()         # one-shot declaration blocks already emitted
+        self.traits = []          # (trait, method, default, [(struct, fty, field)])
 
     # ── plumbing ─────────────────────────────────────────────────
 
@@ -112,8 +115,23 @@ class Prog:
                  ">=": va >= vb, "==": va == vb, "!=": va != vb}[op]
         return f"{op} {a.render()} {b.render()}", truth
 
+    def chk(self, node_render, value_bits, cast=True):
+        """The rendered observation call for one value.
+
+        Normal mode prints the 64-bit pattern and `fuzz.sh` compares the
+        whole stdout against the separately-generated oracle. Self-check mode
+        carries the expectation INSIDE the program as a 16-hex-digit string
+        literal and compares there — which is what makes the reducer sound:
+        deleting a line cannot invalidate the checks that remain, the way
+        deleting a line would desynchronise an external oracle."""
+        bits = value_bits & ((1 << 64) - 1)
+        wide = f"# i64 {node_render}" if cast else node_render
+        if self.selfcheck:
+            return f"( fzchk {wide} `{bits:016x}` )"
+        return f"( phex {wide} )"
+
     def phex(self, node_render, value_bits):
-        self.emit(f"    ( phex # i64 {node_render} )")
+        self.emit("    " + self.chk(node_render, value_bits))
         self.expect_i64_bits(value_bits)
 
     # ── features ─────────────────────────────────────────────────
@@ -372,13 +390,14 @@ class Prog:
 
     def stmt_defer(self):
         lit = self.rng.randrange(1 << 32)
+        call = self.chk(str(lit), lit, cast=False)
         if self.rng.random() < 0.6:
-            self.emit(f"    ; {{ ( phex {lit} ) }}")
+            self.emit(f"    ; {{ {call} }}")
             self.deferred.append(lit)
         else:
             # defer inside a conditional arm: armed iff the arm runs
             crender, truth = self.cond()
-            self.emit(f"    ? {crender} {{ ; {{ ( phex {lit} ) }} }} {{}}")
+            self.emit(f"    ? {crender} {{ ; {{ {call} }} }} {{}}")
             if truth:
                 self.deferred.append(lit)
 
@@ -485,6 +504,307 @@ class Prog:
         self.phex(r, to_u64_bits(val, ty))
         self.env.append(Var(ty, r, val))
 
+    # ── generics ─────────────────────────────────────────────────
+
+    def decl_generics(self):
+        """Generic functions + a generic struct, declared once per program.
+
+        `Q7` is a CONCRETE struct whose name is deliberately spelled like a
+        type parameter. Instantiation used to be decided by spelling, so
+        `( GBox Q7 )` was skipped as "still abstract" and the program died
+        on a `%GBox__Q7` nothing defined — a failure that depended on the
+        length of the user's own type name (fixed 2026-08-25)."""
+        if "gen" in self.once:
+            return
+        self.once.add("gen")
+        self.decls += [
+            ": Q7 { i8 qa  u16 qb }",
+            ": GBox [T] { T slot }",
+            "@ g_id [T] T x → T { ^ x }",
+            "@ g_add [T] T a T b → T { ^ + a b }",
+            "@ g_div [T] T a T b → T { ^ / a b }",
+            "@ g_shr [T] T a T b → T { ^ >> a b }",
+            "@ g_box [T] T x → ( GBox T ) { ^ @ ( GBox T ) { x } }",
+        ]
+
+    def stmt_generic(self):
+        """A generic call or generic-struct instantiation at a random type.
+
+        The type argument decides signedness AFTER monomorphisation, which
+        is the interesting part: `g_div` must pick sdiv for `[i8]` and udiv
+        for `[u]` from the same template body."""
+        self.decl_generics()
+        kind = self.rng.choice(["id", "add", "div", "shr", "box", "qbox"])
+        if kind == "qbox":
+            a = self.rng.randrange(1 << 8)
+            b = self.rng.randrange(1 << 16)
+            gb = self.fresh("gq")
+            self.emit(f"    : ( GBox Q7 ) {gb} "
+                      f"( g_box [Q7] @ Q7 {{ # i8 {a} # u16 {b} }} )")
+            self.phex(f". . {gb} slot qa", to_u64_bits(wrap(a, "i8"), "i8"))
+            self.phex(f". . {gb} slot qb", to_u64_bits(wrap(b, "u16"), "u16"))
+            return
+        ty = self.rng.choice(INT_PAYLOADS)
+        w, _signed = TYPES[ty]
+        a = Lit(ty, self.rng.randrange(1 << min(w, 62)))
+        if kind == "id":
+            self.phex(f"( g_id [{ty}] {a.render()} )", to_u64_bits(a.eval(), ty))
+            return
+        if kind == "box":
+            gb = self.fresh("gb")
+            self.emit(f"    : ( GBox {ty} ) {gb} ( g_box [{ty}] {a.render()} )")
+            self.phex(f". {gb} slot", to_u64_bits(a.eval(), ty))
+            self.env.append(gen.FieldRead(ty, gb, "slot", a.eval()))
+            return
+        if kind == "div":
+            # A small POSITIVE divisor in every type: no /0, and no
+            # INT_MIN/-1 (the one signed division that traps).
+            b = Lit(ty, self.rng.randint(1, min(9, (1 << w) - 1)))
+        elif kind == "shr":
+            b = Lit(ty, self.rng.randrange(w))       # shift amount < width
+        else:
+            b = Lit(ty, self.rng.randrange(1 << min(w, 62)))
+        op = {"add": "+", "div": "/", "shr": ">>"}[kind]
+        node = Bin(ty, op, a, b)
+        self.phex(f"( g_{kind} [{ty}] {a.render()} {b.render()} )",
+                  to_u64_bits(node.eval(), ty))
+
+    # ── option / result ──────────────────────────────────────────
+
+    def stmt_option(self):
+        """`?T` construction, `??` destructure, and a stdlib combinator."""
+        fn = self.fresh("optf")
+        thr = self.rng.randrange(1 << 16)
+        self.decls.append(
+            f"@ {fn} i n → ?i {{ ? > n {thr} "
+            f"{{ ^ @ ?i {{ T * n 3 }} }} {{ ^ @ ?i {{ F 0 }} }} }}")
+        arg = self.rng.randrange(1 << 17)
+        alt = self.rng.randrange(1 << 20)
+        ov = self.fresh("ov")
+        bnd = self.fresh("ob")
+        res = self.fresh("orv")
+        self.emit(f"    : ?i {ov} ( {fn} {arg} )")
+        self.emit(f"    : i {res} ?? {ov} {{")
+        self.emit(f"        T {bnd} → * {bnd} 2")
+        self.emit(f"        F      → {alt}")
+        self.emit("    }")
+        val = wrap(arg * 3 * 2, "i64") if arg > thr else alt
+        self.phex(res, to_u64_bits(val, "i64"))
+        self.env.append(Var("i64", res, val))
+        d = self.rng.randrange(1 << 20)
+        got = wrap(arg * 3, "i64") if arg > thr else d
+        self.phex(f"( opt_unwrap_or [i] ( {fn} {arg} ) {d} )",
+                  to_u64_bits(got, "i64"))
+
+    def stmt_result(self):
+        """`!T E` through a `\\` try-propagation chain, then destructured.
+
+        The propagating wrapper is the point: the Err path has to return
+        early out of the middle of a function whose own Ok payload is built
+        afterwards."""
+        fn = self.fresh("resf")
+        use = self.fresh("resu")
+        thr = self.rng.randrange(1 << 16)
+        k = self.rng.randrange(1 << 10)
+        self.decls.append(
+            f"@ {fn} i n → !i i {{ ? > n {thr} "
+            f"{{ ^ @ !i i {{ T * n 2 }} }} {{ ^ @ !i i {{ F - 0 n }} }} }}")
+        self.decls.append(
+            f"@ {use} i n → !i i {{ : i q \\ ( {fn} n )  ^ @ !i i {{ T + q {k} }} }}")
+        arg = self.rng.randrange(1 << 17)
+        rv = self.fresh("rv")
+        ok = self.fresh("rok")
+        er = self.fresh("rer")
+        out = self.fresh("rout")
+        self.emit(f"    : !i i {rv} ( {use} {arg} )")
+        self.emit(f"    : i {out} ?? {rv} {{")
+        self.emit(f"        T {ok} → {ok}")
+        self.emit(f"        F {er} → {er}")
+        self.emit("    }")
+        val = wrap(arg * 2 + k, "i64") if arg > thr else wrap(-arg, "i64")
+        self.phex(out, to_u64_bits(val, "i64"))
+        self.env.append(Var("i64", out, val))
+
+    # ── traits ───────────────────────────────────────────────────
+
+    def decl_trait(self):
+        """A trait with one required method and one default, implemented for
+        two or three structs of different field types, plus a bounded
+        generic that reaches the default through the bound."""
+        n = len(self.traits) + 1
+        tr, m1, m2 = f"Tr{n}", f"tm{n}base", f"tm{n}scaled"
+        impls = []
+        self.decls.append(f"% {tr} [T] {{")
+        self.decls.append(f"    @ {m1} T self → i")
+        self.decls.append(f"    @ {m2} T self i k → i {{ ^ * ( {m1} self ) k }}")
+        self.decls.append("}")
+        for j in range(self.rng.randint(2, 3)):
+            sname, fty, fld = f"{tr}S{j}", self.rng.choice(INT_PAYLOADS), f"fv{j}"
+            self.decls.append(f": {sname} {{ {fty} {fld} }}")
+            impls.append((sname, fty, fld))
+        for sname, fty, fld in impls:
+            read = f". self {fld}" if fty == "i64" else f"# i . self {fld}"
+            self.decls.append(
+                f"% {tr} {sname} {{ @ {m1} {sname} self → i {{ ^ {read} }} }}")
+        self.decls.append(
+            f"@ {tr}_via [X: {tr}] X x i k → i {{ ^ ( {m2} x k ) }}")
+        self.traits.append((tr, m1, m2, impls))
+
+    def stmt_trait(self):
+        if not self.traits or self.rng.random() < 0.5:
+            self.decl_trait()
+        tr, m1, m2, impls = self.rng.choice(self.traits)
+        sname, fty, _fld = self.rng.choice(impls)
+        w, _ = TYPES[fty]
+        val = wrap(self.rng.randrange(1 << min(w, 62)), fty)
+        inst = self.fresh("ti")
+        self.emit(f"    : {sname} {inst} @ {sname} {{ # {fty} {val & ((1 << w) - 1)} }}")
+        base = to_u64_bits(val, fty)              # widened per the field's sign
+        self.phex(f"( {m1} {inst} )", base)
+        k = self.rng.randrange(1 << 12)
+        widened = wrap(val, fty) if TYPES[fty][1] else val & ((1 << w) - 1)
+        scaled = to_u64_bits(wrap(widened * k, "i64"), "i64")
+        self.phex(f"( {m2} {inst} {k} )", scaled)          # default method
+        self.phex(f"( {tr}_via [{sname}] {inst} {k} )", scaled)  # via the bound
+
+    # ── nested aggregates ────────────────────────────────────────
+
+    def decl_nested(self):
+        if "nest" in self.once:
+            return
+        self.once.add("nest")
+        self.decls += [
+            ": NIn { i8 nx  u16 ny }",
+            ": NOut { NIn ninner  i32 nz }",
+            ": | NShape {",
+            "    NPt NIn",
+            "    NSeg NIn NIn",
+            "    NNil",
+            "}",
+        ]
+
+    def _nin(self):
+        """One `NIn` literal + its (nx, ny) oracle values."""
+        a, b = self.rng.randrange(1 << 8), self.rng.randrange(1 << 16)
+        return f"@ NIn {{ # i8 {a} # u16 {b} }}", wrap(a, "i8"), b & 0xffff
+
+    def stmt_nested(self):
+        """A struct inside a struct, and a struct as an enum payload —
+        aggregates whose members are themselves aggregates, read through a
+        two-hop `. . o inner field` path and through match bindings."""
+        self.decl_nested()
+        lit, nx, ny = self._nin()
+        c = self.rng.randrange(1 << 32)
+        o = self.fresh("no")
+        self.emit(f"    : NOut {o} @ NOut {{ {lit} # i32 {c} }}")
+        self.phex(f". . {o} ninner nx", to_u64_bits(nx, "i8"))
+        self.phex(f". . {o} ninner ny", to_u64_bits(ny, "u16"))
+        self.phex(f". {o} nz", to_u64_bits(wrap(c, "i32"), "i32"))
+        self.env.append(Var("i64", f"# i . {o} nz", wrap(c, "i32")))
+
+        which = self.rng.choice(["NPt", "NSeg", "NNil"])
+        ev = self.fresh("ns")
+        if which == "NPt":
+            l1, x1, y1 = self._nin()
+            self.emit(f"    : NShape {ev} @ NShape {{ NPt {l1} }}")
+            val = wrap(x1 + y1, "i64")
+        elif which == "NSeg":
+            l1, x1, y1 = self._nin()
+            l2, x2, y2 = self._nin()
+            self.emit(f"    : NShape {ev} @ NShape {{ NSeg {l1} {l2} }}")
+            val = wrap(x1 + y1 + x2 + y2, "i64")
+        else:
+            self.emit(f"    : NShape {ev} @ NShape {{ NNil }}")
+            val = 0
+        rv = self.fresh("nm")
+        self.emit(f"    : i {rv} ?? {ev} {{")
+        self.emit("        NPt np1        → + # i . np1 nx # i . np1 ny")
+        self.emit("        NSeg np1 np2   → + + # i . np1 nx # i . np1 ny "
+                  "+ # i . np2 nx # i . np2 ny")
+        self.emit("        NNil           → 0")
+        self.emit("    }")
+        self.phex(rv, to_u64_bits(val, "i64"))
+        self.env.append(Var("i64", rv, val))
+
+    # ── loop control ─────────────────────────────────────────────
+
+    def stmt_loopctl(self):
+        """A loop whose body jumps: `continue` on one predicate, `break` on
+        another, over both loop forms. A `% Drop` value built at the top of
+        the body must be released exactly once on every path out — the
+        jump skips the block's own cleanup, so the jump has to emit it."""
+        n = self.rng.randint(2, 9)
+        skip = self.rng.randint(1, 4)
+        stop = self.rng.randint(1, n + 2)
+        acc = self.fresh("lacc")
+        drop_here = self.drop_used and self.rng.random() < 0.5
+        self.emit(f"    : ~ i {acc} 0")
+        if self.rng.random() < 0.5:
+            xs = self.fresh("lxs")
+            self.emit(f"    : [i {xs} [ i | {' '.join(str(e) for e in range(1, n + 1))} ]")
+            var = self.fresh("lel")
+            self.emit(f"    ~ {var} {xs} {{")
+        else:
+            var = self.fresh("lk")
+            self.emit(f"    : ~ i {var} 0")
+            self.emit(f"    ~ < {var} {n} {{")
+            self.emit(f"        = {var} + {var} 1")
+        if drop_here:
+            h = self.fresh("lh")
+            self.emit(f"        : DH {h} @ DH {{ {var} }}")
+        self.emit(f"        ? == % {var} {skip} 0 {{ continue }} {{}}")
+        self.emit(f"        ? == {var} {stop} {{ break }} {{}}")
+        self.emit(f"        = {acc} + {acc} {var}")
+        self.emit("    }")
+        total = 0
+        for k in range(1, n + 1):
+            if drop_here:
+                self.drops += 1
+            if k % skip == 0:
+                continue
+            if k == stop:
+                break
+            total = wrap(total + k, "i64")
+        self.phex(acc, to_u64_bits(total, "i64"))
+        self.env.append(Var("i64", acc, total))
+
+    # ── containers of aggregates ─────────────────────────────────
+
+    def stmt_vec_struct(self):
+        """A Vec and a slice whose ELEMENT is a struct — the generic
+        instantiation, the element-sized GEP, and the by-value load out of
+        `vec_get`'s `?A` all at once."""
+        self.decl_generics()
+        items = [(self.rng.randrange(1 << 8), self.rng.randrange(1 << 16))
+                 for _ in range(self.rng.randint(1, 4))]
+        total = 0
+        for a, b in items:
+            total = wrap(total + wrap(a, "i8") + (b & 0xffff), "i64")
+
+        if self.rng.random() < 0.5:
+            vv = self.fresh("vq")
+            self.emit(f"    : ( Vec Q7 ) {vv} ( vec_new [Q7] )")
+            for a, b in items:
+                self.emit(f"    ( vec_push [Q7] {vv} @ Q7 {{ # i8 {a} # u16 {b} }} )")
+            self.phex(f"( vec_len [Q7] {vv} )", len(items))
+            sm, j, e = self.fresh("vs"), self.fresh("vj"), self.fresh("ve")
+            self.emit(f"    : ~ i {sm} 0")
+            self.emit(f"    : ~ i {j} 0")
+            self.emit(f"    ~ < {j} ( vec_len [Q7] {vv} ) {{")
+            self.emit(f"        : Q7 {e} ( opt_unwrap [Q7] ( vec_get [Q7] {vv} {j} ) )")
+            self.emit(f"        = {sm} + {sm} + # i . {e} qa # i . {e} qb")
+            self.emit(f"        = {j} + {j} 1")
+            self.emit("    }")
+            self.emit(f"    ( vec_free [Q7] {vv} )")
+        else:
+            xs, sm, e = self.fresh("sq"), self.fresh("ss"), self.fresh("se")
+            lits = " ".join(f"@ Q7 {{ # i8 {a} # u16 {b} }}" for a, b in items)
+            self.emit(f"    : [Q7 {xs} [ Q7 | {lits} ]")
+            self.emit(f"    : ~ i {sm} 0")
+            self.emit(f"    ~ {e} {xs} {{ = {sm} + {sm} + # i . {e} qa # i . {e} qb }}")
+        self.phex(sm, to_u64_bits(total, "i64"))
+        self.env.append(Var("i64", sm, total))
+
 
 def to_i64(bits, ty):
     """Widen a non-negative bit pattern of type ty to its i64 value."""
@@ -496,12 +816,38 @@ FEATURES = [
     ("while", 2), ("foreach", 2), ("closure", 2), ("defer", 2),
     ("drop_scope", 2), ("string", 2), ("vec", 1), ("helper_call", 2),
     ("recursion", 1), ("ternary", 2),
+    # The second wave: the surface the first wave never reached.
+    ("generic", 3), ("option", 2), ("result", 2), ("trait", 2),
+    ("nested", 3), ("loopctl", 2), ("vec_struct", 2),
 ]
 
 
-def build(seed, n_stmts, depth):
+SELFCHECK_PRELUDE = """\
+// Self-check mode: the program carries its own expectations, so a reducer
+// may delete any line without desynchronising the rest. Exit status is
+// nonzero iff some observation disagreed with what the generator computed.
+: ~ i g_fail 0
+
+@ fzchk i v s want → v {
+    : String hs ( string_new )
+    : ~ i k 15
+    ~ >= k 0 {
+        ( string_push_char hs ( hexd & 15 >> v * k 4 ) )
+        = k - k 1
+    }
+    ? ( nurl_str_eq ( string_data hs ) want ) {} {
+        = g_fail + g_fail 1
+        ( nurl_print `MISMATCH got=` ) ( nurl_print ( string_data hs ) )
+        ( nurl_print ` want=` ) ( nurl_print want ) ( nurl_print `\\n` )
+    }
+    ( string_free hs )
+}
+"""
+
+
+def build(seed, n_stmts, depth, selfcheck=False):
     rng = random.Random(seed)
-    p = Prog(rng, depth)
+    p = Prog(rng, depth, selfcheck)
     weighted = [name for name, w in FEATURES for _ in range(w)]
     # decide up front whether %Drop is in play so the decls exist
     p.drop_used = rng.random() < 0.6
@@ -523,6 +869,8 @@ def emit_program(p):
     out.append("$ `stdlib/core/vec.nu`")
     out.append("$ `stdlib/core/option.nu`")
     out.append("")
+    if p.selfcheck:
+        out.append(SELFCHECK_PRELUDE)
     if p.drop_used:
         out.append(": ~ i g_drops 0")
         out.append("")
@@ -533,7 +881,7 @@ def emit_program(p):
     out.append("")
     out.append("@ main → i {")
     out.extend(p.lines)
-    out.append("    ^ 0")
+    out.append("    ^ ? != g_fail 0 1 0" if p.selfcheck else "    ^ 0")
     out.append("}")
     return "\n".join(out) + "\n"
 
@@ -545,7 +893,8 @@ def emit_oracle(p):
 def main():
     args = sys.argv[1:]
     if not args:
-        sys.exit("usage: genprog.py SEED [--oracle] [--stmts N] [--depth D]")
+        sys.exit("usage: genprog.py SEED [--oracle] [--selfcheck] "
+                 "[--stmts N] [--depth D]")
     seed = int(args[0])
     n_stmts = 14
     depth = 3
@@ -553,7 +902,7 @@ def main():
         n_stmts = int(args[args.index("--stmts") + 1])
     if "--depth" in args:
         depth = int(args[args.index("--depth") + 1])
-    p = build(seed, n_stmts, depth)
+    p = build(seed, n_stmts, depth, selfcheck="--selfcheck" in args)
     sys.stdout.write(emit_oracle(p) if "--oracle" in args else emit_program(p))
 
 

--- a/tools/fuzz/genprog.py
+++ b/tools/fuzz/genprog.py
@@ -388,6 +388,83 @@ class Prog:
             x.value = arg
             self.phex(f"( {f} {arg} )", to_u64_bits(body.eval(), "i64"))
 
+    def stmt_nested_closure(self):
+        """A closure literal inside a closure literal, and a closure that owns
+        a `% Drop` value of its own while one is live in the frame around it.
+
+        The lifted-function boundary is where ownership bookkeeping goes
+        wrong: the outer frame's rosters were visible inside the closure body
+        until 2026-08-26, so its `^` dropped values belonging to its caller.
+        Nesting asks the same question one level deeper, and the `% Drop`
+        variant asks whether the closure's OWN values still get released."""
+        f = self.fresh("nc")
+        inner = self.fresh("ni")
+        k = self.rng.randrange(1 << 20)
+        m = self.rng.randint(2, 7)
+        own_drop = self.drop_used and self.rng.random() < 0.5
+        body = [f"        : ( @ i i ) {inner} \\ i y → i {{ ^ * y {m} }}"]
+        if own_drop:
+            h = self.fresh("nh")
+            body.append(f"        : DH {h} @ DH {{ x }}")
+        body.append(f"        ^ + ( {inner} x ) {k}")
+        self.emit(f"    : ( @ i i ) {f} \\ i x → i {{")
+        self.lines.extend(body)
+        self.emit("    }")
+        for _ in range(self.rng.randint(1, 2)):
+            arg = self.rng.randrange(1 << 24)
+            self.phex(f"( {f} {arg} )", to_u64_bits(wrap(arg * m + k, "i64"), "i64"))
+            if own_drop:
+                self.drops += 1
+
+    def stmt_early_return(self):
+        """A helper that returns from INSIDE a loop with owned values live.
+
+        `^` is not the block's normal exit: it skips the code the
+        fall-through would have run, so the compiler has to emit the whole
+        drop sequence — for the loop body's values AND the function's — at
+        the return. One value is created before the loop and one per
+        iteration, so the oracle knows exactly how many destructors must
+        have fired by the time control leaves."""
+        if not self.drop_used:
+            self.stmt_helper_call()          # nothing to count without % Drop
+            return
+        fn = self.fresh("erf")
+        n = self.rng.randint(2, 7)
+        thr = self.rng.randint(1, n + 1)     # > n means "never taken"
+        bonus = self.rng.randrange(1 << 16)
+        self.decls += [
+            f"@ {fn} i seed → i {{",
+            "    : DH outer @ DH { seed }",
+            "    : ~ i acc seed",
+            "    : ~ i k 0",
+            f"    ~ < k {n} {{",
+            "        = k + k 1",
+            "        : DH inner @ DH { k }",
+            f"        ? == k {thr} {{ ^ + acc {bonus} }} {{}}",
+            "        = acc + acc k",
+            "    }",
+            "    ^ acc",
+            "}",
+        ]
+        seed = self.rng.randrange(1 << 20)
+        acc = seed
+        fired = 1                            # `outer`, on whichever exit
+        for k in range(1, n + 1):
+            fired += 1                       # `inner`, this iteration
+            if k == thr:
+                acc = wrap(acc + bonus, "i64")
+                break
+            acc = wrap(acc + k, "i64")
+        self.drops += fired
+        # Bind before observing: the call has SIDE EFFECTS (each invocation
+        # fires its destructors), so a leaf that re-renders as the call would
+        # run it again every time an expression tree picked it up and the
+        # drop count would stop matching.
+        rv = self.fresh("er")
+        self.emit(f"    : i {rv} ( {fn} {seed} )")
+        self.phex(rv, to_u64_bits(acc, "i64"))
+        self.env.append(Var("i64", rv, acc))
+
     def stmt_defer(self):
         lit = self.rng.randrange(1 << 32)
         call = self.chk(str(lit), lit, cast=False)
@@ -819,6 +896,7 @@ FEATURES = [
     # The second wave: the surface the first wave never reached.
     ("generic", 3), ("option", 2), ("result", 2), ("trait", 2),
     ("nested", 3), ("loopctl", 2), ("vec_struct", 2),
+    ("nested_closure", 2), ("early_return", 2),
 ]
 
 

--- a/tools/fuzz/reduce.py
+++ b/tools/fuzz/reduce.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+# tools/fuzz/reduce.py — shrink a failing generated program to the smallest
+# one that still fails.
+#
+# A finding is only worth as much as its reproducer. A generated seed is
+# 150–400 lines across a dozen unrelated features; the bug is usually two of
+# them interacting, and finding out which two by hand costs more than the
+# fix. This does that automatically: delete lines, keep whatever still
+# reproduces, repeat with smaller chunks (classic ddmin over line
+# granularity, plus a brace-repair pass so a half-deleted block does not just
+# fail to parse and look like a hit).
+#
+# WHAT IS PRESERVED. The property being reduced against must survive line
+# deletion, or the reducer converges on a different bug. Two of the four
+# modes are oracle-free and always sound:
+#
+#   build   — the program does not compile (nurlc error, or clang rejecting
+#             nurlc's IR). The largest finding class in practice.
+#   crash   — it compiles but exits nonzero.
+#   diverge — stdout at -O0 differs from stdout at -O2. Needs no oracle:
+#             the two builds disagree with each other.
+#   check   — the program is its OWN oracle (genprog.py --selfcheck embeds
+#             each expected value as a string literal next to the expression
+#             that produces it) and exits nonzero when one disagrees. This is
+#             the mode that reduces a "wrong at every optimisation level"
+#             miscompile, which the external-oracle form cannot: deleting a
+#             line there desynchronises every later line of the oracle file.
+#   sanitize — built with NURL_SAN=1 and run leak-detection-on; an
+#             ASan/LSan/UBSan report or a nonzero exit is the property. For
+#             the ownership-traffic findings, where stdout is right and the
+#             bug is a leak or a double free.
+#
+# The `check` mode is why `--selfcheck` exists at all. Reduce a differential
+# finding by regenerating the seed with `--selfcheck` first:
+#
+#   python3 tools/fuzz/genprog.py 684 --selfcheck > bug.nu
+#   tools/fuzz/reduce.py bug.nu --mode check -o bug.min.nu
+#
+# fuzz.sh does exactly that for you on every finding.
+#
+# Usage:
+#   reduce.py PROGRAM.nu [--mode build|crash|diverge|check] [-o OUT.nu]
+#             [--opt -O0] [--timeout 40] [--quiet]
+#
+# Exit status: 0 if the reduced program still reproduces, 1 if the input did
+# not reproduce in the first place (reported, never reduced silently).
+
+import argparse
+import re
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+NURL = os.path.join(ROOT, "nurl.sh")
+
+
+def _build(src_path, out_path, opt, timeout, san=False):
+    """(ok, combined_output) for one nurl.sh compile."""
+    env = dict(os.environ, NURL_STDLIB=os.environ.get("NURL_STDLIB", ROOT))
+    if san:
+        env["NURL_SAN"] = "1"
+    try:
+        r = subprocess.run([NURL, opt, src_path, out_path],
+                           capture_output=True, text=True,
+                           timeout=timeout, env=env)
+    except subprocess.TimeoutExpired:
+        return False, "<compile timeout>"
+    return r.returncode == 0, r.stdout + r.stderr
+
+
+def _run(bin_path, timeout, san=False):
+    """(returncode, stdout, stderr) for the compiled program; rc 124 on
+    timeout. Leak detection is on for the sanitized property — a leak is a
+    finding even when the program's output is right."""
+    env = dict(os.environ)
+    if san:
+        env["ASAN_OPTIONS"] = "detect_leaks=1:exitcode=99"
+    try:
+        r = subprocess.run([bin_path], capture_output=True, text=True,
+                           timeout=timeout, env=env)
+    except subprocess.TimeoutExpired:
+        return 124, "", ""
+    return r.returncode, r.stdout, r.stderr
+
+
+def _err_sig(text, marker="error: "):
+    """A stable fingerprint of a failure message: the first line carrying
+    `marker`, with positions, quoted names and register numbers normalised
+    away so the same bug in a smaller program still matches.
+
+    Without this the reducer is worthless for build failures: "does not
+    compile" is true of almost any mangled program, so ddmin happily deletes
+    the binding a loop reads and reports a four-line file whose only problem
+    is an undefined identifier."""
+    for ln in text.splitlines():
+        i = ln.find(marker)
+        if i < 0:
+            continue
+        msg = ln[i + len(marker):].strip()
+        msg = re.sub(r"%[A-Za-z_.]*\d+", "%REG", msg)
+        msg = re.sub(r"'[^']*'", "'X'", msg)
+        msg = re.sub(r"\d+", "N", msg)
+        return msg[:160]
+    return None
+
+
+class Budget(Exception):
+    """Raised when the test budget runs out — reduction stops with whatever
+    it has. A reducer that runs unbounded is a reducer CI cannot call."""
+
+
+class Property:
+    """Does this source still exhibit the failure we are reducing?"""
+
+    def __init__(self, mode, opt, timeout, budget=None):
+        self.mode, self.opt, self.timeout = mode, opt, timeout
+        self.budget = budget
+        self.tests = 0
+        # Fingerprint of the ORIGINAL failure, learned on the first call and
+        # required of every candidate afterwards. Reducing against the bare
+        # shape of the failure ("it does not compile", "it exits nonzero")
+        # lets ddmin drift onto an unrelated breakage it introduced itself.
+        self.sig = None
+        self.sig_locked = False
+        self.tmp = tempfile.mkdtemp(prefix="nurl-reduce-")
+
+    def _same(self, sig):
+        """First call defines the fingerprint; later calls must match it."""
+        if not self.sig_locked:
+            self.sig, self.sig_locked = sig, True
+            return True
+        return sig == self.sig
+
+    def __call__(self, text):
+        if self.budget is not None and self.tests >= self.budget:
+            raise Budget()
+        self.tests += 1
+        return self._check(text)
+
+    def _check(self, text):
+        src = os.path.join(self.tmp, "p.nu")
+        with open(src, "w") as f:
+            f.write(text)
+        if self.mode == "diverge":
+            ok0, _ = _build(src, os.path.join(self.tmp, "a0"), "-O0", self.timeout)
+            ok2, _ = _build(src, os.path.join(self.tmp, "a2"), "-O2", self.timeout)
+            if not (ok0 and ok2):
+                return False          # a build failure is a DIFFERENT bug
+            rc0, out0, _ = _run(os.path.join(self.tmp, "a0"), self.timeout)
+            rc2, out2, _ = _run(os.path.join(self.tmp, "a2"), self.timeout)
+            return out0 != out2 or rc0 != rc2
+        san = self.mode == "sanitize"
+        ok, log = _build(src, os.path.join(self.tmp, "a"), self.opt,
+                         self.timeout, san)
+        if self.mode == "build":
+            return (not ok) and self._same(_err_sig(log))
+        if not ok:
+            return False              # the other modes need it to compile
+        rc, out, err = _run(os.path.join(self.tmp, "a"), self.timeout, san)
+        if san:
+            if rc == 0 and "ERROR:" not in err:
+                return False
+            return self._same(_err_sig(err, "ERROR: ") or f"rc={rc}")
+        if rc == 0:
+            return False
+        if self.mode == "check":
+            # Pin the specific expectation that disagreed, so the reducer
+            # cannot swap one miscompiled value for another on the way down.
+            want = None
+            for ln in out.splitlines():
+                if ln.startswith("MISMATCH "):
+                    want = ln.split("want=")[-1].strip()
+                    break
+            return self._same(want or f"rc={rc}")
+        return self._same(f"rc={rc}")
+
+
+def _balanced(lines):
+    """Reject a candidate whose braces no longer pair up. Without this the
+    reducer happily deletes a `{` and calls the resulting parse error a hit,
+    converging on a syntactically broken file instead of the bug."""
+    depth = 0
+    in_str = False
+    for ln in lines:
+        for ch in ln:
+            if ch == "`":
+                in_str = not in_str
+            elif in_str:
+                continue
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth < 0:
+                    return False
+    return depth == 0 and not in_str
+
+
+def _units(lines):
+    """Group lines into brace-balanced STATEMENTS.
+
+    Deleting raw lines can never remove a multi-line construct — dropping the
+    `: i m ?? e {` head leaves its arms and `}` behind, which does not parse,
+    so the whole match survives every sweep. Grouping first means a five-line
+    `??` block, a struct declaration or a loop body is one deletable item."""
+    units, i, n = [], 0, len(lines)
+    while i < n:
+        j, depth = i, 0
+        while j < n:
+            for ch in lines[j]:
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+            j += 1
+            if depth <= 0:
+                break
+        units.append(lines[i:j])
+        i = j
+    return units
+
+
+def _ddmin(items, join, prop, log, what):
+    """Classic ddmin over a list: halve the chunk size down to one item.
+    Returns (items, exhausted) — on budget exhaustion the progress made so
+    far is kept, never discarded."""
+    chunk = max(1, len(items) // 2)
+    while chunk >= 1:
+        i = 0
+        while i < len(items):
+            cand = items[:i] + items[i + chunk:]
+            flat = join(cand)
+            try:
+                hit = bool(flat) and _balanced(flat) and prop("\n".join(flat))
+            except Budget:
+                return items, True
+            if hit:
+                items = cand
+                log(f"  -{chunk} {what} at {i} → {len(join(items))} lines")
+            else:
+                i += chunk
+        chunk //= 2
+    return items, False
+
+
+def reduce_lines(lines, prop, log):
+    """Statement-granular ddmin, then line-granular, repeated until a whole
+    sweep changes nothing — one removal routinely unblocks another (dropping
+    the last use of a binding is what lets the binding itself go)."""
+    while True:
+        before = len(lines)
+        units, out = _ddmin(_units(lines), lambda us: [l for u in us for l in u],
+                            prop, log, "stmt(s)")
+        lines = [l for u in units for l in u]
+        if not out:
+            lines, out = _ddmin(lines, lambda ls: ls, prop, log, "line(s)")
+        if out:
+            log(f"  budget exhausted after {prop.tests} tests — "
+                f"stopping at {len(lines)} lines")
+            return lines
+        if len(lines) == before:
+            return lines
+
+
+def main():
+    ap = argparse.ArgumentParser(description="shrink a failing NURL program")
+    ap.add_argument("program")
+    ap.add_argument("--mode", default="build",
+                    choices=["build", "crash", "diverge", "check", "sanitize"])
+    ap.add_argument("-o", "--out", default=None,
+                    help="output path (default: PROGRAM with .min.nu)")
+    ap.add_argument("--opt", default="-O0", help="opt level for build/crash/check")
+    ap.add_argument("--timeout", type=int, default=40)
+    ap.add_argument("--max-tests", type=int, default=400,
+                    help="compile+run budget; 0 = unbounded (default 400)")
+    ap.add_argument("--quiet", action="store_true")
+    a = ap.parse_args()
+
+    def log(msg):
+        if not a.quiet:
+            print(msg, file=sys.stderr)
+
+    text = open(a.program).read()
+    lines = text.rstrip("\n").split("\n")
+    prop = Property(a.mode, a.opt, a.timeout,
+                   a.max_tests if a.max_tests > 0 else None)
+
+    if not prop(text):
+        print(f"reduce.py: {a.program} does not reproduce under --mode "
+              f"{a.mode} — nothing to reduce (wrong mode, or the bug is "
+              f"already fixed).", file=sys.stderr)
+        return 1
+
+    log(f"reduce.py: {len(lines)} lines, mode={a.mode}")
+    lines = reduce_lines(lines, prop, log)
+    out = a.out or (a.program[:-3] if a.program.endswith(".nu") else a.program) + ".min.nu"
+    with open(out, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    log(f"reduce.py: {len(lines)} lines → {out}")
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/fuzz/report.py
+++ b/tools/fuzz/report.py
@@ -29,10 +29,14 @@ FAMILY_DESC = {
     "differential-struct":
         "`genprog.py` — whole structural programs (enums with N-ary mixed "
         "payloads, match guards/or-patterns/literal constraints, struct "
-        "field writes, closures, while/foreach, defer, `% Drop`, "
-        "string/Vec/slice ownership, helper calls, recursion) with a "
-        "statement-level oracle; `-O0` vs `-O2` vs oracle, plus an "
-        "ASan+LSan leg and a wasm32-wasi/wasmtime leg on sampled seeds",
+        "field writes, nested aggregates and struct-payload enums, generic "
+        "functions and generic structs, `?T` / `!T E` with `\\` "
+        "propagation, traits with default methods and bounds, closures, "
+        "while/foreach with `break`/`continue`, defer, `% Drop`, "
+        "string/Vec/slice ownership incl. containers of structs, helper "
+        "calls, recursion) with a statement-level oracle; `-O0` vs `-O2` vs "
+        "oracle, plus an ASan+LSan leg and a wasm32-wasi/wasmtime leg on "
+        "sampled seeds",
     "parser-mutational":
         "`fuzz_parsers.py` — mutated inputs for the untrusted-input "
         "parsers (x509/DER, cbor, msgpack, json, yaml, xml, toml) against "
@@ -111,6 +115,18 @@ def main():
     a("ASan/LSan/UBSan report. Reproducers are")
     a("uploaded as workflow artifacts and land in `tools/fuzz/failures/`.")
     a("")
+    a("Every finding is **shrunk before it is filed**: `tools/fuzz/reduce.py`")
+    a("deletes statements while the same failure survives, so the artifact")
+    a("carries a `*.min.nu` of a few dozen lines next to the full seed. The")
+    a("property it reduces against is fingerprinted from the original failure")
+    a("(the normalised error message, the ASan report kind, or the specific")
+    a("expectation that disagreed), so the reducer cannot drift onto an")
+    a("unrelated breakage it introduced itself. Oracle mismatches reduce")
+    a("through `genprog.py --selfcheck`, which puts each expected value inside")
+    a("the program next to the expression that produces it — the external")
+    a("oracle file cannot survive line deletion, and a self-checking program")
+    a("can.")
+    a("")
     a("## Findings log — real bugs the fuzzers have caught")
     a("")
     a("| date | family | severity | finding | status |")
@@ -126,6 +142,10 @@ def main():
     a("FUZZ_GEN=struct FUZZ_SAN_EVERY=5 FUZZ_WASM_EVERY=5 \\")
     a("    tools/fuzz/fuzz.sh 1 300 14 3               # structural + sanitizer + wasm legs")
     a("tools/fuzz/fuzz_parsers.sh 1 4000 8             # parser mutational")
+    a("")
+    a("# reproduce and shrink one seed by hand")
+    a("python3 tools/fuzz/genprog.py 684 --selfcheck > bug.nu")
+    a("tools/fuzz/reduce.py bug.nu --mode check -o bug.min.nu")
     a("```")
     a("")
 


### PR DESCRIPTION
## Why

The structural fuzzer had gone quiet: **250 seeds, zero findings**. Not because nurlc is clean there — because the generator's grammar stopped at scalars. Everything it built was a struct of sized ints, an enum of scalar payloads, a while loop and a closure. Whole regions of the language were unreachable from any seed.

## Generator

Nine new statement kinds, each with an exact oracle:

| kind | what it reaches |
|---|---|
| `generic` | generic fns + a generic struct at every sized type — the type argument decides signedness **after** monomorphisation, so one template body must pick `sdiv` for `[i8]` and `udiv` for `[u]` — and at a concrete struct whose *name* is tparam-shaped |
| `option` | `?T` construction, `??` destructure, stdlib combinator |
| `result` | `!T E` through a `\` try-propagation chain: the Err path returns early out of the middle of a function whose Ok payload is built afterwards |
| `trait` | a required method, a default method, impls for two or three structs of different field types, and a bounded generic reaching the default through the bound |
| `nested` | a struct inside a struct read through a two-hop path, and a struct as an enum payload destructured by match |
| `loopctl` | `break`/`continue` over both loop forms, with a `% Drop` value at the top of the body that must be released exactly once on every path out |
| `vec_struct` | a Vec and a slice whose **element** is a struct |
| `nested_closure` | a closure inside a closure, and a closure owning a `% Drop` value while one is live in the frame around it |
| `early_return` | a helper that returns from **inside** a loop with owned values live — `^` skips what the fall-through would have run, so the drops have to be emitted at the return |

It found a miscompile in **3 of the first 25 seeds**: a `^`-bodied closure literal written after an owned value emitted the *enclosing* frame's drop battery inside the lifted function (#1005). 400 seeds at `stmts=20 depth=4` are clean with that fix, sanitizer and wasm legs included.

Two more bugs turned up while hand-probing this surface to write the generators for it — #1003 and #1004 — which is the honest reason to write them.

## Reduction

A finding is worth what its reproducer is worth, and a raw seed is 150–400 lines across a dozen unrelated features. `tools/fuzz/reduce.py` deletes statements while the same failure survives; `fuzz.sh` calls it on every finding, so `failures/` now carries a `*.min.nu` beside the full seed. **The closure miscompile came out of a 397-line seed as 23 lines in 19 seconds** — the enum, the closure, nothing else.

Two things make it work rather than merely run:

- **The property is fingerprinted from the original failure** — the normalised error message, the ASan report kind, or the specific expectation that disagreed — and every candidate must reproduce *that*. Reducing against the bare shape of a failure does not work: "does not compile" is true of almost any mangled program, and the first version proudly reported a four-line file whose only problem was an undefined identifier it had created itself.

- **`genprog.py --selfcheck`** emits the same program with each expected value embedded next to the expression that produces it, so the program is its own oracle. That is what lets an oracle mismatch reduce at all: deleting a line desynchronises every later line of an external oracle file, but a self-checking program stays sound. It is the only way to shrink a *wrong at every optimisation level* miscompile — the class this fuzzer exists for.

Statement-granular ddmin first (a five-line `??` block is one deletable item, so multi-line constructs can actually go), then line-granular, repeated until a sweep changes nothing. `--max-tests` bounds the compile budget and stops with what it has, so CI can always call it.

## Workflow

Every knob is a `workflow_dispatch` input now: `seed_start`, `struct_stmts`, `struct_depth`, `san_every`, `wasm_every`, `reduce_tests`. `seed_start` is the one worth moving — a weekly run pinned at seed 1 re-tests the same programs forever, while walking the start covers ground no run has seen.

## Verification

- 400 seeds `stmts=20 depth=4` + sanitizer leg: clean.
- wasm32-wasi leg exercised locally against the new constructs (zig 0.16.0 + wasmtime): clean.
- Reducer verified end-to-end by reverting the closure fix, running the fuzzer, and checking the emitted `.min.nu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU