### PR TITLE
diag(nurlc): name the `[T]`-is-also-`true` collision when it bites

### DIFF
--- a/compiler/nurlc.nu
+++ b/compiler/nurlc.nu
@@ -4366,6 +4366,35 @@
 // subst_source_raw: replace whole-identifier occurrences of 'from' with 'to'
 // in a raw source string (preserves whitespace, backticks, punctuation).
 // Identifier chars: alpha, digit, underscore (95).
+// __word_after_cond_sigil: does `src` spell the whole word `w` directly after
+// a `?`, `~` or `^` — the three prefixes that take a VALUE and are how a
+// boolean literal is realistically written (`? T { … }`, `~ T { … }`,
+// `^ T`)?
+//
+// Used to decide whether a generic named `[T]` / `[F]` deserves the
+// boolean-collision note. `[T]` is fine in a template that never writes a
+// boolean, and most templates do not, so the note has to be earned or it
+// buries the real error under a guess.
+@ __word_after_cond_sigil s src s w → b {
+    : i n ( nurl_str_len src )
+    : i wl ( nurl_str_len w )
+    : ~ i i 0
+    ~ < i n {
+        : i c ( nurl_str_get src i )
+        ? | | == c 63 == c 126 == c 94 {  // '?' '~' '^'
+            : ~ i j + i 1
+            ~ & < j n | | == ( nurl_str_get src j ) 32 == ( nurl_str_get src j ) 9
+            == ( nurl_str_get src j ) 10 { = j + j 1 }
+            ? & <= + j wl n ( seq ( nurl_str_slice src j wl ) w )
+            { ? | == + j wl n ! ( __is_ident_char ( nurl_str_get src + j wl ) )
+                { ^ T } {} }
+            {}
+        } {}
+        = i + i 1
+    }
+    F
+}
+
 @ subst_source_raw s src s from s to → s {
     : ~ s result ``
     : i slen ( nurl_str_len src )
@@ -24654,6 +24683,33 @@
     = g_diag_ctx ( nurl_str_cat3
     ` [while instantiating '` mangled
     ( nurl_str_cat3 `' — the error may depend on the concrete type arguments` __ctx_from `]` ) )
+    // `T` and `F` are the boolean literals, and the lexer is context-free:
+    // a bare `T` is TT_BOOL wherever it appears. Monomorphisation rewrites
+    // the type parameter through the body by whole word, so a template
+    // written `[T]` has every VALUE-position `T` rewritten too — `? T { … }`
+    // becomes `? i { … }`, and the instantiation dies on "use of undefined
+    // identifier 'i'" against source the user never wrote. The stdlib avoids
+    // this by convention (`vec.nu` names its parameter `A` and says why);
+    // nothing warned anyone else. Any diagnostic raised inside this re-parse
+    // now carries the reason, since this is exactly when it matters.
+    : ~ s __tp_scan ( nurl_sym_get2 g_generic_syms fname `__tparams` )
+    : ~ s __tp_bool ``
+    ~ != 0 ( nurl_str_len __tp_scan ) {
+        : s __tp1 ( str_first_word __tp_scan )
+        = __tp_scan ( str_skip_word __tp_scan )
+        // …and only when the body actually spells it as a CONDITION. `[T]`
+        // is perfectly fine in a template that never writes a boolean, and
+        // most do not — attaching the note to every `[T]` instantiation
+        // failure would bury the real error under a guess.
+        ? & & == 0 ( nurl_str_len __tp_bool ) | ( seq __tp1 `T` ) ( seq __tp1 `F` )
+        ( __word_after_cond_sigil ( nurl_sym_get2 g_generic_syms fname `__gsrc` ) __tp1 )
+        { = __tp_bool ( nurl_str_cat __tp1 `` ) } {}
+    }
+    ? != 0 ( nurl_str_len __tp_bool )
+    { = g_diag_ctx ( nurl_str_cat g_diag_ctx ( nurl_str_cat3
+        ` [note: this generic's type parameter is named '` __tp_bool
+        `', which is also a boolean literal. Monomorphisation rewrites the parameter through the body by whole word, so a value-position use of it — '? T { … }' — is rewritten into the type argument too. Rename the parameter; the stdlib uses '[A]', '[K V]', '[E]'.]` ) ) }
+    {}
     // DWARF Phase 7: stash the original generic-decl line so
     // gen_fn_decl_concrete points this mono's !DISubprogram at the
     // real source, not the synthetic `<generic>:1`. Cleared in a

--- a/compiler/tests/diag_generic_tparam_bool_name.nu
+++ b/compiler/tests/diag_generic_tparam_bool_name.nu
@@ -1,0 +1,35 @@
+// diag_generic_tparam_bool_name.nu — a generic whose type parameter is named
+// `T` and whose body uses the boolean literal `T` says why it failed.
+//
+// `T` and `F` are the boolean literals, and the lexer is context-free: a bare
+// `T` is TT_BOOL wherever it appears, in type position and value position
+// alike (see compute_generic_inout_sink, which already documents this).
+// Monomorphisation rewrites the type parameter through the body by whole
+// word, so a template written `[T]` has its VALUE-position `T`s rewritten
+// too — `? T { … }` becomes `? i { … }`, and the instantiation dies on
+//
+//     error: use of undefined identifier 'i'
+//     @ g__i64 i x → i { ? i { ^ 1 } { } ^ 0 }
+//
+// against source the user never wrote. Renaming the parameter to `A` makes
+// the identical program compile, which is not a hint anyone gets from the
+// message.
+//
+// The stdlib avoids the collision by convention — `stdlib/core/vec.nu` names
+// its type variable `A` and says why — but nothing warned anyone else, and
+// docs/spec.md §4.8 spells its own canonical example `[T]`.
+//
+// The ambiguity itself is not removed here: doing that means teaching the
+// PARSER to resolve `T` by position (types and values are different
+// namespaces) instead of rewriting the body textually before it is parsed.
+// What is fixed is that the failure now names its cause, which is the
+// contract §10.1 sets for every other foot-gun in the language.
+
+@ g [T] T x → i {
+    ? T { ^ 1 } {}
+    ^ 0
+}
+
+@ main → i {
+    ^ ( g [i] 1 )
+}

--- a/compiler/tests/outputs/diag_generic_tparam_bool_name.txt
+++ b/compiler/tests/outputs/diag_generic_tparam_bool_name.txt
@@ -1,0 +1,5 @@
+COMPILE FAIL
+ERRORS
+compiler/tests/diag_generic_tparam_bool_name.nu:29:3: error: use of undefined identifier 'i' — no binding, parameter, constant, enum variant, or function with this name is in scope [while instantiating 'g__i64' — the error may depend on the concrete type arguments; first call site: compiler/tests/diag_generic_tparam_bool_name.nu:34] [note: this generic's type parameter is named 'T', which is also a boolean literal. Monomorphisation rewrites the parameter through the body by whole word, so a value-position use of it — '? T { … }' — is rewritten into the type argument too. Rename the parameter; the stdlib uses '[A]', '[K V]', '[E]'.]
+? i { ^ 1 } { } 
+  ^

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -690,6 +690,17 @@ copy:
 ( id [s] `hi` )     // → @id__i8ptr
 ```
 
+**Do not name a type parameter `T` or `F` if its body uses that boolean
+literal.** Monomorphisation substitutes the parameter through the body by
+whole word, before the body is parsed, and the lexer is context-free: a bare
+`T` is the boolean literal `true` wherever it appears. So in a template
+written `[T]`, a value-position `T` is rewritten along with the type
+positions — `? T { … }` becomes `? i { … }`, and the instantiation fails
+against source that was never written. The stdlib names its type variables
+`A`, `K`/`V`, `E` for this reason (see `stdlib/core/vec.nu`); `[T]` is fine
+in a body that never spells a boolean. The compiler names the collision in
+the diagnostic when an instantiation of a `[T]` / `[F]` template fails.
+
 Type arguments at call sites may be *compound types*, not just base
 identifiers: a base IDENT (type keyword or named type), a pointer / option
 (`*T`, `?T`, `??T`), or a nested generic / closure application


### PR DESCRIPTION
## What

```
@ g [T] T x → i { ? T { ^ 1 } {}  ^ 0 }
( g [i] 1 )
```

```
error: use of undefined identifier 'i'
@ g__i64 i x → i { ? i { ^ 1 } { } ^ 0 }
                       ^
```

An error against source the user never wrote, naming a token they never typed. Renaming the parameter to `A` makes the identical program compile — not a hint the message offers.

## Why

`T` and `F` are the boolean literals, and the lexer is context-free: a bare `T` is `TT_BOOL` wherever it appears, in type position and value position alike (`compute_generic_inout_sink` already documents this). Monomorphisation rewrites a type parameter through the body by whole word **before** the body is parsed, so a template written `[T]` has its value-position `T`s rewritten along with the type positions.

The stdlib avoids the collision by convention — `stdlib/core/vec.nu` names its type variable `A` and says why — but nothing warned anyone else, and spec §4.8 spells its own canonical example `[T]`.

## This change

- The instantiation diagnostic **names the cause**.
- The spec says not to name a parameter `T` or `F` when the body uses that literal, and why.

The note is *earned*, not blanket: it appears only when the parameter is `T`/`F` **and** the body actually spells it after a `?`, `~` or `^` — the three prefixes that take a value. `[T]` in a template that never writes a boolean is fine and stays silent, so an unrelated error inside a generic is not buried under a guess (`diag_generic_body_error_loc` is unchanged, and pins that).

## What is NOT fixed

The ambiguity itself. Removing it means resolving `T` by **position** in the parser — types and values are different namespaces — instead of rewriting the body textually before parsing it. That is a rework of monomorphisation, not a diagnostic change, and is left for its own work. The message now points at the cure that exists today.

## Test

`diag_generic_tparam_bool_name.nu`. Full build: `BUILD SUCCESS & TESTS PASSED` (876 tests, bootstrap fixed point holds).

## Provenance

Found by the differential fuzzer's inverse-oracle generator, which wrote `? T { … }` inside a `[T]` generic while probing borrow-checker coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU