### PR TITLE
fix(net): a partial non-blocking send is progress, not failure

### DIFF
--- a/stdlib/runtime_ffi.c
+++ b/stdlib/runtime_ffi.c
@@ -1391,6 +1391,13 @@ long long nurl_tcp_write(long long handle, const char *buf, long long n) {
              * still return immediately for the reactor. */
             int we = WSAGetLastError();
             if (wn < 0 && we == WSAETIMEDOUT && ++stalls <= 2) continue;
+            /* Would-block on a non-blocking socket is PROGRESS, not
+             * failure — see the POSIX branch below for why -1 here
+             * corrupts the caller's stream. */
+            if (wn < 0 && we == WSAEWOULDBLOCK && total > 0) {
+                h->err_kind = NURL_NET_ERR_OK;
+                return total;
+            }
             h->err_kind = nurl__net_map_wsa(we, NURL_NET_ERR_WRITE);
 #else
             /* On POSIX a SO_SNDTIMEO expiry and a nonblocking would-block
@@ -1403,6 +1410,28 @@ long long nurl_tcp_write(long long handle, const char *buf, long long n) {
                            0)) {
                 int fl = fcntl(h->fd, F_GETFL, 0);
                 if (fl >= 0 && !(fl & O_NONBLOCK) && ++stalls <= 2) continue;
+                /* NON-BLOCKING would-block after a PARTIAL send: those
+                 * bytes are already on the wire, so this is progress,
+                 * and the count is the only record of it. Returning -1
+                 * threw it away — the async wrapper in std/net.nu then
+                 * parked on the reactor and retried from its own `sent`,
+                 * which had never advanced, so it re-sent the buffer
+                 * from the front. The peer got the prefix again instead
+                 * of the continuation, and since callers frame their
+                 * writes (relay.nu's 5-byte type+length header), reading
+                 * the announced length spliced a repeat into the middle
+                 * of the message: a frame of exactly the right size with
+                 * the wrong bytes, and every frame after it garbage.
+                 * Measured before the fix: a 1.1 MB relay frame put
+                 * 37.7 MB on the wire, ~17 copies of its own prefix.
+                 * Loopback hid it completely — the peer drains as fast
+                 * as we fill, so send() never blocks and the whole
+                 * buffer goes in one call. Report the count; -1 is for
+                 * "nothing was written". */
+                if (total > 0) {
+                    h->err_kind = NURL_NET_ERR_OK;
+                    return total;
+                }
             }
             h->err_kind = nurl__net_map_errno(errno, NURL_NET_ERR_WRITE);
 #endif

--- a/stdlib/std/net.nu
+++ b/stdlib/std/net.nu
@@ -803,15 +803,40 @@ $ `stdlib/std/pkey.nu`
     ? != fcur 0 { ^ ( tcp_write_all_async c bytes ) } {}
     : s rp . c raw
     : i raw # i rp
-    : i n ( vec_len [u] bytes )
-    ? <= n 0 { ^ @ !v NetErr { T 0 } } {}
+    : i total ( vec_len [u] bytes )
+    ? <= total 0 { ^ @ !v NetErr { T 0 } } {}
     : *u p ( vec_data [u] bytes )
     : s pbuf # s p
