### PR TITLE
fix(borrowck): a double free inside a `??` arm is a compile error

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -14401,16 +14401,54 @@
     ( bck_join_state s_then s_else )
 }
 
-// `??` — Phase 1 does NOT descend into match arms. A `??` arm binds
-// payload variables (`T v -> ...`) that have no `let` row, so the
-// flat name-keyed state cannot tell an arm's `v` from a same-named
-// binding in an enclosing scope — analysing the arm would conflate
-// them and false-positive. The whole match is therefore treated as a
-// state-preserving black box: its scrutinee is still move-checked (on
-// the `match` row, before this is called), but nothing inside the
-// arms is. Use-after-move *within* a `??` arm is a known Phase 1 gap
-// — closing it needs scope-qualified state (a later phase).
+// `??` — walk each arm in ISOLATION, then leave the outer state alone.
+//
+// A `??` arm binds payload variables (`T v -> ...`) that have no `let`
+// row, so the flat name-keyed state cannot tell an arm's `v` from a
+// same-named binding in an enclosing scope. Descending with the outer
+// state would conflate them and false-positive, which is why the whole
+// match used to be a state-preserving black box — and why a double free
+// written inside an arm compiled clean and segfaulted at run time,
+// while the identical code inside a `?` arm, a loop, a bare block or a
+// helper was rejected.
+//
+// The conflation is avoidable without scope-qualified state: walk each
+// arm from an EMPTY state, where every id reads Uninit. Then only a
+// binding that gets its own `let` row inside the arm becomes tracked,
+// and such a binding is arm-local by construction — nothing outside can
+// be confused with it. A payload name, or an outer name the arm merely
+// touches, starts Uninit and is ignored, so no diagnostic can fire on
+// it. Moving one twice WITHIN the arm is still caught, because the
+// first move is what makes it tracked.
+//
+// The arm's exit state is discarded and the entry state returned
+// unchanged: what an arm did to an outer binding remains out of scope
+// here (the scrutinee itself is still move-checked on the `match` row,
+// before this is called). This closes the intra-arm hole without
+// widening the lattice, and cannot report anything that was not a
+// definite bug.
 @ bck_handle_match i mi i em s state → s {
+    : ~ i j + mi 1
+    ~ < j em {
+        : s rec ( bck_rec j )
+        : s k ( bck_field rec 0 )
+        : ~ b adv F
+        // Step over a nested conditional / match wholesale, so its own
+        // arm-blocks are not mistaken for this match's arms.
+        ? ( seq k `cond` ) { = j + ( bck_match_close j `cond` `endcond` ) 1 = adv T } {}
+        ? & ! adv ( seq k `match` ) { = j + ( bck_match_close j `match` `endmatch` ) 1 = adv T } {}
+        ? & ! adv ( seq k `block` ) {
+            : i eb ( bck_match_close j `block` `endblock` )
+            ? ( seq ( bck_field rec 1 ) `match-arm` )
+            { : s armfinal ( bck_walk_seq + j 1 eb `` )
+                // The walk reports as it goes; its result is not needed.
+                ? != 0 ( nurl_str_len armfinal ) {} {} }
+            {}
+            = j + eb 1
+            = adv T
+        } {}
+        ? ! adv { = j + j 1 } {}
+    }
     ( nurl_str_cat state `` )
 }
 

