### PR TITLE
fuzz: an inverse oracle — programs the compiler MUST reject

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,6 +14,12 @@ name: fuzz
 #      (packages/wasmbuilder + reference wasmtime) — a third independent
 #      execution environment against the same oracle, catching
 #      target-dependent codegen (32-bit pointers, i64 payload slots).
+#   2b. INVERSE oracle (FUZZ_GEN=reject, tools/fuzz/genreject.py): programs
+#      that are ownership violations by construction, crossed with every
+#      context the language offers. The compiler must reject each one, with
+#      the diagnostic that violation deserves. A missed rejection is the one
+#      failure mode nothing else catches — the program compiles, runs, and
+#      corrupts the heap.
 #   3. mutational parser fuzzer (tools/fuzz/fuzz_parsers.sh): mutate seeds for
 #      the untrusted-input parsers (x509/DER, cbor, msgpack, json, yaml, xml,
 #      toml) against an ASan+UBSan harness; any crash / OOB / UB / hang is a
@@ -71,6 +77,12 @@ on:
       reduce_tests:
         description: 'reducer budget per finding, in compiles (0 = no reduction)'
         default: '400'
+      reject_seeds:
+        description: 'inverse oracle: number of must-be-rejected programs'
+        default: '400'
+      reject_depth:
+        description: 'inverse oracle: max nested contexts around the violation'
+        default: '3'
 
 concurrency:
   group: fuzz-${{ github.ref }}
@@ -146,6 +158,23 @@ jobs:
           FUZZ_REDUCE_TESTS="$REDUCE_TESTS" \
           FUZZ_SUMMARY="$RUNNER_TEMP/fuzz-summaries/struct.json" \
             ./tools/fuzz/fuzz.sh "$SEED_START" "$SEEDS" "$STMTS" "$DEPTH"
+
+      - name: Inverse oracle (programs the compiler MUST reject)
+        if: success() || failure()
+        # The other legs emit VALID programs and ask whether the answer is
+        # right. This one emits ownership violations by construction and asks
+        # whether they are caught — the question a borrow checker is actually
+        # judged on, and the only one whose failures are silent (the program
+        # compiles, runs, and corrupts the heap). No sanitizer or wasm leg:
+        # nothing here is meant to run.
+        env:
+          SEED_START: ${{ github.event.inputs.seed_start || '1' }}
+          SEEDS: ${{ github.event.inputs.reject_seeds || '400' }}
+          DEPTH: ${{ github.event.inputs.reject_depth || '3' }}
+        run: |
+          FUZZ_GEN=reject \
+          FUZZ_SUMMARY="$RUNNER_TEMP/fuzz-summaries/reject.json" \
+            ./tools/fuzz/fuzz.sh "$SEED_START" "$SEEDS" 0 "$DEPTH"
 
       - name: Parser fuzzer (ASan + UBSan)
         if: success() || failure()

--- a/tools/fuzz/FINDINGS.json
+++ b/tools/fuzz/FINDINGS.json
@@ -3,6 +3,34 @@
   "findings": [
     {
       "date": "2026-08-26",
+      "family": "reject-inverse",
+      "title": "Borrow-checker blind spot: a definite double free inside a closure body was accepted — one flag meant both 'this belongs to the closure' and 'record nothing', so the checker was off for everything written in a closure. The body now gets its own recording context and its own analyze pass",
+      "severity": "unsoundness",
+      "status": "fixed (borrow_closure_body_double_free)"
+    },
+    {
+      "date": "2026-08-26",
+      "family": "reject-inverse",
+      "title": "Borrow-checker blind spot: a definite double free inside a `??` arm was accepted — arms were a state-preserving black box because payload bindings have no `let` row. Each arm is now walked from an EMPTY state, so only arm-local bindings are tracked and nothing can be conflated",
+      "severity": "unsoundness",
+      "status": "fixed (borrow_match_arm_double_free)"
+    },
+    {
+      "date": "2026-08-26",
+      "family": "reject-inverse",
+      "title": "A generic named `[T]` has its VALUE-position `T` — the boolean literal — rewritten by monomorphisation, so `? T { … }` becomes `? i { … }` and the instantiation fails against source nobody wrote. The diagnostic now names the collision",
+      "severity": "diagnostic",
+      "status": "fixed (diag_generic_tparam_bool_name); the underlying lexer ambiguity remains"
+    },
+    {
+      "date": "2026-08-26",
+      "family": "hand-probe",
+      "title": "A nested field could be READ but not WRITTEN: `= . . o inner x v` died with \"cannot assign to a field of ''\" because the object of a nested path is a by-value register, not a binding with an alloca. The chain is now walked by address",
+      "severity": "language-gap",
+      "status": "fixed (nested_field_store)"
+    },
+    {
+      "date": "2026-08-26",
       "family": "differential-struct",
       "title": "A closure body emitted the ENCLOSING frame's drop battery: a `^`-bodied closure literal written after an owned value (`% Drop`, String, owned struct field) ended the lifted function with `load %DH, %DH* %r2` against an alloca that only exists in the caller — invalid IR at best, use-after-scope plus a double drop had the register resolved",
       "severity": "miscompile",

--- a/tools/fuzz/README.md
+++ b/tools/fuzz/README.md
@@ -1,6 +1,6 @@
 # tools/fuzz — fuzzing for nurlc and the stdlib parsers
 
-Three fuzzers, all run weekly (and on demand) by
+Four fuzzers, all run weekly (and on demand) by
 [`.github/workflows/fuzz.yml`](../../.github/workflows/fuzz.yml), never as a
 per-PR gate. Any finding fails the run and uploads its reproducer inputs
 from `failures/` as an artifact. After every run the workflow renders
@@ -31,11 +31,32 @@ of real bugs lives in [`FINDINGS.json`](FINDINGS.json).
    reference wasmtime — a THIRD independent execution environment against
    the same oracle, hunting target-dependent codegen (32-bit pointers, i64
    payload slots). Requires zig + wasmtime.
+3. **Inverse oracle** (`FUZZ_GEN=reject fuzz.sh` + `genreject.py`) — the
+   other direction. The differential fuzzers emit VALID programs and ask
+   whether the answer is right; this emits programs that are **ownership
+   violations by construction** and asks whether they are caught. That is
+   the question a borrow checker is actually judged on, and the only one
+   whose failures are silent: a missed rejection compiles, runs, and
+   corrupts the heap.
+
+   A small set of violation CORES (alias double free, one binding freed
+   twice, use after move, `String` double free, loop-carried free, iterator
+   invalidation) is crossed with every CONTEXT the language offers (`?`
+   arms, `~` loops, foreach bodies, bare blocks, `;` defers, `??` arms,
+   helpers, generic bodies, trait methods, closure bodies) and nested: one
+   bug written every way the language allows.
+
+   The oracle is a diagnostic **marker**, not an output — the compile must
+   fail *and* the message must be the one that violation deserves, so a
+   syntax error in the generator cannot pass for a working checker. Both
+   holes it found (§ Bugs found 2026-08-26) had been silent for as long as
+   the constructs existed.
+
 2b. **Reducer** (`reduce.py`) — not a fuzzer: the thing that makes a finding
    usable. Called automatically by `fuzz.sh` on every finding; see
    [Reducing a finding](#reducing-a-finding-reducepy) below.
 
-3. **Mutational parser fuzzer** (`fuzz_parsers.sh` + `fuzz_parsers.py` +
+4. **Mutational parser fuzzer** (`fuzz_parsers.sh` + `fuzz_parsers.py` +
    `parse_harness.nu`) — mutates seeds for the untrusted-input parsers
    (x509/DER, cbor, msgpack, json, yaml, xml, toml) against an ASan+UBSan
    harness; a crash / out-of-bounds / UB / hang is a bug. Run it locally with
@@ -195,6 +216,29 @@ cleanup block (invalid IR), field/element stores skipping width coercion
 (invalid IR), and non-canonical narrow-int enum payload slots making a
 match literal constraint disagree with the arm's own payload binding
 (miscompile class).
+
+## Bugs found (2026-08-26, inverse oracle)
+
+Two borrow-checker soundness holes, each a **definite** double free that the
+checker rejects everywhere else and accepted here — compiling clean and
+segfaulting in the allocator at run time:
+
+1. **Inside a `??` arm.** Arms bind payload variables with no `let` row, so
+   descending with the outer flat name-keyed state would conflate an arm's
+   `v` with a same-named binding outside; the whole match was a black box.
+   Fixed by walking each arm from an EMPTY state — only a binding with its
+   own `let` row inside the arm is tracked, and that is arm-local by
+   construction. (`borrow_match_arm_double_free.nu`)
+2. **Inside a closure body.** One flag meant both "this belongs to the
+   closure, not the enclosing function" and "record nothing", so the checker
+   was off for everything written in a closure. Fixed by giving the body its
+   own recording context and its own analyze pass — a closure is its own
+   function. (`borrow_closure_body_double_free.nu`)
+
+The same sweep also turned up a language trap: a generic named `[T]` has its
+value-position `T` — the boolean literal — rewritten by monomorphisation, so
+`? T { … }` becomes `? i { … }` and fails against source nobody wrote. The
+diagnostic now names the collision (`diag_generic_tparam_bool_name.nu`).
 
 ## Bugs found (2026-08-26, structural surface wave 2)
 

--- a/tools/fuzz/fuzz.sh
+++ b/tools/fuzz/fuzz.sh
@@ -61,8 +61,71 @@ RUN_TIMEOUT="${FUZZ_RUN_TIMEOUT:-40}"
 case "$GEN_KIND" in
     int)    GEN="$ROOT/tools/fuzz/gen.py";     SIZE_FLAG="--exprs" ;;
     struct) GEN="$ROOT/tools/fuzz/genprog.py"; SIZE_FLAG="--stmts" ;;
-    *) echo "fuzz.sh: unknown FUZZ_GEN '$GEN_KIND' (int|struct)" >&2; exit 2 ;;
+    reject) GEN="$ROOT/tools/fuzz/genreject.py"; SIZE_FLAG="" ;;
+    *) echo "fuzz.sh: unknown FUZZ_GEN '$GEN_KIND' (int|struct|reject)" >&2; exit 2 ;;
 esac
+
+# ── the INVERSE oracle ───────────────────────────────────────────────
+# FUZZ_GEN=reject flips the contract. The other two generators emit VALID
+# programs and ask whether the answer is right; this one emits programs that
+# are ownership violations by construction and asks whether they are caught.
+# A missed rejection is silent — the program compiles, runs and corrupts the
+# heap — so nothing but a deliberate hunt finds it, and the two holes this
+# found (a `??` arm and a closure body) had both been silent for as long as
+# the constructs existed.
+#
+# The oracle is a diagnostic MARKER, not an output: the compile must fail and
+# the message must be the one this violation deserves. Rejecting it for an
+# unrelated reason does not count as catching it — that would let a syntax
+# error in the generator pass for a working checker.
+if [[ "$GEN_KIND" == "reject" ]]; then
+    end=$((START + COUNT - 1))
+    caught=0
+    missed=0
+    for seed in $(seq "$START" "$end"); do
+        prog="$TMP/r.nu"
+        python3 "$GEN" "$seed" --depth "$DEPTH" > "$prog"
+        marker="$(python3 "$GEN" "$seed" --oracle)"
+        out="$("$NURL" -O0 "$prog" "$TMP/r.bin" 2>&1)"
+        if grep -qF "$marker" <<<"$out"; then
+            caught=$((caught+1))
+        else
+            missed=$((missed+1))
+            if grep -qE "^[^ ]*error:" <<<"$out" || grep -q "error:" <<<"$out"; then
+                echo "SEED $seed [reject]: FINDING — rejected, but not as '$marker'"
+            else
+                echo "SEED $seed [reject]: FINDING — ACCEPTED an invalid program (want '$marker')"
+            fi
+            cp "$prog" "$FAILDIR/reject_seed_${seed}.nu"
+            printf '%s\n' "$marker" > "$FAILDIR/reject_seed_${seed}.marker"
+            printf '%s\n' "$out"    > "$FAILDIR/reject_seed_${seed}.log"
+        fi
+    done
+    echo "─────────────────────────────────────────"
+    echo "[reject] seeds $START..$end   caught=$caught findings=$missed"
+    if [[ -n "$SUMMARY" ]]; then
+        mkdir -p "$(dirname "$SUMMARY")"
+        cat > "$SUMMARY" <<JSON
+{
+  "family": "reject-inverse",
+  "generator": "genreject.py",
+  "seed_start": $START,
+  "seed_count": $COUNT,
+  "size": $COUNT,
+  "depth": $DEPTH,
+  "pass": $caught,
+  "findings": $missed,
+  "buildfail": 0,
+  "san_runs": 0,
+  "san_findings": 0,
+  "wasm_runs": 0,
+  "wasm_findings": 0
+}
+JSON
+    fi
+    [[ $missed -eq 0 ]]
+    exit $?
+fi
 
 mkdir -p "$FAILDIR"
 

--- a/tools/fuzz/genprog.py
+++ b/tools/fuzz/genprog.py
@@ -752,7 +752,9 @@ class Prog:
         self.once.add("nest")
         self.decls += [
             ": NIn { i8 nx  u16 ny }",
+            ": NMid { NIn nm  i32 nk }",
             ": NOut { NIn ninner  i32 nz }",
+            ": NTop { NMid nt  i64 nw }",
             ": | NShape {",
             "    NPt NIn",
             "    NSeg NIn NIn",
@@ -764,6 +766,37 @@ class Prog:
         """One `NIn` literal + its (nx, ny) oracle values."""
         a, b = self.rng.randrange(1 << 8), self.rng.randrange(1 << 16)
         return f"@ NIn {{ # i8 {a} # u16 {b} }}", wrap(a, "i8"), b & 0xffff
+
+    def stmt_nested_store(self):
+        """Three levels of aggregate, WRITTEN at every depth.
+
+        Reading a nested path always worked; writing one was rejected until
+        2026-08-26, because the object of a nested path is a by-value
+        register rather than a binding with an alloca. Each write is read
+        back, and its neighbours are read back too — a store that lands one
+        field over is exactly what a GEP chain gets wrong."""
+        self.decl_nested()
+        a0, b0 = self.rng.randrange(1 << 8), self.rng.randrange(1 << 16)
+        k0 = self.rng.randrange(1 << 32)
+        w0 = self.rng.randrange(1 << 40)
+        t = self.fresh("nt")
+        self.emit(f"    : ~ NTop {t} @ NTop {{ @ NMid {{ "
+                  f"@ NIn {{ # i8 {a0} # u16 {b0} }} # i32 {k0} }} {w0} }}")
+        vals = {"nx": wrap(a0, "i8"), "ny": b0 & 0xffff,
+                "nk": wrap(k0, "i32"), "nw": wrap(w0, "i64")}
+        paths = {"nx": f". . . {t} nt nm nx", "ny": f". . . {t} nt nm ny",
+                 "nk": f". . {t} nt nk", "nw": f". {t} nw"}
+        types = {"nx": "i8", "ny": "u16", "nk": "i32", "nw": "i64"}
+        for _ in range(self.rng.randint(1, 4)):
+            f = self.rng.choice(["nx", "ny", "nk", "nw"])
+            ty = types[f]
+            w, _signed = TYPES[ty]
+            bits = self.rng.randrange(1 << min(w, 62))
+            self.emit(f"    = {paths[f]} # {ty} {bits}")
+            vals[f] = wrap(bits, ty)
+        for f in ["nx", "ny", "nk", "nw"]:
+            self.phex(paths[f], to_u64_bits(vals[f], types[f]))
+        self.env.append(Var("i64", paths["nw"], vals["nw"]))
 
     def stmt_nested(self):
         """A struct inside a struct, and a struct as an enum payload —
@@ -896,7 +929,7 @@ FEATURES = [
     # The second wave: the surface the first wave never reached.
     ("generic", 3), ("option", 2), ("result", 2), ("trait", 2),
     ("nested", 3), ("loopctl", 2), ("vec_struct", 2),
-    ("nested_closure", 2), ("early_return", 2),
+    ("nested_closure", 2), ("early_return", 2), ("nested_store", 2),
 ]
 
 

--- a/tools/fuzz/genreject.py
+++ b/tools/fuzz/genreject.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# tools/fuzz/genreject.py — the INVERSE oracle: programs the compiler MUST
+# reject.
+#
+# gen.py and genprog.py ask "does this valid program compute the right
+# answer?". This asks the opposite question, and it is the one a borrow
+# checker is actually judged on: "does this INVALID program get caught?" A
+# missed rejection is silent — the program compiles, runs, and corrupts the
+# heap — so nothing but a deliberate hunt finds it.
+#
+# The shape of the hunt comes from what the two holes it found had in common:
+# both were the SAME violation, in a context nobody had written it in. A
+# double free is rejected at the top of a function, inside a `?` arm, a `~`
+# loop, a foreach body, a bare block, a helper, a generic body, a trait
+# method and a defer — and used to sail through a `??` arm and a closure
+# body, where the checker was, for principled reasons, not looking. So the
+# generator crosses a small set of violation CORES with a large set of
+# CONTEXTS and nests them: one bug written every way the language allows.
+#
+# The oracle is a marker string, not an output: the program must fail to
+# compile AND the diagnostic must be the one this violation deserves.
+# Rejecting it for an unrelated reason (a syntax error the generator
+# introduced, say) does not count as catching it.
+#
+# Usage:
+#   genreject.py SEED             → the NURL program on stdout
+#   genreject.py SEED --oracle    → the diagnostic marker it must produce
+#   genreject.py SEED --depth N   → max nested contexts (default 3)
+#
+# A finding here is a program that COMPILES, or one rejected with the wrong
+# diagnostic. Both mean the checker has a blind spot with a shape.
+
+import sys
+import random
+
+# ── violation cores ───────────────────────────────────────────────────
+#
+# Each core is a body that is a definite ownership violation wherever it is
+# placed, and the marker its diagnostic must contain. `n` makes every binding
+# unique so nesting two cores, or a core beside a context's own bindings,
+# cannot collide.
+
+
+def core_alias_double_free(n):
+    """Two names for one Vec, both freed."""
+    return ([
+        f": ( Vec i ) a{n} ( vec_new [i] )",
+        f"( vec_push [i] a{n} 10 )",
+        f": ( Vec i ) b{n} a{n}",
+        f"( vec_free [i] a{n} )",
+        f"( vec_free [i] b{n} )",
+    ], "use of moved value")
+
+
+def core_same_binding_double_free(n):
+    """One name, freed twice."""
+    return ([
+        f": ( Vec i ) a{n} ( vec_new [i] )",
+        f"( vec_free [i] a{n} )",
+        f"( vec_free [i] a{n} )",
+    ], "use of moved value")
+
+
+def core_use_after_move(n):
+    """Read through a name whose value has moved to another binding."""
+    return ([
+        f": ( Vec i ) a{n} ( vec_new [i] )",
+        f": ( Vec i ) b{n} a{n}",
+        f": i n{n} ( vec_len [i] a{n} )",
+        f"( vec_free [i] b{n} )",
+        f"( nurl_print ( nurl_str_int n{n} ) )",
+    ], "use of moved value")
+
+
+def core_string_double_free(n):
+    """The same violation on a String handle rather than a Vec."""
+    return ([
+        f": String s{n} ( string_new )",
+        f"( string_push_char s{n} 65 )",
+        f": String t{n} s{n}",
+        f"( string_free s{n} )",
+        f"( string_free t{n} )",
+    ], "use of moved value")
+
+
+def core_loop_carried_free(n):
+    """A free inside a loop body: the second iteration frees a dead handle."""
+    return ([
+        f": ( Vec i ) a{n} ( vec_new [i] )",
+        f": ~ i k{n} 0",
+        f"~ < k{n} 3 {{",
+        f"    ( vec_free [i] a{n} )",
+        f"    = k{n} + k{n} 1",
+        "}",
+    ], "use of moved value")
+
+
+def core_iter_invalidation(n):
+    """Growing a container while a `~` cursor is walking it."""
+    return ([
+        f": ( Vec i ) xs{n} ( vec_new [i] )",
+        f"( vec_push [i] xs{n} 1 )",
+        f"~ e{n} xs{n} {{ ( vec_push [i] xs{n} e{n} ) }}",
+        f"( vec_free [i] xs{n} )",
+    ], "while iterating over it")
+
+
+CORES = [
+    core_alias_double_free,
+    core_same_binding_double_free,
+    core_use_after_move,
+    core_string_double_free,
+    core_loop_carried_free,
+    core_iter_invalidation,
+]
+
+# Cores that already contain a loop of their own. Nesting one inside a
+# foreach would iterate a container it also mutates — a second, different
+# violation whose diagnostic wins, and the oracle would be checking for the
+# wrong marker. Keep the finding attributable to one cause.
+LOOPY = {core_loop_carried_free, core_iter_invalidation}
+
+
+def indent(lines, by="    "):
+    return [by + l for l in lines]
+
+
+# ── contexts ──────────────────────────────────────────────────────────
+#
+# A context wraps a body in one more layer of syntax without changing
+# whether the body is a violation. Block contexts nest freely inside each
+# other; function contexts open a new frame and may only appear outermost.
+
+
+class Ctx:
+    """(name, wrap) where wrap(body_lines, n, decls) -> lines. A context that
+    needs a top-level declaration of its own appends it to `decls`."""
+
+    def __init__(self, name, wrap, loopish=False, blocks_defer=False):
+        self.name, self.wrap = name, wrap
+        self.loopish = loopish            # introduces a `~` cursor
+        self.blocks_defer = blocks_defer  # `;` is rejected inside this
+
+
+def _if_then(body, n, decls):
+    return ["? T {"] + indent(body) + ["} {}"]
+
+
+def _if_else(body, n, decls):
+    return [f"? > {n} 1000 {{}} {{"] + indent(body) + ["}"]
+
+
+def _while(body, n, decls):
+    return [f": ~ i w{n} 0", f"~ < w{n} 1 {{"] + indent(body) + \
+           [f"    = w{n} + w{n} 1", "}"]
+
+
+def _foreach(body, n, decls):
+    return [f": [i fx{n} [ i | 1 ]", f"~ fe{n} fx{n} {{"] + indent(body) + ["}"]
+
+
+def _bare_block(body, n, decls):
+    return ["{"] + indent(body) + ["}"]
+
+
+def _defer(body, n, decls):
+    return ["; {"] + indent(body) + ["}"]
+
+
+def _match_arm(body, n, decls):
+    decls.append(f": | Sel{n} {{ SA{n} i  SB{n} i  SC{n} }}")
+    return [
+        f": Sel{n} sel{n} @ Sel{n} {{ SA{n} 1 }}",
+        f"?? sel{n} {{",
+        f"    SA{n} p{n} → {{",
+    ] + indent(body, "        ") + [
+        f"        p{n}",
+        "    }",
+        f"    SB{n} p{n} → p{n}",
+        f"    SC{n}     → 0",
+        "}",
+    ]
+
+
+BLOCK_CTXS = [
+    Ctx("if-then", _if_then),
+    Ctx("if-else", _if_else),
+    Ctx("while", _while, loopish=True),
+    Ctx("foreach", _foreach, loopish=True),
+    Ctx("bare-block", _bare_block),
+    Ctx("defer", _defer),
+    Ctx("match-arm", _match_arm),
+]
+
+# Function contexts: each emits a top-level declaration holding the body and
+# a call in main. `decl(body, n) -> (decl_lines, call_line, extra_decls)`.
+
+
+def _fn_helper(body, n):
+    return ([f"@ hf{n} → v {{"] + indent(body) + ["}"], f"( hf{n} )", [])
+
+
+def _fn_generic(body, n):
+    # `[A]`, not `[T]`: `T` is also the boolean literal, and monomorphisation
+    # rewrites the type parameter through the body by whole word — a `? T { }`
+    # anywhere inside would be rewritten into the type argument. The stdlib
+    # names its type variables `A` for exactly this reason.
+    return ([f"@ gf{n} [A] A x{n} → i {{"] + indent(body) +
+            ["    ^ 0", "}"], f"( gf{n} [i] 1 )", [])
+
+
+def _fn_closure(body, n):
+    return ([], f"( cl{n} 1 )",
+            [f"    : ( @ i i ) cl{n} \\ i cx{n} → i {{"] +
+            indent(body, "        ") + [f"        ^ cx{n}", "    }"])
+
+
+def _fn_trait(body, n):
+    return ([
+        f"% Tr{n} [A] {{ @ tm{n} A self → i }}",
+        f": Ts{n} {{ i f{n} }}",
+        f"% Tr{n} Ts{n} {{",
+        f"    @ tm{n} Ts{n} self → i {{",
+    ] + indent(body, "        ") + [
+        f"        ^ . self f{n}",
+        "    }",
+        "}",
+    ], f"( tm{n} @ Ts{n} {{ 1 }} )", [])
+
+
+FN_CTXS = [
+    Ctx("helper", _fn_helper),
+    Ctx("generic", _fn_generic),
+    Ctx("closure", _fn_closure, blocks_defer=True),
+    Ctx("trait-method", _fn_trait),
+]
+
+
+def build(seed, depth):
+    rng = random.Random(seed)
+    core = rng.choice(CORES)
+    n = rng.randrange(1000, 9999)
+    body, marker = core(n)
+
+    # Nest 0..depth-1 block contexts, innermost first.
+    nblocks = rng.randint(0, max(0, depth - 1))
+    picks = []
+    for _ in range(nblocks):
+        c = rng.choice(BLOCK_CTXS)
+        if c.loopish and core in LOOPY:
+            continue                      # see LOOPY
+        picks.append(c)
+
+    fn = rng.choice(FN_CTXS) if rng.random() < 0.55 else None
+    if fn is not None and fn.blocks_defer:
+        picks = [c for c in picks if c.name != "defer"]
+
+    decls = []
+    for c in picks:
+        n += 1
+        body = c.wrap(body, n, decls)
+
+    if fn is None:
+        main_body = indent(body)
+    else:
+        d, call, inline = fn.wrap(body, n + 1)
+        decls += d
+        main_body = inline + indent([call])
+
+    out = [
+        "// AUTO-GENERATED by tools/fuzz/genreject.py — INVERSE oracle.",
+        "// This program is INVALID on purpose. The compiler must reject it,",
+        f"// with a diagnostic containing: {marker}",
+        "$ `stdlib/core/string.nu`",
+        "$ `stdlib/core/vec.nu`",
+        "",
+    ]
+    out += decls
+    out += ["", "@ main → i {"] + main_body + ["    ^ 0", "}"]
+    return "\n".join(out) + "\n", marker
+
+
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        sys.exit("usage: genreject.py SEED [--oracle] [--depth N]")
+    seed = int(args[0])
+    depth = 3
+    if "--depth" in args:
+        depth = int(args[args.index("--depth") + 1])
+    prog, marker = build(seed, depth)
+    sys.stdout.write(marker + "\n" if "--oracle" in args else prog)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fuzz/report.py
+++ b/tools/fuzz/report.py
@@ -37,6 +37,15 @@ FAMILY_DESC = {
         "calls, recursion) with a statement-level oracle; `-O0` vs `-O2` vs "
         "oracle, plus an ASan+LSan leg and a wasm32-wasi/wasmtime leg on "
         "sampled seeds",
+    "reject-inverse":
+        "`genreject.py` — the inverse oracle: programs that are ownership "
+        "violations by construction (alias double free, use after move, "
+        "loop-carried free, iterator invalidation), crossed with every "
+        "context the language offers (`?` arms, loops, foreach, bare "
+        "blocks, defers, `??` arms, helpers, generic bodies, trait methods, "
+        "closure bodies) and nested. Each MUST be rejected, with the "
+        "diagnostic that violation deserves — a program that compiles, or "
+        "one rejected for an unrelated reason, is the finding",
     "parser-mutational":
         "`fuzz_parsers.py` — mutated inputs for the untrusted-input "
         "parsers (x509/DER, cbor, msgpack, json, yaml, xml, toml) against "
@@ -94,6 +103,11 @@ def main():
         if fam.startswith("parser"):
             cfg = f"iters={r.get('size')} rng-seed={r.get('seed_start')}"
             execs = r.get("size", 0)
+        elif fam == "reject-inverse":
+            cfg = (f"seeds {r.get('seed_start')}–"
+                   f"{r.get('seed_start', 1) + r.get('seed_count', 0) - 1}, "
+                   f"depth={r.get('depth')}")
+            execs = r.get("seed_count", 0)
         else:
             cfg = (f"seeds {r.get('seed_start')}–"
                    f"{r.get('seed_start', 1) + r.get('seed_count', 0) - 1}, "
@@ -114,6 +128,10 @@ def main():
     a("(always-valid) program, a nonzero exit, a hang, or an")
     a("ASan/LSan/UBSan report. Reproducers are")
     a("uploaded as workflow artifacts and land in `tools/fuzz/failures/`.")
+    a("")
+    a("The inverse family reads the other way round: its programs are invalid")
+    a("by construction, so a **compile that succeeds** is the finding, as is a")
+    a("rejection carrying the wrong diagnostic.")
     a("")
     a("Every finding is **shrunk before it is filed**: `tools/fuzz/reduce.py`")
     a("deletes statements while the same failure survives, so the artifact")
@@ -141,6 +159,7 @@ def main():
     a("tools/fuzz/fuzz.sh 1 500                        # integer differential")
     a("FUZZ_GEN=struct FUZZ_SAN_EVERY=5 FUZZ_WASM_EVERY=5 \\")
     a("    tools/fuzz/fuzz.sh 1 300 14 3               # structural + sanitizer + wasm legs")
+    a("FUZZ_GEN=reject tools/fuzz/fuzz.sh 1 400 0 3   # inverse oracle")
     a("tools/fuzz/fuzz_parsers.sh 1 4000 8             # parser mutational")
     a("")
     a("# reproduce and shrink one seed by hand")


### PR DESCRIPTION
## Why

The two differential generators emit **valid** programs and ask whether the answer is right. Nothing asked the opposite question — the one a borrow checker is actually judged on: *does an invalid program get caught?*

That failure mode is silent. The program compiles, runs, and corrupts the heap. Only a deliberate hunt finds it, and both holes this found had been silent for as long as the constructs existed.

## What

`tools/fuzz/genreject.py` crosses a small set of violation **cores** with the **contexts** the language offers, and nests them: one bug written every way the language allows.

| | |
|---|---|
| **cores** | alias double free · one binding freed twice · use after move · `String` double free · loop-carried free · iterator invalidation |
| **contexts** | `?` then/else arms · `~` loops · foreach bodies · bare blocks · `;` defers · `??` arms · helpers · generic bodies · trait methods · closure bodies |

The oracle is a diagnostic **marker**, not an output: the compile must fail **and** the message must be the one that violation deserves. Rejecting it for an unrelated reason does not count — otherwise a syntax error in the generator would pass for a working checker.

## What it found

Two borrow-checker soundness holes on the first sweep, both fixed at the root, both confirmed as heap corruption under AddressSanitizer:

- **#1008** — a definite double free inside a `??` arm was accepted. Arms were a state-preserving black box because payload bindings have no `let` row.
- **#1009** — a definite double free inside a closure body was accepted. One flag meant both "belongs to the closure" and "record nothing".

A third finding fell out of the same programs: **#1010**, the `[T]`-is-also-`true` collision.

400 seeds at depth 4 are clean now.

## Also here

`nested_store` in `genprog.py` — three levels of aggregate, written at every depth, each write read back **along with its neighbours**, since a store that lands one field over is exactly what a GEP chain gets wrong. That closes the loop on #1006, which added the ability to write a nested field at all.

## Wiring

`FUZZ_GEN=reject` runs it. The workflow gains a leg and two inputs (`reject_seeds`, `reject_depth`); `report.py` renders the family and states the inverted reading — for this one, a compile that **succeeds** is the finding.

Verified: 400/400 caught at depth 4; the failure path checked by forcing a marker that cannot match (3/3 reported, exit 1); struct leg with `nested_store` clean over 120 seeds including the sanitizer leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRZBWg6tZYNEWSw9cHmmdU