-    : i wn ( nurl_tcp_write raw pbuf n )
-    ? < wn 0 {
-        : i ek ( nurl_tcp_err_kind raw )
-        ^ @ !v NetErr { F ( _net_err_of ek ) }
-    } {}
+    // write(2) on a blocking socket is NOT all-or-nothing: it returns as soon
+    // as it has copied SOME bytes into the send buffer, and with SO_SNDTIMEO
+    // set (tcp_set_timeout) it returns a short count when the timer fires with
+    // the peer's window full. Writing once and reporting success left the rest
+    // of the buffer unsent, and — because the frame header had already
+    // announced the full length — DESYNCED the stream: the peer's next
+    // read_exact spliced the tail of one frame onto the head of the next and
+    // handed up a frame of the right length with the wrong bytes. Loopback
+    // hides it (the receiver drains as fast as the sender fills, so one write
+    // takes everything); a real network path with an autotuned 64 KiB initial
+    // send buffer does not, past a few hundred KiB. Loop until it is all gone,
+    // exactly as tcp_write_all_async already does.
+    : ~ i sent 0
+    : ~ i idle 0
+    ~ < sent total {
+        : i remaining - total sent
+        : s slice # s + # i pbuf sent
+        : i wn ( nurl_tcp_write raw slice remaining )
+        ? > wn 0 { = sent + sent wn = idle 0 } {
+            : i ek ( nurl_tcp_err_kind raw )
+            // ek 7 is EAGAIN / SO_SNDTIMEO. The peer is still connected and
+            // the rest still has to go, so retry — bounded, so a peer that
+            // stops draining forever cannot wedge us. wn == 0 with no error
+            // is the same situation: no progress, do not spin on it.
+            ? | == ek 7 == wn 0 {
+                = idle + idle 1
+                ? > idle 2400 { ^ @ !v NetErr { F # NetErr NetTimeout } } {}
+            } { ^ @ !v NetErr { F ( _net_err_of ek ) } }
+        }
+    }
     ^ @ !v NetErr { T 0 }
 }
 
@@ -827,13 +852,26 @@ $ `stdlib/std/pkey.nu`
     } {}
     : s rp . c raw
     : i raw # i rp
-    : i n ( nurl_str_len text )
-    ? <= n 0 { ^ @ !v NetErr { T 0 } } {}
-    : i wn ( nurl_tcp_write raw text n )
-    ? < wn 0 {
-        : i ek ( nurl_tcp_err_kind raw )
-        ^ @ !v NetErr { F ( _net_err_of ek ) }
-    } {}
+    : i total ( nurl_str_len text )
+    ? <= total 0 { ^ @ !v NetErr { T 0 } } {}
+    // Same short-write rule as tcp_write_all — see the note there. Status
+    // lines and headers are small enough that one write almost always takes
+    // them, which is exactly why a partial one here would be a rare,
+    // load-dependent corruption rather than an outright failure.
+    : ~ i sent 0
+    : ~ i idle 0
+    ~ < sent total {
+        : i remaining - total sent
+        : s slice # s + # i text sent
+        : i wn ( nurl_tcp_write raw slice remaining )
+        ? > wn 0 { = sent + sent wn = idle 0 } {
+            : i ek ( nurl_tcp_err_kind raw )
+            ? | == ek 7 == wn 0 {
+                = idle + idle 1
+                ? > idle 2400 { ^ @ !v NetErr { F # NetErr NetTimeout } } {}
+            } { ^ @ !v NetErr { F ( _net_err_of ek ) } }
+        }
+    }
     ^ @ !v NetErr { T 0 }
 }
 
@@ -1005,19 +1043,38 @@ $ `stdlib/std/async_ffi.nu`
     : *u p ( vec_data [u] bytes )
     : s pbuf # s p
     : ~ i sent 0
+    // Once ANY byte of this buffer is on the wire, giving up is not an
+    // option the caller can recover from. Callers frame their writes
+    // (relay.nu puts a 5-byte type+length header in front of every
+    // message), so a half-written buffer does not lose a message — it
+    // DESYNCS the stream: the peer reads the announced length, takes the
+    // tail from whatever is written next, and every frame after that is
+    // garbage of plausible length. It surfaces far away as an integrity
+    // failure, not as a write error.
+    //
+    // So a reactor timeout is fatal only while `sent` is still 0. Past
+    // that we keep waiting, bounded exactly like __read_exact's mirror of
+    // this rule on the reading side — the peer is still connected and the
+    // rest of the buffer still has to go. A peer that never drains ends
+    // the loop with an error, and the caller drops the connection, which
+    // is the only correct way out of a partial frame.
+    : ~ i idle 0
     ~ < sent total {
         : i remaining - total sent
         : s slice # s + # i pbuf sent
         : i n ( nurl_tcp_write raw slice remaining )
         ? > n 0 {
             = sent + sent n
+            = idle 0
         } {
             ? < n 0 {
                 : i ek ( nurl_tcp_err_kind raw )
                 ? == ek 7 {
                     : i rc ( nurl_reactor_wait_write fd ( __wait_ms raw ) )
                     ? <= rc 0 {
-                        ^ @ !v NetErr { F # NetErr NetTimeout }
+                        ? == sent 0 { ^ @ !v NetErr { F # NetErr NetTimeout } } {}
+                        = idle + idle 1
+                        ? > idle 2400 { ^ @ !v NetErr { F # NetErr NetTimeout } } {}
                     } {}
                 } {
                     ^ @ !v NetErr { F ( _net_err_of ek ) }
@@ -1026,7 +1083,11 @@ $ `stdlib/std/async_ffi.nu`
                 // n == 0 — kernel says "wrote nothing" without error.
                 // Treat as EAGAIN to avoid spinning.
                 : i rc ( nurl_reactor_wait_write fd ( __wait_ms raw ) )
-                ? <= rc 0 { ^ @ !v NetErr { F # NetErr NetTimeout } } {}
+                ? <= rc 0 {
+                    ? == sent 0 { ^ @ !v NetErr { F # NetErr NetTimeout } } {}
+                    = idle + idle 1
+                    ? > idle 2400 { ^ @ !v NetErr { F # NetErr NetTimeout } } {}
+                } {}
             }
         }
     }


### PR DESCRIPTION
A wasm compute kernel dispatched to a `swarm-mcp` worker on **another machine** always failed with `payload failed the cluster HMAC check (wrong --token?)`. The token was fine.

Measured on a three-node swarm (Linux x86-64, FreeBSD 14.3, ARM64 odroid):

| worker ↔ relay | wasm kernel (~1.1 MB) | expression kernel |
|---|---|---|
| same host (loopback) | passes | passes |
| different hosts | **fails** | passes |

Platform, architecture, coordinator location and chunk count were all ruled out by measurement — only co-location mattered.

## Root cause

`nurl_tcp_write` loops internally and counts what it has sent in `total`. On a **non-blocking** socket — which the fiber write path sets — `send()` returns EAGAIN partway through a large buffer, and the EAGAIN branch returned `-1`, **discarding `total`**. Those bytes were already on the wire; the count was the only record that they had gone.

`tcp_write_all_async` then saw an error, parked on the reactor, and retried from its own `sent`, which had never advanced — so it re-sent the buffer **from the front**. The peer received the prefix again instead of the continuation.

Because callers frame their writes (`relay.nu` puts a 5-byte type+length header in front of every message), reading the announced length spliced that repeat into the middle of the message: a frame of exactly the right size with the wrong bytes, and every frame after it garbage. The integrity check caught it and blamed the token — which is why this read as an auth problem rather than a transport one.

**Measured on one 1.1 MB relay frame: 37,713,045 bytes reached the peer where 2,249,298 were asked for** — about 17 copies of its own prefix. After the fix: 2,248,717. The received module is byte-correct where it used to diverge exactly 64 KiB in, at the first socket-buffer boundary.

Loopback hid all of it: the peer drains as fast as we fill, `send()` never blocks, and the whole buffer goes in one call. That is exactly why every single-machine test passed and why this only ever appeared between two physical machines.

## The fix

**`stdlib/runtime_ffi.c`** — report `total` when a non-blocking send would block after partial progress; `-1` now means "nothing was written". Windows gets the same rule for `WSAEWOULDBLOCK`.

**`stdlib/std/net.nu`** — three related gaps on the NURL side, each of which could desync a framed stream on its own:

- `tcp_write_all` (sync) issued **one** write and reported success without comparing it to the length. Its async twin already looped; the name promised the loop and the body did not have it.
- `tcp_write_str` had the same single-write shape.
- `tcp_write_all_async` gave up on a reactor timeout even after putting part of a frame on the wire. A half-written frame is not something a caller can recover from, so a timeout is now fatal only while nothing has been sent yet — the mirror of the rule `__read_exact` already applies on the reading side.

## Verification

- wasm kernels run correctly on a remote worker: **5/5 consecutive jobs across three physical machines and two architectures**, with an ARM64 and a FreeBSD worker sharing the same task
- FreeBSD alone and ARM64 alone as remote workers both pass
- expression kernels unaffected
- write amplification gone: 37.7 MB → 2.25 MB for one job
- full `./build.sh` build + test corpus passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyDDy4qzKJRsJd91x9e57P