--- a/compiler/tests/borrow_match_arm_double_free.nu
+++ b/compiler/tests/borrow_match_arm_double_free.nu
@@ -1,0 +1,81 @@
+// borrow_match_arm_double_free.nu — a double free written inside a `??` arm
+// is a compile error, like the same code anywhere else.
+//
+// The borrow checker rejected this shape inside a `?` arm, a `~` loop, a
+// foreach body, a bare `{ }` block, a helper, a generic body, a trait method
+// and a defer — but not inside a `??` arm, where it compiled clean and
+// segfaulted in the allocator at run time (confirmed under AddressSanitizer).
+//
+// The reason was principled: a `??` arm binds payload variables (`T v → …`)
+// that have no `let` row, so descending into an arm with the outer, flat
+// name-keyed state would conflate an arm's `v` with a same-named binding
+// outside and report a bug that is not one. The whole match was therefore a
+// state-preserving black box.
+//
+// The conflation is avoidable without scope-qualified state: walk each arm
+// from an EMPTY state. Only a binding that gets its own `let` row inside the
+// arm becomes tracked, and such a binding is arm-local by construction. A
+// payload name, or an outer name the arm merely touches, starts Uninit and
+// is ignored, so no diagnostic can fire on it — while moving an arm-local
+// binding twice is still caught, because the first move is what makes it
+// tracked. The arm's exit state is discarded, so nothing widens.
+//
+// POSITIVE below: two arm-local aliases of one Vec, both freed, in an arm of
+// a match used as a statement and in one used as a value.
+//
+// CONTROL: an arm that reads its payload binding and an outer binding by the
+// same name as another arm's — the shape the black box existed to protect —
+// and an arm that frees an arm-local Vec exactly once. Neither may warn.
+
+$ `stdlib/core/vec.nu`
+
+: | Sel { SA i SB i SC }
+
+@ control ( Vec i ) outer → i {
+    : Sel s @ Sel { SA 1 }
+    // Payload `v` in two arms, and an outer binding also named `v` in scope
+    // — nothing here is a violation and nothing may be reported.
+    : i v 7
+    ^ ?? s {
+        SA v → + v ( vec_len [i] outer )
+        SB v → { : ( Vec i ) local ( vec_new [i] )
+            : i n + v ( vec_len [i] local )
+            ( vec_free [i] local )
+            n }
+        SC → v
+    }
+}
+
+@ main → i {
+    : ( Vec i ) keep ( vec_new [i] )
+    ( vec_push [i] keep 1 )
+    ( nurl_print ( nurl_str_int ( control keep ) ) )
+
+    : Sel s @ Sel { SA 1 }
+
+    // POSITIVE — match as a statement.
+    ?? s {
+        SA n → { : ( Vec i ) a ( vec_new [i] )
+            : ( Vec i ) b a
+            ( vec_free [i] a )
+            ( vec_free [i] b )
+            n }
+        SB n → n
+        SC → 0
+    }
+
+    // POSITIVE — match as a value.
+    : i r ?? s {
+        SA n → { : ( Vec i ) c ( vec_new [i] )
+            : ( Vec i ) d c
+            ( vec_free [i] c )
+            ( vec_free [i] d )
+            n }
+        SB n → n
+        SC → 0
+    }
+    ( nurl_print ( nurl_str_int r ) )
+
+    ( vec_free [i] keep )
+    ^ 0
+}

--- a/compiler/tests/outputs/borrow_match_arm_double_free.txt
+++ b/compiler/tests/outputs/borrow_match_arm_double_free.txt
@@ -1,0 +1,7 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/borrow_match_arm_double_free.nu:60: error: use of moved value 'a' — a heap handle has exactly one owner, and this one was consumed at line 59 by an alias copy. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
+            ( vec_free [i] a )
+compiler/tests/borrow_match_arm_double_free.nu:71: error: use of moved value 'c' — a heap handle has exactly one owner, and this one was consumed at line 70 by an alias copy. After that the binding is dead: free or read the value through whatever owns it now, or rebind this name to a fresh value.
+            ( vec_free [i] c )
+error: compilation aborted — 2 borrow-checker violations (re-run with --no-borrowck to bypass)


### PR DESCRIPTION
## What

The borrow checker rejected this shape inside a `?` arm, a `~` loop, a foreach body, a bare `{ }` block, a helper, a generic body, a trait method and a defer — but **not** inside a `??` arm, where it compiled clean and segfaulted in the allocator at run time (confirmed under AddressSanitizer):

```
?? s {
    SA n → { : ( Vec i ) a ( vec_new [i] )
        : ( Vec i ) b a
        ( vec_free [i] a )
        ( vec_free [i] b )
        n }
    …
}
```

## Why it was that way

The reason was principled, and the code said so. A `??` arm binds payload variables (`T v → …`) that have no `let` row, so descending into an arm with the outer, flat name-keyed state would conflate an arm's `v` with a same-named binding outside and report a bug that is not one. The whole match was therefore a state-preserving black box, and use-after-move within an arm was left as a *known Phase 1 gap* needing scope-qualified state.

## Fix

The conflation is avoidable without widening the lattice: **walk each arm from an empty state.**

Only a binding that gets its own `let` row inside the arm becomes tracked, and such a binding is arm-local by construction — nothing outside can be confused with it. A payload name, or an outer name the arm merely touches, starts Uninit and is ignored, so no diagnostic can fire on it; moving an arm-local binding twice is still caught, because the first move is what makes it tracked. The arm's exit state is discarded and the entry state returned unchanged, so what an arm does to an *outer* binding stays out of scope exactly as before.

The no-false-positive contract holds: everything reported is still a definite bug.

## Test

`borrow_match_arm_double_free.nu` — the violation in a match used as a statement and as a value, plus controls that must stay silent: a payload binding named the same as an outer binding (the shape the black box existed to protect), and an arm-local `Vec` freed exactly once.

nurlc self-compiles clean under the change; full build `BUILD SUCCESS & TESTS PASSED`.

## Provenance

Found by writing one ownership violation into every context the language offers and asking which ones the checker declines to reject — the inverse oracle (a program that *compiles* is the finding) that the fuzzer's generator work is being extended with. A second hole from the same sweep, a violation wholly inside a closure body, is left for its own change: closing it needs the closure's statements recorded as their own function, which the capture hooks currently suppress by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU